### PR TITLE
Add native agent authoring API and UI

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -56,6 +56,7 @@ func main() {
 	)
 	agentDeploymentReadManager := api.NewAgentDeploymentReadManager(repo)
 	challengePackReadManager := api.NewChallengePackReadManager(repo)
+	agentBuildManager := api.NewAgentBuildManager(repo)
 
 	server := api.NewServer(
 		cfg,
@@ -69,6 +70,7 @@ func main() {
 		hostedRunIngestionManager,
 		agentDeploymentReadManager,
 		challengePackReadManager,
+		agentBuildManager,
 	)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/backend/db/queries/agent_builds.sql
+++ b/backend/db/queries/agent_builds.sql
@@ -1,0 +1,67 @@
+-- name: CreateAgentBuild :one
+INSERT INTO agent_builds (organization_id, workspace_id, name, slug, description, created_by_user_id)
+VALUES (@organization_id, @workspace_id, @name, @slug, @description, @created_by_user_id)
+RETURNING *;
+
+-- name: GetAgentBuildByID :one
+SELECT * FROM agent_builds WHERE id = @id AND archived_at IS NULL;
+
+-- name: ListAgentBuildsByWorkspaceID :many
+SELECT * FROM agent_builds
+WHERE workspace_id = @workspace_id AND lifecycle_status = 'active' AND archived_at IS NULL
+ORDER BY updated_at DESC;
+
+-- name: CreateAgentBuildVersion :one
+INSERT INTO agent_build_versions (
+    agent_build_id, version_number, version_status,
+    agent_kind, interface_spec, policy_spec, reasoning_spec,
+    memory_spec, workflow_spec, guardrail_spec, model_spec,
+    output_schema, trace_contract, publication_spec, created_by_user_id
+) VALUES (
+    @agent_build_id, @version_number, 'draft',
+    @agent_kind, @interface_spec, @policy_spec, @reasoning_spec,
+    @memory_spec, @workflow_spec, @guardrail_spec, @model_spec,
+    @output_schema, @trace_contract, @publication_spec, @created_by_user_id
+) RETURNING *;
+
+-- name: GetAgentBuildVersionByID :one
+SELECT * FROM agent_build_versions WHERE id = @id;
+
+-- name: GetLatestVersionNumberForBuild :one
+SELECT COALESCE(MAX(version_number), 0)::integer AS max_version
+FROM agent_build_versions WHERE agent_build_id = @agent_build_id;
+
+-- name: ListAgentBuildVersionsByBuildID :many
+SELECT * FROM agent_build_versions
+WHERE agent_build_id = @agent_build_id
+ORDER BY version_number DESC;
+
+-- name: UpdateAgentBuildVersionDraft :exec
+UPDATE agent_build_versions SET
+    agent_kind = @agent_kind,
+    interface_spec = @interface_spec,
+    policy_spec = @policy_spec,
+    reasoning_spec = @reasoning_spec,
+    memory_spec = @memory_spec,
+    workflow_spec = @workflow_spec,
+    guardrail_spec = @guardrail_spec,
+    model_spec = @model_spec,
+    output_schema = @output_schema,
+    trace_contract = @trace_contract,
+    publication_spec = @publication_spec
+WHERE id = @id AND version_status = 'draft';
+
+-- name: MarkAgentBuildVersionReady :exec
+UPDATE agent_build_versions SET version_status = 'ready'
+WHERE id = @id AND version_status = 'draft';
+
+-- name: CreateAgentDeployment :one
+INSERT INTO agent_deployments (
+    organization_id, workspace_id, agent_build_id, current_build_version_id,
+    runtime_profile_id, provider_account_id, model_alias_id,
+    name, slug, deployment_type, deployment_config
+) VALUES (
+    @organization_id, @workspace_id, @agent_build_id, @current_build_version_id,
+    @runtime_profile_id, @provider_account_id, @model_alias_id,
+    @name, @slug, 'native', @deployment_config
+) RETURNING *;

--- a/backend/internal/api/agent_builds.go
+++ b/backend/internal/api/agent_builds.go
@@ -1,0 +1,1207 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+const maxAgentBuildRequestBytes = 1 << 20
+
+var slugRe = regexp.MustCompile(`[^a-z0-9]+`)
+
+type AgentBuildRepository interface {
+	GetOrganizationIDByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (uuid.UUID, error)
+	CreateAgentBuild(ctx context.Context, params repository.CreateAgentBuildParams) (repository.AgentBuild, error)
+	GetAgentBuildByID(ctx context.Context, id uuid.UUID) (repository.AgentBuild, error)
+	ListAgentBuildsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]repository.AgentBuild, error)
+	CreateAgentBuildVersion(ctx context.Context, params repository.CreateAgentBuildVersionParams) (repository.AgentBuildVersion, error)
+	GetAgentBuildVersionByID(ctx context.Context, id uuid.UUID) (repository.AgentBuildVersion, error)
+	GetLatestVersionNumberForBuild(ctx context.Context, agentBuildID uuid.UUID) (int32, error)
+	ListAgentBuildVersionsByBuildID(ctx context.Context, agentBuildID uuid.UUID) ([]repository.AgentBuildVersion, error)
+	UpdateAgentBuildVersionDraft(ctx context.Context, params repository.UpdateAgentBuildVersionDraftParams) error
+	MarkAgentBuildVersionReady(ctx context.Context, id uuid.UUID) error
+	CreateAgentDeployment(ctx context.Context, params repository.CreateAgentDeploymentParams) (repository.AgentDeploymentRow, error)
+}
+
+type AgentBuildService interface {
+	CreateBuild(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateAgentBuildInput) (repository.AgentBuild, error)
+	GetBuild(ctx context.Context, id uuid.UUID) (repository.AgentBuild, error)
+	ListBuilds(ctx context.Context, workspaceID uuid.UUID) ([]repository.AgentBuild, error)
+	ListVersions(ctx context.Context, agentBuildID uuid.UUID) ([]repository.AgentBuildVersion, error)
+	CreateVersion(ctx context.Context, caller Caller, agentBuildID uuid.UUID, input CreateAgentBuildVersionInput) (repository.AgentBuildVersion, error)
+	GetVersion(ctx context.Context, id uuid.UUID) (repository.AgentBuildVersion, error)
+	UpdateVersion(ctx context.Context, id uuid.UUID, input UpdateAgentBuildVersionInput) (repository.AgentBuildVersion, error)
+	ValidateVersion(ctx context.Context, id uuid.UUID) (ValidateBuildVersionResult, error)
+	MarkVersionReady(ctx context.Context, id uuid.UUID) error
+	CreateDeployment(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateAgentDeploymentInput) (repository.AgentDeploymentRow, error)
+}
+
+type CreateAgentBuildInput struct {
+	Name        string
+	Description string
+}
+
+type CreateAgentBuildVersionInput struct {
+	AgentKind        string
+	InterfaceSpec    json.RawMessage
+	PolicySpec       json.RawMessage
+	ReasoningSpec    json.RawMessage
+	MemorySpec       json.RawMessage
+	WorkflowSpec     json.RawMessage
+	GuardrailSpec    json.RawMessage
+	ModelSpec        json.RawMessage
+	OutputSchema     json.RawMessage
+	TraceContract    json.RawMessage
+	PublicationSpec  json.RawMessage
+	Tools            []repository.AgentBuildVersionToolBinding
+	KnowledgeSources []repository.AgentBuildVersionKnowledgeSourceBinding
+}
+
+type UpdateAgentBuildVersionInput = CreateAgentBuildVersionInput
+
+type CreateAgentDeploymentInput struct {
+	Name              string
+	AgentBuildID      uuid.UUID
+	BuildVersionID    uuid.UUID
+	RuntimeProfileID  uuid.UUID
+	ProviderAccountID *uuid.UUID
+	ModelAliasID      *uuid.UUID
+	DeploymentConfig  json.RawMessage
+}
+
+type ValidateBuildVersionResult struct {
+	Valid  bool
+	Errors []validationErrorDetail
+}
+
+type AgentBuildManager struct {
+	repo AgentBuildRepository
+}
+
+func NewAgentBuildManager(repo AgentBuildRepository) *AgentBuildManager {
+	return &AgentBuildManager{repo: repo}
+}
+
+func (m *AgentBuildManager) CreateBuild(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateAgentBuildInput) (repository.AgentBuild, error) {
+	if strings.TrimSpace(input.Name) == "" {
+		return repository.AgentBuild{}, AgentBuildValidationError{Code: "invalid_name", Message: "name is required"}
+	}
+
+	orgID, err := m.repo.GetOrganizationIDByWorkspaceID(ctx, workspaceID)
+	if err != nil {
+		return repository.AgentBuild{}, err
+	}
+
+	slug := generateSlug(input.Name)
+
+	return m.repo.CreateAgentBuild(ctx, repository.CreateAgentBuildParams{
+		OrganizationID:  orgID,
+		WorkspaceID:     workspaceID,
+		Name:            strings.TrimSpace(input.Name),
+		Slug:            slug,
+		Description:     strings.TrimSpace(input.Description),
+		CreatedByUserID: &caller.UserID,
+	})
+}
+
+func (m *AgentBuildManager) GetBuild(ctx context.Context, id uuid.UUID) (repository.AgentBuild, error) {
+	return m.repo.GetAgentBuildByID(ctx, id)
+}
+
+func (m *AgentBuildManager) ListBuilds(ctx context.Context, workspaceID uuid.UUID) ([]repository.AgentBuild, error) {
+	return m.repo.ListAgentBuildsByWorkspaceID(ctx, workspaceID)
+}
+
+func (m *AgentBuildManager) ListVersions(ctx context.Context, agentBuildID uuid.UUID) ([]repository.AgentBuildVersion, error) {
+	return m.repo.ListAgentBuildVersionsByBuildID(ctx, agentBuildID)
+}
+
+func (m *AgentBuildManager) CreateVersion(ctx context.Context, caller Caller, agentBuildID uuid.UUID, input CreateAgentBuildVersionInput) (repository.AgentBuildVersion, error) {
+	_, err := m.repo.GetAgentBuildByID(ctx, agentBuildID)
+	if err != nil {
+		return repository.AgentBuildVersion{}, err
+	}
+
+	latestVersion, err := m.repo.GetLatestVersionNumberForBuild(ctx, agentBuildID)
+	if err != nil {
+		return repository.AgentBuildVersion{}, err
+	}
+
+	return m.repo.CreateAgentBuildVersion(ctx, repository.CreateAgentBuildVersionParams{
+		AgentBuildID:     agentBuildID,
+		VersionNumber:    latestVersion + 1,
+		AgentKind:        defaultString(input.AgentKind, "llm_agent"),
+		InterfaceSpec:    defaultJSON(input.InterfaceSpec),
+		PolicySpec:       defaultJSON(input.PolicySpec),
+		ReasoningSpec:    defaultJSON(input.ReasoningSpec),
+		MemorySpec:       defaultJSON(input.MemorySpec),
+		WorkflowSpec:     defaultJSON(input.WorkflowSpec),
+		GuardrailSpec:    defaultJSON(input.GuardrailSpec),
+		ModelSpec:        defaultJSON(input.ModelSpec),
+		OutputSchema:     defaultJSON(input.OutputSchema),
+		TraceContract:    defaultJSON(input.TraceContract),
+		PublicationSpec:  defaultJSON(input.PublicationSpec),
+		Tools:            input.Tools,
+		KnowledgeSources: input.KnowledgeSources,
+		CreatedByUserID:  &caller.UserID,
+	})
+}
+
+func (m *AgentBuildManager) GetVersion(ctx context.Context, id uuid.UUID) (repository.AgentBuildVersion, error) {
+	return m.repo.GetAgentBuildVersionByID(ctx, id)
+}
+
+func (m *AgentBuildManager) UpdateVersion(ctx context.Context, id uuid.UUID, input UpdateAgentBuildVersionInput) (repository.AgentBuildVersion, error) {
+	version, err := m.repo.GetAgentBuildVersionByID(ctx, id)
+	if err != nil {
+		return repository.AgentBuildVersion{}, err
+	}
+
+	if version.VersionStatus != "draft" {
+		return repository.AgentBuildVersion{}, AgentBuildValidationError{
+			Code:    "version_not_draft",
+			Message: "only draft versions can be updated",
+		}
+	}
+
+	err = m.repo.UpdateAgentBuildVersionDraft(ctx, repository.UpdateAgentBuildVersionDraftParams{
+		ID:               id,
+		AgentKind:        defaultString(input.AgentKind, version.AgentKind),
+		InterfaceSpec:    defaultJSONOrExisting(input.InterfaceSpec, version.InterfaceSpec),
+		PolicySpec:       defaultJSONOrExisting(input.PolicySpec, version.PolicySpec),
+		ReasoningSpec:    defaultJSONOrExisting(input.ReasoningSpec, version.ReasoningSpec),
+		MemorySpec:       defaultJSONOrExisting(input.MemorySpec, version.MemorySpec),
+		WorkflowSpec:     defaultJSONOrExisting(input.WorkflowSpec, version.WorkflowSpec),
+		GuardrailSpec:    defaultJSONOrExisting(input.GuardrailSpec, version.GuardrailSpec),
+		ModelSpec:        defaultJSONOrExisting(input.ModelSpec, version.ModelSpec),
+		OutputSchema:     defaultJSONOrExisting(input.OutputSchema, version.OutputSchema),
+		TraceContract:    defaultJSONOrExisting(input.TraceContract, version.TraceContract),
+		PublicationSpec:  defaultJSONOrExisting(input.PublicationSpec, version.PublicationSpec),
+		Tools:            defaultToolBindingsOrExisting(input.Tools, version.Tools),
+		KnowledgeSources: defaultKnowledgeSourceBindingsOrExisting(input.KnowledgeSources, version.KnowledgeSources),
+	})
+	if err != nil {
+		return repository.AgentBuildVersion{}, err
+	}
+
+	return m.repo.GetAgentBuildVersionByID(ctx, id)
+}
+
+func (m *AgentBuildManager) ValidateVersion(ctx context.Context, id uuid.UUID) (ValidateBuildVersionResult, error) {
+	version, err := m.repo.GetAgentBuildVersionByID(ctx, id)
+	if err != nil {
+		return ValidateBuildVersionResult{}, err
+	}
+
+	var validationErrors []validationErrorDetail
+
+	validKinds := map[string]bool{
+		"llm_agent": true, "workflow_agent": true, "programmatic_agent": true,
+		"multi_agent_system": true, "hosted_external": true,
+	}
+	if !validKinds[version.AgentKind] {
+		validationErrors = append(validationErrors, validationErrorDetail{
+			Field:   "agent_kind",
+			Message: fmt.Sprintf("agent_kind must be one of: llm_agent, workflow_agent, programmatic_agent, multi_agent_system, hosted_external; got %q", version.AgentKind),
+		})
+	}
+
+	if hasInstructions := jsonHasKey(version.PolicySpec, "instructions"); !hasInstructions {
+		validationErrors = append(validationErrors, validationErrorDetail{
+			Field:   "policy_spec",
+			Message: "policy_spec must contain an 'instructions' field",
+		})
+	}
+
+	return ValidateBuildVersionResult{
+		Valid:  len(validationErrors) == 0,
+		Errors: validationErrors,
+	}, nil
+}
+
+func (m *AgentBuildManager) MarkVersionReady(ctx context.Context, id uuid.UUID) error {
+	result, err := m.ValidateVersion(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !result.Valid {
+		return AgentBuildValidationError{
+			Code:    "validation_failed",
+			Message: "version has validation errors and cannot be marked ready",
+		}
+	}
+
+	return m.repo.MarkAgentBuildVersionReady(ctx, id)
+}
+
+func (m *AgentBuildManager) CreateDeployment(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateAgentDeploymentInput) (repository.AgentDeploymentRow, error) {
+	version, err := m.repo.GetAgentBuildVersionByID(ctx, input.BuildVersionID)
+	if err != nil {
+		return repository.AgentDeploymentRow{}, err
+	}
+
+	if version.VersionStatus != "ready" {
+		return repository.AgentDeploymentRow{}, AgentBuildValidationError{
+			Code:    "version_not_ready",
+			Message: "only ready versions can be deployed",
+		}
+	}
+
+	build, err := m.repo.GetAgentBuildByID(ctx, input.AgentBuildID)
+	if err != nil {
+		return repository.AgentDeploymentRow{}, err
+	}
+
+	slug := generateSlug(input.Name)
+
+	return m.repo.CreateAgentDeployment(ctx, repository.CreateAgentDeploymentParams{
+		OrganizationID:        build.OrganizationID,
+		WorkspaceID:           workspaceID,
+		AgentBuildID:          input.AgentBuildID,
+		CurrentBuildVersionID: input.BuildVersionID,
+		RuntimeProfileID:      input.RuntimeProfileID,
+		ProviderAccountID:     input.ProviderAccountID,
+		ModelAliasID:          input.ModelAliasID,
+		Name:                  strings.TrimSpace(input.Name),
+		Slug:                  slug,
+		DeploymentConfig:      defaultJSON(input.DeploymentConfig),
+	})
+}
+
+// --- Request types ---
+
+type createAgentBuildRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+type createAgentBuildVersionRequest struct {
+	AgentKind        string                          `json:"agent_kind"`
+	InterfaceSpec    json.RawMessage                 `json:"interface_spec"`
+	PolicySpec       json.RawMessage                 `json:"policy_spec"`
+	ReasoningSpec    json.RawMessage                 `json:"reasoning_spec"`
+	MemorySpec       json.RawMessage                 `json:"memory_spec"`
+	WorkflowSpec     json.RawMessage                 `json:"workflow_spec"`
+	GuardrailSpec    json.RawMessage                 `json:"guardrail_spec"`
+	ModelSpec        json.RawMessage                 `json:"model_spec"`
+	OutputSchema     json.RawMessage                 `json:"output_schema"`
+	TraceContract    json.RawMessage                 `json:"trace_contract"`
+	PublicationSpec  json.RawMessage                 `json:"publication_spec"`
+	Tools            []toolBindingRequest            `json:"tools"`
+	KnowledgeSources []knowledgeSourceBindingRequest `json:"knowledge_sources"`
+}
+
+type createAgentDeploymentRequest struct {
+	Name              string          `json:"name"`
+	AgentBuildID      string          `json:"agent_build_id"`
+	BuildVersionID    string          `json:"build_version_id"`
+	RuntimeProfileID  string          `json:"runtime_profile_id"`
+	ProviderAccountID *string         `json:"provider_account_id,omitempty"`
+	ModelAliasID      *string         `json:"model_alias_id,omitempty"`
+	DeploymentConfig  json.RawMessage `json:"deployment_config,omitempty"`
+}
+
+// --- Response types ---
+
+type agentBuildResponse struct {
+	ID              uuid.UUID `json:"id"`
+	WorkspaceID     uuid.UUID `json:"workspace_id"`
+	Name            string    `json:"name"`
+	Slug            string    `json:"slug"`
+	Description     string    `json:"description,omitempty"`
+	LifecycleStatus string    `json:"lifecycle_status"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+}
+
+type agentBuildDetailResponse struct {
+	agentBuildResponse
+	Versions []agentBuildVersionResponse `json:"versions"`
+}
+
+type agentBuildVersionResponse struct {
+	ID               uuid.UUID                        `json:"id"`
+	AgentBuildID     uuid.UUID                        `json:"agent_build_id"`
+	VersionNumber    int32                            `json:"version_number"`
+	VersionStatus    string                           `json:"version_status"`
+	AgentKind        string                           `json:"agent_kind"`
+	InterfaceSpec    json.RawMessage                  `json:"interface_spec"`
+	PolicySpec       json.RawMessage                  `json:"policy_spec"`
+	ReasoningSpec    json.RawMessage                  `json:"reasoning_spec"`
+	MemorySpec       json.RawMessage                  `json:"memory_spec"`
+	WorkflowSpec     json.RawMessage                  `json:"workflow_spec"`
+	GuardrailSpec    json.RawMessage                  `json:"guardrail_spec"`
+	ModelSpec        json.RawMessage                  `json:"model_spec"`
+	OutputSchema     json.RawMessage                  `json:"output_schema"`
+	TraceContract    json.RawMessage                  `json:"trace_contract"`
+	PublicationSpec  json.RawMessage                  `json:"publication_spec"`
+	Tools            []toolBindingResponse            `json:"tools"`
+	KnowledgeSources []knowledgeSourceBindingResponse `json:"knowledge_sources"`
+	CreatedAt        time.Time                        `json:"created_at"`
+}
+
+type toolBindingRequest struct {
+	ToolID        string          `json:"tool_id"`
+	BindingRole   string          `json:"binding_role"`
+	BindingConfig json.RawMessage `json:"binding_config"`
+}
+
+type knowledgeSourceBindingRequest struct {
+	KnowledgeSourceID string          `json:"knowledge_source_id"`
+	BindingRole       string          `json:"binding_role"`
+	BindingConfig     json.RawMessage `json:"binding_config"`
+}
+
+type toolBindingResponse struct {
+	ToolID        uuid.UUID       `json:"tool_id"`
+	BindingRole   string          `json:"binding_role"`
+	BindingConfig json.RawMessage `json:"binding_config"`
+}
+
+type knowledgeSourceBindingResponse struct {
+	KnowledgeSourceID uuid.UUID       `json:"knowledge_source_id"`
+	BindingRole       string          `json:"binding_role"`
+	BindingConfig     json.RawMessage `json:"binding_config"`
+}
+
+type listAgentBuildsResponse struct {
+	Items []agentBuildResponse `json:"items"`
+}
+
+type validationErrorDetail struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+type validateBuildVersionResponse struct {
+	Valid  bool                    `json:"valid"`
+	Errors []validationErrorDetail `json:"errors"`
+}
+
+type agentDeploymentCreateResponse struct {
+	ID                    uuid.UUID `json:"id"`
+	WorkspaceID           uuid.UUID `json:"workspace_id"`
+	AgentBuildID          uuid.UUID `json:"agent_build_id"`
+	CurrentBuildVersionID uuid.UUID `json:"current_build_version_id"`
+	Name                  string    `json:"name"`
+	Slug                  string    `json:"slug"`
+	DeploymentType        string    `json:"deployment_type"`
+	Status                string    `json:"status"`
+	CreatedAt             time.Time `json:"created_at"`
+	UpdatedAt             time.Time `json:"updated_at"`
+}
+
+// --- Error type ---
+
+type AgentBuildValidationError struct {
+	Code    string
+	Message string
+}
+
+func (e AgentBuildValidationError) Error() string {
+	return e.Message
+}
+
+// --- Handlers ---
+
+func createAgentBuildHandler(logger *slog.Logger, service AgentBuildService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		workspaceID, err := WorkspaceIDFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, maxAgentBuildRequestBytes)
+
+		var body createAgentBuildRequest
+		if err := decodeJSON(r, &body); err != nil {
+			handleDecodeError(w, logger, r, err)
+			return
+		}
+
+		build, err := service.CreateBuild(r.Context(), caller, workspaceID, CreateAgentBuildInput{
+			Name:        body.Name,
+			Description: body.Description,
+		})
+		if err != nil {
+			handleServiceError(w, logger, r, err)
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, buildAgentBuildResponse(build))
+	}
+}
+
+func listAgentBuildsHandler(logger *slog.Logger, service AgentBuildService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		workspaceID, err := WorkspaceIDFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		builds, err := service.ListBuilds(r.Context(), workspaceID)
+		if err != nil {
+			logger.Error("list agent builds request failed",
+				"method", r.Method,
+				"path", r.URL.Path,
+				"workspace_id", workspaceID,
+				"error", err,
+			)
+			writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+			return
+		}
+
+		items := make([]agentBuildResponse, 0, len(builds))
+		for _, b := range builds {
+			items = append(items, buildAgentBuildResponse(b))
+		}
+
+		writeJSON(w, http.StatusOK, listAgentBuildsResponse{Items: items})
+	}
+}
+
+func getAgentBuildHandler(logger *slog.Logger, service AgentBuildService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		id, err := uuid.Parse(chi.URLParam(r, "agentBuildID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_agent_build_id", "agent_build_id must be a valid UUID")
+			return
+		}
+
+		build, err := service.GetBuild(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, repository.ErrAgentBuildNotFound) {
+				writeError(w, http.StatusNotFound, "not_found", "agent build not found")
+				return
+			}
+			logger.Error("get agent build request failed",
+				"method", r.Method,
+				"path", r.URL.Path,
+				"error", err,
+			)
+			writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+			return
+		}
+		if err := ensureCallerCanAccessWorkspace(caller, build.WorkspaceID); err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		versions, err := service.ListVersions(r.Context(), id)
+		if err != nil {
+			logger.Error("list agent build versions request failed",
+				"method", r.Method,
+				"path", r.URL.Path,
+				"error", err,
+			)
+			writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+			return
+		}
+
+		versionItems := make([]agentBuildVersionResponse, 0, len(versions))
+		for _, v := range versions {
+			versionItems = append(versionItems, buildAgentBuildVersionResponse(v))
+		}
+
+		writeJSON(w, http.StatusOK, agentBuildDetailResponse{
+			agentBuildResponse: buildAgentBuildResponse(build),
+			Versions:           versionItems,
+		})
+	}
+}
+
+func createAgentBuildVersionHandler(logger *slog.Logger, service AgentBuildService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		agentBuildID, err := uuid.Parse(chi.URLParam(r, "agentBuildID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_agent_build_id", "agent_build_id must be a valid UUID")
+			return
+		}
+		build, err := service.GetBuild(r.Context(), agentBuildID)
+		if err != nil {
+			if errors.Is(err, repository.ErrAgentBuildNotFound) {
+				writeError(w, http.StatusNotFound, "not_found", "agent build not found")
+				return
+			}
+			handleServiceError(w, logger, r, err)
+			return
+		}
+		if err := ensureCallerCanAccessWorkspace(caller, build.WorkspaceID); err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, maxAgentBuildRequestBytes)
+
+		var body createAgentBuildVersionRequest
+		if err := decodeJSON(r, &body); err != nil {
+			handleDecodeError(w, logger, r, err)
+			return
+		}
+		input, err := decodeCreateAgentBuildVersionInput(body)
+		if err != nil {
+			handleServiceError(w, logger, r, err)
+			return
+		}
+
+		version, err := service.CreateVersion(r.Context(), caller, agentBuildID, input)
+		if err != nil {
+			if errors.Is(err, repository.ErrAgentBuildNotFound) {
+				writeError(w, http.StatusNotFound, "not_found", "agent build not found")
+				return
+			}
+			handleServiceError(w, logger, r, err)
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, buildAgentBuildVersionResponse(version))
+	}
+}
+
+func getAgentBuildVersionHandler(logger *slog.Logger, service AgentBuildService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		id, err := uuid.Parse(chi.URLParam(r, "versionID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_version_id", "version_id must be a valid UUID")
+			return
+		}
+
+		version, err := service.GetVersion(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, repository.ErrAgentBuildVersionNotFound) {
+				writeError(w, http.StatusNotFound, "not_found", "agent build version not found")
+				return
+			}
+			logger.Error("get agent build version request failed",
+				"method", r.Method,
+				"path", r.URL.Path,
+				"error", err,
+			)
+			writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+			return
+		}
+		if err := ensureCallerCanAccessVersionWorkspace(r.Context(), caller, service, version); err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, buildAgentBuildVersionResponse(version))
+	}
+}
+
+func updateAgentBuildVersionHandler(logger *slog.Logger, service AgentBuildService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		id, err := uuid.Parse(chi.URLParam(r, "versionID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_version_id", "version_id must be a valid UUID")
+			return
+		}
+		currentVersion, err := service.GetVersion(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, repository.ErrAgentBuildVersionNotFound) {
+				writeError(w, http.StatusNotFound, "not_found", "agent build version not found")
+				return
+			}
+			handleServiceError(w, logger, r, err)
+			return
+		}
+		if err := ensureCallerCanAccessVersionWorkspace(r.Context(), caller, service, currentVersion); err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, maxAgentBuildRequestBytes)
+
+		var body createAgentBuildVersionRequest
+		if err := decodeJSON(r, &body); err != nil {
+			handleDecodeError(w, logger, r, err)
+			return
+		}
+		input, err := decodeCreateAgentBuildVersionInput(body)
+		if err != nil {
+			handleServiceError(w, logger, r, err)
+			return
+		}
+
+		version, err := service.UpdateVersion(r.Context(), id, input)
+		if err != nil {
+			if errors.Is(err, repository.ErrAgentBuildVersionNotFound) {
+				writeError(w, http.StatusNotFound, "not_found", "agent build version not found")
+				return
+			}
+			handleServiceError(w, logger, r, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, buildAgentBuildVersionResponse(version))
+	}
+}
+
+func validateAgentBuildVersionHandler(logger *slog.Logger, service AgentBuildService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		id, err := uuid.Parse(chi.URLParam(r, "versionID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_version_id", "version_id must be a valid UUID")
+			return
+		}
+		version, err := service.GetVersion(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, repository.ErrAgentBuildVersionNotFound) {
+				writeError(w, http.StatusNotFound, "not_found", "agent build version not found")
+				return
+			}
+			handleServiceError(w, logger, r, err)
+			return
+		}
+		if err := ensureCallerCanAccessVersionWorkspace(r.Context(), caller, service, version); err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		result, err := service.ValidateVersion(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, repository.ErrAgentBuildVersionNotFound) {
+				writeError(w, http.StatusNotFound, "not_found", "agent build version not found")
+				return
+			}
+			logger.Error("validate agent build version request failed",
+				"method", r.Method,
+				"path", r.URL.Path,
+				"error", err,
+			)
+			writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+			return
+		}
+
+		errs := result.Errors
+		if errs == nil {
+			errs = []validationErrorDetail{}
+		}
+
+		writeJSON(w, http.StatusOK, validateBuildVersionResponse{
+			Valid:  result.Valid,
+			Errors: errs,
+		})
+	}
+}
+
+func markAgentBuildVersionReadyHandler(logger *slog.Logger, service AgentBuildService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		id, err := uuid.Parse(chi.URLParam(r, "versionID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_version_id", "version_id must be a valid UUID")
+			return
+		}
+		version, err := service.GetVersion(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, repository.ErrAgentBuildVersionNotFound) {
+				writeError(w, http.StatusNotFound, "not_found", "agent build version not found")
+				return
+			}
+			handleServiceError(w, logger, r, err)
+			return
+		}
+		if err := ensureCallerCanAccessVersionWorkspace(r.Context(), caller, service, version); err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		if err := service.MarkVersionReady(r.Context(), id); err != nil {
+			if errors.Is(err, repository.ErrAgentBuildVersionNotFound) {
+				writeError(w, http.StatusNotFound, "not_found", "agent build version not found")
+				return
+			}
+			handleServiceError(w, logger, r, err)
+			return
+		}
+
+		version, err = service.GetVersion(r.Context(), id)
+		if err != nil {
+			logger.Error("get version after mark ready failed",
+				"method", r.Method,
+				"path", r.URL.Path,
+				"error", err,
+			)
+			writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+			return
+		}
+
+		writeJSON(w, http.StatusOK, buildAgentBuildVersionResponse(version))
+	}
+}
+
+func createAgentDeploymentHandler(logger *slog.Logger, service AgentBuildService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		workspaceID, err := WorkspaceIDFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, maxAgentBuildRequestBytes)
+
+		var body createAgentDeploymentRequest
+		if err := decodeJSON(r, &body); err != nil {
+			handleDecodeError(w, logger, r, err)
+			return
+		}
+
+		input, err := decodeCreateAgentDeploymentInput(body)
+		if err != nil {
+			handleServiceError(w, logger, r, err)
+			return
+		}
+
+		dep, err := service.CreateDeployment(r.Context(), caller, workspaceID, input)
+		if err != nil {
+			if errors.Is(err, repository.ErrAgentBuildNotFound) || errors.Is(err, repository.ErrAgentBuildVersionNotFound) {
+				writeError(w, http.StatusNotFound, "not_found", "agent build or version not found")
+				return
+			}
+			handleServiceError(w, logger, r, err)
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, agentDeploymentCreateResponse{
+			ID:                    dep.ID,
+			WorkspaceID:           dep.WorkspaceID,
+			AgentBuildID:          dep.AgentBuildID,
+			CurrentBuildVersionID: dep.CurrentBuildVersionID,
+			Name:                  dep.Name,
+			Slug:                  dep.Slug,
+			DeploymentType:        dep.DeploymentType,
+			Status:                dep.Status,
+			CreatedAt:             dep.CreatedAt,
+			UpdatedAt:             dep.UpdatedAt,
+		})
+	}
+}
+
+// --- Response builders ---
+
+func buildAgentBuildResponse(b repository.AgentBuild) agentBuildResponse {
+	return agentBuildResponse{
+		ID:              b.ID,
+		WorkspaceID:     b.WorkspaceID,
+		Name:            b.Name,
+		Slug:            b.Slug,
+		Description:     b.Description,
+		LifecycleStatus: b.LifecycleStatus,
+		CreatedAt:       b.CreatedAt,
+		UpdatedAt:       b.UpdatedAt,
+	}
+}
+
+func buildAgentBuildVersionResponse(v repository.AgentBuildVersion) agentBuildVersionResponse {
+	return agentBuildVersionResponse{
+		ID:               v.ID,
+		AgentBuildID:     v.AgentBuildID,
+		VersionNumber:    v.VersionNumber,
+		VersionStatus:    v.VersionStatus,
+		AgentKind:        v.AgentKind,
+		InterfaceSpec:    defaultJSON(v.InterfaceSpec),
+		PolicySpec:       defaultJSON(v.PolicySpec),
+		ReasoningSpec:    defaultJSON(v.ReasoningSpec),
+		MemorySpec:       defaultJSON(v.MemorySpec),
+		WorkflowSpec:     defaultJSON(v.WorkflowSpec),
+		GuardrailSpec:    defaultJSON(v.GuardrailSpec),
+		ModelSpec:        defaultJSON(v.ModelSpec),
+		OutputSchema:     defaultJSON(v.OutputSchema),
+		TraceContract:    defaultJSON(v.TraceContract),
+		PublicationSpec:  defaultJSON(v.PublicationSpec),
+		Tools:            buildToolBindingResponses(v.Tools),
+		KnowledgeSources: buildKnowledgeSourceBindingResponses(v.KnowledgeSources),
+		CreatedAt:        v.CreatedAt,
+	}
+}
+
+// --- Decode helpers ---
+
+func decodeJSON(r *http.Request, dst any) error {
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(dst); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			return err
+		}
+		if errors.Is(err, io.EOF) {
+			return AgentBuildValidationError{
+				Code:    "invalid_request",
+				Message: "request body is required",
+			}
+		}
+		return AgentBuildValidationError{
+			Code:    "invalid_request",
+			Message: "request body must be valid JSON",
+		}
+	}
+	return nil
+}
+
+func decodeCreateAgentDeploymentInput(body createAgentDeploymentRequest) (CreateAgentDeploymentInput, error) {
+	if strings.TrimSpace(body.Name) == "" {
+		return CreateAgentDeploymentInput{}, AgentBuildValidationError{
+			Code:    "invalid_name",
+			Message: "name is required",
+		}
+	}
+
+	agentBuildID, err := uuid.Parse(body.AgentBuildID)
+	if err != nil {
+		return CreateAgentDeploymentInput{}, AgentBuildValidationError{
+			Code:    "invalid_agent_build_id",
+			Message: "agent_build_id must be a valid UUID",
+		}
+	}
+
+	buildVersionID, err := uuid.Parse(body.BuildVersionID)
+	if err != nil {
+		return CreateAgentDeploymentInput{}, AgentBuildValidationError{
+			Code:    "invalid_build_version_id",
+			Message: "build_version_id must be a valid UUID",
+		}
+	}
+
+	runtimeProfileID, err := uuid.Parse(body.RuntimeProfileID)
+	if err != nil {
+		return CreateAgentDeploymentInput{}, AgentBuildValidationError{
+			Code:    "invalid_runtime_profile_id",
+			Message: "runtime_profile_id must be a valid UUID",
+		}
+	}
+
+	var providerAccountID *uuid.UUID
+	if body.ProviderAccountID != nil && strings.TrimSpace(*body.ProviderAccountID) != "" {
+		parsed, parseErr := uuid.Parse(*body.ProviderAccountID)
+		if parseErr != nil {
+			return CreateAgentDeploymentInput{}, AgentBuildValidationError{
+				Code:    "invalid_provider_account_id",
+				Message: "provider_account_id must be a valid UUID",
+			}
+		}
+		providerAccountID = &parsed
+	}
+
+	var modelAliasID *uuid.UUID
+	if body.ModelAliasID != nil && strings.TrimSpace(*body.ModelAliasID) != "" {
+		parsed, parseErr := uuid.Parse(*body.ModelAliasID)
+		if parseErr != nil {
+			return CreateAgentDeploymentInput{}, AgentBuildValidationError{
+				Code:    "invalid_model_alias_id",
+				Message: "model_alias_id must be a valid UUID",
+			}
+		}
+		modelAliasID = &parsed
+	}
+
+	return CreateAgentDeploymentInput{
+		Name:              body.Name,
+		AgentBuildID:      agentBuildID,
+		BuildVersionID:    buildVersionID,
+		RuntimeProfileID:  runtimeProfileID,
+		ProviderAccountID: providerAccountID,
+		ModelAliasID:      modelAliasID,
+		DeploymentConfig:  body.DeploymentConfig,
+	}, nil
+}
+
+func decodeCreateAgentBuildVersionInput(body createAgentBuildVersionRequest) (CreateAgentBuildVersionInput, error) {
+	tools, err := decodeToolBindings(body.Tools)
+	if err != nil {
+		return CreateAgentBuildVersionInput{}, err
+	}
+	knowledgeSources, err := decodeKnowledgeSourceBindings(body.KnowledgeSources)
+	if err != nil {
+		return CreateAgentBuildVersionInput{}, err
+	}
+
+	return CreateAgentBuildVersionInput{
+		AgentKind:        body.AgentKind,
+		InterfaceSpec:    body.InterfaceSpec,
+		PolicySpec:       body.PolicySpec,
+		ReasoningSpec:    body.ReasoningSpec,
+		MemorySpec:       body.MemorySpec,
+		WorkflowSpec:     body.WorkflowSpec,
+		GuardrailSpec:    body.GuardrailSpec,
+		ModelSpec:        body.ModelSpec,
+		OutputSchema:     body.OutputSchema,
+		TraceContract:    body.TraceContract,
+		PublicationSpec:  body.PublicationSpec,
+		Tools:            tools,
+		KnowledgeSources: knowledgeSources,
+	}, nil
+}
+
+func decodeToolBindings(bindings []toolBindingRequest) ([]repository.AgentBuildVersionToolBinding, error) {
+	if bindings == nil {
+		return []repository.AgentBuildVersionToolBinding{}, nil
+	}
+	out := make([]repository.AgentBuildVersionToolBinding, 0, len(bindings))
+	for _, binding := range bindings {
+		toolID, err := uuid.Parse(strings.TrimSpace(binding.ToolID))
+		if err != nil {
+			return nil, AgentBuildValidationError{
+				Code:    "invalid_tool_id",
+				Message: "each tools entry must include a valid tool_id",
+			}
+		}
+		out = append(out, repository.AgentBuildVersionToolBinding{
+			ToolID:        toolID,
+			BindingRole:   binding.BindingRole,
+			BindingConfig: binding.BindingConfig,
+		})
+	}
+	return out, nil
+}
+
+func decodeKnowledgeSourceBindings(bindings []knowledgeSourceBindingRequest) ([]repository.AgentBuildVersionKnowledgeSourceBinding, error) {
+	if bindings == nil {
+		return []repository.AgentBuildVersionKnowledgeSourceBinding{}, nil
+	}
+	out := make([]repository.AgentBuildVersionKnowledgeSourceBinding, 0, len(bindings))
+	for _, binding := range bindings {
+		knowledgeSourceID, err := uuid.Parse(strings.TrimSpace(binding.KnowledgeSourceID))
+		if err != nil {
+			return nil, AgentBuildValidationError{
+				Code:    "invalid_knowledge_source_id",
+				Message: "each knowledge_sources entry must include a valid knowledge_source_id",
+			}
+		}
+		out = append(out, repository.AgentBuildVersionKnowledgeSourceBinding{
+			KnowledgeSourceID: knowledgeSourceID,
+			BindingRole:       binding.BindingRole,
+			BindingConfig:     binding.BindingConfig,
+		})
+	}
+	return out, nil
+}
+
+func buildToolBindingResponses(bindings []repository.AgentBuildVersionToolBinding) []toolBindingResponse {
+	if bindings == nil {
+		return []toolBindingResponse{}
+	}
+	items := make([]toolBindingResponse, 0, len(bindings))
+	for _, binding := range bindings {
+		items = append(items, toolBindingResponse{
+			ToolID:        binding.ToolID,
+			BindingRole:   defaultString(binding.BindingRole, "default"),
+			BindingConfig: defaultJSON(binding.BindingConfig),
+		})
+	}
+	return items
+}
+
+func buildKnowledgeSourceBindingResponses(bindings []repository.AgentBuildVersionKnowledgeSourceBinding) []knowledgeSourceBindingResponse {
+	if bindings == nil {
+		return []knowledgeSourceBindingResponse{}
+	}
+	items := make([]knowledgeSourceBindingResponse, 0, len(bindings))
+	for _, binding := range bindings {
+		items = append(items, knowledgeSourceBindingResponse{
+			KnowledgeSourceID: binding.KnowledgeSourceID,
+			BindingRole:       defaultString(binding.BindingRole, "default"),
+			BindingConfig:     defaultJSON(binding.BindingConfig),
+		})
+	}
+	return items
+}
+
+func ensureCallerCanAccessWorkspace(caller Caller, workspaceID uuid.UUID) error {
+	if _, ok := caller.WorkspaceMemberships[workspaceID]; !ok {
+		return fmt.Errorf("%w: caller %s does not belong to workspace %s", ErrForbidden, caller.UserID, workspaceID)
+	}
+	return nil
+}
+
+func ensureCallerCanAccessVersionWorkspace(ctx context.Context, caller Caller, service AgentBuildService, version repository.AgentBuildVersion) error {
+	build, err := service.GetBuild(ctx, version.AgentBuildID)
+	if err != nil {
+		return err
+	}
+	return ensureCallerCanAccessWorkspace(caller, build.WorkspaceID)
+}
+
+func handleDecodeError(w http.ResponseWriter, logger *slog.Logger, r *http.Request, err error) {
+	var validationErr AgentBuildValidationError
+	if errors.As(err, &validationErr) {
+		writeError(w, http.StatusBadRequest, validationErr.Code, validationErr.Message)
+		return
+	}
+	var maxBytesErr *http.MaxBytesError
+	if errors.As(err, &maxBytesErr) {
+		writeError(w, http.StatusRequestEntityTooLarge, "request_too_large", "request body must be 1 MiB or smaller")
+		return
+	}
+	logger.Error("failed to decode request",
+		"method", r.Method,
+		"path", r.URL.Path,
+		"error", err,
+	)
+	writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+}
+
+func handleServiceError(w http.ResponseWriter, logger *slog.Logger, r *http.Request, err error) {
+	var validationErr AgentBuildValidationError
+	if errors.As(err, &validationErr) {
+		writeError(w, http.StatusBadRequest, validationErr.Code, validationErr.Message)
+		return
+	}
+	if errors.Is(err, ErrForbidden) {
+		writeAuthzError(w, err)
+		return
+	}
+	logger.Error("request failed",
+		"method", r.Method,
+		"path", r.URL.Path,
+		"error", err,
+	)
+	writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+}
+
+// --- Utility functions ---
+
+func generateSlug(name string) string {
+	slug := strings.ToLower(strings.TrimSpace(name))
+	slug = slugRe.ReplaceAllString(slug, "-")
+	slug = strings.Trim(slug, "-")
+	if len(slug) > 60 {
+		slug = slug[:60]
+		slug = strings.TrimRight(slug, "-")
+	}
+	return slug
+}
+
+func defaultJSON(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return json.RawMessage(`{}`)
+	}
+	return raw
+}
+
+func defaultJSONOrExisting(input json.RawMessage, existing json.RawMessage) json.RawMessage {
+	if len(input) == 0 {
+		return existing
+	}
+	return input
+}
+
+func defaultToolBindingsOrExisting(
+	input []repository.AgentBuildVersionToolBinding,
+	existing []repository.AgentBuildVersionToolBinding,
+) []repository.AgentBuildVersionToolBinding {
+	if input == nil {
+		return existing
+	}
+	return input
+}
+
+func defaultKnowledgeSourceBindingsOrExisting(
+	input []repository.AgentBuildVersionKnowledgeSourceBinding,
+	existing []repository.AgentBuildVersionKnowledgeSourceBinding,
+) []repository.AgentBuildVersionKnowledgeSourceBinding {
+	if input == nil {
+		return existing
+	}
+	return input
+}
+
+func defaultString(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}
+
+func jsonHasKey(raw json.RawMessage, key string) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return false
+	}
+	_, ok := m[key]
+	return ok
+}

--- a/backend/internal/api/agent_builds_test.go
+++ b/backend/internal/api/agent_builds_test.go
@@ -1,0 +1,240 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+type testAgentBuildService struct {
+	builds   map[uuid.UUID]repository.AgentBuild
+	versions map[uuid.UUID]repository.AgentBuildVersion
+}
+
+func (s testAgentBuildService) CreateBuild(_ context.Context, _ Caller, _ uuid.UUID, _ CreateAgentBuildInput) (repository.AgentBuild, error) {
+	return repository.AgentBuild{}, errors.New("not implemented")
+}
+
+func (s testAgentBuildService) GetBuild(_ context.Context, id uuid.UUID) (repository.AgentBuild, error) {
+	build, ok := s.builds[id]
+	if !ok {
+		return repository.AgentBuild{}, repository.ErrAgentBuildNotFound
+	}
+	return build, nil
+}
+
+func (s testAgentBuildService) ListBuilds(_ context.Context, _ uuid.UUID) ([]repository.AgentBuild, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s testAgentBuildService) ListVersions(_ context.Context, agentBuildID uuid.UUID) ([]repository.AgentBuildVersion, error) {
+	items := make([]repository.AgentBuildVersion, 0)
+	for _, version := range s.versions {
+		if version.AgentBuildID == agentBuildID {
+			items = append(items, version)
+		}
+	}
+	return items, nil
+}
+
+func (s testAgentBuildService) CreateVersion(_ context.Context, _ Caller, _ uuid.UUID, _ CreateAgentBuildVersionInput) (repository.AgentBuildVersion, error) {
+	return repository.AgentBuildVersion{}, errors.New("not implemented")
+}
+
+func (s testAgentBuildService) GetVersion(_ context.Context, id uuid.UUID) (repository.AgentBuildVersion, error) {
+	version, ok := s.versions[id]
+	if !ok {
+		return repository.AgentBuildVersion{}, repository.ErrAgentBuildVersionNotFound
+	}
+	return version, nil
+}
+
+func (s testAgentBuildService) UpdateVersion(_ context.Context, _ uuid.UUID, _ UpdateAgentBuildVersionInput) (repository.AgentBuildVersion, error) {
+	return repository.AgentBuildVersion{}, errors.New("not implemented")
+}
+
+func (s testAgentBuildService) ValidateVersion(_ context.Context, _ uuid.UUID) (ValidateBuildVersionResult, error) {
+	return ValidateBuildVersionResult{}, errors.New("not implemented")
+}
+
+func (s testAgentBuildService) MarkVersionReady(_ context.Context, _ uuid.UUID) error {
+	return errors.New("not implemented")
+}
+
+func (s testAgentBuildService) CreateDeployment(_ context.Context, _ Caller, _ uuid.UUID, _ CreateAgentDeploymentInput) (repository.AgentDeploymentRow, error) {
+	return repository.AgentDeploymentRow{}, errors.New("not implemented")
+}
+
+func TestGetAgentBuildRequiresWorkspaceMembership(t *testing.T) {
+	userID := uuid.New()
+	buildWorkspaceID := uuid.New()
+	buildID := uuid.New()
+
+	router := newRouter(
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		stubRunCreationService{},
+		stubRunReadService{},
+		stubReplayReadService{},
+		stubHostedRunIngestionService{},
+		nil,
+		stubAgentDeploymentReadService{},
+		stubChallengePackReadService{},
+		testAgentBuildService{
+			builds: map[uuid.UUID]repository.AgentBuild{
+				buildID: {
+					ID:          buildID,
+					WorkspaceID: buildWorkspaceID,
+				},
+			},
+			versions: map[uuid.UUID]repository.AgentBuildVersion{},
+		},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/agent-builds/"+buildID.String(), nil)
+	req.Header.Set(headerUserID, userID.String())
+	req.Header.Set(headerWorkspaceMemberships, uuid.New().String()+":workspace_member")
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusForbidden)
+	}
+}
+
+func TestGetAgentBuildVersionRequiresWorkspaceMembership(t *testing.T) {
+	userID := uuid.New()
+	buildWorkspaceID := uuid.New()
+	buildID := uuid.New()
+	versionID := uuid.New()
+
+	router := newRouter(
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		stubRunCreationService{},
+		stubRunReadService{},
+		stubReplayReadService{},
+		stubHostedRunIngestionService{},
+		nil,
+		stubAgentDeploymentReadService{},
+		stubChallengePackReadService{},
+		testAgentBuildService{
+			builds: map[uuid.UUID]repository.AgentBuild{
+				buildID: {
+					ID:          buildID,
+					WorkspaceID: buildWorkspaceID,
+				},
+			},
+			versions: map[uuid.UUID]repository.AgentBuildVersion{
+				versionID: {
+					ID:           versionID,
+					AgentBuildID: buildID,
+				},
+			},
+		},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/agent-build-versions/"+versionID.String(), nil)
+	req.Header.Set(headerUserID, userID.String())
+	req.Header.Set(headerWorkspaceMemberships, uuid.New().String()+":workspace_member")
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusForbidden)
+	}
+}
+
+func TestGetAgentBuildVersionReturnsToolAndKnowledgeBindings(t *testing.T) {
+	userID := uuid.New()
+	buildWorkspaceID := uuid.New()
+	buildID := uuid.New()
+	versionID := uuid.New()
+	toolID := uuid.New()
+	knowledgeSourceID := uuid.New()
+
+	router := newRouter(
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		stubRunCreationService{},
+		stubRunReadService{},
+		stubReplayReadService{},
+		stubHostedRunIngestionService{},
+		nil,
+		stubAgentDeploymentReadService{},
+		stubChallengePackReadService{},
+		testAgentBuildService{
+			builds: map[uuid.UUID]repository.AgentBuild{
+				buildID: {
+					ID:          buildID,
+					WorkspaceID: buildWorkspaceID,
+				},
+			},
+			versions: map[uuid.UUID]repository.AgentBuildVersion{
+				versionID: {
+					ID:            versionID,
+					AgentBuildID:  buildID,
+					VersionNumber: 1,
+					VersionStatus: "draft",
+					AgentKind:     "llm_agent",
+					CreatedAt:     time.Now().UTC(),
+					Tools: []repository.AgentBuildVersionToolBinding{
+						{
+							ToolID:        toolID,
+							BindingRole:   "default",
+							BindingConfig: json.RawMessage(`{"mode":"sync"}`),
+						},
+					},
+					KnowledgeSources: []repository.AgentBuildVersionKnowledgeSourceBinding{
+						{
+							KnowledgeSourceID: knowledgeSourceID,
+							BindingRole:       "context",
+							BindingConfig:     json.RawMessage(`{"top_k":3}`),
+						},
+					},
+				},
+			},
+		},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/agent-build-versions/"+versionID.String(), nil)
+	req.Header.Set(headerUserID, userID.String())
+	req.Header.Set(headerWorkspaceMemberships, buildWorkspaceID.String()+":workspace_member")
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+
+	var response agentBuildVersionResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(response.Tools) != 1 {
+		t.Fatalf("tools count = %d, want 1", len(response.Tools))
+	}
+	if response.Tools[0].ToolID != toolID {
+		t.Fatalf("tool id = %s, want %s", response.Tools[0].ToolID, toolID)
+	}
+	if len(response.KnowledgeSources) != 1 {
+		t.Fatalf("knowledge sources count = %d, want 1", len(response.KnowledgeSources))
+	}
+	if response.KnowledgeSources[0].KnowledgeSourceID != knowledgeSourceID {
+		t.Fatalf("knowledge source id = %s, want %s", response.KnowledgeSources[0].KnowledgeSourceID, knowledgeSourceID)
+	}
+}

--- a/backend/internal/api/compare_reads_test.go
+++ b/backend/internal/api/compare_reads_test.go
@@ -106,6 +106,7 @@ func TestGetRunComparisonEndpointReturnsJSONPayload(t *testing.T) {
 		},
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -145,6 +146,7 @@ func TestCompareViewerEndpointReturnsHTMLShell(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {

--- a/backend/internal/api/cors.go
+++ b/backend/internal/api/cors.go
@@ -5,7 +5,7 @@ import "net/http"
 func corsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Agentclash-User-Id, X-Agentclash-WorkOS-User-Id, X-Agentclash-User-Email, X-Agentclash-User-Display-Name, X-Agentclash-Workspace-Memberships")
 		w.Header().Set("Access-Control-Max-Age", "86400")
 

--- a/backend/internal/api/hosted_runs_test.go
+++ b/backend/internal/api/hosted_runs_test.go
@@ -236,6 +236,7 @@ func TestIngestHostedRunEventHandlerReturnsInternalErrorForRepositoryFailure(t *
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	)
 	router.ServeHTTP(recorder, req)
 

--- a/backend/internal/api/replay_reads_test.go
+++ b/backend/internal/api/replay_reads_test.go
@@ -204,6 +204,7 @@ func TestGetRunAgentReplayEndpointReturnsPaginatedReplay(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -263,6 +264,7 @@ func TestGetRunAgentReplayEndpointReturnsPendingState(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusAccepted {
@@ -313,6 +315,7 @@ func TestGetRunAgentReplayEndpointReturnsErroredState(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusConflict {
@@ -339,6 +342,7 @@ func TestGetRunAgentReplayEndpointReturnsNotFoundWhenRunAgentMissing(t *testing.
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusNotFound {
@@ -364,6 +368,7 @@ func TestGetRunAgentReplayEndpointReturnsForbidden(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusForbidden {
@@ -389,6 +394,7 @@ func TestGetRunAgentReplayEndpointRejectsMalformedRunAgentID(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusBadRequest {
@@ -415,6 +421,7 @@ func TestGetRunAgentReplayEndpointRejectsMalformedPagination(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusBadRequest {
@@ -459,6 +466,7 @@ func TestGetRunAgentScorecardEndpointReturnsScorecard(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -498,6 +506,7 @@ func TestGetRunAgentScorecardEndpointReturnsForbidden(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusForbidden {
@@ -533,6 +542,7 @@ func TestGetRunAgentScorecardEndpointReturnsPendingWhenScorecardIsPending(t *tes
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusAccepted {
@@ -576,6 +586,7 @@ func TestGetRunAgentScorecardEndpointReturnsConflictWhenScorecardIsMissingAfterT
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusConflict {
@@ -602,6 +613,7 @@ func TestGetRunAgentScorecardEndpointReturnsNotFoundWhenRunAgentMissing(t *testi
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusNotFound {

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -18,6 +18,7 @@ func registerProtectedRoutes(
 	compareReadService CompareReadService,
 	agentDeploymentReadService AgentDeploymentReadService,
 	challengePackReadService ChallengePackReadService,
+	agentBuildService AgentBuildService,
 ) {
 	router.Get("/auth/session", sessionHandler)
 	// POST /v1/runs resolves workspace access from the JSON body, so authz stays in the run-creation service
@@ -39,6 +40,22 @@ func registerProtectedRoutes(
 		Get("/workspaces/{workspaceID}/agent-deployments", listAgentDeploymentsHandler(logger, agentDeploymentReadService))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Get("/workspaces/{workspaceID}/challenge-packs", listChallengePacksHandler(logger, challengePackReadService))
+
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Post("/workspaces/{workspaceID}/agent-builds", createAgentBuildHandler(logger, agentBuildService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Get("/workspaces/{workspaceID}/agent-builds", listAgentBuildsHandler(logger, agentBuildService))
+
+	router.Get("/agent-builds/{agentBuildID}", getAgentBuildHandler(logger, agentBuildService))
+	router.Post("/agent-builds/{agentBuildID}/versions", createAgentBuildVersionHandler(logger, agentBuildService))
+
+	router.Get("/agent-build-versions/{versionID}", getAgentBuildVersionHandler(logger, agentBuildService))
+	router.Patch("/agent-build-versions/{versionID}", updateAgentBuildVersionHandler(logger, agentBuildService))
+	router.Post("/agent-build-versions/{versionID}/validate", validateAgentBuildVersionHandler(logger, agentBuildService))
+	router.Post("/agent-build-versions/{versionID}/ready", markAgentBuildVersionReadyHandler(logger, agentBuildService))
+
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Post("/workspaces/{workspaceID}/agent-deployments", createAgentDeploymentHandler(logger, agentBuildService))
 }
 
 func registerHostedIntegrationRoutes(router chi.Router, logger *slog.Logger, service HostedRunIngestionService) {

--- a/backend/internal/api/run_reads_test.go
+++ b/backend/internal/api/run_reads_test.go
@@ -132,6 +132,7 @@ func TestGetRunEndpointReturnsRun(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -170,6 +171,7 @@ func TestGetRunEndpointReturnsNotFound(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusNotFound {
@@ -195,6 +197,7 @@ func TestGetRunEndpointRejectsMalformedRunID(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusBadRequest {
@@ -235,6 +238,7 @@ func TestListRunAgentsEndpointReturnsOrderedItems(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -273,6 +277,7 @@ func TestListRunAgentsEndpointReturnsForbidden(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusForbidden {

--- a/backend/internal/api/runs_test.go
+++ b/backend/internal/api/runs_test.go
@@ -53,6 +53,7 @@ func TestCreateRunEndpointReturnsCreated(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusCreated {
@@ -93,6 +94,7 @@ func TestCreateRunEndpointRejectsInvalidPayload(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusBadRequest {
@@ -136,6 +138,7 @@ func TestCreateRunEndpointReturnsQueuedRunOnWorkflowStartFailure(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusBadGateway {
@@ -177,6 +180,7 @@ func TestCreateRunEndpointRejectsNonJSONContentType(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusUnsupportedMediaType {
@@ -209,6 +213,7 @@ func TestCreateRunEndpointRejectsOversizedRequestBody(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusRequestEntityTooLarge {

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -26,8 +26,9 @@ func NewServer(
 	hostedRunIngestionService HostedRunIngestionService,
 	agentDeploymentReadService AgentDeploymentReadService,
 	challengePackReadService ChallengePackReadService,
+	agentBuildService AgentBuildService,
 ) *Server {
-	router := newRouter(logger, authenticator, authorizer, runCreationService, runReadService, replayReadService, hostedRunIngestionService, compareReadService, agentDeploymentReadService, challengePackReadService)
+	router := newRouter(logger, authenticator, authorizer, runCreationService, runReadService, replayReadService, hostedRunIngestionService, compareReadService, agentDeploymentReadService, challengePackReadService, agentBuildService)
 
 	return &Server{
 		config: cfg,
@@ -85,6 +86,7 @@ func newRouter(
 	compareReadService CompareReadService,
 	agentDeploymentReadService AgentDeploymentReadService,
 	challengePackReadService ChallengePackReadService,
+	agentBuildService AgentBuildService,
 ) http.Handler {
 	if hostedRunIngestionService == nil {
 		hostedRunIngestionService = noopHostedRunIngestionService{}
@@ -102,7 +104,7 @@ func newRouter(
 	registerHostedIntegrationRoutes(router, logger, hostedRunIngestionService)
 	router.Route("/v1", func(r chi.Router) {
 		r.Use(authenticateRequest(logger, authenticator))
-		registerProtectedRoutes(r, logger, authorizer, runCreationService, runReadService, replayReadService, compareReadService, agentDeploymentReadService, challengePackReadService)
+		registerProtectedRoutes(r, logger, authorizer, runCreationService, runReadService, replayReadService, compareReadService, agentDeploymentReadService, challengePackReadService, agentBuildService)
 	})
 
 	return router

--- a/backend/internal/api/server_test.go
+++ b/backend/internal/api/server_test.go
@@ -71,6 +71,7 @@ func TestHealthzReturnsJSONSuccessPayload(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -133,6 +134,7 @@ func TestSessionEndpointRequiresAuthentication(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusUnauthorized {
@@ -170,6 +172,7 @@ func TestSessionEndpointReturnsCallerIdentity(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -210,6 +213,7 @@ func TestWorkspaceAuthorizationReturnsForbiddenWithoutMembership(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusForbidden {
@@ -245,6 +249,7 @@ func TestWorkspaceAuthorizationReturnsOKWithMembership(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -281,6 +286,7 @@ func TestWorkspaceAuthorizationRejectsMalformedWorkspaceID(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusBadRequest {
@@ -317,6 +323,7 @@ func TestReplayViewerEndpointReturnsHTMLShell(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -353,6 +360,7 @@ func TestReplayViewerEndpointRejectsInvalidReplayPagination(t *testing.T) {
 		nil,
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
+		stubAgentBuildService{},
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusBadRequest {

--- a/backend/internal/api/test_helpers_test.go
+++ b/backend/internal/api/test_helpers_test.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"context"
+	"errors"
 
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/hostedruns"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
 	"github.com/google/uuid"
 )
 
@@ -11,4 +13,37 @@ type stubHostedRunIngestionService struct{}
 
 func (stubHostedRunIngestionService) IngestEvent(_ context.Context, _ uuid.UUID, _ string, _ hostedruns.Event) error {
 	return nil
+}
+
+type stubAgentBuildService struct{}
+
+func (stubAgentBuildService) CreateBuild(_ context.Context, _ Caller, _ uuid.UUID, _ CreateAgentBuildInput) (repository.AgentBuild, error) {
+	return repository.AgentBuild{}, errors.New("not implemented")
+}
+func (stubAgentBuildService) GetBuild(_ context.Context, _ uuid.UUID) (repository.AgentBuild, error) {
+	return repository.AgentBuild{}, errors.New("not implemented")
+}
+func (stubAgentBuildService) ListBuilds(_ context.Context, _ uuid.UUID) ([]repository.AgentBuild, error) {
+	return nil, errors.New("not implemented")
+}
+func (stubAgentBuildService) ListVersions(_ context.Context, _ uuid.UUID) ([]repository.AgentBuildVersion, error) {
+	return nil, errors.New("not implemented")
+}
+func (stubAgentBuildService) CreateVersion(_ context.Context, _ Caller, _ uuid.UUID, _ CreateAgentBuildVersionInput) (repository.AgentBuildVersion, error) {
+	return repository.AgentBuildVersion{}, errors.New("not implemented")
+}
+func (stubAgentBuildService) GetVersion(_ context.Context, _ uuid.UUID) (repository.AgentBuildVersion, error) {
+	return repository.AgentBuildVersion{}, errors.New("not implemented")
+}
+func (stubAgentBuildService) UpdateVersion(_ context.Context, _ uuid.UUID, _ UpdateAgentBuildVersionInput) (repository.AgentBuildVersion, error) {
+	return repository.AgentBuildVersion{}, errors.New("not implemented")
+}
+func (stubAgentBuildService) ValidateVersion(_ context.Context, _ uuid.UUID) (ValidateBuildVersionResult, error) {
+	return ValidateBuildVersionResult{}, errors.New("not implemented")
+}
+func (stubAgentBuildService) MarkVersionReady(_ context.Context, _ uuid.UUID) error {
+	return errors.New("not implemented")
+}
+func (stubAgentBuildService) CreateDeployment(_ context.Context, _ Caller, _ uuid.UUID, _ CreateAgentDeploymentInput) (repository.AgentDeploymentRow, error) {
+	return repository.AgentDeploymentRow{}, errors.New("not implemented")
 }

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/scoring"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -1712,6 +1713,583 @@ func (r *Repository) ListRunnableChallengePVersionsByPackID(ctx context.Context,
 	}
 
 	return versions, nil
+}
+
+var (
+	ErrAgentBuildNotFound        = errors.New("agent build not found")
+	ErrAgentBuildVersionNotFound = errors.New("agent build version not found")
+	ErrWorkspaceNotFound         = errors.New("workspace not found")
+)
+
+func (r *Repository) GetOrganizationIDByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (uuid.UUID, error) {
+	var orgID uuid.UUID
+	err := r.db.QueryRow(ctx, `SELECT organization_id FROM workspaces WHERE id = $1`, workspaceID).Scan(&orgID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return uuid.Nil, ErrWorkspaceNotFound
+		}
+		return uuid.Nil, fmt.Errorf("get organization id by workspace id: %w", err)
+	}
+	return orgID, nil
+}
+
+type AgentBuild struct {
+	ID              uuid.UUID
+	OrganizationID  uuid.UUID
+	WorkspaceID     uuid.UUID
+	Name            string
+	Slug            string
+	Description     string
+	LifecycleStatus string
+	CreatedByUserID *uuid.UUID
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+type AgentBuildVersion struct {
+	ID               uuid.UUID
+	AgentBuildID     uuid.UUID
+	VersionNumber    int32
+	VersionStatus    string
+	AgentKind        string
+	InterfaceSpec    json.RawMessage
+	PolicySpec       json.RawMessage
+	ReasoningSpec    json.RawMessage
+	MemorySpec       json.RawMessage
+	WorkflowSpec     json.RawMessage
+	GuardrailSpec    json.RawMessage
+	ModelSpec        json.RawMessage
+	OutputSchema     json.RawMessage
+	TraceContract    json.RawMessage
+	PublicationSpec  json.RawMessage
+	Tools            []AgentBuildVersionToolBinding
+	KnowledgeSources []AgentBuildVersionKnowledgeSourceBinding
+	CreatedByUserID  *uuid.UUID
+	CreatedAt        time.Time
+}
+
+type AgentBuildVersionToolBinding struct {
+	ToolID        uuid.UUID
+	BindingRole   string
+	BindingConfig json.RawMessage
+}
+
+type AgentBuildVersionKnowledgeSourceBinding struct {
+	KnowledgeSourceID uuid.UUID
+	BindingRole       string
+	BindingConfig     json.RawMessage
+}
+
+type AgentDeploymentRow struct {
+	ID                    uuid.UUID
+	OrganizationID        uuid.UUID
+	WorkspaceID           uuid.UUID
+	AgentBuildID          uuid.UUID
+	CurrentBuildVersionID uuid.UUID
+	Name                  string
+	Slug                  string
+	DeploymentType        string
+	Status                string
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
+}
+
+type CreateAgentBuildParams struct {
+	OrganizationID  uuid.UUID
+	WorkspaceID     uuid.UUID
+	Name            string
+	Slug            string
+	Description     string
+	CreatedByUserID *uuid.UUID
+}
+
+type CreateAgentBuildVersionParams struct {
+	AgentBuildID     uuid.UUID
+	VersionNumber    int32
+	AgentKind        string
+	InterfaceSpec    json.RawMessage
+	PolicySpec       json.RawMessage
+	ReasoningSpec    json.RawMessage
+	MemorySpec       json.RawMessage
+	WorkflowSpec     json.RawMessage
+	GuardrailSpec    json.RawMessage
+	ModelSpec        json.RawMessage
+	OutputSchema     json.RawMessage
+	TraceContract    json.RawMessage
+	PublicationSpec  json.RawMessage
+	Tools            []AgentBuildVersionToolBinding
+	KnowledgeSources []AgentBuildVersionKnowledgeSourceBinding
+	CreatedByUserID  *uuid.UUID
+}
+
+type UpdateAgentBuildVersionDraftParams struct {
+	ID               uuid.UUID
+	AgentKind        string
+	InterfaceSpec    json.RawMessage
+	PolicySpec       json.RawMessage
+	ReasoningSpec    json.RawMessage
+	MemorySpec       json.RawMessage
+	WorkflowSpec     json.RawMessage
+	GuardrailSpec    json.RawMessage
+	ModelSpec        json.RawMessage
+	OutputSchema     json.RawMessage
+	TraceContract    json.RawMessage
+	PublicationSpec  json.RawMessage
+	Tools            []AgentBuildVersionToolBinding
+	KnowledgeSources []AgentBuildVersionKnowledgeSourceBinding
+}
+
+type CreateAgentDeploymentParams struct {
+	OrganizationID        uuid.UUID
+	WorkspaceID           uuid.UUID
+	AgentBuildID          uuid.UUID
+	CurrentBuildVersionID uuid.UUID
+	RuntimeProfileID      uuid.UUID
+	ProviderAccountID     *uuid.UUID
+	ModelAliasID          *uuid.UUID
+	Name                  string
+	Slug                  string
+	DeploymentConfig      json.RawMessage
+}
+
+func (r *Repository) CreateAgentBuild(ctx context.Context, params CreateAgentBuildParams) (AgentBuild, error) {
+	row := r.db.QueryRow(ctx, `
+		INSERT INTO agent_builds (organization_id, workspace_id, name, slug, description, created_by_user_id)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id, organization_id, workspace_id, name, slug, description, lifecycle_status, created_by_user_id, created_at, updated_at
+	`, params.OrganizationID, params.WorkspaceID, params.Name, params.Slug, params.Description, params.CreatedByUserID)
+
+	var build AgentBuild
+	var createdAt, updatedAt pgtype.Timestamptz
+	err := row.Scan(
+		&build.ID, &build.OrganizationID, &build.WorkspaceID,
+		&build.Name, &build.Slug, &build.Description, &build.LifecycleStatus,
+		&build.CreatedByUserID, &createdAt, &updatedAt,
+	)
+	if err != nil {
+		return AgentBuild{}, fmt.Errorf("create agent build: %w", err)
+	}
+
+	build.CreatedAt = createdAt.Time
+	build.UpdatedAt = updatedAt.Time
+	return build, nil
+}
+
+func (r *Repository) GetAgentBuildByID(ctx context.Context, id uuid.UUID) (AgentBuild, error) {
+	row := r.db.QueryRow(ctx, `
+		SELECT id, organization_id, workspace_id, name, slug, description, lifecycle_status, created_by_user_id, created_at, updated_at
+		FROM agent_builds WHERE id = $1 AND archived_at IS NULL
+	`, id)
+
+	var build AgentBuild
+	var createdAt, updatedAt pgtype.Timestamptz
+	err := row.Scan(
+		&build.ID, &build.OrganizationID, &build.WorkspaceID,
+		&build.Name, &build.Slug, &build.Description, &build.LifecycleStatus,
+		&build.CreatedByUserID, &createdAt, &updatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return AgentBuild{}, ErrAgentBuildNotFound
+		}
+		return AgentBuild{}, fmt.Errorf("get agent build by id: %w", err)
+	}
+
+	build.CreatedAt = createdAt.Time
+	build.UpdatedAt = updatedAt.Time
+	return build, nil
+}
+
+func (r *Repository) ListAgentBuildsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]AgentBuild, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, organization_id, workspace_id, name, slug, description, lifecycle_status, created_by_user_id, created_at, updated_at
+		FROM agent_builds
+		WHERE workspace_id = $1 AND lifecycle_status = 'active' AND archived_at IS NULL
+		ORDER BY updated_at DESC
+	`, workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("list agent builds by workspace id: %w", err)
+	}
+	defer rows.Close()
+
+	var builds []AgentBuild
+	for rows.Next() {
+		var build AgentBuild
+		var createdAt, updatedAt pgtype.Timestamptz
+		if err := rows.Scan(
+			&build.ID, &build.OrganizationID, &build.WorkspaceID,
+			&build.Name, &build.Slug, &build.Description, &build.LifecycleStatus,
+			&build.CreatedByUserID, &createdAt, &updatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan agent build: %w", err)
+		}
+		build.CreatedAt = createdAt.Time
+		build.UpdatedAt = updatedAt.Time
+		builds = append(builds, build)
+	}
+
+	if builds == nil {
+		builds = []AgentBuild{}
+	}
+	return builds, nil
+}
+
+func (r *Repository) CreateAgentBuildVersion(ctx context.Context, params CreateAgentBuildVersionParams) (AgentBuildVersion, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return AgentBuildVersion{}, fmt.Errorf("begin create agent build version tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	row := tx.QueryRow(ctx, `
+		INSERT INTO agent_build_versions (
+			agent_build_id, version_number, version_status,
+			agent_kind, interface_spec, policy_spec, reasoning_spec,
+			memory_spec, workflow_spec, guardrail_spec, model_spec,
+			output_schema, trace_contract, publication_spec, created_by_user_id
+		) VALUES (
+			$1, $2, 'draft',
+			$3, $4, $5, $6,
+			$7, $8, $9, $10,
+			$11, $12, $13, $14
+		) RETURNING id, agent_build_id, version_number, version_status,
+			agent_kind, interface_spec, policy_spec, reasoning_spec,
+			memory_spec, workflow_spec, guardrail_spec, model_spec,
+			output_schema, trace_contract, publication_spec, created_by_user_id, created_at
+	`, params.AgentBuildID, params.VersionNumber,
+		params.AgentKind, params.InterfaceSpec, params.PolicySpec, params.ReasoningSpec,
+		params.MemorySpec, params.WorkflowSpec, params.GuardrailSpec, params.ModelSpec,
+		params.OutputSchema, params.TraceContract, params.PublicationSpec, params.CreatedByUserID,
+	)
+
+	version, err := scanAgentBuildVersion(row)
+	if err != nil {
+		return AgentBuildVersion{}, err
+	}
+
+	if err := replaceAgentBuildVersionBindings(ctx, tx, version.ID, params.Tools, params.KnowledgeSources); err != nil {
+		return AgentBuildVersion{}, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return AgentBuildVersion{}, fmt.Errorf("commit create agent build version tx: %w", err)
+	}
+
+	version.Tools = normalizeToolBindings(params.Tools)
+	version.KnowledgeSources = normalizeKnowledgeSourceBindings(params.KnowledgeSources)
+	return version, nil
+}
+
+func (r *Repository) GetAgentBuildVersionByID(ctx context.Context, id uuid.UUID) (AgentBuildVersion, error) {
+	row := r.db.QueryRow(ctx, `
+		SELECT id, agent_build_id, version_number, version_status,
+			agent_kind, interface_spec, policy_spec, reasoning_spec,
+			memory_spec, workflow_spec, guardrail_spec, model_spec,
+			output_schema, trace_contract, publication_spec, created_by_user_id, created_at
+		FROM agent_build_versions WHERE id = $1
+	`, id)
+
+	version, err := scanAgentBuildVersion(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return AgentBuildVersion{}, ErrAgentBuildVersionNotFound
+		}
+		return AgentBuildVersion{}, err
+	}
+	if err := r.loadAgentBuildVersionBindings(ctx, &version); err != nil {
+		return AgentBuildVersion{}, err
+	}
+	return version, nil
+}
+
+func (r *Repository) GetLatestVersionNumberForBuild(ctx context.Context, agentBuildID uuid.UUID) (int32, error) {
+	var maxVersion int32
+	err := r.db.QueryRow(ctx, `
+		SELECT COALESCE(MAX(version_number), 0)::integer
+		FROM agent_build_versions WHERE agent_build_id = $1
+	`, agentBuildID).Scan(&maxVersion)
+	if err != nil {
+		return 0, fmt.Errorf("get latest version number for build: %w", err)
+	}
+	return maxVersion, nil
+}
+
+func (r *Repository) ListAgentBuildVersionsByBuildID(ctx context.Context, agentBuildID uuid.UUID) ([]AgentBuildVersion, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, agent_build_id, version_number, version_status,
+			agent_kind, interface_spec, policy_spec, reasoning_spec,
+			memory_spec, workflow_spec, guardrail_spec, model_spec,
+			output_schema, trace_contract, publication_spec, created_by_user_id, created_at
+		FROM agent_build_versions
+		WHERE agent_build_id = $1
+		ORDER BY version_number DESC
+	`, agentBuildID)
+	if err != nil {
+		return nil, fmt.Errorf("list agent build versions by build id: %w", err)
+	}
+	defer rows.Close()
+
+	var versions []AgentBuildVersion
+	for rows.Next() {
+		var v AgentBuildVersion
+		var createdAt pgtype.Timestamptz
+		if err := rows.Scan(
+			&v.ID, &v.AgentBuildID, &v.VersionNumber, &v.VersionStatus,
+			&v.AgentKind, &v.InterfaceSpec, &v.PolicySpec, &v.ReasoningSpec,
+			&v.MemorySpec, &v.WorkflowSpec, &v.GuardrailSpec, &v.ModelSpec,
+			&v.OutputSchema, &v.TraceContract, &v.PublicationSpec, &v.CreatedByUserID, &createdAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan agent build version: %w", err)
+		}
+		v.CreatedAt = createdAt.Time
+		if err := r.loadAgentBuildVersionBindings(ctx, &v); err != nil {
+			return nil, err
+		}
+		versions = append(versions, v)
+	}
+
+	if versions == nil {
+		versions = []AgentBuildVersion{}
+	}
+	return versions, nil
+}
+
+func (r *Repository) UpdateAgentBuildVersionDraft(ctx context.Context, params UpdateAgentBuildVersionDraftParams) error {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin update agent build version tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	tag, err := tx.Exec(ctx, `
+		UPDATE agent_build_versions SET
+			agent_kind = $2,
+			interface_spec = $3,
+			policy_spec = $4,
+			reasoning_spec = $5,
+			memory_spec = $6,
+			workflow_spec = $7,
+			guardrail_spec = $8,
+			model_spec = $9,
+			output_schema = $10,
+			trace_contract = $11,
+			publication_spec = $12
+		WHERE id = $1 AND version_status = 'draft'
+	`, params.ID,
+		params.AgentKind, params.InterfaceSpec, params.PolicySpec, params.ReasoningSpec,
+		params.MemorySpec, params.WorkflowSpec, params.GuardrailSpec, params.ModelSpec,
+		params.OutputSchema, params.TraceContract, params.PublicationSpec,
+	)
+	if err != nil {
+		return fmt.Errorf("update agent build version draft: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrAgentBuildVersionNotFound
+	}
+	if err := replaceAgentBuildVersionBindings(ctx, tx, params.ID, params.Tools, params.KnowledgeSources); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit update agent build version tx: %w", err)
+	}
+	return nil
+}
+
+func (r *Repository) MarkAgentBuildVersionReady(ctx context.Context, id uuid.UUID) error {
+	tag, err := r.db.Exec(ctx, `
+		UPDATE agent_build_versions SET version_status = 'ready'
+		WHERE id = $1 AND version_status = 'draft'
+	`, id)
+	if err != nil {
+		return fmt.Errorf("mark agent build version ready: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrAgentBuildVersionNotFound
+	}
+	return nil
+}
+
+func (r *Repository) CreateAgentDeployment(ctx context.Context, params CreateAgentDeploymentParams) (AgentDeploymentRow, error) {
+	row := r.db.QueryRow(ctx, `
+		INSERT INTO agent_deployments (
+			organization_id, workspace_id, agent_build_id, current_build_version_id,
+			runtime_profile_id, provider_account_id, model_alias_id,
+			name, slug, deployment_type, deployment_config
+		) VALUES (
+			$1, $2, $3, $4,
+			$5, $6, $7,
+			$8, $9, 'native', $10
+		) RETURNING id, organization_id, workspace_id, agent_build_id, current_build_version_id,
+			name, slug, deployment_type, status, created_at, updated_at
+	`, params.OrganizationID, params.WorkspaceID, params.AgentBuildID, params.CurrentBuildVersionID,
+		params.RuntimeProfileID, params.ProviderAccountID, params.ModelAliasID,
+		params.Name, params.Slug, params.DeploymentConfig,
+	)
+
+	var dep AgentDeploymentRow
+	var createdAt, updatedAt pgtype.Timestamptz
+	err := row.Scan(
+		&dep.ID, &dep.OrganizationID, &dep.WorkspaceID, &dep.AgentBuildID, &dep.CurrentBuildVersionID,
+		&dep.Name, &dep.Slug, &dep.DeploymentType, &dep.Status, &createdAt, &updatedAt,
+	)
+	if err != nil {
+		return AgentDeploymentRow{}, fmt.Errorf("create agent deployment: %w", err)
+	}
+
+	dep.CreatedAt = createdAt.Time
+	dep.UpdatedAt = updatedAt.Time
+	return dep, nil
+}
+
+func scanAgentBuildVersion(row pgx.Row) (AgentBuildVersion, error) {
+	var v AgentBuildVersion
+	var createdAt pgtype.Timestamptz
+	err := row.Scan(
+		&v.ID, &v.AgentBuildID, &v.VersionNumber, &v.VersionStatus,
+		&v.AgentKind, &v.InterfaceSpec, &v.PolicySpec, &v.ReasoningSpec,
+		&v.MemorySpec, &v.WorkflowSpec, &v.GuardrailSpec, &v.ModelSpec,
+		&v.OutputSchema, &v.TraceContract, &v.PublicationSpec, &v.CreatedByUserID, &createdAt,
+	)
+	if err != nil {
+		return AgentBuildVersion{}, fmt.Errorf("scan agent build version: %w", err)
+	}
+	v.CreatedAt = createdAt.Time
+	return v, nil
+}
+
+type agentBuildVersionBindingQuerier interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+}
+
+func replaceAgentBuildVersionBindings(
+	ctx context.Context,
+	q agentBuildVersionBindingQuerier,
+	versionID uuid.UUID,
+	tools []AgentBuildVersionToolBinding,
+	knowledgeSources []AgentBuildVersionKnowledgeSourceBinding,
+) error {
+	if _, err := q.Exec(ctx, `DELETE FROM agent_build_version_tools WHERE agent_build_version_id = $1`, versionID); err != nil {
+		return fmt.Errorf("delete agent build version tools: %w", err)
+	}
+	for _, binding := range normalizeToolBindings(tools) {
+		if _, err := q.Exec(ctx, `
+			INSERT INTO agent_build_version_tools (agent_build_version_id, tool_id, binding_role, binding_config)
+			VALUES ($1, $2, $3, $4)
+		`, versionID, binding.ToolID, binding.BindingRole, binding.BindingConfig); err != nil {
+			return fmt.Errorf("insert agent build version tool binding: %w", err)
+		}
+	}
+
+	if _, err := q.Exec(ctx, `DELETE FROM agent_build_version_knowledge_sources WHERE agent_build_version_id = $1`, versionID); err != nil {
+		return fmt.Errorf("delete agent build version knowledge sources: %w", err)
+	}
+	for _, binding := range normalizeKnowledgeSourceBindings(knowledgeSources) {
+		if _, err := q.Exec(ctx, `
+			INSERT INTO agent_build_version_knowledge_sources (agent_build_version_id, knowledge_source_id, binding_role, binding_config)
+			VALUES ($1, $2, $3, $4)
+		`, versionID, binding.KnowledgeSourceID, binding.BindingRole, binding.BindingConfig); err != nil {
+			return fmt.Errorf("insert agent build version knowledge source binding: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (r *Repository) loadAgentBuildVersionBindings(ctx context.Context, version *AgentBuildVersion) error {
+	toolRows, err := r.db.Query(ctx, `
+		SELECT tool_id, binding_role, binding_config
+		FROM agent_build_version_tools
+		WHERE agent_build_version_id = $1
+		ORDER BY tool_id
+	`, version.ID)
+	if err != nil {
+		return fmt.Errorf("list agent build version tools: %w", err)
+	}
+	defer toolRows.Close()
+
+	var tools []AgentBuildVersionToolBinding
+	for toolRows.Next() {
+		var binding AgentBuildVersionToolBinding
+		if err := toolRows.Scan(&binding.ToolID, &binding.BindingRole, &binding.BindingConfig); err != nil {
+			return fmt.Errorf("scan agent build version tool binding: %w", err)
+		}
+		tools = append(tools, binding)
+	}
+	if err := toolRows.Err(); err != nil {
+		return fmt.Errorf("iterate agent build version tools: %w", err)
+	}
+
+	knowledgeRows, err := r.db.Query(ctx, `
+		SELECT knowledge_source_id, binding_role, binding_config
+		FROM agent_build_version_knowledge_sources
+		WHERE agent_build_version_id = $1
+		ORDER BY knowledge_source_id
+	`, version.ID)
+	if err != nil {
+		return fmt.Errorf("list agent build version knowledge sources: %w", err)
+	}
+	defer knowledgeRows.Close()
+
+	var knowledgeSources []AgentBuildVersionKnowledgeSourceBinding
+	for knowledgeRows.Next() {
+		var binding AgentBuildVersionKnowledgeSourceBinding
+		if err := knowledgeRows.Scan(&binding.KnowledgeSourceID, &binding.BindingRole, &binding.BindingConfig); err != nil {
+			return fmt.Errorf("scan agent build version knowledge source binding: %w", err)
+		}
+		knowledgeSources = append(knowledgeSources, binding)
+	}
+	if err := knowledgeRows.Err(); err != nil {
+		return fmt.Errorf("iterate agent build version knowledge sources: %w", err)
+	}
+
+	version.Tools = normalizeToolBindings(tools)
+	version.KnowledgeSources = normalizeKnowledgeSourceBindings(knowledgeSources)
+	return nil
+}
+
+func normalizeToolBindings(bindings []AgentBuildVersionToolBinding) []AgentBuildVersionToolBinding {
+	if bindings == nil {
+		return []AgentBuildVersionToolBinding{}
+	}
+	out := make([]AgentBuildVersionToolBinding, 0, len(bindings))
+	for _, binding := range bindings {
+		out = append(out, AgentBuildVersionToolBinding{
+			ToolID:        binding.ToolID,
+			BindingRole:   defaultStringOrFallback(binding.BindingRole, "default"),
+			BindingConfig: defaultJSONObject(binding.BindingConfig),
+		})
+	}
+	return out
+}
+
+func normalizeKnowledgeSourceBindings(bindings []AgentBuildVersionKnowledgeSourceBinding) []AgentBuildVersionKnowledgeSourceBinding {
+	if bindings == nil {
+		return []AgentBuildVersionKnowledgeSourceBinding{}
+	}
+	out := make([]AgentBuildVersionKnowledgeSourceBinding, 0, len(bindings))
+	for _, binding := range bindings {
+		out = append(out, AgentBuildVersionKnowledgeSourceBinding{
+			KnowledgeSourceID: binding.KnowledgeSourceID,
+			BindingRole:       defaultStringOrFallback(binding.BindingRole, "default"),
+			BindingConfig:     defaultJSONObject(binding.BindingConfig),
+		})
+	}
+	return out
+}
+
+func defaultStringOrFallback(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}
+
+func defaultJSONObject(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return json.RawMessage(`{}`)
+	}
+	return raw
 }
 
 func temporalIDsMatch(row repositorysqlc.Run, params SetRunTemporalIDsParams) bool {

--- a/backend/sqlc.yaml
+++ b/backend/sqlc.yaml
@@ -15,6 +15,7 @@ sql:
       - "db/queries/run_comparisons.sql"
       - "db/queries/agent_deployments.sql"
       - "db/queries/challenge_packs.sql"
+      - "db/queries/agent_builds.sql"
     gen:
       go:
         package: "sqlc"

--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -13,7 +13,7 @@ const PRESETS = {
     userId: "11111111-1111-1111-1111-111111111111",
     email: "dev@agentclash.dev",
     displayName: "Dev User",
-    workspaceMemberships: "22222222-2222-2222-2222-222222222222:admin",
+    workspaceMemberships: "22222222-2222-2222-2222-222222222222:workspace_admin",
   },
 };
 

--- a/web/src/app/(dashboard)/builds/[id]/page.tsx
+++ b/web/src/app/(dashboard)/builds/[id]/page.tsx
@@ -1,0 +1,728 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { useAuthStore } from "@/lib/stores/auth";
+import {
+  api,
+  type AgentBuildResponse,
+  type AgentBuildVersionResponse,
+  type AgentBuildToolBinding,
+  type AgentBuildKnowledgeSourceBinding,
+  type ValidationError,
+} from "@/lib/api/client";
+import { PageHeader } from "@/components/layout/page-header";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  ArrowLeft,
+  Loader2,
+  Save,
+  Shield,
+  Rocket,
+  Check,
+  AlertCircle,
+  ChevronDown,
+  ChevronRight,
+  Plus,
+} from "lucide-react";
+
+type BuildWithVersions = AgentBuildResponse & { versions: AgentBuildVersionResponse[] };
+
+const AGENT_KINDS = [
+  "llm_agent",
+  "workflow_agent",
+  "programmatic_agent",
+  "multi_agent_system",
+  "hosted_external",
+] as const;
+
+type VersionStatusVariant = "pass" | "fail" | "warn" | "pending" | "neutral";
+
+function getVersionStatusVariant(status: string): VersionStatusVariant {
+  switch (status) {
+    case "ready": return "pass";
+    case "draft": return "pending";
+    case "invalid": return "fail";
+    default: return "neutral";
+  }
+}
+
+const variantStyles: Record<VersionStatusVariant, string> = {
+  pass: "text-status-pass bg-status-pass/10",
+  fail: "text-status-fail bg-status-fail/10",
+  warn: "text-status-warn bg-status-warn/10",
+  pending: "text-text-3 bg-surface",
+  neutral: "text-text-2 bg-surface",
+};
+
+function VersionStatusBadge({ status }: { status: string }) {
+  const variant = getVersionStatusVariant(status);
+  return (
+    <span
+      className={`
+        inline-flex items-center
+        font-[family-name:var(--font-mono)] text-[11px] font-semibold
+        uppercase tracking-[0.06em]
+        px-2.5 py-1 rounded
+        ${variantStyles[variant]}
+      `}
+    >
+      {status}
+    </span>
+  );
+}
+
+function CollapsibleSection({
+  title,
+  defaultOpen = false,
+  children,
+}: {
+  title: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <Card className="bg-card">
+      <CardHeader
+        className="cursor-pointer select-none"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <CardTitle className="flex items-center gap-2 text-sm">
+          {open ? (
+            <ChevronDown className="size-4 text-text-3" />
+          ) : (
+            <ChevronRight className="size-4 text-text-3" />
+          )}
+          {title}
+        </CardTitle>
+      </CardHeader>
+      {open && <CardContent>{children}</CardContent>}
+    </Card>
+  );
+}
+
+function JsonTextarea({
+  value,
+  onChange,
+}: {
+  value: Record<string, unknown> | unknown[];
+  onChange: (v: Record<string, unknown> | unknown[]) => void;
+}) {
+  const [text, setText] = useState(JSON.stringify(value, null, 2));
+  const [parseError, setParseError] = useState(false);
+
+  useEffect(() => {
+    setText(JSON.stringify(value, null, 2));
+  }, [value]);
+
+  return (
+    <div>
+      <textarea
+        value={text}
+        onChange={(e) => {
+          setText(e.target.value);
+          try {
+            const parsed = JSON.parse(e.target.value);
+            onChange(parsed);
+            setParseError(false);
+          } catch {
+            setParseError(true);
+          }
+        }}
+        className={`w-full min-h-[120px] rounded-lg border p-3 font-[family-name:var(--font-mono)] text-xs text-text-1 focus:outline-none focus:ring-1 focus:ring-ds-accent bg-surface ${parseError ? "border-status-fail" : "border-border"}`}
+      />
+      {parseError && (
+        <p className="text-[10px] text-status-fail mt-1">Invalid JSON</p>
+      )}
+    </div>
+  );
+}
+
+export default function BuildDetailPage() {
+  const params = useParams();
+  const buildId = params.id as string;
+  const { activeWorkspaceId } = useAuthStore();
+
+  const [build, setBuild] = useState<BuildWithVersions | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const [activeVersion, setActiveVersion] = useState<AgentBuildVersionResponse | null>(null);
+  const [agentKind, setAgentKind] = useState("llm_agent");
+  const [instructions, setInstructions] = useState("");
+  const [interfaceSpec, setInterfaceSpec] = useState<Record<string, unknown>>({});
+  const [outputSchema, setOutputSchema] = useState<Record<string, unknown>>({});
+  const [tools, setTools] = useState<AgentBuildToolBinding[]>([]);
+  const [knowledgeSources, setKnowledgeSources] = useState<AgentBuildKnowledgeSourceBinding[]>([]);
+  const [guardrailSpec, setGuardrailSpec] = useState<Record<string, unknown>>({});
+  const [reasoningSpec, setReasoningSpec] = useState<Record<string, unknown>>({});
+  const [memorySpec, setMemorySpec] = useState<Record<string, unknown>>({});
+  const [workflowSpec, setWorkflowSpec] = useState<Record<string, unknown>>({});
+  const [modelSpec, setModelSpec] = useState<Record<string, unknown>>({});
+  const [publicationSpec, setPublicationSpec] = useState<Record<string, unknown>>({});
+
+  const [saving, setSaving] = useState(false);
+  const [validating, setValidating] = useState(false);
+  const [validationErrors, setValidationErrors] = useState<ValidationError[]>([]);
+  const [validationSuccess, setValidationSuccess] = useState(false);
+  const [markingReady, setMarkingReady] = useState(false);
+  const [actionError, setActionError] = useState("");
+  const [actionSuccess, setActionSuccess] = useState("");
+
+  const [deployName, setDeployName] = useState("");
+  const [runtimeProfileId, setRuntimeProfileId] = useState("");
+  const [providerAccountId, setProviderAccountId] = useState("");
+  const [modelAliasId, setModelAliasId] = useState("");
+  const [deploying, setDeploying] = useState(false);
+
+  const loadBuild = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const result = await api.getAgentBuild(buildId);
+      setBuild(result);
+      if (result.versions && result.versions.length > 0) {
+        populateVersionForm(result.versions[0]);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load build");
+    } finally {
+      setLoading(false);
+    }
+  }, [buildId]);
+
+  function populateVersionForm(v: AgentBuildVersionResponse) {
+    setActiveVersion(v);
+    setAgentKind(v.agent_kind || "llm_agent");
+    setInstructions(
+      (v.policy_spec as Record<string, unknown>)?.instructions as string || ""
+    );
+    setInterfaceSpec(v.interface_spec || {});
+    setOutputSchema(v.output_schema || {});
+    setTools(v.tools || []);
+    setKnowledgeSources(v.knowledge_sources || []);
+    setGuardrailSpec(v.guardrail_spec || {});
+    setReasoningSpec(v.reasoning_spec || {});
+    setMemorySpec(v.memory_spec || {});
+    setWorkflowSpec(v.workflow_spec || {});
+    setModelSpec(v.model_spec || {});
+    setPublicationSpec(v.publication_spec || {});
+  }
+
+  useEffect(() => {
+    loadBuild();
+  }, [loadBuild]);
+
+  function buildVersionPayload() {
+    return {
+      agent_kind: agentKind,
+      policy_spec: instructions ? { instructions } : {},
+      interface_spec: interfaceSpec,
+      output_schema: outputSchema,
+      tools,
+      knowledge_sources: knowledgeSources,
+      guardrail_spec: guardrailSpec,
+      reasoning_spec: reasoningSpec,
+      memory_spec: memorySpec,
+      workflow_spec: workflowSpec,
+      model_spec: modelSpec,
+      publication_spec: publicationSpec,
+    };
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setActionError("");
+    setActionSuccess("");
+    try {
+      const payload = buildVersionPayload();
+      if (activeVersion) {
+        const updated = await api.updateAgentBuildVersion(activeVersion.id, payload);
+        setActiveVersion(updated);
+        setActionSuccess("Draft saved");
+      } else {
+        const created = await api.createAgentBuildVersion(buildId, payload);
+        setActiveVersion(created);
+        setActionSuccess("Version created");
+      }
+      await loadBuild();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleValidate() {
+    if (!activeVersion) return;
+    setValidating(true);
+    setValidationErrors([]);
+    setValidationSuccess(false);
+    setActionError("");
+    setActionSuccess("");
+    try {
+      const result = await api.validateAgentBuildVersion(activeVersion.id);
+      if (result.valid) {
+        setValidationSuccess(true);
+        setActionSuccess("Validation passed");
+      } else {
+        setValidationErrors(result.errors);
+      }
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Validation failed");
+    } finally {
+      setValidating(false);
+    }
+  }
+
+  async function handleMarkReady() {
+    if (!activeVersion) return;
+    setMarkingReady(true);
+    setActionError("");
+    setActionSuccess("");
+    try {
+      const updated = await api.markAgentBuildVersionReady(activeVersion.id);
+      setActiveVersion(updated);
+      setActionSuccess("Version marked as ready");
+      await loadBuild();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Failed to mark ready");
+    } finally {
+      setMarkingReady(false);
+    }
+  }
+
+  async function handleCreateNewVersion() {
+    setSaving(true);
+    setActionError("");
+    setActionSuccess("");
+    try {
+      const payload = buildVersionPayload();
+      const created = await api.createAgentBuildVersion(buildId, payload);
+      populateVersionForm(created);
+      setActionSuccess("New version created");
+      await loadBuild();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Failed to create version");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDeploy(e: React.FormEvent) {
+    e.preventDefault();
+    if (!activeWorkspaceId || !activeVersion || !build) return;
+    setDeploying(true);
+    setActionError("");
+    setActionSuccess("");
+    try {
+      await api.createAgentDeployment(activeWorkspaceId, {
+        name: deployName.trim(),
+        agent_build_id: build.id,
+        build_version_id: activeVersion.id,
+        runtime_profile_id: runtimeProfileId.trim(),
+        provider_account_id: providerAccountId.trim() || undefined,
+        model_alias_id: modelAliasId.trim() || undefined,
+      });
+      setActionSuccess("Deployment created");
+      setDeployName("");
+      setRuntimeProfileId("");
+      setProviderAccountId("");
+      setModelAliasId("");
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Failed to create deployment");
+    } finally {
+      setDeploying(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="max-w-4xl space-y-4">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-64" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="max-w-4xl">
+        <div className="mb-4">
+          <Link
+            href="/builds"
+            className="inline-flex items-center gap-1.5 text-xs text-text-3 hover:text-text-1 transition-colors"
+          >
+            <ArrowLeft className="size-3" />
+            Back to builds
+          </Link>
+        </div>
+        <div className="rounded-lg border border-status-fail/20 bg-status-fail/5 p-4">
+          <p className="text-sm text-status-fail">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!build) return null;
+
+  const isDraft = activeVersion?.version_status === "draft";
+  const isReady = activeVersion?.version_status === "ready";
+
+  return (
+    <div className="max-w-4xl">
+      <div className="mb-4">
+        <Link
+          href="/builds"
+          className="inline-flex items-center gap-1.5 text-xs text-text-3 hover:text-text-1 transition-colors"
+        >
+          <ArrowLeft className="size-3" />
+          Back to builds
+        </Link>
+      </div>
+
+      <PageHeader
+        eyebrow="Build"
+        title={build.name}
+        description={build.description || `Build ${build.id.slice(0, 8)}`}
+      />
+
+      {actionError && (
+        <div className="rounded-lg border border-status-fail/20 bg-status-fail/5 p-3 mb-4">
+          <p className="text-xs text-status-fail">{actionError}</p>
+        </div>
+      )}
+
+      {actionSuccess && (
+        <div className="rounded-lg border border-status-pass/20 bg-status-pass/5 p-3 mb-4">
+          <p className="text-xs text-status-pass flex items-center gap-1.5">
+            <Check className="size-3" />
+            {actionSuccess}
+          </p>
+        </div>
+      )}
+
+      {validationErrors.length > 0 && (
+        <div className="rounded-lg border border-status-fail/20 bg-status-fail/5 p-3 mb-4">
+          <p className="text-xs font-medium text-status-fail mb-2 flex items-center gap-1.5">
+            <AlertCircle className="size-3" />
+            Validation errors
+          </p>
+          <ul className="space-y-1">
+            {validationErrors.map((ve, i) => (
+              <li key={i} className="text-[11px] text-status-fail">
+                <span className="font-[family-name:var(--font-mono)]">{ve.field}</span>: {ve.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {build.versions && build.versions.length > 1 && (
+        <div className="mb-6">
+          <Label className="text-xs text-text-2 mb-2 block">Versions</Label>
+          <div className="flex flex-wrap gap-2">
+            {build.versions.map((v) => (
+              <button
+                key={v.id}
+                type="button"
+                onClick={() => populateVersionForm(v)}
+                className={`
+                  inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs
+                  font-[family-name:var(--font-mono)] border cursor-pointer transition-colors
+                  ${activeVersion?.id === v.id
+                    ? "border-ds-accent text-ds-accent bg-ds-accent/5"
+                    : "border-border text-text-2 hover:border-text-3"
+                  }
+                `}
+              >
+                v{v.version_number}
+                <VersionStatusBadge status={v.version_status} />
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-4">
+        <CollapsibleSection title="Basics" defaultOpen>
+          <div className="space-y-4">
+            <div className="flex items-center gap-4">
+              {activeVersion && (
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-text-3">Status:</span>
+                  <VersionStatusBadge status={activeVersion.version_status} />
+                </div>
+              )}
+              {activeVersion && (
+                <div className="text-xs text-text-3">
+                  Version {activeVersion.version_number}
+                </div>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label className="text-xs text-text-2">Agent Kind</Label>
+              <select
+                value={agentKind}
+                onChange={(e) => setAgentKind(e.target.value)}
+                className="w-full max-w-md rounded-lg border border-border bg-surface p-2 text-sm text-text-1 font-[family-name:var(--font-mono)] focus:outline-none focus:ring-1 focus:ring-ds-accent"
+              >
+                {AGENT_KINDS.map((kind) => (
+                  <option key={kind} value={kind}>
+                    {kind}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Instructions" defaultOpen>
+          <div className="space-y-2">
+            <Label className="text-xs text-text-2">Policy Instructions</Label>
+            <textarea
+              value={instructions}
+              onChange={(e) => setInstructions(e.target.value)}
+              placeholder="Enter agent instructions..."
+              className="w-full min-h-[160px] rounded-lg border border-border bg-surface p-3 text-sm text-text-1 focus:outline-none focus:ring-1 focus:ring-ds-accent"
+            />
+          </div>
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Interface">
+          <div className="space-y-2">
+            <Label className="text-xs text-text-2">Interface Spec (JSON)</Label>
+            <JsonTextarea
+              value={interfaceSpec}
+              onChange={(v) => setInterfaceSpec(v as Record<string, unknown>)}
+            />
+          </div>
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Output Schema">
+          <div className="space-y-2">
+            <Label className="text-xs text-text-2">Output Schema (JSON)</Label>
+            <JsonTextarea
+              value={outputSchema}
+              onChange={(v) => setOutputSchema(v as Record<string, unknown>)}
+            />
+          </div>
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Tools">
+          <div className="space-y-2">
+            <Label className="text-xs text-text-2">Tools (JSON Array)</Label>
+            <JsonTextarea
+              value={tools}
+              onChange={(v) => setTools(v as AgentBuildToolBinding[])}
+            />
+          </div>
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Knowledge Sources">
+          <div className="space-y-2">
+            <Label className="text-xs text-text-2">Knowledge Sources (JSON Array)</Label>
+            <JsonTextarea
+              value={knowledgeSources}
+              onChange={(v) => setKnowledgeSources(v as AgentBuildKnowledgeSourceBinding[])}
+            />
+          </div>
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Guardrails">
+          <div className="space-y-2">
+            <Label className="text-xs text-text-2">Guardrail Spec (JSON)</Label>
+            <JsonTextarea
+              value={guardrailSpec}
+              onChange={(v) => setGuardrailSpec(v as Record<string, unknown>)}
+            />
+          </div>
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Reasoning">
+          <div className="space-y-2">
+            <Label className="text-xs text-text-2">Reasoning Spec (JSON)</Label>
+            <JsonTextarea
+              value={reasoningSpec}
+              onChange={(v) => setReasoningSpec(v as Record<string, unknown>)}
+            />
+          </div>
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Memory">
+          <div className="space-y-2">
+            <Label className="text-xs text-text-2">Memory Spec (JSON)</Label>
+            <JsonTextarea
+              value={memorySpec}
+              onChange={(v) => setMemorySpec(v as Record<string, unknown>)}
+            />
+          </div>
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Workflow">
+          <div className="space-y-2">
+            <Label className="text-xs text-text-2">Workflow Spec (JSON)</Label>
+            <JsonTextarea
+              value={workflowSpec}
+              onChange={(v) => setWorkflowSpec(v as Record<string, unknown>)}
+            />
+          </div>
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Model">
+          <div className="space-y-2">
+            <Label className="text-xs text-text-2">Model Spec (JSON)</Label>
+            <JsonTextarea
+              value={modelSpec}
+              onChange={(v) => setModelSpec(v as Record<string, unknown>)}
+            />
+          </div>
+        </CollapsibleSection>
+
+        <CollapsibleSection title="Publication">
+          <div className="space-y-2">
+            <Label className="text-xs text-text-2">Publication Spec (JSON)</Label>
+            <JsonTextarea
+              value={publicationSpec}
+              onChange={(v) => setPublicationSpec(v as Record<string, unknown>)}
+            />
+          </div>
+        </CollapsibleSection>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3 mt-8">
+        <Button onClick={handleSave} disabled={saving}>
+          {saving ? (
+            <>
+              <Loader2 className="size-3.5 animate-spin" />
+              Saving...
+            </>
+          ) : (
+            <>
+              <Save className="size-3.5" />
+              {activeVersion ? "Save Draft" : "Create Version"}
+            </>
+          )}
+        </Button>
+
+        {activeVersion && (
+          <Button variant="outline" onClick={handleValidate} disabled={validating}>
+            {validating ? (
+              <>
+                <Loader2 className="size-3.5 animate-spin" />
+                Validating...
+              </>
+            ) : (
+              <>
+                <Shield className="size-3.5" />
+                Validate
+              </>
+            )}
+          </Button>
+        )}
+
+        {activeVersion && isDraft && (
+          <Button variant="outline" onClick={handleMarkReady} disabled={markingReady}>
+            {markingReady ? (
+              <>
+                <Loader2 className="size-3.5 animate-spin" />
+                Marking...
+              </>
+            ) : (
+              <>
+                <Check className="size-3.5" />
+                Mark Ready
+              </>
+            )}
+          </Button>
+        )}
+
+        {activeVersion && isReady && (
+          <Button variant="outline" onClick={handleCreateNewVersion} disabled={saving}>
+            <Plus className="size-3.5" />
+            New Version
+          </Button>
+        )}
+      </div>
+
+      {validationSuccess && (
+        <div className="mt-4 rounded-lg border border-status-pass/20 bg-status-pass/5 p-3">
+          <p className="text-xs text-status-pass flex items-center gap-1.5">
+            <Check className="size-3" />
+            All checks passed
+          </p>
+        </div>
+      )}
+
+      {activeVersion && isReady && (
+        <div className="mt-10">
+          <h2 className="font-[family-name:var(--font-display)] text-lg text-text-1 mb-4 flex items-center gap-2">
+            <Rocket className="size-4 text-ds-accent" />
+            Create Deployment
+          </h2>
+          <Card className="bg-card">
+            <CardContent className="pt-2">
+              <form onSubmit={handleDeploy} className="space-y-4">
+                <div className="space-y-2">
+                  <Label className="text-xs text-text-2">Deployment Name</Label>
+                  <Input
+                    value={deployName}
+                    onChange={(e) => setDeployName(e.target.value)}
+                    placeholder="e.g., my-agent-prod"
+                    className="max-w-md"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-xs text-text-2">Runtime Profile ID</Label>
+                  <Input
+                    value={runtimeProfileId}
+                    onChange={(e) => setRuntimeProfileId(e.target.value)}
+                    placeholder="UUID"
+                    className="max-w-md font-[family-name:var(--font-mono)] text-xs"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-xs text-text-2">Provider Account ID (optional)</Label>
+                  <Input
+                    value={providerAccountId}
+                    onChange={(e) => setProviderAccountId(e.target.value)}
+                    placeholder="UUID"
+                    className="max-w-md font-[family-name:var(--font-mono)] text-xs"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-xs text-text-2">Model Alias ID (optional)</Label>
+                  <Input
+                    value={modelAliasId}
+                    onChange={(e) => setModelAliasId(e.target.value)}
+                    placeholder="UUID"
+                    className="max-w-md font-[family-name:var(--font-mono)] text-xs"
+                  />
+                </div>
+                <Button type="submit" disabled={deploying || !deployName.trim() || !runtimeProfileId.trim()}>
+                  {deploying ? (
+                    <>
+                      <Loader2 className="size-3.5 animate-spin" />
+                      Deploying...
+                    </>
+                  ) : (
+                    <>
+                      <Rocket className="size-3.5" />
+                      Deploy
+                    </>
+                  )}
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/(dashboard)/builds/new/page.tsx
+++ b/web/src/app/(dashboard)/builds/new/page.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useAuthStore } from "@/lib/stores/auth";
+import { api } from "@/lib/api/client";
+import { PageHeader } from "@/components/layout/page-header";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ArrowLeft, Loader2, Plus } from "lucide-react";
+
+export default function CreateBuildPage() {
+  const router = useRouter();
+  const { activeWorkspaceId } = useAuthStore();
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!activeWorkspaceId) return;
+
+    setError("");
+    if (!name.trim()) {
+      setError("Name is required");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const result = await api.createAgentBuild(activeWorkspaceId, {
+        name: name.trim(),
+        description: description.trim() || undefined,
+      });
+      router.push(`/builds/${result.id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create build");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="max-w-3xl">
+      <div className="mb-4">
+        <Link
+          href="/builds"
+          className="inline-flex items-center gap-1.5 text-xs text-text-3 hover:text-text-1 transition-colors"
+        >
+          <ArrowLeft className="size-3" />
+          Back to builds
+        </Link>
+      </div>
+
+      <PageHeader
+        eyebrow="Create"
+        title="New Build"
+        description="Define an agent build configuration"
+      />
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="space-y-2">
+          <Label className="text-xs text-text-2">Name</Label>
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g., my-llm-agent"
+            className="max-w-md"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label className="text-xs text-text-2">Description (optional)</Label>
+          <Input
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Brief description of this agent build"
+            className="max-w-md"
+          />
+        </div>
+
+        {error && (
+          <div className="rounded-lg border border-status-fail/20 bg-status-fail/5 p-3">
+            <p className="text-xs text-status-fail">{error}</p>
+          </div>
+        )}
+
+        <div className="flex items-center gap-3 pt-2">
+          <Button type="submit" disabled={submitting}>
+            {submitting ? (
+              <>
+                <Loader2 className="size-3.5 animate-spin" />
+                Creating...
+              </>
+            ) : (
+              <>
+                <Plus className="size-3.5" data-icon="inline-start" />
+                Create Build
+              </>
+            )}
+          </Button>
+          <Link href="/builds">
+            <Button type="button" variant="outline">
+              Cancel
+            </Button>
+          </Link>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/web/src/app/(dashboard)/builds/page.tsx
+++ b/web/src/app/(dashboard)/builds/page.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import { useAuthStore } from "@/lib/stores/auth";
+import { api, type AgentBuildResponse, type ListAgentBuildsResponse } from "@/lib/api/client";
+import { PageHeader } from "@/components/layout/page-header";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Plus } from "lucide-react";
+
+function formatRelativeTime(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 60) return "just now";
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDays = Math.floor(diffHr / 24);
+  return `${diffDays}d ago`;
+}
+
+type BuildStatusVariant = "pass" | "fail" | "warn" | "pending" | "neutral";
+
+function getBuildStatusVariant(status: string): BuildStatusVariant {
+  switch (status) {
+    case "active": return "pass";
+    case "archived": return "neutral";
+    case "draft": return "pending";
+    default: return "neutral";
+  }
+}
+
+const variantStyles: Record<BuildStatusVariant, string> = {
+  pass: "text-status-pass bg-status-pass/10",
+  fail: "text-status-fail bg-status-fail/10",
+  warn: "text-status-warn bg-status-warn/10",
+  pending: "text-text-3 bg-surface",
+  neutral: "text-text-2 bg-surface",
+};
+
+function BuildStatusBadge({ status }: { status: string }) {
+  const variant = getBuildStatusVariant(status);
+  return (
+    <span
+      className={`
+        inline-flex items-center
+        font-[family-name:var(--font-mono)] text-[11px] font-semibold
+        uppercase tracking-[0.06em]
+        px-2.5 py-1 rounded
+        ${variantStyles[variant]}
+      `}
+    >
+      {status}
+    </span>
+  );
+}
+
+export default function BuildsPage() {
+  const { activeWorkspaceId } = useAuthStore();
+  const [data, setData] = useState<ListAgentBuildsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const fetchBuilds = useCallback(async () => {
+    if (!activeWorkspaceId) return;
+    setLoading(true);
+    setError("");
+    try {
+      const result = await api.listAgentBuilds(activeWorkspaceId);
+      setData(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load builds");
+    } finally {
+      setLoading(false);
+    }
+  }, [activeWorkspaceId]);
+
+  useEffect(() => {
+    fetchBuilds();
+  }, [fetchBuilds]);
+
+  return (
+    <div className="max-w-5xl">
+      <PageHeader
+        eyebrow="Agent Authoring"
+        title="Builds"
+        description="Agent build definitions in this workspace"
+        actions={
+          <Link href="/builds/new">
+            <Button size="sm">
+              <Plus className="size-4" data-icon="inline-start" />
+              New Build
+            </Button>
+          </Link>
+        }
+      />
+
+      {error && (
+        <div className="rounded-lg border border-status-fail/20 bg-status-fail/5 p-4 mb-6">
+          <p className="text-sm text-status-fail">{error}</p>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full" />
+          ))}
+        </div>
+      ) : data && data.items.length > 0 ? (
+        <div className="rounded-xl border border-border overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow className="hover:bg-transparent">
+                <TableHead className="font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.06em] text-text-4">
+                  Name
+                </TableHead>
+                <TableHead className="font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.06em] text-text-4">
+                  Status
+                </TableHead>
+                <TableHead className="font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.06em] text-text-4 text-right">
+                  Updated
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {data.items.map((build: AgentBuildResponse) => (
+                <TableRow key={build.id} className="group">
+                  <TableCell>
+                    <Link
+                      href={`/builds/${build.id}`}
+                      className="text-sm font-medium text-text-1 group-hover:text-ds-accent transition-colors"
+                    >
+                      {build.name}
+                    </Link>
+                    <p className="text-[11px] text-text-3 font-[family-name:var(--font-mono)]">
+                      {build.id.slice(0, 8)}
+                    </p>
+                  </TableCell>
+                  <TableCell>
+                    <BuildStatusBadge status={build.lifecycle_status} />
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <span className="text-xs text-text-3">
+                      {formatRelativeTime(build.updated_at)}
+                    </span>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      ) : (
+        <div className="text-center py-20">
+          <p className="text-text-3 text-sm mb-4">No builds yet</p>
+          <Link href="/builds/new">
+            <Button size="sm">
+              <Plus className="size-4" data-icon="inline-start" />
+              Create your first build
+            </Button>
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/layout/app-sidebar.tsx
+++ b/web/src/components/layout/app-sidebar.tsx
@@ -25,6 +25,7 @@ import {
   Play,
   GitCompareArrows,
   LayoutDashboard,
+  Blocks,
   LogOut,
   ChevronUp,
   User,
@@ -32,6 +33,7 @@ import {
 
 const navItems = [
   { title: "Runs", href: "/", icon: LayoutDashboard },
+  { title: "Builds", href: "/builds", icon: Blocks },
   { title: "Compare", href: "/compare", icon: GitCompareArrows },
   { title: "New Run", href: "/runs/new", icon: Play },
 ];

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -136,6 +136,54 @@ export const api = {
   // Challenge Packs
   listChallengePacks: (workspaceId: string) =>
     apiFetch<ListChallengePacksResponse>(`/workspaces/${workspaceId}/challenge-packs`),
+
+  // Agent Builds
+  listAgentBuilds: (workspaceId: string) =>
+    apiFetch<ListAgentBuildsResponse>(`/workspaces/${workspaceId}/agent-builds`),
+
+  createAgentBuild: (workspaceId: string, input: CreateAgentBuildInput) =>
+    apiFetch<AgentBuildResponse>(`/workspaces/${workspaceId}/agent-builds`, {
+      method: "POST",
+      body: input,
+    }),
+
+  getAgentBuild: (agentBuildId: string) =>
+    apiFetch<AgentBuildResponse & { versions: AgentBuildVersionResponse[] }>(
+      `/agent-builds/${agentBuildId}`,
+    ),
+
+  createAgentBuildVersion: (agentBuildId: string, input: CreateAgentBuildVersionInput) =>
+    apiFetch<AgentBuildVersionResponse>(
+      `/agent-builds/${agentBuildId}/versions`,
+      { method: "POST", body: input },
+    ),
+
+  getAgentBuildVersion: (versionId: string) =>
+    apiFetch<AgentBuildVersionResponse>(`/agent-build-versions/${versionId}`),
+
+  updateAgentBuildVersion: (versionId: string, input: UpdateAgentBuildVersionInput) =>
+    apiFetch<AgentBuildVersionResponse>(`/agent-build-versions/${versionId}`, {
+      method: "PATCH",
+      body: input,
+    }),
+
+  validateAgentBuildVersion: (versionId: string) =>
+    apiFetch<ValidateBuildVersionResponse>(
+      `/agent-build-versions/${versionId}/validate`,
+      { method: "POST" },
+    ),
+
+  markAgentBuildVersionReady: (versionId: string) =>
+    apiFetch<AgentBuildVersionResponse>(
+      `/agent-build-versions/${versionId}/ready`,
+      { method: "POST" },
+    ),
+
+  createAgentDeployment: (workspaceId: string, input: CreateAgentDeploymentInput) =>
+    apiFetch<AgentDeployment>(`/workspaces/${workspaceId}/agent-deployments`, {
+      method: "POST",
+      body: input,
+    }),
 };
 
 // Response types
@@ -325,4 +373,94 @@ export type ChallengePack = {
 
 export type ListChallengePacksResponse = {
   items: ChallengePack[];
+};
+
+export type AgentBuildResponse = {
+  id: string;
+  workspace_id: string;
+  name: string;
+  description?: string;
+  lifecycle_status: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ListAgentBuildsResponse = {
+  items: AgentBuildResponse[];
+};
+
+export type AgentBuildVersionResponse = {
+  id: string;
+  agent_build_id: string;
+  version_number: number;
+  version_status: string;
+  agent_kind: string;
+  interface_spec: Record<string, unknown>;
+  policy_spec: Record<string, unknown>;
+  reasoning_spec: Record<string, unknown>;
+  memory_spec: Record<string, unknown>;
+  workflow_spec: Record<string, unknown>;
+  guardrail_spec: Record<string, unknown>;
+  model_spec: Record<string, unknown>;
+  output_schema: Record<string, unknown>;
+  trace_contract: Record<string, unknown>;
+  publication_spec: Record<string, unknown>;
+  tools: AgentBuildToolBinding[];
+  knowledge_sources: AgentBuildKnowledgeSourceBinding[];
+  created_at: string;
+};
+
+export type AgentBuildToolBinding = {
+  tool_id: string;
+  binding_role: string;
+  binding_config: Record<string, unknown>;
+};
+
+export type AgentBuildKnowledgeSourceBinding = {
+  knowledge_source_id: string;
+  binding_role: string;
+  binding_config: Record<string, unknown>;
+};
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+export type ValidateBuildVersionResponse = {
+  valid: boolean;
+  errors: ValidationError[];
+};
+
+export type CreateAgentBuildInput = {
+  name: string;
+  description?: string;
+};
+
+export type CreateAgentBuildVersionInput = {
+  agent_kind: string;
+  interface_spec?: Record<string, unknown>;
+  policy_spec?: Record<string, unknown>;
+  reasoning_spec?: Record<string, unknown>;
+  memory_spec?: Record<string, unknown>;
+  workflow_spec?: Record<string, unknown>;
+  guardrail_spec?: Record<string, unknown>;
+  model_spec?: Record<string, unknown>;
+  output_schema?: Record<string, unknown>;
+  trace_contract?: Record<string, unknown>;
+  publication_spec?: Record<string, unknown>;
+  tools?: AgentBuildToolBinding[];
+  knowledge_sources?: AgentBuildKnowledgeSourceBinding[];
+};
+
+export type UpdateAgentBuildVersionInput = Partial<CreateAgentBuildVersionInput>;
+
+export type CreateAgentDeploymentInput = {
+  name: string;
+  agent_build_id: string;
+  build_version_id: string;
+  runtime_profile_id: string;
+  provider_account_id?: string;
+  model_alias_id?: string;
+  deployment_config?: Record<string, unknown>;
 };

--- a/web/src/lib/schemas/index.ts
+++ b/web/src/lib/schemas/index.ts
@@ -80,3 +80,16 @@ export const devAuthSchema = z.object({
 });
 
 export type DevAuthForm = z.infer<typeof devAuthSchema>;
+
+// ─── Agent Build Schemas ───
+
+export const agentKindSchema = z.enum([
+  "llm_agent", "workflow_agent", "programmatic_agent", "multi_agent_system", "hosted_external",
+]);
+
+export const createAgentBuildSchema = z.object({
+  name: z.string().min(1, "Name is required").max(100, "Name too long"),
+  description: z.string().max(500, "Description too long").optional().or(z.literal("")),
+});
+
+export type CreateAgentBuildForm = z.infer<typeof createAgentBuildSchema>;

--- a/web/src/lib/stores/auth.ts
+++ b/web/src/lib/stores/auth.ts
@@ -19,7 +19,7 @@ type AuthState = {
 
 export const useAuthStore = create<AuthState>()(
   persist(
-    (set, get) => ({
+    (set) => ({
       isAuthenticated: false,
       devAuth: null,
       activeWorkspaceId: null,
@@ -32,7 +32,7 @@ export const useAuthStore = create<AuthState>()(
         set({
           isAuthenticated: true,
           devAuth: auth,
-          activeWorkspaceId: get().activeWorkspaceId || firstWorkspace,
+          activeWorkspaceId: firstWorkspace,
         });
       },
 


### PR DESCRIPTION
## Summary

- Add CRUD-lite backend APIs for `agent_builds`, `agent_build_versions`, and `agent_deployments` (native type)
- Add form-driven frontend UI: builds list, create build, build detail with structured-config version editor
- Wire end-to-end flow: create build → create/edit draft version → validate → mark ready → create deployment

Closes #106

## Backend

- **SQL queries** (`db/queries/agent_builds.sql`): create/get/list builds, create/get/list/update versions, mark ready, create deployments
- **Repository layer** (`repository.go`): 10 new methods with raw SQL, domain types for `AgentBuild`, `AgentBuildVersion`, `AgentDeploymentRow`, structured tool/knowledge bindings
- **API handlers** (`agent_builds.go`): 9 endpoints with service interface, validation, workspace authz on resource-scoped routes, slug generation, draft-only update guard, ready-gate before deploy
- **Routes**: workspace-scoped (POST/GET builds, POST deployments) and resource-scoped (GET/PATCH/POST versions, validate, ready)
- **Tests**: workspace authorization tests, tool/knowledge binding serialization test

### API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | `/v1/workspaces/{id}/agent-builds` | Create build |
| GET | `/v1/workspaces/{id}/agent-builds` | List builds |
| GET | `/v1/agent-builds/{id}` | Get build + versions |
| POST | `/v1/agent-builds/{id}/versions` | Create draft version |
| GET | `/v1/agent-build-versions/{id}` | Get version |
| PATCH | `/v1/agent-build-versions/{id}` | Update draft |
| POST | `/v1/agent-build-versions/{id}/validate` | Validate version |
| POST | `/v1/agent-build-versions/{id}/ready` | Mark ready |
| POST | `/v1/workspaces/{id}/agent-deployments` | Create deployment |

## Frontend

- **Builds list** (`/builds`): table with name, status, updated time; empty state; "New Build" CTA
- **Create build** (`/builds/new`): name + description form
- **Build detail** (`/builds/[id]`): version selector, collapsible section editor (Basics, Instructions, Interface, Output Schema, Tools, Knowledge Sources, Guardrails, Reasoning, Memory, Workflow, Model, Publication), Save/Validate/Mark Ready actions, deployment creation form for ready versions
- **Sidebar**: added "Builds" nav item
- **API client**: 9 typed methods, structured binding types
- **Schemas**: `agentKindSchema`, `createAgentBuildSchema`

## Test plan

- [ ] `go test ./internal/api/` passes (3 new tests + all existing)
- [ ] `go vet ./...` clean
- [ ] `npx tsc --noEmit` clean
- [ ] Create a build via UI, edit draft version, validate, mark ready, create deployment
- [ ] Verify workspace authz: resource-scoped endpoints reject users without membership
- [ ] Verify draft-only guard: PATCH returns 400 for ready versions
- [ ] Verify ready-gate: deployment creation fails for non-ready versions