### PR TITLE
feat(scoring): sandbox state verification with file and directory validators

### DIFF
--- a/backend/internal/engine/executor_verification.go
+++ b/backend/internal/engine/executor_verification.go
@@ -1,0 +1,143 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/sandbox"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/scoring"
+)
+
+// extractPostExecutionChecks loads post-execution check declarations from the
+// challenge pack manifest's evaluation spec. Returns nil when the manifest
+// cannot be parsed or contains no checks.
+func extractPostExecutionChecks(executionContext repository.RunAgentExecutionContext) []scoring.PostExecutionCheck {
+	if len(executionContext.ChallengePackVersion.Manifest) == 0 {
+		return nil
+	}
+	spec, err := scoring.LoadEvaluationSpec(executionContext.ChallengePackVersion.Manifest)
+	if err != nil {
+		return nil
+	}
+	return spec.PostExecutionChecks
+}
+
+// executePostExecutionChecks reads the specified files and directories from the
+// sandbox session and returns results suitable for observer emission. Each check
+// produces one PostExecutionVerificationResult with a JSON payload.
+func executePostExecutionChecks(
+	ctx context.Context,
+	session sandbox.Session,
+	checks []scoring.PostExecutionCheck,
+) []PostExecutionVerificationResult {
+	results := make([]PostExecutionVerificationResult, 0, len(checks))
+	var totalCaptured int64
+
+	for _, check := range checks {
+		switch check.Type {
+		case scoring.PostExecutionCheckTypeFileCapture:
+			capture := executeFileCaptureCheck(ctx, session, check, totalCaptured)
+			totalCaptured += capture.Size
+			payload, err := json.Marshal(capture)
+			if err != nil {
+				slog.Default().Warn("marshal file capture result", "key", check.Key, "error", err)
+				continue
+			}
+			results = append(results, PostExecutionVerificationResult{
+				Key:     check.Key,
+				Type:    scoring.PostExecutionCheckTypeFileCapture,
+				Payload: payload,
+			})
+
+		case scoring.PostExecutionCheckTypeDirectoryListing:
+			listing := executeDirectoryListingCheck(ctx, session, check)
+			payload, err := json.Marshal(listing)
+			if err != nil {
+				slog.Default().Warn("marshal directory listing result", "key", check.Key, "error", err)
+				continue
+			}
+			results = append(results, PostExecutionVerificationResult{
+				Key:     check.Key,
+				Type:    scoring.PostExecutionCheckTypeDirectoryListing,
+				Payload: payload,
+			})
+		}
+	}
+	return results
+}
+
+// executeFileCaptureCheck reads a single file from the sandbox, enforcing per-file
+// and total capture size limits. Files that exceed the limit are truncated.
+func executeFileCaptureCheck(
+	ctx context.Context,
+	session sandbox.Session,
+	check scoring.PostExecutionCheck,
+	totalCapturedSoFar int64,
+) scoring.FileCaptureResult {
+	result := scoring.FileCaptureResult{
+		Key:  check.Key,
+		Path: check.Path,
+	}
+
+	content, err := session.ReadFile(ctx, check.Path)
+	if err != nil {
+		// File does not exist or is unreadable.
+		result.Exists = false
+		return result
+	}
+	result.Exists = true
+	result.Size = int64(len(content))
+
+	maxSize := check.EffectiveMaxSizeBytes()
+
+	// Enforce total capture budget.
+	remaining := scoring.DefaultMaxTotalCaptureBytes - totalCapturedSoFar
+	if remaining <= 0 {
+		result.Content = ""
+		result.Truncated = true
+		return result
+	}
+	if maxSize > remaining {
+		maxSize = remaining
+	}
+
+	if int64(len(content)) > maxSize {
+		result.Content = string(content[:maxSize])
+		result.Truncated = true
+	} else {
+		result.Content = string(content)
+	}
+	return result
+}
+
+// executeDirectoryListingCheck lists files in a sandbox directory. When
+// check.Recursive is false the prefix is used as-is; the sandbox ListFiles
+// implementation controls depth behavior.
+func executeDirectoryListingCheck(
+	ctx context.Context,
+	session sandbox.Session,
+	check scoring.PostExecutionCheck,
+) scoring.DirectoryListingResult {
+	result := scoring.DirectoryListingResult{
+		Key:  check.Key,
+		Path: check.Path,
+	}
+
+	files, err := session.ListFiles(ctx, check.Path)
+	if err != nil {
+		result.Entries = []scoring.DirectoryEntry{}
+		return result
+	}
+
+	entries := make([]scoring.DirectoryEntry, 0, len(files))
+	for _, f := range files {
+		entries = append(entries, scoring.DirectoryEntry{
+			Path: f.Path,
+			Size: f.Size,
+		})
+	}
+	result.Entries = entries
+	return result
+}

--- a/backend/internal/engine/executor_verification_test.go
+++ b/backend/internal/engine/executor_verification_test.go
@@ -1,0 +1,226 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/sandbox"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/scoring"
+)
+
+type fakeSandboxSession struct {
+	files map[string][]byte
+	dirs  map[string][]sandbox.FileInfo
+}
+
+func (s *fakeSandboxSession) ID() string { return "fake-session" }
+func (s *fakeSandboxSession) UploadFile(ctx context.Context, path string, content []byte) error {
+	return nil
+}
+func (s *fakeSandboxSession) ReadFile(ctx context.Context, path string) ([]byte, error) {
+	if content, ok := s.files[path]; ok {
+		return content, nil
+	}
+	return nil, fmt.Errorf("file not found: %s", path)
+}
+func (s *fakeSandboxSession) WriteFile(ctx context.Context, path string, content []byte) error {
+	return nil
+}
+func (s *fakeSandboxSession) ListFiles(ctx context.Context, prefix string) ([]sandbox.FileInfo, error) {
+	if entries, ok := s.dirs[prefix]; ok {
+		return entries, nil
+	}
+	return nil, fmt.Errorf("directory not found: %s", prefix)
+}
+func (s *fakeSandboxSession) Exec(ctx context.Context, request sandbox.ExecRequest) (sandbox.ExecResult, error) {
+	return sandbox.ExecResult{}, nil
+}
+func (s *fakeSandboxSession) DownloadFile(ctx context.Context, path string) ([]byte, error) {
+	return s.ReadFile(ctx, path)
+}
+func (s *fakeSandboxSession) Destroy(ctx context.Context) error { return nil }
+
+func TestExecuteFileCaptureCheck_FileExists(t *testing.T) {
+	session := &fakeSandboxSession{
+		files: map[string][]byte{
+			"/workspace/app.py": []byte("def main(): pass"),
+		},
+	}
+
+	check := scoring.PostExecutionCheck{
+		Key:  "app_py",
+		Type: scoring.PostExecutionCheckTypeFileCapture,
+		Path: "/workspace/app.py",
+	}
+	result := executeFileCaptureCheck(context.Background(), session, check, 0)
+	if !result.Exists {
+		t.Fatal("expected file to exist")
+	}
+	if result.Content != "def main(): pass" {
+		t.Fatalf("content = %q, want %q", result.Content, "def main(): pass")
+	}
+	if result.Size != 16 {
+		t.Fatalf("size = %d, want 16", result.Size)
+	}
+	if result.Truncated {
+		t.Fatal("should not be truncated")
+	}
+}
+
+func TestExecuteFileCaptureCheck_FileMissing(t *testing.T) {
+	session := &fakeSandboxSession{files: map[string][]byte{}}
+
+	check := scoring.PostExecutionCheck{
+		Key:  "missing",
+		Type: scoring.PostExecutionCheckTypeFileCapture,
+		Path: "/workspace/missing.py",
+	}
+	result := executeFileCaptureCheck(context.Background(), session, check, 0)
+	if result.Exists {
+		t.Fatal("expected file to not exist")
+	}
+	if result.Content != "" {
+		t.Fatalf("content should be empty for missing file, got %q", result.Content)
+	}
+}
+
+func TestExecuteFileCaptureCheck_ExceedsSizeLimit(t *testing.T) {
+	largeContent := make([]byte, 2000)
+	for i := range largeContent {
+		largeContent[i] = 'x'
+	}
+	session := &fakeSandboxSession{
+		files: map[string][]byte{
+			"/workspace/large.txt": largeContent,
+		},
+	}
+
+	check := scoring.PostExecutionCheck{
+		Key:          "large",
+		Type:         scoring.PostExecutionCheckTypeFileCapture,
+		Path:         "/workspace/large.txt",
+		MaxSizeBytes: 100,
+	}
+	result := executeFileCaptureCheck(context.Background(), session, check, 0)
+	if !result.Exists {
+		t.Fatal("expected file to exist")
+	}
+	if !result.Truncated {
+		t.Fatal("expected file to be truncated")
+	}
+	if len(result.Content) != 100 {
+		t.Fatalf("truncated content length = %d, want 100", len(result.Content))
+	}
+	if result.Size != 2000 {
+		t.Fatalf("original size = %d, want 2000", result.Size)
+	}
+}
+
+func TestExecuteFileCaptureCheck_TotalBudgetExhausted(t *testing.T) {
+	session := &fakeSandboxSession{
+		files: map[string][]byte{
+			"/workspace/file.txt": []byte("content"),
+		},
+	}
+
+	check := scoring.PostExecutionCheck{
+		Key:  "file",
+		Type: scoring.PostExecutionCheckTypeFileCapture,
+		Path: "/workspace/file.txt",
+	}
+	// Set totalCapturedSoFar to exceed the budget.
+	result := executeFileCaptureCheck(context.Background(), session, check, scoring.DefaultMaxTotalCaptureBytes)
+	if !result.Exists {
+		t.Fatal("expected file to exist")
+	}
+	if !result.Truncated {
+		t.Fatal("expected truncation when budget exhausted")
+	}
+	if result.Content != "" {
+		t.Fatalf("content should be empty when budget exhausted, got %q", result.Content)
+	}
+}
+
+func TestExecuteDirectoryListingCheck(t *testing.T) {
+	session := &fakeSandboxSession{
+		dirs: map[string][]sandbox.FileInfo{
+			"/workspace/": {
+				{Path: "/workspace/main.py", Size: 100},
+				{Path: "/workspace/tests/test_main.py", Size: 200},
+			},
+		},
+	}
+
+	check := scoring.PostExecutionCheck{
+		Key:       "project",
+		Type:      scoring.PostExecutionCheckTypeDirectoryListing,
+		Path:      "/workspace/",
+		Recursive: true,
+	}
+	result := executeDirectoryListingCheck(context.Background(), session, check)
+	if result.Key != "project" {
+		t.Fatalf("key = %q, want project", result.Key)
+	}
+	if len(result.Entries) != 2 {
+		t.Fatalf("entries = %d, want 2", len(result.Entries))
+	}
+}
+
+func TestExecuteDirectoryListingCheck_NotFound(t *testing.T) {
+	session := &fakeSandboxSession{dirs: map[string][]sandbox.FileInfo{}}
+
+	check := scoring.PostExecutionCheck{
+		Key:  "missing_dir",
+		Type: scoring.PostExecutionCheckTypeDirectoryListing,
+		Path: "/workspace/missing/",
+	}
+	result := executeDirectoryListingCheck(context.Background(), session, check)
+	if len(result.Entries) != 0 {
+		t.Fatalf("entries = %d, want 0 for missing dir", len(result.Entries))
+	}
+}
+
+func TestExecutePostExecutionChecks_EmptyChecks(t *testing.T) {
+	session := &fakeSandboxSession{}
+	results := executePostExecutionChecks(context.Background(), session, nil)
+	if len(results) != 0 {
+		t.Fatalf("results = %d, want 0 for nil checks", len(results))
+	}
+}
+
+func TestExecutePostExecutionChecks_MixedTypes(t *testing.T) {
+	session := &fakeSandboxSession{
+		files: map[string][]byte{
+			"/workspace/app.py": []byte("code"),
+		},
+		dirs: map[string][]sandbox.FileInfo{
+			"/workspace/": {{Path: "/workspace/app.py", Size: 4}},
+		},
+	}
+
+	checks := []scoring.PostExecutionCheck{
+		{Key: "app", Type: scoring.PostExecutionCheckTypeFileCapture, Path: "/workspace/app.py"},
+		{Key: "dir", Type: scoring.PostExecutionCheckTypeDirectoryListing, Path: "/workspace/"},
+	}
+	results := executePostExecutionChecks(context.Background(), session, checks)
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+	if results[0].Type != scoring.PostExecutionCheckTypeFileCapture {
+		t.Fatalf("first result type = %q, want file_capture", results[0].Type)
+	}
+	if results[1].Type != scoring.PostExecutionCheckTypeDirectoryListing {
+		t.Fatalf("second result type = %q, want directory_listing", results[1].Type)
+	}
+
+	// Verify payloads are valid JSON.
+	var capture scoring.FileCaptureResult
+	if err := json.Unmarshal(results[0].Payload, &capture); err != nil {
+		t.Fatalf("invalid file capture payload: %v", err)
+	}
+	if capture.Content != "code" {
+		t.Fatalf("capture content = %q, want code", capture.Content)
+	}
+}

