### PR TITLE
Strengthen local proof path for latency and cost scorecards

### DIFF
--- a/scripts/dev/curl-create-run.sh
+++ b/scripts/dev/curl-create-run.sh
@@ -12,6 +12,7 @@ WORKSPACE_ID="${WORKSPACE_ID:-22222222-2222-2222-2222-222222222222}"
 USER_ID="${USER_ID:-33333333-3333-3333-3333-333333333333}"
 CHALLENGE_PACK_VERSION_ID="${CHALLENGE_PACK_VERSION_ID:-55555555-5555-5555-5555-555555555555}"
 AGENT_DEPLOYMENT_ID="${AGENT_DEPLOYMENT_ID:-eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee}"
+CHALLENGE_INPUT_SET_ID="${CHALLENGE_INPUT_SET_ID:-abababab-abab-abab-abab-abababababab}"
 API_BASE_URL="${API_BASE_URL:-http://localhost:8080}"
 
 echo "==> Checking API health"
@@ -27,6 +28,7 @@ curl \
   -d '{
     "workspace_id": "'"${WORKSPACE_ID}"'",
     "challenge_pack_version_id": "'"${CHALLENGE_PACK_VERSION_ID}"'",
+    "challenge_input_set_id": "'"${CHALLENGE_INPUT_SET_ID}"'",
     "agent_deployment_ids": ["'"${AGENT_DEPLOYMENT_ID}"'"]
   }'
 echo

--- a/scripts/dev/seed-local-run-fixture.sh
+++ b/scripts/dev/seed-local-run-fixture.sh
@@ -36,6 +36,8 @@ CHALLENGE_PACK_ID="44444444-4444-4444-4444-444444444444"
 CHALLENGE_PACK_VERSION_ID="55555555-5555-5555-5555-555555555555"
 CHALLENGE_IDENTITY_ID="66666666-6666-6666-6666-666666666666"
 CHALLENGE_VERSION_ID="77777777-7777-7777-7777-777777777777"
+CHALLENGE_INPUT_SET_ID="abababab-abab-abab-abab-abababababab"
+CHALLENGE_INPUT_ITEM_ID="cdcdcdcd-cdcd-cdcd-cdcd-cdcdcdcdcdcd"
 RUNTIME_PROFILE_ID="88888888-8888-8888-8888-888888888888"
 PROVIDER_ACCOUNT_ID="99999999-9999-9999-9999-999999999999"
 MODEL_CATALOG_ENTRY_ID="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
