### PR TITLE
fix(auth): add structured logging to resolveUser and fix error wrapping

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -89,7 +89,7 @@ func main() {
 		authenticator, err = api.NewWorkOSAuthenticator(api.WorkOSAuthenticatorConfig{
 			ClientID: cfg.WorkOSClientID,
 			Issuer:   cfg.WorkOSIssuer,
-		}, repo)
+		}, repo, logger)
 		if err != nil {
 			logger.Error("failed to initialize workos authenticator", "error", err)
 			os.Exit(1)

--- a/backend/internal/api/auth_workos.go
+++ b/backend/internal/api/auth_workos.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -38,6 +39,7 @@ type UserRepository interface {
 type WorkOSAuthenticator struct {
 	cachedSet jwk.Set
 	repo      UserRepository
+	logger    *slog.Logger
 	issuer    string
 	clientID  string
 }
@@ -53,18 +55,18 @@ type WorkOSAuthenticatorConfig struct {
 }
 
 // NewWorkOSAuthenticator creates an authenticator that validates WorkOS JWTs.
-func NewWorkOSAuthenticator(cfg WorkOSAuthenticatorConfig, repo UserRepository) (*WorkOSAuthenticator, error) {
+func NewWorkOSAuthenticator(cfg WorkOSAuthenticatorConfig, repo UserRepository, logger *slog.Logger) (*WorkOSAuthenticator, error) {
 	jwksURL := "https://api.workos.com/sso/jwks/" + cfg.ClientID
 	issuer := cfg.Issuer
 	if issuer == "" {
 		issuer = defaultWorkOSIssuer + "/user_management/" + cfg.ClientID
 	}
-	return newWorkOSAuthenticator(jwksURL, cfg.ClientID, issuer, repo)
+	return newWorkOSAuthenticator(jwksURL, cfg.ClientID, issuer, repo, logger)
 }
 
 // newWorkOSAuthenticator is the internal constructor that accepts a full JWKS URL.
 // Tests use this directly to point at a local JWKS server.
-func newWorkOSAuthenticator(jwksURL, clientID, issuer string, repo UserRepository) (*WorkOSAuthenticator, error) {
+func newWorkOSAuthenticator(jwksURL, clientID, issuer string, repo UserRepository, logger *slog.Logger) (*WorkOSAuthenticator, error) {
 	cacheCtx := context.Background()
 	cache := jwk.NewCache(cacheCtx)
 	if err := cache.Register(jwksURL, jwk.WithMinRefreshInterval(15*time.Minute)); err != nil {
@@ -82,6 +84,7 @@ func newWorkOSAuthenticator(jwksURL, clientID, issuer string, repo UserRepositor
 	return &WorkOSAuthenticator{
 		cachedSet: jwk.NewCachedSet(cache, jwksURL),
 		repo:      repo,
+		logger:    logger,
 		issuer:    issuer,
 		clientID:  clientID,
 	}, nil
@@ -165,50 +168,77 @@ func (a *WorkOSAuthenticator) Authenticate(r *http.Request) (Caller, error) {
 //     workos_user_id) → link the real WorkOS ID and return it.
 //  3. Completely new user → create and return.
 func (a *WorkOSAuthenticator) resolveUser(ctx context.Context, workosUserID, email string) (repository.User, error) {
+	log := a.logger.With("workos_user_id", workosUserID, "email", email)
+
+	// Case 1: user already linked to this WorkOS ID.
 	user, err := a.repo.GetUserByWorkOSID(ctx, workosUserID)
 	if err == nil {
+		log.DebugContext(ctx, "resolve_user: found by workos_id", "user_id", user.ID)
 		return user, nil
 	}
 	if !errors.Is(err, repository.ErrUserNotFound) {
+		log.ErrorContext(ctx, "resolve_user: unexpected error looking up by workos_id", "error", err)
 		return repository.User{}, fmt.Errorf("%w: %v", ErrUnauthenticated, err)
 	}
+	log.InfoContext(ctx, "resolve_user: no user with this workos_id, checking email")
 
-	// No user with this WorkOS ID. Check if a stub user was created via invite.
-	// Only link to stub users (workos_user_id starts with "pending:") — never
-	// overwrite a real user's identity, which would be an account takeover.
+	// Case 2: stub user from invite (workos_user_id starts with "pending:").
 	if email != "" {
 		stubUser, emailErr := a.repo.GetUserByEmail(ctx, email)
 		if emailErr == nil && strings.HasPrefix(stubUser.WorkOSUserID, "pending:") {
+			log.InfoContext(ctx, "resolve_user: found invited stub, linking workos_id",
+				"stub_user_id", stubUser.ID, "stub_workos_id", stubUser.WorkOSUserID)
 			linked, linkErr := a.repo.LinkWorkOSUser(ctx, stubUser.ID, workosUserID)
 			if linkErr != nil {
+				log.ErrorContext(ctx, "resolve_user: failed to link workos_id to stub",
+					"stub_user_id", stubUser.ID, "error", linkErr)
 				return repository.User{}, fmt.Errorf("link workos user to invited stub: %w", linkErr)
 			}
+			log.InfoContext(ctx, "resolve_user: linked workos_id to stub", "user_id", linked.ID)
 			return linked, nil
+		}
+		if emailErr != nil && !errors.Is(emailErr, repository.ErrUserNotFound) {
+			log.ErrorContext(ctx, "resolve_user: unexpected error looking up by email", "error", emailErr)
+		}
+		if emailErr == nil && !strings.HasPrefix(stubUser.WorkOSUserID, "pending:") {
+			log.WarnContext(ctx, "resolve_user: email match exists but is not a stub — skipping link to avoid account takeover",
+				"existing_user_id", stubUser.ID, "existing_workos_id", stubUser.WorkOSUserID)
 		}
 	}
 
-	// Truly new user — auto-create.
+	// Case 3: truly new user — auto-create.
+	log.InfoContext(ctx, "resolve_user: creating new user")
 	user, err = a.repo.CreateUser(ctx, repository.CreateUserInput{
 		WorkOSUserID: workosUserID,
 		Email:        email,
 	})
 	if err != nil {
-		// If creation failed because the email already exists, the user's WorkOS
-		// identity likely changed (re-provisioned account, different auth method).
-		// Link the new WorkOS ID to the existing account.
 		if errors.Is(err, repository.ErrUserAlreadyExists) && email != "" {
+			// The email already exists — the user's WorkOS identity likely changed
+			// (re-provisioned account, different auth method, or race condition).
+			log.WarnContext(ctx, "resolve_user: create hit unique constraint, attempting to link existing account",
+				"create_error", err)
 			existing, lookupErr := a.repo.GetUserByEmail(ctx, email)
 			if lookupErr != nil {
-				return repository.User{}, fmt.Errorf("auto-create user: %w", err)
+				log.ErrorContext(ctx, "resolve_user: failed to look up existing user by email after create conflict",
+					"lookup_error", lookupErr, "original_create_error", err)
+				return repository.User{}, fmt.Errorf("auto-create user: lookup after conflict failed: %w", lookupErr)
 			}
+			log.InfoContext(ctx, "resolve_user: found existing user after conflict, linking workos_id",
+				"existing_user_id", existing.ID, "existing_workos_id", existing.WorkOSUserID)
 			linked, linkErr := a.repo.LinkWorkOSUser(ctx, existing.ID, workosUserID)
 			if linkErr != nil {
+				log.ErrorContext(ctx, "resolve_user: failed to link workos_id to existing user after conflict",
+					"existing_user_id", existing.ID, "existing_workos_id", existing.WorkOSUserID, "error", linkErr)
 				return repository.User{}, fmt.Errorf("link workos user after conflict: %w", linkErr)
 			}
+			log.InfoContext(ctx, "resolve_user: linked workos_id to existing user after conflict", "user_id", linked.ID)
 			return linked, nil
 		}
+		log.ErrorContext(ctx, "resolve_user: failed to create user", "error", err)
 		return repository.User{}, fmt.Errorf("auto-create user: %w", err)
 	}
+	log.InfoContext(ctx, "resolve_user: created new user", "user_id", user.ID)
 	return user, nil
 }
 

--- a/backend/internal/api/auth_workos_test.go
+++ b/backend/internal/api/auth_workos_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -17,6 +18,8 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 )
+
+var authTestLogger = slog.Default()
 
 // --- test helpers ---
 
@@ -157,7 +160,7 @@ func TestWorkOSAuthenticator_ValidToken(t *testing.T) {
 		},
 	}
 
-	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", repo)
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", repo, authTestLogger)
 	if err != nil {
 		t.Fatalf("create authenticator: %v", err)
 	}
@@ -202,7 +205,7 @@ func TestWorkOSAuthenticator_MissingAuthorizationHeader(t *testing.T) {
 	privKey, jwksServer := testJWKS(t)
 	_ = privKey
 
-	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", stubUserRepo{})
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", stubUserRepo{}, authTestLogger)
 	if err != nil {
 		t.Fatalf("create authenticator: %v", err)
 	}
@@ -217,7 +220,7 @@ func TestWorkOSAuthenticator_MissingAuthorizationHeader(t *testing.T) {
 func TestWorkOSAuthenticator_MalformedBearerToken(t *testing.T) {
 	_, jwksServer := testJWKS(t)
 
-	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", stubUserRepo{})
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", stubUserRepo{}, authTestLogger)
 	if err != nil {
 		t.Fatalf("create authenticator: %v", err)
 	}
@@ -233,7 +236,7 @@ func TestWorkOSAuthenticator_MalformedBearerToken(t *testing.T) {
 func TestWorkOSAuthenticator_ExpiredToken(t *testing.T) {
 	privKey, jwksServer := testJWKS(t)
 
-	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", stubUserRepo{})
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", stubUserRepo{}, authTestLogger)
 	if err != nil {
 		t.Fatalf("create authenticator: %v", err)
 	}
@@ -263,7 +266,7 @@ func TestWorkOSAuthenticator_InvalidSignature(t *testing.T) {
 		t.Fatalf("generate other key: %v", err)
 	}
 
-	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", stubUserRepo{})
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", stubUserRepo{}, authTestLogger)
 	if err != nil {
 		t.Fatalf("create authenticator: %v", err)
 	}
@@ -297,7 +300,7 @@ func TestWorkOSAuthenticator_FirstLoginCreatesUser(t *testing.T) {
 		},
 	}
 
-	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", repo)
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", repo, authTestLogger)
 	if err != nil {
 		t.Fatalf("create authenticator: %v", err)
 	}
@@ -336,7 +339,7 @@ func TestWorkOSAuthenticator_FirstLoginCreateUserFails(t *testing.T) {
 		createUserErr: errors.New("db connection lost"),
 	}
 
-	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", repo)
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", repo, authTestLogger)
 	if err != nil {
 		t.Fatalf("create authenticator: %v", err)
 	}
@@ -360,7 +363,7 @@ func TestWorkOSAuthenticator_FirstLoginCreateUserFails(t *testing.T) {
 func TestWorkOSAuthenticator_EmptySubClaim(t *testing.T) {
 	privKey, jwksServer := testJWKS(t)
 
-	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", stubUserRepo{})
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", stubUserRepo{}, authTestLogger)
 	if err != nil {
 		t.Fatalf("create authenticator: %v", err)
 	}
@@ -384,7 +387,7 @@ func TestWorkOSAuthenticator_EmptySubClaim(t *testing.T) {
 func TestWorkOSAuthenticator_GarbageToken(t *testing.T) {
 	_, jwksServer := testJWKS(t)
 
-	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", stubUserRepo{})
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", stubUserRepo{}, authTestLogger)
 	if err != nil {
 		t.Fatalf("create authenticator: %v", err)
 	}
@@ -410,7 +413,7 @@ func TestWorkOSAuthenticator_MembershipLoadError(t *testing.T) {
 		membershipErr: errors.New("db connection lost"),
 	}
 
-	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", repo)
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", repo, authTestLogger)
 	if err != nil {
 		t.Fatalf("create authenticator: %v", err)
 	}
@@ -435,7 +438,7 @@ func TestWorkOSAuthenticator_WrongIssuer(t *testing.T) {
 	privKey, jwksServer := testJWKS(t)
 
 	// Authenticator expects "https://api.workos.com" but token has a different issuer
-	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", stubUserRepo{})
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", stubUserRepo{}, authTestLogger)
 	if err != nil {
 		t.Fatalf("create authenticator: %v", err)
 	}
@@ -469,7 +472,7 @@ func TestWorkOSAuthenticator_CustomIssuer(t *testing.T) {
 		memberships: []repository.WorkspaceMembershipRow{},
 	}
 
-	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://auth.mycompany.com", repo)
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://auth.mycompany.com", repo, authTestLogger)
 	if err != nil {
 		t.Fatalf("create authenticator: %v", err)
 	}

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -1983,7 +1983,7 @@ func (r *Repository) CreateUser(ctx context.Context, input CreateUserInput) (Use
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-			return User{}, fmt.Errorf("%w: user already exists", ErrUserAlreadyExists)
+			return User{}, fmt.Errorf("%w: constraint=%s detail=%s", ErrUserAlreadyExists, pgErr.ConstraintName, pgErr.Detail)
 		}
 		return User{}, fmt.Errorf("create user: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Adds structured `slog` logging to every decision branch in `resolveUser` (WorkOS auth sign-in flow) with `workos_user_id` and `email` context — covers the happy path, stub linking, auto-create, conflict recovery, and all error paths
- Fixes a bug where a failed `GetUserByEmail` after a create conflict returned the **original** `CreateUser` error instead of the lookup error, producing the confusing `"auto-create user: user already exists: user already exists"` message
- Enriches the repository `CreateUser` constraint-violation error with `pgErr.ConstraintName` and `pgErr.Detail` so logs show which unique constraint (email vs workos_user_id) fired

## Test plan
- [x] All existing `TestWorkOS*` tests pass
- [x] Full backend test suite passes (`go test -short -race -count=1 ./...`)
- [ ] Deploy to staging and sign in — verify structured logs appear in Railway with correct fields
- [ ] Reproduce the prod error scenario (user with changed WorkOS identity) and confirm logs now show the exact failure path

🤖 Generated with [Claude Code](https://claude.com/claude-code)