### PR TITLE
Infrastructure CRUD APIs: runtime profiles, provider accounts, model aliases, routing, spend, tools, knowledge sources

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -79,6 +79,7 @@ func main() {
 	orgMembershipManager := api.NewOrgMembershipManager(orgAuthz, repo)
 	wsMembershipManager := api.NewWorkspaceMembershipManager(repo)
 	onboardingManager := api.NewOnboardingManager(repo)
+	infraManager := api.NewInfrastructureManager(repo)
 
 	var authenticator api.Authenticator
 	switch cfg.AuthMode {
@@ -119,6 +120,7 @@ func main() {
 		orgMembershipManager,
 		wsMembershipManager,
 		onboardingManager,
+		infraManager,
 	)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/backend/internal/api/agent_builds_test.go
+++ b/backend/internal/api/agent_builds_test.go
@@ -107,6 +107,8 @@ func TestGetAgentBuildRequiresWorkspaceMembership(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	)
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/agent-builds/"+buildID.String(), nil)
@@ -155,6 +157,8 @@ func TestGetAgentBuildVersionRequiresWorkspaceMembership(t *testing.T) {
 			},
 		},
 		noopReleaseGateService{},
+		nil,
+		nil,
 		nil,
 		nil,
 		nil,
@@ -229,6 +233,8 @@ func TestGetAgentBuildVersionReturnsToolAndKnowledgeBindings(t *testing.T) {
 			},
 		},
 		noopReleaseGateService{},
+		nil,
+		nil,
 		nil,
 		nil,
 		nil,

