### PR TITLE
[codex] Implement composed tool delegation chaining

### DIFF
--- a/backend/internal/challengepack/tools_validation_test.go
+++ b/backend/internal/challengepack/tools_validation_test.go
@@ -242,3 +242,68 @@ tools:
 		t.Fatalf("error = %v, want parameter schema validation", err)
 	}
 }
+
+func TestParseYAML_RejectsCyclicComposedToolDelegation(t *testing.T) {
+	_, err := ParseYAML([]byte(`
+pack:
+  slug: support-eval
+  name: Support Eval
+  family: support
+version:
+  number: 1
+  evaluation_spec:
+    name: support-v1
+    version_number: 1
+    judge_mode: deterministic
+    validators:
+      - key: exact
+        type: exact_match
+        target: final_output
+        expected_from: challenge_input
+    scorecard:
+      dimensions: [correctness]
+challenges:
+  - key: ticket-1
+    title: Ticket One
+    category: support
+    difficulty: medium
+input_sets:
+  - key: default
+    name: Default Inputs
+    cases:
+      - challenge_key: ticket-1
+        case_key: sample-1
+        inputs:
+          - key: prompt
+            kind: text
+            value: hello
+        expectations:
+          - key: answer
+            kind: text
+            source: input:prompt
+tools:
+  custom:
+    - name: toolA
+      description: A
+      parameters:
+        type: object
+      implementation:
+        primitive: toolB
+        args:
+          dummy: value
+    - name: toolB
+      description: B
+      parameters:
+        type: object
+      implementation:
+        primitive: toolA
+        args:
+          dummy: value
+`))
+	if err == nil {
+		t.Fatal("expected ParseYAML to reject cyclic delegation")
+	}
+	if !strings.Contains(err.Error(), "delegation cycle") {
+		t.Fatalf("error = %v, want delegation cycle error", err)
+	}
+}

--- a/backend/internal/challengepack/validation.go
+++ b/backend/internal/challengepack/validation.go
@@ -190,6 +190,56 @@ func validateToolsConfig(path string, tools map[string]any) ValidationErrors {
 		toolPath := fmt.Sprintf("%s.custom[%d]", path, i)
 		errs = append(errs, validateComposedToolConfig(toolPath, custom.Name, custom.Parameters, custom.Implementation)...)
 	}
+
+	delegateMap := map[string]string{}
+	for _, custom := range decoded.Custom {
+		if len(custom.Implementation) == 0 {
+			continue
+		}
+		var impl struct {
+			Type      string `json:"type"`
+			Primitive string `json:"primitive"`
+		}
+		if err := json.Unmarshal(custom.Implementation, &impl); err != nil {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(impl.Type), "mock") {
+			continue
+		}
+		name := strings.TrimSpace(custom.Name)
+		primitive := strings.TrimSpace(impl.Primitive)
+		if name != "" && primitive != "" {
+			delegateMap[name] = primitive
+		}
+	}
+	for name := range delegateMap {
+		visited := map[string]bool{name: true}
+		current := delegateMap[name]
+		depth := 1
+		for {
+			if depth > 8 {
+				errs = append(errs, ValidationError{
+					Field:   path,
+					Message: fmt.Sprintf("tool %q exceeds maximum delegation depth of 8", name),
+				})
+				break
+			}
+			if visited[current] {
+				errs = append(errs, ValidationError{
+					Field:   path,
+					Message: fmt.Sprintf("tool %q has a delegation cycle through %q", name, current),
+				})
+				break
+			}
+			next, exists := delegateMap[current]
+			if !exists {
+				break
+			}
+			visited[current] = true
+			current = next
+			depth++
+		}
+	}
 	return errs
 }
 

