### PR TITLE
FE-04: Agent build & version management

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/create-version-button.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/create-version-button.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import type { AgentBuildVersion } from "@/lib/api/types";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+import { Loader2, Plus } from "lucide-react";
+
+interface CreateVersionButtonProps {
+  buildId: string;
+  workspaceId: string;
+}
+
+export function CreateVersionButton({
+  buildId,
+  workspaceId,
+}: CreateVersionButtonProps) {
+  const router = useRouter();
+  const { getAccessToken } = useAccessToken();
+  const [creating, setCreating] = useState(false);
+
+  async function handleCreate() {
+    setCreating(true);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      const version = await api.post<AgentBuildVersion>(
+        `/v1/agent-builds/${buildId}/versions`,
+        {
+          agent_kind: "llm_agent",
+          interface_spec: {},
+          policy_spec: { instructions: "" },
+        },
+      );
+      toast.success(`Created version ${version.version_number}`);
+      router.push(
+        `/workspaces/${workspaceId}/builds/${buildId}/versions/${version.id}`,
+      );
+    } catch (err) {
+      if (err instanceof ApiError) {
+        toast.error(err.message);
+      } else {
+        toast.error("Failed to create version");
+      }
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return (
+    <Button size="sm" onClick={handleCreate} disabled={creating}>
+      {creating ? (
+        <Loader2 className="size-4 animate-spin" />
+      ) : (
+        <>
+          <Plus data-icon="inline-start" className="size-4" />
+          New Version
+        </>
+      )}
+    </Button>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/page.tsx
@@ -1,0 +1,132 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { createApiClient } from "@/lib/api/client";
+import type { AgentBuildDetail } from "@/lib/api/types";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Layers } from "lucide-react";
+import { CreateVersionButton } from "./create-version-button";
+
+const versionStatusVariant: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
+  draft: "outline",
+  ready: "default",
+  archived: "secondary",
+};
+
+export default async function BuildDetailPage({
+  params,
+}: {
+  params: Promise<{ workspaceId: string; buildId: string }>;
+}) {
+  const { accessToken } = await withAuth();
+  if (!accessToken) redirect("/auth/login");
+
+  const { workspaceId, buildId } = await params;
+
+  const api = createApiClient(accessToken);
+  const build = await api.get<AgentBuildDetail>(
+    `/v1/agent-builds/${buildId}`,
+  );
+
+  return (
+    <div>
+      {/* Build header */}
+      <div className="mb-6">
+        <div className="flex items-center gap-3 mb-1">
+          <Link
+            href={`/workspaces/${workspaceId}/builds`}
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Builds
+          </Link>
+          <span className="text-muted-foreground/40">/</span>
+          <h1 className="text-lg font-semibold tracking-tight">
+            {build.name}
+          </h1>
+          <Badge variant={versionStatusVariant[build.lifecycle_status] ?? "outline"}>
+            {build.lifecycle_status}
+          </Badge>
+        </div>
+        {build.description && (
+          <p className="text-sm text-muted-foreground">{build.description}</p>
+        )}
+        <div className="mt-2 flex gap-4 text-xs text-muted-foreground/60">
+          <span>
+            Slug:{" "}
+            <code className="font-[family-name:var(--font-mono)]">
+              {build.slug}
+            </code>
+          </span>
+          <span>
+            Created: {new Date(build.created_at).toLocaleDateString()}
+          </span>
+        </div>
+      </div>
+
+      {/* Versions */}
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-sm font-semibold">Versions</h2>
+        <CreateVersionButton buildId={buildId} workspaceId={workspaceId} />
+      </div>
+
+      {build.versions.length === 0 ? (
+        <EmptyState
+          icon={<Layers className="size-10" />}
+          title="No versions yet"
+          description="Create a version to define this agent's behavior, model, and tools."
+        />
+      ) : (
+        <div className="rounded-lg border border-border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Version</TableHead>
+                <TableHead>Agent Kind</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Created</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {build.versions.map((v) => (
+                <TableRow key={v.id}>
+                  <TableCell>
+                    <Link
+                      href={`/workspaces/${workspaceId}/builds/${buildId}/versions/${v.id}`}
+                      className="font-medium text-foreground hover:underline underline-offset-4"
+                    >
+                      v{v.version_number}
+                    </Link>
+                  </TableCell>
+                  <TableCell>
+                    <code className="text-xs font-[family-name:var(--font-mono)] text-muted-foreground">
+                      {v.agent_kind}
+                    </code>
+                  </TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={versionStatusVariant[v.version_status] ?? "outline"}
+                    >
+                      {v.version_status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {new Date(v.created_at).toLocaleDateString()}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/page.tsx
@@ -1,0 +1,55 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { createApiClient } from "@/lib/api/client";
+import type { AgentBuildVersion, AgentBuildDetail } from "@/lib/api/types";
+import { VersionEditor } from "./version-editor";
+
+export default async function VersionEditorPage({
+  params,
+}: {
+  params: Promise<{
+    workspaceId: string;
+    buildId: string;
+    versionId: string;
+  }>;
+}) {
+  const { accessToken } = await withAuth();
+  if (!accessToken) redirect("/auth/login");
+
+  const { workspaceId, buildId, versionId } = await params;
+
+  const api = createApiClient(accessToken);
+  const [version, build] = await Promise.all([
+    api.get<AgentBuildVersion>(`/v1/agent-build-versions/${versionId}`),
+    api.get<AgentBuildDetail>(`/v1/agent-builds/${buildId}`),
+  ]);
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-6 text-sm text-muted-foreground">
+        <Link
+          href={`/workspaces/${workspaceId}/builds`}
+          className="hover:text-foreground transition-colors"
+        >
+          Builds
+        </Link>
+        <span className="text-muted-foreground/40">/</span>
+        <Link
+          href={`/workspaces/${workspaceId}/builds/${buildId}`}
+          className="hover:text-foreground transition-colors"
+        >
+          {build.name}
+        </Link>
+        <span className="text-muted-foreground/40">/</span>
+        <span className="text-foreground">v{version.version_number}</span>
+      </div>
+
+      <VersionEditor
+        version={version}
+        workspaceId={workspaceId}
+        buildId={buildId}
+      />
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/page.tsx
@@ -45,11 +45,7 @@ export default async function VersionEditorPage({
         <span className="text-foreground">v{version.version_number}</span>
       </div>
 
-      <VersionEditor
-        version={version}
-        workspaceId={workspaceId}
-        buildId={buildId}
-      />
+      <VersionEditor version={version} />
     </div>
   );
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/version-editor.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/version-editor.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import type {
+  AgentBuildVersion,
+  ValidationResult,
+  ValidationError,
+} from "@/lib/api/types";
+import { AGENT_KINDS } from "@/lib/api/types";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { JsonField } from "@/components/ui/json-field";
+import { toast } from "sonner";
+import { Loader2, Save, ShieldCheck, CheckCircle } from "lucide-react";
+
+interface VersionEditorProps {
+  version: AgentBuildVersion;
+  workspaceId: string;
+  buildId: string;
+}
+
+function jsonStr(val: unknown): string {
+  if (val === null || val === undefined) return "";
+  if (typeof val === "string") return val;
+  return JSON.stringify(val, null, 2);
+}
+
+const specFields = [
+  { key: "policy_spec", label: "Policy Spec", description: "Must contain an \"instructions\" field.", required: true as const },
+  { key: "interface_spec", label: "Interface Spec", description: undefined, required: true as const },
+  { key: "model_spec", label: "Model Spec", description: undefined, required: false as const },
+  { key: "reasoning_spec", label: "Reasoning Spec", description: undefined, required: false as const },
+  { key: "memory_spec", label: "Memory Spec", description: undefined, required: false as const },
+  { key: "workflow_spec", label: "Workflow Spec", description: undefined, required: false as const },
+  { key: "guardrail_spec", label: "Guardrail Spec", description: undefined, required: false as const },
+  { key: "output_schema", label: "Output Schema", description: undefined, required: false as const },
+  { key: "trace_contract", label: "Trace Contract", description: undefined, required: false as const },
+  { key: "publication_spec", label: "Publication Spec", description: undefined, required: false as const },
+] as const;
+
+type SpecKey = (typeof specFields)[number]["key"];
+
+export function VersionEditor({
+  version,
+  workspaceId,
+  buildId,
+}: VersionEditorProps) {
+  const router = useRouter();
+  const { getAccessToken } = useAccessToken();
+
+  const isLocked = version.version_status === "ready";
+
+  const [agentKind, setAgentKind] = useState(version.agent_kind);
+  const [specs, setSpecs] = useState<Record<SpecKey, string>>(() => {
+    const initial: Record<string, string> = {};
+    for (const f of specFields) {
+      initial[f.key] = jsonStr(
+        version[f.key as keyof AgentBuildVersion],
+      );
+    }
+    return initial as Record<SpecKey, string>;
+  });
+
+  const [saving, setSaving] = useState(false);
+  const [validating, setValidating] = useState(false);
+  const [markingReady, setMarkingReady] = useState(false);
+  const [validationErrors, setValidationErrors] = useState<
+    Record<string, string>
+  >({});
+
+  function updateSpec(key: SpecKey, value: string) {
+    setSpecs((prev) => ({ ...prev, [key]: value }));
+    // Clear validation error for this field when edited
+    if (validationErrors[key]) {
+      setValidationErrors((prev) => {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+    }
+  }
+
+  function buildRequestBody() {
+    const body: Record<string, unknown> = { agent_kind: agentKind };
+    for (const f of specFields) {
+      const raw = specs[f.key].trim();
+      if (raw) {
+        try {
+          body[f.key] = JSON.parse(raw);
+        } catch {
+          toast.error(`Invalid JSON in ${f.label}`);
+          return null;
+        }
+      } else if (f.required) {
+        body[f.key] = {};
+      }
+    }
+    return body;
+  }
+
+  async function handleSave() {
+    const body = buildRequestBody();
+    if (!body) return;
+
+    setSaving(true);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      await api.patch(`/v1/agent-build-versions/${version.id}`, body);
+      toast.success("Saved");
+      router.refresh();
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleValidate() {
+    setValidating(true);
+    setValidationErrors({});
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      const result = await api.post<ValidationResult>(
+        `/v1/agent-build-versions/${version.id}/validate`,
+      );
+      if (result.valid) {
+        toast.success("Validation passed");
+      } else {
+        const errorMap: Record<string, string> = {};
+        for (const e of result.errors) {
+          errorMap[e.field] = e.message;
+        }
+        setValidationErrors(errorMap);
+        toast.error(`${result.errors.length} validation error(s)`);
+      }
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError ? err.message : "Validation failed",
+      );
+    } finally {
+      setValidating(false);
+    }
+  }
+
+  async function handleMarkReady() {
+    setMarkingReady(true);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      await api.post(`/v1/agent-build-versions/${version.id}/ready`);
+      toast.success("Version marked as ready");
+      router.refresh();
+    } catch (err) {
+      if (err instanceof ApiError && err.code === "validation_failed") {
+        toast.error("Cannot mark ready — fix validation errors first");
+        handleValidate();
+      } else {
+        toast.error(
+          err instanceof ApiError ? err.message : "Failed to mark ready",
+        );
+      }
+    } finally {
+      setMarkingReady(false);
+    }
+  }
+
+  return (
+    <div className="max-w-3xl">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <h2 className="text-sm font-semibold">
+            Version {version.version_number}
+          </h2>
+          <Badge
+            variant={
+              version.version_status === "ready"
+                ? "default"
+                : version.version_status === "draft"
+                  ? "outline"
+                  : "secondary"
+            }
+          >
+            {version.version_status}
+          </Badge>
+        </div>
+        {!isLocked && (
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleValidate}
+              disabled={validating}
+            >
+              {validating ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <>
+                  <ShieldCheck data-icon="inline-start" className="size-4" />
+                  Validate
+                </>
+              )}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleSave}
+              disabled={saving}
+            >
+              {saving ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <>
+                  <Save data-icon="inline-start" className="size-4" />
+                  Save Draft
+                </>
+              )}
+            </Button>
+            <Button size="sm" onClick={handleMarkReady} disabled={markingReady}>
+              {markingReady ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <>
+                  <CheckCircle data-icon="inline-start" className="size-4" />
+                  Mark Ready
+                </>
+              )}
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {isLocked && (
+        <div className="mb-6 rounded-lg border border-white/[0.06] bg-white/[0.02] p-3 text-sm text-muted-foreground">
+          This version is locked. Fields cannot be edited after marking as ready.
+        </div>
+      )}
+
+      {/* Agent Kind */}
+      <div className="mb-6">
+        <label className="mb-1.5 block text-sm font-medium">Agent Kind</label>
+        <select
+          value={agentKind}
+          onChange={(e) => setAgentKind(e.target.value)}
+          disabled={isLocked}
+          className="block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {AGENT_KINDS.map((kind) => (
+            <option key={kind} value={kind}>
+              {kind}
+            </option>
+          ))}
+        </select>
+        {validationErrors.agent_kind && (
+          <p className="mt-1 text-xs text-destructive">
+            {validationErrors.agent_kind}
+          </p>
+        )}
+      </div>
+
+      {/* Spec fields */}
+      <div className="space-y-5">
+        {specFields.map((f) => (
+          <JsonField
+            key={f.key}
+            label={
+              f.label +
+              (f.required ? "" : " (optional)")
+            }
+            description={f.description}
+            value={specs[f.key]}
+            onChange={(v) => updateSpec(f.key, v)}
+            error={validationErrors[f.key]}
+            disabled={isLocked}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/version-editor.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/version-editor.tsx
@@ -8,7 +8,6 @@ import { ApiError } from "@/lib/api/errors";
 import type {
   AgentBuildVersion,
   ValidationResult,
-  ValidationError,
 } from "@/lib/api/types";
 import { AGENT_KINDS } from "@/lib/api/types";
 import { Button } from "@/components/ui/button";
@@ -19,8 +18,6 @@ import { Loader2, Save, ShieldCheck, CheckCircle } from "lucide-react";
 
 interface VersionEditorProps {
   version: AgentBuildVersion;
-  workspaceId: string;
-  buildId: string;
 }
 
 function jsonStr(val: unknown): string {
@@ -46,8 +43,6 @@ type SpecKey = (typeof specFields)[number]["key"];
 
 export function VersionEditor({
   version,
-  workspaceId,
-  buildId,
 }: VersionEditorProps) {
   const router = useRouter();
   const { getAccessToken } = useAccessToken();

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/create-build-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/create-build-dialog.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import type { AgentBuild } from "@/lib/api/types";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { toast } from "sonner";
+import { Loader2, Plus } from "lucide-react";
+
+interface CreateBuildDialogProps {
+  workspaceId: string;
+}
+
+export function CreateBuildDialog({ workspaceId }: CreateBuildDialogProps) {
+  const router = useRouter();
+  const { getAccessToken } = useAccessToken();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleCreate() {
+    if (!name.trim()) return;
+
+    setSubmitting(true);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      const build = await api.post<AgentBuild>(
+        `/v1/workspaces/${workspaceId}/agent-builds`,
+        {
+          name: name.trim(),
+          description: description.trim() || undefined,
+        },
+      );
+      toast.success(`Created "${build.name}"`);
+      setOpen(false);
+      setName("");
+      setDescription("");
+      router.refresh();
+    } catch (err) {
+      if (err instanceof ApiError) {
+        toast.error(err.message);
+      } else {
+        toast.error("Failed to create agent build");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger
+        render={<Button size="sm" />}
+      >
+        <Plus data-icon="inline-start" className="size-4" />
+        New Agent Build
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New Agent Build</DialogTitle>
+          <DialogDescription>
+            Define a new agent — you&apos;ll configure its behavior in a version after creating it.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">Name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Code Review Agent"
+              autoFocus
+              className="block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/50"
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && name.trim()) handleCreate();
+              }}
+            />
+          </div>
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">
+              Description{" "}
+              <span className="text-muted-foreground font-normal">
+                (optional)
+              </span>
+            </label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What does this agent do?"
+              rows={3}
+              className="block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/50 resize-none"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => setOpen(false)}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            disabled={!name.trim() || submitting}
+            onClick={handleCreate}
+          >
+            {submitting ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              "Create"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/page.tsx
@@ -1,10 +1,100 @@
-export default function UbuildsPage() {
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { createApiClient } from "@/lib/api/client";
+import type { AgentBuild } from "@/lib/api/types";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Bot } from "lucide-react";
+import { CreateBuildDialog } from "./create-build-dialog";
+
+const statusVariant: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
+  active: "default",
+  archived: "secondary",
+};
+
+export default async function BuildsPage({
+  params,
+}: {
+  params: Promise<{ workspaceId: string }>;
+}) {
+  const { accessToken } = await withAuth();
+  if (!accessToken) redirect("/auth/login");
+
+  const { workspaceId } = await params;
+
+  const api = createApiClient(accessToken);
+  const { items: builds } = await api.get<{ items: AgentBuild[] }>(
+    `/v1/workspaces/${workspaceId}/agent-builds`,
+  );
+
   return (
     <div>
-      <h1 className="text-lg font-semibold tracking-tight mb-4">Uuilds</h1>
-      <div className="rounded-lg border border-border bg-card p-6 text-sm text-muted-foreground">
-        Coming soon.
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-lg font-semibold tracking-tight">Agent Builds</h1>
+        <CreateBuildDialog workspaceId={workspaceId} />
       </div>
+
+      {builds.length === 0 ? (
+        <EmptyState
+          icon={<Bot className="size-10" />}
+          title="No agent builds yet"
+          description="Create your first agent build to define how an AI agent behaves."
+        />
+      ) : (
+        <div className="rounded-lg border border-border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Slug</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Created</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {builds.map((build) => (
+                <TableRow key={build.id}>
+                  <TableCell>
+                    <Link
+                      href={`/workspaces/${workspaceId}/builds/${build.id}`}
+                      className="font-medium text-foreground hover:underline underline-offset-4"
+                    >
+                      {build.name}
+                    </Link>
+                    {build.description && (
+                      <p className="text-xs text-muted-foreground mt-0.5 truncate max-w-xs">
+                        {build.description}
+                      </p>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <code className="text-xs font-[family-name:var(--font-mono)] text-muted-foreground">
+                      {build.slug}
+                    </code>
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={statusVariant[build.lifecycle_status] ?? "outline"}>
+                      {build.lifecycle_status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {new Date(build.created_at).toLocaleDateString()}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/ui/json-field.tsx
+++ b/web/src/components/ui/json-field.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface JsonFieldProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  error?: string;
+  disabled?: boolean;
+  rows?: number;
+  description?: string;
+}
+
+export function JsonField({
+  label,
+  value,
+  onChange,
+  error,
+  disabled,
+  rows = 6,
+  description,
+}: JsonFieldProps) {
+  return (
+    <div>
+      <label className="mb-1.5 block text-sm font-medium">{label}</label>
+      {description && (
+        <p className="mb-1.5 text-xs text-muted-foreground">{description}</p>
+      )}
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        rows={rows}
+        spellCheck={false}
+        className={cn(
+          "block w-full rounded-lg border bg-transparent px-3 py-2 font-[family-name:var(--font-mono)] text-xs leading-relaxed placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50 resize-y disabled:opacity-50 disabled:cursor-not-allowed",
+          error
+            ? "border-destructive focus:border-destructive focus:ring-destructive/50"
+            : "border-input focus:border-ring",
+        )}
+      />
+      {error && <p className="mt-1 text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/web/src/lib/api/__tests__/client.test.ts
+++ b/web/src/lib/api/__tests__/client.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createApiClient } from "../client";
+import { ApiError, NetworkError } from "../errors";
+
+// Mock environment variable
+vi.stubEnv("NEXT_PUBLIC_API_URL", "http://localhost:8080");
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function errorResponse(status: number, code: string, message: string) {
+  return new Response(
+    JSON.stringify({ error: { code, message } }),
+    { status, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+describe("createApiClient", () => {
+  it("attaches Bearer token to requests", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ user_id: "123" }));
+
+    const api = createApiClient("my-token");
+    await api.get("/v1/auth/session");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/v1/auth/session",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer my-token",
+        }),
+      }),
+    );
+  });
+
+  it("does not attach Authorization header when no token", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({}));
+
+    const api = createApiClient();
+    await api.get("/v1/healthz");
+
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  it("get() returns parsed JSON response", async () => {
+    const session = {
+      user_id: "abc",
+      email: "test@example.com",
+      organization_memberships: [],
+      workspace_memberships: [],
+    };
+    mockFetch.mockResolvedValueOnce(jsonResponse(session));
+
+    const api = createApiClient("token");
+    const result = await api.get("/v1/auth/session");
+
+    expect(result).toEqual(session);
+  });
+
+  it("post() sends JSON body with Content-Type", async () => {
+    const responseData = {
+      id: "build-1",
+      name: "Test Agent",
+      slug: "test-agent",
+    };
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(responseData), { status: 201 }),
+    );
+
+    const api = createApiClient("token");
+    await api.post("/v1/workspaces/ws-1/agent-builds", {
+      name: "Test Agent",
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/v1/workspaces/ws-1/agent-builds",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ name: "Test Agent" }),
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+        }),
+      }),
+    );
+  });
+
+  it("throws ApiError on 4xx/5xx with error envelope", async () => {
+    mockFetch.mockResolvedValueOnce(
+      errorResponse(409, "already_onboarded", "you already have an organization"),
+    );
+
+    const api = createApiClient("token");
+
+    await expect(api.post("/v1/onboarding", {})).rejects.toThrow(ApiError);
+
+    try {
+      mockFetch.mockResolvedValueOnce(
+        errorResponse(409, "already_onboarded", "you already have an organization"),
+      );
+      await api.post("/v1/onboarding", {});
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      const apiErr = err as ApiError;
+      expect(apiErr.status).toBe(409);
+      expect(apiErr.code).toBe("already_onboarded");
+      expect(apiErr.message).toBe("you already have an organization");
+    }
+  });
+
+  it("throws ApiError on non-JSON error response", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response("Internal Server Error", { status: 500 }),
+    );
+
+    const api = createApiClient("token");
+
+    await expect(api.get("/v1/broken")).rejects.toThrow(ApiError);
+  });
+
+  it("throws NetworkError when fetch fails", async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+    const api = createApiClient("token");
+
+    await expect(api.get("/v1/auth/session")).rejects.toThrow(NetworkError);
+  });
+
+  it("paginated() appends limit and offset params", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ items: [], total: 0, limit: 10, offset: 0 }),
+    );
+
+    const api = createApiClient("token");
+    await api.paginated("/v1/workspaces/ws-1/runs", {
+      limit: 10,
+      offset: 20,
+    });
+
+    const url = mockFetch.mock.calls[0][0];
+    expect(url).toContain("limit=10");
+    expect(url).toContain("offset=20");
+  });
+
+  it("paginated() uses defaults when not specified", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ items: [], total: 0, limit: 20, offset: 0 }),
+    );
+
+    const api = createApiClient("token");
+    await api.paginated("/v1/workspaces/ws-1/runs");
+
+    const url = mockFetch.mock.calls[0][0];
+    expect(url).toContain("limit=20");
+    expect(url).toContain("offset=0");
+  });
+
+  it("patch() sends PATCH request", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ id: "v1" }));
+
+    const api = createApiClient("token");
+    await api.patch("/v1/agent-build-versions/v1", { agent_kind: "llm_agent" });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ method: "PATCH" }),
+    );
+  });
+
+  it("del() sends DELETE request", async () => {
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    const api = createApiClient("token");
+    await api.del("/v1/some-resource/123");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+});