@@ -79,15 +81,33 @@ VALUES (
   '{
     "tool_policy":{"allowed_tool_kinds":["file"]},
     "evaluation_spec":{
-      "name":"local-smoke-scorecard",
+      "name":"local-phase1-scorecard",
       "version_number":1,
       "judge_mode":"deterministic",
       "validators":[
         {
-          "key":"answer-present",
-          "type":"contains",
+          "key":"output-shape",
+          "type":"json_schema",
           "target":"final_output",
-          "expected_from":"literal:answer"
+          "expected_from":"literal:{\"type\":\"object\",\"required\":[\"code\",\"risk_level\",\"summary\"],\"properties\":{\"code\":{\"type\":\"string\"},\"risk_level\":{\"type\":\"string\"},\"summary\":{\"type\":\"string\"}}}"
+        },
+        {
+          "key":"ticket-code",
+          "type":"json_path_match",
+          "target":"final_output",
+          "expected_from":"literal:{\"path\":\"$.code\",\"comparator\":\"equals\",\"value\":\"KAPPA-4821\"}"
+        },
+        {
+          "key":"risk-level",
+          "type":"json_path_match",
+          "target":"final_output",
+          "expected_from":"literal:{\"path\":\"$.risk_level\",\"comparator\":\"equals\",\"value\":\"high\"}"
+        },
+        {
+          "key":"summary-mentions-cache",
+          "type":"json_path_match",
+          "target":"final_output",
+          "expected_from":"literal:{\"path\":\"$.summary\",\"comparator\":\"contains\",\"value\":\"cache invalidation\"}"
         }
       ],
       "metrics":[
@@ -95,10 +115,56 @@ VALUES (
           "key":"completion",
           "type":"boolean",
           "collector":"run_completed_successfully"
+        },
+        {
+          "key":"failures",
+          "type":"numeric",
+          "collector":"run_failure_count"
+        },
+        {
+          "key":"total-latency-ms",
+          "type":"numeric",
+          "collector":"run_total_latency_ms",
+          "unit":"ms"
+        },
+        {
+          "key":"ttft-ms",
+          "type":"numeric",
+          "collector":"run_ttft_ms",
+          "unit":"ms"
+        },
+        {
+          "key":"model-cost-usd",
+          "type":"numeric",
+          "collector":"run_model_cost_usd",
+          "unit":"usd"
+        },
+        {
+          "key":"validator-pass-rate",
+          "type":"numeric",
+          "collector":"validator_pass_rate"
         }
       ],
+      "runtime_limits":{
+        "max_cost_usd":0.2,
+        "max_duration_ms":90000
+      },
+      "pricing":{
+        "models":[
+          {
+            "provider_key":"openai",
+            "provider_model_id":"gpt-4.1-mini",
+            "input_cost_per_million_tokens":0.4,
+            "output_cost_per_million_tokens":1.6
+          }
+        ]
+      },
       "scorecard":{
-        "dimensions":["correctness","reliability"]
+        "dimensions":["correctness","reliability","latency","cost"],
+        "normalization":{
+          "latency":{"target_ms":2500,"max_ms":20000},
+          "cost":{"target_usd":0.002,"max_usd":0.05}
+        }
       }
     }
   }'::jsonb
@@ -143,7 +209,39 @@ VALUES (
   'Local Smoke Challenge',
   'support',
   'easy',
-  '{"instructions":"Reply with a short answer."}'::jsonb
+  '{"instructions":"Return strict JSON with keys code, risk_level, and summary. Use code KAPPA-4821, risk_level high, and mention cache invalidation in the summary."}'::jsonb
+);
+
+INSERT INTO challenge_input_sets (
+  id,
+  challenge_pack_version_id,
+  input_key,
+  name,
+  input_checksum
+)
+VALUES (
+  '${CHALLENGE_INPUT_SET_ID}',
+  '${CHALLENGE_PACK_VERSION_ID}',
+  'local-phase1-inputs',
+  'Local Phase 1 Inputs',
+  'local-phase1-input-checksum'
+);
+
+INSERT INTO challenge_input_items (
+  id,
+  challenge_input_set_id,
+  challenge_pack_version_id,
+  challenge_identity_id,
+  item_key,
+  payload
+)
+VALUES (
+  '${CHALLENGE_INPUT_ITEM_ID}',
+  '${CHALLENGE_INPUT_SET_ID}',
+  '${CHALLENGE_PACK_VERSION_ID}',
+  '${CHALLENGE_IDENTITY_ID}',
+  'prompt.json',
+  '{"content":"Investigate incident KAPPA-4821. The incident points to cache invalidation issues causing stale payload replay. Output strict JSON with code, risk_level, and summary."}'::jsonb
 );
 
 INSERT INTO runtime_profiles (
@@ -325,6 +423,7 @@ Use these values for curl:
   WORKSPACE_ID=${WORKSPACE_ID}
   USER_ID=${USER_ID}
   CHALLENGE_PACK_VERSION_ID=${CHALLENGE_PACK_VERSION_ID}
+  CHALLENGE_INPUT_SET_ID=${CHALLENGE_INPUT_SET_ID}
   AGENT_DEPLOYMENT_ID=${AGENT_DEPLOYMENT_ID}
 
 EOF

--- a/scripts/smoke/scorecard-api-smoke.sh
+++ b/scripts/smoke/scorecard-api-smoke.sh
@@ -20,6 +20,7 @@ export API_BASE_URL="${API_BASE_URL:-http://localhost:8080}"
 export WORKSPACE_ID="${WORKSPACE_ID:-22222222-2222-2222-2222-222222222222}"
 export USER_ID="${USER_ID:-33333333-3333-3333-3333-333333333333}"
 export CHALLENGE_PACK_VERSION_ID="${CHALLENGE_PACK_VERSION_ID:-55555555-5555-5555-5555-555555555555}"
+export CHALLENGE_INPUT_SET_ID="${CHALLENGE_INPUT_SET_ID:-abababab-abab-abab-abab-abababababab}"
 export AGENT_DEPLOYMENT_ID="${AGENT_DEPLOYMENT_ID:-eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee}"
 export SCORECARD_TIMEOUT_SECONDS="${SCORECARD_TIMEOUT_SECONDS:-240}"
 export POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-2}"
