### PR TITLE
feat(auth): web-based CLI login with device code fallback

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -107,10 +107,12 @@ func main() {
 	infraManager := api.NewInfrastructureManager(repo)
 	workspaceSecretsManager := api.NewWorkspaceSecretsManager(repo)
 
+	cliTokenAuth := api.NewCLITokenAuthenticator(repo, logger)
+
 	var authenticator api.Authenticator
 	switch cfg.AuthMode {
 	case "workos":
-		authenticator, err = api.NewWorkOSAuthenticator(api.WorkOSAuthenticatorConfig{
+		workosAuth, err := api.NewWorkOSAuthenticator(api.WorkOSAuthenticatorConfig{
 			ClientID: cfg.WorkOSClientID,
 			Issuer:   cfg.WorkOSIssuer,
 		}, repo, logger)
@@ -118,11 +120,14 @@ func main() {
 			logger.Error("failed to initialize workos authenticator", "error", err)
 			os.Exit(1)
 		}
-		logger.Info("authentication mode: workos")
+		authenticator = api.NewCompositeAuthenticator(workosAuth, cliTokenAuth)
+		logger.Info("authentication mode: workos (with CLI token support)")
 	default:
-		authenticator = api.NewDevelopmentAuthenticator()
-		logger.Info("authentication mode: dev (development headers)")
+		authenticator = api.NewCompositeAuthenticator(api.NewDevelopmentAuthenticator(), cliTokenAuth)
+		logger.Info("authentication mode: dev (development headers + CLI tokens)")
 	}
+
+	cliAuthManager := api.NewCLIAuthManager(repo, logger)
 
 	server := api.NewServer(
 		cfg,
@@ -150,6 +155,7 @@ func main() {
 		infraManager,
 		workspaceSecretsManager,
 		eventSubscriber,
+		cliAuthManager,
 	)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/backend/db/migrations/00021_cli_auth.sql
+++ b/backend/db/migrations/00021_cli_auth.sql
@@ -1,9 +1,8 @@
 -- +goose Up
 
 -- CLI tokens: long-lived, separately revocable tokens for CLI/CI authentication.
--- The raw token is returned once at creation and never stored. Only the SHA-256
--- hash is persisted, enabling fast lookup without brute-force risk (tokens have
--- 256 bits of entropy).
+-- Only the SHA-256 hash is persisted for auth lookup. The raw token is returned
+-- exactly once at creation time and never stored server-side.
 CREATE TABLE cli_tokens (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
@@ -22,6 +21,9 @@ CREATE INDEX cli_tokens_user_id_idx ON cli_tokens (user_id);
 -- The CLI gets a device_code (secret) and user_code (displayed). The user
 -- visits the web app, enters the user_code, and approves. The CLI polls
 -- until the status transitions from 'pending' to 'approved'.
+--
+-- raw_token is a temporary column that holds the raw CLI token after approval,
+-- allowing the polling CLI to retrieve it. It is NULLed out after first retrieval.
 CREATE TABLE device_auth_codes (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     device_code text NOT NULL,
@@ -29,7 +31,8 @@ CREATE TABLE device_auth_codes (
     status text NOT NULL DEFAULT 'pending'
         CHECK (status IN ('pending', 'approved', 'denied', 'expired')),
     user_id uuid REFERENCES users (id),
-    cli_token_id uuid REFERENCES cli_tokens (id),
+    cli_token_id uuid REFERENCES cli_tokens (id) ON DELETE SET NULL,
+    raw_token text,
     expires_at timestamptz NOT NULL,
     created_at timestamptz NOT NULL DEFAULT now()
 );

--- a/backend/db/migrations/00021_cli_auth.sql
+++ b/backend/db/migrations/00021_cli_auth.sql
@@ -1,0 +1,43 @@
+-- +goose Up
+
+-- CLI tokens: long-lived, separately revocable tokens for CLI/CI authentication.
+-- The raw token is returned once at creation and never stored. Only the SHA-256
+-- hash is persisted, enabling fast lookup without brute-force risk (tokens have
+-- 256 bits of entropy).
+CREATE TABLE cli_tokens (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    token_hash text NOT NULL,
+    name text NOT NULL DEFAULT '',
+    last_used_at timestamptz,
+    expires_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    revoked_at timestamptz
+);
+
+CREATE UNIQUE INDEX cli_tokens_token_hash_uq ON cli_tokens (token_hash);
+CREATE INDEX cli_tokens_user_id_idx ON cli_tokens (user_id);
+
+-- Device authorization codes for the RFC 8628-style device code flow.
+-- The CLI gets a device_code (secret) and user_code (displayed). The user
+-- visits the web app, enters the user_code, and approves. The CLI polls
+-- until the status transitions from 'pending' to 'approved'.
+CREATE TABLE device_auth_codes (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    device_code text NOT NULL,
+    user_code text NOT NULL,
+    status text NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'approved', 'denied', 'expired')),
+    user_id uuid REFERENCES users (id),
+    cli_token_id uuid REFERENCES cli_tokens (id),
+    expires_at timestamptz NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX device_auth_codes_device_code_uq ON device_auth_codes (device_code);
+CREATE UNIQUE INDEX device_auth_codes_user_code_pending_uq ON device_auth_codes (user_code)
+    WHERE status = 'pending';
+
+-- +goose Down
+DROP TABLE IF EXISTS device_auth_codes;
+DROP TABLE IF EXISTS cli_tokens;

--- a/backend/internal/api/agent_builds_test.go
+++ b/backend/internal/api/agent_builds_test.go
@@ -112,6 +112,7 @@ func TestGetAgentBuildRequiresWorkspaceMembership(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/agent-builds/"+buildID.String(), nil)
@@ -160,6 +161,7 @@ func TestGetAgentBuildVersionRequiresWorkspaceMembership(t *testing.T) {
 			},
 		},
 		noopReleaseGateService{},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -239,6 +241,7 @@ func TestGetAgentBuildVersionReturnsToolAndKnowledgeBindings(t *testing.T) {
 			},
 		},
 		noopReleaseGateService{},
+		nil,
 		nil,
 		nil,
 		nil,

--- a/backend/internal/api/artifacts_test.go
+++ b/backend/internal/api/artifacts_test.go
@@ -116,6 +116,7 @@ func TestArtifactManagerUploadAndSignedDownloadFlow(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {

--- a/backend/internal/api/auth_cli_token.go
+++ b/backend/internal/api/auth_cli_token.go
@@ -89,11 +89,10 @@ func (a *CLITokenAuthenticator) Authenticate(r *http.Request) (Caller, error) {
 		}
 	}
 
-	// Update last_used_at in the background (non-blocking).
+	// Best-effort update of last_used_at using the request context.
+	// If the server is shutting down this will fail gracefully.
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := a.repo.TouchCLITokenLastUsed(ctx, token.ID); err != nil {
+		if err := a.repo.TouchCLITokenLastUsed(r.Context(), token.ID); err != nil {
 			a.logger.Warn("failed to update CLI token last_used_at", "token_id", token.ID, "error", err)
 		}
 	}()

--- a/backend/internal/api/auth_cli_token.go
+++ b/backend/internal/api/auth_cli_token.go
@@ -1,0 +1,129 @@
+package api
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+const cliTokenPrefix = "clitok_"
+
+// CLITokenRepository is the subset of repository needed for CLI token auth.
+type CLITokenRepository interface {
+	GetCLITokenByHash(ctx context.Context, tokenHash string) (repository.CLIToken, error)
+	TouchCLITokenLastUsed(ctx context.Context, tokenID uuid.UUID) error
+	GetUserByID(ctx context.Context, userID uuid.UUID) (repository.User, error)
+	GetActiveOrganizationMembershipsByUserID(ctx context.Context, userID uuid.UUID) ([]repository.OrgMembershipRow, error)
+	GetActiveWorkspaceMembershipsByUserID(ctx context.Context, userID uuid.UUID) ([]repository.WorkspaceMembershipRow, error)
+}
+
+// CLITokenAuthenticator validates CLI tokens (prefixed with "clitok_") by
+// looking up their SHA-256 hash in the database.
+type CLITokenAuthenticator struct {
+	repo   CLITokenRepository
+	logger *slog.Logger
+}
+
+func NewCLITokenAuthenticator(repo CLITokenRepository, logger *slog.Logger) *CLITokenAuthenticator {
+	return &CLITokenAuthenticator{repo: repo, logger: logger}
+}
+
+func (a *CLITokenAuthenticator) Authenticate(r *http.Request) (Caller, error) {
+	tokenStr := extractBearerToken(r)
+	if tokenStr == "" {
+		return Caller{}, fmt.Errorf("%w: missing authorization header", ErrUnauthenticated)
+	}
+
+	if !strings.HasPrefix(tokenStr, cliTokenPrefix) {
+		return Caller{}, fmt.Errorf("%w: not a CLI token", ErrUnauthenticated)
+	}
+
+	hash := hashToken(tokenStr)
+	token, err := a.repo.GetCLITokenByHash(r.Context(), hash)
+	if err != nil {
+		return Caller{}, fmt.Errorf("%w: invalid CLI token", ErrUnauthenticated)
+	}
+
+	if token.RevokedAt != nil {
+		return Caller{}, fmt.Errorf("%w: CLI token has been revoked", ErrUnauthenticated)
+	}
+	if token.ExpiresAt != nil && token.ExpiresAt.Before(time.Now()) {
+		return Caller{}, fmt.Errorf("%w: CLI token has expired", ErrUnauthenticated)
+	}
+
+	// GetUserByID only returns active (non-archived) users.
+	user, err := a.repo.GetUserByID(r.Context(), token.UserID)
+	if err != nil {
+		return Caller{}, fmt.Errorf("%w: user not found or deactivated", ErrUnauthenticated)
+	}
+
+	orgMemberships, err := a.repo.GetActiveOrganizationMembershipsByUserID(r.Context(), user.ID)
+	if err != nil {
+		return Caller{}, fmt.Errorf("%w: failed to load organization memberships", ErrUnauthenticated)
+	}
+	orgMap := make(map[uuid.UUID]OrganizationMembership, len(orgMemberships))
+	for _, m := range orgMemberships {
+		orgMap[m.OrganizationID] = OrganizationMembership{
+			OrganizationID: m.OrganizationID,
+			Role:           m.Role,
+		}
+	}
+
+	wsMemberships, err := a.repo.GetActiveWorkspaceMembershipsByUserID(r.Context(), user.ID)
+	if err != nil {
+		return Caller{}, fmt.Errorf("%w: failed to load workspace memberships", ErrUnauthenticated)
+	}
+	wsMap := make(map[uuid.UUID]WorkspaceMembership, len(wsMemberships))
+	for _, m := range wsMemberships {
+		wsMap[m.WorkspaceID] = WorkspaceMembership{
+			WorkspaceID: m.WorkspaceID,
+			Role:        m.Role,
+		}
+	}
+
+	// Update last_used_at in the background (non-blocking).
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := a.repo.TouchCLITokenLastUsed(ctx, token.ID); err != nil {
+			a.logger.Warn("failed to update CLI token last_used_at", "token_id", token.ID, "error", err)
+		}
+	}()
+
+	return Caller{
+		UserID:                  user.ID,
+		WorkOSUserID:            user.WorkOSUserID,
+		Email:                   user.Email,
+		DisplayName:             user.DisplayName,
+		OrganizationMemberships: orgMap,
+		WorkspaceMemberships:    wsMap,
+	}, nil
+}
+
+// hashToken computes the SHA-256 hex digest of a raw token.
+func hashToken(raw string) string {
+	h := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(h[:])
+}
+
+// extractBearerToken gets the Bearer token from the Authorization header.
+func extractBearerToken(r *http.Request) string {
+	auth := r.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, "Bearer ") {
+		return ""
+	}
+	return strings.TrimPrefix(auth, "Bearer ")
+}
+
+// IsCLIToken returns true if the token string has the CLI token prefix.
+func IsCLIToken(token string) bool {
+	return strings.HasPrefix(token, cliTokenPrefix)
+}

--- a/backend/internal/api/auth_composite.go
+++ b/backend/internal/api/auth_composite.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// CompositeAuthenticator tries multiple authenticators based on the token format.
+// CLI tokens (prefixed with "clitok_") are routed to the CLITokenAuthenticator.
+// All other tokens are routed to the primary authenticator (WorkOS JWT).
+type CompositeAuthenticator struct {
+	primary  Authenticator // WorkOS JWT authenticator
+	cliToken Authenticator // CLI token authenticator
+}
+
+func NewCompositeAuthenticator(primary, cliToken Authenticator) *CompositeAuthenticator {
+	return &CompositeAuthenticator{primary: primary, cliToken: cliToken}
+}
+
+func (c *CompositeAuthenticator) Authenticate(r *http.Request) (Caller, error) {
+	token := extractBearerToken(r)
+	if token == "" {
+		return Caller{}, fmt.Errorf("%w: missing authorization header", ErrUnauthenticated)
+	}
+
+	if IsCLIToken(token) {
+		return c.cliToken.Authenticate(r)
+	}
+	return c.primary.Authenticate(r)
+}

--- a/backend/internal/api/challenge_packs_test.go
+++ b/backend/internal/api/challenge_packs_test.go
@@ -188,6 +188,7 @@ challenges:
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusCreated {

--- a/backend/internal/api/cli_auth.go
+++ b/backend/internal/api/cli_auth.go
@@ -1,0 +1,450 @@
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+// --------------------------------------------------------------------------
+// Service Interface
+// --------------------------------------------------------------------------
+
+type CLIAuthService interface {
+	CreateDeviceCode(ctx context.Context) (CreateDeviceCodeResult, error)
+	PollDeviceToken(ctx context.Context, deviceCode string) (PollDeviceTokenResult, error)
+	ApproveDeviceCode(ctx context.Context, caller Caller, userCode string) error
+	CreateCLIToken(ctx context.Context, caller Caller, name string) (CreateCLITokenResult, error)
+	ListCLITokens(ctx context.Context, caller Caller) ([]CLITokenSummary, error)
+	RevokeCLIToken(ctx context.Context, caller Caller, tokenID uuid.UUID) error
+}
+
+type CreateDeviceCodeResult struct {
+	DeviceCode      string `json:"device_code"`
+	UserCode        string `json:"user_code"`
+	VerificationURL string `json:"verification_url"`
+	ExpiresIn       int    `json:"expires_in"`
+	Interval        int    `json:"interval"`
+}
+
+type PollDeviceTokenResult struct {
+	Status string `json:"status"` // authorization_pending | approved | access_denied | expired_token
+	Token  string `json:"token,omitempty"`
+	UserID string `json:"user_id,omitempty"`
+	Email  string `json:"email,omitempty"`
+}
+
+type CreateCLITokenResult struct {
+	ID        uuid.UUID  `json:"id"`
+	Token     string     `json:"token"` // raw token, shown once
+	Name      string     `json:"name"`
+	CreatedAt time.Time  `json:"created_at"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+}
+
+type CLITokenSummary struct {
+	ID         uuid.UUID  `json:"id"`
+	Name       string     `json:"name"`
+	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
+	ExpiresAt  *time.Time `json:"expires_at,omitempty"`
+	CreatedAt  time.Time  `json:"created_at"`
+}
+
+// --------------------------------------------------------------------------
+// Manager (implements CLIAuthService)
+// --------------------------------------------------------------------------
+
+type CLIAuthRepository interface {
+	CreateCLIToken(ctx context.Context, userID uuid.UUID, tokenHash, name string, expiresAt *time.Time) (repository.CLIToken, error)
+	GetCLITokenByHash(ctx context.Context, tokenHash string) (repository.CLIToken, error)
+	ListCLITokensByUserID(ctx context.Context, userID uuid.UUID) ([]repository.CLIToken, error)
+	RevokeCLIToken(ctx context.Context, tokenID, userID uuid.UUID) error
+	CreateDeviceAuthCode(ctx context.Context, deviceCode, userCode string, expiresAt time.Time) (repository.DeviceAuthCode, error)
+	GetDeviceAuthCodeByDeviceCode(ctx context.Context, deviceCode string) (repository.DeviceAuthCode, error)
+	GetDeviceAuthCodeByUserCode(ctx context.Context, userCode string) (repository.DeviceAuthCode, error)
+	ApproveDeviceAuthCode(ctx context.Context, id, userID uuid.UUID, cliTokenID uuid.UUID) error
+	ExpireDeviceAuthCode(ctx context.Context, id uuid.UUID) error
+}
+
+type CLIAuthManager struct {
+	repo   CLIAuthRepository
+	logger *slog.Logger
+}
+
+func NewCLIAuthManager(repo CLIAuthRepository, logger *slog.Logger) *CLIAuthManager {
+	return &CLIAuthManager{repo: repo, logger: logger}
+}
+
+func (m *CLIAuthManager) CreateDeviceCode(ctx context.Context) (CreateDeviceCodeResult, error) {
+	deviceCode, err := generateSecureToken(32)
+	if err != nil {
+		return CreateDeviceCodeResult{}, fmt.Errorf("generating device code: %w", err)
+	}
+	deviceCode = "dc_" + deviceCode
+
+	userCode, err := generateUserCode()
+	if err != nil {
+		return CreateDeviceCodeResult{}, fmt.Errorf("generating user code: %w", err)
+	}
+
+	expiresAt := time.Now().Add(10 * time.Minute)
+
+	_, err = m.repo.CreateDeviceAuthCode(ctx, deviceCode, userCode, expiresAt)
+	if err != nil {
+		return CreateDeviceCodeResult{}, fmt.Errorf("storing device code: %w", err)
+	}
+
+	return CreateDeviceCodeResult{
+		DeviceCode:      deviceCode,
+		UserCode:        userCode,
+		VerificationURL: "/auth/device",
+		ExpiresIn:       600,
+		Interval:        5,
+	}, nil
+}
+
+func (m *CLIAuthManager) PollDeviceToken(ctx context.Context, deviceCode string) (PollDeviceTokenResult, error) {
+	code, err := m.repo.GetDeviceAuthCodeByDeviceCode(ctx, deviceCode)
+	if err != nil {
+		return PollDeviceTokenResult{Status: "expired_token"}, nil
+	}
+
+	if code.ExpiresAt.Before(time.Now()) {
+		m.repo.ExpireDeviceAuthCode(ctx, code.ID)
+		return PollDeviceTokenResult{Status: "expired_token"}, nil
+	}
+
+	switch code.Status {
+	case "pending":
+		return PollDeviceTokenResult{Status: "authorization_pending"}, nil
+	case "denied":
+		return PollDeviceTokenResult{Status: "access_denied"}, nil
+	case "approved":
+		if code.CLITokenID == nil {
+			return PollDeviceTokenResult{Status: "authorization_pending"}, nil
+		}
+		// Look up the CLI token to get the raw token — but we don't store raw tokens.
+		// Instead, the approval flow creates the token and stores it on the device code row.
+		// We need a different approach: store the raw token temporarily.
+		// For now, return that it's approved. The CLI will need to get the token another way.
+		// Actually, let's store the raw token in a separate field or use a different approach.
+
+		// Revised approach: when the device code is approved, the approver creates a CLI token
+		// and we store the raw token on the device_auth_code row temporarily. But we don't have
+		// a column for that. Instead, use the device_code field itself as a lookup key, and when
+		// approved, the CLI receives the token through a secure side channel.
+
+		// Simplest correct approach: the approve endpoint creates the CLI token and returns
+		// it in the PollDeviceToken response by looking up the CLI token hash.
+		// Since we can't reverse SHA-256, we need to store the raw token somewhere.
+		// Let's use a simple approach: store the raw token in-memory via the device_code row.
+
+		// For a production system, this would use Redis or a temporary encrypted storage.
+		// For now, we'll put the raw token directly in the user_code field after approval
+		// (since user_code is no longer needed after approval).
+		// This is a pragmatic choice — the device_code lookup is already gated by the secret device_code.
+
+		return PollDeviceTokenResult{
+			Status: "approved",
+			Token:  code.UserCode, // repurposed to hold the raw token after approval
+		}, nil
+	default:
+		return PollDeviceTokenResult{Status: "expired_token"}, nil
+	}
+}
+
+func (m *CLIAuthManager) ApproveDeviceCode(ctx context.Context, caller Caller, userCode string) error {
+	code, err := m.repo.GetDeviceAuthCodeByUserCode(ctx, userCode)
+	if err != nil {
+		return fmt.Errorf("device code not found or expired")
+	}
+	if code.ExpiresAt.Before(time.Now()) {
+		m.repo.ExpireDeviceAuthCode(ctx, code.ID)
+		return fmt.Errorf("device code expired")
+	}
+
+	// Create a CLI token for the caller.
+	result, err := m.CreateCLIToken(ctx, caller, "CLI Device Login")
+	if err != nil {
+		return fmt.Errorf("creating CLI token: %w", err)
+	}
+
+	// Approve the device code. Store the raw token in user_code for the polling endpoint to retrieve.
+	// This is safe because: (1) only the holder of the secret device_code can poll, (2) the row
+	// transitions from "pending" to "approved" atomically.
+	if err := m.repo.ApproveDeviceAuthCode(ctx, code.ID, caller.UserID, result.ID); err != nil {
+		return fmt.Errorf("approving device code: %w", err)
+	}
+
+	// Store the raw token by updating user_code (no longer needed after approval).
+	// This is a pragmatic choice for the MVP. A production system would use Redis or an encrypted temp store.
+	m.storeRawTokenOnDevice(ctx, code.ID, result.Token)
+
+	return nil
+}
+
+func (m *CLIAuthManager) storeRawTokenOnDevice(ctx context.Context, codeID uuid.UUID, rawToken string) {
+	// Update user_code to hold the raw token. This is only readable by the device_code holder.
+	// We bypass the unique index constraint because the status is now "approved", not "pending".
+	// The partial unique index on user_code only applies WHERE status = 'pending'.
+	_, err := m.execRaw(ctx, `UPDATE device_auth_codes SET user_code = $1 WHERE id = $2`, rawToken, codeID)
+	if err != nil {
+		m.logger.Warn("failed to store raw token on device code", "error", err)
+	}
+}
+
+func (m *CLIAuthManager) CreateCLIToken(ctx context.Context, caller Caller, name string) (CreateCLITokenResult, error) {
+	rawBytes := make([]byte, 32)
+	if _, err := rand.Read(rawBytes); err != nil {
+		return CreateCLITokenResult{}, fmt.Errorf("generating token: %w", err)
+	}
+	rawToken := cliTokenPrefix + base64.RawURLEncoding.EncodeToString(rawBytes)
+	hash := sha256.Sum256([]byte(rawToken))
+	tokenHash := hex.EncodeToString(hash[:])
+
+	token, err := m.repo.CreateCLIToken(ctx, caller.UserID, tokenHash, name, nil)
+	if err != nil {
+		return CreateCLITokenResult{}, err
+	}
+
+	return CreateCLITokenResult{
+		ID:        token.ID,
+		Token:     rawToken,
+		Name:      token.Name,
+		CreatedAt: token.CreatedAt,
+		ExpiresAt: token.ExpiresAt,
+	}, nil
+}
+
+func (m *CLIAuthManager) ListCLITokens(ctx context.Context, caller Caller) ([]CLITokenSummary, error) {
+	tokens, err := m.repo.ListCLITokensByUserID(ctx, caller.UserID)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]CLITokenSummary, len(tokens))
+	for i, t := range tokens {
+		out[i] = CLITokenSummary{
+			ID:         t.ID,
+			Name:       t.Name,
+			LastUsedAt: t.LastUsedAt,
+			ExpiresAt:  t.ExpiresAt,
+			CreatedAt:  t.CreatedAt,
+		}
+	}
+	return out, nil
+}
+
+func (m *CLIAuthManager) RevokeCLIToken(ctx context.Context, caller Caller, tokenID uuid.UUID) error {
+	return m.repo.RevokeCLIToken(ctx, tokenID, caller.UserID)
+}
+
+// execRaw is a helper for ad-hoc queries not in the repository interface.
+// Uses the Repository's db pool directly. This requires the repository to implement
+// a method we can call. Since CLIAuthRepository is an interface, we'll use a type assertion.
+func (m *CLIAuthManager) execRaw(ctx context.Context, query string, args ...any) (int64, error) {
+	if repo, ok := m.repo.(*repository.Repository); ok {
+		return repo.ExecRaw(ctx, query, args...)
+	}
+	return 0, fmt.Errorf("raw exec not supported")
+}
+
+// --------------------------------------------------------------------------
+// Handlers
+// --------------------------------------------------------------------------
+
+// registerCLIAuthPublicRoutes adds unauthenticated device code endpoints.
+func registerCLIAuthPublicRoutes(router chi.Router, logger *slog.Logger, service CLIAuthService) {
+	router.Route("/v1/auth", func(r chi.Router) {
+		r.Post("/device", createDeviceCodeHandler(logger, service))
+		r.Post("/device/token", pollDeviceTokenHandler(logger, service))
+	})
+}
+
+func createDeviceCodeHandler(logger *slog.Logger, service CLIAuthService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		result, err := service.CreateDeviceCode(r.Context())
+		if err != nil {
+			logger.Error("create device code failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "failed to create device code")
+			return
+		}
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func pollDeviceTokenHandler(logger *slog.Logger, service CLIAuthService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var input struct {
+			DeviceCode string `json:"device_code"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil || input.DeviceCode == "" {
+			writeError(w, http.StatusBadRequest, "invalid_request", "device_code is required")
+			return
+		}
+
+		result, err := service.PollDeviceToken(r.Context(), input.DeviceCode)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+			return
+		}
+
+		if result.Status == "authorization_pending" {
+			writeError(w, http.StatusBadRequest, "authorization_pending", "waiting for user authorization")
+			return
+		}
+		if result.Status == "access_denied" {
+			writeError(w, http.StatusBadRequest, "access_denied", "user denied authorization")
+			return
+		}
+		if result.Status == "expired_token" {
+			writeError(w, http.StatusBadRequest, "expired_token", "device code has expired")
+			return
+		}
+
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func approveDeviceCodeHandler(logger *slog.Logger, service CLIAuthService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "authentication required")
+			return
+		}
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+
+		var input struct {
+			UserCode string `json:"user_code"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil || input.UserCode == "" {
+			writeError(w, http.StatusBadRequest, "invalid_request", "user_code is required")
+			return
+		}
+
+		if err := service.ApproveDeviceCode(r.Context(), caller, strings.ToUpper(strings.TrimSpace(input.UserCode))); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+	}
+}
+
+func createCLITokenHandler(logger *slog.Logger, service CLIAuthService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "authentication required")
+			return
+		}
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+
+		var input struct {
+			Name string `json:"name"`
+		}
+		json.NewDecoder(r.Body).Decode(&input)
+		if input.Name == "" {
+			input.Name = "CLI Token"
+		}
+
+		result, err := service.CreateCLIToken(r.Context(), caller, input.Name)
+		if err != nil {
+			logger.Error("create CLI token failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "failed to create token")
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, result)
+	}
+}
+
+func listCLITokensHandler(logger *slog.Logger, service CLIAuthService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "authentication required")
+			return
+		}
+
+		tokens, err := service.ListCLITokens(r.Context(), caller)
+		if err != nil {
+			logger.Error("list CLI tokens failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "failed to list tokens")
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{"items": tokens})
+	}
+}
+
+func revokeCLITokenHandler(logger *slog.Logger, service CLIAuthService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "authentication required")
+			return
+		}
+
+		raw := chi.URLParam(r, "id")
+		tokenID, err := uuid.Parse(raw)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "invalid token ID")
+			return
+		}
+
+		if err := service.RevokeCLIToken(r.Context(), caller, tokenID); err != nil {
+			writeError(w, http.StatusNotFound, "not_found", "token not found")
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+func generateSecureToken(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// generateUserCode creates a short code like "RRGQ-BJVS" from a 22-char alphabet
+// (A-Z minus I,O; 0-9 minus 0,1 to avoid ambiguity).
+func generateUserCode() (string, error) {
+	const alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+	code := make([]byte, 8)
+	for i := range code {
+		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(alphabet))))
+		if err != nil {
+			return "", err
+		}
+		code[i] = alphabet[n.Int64()]
+	}
+	return string(code[:4]) + "-" + string(code[4:]), nil
+}

--- a/backend/internal/api/cli_auth.go
+++ b/backend/internal/api/cli_auth.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math/big"
@@ -23,6 +24,7 @@ import (
 // Service Interface
 // --------------------------------------------------------------------------
 
+// CLIAuthService handles CLI token lifecycle and device code flow.
 type CLIAuthService interface {
 	CreateDeviceCode(ctx context.Context) (CreateDeviceCodeResult, error)
 	PollDeviceToken(ctx context.Context, deviceCode string) (PollDeviceTokenResult, error)
@@ -32,16 +34,16 @@ type CLIAuthService interface {
 	RevokeCLIToken(ctx context.Context, caller Caller, tokenID uuid.UUID) error
 }
 
+// CreateDeviceCodeResult follows RFC 8628 Section 3.2 field naming.
 type CreateDeviceCodeResult struct {
 	DeviceCode      string `json:"device_code"`
 	UserCode        string `json:"user_code"`
-	VerificationURL string `json:"verification_url"`
+	VerificationURI string `json:"verification_uri"`
 	ExpiresIn       int    `json:"expires_in"`
 	Interval        int    `json:"interval"`
 }
 
 type PollDeviceTokenResult struct {
-	Status string `json:"status"` // authorization_pending | approved | access_denied | expired_token
 	Token  string `json:"token,omitempty"`
 	UserID string `json:"user_id,omitempty"`
 	Email  string `json:"email,omitempty"`
@@ -49,7 +51,7 @@ type PollDeviceTokenResult struct {
 
 type CreateCLITokenResult struct {
 	ID        uuid.UUID  `json:"id"`
-	Token     string     `json:"token"` // raw token, shown once
+	Token     string     `json:"token"`
 	Name      string     `json:"name"`
 	CreatedAt time.Time  `json:"created_at"`
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
@@ -64,21 +66,23 @@ type CLITokenSummary struct {
 }
 
 // --------------------------------------------------------------------------
-// Manager (implements CLIAuthService)
+// Manager
 // --------------------------------------------------------------------------
 
+// CLIAuthRepository defines the data access methods the manager needs.
 type CLIAuthRepository interface {
 	CreateCLIToken(ctx context.Context, userID uuid.UUID, tokenHash, name string, expiresAt *time.Time) (repository.CLIToken, error)
-	GetCLITokenByHash(ctx context.Context, tokenHash string) (repository.CLIToken, error)
 	ListCLITokensByUserID(ctx context.Context, userID uuid.UUID) ([]repository.CLIToken, error)
 	RevokeCLIToken(ctx context.Context, tokenID, userID uuid.UUID) error
 	CreateDeviceAuthCode(ctx context.Context, deviceCode, userCode string, expiresAt time.Time) (repository.DeviceAuthCode, error)
 	GetDeviceAuthCodeByDeviceCode(ctx context.Context, deviceCode string) (repository.DeviceAuthCode, error)
 	GetDeviceAuthCodeByUserCode(ctx context.Context, userCode string) (repository.DeviceAuthCode, error)
-	ApproveDeviceAuthCode(ctx context.Context, id, userID uuid.UUID, cliTokenID uuid.UUID) error
+	ApproveDeviceAuthCode(ctx context.Context, id, userID uuid.UUID, cliTokenID uuid.UUID, rawToken string) error
+	ConsumeDeviceRawToken(ctx context.Context, id uuid.UUID) (string, error)
 	ExpireDeviceAuthCode(ctx context.Context, id uuid.UUID) error
 }
 
+// CLIAuthManager implements CLIAuthService.
 type CLIAuthManager struct {
 	repo   CLIAuthRepository
 	logger *slog.Logger
@@ -101,16 +105,14 @@ func (m *CLIAuthManager) CreateDeviceCode(ctx context.Context) (CreateDeviceCode
 	}
 
 	expiresAt := time.Now().Add(10 * time.Minute)
-
-	_, err = m.repo.CreateDeviceAuthCode(ctx, deviceCode, userCode, expiresAt)
-	if err != nil {
+	if _, err := m.repo.CreateDeviceAuthCode(ctx, deviceCode, userCode, expiresAt); err != nil {
 		return CreateDeviceCodeResult{}, fmt.Errorf("storing device code: %w", err)
 	}
 
 	return CreateDeviceCodeResult{
 		DeviceCode:      deviceCode,
 		UserCode:        userCode,
-		VerificationURL: "/auth/device",
+		VerificationURI: "/auth/device",
 		ExpiresIn:       600,
 		Interval:        5,
 	}, nil
@@ -119,50 +121,35 @@ func (m *CLIAuthManager) CreateDeviceCode(ctx context.Context) (CreateDeviceCode
 func (m *CLIAuthManager) PollDeviceToken(ctx context.Context, deviceCode string) (PollDeviceTokenResult, error) {
 	code, err := m.repo.GetDeviceAuthCodeByDeviceCode(ctx, deviceCode)
 	if err != nil {
-		return PollDeviceTokenResult{Status: "expired_token"}, nil
+		if errors.Is(err, repository.ErrDeviceCodeNotFound) {
+			return PollDeviceTokenResult{}, fmt.Errorf("expired_token")
+		}
+		return PollDeviceTokenResult{}, fmt.Errorf("lookup failed: %w", err)
 	}
 
 	if code.ExpiresAt.Before(time.Now()) {
 		m.repo.ExpireDeviceAuthCode(ctx, code.ID)
-		return PollDeviceTokenResult{Status: "expired_token"}, nil
+		return PollDeviceTokenResult{}, fmt.Errorf("expired_token")
 	}
 
 	switch code.Status {
 	case "pending":
-		return PollDeviceTokenResult{Status: "authorization_pending"}, nil
+		return PollDeviceTokenResult{}, fmt.Errorf("authorization_pending")
 	case "denied":
-		return PollDeviceTokenResult{Status: "access_denied"}, nil
+		return PollDeviceTokenResult{}, fmt.Errorf("access_denied")
 	case "approved":
-		if code.CLITokenID == nil {
-			return PollDeviceTokenResult{Status: "authorization_pending"}, nil
+		// Atomically consume the raw token (read + NULL in one query).
+		rawToken, err := m.repo.ConsumeDeviceRawToken(ctx, code.ID)
+		if err != nil {
+			return PollDeviceTokenResult{}, fmt.Errorf("consuming token: %w", err)
 		}
-		// Look up the CLI token to get the raw token — but we don't store raw tokens.
-		// Instead, the approval flow creates the token and stores it on the device code row.
-		// We need a different approach: store the raw token temporarily.
-		// For now, return that it's approved. The CLI will need to get the token another way.
-		// Actually, let's store the raw token in a separate field or use a different approach.
-
-		// Revised approach: when the device code is approved, the approver creates a CLI token
-		// and we store the raw token on the device_auth_code row temporarily. But we don't have
-		// a column for that. Instead, use the device_code field itself as a lookup key, and when
-		// approved, the CLI receives the token through a secure side channel.
-
-		// Simplest correct approach: the approve endpoint creates the CLI token and returns
-		// it in the PollDeviceToken response by looking up the CLI token hash.
-		// Since we can't reverse SHA-256, we need to store the raw token somewhere.
-		// Let's use a simple approach: store the raw token in-memory via the device_code row.
-
-		// For a production system, this would use Redis or a temporary encrypted storage.
-		// For now, we'll put the raw token directly in the user_code field after approval
-		// (since user_code is no longer needed after approval).
-		// This is a pragmatic choice — the device_code lookup is already gated by the secret device_code.
-
-		return PollDeviceTokenResult{
-			Status: "approved",
-			Token:  code.UserCode, // repurposed to hold the raw token after approval
-		}, nil
+		if rawToken == "" {
+			// Token already consumed by a previous poll.
+			return PollDeviceTokenResult{}, fmt.Errorf("expired_token")
+		}
+		return PollDeviceTokenResult{Token: rawToken}, nil
 	default:
-		return PollDeviceTokenResult{Status: "expired_token"}, nil
+		return PollDeviceTokenResult{}, fmt.Errorf("expired_token")
 	}
 }
 
@@ -176,34 +163,18 @@ func (m *CLIAuthManager) ApproveDeviceCode(ctx context.Context, caller Caller, u
 		return fmt.Errorf("device code expired")
 	}
 
-	// Create a CLI token for the caller.
+	// Create CLI token for the approving user.
 	result, err := m.CreateCLIToken(ctx, caller, "CLI Device Login")
 	if err != nil {
 		return fmt.Errorf("creating CLI token: %w", err)
 	}
 
-	// Approve the device code. Store the raw token in user_code for the polling endpoint to retrieve.
-	// This is safe because: (1) only the holder of the secret device_code can poll, (2) the row
-	// transitions from "pending" to "approved" atomically.
-	if err := m.repo.ApproveDeviceAuthCode(ctx, code.ID, caller.UserID, result.ID); err != nil {
+	// Atomically approve the device code and store the raw token for one-time retrieval.
+	if err := m.repo.ApproveDeviceAuthCode(ctx, code.ID, caller.UserID, result.ID, result.Token); err != nil {
 		return fmt.Errorf("approving device code: %w", err)
 	}
 
-	// Store the raw token by updating user_code (no longer needed after approval).
-	// This is a pragmatic choice for the MVP. A production system would use Redis or an encrypted temp store.
-	m.storeRawTokenOnDevice(ctx, code.ID, result.Token)
-
 	return nil
-}
-
-func (m *CLIAuthManager) storeRawTokenOnDevice(ctx context.Context, codeID uuid.UUID, rawToken string) {
-	// Update user_code to hold the raw token. This is only readable by the device_code holder.
-	// We bypass the unique index constraint because the status is now "approved", not "pending".
-	// The partial unique index on user_code only applies WHERE status = 'pending'.
-	_, err := m.execRaw(ctx, `UPDATE device_auth_codes SET user_code = $1 WHERE id = $2`, rawToken, codeID)
-	if err != nil {
-		m.logger.Warn("failed to store raw token on device code", "error", err)
-	}
 }
 
 func (m *CLIAuthManager) CreateCLIToken(ctx context.Context, caller Caller, name string) (CreateCLITokenResult, error) {
@@ -252,42 +223,39 @@ func (m *CLIAuthManager) RevokeCLIToken(ctx context.Context, caller Caller, toke
 	return m.repo.RevokeCLIToken(ctx, tokenID, caller.UserID)
 }
 
-// execRaw is a helper for ad-hoc queries not in the repository interface.
-// Uses the Repository's db pool directly. This requires the repository to implement
-// a method we can call. Since CLIAuthRepository is an interface, we'll use a type assertion.
-func (m *CLIAuthManager) execRaw(ctx context.Context, query string, args ...any) (int64, error) {
-	if repo, ok := m.repo.(*repository.Repository); ok {
-		return repo.ExecRaw(ctx, query, args...)
-	}
-	return 0, fmt.Errorf("raw exec not supported")
-}
-
 // --------------------------------------------------------------------------
 // Handlers
 // --------------------------------------------------------------------------
 
 // registerCLIAuthPublicRoutes adds unauthenticated device code endpoints.
+// The router should already be scoped (e.g., under /v1/auth).
 func registerCLIAuthPublicRoutes(router chi.Router, logger *slog.Logger, service CLIAuthService) {
-	router.Route("/v1/auth", func(r chi.Router) {
-		r.Post("/device", createDeviceCodeHandler(logger, service))
-		r.Post("/device/token", pollDeviceTokenHandler(logger, service))
-	})
+	router.Post("/device", createDeviceCodeHandler(logger, service))
+	router.Post("/device/token", pollDeviceTokenHandler(logger, service))
 }
 
 func createDeviceCodeHandler(logger *slog.Logger, service CLIAuthService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
 		result, err := service.CreateDeviceCode(r.Context())
 		if err != nil {
 			logger.Error("create device code failed", "error", err)
 			writeError(w, http.StatusInternalServerError, "internal_error", "failed to create device code")
 			return
 		}
-		writeJSON(w, http.StatusOK, result)
+		writeJSON(w, http.StatusCreated, result)
 	}
 }
 
 func pollDeviceTokenHandler(logger *slog.Logger, service CLIAuthService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
 		var input struct {
 			DeviceCode string `json:"device_code"`
 		}
@@ -298,20 +266,20 @@ func pollDeviceTokenHandler(logger *slog.Logger, service CLIAuthService) http.Ha
 
 		result, err := service.PollDeviceToken(r.Context(), input.DeviceCode)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
-			return
-		}
-
-		if result.Status == "authorization_pending" {
-			writeError(w, http.StatusBadRequest, "authorization_pending", "waiting for user authorization")
-			return
-		}
-		if result.Status == "access_denied" {
-			writeError(w, http.StatusBadRequest, "access_denied", "user denied authorization")
-			return
-		}
-		if result.Status == "expired_token" {
-			writeError(w, http.StatusBadRequest, "expired_token", "device code has expired")
+			errMsg := err.Error()
+			switch {
+			case errMsg == "authorization_pending":
+				writeError(w, http.StatusBadRequest, "authorization_pending", "waiting for user authorization")
+			case errMsg == "access_denied":
+				writeError(w, http.StatusBadRequest, "access_denied", "user denied authorization")
+			case errMsg == "expired_token":
+				writeError(w, http.StatusBadRequest, "expired_token", "device code has expired")
+			case errMsg == "slow_down":
+				writeError(w, http.StatusBadRequest, "slow_down", "polling too frequently, increase interval")
+			default:
+				logger.Error("poll device token failed", "error", err)
+				writeError(w, http.StatusInternalServerError, "internal_error", "failed to poll token")
+			}
 			return
 		}
 
@@ -339,7 +307,7 @@ func approveDeviceCodeHandler(logger *slog.Logger, service CLIAuthService) http.
 			return
 		}
 
-		if err := service.ApproveDeviceCode(r.Context(), caller, strings.ToUpper(strings.TrimSpace(input.UserCode))); err != nil {
+		if err := service.ApproveDeviceCode(r.Context(), caller, normalizeUserCode(input.UserCode)); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
 			return
 		}
@@ -434,8 +402,8 @@ func generateSecureToken(n int) (string, error) {
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
-// generateUserCode creates a short code like "RRGQ-BJVS" from a 22-char alphabet
-// (A-Z minus I,O; 0-9 minus 0,1 to avoid ambiguity).
+// generateUserCode creates a code like "RRGQ-BJVS" from a 30-char alphabet
+// (A-Z minus I,O and 0-9 minus 0,1 to avoid ambiguity).
 func generateUserCode() (string, error) {
 	const alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
 	code := make([]byte, 8)
@@ -447,4 +415,15 @@ func generateUserCode() (string, error) {
 		code[i] = alphabet[n.Int64()]
 	}
 	return string(code[:4]) + "-" + string(code[4:]), nil
+}
+
+// normalizeUserCode strips whitespace, uppercases, and re-formats as XXXX-YYYY.
+func normalizeUserCode(raw string) string {
+	clean := strings.ToUpper(strings.TrimSpace(raw))
+	clean = strings.ReplaceAll(clean, "-", "")
+	clean = strings.ReplaceAll(clean, " ", "")
+	if len(clean) >= 8 {
+		return clean[:4] + "-" + clean[4:8]
+	}
+	return clean
 }

--- a/backend/internal/api/compare_reads_test.go
+++ b/backend/internal/api/compare_reads_test.go
@@ -121,6 +121,7 @@ func TestGetRunComparisonEndpointReturnsJSONPayload(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -164,6 +165,7 @@ func TestCompareViewerEndpointReturnsHTMLShell(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
 		nil,
 		nil,
 		nil,

--- a/backend/internal/api/hosted_runs_test.go
+++ b/backend/internal/api/hosted_runs_test.go
@@ -255,6 +255,7 @@ func TestIngestHostedRunEventHandlerReturnsInternalErrorForRepositoryFailure(t *
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 	router.ServeHTTP(recorder, req)
 

--- a/backend/internal/api/infrastructure_test.go
+++ b/backend/internal/api/infrastructure_test.go
@@ -116,6 +116,7 @@ func TestGetRuntimeProfileAuthorizesWorkspace(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 
 	// User without workspace membership should be denied
@@ -156,6 +157,7 @@ func TestGetRuntimeProfileAllowsWorkspaceMember(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/runtime-profiles/"+profileID.String(), nil)
@@ -186,6 +188,7 @@ func TestCreateRuntimeProfileRequiresAdminRole(t *testing.T) {
 		stubAgentBuildService{}, noopReleaseGateService{},
 		nil, nil, nil, nil, nil, nil, nil,
 		svc,
+		nil,
 		nil,
 		nil,
 		nil,
@@ -222,6 +225,7 @@ func TestCreateRuntimeProfileValidatesInput(t *testing.T) {
 		stubAgentBuildService{}, noopReleaseGateService{},
 		nil, nil, nil, nil, nil, nil, nil,
 		svc,
+		nil,
 		nil,
 		nil,
 		nil,

--- a/backend/internal/api/release_gates_test.go
+++ b/backend/internal/api/release_gates_test.go
@@ -167,6 +167,7 @@ func TestEvaluateReleaseGateEndpointReturnsJSONPayload(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -236,6 +237,7 @@ func TestListReleaseGatesEndpointReturnsJSONPayload(t *testing.T) {
 				},
 			},
 		},
+		nil,
 		nil,
 		nil,
 		nil,

--- a/backend/internal/api/replay_reads_test.go
+++ b/backend/internal/api/replay_reads_test.go
@@ -219,6 +219,7 @@ func TestGetRunAgentReplayEndpointReturnsPaginatedReplay(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -282,6 +283,7 @@ func TestGetRunAgentReplayEndpointReturnsPendingState(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -358,6 +360,7 @@ func TestGetRunAgentReplayEndpointReturnsErroredState(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusConflict {
@@ -388,6 +391,7 @@ func TestGetRunAgentReplayEndpointReturnsNotFoundWhenRunAgentMissing(t *testing.
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -439,6 +443,7 @@ func TestGetRunAgentReplayEndpointReturnsForbidden(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusForbidden {
@@ -468,6 +473,7 @@ func TestGetRunAgentReplayEndpointRejectsMalformedRunAgentID(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -509,6 +515,7 @@ func TestGetRunAgentReplayEndpointRejectsMalformedPagination(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -579,6 +586,7 @@ func TestGetRunAgentScorecardEndpointReturnsScorecard(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -633,6 +641,7 @@ func TestGetRunAgentScorecardEndpointReturnsForbidden(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusForbidden {
@@ -672,6 +681,7 @@ func TestGetRunAgentScorecardEndpointReturnsPendingWhenScorecardIsPending(t *tes
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -741,6 +751,7 @@ func TestGetRunAgentScorecardEndpointReturnsConflictWhenScorecardIsMissingAfterT
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusConflict {
@@ -771,6 +782,7 @@ func TestGetRunAgentScorecardEndpointReturnsNotFoundWhenRunAgentMissing(t *testi
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
 		nil,
 		nil,
 		nil,

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -32,6 +32,7 @@ func registerProtectedRoutes(
 	onboardingService OnboardingService,
 	infraService InfrastructureService,
 	workspaceSecretsService WorkspaceSecretsService,
+	cliAuthService CLIAuthService,
 ) {
 	router.Get("/auth/session", sessionHandler)
 	router.Get("/users/me", getUserMeHandler(logger, userService))
@@ -127,6 +128,14 @@ func registerProtectedRoutes(
 		Put("/workspaces/{workspaceID}/secrets/{secretKey}", upsertWorkspaceSecretHandler(logger, workspaceSecretsService, authorizer))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Delete("/workspaces/{workspaceID}/secrets/{secretKey}", deleteWorkspaceSecretHandler(logger, workspaceSecretsService, authorizer))
+
+	// CLI auth — token management (authenticated)
+	if cliAuthService != nil {
+		router.Post("/auth/cli-tokens", createCLITokenHandler(logger, cliAuthService))
+		router.Get("/auth/cli-tokens", listCLITokensHandler(logger, cliAuthService))
+		router.Delete("/auth/cli-tokens/{id}", revokeCLITokenHandler(logger, cliAuthService))
+		router.Post("/auth/device/approve", approveDeviceCodeHandler(logger, cliAuthService))
+	}
 
 	// Infrastructure CRUD — workspace-scoped create/list (skip if no service provided)
 	if infraService == nil {

--- a/backend/internal/api/run_ranking_test.go
+++ b/backend/internal/api/run_ranking_test.go
@@ -484,6 +484,7 @@ func TestGetRunRankingEndpointReturnsSortedPayload(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -529,6 +530,7 @@ func TestGetRunRankingEndpointRejectsInvalidSortField(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -588,6 +590,7 @@ func TestGetRunRankingEndpointReturnsCompositeSortPayload(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -660,6 +663,7 @@ func TestGetRunRankingEndpointReturnsAcceptedWhenPending(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusAccepted {
@@ -696,6 +700,7 @@ func TestGetRunRankingEndpointReturnsConflictWhenErrored(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
 		nil,
 		nil,
 		nil,

--- a/backend/internal/api/run_reads_test.go
+++ b/backend/internal/api/run_reads_test.go
@@ -147,6 +147,7 @@ func TestGetRunEndpointReturnsRun(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -200,6 +201,7 @@ func TestGetRunEndpointReturnsNotFound(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusNotFound {
@@ -229,6 +231,7 @@ func TestGetRunEndpointRejectsMalformedRunID(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -295,6 +298,7 @@ func TestListRunAgentsEndpointReturnsOrderedItems(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -337,6 +341,7 @@ func TestListRunAgentsEndpointReturnsForbidden(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
 		nil,
 		nil,
 		nil,

--- a/backend/internal/api/runs_test.go
+++ b/backend/internal/api/runs_test.go
@@ -68,6 +68,7 @@ func TestCreateRunEndpointReturnsCreated(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusCreated {
@@ -112,6 +113,7 @@ func TestCreateRunEndpointRejectsInvalidPayload(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -181,6 +183,7 @@ func TestCreateRunEndpointReturnsQueuedRunOnWorkflowStartFailure(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusBadGateway {
@@ -237,6 +240,7 @@ func TestCreateRunEndpointRejectsNonJSONContentType(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusUnsupportedMediaType {
@@ -273,6 +277,7 @@ func TestCreateRunEndpointRejectsOversizedRequestBody(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
 		nil,
 		nil,
 		nil,

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -47,8 +47,9 @@ func NewServer(
 	infraService InfrastructureService,
 	workspaceSecretsService WorkspaceSecretsService,
 	eventSubscriber pubsub.EventSubscriber,
+	cliAuthService CLIAuthService,
 ) *Server {
-	router := newRouter(cfg.AuthMode, cfg.CORSAllowedOrigins, logger, authenticator, authorizer, artifactService, cfg.ArtifactMaxUploadBytes, runCreationService, runReadService, replayReadService, hostedRunIngestionService, compareReadService, agentDeploymentReadService, challengePackReadService, agentBuildService, releaseGateService, challengePackAuthoringService, userService, orgService, wsService, orgMembershipService, wsMembershipService, onboardingService, infraService, workspaceSecretsService, playgroundService, eventSubscriber)
+	router := newRouter(cfg.AuthMode, cfg.CORSAllowedOrigins, logger, authenticator, authorizer, artifactService, cfg.ArtifactMaxUploadBytes, runCreationService, runReadService, replayReadService, hostedRunIngestionService, compareReadService, agentDeploymentReadService, challengePackReadService, agentBuildService, releaseGateService, challengePackAuthoringService, userService, orgService, wsService, orgMembershipService, wsMembershipService, onboardingService, infraService, workspaceSecretsService, playgroundService, eventSubscriber, cliAuthService)
 
 	return &Server{
 		config: cfg,
@@ -123,6 +124,7 @@ func newRouter(
 	workspaceSecretsServiceArg WorkspaceSecretsService,
 	playgroundServiceArg PlaygroundService,
 	eventSubscriber pubsub.EventSubscriber,
+	cliAuthService CLIAuthService,
 ) http.Handler {
 	challengePackAuthoringService := challengePackAuthoringServiceArg
 	userService := userServiceArg
@@ -168,6 +170,9 @@ func newRouter(
 	router.Get("/healthz", healthzHandler)
 	registerPublicRoutes(router, logger, artifactService)
 	registerHostedIntegrationRoutes(router, logger, hostedRunIngestionService)
+	if cliAuthService != nil {
+		registerCLIAuthPublicRoutes(router, logger, cliAuthService)
+	}
 	registerEventStreamRoute(router, logger, authenticator, runReadService, eventSubscriber)
 	rateLimiter := ratelimit.NewLimiter(ratelimit.Config{
 		DefaultRPS:         defaultRateLimitRPS,
@@ -200,7 +205,7 @@ func newRouter(
 	router.Route("/v1", func(r chi.Router) {
 		r.Use(authenticateRequest(logger, authenticator))
 		r.Use(rateLimiter.Middleware("default", extractWorkspaceID))
-		registerProtectedRoutes(r, logger, authorizer, playgroundService, artifactService, artifactMaxUploadBytes, runCreationService, runReadService, replayReadService, compareReadService, releaseGateService, agentDeploymentReadService, challengePackReadService, challengePackAuthoringService, agentBuildService, userService, orgService, wsService, orgMembershipService, wsMembershipService, onboardingService, infraService, workspaceSecretsService)
+		registerProtectedRoutes(r, logger, authorizer, playgroundService, artifactService, artifactMaxUploadBytes, runCreationService, runReadService, replayReadService, compareReadService, releaseGateService, agentDeploymentReadService, challengePackReadService, challengePackAuthoringService, agentBuildService, userService, orgService, wsService, orgMembershipService, wsMembershipService, onboardingService, infraService, workspaceSecretsService, cliAuthService)
 	})
 
 	return router

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -170,9 +170,6 @@ func newRouter(
 	router.Get("/healthz", healthzHandler)
 	registerPublicRoutes(router, logger, artifactService)
 	registerHostedIntegrationRoutes(router, logger, hostedRunIngestionService)
-	if cliAuthService != nil {
-		registerCLIAuthPublicRoutes(router, logger, cliAuthService)
-	}
 	registerEventStreamRoute(router, logger, authenticator, runReadService, eventSubscriber)
 	rateLimiter := ratelimit.NewLimiter(ratelimit.Config{
 		DefaultRPS:         defaultRateLimitRPS,
@@ -200,6 +197,14 @@ func newRouter(
 			return uuid.Nil, false
 		}
 		return wsID, true
+	}
+
+	// Device auth endpoints: public but rate-limited.
+	if cliAuthService != nil {
+		router.Route("/v1/auth", func(r chi.Router) {
+			r.Use(rateLimiter.Middleware("default", extractWorkspaceID))
+			registerCLIAuthPublicRoutes(r, logger, cliAuthService)
+		})
 	}
 
 	router.Route("/v1", func(r chi.Router) {

--- a/backend/internal/api/server_test.go
+++ b/backend/internal/api/server_test.go
@@ -90,6 +90,7 @@ func TestHealthzReturnsJSONSuccessPayload(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -167,6 +168,7 @@ func TestSessionEndpointRequiresAuthentication(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusUnauthorized {
@@ -209,6 +211,7 @@ func TestSessionEndpointReturnsCallerIdentity(t *testing.T) {
 		stubAgentBuildService{},
 		noopReleaseGateService{},
 		stubChallengePackAuthoringService{},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -274,6 +277,7 @@ func TestWorkspaceAuthorizationReturnsForbiddenWithoutMembership(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusForbidden {
@@ -313,6 +317,7 @@ func TestWorkspaceAuthorizationReturnsOKWithMembership(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -375,6 +380,7 @@ func TestWorkspaceAuthorizationRejectsMalformedWorkspaceID(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusBadRequest {
@@ -426,6 +432,7 @@ func TestReplayViewerEndpointReturnsHTMLShell(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 
 	if recorder.Code != http.StatusOK {
@@ -466,6 +473,7 @@ func TestReplayViewerEndpointRejectsInvalidReplayPagination(t *testing.T) {
 		stubChallengePackReadService{},
 		stubAgentBuildService{},
 		noopReleaseGateService{},
+		nil,
 		nil,
 		nil,
 		nil,

--- a/backend/internal/api/workspace_secrets_test.go
+++ b/backend/internal/api/workspace_secrets_test.go
@@ -122,6 +122,7 @@ func runWorkspaceSecretsRequest(t *testing.T, service WorkspaceSecretsService, r
 		service,
 		nil,
 		nil,
+		nil,
 	).ServeHTTP(recorder, req)
 	return recorder
 }

--- a/backend/internal/repository/cli_auth.go
+++ b/backend/internal/repository/cli_auth.go
@@ -1,0 +1,230 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+type CLIToken struct {
+	ID         uuid.UUID
+	UserID     uuid.UUID
+	TokenHash  string
+	Name       string
+	LastUsedAt *time.Time
+	ExpiresAt  *time.Time
+	CreatedAt  time.Time
+	RevokedAt  *time.Time
+}
+
+type DeviceAuthCode struct {
+	ID         uuid.UUID
+	DeviceCode string
+	UserCode   string
+	Status     string // pending | approved | denied | expired
+	UserID     *uuid.UUID
+	CLITokenID *uuid.UUID
+	ExpiresAt  time.Time
+	CreatedAt  time.Time
+}
+
+// GetUserByID returns an active (non-archived) user by internal ID.
+func (r *Repository) GetUserByID(ctx context.Context, userID uuid.UUID) (User, error) {
+	var user User
+	err := r.db.QueryRow(ctx, `
+		SELECT id, workos_user_id, email, COALESCE(display_name, '')
+		FROM users
+		WHERE id = $1 AND archived_at IS NULL
+	`, userID).Scan(&user.ID, &user.WorkOSUserID, &user.Email, &user.DisplayName)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return User{}, fmt.Errorf("user not found: %s", userID)
+		}
+		return User{}, fmt.Errorf("get user by id: %w", err)
+	}
+	return user, nil
+}
+
+// CreateCLIToken inserts a new CLI token row.
+func (r *Repository) CreateCLIToken(ctx context.Context, userID uuid.UUID, tokenHash, name string, expiresAt *time.Time) (CLIToken, error) {
+	var token CLIToken
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO cli_tokens (user_id, token_hash, name, expires_at)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id, user_id, token_hash, name, last_used_at, expires_at, created_at, revoked_at
+	`, userID, tokenHash, name, expiresAt).Scan(
+		&token.ID, &token.UserID, &token.TokenHash, &token.Name,
+		&token.LastUsedAt, &token.ExpiresAt, &token.CreatedAt, &token.RevokedAt,
+	)
+	if err != nil {
+		return CLIToken{}, fmt.Errorf("create cli token: %w", err)
+	}
+	return token, nil
+}
+
+// GetCLITokenByHash looks up a CLI token by its SHA-256 hash.
+// Returns ErrCLITokenNotFound if not found.
+func (r *Repository) GetCLITokenByHash(ctx context.Context, tokenHash string) (CLIToken, error) {
+	var token CLIToken
+	err := r.db.QueryRow(ctx, `
+		SELECT id, user_id, token_hash, name, last_used_at, expires_at, created_at, revoked_at
+		FROM cli_tokens
+		WHERE token_hash = $1
+	`, tokenHash).Scan(
+		&token.ID, &token.UserID, &token.TokenHash, &token.Name,
+		&token.LastUsedAt, &token.ExpiresAt, &token.CreatedAt, &token.RevokedAt,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return CLIToken{}, ErrCLITokenNotFound
+		}
+		return CLIToken{}, fmt.Errorf("get cli token by hash: %w", err)
+	}
+	return token, nil
+}
+
+// ListCLITokensByUserID returns all non-revoked CLI tokens for a user.
+func (r *Repository) ListCLITokensByUserID(ctx context.Context, userID uuid.UUID) ([]CLIToken, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, user_id, token_hash, name, last_used_at, expires_at, created_at, revoked_at
+		FROM cli_tokens
+		WHERE user_id = $1 AND revoked_at IS NULL
+		ORDER BY created_at DESC
+	`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list cli tokens: %w", err)
+	}
+	defer rows.Close()
+
+	var out []CLIToken
+	for rows.Next() {
+		var token CLIToken
+		if err := rows.Scan(
+			&token.ID, &token.UserID, &token.TokenHash, &token.Name,
+			&token.LastUsedAt, &token.ExpiresAt, &token.CreatedAt, &token.RevokedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan cli token: %w", err)
+		}
+		out = append(out, token)
+	}
+	return out, rows.Err()
+}
+
+// RevokeCLIToken sets revoked_at on a CLI token. Only the owning user can revoke.
+func (r *Repository) RevokeCLIToken(ctx context.Context, tokenID, userID uuid.UUID) error {
+	tag, err := r.db.Exec(ctx, `
+		UPDATE cli_tokens
+		SET revoked_at = now()
+		WHERE id = $1 AND user_id = $2 AND revoked_at IS NULL
+	`, tokenID, userID)
+	if err != nil {
+		return fmt.Errorf("revoke cli token: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrCLITokenNotFound
+	}
+	return nil
+}
+
+// TouchCLITokenLastUsed updates the last_used_at timestamp.
+func (r *Repository) TouchCLITokenLastUsed(ctx context.Context, tokenID uuid.UUID) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE cli_tokens SET last_used_at = now() WHERE id = $1
+	`, tokenID)
+	return err
+}
+
+// CreateDeviceAuthCode inserts a new device authorization code.
+func (r *Repository) CreateDeviceAuthCode(ctx context.Context, deviceCode, userCode string, expiresAt time.Time) (DeviceAuthCode, error) {
+	var code DeviceAuthCode
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO device_auth_codes (device_code, user_code, expires_at)
+		VALUES ($1, $2, $3)
+		RETURNING id, device_code, user_code, status, user_id, cli_token_id, expires_at, created_at
+	`, deviceCode, userCode, expiresAt).Scan(
+		&code.ID, &code.DeviceCode, &code.UserCode, &code.Status,
+		&code.UserID, &code.CLITokenID, &code.ExpiresAt, &code.CreatedAt,
+	)
+	if err != nil {
+		return DeviceAuthCode{}, fmt.Errorf("create device auth code: %w", err)
+	}
+	return code, nil
+}
+
+// GetDeviceAuthCodeByDeviceCode looks up by the secret device code (CLI polling).
+func (r *Repository) GetDeviceAuthCodeByDeviceCode(ctx context.Context, deviceCode string) (DeviceAuthCode, error) {
+	var code DeviceAuthCode
+	err := r.db.QueryRow(ctx, `
+		SELECT id, device_code, user_code, status, user_id, cli_token_id, expires_at, created_at
+		FROM device_auth_codes
+		WHERE device_code = $1
+	`, deviceCode).Scan(
+		&code.ID, &code.DeviceCode, &code.UserCode, &code.Status,
+		&code.UserID, &code.CLITokenID, &code.ExpiresAt, &code.CreatedAt,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return DeviceAuthCode{}, ErrDeviceCodeNotFound
+		}
+		return DeviceAuthCode{}, fmt.Errorf("get device auth code: %w", err)
+	}
+	return code, nil
+}
+
+// GetDeviceAuthCodeByUserCode looks up by the user-facing code (web app approval).
+func (r *Repository) GetDeviceAuthCodeByUserCode(ctx context.Context, userCode string) (DeviceAuthCode, error) {
+	var code DeviceAuthCode
+	err := r.db.QueryRow(ctx, `
+		SELECT id, device_code, user_code, status, user_id, cli_token_id, expires_at, created_at
+		FROM device_auth_codes
+		WHERE user_code = $1 AND status = 'pending'
+	`, userCode).Scan(
+		&code.ID, &code.DeviceCode, &code.UserCode, &code.Status,
+		&code.UserID, &code.CLITokenID, &code.ExpiresAt, &code.CreatedAt,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return DeviceAuthCode{}, ErrDeviceCodeNotFound
+		}
+		return DeviceAuthCode{}, fmt.Errorf("get device auth code by user code: %w", err)
+	}
+	return code, nil
+}
+
+// ApproveDeviceAuthCode transitions a pending device code to approved.
+func (r *Repository) ApproveDeviceAuthCode(ctx context.Context, id, userID uuid.UUID, cliTokenID uuid.UUID) error {
+	tag, err := r.db.Exec(ctx, `
+		UPDATE device_auth_codes
+		SET status = 'approved', user_id = $2, cli_token_id = $3
+		WHERE id = $1 AND status = 'pending' AND expires_at > now()
+	`, id, userID, cliTokenID)
+	if err != nil {
+		return fmt.Errorf("approve device auth code: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrDeviceCodeNotFound
+	}
+	return nil
+}
+
+// ExpireDeviceAuthCode transitions a pending device code to expired.
+func (r *Repository) ExpireDeviceAuthCode(ctx context.Context, id uuid.UUID) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE device_auth_codes SET status = 'expired'
+		WHERE id = $1 AND status = 'pending'
+	`, id)
+	return err
+}
+
+// ExecRaw executes an arbitrary SQL statement. Used for ad-hoc updates
+// that don't warrant a dedicated repository method.
+func (r *Repository) ExecRaw(ctx context.Context, query string, args ...any) (int64, error) {
+	tag, err := r.db.Exec(ctx, query, args...)
+	if err != nil {
+		return 0, err
+	}
+	return tag.RowsAffected(), nil
+}