--- a/backend/internal/engine/native_executor.go
+++ b/backend/internal/engine/native_executor.go
@@ -466,6 +466,8 @@ func (e NativeExecutor) executeToolCalls(
 			ResolvedToolName:     executionResult.ResolvedToolName,
 			ResolvedToolCategory: executionResult.ResolvedToolCategory,
 			FailureOrigin:        executionResult.FailureOrigin,
+			ResolutionChain:      executionResult.ResolutionChain,
+			FailureDepth:         executionResult.FailureDepth,
 		}
 		if observerErr := e.observer.OnToolExecution(ctx, record); observerErr != nil {
 			return nil, "", false, toolCallsUsed, NewFailure(StopReasonObserverError, "record native tool event", observerErr)

--- a/backend/internal/engine/tool_registry.go
+++ b/backend/internal/engine/tool_registry.go
@@ -174,6 +174,7 @@ func buildToolRegistry(toolPolicy sandbox.ToolPolicy, manifest json.RawMessage, 
 
 	composed := map[string]Tool{}
 	mocks := map[string]Tool{}
+
 	for _, custom := range manifestTools.Custom {
 		tool, disabledReason, err := newManifestCustomTool(custom, secrets)
 		if err != nil {
@@ -197,19 +198,54 @@ func buildToolRegistry(toolPolicy sandbox.ToolPolicy, manifest json.RawMessage, 
 		case ToolCategoryMock:
 			mocks[name] = tool
 		case ToolCategoryComposed:
-			composedTool, ok := tool.(*composedTool)
-			if !ok {
-				return nil, fmt.Errorf("tool %q is marked composed but has unexpected type %T", name, tool)
-			}
-			if _, exists := primitives[composedTool.primitive]; !exists {
-				slog.Default().Warn("disabling composed tool with missing primitive", "tool_name", name, "primitive", composedTool.primitive)
-				continue
-			}
 			composed[name] = tool
 		default:
 			return nil, fmt.Errorf("tool %q has unsupported category %q", name, tool.Category())
 		}
 		visible[name] = tool
+	}
+
+	for name, tool := range composed {
+		ct, ok := tool.(*composedTool)
+		if !ok {
+			return nil, fmt.Errorf("tool %q is marked composed but has unexpected type %T", name, tool)
+		}
+		if _, exists := primitives[ct.primitive]; !exists {
+			if _, exists := composed[ct.primitive]; !exists {
+				if _, exists := mocks[ct.primitive]; !exists {
+					slog.Default().Warn("disabling composed tool with missing delegate", "tool_name", name, "delegate", ct.primitive)
+					delete(composed, name)
+					delete(visible, name)
+					continue
+				}
+			}
+		}
+	}
+
+	for name, tool := range composed {
+		ct := tool.(*composedTool)
+		visited := map[string]bool{name: true}
+		current := ct.primitive
+		depth := 1
+		for {
+			if depth > MaxDelegationDepth {
+				return nil, fmt.Errorf("tool %q exceeds maximum delegation depth of %d", name, MaxDelegationDepth)
+			}
+			if visited[current] {
+				return nil, fmt.Errorf("tool %q has a delegation cycle through %q", name, current)
+			}
+			nextTool, exists := composed[current]
+			if !exists {
+				break
+			}
+			nextCT, ok := nextTool.(*composedTool)
+			if !ok {
+				break
+			}
+			visited[current] = true
+			current = nextCT.primitive
+			depth++
+		}
 	}
 
 	for _, denied := range decodeSnapshotToolOverrides(snapshotConfig).Denied {

--- a/backend/internal/engine/tool_registry.go
+++ b/backend/internal/engine/tool_registry.go
@@ -24,7 +24,11 @@ const (
 	ToolFailureOriginResolution ToolFailureOrigin = "resolution"
 	ToolFailureOriginPrimitive  ToolFailureOrigin = "primitive"
 	ToolFailureOriginDelegation ToolFailureOrigin = "delegation"
+	ToolFailureOriginCycle      ToolFailureOrigin = "cycle"
+	ToolFailureOriginDepth      ToolFailureOrigin = "depth"
 )
+
+const MaxDelegationDepth = 8
 
 type Tool interface {
 	Name() string
@@ -40,6 +44,7 @@ type ToolExecutionRequest struct {
 	ToolPolicy       sandbox.ToolPolicy
 	NetworkAllowlist []string
 	Registry         *Registry
+	DelegationChain  []string
 }
 
 type ToolExecutionResult struct {
@@ -50,6 +55,8 @@ type ToolExecutionResult struct {
 	ResolvedToolName     string
 	ResolvedToolCategory ToolCategory
 	FailureOrigin        ToolFailureOrigin
+	ResolutionChain      []string
+	FailureDepth         int
 }
 
 type ToolExecutionRecord struct {
@@ -59,6 +66,8 @@ type ToolExecutionRecord struct {
 	ResolvedToolName     string
 	ResolvedToolCategory ToolCategory
 	FailureOrigin        ToolFailureOrigin
+	ResolutionChain      []string
+	FailureDepth         int
 }
 
 type Registry struct {

--- a/backend/internal/engine/tool_registry.go
+++ b/backend/internal/engine/tool_registry.go
@@ -205,20 +205,27 @@ func buildToolRegistry(toolPolicy sandbox.ToolPolicy, manifest json.RawMessage, 
 		visible[name] = tool
 	}
 
-	for name, tool := range composed {
-		ct, ok := tool.(*composedTool)
-		if !ok {
-			return nil, fmt.Errorf("tool %q is marked composed but has unexpected type %T", name, tool)
-		}
-		if _, exists := primitives[ct.primitive]; !exists {
-			if _, exists := composed[ct.primitive]; !exists {
-				if _, exists := mocks[ct.primitive]; !exists {
-					slog.Default().Warn("disabling composed tool with missing delegate", "tool_name", name, "delegate", ct.primitive)
-					delete(composed, name)
-					delete(visible, name)
-					continue
+	for {
+		removed := 0
+		for name, tool := range composed {
+			ct, ok := tool.(*composedTool)
+			if !ok {
+				return nil, fmt.Errorf("tool %q is marked composed but has unexpected type %T", name, tool)
+			}
+			if _, exists := primitives[ct.primitive]; !exists {
+				if _, exists := composed[ct.primitive]; !exists {
+					if _, exists := mocks[ct.primitive]; !exists {
+						slog.Default().Warn("disabling composed tool with missing delegate", "tool_name", name, "delegate", ct.primitive)
+						delete(composed, name)
+						delete(visible, name)
+						removed++
+						continue
+					}
 				}
 			}
+		}
+		if removed == 0 {
+			break
 		}
 	}
 

--- a/backend/internal/engine/tool_registry.go
+++ b/backend/internal/engine/tool_registry.go
@@ -363,15 +363,41 @@ func (t *composedTool) Category() ToolCategory {
 }
 
 func (t *composedTool) Execute(ctx context.Context, request ToolExecutionRequest) (ToolExecutionResult, error) {
-	resolvedPrimitive, ok := request.Registry.resolvePrimitive(t.primitive)
+	chain := make([]string, len(request.DelegationChain)+1)
+	copy(chain, request.DelegationChain)
+	chain[len(chain)-1] = t.name
+
+	if len(chain) > MaxDelegationDepth {
+		return t.chainError(
+			fmt.Sprintf("delegation chain exceeded maximum depth of %d", MaxDelegationDepth),
+			"", "", ToolFailureOriginDepth, chain, len(chain)-1,
+		), nil
+	}
+
+	for _, visited := range chain {
+		if visited == t.primitive {
+			return t.chainError(
+				fmt.Sprintf("delegation cycle detected: %s already appears in chain", t.primitive),
+				t.primitive, "", ToolFailureOriginCycle, chain, len(chain)-1,
+			), nil
+		}
+	}
+
+	resolved, ok := request.Registry.resolveAny(t.primitive)
 	if !ok {
-		return t.errorResult("tool is not available in this runtime", t.primitive, ToolCategoryPrimitive, ToolFailureOriginDelegation), nil
+		return t.chainError(
+			"tool is not available in this runtime",
+			t.primitive, "", ToolFailureOriginDelegation, chain, len(chain)-1,
+		), nil
 	}
 
 	args := map[string]any{}
 	if len(request.Args) > 0 {
 		if err := json.Unmarshal(request.Args, &args); err != nil {
-			return t.errorResult("arguments must be valid JSON", resolvedPrimitive.Name(), resolvedPrimitive.Category(), ToolFailureOriginResolution), nil
+			return t.chainError(
+				"arguments must be valid JSON",
+				resolved.Name(), resolved.Category(), ToolFailureOriginResolution, chain, len(chain)-1,
+			), nil
 		}
 	}
 	if args == nil {
@@ -384,41 +410,58 @@ func (t *composedTool) Execute(ctx context.Context, request ToolExecutionRequest
 		errorOnMissingParams: true,
 	})
 	if err != nil {
-		return t.errorResult(err.Error(), resolvedPrimitive.Name(), resolvedPrimitive.Category(), ToolFailureOriginResolution), nil
+		return t.chainError(
+			err.Error(),
+			resolved.Name(), resolved.Category(), ToolFailureOriginResolution, chain, len(chain)-1,
+		), nil
 	}
 
 	encodedArgs, err := json.Marshal(resolvedArgs)
 	if err != nil {
-		return t.errorResult("failed to encode delegated tool arguments", resolvedPrimitive.Name(), resolvedPrimitive.Category(), ToolFailureOriginResolution), nil
+		return t.chainError(
+			"failed to encode delegated tool arguments",
+			resolved.Name(), resolved.Category(), ToolFailureOriginResolution, chain, len(chain)-1,
+		), nil
 	}
 
-	result, execErr := resolvedPrimitive.Execute(ctx, ToolExecutionRequest{
+	result, execErr := resolved.Execute(ctx, ToolExecutionRequest{
 		Args:             encodedArgs,
 		Session:          request.Session,
 		ToolPolicy:       request.ToolPolicy,
 		NetworkAllowlist: append([]string(nil), request.NetworkAllowlist...),
 		Registry:         request.Registry,
+		DelegationChain:  chain,
 	})
 	if execErr != nil {
 		return ToolExecutionResult{}, execErr
 	}
 
-	result.ResolvedToolName = resolvedPrimitive.Name()
-	result.ResolvedToolCategory = resolvedPrimitive.Category()
+	if result.ResolutionChain == nil {
+		result.ResolutionChain = append(chain, resolved.Name())
+	}
+	if resolved.Category() == ToolCategoryPrimitive {
+		result.ResolvedToolName = resolved.Name()
+		result.ResolvedToolCategory = resolved.Category()
+	}
+
 	if result.IsError {
-		result.FailureOrigin = ToolFailureOriginPrimitive
+		if result.FailureOrigin == "" {
+			result.FailureOrigin = ToolFailureOriginPrimitive
+		}
 		result.Content = encodeToolErrorMessage(fmt.Sprintf("%s failed: %s", t.name, decodeToolErrorMessage(result.Content)))
 	}
 	return result, nil
 }
 
-func (t *composedTool) errorResult(message string, resolvedToolName string, resolvedToolCategory ToolCategory, failureOrigin ToolFailureOrigin) ToolExecutionResult {
+func (t *composedTool) chainError(message string, resolvedName string, resolvedCategory ToolCategory, origin ToolFailureOrigin, chain []string, depth int) ToolExecutionResult {
 	return ToolExecutionResult{
 		Content:              encodeToolErrorMessage(fmt.Sprintf("%s failed: %s", t.name, message)),
 		IsError:              true,
-		ResolvedToolName:     resolvedToolName,
-		ResolvedToolCategory: resolvedToolCategory,
-		FailureOrigin:        failureOrigin,
+		ResolvedToolName:     resolvedName,
+		ResolvedToolCategory: resolvedCategory,
+		FailureOrigin:        origin,
+		ResolutionChain:      chain,
+		FailureDepth:         depth,
 	}
 }
 

--- a/backend/internal/engine/tool_registry.go
+++ b/backend/internal/engine/tool_registry.go
@@ -482,7 +482,7 @@ func (t *composedTool) Execute(ctx context.Context, request ToolExecutionRequest
 	if result.ResolutionChain == nil {
 		result.ResolutionChain = append(chain, resolved.Name())
 	}
-	if resolved.Category() == ToolCategoryPrimitive {
+	if resolved.Category() != ToolCategoryComposed {
 		result.ResolvedToolName = resolved.Name()
 		result.ResolvedToolCategory = resolved.Category()
 	}

--- a/backend/internal/engine/tool_registry_test.go
+++ b/backend/internal/engine/tool_registry_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/provider"
@@ -564,5 +566,218 @@ func assertRegistryVisibleTools(t *testing.T, registry *Registry, want ...string
 		if _, ok := registry.Resolve(name); !ok {
 			t.Fatalf("tool %q was not visible", name)
 		}
+	}
+}
+
+type passthroughPrimitive struct{ name string }
+
+func (p passthroughPrimitive) Name() string {
+	return p.name
+}
+
+func (p passthroughPrimitive) Description() string {
+	return "passthrough"
+}
+
+func (p passthroughPrimitive) Parameters() json.RawMessage {
+	return json.RawMessage(`{"type":"object"}`)
+}
+
+func (p passthroughPrimitive) Category() ToolCategory {
+	return ToolCategoryPrimitive
+}
+
+func (p passthroughPrimitive) Execute(_ context.Context, req ToolExecutionRequest) (ToolExecutionResult, error) {
+	return ToolExecutionResult{Content: string(req.Args)}, nil
+}
+
+func TestComposedTool_ChainsComposedToComposed(t *testing.T) {
+	inner, _, err := newManifestCustomTool(manifestCustomToolConfig{
+		Name:           "inner",
+		Description:    "inner tool",
+		Parameters:     json.RawMessage(`{"type":"object","properties":{"val":{"type":"string"}}}`),
+		Implementation: json.RawMessage(`{"primitive":"passthrough","args":{"val":"${val}"}}`),
+	}, nil)
+	if err != nil {
+		t.Fatalf("create inner: %v", err)
+	}
+	outer, _, err := newManifestCustomTool(manifestCustomToolConfig{
+		Name:           "outer",
+		Description:    "outer tool",
+		Parameters:     json.RawMessage(`{"type":"object","properties":{"val":{"type":"string"}}}`),
+		Implementation: json.RawMessage(`{"primitive":"inner","args":{"val":"${val}"}}`),
+	}, nil)
+	if err != nil {
+		t.Fatalf("create outer: %v", err)
+	}
+
+	registry := &Registry{
+		primitives: map[string]Tool{"passthrough": passthroughPrimitive{name: "passthrough"}},
+		composed:   map[string]Tool{"inner": inner},
+	}
+	result, execErr := outer.Execute(t.Context(), ToolExecutionRequest{
+		Args:     json.RawMessage(`{"val":"hello"}`),
+		Registry: registry,
+	})
+	if execErr != nil {
+		t.Fatalf("Execute returned error: %v", execErr)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.Content)
+	}
+	if result.ResolvedToolName != "passthrough" {
+		t.Fatalf("ResolvedToolName = %q, want passthrough", result.ResolvedToolName)
+	}
+	if len(result.ResolutionChain) != 3 {
+		t.Fatalf("ResolutionChain length = %d, want 3", len(result.ResolutionChain))
+	}
+	if result.ResolutionChain[0] != "outer" || result.ResolutionChain[1] != "inner" || result.ResolutionChain[2] != "passthrough" {
+		t.Fatalf("ResolutionChain = %v, want [outer inner passthrough]", result.ResolutionChain)
+	}
+}
+
+func TestComposedTool_DetectsCycleAtRuntime(t *testing.T) {
+	toolA, _, err := newManifestCustomTool(manifestCustomToolConfig{
+		Name:           "toolA",
+		Description:    "A",
+		Parameters:     json.RawMessage(`{"type":"object"}`),
+		Implementation: json.RawMessage(`{"primitive":"toolB","args":{}}`),
+	}, nil)
+	if err != nil {
+		t.Fatalf("create toolA: %v", err)
+	}
+	toolB, _, err := newManifestCustomTool(manifestCustomToolConfig{
+		Name:           "toolB",
+		Description:    "B",
+		Parameters:     json.RawMessage(`{"type":"object"}`),
+		Implementation: json.RawMessage(`{"primitive":"toolA","args":{}}`),
+	}, nil)
+	if err != nil {
+		t.Fatalf("create toolB: %v", err)
+	}
+
+	registry := &Registry{
+		primitives: map[string]Tool{},
+		composed:   map[string]Tool{"toolA": toolA, "toolB": toolB},
+	}
+	result, execErr := toolA.Execute(t.Context(), ToolExecutionRequest{Registry: registry})
+	if execErr != nil {
+		t.Fatalf("Execute returned error: %v", execErr)
+	}
+	if !result.IsError {
+		t.Fatal("expected cycle error")
+	}
+	if result.FailureOrigin != ToolFailureOriginCycle {
+		t.Fatalf("FailureOrigin = %q, want cycle", result.FailureOrigin)
+	}
+}
+
+func TestComposedTool_EnforcesDepthCap(t *testing.T) {
+	tools := map[string]Tool{}
+	for i := MaxDelegationDepth + 1; i >= 1; i-- {
+		name := fmt.Sprintf("tool_%d", i)
+		delegate := "terminal"
+		if i > 1 {
+			delegate = fmt.Sprintf("tool_%d", i-1)
+		}
+		tool, _, err := newManifestCustomTool(manifestCustomToolConfig{
+			Name:           name,
+			Description:    name,
+			Parameters:     json.RawMessage(`{"type":"object"}`),
+			Implementation: json.RawMessage(fmt.Sprintf(`{"primitive":"%s","args":{}}`, delegate)),
+		}, nil)
+		if err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+		tools[name] = tool
+	}
+
+	registry := &Registry{
+		primitives: map[string]Tool{"terminal": passthroughPrimitive{name: "terminal"}},
+		composed:   tools,
+	}
+	entry := fmt.Sprintf("tool_%d", MaxDelegationDepth+1)
+	result, execErr := tools[entry].Execute(t.Context(), ToolExecutionRequest{Registry: registry})
+	if execErr != nil {
+		t.Fatalf("Execute returned error: %v", execErr)
+	}
+	if !result.IsError {
+		t.Fatal("expected depth cap error")
+	}
+	if result.FailureOrigin != ToolFailureOriginDepth {
+		t.Fatalf("FailureOrigin = %q, want depth", result.FailureOrigin)
+	}
+}
+
+func TestComposedTool_ReportsFailureDepthInChain(t *testing.T) {
+	middle, _, err := newManifestCustomTool(manifestCustomToolConfig{
+		Name:           "middle",
+		Description:    "middle",
+		Parameters:     json.RawMessage(`{"type":"object","properties":{"required_param":{"type":"string"}}}`),
+		Implementation: json.RawMessage(`{"primitive":"submit","args":{"answer":"${required_param}"}}`),
+	}, nil)
+	if err != nil {
+		t.Fatalf("create middle: %v", err)
+	}
+	outer, _, err := newManifestCustomTool(manifestCustomToolConfig{
+		Name:           "outer",
+		Description:    "outer",
+		Parameters:     json.RawMessage(`{"type":"object"}`),
+		Implementation: json.RawMessage(`{"primitive":"middle","args":{}}`),
+	}, nil)
+	if err != nil {
+		t.Fatalf("create outer: %v", err)
+	}
+
+	registry := &Registry{
+		primitives: map[string]Tool{"submit": nativePrimitiveTools(sandbox.ToolPolicy{})["submit"]},
+		composed:   map[string]Tool{"middle": middle},
+	}
+	result, execErr := outer.Execute(t.Context(), ToolExecutionRequest{Registry: registry})
+	if execErr != nil {
+		t.Fatalf("Execute returned error: %v", execErr)
+	}
+	if !result.IsError {
+		t.Fatal("expected resolution error at middle level")
+	}
+	if result.FailureDepth != 1 {
+		t.Fatalf("FailureDepth = %d, want 1", result.FailureDepth)
+	}
+}
+
+func TestBuildToolRegistry_TwoPassAllowsOutOfOrderComposedTools(t *testing.T) {
+	registry, err := buildToolRegistry(
+		sandbox.ToolPolicy{},
+		[]byte(`{"tools":{"custom":[
+			{"name":"outer","description":"outer","parameters":{"type":"object"},"implementation":{"primitive":"inner","args":{}}},
+			{"name":"inner","description":"inner","parameters":{"type":"object"},"implementation":{"primitive":"submit","args":{"answer":"done"}}}
+		]}}`),
+		nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("buildToolRegistry returned error: %v", err)
+	}
+	if _, ok := registry.Resolve("outer"); !ok {
+		t.Fatal("outer should be visible")
+	}
+	if _, ok := registry.Resolve("inner"); !ok {
+		t.Fatal("inner should be visible")
+	}
+}
+
+func TestBuildToolRegistry_RejectsStaticCycle(t *testing.T) {
+	_, err := buildToolRegistry(
+		sandbox.ToolPolicy{},
+		[]byte(`{"tools":{"custom":[
+			{"name":"toolA","description":"A","parameters":{"type":"object"},"implementation":{"primitive":"toolB","args":{}}},
+			{"name":"toolB","description":"B","parameters":{"type":"object"},"implementation":{"primitive":"toolA","args":{}}}
+		]}}`),
+		nil, nil,
+	)
+	if err == nil {
+		t.Fatal("expected cycle error from buildToolRegistry")
+	}
+	if !strings.Contains(err.Error(), "delegation cycle") {
+		t.Fatalf("error = %v, want delegation cycle error", err)
 	}
 }

--- a/backend/internal/engine/tool_registry_test.go
+++ b/backend/internal/engine/tool_registry_test.go
@@ -781,3 +781,23 @@ func TestBuildToolRegistry_RejectsStaticCycle(t *testing.T) {
 		t.Fatalf("error = %v, want delegation cycle error", err)
 	}
 }
+
+func TestBuildToolRegistry_CascadesRemovalWhenDelegateChainBreaks(t *testing.T) {
+	registry, err := buildToolRegistry(
+		sandbox.ToolPolicy{},
+		[]byte(`{"tools":{"custom":[
+			{"name":"smart_exec","description":"S","parameters":{"type":"object"},"implementation":{"primitive":"safe_exec","args":{}}},
+			{"name":"safe_exec","description":"S","parameters":{"type":"object"},"implementation":{"primitive":"exec","args":{"command":["echo","hi"]}}}
+		]}}`),
+		nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("buildToolRegistry returned error: %v", err)
+	}
+	if _, ok := registry.Resolve("smart_exec"); ok {
+		t.Fatal("smart_exec should be removed when its delegate chain is broken")
+	}
+	if _, ok := registry.Resolve("safe_exec"); ok {
+		t.Fatal("safe_exec should be removed when its delegate is missing")
+	}
+}

--- a/backend/internal/engine/tool_registry_test.go
+++ b/backend/internal/engine/tool_registry_test.go
@@ -636,6 +636,46 @@ func TestComposedTool_ChainsComposedToComposed(t *testing.T) {
 	}
 }
 
+func TestComposedTool_ReportsTerminalMockResolution(t *testing.T) {
+	tool, _, err := newManifestCustomTool(manifestCustomToolConfig{
+		Name:           "outer",
+		Description:    "outer tool",
+		Parameters:     json.RawMessage(`{"type":"object"}`),
+		Implementation: json.RawMessage(`{"primitive":"mock_lookup","args":{}}`),
+	}, nil)
+	if err != nil {
+		t.Fatalf("create outer: %v", err)
+	}
+	mock, _, err := newManifestCustomTool(manifestCustomToolConfig{
+		Name:           "mock_lookup",
+		Description:    "mock lookup",
+		Parameters:     json.RawMessage(`{"type":"object"}`),
+		Implementation: json.RawMessage(`{"type":"mock","strategy":"static","response":{"ok":true}}`),
+	}, nil)
+	if err != nil {
+		t.Fatalf("create mock: %v", err)
+	}
+
+	registry := &Registry{
+		primitives: map[string]Tool{},
+		composed:   map[string]Tool{},
+		mocks:      map[string]Tool{"mock_lookup": mock},
+	}
+	result, execErr := tool.Execute(t.Context(), ToolExecutionRequest{Registry: registry})
+	if execErr != nil {
+		t.Fatalf("Execute returned error: %v", execErr)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.Content)
+	}
+	if result.ResolvedToolName != "mock_lookup" {
+		t.Fatalf("ResolvedToolName = %q, want mock_lookup", result.ResolvedToolName)
+	}
+	if result.ResolvedToolCategory != ToolCategoryMock {
+		t.Fatalf("ResolvedToolCategory = %q, want mock", result.ResolvedToolCategory)
+	}
+}
+
 func TestComposedTool_DetectsCycleAtRuntime(t *testing.T) {
 	toolA, _, err := newManifestCustomTool(manifestCustomToolConfig{
 		Name:           "toolA",

--- a/backend/internal/engine/tool_registry_test.go
+++ b/backend/internal/engine/tool_registry_test.go
@@ -803,6 +803,24 @@ func TestBuildToolRegistry_TwoPassAllowsOutOfOrderComposedTools(t *testing.T) {
 	if _, ok := registry.Resolve("inner"); !ok {
 		t.Fatal("inner should be visible")
 	}
+
+	outer, ok := registry.Resolve("outer")
+	if !ok {
+		t.Fatal("outer should resolve for execution")
+	}
+	result, execErr := outer.Execute(t.Context(), ToolExecutionRequest{Registry: registry})
+	if execErr != nil {
+		t.Fatalf("Execute returned error: %v", execErr)
+	}
+	if result.IsError {
+		t.Fatalf("expected out-of-order chain to execute successfully, got error: %s", result.Content)
+	}
+	if !result.Completed {
+		t.Fatal("expected chain to reach submit and complete")
+	}
+	if result.FinalOutput != "done" {
+		t.Fatalf("FinalOutput = %q, want done", result.FinalOutput)
+	}
 }
 
 func TestBuildToolRegistry_RejectsStaticCycle(t *testing.T) {

--- a/backend/internal/worker/native_event_observer.go
+++ b/backend/internal/worker/native_event_observer.go
@@ -182,7 +182,9 @@ func (o *NativeRunEventObserver) OnToolExecution(ctx context.Context, record eng
 	}
 	if len(record.ResolutionChain) > 1 {
 		payload["resolution_chain"] = record.ResolutionChain
-		payload["failure_depth"] = record.FailureDepth
+		if record.Result.IsError {
+			payload["failure_depth"] = record.FailureDepth
+		}
 	}
 
 	return o.recordEvent(ctx, eventType, payload, runevents.SummaryMetadata{

--- a/backend/internal/worker/native_event_observer.go
+++ b/backend/internal/worker/native_event_observer.go
@@ -180,6 +180,10 @@ func (o *NativeRunEventObserver) OnToolExecution(ctx context.Context, record eng
 	if record.FailureOrigin != "" {
 		payload["failure_origin"] = record.FailureOrigin
 	}
+	if len(record.ResolutionChain) > 1 {
+		payload["resolution_chain"] = record.ResolutionChain
+		payload["failure_depth"] = record.FailureDepth
+	}
 
 	return o.recordEvent(ctx, eventType, payload, runevents.SummaryMetadata{
 		Status:        status,

--- a/backend/internal/worker/native_event_observer_test.go
+++ b/backend/internal/worker/native_event_observer_test.go
@@ -179,6 +179,49 @@ func TestNativeRunEventObserverRecordsFailureOriginForToolFailures(t *testing.T)
 	}
 }
 
+func TestNativeRunEventObserverOmitsFailureDepthForSuccessfulChains(t *testing.T) {
+	recorder := &fakeRunEventRecorder{}
+	observer := &NativeRunEventObserver{
+		recorder:         recorder,
+		executionContext: nativeModelExecutionContext(),
+	}
+
+	err := observer.OnToolExecution(context.Background(), engine.ToolExecutionRecord{
+		ToolCall: provider.ToolCall{
+			ID:        "call-2",
+			Name:      "outer",
+			Arguments: []byte(`{"val":"hello"}`),
+		},
+		Result: provider.ToolResult{
+			ToolCallID: "call-2",
+			Content:    `{"val":"hello"}`,
+			IsError:    false,
+		},
+		ToolCategory:         engine.ToolCategoryComposed,
+		ResolvedToolName:     "passthrough",
+		ResolvedToolCategory: engine.ToolCategoryPrimitive,
+		ResolutionChain:      []string{"outer", "inner", "passthrough"},
+		FailureDepth:         0,
+	})
+	if err != nil {
+		t.Fatalf("OnToolExecution returned error: %v", err)
+	}
+	if len(recorder.events) != 2 {
+		t.Fatalf("event count = %d, want 2 including run start", len(recorder.events))
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(recorder.events[1].Payload, &payload); err != nil {
+		t.Fatalf("decode tool payload: %v", err)
+	}
+	if _, ok := payload["failure_depth"]; ok {
+		t.Fatalf("failure_depth should be omitted for successful chained executions: %#v", payload)
+	}
+	if got, ok := payload["resolution_chain"].([]any); !ok || len(got) != 3 {
+		t.Fatalf("resolution_chain = %#v, want 3-item chain", payload["resolution_chain"])
+	}
+}
+
 type fakeRunEventRecorder struct {
 	events []repository.RunEvent
 }

--- a/testing/codex-issue-187-strict-plan.md
+++ b/testing/codex-issue-187-strict-plan.md
@@ -36,8 +36,8 @@ N/A — not applicable for this change. This work stays inside backend engine, v
 Manual verification is code-level for this backend-only change.
 
 ```bash
-cd /Users/atharva/agentclash/backend && go build ./...
-cd /Users/atharva/agentclash/backend && go test ./... -count=1
+cd backend && go build ./...
+cd backend && go test ./... -count=1
 ```
 
 Expected:

--- a/testing/codex-issue-187-strict-plan.md
+++ b/testing/codex-issue-187-strict-plan.md
@@ -1,0 +1,47 @@
+# codex/issue-187-strict-plan — Test Contract
+
+## Functional Behavior
+Implement composed-tool delegation chaining exactly as specified in issue #187 and its linked implementation plan.
+- A composed tool may delegate to another composed tool through the existing `primitive` field; declaration order must not matter.
+- Delegation resolution must use `resolveAny()` so hidden tools can still participate in the chain.
+- Runtime execution must track the full delegation chain and enforce a hard maximum chain depth of `8`.
+- Runtime execution must detect delegation cycles and surface them as structured tool errors.
+- Failure metadata must preserve nested wrapping per level and include `ResolutionChain` plus `FailureDepth`.
+- Parameter visibility must remain explicit passthrough only; delegated tools only receive args provided by their caller.
+- Tool execution telemetry must include `resolution_chain` and `failure_depth` only when the chain length is greater than `1`.
+- Validation must reject cyclic or over-depth composed-tool declarations before execution.
+
+## Unit Tests
+The following unit coverage must exist and pass.
+- `TestComposedTool_ChainsComposedToComposed` — two-level composed delegation reaches the terminal primitive and records full chain metadata.
+- `TestComposedTool_DetectsCycleAtRuntime` — runtime cycle detection returns a structured cycle failure.
+- `TestComposedTool_EnforcesDepthCap` — runtime execution fails when delegation exceeds `MaxDelegationDepth`.
+- `TestComposedTool_ReportsFailureDepthInChain` — resolution failures inside a chain report the correct failure depth.
+- `TestBuildToolRegistry_TwoPassAllowsOutOfOrderComposedTools` — registry build succeeds when composed tools are declared out of order.
+- `TestBuildToolRegistry_RejectsStaticCycle` — registry build rejects static composed-tool cycles.
+- Existing `TestBuildToolRegistry*` coverage continues to pass after the two-pass registration change.
+
+## Integration / Functional Tests
+N/A — not applicable for this change per the locked implementation plan, which explicitly limits testing to unit, registry-build, and validation coverage.
+
+## Smoke Tests
+- `cd backend && go build ./...`
+- `cd backend && go test ./internal/engine/... -run TestBuildToolRegistry`
+- `cd backend && go test ./internal/engine/... ./internal/challengepack/... -v -count=1`
+
+## E2E Tests
+N/A — not applicable for this change. This work stays inside backend engine, validation, and native telemetry plumbing.
+
+## Manual / cURL Tests
+Manual verification is code-level for this backend-only change.
+
+```bash
+cd /Users/atharva/agentclash/backend && go build ./...
+cd /Users/atharva/agentclash/backend && go test ./... -count=1
+```
+
+Expected:
+- Build succeeds without compile errors.
+- All backend tests pass.
+- New chain metadata only appears for multi-level delegation events.
+- Validation and registry build reject cyclic chains before runtime where applicable.


### PR DESCRIPTION
## What changed

Implements issue #187 by allowing composed tools to delegate through other composed tools before reaching a terminal primitive or mock.

The change adds:
- chained composed-tool resolution through `resolveAny()`
- runtime cycle detection and a hard delegation depth cap of `8`
- two-pass custom tool registration so declaration order does not matter
- structured resolution metadata via `ResolutionChain` and `FailureDepth`
- telemetry pass-through for multi-level delegation chains
- validation-time detection of cyclic composed-tool graphs
- focused unit and validation coverage for the new chain behavior

## Why this changed

Issue #187 extends the composed-tool template engine so a composed tool can reference another composed tool in its `primitive` field. Without this, delegation stopped after one level and could not support multi-level tool wrappers.

## Impact

This unlocks composed -> composed -> primitive delegation while preserving explicit parameter passthrough, adding better failure reporting, and rejecting invalid delegation graphs earlier.

## Validation

- `cd backend && go build ./...`
- `cd backend && go test ./internal/engine/... -run TestBuildToolRegistry -count=1`
- `cd backend && go test ./internal/engine/... ./internal/challengepack/... -v -count=1`
- `cd backend && go build ./... && go test ./... -count=1`
