### PR TITLE
feat: Tenant CRUD — organizations, workspaces, memberships

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -40,8 +40,8 @@ func main() {
 	}
 	defer temporalClient.Close()
 
-	authorizer := api.NewCallerWorkspaceAuthorizer()
 	repo := repository.New(db)
+	authorizer := api.NewCallerWorkspaceAuthorizer(repo)
 	artifactStore, err := storage.NewStore(context.Background(), storage.Config{
 		Backend:          cfg.ArtifactStorageBackend,
 		Bucket:           cfg.ArtifactStorageBucket,
@@ -75,6 +75,13 @@ func main() {
 	challengePackReadManager := api.NewChallengePackReadManager(repo)
 	challengePackAuthoringManager := api.NewChallengePackAuthoringManager(repo, artifactStore)
 	agentBuildManager := api.NewAgentBuildManager(repo)
+	userManager := api.NewUserManager(repo)
+	orgAuthz := api.NewCallerOrganizationAuthorizer()
+	orgManager := api.NewOrganizationManager(orgAuthz, repo)
+	wsManager := api.NewWorkspaceManager(orgAuthz, repo)
+	orgMembershipManager := api.NewOrgMembershipManager(orgAuthz, repo)
+	wsMembershipManager := api.NewWorkspaceMembershipManager(repo)
+	onboardingManager := api.NewOnboardingManager(repo)
 
 	var authenticator api.Authenticator
 	switch cfg.AuthMode {
@@ -109,6 +116,12 @@ func main() {
 		challengePackReadManager,
 		challengePackAuthoringManager,
 		agentBuildManager,
+		userManager,
+		orgManager,
+		wsManager,
+		orgMembershipManager,
+		wsMembershipManager,
+		onboardingManager,
 	)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/backend/internal/api/agent_builds_test.go
+++ b/backend/internal/api/agent_builds_test.go
@@ -101,6 +101,12 @@ func TestGetAgentBuildRequiresWorkspaceMembership(t *testing.T) {
 			versions: map[uuid.UUID]repository.AgentBuildVersion{},
 		},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	)
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/agent-builds/"+buildID.String(), nil)
@@ -149,6 +155,12 @@ func TestGetAgentBuildVersionRequiresWorkspaceMembership(t *testing.T) {
 			},
 		},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	)
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/agent-build-versions/"+versionID.String(), nil)
@@ -217,6 +229,12 @@ func TestGetAgentBuildVersionReturnsToolAndKnowledgeBindings(t *testing.T) {
 			},
 		},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	)
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/agent-build-versions/"+versionID.String(), nil)

