### PR TITLE
Support n-wise judges and hosted structured trace replay

### DIFF
--- a/backend/internal/api/hosted_runs.go
+++ b/backend/internal/api/hosted_runs.go
@@ -90,6 +90,10 @@ func (m *HostedRunIngestionManager) IngestEvent(ctx context.Context, runID uuid.
 	if err != nil {
 		return err
 	}
+	traceEvents, err := runevents.NormalizeHostedTraceEvents(runID, event)
+	if err != nil {
+		return err
+	}
 	replaySummary, err := hostedReplaySummary(normalizedEvent, event)
 	if err != nil {
 		return err
@@ -107,8 +111,9 @@ func (m *HostedRunIngestionManager) IngestEvent(ctx context.Context, runID uuid.
 		return err
 	}
 	replayRecord, err := m.repo.RecordHostedRunEvent(ctx, repository.RecordHostedRunEventParams{
-		Event:   normalizedEvent,
-		Summary: replaySummary,
+		Event:            normalizedEvent,
+		AdditionalEvents: traceEvents,
+		Summary:          replaySummary,
 	})
 	if err != nil {
 		return err

--- a/backend/internal/api/hosted_runs_test.go
+++ b/backend/internal/api/hosted_runs_test.go
@@ -149,6 +149,55 @@ func TestHostedRunIngestionManagerNormalizesErrorEventIntoCanonicalVocabulary(t 
 	}
 }
 
+func TestHostedRunIngestionManagerPersistsStructuredTraceFragments(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	externalRunID := "ext-trace"
+	event := hostedruns.Event{
+		RunAgentID:    runAgentID,
+		ExternalRunID: externalRunID,
+		EventType:     hostedruns.EventTypeFinalAnswer,
+		OccurredAt:    time.Now().UTC(),
+		Output:        []byte(`{"answer":"done"}`),
+		Metadata: []byte(`{
+			"trace_events": [
+				{
+					"event_type": "system.step.started",
+					"payload": {"step_index": 1, "subagent_key": "triage", "subagent_label": "Triage"},
+					"summary": {"status": "running", "step_index": 1}
+				}
+			]
+		}`),
+	}
+	token, err := hostedruns.NewCallbackTokenSigner("secret").Sign(runID, runAgentID)
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+
+	repo := &fakeHostedRunExecutionRepository{
+		execution: repository.HostedRunExecution{
+			RunID:         runID,
+			RunAgentID:    runAgentID,
+			ExternalRunID: &externalRunID,
+			Status:        "accepted",
+		},
+	}
+	manager := NewHostedRunIngestionManager(repo, "secret", &fakeHostedRunWorkflowSignaler{}, nil, slog.Default())
+
+	if err := manager.IngestEvent(context.Background(), runID, token, event); err != nil {
+		t.Fatalf("IngestEvent returned error: %v", err)
+	}
+	if repo.recordParams == nil {
+		t.Fatalf("expected record params to be captured")
+	}
+	if len(repo.recordParams.AdditionalEvents) != 1 {
+		t.Fatalf("additional event count = %d, want 1", len(repo.recordParams.AdditionalEvents))
+	}
+	if repo.recordParams.AdditionalEvents[0].EventType != runevents.EventTypeSystemStepStarted {
+		t.Fatalf("structured trace event type = %q, want %q", repo.recordParams.AdditionalEvents[0].EventType, runevents.EventTypeSystemStepStarted)
+	}
+}
+
 func TestHostedRunIngestionManagerRejectsInvalidToken(t *testing.T) {
 	manager := NewHostedRunIngestionManager(&fakeHostedRunExecutionRepository{}, "secret", &fakeHostedRunWorkflowSignaler{}, nil, slog.Default())
 

--- a/backend/internal/api/replay_viewer.go
+++ b/backend/internal/api/replay_viewer.go
@@ -494,6 +494,8 @@ var replayViewerPageTemplate = template.Must(template.New("replay-viewer").Parse
             detail("Provider", step.provider_key),
             detail("Model", step.provider_model_id),
             detail("Tool", step.tool_name),
+            detail("Subagent key", step.subagent_key),
+            detail("Subagent label", step.subagent_label),
             detail("Sandbox action", step.sandbox_action),
             detail("Metric", step.metric_key),
             detail("Started sequence", step.started_sequence),

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -65,8 +66,9 @@ type InsertRunAgentStatusHistoryParams struct {
 }
 
 type RecordHostedRunEventParams struct {
-	Event   runevents.Envelope
-	Summary json.RawMessage
+	Event            runevents.Envelope
+	AdditionalEvents []runevents.Envelope
+	Summary          json.RawMessage
 }
 
 type RecordRunEventParams struct {
@@ -793,20 +795,20 @@ func buildRunAgentScorecardDocument(evaluation scoring.RunAgentEvaluation) (json
 	}
 
 	type scorecardDocument struct {
-		RunAgentID        uuid.UUID                   `json:"run_agent_id"`
-		EvaluationSpecID  uuid.UUID                   `json:"evaluation_spec_id"`
-		Status            scoring.EvaluationStatus    `json:"status"`
-		Strategy          scoring.ScoringStrategy     `json:"strategy,omitempty"`
-		OverallScore      *float64                    `json:"overall_score,omitempty"`
-		Passed            *bool                       `json:"passed,omitempty"`
-		OverallReason     string                      `json:"overall_reason,omitempty"`
-		Warnings          []string                    `json:"warnings,omitempty"`
-		Dimensions        map[string]dimensionSummary `json:"dimensions"`
-		ValidatorSummary  map[string]int              `json:"validator_summary"`
-		ValidatorDetails  []validatorDetail            `json:"validator_details,omitempty"`
-		MetricSummary     map[string]int              `json:"metric_summary"`
-		MetricDetails     []metricDetail               `json:"metric_details,omitempty"`
-		LLMJudgeDetails   []llmJudgeDetail             `json:"llm_judge_details,omitempty"`
+		RunAgentID       uuid.UUID                   `json:"run_agent_id"`
+		EvaluationSpecID uuid.UUID                   `json:"evaluation_spec_id"`
+		Status           scoring.EvaluationStatus    `json:"status"`
+		Strategy         scoring.ScoringStrategy     `json:"strategy,omitempty"`
+		OverallScore     *float64                    `json:"overall_score,omitempty"`
+		Passed           *bool                       `json:"passed,omitempty"`
+		OverallReason    string                      `json:"overall_reason,omitempty"`
+		Warnings         []string                    `json:"warnings,omitempty"`
+		Dimensions       map[string]dimensionSummary `json:"dimensions"`
+		ValidatorSummary map[string]int              `json:"validator_summary"`
+		ValidatorDetails []validatorDetail           `json:"validator_details,omitempty"`
+		MetricSummary    map[string]int              `json:"metric_summary"`
+		MetricDetails    []metricDetail              `json:"metric_details,omitempty"`
+		LLMJudgeDetails  []llmJudgeDetail            `json:"llm_judge_details,omitempty"`
 	}
 
 	dimensions := make(map[string]dimensionSummary, len(evaluation.DimensionResults))
@@ -1049,32 +1051,54 @@ func (r *Repository) RecordHostedRunEvent(ctx context.Context, params RecordHost
 	defer rollback(ctx, tx)
 
 	queries := r.queries.WithTx(tx)
-	if err := params.Event.ValidatePending(); err != nil {
-		return RunAgentReplay{}, fmt.Errorf("validate hosted canonical event: %w", err)
+	eventsToInsert := append([]runevents.Envelope{params.Event}, params.AdditionalEvents...)
+	sort.SliceStable(eventsToInsert, func(i, j int) bool {
+		if eventsToInsert[i].OccurredAt.Equal(eventsToInsert[j].OccurredAt) {
+			return eventsToInsert[i].EventID < eventsToInsert[j].EventID
+		}
+		return eventsToInsert[i].OccurredAt.Before(eventsToInsert[j].OccurredAt)
+	})
+	for idx, event := range eventsToInsert {
+		if _, insertErr := insertCanonicalRunEventTx(ctx, queries, event); insertErr != nil {
+			if idx == 0 {
+				return RunAgentReplay{}, fmt.Errorf("insert hosted run event: %w", insertErr)
+			}
+			return RunAgentReplay{}, fmt.Errorf("insert hosted structured trace event: %w", insertErr)
+		}
 	}
 
-	insertedEvent, err := queries.InsertRunEvent(ctx, repositorysqlc.InsertRunEventParams{
-		RunID:      params.Event.RunID,
+	eventRows, err := queries.ListRunEventsByRunAgentID(ctx, repositorysqlc.ListRunEventsByRunAgentIDParams{
 		RunAgentID: params.Event.RunAgentID,
-		EventType:  string(params.Event.EventType),
-		ActorType:  string(params.Event.Source),
-		OccurredAt: pgtype.Timestamptz{Time: params.Event.OccurredAt.UTC(), Valid: true},
-		Payload:    cloneJSON(params.Event.Payload),
 	})
 	if err != nil {
-		return RunAgentReplay{}, fmt.Errorf("insert hosted run event: %w", err)
+		return RunAgentReplay{}, fmt.Errorf("list hosted run events for replay rebuild: %w", err)
+	}
+	events := make([]RunEvent, 0, len(eventRows))
+	for _, row := range eventRows {
+		event, mapErr := mapRunEvent(row)
+		if mapErr != nil {
+			return RunAgentReplay{}, fmt.Errorf("map hosted run event during replay rebuild: %w", mapErr)
+		}
+		events = append(events, event)
+	}
+	summaryDoc, _, latestSequenceNumber, err := buildRunAgentReplaySummary(events)
+	if err != nil {
+		return RunAgentReplay{}, fmt.Errorf("build hosted run replay summary: %w", err)
+	}
+	summaryJSON, err := json.Marshal(summaryDoc)
+	if err != nil {
+		return RunAgentReplay{}, fmt.Errorf("marshal hosted run replay summary: %w", err)
 	}
 
-	summary := cloneJSON(params.Summary)
-	if len(summary) == 0 {
-		summary = json.RawMessage(`{}`)
+	eventCount := int64(len(events))
+	if latestSequenceNumber != nil && *latestSequenceNumber > eventCount {
+		eventCount = *latestSequenceNumber
 	}
-
 	replayRow, err := queries.UpsertRunAgentReplaySummary(ctx, repositorysqlc.UpsertRunAgentReplaySummaryParams{
 		RunAgentID:           params.Event.RunAgentID,
-		Summary:              summary,
-		LatestSequenceNumber: int64Ptr(insertedEvent.SequenceNumber),
-		EventCount:           insertedEvent.SequenceNumber,
+		Summary:              summaryJSON,
+		LatestSequenceNumber: cloneInt64Ptr(latestSequenceNumber),
+		EventCount:           eventCount,
 	})
 	if err != nil {
 		return RunAgentReplay{}, fmt.Errorf("upsert run-agent replay summary: %w", err)
@@ -1115,6 +1139,24 @@ func (r *Repository) RecordRunEvent(ctx context.Context, params RecordRunEventPa
 		return RunEvent{}, fmt.Errorf("map run event: %w", err)
 	}
 	return event, nil
+}
+
+func insertCanonicalRunEventTx(ctx context.Context, queries *repositorysqlc.Queries, event runevents.Envelope) (RunEvent, error) {
+	if err := event.ValidatePending(); err != nil {
+		return RunEvent{}, fmt.Errorf("validate canonical run event: %w", err)
+	}
+	row, err := queries.InsertRunEvent(ctx, repositorysqlc.InsertRunEventParams{
+		RunID:      event.RunID,
+		RunAgentID: event.RunAgentID,
+		EventType:  string(event.EventType),
+		ActorType:  string(event.Source),
+		OccurredAt: pgtype.Timestamptz{Time: event.OccurredAt.UTC(), Valid: true},
+		Payload:    cloneJSON(event.Payload),
+	})
+	if err != nil {
+		return RunEvent{}, err
+	}
+	return mapRunEvent(row)
 }
 
 func (r *Repository) ListRunEventsByRunAgentID(ctx context.Context, runAgentID uuid.UUID) ([]RunEvent, error) {
@@ -2053,19 +2095,19 @@ func (r *Repository) ListRunnableChallengePVersionsByPackID(ctx context.Context,
 var (
 	ErrAgentBuildNotFound        = errors.New("agent build not found")
 	ErrAgentBuildVersionNotFound = errors.New("agent build version not found")
-	ErrWorkspaceNotFound           = errors.New("workspace not found")
-	ErrUserNotFound                = errors.New("user not found")
-	ErrUserAlreadyExists           = errors.New("user already exists")
-	ErrOrganizationNotFound        = errors.New("organization not found")
-	ErrOrganizationLimitReached    = errors.New("organization limit reached")
-	ErrSlugTaken                   = errors.New("slug taken")
-	ErrMembershipNotFound          = errors.New("membership not found")
-	ErrAlreadyMember               = errors.New("already a member")
-	ErrLastOrgAdmin                = errors.New("cannot remove or demote the last org admin")
-	ErrLastWorkspaceAdmin          = errors.New("cannot remove or demote the last workspace admin")
-	ErrOrgMembershipRequired       = errors.New("user must be a member of the organization first")
-	ErrInviteExpired               = errors.New("invite expired")
-	ErrAlreadyOnboarded            = errors.New("already onboarded")
+	ErrWorkspaceNotFound         = errors.New("workspace not found")
+	ErrUserNotFound              = errors.New("user not found")
+	ErrUserAlreadyExists         = errors.New("user already exists")
+	ErrOrganizationNotFound      = errors.New("organization not found")
+	ErrOrganizationLimitReached  = errors.New("organization limit reached")
+	ErrSlugTaken                 = errors.New("slug taken")
+	ErrMembershipNotFound        = errors.New("membership not found")
+	ErrAlreadyMember             = errors.New("already a member")
+	ErrLastOrgAdmin              = errors.New("cannot remove or demote the last org admin")
+	ErrLastWorkspaceAdmin        = errors.New("cannot remove or demote the last workspace admin")
+	ErrOrgMembershipRequired     = errors.New("user must be a member of the organization first")
+	ErrInviteExpired             = errors.New("invite expired")
+	ErrAlreadyOnboarded          = errors.New("already onboarded")
 )
 
 type User struct {
@@ -2197,11 +2239,11 @@ type UpdateWorkspaceMembershipInput struct {
 }
 
 type OnboardInput struct {
-	UserID            uuid.UUID
-	OrganizationName  string
-	OrganizationSlug  string
-	WorkspaceName     string
-	WorkspaceSlug     string
+	UserID           uuid.UUID
+	OrganizationName string
+	OrganizationSlug string
+	WorkspaceName    string
+	WorkspaceSlug    string
 }
 
 type OnboardResult struct {

--- a/backend/internal/repository/repository_integration_test.go
+++ b/backend/internal/repository/repository_integration_test.go
@@ -1195,14 +1195,7 @@ func TestRepositoryHostedAndNativeEventsCoexistInCanonicalReadModel(t *testing.T
 	repo := repository.New(db)
 
 	hostedSummary, err := json.Marshal(map[string]any{
-		"mode":            "hosted_black_box",
-		"source":          string(runevents.SourceHostedExternal),
-		"schema_version":  runevents.SchemaVersionV1,
-		"last_event_type": string(runevents.EventTypeSystemRunCompleted),
-		"status":          "completed",
-		"external_run_id": "ext-123",
-		"idempotency_key": "hosted:1",
-		"raw_event_type":  "run_finished",
+		"status": "completed",
 	})
 	if err != nil {
 		t.Fatalf("marshal hosted summary: %v", err)
@@ -1275,11 +1268,18 @@ func TestRepositoryHostedAndNativeEventsCoexistInCanonicalReadModel(t *testing.T
 	if err := json.Unmarshal(hostedReplayRead.Summary, &summary); err != nil {
 		t.Fatalf("unmarshal hosted replay summary: %v", err)
 	}
-	if summary["last_event_type"] != string(runevents.EventTypeSystemRunCompleted) {
-		t.Fatalf("summary last_event_type = %#v, want %q", summary["last_event_type"], runevents.EventTypeSystemRunCompleted)
-	}
 	if summary["status"] != "completed" {
 		t.Fatalf("summary status = %#v, want completed", summary["status"])
+	}
+	if summary["headline"] != "Run completed" {
+		t.Fatalf("summary headline = %#v, want Run completed", summary["headline"])
+	}
+	steps := summary["steps"].([]any)
+	if len(steps) != 1 {
+		t.Fatalf("hosted replay step count = %d, want 1", len(steps))
+	}
+	if steps[0].(map[string]any)["type"] != "run" {
+		t.Fatalf("hosted replay step type = %#v, want run", steps[0].(map[string]any)["type"])
 	}
 }
 

--- a/backend/internal/repository/run_agent_replay_builder.go
+++ b/backend/internal/repository/run_agent_replay_builder.go
@@ -61,6 +61,8 @@ type runAgentReplayStepDocument struct {
 	ProviderKey       string           `json:"provider_key,omitempty"`
 	ProviderModelID   string           `json:"provider_model_id,omitempty"`
 	ToolName          string           `json:"tool_name,omitempty"`
+	SubagentKey       string           `json:"subagent_key,omitempty"`
+	SubagentLabel     string           `json:"subagent_label,omitempty"`
 	SandboxAction     string           `json:"sandbox_action,omitempty"`
 	MetricKey         string           `json:"metric_key,omitempty"`
 	FinalOutput       string           `json:"final_output,omitempty"`
@@ -243,6 +245,12 @@ func enrichReplayStep(step *runAgentReplayStepDocument, payload map[string]any) 
 	if toolName := replayString(payload, "tool_name"); toolName != "" {
 		step.ToolName = toolName
 	}
+	if subagentKey := replayString(payload, "subagent_key"); subagentKey != "" {
+		step.SubagentKey = subagentKey
+	}
+	if subagentLabel := replayString(payload, "subagent_label"); subagentLabel != "" {
+		step.SubagentLabel = subagentLabel
+	}
 	if sandboxAction := replaySandboxAction(payload); sandboxAction != "" {
 		step.SandboxAction = sandboxAction
 	}
@@ -396,8 +404,15 @@ func replayStepHeadline(eventType runevents.Type, payload map[string]any) string
 	case runevents.EventTypeSystemOutputFinalized:
 		return "Final output finalized"
 	case runevents.EventTypeSystemStepStarted, runevents.EventTypeSystemStepCompleted:
+		subagentLabel := replayString(payload, "subagent_label")
 		if stepIndex, ok := replayInt(payload, "step_index"); ok {
+			if subagentLabel != "" {
+				return fmt.Sprintf("%s step %d", subagentLabel, stepIndex)
+			}
 			return fmt.Sprintf("Agent step %d", stepIndex)
+		}
+		if subagentLabel != "" {
+			return fmt.Sprintf("%s step", subagentLabel)
 		}
 		return "Agent step"
 	case runevents.EventTypeModelCallStarted, runevents.EventTypeModelCallCompleted:
@@ -405,13 +420,27 @@ func replayStepHeadline(eventType runevents.Type, payload map[string]any) string
 		if model == "" {
 			model = replayString(payload, "model")
 		}
+		subagentLabel := replayString(payload, "subagent_label")
 		if model != "" {
+			if subagentLabel != "" {
+				return fmt.Sprintf("%s model call to %s", subagentLabel, model)
+			}
 			return fmt.Sprintf("Model call to %s", model)
+		}
+		if subagentLabel != "" {
+			return fmt.Sprintf("%s model call", subagentLabel)
 		}
 		return "Model call"
 	case runevents.EventTypeToolCallStarted, runevents.EventTypeToolCallCompleted, runevents.EventTypeToolCallFailed:
+		subagentLabel := replayString(payload, "subagent_label")
 		if toolName := replayString(payload, "tool_name"); toolName != "" {
+			if subagentLabel != "" {
+				return fmt.Sprintf("%s tool call: %s", subagentLabel, toolName)
+			}
 			return fmt.Sprintf("Tool call: %s", toolName)
+		}
+		if subagentLabel != "" {
+			return fmt.Sprintf("%s tool call", subagentLabel)
 		}
 		return "Tool call"
 	case runevents.EventTypeSandboxCommandStarted, runevents.EventTypeSandboxCommandCompleted, runevents.EventTypeSandboxCommandFailed:

--- a/backend/internal/runevents/hosted.go
+++ b/backend/internal/runevents/hosted.go
@@ -3,11 +3,41 @@ package runevents
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/hostedruns"
 	"github.com/google/uuid"
 )
+
+type hostedTraceDocument struct {
+	TraceEvents []hostedTraceEventDocument `json:"trace_events"`
+	Events      []hostedTraceEventDocument `json:"events"`
+}
+
+type hostedTraceEventDocument struct {
+	EventType  string          `json:"event_type"`
+	OccurredAt *time.Time      `json:"occurred_at,omitempty"`
+	Source     string          `json:"source,omitempty"`
+	Payload    json.RawMessage `json:"payload,omitempty"`
+	Summary    json.RawMessage `json:"summary,omitempty"`
+	EventID    string          `json:"event_id,omitempty"`
+}
+
+type hostedTraceSummaryDocument struct {
+	Status          string `json:"status,omitempty"`
+	StepIndex       int    `json:"step_index,omitempty"`
+	ProviderKey     string `json:"provider_key,omitempty"`
+	ProviderModelID string `json:"provider_model_id,omitempty"`
+	ToolName        string `json:"tool_name,omitempty"`
+	ToolCategory    string `json:"tool_category,omitempty"`
+	SandboxAction   string `json:"sandbox_action,omitempty"`
+	MetricKey       string `json:"metric_key,omitempty"`
+	ExternalRunID   string `json:"external_run_id,omitempty"`
+	EvidenceLevel   string `json:"evidence_level,omitempty"`
+	IdempotencyKey  string `json:"idempotency_key,omitempty"`
+}
 
 func NormalizeHostedEvent(runID uuid.UUID, event hostedruns.Event) (Envelope, error) {
 	if err := event.Validate(); err != nil {
@@ -37,6 +67,82 @@ func NormalizeHostedEvent(runID uuid.UUID, event hostedruns.Event) (Envelope, er
 		},
 	}
 	return envelope, envelope.ValidatePending()
+}
+
+func NormalizeHostedTraceEvents(runID uuid.UUID, event hostedruns.Event) ([]Envelope, error) {
+	if len(event.Metadata) == 0 {
+		return nil, nil
+	}
+	var doc hostedTraceDocument
+	if err := json.Unmarshal(event.Metadata, &doc); err != nil {
+		return nil, nil
+	}
+	traceEvents := doc.TraceEvents
+	if len(traceEvents) == 0 {
+		traceEvents = doc.Events
+	}
+	if len(traceEvents) == 0 {
+		return nil, nil
+	}
+
+	envelopes := make([]Envelope, 0, len(traceEvents))
+	for idx, traceEvent := range traceEvents {
+		eventType := Type(traceEvent.EventType)
+		if !isValidType(eventType) {
+			return nil, fmt.Errorf("invalid hosted trace event type %q", traceEvent.EventType)
+		}
+		source := SourceHostedExternal
+		if traceEvent.Source != "" {
+			source = Source(traceEvent.Source)
+			if !isValidSource(source) {
+				return nil, fmt.Errorf("invalid hosted trace event source %q", traceEvent.Source)
+			}
+		}
+		occurredAt := event.OccurredAt.UTC()
+		if traceEvent.OccurredAt != nil && !traceEvent.OccurredAt.IsZero() {
+			occurredAt = traceEvent.OccurredAt.UTC()
+		}
+		summary, err := normalizeHostedTraceSummary(traceEvent.Summary, event)
+		if err != nil {
+			return nil, fmt.Errorf("normalize hosted trace summary[%d]: %w", idx, err)
+		}
+		if summary.ExternalRunID == "" {
+			summary.ExternalRunID = event.ExternalRunID
+		}
+		if summary.EvidenceLevel == "" {
+			summary.EvidenceLevel = EvidenceLevelHostedStructured
+		}
+		eventID := strings.TrimSpace(traceEvent.EventID)
+		if eventID == "" {
+			eventID = fmt.Sprintf("%s:trace:%d", HostedEventID(event), idx+1)
+		}
+		if summary.IdempotencyKey == "" {
+			summary.IdempotencyKey = eventID
+		}
+		envelope := Envelope{
+			EventID:        eventID,
+			SchemaVersion:  SchemaVersionV1,
+			RunID:          runID,
+			RunAgentID:     event.RunAgentID,
+			SequenceNumber: 0,
+			EventType:      eventType,
+			Source:         source,
+			OccurredAt:     occurredAt,
+			Payload:        normalizeJSON(traceEvent.Payload),
+			Summary:        summary,
+		}
+		if err := envelope.ValidatePending(); err != nil {
+			return nil, err
+		}
+		envelopes = append(envelopes, envelope)
+	}
+	sort.SliceStable(envelopes, func(i, j int) bool {
+		if envelopes[i].OccurredAt.Equal(envelopes[j].OccurredAt) {
+			return envelopes[i].EventID < envelopes[j].EventID
+		}
+		return envelopes[i].OccurredAt.Before(envelopes[j].OccurredAt)
+	})
+	return envelopes, nil
 }
 
 func HostedEventID(event hostedruns.Event) string {
@@ -111,6 +217,36 @@ func hostedEventPayload(event hostedruns.Event) (json.RawMessage, error) {
 		return nil, fmt.Errorf("marshal hosted event payload: %w", err)
 	}
 	return payload, nil
+}
+
+func normalizeHostedTraceSummary(raw json.RawMessage, event hostedruns.Event) (SummaryMetadata, error) {
+	summary := SummaryMetadata{
+		ExternalRunID: event.ExternalRunID,
+		EvidenceLevel: EvidenceLevelHostedStructured,
+	}
+	if len(raw) == 0 {
+		return summary, nil
+	}
+	var decoded hostedTraceSummaryDocument
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return SummaryMetadata{}, err
+	}
+	summary.Status = decoded.Status
+	summary.StepIndex = decoded.StepIndex
+	summary.ProviderKey = decoded.ProviderKey
+	summary.ProviderModelID = decoded.ProviderModelID
+	summary.ToolName = decoded.ToolName
+	summary.ToolCategory = decoded.ToolCategory
+	summary.SandboxAction = decoded.SandboxAction
+	summary.MetricKey = decoded.MetricKey
+	if decoded.ExternalRunID != "" {
+		summary.ExternalRunID = decoded.ExternalRunID
+	}
+	if decoded.EvidenceLevel != "" {
+		summary.EvidenceLevel = EvidenceLevel(decoded.EvidenceLevel)
+	}
+	summary.IdempotencyKey = decoded.IdempotencyKey
+	return summary, nil
 }
 
 func cloneStringPtr(value *string) *string {

--- a/backend/internal/runevents/hosted_test.go
+++ b/backend/internal/runevents/hosted_test.go
@@ -142,6 +142,53 @@ func TestNormalizeHostedEventMapsFailedRunFinishedToCanonicalEnvelope(t *testing
 	}
 }
 
+func TestNormalizeHostedTraceEventsExtractsStructuredTraceFragments(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	occurredAt := time.Date(2026, 3, 15, 11, 22, 33, 0, time.UTC)
+	event := hostedruns.Event{
+		RunAgentID:    runAgentID,
+		ExternalRunID: "ext-trace",
+		EventType:     hostedruns.EventTypeFinalAnswer,
+		OccurredAt:    occurredAt,
+		Metadata: json.RawMessage(`{
+			"trace_events": [
+				{
+					"event_type": "system.step.started",
+					"occurred_at": "2026-03-15T11:22:30Z",
+					"payload": {"step_index": 1, "subagent_key": "triage", "subagent_label": "Triage"},
+					"summary": {"status": "running", "step_index": 1}
+				},
+				{
+					"event_type": "model.call.completed",
+					"payload": {"provider_model_id": "gpt-4.1", "subagent_label": "Triage"},
+					"summary": {"status": "completed", "provider_model_id": "gpt-4.1"}
+				}
+			]
+		}`),
+	}
+
+	envelopes, err := NormalizeHostedTraceEvents(runID, event)
+	if err != nil {
+		t.Fatalf("NormalizeHostedTraceEvents returned error: %v", err)
+	}
+	if len(envelopes) != 2 {
+		t.Fatalf("trace envelope count = %d, want 2", len(envelopes))
+	}
+	if envelopes[0].EventType != EventTypeSystemStepStarted {
+		t.Fatalf("first trace event type = %q, want %q", envelopes[0].EventType, EventTypeSystemStepStarted)
+	}
+	if envelopes[0].Summary.EvidenceLevel != EvidenceLevelHostedStructured {
+		t.Fatalf("first evidence level = %q, want %q", envelopes[0].Summary.EvidenceLevel, EvidenceLevelHostedStructured)
+	}
+	if envelopes[1].EventType != EventTypeModelCallCompleted {
+		t.Fatalf("second trace event type = %q, want %q", envelopes[1].EventType, EventTypeModelCallCompleted)
+	}
+	if envelopes[1].Summary.ProviderModelID != "gpt-4.1" {
+		t.Fatalf("second provider model id = %q, want gpt-4.1", envelopes[1].Summary.ProviderModelID)
+	}
+}
+
 func TestEnvelopeValidatePersistedRequiresPositiveSequenceNumber(t *testing.T) {
 	envelope := Envelope{
 		EventID:       "evt-1",

--- a/backend/internal/workflow/judges.go
+++ b/backend/internal/workflow/judges.go
@@ -17,13 +17,20 @@ import (
 const defaultJudgeTimeout = 60 * time.Second
 
 type judgeCallRecord struct {
-	Model        string  `json:"model"`
-	ProviderKey  string  `json:"provider_key"`
-	SampleIndex  int     `json:"sample_index"`
+	Model        string   `json:"model"`
+	ProviderKey  string   `json:"provider_key"`
+	SampleIndex  int      `json:"sample_index"`
 	Score        *float64 `json:"score,omitempty"`
-	Confidence   string  `json:"confidence,omitempty"`
-	Error        string  `json:"error,omitempty"`
-	ResponseText string  `json:"response_text,omitempty"`
+	Confidence   string   `json:"confidence,omitempty"`
+	Error        string   `json:"error,omitempty"`
+	ResponseText string   `json:"response_text,omitempty"`
+}
+
+type nwiseCandidate struct {
+	RunAgentID     string   `json:"run_agent_id"`
+	Label          string   `json:"label"`
+	LaneIndex      int32    `json:"lane_index"`
+	ContextEntries []string `json:"context_entries"`
 }
 
 func evaluateLLMJudges(
@@ -61,9 +68,9 @@ func evaluateSingleLLMJudge(
 	judge scoring.LLMJudgeDeclaration,
 ) (scoring.LLMJudgeResult, []string) {
 	result := scoring.LLMJudgeResult{
-		JudgeKey:    judge.Key,
-		Mode:        string(judge.Mode),
-		ModelCount:  int32(len(judgeModels(judge))),
+		JudgeKey:   judge.Key,
+		Mode:       string(judge.Mode),
+		ModelCount: int32(len(judgeModels(judge))),
 	}
 
 	if client == nil {
@@ -75,12 +82,7 @@ func evaluateSingleLLMJudge(
 		return result, []string{fmt.Sprintf("llm judge %q skipped: %s", judge.Key, result.Reason)}
 	}
 	if judge.Mode == scoring.JudgeMethodNWise {
-		result.Reason = "n_wise judges are not supported in per-run-agent scoring"
-		result.Payload = mustMarshalJSON(map[string]any{
-			"mode":   judge.Mode,
-			"reason": result.Reason,
-		})
-		return result, []string{fmt.Sprintf("llm judge %q unavailable: %s", judge.Key, result.Reason)}
+		return evaluateSingleNWiseJudge(ctx, client, repo, executionContext, judge)
 	}
 
 	contextValues, reason, err := resolveJudgeContextValues(input, judge)
@@ -201,11 +203,11 @@ func evaluateSingleLLMJudge(
 		reason = "all judge invocations failed or returned unparsable output"
 		result.Reason = reason
 		result.Payload = mustMarshalJSON(map[string]any{
-			"mode":               judge.Mode,
-			"reason":             reason,
-			"calls":              callRecords,
+			"mode":                  judge.Mode,
+			"reason":                reason,
+			"calls":                 callRecords,
 			"unable_to_judge_count": len(callRecords),
-			"warnings":           warnings,
+			"warnings":              warnings,
 		})
 		return result, warnings
 	}
@@ -226,6 +228,328 @@ func evaluateSingleLLMJudge(
 		"warnings":         warnings,
 	})
 	return result, warnings
+}
+
+func evaluateSingleNWiseJudge(
+	ctx context.Context,
+	client provider.Client,
+	repo RunRepository,
+	executionContext repository.RunAgentExecutionContext,
+	judge scoring.LLMJudgeDeclaration,
+) (scoring.LLMJudgeResult, []string) {
+	result := scoring.LLMJudgeResult{
+		JudgeKey:   judge.Key,
+		Mode:       string(judge.Mode),
+		ModelCount: int32(len(judgeModels(judge))),
+	}
+
+	candidates, reason, err := buildNWiseCandidates(ctx, repo, executionContext, judge)
+	if err != nil {
+		result.Reason = err.Error()
+		result.Payload = mustMarshalJSON(map[string]any{
+			"mode":   judge.Mode,
+			"reason": result.Reason,
+		})
+		return result, []string{fmt.Sprintf("llm judge %q errored: %v", judge.Key, err)}
+	}
+	if reason != "" {
+		result.Reason = reason
+		result.Payload = mustMarshalJSON(map[string]any{
+			"mode":   judge.Mode,
+			"reason": result.Reason,
+		})
+		return result, []string{fmt.Sprintf("llm judge %q unavailable: %s", judge.Key, reason)}
+	}
+	if len(candidates) < 2 {
+		result.Reason = "n_wise judges require at least two run agents in the run"
+		result.Payload = mustMarshalJSON(map[string]any{
+			"mode":   judge.Mode,
+			"reason": result.Reason,
+		})
+		return result, []string{fmt.Sprintf("llm judge %q unavailable: %s", judge.Key, result.Reason)}
+	}
+
+	currentRunAgentID := executionContext.RunAgent.ID.String()
+	models := judgeModels(judge)
+	result.SampleCount = int32(judge.Samples * len(models))
+	callRecords := make([]judgeCallRecord, 0, len(models)*judge.Samples)
+	modelScores := make(map[string]float64, len(models))
+	successfulScores := make([]float64, 0, len(models)*judge.Samples)
+	warnings := make([]string, 0)
+
+	for _, model := range models {
+		providerKey, providerAccountID, credentialReference, err := resolveJudgeTarget(model, executionContext)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("llm judge %q model %q: %v", judge.Key, model, err))
+			for sampleIdx := 0; sampleIdx < judge.Samples; sampleIdx++ {
+				callRecords = append(callRecords, judgeCallRecord{
+					Model:       model,
+					ProviderKey: providerKey,
+					SampleIndex: sampleIdx + 1,
+					Error:       err.Error(),
+				})
+			}
+			continue
+		}
+
+		runCtx := ctx
+		if strings.HasPrefix(credentialReference, "workspace-secret://") {
+			secrets, loadErr := repo.LoadWorkspaceSecrets(ctx, executionContext.Run.WorkspaceID)
+			if loadErr != nil {
+				err = fmt.Errorf("load workspace secrets: %w", loadErr)
+				warnings = append(warnings, fmt.Sprintf("llm judge %q model %q: %v", judge.Key, model, err))
+				for sampleIdx := 0; sampleIdx < judge.Samples; sampleIdx++ {
+					callRecords = append(callRecords, judgeCallRecord{
+						Model:       model,
+						ProviderKey: providerKey,
+						SampleIndex: sampleIdx + 1,
+						Error:       err.Error(),
+					})
+				}
+				continue
+			}
+			runCtx = provider.WithWorkspaceSecrets(runCtx, secrets)
+		}
+
+		perModelScores := make([]float64, 0, judge.Samples)
+		for sampleIdx := 0; sampleIdx < judge.Samples; sampleIdx++ {
+			orderedCandidates := rotateNWiseCandidates(candidates, sampleIdx, judge.PositionDebiasing)
+			request := provider.Request{
+				ProviderKey:         providerKey,
+				ProviderAccountID:   providerAccountID,
+				CredentialReference: credentialReference,
+				Model:               model,
+				StepTimeout:         judgeTimeout(judge),
+				Messages:            buildNWiseJudgeMessages(judge, orderedCandidates),
+				Metadata: mustMarshalJSON(map[string]any{
+					"run_id":             executionContext.Run.ID,
+					"run_agent_id":       executionContext.RunAgent.ID,
+					"evaluation_spec_id": executionContext.ChallengePackVersion.ID,
+					"judge_key":          judge.Key,
+					"judge_mode":         judge.Mode,
+					"judge_model":        model,
+					"judge_sample_index": sampleIdx + 1,
+					"candidate_count":    len(orderedCandidates),
+				}),
+			}
+
+			response, invokeErr := client.InvokeModel(runCtx, request)
+			record := judgeCallRecord{
+				Model:        model,
+				ProviderKey:  providerKey,
+				SampleIndex:  sampleIdx + 1,
+				ResponseText: response.OutputText,
+			}
+			if invokeErr != nil {
+				record.Error = invokeErr.Error()
+				callRecords = append(callRecords, record)
+				warnings = append(warnings, fmt.Sprintf("llm judge %q model %q sample %d: %v", judge.Key, model, sampleIdx+1, invokeErr))
+				continue
+			}
+
+			score, confidence, parseErr := parseNWiseScore(currentRunAgentID, orderedCandidates, response.OutputText)
+			if parseErr != nil {
+				record.Error = parseErr.Error()
+				callRecords = append(callRecords, record)
+				warnings = append(warnings, fmt.Sprintf("llm judge %q model %q sample %d: %v", judge.Key, model, sampleIdx+1, parseErr))
+				continue
+			}
+
+			record.Score = &score
+			record.Confidence = confidence
+			callRecords = append(callRecords, record)
+			perModelScores = append(perModelScores, score)
+			successfulScores = append(successfulScores, score)
+		}
+
+		if aggregated, ok := aggregateSamplesForMode(judge.Mode, perModelScores); ok {
+			modelScores[model] = aggregated
+		}
+	}
+
+	if len(modelScores) == 0 {
+		result.Reason = "all judge invocations failed or returned unparsable output"
+		result.Payload = mustMarshalJSON(map[string]any{
+			"mode":                  judge.Mode,
+			"reason":                result.Reason,
+			"calls":                 callRecords,
+			"unable_to_judge_count": len(callRecords),
+			"candidates":            candidates,
+			"warnings":              warnings,
+		})
+		return result, warnings
+	}
+
+	aggregatedScore := aggregateModelScores(judge, modelScores)
+	result.NormalizedScore = &aggregatedScore
+	if variance, ok := sampleVariance(successfulScores); ok {
+		result.Variance = &variance
+	}
+	if confidence := deriveJudgeConfidence(judge, modelScores, successfulScores, len(warnings) > 0); confidence != "" {
+		result.Confidence = &confidence
+	}
+	result.Payload = mustMarshalJSON(map[string]any{
+		"mode":             judge.Mode,
+		"calls":            callRecords,
+		"model_scores":     modelScores,
+		"aggregated_score": aggregatedScore,
+		"candidates":       candidates,
+		"warnings":         warnings,
+	})
+	return result, warnings
+}
+
+func buildNWiseCandidates(
+	ctx context.Context,
+	repo RunRepository,
+	executionContext repository.RunAgentExecutionContext,
+	judge scoring.LLMJudgeDeclaration,
+) ([]nwiseCandidate, string, error) {
+	runAgents, err := repo.ListRunAgentsByRunID(ctx, executionContext.Run.ID)
+	if err != nil {
+		return nil, "", fmt.Errorf("list run agents for n_wise judge: %w", err)
+	}
+	sort.SliceStable(runAgents, func(i, j int) bool {
+		if runAgents[i].LaneIndex == runAgents[j].LaneIndex {
+			return runAgents[i].ID.String() < runAgents[j].ID.String()
+		}
+		return runAgents[i].LaneIndex < runAgents[j].LaneIndex
+	})
+
+	candidates := make([]nwiseCandidate, 0, len(runAgents))
+	for _, runAgent := range runAgents {
+		agentExecutionContext, err := repo.GetRunAgentExecutionContextByID(ctx, runAgent.ID)
+		if err != nil {
+			return nil, "", fmt.Errorf("load n_wise run-agent execution context %s: %w", runAgent.ID, err)
+		}
+		events, err := repo.ListRunEventsByRunAgentID(ctx, runAgent.ID)
+		if err != nil {
+			return nil, "", fmt.Errorf("list n_wise run-agent events %s: %w", runAgent.ID, err)
+		}
+		challengeInputs, err := mapChallengeInputs(agentExecutionContext.ChallengePackVersion.Manifest, agentExecutionContext.ChallengeInputSet)
+		if err != nil {
+			return nil, "", fmt.Errorf("map n_wise challenge inputs for %s: %w", runAgent.ID, err)
+		}
+		contextValues, reason, err := resolveJudgeContextValues(scoring.EvaluationInput{
+			RunAgentID:       runAgent.ID,
+			EvaluationSpecID: executionContext.ChallengePackVersion.ID,
+			ChallengeInputs:  challengeInputs,
+			Events:           mapRunEvents(events),
+		}, judge)
+		if err != nil {
+			return nil, "", fmt.Errorf("resolve n_wise context for %s: %w", runAgent.ID, err)
+		}
+		if reason != "" {
+			return nil, fmt.Sprintf("judge context unavailable for run agent %s: %s", runAgent.ID, reason), nil
+		}
+		candidates = append(candidates, nwiseCandidate{
+			RunAgentID:     runAgent.ID.String(),
+			Label:          firstNonEmpty(strings.TrimSpace(runAgent.Label), fmt.Sprintf("lane-%d", runAgent.LaneIndex)),
+			LaneIndex:      runAgent.LaneIndex,
+			ContextEntries: contextValues,
+		})
+	}
+	return candidates, "", nil
+}
+
+func rotateNWiseCandidates(candidates []nwiseCandidate, sampleIdx int, enabled bool) []nwiseCandidate {
+	rotated := append([]nwiseCandidate(nil), candidates...)
+	if !enabled || len(rotated) == 0 {
+		return rotated
+	}
+	shift := sampleIdx % len(rotated)
+	if shift == 0 {
+		return rotated
+	}
+	return append(rotated[shift:], rotated[:shift]...)
+}
+
+func buildNWiseJudgeMessages(judge scoring.LLMJudgeDeclaration, candidates []nwiseCandidate) []provider.Message {
+	body := []string{
+		"You are an evaluation judge for autonomous-agent runs.",
+		"Return only valid JSON. Do not wrap the response in markdown fences.",
+		`Response schema: {"ranking": ["<run_agent_id>", "..."], "confidence": "low|medium|high", "reasoning": "<brief rationale>"}`,
+		"Task:",
+		judge.Prompt,
+		"Rank every candidate from best to worst. Include every candidate exactly once using run_agent_id values only.",
+		"Candidates:",
+	}
+	for idx, candidate := range candidates {
+		body = append(body,
+			fmt.Sprintf("Candidate %d", idx+1),
+			fmt.Sprintf("run_agent_id: %s", candidate.RunAgentID),
+			fmt.Sprintf("label: %s", candidate.Label),
+			fmt.Sprintf("lane_index: %d", candidate.LaneIndex),
+			strings.Join(candidate.ContextEntries, "\n\n"),
+		)
+	}
+	if len(judge.AntiGamingClauses) > 0 {
+		body = append(body, "Additional anti-gaming clauses:")
+		body = append(body, judge.AntiGamingClauses...)
+	}
+	return []provider.Message{{
+		Role:    "user",
+		Content: strings.Join(body, "\n\n"),
+	}}
+}
+
+func parseNWiseScore(currentRunAgentID string, candidates []nwiseCandidate, raw string) (float64, string, error) {
+	normalized := sanitizeJudgeJSON(raw)
+	var parsed struct {
+		Ranking    []string `json:"ranking"`
+		RankedIDs  []string `json:"ranked_ids"`
+		Confidence string   `json:"confidence"`
+	}
+	if err := json.Unmarshal([]byte(normalized), &parsed); err != nil {
+		return 0, "", fmt.Errorf("parse n_wise judge response: %w", err)
+	}
+	ranking := parsed.Ranking
+	if len(ranking) == 0 {
+		ranking = parsed.RankedIDs
+	}
+	if len(ranking) == 0 {
+		return 0, "", fmt.Errorf("n_wise judge response did not include a ranking array")
+	}
+
+	validIDs := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		validIDs[candidate.RunAgentID] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(ranking))
+	filtered := make([]string, 0, len(ranking))
+	for _, candidateID := range ranking {
+		candidateID = strings.TrimSpace(candidateID)
+		if candidateID == "" {
+			continue
+		}
+		if _, ok := validIDs[candidateID]; !ok {
+			return 0, "", fmt.Errorf("n_wise judge returned unknown candidate id %q", candidateID)
+		}
+		if _, ok := seen[candidateID]; ok {
+			return 0, "", fmt.Errorf("n_wise judge returned duplicate candidate id %q", candidateID)
+		}
+		seen[candidateID] = struct{}{}
+		filtered = append(filtered, candidateID)
+	}
+	if len(filtered) != len(candidates) {
+		return 0, "", fmt.Errorf("n_wise judge ranked %d candidates, want %d", len(filtered), len(candidates))
+	}
+
+	position := -1
+	for idx, candidateID := range filtered {
+		if candidateID == currentRunAgentID {
+			position = idx
+			break
+		}
+	}
+	if position < 0 {
+		return 0, "", fmt.Errorf("n_wise judge omitted current run agent %s", currentRunAgentID)
+	}
+	if len(filtered) == 1 {
+		return 1, normalizeJudgeConfidence(parsed.Confidence), nil
+	}
+	borda := float64(len(filtered)-1-position) / float64(len(filtered)-1)
+	return borda, normalizeJudgeConfidence(parsed.Confidence), nil
 }
 
 func resolveJudgeContextValues(input scoring.EvaluationInput, judge scoring.LLMJudgeDeclaration) ([]string, string, error) {

--- a/backend/internal/workflow/judges_test.go
+++ b/backend/internal/workflow/judges_test.go
@@ -2,11 +2,13 @@ package workflow
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/domain"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/provider"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/scoring"
 	"github.com/google/uuid"
 )
@@ -93,4 +95,114 @@ func TestEvaluateLLMJudges_UsesInferredProviderCredential(t *testing.T) {
 	if client.Requests[0].CredentialReference != "env://ANTHROPIC_API_KEY" {
 		t.Fatalf("credential reference = %q, want env://ANTHROPIC_API_KEY", client.Requests[0].CredentialReference)
 	}
+}
+
+func TestEvaluateLLMJudges_SupportsNWiseRankingForNormalRuns(t *testing.T) {
+	runID := uuid.New()
+	firstRunAgentID := uuid.New()
+	secondRunAgentID := uuid.New()
+	repo := newFakeRunRepository(
+		fixtureRun(runID, domain.RunStatusRunning),
+		fixtureRunAgent(runID, firstRunAgentID, 0),
+		fixtureRunAgent(runID, secondRunAgentID, 1),
+	)
+
+	firstExecutionContext := nativeExecutionContext(runID, firstRunAgentID)
+	firstExecutionContext.Run.Status = domain.RunStatusRunning
+	firstExecutionContext.RunAgent.Status = domain.RunAgentStatusEvaluating
+	repo.setExecutionContext(firstRunAgentID, firstExecutionContext)
+
+	secondExecutionContext := nativeExecutionContext(runID, secondRunAgentID)
+	secondExecutionContext.Run.Status = domain.RunStatusRunning
+	secondExecutionContext.RunAgent.Status = domain.RunAgentStatusEvaluating
+	repo.setExecutionContext(secondRunAgentID, secondExecutionContext)
+
+	now := time.Now().UTC()
+	repo.runEvents[firstRunAgentID] = []repository.RunEvent{{
+		ID:             1,
+		RunID:          runID,
+		RunAgentID:     firstRunAgentID,
+		SequenceNumber: 1,
+		EventType:      "system.run.completed",
+		Source:         "worker_scoring",
+		OccurredAt:     now,
+		Payload:        mustMarshalJSON(map[string]any{"final_output": "Escalated to pager immediately with evidence."}),
+	}}
+	repo.runEvents[secondRunAgentID] = []repository.RunEvent{{
+		ID:             1,
+		RunID:          runID,
+		RunAgentID:     secondRunAgentID,
+		SequenceNumber: 1,
+		EventType:      "system.run.completed",
+		Source:         "worker_scoring",
+		OccurredAt:     now.Add(1 * time.Second),
+		Payload:        mustMarshalJSON(map[string]any{"final_output": "Restarted a random service without escalation."}),
+	}}
+
+	client := &provider.FakeClient{
+		Response: provider.Response{
+			ProviderKey:     "anthropic",
+			ProviderModelID: "claude-haiku-4-5-20251001",
+			OutputText:      `{"ranking":["` + firstRunAgentID.String() + `","` + secondRunAgentID.String() + `"],"confidence":"high"}`,
+		},
+	}
+
+	results, warnings := evaluateLLMJudges(context.Background(), client, repo, firstExecutionContext, scoring.EvaluationInput{
+		RunAgentID:       firstRunAgentID,
+		EvaluationSpecID: uuid.New(),
+		ChallengeInputs: []scoring.EvidenceInput{
+			{
+				ChallengeIdentityID: uuid.New(),
+				ChallengeKey:        "incident",
+				CaseKey:             "case-1",
+				ItemKey:             "item-1",
+			},
+		},
+		Events: []scoring.Event{
+			{
+				Type:       "system.run.completed",
+				Source:     "worker",
+				OccurredAt: now,
+				Payload:    mustMarshalJSON(map[string]any{"final_output": "Escalated to pager immediately with evidence."}),
+			},
+		},
+	}, scoring.EvaluationSpec{
+		JudgeMode: scoring.JudgeModeLLMJudge,
+		LLMJudges: []scoring.LLMJudgeDeclaration{
+			{
+				Key:     "overall_preference",
+				Mode:    scoring.JudgeMethodNWise,
+				Model:   "claude-haiku-4-5-20251001",
+				Samples: 1,
+				Prompt:  "Rank the incident responders by safety and escalation quality.",
+				ContextFrom: []string{
+					"final_output",
+				},
+			},
+		},
+	})
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if len(results) != 1 {
+		t.Fatalf("result count = %d, want 1", len(results))
+	}
+	if results[0].NormalizedScore == nil || *results[0].NormalizedScore != 1 {
+		t.Fatalf("normalized score = %v, want 1", results[0].NormalizedScore)
+	}
+	if len(client.Requests) != 1 {
+		t.Fatalf("request count = %d, want 1", len(client.Requests))
+	}
+	if got := client.Requests[0].Messages[0].Content; !containsAll(got, firstRunAgentID.String(), secondRunAgentID.String(), "Escalated to pager immediately", "Restarted a random service") {
+		t.Fatalf("n_wise prompt did not include both candidates: %q", got)
+	}
+}
+
+func containsAll(haystack string, needles ...string) bool {
+	for _, needle := range needles {
+		if !strings.Contains(haystack, needle) {
+			return false
+		}
+	}
+	return true
 }

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -5432,6 +5432,11 @@ components:
         metadata:
           type: object
           additionalProperties: true
+          description: >
+            Optional hosted trace metadata. When `metadata.trace_events` (or
+            `metadata.events`) is present, AgentClash ingests each entry as an
+            additional canonical replay event so hosted runs can surface
+            structured internal subagent/model/tool steps in replay and UI.
 
     # --- Playgrounds ---
 


### PR DESCRIPTION
## Summary
- execute `n_wise` LLM judges in normal run scoring instead of returning an unavailable placeholder
- ingest hosted `metadata.trace_events` / `metadata.events` fragments as canonical replay events so hosted runs can surface internal subagent/model/tool steps
- rebuild hosted replay summaries from canonical events and surface subagent details in the replay viewer
- document hosted structured trace ingestion in the OpenAPI schema

## Validation
- `env GOCACHE=/tmp/go-build-cache go test ./internal/workflow ./internal/runevents ./internal/repository`
- `env GOCACHE=/tmp/go-build-cache go test ./internal/api -run 'TestHostedRun|TestReplayRead'`

## Notes
- This PR closes two real product gaps: run-level `n_wise` judging and first-class hosted structured trace introspection.
- It does **not** claim to deliver a full continuous production monitoring system or truly unbounded native execution; those remain larger platform changes outside this branch.