--- a/backend/internal/api/artifacts_test.go
+++ b/backend/internal/api/artifacts_test.go
@@ -111,6 +111,8 @@ func TestArtifactManagerUploadAndSignedDownloadFlow(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {

--- a/backend/internal/api/challenge_packs_test.go
+++ b/backend/internal/api/challenge_packs_test.go
@@ -183,6 +183,8 @@ challenges:
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusCreated {

--- a/backend/internal/api/compare_reads_test.go
+++ b/backend/internal/api/compare_reads_test.go
@@ -116,6 +116,8 @@ func TestGetRunComparisonEndpointReturnsJSONPayload(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -159,6 +161,8 @@ func TestCompareViewerEndpointReturnsHTMLShell(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
 		nil,
 		nil,
 		nil,

--- a/backend/internal/api/hosted_runs_test.go
+++ b/backend/internal/api/hosted_runs_test.go
@@ -246,6 +246,8 @@ func TestIngestHostedRunEventHandlerReturnsInternalErrorForRepositoryFailure(t *
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	)
 	router.ServeHTTP(recorder, req)
 

--- a/backend/internal/api/infrastructure.go
+++ b/backend/internal/api/infrastructure.go
@@ -1,0 +1,450 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+// --------------------------------------------------------------------------
+// Service Interface
+// --------------------------------------------------------------------------
+
+type InfrastructureService interface {
+	// Runtime Profiles
+	CreateRuntimeProfile(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateRuntimeProfileInput) (repository.RuntimeProfileRow, error)
+	ListRuntimeProfiles(ctx context.Context, workspaceID uuid.UUID) ([]repository.RuntimeProfileRow, error)
+	GetRuntimeProfile(ctx context.Context, id uuid.UUID) (repository.RuntimeProfileRow, error)
+	ArchiveRuntimeProfile(ctx context.Context, id uuid.UUID) error
+
+	// Provider Accounts
+	CreateProviderAccount(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateProviderAccountInput) (repository.ProviderAccountRow, error)
+	ListProviderAccounts(ctx context.Context, workspaceID uuid.UUID) ([]repository.ProviderAccountRow, error)
+	GetProviderAccount(ctx context.Context, id uuid.UUID) (repository.ProviderAccountRow, error)
+
+	// Model Catalog (global, read-only)
+	ListModelCatalog(ctx context.Context) ([]repository.ModelCatalogEntryRow, error)
+	GetModelCatalogEntry(ctx context.Context, id uuid.UUID) (repository.ModelCatalogEntryRow, error)
+
+	// Model Aliases
+	CreateModelAlias(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateModelAliasInput) (repository.ModelAliasRow, error)
+	ListModelAliases(ctx context.Context, workspaceID uuid.UUID) ([]repository.ModelAliasRow, error)
+	GetModelAlias(ctx context.Context, id uuid.UUID) (repository.ModelAliasRow, error)
+
+	// Tools
+	CreateTool(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateToolInput) (repository.ToolRow, error)
+	ListTools(ctx context.Context, workspaceID uuid.UUID) ([]repository.ToolRow, error)
+	GetTool(ctx context.Context, id uuid.UUID) (repository.ToolRow, error)
+
+	// Knowledge Sources
+	CreateKnowledgeSource(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateKnowledgeSourceInput) (repository.KnowledgeSourceRow, error)
+	ListKnowledgeSources(ctx context.Context, workspaceID uuid.UUID) ([]repository.KnowledgeSourceRow, error)
+	GetKnowledgeSource(ctx context.Context, id uuid.UUID) (repository.KnowledgeSourceRow, error)
+
+	// Routing Policies
+	CreateRoutingPolicy(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateRoutingPolicyInput) (repository.RoutingPolicyRow, error)
+	ListRoutingPolicies(ctx context.Context, workspaceID uuid.UUID) ([]repository.RoutingPolicyRow, error)
+
+	// Spend Policies
+	CreateSpendPolicy(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateSpendPolicyInput) (repository.SpendPolicyRow, error)
+	ListSpendPolicies(ctx context.Context, workspaceID uuid.UUID) ([]repository.SpendPolicyRow, error)
+}
+
+// --------------------------------------------------------------------------
+// Input Types
+// --------------------------------------------------------------------------
+
+type CreateRuntimeProfileInput struct {
+	Name               string          `json:"name"`
+	ExecutionTarget    string          `json:"execution_target"`
+	TraceMode          string          `json:"trace_mode,omitempty"`
+	MaxIterations      int32           `json:"max_iterations,omitempty"`
+	MaxToolCalls       int32           `json:"max_tool_calls,omitempty"`
+	StepTimeoutSeconds int32           `json:"step_timeout_seconds,omitempty"`
+	RunTimeoutSeconds  int32           `json:"run_timeout_seconds,omitempty"`
+	ProfileConfig      json.RawMessage `json:"profile_config,omitempty"`
+}
+
+type CreateProviderAccountInput struct {
+	ProviderKey         string          `json:"provider_key"`
+	Name                string          `json:"name"`
+	CredentialReference string          `json:"credential_reference"`
+	LimitsConfig        json.RawMessage `json:"limits_config,omitempty"`
+}
+
+type CreateModelAliasInput struct {
+	AliasKey            string     `json:"alias_key"`
+	DisplayName         string     `json:"display_name"`
+	ModelCatalogEntryID string     `json:"model_catalog_entry_id"`
+	ProviderAccountID   *string    `json:"provider_account_id,omitempty"`
+}
+
+type CreateToolInput struct {
+	Name          string          `json:"name"`
+	ToolKind      string          `json:"tool_kind"`
+	CapabilityKey string          `json:"capability_key"`
+	Definition    json.RawMessage `json:"definition,omitempty"`
+}
+
+type CreateKnowledgeSourceInput struct {
+	Name             string          `json:"name"`
+	SourceKind       string          `json:"source_kind"`
+	ConnectionConfig json.RawMessage `json:"connection_config,omitempty"`
+}
+
+type CreateRoutingPolicyInput struct {
+	Name       string          `json:"name"`
+	PolicyKind string          `json:"policy_kind"`
+	Config     json.RawMessage `json:"config,omitempty"`
+}
+
+type CreateSpendPolicyInput struct {
+	Name         string          `json:"name"`
+	CurrencyCode string          `json:"currency_code,omitempty"`
+	WindowKind   string          `json:"window_kind"`
+	SoftLimit    *float64        `json:"soft_limit,omitempty"`
+	HardLimit    *float64        `json:"hard_limit,omitempty"`
+	Config       json.RawMessage `json:"config,omitempty"`
+}
+
+// --------------------------------------------------------------------------
+// Response Types
+// --------------------------------------------------------------------------
+
+type runtimeProfileResponse struct {
+	ID                 uuid.UUID       `json:"id"`
+	WorkspaceID        *uuid.UUID      `json:"workspace_id,omitempty"`
+	Name               string          `json:"name"`
+	Slug               string          `json:"slug"`
+	ExecutionTarget    string          `json:"execution_target"`
+	TraceMode          string          `json:"trace_mode"`
+	MaxIterations      int32           `json:"max_iterations"`
+	MaxToolCalls       int32           `json:"max_tool_calls"`
+	StepTimeoutSeconds int32           `json:"step_timeout_seconds"`
+	RunTimeoutSeconds  int32           `json:"run_timeout_seconds"`
+	ProfileConfig      json.RawMessage `json:"profile_config"`
+	CreatedAt          time.Time       `json:"created_at"`
+	UpdatedAt          time.Time       `json:"updated_at"`
+}
+
+type providerAccountResponse struct {
+	ID                  uuid.UUID       `json:"id"`
+	WorkspaceID         *uuid.UUID      `json:"workspace_id,omitempty"`
+	ProviderKey         string          `json:"provider_key"`
+	Name                string          `json:"name"`
+	CredentialReference string          `json:"credential_reference"`
+	Status              string          `json:"status"`
+	LimitsConfig        json.RawMessage `json:"limits_config"`
+	CreatedAt           time.Time       `json:"created_at"`
+	UpdatedAt           time.Time       `json:"updated_at"`
+}
+
+type modelCatalogResponse struct {
+	ID              uuid.UUID       `json:"id"`
+	ProviderKey     string          `json:"provider_key"`
+	ProviderModelID string          `json:"provider_model_id"`
+	DisplayName     string          `json:"display_name"`
+	ModelFamily     string          `json:"model_family"`
+	Modality        string          `json:"modality"`
+	LifecycleStatus string          `json:"lifecycle_status"`
+	Metadata        json.RawMessage `json:"metadata"`
+	CreatedAt       time.Time       `json:"created_at"`
+	UpdatedAt       time.Time       `json:"updated_at"`
+}
+
+type modelAliasResponse struct {
+	ID                  uuid.UUID  `json:"id"`
+	WorkspaceID         *uuid.UUID `json:"workspace_id,omitempty"`
+	ProviderAccountID   *uuid.UUID `json:"provider_account_id,omitempty"`
+	ModelCatalogEntryID uuid.UUID  `json:"model_catalog_entry_id"`
+	AliasKey            string     `json:"alias_key"`
+	DisplayName         string     `json:"display_name"`
+	Status              string     `json:"status"`
+	CreatedAt           time.Time  `json:"created_at"`
+	UpdatedAt           time.Time  `json:"updated_at"`
+}
+
+type toolResponse struct {
+	ID              uuid.UUID       `json:"id"`
+	WorkspaceID     *uuid.UUID      `json:"workspace_id,omitempty"`
+	Name            string          `json:"name"`
+	Slug            string          `json:"slug"`
+	ToolKind        string          `json:"tool_kind"`
+	CapabilityKey   string          `json:"capability_key"`
+	Definition      json.RawMessage `json:"definition"`
+	LifecycleStatus string          `json:"lifecycle_status"`
+	CreatedAt       time.Time       `json:"created_at"`
+	UpdatedAt       time.Time       `json:"updated_at"`
+}
+
+type knowledgeSourceResponse struct {
+	ID               uuid.UUID       `json:"id"`
+	WorkspaceID      *uuid.UUID      `json:"workspace_id,omitempty"`
+	Name             string          `json:"name"`
+	Slug             string          `json:"slug"`
+	SourceKind       string          `json:"source_kind"`
+	ConnectionConfig json.RawMessage `json:"connection_config"`
+	LifecycleStatus  string          `json:"lifecycle_status"`
+	CreatedAt        time.Time       `json:"created_at"`
+	UpdatedAt        time.Time       `json:"updated_at"`
+}
+
+type routingPolicyResponse struct {
+	ID          uuid.UUID       `json:"id"`
+	WorkspaceID *uuid.UUID      `json:"workspace_id,omitempty"`
+	Name        string          `json:"name"`
+	PolicyKind  string          `json:"policy_kind"`
+	Config      json.RawMessage `json:"config"`
+	CreatedAt   time.Time       `json:"created_at"`
+	UpdatedAt   time.Time       `json:"updated_at"`
+}
+
+type spendPolicyResponse struct {
+	ID           uuid.UUID       `json:"id"`
+	WorkspaceID  *uuid.UUID      `json:"workspace_id,omitempty"`
+	Name         string          `json:"name"`
+	CurrencyCode string          `json:"currency_code"`
+	WindowKind   string          `json:"window_kind"`
+	SoftLimit    *float64        `json:"soft_limit,omitempty"`
+	HardLimit    *float64        `json:"hard_limit,omitempty"`
+	Config       json.RawMessage `json:"config"`
+	CreatedAt    time.Time       `json:"created_at"`
+	UpdatedAt    time.Time       `json:"updated_at"`
+}
+
+// --------------------------------------------------------------------------
+// Generic Handlers (DRY pattern for workspace-scoped create/list)
+// --------------------------------------------------------------------------
+
+func infraCreateHandler[Input any, Row any, Resp any](
+	logger *slog.Logger,
+	create func(ctx context.Context, caller Caller, wsID uuid.UUID, input Input) (Row, error),
+	toResponse func(Row) Resp,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "authentication required")
+			return
+		}
+		wsID, err := WorkspaceIDFromContext(r.Context())
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "workspace ID required")
+			return
+		}
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+		var input Input
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body")
+			return
+		}
+		row, err := create(r.Context(), caller, wsID, input)
+		if err != nil {
+			logger.Error("create failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "failed to create resource")
+			return
+		}
+		writeJSON(w, http.StatusCreated, toResponse(row))
+	}
+}
+
+func infraListHandler[Row any, Resp any](
+	logger *slog.Logger,
+	list func(ctx context.Context, wsID uuid.UUID) ([]Row, error),
+	toResponse func(Row) Resp,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		wsID, err := WorkspaceIDFromContext(r.Context())
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "workspace ID required")
+			return
+		}
+		rows, err := list(r.Context(), wsID)
+		if err != nil {
+			logger.Error("list failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "failed to list resources")
+			return
+		}
+		items := make([]Resp, len(rows))
+		for i, row := range rows {
+			items[i] = toResponse(row)
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"items": items})
+	}
+}
+
+func infraGetHandler[Row any, Resp any](
+	logger *slog.Logger,
+	paramName string,
+	get func(ctx context.Context, id uuid.UUID) (Row, error),
+	toResponse func(Row) Resp,
+	notFoundCode string,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		raw := chi.URLParam(r, paramName)
+		id, err := uuid.Parse(raw)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "invalid ID")
+			return
+		}
+		row, err := get(r.Context(), id)
+		if err != nil {
+			if err.Error() == notFoundCode+" not found" || isNotFoundErr(err) {
+				writeError(w, http.StatusNotFound, "not_found", notFoundCode+" not found")
+				return
+			}
+			logger.Error("get failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "failed to get resource")
+			return
+		}
+		writeJSON(w, http.StatusOK, toResponse(row))
+	}
+}
+
+func isNotFoundErr(err error) bool {
+	msg := err.Error()
+	return msg == repository.ErrRuntimeProfileNotFound.Error() ||
+		msg == repository.ErrProviderAccountNotFound.Error() ||
+		msg == repository.ErrModelAliasNotFound.Error() ||
+		msg == repository.ErrModelCatalogNotFound.Error() ||
+		msg == repository.ErrToolNotFound.Error() ||
+		msg == repository.ErrKnowledgeSourceNotFound.Error() ||
+		msg == repository.ErrRoutingPolicyNotFound.Error() ||
+		msg == repository.ErrSpendPolicyNotFound.Error()
+}
+
+// --------------------------------------------------------------------------
+// Response Mappers
+// --------------------------------------------------------------------------
+
+func mapRuntimeProfile(r repository.RuntimeProfileRow) runtimeProfileResponse {
+	return runtimeProfileResponse{
+		ID: r.ID, WorkspaceID: r.WorkspaceID, Name: r.Name, Slug: r.Slug,
+		ExecutionTarget: r.ExecutionTarget, TraceMode: r.TraceMode,
+		MaxIterations: r.MaxIterations, MaxToolCalls: r.MaxToolCalls,
+		StepTimeoutSeconds: r.StepTimeoutSeconds, RunTimeoutSeconds: r.RunTimeoutSeconds,
+		ProfileConfig: r.ProfileConfig, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+	}
+}
+
+func mapProviderAccount(r repository.ProviderAccountRow) providerAccountResponse {
+	return providerAccountResponse{
+		ID: r.ID, WorkspaceID: r.WorkspaceID, ProviderKey: r.ProviderKey, Name: r.Name,
+		CredentialReference: r.CredentialReference, Status: r.Status, LimitsConfig: r.LimitsConfig,
+		CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+	}
+}
+
+func mapModelCatalog(r repository.ModelCatalogEntryRow) modelCatalogResponse {
+	return modelCatalogResponse{
+		ID: r.ID, ProviderKey: r.ProviderKey, ProviderModelID: r.ProviderModelID,
+		DisplayName: r.DisplayName, ModelFamily: r.ModelFamily, Modality: r.Modality,
+		LifecycleStatus: r.LifecycleStatus, Metadata: r.Metadata,
+		CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+	}
+}
+
+func mapModelAlias(r repository.ModelAliasRow) modelAliasResponse {
+	return modelAliasResponse{
+		ID: r.ID, WorkspaceID: r.WorkspaceID, ProviderAccountID: r.ProviderAccountID,
+		ModelCatalogEntryID: r.ModelCatalogEntryID, AliasKey: r.AliasKey, DisplayName: r.DisplayName,
+		Status: r.Status, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+	}
+}
+
+func mapTool(r repository.ToolRow) toolResponse {
+	return toolResponse{
+		ID: r.ID, WorkspaceID: r.WorkspaceID, Name: r.Name, Slug: r.Slug,
+		ToolKind: r.ToolKind, CapabilityKey: r.CapabilityKey, Definition: r.Definition,
+		LifecycleStatus: r.LifecycleStatus, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+	}
+}
+
+func mapKnowledgeSource(r repository.KnowledgeSourceRow) knowledgeSourceResponse {
+	return knowledgeSourceResponse{
+		ID: r.ID, WorkspaceID: r.WorkspaceID, Name: r.Name, Slug: r.Slug,
+		SourceKind: r.SourceKind, ConnectionConfig: r.ConnectionConfig,
+		LifecycleStatus: r.LifecycleStatus, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+	}
+}
+
+func mapRoutingPolicy(r repository.RoutingPolicyRow) routingPolicyResponse {
+	return routingPolicyResponse{
+		ID: r.ID, WorkspaceID: r.WorkspaceID, Name: r.Name, PolicyKind: r.PolicyKind,
+		Config: r.Config, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+	}
+}
+
+func mapSpendPolicy(r repository.SpendPolicyRow) spendPolicyResponse {
+	return spendPolicyResponse{
+		ID: r.ID, WorkspaceID: r.WorkspaceID, Name: r.Name, CurrencyCode: r.CurrencyCode,
+		WindowKind: r.WindowKind, SoftLimit: r.SoftLimit, HardLimit: r.HardLimit,
+		Config: r.Config, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+	}
+}
+
+// --------------------------------------------------------------------------
+// Model Catalog Handlers (global, no workspace scope)
+// --------------------------------------------------------------------------
+
+func listModelCatalogHandler(logger *slog.Logger, svc InfrastructureService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		entries, err := svc.ListModelCatalog(r.Context())
+		if err != nil {
+			logger.Error("list model catalog failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "failed to list model catalog")
+			return
+		}
+		items := make([]modelCatalogResponse, len(entries))
+		for i, e := range entries {
+			items[i] = mapModelCatalog(e)
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"items": items})
+	}
+}
+
+func getModelCatalogEntryHandler(logger *slog.Logger, svc InfrastructureService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		raw := chi.URLParam(r, "entryID")
+		id, err := uuid.Parse(raw)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "invalid ID")
+			return
+		}
+		entry, err := svc.GetModelCatalogEntry(r.Context(), id)
+		if err != nil {
+			writeError(w, http.StatusNotFound, "not_found", "model catalog entry not found")
+			return
+		}
+		writeJSON(w, http.StatusOK, mapModelCatalog(entry))
+	}
+}
+
+// --------------------------------------------------------------------------
+// Archive handler for runtime profiles
+// --------------------------------------------------------------------------
+
+func archiveRuntimeProfileHandler(logger *slog.Logger, svc InfrastructureService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		raw := chi.URLParam(r, "profileID")
+		id, err := uuid.Parse(raw)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "invalid ID")
+			return
+		}
+		if err := svc.ArchiveRuntimeProfile(r.Context(), id); err != nil {
+			writeError(w, http.StatusNotFound, "not_found", "runtime profile not found")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/backend/internal/api/infrastructure.go
+++ b/backend/internal/api/infrastructure.go
@@ -3,8 +3,11 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
@@ -71,6 +74,10 @@ type CreateRuntimeProfileInput struct {
 	ProfileConfig      json.RawMessage `json:"profile_config,omitempty"`
 }
 
+func (i *CreateRuntimeProfileInput) Validate() error {
+	return requireFields(map[string]string{"name": i.Name, "execution_target": i.ExecutionTarget})
+}
+
 type CreateProviderAccountInput struct {
 	ProviderKey         string          `json:"provider_key"`
 	Name                string          `json:"name"`
@@ -78,11 +85,19 @@ type CreateProviderAccountInput struct {
 	LimitsConfig        json.RawMessage `json:"limits_config,omitempty"`
 }
 
+func (i *CreateProviderAccountInput) Validate() error {
+	return requireFields(map[string]string{"provider_key": i.ProviderKey, "name": i.Name, "credential_reference": i.CredentialReference})
+}
+
 type CreateModelAliasInput struct {
-	AliasKey            string     `json:"alias_key"`
-	DisplayName         string     `json:"display_name"`
-	ModelCatalogEntryID string     `json:"model_catalog_entry_id"`
-	ProviderAccountID   *string    `json:"provider_account_id,omitempty"`
+	AliasKey            string  `json:"alias_key"`
+	DisplayName         string  `json:"display_name"`
+	ModelCatalogEntryID string  `json:"model_catalog_entry_id"`
+	ProviderAccountID   *string `json:"provider_account_id,omitempty"`
+}
+
+func (i *CreateModelAliasInput) Validate() error {
+	return requireFields(map[string]string{"alias_key": i.AliasKey, "display_name": i.DisplayName, "model_catalog_entry_id": i.ModelCatalogEntryID})
 }
 
 type CreateToolInput struct {
@@ -92,16 +107,28 @@ type CreateToolInput struct {
 	Definition    json.RawMessage `json:"definition,omitempty"`
 }
 
+func (i *CreateToolInput) Validate() error {
+	return requireFields(map[string]string{"name": i.Name, "tool_kind": i.ToolKind, "capability_key": i.CapabilityKey})
+}
+
 type CreateKnowledgeSourceInput struct {
 	Name             string          `json:"name"`
 	SourceKind       string          `json:"source_kind"`
 	ConnectionConfig json.RawMessage `json:"connection_config,omitempty"`
 }
 
+func (i *CreateKnowledgeSourceInput) Validate() error {
+	return requireFields(map[string]string{"name": i.Name, "source_kind": i.SourceKind})
+}
+
 type CreateRoutingPolicyInput struct {
 	Name       string          `json:"name"`
 	PolicyKind string          `json:"policy_kind"`
 	Config     json.RawMessage `json:"config,omitempty"`
+}
+
+func (i *CreateRoutingPolicyInput) Validate() error {
+	return requireFields(map[string]string{"name": i.Name, "policy_kind": i.PolicyKind})
 }
 
 type CreateSpendPolicyInput struct {
@@ -111,6 +138,19 @@ type CreateSpendPolicyInput struct {
 	SoftLimit    *float64        `json:"soft_limit,omitempty"`
 	HardLimit    *float64        `json:"hard_limit,omitempty"`
 	Config       json.RawMessage `json:"config,omitempty"`
+}
+
+func (i *CreateSpendPolicyInput) Validate() error {
+	return requireFields(map[string]string{"name": i.Name, "window_kind": i.WindowKind})
+}
+
+func requireFields(fields map[string]string) error {
+	for name, value := range fields {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%s is required", name)
+		}
+	}
+	return nil
 }
 
 // --------------------------------------------------------------------------
@@ -222,6 +262,11 @@ type spendPolicyResponse struct {
 // Generic Handlers (DRY pattern for workspace-scoped create/list)
 // --------------------------------------------------------------------------
 
+// Validatable can be implemented by input types to provide field validation.
+type Validatable interface {
+	Validate() error
+}
+
 func infraCreateHandler[Input any, Row any, Resp any](
 	logger *slog.Logger,
 	authorizer WorkspaceAuthorizer,
@@ -252,8 +297,18 @@ func infraCreateHandler[Input any, Row any, Resp any](
 			writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body")
 			return
 		}
+		if v, ok := any(&input).(Validatable); ok {
+			if err := v.Validate(); err != nil {
+				writeError(w, http.StatusBadRequest, "validation_error", err.Error())
+				return
+			}
+		}
 		row, err := create(r.Context(), caller, wsID, input)
 		if err != nil {
+			if errors.Is(err, repository.ErrSlugTaken) {
+				writeError(w, http.StatusConflict, "slug_taken", "a resource with that name already exists")
+				return
+			}
 			logger.Error("create failed", "error", err)
 			writeError(w, http.StatusInternalServerError, "internal_error", "failed to create resource")
 			return
@@ -315,7 +370,7 @@ func infraGetHandler[Row WorkspaceOwned, Resp any](
 		}
 		row, err := get(r.Context(), id)
 		if err != nil {
-			if isNotFoundErr(err) {
+			if isInfraNotFoundErr(err) {
 				writeError(w, http.StatusNotFound, "not_found", notFoundCode+" not found")
 				return
 			}
@@ -336,16 +391,15 @@ func infraGetHandler[Row WorkspaceOwned, Resp any](
 	}
 }
 
-func isNotFoundErr(err error) bool {
-	msg := err.Error()
-	return msg == repository.ErrRuntimeProfileNotFound.Error() ||
-		msg == repository.ErrProviderAccountNotFound.Error() ||
-		msg == repository.ErrModelAliasNotFound.Error() ||
-		msg == repository.ErrModelCatalogNotFound.Error() ||
-		msg == repository.ErrToolNotFound.Error() ||
-		msg == repository.ErrKnowledgeSourceNotFound.Error() ||
-		msg == repository.ErrRoutingPolicyNotFound.Error() ||
-		msg == repository.ErrSpendPolicyNotFound.Error()
+func isInfraNotFoundErr(err error) bool {
+	return errors.Is(err, repository.ErrRuntimeProfileNotFound) ||
+		errors.Is(err, repository.ErrProviderAccountNotFound) ||
+		errors.Is(err, repository.ErrModelAliasNotFound) ||
+		errors.Is(err, repository.ErrModelCatalogNotFound) ||
+		errors.Is(err, repository.ErrToolNotFound) ||
+		errors.Is(err, repository.ErrKnowledgeSourceNotFound) ||
+		errors.Is(err, repository.ErrRoutingPolicyNotFound) ||
+		errors.Is(err, repository.ErrSpendPolicyNotFound)
 }
 
 // --------------------------------------------------------------------------

--- a/backend/internal/api/infrastructure.go
+++ b/backend/internal/api/infrastructure.go
@@ -224,6 +224,7 @@ type spendPolicyResponse struct {
 
 func infraCreateHandler[Input any, Row any, Resp any](
 	logger *slog.Logger,
+	authorizer WorkspaceAuthorizer,
 	create func(ctx context.Context, caller Caller, wsID uuid.UUID, input Input) (Row, error),
 	toResponse func(Row) Resp,
 ) http.HandlerFunc {
@@ -236,6 +237,10 @@ func infraCreateHandler[Input any, Row any, Resp any](
 		wsID, err := WorkspaceIDFromContext(r.Context())
 		if err != nil {
 			writeError(w, http.StatusBadRequest, "invalid_request", "workspace ID required")
+			return
+		}
+		if err := AuthorizeWorkspaceAction(r.Context(), authorizer, caller, wsID, ActionManageInfrastructure); err != nil {
+			writeAuthzError(w, err)
 			return
 		}
 		if err := requireJSONContentType(r); err != nil {
@@ -282,14 +287,26 @@ func infraListHandler[Row any, Resp any](
 	}
 }
 
-func infraGetHandler[Row any, Resp any](
+// WorkspaceOwned is implemented by row types that carry a workspace ID for authorization.
+type WorkspaceOwned interface {
+	GetWorkspaceID() *uuid.UUID
+}
+
+func infraGetHandler[Row WorkspaceOwned, Resp any](
 	logger *slog.Logger,
+	authorizer WorkspaceAuthorizer,
 	paramName string,
 	get func(ctx context.Context, id uuid.UUID) (Row, error),
 	toResponse func(Row) Resp,
 	notFoundCode string,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "authentication required")
+			return
+		}
+
 		raw := chi.URLParam(r, paramName)
 		id, err := uuid.Parse(raw)
 		if err != nil {
@@ -298,7 +315,7 @@ func infraGetHandler[Row any, Resp any](
 		}
 		row, err := get(r.Context(), id)
 		if err != nil {
-			if err.Error() == notFoundCode+" not found" || isNotFoundErr(err) {
+			if isNotFoundErr(err) {
 				writeError(w, http.StatusNotFound, "not_found", notFoundCode+" not found")
 				return
 			}
@@ -306,6 +323,15 @@ func infraGetHandler[Row any, Resp any](
 			writeError(w, http.StatusInternalServerError, "internal_error", "failed to get resource")
 			return
 		}
+
+		// Authorize: caller must have access to the resource's workspace
+		if wsID := row.GetWorkspaceID(); wsID != nil {
+			if err := AuthorizeWorkspaceAction(r.Context(), authorizer, caller, *wsID, ActionReadWorkspace); err != nil {
+				writeAuthzError(w, err)
+				return
+			}
+		}
+
 		writeJSON(w, http.StatusOK, toResponse(row))
 	}
 }
@@ -433,14 +459,34 @@ func getModelCatalogEntryHandler(logger *slog.Logger, svc InfrastructureService)
 // Archive handler for runtime profiles
 // --------------------------------------------------------------------------
 
-func archiveRuntimeProfileHandler(logger *slog.Logger, svc InfrastructureService) http.HandlerFunc {
+func archiveRuntimeProfileHandler(logger *slog.Logger, svc InfrastructureService, authorizer WorkspaceAuthorizer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "authentication required")
+			return
+		}
+
 		raw := chi.URLParam(r, "profileID")
 		id, err := uuid.Parse(raw)
 		if err != nil {
 			writeError(w, http.StatusBadRequest, "invalid_request", "invalid ID")
 			return
 		}
+
+		// Fetch first to get workspace ID for authorization
+		profile, err := svc.GetRuntimeProfile(r.Context(), id)
+		if err != nil {
+			writeError(w, http.StatusNotFound, "not_found", "runtime profile not found")
+			return
+		}
+		if profile.WorkspaceID != nil {
+			if err := AuthorizeWorkspaceAction(r.Context(), authorizer, caller, *profile.WorkspaceID, ActionManageInfrastructure); err != nil {
+				writeAuthzError(w, err)
+				return
+			}
+		}
+
 		if err := svc.ArchiveRuntimeProfile(r.Context(), id); err != nil {
 			writeError(w, http.StatusNotFound, "not_found", "runtime profile not found")
 			return

--- a/backend/internal/api/infrastructure_manager.go
+++ b/backend/internal/api/infrastructure_manager.go
@@ -1,0 +1,283 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+type InfrastructureRepository interface {
+	// Runtime Profiles
+	CreateRuntimeProfile(ctx context.Context, p repository.CreateRuntimeProfileParams) (repository.RuntimeProfileRow, error)
+	GetRuntimeProfileByID(ctx context.Context, id uuid.UUID) (repository.RuntimeProfileRow, error)
+	ListRuntimeProfilesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]repository.RuntimeProfileRow, error)
+	ArchiveRuntimeProfile(ctx context.Context, id uuid.UUID) error
+
+	// Provider Accounts
+	CreateProviderAccount(ctx context.Context, p repository.CreateProviderAccountParams) (repository.ProviderAccountRow, error)
+	GetProviderAccountByID(ctx context.Context, id uuid.UUID) (repository.ProviderAccountRow, error)
+	ListProviderAccountsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]repository.ProviderAccountRow, error)
+
+	// Model Catalog
+	ListModelCatalogEntries(ctx context.Context) ([]repository.ModelCatalogEntryRow, error)
+	GetModelCatalogEntryByID(ctx context.Context, id uuid.UUID) (repository.ModelCatalogEntryRow, error)
+
+	// Model Aliases
+	CreateModelAlias(ctx context.Context, p repository.CreateModelAliasParams) (repository.ModelAliasRow, error)
+	GetModelAliasByID(ctx context.Context, id uuid.UUID) (repository.ModelAliasRow, error)
+	ListModelAliasesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]repository.ModelAliasRow, error)
+
+	// Tools
+	CreateTool(ctx context.Context, p repository.CreateToolParams) (repository.ToolRow, error)
+	GetToolByID(ctx context.Context, id uuid.UUID) (repository.ToolRow, error)
+	ListToolsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]repository.ToolRow, error)
+
+	// Knowledge Sources
+	CreateKnowledgeSource(ctx context.Context, p repository.CreateKnowledgeSourceParams) (repository.KnowledgeSourceRow, error)
+	GetKnowledgeSourceByID(ctx context.Context, id uuid.UUID) (repository.KnowledgeSourceRow, error)
+	ListKnowledgeSourcesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]repository.KnowledgeSourceRow, error)
+
+	// Routing Policies
+	CreateRoutingPolicy(ctx context.Context, p repository.CreateRoutingPolicyParams) (repository.RoutingPolicyRow, error)
+	ListRoutingPoliciesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]repository.RoutingPolicyRow, error)
+
+	// Spend Policies
+	CreateSpendPolicy(ctx context.Context, p repository.CreateSpendPolicyParams) (repository.SpendPolicyRow, error)
+	ListSpendPoliciesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]repository.SpendPolicyRow, error)
+
+	// Workspace lookup for org ID
+	GetOrganizationIDByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (uuid.UUID, error)
+}
+
+type InfrastructureManager struct {
+	repo InfrastructureRepository
+}
+
+func NewInfrastructureManager(repo InfrastructureRepository) *InfrastructureManager {
+	return &InfrastructureManager{repo: repo}
+}
+
+func (m *InfrastructureManager) resolveOrgID(ctx context.Context, workspaceID uuid.UUID) (uuid.UUID, error) {
+	return m.repo.GetOrganizationIDByWorkspaceID(ctx, workspaceID)
+}
+
+// --------------------------------------------------------------------------
+// Runtime Profiles
+// --------------------------------------------------------------------------
+
+func (m *InfrastructureManager) CreateRuntimeProfile(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateRuntimeProfileInput) (repository.RuntimeProfileRow, error) {
+	orgID, err := m.resolveOrgID(ctx, workspaceID)
+	if err != nil {
+		return repository.RuntimeProfileRow{}, fmt.Errorf("resolve org: %w", err)
+	}
+	slug := generateSlug(input.Name)
+	return m.repo.CreateRuntimeProfile(ctx, repository.CreateRuntimeProfileParams{
+		OrganizationID:     orgID,
+		WorkspaceID:        workspaceID,
+		Name:               input.Name,
+		Slug:               slug,
+		ExecutionTarget:    input.ExecutionTarget,
+		TraceMode:          input.TraceMode,
+		MaxIterations:      input.MaxIterations,
+		MaxToolCalls:       input.MaxToolCalls,
+		StepTimeoutSeconds: input.StepTimeoutSeconds,
+		RunTimeoutSeconds:  input.RunTimeoutSeconds,
+		ProfileConfig:      input.ProfileConfig,
+	})
+}
+
+func (m *InfrastructureManager) ListRuntimeProfiles(ctx context.Context, workspaceID uuid.UUID) ([]repository.RuntimeProfileRow, error) {
+	return m.repo.ListRuntimeProfilesByWorkspaceID(ctx, workspaceID)
+}
+
+func (m *InfrastructureManager) GetRuntimeProfile(ctx context.Context, id uuid.UUID) (repository.RuntimeProfileRow, error) {
+	return m.repo.GetRuntimeProfileByID(ctx, id)
+}
+
+func (m *InfrastructureManager) ArchiveRuntimeProfile(ctx context.Context, id uuid.UUID) error {
+	return m.repo.ArchiveRuntimeProfile(ctx, id)
+}
+
+// --------------------------------------------------------------------------
+// Provider Accounts
+// --------------------------------------------------------------------------
+
+func (m *InfrastructureManager) CreateProviderAccount(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateProviderAccountInput) (repository.ProviderAccountRow, error) {
+	orgID, err := m.resolveOrgID(ctx, workspaceID)
+	if err != nil {
+		return repository.ProviderAccountRow{}, fmt.Errorf("resolve org: %w", err)
+	}
+	return m.repo.CreateProviderAccount(ctx, repository.CreateProviderAccountParams{
+		OrganizationID:      orgID,
+		WorkspaceID:         workspaceID,
+		ProviderKey:         input.ProviderKey,
+		Name:                input.Name,
+		CredentialReference: input.CredentialReference,
+		LimitsConfig:        input.LimitsConfig,
+	})
+}
+
+func (m *InfrastructureManager) ListProviderAccounts(ctx context.Context, workspaceID uuid.UUID) ([]repository.ProviderAccountRow, error) {
+	return m.repo.ListProviderAccountsByWorkspaceID(ctx, workspaceID)
+}
+
+func (m *InfrastructureManager) GetProviderAccount(ctx context.Context, id uuid.UUID) (repository.ProviderAccountRow, error) {
+	return m.repo.GetProviderAccountByID(ctx, id)
+}
+
+// --------------------------------------------------------------------------
+// Model Catalog
+// --------------------------------------------------------------------------
+
+func (m *InfrastructureManager) ListModelCatalog(ctx context.Context) ([]repository.ModelCatalogEntryRow, error) {
+	return m.repo.ListModelCatalogEntries(ctx)
+}
+
+func (m *InfrastructureManager) GetModelCatalogEntry(ctx context.Context, id uuid.UUID) (repository.ModelCatalogEntryRow, error) {
+	return m.repo.GetModelCatalogEntryByID(ctx, id)
+}
+
+// --------------------------------------------------------------------------
+// Model Aliases
+// --------------------------------------------------------------------------
+
+func (m *InfrastructureManager) CreateModelAlias(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateModelAliasInput) (repository.ModelAliasRow, error) {
+	orgID, err := m.resolveOrgID(ctx, workspaceID)
+	if err != nil {
+		return repository.ModelAliasRow{}, fmt.Errorf("resolve org: %w", err)
+	}
+	catalogID, err := uuid.Parse(input.ModelCatalogEntryID)
+	if err != nil {
+		return repository.ModelAliasRow{}, fmt.Errorf("invalid model_catalog_entry_id: %w", err)
+	}
+	var providerAccountID *uuid.UUID
+	if input.ProviderAccountID != nil {
+		parsed, err := uuid.Parse(*input.ProviderAccountID)
+		if err != nil {
+			return repository.ModelAliasRow{}, fmt.Errorf("invalid provider_account_id: %w", err)
+		}
+		providerAccountID = &parsed
+	}
+	return m.repo.CreateModelAlias(ctx, repository.CreateModelAliasParams{
+		OrganizationID:      orgID,
+		WorkspaceID:         workspaceID,
+		ProviderAccountID:   providerAccountID,
+		ModelCatalogEntryID: catalogID,
+		AliasKey:            input.AliasKey,
+		DisplayName:         input.DisplayName,
+	})
+}
+
+func (m *InfrastructureManager) ListModelAliases(ctx context.Context, workspaceID uuid.UUID) ([]repository.ModelAliasRow, error) {
+	return m.repo.ListModelAliasesByWorkspaceID(ctx, workspaceID)
+}
+
+func (m *InfrastructureManager) GetModelAlias(ctx context.Context, id uuid.UUID) (repository.ModelAliasRow, error) {
+	return m.repo.GetModelAliasByID(ctx, id)
+}
+
+// --------------------------------------------------------------------------
+// Tools
+// --------------------------------------------------------------------------
+
+func (m *InfrastructureManager) CreateTool(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateToolInput) (repository.ToolRow, error) {
+	orgID, err := m.resolveOrgID(ctx, workspaceID)
+	if err != nil {
+		return repository.ToolRow{}, fmt.Errorf("resolve org: %w", err)
+	}
+	slug := generateSlug(input.Name)
+	return m.repo.CreateTool(ctx, repository.CreateToolParams{
+		OrganizationID: orgID,
+		WorkspaceID:    workspaceID,
+		Name:           input.Name,
+		Slug:           slug,
+		ToolKind:       input.ToolKind,
+		CapabilityKey:  input.CapabilityKey,
+		Definition:     input.Definition,
+	})
+}
+
+func (m *InfrastructureManager) ListTools(ctx context.Context, workspaceID uuid.UUID) ([]repository.ToolRow, error) {
+	return m.repo.ListToolsByWorkspaceID(ctx, workspaceID)
+}
+
+func (m *InfrastructureManager) GetTool(ctx context.Context, id uuid.UUID) (repository.ToolRow, error) {
+	return m.repo.GetToolByID(ctx, id)
+}
+
+// --------------------------------------------------------------------------
+// Knowledge Sources
+// --------------------------------------------------------------------------
+
+func (m *InfrastructureManager) CreateKnowledgeSource(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateKnowledgeSourceInput) (repository.KnowledgeSourceRow, error) {
+	orgID, err := m.resolveOrgID(ctx, workspaceID)
+	if err != nil {
+		return repository.KnowledgeSourceRow{}, fmt.Errorf("resolve org: %w", err)
+	}
+	slug := generateSlug(input.Name)
+	return m.repo.CreateKnowledgeSource(ctx, repository.CreateKnowledgeSourceParams{
+		OrganizationID:   orgID,
+		WorkspaceID:      workspaceID,
+		Name:             input.Name,
+		Slug:             slug,
+		SourceKind:       input.SourceKind,
+		ConnectionConfig: input.ConnectionConfig,
+	})
+}
+
+func (m *InfrastructureManager) ListKnowledgeSources(ctx context.Context, workspaceID uuid.UUID) ([]repository.KnowledgeSourceRow, error) {
+	return m.repo.ListKnowledgeSourcesByWorkspaceID(ctx, workspaceID)
+}
+
+func (m *InfrastructureManager) GetKnowledgeSource(ctx context.Context, id uuid.UUID) (repository.KnowledgeSourceRow, error) {
+	return m.repo.GetKnowledgeSourceByID(ctx, id)
+}
+
+// --------------------------------------------------------------------------
+// Routing Policies
+// --------------------------------------------------------------------------
+
+func (m *InfrastructureManager) CreateRoutingPolicy(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateRoutingPolicyInput) (repository.RoutingPolicyRow, error) {
+	orgID, err := m.resolveOrgID(ctx, workspaceID)
+	if err != nil {
+		return repository.RoutingPolicyRow{}, fmt.Errorf("resolve org: %w", err)
+	}
+	return m.repo.CreateRoutingPolicy(ctx, repository.CreateRoutingPolicyParams{
+		OrganizationID: orgID,
+		WorkspaceID:    workspaceID,
+		Name:           input.Name,
+		PolicyKind:     input.PolicyKind,
+		Config:         input.Config,
+	})
+}
+
+func (m *InfrastructureManager) ListRoutingPolicies(ctx context.Context, workspaceID uuid.UUID) ([]repository.RoutingPolicyRow, error) {
+	return m.repo.ListRoutingPoliciesByWorkspaceID(ctx, workspaceID)
+}
+
+// --------------------------------------------------------------------------
+// Spend Policies
+// --------------------------------------------------------------------------
+
+func (m *InfrastructureManager) CreateSpendPolicy(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateSpendPolicyInput) (repository.SpendPolicyRow, error) {
+	orgID, err := m.resolveOrgID(ctx, workspaceID)
+	if err != nil {
+		return repository.SpendPolicyRow{}, fmt.Errorf("resolve org: %w", err)
+	}
+	return m.repo.CreateSpendPolicy(ctx, repository.CreateSpendPolicyParams{
+		OrganizationID: orgID,
+		WorkspaceID:    workspaceID,
+		Name:           input.Name,
+		CurrencyCode:   input.CurrencyCode,
+		WindowKind:     input.WindowKind,
+		SoftLimit:      input.SoftLimit,
+		HardLimit:      input.HardLimit,
+		Config:         input.Config,
+	})
+}
+
+func (m *InfrastructureManager) ListSpendPolicies(ctx context.Context, workspaceID uuid.UUID) ([]repository.SpendPolicyRow, error) {
+	return m.repo.ListSpendPoliciesByWorkspaceID(ctx, workspaceID)
+}

