### PR TITLE
[codex] Add token_f1 scoring validator

### DIFF
--- a/backend/internal/scoring/engine_test.go
+++ b/backend/internal/scoring/engine_test.go
@@ -2,6 +2,7 @@ package scoring
 
 import (
 	"encoding/json"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -1655,6 +1656,125 @@ func TestEvaluateRunAgent_NormalizedMatchPassesWithPipeline(t *testing.T) {
 	}
 	if evaluation.DimensionScores[string(ScorecardDimensionCorrectness)] == nil || *evaluation.DimensionScores[string(ScorecardDimensionCorrectness)] != 1 {
 		t.Fatalf("correctness score = %v, want 1", evaluation.DimensionScores[string(ScorecardDimensionCorrectness)])
+	}
+}
+
+func TestEvaluateRunAgent_TokenF1PassesAboveThreshold(t *testing.T) {
+	spec := EvaluationSpec{
+		Name:          "token-f1-pass",
+		VersionNumber: 1,
+		JudgeMode:     JudgeModeDeterministic,
+		Validators: []ValidatorDeclaration{
+			{
+				Key:          "token_f1",
+				Type:         ValidatorTypeTokenF1,
+				Target:       "final_output",
+				ExpectedFrom: "literal:eiffel tower paris",
+				Config:       json.RawMessage(`{"threshold": 0.75}`),
+			},
+		},
+		Scorecard: ScorecardDeclaration{
+			Dimensions: []DimensionDeclaration{{Key: ScorecardDimensionCorrectness}},
+		},
+	}
+
+	evaluation, err := EvaluateRunAgent(EvaluationInput{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		Events: []Event{
+			{Type: "system.run.completed", OccurredAt: time.Date(2026, 3, 16, 9, 0, 2, 0, time.UTC), Payload: []byte(`{"final_output":"eiffel tower"}`)},
+		},
+	}, spec)
+	if err != nil {
+		t.Fatalf("EvaluateRunAgent returned error: %v", err)
+	}
+
+	if evaluation.ValidatorResults[0].Verdict != "pass" {
+		t.Fatalf("validator verdict = %q, want pass", evaluation.ValidatorResults[0].Verdict)
+	}
+	if got := *evaluation.ValidatorResults[0].NormalizedScore; math.Abs(got-0.8) > 1e-9 {
+		t.Fatalf("normalizedScore = %f, want 0.8", got)
+	}
+}
+
+func TestEvaluateRunAgent_TokenF1FailsBelowThreshold(t *testing.T) {
+	spec := EvaluationSpec{
+		Name:          "token-f1-fail",
+		VersionNumber: 1,
+		JudgeMode:     JudgeModeDeterministic,
+		Validators: []ValidatorDeclaration{
+			{
+				Key:          "token_f1",
+				Type:         ValidatorTypeTokenF1,
+				Target:       "final_output",
+				ExpectedFrom: "literal:eiffel tower in paris",
+				Config:       json.RawMessage(`{"threshold": 0.5}`),
+			},
+		},
+		Scorecard: ScorecardDeclaration{
+			Dimensions: []DimensionDeclaration{{Key: ScorecardDimensionCorrectness}},
+		},
+	}
+
+	evaluation, err := EvaluateRunAgent(EvaluationInput{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		Events: []Event{
+			{Type: "system.run.completed", OccurredAt: time.Date(2026, 3, 16, 9, 0, 2, 0, time.UTC), Payload: []byte(`{"final_output":"paris museum"}`)},
+		},
+	}, spec)
+	if err != nil {
+		t.Fatalf("EvaluateRunAgent returned error: %v", err)
+	}
+
+	if evaluation.ValidatorResults[0].Verdict != "fail" {
+		t.Fatalf("validator verdict = %q, want fail", evaluation.ValidatorResults[0].Verdict)
+	}
+	score := evaluation.DimensionScores[string(ScorecardDimensionCorrectness)]
+	if score == nil {
+		t.Fatal("correctness score is nil")
+	}
+	if math.Abs(*score-(1.0/3.0)) > 1e-9 {
+		t.Fatalf("correctness score = %f, want %f", *score, 1.0/3.0)
+	}
+}
+
+func TestEvaluateRunAgent_TokenF1NormalizesBeforeTokenizing(t *testing.T) {
+	spec := EvaluationSpec{
+		Name:          "token-f1-normalized",
+		VersionNumber: 1,
+		JudgeMode:     JudgeModeDeterministic,
+		Validators: []ValidatorDeclaration{
+			{
+				Key:          "token_f1",
+				Type:         ValidatorTypeTokenF1,
+				Target:       "final_output",
+				ExpectedFrom: "literal:eiffel tower in paris",
+				Config:       json.RawMessage(`{"threshold": 1.0, "normalize": true, "remove_articles": true, "remove_punctuation": true}`),
+			},
+		},
+		Scorecard: ScorecardDeclaration{
+			Dimensions: []DimensionDeclaration{{Key: ScorecardDimensionCorrectness}},
+		},
+	}
+
+	evaluation, err := EvaluateRunAgent(EvaluationInput{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		Events: []Event{
+			{Type: "system.run.completed", OccurredAt: time.Date(2026, 3, 16, 9, 0, 2, 0, time.UTC), Payload: []byte(`{"final_output":"The Eiffel Tower, in Paris!"}`)},
+		},
+	}, spec)
+	if err != nil {
+		t.Fatalf("EvaluateRunAgent returned error: %v", err)
+	}
+
+	if evaluation.ValidatorResults[0].Verdict != "pass" {
+		t.Fatalf("validator verdict = %q, want pass", evaluation.ValidatorResults[0].Verdict)
+	}
+	raw := mustUnmarshalObject(t, evaluation.ValidatorResults[0].RawOutput)
+	if got := raw["normalized_actual"]; got != "eiffel tower in paris" {
+		t.Fatalf("normalized_actual = %#v, want %q", got, "eiffel tower in paris")
 	}
 }
 

