### PR TITLE
Harden tests and docs for the first run API slice

### DIFF
--- a/backend/internal/api/replay_reads_test.go
+++ b/backend/internal/api/replay_reads_test.go
@@ -180,6 +180,27 @@ func TestGetRunAgentReplayEndpointReturnsNotFoundWhenRunAgentMissing(t *testing.
 	}
 }
 
+func TestGetRunAgentReplayEndpointRejectsMalformedRunAgentID(t *testing.T) {
+	workspaceID := uuid.New()
+	req := httptest.NewRequest(http.MethodGet, "/v1/replays/not-a-uuid", nil)
+	req.Header.Set(headerUserID, uuid.New().String())
+	req.Header.Set(headerWorkspaceMemberships, workspaceID.String()+":workspace_member")
+	recorder := httptest.NewRecorder()
+
+	newRouter(
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		stubRunCreationService{},
+		stubRunReadService{},
+		&fakeReplayReadService{},
+	).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+	}
+}
+
 func TestGetRunAgentScorecardEndpointReturnsScorecard(t *testing.T) {
 	workspaceID := uuid.New()
 	runAgentID := uuid.New()

--- a/backend/internal/api/run_reads_test.go
+++ b/backend/internal/api/run_reads_test.go
@@ -169,6 +169,27 @@ func TestGetRunEndpointReturnsNotFound(t *testing.T) {
 	}
 }
 
+func TestGetRunEndpointRejectsMalformedRunID(t *testing.T) {
+	workspaceID := uuid.New()
+	req := httptest.NewRequest(http.MethodGet, "/v1/runs/not-a-uuid", nil)
+	req.Header.Set(headerUserID, uuid.New().String())
+	req.Header.Set(headerWorkspaceMemberships, workspaceID.String()+":workspace_member")
+	recorder := httptest.NewRecorder()
+
+	newRouter(
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		stubRunCreationService{},
+		&fakeRunReadService{},
+		&fakeReplayReadService{},
+	).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+	}
+}
+
 func TestListRunAgentsEndpointReturnsOrderedItems(t *testing.T) {
 	workspaceID := uuid.New()
 	runID := uuid.New()

--- a/backend/internal/api/run_service_test.go
+++ b/backend/internal/api/run_service_test.go
@@ -170,6 +170,63 @@ func TestRunCreationManagerRejectsDuplicateDeployments(t *testing.T) {
 	}
 }
 
+func TestRunCreationManagerRejectsEmptyDeployments(t *testing.T) {
+	workspaceID := uuid.New()
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), &fakeRunCreationRepository{}, &fakeRunWorkflowStarter{})
+
+	_, err := manager.CreateRun(context.Background(), Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}, CreateRunInput{
+		WorkspaceID:            workspaceID,
+		ChallengePackVersionID: uuid.New(),
+		AgentDeploymentIDs:     nil,
+	})
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+
+	var validationErr RunCreationValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error = %v, want RunCreationValidationError", err)
+	}
+	if validationErr.Code != "invalid_agent_deployment_ids" {
+		t.Fatalf("validation code = %q, want invalid_agent_deployment_ids", validationErr.Code)
+	}
+}
+
+func TestRunCreationManagerRejectsChallengePackVersionNotFound(t *testing.T) {
+	workspaceID := uuid.New()
+	deploymentID := uuid.New()
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), &fakeRunCreationRepository{
+		challengePackVersionErr: repository.ErrChallengePackVersionNotFound,
+	}, &fakeRunWorkflowStarter{})
+
+	_, err := manager.CreateRun(context.Background(), Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}, CreateRunInput{
+		WorkspaceID:            workspaceID,
+		ChallengePackVersionID: uuid.New(),
+		AgentDeploymentIDs:     []uuid.UUID{deploymentID},
+	})
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+
+	var validationErr RunCreationValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error = %v, want RunCreationValidationError", err)
+	}
+	if validationErr.Code != "invalid_challenge_pack_version_id" {
+		t.Fatalf("validation code = %q, want invalid_challenge_pack_version_id", validationErr.Code)
+	}
+}
+
 func TestRunCreationManagerRejectsChallengeInputSetFromAnotherPackVersion(t *testing.T) {
 	workspaceID := uuid.New()
 	challengePackVersionID := uuid.New()
@@ -218,6 +275,81 @@ func TestRunCreationManagerRejectsChallengeInputSetFromAnotherPackVersion(t *tes
 	}
 }
 
