### PR TITLE
fix(auth): handle archived users + WorkOS re-provisioning in resolveUser

### DIFF
--- a/backend/internal/api/auth_workos.go
+++ b/backend/internal/api/auth_workos.go
@@ -33,6 +33,7 @@ type UserRepository interface {
 	CreateUser(ctx context.Context, input repository.CreateUserInput) (repository.User, error)
 	LinkWorkOSUser(ctx context.Context, userID uuid.UUID, workosUserID string) (repository.User, error)
 	RelinkWorkOSUser(ctx context.Context, userID uuid.UUID, workosUserID string) (repository.User, error)
+	UnarchiveAndRelinkUser(ctx context.Context, email, workosUserID string) (repository.User, error)
 }
 
 // WorkOSAuthenticator validates WorkOS AuthKit JWTs using the public JWKS
@@ -231,24 +232,36 @@ func (a *WorkOSAuthenticator) resolveUser(ctx context.Context, workosUserID, ema
 	})
 	if err != nil {
 		if errors.Is(err, repository.ErrUserAlreadyExists) && email != "" {
-			// Race condition: another request created/linked the user between our
-			// email lookup and this insert. Re-link to be safe.
-			log.WarnContext(ctx, "resolve_user: create hit unique constraint (race), re-linking",
+			log.WarnContext(ctx, "resolve_user: create hit unique constraint, recovering",
 				"create_error", err)
+
+			// First try: the conflicting user may be active (race condition or
+			// missed by the email lookup above for some other reason).
 			existing, lookupErr := a.repo.GetUserByEmail(ctx, email)
-			if lookupErr != nil {
-				log.ErrorContext(ctx, "resolve_user: failed to look up user after create conflict",
-					"lookup_error", lookupErr, "original_create_error", err)
-				return repository.User{}, fmt.Errorf("auto-create user: lookup after conflict failed: %w", lookupErr)
+			if lookupErr == nil {
+				relinked, relinkErr := a.repo.RelinkWorkOSUser(ctx, existing.ID, workosUserID)
+				if relinkErr != nil {
+					log.ErrorContext(ctx, "resolve_user: failed to re-link after create conflict",
+						"existing_user_id", existing.ID, "existing_workos_id", existing.WorkOSUserID, "error", relinkErr)
+					return repository.User{}, fmt.Errorf("re-link workos user after conflict: %w", relinkErr)
+				}
+				log.InfoContext(ctx, "resolve_user: re-linked after create conflict", "user_id", relinked.ID)
+				return relinked, nil
 			}
-			relinked, relinkErr := a.repo.RelinkWorkOSUser(ctx, existing.ID, workosUserID)
-			if relinkErr != nil {
-				log.ErrorContext(ctx, "resolve_user: failed to re-link after create conflict",
-					"existing_user_id", existing.ID, "existing_workos_id", existing.WorkOSUserID, "error", relinkErr)
-				return repository.User{}, fmt.Errorf("re-link workos user after conflict: %w", relinkErr)
+
+			// Second try: the email may be held by a soft-deleted (archived)
+			// user that is invisible to normal lookups but still blocks the
+			// unique constraint. Restore and re-link in one step.
+			log.WarnContext(ctx, "resolve_user: active user not found by email, checking for archived user",
+				"lookup_error", lookupErr)
+			restored, restoreErr := a.repo.UnarchiveAndRelinkUser(ctx, email, workosUserID)
+			if restoreErr != nil {
+				log.ErrorContext(ctx, "resolve_user: failed to restore archived user",
+					"restore_error", restoreErr, "original_create_error", err)
+				return repository.User{}, fmt.Errorf("auto-create user: %w", err)
 			}
-			log.InfoContext(ctx, "resolve_user: re-linked after create conflict", "user_id", relinked.ID)
-			return relinked, nil
+			log.InfoContext(ctx, "resolve_user: restored archived user and re-linked", "user_id", restored.ID)
+			return restored, nil
 		}
 		log.ErrorContext(ctx, "resolve_user: failed to create user", "error", err)
 		return repository.User{}, fmt.Errorf("auto-create user: %w", err)

--- a/backend/internal/api/auth_workos_test.go
+++ b/backend/internal/api/auth_workos_test.go
@@ -144,6 +144,10 @@ func (s stubUserRepo) RelinkWorkOSUser(_ context.Context, _ uuid.UUID, _ string)
 	return repository.User{}, errors.New("not implemented in stub")
 }
 
+func (s stubUserRepo) UnarchiveAndRelinkUser(_ context.Context, _ string, _ string) (repository.User, error) {
+	return repository.User{}, errors.New("not implemented in stub")
+}
+
 // --- tests ---
 
 func TestWorkOSAuthenticator_ValidToken(t *testing.T) {

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -2026,6 +2026,26 @@ func (r *Repository) RelinkWorkOSUser(ctx context.Context, userID uuid.UUID, wor
 	return user, nil
 }
 
+// UnarchiveAndRelinkUser finds an archived (soft-deleted) user by email,
+// clears archived_at, updates the workos_user_id, and returns the restored
+// user. Returns ErrUserNotFound if no archived user with that email exists.
+func (r *Repository) UnarchiveAndRelinkUser(ctx context.Context, email, workosUserID string) (User, error) {
+	var user User
+	err := r.db.QueryRow(ctx, `
+		UPDATE users
+		SET workos_user_id = $2, archived_at = NULL, updated_at = now()
+		WHERE email = $1 AND archived_at IS NOT NULL
+		RETURNING id, workos_user_id, email, COALESCE(display_name, '')
+	`, email, workosUserID).Scan(&user.ID, &user.WorkOSUserID, &user.Email, &user.DisplayName)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return User{}, ErrUserNotFound
+		}
+		return User{}, fmt.Errorf("unarchive and relink user: %w", err)
+	}
+	return user, nil
+}
+
 func (r *Repository) GetOrganizationsForUser(ctx context.Context, userID uuid.UUID) ([]UserMeOrgRow, error) {
 	rows, err := r.db.Query(ctx, `
 		SELECT o.id, o.name, o.slug, om.role


### PR DESCRIPTION
## Summary

Fixes permanent sign-in lockout caused by two related issues in `resolveUser`:

**Issue 1 (from PR #252):** Users whose WorkOS identity changed (re-provisioned account) couldn't sign in because `LinkWorkOSUser` only updates stub users with `pending:` prefix.
- Adds `RelinkWorkOSUser` repo method that updates `workos_user_id` unconditionally

**Issue 2 (new — the actual prod blocker):** Soft-deleted (archived) users hold a phantom `UNIQUE(email)` constraint that blocks new user creation, while being invisible to all lookups (`WHERE archived_at IS NULL`):
1. `GetUserByWorkOSID` → not found (archived row filtered out)
2. `GetUserByEmail` → not found (archived row filtered out)
3. `CreateUser` → fails on `UNIQUE(email)` held by the ghost row
4. Every conflict recovery lookup also returns not found → **permanent lockout**

- Adds `UnarchiveAndRelinkUser` repo method that finds archived users by email, restores them (`archived_at = NULL`), and re-links the WorkOS ID in one atomic UPDATE
- `resolveUser` conflict recovery now falls through to archived-user restoration when the active-user lookup returns not found

## Test plan
- [x] Full backend test suite passes
- [ ] Deploy to prod and verify sign-in works for the affected user
- [ ] Check logs for `resolve_user: restored archived user and re-linked` confirming the fix path

🤖 Generated with [Claude Code](https://claude.com/claude-code)