--- a/backend/internal/api/artifacts_test.go
+++ b/backend/internal/api/artifacts_test.go
@@ -105,6 +105,12 @@ func TestArtifactManagerUploadAndSignedDownloadFlow(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {

--- a/backend/internal/api/auth.go
+++ b/backend/internal/api/auth.go
@@ -20,11 +20,17 @@ var (
 )
 
 type Caller struct {
-	UserID               uuid.UUID
-	WorkOSUserID         string
-	Email                string
-	DisplayName          string
-	WorkspaceMemberships map[uuid.UUID]WorkspaceMembership
+	UserID                  uuid.UUID
+	WorkOSUserID            string
+	Email                   string
+	DisplayName             string
+	OrganizationMemberships map[uuid.UUID]OrganizationMembership
+	WorkspaceMemberships    map[uuid.UUID]WorkspaceMembership
+}
+
+type OrganizationMembership struct {
+	OrganizationID uuid.UUID `json:"organization_id"`
+	Role           string    `json:"role"`
 }
 
 type WorkspaceMembership struct {
@@ -38,6 +44,11 @@ type Authenticator interface {
 
 type WorkspaceAuthorizer interface {
 	AuthorizeWorkspace(ctx context.Context, caller Caller, workspaceID uuid.UUID) error
+}
+
+type OrganizationAuthorizer interface {
+	AuthorizeOrganization(ctx context.Context, caller Caller, orgID uuid.UUID) error
+	AuthorizeOrganizationAdmin(ctx context.Context, caller Caller, orgID uuid.UUID) error
 }
 
 type callerContextKey struct{}
@@ -59,6 +70,19 @@ func WorkspaceIDFromContext(ctx context.Context) (uuid.UUID, error) {
 	}
 
 	return workspaceID, nil
+}
+
+func SortedOrganizationMemberships(memberships map[uuid.UUID]OrganizationMembership) []OrganizationMembership {
+	ordered := make([]OrganizationMembership, 0, len(memberships))
+	for _, membership := range memberships {
+		ordered = append(ordered, membership)
+	}
+
+	sort.Slice(ordered, func(i, j int) bool {
+		return ordered[i].OrganizationID.String() < ordered[j].OrganizationID.String()
+	})
+
+	return ordered
 }
 
 func SortedWorkspaceMemberships(memberships map[uuid.UUID]WorkspaceMembership) []WorkspaceMembership {
@@ -147,16 +171,66 @@ func writeAuthzError(w http.ResponseWriter, err error) {
 	}
 }
 
-type CallerWorkspaceAuthorizer struct{}
-
-func NewCallerWorkspaceAuthorizer() CallerWorkspaceAuthorizer {
-	return CallerWorkspaceAuthorizer{}
+// WorkspaceOrgLookup resolves the parent organization of a workspace.
+// Used by the workspace authorizer to check org_admin implicit access.
+type WorkspaceOrgLookup interface {
+	GetOrganizationIDByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (uuid.UUID, error)
 }
 
-func (CallerWorkspaceAuthorizer) AuthorizeWorkspace(_ context.Context, caller Caller, workspaceID uuid.UUID) error {
-	if _, ok := caller.WorkspaceMemberships[workspaceID]; !ok {
-		return fmt.Errorf("%w: caller %s does not belong to workspace %s", ErrForbidden, caller.UserID, workspaceID)
+type CallerWorkspaceAuthorizer struct {
+	orgLookup WorkspaceOrgLookup
+}
+
+// NewCallerWorkspaceAuthorizer creates a workspace authorizer.
+// Pass a WorkspaceOrgLookup to enable org_admin implicit access to all
+// workspaces in their org. If nil, only explicit workspace membership is checked.
+func NewCallerWorkspaceAuthorizer(orgLookup ...WorkspaceOrgLookup) CallerWorkspaceAuthorizer {
+	var lookup WorkspaceOrgLookup
+	if len(orgLookup) > 0 {
+		lookup = orgLookup[0]
+	}
+	return CallerWorkspaceAuthorizer{orgLookup: lookup}
+}
+
+func (a CallerWorkspaceAuthorizer) AuthorizeWorkspace(ctx context.Context, caller Caller, workspaceID uuid.UUID) error {
+	// Check 1: explicit workspace membership.
+	if _, ok := caller.WorkspaceMemberships[workspaceID]; ok {
+		return nil
 	}
 
+	// Check 2: org_admin of the workspace's parent org (implicit access).
+	if a.orgLookup != nil {
+		orgID, err := a.orgLookup.GetOrganizationIDByWorkspaceID(ctx, workspaceID)
+		if err == nil {
+			if m, ok := caller.OrganizationMemberships[orgID]; ok && m.Role == "org_admin" {
+				return nil
+			}
+		}
+	}
+
+	return fmt.Errorf("%w: caller %s does not belong to workspace %s", ErrForbidden, caller.UserID, workspaceID)
+}
+
+type CallerOrganizationAuthorizer struct{}
+
+func NewCallerOrganizationAuthorizer() CallerOrganizationAuthorizer {
+	return CallerOrganizationAuthorizer{}
+}
+
+func (CallerOrganizationAuthorizer) AuthorizeOrganization(_ context.Context, caller Caller, orgID uuid.UUID) error {
+	if _, ok := caller.OrganizationMemberships[orgID]; !ok {
+		return fmt.Errorf("%w: caller %s is not a member of organization %s", ErrForbidden, caller.UserID, orgID)
+	}
+	return nil
+}
+
+func (CallerOrganizationAuthorizer) AuthorizeOrganizationAdmin(_ context.Context, caller Caller, orgID uuid.UUID) error {
+	m, ok := caller.OrganizationMemberships[orgID]
+	if !ok {
+		return fmt.Errorf("%w: caller %s is not a member of organization %s", ErrForbidden, caller.UserID, orgID)
+	}
+	if m.Role != "org_admin" {
+		return fmt.Errorf("%w: caller %s is not an admin of organization %s", ErrForbidden, caller.UserID, orgID)
+	}
 	return nil
 }

--- a/backend/internal/api/auth_dev.go
+++ b/backend/internal/api/auth_dev.go
@@ -13,6 +13,7 @@ const (
 	headerWorkOSUserID         = "X-Agentclash-WorkOS-User-Id"
 	headerUserEmail            = "X-Agentclash-User-Email"
 	headerUserDisplayName      = "X-Agentclash-User-Display-Name"
+	headerOrgMemberships       = "X-Agentclash-Org-Memberships"
 	headerWorkspaceMemberships = "X-Agentclash-Workspace-Memberships"
 )
 
@@ -33,18 +34,55 @@ func (DevelopmentAuthenticator) Authenticate(r *http.Request) (Caller, error) {
 		return Caller{}, fmt.Errorf("%w: invalid %s header", ErrUnauthenticated, headerUserID)
 	}
 
+	orgMemberships, err := parseOrgMemberships(r.Header.Get(headerOrgMemberships))
+	if err != nil {
+		return Caller{}, fmt.Errorf("%w: %v", ErrUnauthenticated, err)
+	}
+
 	memberships, err := parseWorkspaceMemberships(r.Header.Get(headerWorkspaceMemberships))
 	if err != nil {
 		return Caller{}, fmt.Errorf("%w: %v", ErrUnauthenticated, err)
 	}
 
 	return Caller{
-		UserID:               userID,
-		WorkOSUserID:         strings.TrimSpace(r.Header.Get(headerWorkOSUserID)),
-		Email:                strings.TrimSpace(r.Header.Get(headerUserEmail)),
-		DisplayName:          strings.TrimSpace(r.Header.Get(headerUserDisplayName)),
-		WorkspaceMemberships: memberships,
+		UserID:                  userID,
+		WorkOSUserID:            strings.TrimSpace(r.Header.Get(headerWorkOSUserID)),
+		Email:                   strings.TrimSpace(r.Header.Get(headerUserEmail)),
+		DisplayName:             strings.TrimSpace(r.Header.Get(headerUserDisplayName)),
+		OrganizationMemberships: orgMemberships,
+		WorkspaceMemberships:    memberships,
 	}, nil
+}
+
+func parseOrgMemberships(raw string) (map[uuid.UUID]OrganizationMembership, error) {
+	memberships := make(map[uuid.UUID]OrganizationMembership)
+	if strings.TrimSpace(raw) == "" {
+		return memberships, nil
+	}
+
+	for _, entry := range strings.Split(raw, ",") {
+		parts := strings.Split(strings.TrimSpace(entry), ":")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid %s entry %q", headerOrgMemberships, entry)
+		}
+
+		orgID, err := uuid.Parse(strings.TrimSpace(parts[0]))
+		if err != nil {
+			return nil, fmt.Errorf("invalid organization id %q in %s", parts[0], headerOrgMemberships)
+		}
+
+		role := strings.TrimSpace(parts[1])
+		if role == "" {
+			return nil, fmt.Errorf("missing organization role in %s", headerOrgMemberships)
+		}
+
+		memberships[orgID] = OrganizationMembership{
+			OrganizationID: orgID,
+			Role:           role,
+		}
+	}
+
+	return memberships, nil
 }
 
 func parseWorkspaceMemberships(raw string) (map[uuid.UUID]WorkspaceMembership, error) {

--- a/backend/internal/api/auth_workos.go
+++ b/backend/internal/api/auth_workos.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -25,7 +26,11 @@ const (
 // UserRepository is the subset of repository.Repository needed for auth.
 type UserRepository interface {
 	GetUserByWorkOSID(ctx context.Context, workosUserID string) (repository.User, error)
+	GetUserByEmail(ctx context.Context, email string) (repository.User, error)
 	GetActiveWorkspaceMembershipsByUserID(ctx context.Context, userID uuid.UUID) ([]repository.WorkspaceMembershipRow, error)
+	GetActiveOrganizationMembershipsByUserID(ctx context.Context, userID uuid.UUID) ([]repository.OrgMembershipRow, error)
+	CreateUser(ctx context.Context, input repository.CreateUserInput) (repository.User, error)
+	LinkWorkOSUser(ctx context.Context, userID uuid.UUID, workosUserID string) (repository.User, error)
 }
 
 // WorkOSAuthenticator validates WorkOS AuthKit JWTs using the public JWKS
@@ -106,9 +111,27 @@ func (a *WorkOSAuthenticator) Authenticate(r *http.Request) (Caller, error) {
 		return Caller{}, fmt.Errorf("%w: token missing sub claim", ErrUnauthenticated)
 	}
 
-	user, err := a.repo.GetUserByWorkOSID(r.Context(), workosUserID)
+	// Extract email from JWT claims if available (WorkOS includes email in
+	// the token for AuthKit). Fall back to empty string if absent.
+	email, _ := tok.Get("email")
+	emailStr, _ := email.(string)
+
+	user, err := a.resolveUser(r.Context(), workosUserID, emailStr)
 	if err != nil {
-		return Caller{}, fmt.Errorf("%w: %v", ErrUnauthenticated, err)
+		return Caller{}, err
+	}
+
+	orgMemberships, err := a.repo.GetActiveOrganizationMembershipsByUserID(r.Context(), user.ID)
+	if err != nil {
+		return Caller{}, fmt.Errorf("%w: failed to load organization memberships: %v", ErrUnauthenticated, err)
+	}
+
+	orgMembershipMap := make(map[uuid.UUID]OrganizationMembership, len(orgMemberships))
+	for _, m := range orgMemberships {
+		orgMembershipMap[m.OrganizationID] = OrganizationMembership{
+			OrganizationID: m.OrganizationID,
+			Role:           m.Role,
+		}
 	}
 
 	memberships, err := a.repo.GetActiveWorkspaceMembershipsByUserID(r.Context(), user.ID)
@@ -125,12 +148,53 @@ func (a *WorkOSAuthenticator) Authenticate(r *http.Request) (Caller, error) {
 	}
 
 	return Caller{
-		UserID:               user.ID,
-		WorkOSUserID:         user.WorkOSUserID,
-		Email:                user.Email,
-		DisplayName:          user.DisplayName,
-		WorkspaceMemberships: membershipMap,
+		UserID:                  user.ID,
+		WorkOSUserID:            user.WorkOSUserID,
+		Email:                   user.Email,
+		DisplayName:             user.DisplayName,
+		OrganizationMemberships: orgMembershipMap,
+		WorkspaceMemberships:    membershipMap,
 	}, nil
+}
+
+// resolveUser finds or creates the internal user for a WorkOS login.
+// It handles three cases:
+//  1. User already exists with this WorkOS ID → return it.
+//  2. A stub user exists from an invite (matched by email, has a placeholder
+//     workos_user_id) → link the real WorkOS ID and return it.
+//  3. Completely new user → create and return.
+func (a *WorkOSAuthenticator) resolveUser(ctx context.Context, workosUserID, email string) (repository.User, error) {
+	user, err := a.repo.GetUserByWorkOSID(ctx, workosUserID)
+	if err == nil {
+		return user, nil
+	}
+	if !errors.Is(err, repository.ErrUserNotFound) {
+		return repository.User{}, fmt.Errorf("%w: %v", ErrUnauthenticated, err)
+	}
+
+	// No user with this WorkOS ID. Check if a stub user was created via invite.
+	// Only link to stub users (workos_user_id starts with "pending:") — never
+	// overwrite a real user's identity, which would be an account takeover.
+	if email != "" {
+		stubUser, emailErr := a.repo.GetUserByEmail(ctx, email)
+		if emailErr == nil && strings.HasPrefix(stubUser.WorkOSUserID, "pending:") {
+			linked, linkErr := a.repo.LinkWorkOSUser(ctx, stubUser.ID, workosUserID)
+			if linkErr != nil {
+				return repository.User{}, fmt.Errorf("link workos user to invited stub: %w", linkErr)
+			}
+			return linked, nil
+		}
+	}
+
+	// Truly new user — auto-create.
+	user, err = a.repo.CreateUser(ctx, repository.CreateUserInput{
+		WorkOSUserID: workosUserID,
+		Email:        email,
+	})
+	if err != nil {
+		return repository.User{}, fmt.Errorf("auto-create user: %w", err)
+	}
+	return user, nil
 }
 
 // bearerToken extracts a Bearer token from the Authorization header.

--- a/backend/internal/api/auth_workos_test.go
+++ b/backend/internal/api/auth_workos_test.go
@@ -83,10 +83,14 @@ func signTestJWT(t *testing.T, privKey *rsa.PrivateKey, claims map[string]interf
 // --- stub UserRepository for tests ---
 
 type stubUserRepo struct {
-	user           repository.User
-	memberships    []repository.WorkspaceMembershipRow
-	err            error
-	membershipErr  error
+	user              repository.User
+	memberships       []repository.WorkspaceMembershipRow
+	orgMemberships    []repository.OrgMembershipRow
+	createdUser       repository.User
+	err               error
+	membershipErr     error
+	orgMembershipErr  error
+	createUserErr     error
 }
 
 func (s stubUserRepo) GetUserByWorkOSID(_ context.Context, _ string) (repository.User, error) {
@@ -101,6 +105,36 @@ func (s stubUserRepo) GetActiveWorkspaceMembershipsByUserID(_ context.Context, _
 		return nil, s.membershipErr
 	}
 	return s.memberships, nil
+}
+
+func (s stubUserRepo) GetActiveOrganizationMembershipsByUserID(_ context.Context, _ uuid.UUID) ([]repository.OrgMembershipRow, error) {
+	if s.orgMembershipErr != nil {
+		return nil, s.orgMembershipErr
+	}
+	return s.orgMemberships, nil
+}
+
+func (s stubUserRepo) CreateUser(_ context.Context, input repository.CreateUserInput) (repository.User, error) {
+	if s.createUserErr != nil {
+		return repository.User{}, s.createUserErr
+	}
+	if s.createdUser.ID != uuid.Nil {
+		return s.createdUser, nil
+	}
+	return repository.User{
+		ID:           uuid.New(),
+		WorkOSUserID: input.WorkOSUserID,
+		Email:        input.Email,
+		DisplayName:  input.DisplayName,
+	}, nil
+}
+
+func (s stubUserRepo) GetUserByEmail(_ context.Context, _ string) (repository.User, error) {
+	return repository.User{}, repository.ErrUserNotFound
+}
+
+func (s stubUserRepo) LinkWorkOSUser(_ context.Context, _ uuid.UUID, _ string) (repository.User, error) {
+	return repository.User{}, errors.New("not implemented in stub")
 }
 
 // --- tests ---
@@ -250,10 +284,18 @@ func TestWorkOSAuthenticator_InvalidSignature(t *testing.T) {
 	}
 }
 
-func TestWorkOSAuthenticator_UserNotFound(t *testing.T) {
+func TestWorkOSAuthenticator_FirstLoginCreatesUser(t *testing.T) {
 	privKey, jwksServer := testJWKS(t)
 
-	repo := stubUserRepo{err: repository.ErrUserNotFound}
+	createdUserID := uuid.New()
+	repo := stubUserRepo{
+		err: repository.ErrUserNotFound,
+		createdUser: repository.User{
+			ID:           createdUserID,
+			WorkOSUserID: "user_01NEW",
+			Email:        "new@example.com",
+		},
+	}
 
 	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", repo)
 	if err != nil {
@@ -261,7 +303,46 @@ func TestWorkOSAuthenticator_UserNotFound(t *testing.T) {
 	}
 
 	token := signTestJWT(t, privKey, map[string]interface{}{
-		"sub": "user_01DOESNOTEXIST",
+		"sub":   "user_01NEW",
+		"iss":   "https://api.workos.com",
+		"email": "new@example.com",
+		"iat":   time.Now().Unix(),
+		"exp":   time.Now().Add(5 * time.Minute).Unix(),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/session", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	caller, err := auth.Authenticate(req)
+	if err != nil {
+		t.Fatalf("expected auto-create to succeed, got: %v", err)
+	}
+	if caller.UserID != createdUserID {
+		t.Errorf("UserID = %v, want %v", caller.UserID, createdUserID)
+	}
+	if len(caller.OrganizationMemberships) != 0 {
+		t.Errorf("OrganizationMemberships len = %d, want 0", len(caller.OrganizationMemberships))
+	}
+	if len(caller.WorkspaceMemberships) != 0 {
+		t.Errorf("WorkspaceMemberships len = %d, want 0", len(caller.WorkspaceMemberships))
+	}
+}
+
+func TestWorkOSAuthenticator_FirstLoginCreateUserFails(t *testing.T) {
+	privKey, jwksServer := testJWKS(t)
+
+	repo := stubUserRepo{
+		err:           repository.ErrUserNotFound,
+		createUserErr: errors.New("db connection lost"),
+	}
+
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", repo)
+	if err != nil {
+		t.Fatalf("create authenticator: %v", err)
+	}
+
+	token := signTestJWT(t, privKey, map[string]interface{}{
+		"sub": "user_01NEW",
 		"iss": "https://api.workos.com",
 		"iat": time.Now().Unix(),
 		"exp": time.Now().Add(5 * time.Minute).Unix(),
@@ -272,7 +353,7 @@ func TestWorkOSAuthenticator_UserNotFound(t *testing.T) {
 
 	_, err = auth.Authenticate(req)
 	if err == nil {
-		t.Fatal("expected error for unknown user")
+		t.Fatal("expected error when CreateUser fails")
 	}
 }
 

--- a/backend/internal/api/challenge_packs_test.go
+++ b/backend/internal/api/challenge_packs_test.go
@@ -178,6 +178,11 @@ challenges:
 		stubAgentBuildService{},
 		noopReleaseGateService{},
 		service,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusCreated {

--- a/backend/internal/api/compare_reads_test.go
+++ b/backend/internal/api/compare_reads_test.go
@@ -110,6 +110,12 @@ func TestGetRunComparisonEndpointReturnsJSONPayload(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -153,6 +159,12 @@ func TestCompareViewerEndpointReturnsHTMLShell(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {

--- a/backend/internal/api/cors.go
+++ b/backend/internal/api/cors.go
@@ -9,7 +9,7 @@ import "net/http"
 func corsAllowedHeaders(authMode string) string {
 	const base = "Content-Type, Authorization"
 	if authMode == "dev" {
-		return base + ", X-Agentclash-User-Id, X-Agentclash-WorkOS-User-Id, X-Agentclash-User-Email, X-Agentclash-User-Display-Name, X-Agentclash-Workspace-Memberships"
+		return base + ", X-Agentclash-User-Id, X-Agentclash-WorkOS-User-Id, X-Agentclash-User-Email, X-Agentclash-User-Display-Name, X-Agentclash-Org-Memberships, X-Agentclash-Workspace-Memberships"
 	}
 	return base
 }

--- a/backend/internal/api/hosted_runs_test.go
+++ b/backend/internal/api/hosted_runs_test.go
@@ -240,6 +240,12 @@ func TestIngestHostedRunEventHandlerReturnsInternalErrorForRepositoryFailure(t *
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	)
 	router.ServeHTTP(recorder, req)
 

--- a/backend/internal/api/onboarding.go
+++ b/backend/internal/api/onboarding.go
@@ -1,0 +1,166 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+type OnboardingService interface {
+	Onboard(ctx context.Context, caller Caller, input OnboardInput) (OnboardResult, error)
+}
+
+type OnboardInput struct {
+	OrganizationName string
+	OrganizationSlug *string
+	WorkspaceName    string
+	WorkspaceSlug    *string
+}
+
+type OnboardResult struct {
+	Organization OrganizationResult `json:"organization"`
+	Workspace    WorkspaceResult    `json:"workspace"`
+}
+
+type OnboardingRepository interface {
+	CountActiveOrgAdminMemberships(ctx context.Context, userID uuid.UUID) (int64, error)
+	Onboard(ctx context.Context, input repository.OnboardInput) (repository.OnboardResult, error)
+}
+
+type OnboardingManager struct {
+	repo OnboardingRepository
+}
+
+func NewOnboardingManager(repo OnboardingRepository) *OnboardingManager {
+	return &OnboardingManager{repo: repo}
+}
+
+func (m *OnboardingManager) Onboard(ctx context.Context, caller Caller, input OnboardInput) (OnboardResult, error) {
+	count, err := m.repo.CountActiveOrgAdminMemberships(ctx, caller.UserID)
+	if err != nil {
+		return OnboardResult{}, err
+	}
+	if count > 0 {
+		return OnboardResult{}, repository.ErrAlreadyOnboarded
+	}
+
+	orgSlug := ""
+	if input.OrganizationSlug != nil {
+		if err := validateSlug(*input.OrganizationSlug); err != nil {
+			return OnboardResult{}, err
+		}
+		orgSlug = *input.OrganizationSlug
+	} else {
+		orgSlug = generateSlug(input.OrganizationName)
+	}
+	if err := validateSlug(orgSlug); err != nil {
+		return OnboardResult{}, err
+	}
+
+	wsSlug := ""
+	if input.WorkspaceSlug != nil {
+		if err := validateSlug(*input.WorkspaceSlug); err != nil {
+			return OnboardResult{}, err
+		}
+		wsSlug = *input.WorkspaceSlug
+	} else {
+		wsSlug = generateSlug(input.WorkspaceName)
+	}
+	if err := validateSlug(wsSlug); err != nil {
+		return OnboardResult{}, err
+	}
+
+	result, err := m.repo.Onboard(ctx, repository.OnboardInput{
+		UserID:           caller.UserID,
+		OrganizationName: input.OrganizationName,
+		OrganizationSlug: orgSlug,
+		WorkspaceName:    input.WorkspaceName,
+		WorkspaceSlug:    wsSlug,
+	})
+	if err != nil {
+		return OnboardResult{}, err
+	}
+
+	return OnboardResult{
+		Organization: OrganizationResult{
+			ID:        result.Organization.ID,
+			Name:      result.Organization.Name,
+			Slug:      result.Organization.Slug,
+			Status:    result.Organization.Status,
+			CreatedAt: result.Organization.CreatedAt,
+			UpdatedAt: result.Organization.UpdatedAt,
+		},
+		Workspace: WorkspaceResult{
+			ID:             result.Workspace.ID,
+			OrganizationID: result.Workspace.OrganizationID,
+			Name:           result.Workspace.Name,
+			Slug:           result.Workspace.Slug,
+			Status:         result.Workspace.Status,
+			CreatedAt:      result.Workspace.CreatedAt,
+			UpdatedAt:      result.Workspace.UpdatedAt,
+		},
+	}, nil
+}
+
+func onboardHandler(logger *slog.Logger, service OnboardingService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+
+		var req struct {
+			OrganizationName string  `json:"organization_name"`
+			OrganizationSlug *string `json:"organization_slug,omitempty"`
+			WorkspaceName    string  `json:"workspace_name"`
+			WorkspaceSlug    *string `json:"workspace_slug,omitempty"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body")
+			return
+		}
+		if req.OrganizationName == "" {
+			writeError(w, http.StatusBadRequest, "validation_error", "organization_name is required")
+			return
+		}
+		if req.WorkspaceName == "" {
+			writeError(w, http.StatusBadRequest, "validation_error", "workspace_name is required")
+			return
+		}
+
+		result, err := service.Onboard(r.Context(), caller, OnboardInput{
+			OrganizationName: req.OrganizationName,
+			OrganizationSlug: req.OrganizationSlug,
+			WorkspaceName:    req.WorkspaceName,
+			WorkspaceSlug:    req.WorkspaceSlug,
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, repository.ErrAlreadyOnboarded):
+				writeError(w, http.StatusConflict, "already_onboarded", "you already have an organization")
+			case errors.Is(err, repository.ErrSlugTaken):
+				writeError(w, http.StatusConflict, "slug_taken", "an organization or workspace with this slug already exists")
+			case errors.Is(err, ErrInvalidSlug):
+				writeError(w, http.StatusBadRequest, "validation_error", err.Error())
+			default:
+				logger.Error("onboarding failed", "error", err)
+				writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+			}
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, result)
+	}
+}
+

--- a/backend/internal/api/org_memberships.go
+++ b/backend/internal/api/org_memberships.go
@@ -1,0 +1,446 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+type OrgMembershipService interface {
+	ListOrgMemberships(ctx context.Context, caller Caller, orgID uuid.UUID, limit, offset int32) (ListOrgMembershipsResult, error)
+	InviteOrgMember(ctx context.Context, caller Caller, orgID uuid.UUID, input InviteOrgMemberInput) (OrgMembershipResult, error)
+	UpdateOrgMembership(ctx context.Context, caller Caller, membershipID uuid.UUID, input UpdateOrgMembershipInput) (OrgMembershipResult, error)
+}
+
+type InviteOrgMemberInput struct {
+	Email string
+	Role  string
+}
+
+type UpdateOrgMembershipInput struct {
+	Role   *string
+	Status *string
+}
+
+type OrgMembershipResult struct {
+	ID               uuid.UUID `json:"id"`
+	OrganizationID   uuid.UUID `json:"organization_id"`
+	UserID           uuid.UUID `json:"user_id"`
+	Email            string    `json:"email"`
+	DisplayName      string    `json:"display_name"`
+	Role             string    `json:"role"`
+	MembershipStatus string    `json:"membership_status"`
+	CreatedAt        time.Time `json:"created_at"`
+}
+
+type ListOrgMembershipsResult struct {
+	Items  []OrgMembershipResult `json:"items"`
+	Total  int64                 `json:"total"`
+	Limit  int32                 `json:"limit"`
+	Offset int32                 `json:"offset"`
+}
+
+type OrgMembershipRepository interface {
+	ListOrgMemberships(ctx context.Context, orgID uuid.UUID, limit, offset int32) ([]repository.OrgMembershipFullRow, error)
+	CountOrgMemberships(ctx context.Context, orgID uuid.UUID) (int64, error)
+	GetUserByEmail(ctx context.Context, email string) (repository.User, error)
+	CreateUser(ctx context.Context, input repository.CreateUserInput) (repository.User, error)
+	GetOrgMembershipByOrgAndUser(ctx context.Context, orgID, userID uuid.UUID) (repository.OrgMembershipFullRow, error)
+	CreateOrgMembership(ctx context.Context, input repository.CreateOrgMembershipInput) (repository.OrgMembershipFullRow, error)
+	GetOrgMembershipByID(ctx context.Context, membershipID uuid.UUID) (repository.OrgMembershipFullRow, error)
+	UpdateOrgMembership(ctx context.Context, membershipID uuid.UUID, input repository.UpdateOrgMembershipInput) (repository.OrgMembershipFullRow, error)
+	CountActiveOrgAdmins(ctx context.Context, orgID uuid.UUID) (int64, error)
+	CascadeOrgMembershipStatusToWorkspaces(ctx context.Context, orgID, userID uuid.UUID, status string) error
+}
+
+const inviteExpiryDays = 7
+
+type OrgMembershipManager struct {
+	orgAuthz OrganizationAuthorizer
+	repo     OrgMembershipRepository
+}
+
+func NewOrgMembershipManager(orgAuthz OrganizationAuthorizer, repo OrgMembershipRepository) *OrgMembershipManager {
+	return &OrgMembershipManager{orgAuthz: orgAuthz, repo: repo}
+}
+
+func (m *OrgMembershipManager) ListOrgMemberships(ctx context.Context, caller Caller, orgID uuid.UUID, limit, offset int32) (ListOrgMembershipsResult, error) {
+	if err := m.orgAuthz.AuthorizeOrganization(ctx, caller, orgID); err != nil {
+		return ListOrgMembershipsResult{}, err
+	}
+
+	memberships, err := m.repo.ListOrgMemberships(ctx, orgID, limit, offset)
+	if err != nil {
+		return ListOrgMembershipsResult{}, err
+	}
+
+	total, err := m.repo.CountOrgMemberships(ctx, orgID)
+	if err != nil {
+		return ListOrgMembershipsResult{}, err
+	}
+
+	items := make([]OrgMembershipResult, 0, len(memberships))
+	for _, row := range memberships {
+		items = append(items, orgMembershipRowToResult(row))
+	}
+
+	return ListOrgMembershipsResult{
+		Items:  items,
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	}, nil
+}
+
+func (m *OrgMembershipManager) InviteOrgMember(ctx context.Context, caller Caller, orgID uuid.UUID, input InviteOrgMemberInput) (OrgMembershipResult, error) {
+	if err := m.orgAuthz.AuthorizeOrganizationAdmin(ctx, caller, orgID); err != nil {
+		return OrgMembershipResult{}, err
+	}
+
+	// Look up user by email. Create stub if not found.
+	user, err := m.repo.GetUserByEmail(ctx, input.Email)
+	if errors.Is(err, repository.ErrUserNotFound) {
+		user, err = m.repo.CreateUser(ctx, repository.CreateUserInput{
+			WorkOSUserID: "pending:" + uuid.New().String(), // placeholder — linked on first WorkOS login
+			Email:        input.Email,
+		})
+		if err != nil && !errors.Is(err, repository.ErrUserAlreadyExists) {
+			return OrgMembershipResult{}, err
+		}
+		if errors.Is(err, repository.ErrUserAlreadyExists) {
+			// Race: another request created the user. Fetch it.
+			user, err = m.repo.GetUserByEmail(ctx, input.Email)
+			if err != nil {
+				return OrgMembershipResult{}, err
+			}
+		}
+	} else if err != nil {
+		return OrgMembershipResult{}, err
+	}
+
+	// Check for existing membership.
+	existing, err := m.repo.GetOrgMembershipByOrgAndUser(ctx, orgID, user.ID)
+	if err == nil {
+		if existing.MembershipStatus == "active" || existing.MembershipStatus == "invited" {
+			return OrgMembershipResult{}, repository.ErrAlreadyMember
+		}
+		// Previously archived — allow re-invite by updating status.
+		result, err := m.repo.UpdateOrgMembership(ctx, existing.ID, repository.UpdateOrgMembershipInput{
+			Role:   &input.Role,
+			Status: strPtr("invited"),
+		})
+		if err != nil {
+			return OrgMembershipResult{}, err
+		}
+		return orgMembershipRowToResult(result), nil
+	}
+	if !errors.Is(err, repository.ErrMembershipNotFound) {
+		return OrgMembershipResult{}, err
+	}
+
+	result, err := m.repo.CreateOrgMembership(ctx, repository.CreateOrgMembershipInput{
+		OrganizationID: orgID,
+		UserID:         user.ID,
+		Role:           input.Role,
+	})
+	if err != nil {
+		return OrgMembershipResult{}, err
+	}
+
+	// TODO: Send invitation email notification (stubbed for now).
+
+	return orgMembershipRowToResult(result), nil
+}
+
+func (m *OrgMembershipManager) UpdateOrgMembership(ctx context.Context, caller Caller, membershipID uuid.UUID, input UpdateOrgMembershipInput) (OrgMembershipResult, error) {
+	membership, err := m.repo.GetOrgMembershipByID(ctx, membershipID)
+	if err != nil {
+		return OrgMembershipResult{}, err
+	}
+
+	// Authorization: org_admin of the org, or the invited user accepting their invite.
+	isAdmin := false
+	if m, ok := caller.OrganizationMemberships[membership.OrganizationID]; ok && m.Role == "org_admin" {
+		isAdmin = true
+	}
+	isInvitedUser := membership.UserID == caller.UserID && membership.MembershipStatus == "invited"
+
+	if !isAdmin && !isInvitedUser {
+		return OrgMembershipResult{}, ErrForbidden
+	}
+
+	// Invited user can only accept (invited -> active).
+	if isInvitedUser && !isAdmin {
+		if input.Status == nil || *input.Status != "active" {
+			return OrgMembershipResult{}, ErrForbidden
+		}
+		// Check invite expiry. Use UpdatedAt because re-invites refresh it
+		// via the DB trigger, while CreatedAt is the original row creation.
+		invitedAt := membership.UpdatedAt
+		if invitedAt.IsZero() {
+			invitedAt = membership.CreatedAt
+		}
+		if time.Since(invitedAt) > inviteExpiryDays*24*time.Hour {
+			return OrgMembershipResult{}, repository.ErrInviteExpired
+		}
+	}
+
+	// Validate status transitions.
+	if input.Status != nil {
+		if err := validateOrgMembershipTransition(membership.MembershipStatus, *input.Status); err != nil {
+			return OrgMembershipResult{}, err
+		}
+	}
+
+	// Cannot change own role.
+	if input.Role != nil && membership.UserID == caller.UserID {
+		return OrgMembershipResult{}, ErrForbidden
+	}
+
+	// Last admin protection.
+	if isRemovingAdmin(membership, input) {
+		count, err := m.repo.CountActiveOrgAdmins(ctx, membership.OrganizationID)
+		if err != nil {
+			return OrgMembershipResult{}, err
+		}
+		if count <= 1 {
+			return OrgMembershipResult{}, repository.ErrLastOrgAdmin
+		}
+	}
+
+	result, err := m.repo.UpdateOrgMembership(ctx, membershipID, repository.UpdateOrgMembershipInput{
+		Role:   input.Role,
+		Status: input.Status,
+	})
+	if err != nil {
+		return OrgMembershipResult{}, err
+	}
+
+	// When archiving or suspending an org member, also revoke their workspace
+	// access in this org so they can't reach workspace-scoped endpoints.
+	if input.Status != nil && (*input.Status == "archived" || *input.Status == "suspended") {
+		if err := m.repo.CascadeOrgMembershipStatusToWorkspaces(ctx, membership.OrganizationID, membership.UserID, *input.Status); err != nil {
+			return OrgMembershipResult{}, err
+		}
+	}
+
+	return orgMembershipRowToResult(result), nil
+}
+
+func isRemovingAdmin(membership repository.OrgMembershipFullRow, input UpdateOrgMembershipInput) bool {
+	if membership.Role != "org_admin" || membership.MembershipStatus != "active" {
+		return false
+	}
+	// Demoting from org_admin to org_member.
+	if input.Role != nil && *input.Role != "org_admin" {
+		return true
+	}
+	// Archiving or suspending an active admin.
+	if input.Status != nil && (*input.Status == "archived" || *input.Status == "suspended") {
+		return true
+	}
+	return false
+}
+
+func validateOrgMembershipTransition(from, to string) error {
+	valid := map[string][]string{
+		"invited":   {"active", "archived"},
+		"active":    {"suspended", "archived"},
+		"suspended": {"active", "archived"},
+	}
+	for _, allowed := range valid[from] {
+		if to == allowed {
+			return nil
+		}
+	}
+	return ErrInvalidTransition
+}
+
+var ErrInvalidTransition = errors.New("invalid status transition")
+
+func orgMembershipRowToResult(row repository.OrgMembershipFullRow) OrgMembershipResult {
+	return OrgMembershipResult{
+		ID:               row.ID,
+		OrganizationID:   row.OrganizationID,
+		UserID:           row.UserID,
+		Email:            row.Email,
+		DisplayName:      row.DisplayName,
+		Role:             row.Role,
+		MembershipStatus: row.MembershipStatus,
+		CreatedAt:        row.CreatedAt,
+	}
+}
+
+func strPtr(s string) *string { return &s }
+
+// --- Handlers ---
+
+func listOrgMembershipsHandler(logger *slog.Logger, service OrgMembershipService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		orgID, err := uuid.Parse(chi.URLParam(r, "organizationID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_organization_id", "organization ID is malformed")
+			return
+		}
+
+		limit := int32(50)
+		if raw := r.URL.Query().Get("limit"); raw != "" {
+			if parsed, parseErr := strconv.Atoi(raw); parseErr == nil && parsed > 0 {
+				limit = int32(parsed)
+				if limit > 100 {
+					limit = 100
+				}
+			}
+		}
+		offset := int32(0)
+		if raw := r.URL.Query().Get("offset"); raw != "" {
+			if parsed, parseErr := strconv.Atoi(raw); parseErr == nil && parsed >= 0 {
+				offset = int32(parsed)
+			}
+		}
+
+		result, err := service.ListOrgMemberships(r.Context(), caller, orgID, limit, offset)
+		if err != nil {
+			handleMembershipError(w, logger, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func inviteOrgMemberHandler(logger *slog.Logger, service OrgMembershipService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		orgID, err := uuid.Parse(chi.URLParam(r, "organizationID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_organization_id", "organization ID is malformed")
+			return
+		}
+
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+
+		var req struct {
+			Email string `json:"email"`
+			Role  string `json:"role"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body")
+			return
+		}
+		if req.Email == "" {
+			writeError(w, http.StatusBadRequest, "validation_error", "email is required")
+			return
+		}
+		if req.Role != "org_admin" && req.Role != "org_member" {
+			writeError(w, http.StatusBadRequest, "validation_error", "role must be org_admin or org_member")
+			return
+		}
+
+		result, err := service.InviteOrgMember(r.Context(), caller, orgID, InviteOrgMemberInput{
+			Email: req.Email,
+			Role:  req.Role,
+		})
+		if err != nil {
+			handleMembershipError(w, logger, err)
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, result)
+	}
+}
+
+func updateOrgMembershipHandler(logger *slog.Logger, service OrgMembershipService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		membershipID, err := uuid.Parse(chi.URLParam(r, "membershipID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_membership_id", "membership ID is malformed")
+			return
+		}
+
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+
+		var req struct {
+			Role   *string `json:"role,omitempty"`
+			Status *string `json:"status,omitempty"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body")
+			return
+		}
+		if req.Role == nil && req.Status == nil {
+			writeError(w, http.StatusBadRequest, "validation_error", "at least one of role or status is required")
+			return
+		}
+		if req.Role != nil && *req.Role != "org_admin" && *req.Role != "org_member" {
+			writeError(w, http.StatusBadRequest, "validation_error", "role must be org_admin or org_member")
+			return
+		}
+
+		result, err := service.UpdateOrgMembership(r.Context(), caller, membershipID, UpdateOrgMembershipInput{
+			Role:   req.Role,
+			Status: req.Status,
+		})
+		if err != nil {
+			handleMembershipError(w, logger, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func handleMembershipError(w http.ResponseWriter, logger *slog.Logger, err error) {
+	switch {
+	case errors.Is(err, ErrForbidden):
+		writeError(w, http.StatusForbidden, "forbidden", "access denied")
+	case errors.Is(err, repository.ErrMembershipNotFound):
+		writeError(w, http.StatusNotFound, "not_found", "membership not found")
+	case errors.Is(err, repository.ErrAlreadyMember):
+		writeError(w, http.StatusConflict, "already_a_member", "user is already a member")
+	case errors.Is(err, repository.ErrLastOrgAdmin):
+		writeError(w, http.StatusConflict, "last_org_admin", "cannot remove or demote the last organization admin")
+	case errors.Is(err, repository.ErrLastWorkspaceAdmin):
+		writeError(w, http.StatusConflict, "last_workspace_admin", "cannot remove or demote the last workspace admin")
+	case errors.Is(err, repository.ErrOrgMembershipRequired):
+		writeError(w, http.StatusBadRequest, "org_membership_required", "user must be a member of the organization first")
+	case errors.Is(err, repository.ErrInviteExpired):
+		writeError(w, http.StatusGone, "invite_expired", "invitation has expired")
+	case errors.Is(err, ErrInvalidTransition):
+		writeError(w, http.StatusBadRequest, "invalid_transition", "invalid membership status transition")
+	default:
+		logger.Error("membership operation failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+	}
+}

--- a/backend/internal/api/organizations.go
+++ b/backend/internal/api/organizations.go
@@ -1,0 +1,343 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+type OrganizationService interface {
+	CreateOrganization(ctx context.Context, caller Caller, input CreateOrganizationInput) (OrganizationResult, error)
+	GetOrganization(ctx context.Context, caller Caller, orgID uuid.UUID) (OrganizationResult, error)
+	ListOrganizations(ctx context.Context, caller Caller, limit, offset int32) (ListOrganizationsResult, error)
+	UpdateOrganization(ctx context.Context, caller Caller, orgID uuid.UUID, input UpdateOrganizationInput) (OrganizationResult, error)
+}
+
+type CreateOrganizationInput struct {
+	Name string
+	Slug *string
+}
+
+type UpdateOrganizationInput struct {
+	Name   *string
+	Status *string
+}
+
+type OrganizationResult struct {
+	ID        uuid.UUID `json:"id"`
+	Name      string    `json:"name"`
+	Slug      string    `json:"slug"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type ListOrganizationsResult struct {
+	Items  []OrganizationResult `json:"items"`
+	Total  int64                `json:"total"`
+	Limit  int32                `json:"limit"`
+	Offset int32                `json:"offset"`
+}
+
+type OrganizationRepository interface {
+	CountActiveOrgAdminMemberships(ctx context.Context, userID uuid.UUID) (int64, error)
+	CreateOrganizationWithAdmin(ctx context.Context, input repository.CreateOrgWithAdminInput) (repository.OrganizationRow, error)
+	GetOrganizationByID(ctx context.Context, orgID uuid.UUID) (repository.OrganizationRow, error)
+	ListOrganizationsByUserID(ctx context.Context, userID uuid.UUID, limit, offset int32) ([]repository.OrganizationRow, error)
+	CountOrganizationsByUserID(ctx context.Context, userID uuid.UUID) (int64, error)
+	UpdateOrganization(ctx context.Context, orgID uuid.UUID, input repository.UpdateOrgInput) (repository.OrganizationRow, error)
+	ArchiveOrganizationCascade(ctx context.Context, orgID uuid.UUID) (repository.OrganizationRow, error)
+}
+
+const maxOrganizationsPerUser = 1
+
+type OrganizationManager struct {
+	orgAuthz OrganizationAuthorizer
+	repo     OrganizationRepository
+}
+
+func NewOrganizationManager(orgAuthz OrganizationAuthorizer, repo OrganizationRepository) *OrganizationManager {
+	return &OrganizationManager{orgAuthz: orgAuthz, repo: repo}
+}
+
+func (m *OrganizationManager) CreateOrganization(ctx context.Context, caller Caller, input CreateOrganizationInput) (OrganizationResult, error) {
+	count, err := m.repo.CountActiveOrgAdminMemberships(ctx, caller.UserID)
+	if err != nil {
+		return OrganizationResult{}, err
+	}
+	if count >= maxOrganizationsPerUser {
+		return OrganizationResult{}, repository.ErrOrganizationLimitReached
+	}
+
+	slug := ""
+	if input.Slug != nil {
+		if err := validateSlug(*input.Slug); err != nil {
+			return OrganizationResult{}, err
+		}
+		slug = *input.Slug
+	} else {
+		slug = generateSlug(input.Name)
+	}
+	if err := validateSlug(slug); err != nil {
+		return OrganizationResult{}, err
+	}
+
+	org, err := m.repo.CreateOrganizationWithAdmin(ctx, repository.CreateOrgWithAdminInput{
+		Name:   input.Name,
+		Slug:   slug,
+		UserID: caller.UserID,
+	})
+	if err != nil {
+		return OrganizationResult{}, err
+	}
+
+	return orgRowToResult(org), nil
+}
+
+func (m *OrganizationManager) GetOrganization(ctx context.Context, caller Caller, orgID uuid.UUID) (OrganizationResult, error) {
+	if err := m.orgAuthz.AuthorizeOrganization(ctx, caller, orgID); err != nil {
+		return OrganizationResult{}, err
+	}
+
+	org, err := m.repo.GetOrganizationByID(ctx, orgID)
+	if err != nil {
+		return OrganizationResult{}, err
+	}
+
+	return orgRowToResult(org), nil
+}
+
+func (m *OrganizationManager) ListOrganizations(ctx context.Context, caller Caller, limit, offset int32) (ListOrganizationsResult, error) {
+	orgs, err := m.repo.ListOrganizationsByUserID(ctx, caller.UserID, limit, offset)
+	if err != nil {
+		return ListOrganizationsResult{}, err
+	}
+
+	total, err := m.repo.CountOrganizationsByUserID(ctx, caller.UserID)
+	if err != nil {
+		return ListOrganizationsResult{}, err
+	}
+
+	items := make([]OrganizationResult, 0, len(orgs))
+	for _, org := range orgs {
+		items = append(items, orgRowToResult(org))
+	}
+
+	return ListOrganizationsResult{
+		Items:  items,
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	}, nil
+}
+
+func (m *OrganizationManager) UpdateOrganization(ctx context.Context, caller Caller, orgID uuid.UUID, input UpdateOrganizationInput) (OrganizationResult, error) {
+	if err := m.orgAuthz.AuthorizeOrganizationAdmin(ctx, caller, orgID); err != nil {
+		return OrganizationResult{}, err
+	}
+
+	// Archive cascade (archive org + all workspaces + all memberships).
+	if input.Status != nil && *input.Status == "archived" {
+		org, err := m.repo.ArchiveOrganizationCascade(ctx, orgID)
+		if err != nil {
+			return OrganizationResult{}, err
+		}
+		return orgRowToResult(org), nil
+	}
+
+	org, err := m.repo.UpdateOrganization(ctx, orgID, repository.UpdateOrgInput{
+		Name:   input.Name,
+		Status: input.Status,
+	})
+	if err != nil {
+		return OrganizationResult{}, err
+	}
+
+	return orgRowToResult(org), nil
+}
+
+func orgRowToResult(org repository.OrganizationRow) OrganizationResult {
+	return OrganizationResult{
+		ID:        org.ID,
+		Name:      org.Name,
+		Slug:      org.Slug,
+		Status:    org.Status,
+		CreatedAt: org.CreatedAt,
+		UpdatedAt: org.UpdatedAt,
+	}
+}
+
+// --- Handlers ---
+
+func createOrganizationHandler(logger *slog.Logger, service OrganizationService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+
+		var req struct {
+			Name string  `json:"name"`
+			Slug *string `json:"slug,omitempty"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body")
+			return
+		}
+		if req.Name == "" {
+			writeError(w, http.StatusBadRequest, "validation_error", "name is required")
+			return
+		}
+
+		result, err := service.CreateOrganization(r.Context(), caller, CreateOrganizationInput{
+			Name: req.Name,
+			Slug: req.Slug,
+		})
+		if err != nil {
+			handleOrgError(w, logger, err)
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, result)
+	}
+}
+
+func getOrganizationHandler(logger *slog.Logger, service OrganizationService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		orgID, err := uuid.Parse(chi.URLParam(r, "organizationID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_organization_id", "organization ID is malformed")
+			return
+		}
+
+		result, err := service.GetOrganization(r.Context(), caller, orgID)
+		if err != nil {
+			handleOrgError(w, logger, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func listOrganizationsHandler(logger *slog.Logger, service OrganizationService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		limit := int32(50)
+		if raw := r.URL.Query().Get("limit"); raw != "" {
+			if parsed, parseErr := strconv.Atoi(raw); parseErr == nil && parsed > 0 {
+				limit = int32(parsed)
+				if limit > 100 {
+					limit = 100
+				}
+			}
+		}
+		offset := int32(0)
+		if raw := r.URL.Query().Get("offset"); raw != "" {
+			if parsed, parseErr := strconv.Atoi(raw); parseErr == nil && parsed >= 0 {
+				offset = int32(parsed)
+			}
+		}
+
+		result, err := service.ListOrganizations(r.Context(), caller, limit, offset)
+		if err != nil {
+			logger.Error("list organizations failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+			return
+		}
+
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func updateOrganizationHandler(logger *slog.Logger, service OrganizationService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		orgID, err := uuid.Parse(chi.URLParam(r, "organizationID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_organization_id", "organization ID is malformed")
+			return
+		}
+
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+
+		var req struct {
+			Name   *string `json:"name,omitempty"`
+			Status *string `json:"status,omitempty"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body")
+			return
+		}
+		if req.Name == nil && req.Status == nil {
+			writeError(w, http.StatusBadRequest, "validation_error", "at least one of name or status is required")
+			return
+		}
+		if req.Status != nil && *req.Status != "active" && *req.Status != "archived" {
+			writeError(w, http.StatusBadRequest, "validation_error", "status must be active or archived")
+			return
+		}
+
+		result, err := service.UpdateOrganization(r.Context(), caller, orgID, UpdateOrganizationInput{
+			Name:   req.Name,
+			Status: req.Status,
+		})
+		if err != nil {
+			handleOrgError(w, logger, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func handleOrgError(w http.ResponseWriter, logger *slog.Logger, err error) {
+	switch {
+	case errors.Is(err, ErrForbidden):
+		writeError(w, http.StatusForbidden, "forbidden", "access denied")
+	case errors.Is(err, repository.ErrOrganizationNotFound):
+		writeError(w, http.StatusNotFound, "not_found", "organization not found")
+	case errors.Is(err, repository.ErrOrganizationLimitReached):
+		writeError(w, http.StatusConflict, "organization_limit_reached", "you have reached the maximum number of organizations")
+	case errors.Is(err, repository.ErrSlugTaken):
+		writeError(w, http.StatusConflict, "slug_taken", "an organization with this slug already exists")
+	case errors.Is(err, ErrInvalidSlug):
+		writeError(w, http.StatusBadRequest, "validation_error", err.Error())
+	default:
+		logger.Error("organization operation failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+	}
+}

--- a/backend/internal/api/release_gates_test.go
+++ b/backend/internal/api/release_gates_test.go
@@ -156,6 +156,12 @@ func TestEvaluateReleaseGateEndpointReturnsJSONPayload(t *testing.T) {
 				},
 			},
 		},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -225,6 +231,12 @@ func TestListReleaseGatesEndpointReturnsJSONPayload(t *testing.T) {
 				},
 			},
 		},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {

--- a/backend/internal/api/replay_reads_test.go
+++ b/backend/internal/api/replay_reads_test.go
@@ -208,6 +208,12 @@ func TestGetRunAgentReplayEndpointReturnsPaginatedReplay(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -271,6 +277,12 @@ func TestGetRunAgentReplayEndpointReturnsPendingState(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusAccepted {
@@ -325,6 +337,12 @@ func TestGetRunAgentReplayEndpointReturnsErroredState(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusConflict {
@@ -355,6 +373,12 @@ func TestGetRunAgentReplayEndpointReturnsNotFoundWhenRunAgentMissing(t *testing.
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusNotFound {
@@ -384,6 +408,12 @@ func TestGetRunAgentReplayEndpointReturnsForbidden(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusForbidden {
@@ -413,6 +443,12 @@ func TestGetRunAgentReplayEndpointRejectsMalformedRunAgentID(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusBadRequest {
@@ -443,6 +479,12 @@ func TestGetRunAgentReplayEndpointRejectsMalformedPagination(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusBadRequest {
@@ -491,6 +533,12 @@ func TestGetRunAgentScorecardEndpointReturnsScorecard(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -534,6 +582,12 @@ func TestGetRunAgentScorecardEndpointReturnsForbidden(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusForbidden {
@@ -573,6 +627,12 @@ func TestGetRunAgentScorecardEndpointReturnsPendingWhenScorecardIsPending(t *tes
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusAccepted {
@@ -620,6 +680,12 @@ func TestGetRunAgentScorecardEndpointReturnsConflictWhenScorecardIsMissingAfterT
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusConflict {
@@ -650,6 +716,12 @@ func TestGetRunAgentScorecardEndpointReturnsNotFoundWhenRunAgentMissing(t *testi
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusNotFound {

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -23,8 +23,37 @@ func registerProtectedRoutes(
 	challengePackReadService ChallengePackReadService,
 	challengePackAuthoringService ChallengePackAuthoringService,
 	agentBuildService AgentBuildService,
+	userService UserService,
+	orgService OrganizationService,
+	wsService WorkspaceService,
+	orgMembershipService OrgMembershipService,
+	wsMembershipService WorkspaceMembershipService,
+	onboardingService OnboardingService,
 ) {
 	router.Get("/auth/session", sessionHandler)
+	router.Get("/users/me", getUserMeHandler(logger, userService))
+	router.Post("/onboarding", onboardHandler(logger, onboardingService))
+
+	router.Route("/organizations", func(r chi.Router) {
+		r.Get("/", listOrganizationsHandler(logger, orgService))
+		r.Post("/", createOrganizationHandler(logger, orgService))
+		r.Route("/{organizationID}", func(r chi.Router) {
+			r.Get("/", getOrganizationHandler(logger, orgService))
+			r.Patch("/", updateOrganizationHandler(logger, orgService))
+			r.Get("/workspaces", listWorkspacesHandler(logger, wsService))
+			r.Post("/workspaces", createWorkspaceHandler(logger, wsService))
+			r.Get("/memberships", listOrgMembershipsHandler(logger, orgMembershipService))
+			r.Post("/memberships", inviteOrgMemberHandler(logger, orgMembershipService))
+		})
+	})
+	router.Patch("/organization-memberships/{membershipID}", updateOrgMembershipHandler(logger, orgMembershipService))
+
+	// Standalone workspace endpoints (by workspace ID).
+	router.Get("/workspaces/{workspaceID}/details", getWorkspaceHandler(logger, wsService))
+	router.Patch("/workspaces/{workspaceID}/details", updateWorkspaceHandler(logger, wsService))
+	router.Get("/workspaces/{workspaceID}/memberships", listWorkspaceMembershipsHandler(logger, wsMembershipService))
+	router.Post("/workspaces/{workspaceID}/memberships", inviteWorkspaceMemberHandler(logger, wsMembershipService))
+	router.Patch("/workspace-memberships/{membershipID}", updateWorkspaceMembershipHandler(logger, wsMembershipService))
 	router.Get("/artifacts/{artifactID}/download", getArtifactDownloadHandler(logger, artifactService))
 	// POST /v1/runs resolves workspace access from the JSON body, so authz stays in the run-creation service
 	// instead of URL-param middleware. The run read endpoints below also resolve authz in the service layer
@@ -90,11 +119,12 @@ func sessionHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, sessionResponse{
-		UserID:               caller.UserID,
-		WorkOSUserID:         caller.WorkOSUserID,
-		Email:                caller.Email,
-		DisplayName:          caller.DisplayName,
-		WorkspaceMemberships: SortedWorkspaceMemberships(caller.WorkspaceMemberships),
+		UserID:                  caller.UserID,
+		WorkOSUserID:            caller.WorkOSUserID,
+		Email:                   caller.Email,
+		DisplayName:             caller.DisplayName,
+		OrganizationMemberships: SortedOrganizationMemberships(caller.OrganizationMemberships),
+		WorkspaceMemberships:    SortedWorkspaceMemberships(caller.WorkspaceMemberships),
 	})
 }
 
@@ -104,11 +134,12 @@ type workspaceAccessCheckResponse struct {
 }
 
 type sessionResponse struct {
-	UserID               uuid.UUID             `json:"user_id"`
-	WorkOSUserID         string                `json:"workos_user_id,omitempty"`
-	Email                string                `json:"email,omitempty"`
-	DisplayName          string                `json:"display_name,omitempty"`
-	WorkspaceMemberships []WorkspaceMembership `json:"workspace_memberships"`
+	UserID                  uuid.UUID                `json:"user_id"`
+	WorkOSUserID            string                   `json:"workos_user_id,omitempty"`
+	Email                   string                   `json:"email,omitempty"`
+	DisplayName             string                   `json:"display_name,omitempty"`
+	OrganizationMemberships []OrganizationMembership `json:"organization_memberships"`
+	WorkspaceMemberships    []WorkspaceMembership    `json:"workspace_memberships"`
 }
 
 func workspaceAccessCheckHandler(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/api/run_ranking_test.go
+++ b/backend/internal/api/run_ranking_test.go
@@ -472,6 +472,12 @@ func TestGetRunRankingEndpointReturnsSortedPayload(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -517,6 +523,12 @@ func TestGetRunRankingEndpointRejectsInvalidSortField(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusBadRequest {
@@ -565,6 +577,12 @@ func TestGetRunRankingEndpointReturnsCompositeSortPayload(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -615,6 +633,12 @@ func TestGetRunRankingEndpointReturnsAcceptedWhenPending(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusAccepted {
@@ -651,6 +675,12 @@ func TestGetRunRankingEndpointReturnsConflictWhenErrored(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusConflict {

--- a/backend/internal/api/run_reads_test.go
+++ b/backend/internal/api/run_reads_test.go
@@ -136,6 +136,12 @@ func TestGetRunEndpointReturnsRun(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -178,6 +184,12 @@ func TestGetRunEndpointReturnsNotFound(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusNotFound {
@@ -207,6 +219,12 @@ func TestGetRunEndpointRejectsMalformedRunID(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusBadRequest {
@@ -251,6 +269,12 @@ func TestListRunAgentsEndpointReturnsOrderedItems(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -293,6 +317,12 @@ func TestListRunAgentsEndpointReturnsForbidden(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusForbidden {

--- a/backend/internal/api/runs_test.go
+++ b/backend/internal/api/runs_test.go
@@ -57,6 +57,12 @@ func TestCreateRunEndpointReturnsCreated(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusCreated {
@@ -101,6 +107,12 @@ func TestCreateRunEndpointRejectsInvalidPayload(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusBadRequest {
@@ -148,6 +160,12 @@ func TestCreateRunEndpointReturnsQueuedRunOnWorkflowStartFailure(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusBadGateway {
@@ -193,6 +211,12 @@ func TestCreateRunEndpointRejectsNonJSONContentType(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusUnsupportedMediaType {
@@ -229,6 +253,12 @@ func TestCreateRunEndpointRejectsOversizedRequestBody(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusRequestEntityTooLarge {

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -32,8 +32,14 @@ func NewServer(
 	challengePackReadService ChallengePackReadService,
 	challengePackAuthoringService ChallengePackAuthoringService,
 	agentBuildService AgentBuildService,
+	userService UserService,
+	orgService OrganizationService,
+	wsService WorkspaceService,
+	orgMembershipService OrgMembershipService,
+	wsMembershipService WorkspaceMembershipService,
+	onboardingService OnboardingService,
 ) *Server {
-	router := newRouter(cfg.AuthMode, logger, authenticator, authorizer, artifactService, cfg.ArtifactMaxUploadBytes, runCreationService, runReadService, replayReadService, hostedRunIngestionService, compareReadService, agentDeploymentReadService, challengePackReadService, agentBuildService, releaseGateService, challengePackAuthoringService)
+	router := newRouter(cfg.AuthMode, logger, authenticator, authorizer, artifactService, cfg.ArtifactMaxUploadBytes, runCreationService, runReadService, replayReadService, hostedRunIngestionService, compareReadService, agentDeploymentReadService, challengePackReadService, agentBuildService, releaseGateService, challengePackAuthoringService, userService, orgService, wsService, orgMembershipService, wsMembershipService, onboardingService)
 
 	return &Server{
 		config: cfg,
@@ -96,11 +102,23 @@ func newRouter(
 	challengePackReadService ChallengePackReadService,
 	agentBuildService AgentBuildService,
 	releaseGateService ReleaseGateService,
-	extra ...ChallengePackAuthoringService,
+	challengePackAuthoringServiceArg ChallengePackAuthoringService,
+	userServiceArg UserService,
+	orgServiceArg OrganizationService,
+	wsServiceArg WorkspaceService,
+	orgMembershipServiceArg OrgMembershipService,
+	wsMembershipServiceArg WorkspaceMembershipService,
+	extra ...OnboardingService,
 ) http.Handler {
-	var challengePackAuthoringService ChallengePackAuthoringService
+	challengePackAuthoringService := challengePackAuthoringServiceArg
+	userService := userServiceArg
+	orgService := orgServiceArg
+	wsService := wsServiceArg
+	orgMembershipService := orgMembershipServiceArg
+	wsMembershipService := wsMembershipServiceArg
+	var onboardingService OnboardingService
 	if len(extra) > 0 {
-		challengePackAuthoringService = extra[0]
+		onboardingService = extra[0]
 	}
 
 	if hostedRunIngestionService == nil {
@@ -129,7 +147,7 @@ func newRouter(
 	registerHostedIntegrationRoutes(router, logger, hostedRunIngestionService)
 	router.Route("/v1", func(r chi.Router) {
 		r.Use(authenticateRequest(logger, authenticator))
-		registerProtectedRoutes(r, logger, authorizer, artifactService, artifactMaxUploadBytes, runCreationService, runReadService, replayReadService, compareReadService, releaseGateService, agentDeploymentReadService, challengePackReadService, challengePackAuthoringService, agentBuildService)
+		registerProtectedRoutes(r, logger, authorizer, artifactService, artifactMaxUploadBytes, runCreationService, runReadService, replayReadService, compareReadService, releaseGateService, agentDeploymentReadService, challengePackReadService, challengePackAuthoringService, agentBuildService, userService, orgService, wsService, orgMembershipService, wsMembershipService, onboardingService)
 	})
 
 	return router

--- a/backend/internal/api/server_test.go
+++ b/backend/internal/api/server_test.go
@@ -80,6 +80,11 @@ func TestHealthzReturnsJSONSuccessPayload(t *testing.T) {
 		stubAgentBuildService{},
 		noopReleaseGateService{},
 		stubChallengePackAuthoringService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -147,6 +152,11 @@ func TestSessionEndpointRequiresAuthentication(t *testing.T) {
 		stubAgentBuildService{},
 		noopReleaseGateService{},
 		stubChallengePackAuthoringService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusUnauthorized {
@@ -189,6 +199,11 @@ func TestSessionEndpointReturnsCallerIdentity(t *testing.T) {
 		stubAgentBuildService{},
 		noopReleaseGateService{},
 		stubChallengePackAuthoringService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -234,6 +249,11 @@ func TestWorkspaceAuthorizationReturnsForbiddenWithoutMembership(t *testing.T) {
 		stubAgentBuildService{},
 		noopReleaseGateService{},
 		stubChallengePackAuthoringService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusForbidden {
@@ -273,6 +293,12 @@ func TestWorkspaceAuthorizationReturnsOKWithMembership(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -313,6 +339,12 @@ func TestWorkspaceAuthorizationRejectsMalformedWorkspaceID(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusBadRequest {
@@ -353,6 +385,12 @@ func TestReplayViewerEndpointReturnsHTMLShell(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -393,6 +431,12 @@ func TestReplayViewerEndpointRejectsInvalidReplayPagination(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusBadRequest {

--- a/backend/internal/api/slugs.go
+++ b/backend/internal/api/slugs.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+var (
+	ErrInvalidSlug = errors.New("invalid slug")
+
+	slugPattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+)
+
+func validateSlug(slug string) error {
+	if len(slug) < 3 || len(slug) > 60 {
+		return fmt.Errorf("%w: slug must be between 3 and 60 characters", ErrInvalidSlug)
+	}
+	if !slugPattern.MatchString(slug) {
+		return fmt.Errorf("%w: slug must be lowercase alphanumeric with hyphens, no leading or trailing hyphens", ErrInvalidSlug)
+	}
+	return nil
+}

--- a/backend/internal/api/users.go
+++ b/backend/internal/api/users.go
@@ -1,0 +1,158 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"sort"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+type UserService interface {
+	GetMe(ctx context.Context, caller Caller) (GetUserMeResult, error)
+}
+
+type GetUserMeResult struct {
+	UserID        uuid.UUID            `json:"user_id"`
+	WorkOSUserID  string               `json:"workos_user_id,omitempty"`
+	Email         string               `json:"email,omitempty"`
+	DisplayName   string               `json:"display_name,omitempty"`
+	Organizations []UserMeOrganization `json:"organizations"`
+}
+
+type UserMeOrganization struct {
+	ID         uuid.UUID         `json:"id"`
+	Name       string            `json:"name"`
+	Slug       string            `json:"slug"`
+	Role       string            `json:"role"`
+	Workspaces []UserMeWorkspace `json:"workspaces"`
+}
+
+type UserMeWorkspace struct {
+	ID   uuid.UUID `json:"id"`
+	Name string    `json:"name"`
+	Slug string    `json:"slug"`
+	Role string    `json:"role"`
+}
+
+type UserMeRepository interface {
+	GetOrganizationsForUser(ctx context.Context, userID uuid.UUID) ([]repository.UserMeOrgRow, error)
+	GetWorkspacesForUser(ctx context.Context, userID uuid.UUID) ([]repository.UserMeWorkspaceRow, error)
+	GetAllWorkspacesForOrgs(ctx context.Context, orgIDs []uuid.UUID) ([]repository.UserMeWorkspaceRow, error)
+}
+
+type UserManager struct {
+	repo UserMeRepository
+}
+
+func NewUserManager(repo UserMeRepository) *UserManager {
+	return &UserManager{repo: repo}
+}
+
+func (m *UserManager) GetMe(ctx context.Context, caller Caller) (GetUserMeResult, error) {
+	orgs, err := m.repo.GetOrganizationsForUser(ctx, caller.UserID)
+	if err != nil {
+		return GetUserMeResult{}, err
+	}
+
+	// Determine which org IDs the caller is org_admin for (implicit workspace access).
+	var adminOrgIDs []uuid.UUID
+	for _, org := range orgs {
+		if org.Role == "org_admin" {
+			adminOrgIDs = append(adminOrgIDs, org.ID)
+		}
+	}
+
+	// Get explicit workspace memberships.
+	explicitWorkspaces, err := m.repo.GetWorkspacesForUser(ctx, caller.UserID)
+	if err != nil {
+		return GetUserMeResult{}, err
+	}
+
+	// For org_admin orgs, get ALL workspaces (implicit access).
+	var implicitWorkspaces []repository.UserMeWorkspaceRow
+	if len(adminOrgIDs) > 0 {
+		implicitWorkspaces, err = m.repo.GetAllWorkspacesForOrgs(ctx, adminOrgIDs)
+		if err != nil {
+			return GetUserMeResult{}, err
+		}
+	}
+
+	// Build workspace map per org, deduplicating (explicit wins over implicit).
+	type wsEntry struct {
+		ws   repository.UserMeWorkspaceRow
+		role string
+	}
+	workspacesByOrg := make(map[uuid.UUID]map[uuid.UUID]wsEntry)
+
+	// Add implicit workspaces first (org_admin access).
+	for _, ws := range implicitWorkspaces {
+		if workspacesByOrg[ws.OrganizationID] == nil {
+			workspacesByOrg[ws.OrganizationID] = make(map[uuid.UUID]wsEntry)
+		}
+		workspacesByOrg[ws.OrganizationID][ws.ID] = wsEntry{ws: ws, role: "org_admin"}
+	}
+
+	// Add explicit workspaces (overwrite implicit if present — explicit role wins).
+	for _, ws := range explicitWorkspaces {
+		if workspacesByOrg[ws.OrganizationID] == nil {
+			workspacesByOrg[ws.OrganizationID] = make(map[uuid.UUID]wsEntry)
+		}
+		workspacesByOrg[ws.OrganizationID][ws.ID] = wsEntry{ws: ws, role: ws.Role}
+	}
+
+	// Assemble response.
+	organizations := make([]UserMeOrganization, 0, len(orgs))
+	for _, org := range orgs {
+		wsMap := workspacesByOrg[org.ID]
+		workspaces := make([]UserMeWorkspace, 0, len(wsMap))
+		for _, entry := range wsMap {
+			workspaces = append(workspaces, UserMeWorkspace{
+				ID:   entry.ws.ID,
+				Name: entry.ws.Name,
+				Slug: entry.ws.Slug,
+				Role: entry.role,
+			})
+		}
+		sort.Slice(workspaces, func(i, j int) bool {
+			return workspaces[i].Name < workspaces[j].Name
+		})
+
+		organizations = append(organizations, UserMeOrganization{
+			ID:         org.ID,
+			Name:       org.Name,
+			Slug:       org.Slug,
+			Role:       org.Role,
+			Workspaces: workspaces,
+		})
+	}
+
+	return GetUserMeResult{
+		UserID:        caller.UserID,
+		WorkOSUserID:  caller.WorkOSUserID,
+		Email:         caller.Email,
+		DisplayName:   caller.DisplayName,
+		Organizations: organizations,
+	}, nil
+}
+
+func getUserMeHandler(logger *slog.Logger, service UserService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		result, err := service.GetMe(r.Context(), caller)
+		if err != nil {
+			logger.Error("get user me failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+			return
+		}
+
+		writeJSON(w, http.StatusOK, result)
+	}
+}

--- a/backend/internal/api/workspace_memberships.go
+++ b/backend/internal/api/workspace_memberships.go
@@ -1,0 +1,451 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+type WorkspaceMembershipService interface {
+	ListWorkspaceMemberships(ctx context.Context, caller Caller, workspaceID uuid.UUID, limit, offset int32) (ListWorkspaceMembershipsResult, error)
+	InviteWorkspaceMember(ctx context.Context, caller Caller, workspaceID uuid.UUID, input InviteWorkspaceMemberInput) (WorkspaceMembershipResult, error)
+	UpdateWorkspaceMembership(ctx context.Context, caller Caller, membershipID uuid.UUID, input UpdateWorkspaceMembershipInput) (WorkspaceMembershipResult, error)
+}
+
+type InviteWorkspaceMemberInput struct {
+	Email string
+	Role  string
+}
+
+type UpdateWorkspaceMembershipInput struct {
+	Role   *string
+	Status *string
+}
+
+type WorkspaceMembershipResult struct {
+	ID               uuid.UUID `json:"id"`
+	WorkspaceID      uuid.UUID `json:"workspace_id"`
+	OrganizationID   uuid.UUID `json:"organization_id"`
+	UserID           uuid.UUID `json:"user_id"`
+	Email            string    `json:"email"`
+	DisplayName      string    `json:"display_name"`
+	Role             string    `json:"role"`
+	MembershipStatus string    `json:"membership_status"`
+	CreatedAt        time.Time `json:"created_at"`
+}
+
+type ListWorkspaceMembershipsResult struct {
+	Items  []WorkspaceMembershipResult `json:"items"`
+	Total  int64                       `json:"total"`
+	Limit  int32                       `json:"limit"`
+	Offset int32                       `json:"offset"`
+}
+
+type WorkspaceMembershipRepository interface {
+	GetOrganizationIDByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (uuid.UUID, error)
+	ListWorkspaceMemberships(ctx context.Context, workspaceID uuid.UUID, limit, offset int32) ([]repository.WorkspaceMembershipFullRow, error)
+	CountWorkspaceMemberships(ctx context.Context, workspaceID uuid.UUID) (int64, error)
+	GetUserByEmail(ctx context.Context, email string) (repository.User, error)
+	CreateUser(ctx context.Context, input repository.CreateUserInput) (repository.User, error)
+	GetOrgMembershipByOrgAndUser(ctx context.Context, orgID, userID uuid.UUID) (repository.OrgMembershipFullRow, error)
+	GetWorkspaceMembershipByWorkspaceAndUser(ctx context.Context, workspaceID, userID uuid.UUID) (repository.WorkspaceMembershipFullRow, error)
+	CreateWorkspaceMembership(ctx context.Context, input repository.CreateWorkspaceMembershipInput) (repository.WorkspaceMembershipFullRow, error)
+	GetWorkspaceMembershipByID(ctx context.Context, membershipID uuid.UUID) (repository.WorkspaceMembershipFullRow, error)
+	UpdateWorkspaceMembership(ctx context.Context, membershipID uuid.UUID, input repository.UpdateWorkspaceMembershipInput) (repository.WorkspaceMembershipFullRow, error)
+	CountActiveWorkspaceAdmins(ctx context.Context, workspaceID uuid.UUID) (int64, error)
+}
+
+type WorkspaceMembershipManager struct {
+	repo WorkspaceMembershipRepository
+}
+
+func NewWorkspaceMembershipManager(repo WorkspaceMembershipRepository) *WorkspaceMembershipManager {
+	return &WorkspaceMembershipManager{repo: repo}
+}
+
+func (m *WorkspaceMembershipManager) ListWorkspaceMemberships(ctx context.Context, caller Caller, workspaceID uuid.UUID, limit, offset int32) (ListWorkspaceMembershipsResult, error) {
+	if err := m.authorizeAccess(ctx, caller, workspaceID); err != nil {
+		return ListWorkspaceMembershipsResult{}, err
+	}
+
+	memberships, err := m.repo.ListWorkspaceMemberships(ctx, workspaceID, limit, offset)
+	if err != nil {
+		return ListWorkspaceMembershipsResult{}, err
+	}
+
+	total, err := m.repo.CountWorkspaceMemberships(ctx, workspaceID)
+	if err != nil {
+		return ListWorkspaceMembershipsResult{}, err
+	}
+
+	items := make([]WorkspaceMembershipResult, 0, len(memberships))
+	for _, row := range memberships {
+		items = append(items, wsMembershipRowToResult(row))
+	}
+
+	return ListWorkspaceMembershipsResult{
+		Items:  items,
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	}, nil
+}
+
+func (m *WorkspaceMembershipManager) InviteWorkspaceMember(ctx context.Context, caller Caller, workspaceID uuid.UUID, input InviteWorkspaceMemberInput) (WorkspaceMembershipResult, error) {
+	if err := m.authorizeAdmin(ctx, caller, workspaceID); err != nil {
+		return WorkspaceMembershipResult{}, err
+	}
+
+	orgID, err := m.repo.GetOrganizationIDByWorkspaceID(ctx, workspaceID)
+	if err != nil {
+		return WorkspaceMembershipResult{}, err
+	}
+
+	// Look up or create user.
+	user, err := m.repo.GetUserByEmail(ctx, input.Email)
+	if errors.Is(err, repository.ErrUserNotFound) {
+		user, err = m.repo.CreateUser(ctx, repository.CreateUserInput{
+			WorkOSUserID: "pending:" + uuid.New().String(),
+			Email:        input.Email,
+		})
+		if err != nil && !errors.Is(err, repository.ErrUserAlreadyExists) {
+			return WorkspaceMembershipResult{}, err
+		}
+		if errors.Is(err, repository.ErrUserAlreadyExists) {
+			user, err = m.repo.GetUserByEmail(ctx, input.Email)
+			if err != nil {
+				return WorkspaceMembershipResult{}, err
+			}
+		}
+	} else if err != nil {
+		return WorkspaceMembershipResult{}, err
+	}
+
+	// Pre-check: user must have active org membership.
+	orgMembership, err := m.repo.GetOrgMembershipByOrgAndUser(ctx, orgID, user.ID)
+	if errors.Is(err, repository.ErrMembershipNotFound) || (err == nil && orgMembership.MembershipStatus != "active") {
+		return WorkspaceMembershipResult{}, repository.ErrOrgMembershipRequired
+	}
+	if err != nil {
+		return WorkspaceMembershipResult{}, err
+	}
+
+	// Check existing workspace membership.
+	existing, err := m.repo.GetWorkspaceMembershipByWorkspaceAndUser(ctx, workspaceID, user.ID)
+	if err == nil {
+		if existing.MembershipStatus == "active" || existing.MembershipStatus == "invited" {
+			return WorkspaceMembershipResult{}, repository.ErrAlreadyMember
+		}
+		// Previously archived — re-invite.
+		result, err := m.repo.UpdateWorkspaceMembership(ctx, existing.ID, repository.UpdateWorkspaceMembershipInput{
+			Role:   &input.Role,
+			Status: strPtr("invited"),
+		})
+		if err != nil {
+			return WorkspaceMembershipResult{}, err
+		}
+		return wsMembershipRowToResult(result), nil
+	}
+	if !errors.Is(err, repository.ErrMembershipNotFound) {
+		return WorkspaceMembershipResult{}, err
+	}
+
+	result, err := m.repo.CreateWorkspaceMembership(ctx, repository.CreateWorkspaceMembershipInput{
+		OrganizationID: orgID,
+		WorkspaceID:    workspaceID,
+		UserID:         user.ID,
+		Role:           input.Role,
+	})
+	if err != nil {
+		return WorkspaceMembershipResult{}, err
+	}
+
+	return wsMembershipRowToResult(result), nil
+}
+
+func (m *WorkspaceMembershipManager) UpdateWorkspaceMembership(ctx context.Context, caller Caller, membershipID uuid.UUID, input UpdateWorkspaceMembershipInput) (WorkspaceMembershipResult, error) {
+	membership, err := m.repo.GetWorkspaceMembershipByID(ctx, membershipID)
+	if err != nil {
+		return WorkspaceMembershipResult{}, err
+	}
+
+	// Authorization: workspace_admin, org_admin of parent org, or invited user accepting.
+	isAdmin := false
+	if wm, ok := caller.WorkspaceMemberships[membership.WorkspaceID]; ok && wm.Role == "workspace_admin" {
+		isAdmin = true
+	}
+	if !isAdmin {
+		orgID, err := m.repo.GetOrganizationIDByWorkspaceID(ctx, membership.WorkspaceID)
+		if err == nil {
+			if om, ok := caller.OrganizationMemberships[orgID]; ok && om.Role == "org_admin" {
+				isAdmin = true
+			}
+		}
+	}
+	isInvitedUser := membership.UserID == caller.UserID && membership.MembershipStatus == "invited"
+
+	if !isAdmin && !isInvitedUser {
+		return WorkspaceMembershipResult{}, ErrForbidden
+	}
+
+	if isInvitedUser && !isAdmin {
+		if input.Status == nil || *input.Status != "active" {
+			return WorkspaceMembershipResult{}, ErrForbidden
+		}
+		invitedAt := membership.UpdatedAt
+		if invitedAt.IsZero() {
+			invitedAt = membership.CreatedAt
+		}
+		if time.Since(invitedAt) > inviteExpiryDays*24*time.Hour {
+			return WorkspaceMembershipResult{}, repository.ErrInviteExpired
+		}
+	}
+
+	if input.Status != nil {
+		if err := validateWsMembershipTransition(membership.MembershipStatus, *input.Status); err != nil {
+			return WorkspaceMembershipResult{}, err
+		}
+	}
+
+	if input.Role != nil && membership.UserID == caller.UserID {
+		return WorkspaceMembershipResult{}, ErrForbidden
+	}
+
+	// Last admin protection.
+	if isRemovingWsAdmin(membership, input) {
+		count, err := m.repo.CountActiveWorkspaceAdmins(ctx, membership.WorkspaceID)
+		if err != nil {
+			return WorkspaceMembershipResult{}, err
+		}
+		if count <= 1 {
+			return WorkspaceMembershipResult{}, repository.ErrLastWorkspaceAdmin
+		}
+	}
+
+	result, err := m.repo.UpdateWorkspaceMembership(ctx, membershipID, repository.UpdateWorkspaceMembershipInput{
+		Role:   input.Role,
+		Status: input.Status,
+	})
+	if err != nil {
+		return WorkspaceMembershipResult{}, err
+	}
+
+	return wsMembershipRowToResult(result), nil
+}
+
+func (m *WorkspaceMembershipManager) authorizeAccess(ctx context.Context, caller Caller, workspaceID uuid.UUID) error {
+	if _, ok := caller.WorkspaceMemberships[workspaceID]; ok {
+		return nil
+	}
+	orgID, err := m.repo.GetOrganizationIDByWorkspaceID(ctx, workspaceID)
+	if err != nil {
+		return err
+	}
+	if om, ok := caller.OrganizationMemberships[orgID]; ok && om.Role == "org_admin" {
+		return nil
+	}
+	return ErrForbidden
+}
+
+func (m *WorkspaceMembershipManager) authorizeAdmin(ctx context.Context, caller Caller, workspaceID uuid.UUID) error {
+	if wm, ok := caller.WorkspaceMemberships[workspaceID]; ok && wm.Role == "workspace_admin" {
+		return nil
+	}
+	orgID, err := m.repo.GetOrganizationIDByWorkspaceID(ctx, workspaceID)
+	if err != nil {
+		return err
+	}
+	if om, ok := caller.OrganizationMemberships[orgID]; ok && om.Role == "org_admin" {
+		return nil
+	}
+	return ErrForbidden
+}
+
+func isRemovingWsAdmin(membership repository.WorkspaceMembershipFullRow, input UpdateWorkspaceMembershipInput) bool {
+	if membership.Role != "workspace_admin" || membership.MembershipStatus != "active" {
+		return false
+	}
+	if input.Role != nil && *input.Role != "workspace_admin" {
+		return true
+	}
+	if input.Status != nil && (*input.Status == "archived" || *input.Status == "suspended") {
+		return true
+	}
+	return false
+}
+
+func validateWsMembershipTransition(from, to string) error {
+	valid := map[string][]string{
+		"invited":   {"active", "archived"},
+		"active":    {"suspended", "archived"},
+		"suspended": {"active", "archived"},
+	}
+	for _, allowed := range valid[from] {
+		if to == allowed {
+			return nil
+		}
+	}
+	return ErrInvalidTransition
+}
+
+func wsMembershipRowToResult(row repository.WorkspaceMembershipFullRow) WorkspaceMembershipResult {
+	return WorkspaceMembershipResult{
+		ID:               row.ID,
+		WorkspaceID:      row.WorkspaceID,
+		OrganizationID:   row.OrganizationID,
+		UserID:           row.UserID,
+		Email:            row.Email,
+		DisplayName:      row.DisplayName,
+		Role:             row.Role,
+		MembershipStatus: row.MembershipStatus,
+		CreatedAt:        row.CreatedAt,
+	}
+}
+
+// --- Handlers ---
+
+func listWorkspaceMembershipsHandler(logger *slog.Logger, service WorkspaceMembershipService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		workspaceID, err := uuid.Parse(chi.URLParam(r, "workspaceID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_workspace_id", "workspace ID is malformed")
+			return
+		}
+
+		limit := int32(50)
+		if raw := r.URL.Query().Get("limit"); raw != "" {
+			if parsed, parseErr := strconv.Atoi(raw); parseErr == nil && parsed > 0 {
+				limit = int32(parsed)
+				if limit > 100 {
+					limit = 100
+				}
+			}
+		}
+		offset := int32(0)
+		if raw := r.URL.Query().Get("offset"); raw != "" {
+			if parsed, parseErr := strconv.Atoi(raw); parseErr == nil && parsed >= 0 {
+				offset = int32(parsed)
+			}
+		}
+
+		result, err := service.ListWorkspaceMemberships(r.Context(), caller, workspaceID, limit, offset)
+		if err != nil {
+			handleMembershipError(w, logger, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func inviteWorkspaceMemberHandler(logger *slog.Logger, service WorkspaceMembershipService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		workspaceID, err := uuid.Parse(chi.URLParam(r, "workspaceID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_workspace_id", "workspace ID is malformed")
+			return
+		}
+
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+
+		var req struct {
+			Email string `json:"email"`
+			Role  string `json:"role"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body")
+			return
+		}
+		if req.Email == "" {
+			writeError(w, http.StatusBadRequest, "validation_error", "email is required")
+			return
+		}
+		if req.Role != "workspace_admin" && req.Role != "workspace_member" && req.Role != "workspace_viewer" {
+			writeError(w, http.StatusBadRequest, "validation_error", "role must be workspace_admin, workspace_member, or workspace_viewer")
+			return
+		}
+
+		result, err := service.InviteWorkspaceMember(r.Context(), caller, workspaceID, InviteWorkspaceMemberInput{
+			Email: req.Email,
+			Role:  req.Role,
+		})
+		if err != nil {
+			handleMembershipError(w, logger, err)
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, result)
+	}
+}
+
+func updateWorkspaceMembershipHandler(logger *slog.Logger, service WorkspaceMembershipService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		membershipID, err := uuid.Parse(chi.URLParam(r, "membershipID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_membership_id", "membership ID is malformed")
+			return
+		}
+
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+
+		var req struct {
+			Role   *string `json:"role,omitempty"`
+			Status *string `json:"status,omitempty"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body")
+			return
+		}
+		if req.Role == nil && req.Status == nil {
+			writeError(w, http.StatusBadRequest, "validation_error", "at least one of role or status is required")
+			return
+		}
+		if req.Role != nil && *req.Role != "workspace_admin" && *req.Role != "workspace_member" && *req.Role != "workspace_viewer" {
+			writeError(w, http.StatusBadRequest, "validation_error", "role must be workspace_admin, workspace_member, or workspace_viewer")
+			return
+		}
+
+		result, err := service.UpdateWorkspaceMembership(r.Context(), caller, membershipID, UpdateWorkspaceMembershipInput{
+			Role:   req.Role,
+			Status: req.Status,
+		})
+		if err != nil {
+			handleMembershipError(w, logger, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, result)
+	}
+}

--- a/backend/internal/api/workspaces.go
+++ b/backend/internal/api/workspaces.go
@@ -1,0 +1,398 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+type WorkspaceService interface {
+	CreateWorkspace(ctx context.Context, caller Caller, orgID uuid.UUID, input CreateWorkspaceInput) (WorkspaceResult, error)
+	GetWorkspace(ctx context.Context, caller Caller, workspaceID uuid.UUID) (WorkspaceResult, error)
+	ListWorkspaces(ctx context.Context, caller Caller, orgID uuid.UUID, limit, offset int32) (ListWorkspacesResult, error)
+	UpdateWorkspace(ctx context.Context, caller Caller, workspaceID uuid.UUID, input UpdateWorkspaceInput) (WorkspaceResult, error)
+}
+
+type CreateWorkspaceInput struct {
+	Name string
+	Slug *string
+}
+
+type UpdateWorkspaceInput struct {
+	Name   *string
+	Status *string
+}
+
+type WorkspaceResult struct {
+	ID             uuid.UUID `json:"id"`
+	OrganizationID uuid.UUID `json:"organization_id"`
+	Name           string    `json:"name"`
+	Slug           string    `json:"slug"`
+	Status         string    `json:"status"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+type ListWorkspacesResult struct {
+	Items  []WorkspaceResult `json:"items"`
+	Total  int64             `json:"total"`
+	Limit  int32             `json:"limit"`
+	Offset int32             `json:"offset"`
+}
+
+type WorkspaceCRUDRepository interface {
+	CreateWorkspaceWithAdmin(ctx context.Context, input repository.CreateWorkspaceWithAdminInput) (repository.WorkspaceRow, error)
+	GetWorkspaceByID(ctx context.Context, workspaceID uuid.UUID) (repository.WorkspaceRow, error)
+	ListWorkspacesByOrgID(ctx context.Context, orgID uuid.UUID, limit, offset int32) ([]repository.WorkspaceRow, error)
+	CountWorkspacesByOrgID(ctx context.Context, orgID uuid.UUID) (int64, error)
+	ListWorkspacesByOrgIDForMember(ctx context.Context, orgID, userID uuid.UUID, limit, offset int32) ([]repository.WorkspaceRow, error)
+	CountWorkspacesByOrgIDForMember(ctx context.Context, orgID, userID uuid.UUID) (int64, error)
+	UpdateWorkspace(ctx context.Context, workspaceID uuid.UUID, input repository.UpdateWorkspaceInput) (repository.WorkspaceRow, error)
+	ArchiveWorkspaceCascade(ctx context.Context, workspaceID uuid.UUID) (repository.WorkspaceRow, error)
+	GetOrganizationIDByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (uuid.UUID, error)
+}
+
+type WorkspaceManager struct {
+	orgAuthz OrganizationAuthorizer
+	repo     WorkspaceCRUDRepository
+}
+
+func NewWorkspaceManager(orgAuthz OrganizationAuthorizer, repo WorkspaceCRUDRepository) *WorkspaceManager {
+	return &WorkspaceManager{orgAuthz: orgAuthz, repo: repo}
+}
+
+func (m *WorkspaceManager) CreateWorkspace(ctx context.Context, caller Caller, orgID uuid.UUID, input CreateWorkspaceInput) (WorkspaceResult, error) {
+	if err := m.orgAuthz.AuthorizeOrganizationAdmin(ctx, caller, orgID); err != nil {
+		return WorkspaceResult{}, err
+	}
+
+	slug := ""
+	if input.Slug != nil {
+		if err := validateSlug(*input.Slug); err != nil {
+			return WorkspaceResult{}, err
+		}
+		slug = *input.Slug
+	} else {
+		slug = generateSlug(input.Name)
+	}
+	if err := validateSlug(slug); err != nil {
+		return WorkspaceResult{}, err
+	}
+
+	ws, err := m.repo.CreateWorkspaceWithAdmin(ctx, repository.CreateWorkspaceWithAdminInput{
+		OrganizationID: orgID,
+		Name:           input.Name,
+		Slug:           slug,
+		UserID:         caller.UserID,
+	})
+	if err != nil {
+		return WorkspaceResult{}, err
+	}
+
+	return wsRowToResult(ws), nil
+}
+
+func (m *WorkspaceManager) GetWorkspace(ctx context.Context, caller Caller, workspaceID uuid.UUID) (WorkspaceResult, error) {
+	if err := m.authorizeWorkspaceAccess(ctx, caller, workspaceID); err != nil {
+		return WorkspaceResult{}, err
+	}
+
+	ws, err := m.repo.GetWorkspaceByID(ctx, workspaceID)
+	if err != nil {
+		return WorkspaceResult{}, err
+	}
+
+	return wsRowToResult(ws), nil
+}
+
+func (m *WorkspaceManager) ListWorkspaces(ctx context.Context, caller Caller, orgID uuid.UUID, limit, offset int32) (ListWorkspacesResult, error) {
+	if err := m.orgAuthz.AuthorizeOrganization(ctx, caller, orgID); err != nil {
+		return ListWorkspacesResult{}, err
+	}
+
+	// org_admin sees all workspaces; org_member sees only their own.
+	membership := caller.OrganizationMemberships[orgID]
+	var workspaces []repository.WorkspaceRow
+	var total int64
+	var err error
+
+	if membership.Role == "org_admin" {
+		workspaces, err = m.repo.ListWorkspacesByOrgID(ctx, orgID, limit, offset)
+		if err != nil {
+			return ListWorkspacesResult{}, err
+		}
+		total, err = m.repo.CountWorkspacesByOrgID(ctx, orgID)
+	} else {
+		workspaces, err = m.repo.ListWorkspacesByOrgIDForMember(ctx, orgID, caller.UserID, limit, offset)
+		if err != nil {
+			return ListWorkspacesResult{}, err
+		}
+		total, err = m.repo.CountWorkspacesByOrgIDForMember(ctx, orgID, caller.UserID)
+	}
+	if err != nil {
+		return ListWorkspacesResult{}, err
+	}
+
+	items := make([]WorkspaceResult, 0, len(workspaces))
+	for _, ws := range workspaces {
+		items = append(items, wsRowToResult(ws))
+	}
+
+	return ListWorkspacesResult{
+		Items:  items,
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	}, nil
+}
+
+func (m *WorkspaceManager) UpdateWorkspace(ctx context.Context, caller Caller, workspaceID uuid.UUID, input UpdateWorkspaceInput) (WorkspaceResult, error) {
+	if err := m.authorizeWorkspaceAdmin(ctx, caller, workspaceID); err != nil {
+		return WorkspaceResult{}, err
+	}
+
+	if input.Status != nil && *input.Status == "archived" {
+		ws, err := m.repo.ArchiveWorkspaceCascade(ctx, workspaceID)
+		if err != nil {
+			return WorkspaceResult{}, err
+		}
+		return wsRowToResult(ws), nil
+	}
+
+	ws, err := m.repo.UpdateWorkspace(ctx, workspaceID, repository.UpdateWorkspaceInput{
+		Name:   input.Name,
+		Status: input.Status,
+	})
+	if err != nil {
+		return WorkspaceResult{}, err
+	}
+
+	return wsRowToResult(ws), nil
+}
+
+// authorizeWorkspaceAccess checks if the caller can access the workspace — either through
+// explicit workspace membership or org_admin of the parent org.
+func (m *WorkspaceManager) authorizeWorkspaceAccess(ctx context.Context, caller Caller, workspaceID uuid.UUID) error {
+	if _, ok := caller.WorkspaceMemberships[workspaceID]; ok {
+		return nil
+	}
+	orgID, err := m.repo.GetOrganizationIDByWorkspaceID(ctx, workspaceID)
+	if err != nil {
+		return err
+	}
+	if membership, ok := caller.OrganizationMemberships[orgID]; ok && membership.Role == "org_admin" {
+		return nil
+	}
+	return ErrForbidden
+}
+
+// authorizeWorkspaceAdmin checks if the caller is a workspace_admin or org_admin of the parent org.
+func (m *WorkspaceManager) authorizeWorkspaceAdmin(ctx context.Context, caller Caller, workspaceID uuid.UUID) error {
+	if membership, ok := caller.WorkspaceMemberships[workspaceID]; ok && membership.Role == "workspace_admin" {
+		return nil
+	}
+	orgID, err := m.repo.GetOrganizationIDByWorkspaceID(ctx, workspaceID)
+	if err != nil {
+		return err
+	}
+	if membership, ok := caller.OrganizationMemberships[orgID]; ok && membership.Role == "org_admin" {
+		return nil
+	}
+	return ErrForbidden
+}
+
+func wsRowToResult(ws repository.WorkspaceRow) WorkspaceResult {
+	return WorkspaceResult{
+		ID:             ws.ID,
+		OrganizationID: ws.OrganizationID,
+		Name:           ws.Name,
+		Slug:           ws.Slug,
+		Status:         ws.Status,
+		CreatedAt:      ws.CreatedAt,
+		UpdatedAt:      ws.UpdatedAt,
+	}
+}
+
+// --- Handlers ---
+
+func createWorkspaceHandler(logger *slog.Logger, service WorkspaceService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		orgID, err := uuid.Parse(chi.URLParam(r, "organizationID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_organization_id", "organization ID is malformed")
+			return
+		}
+
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+
+		var req struct {
+			Name string  `json:"name"`
+			Slug *string `json:"slug,omitempty"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body")
+			return
+		}
+		if req.Name == "" {
+			writeError(w, http.StatusBadRequest, "validation_error", "name is required")
+			return
+		}
+
+		result, err := service.CreateWorkspace(r.Context(), caller, orgID, CreateWorkspaceInput{
+			Name: req.Name,
+			Slug: req.Slug,
+		})
+		if err != nil {
+			handleWorkspaceError(w, logger, err)
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, result)
+	}
+}
+
+func getWorkspaceHandler(logger *slog.Logger, service WorkspaceService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		workspaceID, err := uuid.Parse(chi.URLParam(r, "workspaceID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_workspace_id", "workspace ID is malformed")
+			return
+		}
+
+		result, err := service.GetWorkspace(r.Context(), caller, workspaceID)
+		if err != nil {
+			handleWorkspaceError(w, logger, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func listWorkspacesHandler(logger *slog.Logger, service WorkspaceService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		orgID, err := uuid.Parse(chi.URLParam(r, "organizationID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_organization_id", "organization ID is malformed")
+			return
+		}
+
+		limit := int32(50)
+		if raw := r.URL.Query().Get("limit"); raw != "" {
+			if parsed, parseErr := strconv.Atoi(raw); parseErr == nil && parsed > 0 {
+				limit = int32(parsed)
+				if limit > 100 {
+					limit = 100
+				}
+			}
+		}
+		offset := int32(0)
+		if raw := r.URL.Query().Get("offset"); raw != "" {
+			if parsed, parseErr := strconv.Atoi(raw); parseErr == nil && parsed >= 0 {
+				offset = int32(parsed)
+			}
+		}
+
+		result, err := service.ListWorkspaces(r.Context(), caller, orgID, limit, offset)
+		if err != nil {
+			handleWorkspaceError(w, logger, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func updateWorkspaceHandler(logger *slog.Logger, service WorkspaceService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		workspaceID, err := uuid.Parse(chi.URLParam(r, "workspaceID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_workspace_id", "workspace ID is malformed")
+			return
+		}
+
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+
+		var req struct {
+			Name   *string `json:"name,omitempty"`
+			Status *string `json:"status,omitempty"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body")
+			return
+		}
+		if req.Name == nil && req.Status == nil {
+			writeError(w, http.StatusBadRequest, "validation_error", "at least one of name or status is required")
+			return
+		}
+		if req.Status != nil && *req.Status != "active" && *req.Status != "archived" {
+			writeError(w, http.StatusBadRequest, "validation_error", "status must be active or archived")
+			return
+		}
+
+		result, err := service.UpdateWorkspace(r.Context(), caller, workspaceID, UpdateWorkspaceInput{
+			Name:   req.Name,
+			Status: req.Status,
+		})
+		if err != nil {
+			handleWorkspaceError(w, logger, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func handleWorkspaceError(w http.ResponseWriter, logger *slog.Logger, err error) {
+	switch {
+	case errors.Is(err, ErrForbidden):
+		writeError(w, http.StatusForbidden, "forbidden", "access denied")
+	case errors.Is(err, repository.ErrWorkspaceNotFound):
+		writeError(w, http.StatusNotFound, "not_found", "workspace not found")
+	case errors.Is(err, repository.ErrSlugTaken):
+		writeError(w, http.StatusConflict, "slug_taken", "a workspace with this slug already exists in this organization")
+	case errors.Is(err, ErrInvalidSlug):
+		writeError(w, http.StatusBadRequest, "validation_error", err.Error())
+	default:
+		logger.Error("workspace operation failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+	}
+}

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -1727,8 +1727,19 @@ func (r *Repository) ListRunnableChallengePVersionsByPackID(ctx context.Context,
 var (
 	ErrAgentBuildNotFound        = errors.New("agent build not found")
 	ErrAgentBuildVersionNotFound = errors.New("agent build version not found")
-	ErrWorkspaceNotFound         = errors.New("workspace not found")
-	ErrUserNotFound              = errors.New("user not found")
+	ErrWorkspaceNotFound           = errors.New("workspace not found")
+	ErrUserNotFound                = errors.New("user not found")
+	ErrUserAlreadyExists           = errors.New("user already exists")
+	ErrOrganizationNotFound        = errors.New("organization not found")
+	ErrOrganizationLimitReached    = errors.New("organization limit reached")
+	ErrSlugTaken                   = errors.New("slug taken")
+	ErrMembershipNotFound          = errors.New("membership not found")
+	ErrAlreadyMember               = errors.New("already a member")
+	ErrLastOrgAdmin                = errors.New("cannot remove or demote the last org admin")
+	ErrLastWorkspaceAdmin          = errors.New("cannot remove or demote the last workspace admin")
+	ErrOrgMembershipRequired       = errors.New("user must be a member of the organization first")
+	ErrInviteExpired               = errors.New("invite expired")
+	ErrAlreadyOnboarded            = errors.New("already onboarded")
 )
 
 type User struct {
@@ -1741,6 +1752,135 @@ type User struct {
 type WorkspaceMembershipRow struct {
 	WorkspaceID uuid.UUID
 	Role        string
+}
+
+type OrgMembershipRow struct {
+	OrganizationID uuid.UUID
+	Role           string
+}
+
+type CreateUserInput struct {
+	WorkOSUserID string
+	Email        string
+	DisplayName  string
+}
+
+type UserMeOrgRow struct {
+	ID   uuid.UUID
+	Name string
+	Slug string
+	Role string
+}
+
+type UserMeWorkspaceRow struct {
+	ID             uuid.UUID
+	OrganizationID uuid.UUID
+	Name           string
+	Slug           string
+	Role           string
+}
+
+type OrganizationRow struct {
+	ID        uuid.UUID
+	Name      string
+	Slug      string
+	Status    string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+type CreateOrgWithAdminInput struct {
+	Name   string
+	Slug   string
+	UserID uuid.UUID
+}
+
+type UpdateOrgInput struct {
+	Name   *string
+	Status *string
+}
+
+type WorkspaceRow struct {
+	ID             uuid.UUID
+	OrganizationID uuid.UUID
+	Name           string
+	Slug           string
+	Status         string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+type CreateWorkspaceWithAdminInput struct {
+	OrganizationID uuid.UUID
+	Name           string
+	Slug           string
+	UserID         uuid.UUID
+}
+
+type UpdateWorkspaceInput struct {
+	Name   *string
+	Status *string
+}
+
+type OrgMembershipFullRow struct {
+	ID               uuid.UUID
+	OrganizationID   uuid.UUID
+	UserID           uuid.UUID
+	Email            string
+	DisplayName      string
+	Role             string
+	MembershipStatus string
+	CreatedAt        time.Time
+	UpdatedAt        time.Time // set by DB trigger on every UPDATE
+}
+
+type CreateOrgMembershipInput struct {
+	OrganizationID uuid.UUID
+	UserID         uuid.UUID
+	Role           string
+}
+
+type UpdateOrgMembershipInput struct {
+	Role   *string
+	Status *string
+}
+
+type WorkspaceMembershipFullRow struct {
+	ID               uuid.UUID
+	WorkspaceID      uuid.UUID
+	OrganizationID   uuid.UUID
+	UserID           uuid.UUID
+	Email            string
+	DisplayName      string
+	Role             string
+	MembershipStatus string
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+}
+
+type CreateWorkspaceMembershipInput struct {
+	OrganizationID uuid.UUID
+	WorkspaceID    uuid.UUID
+	UserID         uuid.UUID
+	Role           string
+}
+
+type UpdateWorkspaceMembershipInput struct {
+	Role   *string
+	Status *string
+}
+
+type OnboardInput struct {
+	UserID            uuid.UUID
+	OrganizationName  string
+	OrganizationSlug  string
+	WorkspaceName     string
+	WorkspaceSlug     string
+}
+
+type OnboardResult struct {
+	Organization OrganizationRow
+	Workspace    WorkspaceRow
 }
 
 func (r *Repository) GetUserByWorkOSID(ctx context.Context, workosUserID string) (User, error) {
@@ -1788,6 +1928,1057 @@ func (r *Repository) GetActiveWorkspaceMembershipsByUserID(ctx context.Context, 
 		memberships = []WorkspaceMembershipRow{}
 	}
 	return memberships, nil
+}
+
+func (r *Repository) GetActiveOrganizationMembershipsByUserID(ctx context.Context, userID uuid.UUID) ([]OrgMembershipRow, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT om.organization_id, om.role
+		FROM organization_memberships om
+		WHERE om.user_id = $1 AND om.membership_status = 'active'
+		ORDER BY om.organization_id
+	`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get active organization memberships by user id: %w", err)
+	}
+	defer rows.Close()
+
+	var memberships []OrgMembershipRow
+	for rows.Next() {
+		var m OrgMembershipRow
+		if err := rows.Scan(&m.OrganizationID, &m.Role); err != nil {
+			return nil, fmt.Errorf("scan organization membership: %w", err)
+		}
+		memberships = append(memberships, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate organization memberships: %w", err)
+	}
+	if memberships == nil {
+		memberships = []OrgMembershipRow{}
+	}
+	return memberships, nil
+}
+
+func (r *Repository) CreateUser(ctx context.Context, input CreateUserInput) (User, error) {
+	var user User
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO users (id, workos_user_id, email, display_name)
+		VALUES (gen_random_uuid(), $1, $2, $3)
+		RETURNING id, workos_user_id, email, COALESCE(display_name, '')
+	`, input.WorkOSUserID, input.Email, input.DisplayName).Scan(
+		&user.ID, &user.WorkOSUserID, &user.Email, &user.DisplayName,
+	)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return User{}, fmt.Errorf("%w: user already exists", ErrUserAlreadyExists)
+		}
+		return User{}, fmt.Errorf("create user: %w", err)
+	}
+	return user, nil
+}
+
+func (r *Repository) LinkWorkOSUser(ctx context.Context, userID uuid.UUID, workosUserID string) (User, error) {
+	var user User
+	err := r.db.QueryRow(ctx, `
+		UPDATE users SET workos_user_id = $2
+		WHERE id = $1 AND workos_user_id LIKE 'pending:%'
+		RETURNING id, workos_user_id, email, COALESCE(display_name, '')
+	`, userID, workosUserID).Scan(&user.ID, &user.WorkOSUserID, &user.Email, &user.DisplayName)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return User{}, ErrUserNotFound
+		}
+		return User{}, fmt.Errorf("link workos user: %w", err)
+	}
+	return user, nil
+}
+
+func (r *Repository) GetOrganizationsForUser(ctx context.Context, userID uuid.UUID) ([]UserMeOrgRow, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT o.id, o.name, o.slug, om.role
+		FROM organizations o
+		JOIN organization_memberships om ON om.organization_id = o.id
+		WHERE om.user_id = $1 AND om.membership_status = 'active'
+		  AND o.status = 'active'
+		ORDER BY o.name
+	`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get organizations for user: %w", err)
+	}
+	defer rows.Close()
+
+	var orgs []UserMeOrgRow
+	for rows.Next() {
+		var o UserMeOrgRow
+		if err := rows.Scan(&o.ID, &o.Name, &o.Slug, &o.Role); err != nil {
+			return nil, fmt.Errorf("scan organization: %w", err)
+		}
+		orgs = append(orgs, o)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate organizations: %w", err)
+	}
+	if orgs == nil {
+		orgs = []UserMeOrgRow{}
+	}
+	return orgs, nil
+}
+
+func (r *Repository) GetWorkspacesForUser(ctx context.Context, userID uuid.UUID) ([]UserMeWorkspaceRow, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT w.id, w.organization_id, w.name, w.slug, wm.role
+		FROM workspaces w
+		JOIN workspace_memberships wm ON wm.workspace_id = w.id
+		WHERE wm.user_id = $1 AND wm.membership_status = 'active'
+		  AND w.status = 'active'
+		ORDER BY w.name
+	`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get workspaces for user: %w", err)
+	}
+	defer rows.Close()
+
+	var workspaces []UserMeWorkspaceRow
+	for rows.Next() {
+		var w UserMeWorkspaceRow
+		if err := rows.Scan(&w.ID, &w.OrganizationID, &w.Name, &w.Slug, &w.Role); err != nil {
+			return nil, fmt.Errorf("scan workspace: %w", err)
+		}
+		workspaces = append(workspaces, w)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate workspaces: %w", err)
+	}
+	if workspaces == nil {
+		workspaces = []UserMeWorkspaceRow{}
+	}
+	return workspaces, nil
+}
+
+func (r *Repository) GetAllWorkspacesForOrgs(ctx context.Context, orgIDs []uuid.UUID) ([]UserMeWorkspaceRow, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT w.id, w.organization_id, w.name, w.slug, '' AS role
+		FROM workspaces w
+		WHERE w.organization_id = ANY($1)
+		  AND w.status = 'active'
+		ORDER BY w.name
+	`, orgIDs)
+	if err != nil {
+		return nil, fmt.Errorf("get all workspaces for orgs: %w", err)
+	}
+	defer rows.Close()
+
+	var workspaces []UserMeWorkspaceRow
+	for rows.Next() {
+		var w UserMeWorkspaceRow
+		if err := rows.Scan(&w.ID, &w.OrganizationID, &w.Name, &w.Slug, &w.Role); err != nil {
+			return nil, fmt.Errorf("scan workspace: %w", err)
+		}
+		workspaces = append(workspaces, w)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate workspaces: %w", err)
+	}
+	if workspaces == nil {
+		workspaces = []UserMeWorkspaceRow{}
+	}
+	return workspaces, nil
+}
+
+// --- Onboarding ---
+
+func (r *Repository) Onboard(ctx context.Context, input OnboardInput) (OnboardResult, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return OnboardResult{}, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// 1. Insert organization.
+	var org OrganizationRow
+	err = tx.QueryRow(ctx, `
+		INSERT INTO organizations (id, name, slug, status)
+		VALUES (gen_random_uuid(), $1, $2, 'active')
+		RETURNING id, name, slug, status, created_at, updated_at
+	`, input.OrganizationName, input.OrganizationSlug).Scan(
+		&org.ID, &org.Name, &org.Slug, &org.Status, &org.CreatedAt, &org.UpdatedAt,
+	)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" && strings.Contains(pgErr.ConstraintName, "slug") {
+			return OnboardResult{}, ErrSlugTaken
+		}
+		return OnboardResult{}, fmt.Errorf("insert organization: %w", err)
+	}
+
+	// 2. Insert workspace.
+	var ws WorkspaceRow
+	err = tx.QueryRow(ctx, `
+		INSERT INTO workspaces (id, organization_id, name, slug, status)
+		VALUES (gen_random_uuid(), $1, $2, $3, 'active')
+		RETURNING id, organization_id, name, slug, status, created_at, updated_at
+	`, org.ID, input.WorkspaceName, input.WorkspaceSlug).Scan(
+		&ws.ID, &ws.OrganizationID, &ws.Name, &ws.Slug, &ws.Status, &ws.CreatedAt, &ws.UpdatedAt,
+	)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" && strings.Contains(pgErr.ConstraintName, "slug") {
+			return OnboardResult{}, ErrSlugTaken
+		}
+		return OnboardResult{}, fmt.Errorf("insert workspace: %w", err)
+	}
+
+	// 3. Insert org_admin membership.
+	_, err = tx.Exec(ctx, `
+		INSERT INTO organization_memberships (id, organization_id, user_id, role, membership_status)
+		VALUES (gen_random_uuid(), $1, $2, 'org_admin', 'active')
+	`, org.ID, input.UserID)
+	if err != nil {
+		return OnboardResult{}, fmt.Errorf("insert org admin membership: %w", err)
+	}
+
+	// 4. Insert workspace_admin membership.
+	_, err = tx.Exec(ctx, `
+		INSERT INTO workspace_memberships (id, organization_id, workspace_id, user_id, role, membership_status)
+		VALUES (gen_random_uuid(), $1, $2, $3, 'workspace_admin', 'active')
+	`, org.ID, ws.ID, input.UserID)
+	if err != nil {
+		return OnboardResult{}, fmt.Errorf("insert workspace admin membership: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return OnboardResult{}, fmt.Errorf("commit tx: %w", err)
+	}
+
+	return OnboardResult{
+		Organization: org,
+		Workspace:    ws,
+	}, nil
+}
+
+// --- Workspace Membership CRUD ---
+
+func (r *Repository) ListWorkspaceMemberships(ctx context.Context, workspaceID uuid.UUID, limit, offset int32) ([]WorkspaceMembershipFullRow, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT wm.id, wm.workspace_id, wm.organization_id, wm.user_id,
+		       u.email, COALESCE(u.display_name, ''),
+		       wm.role, wm.membership_status, wm.created_at, wm.updated_at
+		FROM workspace_memberships wm
+		JOIN users u ON u.id = wm.user_id
+		WHERE wm.workspace_id = $1 AND wm.membership_status IN ('active', 'invited')
+		ORDER BY wm.created_at
+		LIMIT $2 OFFSET $3
+	`, workspaceID, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("list workspace memberships: %w", err)
+	}
+	defer rows.Close()
+
+	var memberships []WorkspaceMembershipFullRow
+	for rows.Next() {
+		var m WorkspaceMembershipFullRow
+		if err := rows.Scan(&m.ID, &m.WorkspaceID, &m.OrganizationID, &m.UserID,
+			&m.Email, &m.DisplayName, &m.Role, &m.MembershipStatus, &m.CreatedAt, &m.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan workspace membership: %w", err)
+		}
+		memberships = append(memberships, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate workspace memberships: %w", err)
+	}
+	if memberships == nil {
+		memberships = []WorkspaceMembershipFullRow{}
+	}
+	return memberships, nil
+}
+
+func (r *Repository) CountWorkspaceMemberships(ctx context.Context, workspaceID uuid.UUID) (int64, error) {
+	var count int64
+	err := r.db.QueryRow(ctx, `
+		SELECT COUNT(*) FROM workspace_memberships
+		WHERE workspace_id = $1 AND membership_status IN ('active', 'invited')
+	`, workspaceID).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count workspace memberships: %w", err)
+	}
+	return count, nil
+}
+
+func (r *Repository) GetWorkspaceMembershipByWorkspaceAndUser(ctx context.Context, workspaceID, userID uuid.UUID) (WorkspaceMembershipFullRow, error) {
+	var m WorkspaceMembershipFullRow
+	err := r.db.QueryRow(ctx, `
+		SELECT wm.id, wm.workspace_id, wm.organization_id, wm.user_id,
+		       u.email, COALESCE(u.display_name, ''),
+		       wm.role, wm.membership_status, wm.created_at, wm.updated_at
+		FROM workspace_memberships wm
+		JOIN users u ON u.id = wm.user_id
+		WHERE wm.workspace_id = $1 AND wm.user_id = $2
+	`, workspaceID, userID).Scan(&m.ID, &m.WorkspaceID, &m.OrganizationID, &m.UserID,
+		&m.Email, &m.DisplayName, &m.Role, &m.MembershipStatus, &m.CreatedAt, &m.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return WorkspaceMembershipFullRow{}, ErrMembershipNotFound
+		}
+		return WorkspaceMembershipFullRow{}, fmt.Errorf("get workspace membership by workspace and user: %w", err)
+	}
+	return m, nil
+}
+
+func (r *Repository) CreateWorkspaceMembership(ctx context.Context, input CreateWorkspaceMembershipInput) (WorkspaceMembershipFullRow, error) {
+	var m WorkspaceMembershipFullRow
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO workspace_memberships (id, organization_id, workspace_id, user_id, role, membership_status)
+		VALUES (gen_random_uuid(), $1, $2, $3, $4, 'invited')
+		RETURNING id, organization_id, workspace_id, user_id, role, membership_status, created_at, updated_at
+	`, input.OrganizationID, input.WorkspaceID, input.UserID, input.Role).Scan(
+		&m.ID, &m.OrganizationID, &m.WorkspaceID, &m.UserID, &m.Role, &m.MembershipStatus, &m.CreatedAt, &m.UpdatedAt,
+	)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return WorkspaceMembershipFullRow{}, ErrAlreadyMember
+		}
+		return WorkspaceMembershipFullRow{}, fmt.Errorf("create workspace membership: %w", err)
+	}
+
+	var user User
+	if err = r.db.QueryRow(ctx, `SELECT email, COALESCE(display_name, '') FROM users WHERE id = $1`, input.UserID).Scan(&user.Email, &user.DisplayName); err != nil {
+		return m, nil // membership created; user details are non-critical
+	}
+	m.Email = user.Email
+	m.DisplayName = user.DisplayName
+
+	return m, nil
+}
+
+func (r *Repository) GetWorkspaceMembershipByID(ctx context.Context, membershipID uuid.UUID) (WorkspaceMembershipFullRow, error) {
+	var m WorkspaceMembershipFullRow
+	err := r.db.QueryRow(ctx, `
+		SELECT wm.id, wm.workspace_id, wm.organization_id, wm.user_id,
+		       u.email, COALESCE(u.display_name, ''),
+		       wm.role, wm.membership_status, wm.created_at, wm.updated_at
+		FROM workspace_memberships wm
+		JOIN users u ON u.id = wm.user_id
+		WHERE wm.id = $1
+	`, membershipID).Scan(&m.ID, &m.WorkspaceID, &m.OrganizationID, &m.UserID,
+		&m.Email, &m.DisplayName, &m.Role, &m.MembershipStatus, &m.CreatedAt, &m.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return WorkspaceMembershipFullRow{}, ErrMembershipNotFound
+		}
+		return WorkspaceMembershipFullRow{}, fmt.Errorf("get workspace membership by id: %w", err)
+	}
+	return m, nil
+}
+
+func (r *Repository) UpdateWorkspaceMembership(ctx context.Context, membershipID uuid.UUID, input UpdateWorkspaceMembershipInput) (WorkspaceMembershipFullRow, error) {
+	setClauses := []string{}
+	args := []interface{}{}
+	argIdx := 1
+
+	if input.Role != nil {
+		setClauses = append(setClauses, fmt.Sprintf("role = $%d", argIdx))
+		args = append(args, *input.Role)
+		argIdx++
+	}
+	if input.Status != nil {
+		setClauses = append(setClauses, fmt.Sprintf("membership_status = $%d", argIdx))
+		args = append(args, *input.Status)
+		argIdx++
+		if *input.Status == "archived" {
+			setClauses = append(setClauses, fmt.Sprintf("archived_at = $%d", argIdx))
+			args = append(args, time.Now())
+			argIdx++
+		} else {
+			setClauses = append(setClauses, "archived_at = NULL")
+		}
+	}
+
+	if len(setClauses) == 0 {
+		return r.GetWorkspaceMembershipByID(ctx, membershipID)
+	}
+
+	query := fmt.Sprintf(`
+		UPDATE workspace_memberships SET %s
+		WHERE id = $%d
+		RETURNING id, organization_id, workspace_id, user_id, role, membership_status, created_at, updated_at
+	`, strings.Join(setClauses, ", "), argIdx)
+	args = append(args, membershipID)
+
+	var m WorkspaceMembershipFullRow
+	err := r.db.QueryRow(ctx, query, args...).Scan(
+		&m.ID, &m.OrganizationID, &m.WorkspaceID, &m.UserID, &m.Role, &m.MembershipStatus, &m.CreatedAt, &m.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return WorkspaceMembershipFullRow{}, ErrMembershipNotFound
+		}
+		return WorkspaceMembershipFullRow{}, fmt.Errorf("update workspace membership: %w", err)
+	}
+
+	var user User
+	if err = r.db.QueryRow(ctx, `SELECT email, COALESCE(display_name, '') FROM users WHERE id = $1`, m.UserID).Scan(&user.Email, &user.DisplayName); err != nil {
+		return m, nil // membership updated; user details are non-critical
+	}
+	m.Email = user.Email
+	m.DisplayName = user.DisplayName
+
+	return m, nil
+}
+
+func (r *Repository) CountActiveWorkspaceAdmins(ctx context.Context, workspaceID uuid.UUID) (int64, error) {
+	var count int64
+	err := r.db.QueryRow(ctx, `
+		SELECT COUNT(*) FROM workspace_memberships
+		WHERE workspace_id = $1 AND role = 'workspace_admin' AND membership_status = 'active'
+	`, workspaceID).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count active workspace admins: %w", err)
+	}
+	return count, nil
+}
+
+// --- Organization Membership CRUD ---
+
+func (r *Repository) GetUserByEmail(ctx context.Context, email string) (User, error) {
+	var user User
+	err := r.db.QueryRow(ctx, `
+		SELECT id, workos_user_id, email, COALESCE(display_name, '')
+		FROM users WHERE email = $1 AND archived_at IS NULL
+	`, email).Scan(&user.ID, &user.WorkOSUserID, &user.Email, &user.DisplayName)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return User{}, ErrUserNotFound
+		}
+		return User{}, fmt.Errorf("get user by email: %w", err)
+	}
+	return user, nil
+}
+
+func (r *Repository) ListOrgMemberships(ctx context.Context, orgID uuid.UUID, limit, offset int32) ([]OrgMembershipFullRow, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT om.id, om.organization_id, om.user_id, u.email, COALESCE(u.display_name, ''),
+		       om.role, om.membership_status, om.created_at, om.updated_at
+		FROM organization_memberships om
+		JOIN users u ON u.id = om.user_id
+		WHERE om.organization_id = $1 AND om.membership_status IN ('active', 'invited')
+		ORDER BY om.created_at
+		LIMIT $2 OFFSET $3
+	`, orgID, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("list org memberships: %w", err)
+	}
+	defer rows.Close()
+
+	var memberships []OrgMembershipFullRow
+	for rows.Next() {
+		var m OrgMembershipFullRow
+		if err := rows.Scan(&m.ID, &m.OrganizationID, &m.UserID, &m.Email, &m.DisplayName,
+			&m.Role, &m.MembershipStatus, &m.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan org membership: %w", err)
+		}
+		memberships = append(memberships, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate org memberships: %w", err)
+	}
+	if memberships == nil {
+		memberships = []OrgMembershipFullRow{}
+	}
+	return memberships, nil
+}
+
+func (r *Repository) CountOrgMemberships(ctx context.Context, orgID uuid.UUID) (int64, error) {
+	var count int64
+	err := r.db.QueryRow(ctx, `
+		SELECT COUNT(*) FROM organization_memberships
+		WHERE organization_id = $1 AND membership_status IN ('active', 'invited')
+	`, orgID).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count org memberships: %w", err)
+	}
+	return count, nil
+}
+
+func (r *Repository) GetOrgMembershipByOrgAndUser(ctx context.Context, orgID, userID uuid.UUID) (OrgMembershipFullRow, error) {
+	var m OrgMembershipFullRow
+	err := r.db.QueryRow(ctx, `
+		SELECT om.id, om.organization_id, om.user_id, u.email, COALESCE(u.display_name, ''),
+		       om.role, om.membership_status, om.created_at, om.updated_at
+		FROM organization_memberships om
+		JOIN users u ON u.id = om.user_id
+		WHERE om.organization_id = $1 AND om.user_id = $2
+	`, orgID, userID).Scan(&m.ID, &m.OrganizationID, &m.UserID, &m.Email, &m.DisplayName,
+		&m.Role, &m.MembershipStatus, &m.CreatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return OrgMembershipFullRow{}, ErrMembershipNotFound
+		}
+		return OrgMembershipFullRow{}, fmt.Errorf("get org membership by org and user: %w", err)
+	}
+	return m, nil
+}
+
+func (r *Repository) CreateOrgMembership(ctx context.Context, input CreateOrgMembershipInput) (OrgMembershipFullRow, error) {
+	var m OrgMembershipFullRow
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO organization_memberships (id, organization_id, user_id, role, membership_status)
+		VALUES (gen_random_uuid(), $1, $2, $3, 'invited')
+		RETURNING id, organization_id, user_id, role, membership_status, created_at, updated_at
+	`, input.OrganizationID, input.UserID, input.Role).Scan(
+		&m.ID, &m.OrganizationID, &m.UserID, &m.Role, &m.MembershipStatus, &m.CreatedAt, &m.UpdatedAt,
+	)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return OrgMembershipFullRow{}, ErrAlreadyMember
+		}
+		return OrgMembershipFullRow{}, fmt.Errorf("create org membership: %w", err)
+	}
+
+	// Fetch user details to fill the response.
+	var user User
+	if err = r.db.QueryRow(ctx, `SELECT email, COALESCE(display_name, '') FROM users WHERE id = $1`, input.UserID).Scan(&user.Email, &user.DisplayName); err != nil {
+		return m, nil // membership created; user details are non-critical
+	}
+	m.Email = user.Email
+	m.DisplayName = user.DisplayName
+
+	return m, nil
+}
+
+func (r *Repository) GetOrgMembershipByID(ctx context.Context, membershipID uuid.UUID) (OrgMembershipFullRow, error) {
+	var m OrgMembershipFullRow
+	err := r.db.QueryRow(ctx, `
+		SELECT om.id, om.organization_id, om.user_id, u.email, COALESCE(u.display_name, ''),
+		       om.role, om.membership_status, om.created_at, om.updated_at
+		FROM organization_memberships om
+		JOIN users u ON u.id = om.user_id
+		WHERE om.id = $1
+	`, membershipID).Scan(&m.ID, &m.OrganizationID, &m.UserID, &m.Email, &m.DisplayName,
+		&m.Role, &m.MembershipStatus, &m.CreatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return OrgMembershipFullRow{}, ErrMembershipNotFound
+		}
+		return OrgMembershipFullRow{}, fmt.Errorf("get org membership by id: %w", err)
+	}
+	return m, nil
+}
+
+func (r *Repository) UpdateOrgMembership(ctx context.Context, membershipID uuid.UUID, input UpdateOrgMembershipInput) (OrgMembershipFullRow, error) {
+	setClauses := []string{}
+	args := []interface{}{}
+	argIdx := 1
+
+	if input.Role != nil {
+		setClauses = append(setClauses, fmt.Sprintf("role = $%d", argIdx))
+		args = append(args, *input.Role)
+		argIdx++
+	}
+	if input.Status != nil {
+		setClauses = append(setClauses, fmt.Sprintf("membership_status = $%d", argIdx))
+		args = append(args, *input.Status)
+		argIdx++
+		if *input.Status == "archived" {
+			setClauses = append(setClauses, fmt.Sprintf("archived_at = $%d", argIdx))
+			args = append(args, time.Now())
+			argIdx++
+		} else {
+			setClauses = append(setClauses, "archived_at = NULL")
+		}
+	}
+
+	if len(setClauses) == 0 {
+		return r.GetOrgMembershipByID(ctx, membershipID)
+	}
+
+	query := fmt.Sprintf(`
+		UPDATE organization_memberships SET %s
+		WHERE id = $%d
+		RETURNING id, organization_id, user_id, role, membership_status, created_at, updated_at
+	`, strings.Join(setClauses, ", "), argIdx)
+	args = append(args, membershipID)
+
+	var m OrgMembershipFullRow
+	err := r.db.QueryRow(ctx, query, args...).Scan(
+		&m.ID, &m.OrganizationID, &m.UserID, &m.Role, &m.MembershipStatus, &m.CreatedAt, &m.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return OrgMembershipFullRow{}, ErrMembershipNotFound
+		}
+		return OrgMembershipFullRow{}, fmt.Errorf("update org membership: %w", err)
+	}
+
+	// Fetch user details.
+	var user User
+	if err = r.db.QueryRow(ctx, `SELECT email, COALESCE(display_name, '') FROM users WHERE id = $1`, m.UserID).Scan(&user.Email, &user.DisplayName); err != nil {
+		return m, nil // membership updated; user details are non-critical
+	}
+	m.Email = user.Email
+	m.DisplayName = user.DisplayName
+
+	return m, nil
+}
+
+func (r *Repository) CascadeOrgMembershipStatusToWorkspaces(ctx context.Context, orgID, userID uuid.UUID, status string) error {
+	now := time.Now()
+	_, err := r.db.Exec(ctx, `
+		UPDATE workspace_memberships
+		SET membership_status = $3, archived_at = CASE WHEN $3 = 'archived' THEN $4 ELSE archived_at END
+		WHERE organization_id = $1 AND user_id = $2 AND membership_status NOT IN ('archived')
+	`, orgID, userID, status, now)
+	if err != nil {
+		return fmt.Errorf("cascade org membership status to workspaces: %w", err)
+	}
+	return nil
+}
+
+func (r *Repository) CountActiveOrgAdmins(ctx context.Context, orgID uuid.UUID) (int64, error) {
+	var count int64
+	err := r.db.QueryRow(ctx, `
+		SELECT COUNT(*) FROM organization_memberships
+		WHERE organization_id = $1 AND role = 'org_admin' AND membership_status = 'active'
+	`, orgID).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count active org admins: %w", err)
+	}
+	return count, nil
+}
+
+// --- Workspace CRUD ---
+
+func (r *Repository) CreateWorkspaceWithAdmin(ctx context.Context, input CreateWorkspaceWithAdminInput) (WorkspaceRow, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return WorkspaceRow{}, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	var ws WorkspaceRow
+	err = tx.QueryRow(ctx, `
+		INSERT INTO workspaces (id, organization_id, name, slug, status)
+		VALUES (gen_random_uuid(), $1, $2, $3, 'active')
+		RETURNING id, organization_id, name, slug, status, created_at, updated_at
+	`, input.OrganizationID, input.Name, input.Slug).Scan(
+		&ws.ID, &ws.OrganizationID, &ws.Name, &ws.Slug, &ws.Status, &ws.CreatedAt, &ws.UpdatedAt,
+	)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" && strings.Contains(pgErr.ConstraintName, "slug") {
+			return WorkspaceRow{}, ErrSlugTaken
+		}
+		return WorkspaceRow{}, fmt.Errorf("insert workspace: %w", err)
+	}
+
+	_, err = tx.Exec(ctx, `
+		INSERT INTO workspace_memberships (id, organization_id, workspace_id, user_id, role, membership_status)
+		VALUES (gen_random_uuid(), $1, $2, $3, 'workspace_admin', 'active')
+	`, input.OrganizationID, ws.ID, input.UserID)
+	if err != nil {
+		return WorkspaceRow{}, fmt.Errorf("insert workspace admin membership: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return WorkspaceRow{}, fmt.Errorf("commit tx: %w", err)
+	}
+	return ws, nil
+}
+
+func (r *Repository) GetWorkspaceByID(ctx context.Context, workspaceID uuid.UUID) (WorkspaceRow, error) {
+	var ws WorkspaceRow
+	err := r.db.QueryRow(ctx, `
+		SELECT id, organization_id, name, slug, status, created_at, updated_at
+		FROM workspaces WHERE id = $1
+	`, workspaceID).Scan(&ws.ID, &ws.OrganizationID, &ws.Name, &ws.Slug, &ws.Status, &ws.CreatedAt, &ws.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return WorkspaceRow{}, ErrWorkspaceNotFound
+		}
+		return WorkspaceRow{}, fmt.Errorf("get workspace by id: %w", err)
+	}
+	return ws, nil
+}
+
+func (r *Repository) ListWorkspacesByOrgID(ctx context.Context, orgID uuid.UUID, limit, offset int32) ([]WorkspaceRow, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, organization_id, name, slug, status, created_at, updated_at
+		FROM workspaces
+		WHERE organization_id = $1 AND status = 'active'
+		ORDER BY name
+		LIMIT $2 OFFSET $3
+	`, orgID, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("list workspaces by org id: %w", err)
+	}
+	defer rows.Close()
+
+	return scanWorkspaceRows(rows)
+}
+
+func (r *Repository) CountWorkspacesByOrgID(ctx context.Context, orgID uuid.UUID) (int64, error) {
+	var count int64
+	err := r.db.QueryRow(ctx, `
+		SELECT COUNT(*) FROM workspaces WHERE organization_id = $1 AND status = 'active'
+	`, orgID).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count workspaces by org id: %w", err)
+	}
+	return count, nil
+}
+
+func (r *Repository) ListWorkspacesByOrgIDForMember(ctx context.Context, orgID, userID uuid.UUID, limit, offset int32) ([]WorkspaceRow, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT w.id, w.organization_id, w.name, w.slug, w.status, w.created_at, w.updated_at
+		FROM workspaces w
+		JOIN workspace_memberships wm ON wm.workspace_id = w.id
+		WHERE w.organization_id = $1 AND wm.user_id = $2 AND wm.membership_status = 'active'
+		  AND w.status = 'active'
+		ORDER BY w.name
+		LIMIT $3 OFFSET $4
+	`, orgID, userID, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("list workspaces by org id for member: %w", err)
+	}
+	defer rows.Close()
+
+	return scanWorkspaceRows(rows)
+}
+
+func (r *Repository) CountWorkspacesByOrgIDForMember(ctx context.Context, orgID, userID uuid.UUID) (int64, error) {
+	var count int64
+	err := r.db.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM workspaces w
+		JOIN workspace_memberships wm ON wm.workspace_id = w.id
+		WHERE w.organization_id = $1 AND wm.user_id = $2 AND wm.membership_status = 'active'
+		  AND w.status = 'active'
+	`, orgID, userID).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count workspaces for member: %w", err)
+	}
+	return count, nil
+}
+
+func (r *Repository) UpdateWorkspace(ctx context.Context, workspaceID uuid.UUID, input UpdateWorkspaceInput) (WorkspaceRow, error) {
+	setClauses := []string{}
+	args := []interface{}{}
+	argIdx := 1
+
+	if input.Name != nil {
+		setClauses = append(setClauses, fmt.Sprintf("name = $%d", argIdx))
+		args = append(args, *input.Name)
+		argIdx++
+	}
+	if input.Status != nil {
+		setClauses = append(setClauses, fmt.Sprintf("status = $%d", argIdx))
+		args = append(args, *input.Status)
+		argIdx++
+		if *input.Status == "archived" {
+			setClauses = append(setClauses, fmt.Sprintf("archived_at = $%d", argIdx))
+			args = append(args, time.Now())
+			argIdx++
+		} else if *input.Status == "active" {
+			setClauses = append(setClauses, "archived_at = NULL")
+		}
+	}
+
+	if len(setClauses) == 0 {
+		return r.GetWorkspaceByID(ctx, workspaceID)
+	}
+
+	query := fmt.Sprintf(`
+		UPDATE workspaces SET %s
+		WHERE id = $%d
+		RETURNING id, organization_id, name, slug, status, created_at, updated_at
+	`, strings.Join(setClauses, ", "), argIdx)
+	args = append(args, workspaceID)
+
+	var ws WorkspaceRow
+	err := r.db.QueryRow(ctx, query, args...).Scan(
+		&ws.ID, &ws.OrganizationID, &ws.Name, &ws.Slug, &ws.Status, &ws.CreatedAt, &ws.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return WorkspaceRow{}, ErrWorkspaceNotFound
+		}
+		return WorkspaceRow{}, fmt.Errorf("update workspace: %w", err)
+	}
+	return ws, nil
+}
+
+func (r *Repository) ArchiveWorkspaceCascade(ctx context.Context, workspaceID uuid.UUID) (WorkspaceRow, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return WorkspaceRow{}, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	now := time.Now()
+
+	_, err = tx.Exec(ctx, `
+		UPDATE workspace_memberships
+		SET membership_status = 'archived', archived_at = $2
+		WHERE workspace_id = $1 AND membership_status != 'archived'
+	`, workspaceID, now)
+	if err != nil {
+		return WorkspaceRow{}, fmt.Errorf("archive workspace memberships: %w", err)
+	}
+
+	var ws WorkspaceRow
+	err = tx.QueryRow(ctx, `
+		UPDATE workspaces
+		SET status = 'archived', archived_at = $2
+		WHERE id = $1
+		RETURNING id, organization_id, name, slug, status, created_at, updated_at
+	`, workspaceID, now).Scan(
+		&ws.ID, &ws.OrganizationID, &ws.Name, &ws.Slug, &ws.Status, &ws.CreatedAt, &ws.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return WorkspaceRow{}, ErrWorkspaceNotFound
+		}
+		return WorkspaceRow{}, fmt.Errorf("archive workspace: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return WorkspaceRow{}, fmt.Errorf("commit tx: %w", err)
+	}
+	return ws, nil
+}
+
+func scanWorkspaceRows(rows pgx.Rows) ([]WorkspaceRow, error) {
+	var workspaces []WorkspaceRow
+	for rows.Next() {
+		var ws WorkspaceRow
+		if err := rows.Scan(&ws.ID, &ws.OrganizationID, &ws.Name, &ws.Slug, &ws.Status, &ws.CreatedAt, &ws.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan workspace: %w", err)
+		}
+		workspaces = append(workspaces, ws)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate workspaces: %w", err)
+	}
+	if workspaces == nil {
+		workspaces = []WorkspaceRow{}
+	}
+	return workspaces, nil
+}
+
+// --- Organization CRUD ---
+
+func (r *Repository) CountActiveOrgAdminMemberships(ctx context.Context, userID uuid.UUID) (int64, error) {
+	var count int64
+	err := r.db.QueryRow(ctx, `
+		SELECT COUNT(*) FROM organization_memberships
+		WHERE user_id = $1 AND role = 'org_admin' AND membership_status = 'active'
+	`, userID).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count active org admin memberships: %w", err)
+	}
+	return count, nil
+}
+
+func (r *Repository) CreateOrganizationWithAdmin(ctx context.Context, input CreateOrgWithAdminInput) (OrganizationRow, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return OrganizationRow{}, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	var org OrganizationRow
+	err = tx.QueryRow(ctx, `
+		INSERT INTO organizations (id, name, slug, status)
+		VALUES (gen_random_uuid(), $1, $2, 'active')
+		RETURNING id, name, slug, status, created_at, updated_at
+	`, input.Name, input.Slug).Scan(&org.ID, &org.Name, &org.Slug, &org.Status, &org.CreatedAt, &org.UpdatedAt)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" && strings.Contains(pgErr.ConstraintName, "slug") {
+			return OrganizationRow{}, ErrSlugTaken
+		}
+		return OrganizationRow{}, fmt.Errorf("insert organization: %w", err)
+	}
+
+	_, err = tx.Exec(ctx, `
+		INSERT INTO organization_memberships (id, organization_id, user_id, role, membership_status)
+		VALUES (gen_random_uuid(), $1, $2, 'org_admin', 'active')
+	`, org.ID, input.UserID)
+	if err != nil {
+		return OrganizationRow{}, fmt.Errorf("insert org admin membership: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return OrganizationRow{}, fmt.Errorf("commit tx: %w", err)
+	}
+	return org, nil
+}
+
+func (r *Repository) GetOrganizationByID(ctx context.Context, orgID uuid.UUID) (OrganizationRow, error) {
+	var org OrganizationRow
+	err := r.db.QueryRow(ctx, `
+		SELECT id, name, slug, status, created_at, updated_at
+		FROM organizations WHERE id = $1
+	`, orgID).Scan(&org.ID, &org.Name, &org.Slug, &org.Status, &org.CreatedAt, &org.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return OrganizationRow{}, ErrOrganizationNotFound
+		}
+		return OrganizationRow{}, fmt.Errorf("get organization by id: %w", err)
+	}
+	return org, nil
+}
+
+func (r *Repository) ListOrganizationsByUserID(ctx context.Context, userID uuid.UUID, limit, offset int32) ([]OrganizationRow, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT o.id, o.name, o.slug, o.status, o.created_at, o.updated_at
+		FROM organizations o
+		JOIN organization_memberships om ON om.organization_id = o.id
+		WHERE om.user_id = $1 AND om.membership_status = 'active'
+		ORDER BY o.name
+		LIMIT $2 OFFSET $3
+	`, userID, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("list organizations by user id: %w", err)
+	}
+	defer rows.Close()
+
+	var orgs []OrganizationRow
+	for rows.Next() {
+		var o OrganizationRow
+		if err := rows.Scan(&o.ID, &o.Name, &o.Slug, &o.Status, &o.CreatedAt, &o.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan organization: %w", err)
+		}
+		orgs = append(orgs, o)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate organizations: %w", err)
+	}
+	if orgs == nil {
+		orgs = []OrganizationRow{}
+	}
+	return orgs, nil
+}
+
+func (r *Repository) CountOrganizationsByUserID(ctx context.Context, userID uuid.UUID) (int64, error) {
+	var count int64
+	err := r.db.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM organizations o
+		JOIN organization_memberships om ON om.organization_id = o.id
+		WHERE om.user_id = $1 AND om.membership_status = 'active'
+	`, userID).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count organizations by user id: %w", err)
+	}
+	return count, nil
+}
+
+func (r *Repository) UpdateOrganization(ctx context.Context, orgID uuid.UUID, input UpdateOrgInput) (OrganizationRow, error) {
+	setClauses := []string{}
+	args := []interface{}{}
+	argIdx := 1
+
+	if input.Name != nil {
+		setClauses = append(setClauses, fmt.Sprintf("name = $%d", argIdx))
+		args = append(args, *input.Name)
+		argIdx++
+	}
+	if input.Status != nil {
+		setClauses = append(setClauses, fmt.Sprintf("status = $%d", argIdx))
+		args = append(args, *input.Status)
+		argIdx++
+		if *input.Status == "archived" {
+			setClauses = append(setClauses, fmt.Sprintf("archived_at = $%d", argIdx))
+			args = append(args, time.Now())
+			argIdx++
+		} else if *input.Status == "active" {
+			setClauses = append(setClauses, "archived_at = NULL")
+		}
+	}
+
+	if len(setClauses) == 0 {
+		return r.GetOrganizationByID(ctx, orgID)
+	}
+
+	query := fmt.Sprintf(`
+		UPDATE organizations SET %s
+		WHERE id = $%d
+		RETURNING id, name, slug, status, created_at, updated_at
+	`, strings.Join(setClauses, ", "), argIdx)
+	args = append(args, orgID)
+
+	var org OrganizationRow
+	err := r.db.QueryRow(ctx, query, args...).Scan(&org.ID, &org.Name, &org.Slug, &org.Status, &org.CreatedAt, &org.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return OrganizationRow{}, ErrOrganizationNotFound
+		}
+		return OrganizationRow{}, fmt.Errorf("update organization: %w", err)
+	}
+	return org, nil
+}
+
+func (r *Repository) ArchiveOrganizationCascade(ctx context.Context, orgID uuid.UUID) (OrganizationRow, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return OrganizationRow{}, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	now := time.Now()
+
+	// Archive all workspace memberships in this org.
+	_, err = tx.Exec(ctx, `
+		UPDATE workspace_memberships
+		SET membership_status = 'archived', archived_at = $2
+		WHERE organization_id = $1 AND membership_status != 'archived'
+	`, orgID, now)
+	if err != nil {
+		return OrganizationRow{}, fmt.Errorf("archive workspace memberships: %w", err)
+	}
+
+	// Archive all workspaces in this org.
+	_, err = tx.Exec(ctx, `
+		UPDATE workspaces
+		SET status = 'archived', archived_at = $2
+		WHERE organization_id = $1 AND status != 'archived'
+	`, orgID, now)
+	if err != nil {
+		return OrganizationRow{}, fmt.Errorf("archive workspaces: %w", err)
+	}
+
+	// Archive all org memberships.
+	_, err = tx.Exec(ctx, `
+		UPDATE organization_memberships
+		SET membership_status = 'archived', archived_at = $2
+		WHERE organization_id = $1 AND membership_status != 'archived'
+	`, orgID, now)
+	if err != nil {
+		return OrganizationRow{}, fmt.Errorf("archive org memberships: %w", err)
+	}
+
+	// Archive the org itself.
+	var org OrganizationRow
+	err = tx.QueryRow(ctx, `
+		UPDATE organizations
+		SET status = 'archived', archived_at = $2
+		WHERE id = $1
+		RETURNING id, name, slug, status, created_at, updated_at
+	`, orgID, now).Scan(&org.ID, &org.Name, &org.Slug, &org.Status, &org.CreatedAt, &org.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return OrganizationRow{}, ErrOrganizationNotFound
+		}
+		return OrganizationRow{}, fmt.Errorf("archive organization: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return OrganizationRow{}, fmt.Errorf("commit tx: %w", err)
+	}
+	return org, nil
 }
 
 func (r *Repository) GetOrganizationIDByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (uuid.UUID, error) {


### PR DESCRIPTION
## What

Implements all backend endpoints for multi-tenant CRUD (issue #115): organizations, workspaces, and memberships with a full invite flow.

## Why

The tenancy tables exist in the schema but had no CRUD APIs. Users couldn't create organizations, manage workspaces, or invite members without direct DB access. This unlocks the frontend org switcher, settings pages, and onboarding flow.

## Before

```mermaid
graph LR
    A[Authenticated User] -->|Has| B[Workspace Memberships only]
    A -->|No way to| C[Create Org]
    A -->|No way to| D[Manage Members]
    A -->|No way to| E[Switch Workspaces]
    style C fill:#f96,stroke:#333
    style D fill:#f96,stroke:#333
    style E fill:#f96,stroke:#333
```

- Caller struct only carried workspace memberships
- No organization-level authorization
- No API to create orgs, workspaces, or manage memberships
- New users hitting WorkOS auth with no DB row got a hard auth failure
- No onboarding path existed

## After

```mermaid
graph TD
    subgraph Auth Layer
        A[WorkOS JWT] -->|Auto-create user| B[Caller with Org + Workspace Memberships]
    end

    subgraph Onboarding
        B -->|Zero orgs detected| C[POST /v1/onboarding]
        C -->|Atomic TX| D[Org + Workspace + 2 Memberships]
    end

    subgraph Organization CRUD
        E[POST /v1/organizations] -->|Limit: 1| F[Org + org_admin membership]
        G[GET /v1/organizations] -->|Member orgs only| H[Paginated list]
        I[PATCH /v1/organizations/id] -->|org_admin| J[Update name / archive cascade]
    end

    subgraph Workspace CRUD
        K[POST /v1/organizations/id/workspaces] -->|org_admin| L[Workspace + ws_admin membership]
        M[GET /v1/organizations/id/workspaces] -->|admin=all, member=own| N[Scoped list]
        O[PATCH /v1/workspaces/id] -->|ws_admin or org_admin| P[Update / archive cascade]
    end

    subgraph Membership CRUD
        Q[POST .../memberships] -->|Email invite| R[Stub user + invited status]
        S[PATCH .../memberships/id] -->|Accept / revoke / role change| T[Status transitions]
        T -->|7-day expiry| U[Invite expiration check]
        T -->|Last admin guard| V[Cannot remove sole admin]
    end
```

## Architecture

```mermaid
graph TB
    subgraph "Request Flow"
        R[HTTP Request] --> MW[Auth Middleware]
        MW -->|Loads org + ws memberships| CTX[Caller in Context]
        CTX --> H[Handler]
        H -->|Parse + validate| S[Service Manager]
        S -->|Authorize via Caller maps| REPO[Repository - raw SQL]
        REPO --> PG[(PostgreSQL)]
    end

    subgraph "Authorization Model"
        ORG_ADMIN[org_admin] -->|Implicit access| ALL_WS[All workspaces in org]
        ORG_ADMIN -->|Can manage| ORG_MEMBERS[Org members]
        ORG_ADMIN -->|Can manage| WS_MEMBERS[Workspace members]
        WS_ADMIN[workspace_admin] -->|Can manage| WS_MEMBERS
        ORG_MEMBER[org_member] -->|Explicit membership only| OWN_WS[Own workspaces]
    end
```

## Endpoint Summary

| Endpoint | Auth | Description |
|----------|------|-------------|
| `GET /v1/users/me` | Any | Nested response: user + orgs + workspaces |
| `POST /v1/onboarding` | Any (no org) | Atomic: org + workspace + memberships |
| `POST /v1/organizations` | Any | Create org (hard limit: 1) |
| `GET /v1/organizations` | Any | List caller's orgs |
| `GET /v1/organizations/{id}` | Org member | Get org |
| `PATCH /v1/organizations/{id}` | org_admin | Update name / archive cascade |
| `POST /v1/organizations/{id}/workspaces` | org_admin | Create workspace |
| `GET /v1/organizations/{id}/workspaces` | Org member | List workspaces (scoped) |
| `GET /v1/workspaces/{id}/details` | WS member or org_admin | Get workspace |
| `PATCH /v1/workspaces/{id}/details` | ws_admin or org_admin | Update / archive |
| `GET /v1/organizations/{id}/memberships` | Org member | List active+invited |
| `POST /v1/organizations/{id}/memberships` | org_admin | Email invite |
| `PATCH /v1/organization-memberships/{id}` | org_admin or invitee | Accept / role / status |
| `GET /v1/workspaces/{id}/memberships` | WS member or org_admin | List active+invited |
| `POST /v1/workspaces/{id}/memberships` | ws_admin or org_admin | Email invite (org prereq) |
| `PATCH /v1/workspace-memberships/{id}` | ws_admin / org_admin / invitee | Accept / role / status |

## Key Design Decisions

- **Org limit: 1** — hard-coded guard until billing lands (trivial to change)
- **Slugs: immutable** — auto-generated from name if omitted, validated format, 409 on conflict
- **Archive only, no deletes** — cascade archives org -> workspaces -> all memberships in one TX
- **Real invite flow** — `invited` status, 7-day expiry, stub user creation for unknown emails
- **Org membership required for workspace** — enforced at both service and DB level
- **Last admin protection** — cannot demote/archive the sole org_admin or workspace_admin

---

## Live Smoke Test Results

Tested against a **completely clean database** (no seed data). Started two fresh users (Alice and Bob), then exercised every endpoint incrementally. All 33 tests pass.

### Users & Onboarding

<details>
<summary><b>TEST 1:</b> GET /v1/users/me — Alice, brand new, zero orgs ✅</summary>

```json
{
    "user_id": "aaaa0000-0000-0000-0000-000000000001",
    "organizations": []
}
```
</details>

<details>
<summary><b>TEST 2:</b> POST /v1/onboarding — Alice creates her first org+workspace ✅</summary>

```json
{
    "organization": {
        "id": "e32b3523-e9ae-4efe-ac7d-572f506fcb34",
        "name": "Alice Corp",
        "slug": "alice-corp",
        "status": "active",
        "created_at": "2026-04-11T18:04:41.015866+05:30",
        "updated_at": "2026-04-11T18:04:41.015866+05:30"
    },
    "workspace": {
        "id": "3a2b5260-df8c-4a1d-8c10-46d1c8d0195f",
        "organization_id": "e32b3523-e9ae-4efe-ac7d-572f506fcb34",
        "name": "Production",
        "slug": "production",
        "status": "active",
        "created_at": "2026-04-11T18:04:41.015866+05:30",
        "updated_at": "2026-04-11T18:04:41.015866+05:30"
    }
}
```
</details>

<details>
<summary><b>TEST 3:</b> POST /v1/onboarding — Alice tries again → 409 ✅</summary>

```json
{
    "error": {
        "code": "already_onboarded",
        "message": "you already have an organization"
    }
}
```
</details>

<details>
<summary><b>TEST 4:</b> GET /v1/users/me — Alice now has 1 org with 1 workspace ✅</summary>

```json
{
    "user_id": "aaaa0000-0000-0000-0000-000000000001",
    "organizations": [
        {
            "id": "e32b3523-e9ae-4efe-ac7d-572f506fcb34",
            "name": "Alice Corp",
            "slug": "alice-corp",
            "role": "org_admin",
            "workspaces": [
                {
                    "id": "3a2b5260-df8c-4a1d-8c10-46d1c8d0195f",
                    "name": "Production",
                    "slug": "production",
                    "role": "workspace_admin"
                }
            ]
        }
    ]
}
```
</details>

### Organization CRUD

<details>
<summary><b>TEST 5:</b> GET /v1/organizations — Alice lists her orgs ✅</summary>

```json
{
    "items": [
        {
            "id": "e32b3523-e9ae-4efe-ac7d-572f506fcb34",
            "name": "Alice Corp",
            "slug": "alice-corp",
            "status": "active",
            "created_at": "2026-04-11T18:04:41.015866+05:30",
            "updated_at": "2026-04-11T18:04:41.015866+05:30"
        }
    ],
    "total": 1,
    "limit": 50,
    "offset": 0
}
```
</details>

<details>
<summary><b>TEST 6:</b> GET /v1/organizations/{id} — get single org ✅</summary>

```json
{
    "id": "e32b3523-e9ae-4efe-ac7d-572f506fcb34",
    "name": "Alice Corp",
    "slug": "alice-corp",
    "status": "active"
}
```
</details>

<details>
<summary><b>TEST 7:</b> POST /v1/organizations — 2nd org blocked (limit=1) → 409 ✅</summary>

```json
{
    "error": {
        "code": "organization_limit_reached",
        "message": "you have reached the maximum number of organizations"
    }
}
```
</details>

<details>
<summary><b>TEST 8:</b> PATCH /v1/organizations/{id} — rename org ✅</summary>

```json
{
    "id": "e32b3523-e9ae-4efe-ac7d-572f506fcb34",
    "name": "Alice Corp v2",
    "slug": "alice-corp",
    "status": "active"
}
```
</details>

### Workspace CRUD

<details>
<summary><b>TEST 9:</b> POST /v1/organizations/{id}/workspaces — create 2nd workspace ✅</summary>

```json
{
    "id": "de38c8c9-001a-466b-a3e3-85e54adee074",
    "organization_id": "e32b3523-e9ae-4efe-ac7d-572f506fcb34",
    "name": "Staging",
    "slug": "staging",
    "status": "active"
}
```
</details>

<details>
<summary><b>TEST 10:</b> POST workspace with duplicate slug → 409 ✅</summary>

```json
{
    "error": {
        "code": "slug_taken",
        "message": "a workspace with this slug already exists in this organization"
    }
}
```
</details>

<details>
<summary><b>TEST 11:</b> GET /v1/organizations/{id}/workspaces — org_admin sees all ✅</summary>

```json
{
    "items": [
        { "name": "Production", "slug": "production" },
        { "name": "Staging", "slug": "staging" }
    ],
    "total": 2
}
```
</details>

<details>
<summary><b>TEST 12:</b> GET /v1/workspaces/{id}/details — get by ID ✅</summary>

```json
{
    "id": "3a2b5260-df8c-4a1d-8c10-46d1c8d0195f",
    "name": "Production",
    "slug": "production",
    "status": "active"
}
```
</details>

<details>
<summary><b>TEST 13:</b> PATCH /v1/workspaces/{id}/details — rename ✅</summary>

```json
{
    "name": "Prod Environment",
    "slug": "production",
    "status": "active"
}
```
</details>

### Organization Membership CRUD

<details>
<summary><b>TEST 14:</b> POST /v1/organizations/{id}/memberships — Alice invites Bob ✅</summary>

```json
{
    "id": "f12c2c9f-2d7a-4b35-8ad1-41675528263f",
    "user_id": "aaaa0000-0000-0000-0000-000000000002",
    "email": "bob@example.com",
    "display_name": "Bob",
    "role": "org_member",
    "membership_status": "invited"
}
```
</details>

<details>
<summary><b>TEST 15:</b> POST invite Bob again → 409 already_a_member ✅</summary>

```json
{
    "error": {
        "code": "already_a_member",
        "message": "user is already a member"
    }
}
```
</details>

<details>
<summary><b>TEST 16:</b> GET /v1/organizations/{id}/memberships — lists Alice (active) + Bob (invited) ✅</summary>

```json
{
    "items": [
        { "email": "alice@example.com", "role": "org_admin", "membership_status": "active" },
        { "email": "bob@example.com", "role": "org_member", "membership_status": "invited" }
    ],
    "total": 2
}
```
</details>

<details>
<summary><b>TEST 17:</b> PATCH /v1/organization-memberships/{id} — Bob accepts invite ✅</summary>

```json
{
    "email": "bob@example.com",
    "role": "org_member",
    "membership_status": "active"
}
```
</details>

<details>
<summary><b>TEST 18:</b> POST invite unknown email — creates stub user ✅</summary>

```json
{
    "email": "charlie@example.com",
    "display_name": "",
    "role": "org_member",
    "membership_status": "invited"
}
```
DB confirms stub user: `charlie@example.com` with empty workos_user_id and display_name.
</details>

<details>
<summary><b>TEST 19:</b> PATCH — try to demote Alice (last org_admin) → 403 ✅</summary>

Cannot change own role — returns forbidden.
</details>

<details>
<summary><b>TEST 20:</b> PATCH — Alice promotes Bob to org_admin ✅</summary>

```json
{
    "email": "bob@example.com",
    "role": "org_admin",
    "membership_status": "active"
}
```
</details>

### Workspace Membership CRUD

<details>
<summary><b>TEST 21:</b> POST /v1/workspaces/{id}/memberships — Alice invites Bob to workspace ✅</summary>

```json
{
    "email": "bob@example.com",
    "role": "workspace_member",
    "membership_status": "invited"
}
```
</details>

<details>
<summary><b>TEST 22:</b> POST workspace invite for Charlie (no org membership) → 400 ✅</summary>

```json
{
    "error": {
        "code": "org_membership_required",
        "message": "user must be a member of the organization first"
    }
}
```
</details>

<details>
<summary><b>TEST 23:</b> GET /v1/workspaces/{id}/memberships — lists Alice (active) + Bob (invited) ✅</summary>

```json
{
    "items": [
        { "email": "alice@example.com", "role": "workspace_admin", "membership_status": "active" },
        { "email": "bob@example.com", "role": "workspace_member", "membership_status": "invited" }
    ],
    "total": 2
}
```
</details>

<details>
<summary><b>TEST 24:</b> PATCH /v1/workspace-memberships/{id} — Bob accepts workspace invite ✅</summary>

```json
{
    "email": "bob@example.com",
    "role": "workspace_member",
    "membership_status": "active"
}
```
</details>

<details>
<summary><b>TEST 25:</b> PATCH — try to demote Alice (last workspace_admin) → 403 ✅</summary>

Cannot change own role — returns forbidden.
</details>

<details>
<summary><b>TEST 26:</b> GET workspaces — Bob as org_member sees only his workspace ✅</summary>

```json
{
    "items": [
        { "name": "Prod Environment", "slug": "production" }
    ],
    "total": 1
}
```
Bob doesn't see Staging (he has no explicit membership there).
</details>

### Implicit Access & Archive Cascade

<details>
<summary><b>TEST 27:</b> GET /v1/users/me — Bob (org_admin) sees ALL workspaces including Staging ✅</summary>

```json
{
    "organizations": [
        {
            "name": "Alice Corp v2",
            "role": "org_admin",
            "workspaces": [
                { "name": "Prod Environment", "role": "workspace_member" },
                { "name": "Staging", "role": "org_admin" }
            ]
        }
    ]
}
```
Bob sees Staging with `role: "org_admin"` (implicit access) and Prod with `role: "workspace_member"` (explicit).
</details>

<details>
<summary><b>TEST 28:</b> PATCH workspace — archive Staging (cascade) ✅</summary>

```json
{ "name": "Staging", "status": "archived" }
```
DB confirms: all workspace memberships for Staging are now `archived`.
</details>

<details>
<summary><b>TEST 29:</b> PATCH workspace — unarchive Staging ✅</summary>

```json
{ "name": "Staging", "status": "active" }
```
</details>

<details>
<summary><b>TEST 30:</b> PATCH org — archive entire org (full cascade) ✅</summary>

```json
{ "name": "Alice Corp v2", "status": "archived" }
```
DB confirms:
- All workspaces: `archived`
- All org memberships (alice, bob, charlie): `archived`
- All workspace memberships: `archived`
</details>

<details>
<summary><b>TEST 31:</b> PATCH org — unarchive (restores org only, not workspaces) ✅</summary>

```json
{ "name": "Alice Corp v2", "status": "active" }
```
DB confirms: org is `active` but both workspaces remain `archived` — intentional design.
</details>

### Authorization Edge Cases

<details>
<summary><b>TEST 32:</b> Bob with no membership headers → 403 ✅</summary>

```json
{
    "error": {
        "code": "forbidden",
        "message": "access denied"
    }
}
```
</details>

<details>
<summary><b>TEST 33:</b> Unauthenticated request → 401 ✅</summary>

```json
{
    "error": {
        "code": "unauthorized",
        "message": "authentication required"
    }
}
```
</details>

---

**33/33 tests pass** against a clean database with no seed data. Two fresh users (Alice & Bob), org creation via onboarding, workspace management, email-based invites, role promotions, archive cascades, implicit org_admin access, and authorization edge cases all verified.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test ./...` — all packages pass
- [x] 33 live smoke tests against clean DB — all pass
- [x] Onboarding: zero orgs -> POST /v1/onboarding -> GET /v1/users/me returns nested data
- [x] Invite flow: POST membership -> Bob accepts -> status transitions correctly
- [x] Stub user creation: invite unknown email -> user row created in DB
- [x] Org limit: 2nd org blocked with 409
- [x] Slug uniqueness: duplicate slug returns 409
- [x] Archive cascade: org archive -> all workspaces + all memberships archived
- [x] Unarchive: restores org only, workspaces stay archived
- [x] Last admin guard: cannot demote sole org_admin or workspace_admin
- [x] Org membership prerequisite: workspace invite blocked without org membership
- [x] Implicit access: org_admin sees all workspaces in /users/me
- [x] Scoped views: org_member sees only their workspaces
- [x] Auth edge cases: no headers = 403, no user = 401