### PR TITLE
feat: rate limiting, spend policy enforcement, and routing policy framework

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/api"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/budget"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/storage"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/temporalutil"
@@ -55,10 +56,12 @@ func main() {
 	}
 	artifactManager := api.NewArtifactManager(authorizer, repo, artifactStore, cfg.ArtifactSigningSecret, cfg.ArtifactSignedURLTTL, cfg.ArtifactMaxUploadBytes)
 	playgroundManager := api.NewPlaygroundManager(authorizer, repo, api.NewTemporalPlaygroundWorkflowStarter(temporalClient))
+	budgetChecker := budget.NewChecker(repository.NewBudgetRepositoryAdapter(repo))
 	runCreationManager := api.NewRunCreationManager(
 		authorizer,
 		repo,
 		api.NewTemporalRunWorkflowStarter(temporalClient),
+		budgetChecker,
 	)
 	runReadManager := api.NewRunReadManager(authorizer, repo)
 	replayReadManager := api.NewReplayReadManager(authorizer, repo)

--- a/backend/db/migrations/00020_spend_tracking.sql
+++ b/backend/db/migrations/00020_spend_tracking.sql
@@ -1,0 +1,56 @@
+-- +goose Up
+
+-- Pricing columns on model catalog so we can compute cost at execution time.
+ALTER TABLE model_catalog_entries
+ADD COLUMN input_cost_per_million_tokens numeric(18,6) NOT NULL DEFAULT 0,
+ADD COLUMN output_cost_per_million_tokens numeric(18,6) NOT NULL DEFAULT 0;
+
+-- Per-run cost snapshot, written after scoring completes.
+CREATE TABLE run_cost_summaries (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    run_id uuid NOT NULL UNIQUE REFERENCES runs (id) ON DELETE CASCADE,
+    workspace_id uuid NOT NULL,
+    total_cost_usd numeric(18,6) NOT NULL DEFAULT 0,
+    total_input_tokens bigint NOT NULL DEFAULT 0,
+    total_output_tokens bigint NOT NULL DEFAULT 0,
+    cost_breakdown jsonb NOT NULL DEFAULT '[]'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX run_cost_summaries_workspace_idx
+ON run_cost_summaries (workspace_id, created_at);
+
+-- Accumulates actual spend per (spend_policy, window). Upserted after each run.
+CREATE TABLE workspace_spend_ledger (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id uuid NOT NULL REFERENCES organizations (id) ON DELETE CASCADE,
+    workspace_id uuid NOT NULL,
+    spend_policy_id uuid NOT NULL REFERENCES spend_policies (id) ON DELETE CASCADE,
+    window_start timestamptz NOT NULL,
+    window_end timestamptz NOT NULL,
+    total_cost_usd numeric(18,6) NOT NULL DEFAULT 0,
+    total_input_tokens bigint NOT NULL DEFAULT 0,
+    total_output_tokens bigint NOT NULL DEFAULT 0,
+    run_count int NOT NULL DEFAULT 0,
+    last_run_id uuid REFERENCES runs (id) ON DELETE SET NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    FOREIGN KEY (workspace_id, organization_id) REFERENCES workspaces (id, organization_id) ON DELETE CASCADE,
+    UNIQUE (spend_policy_id, window_start)
+);
+
+CREATE INDEX workspace_spend_ledger_workspace_window_idx
+ON workspace_spend_ledger (workspace_id, window_start, window_end);
+
+CREATE TRIGGER workspace_spend_ledger_set_updated_at
+BEFORE UPDATE ON workspace_spend_ledger
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+-- +goose Down
+DROP TRIGGER IF EXISTS workspace_spend_ledger_set_updated_at ON workspace_spend_ledger;
+DROP TABLE IF EXISTS workspace_spend_ledger;
+DROP TABLE IF EXISTS run_cost_summaries;
+ALTER TABLE model_catalog_entries
+DROP COLUMN IF EXISTS input_cost_per_million_tokens,
+DROP COLUMN IF EXISTS output_cost_per_million_tokens;

--- a/backend/db/queries/run_creation.sql
+++ b/backend/db/queries/run_creation.sql
@@ -19,7 +19,9 @@ SELECT DISTINCT ON (agent_deployments.id)
     agent_deployments.organization_id,
     agent_deployments.workspace_id,
     agent_deployments.name,
-    agent_deployment_snapshots.id AS agent_deployment_snapshot_id
+    agent_deployment_snapshots.id AS agent_deployment_snapshot_id,
+    agent_deployments.spend_policy_id,
+    agent_deployments.routing_policy_id
 FROM agent_deployments
 JOIN agent_deployment_snapshots
   ON agent_deployment_snapshots.agent_deployment_id = agent_deployments.id

--- a/backend/db/queries/worker_execution_context.sql
+++ b/backend/db/queries/worker_execution_context.sql
@@ -95,7 +95,9 @@ SELECT
     mce.display_name AS model_catalog_display_name,
     mce.model_family AS model_catalog_model_family,
     mce.modality AS model_catalog_modality,
-    mce.metadata AS model_catalog_metadata
+    mce.metadata AS model_catalog_metadata,
+    mce.input_cost_per_million_tokens AS model_catalog_input_cost_per_million_tokens,
+    mce.output_cost_per_million_tokens AS model_catalog_output_cost_per_million_tokens
 FROM run_agents AS ra
 JOIN runs AS r
   ON r.id = ra.run_id

--- a/backend/internal/api/config.go
+++ b/backend/internal/api/config.go
@@ -29,6 +29,10 @@ const (
 	defaultArtifactStorageBucket   = "agentclash-dev-artifacts"
 	defaultArtifactSignedURLTTL    = 5 * time.Minute
 	defaultArtifactMaxUploadBytes  = 100 << 20
+	defaultRateLimitRPS            = 10.0
+	defaultRateLimitBurst          = 20
+	defaultRateLimitRunCreationRPM = 30.0
+	defaultRateLimitRunCreationBurst = 10
 )
 
 var ErrInvalidConfig = errors.New("invalid api server config")
@@ -57,6 +61,10 @@ type Config struct {
 	ArtifactSignedURLTTL     time.Duration
 	ArtifactMaxUploadBytes   int64
 	SecretsCipher            *secrets.AESGCMCipher
+	RateLimitRPS             float64
+	RateLimitBurst           int
+	RateLimitRunCreationRPM  float64
+	RateLimitRunCreationBurst int
 }
 
 func LoadConfigFromEnv() (Config, error) {
@@ -165,7 +173,11 @@ func LoadConfigFromEnv() (Config, error) {
 		ArtifactS3ForcePathStyle: artifactS3ForcePathStyle,
 		ArtifactSigningSecret:    artifactSigningSecret,
 		ArtifactSignedURLTTL:     artifactSignedURLTTL,
-		ArtifactMaxUploadBytes:   artifactMaxUploadBytes,
+		ArtifactMaxUploadBytes:    artifactMaxUploadBytes,
+		RateLimitRPS:              defaultRateLimitRPS,
+		RateLimitBurst:            defaultRateLimitBurst,
+		RateLimitRunCreationRPM:   defaultRateLimitRunCreationRPM,
+		RateLimitRunCreationBurst: defaultRateLimitRunCreationBurst,
 	}
 
 	if err := validateArtifactConfig(cfg); err != nil {

--- a/backend/internal/api/permissions_test.go
+++ b/backend/internal/api/permissions_test.go
@@ -353,7 +353,7 @@ func TestRunCreation_ViewerDenied(t *testing.T) {
 		},
 	}
 
-	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), &fakeRunCreationRepository{}, &fakeRunWorkflowStarter{})
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), &fakeRunCreationRepository{}, &fakeRunWorkflowStarter{}, nil)
 
 	_, err := manager.CreateRun(context.Background(), caller, CreateRunInput{
 		WorkspaceID:        workspaceID,

--- a/backend/internal/api/run_service.go
+++ b/backend/internal/api/run_service.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"time"
 
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/budget"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
 	"github.com/google/uuid"
 )
@@ -25,6 +27,7 @@ type RunCreationManager struct {
 	authorizer      WorkspaceAuthorizer
 	repo            RunCreationRepository
 	workflowStarter RunWorkflowStarter
+	budgetChecker   budget.BudgetChecker
 	now             func() time.Time
 }
 
@@ -32,11 +35,16 @@ func NewRunCreationManager(
 	authorizer WorkspaceAuthorizer,
 	repo RunCreationRepository,
 	workflowStarter RunWorkflowStarter,
+	budgetChecker budget.BudgetChecker,
 ) *RunCreationManager {
+	if budgetChecker == nil {
+		budgetChecker = budget.NoopChecker{}
+	}
 	return &RunCreationManager{
 		authorizer:      authorizer,
 		repo:            repo,
 		workflowStarter: workflowStarter,
+		budgetChecker:   budgetChecker,
 		now:             time.Now,
 	}
 }
@@ -119,6 +127,36 @@ func (m *RunCreationManager) CreateRun(ctx context.Context, caller Caller, input
 	for _, deployment := range deployments[1:] {
 		if deployment.OrganizationID != organizationID {
 			return CreateRunResult{}, fmt.Errorf("deployments in workspace %s resolved to multiple organizations", input.WorkspaceID)
+		}
+	}
+
+	// Pre-run spend policy check: reject if any deployment's spend policy budget is exceeded.
+	checkedPolicies := make(map[uuid.UUID]struct{})
+	for _, deployment := range deployments {
+		if deployment.SpendPolicyID == nil {
+			continue
+		}
+		if _, already := checkedPolicies[*deployment.SpendPolicyID]; already {
+			continue
+		}
+		checkedPolicies[*deployment.SpendPolicyID] = struct{}{}
+
+		result, err := m.budgetChecker.CheckPreRunBudget(ctx, input.WorkspaceID, *deployment.SpendPolicyID)
+		if err != nil {
+			return CreateRunResult{}, fmt.Errorf("check spend policy budget: %w", err)
+		}
+		if !result.Allowed {
+			return CreateRunResult{}, RunCreationValidationError{
+				Code:    "budget_exceeded",
+				Message: fmt.Sprintf("workspace spend limit exceeded (current: $%.2f, limit: $%.2f)", result.CurrentSpend, *result.HardLimit),
+			}
+		}
+		if result.SoftLimitHit {
+			slog.Default().Warn("spend policy soft limit reached",
+				"workspace_id", input.WorkspaceID,
+				"spend_policy_id", *deployment.SpendPolicyID,
+				"current_spend", result.CurrentSpend,
+			)
 		}
 	}
 

--- a/backend/internal/api/run_service_test.go
+++ b/backend/internal/api/run_service_test.go
@@ -47,7 +47,7 @@ func TestRunCreationManagerCreatesQueuedRunAndStartsWorkflow(t *testing.T) {
 		},
 	}
 	starter := &fakeRunWorkflowStarter{}
-	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, starter)
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, starter, nil)
 	manager.now = func() time.Time {
 		return time.Date(2026, 3, 13, 12, 0, 0, 0, time.UTC)
 	}
@@ -119,7 +119,7 @@ func TestRunCreationManagerReturnsQueuedRunOnWorkflowStartFailure(t *testing.T) 
 		},
 	}
 	starter := &fakeRunWorkflowStarter{err: errors.New("temporal unavailable")}
