### PR TITLE
FE-07: Run creation & run list

### DIFF
--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/page.tsx
@@ -1,0 +1,94 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { createApiClient } from "@/lib/api/client";
+import type { Run } from "@/lib/api/types";
+import { Badge } from "@/components/ui/badge";
+import type { RunStatus } from "@/lib/api/types";
+
+const statusVariant: Record<
+  RunStatus,
+  "default" | "secondary" | "outline" | "destructive"
+> = {
+  draft: "outline",
+  queued: "secondary",
+  provisioning: "secondary",
+  running: "outline",
+  scoring: "outline",
+  completed: "default",
+  failed: "destructive",
+  cancelled: "secondary",
+};
+
+export default async function RunDetailPage({
+  params,
+}: {
+  params: Promise<{ workspaceId: string; runId: string }>;
+}) {
+  const { accessToken } = await withAuth();
+  if (!accessToken) redirect("/auth/login");
+
+  const { workspaceId, runId } = await params;
+
+  const api = createApiClient(accessToken);
+  const run = await api.get<Run>(`/v1/runs/${runId}`);
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="mb-6">
+        <div className="flex items-center gap-3 mb-1">
+          <Link
+            href={`/workspaces/${workspaceId}/runs`}
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Runs
+          </Link>
+          <span className="text-muted-foreground/40">/</span>
+          <h1 className="text-lg font-semibold tracking-tight">{run.name}</h1>
+          <Badge variant={statusVariant[run.status] ?? "outline"}>
+            {run.status}
+          </Badge>
+        </div>
+        <div className="mt-2 flex flex-wrap gap-4 text-xs text-muted-foreground/60">
+          <span>
+            ID:{" "}
+            <code className="font-[family-name:var(--font-mono)]">
+              {run.id}
+            </code>
+          </span>
+          <span>
+            Mode:{" "}
+            {run.execution_mode === "comparison"
+              ? "Comparison"
+              : "Single Agent"}
+          </span>
+          <span>
+            Created: {new Date(run.created_at).toLocaleDateString()}
+          </span>
+          {run.started_at && (
+            <span>
+              Started: {new Date(run.started_at).toLocaleString()}
+            </span>
+          )}
+          {run.finished_at && (
+            <span>
+              Finished: {new Date(run.finished_at).toLocaleString()}
+            </span>
+          )}
+          {run.failed_at && (
+            <span>
+              Failed: {new Date(run.failed_at).toLocaleString()}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Placeholder for future agent details, scoring, replay, etc. */}
+      <div className="rounded-lg border border-border bg-card p-6 text-sm text-muted-foreground">
+        Run agent details, scoring, and replay will be displayed here in a
+        future update.
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import type {
+  AgentDeployment,
+  ChallengePack,
+  ChallengePackVersion,
+  CreateRunResponse,
+} from "@/lib/api/types";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { toast } from "sonner";
+import { Loader2, Plus } from "lucide-react";
+
+interface CreateRunDialogProps {
+  workspaceId: string;
+}
+
+export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
+  const router = useRouter();
+  const { getAccessToken } = useAccessToken();
+
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [selectedPackId, setSelectedPackId] = useState("");
+  const [selectedVersionId, setSelectedVersionId] = useState("");
+  const [inputSetId, setInputSetId] = useState("");
+  const [selectedDeploymentIds, setSelectedDeploymentIds] = useState<string[]>(
+    [],
+  );
+  const [submitting, setSubmitting] = useState(false);
+
+  const [packs, setPacks] = useState<ChallengePack[]>([]);
+  const [runnableVersions, setRunnableVersions] = useState<
+    ChallengePackVersion[]
+  >([]);
+  const [deployments, setDeployments] = useState<AgentDeployment[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      const [packsRes, deploymentsRes] = await Promise.all([
+        api.get<{ items: ChallengePack[] }>(
+          `/v1/workspaces/${workspaceId}/challenge-packs`,
+        ),
+        api.get<{ items: AgentDeployment[] }>(
+          `/v1/workspaces/${workspaceId}/agent-deployments`,
+        ),
+      ]);
+      setPacks(packsRes.items);
+      setDeployments(deploymentsRes.items.filter((d) => d.status === "active"));
+    } catch {
+      toast.error("Failed to load data");
+    } finally {
+      setLoading(false);
+    }
+  }, [getAccessToken, workspaceId]);
+
+  useEffect(() => {
+    if (open) loadData();
+  }, [open, loadData]);
+
+  function handlePackChange(packId: string) {
+    setSelectedPackId(packId);
+    setSelectedVersionId("");
+    if (packId) {
+      const pack = packs.find((p) => p.id === packId);
+      const runnable = (pack?.versions ?? []).filter(
+        (v) => v.lifecycle_status === "runnable",
+      );
+      setRunnableVersions(runnable);
+      if (runnable.length === 1) setSelectedVersionId(runnable[0].id);
+    } else {
+      setRunnableVersions([]);
+    }
+  }
+
+  function toggleDeployment(id: string) {
+    setSelectedDeploymentIds((prev) =>
+      prev.includes(id) ? prev.filter((d) => d !== id) : [...prev, id],
+    );
+  }
+
+  async function handleCreate() {
+    if (!selectedVersionId || selectedDeploymentIds.length === 0) return;
+
+    setSubmitting(true);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      const result = await api.post<CreateRunResponse>("/v1/runs", {
+        workspace_id: workspaceId,
+        challenge_pack_version_id: selectedVersionId,
+        challenge_input_set_id: inputSetId.trim() || undefined,
+        name: name.trim() || undefined,
+        agent_deployment_ids: selectedDeploymentIds,
+      });
+      toast.success("Run created");
+      setOpen(false);
+      resetForm();
+      router.push(`/workspaces/${workspaceId}/runs/${result.id}`);
+      router.refresh();
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError ? err.message : "Failed to create run",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function resetForm() {
+    setName("");
+    setSelectedPackId("");
+    setSelectedVersionId("");
+    setInputSetId("");
+    setSelectedDeploymentIds([]);
+    setRunnableVersions([]);
+  }
+
+  const executionMode =
+    selectedDeploymentIds.length > 1 ? "comparison" : "single_agent";
+  const canSubmit = selectedVersionId && selectedDeploymentIds.length > 0;
+
+  const selectClass =
+    "block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:opacity-50";
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger render={<Button size="sm" />}>
+        <Plus data-icon="inline-start" className="size-4" />
+        New Run
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>New Run</DialogTitle>
+          <DialogDescription>
+            Run agent deployments against a challenge pack.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2 max-h-[60vh] overflow-y-auto">
+          {/* Name */}
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">
+              Name{" "}
+              <span className="text-muted-foreground font-normal">
+                (optional)
+              </span>
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Auto-generated if empty"
+              className="block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/50"
+            />
+          </div>
+
+          {/* Challenge Pack */}
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">
+              Challenge Pack
+            </label>
+            <select
+              value={selectedPackId}
+              onChange={(e) => handlePackChange(e.target.value)}
+              disabled={loading}
+              className={selectClass}
+            >
+              <option value="">
+                {loading ? "Loading..." : "Select a challenge pack"}
+              </option>
+              {packs.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Pack Version */}
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">
+              Version{" "}
+              <span className="text-muted-foreground font-normal">
+                (runnable only)
+              </span>
+            </label>
+            <select
+              value={selectedVersionId}
+              onChange={(e) => setSelectedVersionId(e.target.value)}
+              disabled={!selectedPackId}
+              className={selectClass}
+            >
+              <option value="">
+                {runnableVersions.length === 0 && selectedPackId
+                  ? "No runnable versions"
+                  : "Select a version"}
+              </option>
+              {runnableVersions.map((v) => (
+                <option key={v.id} value={v.id}>
+                  v{v.version_number}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Input Set ID (optional) */}
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">
+              Input Set ID{" "}
+              <span className="text-muted-foreground font-normal">
+                (optional)
+              </span>
+            </label>
+            <input
+              type="text"
+              value={inputSetId}
+              onChange={(e) => setInputSetId(e.target.value)}
+              placeholder="UUID — leave empty for all input sets"
+              className="block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm font-[family-name:var(--font-mono)] placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/50"
+            />
+          </div>
+
+          {/* Agent Deployments (multi-select) */}
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">
+              Agent Deployments
+            </label>
+            {loading ? (
+              <p className="text-sm text-muted-foreground">Loading...</p>
+            ) : deployments.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No active deployments — create one first.
+              </p>
+            ) : (
+              <div className="space-y-1.5 rounded-lg border border-input p-2 max-h-40 overflow-y-auto">
+                {deployments.map((d) => (
+                  <label
+                    key={d.id}
+                    className="flex items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted/50 cursor-pointer"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedDeploymentIds.includes(d.id)}
+                      onChange={() => toggleDeployment(d.id)}
+                      className="rounded border-input"
+                    />
+                    <span className="truncate">{d.name}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Preview */}
+          {canSubmit && (
+            <div className="rounded-lg border border-border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+              This will run{" "}
+              <span className="text-foreground font-medium">
+                {selectedDeploymentIds.length} agent
+                {selectedDeploymentIds.length !== 1 ? "s" : ""}
+              </span>{" "}
+              against the selected challenge pack in{" "}
+              <span className="text-foreground font-medium">
+                {executionMode === "comparison"
+                  ? "comparison"
+                  : "single-agent"}{" "}
+                mode
+              </span>
+              .
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => setOpen(false)}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button disabled={!canSubmit || submitting} onClick={handleCreate}>
+            {submitting ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              "Create Run"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/page.tsx
@@ -1,10 +1,47 @@
-export default function UrunsPage() {
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { redirect } from "next/navigation";
+import { createApiClient } from "@/lib/api/client";
+import type { Run } from "@/lib/api/types";
+import { RunList } from "./run-list";
+import { CreateRunDialog } from "./create-run-dialog";
+
+export default async function RunsPage({
+  params,
+}: {
+  params: Promise<{ workspaceId: string }>;
+}) {
+  const { accessToken } = await withAuth();
+  if (!accessToken) redirect("/auth/login");
+
+  const { workspaceId } = await params;
+
+  const api = createApiClient(accessToken);
+  const res = await api.get<{
+    items: Run[];
+    total: number;
+    limit: number;
+    offset: number;
+  }>(`/v1/workspaces/${workspaceId}/runs`, {
+    params: { limit: 20, offset: 0 },
+  });
+
   return (
     <div>
-      <h1 className="text-lg font-semibold tracking-tight mb-4">runs</h1>
-      <div className="rounded-lg border border-border bg-card p-6 text-sm text-muted-foreground">
-        Coming soon.
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-lg font-semibold tracking-tight">Runs</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Benchmark runs pitting agents against challenge packs.
+          </p>
+        </div>
+        <CreateRunDialog workspaceId={workspaceId} />
       </div>
+
+      <RunList
+        workspaceId={workspaceId}
+        initialRuns={res.items}
+        initialTotal={res.total}
+      />
     </div>
   );
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/run-list.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/run-list.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import type { Run, RunStatus } from "@/lib/api/types";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Play, ChevronLeft, ChevronRight } from "lucide-react";
+
+const statusVariant: Record<
+  RunStatus,
+  "default" | "secondary" | "outline" | "destructive"
+> = {
+  draft: "outline",
+  queued: "secondary",
+  provisioning: "secondary",
+  running: "outline",
+  scoring: "outline",
+  completed: "default",
+  failed: "destructive",
+  cancelled: "secondary",
+};
+
+const ACTIVE_STATUSES: RunStatus[] = [
+  "queued",
+  "provisioning",
+  "running",
+  "scoring",
+];
+const PAGE_SIZE = 20;
+const POLL_INTERVAL_MS = 5000;
+
+interface RunListProps {
+  workspaceId: string;
+  initialRuns: Run[];
+  initialTotal: number;
+}
+
+export function RunList({
+  workspaceId,
+  initialRuns,
+  initialTotal,
+}: RunListProps) {
+  const { getAccessToken } = useAccessToken();
+  const [runs, setRuns] = useState<Run[]>(initialRuns);
+  const [total, setTotal] = useState(initialTotal);
+  const [offset, setOffset] = useState(0);
+
+  const hasActiveRuns = runs.some((r) =>
+    ACTIVE_STATUSES.includes(r.status),
+  );
+
+  const fetchRuns = useCallback(
+    async (currentOffset: number) => {
+      try {
+        const token = await getAccessToken();
+        const api = createApiClient(token);
+        const res = await api.get<{
+          items: Run[];
+          total: number;
+          limit: number;
+          offset: number;
+        }>(`/v1/workspaces/${workspaceId}/runs`, {
+          params: { limit: PAGE_SIZE, offset: currentOffset },
+        });
+        setRuns(res.items);
+        setTotal(res.total);
+      } catch {
+        // Silently fail on poll — data stays stale until next poll
+      }
+    },
+    [getAccessToken, workspaceId],
+  );
+
+  // Auto-refresh when there are active runs
+  useEffect(() => {
+    if (!hasActiveRuns) return;
+    const interval = setInterval(() => fetchRuns(offset), POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [hasActiveRuns, offset, fetchRuns]);
+
+  function handlePrev() {
+    const newOffset = Math.max(0, offset - PAGE_SIZE);
+    setOffset(newOffset);
+    fetchRuns(newOffset);
+  }
+
+  function handleNext() {
+    const newOffset = offset + PAGE_SIZE;
+    if (newOffset < total) {
+      setOffset(newOffset);
+      fetchRuns(newOffset);
+    }
+  }
+
+  if (runs.length === 0 && offset === 0) {
+    return (
+      <EmptyState
+        icon={<Play className="size-10" />}
+        title="No runs yet"
+        description="Create a run to benchmark your agent deployments against challenge packs."
+      />
+    );
+  }
+
+  const page = Math.floor(offset / PAGE_SIZE) + 1;
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+
+  return (
+    <>
+      <div className="rounded-lg border border-border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Mode</TableHead>
+              <TableHead>Created</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {runs.map((run) => (
+              <TableRow key={run.id}>
+                <TableCell>
+                  <Link
+                    href={`/workspaces/${workspaceId}/runs/${run.id}`}
+                    className="font-medium text-foreground hover:underline underline-offset-4"
+                  >
+                    {run.name}
+                  </Link>
+                </TableCell>
+                <TableCell>
+                  <Badge variant={statusVariant[run.status] ?? "outline"}>
+                    {run.status}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-muted-foreground text-sm">
+                  {run.execution_mode === "comparison"
+                    ? "Comparison"
+                    : "Single Agent"}
+                </TableCell>
+                <TableCell className="text-muted-foreground text-sm">
+                  {new Date(run.created_at).toLocaleDateString()}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between mt-4">
+          <p className="text-sm text-muted-foreground">
+            {total} run{total !== 1 ? "s" : ""} total
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="icon-sm"
+              disabled={offset === 0}
+              onClick={handlePrev}
+            >
+              <ChevronLeft className="size-4" />
+            </Button>
+            <span className="text-sm text-muted-foreground">
+              {page} / {totalPages}
+            </span>
+            <Button
+              variant="outline"
+              size="icon-sm"
+              disabled={offset + PAGE_SIZE >= total}
+              onClick={handleNext}
+            >
+              <ChevronRight className="size-4" />
+            </Button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/lib/api/__tests__/runs.test.ts
+++ b/web/src/lib/api/__tests__/runs.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createApiClient } from "../client";
+import { ApiError } from "../errors";
+
+vi.stubEnv("NEXT_PUBLIC_API_URL", "http://localhost:8080");
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("Runs API", () => {
+  it("lists runs with pagination", async () => {
+    const runsResponse = {
+      items: [
+        {
+          id: "run-1",
+          workspace_id: "ws-1",
+          challenge_pack_version_id: "cpv-1",
+          name: "Run 2026-04-12T00:00:00Z",
+          status: "completed",
+          execution_mode: "single_agent",
+          created_at: "2026-04-12T00:00:00Z",
+          updated_at: "2026-04-12T01:00:00Z",
+          links: {
+            self: "/v1/runs/run-1",
+            agents: "/v1/runs/run-1/agents",
+          },
+        },
+        {
+          id: "run-2",
+          workspace_id: "ws-1",
+          challenge_pack_version_id: "cpv-1",
+          name: "Comparison Run",
+          status: "running",
+          execution_mode: "comparison",
+          created_at: "2026-04-12T02:00:00Z",
+          updated_at: "2026-04-12T02:30:00Z",
+          links: {
+            self: "/v1/runs/run-2",
+            agents: "/v1/runs/run-2/agents",
+          },
+        },
+      ],
+      total: 42,
+      limit: 20,
+      offset: 0,
+    };
+    mockFetch.mockResolvedValueOnce(jsonResponse(runsResponse));
+
+    const api = createApiClient("token");
+    const result = await api.get("/v1/workspaces/ws-1/runs", {
+      params: { limit: 20, offset: 0 },
+    });
+
+    expect(result).toEqual(runsResponse);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/v1/workspaces/ws-1/runs?limit=20&offset=0",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Bearer token",
+        }),
+      }),
+    );
+
+    const items = (result as typeof runsResponse).items;
+    expect(items).toHaveLength(2);
+    expect(items[0].status).toBe("completed");
+    expect(items[1].execution_mode).toBe("comparison");
+  });
+
+  it("lists runs with offset for page 2", async () => {
+    const page2 = {
+      items: [
+        {
+          id: "run-21",
+          workspace_id: "ws-1",
+          challenge_pack_version_id: "cpv-1",
+          name: "Page 2 Run",
+          status: "queued",
+          execution_mode: "single_agent",
+          created_at: "2026-04-10T00:00:00Z",
+          updated_at: "2026-04-10T00:00:00Z",
+          links: { self: "/v1/runs/run-21", agents: "/v1/runs/run-21/agents" },
+        },
+      ],
+      total: 42,
+      limit: 20,
+      offset: 20,
+    };
+    mockFetch.mockResolvedValueOnce(jsonResponse(page2));
+
+    const api = createApiClient("token");
+    await api.get("/v1/workspaces/ws-1/runs", {
+      params: { limit: 20, offset: 20 },
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/v1/workspaces/ws-1/runs?limit=20&offset=20",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("creates a single-agent run", async () => {
+    const createResponse = {
+      id: "run-new",
+      workspace_id: "ws-1",
+      challenge_pack_version_id: "cpv-1",
+      status: "queued",
+      execution_mode: "single_agent",
+      created_at: "2026-04-12T03:00:00Z",
+      queued_at: "2026-04-12T03:00:00Z",
+      links: {
+        self: "/v1/runs/run-new",
+        agents: "/v1/runs/run-new/agents",
+      },
+    };
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(createResponse), { status: 201 }),
+    );
+
+    const api = createApiClient("token");
+    const result = await api.post("/v1/runs", {
+      workspace_id: "ws-1",
+      challenge_pack_version_id: "cpv-1",
+      agent_deployment_ids: ["dep-1"],
+    });
+
+    expect(result).toEqual(createResponse);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.workspace_id).toBe("ws-1");
+    expect(body.challenge_pack_version_id).toBe("cpv-1");
+    expect(body.agent_deployment_ids).toEqual(["dep-1"]);
+  });
+
+  it("creates a comparison run with multiple deployments", async () => {
+    const createResponse = {
+      id: "run-compare",
+      workspace_id: "ws-1",
+      challenge_pack_version_id: "cpv-1",
+      status: "queued",
+      execution_mode: "comparison",
+      created_at: "2026-04-12T03:00:00Z",
+      queued_at: "2026-04-12T03:00:00Z",
+      links: {
+        self: "/v1/runs/run-compare",
+        agents: "/v1/runs/run-compare/agents",
+      },
+    };
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(createResponse), { status: 201 }),
+    );
+
+    const api = createApiClient("token");
+    const result = await api.post("/v1/runs", {
+      workspace_id: "ws-1",
+      challenge_pack_version_id: "cpv-1",
+      agent_deployment_ids: ["dep-1", "dep-2", "dep-3"],
+      name: "My Comparison",
+    });
+
+    expect((result as typeof createResponse).execution_mode).toBe("comparison");
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.agent_deployment_ids).toHaveLength(3);
+    expect(body.name).toBe("My Comparison");
+  });
+
+  it("handles duplicate deployment IDs error (400)", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: "validation_error",
+            message: "agent_deployment_ids contains duplicates",
+          },
+        }),
+        { status: 400 },
+      ),
+    );
+
+    const api = createApiClient("token");
+
+    try {
+      await api.post("/v1/runs", {
+        workspace_id: "ws-1",
+        challenge_pack_version_id: "cpv-1",
+        agent_deployment_ids: ["dep-1", "dep-1"],
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      const apiErr = err as ApiError;
+      expect(apiErr.status).toBe(400);
+      expect(apiErr.code).toBe("validation_error");
+    }
+  });
+
+  it("handles missing deployments error (400)", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: "validation_error",
+            message: "agent_deployment_ids is required and must not be empty",
+          },
+        }),
+        { status: 400 },
+      ),
+    );
+
+    const api = createApiClient("token");
+
+    try {
+      await api.post("/v1/runs", {
+        workspace_id: "ws-1",
+        challenge_pack_version_id: "cpv-1",
+        agent_deployment_ids: [],
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as ApiError).status).toBe(400);
+    }
+  });
+
+  it("gets a single run by ID", async () => {
+    const run = {
+      id: "run-1",
+      workspace_id: "ws-1",
+      challenge_pack_version_id: "cpv-1",
+      name: "My Run",
+      status: "completed",
+      execution_mode: "single_agent",
+      started_at: "2026-04-12T00:01:00Z",
+      finished_at: "2026-04-12T00:05:00Z",
+      created_at: "2026-04-12T00:00:00Z",
+      updated_at: "2026-04-12T00:05:00Z",
+      links: {
+        self: "/v1/runs/run-1",
+        agents: "/v1/runs/run-1/agents",
+      },
+    };
+    mockFetch.mockResolvedValueOnce(jsonResponse(run));
+
+    const api = createApiClient("token");
+    const result = await api.get("/v1/runs/run-1");
+
+    expect(result).toEqual(run);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/v1/runs/run-1",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+});

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -252,6 +252,88 @@ export interface ModelAlias {
   updated_at: string;
 }
 
+// --- Challenge Packs (used by pack selector in run creation) ---
+
+/** GET /v1/workspaces/{id}/challenge-packs list item */
+export interface ChallengePack {
+  id: string;
+  name: string;
+  description?: string;
+  versions: ChallengePackVersion[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ChallengePackVersion {
+  id: string;
+  challenge_pack_id: string;
+  version_number: number;
+  lifecycle_status: string; // "draft" | "runnable" | "deprecated" | "archived"
+  created_at: string;
+  updated_at: string;
+}
+
+// --- Runs ---
+
+/** GET /v1/workspaces/{id}/runs list item, GET /v1/runs/{id} detail */
+export interface Run {
+  id: string;
+  workspace_id: string;
+  challenge_pack_version_id: string;
+  challenge_input_set_id?: string;
+  name: string;
+  status: RunStatus;
+  execution_mode: string; // "single_agent" | "comparison"
+  temporal_workflow_id?: string;
+  temporal_run_id?: string;
+  queued_at?: string;
+  started_at?: string;
+  finished_at?: string;
+  cancelled_at?: string;
+  failed_at?: string;
+  created_at: string;
+  updated_at: string;
+  links: {
+    self: string;
+    agents: string;
+  };
+}
+
+export type RunStatus =
+  | "draft"
+  | "queued"
+  | "provisioning"
+  | "running"
+  | "scoring"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+/** POST /v1/runs request */
+export interface CreateRunRequest {
+  workspace_id: string;
+  challenge_pack_version_id: string;
+  challenge_input_set_id?: string;
+  name?: string;
+  agent_deployment_ids: string[];
+}
+
+/** POST /v1/runs response (201) */
+export interface CreateRunResponse {
+  id: string;
+  workspace_id: string;
+  challenge_pack_version_id: string;
+  challenge_input_set_id?: string;
+  status: RunStatus;
+  execution_mode: string;
+  created_at: string;
+  queued_at?: string;
+  links: {
+    self: string;
+    agents: string;
+  };
+}
+
 // --- Workspace Secrets ---
 
 /** GET /v1/workspaces/{id}/secrets list item — metadata only, never the value */


### PR DESCRIPTION
## Summary
- **Run list page** (`/workspaces/{id}/runs`): Paginated table (20 per page) with name, status badge, execution mode, and created date. Auto-refresh polls every 5s when active runs (queued/provisioning/running/scoring) exist. Pagination controls with page count.
- **Create run dialog**: Cascading selectors — pick a challenge pack, then a runnable version, optionally an input set ID. Agent deployments shown as a checkbox multi-selector (filtered to active). Preview shows agent count and execution mode (single-agent vs comparison). On success, redirects to the new run's detail page.
- **Run detail page** (`/workspaces/{id}/runs/{runId}`): Header with breadcrumb, name, status badge, metadata (ID, mode, timestamps). Placeholder for future agent details/scoring/replay.
- **Types**: Added `Run`, `RunStatus`, `CreateRunRequest`, `CreateRunResponse`, `ChallengePack`, `ChallengePackVersion` to shared types module.
- **Tests**: 7 API integration tests covering paginated list, page 2 offset, single-agent creation, comparison creation, duplicate deployment error, empty deployment error, and single run GET.

Closes #206

## Test plan
- [x] `npx vitest run` — 29 passed, 3 skipped, 0 failures
- [x] `npx tsc --noEmit` — clean
- [x] `next lint` — no warnings or errors
- [ ] Manual: navigate to `/workspaces/{id}/runs` and verify empty state
- [ ] Manual: create a single-agent run and verify redirect to detail page
- [ ] Manual: create a comparison run with 2+ deployments
- [ ] Manual: verify active runs auto-refresh (status badges update)
- [ ] Manual: verify pagination controls with >20 runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)