--- a/backend/internal/engine/native_executor.go
+++ b/backend/internal/engine/native_executor.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -73,6 +74,14 @@ func AsFailure(err error) (Failure, bool) {
 	return failure, true
 }
 
+// PostExecutionVerificationResult holds captured file or directory state from
+// the sandbox, emitted as a grader.verification.* event before sandbox teardown.
+type PostExecutionVerificationResult struct {
+	Key     string          `json:"key"`
+	Type    string          `json:"type"` // "file_capture" or "directory_listing"
+	Payload json.RawMessage `json:"payload"`
+}
+
 type Observer interface {
 	OnStepStart(ctx context.Context, step int) error
 	OnProviderCall(ctx context.Context, request provider.Request) error
@@ -80,6 +89,7 @@ type Observer interface {
 	OnProviderResponse(ctx context.Context, response provider.Response) error
 	OnToolExecution(ctx context.Context, record ToolExecutionRecord) error
 	OnStepEnd(ctx context.Context, step int) error
+	OnPostExecutionVerification(ctx context.Context, results []PostExecutionVerificationResult) error
 	OnRunComplete(ctx context.Context, result Result) error
 	OnRunFailure(ctx context.Context, err error) error
 }
@@ -96,6 +106,9 @@ func (NoopObserver) OnToolExecution(context.Context, ToolExecutionRecord) error 
 	return nil
 }
 func (NoopObserver) OnStepEnd(context.Context, int) error        { return nil }
+func (NoopObserver) OnPostExecutionVerification(context.Context, []PostExecutionVerificationResult) error {
+	return nil
+}
 func (NoopObserver) OnRunComplete(context.Context, Result) error { return nil }
 func (NoopObserver) OnRunFailure(context.Context, error) error   { return nil }
 