@@ -49,6 +50,7 @@ create_response="$(curl -fsS \
   -d '{
     "workspace_id": "'"${WORKSPACE_ID}"'",
     "challenge_pack_version_id": "'"${CHALLENGE_PACK_VERSION_ID}"'",
+    "challenge_input_set_id": "'"${CHALLENGE_INPUT_SET_ID}"'",
     "agent_deployment_ids": ["'"${AGENT_DEPLOYMENT_ID}"'"]
   }')"
 
@@ -93,10 +95,24 @@ while (( SECONDS < deadline )); do
       state="$(jq -r '.state' /tmp/agentclash-scorecard-smoke.json)"
       correctness_score="$(jq -r '.correctness_score // "null"' /tmp/agentclash-scorecard-smoke.json)"
       reliability_score="$(jq -r '.reliability_score // "null"' /tmp/agentclash-scorecard-smoke.json)"
+      latency_score="$(jq -r '.latency_score // "null"' /tmp/agentclash-scorecard-smoke.json)"
+      cost_score="$(jq -r '.cost_score // "null"' /tmp/agentclash-scorecard-smoke.json)"
       echo "==> Scorecard ready"
       echo "    state: ${state}"
       echo "    correctness_score: ${correctness_score}"
       echo "    reliability_score: ${reliability_score}"
+      echo "    latency_score: ${latency_score}"
+      echo "    cost_score: ${cost_score}"
+      if [[ "${latency_score}" == "null" ]]; then
+        echo "latency_score was null; expected a real value" >&2
+        cat /tmp/agentclash-scorecard-smoke.json >&2
+        exit 1
+      fi
+      if [[ "${cost_score}" == "null" ]]; then
+        echo "cost_score was null; expected a real value" >&2
+        cat /tmp/agentclash-scorecard-smoke.json >&2
+        exit 1
+      fi
       exit 0
       ;;
     202)


### PR DESCRIPTION
## Summary

Strengthens the canonical local fixture and smoke validation path for `#122` so latency and cost are proven end to end instead of only existing in scoring-engine code.

This PR:

- upgrades the seeded local challenge pack to include structured validators
- adds real latency, TTFT, cost, and reliability metrics to the local evaluation spec
- adds pricing and normalization config to the local evaluation spec
- seeds a real `challenge_input_set`
- updates local run creation helpers to pass `challenge_input_set_id`
- makes the scorecard smoke script fail unless `latency_score` and `cost_score` are non-null

## Why This PR Exists

The scoring engine already contains real latency and cost collection logic in `backend/internal/scoring/engine.go`.

The actual gap for `#122` was operational:

- the default seeded fixture only exercised correctness and reliability
- the default smoke path did not prove latency or cost through the API

That meant `#122` was hard to trust and hard to close even though much of the core logic already existed.

## Scope

Included:

- local seed fixture upgrade
- local run-create helper upgrade
- scorecard smoke validation upgrade
- real API proof path for latency and cost

Not included:

- no changes to ranking semantics
- no release-gate changes
- no UI work
- no scoring-engine algorithm rewrite

## Files

