### PR TITLE
fix: require provider account and model alias for deployments

### DIFF
--- a/backend/internal/api/agent_builds.go
+++ b/backend/internal/api/agent_builds.go
@@ -247,6 +247,19 @@ func (m *AgentBuildManager) MarkVersionReady(ctx context.Context, id uuid.UUID) 
 }
 
 func (m *AgentBuildManager) CreateDeployment(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateAgentDeploymentInput) (repository.AgentDeploymentRow, error) {
+	if input.ProviderAccountID == nil {
+		return repository.AgentDeploymentRow{}, AgentBuildValidationError{
+			Code:    "missing_provider_account",
+			Message: "provider_account_id is required for native deployments",
+		}
+	}
+	if input.ModelAliasID == nil {
+		return repository.AgentDeploymentRow{}, AgentBuildValidationError{
+			Code:    "missing_model_alias",
+			Message: "model_alias_id is required for native deployments",
+		}
+	}
+
 	version, err := m.repo.GetAgentBuildVersionByID(ctx, input.BuildVersionID)
 	if err != nil {
 		return repository.AgentDeploymentRow{}, err

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/deployments/create-deployment-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/deployments/create-deployment-dialog.tsx
@@ -166,7 +166,7 @@ export function CreateDeploymentDialog({
 
   const selectClass =
     "block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:opacity-50";
-  const canSubmit = name.trim() && selectedBuildId && selectedVersionId && selectedProfileId;
+  const canSubmit = name.trim() && selectedBuildId && selectedVersionId && selectedProfileId && selectedAccountId && selectedAliasId;
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -230,11 +230,9 @@ export function CreateDeploymentDialog({
           </div>
 
           <div>
-            <label className="mb-1.5 block text-sm font-medium">
-              Provider Account <span className="text-muted-foreground font-normal">(optional)</span>
-            </label>
+            <label className="mb-1.5 block text-sm font-medium">Provider Account</label>
             <select value={selectedAccountId} onChange={(e) => setSelectedAccountId(e.target.value)} disabled={loading} className={selectClass}>
-              <option value="">None</option>
+              <option value="">{loading ? "Loading..." : accounts.length === 0 ? "No accounts — create one first" : "Select a provider account"}</option>
               {accounts.map((a) => (
                 <option key={a.id} value={a.id}>{a.name} ({a.provider_key})</option>
               ))}
@@ -242,11 +240,9 @@ export function CreateDeploymentDialog({
           </div>
 
           <div>
-            <label className="mb-1.5 block text-sm font-medium">
-              Model Alias <span className="text-muted-foreground font-normal">(optional)</span>
-            </label>
+            <label className="mb-1.5 block text-sm font-medium">Model Alias</label>
             <select value={selectedAliasId} onChange={(e) => setSelectedAliasId(e.target.value)} disabled={loading} className={selectClass}>
-              <option value="">None</option>
+              <option value="">{loading ? "Loading..." : aliases.length === 0 ? "No aliases — create one first" : "Select a model alias"}</option>
               {aliases.map((a) => (
                 <option key={a.id} value={a.id}>{a.display_name} ({a.alias_key})</option>
               ))}


### PR DESCRIPTION
## Summary
- **Backend**: `CreateDeployment` now validates that `provider_account_id` and `model_alias_id` are present, returning a clear 400 error instead of letting the run fail at worker execution time with a cryptic `"native deployment is missing model alias"` error.
- **Frontend**: Provider Account and Model Alias dropdowns are no longer marked "(optional)". The Deploy button is disabled until both are selected. Empty states guide the user ("No accounts — create one first").

## Test plan
- [ ] Create a deployment without provider account → expect 400 `missing_provider_account`
- [ ] Create a deployment without model alias → expect 400 `missing_model_alias`
- [ ] Create a deployment with both set → succeeds as before
- [ ] Frontend: deploy button stays disabled until all fields including provider account and model alias are selected
- [ ] `cd backend && go test -short -race -count=1 ./internal/api/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)