### PR TITLE
security(auth): redact internal errors from HTTP responses, harden LinkWorkOSUser

### DIFF
--- a/backend/internal/api/auth.go
+++ b/backend/internal/api/auth.go
@@ -118,7 +118,7 @@ func authenticateRequest(logger *slog.Logger, authenticator Authenticator) func(
 					"path", r.URL.Path,
 					"error", err,
 				)
-				writeError(w, http.StatusUnauthorized, "unauthorized", err.Error())
+				writeError(w, http.StatusUnauthorized, "unauthorized", "invalid or expired credentials")
 				return
 			}
 

--- a/backend/internal/api/auth_workos.go
+++ b/backend/internal/api/auth_workos.go
@@ -201,7 +201,7 @@ func (a *WorkOSAuthenticator) resolveUser(ctx context.Context, workosUserID, ema
 	}
 	if archived {
 		log.WarnContext(ctx, "resolve_user: user is archived (deactivated)")
-		return repository.User{}, fmt.Errorf("%w: sign in with workos_user_id %s", ErrAccountDeactivated, workosUserID)
+		return repository.User{}, ErrAccountDeactivated
 	}
 
 	log.InfoContext(ctx, "resolve_user: no active or archived user with this workos_id")
@@ -249,7 +249,7 @@ func (a *WorkOSAuthenticator) resolveUser(ctx context.Context, workosUserID, ema
 		}
 		if archivedByEmail {
 			log.WarnContext(ctx, "resolve_user: user with this email is archived (deactivated)")
-			return repository.User{}, fmt.Errorf("%w: sign in with email %s", ErrAccountDeactivated, email)
+			return repository.User{}, ErrAccountDeactivated
 		}
 	}
 

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -1995,7 +1995,7 @@ func (r *Repository) LinkWorkOSUser(ctx context.Context, userID uuid.UUID, worko
 	var user User
 	err := r.db.QueryRow(ctx, `
 		UPDATE users SET workos_user_id = $2
-		WHERE id = $1 AND workos_user_id LIKE 'pending:%'
+		WHERE id = $1 AND workos_user_id LIKE 'pending:%' AND archived_at IS NULL
 		RETURNING id, workos_user_id, email, COALESCE(display_name, '')
 	`, userID, workosUserID).Scan(&user.ID, &user.WorkOSUserID, &user.Email, &user.DisplayName)
 	if err != nil {


### PR DESCRIPTION
## Summary

Security hardening from post-merge audit of the auth flow:

1. **Stop leaking internal error details to clients** — `authenticateRequest` was sending `err.Error()` as the HTTP response body for 401s, which could include constraint names, email addresses, and PostgreSQL detail strings (e.g. `"constraint=users_email_key detail=Key (email)=(alice@example.com) already exists."`). Now returns a generic `"invalid or expired credentials"` message. Full error is still logged server-side.

2. **Redact identifiers from ErrAccountDeactivated** — the wrapped error included `workos_user_id` and `email` in the error chain. While the middleware returns a hardcoded message, the identifiers could leak through error introspection. Now returns bare `ErrAccountDeactivated`.

3. **Harden LinkWorkOSUser** — added `AND archived_at IS NULL` to the WHERE clause, preventing linking a WorkOS ID to an archived stub user (defense-in-depth).

## Why this won't break anything

- The 401 message change is client-facing only — server logs still capture the full error
- `errors.Is(err, ErrAccountDeactivated)` works identically with or without wrapping
- `LinkWorkOSUser` already requires `workos_user_id LIKE 'pending:%'` and the caller pre-filters archived users via `GetUserByEmail`

## Test plan
- [x] Full test suite passes (`go test -short -race -count=1 ./...`)
- [x] `go vet ./...` clean
- [x] Cherry-picked cleanly from post-merge commit with zero conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)