### PR TITLE
fix(worker): decouple event recording from executor with buffered observer

### DIFF
--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -62,11 +62,11 @@ func main() {
 	nativeModelInvoker := workerapp.NewNativeModelInvokerWithObserverFactory(
 		providerRouter,
 		sandboxProvider,
-		workerapp.NewNativeRunEventObserverFactory(repo),
+		workerapp.NewBufferedNativeObserverFactory(repo),
 	).WithSecretsLookup(repo)
 	promptEvalInvoker := workerapp.NewPromptEvalInvokerWithObserverFactory(
 		providerRouter,
-		workerapp.NewPromptEvalRunEventObserverFactory(repo),
+		workerapp.NewBufferedPromptEvalObserverFactory(repo),
 	)
 	temporalWorker := workerapp.NewTemporalWorker(temporalClient, cfg, repo, providerRouter, workflowpkg.FakeWorkHooks{
 		HostedRunStarter:   hostedRunClient,

--- a/backend/internal/worker/buffered_observer.go
+++ b/backend/internal/worker/buffered_observer.go
@@ -1,0 +1,284 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/engine"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/provider"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+)
+
+type observerCall struct {
+	fn      func() error
+	errChan chan error // nil = fire-and-forget; non-nil = synchronous flush sentinel
+}
+
+// BufferedObserver wraps an engine.Observer and decouples non-terminal event
+// recording from the executor goroutine. Events are enqueued to a channel and
+// processed by a single background flusher goroutine, preserving write order.
+// Terminal calls (OnRunComplete, OnRunFailure) synchronously drain the queue
+// before delegating to the inner observer, guaranteeing all events are
+// persisted before scoring begins.
+type BufferedObserver struct {
+	inner engine.Observer
+	queue chan observerCall
+	done  chan struct{}
+
+	mu    sync.Mutex
+	bgErr error // first permanent background error
+
+	maxRetries      int
+	retryBackoff    time.Duration
+	maxRetryBackoff time.Duration
+}
+
+// NewBufferedObserver wraps inner with an asynchronous write buffer.
+// The caller must ensure that one of the terminal methods (OnRunComplete or
+// OnRunFailure) is called exactly once to drain the buffer and stop the
+// background goroutine.
+func NewBufferedObserver(inner engine.Observer) *BufferedObserver {
+	b := &BufferedObserver{
+		inner:           inner,
+		queue:           make(chan observerCall, 256),
+		done:            make(chan struct{}),
+		maxRetries:      3,
+		retryBackoff:    100 * time.Millisecond,
+		maxRetryBackoff: 2 * time.Second,
+	}
+	go b.flusher()
+	return b
+}
+
+// --- Non-terminal methods: enqueue and return immediately ---
+
+func (b *BufferedObserver) OnStepStart(ctx context.Context, step int) error {
+	if err := b.checkBgError(); err != nil {
+		return err
+	}
+	bgCtx := context.WithoutCancel(ctx)
+	b.enqueue(func() error {
+		return b.inner.OnStepStart(bgCtx, step)
+	})
+	return nil
+}
+
+func (b *BufferedObserver) OnProviderCall(ctx context.Context, request provider.Request) error {
+	if err := b.checkBgError(); err != nil {
+		return err
+	}
+	bgCtx := context.WithoutCancel(ctx)
+	b.enqueue(func() error {
+		return b.inner.OnProviderCall(bgCtx, request)
+	})
+	return nil
+}
+
+func (b *BufferedObserver) OnProviderOutput(ctx context.Context, request provider.Request, delta provider.StreamDelta) error {
+	if err := b.checkBgError(); err != nil {
+		return err
+	}
+	bgCtx := context.WithoutCancel(ctx)
+	b.enqueue(func() error {
+		return b.inner.OnProviderOutput(bgCtx, request, delta)
+	})
+	return nil
+}
+
+func (b *BufferedObserver) OnProviderResponse(ctx context.Context, response provider.Response) error {
+	if err := b.checkBgError(); err != nil {
+		return err
+	}
+	bgCtx := context.WithoutCancel(ctx)
+	b.enqueue(func() error {
+		return b.inner.OnProviderResponse(bgCtx, response)
+	})
+	return nil
+}
+
+func (b *BufferedObserver) OnToolExecution(ctx context.Context, record engine.ToolExecutionRecord) error {
+	if err := b.checkBgError(); err != nil {
+		return err
+	}
+	bgCtx := context.WithoutCancel(ctx)
+	b.enqueue(func() error {
+		return b.inner.OnToolExecution(bgCtx, record)
+	})
+	return nil
+}
+
+func (b *BufferedObserver) OnStepEnd(ctx context.Context, step int) error {
+	if err := b.checkBgError(); err != nil {
+		return err
+	}
+	bgCtx := context.WithoutCancel(ctx)
+	b.enqueue(func() error {
+		return b.inner.OnStepEnd(bgCtx, step)
+	})
+	return nil
+}
+
+// --- Terminal methods: flush then delegate synchronously ---
+
+func (b *BufferedObserver) OnRunComplete(ctx context.Context, result engine.Result) error {
+	if err := b.flush(ctx); err != nil {
+		b.shutdown()
+		return err
+	}
+	err := b.inner.OnRunComplete(ctx, result)
+	b.shutdown()
+	return err
+}
+
+func (b *BufferedObserver) OnRunFailure(ctx context.Context, runErr error) error {
+	if err := b.flush(ctx); err != nil {
+		b.shutdown()
+		return err
+	}
+	err := b.inner.OnRunFailure(ctx, runErr)
+	b.shutdown()
+	return err
+}
+
+// --- Internal machinery ---
+
+var errFlusherDead = errors.New("event observer flusher terminated unexpectedly")
+
+func (b *BufferedObserver) enqueue(fn func() error) {
+	select {
+	case b.queue <- observerCall{fn: fn}:
+	case <-b.done:
+		// Flusher died (e.g. unrecoverable panic). The error will be
+		// surfaced via the next checkBgError or flush call.
+	}
+}
+
+// flush sends a synchronous sentinel through the queue and blocks until all
+// prior items have been processed. Returns the first permanent background
+// error if one occurred.
+func (b *BufferedObserver) flush(ctx context.Context) error {
+	errCh := make(chan error, 1)
+	// Send the flush sentinel, but don't block forever if the flusher is
+	// dead or the queue is full and the context is cancelled.
+	select {
+	case b.queue <- observerCall{fn: func() error { return nil }, errChan: errCh}:
+	case <-b.done:
+		if err := b.checkBgError(); err != nil {
+			return err
+		}
+		return errFlusherDead
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	// Wait for the flusher to drain all items up to our sentinel.
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// shutdown closes the queue channel and waits for the flusher goroutine to
+// exit, preventing goroutine leaks.
+func (b *BufferedObserver) shutdown() {
+	close(b.queue)
+	<-b.done
+}
+
+// flusher is the background goroutine that drains the queue sequentially.
+func (b *BufferedObserver) flusher() {
+	defer close(b.done)
+	for call := range b.queue {
+		err := b.safeExecuteWithRetry(call.fn)
+
+		if call.errChan != nil {
+			// Synchronous flush sentinel: report accumulated bgErr.
+			if err == nil {
+				err = b.checkBgError()
+			}
+			call.errChan <- err
+			continue
+		}
+
+		if err != nil {
+			b.mu.Lock()
+			if b.bgErr == nil {
+				b.bgErr = err
+			}
+			b.mu.Unlock()
+		}
+	}
+}
+
+// safeExecuteWithRetry wraps executeWithRetry with panic recovery so that a
+// panicking inner observer does not crash the entire worker process.
+func (b *BufferedObserver) safeExecuteWithRetry(fn func() error) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("observer panic: %v", r)
+		}
+	}()
+	return b.executeWithRetry(fn)
+}
+
+func (b *BufferedObserver) executeWithRetry(fn func() error) error {
+	var lastErr error
+	backoff := b.retryBackoff
+	for attempt := 0; attempt <= b.maxRetries; attempt++ {
+		if err := fn(); err != nil {
+			lastErr = err
+			if attempt < b.maxRetries {
+				time.Sleep(backoff)
+				backoff = min(backoff*2, b.maxRetryBackoff)
+			}
+			continue
+		}
+		return nil
+	}
+	return lastErr
+}
+
+func (b *BufferedObserver) checkBgError() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.bgErr
+}
+
+// --- Buffered factory constructors ---
+
+// NewBufferedNativeObserverFactory wraps the standard native observer factory
+// with a BufferedObserver so that event recording does not block the executor.
+func NewBufferedNativeObserverFactory(recorder RunEventRecorder) NativeObserverFactory {
+	innerFactory := NewNativeRunEventObserverFactory(recorder)
+	return func(executionContext repository.RunAgentExecutionContext) (engine.Observer, error) {
+		inner, err := innerFactory(executionContext)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := inner.(engine.NoopObserver); ok {
+			return inner, nil
+		}
+		return NewBufferedObserver(inner), nil
+	}
+}
+
+// NewBufferedPromptEvalObserverFactory wraps the standard prompt-eval observer
+// factory with a BufferedObserver so that event recording does not block the
+// executor.
+func NewBufferedPromptEvalObserverFactory(recorder RunEventRecorder) PromptEvalObserverFactory {
+	innerFactory := NewPromptEvalRunEventObserverFactory(recorder)
+	return func(executionContext repository.RunAgentExecutionContext) (engine.Observer, error) {
+		inner, err := innerFactory(executionContext)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := inner.(engine.NoopObserver); ok {
+			return inner, nil
+		}
+		return NewBufferedObserver(inner), nil
+	}
+}