--- a/web/src/lib/api/__tests__/integration.test.ts
+++ b/web/src/lib/api/__tests__/integration.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { createApiClient } from "../client";
+import { ApiError } from "../errors";
+
+/**
+ * Integration smoke tests that hit the real backend.
+ * Skip these in CI unless the backend is running.
+ *
+ * Run with: API_URL=http://localhost:8080 npx vitest run --reporter=verbose src/lib/api/__tests__/integration.test.ts
+ */
+
+const API_URL = process.env.API_URL || process.env.NEXT_PUBLIC_API_URL;
+// Only run if INTEGRATION_TESTS=1 is explicitly set — avoids false failures in CI
+const canRun = process.env.INTEGRATION_TESTS === "1" && !!API_URL;
+
+describe.skipIf(!canRun)("Backend integration smoke tests", () => {
+  it("healthz returns ok", async () => {
+    const res = await fetch(`${API_URL}/healthz`);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, service: "api-server" });
+  });
+
+  it("unauthenticated session request returns 401 ApiError", async () => {
+    const api = createApiClient(); // no token
+    try {
+      await api.get("/v1/auth/session");
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      const apiErr = err as ApiError;
+      expect(apiErr.status).toBe(401);
+      expect(apiErr.code).toBe("unauthorized");
+    }
+  });
+
+  it("backend error envelope matches ApiErrorResponse type shape", async () => {
+    const res = await fetch(`${API_URL}/v1/auth/session`);
+    expect(res.status).toBe(401);
+
+    const body = await res.json();
+    expect(body).toHaveProperty("error");
+    expect(body.error).toHaveProperty("code");
+    expect(body.error).toHaveProperty("message");
+    expect(typeof body.error.code).toBe("string");
+    expect(typeof body.error.message).toBe("string");
+  });
+});

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -11,4 +11,15 @@ export type {
   OrganizationResult,
   WorkspaceResult,
   ApiErrorResponse,
+  AgentBuild,
+  AgentBuildDetail,
+  CreateAgentBuildRequest,
+  AgentBuildVersion,
+  AgentBuildVersionInput,
+  ToolBinding,
+  KnowledgeSourceBinding,
+  ValidationResult,
+  ValidationError,
+  AgentKind,
 } from "./types";
