### PR TITLE
feat(infra): delete endpoints + UI for provider accounts and model aliases

### DIFF
--- a/backend/internal/api/infrastructure.go
+++ b/backend/internal/api/infrastructure.go
@@ -30,6 +30,7 @@ type InfrastructureService interface {
 	CreateProviderAccount(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateProviderAccountInput) (repository.ProviderAccountRow, error)
 	ListProviderAccounts(ctx context.Context, workspaceID uuid.UUID) ([]repository.ProviderAccountRow, error)
 	GetProviderAccount(ctx context.Context, id uuid.UUID) (repository.ProviderAccountRow, error)
+	DeleteProviderAccount(ctx context.Context, id uuid.UUID) error
 
 	// Model Catalog (global, read-only)
 	ListModelCatalog(ctx context.Context) ([]repository.ModelCatalogEntryRow, error)
@@ -39,6 +40,7 @@ type InfrastructureService interface {
 	CreateModelAlias(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateModelAliasInput) (repository.ModelAliasRow, error)
 	ListModelAliases(ctx context.Context, workspaceID uuid.UUID) ([]repository.ModelAliasRow, error)
 	GetModelAlias(ctx context.Context, id uuid.UUID) (repository.ModelAliasRow, error)
+	DeleteModelAlias(ctx context.Context, id uuid.UUID) error
 
 	// Tools
 	CreateTool(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateToolInput) (repository.ToolRow, error)
@@ -395,6 +397,60 @@ func infraGetHandler[Row WorkspaceOwned, Resp any](
 		}
 
 		writeJSON(w, http.StatusOK, toResponse(row))
+	}
+}
+
+func infraDeleteHandler[Row WorkspaceOwned](
+	logger *slog.Logger,
+	authorizer WorkspaceAuthorizer,
+	paramName string,
+	get func(ctx context.Context, id uuid.UUID) (Row, error),
+	del func(ctx context.Context, id uuid.UUID) error,
+	resourceName string,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "authentication required")
+			return
+		}
+
+		raw := chi.URLParam(r, paramName)
+		id, err := uuid.Parse(raw)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "invalid ID")
+			return
+		}
+
+		// Fetch first to get workspace ID for authorization.
+		row, err := get(r.Context(), id)
+		if err != nil {
+			if isInfraNotFoundErr(err) {
+				writeError(w, http.StatusNotFound, "not_found", resourceName+" not found")
+				return
+			}
+			logger.Error("get for delete failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "failed to get resource")
+			return
+		}
+
+		if wsID := row.GetWorkspaceID(); wsID != nil {
+			if err := AuthorizeWorkspaceAction(r.Context(), authorizer, caller, *wsID, ActionManageInfrastructure); err != nil {
+				writeAuthzError(w, err)
+				return
+			}
+		}
+
+		if err := del(r.Context(), id); err != nil {
+			if isInfraNotFoundErr(err) {
+				writeError(w, http.StatusNotFound, "not_found", resourceName+" not found")
+				return
+			}
+			logger.Error("delete failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "failed to delete resource")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
 	}
 }
 

--- a/backend/internal/api/infrastructure_manager.go
+++ b/backend/internal/api/infrastructure_manager.go
@@ -20,6 +20,7 @@ type InfrastructureRepository interface {
 	CreateProviderAccount(ctx context.Context, p repository.CreateProviderAccountParams) (repository.ProviderAccountRow, error)
 	GetProviderAccountByID(ctx context.Context, id uuid.UUID) (repository.ProviderAccountRow, error)
 	ListProviderAccountsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]repository.ProviderAccountRow, error)
+	ArchiveProviderAccount(ctx context.Context, id uuid.UUID) error
 
 	// Workspace Secrets
 	UpsertWorkspaceSecret(ctx context.Context, params repository.UpsertWorkspaceSecretParams) error