-	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, starter)
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, starter, nil)
 
 	_, err := manager.CreateRun(context.Background(), caller, CreateRunInput{
 		WorkspaceID:            workspaceID,
@@ -150,7 +150,7 @@ func TestRunCreationManagerRejectsDuplicateDeployments(t *testing.T) {
 		},
 	}
 
-	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), &fakeRunCreationRepository{}, &fakeRunWorkflowStarter{})
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), &fakeRunCreationRepository{}, &fakeRunWorkflowStarter{}, nil)
 
 	_, err := manager.CreateRun(context.Background(), caller, CreateRunInput{
 		WorkspaceID:            workspaceID,
@@ -172,7 +172,7 @@ func TestRunCreationManagerRejectsDuplicateDeployments(t *testing.T) {
 
 func TestRunCreationManagerRejectsEmptyDeployments(t *testing.T) {
 	workspaceID := uuid.New()
-	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), &fakeRunCreationRepository{}, &fakeRunWorkflowStarter{})
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), &fakeRunCreationRepository{}, &fakeRunWorkflowStarter{}, nil)
 
 	_, err := manager.CreateRun(context.Background(), Caller{
 		UserID: uuid.New(),
@@ -202,7 +202,7 @@ func TestRunCreationManagerRejectsChallengePackVersionNotFound(t *testing.T) {
 	deploymentID := uuid.New()
 	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), &fakeRunCreationRepository{
 		challengePackVersionErr: repository.ErrChallengePackVersionNotFound,
-	}, &fakeRunWorkflowStarter{})
+	}, &fakeRunWorkflowStarter{}, nil)
 
 	_, err := manager.CreateRun(context.Background(), Caller{
 		UserID: uuid.New(),
@@ -254,7 +254,7 @@ func TestRunCreationManagerRejectsChallengeInputSetFromAnotherPackVersion(t *tes
 				AgentDeploymentSnapshotID: uuid.New(),
 			},
 		},
-	}, &fakeRunWorkflowStarter{})
+	}, &fakeRunWorkflowStarter{}, nil)
 
 	_, err := manager.CreateRun(context.Background(), caller, CreateRunInput{
 		WorkspaceID:            workspaceID,
@@ -292,7 +292,7 @@ func TestRunCreationManagerRejectsMissingChallengeInputSet(t *testing.T) {
 				AgentDeploymentSnapshotID: uuid.New(),
 			},
 		},
-	}, &fakeRunWorkflowStarter{})
+	}, &fakeRunWorkflowStarter{}, nil)
 
 	_, err := manager.CreateRun(context.Background(), Caller{
 		UserID: uuid.New(),
@@ -325,7 +325,7 @@ func TestRunCreationManagerRejectsDeploymentOutsideWorkspace(t *testing.T) {
 	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), &fakeRunCreationRepository{
 		challengePackVersion: repository.RunnableChallengePackVersion{ID: challengePackVersionID},
 		deployments:          nil,
-	}, &fakeRunWorkflowStarter{})
+	}, &fakeRunWorkflowStarter{}, nil)
 
 	_, err := manager.CreateRun(context.Background(), Caller{
 		UserID: uuid.New(),
@@ -352,7 +352,7 @@ func TestRunCreationManagerRejectsDeploymentOutsideWorkspace(t *testing.T) {
 
 func TestRunCreationManagerRejectsForbiddenWorkspaceAccess(t *testing.T) {
 	workspaceID := uuid.New()
-	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), &fakeRunCreationRepository{}, &fakeRunWorkflowStarter{})
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), &fakeRunCreationRepository{}, &fakeRunWorkflowStarter{}, nil)
 
 	_, err := manager.CreateRun(context.Background(), Caller{
 		UserID:               uuid.New(),

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/ratelimit"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -159,8 +160,23 @@ func newRouter(
 	router.Get("/healthz", healthzHandler)
 	registerPublicRoutes(router, logger, artifactService)
 	registerHostedIntegrationRoutes(router, logger, hostedRunIngestionService)
+	rateLimiter := ratelimit.NewLimiter(ratelimit.Config{
+		DefaultRPS:         defaultRateLimitRPS,
+		DefaultBurst:       defaultRateLimitBurst,
+		RunCreationRPM:     defaultRateLimitRunCreationRPM,
+		RunCreationBurst:   defaultRateLimitRunCreationBurst,
+	})
+	extractWorkspaceID := func(r *http.Request) (uuid.UUID, bool) {
+		wsID, err := WorkspaceIDFromContext(r.Context())
+		if err != nil {
+			return uuid.Nil, false
+		}
+		return wsID, true
+	}
+
 	router.Route("/v1", func(r chi.Router) {
 		r.Use(authenticateRequest(logger, authenticator))
+		r.Use(rateLimiter.Middleware("default", extractWorkspaceID))
 		registerProtectedRoutes(r, logger, authorizer, playgroundService, artifactService, artifactMaxUploadBytes, runCreationService, runReadService, replayReadService, compareReadService, releaseGateService, agentDeploymentReadService, challengePackReadService, challengePackAuthoringService, agentBuildService, userService, orgService, wsService, orgMembershipService, wsMembershipService, onboardingService, infraService, workspaceSecretsService)
 	})
 

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"time"
 
+	"strings"
+
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/ratelimit"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
 	"github.com/go-chi/chi/v5"
@@ -167,7 +169,21 @@ func newRouter(
 		RunCreationBurst:   defaultRateLimitRunCreationBurst,
 	})
 	extractWorkspaceID := func(r *http.Request) (uuid.UUID, bool) {
-		wsID, err := WorkspaceIDFromContext(r.Context())
+		// Try context first (set by authorizeWorkspaceAccess middleware).
+		if wsID, err := WorkspaceIDFromContext(r.Context()); err == nil {
+			return wsID, true
+		}
+		// Fall back to parsing from URL path (/v1/workspaces/{workspaceID}/...).
+		const prefix = "/workspaces/"
+		idx := strings.Index(r.URL.Path, prefix)
+		if idx < 0 {
+			return uuid.Nil, false
+		}
+		rest := r.URL.Path[idx+len(prefix):]
+		if slashIdx := strings.IndexByte(rest, '/'); slashIdx > 0 {
+			rest = rest[:slashIdx]
+		}
+		wsID, err := uuid.Parse(rest)
 		if err != nil {
 			return uuid.Nil, false
 		}

--- a/backend/internal/budget/budget.go
+++ b/backend/internal/budget/budget.go
@@ -1,0 +1,63 @@
+package budget
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// SpendPolicy defines budget limits for a workspace over a rolling window.
+type SpendPolicy struct {
+	ID           uuid.UUID
+	WorkspaceID  uuid.UUID
+	WindowKind   string
+	SoftLimit    *float64
+	HardLimit    *float64
+	CurrencyCode string
+}
+
+// WindowSpend holds aggregated spend data for a single budget window.
+type WindowSpend struct {
+	TotalCostUSD      float64
+	TotalInputTokens  int64
+	TotalOutputTokens int64
+	RunCount          int
+	WindowStart       time.Time
+	WindowEnd         time.Time
+}
+
+// BudgetCheckResult is the outcome of a pre-run budget check.
+type BudgetCheckResult struct {
+	Allowed         bool
+	SoftLimitHit    bool
+	CurrentSpend    float64
+	HardLimit       *float64
+	SoftLimit       *float64
+	RemainingBudget *float64
+	WindowStart     time.Time
+	WindowEnd       time.Time
+}
+
+// RecordRunCostParams contains the data needed to record a run's cost.
+type RecordRunCostParams struct {
+	RunID           uuid.UUID
+	OrganizationID  uuid.UUID
+	WorkspaceID     uuid.UUID
+	SpendPolicyID   uuid.UUID
+	WindowKind      string
+	TotalCostUSD    float64
+	TotalInputTokens  int64
+	TotalOutputTokens int64
+	CostBreakdown   []byte // json
+}
+
+// BudgetChecker determines whether a run is allowed under the current budget.
+type BudgetChecker interface {
+	CheckPreRunBudget(ctx context.Context, workspaceID uuid.UUID, spendPolicyID uuid.UUID) (BudgetCheckResult, error)
+}
+
+// CostRecorder persists cost data after a run completes.
+type CostRecorder interface {
+	RecordRunCost(ctx context.Context, params RecordRunCostParams) error
+}

--- a/backend/internal/budget/checker.go
+++ b/backend/internal/budget/checker.go
@@ -1,0 +1,141 @@
+package budget
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ErrPolicyNotFound is returned when a spend policy does not exist.
+var ErrPolicyNotFound = errors.New("budget: spend policy not found")
+
+// Repository is the data-access interface required by the budget checker.
+type Repository interface {
+	GetSpendPolicyByID(ctx context.Context, id uuid.UUID) (SpendPolicy, error)
+	GetWindowSpend(ctx context.Context, spendPolicyID uuid.UUID, windowStart, windowEnd time.Time) (WindowSpend, error)
+	UpsertWindowSpend(ctx context.Context, params UpsertWindowSpendParams) error
+	CreateRunCostSummary(ctx context.Context, params CreateRunCostSummaryParams) error
+}
+
+// UpsertWindowSpendParams holds parameters for upserting a window spend entry.
+type UpsertWindowSpendParams struct {
+	OrganizationID uuid.UUID
+	WorkspaceID    uuid.UUID
+	SpendPolicyID  uuid.UUID
+	WindowStart    time.Time
+	WindowEnd      time.Time
+	CostUSD        float64
+	InputTokens    int64
+	OutputTokens   int64
+	RunID          uuid.UUID
+}
+
+// CreateRunCostSummaryParams holds parameters for creating a run cost summary.
+type CreateRunCostSummaryParams struct {
+	RunID             uuid.UUID
+	WorkspaceID       uuid.UUID
+	TotalCostUSD      float64
+	TotalInputTokens  int64
+	TotalOutputTokens int64
+	CostBreakdown     []byte
+}
+
+// Checker implements BudgetChecker and CostRecorder.
+type Checker struct {
+	repo Repository
+	now  func() time.Time // injectable clock for testing
+}
+
+// NewChecker creates a Checker backed by the given repository.
+func NewChecker(repo Repository) *Checker {
+	return &Checker{repo: repo, now: time.Now}
+}
+
+// CheckPreRunBudget determines whether a new run is allowed under the spend
+// policy's budget window. It implements the BudgetChecker interface.
+func (c *Checker) CheckPreRunBudget(ctx context.Context, workspaceID uuid.UUID, spendPolicyID uuid.UUID) (BudgetCheckResult, error) {
+	policy, err := c.repo.GetSpendPolicyByID(ctx, spendPolicyID)
+	if errors.Is(err, ErrPolicyNotFound) {
+		return BudgetCheckResult{Allowed: true}, nil
+	}
+	if err != nil {
+		return BudgetCheckResult{}, err
+	}
+
+	// Per-run policies never block future runs.
+	if policy.WindowKind == "run" {
+		return BudgetCheckResult{Allowed: true}, nil
+	}
+
+	windowStart, windowEnd := ComputeWindow(policy.WindowKind, c.now())
+
+	spend, err := c.repo.GetWindowSpend(ctx, spendPolicyID, windowStart, windowEnd)
+	if err != nil {
+		return BudgetCheckResult{}, err
+	}
+
+	result := BudgetCheckResult{
+		Allowed:      true,
+		CurrentSpend: spend.TotalCostUSD,
+		HardLimit:    policy.HardLimit,
+		SoftLimit:    policy.SoftLimit,
+		WindowStart:  windowStart,
+		WindowEnd:    windowEnd,
+	}
+
+	// Compute remaining budget relative to hard limit.
+	if policy.HardLimit != nil {
+		remaining := *policy.HardLimit - spend.TotalCostUSD
+		result.RemainingBudget = &remaining
+	}
+
+	// Hard limit check: block the run if spend meets or exceeds the limit.
+	if policy.HardLimit != nil && spend.TotalCostUSD >= *policy.HardLimit {
+		result.Allowed = false
+		return result, nil
+	}
+
+	// Soft limit check: allow but flag.
+	if policy.SoftLimit != nil && spend.TotalCostUSD >= *policy.SoftLimit {
+		result.SoftLimitHit = true
+	}
+
+	return result, nil
+}
+
+// RecordRunCost persists a run's cost summary and updates the ledger window.
+// It implements the CostRecorder interface.
+func (c *Checker) RecordRunCost(ctx context.Context, params RecordRunCostParams) error {
+	windowStart, windowEnd := ComputeWindow(params.WindowKind, c.now())
+
+	err := c.repo.CreateRunCostSummary(ctx, CreateRunCostSummaryParams{
+		RunID:             params.RunID,
+		WorkspaceID:       params.WorkspaceID,
+		TotalCostUSD:      params.TotalCostUSD,
+		TotalInputTokens:  params.TotalInputTokens,
+		TotalOutputTokens: params.TotalOutputTokens,
+		CostBreakdown:     params.CostBreakdown,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Per-run windows have no aggregation ledger.
+	if params.WindowKind == "run" {
+		return nil
+	}
+
+	return c.repo.UpsertWindowSpend(ctx, UpsertWindowSpendParams{
+		OrganizationID: params.OrganizationID,
+		WorkspaceID:    params.WorkspaceID,
+		SpendPolicyID:  params.SpendPolicyID,
+		WindowStart:    windowStart,
+		WindowEnd:      windowEnd,
+		CostUSD:        params.TotalCostUSD,
+		InputTokens:    params.TotalInputTokens,
+		OutputTokens:   params.TotalOutputTokens,
+		RunID:          params.RunID,
+	})
+}

--- a/backend/internal/budget/checker_test.go
+++ b/backend/internal/budget/checker_test.go
@@ -1,0 +1,377 @@
+package budget
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// mockRepository implements Repository for testing using in-memory maps.
+type mockRepository struct {
+	policies     map[uuid.UUID]SpendPolicy
+	windowSpends map[uuid.UUID]WindowSpend // keyed by spendPolicyID
+
+	createdSummaries []CreateRunCostSummaryParams
+	upsertedSpends   []UpsertWindowSpendParams
+}
+
+func newMockRepository() *mockRepository {
+	return &mockRepository{
+		policies:     make(map[uuid.UUID]SpendPolicy),
+		windowSpends: make(map[uuid.UUID]WindowSpend),
+	}
+}
+
+func (m *mockRepository) GetSpendPolicyByID(_ context.Context, id uuid.UUID) (SpendPolicy, error) {
+	p, ok := m.policies[id]
+	if !ok {
+		return SpendPolicy{}, ErrPolicyNotFound
+	}
+	return p, nil
+}
+
+func (m *mockRepository) GetWindowSpend(_ context.Context, spendPolicyID uuid.UUID, _, _ time.Time) (WindowSpend, error) {
+	ws, ok := m.windowSpends[spendPolicyID]
+	if !ok {
+		return WindowSpend{}, nil // no spend yet
+	}
+	return ws, nil
+}
+
+func (m *mockRepository) UpsertWindowSpend(_ context.Context, params UpsertWindowSpendParams) error {
+	m.upsertedSpends = append(m.upsertedSpends, params)
+	return nil
+}
+
+func (m *mockRepository) CreateRunCostSummary(_ context.Context, params CreateRunCostSummaryParams) error {
+	m.createdSummaries = append(m.createdSummaries, params)
+	return nil
+}
+
+func ptr(f float64) *float64 { return &f }
+
+func fixedNow() time.Time {
+	return time.Date(2024, 3, 15, 14, 0, 0, 0, time.UTC)
+}
+
+func newTestChecker(repo *mockRepository) *Checker {
+	c := NewChecker(repo)
+	c.now = fixedNow
+	return c
+}
+
+func TestCheckPreRunBudget_NoPolicyFound(t *testing.T) {
+	repo := newMockRepository()
+	c := newTestChecker(repo)
+
+	result, err := c.CheckPreRunBudget(context.Background(), uuid.New(), uuid.New())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Allowed {
+		t.Error("expected Allowed=true when policy not found")
+	}
+}
+
+func TestCheckPreRunBudget_NoLimits(t *testing.T) {
+	repo := newMockRepository()
+	c := newTestChecker(repo)
+
+	policyID := uuid.New()
+	repo.policies[policyID] = SpendPolicy{
+		ID:           policyID,
+		WorkspaceID:  uuid.New(),
+		WindowKind:   "month",
+		SoftLimit:    nil,
+		HardLimit:    nil,
+		CurrencyCode: "USD",
+	}
+
+	result, err := c.CheckPreRunBudget(context.Background(), uuid.New(), policyID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Allowed {
+		t.Error("expected Allowed=true when no limits set")
+	}
+	if result.SoftLimitHit {
+		t.Error("expected SoftLimitHit=false when no limits set")
+	}
+	if result.RemainingBudget != nil {
+		t.Error("expected RemainingBudget=nil when no hard limit")
+	}
+}
+
+func TestCheckPreRunBudget_UnderHardLimit(t *testing.T) {
+	repo := newMockRepository()
+	c := newTestChecker(repo)
+
+	policyID := uuid.New()
+	repo.policies[policyID] = SpendPolicy{
+		ID:           policyID,
+		WorkspaceID:  uuid.New(),
+		WindowKind:   "month",
+		HardLimit:    ptr(100.0),
+		CurrencyCode: "USD",
+	}
+	repo.windowSpends[policyID] = WindowSpend{
+		TotalCostUSD: 50.0,
+		RunCount:     5,
+	}
+
+	result, err := c.CheckPreRunBudget(context.Background(), uuid.New(), policyID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Allowed {
+		t.Error("expected Allowed=true when under hard limit")
+	}
+	if result.CurrentSpend != 50.0 {
+		t.Errorf("CurrentSpend = %v, want 50.0", result.CurrentSpend)
+	}
+	if result.RemainingBudget == nil || *result.RemainingBudget != 50.0 {
+		t.Errorf("RemainingBudget = %v, want 50.0", result.RemainingBudget)
+	}
+}
+
+func TestCheckPreRunBudget_AtHardLimit(t *testing.T) {
+	repo := newMockRepository()
+	c := newTestChecker(repo)
+
+	policyID := uuid.New()
+	repo.policies[policyID] = SpendPolicy{
+		ID:           policyID,
+		WorkspaceID:  uuid.New(),
+		WindowKind:   "month",
+		HardLimit:    ptr(100.0),
+		CurrencyCode: "USD",
+	}
+	repo.windowSpends[policyID] = WindowSpend{
+		TotalCostUSD: 100.0,
+		RunCount:     10,
+	}
+
+	result, err := c.CheckPreRunBudget(context.Background(), uuid.New(), policyID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Allowed {
+		t.Error("expected Allowed=false when at hard limit")
+	}
+	if result.RemainingBudget == nil || *result.RemainingBudget != 0.0 {
+		t.Errorf("RemainingBudget = %v, want 0.0", result.RemainingBudget)
+	}
+}
+
+func TestCheckPreRunBudget_OverHardLimit(t *testing.T) {
+	repo := newMockRepository()
+	c := newTestChecker(repo)
+
+	policyID := uuid.New()
+	repo.policies[policyID] = SpendPolicy{
+		ID:           policyID,
+		WorkspaceID:  uuid.New(),
+		WindowKind:   "day",
+		HardLimit:    ptr(50.0),
+		CurrencyCode: "USD",
+	}
+	repo.windowSpends[policyID] = WindowSpend{
+		TotalCostUSD: 75.0,
+	}
+
+	result, err := c.CheckPreRunBudget(context.Background(), uuid.New(), policyID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Allowed {
+		t.Error("expected Allowed=false when over hard limit")
+	}
+}
+
+func TestCheckPreRunBudget_SoftLimitHit(t *testing.T) {
+	repo := newMockRepository()
+	c := newTestChecker(repo)
+
+	policyID := uuid.New()
+	repo.policies[policyID] = SpendPolicy{
+		ID:           policyID,
+		WorkspaceID:  uuid.New(),
+		WindowKind:   "week",
+		SoftLimit:    ptr(80.0),
+		HardLimit:    ptr(100.0),
+		CurrencyCode: "USD",
+	}
+	repo.windowSpends[policyID] = WindowSpend{
+		TotalCostUSD: 85.0,
+		RunCount:     8,
+	}
+
+	result, err := c.CheckPreRunBudget(context.Background(), uuid.New(), policyID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Allowed {
+		t.Error("expected Allowed=true when only soft limit hit")
+	}
+	if !result.SoftLimitHit {
+		t.Error("expected SoftLimitHit=true")
+	}
+	if result.RemainingBudget == nil || *result.RemainingBudget != 15.0 {
+		t.Errorf("RemainingBudget = %v, want 15.0", result.RemainingBudget)
+	}
+}
+
+func TestCheckPreRunBudget_RunWindowKind(t *testing.T) {
+	repo := newMockRepository()
+	c := newTestChecker(repo)
+
+	policyID := uuid.New()
+	repo.policies[policyID] = SpendPolicy{
+		ID:           policyID,
+		WorkspaceID:  uuid.New(),
+		WindowKind:   "run",
+		HardLimit:    ptr(10.0),
+		CurrencyCode: "USD",
+	}
+
+	result, err := c.CheckPreRunBudget(context.Background(), uuid.New(), policyID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Allowed {
+		t.Error("expected Allowed=true for per-run window kind")
+	}
+}
+
+func TestCheckPreRunBudget_RepositoryError(t *testing.T) {
+	repo := newMockRepository()
+	c := newTestChecker(repo)
+
+	// Use a policyID that exists but will cause GetWindowSpend to fail.
+	policyID := uuid.New()
+	repo.policies[policyID] = SpendPolicy{
+		ID:           policyID,
+		WorkspaceID:  uuid.New(),
+		WindowKind:   "month",
+		HardLimit:    ptr(100.0),
+		CurrencyCode: "USD",
+	}
+
+	// Replace the repo with one that returns an error from GetWindowSpend.
+	errRepo := &errorRepository{
+		mockRepository:   repo,
+		getWindowSpendErr: errors.New("db connection failed"),
+	}
+	c.repo = errRepo
+
+	_, err := c.CheckPreRunBudget(context.Background(), uuid.New(), policyID)
+	if err == nil {
+		t.Fatal("expected error from repository")
+	}
+}
+
+func TestRecordRunCost_CreatesAndUpserts(t *testing.T) {
+	repo := newMockRepository()
+	c := newTestChecker(repo)
+
+	runID := uuid.New()
+	orgID := uuid.New()
+	wsID := uuid.New()
+	policyID := uuid.New()
+
+	params := RecordRunCostParams{
+		RunID:             runID,
+		OrganizationID:    orgID,
+		WorkspaceID:       wsID,
+		SpendPolicyID:     policyID,
+		WindowKind:        "month",
+		TotalCostUSD:      12.50,
+		TotalInputTokens:  1000,
+		TotalOutputTokens: 500,
+		CostBreakdown:     []byte(`{"model":"gpt-4"}`),
+	}
+
+	err := c.RecordRunCost(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify summary was created.
+	if len(repo.createdSummaries) != 1 {
+		t.Fatalf("expected 1 summary, got %d", len(repo.createdSummaries))
+	}
+	s := repo.createdSummaries[0]
+	if s.RunID != runID {
+		t.Errorf("summary RunID = %v, want %v", s.RunID, runID)
+	}
+	if s.TotalCostUSD != 12.50 {
+		t.Errorf("summary TotalCostUSD = %v, want 12.50", s.TotalCostUSD)
+	}
+
+	// Verify window spend was upserted.
+	if len(repo.upsertedSpends) != 1 {
+		t.Fatalf("expected 1 upserted spend, got %d", len(repo.upsertedSpends))
+	}
+	u := repo.upsertedSpends[0]
+	if u.SpendPolicyID != policyID {
+		t.Errorf("upsert SpendPolicyID = %v, want %v", u.SpendPolicyID, policyID)
+	}
+	if u.CostUSD != 12.50 {
+		t.Errorf("upsert CostUSD = %v, want 12.50", u.CostUSD)
+	}
+	if u.RunID != runID {
+		t.Errorf("upsert RunID = %v, want %v", u.RunID, runID)
+	}
+
+	// Verify window bounds are for March 2024.
+	wantStart := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC)
+	if !u.WindowStart.Equal(wantStart) {
+		t.Errorf("upsert WindowStart = %v, want %v", u.WindowStart, wantStart)
+	}
+	if !u.WindowEnd.Equal(wantEnd) {
+		t.Errorf("upsert WindowEnd = %v, want %v", u.WindowEnd, wantEnd)
+	}
+}
+
+func TestRecordRunCost_RunWindowSkipsUpsert(t *testing.T) {
+	repo := newMockRepository()
+	c := newTestChecker(repo)
+
+	params := RecordRunCostParams{
+		RunID:             uuid.New(),
+		OrganizationID:    uuid.New(),
+		WorkspaceID:       uuid.New(),
+		SpendPolicyID:     uuid.New(),
+		WindowKind:        "run",
+		TotalCostUSD:      5.00,
+		TotalInputTokens:  500,
+		TotalOutputTokens: 250,
+		CostBreakdown:     []byte(`{}`),
+	}
+
+	err := c.RecordRunCost(context.Background(), params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(repo.createdSummaries) != 1 {
+		t.Fatalf("expected 1 summary, got %d", len(repo.createdSummaries))
+	}
+	if len(repo.upsertedSpends) != 0 {
+		t.Errorf("expected 0 upserted spends for 'run' window, got %d", len(repo.upsertedSpends))
+	}
+}
+
+// errorRepository wraps mockRepository but returns errors from specific methods.
+type errorRepository struct {
+	*mockRepository
+	getWindowSpendErr error
+}
+
+func (e *errorRepository) GetWindowSpend(_ context.Context, _ uuid.UUID, _, _ time.Time) (WindowSpend, error) {
+	return WindowSpend{}, e.getWindowSpendErr
+}

--- a/backend/internal/budget/noop.go
+++ b/backend/internal/budget/noop.go
@@ -1,0 +1,25 @@
+package budget
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// NoopChecker is a budget checker that always allows runs.
+// Use when the budget service is not configured.
+type NoopChecker struct{}
+
+// CheckPreRunBudget always returns Allowed: true.
+func (NoopChecker) CheckPreRunBudget(_ context.Context, _ uuid.UUID, _ uuid.UUID) (BudgetCheckResult, error) {
+	return BudgetCheckResult{Allowed: true}, nil
+}
+
+// NoopRecorder is a cost recorder that silently discards cost data.
+// Use when the budget service is not configured.
+type NoopRecorder struct{}
+
+// RecordRunCost is a no-op.
+func (NoopRecorder) RecordRunCost(_ context.Context, _ RecordRunCostParams) error {
+	return nil
+}

--- a/backend/internal/budget/window.go
+++ b/backend/internal/budget/window.go
@@ -1,0 +1,39 @@
+package budget
+
+import "time"
+
+// ComputeWindow returns the start and end of the budget window containing
+// referenceTime for the given windowKind. All times are in UTC.
+//
+// Supported window kinds:
+//   - "day":   midnight-to-midnight UTC
+//   - "week":  Monday midnight UTC to the following Monday
+//   - "month": first of the month to first of the next month (UTC)
+//   - "run":   per-run window; returns zero times (no accumulation)
+func ComputeWindow(windowKind string, referenceTime time.Time) (start time.Time, end time.Time) {
+	ref := referenceTime.UTC()
+
+	switch windowKind {
+	case "day":
+		start = time.Date(ref.Year(), ref.Month(), ref.Day(), 0, 0, 0, 0, time.UTC)
+		end = start.AddDate(0, 0, 1)
+
+	case "week":
+		// Weekday: Sunday=0 ... Saturday=6. We want Monday=0-based offset.
+		weekday := ref.Weekday()
+		daysSinceMonday := int(weekday+6) % 7 // Monday=0, Tuesday=1, ..., Sunday=6
+		start = time.Date(ref.Year(), ref.Month(), ref.Day()-daysSinceMonday, 0, 0, 0, 0, time.UTC)
+		end = start.AddDate(0, 0, 7)
+
+	case "month":
+		start = time.Date(ref.Year(), ref.Month(), 1, 0, 0, 0, 0, time.UTC)
+		end = start.AddDate(0, 1, 0)
+
+	case "run":
+		// Per-run windows have no accumulation period.
+		start = time.Time{}
+		end = time.Time{}
+	}
+
+	return start, end
+}

--- a/backend/internal/budget/window_test.go
+++ b/backend/internal/budget/window_test.go
@@ -1,0 +1,146 @@
+package budget
+
+import (
+	"testing"
+	"time"
+)
+
+func TestComputeWindow_Day(t *testing.T) {
+	ref := time.Date(2024, 3, 15, 14, 30, 0, 0, time.UTC)
+	start, end := ComputeWindow("day", ref)
+
+	wantStart := time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2024, 3, 16, 0, 0, 0, 0, time.UTC)
+
+	if !start.Equal(wantStart) {
+		t.Errorf("day start = %v, want %v", start, wantStart)
+	}
+	if !end.Equal(wantEnd) {
+		t.Errorf("day end = %v, want %v", end, wantEnd)
+	}
+}
+
+func TestComputeWindow_Week(t *testing.T) {
+	// 2024-03-13 is a Wednesday.
+	ref := time.Date(2024, 3, 13, 10, 0, 0, 0, time.UTC)
+	start, end := ComputeWindow("week", ref)
+
+	wantStart := time.Date(2024, 3, 11, 0, 0, 0, 0, time.UTC) // Monday
+	wantEnd := time.Date(2024, 3, 18, 0, 0, 0, 0, time.UTC)   // next Monday
+
+	if !start.Equal(wantStart) {
+		t.Errorf("week start = %v, want %v", start, wantStart)
+	}
+	if !end.Equal(wantEnd) {
+		t.Errorf("week end = %v, want %v", end, wantEnd)
+	}
+}
+
+func TestComputeWindow_WeekOnMonday(t *testing.T) {
+	// Edge case: reference time is already Monday.
+	ref := time.Date(2024, 3, 11, 8, 0, 0, 0, time.UTC)
+	start, end := ComputeWindow("week", ref)
+
+	wantStart := time.Date(2024, 3, 11, 0, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2024, 3, 18, 0, 0, 0, 0, time.UTC)
+
+	if !start.Equal(wantStart) {
+		t.Errorf("week-on-monday start = %v, want %v", start, wantStart)
+	}
+	if !end.Equal(wantEnd) {
+		t.Errorf("week-on-monday end = %v, want %v", end, wantEnd)
+	}
+}
+
+func TestComputeWindow_WeekOnSunday(t *testing.T) {
+	// Edge case: reference time is Sunday.
+	ref := time.Date(2024, 3, 17, 23, 59, 0, 0, time.UTC)
+	start, end := ComputeWindow("week", ref)
+
+	wantStart := time.Date(2024, 3, 11, 0, 0, 0, 0, time.UTC) // preceding Monday
+	wantEnd := time.Date(2024, 3, 18, 0, 0, 0, 0, time.UTC)
+
+	if !start.Equal(wantStart) {
+		t.Errorf("week-on-sunday start = %v, want %v", start, wantStart)
+	}
+	if !end.Equal(wantEnd) {
+		t.Errorf("week-on-sunday end = %v, want %v", end, wantEnd)
+	}
+}
+
+func TestComputeWindow_Month(t *testing.T) {
+	ref := time.Date(2024, 3, 15, 12, 0, 0, 0, time.UTC)
+	start, end := ComputeWindow("month", ref)
+
+	wantStart := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC)
+
+	if !start.Equal(wantStart) {
+		t.Errorf("month start = %v, want %v", start, wantStart)
+	}
+	if !end.Equal(wantEnd) {
+		t.Errorf("month end = %v, want %v", end, wantEnd)
+	}
+}
+
+func TestComputeWindow_MonthBoundary(t *testing.T) {
+	// January 31 -> start=Jan 1, end=Feb 1.
+	ref := time.Date(2024, 1, 31, 23, 59, 59, 0, time.UTC)
+	start, end := ComputeWindow("month", ref)
+
+	wantStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	if !start.Equal(wantStart) {
+		t.Errorf("month-boundary start = %v, want %v", start, wantStart)
+	}
+	if !end.Equal(wantEnd) {
+		t.Errorf("month-boundary end = %v, want %v", end, wantEnd)
+	}
+}
+
+func TestComputeWindow_MonthDecemberToJanuary(t *testing.T) {
+	// December rolls into January of the next year.
+	ref := time.Date(2024, 12, 25, 0, 0, 0, 0, time.UTC)
+	start, end := ComputeWindow("month", ref)
+
+	wantStart := time.Date(2024, 12, 1, 0, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	if !start.Equal(wantStart) {
+		t.Errorf("month-dec start = %v, want %v", start, wantStart)
+	}
+	if !end.Equal(wantEnd) {
+		t.Errorf("month-dec end = %v, want %v", end, wantEnd)
+	}
+}
+
+func TestComputeWindow_Run(t *testing.T) {
+	ref := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	start, end := ComputeWindow("run", ref)
+
+	if !start.IsZero() {
+		t.Errorf("run start = %v, want zero", start)
+	}
+	if !end.IsZero() {
+		t.Errorf("run end = %v, want zero", end)
+	}
+}
+
+func TestComputeWindow_DayNonUTC(t *testing.T) {
+	// Ensure non-UTC input is normalized to UTC.
+	loc := time.FixedZone("UTC+5", 5*60*60)
+	// 2024-03-16 02:00 UTC+5 == 2024-03-15 21:00 UTC
+	ref := time.Date(2024, 3, 16, 2, 0, 0, 0, loc)
+	start, end := ComputeWindow("day", ref)
+
+	wantStart := time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2024, 3, 16, 0, 0, 0, 0, time.UTC)
+
+	if !start.Equal(wantStart) {
+		t.Errorf("day-nonUTC start = %v, want %v", start, wantStart)
+	}
+	if !end.Equal(wantEnd) {
+		t.Errorf("day-nonUTC end = %v, want %v", end, wantEnd)
+	}
+}

--- a/backend/internal/ratelimit/limiter.go
+++ b/backend/internal/ratelimit/limiter.go
@@ -1,0 +1,123 @@
+package ratelimit
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/time/rate"
+)
+
+// Config holds the rate limiting configuration.
+type Config struct {
+	DefaultRPS       float64
+	DefaultBurst     int
+	RunCreationRPM   float64
+	RunCreationBurst int
+}
+
+// limiterKey uniquely identifies a rate limiter by workspace and group.
+type limiterKey struct {
+	WorkspaceID uuid.UUID
+	Group       string
+}
+
+// Limiter provides per-workspace, per-group rate limiting backed by
+// in-memory token bucket limiters from golang.org/x/time/rate.
+type Limiter struct {
+	cfg      Config
+	limiters sync.Map // map[limiterKey]*rate.Limiter
+}
+
+// NewLimiter creates a new Limiter with the given configuration.
+func NewLimiter(cfg Config) *Limiter {
+	return &Limiter{cfg: cfg}
+}
+
+// Allow checks whether a request from the given workspace in the given group
+// is allowed. It returns true if the request is permitted, or false with the
+// duration the caller should wait before retrying.
+func (l *Limiter) Allow(workspaceID uuid.UUID, group string) (allowed bool, retryAfter time.Duration) {
+	key := limiterKey{WorkspaceID: workspaceID, Group: group}
+
+	val, loaded := l.limiters.Load(key)
+	if !loaded {
+		val, _ = l.limiters.LoadOrStore(key, limiterForGroup(l.cfg, group))
+	}
+	lim := val.(*rate.Limiter)
+
+	r := lim.Reserve()
+	if !r.OK() {
+		return false, 0
+	}
+
+	delay := r.Delay()
+	if delay > 0 {
+		// The reservation requires waiting, which means the rate is exceeded.
+		// Cancel the reservation so the token is returned.
+		r.Cancel()
+		return false, delay
+	}
+
+	return true, 0
+}
+
+// Middleware returns chi-compatible HTTP middleware that rate limits requests
+// by workspace ID for the given group. The extractWorkspaceID function is
+// called to obtain the workspace ID from each request; if it returns false
+// (e.g. unauthenticated requests), the request passes through without
+// rate limiting.
+func (l *Limiter) Middleware(group string, extractWorkspaceID func(*http.Request) (uuid.UUID, bool)) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			wsID, ok := extractWorkspaceID(r)
+			if !ok {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			allowed, retryAfter := l.Allow(wsID, group)
+
+			// Look up the limiter to write headers.
+			key := limiterKey{WorkspaceID: wsID, Group: group}
+			val, _ := l.limiters.Load(key)
+			lim := val.(*rate.Limiter)
+
+			// Write rate limit headers on every response.
+			burstLimit := lim.Burst()
+			tokensNow := lim.Tokens()
+			remaining := int(math.Max(0, math.Floor(tokensNow)))
+
+			w.Header().Set("X-RateLimit-Limit", strconv.Itoa(burstLimit))
+			w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(remaining))
+			w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(time.Now().Add(time.Second).Unix(), 10))
+
+			if !allowed {
+				retryAfterSec := int(math.Ceil(retryAfter.Seconds()))
+				if retryAfterSec < 1 {
+					retryAfterSec = 1
+				}
+				w.Header().Set("Retry-After", strconv.Itoa(retryAfterSec))
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusTooManyRequests)
+				fmt.Fprintf(w, `{"error":{"code":"rate_limited","message":"too many requests, retry after %d seconds"}}`, retryAfterSec)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// limiterForGroup creates a *rate.Limiter configured for the given group.
+func limiterForGroup(cfg Config, group string) *rate.Limiter {
+	if group == "run_creation" {
+		rps := cfg.RunCreationRPM / 60.0
+		return rate.NewLimiter(rate.Limit(rps), cfg.RunCreationBurst)
+	}
+	return rate.NewLimiter(rate.Limit(cfg.DefaultRPS), cfg.DefaultBurst)
+}

--- a/backend/internal/ratelimit/limiter_test.go
+++ b/backend/internal/ratelimit/limiter_test.go
@@ -1,0 +1,236 @@
+package ratelimit
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestAllow_UnderLimit(t *testing.T) {
+	l := NewLimiter(Config{
+		DefaultRPS:   100,
+		DefaultBurst: 10,
+	})
+
+	wsID := uuid.New()
+	allowed, retryAfter := l.Allow(wsID, "default")
+	if !allowed {
+		t.Fatalf("expected request to be allowed, got retryAfter=%v", retryAfter)
+	}
+	if retryAfter != 0 {
+		t.Fatalf("expected retryAfter=0, got %v", retryAfter)
+	}
+}
+
+func TestAllow_OverLimit(t *testing.T) {
+	l := NewLimiter(Config{
+		DefaultRPS:   1,
+		DefaultBurst: 1,
+	})
+
+	wsID := uuid.New()
+
+	// First request should succeed (consumes the burst).
+	allowed, _ := l.Allow(wsID, "default")
+	if !allowed {
+		t.Fatal("expected first request to be allowed")
+	}
+
+	// Second request should be rejected since burst is exhausted.
+	allowed, retryAfter := l.Allow(wsID, "default")
+	if allowed {
+		t.Fatal("expected second request to be rejected")
+	}
+	if retryAfter <= 0 {
+		t.Fatalf("expected positive retryAfter, got %v", retryAfter)
+	}
+}
+
+func TestAllow_WorkspaceIsolation(t *testing.T) {
+	l := NewLimiter(Config{
+		DefaultRPS:   1,
+		DefaultBurst: 1,
+	})
+
+	ws1 := uuid.New()
+	ws2 := uuid.New()
+
+	// Exhaust workspace 1's limit.
+	allowed, _ := l.Allow(ws1, "default")
+	if !allowed {
+		t.Fatal("expected ws1 first request to be allowed")
+	}
+	allowed, _ = l.Allow(ws1, "default")
+	if allowed {
+		t.Fatal("expected ws1 second request to be rejected")
+	}
+
+	// Workspace 2 should still be allowed.
+	allowed, _ = l.Allow(ws2, "default")
+	if !allowed {
+		t.Fatal("expected ws2 first request to be allowed")
+	}
+}
+
+func TestAllow_GroupIsolation(t *testing.T) {
+	l := NewLimiter(Config{
+		DefaultRPS:       1,
+		DefaultBurst:     1,
+		RunCreationRPM:   60, // 1 per second
+		RunCreationBurst: 1,
+	})
+
+	wsID := uuid.New()
+
+	// Exhaust the default group.
+	allowed, _ := l.Allow(wsID, "default")
+	if !allowed {
+		t.Fatal("expected default group first request to be allowed")
+	}
+	allowed, _ = l.Allow(wsID, "default")
+	if allowed {
+		t.Fatal("expected default group second request to be rejected")
+	}
+
+	// run_creation group should still be allowed (independent limiter).
+	allowed, _ = l.Allow(wsID, "run_creation")
+	if !allowed {
+		t.Fatal("expected run_creation group first request to be allowed")
+	}
+}
+
+func TestMiddleware_AllowedRequest(t *testing.T) {
+	l := NewLimiter(Config{
+		DefaultRPS:   100,
+		DefaultBurst: 10,
+	})
+
+	wsID := uuid.New()
+	extract := func(r *http.Request) (uuid.UUID, bool) {
+		return wsID, true
+	}
+
+	handler := l.Middleware("default", extract)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	// Verify rate limit headers are present.
+	if rec.Header().Get("X-RateLimit-Limit") == "" {
+		t.Error("expected X-RateLimit-Limit header")
+	}
+	if rec.Header().Get("X-RateLimit-Remaining") == "" {
+		t.Error("expected X-RateLimit-Remaining header")
+	}
+	if rec.Header().Get("X-RateLimit-Reset") == "" {
+		t.Error("expected X-RateLimit-Reset header")
+	}
+}
+
+func TestMiddleware_RateLimited(t *testing.T) {
+	l := NewLimiter(Config{
+		DefaultRPS:   1,
+		DefaultBurst: 1,
+	})
+
+	wsID := uuid.New()
+	extract := func(r *http.Request) (uuid.UUID, bool) {
+		return wsID, true
+	}
+
+	handler := l.Middleware("default", extract)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// First request consumes the burst.
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected first request to return 200, got %d", rec.Code)
+	}
+
+	// Second request should be rate limited.
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", rec.Code)
+	}
+
+	if rec.Header().Get("Retry-After") == "" {
+		t.Error("expected Retry-After header on 429 response")
+	}
+	if rec.Header().Get("Content-Type") != "application/json" {
+		t.Errorf("expected application/json Content-Type, got %q", rec.Header().Get("Content-Type"))
+	}
+
+	// Verify the error body structure.
+	var body struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+	if body.Error.Code != "rate_limited" {
+		t.Errorf("expected error code 'rate_limited', got %q", body.Error.Code)
+	}
+	if body.Error.Message == "" {
+		t.Error("expected non-empty error message")
+	}
+
+	// Verify rate limit headers are still present on 429.
+	if rec.Header().Get("X-RateLimit-Limit") == "" {
+		t.Error("expected X-RateLimit-Limit header on 429 response")
+	}
+	if rec.Header().Get("X-RateLimit-Remaining") == "" {
+		t.Error("expected X-RateLimit-Remaining header on 429 response")
+	}
+}
+
+func TestMiddleware_NoWorkspaceID(t *testing.T) {
+	l := NewLimiter(Config{
+		DefaultRPS:   1,
+		DefaultBurst: 1,
+	})
+
+	extract := func(r *http.Request) (uuid.UUID, bool) {
+		return uuid.Nil, false
+	}
+
+	innerCalled := false
+	handler := l.Middleware("default", extract)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		innerCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !innerCalled {
+		t.Error("expected inner handler to be called when workspace ID is not extractable")
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	// No rate limit headers should be set when workspace is not available.
+	if rec.Header().Get("X-RateLimit-Limit") != "" {
+		t.Error("expected no X-RateLimit-Limit header when workspace ID is missing")
+	}
+}

--- a/backend/internal/repository/budget.go
+++ b/backend/internal/repository/budget.go
@@ -1,0 +1,133 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+var ErrRunCostSummaryNotFound = errors.New("run cost summary not found")
+
+type WindowSpendRow struct {
+	TotalCostUSD      float64
+	TotalInputTokens  int64
+	TotalOutputTokens int64
+	RunCount          int
+}
+
+type UpsertWindowSpendParams struct {
+	OrganizationID uuid.UUID
+	WorkspaceID    uuid.UUID
+	SpendPolicyID  uuid.UUID
+	WindowStart    time.Time
+	WindowEnd      time.Time
+	CostUSD        float64
+	InputTokens    int64
+	OutputTokens   int64
+	RunID          uuid.UUID
+}
+
+type CreateRunCostSummaryParams struct {
+	RunID             uuid.UUID
+	WorkspaceID       uuid.UUID
+	TotalCostUSD      float64
+	TotalInputTokens  int64
+	TotalOutputTokens int64
+	CostBreakdown     []byte
+}
+
+type RunCostSummaryRow struct {
+	ID                uuid.UUID
+	RunID             uuid.UUID
+	WorkspaceID       uuid.UUID
+	TotalCostUSD      float64
+	TotalInputTokens  int64
+	TotalOutputTokens int64
+	CostBreakdown     []byte
+	CreatedAt         time.Time
+}
+
+func (r *Repository) GetWindowSpend(ctx context.Context, spendPolicyID uuid.UUID, windowStart, windowEnd time.Time) (WindowSpendRow, error) {
+	var row WindowSpendRow
+	err := r.db.QueryRow(ctx, `
+		SELECT total_cost_usd, total_input_tokens, total_output_tokens, run_count
+		FROM workspace_spend_ledger
+		WHERE spend_policy_id = $1
+		  AND window_start = $2
+		  AND window_end = $3
+	`, spendPolicyID,
+		pgtype.Timestamptz{Time: windowStart, Valid: true},
+		pgtype.Timestamptz{Time: windowEnd, Valid: true},
+	).Scan(&row.TotalCostUSD, &row.TotalInputTokens, &row.TotalOutputTokens, &row.RunCount)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return WindowSpendRow{}, nil
+		}
+		return WindowSpendRow{}, fmt.Errorf("get window spend: %w", err)
+	}
+	return row, nil
+}
+
+func (r *Repository) UpsertWindowSpend(ctx context.Context, p UpsertWindowSpendParams) error {
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO workspace_spend_ledger (
+			organization_id, workspace_id, spend_policy_id,
+			window_start, window_end,
+			total_cost_usd, total_input_tokens, total_output_tokens,
+			run_count, last_run_id
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 1, $9)
+		ON CONFLICT (spend_policy_id, window_start) DO UPDATE SET
+			total_cost_usd = workspace_spend_ledger.total_cost_usd + EXCLUDED.total_cost_usd,
+			total_input_tokens = workspace_spend_ledger.total_input_tokens + EXCLUDED.total_input_tokens,
+			total_output_tokens = workspace_spend_ledger.total_output_tokens + EXCLUDED.total_output_tokens,
+			run_count = workspace_spend_ledger.run_count + 1,
+			last_run_id = EXCLUDED.last_run_id
+	`, p.OrganizationID, p.WorkspaceID, p.SpendPolicyID,
+		pgtype.Timestamptz{Time: p.WindowStart, Valid: true},
+		pgtype.Timestamptz{Time: p.WindowEnd, Valid: true},
+		p.CostUSD, p.InputTokens, p.OutputTokens, p.RunID,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert window spend: %w", err)
+	}
+	return nil
+}
+
+func (r *Repository) CreateRunCostSummary(ctx context.Context, p CreateRunCostSummaryParams) error {
+	breakdown := p.CostBreakdown
+	if len(breakdown) == 0 {
+		breakdown = []byte("[]")
+	}
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO run_cost_summaries (run_id, workspace_id, total_cost_usd, total_input_tokens, total_output_tokens, cost_breakdown)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (run_id) DO NOTHING
+	`, p.RunID, p.WorkspaceID, p.TotalCostUSD, p.TotalInputTokens, p.TotalOutputTokens, breakdown)
+	if err != nil {
+		return fmt.Errorf("create run cost summary: %w", err)
+	}
+	return nil
+}
+
+func (r *Repository) GetRunCostSummary(ctx context.Context, runID uuid.UUID) (RunCostSummaryRow, error) {
+	var row RunCostSummaryRow
+	var createdAt pgtype.Timestamptz
+	err := r.db.QueryRow(ctx, `
+		SELECT id, run_id, workspace_id, total_cost_usd, total_input_tokens, total_output_tokens, cost_breakdown, created_at
+		FROM run_cost_summaries WHERE run_id = $1
+	`, runID).Scan(&row.ID, &row.RunID, &row.WorkspaceID, &row.TotalCostUSD,
+		&row.TotalInputTokens, &row.TotalOutputTokens, &row.CostBreakdown, &createdAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return RunCostSummaryRow{}, ErrRunCostSummaryNotFound
+		}
+		return RunCostSummaryRow{}, fmt.Errorf("get run cost summary: %w", err)
+	}
+	row.CreatedAt = createdAt.Time
+	return row, nil
+}

--- a/backend/internal/repository/budget_adapter.go
+++ b/backend/internal/repository/budget_adapter.go
@@ -1,0 +1,80 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/budget"
+	"github.com/google/uuid"
+)
+
+// BudgetRepositoryAdapter adapts *Repository to the budget.Repository interface.
+type BudgetRepositoryAdapter struct {
+	repo *Repository
+}
+
+func NewBudgetRepositoryAdapter(repo *Repository) *BudgetRepositoryAdapter {
+	return &BudgetRepositoryAdapter{repo: repo}
+}
+
+func (a *BudgetRepositoryAdapter) GetSpendPolicyByID(ctx context.Context, id uuid.UUID) (budget.SpendPolicy, error) {
+	row, err := a.repo.GetSpendPolicyByID(ctx, id)
+	if err != nil {
+		if err == ErrSpendPolicyNotFound {
+			return budget.SpendPolicy{}, budget.ErrPolicyNotFound
+		}
+		return budget.SpendPolicy{}, err
+	}
+	var wsID uuid.UUID
+	if row.WorkspaceID != nil {
+		wsID = *row.WorkspaceID
+	}
+	return budget.SpendPolicy{
+		ID:           row.ID,
+		WorkspaceID:  wsID,
+		WindowKind:   row.WindowKind,
+		SoftLimit:    row.SoftLimit,
+		HardLimit:    row.HardLimit,
+		CurrencyCode: row.CurrencyCode,
+	}, nil
+}
+
+func (a *BudgetRepositoryAdapter) GetWindowSpend(ctx context.Context, spendPolicyID uuid.UUID, windowStart, windowEnd time.Time) (budget.WindowSpend, error) {
+	row, err := a.repo.GetWindowSpend(ctx, spendPolicyID, windowStart, windowEnd)
+	if err != nil {
+		return budget.WindowSpend{}, err
+	}
+	return budget.WindowSpend{
+		TotalCostUSD:      row.TotalCostUSD,
+		TotalInputTokens:  row.TotalInputTokens,
+		TotalOutputTokens: row.TotalOutputTokens,
+		RunCount:          row.RunCount,
+		WindowStart:       windowStart,
+		WindowEnd:         windowEnd,
+	}, nil
+}
+
+func (a *BudgetRepositoryAdapter) UpsertWindowSpend(ctx context.Context, params budget.UpsertWindowSpendParams) error {
+	return a.repo.UpsertWindowSpend(ctx, UpsertWindowSpendParams{
+		OrganizationID: params.OrganizationID,
+		WorkspaceID:    params.WorkspaceID,
+		SpendPolicyID:  params.SpendPolicyID,
+		WindowStart:    params.WindowStart,
+		WindowEnd:      params.WindowEnd,
+		CostUSD:        params.CostUSD,
+		InputTokens:    params.InputTokens,
+		OutputTokens:   params.OutputTokens,
+		RunID:          params.RunID,
+	})
+}
+
+func (a *BudgetRepositoryAdapter) CreateRunCostSummary(ctx context.Context, params budget.CreateRunCostSummaryParams) error {
+	return a.repo.CreateRunCostSummary(ctx, CreateRunCostSummaryParams{
+		RunID:             params.RunID,
+		WorkspaceID:       params.WorkspaceID,
+		TotalCostUSD:      params.TotalCostUSD,
+		TotalInputTokens:  params.TotalInputTokens,
+		TotalOutputTokens: params.TotalOutputTokens,
+		CostBreakdown:     params.CostBreakdown,
+	})
+}

--- a/backend/internal/repository/infrastructure.go
+++ b/backend/internal/repository/infrastructure.go
@@ -273,26 +273,30 @@ func (r *Repository) ArchiveProviderAccount(ctx context.Context, id uuid.UUID) e
 // --------------------------------------------------------------------------
 
 type ModelCatalogEntryRow struct {
-	ID              uuid.UUID
-	ProviderKey     string
-	ProviderModelID string
-	DisplayName     string
-	ModelFamily     string
-	Modality        string
-	LifecycleStatus string
-	Metadata        json.RawMessage
-	CreatedAt       time.Time
-	UpdatedAt       time.Time
+	ID                          uuid.UUID
+	ProviderKey                 string
+	ProviderModelID             string
+	DisplayName                 string
+	ModelFamily                 string
+	Modality                    string
+	LifecycleStatus             string
+	Metadata                    json.RawMessage
+	InputCostPerMillionTokens   float64
+	OutputCostPerMillionTokens  float64
+	CreatedAt                   time.Time
+	UpdatedAt                   time.Time
 }
 
 func (r *Repository) GetModelCatalogEntryByID(ctx context.Context, id uuid.UUID) (ModelCatalogEntryRow, error) {
 	var row ModelCatalogEntryRow
 	var createdAt, updatedAt pgtype.Timestamptz
 	err := r.db.QueryRow(ctx, `
-		SELECT id, provider_key, provider_model_id, display_name, model_family, modality, lifecycle_status, metadata, created_at, updated_at
+		SELECT id, provider_key, provider_model_id, display_name, model_family, modality, lifecycle_status, metadata,
+			input_cost_per_million_tokens, output_cost_per_million_tokens, created_at, updated_at
 		FROM model_catalog_entries WHERE id = $1
 	`, id).Scan(&row.ID, &row.ProviderKey, &row.ProviderModelID, &row.DisplayName, &row.ModelFamily,
-		&row.Modality, &row.LifecycleStatus, &row.Metadata, &createdAt, &updatedAt)
+		&row.Modality, &row.LifecycleStatus, &row.Metadata,
+		&row.InputCostPerMillionTokens, &row.OutputCostPerMillionTokens, &createdAt, &updatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return ModelCatalogEntryRow{}, ErrModelCatalogNotFound
@@ -343,7 +347,8 @@ func (r *Repository) GetModelCatalogEntryByProviderModel(ctx context.Context, pr
 
 func (r *Repository) ListModelCatalogEntries(ctx context.Context) ([]ModelCatalogEntryRow, error) {
 	rows, err := r.db.Query(ctx, `
-		SELECT id, provider_key, provider_model_id, display_name, model_family, modality, lifecycle_status, metadata, created_at, updated_at
+		SELECT id, provider_key, provider_model_id, display_name, model_family, modality, lifecycle_status, metadata,
+			input_cost_per_million_tokens, output_cost_per_million_tokens, created_at, updated_at
 		FROM model_catalog_entries
 		WHERE lifecycle_status != 'archived'
 		ORDER BY provider_key, display_name
@@ -358,7 +363,8 @@ func (r *Repository) ListModelCatalogEntries(ctx context.Context) ([]ModelCatalo
 		var row ModelCatalogEntryRow
 		var createdAt, updatedAt pgtype.Timestamptz
 		if err := rows.Scan(&row.ID, &row.ProviderKey, &row.ProviderModelID, &row.DisplayName, &row.ModelFamily,
-			&row.Modality, &row.LifecycleStatus, &row.Metadata, &createdAt, &updatedAt); err != nil {
+			&row.Modality, &row.LifecycleStatus, &row.Metadata,
+			&row.InputCostPerMillionTokens, &row.OutputCostPerMillionTokens, &createdAt, &updatedAt); err != nil {
 			return nil, fmt.Errorf("scan model catalog entry: %w", err)
 		}
 		row.CreatedAt = createdAt.Time
@@ -776,6 +782,24 @@ func (r *Repository) ListRoutingPoliciesByWorkspaceID(ctx context.Context, works
 	return result, nil
 }
 
+func (r *Repository) GetRoutingPolicyByID(ctx context.Context, id uuid.UUID) (RoutingPolicyRow, error) {
+	var row RoutingPolicyRow
+	var createdAt, updatedAt pgtype.Timestamptz
+	err := r.db.QueryRow(ctx, `
+		SELECT id, organization_id, workspace_id, name, policy_kind, config, created_at, updated_at
+		FROM routing_policies WHERE id = $1 AND archived_at IS NULL
+	`, id).Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.Name, &row.PolicyKind, &row.Config, &createdAt, &updatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return RoutingPolicyRow{}, ErrRoutingPolicyNotFound
+		}
+		return RoutingPolicyRow{}, fmt.Errorf("get routing policy: %w", err)
+	}
+	row.CreatedAt = createdAt.Time
+	row.UpdatedAt = updatedAt.Time
+	return row, nil
+}
+
 // --------------------------------------------------------------------------
 // Spend Policies
 // --------------------------------------------------------------------------
@@ -855,6 +879,25 @@ func (r *Repository) ListSpendPoliciesByWorkspaceID(ctx context.Context, workspa
 		result = []SpendPolicyRow{}
 	}
 	return result, nil
+}
+
+func (r *Repository) GetSpendPolicyByID(ctx context.Context, id uuid.UUID) (SpendPolicyRow, error) {
+	var row SpendPolicyRow
+	var createdAt, updatedAt pgtype.Timestamptz
+	err := r.db.QueryRow(ctx, `
+		SELECT id, organization_id, workspace_id, name, currency_code, window_kind, soft_limit, hard_limit, config, created_at, updated_at
+		FROM spend_policies WHERE id = $1 AND archived_at IS NULL
+	`, id).Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.Name, &row.CurrencyCode, &row.WindowKind,
+		&row.SoftLimit, &row.HardLimit, &row.Config, &createdAt, &updatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return SpendPolicyRow{}, ErrSpendPolicyNotFound
+		}
+		return SpendPolicyRow{}, fmt.Errorf("get spend policy: %w", err)
+	}
+	row.CreatedAt = createdAt.Time
+	row.UpdatedAt = updatedAt.Time
+	return row, nil
 }
 
 // --------------------------------------------------------------------------

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -90,6 +90,8 @@ type RunnableDeployment struct {
 	WorkspaceID               uuid.UUID
 	Name                      string
 	AgentDeploymentSnapshotID uuid.UUID
+	SpendPolicyID             *uuid.UUID
+	RoutingPolicyID           *uuid.UUID
 }
 
 type CreateQueuedRunAgentParams struct {
@@ -290,6 +292,8 @@ func (r *Repository) ListRunnableDeploymentsWithLatestSnapshot(
 			WorkspaceID:               row.WorkspaceID,
 			Name:                      row.Name,
 			AgentDeploymentSnapshotID: row.AgentDeploymentSnapshotID,
+			SpendPolicyID:             row.SpendPolicyID,
+			RoutingPolicyID:           row.RoutingPolicyID,
 		})
 	}
 
@@ -1508,6 +1512,13 @@ func cloneFloat64Ptr(value *float64) *float64 {
 	}
 	cloned := *value
 	return &cloned
+}
+
+func derefFloat64(value *float64) float64 {
+	if value == nil {
+		return 0
+	}
+	return *value
 }
 
 func numericPtr(value pgtype.Numeric) *float64 {

--- a/backend/internal/repository/run_agent_execution_context.go
+++ b/backend/internal/repository/run_agent_execution_context.go
@@ -138,13 +138,15 @@ type ModelAliasExecutionContext struct {
 }
 
 type ModelCatalogEntryExecutionContext struct {
-	ID              uuid.UUID
-	ProviderKey     string
-	ProviderModelID string
-	DisplayName     string
-	ModelFamily     string
-	Modality        string
-	Metadata        json.RawMessage
+	ID                         uuid.UUID
+	ProviderKey                string
+	ProviderModelID            string
+	DisplayName                string
+	ModelFamily                string
+	Modality                   string
+	Metadata                   json.RawMessage
+	InputCostPerMillionTokens  float64
+	OutputCostPerMillionTokens float64
 }
 
 func (r *Repository) GetRunAgentExecutionContextByID(ctx context.Context, runAgentID uuid.UUID) (RunAgentExecutionContext, error) {
@@ -386,13 +388,15 @@ func mapRunAgentExecutionContext(row repositorysqlc.GetRunAgentExecutionContextB
 			AliasKey:          *row.ModelAliasAliasKey,
 			DisplayName:       *row.ModelAliasDisplayName,
 			ModelCatalogEntry: ModelCatalogEntryExecutionContext{
-				ID:              *row.ModelCatalogEntryID,
-				ProviderKey:     *row.ModelCatalogProviderKey,
-				ProviderModelID: *row.ModelCatalogProviderModelID,
-				DisplayName:     *row.ModelCatalogDisplayName,
-				ModelFamily:     *row.ModelCatalogModelFamily,
-				Modality:        *row.ModelCatalogModality,
-				Metadata:        cloneJSON(row.ModelCatalogMetadata),
+				ID:                         *row.ModelCatalogEntryID,
+				ProviderKey:                *row.ModelCatalogProviderKey,
+				ProviderModelID:            *row.ModelCatalogProviderModelID,
+				DisplayName:                *row.ModelCatalogDisplayName,
+				ModelFamily:                *row.ModelCatalogModelFamily,
+				Modality:                   *row.ModelCatalogModality,
+				Metadata:                   cloneJSON(row.ModelCatalogMetadata),
+				InputCostPerMillionTokens:  derefFloat64(row.ModelCatalogInputCostPerMillionTokens),
+				OutputCostPerMillionTokens: derefFloat64(row.ModelCatalogOutputCostPerMillionTokens),
 			},
 		}
 	}

--- a/backend/internal/repository/sqlc/run_creation.sql.go
+++ b/backend/internal/repository/sqlc/run_creation.sql.go
@@ -78,7 +78,9 @@ SELECT DISTINCT ON (agent_deployments.id)
     agent_deployments.organization_id,
     agent_deployments.workspace_id,
     agent_deployments.name,
-    agent_deployment_snapshots.id AS agent_deployment_snapshot_id
+    agent_deployment_snapshots.id AS agent_deployment_snapshot_id,
+    agent_deployments.spend_policy_id,
+    agent_deployments.routing_policy_id
 FROM agent_deployments
 JOIN agent_deployment_snapshots
   ON agent_deployment_snapshots.agent_deployment_id = agent_deployments.id
@@ -102,6 +104,8 @@ type ListRunnableDeploymentsWithLatestSnapshotRow struct {
 	WorkspaceID               uuid.UUID
 	Name                      string
 	AgentDeploymentSnapshotID uuid.UUID
+	SpendPolicyID             *uuid.UUID
+	RoutingPolicyID           *uuid.UUID
 }
 
 func (q *Queries) ListRunnableDeploymentsWithLatestSnapshot(ctx context.Context, arg ListRunnableDeploymentsWithLatestSnapshotParams) ([]ListRunnableDeploymentsWithLatestSnapshotRow, error) {
@@ -119,6 +123,8 @@ func (q *Queries) ListRunnableDeploymentsWithLatestSnapshot(ctx context.Context,
 			&i.WorkspaceID,
 			&i.Name,
 			&i.AgentDeploymentSnapshotID,
+			&i.SpendPolicyID,
+			&i.RoutingPolicyID,
 		); err != nil {
 			return nil, err
 		}

--- a/backend/internal/repository/sqlc/worker_execution_context.sql.go
+++ b/backend/internal/repository/sqlc/worker_execution_context.sql.go
@@ -109,7 +109,9 @@ SELECT
     mce.display_name AS model_catalog_display_name,
     mce.model_family AS model_catalog_model_family,
     mce.modality AS model_catalog_modality,
-    mce.metadata AS model_catalog_metadata
+    mce.metadata AS model_catalog_metadata,
+    mce.input_cost_per_million_tokens AS model_catalog_input_cost_per_million_tokens,
+    mce.output_cost_per_million_tokens AS model_catalog_output_cost_per_million_tokens
 FROM run_agents AS ra
 JOIN runs AS r
   ON r.id = ra.run_id
@@ -281,6 +283,8 @@ type GetRunAgentExecutionContextByIDRow struct {
 	ModelCatalogModelFamily                 *string
 	ModelCatalogModality                    *string
 	ModelCatalogMetadata                    []byte
+	ModelCatalogInputCostPerMillionTokens   *float64
+	ModelCatalogOutputCostPerMillionTokens  *float64
 }
 
 func (q *Queries) GetRunAgentExecutionContextByID(ctx context.Context, arg GetRunAgentExecutionContextByIDParams) (GetRunAgentExecutionContextByIDRow, error) {
@@ -375,6 +379,8 @@ func (q *Queries) GetRunAgentExecutionContextByID(ctx context.Context, arg GetRu
 		&i.ModelCatalogModelFamily,
 		&i.ModelCatalogModality,
 		&i.ModelCatalogMetadata,
+		&i.ModelCatalogInputCostPerMillionTokens,
+		&i.ModelCatalogOutputCostPerMillionTokens,
 	)
 	return i, err
 }

--- a/backend/internal/routing/fallback.go
+++ b/backend/internal/routing/fallback.go
@@ -1,0 +1,49 @@
+package routing
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// FallbackSelector tries models in priority order defined in the policy config.
+type FallbackSelector struct{}
+
+type fallbackConfig struct {
+	Models []fallbackModel `json:"models"`
+}
+
+type fallbackModel struct {
+	ProviderKey string `json:"provider_key"`
+	Model       string `json:"model"`
+}
+
+// Select iterates through the policy config's model list in priority order,
+// returning the first model that exists in the available targets. If the config
+// is empty or nil, it falls back to returning the first available target.
+func (FallbackSelector) Select(_ context.Context, policy Policy, available []ModelTarget) (ModelTarget, error) {
+	if len(available) == 0 {
+		return ModelTarget{}, ErrNoModelsAvailable
+	}
+
+	var cfg fallbackConfig
+	if len(policy.Config) > 0 {
+		if err := json.Unmarshal(policy.Config, &cfg); err != nil {
+			// Malformed config: fall through to first available.
+			return available[0], nil
+		}
+	}
+
+	if len(cfg.Models) == 0 {
+		return available[0], nil
+	}
+
+	for _, m := range cfg.Models {
+		for _, t := range available {
+			if t.ProviderKey == m.ProviderKey && t.Model == m.Model {
+				return t, nil
+			}
+		}
+	}
+
+	return ModelTarget{}, ErrAllModelsFailed
+}

--- a/backend/internal/routing/router.go
+++ b/backend/internal/routing/router.go
@@ -1,0 +1,50 @@
+package routing
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+var (
+	ErrNoModelsAvailable     = errors.New("no models available for routing")
+	ErrUnsupportedPolicyKind = errors.New("routing policy kind is not yet supported")
+	ErrAllModelsFailed       = errors.New("all models in fallback chain failed")
+)
+
+// Policy represents a routing policy loaded from the database.
+type Policy struct {
+	ID         uuid.UUID
+	PolicyKind string          // "single_model", "fallback", "budget_aware", "latency_aware"
+	Config     json.RawMessage
+}
+
+// ModelTarget represents a selectable provider+model combination.
+type ModelTarget struct {
+	ProviderKey         string
+	ProviderAccountID   string
+	CredentialReference string
+	Model               string
+}
+
+// Selector picks a model target from the available targets based on the policy.
+type Selector interface {
+	Select(ctx context.Context, policy Policy, available []ModelTarget) (ModelTarget, error)
+}
+
+// NewSelector returns the appropriate Selector for the given policy kind.
+func NewSelector(policyKind string) (Selector, error) {
+	switch policyKind {
+	case "single_model":
+		return SingleModelSelector{}, nil
+	case "fallback":
+		return FallbackSelector{}, nil
+	case "budget_aware", "latency_aware":
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedPolicyKind, policyKind)
+	default:
+		return nil, fmt.Errorf("unknown routing policy kind: %s", policyKind)
+	}
+}

--- a/backend/internal/routing/router_test.go
+++ b/backend/internal/routing/router_test.go
@@ -1,0 +1,178 @@
+package routing
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestNewSelector_SingleModel(t *testing.T) {
+	sel, err := NewSelector("single_model")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := sel.(SingleModelSelector); !ok {
+		t.Fatalf("expected SingleModelSelector, got %T", sel)
+	}
+}
+
+func TestNewSelector_Fallback(t *testing.T) {
+	sel, err := NewSelector("fallback")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := sel.(FallbackSelector); !ok {
+		t.Fatalf("expected FallbackSelector, got %T", sel)
+	}
+}
+
+func TestNewSelector_Unsupported(t *testing.T) {
+	for _, kind := range []string{"budget_aware", "latency_aware"} {
+		_, err := NewSelector(kind)
+		if err == nil {
+			t.Fatalf("expected error for %s, got nil", kind)
+		}
+		if !errors.Is(err, ErrUnsupportedPolicyKind) {
+			t.Fatalf("expected ErrUnsupportedPolicyKind for %s, got: %v", kind, err)
+		}
+	}
+}
+
+func TestNewSelector_Unknown(t *testing.T) {
+	_, err := NewSelector("round_robin")
+	if err == nil {
+		t.Fatal("expected error for unknown kind, got nil")
+	}
+	if errors.Is(err, ErrUnsupportedPolicyKind) {
+		t.Fatal("unknown kind should not be ErrUnsupportedPolicyKind")
+	}
+}
+
+func TestSingleModel_ReturnsFirst(t *testing.T) {
+	sel := SingleModelSelector{}
+	targets := []ModelTarget{
+		{ProviderKey: "anthropic", Model: "claude-sonnet-4-20250514"},
+		{ProviderKey: "openai", Model: "gpt-4o"},
+	}
+
+	got, err := sel.Select(context.Background(), Policy{}, targets)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ProviderKey != "anthropic" || got.Model != "claude-sonnet-4-20250514" {
+		t.Fatalf("expected first target, got %+v", got)
+	}
+}
+
+func TestSingleModel_NoAvailable(t *testing.T) {
+	sel := SingleModelSelector{}
+
+	_, err := sel.Select(context.Background(), Policy{}, nil)
+	if !errors.Is(err, ErrNoModelsAvailable) {
+		t.Fatalf("expected ErrNoModelsAvailable, got: %v", err)
+	}
+}
+
+func TestFallback_PriorityOrder(t *testing.T) {
+	sel := FallbackSelector{}
+	cfg := fallbackConfig{
+		Models: []fallbackModel{
+			{ProviderKey: "anthropic", Model: "claude-sonnet-4-20250514"},
+			{ProviderKey: "openai", Model: "gpt-4o"},
+		},
+	}
+	cfgJSON, _ := json.Marshal(cfg)
+
+	// Both models are available, but anthropic should be picked first.
+	targets := []ModelTarget{
+		{ProviderKey: "openai", Model: "gpt-4o"},
+		{ProviderKey: "anthropic", Model: "claude-sonnet-4-20250514"},
+	}
+
+	got, err := sel.Select(context.Background(), Policy{Config: cfgJSON}, targets)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ProviderKey != "anthropic" || got.Model != "claude-sonnet-4-20250514" {
+		t.Fatalf("expected anthropic model (highest priority), got %+v", got)
+	}
+}
+
+func TestFallback_SkipsUnavailable(t *testing.T) {
+	sel := FallbackSelector{}
+	cfg := fallbackConfig{
+		Models: []fallbackModel{
+			{ProviderKey: "anthropic", Model: "claude-sonnet-4-20250514"},
+			{ProviderKey: "openai", Model: "gpt-4o"},
+		},
+	}
+	cfgJSON, _ := json.Marshal(cfg)
+
+	// Only openai is available; anthropic is not.
+	targets := []ModelTarget{
+		{ProviderKey: "openai", Model: "gpt-4o"},
+	}
+
+	got, err := sel.Select(context.Background(), Policy{Config: cfgJSON}, targets)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ProviderKey != "openai" || got.Model != "gpt-4o" {
+		t.Fatalf("expected openai (first available match), got %+v", got)
+	}
+}
+
+func TestFallback_AllUnavailable(t *testing.T) {
+	sel := FallbackSelector{}
+	cfg := fallbackConfig{
+		Models: []fallbackModel{
+			{ProviderKey: "anthropic", Model: "claude-sonnet-4-20250514"},
+			{ProviderKey: "openai", Model: "gpt-4o"},
+		},
+	}
+	cfgJSON, _ := json.Marshal(cfg)
+
+	// Available targets don't match any config model.
+	targets := []ModelTarget{
+		{ProviderKey: "mistral", Model: "mistral-large"},
+	}
+
+	_, err := sel.Select(context.Background(), Policy{Config: cfgJSON}, targets)
+	if !errors.Is(err, ErrAllModelsFailed) {
+		t.Fatalf("expected ErrAllModelsFailed, got: %v", err)
+	}
+}
+
+func TestFallback_EmptyConfig(t *testing.T) {
+	sel := FallbackSelector{}
+	targets := []ModelTarget{
+		{ProviderKey: "openai", Model: "gpt-4o"},
+		{ProviderKey: "anthropic", Model: "claude-sonnet-4-20250514"},
+	}
+
+	// Empty config: should return first available.
+	got, err := sel.Select(context.Background(), Policy{}, targets)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ProviderKey != "openai" || got.Model != "gpt-4o" {
+		t.Fatalf("expected first available target, got %+v", got)
+	}
+}
+
+func TestFallback_InvalidConfig(t *testing.T) {
+	sel := FallbackSelector{}
+	targets := []ModelTarget{
+		{ProviderKey: "openai", Model: "gpt-4o"},
+	}
+
+	// Malformed JSON config: should gracefully fall back to first available.
+	got, err := sel.Select(context.Background(), Policy{Config: json.RawMessage(`{invalid}`)}, targets)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ProviderKey != "openai" || got.Model != "gpt-4o" {
+		t.Fatalf("expected first available target on invalid config, got %+v", got)
+	}
+}

--- a/backend/internal/routing/single_model.go
+++ b/backend/internal/routing/single_model.go
@@ -1,0 +1,14 @@
+package routing
+
+import "context"
+
+// SingleModelSelector returns the first available model target.
+type SingleModelSelector struct{}
+
+// Select returns the first model target from the available list.
+func (SingleModelSelector) Select(_ context.Context, _ Policy, available []ModelTarget) (ModelTarget, error) {
+	if len(available) == 0 {
+		return ModelTarget{}, ErrNoModelsAvailable
+	}
+	return available[0], nil
+}

--- a/backend/internal/worker/budget_guard_observer.go
+++ b/backend/internal/worker/budget_guard_observer.go
@@ -1,0 +1,79 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/engine"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/provider"
+)
+
+// BudgetGuardObserver wraps another observer and performs synchronous budget
+// checks on each provider response. If the accumulated cost exceeds the
+// hard limit, it returns an error that causes the engine to stop the run.
+type BudgetGuardObserver struct {
+	inner              engine.Observer
+	mu                 sync.Mutex
+	accumulatedCostUSD float64
+	hardLimitUSD       float64
+	inputCostPerM      float64
+	outputCostPerM     float64
+}
+
+// NewBudgetGuardObserver creates a budget guard that wraps inner.
+// If hardLimitUSD <= 0, the guard is effectively disabled (never triggers).
+func NewBudgetGuardObserver(inner engine.Observer, hardLimitUSD, inputCostPerM, outputCostPerM float64) *BudgetGuardObserver {
+	return &BudgetGuardObserver{
+		inner:          inner,
+		hardLimitUSD:   hardLimitUSD,
+		inputCostPerM:  inputCostPerM,
+		outputCostPerM: outputCostPerM,
+	}
+}
+
+func (b *BudgetGuardObserver) OnStepStart(ctx context.Context, step int) error {
+	return b.inner.OnStepStart(ctx, step)
+}
+
+func (b *BudgetGuardObserver) OnProviderCall(ctx context.Context, request provider.Request) error {
+	return b.inner.OnProviderCall(ctx, request)
+}
+
+func (b *BudgetGuardObserver) OnProviderOutput(ctx context.Context, request provider.Request, delta provider.StreamDelta) error {
+	return b.inner.OnProviderOutput(ctx, request, delta)
+}
+
+func (b *BudgetGuardObserver) OnProviderResponse(ctx context.Context, response provider.Response) error {
+	if b.hardLimitUSD > 0 {
+		incrementalCost := (float64(response.Usage.InputTokens)/1_000_000.0)*b.inputCostPerM +
+			(float64(response.Usage.OutputTokens)/1_000_000.0)*b.outputCostPerM
+
+		b.mu.Lock()
+		b.accumulatedCostUSD += incrementalCost
+		total := b.accumulatedCostUSD
+		b.mu.Unlock()
+
+		if total > b.hardLimitUSD {
+			return fmt.Errorf("budget exceeded: accumulated cost $%.4f exceeds hard limit $%.4f", total, b.hardLimitUSD)
+		}
+	}
+
+	return b.inner.OnProviderResponse(ctx, response)
+}
+
+func (b *BudgetGuardObserver) OnToolExecution(ctx context.Context, record engine.ToolExecutionRecord) error {
+	return b.inner.OnToolExecution(ctx, record)
+}
+
+func (b *BudgetGuardObserver) OnStepEnd(ctx context.Context, step int) error {
+	return b.inner.OnStepEnd(ctx, step)
+}
+
+func (b *BudgetGuardObserver) OnRunComplete(ctx context.Context, result engine.Result) error {
+	return b.inner.OnRunComplete(ctx, result)
+}
+
+func (b *BudgetGuardObserver) OnRunFailure(ctx context.Context, err error) error {
+	return b.inner.OnRunFailure(ctx, err)
+}

--- a/backend/internal/worker/budget_guard_observer_test.go
+++ b/backend/internal/worker/budget_guard_observer_test.go
@@ -1,0 +1,197 @@
+package worker
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/engine"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/provider"
+)
+
+func responseWithUsage(input, output int64) provider.Response {
+	return provider.Response{
+		Usage: provider.Usage{
+			InputTokens:  input,
+			OutputTokens: output,
+			TotalTokens:  input + output,
+		},
+	}
+}
+
+func TestBudgetGuardObserver_UnderLimit(t *testing.T) {
+	inner := &recordingObserver{}
+	// Hard limit $1.00, input $10/M, output $30/M.
+	guard := NewBudgetGuardObserver(inner, 1.0, 10.0, 30.0)
+
+	// 1000 input tokens + 500 output tokens =
+	// (1000/1M)*10 + (500/1M)*30 = 0.01 + 0.015 = $0.025
+	resp := responseWithUsage(1000, 500)
+	err := guard.OnProviderResponse(context.Background(), resp)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	calls := inner.getCalls()
+	if len(calls) != 1 || calls[0] != "OnProviderResponse" {
+		t.Errorf("expected [OnProviderResponse], got %v", calls)
+	}
+}
+
+func TestBudgetGuardObserver_ExceedsLimit(t *testing.T) {
+	inner := &recordingObserver{}
+	// Hard limit $0.01, input $10/M, output $30/M.
+	guard := NewBudgetGuardObserver(inner, 0.01, 10.0, 30.0)
+
+	// 1000 input + 500 output = $0.025, exceeds $0.01.
+	resp := responseWithUsage(1000, 500)
+	err := guard.OnProviderResponse(context.Background(), resp)
+	if err == nil {
+		t.Fatal("expected budget exceeded error, got nil")
+	}
+	if !strings.Contains(err.Error(), "budget exceeded") {
+		t.Errorf("expected error to contain 'budget exceeded', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "hard limit") {
+		t.Errorf("expected error to contain 'hard limit', got: %v", err)
+	}
+
+	// Inner observer should NOT have been called.
+	calls := inner.getCalls()
+	if len(calls) != 0 {
+		t.Errorf("expected no inner calls when budget exceeded, got %v", calls)
+	}
+}
+
+func TestBudgetGuardObserver_AccumulatesAcrossCalls(t *testing.T) {
+	inner := &recordingObserver{}
+	// Hard limit $0.05, input $10/M, output $30/M.
+	guard := NewBudgetGuardObserver(inner, 0.05, 10.0, 30.0)
+
+	// Each call: 1000 input + 500 output = $0.025.
+	resp := responseWithUsage(1000, 500)
+
+	// First call: accumulated = $0.025, under limit.
+	err := guard.OnProviderResponse(context.Background(), resp)
+	if err != nil {
+		t.Fatalf("first call: expected no error, got: %v", err)
+	}
+
+	// Second call: accumulated = $0.050, still under limit (not strictly greater).
+	err = guard.OnProviderResponse(context.Background(), resp)
+	if err != nil {
+		t.Fatalf("second call: expected no error at exact limit, got: %v", err)
+	}
+
+	// Third call: accumulated = $0.075, exceeds $0.05.
+	err = guard.OnProviderResponse(context.Background(), resp)
+	if err == nil {
+		t.Fatal("third call: expected budget exceeded error, got nil")
+	}
+	if !strings.Contains(err.Error(), "budget exceeded") {
+		t.Errorf("expected error to contain 'budget exceeded', got: %v", err)
+	}
+
+	// Inner should have been called twice (first two calls delegated).
+	calls := inner.getCalls()
+	if len(calls) != 2 {
+		t.Errorf("expected 2 inner calls, got %d: %v", len(calls), calls)
+	}
+}
+
+func TestBudgetGuardObserver_ZeroLimit(t *testing.T) {
+	inner := &recordingObserver{}
+	// Hard limit 0 means disabled.
+	guard := NewBudgetGuardObserver(inner, 0, 10.0, 30.0)
+
+	// Even a large usage should pass through.
+	resp := responseWithUsage(1_000_000, 1_000_000)
+	err := guard.OnProviderResponse(context.Background(), resp)
+	if err != nil {
+		t.Fatalf("expected no error with zero limit (disabled), got: %v", err)
+	}
+
+	calls := inner.getCalls()
+	if len(calls) != 1 || calls[0] != "OnProviderResponse" {
+		t.Errorf("expected [OnProviderResponse], got %v", calls)
+	}
+}
+
+func TestBudgetGuardObserver_NegativeLimit(t *testing.T) {
+	inner := &recordingObserver{}
+	// Negative hard limit also means disabled.
+	guard := NewBudgetGuardObserver(inner, -5.0, 10.0, 30.0)
+
+	resp := responseWithUsage(1_000_000, 1_000_000)
+	err := guard.OnProviderResponse(context.Background(), resp)
+	if err != nil {
+		t.Fatalf("expected no error with negative limit (disabled), got: %v", err)
+	}
+
+	calls := inner.getCalls()
+	if len(calls) != 1 || calls[0] != "OnProviderResponse" {
+		t.Errorf("expected [OnProviderResponse], got %v", calls)
+	}
+}
+
+func TestBudgetGuardObserver_DelegatesToInner(t *testing.T) {
+	inner := &recordingObserver{}
+	guard := NewBudgetGuardObserver(inner, 100.0, 10.0, 30.0)
+	ctx := context.Background()
+
+	// Call every method and verify delegation.
+	if err := guard.OnStepStart(ctx, 1); err != nil {
+		t.Fatalf("OnStepStart: %v", err)
+	}
+	if err := guard.OnProviderCall(ctx, provider.Request{}); err != nil {
+		t.Fatalf("OnProviderCall: %v", err)
+	}
+	if err := guard.OnProviderOutput(ctx, provider.Request{}, provider.StreamDelta{}); err != nil {
+		t.Fatalf("OnProviderOutput: %v", err)
+	}
+	if err := guard.OnProviderResponse(ctx, provider.Response{}); err != nil {
+		t.Fatalf("OnProviderResponse: %v", err)
+	}
+	if err := guard.OnToolExecution(ctx, engine.ToolExecutionRecord{}); err != nil {
+		t.Fatalf("OnToolExecution: %v", err)
+	}
+	if err := guard.OnStepEnd(ctx, 1); err != nil {
+		t.Fatalf("OnStepEnd: %v", err)
+	}
+	if err := guard.OnRunComplete(ctx, engine.Result{}); err != nil {
+		t.Fatalf("OnRunComplete: %v", err)
+	}
+
+	expected := []string{
+		"OnStepStart",
+		"OnProviderCall",
+		"OnProviderOutput",
+		"OnProviderResponse",
+		"OnToolExecution",
+		"OnStepEnd",
+		"OnRunComplete",
+	}
+	calls := inner.getCalls()
+	if len(calls) != len(expected) {
+		t.Fatalf("expected %d calls, got %d: %v", len(expected), len(calls), calls)
+	}
+	for i, want := range expected {
+		if calls[i] != want {
+			t.Errorf("call[%d] = %q, want %q", i, calls[i], want)
+		}
+	}
+}
+
+func TestBudgetGuardObserver_DelegatesOnRunFailure(t *testing.T) {
+	inner := &recordingObserver{}
+	guard := NewBudgetGuardObserver(inner, 100.0, 10.0, 30.0)
+
+	if err := guard.OnRunFailure(context.Background(), nil); err != nil {
+		t.Fatalf("OnRunFailure: %v", err)
+	}
+
+	calls := inner.getCalls()
+	if len(calls) != 1 || calls[0] != "OnRunFailure" {
+		t.Errorf("expected [OnRunFailure], got %v", calls)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds per-workspace API rate limiting with standard `X-RateLimit-*` headers and `429` responses (in-memory, `golang.org/x/time/rate`)
- Enforces spend policy `hard_limit` before run creation — rejects with `budget_exceeded` when workspace spend exceeds the limit
- Adds `BudgetGuardObserver` for synchronous in-run cost tracking that halts runs exceeding budget mid-execution
- Implements routing policy framework with `single_model` and `fallback` selectors (`budget_aware`/`latency_aware` return unsupported for now)
- New DB migration (`00020`): `workspace_spend_ledger`, `run_cost_summaries` tables, pricing columns on `model_catalog_entries`
- Budget repository layer: window spend queries, cost summary persistence, upsert ledger
- All new packages have comprehensive tests (37 tests across 4 packages)

Closes #127

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test -short -race -count=1 ./internal/ratelimit/...` — 7 tests pass
- [x] `go test -short -race -count=1 ./internal/budget/...` — 19 tests pass  
- [x] `go test -short -race -count=1 ./internal/routing/...` — 11 tests pass
- [x] `go test -short -race -count=1 ./internal/worker/...` — all tests pass (includes budget guard observer)
- [x] `go test -short -race -count=1 ./internal/api/...` — all tests pass (includes run creation with budget checker)
- [x] Migration applies cleanly: all 20 migrations applied successfully on fresh DB
- [x] Manual: create spend policy with hard_limit=$0.01, seed ledger with $0.02 spent → run creation returns `{"error":{"code":"budget_exceeded","message":"workspace spend limit exceeded (current: $0.02, limit: $0.01)"}}`; reset to $0.001 → run creation succeeds with status "queued"
- [x] Manual: rapid-fire 25 requests to workspace endpoint → request 25 returns `429` with `X-RateLimit-Limit: 20`, `X-RateLimit-Remaining: 0`, `Retry-After: 1` headers and `{"error":{"code":"rate_limited","message":"too many requests, retry after 1 seconds"}}` body

🤖 Generated with [Claude Code](https://claude.com/claude-code)