+func TestRunCreationManagerRejectsMissingChallengeInputSet(t *testing.T) {
+	workspaceID := uuid.New()
+	challengePackVersionID := uuid.New()
+	challengeInputSetID := uuid.New()
+	deploymentID := uuid.New()
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{ID: challengePackVersionID},
+		challengeInputSetErr: repository.ErrChallengeInputSetNotFound,
+		deployments: []repository.RunnableDeployment{
+			{
+				ID:                        deploymentID,
+				OrganizationID:            uuid.New(),
+				WorkspaceID:               workspaceID,
+				Name:                      "Support Agent Deployment",
+				AgentDeploymentSnapshotID: uuid.New(),
+			},
+		},
+	}, &fakeRunWorkflowStarter{})
+
+	_, err := manager.CreateRun(context.Background(), Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}, CreateRunInput{
+		WorkspaceID:            workspaceID,
+		ChallengePackVersionID: challengePackVersionID,
+		ChallengeInputSetID:    &challengeInputSetID,
+		AgentDeploymentIDs:     []uuid.UUID{deploymentID},
+	})
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+
+	var validationErr RunCreationValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error = %v, want RunCreationValidationError", err)
+	}
+	if validationErr.Code != "invalid_challenge_input_set_id" {
+		t.Fatalf("validation code = %q, want invalid_challenge_input_set_id", validationErr.Code)
+	}
+}
+
+func TestRunCreationManagerRejectsDeploymentOutsideWorkspace(t *testing.T) {
+	workspaceID := uuid.New()
+	challengePackVersionID := uuid.New()
+	deploymentID := uuid.New()
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{ID: challengePackVersionID},
+		deployments:          nil,
+	}, &fakeRunWorkflowStarter{})
+
+	_, err := manager.CreateRun(context.Background(), Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}, CreateRunInput{
+		WorkspaceID:            workspaceID,
+		ChallengePackVersionID: challengePackVersionID,
+		AgentDeploymentIDs:     []uuid.UUID{deploymentID},
+	})
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+
+	var validationErr RunCreationValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error = %v, want RunCreationValidationError", err)
+	}
+	if validationErr.Code != "invalid_agent_deployment_ids" {
+		t.Fatalf("validation code = %q, want invalid_agent_deployment_ids", validationErr.Code)
+	}
+}
+
 func TestRunCreationManagerRejectsForbiddenWorkspaceAccess(t *testing.T) {
 	workspaceID := uuid.New()
 	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), &fakeRunCreationRepository{}, &fakeRunWorkflowStarter{})
