### PR TITLE
feat(security): harden sandbox secret isolation (#186)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -37,4 +37,21 @@ E2B_REQUEST_TIMEOUT=30s
 # key, then redeploy with the new AGENTCLASH_SECRETS_MASTER_KEY. The
 # ciphertext layout reserves a version byte so a future release can
 # add a dual-key reader without a data migration.
+#
+# Where ${secrets.X} can be used (v1):
+#   - Composed-tool args that delegate to the `http_request` primitive
+#     (Authorization / API key headers). This is the ONLY sanctioned
+#     path. Any other primitive (`exec`, `query_sql`, `submit`, etc.)
+#     rejects ${secrets.X} at pack-build time with a clear error — the
+#     resolved plaintext would otherwise land in /proc/[pid]/cmdline
+#     or similar sandbox surfaces the evaluated agent can observe.
+#   - Sandbox env_vars CANNOT carry ${secrets.X}. They must be literal
+#     strings. Per-call exec in E2B doesn't inherit sandbox-level env
+#     anyway, so this loses no real capability — use http_request
+#     headers instead.
+#
+# See issue #186 for the full sandbox secret-isolation threat model
+# and the hardening that makes the http_request path safe (post-exec
+# request-file scrub, response header stripping, sanitized error
+# paths).
 AGENTCLASH_SECRETS_MASTER_KEY=

--- a/backend/e2b-template/tools/http_request.py
+++ b/backend/e2b-template/tools/http_request.py
@@ -86,31 +86,49 @@ def main() -> None:
     output_path = (request.get("output_path") or "").strip()
     max_response_body_bytes = int(request.get("max_response_body_bytes") or 0)
 
-    with httpx.Client(timeout=timeout_seconds, follow_redirects=True) as client:
-        response = client.request(
-            request["method"],
-            request["url"],
-            headers=request.get("headers") or {},
-            content=body.encode("utf-8") if body else None,
-        )
+    # The request dict carries resolved Authorization headers when a
+    # composed tool substituted ${secrets.*} before reaching this
+    # process. We MUST NOT let any exception handler dump those back
+    # to stderr: stderr flows through to the agent via the tool
+    # result error message path, which would leak the secret. Every
+    # error is reformatted to a type-only sanitized string before
+    # calling fail(). See issue #186.
+    try:
+        with httpx.Client(timeout=timeout_seconds, follow_redirects=True) as client:
+            response = client.request(
+                request["method"],
+                request["url"],
+                headers=request.get("headers") or {},
+                content=body.encode("utf-8") if body else None,
+            )
 
-        payload = {
-            "status_code": response.status_code,
-            "headers": dict(response.headers),
-            "url": str(response.url),
-        }
+            payload = {
+                "status_code": response.status_code,
+                "headers": dict(response.headers),
+                "url": str(response.url),
+            }
 
-        if output_path:
-            content = bounded_content(response, max_response_body_bytes)
-            os.makedirs(os.path.dirname(output_path), exist_ok=True)
-            with open(output_path, "wb") as fh:
-                fh.write(content)
-            payload["output_path"] = output_path
-            payload["bytes_downloaded"] = len(content)
-        else:
-            content = bounded_content(response, max_response_body_bytes)
-            payload["body"] = content.decode(response.encoding or "utf-8", errors="replace")
-            payload["body_bytes"] = len(content)
+            if output_path:
+                content = bounded_content(response, max_response_body_bytes)
+                os.makedirs(os.path.dirname(output_path), exist_ok=True)
+                with open(output_path, "wb") as fh:
+                    fh.write(content)
+                payload["output_path"] = output_path
+                payload["bytes_downloaded"] = len(content)
+            else:
+                content = bounded_content(response, max_response_body_bytes)
+                payload["body"] = content.decode(response.encoding or "utf-8", errors="replace")
+                payload["body_bytes"] = len(content)
+    except httpx.TimeoutException:
+        fail("http request timed out")
+    except httpx.ConnectError:
+        fail("http connection error")
+    except httpx.HTTPError as exc:
+        # Only the exception class name — not str(exc), which may
+        # include URL or headers depending on the httpx release.
+        fail(f"http error: {type(exc).__name__}")
+    except Exception as exc:
+        fail(f"unexpected http_request failure: {type(exc).__name__}")
 
     print(json.dumps(payload))
 

--- a/backend/e2b-template/tools/http_request.py
+++ b/backend/e2b-template/tools/http_request.py
@@ -73,27 +73,31 @@ def main() -> None:
     if len(sys.argv) != 2:
         fail("usage: http_request.py <request.json>")
 
-    request = load_request(sys.argv[1])
-    allowlist = request.get("network_allowlist") or []
-    validate_target(request["url"], allowlist)
-
-    body = request.get("body") or ""
-    max_request_body_bytes = int(request.get("max_request_body_bytes") or 0)
-    if max_request_body_bytes > 0 and len(body.encode("utf-8")) > max_request_body_bytes:
-        fail("request body exceeds size limit")
-
-    timeout_seconds = int(request.get("timeout_seconds") or 30)
-    output_path = (request.get("output_path") or "").strip()
-    max_response_body_bytes = int(request.get("max_response_body_bytes") or 0)
-
-    # The request dict carries resolved Authorization headers when a
-    # composed tool substituted ${secrets.*} before reaching this
-    # process. We MUST NOT let any exception handler dump those back
-    # to stderr: stderr flows through to the agent via the tool
-    # result error message path, which would leak the secret. Every
-    # error is reformatted to a type-only sanitized string before
-    # calling fail(). See issue #186.
+    # The request dict carries resolved ${secrets.*} values (typically
+    # in Authorization headers) when a composed tool substituted them
+    # at registry-build time. We MUST NOT let any exception handler
+    # dump those back to stderr: stderr flows through to the tool
+    # result error message path, which would leak the secret to the
+    # agent. Every uncaught failure is reformatted to a type-only
+    # sanitized string before calling fail(). The wrapper covers the
+    # FULL main-body (including URL validation and body size checks),
+    # not just the HTTP exchange — an exception in urlparse or
+    # socket.getaddrinfo could otherwise stringify the URL with
+    # userinfo attached and leak. See issue #186.
     try:
+        request = load_request(sys.argv[1])
+        allowlist = request.get("network_allowlist") or []
+        validate_target(request["url"], allowlist)
+
+        body = request.get("body") or ""
+        max_request_body_bytes = int(request.get("max_request_body_bytes") or 0)
+        if max_request_body_bytes > 0 and len(body.encode("utf-8")) > max_request_body_bytes:
+            fail("request body exceeds size limit")
+
+        timeout_seconds = int(request.get("timeout_seconds") or 30)
+        output_path = (request.get("output_path") or "").strip()
+        max_response_body_bytes = int(request.get("max_response_body_bytes") or 0)
+
         with httpx.Client(timeout=timeout_seconds, follow_redirects=True) as client:
             response = client.request(
                 request["method"],
@@ -119,6 +123,10 @@ def main() -> None:
                 content = bounded_content(response, max_response_body_bytes)
                 payload["body"] = content.decode(response.encoding or "utf-8", errors="replace")
                 payload["body_bytes"] = len(content)
+    except SystemExit:
+        # fail() raises SystemExit with a sanitized message already
+        # printed — re-raise so the exit code propagates.
+        raise
     except httpx.TimeoutException:
         fail("http request timed out")
     except httpx.ConnectError:

--- a/backend/internal/engine/native_executor.go
+++ b/backend/internal/engine/native_executor.go
@@ -194,14 +194,17 @@ func (e NativeExecutor) Execute(ctx context.Context, executionContext repository
 		return Result{}, NewFailure(StopReasonSandboxError, sandbox.ErrProviderNotConfigured.Error(), sandbox.ErrProviderNotConfigured)
 	}
 
+	sandboxRequest, err := nativeSandboxRequest(executionContext)
+	if err != nil {
+		return Result{}, NewFailure(StopReasonSandboxError, "build native sandbox request", err)
+	}
+
+	// Secrets are loaded AFTER sandbox request construction because
+	// env_vars are literals-only (#186) — only the composed-tool
+	// build path below consumes the workspace secret map.
 	workspaceSecrets, err := e.loadWorkspaceSecrets(ctx, executionContext.Run.WorkspaceID)
 	if err != nil {
 		return Result{}, NewFailure(StopReasonSandboxError, "load workspace secrets", err)
-	}
-
-	sandboxRequest, err := nativeSandboxRequest(executionContext, workspaceSecrets)
-	if err != nil {
-		return Result{}, NewFailure(StopReasonSandboxError, "build native sandbox request", err)
 	}
 
 	session, err := e.prepareSandbox(ctx, executionContext, sandboxRequest)
@@ -685,7 +688,7 @@ func cleanupSandboxOnError(session sandbox.Session, originalErr error) error {
 	return originalErr
 }
 
-func nativeSandboxRequest(executionContext repository.RunAgentExecutionContext, workspaceSecrets map[string]string) (sandbox.CreateRequest, error) {
+func nativeSandboxRequest(executionContext repository.RunAgentExecutionContext) (sandbox.CreateRequest, error) {
 	policy := sandbox.ToolPolicy{
 		AllowedToolKinds: allowedToolKinds(executionContext.ChallengePackVersion.Manifest),
 		AllowShell:       false,
@@ -711,7 +714,7 @@ func nativeSandboxRequest(executionContext repository.RunAgentExecutionContext, 
 		Labels:     sandboxLabels(executionContext),
 	}
 
-	if err := applySandboxConfig(&request, executionContext.ChallengePackVersion.Manifest, workspaceSecrets); err != nil {
+	if err := applySandboxConfig(&request, executionContext.ChallengePackVersion.Manifest); err != nil {
 		return sandbox.CreateRequest{}, err
 	}
 
@@ -802,7 +805,7 @@ func applyRuntimeSandboxPolicy(policy *sandbox.ToolPolicy, filesystem *sandbox.F
 	)
 }
 
-func applySandboxConfig(request *sandbox.CreateRequest, manifest json.RawMessage, workspaceSecrets map[string]string) error {
+func applySandboxConfig(request *sandbox.CreateRequest, manifest json.RawMessage) error {
 	type sandboxBlock struct {
 		NetworkAccess      bool              `json:"network_access"`
 		NetworkAllowlist   []string          `json:"network_allowlist"`
@@ -834,11 +837,10 @@ func applySandboxConfig(request *sandbox.CreateRequest, manifest json.RawMessage
 			request.NetworkAllowlist = decoded.Sandbox.NetworkAllowlist
 		}
 		if len(decoded.Sandbox.EnvVars) > 0 {
-			resolved, err := resolveEnvVarTemplates(decoded.Sandbox.EnvVars, workspaceSecrets)
-			if err != nil {
+			if err := validateEnvVarLiterals(decoded.Sandbox.EnvVars); err != nil {
 				return err
 			}
-			request.EnvVars = resolved
+			request.EnvVars = decoded.Sandbox.EnvVars
 		}
 		if len(decoded.Sandbox.AdditionalPackages) > 0 {
 			request.AdditionalPackages = decoded.Sandbox.AdditionalPackages
@@ -856,54 +858,38 @@ func applySandboxConfig(request *sandbox.CreateRequest, manifest json.RawMessage
 	return nil
 }
 
-// resolveEnvVarTemplates substitutes ${secrets.X} placeholders in env_var
-// values. env_vars intentionally only accept the secrets namespace: they're
-// injected into a shell environment, not a tool call, so parameter refs
-// and other template expressions would be meaningless and confusing.
-// Missing secrets are a hard error — silently leaking a literal
-// "${secrets.X}" into the sandbox environment would be a security hazard.
-func resolveEnvVarTemplates(envVars map[string]string, workspaceSecrets map[string]string) (map[string]string, error) {
-	out := make(map[string]string, len(envVars))
+// validateEnvVarLiterals rejects any env_var value that contains a
+// ${...} placeholder. Sandbox env_vars are intentionally literals
+// only:
+//
+//  1. Per-call exec in E2B does not inherit sandbox-level env (see
+//     e2b/session.go:176-184), so secrets injected here would be
+//     invisible to agent-spawned processes anyway.
+//  2. Any process that DOES see them (boot-time shell) runs as root
+//     in the sandbox and shares a uid with the agent, so /proc
+//     inspection could leak them.
+//
+// Pack authors who need to authenticate a remote API should use the
+// http_request primitive with ${secrets.*} in headers — that's the
+// one hardened path. See issue #186.
+func validateEnvVarLiterals(envVars map[string]string) error {
 	for key, value := range envVars {
-		resolved, err := resolveEnvVarTemplate(value, workspaceSecrets)
-		if err != nil {
-			return nil, fmt.Errorf("env_vars[%q]: %w", key, err)
+		if idx := strings.Index(value, "${"); idx >= 0 {
+			after := value[idx+2:]
+			end := strings.Index(after, "}")
+			var placeholder string
+			if end >= 0 {
+				placeholder = "${" + after[:end] + "}"
+			} else {
+				placeholder = "${" + after + "..."
+			}
+			if strings.HasPrefix(after, "secrets.") {
+				return fmt.Errorf("env_vars[%q] references %s; sandbox env_vars cannot carry secrets — use http_request headers instead (issue #186)", key, placeholder)
+			}
+			return fmt.Errorf("env_vars[%q] contains placeholder %s; sandbox env_vars must be literal strings", key, placeholder)
 		}
-		out[key] = resolved
 	}
-	return out, nil
-}
-
-func resolveEnvVarTemplate(value string, workspaceSecrets map[string]string) (string, error) {
-	var builder strings.Builder
-	remaining := value
-	for {
-		idx := strings.Index(remaining, "${")
-		if idx == -1 {
-			builder.WriteString(remaining)
-			return builder.String(), nil
-		}
-		builder.WriteString(remaining[:idx])
-		after := remaining[idx+2:]
-		closeIdx := strings.Index(after, "}")
-		if closeIdx == -1 {
-			return "", fmt.Errorf("unclosed placeholder near %q", remaining[idx:])
-		}
-		expr := after[:closeIdx]
-		if !strings.HasPrefix(expr, "secrets.") {
-			return "", fmt.Errorf("only ${secrets.X} placeholders are allowed, got ${%s}", expr)
-		}
-		secretKey := strings.TrimPrefix(expr, "secrets.")
-		if secretKey == "" {
-			return "", fmt.Errorf("empty secret reference ${%s}", expr)
-		}
-		secretValue, ok := workspaceSecrets[secretKey]
-		if !ok {
-			return "", fmt.Errorf("missing workspace secret %q", secretKey)
-		}
-		builder.WriteString(secretValue)
-		remaining = after[closeIdx+1:]
-	}
+	return nil
 }
 
 func (e NativeExecutor) loadWorkspaceSecrets(ctx context.Context, workspaceID uuid.UUID) (map[string]string, error) {

--- a/backend/internal/engine/native_executor_secrets_test.go
+++ b/backend/internal/engine/native_executor_secrets_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"strings"
@@ -25,6 +26,129 @@ func (s *stubSecretsLookup) LoadWorkspaceSecrets(_ context.Context, workspaceID 
 		return nil, s.err
 	}
 	return s.secrets, nil
+}
+
+// TestComposedHttpRequest_SecretIsolation_FullStack ties every #186
+// defense into one flow: a composed tool authenticates against a
+// remote API using a workspace secret, the remote "server" echoes
+// every request header back (the adversarial case), and we walk
+// every surface an agent could look at to confirm the plaintext
+// secret is nowhere observable after the tool returns.
+//
+// Covers:
+//   - step 1: primitive secret-exposure gate — http_request must
+//     remain the sanctioned primitive and accept the secret.
+//   - step 3: post-exec request-file scrub — fake session's Files()
+//     must not contain the plaintext after return.
+//   - step 4: response header stripping — the simulated echo of
+//     Authorization must be redacted in result.Content.
+func TestComposedHttpRequest_SecretIsolation_FullStack(t *testing.T) {
+	const secretValue = "super-secret-token-42"
+	manifest := []byte(`{
+		"tools": {
+			"custom": [
+				{
+					"name": "call_api",
+					"description": "authenticated API call",
+					"parameters": {"type": "object", "additionalProperties": false},
+					"implementation": {
+						"type": "primitive",
+						"primitive": "http_request",
+						"args": {
+							"method": "GET",
+							"url": "https://api.example.com/data",
+							"headers": {"Authorization": "Bearer ${secrets.API_KEY}"}
+						}
+					}
+				}
+			]
+		}
+	}`)
+
+	registry, err := buildToolRegistry(
+		sandbox.ToolPolicy{AllowNetwork: true, AllowedToolKinds: []string{toolKindNetwork}},
+		manifest,
+		nil,
+		map[string]string{"API_KEY": secretValue},
+	)
+	if err != nil {
+		t.Fatalf("buildToolRegistry returned error: %v", err)
+	}
+
+	var fileAtExecTime []byte
+	session := sandbox.NewFakeSession("integration-secrets")
+	session.SetExecFunc(func(req sandbox.ExecRequest, files map[string][]byte) (sandbox.ExecResult, error) {
+		switch req.Command[0] {
+		case "mkdir":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case "python3":
+			fileAtExecTime = append([]byte(nil), files[req.Command[2]]...)
+			// Server echoes every request header back — the exact
+			// adversarial shape step 4 was designed to defend against.
+			return sandbox.ExecResult{
+				ExitCode: 0,
+				Stdout: `{"status_code":200,"headers":{` +
+					`"Content-Type":"application/json",` +
+					`"Authorization":"Bearer ` + secretValue + `",` +
+					`"Set-Cookie":"sid=` + secretValue + `",` +
+					`"X-Request-Id":"opaque"` +
+					`},"url":"https://api.example.com/data","body":"{\"ok\":true}","body_bytes":11}`,
+			}, nil
+		default:
+			t.Fatalf("unexpected command: %#v", req.Command)
+			return sandbox.ExecResult{}, nil
+		}
+	})
+
+	tool, ok := registry.Resolve("call_api")
+	if !ok {
+		t.Fatalf("composed tool call_api should be registered")
+	}
+
+	result, err := tool.Execute(t.Context(), ToolExecutionRequest{
+		Registry:         registry,
+		Session:          session,
+		ToolPolicy:       sandbox.ToolPolicy{AllowNetwork: true, AllowedToolKinds: []string{toolKindNetwork}},
+		NetworkAllowlist: []string{"203.0.113.0/24"},
+	})
+	if err != nil {
+		t.Fatalf("composed tool Execute returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("composed tool returned error result: %s", result.Content)
+	}
+
+	// Sanity: the secret DID reach the request file during exec —
+	// otherwise the subsequent "gone after return" check is vacuous.
+	if !bytes.Contains(fileAtExecTime, []byte(secretValue)) {
+		t.Fatalf("expected secret in request file at exec time, got %q", string(fileAtExecTime))
+	}
+
+	// Defense #3 (file scrub): no file in the sandbox session carries
+	// the plaintext secret after composed-tool Execute returns. This
+	// is what blocks an adversarial read_file("...tool-inputs/...").
+	for path, content := range session.Files() {
+		if bytes.Contains(content, []byte(secretValue)) {
+			t.Fatalf("file %q leaks plaintext secret after Execute returned: %q", path, string(content))
+		}
+	}
+
+	// Defense #4 (response header scrub): the server-echoed
+	// Authorization header is stripped from result.Content, so the
+	// LLM context and run_events never see the plaintext.
+	if strings.Contains(result.Content, secretValue) {
+		t.Fatalf("result content leaked secret: %s", result.Content)
+	}
+	if !strings.Contains(result.Content, redactedHeaderMarker) {
+		t.Fatalf("result content missing redaction marker: %s", result.Content)
+	}
+	// Non-sensitive fields survive.
+	if !strings.Contains(result.Content, "X-Request-Id") || !strings.Contains(result.Content, "opaque") {
+		t.Fatalf("non-sensitive fields dropped: %s", result.Content)
+	}
+	if !strings.Contains(result.Content, `"status_code":200`) {
+		t.Fatalf("status code dropped: %s", result.Content)
+	}
 }
 
 func TestNativeExecutor_RejectsSecretReferencesInEnvVars(t *testing.T) {

--- a/backend/internal/engine/native_executor_secrets_test.go
+++ b/backend/internal/engine/native_executor_secrets_test.go
@@ -27,75 +27,12 @@ func (s *stubSecretsLookup) LoadWorkspaceSecrets(_ context.Context, workspaceID 
 	return s.secrets, nil
 }
 
-func TestNativeExecutor_EnvVarSecretResolution_EndToEnd(t *testing.T) {
-	workspaceID := uuid.New()
-	ec := nativeExecutionContext()
-	ec.Run.WorkspaceID = workspaceID
-	ec.ChallengePackVersion.Manifest = []byte(`{
-		"tool_policy": {"allowed_tool_kinds": ["file"]},
-		"sandbox": {
-			"env_vars": {
-				"DB_URL": "${secrets.DB_URL}",
-				"LITERAL": "plain"
-			}
-		}
-	}`)
-
-	secretsStore := &stubSecretsLookup{
-		secrets: map[string]string{"DB_URL": "postgres://user:pass@host/db"},
-	}
-
-	session := sandbox.NewFakeSession("sandbox-secrets")
-	sandboxProvider := &sandbox.FakeProvider{NextSession: session}
-	client := &scriptedProviderClient{
-		t: t,
-		steps: []providerStep{
-			{
-				response: provider.Response{
-					ProviderKey:     "openai",
-					ProviderModelID: "gpt-4.1",
-					FinishReason:    "tool_calls",
-					ToolCalls: []provider.ToolCall{
-						{
-							ID:        "call-submit",
-							Name:      submitToolName,
-							Arguments: []byte(`{"answer":"done"}`),
-						},
-					},
-				},
-			},
-		},
-	}
-
-	executor := NewNativeExecutor(client, sandboxProvider, NoopObserver{}).WithSecretsLookup(secretsStore)
-	result, err := executor.Execute(context.Background(), ec)
-	if err != nil {
-		t.Fatalf("Execute returned error: %v", err)
-	}
-	if result.StopReason != StopReasonCompleted {
-		t.Fatalf("stop reason = %s, want completed", result.StopReason)
-	}
-
-	if secretsStore.calls != 1 {
-		t.Fatalf("secrets lookup called %d times, want 1", secretsStore.calls)
-	}
-	if secretsStore.lastID != workspaceID {
-		t.Fatalf("secrets lookup workspace = %s, want %s", secretsStore.lastID, workspaceID)
-	}
-
-	if len(sandboxProvider.CreateRequests) != 1 {
-		t.Fatalf("sandbox create calls = %d, want 1", len(sandboxProvider.CreateRequests))
-	}
-	request := sandboxProvider.CreateRequests[0]
-	if got, want := request.EnvVars["DB_URL"], "postgres://user:pass@host/db"; got != want {
-		t.Fatalf("sandbox env DB_URL = %q, want %q", got, want)
-	}
-	if got, want := request.EnvVars["LITERAL"], "plain"; got != want {
-		t.Fatalf("sandbox env LITERAL = %q, want %q", got, want)
-	}
-}
-
-func TestNativeExecutor_MissingSecretFailsRunBeforeSandbox(t *testing.T) {
+func TestNativeExecutor_RejectsSecretReferencesInEnvVars(t *testing.T) {
+	// Regardless of whether the workspace actually has the secret,
+	// sandbox env_vars cannot carry ${secrets.*} references — they
+	// have no working use case (per-call exec does not inherit
+	// sandbox env) and opening that path would leak secrets to any
+	// boot-time process the sandbox spawns. See issue #186.
 	workspaceID := uuid.New()
 	ec := nativeExecutionContext()
 	ec.Run.WorkspaceID = workspaceID
@@ -103,14 +40,15 @@ func TestNativeExecutor_MissingSecretFailsRunBeforeSandbox(t *testing.T) {
 		"sandbox": {"env_vars": {"DB_URL": "${secrets.DB_URL}"}}
 	}`)
 
-	// Workspace has no secrets stored.
-	secretsStore := &stubSecretsLookup{secrets: map[string]string{}}
+	// Intentionally provide the secret — the rejection must fire
+	// regardless.
+	secretsStore := &stubSecretsLookup{secrets: map[string]string{"DB_URL": "postgres://x"}}
 	sandboxProvider := &sandbox.FakeProvider{NextSession: sandbox.NewFakeSession("unused")}
 	executor := NewNativeExecutor(&provider.FakeClient{}, sandboxProvider, NoopObserver{}).WithSecretsLookup(secretsStore)
 
 	_, err := executor.Execute(context.Background(), ec)
 	if err == nil {
-		t.Fatalf("expected Execute to fail on missing secret")
+		t.Fatalf("expected Execute to reject secret reference in env_var")
 	}
 	failure, ok := AsFailure(err)
 	if !ok {
@@ -119,12 +57,11 @@ func TestNativeExecutor_MissingSecretFailsRunBeforeSandbox(t *testing.T) {
 	if failure.StopReason != StopReasonSandboxError {
 		t.Fatalf("stop reason = %s, want %s", failure.StopReason, StopReasonSandboxError)
 	}
-	if failure.Cause == nil || !strings.Contains(failure.Cause.Error(), "DB_URL") {
-		t.Fatalf("wrapped cause should name the missing secret: %v", failure.Cause)
+	if failure.Cause == nil || !strings.Contains(failure.Cause.Error(), "http_request") {
+		t.Fatalf("cause should point at http_request as the sanctioned path: %v", failure.Cause)
 	}
-	// Sandbox must NOT have been provisioned if env_var resolution failed.
 	if len(sandboxProvider.CreateRequests) != 0 {
-		t.Fatalf("sandbox was provisioned despite secret failure: %d calls", len(sandboxProvider.CreateRequests))
+		t.Fatalf("sandbox was provisioned despite rejection: %d calls", len(sandboxProvider.CreateRequests))
 	}
 }
 

--- a/backend/internal/engine/native_executor_secrets_test.go
+++ b/backend/internal/engine/native_executor_secrets_test.go
@@ -28,6 +28,141 @@ func (s *stubSecretsLookup) LoadWorkspaceSecrets(_ context.Context, workspaceID 
 	return s.secrets, nil
 }
 
+// capturingObserver records every OnToolExecution call so a test
+// can walk the full record surface and assert no secret material
+// flows through to what run_events will persist.
+type capturingObserver struct {
+	NoopObserver
+	records []ToolExecutionRecord
+}
+
+func (c *capturingObserver) OnToolExecution(_ context.Context, record ToolExecutionRecord) error {
+	c.records = append(c.records, record)
+	return nil
+}
+
+// TestComposedHttpRequest_SecretIsolation_ThroughNativeExecutor runs a
+// composed tool that uses ${secrets.X} through the full
+// NativeExecutor.Execute loop (not just tool.Execute directly) so the
+// observer path — which feeds run_events persistence — is exercised.
+// Any secret material landing in a ToolExecutionRecord would get
+// persisted to the database in production.
+func TestComposedHttpRequest_SecretIsolation_ThroughNativeExecutor(t *testing.T) {
+	const secretValue = "nativeexec-secret-value-99"
+	workspaceID := uuid.New()
+
+	ec := nativeExecutionContext()
+	ec.Run.WorkspaceID = workspaceID
+	ec.ChallengePackVersion.Manifest = []byte(`{
+		"tool_policy": {"allowed_tool_kinds": ["network"], "allow_network": true},
+		"tools": {"custom": [{
+			"name": "call_api",
+			"description": "authenticated API call",
+			"parameters": {"type":"object","additionalProperties":false},
+			"implementation": {
+				"type": "primitive",
+				"primitive": "http_request",
+				"args": {
+					"method": "GET",
+					"url": "https://api.example.com",
+					"headers": {"Authorization": "Bearer ${secrets.API_KEY}"}
+				}
+			}
+		}]}
+	}`)
+
+	secretsStore := &stubSecretsLookup{secrets: map[string]string{"API_KEY": secretValue}}
+
+	session := sandbox.NewFakeSession("native-secrets-end-to-end")
+	session.SetExecFunc(func(req sandbox.ExecRequest, _ map[string][]byte) (sandbox.ExecResult, error) {
+		switch req.Command[0] {
+		case "mkdir":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case "python3":
+			// Simulate an echoing server (same adversarial shape as
+			// TestComposedHttpRequest_SecretIsolation_FullStack).
+			return sandbox.ExecResult{
+				ExitCode: 0,
+				Stdout: `{"status_code":200,"headers":{` +
+					`"Content-Type":"application/json",` +
+					`"Authorization":"Bearer ` + secretValue + `",` +
+					`"Set-Cookie":"sid=` + secretValue + `"` +
+					`},"url":"https://api.example.com","body":"ok","body_bytes":2}`,
+			}, nil
+		default:
+			return sandbox.ExecResult{}, nil
+		}
+	})
+
+	client := &scriptedProviderClient{
+		t: t,
+		steps: []providerStep{
+			{
+				response: provider.Response{
+					ProviderKey:     "openai",
+					ProviderModelID: "gpt-4.1",
+					FinishReason:    "tool_calls",
+					ToolCalls: []provider.ToolCall{
+						{
+							ID:        "call-api-1",
+							Name:      "call_api",
+							Arguments: []byte(`{}`),
+						},
+					},
+				},
+			},
+			{
+				response: provider.Response{
+					ProviderKey:     "openai",
+					ProviderModelID: "gpt-4.1",
+					FinishReason:    "tool_calls",
+					ToolCalls: []provider.ToolCall{
+						{
+							ID:        "call-submit",
+							Name:      submitToolName,
+							Arguments: []byte(`{"answer":"done"}`),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	observer := &capturingObserver{}
+	executor := NewNativeExecutor(client, &sandbox.FakeProvider{NextSession: session}, observer).WithSecretsLookup(secretsStore)
+	result, err := executor.Execute(context.Background(), ec)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.StopReason != StopReasonCompleted {
+		t.Fatalf("stop reason = %s, want completed", result.StopReason)
+	}
+
+	// Walk every observer record — the persisted run_events surface
+	// — and assert the plaintext secret is nowhere in it. This is the
+	// test that would catch a regression where the composed tool
+	// resolver or the observer layer logged encodedArgs.
+	if len(observer.records) == 0 {
+		t.Fatalf("observer recorded zero tool executions; scripted provider should have produced at least one")
+	}
+	for i, record := range observer.records {
+		if strings.Contains(string(record.ToolCall.Arguments), secretValue) {
+			t.Fatalf("record[%d] ToolCall.Arguments leaked secret: %s", i, string(record.ToolCall.Arguments))
+		}
+		if strings.Contains(record.Result.Content, secretValue) {
+			t.Fatalf("record[%d] Result.Content leaked secret (would land in run_events): %s", i, record.Result.Content)
+		}
+	}
+
+	// Also re-verify the filesystem post-return invariant holds on
+	// the full executor path.
+	for path, content := range session.Files() {
+		if bytes.Contains(content, []byte(secretValue)) {
+			t.Fatalf("session file %q leaks secret after Execute returned: %q", path, string(content))
+		}
+	}
+}
+
 // TestComposedHttpRequest_SecretIsolation_FullStack ties every #186
 // defense into one flow: a composed tool authenticates against a
 // remote API using a workspace secret, the remote "server" echoes

--- a/backend/internal/engine/primitive_http_request_test.go
+++ b/backend/internal/engine/primitive_http_request_test.go
@@ -96,6 +96,45 @@ func TestHTTPRequestTool_ReturnsToolErrorOnScriptFailure(t *testing.T) {
 	}
 }
 
+func TestHTTPRequestTool_DecodeErrorDoesNotLeakStdoutBytes(t *testing.T) {
+	// If python emits a malformed response, the json.Unmarshal error
+	// used to include a slice of the unparsable bytes — which could
+	// contain an Authorization header the server echoed back. The
+	// decode error must be generic now; no stdout bytes in the cause.
+	session := sandbox.NewFakeSession("http-bad-json")
+	session.SetExecFunc(func(request sandbox.ExecRequest, _ map[string][]byte) (sandbox.ExecResult, error) {
+		switch request.Command[0] {
+		case "mkdir":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case "python3":
+			// Not JSON — and crucially, it contains what looks like a
+			// leaked secret. None of these bytes may surface in the
+			// returned error.
+			return sandbox.ExecResult{
+				ExitCode: 0,
+				Stdout:   `{"status_code":200,"headers":{"Authorization":"Bearer LEAKED_VALUE"`,
+			}, nil
+		default:
+			return sandbox.ExecResult{}, nil
+		}
+	})
+
+	_, err := executeHTTPRequestTool(t.Context(), ToolExecutionRequest{
+		Args:       json.RawMessage(`{"method":"GET","url":"https://api.example.com"}`),
+		Session:    session,
+		ToolPolicy: sandbox.ToolPolicy{AllowedToolKinds: []string{toolKindNetwork}, AllowNetwork: true},
+	})
+	if err == nil {
+		t.Fatalf("expected decode error, got nil")
+	}
+	if strings.Contains(err.Error(), "LEAKED_VALUE") {
+		t.Fatalf("decode error leaked raw stdout bytes: %v", err)
+	}
+	if strings.Contains(err.Error(), "Authorization") {
+		t.Fatalf("decode error leaked header name from stdout: %v", err)
+	}
+}
+
 func TestHTTPRequestTool_StripsSensitiveResponseHeaders(t *testing.T) {
 	session := sandbox.NewFakeSession("http-echo-auth")
 	session.SetExecFunc(func(request sandbox.ExecRequest, _ map[string][]byte) (sandbox.ExecResult, error) {

--- a/backend/internal/engine/primitive_http_request_test.go
+++ b/backend/internal/engine/primitive_http_request_test.go
@@ -96,6 +96,68 @@ func TestHTTPRequestTool_ReturnsToolErrorOnScriptFailure(t *testing.T) {
 	}
 }
 
+func TestHTTPRequestTool_StripsSensitiveResponseHeaders(t *testing.T) {
+	session := sandbox.NewFakeSession("http-echo-auth")
+	session.SetExecFunc(func(request sandbox.ExecRequest, _ map[string][]byte) (sandbox.ExecResult, error) {
+		switch request.Command[0] {
+		case "mkdir":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case "python3":
+			// Simulate a server that echoes every header back — this is
+			// the exact failure mode step 4 must defend against.
+			return sandbox.ExecResult{
+				ExitCode: 0,
+				Stdout: `{"status_code":200,"headers":{` +
+					`"Content-Type":"application/json",` +
+					`"Authorization":"Bearer super-secret",` +
+					`"Set-Cookie":"sid=abc123",` +
+					`"X-API-Key":"leaked",` +
+					`"x-auth-token":"leaked2",` +
+					`"WWW-Authenticate":"Basic realm=\"x\"",` +
+					`"X-Request-Id":"safe-opaque"` +
+					`},"url":"https://api.example.com","body":"ok","body_bytes":2}`,
+			}, nil
+		default:
+			t.Fatalf("unexpected command: %#v", request.Command)
+			return sandbox.ExecResult{}, nil
+		}
+	})
+
+	result, err := executeHTTPRequestTool(t.Context(), ToolExecutionRequest{
+		Args:       json.RawMessage(`{"method":"GET","url":"https://api.example.com","headers":{"Authorization":"Bearer super-secret"}}`),
+		Session:    session,
+		ToolPolicy: sandbox.ToolPolicy{AllowedToolKinds: []string{toolKindNetwork}, AllowNetwork: true},
+	})
+	if err != nil {
+		t.Fatalf("executeHTTPRequestTool returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got %#v", result)
+	}
+
+	// Sensitive header values must not appear anywhere in the result
+	// content that flows back to the LLM and into run_events.
+	sensitiveValues := []string{"Bearer super-secret", "sid=abc123", "leaked", "leaked2"}
+	for _, value := range sensitiveValues {
+		if strings.Contains(result.Content, value) {
+			t.Fatalf("tool result leaked %q: %s", value, result.Content)
+		}
+	}
+
+	// Redaction marker should appear — proves the scrubber ran.
+	if !strings.Contains(result.Content, redactedHeaderMarker) {
+		t.Fatalf("expected %q marker in scrubbed response, got %s", redactedHeaderMarker, result.Content)
+	}
+
+	// Safe headers must survive.
+	if !strings.Contains(result.Content, "safe-opaque") {
+		t.Fatalf("expected non-sensitive X-Request-Id header to survive, got %s", result.Content)
+	}
+	if !strings.Contains(result.Content, "application/json") {
+		t.Fatalf("expected Content-Type to survive, got %s", result.Content)
+	}
+}
+
 func TestHTTPRequestTool_ScrubsRequestFileAfterExec(t *testing.T) {
 	session := sandbox.NewFakeSession("http-scrub")
 	var requestSnapshot []byte

--- a/backend/internal/engine/primitive_http_request_test.go
+++ b/backend/internal/engine/primitive_http_request_test.go
@@ -138,6 +138,7 @@ func TestScrubStderrSecrets_RemovesAuthPatterns(t *testing.T) {
 		{"x-api-key with value", "x-api-key: leaked-value-here", "leaked-value-here"},
 		{"proxy-authorization", "proxy-authorization: Digest leaked", "Digest leaked"},
 		{"mixed case header", "AUTHORIZATION: Bearer shouty-secret", "shouty-secret"},
+		{"bearer token with special chars", "Bearer abc:~def!123@456", "abc:~def!123@456"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/backend/internal/engine/primitive_http_request_test.go
+++ b/backend/internal/engine/primitive_http_request_test.go
@@ -96,6 +96,122 @@ func TestHTTPRequestTool_ReturnsToolErrorOnScriptFailure(t *testing.T) {
 	}
 }
 
+func TestScrubSensitiveResponseHeaders_CaseInsensitive(t *testing.T) {
+	// HTTP header names are case-insensitive (RFC 7230). Vendors
+	// capitalize all over the place — AUTHORIZATION, authorization,
+	// Authorization, X-API-KEY, x-api-key, X-Api-Key. The scrubber
+	// must catch every casing.
+	payload := map[string]any{
+		"headers": map[string]any{
+			"AUTHORIZATION":   "Bearer leaked1",
+			"Proxy-Authorization": "Bearer leaked2",
+			"SET-COOKIE":      "sid=leaked3",
+			"X-Api-Key":       "leaked4",
+			"x-access-token":  "leaked5",
+			"X-CSRF-Token":    "leaked6",
+			"X-Request-Id":    "safe-id",
+		},
+	}
+	scrubSensitiveResponseHeaders(payload)
+
+	headers := payload["headers"].(map[string]any)
+	for _, key := range []string{"AUTHORIZATION", "Proxy-Authorization", "SET-COOKIE", "X-Api-Key", "x-access-token", "X-CSRF-Token"} {
+		if got := headers[key]; got != redactedHeaderMarker {
+			t.Errorf("header %q = %v, want %q", key, got, redactedHeaderMarker)
+		}
+	}
+	if got := headers["X-Request-Id"]; got != "safe-id" {
+		t.Errorf("non-sensitive X-Request-Id was scrubbed: %v", got)
+	}
+}
+
+func TestScrubStderrSecrets_RemovesAuthPatterns(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		reject string // substring that must not survive
+	}{
+		{"authorization header in traceback", "httpx error at line 42: Authorization: Bearer super-secret-token", "super-secret-token"},
+		{"cookie header", "Traceback: sent Cookie: session=abc123", "session=abc123"},
+		{"bearer token in prose", "failed with token Bearer abc123def456", "abc123def456"},
+		{"basic auth", "server rejected Basic YWRtaW46cGFzc3dvcmQ=", "YWRtaW46cGFzc3dvcmQ="},
+		{"x-api-key with value", "x-api-key: leaked-value-here", "leaked-value-here"},
+		{"proxy-authorization", "proxy-authorization: Digest leaked", "Digest leaked"},
+		{"mixed case header", "AUTHORIZATION: Bearer shouty-secret", "shouty-secret"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scrubbed := scrubStderrSecrets(tc.input)
+			if strings.Contains(scrubbed, tc.reject) {
+				t.Fatalf("scrub left %q in output: %q", tc.reject, scrubbed)
+			}
+			if !strings.Contains(scrubbed, redactedHeaderMarker) {
+				t.Fatalf("expected redaction marker in output: %q", scrubbed)
+			}
+		})
+	}
+}
+
+func TestScrubStderrSecrets_PreservesNonSensitiveText(t *testing.T) {
+	// A scrubber that over-matches is nearly as bad as no scrubber —
+	// pack authors lose debuggability. Assert that normal error text
+	// survives.
+	cases := []string{
+		"dns resolution failed: Name or service not known",
+		"request timed out",
+		"target host is blocked by network policy",
+		"http error: TimeoutException",
+		"connection refused by 203.0.113.42",
+	}
+	for _, input := range cases {
+		t.Run(input, func(t *testing.T) {
+			if got := scrubStderrSecrets(input); got != input {
+				t.Fatalf("legitimate error text was scrubbed: input=%q output=%q", input, got)
+			}
+		})
+	}
+}
+
+func TestHTTPRequestTool_ScrubsStderrLeaksDefenseInDepth(t *testing.T) {
+	// Simulate an older http_request.py version that did NOT wrap its
+	// httpx call in try/except and instead printed a raw traceback
+	// with the full Authorization header to stderr. The Go-side
+	// scrubber must catch this even if the python sanitization is
+	// absent.
+	session := sandbox.NewFakeSession("http-legacy-stderr")
+	session.SetExecFunc(func(request sandbox.ExecRequest, _ map[string][]byte) (sandbox.ExecResult, error) {
+		switch request.Command[0] {
+		case "mkdir":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case "python3":
+			return sandbox.ExecResult{
+				ExitCode: 1,
+				Stderr: "Traceback (most recent call last):\n" +
+					"  File \"/tools/http_request.py\", line 90, in main\n" +
+					"    response = client.request(request[\"method\"], request[\"url\"], headers={'Authorization': 'Bearer LEAKED_LEGACY'})\n" +
+					"httpx.ConnectError: connection refused\n",
+			}, nil
+		default:
+			return sandbox.ExecResult{}, nil
+		}
+	})
+
+	result, err := executeHTTPRequestTool(t.Context(), ToolExecutionRequest{
+		Args:       json.RawMessage(`{"method":"GET","url":"https://api.example.com","headers":{"Authorization":"Bearer LEAKED_LEGACY"}}`),
+		Session:    session,
+		ToolPolicy: sandbox.ToolPolicy{AllowedToolKinds: []string{toolKindNetwork}, AllowNetwork: true},
+	})
+	if err != nil {
+		t.Fatalf("executeHTTPRequestTool returned error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected tool error result")
+	}
+	if strings.Contains(result.Content, "LEAKED_LEGACY") {
+		t.Fatalf("stderr leak survived Go-side scrubber: %s", result.Content)
+	}
+}
+
 func TestHTTPRequestTool_DecodeErrorDoesNotLeakStdoutBytes(t *testing.T) {
 	// If python emits a malformed response, the json.Unmarshal error
 	// used to include a slice of the unparsable bytes — which could

--- a/backend/internal/engine/primitive_http_request_test.go
+++ b/backend/internal/engine/primitive_http_request_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"bytes"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -92,5 +93,61 @@ func TestHTTPRequestTool_ReturnsToolErrorOnScriptFailure(t *testing.T) {
 	}
 	if !result.IsError {
 		t.Fatalf("expected tool error, got %#v", result)
+	}
+}
+
+func TestHTTPRequestTool_ScrubsRequestFileAfterExec(t *testing.T) {
+	session := sandbox.NewFakeSession("http-scrub")
+	var requestSnapshot []byte
+	session.SetExecFunc(func(request sandbox.ExecRequest, files map[string][]byte) (sandbox.ExecResult, error) {
+		switch request.Command[0] {
+		case "mkdir":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case "python3":
+			// Capture what the tool-inputs file looked like at exec time —
+			// the assertions below prove the scrub runs AFTER this.
+			requestSnapshot = append([]byte(nil), files[request.Command[2]]...)
+			return sandbox.ExecResult{
+				ExitCode: 0,
+				Stdout:   `{"status_code":200,"headers":{},"url":"https://api.example.com","body":"ok","body_bytes":2}`,
+			}, nil
+		default:
+			t.Fatalf("unexpected command: %#v", request.Command)
+			return sandbox.ExecResult{}, nil
+		}
+	})
+
+	const secretValue = "Bearer super-secret-token"
+	argsBytes, _ := json.Marshal(map[string]any{
+		"method":  "GET",
+		"url":     "https://api.example.com",
+		"headers": map[string]string{"Authorization": secretValue},
+	})
+
+	result, err := executeHTTPRequestTool(t.Context(), ToolExecutionRequest{
+		Args:       argsBytes,
+		Session:    session,
+		ToolPolicy: sandbox.ToolPolicy{AllowedToolKinds: []string{toolKindNetwork}, AllowNetwork: true},
+	})
+	if err != nil {
+		t.Fatalf("executeHTTPRequestTool returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got %#v", result)
+	}
+
+	// Sanity check: the secret WAS present in the request file at
+	// exec time. Without this, the assertion below would be vacuous.
+	if !bytes.Contains(requestSnapshot, []byte(secretValue)) {
+		t.Fatalf("expected request snapshot to contain secret before scrub, got %q", string(requestSnapshot))
+	}
+
+	// After http_request returns, no file in the sandbox session may
+	// still carry the plaintext secret. The agent's read_file primitive
+	// walks the same backing store as session.Files().
+	for path, content := range session.Files() {
+		if bytes.Contains(content, []byte(secretValue)) {
+			t.Fatalf("file %q still contains the secret after http_request returned: %q", path, string(content))
+		}
 	}
 }

--- a/backend/internal/engine/primitive_secrets.go
+++ b/backend/internal/engine/primitive_secrets.go
@@ -71,3 +71,50 @@ func stringReferencesSecrets(s string) bool {
 		remaining = after[closeIdx+1:]
 	}
 }
+
+// sensitiveResponseHeaders is the case-insensitive denylist of HTTP
+// response header names that may carry authentication material echoed
+// back by a remote API. When http_request returns its parsed response
+// to the LLM, these headers are replaced with a redacted marker so a
+// server that mirrors the request Authorization header (for debug or
+// by accident) cannot leak a ${secrets.X}-substituted value back into
+// the agent's context.
+//
+// The list is intentionally curated rather than heuristic ("strip any
+// header containing 'auth'"): a fixed allowlist gives the security
+// reviewer a single place to audit, and a heuristic would
+// false-positive on legitimate headers like X-Auth-Request-Redirect.
+var sensitiveResponseHeaders = map[string]struct{}{
+	"authorization":       {},
+	"proxy-authorization": {},
+	"www-authenticate":    {},
+	"proxy-authenticate":  {},
+	"cookie":              {},
+	"set-cookie":          {},
+	"x-api-key":           {},
+	"x-auth-token":        {},
+	"x-access-token":      {},
+	"x-amz-security-token": {},
+}
+
+const redactedHeaderMarker = "[redacted]"
+
+// scrubSensitiveResponseHeaders walks a decoded http_request response
+// payload and replaces any sensitive header value with a redacted
+// marker. Safe to call on any shape — a nil, a non-map, or a response
+// without headers is a no-op.
+func scrubSensitiveResponseHeaders(payload any) {
+	m, ok := payload.(map[string]any)
+	if !ok {
+		return
+	}
+	headers, ok := m["headers"].(map[string]any)
+	if !ok {
+		return
+	}
+	for key := range headers {
+		if _, sensitive := sensitiveResponseHeaders[strings.ToLower(strings.TrimSpace(key))]; sensitive {
+			headers[key] = redactedHeaderMarker
+		}
+	}
+}

--- a/backend/internal/engine/primitive_secrets.go
+++ b/backend/internal/engine/primitive_secrets.go
@@ -1,6 +1,9 @@
 package engine
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
 // secretSafePrimitives enumerates every primitive that is hardened to
 // handle plaintext ${secrets.*} values inside the sandbox without
@@ -19,7 +22,22 @@ import "strings"
 //   - the primitive must never include a resolved secret in an error
 //     message.
 //
-// See issue #186 for the full threat model.
+// v1 includes only http_request. INTENTIONALLY EXCLUDED:
+//
+//   - exec / query_sql / query_json: the command or query text lands
+//     in argv (observable via /proc/[pid]/cmdline) with no stdin
+//     alternative implemented today.
+//   - submit: the argument is the agent's final answer; anything
+//     substituted into it is echoed back through the LLM context and
+//     persisted in run_events as the run output.
+//   - build / run_tests: pass env_vars to a subprocess whose stderr
+//     is returned verbatim to the LLM as the tool result; no
+//     scrubbing.
+//
+// Expanding this list to add a new primitive requires completing
+// each bullet above for that primitive AND the scrubbing / error-
+// sanitization work #186 step 3-5 did for http_request. See the
+// issue for the full threat model.
 var secretSafePrimitives = map[string]struct{}{
 	httpRequestToolName: {},
 }
@@ -84,17 +102,39 @@ func stringReferencesSecrets(s string) bool {
 // header containing 'auth'"): a fixed allowlist gives the security
 // reviewer a single place to audit, and a heuristic would
 // false-positive on legitimate headers like X-Auth-Request-Redirect.
+// Expand with care — a missed entry is a leak, but a false add breaks
+// legitimate response inspection. Entries must be lower-case; the
+// lookup lower-cases at the call site (HTTP header names are
+// case-insensitive per RFC 7230).
 var sensitiveResponseHeaders = map[string]struct{}{
+	// RFC 7235 challenge / credential headers.
 	"authorization":       {},
 	"proxy-authorization": {},
 	"www-authenticate":    {},
 	"proxy-authenticate":  {},
-	"cookie":              {},
-	"set-cookie":          {},
-	"x-api-key":           {},
-	"x-auth-token":        {},
-	"x-access-token":      {},
+	// RFC 6265 cookies.
+	"cookie":     {},
+	"set-cookie": {},
+	// Common vendor / custom auth headers.
+	"x-api-key":            {},
+	"x-apikey":             {},
+	"api-key":              {},
+	"apikey":               {},
+	"x-auth-token":         {},
+	"x-access-token":       {},
+	"x-access-key":         {},
+	"x-secret-key":         {},
+	"x-session-token":      {},
+	"x-session-id":         {},
+	"x-csrf-token":         {},
+	"x-xsrf-token":         {},
+	// AWS SigV4 / STS.
 	"x-amz-security-token": {},
+	// Google Cloud user credential headers.
+	"x-goog-api-key":         {},
+	"x-goog-iam-authorization-token": {},
+	// Bare token-style names some APIs use.
+	"token": {},
 }
 
 const redactedHeaderMarker = "[redacted]"
@@ -117,4 +157,45 @@ func scrubSensitiveResponseHeaders(payload any) {
 			headers[key] = redactedHeaderMarker
 		}
 	}
+}
+
+// stderrSecretPatterns is the set of regex patterns scrubbed from
+// primitive stderr before it flows back to the LLM as a tool error
+// message. This is defense-in-depth for two scenarios:
+//
+//  1. An older E2B template version is pinned to a pack that still
+//     ships http_request.py WITHOUT the try/except wrapper #186 step 5
+//     added. In that case Python would print a raw traceback (which
+//     may contain request headers in the exception repr) directly to
+//     stderr, and without Go-side scrubbing the raw trace would flow
+//     back to the LLM.
+//  2. A future refactor introduces another primitive whose error
+//     path goes through executeInternalCommand's stderr return but
+//     gets missed in a security review.
+//
+// The patterns deliberately over-match (greedy until end-of-line).
+// Legitimate error messages with these tokens are rare, and a
+// false-positive scrub loses a bit of debuggability but never leaks.
+var stderrSecretPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)authorization\s*:\s*[^\r\n]*`),
+	regexp.MustCompile(`(?i)proxy-authorization\s*:\s*[^\r\n]*`),
+	regexp.MustCompile(`(?i)cookie\s*:\s*[^\r\n]*`),
+	regexp.MustCompile(`(?i)set-cookie\s*:\s*[^\r\n]*`),
+	regexp.MustCompile(`(?i)x-(?:api|auth|access|secret|session|csrf|xsrf)[-_](?:key|token|id)\s*:\s*[^\r\n]*`),
+	regexp.MustCompile(`(?i)api[-_]?key\s*:\s*[^\r\n]*`),
+	regexp.MustCompile(`(?i)bearer\s+[A-Za-z0-9._\-+=/]+`),
+	regexp.MustCompile(`(?i)basic\s+[A-Za-z0-9+/=]{8,}`),
+}
+
+// scrubStderrSecrets replaces any fragment of stderr that matches a
+// well-known auth pattern with a fixed marker. Called on the stderr
+// returned from primitive executions before it becomes a tool error
+// message, so a raw python traceback (or any future primitive that
+// misbehaves) cannot dump a resolved secret back to the LLM.
+func scrubStderrSecrets(stderr string) string {
+	scrubbed := stderr
+	for _, pattern := range stderrSecretPatterns {
+		scrubbed = pattern.ReplaceAllString(scrubbed, redactedHeaderMarker)
+	}
+	return scrubbed
 }

--- a/backend/internal/engine/primitive_secrets.go
+++ b/backend/internal/engine/primitive_secrets.go
@@ -71,6 +71,20 @@ func templateReferencesSecrets(value any) bool {
 	return false
 }
 
+// argsTemplateHasOutputPath checks whether an http_request argsTemplate
+// declares a non-empty output_path. Composed tools that carry ${secrets.*}
+// must not also specify output_path because the response body (which could
+// echo credentials from the request) would persist as a file the agent can
+// read_file on, bypassing the response header scrubber.
+func argsTemplateHasOutputPath(args map[string]any) bool {
+	v, ok := args["output_path"]
+	if !ok {
+		return false
+	}
+	s, ok := v.(string)
+	return ok && strings.TrimSpace(s) != ""
+}
+
 func stringReferencesSecrets(s string) bool {
 	remaining := s
 	for {
@@ -183,7 +197,7 @@ var stderrSecretPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)set-cookie\s*:\s*[^\r\n]*`),
 	regexp.MustCompile(`(?i)x-(?:api|auth|access|secret|session|csrf|xsrf)[-_](?:key|token|id)\s*:\s*[^\r\n]*`),
 	regexp.MustCompile(`(?i)api[-_]?key\s*:\s*[^\r\n]*`),
-	regexp.MustCompile(`(?i)bearer\s+[A-Za-z0-9._\-+=/]+`),
+	regexp.MustCompile(`(?i)bearer\s+[^\s\r\n]+`),
 	regexp.MustCompile(`(?i)basic\s+[A-Za-z0-9+/=]{8,}`),
 }
 

--- a/backend/internal/engine/primitive_secrets.go
+++ b/backend/internal/engine/primitive_secrets.go
@@ -1,0 +1,73 @@
+package engine
+
+import "strings"
+
+// secretSafePrimitives enumerates every primitive that is hardened to
+// handle plaintext ${secrets.*} values inside the sandbox without
+// exposing them to the evaluated agent. Adding a primitive to this set
+// is a security-relevant change and should be reviewed carefully:
+//
+//   - the primitive must NOT write its resolved args to a sandbox
+//     filesystem path the agent can read (use stdin pipes or private
+//     filesystem roots not in ReadableRoots).
+//   - the primitive must NOT place the resolved secret in argv — argv
+//     is observable via /proc/[pid]/cmdline by any process in the
+//     sandbox.
+//   - the primitive must strip sensitive response/output fields
+//     (Authorization / Cookie / X-API-Key headers, etc.) before
+//     returning a ToolExecutionResult to the LLM.
+//   - the primitive must never include a resolved secret in an error
+//     message.
+//
+// See issue #186 for the full threat model.
+var secretSafePrimitives = map[string]struct{}{
+	httpRequestToolName: {},
+}
+
+func primitiveAcceptsSecrets(primitiveName string) bool {
+	_, ok := secretSafePrimitives[primitiveName]
+	return ok
+}
+
+// templateReferencesSecrets walks any template value (map / slice /
+// string) and reports whether at least one string element references
+// a ${secrets.*} placeholder. Used at composed-tool build time to
+// gate secret-bearing args to primitives that can handle them safely.
+func templateReferencesSecrets(value any) bool {
+	switch v := value.(type) {
+	case string:
+		return stringReferencesSecrets(v)
+	case map[string]any:
+		for _, inner := range v {
+			if templateReferencesSecrets(inner) {
+				return true
+			}
+		}
+	case []any:
+		for _, inner := range v {
+			if templateReferencesSecrets(inner) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func stringReferencesSecrets(s string) bool {
+	remaining := s
+	for {
+		idx := strings.Index(remaining, "${")
+		if idx == -1 {
+			return false
+		}
+		after := remaining[idx+2:]
+		closeIdx := strings.Index(after, "}")
+		if closeIdx == -1 {
+			return false
+		}
+		if strings.HasPrefix(after[:closeIdx], "secrets.") {
+			return true
+		}
+		remaining = after[closeIdx+1:]
+	}
+}

--- a/backend/internal/engine/primitive_tools.go
+++ b/backend/internal/engine/primitive_tools.go
@@ -612,6 +612,15 @@ func executeHTTPRequestTool(ctx context.Context, request ToolExecutionRequest) (
 	if err := json.Unmarshal([]byte(strings.TrimSpace(commandResult.ExecResult.Stdout)), &responsePayload); err != nil {
 		return ToolExecutionResult{}, NewFailure(StopReasonSandboxError, "decode http_request output", err)
 	}
+	// Strip well-known authentication headers from the response before
+	// it flows into the LLM context and the run_events table. Some APIs
+	// echo the Authorization / Cookie header back verbatim (for debug or
+	// by accident); without scrubbing, a composed tool that authenticates
+	// with ${secrets.X} would leak the plaintext back to the agent.
+	// NOTE: response BODY scrubbing is deliberately out of scope — body
+	// content is structured, pack-specific, and can't be safely stripped
+	// without domain knowledge. See issue #186 for the full threat model.
+	scrubSensitiveResponseHeaders(responsePayload)
 	content, err := toolJSONOutput(ctx, request, httpRequestToolName, responsePayload)
 	if err != nil {
 		return ToolExecutionResult{}, err

--- a/backend/internal/engine/primitive_tools.go
+++ b/backend/internal/engine/primitive_tools.go
@@ -610,7 +610,12 @@ func executeHTTPRequestTool(ctx context.Context, request ToolExecutionRequest) (
 
 	var responsePayload any
 	if err := json.Unmarshal([]byte(strings.TrimSpace(commandResult.ExecResult.Stdout)), &responsePayload); err != nil {
-		return ToolExecutionResult{}, NewFailure(StopReasonSandboxError, "decode http_request output", err)
+		// Deliberately drop the json.Unmarshal error: its message
+		// quotes a slice of the malformed input, which could include
+		// unscrubbed response headers (Authorization echoed by a
+		// misbehaving server). A generic error avoids leaking any
+		// stdout bytes into the NewFailure cause chain. See #186.
+		return ToolExecutionResult{}, NewFailure(StopReasonSandboxError, "decode http_request output", errors.New("malformed response payload"))
 	}
 	// Strip well-known authentication headers from the response before
 	// it flows into the LLM context and the run_events table. Some APIs

--- a/backend/internal/engine/primitive_tools.go
+++ b/backend/internal/engine/primitive_tools.go
@@ -578,6 +578,21 @@ func executeHTTPRequestTool(ctx context.Context, request ToolExecutionRequest) (
 	if err := request.Session.WriteFile(ctx, requestPath, inputPayload); err != nil {
 		return ToolExecutionResult{}, NewFailure(StopReasonSandboxError, "write http_request input", err)
 	}
+	// Scrub the request file as soon as the python helper has consumed
+	// it. The file carries resolved ${secrets.*} headers and lives
+	// under /workspace, which the agent's read_file primitive can
+	// reach. The engine loop is strictly serial (a single tool call
+	// completes before the agent sees the result and can issue the
+	// next call), so overwriting after executeInternalCommand returns
+	// closes the window before the agent ever has a chance to look.
+	// A detached context keeps the cleanup running even when the
+	// request context was cancelled — the session is still alive
+	// until prepareSandbox tears it down. See issue #186.
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = request.Session.WriteFile(cleanupCtx, requestPath, nil)
+	}()
 
 	commandResult, err := executeInternalCommand(ctx, request, httpRequestToolName, sandbox.ExecRequest{
 		Command: []string{"python3", "/tools/http_request.py", requestPath},

--- a/backend/internal/engine/primitive_tools.go
+++ b/backend/internal/engine/primitive_tools.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"path"
 	"strings"
 	"time"
@@ -591,7 +592,12 @@ func executeHTTPRequestTool(ctx context.Context, request ToolExecutionRequest) (
 	defer func() {
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_ = request.Session.WriteFile(cleanupCtx, requestPath, nil)
+		if scrubErr := request.Session.WriteFile(cleanupCtx, requestPath, nil); scrubErr != nil {
+			slog.Default().Warn("failed to scrub http_request input file after exec; plaintext secret may persist in sandbox",
+				"path", requestPath,
+				"error", scrubErr,
+			)
+		}
 	}()
 
 	commandResult, err := executeInternalCommand(ctx, request, httpRequestToolName, sandbox.ExecRequest{

--- a/backend/internal/engine/primitive_tools.go
+++ b/backend/internal/engine/primitive_tools.go
@@ -601,7 +601,13 @@ func executeHTTPRequestTool(ctx context.Context, request ToolExecutionRequest) (
 		return ToolExecutionResult{}, err
 	}
 	if commandResult.IsError {
-		message := strings.TrimSpace(commandResult.ExecResult.Stderr)
+		// Defense-in-depth: even though http_request.py #186 step 5
+		// wraps its httpx call in try/except with type-only error
+		// formatting, a pack pinned to an older sandbox template may
+		// still ship the pre-#186 script and emit a raw traceback
+		// that includes resolved request headers. Scrub any
+		// auth-shaped stderr fragment before it becomes a tool error.
+		message := strings.TrimSpace(scrubStderrSecrets(commandResult.ExecResult.Stderr))
 		if message == "" {
 			message = "http request failed"
 		}

--- a/backend/internal/engine/sandbox_config_test.go
+++ b/backend/internal/engine/sandbox_config_test.go
@@ -24,7 +24,7 @@ func TestApplySandboxConfig_WithSandboxBlock(t *testing.T) {
 	}`)
 
 	request := &sandbox.CreateRequest{}
-	if err := applySandboxConfig(request, manifest, nil); err != nil {
+	if err := applySandboxConfig(request, manifest); err != nil {
 		t.Fatalf("applySandboxConfig returned error: %v", err)
 	}
 
@@ -55,7 +55,7 @@ func TestApplySandboxConfig_WithoutSandboxBlock(t *testing.T) {
 	request := &sandbox.CreateRequest{
 		ToolPolicy: sandbox.ToolPolicy{AllowNetwork: false},
 	}
-	if err := applySandboxConfig(request, manifest, nil); err != nil {
+	if err := applySandboxConfig(request, manifest); err != nil {
 		t.Fatalf("applySandboxConfig returned error: %v", err)
 	}
 
@@ -85,7 +85,7 @@ func TestApplySandboxConfig_TemplateIDFromSandboxOnly(t *testing.T) {
 	}`)
 
 	request := &sandbox.CreateRequest{}
-	if err := applySandboxConfig(request, manifest, nil); err != nil {
+	if err := applySandboxConfig(request, manifest); err != nil {
 		t.Fatalf("applySandboxConfig returned error: %v", err)
 	}
 
@@ -96,7 +96,7 @@ func TestApplySandboxConfig_TemplateIDFromSandboxOnly(t *testing.T) {
 
 func TestApplySandboxConfig_InvalidJSON(t *testing.T) {
 	request := &sandbox.CreateRequest{}
-	if err := applySandboxConfig(request, json.RawMessage(`{invalid`), nil); err != nil {
+	if err := applySandboxConfig(request, json.RawMessage(`{invalid`)); err != nil {
 		t.Fatalf("applySandboxConfig on invalid JSON returned error: %v", err)
 	}
 
@@ -106,37 +106,7 @@ func TestApplySandboxConfig_InvalidJSON(t *testing.T) {
 	}
 }
 
-func TestApplySandboxConfig_ResolvesSecretsInEnvVars(t *testing.T) {
-	manifest := json.RawMessage(`{
-		"sandbox": {
-			"env_vars": {
-				"DB_URL": "${secrets.DB_URL}",
-				"COMBINED": "prefix-${secrets.TOKEN}-suffix",
-				"LITERAL": "plain-value"
-			}
-		}
-	}`)
-	secrets := map[string]string{
-		"DB_URL": "postgres://user:pass@host/db",
-		"TOKEN":  "abc123",
-	}
-
-	request := &sandbox.CreateRequest{}
-	if err := applySandboxConfig(request, manifest, secrets); err != nil {
-		t.Fatalf("applySandboxConfig returned error: %v", err)
-	}
-	if got, want := request.EnvVars["DB_URL"], "postgres://user:pass@host/db"; got != want {
-		t.Errorf("DB_URL = %q, want %q", got, want)
-	}
-	if got, want := request.EnvVars["COMBINED"], "prefix-abc123-suffix"; got != want {
-		t.Errorf("COMBINED = %q, want %q", got, want)
-	}
-	if got, want := request.EnvVars["LITERAL"], "plain-value"; got != want {
-		t.Errorf("LITERAL = %q, want %q", got, want)
-	}
-}
-
-func TestApplySandboxConfig_MissingSecretIsError(t *testing.T) {
+func TestApplySandboxConfig_RejectsSecretsInEnvVars(t *testing.T) {
 	manifest := json.RawMessage(`{
 		"sandbox": {
 			"env_vars": {"DB_URL": "${secrets.DB_URL}"}
@@ -144,45 +114,66 @@ func TestApplySandboxConfig_MissingSecretIsError(t *testing.T) {
 	}`)
 
 	request := &sandbox.CreateRequest{}
-	err := applySandboxConfig(request, manifest, map[string]string{})
+	err := applySandboxConfig(request, manifest)
 	if err == nil {
-		t.Fatalf("expected error for missing secret, got nil")
+		t.Fatalf("expected error for secrets in env_vars, got nil")
 	}
 	if !strings.Contains(err.Error(), "DB_URL") {
-		t.Fatalf("error should name the missing secret: %v", err)
+		t.Fatalf("error should name the offending env var: %v", err)
+	}
+	if !strings.Contains(err.Error(), "http_request") {
+		t.Fatalf("error should point at the sanctioned path: %v", err)
+	}
+	if !strings.Contains(err.Error(), "#186") {
+		t.Fatalf("error should reference the issue: %v", err)
 	}
 }
 
-func TestApplySandboxConfig_RejectsNonSecretsNamespaceInEnvVars(t *testing.T) {
-	manifest := json.RawMessage(`{
-		"sandbox": {
-			"env_vars": {"BAD": "${parameters.url}"}
-		}
-	}`)
-
-	request := &sandbox.CreateRequest{}
-	err := applySandboxConfig(request, manifest, nil)
-	if err == nil {
-		t.Fatalf("expected error for parameters namespace, got nil")
+func TestApplySandboxConfig_RejectsAllPlaceholdersInEnvVars(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{"parameters namespace", "${parameters.url}"},
+		{"unknown namespace", "${something.foo}"},
+		{"unclosed placeholder", "${secrets.DB_URL"},
+		{"embedded in longer string", "prefix-${secrets.TOKEN}-suffix"},
 	}
-	if !strings.Contains(err.Error(), "only ${secrets.X}") {
-		t.Fatalf("error should reject non-secrets namespace: %v", err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest := json.RawMessage(`{
+				"sandbox": {"env_vars": {"BAD": "` + tc.value + `"}}
+			}`)
+			request := &sandbox.CreateRequest{}
+			if err := applySandboxConfig(request, manifest); err == nil {
+				t.Fatalf("expected error for placeholder %q, got nil", tc.value)
+			}
+		})
 	}
 }
 
-func TestApplySandboxConfig_RejectsUnclosedPlaceholder(t *testing.T) {
+func TestApplySandboxConfig_AcceptsLiteralEnvVars(t *testing.T) {
 	manifest := json.RawMessage(`{
 		"sandbox": {
-			"env_vars": {"BAD": "${secrets.DB_URL"}
+			"env_vars": {
+				"DB_URL": "postgres://localhost:5432/app",
+				"SERVICE_URL": "https://api.example.com",
+				"FEATURE_FLAGS": "a=1,b=2",
+				"EMPTY": ""
+			}
 		}
 	}`)
-
 	request := &sandbox.CreateRequest{}
-	err := applySandboxConfig(request, manifest, map[string]string{"DB_URL": "x"})
-	if err == nil {
-		t.Fatalf("expected error for unclosed placeholder, got nil")
+	if err := applySandboxConfig(request, manifest); err != nil {
+		t.Fatalf("applySandboxConfig returned error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "unclosed placeholder") {
-		t.Fatalf("error should mention unclosed placeholder: %v", err)
+	if got, want := request.EnvVars["DB_URL"], "postgres://localhost:5432/app"; got != want {
+		t.Errorf("DB_URL = %q, want %q", got, want)
+	}
+	if got, want := request.EnvVars["SERVICE_URL"], "https://api.example.com"; got != want {
+		t.Errorf("SERVICE_URL = %q, want %q", got, want)
+	}
+	if got, want := request.EnvVars["FEATURE_FLAGS"], "a=1,b=2"; got != want {
+		t.Errorf("FEATURE_FLAGS = %q, want %q", got, want)
 	}
 }

--- a/backend/internal/engine/tool_registry.go
+++ b/backend/internal/engine/tool_registry.go
@@ -362,6 +362,18 @@ func newManifestCustomTool(config manifestCustomToolConfig, secrets map[string]s
 	if err := validateTemplateReferences(argsTemplate, "args", declaredParams); err != nil {
 		return nil, "", fmt.Errorf("custom tool %q has invalid args template: %w", name, err)
 	}
+	// Reject secret references in primitives that cannot safely handle
+	// plaintext secrets. The resolved value would otherwise land in an
+	// observable sandbox surface (exec argv, query_sql command line,
+	// etc.) and be exfiltrated by the evaluated agent. See issue #186.
+	// In v1 only http_request is hardened for secret-bearing args.
+	if templateReferencesSecrets(argsTemplate) && !primitiveAcceptsSecrets(primitiveName) {
+		return nil, "", fmt.Errorf(
+			"custom tool %q delegates to primitive %q which does not accept ${secrets.*} references; "+
+				"only %q supports secret-bearing args in v1 (see issue #186)",
+			name, primitiveName, httpRequestToolName,
+		)
+	}
 	resolvedTemplate, err := resolveTemplateMap(argsTemplate, templateResolutionOptions{
 		secrets:              cloneStringMap(secrets),
 		errorOnMissingSecret: true,

--- a/backend/internal/engine/tool_registry.go
+++ b/backend/internal/engine/tool_registry.go
@@ -374,6 +374,14 @@ func newManifestCustomTool(config manifestCustomToolConfig, secrets map[string]s
 			name, primitiveName, httpRequestToolName,
 		)
 	}
+	if templateReferencesSecrets(argsTemplate) && argsTemplateHasOutputPath(argsTemplate) {
+		return nil, "", fmt.Errorf(
+			"custom tool %q uses ${secrets.*} and also sets output_path; "+
+				"this combination is rejected because the response body (which may echo "+
+				"credentials) would persist as a readable file in the sandbox (see issue #186)",
+			name,
+		)
+	}
 	resolvedTemplate, err := resolveTemplateMap(argsTemplate, templateResolutionOptions{
 		secrets:              cloneStringMap(secrets),
 		errorOnMissingSecret: true,

--- a/backend/internal/engine/tool_registry_test.go
+++ b/backend/internal/engine/tool_registry_test.go
@@ -386,6 +386,32 @@ func TestBuildToolRegistry_RejectsSecretsInNonSecretSafePrimitives(t *testing.T)
 	}
 }
 
+func TestBuildToolRegistry_RejectsSecretsWithOutputPath(t *testing.T) {
+	manifest := []byte(`{"tools":{"custom":[{
+		"name":"fetch_and_save",
+		"description":"fetches and saves to file",
+		"parameters":{"type":"object","additionalProperties":false},
+		"implementation":{"primitive":"http_request","args":{
+			"method":"GET",
+			"url":"https://api.example.com",
+			"headers":{"Authorization":"Bearer ${secrets.API_KEY}"},
+			"output_path":"/workspace/data.json"
+		}}
+	}]}}`)
+	_, err := buildToolRegistry(
+		sandbox.ToolPolicy{AllowNetwork: true},
+		manifest,
+		nil,
+		map[string]string{"API_KEY": "real-key"},
+	)
+	if err == nil {
+		t.Fatalf("expected error for secrets + output_path combination")
+	}
+	if !strings.Contains(err.Error(), "output_path") {
+		t.Fatalf("error should mention output_path: %v", err)
+	}
+}
+
 func TestComposedTool_ReportsFailureOriginByFailureType(t *testing.T) {
 	registry, err := buildToolRegistry(sandbox.ToolPolicy{}, []byte(`{"tools":{"custom":[]}}`), nil, nil)
 	if err != nil {

--- a/backend/internal/engine/tool_registry_test.go
+++ b/backend/internal/engine/tool_registry_test.go
@@ -272,7 +272,7 @@ func TestBuildToolRegistry_SoftDisablesComposedToolWithMissingPrimitive(t *testi
 
 func TestBuildToolRegistry_SoftDisablesComposedToolWithMissingSecret(t *testing.T) {
 	registry, err := buildToolRegistry(
-		sandbox.ToolPolicy{},
+		sandbox.ToolPolicy{AllowNetwork: true},
 		[]byte(`{
 			"tools":{
 				"custom":[
@@ -280,7 +280,7 @@ func TestBuildToolRegistry_SoftDisablesComposedToolWithMissingSecret(t *testing.
 						"name":"inventory_lookup",
 						"description":"Lookup inventory",
 						"parameters":{"type":"object","properties":{"sku":{"type":"string"}}},
-						"implementation":{"primitive":"submit","args":{"answer":"Bearer ${secrets.API_KEY}"}}
+						"implementation":{"primitive":"http_request","args":{"method":"GET","url":"https://api.example.com","headers":{"Authorization":"Bearer ${secrets.API_KEY}"}}}
 					}
 				]
 			}
@@ -298,7 +298,7 @@ func TestBuildToolRegistry_SoftDisablesComposedToolWithMissingSecret(t *testing.
 
 func TestBuildToolRegistry_ComposedToolResolvesSecretsAtBuildTime(t *testing.T) {
 	registry, err := buildToolRegistry(
-		sandbox.ToolPolicy{},
+		sandbox.ToolPolicy{AllowNetwork: true},
 		[]byte(`{
 			"tools":{
 				"custom":[
@@ -306,7 +306,7 @@ func TestBuildToolRegistry_ComposedToolResolvesSecretsAtBuildTime(t *testing.T) 
 						"name":"send_token",
 						"description":"Send token",
 						"parameters":{"type":"object"},
-						"implementation":{"primitive":"submit","args":{"answer":"Bearer ${secrets.API_KEY}"}}
+						"implementation":{"primitive":"http_request","args":{"method":"GET","url":"https://api.example.com","headers":{"Authorization":"Bearer ${secrets.API_KEY}"}}}
 					}
 				]
 			}
@@ -322,15 +322,67 @@ func TestBuildToolRegistry_ComposedToolResolvesSecretsAtBuildTime(t *testing.T) 
 	if !ok {
 		t.Fatal("send_token should be visible when the secret is provided")
 	}
-	result, err := tool.Execute(t.Context(), ToolExecutionRequest{Registry: registry})
-	if err != nil {
-		t.Fatalf("Execute returned error: %v", err)
+	composed, ok := tool.(*composedTool)
+	if !ok {
+		t.Fatalf("send_token has unexpected type %T", tool)
 	}
-	if result.IsError {
-		t.Fatalf("expected success, got error: %s", result.Content)
+	// The resolved secret value should be baked into argsTemplate at
+	// build time so runtime never has to see the placeholder.
+	headers, ok := composed.argsTemplate["headers"].(map[string]any)
+	if !ok {
+		t.Fatalf("argsTemplate.headers has unexpected shape: %#v", composed.argsTemplate["headers"])
 	}
-	if result.FinalOutput != "Bearer top-secret" {
-		t.Fatalf("final output = %q, want resolved secret output", result.FinalOutput)
+	if got := headers["Authorization"]; got != "Bearer top-secret" {
+		t.Fatalf("argsTemplate.headers.Authorization = %v, want Bearer top-secret", got)
+	}
+}
+
+func TestBuildToolRegistry_RejectsSecretsInNonSecretSafePrimitives(t *testing.T) {
+	cases := []struct {
+		name      string
+		primitive string
+		args      string
+	}{
+		{
+			name:      "exec with secret in argv",
+			primitive: "exec",
+			args:      `{"command":["curl","-H","Authorization: Bearer ${secrets.API_KEY}","https://example.com"]}`,
+		},
+		{
+			name:      "submit with secret in answer",
+			primitive: "submit",
+			args:      `{"answer":"Bearer ${secrets.API_KEY}"}`,
+		},
+		{
+			name:      "query_sql with secret in query text",
+			primitive: "query_sql",
+			args:      `{"engine":"sqlite","query":"SELECT * FROM t WHERE k='${secrets.API_KEY}'","database_path":"/workspace/db.sqlite"}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest := []byte(`{"tools":{"custom":[{
+				"name":"bad_tool",
+				"description":"x",
+				"parameters":{"type":"object","additionalProperties":false},
+				"implementation":{"primitive":"` + tc.primitive + `","args":` + tc.args + `}
+			}]}}`)
+			_, err := buildToolRegistry(
+				sandbox.ToolPolicy{AllowNetwork: true, AllowShell: true},
+				manifest,
+				nil,
+				map[string]string{"API_KEY": "real-key"},
+			)
+			if err == nil {
+				t.Fatalf("expected buildToolRegistry to reject secrets in %s, got nil", tc.primitive)
+			}
+			if !strings.Contains(err.Error(), "does not accept ${secrets.*}") {
+				t.Fatalf("error should explain the secret-safe constraint: %v", err)
+			}
+			if !strings.Contains(err.Error(), httpRequestToolName) {
+				t.Fatalf("error should point at the sanctioned primitive: %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #186. **Stacked on top of #193 (issue #178).**

## Why

[PR #193](https://github.com/agentclash/agentclash/pull/193) ships the storage layer for workspace secrets. With that in place, composed tools can substitute `${secrets.X}` into primitive args at build time — and those resolved plaintext values would then flow into multiple sandbox surfaces the evaluated agent can observe:

| Leak vector | Attack |
|-------------|--------|
| `http_request` tool-input file at `/workspace/.agentclash/tool-inputs/http_request_<uuid>.json` | `read_file` on the path after the tool returns |
| `exec` primitive argv containing resolved secret | `/proc/[pid]/cmdline` via any allowed primitive |
| Sandbox `env_vars` carrying `${secrets.*}` | `/proc/self/environ` (E2B runs as root, no user separation) |
| Response headers echoed by remote API | flows into `ToolExecutionResult.Content` → LLM context → `run_events` DB |
| Python stderr from unhandled exceptions | flows back as the tool error message with the full request dict in the traceback |

Before #178 these were **dormant** — the secrets map was always empty so composed tools referencing `${secrets.*}` were disabled at build time. PR #193 activates them. This PR closes every vector at the earliest possible point before any of them get a chance to fire.

## What

Eight commits, each a self-contained step:

| # | Commit | Scope |
|---|--------|-------|
| 1 | `feat(engine): #186 step 1 — gate secrets to hardened primitives only` | New `primitive_secrets.go` with `secretSafePrimitives` allowlist. v1 includes only `http_request`; `exec`/`query_sql`/`submit`/etc. reject `${secrets.*}` at pack-build time |
| 2 | `feat(engine): #186 step 2 — reject ${secrets.*} in sandbox env_vars` | Reverts the user-visible env_var secret resolution from #178 step 4. env_vars are literal-only |
| 3 | `feat(engine): #186 step 3 — scrub http_request input file after exec` | `defer` overwrites the tool-inputs file with empty bytes after the python exec returns; detached cleanup context |
| 4 | `feat(engine): #186 step 4 — strip sensitive response headers` | Curated denylist (Authorization, Cookie, X-API-Key, etc.) redacted before response flows to LLM/run_events |
| 5 | `feat(engine): #186 step 5 — sanitize http_request error paths` | `http_request.py` wraps full `main()` in `try/except` with type-only error formatting; Go `json.Unmarshal` decode errors no longer propagate stdout bytes |
| 6 | `test(engine): #186 step 6 — end-to-end isolation coverage` | `TestComposedHttpRequest_SecretIsolation_FullStack` ties every defense together |
| 7 | `docs(backend): #186 step 7 — document secret usage model` | `.env.example` documents "secrets only via http_request in v1" |
| 8 | `feat(engine): #186 review followups — self-review hardening` | Post-review: expanded header denylist, Go-side stderr regex scrubber (defense in depth for template version skew), widened Python try/except, observer-path integration test, case-insensitivity tests |

## Core principle

**Secrets resolution is opt-in per primitive.** Only primitives that can handle plaintext without exposing it to the agent declare themselves secret-safe. In v1, exactly one primitive qualifies: `http_request`. Every other path rejects at pack-build time with a clear error pointing at `http_request` as the sanctioned alternative.

## Architecture

### Attack surface before this PR

```mermaid
flowchart TD
    Pack["Pack manifest<br/>\${secrets.API_KEY}"] --> Build["Composed tool build"]
    Build --> Store["Store resolved value<br/>in argsTemplate"]
    Store --> Run["Runtime: primitive dispatch"]

    Run --> FReq["http_request writes<br/>/workspace/.agentclash/tool-inputs/*.json"]
    Run --> ExecArgv["exec: secret in argv<br/>/proc/[pid]/cmdline"]
    Run --> EnvVars["env_vars: secret in sandbox env<br/>/proc/self/environ"]
    Run --> ResHdr["Response headers echoed<br/>back to LLM context"]
    Run --> Stderr["Python traceback on error<br/>leaks request dict"]

    FReq -.->|read_file| Agent
    ExecArgv -.->|read_file /proc| Agent
    EnvVars -.->|read_file /proc| Agent
    ResHdr -.->|next LLM call| Agent
    Stderr -.->|tool error message| Agent

    Agent["Evaluated agent<br/>(adversary)"]:::attacker

    classDef attacker fill:#f99,stroke:#900,color:#000
```

### Defense chain after this PR

```mermaid
flowchart TD
    Pack["Pack manifest<br/>\${secrets.API_KEY}"] --> Gate{{"Step 1:<br/>primitive<br/>secret-safe?"}}

    Gate -->|no, e.g. exec/submit| Reject["❌ pack-build REJECT<br/>(points at http_request)"]
    Gate -->|yes, http_request| Build["Composed tool build<br/>strict resolve"]

    EnvVars["Sandbox env_vars<br/>\${secrets.X}"] --> Step2{{"Step 2:<br/>literal only?"}}
    Step2 -->|no| Reject2["❌ applySandboxConfig REJECT"]
    Step2 -->|yes literal| SandboxEnv["sandbox CreateRequest.EnvVars"]

    Build --> HReq["http_request primitive"]
    HReq --> WriteFile["Write tool-inputs JSON<br/>(has resolved Authorization)"]
    WriteFile --> PyExec["python3 /tools/http_request.py"]
    PyExec -->|try/except<br/>type-only errors| PyResult

    PyExec -.->|defer scrub| OverwriteFile["Step 3:<br/>overwrite file with nil<br/>before return"]

    PyResult["Response JSON"] --> HeaderScrub["Step 4:<br/>strip Authorization/<br/>Cookie/X-API-Key/etc."]
    HeaderScrub --> Content["ToolExecutionResult.Content"]

    PyErr["Python stderr<br/>on error"] --> StderrScrub["Step 5:<br/>Go-side regex scrub<br/>(defense in depth)"]
    StderrScrub --> ErrMsg["Tool error message"]

    Content --> Observer["OnToolExecution"]
    ErrMsg --> Observer
    Observer --> DB["run_events DB"]
    Observer --> LLM["Next LLM call"]

    LLM -.->|no plaintext| Agent["Evaluated agent"]
    DB -.->|no plaintext| Agent
    OverwriteFile -.->|nothing to read| Agent

    classDef reject fill:#f99,stroke:#900,color:#000
    class Reject,Reject2 reject
```

## Explicit non-goals (noted in individual commits)

- **Worker-side sidecar execution** (Strategy A): ~3x effort, deferred until in-sandbox hardening proves insufficient.
- **Stdin-piped `http_request` args via E2B `SendInput` RPC**: cleaner than defer-overwrite but requires extending `sandbox.Session`. Current in-loop serialization invariant makes overwrite equivalent security.
- **Response body scrubbing**: body is structured/pack-specific and can't be safely stripped without domain knowledge. Pack authors own their body-level security.
- **Filesystem allowlist enforcement**: flagged as a separate finding in step 3's commit. `ReadableRoots`/`WritableRoots` are vestigial — never sent to E2B, never validated Go-side. Orthogonal to #186 because steps 1+2+3 close the specific leak vectors here, but the allowlist gap deserves its own issue.
- **Multi-tenancy user separation in E2B template**: template-level concern (#155 territory).

## Dependencies

- **Depends on**: #193 (issue #178 workspace secrets store). This PR's base branch is `feat/issue-178-sandbox-secrets`, not `main`.
- **Blocks**: #193 from safely reaching `main`. Either merge both together or merge #193 → this PR → main in sequence.
- **Related**: the filesystem-allowlist-enforcement follow-up will be filed as a new issue after this lands.

## Test plan

- [x] `go test ./...` green across all packages
- [x] New test coverage:
  - 7 build-time rejection cases (`TestBuildToolRegistry_RejectsSecretsInNonSecretSafePrimitives` table)
  - env_var placeholder rejection (all namespaces + unclosed)
  - request-file scrub (captures snapshot at exec time, asserts post-return scrub)
  - response header stripping (case-insensitive, adversarial echo simulation)
  - decode-error stdout byte non-leak
  - Python stderr scrubbing defense-in-depth (simulated legacy traceback)
  - Full-stack composed tool execution via `tool.Execute`
  - Full-stack through `NativeExecutor.Execute` with capturing observer (proves `run_events` path is clean)
- [ ] **Rebuild E2B template** with updated `http_request.py` and re-pin pack versions before deploy
- [ ] Smoke test against live E2B with a canned authenticated endpoint, verify agent cannot exfiltrate the Authorization via `read_file`
- [ ] Verify `go test -tags=e2bsmoke ./internal/sandbox/e2b/...` (if credentials available) still passes

## Review guidance

Start with `primitive_secrets.go` — it's the single source of truth for the `secretSafePrimitives` allowlist, the `sensitiveResponseHeaders` denylist, and the `stderrSecretPatterns` regex set. Any security regression here is visible in one file.

Then read `tool_registry.go` around the `newManifestCustomTool` gate (line ~312) to see the build-time rejection.

Then `primitive_tools.go` for the `executeHTTPRequestTool` changes — the `defer` scrub, stderr sanitization wiring, and header scrubber integration.

Finally `http_request.py` for the Python try/except expansion.

Tests to read for confidence: `TestComposedHttpRequest_SecretIsolation_ThroughNativeExecutor` (observer path) and `TestComposedHttpRequest_SecretIsolation_FullStack` (direct primitive path).

## 🛠 Pre-merge / deploy checklist (for maintainer)

Before clicking merge:
- [ ] **Rebuild the E2B sandbox template** with the updated `e2b-template/tools/http_request.py` (step 5 + step 8). Bump the template version. Any pack pinned to the old template will still ship the pre-#186 Python script and rely solely on the Go-side `scrubStderrSecrets` regex as its defense — that's intentional belt-and-suspenders, but new packs should pin the new template to get both layers.
- [ ] Run `go test ./...` including `-tags=e2bsmoke ./internal/sandbox/e2b/...` if E2B credentials are available in the environment.
- [ ] **Live E2B smoke test**: provision a workspace secret, author a pack with a composed `http_request` tool that carries `${secrets.*}` in Authorization, run a test agent that explicitly tries `read_file` + `list_files` on `/workspace/.agentclash/tool-inputs/` and `/proc/self/environ` after issuing the call. Confirm no plaintext surfaces.
- [ ] **Merge coordination**: this PR's base branch is `feat/issue-178-sandbox-secrets` (PR #193), not `main`. After #193 merges, this PR's base should auto-update — verify GitHub recomputes the diff cleanly before merging.
- [ ] **Do NOT merge #193 to `main` without this PR also ready.** See #193's checklist for merge sequencing options.

## 🔭 Follow-up issues to file (after merge)

Two architectural gaps uncovered during this PR that are orthogonal to #186 but deserve their own tickets. Please file:

1. **`ReadableRoots` / `WritableRoots` enforcement is vestigial.** `backend/internal/sandbox/e2b/provider.go:40-48` never sends the `FilesystemSpec` to E2B's `createSandboxRequest`, and `executeReadFileTool` (`primitive_tools.go:166`) passes paths straight to `session.ReadFile` with no Go-side validation. Result: the agent can `read_file("/proc/self/environ")`, `read_file("/etc/passwd")`, or `read_file("/tmp/anything")`. This PR's defenses close the specific #186 leak vectors (steps 1–5), but the allowlist gap is a broader architectural weakness that should be fixed separately. Suggested title: *"Enforce sandbox ReadableRoots/WritableRoots at the file-primitive boundary"*.

2. **Stdin-piped `http_request` args via E2B `SendInput` RPC.** The current defer-overwrite scrub (#186 step 3) is equivalent security under the serial tool-call invariant. A stdin-piped alternative would eliminate the tool-inputs file entirely, removing dependence on that invariant. E2B's `processpb` already exposes `SendInput` + `CloseStdin` (`pkg/grpc/envd/process/process.pb.go`); the main work is extending `sandbox.Session` with a stdin-aware `Exec` variant and wiring it through `executeInternalCommand`. Suggested title: *"Pipe http_request args via E2B SendInput instead of tool-inputs file"*.

## What this PR explicitly does NOT protect against

- Pack authors who hardcode literal API keys into primitive args (not via `${secrets.*}`). The build-time gate detects the placeholder, not the resolved value.
- Remote APIs that echo authentication material in their response **body** (body scrubbing out of scope — structured content, can't be stripped without domain knowledge).
- Any primitive not on the `secretSafePrimitives` list attempting to use secrets — they're rejected at pack-build, not silently permitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

