### PR TITLE
fix: auto-create model alias on deploy

### DIFF
--- a/backend/internal/api/agent_builds.go
+++ b/backend/internal/api/agent_builds.go
@@ -33,6 +33,9 @@ type AgentBuildRepository interface {
 	UpdateAgentBuildVersionDraft(ctx context.Context, params repository.UpdateAgentBuildVersionDraftParams) error
 	MarkAgentBuildVersionReady(ctx context.Context, id uuid.UUID) error
 	CreateAgentDeployment(ctx context.Context, params repository.CreateAgentDeploymentParams) (repository.AgentDeploymentRow, error)
+	GetProviderAccountByID(ctx context.Context, id uuid.UUID) (repository.ProviderAccountRow, error)
+	GetModelCatalogEntryByProviderModel(ctx context.Context, providerKey, providerModelID string) (repository.ModelCatalogEntryRow, error)
+	CreateModelAlias(ctx context.Context, p repository.CreateModelAliasParams) (repository.ModelAliasRow, error)
 }
 
 type AgentBuildService interface {
@@ -78,6 +81,7 @@ type CreateAgentDeploymentInput struct {
 	RuntimeProfileID  uuid.UUID
 	ProviderAccountID *uuid.UUID
 	ModelAliasID      *uuid.UUID
+	Model             string
 	DeploymentConfig  json.RawMessage
 }
 
@@ -277,6 +281,28 @@ func (m *AgentBuildManager) CreateDeployment(ctx context.Context, caller Caller,
 		return repository.AgentDeploymentRow{}, err
 	}
 
+	// Auto-create model alias when user provides provider_account + model but no alias.
+	if input.ModelAliasID == nil && input.ProviderAccountID != nil && input.Model != "" {
+		alias, resolveErr := m.resolveOrCreateModelAlias(ctx, build.OrganizationID, workspaceID, *input.ProviderAccountID, input.Model)
+		if resolveErr != nil {
+			return repository.AgentDeploymentRow{}, resolveErr
+		}
+		input.ModelAliasID = &alias.ID
+	}
+
+	if input.ProviderAccountID == nil {
+		return repository.AgentDeploymentRow{}, AgentBuildValidationError{
+			Code:    "missing_provider_account",
+			Message: "provider_account_id is required",
+		}
+	}
+	if input.ModelAliasID == nil {
+		return repository.AgentDeploymentRow{}, AgentBuildValidationError{
+			Code:    "missing_model",
+			Message: "either model_alias_id or model (e.g. \"gpt-4.1\") is required",
+		}
+	}
+
 	slug := generateSlug(input.Name)
 
 	return m.repo.CreateAgentDeployment(ctx, repository.CreateAgentDeploymentParams{
@@ -291,6 +317,37 @@ func (m *AgentBuildManager) CreateDeployment(ctx context.Context, caller Caller,
 		Slug:                  slug,
 		DeploymentConfig:      defaultJSON(input.DeploymentConfig),
 	})
+}
+
+// resolveOrCreateModelAlias looks up the provider account to get its provider_key,
+// finds the matching model catalog entry, and creates a model alias automatically.
+func (m *AgentBuildManager) resolveOrCreateModelAlias(ctx context.Context, orgID, workspaceID, providerAccountID uuid.UUID, model string) (repository.ModelAliasRow, error) {
+	account, err := m.repo.GetProviderAccountByID(ctx, providerAccountID)
+	if err != nil {
+		return repository.ModelAliasRow{}, fmt.Errorf("look up provider account: %w", err)
+	}
+
+	catalogEntry, err := m.repo.GetModelCatalogEntryByProviderModel(ctx, account.ProviderKey, model)
+	if err != nil {
+		return repository.ModelAliasRow{}, AgentBuildValidationError{
+			Code:    "unknown_model",
+			Message: fmt.Sprintf("model %q not found in catalog for provider %q", model, account.ProviderKey),
+		}
+	}
+
+	alias, err := m.repo.CreateModelAlias(ctx, repository.CreateModelAliasParams{
+		OrganizationID:      orgID,
+		WorkspaceID:         workspaceID,
+		ProviderAccountID:   &providerAccountID,
+		ModelCatalogEntryID: catalogEntry.ID,
+		AliasKey:            fmt.Sprintf("auto-%s-%s", account.ProviderKey, model),
+		DisplayName:         fmt.Sprintf("%s (auto)", catalogEntry.DisplayName),
+	})
+	if err != nil {
+		return repository.ModelAliasRow{}, fmt.Errorf("auto-create model alias: %w", err)
+	}
+
+	return alias, nil
 }
 
 // --- Request types ---
@@ -323,6 +380,7 @@ type createAgentDeploymentRequest struct {
 	RuntimeProfileID  string          `json:"runtime_profile_id"`
 	ProviderAccountID *string         `json:"provider_account_id,omitempty"`
 	ModelAliasID      *string         `json:"model_alias_id,omitempty"`
+	Model             string          `json:"model,omitempty"`
 	DeploymentConfig  json.RawMessage `json:"deployment_config,omitempty"`
 }
 
@@ -1006,6 +1064,7 @@ func decodeCreateAgentDeploymentInput(body createAgentDeploymentRequest) (Create
 		RuntimeProfileID:  runtimeProfileID,
 		ProviderAccountID: providerAccountID,
 		ModelAliasID:      modelAliasID,
+		Model:             strings.TrimSpace(body.Model),
 		DeploymentConfig:  body.DeploymentConfig,
 	}, nil
 }

