### PR TITLE
fix(cli): use separate token for Homebrew tap push

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -37,3 +37,4 @@ jobs:
           workdir: cli
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -43,6 +43,8 @@ brews:
   - repository:
       owner: agentclash
       name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    skip_upload: auto
     homepage: "https://github.com/agentclash/agentclash"
     description: "CLI for the AgentClash AI agent evaluation platform"
     license: "MIT"


### PR DESCRIPTION
## Summary

- Use `HOMEBREW_TAP_TOKEN` secret for pushing to `agentclash/homebrew-tap` (GITHUB_TOKEN can't write to other repos)
- Set `skip_upload: auto` so the release succeeds even without the token configured

To enable Homebrew tap updates: add a `HOMEBREW_TAP_TOKEN` repo secret with a PAT that has `repo` scope on `agentclash/homebrew-tap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)