@@ -332,6 +345,17 @@ func (e NativeExecutor) Execute(ctx context.Context, executionContext repository
 		}
 
 		if completed {
+			// Post-execution verification: capture files while sandbox is still alive.
+			if checks := extractPostExecutionChecks(executionContext); len(checks) > 0 {
+				verificationResults := executePostExecutionChecks(runCtx, session, checks)
+				if observerErr := e.observer.OnPostExecutionVerification(runCtx, verificationResults); observerErr != nil {
+					slog.Default().Warn("post-execution verification observer error",
+						"run_id", executionContext.Run.ID,
+						"run_agent_id", executionContext.RunAgent.ID,
+						"error", observerErr,
+					)
+				}
+			}
 			return Result{
 				FinalOutput:   finalOutput,
 				StopReason:    StopReasonCompleted,

--- a/backend/internal/engine/native_executor_test.go
+++ b/backend/internal/engine/native_executor_test.go
@@ -784,80 +784,36 @@ func (completedErrorTool) Execute(context.Context, ToolExecutionRequest) (ToolEx
 	}, nil
 }
 
-type failingObserver struct{}
+// Test observers embed NoopObserver so that future Observer interface additions
+// only require a single change to the noop implementation.
+
+type failingObserver struct{ NoopObserver }
 
 func (failingObserver) OnStepStart(context.Context, int) error {
 	return errors.New("observer unavailable")
 }
-func (failingObserver) OnProviderCall(context.Context, provider.Request) error { return nil }
-func (failingObserver) OnProviderOutput(context.Context, provider.Request, provider.StreamDelta) error {
-	return nil
-}
-func (failingObserver) OnProviderResponse(context.Context, provider.Response) error { return nil }
-func (failingObserver) OnToolExecution(context.Context, ToolExecutionRecord) error {
-	return nil
-}
-func (failingObserver) OnStepEnd(context.Context, int) error        { return nil }
-func (failingObserver) OnRunComplete(context.Context, Result) error { return nil }
-func (failingObserver) OnRunFailure(context.Context, error) error   { return nil }
 
-type runCompleteFailingObserver struct{}
+type runCompleteFailingObserver struct{ NoopObserver }
 
-func (runCompleteFailingObserver) OnStepStart(context.Context, int) error                 { return nil }
-func (runCompleteFailingObserver) OnProviderCall(context.Context, provider.Request) error { return nil }
-func (runCompleteFailingObserver) OnProviderOutput(context.Context, provider.Request, provider.StreamDelta) error {
-	return nil
-}
-func (runCompleteFailingObserver) OnProviderResponse(context.Context, provider.Response) error {
-	return nil
-}
-func (runCompleteFailingObserver) OnToolExecution(context.Context, ToolExecutionRecord) error {
-	return nil
-}
-func (runCompleteFailingObserver) OnStepEnd(context.Context, int) error { return nil }
 func (runCompleteFailingObserver) OnRunComplete(context.Context, Result) error {
 	return errors.New("observer completion write failed")
 }
-func (runCompleteFailingObserver) OnRunFailure(context.Context, error) error { return nil }
 
-type runFailureFailingObserver struct{}
+type runFailureFailingObserver struct{ NoopObserver }
 
-func (runFailureFailingObserver) OnStepStart(context.Context, int) error                 { return nil }
-func (runFailureFailingObserver) OnProviderCall(context.Context, provider.Request) error { return nil }
-func (runFailureFailingObserver) OnProviderOutput(context.Context, provider.Request, provider.StreamDelta) error {
-	return nil
-}
-func (runFailureFailingObserver) OnProviderResponse(context.Context, provider.Response) error {
-	return nil
-}
-func (runFailureFailingObserver) OnToolExecution(context.Context, ToolExecutionRecord) error {
-	return nil
-}
-func (runFailureFailingObserver) OnStepEnd(context.Context, int) error        { return nil }
-func (runFailureFailingObserver) OnRunComplete(context.Context, Result) error { return nil }
 func (runFailureFailingObserver) OnRunFailure(context.Context, error) error {
 	return errors.New("observer failure write failed")
 }
 
 type countingObserver struct {
+	NoopObserver
 	providerOutputCount int
 }
 
-func (o *countingObserver) OnStepStart(context.Context, int) error                 { return nil }
-func (o *countingObserver) OnProviderCall(context.Context, provider.Request) error { return nil }
 func (o *countingObserver) OnProviderOutput(context.Context, provider.Request, provider.StreamDelta) error {
 	o.providerOutputCount++
 	return nil
 }
-func (o *countingObserver) OnProviderResponse(context.Context, provider.Response) error {
-	return nil
-}
-func (o *countingObserver) OnToolExecution(context.Context, ToolExecutionRecord) error {
-	return nil
-}
-func (o *countingObserver) OnStepEnd(context.Context, int) error        { return nil }
-func (o *countingObserver) OnRunComplete(context.Context, Result) error { return nil }
-func (o *countingObserver) OnRunFailure(context.Context, error) error   { return nil }
 
 type providerStep struct {
 	validate       func(t *testing.T, request provider.Request)

--- a/backend/internal/engine/prompt_eval_executor_test.go
+++ b/backend/internal/engine/prompt_eval_executor_test.go
@@ -269,6 +269,9 @@ func (o *recordingObserver) OnStepEnd(context.Context, int) error {
 	o.stepEnds++
 	return nil
 }
+func (o *recordingObserver) OnPostExecutionVerification(context.Context, []PostExecutionVerificationResult) error {
+	return nil
+}
 func (o *recordingObserver) OnRunComplete(context.Context, Result) error {
 	o.runComplete = true
 	return nil

--- a/backend/internal/runevents/envelope.go
+++ b/backend/internal/runevents/envelope.go
@@ -37,6 +37,9 @@ const (
 	EventTypeSandboxFileWritten      Type = "sandbox.file.written"
 	EventTypeSandboxFileListed       Type = "sandbox.file.listed"
 
+	EventTypeGraderVerificationFileCaptured    Type = "grader.verification.file_captured"
+	EventTypeGraderVerificationDirectoryListed Type = "grader.verification.directory_listed"
+
 	EventTypeScoringStarted        Type = "scoring.started"
 	EventTypeScoringMetricRecorded Type = "scoring.metric.recorded"
 	EventTypeScoringCompleted      Type = "scoring.completed"
@@ -50,7 +53,8 @@ const (
 	SourcePromptEvalEngine Source = "prompt_eval_engine"
 	SourceHostedExternal   Source = "hosted_external"
 	SourceHostedCallback   Source = "hosted_callback"
-	SourceWorkerScoring    Source = "worker_scoring"
+	SourceWorkerScoring      Source = "worker_scoring"
+	SourceGraderVerification Source = "grader_verification"
 )
 
 type EvidenceLevel string
@@ -159,6 +163,8 @@ func isValidType(eventType Type) bool {
 		EventTypeSandboxFileRead,
 		EventTypeSandboxFileWritten,
 		EventTypeSandboxFileListed,
+		EventTypeGraderVerificationFileCaptured,
+		EventTypeGraderVerificationDirectoryListed,
 		EventTypeScoringStarted,
 		EventTypeScoringMetricRecorded,
 		EventTypeScoringCompleted,
@@ -171,7 +177,7 @@ func isValidType(eventType Type) bool {
 
 func isValidSource(source Source) bool {
 	switch source {
-	case SourceNativeEngine, SourcePromptEvalEngine, SourceHostedExternal, SourceHostedCallback, SourceWorkerScoring:
+	case SourceNativeEngine, SourcePromptEvalEngine, SourceHostedExternal, SourceHostedCallback, SourceWorkerScoring, SourceGraderVerification:
 		return true
 	default:
 		return false

--- a/backend/internal/scoring/engine_evidence.go
+++ b/backend/internal/scoring/engine_evidence.go
@@ -1,6 +1,7 @@
 package scoring
 
 import (
+	"encoding/json"
 	"sort"
 	"time"
 
@@ -25,6 +26,8 @@ type extractedEvidence struct {
 	modelUsage                []pricedUsage
 	observedModels            []modelRef
 	stepDurations             []stepDurationEvidence
+	capturedFiles             map[string]FileCaptureResult
+	capturedDirListings       map[string]DirectoryListingResult
 	warnings                  []string
 }
 
@@ -146,6 +149,22 @@ func buildEvidence(challengeInputs []EvidenceInput, events []Event) extractedEvi
 				totalFromCalls += value
 				usageFromCalls = true
 				addModelUsage(usageByModel, providerKey, providerModelID, "total_tokens", value)
+			}
+		case "grader.verification.file_captured":
+			var capture FileCaptureResult
+			if err := json.Unmarshal(event.Payload, &capture); err == nil && capture.Key != "" {
+				if evidence.capturedFiles == nil {
+					evidence.capturedFiles = make(map[string]FileCaptureResult)
+				}
+				evidence.capturedFiles[capture.Key] = capture
+			}
+		case "grader.verification.directory_listed":
+			var listing DirectoryListingResult
+			if err := json.Unmarshal(event.Payload, &listing); err == nil && listing.Key != "" {
+				if evidence.capturedDirListings == nil {
+					evidence.capturedDirListings = make(map[string]DirectoryListingResult)
+				}
+				evidence.capturedDirListings[listing.Key] = listing
 			}
 		case "model.call.started":
 			providerKey, _ := stringValue(payload, "provider_key")

--- a/backend/internal/scoring/engine_resolution.go
+++ b/backend/internal/scoring/engine_resolution.go
@@ -37,6 +37,9 @@ func resolveEvidenceValue(source string, evidence extractedEvidence) (*string, *
 			return nil, evidence.challengeInputChallengeID, firstNonEmpty(evidence.caseInputReason, "case evidence is unavailable"), nil
 		}
 		return resolveArtifactEvidence(source, *evidence.caseInput)
+	case strings.HasPrefix(source, "file:"):
+		checkKey := strings.TrimPrefix(source, "file:")
+		return resolveFileCaptureEvidence(checkKey, evidence)
 	case strings.HasPrefix(source, "literal:"):
 		value := strings.TrimPrefix(source, "literal:")
 		return &value, nil, "", nil
@@ -250,4 +253,24 @@ func walkEvidenceValue(value any, segments []string) (any, bool) {
 		}
 	}
 	return current, true
+}
+
+// resolveFileCaptureEvidence looks up a captured file or directory listing by
+// its check key and returns the content as a string suitable for validators.
+func resolveFileCaptureEvidence(checkKey string, evidence extractedEvidence) (*string, *uuid.UUID, string, error) {
+	if capture, ok := evidence.capturedFiles[checkKey]; ok {
+		if !capture.Exists {
+			return nil, nil, fmt.Sprintf("captured file %q does not exist at path %q", checkKey, capture.Path), nil
+		}
+		return &capture.Content, nil, "", nil
+	}
+	if listing, ok := evidence.capturedDirListings[checkKey]; ok {
+		encoded, err := json.Marshal(listing)
+		if err != nil {
+			return nil, nil, "", fmt.Errorf("marshal directory listing evidence: %w", err)
+		}
+		value := string(encoded)
+		return &value, nil, "", nil
+	}
+	return nil, nil, fmt.Sprintf("file capture key %q is unavailable", checkKey), nil
 }

--- a/backend/internal/scoring/engine_validators.go
+++ b/backend/internal/scoring/engine_validators.go
@@ -1,9 +1,12 @@
 package scoring
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 func evaluateValidators(validators []ValidatorDeclaration, evidence extractedEvidence) ([]ValidatorResult, []string) {
@@ -17,9 +20,8 @@ func evaluateValidators(validators []ValidatorDeclaration, evidence extractedEvi
 			ExpectedFrom: validator.ExpectedFrom,
 		}
 
+		// Resolve the target (actual) evidence.
 		actualValue, actualChallengeID, actualReason, actualErr := resolveEvidenceValue(validator.Target, evidence)
-		expectedValue, expectedChallengeID, expectedReason, expectedErr := resolveEvidenceValue(validator.ExpectedFrom, evidence)
-
 		if actualErr != nil {
 			result.State = OutputStateError
 			result.Reason = actualErr.Error()
@@ -30,17 +32,49 @@ func evaluateValidators(validators []ValidatorDeclaration, evidence extractedEvi
 			results = append(results, result)
 			continue
 		}
-		if expectedErr != nil {
-			result.State = OutputStateError
-			result.Reason = expectedErr.Error()
+
+		// For file_exists validators, unavailable evidence means the file
+		// doesn't exist — that's a valid signal, not an error. Handle this
+		// case specially so the validator can distinguish exists vs not-exists.
+		if validator.Type == ValidatorTypeFileExists && actualValue == nil {
+			result.ChallengeIdentityID = actualChallengeID
+			outcome := validateFileExistsUnavailable(validator.Config)
+			result.State = OutputStateAvailable
+			result.Verdict = outcome.verdict
+			result.NormalizedScore = outcome.normalizedScore
+			result.Reason = outcome.reason
 			result.RawOutput = mustMarshalJSON(map[string]any{
-				"state":  result.State,
-				"reason": result.Reason,
+				"state":            result.State,
+				"verdict":          result.Verdict,
+				"normalized_score": result.NormalizedScore,
+				"reason":           result.Reason,
+				"target":           validator.Target,
 			})
 			results = append(results, result)
 			continue
 		}
-		if actualValue == nil || expectedValue == nil {
+
+		// Resolve the expected evidence. For config-only validators (file_exists,
+		// file_json_schema, directory_structure) expected_from is empty — skip.
+		var expectedValue *string
+		var expectedChallengeID *uuid.UUID
+		var expectedReason string
+		if validator.Type.RequiresExpectedFrom() {
+			var expectedErr error
+			expectedValue, expectedChallengeID, expectedReason, expectedErr = resolveEvidenceValue(validator.ExpectedFrom, evidence)
+			if expectedErr != nil {
+				result.State = OutputStateError
+				result.Reason = expectedErr.Error()
+				result.RawOutput = mustMarshalJSON(map[string]any{
+					"state":  result.State,
+					"reason": result.Reason,
+				})
+				results = append(results, result)
+				continue
+			}
+		}
+
+		if actualValue == nil || (validator.Type.RequiresExpectedFrom() && expectedValue == nil) {
 			result.State = OutputStateUnavailable
 			result.Reason = firstNonEmpty(actualReason, expectedReason, "evidence is unavailable")
 			if actualChallengeID != nil {
@@ -57,14 +91,20 @@ func evaluateValidators(validators []ValidatorDeclaration, evidence extractedEvi
 		}
 
 		result.ActualValue = stringPtr(*actualValue)
-		result.ExpectedValue = stringPtr(*expectedValue)
+		if expectedValue != nil {
+			result.ExpectedValue = stringPtr(*expectedValue)
+		}
 		if actualChallengeID != nil {
 			result.ChallengeIdentityID = actualChallengeID
 		} else {
 			result.ChallengeIdentityID = expectedChallengeID
 		}
 
-		outcome := applyValidator(validator, *actualValue, *expectedValue)
+		expectedStr := ""
+		if expectedValue != nil {
+			expectedStr = *expectedValue
+		}
+		outcome := applyValidator(validator, *actualValue, expectedStr)
 		result.Verdict = outcome.verdict
 		result.NormalizedScore = outcome.normalizedScore
 		result.Reason = outcome.reason
@@ -86,6 +126,20 @@ func evaluateValidators(validators []ValidatorDeclaration, evidence extractedEvi
 		results = append(results, result)
 	}
 	return results, warnings
+}
+
+// validateFileExistsUnavailable handles file_exists when the target file was
+// not captured (evidence unavailable). This means the file does not exist.
+func validateFileExistsUnavailable(config json.RawMessage) validatorOutcome {
+	var cfg fileExistsConfig
+	cfg.MustExist = true
+	if len(config) > 0 {
+		_ = json.Unmarshal(config, &cfg)
+	}
+	if cfg.MustExist {
+		return validatorOutcome{verdict: "fail", normalizedScore: floatPtr(0), reason: "file does not exist"}
+	}
+	return validatorOutcome{verdict: "pass", normalizedScore: floatPtr(1), reason: "file correctly does not exist"}
 }
 
 func applyValidator(validator ValidatorDeclaration, actual string, expected string) validatorOutcome {
@@ -123,6 +177,14 @@ func applyValidator(validator ValidatorDeclaration, actual string, expected stri
 		return validateNumericMatch(actual, expected, validator.Config)
 	case ValidatorTypeNormalizedMatch:
 		return validateNormalizedMatch(actual, expected, validator.Config)
+	case ValidatorTypeFileExists:
+		return validateFileExists(actual, validator.Config)
+	case ValidatorTypeFileContentMatch:
+		return validateFileContentMatch(actual, expected, validator.Config)
+	case ValidatorTypeFileJSONSchema:
+		return validateFileJSONSchema(actual, validator.Config)
+	case ValidatorTypeDirectoryStructure:
+		return validateDirectoryStructure(actual, validator.Config)
 	default:
 		return validatorOutcome{verdict: "error", reason: fmt.Sprintf("unsupported validator type %q", validator.Type)}
 	}

--- a/backend/internal/scoring/file_validators.go
+++ b/backend/internal/scoring/file_validators.go
@@ -1,0 +1,215 @@
+package scoring
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strings"
+)
+
+// --- file_exists ---
+
+type fileExistsConfig struct {
+	MustExist bool `json:"must_exist"`
+}
+
+func validateFileExists(actual string, config json.RawMessage) validatorOutcome {
+	var cfg fileExistsConfig
+	cfg.MustExist = true // default: file should exist
+	if len(config) > 0 {
+		if err := json.Unmarshal(config, &cfg); err != nil {
+			return validatorOutcome{verdict: "error", reason: fmt.Sprintf("invalid file_exists config: %v", err)}
+		}
+	}
+
+	// applyValidator is only called when evidence is non-nil, which means the
+	// file exists. The not-exists case is handled earlier in evaluateValidators
+	// via validateFileExistsUnavailable.
+	if cfg.MustExist {
+		return validatorOutcome{verdict: "pass", normalizedScore: floatPtr(1)}
+	}
+	// must_exist: false — file should NOT exist, but it does.
+	return validatorOutcome{verdict: "fail", normalizedScore: floatPtr(0), reason: "file exists but should not"}
+}
+
+// --- file_content_match ---
+
+type fileContentMatchConfig struct {
+	MatchMode        string `json:"match_mode"`
+	IgnoreWhitespace bool   `json:"ignore_whitespace,omitempty"`
+}
+
+func validateFileContentMatch(actual, expected string, config json.RawMessage) validatorOutcome {
+	var cfg fileContentMatchConfig
+	cfg.MatchMode = "contains" // default match mode
+	if len(config) > 0 {
+		if err := json.Unmarshal(config, &cfg); err != nil {
+			return validatorOutcome{verdict: "error", reason: fmt.Sprintf("invalid file_content_match config: %v", err)}
+		}
+	}
+
+	actualVal := actual
+	expectedVal := expected
+	if cfg.IgnoreWhitespace {
+		actualVal = collapseWhitespace(actualVal)
+		expectedVal = collapseWhitespace(expectedVal)
+	}
+
+	switch cfg.MatchMode {
+	case "exact":
+		if actualVal == expectedVal {
+			return validatorOutcome{verdict: "pass", normalizedScore: floatPtr(1)}
+		}
+		return validatorOutcome{verdict: "fail", normalizedScore: floatPtr(0), reason: "file content does not match exactly"}
+
+	case "contains":
+		if strings.Contains(actualVal, expectedVal) {
+			return validatorOutcome{verdict: "pass", normalizedScore: floatPtr(1)}
+		}
+		return validatorOutcome{verdict: "fail", normalizedScore: floatPtr(0), reason: "file content does not contain expected string"}
+
+	case "regex":
+		pattern, err := regexp.Compile(expected) // Use original expected for regex (not whitespace-collapsed)
+		if err != nil {
+			return validatorOutcome{verdict: "error", reason: fmt.Sprintf("invalid regex pattern: %v", err)}
+		}
+		if pattern.MatchString(actual) {
+			return validatorOutcome{verdict: "pass", normalizedScore: floatPtr(1)}
+		}
+		return validatorOutcome{verdict: "fail", normalizedScore: floatPtr(0), reason: "file content does not match regex pattern"}
+
+	case "not_contains":
+		if !strings.Contains(actualVal, expectedVal) {
+			return validatorOutcome{verdict: "pass", normalizedScore: floatPtr(1)}
+		}
+		return validatorOutcome{verdict: "fail", normalizedScore: floatPtr(0), reason: "file content contains forbidden string"}
+
+	case "json_equal":
+		return validateJSONEqual(actual, expected)
+
+	default:
+		return validatorOutcome{verdict: "error", reason: fmt.Sprintf("unsupported match_mode %q", cfg.MatchMode)}
+	}
+}
+
+func validateJSONEqual(actual, expected string) validatorOutcome {
+	var actualJSON, expectedJSON any
+	if err := json.Unmarshal([]byte(actual), &actualJSON); err != nil {
+		return validatorOutcome{verdict: "error", reason: fmt.Sprintf("parse actual as JSON: %v", err)}
+	}
+	if err := json.Unmarshal([]byte(expected), &expectedJSON); err != nil {
+		return validatorOutcome{verdict: "error", reason: fmt.Sprintf("parse expected as JSON: %v", err)}
+	}
+	if reflect.DeepEqual(actualJSON, expectedJSON) {
+		return validatorOutcome{verdict: "pass", normalizedScore: floatPtr(1)}
+	}
+	return validatorOutcome{verdict: "fail", normalizedScore: floatPtr(0), reason: "file JSON content is not structurally equal"}
+}
+
+// --- file_json_schema ---
+
+type fileJSONSchemaConfig struct {
+	Schema json.RawMessage `json:"schema"`
+}
+
+func validateFileJSONSchema(actual string, config json.RawMessage) validatorOutcome {
+	var cfg fileJSONSchemaConfig
+	if len(config) == 0 {
+		return validatorOutcome{verdict: "error", reason: "file_json_schema config is required"}
+	}
+	if err := json.Unmarshal(config, &cfg); err != nil {
+		return validatorOutcome{verdict: "error", reason: fmt.Sprintf("invalid file_json_schema config: %v", err)}
+	}
+	if len(cfg.Schema) == 0 {
+		return validatorOutcome{verdict: "error", reason: "file_json_schema config.schema is required"}
+	}
+	// Reuse the existing JSON schema validator: it takes actual JSON and expected
+	// (the schema) as strings.
+	return validateJSONSchema(actual, string(cfg.Schema))
+}
+
+// --- directory_structure ---
+
+type directoryStructureConfig struct {
+	RequiredFiles       []string `json:"required_files,omitempty"`
+	ForbiddenFiles      []string `json:"forbidden_files,omitempty"`
+	RequiredDirectories []string `json:"required_directories,omitempty"`
+}
+
+func validateDirectoryStructure(actual string, config json.RawMessage) validatorOutcome {
+	var cfg directoryStructureConfig
+	if len(config) == 0 {
+		return validatorOutcome{verdict: "error", reason: "directory_structure config is required"}
+	}
+	if err := json.Unmarshal(config, &cfg); err != nil {
+		return validatorOutcome{verdict: "error", reason: fmt.Sprintf("invalid directory_structure config: %v", err)}
+	}
+
+	// Parse the directory listing from the actual value (JSON-serialized DirectoryListingResult).
+	var listing DirectoryListingResult
+	if err := json.Unmarshal([]byte(actual), &listing); err != nil {
+		return validatorOutcome{verdict: "error", reason: fmt.Sprintf("parse directory listing: %v", err)}
+	}
+
+	filePaths := make(map[string]bool, len(listing.Entries))
+	dirPaths := make(map[string]bool)
+	for _, entry := range listing.Entries {
+		// Use filepath.Rel for robust relative-path computation regardless of
+		// trailing-slash inconsistencies between listing.Path and entry.Path.
+		rel, err := filepath.Rel(listing.Path, entry.Path)
+		if err != nil {
+			rel = entry.Path
+		}
+		filePaths[rel] = true
+		filePaths[entry.Path] = true
+		if entry.IsDir {
+			dirPaths[rel] = true
+			dirPaths[entry.Path] = true
+		}
+	}
+
+	var missing []string
+	for _, required := range cfg.RequiredFiles {
+		if !filePaths[required] {
+			missing = append(missing, required)
+		}
+	}
+	var forbidden []string
+	for _, deny := range cfg.ForbiddenFiles {
+		if filePaths[deny] {
+			forbidden = append(forbidden, deny)
+		}
+	}
+	var missingDirs []string
+	for _, required := range cfg.RequiredDirectories {
+		trimmed := strings.TrimSuffix(required, "/")
+		if !dirPaths[trimmed] && !dirPaths[required] && !filePaths[trimmed] {
+			missingDirs = append(missingDirs, required)
+		}
+	}
+
+	if len(missing) == 0 && len(forbidden) == 0 && len(missingDirs) == 0 {
+		return validatorOutcome{verdict: "pass", normalizedScore: floatPtr(1)}
+	}
+
+	var reasons []string
+	if len(missing) > 0 {
+		reasons = append(reasons, fmt.Sprintf("missing required files: %s", strings.Join(missing, ", ")))
+	}
+	if len(forbidden) > 0 {
+		reasons = append(reasons, fmt.Sprintf("forbidden files present: %s", strings.Join(forbidden, ", ")))
+	}
+	if len(missingDirs) > 0 {
+		reasons = append(reasons, fmt.Sprintf("missing required directories: %s", strings.Join(missingDirs, ", ")))
+	}
+	return validatorOutcome{
+		verdict:         "fail",
+		normalizedScore: floatPtr(0),
+		reason:          strings.Join(reasons, "; "),
+	}
+}
+
+// collapseWhitespace is defined in string_validators.go and shared across
+// all validators in the scoring package.

--- a/backend/internal/scoring/file_validators_test.go
+++ b/backend/internal/scoring/file_validators_test.go
@@ -1,0 +1,238 @@
+package scoring
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestValidateFileExists_MustExistTrue_FileExists(t *testing.T) {
+	outcome := validateFileExists("some content", json.RawMessage(`{"must_exist": true}`))
+	if outcome.verdict != "pass" {
+		t.Fatalf("verdict = %q, want pass", outcome.verdict)
+	}
+}
+
+func TestValidateFileExists_MustExistTrue_FileDoesNotExist(t *testing.T) {
+	// When file doesn't exist, evaluateValidators calls validateFileExistsUnavailable.
+	outcome := validateFileExistsUnavailable(json.RawMessage(`{"must_exist": true}`))
+	if outcome.verdict != "fail" {
+		t.Fatalf("verdict = %q, want fail", outcome.verdict)
+	}
+}
+
+func TestValidateFileExists_MustExistFalse_FileDoesNotExist(t *testing.T) {
+	outcome := validateFileExistsUnavailable(json.RawMessage(`{"must_exist": false}`))
+	if outcome.verdict != "pass" {
+		t.Fatalf("verdict = %q, want pass", outcome.verdict)
+	}
+}
+
+func TestValidateFileExists_MustExistFalse_FileExists(t *testing.T) {
+	outcome := validateFileExists("some content", json.RawMessage(`{"must_exist": false}`))
+	if outcome.verdict != "fail" {
+		t.Fatalf("verdict = %q, want fail", outcome.verdict)
+	}
+}
+
+func TestValidateFileExists_DefaultConfigMeansExists(t *testing.T) {
+	outcome := validateFileExists("content", nil)
+	if outcome.verdict != "pass" {
+		t.Fatalf("verdict = %q, want pass (default must_exist=true, file exists)", outcome.verdict)
+	}
+}
+
+func TestValidateFileContentMatch_Exact(t *testing.T) {
+	config := json.RawMessage(`{"match_mode": "exact"}`)
+	outcome := validateFileContentMatch("hello world", "hello world", config)
+	if outcome.verdict != "pass" {
+		t.Fatalf("exact match: verdict = %q, want pass", outcome.verdict)
+	}
+
+	outcome = validateFileContentMatch("hello world!", "hello world", config)
+	if outcome.verdict != "fail" {
+		t.Fatalf("exact mismatch: verdict = %q, want fail", outcome.verdict)
+	}
+}
+
+func TestValidateFileContentMatch_Contains(t *testing.T) {
+	config := json.RawMessage(`{"match_mode": "contains"}`)
+	outcome := validateFileContentMatch("the quick brown fox", "brown fox", config)
+	if outcome.verdict != "pass" {
+		t.Fatalf("contains match: verdict = %q, want pass", outcome.verdict)
+	}
+
+	outcome = validateFileContentMatch("the quick brown fox", "lazy dog", config)
+	if outcome.verdict != "fail" {
+		t.Fatalf("contains mismatch: verdict = %q, want fail", outcome.verdict)
+	}
+}
+
+func TestValidateFileContentMatch_Regex(t *testing.T) {
+	config := json.RawMessage(`{"match_mode": "regex"}`)
+	outcome := validateFileContentMatch("status: 200 OK", `status:\s+\d+ OK`, config)
+	if outcome.verdict != "pass" {
+		t.Fatalf("regex match: verdict = %q, want pass", outcome.verdict)
+	}
+
+	outcome = validateFileContentMatch("status: error", `status:\s+\d+ OK`, config)
+	if outcome.verdict != "fail" {
+		t.Fatalf("regex mismatch: verdict = %q, want fail", outcome.verdict)
+	}
+}
+
+func TestValidateFileContentMatch_NotContains(t *testing.T) {
+	config := json.RawMessage(`{"match_mode": "not_contains"}`)
+	outcome := validateFileContentMatch("clean code here", "dead_code_function", config)
+	if outcome.verdict != "pass" {
+		t.Fatalf("not_contains (absent): verdict = %q, want pass", outcome.verdict)
+	}
+
+	outcome = validateFileContentMatch("keep dead_code_function around", "dead_code_function", config)
+	if outcome.verdict != "fail" {
+		t.Fatalf("not_contains (present): verdict = %q, want fail", outcome.verdict)
+	}
+}
+
+func TestValidateFileContentMatch_JSONEqual(t *testing.T) {
+	actual := `{"b": 2, "a": 1}`
+	expected := `{"a":1,"b":2}`
+	config := json.RawMessage(`{"match_mode": "json_equal"}`)
+	outcome := validateFileContentMatch(actual, expected, config)
+	if outcome.verdict != "pass" {
+		t.Fatalf("json_equal match: verdict = %q, want pass", outcome.verdict)
+	}
+
+	outcome = validateFileContentMatch(`{"a": 1}`, `{"a": 2}`, config)
+	if outcome.verdict != "fail" {
+		t.Fatalf("json_equal mismatch: verdict = %q, want fail", outcome.verdict)
+	}
+}
+
+func TestValidateFileContentMatch_IgnoreWhitespace(t *testing.T) {
+	config := json.RawMessage(`{"match_mode": "exact", "ignore_whitespace": true}`)
+	outcome := validateFileContentMatch("hello   world", "hello world", config)
+	if outcome.verdict != "pass" {
+		t.Fatalf("ignore_whitespace: verdict = %q, want pass", outcome.verdict)
+	}
+}
+
+func TestValidateFileContentMatch_DefaultModeIsContains(t *testing.T) {
+	outcome := validateFileContentMatch("the answer is 42", "42", nil)
+	if outcome.verdict != "pass" {
+		t.Fatalf("default contains: verdict = %q, want pass", outcome.verdict)
+	}
+}
+
+func TestValidateFileJSONSchema_Valid(t *testing.T) {
+	actual := `{"status": "success", "results": [1, 2]}`
+	config := json.RawMessage(`{
+		"schema": {
+			"type": "object",
+			"required": ["status", "results"],
+			"properties": {
+				"status": {"type": "string", "enum": ["success", "partial", "failure"]},
+				"results": {"type": "array"}
+			}
+		}
+	}`)
+	outcome := validateFileJSONSchema(actual, config)
+	if outcome.verdict != "pass" {
+		t.Fatalf("json_schema valid: verdict = %q, reason = %q", outcome.verdict, outcome.reason)
+	}
+}
+
+func TestValidateFileJSONSchema_Invalid(t *testing.T) {
+	actual := `{"name": "test"}`
+	config := json.RawMessage(`{
+		"schema": {
+			"type": "object",
+			"required": ["status", "name"],
+			"properties": {
+				"status": {"type": "string"},
+				"name": {"type": "string"}
+			}
+		}
+	}`)
+	outcome := validateFileJSONSchema(actual, config)
+	if outcome.verdict != "fail" {
+		t.Fatalf("json_schema invalid: verdict = %q, want fail (missing required field)", outcome.verdict)
+	}
+}
+
+func TestValidateFileJSONSchema_MissingConfig(t *testing.T) {
+	outcome := validateFileJSONSchema(`{}`, nil)
+	if outcome.verdict != "error" {
+		t.Fatalf("missing config: verdict = %q, want error", outcome.verdict)
+	}
+}
+
+func TestValidateDirectoryStructure_AllPresent(t *testing.T) {
+	listing := DirectoryListingResult{
+		Key:  "project_structure",
+		Path: "/workspace/project/",
+		Entries: []DirectoryEntry{
+			{Path: "/workspace/project/src/main.py", Size: 100},
+			{Path: "/workspace/project/tests/test_main.py", Size: 200},
+			{Path: "/workspace/project/requirements.txt", Size: 50},
+			{Path: "/workspace/project/src/", Size: 0, IsDir: true},
+			{Path: "/workspace/project/tests/", Size: 0, IsDir: true},
+		},
+	}
+	actual, _ := json.Marshal(listing)
+	config := json.RawMessage(`{
+		"required_files": ["src/main.py", "tests/test_main.py", "requirements.txt"],
+		"forbidden_files": [".env", "src/main.py.bak"],
+		"required_directories": ["src/", "tests/"]
+	}`)
+	outcome := validateDirectoryStructure(string(actual), config)
+	if outcome.verdict != "pass" {
+		t.Fatalf("all present: verdict = %q, reason = %q", outcome.verdict, outcome.reason)
+	}
+}
+
+func TestValidateDirectoryStructure_MissingRequired(t *testing.T) {
+	listing := DirectoryListingResult{
+		Key:  "project_structure",
+		Path: "/workspace/project/",
+		Entries: []DirectoryEntry{
+			{Path: "/workspace/project/src/main.py", Size: 100},
+		},
+	}
+	actual, _ := json.Marshal(listing)
+	config := json.RawMessage(`{
+		"required_files": ["src/main.py", "tests/test_main.py"]
+	}`)
+	outcome := validateDirectoryStructure(string(actual), config)
+	if outcome.verdict != "fail" {
+		t.Fatalf("missing required: verdict = %q, want fail", outcome.verdict)
+	}
+	if outcome.reason == "" {
+		t.Fatal("expected a reason describing what's missing")
+	}
+}
+
+func TestValidateDirectoryStructure_ForbiddenPresent(t *testing.T) {
+	listing := DirectoryListingResult{
+		Key:  "project_structure",
+		Path: "/workspace/project/",
+		Entries: []DirectoryEntry{
+			{Path: "/workspace/project/.env", Size: 100},
+			{Path: "/workspace/project/src/main.py", Size: 200},
+		},
+	}
+	actual, _ := json.Marshal(listing)
+	config := json.RawMessage(`{
+		"forbidden_files": [".env"]
+	}`)
+	outcome := validateDirectoryStructure(string(actual), config)
+	if outcome.verdict != "fail" {
+		t.Fatalf("forbidden present: verdict = %q, want fail", outcome.verdict)
+	}
+}
+
+func TestValidateDirectoryStructure_MissingConfig(t *testing.T) {
+	outcome := validateDirectoryStructure(`{}`, nil)
+	if outcome.verdict != "error" {
+		t.Fatalf("missing config: verdict = %q, want error", outcome.verdict)
+	}
+}

--- a/backend/internal/scoring/post_execution.go
+++ b/backend/internal/scoring/post_execution.go
@@ -1,0 +1,53 @@
+package scoring
+
+const (
+	PostExecutionCheckTypeFileCapture     = "file_capture"
+	PostExecutionCheckTypeDirectoryListing = "directory_listing"
+
+	DefaultMaxFileSizeBytes     int64 = 1 << 20  // 1MB per file
+	DefaultMaxTotalCaptureBytes int64 = 10 << 20 // 10MB total per run
+)
+
+// PostExecutionCheck specifies a file or directory to capture from the sandbox
+// after agent execution completes, before the sandbox is destroyed. Results are
+// emitted as grader.verification.* events and made available to the scoring
+// engine via the file: evidence prefix.
+type PostExecutionCheck struct {
+	Key          string `json:"key"`
+	Type         string `json:"type"` // "file_capture" or "directory_listing"
+	Path         string `json:"path"`
+	Recursive    bool   `json:"recursive,omitempty"`
+	MaxSizeBytes int64  `json:"max_size_bytes,omitempty"`
+}
+
+// EffectiveMaxSizeBytes returns the configured max size or the default.
+func (c PostExecutionCheck) EffectiveMaxSizeBytes() int64 {
+	if c.MaxSizeBytes > 0 {
+		return c.MaxSizeBytes
+	}
+	return DefaultMaxFileSizeBytes
+}
+
+// FileCaptureResult holds the content of a file read from the sandbox.
+type FileCaptureResult struct {
+	Key       string `json:"key"`
+	Path      string `json:"path"`
+	Exists    bool   `json:"exists"`
+	Content   string `json:"content,omitempty"`
+	Size      int64  `json:"size"`
+	Truncated bool   `json:"truncated,omitempty"`
+}
+
+// DirectoryListingResult holds the listing of a directory from the sandbox.
+type DirectoryListingResult struct {
+	Key     string           `json:"key"`
+	Path    string           `json:"path"`
+	Entries []DirectoryEntry `json:"entries"`
+}
+
+// DirectoryEntry represents a single file or directory within a listing.
+type DirectoryEntry struct {
+	Path  string `json:"path"`
+	Size  int64  `json:"size"`
+	IsDir bool   `json:"is_dir,omitempty"`
+}

--- a/backend/internal/scoring/post_execution_test.go
+++ b/backend/internal/scoring/post_execution_test.go
@@ -1,0 +1,336 @@
+package scoring
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestResolveFileCaptureEvidence_FileExists(t *testing.T) {
+	evidence := extractedEvidence{
+		capturedFiles: map[string]FileCaptureResult{
+			"app_py": {
+				Key:     "app_py",
+				Path:    "/workspace/app.py",
+				Exists:  true,
+				Content: "print('hello')",
+				Size:    14,
+			},
+		},
+	}
+	value, _, reason, err := resolveFileCaptureEvidence("app_py", evidence)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reason != "" {
+		t.Fatalf("unexpected reason: %q", reason)
+	}
+	if value == nil || *value != "print('hello')" {
+		t.Fatalf("value = %v, want %q", value, "print('hello')")
+	}
+}
+
+func TestResolveFileCaptureEvidence_FileDoesNotExist(t *testing.T) {
+	evidence := extractedEvidence{
+		capturedFiles: map[string]FileCaptureResult{
+			"missing": {
+				Key:    "missing",
+				Path:   "/workspace/nope.txt",
+				Exists: false,
+			},
+		},
+	}
+	value, _, reason, err := resolveFileCaptureEvidence("missing", evidence)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if value != nil {
+		t.Fatalf("value should be nil for non-existent file, got %q", *value)
+	}
+	if reason == "" {
+		t.Fatal("expected a reason for non-existent file")
+	}
+}
+
+func TestResolveFileCaptureEvidence_KeyNotFound(t *testing.T) {
+	evidence := extractedEvidence{}
+	value, _, reason, err := resolveFileCaptureEvidence("unknown_key", evidence)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if value != nil {
+		t.Fatalf("value should be nil for unknown key, got %q", *value)
+	}
+	if reason == "" {
+		t.Fatal("expected a reason for unknown key")
+	}
+}
+
+func TestResolveFileCaptureEvidence_DirectoryListing(t *testing.T) {
+	evidence := extractedEvidence{
+		capturedDirListings: map[string]DirectoryListingResult{
+			"project_dir": {
+				Key:  "project_dir",
+				Path: "/workspace/",
+				Entries: []DirectoryEntry{
+					{Path: "/workspace/main.py", Size: 100},
+				},
+			},
+		},
+	}
+	value, _, reason, err := resolveFileCaptureEvidence("project_dir", evidence)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reason != "" {
+		t.Fatalf("unexpected reason: %q", reason)
+	}
+	if value == nil {
+		t.Fatal("expected non-nil value for directory listing")
+	}
+	// Should be valid JSON
+	var parsed DirectoryListingResult
+	if err := json.Unmarshal([]byte(*value), &parsed); err != nil {
+		t.Fatalf("directory listing value is not valid JSON: %v", err)
+	}
+	if len(parsed.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(parsed.Entries))
+	}
+}
+
+func TestBuildEvidence_ExtractsFileCaptureEvents(t *testing.T) {
+	capturePayload, _ := json.Marshal(FileCaptureResult{
+		Key:     "output_json",
+		Path:    "/workspace/output.json",
+		Exists:  true,
+		Content: `{"result": "ok"}`,
+		Size:    16,
+	})
+
+	events := []Event{
+		{Type: "system.run.started", OccurredAt: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), Payload: []byte(`{}`)},
+		{Type: "grader.verification.file_captured", OccurredAt: time.Date(2026, 4, 1, 0, 0, 1, 0, time.UTC), Payload: capturePayload},
+		{Type: "system.run.completed", OccurredAt: time.Date(2026, 4, 1, 0, 0, 2, 0, time.UTC), Payload: []byte(`{"final_output":"done"}`)},
+	}
+
+	evidence := buildEvidence(nil, events)
+	if evidence.capturedFiles == nil {
+		t.Fatal("capturedFiles should not be nil")
+	}
+	capture, ok := evidence.capturedFiles["output_json"]
+	if !ok {
+		t.Fatal("expected output_json in capturedFiles")
+	}
+	if !capture.Exists {
+		t.Fatal("expected file to exist")
+	}
+	if capture.Content != `{"result": "ok"}` {
+		t.Fatalf("content = %q, want %q", capture.Content, `{"result": "ok"}`)
+	}
+}
+
+func TestBuildEvidence_ExtractsDirectoryListingEvents(t *testing.T) {
+	listingPayload, _ := json.Marshal(DirectoryListingResult{
+		Key:  "project_structure",
+		Path: "/workspace/",
+		Entries: []DirectoryEntry{
+			{Path: "/workspace/main.py", Size: 100},
+			{Path: "/workspace/tests/", Size: 0, IsDir: true},
+		},
+	})
+
+	events := []Event{
+		{Type: "system.run.started", OccurredAt: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), Payload: []byte(`{}`)},
+		{Type: "grader.verification.directory_listed", OccurredAt: time.Date(2026, 4, 1, 0, 0, 1, 0, time.UTC), Payload: listingPayload},
+		{Type: "system.run.completed", OccurredAt: time.Date(2026, 4, 1, 0, 0, 2, 0, time.UTC), Payload: []byte(`{"final_output":"done"}`)},
+	}
+
+	evidence := buildEvidence(nil, events)
+	if evidence.capturedDirListings == nil {
+		t.Fatal("capturedDirListings should not be nil")
+	}
+	listing, ok := evidence.capturedDirListings["project_structure"]
+	if !ok {
+		t.Fatal("expected project_structure in capturedDirListings")
+	}
+	if len(listing.Entries) != 2 {
+		t.Fatalf("entries = %d, want 2", len(listing.Entries))
+	}
+}
+
+func TestEvaluateRunAgent_WithFileValidators(t *testing.T) {
+	capturePayload, _ := json.Marshal(FileCaptureResult{
+		Key:     "app_py_content",
+		Path:    "/workspace/app.py",
+		Exists:  true,
+		Content: "def main():\n    print('fixed')\n",
+		Size:    30,
+	})
+
+	spec := EvaluationSpec{
+		Name:          "file-check-fixture",
+		VersionNumber: 1,
+		JudgeMode:     JudgeModeDeterministic,
+		Validators: []ValidatorDeclaration{
+			{
+				Key:          "app_fixed",
+				Type:         ValidatorTypeFileContentMatch,
+				Target:       "file:app_py_content",
+				ExpectedFrom: "literal:fixed",
+				Config:       json.RawMessage(`{"match_mode": "contains"}`),
+			},
+			{
+				Key:    "app_exists",
+				Type:   ValidatorTypeFileExists,
+				Target: "file:app_py_content",
+				Config: json.RawMessage(`{"must_exist": true}`),
+			},
+		},
+		PostExecutionChecks: []PostExecutionCheck{
+			{Key: "app_py_content", Type: PostExecutionCheckTypeFileCapture, Path: "/workspace/app.py"},
+		},
+		Metrics: []MetricDeclaration{
+			{Key: "completed", Type: MetricTypeBoolean, Collector: "run_completed_successfully"},
+		},
+		Scorecard: ScorecardDeclaration{
+			Dimensions: []DimensionDeclaration{{Key: ScorecardDimensionCorrectness}, {Key: ScorecardDimensionReliability}},
+		},
+	}
+
+	evaluation, err := EvaluateRunAgent(EvaluationInput{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		Events: []Event{
+			{Type: "system.run.started", OccurredAt: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), Payload: []byte(`{}`)},
+			{Type: "grader.verification.file_captured", OccurredAt: time.Date(2026, 4, 1, 0, 0, 1, 0, time.UTC), Payload: capturePayload},
+			{Type: "system.run.completed", OccurredAt: time.Date(2026, 4, 1, 0, 0, 2, 0, time.UTC), Payload: []byte(`{"final_output":"done","total_tokens":5}`)},
+		},
+	}, spec)
+	if err != nil {
+		t.Fatalf("EvaluateRunAgent returned error: %v", err)
+	}
+
+	if len(evaluation.ValidatorResults) != 2 {
+		t.Fatalf("validator results = %d, want 2", len(evaluation.ValidatorResults))
+	}
+
+	// file_content_match
+	contentResult := evaluation.ValidatorResults[0]
+	if contentResult.Verdict != "pass" {
+		t.Fatalf("file_content_match verdict = %q, want pass (reason: %s)", contentResult.Verdict, contentResult.Reason)
+	}
+
+	// file_exists
+	existsResult := evaluation.ValidatorResults[1]
+	if existsResult.Verdict != "pass" {
+		t.Fatalf("file_exists verdict = %q, want pass (reason: %s)", existsResult.Verdict, existsResult.Reason)
+	}
+
+	if evaluation.DimensionScores[string(ScorecardDimensionCorrectness)] == nil || *evaluation.DimensionScores[string(ScorecardDimensionCorrectness)] != 1 {
+		t.Fatalf("correctness = %v, want 1.0", evaluation.DimensionScores[string(ScorecardDimensionCorrectness)])
+	}
+}
+
+func TestEvaluateRunAgent_FileExistsFail_WhenMissing(t *testing.T) {
+	capturePayload, _ := json.Marshal(FileCaptureResult{
+		Key:    "missing_file",
+		Path:   "/workspace/missing.py",
+		Exists: false,
+	})
+
+	spec := EvaluationSpec{
+		Name:          "file-missing-fixture",
+		VersionNumber: 1,
+		JudgeMode:     JudgeModeDeterministic,
+		Validators: []ValidatorDeclaration{
+			{
+				Key:    "file_must_exist",
+				Type:   ValidatorTypeFileExists,
+				Target: "file:missing_file",
+				Config: json.RawMessage(`{"must_exist": true}`),
+			},
+		},
+		PostExecutionChecks: []PostExecutionCheck{
+			{Key: "missing_file", Type: PostExecutionCheckTypeFileCapture, Path: "/workspace/missing.py"},
+		},
+		Scorecard: ScorecardDeclaration{
+			Dimensions: []DimensionDeclaration{{Key: ScorecardDimensionCorrectness}},
+		},
+	}
+
+	evaluation, err := EvaluateRunAgent(EvaluationInput{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		Events: []Event{
+			{Type: "system.run.started", OccurredAt: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), Payload: []byte(`{}`)},
+			{Type: "grader.verification.file_captured", OccurredAt: time.Date(2026, 4, 1, 0, 0, 1, 0, time.UTC), Payload: capturePayload},
+			{Type: "system.run.completed", OccurredAt: time.Date(2026, 4, 1, 0, 0, 2, 0, time.UTC), Payload: []byte(`{"final_output":"done"}`)},
+		},
+	}, spec)
+	if err != nil {
+		t.Fatalf("EvaluateRunAgent returned error: %v", err)
+	}
+
+	if len(evaluation.ValidatorResults) != 1 {
+		t.Fatalf("validator results = %d, want 1", len(evaluation.ValidatorResults))
+	}
+	result := evaluation.ValidatorResults[0]
+	if result.Verdict != "fail" {
+		t.Fatalf("file_exists verdict = %q, want fail (file doesn't exist)", result.Verdict)
+	}
+	if result.NormalizedScore == nil || *result.NormalizedScore != 0 {
+		t.Fatalf("normalized_score = %v, want 0", result.NormalizedScore)
+	}
+}
+
+func TestEvaluateRunAgent_NoCaptureEvents_ExistingPacksUnaffected(t *testing.T) {
+	// Existing packs without post_execution_checks should behave identically.
+	spec := EvaluationSpec{
+		Name:          "legacy-fixture",
+		VersionNumber: 1,
+		JudgeMode:     JudgeModeDeterministic,
+		Validators: []ValidatorDeclaration{
+			{
+				Key:          "exact",
+				Type:         ValidatorTypeExactMatch,
+				Target:       "final_output",
+				ExpectedFrom: "challenge_input",
+			},
+		},
+		Scorecard: ScorecardDeclaration{
+			Dimensions: []DimensionDeclaration{{Key: ScorecardDimensionCorrectness}},
+		},
+	}
+
+	evaluation, err := EvaluateRunAgent(EvaluationInput{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		ChallengeInputs: []EvidenceInput{
+			{ChallengeIdentityID: uuid.New(), ItemKey: "test", Payload: []byte(`"42"`)},
+		},
+		Events: []Event{
+			{Type: "system.run.started", OccurredAt: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), Payload: []byte(`{}`)},
+			{Type: "system.run.completed", OccurredAt: time.Date(2026, 4, 1, 0, 0, 2, 0, time.UTC), Payload: []byte(`{"final_output":"42"}`)},
+		},
+	}, spec)
+	if err != nil {
+		t.Fatalf("EvaluateRunAgent returned error: %v", err)
+	}
+	if evaluation.ValidatorResults[0].Verdict != "pass" {
+		t.Fatalf("legacy pack verdict = %q, want pass", evaluation.ValidatorResults[0].Verdict)
+	}
+}
+
+func TestPostExecutionCheck_EffectiveMaxSizeBytes(t *testing.T) {
+	check := PostExecutionCheck{Key: "test", Type: "file_capture", Path: "/test"}
+	if got := check.EffectiveMaxSizeBytes(); got != DefaultMaxFileSizeBytes {
+		t.Fatalf("default max size = %d, want %d", got, DefaultMaxFileSizeBytes)
+	}
+
+	check.MaxSizeBytes = 500
+	if got := check.EffectiveMaxSizeBytes(); got != 500 {
+		t.Fatalf("custom max size = %d, want 500", got)
+	}
+}

--- a/backend/internal/scoring/spec.go
+++ b/backend/internal/scoring/spec.go
@@ -23,6 +23,11 @@ const (
 	ValidatorTypeFuzzyMatch      ValidatorType = "fuzzy_match"
 	ValidatorTypeNumericMatch    ValidatorType = "numeric_match"
 	ValidatorTypeNormalizedMatch ValidatorType = "normalized_match"
+
+	ValidatorTypeFileContentMatch   ValidatorType = "file_content_match"
+	ValidatorTypeFileExists         ValidatorType = "file_exists"
+	ValidatorTypeFileJSONSchema     ValidatorType = "file_json_schema"
+	ValidatorTypeDirectoryStructure ValidatorType = "directory_structure"
 )
 
 type MetricType string
@@ -127,21 +132,22 @@ type DimensionNormalization struct {
 }
 
 type EvaluationSpec struct {
-	Name          string                 `json:"name"`
-	VersionNumber int32                  `json:"version_number"`
-	JudgeMode     JudgeMode              `json:"judge_mode"`
-	Validators    []ValidatorDeclaration `json:"validators"`
-	Metrics       []MetricDeclaration    `json:"metrics"`
-	RuntimeLimits RuntimeLimits          `json:"runtime_limits,omitempty"`
-	Pricing       PricingConfig          `json:"pricing,omitempty"`
-	Scorecard     ScorecardDeclaration   `json:"scorecard"`
+	Name                string                 `json:"name"`
+	VersionNumber       int32                  `json:"version_number"`
+	JudgeMode           JudgeMode              `json:"judge_mode"`
+	Validators          []ValidatorDeclaration `json:"validators"`
+	Metrics             []MetricDeclaration    `json:"metrics"`
+	PostExecutionChecks []PostExecutionCheck   `json:"post_execution_checks,omitempty"`
+	RuntimeLimits       RuntimeLimits          `json:"runtime_limits,omitempty"`
+	Pricing             PricingConfig          `json:"pricing,omitempty"`
+	Scorecard           ScorecardDeclaration   `json:"scorecard"`
 }
 
 type ValidatorDeclaration struct {
 	Key          string          `json:"key"`
 	Type         ValidatorType   `json:"type"`
 	Target       string          `json:"target"`
-	ExpectedFrom string          `json:"expected_from"`
+	ExpectedFrom string          `json:"expected_from,omitempty"`
 	Config       json.RawMessage `json:"config,omitempty"`
 }
 
@@ -204,11 +210,38 @@ func (m JudgeMode) IsValid() bool {
 
 func (t ValidatorType) IsValid() bool {
 	switch t {
-	case ValidatorTypeExactMatch, ValidatorTypeContains, ValidatorTypeRegexMatch, ValidatorTypeJSONSchema, ValidatorTypeJSONPathMatch, ValidatorTypeBooleanAssert,
-		ValidatorTypeFuzzyMatch, ValidatorTypeNumericMatch, ValidatorTypeNormalizedMatch:
+	case ValidatorTypeExactMatch, ValidatorTypeContains, ValidatorTypeRegexMatch,
+		ValidatorTypeJSONSchema, ValidatorTypeJSONPathMatch, ValidatorTypeBooleanAssert,
+		ValidatorTypeFuzzyMatch, ValidatorTypeNumericMatch, ValidatorTypeNormalizedMatch,
+		ValidatorTypeFileContentMatch, ValidatorTypeFileExists,
+		ValidatorTypeFileJSONSchema, ValidatorTypeDirectoryStructure:
 		return true
 	default:
 		return false
+	}
+}
+
+// IsFileValidator returns true for validator types that operate on captured
+// sandbox file/directory evidence rather than the agent's final output.
+func (t ValidatorType) IsFileValidator() bool {
+	switch t {
+	case ValidatorTypeFileContentMatch, ValidatorTypeFileExists,
+		ValidatorTypeFileJSONSchema, ValidatorTypeDirectoryStructure:
+		return true
+	default:
+		return false
+	}
+}
+
+// RequiresExpectedFrom returns true for validator types that need a non-empty
+// expected_from field. File validators that use config-only expectations
+// (file_exists, file_json_schema, directory_structure) return false.
+func (t ValidatorType) RequiresExpectedFrom() bool {
+	switch t {
+	case ValidatorTypeFileExists, ValidatorTypeFileJSONSchema, ValidatorTypeDirectoryStructure:
+		return false
+	default:
+		return true
 	}
 }
 

--- a/backend/internal/scoring/validation.go
+++ b/backend/internal/scoring/validation.go
@@ -94,10 +94,52 @@ func ValidateEvaluationSpec(spec EvaluationSpec) error {
 		} else if !isSupportedEvidenceReference(validator.Target) {
 			errs = append(errs, ValidationError{Field: path + ".target", Message: "must be a supported evidence reference"})
 		}
-		if strings.TrimSpace(validator.ExpectedFrom) == "" {
-			errs = append(errs, ValidationError{Field: path + ".expected_from", Message: "is required"})
-		} else if !isSupportedEvidenceReference(validator.ExpectedFrom) {
-			errs = append(errs, ValidationError{Field: path + ".expected_from", Message: "must be a supported evidence reference"})
+		if validator.Type.RequiresExpectedFrom() {
+			if strings.TrimSpace(validator.ExpectedFrom) == "" {
+				errs = append(errs, ValidationError{Field: path + ".expected_from", Message: "is required"})
+			} else if !isSupportedEvidenceReference(validator.ExpectedFrom) {
+				errs = append(errs, ValidationError{Field: path + ".expected_from", Message: "must be a supported evidence reference"})
+			}
+		}
+		if validator.Type.IsFileValidator() {
+			if strings.TrimSpace(validator.Target) != "" && !strings.HasPrefix(validator.Target, "file:") {
+				errs = append(errs, ValidationError{Field: path + ".target", Message: "must use file: prefix for file validators"})
+			}
+		}
+	}
+
+	checkKeys := map[string]struct{}{}
+	for i, check := range spec.PostExecutionChecks {
+		path := fmt.Sprintf("evaluation_spec.post_execution_checks[%d]", i)
+		key := strings.TrimSpace(check.Key)
+		if key == "" {
+			errs = append(errs, ValidationError{Field: path + ".key", Message: "is required"})
+		} else {
+			if _, exists := checkKeys[key]; exists {
+				errs = append(errs, ValidationError{Field: path + ".key", Message: "must be unique"})
+			}
+			checkKeys[key] = struct{}{}
+		}
+		if check.Type != PostExecutionCheckTypeFileCapture && check.Type != PostExecutionCheckTypeDirectoryListing {
+			errs = append(errs, ValidationError{Field: path + ".type", Message: "must be file_capture or directory_listing"})
+		}
+		if strings.TrimSpace(check.Path) == "" {
+			errs = append(errs, ValidationError{Field: path + ".path", Message: "is required"})
+		}
+		if check.MaxSizeBytes < 0 {
+			errs = append(errs, ValidationError{Field: path + ".max_size_bytes", Message: "must be greater than or equal to 0"})
+		}
+	}
+
+	// Cross-reference: file: targets in validators must reference a declared
+	// post_execution_checks key to catch typos at validation time.
+	for i, validator := range spec.Validators {
+		if strings.HasPrefix(validator.Target, "file:") {
+			refKey := strings.TrimPrefix(validator.Target, "file:")
+			if _, exists := checkKeys[refKey]; !exists && len(checkKeys) > 0 {
+				path := fmt.Sprintf("evaluation_spec.validators[%d]", i)
+				errs = append(errs, ValidationError{Field: path + ".target", Message: fmt.Sprintf("references unknown post_execution_check key %q", refKey)})
+			}
 		}
 	}
 
@@ -268,6 +310,7 @@ func normalizeEvaluationSpec(spec *EvaluationSpec) {
 	spec.Name = strings.TrimSpace(spec.Name)
 	spec.Validators = append([]ValidatorDeclaration(nil), spec.Validators...)
 	spec.Metrics = append([]MetricDeclaration(nil), spec.Metrics...)
+	spec.PostExecutionChecks = append([]PostExecutionCheck(nil), spec.PostExecutionChecks...)
 	spec.Pricing.Models = append([]ModelPricing(nil), spec.Pricing.Models...)
 	spec.Scorecard.Dimensions = append([]DimensionDeclaration(nil), spec.Scorecard.Dimensions...)
 
@@ -279,6 +322,10 @@ func normalizeEvaluationSpec(spec *EvaluationSpec) {
 		spec.Validators[i].Key = strings.TrimSpace(spec.Validators[i].Key)
 		spec.Validators[i].Target = strings.TrimSpace(spec.Validators[i].Target)
 		spec.Validators[i].ExpectedFrom = strings.TrimSpace(spec.Validators[i].ExpectedFrom)
+	}
+	for i := range spec.PostExecutionChecks {
+		spec.PostExecutionChecks[i].Key = strings.TrimSpace(spec.PostExecutionChecks[i].Key)
+		spec.PostExecutionChecks[i].Path = strings.TrimSpace(spec.PostExecutionChecks[i].Path)
 	}
 	for i := range spec.Metrics {
 		spec.Metrics[i].Key = strings.TrimSpace(spec.Metrics[i].Key)
@@ -367,6 +414,9 @@ func isSupportedEvidenceReference(value string) bool {
 		return hasValidDottedPathAfterPrefix(value, "case.expectations.")
 	case strings.HasPrefix(value, "artifact."):
 		return hasValidDottedPathAfterPrefix(value, "artifact.")
+	case strings.HasPrefix(value, "file:"):
+		remainder := strings.TrimPrefix(value, "file:")
+		return strings.TrimSpace(remainder) != ""
 	case strings.HasPrefix(value, "literal:"):
 		return true
 	default:

--- a/backend/internal/worker/buffered_observer.go
+++ b/backend/internal/worker/buffered_observer.go
@@ -121,6 +121,17 @@ func (b *BufferedObserver) OnStepEnd(ctx context.Context, step int) error {
 	return nil
 }
 
+func (b *BufferedObserver) OnPostExecutionVerification(ctx context.Context, results []engine.PostExecutionVerificationResult) error {
+	if err := b.checkBgError(); err != nil {
+		return err
+	}
+	bgCtx := context.WithoutCancel(ctx)
+	b.enqueue(func() error {
+		return b.inner.OnPostExecutionVerification(bgCtx, results)
+	})
+	return nil
+}
+
 // --- Terminal methods: flush then delegate synchronously ---
 
 func (b *BufferedObserver) OnRunComplete(ctx context.Context, result engine.Result) error {

--- a/backend/internal/worker/buffered_observer_test.go
+++ b/backend/internal/worker/buffered_observer_test.go
@@ -59,6 +59,10 @@ func (o *recordingObserver) OnStepEnd(_ context.Context, _ int) error {
 	o.record("OnStepEnd")
 	return nil
 }
+func (o *recordingObserver) OnPostExecutionVerification(_ context.Context, _ []engine.PostExecutionVerificationResult) error {
+	o.record("OnPostExecutionVerification")
+	return nil
+}
 func (o *recordingObserver) OnRunComplete(_ context.Context, _ engine.Result) error {
 	o.record("OnRunComplete")
 	return nil

--- a/backend/internal/worker/native_event_observer.go
+++ b/backend/internal/worker/native_event_observer.go
@@ -209,6 +209,36 @@ func (o *NativeRunEventObserver) OnStepEnd(ctx context.Context, step int) error 
 	})
 }
 
+func (o *NativeRunEventObserver) OnPostExecutionVerification(ctx context.Context, results []engine.PostExecutionVerificationResult) error {
+	if err := o.ensureRunStarted(ctx); err != nil {
+		return err
+	}
+	for _, result := range results {
+		var eventType runevents.Type
+		switch result.Type {
+		case "file_capture":
+			eventType = runevents.EventTypeGraderVerificationFileCaptured
+		case "directory_listing":
+			eventType = runevents.EventTypeGraderVerificationDirectoryListed
+		default:
+			continue
+		}
+
+		payload := make(map[string]any)
+		if len(result.Payload) > 0 {
+			_ = json.Unmarshal(result.Payload, &payload)
+		}
+		if err := o.recordEvent(ctx, eventType, payload, runevents.SummaryMetadata{
+			Status:        "captured",
+			StepIndex:     o.currentStep(),
+			EvidenceLevel: runevents.EvidenceLevelNativeStructured,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (o *NativeRunEventObserver) OnRunComplete(ctx context.Context, result engine.Result) error {
 	if err := o.ensureRunStarted(ctx); err != nil {
 		return err

--- a/backend/internal/worker/prompt_eval_event_observer.go
+++ b/backend/internal/worker/prompt_eval_event_observer.go
@@ -126,6 +126,10 @@ func (o *PromptEvalRunEventObserver) OnStepEnd(context.Context, int) error {
 	return nil
 }
 
+func (o *PromptEvalRunEventObserver) OnPostExecutionVerification(context.Context, []engine.PostExecutionVerificationResult) error {
+	return nil
+}
+
 func (o *PromptEvalRunEventObserver) OnRunComplete(ctx context.Context, result engine.Result) error {
 	if err := o.ensureRunStarted(ctx); err != nil {
 		return err


### PR DESCRIPTION
## Summary

- **File capture from sandbox**: Before the sandbox is destroyed, specified files and directory listings are read and emitted as `grader.verification.file_captured` / `grader.verification.directory_listed` events
- **4 new validator types**: `file_content_match` (exact/contains/regex/not_contains/json_equal), `file_exists`, `file_json_schema`, `directory_structure` — all operating on captured sandbox state
- **`file:` evidence prefix**: The scoring engine's `resolveEvidenceValue()` now supports `file:{check_key}` to reference captured file content, alongside existing `final_output`, `challenge_input`, `case.*`, `artifact.*`, and `literal:*` sources
- **Size limits**: Default 1MB per file, 10MB total per run, with per-check override via `max_size_bytes`
- **Backward compatible**: Packs without `post_execution_checks` behave identically to before

Closes #171

## What changed

### New event types (`runevents/envelope.go`)
- `grader.verification.file_captured` — file content read from sandbox
- `grader.verification.directory_listed` — directory listing captured
- `grader_verification` source constant

### Scoring engine extensions
- `PostExecutionChecks` field on `EvaluationSpec` (opt-in, omitempty)
- `Config` field on `ValidatorDeclaration` for config-driven validators
- `capturedFiles` / `capturedDirListings` in `extractedEvidence`
- `file:` prefix in `resolveEvidenceValue()` and `isSupportedEvidenceReference()`
- `evaluateValidators()` handles validators where `expected_from` is optional

### Execution pipeline
- `OnPostExecutionVerification` added to `Observer` interface (all 7 implementations updated)
- File capture runs at `native_executor.go` completion point — after agent submits but before sandbox destruction (defer LIFO ordering)
- `executor_verification.go` implements `ReadFile` / `ListFiles` calls with size enforcement

### New files
- `scoring/post_execution.go` — check/result types and size constants
- `scoring/file_validators.go` — 4 validator implementations
- `engine/executor_verification.go` — sandbox file capture execution

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test -short -race -count=1 ./...` — all 21 packages pass
- [x] File exists / not exists with `must_exist: true/false`
- [x] Content match: exact, contains, regex, not_contains, json_equal modes
- [x] Content match with ignore_whitespace
- [x] JSON schema validation against file content
- [x] Directory structure: required present/missing, forbidden absent/present
- [x] Size limit enforcement (truncation, total budget exhaustion)
- [x] Evidence resolution with `file:` prefix: found, not found, file absent
- [x] Full integration: `EvaluateRunAgent` with file-based validators + verification events
- [x] Backward compatibility: existing packs without file checks work identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)