### PR TITLE
feat: FE-12 release gates UI

### DIFF
--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/ci-hint.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/ci-hint.tsx
@@ -1,11 +1,98 @@
 "use client";
 
+import { useState } from "react";
+import { ChevronDown, ChevronRight, Terminal, Copy, Check } from "lucide-react";
+
 interface CiHintProps {
   baselineRunId: string;
   candidateRunId: string;
 }
 
-export function CiHint(_props: CiHintProps) {
-  // Placeholder — will be implemented in step 4
-  return null;
+export function CiHint({ baselineRunId, candidateRunId }: CiHintProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const curlCommand = `curl -s -X POST "$API_URL/v1/release-gates/evaluate" \\
+  -H "Authorization: Bearer $TOKEN" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "baseline_run_id": "${baselineRunId}",
+    "candidate_run_id": "${candidateRunId}",
+    "policy": {}
+  }'`;
+
+  const responseExample = `{
+  "baseline_run_id": "${baselineRunId}",
+  "candidate_run_id": "${candidateRunId}",
+  "release_gate": {
+    "verdict": "pass | warn | fail | insufficient_evidence",
+    "reason_code": "within_thresholds",
+    "summary": "All metrics within acceptable thresholds",
+    "evidence_status": "sufficient"
+  }
+}`;
+
+  function handleCopy() {
+    navigator.clipboard.writeText(curlCommand);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <div className="mt-4">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+      >
+        {expanded ? (
+          <ChevronDown className="size-3" />
+        ) : (
+          <ChevronRight className="size-3" />
+        )}
+        <Terminal className="size-3" />
+        CI/CD Integration
+      </button>
+
+      {expanded && (
+        <div className="mt-2 rounded-lg border border-border bg-card p-4 space-y-4">
+          <div>
+            <div className="flex items-center justify-between mb-1.5">
+              <p className="text-xs font-medium">
+                Evaluate in your pipeline
+              </p>
+              <button
+                onClick={handleCopy}
+                className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {copied ? (
+                  <Check className="size-3 text-emerald-400" />
+                ) : (
+                  <Copy className="size-3" />
+                )}
+                {copied ? "Copied" : "Copy"}
+              </button>
+            </div>
+            <pre className="rounded-md bg-muted/50 px-3 py-2 text-xs font-[family-name:var(--font-mono)] overflow-x-auto whitespace-pre">
+              {curlCommand}
+            </pre>
+          </div>
+
+          <div>
+            <p className="text-xs font-medium mb-1.5">Expected response</p>
+            <pre className="rounded-md bg-muted/50 px-3 py-2 text-xs font-[family-name:var(--font-mono)] overflow-x-auto whitespace-pre text-muted-foreground">
+              {responseExample}
+            </pre>
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            Pass an empty <code className="text-foreground">{"{}"}</code> as the
+            policy to use the default thresholds. Check the{" "}
+            <code className="text-foreground">verdict</code> field to gate your
+            deployment: <code className="text-emerald-400">&quot;pass&quot;</code>{" "}
+            means safe to ship.
+          </p>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/ci-hint.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/ci-hint.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+interface CiHintProps {
+  baselineRunId: string;
+  candidateRunId: string;
+}
+
+export function CiHint(_props: CiHintProps) {
+  // Placeholder — will be implemented in step 4
+  return null;
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/compare-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/compare-client.tsx
@@ -24,6 +24,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { scorePercent } from "@/lib/scores";
+import { ReleaseGatesSection } from "./release-gates-section";
 
 // --- State badge ---
 
@@ -259,6 +260,12 @@ export function CompareClient({
             </div>
           </div>
         )}
+
+      {/* Release Gates */}
+      <ReleaseGatesSection
+        baselineRunId={comparison.baseline_run_id}
+        candidateRunId={comparison.candidate_run_id}
+      />
     </div>
   );
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/evaluate-release-gate-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/evaluate-release-gate-dialog.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { ShieldCheck } from "lucide-react";
+
+interface EvaluateReleaseGateDialogProps {
+  baselineRunId: string;
+  candidateRunId: string;
+  onEvaluated: () => void;
+}
+
+export function EvaluateReleaseGateDialog(_props: EvaluateReleaseGateDialogProps) {
+  // Placeholder — will be implemented in step 3
+  return (
+    <Button variant="outline" size="sm" disabled>
+      <ShieldCheck className="size-4 mr-1.5" />
+      Evaluate Release Gate
+    </Button>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/evaluate-release-gate-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/evaluate-release-gate-dialog.tsx
@@ -6,7 +6,6 @@ import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";
 import type {
   ReleaseGate,
-  ReleaseGateVerdict,
   EvaluateReleaseGateResponse,
 } from "@/lib/api/types";
 import { Button } from "@/components/ui/button";
@@ -21,13 +20,8 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { JsonField } from "@/components/ui/json-field";
-import {
-  ShieldCheck,
-  ShieldAlert,
-  ShieldX,
-  ShieldQuestion,
-  Loader2,
-} from "lucide-react";
+import { ShieldCheck, Loader2 } from "lucide-react";
+import { VERDICT_CONFIG, outcomeColor } from "./verdict-config";
 
 const DEFAULT_POLICY = JSON.stringify(
   {
@@ -48,46 +42,6 @@ const DEFAULT_POLICY = JSON.stringify(
   null,
   2,
 );
-
-const verdictConfig: Record<
-  ReleaseGateVerdict,
-  {
-    variant: "default" | "secondary" | "destructive" | "outline";
-    icon: typeof ShieldCheck;
-    label: string;
-    border: string;
-    bg: string;
-  }
-> = {
-  pass: {
-    variant: "default",
-    icon: ShieldCheck,
-    label: "Pass",
-    border: "border-emerald-500/30",
-    bg: "bg-emerald-500/5",
-  },
-  warn: {
-    variant: "secondary",
-    icon: ShieldAlert,
-    label: "Warn",
-    border: "border-amber-500/30",
-    bg: "bg-amber-500/5",
-  },
-  fail: {
-    variant: "destructive",
-    icon: ShieldX,
-    label: "Fail",
-    border: "border-red-500/30",
-    bg: "bg-red-500/5",
-  },
-  insufficient_evidence: {
-    variant: "outline",
-    icon: ShieldQuestion,
-    label: "Insufficient Evidence",
-    border: "border-border",
-    bg: "bg-muted/30",
-  },
-};
 
 interface EvaluateReleaseGateDialogProps {
   baselineRunId: string;
@@ -156,7 +110,7 @@ export function EvaluateReleaseGateDialog({
   }
 
   const resultConfig = result
-    ? verdictConfig[result.verdict] ?? verdictConfig.insufficient_evidence
+    ? VERDICT_CONFIG[result.verdict] ?? VERDICT_CONFIG.insufficient_evidence
     : null;
 
   return (
@@ -237,17 +191,7 @@ export function EvaluateReleaseGateDialog({
                         className="flex items-center gap-2 text-xs"
                       >
                         <span className="font-medium w-24">{dim}</span>
-                        <span
-                          className={
-                            res.outcome === "pass"
-                              ? "text-emerald-400"
-                              : res.outcome === "warn"
-                                ? "text-amber-400"
-                                : res.outcome === "fail"
-                                  ? "text-red-400"
-                                  : "text-muted-foreground"
-                          }
-                        >
+                        <span className={outcomeColor(res.outcome)}>
                           {res.outcome}
                         </span>
                         {res.worsening_delta != null && (

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/evaluate-release-gate-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/evaluate-release-gate-dialog.tsx
@@ -1,7 +1,93 @@
 "use client";
 
+import { useState } from "react";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import type {
+  ReleaseGate,
+  ReleaseGateVerdict,
+  EvaluateReleaseGateResponse,
+} from "@/lib/api/types";
 import { Button } from "@/components/ui/button";
-import { ShieldCheck } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { JsonField } from "@/components/ui/json-field";
+import {
+  ShieldCheck,
+  ShieldAlert,
+  ShieldX,
+  ShieldQuestion,
+  Loader2,
+} from "lucide-react";
+
+const DEFAULT_POLICY = JSON.stringify(
+  {
+    policy_key: "default",
+    policy_version: 1,
+    require_comparable: true,
+    require_evidence_quality: true,
+    fail_on_candidate_failure: true,
+    fail_on_both_failed_differently: true,
+    required_dimensions: ["correctness", "reliability", "latency", "cost"],
+    dimensions: {
+      correctness: { warn_delta: 0.02, fail_delta: 0.05 },
+      reliability: { warn_delta: 0.02, fail_delta: 0.05 },
+      latency: { warn_delta: 0.05, fail_delta: 0.15 },
+      cost: { warn_delta: 0.1, fail_delta: 0.25 },
+    },
+  },
+  null,
+  2,
+);
+
+const verdictConfig: Record<
+  ReleaseGateVerdict,
+  {
+    variant: "default" | "secondary" | "destructive" | "outline";
+    icon: typeof ShieldCheck;
+    label: string;
+    border: string;
+    bg: string;
+  }
+> = {
+  pass: {
+    variant: "default",
+    icon: ShieldCheck,
+    label: "Pass",
+    border: "border-emerald-500/30",
+    bg: "bg-emerald-500/5",
+  },
+  warn: {
+    variant: "secondary",
+    icon: ShieldAlert,
+    label: "Warn",
+    border: "border-amber-500/30",
+    bg: "bg-amber-500/5",
+  },
+  fail: {
+    variant: "destructive",
+    icon: ShieldX,
+    label: "Fail",
+    border: "border-red-500/30",
+    bg: "bg-red-500/5",
+  },
+  insufficient_evidence: {
+    variant: "outline",
+    icon: ShieldQuestion,
+    label: "Insufficient Evidence",
+    border: "border-border",
+    bg: "bg-muted/30",
+  },
+};
 
 interface EvaluateReleaseGateDialogProps {
   baselineRunId: string;
@@ -9,12 +95,186 @@ interface EvaluateReleaseGateDialogProps {
   onEvaluated: () => void;
 }
 
-export function EvaluateReleaseGateDialog(_props: EvaluateReleaseGateDialogProps) {
-  // Placeholder — will be implemented in step 3
+export function EvaluateReleaseGateDialog({
+  baselineRunId,
+  candidateRunId,
+  onEvaluated,
+}: EvaluateReleaseGateDialogProps) {
+  const { getAccessToken } = useAccessToken();
+  const [open, setOpen] = useState(false);
+  const [policyJson, setPolicyJson] = useState(DEFAULT_POLICY);
+  const [jsonError, setJsonError] = useState<string>();
+  const [evaluating, setEvaluating] = useState(false);
+  const [apiError, setApiError] = useState<string>();
+  const [result, setResult] = useState<ReleaseGate | null>(null);
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (next) {
+      // Reset state when opening
+      setJsonError(undefined);
+      setApiError(undefined);
+      setResult(null);
+    }
+  }
+
+  async function handleEvaluate() {
+    setJsonError(undefined);
+    setApiError(undefined);
+
+    let policy: unknown;
+    try {
+      policy = JSON.parse(policyJson);
+    } catch {
+      setJsonError("Invalid JSON. Please check the syntax.");
+      return;
+    }
+
+    setEvaluating(true);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      const res = await api.post<EvaluateReleaseGateResponse>(
+        "/v1/release-gates/evaluate",
+        {
+          baseline_run_id: baselineRunId,
+          candidate_run_id: candidateRunId,
+          policy,
+        },
+      );
+      setResult(res.release_gate);
+      onEvaluated();
+    } catch (err) {
+      setApiError(
+        err instanceof ApiError
+          ? err.message
+          : "Failed to evaluate release gate",
+      );
+    } finally {
+      setEvaluating(false);
+    }
+  }
+
+  const resultConfig = result
+    ? verdictConfig[result.verdict] ?? verdictConfig.insufficient_evidence
+    : null;
+
   return (
-    <Button variant="outline" size="sm" disabled>
-      <ShieldCheck className="size-4 mr-1.5" />
-      Evaluate Release Gate
-    </Button>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger render={<Button variant="outline" size="sm" />}>
+        <ShieldCheck className="size-4 mr-1.5" />
+        Evaluate Release Gate
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Evaluate Release Gate</DialogTitle>
+          <DialogDescription>
+            Define a release gate policy and evaluate it against this
+            comparison. The default policy checks all standard dimensions.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <JsonField
+            label="Policy JSON"
+            description="Release gate policy with dimension thresholds. Leave as default for standard evaluation."
+            value={policyJson}
+            onChange={setPolicyJson}
+            error={jsonError}
+            disabled={evaluating}
+            rows={12}
+          />
+
+          {apiError && (
+            <div className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2 text-xs text-destructive">
+              {apiError}
+            </div>
+          )}
+
+          {result && resultConfig && (
+            <div
+              className={`rounded-lg border ${resultConfig.border} ${resultConfig.bg} px-4 py-3`}
+            >
+              <div className="flex items-center gap-2 mb-2">
+                <Badge variant={resultConfig.variant}>
+                  <resultConfig.icon
+                    data-icon="inline-start"
+                    className="size-3"
+                  />
+                  {resultConfig.label}
+                </Badge>
+                <span className="text-xs text-muted-foreground">
+                  {result.reason_code}
+                </span>
+              </div>
+              <p className="text-sm text-muted-foreground">{result.summary}</p>
+              <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground">
+                <span>
+                  Evidence:{" "}
+                  <span
+                    className={
+                      result.evidence_status === "sufficient"
+                        ? "text-emerald-400"
+                        : "text-amber-400"
+                    }
+                  >
+                    {result.evidence_status}
+                  </span>
+                </span>
+              </div>
+
+              {/* Dimension results */}
+              {result.evaluation_details?.dimension_results &&
+                Object.keys(result.evaluation_details.dimension_results)
+                  .length > 0 && (
+                  <div className="mt-3 space-y-1">
+                    <p className="text-xs font-medium">Dimension Results:</p>
+                    {Object.entries(
+                      result.evaluation_details.dimension_results,
+                    ).map(([dim, res]) => (
+                      <div
+                        key={dim}
+                        className="flex items-center gap-2 text-xs"
+                      >
+                        <span className="font-medium w-24">{dim}</span>
+                        <span
+                          className={
+                            res.outcome === "pass"
+                              ? "text-emerald-400"
+                              : res.outcome === "warn"
+                                ? "text-amber-400"
+                                : res.outcome === "fail"
+                                  ? "text-red-400"
+                                  : "text-muted-foreground"
+                          }
+                        >
+                          {res.outcome}
+                        </span>
+                        {res.worsening_delta != null && (
+                          <span className="text-muted-foreground">
+                            ({(res.worsening_delta * 100).toFixed(1)}% delta)
+                          </span>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button onClick={handleEvaluate} disabled={evaluating}>
+            {evaluating && (
+              <Loader2
+                data-icon="inline-start"
+                className="size-4 animate-spin"
+              />
+            )}
+            {evaluating ? "Evaluating..." : "Evaluate"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/release-gates-section.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/release-gates-section.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import type {
+  ReleaseGate,
+  ReleaseGateVerdict,
+  ListReleaseGatesResponse,
+} from "@/lib/api/types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  ShieldCheck,
+  ShieldAlert,
+  ShieldX,
+  ShieldQuestion,
+  Loader2,
+  ChevronDown,
+  ChevronRight,
+} from "lucide-react";
+import { EvaluateReleaseGateDialog } from "./evaluate-release-gate-dialog";
+import { CiHint } from "./ci-hint";
+
+// --- Verdict badge ---
+
+const verdictConfig: Record<
+  ReleaseGateVerdict,
+  {
+    variant: "default" | "secondary" | "destructive" | "outline";
+    icon: typeof ShieldCheck;
+    label: string;
+  }
+> = {
+  pass: { variant: "default", icon: ShieldCheck, label: "Pass" },
+  warn: { variant: "secondary", icon: ShieldAlert, label: "Warn" },
+  fail: { variant: "destructive", icon: ShieldX, label: "Fail" },
+  insufficient_evidence: {
+    variant: "outline",
+    icon: ShieldQuestion,
+    label: "Insufficient Evidence",
+  },
+};
+
+function VerdictBadge({ verdict }: { verdict: ReleaseGateVerdict }) {
+  const config = verdictConfig[verdict] ?? verdictConfig.insufficient_evidence;
+  const Icon = config.icon;
+  return (
+    <Badge variant={config.variant}>
+      <Icon data-icon="inline-start" className="size-3" />
+      {config.label}
+    </Badge>
+  );
+}
+
+function EvidenceBadge({ status }: { status: string }) {
+  if (status === "sufficient") {
+    return (
+      <span className="text-xs text-emerald-400">Evidence: sufficient</span>
+    );
+  }
+  return (
+    <span className="text-xs text-amber-400">Evidence: insufficient</span>
+  );
+}
+
+// --- Gate card ---
+
+function GateCard({ gate }: { gate: ReleaseGate }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="rounded-lg border border-border p-4">
+      <div className="flex items-center justify-between mb-1">
+        <div className="flex items-center gap-2">
+          <VerdictBadge verdict={gate.verdict} />
+          <span className="text-sm font-medium">{gate.policy_key}</span>
+          <span className="text-xs text-muted-foreground">
+            v{gate.policy_version}
+          </span>
+        </div>
+        <EvidenceBadge status={gate.evidence_status} />
+      </div>
+      <p className="text-sm text-muted-foreground mb-1">{gate.summary}</p>
+      <div className="flex items-center gap-3 text-xs text-muted-foreground">
+        <span>Reason: {gate.reason_code}</span>
+        <span>&middot;</span>
+        <span>{new Date(gate.generated_at).toLocaleString()}</span>
+      </div>
+
+      {/* Expandable details */}
+      {gate.evaluation_details && (
+        <div className="mt-2">
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {expanded ? (
+              <ChevronDown className="size-3" />
+            ) : (
+              <ChevronRight className="size-3" />
+            )}
+            Details
+          </button>
+          {expanded && (
+            <div className="mt-2 rounded-md bg-muted/30 px-3 py-2 text-xs space-y-1">
+              {gate.evaluation_details.triggered_conditions &&
+                gate.evaluation_details.triggered_conditions.length > 0 && (
+                  <div>
+                    <span className="font-medium">Triggered conditions:</span>
+                    <ul className="list-disc list-inside ml-2 mt-0.5">
+                      {gate.evaluation_details.triggered_conditions.map(
+                        (c, i) => (
+                          <li key={i}>{c}</li>
+                        ),
+                      )}
+                    </ul>
+                  </div>
+                )}
+              {gate.evaluation_details.dimension_results &&
+                Object.keys(gate.evaluation_details.dimension_results).length >
+                  0 && (
+                  <div>
+                    <span className="font-medium">Dimension results:</span>
+                    <div className="mt-0.5 space-y-0.5 ml-2">
+                      {Object.entries(
+                        gate.evaluation_details.dimension_results,
+                      ).map(([dim, result]) => (
+                        <div key={dim} className="flex items-center gap-2">
+                          <span className="font-medium">{dim}:</span>
+                          <span>{result.outcome}</span>
+                          {result.worsening_delta != null && (
+                            <span className="text-muted-foreground">
+                              (delta: {(result.worsening_delta * 100).toFixed(1)}
+                              %)
+                            </span>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              {gate.evaluation_details.warnings &&
+                gate.evaluation_details.warnings.length > 0 && (
+                  <div>
+                    <span className="font-medium">Warnings:</span>
+                    <ul className="list-disc list-inside ml-2 mt-0.5">
+                      {gate.evaluation_details.warnings.map((w, i) => (
+                        <li key={i}>{w}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// --- Main section ---
+
+interface ReleaseGatesSectionProps {
+  baselineRunId: string;
+  candidateRunId: string;
+}
+
+export function ReleaseGatesSection({
+  baselineRunId,
+  candidateRunId,
+}: ReleaseGatesSectionProps) {
+  const { getAccessToken } = useAccessToken();
+  const [gates, setGates] = useState<ReleaseGate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [fetchKey, setFetchKey] = useState(0);
+
+  const fetchGates = useCallback(async () => {
+    setLoading(true);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      const res = await api.get<ListReleaseGatesResponse>(
+        "/v1/release-gates",
+        {
+          params: {
+            baseline_run_id: baselineRunId,
+            candidate_run_id: candidateRunId,
+          },
+        },
+      );
+      setGates(res.release_gates ?? []);
+    } catch {
+      // Gates are supplementary — silently fail
+    } finally {
+      setLoading(false);
+    }
+  }, [getAccessToken, baselineRunId, candidateRunId, fetchKey]);
+
+  useEffect(() => {
+    fetchGates();
+  }, [fetchGates]);
+
+  function handleEvaluated() {
+    setFetchKey((k) => k + 1);
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-sm font-semibold">Release Gates</h2>
+        <EvaluateReleaseGateDialog
+          baselineRunId={baselineRunId}
+          candidateRunId={candidateRunId}
+          onEvaluated={handleEvaluated}
+        />
+      </div>
+
+      {loading ? (
+        <div className="rounded-lg border border-border p-6 text-center">
+          <Loader2 className="size-5 animate-spin mx-auto mb-2 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">
+            Loading release gates...
+          </p>
+        </div>
+      ) : gates.length === 0 ? (
+        <div className="rounded-lg border border-border bg-card p-6 text-center text-sm text-muted-foreground">
+          No release gates evaluated yet. Use the button above to evaluate a
+          policy against this comparison.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {gates.map((gate) => (
+            <GateCard key={gate.id} gate={gate} />
+          ))}
+        </div>
+      )}
+
+      <CiHint
+        baselineRunId={baselineRunId}
+        candidateRunId={candidateRunId}
+      />
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/release-gates-section.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/release-gates-section.tsx
@@ -10,39 +10,16 @@ import type {
 } from "@/lib/api/types";
 import { Badge } from "@/components/ui/badge";
 import {
-  ShieldCheck,
-  ShieldAlert,
-  ShieldX,
-  ShieldQuestion,
   Loader2,
   ChevronDown,
   ChevronRight,
 } from "lucide-react";
 import { EvaluateReleaseGateDialog } from "./evaluate-release-gate-dialog";
 import { CiHint } from "./ci-hint";
-
-// --- Verdict badge ---
-
-const verdictConfig: Record<
-  ReleaseGateVerdict,
-  {
-    variant: "default" | "secondary" | "destructive" | "outline";
-    icon: typeof ShieldCheck;
-    label: string;
-  }
-> = {
-  pass: { variant: "default", icon: ShieldCheck, label: "Pass" },
-  warn: { variant: "secondary", icon: ShieldAlert, label: "Warn" },
-  fail: { variant: "destructive", icon: ShieldX, label: "Fail" },
-  insufficient_evidence: {
-    variant: "outline",
-    icon: ShieldQuestion,
-    label: "Insufficient Evidence",
-  },
-};
+import { VERDICT_CONFIG, outcomeColor } from "./verdict-config";
 
 function VerdictBadge({ verdict }: { verdict: ReleaseGateVerdict }) {
-  const config = verdictConfig[verdict] ?? verdictConfig.insufficient_evidence;
+  const config = VERDICT_CONFIG[verdict] ?? VERDICT_CONFIG.insufficient_evidence;
   const Icon = config.icon;
   return (
     <Badge variant={config.variant}>
@@ -127,7 +104,7 @@ function GateCard({ gate }: { gate: ReleaseGate }) {
                       ).map(([dim, result]) => (
                         <div key={dim} className="flex items-center gap-2">
                           <span className="font-medium">{dim}:</span>
-                          <span>{result.outcome}</span>
+                          <span className={outcomeColor(result.outcome)}>{result.outcome}</span>
                           {result.worsening_delta != null && (
                             <span className="text-muted-foreground">
                               (delta: {(result.worsening_delta * 100).toFixed(1)}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/release-gates-section.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/release-gates-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { createApiClient } from "@/lib/api/client";
 import type {
@@ -9,7 +9,6 @@ import type {
   ListReleaseGatesResponse,
 } from "@/lib/api/types";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import {
   ShieldCheck,
   ShieldAlert,
@@ -173,36 +172,38 @@ export function ReleaseGatesSection({
   const { getAccessToken } = useAccessToken();
   const [gates, setGates] = useState<ReleaseGate[]>([]);
   const [loading, setLoading] = useState(true);
-  const [fetchKey, setFetchKey] = useState(0);
-
-  const fetchGates = useCallback(async () => {
-    setLoading(true);
-    try {
-      const token = await getAccessToken();
-      const api = createApiClient(token);
-      const res = await api.get<ListReleaseGatesResponse>(
-        "/v1/release-gates",
-        {
-          params: {
-            baseline_run_id: baselineRunId,
-            candidate_run_id: candidateRunId,
-          },
-        },
-      );
-      setGates(res.release_gates ?? []);
-    } catch {
-      // Gates are supplementary — silently fail
-    } finally {
-      setLoading(false);
-    }
-  }, [getAccessToken, baselineRunId, candidateRunId, fetchKey]);
+  const [refreshCounter, setRefreshCounter] = useState(0);
 
   useEffect(() => {
-    fetchGates();
-  }, [fetchGates]);
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      try {
+        const token = await getAccessToken();
+        const api = createApiClient(token);
+        const res = await api.get<ListReleaseGatesResponse>(
+          "/v1/release-gates",
+          {
+            params: {
+              baseline_run_id: baselineRunId,
+              candidate_run_id: candidateRunId,
+            },
+          },
+        );
+        if (!cancelled) setGates(res.release_gates ?? []);
+      } catch {
+        // Gates are supplementary — silently fail
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [getAccessToken, baselineRunId, candidateRunId, refreshCounter]);
 
   function handleEvaluated() {
-    setFetchKey((k) => k + 1);
+    setRefreshCounter((c) => c + 1);
   }
 
   return (

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/verdict-config.ts
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/verdict-config.ts
@@ -1,0 +1,60 @@
+import type { ReleaseGateVerdict } from "@/lib/api/types";
+import {
+  ShieldCheck,
+  ShieldAlert,
+  ShieldX,
+  ShieldQuestion,
+  type LucideIcon,
+} from "lucide-react";
+
+export interface VerdictStyle {
+  variant: "default" | "secondary" | "destructive" | "outline";
+  icon: LucideIcon;
+  label: string;
+  border: string;
+  bg: string;
+}
+
+export const VERDICT_CONFIG: Record<ReleaseGateVerdict, VerdictStyle> = {
+  pass: {
+    variant: "default",
+    icon: ShieldCheck,
+    label: "Pass",
+    border: "border-emerald-500/30",
+    bg: "bg-emerald-500/5",
+  },
+  warn: {
+    variant: "secondary",
+    icon: ShieldAlert,
+    label: "Warn",
+    border: "border-amber-500/30",
+    bg: "bg-amber-500/5",
+  },
+  fail: {
+    variant: "destructive",
+    icon: ShieldX,
+    label: "Fail",
+    border: "border-red-500/30",
+    bg: "bg-red-500/5",
+  },
+  insufficient_evidence: {
+    variant: "outline",
+    icon: ShieldQuestion,
+    label: "Insufficient Evidence",
+    border: "border-border",
+    bg: "bg-muted/30",
+  },
+};
+
+export function outcomeColor(outcome: string): string {
+  switch (outcome) {
+    case "pass":
+      return "text-emerald-400";
+    case "warn":
+      return "text-amber-400";
+    case "fail":
+      return "text-red-400";
+    default:
+      return "text-muted-foreground";
+  }
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/release-gates/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/release-gates/page.tsx
@@ -1,9 +1,31 @@
-export default function UreleaseUgatesPage() {
+import { ShieldCheck } from "lucide-react";
+import { ReleaseGatesLanding } from "./release-gates-landing";
+
+export default async function ReleaseGatesPage({
+  params,
+}: {
+  params: Promise<{ workspaceId: string }>;
+}) {
+  const { workspaceId } = await params;
+
   return (
     <div>
-      <h1 className="text-lg font-semibold tracking-tight mb-4">release gates</h1>
-      <div className="rounded-lg border border-border bg-card p-6 text-sm text-muted-foreground">
-        Coming soon.
+      <h1 className="text-lg font-semibold tracking-tight mb-4">
+        Release Gates
+      </h1>
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <div className="mb-4 text-muted-foreground">
+          <ShieldCheck className="size-10" />
+        </div>
+        <h3 className="text-sm font-medium text-foreground">
+          Automated pass/fail decisions
+        </h3>
+        <p className="mt-1 text-sm text-muted-foreground max-w-sm">
+          Release gates evaluate whether a candidate agent is ready to ship by
+          checking metric thresholds against a baseline. Compare two runs to
+          evaluate a release gate.
+        </p>
+        <ReleaseGatesLanding workspaceId={workspaceId} />
       </div>
     </div>
   );

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/release-gates/release-gates-landing.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/release-gates/release-gates-landing.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+
+export function ReleaseGatesLanding({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const router = useRouter();
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className="mt-4"
+      onClick={() => router.push(`/workspaces/${workspaceId}/runs`)}
+    >
+      Go to Runs
+    </Button>
+  );
+}

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -632,6 +632,93 @@ export interface ComparisonSummary {
   evidence_quality: EvidenceQuality;
 }
 
+// --- Release Gates ---
+
+export type ReleaseGateVerdict =
+  | "pass"
+  | "warn"
+  | "fail"
+  | "insufficient_evidence";
+
+export type ReleaseGateEvidenceStatus = "sufficient" | "insufficient";
+
+/** Individual release gate — mirrors releaseGateResponse in release_gates.go */
+export interface ReleaseGate {
+  id: string;
+  run_comparison_id: string;
+  policy_key: string;
+  policy_version: number;
+  policy_fingerprint: string;
+  policy_snapshot: ReleaseGatePolicy;
+  verdict: ReleaseGateVerdict;
+  reason_code: string;
+  summary: string;
+  evidence_status: ReleaseGateEvidenceStatus;
+  evaluation_details: ReleaseGateEvaluationDetails;
+  generated_at: string;
+  updated_at: string;
+}
+
+/** GET /v1/release-gates response */
+export interface ListReleaseGatesResponse {
+  baseline_run_id: string;
+  candidate_run_id: string;
+  release_gates: ReleaseGate[];
+}
+
+/** POST /v1/release-gates/evaluate request */
+export interface EvaluateReleaseGateRequest {
+  baseline_run_id: string;
+  candidate_run_id: string;
+  baseline_run_agent_id?: string;
+  candidate_run_agent_id?: string;
+  policy: ReleaseGatePolicy;
+}
+
+/** POST /v1/release-gates/evaluate response */
+export interface EvaluateReleaseGateResponse {
+  baseline_run_id: string;
+  candidate_run_id: string;
+  release_gate: ReleaseGate;
+}
+
+export interface ReleaseGatePolicy {
+  policy_key: string;
+  policy_version: number;
+  require_comparable?: boolean;
+  require_evidence_quality?: boolean;
+  fail_on_candidate_failure?: boolean;
+  fail_on_both_failed_differently?: boolean;
+  required_dimensions?: string[];
+  dimensions?: Record<string, DimensionThreshold>;
+}
+
+export interface DimensionThreshold {
+  warn_delta?: number;
+  fail_delta?: number;
+}
+
+export interface ReleaseGateEvaluationDetails {
+  policy_key: string;
+  policy_version: number;
+  comparison_status: string;
+  missing_fields?: string[];
+  warnings?: string[];
+  triggered_conditions?: string[];
+  required_dimensions?: string[];
+  dimension_results?: Record<string, DimensionEvaluation>;
+}
+
+export interface DimensionEvaluation {
+  state: string;
+  better_direction?: string;
+  observed_delta?: number;
+  worsening_delta?: number;
+  warn_threshold?: number;
+  fail_threshold?: number;
+  outcome: string;
+}
+
 // --- Errors ---
 
 /** Standard error envelope returned by all backend error responses. */


### PR DESCRIPTION
## Summary

Closes #211

- **Release gates section** on comparison page — fetches `GET /v1/release-gates` and lists each evaluated gate with verdict badge (pass/warn/fail/insufficient_evidence), policy key, version, summary, evidence status, and expandable evaluation details
- **Evaluate release gate dialog** — policy JSON editor pre-filled with default policy (correctness, reliability, latency, cost thresholds), calls `POST /v1/release-gates/evaluate`, shows result inline with per-dimension outcomes. Refreshes gate list on success
- **CI/CD integration hint** — collapsible section with copy-to-clipboard cURL command and expected response format
- **Release-gates landing page** — updated from stub to helpful empty state explaining release gates and pointing to runs
- **API types** — added `ReleaseGate`, `ReleaseGatePolicy`, `DimensionThreshold`, `EvaluateReleaseGateRequest/Response`, `ListReleaseGatesResponse`, and supporting types

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `pnpm lint` — passes (0 errors, 0 warnings)
- [x] `pnpm build` — passes, compare page at 6.12kB
- [ ] Navigate to `/workspaces/{id}/compare?baseline=X&candidate=Y` — release gates section appears below deltas
- [ ] Click "Evaluate Release Gate" — dialog opens with pre-filled default policy
- [ ] Click "Evaluate" — result appears with verdict badge and dimension results
- [ ] Expand "CI/CD Integration" — shows cURL command with copy button
- [ ] Navigate to `/workspaces/{id}/release-gates` — landing page renders with explanation

🤖 Generated with [Claude Code](https://claude.com/claude-code)