### PR TITLE
fix(api): auto-select input set on run creation

### DIFF
--- a/backend/db/queries/run_creation.sql
+++ b/backend/db/queries/run_creation.sql
@@ -13,6 +13,13 @@ WHERE id = @id
   AND archived_at IS NULL
 LIMIT 1;
 
+-- name: ListChallengeInputSetsByVersionID :many
+SELECT id, challenge_pack_version_id, input_key, name
+FROM challenge_input_sets
+WHERE challenge_pack_version_id = @challenge_pack_version_id
+  AND archived_at IS NULL
+ORDER BY created_at ASC;
+
 -- name: ListRunnableDeploymentsWithLatestSnapshot :many
 SELECT DISTINCT ON (agent_deployments.id)
     agent_deployments.id,

--- a/backend/internal/api/run_service.go
+++ b/backend/internal/api/run_service.go
@@ -15,6 +15,7 @@ import (
 type RunCreationRepository interface {
 	GetRunnableChallengePackVersionByID(ctx context.Context, id uuid.UUID) (repository.RunnableChallengePackVersion, error)
 	GetChallengeInputSetByID(ctx context.Context, id uuid.UUID) (repository.ChallengeInputSet, error)
+	ListChallengeInputSetsByVersionID(ctx context.Context, challengePackVersionID uuid.UUID) ([]repository.ChallengeInputSetSummary, error)
 	ListRunnableDeploymentsWithLatestSnapshot(ctx context.Context, workspaceID uuid.UUID, deploymentIDs []uuid.UUID) ([]repository.RunnableDeployment, error)
 	CreateQueuedRun(ctx context.Context, params repository.CreateQueuedRunParams) (repository.CreateQueuedRunResult, error)
 }
@@ -104,6 +105,22 @@ func (m *RunCreationManager) CreateRun(ctx context.Context, caller Caller, input
 			return CreateRunResult{}, RunCreationValidationError{
 				Code:    "invalid_challenge_input_set_id",
 				Message: "challenge_input_set_id must belong to the selected challenge pack version",
+			}
+		}
+	} else {
+		inputSets, err := m.repo.ListChallengeInputSetsByVersionID(ctx, input.ChallengePackVersionID)
+		if err != nil {
+			return CreateRunResult{}, fmt.Errorf("list challenge input sets: %w", err)
+		}
+		switch len(inputSets) {
+		case 0:
+			// Pack has no input sets — proceed without one.
+		case 1:
+			input.ChallengeInputSetID = &inputSets[0].ID
+		default:
+			return CreateRunResult{}, RunCreationValidationError{
+				Code:    "missing_challenge_input_set_id",
+				Message: "challenge pack has multiple input sets; challenge_input_set_id is required",
 			}
 		}
 	}

--- a/backend/internal/api/run_service_test.go
+++ b/backend/internal/api/run_service_test.go
@@ -370,11 +370,175 @@ func TestRunCreationManagerRejectsForbiddenWorkspaceAccess(t *testing.T) {
 	}
 }
 