--- a/backend/internal/repository/infrastructure.go
+++ b/backend/internal/repository/infrastructure.go
@@ -293,6 +293,25 @@ func (r *Repository) GetModelCatalogEntryByID(ctx context.Context, id uuid.UUID)
 	return row, nil
 }
 
+func (r *Repository) GetModelCatalogEntryByProviderModel(ctx context.Context, providerKey, providerModelID string) (ModelCatalogEntryRow, error) {
+	var row ModelCatalogEntryRow
+	var createdAt, updatedAt pgtype.Timestamptz
+	err := r.db.QueryRow(ctx, `
+		SELECT id, provider_key, provider_model_id, display_name, model_family, modality, lifecycle_status, metadata, created_at, updated_at
+		FROM model_catalog_entries WHERE provider_key = $1 AND provider_model_id = $2
+	`, providerKey, providerModelID).Scan(&row.ID, &row.ProviderKey, &row.ProviderModelID, &row.DisplayName, &row.ModelFamily,
+		&row.Modality, &row.LifecycleStatus, &row.Metadata, &createdAt, &updatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ModelCatalogEntryRow{}, ErrModelCatalogNotFound
+		}
+		return ModelCatalogEntryRow{}, fmt.Errorf("get model catalog entry by provider model: %w", err)
+	}
+	row.CreatedAt = createdAt.Time
+	row.UpdatedAt = updatedAt.Time
+	return row, nil
+}
+
 func (r *Repository) ListModelCatalogEntries(ctx context.Context) ([]ModelCatalogEntryRow, error) {
 	rows, err := r.db.Query(ctx, `
 		SELECT id, provider_key, provider_model_id, display_name, model_family, modality, lifecycle_status, metadata, created_at, updated_at

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/deployments/create-deployment-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/deployments/create-deployment-dialog.tsx
@@ -44,6 +44,7 @@ export function CreateDeploymentDialog({
   const [selectedVersionId, setSelectedVersionId] = useState("");
   const [selectedProfileId, setSelectedProfileId] = useState("");
   const [selectedAccountId, setSelectedAccountId] = useState("");
+  const [model, setModel] = useState("");
   const [selectedAliasId, setSelectedAliasId] = useState("");
   const [deploymentConfig, setDeploymentConfig] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -114,7 +115,8 @@ export function CreateDeploymentDialog({
   }
 
   async function handleCreate() {
-    if (!name.trim() || !selectedBuildId || !selectedVersionId || !selectedProfileId) return;
+    if (!name.trim() || !selectedBuildId || !selectedVersionId || !selectedProfileId || !selectedAccountId) return;
+    if (!model.trim() && !selectedAliasId) return;
 
     let configJson: unknown = undefined;
     if (deploymentConfig.trim()) {
@@ -137,8 +139,9 @@ export function CreateDeploymentDialog({
           agent_build_id: selectedBuildId,
           build_version_id: selectedVersionId,
           runtime_profile_id: selectedProfileId,
-          provider_account_id: selectedAccountId || undefined,
+          provider_account_id: selectedAccountId,
           model_alias_id: selectedAliasId || undefined,
+          model: model.trim() || undefined,
           deployment_config: configJson,
         },
       );
@@ -159,6 +162,7 @@ export function CreateDeploymentDialog({
     setSelectedVersionId("");
     setSelectedProfileId("");
     setSelectedAccountId("");
+    setModel("");
     setSelectedAliasId("");
     setDeploymentConfig("");
     setReadyVersions([]);
@@ -166,7 +170,8 @@ export function CreateDeploymentDialog({
 
   const selectClass =
     "block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:opacity-50";
-  const canSubmit = name.trim() && selectedBuildId && selectedVersionId && selectedProfileId && selectedAccountId && selectedAliasId;
+  const hasModel = model.trim() || selectedAliasId;
+  const canSubmit = name.trim() && selectedBuildId && selectedVersionId && selectedProfileId && selectedAccountId && hasModel;
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -240,9 +245,31 @@ export function CreateDeploymentDialog({
           </div>
 
           <div>
-            <label className="mb-1.5 block text-sm font-medium">Model Alias</label>
-            <select value={selectedAliasId} onChange={(e) => setSelectedAliasId(e.target.value)} disabled={loading} className={selectClass}>
-              <option value="">{loading ? "Loading..." : aliases.length === 0 ? "No aliases — create one first" : "Select a model alias"}</option>
+            <label className="mb-1.5 block text-sm font-medium">Model</label>
+            <input
+              type="text"
+              value={model}
+              onChange={(e) => { setModel(e.target.value); if (e.target.value.trim()) setSelectedAliasId(""); }}
+              placeholder="e.g. gpt-4.1, claude-sonnet-4-6"
+              disabled={!!selectedAliasId}
+              className="block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:opacity-50"
+            />
+            <p className="mt-1 text-xs text-muted-foreground">
+              The provider model ID. Or pick an existing model alias below.
+            </p>
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">
+              Model Alias <span className="text-muted-foreground font-normal">(advanced)</span>
+            </label>
+            <select
+              value={selectedAliasId}
+              onChange={(e) => { setSelectedAliasId(e.target.value); if (e.target.value) setModel(""); }}
+              disabled={loading}
+              className={selectClass}
+            >
+              <option value="">None — use model name above</option>
               {aliases.map((a) => (
                 <option key={a.id} value={a.id}>{a.display_name} ({a.alias_key})</option>
               ))}


### PR DESCRIPTION
## Summary
- Users no longer need to manually create a model alias before deploying an agent. Just type the model name (e.g. `gpt-4.1`) and pick a provider account — the backend handles the rest.
- Added `model` field to the deployment creation API. When `model_alias_id` is omitted but `provider_account_id` + `model` are provided, the backend resolves the model catalog entry and auto-creates the alias.
- Frontend: provider account is now required, "Model" text input is the primary UX, model alias dropdown is kept as an advanced override.
- Backend validates that `provider_account_id` is always required and either `model` or `model_alias_id` must be set.

## Test plan
- [ ] Deploy with `provider_account_id` + `model: "gpt-4.1"` (no alias) → alias auto-created, deployment succeeds
- [ ] Deploy with explicit `model_alias_id` → works as before
- [ ] Deploy without provider account → 400 `missing_provider_account`
- [ ] Deploy without model or alias → 400 `missing_model`
- [ ] Deploy with unknown model string → 400 `unknown_model`
- [ ] Frontend: typing in model field clears alias dropdown and vice versa
- [ ] `cd backend && go test -short -race -count=1 ./internal/api/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)