### PR TITLE
fix(auth): handle WorkOS identity change instead of returning 401

### DIFF
--- a/backend/internal/api/auth_workos.go
+++ b/backend/internal/api/auth_workos.go
@@ -193,6 +193,20 @@ func (a *WorkOSAuthenticator) resolveUser(ctx context.Context, workosUserID, ema
 		Email:        email,
 	})
 	if err != nil {
+		// If creation failed because the email already exists, the user's WorkOS
+		// identity likely changed (re-provisioned account, different auth method).
+		// Link the new WorkOS ID to the existing account.
+		if errors.Is(err, repository.ErrUserAlreadyExists) && email != "" {
+			existing, lookupErr := a.repo.GetUserByEmail(ctx, email)
+			if lookupErr != nil {
+				return repository.User{}, fmt.Errorf("auto-create user: %w", err)
+			}
+			linked, linkErr := a.repo.LinkWorkOSUser(ctx, existing.ID, workosUserID)
+			if linkErr != nil {
+				return repository.User{}, fmt.Errorf("link workos user after conflict: %w", linkErr)
+			}
+			return linked, nil
+		}
 		return repository.User{}, fmt.Errorf("auto-create user: %w", err)
 	}
 	return user, nil


### PR DESCRIPTION
## Summary
- Fixes repeated **401 errors** on `GET /v1/auth/session` caused by `auto-create user: user already exists`
- When a user's WorkOS ID changes (re-provisioned account, different auth method) but their email is the same, `resolveUser()` now detects the email collision and re-links the new WorkOS ID to the existing account
- Single-file change in `backend/internal/api/auth_workos.go` — adds a conflict-recovery path after `CreateUser` fails with `ErrUserAlreadyExists`

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -short -race -count=1 ./internal/api/...` passes
- [ ] Deploy to staging and verify affected users can authenticate (session endpoint returns 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)