### PR TITLE
Stabilize E2B read_file fallback

### DIFF
--- a/backend/internal/sandbox/e2b/session.go
+++ b/backend/internal/sandbox/e2b/session.go
@@ -36,7 +36,18 @@ func (s *session) ReadFile(ctx context.Context, path string) ([]byte, error) {
 	if err := s.ensureActive(); err != nil {
 		return nil, err
 	}
-	return s.client.api.readFile(ctx, s.client.record, path)
+	content, err := s.client.api.readFile(ctx, s.client.record, path)
+	if err == nil {
+		return content, nil
+	}
+	if !s.allowShell {
+		return nil, err
+	}
+	fallbackContent, fallbackErr := s.readFileByCat(ctx, path)
+	if fallbackErr != nil {
+		return nil, errors.Join(err, fmt.Errorf("fallback read_file failed: %w", fallbackErr))
+	}
+	return fallbackContent, nil
 }
 
 func (s *session) WriteFile(ctx context.Context, path string, content []byte) error {
@@ -127,6 +138,27 @@ func (s *session) listFilesByFind(ctx context.Context, prefix string) ([]sandbox
 		})
 	}
 	return items, nil
+}
+
+func (s *session) readFileByCat(ctx context.Context, path string) ([]byte, error) {
+	trimmedPath := strings.TrimSpace(path)
+	if trimmedPath == "" {
+		return nil, sandbox.ErrFileNotFound
+	}
+
+	result, err := s.Exec(ctx, sandbox.ExecRequest{
+		Command: []string{"sh", "-lc", "cat \"$1\"", "sh", trimmedPath},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if result.ExitCode != 0 {
+		if strings.Contains(result.Stderr, "No such file or directory") {
+			return nil, sandbox.ErrFileNotFound
+		}
+		return nil, fmt.Errorf("cat exited with code %d: %s", result.ExitCode, strings.TrimSpace(result.Stderr))
+	}
+	return []byte(result.Stdout), nil
 }
 
 func (s *session) Exec(ctx context.Context, request sandbox.ExecRequest) (sandbox.ExecResult, error) {

--- a/backend/internal/sandbox/e2b/smoke_test.go
+++ b/backend/internal/sandbox/e2b/smoke_test.go
@@ -65,6 +65,23 @@ func TestE2BSmokeLifecycle(t *testing.T) {
 	if len(files) == 0 {
 		t.Fatalf("ListFiles returned no files, want smoke.txt")
 	}
+	content, err := session.ReadFile(ctx, "/workspace/smoke.txt")
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	if string(content) != "hello" {
+		t.Fatalf("ReadFile content = %q, want hello", content)
+	}
+	if err := session.WriteFile(ctx, "/workspace/smoke.txt", []byte("updated")); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	updatedContent, err := session.ReadFile(ctx, "/workspace/smoke.txt")
+	if err != nil {
+		t.Fatalf("ReadFile after write returned error: %v", err)
+	}
+	if string(updatedContent) != "updated" {
+		t.Fatalf("ReadFile after write = %q, want updated", updatedContent)
+	}
 	result, err := session.Exec(ctx, sandbox.ExecRequest{
 		Command:          []string{"/bin/bash", "-lc", "cat /workspace/smoke.txt"},
 		WorkingDirectory: "/workspace",
@@ -76,14 +93,14 @@ func TestE2BSmokeLifecycle(t *testing.T) {
 	if result.ExitCode != 0 {
 		t.Fatalf("Exec exit code = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
 	}
-	if result.Stdout != "hello" {
-		t.Fatalf("Exec stdout = %q, want hello", result.Stdout)
+	if result.Stdout != "updated" {
+		t.Fatalf("Exec stdout = %q, want updated", result.Stdout)
 	}
 	downloaded, err := session.DownloadFile(ctx, "/workspace/smoke.txt")
 	if err != nil {
 		t.Fatalf("DownloadFile returned error: %v", err)
 	}
-	if string(downloaded) != "hello" {
-		t.Fatalf("DownloadFile content = %q, want hello", downloaded)
+	if string(downloaded) != "updated" {
+		t.Fatalf("DownloadFile content = %q, want updated", downloaded)
 	}
 }

--- a/scripts/smoke/swebench-pack-smoke.sh
+++ b/scripts/smoke/swebench-pack-smoke.sh
@@ -160,7 +160,7 @@ done
 echo "==> Fetching ranking"
 ranking_response="$(curl -fsS "${headers[@]}" "${API_BASE_URL}/v1/runs/${run_id}/ranking?sort_by=composite")"
 echo "==> Composite ranking"
-jq -r '.items[] | "\(.rank // "null")\t\(.label)\t\(.sort_state)\t\(.composite_score // "null")\t\(.delta_from_top // "null")"' <<<"${ranking_response}"
+jq -r '.ranking.items[] | "\(.rank // "null")\t\(.label)\t\(.sort_state)\t\(.composite_score // "null")\t\(.delta_from_top // "null")"' <<<"${ranking_response}"
 
 echo "==> Ranking payload"
 echo "${ranking_response}" | jq .


### PR DESCRIPTION
## Summary
- add a shell-backed fallback for E2B `read_file` when the direct file API becomes unstable mid-run
- extend the real E2B smoke coverage to verify read -> write -> read still works
- fix the SWE-bench smoke script to read the ranking payload from `.ranking.items`

## Why
Issue #139 came from a real coding-pack run where:
- GPT-5.4 and GPT-4.1 were previously failing with late-step `read sandbox file`
- the benchmark pack itself was valid, but the native runtime was not stable enough for a trustworthy Phase 1 benchmark

This PR targets that runtime instability directly.

## What Changed
### E2B read fallback
- `session.ReadFile` now tries the normal E2B file API first
- if that fails and shell is allowed, it falls back to `cat` via the existing exec path
- if the fallback also fails, both errors are preserved

### Smoke coverage
- the E2B smoke test now validates:
  - upload
  - list
  - read
  - overwrite
  - read again
  - exec sees the updated file
  - download sees the updated file

### SWE-bench smoke script
- the local benchmark smoke script now parses `GET /v1/runs/{id}/ranking` correctly from `.ranking.items`

## Real Validation
### Automated
```bash
cd backend && GOCACHE=/tmp/agentclash-go-build go test ./internal/sandbox/...
```

### Real benchmark reruns
#### Before this fix
Run `2e4697cb-1c4f-4f1a-b1c2-4bffbe04bdab`
- completed: GPT-5.4 Nano, GPT-4.1 Mini, GPT-4o Mini
- failed: GPT-5.4, GPT-4.1
- failure class: late-step `read sandbox file`

#### After this fix
Run `971ddec2-b237-410f-a288-3ebbeed2b0c6`
- completed: GPT-5.4, GPT-5.4 Nano, GPT-4.1 Mini, GPT-4o Mini
- failed: GPT-4.1

Important result:
- GPT-5.4 no longer fails on the old late-step `read_file` path
- the remaining GPT-4.1 failure is now a different issue:
  - `assistant response did not contain a tool call or submit action`

That means this PR materially improves the original blocker, but does not fully solve all frontier-model completion behavior for the benchmark.

## Final Ranking From The Preserved Real Run
Run `971ddec2-b237-410f-a288-3ebbeed2b0c6`

1. GPT-5.4 Nano, composite `1.0`
2. GPT-4.1 Mini, composite `1.0`
3. GPT-4o Mini, composite `1.0`
4. GPT-5.4, composite `0.947275`
5. GPT-4.1, unavailable because the run failed

## Reviewer Focus
- verify the fallback is narrow and only activates after the normal E2B read path fails
- verify the fallback respects `allowShell`
- verify the E2B smoke test actually covers the updated failure class
- verify the benchmark smoke script now renders ranking output correctly

## Remaining Risk
- GPT-4.1 still fails in the preserved real run, but for a new reason unrelated to the original `read_file` runtime bug
- if we want full 5/5 Phase 1 benchmark stability, that remaining execution-loop / model-behavior issue still needs follow-up