@@ -239,19 +371,21 @@ func TestRunCreationManagerRejectsForbiddenWorkspaceAccess(t *testing.T) {
 }
 
 type fakeRunCreationRepository struct {
-	challengePackVersion repository.RunnableChallengePackVersion
-	challengeInputSet    repository.ChallengeInputSet
-	deployments          []repository.RunnableDeployment
-	createResult         repository.CreateQueuedRunResult
-	createParams         *repository.CreateQueuedRunParams
+	challengePackVersion    repository.RunnableChallengePackVersion
+	challengePackVersionErr error
+	challengeInputSet       repository.ChallengeInputSet
+	challengeInputSetErr    error
+	deployments             []repository.RunnableDeployment
+	createResult            repository.CreateQueuedRunResult
+	createParams            *repository.CreateQueuedRunParams
 }
 
 func (f *fakeRunCreationRepository) GetRunnableChallengePackVersionByID(_ context.Context, _ uuid.UUID) (repository.RunnableChallengePackVersion, error) {
-	return f.challengePackVersion, nil
+	return f.challengePackVersion, f.challengePackVersionErr
 }
 
 func (f *fakeRunCreationRepository) GetChallengeInputSetByID(_ context.Context, _ uuid.UUID) (repository.ChallengeInputSet, error) {
-	return f.challengeInputSet, nil
+	return f.challengeInputSet, f.challengeInputSetErr
 }
 
 func (f *fakeRunCreationRepository) ListRunnableDeploymentsWithLatestSnapshot(_ context.Context, _ uuid.UUID, _ []uuid.UUID) ([]repository.RunnableDeployment, error) {

--- a/backend/internal/api/runs.go
+++ b/backend/internal/api/runs.go
@@ -185,6 +185,10 @@ func decodeCreateRunRequest(r *http.Request) (CreateRunInput, error) {
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&body); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			return CreateRunInput{}, err
+		}
 		if errors.Is(err, io.EOF) {
 			return CreateRunInput{}, RunCreationValidationError{
 				Code:    "invalid_request",

--- a/backend/internal/api/runs_test.go
+++ b/backend/internal/api/runs_test.go
@@ -168,6 +168,34 @@ func TestCreateRunEndpointRejectsNonJSONContentType(t *testing.T) {
 	}
 }
 
+func TestCreateRunEndpointRejectsOversizedRequestBody(t *testing.T) {
+	workspaceID := uuid.New()
+	oversizedName := bytes.Repeat([]byte("a"), maxCreateRunRequestBytes+1)
+	req := httptest.NewRequest(http.MethodPost, "/v1/runs", bytes.NewBufferString(`{
+		"workspace_id":"`+workspaceID.String()+`",
+		"challenge_pack_version_id":"`+uuid.New().String()+`",
+		"name":"`+string(oversizedName)+`",
+		"agent_deployment_ids":["`+uuid.New().String()+`"]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(headerUserID, uuid.New().String())
+	req.Header.Set(headerWorkspaceMemberships, workspaceID.String()+":workspace_member")
+	recorder := httptest.NewRecorder()
+
+	newRouter(
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		&fakeRunCreationService{},
+		&fakeRunReadService{},
+		&fakeReplayReadService{},
+	).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusRequestEntityTooLarge)
+	}
+}
+
 type fakeRunCreationService struct {
 	caller Caller
 	input  CreateRunInput

--- a/docs/api-server/local-development.md
+++ b/docs/api-server/local-development.md
@@ -51,6 +51,159 @@ Expected response:
 {"ok":true,"service":"api-server"}
 ```
 
+## Endpoint Contracts
+
+### `POST /v1/runs`
+
+Request body:
+
+```json
+{
+  "workspace_id": "uuid",
+  "challenge_pack_version_id": "uuid",
+  "challenge_input_set_id": "uuid-or-null",
+  "name": "optional human label",
+  "agent_deployment_ids": ["uuid"]
+}
+```
+
+Success response:
+
+```json
+{
+  "id": "uuid",
+  "workspace_id": "uuid",
+  "challenge_pack_version_id": "uuid",
+  "challenge_input_set_id": "uuid-or-null",
+  "status": "queued",
+  "execution_mode": "single_agent | comparison",
+  "created_at": "timestamp",
+  "queued_at": "timestamp",
+  "links": {
+    "self": "/v1/runs/{id}",
+    "agents": "/v1/runs/{id}/agents"
+  }
+}
+```
+
+Status codes:
+
+- `201` when the queued run was created and the workflow start succeeded
+- `400` for malformed JSON or invalid benchmark/deployment references
+- `401` when auth headers are missing or invalid
+- `403` when the caller lacks workspace access
+- `413` when the JSON body exceeds 1 MiB
+- `415` when `Content-Type` is not `application/json`
+- `502` when the run row was created but Temporal workflow start failed
+
+### `GET /v1/runs/{id}`
+
+Success response fields:
+
+- `id`
+- `workspace_id`
+- `challenge_pack_version_id`
+- `challenge_input_set_id`
+- `name`
+- `status`
+- `execution_mode`
+- `temporal_workflow_id`
+- `temporal_run_id`
+- `queued_at`
+- `started_at`
+- `finished_at`
+- `cancelled_at`
+- `failed_at`
+- `created_at`
+- `updated_at`
+- `links`
+
+Status codes:
+
+- `200` when the run exists and belongs to one of the caller's workspaces
+- `400` when `{id}` is not a UUID
+- `401` when auth headers are missing or invalid
+- `403` when the caller lacks workspace access
+- `404` when the run does not exist
+
+### `GET /v1/runs/{id}/agents`
+
+Success response shape:
+
+```json
+{
+  "items": [
+    {
+      "id": "uuid",
+      "run_id": "uuid",
+      "lane_index": 0,
+      "label": "lane label",
+      "agent_deployment_id": "uuid",
+      "agent_deployment_snapshot_id": "uuid",
+      "status": "queued",
+      "queued_at": "timestamp",
+      "started_at": "timestamp",
+      "finished_at": "timestamp",
+      "failure_reason": "string-or-null",
+      "created_at": "timestamp",
+      "updated_at": "timestamp"
+    }
+  ]
+}
+```
+
+Status codes:
+
+- `200` when the run exists and the caller is authorized
+- `400`, `401`, `403`, and `404` with the same meanings as `GET /v1/runs/{id}`
+
+### `GET /v1/replays/{runAgentId}`
+
+Success response fields:
+
+- `id`
+- `run_agent_id`
+- `run_id`
+- `artifact_id`
+- `summary`
+- `latest_sequence_number`
+- `event_count`
+- `created_at`
+- `updated_at`
+
+Status codes:
+
+- `200` when a replay row exists for the requested run agent
+- `400` when `{runAgentId}` is not a UUID
+- `401` when auth headers are missing or invalid
+- `403` when the caller lacks workspace access
+- `404` when the run agent or replay row does not exist
+
+### `GET /v1/scorecards/{runAgentId}`
+
+Success response fields:
+
+- `id`
+- `run_agent_id`
+- `run_id`
+- `evaluation_spec_id`
+- `overall_score`
+- `correctness_score`
+- `reliability_score`
+- `latency_score`
+- `cost_score`
+- `scorecard`
+- `created_at`
+- `updated_at`
+
+Status codes:
+
+- `200` when a scorecard row exists for the requested run agent
+- `400` when `{runAgentId}` is not a UUID
+- `401` when auth headers are missing or invalid
+- `403` when the caller lacks workspace access
+- `404` when the run agent or scorecard row does not exist
+
 Protected development endpoints currently use a temporary header-backed auth contract so the API-side tenancy boundary can be exercised before full WorkOS integration exists.
 
 Example:


### PR DESCRIPTION
## Summary
- add focused Step 4 validation and error-path tests across the run creation, run read, and replay read HTTP/service layers
- document endpoint request/response contracts and expected status codes for the current API slice
- fix oversized POST /v1/runs request handling so bodies over 1 MiB return 413 as intended

## Testing
- env GOCACHE=/tmp/agentclash-go-build go test ./...

Closes #10
Part of #6