### PR TITLE
Materialize within-run scorecards

### DIFF
--- a/backend/db/queries/scoring_results.sql
+++ b/backend/db/queries/scoring_results.sql
@@ -103,3 +103,27 @@ DO UPDATE SET
     cost_score = EXCLUDED.cost_score,
     scorecard = EXCLUDED.scorecard
 RETURNING id, run_agent_id, evaluation_spec_id, overall_score, correctness_score, reliability_score, latency_score, cost_score, scorecard, created_at, updated_at;
+
+-- name: GetRunScorecardByRunID :one
+SELECT id, run_id, evaluation_spec_id, winning_run_agent_id, scorecard, created_at, updated_at
+FROM run_scorecards
+WHERE run_id = @run_id;
+
+-- name: UpsertRunScorecard :one
+INSERT INTO run_scorecards (
+    run_id,
+    evaluation_spec_id,
+    winning_run_agent_id,
+    scorecard
+) VALUES (
+    @run_id,
+    @evaluation_spec_id,
+    @winning_run_agent_id,
+    @scorecard
+)
+ON CONFLICT (run_id)
+DO UPDATE SET
+    evaluation_spec_id = EXCLUDED.evaluation_spec_id,
+    winning_run_agent_id = EXCLUDED.winning_run_agent_id,
+    scorecard = EXCLUDED.scorecard
+RETURNING id, run_id, evaluation_spec_id, winning_run_agent_id, scorecard, created_at, updated_at;

--- a/backend/internal/repository/errors.go
+++ b/backend/internal/repository/errors.go
@@ -12,6 +12,7 @@ var (
 	ErrRunAgentNotFound             = errors.New("run agent not found")
 	ErrRunAgentReplayNotFound       = errors.New("run agent replay not found")
 	ErrRunAgentScorecardNotFound    = errors.New("run agent scorecard not found")
+	ErrRunScorecardNotFound         = errors.New("run scorecard not found")
 	ErrRunComparisonNotFound        = errors.New("run comparison not found")
 	ErrEvaluationSpecNotFound       = errors.New("evaluation spec not found")
 	ErrChallengePackVersionNotFound = errors.New("challenge pack version not found")

--- a/backend/internal/repository/repository_integration_test.go
+++ b/backend/internal/repository/repository_integration_test.go
@@ -1107,6 +1107,65 @@ func TestRepositoryGetRunAgentScorecardByRunAgentIDPreservesNullScores(t *testin
 	}
 }
 
