### PR TITLE
FE: Workspace secrets management page

### DIFF
--- a/web/src/app/(workspace)/workspaces/[workspaceId]/secrets/delete-secret-button.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/secrets/delete-secret-button.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+import { Loader2, Trash2 } from "lucide-react";
+
+interface DeleteSecretButtonProps {
+  workspaceId: string;
+  secretKey: string;
+}
+
+export function DeleteSecretButton({
+  workspaceId,
+  secretKey,
+}: DeleteSecretButtonProps) {
+  const router = useRouter();
+  const { getAccessToken } = useAccessToken();
+  const [deleting, setDeleting] = useState(false);
+
+  async function handleDelete() {
+    if (!confirm(`Delete secret "${secretKey}"? This cannot be undone.`)) return;
+
+    setDeleting(true);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      await api.del(
+        `/v1/workspaces/${workspaceId}/secrets/${encodeURIComponent(secretKey)}`,
+      );
+      toast.success(`Deleted "${secretKey}"`);
+      router.refresh();
+    } catch (err) {
+      if (err instanceof ApiError && err.code === "secret_not_found") {
+        toast.error("Secret not found — it may have already been deleted");
+      } else {
+        toast.error("Failed to delete secret");
+      }
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      onClick={handleDelete}
+      disabled={deleting}
+      className="text-muted-foreground hover:text-destructive"
+    >
+      {deleting ? (
+        <Loader2 className="size-3.5 animate-spin" />
+      ) : (
+        <Trash2 className="size-3.5" />
+      )}
+    </Button>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/secrets/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/secrets/page.tsx
@@ -1,0 +1,92 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { redirect } from "next/navigation";
+import { createApiClient } from "@/lib/api/client";
+import type { WorkspaceSecret } from "@/lib/api/types";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Lock } from "lucide-react";
+import { UpsertSecretDialog } from "./upsert-secret-dialog";
+import { DeleteSecretButton } from "./delete-secret-button";
+
+export default async function SecretsPage({
+  params,
+}: {
+  params: Promise<{ workspaceId: string }>;
+}) {
+  const { accessToken } = await withAuth();
+  if (!accessToken) redirect("/auth/login");
+  const { workspaceId } = await params;
+
+  const api = createApiClient(accessToken);
+  const { items: secrets } = await api.get<{ items: WorkspaceSecret[] }>(
+    `/v1/workspaces/${workspaceId}/secrets`,
+  );
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-lg font-semibold tracking-tight">Secrets</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Encrypted key-value pairs referenced by agents as{" "}
+            <code className="font-[family-name:var(--font-mono)] text-xs">
+              {"${secrets.KEY}"}
+            </code>
+          </p>
+        </div>
+        <UpsertSecretDialog workspaceId={workspaceId} />
+      </div>
+
+      {secrets.length === 0 ? (
+        <EmptyState
+          icon={<Lock className="size-10" />}
+          title="No secrets stored"
+          description="Add secrets like API keys or database URLs that your agents can reference at runtime."
+        />
+      ) : (
+        <div className="rounded-lg border border-border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Key</TableHead>
+                <TableHead>Value</TableHead>
+                <TableHead>Updated</TableHead>
+                <TableHead className="w-12" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {secrets.map((s) => (
+                <TableRow key={s.key}>
+                  <TableCell>
+                    <code className="text-sm font-[family-name:var(--font-mono)] font-medium">
+                      {s.key}
+                    </code>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground text-sm">
+                    ••••••••
+                  </TableCell>
+                  <TableCell className="text-muted-foreground text-sm">
+                    {new Date(s.updated_at).toLocaleDateString()}
+                  </TableCell>
+                  <TableCell>
+                    <DeleteSecretButton
+                      workspaceId={workspaceId}
+                      secretKey={s.key}
+                    />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/secrets/upsert-secret-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/secrets/upsert-secret-dialog.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { toast } from "sonner";
+import { Loader2, Plus } from "lucide-react";
+
+const SECRET_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+interface UpsertSecretDialogProps {
+  workspaceId: string;
+}
+
+export function UpsertSecretDialog({ workspaceId }: UpsertSecretDialogProps) {
+  const router = useRouter();
+  const { getAccessToken } = useAccessToken();
+  const [open, setOpen] = useState(false);
+  const [key, setKey] = useState("");
+  const [value, setValue] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [keyError, setKeyError] = useState("");
+
+  function validateKey(k: string) {
+    if (!k.trim()) {
+      setKeyError("Key is required");
+      return false;
+    }
+    if (!SECRET_KEY_PATTERN.test(k)) {
+      setKeyError("Must match [A-Za-z_][A-Za-z0-9_]* (e.g. API_KEY, db_url)");
+      return false;
+    }
+    if (k.length > 128) {
+      setKeyError("Max 128 characters");
+      return false;
+    }
+    setKeyError("");
+    return true;
+  }
+
+  async function handleSubmit() {
+    if (!validateKey(key) || !value.trim()) return;
+
+    setSubmitting(true);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      await api.put(
+        `/v1/workspaces/${workspaceId}/secrets/${encodeURIComponent(key.trim())}`,
+        { value: value },
+      );
+      toast.success(`Secret "${key.trim()}" saved`);
+      setOpen(false);
+      setKey("");
+      setValue("");
+      setKeyError("");
+      router.refresh();
+    } catch (err) {
+      if (err instanceof ApiError) {
+        toast.error(err.message);
+      } else {
+        toast.error("Failed to save secret");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger render={<Button size="sm" />}>
+        <Plus data-icon="inline-start" className="size-4" />
+        New Secret
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New Secret</DialogTitle>
+          <DialogDescription>
+            Store a secret value that agents can reference as {`\${secrets.KEY}`}.
+            Values are encrypted at rest and never displayed after saving.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">Key</label>
+            <input
+              type="text"
+              value={key}
+              onChange={(e) => {
+                setKey(e.target.value);
+                if (keyError) validateKey(e.target.value);
+              }}
+              placeholder="e.g. OPENAI_API_KEY"
+              autoFocus
+              className={`block w-full rounded-lg border bg-transparent px-3 py-2 text-sm font-[family-name:var(--font-mono)] placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50 ${
+                keyError ? "border-destructive" : "border-input focus:border-ring"
+              }`}
+            />
+            {keyError && (
+              <p className="mt-1 text-xs text-destructive">{keyError}</p>
+            )}
+          </div>
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">Value</label>
+            <textarea
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder="Secret value (encrypted at rest)"
+              rows={3}
+              className="block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm font-[family-name:var(--font-mono)] placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/50 resize-none"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            disabled={!key.trim() || !value.trim() || !!keyError || submitting}
+            onClick={handleSubmit}
+          >
+            {submitting ? <Loader2 className="size-4 animate-spin" /> : "Save Secret"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/app-shell/nav-items.ts
+++ b/web/src/components/app-shell/nav-items.ts
@@ -10,6 +10,7 @@ import {
   Tag,
   Wrench,
   Database,
+  Lock,
   type LucideIcon,
 } from "lucide-react";
 
@@ -97,6 +98,11 @@ export const navSections: NavSection[] = [
         label: "Knowledge Sources",
         href: (id) => `/workspaces/${id}/knowledge-sources`,
         icon: Database,
+      },
+      {
+        label: "Secrets",
+        href: (id) => `/workspaces/${id}/secrets`,
+        icon: Lock,
       },
     ],
   },

--- a/web/src/lib/api/__tests__/secrets.test.ts
+++ b/web/src/lib/api/__tests__/secrets.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createApiClient } from "../client";
+import { ApiError } from "../errors";
+
+vi.stubEnv("NEXT_PUBLIC_API_URL", "http://localhost:8080");
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("Workspace Secrets API", () => {
+  it("lists secrets — returns metadata only, no values", async () => {
+    const secrets = {
+      items: [
+        {
+          key: "OPENAI_API_KEY",
+          created_at: "2026-04-12T00:00:00Z",
+          updated_at: "2026-04-12T00:00:00Z",
+          created_by: "user-1",
+        },
+        {
+          key: "DB_URL",
+          created_at: "2026-04-12T00:00:00Z",
+          updated_at: "2026-04-12T01:00:00Z",
+        },
+      ],
+    };
+    mockFetch.mockResolvedValueOnce(jsonResponse(secrets));
+
+    const api = createApiClient("token");
+    const result = await api.get("/v1/workspaces/ws-1/secrets");
+
+    expect(result).toEqual(secrets);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/v1/workspaces/ws-1/secrets",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Bearer token",
+        }),
+      }),
+    );
+    // Verify no "value" field in response items
+    const items = (result as typeof secrets).items;
+    for (const item of items) {
+      expect(item).not.toHaveProperty("value");
+      expect(item).not.toHaveProperty("encrypted_value");
+    }
+  });
+
+  it("upserts a secret via PUT with key in URL", async () => {
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    const api = createApiClient("token");
+    await api.put("/v1/workspaces/ws-1/secrets/MY_SECRET", {
+      value: "super-secret-value",
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/v1/workspaces/ws-1/secrets/MY_SECRET",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ value: "super-secret-value" }),
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          Authorization: "Bearer token",
+        }),
+      }),
+    );
+  });
+
+  it("deletes a secret via DELETE", async () => {
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    const api = createApiClient("token");
+    await api.del("/v1/workspaces/ws-1/secrets/OLD_KEY");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/v1/workspaces/ws-1/secrets/OLD_KEY",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("handles invalid secret key error (400)", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: "invalid_secret_key",
+            message:
+              "secret key must match [A-Za-z_][A-Za-z0-9_]* and be 1..128 characters",
+          },
+        }),
+        { status: 400 },
+      ),
+    );
+
+    const api = createApiClient("token");
+
+    try {
+      await api.put("/v1/workspaces/ws-1/secrets/123-bad-key", {
+        value: "test",
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      const apiErr = err as ApiError;
+      expect(apiErr.status).toBe(400);
+      expect(apiErr.code).toBe("invalid_secret_key");
+    }
+  });
+
+  it("handles secret not found on delete (404)", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: "secret_not_found",
+            message: "secret does not exist",
+          },
+        }),
+        { status: 404 },
+      ),
+    );
+
+    const api = createApiClient("token");
+
+    try {
+      await api.del("/v1/workspaces/ws-1/secrets/GONE");
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      const apiErr = err as ApiError;
+      expect(apiErr.status).toBe(404);
+      expect(apiErr.code).toBe("secret_not_found");
+    }
+  });
+
+  it("put method sends correct HTTP method", async () => {
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    const api = createApiClient("token");
+    await api.put("/v1/test", { data: true });
+
+    expect(mockFetch.mock.calls[0][1].method).toBe("PUT");
+  });
+});

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -129,6 +129,10 @@ export function createApiClient(token?: string) {
       return request<T>("POST", path, token, body, opts);
     },
 