@@ -32,6 +33,7 @@ type InfrastructureRepository interface {
 	CreateModelAlias(ctx context.Context, p repository.CreateModelAliasParams) (repository.ModelAliasRow, error)
 	GetModelAliasByID(ctx context.Context, id uuid.UUID) (repository.ModelAliasRow, error)
 	ListModelAliasesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]repository.ModelAliasRow, error)
+	ArchiveModelAlias(ctx context.Context, id uuid.UUID) error
 
 	// Tools
 	CreateTool(ctx context.Context, p repository.CreateToolParams) (repository.ToolRow, error)
@@ -149,6 +151,10 @@ func (m *InfrastructureManager) GetProviderAccount(ctx context.Context, id uuid.
 	return m.repo.GetProviderAccountByID(ctx, id)
 }
 
+func (m *InfrastructureManager) DeleteProviderAccount(ctx context.Context, id uuid.UUID) error {
+	return m.repo.ArchiveProviderAccount(ctx, id)
+}
+
 // --------------------------------------------------------------------------
 // Model Catalog
 // --------------------------------------------------------------------------
@@ -198,6 +204,10 @@ func (m *InfrastructureManager) ListModelAliases(ctx context.Context, workspaceI
 
 func (m *InfrastructureManager) GetModelAlias(ctx context.Context, id uuid.UUID) (repository.ModelAliasRow, error) {
 	return m.repo.GetModelAliasByID(ctx, id)
+}
+
+func (m *InfrastructureManager) DeleteModelAlias(ctx context.Context, id uuid.UUID) error {
+	return m.repo.ArchiveModelAlias(ctx, id)
 }
 
 // --------------------------------------------------------------------------

--- a/backend/internal/api/infrastructure_test.go
+++ b/backend/internal/api/infrastructure_test.go
@@ -43,6 +43,7 @@ func (s stubInfraService) ListProviderAccounts(_ context.Context, _ uuid.UUID) (
 func (s stubInfraService) GetProviderAccount(_ context.Context, _ uuid.UUID) (repository.ProviderAccountRow, error) {
 	return repository.ProviderAccountRow{}, repository.ErrProviderAccountNotFound
 }
+func (s stubInfraService) DeleteProviderAccount(_ context.Context, _ uuid.UUID) error { return nil }
 func (s stubInfraService) ListModelCatalog(_ context.Context) ([]repository.ModelCatalogEntryRow, error) {
 	return nil, nil
 }
@@ -58,6 +59,7 @@ func (s stubInfraService) ListModelAliases(_ context.Context, _ uuid.UUID) ([]re
 func (s stubInfraService) GetModelAlias(_ context.Context, _ uuid.UUID) (repository.ModelAliasRow, error) {
 	return repository.ModelAliasRow{}, repository.ErrModelAliasNotFound
 }
+func (s stubInfraService) DeleteModelAlias(_ context.Context, _ uuid.UUID) error { return nil }
 func (s stubInfraService) CreateTool(_ context.Context, _ Caller, _ uuid.UUID, _ CreateToolInput) (repository.ToolRow, error) {
 	return repository.ToolRow{}, nil
 }

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -146,6 +146,7 @@ func registerProtectedRoutes(
 	router.Method("POST", "/workspaces/{workspaceID}/provider-accounts", wsMiddleware(infraCreateHandler(logger, authorizer, infraService.CreateProviderAccount, mapProviderAccount)))
 	router.Method("GET", "/workspaces/{workspaceID}/provider-accounts", wsMiddleware(infraListHandler(logger, infraService.ListProviderAccounts, mapProviderAccount)))
 	router.Get("/provider-accounts/{accountID}", infraGetHandler(logger, authorizer, "accountID", infraService.GetProviderAccount, mapProviderAccount, "provider account"))
+	router.Delete("/provider-accounts/{accountID}", infraDeleteHandler(logger, authorizer, "accountID", infraService.GetProviderAccount, infraService.DeleteProviderAccount, "provider account"))
 
 	// Model Catalog (global, no workspace scope)
 	router.Get("/model-catalog", listModelCatalogHandler(logger, infraService))
@@ -155,6 +156,7 @@ func registerProtectedRoutes(
 	router.Method("POST", "/workspaces/{workspaceID}/model-aliases", wsMiddleware(infraCreateHandler(logger, authorizer, infraService.CreateModelAlias, mapModelAlias)))
 	router.Method("GET", "/workspaces/{workspaceID}/model-aliases", wsMiddleware(infraListHandler(logger, infraService.ListModelAliases, mapModelAlias)))
 	router.Get("/model-aliases/{aliasID}", infraGetHandler(logger, authorizer, "aliasID", infraService.GetModelAlias, mapModelAlias, "model alias"))
+	router.Delete("/model-aliases/{aliasID}", infraDeleteHandler(logger, authorizer, "aliasID", infraService.GetModelAlias, infraService.DeleteModelAlias, "model alias"))
 
 	// Tools
 	router.Method("POST", "/workspaces/{workspaceID}/tools", wsMiddleware(infraCreateHandler(logger, authorizer, infraService.CreateTool, mapTool)))

--- a/backend/internal/repository/infrastructure.go
+++ b/backend/internal/repository/infrastructure.go
@@ -257,6 +257,17 @@ func (r *Repository) ListProviderAccountsByWorkspaceID(ctx context.Context, work
 	return result, nil
 }
 
+func (r *Repository) ArchiveProviderAccount(ctx context.Context, id uuid.UUID) error {
+	tag, err := r.db.Exec(ctx, `UPDATE provider_accounts SET status = 'archived', archived_at = now(), updated_at = now() WHERE id = $1 AND archived_at IS NULL`, id)
+	if err != nil {
+		return fmt.Errorf("archive provider account: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrProviderAccountNotFound
+	}
+	return nil
+}
+
 // --------------------------------------------------------------------------
 // Model Catalog Entries (global, read-only)
 // --------------------------------------------------------------------------
@@ -457,6 +468,17 @@ func (r *Repository) ListModelAliasesByWorkspaceID(ctx context.Context, workspac
 		result = []ModelAliasRow{}
 	}
 	return result, nil
+}
+
+func (r *Repository) ArchiveModelAlias(ctx context.Context, id uuid.UUID) error {
+	tag, err := r.db.Exec(ctx, `UPDATE model_aliases SET status = 'archived', archived_at = now(), updated_at = now() WHERE id = $1 AND archived_at IS NULL`, id)
+	if err != nil {
+		return fmt.Errorf("archive model alias: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrModelAliasNotFound
+	}
+	return nil
 }
 
 // --------------------------------------------------------------------------

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -1040,6 +1040,26 @@ paths:
           $ref: "#/components/responses/ForbiddenError"
         "404":
           $ref: "#/components/responses/NotFoundError"
+    delete:
+      operationId: deleteProviderAccount
+      tags: [ProviderAccounts]
+      summary: Delete (archive) a provider account
+      description: Soft-deletes the provider account by setting its status to archived.
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/AccountID"
+      responses:
+        "204":
+          description: Provider account deleted
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
 
   # ---------------------------------------------------------------------------
   # Model Catalog
@@ -1156,6 +1176,26 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ModelAliasResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+    delete:
+      operationId: deleteModelAlias
+      tags: [ModelAliases]
+      summary: Delete (archive) a model alias
+      description: Soft-deletes the model alias by setting its status to archived.
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/AliasID"
+      responses:
+        "204":
+          description: Model alias deleted
         "400":
           $ref: "#/components/responses/ValidationError"
         "401":

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/model-aliases/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/model-aliases/page.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { CreateResourceDialog } from "@/components/infra/create-resource-dialog";
+import { DeleteResourceButton } from "@/components/infra/delete-resource-button";
 import { Tag } from "lucide-react";
 
 export default async function ModelAliasesPage({
@@ -51,6 +52,7 @@ export default async function ModelAliasesPage({
                 <TableHead>Alias Key</TableHead>
                 <TableHead>Status</TableHead>
                 <TableHead>Created</TableHead>
+                <TableHead className="w-10" />
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -60,6 +62,12 @@ export default async function ModelAliasesPage({
                   <TableCell><code className="text-xs font-[family-name:var(--font-mono)] text-muted-foreground">{a.alias_key}</code></TableCell>
                   <TableCell><Badge variant={a.status === "active" ? "default" : "secondary"}>{a.status}</Badge></TableCell>
                   <TableCell className="text-muted-foreground">{new Date(a.created_at).toLocaleDateString()}</TableCell>
+                  <TableCell>
+                    <DeleteResourceButton
+                      endpoint={`/v1/model-aliases/${a.id}`}
+                      resourceName="model alias"
+                    />
+                  </TableCell>
                 </TableRow>
               ))}
             </TableBody>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/provider-accounts/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/provider-accounts/page.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { CreateResourceDialog } from "@/components/infra/create-resource-dialog";
+import { DeleteResourceButton } from "@/components/infra/delete-resource-button";
 import { Key } from "lucide-react";
 
 const statusVariant: Record<string, "default" | "secondary" | "outline"> = {
@@ -70,6 +71,7 @@ export default async function ProviderAccountsPage({
                 <TableHead>Provider</TableHead>
                 <TableHead>Status</TableHead>
                 <TableHead>Created</TableHead>
+                <TableHead className="w-10" />
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -79,6 +81,12 @@ export default async function ProviderAccountsPage({
                   <TableCell><code className="text-xs font-[family-name:var(--font-mono)] text-muted-foreground">{a.provider_key}</code></TableCell>
                   <TableCell><Badge variant={statusVariant[a.status] ?? "outline"}>{a.status}</Badge></TableCell>
                   <TableCell className="text-muted-foreground">{new Date(a.created_at).toLocaleDateString()}</TableCell>
+                  <TableCell>
+                    <DeleteResourceButton
+                      endpoint={`/v1/provider-accounts/${a.id}`}
+                      resourceName="provider account"
+                    />
+                  </TableCell>
                 </TableRow>
               ))}
             </TableBody>

--- a/web/src/components/infra/delete-resource-button.tsx
+++ b/web/src/components/infra/delete-resource-button.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { toast } from "sonner";
+import { Loader2, Trash2 } from "lucide-react";
+
+interface DeleteResourceButtonProps {
+  endpoint: string;
+  resourceName: string;
+}
+
+export function DeleteResourceButton({
+  endpoint,
+  resourceName,
+}: DeleteResourceButtonProps) {
+  const router = useRouter();
+  const { getAccessToken } = useAccessToken();
+  const [open, setOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  async function handleDelete() {
+    setDeleting(true);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      await api.del(endpoint);
+      toast.success(`${resourceName} deleted`);
+      setOpen(false);
+      router.refresh();
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError ? err.message : `Failed to delete ${resourceName}`,
+      );
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="icon-xs"
+        onClick={() => setOpen(true)}
+        aria-label={`Delete ${resourceName}`}
+      >
+        <Trash2 className="size-3.5 text-muted-foreground hover:text-destructive" />
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete {resourceName}</DialogTitle>
+            <DialogDescription>
+              This will archive the {resourceName.toLowerCase()}. It will no longer appear in lists or be usable in new runs.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)} disabled={deleting}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleDelete} disabled={deleting}>
+              {deleting ? <Loader2 className="size-4 animate-spin" /> : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `DELETE /v1/provider-accounts/{accountID}` and `DELETE /v1/model-aliases/{aliasID}` backend endpoints (soft-delete via archive)
- Add generic `infraDeleteHandler` in the API layer (auth-checks workspace ownership before archiving)
- Add reusable `DeleteResourceButton` client component with confirmation dialog
- Add delete buttons to provider accounts and model aliases table rows in the UI

## Test plan
- [x] `go build ./...` and `go vet ./...` pass
- [x] `go test -short -race -count=1 ./...` all pass
- [x] `npx tsc --noEmit` passes
- [x] `pnpm lint` passes (no new warnings)
- [x] `npx @redocly/cli lint docs/api-server/openapi.yaml` validates clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)