+func TestRepositoryBuildRunScorecardPersistsWinnerAndSummary(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	evaluationSpecID := insertEvaluationSpecRecord(t, ctx, db, fixture.challengePackVersionID, "run-scorecard", 1)
+	insertRunAgentScorecardRecord(t, ctx, db, fixture.primaryRunAgentID, evaluationSpecID, scorecardFixture{
+		Correctness: float64Ptr(0.84),
+		Reliability: float64Ptr(0.72),
+	})
+	insertRunAgentScorecardRecord(t, ctx, db, fixture.secondaryRunAgentID, evaluationSpecID, scorecardFixture{
+		Correctness: float64Ptr(0.84),
+		Reliability: float64Ptr(0.91),
+	})
+
+	scorecard, err := repo.BuildRunScorecard(ctx, fixture.runID)
+	if err != nil {
+		t.Fatalf("BuildRunScorecard returned error: %v", err)
+	}
+	if scorecard.RunID != fixture.runID {
+		t.Fatalf("run id = %s, want %s", scorecard.RunID, fixture.runID)
+	}
+	if scorecard.WinningRunAgentID == nil || *scorecard.WinningRunAgentID != fixture.secondaryRunAgentID {
+		t.Fatalf("winning run agent id = %v, want %s", scorecard.WinningRunAgentID, fixture.secondaryRunAgentID)
+	}
+
+	stored, err := repo.GetRunScorecardByRunID(ctx, fixture.runID)
+	if err != nil {
+		t.Fatalf("GetRunScorecardByRunID returned error: %v", err)
+	}
+	if stored.ID != scorecard.ID {
+		t.Fatalf("stored id = %s, want %s", stored.ID, scorecard.ID)
+	}
+
+	document := decodeReplaySummary(t, stored.Scorecard)
+	if document["winning_run_agent_id"] != fixture.secondaryRunAgentID.String() {
+		t.Fatalf("winning_run_agent_id = %v, want %s", document["winning_run_agent_id"], fixture.secondaryRunAgentID)
+	}
+	winnerDetermination, ok := document["winner_determination"].(map[string]any)
+	if !ok {
+		t.Fatalf("winner_determination = %T, want map", document["winner_determination"])
+	}
+	if winnerDetermination["reason_code"] != "reliability_tiebreaker" {
+		t.Fatalf("winner reason_code = %v, want reliability_tiebreaker", winnerDetermination["reason_code"])
+	}
+	dimensionDeltas, ok := document["dimension_deltas"].(map[string]any)
+	if !ok {
+		t.Fatalf("dimension_deltas = %T, want map", document["dimension_deltas"])
+	}
+	reliabilityDelta, ok := dimensionDeltas["reliability"].(map[string]any)
+	if !ok {
+		t.Fatalf("reliability delta = %T, want map", dimensionDeltas["reliability"])
+	}
+	if delta, ok := reliabilityDelta["delta"].(float64); !ok || math.Abs(delta-0.19) > 1e-9 {
+		t.Fatalf("reliability delta = %v, want 0.19", reliabilityDelta["delta"])
+	}
+}
+
 func TestRepositoryCreateEvaluationSpecAndReadItBack(t *testing.T) {
 	ctx := context.Background()
 	db := openTestDB(t)

--- a/backend/internal/repository/run_scorecard.go
+++ b/backend/internal/repository/run_scorecard.go
@@ -1,0 +1,442 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/domain"
+	repositorysqlc "github.com/Atharva-Kanherkar/agentclash/backend/internal/repository/sqlc"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+const runScorecardSummarySchemaVersion = "2026-03-17"
+
+type RunScorecard struct {
+	ID                uuid.UUID
+	RunID             uuid.UUID
+	EvaluationSpecID  uuid.UUID
+	WinningRunAgentID *uuid.UUID
+	Scorecard         json.RawMessage
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+}
+
+type runScorecardParticipant struct {
+	runAgent  domain.RunAgent
+	scorecard *RunAgentScorecard
+	document  *comparisonScorecardDocument
+}
+
+type runScorecardDocument struct {
+	SchemaVersion       string                       `json:"schema_version"`
+	RunID               uuid.UUID                    `json:"run_id"`
+	EvaluationSpecID    uuid.UUID                    `json:"evaluation_spec_id"`
+	WinningRunAgentID   *uuid.UUID                   `json:"winning_run_agent_id,omitempty"`
+	WinnerDetermination runScorecardWinnerSummary    `json:"winner_determination"`
+	Agents              []runScorecardAgentSummary   `json:"agents"`
+	DimensionDeltas     map[string]runScorecardDelta `json:"dimension_deltas"`
+	EvidenceQuality     runScorecardEvidenceQuality  `json:"evidence_quality"`
+}
+
+type runScorecardWinnerSummary struct {
+	Strategy   string `json:"strategy"`
+	Status     string `json:"status"`
+	ReasonCode string `json:"reason_code"`
+}
+
+type runScorecardAgentSummary struct {
+	RunAgentID       uuid.UUID                                   `json:"run_agent_id"`
+	LaneIndex        int32                                       `json:"lane_index"`
+	Label            string                                      `json:"label"`
+	Status           domain.RunAgentStatus                       `json:"status"`
+	HasScorecard     bool                                        `json:"has_scorecard"`
+	EvaluationStatus string                                      `json:"evaluation_status,omitempty"`
+	OverallScore     *float64                                    `json:"overall_score,omitempty"`
+	CorrectnessScore *float64                                    `json:"correctness_score,omitempty"`
+	ReliabilityScore *float64                                    `json:"reliability_score,omitempty"`
+	LatencyScore     *float64                                    `json:"latency_score,omitempty"`
+	CostScore        *float64                                    `json:"cost_score,omitempty"`
+	Dimensions       map[string]comparisonScorecardDimensionInfo `json:"dimensions,omitempty"`
+}
+
+type runScorecardDelta struct {
+	BetterDirection string                       `json:"better_direction"`
+	State           string                       `json:"state"`
+	WinnerValue     *float64                     `json:"winner_value,omitempty"`
+	RunnerUpValue   *float64                     `json:"runner_up_value,omitempty"`
+	Delta           *float64                     `json:"delta,omitempty"`
+	Values          []runScorecardDimensionValue `json:"values"`
+}
+
+type runScorecardDimensionValue struct {
+	RunAgentID uuid.UUID `json:"run_agent_id"`
+	State      string    `json:"state"`
+	Value      *float64  `json:"value,omitempty"`
+}
+
+type runScorecardEvidenceQuality struct {
+	MissingFields []string `json:"missing_fields,omitempty"`
+	Warnings      []string `json:"warnings,omitempty"`
+}
+
+type scoredRunAgent struct {
+	runAgent         domain.RunAgent
+	scorecard        RunAgentScorecard
+	correctnessScore *float64
+	reliabilityScore *float64
+}
+
+func (r *Repository) GetRunScorecardByRunID(ctx context.Context, runID uuid.UUID) (RunScorecard, error) {
+	row, err := r.queries.GetRunScorecardByRunID(ctx, repositorysqlc.GetRunScorecardByRunIDParams{RunID: runID})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return RunScorecard{}, ErrRunScorecardNotFound
+		}
+		return RunScorecard{}, fmt.Errorf("get run scorecard by run id: %w", err)
+	}
+
+	scorecard, err := mapRunScorecard(row)
+	if err != nil {
+		return RunScorecard{}, fmt.Errorf("map run scorecard: %w", err)
+	}
+
+	return scorecard, nil
+}
+
+func (r *Repository) BuildRunScorecard(ctx context.Context, runID uuid.UUID) (RunScorecard, error) {
+	runAgents, err := r.ListRunAgentsByRunID(ctx, runID)
+	if err != nil {
+		return RunScorecard{}, fmt.Errorf("list run agents: %w", err)
+	}
+	if len(runAgents) == 0 {
+		return RunScorecard{}, fmt.Errorf("build run scorecard: run %s has no run agents", runID)
+	}
+
+	participants := make([]runScorecardParticipant, 0, len(runAgents))
+	warnings := make([]string, 0)
+	var evaluationSpecID *uuid.UUID
+
+	for _, runAgent := range runAgents {
+		participant := runScorecardParticipant{runAgent: runAgent}
+
+		scorecard, err := r.GetRunAgentScorecardByRunAgentID(ctx, runAgent.ID)
+		switch {
+		case err == nil:
+			document, decodeErr := decodeComparisonScorecard(scorecard.Scorecard)
+			if decodeErr != nil {
+				return RunScorecard{}, fmt.Errorf("decode run-agent scorecard %s: %w", runAgent.ID, decodeErr)
+			}
+			if evaluationSpecID == nil {
+				value := scorecard.EvaluationSpecID
+				evaluationSpecID = &value
+			} else if *evaluationSpecID != scorecard.EvaluationSpecID {
+				return RunScorecard{}, fmt.Errorf("build run scorecard: run %s has inconsistent evaluation specs", runID)
+			}
+			participant.scorecard = &scorecard
+			participant.document = &document
+		case errors.Is(err, ErrRunAgentScorecardNotFound):
+			warnings = append(warnings, fmt.Sprintf("run-agent %s scorecard unavailable", runAgent.ID))
+		default:
+			return RunScorecard{}, fmt.Errorf("load run-agent scorecard %s: %w", runAgent.ID, err)
+		}
+
+		participants = append(participants, participant)
+	}
+
+	if evaluationSpecID == nil {
+		return RunScorecard{}, fmt.Errorf("build run scorecard: run %s has no run-agent scorecards", runID)
+	}
+
+	document, winningRunAgentID, err := buildRunScorecardDocument(runID, *evaluationSpecID, participants, warnings)
+	if err != nil {
+		return RunScorecard{}, err
+	}
+
+	row, err := r.queries.UpsertRunScorecard(ctx, repositorysqlc.UpsertRunScorecardParams{
+		RunID:             runID,
+		EvaluationSpecID:  *evaluationSpecID,
+		WinningRunAgentID: cloneUUIDPtr(winningRunAgentID),
+		Scorecard:         document,
+	})
+	if err != nil {
+		return RunScorecard{}, fmt.Errorf("upsert run scorecard: %w", err)
+	}
+
+	scorecard, err := mapRunScorecard(row)
+	if err != nil {
+		return RunScorecard{}, fmt.Errorf("map run scorecard: %w", err)
+	}
+	return scorecard, nil
+}
+
+func buildRunScorecardDocument(
+	runID uuid.UUID,
+	evaluationSpecID uuid.UUID,
+	participants []runScorecardParticipant,
+	warnings []string,
+) (json.RawMessage, *uuid.UUID, error) {
+	agents := make([]runScorecardAgentSummary, 0, len(participants))
+	scoredAgents := make([]scoredRunAgent, 0, len(participants))
+	missingFields := make([]string, 0)
+
+	for _, participant := range participants {
+		summary := runScorecardAgentSummary{
+			RunAgentID:   participant.runAgent.ID,
+			LaneIndex:    participant.runAgent.LaneIndex,
+			Label:        participant.runAgent.Label,
+			Status:       participant.runAgent.Status,
+			HasScorecard: participant.scorecard != nil,
+		}
+
+		if participant.scorecard != nil && participant.document != nil {
+			summary.EvaluationStatus = participant.document.Status
+			summary.OverallScore = cloneFloat64Ptr(participant.scorecard.OverallScore)
+			summary.CorrectnessScore = cloneFloat64Ptr(participant.scorecard.CorrectnessScore)
+			summary.ReliabilityScore = cloneFloat64Ptr(participant.scorecard.ReliabilityScore)
+			summary.LatencyScore = cloneFloat64Ptr(participant.scorecard.LatencyScore)
+			summary.CostScore = cloneFloat64Ptr(participant.scorecard.CostScore)
+			summary.Dimensions = cloneRunScorecardDimensions(participant.document.Dimensions)
+			scoredAgents = append(scoredAgents, scoredRunAgent{
+				runAgent:         participant.runAgent,
+				scorecard:        *participant.scorecard,
+				correctnessScore: availableDimensionScore(participant.scorecard.CorrectnessScore, participant.document.Dimensions["correctness"]),
+				reliabilityScore: availableDimensionScore(participant.scorecard.ReliabilityScore, participant.document.Dimensions["reliability"]),
+			})
+		}
+
+		agents = append(agents, summary)
+	}
+
+	sort.Slice(agents, func(i, j int) bool {
+		return agents[i].LaneIndex < agents[j].LaneIndex
+	})
+
+	dimensionDeltas := map[string]runScorecardDelta{
+		"correctness": buildRunScorecardDelta(participants, "correctness", "higher", &missingFields),
+		"reliability": buildRunScorecardDelta(participants, "reliability", "higher", &missingFields),
+		"latency":     buildRunScorecardDelta(participants, "latency", "lower", &missingFields),
+		"cost":        buildRunScorecardDelta(participants, "cost", "lower", &missingFields),
+	}
+
+	winningRunAgentID, winnerSummary := determineRunWinner(participants, scoredAgents)
+	document := runScorecardDocument{
+		SchemaVersion:       runScorecardSummarySchemaVersion,
+		RunID:               runID,
+		EvaluationSpecID:    evaluationSpecID,
+		WinningRunAgentID:   cloneUUIDPtr(winningRunAgentID),
+		WinnerDetermination: winnerSummary,
+		Agents:              agents,
+		DimensionDeltas:     dimensionDeltas,
+		EvidenceQuality: runScorecardEvidenceQuality{
+			MissingFields: uniqueSortedStrings(missingFields),
+			Warnings:      uniqueSortedStrings(warnings),
+		},
+	}
+
+	encoded, err := json.Marshal(document)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal run scorecard: %w", err)
+	}
+	return encoded, winningRunAgentID, nil
+}
+
+func determineRunWinner(participants []runScorecardParticipant, scoredAgents []scoredRunAgent) (*uuid.UUID, runScorecardWinnerSummary) {
+	summary := runScorecardWinnerSummary{
+		Strategy: "correctness_then_reliability",
+	}
+
+	if len(participants) == 1 {
+		winner := participants[0].runAgent.ID
+		summary.Status = "winner"
+		summary.ReasonCode = "single_agent_trivial_winner"
+		return &winner, summary
+	}
+	if len(scoredAgents) == 0 {
+		summary.Status = "inconclusive"
+		summary.ReasonCode = "no_scored_agents"
+		return nil, summary
+	}
+
+	bestCorrectness := highestAgentsByScore(scoredAgents, func(agent scoredRunAgent) *float64 { return agent.correctnessScore })
+	if len(bestCorrectness) == 0 {
+		summary.Status = "inconclusive"
+		summary.ReasonCode = "missing_correctness"
+		return nil, summary
+	}
+	if len(bestCorrectness) == 1 {
+		winner := bestCorrectness[0].runAgent.ID
+		summary.Status = "winner"
+		summary.ReasonCode = "best_correctness"
+		return &winner, summary
+	}
+
+	bestReliability := highestAgentsByScore(bestCorrectness, func(agent scoredRunAgent) *float64 { return agent.reliabilityScore })
+	if len(bestReliability) == 0 {
+		summary.Status = "inconclusive"
+		summary.ReasonCode = "missing_reliability_tiebreaker"
+		return nil, summary
+	}
+	if len(bestReliability) == 1 {
+		winner := bestReliability[0].runAgent.ID
+		summary.Status = "winner"
+		summary.ReasonCode = "reliability_tiebreaker"
+		return &winner, summary
+	}
+
+	summary.Status = "tie"
+	summary.ReasonCode = "correctness_reliability_tie"
+	return nil, summary
+}
+
+func highestAgentsByScore[T any](agents []T, scoreFn func(T) *float64) []T {
+	var best *float64
+	selected := make([]T, 0, len(agents))
+	for _, agent := range agents {
+		score := scoreFn(agent)
+		if score == nil {
+			continue
+		}
+		switch {
+		case best == nil || *score > *best:
+			value := *score
+			best = &value
+			selected = []T{agent}
+		case *score == *best:
+			selected = append(selected, agent)
+		}
+	}
+	return selected
+}
+
+func buildRunScorecardDelta(
+	participants []runScorecardParticipant,
+	dimension string,
+	betterDirection string,
+	missingFields *[]string,
+) runScorecardDelta {
+	values := make([]runScorecardDimensionValue, 0, len(participants))
+	available := make([]runScorecardDimensionValue, 0, len(participants))
+
+	for _, participant := range participants {
+		value := runScorecardDimensionValue{
+			RunAgentID: participant.runAgent.ID,
+			State:      "unavailable",
+		}
+		if participant.scorecard != nil && participant.document != nil {
+			info := participant.document.Dimensions[dimension]
+			score := scoreByDimension(*participant.scorecard, dimension)
+			value.State = info.State
+			value.Value = availableDimensionScore(score, info)
+			if value.Value != nil {
+				value.State = "available"
+				available = append(available, value)
+			} else if value.State == "" {
+				value.State = "unavailable"
+			}
+		}
+		values = append(values, value)
+	}
+
+	delta := runScorecardDelta{
+		BetterDirection: betterDirection,
+		State:           "unavailable",
+		Values:          values,
+	}
+	if len(available) < 2 {
+		*missingFields = append(*missingFields, "dimension_deltas."+dimension)
+		return delta
+	}
+
+	sort.Slice(available, func(i, j int) bool {
+		left := *available[i].Value
+		right := *available[j].Value
+		if betterDirection == "lower" {
+			if left == right {
+				return available[i].RunAgentID.String() < available[j].RunAgentID.String()
+			}
+			return left < right
+		}
+		if left == right {
+			return available[i].RunAgentID.String() < available[j].RunAgentID.String()
+		}
+		return left > right
+	})
+
+	best := *available[0].Value
+	runnerUp := *available[1].Value
+	margin := best - runnerUp
+	if betterDirection == "lower" {
+		margin = runnerUp - best
+	}
+
+	delta.State = "available"
+	delta.WinnerValue = cloneFloat64Ptr(&best)
+	delta.RunnerUpValue = cloneFloat64Ptr(&runnerUp)
+	delta.Delta = cloneFloat64Ptr(&margin)
+	return delta
+}
+
+func availableDimensionScore(score *float64, dimension comparisonScorecardDimensionInfo) *float64 {
+	if score == nil {
+		return nil
+	}
+	if dimension.State != "available" {
+		return nil
+	}
+	return cloneFloat64Ptr(score)
+}
+
+func scoreByDimension(scorecard RunAgentScorecard, dimension string) *float64 {
+	switch dimension {
+	case "correctness":
+		return scorecard.CorrectnessScore
+	case "reliability":
+		return scorecard.ReliabilityScore
+	case "latency":
+		return scorecard.LatencyScore
+	case "cost":
+		return scorecard.CostScore
+	default:
+		return nil
+	}
+}
+
+func cloneRunScorecardDimensions(input map[string]comparisonScorecardDimensionInfo) map[string]comparisonScorecardDimensionInfo {
+	if len(input) == 0 {
+		return nil
+	}
+	cloned := make(map[string]comparisonScorecardDimensionInfo, len(input))
+	for key, value := range input {
+		cloned[key] = comparisonScorecardDimensionInfo{
+			State: value.State,
+			Score: cloneFloat64Ptr(value.Score),
+		}
+	}
+	return cloned
+}
+
+func mapRunScorecard(row repositorysqlc.RunScorecard) (RunScorecard, error) {
+	createdAt, err := requiredTime("run_scorecards.created_at", row.CreatedAt)
+	if err != nil {
+		return RunScorecard{}, err
+	}
+	updatedAt, err := requiredTime("run_scorecards.updated_at", row.UpdatedAt)
+	if err != nil {
+		return RunScorecard{}, err
+	}
+
+	return RunScorecard{
+		ID:                row.ID,
+		RunID:             row.RunID,
+		EvaluationSpecID:  row.EvaluationSpecID,
+		WinningRunAgentID: cloneUUIDPtr(row.WinningRunAgentID),
+		Scorecard:         cloneJSON(row.Scorecard),
+		CreatedAt:         createdAt,
+		UpdatedAt:         updatedAt,
+	}, nil
+}

