### PR TITLE
feat(provider): multi-provider adapter architecture

### DIFF
--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -47,7 +47,11 @@ func main() {
 	repo := repository.New(db)
 	hostedRunClient := workerapp.NewHostedRunClient(&http.Client{}, cfg.HostedCallbackBaseURL, cfg.HostedCallbackSecret)
 	providerRouter := provider.NewRouter(map[string]provider.Client{
-		"openai": provider.NewOpenAICompatibleClient(&http.Client{}, "", provider.EnvCredentialResolver{}),
+		"openai":     provider.NewOpenAICompatibleClient(&http.Client{}, "", provider.EnvCredentialResolver{}),
+		"anthropic":  provider.NewAnthropicClient(&http.Client{}, "", "", provider.EnvCredentialResolver{}),
+		"gemini":     provider.NewGeminiClient(&http.Client{}, "", provider.EnvCredentialResolver{}),
+		"openrouter": provider.NewOpenAICompatibleClient(&http.Client{}, "https://openrouter.ai/api/v1", provider.EnvCredentialResolver{}),
+		"mistral":    provider.NewOpenAICompatibleClient(&http.Client{}, "https://api.mistral.ai/v1", provider.EnvCredentialResolver{}),
 	})
 	sandboxProvider := sandbox.Provider(sandbox.UnconfiguredProvider{})
 	if cfg.Sandbox.Provider == "e2b" {

--- a/backend/internal/provider/anthropic.go
+++ b/backend/internal/provider/anthropic.go
@@ -480,6 +480,9 @@ func processAnthropicStreamEvent(providerKey string, eventType string, raw []byt
 	case "error":
 		var envelope anthropicErrorEnvelope
 		if err := json.Unmarshal(raw, &envelope); err == nil && envelope.Error.Message != "" {
+			if envelope.Error.Type == "overloaded_error" {
+				return NewFailure(providerKey, FailureCodeRateLimit, envelope.Error.Message, true, nil)
+			}
 			return NewFailure(providerKey, FailureCodeUnknown, envelope.Error.Message, false, nil)
 		}
 		return NewFailure(providerKey, FailureCodeUnknown, "provider stream error", false, nil)

--- a/backend/internal/provider/anthropic.go
+++ b/backend/internal/provider/anthropic.go
@@ -1,0 +1,539 @@
+package provider
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	defaultAnthropicBaseURL    = "https://api.anthropic.com"
+	defaultAnthropicAPIVersion = "2023-06-01"
+	defaultAnthropicMaxTokens  = 4096
+)
+
+type AnthropicClient struct {
+	httpClient         *http.Client
+	baseURL            string
+	apiVersion         string
+	credentialResolver CredentialResolver
+}
+
+func NewAnthropicClient(httpClient *http.Client, baseURL string, apiVersion string, credentialResolver CredentialResolver) AnthropicClient {
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = defaultAnthropicBaseURL
+	}
+	if strings.TrimSpace(apiVersion) == "" {
+		apiVersion = defaultAnthropicAPIVersion
+	}
+	return AnthropicClient{
+		httpClient:         httpClient,
+		baseURL:            strings.TrimRight(baseURL, "/"),
+		apiVersion:         apiVersion,
+		credentialResolver: credentialResolver,
+	}
+}
+
+func (c AnthropicClient) InvokeModel(ctx context.Context, request Request) (Response, error) {
+	return c.StreamModel(ctx, request, nil)
+}
+
+func (c AnthropicClient) StreamModel(ctx context.Context, request Request, onDelta func(StreamDelta) error) (Response, error) {
+	apiKey, err := c.credentialResolver.Resolve(ctx, request.CredentialReference)
+	if err != nil {
+		return Response{}, normalizeCredentialError(request.ProviderKey, err)
+	}
+
+	body, err := buildAnthropicRequestBody(request)
+	if err != nil {
+		return Response{}, err
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return Response{}, NewFailure(request.ProviderKey, FailureCodeInvalidRequest, "marshal provider request", false, err)
+	}
+
+	callCtx := ctx
+	if request.StepTimeout > 0 {
+		var cancel context.CancelFunc
+		callCtx, cancel = context.WithTimeout(ctx, request.StepTimeout)
+		defer cancel()
+	}
+
+	req, err := http.NewRequestWithContext(callCtx, http.MethodPost, c.baseURL+"/v1/messages", bytes.NewReader(payload))
+	if err != nil {
+		return Response{}, NewFailure(request.ProviderKey, FailureCodeInvalidRequest, "build provider request", false, err)
+	}
+	req.Header.Set("x-api-key", apiKey)
+	req.Header.Set("anthropic-version", c.apiVersion)
+	req.Header.Set("Content-Type", "application/json")
+
+	startedAt := time.Now().UTC()
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return Response{}, classifyTransportError(request.ProviderKey, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		raw, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return Response{}, NewFailure(request.ProviderKey, FailureCodeUnavailable, "read provider response", true, err)
+		}
+		return Response{}, normalizeAnthropicErrorResponse(request.ProviderKey, resp.StatusCode, raw)
+	}
+
+	accumulator := NewStreamAccumulator(request.ProviderKey, startedAt)
+	if err := consumeAnthropicStream(resp.Body, request.ProviderKey, accumulator, onDelta); err != nil {
+		return Response{}, err
+	}
+
+	return accumulator.Finalize(time.Now().UTC())
+}
+
+func buildAnthropicRequestBody(request Request) (anthropicRequest, error) {
+	var system string
+	messages := make([]anthropicMessage, 0, len(request.Messages))
+
+	for _, msg := range request.Messages {
+		if msg.Role == "system" {
+			system = msg.Content
+			continue
+		}
+
+		converted, err := normalizeAnthropicRequestMessage(request.ProviderKey, msg)
+		if err != nil {
+			return anthropicRequest{}, err
+		}
+		messages = append(messages, converted)
+	}
+
+	tools := make([]anthropicTool, 0, len(request.Tools))
+	for _, tool := range request.Tools {
+		normalized, err := normalizeAnthropicRequestTool(request.ProviderKey, tool)
+		if err != nil {
+			return anthropicRequest{}, err
+		}
+		tools = append(tools, normalized)
+	}
+
+	return anthropicRequest{
+		Model:     request.Model,
+		MaxTokens: defaultAnthropicMaxTokens,
+		System:    system,
+		Messages:  messages,
+		Tools:     tools,
+		Stream:    true,
+	}, nil
+}
+
+func normalizeAnthropicRequestMessage(providerKey string, msg Message) (anthropicMessage, error) {
+	switch msg.Role {
+	case "user":
+		return anthropicMessage{
+			Role:    "user",
+			Content: anthropicContentFromString(msg.Content),
+		}, nil
+
+	case "assistant":
+		if len(msg.ToolCalls) > 0 {
+			blocks := make([]anthropicContentBlock, 0, len(msg.ToolCalls)+1)
+			if msg.Content != "" {
+				blocks = append(blocks, anthropicContentBlock{
+					Type: "text",
+					Text: msg.Content,
+				})
+			}
+			for _, tc := range msg.ToolCalls {
+				input := tc.Arguments
+				if len(input) == 0 {
+					input = json.RawMessage(`{}`)
+				}
+				if !json.Valid(input) {
+					return anthropicMessage{}, NewFailure(providerKey, FailureCodeInvalidRequest, fmt.Sprintf("tool call %q arguments must be valid JSON", tc.Name), false, nil)
+				}
+				blocks = append(blocks, anthropicContentBlock{
+					Type:  "tool_use",
+					ID:    tc.ID,
+					Name:  tc.Name,
+					Input: append(json.RawMessage(nil), input...),
+				})
+			}
+			return anthropicMessage{
+				Role:          "assistant",
+				ContentBlocks: blocks,
+			}, nil
+		}
+		return anthropicMessage{
+			Role:    "assistant",
+			Content: anthropicContentFromString(msg.Content),
+		}, nil
+
+	case "tool":
+		return anthropicMessage{
+			Role: "user",
+			ContentBlocks: []anthropicContentBlock{
+				{
+					Type:      "tool_result",
+					ToolUseID: msg.ToolCallID,
+					Content:   msg.Content,
+					IsError:   msg.IsError,
+				},
+			},
+		}, nil
+
+	default:
+		return anthropicMessage{}, NewFailure(providerKey, FailureCodeInvalidRequest, fmt.Sprintf("unsupported message role %q", msg.Role), false, nil)
+	}
+}
+
+func anthropicContentFromString(s string) json.RawMessage {
+	b, _ := json.Marshal(s)
+	return b
+}
+
+func normalizeAnthropicRequestTool(providerKey string, tool ToolDefinition) (anthropicTool, error) {
+	schema := tool.Parameters
+	if len(schema) == 0 {
+		schema = json.RawMessage(`{"type":"object","properties":{},"additionalProperties":false}`)
+	}
+	if !json.Valid(schema) {
+		return anthropicTool{}, NewFailure(providerKey, FailureCodeInvalidRequest, fmt.Sprintf("tool %q parameters must be valid JSON", tool.Name), false, nil)
+	}
+
+	return anthropicTool{
+		Name:        tool.Name,
+		Description: tool.Description,
+		InputSchema: append(json.RawMessage(nil), schema...),
+	}, nil
+}
+
+// --- Anthropic request/response types ---
+
+type anthropicRequest struct {
+	Model     string             `json:"model"`
+	MaxTokens int                `json:"max_tokens"`
+	System    string             `json:"system,omitempty"`
+	Messages  []anthropicMessage `json:"messages"`
+	Tools     []anthropicTool    `json:"tools,omitempty"`
+	Stream    bool               `json:"stream"`
+}
+
+type anthropicMessage struct {
+	Role          string                 `json:"role"`
+	Content       json.RawMessage        `json:"content,omitempty"`
+	ContentBlocks []anthropicContentBlock `json:"-"`
+}
+
+func (m anthropicMessage) MarshalJSON() ([]byte, error) {
+	if len(m.ContentBlocks) > 0 {
+		type alias struct {
+			Role    string                 `json:"role"`
+			Content []anthropicContentBlock `json:"content"`
+		}
+		return json.Marshal(alias{Role: m.Role, Content: m.ContentBlocks})
+	}
+	type alias struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	}
+	return json.Marshal(alias{Role: m.Role, Content: m.Content})
+}
+
+type anthropicContentBlock struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Input     json.RawMessage `json:"input,omitempty"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Content   string          `json:"content,omitempty"`
+	IsError   bool            `json:"is_error,omitempty"`
+}
+
+type anthropicTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+// --- Anthropic SSE event types ---
+
+type anthropicMessageStart struct {
+	Message struct {
+		Model string `json:"model"`
+		Usage struct {
+			InputTokens  int64 `json:"input_tokens"`
+			OutputTokens int64 `json:"output_tokens"`
+		} `json:"usage"`
+	} `json:"message"`
+}
+
+type anthropicContentBlockStart struct {
+	Index        int `json:"index"`
+	ContentBlock struct {
+		Type string `json:"type"`
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"content_block"`
+}
+
+type anthropicContentBlockDelta struct {
+	Index int `json:"index"`
+	Delta struct {
+		Type        string `json:"type"`
+		Text        string `json:"text"`
+		PartialJSON string `json:"partial_json"`
+	} `json:"delta"`
+}
+
+type anthropicMessageDelta struct {
+	Delta struct {
+		StopReason string `json:"stop_reason"`
+	} `json:"delta"`
+	Usage struct {
+		OutputTokens int64 `json:"output_tokens"`
+	} `json:"usage"`
+}
+
+type anthropicErrorEnvelope struct {
+	Type  string `json:"type"`
+	Error struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// --- Anthropic stream consumption ---
+
+func consumeAnthropicStream(body io.Reader, providerKey string, accumulator *StreamAccumulator, onDelta func(StreamDelta) error) error {
+	reader := bufio.NewReader(body)
+	var currentEvent string
+	dataLines := make([]string, 0, 1)
+	eventsProcessed := false
+
+	// Track tool call indices for mapping content blocks to ToolCallFragment.Index.
+	toolCallIndex := 0
+	lastBlockWasToolUse := false
+	var inputTokens int64
+
+	flush := func() error {
+		if len(dataLines) == 0 {
+			return nil
+		}
+		data := strings.Join(dataLines, "\n")
+		dataLines = dataLines[:0]
+		eventType := currentEvent
+		currentEvent = ""
+
+		if strings.TrimSpace(data) == "" {
+			return nil
+		}
+
+		eventsProcessed = true
+		return processAnthropicStreamEvent(providerKey, eventType, []byte(data), accumulator, onDelta, &toolCallIndex, &lastBlockWasToolUse, &inputTokens)
+	}
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			return classifyTransportError(providerKey, err)
+		}
+
+		trimmed := strings.TrimRight(line, "\r\n")
+		switch {
+		case trimmed == "":
+			if flushErr := flush(); flushErr != nil {
+				return flushErr
+			}
+		case strings.HasPrefix(trimmed, ":"):
+			// SSE comment / keepalive
+		default:
+			field, value, found := strings.Cut(trimmed, ":")
+			if !found {
+				continue
+			}
+			value = strings.TrimPrefix(value, " ")
+			switch field {
+			case "event":
+				currentEvent = value
+			case "data":
+				dataLines = append(dataLines, value)
+			}
+		}
+
+		if errors.Is(err, io.EOF) {
+			if flushErr := flush(); flushErr != nil {
+				return flushErr
+			}
+			if !eventsProcessed {
+				return NewFailure(providerKey, FailureCodeMalformedResponse, "provider returned empty or non-streaming response", false, nil)
+			}
+			return nil
+		}
+	}
+}
+
+func processAnthropicStreamEvent(providerKey string, eventType string, raw []byte, accumulator *StreamAccumulator, onDelta func(StreamDelta) error, toolCallIndex *int, lastBlockWasToolUse *bool, inputTokens *int64) error {
+	timestamp := time.Now().UTC()
+
+	switch eventType {
+	case "message_start":
+		var msg anthropicMessageStart
+		if err := json.Unmarshal(raw, &msg); err != nil {
+			return NewFailure(providerKey, FailureCodeMalformedResponse, "decode message_start", false, err)
+		}
+		*inputTokens = msg.Message.Usage.InputTokens
+		return emitAnthropicDelta(accumulator, onDelta, StreamDelta{
+			Kind:      StreamDeltaKindTerminal,
+			Timestamp: timestamp,
+			Terminal: StreamTerminal{
+				ProviderModelID: msg.Message.Model,
+				RawResponse:     raw,
+			},
+		})
+
+	case "content_block_start":
+		var block anthropicContentBlockStart
+		if err := json.Unmarshal(raw, &block); err != nil {
+			return NewFailure(providerKey, FailureCodeMalformedResponse, "decode content_block_start", false, err)
+		}
+		*lastBlockWasToolUse = block.ContentBlock.Type == "tool_use"
+		if *lastBlockWasToolUse {
+			return emitAnthropicDelta(accumulator, onDelta, StreamDelta{
+				Kind:      StreamDeltaKindToolCall,
+				Timestamp: timestamp,
+				ToolCall: ToolCallFragment{
+					Index:        *toolCallIndex,
+					IDFragment:   block.ContentBlock.ID,
+					NameFragment: block.ContentBlock.Name,
+				},
+			})
+		}
+		return nil
+
+	case "content_block_delta":
+		var delta anthropicContentBlockDelta
+		if err := json.Unmarshal(raw, &delta); err != nil {
+			return NewFailure(providerKey, FailureCodeMalformedResponse, "decode content_block_delta", false, err)
+		}
+		switch delta.Delta.Type {
+		case "text_delta":
+			return emitAnthropicDelta(accumulator, onDelta, StreamDelta{
+				Kind:      StreamDeltaKindText,
+				Timestamp: timestamp,
+				Text:      delta.Delta.Text,
+			})
+		case "input_json_delta":
+			return emitAnthropicDelta(accumulator, onDelta, StreamDelta{
+				Kind:      StreamDeltaKindToolCall,
+				Timestamp: timestamp,
+				ToolCall: ToolCallFragment{
+					Index:             *toolCallIndex,
+					ArgumentsFragment: delta.Delta.PartialJSON,
+				},
+			})
+		}
+		return nil
+
+	case "content_block_stop":
+		if *lastBlockWasToolUse {
+			*toolCallIndex++
+			*lastBlockWasToolUse = false
+		}
+		return nil
+
+	case "message_delta":
+		var msgDelta anthropicMessageDelta
+		if err := json.Unmarshal(raw, &msgDelta); err != nil {
+			return NewFailure(providerKey, FailureCodeMalformedResponse, "decode message_delta", false, err)
+		}
+		outputTokens := msgDelta.Usage.OutputTokens
+		return emitAnthropicDelta(accumulator, onDelta, StreamDelta{
+			Kind:      StreamDeltaKindTerminal,
+			Timestamp: timestamp,
+			Terminal: StreamTerminal{
+				FinishReason: NormalizeAnthropicStopReason(msgDelta.Delta.StopReason),
+				Usage: &Usage{
+					InputTokens:  *inputTokens,
+					OutputTokens: outputTokens,
+					TotalTokens:  *inputTokens + outputTokens,
+				},
+				RawResponse: raw,
+			},
+		})
+
+	case "message_stop":
+		return nil
+
+	case "error":
+		var envelope anthropicErrorEnvelope
+		if err := json.Unmarshal(raw, &envelope); err == nil && envelope.Error.Message != "" {
+			return NewFailure(providerKey, FailureCodeUnknown, envelope.Error.Message, false, nil)
+		}
+		return NewFailure(providerKey, FailureCodeUnknown, "provider stream error", false, nil)
+
+	case "ping":
+		return nil
+
+	default:
+		// Ignore unknown event types for forward compatibility.
+		return nil
+	}
+}
+
+func emitAnthropicDelta(accumulator *StreamAccumulator, onDelta func(StreamDelta) error, delta StreamDelta) error {
+	if err := accumulator.Consume(delta); err != nil {
+		return err
+	}
+	if onDelta != nil {
+		if err := onDelta(cloneStreamDelta(delta)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func normalizeAnthropicErrorResponse(providerKey string, statusCode int, raw []byte) error {
+	var envelope anthropicErrorEnvelope
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return NewFailure(
+			providerKey,
+			FailureCodeMalformedResponse,
+			fmt.Sprintf("provider returned HTTP %d with invalid error payload", statusCode),
+			false,
+			err,
+		)
+	}
+
+	message := envelope.Error.Message
+	if strings.TrimSpace(message) == "" {
+		message = fmt.Sprintf("provider returned HTTP %d", statusCode)
+	}
+
+	switch statusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return NewFailure(providerKey, FailureCodeAuth, message, false, nil)
+	case http.StatusTooManyRequests:
+		return NewFailure(providerKey, FailureCodeRateLimit, message, true, nil)
+	case 529: // Anthropic overloaded
+		return NewFailure(providerKey, FailureCodeRateLimit, message, true, nil)
+	case http.StatusBadRequest, http.StatusUnprocessableEntity:
+		return NewFailure(providerKey, FailureCodeInvalidRequest, message, false, nil)
+	case http.StatusGatewayTimeout, http.StatusBadGateway, http.StatusServiceUnavailable:
+		return NewFailure(providerKey, FailureCodeUnavailable, message, true, nil)
+	default:
+		return NewFailure(providerKey, FailureCodeUnknown, message, statusCode >= 500, nil)
+	}
+}

--- a/backend/internal/provider/anthropic_smoke_test.go
+++ b/backend/internal/provider/anthropic_smoke_test.go
@@ -1,0 +1,63 @@
+//go:build anthropicsmoke
+
+package provider
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestAnthropicClientSmoke(t *testing.T) {
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		t.Skip("ANTHROPIC_API_KEY is not set")
+	}
+
+	model := os.Getenv("ANTHROPIC_MODEL")
+	if model == "" {
+		model = "claude-sonnet-4-20250514"
+	}
+
+	t.Setenv("ANTHROPIC_API_KEY", apiKey)
+
+	client := NewAnthropicClient(nil, "", "", EnvCredentialResolver{})
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	response, err := client.InvokeModel(ctx, Request{
+		ProviderKey:         "anthropic",
+		CredentialReference: "env://ANTHROPIC_API_KEY",
+		Model:               model,
+		StepTimeout:         40 * time.Second,
+		Messages: []Message{
+			{
+				Role:    "user",
+				Content: "Reply with exactly: smoke-ok",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("InvokeModel returned error: %v", err)
+	}
+
+	if !response.Streamed {
+		t.Fatalf("expected streamed response")
+	}
+	if response.ProviderModelID == "" {
+		t.Fatalf("expected provider model id")
+	}
+	if response.FinishReason == "" {
+		t.Fatalf("expected finish reason")
+	}
+	if response.Timing.TTFT <= 0 {
+		t.Fatalf("expected TTFT > 0, got %s", response.Timing.TTFT)
+	}
+	if response.Timing.TotalLatency <= 0 {
+		t.Fatalf("expected total latency > 0, got %s", response.Timing.TotalLatency)
+	}
+	if response.OutputText == "" && len(response.ToolCalls) == 0 {
+		t.Fatalf("expected output text or tool calls in response")
+	}
+}

--- a/backend/internal/provider/anthropic_test.go
+++ b/backend/internal/provider/anthropic_test.go
@@ -223,6 +223,44 @@ func TestAnthropicClientNormalizesOverloadedFailure(t *testing.T) {
 	}
 }
 
+func TestAnthropicClientNormalizesMidStreamOverloadedAsRetryable(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return sseResponse(http.StatusOK, strings.Join([]string{
+				`event: message_start`,
+				`data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","usage":{"input_tokens":5,"output_tokens":0}}}`,
+				``,
+				`event: error`,
+				`data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`,
+				``,
+			}, "\n")), nil
+		}),
+	}
+
+	client := NewAnthropicClient(httpClient, "https://example.com", "", staticCredentialResolver{value: "test-key"})
+
+	_, err := client.InvokeModel(context.Background(), Request{
+		ProviderKey:         "anthropic",
+		CredentialReference: "env://ANTHROPIC_API_KEY",
+		Model:               "claude-sonnet-4-20250514",
+		Messages:            []Message{{Role: "user", Content: "hello"}},
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	failure, ok := AsFailure(err)
+	if !ok {
+		t.Fatalf("expected provider failure, got %T", err)
+	}
+	if failure.Code != FailureCodeRateLimit {
+		t.Fatalf("failure code = %s, want %s", failure.Code, FailureCodeRateLimit)
+	}
+	if !failure.Retryable {
+		t.Fatalf("mid-stream overloaded error should be retryable")
+	}
+}
+
 func TestAnthropicClientNormalizesMidStreamError(t *testing.T) {
 	httpClient := &http.Client{
 		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {

--- a/backend/internal/provider/anthropic_test.go
+++ b/backend/internal/provider/anthropic_test.go
@@ -1,0 +1,380 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAnthropicClientInvokeModelStreamsTextAndCapturesTiming(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			assertAnthropicStreamingRequest(t, r)
+			return sseResponse(http.StatusOK, strings.Join([]string{
+				`event: message_start`,
+				`data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","usage":{"input_tokens":12,"output_tokens":0}}}`,
+				``,
+				`event: content_block_start`,
+				`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+				``,
+				`event: content_block_delta`,
+				`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"native "}}`,
+				``,
+				`event: content_block_delta`,
+				`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"step output"}}`,
+				``,
+				`event: content_block_stop`,
+				`data: {"type":"content_block_stop","index":0}`,
+				``,
+				`event: message_delta`,
+				`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":7}}`,
+				``,
+				`event: message_stop`,
+				`data: {"type":"message_stop"}`,
+				``,
+			}, "\n")), nil
+		}),
+	}
+
+	client := NewAnthropicClient(httpClient, "https://example.com", "", staticCredentialResolver{value: "test-key"})
+
+	response, err := client.InvokeModel(context.Background(), Request{
+		ProviderKey:         "anthropic",
+		CredentialReference: "env://ANTHROPIC_API_KEY",
+		Model:               "claude-sonnet-4-20250514",
+		StepTimeout:         time.Second,
+		Messages: []Message{
+			{Role: "system", Content: "You are helpful."},
+			{Role: "user", Content: "hello"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("InvokeModel returned error: %v", err)
+	}
+	if !response.Streamed {
+		t.Fatalf("expected streamed response")
+	}
+	if response.OutputText != "native step output" {
+		t.Fatalf("output text = %q, want native step output", response.OutputText)
+	}
+	if response.Usage.InputTokens != 12 {
+		t.Fatalf("input tokens = %d, want 12", response.Usage.InputTokens)
+	}
+	if response.Usage.OutputTokens != 7 {
+		t.Fatalf("output tokens = %d, want 7", response.Usage.OutputTokens)
+	}
+	if response.Usage.TotalTokens != 19 {
+		t.Fatalf("total tokens = %d, want 19", response.Usage.TotalTokens)
+	}
+	if response.FinishReason != "stop" {
+		t.Fatalf("finish reason = %q, want stop", response.FinishReason)
+	}
+	if response.ProviderModelID != "claude-sonnet-4-20250514" {
+		t.Fatalf("provider model id = %q, want claude-sonnet-4-20250514", response.ProviderModelID)
+	}
+	if response.Timing.StartedAt.IsZero() || response.Timing.FirstTokenAt.IsZero() || response.Timing.CompletedAt.IsZero() {
+		t.Fatalf("expected timing metadata to be populated: %#v", response.Timing)
+	}
+	if response.Timing.TTFT <= 0 {
+		t.Fatalf("expected TTFT > 0, got %s", response.Timing.TTFT)
+	}
+}
+
+func TestAnthropicClientStreamModelEmitsToolCallDeltas(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			assertAnthropicStreamingRequest(t, r)
+			return sseResponse(http.StatusOK, strings.Join([]string{
+				`event: message_start`,
+				`data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","usage":{"input_tokens":21,"output_tokens":0}}}`,
+				``,
+				`event: content_block_start`,
+				`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01","name":"read_file"}}`,
+				``,
+				`event: content_block_delta`,
+				`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\""}}`,
+				``,
+				`event: content_block_delta`,
+				`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"/workspace/app.go\"}"}}`,
+				``,
+				`event: content_block_stop`,
+				`data: {"type":"content_block_stop","index":0}`,
+				``,
+				`event: message_delta`,
+				`data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":9}}`,
+				``,
+				`event: message_stop`,
+				`data: {"type":"message_stop"}`,
+				``,
+			}, "\n")), nil
+		}),
+	}
+
+	client := NewAnthropicClient(httpClient, "https://example.com", "", staticCredentialResolver{value: "test-key"})
+
+	var deltas []StreamDelta
+	response, err := client.StreamModel(context.Background(), Request{
+		ProviderKey:         "anthropic",
+		CredentialReference: "env://ANTHROPIC_API_KEY",
+		Model:               "claude-sonnet-4-20250514",
+		Messages: []Message{
+			{Role: "user", Content: "inspect workspace"},
+		},
+		Tools: []ToolDefinition{
+			{Name: "read_file", Parameters: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}`)},
+		},
+	}, func(delta StreamDelta) error {
+		deltas = append(deltas, delta)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("StreamModel returned error: %v", err)
+	}
+	if response.FinishReason != "tool_calls" {
+		t.Fatalf("finish reason = %q, want tool_calls", response.FinishReason)
+	}
+	if len(response.ToolCalls) != 1 {
+		t.Fatalf("tool calls = %d, want 1", len(response.ToolCalls))
+	}
+	if response.ToolCalls[0].Name != "read_file" {
+		t.Fatalf("tool call name = %q, want read_file", response.ToolCalls[0].Name)
+	}
+	if response.ToolCalls[0].ID != "toolu_01" {
+		t.Fatalf("tool call id = %q, want toolu_01", response.ToolCalls[0].ID)
+	}
+	var args struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(response.ToolCalls[0].Arguments, &args); err != nil {
+		t.Fatalf("unmarshal tool call arguments: %v", err)
+	}
+	if args.Path != "/workspace/app.go" {
+		t.Fatalf("tool call path = %q, want /workspace/app.go", args.Path)
+	}
+}
+
+func TestAnthropicClientNormalizesRateLimitFailure(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return jsonResponse(http.StatusTooManyRequests, `{"type":"error","error":{"type":"rate_limit_error","message":"too many requests"}}`), nil
+		}),
+	}
+
+	client := NewAnthropicClient(httpClient, "https://example.com", "", staticCredentialResolver{value: "test-key"})
+
+	_, err := client.InvokeModel(context.Background(), Request{
+		ProviderKey:         "anthropic",
+		CredentialReference: "env://ANTHROPIC_API_KEY",
+		Model:               "claude-sonnet-4-20250514",
+		Messages:            []Message{{Role: "user", Content: "hello"}},
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	failure, ok := AsFailure(err)
+	if !ok {
+		t.Fatalf("expected provider failure, got %T", err)
+	}
+	if failure.Code != FailureCodeRateLimit {
+		t.Fatalf("failure code = %s, want %s", failure.Code, FailureCodeRateLimit)
+	}
+	if !failure.Retryable {
+		t.Fatalf("rate limit failure should be retryable")
+	}
+}
+
+func TestAnthropicClientNormalizesOverloadedFailure(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 529,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"overloaded_error","message":"overloaded"}}`)),
+			}, nil
+		}),
+	}
+
+	client := NewAnthropicClient(httpClient, "https://example.com", "", staticCredentialResolver{value: "test-key"})
+
+	_, err := client.InvokeModel(context.Background(), Request{
+		ProviderKey:         "anthropic",
+		CredentialReference: "env://ANTHROPIC_API_KEY",
+		Model:               "claude-sonnet-4-20250514",
+		Messages:            []Message{{Role: "user", Content: "hello"}},
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	failure, ok := AsFailure(err)
+	if !ok {
+		t.Fatalf("expected provider failure, got %T", err)
+	}
+	if failure.Code != FailureCodeRateLimit {
+		t.Fatalf("failure code = %s, want %s", failure.Code, FailureCodeRateLimit)
+	}
+	if !failure.Retryable {
+		t.Fatalf("overloaded failure should be retryable")
+	}
+}
+
+func TestAnthropicClientNormalizesMidStreamError(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return sseResponse(http.StatusOK, strings.Join([]string{
+				`event: error`,
+				`data: {"type":"error","error":{"type":"server_error","message":"stream exploded"}}`,
+				``,
+			}, "\n")), nil
+		}),
+	}
+
+	client := NewAnthropicClient(httpClient, "https://example.com", "", staticCredentialResolver{value: "test-key"})
+
+	_, err := client.InvokeModel(context.Background(), Request{
+		ProviderKey:         "anthropic",
+		CredentialReference: "env://ANTHROPIC_API_KEY",
+		Model:               "claude-sonnet-4-20250514",
+		Messages:            []Message{{Role: "user", Content: "hello"}},
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	failure, ok := AsFailure(err)
+	if !ok {
+		t.Fatalf("expected provider failure, got %T", err)
+	}
+	if failure.Code != FailureCodeUnknown {
+		t.Fatalf("failure code = %s, want %s", failure.Code, FailureCodeUnknown)
+	}
+}
+
+func TestAnthropicClientClassifiesStreamReadTimeout(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body:       io.NopCloser(timeoutReader{}),
+			}, nil
+		}),
+	}
+
+	client := NewAnthropicClient(httpClient, "https://example.com", "", staticCredentialResolver{value: "test-key"})
+
+	_, err := client.InvokeModel(context.Background(), Request{
+		ProviderKey:         "anthropic",
+		CredentialReference: "env://ANTHROPIC_API_KEY",
+		Model:               "claude-sonnet-4-20250514",
+		Messages:            []Message{{Role: "user", Content: "hello"}},
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	failure, ok := AsFailure(err)
+	if !ok {
+		t.Fatalf("expected provider failure, got %T", err)
+	}
+	if failure.Code != FailureCodeTimeout {
+		t.Fatalf("failure code = %s, want %s", failure.Code, FailureCodeTimeout)
+	}
+}
+
+func TestAnthropicClientMultiToolCalls(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return sseResponse(http.StatusOK, strings.Join([]string{
+				`event: message_start`,
+				`data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","usage":{"input_tokens":30,"output_tokens":0}}}`,
+				``,
+				`event: content_block_start`,
+				`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01","name":"read_file"}}`,
+				``,
+				`event: content_block_delta`,
+				`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\"/a.go\"}"}}`,
+				``,
+				`event: content_block_stop`,
+				`data: {"type":"content_block_stop","index":0}`,
+				``,
+				`event: content_block_start`,
+				`data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_02","name":"write_file"}}`,
+				``,
+				`event: content_block_delta`,
+				`data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\"/b.go\"}"}}`,
+				``,
+				`event: content_block_stop`,
+				`data: {"type":"content_block_stop","index":1}`,
+				``,
+				`event: message_delta`,
+				`data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":15}}`,
+				``,
+				`event: message_stop`,
+				`data: {"type":"message_stop"}`,
+				``,
+			}, "\n")), nil
+		}),
+	}
+
+	client := NewAnthropicClient(httpClient, "https://example.com", "", staticCredentialResolver{value: "test-key"})
+
+	response, err := client.InvokeModel(context.Background(), Request{
+		ProviderKey:         "anthropic",
+		CredentialReference: "env://ANTHROPIC_API_KEY",
+		Model:               "claude-sonnet-4-20250514",
+		Messages:            []Message{{Role: "user", Content: "read and write files"}},
+		Tools: []ToolDefinition{
+			{Name: "read_file", Parameters: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`)},
+			{Name: "write_file", Parameters: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("InvokeModel returned error: %v", err)
+	}
+	if len(response.ToolCalls) != 2 {
+		t.Fatalf("tool calls = %d, want 2", len(response.ToolCalls))
+	}
+	if response.ToolCalls[0].Name != "read_file" || response.ToolCalls[0].ID != "toolu_01" {
+		t.Fatalf("first tool call = %+v, want read_file/toolu_01", response.ToolCalls[0])
+	}
+	if response.ToolCalls[1].Name != "write_file" || response.ToolCalls[1].ID != "toolu_02" {
+		t.Fatalf("second tool call = %+v, want write_file/toolu_02", response.ToolCalls[1])
+	}
+}
+
+func assertAnthropicStreamingRequest(t *testing.T, r *http.Request) {
+	t.Helper()
+
+	if got := r.Header.Get("x-api-key"); got != "test-key" {
+		t.Fatalf("x-api-key header = %q, want test-key", got)
+	}
+	if got := r.Header.Get("anthropic-version"); got == "" {
+		t.Fatalf("anthropic-version header is missing")
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read request body: %v", err)
+	}
+
+	var payload struct {
+		Model     string `json:"model"`
+		MaxTokens int    `json:"max_tokens"`
+		Stream    bool   `json:"stream"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	if !payload.Stream {
+		t.Fatalf("expected stream=true request")
+	}
+	if payload.MaxTokens == 0 {
+		t.Fatalf("expected max_tokens to be set")
+	}
+}

--- a/backend/internal/provider/conformance_test.go
+++ b/backend/internal/provider/conformance_test.go
@@ -1,0 +1,414 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type conformanceAdapter struct {
+	name   string
+	client func(transport http.RoundTripper) Client
+}
+
+func conformanceAdapters() []conformanceAdapter {
+	return []conformanceAdapter{
+		{
+			name: "openai",
+			client: func(transport http.RoundTripper) Client {
+				return NewOpenAICompatibleClient(&http.Client{Transport: transport}, "https://example.com/v1", staticCredentialResolver{value: "test-key"})
+			},
+		},
+		{
+			name: "anthropic",
+			client: func(transport http.RoundTripper) Client {
+				return NewAnthropicClient(&http.Client{Transport: transport}, "https://example.com", "", staticCredentialResolver{value: "test-key"})
+			},
+		},
+		{
+			name: "gemini",
+			client: func(transport http.RoundTripper) Client {
+				return NewGeminiClient(&http.Client{Transport: transport}, "https://example.com", staticCredentialResolver{value: "test-key"})
+			},
+		},
+	}
+}
+
+// --- Conformance: simple text response ---
+
+func TestConformanceSimpleTextResponse(t *testing.T) {
+	responses := map[string]string{
+		"openai": strings.Join([]string{
+			`data: {"model":"gpt-4.1","choices":[{"delta":{"role":"assistant","content":"Hello world"},"finish_reason":"stop"}]}`,
+			``,
+			`data: {"model":"gpt-4.1","choices":[],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}`,
+			``,
+			`data: [DONE]`,
+			``,
+		}, "\n"),
+		"anthropic": strings.Join([]string{
+			`event: message_start`,
+			`data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","usage":{"input_tokens":5,"output_tokens":0}}}`,
+			``,
+			`event: content_block_start`,
+			`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+			``,
+			`event: content_block_delta`,
+			`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello world"}}`,
+			``,
+			`event: content_block_stop`,
+			`data: {"type":"content_block_stop","index":0}`,
+			``,
+			`event: message_delta`,
+			`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}`,
+			``,
+			`event: message_stop`,
+			`data: {"type":"message_stop"}`,
+			``,
+		}, "\n"),
+		"gemini": strings.Join([]string{
+			`data: {"candidates":[{"content":{"parts":[{"text":"Hello world"}]},"finishReason":"STOP"}],"modelVersion":"gemini-1.5-pro-001","usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":2,"totalTokenCount":7}}`,
+			``,
+		}, "\n"),
+	}
+
+	for _, adapter := range conformanceAdapters() {
+		t.Run(adapter.name, func(t *testing.T) {
+			body := responses[adapter.name]
+			transport := roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return sseResponse(http.StatusOK, body), nil
+			})
+			client := adapter.client(transport)
+
+			response, err := client.InvokeModel(context.Background(), Request{
+				ProviderKey:         adapter.name,
+				CredentialReference: "env://KEY",
+				Model:               "test-model",
+				Messages:            []Message{{Role: "user", Content: "say hello"}},
+			})
+			if err != nil {
+				t.Fatalf("InvokeModel returned error: %v", err)
+			}
+
+			if response.OutputText != "Hello world" {
+				t.Errorf("output text = %q, want Hello world", response.OutputText)
+			}
+			if response.FinishReason != FinishReasonStop {
+				t.Errorf("finish reason = %q, want %q", response.FinishReason, FinishReasonStop)
+			}
+			if response.Usage.InputTokens != 5 {
+				t.Errorf("input tokens = %d, want 5", response.Usage.InputTokens)
+			}
+			if response.Usage.OutputTokens != 2 {
+				t.Errorf("output tokens = %d, want 2", response.Usage.OutputTokens)
+			}
+			if response.Usage.TotalTokens != 7 {
+				t.Errorf("total tokens = %d, want 7", response.Usage.TotalTokens)
+			}
+			if !response.Streamed {
+				t.Errorf("expected streamed = true")
+			}
+		})
+	}
+}
+
+// --- Conformance: single tool call ---
+
+func TestConformanceSingleToolCall(t *testing.T) {
+	responses := map[string]string{
+		"openai": strings.Join([]string{
+			`data: {"model":"gpt-4.1","choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-1","type":"function","function":{"name":"read_file","arguments":"{\"path\":\"/app.go\"}"}}]},"finish_reason":"tool_calls"}]}`,
+			``,
+			`data: {"model":"gpt-4.1","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+			``,
+			`data: [DONE]`,
+			``,
+		}, "\n"),
+		"anthropic": strings.Join([]string{
+			`event: message_start`,
+			`data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","usage":{"input_tokens":10,"output_tokens":0}}}`,
+			``,
+			`event: content_block_start`,
+			`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"call-1","name":"read_file"}}`,
+			``,
+			`event: content_block_delta`,
+			`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\"/app.go\"}"}}`,
+			``,
+			`event: content_block_stop`,
+			`data: {"type":"content_block_stop","index":0}`,
+			``,
+			`event: message_delta`,
+			`data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":5}}`,
+			``,
+			`event: message_stop`,
+			`data: {"type":"message_stop"}`,
+			``,
+		}, "\n"),
+		"gemini": strings.Join([]string{
+			`data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"read_file","args":{"path":"/app.go"}}}]},"finishReason":"STOP"}],"modelVersion":"gemini-1.5-pro-001","usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}`,
+			``,
+		}, "\n"),
+	}
+
+	for _, adapter := range conformanceAdapters() {
+		t.Run(adapter.name, func(t *testing.T) {
+			body := responses[adapter.name]
+			transport := roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return sseResponse(http.StatusOK, body), nil
+			})
+			client := adapter.client(transport)
+
+			response, err := client.InvokeModel(context.Background(), Request{
+				ProviderKey:         adapter.name,
+				CredentialReference: "env://KEY",
+				Model:               "test-model",
+				Messages:            []Message{{Role: "user", Content: "read file"}},
+				Tools:               []ToolDefinition{{Name: "read_file", Parameters: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`)}},
+			})
+			if err != nil {
+				t.Fatalf("InvokeModel returned error: %v", err)
+			}
+
+			if len(response.ToolCalls) != 1 {
+				t.Fatalf("tool calls = %d, want 1", len(response.ToolCalls))
+			}
+			tc := response.ToolCalls[0]
+			if tc.Name != "read_file" {
+				t.Errorf("tool call name = %q, want read_file", tc.Name)
+			}
+			var args struct {
+				Path string `json:"path"`
+			}
+			if err := json.Unmarshal(tc.Arguments, &args); err != nil {
+				t.Fatalf("unmarshal arguments: %v", err)
+			}
+			if args.Path != "/app.go" {
+				t.Errorf("tool call path = %q, want /app.go", args.Path)
+			}
+			if response.Usage.InputTokens != 10 {
+				t.Errorf("input tokens = %d, want 10", response.Usage.InputTokens)
+			}
+		})
+	}
+}
+
+// --- Conformance: rate limit error ---
+
+func TestConformanceRateLimitError(t *testing.T) {
+	responses := map[string]struct {
+		statusCode int
+		body       string
+	}{
+		"openai": {
+			statusCode: http.StatusTooManyRequests,
+			body:       `{"error":{"message":"rate limited","type":"rate_limit_error"}}`,
+		},
+		"anthropic": {
+			statusCode: http.StatusTooManyRequests,
+			body:       `{"type":"error","error":{"type":"rate_limit_error","message":"rate limited"}}`,
+		},
+		"gemini": {
+			statusCode: http.StatusTooManyRequests,
+			body:       `{"error":{"code":429,"message":"rate limited","status":"RESOURCE_EXHAUSTED"}}`,
+		},
+	}
+
+	for _, adapter := range conformanceAdapters() {
+		t.Run(adapter.name, func(t *testing.T) {
+			resp := responses[adapter.name]
+			transport := roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return jsonResponse(resp.statusCode, resp.body), nil
+			})
+			client := adapter.client(transport)
+
+			_, err := client.InvokeModel(context.Background(), Request{
+				ProviderKey:         adapter.name,
+				CredentialReference: "env://KEY",
+				Model:               "test-model",
+				Messages:            []Message{{Role: "user", Content: "hello"}},
+			})
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+
+			failure, ok := AsFailure(err)
+			if !ok {
+				t.Fatalf("expected provider Failure, got %T", err)
+			}
+			if failure.Code != FailureCodeRateLimit {
+				t.Errorf("failure code = %s, want %s", failure.Code, FailureCodeRateLimit)
+			}
+			if !failure.Retryable {
+				t.Errorf("expected retryable = true")
+			}
+		})
+	}
+}
+
+// --- Conformance: auth error ---
+
+func TestConformanceAuthError(t *testing.T) {
+	responses := map[string]struct {
+		statusCode int
+		body       string
+	}{
+		"openai": {
+			statusCode: http.StatusUnauthorized,
+			body:       `{"error":{"message":"invalid key","type":"authentication_error"}}`,
+		},
+		"anthropic": {
+			statusCode: http.StatusUnauthorized,
+			body:       `{"type":"error","error":{"type":"authentication_error","message":"invalid key"}}`,
+		},
+		"gemini": {
+			statusCode: http.StatusUnauthorized,
+			body:       `{"error":{"code":401,"message":"invalid key","status":"UNAUTHENTICATED"}}`,
+		},
+	}
+
+	for _, adapter := range conformanceAdapters() {
+		t.Run(adapter.name, func(t *testing.T) {
+			resp := responses[adapter.name]
+			transport := roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return jsonResponse(resp.statusCode, resp.body), nil
+			})
+			client := adapter.client(transport)
+
+			_, err := client.InvokeModel(context.Background(), Request{
+				ProviderKey:         adapter.name,
+				CredentialReference: "env://KEY",
+				Model:               "test-model",
+				Messages:            []Message{{Role: "user", Content: "hello"}},
+			})
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+
+			failure, ok := AsFailure(err)
+			if !ok {
+				t.Fatalf("expected provider Failure, got %T", err)
+			}
+			if failure.Code != FailureCodeAuth {
+				t.Errorf("failure code = %s, want %s", failure.Code, FailureCodeAuth)
+			}
+			if failure.Retryable {
+				t.Errorf("expected retryable = false")
+			}
+		})
+	}
+}
+
+// --- Conformance: timeout ---
+
+func TestConformanceTimeout(t *testing.T) {
+	for _, adapter := range conformanceAdapters() {
+		t.Run(adapter.name, func(t *testing.T) {
+			transport := roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+					Body:       io.NopCloser(timeoutReader{}),
+				}, nil
+			})
+			client := adapter.client(transport)
+
+			_, err := client.InvokeModel(context.Background(), Request{
+				ProviderKey:         adapter.name,
+				CredentialReference: "env://KEY",
+				Model:               "test-model",
+				Messages:            []Message{{Role: "user", Content: "hello"}},
+			})
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+
+			failure, ok := AsFailure(err)
+			if !ok {
+				t.Fatalf("expected provider Failure, got %T", err)
+			}
+			if failure.Code != FailureCodeTimeout {
+				t.Errorf("failure code = %s, want %s", failure.Code, FailureCodeTimeout)
+			}
+			if !failure.Retryable {
+				t.Errorf("expected retryable = true")
+			}
+		})
+	}
+}
+
+// --- Conformance: empty stream → malformed response ---
+
+func TestConformanceMalformedEmptyStream(t *testing.T) {
+	for _, adapter := range conformanceAdapters() {
+		t.Run(adapter.name, func(t *testing.T) {
+			transport := roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return sseResponse(http.StatusOK, ""), nil
+			})
+			client := adapter.client(transport)
+
+			_, err := client.InvokeModel(context.Background(), Request{
+				ProviderKey:         adapter.name,
+				CredentialReference: "env://KEY",
+				Model:               "test-model",
+				Messages:            []Message{{Role: "user", Content: "hello"}},
+			})
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+
+			failure, ok := AsFailure(err)
+			if !ok {
+				t.Fatalf("expected provider Failure, got %T", err)
+			}
+			if failure.Code != FailureCodeMalformedResponse {
+				t.Errorf("failure code = %s, want %s", failure.Code, FailureCodeMalformedResponse)
+			}
+		})
+	}
+}
+
+// --- Conformance: credential error ---
+
+func TestConformanceCredentialError(t *testing.T) {
+	for _, adapter := range conformanceAdapters() {
+		t.Run(adapter.name, func(t *testing.T) {
+			credErr := errors.New("credential not found")
+			var client Client
+			httpClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				t.Fatal("should not make HTTP request on credential error")
+				return nil, nil
+			})}
+
+			switch adapter.name {
+			case "openai":
+				client = NewOpenAICompatibleClient(httpClient, "https://example.com/v1", staticCredentialResolver{err: credErr})
+			case "anthropic":
+				client = NewAnthropicClient(httpClient, "https://example.com", "", staticCredentialResolver{err: credErr})
+			case "gemini":
+				client = NewGeminiClient(httpClient, "https://example.com", staticCredentialResolver{err: credErr})
+			}
+
+			_, err := client.InvokeModel(context.Background(), Request{
+				ProviderKey:         adapter.name,
+				CredentialReference: "env://KEY",
+				Model:               "test-model",
+				Messages:            []Message{{Role: "user", Content: "hello"}},
+			})
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+
+			failure, ok := AsFailure(err)
+			if !ok {
+				t.Fatalf("expected provider Failure, got %T", err)
+			}
+			if failure.Code != FailureCodeCredentialUnavailable {
+				t.Errorf("failure code = %s, want %s", failure.Code, FailureCodeCredentialUnavailable)
+			}
+		})
+	}
+}

--- a/backend/internal/provider/error_classification.go
+++ b/backend/internal/provider/error_classification.go
@@ -1,0 +1,24 @@
+package provider
+
+import (
+	"net"
+	"strings"
+)
+
+func classifyTransportError(providerKey string, err error) error {
+	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		return NewFailure(providerKey, FailureCodeTimeout, "provider request timed out", true, err)
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "context deadline exceeded") {
+		return NewFailure(providerKey, FailureCodeTimeout, "provider request timed out", true, err)
+	}
+	return NewFailure(providerKey, FailureCodeUnavailable, "provider request failed", true, err)
+}
+
+func normalizeCredentialError(providerKey string, err error) error {
+	if failure, ok := AsFailure(err); ok {
+		failure.ProviderKey = providerKey
+		return failure
+	}
+	return NewFailure(providerKey, FailureCodeCredentialUnavailable, err.Error(), false, err)
+}

--- a/backend/internal/provider/finish_reason.go
+++ b/backend/internal/provider/finish_reason.go
@@ -1,0 +1,35 @@
+package provider
+
+import "strings"
+
+const (
+	FinishReasonStop      = "stop"
+	FinishReasonToolCalls = "tool_calls"
+	FinishReasonMaxTokens = "max_tokens"
+)
+
+func NormalizeAnthropicStopReason(reason string) string {
+	switch strings.TrimSpace(reason) {
+	case "end_turn":
+		return FinishReasonStop
+	case "tool_use":
+		return FinishReasonToolCalls
+	case "max_tokens":
+		return FinishReasonMaxTokens
+	default:
+		return reason
+	}
+}
+
+func NormalizeGeminiFinishReason(reason string) string {
+	switch strings.TrimSpace(strings.ToUpper(reason)) {
+	case "STOP":
+		return FinishReasonStop
+	case "MAX_TOKENS":
+		return FinishReasonMaxTokens
+	case "SAFETY", "RECITATION", "OTHER":
+		return FinishReasonStop
+	default:
+		return reason
+	}
+}

--- a/backend/internal/provider/gemini.go
+++ b/backend/internal/provider/gemini.go
@@ -1,0 +1,462 @@
+package provider
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const defaultGeminiBaseURL = "https://generativelanguage.googleapis.com"
+
+type GeminiClient struct {
+	httpClient         *http.Client
+	baseURL            string
+	credentialResolver CredentialResolver
+}
+
+func NewGeminiClient(httpClient *http.Client, baseURL string, credentialResolver CredentialResolver) GeminiClient {
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = defaultGeminiBaseURL
+	}
+	return GeminiClient{
+		httpClient:         httpClient,
+		baseURL:            strings.TrimRight(baseURL, "/"),
+		credentialResolver: credentialResolver,
+	}
+}
+
+func (c GeminiClient) InvokeModel(ctx context.Context, request Request) (Response, error) {
+	return c.StreamModel(ctx, request, nil)
+}
+
+func (c GeminiClient) StreamModel(ctx context.Context, request Request, onDelta func(StreamDelta) error) (Response, error) {
+	apiKey, err := c.credentialResolver.Resolve(ctx, request.CredentialReference)
+	if err != nil {
+		return Response{}, normalizeCredentialError(request.ProviderKey, err)
+	}
+
+	body, err := buildGeminiRequestBody(request)
+	if err != nil {
+		return Response{}, err
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return Response{}, NewFailure(request.ProviderKey, FailureCodeInvalidRequest, "marshal provider request", false, err)
+	}
+
+	callCtx := ctx
+	if request.StepTimeout > 0 {
+		var cancel context.CancelFunc
+		callCtx, cancel = context.WithTimeout(ctx, request.StepTimeout)
+		defer cancel()
+	}
+
+	endpoint := fmt.Sprintf("%s/v1beta/models/%s:streamGenerateContent?key=%s&alt=sse", c.baseURL, request.Model, apiKey)
+	req, err := http.NewRequestWithContext(callCtx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return Response{}, NewFailure(request.ProviderKey, FailureCodeInvalidRequest, "build provider request", false, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	startedAt := time.Now().UTC()
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return Response{}, classifyTransportError(request.ProviderKey, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		raw, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return Response{}, NewFailure(request.ProviderKey, FailureCodeUnavailable, "read provider response", true, err)
+		}
+		return Response{}, normalizeGeminiErrorResponse(request.ProviderKey, resp.StatusCode, raw)
+	}
+
+	accumulator := NewStreamAccumulator(request.ProviderKey, startedAt)
+	if err := consumeGeminiStream(resp.Body, request.ProviderKey, request.Model, accumulator, onDelta); err != nil {
+		return Response{}, err
+	}
+
+	return accumulator.Finalize(time.Now().UTC())
+}
+
+func buildGeminiRequestBody(request Request) (geminiRequest, error) {
+	var systemInstruction *geminiContent
+	contents := make([]geminiContent, 0, len(request.Messages))
+
+	for _, msg := range request.Messages {
+		if msg.Role == "system" {
+			systemInstruction = &geminiContent{
+				Parts: []geminiPart{{Text: msg.Content}},
+			}
+			continue
+		}
+
+		converted, err := normalizeGeminiRequestMessage(request.ProviderKey, msg)
+		if err != nil {
+			return geminiRequest{}, err
+		}
+		contents = append(contents, converted)
+	}
+
+	var tools []geminiToolDeclarationWrapper
+	if len(request.Tools) > 0 {
+		declarations := make([]geminiFunctionDeclaration, 0, len(request.Tools))
+		for _, tool := range request.Tools {
+			normalized, err := normalizeGeminiRequestTool(request.ProviderKey, tool)
+			if err != nil {
+				return geminiRequest{}, err
+			}
+			declarations = append(declarations, normalized)
+		}
+		tools = []geminiToolDeclarationWrapper{{FunctionDeclarations: declarations}}
+	}
+
+	return geminiRequest{
+		Contents:          contents,
+		Tools:             tools,
+		SystemInstruction: systemInstruction,
+	}, nil
+}
+
+func normalizeGeminiRequestMessage(providerKey string, msg Message) (geminiContent, error) {
+	switch msg.Role {
+	case "user":
+		return geminiContent{
+			Role:  "user",
+			Parts: []geminiPart{{Text: msg.Content}},
+		}, nil
+
+	case "assistant":
+		if len(msg.ToolCalls) > 0 {
+			parts := make([]geminiPart, 0, len(msg.ToolCalls)+1)
+			if msg.Content != "" {
+				parts = append(parts, geminiPart{Text: msg.Content})
+			}
+			for _, tc := range msg.ToolCalls {
+				args := tc.Arguments
+				if len(args) == 0 {
+					args = json.RawMessage(`{}`)
+				}
+				if !json.Valid(args) {
+					return geminiContent{}, NewFailure(providerKey, FailureCodeInvalidRequest, fmt.Sprintf("tool call %q arguments must be valid JSON", tc.Name), false, nil)
+				}
+				parts = append(parts, geminiPart{
+					FunctionCall: &geminiFunctionCall{
+						Name: tc.Name,
+						Args: append(json.RawMessage(nil), args...),
+					},
+				})
+			}
+			return geminiContent{Role: "model", Parts: parts}, nil
+		}
+		return geminiContent{
+			Role:  "model",
+			Parts: []geminiPart{{Text: msg.Content}},
+		}, nil
+
+	case "tool":
+		return geminiContent{
+			Role: "user",
+			Parts: []geminiPart{
+				{
+					FunctionResponse: &geminiFunctionResponse{
+						Name: msg.ToolCallID,
+						Response: geminiResponsePayload{
+							Content: msg.Content,
+						},
+					},
+				},
+			},
+		}, nil
+
+	default:
+		return geminiContent{}, NewFailure(providerKey, FailureCodeInvalidRequest, fmt.Sprintf("unsupported message role %q", msg.Role), false, nil)
+	}
+}
+
+func normalizeGeminiRequestTool(providerKey string, tool ToolDefinition) (geminiFunctionDeclaration, error) {
+	parameters := tool.Parameters
+	if len(parameters) == 0 {
+		parameters = json.RawMessage(`{"type":"object","properties":{}}`)
+	}
+	if !json.Valid(parameters) {
+		return geminiFunctionDeclaration{}, NewFailure(providerKey, FailureCodeInvalidRequest, fmt.Sprintf("tool %q parameters must be valid JSON", tool.Name), false, nil)
+	}
+
+	return geminiFunctionDeclaration{
+		Name:        tool.Name,
+		Description: tool.Description,
+		Parameters:  append(json.RawMessage(nil), parameters...),
+	}, nil
+}
+
+// --- Gemini request/response types ---
+
+type geminiRequest struct {
+	Contents          []geminiContent                `json:"contents"`
+	Tools             []geminiToolDeclarationWrapper `json:"tools,omitempty"`
+	SystemInstruction *geminiContent                 `json:"system_instruction,omitempty"`
+}
+
+type geminiContent struct {
+	Role  string       `json:"role,omitempty"`
+	Parts []geminiPart `json:"parts"`
+}
+
+type geminiPart struct {
+	Text             string                  `json:"text,omitempty"`
+	FunctionCall     *geminiFunctionCall     `json:"functionCall,omitempty"`
+	FunctionResponse *geminiFunctionResponse `json:"functionResponse,omitempty"`
+}
+
+type geminiFunctionCall struct {
+	Name string          `json:"name"`
+	Args json.RawMessage `json:"args"`
+}
+
+type geminiFunctionResponse struct {
+	Name     string               `json:"name"`
+	Response geminiResponsePayload `json:"response"`
+}
+
+type geminiResponsePayload struct {
+	Content string `json:"content"`
+}
+
+type geminiToolDeclarationWrapper struct {
+	FunctionDeclarations []geminiFunctionDeclaration `json:"functionDeclarations"`
+}
+
+type geminiFunctionDeclaration struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+}
+
+// --- Gemini streaming response types ---
+
+type geminiStreamChunk struct {
+	Candidates []struct {
+		Content struct {
+			Parts []struct {
+				Text         string              `json:"text,omitempty"`
+				FunctionCall *geminiFunctionCall `json:"functionCall,omitempty"`
+			} `json:"parts"`
+		} `json:"content"`
+		FinishReason string `json:"finishReason,omitempty"`
+	} `json:"candidates"`
+	UsageMetadata *struct {
+		PromptTokenCount     int64 `json:"promptTokenCount"`
+		CandidatesTokenCount int64 `json:"candidatesTokenCount"`
+		TotalTokenCount      int64 `json:"totalTokenCount"`
+	} `json:"usageMetadata,omitempty"`
+	ModelVersion string `json:"modelVersion,omitempty"`
+}
+
+type geminiErrorEnvelope struct {
+	Error struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Status  string `json:"status"`
+	} `json:"error"`
+}
+
+// --- Gemini stream consumption ---
+
+func consumeGeminiStream(body io.Reader, providerKey string, model string, accumulator *StreamAccumulator, onDelta func(StreamDelta) error) error {
+	reader := bufio.NewReader(body)
+	dataLines := make([]string, 0, 1)
+	eventsProcessed := false
+	toolCallIndex := 0
+
+	flush := func() error {
+		if len(dataLines) == 0 {
+			return nil
+		}
+		data := strings.Join(dataLines, "\n")
+		dataLines = dataLines[:0]
+
+		if strings.TrimSpace(data) == "" {
+			return nil
+		}
+
+		eventsProcessed = true
+		return processGeminiStreamEvent(providerKey, model, []byte(data), accumulator, onDelta, &toolCallIndex)
+	}
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			return classifyTransportError(providerKey, err)
+		}
+
+		trimmed := strings.TrimRight(line, "\r\n")
+		switch {
+		case trimmed == "":
+			if flushErr := flush(); flushErr != nil {
+				return flushErr
+			}
+		case strings.HasPrefix(trimmed, ":"):
+			// SSE comment / keepalive
+		default:
+			field, value, found := strings.Cut(trimmed, ":")
+			if found && field == "data" {
+				dataLines = append(dataLines, strings.TrimPrefix(value, " "))
+			}
+		}
+
+		if errors.Is(err, io.EOF) {
+			if flushErr := flush(); flushErr != nil {
+				return flushErr
+			}
+			if !eventsProcessed {
+				return NewFailure(providerKey, FailureCodeMalformedResponse, "provider returned empty or non-streaming response", false, nil)
+			}
+			return nil
+		}
+	}
+}
+
+func processGeminiStreamEvent(providerKey string, model string, raw []byte, accumulator *StreamAccumulator, onDelta func(StreamDelta) error, toolCallIndex *int) error {
+	// Check for error response first.
+	var errEnvelope geminiErrorEnvelope
+	if err := json.Unmarshal(raw, &errEnvelope); err == nil && errEnvelope.Error.Message != "" {
+		return NewFailure(providerKey, FailureCodeUnknown, errEnvelope.Error.Message, false, nil)
+	}
+
+	var chunk geminiStreamChunk
+	if err := json.Unmarshal(raw, &chunk); err != nil {
+		return NewFailure(providerKey, FailureCodeMalformedResponse, "decode provider stream chunk", false, err)
+	}
+
+	timestamp := time.Now().UTC()
+
+	if len(chunk.Candidates) > 0 {
+		candidate := chunk.Candidates[0]
+
+		for _, part := range candidate.Content.Parts {
+			if part.Text != "" {
+				if err := emitGeminiDelta(accumulator, onDelta, StreamDelta{
+					Kind:      StreamDeltaKindText,
+					Timestamp: timestamp,
+					Text:      part.Text,
+				}); err != nil {
+					return err
+				}
+			}
+			if part.FunctionCall != nil {
+				args := part.FunctionCall.Args
+				if len(args) == 0 {
+					args = json.RawMessage(`{}`)
+				}
+				if err := emitGeminiDelta(accumulator, onDelta, StreamDelta{
+					Kind:      StreamDeltaKindToolCall,
+					Timestamp: timestamp,
+					ToolCall: ToolCallFragment{
+						Index:             *toolCallIndex,
+						IDFragment:        fmt.Sprintf("gemini-call-%d", *toolCallIndex),
+						NameFragment:      part.FunctionCall.Name,
+						ArgumentsFragment: string(args),
+					},
+				}); err != nil {
+					return err
+				}
+				*toolCallIndex++
+			}
+		}
+
+		if candidate.FinishReason != "" {
+			modelVersion := model
+			if chunk.ModelVersion != "" {
+				modelVersion = chunk.ModelVersion
+			}
+			terminal := StreamTerminal{
+				FinishReason:    NormalizeGeminiFinishReason(candidate.FinishReason),
+				ProviderModelID: modelVersion,
+				RawResponse:     raw,
+			}
+			if err := emitGeminiDelta(accumulator, onDelta, StreamDelta{
+				Kind:      StreamDeltaKindTerminal,
+				Timestamp: timestamp,
+				Terminal:  terminal,
+			}); err != nil {
+				return err
+			}
+		}
+	}
+
+	if chunk.UsageMetadata != nil {
+		if err := emitGeminiDelta(accumulator, onDelta, StreamDelta{
+			Kind:      StreamDeltaKindTerminal,
+			Timestamp: timestamp,
+			Terminal: StreamTerminal{
+				Usage: &Usage{
+					InputTokens:  chunk.UsageMetadata.PromptTokenCount,
+					OutputTokens: chunk.UsageMetadata.CandidatesTokenCount,
+					TotalTokens:  chunk.UsageMetadata.TotalTokenCount,
+				},
+				RawResponse: raw,
+			},
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func emitGeminiDelta(accumulator *StreamAccumulator, onDelta func(StreamDelta) error, delta StreamDelta) error {
+	if err := accumulator.Consume(delta); err != nil {
+		return err
+	}
+	if onDelta != nil {
+		if err := onDelta(cloneStreamDelta(delta)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func normalizeGeminiErrorResponse(providerKey string, statusCode int, raw []byte) error {
+	var envelope geminiErrorEnvelope
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return NewFailure(
+			providerKey,
+			FailureCodeMalformedResponse,
+			fmt.Sprintf("provider returned HTTP %d with invalid error payload", statusCode),
+			false,
+			err,
+		)
+	}
+
+	message := envelope.Error.Message
+	if strings.TrimSpace(message) == "" {
+		message = fmt.Sprintf("provider returned HTTP %d", statusCode)
+	}
+
+	switch statusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return NewFailure(providerKey, FailureCodeAuth, message, false, nil)
+	case http.StatusTooManyRequests:
+		return NewFailure(providerKey, FailureCodeRateLimit, message, true, nil)
+	case http.StatusBadRequest, http.StatusUnprocessableEntity:
+		return NewFailure(providerKey, FailureCodeInvalidRequest, message, false, nil)
+	case http.StatusGatewayTimeout, http.StatusBadGateway, http.StatusServiceUnavailable:
+		return NewFailure(providerKey, FailureCodeUnavailable, message, true, nil)
+	default:
+		return NewFailure(providerKey, FailureCodeUnknown, message, statusCode >= 500, nil)
+	}
+}

--- a/backend/internal/provider/gemini.go
+++ b/backend/internal/provider/gemini.go
@@ -196,11 +196,103 @@ func normalizeGeminiRequestTool(providerKey string, tool ToolDefinition) (gemini
 		return geminiFunctionDeclaration{}, NewFailure(providerKey, FailureCodeInvalidRequest, fmt.Sprintf("tool %q parameters must be valid JSON", tool.Name), false, nil)
 	}
 
+	// Gemini uses a protobuf-defined subset of OpenAPI schema and rejects
+	// unknown fields like additionalProperties, $schema, $ref, oneOf, etc.
+	parameters = stripUnsupportedGeminiSchemaFields(parameters)
+
 	return geminiFunctionDeclaration{
 		Name:        tool.Name,
 		Description: tool.Description,
 		Parameters:  append(json.RawMessage(nil), parameters...),
 	}, nil
+}
+
+// geminiUnsupportedSchemaFields lists JSON Schema keywords that the Gemini API
+// does not recognise. The API accepts only the fields defined in its protobuf
+// Schema message: type, format, title, description, nullable, enum, items,
+// maxItems, minItems, properties, required, minProperties, maxProperties,
+// minimum, maximum, minLength, maxLength, pattern, example, anyOf,
+// propertyOrdering, default. Everything else must be stripped.
+var geminiUnsupportedSchemaFields = map[string]bool{
+	"additionalProperties":  true,
+	"$schema":               true,
+	"$ref":                  true,
+	"$defs":                 true,
+	"$id":                   true,
+	"$comment":              true,
+	"$anchor":               true,
+	"definitions":           true,
+	"oneOf":                 true,
+	"allOf":                 true,
+	"not":                   true,
+	"if":                    true,
+	"then":                  true,
+	"else":                  true,
+	"const":                 true,
+	"patternProperties":     true,
+	"propertyNames":         true,
+	"dependentRequired":     true,
+	"dependentSchemas":      true,
+	"unevaluatedProperties": true,
+	"unevaluatedItems":      true,
+	"prefixItems":           true,
+	"contains":              true,
+	"uniqueItems":           true,
+	"multipleOf":            true,
+	"exclusiveMinimum":      true,
+	"exclusiveMaximum":      true,
+	"examples":              true,
+	"readOnly":              true,
+	"writeOnly":             true,
+	"deprecated":            true,
+	"contentMediaType":      true,
+	"contentEncoding":       true,
+}
+
+func stripUnsupportedGeminiSchemaFields(schema json.RawMessage) json.RawMessage {
+	var parsed map[string]any
+	if err := json.Unmarshal(schema, &parsed); err != nil {
+		return schema
+	}
+
+	stripped := stripGeminiFieldsRecursive(parsed)
+
+	cleaned, err := json.Marshal(stripped)
+	if err != nil {
+		return schema
+	}
+	return cleaned
+}
+
+func stripGeminiFieldsRecursive(obj map[string]any) map[string]any {
+	for key := range geminiUnsupportedSchemaFields {
+		delete(obj, key)
+	}
+
+	// Recurse into properties (each value is a sub-schema).
+	if props, ok := obj["properties"].(map[string]any); ok {
+		for propKey, propVal := range props {
+			if propSchema, ok := propVal.(map[string]any); ok {
+				props[propKey] = stripGeminiFieldsRecursive(propSchema)
+			}
+		}
+	}
+
+	// Recurse into items (array element schema).
+	if items, ok := obj["items"].(map[string]any); ok {
+		obj["items"] = stripGeminiFieldsRecursive(items)
+	}
+
+	// Recurse into anyOf (the only composition keyword Gemini supports).
+	if anyOf, ok := obj["anyOf"].([]any); ok {
+		for i, branch := range anyOf {
+			if branchSchema, ok := branch.(map[string]any); ok {
+				anyOf[i] = stripGeminiFieldsRecursive(branchSchema)
+			}
+		}
+	}
+
+	return obj
 }
 
 // --- Gemini request/response types ---

--- a/backend/internal/provider/gemini_smoke_test.go
+++ b/backend/internal/provider/gemini_smoke_test.go
@@ -1,0 +1,63 @@
+//go:build geminismoke
+
+package provider
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestGeminiClientSmoke(t *testing.T) {
+	apiKey := os.Getenv("GEMINI_API_KEY")
+	if apiKey == "" {
+		t.Skip("GEMINI_API_KEY is not set")
+	}
+
+	model := os.Getenv("GEMINI_MODEL")
+	if model == "" {
+		model = "gemini-2.0-flash"
+	}
+
+	t.Setenv("GEMINI_API_KEY", apiKey)
+
+	client := NewGeminiClient(nil, "", EnvCredentialResolver{})
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	response, err := client.InvokeModel(ctx, Request{
+		ProviderKey:         "gemini",
+		CredentialReference: "env://GEMINI_API_KEY",
+		Model:               model,
+		StepTimeout:         40 * time.Second,
+		Messages: []Message{
+			{
+				Role:    "user",
+				Content: "Reply with exactly: smoke-ok",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("InvokeModel returned error: %v", err)
+	}
+
+	if !response.Streamed {
+		t.Fatalf("expected streamed response")
+	}
+	if response.ProviderModelID == "" {
+		t.Fatalf("expected provider model id")
+	}
+	if response.FinishReason == "" {
+		t.Fatalf("expected finish reason")
+	}
+	if response.Timing.TTFT <= 0 {
+		t.Fatalf("expected TTFT > 0, got %s", response.Timing.TTFT)
+	}
+	if response.Timing.TotalLatency <= 0 {
+		t.Fatalf("expected total latency > 0, got %s", response.Timing.TotalLatency)
+	}
+	if response.OutputText == "" && len(response.ToolCalls) == 0 {
+		t.Fatalf("expected output text or tool calls in response")
+	}
+}

--- a/backend/internal/provider/gemini_test.go
+++ b/backend/internal/provider/gemini_test.go
@@ -1,0 +1,343 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGeminiClientInvokeModelStreamsTextAndCapturesTiming(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			assertGeminiStreamingRequest(t, r, "gemini-1.5-pro")
+			return sseResponse(http.StatusOK, strings.Join([]string{
+				`data: {"candidates":[{"content":{"parts":[{"text":"native "}]}}],"modelVersion":"gemini-1.5-pro-001"}`,
+				``,
+				`data: {"candidates":[{"content":{"parts":[{"text":"step output"}]},"finishReason":"STOP"}],"modelVersion":"gemini-1.5-pro-001","usageMetadata":{"promptTokenCount":11,"candidatesTokenCount":7,"totalTokenCount":18}}`,
+				``,
+			}, "\n")), nil
+		}),
+	}
+
+	client := NewGeminiClient(httpClient, "https://example.com", staticCredentialResolver{value: "test-key"})
+
+	response, err := client.InvokeModel(context.Background(), Request{
+		ProviderKey:         "gemini",
+		CredentialReference: "env://GEMINI_API_KEY",
+		Model:               "gemini-1.5-pro",
+		StepTimeout:         time.Second,
+		Messages: []Message{
+			{Role: "system", Content: "You are helpful."},
+			{Role: "user", Content: "hello"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("InvokeModel returned error: %v", err)
+	}
+	if !response.Streamed {
+		t.Fatalf("expected streamed response")
+	}
+	if response.OutputText != "native step output" {
+		t.Fatalf("output text = %q, want native step output", response.OutputText)
+	}
+	if response.Usage.InputTokens != 11 {
+		t.Fatalf("input tokens = %d, want 11", response.Usage.InputTokens)
+	}
+	if response.Usage.OutputTokens != 7 {
+		t.Fatalf("output tokens = %d, want 7", response.Usage.OutputTokens)
+	}
+	if response.Usage.TotalTokens != 18 {
+		t.Fatalf("total tokens = %d, want 18", response.Usage.TotalTokens)
+	}
+	if response.FinishReason != "stop" {
+		t.Fatalf("finish reason = %q, want stop", response.FinishReason)
+	}
+	if response.ProviderModelID != "gemini-1.5-pro-001" {
+		t.Fatalf("provider model id = %q, want gemini-1.5-pro-001", response.ProviderModelID)
+	}
+	if response.Timing.StartedAt.IsZero() || response.Timing.FirstTokenAt.IsZero() || response.Timing.CompletedAt.IsZero() {
+		t.Fatalf("expected timing metadata to be populated: %#v", response.Timing)
+	}
+	if response.Timing.TTFT <= 0 {
+		t.Fatalf("expected TTFT > 0, got %s", response.Timing.TTFT)
+	}
+}
+
+func TestGeminiClientStreamModelEmitsToolCallDeltas(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			assertGeminiStreamingRequest(t, r, "gemini-1.5-pro")
+			return sseResponse(http.StatusOK, strings.Join([]string{
+				`data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"read_file","args":{"path":"/workspace/app.go"}}}]},"finishReason":"STOP"}],"modelVersion":"gemini-1.5-pro-001","usageMetadata":{"promptTokenCount":21,"candidatesTokenCount":9,"totalTokenCount":30}}`,
+				``,
+			}, "\n")), nil
+		}),
+	}
+
+	client := NewGeminiClient(httpClient, "https://example.com", staticCredentialResolver{value: "test-key"})
+
+	var deltas []StreamDelta
+	response, err := client.StreamModel(context.Background(), Request{
+		ProviderKey:         "gemini",
+		CredentialReference: "env://GEMINI_API_KEY",
+		Model:               "gemini-1.5-pro",
+		Messages: []Message{
+			{Role: "user", Content: "inspect workspace"},
+		},
+		Tools: []ToolDefinition{
+			{Name: "read_file", Parameters: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}`)},
+		},
+	}, func(delta StreamDelta) error {
+		deltas = append(deltas, delta)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("StreamModel returned error: %v", err)
+	}
+	if response.FinishReason != "stop" {
+		t.Fatalf("finish reason = %q, want stop", response.FinishReason)
+	}
+	if len(response.ToolCalls) != 1 {
+		t.Fatalf("tool calls = %d, want 1", len(response.ToolCalls))
+	}
+	if response.ToolCalls[0].Name != "read_file" {
+		t.Fatalf("tool call name = %q, want read_file", response.ToolCalls[0].Name)
+	}
+	var args struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(response.ToolCalls[0].Arguments, &args); err != nil {
+		t.Fatalf("unmarshal tool call arguments: %v", err)
+	}
+	if args.Path != "/workspace/app.go" {
+		t.Fatalf("tool call path = %q, want /workspace/app.go", args.Path)
+	}
+}
+
+func TestGeminiClientNormalizesRateLimitFailure(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return jsonResponse(http.StatusTooManyRequests, `{"error":{"code":429,"message":"too many requests","status":"RESOURCE_EXHAUSTED"}}`), nil
+		}),
+	}
+
+	client := NewGeminiClient(httpClient, "https://example.com", staticCredentialResolver{value: "test-key"})
+
+	_, err := client.InvokeModel(context.Background(), Request{
+		ProviderKey:         "gemini",
+		CredentialReference: "env://GEMINI_API_KEY",
+		Model:               "gemini-1.5-pro",
+		Messages:            []Message{{Role: "user", Content: "hello"}},
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	failure, ok := AsFailure(err)
+	if !ok {
+		t.Fatalf("expected provider failure, got %T", err)
+	}
+	if failure.Code != FailureCodeRateLimit {
+		t.Fatalf("failure code = %s, want %s", failure.Code, FailureCodeRateLimit)
+	}
+	if !failure.Retryable {
+		t.Fatalf("rate limit failure should be retryable")
+	}
+}
+
+func TestGeminiClientNormalizesAuthFailure(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return jsonResponse(http.StatusUnauthorized, `{"error":{"code":401,"message":"invalid API key","status":"UNAUTHENTICATED"}}`), nil
+		}),
+	}
+
+	client := NewGeminiClient(httpClient, "https://example.com", staticCredentialResolver{value: "bad-key"})
+
+	_, err := client.InvokeModel(context.Background(), Request{
+		ProviderKey:         "gemini",
+		CredentialReference: "env://GEMINI_API_KEY",
+		Model:               "gemini-1.5-pro",
+		Messages:            []Message{{Role: "user", Content: "hello"}},
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	failure, ok := AsFailure(err)
+	if !ok {
+		t.Fatalf("expected provider failure, got %T", err)
+	}
+	if failure.Code != FailureCodeAuth {
+		t.Fatalf("failure code = %s, want %s", failure.Code, FailureCodeAuth)
+	}
+	if failure.Retryable {
+		t.Fatalf("auth failure should not be retryable")
+	}
+}
+
+func TestGeminiClientNormalizesMidStreamError(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return sseResponse(http.StatusOK, strings.Join([]string{
+				`data: {"error":{"code":500,"message":"stream exploded","status":"INTERNAL"}}`,
+				``,
+			}, "\n")), nil
+		}),
+	}
+
+	client := NewGeminiClient(httpClient, "https://example.com", staticCredentialResolver{value: "test-key"})
+
+	_, err := client.InvokeModel(context.Background(), Request{
+		ProviderKey:         "gemini",
+		CredentialReference: "env://GEMINI_API_KEY",
+		Model:               "gemini-1.5-pro",
+		Messages:            []Message{{Role: "user", Content: "hello"}},
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	failure, ok := AsFailure(err)
+	if !ok {
+		t.Fatalf("expected provider failure, got %T", err)
+	}
+	if failure.Code != FailureCodeUnknown {
+		t.Fatalf("failure code = %s, want %s", failure.Code, FailureCodeUnknown)
+	}
+}
+
+func TestGeminiClientClassifiesStreamReadTimeout(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body:       io.NopCloser(timeoutReader{}),
+			}, nil
+		}),
+	}
+
+	client := NewGeminiClient(httpClient, "https://example.com", staticCredentialResolver{value: "test-key"})
+
+	_, err := client.InvokeModel(context.Background(), Request{
+		ProviderKey:         "gemini",
+		CredentialReference: "env://GEMINI_API_KEY",
+		Model:               "gemini-1.5-pro",
+		Messages:            []Message{{Role: "user", Content: "hello"}},
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	failure, ok := AsFailure(err)
+	if !ok {
+		t.Fatalf("expected provider failure, got %T", err)
+	}
+	if failure.Code != FailureCodeTimeout {
+		t.Fatalf("failure code = %s, want %s", failure.Code, FailureCodeTimeout)
+	}
+}
+
+func TestGeminiClientMultiToolCalls(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return sseResponse(http.StatusOK, strings.Join([]string{
+				`data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"read_file","args":{"path":"/a.go"}}},{"functionCall":{"name":"write_file","args":{"path":"/b.go"}}}]},"finishReason":"STOP"}],"modelVersion":"gemini-1.5-pro-001","usageMetadata":{"promptTokenCount":30,"candidatesTokenCount":15,"totalTokenCount":45}}`,
+				``,
+			}, "\n")), nil
+		}),
+	}
+
+	client := NewGeminiClient(httpClient, "https://example.com", staticCredentialResolver{value: "test-key"})
+
+	response, err := client.InvokeModel(context.Background(), Request{
+		ProviderKey:         "gemini",
+		CredentialReference: "env://GEMINI_API_KEY",
+		Model:               "gemini-1.5-pro",
+		Messages:            []Message{{Role: "user", Content: "read and write files"}},
+		Tools: []ToolDefinition{
+			{Name: "read_file", Parameters: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`)},
+			{Name: "write_file", Parameters: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("InvokeModel returned error: %v", err)
+	}
+	if len(response.ToolCalls) != 2 {
+		t.Fatalf("tool calls = %d, want 2", len(response.ToolCalls))
+	}
+	if response.ToolCalls[0].Name != "read_file" {
+		t.Fatalf("first tool call name = %q, want read_file", response.ToolCalls[0].Name)
+	}
+	if response.ToolCalls[1].Name != "write_file" {
+		t.Fatalf("second tool call name = %q, want write_file", response.ToolCalls[1].Name)
+	}
+}
+
+func TestGeminiClientAPIKeyInURL(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if got := r.URL.Query().Get("key"); got != "test-key" {
+				t.Fatalf("API key in URL = %q, want test-key", got)
+			}
+			if got := r.URL.Query().Get("alt"); got != "sse" {
+				t.Fatalf("alt parameter = %q, want sse", got)
+			}
+			if !strings.Contains(r.URL.Path, "gemini-1.5-pro") {
+				t.Fatalf("model not in URL path: %s", r.URL.Path)
+			}
+			return sseResponse(http.StatusOK, strings.Join([]string{
+				`data: {"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}`,
+				``,
+			}, "\n")), nil
+		}),
+	}
+
+	client := NewGeminiClient(httpClient, "https://example.com", staticCredentialResolver{value: "test-key"})
+
+	_, err := client.InvokeModel(context.Background(), Request{
+		ProviderKey:         "gemini",
+		CredentialReference: "env://GEMINI_API_KEY",
+		Model:               "gemini-1.5-pro",
+		Messages:            []Message{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("InvokeModel returned error: %v", err)
+	}
+}
+
+func assertGeminiStreamingRequest(t *testing.T, r *http.Request, model string) {
+	t.Helper()
+
+	if got := r.URL.Query().Get("key"); got != "test-key" {
+		t.Fatalf("API key in URL = %q, want test-key", got)
+	}
+	if !strings.Contains(r.URL.Path, model) {
+		t.Fatalf("model not in URL path: %s", r.URL.Path)
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read request body: %v", err)
+	}
+
+	var payload struct {
+		Contents []struct {
+			Role  string `json:"role"`
+			Parts []struct {
+				Text string `json:"text"`
+			} `json:"parts"`
+		} `json:"contents"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	if len(payload.Contents) == 0 {
+		t.Fatalf("expected contents in request body")
+	}
+}

--- a/backend/internal/provider/gemini_test.go
+++ b/backend/internal/provider/gemini_test.go
@@ -311,6 +311,133 @@ func TestGeminiClientAPIKeyInURL(t *testing.T) {
 	}
 }
 
+func TestGeminiClientStripsAdditionalPropertiesFromToolSchemas(t *testing.T) {
+	var capturedBody []byte
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			var err error
+			capturedBody, err = io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
+			return sseResponse(http.StatusOK, strings.Join([]string{
+				`data: {"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}`,
+				``,
+			}, "\n")), nil
+		}),
+	}
+
+	client := NewGeminiClient(httpClient, "https://example.com", staticCredentialResolver{value: "test-key"})
+
+	_, err := client.InvokeModel(context.Background(), Request{
+		ProviderKey:         "gemini",
+		CredentialReference: "env://GEMINI_API_KEY",
+		Model:               "gemini-2.0-flash",
+		Messages:            []Message{{Role: "user", Content: "hello"}},
+		Tools: []ToolDefinition{
+			{
+				Name: "submit",
+				Parameters: json.RawMessage(`{
+					"type": "object",
+					"properties": {
+						"answer": {
+							"type": "string",
+							"additionalProperties": false
+						}
+					},
+					"required": ["answer"],
+					"additionalProperties": false
+				}`),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("InvokeModel returned error: %v", err)
+	}
+
+	// Verify additionalProperties was stripped from the request body.
+	bodyStr := string(capturedBody)
+	if strings.Contains(bodyStr, "additionalProperties") {
+		t.Fatalf("request body still contains additionalProperties: %s", bodyStr)
+	}
+	// Verify required fields are preserved.
+	if !strings.Contains(bodyStr, "required") {
+		t.Fatalf("request body is missing required field: %s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, `"type"`) {
+		t.Fatalf("request body is missing type field: %s", bodyStr)
+	}
+}
+
+func TestGeminiStripUnsupportedSchemaFieldsRecursive(t *testing.T) {
+	input := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"name": {
+				"type": "string",
+				"additionalProperties": false,
+				"$comment": "test"
+			},
+			"tags": {
+				"type": "array",
+				"items": {
+					"type": "string",
+					"readOnly": true
+				}
+			}
+		},
+		"required": ["name"],
+		"additionalProperties": false,
+		"$schema": "http://json-schema.org/draft-07/schema#"
+	}`)
+
+	result := stripUnsupportedGeminiSchemaFields(input)
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	// Top-level unsupported fields stripped.
+	if _, ok := parsed["additionalProperties"]; ok {
+		t.Error("additionalProperties should be stripped at top level")
+	}
+	if _, ok := parsed["$schema"]; ok {
+		t.Error("$schema should be stripped at top level")
+	}
+
+	// Supported fields preserved.
+	if _, ok := parsed["type"]; !ok {
+		t.Error("type should be preserved")
+	}
+	if _, ok := parsed["required"]; !ok {
+		t.Error("required should be preserved")
+	}
+
+	// Nested property fields stripped.
+	props := parsed["properties"].(map[string]any)
+	nameProp := props["name"].(map[string]any)
+	if _, ok := nameProp["additionalProperties"]; ok {
+		t.Error("additionalProperties should be stripped from nested property")
+	}
+	if _, ok := nameProp["$comment"]; ok {
+		t.Error("$comment should be stripped from nested property")
+	}
+	if _, ok := nameProp["type"]; !ok {
+		t.Error("type should be preserved in nested property")
+	}
+
+	// Items schema stripped.
+	tagsProp := props["tags"].(map[string]any)
+	items := tagsProp["items"].(map[string]any)
+	if _, ok := items["readOnly"]; ok {
+		t.Error("readOnly should be stripped from items schema")
+	}
+	if _, ok := items["type"]; !ok {
+		t.Error("type should be preserved in items schema")
+	}
+}
+
 func assertGeminiStreamingRequest(t *testing.T, r *http.Request, model string) {
 	t.Helper()
 

--- a/backend/internal/provider/openai_compatible.go
+++ b/backend/internal/provider/openai_compatible.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -306,23 +305,6 @@ type openAIErrorEnvelope struct {
 	} `json:"error"`
 }
 
-func normalizeCredentialError(providerKey string, err error) error {
-	if failure, ok := AsFailure(err); ok {
-		failure.ProviderKey = providerKey
-		return failure
-	}
-	return NewFailure(providerKey, FailureCodeCredentialUnavailable, err.Error(), false, err)
-}
-
-func classifyTransportError(providerKey string, err error) error {
-	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-		return NewFailure(providerKey, FailureCodeTimeout, "provider request timed out", true, err)
-	}
-	if strings.Contains(strings.ToLower(err.Error()), "context deadline exceeded") {
-		return NewFailure(providerKey, FailureCodeTimeout, "provider request timed out", true, err)
-	}
-	return NewFailure(providerKey, FailureCodeUnavailable, "provider request failed", true, err)
-}
 
 func normalizeOpenAIErrorResponse(providerKey string, statusCode int, raw []byte) error {
 	var envelope openAIErrorEnvelope


### PR DESCRIPTION
## Summary

- **Anthropic adapter**: Claude models via Messages API with full tool use and SSE streaming support
- **Gemini adapter**: Google AI models via Gemini API with function calling and SSE streaming
- **OpenRouter + Mistral**: Registered as parameterized OpenAI-compatible endpoints (zero new code)
- **Conformance test suite**: 7 scenarios × 3 adapters = 21 cross-adapter tests ensuring normalized responses
- **Shared utilities**: Extracted `classifyTransportError`, `normalizeCredentialError`, and canonical finish reason normalizers

## Why

The native executor only had an OpenAI adapter. Users couldn't say "run this benchmark on Claude Sonnet vs GPT-4o vs Gemini Pro" without manual provider engineering. This ships the adapter layer that makes multi-provider eval self-serve.

## Before

```
provider.Router
  └── "openai" → OpenAICompatibleClient (api.openai.com)
```

Anthropic/Gemini requests failed with `FailureCodeUnsupportedProvider`.

## After

```mermaid
graph LR
    R[provider.Router] -->|"openai"| OAI[OpenAICompatibleClient<br/>api.openai.com]
    R -->|"anthropic"| ANT[AnthropicClient<br/>api.anthropic.com]
    R -->|"gemini"| GEM[GeminiClient<br/>generativelanguage.googleapis.com]
    R -->|"openrouter"| OR[OpenAICompatibleClient<br/>openrouter.ai/api/v1]
    R -->|"mistral"| MIS[OpenAICompatibleClient<br/>api.mistral.ai/v1]
```

Five provider keys, three adapter implementations. All produce normalized `Response` objects with consistent `Usage`, `FinishReason`, `ToolCalls`, and `Timing`.

## Request Flow

```mermaid
sequenceDiagram
    participant E as NativeExecutor
    participant R as Router
    participant A as Adapter
    participant P as Provider API

    E->>R: InvokeModel(request)
    R->>R: adapters[request.ProviderKey]
    R->>A: InvokeModel(request)
    A->>A: Resolve credential
    A->>A: Map messages + tools to provider format
    A->>P: POST (SSE streaming)
    P-->>A: Stream deltas
    A->>A: StreamAccumulator → normalize Response
    A-->>R: Response{OutputText, ToolCalls, Usage, Timing}
    R-->>E: Response
```

## Adapter Class Hierarchy

```mermaid
classDiagram
    class Client {
        <<interface>>
        +InvokeModel(ctx, Request) Response, error
    }
    class StreamingClient {
        <<interface>>
        +StreamModel(ctx, Request, onDelta) Response, error
    }
    class OpenAICompatibleClient {
        -httpClient
        -baseURL
        -credentialResolver
    }
    class AnthropicClient {
        -httpClient
        -baseURL
        -apiVersion
        -credentialResolver
    }
    class GeminiClient {
        -httpClient
        -baseURL
        -credentialResolver
    }

    Client <|.. OpenAICompatibleClient
    StreamingClient <|.. OpenAICompatibleClient
    Client <|.. AnthropicClient
    StreamingClient <|.. AnthropicClient
    Client <|.. GeminiClient
    StreamingClient <|.. GeminiClient
```

## Provider-Specific Mappings

| Concern | OpenAI | Anthropic | Gemini |
|---------|--------|-----------|--------|
| Auth | Bearer token header | x-api-key header | API key in URL query |
| System prompt | message role | top-level `system` field | `system_instruction` field |
| Assistant role | "assistant" | "assistant" | "model" |
| Tool format | function/parameters | tool_use/input_schema | functionDeclarations |
| Stop → finish | "stop" (passthrough) | "end_turn" → "stop" | "STOP" → "stop" |
| Stream format | SSE data-only | SSE event+data pairs | SSE with alt=sse param |
| Usage fields | prompt/completion_tokens | input/output_tokens | promptTokenCount/candidatesTokenCount |

## Test plan

- [x] 42/42 unit tests pass (`go test ./internal/provider/...`)
- [x] Conformance suite validates identical behavior across all 3 adapters (text, tool calls, errors)
- [x] Anthropic smoke test passes against live API (claude-sonnet-4-20250514, 1.91s)
- [x] Gemini smoke test passes against live API (gemini-2.0-flash, 1.13s)
- [x] Worker binary builds cleanly with all 5 adapters registered
- [ ] Existing OpenAI tests still pass (no regression from shared utility extraction)

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)