- `scripts/dev/seed-local-run-fixture.sh`
- `scripts/dev/curl-create-run.sh`
- `scripts/smoke/scorecard-api-smoke.sh`

## Flow

```mermaid
flowchart TD
  A[seed-local-run-fixture.sh] --> B[Seed challenge pack version]
  B --> C[Seed evaluation spec with latency/cost metrics]
  C --> D[Seed challenge_input_set]
  D --> E[curl-create-run.sh / scorecard-api-smoke.sh]
  E --> F[POST /v1/runs with challenge_input_set_id]
  F --> G[Worker executes real run]
  G --> H[Scoring engine computes latency and cost]
  H --> I[GET /v1/scorecards/{runAgentId}]
  I --> J[Smoke script fails if latency_score/cost_score are null]
```

## Review Order

```mermaid
flowchart TD
  A[1. Seed fixture contract] --> B[2. Run creation helper]
  B --> C[3. Smoke assertions]
  C --> D[4. Real validation evidence]
```

### 1. Seed fixture contract

Reviewer should check:

- the seeded challenge pack now includes:
  - `json_schema`
  - `json_path_match`
  - `run_total_latency_ms`
  - `run_ttft_ms`
  - `run_model_cost_usd`
  - pricing config
  - latency and cost normalization
- a `challenge_input_set` is seeded

### 2. Run creation helper

Reviewer should check:

- local run creation now passes `challenge_input_set_id`
- the seeded run uses the same canonical fixture every time

### 3. Smoke assertions

Reviewer should check:

- the smoke script now asserts `latency_score != null`
- the smoke script now asserts `cost_score != null`
- failure output is explicit if either dimension is missing

### 4. Real validation evidence

Reviewer should check:

- the PR includes a real API scorecard response with non-null latency and cost
- the PR includes latency and cost ranking calls

## Testing

Automated:

```bash
cd backend
GOCACHE=/tmp/agentclash-go-build go test ./internal/scoring/...
GOCACHE=/tmp/agentclash-go-build go test ./internal/...
```

Real validation:

```bash
bash scripts/smoke/scorecard-api-smoke.sh
```

Observed real run:

- run id: `eb48d4fe-7138-40b6-b02d-6e435476f224`
- run agent id: `689f04b9-6754-49aa-97f4-de731d2731e6`

Observed scorecard:

- `correctness_score=1`
- `reliability_score=1`
- `latency_score=1`
- `cost_score=1`

Observed live ranking checks:

```bash
curl -sS \
  -H "X-Agentclash-User-Id: 33333333-3333-3333-3333-333333333333" \
  -H "X-Agentclash-Workspace-Memberships: 22222222-2222-2222-2222-222222222222:workspace_admin" \
  "http://localhost:8080/v1/runs/eb48d4fe-7138-40b6-b02d-6e435476f224/ranking?sort_by=latency"

curl -sS \
  -H "X-Agentclash-User-Id: 33333333-3333-3333-3333-333333333333" \
  -H "X-Agentclash-Workspace-Memberships: 22222222-2222-2222-2222-222222222222:workspace_admin" \
  "http://localhost:8080/v1/runs/eb48d4fe-7138-40b6-b02d-6e435476f224/ranking?sort_by=cost"
```

Observed:

- both returned `200`
- both returned available rows with `sort_value=1`

## Known Limitations

### 1. This PR proves the path; it does not redesign latency/cost scoring

The core scoring logic already existed. This PR makes it operationally verifiable and harder to regress.

### 2. The seeded fixture still uses a single deployment

This is enough to validate `#122`, but not enough to prove broad comparative behavior across many agents by itself.

### 3. Hard benchmark comparability remains a separate issue

The known runtime issue where some models spend their only step on exploratory tool calls is still tracked separately in `#136`.

## Confidence

High for `#122` closure-readiness:

- backend automated tests passed
- real local API scorecard returned non-null latency and cost
- real ranking calls by latency and cost succeeded

This PR makes `#122` materially auditable instead of relying on code inspection alone.