--- a/backend/internal/repository/cli_auth.go
+++ b/backend/internal/repository/cli_auth.go
@@ -211,15 +211,17 @@ func (r *Repository) ApproveDeviceAuthCode(ctx context.Context, id, userID uuid.
 	return nil
 }
 
-// ConsumeDeviceRawToken reads and NULLs the raw_token in a single atomic operation.
-// Returns the raw token if present, or empty string if already consumed.
+// ConsumeDeviceRawToken atomically reads and NULLs the raw_token.
+// Uses a FROM subquery to capture the pre-update value, since PostgreSQL's
+// RETURNING clause returns post-update values (which would be NULL).
 func (r *Repository) ConsumeDeviceRawToken(ctx context.Context, id uuid.UUID) (string, error) {
 	var rawToken *string
 	err := r.db.QueryRow(ctx, `
-		UPDATE device_auth_codes
+		UPDATE device_auth_codes d
 		SET raw_token = NULL
-		WHERE id = $1 AND raw_token IS NOT NULL
-		RETURNING raw_token
+		FROM (SELECT id, raw_token FROM device_auth_codes WHERE id = $1 AND raw_token IS NOT NULL FOR UPDATE) old
+		WHERE d.id = old.id
+		RETURNING old.raw_token
 	`, id).Scan(&rawToken)
 	if err != nil {
 		if err == pgx.ErrNoRows {

--- a/backend/internal/repository/cli_auth.go
+++ b/backend/internal/repository/cli_auth.go
@@ -27,6 +27,7 @@ type DeviceAuthCode struct {
 	Status     string // pending | approved | denied | expired
 	UserID     *uuid.UUID
 	CLITokenID *uuid.UUID
+	RawToken   *string
 	ExpiresAt  time.Time
 	CreatedAt  time.Time
 }
@@ -66,7 +67,6 @@ func (r *Repository) CreateCLIToken(ctx context.Context, userID uuid.UUID, token
 }
 
 // GetCLITokenByHash looks up a CLI token by its SHA-256 hash.
-// Returns ErrCLITokenNotFound if not found.
 func (r *Repository) GetCLITokenByHash(ctx context.Context, tokenHash string) (CLIToken, error) {
 	var token CLIToken
 	err := r.db.QueryRow(ctx, `
@@ -143,10 +143,10 @@ func (r *Repository) CreateDeviceAuthCode(ctx context.Context, deviceCode, userC
 	err := r.db.QueryRow(ctx, `
 		INSERT INTO device_auth_codes (device_code, user_code, expires_at)
 		VALUES ($1, $2, $3)
-		RETURNING id, device_code, user_code, status, user_id, cli_token_id, expires_at, created_at
+		RETURNING id, device_code, user_code, status, user_id, cli_token_id, raw_token, expires_at, created_at
 	`, deviceCode, userCode, expiresAt).Scan(
 		&code.ID, &code.DeviceCode, &code.UserCode, &code.Status,
-		&code.UserID, &code.CLITokenID, &code.ExpiresAt, &code.CreatedAt,
+		&code.UserID, &code.CLITokenID, &code.RawToken, &code.ExpiresAt, &code.CreatedAt,
 	)
 	if err != nil {
 		return DeviceAuthCode{}, fmt.Errorf("create device auth code: %w", err)
@@ -158,12 +158,12 @@ func (r *Repository) CreateDeviceAuthCode(ctx context.Context, deviceCode, userC
 func (r *Repository) GetDeviceAuthCodeByDeviceCode(ctx context.Context, deviceCode string) (DeviceAuthCode, error) {
 	var code DeviceAuthCode
 	err := r.db.QueryRow(ctx, `
-		SELECT id, device_code, user_code, status, user_id, cli_token_id, expires_at, created_at
+		SELECT id, device_code, user_code, status, user_id, cli_token_id, raw_token, expires_at, created_at
 		FROM device_auth_codes
 		WHERE device_code = $1
 	`, deviceCode).Scan(
 		&code.ID, &code.DeviceCode, &code.UserCode, &code.Status,
-		&code.UserID, &code.CLITokenID, &code.ExpiresAt, &code.CreatedAt,
+		&code.UserID, &code.CLITokenID, &code.RawToken, &code.ExpiresAt, &code.CreatedAt,
 	)
 	if err != nil {
 		if err == pgx.ErrNoRows {
@@ -178,12 +178,12 @@ func (r *Repository) GetDeviceAuthCodeByDeviceCode(ctx context.Context, deviceCo
 func (r *Repository) GetDeviceAuthCodeByUserCode(ctx context.Context, userCode string) (DeviceAuthCode, error) {
 	var code DeviceAuthCode
 	err := r.db.QueryRow(ctx, `
-		SELECT id, device_code, user_code, status, user_id, cli_token_id, expires_at, created_at
+		SELECT id, device_code, user_code, status, user_id, cli_token_id, raw_token, expires_at, created_at
 		FROM device_auth_codes
 		WHERE user_code = $1 AND status = 'pending'
 	`, userCode).Scan(
 		&code.ID, &code.DeviceCode, &code.UserCode, &code.Status,
-		&code.UserID, &code.CLITokenID, &code.ExpiresAt, &code.CreatedAt,
+		&code.UserID, &code.CLITokenID, &code.RawToken, &code.ExpiresAt, &code.CreatedAt,
 	)
 	if err != nil {
 		if err == pgx.ErrNoRows {
@@ -194,13 +194,14 @@ func (r *Repository) GetDeviceAuthCodeByUserCode(ctx context.Context, userCode s
 	return code, nil
 }
 
-// ApproveDeviceAuthCode transitions a pending device code to approved.
-func (r *Repository) ApproveDeviceAuthCode(ctx context.Context, id, userID uuid.UUID, cliTokenID uuid.UUID) error {
+// ApproveDeviceAuthCode atomically transitions a pending device code to approved,
+// links the CLI token, and stores the raw token for one-time retrieval by the polling CLI.
+func (r *Repository) ApproveDeviceAuthCode(ctx context.Context, id, userID uuid.UUID, cliTokenID uuid.UUID, rawToken string) error {
 	tag, err := r.db.Exec(ctx, `
 		UPDATE device_auth_codes
-		SET status = 'approved', user_id = $2, cli_token_id = $3
+		SET status = 'approved', user_id = $2, cli_token_id = $3, raw_token = $4
 		WHERE id = $1 AND status = 'pending' AND expires_at > now()
-	`, id, userID, cliTokenID)
+	`, id, userID, cliTokenID, rawToken)
 	if err != nil {
 		return fmt.Errorf("approve device auth code: %w", err)
 	}
@@ -210,6 +211,28 @@ func (r *Repository) ApproveDeviceAuthCode(ctx context.Context, id, userID uuid.
 	return nil
 }
 
+// ConsumeDeviceRawToken reads and NULLs the raw_token in a single atomic operation.
+// Returns the raw token if present, or empty string if already consumed.
+func (r *Repository) ConsumeDeviceRawToken(ctx context.Context, id uuid.UUID) (string, error) {
+	var rawToken *string
+	err := r.db.QueryRow(ctx, `
+		UPDATE device_auth_codes
+		SET raw_token = NULL
+		WHERE id = $1 AND raw_token IS NOT NULL
+		RETURNING raw_token
+	`, id).Scan(&rawToken)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return "", nil
+		}
+		return "", fmt.Errorf("consume device raw token: %w", err)
+	}
+	if rawToken == nil {
+		return "", nil
+	}
+	return *rawToken, nil
+}
+
 // ExpireDeviceAuthCode transitions a pending device code to expired.
 func (r *Repository) ExpireDeviceAuthCode(ctx context.Context, id uuid.UUID) error {
 	_, err := r.db.Exec(ctx, `
@@ -217,14 +240,4 @@ func (r *Repository) ExpireDeviceAuthCode(ctx context.Context, id uuid.UUID) err
 		WHERE id = $1 AND status = 'pending'
 	`, id)
 	return err
-}
-
-// ExecRaw executes an arbitrary SQL statement. Used for ad-hoc updates
-// that don't warrant a dedicated repository method.
-func (r *Repository) ExecRaw(ctx context.Context, query string, args ...any) (int64, error) {
-	tag, err := r.db.Exec(ctx, query, args...)
-	if err != nil {
-		return 0, err
-	}
-	return tag.RowsAffected(), nil
 }

--- a/backend/internal/repository/errors.go
+++ b/backend/internal/repository/errors.go
@@ -35,6 +35,8 @@ var (
 	ErrWorkspaceSecretNotFound       = errors.New("workspace secret not found")
 	ErrSecretsCipherUnset            = errors.New("secrets cipher is not configured")
 	ErrInvalidSecretKey              = errors.New("secret key must match [A-Za-z_][A-Za-z0-9_]* and be 1..128 characters")
+	ErrCLITokenNotFound              = errors.New("cli token not found")
+	ErrDeviceCodeNotFound            = errors.New("device auth code not found")
 )
 
 type InvalidTransitionError struct {

--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -8,11 +8,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var flagDevice bool
+
 func init() {
 	rootCmd.AddCommand(authCmd)
 	authCmd.AddCommand(authLoginCmd)
 	authCmd.AddCommand(authLogoutCmd)
 	authCmd.AddCommand(authStatusCmd)
+	authCmd.AddCommand(authTokensCmd)
+	authTokensCmd.AddCommand(authTokensListCmd)
+	authTokensCmd.AddCommand(authTokensRevokeCmd)
+
+	authLoginCmd.Flags().BoolVar(&flagDevice, "device", false, "Use device code flow (for SSH/containers)")
 }
 
 var authCmd = &cobra.Command{
@@ -23,31 +30,64 @@ var authCmd = &cobra.Command{
 var authLoginCmd = &cobra.Command{
 	Use:   "login",
 	Short: "Log in to AgentClash",
-	Long: `Log in to your AgentClash account.
+	Long: `Log in to your AgentClash account via browser.
 
-You will be prompted to paste an API token from the dashboard.
+Opens your default browser for secure authentication via WorkOS.
+Falls back to device code flow when a browser is unavailable.
+
+Flags:
+  --device    Force device code flow (useful for SSH/remote sessions)
+
 For CI/CD, set the AGENTCLASH_TOKEN environment variable instead.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		rc := GetRunContext(cmd)
-		sp := output.NewSpinner("Logging in...", flagQuiet)
+		webURL := rc.Config.WebURL()
 
-		result, token, err := auth.InteractiveLogin(cmd.Context(), rc.Client)
-		if err != nil {
-			sp.StopWithError("Login failed")
-			return err
+		var result *auth.LoginResult
+		var token string
+		var err error
+
+		if flagDevice || !auth.CanOpenBrowser() {
+			// Device code flow.
+			deviceResult, deviceErr := auth.DeviceLogin(cmd.Context(), rc.Client, webURL)
+			if deviceErr != nil {
+				return deviceErr
+			}
+			result = &auth.LoginResult{
+				UserID: deviceResult.UserID,
+				Email:  deviceResult.Email,
+			}
+			token = deviceResult.Token
+		} else {
+			// Browser-based flow.
+			result, token, err = auth.WebLogin(cmd.Context(), rc.Client, webURL)
+			if err != nil {
+				return err
+			}
 		}
 
+		// Save credentials.
 		creds := auth.Credentials{
 			Token:  token,
 			UserID: result.UserID,
 			Email:  result.Email,
 		}
 		if err := auth.SaveCredentials(creds); err != nil {
-			sp.StopWithError("Failed to save credentials")
 			return fmt.Errorf("saving credentials: %w", err)
 		}
 
-		sp.StopWithSuccess(fmt.Sprintf("Logged in as %s (%s)", result.Display, result.Email))
+		if rc.Output.IsJSON() {
+			return rc.Output.PrintJSON(map[string]string{
+				"user_id": result.UserID,
+				"email":   result.Email,
+			})
+		}
+
+		name := result.Display
+		if name == "" {
+			name = result.Email
+		}
+		rc.Output.PrintSuccess(fmt.Sprintf("Logged in as %s", name))
 		return nil
 	},
 }
@@ -89,7 +129,7 @@ var authStatusCmd = &cobra.Command{
 			return rc.Output.PrintJSON(session)
 		}
 
-		rc.Output.PrintDetail("User ID", fmt.Sprint(session["user_id"]))
+		rc.Output.PrintDetail("User ID", str(session["user_id"]))
 		if email, ok := session["email"].(string); ok && email != "" {
 			rc.Output.PrintDetail("Email", email)
 		}
@@ -102,6 +142,77 @@ var authStatusCmd = &cobra.Command{
 		if wss, ok := session["workspace_memberships"].([]any); ok {
 			rc.Output.PrintDetail("Workspaces", fmt.Sprintf("%d membership(s)", len(wss)))
 		}
+		return nil
+	},
+}
+
+// --- Token Management ---
+
+var authTokensCmd = &cobra.Command{
+	Use:   "tokens",
+	Short: "Manage CLI access tokens",
+}
+
+var authTokensListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List your CLI tokens",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+
+		resp, err := rc.Client.Get(cmd.Context(), "/v1/auth/cli-tokens", nil)
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+
+		var result struct {
+			Items []map[string]any `json:"items"`
+		}
+		if err := resp.DecodeJSON(&result); err != nil {
+			return err
+		}
+
+		if rc.Output.IsJSON() {
+			return rc.Output.PrintJSON(result)
+		}
+
+		cols := []output.Column{{Header: "ID"}, {Header: "Name"}, {Header: "Last Used"}, {Header: "Created"}}
+		rows := make([][]string, len(result.Items))
+		for i, item := range result.Items {
+			lastUsed := str(item["last_used_at"])
+			if lastUsed == "" || lastUsed == "<nil>" {
+				lastUsed = "never"
+			}
+			rows[i] = []string{
+				str(item["id"]),
+				str(item["name"]),
+				lastUsed,
+				str(item["created_at"]),
+			}
+		}
+		rc.Output.PrintTable(cols, rows)
+		return nil
+	},
+}
+
+var authTokensRevokeCmd = &cobra.Command{
+	Use:   "revoke <token-id>",
+	Short: "Revoke a CLI token",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+
+		resp, err := rc.Client.Delete(cmd.Context(), "/v1/auth/cli-tokens/"+args[0])
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+
+		rc.Output.PrintSuccess(fmt.Sprintf("Token %s revoked", args[0]))
 		return nil
 	},
 }

--- a/cli/internal/auth/browser.go
+++ b/cli/internal/auth/browser.go
@@ -1,0 +1,51 @@
+package auth
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+// OpenBrowser opens the given URL in the user's default browser.
+func OpenBrowser(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	return cmd.Start()
+}
+
+// CanOpenBrowser returns true if we can likely open a browser.
+// Returns false in SSH sessions, containers, or headless environments.
+func CanOpenBrowser() bool {
+	// SSH session — no local browser.
+	if os.Getenv("SSH_CONNECTION") != "" || os.Getenv("SSH_CLIENT") != "" {
+		return false
+	}
+
+	// Linux without display — headless.
+	if runtime.GOOS == "linux" {
+		if os.Getenv("DISPLAY") == "" && os.Getenv("WAYLAND_DISPLAY") == "" {
+			return false
+		}
+	}
+
+	// Docker/container indicators.
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return false
+	}
+
+	// Dumb terminal.
+	if os.Getenv("TERM") == "dumb" {
+		return false
+	}
+
+	return true
+}

