### PR TITLE
feat(scoring): Temporal wiring for assertion judge (phase 4)

### DIFF
--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -695,6 +695,156 @@ func (r *Repository) StoreRunAgentEvaluationResults(ctx context.Context, evaluat
 	return nil
 }
 
+// StoreFinalizedScoringResults rewrites the run-agent scorecard and
+// writes llm_judge_results rows after the Phase 4 JudgeRunAgent
+// activity has merged judge verdicts into the deterministic
+// evaluation via scoring.FinalizeRunAgentEvaluation.
+//
+// Split from StoreRunAgentEvaluationResults intentionally:
+//
+//   - ScoreRunAgent runs first and writes validators + metrics +
+//     provisional scorecard via StoreRunAgentEvaluationResults. That
+//     scorecard carries llm_judge dims as unavailable.
+//   - JudgeRunAgent runs second, merges the judge results into the
+//     evaluation, and calls this method to refresh the scorecard row
+//     with the finalized overall_score / scorecard_passed plus the
+//     judge_results rows.
+//
+// Every write is an idempotent upsert, so a retry of either activity
+// converges on the same persisted state. The scorecard row and the
+// llm_judge_results rows go in one transaction so a partial write
+// can't leave a new scorecard row pointing at stale judge data.
+//
+// Error-state judge results are persisted with nil NormalizedScore
+// and mode-matching payload so operators can see "judge X failed
+// three times" in the llm_judge_results table instead of losing
+// that signal to ephemeral warnings. See #148 phase 4 Q3 decision.
+func (r *Repository) StoreFinalizedScoringResults(
+	ctx context.Context,
+	evaluation scoring.RunAgentEvaluation,
+	judgeResults []scoring.JudgeResult,
+) error {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin finalized scoring result transaction: %w", err)
+	}
+	defer rollback(ctx, tx)
+
+	queries := r.queries.WithTx(tx)
+
+	scorecard, err := buildRunAgentScorecardDocument(evaluation)
+	if err != nil {
+		return fmt.Errorf("marshal finalized run-agent scorecard: %w", err)
+	}
+
+	overallScore, err := numericFromFloat(evaluation.OverallScore)
+	if err != nil {
+		return fmt.Errorf("encode overall score: %w", err)
+	}
+	correctnessScore, err := numericFromFloat(evaluation.DimensionScores[string(scoring.ScorecardDimensionCorrectness)])
+	if err != nil {
+		return fmt.Errorf("encode correctness score: %w", err)
+	}
+	reliabilityScore, err := numericFromFloat(evaluation.DimensionScores[string(scoring.ScorecardDimensionReliability)])
+	if err != nil {
+		return fmt.Errorf("encode reliability score: %w", err)
+	}
+	latencyScore, err := numericFromFloat(evaluation.DimensionScores[string(scoring.ScorecardDimensionLatency)])
+	if err != nil {
+		return fmt.Errorf("encode latency score: %w", err)
+	}
+	costScore, err := numericFromFloat(evaluation.DimensionScores[string(scoring.ScorecardDimensionCost)])
+	if err != nil {
+		return fmt.Errorf("encode cost score: %w", err)
+	}
+
+	if _, err := queries.UpsertRunAgentScorecard(ctx, repositorysqlc.UpsertRunAgentScorecardParams{
+		RunAgentID:       evaluation.RunAgentID,
+		EvaluationSpecID: evaluation.EvaluationSpecID,
+		OverallScore:     overallScore,
+		CorrectnessScore: correctnessScore,
+		ReliabilityScore: reliabilityScore,
+		LatencyScore:     latencyScore,
+		CostScore:        costScore,
+		ScorecardPassed:  cloneBoolPtr(evaluation.Passed),
+		Scorecard:        scorecard,
+	}); err != nil {
+		return fmt.Errorf("upsert finalized run-agent scorecard: %w", err)
+	}
+
+	for _, jr := range judgeResults {
+		params, paramErr := upsertLLMJudgeParamsFromResult(evaluation.RunAgentID, evaluation.EvaluationSpecID, jr)
+		if paramErr != nil {
+			return fmt.Errorf("encode llm judge result %s: %w", jr.Key, paramErr)
+		}
+		if _, err := queries.UpsertLLMJudgeResult(ctx, params); err != nil {
+			return fmt.Errorf("upsert llm judge result %s: %w", jr.Key, err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit finalized scoring result transaction: %w", err)
+	}
+	return nil
+}
+
+// upsertLLMJudgeParamsFromResult converts a scoring.JudgeResult into
+// the sqlc params shape for llm_judge_results. Handles the nullable
+// score/confidence/variance fields and normalizes the payload to a
+// non-nil jsonb so the NOT NULL column constraint is always satisfied.
+//
+// Error-state judges (State=OutputStateError) are persisted with
+// nil NormalizedScore and the error reason folded into the payload
+// so downstream readers can filter `normalized_score IS NOT NULL`
+// for runnable results while retaining the failure signal.
+func upsertLLMJudgeParamsFromResult(runAgentID uuid.UUID, evaluationSpecID uuid.UUID, jr scoring.JudgeResult) (repositorysqlc.UpsertLLMJudgeResultParams, error) {
+	normalizedScore, err := numericFromFloat(jr.NormalizedScore)
+	if err != nil {
+		return repositorysqlc.UpsertLLMJudgeResultParams{}, fmt.Errorf("encode normalized score: %w", err)
+	}
+	variance, err := numericFromFloat(varianceNullable(jr.Variance))
+	if err != nil {
+		return repositorysqlc.UpsertLLMJudgeResultParams{}, fmt.Errorf("encode variance: %w", err)
+	}
+
+	payload := cloneJSON(jr.Payload)
+	if len(payload) == 0 {
+		payload = json.RawMessage(`{}`)
+	}
+
+	var confidence *string
+	if jr.Confidence != "" {
+		c := jr.Confidence
+		confidence = &c
+	}
+
+	return repositorysqlc.UpsertLLMJudgeResultParams{
+		RunAgentID:       runAgentID,
+		EvaluationSpecID: evaluationSpecID,
+		JudgeKey:         jr.Key,
+		Mode:             string(jr.Mode),
+		NormalizedScore:  normalizedScore,
+		Payload:          payload,
+		Confidence:       confidence,
+		Variance:         variance,
+		SampleCount:      int32(jr.SampleCount),
+		ModelCount:       int32(jr.ModelCount),
+	}, nil
+}
+
+// varianceNullable returns a pointer to the variance only when it is
+// non-zero. Zero variance means either "no variance signal" (e.g.,
+// assertion mode which doesn't compute variance) or "every sample
+// identical" — in both cases NULL is a better DB representation than
+// 0.0 so downstream queries can distinguish "never measured" from
+// "measured and identical."
+func varianceNullable(variance float64) *float64 {
+	if variance == 0 {
+		return nil
+	}
+	return &variance
+}
+
 func buildRunAgentScorecardDocument(evaluation scoring.RunAgentEvaluation) (json.RawMessage, error) {
 	type dimensionSummary struct {
 		State           scoring.OutputState `json:"state"`

--- a/backend/internal/runevents/envelope.go
+++ b/backend/internal/runevents/envelope.go
@@ -43,6 +43,7 @@ const (
 
 	EventTypeScoringStarted        Type = "scoring.started"
 	EventTypeScoringMetricRecorded Type = "scoring.metric.recorded"
+	EventTypeScoringJudgeRecorded  Type = "scoring.judge.recorded"
 	EventTypeScoringCompleted      Type = "scoring.completed"
 	EventTypeScoringFailed         Type = "scoring.failed"
 )
@@ -169,6 +170,7 @@ func isValidType(eventType Type) bool {
 		EventTypeGraderVerificationCodeExecuted,
 		EventTypeScoringStarted,
 		EventTypeScoringMetricRecorded,
+		EventTypeScoringJudgeRecorded,
 		EventTypeScoringCompleted,
 		EventTypeScoringFailed:
 		return true

--- a/backend/internal/scoring/engine.go
+++ b/backend/internal/scoring/engine.go
@@ -3,7 +3,6 @@ package scoring
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -151,8 +150,6 @@ type JudgeResult struct {
 	Payload         json.RawMessage `json:"payload,omitempty"`
 }
 
-var errJudgeModeUnsupported = errors.New("only deterministic evaluation specs are supported")
-
 func DecodeDefinition(definition json.RawMessage) (EvaluationSpec, error) {
 	if len(bytes.TrimSpace(definition)) == 0 {
 		return EvaluationSpec{}, ValidationErrors{{Field: "evaluation_spec.definition", Message: "is required"}}
@@ -170,13 +167,23 @@ func DecodeDefinition(definition json.RawMessage) (EvaluationSpec, error) {
 	return spec, nil
 }
 
+// EvaluateRunAgent runs the deterministic scoring pipeline (validators,
+// metrics, dimension dispatch, overall score) over a single run-agent's
+// evidence. Phase 4 of issue #148 removed the previous JudgeMode gate:
+// llm_judge and hybrid mode specs now run through this function and
+// produce a partial evaluation whose llm_judge-sourced dimensions come
+// back as OutputStateUnavailable. The workflow layer then calls
+// FinalizeRunAgentEvaluation with real judge results to merge those
+// dims and recompute the overall score.
+//
+// Callers that only need the deterministic result (no judge evaluator
+// wired) pass judgeResults=nil to FinalizeRunAgentEvaluation and get
+// a no-op merge — the returned evaluation stays as the partial shape
+// produced here.
 func EvaluateRunAgent(input EvaluationInput, spec EvaluationSpec) (RunAgentEvaluation, error) {
 	normalizeEvaluationSpec(&spec)
 	if err := ValidateEvaluationSpec(spec); err != nil {
 		return RunAgentEvaluation{}, err
-	}
-	if spec.JudgeMode != JudgeModeDeterministic {
-		return RunAgentEvaluation{}, errJudgeModeUnsupported
 	}
 
 	events := append([]Event(nil), input.Events...)
@@ -235,6 +242,154 @@ func EvaluateRunAgent(input EvaluationInput, spec EvaluationSpec) (RunAgentEvalu
 		Strategy:         spec.Scorecard.Strategy,
 		Warnings:         uniqueStrings(warnings),
 	}, nil
+}
+
+// FinalizeRunAgentEvaluation merges LLM-as-judge results into an
+// existing deterministic evaluation and recomputes the overall score
+// and passed verdict. Phase 4 of issue #148 introduces this function
+// as the pure-function counterpart to the Temporal JudgeRunAgent
+// activity: the activity runs the judge evaluator, then calls this
+// helper to produce the finalized RunAgentEvaluation that gets
+// persisted back to run_agent_scorecards.
+//
+// For each dimension with Source=llm_judge, the matching JudgeResult
+// (looked up by JudgeKey) replaces the placeholder unavailable entry
+// that EvaluateRunAgent emitted. The DimensionScores map is rebuilt
+// from the updated results, Status is recomputed from the new states,
+// and computeOverallScore is re-run so OverallScore / Passed /
+// OverallReason reflect the merged picture.
+//
+// Deterministic-only runs (no judges declared) pass judgeResults=nil
+// and get a no-op — the input evaluation is returned unchanged. This
+// keeps the workflow code path identical regardless of whether a
+// spec declares judges.
+//
+// Pure function: no DB access, no context, no side effects. Safe to
+// call from tests and from anywhere in the activity pipeline.
+func FinalizeRunAgentEvaluation(
+	evaluation RunAgentEvaluation,
+	spec EvaluationSpec,
+	judgeResults []JudgeResult,
+) RunAgentEvaluation {
+	if len(judgeResults) == 0 {
+		return evaluation
+	}
+
+	// Build a lookup of judge results by key so the dimension walk
+	// below is O(dims) rather than O(dims × judges).
+	judgeByKey := make(map[string]JudgeResult, len(judgeResults))
+	for _, jr := range judgeResults {
+		judgeByKey[jr.Key] = jr
+	}
+
+	// Index the dimensions in the spec by key so we can look up the
+	// source + judge_key binding without a linear scan per dim.
+	dimByKey := make(map[string]DimensionDeclaration, len(spec.Scorecard.Dimensions))
+	for _, d := range spec.Scorecard.Dimensions {
+		dimByKey[d.Key] = d
+	}
+
+	// Walk the existing dimension results and merge llm_judge-sourced
+	// entries in place. Copy the slice first so we don't mutate the
+	// caller's data.
+	updatedDimensionResults := make([]DimensionResult, len(evaluation.DimensionResults))
+	copy(updatedDimensionResults, evaluation.DimensionResults)
+	for i := range updatedDimensionResults {
+		result := &updatedDimensionResults[i]
+		decl, ok := dimByKey[result.Dimension]
+		if !ok || decl.Source != DimensionSourceLLMJudge {
+			continue
+		}
+		jr, found := judgeByKey[decl.JudgeKey]
+		if !found {
+			// Judge didn't execute — leave the unavailable stub in
+			// place. The release gate already handles missing
+			// required dimensions via #147 phase 4 wiring.
+			continue
+		}
+		result.State = jr.State
+		result.Score = cloneFloatPtr(jr.NormalizedScore)
+		result.Reason = jr.Reason
+	}
+
+	// Rebuild DimensionScores from the updated results so downstream
+	// readers (repository, API) see the merged picture.
+	updatedDimensionScores := make(map[string]*float64, len(updatedDimensionResults))
+	for _, result := range updatedDimensionResults {
+		updatedDimensionScores[result.Dimension] = cloneFloatPtr(result.Score)
+	}
+
+	// Recompute status based on the new dim state distribution.
+	status := EvaluationStatusComplete
+	if len(updatedDimensionResults) == 0 {
+		status = EvaluationStatusPartial
+	}
+	hasDimensionScore := false
+	for _, dimension := range updatedDimensionResults {
+		if dimension.State != OutputStateAvailable {
+			status = EvaluationStatusPartial
+		}
+		if dimension.Score != nil {
+			hasDimensionScore = true
+		}
+	}
+	if !hasDimensionScore {
+		status = EvaluationStatusPartial
+	}
+
+	overallScore, passed, overallReason := computeOverallScore(spec, updatedDimensionResults)
+
+	// Return a fresh RunAgentEvaluation to avoid mutating the input.
+	// Validator/metric results are shared by reference — they're
+	// immutable downstream and copying would waste allocations.
+	finalized := evaluation
+	finalized.Status = status
+	finalized.DimensionResults = updatedDimensionResults
+	finalized.DimensionScores = updatedDimensionScores
+	finalized.OverallScore = overallScore
+	finalized.Passed = passed
+	finalized.OverallReason = overallReason
+	return finalized
+}
+
+// cloneFloatPtr returns a deep copy of a nullable float pointer so
+// the finalized evaluation doesn't alias the caller's data.
+func cloneFloatPtr(value *float64) *float64 {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+// ExtractFinalOutputFromEvents walks a run-agent's event stream and
+// returns the final_output recorded by system.output.finalized or
+// system.run.completed. Empty string if no such event carries the
+// field. Mirrors the subset of buildEvidence logic that the Phase 4
+// JudgeRunAgent activity needs to compose a judge.Input without
+// re-running the full deterministic evaluation.
+//
+// The walk is order-stable: events are iterated in the order
+// supplied. Callers that need chronological ordering must sort the
+// slice before calling (EvaluateRunAgent already sorts internally;
+// the Phase 4 activity re-uses that sorted slice via the same
+// ListRunEventsByRunAgentID repository helper).
+func ExtractFinalOutputFromEvents(events []Event) string {
+	for _, event := range events {
+		if event.Type != "system.output.finalized" && event.Type != "system.run.completed" {
+			continue
+		}
+		payload := decodePayload(event.Payload)
+		if output, ok := stringValue(payload, "final_output"); ok {
+			return output
+		}
+		if event.Type == "system.output.finalized" {
+			if output, ok := extractLooseString(payload["output"]); ok {
+				return output
+			}
+		}
+	}
+	return ""
 }
 
 type scoredDimension struct {

--- a/backend/internal/scoring/engine.go
+++ b/backend/internal/scoring/engine.go
@@ -375,21 +375,23 @@ func cloneFloatPtr(value *float64) *float64 {
 // the Phase 4 activity re-uses that sorted slice via the same
 // ListRunEventsByRunAgentID repository helper).
 func ExtractFinalOutputFromEvents(events []Event) string {
+	var finalOutput string
 	for _, event := range events {
 		if event.Type != "system.output.finalized" && event.Type != "system.run.completed" {
 			continue
 		}
 		payload := decodePayload(event.Payload)
 		if output, ok := stringValue(payload, "final_output"); ok {
-			return output
+			finalOutput = output
+			continue
 		}
 		if event.Type == "system.output.finalized" {
 			if output, ok := extractLooseString(payload["output"]); ok {
-				return output
+				finalOutput = output
 			}
 		}
 	}
-	return ""
+	return finalOutput
 }
 
 type scoredDimension struct {

--- a/backend/internal/scoring/engine_test.go
+++ b/backend/internal/scoring/engine_test.go
@@ -222,6 +222,17 @@ func TestEvaluateRunAgentMarksInvalidRegexAsValidatorError(t *testing.T) {
 	}
 }
 
+func TestExtractFinalOutputFromEventsPrefersTerminalFinalOutput(t *testing.T) {
+	events := []Event{
+		{Type: "system.output.finalized", Payload: []byte(`{"output":"draft answer"}`)},
+		{Type: "system.run.completed", Payload: []byte(`{"final_output":"final answer"}`)},
+	}
+
+	if got := ExtractFinalOutputFromEvents(events); got != "final answer" {
+		t.Fatalf("final output = %q, want %q", got, "final answer")
+	}
+}
+
 func TestEvaluateRunAgentComputesValidatorPassRateAfterValidators(t *testing.T) {
 	spec := EvaluationSpec{
 		Name:          "fixture",

--- a/backend/internal/scoring/judge_finalize_test.go
+++ b/backend/internal/scoring/judge_finalize_test.go
@@ -1,0 +1,344 @@
+package scoring
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// --- FinalizeRunAgentEvaluation unit tests (Phase 4 of issue #148) ---
+
+// buildDeterministicEvaluation constructs a RunAgentEvaluation that
+// mimics what EvaluateRunAgent returns for a hybrid spec with one
+// validator-sourced dim and one llm_judge-sourced dim. The llm_judge
+// dim comes back as unavailable (Phase 1 stub behavior), matching
+// the real call path from Phase 4's JudgeRunAgent activity.
+func buildDeterministicEvaluation() (RunAgentEvaluation, EvaluationSpec) {
+	correctnessScore := 0.75
+	spec := EvaluationSpec{
+		Scorecard: ScorecardDeclaration{
+			Strategy: ScoringStrategyWeighted,
+			Dimensions: []DimensionDeclaration{
+				{Key: "correctness", Source: DimensionSourceValidators, BetterDirection: "higher", Weight: floatPtr(0.5)},
+				{Key: "tone", Source: DimensionSourceLLMJudge, JudgeKey: "professional_tone", BetterDirection: "higher", Weight: floatPtr(0.5)},
+			},
+		},
+	}
+	eval := RunAgentEvaluation{
+		Status:   EvaluationStatusPartial, // llm_judge unavailable → partial
+		Strategy: ScoringStrategyWeighted,
+		DimensionResults: []DimensionResult{
+			{Dimension: "correctness", Score: &correctnessScore, State: OutputStateAvailable, BetterDirection: "higher"},
+			{Dimension: "tone", Score: nil, State: OutputStateUnavailable, Reason: "llm_judge dimensions require the judge evaluator (#148 phase 3+)", BetterDirection: "higher"},
+		},
+		DimensionScores: map[string]*float64{
+			"correctness": &correctnessScore,
+			"tone":        nil,
+		},
+	}
+	return eval, spec
+}
+
+func TestFinalizeRunAgentEvaluation_NilJudgesIsNoop(t *testing.T) {
+	eval, spec := buildDeterministicEvaluation()
+
+	finalized := FinalizeRunAgentEvaluation(eval, spec, nil)
+
+	if finalized.Status != eval.Status {
+		t.Errorf("Status = %q, want unchanged %q", finalized.Status, eval.Status)
+	}
+	if len(finalized.DimensionResults) != len(eval.DimensionResults) {
+		t.Errorf("DimensionResults count = %d, want %d", len(finalized.DimensionResults), len(eval.DimensionResults))
+	}
+	// The llm_judge dim must stay unavailable — no judges supplied.
+	toneDim := finalized.DimensionResults[1]
+	if toneDim.State != OutputStateUnavailable {
+		t.Errorf("tone dim state = %q, want unavailable (no judges merged)", toneDim.State)
+	}
+}
+
+func TestFinalizeRunAgentEvaluation_MergesAssertionPass(t *testing.T) {
+	eval, spec := buildDeterministicEvaluation()
+
+	judgeScore := 1.0
+	judges := []JudgeResult{
+		{
+			Key:             "professional_tone",
+			Mode:            JudgeMethodAssertion,
+			State:           OutputStateAvailable,
+			NormalizedScore: &judgeScore,
+			Confidence:      "high",
+			SampleCount:     3,
+			ModelCount:      1,
+		},
+	}
+
+	finalized := FinalizeRunAgentEvaluation(eval, spec, judges)
+
+	toneDim := finalized.DimensionResults[1]
+	if toneDim.State != OutputStateAvailable {
+		t.Fatalf("tone dim state = %q, want available after merge", toneDim.State)
+	}
+	if toneDim.Score == nil || *toneDim.Score != 1.0 {
+		t.Fatalf("tone dim score = %v, want 1.0", toneDim.Score)
+	}
+	// Status should upgrade from partial → complete now that both
+	// dims are available.
+	if finalized.Status != EvaluationStatusComplete {
+		t.Errorf("Status = %q, want complete after merge", finalized.Status)
+	}
+	// Overall score = (0.75 * 0.5 + 1.0 * 0.5) / 1.0 = 0.875
+	if finalized.OverallScore == nil {
+		t.Fatal("OverallScore is nil after merge")
+	}
+	if *finalized.OverallScore != 0.875 {
+		t.Errorf("OverallScore = %v, want 0.875", *finalized.OverallScore)
+	}
+	// DimensionScores map must reflect the merged score.
+	if got := finalized.DimensionScores["tone"]; got == nil || *got != 1.0 {
+		t.Errorf("DimensionScores[tone] = %v, want 1.0", got)
+	}
+}
+
+func TestFinalizeRunAgentEvaluation_MergesAssertionFail(t *testing.T) {
+	eval, spec := buildDeterministicEvaluation()
+
+	judgeScore := 0.0
+	judges := []JudgeResult{
+		{
+			Key:             "professional_tone",
+			Mode:            JudgeMethodAssertion,
+			State:           OutputStateAvailable,
+			NormalizedScore: &judgeScore,
+		},
+	}
+
+	finalized := FinalizeRunAgentEvaluation(eval, spec, judges)
+
+	toneDim := finalized.DimensionResults[1]
+	if toneDim.Score == nil || *toneDim.Score != 0.0 {
+		t.Fatalf("tone dim score = %v, want 0.0", toneDim.Score)
+	}
+	// Overall = (0.75 * 0.5 + 0.0 * 0.5) / 1.0 = 0.375
+	if finalized.OverallScore == nil || *finalized.OverallScore != 0.375 {
+		t.Errorf("OverallScore = %v, want 0.375", finalized.OverallScore)
+	}
+}
+
+func TestFinalizeRunAgentEvaluation_UnavailableJudgePreservesUnavailable(t *testing.T) {
+	eval, spec := buildDeterministicEvaluation()
+
+	// Judge abstained — all samples UNKNOWN. State=unavailable,
+	// NormalizedScore=nil. The merge should propagate this through
+	// the dimension so the scorecard correctly reflects the abstain.
+	judges := []JudgeResult{
+		{
+			Key:             "professional_tone",
+			Mode:            JudgeMethodAssertion,
+			State:           OutputStateUnavailable,
+			NormalizedScore: nil,
+			Reason:          "every model abstained or errored on assertion",
+			Confidence:      "low",
+			SampleCount:     3,
+		},
+	}
+
+	finalized := FinalizeRunAgentEvaluation(eval, spec, judges)
+
+	toneDim := finalized.DimensionResults[1]
+	if toneDim.State != OutputStateUnavailable {
+		t.Fatalf("tone dim state = %q, want unavailable (abstained judge)", toneDim.State)
+	}
+	if toneDim.Score != nil {
+		t.Errorf("tone dim score = %v, want nil", toneDim.Score)
+	}
+	if finalized.Status != EvaluationStatusPartial {
+		t.Errorf("Status = %q, want partial (one dim still unavailable)", finalized.Status)
+	}
+}
+
+func TestFinalizeRunAgentEvaluation_MissingJudgeKeyLeavesStub(t *testing.T) {
+	eval, spec := buildDeterministicEvaluation()
+
+	// Judge results exist but none match the dim's JudgeKey — a
+	// programming or configuration bug that validation should have
+	// caught upstream. The finalize path must not crash or produce
+	// nonsense; the dim stays as the unavailable stub.
+	unrelatedScore := 1.0
+	judges := []JudgeResult{
+		{
+			Key:             "unrelated_judge",
+			Mode:            JudgeMethodAssertion,
+			State:           OutputStateAvailable,
+			NormalizedScore: &unrelatedScore,
+		},
+	}
+
+	finalized := FinalizeRunAgentEvaluation(eval, spec, judges)
+
+	toneDim := finalized.DimensionResults[1]
+	if toneDim.State != OutputStateUnavailable {
+		t.Errorf("tone dim state = %q, want unavailable (no matching judge)", toneDim.State)
+	}
+}
+
+func TestFinalizeRunAgentEvaluation_DoesNotMutateInput(t *testing.T) {
+	eval, spec := buildDeterministicEvaluation()
+
+	// Snapshot the caller's state so we can assert it stays unchanged.
+	originalDimResultsPtr := &eval.DimensionResults[0]
+	originalScoresPtr := eval.DimensionScores
+
+	judgeScore := 1.0
+	judges := []JudgeResult{
+		{
+			Key:             "professional_tone",
+			Mode:            JudgeMethodAssertion,
+			State:           OutputStateAvailable,
+			NormalizedScore: &judgeScore,
+		},
+	}
+
+	finalized := FinalizeRunAgentEvaluation(eval, spec, judges)
+
+	// The finalized slices/maps must not alias the input.
+	if &finalized.DimensionResults[0] == originalDimResultsPtr {
+		t.Error("DimensionResults slice aliased — finalize mutated caller input")
+	}
+	sameMap := &finalized.DimensionScores == &originalScoresPtr
+	if sameMap {
+		t.Error("DimensionScores map aliased — finalize mutated caller input")
+	}
+	// Caller's data must still show the pre-merge state.
+	if eval.DimensionResults[1].State != OutputStateUnavailable {
+		t.Error("caller DimensionResults mutated by finalize")
+	}
+}
+
+func TestFinalizeRunAgentEvaluation_AllDimsFromJudges(t *testing.T) {
+	// A pure-judge spec (no validator-sourced dims). After merge,
+	// the status and overall are driven entirely by the judge
+	// results. Pins that the function works for the "all llm_judge"
+	// extreme, not just hybrid.
+	spec := EvaluationSpec{
+		Scorecard: ScorecardDeclaration{
+			Strategy: ScoringStrategyWeighted,
+			Dimensions: []DimensionDeclaration{
+				{Key: "tone", Source: DimensionSourceLLMJudge, JudgeKey: "professional_tone", BetterDirection: "higher"},
+				{Key: "accuracy", Source: DimensionSourceLLMJudge, JudgeKey: "factual_accuracy", BetterDirection: "higher"},
+			},
+		},
+	}
+	eval := RunAgentEvaluation{
+		Status:   EvaluationStatusPartial,
+		Strategy: ScoringStrategyWeighted,
+		DimensionResults: []DimensionResult{
+			{Dimension: "tone", State: OutputStateUnavailable, Reason: "stub", BetterDirection: "higher"},
+			{Dimension: "accuracy", State: OutputStateUnavailable, Reason: "stub", BetterDirection: "higher"},
+		},
+		DimensionScores: map[string]*float64{"tone": nil, "accuracy": nil},
+	}
+	toneScore := 1.0
+	accScore := 0.5
+	judges := []JudgeResult{
+		{Key: "professional_tone", Mode: JudgeMethodAssertion, State: OutputStateAvailable, NormalizedScore: &toneScore},
+		{Key: "factual_accuracy", Mode: JudgeMethodAssertion, State: OutputStateAvailable, NormalizedScore: &accScore},
+	}
+
+	finalized := FinalizeRunAgentEvaluation(eval, spec, judges)
+
+	if finalized.Status != EvaluationStatusComplete {
+		t.Errorf("Status = %q, want complete", finalized.Status)
+	}
+	// Default weights (nil) → unweighted mean of (1.0, 0.5) = 0.75
+	if finalized.OverallScore == nil || *finalized.OverallScore != 0.75 {
+		t.Errorf("OverallScore = %v, want 0.75", finalized.OverallScore)
+	}
+}
+
+// --- ExtractFinalOutputFromEvents unit tests ---
+
+func TestExtractFinalOutputFromEvents_FromFinalizedEvent(t *testing.T) {
+	events := []Event{
+		{
+			Type:       "system.output.finalized",
+			OccurredAt: time.Now(),
+			Payload:    json.RawMessage(`{"final_output": "hello world"}`),
+		},
+	}
+	got := ExtractFinalOutputFromEvents(events)
+	if got != "hello world" {
+		t.Errorf("got %q, want hello world", got)
+	}
+}
+
+func TestExtractFinalOutputFromEvents_FromRunCompletedEvent(t *testing.T) {
+	events := []Event{
+		{
+			Type:       "system.run.completed",
+			OccurredAt: time.Now(),
+			Payload:    json.RawMessage(`{"final_output": "done"}`),
+		},
+	}
+	got := ExtractFinalOutputFromEvents(events)
+	if got != "done" {
+		t.Errorf("got %q, want done", got)
+	}
+}
+
+func TestExtractFinalOutputFromEvents_PrefersFinalizedEventFirst(t *testing.T) {
+	// When both events carry a final_output, the first one in the
+	// event stream wins. ExtractFinalOutputFromEvents is order-
+	// stable by design — callers that need chronology sort upstream.
+	events := []Event{
+		{
+			Type:       "system.output.finalized",
+			OccurredAt: time.Now(),
+			Payload:    json.RawMessage(`{"final_output": "early"}`),
+		},
+		{
+			Type:       "system.run.completed",
+			OccurredAt: time.Now().Add(time.Second),
+			Payload:    json.RawMessage(`{"final_output": "late"}`),
+		},
+	}
+	got := ExtractFinalOutputFromEvents(events)
+	if got != "early" {
+		t.Errorf("got %q, want early", got)
+	}
+}
+
+func TestExtractFinalOutputFromEvents_FallsBackToOutputField(t *testing.T) {
+	// system.output.finalized can carry the output under the
+	// "output" key instead of "final_output" — matches the
+	// extractLooseString fallback in buildEvidence.
+	events := []Event{
+		{
+			Type:       "system.output.finalized",
+			OccurredAt: time.Now(),
+			Payload:    json.RawMessage(`{"output": "via output key"}`),
+		},
+	}
+	got := ExtractFinalOutputFromEvents(events)
+	if got != "via output key" {
+		t.Errorf("got %q, want 'via output key'", got)
+	}
+}
+
+func TestExtractFinalOutputFromEvents_NoMatchReturnsEmpty(t *testing.T) {
+	events := []Event{
+		{Type: "system.run.started", OccurredAt: time.Now(), Payload: json.RawMessage(`{}`)},
+		{Type: "system.step.completed", OccurredAt: time.Now(), Payload: json.RawMessage(`{}`)},
+	}
+	got := ExtractFinalOutputFromEvents(events)
+	if got != "" {
+		t.Errorf("got %q, want empty string", got)
+	}
+}
+
+func TestExtractFinalOutputFromEvents_EmptyEventsReturnsEmpty(t *testing.T) {
+	got := ExtractFinalOutputFromEvents(nil)
+	if got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}

--- a/backend/internal/scoring/judge_finalize_test.go
+++ b/backend/internal/scoring/judge_finalize_test.go
@@ -286,10 +286,9 @@ func TestExtractFinalOutputFromEvents_FromRunCompletedEvent(t *testing.T) {
 	}
 }
 
-func TestExtractFinalOutputFromEvents_PrefersFinalizedEventFirst(t *testing.T) {
-	// When both events carry a final_output, the first one in the
-	// event stream wins. ExtractFinalOutputFromEvents is order-
-	// stable by design — callers that need chronology sort upstream.
+func TestExtractFinalOutputFromEvents_PrefersTerminalFinalOutput(t *testing.T) {
+	// When both events carry a final_output, the terminal event
+	// should win so helper callers match buildEvidence.
 	events := []Event{
 		{
 			Type:       "system.output.finalized",
@@ -303,8 +302,8 @@ func TestExtractFinalOutputFromEvents_PrefersFinalizedEventFirst(t *testing.T) {
 		},
 	}
 	got := ExtractFinalOutputFromEvents(events)
-	if got != "early" {
-		t.Errorf("got %q, want early", got)
+	if got != "late" {
+		t.Errorf("got %q, want late", got)
 	}
 }
 

--- a/backend/internal/scoring/judge_spec_test.go
+++ b/backend/internal/scoring/judge_spec_test.go
@@ -553,9 +553,10 @@ func TestNormalizeEvaluationSpec_JudgeDefaults(t *testing.T) {
 
 // Phase 1 dispatch: an llm_judge-sourced dim must reach the engine via the
 // switch and return OutputStateUnavailable with a reason that mentions the
-// phase gating. This test bypasses EvaluateRunAgent (which is still blocked
-// by errJudgeModeUnsupported for non-deterministic judge_mode) and calls
-// evaluateDimensions directly — legal because both live in the same package.
+// phase gating. Phase 4 kept the stub dispatch (the judge evaluator is
+// called OUTSIDE the engine, and FinalizeRunAgentEvaluation merges the
+// results afterwards) so this assertion still holds when EvaluateRunAgent
+// runs without a judge merge step.
 func TestEvaluateDimensions_LLMJudgeStubIsUnavailable(t *testing.T) {
 	spec := EvaluationSpec{
 		Scorecard: ScorecardDeclaration{
@@ -580,13 +581,22 @@ func TestEvaluateDimensions_LLMJudgeStubIsUnavailable(t *testing.T) {
 	}
 }
 
-// The runtime gate at engine.go:147 still rejects llm_judge/hybrid specs
-// end-to-end in Phase 1. This test pins that contract so Phase 4 deliberately
-// has to flip it. When the gate comes out, this test should be replaced
-// with an end-to-end assertion instead of deleted silently.
-func TestEvaluateRunAgent_RuntimeGateStillRejectsNonDeterministic(t *testing.T) {
+// Phase 4 removed the errJudgeModeUnsupported runtime gate from
+// EvaluateRunAgent. llm_judge and hybrid judge_mode specs now run
+// through the deterministic pipeline and produce a partial
+// RunAgentEvaluation whose llm_judge-sourced dimensions come back
+// as OutputStateUnavailable. The workflow layer then calls
+// FinalizeRunAgentEvaluation with real judge results from the
+// JudgeRunAgent activity to merge those dims and recompute overall.
+//
+// This test pins the post-gate-removal contract: the engine accepts
+// the spec, returns a non-error evaluation, and the llm_judge dim
+// surfaces as unavailable with the phase-3+ stub reason. If Phase 5
+// or later wires the evaluator directly into EvaluateRunAgent, this
+// test is what catches the behavioural change.
+func TestEvaluateRunAgent_LLMJudgeModeRunsWithoutGate(t *testing.T) {
 	spec := EvaluationSpec{
-		Name:          "gated",
+		Name:          "ungated",
 		VersionNumber: 1,
 		JudgeMode:     JudgeModeLLMJudge,
 		Validators: []ValidatorDeclaration{
@@ -594,23 +604,30 @@ func TestEvaluateRunAgent_RuntimeGateStillRejectsNonDeterministic(t *testing.T) 
 		},
 		LLMJudges: []LLMJudgeDeclaration{
 			{
-				Mode:   JudgeMethodRubric,
-				Key:    "persuasiveness",
-				Rubric: "Rate the output 1-5 on clarity, correctness, and completeness of the reasoning.",
-				Model:  "claude-sonnet-4-6",
+				Mode:      JudgeMethodAssertion,
+				Key:       "professional_tone",
+				Assertion: "The response maintains a professional tone.",
+				Model:     "claude-haiku-4-5-20251001",
 			},
 		},
 		Scorecard: ScorecardDeclaration{
 			Dimensions: []DimensionDeclaration{
-				{Key: "q", Source: DimensionSourceLLMJudge, JudgeKey: "persuasiveness"},
+				{Key: "q", Source: DimensionSourceLLMJudge, JudgeKey: "professional_tone"},
 			},
 		},
 	}
-	_, err := EvaluateRunAgent(EvaluationInput{}, spec)
-	if err == nil {
-		t.Fatal("EvaluateRunAgent accepted llm_judge spec — gate should still reject in Phase 1")
+	evaluation, err := EvaluateRunAgent(EvaluationInput{}, spec)
+	if err != nil {
+		t.Fatalf("EvaluateRunAgent rejected llm_judge spec: %v", err)
 	}
-	if !strings.Contains(err.Error(), "only deterministic") {
-		t.Fatalf("error = %q, want the errJudgeModeUnsupported message", err.Error())
+	if len(evaluation.DimensionResults) != 1 {
+		t.Fatalf("dimension results = %d, want 1", len(evaluation.DimensionResults))
+	}
+	dim := evaluation.DimensionResults[0]
+	if dim.State != OutputStateUnavailable {
+		t.Fatalf("dim state = %q, want unavailable (pre-finalize stub)", dim.State)
+	}
+	if !strings.Contains(dim.Reason, "judge evaluator") {
+		t.Fatalf("dim reason = %q, want to mention judge evaluator stub", dim.Reason)
 	}
 }

--- a/backend/internal/worker/config.go
+++ b/backend/internal/worker/config.go
@@ -21,22 +21,30 @@ const (
 	defaultShutdownTime          = 10 * time.Second
 	defaultHostedCallbackBaseURL = "http://localhost:8080"
 	defaultHostedCallbackSecret  = "agentclash-dev-hosted-callback-secret"
+	// defaultJudgeCredentialReference points the LLM-as-judge evaluator at
+	// the same env var the anthropic provider client already uses for
+	// agent runs. Dev loops that already export ANTHROPIC_API_KEY for
+	// agent execution immediately get working judges with no extra config.
+	// Phase 7 of issue #148 will move this to a per-pack
+	// ScorecardDeclaration.JudgeProviderRef field.
+	defaultJudgeCredentialReference = "env://ANTHROPIC_API_KEY"
 )
 
 var ErrInvalidConfig = errors.New("invalid worker config")
 
 type Config struct {
-	AppEnvironment        string
-	DatabaseURL           string
-	TemporalAddress       string
-	TemporalNamespace     string
-	Identity              string
-	TaskQueue             string
-	HostedCallbackBaseURL string
-	HostedCallbackSecret  string
-	ShutdownTimeout       time.Duration
-	Sandbox               SandboxConfig
-	SecretsCipher         *secrets.AESGCMCipher
+	AppEnvironment           string
+	DatabaseURL              string
+	TemporalAddress          string
+	TemporalNamespace        string
+	Identity                 string
+	TaskQueue                string
+	HostedCallbackBaseURL    string
+	HostedCallbackSecret     string
+	ShutdownTimeout          time.Duration
+	Sandbox                  SandboxConfig
+	SecretsCipher            *secrets.AESGCMCipher
+	JudgeCredentialReference string
 }
 
 type SandboxConfig struct {
@@ -118,6 +126,11 @@ func LoadConfigFromEnv() (Config, error) {
 		return Config{}, err
 	}
 
+	judgeCredentialReference, err := envOrDefault("JUDGE_CREDENTIAL_REFERENCE", defaultJudgeCredentialReference)
+	if err != nil {
+		return Config{}, err
+	}
+
 	return Config{
 		AppEnvironment:        appEnvironment,
 		DatabaseURL:           databaseURL,
@@ -137,7 +150,8 @@ func LoadConfigFromEnv() (Config, error) {
 				RequestTimeout: e2bRequestTimeout,
 			},
 		},
-		SecretsCipher: secretsCipher,
+		SecretsCipher:            secretsCipher,
+		JudgeCredentialReference: judgeCredentialReference,
 	}, nil
 }
 

--- a/backend/internal/worker/service.go
+++ b/backend/internal/worker/service.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/provider"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/scoring/judge"
 	workflowpkg "github.com/Atharva-Kanherkar/agentclash/backend/internal/workflow"
 	temporalsdk "go.temporal.io/sdk/client"
 	sdkworker "go.temporal.io/sdk/worker"
@@ -20,20 +21,39 @@ type TemporalWorker interface {
 
 // executionHooks is the temporary extension seam for later hosted and native
 // execution work without reshaping worker bootstrap.
+//
+// providerRouter is passed by value (provider.Router is a struct, not an
+// interface). The playground activities take a provider.Client; Router
+// satisfies Client so the same value is reused there. The judge
+// evaluator wants the Router directly because Phase 7 may want
+// per-judge routing decisions that go beyond the single InvokeModel
+// surface — keeping the type narrow now would force a refactor later.
 func NewTemporalWorker(
 	client temporalsdk.Client,
 	cfg Config,
 	repo *repository.Repository,
-	playgroundClient provider.Client,
+	providerRouter provider.Router,
 	executionHooks workflowpkg.FakeWorkHooks,
 ) sdkworker.Worker {
 	temporalWorker := sdkworker.New(client, cfg.TaskQueue, sdkworker.Options{
 		Identity: cfg.Identity,
 	})
 
-	activities := workflowpkg.NewActivities(repo, executionHooks)
+	// Wire the LLM-as-judge evaluator (#148 phase 4) onto the
+	// scoring activities. JudgeCredentialReference comes from worker
+	// config (env var with default env://ANTHROPIC_API_KEY) and
+	// applies to every judge call until Phase 7 introduces per-pack
+	// credential overrides via ScorecardDeclaration.JudgeProviderRef.
+	judgeEvaluator := judge.NewEvaluator(providerRouter, judge.Config{
+		MaxParallel:           4,
+		DefaultAssertionModel: "claude-haiku-4-5-20251001",
+		CredentialReference:   cfg.JudgeCredentialReference,
+		DefaultTimeout:        60 * time.Second,
+	})
+
+	activities := workflowpkg.NewActivities(repo, executionHooks).WithJudgeEvaluator(judgeEvaluator)
 	workflowpkg.Register(temporalWorker, activities)
-	workflowpkg.RegisterPlayground(temporalWorker, workflowpkg.NewPlaygroundActivities(repo, playgroundClient, repo))
+	workflowpkg.RegisterPlayground(temporalWorker, workflowpkg.NewPlaygroundActivities(repo, providerRouter, repo))
 
 	return temporalWorker
 }

--- a/backend/internal/workflow/activities.go
+++ b/backend/internal/workflow/activities.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/provider"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/scoring"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/scoring/judge"
 	"github.com/google/uuid"
 	"go.temporal.io/sdk/temporal"
 )
@@ -30,6 +31,7 @@ const (
 	executeNativeModelStepActivityName       = "workflow.execute_native_model_step"
 	executePromptEvalStepActivityName        = "workflow.execute_prompt_eval_step"
 	scoreRunAgentActivityName                = "workflow.score_run_agent"
+	judgeRunAgentActivityName                = "workflow.judge_run_agent"
 	buildRunScorecardActivityName            = "workflow.build_run_scorecard"
 	buildRunAgentReplayActivityName          = "workflow.build_run_agent_replay"
 	simulateExecutionActivityName            = "workflow.simulate_execution"
@@ -65,8 +67,9 @@ type PromptEvalInvoker interface {
 }
 
 type Activities struct {
-	repo  RunRepository
-	hooks FakeWorkHooks
+	repo           RunRepository
+	hooks          FakeWorkHooks
+	judgeEvaluator *judge.Evaluator
 }
 
 type LoadRunInput struct {
@@ -127,6 +130,17 @@ type ScoreRunAgentInput struct {
 	RunAgentID uuid.UUID `json:"run_agent_id"`
 }
 
+// JudgeRunAgentInput is the input for the JudgeRunAgent activity. The
+// run-workflow captures the deterministic evaluation returned by
+// ScoreRunAgent and threads it here so the activity can call
+// scoring.FinalizeRunAgentEvaluation without re-running the
+// deterministic pipeline. RunAgentID lets the activity load the spec
+// + events independently for the judge prompt envelope.
+type JudgeRunAgentInput struct {
+	RunAgentID              uuid.UUID                  `json:"run_agent_id"`
+	DeterministicEvaluation scoring.RunAgentEvaluation `json:"deterministic_evaluation"`
+}
+
 type BuildRunScorecardInput struct {
 	RunID uuid.UUID `json:"run_id"`
 }
@@ -136,6 +150,22 @@ func NewActivities(repo RunRepository, hooks FakeWorkHooks) *Activities {
 		repo:  repo,
 		hooks: hooks,
 	}
+}
+
+// WithJudgeEvaluator returns a copy of Activities with the LLM-as-judge
+// evaluator attached. Use the functional-option pattern so existing
+// tests that don't need judges (the vast majority of workflow tests)
+// keep constructing Activities via NewActivities and rely on the
+// nil-safe fallback in JudgeRunAgent. The Phase 4 worker bootstrap
+// chains this on top of NewActivities to enable judge mode.
+//
+// Returns a fresh *Activities; the receiver is unchanged so the
+// original (nil-evaluator) reference is still usable for tests that
+// share an activities fixture between cases.
+func (a *Activities) WithJudgeEvaluator(evaluator *judge.Evaluator) *Activities {
+	cloned := *a
+	cloned.judgeEvaluator = evaluator
+	return &cloned
 }
 
 func (a *Activities) LoadRun(ctx context.Context, input LoadRunInput) (domain.Run, error) {
@@ -286,6 +316,36 @@ func (a *Activities) BuildRunAgentReplay(ctx context.Context, input BuildRunAgen
 func (a *Activities) ScoreRunAgent(ctx context.Context, input ScoreRunAgentInput) (scoring.RunAgentEvaluation, error) {
 	evaluation, err := executeRunAgentEvaluation(ctx, a.repo, input.RunAgentID)
 	return evaluation, wrapActivityError(err)
+}
+
+// JudgeRunAgent runs the LLM-as-judge evaluator for a single run-agent
+// after deterministic scoring has completed. The deterministic
+// evaluation comes through input.DeterministicEvaluation (returned by
+// ScoreRunAgent and threaded by the workflow), which means this
+// activity does not re-run the deterministic pipeline.
+//
+// Phase 4 of issue #148 satisfies the "judge evaluation runs as a
+// separate Temporal activity" acceptance criterion via this single
+// new activity. Per-judge fan-out (multi-sample, multi-model) lives
+// inside judge.Evaluator and is bounded by Config.MaxParallel.
+//
+// Three fast-path returns leave the deterministic evaluation
+// unchanged:
+//
+//  1. judgeEvaluator is nil — test fixtures and dev workers without
+//     judge wiring fall through here.
+//  2. The persisted spec declares no LLMJudges — deterministic-only
+//     packs incur zero judge overhead.
+//  3. No final_output is available in the event stream — judges have
+//     nothing to evaluate; the deterministic result is the final
+//     verdict.
+//
+// In all three cases the activity returns the input evaluation
+// unchanged with no DB writes. The workflow uses the returned
+// evaluation as the authoritative final scorecard.
+func (a *Activities) JudgeRunAgent(ctx context.Context, input JudgeRunAgentInput) (scoring.RunAgentEvaluation, error) {
+	finalized, err := executeJudgeRunAgent(ctx, a.repo, a.judgeEvaluator, input.RunAgentID, input.DeterministicEvaluation)
+	return finalized, wrapActivityError(err)
 }
 
 func (a *Activities) BuildRunScorecard(ctx context.Context, input BuildRunScorecardInput) (repository.RunScorecard, error) {

--- a/backend/internal/workflow/register.go
+++ b/backend/internal/workflow/register.go
@@ -26,6 +26,7 @@ func Register(registrar Registrar, activities *Activities) {
 	registrar.RegisterActivityWithOptions(activities.ExecuteNativeModelStep, sdkactivity.RegisterOptions{Name: executeNativeModelStepActivityName})
 	registrar.RegisterActivityWithOptions(activities.ExecutePromptEvalStep, sdkactivity.RegisterOptions{Name: executePromptEvalStepActivityName})
 	registrar.RegisterActivityWithOptions(activities.ScoreRunAgent, sdkactivity.RegisterOptions{Name: scoreRunAgentActivityName})
+	registrar.RegisterActivityWithOptions(activities.JudgeRunAgent, sdkactivity.RegisterOptions{Name: judgeRunAgentActivityName})
 	registrar.RegisterActivityWithOptions(activities.BuildRunScorecard, sdkactivity.RegisterOptions{Name: buildRunScorecardActivityName})
 	registrar.RegisterActivityWithOptions(activities.BuildRunAgentReplay, sdkactivity.RegisterOptions{Name: buildRunAgentReplayActivityName})
 	registrar.RegisterActivityWithOptions(activities.SimulateExecution, sdkactivity.RegisterOptions{Name: simulateExecutionActivityName})

--- a/backend/internal/workflow/repository.go
+++ b/backend/internal/workflow/repository.go
@@ -31,6 +31,7 @@ type RunRepository interface {
 	ListRunEventsByRunAgentID(ctx context.Context, runAgentID uuid.UUID) ([]repository.RunEvent, error)
 	RecordRunEvent(ctx context.Context, params repository.RecordRunEventParams) (repository.RunEvent, error)
 	StoreRunAgentEvaluationResults(ctx context.Context, evaluation scoring.RunAgentEvaluation) error
+	StoreFinalizedScoringResults(ctx context.Context, evaluation scoring.RunAgentEvaluation, judgeResults []scoring.JudgeResult) error
 	BuildRunScorecard(ctx context.Context, runID uuid.UUID) (repository.RunScorecard, error)
 	BuildRunAgentReplay(ctx context.Context, runAgentID uuid.UUID) (repository.RunAgentReplay, error)
 	SetRunTemporalIDs(ctx context.Context, params repository.SetRunTemporalIDsParams) (domain.Run, error)

--- a/backend/internal/workflow/run_workflow.go
+++ b/backend/internal/workflow/run_workflow.go
@@ -16,7 +16,13 @@ import (
 const (
 	defaultActivityTimeout = 5 * time.Second
 	scoreRunAgentTimeout   = 30 * time.Second
-	fakeStageDelay         = 1 * time.Second
+	// judgeRunAgentTimeout caps the LLM-as-judge fan-out per agent.
+	// Multi-sample × multi-model judges can run several minutes when
+	// providers are slow; 5 minutes is the safety ceiling. Phase 4 of
+	// issue #148 introduces this activity; Phase 6 will revisit when
+	// run-level n_wise needs an even longer ceiling.
+	judgeRunAgentTimeout = 5 * time.Minute
+	fakeStageDelay       = 1 * time.Second
 )
 
 var defaultActivityOptions = sdkworkflow.ActivityOptions{
@@ -154,22 +160,86 @@ func scoreEvaluatingRunAgents(ctx sdkworkflow.Context, runAgents []domain.RunAge
 			InitialInterval: 5 * time.Second,
 		},
 	})
-	selector := sdkworkflow.NewSelector(ctx)
-	completedActivities := 0
+	// First pass: ScoreRunAgent in parallel. We capture the
+	// deterministic evaluations so the judge phase can finalize
+	// them without re-running the deterministic pipeline.
+	deterministicEvaluations := make(map[uuid.UUID]scoring.RunAgentEvaluation, len(completedRunAgents))
+	scoreSelector := sdkworkflow.NewSelector(ctx)
+	completedScoreActivities := 0
 
 	for _, runAgent := range completedRunAgents {
 		runAgent := runAgent
 		future := sdkworkflow.ExecuteActivity(scoreCtx, scoreRunAgentActivityName, ScoreRunAgentInput{
 			RunAgentID: runAgent.ID,
 		})
-		selector.AddFuture(future, func(f sdkworkflow.Future) {
-			completedActivities++
+		scoreSelector.AddFuture(future, func(f sdkworkflow.Future) {
+			completedScoreActivities++
 
 			evaluation, err := scoreRunAgentResult(ctx, f)
 			switch {
 			case err != nil:
 				outcomes[runAgent.ID] = "errored"
-			case evaluation.Status == scoring.EvaluationStatusPartial:
+			default:
+				deterministicEvaluations[runAgent.ID] = evaluation
+				if evaluation.Status == scoring.EvaluationStatusPartial {
+					outcomes[runAgent.ID] = "partial"
+				} else {
+					outcomes[runAgent.ID] = "scored"
+				}
+			}
+		})
+	}
+
+	for completedScoreActivities < len(completedRunAgents) {
+		scoreSelector.Select(ctx)
+	}
+
+	// Second pass: JudgeRunAgent (#148 phase 4). Runs only for
+	// agents that completed deterministic scoring successfully.
+	// The activity is nil-safe at the worker layer — it is a
+	// fast no-op when the spec has no LLM judges or when the
+	// worker isn't wired with an evaluator (test fixtures, dev
+	// loops without provider creds). The outcome is overwritten
+	// based on the FINALIZED evaluation, which may upgrade a
+	// partial result back to scored once judge dims become
+	// available.
+	judgeCtx := sdkworkflow.WithActivityOptions(ctx, sdkworkflow.ActivityOptions{
+		StartToCloseTimeout: judgeRunAgentTimeout,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts:    3,
+			InitialInterval:    10 * time.Second,
+			BackoffCoefficient: 2.0,
+		},
+	})
+	judgeSelector := sdkworkflow.NewSelector(ctx)
+	judgeAgentCount := 0
+	completedJudgeActivities := 0
+	for _, runAgent := range completedRunAgents {
+		detEval, ok := deterministicEvaluations[runAgent.ID]
+		if !ok {
+			// ScoreRunAgent errored — nothing for the judge to merge.
+			continue
+		}
+		judgeAgentCount++
+		runAgent := runAgent
+		future := sdkworkflow.ExecuteActivity(judgeCtx, judgeRunAgentActivityName, JudgeRunAgentInput{
+			RunAgentID:              runAgent.ID,
+			DeterministicEvaluation: detEval,
+		})
+		judgeSelector.AddFuture(future, func(f sdkworkflow.Future) {
+			completedJudgeActivities++
+			finalized, err := scoreRunAgentResult(ctx, f)
+			switch {
+			case err != nil:
+				// Judge activity itself failed — leave the outcome
+				// from the deterministic pass in place, log for
+				// observability. The scorecard is already persisted
+				// from the deterministic write.
+				sdkworkflow.GetLogger(ctx).Warn("judge run-agent activity failed",
+					"run_agent_id", runAgent.ID.String(),
+					"error", err,
+				)
+			case finalized.Status == scoring.EvaluationStatusPartial:
 				outcomes[runAgent.ID] = "partial"
 			default:
 				outcomes[runAgent.ID] = "scored"
@@ -177,8 +247,8 @@ func scoreEvaluatingRunAgents(ctx sdkworkflow.Context, runAgents []domain.RunAge
 		})
 	}
 
-	for completedActivities < len(completedRunAgents) {
-		selector.Select(ctx)
+	for completedJudgeActivities < judgeAgentCount {
+		judgeSelector.Select(ctx)
 	}
 
 	for _, runAgent := range completedRunAgents {

--- a/backend/internal/workflow/scoring.go
+++ b/backend/internal/workflow/scoring.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/runevents"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/scoring"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/scoring/judge"
 	"github.com/google/uuid"
 )
 
@@ -320,4 +321,167 @@ func mustMarshalJSON(value any) json.RawMessage {
 		return json.RawMessage(`{}`)
 	}
 	return payload
+}
+
+// executeJudgeRunAgent runs the LLM-as-judge evaluator for a single
+// run-agent and persists the finalized scorecard. Called by the
+// JudgeRunAgent activity after ScoreRunAgent has produced the
+// deterministic evaluation.
+//
+// Fast-path returns leave the deterministic evaluation unchanged
+// (and skip all DB writes) when:
+//
+//   - judgeEvaluator is nil — workers / tests not wired for judges
+//   - the persisted spec declares no LLMJudges — deterministic-only packs
+//   - the spec fails to load — error propagates so Temporal retries
+//
+// When judges are present and the evaluator is wired, the helper:
+//
+//  1. Loads the persisted spec via the same path ScoreRunAgent uses
+//  2. Reads the run-agent's events and extracts final_output
+//  3. Calls judge.Evaluator.Evaluate (bounded fan-out across
+//     models × samples, anti-gaming envelope, multi-model consensus)
+//  4. Calls scoring.FinalizeRunAgentEvaluation to merge the judge
+//     results into the deterministic dimension dispatch and recompute
+//     the overall score / passed verdict
+//  5. Persists the finalized scorecard + judge result rows in one
+//     transaction via repo.StoreFinalizedScoringResults
+//  6. Emits scoring.judge.recorded events (one per judge) for replay
+//     observability
+//
+// Per-judge errors NEVER abort the activity. The judge evaluator
+// captures them as JudgeResults with state=error and a Reason; the
+// finalize merge leaves the corresponding dim as unavailable; the
+// scorecard ships with state=partial. Operators see the failures via
+// the events and the persisted error-state rows.
+func executeJudgeRunAgent(
+	ctx context.Context,
+	repo RunRepository,
+	judgeEvaluator *judge.Evaluator,
+	runAgentID uuid.UUID,
+	deterministicEvaluation scoring.RunAgentEvaluation,
+) (scoring.RunAgentEvaluation, error) {
+	// Fast-path 1: no evaluator wired (test fixtures, dev workers
+	// without provider credentials). Return the deterministic
+	// evaluation unchanged and skip all DB / event work.
+	if judgeEvaluator == nil {
+		return deterministicEvaluation, nil
+	}
+
+	executionContext, err := repo.GetRunAgentExecutionContextByID(ctx, runAgentID)
+	if err != nil {
+		return deterministicEvaluation, fmt.Errorf("load run-agent execution context for judges: %w", err)
+	}
+
+	manifestSpec, err := scoring.LoadEvaluationSpec(executionContext.ChallengePackVersion.Manifest)
+	if err != nil {
+		return deterministicEvaluation, fmt.Errorf("load evaluation spec for judges: %w", err)
+	}
+
+	// Fast-path 2: spec declares no judges. The deterministic
+	// evaluation is already the final answer.
+	if len(manifestSpec.LLMJudges) == 0 {
+		return deterministicEvaluation, nil
+	}
+
+	specRecord, err := ensurePersistedEvaluationSpec(ctx, repo, executionContext.ChallengePackVersion.ID, manifestSpec)
+	if err != nil {
+		return deterministicEvaluation, fmt.Errorf("load persisted evaluation spec for judges: %w", err)
+	}
+	persistedSpec, err := scoring.DecodeDefinition(specRecord.Definition)
+	if err != nil {
+		return deterministicEvaluation, fmt.Errorf("decode persisted evaluation spec for judges: %w", err)
+	}
+
+	events, err := repo.ListRunEventsByRunAgentID(ctx, runAgentID)
+	if err != nil {
+		return deterministicEvaluation, fmt.Errorf("list run events for judges: %w", err)
+	}
+	scoringEvents := mapRunEvents(events)
+	finalOutput := scoring.ExtractFinalOutputFromEvents(scoringEvents)
+
+	judgeResult, judgeErr := judgeEvaluator.Evaluate(ctx, judge.Input{
+		RunAgentID:       runAgentID,
+		EvaluationSpecID: specRecord.ID,
+		Judges:           persistedSpec.LLMJudges,
+		FinalOutput:      finalOutput,
+	})
+	if judgeErr != nil {
+		// Top-level evaluator errors are rare (the per-judge error
+		// path captures provider failures cleanly). Surface as a
+		// warning and continue with whatever results we got.
+		deterministicEvaluation.Warnings = append(deterministicEvaluation.Warnings,
+			fmt.Sprintf("judge evaluator returned error: %v", judgeErr))
+	}
+	if len(judgeResult.Warnings) > 0 {
+		deterministicEvaluation.Warnings = append(deterministicEvaluation.Warnings, judgeResult.Warnings...)
+	}
+
+	finalized := scoring.FinalizeRunAgentEvaluation(deterministicEvaluation, persistedSpec, judgeResult.JudgeResults)
+
+	if err := repo.StoreFinalizedScoringResults(ctx, finalized, judgeResult.JudgeResults); err != nil {
+		return deterministicEvaluation, fmt.Errorf("persist finalized scoring results: %w", err)
+	}
+
+	if err := recordJudgeEvents(ctx, repo, executionContext.Run.ID, finalized.RunAgentID, finalized.EvaluationSpecID, judgeResult.JudgeResults); err != nil {
+		// Persisted judge rows are the source of truth. Failure to
+		// emit derived events should not flip an otherwise successful
+		// finalize into a fatal error after writes are durable.
+		finalized.Warnings = append(finalized.Warnings, fmt.Sprintf("record judge events: %v", err))
+	}
+
+	return finalized, nil
+}
+
+// recordJudgeEvents emits one scoring.judge.recorded event per judge
+// result so the replay timeline shows judge progress alongside
+// deterministic scoring events. Mirrors the per-metric event loop in
+// recordScoringEvents but with judge-specific payload fields.
+func recordJudgeEvents(
+	ctx context.Context,
+	repo RunRepository,
+	runID uuid.UUID,
+	runAgentID uuid.UUID,
+	evaluationSpecID uuid.UUID,
+	judgeResults []scoring.JudgeResult,
+) error {
+	for _, jr := range judgeResults {
+		payload := map[string]any{
+			"evaluation_spec_id": evaluationSpecID,
+			"judge_key":          jr.Key,
+			"mode":               jr.Mode,
+			"state":              jr.State,
+			"sample_count":       jr.SampleCount,
+			"model_count":        jr.ModelCount,
+		}
+		if jr.NormalizedScore != nil {
+			payload["normalized_score"] = *jr.NormalizedScore
+		}
+		if jr.Confidence != "" {
+			payload["confidence"] = jr.Confidence
+		}
+		if jr.Reason != "" {
+			payload["reason"] = jr.Reason
+		}
+
+		if _, err := repo.RecordRunEvent(ctx, repository.RecordRunEventParams{
+			Event: runevents.Envelope{
+				EventID:       fmt.Sprintf("scoring:%s:%s:judge:%s", runAgentID, evaluationSpecID, jr.Key),
+				SchemaVersion: runevents.SchemaVersionV1,
+				RunID:         runID,
+				RunAgentID:    runAgentID,
+				EventType:     runevents.EventTypeScoringJudgeRecorded,
+				Source:        runevents.SourceWorkerScoring,
+				OccurredAt:    time.Now().UTC(),
+				Payload:       mustMarshalJSON(payload),
+				Summary: runevents.SummaryMetadata{
+					Status:        string(jr.State),
+					EvidenceLevel: runevents.EvidenceLevelDerivedSummary,
+				},
+			},
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/backend/internal/workflow/scoring.go
+++ b/backend/internal/workflow/scoring.go
@@ -399,6 +399,9 @@ func executeJudgeRunAgent(
 	}
 	scoringEvents := mapRunEvents(events)
 	finalOutput := scoring.ExtractFinalOutputFromEvents(scoringEvents)
+	if finalOutput == "" {
+		return deterministicEvaluation, nil
+	}
 
 	judgeResult, judgeErr := judgeEvaluator.Evaluate(ctx, judge.Input{
 		RunAgentID:       runAgentID,

--- a/backend/internal/workflow/workflow_test.go
+++ b/backend/internal/workflow/workflow_test.go
@@ -1023,6 +1023,19 @@ func (r *fakeRunRepository) StoreRunAgentEvaluationResults(_ context.Context, ev
 	return nil
 }
 
+func (r *fakeRunRepository) StoreFinalizedScoringResults(_ context.Context, evaluation scoring.RunAgentEvaluation, judgeResults []scoring.JudgeResult) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// The Phase 4 finalize path overwrites the deterministic
+	// evaluation persisted by StoreRunAgentEvaluationResults so the
+	// fake mirrors the real semantics: the latest write wins for
+	// the same run-agent.
+	r.evaluations[evaluation.RunAgentID] = evaluation
+	r.callLog = append(r.callLog, fmt.Sprintf("StoreFinalizedScoringResults:%s:%d", evaluation.RunAgentID, len(judgeResults)))
+	return nil
+}
+
 func (r *fakeRunRepository) BuildRunScorecard(_ context.Context, runID uuid.UUID) (repository.RunScorecard, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/backend/internal/workflow/workflow_test.go
+++ b/backend/internal/workflow/workflow_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/provider"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/scoring"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/scoring/judge"
 	"github.com/google/uuid"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
@@ -1331,6 +1332,89 @@ func fixtureRun(runID uuid.UUID, status domain.RunStatus) domain.Run {
 		ExecutionPlan: []byte(`{}`),
 		CreatedAt:     createdAt,
 		UpdatedAt:     createdAt,
+	}
+}
+
+func TestExecuteJudgeRunAgentSkipsJudgesWhenFinalOutputMissing(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	repo := newFakeRunRepository(
+		fixtureRun(runID, domain.RunStatusRunning),
+		fixtureRunAgent(runID, runAgentID, 0),
+	)
+	repo.setExecutionContext(runAgentID, repository.RunAgentExecutionContext{
+		Run:      fixtureRun(runID, domain.RunStatusRunning),
+		RunAgent: fixtureRunAgent(runID, runAgentID, 0),
+		ChallengePackVersion: repository.ChallengePackVersionExecutionContext{
+			ID: uuid.New(),
+			Manifest: []byte(`{
+				"evaluation_spec": {
+					"name": "fixture-eval",
+					"version_number": 1,
+					"judge_mode": "llm_judge",
+					"validators": [
+						{
+							"key": "final-output-match",
+							"type": "exact_match",
+							"target": "final_output",
+							"expected_from": "challenge_input"
+						}
+					],
+					"scorecard": {
+						"dimensions": ["correctness"]
+					},
+					"llm_judges": [
+						{
+							"key": "rubric-judge",
+							"mode": "rubric",
+							"model": "test-model",
+							"rubric": "score the answer"
+						}
+					]
+				}
+			}`),
+		},
+	})
+	repo.runEvents[runAgentID] = []repository.RunEvent{
+		{
+			RunID:      runID,
+			RunAgentID: runAgentID,
+			EventType:  "system.run.started",
+			OccurredAt: time.Now().UTC(),
+			Payload:    []byte(`{}`),
+		},
+	}
+
+	deterministicEvaluation := scoring.RunAgentEvaluation{
+		RunAgentID:       runAgentID,
+		EvaluationSpecID: uuid.New(),
+		Status:           scoring.EvaluationStatusPartial,
+		Warnings:         []string{"deterministic warning"},
+	}
+
+	finalized, err := executeJudgeRunAgent(
+		context.Background(),
+		repo,
+		judge.NewEvaluator(provider.NewRouter(nil), judge.Config{}),
+		runAgentID,
+		deterministicEvaluation,
+	)
+	if err != nil {
+		t.Fatalf("executeJudgeRunAgent returned error: %v", err)
+	}
+	if finalized.Status != deterministicEvaluation.Status {
+		t.Fatalf("evaluation status = %s, want %s", finalized.Status, deterministicEvaluation.Status)
+	}
+	if len(finalized.Warnings) != 1 || finalized.Warnings[0] != "deterministic warning" {
+		t.Fatalf("warnings = %v, want %v", finalized.Warnings, deterministicEvaluation.Warnings)
+	}
+	for _, call := range repo.callLog {
+		if strings.HasPrefix(call, "StoreFinalizedScoringResults:") {
+			t.Fatalf("unexpected finalized scoring write: %s", call)
+		}
+		if call == "RecordRunEvent:scoring.judge.recorded" {
+			t.Fatalf("unexpected judge event write")
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
Split from #287 (phase 4 of 6). Depends on #294.

- New `JudgeRunAgent` Temporal activity wires assertion mode end-to-end
- Workflow state threads deterministic evaluation to judge activity (no re-run)
- `StoreFinalizedScoringResults` single transaction for scorecard + judge results (idempotent retries)
- `FinalizeRunAgentEvaluation` pure function merges judge dims into deterministic dispatch

## Stack
1. #293 ← phases 1-2 (spec + persistence)
2. #294 ← phase 3 (assertion evaluator)
3. **This PR** ← phase 4
4. #296 ← phase 5 (rubric + reference)
5. #297 ← phase 6 (n_wise)

## Key files
- `workflow/scoring.go` — `JudgeRunAgent` activity + `FinalizeRunAgentEvaluation`
- `workflow/run_workflow.go` — workflow integration
- `scoring/engine.go` — finalize merge logic
- `judge_finalize_test.go` — merge correctness tests

## Test plan
- [x] Finalize merge tests covering judge dim override, partial results, error propagation
- [x] Workflow test updated for new activity registration
- [x] `go vet ./internal/workflow/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)