### PR TITLE
fix(auth): allow sign-up without email in JWT via partial unique index

### DIFF
--- a/backend/db/migrations/00018_users_email_partial_unique.sql
+++ b/backend/db/migrations/00018_users_email_partial_unique.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+
+-- WorkOS AuthKit JWTs do not include an email claim by default. Users who
+-- sign in without email in their token get email = ''. The old unconditional
+-- UNIQUE(email) allowed only ONE such user; every subsequent sign-up collided.
+-- Replace with a partial unique index that ignores empty emails.
+
+ALTER TABLE users ALTER COLUMN email SET DEFAULT '';
+ALTER TABLE users DROP CONSTRAINT users_email_key;
+CREATE UNIQUE INDEX users_email_uq ON users (email) WHERE email != '';
+
+-- +goose Down
+
+DROP INDEX IF EXISTS users_email_uq;
+ALTER TABLE users ADD CONSTRAINT users_email_key UNIQUE (email);
+ALTER TABLE users ALTER COLUMN email DROP DEFAULT;

--- a/backend/internal/api/auth.go
+++ b/backend/internal/api/auth.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	ErrUnauthenticated      = errors.New("unauthenticated")
+	ErrAccountDeactivated   = errors.New("account deactivated")
 	ErrForbidden            = errors.New("forbidden")
 	ErrCallerMissing        = errors.New("caller missing from request context")
 	ErrWorkspaceIDRequired  = errors.New("workspace id is required")