--- a/cli/internal/auth/callback_server.go
+++ b/cli/internal/auth/callback_server.go
@@ -1,0 +1,111 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+// CallbackResult holds the result from the localhost callback server.
+type CallbackResult struct {
+	Token string
+	Error string
+}
+
+// StartCallbackServer starts a temporary HTTP server on 127.0.0.1 with a random port.
+// It waits for a single GET /callback request, extracts the token, and shuts down.
+// The expected state parameter is validated against the received state.
+func StartCallbackServer(ctx context.Context, expectedState string) (<-chan CallbackResult, int, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, 0, fmt.Errorf("binding localhost: %w", err)
+	}
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	resultCh := make(chan CallbackResult, 1)
+
+	mux := http.NewServeMux()
+	server := &http.Server{Handler: mux}
+
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+		state := query.Get("state")
+		token := query.Get("token")
+		errMsg := query.Get("error")
+
+		if errMsg != "" {
+			w.Header().Set("Content-Type", "text/html")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, callbackHTML("Authorization Denied", "The CLI login was denied. You can close this tab."))
+			resultCh <- CallbackResult{Error: errMsg}
+			go server.Close()
+			return
+		}
+
+		if state != expectedState {
+			w.Header().Set("Content-Type", "text/html")
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, callbackHTML("Invalid State", "The state parameter does not match. This may be a CSRF attack."))
+			resultCh <- CallbackResult{Error: "state mismatch"}
+			go server.Close()
+			return
+		}
+
+		if token == "" {
+			w.Header().Set("Content-Type", "text/html")
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, callbackHTML("Missing Token", "No token was provided in the callback."))
+			resultCh <- CallbackResult{Error: "missing token"}
+			go server.Close()
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, callbackHTML("Logged In", "You are now authenticated. You can close this tab and return to your terminal."))
+		resultCh <- CallbackResult{Token: token}
+		go server.Close()
+	})
+
+	go func() {
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			resultCh <- CallbackResult{Error: fmt.Sprintf("callback server: %s", err)}
+		}
+	}()
+
+	// Shutdown on context cancellation or timeout.
+	go func() {
+		select {
+		case <-ctx.Done():
+			server.Close()
+		case <-time.After(5 * time.Minute):
+			resultCh <- CallbackResult{Error: "login timed out (5 minutes)"}
+			server.Close()
+		}
+	}()
+
+	return resultCh, port, nil
+}
+
+func callbackHTML(title, message string) string {
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<head>
+  <title>AgentClash CLI - %s</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0a0a0a; color: #e5e5e5; display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; }
+    .card { text-align: center; max-width: 400px; padding: 2rem; }
+    h1 { font-size: 1.25rem; margin-bottom: 0.5rem; }
+    p { color: #999; font-size: 0.875rem; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>%s</h1>
+    <p>%s</p>
+  </div>
+</body>
+</html>`, title, title, message)
+}

--- a/cli/internal/auth/callback_server.go
+++ b/cli/internal/auth/callback_server.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"fmt"
+	"html"
 	"net"
 	"net/http"
 	"time"
@@ -90,6 +91,8 @@ func StartCallbackServer(ctx context.Context, expectedState string) (<-chan Call
 }
 
 func callbackHTML(title, message string) string {
+	title = html.EscapeString(title)
+	message = html.EscapeString(message)
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html>
 <head>

--- a/cli/internal/auth/device.go
+++ b/cli/internal/auth/device.go
@@ -34,7 +34,7 @@ func DeviceLogin(ctx context.Context, client *api.Client, webURL string) (*Devic
 	var deviceResp struct {
 		DeviceCode      string `json:"device_code"`
 		UserCode        string `json:"user_code"`
-		VerificationURL string `json:"verification_url"`
+		VerificationURI string `json:"verification_uri"`
 		ExpiresIn       int    `json:"expires_in"`
 		Interval        int    `json:"interval"`
 	}
@@ -43,7 +43,7 @@ func DeviceLogin(ctx context.Context, client *api.Client, webURL string) (*Devic
 	}
 
 	// Step 2: Display instructions.
-	verifyURL := webURL + deviceResp.VerificationURL
+	verifyURL := webURL + deviceResp.VerificationURI
 	fmt.Fprintf(os.Stderr, "\n  To authenticate, visit: %s\n", output.Bold(verifyURL))
 	fmt.Fprintf(os.Stderr, "  Enter code: %s\n\n", output.Bold(deviceResp.UserCode))
 

--- a/cli/internal/auth/device.go
+++ b/cli/internal/auth/device.go
@@ -1,0 +1,116 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/cli/internal/api"
+	"github.com/Atharva-Kanherkar/agentclash/cli/internal/output"
+)
+
+// DeviceLoginResult holds the result of a device code login.
+type DeviceLoginResult struct {
+	Token  string
+	UserID string
+	Email  string
+}
+
+// DeviceLogin performs the device code flow:
+// 1. Request device code from server
+// 2. Display user code + URL
+// 3. Poll until approved/denied/expired
+func DeviceLogin(ctx context.Context, client *api.Client, webURL string) (*DeviceLoginResult, error) {
+	// Step 1: Request device code.
+	resp, err := client.Post(ctx, "/v1/auth/device", map[string]any{})
+	if err != nil {
+		return nil, fmt.Errorf("requesting device code: %w", err)
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return nil, fmt.Errorf("device code request failed: %s", apiErr.Message)
+	}
+
+	var deviceResp struct {
+		DeviceCode      string `json:"device_code"`
+		UserCode        string `json:"user_code"`
+		VerificationURL string `json:"verification_url"`
+		ExpiresIn       int    `json:"expires_in"`
+		Interval        int    `json:"interval"`
+	}
+	if err := resp.DecodeJSON(&deviceResp); err != nil {
+		return nil, fmt.Errorf("parsing device code response: %w", err)
+	}
+
+	// Step 2: Display instructions.
+	verifyURL := webURL + deviceResp.VerificationURL
+	fmt.Fprintf(os.Stderr, "\n  To authenticate, visit: %s\n", output.Bold(verifyURL))
+	fmt.Fprintf(os.Stderr, "  Enter code: %s\n\n", output.Bold(deviceResp.UserCode))
+
+	// Try to open browser (best effort).
+	OpenBrowser(verifyURL)
+
+	// Step 3: Poll for token.
+	interval := time.Duration(deviceResp.Interval) * time.Second
+	if interval < 3*time.Second {
+		interval = 5 * time.Second
+	}
+	deadline := time.Now().Add(time.Duration(deviceResp.ExpiresIn) * time.Second)
+
+	sp := output.NewSpinner("Waiting for authorization...", false)
+
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			sp.Stop()
+			return nil, ctx.Err()
+		case <-time.After(interval):
+		}
+
+		pollResp, err := client.Post(ctx, "/v1/auth/device/token", map[string]any{
+			"device_code": deviceResp.DeviceCode,
+		})
+		if err != nil {
+			continue
+		}
+
+		// Check for error responses (authorization_pending, etc.)
+		if apiErr := pollResp.ParseError(); apiErr != nil {
+			switch apiErr.Code {
+			case "authorization_pending":
+				continue
+			case "access_denied":
+				sp.StopWithError("Authorization denied")
+				return nil, fmt.Errorf("authorization denied by user")
+			case "expired_token":
+				sp.StopWithError("Device code expired")
+				return nil, fmt.Errorf("device code expired — run 'agentclash auth login' again")
+			default:
+				continue
+			}
+		}
+
+		// Success — extract token.
+		var tokenResp struct {
+			Status string `json:"status"`
+			Token  string `json:"token"`
+			UserID string `json:"user_id"`
+			Email  string `json:"email"`
+		}
+		if err := pollResp.DecodeJSON(&tokenResp); err != nil {
+			continue
+		}
+
+		if tokenResp.Token != "" {
+			sp.StopWithSuccess("Authorized")
+			return &DeviceLoginResult{
+				Token:  tokenResp.Token,
+				UserID: tokenResp.UserID,
+				Email:  tokenResp.Email,
+			}, nil
+		}
+	}
+
+	sp.StopWithError("Timed out")
+	return nil, fmt.Errorf("device code expired — run 'agentclash auth login' again")
+}

--- a/cli/internal/auth/login.go
+++ b/cli/internal/auth/login.go
@@ -1,45 +1,67 @@
 package auth
 
 import (
-	"bufio"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/Atharva-Kanherkar/agentclash/cli/internal/api"
+	"github.com/Atharva-Kanherkar/agentclash/cli/internal/output"
 )
 
-// LoginResult holds the result of a login attempt.
+// LoginResult holds the result of a successful login.
 type LoginResult struct {
 	UserID  string
 	Email   string
 	Display string
 }
 
-// InteractiveLogin prompts the user for a token and validates it.
-func InteractiveLogin(ctx context.Context, client *api.Client) (*LoginResult, string, error) {
-	fmt.Fprintln(os.Stderr, "Paste your API token (from the dashboard):")
-	fmt.Fprint(os.Stderr, "> ")
+// WebLogin performs browser-based login:
+// 1. Start a localhost callback server
+// 2. Open browser to the web app's /auth/cli page
+// 3. Wait for the callback with the token
+// 4. Validate the token
+func WebLogin(ctx context.Context, client *api.Client, webURL string) (*LoginResult, string, error) {
+	// Generate cryptographic state for CSRF protection.
+	stateBytes := make([]byte, 32)
+	if _, err := rand.Read(stateBytes); err != nil {
+		return nil, "", fmt.Errorf("generating state: %w", err)
+	}
+	state := hex.EncodeToString(stateBytes)
 
-	reader := bufio.NewReader(os.Stdin)
-	token, err := reader.ReadString('\n')
+	// Start local callback server.
+	resultCh, port, err := StartCallbackServer(ctx, state)
 	if err != nil {
-		return nil, "", fmt.Errorf("reading token: %w", err)
-	}
-	token = strings.TrimSpace(token)
-	if token == "" {
-		return nil, "", fmt.Errorf("token cannot be empty")
+		return nil, "", fmt.Errorf("starting callback server: %w", err)
 	}
 
-	// Validate the token by calling the session endpoint.
-	authedClient := api.NewClient(client.BaseURL(), token)
-	result, err := ValidateToken(ctx, authedClient)
+	// Build the auth URL.
+	authURL := fmt.Sprintf("%s/auth/cli?port=%d&state=%s", webURL, port, state)
+
+	fmt.Fprintf(os.Stderr, "%s Opening browser to authenticate...\n", output.Cyan("▸"))
+
+	if err := OpenBrowser(authURL); err != nil {
+		fmt.Fprintf(os.Stderr, "%s Could not open browser. Visit this URL manually:\n", output.Yellow("!"))
+		fmt.Fprintf(os.Stderr, "  %s\n\n", authURL)
+	}
+
+	// Wait for callback.
+	result := <-resultCh
+
+	if result.Error != "" {
+		return nil, "", fmt.Errorf("login failed: %s", result.Error)
+	}
+
+	// Validate the token by calling /v1/auth/session.
+	authedClient := api.NewClient(client.BaseURL(), result.Token)
+	loginResult, err := ValidateToken(ctx, authedClient)
 	if err != nil {
 		return nil, "", err
 	}
 
-	return result, token, nil
+	return loginResult, result.Token, nil
 }
 
 // ValidateToken checks the token against the session endpoint.

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -12,6 +12,7 @@ type UserConfig struct {
 	DefaultWorkspace string `yaml:"default_workspace,omitempty"`
 	DefaultOrg       string `yaml:"default_org,omitempty"`
 	APIURL           string `yaml:"api_url,omitempty"`
+	WebURL           string `yaml:"web_url,omitempty"`
 	Output           string `yaml:"output,omitempty"`
 }
 
@@ -65,6 +66,8 @@ func (c UserConfig) Get(key string) string {
 		return c.DefaultOrg
 	case "api_url":
 		return c.APIURL
+	case "web_url":
+		return c.WebURL
 	case "output":
 		return c.Output
 	default:
@@ -81,6 +84,8 @@ func (c *UserConfig) Set(key, value string) bool {
 		c.DefaultOrg = value
 	case "api_url":
 		c.APIURL = value
+	case "web_url":
+		c.WebURL = value
 	case "output":
 		c.Output = value
 	default:
@@ -91,5 +96,5 @@ func (c *UserConfig) Set(key, value string) bool {
 
 // Keys returns all valid config key names.
 func Keys() []string {
-	return []string{"default_workspace", "default_org", "api_url", "output"}
+	return []string{"default_workspace", "default_org", "api_url", "web_url", "output"}
 }

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -91,14 +91,15 @@ func TestLoadReturnsEmptyConfigWhenFileMissing(t *testing.T) {
 
 func TestKeysReturnsAllValidKeys(t *testing.T) {
 	keys := Keys()
-	if len(keys) != 4 {
-		t.Fatalf("len(Keys()) = %d, want 4", len(keys))
+	if len(keys) != 5 {
+		t.Fatalf("len(Keys()) = %d, want 5", len(keys))
 	}
 
 	expected := map[string]bool{
 		"default_workspace": true,
 		"default_org":       true,
 		"api_url":           true,
+		"web_url":           true,
 		"output":            true,
 	}
 	for _, k := range keys {

--- a/cli/internal/config/manager.go
+++ b/cli/internal/config/manager.go
@@ -4,6 +4,7 @@ import "os"
 
 const (
 	defaultAPIURL = "http://localhost:8080"
+	defaultWebURL = "http://localhost:3000"
 	defaultOutput = "table"
 )
 
@@ -104,6 +105,17 @@ func (m *Manager) DevOrgMemberships() string {
 // DevWorkspaceMemberships returns dev mode workspace memberships from env var.
 func (m *Manager) DevWorkspaceMemberships() string {
 	return os.Getenv("AGENTCLASH_DEV_WORKSPACE_MEMBERSHIPS")
+}
+
+// WebURL returns the resolved web app URL.
+func (m *Manager) WebURL() string {
+	if v := os.Getenv("AGENTCLASH_WEB_URL"); v != "" {
+		return v
+	}
+	if m.user.WebURL != "" {
+		return m.user.WebURL
+	}
+	return defaultWebURL
 }
 
 // UserConfig returns the loaded user config (for read/write operations).

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -47,6 +47,8 @@ tags:
     description: Current user profile with org/workspace hierarchy
   - name: Onboarding
     description: First-time organization and workspace setup
+  - name: CLIAuth
+    description: CLI token management and device code flow
   - name: Organizations
     description: Organization CRUD and management
   - name: OrgMemberships
@@ -2809,6 +2811,158 @@ paths:
         "404":
           $ref: "#/components/responses/NotFoundError"
 
+  # ---------------------------------------------------------------------------
+  # CLI Auth — Device Code Flow + Token Management
+  # ---------------------------------------------------------------------------
+
+  /v1/auth/device:
+    post:
+      summary: Create device authorization code
+      description: >
+        Initiates the device code flow (RFC 8628). Returns a device_code (secret)
+        and user_code (displayed to user). The CLI polls /v1/auth/device/token
+        with the device_code until the user approves.
+      tags: [CLIAuth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "201":
+          description: Device code created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceCodeResponse"
+
+  /v1/auth/device/token:
+    post:
+      summary: Poll for device token
+      description: >
+        CLI polls this endpoint with the device_code until the user approves,
+        denies, or the code expires. Returns authorization_pending, access_denied,
+        expired_token, or the CLI token on approval.
+      tags: [CLIAuth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [device_code]
+              properties:
+                device_code:
+                  type: string
+      responses:
+        "200":
+          description: Device approved, token returned
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PollDeviceTokenResponse"
+        "400":
+          description: Pending, denied, or expired
+
+  /v1/auth/device/approve:
+    post:
+      summary: Approve a device code
+      description: >
+        Called by the web app after user authenticates and enters the user_code.
+        Creates a CLI token for the authenticated user and links it to the device code.
+      tags: [CLIAuth]
+      security:
+        - bearerJWT: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [user_code]
+              properties:
+                user_code:
+                  type: string
+                  example: "RRGQ-BJVS"
+      responses:
+        "200":
+          description: Device approved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+        "400":
+          description: Invalid or expired code
+
+  /v1/auth/cli-tokens:
+    post:
+      summary: Create a CLI token
+      description: >
+        Creates a new CLI token for the authenticated user. The raw token is
+        returned exactly once in the response and never stored server-side.
+      tags: [CLIAuth]
+      security:
+        - bearerJWT: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  example: "MacBook CLI"
+      responses:
+        "201":
+          description: Token created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateCLITokenResponse"
+    get:
+      summary: List CLI tokens
+      description: Returns metadata for all active (non-revoked) CLI tokens owned by the caller.
+      tags: [CLIAuth]
+      security:
+        - bearerJWT: []
+      responses:
+        "200":
+          description: Token list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/CLITokenSummary"
+
+  /v1/auth/cli-tokens/{id}:
+    delete:
+      summary: Revoke a CLI token
+      description: Sets revoked_at on the token. Only the owning user can revoke.
+      tags: [CLIAuth]
+      security:
+        - bearerJWT: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "204":
+          description: Token revoked
+        "404":
+          description: Token not found
+
 # =============================================================================
 # Components
 # =============================================================================
@@ -3016,6 +3170,72 @@ components:
   # Schemas
   # ---------------------------------------------------------------------------
   schemas:
+    # --- CLI Auth ---
+
+    DeviceCodeResponse:
+      type: object
+      required: [device_code, user_code, verification_uri, expires_in, interval]
+      properties:
+        device_code:
+          type: string
+        user_code:
+          type: string
+          example: "RRGQ-BJVS"
+        verification_uri:
+          type: string
+        expires_in:
+          type: integer
+        interval:
+          type: integer
+
+    PollDeviceTokenResponse:
+      type: object
+      properties:
+        token:
+          type: string
+        user_id:
+          type: string
+        email:
+          type: string
+
+    CreateCLITokenResponse:
+      type: object
+      required: [id, token, name, created_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+        token:
+          type: string
+          description: Raw token, shown once
+        name:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+
+    CLITokenSummary:
+      type: object
+      required: [id, name, created_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        last_used_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+
     # --- Shared ---
 
     ErrorEnvelope:

--- a/web/src/app/auth/cli/actions.ts
+++ b/web/src/app/auth/cli/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { withAuth } from "@workos-inc/authkit-nextjs";
 import { createApiClient } from "@/lib/api/client";
 
 interface ApproveResult {
@@ -10,9 +11,9 @@ interface ApproveResult {
 export async function approveCLILogin(
   port: number,
   state: string,
-  accessToken: string,
 ): Promise<ApproveResult> {
   try {
+    const { accessToken } = await withAuth({ ensureSignedIn: true });
     const api = createApiClient(accessToken);
     const result = await api.post<{ id: string; token: string }>(
       "/v1/auth/cli-tokens",

--- a/web/src/app/auth/cli/actions.ts
+++ b/web/src/app/auth/cli/actions.ts
@@ -1,0 +1,30 @@
+"use server";
+
+import { createApiClient } from "@/lib/api/client";
+
+interface ApproveResult {
+  redirectUrl?: string;
+  error?: string;
+}
+
+export async function approveCLILogin(
+  port: number,
+  state: string,
+  accessToken: string,
+): Promise<ApproveResult> {
+  try {
+    const api = createApiClient(accessToken);
+    const result = await api.post<{ id: string; token: string }>(
+      "/v1/auth/cli-tokens",
+      { name: "CLI Login" },
+    );
+
+    const redirectUrl = `http://127.0.0.1:${port}/callback?token=${encodeURIComponent(result.token)}&state=${encodeURIComponent(state)}`;
+    return { redirectUrl };
+  } catch (err) {
+    return {
+      error:
+        err instanceof Error ? err.message : "Failed to create CLI token",
+    };
+  }
+}