+export { AGENT_KINDS } from "./types";

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -78,6 +78,105 @@ export interface WorkspaceResult {
   updated_at: string;
 }
 
+// --- Agent Builds ---
+
+/** GET /v1/workspaces/{id}/agent-builds item, POST response */
+export interface AgentBuild {
+  id: string;
+  workspace_id: string;
+  name: string;
+  slug: string;
+  description?: string;
+  lifecycle_status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/** GET /v1/agent-builds/{id} — build with versions */
+export interface AgentBuildDetail extends AgentBuild {
+  versions: AgentBuildVersion[];
+}
+
+/** POST /v1/workspaces/{id}/agent-builds request */
+export interface CreateAgentBuildRequest {
+  name: string;
+  description?: string;
+}
+
+// --- Agent Build Versions ---
+
+export interface AgentBuildVersion {
+  id: string;
+  agent_build_id: string;
+  version_number: number;
+  version_status: string;
+  agent_kind: string;
+  interface_spec: unknown;
+  policy_spec: unknown;
+  reasoning_spec: unknown;
+  memory_spec: unknown;
+  workflow_spec: unknown;
+  guardrail_spec: unknown;
+  model_spec: unknown;
+  output_schema: unknown;
+  trace_contract: unknown;
+  publication_spec: unknown;
+  tools: ToolBinding[];
+  knowledge_sources: KnowledgeSourceBinding[];
+  created_at: string;
+}
+
+export interface ToolBinding {
+  tool_id: string;
+  binding_role: string;
+  binding_config?: unknown;
+}
+
+export interface KnowledgeSourceBinding {
+  knowledge_source_id: string;
+  binding_role: string;
+  binding_config?: unknown;
+}
+
+/** POST/PATCH agent build version request body */
+export interface AgentBuildVersionInput {
+  agent_kind: string;
+  interface_spec: unknown;
+  policy_spec: unknown;
+  reasoning_spec?: unknown;
+  memory_spec?: unknown;
+  workflow_spec?: unknown;
+  guardrail_spec?: unknown;
+  model_spec?: unknown;
+  output_schema?: unknown;
+  trace_contract?: unknown;
+  publication_spec?: unknown;
+  tools?: ToolBinding[];
+  knowledge_sources?: KnowledgeSourceBinding[];
+}
+
+/** POST /v1/agent-build-versions/{id}/validate response */
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
+}
+
+export interface ValidationError {
+  field: string;
+  message: string;
+}
+
+/** Agent kind enum values */
+export const AGENT_KINDS = [
+  "llm_agent",
+  "workflow_agent",
+  "programmatic_agent",
+  "multi_agent_system",
+  "hosted_external",
+] as const;
+
+export type AgentKind = (typeof AGENT_KINDS)[number];
+
 // --- Errors ---
 
 /** Standard error envelope returned by all backend error responses. */

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
Closes #203

