### PR TITLE
feat: FE-15 workspace settings & membership management

### DIFF
--- a/web/src/app/(workspace)/workspaces/[workspaceId]/settings/members/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/settings/members/page.tsx
@@ -1,0 +1,56 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { redirect } from "next/navigation";
+import { createApiClient } from "@/lib/api/client";
+import type { WorkspaceMember, SessionResponse } from "@/lib/api/types";
+import { WsMembersClient } from "./ws-members-client";
+import Link from "next/link";
+
+export default async function WorkspaceMembersPage({
+  params,
+}: {
+  params: Promise<{ workspaceId: string }>;
+}) {
+  const { accessToken } = await withAuth();
+  if (!accessToken) redirect("/auth/login");
+
+  const { workspaceId } = await params;
+  const api = createApiClient(accessToken);
+
+  const [res, session] = await Promise.all([
+    api.get<{ items: WorkspaceMember[]; total: number }>(
+      `/v1/workspaces/${workspaceId}/memberships`,
+      { params: { limit: 50, offset: 0 } },
+    ),
+    api.get<SessionResponse>("/v1/auth/session"),
+  ]);
+
+  const isWsAdmin = session.workspace_memberships.some(
+    (m) => m.workspace_id === workspaceId && m.role === "workspace_admin",
+  );
+  const isOrgAdmin = session.organization_memberships.some(
+    (m) => m.role === "org_admin",
+  );
+  const isAdmin = isWsAdmin || isOrgAdmin;
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 mb-6">
+        <Link
+          href={`/workspaces/${workspaceId}/settings`}
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Settings
+        </Link>
+        <span className="text-muted-foreground/40">/</span>
+        <h1 className="text-lg font-semibold tracking-tight">Members</h1>
+      </div>
+      <WsMembersClient
+        workspaceId={workspaceId}
+        isAdmin={isAdmin}
+        currentUserId={session.user_id}
+        initialMembers={res.items}
+        initialTotal={res.total}
+      />
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/settings/members/ws-invite-member-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/settings/members/ws-invite-member-dialog.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState } from "react";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import type { WorkspaceRole } from "@/lib/api/types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ToggleGroup } from "@/components/ui/toggle-group";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { UserPlus, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+const ROLE_OPTIONS: { value: WorkspaceRole; label: string }[] = [
+  { value: "workspace_admin", label: "Admin" },
+  { value: "workspace_member", label: "Member" },
+  { value: "workspace_viewer", label: "Viewer" },
+];
+
+const ROLE_DESCRIPTIONS: Record<WorkspaceRole, string> = {
+  workspace_admin: "Full control — manage members, infrastructure, and secrets.",
+  workspace_member: "Can create agents, runs, and challenge packs.",
+  workspace_viewer: "Read-only access to workspace data.",
+};
+
+interface WsInviteMemberDialogProps {
+  workspaceId: string;
+  onInvited: () => void;
+}
+
+export function WsInviteMemberDialog({
+  workspaceId,
+  onInvited,
+}: WsInviteMemberDialogProps) {
+  const { getAccessToken } = useAccessToken();
+  const [open, setOpen] = useState(false);
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<WorkspaceRole>("workspace_member");
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string>();
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (next) {
+      setEmail("");
+      setRole("workspace_member");
+      setError(undefined);
+    }
+  }
+
+  async function handleInvite() {
+    if (!email.trim()) return;
+    setError(undefined);
+    setSending(true);
+    try {
+      const token = await getAccessToken();
+      if (!token) return;
+      const api = createApiClient(token);
+      await api.post(`/v1/workspaces/${workspaceId}/memberships`, {
+        email: email.trim(),
+        role,
+      });
+      toast.success(`Invited ${email.trim()}`);
+      setOpen(false);
+      onInvited();
+    } catch (err) {
+      setError(
+        err instanceof ApiError ? err.message : "Failed to send invite",
+      );
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger render={<Button size="sm" />}>
+        <UserPlus className="size-4 mr-1.5" />
+        Invite Member
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Invite Workspace Member</DialogTitle>
+          <DialogDescription>
+            The user must have an active organization membership first.
+            Invites expire after 7 days.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-1.5">Email</label>
+            <Input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              disabled={sending}
+              placeholder="colleague@company.com"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1.5">Role</label>
+            <ToggleGroup
+              options={ROLE_OPTIONS}
+              value={role}
+              onChange={setRole}
+              disabled={sending}
+            />
+            <p className="mt-1 text-xs text-muted-foreground">
+              {ROLE_DESCRIPTIONS[role]}
+            </p>
+          </div>
+
+          {error && (
+            <div className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2 text-xs text-destructive">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button onClick={handleInvite} disabled={!email.trim() || sending}>
+            {sending && (
+              <Loader2
+                data-icon="inline-start"
+                className="size-4 animate-spin"
+              />
+            )}
+            {sending ? "Inviting..." : "Send Invite"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/settings/members/ws-members-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/settings/members/ws-members-client.tsx
@@ -1,0 +1,419 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import type {
+  WorkspaceMember,
+  WorkspaceRole,
+  OrgMembershipStatus,
+} from "@/lib/api/types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { PaginationControls } from "@/components/ui/pagination-controls";
+import { MoreHorizontal } from "lucide-react";
+import { toast } from "sonner";
+import { WsInviteMemberDialog } from "./ws-invite-member-dialog";
+
+const PAGE_SIZE = 50;
+
+const roleBadgeVariant: Record<string, "default" | "secondary" | "outline"> = {
+  workspace_admin: "default",
+  workspace_member: "secondary",
+  workspace_viewer: "outline",
+};
+
+const statusBadgeVariant: Record<
+  string,
+  "default" | "secondary" | "outline" | "destructive"
+> = {
+  active: "default",
+  invited: "outline",
+  suspended: "secondary",
+  archived: "destructive",
+};
+
+function roleLabel(role: string): string {
+  switch (role) {
+    case "workspace_admin":
+      return "Admin";
+    case "workspace_member":
+      return "Member";
+    case "workspace_viewer":
+      return "Viewer";
+    default:
+      return role;
+  }
+}
+
+function statusLabel(status: string): string {
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+function isInviteExpired(member: WorkspaceMember): boolean {
+  if (member.membership_status !== "invited") return false;
+  const timestamp = member.updated_at ?? member.created_at;
+  const ts = new Date(timestamp).getTime();
+  const sevenDays = 7 * 24 * 60 * 60 * 1000;
+  return Date.now() - ts > sevenDays;
+}
+
+interface MemberAction {
+  label: string;
+  onClick: () => void;
+  variant?: "destructive";
+  separator?: boolean;
+}
+
+function getMemberActions(
+  member: WorkspaceMember,
+  isLastAdmin: boolean,
+  onChangeRole: (role: WorkspaceRole) => void,
+  onChangeStatus: (status: OrgMembershipStatus) => void,
+): MemberAction[] {
+  const actions: MemberAction[] = [];
+  const isArchived = member.membership_status === "archived";
+
+  if (!isArchived) {
+    if (member.role !== "workspace_admin") {
+      actions.push({
+        label: "Make Admin",
+        onClick: () => onChangeRole("workspace_admin"),
+      });
+    }
+    if (member.role !== "workspace_member") {
+      if (member.role === "workspace_admin" && isLastAdmin) {
+        // skip — can't demote last admin
+      } else {
+        actions.push({
+          label: "Make Member",
+          onClick: () => onChangeRole("workspace_member"),
+        });
+      }
+    }
+    if (member.role !== "workspace_viewer") {
+      if (member.role === "workspace_admin" && isLastAdmin) {
+        // skip
+      } else {
+        actions.push({
+          label: "Make Viewer",
+          onClick: () => onChangeRole("workspace_viewer"),
+        });
+      }
+    }
+  }
+
+  if (member.membership_status === "active") {
+    actions.push({
+      label: "Suspend",
+      onClick: () => onChangeStatus("suspended"),
+      separator: true,
+    });
+  }
+  if (member.membership_status === "suspended") {
+    actions.push({
+      label: "Reactivate",
+      onClick: () => onChangeStatus("active"),
+      separator: true,
+    });
+  }
+  if (!isArchived) {
+    actions.push({
+      label: "Archive",
+      onClick: () => onChangeStatus("archived"),
+      variant: "destructive",
+    });
+  }
+
+  return actions;
+}
+
+interface WsMembersClientProps {
+  workspaceId: string;
+  isAdmin: boolean;
+  currentUserId: string;
+  initialMembers: WorkspaceMember[];
+  initialTotal: number;
+}
+
+export function WsMembersClient({
+  workspaceId,
+  isAdmin,
+  currentUserId,
+  initialMembers,
+  initialTotal,
+}: WsMembersClientProps) {
+  const { getAccessToken } = useAccessToken();
+  const [members, setMembers] = useState<WorkspaceMember[]>(initialMembers);
+  const [total, setTotal] = useState(initialTotal);
+  const [offset, setOffset] = useState(0);
+
+  const activeAdminCount = members.filter(
+    (m) => m.role === "workspace_admin" && m.membership_status === "active",
+  ).length;
+
+  const fetchMembers = useCallback(
+    async (currentOffset: number) => {
+      try {
+        const token = await getAccessToken();
+        if (!token) return;
+        const api = createApiClient(token);
+        const res = await api.get<{
+          items: WorkspaceMember[];
+          total: number;
+        }>(`/v1/workspaces/${workspaceId}/memberships`, {
+          params: { limit: PAGE_SIZE, offset: currentOffset },
+        });
+        setMembers(res.items);
+        setTotal(res.total);
+      } catch {
+        // Silently fail
+      }
+    },
+    [getAccessToken, workspaceId],
+  );
+
+  function refreshMembers() {
+    fetchMembers(offset);
+  }
+
+  async function handleChangeRole(
+    member: WorkspaceMember,
+    newRole: WorkspaceRole,
+  ) {
+    setMembers((prev) =>
+      prev.map((m) => (m.id === member.id ? { ...m, role: newRole } : m)),
+    );
+    try {
+      const token = await getAccessToken();
+      if (!token) return;
+      const api = createApiClient(token);
+      await api.patch(`/v1/workspace-memberships/${member.id}`, {
+        role: newRole,
+      });
+      toast.success(
+        `Changed ${member.display_name || member.email} to ${roleLabel(newRole)}`,
+      );
+      refreshMembers();
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError ? err.message : "Failed to change role",
+      );
+      refreshMembers();
+    }
+  }
+
+  async function handleChangeStatus(
+    member: WorkspaceMember,
+    newStatus: OrgMembershipStatus,
+  ) {
+    setMembers((prev) =>
+      prev.map((m) =>
+        m.id === member.id ? { ...m, membership_status: newStatus } : m,
+      ),
+    );
+    try {
+      const token = await getAccessToken();
+      if (!token) return;
+      const api = createApiClient(token);
+      await api.patch(`/v1/workspace-memberships/${member.id}`, {
+        status: newStatus,
+      });
+      toast.success(
+        `${statusLabel(newStatus)} ${member.display_name || member.email}`,
+      );
+      refreshMembers();
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError ? err.message : "Failed to update member",
+      );
+      refreshMembers();
+    }
+  }
+
+  function canManageMember(member: WorkspaceMember): boolean {
+    if (!isAdmin) return false;
+    if (member.user_id === currentUserId) return false;
+    if (
+      member.role === "workspace_admin" &&
+      activeAdminCount <= 1 &&
+      member.membership_status !== "suspended" &&
+      member.membership_status !== "archived"
+    )
+      return false;
+    return true;
+  }
+
+  function handlePageChange(newOffset: number) {
+    setOffset(newOffset);
+    fetchMembers(newOffset);
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          {total} member{total !== 1 ? "s" : ""}
+        </p>
+        {isAdmin && (
+          <WsInviteMemberDialog
+            workspaceId={workspaceId}
+            onInvited={refreshMembers}
+          />
+        )}
+      </div>
+
+      {members.length === 0 ? (
+        <div className="rounded-lg border border-border bg-card p-8 text-center text-sm text-muted-foreground">
+          No members found.
+        </div>
+      ) : (
+        <div className="rounded-lg border border-border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Member</TableHead>
+                <TableHead>Role</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Joined</TableHead>
+                {isAdmin && <TableHead className="w-12" />}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {members.map((member) => {
+                const expired = isInviteExpired(member);
+                const manageable = canManageMember(member);
+                const isLastAdmin =
+                  member.role === "workspace_admin" && activeAdminCount <= 1;
+                const isInactive =
+                  member.membership_status === "suspended" ||
+                  member.membership_status === "archived";
+                const actions = manageable
+                  ? getMemberActions(
+                      member,
+                      isLastAdmin,
+                      (role) => handleChangeRole(member, role),
+                      (status) => handleChangeStatus(member, status),
+                    )
+                  : [];
+
+                return (
+                  <TableRow
+                    key={member.id}
+                    className={isInactive ? "opacity-60" : undefined}
+                  >
+                    <TableCell>
+                      <div>
+                        <span className="font-medium text-sm">
+                          {member.display_name || member.email}
+                        </span>
+                        {member.display_name && (
+                          <p className="text-xs text-muted-foreground">
+                            {member.email}
+                          </p>
+                        )}
+                        {member.user_id === currentUserId && (
+                          <span className="text-xs text-muted-foreground ml-1">
+                            (you)
+                          </span>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant={roleBadgeVariant[member.role] ?? "outline"}
+                      >
+                        {roleLabel(member.role)}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-1.5">
+                        <Badge
+                          variant={
+                            statusBadgeVariant[member.membership_status] ??
+                            "outline"
+                          }
+                        >
+                          {statusLabel(member.membership_status)}
+                        </Badge>
+                        {expired && (
+                          <span className="text-xs text-destructive">
+                            Expired
+                          </span>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {new Date(member.created_at).toLocaleDateString()}
+                    </TableCell>
+                    {isAdmin && (
+                      <TableCell>
+                        {actions.length > 0 && (
+                          <DropdownMenu>
+                            <DropdownMenuTrigger
+                              render={
+                                <Button variant="ghost" size="icon-xs" />
+                              }
+                            >
+                              <MoreHorizontal className="size-4" />
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                              {actions.map((action, i) => (
+                                <span key={action.label}>
+                                  {action.separator && i > 0 && (
+                                    <DropdownMenuSeparator />
+                                  )}
+                                  <DropdownMenuItem
+                                    className={
+                                      action.variant === "destructive"
+                                        ? "text-destructive"
+                                        : undefined
+                                    }
+                                    onClick={action.onClick}
+                                  >
+                                    {action.label}
+                                  </DropdownMenuItem>
+                                </span>
+                              ))}
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        )}
+                      </TableCell>
+                    )}
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      <PaginationControls
+        offset={offset}
+        total={total}
+        pageSize={PAGE_SIZE}
+        onPrev={() => handlePageChange(Math.max(0, offset - PAGE_SIZE))}
+        onNext={() => {
+          const next = offset + PAGE_SIZE;
+          if (next < total) handlePageChange(next);
+        }}
+      />
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/settings/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/settings/page.tsx
@@ -1,0 +1,42 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { redirect } from "next/navigation";
+import { createApiClient } from "@/lib/api/client";
+import type { WorkspaceDetail, SessionResponse } from "@/lib/api/types";
+import { WsGeneralSettings } from "./ws-general-settings";
+
+export default async function WorkspaceSettingsPage({
+  params,
+}: {
+  params: Promise<{ workspaceId: string }>;
+}) {
+  const { accessToken } = await withAuth();
+  if (!accessToken) redirect("/auth/login");
+
+  const { workspaceId } = await params;
+  const api = createApiClient(accessToken);
+
+  const [ws, session] = await Promise.all([
+    api.get<WorkspaceDetail>(`/v1/workspaces/${workspaceId}/details`),
+    api.get<SessionResponse>("/v1/auth/session"),
+  ]);
+
+  // Check admin access (workspace_admin or org_admin)
+  const isWsAdmin = session.workspace_memberships.some(
+    (m) => m.workspace_id === workspaceId && m.role === "workspace_admin",
+  );
+  const isOrgAdmin = session.organization_memberships.some(
+    (m) => m.role === "org_admin",
+  );
+  if (!isWsAdmin && !isOrgAdmin) {
+    redirect(`/workspaces/${workspaceId}`);
+  }
+
+  return (
+    <div>
+      <h1 className="text-lg font-semibold tracking-tight mb-6">
+        Workspace Settings
+      </h1>
+      <WsGeneralSettings workspace={ws} />
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/settings/ws-general-settings.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/settings/ws-general-settings.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import type { WorkspaceDetail } from "@/lib/api/types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Loader2, AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
+import Link from "next/link";
+
+interface WsGeneralSettingsProps {
+  workspace: WorkspaceDetail;
+}
+
+export function WsGeneralSettings({ workspace: initialWs }: WsGeneralSettingsProps) {
+  const { getAccessToken } = useAccessToken();
+  const router = useRouter();
+  const [ws, setWs] = useState(initialWs);
+  const [name, setName] = useState(ws.name);
+  const [saving, setSaving] = useState(false);
+  const [archiveOpen, setArchiveOpen] = useState(false);
+  const [archiveConfirm, setArchiveConfirm] = useState("");
+  const [archiving, setArchiving] = useState(false);
+
+  async function handleSaveName() {
+    if (!name.trim() || name === ws.name) return;
+    setSaving(true);
+    try {
+      const token = await getAccessToken();
+      if (!token) return;
+      const api = createApiClient(token);
+      const updated = await api.patch<WorkspaceDetail>(
+        `/v1/workspaces/${ws.id}/details`,
+        { name: name.trim() },
+      );
+      toast.success("Workspace name updated");
+      setWs(updated);
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError ? err.message : "Failed to update name",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleArchive() {
+    setArchiving(true);
+    try {
+      const token = await getAccessToken();
+      if (!token) return;
+      const api = createApiClient(token);
+      await api.patch(`/v1/workspaces/${ws.id}/details`, {
+        status: "archived",
+      });
+      toast.success("Workspace archived");
+      router.push("/dashboard");
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError ? err.message : "Failed to archive",
+      );
+    } finally {
+      setArchiving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      {/* Name editor */}
+      <div className="rounded-lg border border-border p-4">
+        <label className="block text-sm font-medium mb-1.5">
+          Workspace Name
+        </label>
+        <div className="flex gap-3">
+          <Input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            disabled={saving}
+            className="flex-1"
+          />
+          <Button
+            onClick={handleSaveName}
+            disabled={saving || !name.trim() || name === ws.name}
+            size="sm"
+          >
+            {saving && (
+              <Loader2
+                data-icon="inline-start"
+                className="size-4 animate-spin"
+              />
+            )}
+            Save
+          </Button>
+        </div>
+        <p className="mt-1.5 text-xs text-muted-foreground">
+          Slug:{" "}
+          <code className="font-[family-name:var(--font-mono)]">
+            {ws.slug}
+          </code>
+        </p>
+      </div>
+
+      {/* Workspace ID (for API/CLI) */}
+      <div className="rounded-lg border border-border p-4">
+        <label className="block text-sm font-medium mb-1.5">
+          Workspace ID
+        </label>
+        <code className="text-xs font-[family-name:var(--font-mono)] text-muted-foreground select-all">
+          {ws.id}
+        </code>
+        <p className="mt-1.5 text-xs text-muted-foreground">
+          Use this ID for API calls and CLI commands.
+        </p>
+      </div>
+
+      {/* Members link */}
+      <div className="rounded-lg border border-border p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-sm font-medium">Members</h3>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Manage who has access to this workspace.
+            </p>
+          </div>
+          <Link href={`/workspaces/${ws.id}/settings/members`}>
+            <Button variant="outline" size="sm">
+              Manage Members
+            </Button>
+          </Link>
+        </div>
+      </div>
+
+      {/* Danger zone */}
+      <div className="rounded-lg border border-destructive/20 p-4">
+        <h3 className="text-sm font-medium text-destructive mb-1">
+          Danger Zone
+        </h3>
+        <p className="text-xs text-muted-foreground mb-3">
+          Archiving this workspace will remove all member access. This action
+          cannot be easily undone.
+        </p>
+        <Dialog
+          open={archiveOpen}
+          onOpenChange={(next) => {
+            setArchiveOpen(next);
+            if (next) setArchiveConfirm("");
+          }}
+        >
+          <DialogTrigger render={<Button variant="destructive" size="sm" />}>
+            Archive Workspace
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Archive Workspace</DialogTitle>
+              <DialogDescription>
+                This will archive the workspace and remove all member access.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2 text-xs text-destructive flex items-center gap-2">
+              <AlertTriangle className="size-4 shrink-0" />
+              This action cascades to all workspace memberships.
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1.5">
+                Type <strong>{ws.name}</strong> to confirm
+              </label>
+              <Input
+                type="text"
+                value={archiveConfirm}
+                onChange={(e) => setArchiveConfirm(e.target.value)}
+                disabled={archiving}
+                placeholder={ws.name}
+              />
+            </div>
+            <DialogFooter>
+              <Button
+                variant="destructive"
+                onClick={handleArchive}
+                disabled={archiving || archiveConfirm !== ws.name}
+              >
+                {archiving && (
+                  <Loader2
+                    data-icon="inline-start"
+                    className="size-4 animate-spin"
+                  />
+                )}
+                {archiving ? "Archiving..." : "Yes, archive"}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/app-shell/nav-items.ts
+++ b/web/src/components/app-shell/nav-items.ts
@@ -11,6 +11,7 @@ import {
   Wrench,
   Database,
   Lock,
+  Cog,
   type LucideIcon,
 } from "lucide-react";
 
@@ -103,6 +104,16 @@ export const navSections: NavSection[] = [
         label: "Secrets",
         href: (id) => `/workspaces/${id}/secrets`,
         icon: Lock,
+      },
+    ],
+  },
+  {
+    title: "Workspace",
+    items: [
+      {
+        label: "Settings",
+        href: (id) => `/workspaces/${id}/settings`,
+        icon: Cog,
       },
     ],
   },

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -134,6 +134,38 @@ export interface OrgWorkspace {
   updated_at: string;
 }
 
+// --- Workspace Management ---
+
+export type WorkspaceRole =
+  | "workspace_admin"
+  | "workspace_member"
+  | "workspace_viewer";
+
+/** GET /v1/workspaces/{id}/details response */
+export interface WorkspaceDetail {
+  id: string;
+  organization_id: string;
+  name: string;
+  slug: string;
+  status: string; // "active" | "archived"
+  created_at: string;
+  updated_at: string;
+}
+
+/** GET /v1/workspaces/{id}/memberships list item */
+export interface WorkspaceMember {
+  id: string;
+  workspace_id: string;
+  organization_id: string;
+  user_id: string;
+  email: string;
+  display_name: string;
+  role: WorkspaceRole;
+  membership_status: OrgMembershipStatus; // same enum: invited/active/suspended/archived
+  created_at: string;
+  updated_at?: string;
+}
+
 // --- Agent Builds ---
 
 /** GET /v1/workspaces/{id}/agent-builds item, POST response */


### PR DESCRIPTION
## Summary

Closes #214

### Workspace settings page (`/workspaces/{id}/settings`)
- Workspace name editor with save
- Workspace ID display (for API/CLI usage)
- "Manage Members" link to members sub-page
- Archive workspace with type-to-confirm dialog (cascades to memberships)
- Admin-only — workspace_admin or org_admin required, non-admins redirected

### Workspace members page (`/workspaces/{id}/settings/members`)
- Paginated member table: name, email, role badge (Admin/Member/Viewer), status badge, join date
- **Invite dialog** with 3-option ToggleGroup for workspace roles (Admin/Member/Viewer) + role descriptions
- **Per-member actions** via `getMemberActions()`: role changes (all 3 roles), suspend, reactivate, archive
- Optimistic updates keep suspended/archived members visible for reactivation
- Last admin protection (active admins only)
- Invite expiry based on `updated_at` (handles re-invites)
- Non-admins see read-only table

### Sidebar integration
- "Settings" link with Cog icon in new "Workspace" nav section

### Shared components reused
- `Input` — all text inputs
- `PaginationControls` — member table pagination
- `ToggleGroup` — 3-option role selector (scales from org's 2-option to workspace's 3-option)

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `pnpm lint` — passes (0 errors, 0 warnings)
- [x] `pnpm build` — passes, 2 new routes visible
- [ ] Sidebar → Settings → settings page loads with name editor + workspace ID
- [ ] Edit name → save → name updates
- [ ] Archive workspace → type name → confirm → redirects to dashboard
- [ ] Settings → Manage Members → members table loads
- [ ] Invite Member → enter email + select role → invite sent
- [ ] Actions dropdown → change role / suspend / reactivate / archive
- [ ] Last admin cannot be demoted (no role change options in dropdown)
- [ ] Non-admin user sees read-only members list, settings page redirects

🤖 Generated with [Claude Code](https://claude.com/claude-code)