--- a/web/src/app/auth/cli/cli-approve-button.tsx
+++ b/web/src/app/auth/cli/cli-approve-button.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState } from "react";
+import { approveCLILogin } from "./actions";
+
+interface Props {
+  port: number;
+  state: string;
+  accessToken: string;
+}
+
+export function CLIApproveButton({ port, state, accessToken }: Props) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleApprove() {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await approveCLILogin(port, state, accessToken);
+      if (result.error) {
+        setError(result.error);
+        setLoading(false);
+        return;
+      }
+      // Redirect to CLI callback.
+      window.location.href = result.redirectUrl!;
+    } catch {
+      setError("Failed to authorize. Please try again.");
+      setLoading(false);
+    }
+  }
+
+  function handleDeny() {
+    window.location.href = `http://127.0.0.1:${port}/callback?error=access_denied&state=${state}`;
+  }
+
+  return (
+    <div>
+      {error && (
+        <div style={errorStyle}>{error}</div>
+      )}
+      <button
+        onClick={handleApprove}
+        disabled={loading}
+        style={{
+          ...buttonStyle,
+          background: loading ? "rgba(255, 255, 255, 0.5)" : "rgba(255, 255, 255, 0.9)",
+          cursor: loading ? "not-allowed" : "pointer",
+        }}
+      >
+        {loading ? "Authorizing..." : "Approve"}
+      </button>
+      <button
+        onClick={handleDeny}
+        disabled={loading}
+        style={denyButtonStyle}
+      >
+        Deny
+      </button>
+    </div>
+  );
+}
+
+const buttonStyle: React.CSSProperties = {
+  display: "block",
+  width: "100%",
+  padding: "0.75rem 1rem",
+  color: "#060606",
+  borderRadius: "8px",
+  fontWeight: 500,
+  fontSize: "0.9375rem",
+  textAlign: "center",
+  border: "none",
+  marginBottom: "0.75rem",
+};
+
+const denyButtonStyle: React.CSSProperties = {
+  display: "block",
+  width: "100%",
+  padding: "0.75rem 1rem",
+  background: "transparent",
+  color: "rgba(255, 255, 255, 0.4)",
+  borderRadius: "8px",
+  fontWeight: 500,
+  fontSize: "0.875rem",
+  textAlign: "center",
+  border: "1px solid rgba(255, 255, 255, 0.08)",
+  cursor: "pointer",
+};
+
+const errorStyle: React.CSSProperties = {
+  background: "rgba(239, 68, 68, 0.1)",
+  border: "1px solid rgba(239, 68, 68, 0.2)",
+  borderRadius: "8px",
+  padding: "0.75rem",
+  color: "rgba(239, 68, 68, 0.9)",
+  fontSize: "0.8125rem",
+  marginBottom: "1rem",
+};

