### PR TITLE
feat: FE-14 organization settings & membership management

### DIFF
--- a/web/src/app/(org)/orgs/[orgSlug]/layout.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/layout.tsx
@@ -1,8 +1,9 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { redirect } from "next/navigation";
 import { createApiClient } from "@/lib/api/client";
-import type { UserMeResponse } from "@/lib/api/types";
+import type { UserMeResponse, SessionResponse } from "@/lib/api/types";
 import { OrgSettingsSidebar } from "./org-settings-sidebar";
+import { OrgProvider } from "./org-context";
 
 export default async function OrgLayout({
   children,
@@ -17,9 +18,13 @@ export default async function OrgLayout({
   const { orgSlug } = await params;
 
   let userMe: UserMeResponse;
+  let session: SessionResponse;
   try {
     const api = createApiClient(accessToken);
-    userMe = await api.get<UserMeResponse>("/v1/users/me");
+    [userMe, session] = await Promise.all([
+      api.get<UserMeResponse>("/v1/users/me"),
+      api.get<SessionResponse>("/v1/auth/session"),
+    ]);
   } catch {
     redirect("/auth/login");
   }
@@ -47,15 +52,25 @@ export default async function OrgLayout({
   const isAdmin = org.role === "org_admin";
 
   return (
-    <div className="flex min-h-screen">
-      <OrgSettingsSidebar
-        orgSlug={orgSlug}
-        orgName={org.name}
-        isAdmin={isAdmin}
-      />
-      <main className="flex-1 overflow-y-auto p-6 max-w-4xl">
-        {children}
-      </main>
-    </div>
+    <OrgProvider
+      value={{
+        orgId: org.id,
+        orgSlug: org.slug,
+        orgName: org.name,
+        isAdmin,
+        currentUserId: session.user_id,
+      }}
+    >
+      <div className="flex min-h-screen">
+        <OrgSettingsSidebar
+          orgSlug={orgSlug}
+          orgName={org.name}
+          isAdmin={isAdmin}
+        />
+        <main className="flex-1 overflow-y-auto p-6 max-w-4xl">
+          {children}
+        </main>
+      </div>
+    </OrgProvider>
   );
 }

--- a/web/src/app/(org)/orgs/[orgSlug]/layout.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/layout.tsx
@@ -1,5 +1,5 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { createApiClient } from "@/lib/api/client";
 import type { UserMeResponse, SessionResponse } from "@/lib/api/types";
 import { OrgSettingsSidebar } from "./org-settings-sidebar";
@@ -30,24 +30,7 @@ export default async function OrgLayout({
   }
 
   const org = userMe.organizations.find((o) => o.slug === orgSlug);
-  if (!org) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-4xl font-semibold mb-2">404</h1>
-          <p className="text-sm text-muted-foreground mb-4">
-            Organization not found.
-          </p>
-          <a
-            href="/dashboard"
-            className="text-sm text-foreground underline underline-offset-4"
-          >
-            Go to dashboard
-          </a>
-        </div>
-      </div>
-    );
-  }
+  if (!org) notFound();
 
   const isAdmin = org.role === "org_admin";
 

--- a/web/src/app/(org)/orgs/[orgSlug]/layout.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/layout.tsx
@@ -1,0 +1,61 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { redirect } from "next/navigation";
+import { createApiClient } from "@/lib/api/client";
+import type { UserMeResponse } from "@/lib/api/types";
+import { OrgSettingsSidebar } from "./org-settings-sidebar";
+
+export default async function OrgLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ orgSlug: string }>;
+}) {
+  const { user, accessToken } = await withAuth();
+  if (!user) redirect("/auth/login");
+
+  const { orgSlug } = await params;
+
+  let userMe: UserMeResponse;
+  try {
+    const api = createApiClient(accessToken);
+    userMe = await api.get<UserMeResponse>("/v1/users/me");
+  } catch {
+    redirect("/auth/login");
+  }
+
+  const org = userMe.organizations.find((o) => o.slug === orgSlug);
+  if (!org) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-4xl font-semibold mb-2">404</h1>
+          <p className="text-sm text-muted-foreground mb-4">
+            Organization not found.
+          </p>
+          <a
+            href="/dashboard"
+            className="text-sm text-foreground underline underline-offset-4"
+          >
+            Go to dashboard
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  const isAdmin = org.role === "org_admin";
+
+  return (
+    <div className="flex min-h-screen">
+      <OrgSettingsSidebar
+        orgSlug={orgSlug}
+        orgName={org.name}
+        isAdmin={isAdmin}
+      />
+      <main className="flex-1 overflow-y-auto p-6 max-w-4xl">
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/web/src/app/(org)/orgs/[orgSlug]/members/invite-member-dialog.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/members/invite-member-dialog.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState } from "react";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import type { OrgRole } from "@/lib/api/types";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { UserPlus, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+interface InviteMemberDialogProps {
+  orgId: string;
+  onInvited: () => void;
+}
+
+export function InviteMemberDialog({
+  orgId,
+  onInvited,
+}: InviteMemberDialogProps) {
+  const { getAccessToken } = useAccessToken();
+  const [open, setOpen] = useState(false);
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<OrgRole>("org_member");
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string>();
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (next) {
+      setEmail("");
+      setRole("org_member");
+      setError(undefined);
+    }
+  }
+
+  async function handleInvite() {
+    if (!email.trim()) return;
+    setError(undefined);
+    setSending(true);
+    try {
+      const token = await getAccessToken();
+      if (!token) return;
+      const api = createApiClient(token);
+      await api.post(`/v1/organizations/${orgId}/memberships`, {
+        email: email.trim(),
+        role,
+      });
+      toast.success(`Invited ${email.trim()}`);
+      setOpen(false);
+      onInvited();
+    } catch (err) {
+      setError(
+        err instanceof ApiError ? err.message : "Failed to send invite",
+      );
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger render={<Button size="sm" />}>
+        <UserPlus className="size-4 mr-1.5" />
+        Invite Member
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Invite Member</DialogTitle>
+          <DialogDescription>
+            Send an invitation to join this organization. Invites expire after 7
+            days.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-1.5">Email</label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              disabled={sending}
+              placeholder="colleague@company.com"
+              className="block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:opacity-50"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1.5">Role</label>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setRole("org_member")}
+                disabled={sending}
+                className={`flex-1 rounded-lg border px-3 py-2 text-sm transition-colors ${
+                  role === "org_member"
+                    ? "border-primary bg-primary/10 text-foreground"
+                    : "border-input text-muted-foreground hover:text-foreground"
+                } disabled:opacity-50`}
+              >
+                Member
+              </button>
+              <button
+                type="button"
+                onClick={() => setRole("org_admin")}
+                disabled={sending}
+                className={`flex-1 rounded-lg border px-3 py-2 text-sm transition-colors ${
+                  role === "org_admin"
+                    ? "border-primary bg-primary/10 text-foreground"
+                    : "border-input text-muted-foreground hover:text-foreground"
+                } disabled:opacity-50`}
+              >
+                Admin
+              </button>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {role === "org_admin"
+                ? "Admins can manage members, workspaces, and settings."
+                : "Members can access assigned workspaces."}
+            </p>
+          </div>
+
+          {error && (
+            <div className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2 text-xs text-destructive">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button onClick={handleInvite} disabled={!email.trim() || sending}>
+            {sending && (
+              <Loader2
+                data-icon="inline-start"
+                className="size-4 animate-spin"
+              />
+            )}
+            {sending ? "Inviting..." : "Send Invite"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/app/(org)/orgs/[orgSlug]/members/invite-member-dialog.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/members/invite-member-dialog.tsx
@@ -6,6 +6,8 @@ import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";
 import type { OrgRole } from "@/lib/api/types";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ToggleGroup } from "@/components/ui/toggle-group";
 import {
   Dialog,
   DialogContent,
@@ -85,44 +87,26 @@ export function InviteMemberDialog({
         <div className="space-y-4">
           <div>
             <label className="block text-sm font-medium mb-1.5">Email</label>
-            <input
+            <Input
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               disabled={sending}
               placeholder="colleague@company.com"
-              className="block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:opacity-50"
             />
           </div>
 
           <div>
             <label className="block text-sm font-medium mb-1.5">Role</label>
-            <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={() => setRole("org_member")}
-                disabled={sending}
-                className={`flex-1 rounded-lg border px-3 py-2 text-sm transition-colors ${
-                  role === "org_member"
-                    ? "border-primary bg-primary/10 text-foreground"
-                    : "border-input text-muted-foreground hover:text-foreground"
-                } disabled:opacity-50`}
-              >
-                Member
-              </button>
-              <button
-                type="button"
-                onClick={() => setRole("org_admin")}
-                disabled={sending}
-                className={`flex-1 rounded-lg border px-3 py-2 text-sm transition-colors ${
-                  role === "org_admin"
-                    ? "border-primary bg-primary/10 text-foreground"
-                    : "border-input text-muted-foreground hover:text-foreground"
-                } disabled:opacity-50`}
-              >
-                Admin
-              </button>
-            </div>
+            <ToggleGroup
+              options={[
+                { value: "org_member" as const, label: "Member" },
+                { value: "org_admin" as const, label: "Admin" },
+              ]}
+              value={role}
+              onChange={setRole}
+              disabled={sending}
+            />
             <p className="mt-1 text-xs text-muted-foreground">
               {role === "org_admin"
                 ? "Admins can manage members, workspaces, and settings."

--- a/web/src/app/(org)/orgs/[orgSlug]/members/org-members-client.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/members/org-members-client.tsx
@@ -58,7 +58,6 @@ function isInviteExpired(member: OrgMember): boolean {
 
 interface OrgMembersClientProps {
   orgId: string;
-  orgSlug: string;
   isAdmin: boolean;
   currentUserId: string;
   initialMembers: OrgMember[];
@@ -67,7 +66,6 @@ interface OrgMembersClientProps {
 
 export function OrgMembersClient({
   orgId,
-  orgSlug,
   isAdmin,
   currentUserId,
   initialMembers,

--- a/web/src/app/(org)/orgs/[orgSlug]/members/org-members-client.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/members/org-members-client.tsx
@@ -158,6 +158,11 @@ export function OrgMembersClient({
       </div>
 
       {/* Table */}
+      {members.length === 0 ? (
+        <div className="rounded-lg border border-border bg-card p-8 text-center text-sm text-muted-foreground">
+          No members found.
+        </div>
+      ) : (
       <div className="rounded-lg border border-border">
         <Table>
           <TableHeader>
@@ -292,6 +297,7 @@ export function OrgMembersClient({
           </TableBody>
         </Table>
       </div>
+      )}
     </div>
   );
 }

--- a/web/src/app/(org)/orgs/[orgSlug]/members/org-members-client.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/members/org-members-client.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import type { OrgMember, OrgRole, OrgMembershipStatus } from "@/lib/api/types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { MoreHorizontal } from "lucide-react";
+import { toast } from "sonner";
+import { InviteMemberDialog } from "./invite-member-dialog";
+
+const roleBadgeVariant: Record<string, "default" | "secondary" | "outline"> = {
+  org_admin: "default",
+  org_member: "secondary",
+};
+
+const statusBadgeVariant: Record<
+  string,
+  "default" | "secondary" | "outline" | "destructive"
+> = {
+  active: "default",
+  invited: "outline",
+  suspended: "secondary",
+  archived: "destructive",
+};
+
+function roleLabel(role: string): string {
+  return role === "org_admin" ? "Admin" : "Member";
+}
+
+function statusLabel(status: string): string {
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+function isInviteExpired(member: OrgMember): boolean {
+  if (member.membership_status !== "invited") return false;
+  const createdAt = new Date(member.created_at).getTime();
+  const sevenDays = 7 * 24 * 60 * 60 * 1000;
+  return Date.now() - createdAt > sevenDays;
+}
+
+interface OrgMembersClientProps {
+  orgId: string;
+  orgSlug: string;
+  isAdmin: boolean;
+  currentUserId: string;
+  initialMembers: OrgMember[];
+  initialTotal: number;
+}
+
+export function OrgMembersClient({
+  orgId,
+  orgSlug,
+  isAdmin,
+  currentUserId,
+  initialMembers,
+  initialTotal,
+}: OrgMembersClientProps) {
+  const { getAccessToken } = useAccessToken();
+  const [members, setMembers] = useState<OrgMember[]>(initialMembers);
+  const [total, setTotal] = useState(initialTotal);
+
+  const adminCount = members.filter(
+    (m) =>
+      m.role === "org_admin" &&
+      (m.membership_status === "active" || m.membership_status === "invited"),
+  ).length;
+
+  const refreshMembers = useCallback(async () => {
+    try {
+      const token = await getAccessToken();
+      if (!token) return;
+      const api = createApiClient(token);
+      const res = await api.get<{
+        items: OrgMember[];
+        total: number;
+      }>(`/v1/organizations/${orgId}/memberships`, {
+        params: { limit: 50, offset: 0 },
+      });
+      setMembers(res.items);
+      setTotal(res.total);
+    } catch {
+      // Silently fail
+    }
+  }, [getAccessToken, orgId]);
+
+  async function handleChangeRole(member: OrgMember, newRole: OrgRole) {
+    try {
+      const token = await getAccessToken();
+      if (!token) return;
+      const api = createApiClient(token);
+      await api.patch(`/v1/organization-memberships/${member.id}`, {
+        role: newRole,
+      });
+      toast.success(`Changed ${member.display_name || member.email} to ${roleLabel(newRole)}`);
+      refreshMembers();
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError ? err.message : "Failed to change role",
+      );
+    }
+  }
+
+  async function handleChangeStatus(
+    member: OrgMember,
+    newStatus: OrgMembershipStatus,
+  ) {
+    try {
+      const token = await getAccessToken();
+      if (!token) return;
+      const api = createApiClient(token);
+      await api.patch(`/v1/organization-memberships/${member.id}`, {
+        status: newStatus,
+      });
+      toast.success(
+        `${statusLabel(newStatus)} ${member.display_name || member.email}`,
+      );
+      refreshMembers();
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError ? err.message : "Failed to update member",
+      );
+    }
+  }
+
+  function canManageMember(member: OrgMember): boolean {
+    if (!isAdmin) return false;
+    if (member.user_id === currentUserId) return false;
+    if (member.role === "org_admin" && adminCount <= 1) return false;
+    return true;
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          {total} member{total !== 1 ? "s" : ""}
+        </p>
+        {isAdmin && (
+          <InviteMemberDialog orgId={orgId} onInvited={refreshMembers} />
+        )}
+      </div>
+
+      {/* Table */}
+      <div className="rounded-lg border border-border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Member</TableHead>
+              <TableHead>Role</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Joined</TableHead>
+              {isAdmin && <TableHead className="w-12" />}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {members.map((member) => {
+              const expired = isInviteExpired(member);
+              const manageable = canManageMember(member);
+              const isLastAdmin =
+                member.role === "org_admin" && adminCount <= 1;
+
+              return (
+                <TableRow key={member.id}>
+                  <TableCell>
+                    <div>
+                      <span className="font-medium text-sm">
+                        {member.display_name || member.email}
+                      </span>
+                      {member.display_name && (
+                        <p className="text-xs text-muted-foreground">
+                          {member.email}
+                        </p>
+                      )}
+                      {member.user_id === currentUserId && (
+                        <span className="text-xs text-muted-foreground ml-1">
+                          (you)
+                        </span>
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={roleBadgeVariant[member.role] ?? "outline"}>
+                      {roleLabel(member.role)}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-1.5">
+                      <Badge
+                        variant={
+                          statusBadgeVariant[member.membership_status] ??
+                          "outline"
+                        }
+                      >
+                        {statusLabel(member.membership_status)}
+                      </Badge>
+                      {expired && (
+                        <span className="text-xs text-destructive">
+                          Expired
+                        </span>
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {new Date(member.created_at).toLocaleDateString()}
+                  </TableCell>
+                  {isAdmin && (
+                    <TableCell>
+                      {manageable && (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger
+                            render={
+                              <Button variant="ghost" size="icon-xs" />
+                            }
+                          >
+                            <MoreHorizontal className="size-4" />
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            {/* Role change */}
+                            {member.role === "org_member" && (
+                              <DropdownMenuItem
+                                onClick={() =>
+                                  handleChangeRole(member, "org_admin")
+                                }
+                              >
+                                Make Admin
+                              </DropdownMenuItem>
+                            )}
+                            {member.role === "org_admin" && !isLastAdmin && (
+                              <DropdownMenuItem
+                                onClick={() =>
+                                  handleChangeRole(member, "org_member")
+                                }
+                              >
+                                Make Member
+                              </DropdownMenuItem>
+                            )}
+                            <DropdownMenuSeparator />
+                            {/* Status change */}
+                            {member.membership_status === "active" && (
+                              <DropdownMenuItem
+                                onClick={() =>
+                                  handleChangeStatus(member, "suspended")
+                                }
+                              >
+                                Suspend
+                              </DropdownMenuItem>
+                            )}
+                            {member.membership_status === "suspended" && (
+                              <DropdownMenuItem
+                                onClick={() =>
+                                  handleChangeStatus(member, "active")
+                                }
+                              >
+                                Reactivate
+                              </DropdownMenuItem>
+                            )}
+                            {member.membership_status !== "archived" && (
+                              <DropdownMenuItem
+                                className="text-destructive"
+                                onClick={() =>
+                                  handleChangeStatus(member, "archived")
+                                }
+                              >
+                                Archive
+                              </DropdownMenuItem>
+                            )}
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      )}
+                    </TableCell>
+                  )}
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(org)/orgs/[orgSlug]/members/org-members-client.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/members/org-members-client.tsx
@@ -80,10 +80,10 @@ export function OrgMembersClient({
   const [total, setTotal] = useState(initialTotal);
   const [offset, setOffset] = useState(0);
 
-  const adminCount = members.filter(
-    (m) =>
-      m.role === "org_admin" &&
-      (m.membership_status === "active" || m.membership_status === "invited"),
+  // Only count active admins for last-admin protection — invited admins
+  // haven't accepted yet, so they shouldn't prevent demoting the last active one
+  const activeAdminCount = members.filter(
+    (m) => m.role === "org_admin" && m.membership_status === "active",
   ).length;
 
   const fetchMembers = useCallback(
@@ -174,7 +174,7 @@ export function OrgMembersClient({
     if (member.user_id === currentUserId) return false;
     if (
       member.role === "org_admin" &&
-      adminCount <= 1 &&
+      activeAdminCount <= 1 &&
       member.membership_status !== "suspended" &&
       member.membership_status !== "archived"
     )
@@ -234,7 +234,7 @@ export function OrgMembersClient({
                 const expired = isInviteExpired(member);
                 const manageable = canManageMember(member);
                 const isLastAdmin =
-                  member.role === "org_admin" && adminCount <= 1;
+                  member.role === "org_admin" && activeAdminCount <= 1;
                 const isInactive =
                   member.membership_status === "suspended" ||
                   member.membership_status === "archived";

--- a/web/src/app/(org)/orgs/[orgSlug]/members/org-members-client.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/members/org-members-client.tsx
@@ -22,7 +22,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { MoreHorizontal, ChevronLeft, ChevronRight } from "lucide-react";
+import { PaginationControls } from "@/components/ui/pagination-controls";
+import { MoreHorizontal } from "lucide-react";
 import { toast } from "sonner";
 import { InviteMemberDialog } from "./invite-member-dialog";
 
@@ -51,7 +52,6 @@ function statusLabel(status: string): string {
   return status.charAt(0).toUpperCase() + status.slice(1);
 }
 
-// P2 fix: use updated_at (re-invite refresh) with fallback to created_at
 function isInviteExpired(member: OrgMember): boolean {
   if (member.membership_status !== "invited") return false;
   const timestamp = member.updated_at ?? member.created_at;
@@ -59,6 +59,54 @@ function isInviteExpired(member: OrgMember): boolean {
   const sevenDays = 7 * 24 * 60 * 60 * 1000;
   return Date.now() - ts > sevenDays;
 }
+
+// --- Extracted action logic ---
+
+interface MemberAction {
+  label: string;
+  onClick: () => void;
+  variant?: "destructive";
+  separator?: boolean;
+}
+
+function getMemberActions(
+  member: OrgMember,
+  isLastAdmin: boolean,
+  onChangeRole: (role: OrgRole) => void,
+  onChangeStatus: (status: OrgMembershipStatus) => void,
+): MemberAction[] {
+  const actions: MemberAction[] = [];
+  const isArchived = member.membership_status === "archived";
+
+  // Role changes
+  if (!isArchived) {
+    if (member.role === "org_member") {
+      actions.push({ label: "Make Admin", onClick: () => onChangeRole("org_admin") });
+    }
+    if (member.role === "org_admin" && !isLastAdmin) {
+      actions.push({ label: "Make Member", onClick: () => onChangeRole("org_member") });
+    }
+  }
+
+  // Status changes
+  if (member.membership_status === "active") {
+    actions.push({ label: "Suspend", onClick: () => onChangeStatus("suspended"), separator: true });
+  }
+  if (member.membership_status === "suspended") {
+    actions.push({ label: "Reactivate", onClick: () => onChangeStatus("active"), separator: true });
+  }
+  if (!isArchived) {
+    actions.push({
+      label: "Archive",
+      onClick: () => onChangeStatus("archived"),
+      variant: "destructive",
+    });
+  }
+
+  return actions;
+}
+
+// --- Component ---
 
 interface OrgMembersClientProps {
   orgId: string;
@@ -80,8 +128,6 @@ export function OrgMembersClient({
   const [total, setTotal] = useState(initialTotal);
   const [offset, setOffset] = useState(0);
 
-  // Only count active admins for last-admin protection — invited admins
-  // haven't accepted yet, so they shouldn't prevent demoting the last active one
   const activeAdminCount = members.filter(
     (m) => m.role === "org_admin" && m.membership_status === "active",
   ).length;
@@ -112,7 +158,6 @@ export function OrgMembersClient({
   }
 
   async function handleChangeRole(member: OrgMember, newRole: OrgRole) {
-    // P1 fix: optimistic update so the member stays visible
     setMembers((prev) =>
       prev.map((m) => (m.id === member.id ? { ...m, role: newRole } : m)),
     );
@@ -131,7 +176,7 @@ export function OrgMembersClient({
       toast.error(
         err instanceof ApiError ? err.message : "Failed to change role",
       );
-      refreshMembers(); // revert optimistic update
+      refreshMembers();
     }
   }
 
@@ -139,13 +184,9 @@ export function OrgMembersClient({
     member: OrgMember,
     newStatus: OrgMembershipStatus,
   ) {
-    // P1 fix: optimistic update keeps suspended/archived members visible
-    // in the current page so the Reactivate action stays accessible
     setMembers((prev) =>
       prev.map((m) =>
-        m.id === member.id
-          ? { ...m, membership_status: newStatus }
-          : m,
+        m.id === member.id ? { ...m, membership_status: newStatus } : m,
       ),
     );
     try {
@@ -158,14 +199,12 @@ export function OrgMembersClient({
       toast.success(
         `${statusLabel(newStatus)} ${member.display_name || member.email}`,
       );
-      // Re-fetch to get server state, but optimistic update keeps row visible
-      // even if backend filters it out
       refreshMembers();
     } catch (err) {
       toast.error(
         err instanceof ApiError ? err.message : "Failed to update member",
       );
-      refreshMembers(); // revert optimistic update
+      refreshMembers();
     }
   }
 
@@ -182,27 +221,13 @@ export function OrgMembersClient({
     return true;
   }
 
-  // Pagination
-  const page = Math.floor(offset / PAGE_SIZE) + 1;
-  const totalPages = Math.ceil(total / PAGE_SIZE);
-
-  function handlePrev() {
-    const newOffset = Math.max(0, offset - PAGE_SIZE);
+  function handlePageChange(newOffset: number) {
     setOffset(newOffset);
     fetchMembers(newOffset);
   }
 
-  function handleNext() {
-    const newOffset = offset + PAGE_SIZE;
-    if (newOffset < total) {
-      setOffset(newOffset);
-      fetchMembers(newOffset);
-    }
-  }
-
   return (
     <div className="space-y-4">
-      {/* Header */}
       <div className="flex items-center justify-between">
         <p className="text-sm text-muted-foreground">
           {total} member{total !== 1 ? "s" : ""}
@@ -212,7 +237,6 @@ export function OrgMembersClient({
         )}
       </div>
 
-      {/* Table */}
       {members.length === 0 ? (
         <div className="rounded-lg border border-border bg-card p-8 text-center text-sm text-muted-foreground">
           No members found.
@@ -238,6 +262,14 @@ export function OrgMembersClient({
                 const isInactive =
                   member.membership_status === "suspended" ||
                   member.membership_status === "archived";
+                const actions = manageable
+                  ? getMemberActions(
+                      member,
+                      isLastAdmin,
+                      (role) => handleChangeRole(member, role),
+                      (status) => handleChangeStatus(member, status),
+                    )
+                  : [];
 
                 return (
                   <TableRow
@@ -290,7 +322,7 @@ export function OrgMembersClient({
                     </TableCell>
                     {isAdmin && (
                       <TableCell>
-                        {manageable && (
+                        {actions.length > 0 && (
                           <DropdownMenu>
                             <DropdownMenuTrigger
                               render={
@@ -300,60 +332,23 @@ export function OrgMembersClient({
                               <MoreHorizontal className="size-4" />
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="end">
-                              {/* Role change */}
-                              {member.role === "org_member" &&
-                                member.membership_status !== "archived" && (
+                              {actions.map((action, i) => (
+                                <span key={action.label}>
+                                  {action.separator && i > 0 && (
+                                    <DropdownMenuSeparator />
+                                  )}
                                   <DropdownMenuItem
-                                    onClick={() =>
-                                      handleChangeRole(member, "org_admin")
+                                    className={
+                                      action.variant === "destructive"
+                                        ? "text-destructive"
+                                        : undefined
                                     }
+                                    onClick={action.onClick}
                                   >
-                                    Make Admin
+                                    {action.label}
                                   </DropdownMenuItem>
-                                )}
-                              {member.role === "org_admin" &&
-                                !isLastAdmin &&
-                                member.membership_status !== "archived" && (
-                                  <DropdownMenuItem
-                                    onClick={() =>
-                                      handleChangeRole(member, "org_member")
-                                    }
-                                  >
-                                    Make Member
-                                  </DropdownMenuItem>
-                                )}
-                              {member.membership_status !== "archived" && (
-                                <DropdownMenuSeparator />
-                              )}
-                              {/* Status change */}
-                              {member.membership_status === "active" && (
-                                <DropdownMenuItem
-                                  onClick={() =>
-                                    handleChangeStatus(member, "suspended")
-                                  }
-                                >
-                                  Suspend
-                                </DropdownMenuItem>
-                              )}
-                              {member.membership_status === "suspended" && (
-                                <DropdownMenuItem
-                                  onClick={() =>
-                                    handleChangeStatus(member, "active")
-                                  }
-                                >
-                                  Reactivate
-                                </DropdownMenuItem>
-                              )}
-                              {member.membership_status !== "archived" && (
-                                <DropdownMenuItem
-                                  className="text-destructive"
-                                  onClick={() =>
-                                    handleChangeStatus(member, "archived")
-                                  }
-                                >
-                                  Archive
-                                </DropdownMenuItem>
-                              )}
+                                </span>
+                              ))}
                             </DropdownMenuContent>
                           </DropdownMenu>
                         )}
@@ -367,32 +362,16 @@ export function OrgMembersClient({
         </div>
       )}
 
-      {/* Pagination */}
-      {totalPages > 1 && (
-        <div className="flex items-center justify-between">
-          <p className="text-sm text-muted-foreground">
-            Page {page} of {totalPages}
-          </p>
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              size="icon-sm"
-              disabled={offset === 0}
-              onClick={handlePrev}
-            >
-              <ChevronLeft className="size-4" />
-            </Button>
-            <Button
-              variant="outline"
-              size="icon-sm"
-              disabled={offset + PAGE_SIZE >= total}
-              onClick={handleNext}
-            >
-              <ChevronRight className="size-4" />
-            </Button>
-          </div>
-        </div>
-      )}
+      <PaginationControls
+        offset={offset}
+        total={total}
+        pageSize={PAGE_SIZE}
+        onPrev={() => handlePageChange(Math.max(0, offset - PAGE_SIZE))}
+        onNext={() => {
+          const next = offset + PAGE_SIZE;
+          if (next < total) handlePageChange(next);
+        }}
+      />
     </div>
   );
 }

--- a/web/src/app/(org)/orgs/[orgSlug]/members/org-members-client.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/members/org-members-client.tsx
@@ -22,9 +22,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { MoreHorizontal } from "lucide-react";
+import { MoreHorizontal, ChevronLeft, ChevronRight } from "lucide-react";
 import { toast } from "sonner";
 import { InviteMemberDialog } from "./invite-member-dialog";
+
+const PAGE_SIZE = 50;
 
 const roleBadgeVariant: Record<string, "default" | "secondary" | "outline"> = {
   org_admin: "default",
@@ -49,11 +51,13 @@ function statusLabel(status: string): string {
   return status.charAt(0).toUpperCase() + status.slice(1);
 }
 
+// P2 fix: use updated_at (re-invite refresh) with fallback to created_at
 function isInviteExpired(member: OrgMember): boolean {
   if (member.membership_status !== "invited") return false;
-  const createdAt = new Date(member.created_at).getTime();
+  const timestamp = member.updated_at ?? member.created_at;
+  const ts = new Date(timestamp).getTime();
   const sevenDays = 7 * 24 * 60 * 60 * 1000;
-  return Date.now() - createdAt > sevenDays;
+  return Date.now() - ts > sevenDays;
 }
 
 interface OrgMembersClientProps {
@@ -74,6 +78,7 @@ export function OrgMembersClient({
   const { getAccessToken } = useAccessToken();
   const [members, setMembers] = useState<OrgMember[]>(initialMembers);
   const [total, setTotal] = useState(initialTotal);
+  const [offset, setOffset] = useState(0);
 
   const adminCount = members.filter(
     (m) =>
@@ -81,25 +86,36 @@ export function OrgMembersClient({
       (m.membership_status === "active" || m.membership_status === "invited"),
   ).length;
 
-  const refreshMembers = useCallback(async () => {
-    try {
-      const token = await getAccessToken();
-      if (!token) return;
-      const api = createApiClient(token);
-      const res = await api.get<{
-        items: OrgMember[];
-        total: number;
-      }>(`/v1/organizations/${orgId}/memberships`, {
-        params: { limit: 50, offset: 0 },
-      });
-      setMembers(res.items);
-      setTotal(res.total);
-    } catch {
-      // Silently fail
-    }
-  }, [getAccessToken, orgId]);
+  const fetchMembers = useCallback(
+    async (currentOffset: number) => {
+      try {
+        const token = await getAccessToken();
+        if (!token) return;
+        const api = createApiClient(token);
+        const res = await api.get<{
+          items: OrgMember[];
+          total: number;
+        }>(`/v1/organizations/${orgId}/memberships`, {
+          params: { limit: PAGE_SIZE, offset: currentOffset },
+        });
+        setMembers(res.items);
+        setTotal(res.total);
+      } catch {
+        // Silently fail
+      }
+    },
+    [getAccessToken, orgId],
+  );
+
+  function refreshMembers() {
+    fetchMembers(offset);
+  }
 
   async function handleChangeRole(member: OrgMember, newRole: OrgRole) {
+    // P1 fix: optimistic update so the member stays visible
+    setMembers((prev) =>
+      prev.map((m) => (m.id === member.id ? { ...m, role: newRole } : m)),
+    );
     try {
       const token = await getAccessToken();
       if (!token) return;
@@ -107,12 +123,15 @@ export function OrgMembersClient({
       await api.patch(`/v1/organization-memberships/${member.id}`, {
         role: newRole,
       });
-      toast.success(`Changed ${member.display_name || member.email} to ${roleLabel(newRole)}`);
+      toast.success(
+        `Changed ${member.display_name || member.email} to ${roleLabel(newRole)}`,
+      );
       refreshMembers();
     } catch (err) {
       toast.error(
         err instanceof ApiError ? err.message : "Failed to change role",
       );
+      refreshMembers(); // revert optimistic update
     }
   }
 
@@ -120,6 +139,15 @@ export function OrgMembersClient({
     member: OrgMember,
     newStatus: OrgMembershipStatus,
   ) {
+    // P1 fix: optimistic update keeps suspended/archived members visible
+    // in the current page so the Reactivate action stays accessible
+    setMembers((prev) =>
+      prev.map((m) =>
+        m.id === member.id
+          ? { ...m, membership_status: newStatus }
+          : m,
+      ),
+    );
     try {
       const token = await getAccessToken();
       if (!token) return;
@@ -130,19 +158,46 @@ export function OrgMembersClient({
       toast.success(
         `${statusLabel(newStatus)} ${member.display_name || member.email}`,
       );
+      // Re-fetch to get server state, but optimistic update keeps row visible
+      // even if backend filters it out
       refreshMembers();
     } catch (err) {
       toast.error(
         err instanceof ApiError ? err.message : "Failed to update member",
       );
+      refreshMembers(); // revert optimistic update
     }
   }
 
   function canManageMember(member: OrgMember): boolean {
     if (!isAdmin) return false;
     if (member.user_id === currentUserId) return false;
-    if (member.role === "org_admin" && adminCount <= 1) return false;
+    if (
+      member.role === "org_admin" &&
+      adminCount <= 1 &&
+      member.membership_status !== "suspended" &&
+      member.membership_status !== "archived"
+    )
+      return false;
     return true;
+  }
+
+  // Pagination
+  const page = Math.floor(offset / PAGE_SIZE) + 1;
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+
+  function handlePrev() {
+    const newOffset = Math.max(0, offset - PAGE_SIZE);
+    setOffset(newOffset);
+    fetchMembers(newOffset);
+  }
+
+  function handleNext() {
+    const newOffset = offset + PAGE_SIZE;
+    if (newOffset < total) {
+      setOffset(newOffset);
+      fetchMembers(newOffset);
+    }
   }
 
   return (
@@ -163,140 +218,180 @@ export function OrgMembersClient({
           No members found.
         </div>
       ) : (
-      <div className="rounded-lg border border-border">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Member</TableHead>
-              <TableHead>Role</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead>Joined</TableHead>
-              {isAdmin && <TableHead className="w-12" />}
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {members.map((member) => {
-              const expired = isInviteExpired(member);
-              const manageable = canManageMember(member);
-              const isLastAdmin =
-                member.role === "org_admin" && adminCount <= 1;
+        <div className="rounded-lg border border-border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Member</TableHead>
+                <TableHead>Role</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Joined</TableHead>
+                {isAdmin && <TableHead className="w-12" />}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {members.map((member) => {
+                const expired = isInviteExpired(member);
+                const manageable = canManageMember(member);
+                const isLastAdmin =
+                  member.role === "org_admin" && adminCount <= 1;
+                const isInactive =
+                  member.membership_status === "suspended" ||
+                  member.membership_status === "archived";
 
-              return (
-                <TableRow key={member.id}>
-                  <TableCell>
-                    <div>
-                      <span className="font-medium text-sm">
-                        {member.display_name || member.email}
-                      </span>
-                      {member.display_name && (
-                        <p className="text-xs text-muted-foreground">
-                          {member.email}
-                        </p>
-                      )}
-                      {member.user_id === currentUserId && (
-                        <span className="text-xs text-muted-foreground ml-1">
-                          (you)
-                        </span>
-                      )}
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant={roleBadgeVariant[member.role] ?? "outline"}>
-                      {roleLabel(member.role)}
-                    </Badge>
-                  </TableCell>
-                  <TableCell>
-                    <div className="flex items-center gap-1.5">
-                      <Badge
-                        variant={
-                          statusBadgeVariant[member.membership_status] ??
-                          "outline"
-                        }
-                      >
-                        {statusLabel(member.membership_status)}
-                      </Badge>
-                      {expired && (
-                        <span className="text-xs text-destructive">
-                          Expired
-                        </span>
-                      )}
-                    </div>
-                  </TableCell>
-                  <TableCell className="text-sm text-muted-foreground">
-                    {new Date(member.created_at).toLocaleDateString()}
-                  </TableCell>
-                  {isAdmin && (
+                return (
+                  <TableRow
+                    key={member.id}
+                    className={isInactive ? "opacity-60" : undefined}
+                  >
                     <TableCell>
-                      {manageable && (
-                        <DropdownMenu>
-                          <DropdownMenuTrigger
-                            render={
-                              <Button variant="ghost" size="icon-xs" />
-                            }
-                          >
-                            <MoreHorizontal className="size-4" />
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end">
-                            {/* Role change */}
-                            {member.role === "org_member" && (
-                              <DropdownMenuItem
-                                onClick={() =>
-                                  handleChangeRole(member, "org_admin")
-                                }
-                              >
-                                Make Admin
-                              </DropdownMenuItem>
-                            )}
-                            {member.role === "org_admin" && !isLastAdmin && (
-                              <DropdownMenuItem
-                                onClick={() =>
-                                  handleChangeRole(member, "org_member")
-                                }
-                              >
-                                Make Member
-                              </DropdownMenuItem>
-                            )}
-                            <DropdownMenuSeparator />
-                            {/* Status change */}
-                            {member.membership_status === "active" && (
-                              <DropdownMenuItem
-                                onClick={() =>
-                                  handleChangeStatus(member, "suspended")
-                                }
-                              >
-                                Suspend
-                              </DropdownMenuItem>
-                            )}
-                            {member.membership_status === "suspended" && (
-                              <DropdownMenuItem
-                                onClick={() =>
-                                  handleChangeStatus(member, "active")
-                                }
-                              >
-                                Reactivate
-                              </DropdownMenuItem>
-                            )}
-                            {member.membership_status !== "archived" && (
-                              <DropdownMenuItem
-                                className="text-destructive"
-                                onClick={() =>
-                                  handleChangeStatus(member, "archived")
-                                }
-                              >
-                                Archive
-                              </DropdownMenuItem>
-                            )}
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      )}
+                      <div>
+                        <span className="font-medium text-sm">
+                          {member.display_name || member.email}
+                        </span>
+                        {member.display_name && (
+                          <p className="text-xs text-muted-foreground">
+                            {member.email}
+                          </p>
+                        )}
+                        {member.user_id === currentUserId && (
+                          <span className="text-xs text-muted-foreground ml-1">
+                            (you)
+                          </span>
+                        )}
+                      </div>
                     </TableCell>
-                  )}
-                </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
-      </div>
+                    <TableCell>
+                      <Badge
+                        variant={roleBadgeVariant[member.role] ?? "outline"}
+                      >
+                        {roleLabel(member.role)}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-1.5">
+                        <Badge
+                          variant={
+                            statusBadgeVariant[member.membership_status] ??
+                            "outline"
+                          }
+                        >
+                          {statusLabel(member.membership_status)}
+                        </Badge>
+                        {expired && (
+                          <span className="text-xs text-destructive">
+                            Expired
+                          </span>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {new Date(member.created_at).toLocaleDateString()}
+                    </TableCell>
+                    {isAdmin && (
+                      <TableCell>
+                        {manageable && (
+                          <DropdownMenu>
+                            <DropdownMenuTrigger
+                              render={
+                                <Button variant="ghost" size="icon-xs" />
+                              }
+                            >
+                              <MoreHorizontal className="size-4" />
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                              {/* Role change */}
+                              {member.role === "org_member" &&
+                                member.membership_status !== "archived" && (
+                                  <DropdownMenuItem
+                                    onClick={() =>
+                                      handleChangeRole(member, "org_admin")
+                                    }
+                                  >
+                                    Make Admin
+                                  </DropdownMenuItem>
+                                )}
+                              {member.role === "org_admin" &&
+                                !isLastAdmin &&
+                                member.membership_status !== "archived" && (
+                                  <DropdownMenuItem
+                                    onClick={() =>
+                                      handleChangeRole(member, "org_member")
+                                    }
+                                  >
+                                    Make Member
+                                  </DropdownMenuItem>
+                                )}
+                              {member.membership_status !== "archived" && (
+                                <DropdownMenuSeparator />
+                              )}
+                              {/* Status change */}
+                              {member.membership_status === "active" && (
+                                <DropdownMenuItem
+                                  onClick={() =>
+                                    handleChangeStatus(member, "suspended")
+                                  }
+                                >
+                                  Suspend
+                                </DropdownMenuItem>
+                              )}
+                              {member.membership_status === "suspended" && (
+                                <DropdownMenuItem
+                                  onClick={() =>
+                                    handleChangeStatus(member, "active")
+                                  }
+                                >
+                                  Reactivate
+                                </DropdownMenuItem>
+                              )}
+                              {member.membership_status !== "archived" && (
+                                <DropdownMenuItem
+                                  className="text-destructive"
+                                  onClick={() =>
+                                    handleChangeStatus(member, "archived")
+                                  }
+                                >
+                                  Archive
+                                </DropdownMenuItem>
+                              )}
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        )}
+                      </TableCell>
+                    )}
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-muted-foreground">
+            Page {page} of {totalPages}
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="icon-sm"
+              disabled={offset === 0}
+              onClick={handlePrev}
+            >
+              <ChevronLeft className="size-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon-sm"
+              disabled={offset + PAGE_SIZE >= total}
+              onClick={handleNext}
+            >
+              <ChevronRight className="size-4" />
+            </Button>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/web/src/app/(org)/orgs/[orgSlug]/members/org-members-loader.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/members/org-members-loader.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import type { OrgMember } from "@/lib/api/types";
+import { useOrgContext } from "../org-context";
+import { OrgMembersClient } from "./org-members-client";
+import { Loader2 } from "lucide-react";
+
+export function OrgMembersLoader() {
+  const { orgId, isAdmin, currentUserId } = useOrgContext();
+  const { getAccessToken } = useAccessToken();
+  const [members, setMembers] = useState<OrgMember[] | null>(null);
+  const [total, setTotal] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = await getAccessToken();
+        if (!token) return;
+        const api = createApiClient(token);
+        const res = await api.get<{ items: OrgMember[]; total: number }>(
+          `/v1/organizations/${orgId}/memberships`,
+          { params: { limit: 50, offset: 0 } },
+        );
+        if (!cancelled) {
+          setMembers(res.items);
+          setTotal(res.total);
+        }
+      } catch {
+        if (!cancelled) setMembers([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [getAccessToken, orgId]);
+
+  if (!members) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="size-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <OrgMembersClient
+      orgId={orgId}
+      isAdmin={isAdmin}
+      currentUserId={currentUserId}
+      initialMembers={members}
+      initialTotal={total}
+    />
+  );
+}

--- a/web/src/app/(org)/orgs/[orgSlug]/members/org-members-loader.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/members/org-members-loader.tsx
@@ -1,44 +1,18 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
-import { createApiClient } from "@/lib/api/client";
 import type { OrgMember } from "@/lib/api/types";
 import { useOrgContext } from "../org-context";
+import { useOrgFetch } from "../use-org-fetch";
 import { OrgMembersClient } from "./org-members-client";
 import { Loader2 } from "lucide-react";
 
 export function OrgMembersLoader() {
   const { orgId, isAdmin, currentUserId } = useOrgContext();
-  const { getAccessToken } = useAccessToken();
-  const [members, setMembers] = useState<OrgMember[] | null>(null);
-  const [total, setTotal] = useState(0);
+  const { data: members, total, loading } = useOrgFetch<OrgMember>(
+    `/v1/organizations/${orgId}/memberships`,
+  );
 
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const token = await getAccessToken();
-        if (!token) return;
-        const api = createApiClient(token);
-        const res = await api.get<{ items: OrgMember[]; total: number }>(
-          `/v1/organizations/${orgId}/memberships`,
-          { params: { limit: 50, offset: 0 } },
-        );
-        if (!cancelled) {
-          setMembers(res.items);
-          setTotal(res.total);
-        }
-      } catch {
-        if (!cancelled) setMembers([]);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [getAccessToken, orgId]);
-
-  if (!members) {
+  if (loading || !members) {
     return (
       <div className="flex items-center justify-center py-12">
         <Loader2 className="size-5 animate-spin text-muted-foreground" />

--- a/web/src/app/(org)/orgs/[orgSlug]/members/page.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/members/page.tsx
@@ -1,47 +1,10 @@
-import { withAuth } from "@workos-inc/authkit-nextjs";
-import { redirect } from "next/navigation";
-import { createApiClient } from "@/lib/api/client";
-import type { OrgMember } from "@/lib/api/types";
-import { OrgMembersClient } from "./org-members-client";
+import { OrgMembersLoader } from "./org-members-loader";
 
-export default async function OrgMembersPage({
-  params,
-}: {
-  params: Promise<{ orgSlug: string }>;
-}) {
-  const { accessToken } = await withAuth();
-  if (!accessToken) redirect("/auth/login");
-
-  const { orgSlug } = await params;
-
-  const api = createApiClient(accessToken);
-  const userMe = await api.get<{
-    user_id: string;
-    organizations: { id: string; slug: string; role: string }[];
-  }>("/v1/users/me");
-
-  const orgRef = userMe.organizations.find((o) => o.slug === orgSlug);
-  if (!orgRef) redirect("/dashboard");
-
-  const res = await api.get<{
-    items: OrgMember[];
-    total: number;
-    limit: number;
-    offset: number;
-  }>(`/v1/organizations/${orgRef.id}/memberships`, {
-    params: { limit: 50, offset: 0 },
-  });
-
+export default function OrgMembersPage() {
   return (
     <div>
       <h1 className="text-lg font-semibold tracking-tight mb-6">Members</h1>
-      <OrgMembersClient
-        orgId={orgRef.id}
-        isAdmin={orgRef.role === "org_admin"}
-        currentUserId={userMe.user_id}
-        initialMembers={res.items}
-        initialTotal={res.total}
-      />
+      <OrgMembersLoader />
     </div>
   );
 }

--- a/web/src/app/(org)/orgs/[orgSlug]/members/page.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/members/page.tsx
@@ -37,7 +37,6 @@ export default async function OrgMembersPage({
       <h1 className="text-lg font-semibold tracking-tight mb-6">Members</h1>
       <OrgMembersClient
         orgId={orgRef.id}
-        orgSlug={orgSlug}
         isAdmin={orgRef.role === "org_admin"}
         currentUserId={userMe.user_id}
         initialMembers={res.items}

--- a/web/src/app/(org)/orgs/[orgSlug]/members/page.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/members/page.tsx
@@ -1,0 +1,48 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { redirect } from "next/navigation";
+import { createApiClient } from "@/lib/api/client";
+import type { OrgMember } from "@/lib/api/types";
+import { OrgMembersClient } from "./org-members-client";
+
+export default async function OrgMembersPage({
+  params,
+}: {
+  params: Promise<{ orgSlug: string }>;
+}) {
+  const { accessToken } = await withAuth();
+  if (!accessToken) redirect("/auth/login");
+
+  const { orgSlug } = await params;
+
+  const api = createApiClient(accessToken);
+  const userMe = await api.get<{
+    user_id: string;
+    organizations: { id: string; slug: string; role: string }[];
+  }>("/v1/users/me");
+
+  const orgRef = userMe.organizations.find((o) => o.slug === orgSlug);
+  if (!orgRef) redirect("/dashboard");
+
+  const res = await api.get<{
+    items: OrgMember[];
+    total: number;
+    limit: number;
+    offset: number;
+  }>(`/v1/organizations/${orgRef.id}/memberships`, {
+    params: { limit: 50, offset: 0 },
+  });
+
+  return (
+    <div>
+      <h1 className="text-lg font-semibold tracking-tight mb-6">Members</h1>
+      <OrgMembersClient
+        orgId={orgRef.id}
+        orgSlug={orgSlug}
+        isAdmin={orgRef.role === "org_admin"}
+        currentUserId={userMe.user_id}
+        initialMembers={res.items}
+        initialTotal={res.total}
+      />
+    </div>
+  );
+}

--- a/web/src/app/(org)/orgs/[orgSlug]/org-context.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/org-context.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+export interface OrgContextValue {
+  orgId: string;
+  orgSlug: string;
+  orgName: string;
+  isAdmin: boolean;
+  currentUserId: string;
+}
+
+const OrgContext = createContext<OrgContextValue | null>(null);
+
+export function OrgProvider({
+  value,
+  children,
+}: {
+  value: OrgContextValue;
+  children: React.ReactNode;
+}) {
+  return <OrgContext.Provider value={value}>{children}</OrgContext.Provider>;
+}
+
+export function useOrgContext(): OrgContextValue {
+  const ctx = useContext(OrgContext);
+  if (!ctx) {
+    throw new Error("useOrgContext must be used within an OrgProvider");
+  }
+  return ctx;
+}

--- a/web/src/app/(org)/orgs/[orgSlug]/org-settings-sidebar.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/org-settings-sidebar.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+import { Settings2, Users, Layers, ArrowLeft } from "lucide-react";
+
+interface OrgSettingsSidebarProps {
+  orgSlug: string;
+  orgName: string;
+  isAdmin: boolean;
+}
+
+const navItems = (orgSlug: string, isAdmin: boolean) => [
+  ...(isAdmin
+    ? [
+        {
+          label: "General",
+          href: `/orgs/${orgSlug}/settings`,
+          icon: Settings2,
+        },
+      ]
+    : []),
+  {
+    label: "Members",
+    href: `/orgs/${orgSlug}/members`,
+    icon: Users,
+  },
+  {
+    label: "Workspaces",
+    href: `/orgs/${orgSlug}/workspaces`,
+    icon: Layers,
+  },
+];
+
+export function OrgSettingsSidebar({
+  orgSlug,
+  orgName,
+  isAdmin,
+}: OrgSettingsSidebarProps) {
+  const pathname = usePathname();
+  const items = navItems(orgSlug, isAdmin);
+
+  return (
+    <aside className="w-56 shrink-0 border-r border-white/[0.06] bg-[#0a0a0a] p-4 flex flex-col">
+      <Link
+        href="/dashboard"
+        className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors mb-6"
+      >
+        <ArrowLeft className="size-3" />
+        Back to dashboard
+      </Link>
+
+      <div className="mb-4">
+        <h2 className="text-sm font-semibold truncate">{orgName}</h2>
+        <p className="text-xs text-muted-foreground">Organization settings</p>
+      </div>
+
+      <nav className="space-y-0.5">
+        {items.map((item) => {
+          const isActive = pathname === item.href;
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                "flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors",
+                isActive
+                  ? "bg-white/[0.08] text-foreground font-medium"
+                  : "text-muted-foreground hover:text-foreground hover:bg-white/[0.04]",
+              )}
+            >
+              <item.icon className="size-4" />
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}

--- a/web/src/app/(org)/orgs/[orgSlug]/settings/org-general-settings.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/settings/org-general-settings.tsx
@@ -30,6 +30,7 @@ export function OrgGeneralSettings({ org, orgSlug }: OrgGeneralSettingsProps) {
   const [name, setName] = useState(org.name);
   const [saving, setSaving] = useState(false);
   const [archiveOpen, setArchiveOpen] = useState(false);
+  const [archiveConfirm, setArchiveConfirm] = useState("");
   const [archiving, setArchiving] = useState(false);
 
   async function handleSaveName() {
@@ -112,7 +113,13 @@ export function OrgGeneralSettings({ org, orgSlug }: OrgGeneralSettingsProps) {
           Archiving this organization will cascade to all workspaces and
           memberships. This action cannot be easily undone.
         </p>
-        <Dialog open={archiveOpen} onOpenChange={setArchiveOpen}>
+        <Dialog
+          open={archiveOpen}
+          onOpenChange={(next) => {
+            setArchiveOpen(next);
+            if (next) setArchiveConfirm("");
+          }}
+        >
           <DialogTrigger render={<Button variant="destructive" size="sm" />}>
             Archive Organization
           </DialogTrigger>
@@ -120,19 +127,32 @@ export function OrgGeneralSettings({ org, orgSlug }: OrgGeneralSettingsProps) {
             <DialogHeader>
               <DialogTitle>Archive Organization</DialogTitle>
               <DialogDescription>
-                Are you sure you want to archive <strong>{org.name}</strong>?
                 This will archive all workspaces and remove all member access.
+                This action cannot be easily undone.
               </DialogDescription>
             </DialogHeader>
             <div className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2 text-xs text-destructive flex items-center gap-2">
               <AlertTriangle className="size-4 shrink-0" />
               This action cascades to all workspaces and memberships.
             </div>
+            <div>
+              <label className="block text-sm font-medium mb-1.5">
+                Type <strong>{org.name}</strong> to confirm
+              </label>
+              <input
+                type="text"
+                value={archiveConfirm}
+                onChange={(e) => setArchiveConfirm(e.target.value)}
+                disabled={archiving}
+                placeholder={org.name}
+                className="block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:opacity-50"
+              />
+            </div>
             <DialogFooter>
               <Button
                 variant="destructive"
                 onClick={handleArchive}
-                disabled={archiving}
+                disabled={archiving || archiveConfirm !== org.name}
               >
                 {archiving && (
                   <Loader2

--- a/web/src/app/(org)/orgs/[orgSlug]/settings/org-general-settings.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/settings/org-general-settings.tsx
@@ -7,6 +7,7 @@ import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";
 import type { Organization } from "@/lib/api/types";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Dialog,
   DialogContent,
@@ -79,12 +80,12 @@ export function OrgGeneralSettings({ org, orgSlug, onOrgUpdated }: OrgGeneralSet
           Organization Name
         </label>
         <div className="flex gap-3">
-          <input
+          <Input
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
             disabled={saving}
-            className="flex-1 rounded-lg border border-input bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:opacity-50"
+            className="flex-1"
           />
           <Button
             onClick={handleSaveName}
@@ -140,13 +141,12 @@ export function OrgGeneralSettings({ org, orgSlug, onOrgUpdated }: OrgGeneralSet
               <label className="block text-sm font-medium mb-1.5">
                 Type <strong>{org.name}</strong> to confirm
               </label>
-              <input
+              <Input
                 type="text"
                 value={archiveConfirm}
                 onChange={(e) => setArchiveConfirm(e.target.value)}
                 disabled={archiving}
                 placeholder={org.name}
-                className="block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:opacity-50"
               />
             </div>
             <DialogFooter>

--- a/web/src/app/(org)/orgs/[orgSlug]/settings/org-general-settings.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/settings/org-general-settings.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import type { Organization } from "@/lib/api/types";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Loader2, AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
+
+interface OrgGeneralSettingsProps {
+  org: Organization;
+  orgSlug: string;
+}
+
+export function OrgGeneralSettings({ org, orgSlug }: OrgGeneralSettingsProps) {
+  const { getAccessToken } = useAccessToken();
+  const router = useRouter();
+  const [name, setName] = useState(org.name);
+  const [saving, setSaving] = useState(false);
+  const [archiveOpen, setArchiveOpen] = useState(false);
+  const [archiving, setArchiving] = useState(false);
+
+  async function handleSaveName() {
+    if (!name.trim() || name === org.name) return;
+    setSaving(true);
+    try {
+      const token = await getAccessToken();
+      if (!token) return;
+      const api = createApiClient(token);
+      await api.patch(`/v1/organizations/${org.id}`, { name: name.trim() });
+      toast.success("Organization name updated");
+      router.refresh();
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError ? err.message : "Failed to update name",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleArchive() {
+    setArchiving(true);
+    try {
+      const token = await getAccessToken();
+      if (!token) return;
+      const api = createApiClient(token);
+      await api.patch(`/v1/organizations/${org.id}`, { status: "archived" });
+      toast.success("Organization archived");
+      router.push("/dashboard");
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError ? err.message : "Failed to archive",
+      );
+    } finally {
+      setArchiving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      {/* Name editor */}
+      <div className="rounded-lg border border-border p-4">
+        <label className="block text-sm font-medium mb-1.5">
+          Organization Name
+        </label>
+        <div className="flex gap-3">
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            disabled={saving}
+            className="flex-1 rounded-lg border border-input bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:opacity-50"
+          />
+          <Button
+            onClick={handleSaveName}
+            disabled={saving || !name.trim() || name === org.name}
+            size="sm"
+          >
+            {saving && (
+              <Loader2
+                data-icon="inline-start"
+                className="size-4 animate-spin"
+              />
+            )}
+            Save
+          </Button>
+        </div>
+        <p className="mt-1.5 text-xs text-muted-foreground">
+          Slug: <code className="font-[family-name:var(--font-mono)]">{orgSlug}</code>
+        </p>
+      </div>
+
+      {/* Danger zone */}
+      <div className="rounded-lg border border-destructive/20 p-4">
+        <h3 className="text-sm font-medium text-destructive mb-1">
+          Danger Zone
+        </h3>
+        <p className="text-xs text-muted-foreground mb-3">
+          Archiving this organization will cascade to all workspaces and
+          memberships. This action cannot be easily undone.
+        </p>
+        <Dialog open={archiveOpen} onOpenChange={setArchiveOpen}>
+          <DialogTrigger render={<Button variant="destructive" size="sm" />}>
+            Archive Organization
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Archive Organization</DialogTitle>
+              <DialogDescription>
+                Are you sure you want to archive <strong>{org.name}</strong>?
+                This will archive all workspaces and remove all member access.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2 text-xs text-destructive flex items-center gap-2">
+              <AlertTriangle className="size-4 shrink-0" />
+              This action cascades to all workspaces and memberships.
+            </div>
+            <DialogFooter>
+              <Button
+                variant="destructive"
+                onClick={handleArchive}
+                disabled={archiving}
+              >
+                {archiving && (
+                  <Loader2
+                    data-icon="inline-start"
+                    className="size-4 animate-spin"
+                  />
+                )}
+                {archiving ? "Archiving..." : "Yes, archive"}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(org)/orgs/[orgSlug]/settings/org-general-settings.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/settings/org-general-settings.tsx
@@ -22,9 +22,10 @@ import { toast } from "sonner";
 interface OrgGeneralSettingsProps {
   org: Organization;
   orgSlug: string;
+  onOrgUpdated?: (org: Organization) => void;
 }
 
-export function OrgGeneralSettings({ org, orgSlug }: OrgGeneralSettingsProps) {
+export function OrgGeneralSettings({ org, orgSlug, onOrgUpdated }: OrgGeneralSettingsProps) {
   const { getAccessToken } = useAccessToken();
   const router = useRouter();
   const [name, setName] = useState(org.name);
@@ -40,9 +41,9 @@ export function OrgGeneralSettings({ org, orgSlug }: OrgGeneralSettingsProps) {
       const token = await getAccessToken();
       if (!token) return;
       const api = createApiClient(token);
-      await api.patch(`/v1/organizations/${org.id}`, { name: name.trim() });
+      const updated = await api.patch<Organization>(`/v1/organizations/${org.id}`, { name: name.trim() });
       toast.success("Organization name updated");
-      router.refresh();
+      onOrgUpdated?.(updated);
     } catch (err) {
       toast.error(
         err instanceof ApiError ? err.message : "Failed to update name",

--- a/web/src/app/(org)/orgs/[orgSlug]/settings/org-settings-gate.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/settings/org-settings-gate.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import type { Organization } from "@/lib/api/types";
+import { useOrgContext } from "../org-context";
+import { OrgGeneralSettings } from "./org-general-settings";
+import { Loader2 } from "lucide-react";
+
+export function OrgSettingsGate({ orgSlug }: { orgSlug: string }) {
+  const { orgId, isAdmin } = useOrgContext();
+  const { getAccessToken } = useAccessToken();
+  const router = useRouter();
+  const [org, setOrg] = useState<Organization | null>(null);
+
+  useEffect(() => {
+    if (!isAdmin) {
+      router.replace(`/orgs/${orgSlug}/members`);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = await getAccessToken();
+        if (!token) return;
+        const api = createApiClient(token);
+        const data = await api.get<Organization>(
+          `/v1/organizations/${orgId}`,
+        );
+        if (!cancelled) setOrg(data);
+      } catch {
+        // Silently fail
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [orgId, isAdmin, orgSlug, router, getAccessToken]);
+
+  if (!isAdmin) return null;
+
+  if (!org) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="size-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h1 className="text-lg font-semibold tracking-tight mb-6">
+        General Settings
+      </h1>
+      <OrgGeneralSettings org={org} orgSlug={orgSlug} />
+    </div>
+  );
+}

--- a/web/src/app/(org)/orgs/[orgSlug]/settings/org-settings-gate.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/settings/org-settings-gate.tsx
@@ -7,13 +7,14 @@ import { createApiClient } from "@/lib/api/client";
 import type { Organization } from "@/lib/api/types";
 import { useOrgContext } from "../org-context";
 import { OrgGeneralSettings } from "./org-general-settings";
-import { Loader2 } from "lucide-react";
+import { Loader2, AlertTriangle } from "lucide-react";
 
 export function OrgSettingsGate({ orgSlug }: { orgSlug: string }) {
   const { orgId, isAdmin } = useOrgContext();
   const { getAccessToken } = useAccessToken();
   const router = useRouter();
   const [org, setOrg] = useState<Organization | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isAdmin) {
@@ -31,7 +32,7 @@ export function OrgSettingsGate({ orgSlug }: { orgSlug: string }) {
         );
         if (!cancelled) setOrg(data);
       } catch {
-        // Silently fail
+        if (!cancelled) setError("Failed to load organization settings.");
       }
     })();
     return () => {
@@ -40,6 +41,15 @@ export function OrgSettingsGate({ orgSlug }: { orgSlug: string }) {
   }, [orgId, isAdmin, orgSlug, router, getAccessToken]);
 
   if (!isAdmin) return null;
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-6 text-center text-sm text-destructive flex items-center justify-center gap-2">
+        <AlertTriangle className="size-4" />
+        {error}
+      </div>
+    );
+  }
 
   if (!org) {
     return (
@@ -54,7 +64,7 @@ export function OrgSettingsGate({ orgSlug }: { orgSlug: string }) {
       <h1 className="text-lg font-semibold tracking-tight mb-6">
         General Settings
       </h1>
-      <OrgGeneralSettings org={org} orgSlug={orgSlug} />
+      <OrgGeneralSettings org={org} onOrgUpdated={setOrg} orgSlug={orgSlug} />
     </div>
   );
 }

--- a/web/src/app/(org)/orgs/[orgSlug]/settings/page.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/settings/page.tsx
@@ -1,8 +1,6 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { redirect } from "next/navigation";
-import { createApiClient } from "@/lib/api/client";
-import type { Organization } from "@/lib/api/types";
-import { OrgGeneralSettings } from "./org-general-settings";
+import { OrgSettingsGate } from "./org-settings-gate";
 
 export default async function OrgSettingsPage({
   params,
@@ -14,26 +12,5 @@ export default async function OrgSettingsPage({
 
   const { orgSlug } = await params;
 
-  const api = createApiClient(accessToken);
-
-  // Need to resolve slug → ID. Use /v1/users/me to find the org.
-  const userMe = await api.get<{
-    organizations: { id: string; slug: string; role: string }[];
-  }>("/v1/users/me");
-
-  const orgRef = userMe.organizations.find((o) => o.slug === orgSlug);
-  if (!orgRef || orgRef.role !== "org_admin") redirect(`/orgs/${orgSlug}/members`);
-
-  const org = await api.get<Organization>(
-    `/v1/organizations/${orgRef.id}`,
-  );
-
-  return (
-    <div>
-      <h1 className="text-lg font-semibold tracking-tight mb-6">
-        General Settings
-      </h1>
-      <OrgGeneralSettings org={org} orgSlug={orgSlug} />
-    </div>
-  );
+  return <OrgSettingsGate orgSlug={orgSlug} />;
 }

--- a/web/src/app/(org)/orgs/[orgSlug]/settings/page.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/settings/page.tsx
@@ -1,0 +1,39 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { redirect } from "next/navigation";
+import { createApiClient } from "@/lib/api/client";
+import type { Organization } from "@/lib/api/types";
+import { OrgGeneralSettings } from "./org-general-settings";
+
+export default async function OrgSettingsPage({
+  params,
+}: {
+  params: Promise<{ orgSlug: string }>;
+}) {
+  const { accessToken } = await withAuth();
+  if (!accessToken) redirect("/auth/login");
+
+  const { orgSlug } = await params;
+
+  const api = createApiClient(accessToken);
+
+  // Need to resolve slug → ID. Use /v1/users/me to find the org.
+  const userMe = await api.get<{
+    organizations: { id: string; slug: string; role: string }[];
+  }>("/v1/users/me");
+
+  const orgRef = userMe.organizations.find((o) => o.slug === orgSlug);
+  if (!orgRef || orgRef.role !== "org_admin") redirect(`/orgs/${orgSlug}/members`);
+
+  const org = await api.get<Organization>(
+    `/v1/organizations/${orgRef.id}`,
+  );
+
+  return (
+    <div>
+      <h1 className="text-lg font-semibold tracking-tight mb-6">
+        General Settings
+      </h1>
+      <OrgGeneralSettings org={org} orgSlug={orgSlug} />
+    </div>
+  );
+}

--- a/web/src/app/(org)/orgs/[orgSlug]/settings/page.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/settings/page.tsx
@@ -1,5 +1,3 @@
-import { withAuth } from "@workos-inc/authkit-nextjs";
-import { redirect } from "next/navigation";
 import { OrgSettingsGate } from "./org-settings-gate";
 
 export default async function OrgSettingsPage({
@@ -7,9 +5,6 @@ export default async function OrgSettingsPage({
 }: {
   params: Promise<{ orgSlug: string }>;
 }) {
-  const { accessToken } = await withAuth();
-  if (!accessToken) redirect("/auth/login");
-
   const { orgSlug } = await params;
 
   return <OrgSettingsGate orgSlug={orgSlug} />;

--- a/web/src/app/(org)/orgs/[orgSlug]/use-org-fetch.ts
+++ b/web/src/app/(org)/orgs/[orgSlug]/use-org-fetch.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+
+interface UseOrgFetchResult<T> {
+  data: T | null;
+  total: number;
+  loading: boolean;
+}
+
+/**
+ * Generic hook for fetching paginated org data.
+ * Returns the first page of items + total count.
+ */
+export function useOrgFetch<T>(
+  path: string,
+  pageSize = 50,
+): UseOrgFetchResult<T[]> {
+  const { getAccessToken } = useAccessToken();
+  const [data, setData] = useState<T[] | null>(null);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      try {
+        const token = await getAccessToken();
+        if (!token) return;
+        const api = createApiClient(token);
+        const res = await api.get<{ items: T[]; total: number }>(path, {
+          params: { limit: pageSize, offset: 0 },
+        });
+        if (!cancelled) {
+          setData(res.items);
+          setTotal(res.total);
+        }
+      } catch {
+        if (!cancelled) setData([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [getAccessToken, path, pageSize]);
+
+  return { data, total, loading };
+}

--- a/web/src/app/(org)/orgs/[orgSlug]/workspaces/org-workspaces-client.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/workspaces/org-workspaces-client.tsx
@@ -155,49 +155,55 @@ export function OrgWorkspacesClient({
         )}
       </div>
 
-      <div className="rounded-lg border border-border">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Name</TableHead>
-              <TableHead>Slug</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead>Created</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {workspaces.map((ws) => (
-              <TableRow key={ws.id}>
-                <TableCell>
-                  <Link
-                    href={`/workspaces/${ws.id}`}
-                    className="font-medium text-sm text-foreground hover:underline underline-offset-4"
-                  >
-                    {ws.name}
-                  </Link>
-                </TableCell>
-                <TableCell>
-                  <code className="text-xs font-[family-name:var(--font-mono)] text-muted-foreground">
-                    {ws.slug}
-                  </code>
-                </TableCell>
-                <TableCell>
-                  <Badge
-                    variant={
-                      ws.status === "active" ? "default" : "destructive"
-                    }
-                  >
-                    {ws.status}
-                  </Badge>
-                </TableCell>
-                <TableCell className="text-sm text-muted-foreground">
-                  {new Date(ws.created_at).toLocaleDateString()}
-                </TableCell>
+      {workspaces.length === 0 ? (
+        <div className="rounded-lg border border-border bg-card p-8 text-center text-sm text-muted-foreground">
+          No workspaces yet.{isAdmin ? " Create one to get started." : ""}
+        </div>
+      ) : (
+        <div className="rounded-lg border border-border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Slug</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Created</TableHead>
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </div>
+            </TableHeader>
+            <TableBody>
+              {workspaces.map((ws) => (
+                <TableRow key={ws.id}>
+                  <TableCell>
+                    <Link
+                      href={`/workspaces/${ws.id}`}
+                      className="font-medium text-sm text-foreground hover:underline underline-offset-4"
+                    >
+                      {ws.name}
+                    </Link>
+                  </TableCell>
+                  <TableCell>
+                    <code className="text-xs font-[family-name:var(--font-mono)] text-muted-foreground">
+                      {ws.slug}
+                    </code>
+                  </TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={
+                        ws.status === "active" ? "default" : "destructive"
+                      }
+                    >
+                      {ws.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {new Date(ws.created_at).toLocaleDateString()}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/app/(org)/orgs/[orgSlug]/workspaces/org-workspaces-client.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/workspaces/org-workspaces-client.tsx
@@ -24,7 +24,9 @@ import {
   DialogFooter,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { Plus, Loader2, ChevronLeft, ChevronRight } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { PaginationControls } from "@/components/ui/pagination-controls";
+import { Plus, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import Link from "next/link";
 
@@ -129,13 +131,12 @@ export function OrgWorkspacesClient({
                 <label className="block text-sm font-medium mb-1.5">
                   Workspace Name
                 </label>
-                <input
+                <Input
                   type="text"
                   value={newName}
                   onChange={(e) => setNewName(e.target.value)}
                   disabled={creating}
                   placeholder="My Workspace"
-                  className="block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:opacity-50"
                 />
                 {createError && (
                   <p className="mt-1.5 text-xs text-destructive">
@@ -212,43 +213,23 @@ export function OrgWorkspacesClient({
         </div>
       )}
 
-      {/* Pagination */}
-      {Math.ceil(total / PAGE_SIZE) > 1 && (
-        <div className="flex items-center justify-between">
-          <p className="text-sm text-muted-foreground">
-            Page {Math.floor(offset / PAGE_SIZE) + 1} of{" "}
-            {Math.ceil(total / PAGE_SIZE)}
-          </p>
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              size="icon-sm"
-              disabled={offset === 0}
-              onClick={() => {
-                const newOffset = Math.max(0, offset - PAGE_SIZE);
-                setOffset(newOffset);
-                fetchWorkspaces(newOffset);
-              }}
-            >
-              <ChevronLeft className="size-4" />
-            </Button>
-            <Button
-              variant="outline"
-              size="icon-sm"
-              disabled={offset + PAGE_SIZE >= total}
-              onClick={() => {
-                const newOffset = offset + PAGE_SIZE;
-                if (newOffset < total) {
-                  setOffset(newOffset);
-                  fetchWorkspaces(newOffset);
-                }
-              }}
-            >
-              <ChevronRight className="size-4" />
-            </Button>
-          </div>
-        </div>
-      )}
+      <PaginationControls
+        offset={offset}
+        total={total}
+        pageSize={PAGE_SIZE}
+        onPrev={() => {
+          const newOffset = Math.max(0, offset - PAGE_SIZE);
+          setOffset(newOffset);
+          fetchWorkspaces(newOffset);
+        }}
+        onNext={() => {
+          const newOffset = offset + PAGE_SIZE;
+          if (newOffset < total) {
+            setOffset(newOffset);
+            fetchWorkspaces(newOffset);
+          }
+        }}
+      />
     </div>
   );
 }

--- a/web/src/app/(org)/orgs/[orgSlug]/workspaces/org-workspaces-client.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/workspaces/org-workspaces-client.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useState } from "react";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import type { OrgWorkspace } from "@/lib/api/types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Plus, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import Link from "next/link";
+
+interface OrgWorkspacesClientProps {
+  orgId: string;
+  isAdmin: boolean;
+  initialWorkspaces: OrgWorkspace[];
+  initialTotal: number;
+}
+
+export function OrgWorkspacesClient({
+  orgId,
+  isAdmin,
+  initialWorkspaces,
+  initialTotal,
+}: OrgWorkspacesClientProps) {
+  const { getAccessToken } = useAccessToken();
+  const [workspaces, setWorkspaces] =
+    useState<OrgWorkspace[]>(initialWorkspaces);
+  const [total, setTotal] = useState(initialTotal);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string>();
+
+  async function refreshWorkspaces() {
+    try {
+      const token = await getAccessToken();
+      if (!token) return;
+      const api = createApiClient(token);
+      const res = await api.get<{ items: OrgWorkspace[]; total: number }>(
+        `/v1/organizations/${orgId}/workspaces`,
+        { params: { limit: 50, offset: 0 } },
+      );
+      setWorkspaces(res.items);
+      setTotal(res.total);
+    } catch {
+      // Silently fail
+    }
+  }
+
+  async function handleCreate() {
+    if (!newName.trim()) return;
+    setCreateError(undefined);
+    setCreating(true);
+    try {
+      const token = await getAccessToken();
+      if (!token) return;
+      const api = createApiClient(token);
+      await api.post(`/v1/organizations/${orgId}/workspaces`, {
+        name: newName.trim(),
+      });
+      toast.success(`Created workspace "${newName.trim()}"`);
+      setCreateOpen(false);
+      setNewName("");
+      refreshWorkspaces();
+    } catch (err) {
+      setCreateError(
+        err instanceof ApiError ? err.message : "Failed to create workspace",
+      );
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          {total} workspace{total !== 1 ? "s" : ""}
+        </p>
+        {isAdmin && (
+          <Dialog
+            open={createOpen}
+            onOpenChange={(next) => {
+              setCreateOpen(next);
+              if (next) {
+                setNewName("");
+                setCreateError(undefined);
+              }
+            }}
+          >
+            <DialogTrigger render={<Button size="sm" />}>
+              <Plus className="size-4 mr-1.5" />
+              Create Workspace
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-sm">
+              <DialogHeader>
+                <DialogTitle>Create Workspace</DialogTitle>
+                <DialogDescription>
+                  Add a new workspace to this organization.
+                </DialogDescription>
+              </DialogHeader>
+              <div>
+                <label className="block text-sm font-medium mb-1.5">
+                  Workspace Name
+                </label>
+                <input
+                  type="text"
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  disabled={creating}
+                  placeholder="My Workspace"
+                  className="block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:opacity-50"
+                />
+                {createError && (
+                  <p className="mt-1.5 text-xs text-destructive">
+                    {createError}
+                  </p>
+                )}
+              </div>
+              <DialogFooter>
+                <Button
+                  onClick={handleCreate}
+                  disabled={!newName.trim() || creating}
+                >
+                  {creating && (
+                    <Loader2
+                      data-icon="inline-start"
+                      className="size-4 animate-spin"
+                    />
+                  )}
+                  {creating ? "Creating..." : "Create"}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        )}
+      </div>
+
+      <div className="rounded-lg border border-border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Slug</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Created</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {workspaces.map((ws) => (
+              <TableRow key={ws.id}>
+                <TableCell>
+                  <Link
+                    href={`/workspaces/${ws.id}`}
+                    className="font-medium text-sm text-foreground hover:underline underline-offset-4"
+                  >
+                    {ws.name}
+                  </Link>
+                </TableCell>
+                <TableCell>
+                  <code className="text-xs font-[family-name:var(--font-mono)] text-muted-foreground">
+                    {ws.slug}
+                  </code>
+                </TableCell>
+                <TableCell>
+                  <Badge
+                    variant={
+                      ws.status === "active" ? "default" : "destructive"
+                    }
+                  >
+                    {ws.status}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-sm text-muted-foreground">
+                  {new Date(ws.created_at).toLocaleDateString()}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(org)/orgs/[orgSlug]/workspaces/org-workspaces-client.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/workspaces/org-workspaces-client.tsx
@@ -24,9 +24,11 @@ import {
   DialogFooter,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { Plus, Loader2 } from "lucide-react";
+import { Plus, Loader2, ChevronLeft, ChevronRight } from "lucide-react";
 import { toast } from "sonner";
 import Link from "next/link";
+
+const PAGE_SIZE = 50;
 
 interface OrgWorkspacesClientProps {
   orgId: string;
@@ -45,25 +47,30 @@ export function OrgWorkspacesClient({
   const [workspaces, setWorkspaces] =
     useState<OrgWorkspace[]>(initialWorkspaces);
   const [total, setTotal] = useState(initialTotal);
+  const [offset, setOffset] = useState(0);
   const [createOpen, setCreateOpen] = useState(false);
   const [newName, setNewName] = useState("");
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string>();
 
-  async function refreshWorkspaces() {
+  async function fetchWorkspaces(currentOffset: number) {
     try {
       const token = await getAccessToken();
       if (!token) return;
       const api = createApiClient(token);
       const res = await api.get<{ items: OrgWorkspace[]; total: number }>(
         `/v1/organizations/${orgId}/workspaces`,
-        { params: { limit: 50, offset: 0 } },
+        { params: { limit: PAGE_SIZE, offset: currentOffset } },
       );
       setWorkspaces(res.items);
       setTotal(res.total);
     } catch {
       // Silently fail
     }
+  }
+
+  function refreshWorkspaces() {
+    fetchWorkspaces(offset);
   }
 
   async function handleCreate() {
@@ -202,6 +209,44 @@ export function OrgWorkspacesClient({
               ))}
             </TableBody>
           </Table>
+        </div>
+      )}
+
+      {/* Pagination */}
+      {Math.ceil(total / PAGE_SIZE) > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-muted-foreground">
+            Page {Math.floor(offset / PAGE_SIZE) + 1} of{" "}
+            {Math.ceil(total / PAGE_SIZE)}
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="icon-sm"
+              disabled={offset === 0}
+              onClick={() => {
+                const newOffset = Math.max(0, offset - PAGE_SIZE);
+                setOffset(newOffset);
+                fetchWorkspaces(newOffset);
+              }}
+            >
+              <ChevronLeft className="size-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon-sm"
+              disabled={offset + PAGE_SIZE >= total}
+              onClick={() => {
+                const newOffset = offset + PAGE_SIZE;
+                if (newOffset < total) {
+                  setOffset(newOffset);
+                  fetchWorkspaces(newOffset);
+                }
+              }}
+            >
+              <ChevronRight className="size-4" />
+            </Button>
+          </div>
         </div>
       )}
     </div>

--- a/web/src/app/(org)/orgs/[orgSlug]/workspaces/org-workspaces-loader.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/workspaces/org-workspaces-loader.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import type { OrgWorkspace } from "@/lib/api/types";
+import { useOrgContext } from "../org-context";
+import { OrgWorkspacesClient } from "./org-workspaces-client";
+import { Loader2 } from "lucide-react";
+
+export function OrgWorkspacesLoader() {
+  const { orgId, isAdmin } = useOrgContext();
+  const { getAccessToken } = useAccessToken();
+  const [workspaces, setWorkspaces] = useState<OrgWorkspace[] | null>(null);
+  const [total, setTotal] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = await getAccessToken();
+        if (!token) return;
+        const api = createApiClient(token);
+        const res = await api.get<{ items: OrgWorkspace[]; total: number }>(
+          `/v1/organizations/${orgId}/workspaces`,
+          { params: { limit: 50, offset: 0 } },
+        );
+        if (!cancelled) {
+          setWorkspaces(res.items);
+          setTotal(res.total);
+        }
+      } catch {
+        if (!cancelled) setWorkspaces([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [getAccessToken, orgId]);
+
+  if (!workspaces) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="size-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <OrgWorkspacesClient
+      orgId={orgId}
+      isAdmin={isAdmin}
+      initialWorkspaces={workspaces}
+      initialTotal={total}
+    />
+  );
+}

--- a/web/src/app/(org)/orgs/[orgSlug]/workspaces/org-workspaces-loader.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/workspaces/org-workspaces-loader.tsx
@@ -1,44 +1,18 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
-import { createApiClient } from "@/lib/api/client";
 import type { OrgWorkspace } from "@/lib/api/types";
 import { useOrgContext } from "../org-context";
+import { useOrgFetch } from "../use-org-fetch";
 import { OrgWorkspacesClient } from "./org-workspaces-client";
 import { Loader2 } from "lucide-react";
 
 export function OrgWorkspacesLoader() {
   const { orgId, isAdmin } = useOrgContext();
-  const { getAccessToken } = useAccessToken();
-  const [workspaces, setWorkspaces] = useState<OrgWorkspace[] | null>(null);
-  const [total, setTotal] = useState(0);
+  const { data: workspaces, total, loading } = useOrgFetch<OrgWorkspace>(
+    `/v1/organizations/${orgId}/workspaces`,
+  );
 
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const token = await getAccessToken();
-        if (!token) return;
-        const api = createApiClient(token);
-        const res = await api.get<{ items: OrgWorkspace[]; total: number }>(
-          `/v1/organizations/${orgId}/workspaces`,
-          { params: { limit: 50, offset: 0 } },
-        );
-        if (!cancelled) {
-          setWorkspaces(res.items);
-          setTotal(res.total);
-        }
-      } catch {
-        if (!cancelled) setWorkspaces([]);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [getAccessToken, orgId]);
-
-  if (!workspaces) {
+  if (loading || !workspaces) {
     return (
       <div className="flex items-center justify-center py-12">
         <Loader2 className="size-5 animate-spin text-muted-foreground" />

--- a/web/src/app/(org)/orgs/[orgSlug]/workspaces/page.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/workspaces/page.tsx
@@ -1,43 +1,10 @@
-import { withAuth } from "@workos-inc/authkit-nextjs";
-import { redirect } from "next/navigation";
-import { createApiClient } from "@/lib/api/client";
-import type { OrgWorkspace } from "@/lib/api/types";
-import { OrgWorkspacesClient } from "./org-workspaces-client";
+import { OrgWorkspacesLoader } from "./org-workspaces-loader";
 
-export default async function OrgWorkspacesPage({
-  params,
-}: {
-  params: Promise<{ orgSlug: string }>;
-}) {
-  const { accessToken } = await withAuth();
-  if (!accessToken) redirect("/auth/login");
-
-  const { orgSlug } = await params;
-
-  const api = createApiClient(accessToken);
-  const userMe = await api.get<{
-    organizations: { id: string; slug: string; role: string }[];
-  }>("/v1/users/me");
-
-  const orgRef = userMe.organizations.find((o) => o.slug === orgSlug);
-  if (!orgRef) redirect("/dashboard");
-
-  const res = await api.get<{
-    items: OrgWorkspace[];
-    total: number;
-  }>(`/v1/organizations/${orgRef.id}/workspaces`, {
-    params: { limit: 50, offset: 0 },
-  });
-
+export default function OrgWorkspacesPage() {
   return (
     <div>
       <h1 className="text-lg font-semibold tracking-tight mb-6">Workspaces</h1>
-      <OrgWorkspacesClient
-        orgId={orgRef.id}
-        isAdmin={orgRef.role === "org_admin"}
-        initialWorkspaces={res.items}
-        initialTotal={res.total}
-      />
+      <OrgWorkspacesLoader />
     </div>
   );
 }

--- a/web/src/app/(org)/orgs/[orgSlug]/workspaces/page.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/workspaces/page.tsx
@@ -1,0 +1,43 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { redirect } from "next/navigation";
+import { createApiClient } from "@/lib/api/client";
+import type { OrgWorkspace } from "@/lib/api/types";
+import { OrgWorkspacesClient } from "./org-workspaces-client";
+
+export default async function OrgWorkspacesPage({
+  params,
+}: {
+  params: Promise<{ orgSlug: string }>;
+}) {
+  const { accessToken } = await withAuth();
+  if (!accessToken) redirect("/auth/login");
+
+  const { orgSlug } = await params;
+
+  const api = createApiClient(accessToken);
+  const userMe = await api.get<{
+    organizations: { id: string; slug: string; role: string }[];
+  }>("/v1/users/me");
+
+  const orgRef = userMe.organizations.find((o) => o.slug === orgSlug);
+  if (!orgRef) redirect("/dashboard");
+
+  const res = await api.get<{
+    items: OrgWorkspace[];
+    total: number;
+  }>(`/v1/organizations/${orgRef.id}/workspaces`, {
+    params: { limit: 50, offset: 0 },
+  });
+
+  return (
+    <div>
+      <h1 className="text-lg font-semibold tracking-tight mb-6">Workspaces</h1>
+      <OrgWorkspacesClient
+        orgId={orgRef.id}
+        isAdmin={orgRef.role === "org_admin"}
+        initialWorkspaces={res.items}
+        initialTotal={res.total}
+      />
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/layout.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/layout.tsx
@@ -58,11 +58,13 @@ export default async function WorkspaceLayout({
     );
   }
 
-  // Find org name for the current workspace
+  // Find org name and slug for the current workspace
   let orgName: string | undefined;
+  let orgSlug: string | undefined;
   for (const org of userMe.organizations) {
     if (org.workspaces.some((w) => w.id === workspaceId)) {
       orgName = org.name;
+      orgSlug = org.slug;
       break;
     }
   }
@@ -78,6 +80,7 @@ export default async function WorkspaceLayout({
           email={user.email ?? undefined}
           avatarUrl={user.profilePictureUrl ?? undefined}
           orgName={orgName}
+          orgSlug={orgSlug}
         />
         <main className="flex-1 overflow-y-auto p-6">{children}</main>
       </div>

--- a/web/src/components/app-shell/top-bar.tsx
+++ b/web/src/components/app-shell/top-bar.tsx
@@ -22,6 +22,7 @@ interface TopBarProps {
   email?: string;
   avatarUrl?: string;
   orgName?: string;
+  orgSlug?: string;
 }
 
 const segmentLabels: Record<string, string> = {
@@ -40,6 +41,7 @@ export function TopBar({
   email,
   avatarUrl,
   orgName,
+  orgSlug,
 }: TopBarProps) {
   const pathname = usePathname();
 
@@ -92,6 +94,7 @@ export function TopBar({
           email={email}
           avatarUrl={avatarUrl}
           orgName={orgName}
+          orgSlug={orgSlug}
         />
       </div>
     </header>

--- a/web/src/components/app-shell/user-menu.tsx
+++ b/web/src/components/app-shell/user-menu.tsx
@@ -9,13 +9,15 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { LogOut } from "lucide-react";
+import { LogOut, Settings2 } from "lucide-react";
+import Link from "next/link";
 
 interface UserMenuProps {
   displayName?: string;
   email?: string;
   avatarUrl?: string;
   orgName?: string;
+  orgSlug?: string;
 }
 
 export function UserMenu({
@@ -23,6 +25,7 @@ export function UserMenu({
   email,
   avatarUrl,
   orgName,
+  orgSlug,
 }: UserMenuProps) {
   const { signOut } = useAuth();
   const initials = (displayName || email || "U")
@@ -58,6 +61,14 @@ export function UserMenu({
             )}
           </div>
           <DropdownMenuSeparator />
+          {orgSlug && (
+            <DropdownMenuItem
+              render={<Link href={`/orgs/${orgSlug}/members`} />}
+            >
+              <Settings2 className="size-4" />
+              Organization Settings
+            </DropdownMenuItem>
+          )}
           <DropdownMenuItem onClick={() => signOut()}>
             <LogOut className="size-4" />
             Sign out

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -1,0 +1,16 @@
+import { cn } from "@/lib/utils";
+
+export function Input({
+  className,
+  ...props
+}: React.ComponentProps<"input">) {
+  return (
+    <input
+      className={cn(
+        "block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:opacity-50 disabled:cursor-not-allowed",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/web/src/components/ui/pagination-controls.tsx
+++ b/web/src/components/ui/pagination-controls.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+interface PaginationControlsProps {
+  offset: number;
+  total: number;
+  pageSize: number;
+  onPrev: () => void;
+  onNext: () => void;
+}
+
+export function PaginationControls({
+  offset,
+  total,
+  pageSize,
+  onPrev,
+  onNext,
+}: PaginationControlsProps) {
+  const page = Math.floor(offset / pageSize) + 1;
+  const totalPages = Math.ceil(total / pageSize);
+
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="flex items-center justify-between">
+      <p className="text-sm text-muted-foreground">
+        Page {page} of {totalPages}
+      </p>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="icon-sm"
+          disabled={offset === 0}
+          onClick={onPrev}
+        >
+          <ChevronLeft className="size-4" />
+        </Button>
+        <Button
+          variant="outline"
+          size="icon-sm"
+          disabled={offset + pageSize >= total}
+          onClick={onNext}
+        >
+          <ChevronRight className="size-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ui/toggle-group.tsx
+++ b/web/src/components/ui/toggle-group.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface ToggleGroupOption<T extends string> {
+  value: T;
+  label: string;
+  description?: string;
+}
+
+interface ToggleGroupProps<T extends string> {
+  options: ToggleGroupOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  disabled?: boolean;
+}
+
+export function ToggleGroup<T extends string>({
+  options,
+  value,
+  onChange,
+  disabled,
+}: ToggleGroupProps<T>) {
+  return (
+    <div className="flex gap-2">
+      {options.map((opt) => (
+        <button
+          key={opt.value}
+          type="button"
+          onClick={() => onChange(opt.value)}
+          disabled={disabled}
+          className={cn(
+            "flex-1 rounded-lg border px-3 py-2 text-sm transition-colors disabled:opacity-50",
+            value === opt.value
+              ? "border-primary bg-primary/10 text-foreground"
+              : "border-input text-muted-foreground hover:text-foreground",
+          )}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -78,6 +78,61 @@ export interface WorkspaceResult {
   updated_at: string;
 }
 
+// --- Organization Management ---
+
+export type OrgRole = "org_admin" | "org_member";
+
+export type OrgMembershipStatus =
+  | "invited"
+  | "active"
+  | "suspended"
+  | "archived";
+
+/** GET /v1/organizations/{id} response, PATCH response */
+export interface Organization {
+  id: string;
+  name: string;
+  slug: string;
+  status: string; // "active" | "archived"
+  created_at: string;
+  updated_at: string;
+}
+
+/** GET /v1/organizations/{id}/memberships list item */
+export interface OrgMember {
+  id: string;
+  organization_id: string;
+  user_id: string;
+  email: string;
+  display_name: string;
+  role: OrgRole;
+  membership_status: OrgMembershipStatus;
+  created_at: string;
+}
+
+/** POST /v1/organizations/{id}/memberships request */
+export interface InviteOrgMemberRequest {
+  email: string;
+  role: OrgRole;
+}
+
+/** PATCH /v1/organization-memberships/{id} request */
+export interface UpdateOrgMembershipRequest {
+  role?: OrgRole;
+  status?: OrgMembershipStatus;
+}
+
+/** GET /v1/organizations/{id}/workspaces list item */
+export interface OrgWorkspace {
+  id: string;
+  organization_id: string;
+  name: string;
+  slug: string;
+  status: string; // "active" | "archived"
+  created_at: string;
+  updated_at: string;
+}
+
 // --- Agent Builds ---
 
 /** GET /v1/workspaces/{id}/agent-builds item, POST response */

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -108,6 +108,7 @@ export interface OrgMember {
   role: OrgRole;
   membership_status: OrgMembershipStatus;
   created_at: string;
+  updated_at?: string;
 }
 
 /** POST /v1/organizations/{id}/memberships request */


### PR DESCRIPTION
## Summary

Closes #213

New `(org)` route group with organization settings pages, following the Vercel/Linear/Clerk pattern of a dedicated settings context with sidebar nav.

### Org settings layout (`/orgs/{orgSlug}/...`)
- Settings sidebar with General (admin-only), Members, Workspaces links
- "Back to dashboard" link
- 404 handling for invalid org slugs

### General settings (`/orgs/{orgSlug}/settings`)
- Org name editor with save button
- Danger zone with archive org confirmation dialog (cascades to all workspaces + memberships)
- Admin-only — non-admins redirected to members page

### Members page (`/orgs/{orgSlug}/members`)
- Paginated member table: display name, email, role badge (Admin/Member), status badge (Active/Invited/Suspended/Archived), join date
- Invite expiry detection (7-day TTL shown as "Expired")
- **Invite dialog**: email input + role toggle (Member/Admin) with description
- **Per-member actions dropdown**: Make Admin/Member, Suspend, Reactivate, Archive
- **Last admin protection**: actions disabled on last org_admin
- Non-admins see read-only table (no invite button, no actions column)
- "(you)" label on current user's row

### Workspaces page (`/orgs/{orgSlug}/workspaces`)
- Workspace table with name (linked), slug, status badge, creation date
- **Create workspace dialog** for admins
- Non-admins see read-only list (org_members only see workspaces they belong to, per backend auth)

### Entry point
- "Organization Settings" link added to user menu dropdown in the workspace top bar
- Passes orgSlug from workspace layout → TopBar → UserMenu

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `pnpm lint` — passes (0 errors, 0 warnings)
- [x] `pnpm build` — passes, 3 new routes visible
- [ ] User menu → "Organization Settings" → lands on members page
- [ ] Admin: General settings → edit name → save → name updates
- [ ] Admin: General settings → archive org → confirmation → redirects to dashboard
- [ ] Members page → "Invite Member" → enter email + role → invite sent
- [ ] Members page → actions dropdown → change role / suspend / archive member
- [ ] Members page → last admin has no actions dropdown
- [ ] Non-admin: sees read-only members list, no settings page in sidebar
- [ ] Workspaces page → "Create Workspace" → enter name → workspace created
- [ ] Workspaces page → workspace name links to workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)