### PR TITLE
fix(web): make Go to Dashboard button fully opaque

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -145,7 +145,7 @@ export default function HomePage() {
           ) : user ? (
             <Link
               href="/dashboard"
-              className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/90 px-3 py-1.5 text-xs font-medium text-[#060606] hover:bg-white transition-colors"
+              className="inline-flex items-center gap-1.5 rounded-md border border-white/20 bg-white px-3 py-1.5 text-xs font-medium text-[#060606] hover:bg-white/90 transition-colors"
             >
               Go to Dashboard
               <ArrowRight className="size-3" />


### PR DESCRIPTION
## Summary

- The "Go to Dashboard" button on the home page used `bg-white/90` (90% opacity white) which looked washed out / translucent on the `#060606` dark background
- Changed to solid `bg-white` with `border-white/20` for a clean, fully opaque button
- Hover state now goes `bg-white/90` (slight dim) instead of `bg-white` (no change)

## Test plan

- [ ] Visit home page while logged in — "Go to Dashboard" button should be solid white, not see-through

🤖 Generated with [Claude Code](https://claude.com/claude-code)