### PR TITLE
fix(web): sign-in button UX, data waterfall, and accessibility fixes

### DIFF
--- a/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/experiment-list.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/experiment-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -184,36 +184,41 @@ function ExperimentSummaryStrip({
 }: {
   results: PlaygroundExperimentResult[];
 }) {
-  if (results.length === 0) return null;
+  const stats = useMemo(() => {
+    if (results.length === 0) return null;
 
-  const avgLatency =
-    results.reduce((s, r) => s + r.latency_ms, 0) / results.length;
-  const totalTokens = results.reduce((s, r) => s + r.total_tokens, 0);
-  const totalCost = results.reduce((s, r) => s + (r.cost_usd ?? 0), 0);
+    const avgLatency =
+      results.reduce((s, r) => s + r.latency_ms, 0) / results.length;
+    const totalTokens = results.reduce((s, r) => s + r.total_tokens, 0);
+    const totalCost = results.reduce((s, r) => s + (r.cost_usd ?? 0), 0);
 
-  // Aggregate dimension scores across results
-  const dimAccum: Record<string, { total: number; count: number }> = {};
-  for (const r of results) {
-    if (!r.dimension_scores) continue;
-    for (const [dim, score] of Object.entries(r.dimension_scores)) {
-      if (score == null) continue;
-      const acc = dimAccum[dim] ?? { total: 0, count: 0 };
-      acc.total += score;
-      acc.count++;
-      dimAccum[dim] = acc;
+    const dimAccum: Record<string, { total: number; count: number }> = {};
+    for (const r of results) {
+      if (!r.dimension_scores) continue;
+      for (const [dim, score] of Object.entries(r.dimension_scores)) {
+        if (score == null) continue;
+        const acc = dimAccum[dim] ?? { total: 0, count: 0 };
+        acc.total += score;
+        acc.count++;
+        dimAccum[dim] = acc;
+      }
     }
-  }
-  const avgDimensions: Record<string, number | null> = {};
-  for (const [dim, acc] of Object.entries(dimAccum)) {
-    avgDimensions[dim] = acc.count > 0 ? acc.total / acc.count : null;
-  }
+    const avgDimensions: Record<string, number | null> = {};
+    for (const [dim, acc] of Object.entries(dimAccum)) {
+      avgDimensions[dim] = acc.count > 0 ? acc.total / acc.count : null;
+    }
+
+    return { avgLatency, totalTokens, totalCost, avgDimensions };
+  }, [results]);
+
+  if (!stats) return null;
 
   return (
     <KpiStrip
-      latencyMs={Math.round(avgLatency)}
-      totalTokens={totalTokens}
-      costUsd={totalCost}
-      dimensions={avgDimensions}
+      latencyMs={Math.round(stats.avgLatency)}
+      totalTokens={stats.totalTokens}
+      costUsd={stats.totalCost}
+      dimensions={stats.avgDimensions}
     />
   );
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/page.tsx
@@ -56,29 +56,24 @@ export default async function PlaygroundDetailPage({
     );
   }
 
-  let selectedResults: PlaygroundExperimentResult[] | null = null;
-  if (experiment) {
-    try {
-      const res = await api.get<{ items: PlaygroundExperimentResult[] }>(
-        `/v1/playground-experiments/${experiment}/results`,
-      );
-      selectedResults = res.items;
-    } catch {
-      selectedResults = null;
-    }
-  }
-
-  let comparison: PlaygroundExperimentComparison | null = null;
-  if (baseline && candidate) {
-    try {
-      comparison = await api.get<PlaygroundExperimentComparison>(
-        "/v1/playground-experiments/compare",
-        { params: { baseline, candidate } },
-      );
-    } catch {
-      comparison = null;
-    }
-  }
+  const [selectedResults, comparison] = await Promise.all([
+    experiment
+      ? api
+          .get<{ items: PlaygroundExperimentResult[] }>(
+            `/v1/playground-experiments/${experiment}/results`,
+          )
+          .then((res) => res.items)
+          .catch(() => null)
+      : Promise.resolve(null),
+    baseline && candidate
+      ? api
+          .get<PlaygroundExperimentComparison>(
+            "/v1/playground-experiments/compare",
+            { params: { baseline, candidate } },
+          )
+          .catch(() => null)
+      : Promise.resolve(null),
+  ]);
 
   return (
     <div>

--- a/web/src/app/blog/page.tsx
+++ b/web/src/app/blog/page.tsx
@@ -26,7 +26,7 @@ export default function BlogPage() {
             href={`/blog/${post.slug}`}
             className="group flex flex-col gap-1 rounded-lg border border-white/[0.08] bg-white/[0.03] px-5 py-4 hover:border-white/15 transition-colors"
           >
-            <span className="font-[family-name:var(--font-mono)] text-[11px] text-white/20">
+            <span className="font-[family-name:var(--font-mono)] text-[11px] text-white/40">
               {post.date} &middot; {post.author}
             </span>
             <span className="text-sm font-medium text-white group-hover:text-white/90">

--- a/web/src/app/error.tsx
+++ b/web/src/app/error.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Unhandled error:", error);
+  }, [error]);
+
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center px-6 py-16 text-center">
+      <p className="font-[family-name:var(--font-mono)] text-xs text-white/30 tracking-widest uppercase">
+        Something went wrong
+      </p>
+      <h1 className="mt-3 font-[family-name:var(--font-display)] text-3xl sm:text-4xl tracking-[-0.02em]">
+        Unexpected error
+      </h1>
+      <p className="mt-4 text-sm text-white/40 max-w-xs leading-relaxed">
+        An error occurred while loading this page. Please try again.
+      </p>
+      <button
+        onClick={reset}
+        className="mt-8 text-xs text-white/40 hover:text-white/60 transition-colors underline underline-offset-4"
+      >
+        Try again
+      </button>
+    </main>
+  );
+}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -141,7 +141,7 @@ input {
 .prose-agentclash {
   font-size: 15px;
   line-height: 1.75;
-  color: rgba(255, 255, 255, 0.45);
+  color: rgba(255, 255, 255, 0.65);
 }
 
 .prose-agentclash h2 {

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -138,7 +138,11 @@ export default function HomePage() {
       <nav className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between p-4">
         <div />
         <div className="flex items-center gap-2">
-          {!authLoading && user ? (
+          {authLoading ? (
+            <span className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.06] px-3 py-1.5">
+              <span className="h-3.5 w-14 rounded bg-white/[0.08] animate-pulse" />
+            </span>
+          ) : user ? (
             <Link
               href="/dashboard"
               className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/90 px-3 py-1.5 text-xs font-medium text-[#060606] hover:bg-white transition-colors"
@@ -146,15 +150,15 @@ export default function HomePage() {
               Go to Dashboard
               <ArrowRight className="size-3" />
             </Link>
-          ) : !authLoading && !user ? (
+          ) : (
             <Link
               href="/auth/login"
-              className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.03] px-3 py-1.5 text-xs font-medium text-white/50 hover:text-white/80 hover:border-white/15 transition-colors"
+              className="inline-flex items-center gap-1.5 rounded-md border border-white/15 bg-white/[0.06] px-3 py-1.5 text-xs font-medium text-white/70 hover:text-white/90 hover:bg-white/10 hover:border-white/25 transition-colors"
             >
               <LogIn className="size-3.5" />
               Sign in
             </Link>
-          ) : null}
+          )}
           <a
             href="https://github.com/Atharva-Kanherkar/agentclash"
             target="_blank"

--- a/web/src/components/ui/loading-spinner.tsx
+++ b/web/src/components/ui/loading-spinner.tsx
@@ -14,7 +14,7 @@ interface LoadingSpinnerProps {
 
 export function LoadingSpinner({ size = "md", className }: LoadingSpinnerProps) {
   return (
-    <div className={cn("flex items-center justify-center", className)}>
+    <div role="status" aria-label="Loading" className={cn("flex items-center justify-center", className)}>
       <Loader2 className={cn("animate-spin text-muted-foreground", sizeMap[size])} />
     </div>
   );


### PR DESCRIPTION
## Summary

Deep frontend audit that addresses UX, performance, and accessibility issues across the web app.

### Sign-in button (home page)
- **Delayed rendering fixed**: replaced `null` render during auth loading with a skeleton placeholder — no more pop-in flash
- **Washed-out colors fixed**: increased contrast from `text-white/50 bg-white/[0.03]` to `text-white/70 bg-white/[0.06]` with better border and hover states

### Performance
- **Playground page waterfall eliminated**: `selectedResults` and `comparison` fetches were sequential `await`s — now run in parallel via `Promise.all`
- **ExperimentSummaryStrip**: wrapped `.reduce()` aggregation computations in `useMemo` to skip recomputation during polling re-renders

### Accessibility & contrast
- **Root `error.tsx` added**: the app had zero error boundaries — unhandled server component errors showed a generic Next.js page
- **Blog prose contrast**: increased body text opacity from 0.45 → 0.65 to pass WCAG AA (4.5:1 ratio)
- **Blog metadata contrast**: increased date/author text from `text-white/20` → `text-white/40`
- **LoadingSpinner**: added `role="status"` and `aria-label="Loading"` for screen readers

## Test plan

- [ ] Visit home page — sign-in button should show a subtle skeleton while auth loads, then appear with readable contrast
- [ ] Visit home page while logged in — "Go to Dashboard" button should render normally
- [ ] Navigate to a playground with experiment results — verify results load (parallel fetch should be transparent)
- [ ] Visit `/blog` — date/author metadata should be legible
- [ ] Trigger an error in a server component — verify the new error.tsx renders with "Try again" button
- [ ] Screen reader: LoadingSpinner should announce "Loading"

🤖 Generated with [Claude Code](https://claude.com/claude-code)