### PR TITLE
fix(web): move CSS resets into @layer base so button text colors work

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -56,14 +56,16 @@ body {
   font-family: var(--font-body), system-ui, sans-serif;
 }
 
-a {
-  color: inherit;
-  text-decoration: none;
-}
+@layer base {
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
 
-button,
-input {
-  font: inherit;
+  button,
+  input {
+    font: inherit;
+  }
 }
 
 ::selection {


### PR DESCRIPTION
## Summary

The "Go to Dashboard" button had `text-[#060606]` (dark text on white bg) but rendered as white text — making it invisible on the white button.

**Root cause:** `a { color: inherit; }` in `globals.css` was **unlayered** (outside any `@layer`). In CSS, unlayered styles always beat layered styles. Since Tailwind v4 puts all utilities inside `@layer utilities`, the unlayered `color: inherit` won every time — the `<Link>` (an `<a>` tag) inherited `#fafafa` from the body instead of using the `text-[#060606]` utility.

**Fix:** Wrapped the `a`, `button`, and `input` resets in `@layer base` so Tailwind utility classes can properly override them.

## Test plan

- [ ] Visit home page while logged in — "Go to Dashboard" should show dark text on white button
- [ ] Verify all links across the app still inherit text color by default (blog, footer, nav)
- [ ] Verify Tailwind color utilities on `<a>` and `<button>` elements work everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)