### PR TITLE
feat(engine): add prompt_eval execution mode (#189)

### DIFF
--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -67,9 +67,14 @@ func main() {
 		sandboxProvider,
 		workerapp.NewNativeRunEventObserverFactory(repo),
 	)
+	promptEvalInvoker := workerapp.NewPromptEvalInvokerWithObserverFactory(
+		providerRouter,
+		workerapp.NewPromptEvalRunEventObserverFactory(repo),
+	)
 	temporalWorker := workerapp.NewTemporalWorker(temporalClient, cfg, repo, workflowpkg.FakeWorkHooks{
 		HostedRunStarter:   hostedRunClient,
 		NativeModelInvoker: nativeModelInvoker,
+		PromptEvalInvoker:  promptEvalInvoker,
 	})
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/backend/internal/challengepack/bundle.go
+++ b/backend/internal/challengepack/bundle.go
@@ -28,12 +28,18 @@ type PackMetadata struct {
 
 type VersionMetadata struct {
 	Number         int32                  `yaml:"number" json:"number"`
+	ExecutionMode  string                 `yaml:"execution_mode,omitempty" json:"execution_mode,omitempty"`
 	ToolPolicy     map[string]any         `yaml:"tool_policy,omitempty" json:"tool_policy,omitempty"`
 	Filesystem     map[string]any         `yaml:"filesystem,omitempty" json:"filesystem,omitempty"`
 	Sandbox        *SandboxConfig         `yaml:"sandbox,omitempty" json:"sandbox,omitempty"`
 	EvaluationSpec scoring.EvaluationSpec `yaml:"evaluation_spec" json:"evaluation_spec"`
 	Assets         []AssetReference       `yaml:"assets,omitempty" json:"assets,omitempty"`
 }
+
+const (
+	ExecutionModeNative     = "native"
+	ExecutionModePromptEval = "prompt_eval"
+)
 
 type SandboxConfig struct {
 	NetworkAccess      bool              `yaml:"network_access" json:"network_access"`
@@ -127,6 +133,7 @@ func ParseYAML(data []byte) (Bundle, error) {
 
 	type rawVersionMetadata struct {
 		Number         int32            `yaml:"number"`
+		ExecutionMode  string           `yaml:"execution_mode,omitempty"`
 		ToolPolicy     map[string]any   `yaml:"tool_policy,omitempty"`
 		Filesystem     map[string]any   `yaml:"filesystem,omitempty"`
 		Sandbox        *SandboxConfig   `yaml:"sandbox,omitempty"`
@@ -161,6 +168,7 @@ func ParseYAML(data []byte) (Bundle, error) {
 		Pack: raw.Pack,
 		Version: VersionMetadata{
 			Number:         raw.Version.Number,
+			ExecutionMode:  raw.Version.ExecutionMode,
 			ToolPolicy:     raw.Version.ToolPolicy,
 			Filesystem:     raw.Version.Filesystem,
 			Sandbox:        raw.Version.Sandbox,
@@ -188,6 +196,9 @@ func ManifestJSON(bundle Bundle) (json.RawMessage, error) {
 	}
 
 	versionMap := map[string]any{"number": normalized.Version.Number, "assets": normalized.Version.Assets}
+	if normalized.Version.ExecutionMode != "" {
+		versionMap["execution_mode"] = normalized.Version.ExecutionMode
+	}
 	if normalized.Version.Sandbox != nil {
 		versionMap["sandbox_template_id"] = normalized.Version.Sandbox.SandboxTemplateID
 	}
@@ -221,6 +232,7 @@ func normalizeBundle(bundle *Bundle) {
 	bundle.Pack.Slug = strings.TrimSpace(bundle.Pack.Slug)
 	bundle.Pack.Name = strings.TrimSpace(bundle.Pack.Name)
 	bundle.Pack.Family = strings.TrimSpace(bundle.Pack.Family)
+	bundle.Version.ExecutionMode = strings.TrimSpace(bundle.Version.ExecutionMode)
 	bundle.Challenges = append([]ChallengeDefinition(nil), bundle.Challenges...)
 	bundle.InputSets = append([]InputSetDefinition(nil), bundle.InputSets...)
 	bundle.Version.Assets = append([]AssetReference(nil), bundle.Version.Assets...)

--- a/backend/internal/challengepack/bundle_test.go
+++ b/backend/internal/challengepack/bundle_test.go
@@ -468,6 +468,133 @@ func TestValidateBundleRejectsExpectationReferenceMisses(t *testing.T) {
 	}
 }
 
+func TestParseYAMLPromptEvalBundle(t *testing.T) {
+	bundle, err := ParseYAML([]byte(`
+pack:
+  slug: translation-eval
+  name: Translation Eval
+  family: nlp
+version:
+  number: 1
+  execution_mode: prompt_eval
+  evaluation_spec:
+    name: translation-v1
+    version_number: 1
+    judge_mode: deterministic
+    validators:
+      - key: check-output
+        type: contains
+        target: final_output
+        expected_from: challenge_input
+    scorecard:
+      dimensions: [correctness]
+challenges:
+  - key: translate-greeting
+    title: Translate a greeting
+    category: translation
+    difficulty: easy
+    instructions: "Translate {{text}} to {{language}}"
+input_sets:
+  - key: default
+    name: Default
+    cases:
+      - challenge_key: translate-greeting
+        case_key: french-hello
+        inputs:
+          - key: text
+            kind: text
+            value: hello world
+          - key: language
+            kind: text
+            value: French
+        expectations:
+          - key: answer
+            kind: text
+            source: input:text
+`))
+	if err != nil {
+		t.Fatalf("ParseYAML returned error: %v", err)
+	}
+	if bundle.Version.ExecutionMode != ExecutionModePromptEval {
+		t.Fatalf("execution mode = %q, want prompt_eval", bundle.Version.ExecutionMode)
+	}
+
+	manifest, err := ManifestJSON(bundle)
+	if err != nil {
+		t.Fatalf("ManifestJSON returned error: %v", err)
+	}
+	var decoded struct {
+		Version struct {
+			ExecutionMode string `json:"execution_mode"`
+		} `json:"version"`
+	}
+	if err := json.Unmarshal(manifest, &decoded); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	if decoded.Version.ExecutionMode != ExecutionModePromptEval {
+		t.Fatalf("manifest version.execution_mode = %q, want prompt_eval", decoded.Version.ExecutionMode)
+	}
+}
+
+func TestValidateBundleRejectsPromptEvalWithTools(t *testing.T) {
+	err := ValidateBundle(Bundle{
+		Pack: PackMetadata{Slug: "t", Name: "T", Family: "f"},
+		Version: VersionMetadata{
+			Number:         1,
+			ExecutionMode:  ExecutionModePromptEval,
+			EvaluationSpec: minimalSpec(),
+			Sandbox:        &SandboxConfig{NetworkAccess: true},
+		},
+		Tools: map[string]any{"custom": []any{}},
+		Challenges: []ChallengeDefinition{
+			{Key: "c1", Title: "C1", Category: "cat", Difficulty: "easy"},
+		},
+		InputSets: []InputSetDefinition{
+			{Key: "default", Name: "Default", Cases: []CaseDefinition{{ChallengeKey: "c1", CaseKey: "k"}}},
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected validation error for prompt_eval pack with tools/sandbox")
+	}
+	errs, ok := err.(ValidationErrors)
+	if !ok {
+		t.Fatalf("expected ValidationErrors, got %T", err)
+	}
+	if !containsField(errs, "tools") {
+		t.Fatalf("expected tools validation error; got %v", errs)
+	}
+	if !containsField(errs, "version.sandbox") {
+		t.Fatalf("expected version.sandbox validation error; got %v", errs)
+	}
+}
+
+func TestValidateBundleRejectsUnknownExecutionMode(t *testing.T) {
+	err := ValidateBundle(Bundle{
+		Pack: PackMetadata{Slug: "t", Name: "T", Family: "f"},
+		Version: VersionMetadata{
+			Number:         1,
+			ExecutionMode:  "exotic",
+			EvaluationSpec: minimalSpec(),
+		},
+		Challenges: []ChallengeDefinition{
+			{Key: "c1", Title: "C1", Category: "cat", Difficulty: "easy"},
+		},
+		InputSets: []InputSetDefinition{
+			{Key: "default", Name: "Default", Cases: []CaseDefinition{{ChallengeKey: "c1", CaseKey: "k"}}},
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected validation error for unknown execution_mode")
+	}
+	errs, ok := err.(ValidationErrors)
+	if !ok {
+		t.Fatalf("expected ValidationErrors, got %T", err)
+	}
+	if !containsField(errs, "version.execution_mode") {
+		t.Fatalf("expected version.execution_mode error; got %v", errs)
+	}
+}
+
 func minimalSpec() scoring.EvaluationSpec {
 	return scoring.EvaluationSpec{
 		Name:          "support-v1",

--- a/backend/internal/challengepack/validation.go
+++ b/backend/internal/challengepack/validation.go
@@ -51,6 +51,22 @@ func ValidateBundle(bundle Bundle) error {
 	if bundle.Version.Number <= 0 {
 		errs = append(errs, ValidationError{Field: "version.number", Message: "must be greater than 0"})
 	}
+	switch bundle.Version.ExecutionMode {
+	case "", ExecutionModeNative, ExecutionModePromptEval:
+	default:
+		errs = append(errs, ValidationError{Field: "version.execution_mode", Message: fmt.Sprintf("must be one of %q, %q", ExecutionModeNative, ExecutionModePromptEval)})
+	}
+	if bundle.Version.ExecutionMode == ExecutionModePromptEval {
+		if len(bundle.Tools) > 0 {
+			errs = append(errs, ValidationError{Field: "tools", Message: "must be empty when version.execution_mode is prompt_eval"})
+		}
+		if bundle.Version.Sandbox != nil {
+			errs = append(errs, ValidationError{Field: "version.sandbox", Message: "must be omitted when version.execution_mode is prompt_eval"})
+		}
+		if len(bundle.Version.ToolPolicy) > 0 {
+			errs = append(errs, ValidationError{Field: "version.tool_policy", Message: "must be empty when version.execution_mode is prompt_eval"})
+		}
+	}
 	if len(bundle.Challenges) == 0 {
 		errs = append(errs, ValidationError{Field: "challenges", Message: "must contain at least one challenge"})
 	}

--- a/backend/internal/engine/prompt_eval_executor.go
+++ b/backend/internal/engine/prompt_eval_executor.go
@@ -1,0 +1,270 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/challengepack"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/provider"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+)
+
+// PromptEvalExecutor runs a single provider call without any sandbox, tools,
+// or agent loop. It produces the same Result/event shape as NativeExecutor so
+// the scoring pipeline can consume it unchanged.
+type PromptEvalExecutor struct {
+	client   provider.Client
+	observer Observer
+}
+
+func NewPromptEvalExecutor(client provider.Client, observer Observer) PromptEvalExecutor {
+	if observer == nil {
+		observer = NoopObserver{}
+	}
+	return PromptEvalExecutor{
+		client:   client,
+		observer: observer,
+	}
+}
+
+func (e PromptEvalExecutor) Execute(ctx context.Context, executionContext repository.RunAgentExecutionContext) (result Result, err error) {
+	defer func() {
+		if err != nil {
+			if observerErr := e.observer.OnRunFailure(ctx, err); observerErr != nil {
+				err = errors.Join(err, NewFailure(StopReasonObserverError, "record prompt_eval terminal failure event", observerErr))
+			}
+			return
+		}
+		if observerErr := e.observer.OnRunComplete(ctx, result); observerErr != nil {
+			result = Result{}
+			err = NewFailure(StopReasonObserverError, "record prompt_eval terminal completion event", observerErr)
+		}
+	}()
+
+	if executionContext.Deployment.ProviderAccount == nil {
+		return Result{}, provider.NewFailure(
+			"",
+			provider.FailureCodeInvalidRequest,
+			"prompt_eval deployment is missing provider account in execution context",
+			false,
+			nil,
+		)
+	}
+	if executionContext.Deployment.ModelAlias == nil {
+		return Result{}, provider.NewFailure(
+			executionContext.Deployment.ProviderAccount.ProviderKey,
+			provider.FailureCodeInvalidRequest,
+			"prompt_eval deployment is missing model alias in execution context",
+			false,
+			nil,
+		)
+	}
+
+	runCtx := ctx
+	cancel := func() {}
+	if timeout := runTimeout(executionContext); timeout > 0 {
+		runCtx, cancel = context.WithTimeout(ctx, timeout)
+	}
+	defer cancel()
+
+	messages, err := buildPromptEvalMessages(executionContext)
+	if err != nil {
+		return Result{}, provider.NewFailure(
+			executionContext.Deployment.ProviderAccount.ProviderKey,
+			provider.FailureCodeInvalidRequest,
+			"build prompt_eval messages",
+			false,
+			err,
+		)
+	}
+
+	metadata, err := buildProviderMetadata(executionContext)
+	if err != nil {
+		return Result{}, provider.NewFailure(
+			executionContext.Deployment.ProviderAccount.ProviderKey,
+			provider.FailureCodeInvalidRequest,
+			"marshal prompt_eval provider metadata",
+			false,
+			err,
+		)
+	}
+
+	if observerErr := e.observer.OnStepStart(runCtx, 1); observerErr != nil {
+		return Result{}, NewFailure(StopReasonObserverError, "record prompt_eval step start event", observerErr)
+	}
+
+	request := provider.Request{
+		ProviderKey:         executionContext.Deployment.ProviderAccount.ProviderKey,
+		ProviderAccountID:   executionContext.Deployment.ProviderAccount.ID.String(),
+		CredentialReference: executionContext.Deployment.ProviderAccount.CredentialReference,
+		Model:               executionContext.Deployment.ModelAlias.ModelCatalogEntry.ProviderModelID,
+		TraceMode:           executionContext.Deployment.RuntimeProfile.TraceMode,
+		StepTimeout:         stepTimeout(executionContext),
+		Messages:            messages,
+		Tools:               nil,
+		Metadata:            metadata,
+	}
+
+	if observerErr := e.observer.OnProviderCall(runCtx, request); observerErr != nil {
+		return Result{}, NewFailure(StopReasonObserverError, "record prompt_eval provider call event", observerErr)
+	}
+
+	response, invokeErr := e.client.InvokeModel(runCtx, request)
+	if invokeErr != nil {
+		if errors.Is(invokeErr, context.Canceled) {
+			return Result{}, invokeErr
+		}
+		if errors.Is(runCtx.Err(), context.Canceled) {
+			return Result{}, runCtx.Err()
+		}
+		if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+			return Result{}, NewFailure(StopReasonTimeout, "prompt_eval execution exceeded runtime budget", runCtx.Err())
+		}
+		if _, ok := provider.AsFailure(invokeErr); ok {
+			return Result{}, invokeErr
+		}
+		if failure, ok := AsFailure(invokeErr); ok {
+			return Result{}, failure
+		}
+		return Result{}, NewFailure(StopReasonProviderError, "prompt_eval provider call failed", invokeErr)
+	}
+
+	if observerErr := e.observer.OnProviderResponse(runCtx, response); observerErr != nil {
+		return Result{}, NewFailure(StopReasonObserverError, "record prompt_eval provider response event", observerErr)
+	}
+	if observerErr := e.observer.OnStepEnd(runCtx, 1); observerErr != nil {
+		return Result{}, NewFailure(StopReasonObserverError, "record prompt_eval step completion event", observerErr)
+	}
+
+	return Result{
+		FinalOutput:   response.OutputText,
+		StopReason:    StopReasonCompleted,
+		StepCount:     1,
+		ToolCallCount: 0,
+		Usage:         response.Usage,
+	}, nil
+}
+
+// buildPromptEvalMessages assembles the single-shot prompt:
+//   - system message: policy_spec instructions (if any)
+//   - user message: rendered challenge.instructions with {{var}} substitutions
+//     drawn from the first case in the run agent's input set.
+func buildPromptEvalMessages(executionContext repository.RunAgentExecutionContext) ([]provider.Message, error) {
+	challenge, err := selectPromptEvalChallenge(executionContext)
+	if err != nil {
+		return nil, err
+	}
+	instructions, err := extractChallengeInstructions(challenge.Definition)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(instructions) == "" {
+		return nil, fmt.Errorf("challenge %q is missing instructions required for prompt_eval", challenge.ChallengeKey)
+	}
+
+	vars := promptEvalVariables(executionContext)
+	rendered := renderPromptTemplate(instructions, vars)
+
+	messages := make([]provider.Message, 0, 2)
+	if system := strings.TrimSpace(extractPolicyInstructions(executionContext.Deployment.AgentBuildVersion.PolicySpec)); system != "" {
+		messages = append(messages, provider.Message{Role: "system", Content: system})
+	}
+	messages = append(messages, provider.Message{Role: "user", Content: rendered})
+	return messages, nil
+}
+
+func selectPromptEvalChallenge(executionContext repository.RunAgentExecutionContext) (repository.ChallengeDefinitionExecutionContext, error) {
+	if len(executionContext.ChallengePackVersion.Challenges) == 0 {
+		return repository.ChallengeDefinitionExecutionContext{}, errors.New("prompt_eval run is missing challenge definitions")
+	}
+	if executionContext.ChallengeInputSet == nil || len(executionContext.ChallengeInputSet.Cases) == 0 {
+		return executionContext.ChallengePackVersion.Challenges[0], nil
+	}
+	firstCaseKey := executionContext.ChallengeInputSet.Cases[0].ChallengeKey
+	for _, challenge := range executionContext.ChallengePackVersion.Challenges {
+		if challenge.ChallengeKey == firstCaseKey {
+			return challenge, nil
+		}
+	}
+	return executionContext.ChallengePackVersion.Challenges[0], nil
+}
+
+func extractChallengeInstructions(definition json.RawMessage) (string, error) {
+	if len(definition) == 0 {
+		return "", nil
+	}
+	var decoded struct {
+		Instructions string `json:"instructions"`
+	}
+	if err := json.Unmarshal(definition, &decoded); err != nil {
+		return "", fmt.Errorf("decode challenge definition: %w", err)
+	}
+	return decoded.Instructions, nil
+}
+
+func promptEvalVariables(executionContext repository.RunAgentExecutionContext) map[string]string {
+	vars := map[string]string{}
+	if executionContext.ChallengeInputSet == nil || len(executionContext.ChallengeInputSet.Cases) == 0 {
+		return vars
+	}
+	first := executionContext.ChallengeInputSet.Cases[0]
+	for _, input := range first.Inputs {
+		if input.Key == "" {
+			continue
+		}
+		if rendered, ok := promptEvalRenderInputValue(input); ok {
+			vars[input.Key] = rendered
+		}
+	}
+	return vars
+}
+
+func promptEvalRenderInputValue(input challengepack.CaseInput) (string, bool) {
+	if input.Value == nil {
+		return "", false
+	}
+	switch typed := input.Value.(type) {
+	case string:
+		return typed, true
+	case bool:
+		if typed {
+			return "true", true
+		}
+		return "false", true
+	case int:
+		return fmt.Sprintf("%d", typed), true
+	case int32:
+		return fmt.Sprintf("%d", typed), true
+	case int64:
+		return fmt.Sprintf("%d", typed), true
+	case float32:
+		return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%f", typed), "0"), "."), true
+	case float64:
+		return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%f", typed), "0"), "."), true
+	default:
+		encoded, err := json.Marshal(typed)
+		if err != nil {
+			return "", false
+		}
+		return string(encoded), true
+	}
+}
+
+var promptEvalTemplatePattern = regexp.MustCompile(`\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}`)
+
+func renderPromptTemplate(template string, vars map[string]string) string {
+	return promptEvalTemplatePattern.ReplaceAllStringFunc(template, func(match string) string {
+		groups := promptEvalTemplatePattern.FindStringSubmatch(match)
+		if len(groups) != 2 {
+			return match
+		}
+		if value, ok := vars[groups[1]]; ok {
+			return value
+		}
+		return match
+	})
+}

--- a/backend/internal/engine/prompt_eval_executor.go
+++ b/backend/internal/engine/prompt_eval_executor.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"strings"
 
@@ -168,6 +169,13 @@ func buildPromptEvalMessages(executionContext repository.RunAgentExecutionContex
 
 	vars := promptEvalVariables(executionContext)
 	rendered := renderPromptTemplate(instructions, vars)
+	if leftovers := promptEvalTemplatePattern.FindAllString(rendered, -1); len(leftovers) > 0 {
+		slog.Default().Warn(
+			"prompt_eval executor rendered prompt with unresolved template tokens",
+			"run_agent_id", executionContext.RunAgent.ID.String(),
+			"unresolved_tokens", leftovers,
+		)
+	}
 
 	messages := make([]provider.Message, 0, 2)
 	if system := strings.TrimSpace(extractPolicyInstructions(executionContext.Deployment.AgentBuildVersion.PolicySpec)); system != "" {
@@ -211,6 +219,13 @@ func promptEvalVariables(executionContext repository.RunAgentExecutionContext) m
 	if executionContext.ChallengeInputSet == nil || len(executionContext.ChallengeInputSet.Cases) == 0 {
 		return vars
 	}
+	if n := len(executionContext.ChallengeInputSet.Cases); n > 1 {
+		slog.Default().Warn(
+			"prompt_eval executor using first case only; additional cases ignored",
+			"run_agent_id", executionContext.RunAgent.ID.String(),
+			"case_count", n,
+		)
+	}
 	first := executionContext.ChallengeInputSet.Cases[0]
 	for _, input := range first.Inputs {
 		if input.Key == "" {
@@ -237,12 +252,6 @@ func promptEvalRenderInputValue(input challengepack.CaseInput) (string, bool) {
 		return "false", true
 	case int:
 		return fmt.Sprintf("%d", typed), true
-	case int32:
-		return fmt.Sprintf("%d", typed), true
-	case int64:
-		return fmt.Sprintf("%d", typed), true
-	case float32:
-		return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%f", typed), "0"), "."), true
 	case float64:
 		return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%f", typed), "0"), "."), true
 	default:

--- a/backend/internal/engine/prompt_eval_executor_test.go
+++ b/backend/internal/engine/prompt_eval_executor_test.go
@@ -1,0 +1,227 @@
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/challengepack"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/domain"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/provider"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+func TestPromptEvalExecutorSingleCall(t *testing.T) {
+	client := &provider.FakeClient{
+		Response: provider.Response{
+			ProviderKey:     "openai",
+			ProviderModelID: "gpt-4.1-mini",
+			FinishReason:    "stop",
+			OutputText:      "Bonjour, monde.",
+			Usage:           provider.Usage{InputTokens: 12, OutputTokens: 6, TotalTokens: 18},
+		},
+	}
+	observer := &recordingObserver{}
+	executor := NewPromptEvalExecutor(client, observer)
+
+	result, err := executor.Execute(context.Background(), promptEvalExecutionContext())
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if result.StopReason != StopReasonCompleted {
+		t.Fatalf("stop reason = %s, want completed", result.StopReason)
+	}
+	if result.FinalOutput != "Bonjour, monde." {
+		t.Fatalf("final output = %q, want %q", result.FinalOutput, "Bonjour, monde.")
+	}
+	if result.StepCount != 1 {
+		t.Fatalf("step count = %d, want 1", result.StepCount)
+	}
+	if result.ToolCallCount != 0 {
+		t.Fatalf("tool call count = %d, want 0", result.ToolCallCount)
+	}
+	if result.Usage.TotalTokens != 18 {
+		t.Fatalf("total tokens = %d, want 18", result.Usage.TotalTokens)
+	}
+
+	if len(client.Requests) != 1 {
+		t.Fatalf("provider call count = %d, want 1", len(client.Requests))
+	}
+	req := client.Requests[0]
+	if len(req.Tools) != 0 {
+		t.Fatalf("request tools = %d, want 0", len(req.Tools))
+	}
+	if len(req.Messages) != 2 {
+		t.Fatalf("request message count = %d, want 2 (system + user)", len(req.Messages))
+	}
+	if req.Messages[0].Role != "system" {
+		t.Fatalf("messages[0].role = %q, want system", req.Messages[0].Role)
+	}
+	if req.Messages[1].Role != "user" {
+		t.Fatalf("messages[1].role = %q, want user", req.Messages[1].Role)
+	}
+	if !strings.Contains(req.Messages[1].Content, "French") {
+		t.Fatalf("rendered user prompt %q missing variable substitution for language", req.Messages[1].Content)
+	}
+	if !strings.Contains(req.Messages[1].Content, "hello world") {
+		t.Fatalf("rendered user prompt %q missing variable substitution for text", req.Messages[1].Content)
+	}
+	if strings.Contains(req.Messages[1].Content, "{{") {
+		t.Fatalf("rendered user prompt %q still contains unrendered template tokens", req.Messages[1].Content)
+	}
+
+	if !observer.runComplete {
+		t.Fatalf("observer did not receive OnRunComplete")
+	}
+	if observer.runFailure {
+		t.Fatalf("observer received unexpected OnRunFailure")
+	}
+	if observer.providerCalls != 1 || observer.providerResponses != 1 {
+		t.Fatalf("observer call counts: calls=%d responses=%d, want 1/1", observer.providerCalls, observer.providerResponses)
+	}
+	if observer.stepStarts != 1 || observer.stepEnds != 1 {
+		t.Fatalf("observer step counts: start=%d end=%d, want 1/1", observer.stepStarts, observer.stepEnds)
+	}
+}
+
+func TestPromptEvalExecutorProviderFailurePropagates(t *testing.T) {
+	client := &provider.FakeClient{
+		Err: provider.NewFailure("openai", provider.FailureCodeAuth, "bad key", false, nil),
+	}
+	observer := &recordingObserver{}
+	executor := NewPromptEvalExecutor(client, observer)
+
+	_, err := executor.Execute(context.Background(), promptEvalExecutionContext())
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if _, ok := provider.AsFailure(err); !ok {
+		t.Fatalf("expected provider.Failure, got %T", err)
+	}
+	if !observer.runFailure {
+		t.Fatalf("observer did not record OnRunFailure")
+	}
+}
+
+func TestPromptEvalExecutorRejectsMissingInstructions(t *testing.T) {
+	ctx := promptEvalExecutionContext()
+	ctx.ChallengePackVersion.Challenges[0].Definition = []byte(`{}`)
+
+	client := &provider.FakeClient{Response: provider.Response{OutputText: "ignored"}}
+	_, err := NewPromptEvalExecutor(client, &recordingObserver{}).Execute(context.Background(), ctx)
+	if err == nil {
+		t.Fatalf("expected error when instructions missing")
+	}
+	if _, ok := provider.AsFailure(err); !ok {
+		t.Fatalf("expected provider.Failure, got %T", err)
+	}
+	if len(client.Requests) != 0 {
+		t.Fatalf("provider should not be called when instructions missing; got %d requests", len(client.Requests))
+	}
+}
+
+func promptEvalExecutionContext() repository.RunAgentExecutionContext {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+
+	return repository.RunAgentExecutionContext{
+		Run:      domain.Run{ID: runID},
+		RunAgent: domain.RunAgent{ID: runAgentID, RunID: runID, Status: domain.RunAgentStatusQueued, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()},
+		ChallengePackVersion: repository.ChallengePackVersionExecutionContext{
+			ID:       uuid.New(),
+			Manifest: []byte(`{"version":{"execution_mode":"prompt_eval"}}`),
+			Challenges: []repository.ChallengeDefinitionExecutionContext{
+				{
+					ID:           uuid.New(),
+					ChallengeKey: "translate-greeting",
+					Title:        "Translate a greeting",
+					Definition:   []byte(`{"instructions":"Translate {{text}} to {{language}}."}`),
+				},
+			},
+		},
+		ChallengeInputSet: &repository.ChallengeInputSetExecutionContext{
+			ID:       uuid.New(),
+			InputKey: "default",
+			Name:     "Default",
+			Cases: []repository.ChallengeCaseExecutionContext{
+				{
+					ID:           uuid.New(),
+					ChallengeKey: "translate-greeting",
+					CaseKey:      "french-hello",
+					Inputs: []challengepack.CaseInput{
+						{Key: "text", Kind: "text", Value: "hello world"},
+						{Key: "language", Kind: "text", Value: "French"},
+					},
+				},
+			},
+		},
+		Deployment: repository.AgentDeploymentExecutionContext{
+			DeploymentType: "native",
+			SnapshotConfig: []byte(`{}`),
+			AgentBuildVersion: repository.AgentBuildVersionExecutionContext{
+				ID:         uuid.New(),
+				AgentKind:  "llm_agent",
+				AgentSpec:  []byte(`{}`),
+				PolicySpec: []byte(`{"instructions":"You are a precise translator."}`),
+			},
+			RuntimeProfile: repository.RuntimeProfileExecutionContext{
+				ExecutionTarget:    "prompt_eval",
+				TraceMode:          "preferred",
+				StepTimeoutSeconds: 30,
+				RunTimeoutSeconds:  60,
+				ProfileConfig:      []byte(`{}`),
+			},
+			ProviderAccount: &repository.ProviderAccountExecutionContext{
+				ID:                  uuid.New(),
+				ProviderKey:         "openai",
+				CredentialReference: "env://OPENAI_API_KEY",
+			},
+			ModelAlias: &repository.ModelAliasExecutionContext{
+				ModelCatalogEntry: repository.ModelCatalogEntryExecutionContext{
+					ProviderModelID: "gpt-4.1-mini",
+				},
+			},
+		},
+	}
+}
+
+type recordingObserver struct {
+	stepStarts        int
+	stepEnds          int
+	providerCalls     int
+	providerResponses int
+	runComplete       bool
+	runFailure        bool
+}
+
+func (o *recordingObserver) OnStepStart(context.Context, int) error {
+	o.stepStarts++
+	return nil
+}
+func (o *recordingObserver) OnProviderCall(context.Context, provider.Request) error {
+	o.providerCalls++
+	return nil
+}
+func (o *recordingObserver) OnProviderOutput(context.Context, provider.Request, provider.StreamDelta) error {
+	return nil
+}
+func (o *recordingObserver) OnProviderResponse(context.Context, provider.Response) error {
+	o.providerResponses++
+	return nil
+}
+func (o *recordingObserver) OnToolExecution(context.Context, ToolExecutionRecord) error { return nil }
+func (o *recordingObserver) OnStepEnd(context.Context, int) error {
+	o.stepEnds++
+	return nil
+}
+func (o *recordingObserver) OnRunComplete(context.Context, Result) error {
+	o.runComplete = true
+	return nil
+}
+func (o *recordingObserver) OnRunFailure(context.Context, error) error {
+	o.runFailure = true
+	return nil
+}

--- a/backend/internal/engine/prompt_eval_executor_test.go
+++ b/backend/internal/engine/prompt_eval_executor_test.go
@@ -106,6 +106,58 @@ func TestPromptEvalExecutorProviderFailurePropagates(t *testing.T) {
 	}
 }
 
+func TestPromptEvalExecutorUsesFirstCaseWhenInputSetHasMany(t *testing.T) {
+	ctx := promptEvalExecutionContext()
+	// Add two extra cases to confirm the executor ignores them without erroring.
+	extra := repository.ChallengeCaseExecutionContext{
+		ID:           uuid.New(),
+		ChallengeKey: "translate-greeting",
+		CaseKey:      "german-hello",
+		Inputs: []challengepack.CaseInput{
+			{Key: "text", Kind: "text", Value: "ignored text"},
+			{Key: "language", Kind: "text", Value: "German"},
+		},
+	}
+	ctx.ChallengeInputSet.Cases = append(ctx.ChallengeInputSet.Cases, extra, extra)
+
+	client := &provider.FakeClient{Response: provider.Response{OutputText: "Bonjour"}}
+	if _, err := NewPromptEvalExecutor(client, &recordingObserver{}).Execute(context.Background(), ctx); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if len(client.Requests) != 1 {
+		t.Fatalf("provider call count = %d, want 1", len(client.Requests))
+	}
+	userMessage := client.Requests[0].Messages[len(client.Requests[0].Messages)-1].Content
+	if !strings.Contains(userMessage, "French") {
+		t.Fatalf("rendered prompt %q should reference first case language 'French'", userMessage)
+	}
+	if strings.Contains(userMessage, "German") {
+		t.Fatalf("rendered prompt %q must not leak second case language 'German'", userMessage)
+	}
+}
+
+func TestPromptEvalExecutorPassesThroughUnresolvedTokens(t *testing.T) {
+	ctx := promptEvalExecutionContext()
+	ctx.ChallengePackVersion.Challenges[0].Definition = []byte(`{"instructions":"Use {{text}} and respect {{missing_var}}."}`)
+
+	client := &provider.FakeClient{Response: provider.Response{OutputText: "ok"}}
+	if _, err := NewPromptEvalExecutor(client, &recordingObserver{}).Execute(context.Background(), ctx); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if len(client.Requests) != 1 {
+		t.Fatalf("provider call count = %d, want 1", len(client.Requests))
+	}
+	userMessage := client.Requests[0].Messages[len(client.Requests[0].Messages)-1].Content
+	if !strings.Contains(userMessage, "hello world") {
+		t.Fatalf("rendered prompt %q should substitute resolved var", userMessage)
+	}
+	if !strings.Contains(userMessage, "{{missing_var}}") {
+		t.Fatalf("rendered prompt %q should pass unresolved token through verbatim", userMessage)
+	}
+}
+
 func TestPromptEvalExecutorRejectsMissingInstructions(t *testing.T) {
 	ctx := promptEvalExecutionContext()
 	ctx.ChallengePackVersion.Challenges[0].Definition = []byte(`{}`)

--- a/backend/internal/engine/prompt_eval_smoke_test.go
+++ b/backend/internal/engine/prompt_eval_smoke_test.go
@@ -1,0 +1,201 @@
+//go:build promptevalsmoke
+
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/domain"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/provider"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+type smokeTestCase struct {
+	name           string
+	instructions   string
+	outputContains string
+	checkJSON      bool
+}
+
+var smokePrompts = []smokeTestCase{
+	{
+		name:           "Translation",
+		instructions:   "Translate 'hello world' to French. Reply with only the translation, nothing else.",
+		outputContains: "bonjour",
+	},
+	{
+		name:           "Factual",
+		instructions:   "What is the capital of Japan? Reply with only the city name, nothing else.",
+		outputContains: "Tokyo",
+	},
+	{
+		name:         "JSON",
+		instructions: `Return a JSON object with keys "name" and "age". Name is "Alice", age is 30. Reply with only valid JSON, no markdown fences.`,
+		checkJSON:    true,
+	},
+}
+
+func TestPromptEvalSmokeGemini(t *testing.T) {
+	apiKey := os.Getenv("GEMINI_API_KEY")
+	if apiKey == "" {
+		t.Skip("GEMINI_API_KEY is not set")
+	}
+	t.Setenv("GEMINI_API_KEY", apiKey)
+
+	client := provider.NewGeminiClient(nil, "", provider.EnvCredentialResolver{})
+
+	for _, tc := range smokePrompts {
+		t.Run(tc.name, func(t *testing.T) {
+			runSmokeTest(t, client, "gemini", "env://GEMINI_API_KEY", "gemini-2.0-flash", tc)
+		})
+	}
+}
+
+func TestPromptEvalSmokeAnthropic(t *testing.T) {
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		t.Skip("ANTHROPIC_API_KEY is not set")
+	}
+	t.Setenv("ANTHROPIC_API_KEY", apiKey)
+
+	client := provider.NewAnthropicClient(nil, "", "", provider.EnvCredentialResolver{})
+
+	for _, tc := range smokePrompts {
+		t.Run(tc.name, func(t *testing.T) {
+			runSmokeTest(t, client, "anthropic", "env://ANTHROPIC_API_KEY", "claude-sonnet-4-20250514", tc)
+		})
+	}
+}
+
+func runSmokeTest(t *testing.T, client provider.Client, providerKey, credRef, model string, tc smokeTestCase) {
+	t.Helper()
+
+	observer := &recordingObserver{}
+	executor := NewPromptEvalExecutor(client, observer)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	execCtx := smokeExecutionContext(providerKey, credRef, model, tc.instructions)
+	result, err := executor.Execute(ctx, execCtx)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	t.Logf("Provider: %s | Model: %s", providerKey, model)
+	t.Logf("Output: %q", result.FinalOutput)
+	t.Logf("Tokens: in=%d out=%d total=%d", result.Usage.InputTokens, result.Usage.OutputTokens, result.Usage.TotalTokens)
+
+	if result.StopReason != StopReasonCompleted {
+		t.Fatalf("stop reason = %s, want completed", result.StopReason)
+	}
+	if result.StepCount != 1 {
+		t.Fatalf("step count = %d, want 1", result.StepCount)
+	}
+	if result.ToolCallCount != 0 {
+		t.Fatalf("tool call count = %d, want 0", result.ToolCallCount)
+	}
+	if result.FinalOutput == "" {
+		t.Fatalf("final output is empty")
+	}
+	if result.Usage.TotalTokens <= 0 {
+		t.Fatalf("total tokens = %d, want > 0", result.Usage.TotalTokens)
+	}
+
+	if tc.outputContains != "" {
+		if !strings.Contains(strings.ToLower(result.FinalOutput), strings.ToLower(tc.outputContains)) {
+			t.Fatalf("output %q does not contain expected %q (case-insensitive)", result.FinalOutput, tc.outputContains)
+		}
+	}
+	if tc.checkJSON {
+		trimmed := strings.TrimSpace(result.FinalOutput)
+		if !json.Valid([]byte(trimmed)) {
+			t.Fatalf("output is not valid JSON: %q", trimmed)
+		}
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
+			t.Fatalf("output is not a JSON object: %v", err)
+		}
+		if _, ok := parsed["name"]; !ok {
+			t.Fatalf("JSON output missing 'name' key: %s", trimmed)
+		}
+		if _, ok := parsed["age"]; !ok {
+			t.Fatalf("JSON output missing 'age' key: %s", trimmed)
+		}
+	}
+
+	if !observer.runComplete {
+		t.Fatalf("observer did not receive OnRunComplete")
+	}
+	if observer.runFailure {
+		t.Fatalf("observer received unexpected OnRunFailure")
+	}
+	if observer.providerCalls != 1 {
+		t.Fatalf("observer provider calls = %d, want 1", observer.providerCalls)
+	}
+	if observer.providerResponses != 1 {
+		t.Fatalf("observer provider responses = %d, want 1", observer.providerResponses)
+	}
+}
+
+func smokeExecutionContext(providerKey, credRef, model, instructions string) repository.RunAgentExecutionContext {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	return repository.RunAgentExecutionContext{
+		Run:      domain.Run{ID: runID},
+		RunAgent: domain.RunAgent{ID: runAgentID, RunID: runID, Status: domain.RunAgentStatusQueued, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()},
+		ChallengePackVersion: repository.ChallengePackVersionExecutionContext{
+			ID:       uuid.New(),
+			Manifest: []byte(`{"version":{"execution_mode":"prompt_eval"}}`),
+			Challenges: []repository.ChallengeDefinitionExecutionContext{
+				{
+					ID:           uuid.New(),
+					ChallengeKey: "smoke-test",
+					Title:        "Smoke Test",
+					Definition:   mustJSON(map[string]string{"instructions": instructions}),
+				},
+			},
+		},
+		Deployment: repository.AgentDeploymentExecutionContext{
+			DeploymentType: "native",
+			SnapshotConfig: []byte(`{}`),
+			AgentBuildVersion: repository.AgentBuildVersionExecutionContext{
+				ID:         uuid.New(),
+				AgentKind:  "llm_agent",
+				AgentSpec:  []byte(`{}`),
+				PolicySpec: []byte(`{}`),
+			},
+			RuntimeProfile: repository.RuntimeProfileExecutionContext{
+				ExecutionTarget:    "prompt_eval",
+				TraceMode:          "preferred",
+				StepTimeoutSeconds: 45,
+				RunTimeoutSeconds:  55,
+				ProfileConfig:      []byte(`{}`),
+			},
+			ProviderAccount: &repository.ProviderAccountExecutionContext{
+				ID:                  uuid.New(),
+				ProviderKey:         providerKey,
+				CredentialReference: credRef,
+			},
+			ModelAlias: &repository.ModelAliasExecutionContext{
+				ModelCatalogEntry: repository.ModelCatalogEntryExecutionContext{
+					ProviderModelID: model,
+				},
+			},
+		},
+	}
+}
+
+func mustJSON(v any) json.RawMessage {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/backend/internal/runevents/envelope.go
+++ b/backend/internal/runevents/envelope.go
@@ -46,10 +46,11 @@ const (
 type Source string
 
 const (
-	SourceNativeEngine   Source = "native_engine"
-	SourceHostedExternal Source = "hosted_external"
-	SourceHostedCallback Source = "hosted_callback"
-	SourceWorkerScoring  Source = "worker_scoring"
+	SourceNativeEngine     Source = "native_engine"
+	SourcePromptEvalEngine Source = "prompt_eval_engine"
+	SourceHostedExternal   Source = "hosted_external"
+	SourceHostedCallback   Source = "hosted_callback"
+	SourceWorkerScoring    Source = "worker_scoring"
 )
 
 type EvidenceLevel string
@@ -170,7 +171,7 @@ func isValidType(eventType Type) bool {
 
 func isValidSource(source Source) bool {
 	switch source {
-	case SourceNativeEngine, SourceHostedExternal, SourceHostedCallback, SourceWorkerScoring:
+	case SourceNativeEngine, SourcePromptEvalEngine, SourceHostedExternal, SourceHostedCallback, SourceWorkerScoring:
 		return true
 	default:
 		return false

--- a/backend/internal/worker/prompt_eval_event_observer.go
+++ b/backend/internal/worker/prompt_eval_event_observer.go
@@ -1,0 +1,236 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/engine"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/provider"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/runevents"
+)
+
+type PromptEvalObserverFactory func(executionContext repository.RunAgentExecutionContext) (engine.Observer, error)
+
+// PromptEvalRunEventObserver records the minimal set of run events required by
+// the scoring pipeline for a prompt_eval execution: run.started,
+// model.call.completed, output.finalized, run.completed (or run.failed).
+type PromptEvalRunEventObserver struct {
+	recorder         RunEventRecorder
+	executionContext repository.RunAgentExecutionContext
+
+	mu              sync.Mutex
+	eventIDSequence int64
+	runStarted      bool
+	outputRecorded  bool
+}
+
+func NewPromptEvalRunEventObserverFactory(recorder RunEventRecorder) PromptEvalObserverFactory {
+	return func(executionContext repository.RunAgentExecutionContext) (engine.Observer, error) {
+		if recorder == nil {
+			return engine.NoopObserver{}, nil
+		}
+		return &PromptEvalRunEventObserver{
+			recorder:         recorder,
+			executionContext: executionContext,
+		}, nil
+	}
+}
+
+func (o *PromptEvalRunEventObserver) OnStepStart(ctx context.Context, _ int) error {
+	return o.ensureRunStarted(ctx)
+}
+
+func (o *PromptEvalRunEventObserver) OnProviderCall(ctx context.Context, request provider.Request) error {
+	if err := o.ensureRunStarted(ctx); err != nil {
+		return err
+	}
+	return o.recordEvent(ctx, runevents.EventTypeModelCallStarted, map[string]any{
+		"provider_key":        request.ProviderKey,
+		"provider_account_id": request.ProviderAccountID,
+		"model":               request.Model,
+		"trace_mode":          request.TraceMode,
+		"step_timeout_ms":     request.StepTimeout.Milliseconds(),
+		"message_count":       len(request.Messages),
+		"metadata":            normalizeJSON(request.Metadata),
+	}, runevents.SummaryMetadata{
+		Status:          "running",
+		StepIndex:       1,
+		ProviderKey:     request.ProviderKey,
+		ProviderModelID: request.Model,
+		EvidenceLevel:   runevents.EvidenceLevelNativeStructured,
+	})
+}
+
+func (o *PromptEvalRunEventObserver) OnProviderOutput(context.Context, provider.Request, provider.StreamDelta) error {
+	return nil
+}
+
+func (o *PromptEvalRunEventObserver) OnProviderResponse(ctx context.Context, response provider.Response) error {
+	if err := o.ensureRunStarted(ctx); err != nil {
+		return err
+	}
+	o.mu.Lock()
+	alreadyRecorded := o.outputRecorded
+	o.outputRecorded = true
+	o.mu.Unlock()
+
+	if err := o.recordEvent(ctx, runevents.EventTypeModelCallCompleted, map[string]any{
+		"provider_key":      response.ProviderKey,
+		"provider_model_id": response.ProviderModelID,
+		"finish_reason":     response.FinishReason,
+		"output_text":       response.OutputText,
+		"tool_calls":        []any{},
+		"usage": map[string]int64{
+			"input_tokens":  response.Usage.InputTokens,
+			"output_tokens": response.Usage.OutputTokens,
+			"total_tokens":  response.Usage.TotalTokens,
+		},
+		"timing": map[string]int64{
+			"ttft_ms":          response.Timing.TTFT.Milliseconds(),
+			"total_latency_ms": response.Timing.TotalLatency.Milliseconds(),
+		},
+		"raw_response": normalizeJSON(response.RawResponse),
+	}, runevents.SummaryMetadata{
+		Status:          "running",
+		StepIndex:       1,
+		ProviderKey:     response.ProviderKey,
+		ProviderModelID: response.ProviderModelID,
+		EvidenceLevel:   runevents.EvidenceLevelNativeStructured,
+	}); err != nil {
+		return err
+	}
+	if alreadyRecorded {
+		return nil
+	}
+	return o.recordEvent(ctx, runevents.EventTypeSystemOutputFinalized, map[string]any{
+		"final_output": response.OutputText,
+		"source":       "prompt_eval_engine",
+	}, runevents.SummaryMetadata{
+		Status:        "running",
+		StepIndex:     1,
+		EvidenceLevel: runevents.EvidenceLevelNativeStructured,
+	})
+}
+
+func (o *PromptEvalRunEventObserver) OnToolExecution(context.Context, engine.ToolExecutionRecord) error {
+	return nil
+}
+
+func (o *PromptEvalRunEventObserver) OnStepEnd(context.Context, int) error {
+	return nil
+}
+
+func (o *PromptEvalRunEventObserver) OnRunComplete(ctx context.Context, result engine.Result) error {
+	if err := o.ensureRunStarted(ctx); err != nil {
+		return err
+	}
+	return o.recordEvent(ctx, runevents.EventTypeSystemRunCompleted, map[string]any{
+		"final_output":    result.FinalOutput,
+		"stop_reason":     result.StopReason,
+		"step_count":      result.StepCount,
+		"tool_call_count": result.ToolCallCount,
+		"input_tokens":    result.Usage.InputTokens,
+		"output_tokens":   result.Usage.OutputTokens,
+		"total_tokens":    result.Usage.TotalTokens,
+	}, runevents.SummaryMetadata{
+		Status:        "completed",
+		StepIndex:     1,
+		EvidenceLevel: runevents.EvidenceLevelNativeStructured,
+	})
+}
+
+func (o *PromptEvalRunEventObserver) OnRunFailure(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if startErr := o.ensureRunStarted(ctx); startErr != nil {
+		return startErr
+	}
+
+	payload := map[string]any{
+		"error":       err.Error(),
+		"step_index":  1,
+		"stop_reason": "",
+	}
+	if failure, ok := engine.AsFailure(err); ok {
+		payload["stop_reason"] = failure.StopReason
+	}
+	if failure, ok := provider.AsFailure(err); ok {
+		payload["provider_failure"] = map[string]any{
+			"provider_key": failure.ProviderKey,
+			"code":         failure.Code,
+			"retryable":    failure.Retryable,
+			"message":      failure.Message,
+		}
+	}
+
+	return o.recordEvent(ctx, runevents.EventTypeSystemRunFailed, payload, runevents.SummaryMetadata{
+		Status:        "failed",
+		StepIndex:     1,
+		EvidenceLevel: runevents.EvidenceLevelNativeStructured,
+	})
+}
+
+func (o *PromptEvalRunEventObserver) ensureRunStarted(ctx context.Context) error {
+	o.mu.Lock()
+	if o.runStarted {
+		o.mu.Unlock()
+		return nil
+	}
+	o.mu.Unlock()
+
+	if err := o.recordEvent(ctx, runevents.EventTypeSystemRunStarted, map[string]any{
+		"deployment_type":  o.executionContext.Deployment.DeploymentType,
+		"execution_mode":   "prompt_eval",
+		"execution_target": o.executionContext.Deployment.RuntimeProfile.ExecutionTarget,
+		"trace_mode":       o.executionContext.Deployment.RuntimeProfile.TraceMode,
+		"started_at":       time.Now().UTC(),
+	}, runevents.SummaryMetadata{
+		Status:        "running",
+		EvidenceLevel: runevents.EvidenceLevelNativeStructured,
+	}); err != nil {
+		return err
+	}
+
+	o.mu.Lock()
+	o.runStarted = true
+	o.mu.Unlock()
+	return nil
+}
+
+func (o *PromptEvalRunEventObserver) nextEventID(eventType runevents.Type) string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.eventIDSequence++
+	return fmt.Sprintf("prompt_eval:%s:%s:%d", o.executionContext.RunAgent.ID.String(), eventType, o.eventIDSequence)
+}
+
+func (o *PromptEvalRunEventObserver) recordEvent(ctx context.Context, eventType runevents.Type, payload map[string]any, summary runevents.SummaryMetadata) error {
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal prompt_eval event payload: %w", err)
+	}
+
+	summary.IdempotencyKey = o.nextEventID(eventType)
+	_, err = o.recorder.RecordRunEvent(ctx, repository.RecordRunEventParams{
+		Event: runevents.Envelope{
+			EventID:       summary.IdempotencyKey,
+			SchemaVersion: runevents.SchemaVersionV1,
+			RunID:         o.executionContext.Run.ID,
+			RunAgentID:    o.executionContext.RunAgent.ID,
+			EventType:     eventType,
+			Source:        runevents.SourcePromptEvalEngine,
+			OccurredAt:    time.Now().UTC(),
+			Payload:       payloadJSON,
+			Summary:       summary,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("record prompt_eval run event: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/worker/prompt_eval_event_observer.go
+++ b/backend/internal/worker/prompt_eval_event_observer.go
@@ -24,8 +24,10 @@ type PromptEvalRunEventObserver struct {
 
 	mu              sync.Mutex
 	eventIDSequence int64
-	runStarted      bool
 	outputRecorded  bool
+
+	started    sync.Once
+	startedErr error
 }
 
 func NewPromptEvalRunEventObserverFactory(recorder RunEventRecorder) PromptEvalObserverFactory {
@@ -176,30 +178,19 @@ func (o *PromptEvalRunEventObserver) OnRunFailure(ctx context.Context, err error
 }
 
 func (o *PromptEvalRunEventObserver) ensureRunStarted(ctx context.Context) error {
-	o.mu.Lock()
-	if o.runStarted {
-		o.mu.Unlock()
-		return nil
-	}
-	o.mu.Unlock()
-
-	if err := o.recordEvent(ctx, runevents.EventTypeSystemRunStarted, map[string]any{
-		"deployment_type":  o.executionContext.Deployment.DeploymentType,
-		"execution_mode":   "prompt_eval",
-		"execution_target": o.executionContext.Deployment.RuntimeProfile.ExecutionTarget,
-		"trace_mode":       o.executionContext.Deployment.RuntimeProfile.TraceMode,
-		"started_at":       time.Now().UTC(),
-	}, runevents.SummaryMetadata{
-		Status:        "running",
-		EvidenceLevel: runevents.EvidenceLevelNativeStructured,
-	}); err != nil {
-		return err
-	}
-
-	o.mu.Lock()
-	o.runStarted = true
-	o.mu.Unlock()
-	return nil
+	o.started.Do(func() {
+		o.startedErr = o.recordEvent(ctx, runevents.EventTypeSystemRunStarted, map[string]any{
+			"deployment_type":  o.executionContext.Deployment.DeploymentType,
+			"execution_mode":   "prompt_eval",
+			"execution_target": o.executionContext.Deployment.RuntimeProfile.ExecutionTarget,
+			"trace_mode":       o.executionContext.Deployment.RuntimeProfile.TraceMode,
+			"started_at":       time.Now().UTC(),
+		}, runevents.SummaryMetadata{
+			Status:        "running",
+			EvidenceLevel: runevents.EvidenceLevelNativeStructured,
+		})
+	})
+	return o.startedErr
 }
 
 func (o *PromptEvalRunEventObserver) nextEventID(eventType runevents.Type) string {

--- a/backend/internal/worker/prompt_eval_event_observer_test.go
+++ b/backend/internal/worker/prompt_eval_event_observer_test.go
@@ -1,0 +1,98 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/provider"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/runevents"
+)
+
+func TestPromptEvalInvokerPersistsCanonicalEvents(t *testing.T) {
+	recorder := &fakeRunEventRecorder{}
+	client := &provider.FakeClient{
+		Response: provider.Response{
+			ProviderKey:     "openai",
+			ProviderModelID: "gpt-4.1-mini",
+			FinishReason:    "stop",
+			OutputText:      "Bonjour",
+			Usage:           provider.Usage{InputTokens: 10, OutputTokens: 4, TotalTokens: 14},
+		},
+	}
+
+	invoker := NewPromptEvalInvokerWithObserverFactory(
+		client,
+		NewPromptEvalRunEventObserverFactory(recorder),
+	)
+
+	if _, err := invoker.InvokePromptEval(context.Background(), promptEvalInvokerExecutionContext()); err != nil {
+		t.Fatalf("InvokePromptEval returned error: %v", err)
+	}
+
+	want := []runevents.Type{
+		runevents.EventTypeSystemRunStarted,
+		runevents.EventTypeModelCallStarted,
+		runevents.EventTypeModelCallCompleted,
+		runevents.EventTypeSystemOutputFinalized,
+		runevents.EventTypeSystemRunCompleted,
+	}
+	if len(recorder.events) != len(want) {
+		t.Fatalf("event count = %d, want %d", len(recorder.events), len(want))
+	}
+	for i, event := range recorder.events {
+		if event.EventType != want[i] {
+			t.Fatalf("event[%d] type = %q, want %q", i, event.EventType, want[i])
+		}
+		if event.Source != runevents.SourcePromptEvalEngine {
+			t.Fatalf("event[%d] source = %q, want prompt_eval_engine", i, event.Source)
+		}
+		if event.SequenceNumber != int64(i+1) {
+			t.Fatalf("event[%d] sequence number = %d, want %d", i, event.SequenceNumber, i+1)
+		}
+		if !json.Valid(event.Payload) {
+			t.Fatalf("event[%d] payload is not valid JSON: %s", i, event.Payload)
+		}
+	}
+
+	// system.run.completed must carry final_output + usage so scoring.EvaluateRunAgent
+	// can compute correctness and token metrics without replaying the model call.
+	var completedPayload map[string]any
+	if err := json.Unmarshal(recorder.events[4].Payload, &completedPayload); err != nil {
+		t.Fatalf("unmarshal run.completed payload: %v", err)
+	}
+	if completedPayload["final_output"] != "Bonjour" {
+		t.Fatalf("run.completed final_output = %v, want Bonjour", completedPayload["final_output"])
+	}
+	if totalTokens, _ := completedPayload["total_tokens"].(float64); totalTokens != 14 {
+		t.Fatalf("run.completed total_tokens = %v, want 14", completedPayload["total_tokens"])
+	}
+}
+
+func TestPromptEvalInvokerRecordsRunFailedOnProviderError(t *testing.T) {
+	recorder := &fakeRunEventRecorder{}
+	client := &provider.FakeClient{
+		Err: provider.NewFailure("openai", provider.FailureCodeAuth, "bad key", false, nil),
+	}
+
+	invoker := NewPromptEvalInvokerWithObserverFactory(
+		client,
+		NewPromptEvalRunEventObserverFactory(recorder),
+	)
+
+	if _, err := invoker.InvokePromptEval(context.Background(), promptEvalInvokerExecutionContext()); err == nil {
+		t.Fatal("expected error")
+	}
+
+	var sawFailed bool
+	types := make([]runevents.Type, 0, len(recorder.events))
+	for _, event := range recorder.events {
+		types = append(types, event.EventType)
+		if event.EventType == runevents.EventTypeSystemRunFailed {
+			sawFailed = true
+		}
+	}
+	if !sawFailed {
+		t.Fatalf("expected system.run.failed event; got sequence %v", types)
+	}
+}

--- a/backend/internal/worker/prompt_eval_invoker.go
+++ b/backend/internal/worker/prompt_eval_invoker.go
@@ -1,0 +1,47 @@
+package worker
+
+import (
+	"context"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/engine"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/provider"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+)
+
+type PromptEvalInvoker struct {
+	client          provider.Client
+	observerFactory PromptEvalObserverFactory
+}
+
+func NewPromptEvalInvoker(client provider.Client) PromptEvalInvoker {
+	return NewPromptEvalInvokerWithObserverFactory(client, nil)
+}
+
+func NewPromptEvalInvokerWithObserver(client provider.Client, observer engine.Observer) PromptEvalInvoker {
+	return NewPromptEvalInvokerWithObserverFactory(client, func(repository.RunAgentExecutionContext) (engine.Observer, error) {
+		return observer, nil
+	})
+}
+
+func NewPromptEvalInvokerWithObserverFactory(client provider.Client, observerFactory PromptEvalObserverFactory) PromptEvalInvoker {
+	return PromptEvalInvoker{
+		client:          client,
+		observerFactory: observerFactory,
+	}
+}
+
+func (i PromptEvalInvoker) InvokePromptEval(ctx context.Context, executionContext repository.RunAgentExecutionContext) (engine.Result, error) {
+	observer := engine.Observer(engine.NoopObserver{})
+	if i.observerFactory != nil {
+		builtObserver, err := i.observerFactory(executionContext)
+		if err != nil {
+			return engine.Result{}, err
+		}
+		if builtObserver != nil {
+			observer = builtObserver
+		}
+	}
+
+	executor := engine.NewPromptEvalExecutor(i.client, observer)
+	return executor.Execute(ctx, executionContext)
+}

--- a/backend/internal/worker/prompt_eval_invoker_test.go
+++ b/backend/internal/worker/prompt_eval_invoker_test.go
@@ -1,0 +1,107 @@
+package worker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/challengepack"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/domain"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/engine"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/provider"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+func TestPromptEvalInvokerDelegatesToEngine(t *testing.T) {
+	client := &provider.FakeClient{
+		Response: provider.Response{
+			ProviderKey:     "openai",
+			ProviderModelID: "gpt-4.1-mini",
+			FinishReason:    "stop",
+			OutputText:      "Bonjour",
+			Usage:           provider.Usage{InputTokens: 10, OutputTokens: 4, TotalTokens: 14},
+		},
+	}
+
+	invoker := NewPromptEvalInvoker(client)
+	result, err := invoker.InvokePromptEval(context.Background(), promptEvalInvokerExecutionContext())
+	if err != nil {
+		t.Fatalf("InvokePromptEval returned error: %v", err)
+	}
+	if result.StopReason != engine.StopReasonCompleted {
+		t.Fatalf("stop reason = %s, want completed", result.StopReason)
+	}
+	if result.FinalOutput != "Bonjour" {
+		t.Fatalf("final output = %q, want Bonjour", result.FinalOutput)
+	}
+	if len(client.Requests) != 1 {
+		t.Fatalf("provider request count = %d, want 1", len(client.Requests))
+	}
+	if len(client.Requests[0].Tools) != 0 {
+		t.Fatalf("prompt_eval request must not declare tools, got %d", len(client.Requests[0].Tools))
+	}
+}
+
+func promptEvalInvokerExecutionContext() repository.RunAgentExecutionContext {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+
+	return repository.RunAgentExecutionContext{
+		Run:      domain.Run{ID: runID},
+		RunAgent: domain.RunAgent{ID: runAgentID, RunID: runID, Status: domain.RunAgentStatusQueued, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()},
+		ChallengePackVersion: repository.ChallengePackVersionExecutionContext{
+			ID:       uuid.New(),
+			Manifest: []byte(`{"version":{"execution_mode":"prompt_eval"}}`),
+			Challenges: []repository.ChallengeDefinitionExecutionContext{
+				{
+					ID:           uuid.New(),
+					ChallengeKey: "translate",
+					Title:        "Translate",
+					Definition:   []byte(`{"instructions":"Translate {{text}} to French."}`),
+				},
+			},
+		},
+		ChallengeInputSet: &repository.ChallengeInputSetExecutionContext{
+			ID:       uuid.New(),
+			InputKey: "default",
+			Name:     "Default",
+			Cases: []repository.ChallengeCaseExecutionContext{
+				{
+					ID:           uuid.New(),
+					ChallengeKey: "translate",
+					CaseKey:      "hello",
+					Inputs: []challengepack.CaseInput{
+						{Key: "text", Kind: "text", Value: "hello"},
+					},
+				},
+			},
+		},
+		Deployment: repository.AgentDeploymentExecutionContext{
+			DeploymentType: "native",
+			SnapshotConfig: []byte(`{}`),
+			AgentBuildVersion: repository.AgentBuildVersionExecutionContext{
+				ID:         uuid.New(),
+				AgentKind:  "llm_agent",
+				AgentSpec:  []byte(`{}`),
+				PolicySpec: []byte(`{}`),
+			},
+			RuntimeProfile: repository.RuntimeProfileExecutionContext{
+				ExecutionTarget:   "prompt_eval",
+				TraceMode:         "preferred",
+				RunTimeoutSeconds: 30,
+				ProfileConfig:     []byte(`{}`),
+			},
+			ProviderAccount: &repository.ProviderAccountExecutionContext{
+				ID:                  uuid.New(),
+				ProviderKey:         "openai",
+				CredentialReference: "env://OPENAI_API_KEY",
+			},
+			ModelAlias: &repository.ModelAliasExecutionContext{
+				ModelCatalogEntry: repository.ModelCatalogEntryExecutionContext{
+					ProviderModelID: "gpt-4.1-mini",
+				},
+			},
+		},
+	}
+}

--- a/backend/internal/workflow/activities.go
+++ b/backend/internal/workflow/activities.go
@@ -28,6 +28,7 @@ const (
 	startHostedRunActivityName               = "workflow.start_hosted_run"
 	markHostedRunTimedOutActivityName        = "workflow.mark_hosted_run_timed_out"
 	executeNativeModelStepActivityName       = "workflow.execute_native_model_step"
+	executePromptEvalStepActivityName        = "workflow.execute_prompt_eval_step"
 	scoreRunAgentActivityName                = "workflow.score_run_agent"
 	buildRunScorecardActivityName            = "workflow.build_run_scorecard"
 	buildRunAgentReplayActivityName          = "workflow.build_run_agent_replay"
@@ -52,10 +53,15 @@ type FakeWorkHooks struct {
 	SimulateEvaluation   func(ctx context.Context, input RunAgentWorkflowInput) error
 	HostedRunStarter     HostedRunStarter
 	NativeModelInvoker   NativeModelInvoker
+	PromptEvalInvoker    PromptEvalInvoker
 }
 
 type NativeModelInvoker interface {
 	InvokeNativeModel(ctx context.Context, executionContext repository.RunAgentExecutionContext) (engine.Result, error)
+}
+
+type PromptEvalInvoker interface {
+	InvokePromptEval(ctx context.Context, executionContext repository.RunAgentExecutionContext) (engine.Result, error)
 }
 
 type Activities struct {
@@ -298,6 +304,20 @@ func (a *Activities) ExecuteNativeModelStep(ctx context.Context, input RunAgentW
 	}
 
 	_, err = a.hooks.NativeModelInvoker.InvokeNativeModel(ctx, executionContext)
+	return wrapActivityError(err)
+}
+
+func (a *Activities) ExecutePromptEvalStep(ctx context.Context, input RunAgentWorkflowInput) error {
+	if a.hooks.PromptEvalInvoker == nil {
+		return nil
+	}
+
+	executionContext, err := a.repo.GetRunAgentExecutionContextByID(ctx, input.RunAgentID)
+	if err != nil {
+		return wrapActivityError(err)
+	}
+
+	_, err = a.hooks.PromptEvalInvoker.InvokePromptEval(ctx, executionContext)
 	return wrapActivityError(err)
 }
 

--- a/backend/internal/workflow/activities.go
+++ b/backend/internal/workflow/activities.go
@@ -309,7 +309,11 @@ func (a *Activities) ExecuteNativeModelStep(ctx context.Context, input RunAgentW
 
 func (a *Activities) ExecutePromptEvalStep(ctx context.Context, input RunAgentWorkflowInput) error {
 	if a.hooks.PromptEvalInvoker == nil {
-		return nil
+		return temporal.NewNonRetryableApplicationError(
+			"prompt_eval invoker not configured",
+			"workflow.prompt_eval_invoker_missing",
+			nil,
+		)
 	}
 
 	executionContext, err := a.repo.GetRunAgentExecutionContextByID(ctx, input.RunAgentID)

--- a/backend/internal/workflow/execution_mode_test.go
+++ b/backend/internal/workflow/execution_mode_test.go
@@ -1,0 +1,26 @@
+package workflow
+
+import "testing"
+
+func TestExecutionModeFromManifest(t *testing.T) {
+	cases := []struct {
+		name     string
+		manifest string
+		want     string
+	}{
+		{"empty", "", ""},
+		{"native default", `{"version":{"number":1}}`, ""},
+		{"prompt_eval", `{"version":{"execution_mode":"prompt_eval"}}`, "prompt_eval"},
+		{"native explicit", `{"version":{"execution_mode":"native"}}`, "native"},
+		{"invalid json", `not json`, ""},
+		{"trimmed", `{"version":{"execution_mode":"  prompt_eval  "}}`, "prompt_eval"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := executionModeFromManifest([]byte(tc.manifest))
+			if got != tc.want {
+				t.Fatalf("executionModeFromManifest(%q) = %q, want %q", tc.manifest, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/workflow/register.go
+++ b/backend/internal/workflow/register.go
@@ -24,6 +24,7 @@ func Register(registrar Registrar, activities *Activities) {
 	registrar.RegisterActivityWithOptions(activities.StartHostedRun, sdkactivity.RegisterOptions{Name: startHostedRunActivityName})
 	registrar.RegisterActivityWithOptions(activities.MarkHostedRunTimedOut, sdkactivity.RegisterOptions{Name: markHostedRunTimedOutActivityName})
 	registrar.RegisterActivityWithOptions(activities.ExecuteNativeModelStep, sdkactivity.RegisterOptions{Name: executeNativeModelStepActivityName})
+	registrar.RegisterActivityWithOptions(activities.ExecutePromptEvalStep, sdkactivity.RegisterOptions{Name: executePromptEvalStepActivityName})
 	registrar.RegisterActivityWithOptions(activities.ScoreRunAgent, sdkactivity.RegisterOptions{Name: scoreRunAgentActivityName})
 	registrar.RegisterActivityWithOptions(activities.BuildRunScorecard, sdkactivity.RegisterOptions{Name: buildRunScorecardActivityName})
 	registrar.RegisterActivityWithOptions(activities.BuildRunAgentReplay, sdkactivity.RegisterOptions{Name: buildRunAgentReplayActivityName})

--- a/backend/internal/workflow/run_agent_workflow.go
+++ b/backend/internal/workflow/run_agent_workflow.go
@@ -1,10 +1,13 @@
 package workflow
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/challengepack"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/domain"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/hostedruns"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
@@ -57,6 +60,10 @@ func runAgentWorkflow(ctx sdkworkflow.Context, input RunAgentWorkflowInput) erro
 		return runHostedRunAgent(ctx, input, executionContext)
 	}
 
+	if executionModeFromManifest(executionContext.ChallengePackVersion.Manifest) == challengepack.ExecutionModePromptEval {
+		return runPromptEvalRunAgent(ctx, input, executionContext)
+	}
+
 	if err := transitionRunAgentStatus(ctx, input.RunAgentID, domain.RunAgentStatusExecuting, stringPtr("native execution started"), nil); err != nil {
 		return err
 	}
@@ -68,6 +75,43 @@ func runAgentWorkflow(ctx sdkworkflow.Context, input RunAgentWorkflowInput) erro
 	}
 	warnOnReplayBuildFailure(ctx, input.RunAgentID, "successful execution")
 	return nil
+}
+
+func runPromptEvalRunAgent(ctx sdkworkflow.Context, input RunAgentWorkflowInput, executionContext repository.RunAgentExecutionContext) error {
+	if err := transitionRunAgentStatus(ctx, input.RunAgentID, domain.RunAgentStatusExecuting, stringPtr("prompt_eval execution started"), nil); err != nil {
+		return err
+	}
+	if err := executePromptEvalStep(ctx, input, executionContext).Get(ctx, nil); err != nil {
+		return err
+	}
+	if err := transitionRunAgentStatus(ctx, input.RunAgentID, domain.RunAgentStatusEvaluating, stringPtr("prompt_eval execution completed; parent scoring pending"), nil); err != nil {
+		return err
+	}
+	warnOnReplayBuildFailure(ctx, input.RunAgentID, "successful prompt_eval execution")
+	return nil
+}
+
+func executePromptEvalStep(ctx sdkworkflow.Context, input RunAgentWorkflowInput, executionContext repository.RunAgentExecutionContext) sdkworkflow.Future {
+	return sdkworkflow.ExecuteActivity(
+		sdkworkflow.WithActivityOptions(ctx, nativeModelActivityOptions(executionContext)),
+		executePromptEvalStepActivityName,
+		input,
+	)
+}
+
+func executionModeFromManifest(manifest json.RawMessage) string {
+	if len(manifest) == 0 {
+		return ""
+	}
+	var decoded struct {
+		Version struct {
+			ExecutionMode string `json:"execution_mode"`
+		} `json:"version"`
+	}
+	if err := json.Unmarshal(manifest, &decoded); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(decoded.Version.ExecutionMode)
 }
 
 func executeNativeModelStep(ctx sdkworkflow.Context, input RunAgentWorkflowInput, executionContext repository.RunAgentExecutionContext) sdkworkflow.Future {

--- a/backend/internal/workflow/workflow_test.go
+++ b/backend/internal/workflow/workflow_test.go
@@ -378,6 +378,36 @@ func TestNativeModelActivityOptionsUseRuntimeStepTimeout(t *testing.T) {
 	}
 }
 
+func TestExecutePromptEvalStepFailsWhenInvokerNotConfigured(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	repo := newFakeRunRepository(
+		fixtureRun(runID, domain.RunStatusRunning),
+		fixtureRunAgent(runID, runAgentID, 0),
+	)
+
+	activities := NewActivities(repo, FakeWorkHooks{})
+
+	err := activities.ExecutePromptEvalStep(context.Background(), RunAgentWorkflowInput{
+		RunID:      runID,
+		RunAgentID: runAgentID,
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	var appErr *temporal.ApplicationError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected temporal application error, got %T", err)
+	}
+	if !appErr.NonRetryable() {
+		t.Fatalf("application error should be non-retryable, got %v", appErr)
+	}
+	if appErr.Type() != "workflow.prompt_eval_invoker_missing" {
+		t.Fatalf("application error type = %q, want workflow.prompt_eval_invoker_missing", appErr.Type())
+	}
+}
+
 func TestExecuteNativeModelStepWrapsNonRetryableProviderFailures(t *testing.T) {
 	runAgentID := uuid.New()
 	executionContext := nativeExecutionContext(uuid.New(), runAgentID)


### PR DESCRIPTION
Closes #189.

## Why

Every AgentClash evaluation today flows through the full agentic pipeline: create E2B sandbox → stage files → run think→act→observe loop → destroy sandbox. That is correct for tool-using agents, but it is **massive overkill** for the most common LLM eval use case — "send this prompt to N models, check the response, score it." PromptFoo's entire product is this simpler loop and it has thousands of users. AgentClash already owns every piece of infrastructure needed (providers, validators, metrics, ranking, events, scoring), but there was no way to use any of it without paying the sandbox tax.

A prompt-eval run with 5 models now costs ~$0.01 instead of ~$5, takes seconds instead of minutes, and crucially gives AgentClash the on-ramp the issue describes: **start with prompt eval → graduate to tool use → graduate to full agentic races**. Every competitor owns one of those three steps; none owns the ramp.

Scope of this PR is deliberately narrowed to the backend execution mode per issue #189. CLI (#51), LLM-as-judge (#148), and a simplified flat config format are tracked separately.

## What

A new `prompt_eval` execution mode selected by a single field on the challenge-pack version manifest:

```yaml
version:
  number: 1
  execution_mode: prompt_eval   # vs "native" (default) or hosted_external
```

When set, the run agent takes a parallel path that:

1. Skips sandbox creation / staging / destruction entirely
2. Builds a single `system + user` message pair from the challenge's `instructions` (with `{{var}}` substitution from the first case's inputs)
3. Makes **one** `provider.InvokeModel` call with `Tools: nil`
4. Emits the same event envelope shape the scoring pipeline already consumes
5. Returns a standard `engine.Result{StopReason: completed, StepCount: 1, ToolCallCount: 0}`

The scoring engine, validators, metric collectors, ranking, and run-agent state machine all run **unchanged**. Native execution is byte-identical to `main` — no shared-path refactors, no new dependencies, no schema migration.

### Architecture

```mermaid
flowchart TD
    Start([RunAgentWorkflow]) --> LoadCtx[Load execution context]
    LoadCtx --> Hosted{deployment_type<br/>== hosted_external?}
    Hosted -- yes --> HostedRun[runHostedRunAgent]
    Hosted -- no --> ModeCheck{manifest.version<br/>.execution_mode}
    ModeCheck -- prompt_eval --> PromptEval[runPromptEvalRunAgent<br/>ExecutePromptEvalStep activity]
    ModeCheck -- native/empty --> Native[executeNativeModelStep activity]
    PromptEval --> Eval[Evaluating → Completed]
    Native --> Eval
    HostedRun --> Eval
    Eval --> Score[scoring.EvaluateRunAgent<br/>unchanged]
```

### prompt_eval executor internals vs native

```mermaid
sequenceDiagram
    participant W as Worker Activity
    participant I as PromptEvalInvoker
    participant E as PromptEvalExecutor
    participant O as PromptEvalRunEventObserver
    participant P as provider.Client
    participant R as RunEvent Recorder

    W->>I: InvokePromptEval(ctx)
    I->>E: Execute(ctx, executionContext)
    E->>O: OnStepStart(1)
    O->>R: system.run.started (prompt_eval_engine)
    E->>E: buildPromptEvalMessages<br/>(render {{vars}} from first case)
    E->>O: OnProviderCall(request, Tools=nil)
    O->>R: model.call.started
    E->>P: InvokeModel(request)
    P-->>E: Response{OutputText, Usage, Timing}
    E->>O: OnProviderResponse(response)
    O->>R: model.call.completed + system.output.finalized
    E->>O: OnStepEnd(1)
    E-->>I: Result{FinalOutput, StopReason: completed, StepCount: 1}
    O->>R: system.run.completed
```

Compare the native loop it **does not** go through:

```mermaid
flowchart LR
    N1[prepareSandbox<br/>stage files] --> N2[buildToolRegistry]
    N2 --> N3{think:<br/>invoke model}
    N3 --> N4{tool_calls?}
    N4 -- yes --> N5[executeToolCalls<br/>sandbox session]
    N5 --> N6{completed?}
    N6 -- no --> N3
    N6 -- yes --> N7[destroySandbox]
    style N1 fill:#fee,stroke:#c66
    style N2 fill:#fee,stroke:#c66
    style N3 fill:#fee,stroke:#c66
    style N4 fill:#fee,stroke:#c66
    style N5 fill:#fee,stroke:#c66
    style N6 fill:#fee,stroke:#c66
    style N7 fill:#fee,stroke:#c66
```

Everything red is skipped on the prompt_eval path.

## How

Six small, focused changes:

### 1. Pack schema — \`VersionMetadata.ExecutionMode\`
\`backend/internal/challengepack/bundle.go\`, \`validation.go\`

Adds an \`execution_mode\` field to the version metadata (YAML + JSON), with constants \`ExecutionModeNative\` and \`ExecutionModePromptEval\`. Empty string defaults to native for back-compat with all existing packs. \`ManifestJSON\` serializes the mode into \`version.execution_mode\` so the workflow can read it from the frozen manifest blob stored on the run. Validation rejects:
- Unknown execution modes
- \`prompt_eval\` packs that declare \`tools\`, \`version.sandbox\`, or a non-empty \`version.tool_policy\` (fail fast — the guarantees are obvious)

### 2. Thin executor — \`engine.PromptEvalExecutor\`
\`backend/internal/engine/prompt_eval_executor.go\`

~260 LOC executor that implements the same \`Execute(ctx, RunAgentExecutionContext) (Result, error)\` contract as \`NativeExecutor\`. Reuses \`runTimeout\`, \`stepTimeout\`, \`buildProviderMetadata\`, \`extractPolicyInstructions\` from the native file. Single provider call, no retry loop (providers already handle retries internally for the simple case; can be added later if needed). \`{{var}}\` substitution uses a small regex over the first case's \`Inputs[]\` — deliberately not a full template engine to keep the surface tiny. Missing \`instructions\` and missing \`provider_account\`/\`model_alias\` are validated up front and fail with \`provider.Failure{Code: invalid_request}\`.

### 3. Temporal workflow routing
\`backend/internal/workflow/run_agent_workflow.go\`, \`activities.go\`, \`register.go\`

Adds a new branch after the existing \`hosted_external\` check:

\`\`\`go
if executionModeFromManifest(ctx.ChallengePackVersion.Manifest) == challengepack.ExecutionModePromptEval {
    return runPromptEvalRunAgent(ctx, input, executionContext)
}
\`\`\`

\`executionModeFromManifest\` decodes only \`{version: {execution_mode}}\` from the JSON manifest — zero new fields on \`RunAgentExecutionContext\`. New symmetric activity \`ExecutePromptEvalStep\` registered as \`workflow.execute_prompt_eval_step\`, backed by a new \`PromptEvalInvoker\` interface on \`FakeWorkHooks\`.

### 4. Worker wiring
\`backend/internal/worker/prompt_eval_invoker.go\`, \`prompt_eval_event_observer.go\`

Mirrors \`NativeModelInvoker\` — three constructors (default / with observer / with observer factory) and a single \`InvokePromptEval\` method that builds the executor and delegates. The event observer is a slimmer sibling of \`NativeRunEventObserver\` that:
- Emits \`system.run.started\` lazily on first event
- Records \`model.call.started\` + \`model.call.completed\` with full timing (TTFT, total latency) and usage
- Records \`system.output.finalized\` once per run
- Records \`system.run.completed\` / \`system.run.failed\` in the terminal defer

### 5. Event source
\`backend/internal/runevents/envelope.go\`

New \`SourcePromptEvalEngine = "prompt_eval_engine"\` constant added to the \`isValidSource\` allowlist. Events carry this source so scoring / replay UI can tell native and prompt_eval runs apart without inspecting payloads.

### 6. Tests
- \`engine/prompt_eval_executor_test.go\` — single-call happy path (asserts \`Tools: nil\`, 2 messages, \`{{var}}\` substitution, usage propagated, observer hits \`OnRunComplete\`), provider failure propagation, missing-instructions rejection
- \`challengepack/bundle_test.go\` — YAML parse of the prompt_eval pack from the issue, rejection of \`prompt_eval\` + tools + sandbox, rejection of unknown mode
- \`worker/prompt_eval_invoker_test.go\` — end-to-end via fake \`provider.Client\`
- \`workflow/execution_mode_test.go\` — table test for \`executionModeFromManifest\` covering empty, invalid JSON, native, prompt_eval, and whitespace-trimmed values

## Competitive framing

I did a competitive pass across PromptFoo, OpenAI Evals, Braintrust, LangSmith, Inspect AI, W&B Weave, DeepEval, Ragas, Arize Phoenix, Giskard, and lm-evaluation-harness before cutting this PR. Key findings that influenced scope:

- **PromptFoo ships ~55 assertion types**, but the 6 AgentClash already has (\`exact_match\`, \`contains\`, \`regex_match\`, \`json_schema\`, \`json_path_match\`, \`boolean_assert\`) cover the table-stakes set. Expanding the validator catalog is a separate, low-risk follow-up — not a blocker for this PR.
- **Nobody owns the "prompt-eval → tool-use → agentic" ramp.** PromptFoo's \`trajectory:*\` assertions are bolted on, LangSmith is LangChain-only, Inspect AI is Python research-grade. Keeping prompt_eval as a **mode flag on the existing pack format** rather than a parallel format is the decision that makes the ramp real — users will eventually add \`tools:\` to the same pack and graduate in place.
- **PromptFoo's biggest OSS gaps** (no persistent run history, no cross-run diffing, no \`pass^N\` stability metric, flaky \`llm-rubric\` JSON extraction, YAML doesn't scale for PMs/QA) are all AgentClash strengths or future wedges. None of them are in scope for #189, but this PR is the enabling layer.

Detailed research notes available on request.

## What's intentionally NOT in this PR

- **CLI** — tracked in #51
- **LLM-as-judge** — tracked in #148
- **Simplified flat eval.yaml DX** — future work; the verbose pack format is kept so this PR can be the minimal enabling layer
- **Streaming deltas** — prompt_eval uses a single non-streaming call. TTFT is still captured via \`Response.Timing\`. Streaming can be added in a follow-up without touching the mode plumbing.
- **Multiple cases per run** — first case of the input set is used. Multi-case fan-out is a natural follow-up, but out of scope for the execution-mode plumbing.
- **Schema migration** — none. \`execution_mode\` lives in the pack manifest JSON, not a DB column.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` full backend suite green (api, challengepack, engine, provider, releasegate, repository, runevents, sandbox, scoring, storage, worker, workflow)
- [x] `go test -race ./internal/engine/... ./internal/worker/... ./internal/workflow/...` clean
- [x] New unit tests for: schema parsing, validation rejection, executor happy path, executor failure propagation, executor missing-instructions, multi-case behavior, unresolved-token passthrough, nil-invoker error, invoker delegation, manifest mode extraction, observer event sequence + payload
- [x] Native path regression-free (existing native executor tests and workflow happy-path tests unchanged)
- [x] Live Go smoke tests: Gemini (`gemini-2.0-flash`) 3/3, Anthropic (`claude-sonnet-4-20250514`) 3/3
- [x] Full-stack curl test: Postgres + Temporal + API server + worker → publish pack → create run → run completed sub-second → 5 `prompt_eval_engine` events → scoring `correctness = 1` → scorecard API returns results
- [ ] OpenAI: not tested (no API key available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Manual testing (completed)

Full-stack curl testing was performed with Postgres + Temporal dev server + API server + worker running locally, using Gemini (`gemini-2.0-flash`) as the live provider. See [PR comment with detailed results](https://github.com/agentclash/agentclash/pull/192#issuecomment-4231168739).

### How to reproduce

```bash
export DATABASE_URL="postgres://agentclash:agentclash@localhost:5432/agentclash?sslmode=disable"
export GEMINI_API_KEY="..."     # or ANTHROPIC_API_KEY — any wired provider works
# prompt_eval does NOT need E2B — leave the sandbox provider unconfigured

# Stack
docker compose up -d postgres                            # Postgres only — Temporal is NOT in docker-compose
make db-migrate                                          # or: bash scripts/db/apply-goose-migrations.sh $DATABASE_URL
# Seed: org, workspace, user, Gemini provider account, model catalog, model alias,
#        runtime profile (execution_target=native), agent build+version,
#        agent deployment (deployment_type=native), deployment snapshot
temporal server start-dev --log-level error &             # Temporal dev server (brew install temporal)
GEMINI_API_KEY=$GEMINI_API_KEY make api-server &          # terminal 1 — serves on :8080
GEMINI_API_KEY=$GEMINI_API_KEY make worker &              # terminal 2
```

Dev auth uses headers (no cookies/sessions in dev mode):
```
X-Agentclash-User-Id: 11111111-1111-1111-1111-111111111111
X-Agentclash-Workspace-Memberships: 22222222-2222-2222-2222-222222222222:workspace_admin
```

### 1. Validate + publish a prompt_eval pack

```bash
# All API routes are under /v1/ prefix
curl -sS -X POST http://localhost:8080/v1/workspaces/$WORKSPACE_ID/challenge-packs/validate \
  -H "X-Agentclash-User-Id: 11111111-1111-1111-1111-111111111111" \
  -H "X-Agentclash-Workspace-Memberships: 22222222-2222-2222-2222-222222222222:workspace_admin" \
  --data-binary @translation-eval.yaml | jq
# Expect: {"valid": true, "errors": null}

curl -sS -X POST http://localhost:8080/v1/workspaces/$WORKSPACE_ID/challenge-packs \
  -H "X-Agentclash-User-Id: 11111111-1111-1111-1111-111111111111" \
  -H "X-Agentclash-Workspace-Memberships: 22222222-2222-2222-2222-222222222222:workspace_admin" \
  --data-binary @translation-eval.yaml | jq
# Expect 201: challenge_pack_version_id + input_set_ids[0]
```

### 2. Create a run

```bash
# DisallowUnknownFields is on — field names must be exact
curl -sS -X POST http://localhost:8080/v1/runs \
  -H "X-Agentclash-User-Id: 11111111-1111-1111-1111-111111111111" \
  -H "X-Agentclash-Workspace-Memberships: 22222222-2222-2222-2222-222222222222:workspace_admin" \
  -H "Content-Type: application/json" \
  -d '{"workspace_id":"...","challenge_pack_version_id":"...","challenge_input_set_id":"...","agent_deployment_ids":["..."]}' | jq
# Expect 201, status: queued
```

### 3. Verify

```bash
# Poll — should reach "completed" in seconds (no sandbox boot)
curl -sS http://localhost:8080/v1/runs/$RUN_ID \
  -H "X-Agentclash-User-Id: 11111111-1111-1111-1111-111111111111" \
  -H "X-Agentclash-Workspace-Memberships: 22222222-2222-2222-2222-222222222222:workspace_admin" | jq .status

# Events — all must show actor_type = prompt_eval_engine (DB column is actor_type, not source)
psql "$DATABASE_URL" -c "SELECT sequence_number, event_type, actor_type FROM run_events WHERE run_agent_id = '$RUN_AGENT_ID' ORDER BY sequence_number;"

# Scorecard
curl -sS http://localhost:8080/v1/scorecards/$RUN_AGENT_ID \
  -H "X-Agentclash-User-Id: 11111111-1111-1111-1111-111111111111" \
  -H "X-Agentclash-Workspace-Memberships: 22222222-2222-2222-2222-222222222222:workspace_admin" | jq
```

### Actual results from curl test

| Step | Result |
|---|---|
| Validate pack | `{"valid": true}` |
| Publish pack | 201, manifest `execution_mode = prompt_eval` round-tripped in DB |
| Create run | 201, `status: queued` |
| Poll completion | `completed` on first poll (sub-second) |
| Event sequence | 5 `prompt_eval_engine` events + 2 `worker_scoring` — zero native/sandbox/tool events |
| Final output | `"Bonjour le monde"`, 21 tokens, `stop_reason: completed` |
| Scoring | `correctness_score: 1`, validator `pass: 1, fail: 0` |
| Scorecard API | Full scorecard returned via `GET /v1/scorecards/{id}` |

### Failure modes to watch for

| Symptom | Likely cause |
|---|---|
| Run stuck in `running`, no events | `PromptEvalInvoker` not wired — check `FakeWorkHooks.PromptEvalInvoker` in `cmd/worker/main.go` |
| `actor_type = native_engine` on prompt_eval pack | `executionModeFromManifest` not reading manifest correctly — verify `manifest->'version'->>'execution_mode'` in DB |
| `POST /v1/runs` returns 400 | `DisallowUnknownFields` — use `agent_deployment_ids` + `challenge_input_set_id` exactly |
| Scoring empty | Event payload missing `final_output` — check `PromptEvalRunEventObserver.OnProviderResponse` |
| TTFT == total latency | Expected for non-streaming prompt_eval. True TTFT needs streaming (follow-up) |


## Live provider testing

Smoke-tested the full `PromptEvalExecutor` pipeline against real provider APIs (no mocks, no fakes — real network calls). Three prompt types per provider:

| Provider | Model | Translation | Factual | JSON output |
|---|---|---|---|---|
| Gemini | `gemini-2.0-flash` | PASS ("Bonjour le monde", 21 tokens, 1.0s) | PASS ("Tokyo", 19 tokens, 0.8s) | PASS (`{"name":"Alice","age":30}`, 48 tokens, 0.8s) |
| Anthropic | `claude-sonnet-4-20250514` | PASS ("bonjour le monde", 34 tokens, 1.8s) | PASS ("Tokyo", 28 tokens, 1.4s) | PASS (`{"name":"Alice","age":30}`, 56 tokens, 1.5s) |
| OpenAI | — | **Not tested** (no API key available) | — | — |

**What was verified per test:**
- `StopReason == completed`, `StepCount == 1`, `ToolCallCount == 0`
- `FinalOutput` non-empty and semantically correct (case-insensitive contains for text; `json.Valid` + key check for JSON)
- `Usage.TotalTokens > 0`
- Observer hit `OnProviderCall` + `OnProviderResponse` + `OnRunComplete` exactly once each
- No `OnToolExecution` events (confirms `Tools: nil` in the request)

**How to reproduce** (build-tagged, won't run in CI):
```bash
cd backend
GEMINI_API_KEY=... ANTHROPIC_API_KEY=... \
  go test ./internal/engine/... -tags=promptevalsmoke -run Smoke -v -timeout=120s
```