--- a/backend/internal/worker/buffered_observer_test.go
+++ b/backend/internal/worker/buffered_observer_test.go
@@ -1,0 +1,410 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/engine"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/provider"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+)
+
+// --- Test observers ---
+
+// recordingObserver records every call type in order and tracks call counts.
+type recordingObserver struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (o *recordingObserver) record(name string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.calls = append(o.calls, name)
+}
+
+func (o *recordingObserver) getCalls() []string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	cp := make([]string, len(o.calls))
+	copy(cp, o.calls)
+	return cp
+}
+
+func (o *recordingObserver) OnStepStart(_ context.Context, _ int) error {
+	o.record("OnStepStart")
+	return nil
+}
+func (o *recordingObserver) OnProviderCall(_ context.Context, _ provider.Request) error {
+	o.record("OnProviderCall")
+	return nil
+}
+func (o *recordingObserver) OnProviderOutput(_ context.Context, _ provider.Request, _ provider.StreamDelta) error {
+	o.record("OnProviderOutput")
+	return nil
+}
+func (o *recordingObserver) OnProviderResponse(_ context.Context, _ provider.Response) error {
+	o.record("OnProviderResponse")
+	return nil
+}
+func (o *recordingObserver) OnToolExecution(_ context.Context, _ engine.ToolExecutionRecord) error {
+	o.record("OnToolExecution")
+	return nil
+}
+func (o *recordingObserver) OnStepEnd(_ context.Context, _ int) error {
+	o.record("OnStepEnd")
+	return nil
+}
+func (o *recordingObserver) OnRunComplete(_ context.Context, _ engine.Result) error {
+	o.record("OnRunComplete")
+	return nil
+}
+func (o *recordingObserver) OnRunFailure(_ context.Context, _ error) error {
+	o.record("OnRunFailure")
+	return nil
+}
+
+// slowObserver adds a configurable delay to every non-terminal call.
+type slowObserver struct {
+	recordingObserver
+	delay time.Duration
+}
+
+func (o *slowObserver) OnStepStart(ctx context.Context, step int) error {
+	time.Sleep(o.delay)
+	return o.recordingObserver.OnStepStart(ctx, step)
+}
+func (o *slowObserver) OnProviderCall(ctx context.Context, req provider.Request) error {
+	time.Sleep(o.delay)
+	return o.recordingObserver.OnProviderCall(ctx, req)
+}
+func (o *slowObserver) OnProviderOutput(ctx context.Context, req provider.Request, d provider.StreamDelta) error {
+	time.Sleep(o.delay)
+	return o.recordingObserver.OnProviderOutput(ctx, req, d)
+}
+func (o *slowObserver) OnProviderResponse(ctx context.Context, resp provider.Response) error {
+	time.Sleep(o.delay)
+	return o.recordingObserver.OnProviderResponse(ctx, resp)
+}
+func (o *slowObserver) OnToolExecution(ctx context.Context, rec engine.ToolExecutionRecord) error {
+	time.Sleep(o.delay)
+	return o.recordingObserver.OnToolExecution(ctx, rec)
+}
+func (o *slowObserver) OnStepEnd(ctx context.Context, step int) error {
+	time.Sleep(o.delay)
+	return o.recordingObserver.OnStepEnd(ctx, step)
+}
+
+// failNTimesObserver fails the first N calls to OnStepStart, then succeeds.
+type failNTimesObserver struct {
+	recordingObserver
+	failCount    int
+	currentCount atomic.Int32
+}
+
+func (o *failNTimesObserver) OnStepStart(ctx context.Context, step int) error {
+	n := int(o.currentCount.Add(1))
+	if n <= o.failCount {
+		return errors.New("transient postgres error")
+	}
+	return o.recordingObserver.OnStepStart(ctx, step)
+}
+
+// alwaysFailObserver fails every call to OnStepStart.
+type alwaysFailObserver struct {
+	recordingObserver
+}
+
+func (o *alwaysFailObserver) OnStepStart(_ context.Context, _ int) error {
+	return errors.New("permanent postgres error")
+}
+
+// --- Tests ---
+
+func TestBufferedObserverNonTerminalCallsAreAsync(t *testing.T) {
+	inner := &slowObserver{delay: 200 * time.Millisecond}
+	buf := NewBufferedObserver(inner)
+	ctx := context.Background()
+
+	// Enqueue 5 OnStepStart calls. Each inner call takes 200ms,
+	// but the buffered calls should return near-instantly.
+	start := time.Now()
+	for i := 0; i < 5; i++ {
+		if err := buf.OnStepStart(ctx, i); err != nil {
+			t.Fatalf("OnStepStart(%d) returned unexpected error: %v", i, err)
+		}
+	}
+	enqueueElapsed := time.Since(start)
+
+	// Enqueue should take well under 50ms total (no blocking on inner).
+	if enqueueElapsed > 50*time.Millisecond {
+		t.Errorf("enqueuing 5 calls took %v, expected <50ms", enqueueElapsed)
+	}
+
+	// Flush via OnRunComplete — this blocks until all 5 are drained.
+	if err := buf.OnRunComplete(ctx, engine.Result{}); err != nil {
+		t.Fatalf("OnRunComplete returned unexpected error: %v", err)
+	}
+
+	calls := inner.getCalls()
+	if len(calls) != 6 { // 5 OnStepStart + 1 OnRunComplete
+		t.Fatalf("expected 6 inner calls, got %d: %v", len(calls), calls)
+	}
+	for i := 0; i < 5; i++ {
+		if calls[i] != "OnStepStart" {
+			t.Errorf("call[%d] = %q, want OnStepStart", i, calls[i])
+		}
+	}
+	if calls[5] != "OnRunComplete" {
+		t.Errorf("call[5] = %q, want OnRunComplete", calls[5])
+	}
+}
+
+func TestBufferedObserverFlushDrainsAllEventsInOrder(t *testing.T) {
+	inner := &recordingObserver{}
+	buf := NewBufferedObserver(inner)
+	ctx := context.Background()
+
+	// Enqueue a mix of event types.
+	if err := buf.OnStepStart(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := buf.OnProviderCall(ctx, provider.Request{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := buf.OnProviderOutput(ctx, provider.Request{}, provider.StreamDelta{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := buf.OnProviderResponse(ctx, provider.Response{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := buf.OnToolExecution(ctx, engine.ToolExecutionRecord{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := buf.OnStepEnd(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Flush via OnRunComplete.
+	if err := buf.OnRunComplete(ctx, engine.Result{}); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []string{
+		"OnStepStart",
+		"OnProviderCall",
+		"OnProviderOutput",
+		"OnProviderResponse",
+		"OnToolExecution",
+		"OnStepEnd",
+		"OnRunComplete",
+	}
+	calls := inner.getCalls()
+	if len(calls) != len(expected) {
+		t.Fatalf("expected %d calls, got %d: %v", len(expected), len(calls), calls)
+	}
+	for i, want := range expected {
+		if calls[i] != want {
+			t.Errorf("call[%d] = %q, want %q", i, calls[i], want)
+		}
+	}
+}
+
+func TestBufferedObserverFlushDrainsViaOnRunFailure(t *testing.T) {
+	inner := &recordingObserver{}
+	buf := NewBufferedObserver(inner)
+	ctx := context.Background()
+
+	if err := buf.OnStepStart(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := buf.OnProviderCall(ctx, provider.Request{}); err != nil {
+		t.Fatal(err)
+	}
+
+	runErr := errors.New("provider exploded")
+	if err := buf.OnRunFailure(ctx, runErr); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := inner.getCalls()
+	expected := []string{"OnStepStart", "OnProviderCall", "OnRunFailure"}
+	if len(calls) != len(expected) {
+		t.Fatalf("expected %d calls, got %d: %v", len(expected), len(calls), calls)
+	}
+	for i, want := range expected {
+		if calls[i] != want {
+			t.Errorf("call[%d] = %q, want %q", i, calls[i], want)
+		}
+	}
+}
+
+func TestBufferedObserverRetryOnTransientError(t *testing.T) {
+	inner := &failNTimesObserver{failCount: 2}
+	buf := NewBufferedObserver(inner)
+	// Reduce retry backoff for test speed.
+	buf.retryBackoff = time.Millisecond
+	buf.maxRetryBackoff = 5 * time.Millisecond
+	ctx := context.Background()
+
+	// This enqueues the call; the flusher will retry it.
+	if err := buf.OnStepStart(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Flush — should succeed because retry eventually works.
+	if err := buf.OnRunComplete(ctx, engine.Result{}); err != nil {
+		t.Fatalf("OnRunComplete returned unexpected error: %v", err)
+	}
+
+	// Inner observer should have recorded the successful call.
+	calls := inner.getCalls()
+	if len(calls) != 2 { // OnStepStart (after retries) + OnRunComplete
+		t.Fatalf("expected 2 calls, got %d: %v", len(calls), calls)
+	}
+}
+
+func TestBufferedObserverPermanentFailureSurfacesOnNextCall(t *testing.T) {
+	inner := &alwaysFailObserver{}
+	buf := NewBufferedObserver(inner)
+	buf.retryBackoff = time.Millisecond
+	buf.maxRetryBackoff = 5 * time.Millisecond
+	ctx := context.Background()
+
+	// Enqueue a call that will permanently fail.
+	if err := buf.OnStepStart(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Give the flusher time to exhaust retries.
+	time.Sleep(100 * time.Millisecond)
+
+	// Next non-terminal call should surface the background error.
+	err := buf.OnStepEnd(ctx, 0)
+	if err == nil {
+		t.Fatal("expected error from OnStepEnd after permanent background failure")
+	}
+	if !errors.Is(err, err) || err.Error() != "permanent postgres error" {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Clean up: terminal call should also report the error.
+	err = buf.OnRunComplete(ctx, engine.Result{})
+	if err == nil {
+		t.Fatal("expected error from OnRunComplete after permanent background failure")
+	}
+}
+
+func TestBufferedObserverPermanentFailureSurfacesOnFlush(t *testing.T) {
+	inner := &alwaysFailObserver{}
+	buf := NewBufferedObserver(inner)
+	buf.retryBackoff = time.Millisecond
+	buf.maxRetryBackoff = 5 * time.Millisecond
+	ctx := context.Background()
+
+	// Enqueue a call that will permanently fail.
+	if err := buf.OnStepStart(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// OnRunComplete flush should surface the error.
+	err := buf.OnRunComplete(ctx, engine.Result{})
+	if err == nil {
+		t.Fatal("expected error from flush after permanent background failure")
+	}
+	if err.Error() != "permanent postgres error" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestBufferedObserverNoopPassthrough(t *testing.T) {
+	// With nil recorder, the factory should return NoopObserver, not wrapped.
+	factory := NewBufferedNativeObserverFactory(nil)
+	obs, err := factory(dummyExecutionContext())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := obs.(engine.NoopObserver); !ok {
+		t.Errorf("expected NoopObserver, got %T", obs)
+	}
+
+	// Same for prompt eval.
+	peFactory := NewBufferedPromptEvalObserverFactory(nil)
+	obs, err = peFactory(dummyExecutionContext())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := obs.(engine.NoopObserver); !ok {
+		t.Errorf("expected NoopObserver, got %T", obs)
+	}
+}
+
+func TestBufferedObserverContextCancellationDoesNotBlockFlush(t *testing.T) {
+	inner := &recordingObserver{}
+	buf := NewBufferedObserver(inner)
+
+	// Use a context that we cancel before flush.
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if err := buf.OnStepStart(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Cancel the original context — background writes should still succeed
+	// because BufferedObserver uses context.WithoutCancel for enqueued calls.
+	cancel()
+
+	// Flush with a fresh context.
+	freshCtx := context.Background()
+	if err := buf.OnRunComplete(freshCtx, engine.Result{}); err != nil {
+		t.Fatalf("OnRunComplete should succeed with fresh context: %v", err)
+	}
+
+	calls := inner.getCalls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d: %v", len(calls), calls)
+	}
+}
+
+func TestBufferedObserverRecoversPanicInInnerObserver(t *testing.T) {
+	inner := &panickingObserver{}
+	buf := NewBufferedObserver(inner)
+	buf.retryBackoff = time.Millisecond
+	buf.maxRetryBackoff = 5 * time.Millisecond
+	ctx := context.Background()
+
+	// Enqueue a call whose inner observer panics.
+	if err := buf.OnStepStart(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// The panic should be recovered and surfaced as an error on flush.
+	err := buf.OnRunComplete(ctx, engine.Result{})
+	if err == nil {
+		t.Fatal("expected error from flush after inner observer panic")
+	}
+	if got := err.Error(); got != "observer panic: boom" {
+		t.Errorf("unexpected error message: %q", got)
+	}
+}
+
+// --- Test observers (additional) ---
+
+// panickingObserver panics on every OnStepStart call.
+type panickingObserver struct {
+	recordingObserver
+}
+
+func (o *panickingObserver) OnStepStart(_ context.Context, _ int) error {
+	panic("boom")
+}
+
+// --- Helpers ---
+
+func dummyExecutionContext() repository.RunAgentExecutionContext {
+	return repository.RunAgentExecutionContext{}
+}


### PR DESCRIPTION
## Summary

Fixes #226 — the `NativeRunEventObserver` recorded every event to Postgres **synchronously**, blocking the executor. A slow or unavailable database halted the entire agentic execution loop, and since `observer_error` is non-retryable in Temporal, a single DB hiccup permanently killed the run.

- Introduce `BufferedObserver`, a decorator wrapping any `engine.Observer` that enqueues non-terminal calls to a background flusher goroutine with retry logic
- Terminal calls (`OnRunComplete`/`OnRunFailure`) synchronously drain the queue before delegating, guaranteeing all events are persisted before scoring reads them
- Zero changes to the `Observer` interface, inner observer implementations, or executor code — pure decorator pattern

### How it works

```
Executor ──▶ BufferedObserver ──▶ channel (cap 256) ──▶ flusher goroutine ──▶ inner Observer ──▶ Postgres
                 │                                              │
                 │ non-terminal: enqueue + return nil            │ retries up to 3x with exponential backoff
                 │ terminal: flush queue, then delegate sync     │ panic recovery prevents worker crash
```

### Key design decisions

| Decision | Choice | Why |
|----------|--------|-----|
| **Buffer layer** | Observer decorator (not RunEventRecorder wrapper) | Flush semantics must be triggered from terminal observer methods; the recorder doesn't know which events are terminal |
| **Backpressure** | Block when channel full (cap 256) | Dropping events is unacceptable — scoring, replay, and live UI depend on them |
| **Retry** | 3 retries, exponential backoff 100ms→2s | Handles transient Postgres hiccups without external retry infrastructure |
| **Context** | `context.WithoutCancel` for background writes | Enqueued writes must survive executor context cancellation |
| **`observer_error` retry policy** | Kept non-retryable in Temporal | If internal retries exhaust, the issue isn't transient — retrying the whole activity would fail too |

### Files changed

| File | Change |
|------|--------|
| `backend/internal/worker/buffered_observer.go` | **New** — `BufferedObserver` struct, flusher goroutine, retry logic, panic recovery, buffered factory constructors |
| `backend/internal/worker/buffered_observer_test.go` | **New** — 9 tests covering async behavior, ordered flush, transient retry, permanent failure surfacing, noop passthrough, context cancellation, panic recovery |
| `backend/cmd/worker/main.go` | **Modified** — 2 lines swapping factory constructors to buffered variants |

## Test plan

- [x] `go build ./...` — compiles clean
- [x] `go vet ./...` — no issues
- [x] All 9 new `TestBufferedObserver*` tests pass with `-race`
- [x] All existing `worker` and `engine` tests pass (no regressions)
- [ ] Manual: simulate slow Postgres (e.g. `pg_sleep` or network delay) and verify runs complete within normal time bounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)