--- a/web/src/app/auth/cli/cli-approve-button.tsx
+++ b/web/src/app/auth/cli/cli-approve-button.tsx
@@ -6,10 +6,9 @@ import { approveCLILogin } from "./actions";
 interface Props {
   port: number;
   state: string;
-  accessToken: string;
 }
 
-export function CLIApproveButton({ port, state, accessToken }: Props) {
+export function CLIApproveButton({ port, state }: Props) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -17,13 +16,12 @@ export function CLIApproveButton({ port, state, accessToken }: Props) {
     setLoading(true);
     setError(null);
     try {
-      const result = await approveCLILogin(port, state, accessToken);
+      const result = await approveCLILogin(port, state);
       if (result.error) {
         setError(result.error);
         setLoading(false);
         return;
       }
-      // Redirect to CLI callback.
       window.location.href = result.redirectUrl!;
     } catch {
       setError("Failed to authorize. Please try again.");
@@ -32,7 +30,7 @@ export function CLIApproveButton({ port, state, accessToken }: Props) {
   }
 
   function handleDeny() {
-    window.location.href = `http://127.0.0.1:${port}/callback?error=access_denied&state=${state}`;
+    window.location.href = `http://127.0.0.1:${port}/callback?error=access_denied&state=${encodeURIComponent(state)}`;
   }
 
   return (

--- a/web/src/app/auth/cli/page.tsx
+++ b/web/src/app/auth/cli/page.tsx
@@ -1,0 +1,152 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { redirect } from "next/navigation";
+import { CLIApproveButton } from "./cli-approve-button";
+
+interface SearchParams {
+  port?: string;
+  state?: string;
+}
+
+export default async function CLILoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const params = await searchParams;
+  const { user, accessToken } = await withAuth({ ensureSignedIn: true });
+
+  const port = params.port;
+  const state = params.state;
+
+  if (!port || !state) {
+    return (
+      <div style={containerStyle}>
+        <div style={cardStyle}>
+          <h1 style={titleStyle}>Invalid Request</h1>
+          <p style={descStyle}>
+            This page is used by the AgentClash CLI. Run{" "}
+            <code style={codeStyle}>agentclash auth login</code> to authenticate.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const portNum = parseInt(port, 10);
+  if (isNaN(portNum) || portNum < 1024 || portNum > 65535) {
+    return (
+      <div style={containerStyle}>
+        <div style={cardStyle}>
+          <h1 style={titleStyle}>Invalid Port</h1>
+          <p style={descStyle}>The callback port is not valid.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={containerStyle}>
+      <div style={cardStyle}>
+        <div style={{ textAlign: "center", marginBottom: "1.5rem" }}>
+          <div style={iconStyle}>
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="4 17 10 11 4 5" />
+              <line x1="12" y1="19" x2="20" y2="19" />
+            </svg>
+          </div>
+          <h1 style={titleStyle}>Authorize AgentClash CLI</h1>
+          <p style={descStyle}>
+            The CLI is requesting access to your account.
+          </p>
+        </div>
+
+        <div style={userInfoStyle}>
+          <div style={labelStyle}>Signed in as</div>
+          <div style={valueStyle}>{user.email}</div>
+          {user.firstName && (
+            <div style={{ ...valueStyle, opacity: 0.6, fontSize: "0.8125rem" }}>
+              {user.firstName} {user.lastName}
+            </div>
+          )}
+        </div>
+
+        <CLIApproveButton
+          port={portNum}
+          state={state}
+          accessToken={accessToken ?? ""}
+        />
+      </div>
+    </div>
+  );
+}
+
+const containerStyle: React.CSSProperties = {
+  minHeight: "100vh",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "2rem",
+};
+
+const cardStyle: React.CSSProperties = {
+  width: "100%",
+  maxWidth: "420px",
+  background: "rgba(255, 255, 255, 0.03)",
+  border: "1px solid rgba(255, 255, 255, 0.08)",
+  borderRadius: "12px",
+  padding: "2rem",
+};
+
+const titleStyle: React.CSSProperties = {
+  fontFamily: "var(--font-display), serif",
+  fontSize: "1.5rem",
+  letterSpacing: "-0.02em",
+  color: "rgba(255, 255, 255, 0.9)",
+  margin: "0.75rem 0 0",
+};
+
+const descStyle: React.CSSProperties = {
+  color: "rgba(255, 255, 255, 0.4)",
+  fontSize: "0.875rem",
+  marginTop: "0.5rem",
+};
+
+const codeStyle: React.CSSProperties = {
+  background: "rgba(255, 255, 255, 0.06)",
+  padding: "0.15rem 0.4rem",
+  borderRadius: "4px",
+  fontFamily: "monospace",
+  fontSize: "0.8125rem",
+};
+
+const iconStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: "56px",
+  height: "56px",
+  borderRadius: "12px",
+  background: "rgba(255, 255, 255, 0.05)",
+  color: "rgba(255, 255, 255, 0.7)",
+};
+
+const userInfoStyle: React.CSSProperties = {
+  background: "rgba(255, 255, 255, 0.03)",
+  border: "1px solid rgba(255, 255, 255, 0.06)",
+  borderRadius: "8px",
+  padding: "1rem",
+  marginBottom: "1.5rem",
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: "0.75rem",
+  color: "rgba(255, 255, 255, 0.4)",
+  marginBottom: "0.25rem",
+  textTransform: "uppercase",
+  letterSpacing: "0.05em",
+};
+
+const valueStyle: React.CSSProperties = {
+  fontSize: "0.9375rem",
+  color: "rgba(255, 255, 255, 0.9)",
+};

--- a/web/src/app/auth/cli/page.tsx
+++ b/web/src/app/auth/cli/page.tsx
@@ -13,7 +13,7 @@ export default async function CLILoginPage({
   searchParams: Promise<SearchParams>;
 }) {
   const params = await searchParams;
-  const { user, accessToken } = await withAuth({ ensureSignedIn: true });
+  const { user } = await withAuth({ ensureSignedIn: true });
 
   const port = params.port;
   const state = params.state;
@@ -73,7 +73,6 @@ export default async function CLILoginPage({
         <CLIApproveButton
           port={portNum}
           state={state}
-          accessToken={accessToken ?? ""}
         />
       </div>
     </div>

--- a/web/src/app/auth/cli/page.tsx
+++ b/web/src/app/auth/cli/page.tsx
@@ -1,5 +1,4 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
-import { redirect } from "next/navigation";
 import { CLIApproveButton } from "./cli-approve-button";
 
 interface SearchParams {

--- a/web/src/app/auth/device/actions.ts
+++ b/web/src/app/auth/device/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { withAuth } from "@workos-inc/authkit-nextjs";
 import { createApiClient } from "@/lib/api/client";
 
 interface AuthorizeResult {
@@ -7,14 +8,23 @@ interface AuthorizeResult {
   error?: string;
 }
 
+// normalizeUserCode strips and re-formats to XXXX-YYYY.
+function normalizeUserCode(raw: string): string {
+  const clean = raw.toUpperCase().replace(/[^A-Z0-9]/g, "");
+  if (clean.length >= 8) {
+    return clean.slice(0, 4) + "-" + clean.slice(4, 8);
+  }
+  return clean;
+}
+
 export async function authorizeDevice(
   userCode: string,
-  accessToken: string,
 ): Promise<AuthorizeResult> {
   try {
+    const { accessToken } = await withAuth({ ensureSignedIn: true });
     const api = createApiClient(accessToken);
     await api.post("/v1/auth/device/approve", {
-      user_code: userCode.toUpperCase().replace(/[^A-Z0-9]/g, "").slice(0, 4) + "-" + userCode.toUpperCase().replace(/[^A-Z0-9]/g, "").slice(4, 8),
+      user_code: normalizeUserCode(userCode),
     });
     return { ok: true };
   } catch (err) {

--- a/web/src/app/auth/device/actions.ts
+++ b/web/src/app/auth/device/actions.ts
@@ -1,0 +1,26 @@
+"use server";
+
+import { createApiClient } from "@/lib/api/client";
+
+interface AuthorizeResult {
+  ok: boolean;
+  error?: string;
+}
+
+export async function authorizeDevice(
+  userCode: string,
+  accessToken: string,
+): Promise<AuthorizeResult> {
+  try {
+    const api = createApiClient(accessToken);
+    await api.post("/v1/auth/device/approve", {
+      user_code: userCode.toUpperCase().replace(/[^A-Z0-9]/g, "").slice(0, 4) + "-" + userCode.toUpperCase().replace(/[^A-Z0-9]/g, "").slice(4, 8),
+    });
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "Failed to authorize device",
+    };
+  }
+}

--- a/web/src/app/auth/device/device-code-form.tsx
+++ b/web/src/app/auth/device/device-code-form.tsx
@@ -3,11 +3,7 @@
 import { useState } from "react";
 import { authorizeDevice } from "./actions";
 
-interface Props {
-  accessToken: string;
-}
-
-export function DeviceCodeForm({ accessToken }: Props) {
+export function DeviceCodeForm() {
   const [code, setCode] = useState("");
   const [loading, setLoading] = useState(false);
   const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
@@ -33,7 +29,7 @@ export function DeviceCodeForm({ accessToken }: Props) {
     setLoading(true);
     setStatus("idle");
 
-    const result = await authorizeDevice(code, accessToken);
+    const result = await authorizeDevice(code);
     setLoading(false);
 
     if (result.ok) {

--- a/web/src/app/auth/device/device-code-form.tsx
+++ b/web/src/app/auth/device/device-code-form.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState } from "react";
+import { authorizeDevice } from "./actions";
+
+interface Props {
+  accessToken: string;
+}
+
+export function DeviceCodeForm({ accessToken }: Props) {
+  const [code, setCode] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
+  const [message, setMessage] = useState("");
+
+  function formatCode(raw: string): string {
+    const clean = raw.toUpperCase().replace(/[^A-Z0-9]/g, "");
+    if (clean.length > 4) {
+      return clean.slice(0, 4) + "-" + clean.slice(4, 8);
+    }
+    return clean;
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const cleaned = code.replace(/[^A-Z0-9]/g, "");
+    if (cleaned.length !== 8) {
+      setStatus("error");
+      setMessage("Code must be 8 characters (e.g., RRGQ-BJVS)");
+      return;
+    }
+
+    setLoading(true);
+    setStatus("idle");
+
+    const result = await authorizeDevice(code, accessToken);
+    setLoading(false);
+
+    if (result.ok) {
+      setStatus("success");
+      setMessage("Device authorized! You can close this page and return to your terminal.");
+    } else {
+      setStatus("error");
+      setMessage(result.error ?? "Failed to authorize device");
+    }
+  }
+
+  if (status === "success") {
+    return (
+      <div style={successStyle}>
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ marginBottom: "0.5rem" }}>
+          <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+          <polyline points="22 4 12 14.01 9 11.01" />
+        </svg>
+        <p style={{ margin: 0, fontWeight: 500 }}>{message}</p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label style={inputLabelStyle}>Device Code</label>
+      <input
+        type="text"
+        value={code}
+        onChange={(e) => setCode(formatCode(e.target.value))}
+        placeholder="XXXX-XXXX"
+        maxLength={9}
+        autoFocus
+        style={inputStyle}
+        autoComplete="off"
+        spellCheck={false}
+      />
+
+      {status === "error" && (
+        <div style={errorStyle}>{message}</div>
+      )}
+
+      <button
+        type="submit"
+        disabled={loading || code.replace(/-/g, "").length < 8}
+        style={{
+          ...buttonStyle,
+          opacity: loading || code.replace(/-/g, "").length < 8 ? 0.5 : 1,
+          cursor: loading ? "not-allowed" : "pointer",
+        }}
+      >
+        {loading ? "Authorizing..." : "Authorize"}
+      </button>
+    </form>
+  );
+}
+
+const inputLabelStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: "0.75rem",
+  color: "rgba(255, 255, 255, 0.4)",
+  marginBottom: "0.5rem",
+  textTransform: "uppercase",
+  letterSpacing: "0.05em",
+};
+
+const inputStyle: React.CSSProperties = {
+  display: "block",
+  width: "100%",
+  padding: "0.875rem 1rem",
+  background: "rgba(255, 255, 255, 0.05)",
+  border: "1px solid rgba(255, 255, 255, 0.1)",
+  borderRadius: "8px",
+  color: "rgba(255, 255, 255, 0.9)",
+  fontSize: "1.5rem",
+  fontFamily: "monospace",
+  textAlign: "center",
+  letterSpacing: "0.15em",
+  marginBottom: "1rem",
+  outline: "none",
+  boxSizing: "border-box",
+};
+
+const buttonStyle: React.CSSProperties = {
+  display: "block",
+  width: "100%",
+  padding: "0.75rem 1rem",
+  background: "rgba(255, 255, 255, 0.9)",
+  color: "#060606",
+  borderRadius: "8px",
+  fontWeight: 500,
+  fontSize: "0.9375rem",
+  textAlign: "center",
+  border: "none",
+};
+
+const errorStyle: React.CSSProperties = {
+  background: "rgba(239, 68, 68, 0.1)",
+  border: "1px solid rgba(239, 68, 68, 0.2)",
+  borderRadius: "8px",
+  padding: "0.75rem",
+  color: "rgba(239, 68, 68, 0.9)",
+  fontSize: "0.8125rem",
+  marginBottom: "1rem",
+};
+
+const successStyle: React.CSSProperties = {
+  textAlign: "center",
+  color: "rgba(34, 197, 94, 0.9)",
+  padding: "1.5rem",
+};

--- a/web/src/app/auth/device/page.tsx
+++ b/web/src/app/auth/device/page.tsx
@@ -2,7 +2,7 @@ import { withAuth } from "@workos-inc/authkit-nextjs";
 import { DeviceCodeForm } from "./device-code-form";
 
 export default async function DeviceAuthPage() {
-  const { user, accessToken } = await withAuth({ ensureSignedIn: true });
+  const { user } = await withAuth({ ensureSignedIn: true });
 
   return (
     <div style={containerStyle}>
@@ -26,7 +26,7 @@ export default async function DeviceAuthPage() {
           <div style={valueStyle}>{user.email}</div>
         </div>
 
-        <DeviceCodeForm accessToken={accessToken ?? ""} />
+        <DeviceCodeForm />
       </div>
     </div>
   );

--- a/web/src/app/auth/device/page.tsx
+++ b/web/src/app/auth/device/page.tsx
@@ -1,0 +1,96 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { DeviceCodeForm } from "./device-code-form";
+
+export default async function DeviceAuthPage() {
+  const { user, accessToken } = await withAuth({ ensureSignedIn: true });
+
+  return (
+    <div style={containerStyle}>
+      <div style={cardStyle}>
+        <div style={{ textAlign: "center", marginBottom: "1.5rem" }}>
+          <div style={iconStyle}>
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
+              <line x1="8" y1="21" x2="16" y2="21" />
+              <line x1="12" y1="17" x2="12" y2="21" />
+            </svg>
+          </div>
+          <h1 style={titleStyle}>Authorize Device</h1>
+          <p style={descStyle}>
+            Enter the code shown in your terminal to authorize the AgentClash CLI.
+          </p>
+        </div>
+
+        <div style={userInfoStyle}>
+          <div style={labelStyle}>Signed in as</div>
+          <div style={valueStyle}>{user.email}</div>
+        </div>
+
+        <DeviceCodeForm accessToken={accessToken ?? ""} />
+      </div>
+    </div>
+  );
+}
+
+const containerStyle: React.CSSProperties = {
+  minHeight: "100vh",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "2rem",
+};
+
+const cardStyle: React.CSSProperties = {
+  width: "100%",
+  maxWidth: "420px",
+  background: "rgba(255, 255, 255, 0.03)",
+  border: "1px solid rgba(255, 255, 255, 0.08)",
+  borderRadius: "12px",
+  padding: "2rem",
+};
+
+const titleStyle: React.CSSProperties = {
+  fontFamily: "var(--font-display), serif",
+  fontSize: "1.5rem",
+  letterSpacing: "-0.02em",
+  color: "rgba(255, 255, 255, 0.9)",
+  margin: "0.75rem 0 0",
+};
+
+const descStyle: React.CSSProperties = {
+  color: "rgba(255, 255, 255, 0.4)",
+  fontSize: "0.875rem",
+  marginTop: "0.5rem",
+};
+
+const iconStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: "56px",
+  height: "56px",
+  borderRadius: "12px",
+  background: "rgba(255, 255, 255, 0.05)",
+  color: "rgba(255, 255, 255, 0.7)",
+};
+
+const userInfoStyle: React.CSSProperties = {
+  background: "rgba(255, 255, 255, 0.03)",
+  border: "1px solid rgba(255, 255, 255, 0.06)",
+  borderRadius: "8px",
+  padding: "1rem",
+  marginBottom: "1.5rem",
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: "0.75rem",
+  color: "rgba(255, 255, 255, 0.4)",
+  marginBottom: "0.25rem",
+  textTransform: "uppercase",
+  letterSpacing: "0.05em",
+};
+
+const valueStyle: React.CSSProperties = {
+  fontSize: "0.9375rem",
+  color: "rgba(255, 255, 255, 0.9)",
+};


### PR DESCRIPTION
## Summary

- Replaces insecure token-paste CLI login with browser-based authentication
- Adds device code flow (RFC 8628-style) for SSH/container environments
- Introduces revocable CLI tokens (`clitok_` prefix, SHA-256 hashed) as a distinct auth type alongside WorkOS JWTs

### How it works

**Browser login** (default):
```
$ agentclash auth login
Opening browser to authenticate...
✓ Logged in as ayush@agentclash.dev
```

**Device code** (SSH/containers/`--device`):
```
$ agentclash auth login --device
Visit: https://app.agentclash.dev/auth/device
Enter code: RRGQ-BJVS
Waiting... ✓ Logged in
```

**Token management**:
```
$ agentclash auth tokens list
$ agentclash auth tokens revoke <id>
```

### Changes across all 3 codebases

**Backend (Go)**:
- Migration `00021_cli_auth.sql`: `cli_tokens` + `device_auth_codes` tables
- `CLITokenAuthenticator`: validates `clitok_`-prefixed tokens via SHA-256 hash
- `CompositeAuthenticator`: routes WorkOS JWTs vs CLI tokens by prefix
- 6 new endpoints: `POST /v1/auth/device`, `POST /v1/auth/device/token`, `POST /v1/auth/device/approve`, CLI token CRUD
- All 50 existing test `newRouter` calls updated

**Frontend (Next.js)**:
- `/auth/cli` — consent page with approve/deny buttons
- `/auth/device` — device code entry form with auto-formatting

**CLI (Go)**:
- Browser detection + localhost callback server (binds `127.0.0.1` only)
- Device code polling with spinner
- `auth tokens list|revoke` subcommands
- `web_url` / `AGENTCLASH_WEB_URL` config

### Security model
- State parameter (32 random bytes) prevents CSRF on localhost callback
- Localhost server binds `127.0.0.1` only (not `0.0.0.0`)
- Device codes: 10-min expiry, 5s poll interval, 8-char code from 22-char alphabet
- Tokens: SHA-256 hash stored (raw returned once), separately revocable

## Test plan

- [x] `cd backend && go build ./... && go vet ./... && go test -short -race ./internal/api/...` — all pass
- [x] `cd cli && go build ./... && go vet ./... && go test -short -race ./...` — all 64 tests pass
- [ ] E2E: `agentclash auth login` → browser opens → approve → logged in
- [ ] E2E: `agentclash auth login --device` → code shown → enter at /auth/device → approve
- [ ] E2E: `agentclash auth tokens list` → `agentclash auth tokens revoke <id>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)