### PR TITLE
feat(web): integrated replay viewer page

### DIFF
--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/replay/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/replay/page.tsx
@@ -1,0 +1,72 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { redirect, notFound } from "next/navigation";
+import Link from "next/link";
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import type { Run, RunAgent, ReplayResponse } from "@/lib/api/types";
+import { ReplayViewerClient } from "./replay-viewer-client";
+
+export default async function ReplayPage({
+  params,
+}: {
+  params: Promise<{
+    workspaceId: string;
+    runId: string;
+    runAgentId: string;
+  }>;
+}) {
+  const { accessToken } = await withAuth();
+  if (!accessToken) redirect("/auth/login");
+
+  const { workspaceId, runId, runAgentId } = await params;
+  const api = createApiClient(accessToken);
+
+  let run: Run;
+  try {
+    run = await api.get<Run>(`/v1/runs/${runId}`);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) notFound();
+    throw err;
+  }
+
+  const [{ items: agents }, replay] = await Promise.all([
+    api.get<{ items: RunAgent[] }>(`/v1/runs/${runId}/agents`),
+    api.get<ReplayResponse>(`/v1/replays/${runAgentId}`, {
+      params: { limit: 50 },
+      allowedStatuses: [409],
+    }),
+  ]);
+
+  const agent = agents.find((a) => a.id === runAgentId);
+  if (!agent) notFound();
+
+  return (
+    <div>
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-2 mb-4 text-sm">
+        <Link
+          href={`/workspaces/${workspaceId}/runs`}
+          className="text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Runs
+        </Link>
+        <span className="text-muted-foreground/40">/</span>
+        <Link
+          href={`/workspaces/${workspaceId}/runs/${runId}`}
+          className="text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {run.name}
+        </Link>
+        <span className="text-muted-foreground/40">/</span>
+        <span className="text-foreground">{agent.label} — Replay</span>
+      </div>
+
+      <ReplayViewerClient
+        initialReplay={replay}
+        run={run}
+        agent={agent}
+        workspaceId={workspaceId}
+      />
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/replay/replay-viewer-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/replay/replay-viewer-client.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import Link from "next/link";
+import { createApiClient } from "@/lib/api/client";
+import type {
+  Run,
+  RunAgent,
+  RunAgentStatus,
+  ReplayResponse,
+  ReplayStep,
+} from "@/lib/api/types";
+import { Badge } from "@/components/ui/badge";
+import { ReplayTimeline } from "@/components/replay/replay-timeline";
+import { toast } from "sonner";
+import {
+  Loader2,
+  AlertTriangle,
+  Clock,
+  BrainCircuit,
+  Wrench,
+  Terminal,
+  BarChart3,
+  Layers,
+} from "lucide-react";
+
+const POLL_MS = 5000;
+
+const agentStatusVariant: Record<
+  RunAgentStatus,
+  "default" | "secondary" | "outline" | "destructive"
+> = {
+  queued: "secondary",
+  ready: "secondary",
+  executing: "outline",
+  evaluating: "outline",
+  completed: "default",
+  failed: "destructive",
+};
+
+interface ReplayViewerClientProps {
+  initialReplay: ReplayResponse;
+  run: Run;
+  agent: RunAgent;
+  workspaceId: string;
+}
+
+export function ReplayViewerClient({
+  initialReplay,
+  run,
+  agent,
+  workspaceId,
+}: ReplayViewerClientProps) {
+  const { getAccessToken } = useAccessToken();
+  const [replayData, setReplayData] = useState<ReplayResponse>(initialReplay);
+  const [steps, setSteps] = useState<ReplayStep[]>(initialReplay.steps);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+
+  const isPending = replayData.state === "pending";
+  const isErrored = replayData.state === "errored";
+  const isReady = replayData.state === "ready";
+
+  // Auto-poll when pending
+  useEffect(() => {
+    if (!isPending) return;
+    const interval = setInterval(async () => {
+      try {
+        const token = await getAccessToken();
+        const api = createApiClient(token);
+        const res = await api.get<ReplayResponse>(
+          `/v1/replays/${agent.id}`,
+          { params: { limit: 50 }, allowedStatuses: [409] },
+        );
+        setReplayData(res);
+        setSteps(res.steps);
+      } catch {
+        // Silently retry on next poll
+      }
+    }, POLL_MS);
+    return () => clearInterval(interval);
+  }, [isPending, getAccessToken, agent.id]);
+
+  const handleLoadMore = useCallback(async () => {
+    if (!replayData.pagination.has_more || isLoadingMore) return;
+    setIsLoadingMore(true);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      const res = await api.get<ReplayResponse>(
+        `/v1/replays/${agent.id}`,
+        {
+          params: {
+            cursor: replayData.pagination.next_cursor,
+            limit: 50,
+          },
+          allowedStatuses: [409],
+        },
+      );
+      setReplayData(res);
+      setSteps((prev) => [...prev, ...res.steps]);
+    } catch {
+      toast.error("Failed to load more steps");
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [getAccessToken, agent.id, replayData.pagination, isLoadingMore]);
+
+  const counts = replayData.replay?.summary?.counts;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <div className="flex items-center gap-3 mb-1">
+          <h1 className="text-lg font-semibold tracking-tight">
+            {agent.label}
+          </h1>
+          <Badge
+            variant={
+              agentStatusVariant[agent.status as RunAgentStatus] ?? "outline"
+            }
+          >
+            {agent.status}
+          </Badge>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Replay for{" "}
+          <Link
+            href={`/workspaces/${workspaceId}/runs/${run.id}`}
+            className="hover:text-foreground transition-colors underline underline-offset-2"
+          >
+            {run.name}
+          </Link>
+        </p>
+      </div>
+
+      {/* Pending banner */}
+      {isPending && (
+        <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3 text-sm">
+          <div className="flex items-center gap-2 text-amber-600 dark:text-amber-400">
+            <Loader2 className="size-4 animate-spin" />
+            <span className="font-medium">Replay pending</span>
+          </div>
+          {replayData.message && (
+            <p className="mt-1 text-muted-foreground">
+              {replayData.message}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Errored banner */}
+      {isErrored && (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm">
+          <div className="flex items-center gap-2 text-destructive">
+            <AlertTriangle className="size-4" />
+            <span className="font-medium">Replay unavailable</span>
+          </div>
+          {replayData.message && (
+            <p className="mt-1 text-destructive/80">
+              {replayData.message}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Summary stats */}
+      {isReady && counts && (
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3">
+          <StatCard
+            icon={<Layers className="size-4" />}
+            label="Total Steps"
+            value={counts.replay_steps}
+          />
+          <StatCard
+            icon={<BrainCircuit className="size-4" />}
+            label="Model Calls"
+            value={counts.model_calls}
+          />
+          <StatCard
+            icon={<Wrench className="size-4" />}
+            label="Tool Calls"
+            value={counts.tool_calls}
+          />
+          <StatCard
+            icon={<Terminal className="size-4" />}
+            label="Sandbox Cmds"
+            value={counts.sandbox_commands}
+          />
+          <StatCard
+            icon={<BarChart3 className="size-4" />}
+            label="Scoring"
+            value={counts.scoring_events}
+          />
+        </div>
+      )}
+
+      {/* Terminal state */}
+      {isReady && replayData.replay?.summary?.terminal_state && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Clock className="size-3.5" />
+          <span>{replayData.replay.summary.terminal_state.headline}</span>
+          {replayData.replay.summary.terminal_state.error_message && (
+            <span className="text-destructive">
+              — {replayData.replay.summary.terminal_state.error_message}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Timeline */}
+      {isReady && (
+        <ReplayTimeline
+          steps={steps}
+          hasMore={replayData.pagination.has_more}
+          isLoadingMore={isLoadingMore}
+          onLoadMore={handleLoadMore}
+        />
+      )}
+    </div>
+  );
+}
+
+function StatCard({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: number;
+}) {
+  return (
+    <div className="rounded-lg border border-border px-3 py-2">
+      <div className="flex items-center gap-1.5 text-muted-foreground mb-0.5">
+        {icon}
+        <span className="text-xs">{label}</span>
+      </div>
+      <span className="text-lg font-semibold tabular-nums">{value}</span>
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/page.tsx
@@ -53,6 +53,7 @@ export default async function RunDetailPage({
         initialRun={run}
         initialAgents={agents}
         apiBaseUrl={apiBaseUrl}
+        workspaceId={workspaceId}
       />
     </div>
   );

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
@@ -21,6 +21,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import Link from "next/link";
 import {
   ExternalLink,
   Trophy,
@@ -113,12 +114,14 @@ interface RunDetailClientProps {
   initialRun: Run;
   initialAgents: RunAgent[];
   apiBaseUrl: string;
+  workspaceId: string;
 }
 
 export function RunDetailClient({
   initialRun,
   initialAgents,
   apiBaseUrl,
+  workspaceId,
 }: RunDetailClientProps) {
   const { getAccessToken } = useAccessToken();
   const [run, setRun] = useState<Run>(initialRun);
@@ -325,16 +328,13 @@ export function RunDetailClient({
 
                 {/* Action links */}
                 <div className="flex gap-2 mt-1">
-                  <a
-                    href={`${apiBaseUrl}/v1/replays/${agent.id}/viewer`}
-                    target="_blank"
-                    rel="noopener noreferrer"
+                  <Link
+                    href={`/workspaces/${workspaceId}/runs/${run.id}/agents/${agent.id}/replay`}
                     className="text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"
                   >
                     <Play className="size-3" />
                     Replay
-                    <ExternalLink className="size-2.5" />
-                  </a>
+                  </Link>
                   <a
                     href={`${apiBaseUrl}/v1/scorecards/${agent.id}`}
                     target="_blank"

--- a/web/src/components/replay/replay-step-card.tsx
+++ b/web/src/components/replay/replay-step-card.tsx
@@ -37,11 +37,11 @@ const statusVariant: Record<string, "default" | "secondary" | "outline" | "destr
 };
 
 function formatTime(iso: string): string {
-  return new Date(iso).toLocaleTimeString([], {
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  });
+  const d = new Date(iso);
+  const h = d.getUTCHours().toString().padStart(2, "0");
+  const m = d.getUTCMinutes().toString().padStart(2, "0");
+  const s = d.getUTCSeconds().toString().padStart(2, "0");
+  return `${h}:${m}:${s}`;
 }
 
 function formatDuration(start: string, end?: string): string | null {

--- a/web/src/components/replay/replay-step-card.tsx
+++ b/web/src/components/replay/replay-step-card.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useState } from "react";
+import type { ReplayStep, ReplayStepType } from "@/lib/api/types";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import {
+  BrainCircuit,
+  Wrench,
+  Terminal,
+  FileCode,
+  MessageSquare,
+  BarChart3,
+  Play,
+  Activity,
+  ChevronRight,
+  ChevronDown,
+} from "lucide-react";
+
+const stepIcon: Record<ReplayStepType, React.ComponentType<{ className?: string }>> = {
+  model_call: BrainCircuit,
+  tool_call: Wrench,
+  sandbox_command: Terminal,
+  sandbox_file: FileCode,
+  output: MessageSquare,
+  scoring: BarChart3,
+  scoring_metric: BarChart3,
+  run: Play,
+  agent_step: Play,
+  event: Activity,
+};
+
+const statusVariant: Record<string, "default" | "secondary" | "outline" | "destructive"> = {
+  completed: "default",
+  running: "secondary",
+  failed: "destructive",
+};
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function formatDuration(start: string, end?: string): string | null {
+  if (!end) return null;
+  const ms = new Date(end).getTime() - new Date(start).getTime();
+  if (ms < 1000) return "<1s";
+  const secs = Math.floor(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  return `${mins}m ${secs % 60}s`;
+}
+
+interface ReplayStepCardProps {
+  step: ReplayStep;
+  index: number;
+}
+
+export function ReplayStepCard({ step, index }: ReplayStepCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const Icon = stepIcon[step.type] ?? Activity;
+  const duration = formatDuration(step.occurred_at, step.completed_at);
+
+  const hasDetail =
+    step.provider_key ||
+    step.provider_model_id ||
+    step.tool_name ||
+    step.sandbox_action ||
+    step.metric_key ||
+    step.final_output ||
+    step.error_message ||
+    step.event_types.length > 0;
+
+  return (
+    <div className="group">
+      <button
+        onClick={() => hasDetail && setExpanded(!expanded)}
+        className={cn(
+          "flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition-colors",
+          hasDetail && "hover:bg-muted/50 cursor-pointer",
+          !hasDetail && "cursor-default",
+        )}
+      >
+        {/* Step number */}
+        <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium text-muted-foreground">
+          {index + 1}
+        </span>
+
+        {/* Icon */}
+        <Icon className="size-4 shrink-0 text-muted-foreground" />
+
+        {/* Headline */}
+        <span className="flex-1 truncate font-medium">{step.headline}</span>
+
+        {/* Duration */}
+        {duration && (
+          <span className="shrink-0 text-xs text-muted-foreground">
+            {duration}
+          </span>
+        )}
+
+        {/* Status */}
+        <Badge variant={statusVariant[step.status] ?? "outline"} className="shrink-0">
+          {step.status}
+        </Badge>
+
+        {/* Timestamp */}
+        <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
+          {formatTime(step.occurred_at)}
+        </span>
+
+        {/* Expand chevron */}
+        {hasDetail && (
+          expanded ? (
+            <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
+          )
+        )}
+      </button>
+
+      {/* Expanded detail */}
+      {expanded && (
+        <div className="ml-12 mr-3 mb-2 space-y-2 rounded-md border border-border bg-muted/30 p-3 text-sm">
+          {/* Metadata row */}
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+            {step.provider_key && (
+              <span>
+                Provider: <span className="text-foreground">{step.provider_key}</span>
+              </span>
+            )}
+            {step.provider_model_id && (
+              <span>
+                Model: <span className="text-foreground">{step.provider_model_id}</span>
+              </span>
+            )}
+            {step.tool_name && (
+              <span>
+                Tool: <span className="text-foreground">{step.tool_name}</span>
+              </span>
+            )}
+            {step.sandbox_action && (
+              <span>
+                Action: <span className="text-foreground">{step.sandbox_action}</span>
+              </span>
+            )}
+            {step.metric_key && (
+              <span>
+                Metric: <span className="text-foreground">{step.metric_key}</span>
+              </span>
+            )}
+            <span>
+              Source: <span className="text-foreground">{step.source}</span>
+            </span>
+            <span>
+              Events: <span className="text-foreground">{step.event_count}</span>
+            </span>
+          </div>
+
+          {/* Event types */}
+          {step.event_types.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {step.event_types.map((et, i) => (
+                <span
+                  key={i}
+                  className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-muted-foreground"
+                >
+                  {et}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {/* Error message */}
+          {step.error_message && (
+            <div className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2 text-xs text-destructive">
+              {step.error_message}
+            </div>
+          )}
+
+          {/* Final output */}
+          {step.final_output && (
+            <pre className="max-h-60 overflow-auto rounded-md bg-background border border-border p-3 text-xs font-[family-name:var(--font-mono)] whitespace-pre-wrap break-words">
+              {step.final_output}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/replay/replay-timeline.tsx
+++ b/web/src/components/replay/replay-timeline.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import type { ReplayStep } from "@/lib/api/types";
+import { ReplayStepCard } from "./replay-step-card";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Loader2, ListTree } from "lucide-react";
+
+interface ReplayTimelineProps {
+  steps: ReplayStep[];
+  hasMore: boolean;
+  isLoadingMore: boolean;
+  onLoadMore: () => void;
+}
+
+export function ReplayTimeline({
+  steps,
+  hasMore,
+  isLoadingMore,
+  onLoadMore,
+}: ReplayTimelineProps) {
+  if (steps.length === 0) {
+    return (
+      <EmptyState
+        icon={<ListTree className="size-10 text-muted-foreground" />}
+        title="No replay steps"
+        description="No execution steps have been recorded yet."
+      />
+    );
+  }
+
+  return (
+    <div>
+      {/* Timeline */}
+      <div className="rounded-lg border border-border divide-y divide-border">
+        {steps.map((step, i) => (
+          <ReplayStepCard key={`${step.started_sequence}-${i}`} step={step} index={i} />
+        ))}
+      </div>
+
+      {/* Load more */}
+      {hasMore && (
+        <div className="mt-4 flex justify-center">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onLoadMore}
+            disabled={isLoadingMore}
+          >
+            {isLoadingMore && <Loader2 className="size-4 animate-spin mr-1.5" />}
+            Load more steps
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -17,6 +17,8 @@ interface RequestOptions {
   headers?: Record<string, string>;
   /** AbortSignal for cancellation. */
   signal?: AbortSignal;
+  /** Non-2xx status codes that should be parsed as JSON instead of throwing. */
+  allowedStatuses?: number[];
 }
 
 function resolveBaseUrl(): string {
@@ -99,7 +101,7 @@ async function request<T>(
     );
   }
 
-  if (!res.ok) {
+  if (!res.ok && !opts.allowedStatuses?.includes(res.status)) {
     throw await parseErrorResponse(res);
   }
 

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -25,5 +25,13 @@ export type {
   CreateAgentDeploymentRequest,
   AgentDeploymentCreateResponse,
   WorkspaceSecret,
+  ReplayState,
+  ReplayStepType,
+  ReplayStepStatus,
+  ReplayStep,
+  ReplaySummaryCounts,
+  ReplaySummary,
+  ReplayPagination,
+  ReplayResponse,
 } from "./types";
 export { AGENT_KINDS } from "./types";

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -431,6 +431,103 @@ export interface WorkspaceSecret {
   updated_by?: string;
 }
 
+// --- Replay ---
+
+export type ReplayState = "ready" | "pending" | "errored";
+
+export type ReplayStepType =
+  | "run"
+  | "agent_step"
+  | "model_call"
+  | "tool_call"
+  | "sandbox_command"
+  | "sandbox_file"
+  | "output"
+  | "scoring"
+  | "scoring_metric"
+  | "event";
+
+export type ReplayStepStatus = "completed" | "running" | "failed";
+
+/** Single step in a replay timeline — mirrors runAgentReplayStepDocument in Go. */
+export interface ReplayStep {
+  type: ReplayStepType;
+  status: ReplayStepStatus;
+  headline: string;
+  source: string;
+  started_sequence: number;
+  completed_sequence?: number;
+  occurred_at: string;
+  completed_at?: string;
+  event_count: number;
+  event_types: string[];
+  artifact_ids?: string[];
+  step_index?: number;
+  provider_key?: string;
+  provider_model_id?: string;
+  tool_name?: string;
+  sandbox_action?: string;
+  metric_key?: string;
+  final_output?: string;
+  error_message?: string;
+}
+
+export interface ReplaySummaryCounts {
+  events: number;
+  replay_steps: number;
+  agent_steps: number;
+  model_calls: number;
+  tool_calls: number;
+  sandbox_commands: number;
+  sandbox_file_events: number;
+  outputs: number;
+  scoring_events: number;
+}
+
+export interface ReplaySummary {
+  schema_version: string;
+  status: string;
+  headline: string;
+  counts: ReplaySummaryCounts;
+  artifact_ids?: string[];
+  terminal_state?: {
+    status: string;
+    event_type: string;
+    source: string;
+    sequence_number: number;
+    occurred_at: string;
+    headline: string;
+    error_message?: string;
+  };
+}
+
+export interface ReplayPagination {
+  next_cursor?: string;
+  limit: number;
+  total_steps: number;
+  has_more: boolean;
+}
+
+/** GET /v1/replays/{runAgentID} — mirrors getRunAgentReplayResponse in Go. */
+export interface ReplayResponse {
+  state: ReplayState;
+  message?: string;
+  run_agent_id: string;
+  run_id: string;
+  run_agent_status: string;
+  replay?: {
+    id: string;
+    artifact_id?: string;
+    summary: ReplaySummary;
+    latest_sequence_number?: number;
+    event_count: number;
+    created_at: string;
+    updated_at: string;
+  };
+  steps: ReplayStep[];
+  pagination: ReplayPagination;
+}
+
 // --- Errors ---
 
 /** Standard error envelope returned by all backend error responses. */


### PR DESCRIPTION
Closes #208
Parent: #199

## Why

The run detail page linked to an **external backend HTML viewer** (`/v1/replays/{id}/viewer`) for agent replays — opening in a new tab, losing navigation context, and providing no integration with the rest of the UI. Users need a native replay experience that lives inside the app, supports incremental loading, and handles all three replay states (pending, errored, ready).

## What

Adds a full replay viewer page at `/workspaces/{id}/runs/{runId}/agents/{runAgentId}/replay` that renders step-by-step execution replay inline, with cursor-based pagination and three-state handling.

## How

### Architecture

```mermaid
graph TD
    A[Run Detail Page] -->|"Link: /agents/{id}/replay"| B[Replay Page - Server Component]
    B -->|parallel fetch| C[GET /v1/runs/{runId}]
    B -->|parallel fetch| D[GET /v1/runs/{runId}/agents]
    B -->|parallel fetch| E["GET /v1/replays/{runAgentId}?limit=50"]
    B --> F[ReplayViewerClient]
    F -->|state=pending| G[Amber banner + auto-poll 5s]
    F -->|state=errored| H[Destructive banner + message]
    F -->|state=ready| I[Summary Stats + Timeline]
    I --> J[ReplayTimeline]
    J --> K[ReplayStepCard x N]
    J -->|has_more| L[Load More Button]
    L -->|cursor pagination| E
```

### State Machine

```mermaid
stateDiagram-v2
    [*] --> Pending: HTTP 202
    [*] --> Ready: HTTP 200
    [*] --> Errored: HTTP 409
    Pending --> Ready: poll → 200
    Pending --> Errored: poll → 409
    Ready --> Ready: Load More
```

### Component Tree

```mermaid
graph LR
    subgraph Server
        PageRSC["page.tsx (RSC)"]
    end
    subgraph Client
        Viewer["ReplayViewerClient"]
        Timeline["ReplayTimeline"]
        StepCard["ReplayStepCard"]
    end
    PageRSC --> Viewer
    Viewer --> Timeline
    Timeline --> StepCard
```

## Changes

### New files
| File | Purpose |
|------|---------|
| `web/src/components/replay/replay-step-card.tsx` | Expandable step card — icon by type, headline, status badge, timestamp, collapsible detail (provider, model, tool, output, errors) |
| `web/src/components/replay/replay-timeline.tsx` | Vertical step list with "Load more" pagination |
| `.../agents/[runAgentId]/replay/page.tsx` | Server component — parallel data fetch, breadcrumbs, auth |
| `.../agents/[runAgentId]/replay/replay-viewer-client.tsx` | Client component — pending auto-poll, errored alert, ready view with summary stats grid + timeline |

### Modified files
| File | Change |
|------|--------|
| `web/src/lib/api/types.ts` | Added `ReplayState`, `ReplayStep`, `ReplaySummary`, `ReplayPagination`, `ReplayResponse` (mirrors Go structs) |
| `web/src/lib/api/client.ts` | Added `allowedStatuses` to `RequestOptions` — lets 409 responses be parsed as JSON instead of thrown |
| `web/src/lib/api/index.ts` | Exported new replay types |
| `.../runs/[runId]/run-detail-client.tsx` | Replaced external `<a>` to backend HTML viewer with native `<Link>` to replay page |
| `.../runs/[runId]/page.tsx` | Passes `workspaceId` prop to `RunDetailClient` |

## Acceptance criteria checklist
- [x] Replay loads incrementally via cursor-based pagination
- [x] Each step is expandable to show full payload
- [x] Model calls show provider/model info
- [x] Tool calls show tool name
- [x] Pending replays show loading state with auto-poll
- [x] Errored replays show error details
- [x] Summary section with step/event type breakdown

## Test plan
- [ ] Navigate to a run detail page → "Replay" link points to `/workspaces/.../agents/.../replay` (not external)
- [ ] Visit replay page for an agent in `executing` status → amber pending banner with spinner, auto-refreshes
- [ ] Visit replay page for a completed agent → summary stats + step timeline renders
- [ ] Click a step → expands to show detail (provider, tool, events, output)
- [ ] Click "Load more" → appends additional steps without losing existing ones
- [ ] Visit replay for a failed agent with no replay data → errored banner with message
- [ ] `npx tsc --noEmit` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)