### PR TITLE
fix(cli): use plain v* tags for GoReleaser release

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -3,7 +3,7 @@ name: Release CLI
 on:
   push:
     tags:
-      - "cli/v*"
+      - "v*"
 
 defaults:
   run:

--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -2,9 +2,6 @@ version: 2
 
 project_name: agentclash
 
-monorepo:
-  tag_prefix: cli/
-
 builds:
   - main: .
     binary: agentclash


### PR DESCRIPTION
## Summary

- Remove `monorepo.tag_prefix` from goreleaser config (Pro-only feature)
- Change release workflow trigger from `cli/v*` to `v*` tags

## Test plan

- [ ] Merge, tag `v0.1.0`, verify GoReleaser builds and publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)