### Agent builds list (`/workspaces/{id}/builds`)
- Server-side fetches `GET /v1/workspaces/{id}/agent-builds`
- Table: name (links to detail), slug, lifecycle status badge, created date
- "New Agent Build" dialog: name + description form → `POST /v1/workspaces/{id}/agent-builds`
- Empty state with CTA

### Build detail (`/workspaces/{id}/builds/{buildId}`)
- Shows build metadata (name, slug, status, description)
- Versions table: version number, agent kind, status badge, created date
- "New Version" creates a draft version (llm_agent default) and navigates to editor

### Version editor (`/workspaces/{id}/builds/{buildId}/versions/{versionId}`)
- Agent kind selector (llm_agent, workflow_agent, programmatic_agent, multi_agent_system, hosted_external)
- JSON text fields for all 10 spec types (policy, interface, model, reasoning, memory, workflow, guardrail, output schema, trace contract, publication)
- **Save Draft** → `PATCH /v1/agent-build-versions/{id}`
- **Validate** → `POST .../validate` — errors display inline under the failing field
- **Mark Ready** → `POST .../ready` — locks the version (all fields disabled)
- Breadcrumb navigation: Builds / {name} / v{N}

### API types
- Full TypeScript interfaces for all agent build/version endpoints
- `AGENT_KINDS` const enum

### Testing
- **Vitest** installed with 11 unit tests for the API client:
  - Auth header attachment, JSON body serialization, error parsing (ApiError/NetworkError), pagination params, all HTTP methods
- 3 integration smoke tests (run with `INTEGRATION_TESTS=1 API_URL=... npm test`):
  - Healthz, unauthenticated 401, error envelope shape

## Test plan
- [x] `tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — exits 0, all routes present
- [x] `npm test` — 11 passed, 3 skipped
- [ ] Create a build → appears in list
- [ ] Click build → detail page with versions
- [ ] Create version → editor opens
- [ ] Edit specs, save → persisted on reload
- [ ] Validate with bad data → inline errors
- [ ] Mark ready → fields lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)