### PR TITLE
fix(engine): inject workspace secrets in PromptEvalExecutor

### DIFF
--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -67,7 +67,7 @@ func main() {
 	promptEvalInvoker := workerapp.NewPromptEvalInvokerWithObserverFactory(
 		providerRouter,
 		workerapp.NewBufferedPromptEvalObserverFactory(repo),
-	)
+	).WithSecretsLookup(repo)
 	temporalWorker := workerapp.NewTemporalWorker(temporalClient, cfg, repo, providerRouter, workflowpkg.FakeWorkHooks{
 		HostedRunStarter:   hostedRunClient,
 		NativeModelInvoker: nativeModelInvoker,

--- a/backend/internal/engine/prompt_eval_executor.go
+++ b/backend/internal/engine/prompt_eval_executor.go
@@ -12,14 +12,16 @@ import (
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/challengepack"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/provider"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
 )
 
 // PromptEvalExecutor runs a single provider call without any sandbox, tools,
 // or agent loop. It produces the same Result/event shape as NativeExecutor so
 // the scoring pipeline can consume it unchanged.
 type PromptEvalExecutor struct {
-	client   provider.Client
-	observer Observer
+	client        provider.Client
+	observer      Observer
+	secretsLookup SecretsLookup
 }
 
 func NewPromptEvalExecutor(client provider.Client, observer Observer) PromptEvalExecutor {
@@ -30,6 +32,27 @@ func NewPromptEvalExecutor(client provider.Client, observer Observer) PromptEval
 		client:   client,
 		observer: observer,
 	}
+}
+
+// WithSecretsLookup attaches a secrets source used to resolve
+// workspace-secret:// credential references at run-start.
+func (e PromptEvalExecutor) WithSecretsLookup(lookup SecretsLookup) PromptEvalExecutor {
+	e.secretsLookup = lookup
+	return e
+}
+
+func (e PromptEvalExecutor) loadWorkspaceSecrets(ctx context.Context, workspaceID uuid.UUID) (map[string]string, error) {
+	if e.secretsLookup == nil {
+		return map[string]string{}, nil
+	}
+	loaded, err := e.secretsLookup.LoadWorkspaceSecrets(ctx, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	if loaded == nil {
+		return map[string]string{}, nil
+	}
+	return loaded, nil
 }
 
 func (e PromptEvalExecutor) Execute(ctx context.Context, executionContext repository.RunAgentExecutionContext) (result Result, err error) {
@@ -65,10 +88,14 @@ func (e PromptEvalExecutor) Execute(ctx context.Context, executionContext reposi
 		)
 	}
 
-	runCtx := ctx
+	workspaceSecrets, err := e.loadWorkspaceSecrets(ctx, executionContext.Run.WorkspaceID)
+	if err != nil {
+		return Result{}, NewFailure(StopReasonSandboxError, fmt.Sprintf("load workspace secrets: %v", err), err)
+	}
+	runCtx := provider.WithWorkspaceSecrets(ctx, workspaceSecrets)
 	cancel := func() {}
 	if timeout := runTimeout(executionContext); timeout > 0 {
-		runCtx, cancel = context.WithTimeout(ctx, timeout)
+		runCtx, cancel = context.WithTimeout(runCtx, timeout)
 	}
 	defer cancel()
 

--- a/backend/internal/engine/prompt_eval_executor_test.go
+++ b/backend/internal/engine/prompt_eval_executor_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -172,6 +173,65 @@ func TestPromptEvalExecutorRejectsMissingInstructions(t *testing.T) {
 	}
 	if len(client.Requests) != 0 {
 		t.Fatalf("provider should not be called when instructions missing; got %d requests", len(client.Requests))
+	}
+}
+
+func TestPromptEvalExecutorInjectsWorkspaceSecrets(t *testing.T) {
+	workspaceID := uuid.New()
+	ctx := promptEvalExecutionContext()
+	ctx.Run.WorkspaceID = workspaceID
+
+	secretsStore := &stubSecretsLookup{secrets: map[string]string{
+		"PROVIDER_OPENAI_API_KEY": "sk-test-key-12345",
+	}}
+
+	client := &provider.FakeClient{Response: provider.Response{OutputText: "hello"}}
+	executor := NewPromptEvalExecutor(client, &recordingObserver{}).WithSecretsLookup(secretsStore)
+
+	result, err := executor.Execute(context.Background(), ctx)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.StopReason != StopReasonCompleted {
+		t.Fatalf("stop reason = %s, want completed", result.StopReason)
+	}
+	if secretsStore.calls != 1 {
+		t.Fatalf("secrets lookup calls = %d, want 1", secretsStore.calls)
+	}
+	if secretsStore.lastID != workspaceID {
+		t.Fatalf("secrets lookup workspace ID = %s, want %s", secretsStore.lastID, workspaceID)
+	}
+}
+
+func TestPromptEvalExecutorSecretsLookupErrorFailsRun(t *testing.T) {
+	ctx := promptEvalExecutionContext()
+	ctx.Run.WorkspaceID = uuid.New()
+
+	lookupErr := errors.New("vault is sealed")
+	secretsStore := &stubSecretsLookup{err: lookupErr}
+
+	client := &provider.FakeClient{Response: provider.Response{OutputText: "ignored"}}
+	executor := NewPromptEvalExecutor(client, &recordingObserver{}).WithSecretsLookup(secretsStore)
+
+	_, err := executor.Execute(context.Background(), ctx)
+	if err == nil {
+		t.Fatalf("expected Execute to fail on secrets lookup error")
+	}
+	if !errors.Is(err, lookupErr) {
+		t.Fatalf("expected wrapped lookup error, got %v", err)
+	}
+}
+
+func TestPromptEvalExecutorWithoutSecretsLookupStillWorks(t *testing.T) {
+	client := &provider.FakeClient{Response: provider.Response{OutputText: "ok"}}
+	executor := NewPromptEvalExecutor(client, &recordingObserver{})
+
+	result, err := executor.Execute(context.Background(), promptEvalExecutionContext())
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.StopReason != StopReasonCompleted {
+		t.Fatalf("stop reason = %s, want completed", result.StopReason)
 	}
 }
 

--- a/backend/internal/worker/prompt_eval_invoker.go
+++ b/backend/internal/worker/prompt_eval_invoker.go
@@ -11,6 +11,7 @@ import (
 type PromptEvalInvoker struct {
 	client          provider.Client
 	observerFactory PromptEvalObserverFactory
+	secretsLookup   engine.SecretsLookup
 }
 
 func NewPromptEvalInvoker(client provider.Client) PromptEvalInvoker {
@@ -30,6 +31,13 @@ func NewPromptEvalInvokerWithObserverFactory(client provider.Client, observerFac
 	}
 }
 
+// WithSecretsLookup returns an invoker that propagates the given secrets
+// source to every PromptEvalExecutor it constructs.
+func (i PromptEvalInvoker) WithSecretsLookup(lookup engine.SecretsLookup) PromptEvalInvoker {
+	i.secretsLookup = lookup
+	return i
+}
+
 func (i PromptEvalInvoker) InvokePromptEval(ctx context.Context, executionContext repository.RunAgentExecutionContext) (engine.Result, error) {
 	observer := engine.Observer(engine.NoopObserver{})
 	if i.observerFactory != nil {
@@ -43,5 +51,8 @@ func (i PromptEvalInvoker) InvokePromptEval(ctx context.Context, executionContex
 	}
 
 	executor := engine.NewPromptEvalExecutor(i.client, observer)
+	if i.secretsLookup != nil {
+		executor = executor.WithSecretsLookup(i.secretsLookup)
+	}
 	return executor.Execute(ctx, executionContext)
 }


### PR DESCRIPTION
## Summary
- **PromptEvalExecutor** never loaded workspace secrets into the context, causing all `workspace-secret://` credential references to fail with `FailureCodeCredentialUnavailable` in prompt_eval mode
- Added `SecretsLookup` field + `WithSecretsLookup()` builder to `PromptEvalExecutor` (mirrors `NativeExecutor`)
- Added `WithSecretsLookup()` to `PromptEvalInvoker` and wired `.WithSecretsLookup(repo)` in `cmd/worker/main.go`

## Test plan
- [x] `TestPromptEvalExecutorInjectsWorkspaceSecrets` — verifies secrets lookup is called with correct workspace ID
- [x] `TestPromptEvalExecutorSecretsLookupErrorFailsRun` — verifies lookup errors propagate correctly
- [x] `TestPromptEvalExecutorWithoutSecretsLookupStillWorks` — verifies backward compat (no lookup = empty map)
- [x] All existing prompt_eval and native executor tests pass with `-race`
- [x] `go build ./...` and `go vet ./...` clean

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)