--- a/backend/internal/api/infrastructure_test.go
+++ b/backend/internal/api/infrastructure_test.go
@@ -1,0 +1,229 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+// stubInfraService implements InfrastructureService for testing.
+type stubInfraService struct {
+	profiles []repository.RuntimeProfileRow
+}
+
+func (s stubInfraService) CreateRuntimeProfile(_ context.Context, _ Caller, _ uuid.UUID, _ CreateRuntimeProfileInput) (repository.RuntimeProfileRow, error) {
+	return repository.RuntimeProfileRow{ID: uuid.New(), Name: "test"}, nil
+}
+func (s stubInfraService) ListRuntimeProfiles(_ context.Context, _ uuid.UUID) ([]repository.RuntimeProfileRow, error) {
+	return s.profiles, nil
+}
+func (s stubInfraService) GetRuntimeProfile(_ context.Context, id uuid.UUID) (repository.RuntimeProfileRow, error) {
+	for _, p := range s.profiles {
+		if p.ID == id {
+			return p, nil
+		}
+	}
+	return repository.RuntimeProfileRow{}, repository.ErrRuntimeProfileNotFound
+}
+func (s stubInfraService) ArchiveRuntimeProfile(_ context.Context, _ uuid.UUID) error { return nil }
+func (s stubInfraService) CreateProviderAccount(_ context.Context, _ Caller, _ uuid.UUID, _ CreateProviderAccountInput) (repository.ProviderAccountRow, error) {
+	return repository.ProviderAccountRow{}, nil
+}
+func (s stubInfraService) ListProviderAccounts(_ context.Context, _ uuid.UUID) ([]repository.ProviderAccountRow, error) {
+	return nil, nil
+}
+func (s stubInfraService) GetProviderAccount(_ context.Context, _ uuid.UUID) (repository.ProviderAccountRow, error) {
+	return repository.ProviderAccountRow{}, repository.ErrProviderAccountNotFound
+}
+func (s stubInfraService) ListModelCatalog(_ context.Context) ([]repository.ModelCatalogEntryRow, error) {
+	return nil, nil
+}
+func (s stubInfraService) GetModelCatalogEntry(_ context.Context, _ uuid.UUID) (repository.ModelCatalogEntryRow, error) {
+	return repository.ModelCatalogEntryRow{}, nil
+}
+func (s stubInfraService) CreateModelAlias(_ context.Context, _ Caller, _ uuid.UUID, _ CreateModelAliasInput) (repository.ModelAliasRow, error) {
+	return repository.ModelAliasRow{}, nil
+}
+func (s stubInfraService) ListModelAliases(_ context.Context, _ uuid.UUID) ([]repository.ModelAliasRow, error) {
+	return nil, nil
+}
+func (s stubInfraService) GetModelAlias(_ context.Context, _ uuid.UUID) (repository.ModelAliasRow, error) {
+	return repository.ModelAliasRow{}, repository.ErrModelAliasNotFound
+}
+func (s stubInfraService) CreateTool(_ context.Context, _ Caller, _ uuid.UUID, _ CreateToolInput) (repository.ToolRow, error) {
+	return repository.ToolRow{}, nil
+}
+func (s stubInfraService) ListTools(_ context.Context, _ uuid.UUID) ([]repository.ToolRow, error) {
+	return nil, nil
+}
+func (s stubInfraService) GetTool(_ context.Context, _ uuid.UUID) (repository.ToolRow, error) {
+	return repository.ToolRow{}, repository.ErrToolNotFound
+}
+func (s stubInfraService) CreateKnowledgeSource(_ context.Context, _ Caller, _ uuid.UUID, _ CreateKnowledgeSourceInput) (repository.KnowledgeSourceRow, error) {
+	return repository.KnowledgeSourceRow{}, nil
+}
+func (s stubInfraService) ListKnowledgeSources(_ context.Context, _ uuid.UUID) ([]repository.KnowledgeSourceRow, error) {
+	return nil, nil
+}
+func (s stubInfraService) GetKnowledgeSource(_ context.Context, _ uuid.UUID) (repository.KnowledgeSourceRow, error) {
+	return repository.KnowledgeSourceRow{}, repository.ErrKnowledgeSourceNotFound
+}
+func (s stubInfraService) CreateRoutingPolicy(_ context.Context, _ Caller, _ uuid.UUID, _ CreateRoutingPolicyInput) (repository.RoutingPolicyRow, error) {
+	return repository.RoutingPolicyRow{}, nil
+}
+func (s stubInfraService) ListRoutingPolicies(_ context.Context, _ uuid.UUID) ([]repository.RoutingPolicyRow, error) {
+	return nil, nil
+}
+func (s stubInfraService) CreateSpendPolicy(_ context.Context, _ Caller, _ uuid.UUID, _ CreateSpendPolicyInput) (repository.SpendPolicyRow, error) {
+	return repository.SpendPolicyRow{}, nil
+}
+func (s stubInfraService) ListSpendPolicies(_ context.Context, _ uuid.UUID) ([]repository.SpendPolicyRow, error) {
+	return nil, nil
+}
+
+func TestGetRuntimeProfileAuthorizesWorkspace(t *testing.T) {
+	profileID := uuid.New()
+	workspaceID := uuid.New()
+	wsPtr := &workspaceID
+
+	svc := stubInfraService{
+		profiles: []repository.RuntimeProfileRow{
+			{ID: profileID, WorkspaceID: wsPtr, Name: "test", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+		},
+	}
+
+	router := newRouter("dev",
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		nil, 0,
+		stubRunCreationService{}, stubRunReadService{}, stubReplayReadService{},
+		stubHostedRunIngestionService{}, nil,
+		stubAgentDeploymentReadService{}, stubChallengePackReadService{},
+		stubAgentBuildService{}, noopReleaseGateService{},
+		nil, nil, nil, nil, nil, nil, nil,
+		svc,
+	)
+
+	// User without workspace membership should be denied
+	req := httptest.NewRequest(http.MethodGet, "/v1/runtime-profiles/"+profileID.String(), nil)
+	req.Header.Set(headerUserID, uuid.New().String())
+	req.Header.Set(headerWorkspaceMemberships, uuid.New().String()+":workspace_viewer")
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Errorf("expected 403 Forbidden for non-member, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestGetRuntimeProfileAllowsWorkspaceMember(t *testing.T) {
+	profileID := uuid.New()
+	workspaceID := uuid.New()
+	wsPtr := &workspaceID
+
+	svc := stubInfraService{
+		profiles: []repository.RuntimeProfileRow{
+			{ID: profileID, WorkspaceID: wsPtr, Name: "test", Slug: "test", ExecutionTarget: "native", TraceMode: "required", ProfileConfig: json.RawMessage(`{}`), CreatedAt: time.Now(), UpdatedAt: time.Now()},
+		},
+	}
+
+	router := newRouter("dev",
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		nil, 0,
+		stubRunCreationService{}, stubRunReadService{}, stubReplayReadService{},
+		stubHostedRunIngestionService{}, nil,
+		stubAgentDeploymentReadService{}, stubChallengePackReadService{},
+		stubAgentBuildService{}, noopReleaseGateService{},
+		nil, nil, nil, nil, nil, nil, nil,
+		svc,
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/runtime-profiles/"+profileID.String(), nil)
+	req.Header.Set(headerUserID, uuid.New().String())
+	req.Header.Set(headerWorkspaceMemberships, workspaceID.String()+":workspace_member")
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Errorf("expected 200 OK for workspace member, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestCreateRuntimeProfileRequiresAdminRole(t *testing.T) {
+	workspaceID := uuid.New()
+
+	svc := stubInfraService{}
+
+	router := newRouter("dev",
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		nil, 0,
+		stubRunCreationService{}, stubRunReadService{}, stubReplayReadService{},
+		stubHostedRunIngestionService{}, nil,
+		stubAgentDeploymentReadService{}, stubChallengePackReadService{},
+		stubAgentBuildService{}, noopReleaseGateService{},
+		nil, nil, nil, nil, nil, nil, nil,
+		svc,
+	)
+
+	body := `{"name":"test","execution_target":"native"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/workspaces/"+workspaceID.String()+"/runtime-profiles", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(headerUserID, uuid.New().String())
+	// workspace_viewer should be denied for create (ActionManageInfrastructure is admin-only)
+	req.Header.Set(headerWorkspaceMemberships, workspaceID.String()+":workspace_viewer")
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Errorf("expected 403 Forbidden for viewer creating resource, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestCreateRuntimeProfileValidatesInput(t *testing.T) {
+	workspaceID := uuid.New()
+
+	svc := stubInfraService{}
+
+	router := newRouter("dev",
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		nil, 0,
+		stubRunCreationService{}, stubRunReadService{}, stubReplayReadService{},
+		stubHostedRunIngestionService{}, nil,
+		stubAgentDeploymentReadService{}, stubChallengePackReadService{},
+		stubAgentBuildService{}, noopReleaseGateService{},
+		nil, nil, nil, nil, nil, nil, nil,
+		svc,
+	)
+
+	// Missing execution_target
+	body := `{"name":"test"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/workspaces/"+workspaceID.String()+"/runtime-profiles", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(headerUserID, uuid.New().String())
+	req.Header.Set(headerWorkspaceMemberships, workspaceID.String()+":workspace_admin")
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing required field, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+}

--- a/backend/internal/api/release_gates_test.go
+++ b/backend/internal/api/release_gates_test.go
@@ -162,6 +162,8 @@ func TestEvaluateReleaseGateEndpointReturnsJSONPayload(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -231,6 +233,8 @@ func TestListReleaseGatesEndpointReturnsJSONPayload(t *testing.T) {
 				},
 			},
 		},
+		nil,
+		nil,
 		nil,
 		nil,
 		nil,

--- a/backend/internal/api/replay_reads_test.go
+++ b/backend/internal/api/replay_reads_test.go
@@ -214,6 +214,8 @@ func TestGetRunAgentReplayEndpointReturnsPaginatedReplay(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -283,6 +285,8 @@ func TestGetRunAgentReplayEndpointReturnsPendingState(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusAccepted {
@@ -343,6 +347,8 @@ func TestGetRunAgentReplayEndpointReturnsErroredState(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusConflict {
@@ -373,6 +379,8 @@ func TestGetRunAgentReplayEndpointReturnsNotFoundWhenRunAgentMissing(t *testing.
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
 		nil,
 		nil,
 		nil,
@@ -414,6 +422,8 @@ func TestGetRunAgentReplayEndpointReturnsForbidden(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusForbidden {
@@ -443,6 +453,8 @@ func TestGetRunAgentReplayEndpointRejectsMalformedRunAgentID(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
 		nil,
 		nil,
 		nil,
@@ -479,6 +491,8 @@ func TestGetRunAgentReplayEndpointRejectsMalformedPagination(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
 		nil,
 		nil,
 		nil,
@@ -539,6 +553,8 @@ func TestGetRunAgentScorecardEndpointReturnsScorecard(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -588,6 +604,8 @@ func TestGetRunAgentScorecardEndpointReturnsForbidden(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusForbidden {
@@ -627,6 +645,8 @@ func TestGetRunAgentScorecardEndpointReturnsPendingWhenScorecardIsPending(t *tes
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
 		nil,
 		nil,
 		nil,
@@ -686,6 +706,8 @@ func TestGetRunAgentScorecardEndpointReturnsConflictWhenScorecardIsMissingAfterT
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusConflict {
@@ -716,6 +738,8 @@ func TestGetRunAgentScorecardEndpointReturnsNotFoundWhenRunAgentMissing(t *testi
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
 		nil,
 		nil,
 		nil,

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -29,6 +29,7 @@ func registerProtectedRoutes(
 	orgMembershipService OrgMembershipService,
 	wsMembershipService WorkspaceMembershipService,
 	onboardingService OnboardingService,
+	infraService InfrastructureService,
 ) {
 	router.Get("/auth/session", sessionHandler)
 	router.Get("/users/me", getUserMeHandler(logger, userService))
@@ -99,6 +100,52 @@ func registerProtectedRoutes(
 
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Post("/workspaces/{workspaceID}/agent-deployments", createAgentDeploymentHandler(logger, agentBuildService, authorizer))
+
+	// Infrastructure CRUD — workspace-scoped create/list (skip if no service provided)
+	if infraService == nil {
+		return
+	}
+	wsMiddleware := func(next http.HandlerFunc) http.Handler {
+		return authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))(next)
+	}
+
+	// Runtime Profiles
+	router.Method("POST", "/workspaces/{workspaceID}/runtime-profiles", wsMiddleware(infraCreateHandler(logger, infraService.CreateRuntimeProfile, mapRuntimeProfile)))
+	router.Method("GET", "/workspaces/{workspaceID}/runtime-profiles", wsMiddleware(infraListHandler(logger, infraService.ListRuntimeProfiles, mapRuntimeProfile)))
+	router.Get("/runtime-profiles/{profileID}", infraGetHandler(logger, "profileID", infraService.GetRuntimeProfile, mapRuntimeProfile, "runtime profile"))
+	router.Post("/runtime-profiles/{profileID}/archive", archiveRuntimeProfileHandler(logger, infraService))
+
+	// Provider Accounts
+	router.Method("POST", "/workspaces/{workspaceID}/provider-accounts", wsMiddleware(infraCreateHandler(logger, infraService.CreateProviderAccount, mapProviderAccount)))
+	router.Method("GET", "/workspaces/{workspaceID}/provider-accounts", wsMiddleware(infraListHandler(logger, infraService.ListProviderAccounts, mapProviderAccount)))
+	router.Get("/provider-accounts/{accountID}", infraGetHandler(logger, "accountID", infraService.GetProviderAccount, mapProviderAccount, "provider account"))
+
+	// Model Catalog (global, no workspace scope)
+	router.Get("/model-catalog", listModelCatalogHandler(logger, infraService))
+	router.Get("/model-catalog/{entryID}", getModelCatalogEntryHandler(logger, infraService))
+
+	// Model Aliases
+	router.Method("POST", "/workspaces/{workspaceID}/model-aliases", wsMiddleware(infraCreateHandler(logger, infraService.CreateModelAlias, mapModelAlias)))
+	router.Method("GET", "/workspaces/{workspaceID}/model-aliases", wsMiddleware(infraListHandler(logger, infraService.ListModelAliases, mapModelAlias)))
+	router.Get("/model-aliases/{aliasID}", infraGetHandler(logger, "aliasID", infraService.GetModelAlias, mapModelAlias, "model alias"))
+
+	// Tools
+	router.Method("POST", "/workspaces/{workspaceID}/tools", wsMiddleware(infraCreateHandler(logger, infraService.CreateTool, mapTool)))
+	router.Method("GET", "/workspaces/{workspaceID}/tools", wsMiddleware(infraListHandler(logger, infraService.ListTools, mapTool)))
+	router.Get("/tools/{toolID}", infraGetHandler(logger, "toolID", infraService.GetTool, mapTool, "tool"))
+
+	// Knowledge Sources
+	router.Method("POST", "/workspaces/{workspaceID}/knowledge-sources", wsMiddleware(infraCreateHandler(logger, infraService.CreateKnowledgeSource, mapKnowledgeSource)))
+	router.Method("GET", "/workspaces/{workspaceID}/knowledge-sources", wsMiddleware(infraListHandler(logger, infraService.ListKnowledgeSources, mapKnowledgeSource)))
+	router.Get("/knowledge-sources/{sourceID}", infraGetHandler(logger, "sourceID", infraService.GetKnowledgeSource, mapKnowledgeSource, "knowledge source"))
+
+	// Routing Policies
+	router.Method("POST", "/workspaces/{workspaceID}/routing-policies", wsMiddleware(infraCreateHandler(logger, infraService.CreateRoutingPolicy, mapRoutingPolicy)))
+	router.Method("GET", "/workspaces/{workspaceID}/routing-policies", wsMiddleware(infraListHandler(logger, infraService.ListRoutingPolicies, mapRoutingPolicy)))
+
+	// Spend Policies
+	router.Method("POST", "/workspaces/{workspaceID}/spend-policies", wsMiddleware(infraCreateHandler(logger, infraService.CreateSpendPolicy, mapSpendPolicy)))
+	router.Method("GET", "/workspaces/{workspaceID}/spend-policies", wsMiddleware(infraListHandler(logger, infraService.ListSpendPolicies, mapSpendPolicy)))
 }
 
 func registerPublicRoutes(router chi.Router, logger *slog.Logger, artifactService ArtifactService) {

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -110,41 +110,41 @@ func registerProtectedRoutes(
 	}
 
 	// Runtime Profiles
-	router.Method("POST", "/workspaces/{workspaceID}/runtime-profiles", wsMiddleware(infraCreateHandler(logger, infraService.CreateRuntimeProfile, mapRuntimeProfile)))
+	router.Method("POST", "/workspaces/{workspaceID}/runtime-profiles", wsMiddleware(infraCreateHandler(logger, authorizer, infraService.CreateRuntimeProfile, mapRuntimeProfile)))
 	router.Method("GET", "/workspaces/{workspaceID}/runtime-profiles", wsMiddleware(infraListHandler(logger, infraService.ListRuntimeProfiles, mapRuntimeProfile)))
-	router.Get("/runtime-profiles/{profileID}", infraGetHandler(logger, "profileID", infraService.GetRuntimeProfile, mapRuntimeProfile, "runtime profile"))
-	router.Post("/runtime-profiles/{profileID}/archive", archiveRuntimeProfileHandler(logger, infraService))
+	router.Get("/runtime-profiles/{profileID}", infraGetHandler(logger, authorizer, "profileID", infraService.GetRuntimeProfile, mapRuntimeProfile, "runtime profile"))
+	router.Post("/runtime-profiles/{profileID}/archive", archiveRuntimeProfileHandler(logger, infraService, authorizer))
 
 	// Provider Accounts
-	router.Method("POST", "/workspaces/{workspaceID}/provider-accounts", wsMiddleware(infraCreateHandler(logger, infraService.CreateProviderAccount, mapProviderAccount)))
+	router.Method("POST", "/workspaces/{workspaceID}/provider-accounts", wsMiddleware(infraCreateHandler(logger, authorizer, infraService.CreateProviderAccount, mapProviderAccount)))
 	router.Method("GET", "/workspaces/{workspaceID}/provider-accounts", wsMiddleware(infraListHandler(logger, infraService.ListProviderAccounts, mapProviderAccount)))
-	router.Get("/provider-accounts/{accountID}", infraGetHandler(logger, "accountID", infraService.GetProviderAccount, mapProviderAccount, "provider account"))
+	router.Get("/provider-accounts/{accountID}", infraGetHandler(logger, authorizer, "accountID", infraService.GetProviderAccount, mapProviderAccount, "provider account"))
 
 	// Model Catalog (global, no workspace scope)
 	router.Get("/model-catalog", listModelCatalogHandler(logger, infraService))
 	router.Get("/model-catalog/{entryID}", getModelCatalogEntryHandler(logger, infraService))
 
 	// Model Aliases
-	router.Method("POST", "/workspaces/{workspaceID}/model-aliases", wsMiddleware(infraCreateHandler(logger, infraService.CreateModelAlias, mapModelAlias)))
+	router.Method("POST", "/workspaces/{workspaceID}/model-aliases", wsMiddleware(infraCreateHandler(logger, authorizer, infraService.CreateModelAlias, mapModelAlias)))
 	router.Method("GET", "/workspaces/{workspaceID}/model-aliases", wsMiddleware(infraListHandler(logger, infraService.ListModelAliases, mapModelAlias)))
-	router.Get("/model-aliases/{aliasID}", infraGetHandler(logger, "aliasID", infraService.GetModelAlias, mapModelAlias, "model alias"))
+	router.Get("/model-aliases/{aliasID}", infraGetHandler(logger, authorizer, "aliasID", infraService.GetModelAlias, mapModelAlias, "model alias"))
 
 	// Tools
-	router.Method("POST", "/workspaces/{workspaceID}/tools", wsMiddleware(infraCreateHandler(logger, infraService.CreateTool, mapTool)))
+	router.Method("POST", "/workspaces/{workspaceID}/tools", wsMiddleware(infraCreateHandler(logger, authorizer, infraService.CreateTool, mapTool)))
 	router.Method("GET", "/workspaces/{workspaceID}/tools", wsMiddleware(infraListHandler(logger, infraService.ListTools, mapTool)))
-	router.Get("/tools/{toolID}", infraGetHandler(logger, "toolID", infraService.GetTool, mapTool, "tool"))
+	router.Get("/tools/{toolID}", infraGetHandler(logger, authorizer, "toolID", infraService.GetTool, mapTool, "tool"))
 
 	// Knowledge Sources
-	router.Method("POST", "/workspaces/{workspaceID}/knowledge-sources", wsMiddleware(infraCreateHandler(logger, infraService.CreateKnowledgeSource, mapKnowledgeSource)))
+	router.Method("POST", "/workspaces/{workspaceID}/knowledge-sources", wsMiddleware(infraCreateHandler(logger, authorizer, infraService.CreateKnowledgeSource, mapKnowledgeSource)))
 	router.Method("GET", "/workspaces/{workspaceID}/knowledge-sources", wsMiddleware(infraListHandler(logger, infraService.ListKnowledgeSources, mapKnowledgeSource)))
-	router.Get("/knowledge-sources/{sourceID}", infraGetHandler(logger, "sourceID", infraService.GetKnowledgeSource, mapKnowledgeSource, "knowledge source"))
+	router.Get("/knowledge-sources/{sourceID}", infraGetHandler(logger, authorizer, "sourceID", infraService.GetKnowledgeSource, mapKnowledgeSource, "knowledge source"))
 
 	// Routing Policies
-	router.Method("POST", "/workspaces/{workspaceID}/routing-policies", wsMiddleware(infraCreateHandler(logger, infraService.CreateRoutingPolicy, mapRoutingPolicy)))
+	router.Method("POST", "/workspaces/{workspaceID}/routing-policies", wsMiddleware(infraCreateHandler(logger, authorizer, infraService.CreateRoutingPolicy, mapRoutingPolicy)))
 	router.Method("GET", "/workspaces/{workspaceID}/routing-policies", wsMiddleware(infraListHandler(logger, infraService.ListRoutingPolicies, mapRoutingPolicy)))
 
 	// Spend Policies
-	router.Method("POST", "/workspaces/{workspaceID}/spend-policies", wsMiddleware(infraCreateHandler(logger, infraService.CreateSpendPolicy, mapSpendPolicy)))
+	router.Method("POST", "/workspaces/{workspaceID}/spend-policies", wsMiddleware(infraCreateHandler(logger, authorizer, infraService.CreateSpendPolicy, mapSpendPolicy)))
 	router.Method("GET", "/workspaces/{workspaceID}/spend-policies", wsMiddleware(infraListHandler(logger, infraService.ListSpendPolicies, mapSpendPolicy)))
 }
 

--- a/backend/internal/api/run_ranking_test.go
+++ b/backend/internal/api/run_ranking_test.go
@@ -478,6 +478,8 @@ func TestGetRunRankingEndpointReturnsSortedPayload(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -523,6 +525,8 @@ func TestGetRunRankingEndpointRejectsInvalidSortField(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
 		nil,
 		nil,
 		nil,
@@ -577,6 +581,8 @@ func TestGetRunRankingEndpointReturnsCompositeSortPayload(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
 		nil,
 		nil,
 		nil,
@@ -639,6 +645,8 @@ func TestGetRunRankingEndpointReturnsAcceptedWhenPending(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusAccepted {
@@ -675,6 +683,8 @@ func TestGetRunRankingEndpointReturnsConflictWhenErrored(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
 		nil,
 		nil,
 		nil,

--- a/backend/internal/api/run_reads_test.go
+++ b/backend/internal/api/run_reads_test.go
@@ -142,6 +142,8 @@ func TestGetRunEndpointReturnsRun(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -190,6 +192,8 @@ func TestGetRunEndpointReturnsNotFound(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusNotFound {
@@ -219,6 +223,8 @@ func TestGetRunEndpointRejectsMalformedRunID(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
 		nil,
 		nil,
 		nil,
@@ -275,6 +281,8 @@ func TestListRunAgentsEndpointReturnsOrderedItems(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -317,6 +325,8 @@ func TestListRunAgentsEndpointReturnsForbidden(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
 		nil,
 		nil,
 		nil,

--- a/backend/internal/api/runs_test.go
+++ b/backend/internal/api/runs_test.go
@@ -63,6 +63,8 @@ func TestCreateRunEndpointReturnsCreated(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusCreated {
@@ -107,6 +109,8 @@ func TestCreateRunEndpointRejectsInvalidPayload(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
 		nil,
 		nil,
 		nil,
@@ -166,6 +170,8 @@ func TestCreateRunEndpointReturnsQueuedRunOnWorkflowStartFailure(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusBadGateway {
@@ -217,6 +223,8 @@ func TestCreateRunEndpointRejectsNonJSONContentType(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusUnsupportedMediaType {
@@ -253,6 +261,8 @@ func TestCreateRunEndpointRejectsOversizedRequestBody(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
 		nil,
 		nil,
 		nil,

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -38,8 +38,9 @@ func NewServer(
 	orgMembershipService OrgMembershipService,
 	wsMembershipService WorkspaceMembershipService,
 	onboardingService OnboardingService,
+	infraService InfrastructureService,
 ) *Server {
-	router := newRouter(cfg.AuthMode, logger, authenticator, authorizer, artifactService, cfg.ArtifactMaxUploadBytes, runCreationService, runReadService, replayReadService, hostedRunIngestionService, compareReadService, agentDeploymentReadService, challengePackReadService, agentBuildService, releaseGateService, challengePackAuthoringService, userService, orgService, wsService, orgMembershipService, wsMembershipService, onboardingService)
+	router := newRouter(cfg.AuthMode, logger, authenticator, authorizer, artifactService, cfg.ArtifactMaxUploadBytes, runCreationService, runReadService, replayReadService, hostedRunIngestionService, compareReadService, agentDeploymentReadService, challengePackReadService, agentBuildService, releaseGateService, challengePackAuthoringService, userService, orgService, wsService, orgMembershipService, wsMembershipService, onboardingService, infraService)
 
 	return &Server{
 		config: cfg,
@@ -108,7 +109,8 @@ func newRouter(
 	wsServiceArg WorkspaceService,
 	orgMembershipServiceArg OrgMembershipService,
 	wsMembershipServiceArg WorkspaceMembershipService,
-	extra ...OnboardingService,
+	onboardingServiceArg OnboardingService,
+	infraServiceArg InfrastructureService,
 ) http.Handler {
 	challengePackAuthoringService := challengePackAuthoringServiceArg
 	userService := userServiceArg
@@ -116,10 +118,8 @@ func newRouter(
 	wsService := wsServiceArg
 	orgMembershipService := orgMembershipServiceArg
 	wsMembershipService := wsMembershipServiceArg
-	var onboardingService OnboardingService
-	if len(extra) > 0 {
-		onboardingService = extra[0]
-	}
+	onboardingService := onboardingServiceArg
+	infraService := infraServiceArg
 
 	if hostedRunIngestionService == nil {
 		hostedRunIngestionService = noopHostedRunIngestionService{}
@@ -147,7 +147,7 @@ func newRouter(
 	registerHostedIntegrationRoutes(router, logger, hostedRunIngestionService)
 	router.Route("/v1", func(r chi.Router) {
 		r.Use(authenticateRequest(logger, authenticator))
-		registerProtectedRoutes(r, logger, authorizer, artifactService, artifactMaxUploadBytes, runCreationService, runReadService, replayReadService, compareReadService, releaseGateService, agentDeploymentReadService, challengePackReadService, challengePackAuthoringService, agentBuildService, userService, orgService, wsService, orgMembershipService, wsMembershipService, onboardingService)
+		registerProtectedRoutes(r, logger, authorizer, artifactService, artifactMaxUploadBytes, runCreationService, runReadService, replayReadService, compareReadService, releaseGateService, agentDeploymentReadService, challengePackReadService, challengePackAuthoringService, agentBuildService, userService, orgService, wsService, orgMembershipService, wsMembershipService, onboardingService, infraService)
 	})
 
 	return router

--- a/backend/internal/api/server_test.go
+++ b/backend/internal/api/server_test.go
@@ -85,6 +85,8 @@ func TestHealthzReturnsJSONSuccessPayload(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -157,6 +159,8 @@ func TestSessionEndpointRequiresAuthentication(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusUnauthorized {
@@ -199,6 +203,8 @@ func TestSessionEndpointReturnsCallerIdentity(t *testing.T) {
 		stubAgentBuildService{},
 		noopReleaseGateService{},
 		stubChallengePackAuthoringService{},
+		nil,
+		nil,
 		nil,
 		nil,
 		nil,
@@ -254,6 +260,8 @@ func TestWorkspaceAuthorizationReturnsForbiddenWithoutMembership(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusForbidden {
@@ -293,6 +301,8 @@ func TestWorkspaceAuthorizationReturnsOKWithMembership(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
 		nil,
 		nil,
 		nil,
@@ -345,6 +355,8 @@ func TestWorkspaceAuthorizationRejectsMalformedWorkspaceID(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusBadRequest {
@@ -391,6 +403,8 @@ func TestReplayViewerEndpointReturnsHTMLShell(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -431,6 +445,8 @@ func TestReplayViewerEndpointRejectsInvalidReplayPagination(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
+		nil,
 		nil,
 		nil,
 		nil,

--- a/backend/internal/repository/infrastructure.go
+++ b/backend/internal/repository/infrastructure.go
@@ -1,0 +1,809 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// Sentinel errors for infrastructure resources.
+var (
+	ErrRuntimeProfileNotFound  = errors.New("runtime profile not found")
+	ErrProviderAccountNotFound = errors.New("provider account not found")
+	ErrModelAliasNotFound      = errors.New("model alias not found")
+	ErrModelCatalogNotFound    = errors.New("model catalog entry not found")
+	ErrToolNotFound            = errors.New("tool not found")
+	ErrKnowledgeSourceNotFound = errors.New("knowledge source not found")
+	ErrRoutingPolicyNotFound   = errors.New("routing policy not found")
+	ErrSpendPolicyNotFound     = errors.New("spend policy not found")
+)
+
+// --------------------------------------------------------------------------
+// Runtime Profiles
+// --------------------------------------------------------------------------
+
+type RuntimeProfileRow struct {
+	ID                 uuid.UUID
+	OrganizationID     uuid.UUID
+	WorkspaceID        *uuid.UUID
+	Name               string
+	Slug               string
+	ExecutionTarget    string
+	TraceMode          string
+	MaxIterations      int32
+	MaxToolCalls       int32
+	StepTimeoutSeconds int32
+	RunTimeoutSeconds  int32
+	ProfileConfig      json.RawMessage
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+}
+
+type CreateRuntimeProfileParams struct {
+	OrganizationID     uuid.UUID
+	WorkspaceID        uuid.UUID
+	Name               string
+	Slug               string
+	ExecutionTarget    string
+	TraceMode          string
+	MaxIterations      int32
+	MaxToolCalls       int32
+	StepTimeoutSeconds int32
+	RunTimeoutSeconds  int32
+	ProfileConfig      json.RawMessage
+}
+
+func (r *Repository) CreateRuntimeProfile(ctx context.Context, p CreateRuntimeProfileParams) (RuntimeProfileRow, error) {
+	var row RuntimeProfileRow
+	var createdAt, updatedAt pgtype.Timestamptz
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO runtime_profiles (organization_id, workspace_id, name, slug, execution_target, trace_mode,
+			max_iterations, max_tool_calls, step_timeout_seconds, run_timeout_seconds, profile_config)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		RETURNING id, organization_id, workspace_id, name, slug, execution_target, trace_mode,
+			max_iterations, max_tool_calls, step_timeout_seconds, run_timeout_seconds, profile_config, created_at, updated_at
+	`, p.OrganizationID, p.WorkspaceID, p.Name, p.Slug, p.ExecutionTarget,
+		defaultStr(p.TraceMode, "required"),
+		defaultInt32(p.MaxIterations, 1),
+		defaultInt32(p.MaxToolCalls, 0),
+		defaultInt32(p.StepTimeoutSeconds, 60),
+		defaultInt32(p.RunTimeoutSeconds, 300),
+		defaultRawJSON(p.ProfileConfig),
+	).Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.Name, &row.Slug, &row.ExecutionTarget,
+		&row.TraceMode, &row.MaxIterations, &row.MaxToolCalls, &row.StepTimeoutSeconds, &row.RunTimeoutSeconds,
+		&row.ProfileConfig, &createdAt, &updatedAt)
+	if err != nil {
+		if isDuplicateSlug(err) {
+			return RuntimeProfileRow{}, ErrSlugTaken
+		}
+		return RuntimeProfileRow{}, fmt.Errorf("create runtime profile: %w", err)
+	}
+	row.CreatedAt = createdAt.Time
+	row.UpdatedAt = updatedAt.Time
+	return row, nil
+}
+
+func (r *Repository) GetRuntimeProfileByID(ctx context.Context, id uuid.UUID) (RuntimeProfileRow, error) {
+	var row RuntimeProfileRow
+	var createdAt, updatedAt pgtype.Timestamptz
+	err := r.db.QueryRow(ctx, `
+		SELECT id, organization_id, workspace_id, name, slug, execution_target, trace_mode,
+			max_iterations, max_tool_calls, step_timeout_seconds, run_timeout_seconds, profile_config, created_at, updated_at
+		FROM runtime_profiles WHERE id = $1 AND archived_at IS NULL
+	`, id).Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.Name, &row.Slug, &row.ExecutionTarget,
+		&row.TraceMode, &row.MaxIterations, &row.MaxToolCalls, &row.StepTimeoutSeconds, &row.RunTimeoutSeconds,
+		&row.ProfileConfig, &createdAt, &updatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return RuntimeProfileRow{}, ErrRuntimeProfileNotFound
+		}
+		return RuntimeProfileRow{}, fmt.Errorf("get runtime profile: %w", err)
+	}
+	row.CreatedAt = createdAt.Time
+	row.UpdatedAt = updatedAt.Time
+	return row, nil
+}
+
+func (r *Repository) ListRuntimeProfilesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]RuntimeProfileRow, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, organization_id, workspace_id, name, slug, execution_target, trace_mode,
+			max_iterations, max_tool_calls, step_timeout_seconds, run_timeout_seconds, profile_config, created_at, updated_at
+		FROM runtime_profiles
+		WHERE workspace_id = $1 AND archived_at IS NULL
+		ORDER BY name
+	`, workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("list runtime profiles: %w", err)
+	}
+	defer rows.Close()
+	return scanRuntimeProfiles(rows)
+}
+
+func (r *Repository) ArchiveRuntimeProfile(ctx context.Context, id uuid.UUID) error {
+	tag, err := r.db.Exec(ctx, `UPDATE runtime_profiles SET archived_at = now() WHERE id = $1 AND archived_at IS NULL`, id)
+	if err != nil {
+		return fmt.Errorf("archive runtime profile: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrRuntimeProfileNotFound
+	}
+	return nil
+}
+
+func scanRuntimeProfiles(rows pgx.Rows) ([]RuntimeProfileRow, error) {
+	var result []RuntimeProfileRow
+	for rows.Next() {
+		var row RuntimeProfileRow
+		var createdAt, updatedAt pgtype.Timestamptz
+		if err := rows.Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.Name, &row.Slug, &row.ExecutionTarget,
+			&row.TraceMode, &row.MaxIterations, &row.MaxToolCalls, &row.StepTimeoutSeconds, &row.RunTimeoutSeconds,
+			&row.ProfileConfig, &createdAt, &updatedAt); err != nil {
+			return nil, fmt.Errorf("scan runtime profile: %w", err)
+		}
+		row.CreatedAt = createdAt.Time
+		row.UpdatedAt = updatedAt.Time
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate runtime profiles: %w", err)
+	}
+	if result == nil {
+		result = []RuntimeProfileRow{}
+	}
+	return result, nil
+}
+
+// --------------------------------------------------------------------------
+// Provider Accounts
+// --------------------------------------------------------------------------
+
+type ProviderAccountRow struct {
+	ID                  uuid.UUID
+	OrganizationID      uuid.UUID
+	WorkspaceID         *uuid.UUID
+	ProviderKey         string
+	Name                string
+	CredentialReference string
+	Status              string
+	LimitsConfig        json.RawMessage
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+type CreateProviderAccountParams struct {
+	OrganizationID      uuid.UUID
+	WorkspaceID         uuid.UUID
+	ProviderKey         string
+	Name                string
+	CredentialReference string
+	LimitsConfig        json.RawMessage
+}
+
+func (r *Repository) CreateProviderAccount(ctx context.Context, p CreateProviderAccountParams) (ProviderAccountRow, error) {
+	var row ProviderAccountRow
+	var createdAt, updatedAt pgtype.Timestamptz
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO provider_accounts (organization_id, workspace_id, provider_key, name, credential_reference, limits_config)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id, organization_id, workspace_id, provider_key, name, credential_reference, status, limits_config, created_at, updated_at
+	`, p.OrganizationID, p.WorkspaceID, p.ProviderKey, p.Name, p.CredentialReference, defaultRawJSON(p.LimitsConfig),
+	).Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.ProviderKey, &row.Name, &row.CredentialReference,
+		&row.Status, &row.LimitsConfig, &createdAt, &updatedAt)
+	if err != nil {
+		return ProviderAccountRow{}, fmt.Errorf("create provider account: %w", err)
+	}
+	row.CreatedAt = createdAt.Time
+	row.UpdatedAt = updatedAt.Time
+	return row, nil
+}
+
+func (r *Repository) GetProviderAccountByID(ctx context.Context, id uuid.UUID) (ProviderAccountRow, error) {
+	var row ProviderAccountRow
+	var createdAt, updatedAt pgtype.Timestamptz
+	err := r.db.QueryRow(ctx, `
+		SELECT id, organization_id, workspace_id, provider_key, name, credential_reference, status, limits_config, created_at, updated_at
+		FROM provider_accounts WHERE id = $1 AND archived_at IS NULL
+	`, id).Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.ProviderKey, &row.Name, &row.CredentialReference,
+		&row.Status, &row.LimitsConfig, &createdAt, &updatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ProviderAccountRow{}, ErrProviderAccountNotFound
+		}
+		return ProviderAccountRow{}, fmt.Errorf("get provider account: %w", err)
+	}
+	row.CreatedAt = createdAt.Time
+	row.UpdatedAt = updatedAt.Time
+	return row, nil
+}
+
+func (r *Repository) ListProviderAccountsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]ProviderAccountRow, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, organization_id, workspace_id, provider_key, name, credential_reference, status, limits_config, created_at, updated_at
+		FROM provider_accounts
+		WHERE workspace_id = $1 AND archived_at IS NULL
+		ORDER BY name
+	`, workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("list provider accounts: %w", err)
+	}
+	defer rows.Close()
+
+	var result []ProviderAccountRow
+	for rows.Next() {
+		var row ProviderAccountRow
+		var createdAt, updatedAt pgtype.Timestamptz
+		if err := rows.Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.ProviderKey, &row.Name, &row.CredentialReference,
+			&row.Status, &row.LimitsConfig, &createdAt, &updatedAt); err != nil {
+			return nil, fmt.Errorf("scan provider account: %w", err)
+		}
+		row.CreatedAt = createdAt.Time
+		row.UpdatedAt = updatedAt.Time
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate provider accounts: %w", err)
+	}
+	if result == nil {
+		result = []ProviderAccountRow{}
+	}
+	return result, nil
+}
+
+// --------------------------------------------------------------------------
+// Model Catalog Entries (global, read-only)
+// --------------------------------------------------------------------------
+
+type ModelCatalogEntryRow struct {
+	ID              uuid.UUID
+	ProviderKey     string
+	ProviderModelID string
+	DisplayName     string
+	ModelFamily     string
+	Modality        string
+	LifecycleStatus string
+	Metadata        json.RawMessage
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+func (r *Repository) GetModelCatalogEntryByID(ctx context.Context, id uuid.UUID) (ModelCatalogEntryRow, error) {
+	var row ModelCatalogEntryRow
+	var createdAt, updatedAt pgtype.Timestamptz
+	err := r.db.QueryRow(ctx, `
+		SELECT id, provider_key, provider_model_id, display_name, model_family, modality, lifecycle_status, metadata, created_at, updated_at
+		FROM model_catalog_entries WHERE id = $1
+	`, id).Scan(&row.ID, &row.ProviderKey, &row.ProviderModelID, &row.DisplayName, &row.ModelFamily,
+		&row.Modality, &row.LifecycleStatus, &row.Metadata, &createdAt, &updatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ModelCatalogEntryRow{}, ErrModelCatalogNotFound
+		}
+		return ModelCatalogEntryRow{}, fmt.Errorf("get model catalog entry: %w", err)
+	}
+	row.CreatedAt = createdAt.Time
+	row.UpdatedAt = updatedAt.Time
+	return row, nil
+}
+
+func (r *Repository) ListModelCatalogEntries(ctx context.Context) ([]ModelCatalogEntryRow, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, provider_key, provider_model_id, display_name, model_family, modality, lifecycle_status, metadata, created_at, updated_at
+		FROM model_catalog_entries
+		WHERE lifecycle_status != 'archived'
+		ORDER BY provider_key, display_name
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list model catalog entries: %w", err)
+	}
+	defer rows.Close()
+
+	var result []ModelCatalogEntryRow
+	for rows.Next() {
+		var row ModelCatalogEntryRow
+		var createdAt, updatedAt pgtype.Timestamptz
+		if err := rows.Scan(&row.ID, &row.ProviderKey, &row.ProviderModelID, &row.DisplayName, &row.ModelFamily,
+			&row.Modality, &row.LifecycleStatus, &row.Metadata, &createdAt, &updatedAt); err != nil {
+			return nil, fmt.Errorf("scan model catalog entry: %w", err)
+		}
+		row.CreatedAt = createdAt.Time
+		row.UpdatedAt = updatedAt.Time
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate model catalog entries: %w", err)
+	}
+	if result == nil {
+		result = []ModelCatalogEntryRow{}
+	}
+	return result, nil
+}
+
+// --------------------------------------------------------------------------
+// Model Aliases
+// --------------------------------------------------------------------------
+
+type ModelAliasRow struct {
+	ID                  uuid.UUID
+	OrganizationID      uuid.UUID
+	WorkspaceID         *uuid.UUID
+	ProviderAccountID   *uuid.UUID
+	ModelCatalogEntryID uuid.UUID
+	AliasKey            string
+	DisplayName         string
+	Status              string
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+type CreateModelAliasParams struct {
+	OrganizationID      uuid.UUID
+	WorkspaceID         uuid.UUID
+	ProviderAccountID   *uuid.UUID
+	ModelCatalogEntryID uuid.UUID
+	AliasKey            string
+	DisplayName         string
+}
+
+func (r *Repository) CreateModelAlias(ctx context.Context, p CreateModelAliasParams) (ModelAliasRow, error) {
+	var row ModelAliasRow
+	var createdAt, updatedAt pgtype.Timestamptz
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO model_aliases (organization_id, workspace_id, provider_account_id, model_catalog_entry_id, alias_key, display_name)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id, organization_id, workspace_id, provider_account_id, model_catalog_entry_id, alias_key, display_name, status, created_at, updated_at
+	`, p.OrganizationID, p.WorkspaceID, p.ProviderAccountID, p.ModelCatalogEntryID, p.AliasKey, p.DisplayName,
+	).Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.ProviderAccountID, &row.ModelCatalogEntryID,
+		&row.AliasKey, &row.DisplayName, &row.Status, &createdAt, &updatedAt)
+	if err != nil {
+		return ModelAliasRow{}, fmt.Errorf("create model alias: %w", err)
+	}
+	row.CreatedAt = createdAt.Time
+	row.UpdatedAt = updatedAt.Time
+	return row, nil
+}
+
+func (r *Repository) GetModelAliasByID(ctx context.Context, id uuid.UUID) (ModelAliasRow, error) {
+	var row ModelAliasRow
+	var createdAt, updatedAt pgtype.Timestamptz
+	err := r.db.QueryRow(ctx, `
+		SELECT id, organization_id, workspace_id, provider_account_id, model_catalog_entry_id, alias_key, display_name, status, created_at, updated_at
+		FROM model_aliases WHERE id = $1 AND archived_at IS NULL
+	`, id).Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.ProviderAccountID, &row.ModelCatalogEntryID,
+		&row.AliasKey, &row.DisplayName, &row.Status, &createdAt, &updatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ModelAliasRow{}, ErrModelAliasNotFound
+		}
+		return ModelAliasRow{}, fmt.Errorf("get model alias: %w", err)
+	}
+	row.CreatedAt = createdAt.Time
+	row.UpdatedAt = updatedAt.Time
+	return row, nil
+}
+
+func (r *Repository) ListModelAliasesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]ModelAliasRow, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, organization_id, workspace_id, provider_account_id, model_catalog_entry_id, alias_key, display_name, status, created_at, updated_at
+		FROM model_aliases
+		WHERE workspace_id = $1 AND archived_at IS NULL
+		ORDER BY display_name
+	`, workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("list model aliases: %w", err)
+	}
+	defer rows.Close()
+
+	var result []ModelAliasRow
+	for rows.Next() {
+		var row ModelAliasRow
+		var createdAt, updatedAt pgtype.Timestamptz
+		if err := rows.Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.ProviderAccountID, &row.ModelCatalogEntryID,
+			&row.AliasKey, &row.DisplayName, &row.Status, &createdAt, &updatedAt); err != nil {
+			return nil, fmt.Errorf("scan model alias: %w", err)
+		}
+		row.CreatedAt = createdAt.Time
+		row.UpdatedAt = updatedAt.Time
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate model aliases: %w", err)
+	}
+	if result == nil {
+		result = []ModelAliasRow{}
+	}
+	return result, nil
+}
+
+// --------------------------------------------------------------------------
+// Tools
+// --------------------------------------------------------------------------
+
+type ToolRow struct {
+	ID              uuid.UUID
+	OrganizationID  uuid.UUID
+	WorkspaceID     *uuid.UUID
+	Name            string
+	Slug            string
+	ToolKind        string
+	CapabilityKey   string
+	Definition      json.RawMessage
+	LifecycleStatus string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+type CreateToolParams struct {
+	OrganizationID uuid.UUID
+	WorkspaceID    uuid.UUID
+	Name           string
+	Slug           string
+	ToolKind       string
+	CapabilityKey  string
+	Definition     json.RawMessage
+}
+
+func (r *Repository) CreateTool(ctx context.Context, p CreateToolParams) (ToolRow, error) {
+	var row ToolRow
+	var createdAt, updatedAt pgtype.Timestamptz
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO tools (organization_id, workspace_id, name, slug, tool_kind, capability_key, definition)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		RETURNING id, organization_id, workspace_id, name, slug, tool_kind, capability_key, definition, lifecycle_status, created_at, updated_at
+	`, p.OrganizationID, p.WorkspaceID, p.Name, p.Slug, p.ToolKind, p.CapabilityKey, defaultRawJSON(p.Definition),
+	).Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.Name, &row.Slug, &row.ToolKind,
+		&row.CapabilityKey, &row.Definition, &row.LifecycleStatus, &createdAt, &updatedAt)
+	if err != nil {
+		if isDuplicateSlug(err) {
+			return ToolRow{}, ErrSlugTaken
+		}
+		return ToolRow{}, fmt.Errorf("create tool: %w", err)
+	}
+	row.CreatedAt = createdAt.Time
+	row.UpdatedAt = updatedAt.Time
+	return row, nil
+}
+
+func (r *Repository) GetToolByID(ctx context.Context, id uuid.UUID) (ToolRow, error) {
+	var row ToolRow
+	var createdAt, updatedAt pgtype.Timestamptz
+	err := r.db.QueryRow(ctx, `
+		SELECT id, organization_id, workspace_id, name, slug, tool_kind, capability_key, definition, lifecycle_status, created_at, updated_at
+		FROM tools WHERE id = $1 AND archived_at IS NULL
+	`, id).Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.Name, &row.Slug, &row.ToolKind,
+		&row.CapabilityKey, &row.Definition, &row.LifecycleStatus, &createdAt, &updatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ToolRow{}, ErrToolNotFound
+		}
+		return ToolRow{}, fmt.Errorf("get tool: %w", err)
+	}
+	row.CreatedAt = createdAt.Time
+	row.UpdatedAt = updatedAt.Time
+	return row, nil
+}
+
+func (r *Repository) ListToolsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]ToolRow, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, organization_id, workspace_id, name, slug, tool_kind, capability_key, definition, lifecycle_status, created_at, updated_at
+		FROM tools
+		WHERE workspace_id = $1 AND archived_at IS NULL
+		ORDER BY name
+	`, workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("list tools: %w", err)
+	}
+	defer rows.Close()
+
+	var result []ToolRow
+	for rows.Next() {
+		var row ToolRow
+		var createdAt, updatedAt pgtype.Timestamptz
+		if err := rows.Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.Name, &row.Slug, &row.ToolKind,
+			&row.CapabilityKey, &row.Definition, &row.LifecycleStatus, &createdAt, &updatedAt); err != nil {
+			return nil, fmt.Errorf("scan tool: %w", err)
+		}
+		row.CreatedAt = createdAt.Time
+		row.UpdatedAt = updatedAt.Time
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate tools: %w", err)
+	}
+	if result == nil {
+		result = []ToolRow{}
+	}
+	return result, nil
+}
+
+// --------------------------------------------------------------------------
+// Knowledge Sources
+// --------------------------------------------------------------------------
+
+type KnowledgeSourceRow struct {
+	ID               uuid.UUID
+	OrganizationID   uuid.UUID
+	WorkspaceID      *uuid.UUID
+	Name             string
+	Slug             string
+	SourceKind       string
+	ConnectionConfig json.RawMessage
+	LifecycleStatus  string
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+}
+
+type CreateKnowledgeSourceParams struct {
+	OrganizationID   uuid.UUID
+	WorkspaceID      uuid.UUID
+	Name             string
+	Slug             string
+	SourceKind       string
+	ConnectionConfig json.RawMessage
+}
+
+func (r *Repository) CreateKnowledgeSource(ctx context.Context, p CreateKnowledgeSourceParams) (KnowledgeSourceRow, error) {
+	var row KnowledgeSourceRow
+	var createdAt, updatedAt pgtype.Timestamptz
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO knowledge_sources (organization_id, workspace_id, name, slug, source_kind, connection_config)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id, organization_id, workspace_id, name, slug, source_kind, connection_config, lifecycle_status, created_at, updated_at
+	`, p.OrganizationID, p.WorkspaceID, p.Name, p.Slug, p.SourceKind, defaultRawJSON(p.ConnectionConfig),
+	).Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.Name, &row.Slug, &row.SourceKind,
+		&row.ConnectionConfig, &row.LifecycleStatus, &createdAt, &updatedAt)
+	if err != nil {
+		if isDuplicateSlug(err) {
+			return KnowledgeSourceRow{}, ErrSlugTaken
+		}
+		return KnowledgeSourceRow{}, fmt.Errorf("create knowledge source: %w", err)
+	}
+	row.CreatedAt = createdAt.Time
+	row.UpdatedAt = updatedAt.Time
+	return row, nil
+}
+
+func (r *Repository) GetKnowledgeSourceByID(ctx context.Context, id uuid.UUID) (KnowledgeSourceRow, error) {
+	var row KnowledgeSourceRow
+	var createdAt, updatedAt pgtype.Timestamptz
+	err := r.db.QueryRow(ctx, `
+		SELECT id, organization_id, workspace_id, name, slug, source_kind, connection_config, lifecycle_status, created_at, updated_at
+		FROM knowledge_sources WHERE id = $1 AND archived_at IS NULL
+	`, id).Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.Name, &row.Slug, &row.SourceKind,
+		&row.ConnectionConfig, &row.LifecycleStatus, &createdAt, &updatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return KnowledgeSourceRow{}, ErrKnowledgeSourceNotFound
+		}
+		return KnowledgeSourceRow{}, fmt.Errorf("get knowledge source: %w", err)
+	}
+	row.CreatedAt = createdAt.Time
+	row.UpdatedAt = updatedAt.Time
+	return row, nil
+}
+
+func (r *Repository) ListKnowledgeSourcesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]KnowledgeSourceRow, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, organization_id, workspace_id, name, slug, source_kind, connection_config, lifecycle_status, created_at, updated_at
+		FROM knowledge_sources
+		WHERE workspace_id = $1 AND archived_at IS NULL
+		ORDER BY name
+	`, workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("list knowledge sources: %w", err)
+	}
+	defer rows.Close()
+
+	var result []KnowledgeSourceRow
+	for rows.Next() {
+		var row KnowledgeSourceRow
+		var createdAt, updatedAt pgtype.Timestamptz
+		if err := rows.Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.Name, &row.Slug, &row.SourceKind,
+			&row.ConnectionConfig, &row.LifecycleStatus, &createdAt, &updatedAt); err != nil {
+			return nil, fmt.Errorf("scan knowledge source: %w", err)
+		}
+		row.CreatedAt = createdAt.Time
+		row.UpdatedAt = updatedAt.Time
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate knowledge sources: %w", err)
+	}
+	if result == nil {
+		result = []KnowledgeSourceRow{}
+	}
+	return result, nil
+}
+
+// --------------------------------------------------------------------------
+// Routing Policies
+// --------------------------------------------------------------------------
+
+type RoutingPolicyRow struct {
+	ID             uuid.UUID
+	OrganizationID uuid.UUID
+	WorkspaceID    *uuid.UUID
+	Name           string
+	PolicyKind     string
+	Config         json.RawMessage
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+type CreateRoutingPolicyParams struct {
+	OrganizationID uuid.UUID
+	WorkspaceID    uuid.UUID
+	Name           string
+	PolicyKind     string
+	Config         json.RawMessage
+}
+
+func (r *Repository) CreateRoutingPolicy(ctx context.Context, p CreateRoutingPolicyParams) (RoutingPolicyRow, error) {
+	var row RoutingPolicyRow
+	var createdAt, updatedAt pgtype.Timestamptz
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO routing_policies (organization_id, workspace_id, name, policy_kind, config)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING id, organization_id, workspace_id, name, policy_kind, config, created_at, updated_at
+	`, p.OrganizationID, p.WorkspaceID, p.Name, p.PolicyKind, defaultRawJSON(p.Config),
+	).Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.Name, &row.PolicyKind, &row.Config, &createdAt, &updatedAt)
+	if err != nil {
+		return RoutingPolicyRow{}, fmt.Errorf("create routing policy: %w", err)
+	}
+	row.CreatedAt = createdAt.Time
+	row.UpdatedAt = updatedAt.Time
+	return row, nil
+}
+
+func (r *Repository) ListRoutingPoliciesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]RoutingPolicyRow, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, organization_id, workspace_id, name, policy_kind, config, created_at, updated_at
+		FROM routing_policies
+		WHERE workspace_id = $1 AND archived_at IS NULL
+		ORDER BY name
+	`, workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("list routing policies: %w", err)
+	}
+	defer rows.Close()
+
+	var result []RoutingPolicyRow
+	for rows.Next() {
+		var row RoutingPolicyRow
+		var createdAt, updatedAt pgtype.Timestamptz
+		if err := rows.Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.Name, &row.PolicyKind, &row.Config, &createdAt, &updatedAt); err != nil {
+			return nil, fmt.Errorf("scan routing policy: %w", err)
+		}
+		row.CreatedAt = createdAt.Time
+		row.UpdatedAt = updatedAt.Time
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate routing policies: %w", err)
+	}
+	if result == nil {
+		result = []RoutingPolicyRow{}
+	}
+	return result, nil
+}
+
+// --------------------------------------------------------------------------
+// Spend Policies
+// --------------------------------------------------------------------------
+
+type SpendPolicyRow struct {
+	ID             uuid.UUID
+	OrganizationID uuid.UUID
+	WorkspaceID    *uuid.UUID
+	Name           string
+	CurrencyCode   string
+	WindowKind     string
+	SoftLimit      *float64
+	HardLimit      *float64
+	Config         json.RawMessage
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+type CreateSpendPolicyParams struct {
+	OrganizationID uuid.UUID
+	WorkspaceID    uuid.UUID
+	Name           string
+	CurrencyCode   string
+	WindowKind     string
+	SoftLimit      *float64
+	HardLimit      *float64
+	Config         json.RawMessage
+}
+
+func (r *Repository) CreateSpendPolicy(ctx context.Context, p CreateSpendPolicyParams) (SpendPolicyRow, error) {
+	var row SpendPolicyRow
+	var createdAt, updatedAt pgtype.Timestamptz
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO spend_policies (organization_id, workspace_id, name, currency_code, window_kind, soft_limit, hard_limit, config)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		RETURNING id, organization_id, workspace_id, name, currency_code, window_kind, soft_limit, hard_limit, config, created_at, updated_at
+	`, p.OrganizationID, p.WorkspaceID, p.Name,
+		defaultStr(p.CurrencyCode, "USD"), p.WindowKind, p.SoftLimit, p.HardLimit, defaultRawJSON(p.Config),
+	).Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.Name, &row.CurrencyCode, &row.WindowKind,
+		&row.SoftLimit, &row.HardLimit, &row.Config, &createdAt, &updatedAt)
+	if err != nil {
+		return SpendPolicyRow{}, fmt.Errorf("create spend policy: %w", err)
+	}
+	row.CreatedAt = createdAt.Time
+	row.UpdatedAt = updatedAt.Time
+	return row, nil
+}
+
+func (r *Repository) ListSpendPoliciesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]SpendPolicyRow, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, organization_id, workspace_id, name, currency_code, window_kind, soft_limit, hard_limit, config, created_at, updated_at
+		FROM spend_policies
+		WHERE workspace_id = $1 AND archived_at IS NULL
+		ORDER BY name
+	`, workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("list spend policies: %w", err)
+	}
+	defer rows.Close()
+
+	var result []SpendPolicyRow
+	for rows.Next() {
+		var row SpendPolicyRow
+		var createdAt, updatedAt pgtype.Timestamptz
+		if err := rows.Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.Name, &row.CurrencyCode, &row.WindowKind,
+			&row.SoftLimit, &row.HardLimit, &row.Config, &createdAt, &updatedAt); err != nil {
+			return nil, fmt.Errorf("scan spend policy: %w", err)
+		}
+		row.CreatedAt = createdAt.Time
+		row.UpdatedAt = updatedAt.Time
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate spend policies: %w", err)
+	}
+	if result == nil {
+		result = []SpendPolicyRow{}
+	}
+	return result, nil
+}
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+func isDuplicateSlug(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" && strings.Contains(pgErr.ConstraintName, "slug") {
+		return true
+	}
+	return false
+}
+
+func defaultStr(v, fallback string) string {
+	if v == "" {
+		return fallback
+	}
+	return v
+}
+
+func defaultInt32(v, fallback int32) int32 {
+	if v == 0 {
+		return fallback
+	}
+	return v
+}
+
+func defaultRawJSON(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return json.RawMessage(`{}`)
+	}
+	return raw
+}

--- a/backend/internal/repository/infrastructure.go
+++ b/backend/internal/repository/infrastructure.go
@@ -787,6 +787,13 @@ func isDuplicateSlug(err error) bool {
 	return false
 }
 
+// GetWorkspaceID methods implement WorkspaceOwned for authorization checks.
+func (r RuntimeProfileRow) GetWorkspaceID() *uuid.UUID  { return r.WorkspaceID }
+func (r ProviderAccountRow) GetWorkspaceID() *uuid.UUID  { return r.WorkspaceID }
+func (r ModelAliasRow) GetWorkspaceID() *uuid.UUID       { return r.WorkspaceID }
+func (r ToolRow) GetWorkspaceID() *uuid.UUID             { return r.WorkspaceID }
+func (r KnowledgeSourceRow) GetWorkspaceID() *uuid.UUID  { return r.WorkspaceID }
+
 func defaultStr(v, fallback string) string {
 	if v == "" {
 		return fallback


### PR DESCRIPTION
## Summary
Closes #116

Adds complete CRUD REST APIs for all 8 infrastructure resource types that deployments and builds depend on.

### New endpoints

| Resource | Create | List | Get | Archive |
|---|---|---|---|---|
| Runtime Profiles | `POST /v1/workspaces/{id}/runtime-profiles` | `GET ...` | `GET /v1/runtime-profiles/{id}` | `POST /v1/runtime-profiles/{id}/archive` |
| Provider Accounts | `POST /v1/workspaces/{id}/provider-accounts` | `GET ...` | `GET /v1/provider-accounts/{id}` | — |
| Model Catalog | — (read-only) | `GET /v1/model-catalog` | `GET /v1/model-catalog/{id}` | — |
| Model Aliases | `POST /v1/workspaces/{id}/model-aliases` | `GET ...` | `GET /v1/model-aliases/{id}` | — |
| Tools | `POST /v1/workspaces/{id}/tools` | `GET ...` | `GET /v1/tools/{id}` | — |
| Knowledge Sources | `POST /v1/workspaces/{id}/knowledge-sources` | `GET ...` | `GET /v1/knowledge-sources/{id}` | — |
| Routing Policies | `POST /v1/workspaces/{id}/routing-policies` | `GET ...` | — | — |
| Spend Policies | `POST /v1/workspaces/{id}/spend-policies` | `GET ...` | — | — |

### Architecture
- **Repository layer** (`internal/repository/infrastructure.go`): Raw SQL with pgx, row types + CRUD methods for all 8 tables
- **Service layer** (`internal/api/infrastructure_manager.go`): Resolves org ID from workspace, generates slugs, delegates to repository
- **Handler layer** (`internal/api/infrastructure.go`): Generic handler pattern (`infraCreateHandler`, `infraListHandler`, `infraGetHandler`) reduces boilerplate
- **Routes** registered with workspace auth middleware for scoped endpoints, global access for model catalog

### Implementation details
- All workspace-scoped resources use `authorizeWorkspaceAccess` middleware
- Slug auto-generated from name (same `generateSlug` as existing resources)
- List endpoints filter to active/non-archived rows
- Model catalog is global (no tenant scope) and read-only
- `nil` InfrastructureService gracefully skips route registration (existing tests unaffected)

## Test plan
- [x] `go build ./cmd/api-server` — exits 0
- [x] `go build ./cmd/worker` — exits 0
- [x] `go vet ./...` — clean
- [x] `go test ./internal/api/` — all existing tests pass

### cURL verification (all passed against local backend)

```bash
# 1. Create runtime profile → 201
curl -X POST http://localhost:8080/v1/workspaces/{wsID}/runtime-profiles \
  -H "Content-Type: application/json" \
  -d '{"name":"default-profile","execution_target":"native"}'
# Response: {"id":"c225...","name":"default-profile","slug":"default-profile","execution_target":"native","trace_mode":"required",...}

# 2. List runtime profiles → 200
curl http://localhost:8080/v1/workspaces/{wsID}/runtime-profiles
# Response: {"items":[{"id":"c225...","name":"default-profile",...}]}

# 3. Get runtime profile → 200
curl http://localhost:8080/v1/runtime-profiles/{profileID}
# Response: {"id":"c225...","name":"default-profile",...}

# 4. Create provider account → 201
curl -X POST http://localhost:8080/v1/workspaces/{wsID}/provider-accounts \
  -H "Content-Type: application/json" \
  -d '{"provider_key":"openai","name":"OpenAI Prod","credential_reference":"vault:openai-key"}'
# Response: {"id":"4183...","provider_key":"openai","name":"OpenAI Prod","status":"active",...}

# 5. List provider accounts → 200
curl http://localhost:8080/v1/workspaces/{wsID}/provider-accounts
# Response: {"items":[{"id":"4183...","name":"OpenAI Prod",...}]}

# 6. List model catalog → 200 (empty — no seed data)
curl http://localhost:8080/v1/model-catalog
# Response: {"items":[]}

# 7. Create tool → 201
curl -X POST http://localhost:8080/v1/workspaces/{wsID}/tools \
  -H "Content-Type: application/json" \
  -d '{"name":"code-search","tool_kind":"function","capability_key":"search","definition":{"type":"function"}}'
# Response: {"id":"7737...","name":"code-search","slug":"code-search","lifecycle_status":"active",...}

# 8. Create knowledge source → 201
curl -X POST http://localhost:8080/v1/workspaces/{wsID}/knowledge-sources \
  -H "Content-Type: application/json" \
  -d '{"name":"docs-index","source_kind":"vector_store","connection_config":{"url":"https://example.com"}}'
# Response: {"id":"a7bf...","name":"docs-index","slug":"docs-index","lifecycle_status":"active",...}

# 9. Create routing policy → 201
curl -X POST http://localhost:8080/v1/workspaces/{wsID}/routing-policies \
  -H "Content-Type: application/json" \
  -d '{"name":"default-routing","policy_kind":"single_model"}'
# Response: {"id":"81e2...","name":"default-routing","policy_kind":"single_model",...}

# 10. Create spend policy → 201
curl -X POST http://localhost:8080/v1/workspaces/{wsID}/spend-policies \
  -H "Content-Type: application/json" \
  -d '{"name":"budget-cap","window_kind":"month","hard_limit":100.0}'
# Response: {"id":"6c78...","name":"budget-cap","currency_code":"USD","window_kind":"month","hard_limit":100,...}

# 11. Archive runtime profile → 204, then list returns empty
curl -X POST http://localhost:8080/v1/runtime-profiles/{profileID}/archive
# Response: 204 No Content
curl http://localhost:8080/v1/workspaces/{wsID}/runtime-profiles
# Response: {"items":[]}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)