### PR TITLE
fix(retry): enable Temporal retries, respect rate limit backoff, classify sandbox errors

### DIFF
--- a/backend/internal/engine/native_executor.go
+++ b/backend/internal/engine/native_executor.go
@@ -20,6 +20,7 @@ const (
 	defaultSandboxWorkingDirectory = "/workspace"
 	defaultRetryAttempts           = 3
 	defaultRetryBackoff            = 250 * time.Millisecond
+	rateLimitMinBackoff            = 2 * time.Second
 	defaultSandboxTTL              = 60 * time.Minute
 	sandboxBootBuffer              = 20 * time.Second
 	sandboxCleanupTimeout          = 15 * time.Second
@@ -366,7 +367,8 @@ func (e NativeExecutor) invokeWithRetries(ctx context.Context, request provider.
 		}
 
 		lastErr = err
-		timer := time.NewTimer(backoff)
+		wait := retryBackoff(failure, backoff)
+		timer := time.NewTimer(wait)
 		select {
 		case <-ctx.Done():
 			timer.Stop()
@@ -397,6 +399,16 @@ func isTransientProviderCode(code provider.FailureCode) bool {
 	return code == provider.FailureCodeRateLimit ||
 		code == provider.FailureCodeTimeout ||
 		code == provider.FailureCodeUnavailable
+}
+
+func retryBackoff(failure provider.Failure, baseBackoff time.Duration) time.Duration {
+	if failure.RetryAfter > 0 {
+		return failure.RetryAfter + 1*time.Second
+	}
+	if failure.Code == provider.FailureCodeRateLimit && baseBackoff < rateLimitMinBackoff {
+		return rateLimitMinBackoff
+	}
+	return baseBackoff
 }
 
 func (e NativeExecutor) executeToolCalls(

--- a/backend/internal/engine/native_executor_test.go
+++ b/backend/internal/engine/native_executor_test.go
@@ -1020,3 +1020,49 @@ func TestExtractWorkspaceFixtureFilesRejectsMalformedWorkspaceInput(t *testing.T
 		t.Fatalf("error = %v, want array shape validation", err)
 	}
 }
+
+func TestRetryBackoffUsesRetryAfterHint(t *testing.T) {
+	failure := provider.Failure{
+		Code:       provider.FailureCodeRateLimit,
+		Retryable:  true,
+		RetryAfter: 20 * time.Second,
+	}
+	got := retryBackoff(failure, 250*time.Millisecond)
+	want := 21 * time.Second
+	if got != want {
+		t.Fatalf("retryBackoff = %s, want %s (RetryAfter + 1s)", got, want)
+	}
+}
+
+func TestRetryBackoffRateLimitFloor(t *testing.T) {
+	failure := provider.Failure{
+		Code:      provider.FailureCodeRateLimit,
+		Retryable: true,
+	}
+	got := retryBackoff(failure, 250*time.Millisecond)
+	if got != rateLimitMinBackoff {
+		t.Fatalf("retryBackoff = %s, want %s (rate limit floor)", got, rateLimitMinBackoff)
+	}
+}
+
+func TestRetryBackoffRateLimitAboveFloor(t *testing.T) {
+	failure := provider.Failure{
+		Code:      provider.FailureCodeRateLimit,
+		Retryable: true,
+	}
+	got := retryBackoff(failure, 5*time.Second)
+	if got != 5*time.Second {
+		t.Fatalf("retryBackoff = %s, want 5s (above floor, no hint)", got)
+	}
+}
+
+func TestRetryBackoffNonRateLimitUsesExponentialBackoff(t *testing.T) {
+	failure := provider.Failure{
+		Code:      provider.FailureCodeTimeout,
+		Retryable: true,
+	}
+	got := retryBackoff(failure, 250*time.Millisecond)
+	if got != 250*time.Millisecond {
+		t.Fatalf("retryBackoff = %s, want 250ms (no floor for non-rate-limit)", got)
+	}
+}

--- a/backend/internal/provider/anthropic.go
+++ b/backend/internal/provider/anthropic.go
@@ -91,7 +91,7 @@ func (c AnthropicClient) StreamModel(ctx context.Context, request Request, onDel
 		if err != nil {
 			return Response{}, NewFailure(request.ProviderKey, FailureCodeUnavailable, "read provider response", true, err)
 		}
-		return Response{}, normalizeAnthropicErrorResponse(request.ProviderKey, resp.StatusCode, raw)
+		return Response{}, normalizeAnthropicErrorResponse(request.ProviderKey, resp.StatusCode, resp.Header, raw)
 	}
 
 	accumulator := NewStreamAccumulator(request.ProviderKey, startedAt)
@@ -508,7 +508,7 @@ func emitAnthropicDelta(accumulator *StreamAccumulator, onDelta func(StreamDelta
 	return nil
 }
 
-func normalizeAnthropicErrorResponse(providerKey string, statusCode int, raw []byte) error {
+func normalizeAnthropicErrorResponse(providerKey string, statusCode int, header http.Header, raw []byte) error {
 	var envelope anthropicErrorEnvelope
 	if err := json.Unmarshal(raw, &envelope); err != nil {
 		return NewFailure(
@@ -529,9 +529,11 @@ func normalizeAnthropicErrorResponse(providerKey string, statusCode int, raw []b
 	case http.StatusUnauthorized, http.StatusForbidden:
 		return NewFailure(providerKey, FailureCodeAuth, message, false, nil)
 	case http.StatusTooManyRequests:
-		return NewFailure(providerKey, FailureCodeRateLimit, message, true, nil)
+		f := Failure{ProviderKey: providerKey, Code: FailureCodeRateLimit, Message: message, Retryable: true, RetryAfter: parseRetryAfter(header)}
+		return f
 	case 529: // Anthropic overloaded
-		return NewFailure(providerKey, FailureCodeRateLimit, message, true, nil)
+		f := Failure{ProviderKey: providerKey, Code: FailureCodeRateLimit, Message: message, Retryable: true, RetryAfter: parseRetryAfter(header)}
+		return f
 	case http.StatusBadRequest, http.StatusUnprocessableEntity:
 		return NewFailure(providerKey, FailureCodeInvalidRequest, message, false, nil)
 	case http.StatusGatewayTimeout, http.StatusBadGateway, http.StatusServiceUnavailable:

--- a/backend/internal/provider/anthropic_test.go
+++ b/backend/internal/provider/anthropic_test.go
@@ -416,3 +416,34 @@ func assertAnthropicStreamingRequest(t *testing.T, r *http.Request) {
 		t.Fatalf("expected max_tokens to be set")
 	}
 }
+
+func TestAnthropicRateLimitParsesRetryAfterHeader(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+					"Retry-After":  []string{"15.5"},
+				},
+				Body: io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"rate_limit_error","message":"rate limited"}}`)),
+			}, nil
+		}),
+	}
+
+	client := NewAnthropicClient(httpClient, "https://example.com", "", staticCredentialResolver{value: "test-key"})
+	_, err := client.InvokeModel(context.Background(), Request{
+		ProviderKey:         "anthropic",
+		CredentialReference: "env://ANTHROPIC_API_KEY",
+		Model:               "claude-sonnet-4-20250514",
+		Messages:            []Message{{Role: "user", Content: "hello"}},
+	})
+
+	failure, ok := AsFailure(err)
+	if !ok {
+		t.Fatalf("expected provider failure")
+	}
+	if failure.RetryAfter != 15500*time.Millisecond {
+		t.Fatalf("RetryAfter = %s, want 15.5s", failure.RetryAfter)
+	}
+}

--- a/backend/internal/provider/error_classification.go
+++ b/backend/internal/provider/error_classification.go
@@ -2,7 +2,10 @@ package provider
 
 import (
 	"net"
+	"net/http"
+	"strconv"
 	"strings"
+	"time"
 )
 
 func classifyTransportError(providerKey string, err error) error {
@@ -13,6 +16,21 @@ func classifyTransportError(providerKey string, err error) error {
 		return NewFailure(providerKey, FailureCodeTimeout, "provider request timed out", true, err)
 	}
 	return NewFailure(providerKey, FailureCodeUnavailable, "provider request failed", true, err)
+}
+
+func parseRetryAfter(header http.Header) time.Duration {
+	value := strings.TrimSpace(header.Get("Retry-After"))
+	if value == "" {
+		return 0
+	}
+	seconds, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0
+	}
+	if seconds <= 0 {
+		return 0
+	}
+	return time.Duration(seconds * float64(time.Second))
 }
 
 func normalizeCredentialError(providerKey string, err error) error {

--- a/backend/internal/provider/error_classification_test.go
+++ b/backend/internal/provider/error_classification_test.go
@@ -1,0 +1,46 @@
+package provider
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestParseRetryAfterInteger(t *testing.T) {
+	h := http.Header{}
+	h.Set("Retry-After", "20")
+	if got := parseRetryAfter(h); got != 20*time.Second {
+		t.Fatalf("parseRetryAfter = %s, want 20s", got)
+	}
+}
+
+func TestParseRetryAfterFloat(t *testing.T) {
+	h := http.Header{}
+	h.Set("Retry-After", "15.5")
+	if got := parseRetryAfter(h); got != 15500*time.Millisecond {
+		t.Fatalf("parseRetryAfter = %s, want 15.5s", got)
+	}
+}
+
+func TestParseRetryAfterMissing(t *testing.T) {
+	h := http.Header{}
+	if got := parseRetryAfter(h); got != 0 {
+		t.Fatalf("parseRetryAfter = %s, want 0", got)
+	}
+}
+
+func TestParseRetryAfterNonNumeric(t *testing.T) {
+	h := http.Header{}
+	h.Set("Retry-After", "Wed, 21 Oct 2026 07:28:00 GMT")
+	if got := parseRetryAfter(h); got != 0 {
+		t.Fatalf("parseRetryAfter = %s, want 0 for date format", got)
+	}
+}
+
+func TestParseRetryAfterNegative(t *testing.T) {
+	h := http.Header{}
+	h.Set("Retry-After", "-5")
+	if got := parseRetryAfter(h); got != 0 {
+		t.Fatalf("parseRetryAfter = %s, want 0 for negative", got)
+	}
+}

--- a/backend/internal/provider/gemini.go
+++ b/backend/internal/provider/gemini.go
@@ -81,7 +81,7 @@ func (c GeminiClient) StreamModel(ctx context.Context, request Request, onDelta 
 		if err != nil {
 			return Response{}, NewFailure(request.ProviderKey, FailureCodeUnavailable, "read provider response", true, err)
 		}
-		return Response{}, normalizeGeminiErrorResponse(request.ProviderKey, resp.StatusCode, raw)
+		return Response{}, normalizeGeminiErrorResponse(request.ProviderKey, resp.StatusCode, resp.Header, raw)
 	}
 
 	accumulator := NewStreamAccumulator(request.ProviderKey, startedAt)
@@ -522,7 +522,7 @@ func emitGeminiDelta(accumulator *StreamAccumulator, onDelta func(StreamDelta) e
 	return nil
 }
 
-func normalizeGeminiErrorResponse(providerKey string, statusCode int, raw []byte) error {
+func normalizeGeminiErrorResponse(providerKey string, statusCode int, header http.Header, raw []byte) error {
 	var envelope geminiErrorEnvelope
 	if err := json.Unmarshal(raw, &envelope); err != nil {
 		return NewFailure(
@@ -543,7 +543,8 @@ func normalizeGeminiErrorResponse(providerKey string, statusCode int, raw []byte
 	case http.StatusUnauthorized, http.StatusForbidden:
 		return NewFailure(providerKey, FailureCodeAuth, message, false, nil)
 	case http.StatusTooManyRequests:
-		return NewFailure(providerKey, FailureCodeRateLimit, message, true, nil)
+		f := Failure{ProviderKey: providerKey, Code: FailureCodeRateLimit, Message: message, Retryable: true, RetryAfter: parseRetryAfter(header)}
+		return f
 	case http.StatusBadRequest, http.StatusUnprocessableEntity:
 		return NewFailure(providerKey, FailureCodeInvalidRequest, message, false, nil)
 	case http.StatusGatewayTimeout, http.StatusBadGateway, http.StatusServiceUnavailable:

--- a/backend/internal/provider/gemini_test.go
+++ b/backend/internal/provider/gemini_test.go
@@ -468,3 +468,34 @@ func assertGeminiStreamingRequest(t *testing.T, r *http.Request, model string) {
 		t.Fatalf("expected contents in request body")
 	}
 }
+
+func TestGeminiRateLimitParsesRetryAfterHeader(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+					"Retry-After":  []string{"30"},
+				},
+				Body: io.NopCloser(strings.NewReader(`{"error":{"message":"rate limited","status":"RESOURCE_EXHAUSTED","code":429}}`)),
+			}, nil
+		}),
+	}
+
+	client := NewGeminiClient(httpClient, "https://example.com", staticCredentialResolver{value: "test-key"})
+	_, err := client.InvokeModel(context.Background(), Request{
+		ProviderKey:         "gemini",
+		CredentialReference: "env://GEMINI_API_KEY",
+		Model:               "gemini-2.5-pro",
+		Messages:            []Message{{Role: "user", Content: "hello"}},
+	})
+
+	failure, ok := AsFailure(err)
+	if !ok {
+		t.Fatalf("expected provider failure")
+	}
+	if failure.RetryAfter != 30*time.Second {
+		t.Fatalf("RetryAfter = %s, want 30s", failure.RetryAfter)
+	}
+}

--- a/backend/internal/provider/openai_compatible.go
+++ b/backend/internal/provider/openai_compatible.go
@@ -81,7 +81,7 @@ func (c OpenAICompatibleClient) StreamModel(ctx context.Context, request Request
 		if err != nil {
 			return Response{}, NewFailure(request.ProviderKey, FailureCodeUnavailable, "read provider response", true, err)
 		}
-		return Response{}, normalizeOpenAIErrorResponse(request.ProviderKey, resp.StatusCode, raw)
+		return Response{}, normalizeOpenAIErrorResponse(request.ProviderKey, resp.StatusCode, resp.Header, raw)
 	}
 
 	accumulator := NewStreamAccumulator(request.ProviderKey, startedAt)
@@ -306,7 +306,7 @@ type openAIErrorEnvelope struct {
 }
 
 
-func normalizeOpenAIErrorResponse(providerKey string, statusCode int, raw []byte) error {
+func normalizeOpenAIErrorResponse(providerKey string, statusCode int, header http.Header, raw []byte) error {
 	var envelope openAIErrorEnvelope
 	if err := json.Unmarshal(raw, &envelope); err != nil {
 		return NewFailure(
@@ -327,7 +327,8 @@ func normalizeOpenAIErrorResponse(providerKey string, statusCode int, raw []byte
 	case http.StatusUnauthorized, http.StatusForbidden:
 		return NewFailure(providerKey, FailureCodeAuth, message, false, nil)
 	case http.StatusTooManyRequests:
-		return NewFailure(providerKey, FailureCodeRateLimit, message, true, nil)
+		f := Failure{ProviderKey: providerKey, Code: FailureCodeRateLimit, Message: message, Retryable: true, RetryAfter: parseRetryAfter(header)}
+		return f
 	case http.StatusBadRequest, http.StatusUnprocessableEntity:
 		return NewFailure(providerKey, FailureCodeInvalidRequest, message, false, nil)
 	case http.StatusGatewayTimeout, http.StatusBadGateway, http.StatusServiceUnavailable:

--- a/backend/internal/provider/openai_compatible_test.go
+++ b/backend/internal/provider/openai_compatible_test.go
@@ -380,6 +380,103 @@ func assertStreamingRequest(t *testing.T, r *http.Request) {
 	}
 }
 
+func TestOpenAIRateLimitParsesRetryAfterHeader(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+					"Retry-After":  []string{"20"},
+				},
+				Body: io.NopCloser(strings.NewReader(`{"error":{"message":"rate limited","type":"rate_limit_error"}}`)),
+			}, nil
+		}),
+	}
+
+	client := NewOpenAICompatibleClient(httpClient, "https://example.com/v1", staticCredentialResolver{value: "test-key"})
+	_, err := client.InvokeModel(context.Background(), Request{
+		ProviderKey:         "openai",
+		CredentialReference: "env://OPENAI_API_KEY",
+		Model:               "gpt-4.1",
+		Messages:            []Message{{Role: "user", Content: "hello"}},
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	failure, ok := AsFailure(err)
+	if !ok {
+		t.Fatalf("expected provider failure, got %T", err)
+	}
+	if failure.Code != FailureCodeRateLimit {
+		t.Fatalf("failure code = %s, want rate_limit", failure.Code)
+	}
+	if failure.RetryAfter != 20*time.Second {
+		t.Fatalf("RetryAfter = %s, want 20s", failure.RetryAfter)
+	}
+}
+
+func TestOpenAIRateLimitMissingRetryAfterHeader(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Body: io.NopCloser(strings.NewReader(`{"error":{"message":"rate limited","type":"rate_limit_error"}}`)),
+			}, nil
+		}),
+	}
+
+	client := NewOpenAICompatibleClient(httpClient, "https://example.com/v1", staticCredentialResolver{value: "test-key"})
+	_, err := client.InvokeModel(context.Background(), Request{
+		ProviderKey:         "openai",
+		CredentialReference: "env://OPENAI_API_KEY",
+		Model:               "gpt-4.1",
+		Messages:            []Message{{Role: "user", Content: "hello"}},
+	})
+
+	failure, ok := AsFailure(err)
+	if !ok {
+		t.Fatalf("expected provider failure")
+	}
+	if failure.RetryAfter != 0 {
+		t.Fatalf("RetryAfter = %s, want 0", failure.RetryAfter)
+	}
+}
+
+func TestOpenAINon429DoesNotSetRetryAfter(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Body: io.NopCloser(strings.NewReader(`{"error":{"message":"bad key","type":"auth_error"}}`)),
+			}, nil
+		}),
+	}
+
+	client := NewOpenAICompatibleClient(httpClient, "https://example.com/v1", staticCredentialResolver{value: "test-key"})
+	_, err := client.InvokeModel(context.Background(), Request{
+		ProviderKey:         "openai",
+		CredentialReference: "env://OPENAI_API_KEY",
+		Model:               "gpt-4.1",
+		Messages:            []Message{{Role: "user", Content: "hello"}},
+	})
+
+	failure, ok := AsFailure(err)
+	if !ok {
+		t.Fatalf("expected provider failure")
+	}
+	if failure.RetryAfter != 0 {
+		t.Fatalf("RetryAfter = %s, want 0 for auth error", failure.RetryAfter)
+	}
+}
+
 func jsonResponse(statusCode int, body string) *http.Response {
 	return &http.Response{
 		StatusCode: statusCode,

--- a/backend/internal/provider/provider.go
+++ b/backend/internal/provider/provider.go
@@ -79,6 +79,7 @@ type Failure struct {
 	Code        FailureCode
 	Message     string
 	Retryable   bool
+	RetryAfter  time.Duration
 	Cause       error
 }
 

--- a/backend/internal/provider/provider_test.go
+++ b/backend/internal/provider/provider_test.go
@@ -180,6 +180,24 @@ func TestEnvCredentialResolverSupportsEnvReferences(t *testing.T) {
 	}
 }
 
+func TestFailureRetryAfterField(t *testing.T) {
+	f := Failure{
+		ProviderKey: "openai",
+		Code:        FailureCodeRateLimit,
+		Message:     "rate limited",
+		Retryable:   true,
+		RetryAfter:  20 * time.Second,
+	}
+
+	recovered, ok := AsFailure(f)
+	if !ok {
+		t.Fatalf("AsFailure failed to recover failure")
+	}
+	if recovered.RetryAfter != 20*time.Second {
+		t.Fatalf("RetryAfter = %s, want 20s", recovered.RetryAfter)
+	}
+}
+
 func mustTime(t *testing.T, raw string) time.Time {
 	t.Helper()
 

--- a/backend/internal/workflow/activities.go
+++ b/backend/internal/workflow/activities.go
@@ -346,7 +346,11 @@ func wrapActivityError(err error) error {
 		return temporal.NewNonRetryableApplicationError(err.Error(), repositoryTransitionConflictType, err)
 	default:
 		if failure, ok := engine.AsFailure(err); ok {
-			return temporal.NewNonRetryableApplicationError(failure.Error(), engineFailureErrorTypePrefix+string(failure.StopReason), err)
+			errorType := engineFailureErrorTypePrefix + string(failure.StopReason)
+			if failure.StopReason == engine.StopReasonSandboxError {
+				return temporal.NewApplicationError(failure.Error(), errorType, err)
+			}
+			return temporal.NewNonRetryableApplicationError(failure.Error(), errorType, err)
 		}
 		if failure, ok := provider.AsFailure(err); ok {
 			errorType := providerFailureErrorTypePrefix + string(failure.Code)

--- a/backend/internal/workflow/run_agent_workflow.go
+++ b/backend/internal/workflow/run_agent_workflow.go
@@ -6,7 +6,9 @@ import (
 	"time"
 
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/domain"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/engine"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/hostedruns"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/provider"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
 	"github.com/google/uuid"
 	"go.temporal.io/sdk/temporal"
@@ -79,11 +81,35 @@ func executeNativeModelStep(ctx sdkworkflow.Context, input RunAgentWorkflowInput
 }
 
 func nativeModelActivityOptions(executionContext repository.RunAgentExecutionContext) sdkworkflow.ActivityOptions {
-	options := defaultActivityOptions
+	timeout := defaultActivityOptions.StartToCloseTimeout
 	if executionContext.Deployment.RuntimeProfile.RunTimeoutSeconds > 0 {
-		options.StartToCloseTimeout = time.Duration(executionContext.Deployment.RuntimeProfile.RunTimeoutSeconds)*time.Second + nativeActivityBootBuffer + nativeActivityCleanupBuffer
+		timeout = time.Duration(executionContext.Deployment.RuntimeProfile.RunTimeoutSeconds)*time.Second + nativeActivityBootBuffer + nativeActivityCleanupBuffer
 	}
-	return options
+	return sdkworkflow.ActivityOptions{
+		StartToCloseTimeout: timeout,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts:    3,
+			InitialInterval:    10 * time.Second,
+			BackoffCoefficient: 2.0,
+			MaximumInterval:    2 * time.Minute,
+			NonRetryableErrorTypes: []string{
+				repositoryRunNotFoundErrorType,
+				repositoryRunAgentNotFoundErrorType,
+				repositoryFrozenExecutionContextType,
+				repositoryInvalidTransitionType,
+				repositoryTransitionConflictType,
+				engineFailureErrorTypePrefix + string(engine.StopReasonStepLimit),
+				engineFailureErrorTypePrefix + string(engine.StopReasonToolLimit),
+				engineFailureErrorTypePrefix + string(engine.StopReasonTimeout),
+				engineFailureErrorTypePrefix + string(engine.StopReasonProviderError),
+				engineFailureErrorTypePrefix + string(engine.StopReasonObserverError),
+				providerFailureErrorTypePrefix + string(provider.FailureCodeAuth),
+				providerFailureErrorTypePrefix + string(provider.FailureCodeInvalidRequest),
+				providerFailureErrorTypePrefix + string(provider.FailureCodeUnsupportedProvider),
+				providerFailureErrorTypePrefix + string(provider.FailureCodeCredentialUnavailable),
+			},
+		},
+	}
 }
 
 func runHostedRunAgent(ctx sdkworkflow.Context, input RunAgentWorkflowInput, executionContext repository.RunAgentExecutionContext) error {

--- a/backend/internal/workflow/run_workflow.go
+++ b/backend/internal/workflow/run_workflow.go
@@ -150,7 +150,8 @@ func scoreEvaluatingRunAgents(ctx sdkworkflow.Context, runAgents []domain.RunAge
 	scoreCtx := sdkworkflow.WithActivityOptions(ctx, sdkworkflow.ActivityOptions{
 		StartToCloseTimeout: scoreRunAgentTimeout,
 		RetryPolicy: &temporal.RetryPolicy{
-			MaximumAttempts: 1,
+			MaximumAttempts: 2,
+			InitialInterval: 5 * time.Second,
 		},
 	})
 	selector := sdkworkflow.NewSelector(ctx)

--- a/backend/internal/workflow/workflow_test.go
+++ b/backend/internal/workflow/workflow_test.go
@@ -1507,3 +1507,139 @@ func equalRunAgentStatuses(left []domain.RunAgentStatus, right []domain.RunAgent
 
 	return true
 }
+
+func TestDefaultActivityOptionsNoRetry(t *testing.T) {
+	if defaultActivityOptions.RetryPolicy == nil {
+		t.Fatalf("defaultActivityOptions should have a retry policy")
+	}
+	if defaultActivityOptions.RetryPolicy.MaximumAttempts != 1 {
+		t.Fatalf("default maximum attempts = %d, want 1", defaultActivityOptions.RetryPolicy.MaximumAttempts)
+	}
+}
+
+func TestNativeModelActivityOptionsNonRetryableTypes(t *testing.T) {
+	executionContext := nativeExecutionContext(uuid.New(), uuid.New())
+	options := nativeModelActivityOptions(executionContext)
+
+	nonRetryable := options.RetryPolicy.NonRetryableErrorTypes
+	expected := []string{
+		repositoryRunNotFoundErrorType,
+		repositoryRunAgentNotFoundErrorType,
+		repositoryFrozenExecutionContextType,
+		repositoryInvalidTransitionType,
+		repositoryTransitionConflictType,
+		engineFailureErrorTypePrefix + string(engine.StopReasonStepLimit),
+		engineFailureErrorTypePrefix + string(engine.StopReasonToolLimit),
+		engineFailureErrorTypePrefix + string(engine.StopReasonTimeout),
+		engineFailureErrorTypePrefix + string(engine.StopReasonProviderError),
+		engineFailureErrorTypePrefix + string(engine.StopReasonObserverError),
+		providerFailureErrorTypePrefix + string(provider.FailureCodeAuth),
+		providerFailureErrorTypePrefix + string(provider.FailureCodeInvalidRequest),
+		providerFailureErrorTypePrefix + string(provider.FailureCodeUnsupportedProvider),
+		providerFailureErrorTypePrefix + string(provider.FailureCodeCredentialUnavailable),
+	}
+	if len(nonRetryable) != len(expected) {
+		t.Fatalf("non-retryable types count = %d, want %d", len(nonRetryable), len(expected))
+	}
+	for i, want := range expected {
+		if nonRetryable[i] != want {
+			t.Fatalf("non-retryable[%d] = %q, want %q", i, nonRetryable[i], want)
+		}
+	}
+}
+
+func TestExecuteNativeModelStepRetryableRateLimitIsRetryable(t *testing.T) {
+	runAgentID := uuid.New()
+	executionContext := nativeExecutionContext(uuid.New(), runAgentID)
+	repo := newFakeRunRepository(
+		fixtureRun(executionContext.Run.ID, domain.RunStatusRunning),
+		fixtureRunAgent(executionContext.Run.ID, runAgentID, 0),
+	)
+	repo.setExecutionContext(runAgentID, executionContext)
+
+	activities := NewActivities(repo, FakeWorkHooks{
+		NativeModelInvoker: &fakeNativeModelInvoker{
+			err: provider.NewFailure("openai", provider.FailureCodeRateLimit, "rate limited", true, nil),
+		},
+	})
+
+	err := activities.ExecuteNativeModelStep(context.Background(), RunAgentWorkflowInput{
+		RunID:      executionContext.Run.ID,
+		RunAgentID: runAgentID,
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	var appErr *temporal.ApplicationError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected temporal application error, got %T", err)
+	}
+	if appErr.NonRetryable() {
+		t.Fatalf("rate limit error should be retryable")
+	}
+}
+
+func TestExecuteNativeModelStepSandboxErrorIsRetryable(t *testing.T) {
+	runAgentID := uuid.New()
+	executionContext := nativeExecutionContext(uuid.New(), runAgentID)
+	repo := newFakeRunRepository(
+		fixtureRun(executionContext.Run.ID, domain.RunStatusRunning),
+		fixtureRunAgent(executionContext.Run.ID, runAgentID, 0),
+	)
+	repo.setExecutionContext(runAgentID, executionContext)
+
+	activities := NewActivities(repo, FakeWorkHooks{
+		NativeModelInvoker: &fakeNativeModelInvoker{
+			err: engine.NewFailure(engine.StopReasonSandboxError, "sandbox creation failed", nil),
+		},
+	})
+
+	err := activities.ExecuteNativeModelStep(context.Background(), RunAgentWorkflowInput{
+		RunID:      executionContext.Run.ID,
+		RunAgentID: runAgentID,
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	var appErr *temporal.ApplicationError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected temporal application error, got %T", err)
+	}
+	if appErr.NonRetryable() {
+		t.Fatalf("sandbox error should be retryable")
+	}
+}
+
+func TestExecuteNativeModelStepStepLimitIsNonRetryable(t *testing.T) {
+	runAgentID := uuid.New()
+	executionContext := nativeExecutionContext(uuid.New(), runAgentID)
+	repo := newFakeRunRepository(
+		fixtureRun(executionContext.Run.ID, domain.RunStatusRunning),
+		fixtureRunAgent(executionContext.Run.ID, runAgentID, 0),
+	)
+	repo.setExecutionContext(runAgentID, executionContext)
+
+	activities := NewActivities(repo, FakeWorkHooks{
+		NativeModelInvoker: &fakeNativeModelInvoker{
+			err: engine.NewFailure(engine.StopReasonStepLimit, "step limit reached", nil),
+		},
+	})
+
+	err := activities.ExecuteNativeModelStep(context.Background(), RunAgentWorkflowInput{
+		RunID:      executionContext.Run.ID,
+		RunAgentID: runAgentID,
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	var appErr *temporal.ApplicationError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected temporal application error, got %T", err)
+	}
+	if !appErr.NonRetryable() {
+		t.Fatalf("step limit error should be non-retryable")
+	}
+}

--- a/backend/internal/workflow/workflow_test.go
+++ b/backend/internal/workflow/workflow_test.go
@@ -373,8 +373,20 @@ func TestNativeModelActivityOptionsUseRuntimeStepTimeout(t *testing.T) {
 	if options.StartToCloseTimeout != want {
 		t.Fatalf("start to close timeout = %s, want %s", options.StartToCloseTimeout, want)
 	}
-	if options.RetryPolicy == nil || options.RetryPolicy.MaximumAttempts != defaultActivityOptions.RetryPolicy.MaximumAttempts {
-		t.Fatalf("retry policy = %#v, want maximum attempts %d", options.RetryPolicy, defaultActivityOptions.RetryPolicy.MaximumAttempts)
+	if options.RetryPolicy == nil || options.RetryPolicy.MaximumAttempts != 3 {
+		t.Fatalf("retry policy maximum attempts = %d, want 3", options.RetryPolicy.MaximumAttempts)
+	}
+	if options.RetryPolicy.InitialInterval != 10*time.Second {
+		t.Fatalf("retry policy initial interval = %s, want 10s", options.RetryPolicy.InitialInterval)
+	}
+	if options.RetryPolicy.BackoffCoefficient != 2.0 {
+		t.Fatalf("retry policy backoff coefficient = %f, want 2.0", options.RetryPolicy.BackoffCoefficient)
+	}
+	if options.RetryPolicy.MaximumInterval != 2*time.Minute {
+		t.Fatalf("retry policy maximum interval = %s, want 2m", options.RetryPolicy.MaximumInterval)
+	}
+	if len(options.RetryPolicy.NonRetryableErrorTypes) == 0 {
+		t.Fatalf("retry policy should have non-retryable error types")
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #177

Fixes the execution retry policy so transient failures (rate limits, sandbox blips, network timeouts) are retried instead of permanently killing runs.

**Evidence from real runs:** 3 of 6 models failed permanently on transient errors — GPT-4o and GPT-4.1 hit rate limits (retry window ~20s, but engine retried in <2s), GPT-4o-mini hit an E2B sandbox blip. All would have succeeded with proper retries.

### What changed

- **Provider `Failure.RetryAfter`** — Parse `Retry-After` header from OpenAI, Anthropic, and Gemini 429/529 responses and propagate as a `time.Duration` on the failure struct
- **Engine backoff** — `invokeWithRetries` uses `RetryAfter + 1s` when the provider provides a hint; rate limit errors without a hint use a 2s minimum floor (was 250ms)
- **Temporal activity retries** — `executeNativeModelStep` now uses `MaximumAttempts: 3`, `InitialInterval: 10s`, `BackoffCoefficient: 2.0`, `MaximumInterval: 2m` with explicit `NonRetryableErrorTypes` for permanent failures (auth, step_limit, timeout, etc.)
- **Sandbox errors retryable** — `StopReasonSandboxError` wrapped as retryable `temporal.ApplicationError` (was non-retryable)
- **Scoring retry** — `MaximumAttempts: 2`, `InitialInterval: 5s`
- **Status transitions unchanged** — `defaultActivityOptions` keeps `MaximumAttempts: 1`

### Files changed (16 files, +501 −18)

| Layer | Files | Change |
|-------|-------|--------|
| Provider | `provider.go`, `error_classification.go`, `openai_compatible.go`, `anthropic.go`, `gemini.go` | `RetryAfter` field + `Retry-After` header parsing |
| Engine | `native_executor.go` | `retryBackoff()` helper, `rateLimitMinBackoff` constant |
| Workflow | `run_agent_workflow.go`, `activities.go`, `run_workflow.go` | Retry policies + sandbox retryability |
| Tests | 7 test files | 21 new tests + 1 updated test |

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/provider/... -count=1` — pass (new: RetryAfter roundtrip, Retry-After header parsing for all 3 providers, parseRetryAfter edge cases)
- [x] `go test ./internal/engine/... -count=1` — pass (new: retryBackoff with hint, rate limit floor, above-floor, non-rate-limit backoff)
- [x] `go test ./internal/workflow/... -count=1` — pass (new: retry policy shape, non-retryable types, rate limit retryable, sandbox retryable, step_limit non-retryable, default no-retry)
- [x] `go test ./... -count=1` — 13/13 packages pass, zero failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)