### PR TITLE
fix(cli): add monorepo tag_prefix for GoReleaser

### DIFF
--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -2,6 +2,9 @@ version: 2
 
 project_name: agentclash
 
+monorepo:
+  tag_prefix: cli/
+
 builds:
   - main: .
     binary: agentclash


### PR DESCRIPTION
## Summary

- Adds `monorepo.tag_prefix: cli/` to `.goreleaser.yaml` so GoReleaser can parse `cli/v0.1.0` tags as valid semver

The release workflow failed because GoReleaser couldn't parse `cli/v0.1.0` — it expects plain `v0.1.0` unless a monorepo prefix is configured.

## Test plan

- [ ] Merge, delete old tag, re-tag, verify release workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)