+func TestRunCreationManagerAutoSelectsSingleInputSet(t *testing.T) {
+	workspaceID := uuid.New()
+	challengePackVersionID := uuid.New()
+	inputSetID := uuid.New()
+	deploymentID := uuid.New()
+	snapshotID := uuid.New()
+	runID := uuid.New()
+	caller := Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}
+
+	repo := &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{ID: challengePackVersionID},
+		challengeInputSets: []repository.ChallengeInputSetSummary{
+			{ID: inputSetID, ChallengePackVersionID: challengePackVersionID, InputKey: "default", Name: "Default"},
+		},
+		deployments: []repository.RunnableDeployment{
+			{
+				ID:                        deploymentID,
+				OrganizationID:            uuid.New(),
+				WorkspaceID:               workspaceID,
+				Name:                      "Agent",
+				AgentDeploymentSnapshotID: snapshotID,
+			},
+		},
+		createResult: repository.CreateQueuedRunResult{
+			Run: domain.Run{
+				ID:                     runID,
+				WorkspaceID:            workspaceID,
+				ChallengePackVersionID: challengePackVersionID,
+				ChallengeInputSetID:    &inputSetID,
+				Status:                 domain.RunStatusQueued,
+				ExecutionMode:          "single_agent",
+			},
+		},
+	}
+	starter := &fakeRunWorkflowStarter{}
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, starter, nil)
+
+	// Create a run WITHOUT specifying challenge_input_set_id.
+	_, err := manager.CreateRun(context.Background(), caller, CreateRunInput{
+		WorkspaceID:            workspaceID,
+		ChallengePackVersionID: challengePackVersionID,
+		AgentDeploymentIDs:     []uuid.UUID{deploymentID},
+	})
+	if err != nil {
+		t.Fatalf("CreateRun returned error: %v", err)
+	}
+
+	if repo.createParams == nil {
+		t.Fatal("expected CreateQueuedRun to be called")
+	}
+	if repo.createParams.ChallengeInputSetID == nil {
+		t.Fatal("expected auto-selected challenge_input_set_id, got nil")
+	}
+	if *repo.createParams.ChallengeInputSetID != inputSetID {
+		t.Fatalf("auto-selected input set = %s, want %s", *repo.createParams.ChallengeInputSetID, inputSetID)
+	}
+}
+
+func TestRunCreationManagerRejectsAmbiguousInputSets(t *testing.T) {
+	workspaceID := uuid.New()
+	challengePackVersionID := uuid.New()
+	deploymentID := uuid.New()
+	caller := Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}
+
+	repo := &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{ID: challengePackVersionID},
+		challengeInputSets: []repository.ChallengeInputSetSummary{
+			{ID: uuid.New(), ChallengePackVersionID: challengePackVersionID, InputKey: "default", Name: "Default"},
+			{ID: uuid.New(), ChallengePackVersionID: challengePackVersionID, InputKey: "extended", Name: "Extended"},
+		},
+		deployments: []repository.RunnableDeployment{
+			{
+				ID:                        deploymentID,
+				OrganizationID:            uuid.New(),
+				WorkspaceID:               workspaceID,
+				Name:                      "Agent",
+				AgentDeploymentSnapshotID: uuid.New(),
+			},
+		},
+	}
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, &fakeRunWorkflowStarter{}, nil)
+
+	_, err := manager.CreateRun(context.Background(), caller, CreateRunInput{
+		WorkspaceID:            workspaceID,
+		ChallengePackVersionID: challengePackVersionID,
+		AgentDeploymentIDs:     []uuid.UUID{deploymentID},
+	})
+	if err == nil {
+		t.Fatal("expected validation error for ambiguous input sets")
+	}
+
+	var validationErr RunCreationValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error = %v, want RunCreationValidationError", err)
+	}
+	if validationErr.Code != "missing_challenge_input_set_id" {
+		t.Fatalf("validation code = %q, want missing_challenge_input_set_id", validationErr.Code)
+	}
+}
+
+func TestRunCreationManagerProceedsWithoutInputSetsWhenNoneExist(t *testing.T) {
+	workspaceID := uuid.New()
+	challengePackVersionID := uuid.New()
+	deploymentID := uuid.New()
+	runID := uuid.New()
+	caller := Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}
+
+	repo := &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{ID: challengePackVersionID},
+		challengeInputSets:   nil, // no input sets
+		deployments: []repository.RunnableDeployment{
+			{
+				ID:                        deploymentID,
+				OrganizationID:            uuid.New(),
+				WorkspaceID:               workspaceID,
+				Name:                      "Agent",
+				AgentDeploymentSnapshotID: uuid.New(),
+			},
+		},
+		createResult: repository.CreateQueuedRunResult{
+			Run: domain.Run{
+				ID:                     runID,
+				WorkspaceID:            workspaceID,
+				ChallengePackVersionID: challengePackVersionID,
+				Status:                 domain.RunStatusQueued,
+				ExecutionMode:          "single_agent",
+			},
+		},
+	}
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, &fakeRunWorkflowStarter{}, nil)
+
+	_, err := manager.CreateRun(context.Background(), caller, CreateRunInput{
+		WorkspaceID:            workspaceID,
+		ChallengePackVersionID: challengePackVersionID,
+		AgentDeploymentIDs:     []uuid.UUID{deploymentID},
+	})
+	if err != nil {
+		t.Fatalf("CreateRun returned error: %v", err)
+	}
+
+	if repo.createParams == nil {
+		t.Fatal("expected CreateQueuedRun to be called")
+	}
+	if repo.createParams.ChallengeInputSetID != nil {
+		t.Fatalf("expected nil challenge_input_set_id, got %s", *repo.createParams.ChallengeInputSetID)
+	}
+}
+
 type fakeRunCreationRepository struct {
 	challengePackVersion    repository.RunnableChallengePackVersion
 	challengePackVersionErr error
 	challengeInputSet       repository.ChallengeInputSet
 	challengeInputSetErr    error
+	challengeInputSets      []repository.ChallengeInputSetSummary
 	deployments             []repository.RunnableDeployment
 	createResult            repository.CreateQueuedRunResult
 	createParams            *repository.CreateQueuedRunParams
@@ -386,6 +550,10 @@ func (f *fakeRunCreationRepository) GetRunnableChallengePackVersionByID(_ contex
 
 func (f *fakeRunCreationRepository) GetChallengeInputSetByID(_ context.Context, _ uuid.UUID) (repository.ChallengeInputSet, error) {
 	return f.challengeInputSet, f.challengeInputSetErr
+}
+
+func (f *fakeRunCreationRepository) ListChallengeInputSetsByVersionID(_ context.Context, _ uuid.UUID) ([]repository.ChallengeInputSetSummary, error) {
+	return f.challengeInputSets, nil
 }
 
 func (f *fakeRunCreationRepository) ListRunnableDeploymentsWithLatestSnapshot(_ context.Context, _ uuid.UUID, _ []uuid.UUID) ([]repository.RunnableDeployment, error) {

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -84,6 +84,13 @@ type ChallengeInputSet struct {
 	ChallengePackVersionID uuid.UUID
 }
 
+type ChallengeInputSetSummary struct {
+	ID                     uuid.UUID
+	ChallengePackVersionID uuid.UUID
+	InputKey               string
+	Name                   string
+}
+
 type RunnableDeployment struct {
 	ID                        uuid.UUID
 	OrganizationID            uuid.UUID
@@ -274,6 +281,26 @@ func (r *Repository) GetChallengeInputSetByID(ctx context.Context, id uuid.UUID)
 		ID:                     row.ID,
 		ChallengePackVersionID: row.ChallengePackVersionID,
 	}, nil
+}
+
+func (r *Repository) ListChallengeInputSetsByVersionID(ctx context.Context, challengePackVersionID uuid.UUID) ([]ChallengeInputSetSummary, error) {
+	rows, err := r.queries.ListChallengeInputSetsByVersionID(ctx, repositorysqlc.ListChallengeInputSetsByVersionIDParams{
+		ChallengePackVersionID: challengePackVersionID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list challenge input sets by version id: %w", err)
+	}
+
+	results := make([]ChallengeInputSetSummary, 0, len(rows))
+	for _, row := range rows {
+		results = append(results, ChallengeInputSetSummary{
+			ID:                     row.ID,
+			ChallengePackVersionID: row.ChallengePackVersionID,
+			InputKey:               row.InputKey,
+			Name:                   row.Name,
+		})
+	}
+	return results, nil
 }
 
 func (r *Repository) ListRunnableDeploymentsWithLatestSnapshot(

--- a/backend/internal/repository/sqlc/querier.go
+++ b/backend/internal/repository/sqlc/querier.go
@@ -26,6 +26,7 @@ type Querier interface {
 	GetAgentBuildByID(ctx context.Context, arg GetAgentBuildByIDParams) (AgentBuild, error)
 	GetAgentBuildVersionByID(ctx context.Context, arg GetAgentBuildVersionByIDParams) (AgentBuildVersion, error)
 	GetChallengeInputSetByID(ctx context.Context, arg GetChallengeInputSetByIDParams) (ChallengeInputSet, error)
+	ListChallengeInputSetsByVersionID(ctx context.Context, arg ListChallengeInputSetsByVersionIDParams) ([]ListChallengeInputSetsByVersionIDRow, error)
 	GetEvaluationSpecByChallengePackVersionAndVersion(ctx context.Context, arg GetEvaluationSpecByChallengePackVersionAndVersionParams) (EvaluationSpec, error)
 	GetEvaluationSpecByID(ctx context.Context, arg GetEvaluationSpecByIDParams) (EvaluationSpec, error)
 	GetHostedRunExecutionByRunAgentID(ctx context.Context, arg GetHostedRunExecutionByRunAgentIDParams) (HostedRunExecution, error)

--- a/backend/internal/repository/sqlc/run_creation.sql.go
+++ b/backend/internal/repository/sqlc/run_creation.sql.go
@@ -72,6 +72,50 @@ func (q *Queries) GetRunnableChallengePackVersionByID(ctx context.Context, arg G
 	return i, err
 }
 
+const listChallengeInputSetsByVersionID = `-- name: ListChallengeInputSetsByVersionID :many
+SELECT id, challenge_pack_version_id, input_key, name
+FROM challenge_input_sets
+WHERE challenge_pack_version_id = $1
+  AND archived_at IS NULL
+ORDER BY created_at ASC
+`
+
+type ListChallengeInputSetsByVersionIDParams struct {
+	ChallengePackVersionID uuid.UUID
+}
+
+type ListChallengeInputSetsByVersionIDRow struct {
+	ID                     uuid.UUID
+	ChallengePackVersionID uuid.UUID
+	InputKey               string
+	Name                   string
+}
+
+func (q *Queries) ListChallengeInputSetsByVersionID(ctx context.Context, arg ListChallengeInputSetsByVersionIDParams) ([]ListChallengeInputSetsByVersionIDRow, error) {
+	rows, err := q.db.Query(ctx, listChallengeInputSetsByVersionID, arg.ChallengePackVersionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListChallengeInputSetsByVersionIDRow
+	for rows.Next() {
+		var i ListChallengeInputSetsByVersionIDRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.ChallengePackVersionID,
+			&i.InputKey,
+			&i.Name,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listRunnableDeploymentsWithLatestSnapshot = `-- name: ListRunnableDeploymentsWithLatestSnapshot :many
 SELECT DISTINCT ON (agent_deployments.id)
     agent_deployments.id,

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -4001,6 +4001,11 @@ components:
         challenge_input_set_id:
           type: string
           format: uuid
+          description: >
+            Optional. If omitted and the challenge pack has exactly one input
+            set, it is auto-selected. If omitted and the pack has multiple
+            input sets, the request is rejected with code
+            missing_challenge_input_set_id.
         name:
           type: string
         agent_deployment_ids:


### PR DESCRIPTION
## Summary

- When creating a run without `challenge_input_set_id`, the scoring engine gets no case expectations and every validator silently reports "case evidence is unavailable" — producing a broken run with score 0
- Now the run creation manager queries input sets for the pack version and **auto-selects** when exactly one exists (the 95% case), **errors clearly** when multiple exist, and only skips when the pack has no input sets
- Adds `ListChallengeInputSetsByVersionID` SQL query + repository method, 3 unit tests, and OpenAPI spec docs

## Test plan

- [x] `TestRunCreationManagerAutoSelectsSingleInputSet` — verifies auto-selection when pack has one input set
- [x] `TestRunCreationManagerRejectsAmbiguousInputSets` — verifies `missing_challenge_input_set_id` error when pack has multiple
- [x] `TestRunCreationManagerProceedsWithoutInputSetsWhenNoneExist` — verifies backward compat for packs with no input sets
- [x] All 13 existing run creation tests still pass
- [ ] Manual: upload a challenge pack with one input set, create a run without specifying input set ID, confirm scoring produces validator results instead of "unavailable"

🤖 Generated with [Claude Code](https://claude.com/claude-code)