--- a/backend/internal/scoring/engine_validators.go
+++ b/backend/internal/scoring/engine_validators.go
@@ -244,6 +244,8 @@ func applyValidator(validator ValidatorDeclaration, actual string, expected stri
 		return validateNumericMatch(actual, expected, validator.Config)
 	case ValidatorTypeNormalizedMatch:
 		return validateNormalizedMatch(actual, expected, validator.Config)
+	case ValidatorTypeTokenF1:
+		return validateTokenF1(actual, expected, validator.Config)
 	case ValidatorTypeMathEquivalence:
 		return validateMathEquivalence(actual, expected, validator.Config)
 	case ValidatorTypeBLEUScore:

--- a/backend/internal/scoring/loader_test.go
+++ b/backend/internal/scoring/loader_test.go
@@ -202,6 +202,13 @@ func TestLoadEvaluationSpecAcceptsStringMatchValidators(t *testing.T) {
 					"config": {"pipeline": ["trim", "lowercase", "collapse_whitespace"]}
 				},
 				{
+					"key": "token_f1",
+					"type": "token_f1",
+					"target": "final_output",
+					"expected_from": "literal:the Eiffel Tower in Paris",
+					"config": {"threshold": 0.5, "normalize": true, "remove_articles": true, "remove_punctuation": true}
+				},
+				{
 					"key": "math",
 					"type": "math_equivalence",
 					"target": "final_output",
@@ -218,8 +225,8 @@ func TestLoadEvaluationSpecAcceptsStringMatchValidators(t *testing.T) {
 		t.Fatalf("LoadEvaluationSpec returned error: %v", err)
 	}
 
-	if len(spec.Validators) != 4 {
-		t.Fatalf("validator count = %d, want 4", len(spec.Validators))
+	if len(spec.Validators) != 5 {
+		t.Fatalf("validator count = %d, want 5", len(spec.Validators))
 	}
 	if spec.Validators[0].Type != ValidatorTypeFuzzyMatch {
 		t.Fatalf("validator[0].type = %s, want %s", spec.Validators[0].Type, ValidatorTypeFuzzyMatch)
@@ -230,8 +237,11 @@ func TestLoadEvaluationSpecAcceptsStringMatchValidators(t *testing.T) {
 	if spec.Validators[2].Type != ValidatorTypeNormalizedMatch {
 		t.Fatalf("validator[2].type = %s, want %s", spec.Validators[2].Type, ValidatorTypeNormalizedMatch)
 	}
-	if spec.Validators[3].Type != ValidatorTypeMathEquivalence {
-		t.Fatalf("validator[3].type = %s, want %s", spec.Validators[3].Type, ValidatorTypeMathEquivalence)
+	if spec.Validators[3].Type != ValidatorTypeTokenF1 {
+		t.Fatalf("validator[3].type = %s, want %s", spec.Validators[3].Type, ValidatorTypeTokenF1)
+	}
+	if spec.Validators[4].Type != ValidatorTypeMathEquivalence {
+		t.Fatalf("validator[4].type = %s, want %s", spec.Validators[4].Type, ValidatorTypeMathEquivalence)
 	}
 	if len(spec.Validators[0].Config) == 0 {
 		t.Fatal("validator[0].config is empty, want threshold config")
@@ -369,6 +379,34 @@ func TestLoadEvaluationSpecRejectsInvalidMathEquivalenceConfig(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "evaluation_spec.validators[0].config.tolerance must be greater than or equal to 0") {
 		t.Fatalf("error = %q, want tolerance validation", err.Error())
+	}
+}
+
+func TestLoadEvaluationSpecRejectsInvalidTokenF1Config(t *testing.T) {
+	_, err := LoadEvaluationSpec(json.RawMessage(`{
+		"evaluation_spec": {
+			"name": "token-f1-invalid",
+			"version_number": 1,
+			"judge_mode": "deterministic",
+			"validators": [
+				{
+					"key": "token_f1",
+					"type": "token_f1",
+					"target": "final_output",
+					"expected_from": "literal:hello world",
+					"config": {"threshold": 1.5}
+				}
+			],
+			"scorecard": {
+				"dimensions": ["correctness"]
+			}
+		}
+	}`))
+	if err == nil {
+		t.Fatal("LoadEvaluationSpec returned nil error")
+	}
+	if !strings.Contains(err.Error(), "evaluation_spec.validators[0].config.threshold must be between 0 and 1") {
+		t.Fatalf("error = %q, want threshold validation", err.Error())
 	}
 }
 

--- a/backend/internal/scoring/spec.go
+++ b/backend/internal/scoring/spec.go
@@ -26,6 +26,7 @@ const (
 	ValidatorTypeFuzzyMatch      ValidatorType = "fuzzy_match"
 	ValidatorTypeNumericMatch    ValidatorType = "numeric_match"
 	ValidatorTypeNormalizedMatch ValidatorType = "normalized_match"
+	ValidatorTypeTokenF1         ValidatorType = "token_f1"
 	ValidatorTypeMathEquivalence ValidatorType = "math_equivalence"
 	ValidatorTypeBLEUScore       ValidatorType = "bleu_score"
 	ValidatorTypeROUGEScore      ValidatorType = "rouge_score"
@@ -331,7 +332,7 @@ func (t ValidatorType) IsValid() bool {
 	switch t {
 	case ValidatorTypeExactMatch, ValidatorTypeContains, ValidatorTypeRegexMatch,
 		ValidatorTypeJSONSchema, ValidatorTypeJSONPathMatch, ValidatorTypeBooleanAssert,
-		ValidatorTypeFuzzyMatch, ValidatorTypeNumericMatch, ValidatorTypeNormalizedMatch,
+		ValidatorTypeFuzzyMatch, ValidatorTypeNumericMatch, ValidatorTypeNormalizedMatch, ValidatorTypeTokenF1,
 		ValidatorTypeMathEquivalence, ValidatorTypeBLEUScore, ValidatorTypeROUGEScore, ValidatorTypeChrFScore,
 		ValidatorTypeFileContentMatch, ValidatorTypeFileExists,
 		ValidatorTypeFileJSONSchema, ValidatorTypeDirectoryStructure,

--- a/backend/internal/scoring/string_validators.go
+++ b/backend/internal/scoring/string_validators.go
@@ -279,6 +279,13 @@ type normalizedMatchConfig struct {
 	Normalizations []string `json:"normalizations"`
 }
 
+type tokenF1Config struct {
+	Threshold         *float64 `json:"threshold"`
+	Normalize         bool     `json:"normalize"`
+	RemoveArticles    bool     `json:"remove_articles"`
+	RemovePunctuation bool     `json:"remove_punctuation"`
+}
+
 var knownPipelineSteps = map[string]bool{
 	"trim":                true,
 	"lowercase":           true,
@@ -329,6 +336,99 @@ func validateNormalizedMatch(actual string, expected string, rawConfig json.RawM
 		reason:          "normalized values do not match",
 		evidence:        evidence,
 	}
+}
+
+// --- token_f1 ---
+
+const defaultTokenF1Threshold = 0.5
+
+func validateTokenF1(actual string, expected string, rawConfig json.RawMessage) validatorOutcome {
+	config, err := parseTokenF1Config(rawConfig)
+	if err != nil {
+		return validatorError("parse token_f1 config", err, nil)
+	}
+
+	pipeline := config.pipeline()
+	normalizedActual, err := applyTokenF1Normalization(actual, pipeline)
+	if err != nil {
+		return validatorError("normalize token_f1 actual value", err, nil)
+	}
+	normalizedExpected, err := applyTokenF1Normalization(expected, pipeline)
+	if err != nil {
+		return validatorError("normalize token_f1 expected value", err, nil)
+	}
+
+	predictionTokens := strings.Fields(normalizedActual)
+	referenceTokens := strings.Fields(normalizedExpected)
+	precision, recall, score, overlap := tokenF1Score(predictionTokens, referenceTokens)
+
+	return thresholdedOutcome(score, thresholdOrDefault(config.Threshold, defaultTokenF1Threshold), map[string]any{
+		"normalized_actual":      normalizedActual,
+		"normalized_expected":    normalizedExpected,
+		"pipeline":               pipeline,
+		"prediction_tokens":      predictionTokens,
+		"reference_tokens":       referenceTokens,
+		"prediction_token_count": len(predictionTokens),
+		"reference_token_count":  len(referenceTokens),
+		"overlap_token_count":    overlap,
+		"precision":              precision,
+		"recall":                 recall,
+	})
+}
+
+func applyTokenF1Normalization(value string, pipeline []string) (string, error) {
+	if len(pipeline) == 0 {
+		return value, nil
+	}
+	return applyNormalizationPipeline(value, pipeline)
+}
+
+func (c tokenF1Config) pipeline() []string {
+	pipeline := make([]string, 0, len(defaultPipeline)+4)
+	if c.Normalize {
+		pipeline = append(pipeline, defaultPipeline...)
+	}
+	if c.RemovePunctuation {
+		pipeline = append(pipeline, "strip_punctuation")
+	}
+	if c.RemoveArticles {
+		pipeline = append(pipeline, "remove_articles")
+	}
+	if len(pipeline) == 0 {
+		return nil
+	}
+	return append(pipeline, "collapse_whitespace", "trim")
+}
+
+func tokenF1Score(predictionTokens []string, referenceTokens []string) (precision float64, recall float64, score float64, overlap int) {
+	switch {
+	case len(predictionTokens) == 0 && len(referenceTokens) == 0:
+		return 1, 1, 1, 0
+	case len(predictionTokens) == 0 || len(referenceTokens) == 0:
+		return 0, 0, 0, 0
+	}
+
+	predictionCounts := tokenCounts(predictionTokens)
+	referenceCounts := tokenCounts(referenceTokens)
+	for token, predictionCount := range predictionCounts {
+		overlap += min(predictionCount, referenceCounts[token])
+	}
+
+	precision = float64(overlap) / float64(len(predictionTokens))
+	recall = float64(overlap) / float64(len(referenceTokens))
+	if precision == 0 || recall == 0 {
+		return precision, recall, 0, overlap
+	}
+	score = (2 * precision * recall) / (precision + recall)
+	return precision, recall, score, overlap
+}
+
+func tokenCounts(tokens []string) map[string]int {
+	counts := make(map[string]int, len(tokens))
+	for _, token := range tokens {
+		counts[token]++
+	}
+	return counts
 }
 
 func applyNormalizationPipeline(s string, pipeline []string) (string, error) {
@@ -499,6 +599,17 @@ func (c normalizedMatchConfig) pipeline() ([]string, error) {
 		return c.Normalizations, nil
 	}
 	return defaultPipeline, nil
+}
+
+func parseTokenF1Config(rawConfig json.RawMessage) (tokenF1Config, error) {
+	var config tokenF1Config
+	if len(rawConfig) == 0 {
+		return config, nil
+	}
+	if err := decodeStrictJSON(rawConfig, &config); err != nil {
+		return tokenF1Config{}, err
+	}
+	return config, nil
 }
 
 func runeCountWithinLimit(s string, limit int) (int, bool) {

--- a/backend/internal/scoring/string_validators.go
+++ b/backend/internal/scoring/string_validators.go
@@ -349,11 +349,11 @@ func validateTokenF1(actual string, expected string, rawConfig json.RawMessage) 
 	}
 
 	pipeline := config.pipeline()
-	normalizedActual, err := applyTokenF1Normalization(actual, pipeline)
+	normalizedActual, err := applyNormalizationPipeline(actual, pipeline)
 	if err != nil {
 		return validatorError("normalize token_f1 actual value", err, nil)
 	}
-	normalizedExpected, err := applyTokenF1Normalization(expected, pipeline)
+	normalizedExpected, err := applyNormalizationPipeline(expected, pipeline)
 	if err != nil {
 		return validatorError("normalize token_f1 expected value", err, nil)
 	}
@@ -374,13 +374,6 @@ func validateTokenF1(actual string, expected string, rawConfig json.RawMessage) 
 		"precision":              precision,
 		"recall":                 recall,
 	})
-}
-
-func applyTokenF1Normalization(value string, pipeline []string) (string, error) {
-	if len(pipeline) == 0 {
-		return value, nil
-	}
-	return applyNormalizationPipeline(value, pipeline)
 }
 
 func (c tokenF1Config) pipeline() []string {

--- a/backend/internal/scoring/string_validators_test.go
+++ b/backend/internal/scoring/string_validators_test.go
@@ -508,6 +508,110 @@ func TestValidateNormalizedMatch_Errors(t *testing.T) {
 	}
 }
 
+// --- validateTokenF1 ---
+
+func TestValidateTokenF1(t *testing.T) {
+	tests := []struct {
+		name          string
+		actual        string
+		expected      string
+		config        string
+		wantVerdict   string
+		wantScore     float64
+		wantPrecision float64
+		wantRecall    float64
+	}{
+		{
+			name:          "exact_match_scores_one",
+			actual:        "eiffel tower in paris",
+			expected:      "eiffel tower in paris",
+			config:        `{}`,
+			wantVerdict:   "pass",
+			wantScore:     1.0,
+			wantPrecision: 1.0,
+			wantRecall:    1.0,
+		},
+		{
+			name:          "partial_overlap_scores_between_zero_and_one",
+			actual:        "eiffel tower",
+			expected:      "eiffel tower paris",
+			config:        `{"threshold": 0.9}`,
+			wantVerdict:   "fail",
+			wantScore:     0.8,
+			wantPrecision: 1.0,
+			wantRecall:    2.0 / 3.0,
+		},
+		{
+			name:          "no_overlap_scores_zero",
+			actual:        "louvre museum",
+			expected:      "eiffel tower",
+			config:        `{}`,
+			wantVerdict:   "fail",
+			wantScore:     0.0,
+			wantPrecision: 0.0,
+			wantRecall:    0.0,
+		},
+		{
+			name:          "normalization_removes_articles_and_punctuation",
+			actual:        "The Eiffel Tower!",
+			expected:      "eiffel tower",
+			config:        `{"threshold": 1.0, "normalize": true, "remove_articles": true, "remove_punctuation": true}`,
+			wantVerdict:   "pass",
+			wantScore:     1.0,
+			wantPrecision: 1.0,
+			wantRecall:    1.0,
+		},
+		{
+			name:          "empty_prediction_scores_zero",
+			actual:        "",
+			expected:      "eiffel tower",
+			config:        `{}`,
+			wantVerdict:   "fail",
+			wantScore:     0.0,
+			wantPrecision: 0.0,
+			wantRecall:    0.0,
+		},
+		{
+			name:          "both_empty_scores_one",
+			actual:        "",
+			expected:      "",
+			config:        `{}`,
+			wantVerdict:   "pass",
+			wantScore:     1.0,
+			wantPrecision: 1.0,
+			wantRecall:    1.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outcome := validateTokenF1(tt.actual, tt.expected, json.RawMessage(tt.config))
+			if outcome.verdict != tt.wantVerdict {
+				t.Fatalf("verdict = %q, want %q (reason: %s)", outcome.verdict, tt.wantVerdict, outcome.reason)
+			}
+			if outcome.normalizedScore == nil {
+				t.Fatal("normalizedScore is nil")
+			}
+			if math.Abs(*outcome.normalizedScore-tt.wantScore) > 1e-9 {
+				t.Fatalf("normalizedScore = %f, want %f", *outcome.normalizedScore, tt.wantScore)
+			}
+			if got := outcome.evidence["precision"].(float64); math.Abs(got-tt.wantPrecision) > 1e-9 {
+				t.Fatalf("precision = %f, want %f", got, tt.wantPrecision)
+			}
+			if got := outcome.evidence["recall"].(float64); math.Abs(got-tt.wantRecall) > 1e-9 {
+				t.Fatalf("recall = %f, want %f", got, tt.wantRecall)
+			}
+		})
+	}
+}
+
+func TestValidateTokenF1_Errors(t *testing.T) {
+	outcome := validateTokenF1("a", "b", json.RawMessage(`{bad json`))
+	if outcome.verdict != "error" {
+		t.Fatalf("verdict = %q, want error", outcome.verdict)
+	}
+}
+
 // --- applyNormalizationPipeline ---
 
 func TestApplyNormalizationPipeline(t *testing.T) {

--- a/backend/internal/scoring/string_validators_test.go
+++ b/backend/internal/scoring/string_validators_test.go
@@ -542,6 +542,16 @@ func TestValidateTokenF1(t *testing.T) {
 			wantRecall:    2.0 / 3.0,
 		},
 		{
+			name:          "duplicate_tokens_use_bag_overlap_not_set_overlap",
+			actual:        "paris paris paris",
+			expected:      "paris tower",
+			config:        `{"threshold": 0.5}`,
+			wantVerdict:   "fail",
+			wantScore:     0.4,
+			wantPrecision: 1.0 / 3.0,
+			wantRecall:    0.5,
+		},
+		{
 			name:          "no_overlap_scores_zero",
 			actual:        "louvre museum",
 			expected:      "eiffel tower",

--- a/backend/internal/scoring/validation.go
+++ b/backend/internal/scoring/validation.go
@@ -678,6 +678,16 @@ func validateValidatorConfig(validator ValidatorDeclaration, path string) Valida
 			}
 		}
 
+	case ValidatorTypeTokenF1:
+		cfg, err := parseTokenF1Config(validator.Config)
+		if err != nil {
+			errs = append(errs, ValidationError{Field: configPath, Message: configParseErrorMessage(err)})
+			return errs
+		}
+		if cfg.Threshold != nil && (*cfg.Threshold < 0 || *cfg.Threshold > 1) {
+			errs = append(errs, ValidationError{Field: configPath + ".threshold", Message: "must be between 0 and 1"})
+		}
+
 	case ValidatorTypeMathEquivalence:
 		cfg, err := parseMathEquivalenceConfig(validator.Config)
 		if err != nil {

--- a/testing/codex-issue-267-token-f1.md
+++ b/testing/codex-issue-267-token-f1.md
@@ -1,0 +1,48 @@
+# Issue 267: token_f1 validator contract
+
+## Functional expectations
+
+1. Add a new deterministic validator type `token_f1`.
+2. `token_f1` must compute token-overlap precision, recall, and F1 using whitespace tokenization (`strings.Fields`).
+3. The validator must support config-driven normalization by reusing the existing normalization pipeline before tokenization.
+4. The validator config must accept:
+   - `threshold` in `[0,1]`
+   - `normalize` as a shorthand for the default normalization pipeline
+   - `remove_articles`
+   - `remove_punctuation`
+5. When shorthand booleans are enabled, normalization must be applied in a predictable order before tokenization:
+   - default normalize pipeline when `normalize=true`
+   - punctuation stripping when `remove_punctuation=true`
+   - article removal when `remove_articles=true`
+   - whitespace collapse before tokenization
+6. Exact token overlap must yield score `1.0` and verdict `pass`.
+7. Partial overlap must yield a score strictly between `0` and `1`, with pass/fail determined by `threshold`.
+8. No token overlap must yield score `0.0` and verdict `fail` unless threshold is `0`.
+9. Empty prediction with non-empty reference must yield score `0.0`.
+10. Empty reference with non-empty prediction must yield score `0.0`.
+11. Empty prediction and empty reference must yield score `1.0`.
+12. Validator evidence must include the computed score components needed to inspect the result.
+13. `token_f1` must be accepted by spec loading, validation, and runtime validator dispatch.
+
+## Tests to add or update
+
+- Unit tests in `backend/internal/scoring/string_validators_test.go`
+  - exact match
+  - partial overlap
+  - no overlap
+  - normalization via `normalize`, `remove_articles`, and `remove_punctuation`
+  - empty prediction/reference edge cases
+  - invalid config / invalid threshold
+- Spec-loading and config-validation coverage in:
+  - `backend/internal/scoring/loader_test.go`
+  - `backend/internal/scoring/validation.go` via loader-facing tests
+- Integration-style engine coverage in `backend/internal/scoring/engine_test.go`
+  - pass above threshold
+  - fail below threshold
+  - normalized comparison behavior
+
+## Manual verification
+
+1. Run targeted scoring tests for the backend package.
+2. Confirm the new validator type is accepted by spec loading and produces validator results with normalized scores.
+3. Confirm no unrelated scoring validator tests regress.


### PR DESCRIPTION
## Summary
- add a new deterministic `token_f1` validator to the scoring spec and runtime validator dispatch
- implement token-overlap precision/recall/F1 scoring with optional normalization, article removal, and punctuation stripping
- add contract-first coverage in `testing/codex-issue-267-token-f1.md` plus loader, validator, and engine tests

## Why
Issue #267 requests token-level F1 scoring for QA-style answer evaluation. The backend supported exact, fuzzy, and normalized matching, but it did not have a token-overlap validator that preserved graduated scores while still supporting thresholded pass/fail.

## Impact
Users can now declare `token_f1` validators in deterministic scoring specs and get token-level overlap scoring with inspectable evidence.

## Validation
- `go test ./internal/scoring`

Closes #267