@@ -103,6 +104,15 @@ func authenticateRequest(logger *slog.Logger, authenticator Authenticator) func(
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			caller, err := authenticator.Authenticate(r)
 			if err != nil {
+				if errors.Is(err, ErrAccountDeactivated) {
+					logger.Warn("request from deactivated account",
+						"method", r.Method,
+						"path", r.URL.Path,
+						"error", err,
+					)
+					writeError(w, http.StatusForbidden, "account_deactivated", "your account has been deactivated")
+					return
+				}
 				logger.Warn("request authentication failed",
 					"method", r.Method,
 					"path", r.URL.Path,

--- a/backend/internal/api/auth_workos.go
+++ b/backend/internal/api/auth_workos.go
@@ -34,6 +34,7 @@ type UserRepository interface {
 	LinkWorkOSUser(ctx context.Context, userID uuid.UUID, workosUserID string) (repository.User, error)
 	RelinkWorkOSUser(ctx context.Context, userID uuid.UUID, workosUserID string) (repository.User, error)
 	UnarchiveAndRelinkUser(ctx context.Context, email, workosUserID string) (repository.User, error)
+	UnarchiveUserByWorkOSID(ctx context.Context, workosUserID string) (repository.User, error)
 }
 
 // WorkOSAuthenticator validates WorkOS AuthKit JWTs using the public JWKS
@@ -164,34 +165,51 @@ func (a *WorkOSAuthenticator) Authenticate(r *http.Request) (Caller, error) {
 }
 
 // resolveUser finds or creates the internal user for a WorkOS login.
-// It handles four cases:
-//  1. User already exists with this WorkOS ID → return it.
-//  2. A stub user exists from an invite (matched by email, has a "pending:"
-//     workos_user_id) → link the real WorkOS ID and return it.
-//  3. An existing user has a different WorkOS ID for the same email
-//     (re-provisioned WorkOS account) → re-link and return it.
-//  4. Completely new user → create and return.
+//
+// Resolution order:
+//  1. Active user with this WorkOS ID → return it.
+//  2. Archived user with this WorkOS ID → unarchive and return.
+//  3. Active stub user (invite) matched by email → link WorkOS ID.
+//  4. Active user with different WorkOS ID matched by email → re-link.
+//  5. Truly new user → create. On constraint conflict, recover by
+//     re-linking or unarchiving the conflicting row.
+//
+// Note: WorkOS access tokens may not include an email claim unless JWT
+// Templates are configured. Steps 3-4 are skipped when email is absent.
 func (a *WorkOSAuthenticator) resolveUser(ctx context.Context, workosUserID, email string) (repository.User, error) {
 	log := a.logger.With("workos_user_id", workosUserID, "email", email)
 
-	// Case 1: user already linked to this WorkOS ID.
+	// Step 1: active user with this WorkOS ID.
 	user, err := a.repo.GetUserByWorkOSID(ctx, workosUserID)
 	if err == nil {
-		log.DebugContext(ctx, "resolve_user: found by workos_id", "user_id", user.ID)
+		log.DebugContext(ctx, "resolve_user: found active user by workos_id", "user_id", user.ID)
 		return user, nil
 	}
 	if !errors.Is(err, repository.ErrUserNotFound) {
 		log.ErrorContext(ctx, "resolve_user: unexpected error looking up by workos_id", "error", err)
 		return repository.User{}, fmt.Errorf("%w: %v", ErrUnauthenticated, err)
 	}
-	log.InfoContext(ctx, "resolve_user: no user with this workos_id, checking email")
 
-	// Case 2 & 3: an existing user with this email may need linking.
+	// Step 2: archived user with this WorkOS ID — restore them.
+	// The UNIQUE(workos_user_id) constraint means an archived row with this
+	// ID would block any INSERT, so we must check before creating.
+	restored, restoreErr := a.repo.UnarchiveUserByWorkOSID(ctx, workosUserID)
+	if restoreErr == nil {
+		log.InfoContext(ctx, "resolve_user: restored archived user by workos_id", "user_id", restored.ID)
+		return restored, nil
+	}
+	if !errors.Is(restoreErr, repository.ErrUserNotFound) {
+		log.ErrorContext(ctx, "resolve_user: unexpected error unarchiving by workos_id", "error", restoreErr)
+	}
+
+	log.InfoContext(ctx, "resolve_user: no active or archived user with this workos_id")
+
+	// Steps 3 & 4: match by email (only when JWT includes email claim).
 	if email != "" {
 		existingUser, emailErr := a.repo.GetUserByEmail(ctx, email)
 		if emailErr == nil {
 			if strings.HasPrefix(existingUser.WorkOSUserID, "pending:") {
-				// Case 2: stub user from invite — link the real WorkOS ID.
+				// Step 3: stub user from invite — link the real WorkOS ID.
 				log.InfoContext(ctx, "resolve_user: found invited stub, linking workos_id",
 					"stub_user_id", existingUser.ID, "stub_workos_id", existingUser.WorkOSUserID)
 				linked, linkErr := a.repo.LinkWorkOSUser(ctx, existingUser.ID, workosUserID)
@@ -204,10 +222,9 @@ func (a *WorkOSAuthenticator) resolveUser(ctx context.Context, workosUserID, ema
 				return linked, nil
 			}
 
-			// Case 3: existing user with a different real WorkOS ID. The JWT
+			// Step 4: existing user with a different real WorkOS ID. The JWT
 			// signature was already verified, so WorkOS authoritatively says
-			// this email now belongs to the new WorkOS identity (re-provisioned
-			// account, org-level auth change, etc.). Re-link.
+			// this email now belongs to the new WorkOS identity. Re-link.
 			log.WarnContext(ctx, "resolve_user: email matches existing user with different workos_id, re-linking",
 				"existing_user_id", existingUser.ID, "old_workos_id", existingUser.WorkOSUserID)
 			relinked, relinkErr := a.repo.RelinkWorkOSUser(ctx, existingUser.ID, workosUserID)
@@ -224,46 +241,51 @@ func (a *WorkOSAuthenticator) resolveUser(ctx context.Context, workosUserID, ema
 		}
 	}
 
-	// Case 4: truly new user — auto-create.
+	// Step 5: truly new user — auto-create.
 	log.InfoContext(ctx, "resolve_user: creating new user")
 	user, err = a.repo.CreateUser(ctx, repository.CreateUserInput{
 		WorkOSUserID: workosUserID,
 		Email:        email,
 	})
 	if err != nil {
-		if errors.Is(err, repository.ErrUserAlreadyExists) && email != "" {
-			log.WarnContext(ctx, "resolve_user: create hit unique constraint, recovering",
-				"create_error", err)
+		if !errors.Is(err, repository.ErrUserAlreadyExists) {
+			log.ErrorContext(ctx, "resolve_user: failed to create user", "error", err)
+			return repository.User{}, fmt.Errorf("auto-create user: %w", err)
+		}
 
-			// First try: the conflicting user may be active (race condition or
-			// missed by the email lookup above for some other reason).
+		// Constraint conflict — recover by finding the conflicting row.
+		log.WarnContext(ctx, "resolve_user: create hit unique constraint, recovering", "create_error", err)
+
+		// Try email-based recovery (active then archived).
+		if email != "" {
 			existing, lookupErr := a.repo.GetUserByEmail(ctx, email)
 			if lookupErr == nil {
 				relinked, relinkErr := a.repo.RelinkWorkOSUser(ctx, existing.ID, workosUserID)
 				if relinkErr != nil {
-					log.ErrorContext(ctx, "resolve_user: failed to re-link after create conflict",
-						"existing_user_id", existing.ID, "existing_workos_id", existing.WorkOSUserID, "error", relinkErr)
+					log.ErrorContext(ctx, "resolve_user: failed to re-link after email conflict",
+						"existing_user_id", existing.ID, "error", relinkErr)
 					return repository.User{}, fmt.Errorf("re-link workos user after conflict: %w", relinkErr)
 				}
-				log.InfoContext(ctx, "resolve_user: re-linked after create conflict", "user_id", relinked.ID)
+				log.InfoContext(ctx, "resolve_user: re-linked after email conflict", "user_id", relinked.ID)
 				return relinked, nil
 			}
 
-			// Second try: the email may be held by a soft-deleted (archived)
-			// user that is invisible to normal lookups but still blocks the
-			// unique constraint. Restore and re-link in one step.
-			log.WarnContext(ctx, "resolve_user: active user not found by email, checking for archived user",
-				"lookup_error", lookupErr)
-			restored, restoreErr := a.repo.UnarchiveAndRelinkUser(ctx, email, workosUserID)
-			if restoreErr != nil {
-				log.ErrorContext(ctx, "resolve_user: failed to restore archived user",
-					"restore_error", restoreErr, "original_create_error", err)
-				return repository.User{}, fmt.Errorf("auto-create user: %w", err)
+			archivedByEmail, archiveErr := a.repo.UnarchiveAndRelinkUser(ctx, email, workosUserID)
+			if archiveErr == nil {
+				log.InfoContext(ctx, "resolve_user: restored archived user by email", "user_id", archivedByEmail.ID)
+				return archivedByEmail, nil
 			}
-			log.InfoContext(ctx, "resolve_user: restored archived user and re-linked", "user_id", restored.ID)
-			return restored, nil
 		}
-		log.ErrorContext(ctx, "resolve_user: failed to create user", "error", err)
+
+		// Try workos_user_id-based recovery (archived row blocking the constraint).
+		archivedByWID, archiveErr := a.repo.UnarchiveUserByWorkOSID(ctx, workosUserID)
+		if archiveErr == nil {
+			log.InfoContext(ctx, "resolve_user: restored archived user by workos_id", "user_id", archivedByWID.ID)
+			return archivedByWID, nil
+		}
+
+		log.ErrorContext(ctx, "resolve_user: all recovery paths exhausted",
+			"original_create_error", err)
 		return repository.User{}, fmt.Errorf("auto-create user: %w", err)
 	}
 	log.InfoContext(ctx, "resolve_user: created new user", "user_id", user.ID)

--- a/backend/internal/api/auth_workos.go
+++ b/backend/internal/api/auth_workos.go
@@ -33,8 +33,8 @@ type UserRepository interface {
 	CreateUser(ctx context.Context, input repository.CreateUserInput) (repository.User, error)
 	LinkWorkOSUser(ctx context.Context, userID uuid.UUID, workosUserID string) (repository.User, error)
 	RelinkWorkOSUser(ctx context.Context, userID uuid.UUID, workosUserID string) (repository.User, error)
-	UnarchiveAndRelinkUser(ctx context.Context, email, workosUserID string) (repository.User, error)
-	UnarchiveUserByWorkOSID(ctx context.Context, workosUserID string) (repository.User, error)
+	IsUserArchivedByWorkOSID(ctx context.Context, workosUserID string) (bool, error)
+	IsUserArchivedByEmail(ctx context.Context, email string) (bool, error)
 }
 
 // WorkOSAuthenticator validates WorkOS AuthKit JWTs using the public JWKS
@@ -168,14 +168,15 @@ func (a *WorkOSAuthenticator) Authenticate(r *http.Request) (Caller, error) {
 //
 // Resolution order:
 //  1. Active user with this WorkOS ID → return it.
-//  2. Archived user with this WorkOS ID → unarchive and return.
+//  2. Archived user with this WorkOS ID → reject (account deactivated).
 //  3. Active stub user (invite) matched by email → link WorkOS ID.
 //  4. Active user with different WorkOS ID matched by email → re-link.
-//  5. Truly new user → create. On constraint conflict, recover by
-//     re-linking or unarchiving the conflicting row.
+//  5. Archived user matched by email → reject (account deactivated).
+//  6. Truly new user → create. On constraint conflict, check for archived
+//     rows blocking the unique constraint and return the appropriate error.
 //
 // Note: WorkOS access tokens may not include an email claim unless JWT
-// Templates are configured. Steps 3-4 are skipped when email is absent.
+// Templates are configured. Steps 3-5 are skipped when email is absent.
 func (a *WorkOSAuthenticator) resolveUser(ctx context.Context, workosUserID, email string) (repository.User, error) {
 	log := a.logger.With("workos_user_id", workosUserID, "email", email)
 
@@ -190,16 +191,17 @@ func (a *WorkOSAuthenticator) resolveUser(ctx context.Context, workosUserID, ema
 		return repository.User{}, fmt.Errorf("%w: %v", ErrUnauthenticated, err)
 	}
 
-	// Step 2: archived user with this WorkOS ID — restore them.
-	// The UNIQUE(workos_user_id) constraint means an archived row with this
-	// ID would block any INSERT, so we must check before creating.
-	restored, restoreErr := a.repo.UnarchiveUserByWorkOSID(ctx, workosUserID)
-	if restoreErr == nil {
-		log.InfoContext(ctx, "resolve_user: restored archived user by workos_id", "user_id", restored.ID)
-		return restored, nil
+	// Step 2: check if an archived user holds this WorkOS ID.
+	// The UNIQUE(workos_user_id) constraint includes archived rows, so one
+	// would block INSERT. Don't auto-restore — the account was deactivated
+	// intentionally.
+	archived, archiveErr := a.repo.IsUserArchivedByWorkOSID(ctx, workosUserID)
+	if archiveErr != nil {
+		log.ErrorContext(ctx, "resolve_user: error checking archived status by workos_id", "error", archiveErr)
 	}
-	if !errors.Is(restoreErr, repository.ErrUserNotFound) {
-		log.ErrorContext(ctx, "resolve_user: unexpected error unarchiving by workos_id", "error", restoreErr)
+	if archived {
+		log.WarnContext(ctx, "resolve_user: user is archived (deactivated)")
+		return repository.User{}, fmt.Errorf("%w: sign in with workos_user_id %s", ErrAccountDeactivated, workosUserID)
 	}
 
 	log.InfoContext(ctx, "resolve_user: no active or archived user with this workos_id")
@@ -239,9 +241,19 @@ func (a *WorkOSAuthenticator) resolveUser(ctx context.Context, workosUserID, ema
 		if !errors.Is(emailErr, repository.ErrUserNotFound) {
 			log.ErrorContext(ctx, "resolve_user: unexpected error looking up by email", "error", emailErr)
 		}
+
+		// Step 5: check if an archived user holds this email.
+		archivedByEmail, archiveByEmailErr := a.repo.IsUserArchivedByEmail(ctx, email)
+		if archiveByEmailErr != nil {
+			log.ErrorContext(ctx, "resolve_user: error checking archived status by email", "error", archiveByEmailErr)
+		}
+		if archivedByEmail {
+			log.WarnContext(ctx, "resolve_user: user with this email is archived (deactivated)")
+			return repository.User{}, fmt.Errorf("%w: sign in with email %s", ErrAccountDeactivated, email)
+		}
 	}
 
-	// Step 5: truly new user — auto-create.
+	// Step 6: truly new user — auto-create.
 	log.InfoContext(ctx, "resolve_user: creating new user")
 	user, err = a.repo.CreateUser(ctx, repository.CreateUserInput{
 		WorkOSUserID: workosUserID,
@@ -253,38 +265,23 @@ func (a *WorkOSAuthenticator) resolveUser(ctx context.Context, workosUserID, ema
 			return repository.User{}, fmt.Errorf("auto-create user: %w", err)
 		}
 
-		// Constraint conflict — recover by finding the conflicting row.
+		// Constraint conflict — likely a race condition. Try email-based recovery.
 		log.WarnContext(ctx, "resolve_user: create hit unique constraint, recovering", "create_error", err)
-
-		// Try email-based recovery (active then archived).
 		if email != "" {
 			existing, lookupErr := a.repo.GetUserByEmail(ctx, email)
 			if lookupErr == nil {
 				relinked, relinkErr := a.repo.RelinkWorkOSUser(ctx, existing.ID, workosUserID)
 				if relinkErr != nil {
-					log.ErrorContext(ctx, "resolve_user: failed to re-link after email conflict",
+					log.ErrorContext(ctx, "resolve_user: failed to re-link after conflict",
 						"existing_user_id", existing.ID, "error", relinkErr)
 					return repository.User{}, fmt.Errorf("re-link workos user after conflict: %w", relinkErr)
 				}
-				log.InfoContext(ctx, "resolve_user: re-linked after email conflict", "user_id", relinked.ID)
+				log.InfoContext(ctx, "resolve_user: re-linked after conflict", "user_id", relinked.ID)
 				return relinked, nil
 			}
-
-			archivedByEmail, archiveErr := a.repo.UnarchiveAndRelinkUser(ctx, email, workosUserID)
-			if archiveErr == nil {
-				log.InfoContext(ctx, "resolve_user: restored archived user by email", "user_id", archivedByEmail.ID)
-				return archivedByEmail, nil
-			}
 		}
 
-		// Try workos_user_id-based recovery (archived row blocking the constraint).
-		archivedByWID, archiveErr := a.repo.UnarchiveUserByWorkOSID(ctx, workosUserID)
-		if archiveErr == nil {
-			log.InfoContext(ctx, "resolve_user: restored archived user by workos_id", "user_id", archivedByWID.ID)
-			return archivedByWID, nil
-		}
-
-		log.ErrorContext(ctx, "resolve_user: all recovery paths exhausted",
+		log.ErrorContext(ctx, "resolve_user: constraint conflict, recovery failed",
 			"original_create_error", err)
 		return repository.User{}, fmt.Errorf("auto-create user: %w", err)
 	}

--- a/backend/internal/api/auth_workos.go
+++ b/backend/internal/api/auth_workos.go
@@ -281,6 +281,15 @@ func (a *WorkOSAuthenticator) resolveUser(ctx context.Context, workosUserID, ema
 			}
 		}
 
+		// Email-based recovery didn't work (or email was empty). The conflict
+		// is likely on workos_user_id from a race condition: another request
+		// created the user between our Step 1 lookup and this INSERT.
+		retried, retryErr := a.repo.GetUserByWorkOSID(ctx, workosUserID)
+		if retryErr == nil {
+			log.InfoContext(ctx, "resolve_user: found user on retry after conflict", "user_id", retried.ID)
+			return retried, nil
+		}
+
 		log.ErrorContext(ctx, "resolve_user: constraint conflict, recovery failed",
 			"original_create_error", err)
 		return repository.User{}, fmt.Errorf("auto-create user: %w", err)

--- a/backend/internal/api/auth_workos_test.go
+++ b/backend/internal/api/auth_workos_test.go
@@ -144,12 +144,12 @@ func (s stubUserRepo) RelinkWorkOSUser(_ context.Context, _ uuid.UUID, _ string)
 	return repository.User{}, errors.New("not implemented in stub")
 }
 
-func (s stubUserRepo) UnarchiveAndRelinkUser(_ context.Context, _ string, _ string) (repository.User, error) {
-	return repository.User{}, repository.ErrUserNotFound
+func (s stubUserRepo) IsUserArchivedByWorkOSID(_ context.Context, _ string) (bool, error) {
+	return false, nil
 }
 
-func (s stubUserRepo) UnarchiveUserByWorkOSID(_ context.Context, _ string) (repository.User, error) {
-	return repository.User{}, repository.ErrUserNotFound
+func (s stubUserRepo) IsUserArchivedByEmail(_ context.Context, _ string) (bool, error) {
+	return false, nil
 }
 
 // --- tests ---

--- a/backend/internal/api/auth_workos_test.go
+++ b/backend/internal/api/auth_workos_test.go
@@ -145,7 +145,11 @@ func (s stubUserRepo) RelinkWorkOSUser(_ context.Context, _ uuid.UUID, _ string)
 }
 
 func (s stubUserRepo) UnarchiveAndRelinkUser(_ context.Context, _ string, _ string) (repository.User, error) {
-	return repository.User{}, errors.New("not implemented in stub")
+	return repository.User{}, repository.ErrUserNotFound
+}
+
+func (s stubUserRepo) UnarchiveUserByWorkOSID(_ context.Context, _ string) (repository.User, error) {
+	return repository.User{}, repository.ErrUserNotFound
 }
 
 // --- tests ---

--- a/backend/internal/api/auth_workos_test.go
+++ b/backend/internal/api/auth_workos_test.go
@@ -343,6 +343,47 @@ func TestWorkOSAuthenticator_FirstLoginCreatesUser(t *testing.T) {
 	}
 }
 
+func TestWorkOSAuthenticator_FirstLoginNoEmail(t *testing.T) {
+	privKey, jwksServer := testJWKS(t)
+
+	createdUserID := uuid.New()
+	repo := stubUserRepo{
+		err: repository.ErrUserNotFound,
+		createdUser: repository.User{
+			ID:           createdUserID,
+			WorkOSUserID: "user_01NOEMAIL",
+			Email:        "",
+		},
+	}
+
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", repo, authTestLogger)
+	if err != nil {
+		t.Fatalf("create authenticator: %v", err)
+	}
+
+	// JWT without email claim — simulates WorkOS AuthKit without JWT Templates.
+	token := signTestJWT(t, privKey, map[string]interface{}{
+		"sub": "user_01NOEMAIL",
+		"iss": "https://api.workos.com",
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(5 * time.Minute).Unix(),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/session", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	caller, err := auth.Authenticate(req)
+	if err != nil {
+		t.Fatalf("expected auto-create to succeed without email, got: %v", err)
+	}
+	if caller.UserID != createdUserID {
+		t.Errorf("UserID = %v, want %v", caller.UserID, createdUserID)
+	}
+	if caller.Email != "" {
+		t.Errorf("Email = %q, want empty string", caller.Email)
+	}
+}
+
 func TestWorkOSAuthenticator_FirstLoginCreateUserFails(t *testing.T) {
 	privKey, jwksServer := testJWKS(t)
 

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -2046,6 +2046,27 @@ func (r *Repository) UnarchiveAndRelinkUser(ctx context.Context, email, workosUs
 	return user, nil
 }
 
+// UnarchiveUserByWorkOSID finds an archived (soft-deleted) user by
+// workos_user_id, clears archived_at, and returns the restored user.
+// Use this when a verified JWT arrives for a user whose account was
+// soft-deleted. Returns ErrUserNotFound if no archived user matches.
+func (r *Repository) UnarchiveUserByWorkOSID(ctx context.Context, workosUserID string) (User, error) {
+	var user User
+	err := r.db.QueryRow(ctx, `
+		UPDATE users
+		SET archived_at = NULL, updated_at = now()
+		WHERE workos_user_id = $1 AND archived_at IS NOT NULL
+		RETURNING id, workos_user_id, email, COALESCE(display_name, '')
+	`, workosUserID).Scan(&user.ID, &user.WorkOSUserID, &user.Email, &user.DisplayName)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return User{}, ErrUserNotFound
+		}
+		return User{}, fmt.Errorf("unarchive user by workos id: %w", err)
+	}
+	return user, nil
+}
+
 func (r *Repository) GetOrganizationsForUser(ctx context.Context, userID uuid.UUID) ([]UserMeOrgRow, error) {
 	rows, err := r.db.Query(ctx, `
 		SELECT o.id, o.name, o.slug, om.role

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -2026,45 +2026,36 @@ func (r *Repository) RelinkWorkOSUser(ctx context.Context, userID uuid.UUID, wor
 	return user, nil
 }
 
-// UnarchiveAndRelinkUser finds an archived (soft-deleted) user by email,
-// clears archived_at, updates the workos_user_id, and returns the restored
-// user. Returns ErrUserNotFound if no archived user with that email exists.
-func (r *Repository) UnarchiveAndRelinkUser(ctx context.Context, email, workosUserID string) (User, error) {
-	var user User
+// IsUserArchivedByWorkOSID checks if an archived (soft-deleted) user exists
+// with the given workos_user_id. Returns true if such a row exists.
+func (r *Repository) IsUserArchivedByWorkOSID(ctx context.Context, workosUserID string) (bool, error) {
+	var exists bool
 	err := r.db.QueryRow(ctx, `
-		UPDATE users
-		SET workos_user_id = $2, archived_at = NULL, updated_at = now()
-		WHERE email = $1 AND archived_at IS NOT NULL
-		RETURNING id, workos_user_id, email, COALESCE(display_name, '')
-	`, email, workosUserID).Scan(&user.ID, &user.WorkOSUserID, &user.Email, &user.DisplayName)
+		SELECT EXISTS(
+			SELECT 1 FROM users
+			WHERE workos_user_id = $1 AND archived_at IS NOT NULL
+		)
+	`, workosUserID).Scan(&exists)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return User{}, ErrUserNotFound
-		}
-		return User{}, fmt.Errorf("unarchive and relink user: %w", err)
+		return false, fmt.Errorf("check archived user by workos id: %w", err)
 	}
-	return user, nil
+	return exists, nil
 }
 
-// UnarchiveUserByWorkOSID finds an archived (soft-deleted) user by
-// workos_user_id, clears archived_at, and returns the restored user.
-// Use this when a verified JWT arrives for a user whose account was
-// soft-deleted. Returns ErrUserNotFound if no archived user matches.
-func (r *Repository) UnarchiveUserByWorkOSID(ctx context.Context, workosUserID string) (User, error) {
-	var user User
+// IsUserArchivedByEmail checks if an archived (soft-deleted) user exists
+// with the given email. Returns true if such a row exists.
+func (r *Repository) IsUserArchivedByEmail(ctx context.Context, email string) (bool, error) {
+	var exists bool
 	err := r.db.QueryRow(ctx, `
-		UPDATE users
-		SET archived_at = NULL, updated_at = now()
-		WHERE workos_user_id = $1 AND archived_at IS NOT NULL
-		RETURNING id, workos_user_id, email, COALESCE(display_name, '')
-	`, workosUserID).Scan(&user.ID, &user.WorkOSUserID, &user.Email, &user.DisplayName)
+		SELECT EXISTS(
+			SELECT 1 FROM users
+			WHERE email = $1 AND archived_at IS NOT NULL
+		)
+	`, email).Scan(&exists)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return User{}, ErrUserNotFound
-		}
-		return User{}, fmt.Errorf("unarchive user by workos id: %w", err)
+		return false, fmt.Errorf("check archived user by email: %w", err)
 	}
-	return user, nil
+	return exists, nil
 }
 
 func (r *Repository) GetOrganizationsForUser(ctx context.Context, userID uuid.UUID) ([]UserMeOrgRow, error) {

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -1972,12 +1972,13 @@ func (r *Repository) GetActiveOrganizationMembershipsByUserID(ctx context.Contex
 }
 
 func (r *Repository) CreateUser(ctx context.Context, input CreateUserInput) (User, error) {
+	email := strings.TrimSpace(input.Email)
 	var user User
 	err := r.db.QueryRow(ctx, `
 		INSERT INTO users (id, workos_user_id, email, display_name)
 		VALUES (gen_random_uuid(), $1, $2, $3)
 		RETURNING id, workos_user_id, email, COALESCE(display_name, '')
-	`, input.WorkOSUserID, input.Email, input.DisplayName).Scan(
+	`, input.WorkOSUserID, email, input.DisplayName).Scan(
 		&user.ID, &user.WorkOSUserID, &user.Email, &user.DisplayName,
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary

**Root cause of ALL auth failures:** WorkOS AuthKit JWTs don't include an `email` claim by default. Every new user tried to `INSERT ... email=""`, but the unconditional `UNIQUE(email)` constraint meant only the first user could ever sign up — all others got "user already exists".

### Changes:
1. **Migration 00018**: Replaces `UNIQUE(email)` with `CREATE UNIQUE INDEX users_email_uq ON users (email) WHERE email != ''` — allows unlimited users with empty email, still enforces uniqueness for real emails
2. **CreateUser**: Adds `strings.TrimSpace` on email to prevent whitespace-only emails from bypassing the partial index
3. **resolveUser**: Adds `GetUserByWorkOSID` retry fallback in constraint-conflict recovery for race conditions when email is empty
4. **New test**: `TestWorkOSAuthenticator_FirstLoginNoEmail` verifies sign-up works without email in JWT

Also includes prior commits on this branch:
- `IsUserArchivedByWorkOSID` / `IsUserArchivedByEmail` checks → archived users get `403 account_deactivated` instead of auto-unarchiving (security fix)
- `RelinkWorkOSUser` for re-provisioned WorkOS identities

### What's NOT changed:
- `email` column stays `citext NOT NULL` (empty string, not NULL)
- All JSON responses use `json:"email,omitempty"` so empty emails are omitted
- Invite flows still require real emails
- All existing email-based lookups are already guarded by `email != ""`

## Test plan
- [x] Full backend test suite passes (including new empty-email test)
- [x] `go vet ./...` clean
- [ ] Deploy — migration runs automatically via pre-deploy `/migrate.sh`
- [ ] New user sign-up via WorkOS + Google should succeed
- [ ] Existing users with real emails should still work normally
- [ ] Long-term: configure WorkOS JWT Templates to include email claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)