+    put<T>(path: string, body?: unknown, opts?: RequestOptions): Promise<T> {
+      return request<T>("PUT", path, token, body, opts);
+    },
+
     patch<T>(path: string, body?: unknown, opts?: RequestOptions): Promise<T> {
       return request<T>("PATCH", path, token, body, opts);
     },

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -24,5 +24,6 @@ export type {
   AgentDeployment,
   CreateAgentDeploymentRequest,
   AgentDeploymentCreateResponse,
+  WorkspaceSecret,
 } from "./types";
 export { AGENT_KINDS } from "./types";

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -252,6 +252,17 @@ export interface ModelAlias {
   updated_at: string;
 }
 
+// --- Workspace Secrets ---
+
+/** GET /v1/workspaces/{id}/secrets list item — metadata only, never the value */
+export interface WorkspaceSecret {
+  key: string;
+  created_at: string;
+  updated_at: string;
+  created_by?: string;
+  updated_by?: string;
+}
+
 // --- Errors ---
 
 /** Standard error envelope returned by all backend error responses. */


### PR DESCRIPTION
## Summary

Frontend for workspace secrets management.

### Secrets list page (`/workspaces/{id}/secrets`)
- Server-side fetches `GET /v1/workspaces/{id}/secrets`
- Table shows: key name, masked value (`••••••••`), updated date
- **Values are never displayed** — write-only pattern matching the backend design

### Upsert secret dialog
- Client-side key validation: `[A-Za-z_][A-Za-z0-9_]*`, max 128 chars
- Calls `PUT /v1/workspaces/{id}/secrets/{key}` with `{value: "..."}`

### Delete with confirmation
- Browser confirm dialog, handles 404 gracefully

### Other changes
- Added `put()` method to API client
- Added "Secrets" to sidebar nav (Lock icon)
- `WorkspaceSecret` TypeScript type (metadata only)

## Tests (6 new, all passing)
- List, upsert, delete, invalid key error, not found error, PUT method

## Note
The secrets backend endpoints ship in PR #193. This frontend PR can be merged independently — the page will show an error state until the backend is deployed, same as any other frontend-first PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)