--- a/backend/internal/repository/run_scorecard_test.go
+++ b/backend/internal/repository/run_scorecard_test.go
@@ -1,0 +1,183 @@
+package repository
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/domain"
+	"github.com/google/uuid"
+)
+
+func TestBuildRunScorecardDocumentSelectsWinnerByCorrectnessThenReliability(t *testing.T) {
+	runID := uuid.New()
+	evaluationSpecID := uuid.New()
+	firstAgentID := uuid.New()
+	secondAgentID := uuid.New()
+
+	document, winningRunAgentID, err := buildRunScorecardDocument(runID, evaluationSpecID, []runScorecardParticipant{
+		scorecardParticipantFixture(0, "baseline", domain.RunAgentStatusCompleted, runAgentScorecardFixture{
+			RunAgentID:       firstAgentID,
+			EvaluationSpecID: evaluationSpecID,
+			CorrectnessScore: float64Ptr(0.9),
+			ReliabilityScore: float64Ptr(0.7),
+		}),
+		scorecardParticipantFixture(1, "candidate", domain.RunAgentStatusCompleted, runAgentScorecardFixture{
+			RunAgentID:       secondAgentID,
+			EvaluationSpecID: evaluationSpecID,
+			CorrectnessScore: float64Ptr(0.9),
+			ReliabilityScore: float64Ptr(0.8),
+		}),
+	}, nil)
+	if err != nil {
+		t.Fatalf("buildRunScorecardDocument returned error: %v", err)
+	}
+	if winningRunAgentID == nil || *winningRunAgentID != secondAgentID {
+		t.Fatalf("winning run agent id = %v, want %s", winningRunAgentID, secondAgentID)
+	}
+
+	var decoded runScorecardDocument
+	if err := json.Unmarshal(document, &decoded); err != nil {
+		t.Fatalf("unmarshal run scorecard document: %v", err)
+	}
+	if decoded.WinnerDetermination.ReasonCode != "reliability_tiebreaker" {
+		t.Fatalf("winner reason code = %q, want reliability_tiebreaker", decoded.WinnerDetermination.ReasonCode)
+	}
+	if decoded.DimensionDeltas["correctness"].Delta == nil || *decoded.DimensionDeltas["correctness"].Delta != 0 {
+		t.Fatalf("correctness delta = %v, want 0", decoded.DimensionDeltas["correctness"].Delta)
+	}
+	if decoded.DimensionDeltas["reliability"].Delta == nil || math.Abs(*decoded.DimensionDeltas["reliability"].Delta-0.1) > 1e-9 {
+		t.Fatalf("reliability delta = %v, want 0.1", decoded.DimensionDeltas["reliability"].Delta)
+	}
+}
+
+func TestBuildRunScorecardDocumentMarksSingleAgentAsTrivialWinner(t *testing.T) {
+	runID := uuid.New()
+	evaluationSpecID := uuid.New()
+	runAgentID := uuid.New()
+
+	_, winningRunAgentID, err := buildRunScorecardDocument(runID, evaluationSpecID, []runScorecardParticipant{
+		scorecardParticipantFixture(0, "solo", domain.RunAgentStatusCompleted, runAgentScorecardFixture{
+			RunAgentID:       runAgentID,
+			EvaluationSpecID: evaluationSpecID,
+			CorrectnessScore: float64Ptr(0.65),
+		}),
+	}, nil)
+	if err != nil {
+		t.Fatalf("buildRunScorecardDocument returned error: %v", err)
+	}
+	if winningRunAgentID == nil || *winningRunAgentID != runAgentID {
+		t.Fatalf("winning run agent id = %v, want %s", winningRunAgentID, runAgentID)
+	}
+}
+
+func TestBuildRunScorecardDocumentLeavesWinnerUnsetForTie(t *testing.T) {
+	runID := uuid.New()
+	evaluationSpecID := uuid.New()
+
+	document, winningRunAgentID, err := buildRunScorecardDocument(runID, evaluationSpecID, []runScorecardParticipant{
+		scorecardParticipantFixture(0, "left", domain.RunAgentStatusCompleted, runAgentScorecardFixture{
+			RunAgentID:       uuid.New(),
+			EvaluationSpecID: evaluationSpecID,
+			CorrectnessScore: float64Ptr(0.9),
+			ReliabilityScore: float64Ptr(0.8),
+		}),
+		scorecardParticipantFixture(1, "right", domain.RunAgentStatusCompleted, runAgentScorecardFixture{
+			RunAgentID:       uuid.New(),
+			EvaluationSpecID: evaluationSpecID,
+			CorrectnessScore: float64Ptr(0.9),
+			ReliabilityScore: float64Ptr(0.8),
+		}),
+	}, nil)
+	if err != nil {
+		t.Fatalf("buildRunScorecardDocument returned error: %v", err)
+	}
+	if winningRunAgentID != nil {
+		t.Fatalf("winning run agent id = %v, want nil", *winningRunAgentID)
+	}
+
+	var decoded runScorecardDocument
+	if err := json.Unmarshal(document, &decoded); err != nil {
+		t.Fatalf("unmarshal run scorecard document: %v", err)
+	}
+	if decoded.WinnerDetermination.Status != "tie" {
+		t.Fatalf("winner status = %q, want tie", decoded.WinnerDetermination.Status)
+	}
+}
+
+func scorecardParticipantFixture(
+	laneIndex int32,
+	label string,
+	status domain.RunAgentStatus,
+	fixture runAgentScorecardFixture,
+) runScorecardParticipant {
+	runAgent := domain.RunAgent{
+		ID:        fixture.RunAgentID,
+		RunID:     uuid.New(),
+		LaneIndex: laneIndex,
+		Label:     label,
+		Status:    status,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+	scorecard := RunAgentScorecard{
+		ID:               uuid.New(),
+		RunAgentID:       fixture.RunAgentID,
+		EvaluationSpecID: fixture.EvaluationSpecID,
+		OverallScore:     fixture.OverallScore,
+		CorrectnessScore: fixture.CorrectnessScore,
+		ReliabilityScore: fixture.ReliabilityScore,
+		LatencyScore:     fixture.LatencyScore,
+		CostScore:        fixture.CostScore,
+		Scorecard:        fixture.document(),
+		CreatedAt:        time.Now().UTC(),
+		UpdatedAt:        time.Now().UTC(),
+	}
+	document, err := decodeComparisonScorecard(scorecard.Scorecard)
+	if err != nil {
+		panic(err)
+	}
+	return runScorecardParticipant{
+		runAgent:  runAgent,
+		scorecard: &scorecard,
+		document:  &document,
+	}
+}
+
+type runAgentScorecardFixture struct {
+	RunAgentID       uuid.UUID
+	EvaluationSpecID uuid.UUID
+	OverallScore     *float64
+	CorrectnessScore *float64
+	ReliabilityScore *float64
+	LatencyScore     *float64
+	CostScore        *float64
+}
+
+func (f runAgentScorecardFixture) document() []byte {
+	payload, err := json.Marshal(map[string]any{
+		"status": "complete",
+		"dimensions": map[string]any{
+			"correctness": map[string]any{"state": scorecardState(f.CorrectnessScore), "score": f.CorrectnessScore},
+			"reliability": map[string]any{"state": scorecardState(f.ReliabilityScore), "score": f.ReliabilityScore},
+			"latency":     map[string]any{"state": scorecardState(f.LatencyScore), "score": f.LatencyScore},
+			"cost":        map[string]any{"state": scorecardState(f.CostScore), "score": f.CostScore},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return payload
+}
+
+func scorecardState(score *float64) string {
+	if score == nil {
+		return "unavailable"
+	}
+	return "available"
+}
+
+func float64Ptr(value float64) *float64 {
+	return &value
+}

--- a/backend/internal/repository/sqlc/models.go
+++ b/backend/internal/repository/sqlc/models.go
@@ -194,6 +194,16 @@ type RunEvent struct {
 	Payload        []byte
 }
 
+type RunScorecard struct {
+	ID                uuid.UUID
+	RunID             uuid.UUID
+	EvaluationSpecID  uuid.UUID
+	WinningRunAgentID *uuid.UUID
+	Scorecard         []byte
+	CreatedAt         pgtype.Timestamptz
+	UpdatedAt         pgtype.Timestamptz
+}
+
 type RunStatusHistory struct {
 	ID              uuid.UUID
 	RunID           uuid.UUID

--- a/backend/internal/repository/sqlc/querier.go
+++ b/backend/internal/repository/sqlc/querier.go
@@ -24,6 +24,7 @@ type Querier interface {
 	GetRunAgentScorecardByRunAgentID(ctx context.Context, arg GetRunAgentScorecardByRunAgentIDParams) (RunAgentScorecard, error)
 	GetRunByID(ctx context.Context, arg GetRunByIDParams) (Run, error)
 	GetRunComparisonByRunIDs(ctx context.Context, arg GetRunComparisonByRunIDsParams) (RunComparison, error)
+	GetRunScorecardByRunID(ctx context.Context, arg GetRunScorecardByRunIDParams) (RunScorecard, error)
 	GetRunnableChallengePackVersionByID(ctx context.Context, arg GetRunnableChallengePackVersionByIDParams) (ChallengePackVersion, error)
 	InsertRunAgentStatusHistory(ctx context.Context, arg InsertRunAgentStatusHistoryParams) (RunAgentStatusHistory, error)
 	InsertRunEvent(ctx context.Context, arg InsertRunEventParams) (RunEvent, error)
@@ -47,6 +48,7 @@ type Querier interface {
 	UpsertRunAgentReplaySummary(ctx context.Context, arg UpsertRunAgentReplaySummaryParams) (RunAgentReplay, error)
 	UpsertRunAgentScorecard(ctx context.Context, arg UpsertRunAgentScorecardParams) (RunAgentScorecard, error)
 	UpsertRunComparison(ctx context.Context, arg UpsertRunComparisonParams) (RunComparison, error)
+	UpsertRunScorecard(ctx context.Context, arg UpsertRunScorecardParams) (RunScorecard, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/backend/internal/repository/sqlc/scoring_results.sql.go
+++ b/backend/internal/repository/sqlc/scoring_results.sql.go
@@ -12,6 +12,31 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const getRunScorecardByRunID = `-- name: GetRunScorecardByRunID :one
+SELECT id, run_id, evaluation_spec_id, winning_run_agent_id, scorecard, created_at, updated_at
+FROM run_scorecards
+WHERE run_id = $1
+`
+
+type GetRunScorecardByRunIDParams struct {
+	RunID uuid.UUID
+}
+
+func (q *Queries) GetRunScorecardByRunID(ctx context.Context, arg GetRunScorecardByRunIDParams) (RunScorecard, error) {
+	row := q.db.QueryRow(ctx, getRunScorecardByRunID, arg.RunID)
+	var i RunScorecard
+	err := row.Scan(
+		&i.ID,
+		&i.RunID,
+		&i.EvaluationSpecID,
+		&i.WinningRunAgentID,
+		&i.Scorecard,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const listJudgeResultsByRunAgentAndEvaluationSpec = `-- name: ListJudgeResultsByRunAgentAndEvaluationSpec :many
 SELECT id, run_agent_id, evaluation_spec_id, challenge_identity_id, judge_key, verdict, normalized_score, raw_output, created_at
 FROM judge_results
@@ -307,6 +332,53 @@ func (q *Queries) UpsertRunAgentScorecard(ctx context.Context, arg UpsertRunAgen
 		&i.ReliabilityScore,
 		&i.LatencyScore,
 		&i.CostScore,
+		&i.Scorecard,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const upsertRunScorecard = `-- name: UpsertRunScorecard :one
+INSERT INTO run_scorecards (
+    run_id,
+    evaluation_spec_id,
+    winning_run_agent_id,
+    scorecard
+) VALUES (
+    $1,
+    $2,
+    $3,
+    $4
+)
+ON CONFLICT (run_id)
+DO UPDATE SET
+    evaluation_spec_id = EXCLUDED.evaluation_spec_id,
+    winning_run_agent_id = EXCLUDED.winning_run_agent_id,
+    scorecard = EXCLUDED.scorecard
+RETURNING id, run_id, evaluation_spec_id, winning_run_agent_id, scorecard, created_at, updated_at
+`
+
+type UpsertRunScorecardParams struct {
+	RunID             uuid.UUID
+	EvaluationSpecID  uuid.UUID
+	WinningRunAgentID *uuid.UUID
+	Scorecard         []byte
+}
+
+func (q *Queries) UpsertRunScorecard(ctx context.Context, arg UpsertRunScorecardParams) (RunScorecard, error) {
+	row := q.db.QueryRow(ctx, upsertRunScorecard,
+		arg.RunID,
+		arg.EvaluationSpecID,
+		arg.WinningRunAgentID,
+		arg.Scorecard,
+	)
+	var i RunScorecard
+	err := row.Scan(
+		&i.ID,
+		&i.RunID,
+		&i.EvaluationSpecID,
+		&i.WinningRunAgentID,
 		&i.Scorecard,
 		&i.CreatedAt,
 		&i.UpdatedAt,

--- a/backend/internal/workflow/activities.go
+++ b/backend/internal/workflow/activities.go
@@ -29,6 +29,7 @@ const (
 	markHostedRunTimedOutActivityName        = "workflow.mark_hosted_run_timed_out"
 	executeNativeModelStepActivityName       = "workflow.execute_native_model_step"
 	scoreRunAgentActivityName                = "workflow.score_run_agent"
+	buildRunScorecardActivityName            = "workflow.build_run_scorecard"
 	buildRunAgentReplayActivityName          = "workflow.build_run_agent_replay"
 	simulateExecutionActivityName            = "workflow.simulate_execution"
 	simulateEvaluationActivityName           = "workflow.simulate_evaluation"
@@ -118,6 +119,10 @@ type BuildRunAgentReplayInput struct {
 
 type ScoreRunAgentInput struct {
 	RunAgentID uuid.UUID `json:"run_agent_id"`
+}
+
+type BuildRunScorecardInput struct {
+	RunID uuid.UUID `json:"run_id"`
 }
 
 func NewActivities(repo RunRepository, hooks FakeWorkHooks) *Activities {
@@ -275,6 +280,11 @@ func (a *Activities) BuildRunAgentReplay(ctx context.Context, input BuildRunAgen
 func (a *Activities) ScoreRunAgent(ctx context.Context, input ScoreRunAgentInput) (scoring.RunAgentEvaluation, error) {
 	evaluation, err := executeRunAgentEvaluation(ctx, a.repo, input.RunAgentID)
 	return evaluation, wrapActivityError(err)
+}
+
+func (a *Activities) BuildRunScorecard(ctx context.Context, input BuildRunScorecardInput) (repository.RunScorecard, error) {
+	scorecard, err := a.repo.BuildRunScorecard(ctx, input.RunID)
+	return scorecard, wrapActivityError(err)
 }
 
 func (a *Activities) ExecuteNativeModelStep(ctx context.Context, input RunAgentWorkflowInput) error {

--- a/backend/internal/workflow/register.go
+++ b/backend/internal/workflow/register.go
@@ -25,6 +25,7 @@ func Register(registrar Registrar, activities *Activities) {
 	registrar.RegisterActivityWithOptions(activities.MarkHostedRunTimedOut, sdkactivity.RegisterOptions{Name: markHostedRunTimedOutActivityName})
 	registrar.RegisterActivityWithOptions(activities.ExecuteNativeModelStep, sdkactivity.RegisterOptions{Name: executeNativeModelStepActivityName})
 	registrar.RegisterActivityWithOptions(activities.ScoreRunAgent, sdkactivity.RegisterOptions{Name: scoreRunAgentActivityName})
+	registrar.RegisterActivityWithOptions(activities.BuildRunScorecard, sdkactivity.RegisterOptions{Name: buildRunScorecardActivityName})
 	registrar.RegisterActivityWithOptions(activities.BuildRunAgentReplay, sdkactivity.RegisterOptions{Name: buildRunAgentReplayActivityName})
 	registrar.RegisterActivityWithOptions(activities.SimulateExecution, sdkactivity.RegisterOptions{Name: simulateExecutionActivityName})
 	registrar.RegisterActivityWithOptions(activities.SimulateEvaluation, sdkactivity.RegisterOptions{Name: simulateEvaluationActivityName})

--- a/backend/internal/workflow/repository.go
+++ b/backend/internal/workflow/repository.go
@@ -31,6 +31,7 @@ type RunRepository interface {
 	ListRunEventsByRunAgentID(ctx context.Context, runAgentID uuid.UUID) ([]repository.RunEvent, error)
 	RecordRunEvent(ctx context.Context, params repository.RecordRunEventParams) (repository.RunEvent, error)
 	StoreRunAgentEvaluationResults(ctx context.Context, evaluation scoring.RunAgentEvaluation) error
+	BuildRunScorecard(ctx context.Context, runID uuid.UUID) (repository.RunScorecard, error)
 	BuildRunAgentReplay(ctx context.Context, runAgentID uuid.UUID) (repository.RunAgentReplay, error)
 	SetRunTemporalIDs(ctx context.Context, params repository.SetRunTemporalIDsParams) (domain.Run, error)
 	TransitionRunStatus(ctx context.Context, params repository.TransitionRunStatusParams) (domain.Run, error)

--- a/backend/internal/workflow/run_workflow.go
+++ b/backend/internal/workflow/run_workflow.go
@@ -195,6 +195,12 @@ func scoreEvaluatingRunAgents(ctx sdkworkflow.Context, runAgents []domain.RunAge
 		}
 	}
 
+	if len(runAgents) > 0 {
+		if err := buildRunScorecard(ctx, runAgents[0].RunID); err != nil {
+			return "", err
+		}
+	}
+
 	return summarizeScoreOutcomes(outcomes), nil
 }
 
@@ -238,6 +244,13 @@ func listRunAgents(ctx sdkworkflow.Context, runID uuid.UUID) ([]domain.RunAgent,
 	var runAgents []domain.RunAgent
 	err := sdkworkflow.ExecuteActivity(ctx, listRunAgentsActivityName, ListRunAgentsInput{RunID: runID}).Get(ctx, &runAgents)
 	return runAgents, err
+}
+
+func buildRunScorecard(ctx sdkworkflow.Context, runID uuid.UUID) error {
+	var scorecard struct{}
+	return sdkworkflow.ExecuteActivity(ctx, buildRunScorecardActivityName, BuildRunScorecardInput{
+		RunID: runID,
+	}).Get(ctx, &scorecard)
 }
 
 func attachRunTemporalIDs(ctx sdkworkflow.Context, runID uuid.UUID, workflowID string, temporalRunID string) error {

--- a/backend/internal/workflow/workflow_test.go
+++ b/backend/internal/workflow/workflow_test.go
@@ -85,6 +85,9 @@ func TestRunWorkflowHappyPath(t *testing.T) {
 	if !repo.hasCallPrefix("TransitionRunAgentStatus") {
 		t.Fatalf("expected repository TransitionRunAgentStatus to be used")
 	}
+	if repo.callCountWithPrefix("BuildRunScorecard:") != 1 {
+		t.Fatalf("BuildRunScorecard call count = %d, want 1", repo.callCountWithPrefix("BuildRunScorecard:"))
+	}
 }
 
 func TestRunWorkflowStartsOneChildPerRunAgent(t *testing.T) {
@@ -712,6 +715,7 @@ type fakeRunRepository struct {
 	replays             map[uuid.UUID]repository.RunAgentReplay
 	runEvents           map[uuid.UUID][]repository.RunEvent
 	evaluations         map[uuid.UUID]scoring.RunAgentEvaluation
+	runScorecards       map[uuid.UUID]repository.RunScorecard
 	runAgentStatusErrs  map[string]error
 	buildReplayErr      error
 	recordRunEventErr   error
@@ -729,14 +733,15 @@ func newFakeRunRepository(run domain.Run, runAgents ...domain.RunAgent) *fakeRun
 	}
 
 	return &fakeRunRepository{
-		run:               cloneRun(run),
-		runAgents:         runAgentMap,
-		executionContexts: make(map[uuid.UUID]repository.RunAgentExecutionContext),
-		evaluationSpecs:   make(map[string]repository.EvaluationSpecRecord),
-		hostedExecutions:  make(map[uuid.UUID]repository.HostedRunExecution),
-		replays:           make(map[uuid.UUID]repository.RunAgentReplay),
-		runEvents:         make(map[uuid.UUID][]repository.RunEvent),
-		evaluations:       make(map[uuid.UUID]scoring.RunAgentEvaluation),
+		run:                cloneRun(run),
+		runAgents:          runAgentMap,
+		executionContexts:  make(map[uuid.UUID]repository.RunAgentExecutionContext),
+		evaluationSpecs:    make(map[string]repository.EvaluationSpecRecord),
+		hostedExecutions:   make(map[uuid.UUID]repository.HostedRunExecution),
+		replays:            make(map[uuid.UUID]repository.RunAgentReplay),
+		runEvents:          make(map[uuid.UUID][]repository.RunEvent),
+		evaluations:        make(map[uuid.UUID]scoring.RunAgentEvaluation),
+		runScorecards:      make(map[uuid.UUID]repository.RunScorecard),
 		runAgentStatusErrs: make(map[string]error),
 	}
 }
@@ -930,6 +935,22 @@ func (r *fakeRunRepository) StoreRunAgentEvaluationResults(_ context.Context, ev
 	r.evaluations[evaluation.RunAgentID] = evaluation
 	r.callLog = append(r.callLog, fmt.Sprintf("StoreRunAgentEvaluationResults:%s", evaluation.RunAgentID))
 	return nil
+}
+
+func (r *fakeRunRepository) BuildRunScorecard(_ context.Context, runID uuid.UUID) (repository.RunScorecard, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	scorecard := repository.RunScorecard{
+		ID:               uuid.New(),
+		RunID:            runID,
+		EvaluationSpecID: uuid.New(),
+		CreatedAt:        time.Now().UTC(),
+		UpdatedAt:        time.Now().UTC(),
+	}
+	r.runScorecards[runID] = scorecard
+	r.callLog = append(r.callLog, fmt.Sprintf("BuildRunScorecard:%s", runID))
+	return scorecard, nil
 }
 
 func (r *fakeRunRepository) setExecutionContext(runAgentID uuid.UUID, executionContext repository.RunAgentExecutionContext) {


### PR DESCRIPTION
## Summary
- materialize run-level scorecards in the run_scorecards table after parent scoring completes
- compute per-agent summaries, dimension deltas, and winner selection using correctness with reliability as the tiebreaker
- add repository and workflow tests covering winner selection and workflow orchestration

## Testing
- env GOCACHE=/tmp/agentclash-gocache go test ./internal/workflow ./internal/repository/...

Closes #97