### PR TITLE
feat: send workspace invite emails via Resend

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -56,3 +56,10 @@ E2B_REQUEST_TIMEOUT=30s
 # request-file scrub, response header stripping, sanitized error
 # paths).
 AGENTCLASH_SECRETS_MASTER_KEY=
+
+# --- Email (Resend) ---
+# When set, workspace invite emails are sent via Resend.
+# When unset, invites are logged but no email is sent (noop mode).
+RESEND_API_KEY=
+RESEND_FROM_EMAIL=noreply@agentclash.dev
+FRONTEND_URL=http://localhost:3000

--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/api"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/budget"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/email"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/pubsub"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/storage"
@@ -102,7 +103,16 @@ func main() {
 	orgManager := api.NewOrganizationManager(orgAuthz, repo)
 	wsManager := api.NewWorkspaceManager(orgAuthz, repo)
 	orgMembershipManager := api.NewOrgMembershipManager(orgAuthz, repo)
-	wsMembershipManager := api.NewWorkspaceMembershipManager(repo)
+
+	var emailSender email.Sender
+	if cfg.ResendAPIKey != "" {
+		emailSender = email.NewResendSender(cfg.ResendAPIKey, cfg.ResendFromEmail)
+		logger.Info("email sender: resend")
+	} else {
+		emailSender = email.NoopSender{}
+		logger.Info("email sender: noop (RESEND_API_KEY not set)")
+	}
+	wsMembershipManager := api.NewWorkspaceMembershipManager(repo, emailSender, cfg.FrontendURL)
 	onboardingManager := api.NewOnboardingManager(repo)
 	infraManager := api.NewInfrastructureManager(repo)
 	workspaceSecretsManager := api.NewWorkspaceSecretsManager(repo)

--- a/backend/internal/api/config.go
+++ b/backend/internal/api/config.go
@@ -61,10 +61,13 @@ type Config struct {
 	ArtifactSignedURLTTL     time.Duration
 	ArtifactMaxUploadBytes   int64
 	SecretsCipher            *secrets.AESGCMCipher
-	RateLimitRPS             float64
-	RateLimitBurst           int
-	RateLimitRunCreationRPM  float64
+	RateLimitRPS              float64
+	RateLimitBurst            int
+	RateLimitRunCreationRPM   float64
 	RateLimitRunCreationBurst int
+	ResendAPIKey              string
+	ResendFromEmail           string
+	FrontendURL               string
 }
 
 func LoadConfigFromEnv() (Config, error) {
@@ -151,6 +154,13 @@ func LoadConfigFromEnv() (Config, error) {
 		return Config{}, err
 	}
 
+	resendAPIKey := os.Getenv("RESEND_API_KEY")
+	resendFromEmail := os.Getenv("RESEND_FROM_EMAIL")
+	frontendURL := os.Getenv("FRONTEND_URL")
+	if frontendURL == "" {
+		frontendURL = "http://localhost:3000"
+	}
+
 	cfg := Config{
 		AppEnvironment:           appEnvironment,
 		AuthMode:                 authMode,
@@ -178,6 +188,9 @@ func LoadConfigFromEnv() (Config, error) {
 		RateLimitBurst:            defaultRateLimitBurst,
 		RateLimitRunCreationRPM:   defaultRateLimitRunCreationRPM,
 		RateLimitRunCreationBurst: defaultRateLimitRunCreationBurst,
+		ResendAPIKey:              resendAPIKey,
+		ResendFromEmail:           resendFromEmail,
+		FrontendURL:               frontendURL,
 	}
 
 	if err := validateArtifactConfig(cfg); err != nil {

--- a/backend/internal/api/workspace_memberships.go
+++ b/backend/internal/api/workspace_memberships.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
 
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/email"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -51,6 +53,7 @@ type ListWorkspaceMembershipsResult struct {
 
 type WorkspaceMembershipRepository interface {
 	GetOrganizationIDByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (uuid.UUID, error)
+	GetWorkspaceByID(ctx context.Context, workspaceID uuid.UUID) (repository.WorkspaceRow, error)
 	ListWorkspaceMemberships(ctx context.Context, workspaceID uuid.UUID, limit, offset int32) ([]repository.WorkspaceMembershipFullRow, error)
 	CountWorkspaceMemberships(ctx context.Context, workspaceID uuid.UUID) (int64, error)
 	GetUserByEmail(ctx context.Context, email string) (repository.User, error)
@@ -64,11 +67,13 @@ type WorkspaceMembershipRepository interface {
 }
 
 type WorkspaceMembershipManager struct {
-	repo WorkspaceMembershipRepository
+	repo        WorkspaceMembershipRepository
+	emailSender email.Sender
+	frontendURL string
 }
 
-func NewWorkspaceMembershipManager(repo WorkspaceMembershipRepository) *WorkspaceMembershipManager {
-	return &WorkspaceMembershipManager{repo: repo}
+func NewWorkspaceMembershipManager(repo WorkspaceMembershipRepository, emailSender email.Sender, frontendURL string) *WorkspaceMembershipManager {
+	return &WorkspaceMembershipManager{repo: repo, emailSender: emailSender, frontendURL: frontendURL}
 }
 
 func (m *WorkspaceMembershipManager) ListWorkspaceMemberships(ctx context.Context, caller Caller, workspaceID uuid.UUID, limit, offset int32) (ListWorkspaceMembershipsResult, error) {
@@ -152,6 +157,7 @@ func (m *WorkspaceMembershipManager) InviteWorkspaceMember(ctx context.Context, 
 		if err != nil {
 			return WorkspaceMembershipResult{}, err
 		}
+		m.sendInviteEmail(ctx, caller, workspaceID, input.Email, input.Role)
 		return wsMembershipRowToResult(result), nil
 	}
 	if !errors.Is(err, repository.ErrMembershipNotFound) {
@@ -168,6 +174,7 @@ func (m *WorkspaceMembershipManager) InviteWorkspaceMember(ctx context.Context, 
 		return WorkspaceMembershipResult{}, err
 	}
 
+	m.sendInviteEmail(ctx, caller, workspaceID, input.Email, input.Role)
 	return wsMembershipRowToResult(result), nil
 }
 
@@ -239,6 +246,31 @@ func (m *WorkspaceMembershipManager) UpdateWorkspaceMembership(ctx context.Conte
 	}
 
 	return wsMembershipRowToResult(result), nil
+}
+
+func (m *WorkspaceMembershipManager) sendInviteEmail(ctx context.Context, caller Caller, workspaceID uuid.UUID, inviteeEmail, role string) {
+	workspace, err := m.repo.GetWorkspaceByID(ctx, workspaceID)
+	if err != nil {
+		slog.Default().Warn("failed to load workspace for invite email", "workspace_id", workspaceID, "error", err)
+		return
+	}
+
+	inviterEmail := caller.Email
+	if inviterEmail == "" {
+		inviterEmail = "a team member"
+	}
+
+	acceptURL := fmt.Sprintf("%s/dashboard", m.frontendURL)
+
+	if err := m.emailSender.SendInvite(ctx, email.InviteEmail{
+		To:            inviteeEmail,
+		WorkspaceName: workspace.Name,
+		InviterEmail:  inviterEmail,
+		Role:          role,
+		AcceptURL:     acceptURL,
+	}); err != nil {
+		slog.Default().Warn("failed to send invite email", "to", inviteeEmail, "workspace_id", workspaceID, "error", err)
+	}
 }
 
 func (m *WorkspaceMembershipManager) authorizeAccess(ctx context.Context, caller Caller, workspaceID uuid.UUID) error {

--- a/backend/internal/api/workspace_memberships_test.go
+++ b/backend/internal/api/workspace_memberships_test.go
@@ -1,0 +1,212 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/email"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+type fakeWsMembershipRepo struct {
+	orgID           uuid.UUID
+	workspace       repository.WorkspaceRow
+	user            repository.User
+	userErr         error
+	orgMembership   repository.OrgMembershipFullRow
+	orgMemberErr    error
+	wsMembership    repository.WorkspaceMembershipFullRow
+	wsMemberErr     error
+	created         repository.WorkspaceMembershipFullRow
+	createErr       error
+	updated         repository.WorkspaceMembershipFullRow
+	updateErr       error
+	adminCount      int64
+	memberships     []repository.WorkspaceMembershipFullRow
+	membershipCount int64
+}
+
+func (r *fakeWsMembershipRepo) GetOrganizationIDByWorkspaceID(_ context.Context, _ uuid.UUID) (uuid.UUID, error) {
+	return r.orgID, nil
+}
+
+func (r *fakeWsMembershipRepo) GetWorkspaceByID(_ context.Context, _ uuid.UUID) (repository.WorkspaceRow, error) {
+	return r.workspace, nil
+}
+
+func (r *fakeWsMembershipRepo) ListWorkspaceMemberships(_ context.Context, _ uuid.UUID, _, _ int32) ([]repository.WorkspaceMembershipFullRow, error) {
+	return r.memberships, nil
+}
+
+func (r *fakeWsMembershipRepo) CountWorkspaceMemberships(_ context.Context, _ uuid.UUID) (int64, error) {
+	return r.membershipCount, nil
+}
+
+func (r *fakeWsMembershipRepo) GetUserByEmail(_ context.Context, _ string) (repository.User, error) {
+	return r.user, r.userErr
+}
+
+func (r *fakeWsMembershipRepo) CreateUser(_ context.Context, input repository.CreateUserInput) (repository.User, error) {
+	return repository.User{ID: uuid.New(), Email: input.Email}, nil
+}
+
+func (r *fakeWsMembershipRepo) GetOrgMembershipByOrgAndUser(_ context.Context, _, _ uuid.UUID) (repository.OrgMembershipFullRow, error) {
+	return r.orgMembership, r.orgMemberErr
+}
+
+func (r *fakeWsMembershipRepo) GetWorkspaceMembershipByWorkspaceAndUser(_ context.Context, _, _ uuid.UUID) (repository.WorkspaceMembershipFullRow, error) {
+	return r.wsMembership, r.wsMemberErr
+}
+
+func (r *fakeWsMembershipRepo) CreateWorkspaceMembership(_ context.Context, _ repository.CreateWorkspaceMembershipInput) (repository.WorkspaceMembershipFullRow, error) {
+	return r.created, r.createErr
+}
+
+func (r *fakeWsMembershipRepo) GetWorkspaceMembershipByID(_ context.Context, _ uuid.UUID) (repository.WorkspaceMembershipFullRow, error) {
+	return r.wsMembership, r.wsMemberErr
+}
+
+func (r *fakeWsMembershipRepo) UpdateWorkspaceMembership(_ context.Context, _ uuid.UUID, _ repository.UpdateWorkspaceMembershipInput) (repository.WorkspaceMembershipFullRow, error) {
+	return r.updated, r.updateErr
+}
+
+func (r *fakeWsMembershipRepo) CountActiveWorkspaceAdmins(_ context.Context, _ uuid.UUID) (int64, error) {
+	return r.adminCount, nil
+}
+
+type fakeEmailSender struct {
+	calls []email.InviteEmail
+	err   error
+}
+
+func (s *fakeEmailSender) SendInvite(_ context.Context, input email.InviteEmail) error {
+	s.calls = append(s.calls, input)
+	return s.err
+}
+
+func TestInviteWorkspaceMember_SendsEmail(t *testing.T) {
+	workspaceID := uuid.New()
+	userID := uuid.New()
+	orgID := uuid.New()
+
+	repo := &fakeWsMembershipRepo{
+		orgID: orgID,
+		workspace: repository.WorkspaceRow{
+			ID:   workspaceID,
+			Name: "Test Workspace",
+		},
+		user:    repository.User{ID: userID, Email: "invitee@example.com"},
+		userErr: nil,
+		orgMembership: repository.OrgMembershipFullRow{
+			ID:               uuid.New(),
+			OrganizationID:   orgID,
+			UserID:           userID,
+			MembershipStatus: "active",
+		},
+		orgMemberErr: nil,
+		wsMemberErr:  repository.ErrMembershipNotFound,
+		created: repository.WorkspaceMembershipFullRow{
+			ID:               uuid.New(),
+			WorkspaceID:      workspaceID,
+			OrganizationID:   orgID,
+			UserID:           userID,
+			Email:            "invitee@example.com",
+			Role:             "workspace_member",
+			MembershipStatus: "invited",
+		},
+	}
+
+	sender := &fakeEmailSender{}
+	manager := NewWorkspaceMembershipManager(repo, sender, "https://app.agentclash.dev")
+
+	caller := Caller{
+		UserID: uuid.New(),
+		Email:  "admin@example.com",
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_admin"},
+		},
+	}
+
+	_, err := manager.InviteWorkspaceMember(context.Background(), caller, workspaceID, InviteWorkspaceMemberInput{
+		Email: "invitee@example.com",
+		Role:  "workspace_member",
+	})
+	if err != nil {
+		t.Fatalf("InviteWorkspaceMember returned error: %v", err)
+	}
+
+	if len(sender.calls) != 1 {
+		t.Fatalf("expected 1 email sent, got %d", len(sender.calls))
+	}
+	sent := sender.calls[0]
+	if sent.To != "invitee@example.com" {
+		t.Errorf("email To = %q, want invitee@example.com", sent.To)
+	}
+	if sent.WorkspaceName != "Test Workspace" {
+		t.Errorf("email WorkspaceName = %q, want Test Workspace", sent.WorkspaceName)
+	}
+	if sent.InviterEmail != "admin@example.com" {
+		t.Errorf("email InviterEmail = %q, want admin@example.com", sent.InviterEmail)
+	}
+	if sent.Role != "workspace_member" {
+		t.Errorf("email Role = %q, want workspace_member", sent.Role)
+	}
+}
+
+func TestInviteWorkspaceMember_EmailFailureDoesNotBlockInvite(t *testing.T) {
+	workspaceID := uuid.New()
+	userID := uuid.New()
+	orgID := uuid.New()
+
+	repo := &fakeWsMembershipRepo{
+		orgID: orgID,
+		workspace: repository.WorkspaceRow{
+			ID:   workspaceID,
+			Name: "Test Workspace",
+		},
+		user: repository.User{ID: userID, Email: "invitee@example.com"},
+		orgMembership: repository.OrgMembershipFullRow{
+			ID:               uuid.New(),
+			OrganizationID:   orgID,
+			UserID:           userID,
+			MembershipStatus: "active",
+		},
+		wsMemberErr: repository.ErrMembershipNotFound,
+		created: repository.WorkspaceMembershipFullRow{
+			ID:               uuid.New(),
+			WorkspaceID:      workspaceID,
+			OrganizationID:   orgID,
+			UserID:           userID,
+			Email:            "invitee@example.com",
+			Role:             "workspace_member",
+			MembershipStatus: "invited",
+		},
+	}
+
+	sender := &fakeEmailSender{err: errors.New("resend is down")}
+	manager := NewWorkspaceMembershipManager(repo, sender, "https://app.agentclash.dev")
+
+	caller := Caller{
+		UserID: uuid.New(),
+		Email:  "admin@example.com",
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_admin"},
+		},
+	}
+
+	result, err := manager.InviteWorkspaceMember(context.Background(), caller, workspaceID, InviteWorkspaceMemberInput{
+		Email: "invitee@example.com",
+		Role:  "workspace_member",
+	})
+	if err != nil {
+		t.Fatalf("InviteWorkspaceMember should succeed even when email fails, got: %v", err)
+	}
+	if result.MembershipStatus != "invited" {
+		t.Errorf("membership status = %q, want invited", result.MembershipStatus)
+	}
+	if len(sender.calls) != 1 {
+		t.Errorf("email should have been attempted, got %d calls", len(sender.calls))
+	}
+}

--- a/backend/internal/email/email.go
+++ b/backend/internal/email/email.go
@@ -1,0 +1,102 @@
+package email
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// Sender delivers transactional emails.
+type Sender interface {
+	SendInvite(ctx context.Context, input InviteEmail) error
+}
+
+// InviteEmail contains everything needed to send a workspace invitation.
+type InviteEmail struct {
+	To            string
+	WorkspaceName string
+	InviterEmail  string
+	Role          string
+	AcceptURL     string
+}
+
+// ResendSender sends emails via the Resend API.
+type ResendSender struct {
+	apiKey    string
+	fromEmail string
+	client    *http.Client
+}
+
+func NewResendSender(apiKey, fromEmail string) *ResendSender {
+	return &ResendSender{
+		apiKey:    apiKey,
+		fromEmail: fromEmail,
+		client:    &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (s *ResendSender) SendInvite(ctx context.Context, input InviteEmail) error {
+	subject := fmt.Sprintf("You've been invited to %s on AgentClash", input.WorkspaceName)
+	html := buildInviteHTML(input)
+
+	body, err := json.Marshal(map[string]any{
+		"from":    s.fromEmail,
+		"to":      []string{input.To},
+		"subject": subject,
+		"html":    html,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal resend request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.resend.com/emails", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build resend request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+s.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("resend request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("resend returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return nil
+}
+
+func buildInviteHTML(input InviteEmail) string {
+	return fmt.Sprintf(`<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:480px;margin:0 auto;padding:32px 0">
+  <h2 style="font-size:20px;font-weight:600;margin:0 0 16px">You've been invited to %s</h2>
+  <p style="color:#555;font-size:14px;line-height:1.6;margin:0 0 8px">
+    <strong>%s</strong> invited you as <strong>%s</strong> on AgentClash.
+  </p>
+  <p style="color:#555;font-size:14px;line-height:1.6;margin:0 0 24px">
+    Click the button below to accept the invitation. This invite expires in 7 days.
+  </p>
+  <a href="%s" style="display:inline-block;background:#000;color:#fff;font-size:14px;font-weight:500;padding:10px 24px;border-radius:6px;text-decoration:none">
+    Accept Invitation
+  </a>
+  <p style="color:#999;font-size:12px;margin:24px 0 0">
+    If you didn't expect this invitation, you can ignore this email.
+  </p>
+</div>`, input.WorkspaceName, input.InviterEmail, input.Role, input.AcceptURL)
+}
+
+// NoopSender logs invite emails without sending them.
+type NoopSender struct{}
+
+func (NoopSender) SendInvite(_ context.Context, input InviteEmail) error {
+	slog.Default().Info("invite email (noop)", "to", input.To, "workspace", input.WorkspaceName, "role", input.Role, "accept_url", input.AcceptURL)
+	return nil
+}

--- a/backend/internal/email/email_test.go
+++ b/backend/internal/email/email_test.go
@@ -1,0 +1,49 @@
+package email
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNoopSenderDoesNotError(t *testing.T) {
+	sender := NoopSender{}
+	err := sender.SendInvite(context.Background(), InviteEmail{
+		To:            "test@example.com",
+		WorkspaceName: "My Workspace",
+		InviterEmail:  "admin@example.com",
+		Role:          "workspace_member",
+		AcceptURL:     "https://app.agentclash.dev/dashboard",
+	})
+	if err != nil {
+		t.Fatalf("NoopSender.SendInvite returned error: %v", err)
+	}
+}
+
+func TestBuildInviteHTML_ContainsKeyFields(t *testing.T) {
+	html := buildInviteHTML(InviteEmail{
+		To:            "test@example.com",
+		WorkspaceName: "Eval Team",
+		InviterEmail:  "alice@example.com",
+		Role:          "workspace_admin",
+		AcceptURL:     "https://app.agentclash.dev/dashboard",
+	})
+
+	for _, want := range []string{"Eval Team", "alice@example.com", "workspace_admin", "https://app.agentclash.dev/dashboard", "7 days"} {
+		if !contains(html, want) {
+			t.Errorf("invite HTML missing %q", want)
+		}
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Adds `backend/internal/email/` package with `Sender` interface, `ResendSender`, and `NoopSender`
- Sends workspace invite email after membership creation (new invite + re-invite of archived members)
- Email failures are logged but never block the invite — the DB record is always created
- Configurable via `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, and `FRONTEND_URL` env vars
- Falls back to noop (log-only) when `RESEND_API_KEY` is not set

## Test plan
- [x] `go test -short -race -count=1 ./...` — all pass
- [x] `TestInviteWorkspaceMember_SendsEmail` — verifies email is sent with correct fields
- [x] `TestInviteWorkspaceMember_EmailFailureDoesNotBlockInvite` — verifies invite succeeds even when Resend is down
- [x] `TestNoopSenderDoesNotError` — noop sender works
- [x] `TestBuildInviteHTML_ContainsKeyFields` — HTML template includes all expected fields
- [ ] Set `RESEND_API_KEY` in `.env` and verify real email delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)