### PR TITLE
Fix CLI browser auth flow

### DIFF
--- a/backend/internal/api/cli_auth.go
+++ b/backend/internal/api/cli_auth.go
@@ -33,6 +33,7 @@ type CLIAuthService interface {
 	CreateDeviceCode(ctx context.Context) (CreateDeviceCodeResult, error)
 	PollDeviceToken(ctx context.Context, deviceCode string) (PollDeviceTokenResult, error)
 	ApproveDeviceCode(ctx context.Context, caller Caller, userCode string) error
+	DenyDeviceCode(ctx context.Context, caller Caller, userCode string) error
 	CreateCLIToken(ctx context.Context, caller Caller, name string) (CreateCLITokenResult, error)
 	ListCLITokens(ctx context.Context, caller Caller) ([]CLITokenSummary, error)
 	RevokeCLIToken(ctx context.Context, caller Caller, tokenID uuid.UUID) error
@@ -74,6 +75,7 @@ type CLIAuthRepository interface {
 	CreateDeviceAuthCode(ctx context.Context, deviceCode, userCode string, expiresAt time.Time) (repository.DeviceAuthCode, error)
 	GetDeviceAuthCodeByDeviceCode(ctx context.Context, deviceCode string) (repository.DeviceAuthCode, error)
 	ApproveDeviceAuthCodeWithToken(ctx context.Context, userCode string, userID uuid.UUID, tokenHash, tokenName, rawToken string, expiresAt *time.Time) (repository.CLIToken, error)
+	DenyDeviceAuthCode(ctx context.Context, userCode string) error
 	ConsumeDeviceRawToken(ctx context.Context, id uuid.UUID) (string, error)
 	ExpireDeviceAuthCode(ctx context.Context, id uuid.UUID) error
 	ExpireStaleDeviceAuthCodes(ctx context.Context) error
@@ -112,8 +114,8 @@ func (m *CLIAuthManager) CreateDeviceCode(ctx context.Context) (CreateDeviceCode
 		return CreateDeviceCodeResult{}, fmt.Errorf("storing device code: %w", err)
 	}
 
-	verificationURI := "/auth/device"
-	verificationURIComplete := m.frontendURL + verificationURI + "?user_code=" + url.QueryEscape(userCode)
+	verificationURI := m.frontendURL + "/auth/device"
+	verificationURIComplete := verificationURI + "?user_code=" + url.QueryEscape(userCode)
 
 	return CreateDeviceCodeResult{
 		DeviceCode:              deviceCode,
@@ -184,6 +186,23 @@ func (m *CLIAuthManager) ApproveDeviceCode(ctx context.Context, caller Caller, u
 			return fmt.Errorf("device code not found or expired")
 		default:
 			return fmt.Errorf("approving device code: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (m *CLIAuthManager) DenyDeviceCode(ctx context.Context, _ Caller, userCode string) error {
+	m.cleanupExpiredCodes(ctx)
+
+	if err := m.repo.DenyDeviceAuthCode(ctx, normalizeUserCode(userCode)); err != nil {
+		switch {
+		case errors.Is(err, repository.ErrDeviceCodeExpired):
+			return fmt.Errorf("device code expired")
+		case errors.Is(err, repository.ErrDeviceCodeNotFound):
+			return fmt.Errorf("device code not found or expired")
+		default:
+			return fmt.Errorf("denying device code: %w", err)
 		}
 	}
 
@@ -331,6 +350,35 @@ func approveDeviceCodeHandler(logger *slog.Logger, service CLIAuthService) http.
 		}
 
 		if err := service.ApproveDeviceCode(r.Context(), caller, input.UserCode); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+	}
+}
+
+func denyDeviceCodeHandler(logger *slog.Logger, service CLIAuthService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "authentication required")
+			return
+		}
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+
+		var input struct {
+			UserCode string `json:"user_code"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil || input.UserCode == "" {
+			writeError(w, http.StatusBadRequest, "invalid_request", "user_code is required")
+			return
+		}
+
+		if err := service.DenyDeviceCode(r.Context(), caller, input.UserCode); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
 			return
 		}

--- a/backend/internal/api/cli_auth_routes_test.go
+++ b/backend/internal/api/cli_auth_routes_test.go
@@ -20,7 +20,7 @@ func (stubCLIAuthService) CreateDeviceCode(_ context.Context) (CreateDeviceCodeR
 	return CreateDeviceCodeResult{
 		DeviceCode:              "dc_test",
 		UserCode:                "ABCD-EFGH",
-		VerificationURI:         "/auth/device",
+		VerificationURI:         "http://localhost:3000/auth/device",
 		VerificationURIComplete: "http://localhost:3000/auth/device?user_code=ABCD-EFGH",
 		ExpiresIn:               600,
 		Interval:                5,
@@ -32,6 +32,10 @@ func (stubCLIAuthService) PollDeviceToken(_ context.Context, _ string) (PollDevi
 }
 
 func (stubCLIAuthService) ApproveDeviceCode(_ context.Context, _ Caller, _ string) error {
+	return nil
+}
+
+func (stubCLIAuthService) DenyDeviceCode(_ context.Context, _ Caller, _ string) error {
 	return nil
 }
 
@@ -140,6 +144,9 @@ func TestCLIAuthPublicDeviceRouteIsReachable(t *testing.T) {
 	if body.VerificationURIComplete == "" {
 		t.Fatal("verification_uri_complete should not be empty")
 	}
+	if body.VerificationURI != "http://localhost:3000/auth/device" {
+		t.Fatalf("verification_uri = %q, want absolute frontend URL", body.VerificationURI)
+	}
 }
 
 func TestCLIAuthProtectedTokensRouteIsReachable(t *testing.T) {
@@ -193,6 +200,46 @@ func TestCLIAuthProtectedTokensRouteIsReachable(t *testing.T) {
 
 func TestCLIAuthProtectedApproveRouteIsReachable(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v1/cli-auth/device/approve", bytes.NewBufferString(`{"user_code":"ABCD-EFGH"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(headerUserID, "11111111-1111-1111-1111-111111111111")
+	recorder := httptest.NewRecorder()
+
+	newRouter("dev", nil,
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		nil,
+		0,
+		stubRunCreationService{},
+		stubRunReadService{},
+		stubReplayReadService{},
+		stubHostedRunIngestionService{},
+		nil,
+		stubAgentDeploymentReadService{},
+		stubChallengePackReadService{},
+		stubAgentBuildService{},
+		noopReleaseGateService{},
+		stubChallengePackAuthoringService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		stubCLIAuthService{},
+	).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+}
+
+func TestCLIAuthProtectedDenyRouteIsReachable(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/v1/cli-auth/device/deny", bytes.NewBufferString(`{"user_code":"ABCD-EFGH"}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(headerUserID, "11111111-1111-1111-1111-111111111111")
 	recorder := httptest.NewRecorder()

--- a/backend/internal/api/cli_auth_test.go
+++ b/backend/internal/api/cli_auth_test.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+type fakeCLIAuthRepository struct {
+	createdDeviceCode repository.DeviceAuthCode
+	deviceByCode      repository.DeviceAuthCode
+	deniedUserCode    string
+	denyErr           error
+}
+
+func (f *fakeCLIAuthRepository) CreateCLIToken(context.Context, uuid.UUID, string, string, *time.Time) (repository.CLIToken, error) {
+	return repository.CLIToken{}, nil
+}
+
+func (f *fakeCLIAuthRepository) ListCLITokensByUserID(context.Context, uuid.UUID) ([]repository.CLIToken, error) {
+	return nil, nil
+}
+
+func (f *fakeCLIAuthRepository) RevokeCLIToken(context.Context, uuid.UUID, uuid.UUID) error {
+	return nil
+}
+
+func (f *fakeCLIAuthRepository) CreateDeviceAuthCode(_ context.Context, deviceCode, userCode string, expiresAt time.Time) (repository.DeviceAuthCode, error) {
+	f.createdDeviceCode = repository.DeviceAuthCode{
+		ID:         uuid.New(),
+		DeviceCode: deviceCode,
+		UserCode:   userCode,
+		Status:     "pending",
+		ExpiresAt:  expiresAt,
+		CreatedAt:  time.Now(),
+	}
+	return f.createdDeviceCode, nil
+}
+
+func (f *fakeCLIAuthRepository) GetDeviceAuthCodeByDeviceCode(context.Context, string) (repository.DeviceAuthCode, error) {
+	if f.deviceByCode.DeviceCode != "" {
+		return f.deviceByCode, nil
+	}
+	return repository.DeviceAuthCode{}, repository.ErrDeviceCodeNotFound
+}
+
+func (f *fakeCLIAuthRepository) ApproveDeviceAuthCodeWithToken(context.Context, string, uuid.UUID, string, string, string, *time.Time) (repository.CLIToken, error) {
+	return repository.CLIToken{}, nil
+}
+
+func (f *fakeCLIAuthRepository) DenyDeviceAuthCode(_ context.Context, userCode string) error {
+	f.deniedUserCode = userCode
+	return f.denyErr
+}
+
+func (f *fakeCLIAuthRepository) ConsumeDeviceRawToken(context.Context, uuid.UUID) (string, error) {
+	return "", nil
+}
+
+func (f *fakeCLIAuthRepository) ExpireDeviceAuthCode(context.Context, uuid.UUID) error {
+	return nil
+}
+
+func (f *fakeCLIAuthRepository) ExpireStaleDeviceAuthCodes(context.Context) error {
+	return nil
+}
+
+func TestCLIAuthManagerCreateDeviceCodeReturnsAbsoluteVerificationURLs(t *testing.T) {
+	repo := &fakeCLIAuthRepository{}
+	manager := NewCLIAuthManager(repo, slog.Default(), "https://app.agentclash.dev")
+
+	result, err := manager.CreateDeviceCode(context.Background())
+	if err != nil {
+		t.Fatalf("CreateDeviceCode() error = %v", err)
+	}
+	if result.VerificationURI != "https://app.agentclash.dev/auth/device" {
+		t.Fatalf("verification_uri = %q", result.VerificationURI)
+	}
+	if !strings.HasPrefix(result.VerificationURIComplete, "https://app.agentclash.dev/auth/device?user_code=") {
+		t.Fatalf("verification_uri_complete = %q", result.VerificationURIComplete)
+	}
+	if repo.createdDeviceCode.UserCode != result.UserCode {
+		t.Fatalf("stored user code = %q, want %q", repo.createdDeviceCode.UserCode, result.UserCode)
+	}
+}
+
+func TestCLIAuthManagerDenyDeviceCodeNormalizesUserCode(t *testing.T) {
+	repo := &fakeCLIAuthRepository{}
+	manager := NewCLIAuthManager(repo, slog.Default(), "https://app.agentclash.dev")
+
+	err := manager.DenyDeviceCode(context.Background(), Caller{UserID: uuid.New()}, "ab cd-efgh")
+	if err != nil {
+		t.Fatalf("DenyDeviceCode() error = %v", err)
+	}
+	if repo.deniedUserCode != "ABCD-EFGH" {
+		t.Fatalf("denied user code = %q, want ABCD-EFGH", repo.deniedUserCode)
+	}
+}
+
+func TestCLIAuthManagerPollDeviceTokenReturnsAccessDeniedForDeniedCode(t *testing.T) {
+	repo := &fakeCLIAuthRepository{
+		deviceByCode: repository.DeviceAuthCode{
+			ID:         uuid.New(),
+			DeviceCode: "dc_denied",
+			UserCode:   "ABCD-EFGH",
+			Status:     "denied",
+			ExpiresAt:  time.Now().Add(time.Hour),
+		},
+	}
+	manager := NewCLIAuthManager(repo, slog.Default(), "https://app.agentclash.dev")
+
+	_, err := manager.PollDeviceToken(context.Background(), "dc_denied")
+	if !errors.Is(err, errAccessDenied) {
+		t.Fatalf("PollDeviceToken() error = %v, want errAccessDenied", err)
+	}
+}

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -136,6 +136,7 @@ func registerProtectedRoutes(
 		router.Get("/cli-auth/tokens", listCLITokensHandler(logger, cliAuthService))
 		router.Delete("/cli-auth/tokens/{id}", revokeCLITokenHandler(logger, cliAuthService))
 		router.Post("/cli-auth/device/approve", approveDeviceCodeHandler(logger, cliAuthService))
+		router.Post("/cli-auth/device/deny", denyDeviceCodeHandler(logger, cliAuthService))
 	}
 
 	// Infrastructure CRUD — workspace-scoped create/list (skip if no service provided)

--- a/backend/internal/repository/cli_auth.go
+++ b/backend/internal/repository/cli_auth.go
@@ -216,6 +216,34 @@ func (r *Repository) ApproveDeviceAuthCodeWithToken(ctx context.Context, userCod
 	return token, nil
 }
 
+func (r *Repository) DenyDeviceAuthCode(ctx context.Context, userCode string) error {
+	tag, err := r.db.Exec(ctx, `
+		UPDATE device_auth_codes
+		SET status = 'denied', raw_token = NULL
+		WHERE user_code = $1 AND status = 'pending' AND expires_at > now()
+	`, userCode)
+	if err != nil {
+		return fmt.Errorf("deny device auth code: %w", err)
+	}
+	if tag.RowsAffected() > 0 {
+		return nil
+	}
+
+	var expired bool
+	err = r.db.QueryRow(ctx, `
+		SELECT expires_at <= now()
+		FROM device_auth_codes
+		WHERE user_code = $1 AND status = 'pending'
+	`, userCode).Scan(&expired)
+	if err == nil && expired {
+		return ErrDeviceCodeExpired
+	}
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("check denied device auth code expiry: %w", err)
+	}
+	return ErrDeviceCodeNotFound
+}
+
 func (r *Repository) ConsumeDeviceRawToken(ctx context.Context, id uuid.UUID) (string, error) {
 	var rawToken *string
 	err := r.db.QueryRow(ctx, `

--- a/backend/internal/repository/cli_auth_integration_test.go
+++ b/backend/internal/repository/cli_auth_integration_test.go
@@ -1,0 +1,132 @@
+package repository_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+)
+
+func TestRepositoryDeviceAuthApproveConsumesRawTokenOnce(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	code, err := repo.CreateDeviceAuthCode(ctx, "dc_consume", "ABCD-EFGH", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("CreateDeviceAuthCode() error = %v", err)
+	}
+	if _, err := repo.ApproveDeviceAuthCodeWithToken(ctx, "ABCD-EFGH", fixture.userID, "hash-consume", "CLI Device Login", "clitok_raw", nil); err != nil {
+		t.Fatalf("ApproveDeviceAuthCodeWithToken() error = %v", err)
+	}
+
+	rawToken, err := repo.ConsumeDeviceRawToken(ctx, code.ID)
+	if err != nil {
+		t.Fatalf("ConsumeDeviceRawToken() first error = %v", err)
+	}
+	if rawToken != "clitok_raw" {
+		t.Fatalf("first raw token = %q, want clitok_raw", rawToken)
+	}
+
+	rawToken, err = repo.ConsumeDeviceRawToken(ctx, code.ID)
+	if err != nil {
+		t.Fatalf("ConsumeDeviceRawToken() second error = %v", err)
+	}
+	if rawToken != "" {
+		t.Fatalf("second raw token = %q, want empty", rawToken)
+	}
+}
+
+func TestRepositoryDenyDeviceAuthCode(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	seedFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	code, err := repo.CreateDeviceAuthCode(ctx, "dc_deny", "WXYZ-2345", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("CreateDeviceAuthCode() error = %v", err)
+	}
+	if err := repo.DenyDeviceAuthCode(ctx, "WXYZ-2345"); err != nil {
+		t.Fatalf("DenyDeviceAuthCode() error = %v", err)
+	}
+
+	denied, err := repo.GetDeviceAuthCodeByDeviceCode(ctx, code.DeviceCode)
+	if err != nil {
+		t.Fatalf("GetDeviceAuthCodeByDeviceCode() error = %v", err)
+	}
+	if denied.Status != "denied" {
+		t.Fatalf("status = %q, want denied", denied.Status)
+	}
+}
+
+func TestRepositoryDenyDeviceAuthCodeRejectsExpiredCode(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	seedFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	if _, err := repo.CreateDeviceAuthCode(ctx, "dc_expired_deny", "JKLM-6789", time.Now().Add(-time.Minute)); err != nil {
+		t.Fatalf("CreateDeviceAuthCode() error = %v", err)
+	}
+	err := repo.DenyDeviceAuthCode(ctx, "JKLM-6789")
+	if !errors.Is(err, repository.ErrDeviceCodeExpired) {
+		t.Fatalf("DenyDeviceAuthCode() error = %v, want ErrDeviceCodeExpired", err)
+	}
+}
+
+func TestRepositoryExpireStaleDeviceAuthCodesRevokesOnlyUnusedApprovedTokens(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	unusedCode, err := repo.CreateDeviceAuthCode(ctx, "dc_unused", "QRST-2345", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("CreateDeviceAuthCode() unused error = %v", err)
+	}
+	if _, err := repo.ApproveDeviceAuthCodeWithToken(ctx, unusedCode.UserCode, fixture.userID, "hash-unused", "CLI Device Login", "clitok_unused", nil); err != nil {
+		t.Fatalf("ApproveDeviceAuthCodeWithToken() unused error = %v", err)
+	}
+	if _, err := db.Exec(ctx, `UPDATE device_auth_codes SET expires_at = now() - interval '1 minute' WHERE id = $1`, unusedCode.ID); err != nil {
+		t.Fatalf("expire unused device code: %v", err)
+	}
+
+	usedCode, err := repo.CreateDeviceAuthCode(ctx, "dc_used", "UVWX-6789", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("CreateDeviceAuthCode() used error = %v", err)
+	}
+	usedToken, err := repo.ApproveDeviceAuthCodeWithToken(ctx, usedCode.UserCode, fixture.userID, "hash-used", "CLI Device Login", "clitok_used", nil)
+	if err != nil {
+		t.Fatalf("ApproveDeviceAuthCodeWithToken() used error = %v", err)
+	}
+	if _, err := db.Exec(ctx, `UPDATE cli_tokens SET last_used_at = now() WHERE id = $1`, usedToken.ID); err != nil {
+		t.Fatalf("mark used token: %v", err)
+	}
+	if _, err := db.Exec(ctx, `UPDATE device_auth_codes SET expires_at = now() - interval '1 minute' WHERE id = $1`, usedCode.ID); err != nil {
+		t.Fatalf("expire used device code: %v", err)
+	}
+
+	if err := repo.ExpireStaleDeviceAuthCodes(ctx); err != nil {
+		t.Fatalf("ExpireStaleDeviceAuthCodes() error = %v", err)
+	}
+
+	unusedToken, err := repo.GetCLITokenByHash(ctx, "hash-unused")
+	if err != nil {
+		t.Fatalf("GetCLITokenByHash() unused error = %v", err)
+	}
+	if unusedToken.RevokedAt == nil {
+		t.Fatal("unused stale token should be revoked")
+	}
+
+	usedToken, err = repo.GetCLITokenByHash(ctx, "hash-used")
+	if err != nil {
+		t.Fatalf("GetCLITokenByHash() used error = %v", err)
+	}
+	if usedToken.RevokedAt != nil {
+		t.Fatal("used stale token should not be revoked")
+	}
+}

--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/Atharva-Kanherkar/agentclash/cli/internal/auth"
 	"github.com/Atharva-Kanherkar/agentclash/cli/internal/output"
@@ -9,6 +10,7 @@ import (
 )
 
 var flagDevice bool
+var flagForceLogin bool
 
 func init() {
 	rootCmd.AddCommand(authCmd)
@@ -20,6 +22,7 @@ func init() {
 	authTokensCmd.AddCommand(authTokensRevokeCmd)
 
 	authLoginCmd.Flags().BoolVar(&flagDevice, "device", false, "Print the verification URL instead of opening the browser automatically")
+	authLoginCmd.Flags().BoolVar(&flagForceLogin, "force", false, "Start a new browser login even if existing credentials are valid")
 }
 
 var authCmd = &cobra.Command{
@@ -36,9 +39,41 @@ The CLI prints a verification link, opens it in your default browser when possib
 and waits for you to approve the login in your AgentClash instance.
 
 For headless or remote shells, pass --device to print the link without auto-opening.
+Pass --force to create a fresh CLI token even when you are already logged in.
 For CI/CD, set the AGENTCLASH_TOKEN environment variable instead.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		rc := GetRunContext(cmd)
+
+		envTokenSet := os.Getenv("AGENTCLASH_TOKEN") != ""
+		if !flagForceLogin && rc.Client.Token() != "" {
+			result, err := auth.ValidateToken(cmd.Context(), rc.Client)
+			if err == nil {
+				if rc.Output.IsJSON() {
+					return rc.Output.PrintJSON(map[string]string{
+						"status":  "already_authenticated",
+						"source":  authSource(envTokenSet),
+						"user_id": result.UserID,
+						"email":   result.Email,
+					})
+				}
+
+				name := result.Display
+				if name == "" {
+					name = result.Email
+				}
+				if envTokenSet {
+					rc.Output.PrintSuccess(fmt.Sprintf("Already logged in as %s using AGENTCLASH_TOKEN", name))
+				} else {
+					rc.Output.PrintSuccess(fmt.Sprintf("Already logged in as %s", name))
+				}
+				return nil
+			}
+			if envTokenSet {
+				return fmt.Errorf("AGENTCLASH_TOKEN is set but could not be validated: %w", err)
+			}
+			rc.Output.PrintWarning("Stored credentials are invalid; starting a new browser login.")
+		}
+
 		autoOpen := !flagDevice && auth.CanOpenBrowser()
 		result, token, err := auth.VerificationLogin(cmd.Context(), rc.Client, autoOpen)
 		if err != nil {
@@ -52,6 +87,9 @@ For CI/CD, set the AGENTCLASH_TOKEN environment variable instead.`,
 		}
 		if err := auth.SaveCredentials(creds); err != nil {
 			return fmt.Errorf("saving credentials: %w", err)
+		}
+		if envTokenSet {
+			rc.Output.PrintWarning("Saved new credentials, but AGENTCLASH_TOKEN is still set and will take precedence.")
 		}
 
 		if rc.Output.IsJSON() {
@@ -68,6 +106,13 @@ For CI/CD, set the AGENTCLASH_TOKEN environment variable instead.`,
 		rc.Output.PrintSuccess(fmt.Sprintf("Logged in as %s", name))
 		return nil
 	},
+}
+
+func authSource(envTokenSet bool) string {
+	if envTokenSet {
+		return "env"
+	}
+	return "credentials"
 }
 
 var authLogoutCmd = &cobra.Command{

--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -4,9 +4,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/Atharva-Kanherkar/agentclash/cli/internal/auth"
 )
 
 // executeCommand runs a cobra command with args against a fake API server.
@@ -28,6 +31,8 @@ func executeCommand(t *testing.T, args []string, apiURL string) error {
 	flagWorkspace = ""
 	flagAPIURL = apiURL
 	flagYes = false
+	flagDevice = false
+	flagForceLogin = false
 
 	rootCmd.SetArgs(args)
 	return rootCmd.Execute()
@@ -333,6 +338,193 @@ func TestAuthHeaderSentToAPI(t *testing.T) {
 
 	if gotAuth != "Bearer my-secret-token" {
 		t.Fatalf("auth header = %q, want %q", gotAuth, "Bearer my-secret-token")
+	}
+}
+
+func TestAuthLoginSkipsDeviceFlowWhenStoredTokenValid(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("AGENTCLASH_TOKEN", "")
+	if err := auth.SaveCredentials(auth.Credentials{Token: "stored-token"}); err != nil {
+		t.Fatalf("SaveCredentials() error = %v", err)
+	}
+
+	var sessionCalls int
+	var deviceCalled bool
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/auth/session": func(w http.ResponseWriter, r *http.Request) {
+			sessionCalls++
+			if got := r.Header.Get("Authorization"); got != "Bearer stored-token" {
+				t.Fatalf("Authorization header = %q, want Bearer stored-token", got)
+			}
+			jsonHandler(200, map[string]any{
+				"user_id":      "user-1",
+				"email":        "dev@example.com",
+				"display_name": "Dev User",
+			})(w, r)
+		},
+		"POST /v1/cli-auth/device": func(w http.ResponseWriter, r *http.Request) {
+			deviceCalled = true
+			jsonHandler(201, map[string]any{})(w, r)
+		},
+	})
+	defer srv.Close()
+
+	if err := executeCommand(t, []string{"auth", "login", "--device"}, srv.URL); err != nil {
+		t.Fatalf("auth login error: %v", err)
+	}
+	if sessionCalls != 1 {
+		t.Fatalf("session calls = %d, want 1", sessionCalls)
+	}
+	if deviceCalled {
+		t.Fatal("device flow should not start when stored token is valid")
+	}
+}
+
+func TestAuthLoginSkipsDeviceFlowWhenEnvTokenValid(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("AGENTCLASH_TOKEN", "env-token")
+
+	var deviceCalled bool
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/auth/session": func(w http.ResponseWriter, r *http.Request) {
+			if got := r.Header.Get("Authorization"); got != "Bearer env-token" {
+				t.Fatalf("Authorization header = %q, want Bearer env-token", got)
+			}
+			jsonHandler(200, map[string]any{
+				"user_id": "user-1",
+				"email":   "dev@example.com",
+			})(w, r)
+		},
+		"POST /v1/cli-auth/device": func(w http.ResponseWriter, r *http.Request) {
+			deviceCalled = true
+			jsonHandler(201, map[string]any{})(w, r)
+		},
+	})
+	defer srv.Close()
+
+	if err := executeCommand(t, []string{"auth", "login", "--device"}, srv.URL); err != nil {
+		t.Fatalf("auth login error: %v", err)
+	}
+	if deviceCalled {
+		t.Fatal("device flow should not start when AGENTCLASH_TOKEN is valid")
+	}
+	if _, err := os.Stat(auth.CredentialsPath()); !os.IsNotExist(err) {
+		t.Fatalf("credentials file should not be written, stat error = %v", err)
+	}
+}
+
+func TestAuthLoginInvalidStoredTokenStartsDeviceFlow(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("AGENTCLASH_TOKEN", "")
+	if err := auth.SaveCredentials(auth.Credentials{Token: "stale-token"}); err != nil {
+		t.Fatalf("SaveCredentials() error = %v", err)
+	}
+
+	var deviceCalls int
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/auth/session": func(w http.ResponseWriter, r *http.Request) {
+			switch r.Header.Get("Authorization") {
+			case "Bearer stale-token":
+				jsonHandler(401, map[string]any{
+					"error": map[string]any{"code": "unauthorized", "message": "invalid token"},
+				})(w, r)
+			case "Bearer clitok_new":
+				jsonHandler(200, map[string]any{
+					"user_id":      "user-1",
+					"email":        "dev@example.com",
+					"display_name": "Dev User",
+				})(w, r)
+			default:
+				t.Fatalf("unexpected Authorization header %q", r.Header.Get("Authorization"))
+			}
+		},
+		"POST /v1/cli-auth/device": func(w http.ResponseWriter, r *http.Request) {
+			deviceCalls++
+			jsonHandler(201, map[string]any{
+				"device_code":               "dc_test",
+				"user_code":                 "ABCD-EFGH",
+				"verification_uri":          "https://agentclash.dev/auth/device",
+				"verification_uri_complete": "https://agentclash.dev/auth/device?user_code=ABCD-EFGH",
+				"expires_in":                60,
+				"interval":                  1,
+			})(w, r)
+		},
+		"POST /v1/cli-auth/device/token": jsonHandler(200, map[string]any{
+			"token": "clitok_new",
+		}),
+	})
+	defer srv.Close()
+
+	if err := executeCommand(t, []string{"auth", "login", "--device"}, srv.URL); err != nil {
+		t.Fatalf("auth login error: %v", err)
+	}
+	if deviceCalls != 1 {
+		t.Fatalf("device calls = %d, want 1", deviceCalls)
+	}
+	creds, err := auth.LoadCredentials()
+	if err != nil {
+		t.Fatalf("LoadCredentials() error = %v", err)
+	}
+	if creds.Token != "clitok_new" {
+		t.Fatalf("saved token = %q, want clitok_new", creds.Token)
+	}
+}
+
+func TestAuthLoginForceStartsDeviceFlowWhenStoredTokenValid(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("AGENTCLASH_TOKEN", "")
+	if err := auth.SaveCredentials(auth.Credentials{Token: "stored-token"}); err != nil {
+		t.Fatalf("SaveCredentials() error = %v", err)
+	}
+
+	var preflightCalls int
+	var deviceCalls int
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/auth/session": func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") == "Bearer stored-token" {
+				preflightCalls++
+			}
+			jsonHandler(200, map[string]any{
+				"user_id": "user-1",
+				"email":   "dev@example.com",
+			})(w, r)
+		},
+		"POST /v1/cli-auth/device": func(w http.ResponseWriter, r *http.Request) {
+			deviceCalls++
+			jsonHandler(201, map[string]any{
+				"device_code":               "dc_test",
+				"user_code":                 "ABCD-EFGH",
+				"verification_uri":          "https://agentclash.dev/auth/device",
+				"verification_uri_complete": "https://agentclash.dev/auth/device?user_code=ABCD-EFGH",
+				"expires_in":                60,
+				"interval":                  1,
+			})(w, r)
+		},
+		"POST /v1/cli-auth/device/token": jsonHandler(200, map[string]any{
+			"token": "clitok_forced",
+		}),
+	})
+	defer srv.Close()
+
+	if err := executeCommand(t, []string{"auth", "login", "--device", "--force"}, srv.URL); err != nil {
+		t.Fatalf("auth login error: %v", err)
+	}
+	if preflightCalls != 0 {
+		t.Fatalf("preflight calls = %d, want 0", preflightCalls)
+	}
+	if deviceCalls != 1 {
+		t.Fatalf("device calls = %d, want 1", deviceCalls)
+	}
+	creds, err := auth.LoadCredentials()
+	if err != nil {
+		t.Fatalf("LoadCredentials() error = %v", err)
+	}
+	if creds.Token != "clitok_forced" {
+		t.Fatalf("saved token = %q, want clitok_forced", creds.Token)
 	}
 }
 

--- a/cli/internal/auth/login.go
+++ b/cli/internal/auth/login.go
@@ -3,11 +3,18 @@ package auth
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"time"
 
 	"github.com/Atharva-Kanherkar/agentclash/cli/internal/api"
 	"github.com/Atharva-Kanherkar/agentclash/cli/internal/output"
+)
+
+const (
+	defaultDevicePollInterval = 5 * time.Second
+	defaultDeviceExpiresIn    = 10 * time.Minute
+	maxPollNetworkFailures    = 3
 )
 
 var openBrowserFunc = OpenBrowser
@@ -62,26 +69,32 @@ func VerificationLogin(ctx context.Context, client *api.Client, autoOpen bool) (
 	if err := resp.DecodeJSON(&deviceResp); err != nil {
 		return nil, "", fmt.Errorf("parsing verification response: %w", err)
 	}
-	if deviceResp.VerificationURIComplete == "" {
-		return nil, "", fmt.Errorf("verification response missing verification_uri_complete")
+	verifyURL, err := deviceVerificationURL(deviceResp)
+	if err != nil {
+		return nil, "", err
 	}
 
-	fmt.Fprintf(os.Stderr, "\n  Verify this login in your browser:\n  %s\n", output.Bold(deviceResp.VerificationURIComplete))
+	fmt.Fprintf(os.Stderr, "\n  Verify this login in your browser:\n  %s\n", output.Bold(verifyURL))
 	fmt.Fprintf(os.Stderr, "  Code: %s\n\n", output.Bold(deviceResp.UserCode))
 
 	if autoOpen {
 		fmt.Fprintf(os.Stderr, "%s Opening browser to continue login...\n", output.Cyan("▸"))
-		if err := openBrowserFunc(deviceResp.VerificationURIComplete); err != nil {
+		if err := openBrowserFunc(verifyURL); err != nil {
 			fmt.Fprintf(os.Stderr, "%s Could not open browser automatically. Open the link above manually.\n", output.Yellow("!"))
 		}
 	}
 
 	interval := time.Duration(deviceResp.Interval) * time.Second
 	if interval <= 0 {
-		interval = 5 * time.Second
+		interval = defaultDevicePollInterval
 	}
-	deadline := time.Now().Add(time.Duration(deviceResp.ExpiresIn) * time.Second)
+	expiresIn := time.Duration(deviceResp.ExpiresIn) * time.Second
+	if expiresIn <= 0 {
+		expiresIn = defaultDeviceExpiresIn
+	}
+	deadline := time.Now().Add(expiresIn)
 	sp := output.NewSpinner("Waiting for browser verification...", false)
+	networkFailures := 0
 
 	for time.Now().Before(deadline) {
 		if err := waitForPoll(ctx, interval); err != nil {
@@ -93,29 +106,42 @@ func VerificationLogin(ctx context.Context, client *api.Client, autoOpen bool) (
 			"device_code": deviceResp.DeviceCode,
 		})
 		if err != nil {
+			networkFailures++
+			if networkFailures >= maxPollNetworkFailures {
+				sp.StopWithError("Verification failed")
+				return nil, "", fmt.Errorf("polling verification failed after %d attempts: %w", networkFailures, err)
+			}
 			continue
 		}
+		networkFailures = 0
 		if apiErr := pollResp.ParseError(); apiErr != nil {
 			switch apiErr.Code {
 			case "authorization_pending":
+				continue
+			case "slow_down":
+				interval += 5 * time.Second
+				sp.Update("Waiting for browser verification...")
 				continue
 			case "access_denied":
 				sp.StopWithError("Authorization denied")
 				return nil, "", fmt.Errorf("authorization denied by user")
 			case "expired_token":
 				sp.StopWithError("Verification expired")
-				return nil, "", fmt.Errorf("verification expired — run 'agentclash auth login' again")
+				return nil, "", fmt.Errorf("verification expired - run 'agentclash auth login' again")
 			default:
-				continue
+				sp.StopWithError("Verification failed")
+				return nil, "", fmt.Errorf("verification failed: %s", apiErr.Message)
 			}
 		}
 
 		var tokenResp pollDeviceTokenResponse
 		if err := pollResp.DecodeJSON(&tokenResp); err != nil {
-			continue
+			sp.StopWithError("Verification failed")
+			return nil, "", fmt.Errorf("parsing token response: %w", err)
 		}
 		if tokenResp.Token == "" {
-			continue
+			sp.StopWithError("Verification failed")
+			return nil, "", fmt.Errorf("token response missing token")
 		}
 
 		loginResult, err := ValidateToken(ctx, api.NewClient(client.BaseURL(), tokenResp.Token))
@@ -129,7 +155,34 @@ func VerificationLogin(ctx context.Context, client *api.Client, autoOpen bool) (
 	}
 
 	sp.StopWithError("Timed out")
-	return nil, "", fmt.Errorf("verification expired — run 'agentclash auth login' again")
+	return nil, "", fmt.Errorf("verification expired - run 'agentclash auth login' again")
+}
+
+func deviceVerificationURL(resp createDeviceCodeResponse) (string, error) {
+	if resp.UserCode == "" {
+		return "", fmt.Errorf("verification response missing user_code")
+	}
+	if resp.DeviceCode == "" {
+		return "", fmt.Errorf("verification response missing device_code")
+	}
+	if resp.VerificationURIComplete != "" {
+		return resp.VerificationURIComplete, nil
+	}
+	if resp.VerificationURI == "" {
+		return "", fmt.Errorf("verification response missing verification_uri_complete and verification_uri")
+	}
+
+	parsed, err := url.Parse(resp.VerificationURI)
+	if err != nil {
+		return "", fmt.Errorf("parsing verification_uri: %w", err)
+	}
+	if !parsed.IsAbs() {
+		return "", fmt.Errorf("verification response missing verification_uri_complete and absolute verification_uri")
+	}
+	q := parsed.Query()
+	q.Set("user_code", resp.UserCode)
+	parsed.RawQuery = q.Encode()
+	return parsed.String(), nil
 }
 
 // ValidateToken checks the token against the session endpoint.

--- a/cli/internal/auth/login_test.go
+++ b/cli/internal/auth/login_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -12,7 +13,8 @@ import (
 	"github.com/Atharva-Kanherkar/agentclash/cli/internal/api"
 )
 
-func TestVerificationLoginAutoOpensBrowserAndReturnsValidatedIdentity(t *testing.T) {
+func resetLoginTestHooks(t *testing.T) {
+	t.Helper()
 	t.Cleanup(func() {
 		openBrowserFunc = OpenBrowser
 		waitForPoll = func(ctx context.Context, d time.Duration) error {
@@ -26,6 +28,10 @@ func TestVerificationLoginAutoOpensBrowserAndReturnsValidatedIdentity(t *testing
 			}
 		}
 	})
+}
+
+func TestVerificationLoginAutoOpensBrowserAndReturnsValidatedIdentity(t *testing.T) {
+	resetLoginTestHooks(t)
 
 	var openedURL string
 	openBrowserFunc = func(url string) error {
@@ -86,19 +92,7 @@ func TestVerificationLoginAutoOpensBrowserAndReturnsValidatedIdentity(t *testing
 }
 
 func TestVerificationLoginCanSkipBrowserOpen(t *testing.T) {
-	t.Cleanup(func() {
-		openBrowserFunc = OpenBrowser
-		waitForPoll = func(ctx context.Context, d time.Duration) error {
-			timer := time.NewTimer(d)
-			defer timer.Stop()
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-timer.C:
-				return nil
-			}
-		}
-	})
+	resetLoginTestHooks(t)
 
 	openBrowserCalled := false
 	openBrowserFunc = func(url string) error {
@@ -140,5 +134,239 @@ func TestVerificationLoginCanSkipBrowserOpen(t *testing.T) {
 	}
 	if openBrowserCalled {
 		t.Fatal("OpenBrowser should not be called when autoOpen is false")
+	}
+}
+
+func TestVerificationLoginFallsBackToVerificationURI(t *testing.T) {
+	resetLoginTestHooks(t)
+
+	var openedURL string
+	openBrowserFunc = func(url string) error {
+		openedURL = url
+		return nil
+	}
+	waitForPoll = func(context.Context, time.Duration) error { return nil }
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case "POST /v1/cli-auth/device":
+			json.NewEncoder(w).Encode(map[string]any{
+				"device_code":      "dc_test",
+				"user_code":        "ABCD-EFGH",
+				"verification_uri": "https://agentclash.dev/auth/device",
+				"expires_in":       60,
+				"interval":         1,
+			})
+		case "POST /v1/cli-auth/device/token":
+			json.NewEncoder(w).Encode(map[string]any{"token": "clitok_test"})
+		case "GET /v1/auth/session":
+			json.NewEncoder(w).Encode(map[string]any{
+				"user_id": "user-123",
+				"email":   "dev@example.com",
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	if _, _, err := VerificationLogin(context.Background(), api.NewClient(srv.URL, ""), true); err != nil {
+		t.Fatalf("VerificationLogin() error = %v", err)
+	}
+	if openedURL != "https://agentclash.dev/auth/device?user_code=ABCD-EFGH" {
+		t.Fatalf("opened URL = %q", openedURL)
+	}
+}
+
+func TestVerificationLoginRejectsMissingVerificationURL(t *testing.T) {
+	resetLoginTestHooks(t)
+	waitForPoll = func(context.Context, time.Duration) error { return nil }
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case "POST /v1/cli-auth/device":
+			json.NewEncoder(w).Encode(map[string]any{
+				"device_code":      "dc_test",
+				"user_code":        "ABCD-EFGH",
+				"verification_uri": "/auth/device",
+				"expires_in":       60,
+				"interval":         1,
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	_, _, err := VerificationLogin(context.Background(), api.NewClient(srv.URL, ""), false)
+	if err == nil || !strings.Contains(err.Error(), "absolute verification_uri") {
+		t.Fatalf("error = %v, want absolute verification_uri error", err)
+	}
+}
+
+func TestVerificationLoginHandlesSlowDownThenSuccess(t *testing.T) {
+	resetLoginTestHooks(t)
+
+	var intervals []time.Duration
+	waitForPoll = func(_ context.Context, d time.Duration) error {
+		intervals = append(intervals, d)
+		return nil
+	}
+	var polls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case "POST /v1/cli-auth/device":
+			json.NewEncoder(w).Encode(map[string]any{
+				"device_code":               "dc_test",
+				"user_code":                 "ABCD-EFGH",
+				"verification_uri":          "https://agentclash.dev/auth/device",
+				"verification_uri_complete": "https://agentclash.dev/auth/device?user_code=ABCD-EFGH",
+				"expires_in":                60,
+				"interval":                  1,
+			})
+		case "POST /v1/cli-auth/device/token":
+			if polls.Add(1) == 1 {
+				w.WriteHeader(http.StatusBadRequest)
+				json.NewEncoder(w).Encode(map[string]any{
+					"error": map[string]any{"code": "slow_down", "message": "poll slower"},
+				})
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]any{"token": "clitok_test"})
+		case "GET /v1/auth/session":
+			json.NewEncoder(w).Encode(map[string]any{
+				"user_id": "user-123",
+				"email":   "dev@example.com",
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	if _, _, err := VerificationLogin(context.Background(), api.NewClient(srv.URL, ""), false); err != nil {
+		t.Fatalf("VerificationLogin() error = %v", err)
+	}
+	if len(intervals) < 2 || intervals[0] != time.Second || intervals[1] != 6*time.Second {
+		t.Fatalf("poll intervals = %v, want [1s 6s ...]", intervals)
+	}
+}
+
+func TestVerificationLoginReturnsTerminalPollingErrors(t *testing.T) {
+	tests := []struct {
+		name          string
+		code          string
+		wantSubstring string
+	}{
+		{name: "denied", code: "access_denied", wantSubstring: "denied"},
+		{name: "expired", code: "expired_token", wantSubstring: "expired"},
+		{name: "unexpected", code: "server_confused", wantSubstring: "verification failed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetLoginTestHooks(t)
+			waitForPoll = func(context.Context, time.Duration) error { return nil }
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.Method + " " + r.URL.Path {
+				case "POST /v1/cli-auth/device":
+					json.NewEncoder(w).Encode(map[string]any{
+						"device_code":               "dc_test",
+						"user_code":                 "ABCD-EFGH",
+						"verification_uri":          "https://agentclash.dev/auth/device",
+						"verification_uri_complete": "https://agentclash.dev/auth/device?user_code=ABCD-EFGH",
+						"expires_in":                60,
+						"interval":                  1,
+					})
+				case "POST /v1/cli-auth/device/token":
+					w.WriteHeader(http.StatusBadRequest)
+					json.NewEncoder(w).Encode(map[string]any{
+						"error": map[string]any{"code": tt.code, "message": tt.code},
+					})
+				default:
+					t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer srv.Close()
+
+			_, _, err := VerificationLogin(context.Background(), api.NewClient(srv.URL, ""), false)
+			if err == nil || !strings.Contains(err.Error(), tt.wantSubstring) {
+				t.Fatalf("error = %v, want substring %q", err, tt.wantSubstring)
+			}
+		})
+	}
+}
+
+func TestVerificationLoginRejectsMalformedTokenResponse(t *testing.T) {
+	resetLoginTestHooks(t)
+	waitForPoll = func(context.Context, time.Duration) error { return nil }
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case "POST /v1/cli-auth/device":
+			json.NewEncoder(w).Encode(map[string]any{
+				"device_code":               "dc_test",
+				"user_code":                 "ABCD-EFGH",
+				"verification_uri":          "https://agentclash.dev/auth/device",
+				"verification_uri_complete": "https://agentclash.dev/auth/device?user_code=ABCD-EFGH",
+				"expires_in":                60,
+				"interval":                  1,
+			})
+		case "POST /v1/cli-auth/device/token":
+			json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	_, _, err := VerificationLogin(context.Background(), api.NewClient(srv.URL, ""), false)
+	if err == nil || !strings.Contains(err.Error(), "missing token") {
+		t.Fatalf("error = %v, want missing token", err)
+	}
+}
+
+func TestVerificationLoginFailsAfterRepeatedPollNetworkErrors(t *testing.T) {
+	resetLoginTestHooks(t)
+	waitForPoll = func(context.Context, time.Duration) error { return nil }
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case "POST /v1/cli-auth/device":
+			json.NewEncoder(w).Encode(map[string]any{
+				"device_code":               "dc_test",
+				"user_code":                 "ABCD-EFGH",
+				"verification_uri":          "https://agentclash.dev/auth/device",
+				"verification_uri_complete": "https://agentclash.dev/auth/device?user_code=ABCD-EFGH",
+				"expires_in":                60,
+				"interval":                  1,
+			})
+		case "POST /v1/cli-auth/device/token":
+			hijacker, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatal("response writer does not support hijacking")
+			}
+			conn, _, err := hijacker.Hijack()
+			if err != nil {
+				t.Fatalf("Hijack() error = %v", err)
+			}
+			conn.Close()
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	_, _, err := VerificationLogin(context.Background(), api.NewClient(srv.URL, ""), false)
+	if err == nil || !strings.Contains(err.Error(), "polling verification failed") {
+		t.Fatalf("error = %v, want polling verification failed", err)
 	}
 }

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -306,6 +306,40 @@ paths:
         "415":
           $ref: "#/components/responses/UnsupportedMediaType"
 
+  /v1/cli-auth/device/deny:
+    post:
+      operationId: denyCliDeviceCode
+      tags: [CLIAuth]
+      summary: Deny a pending CLI verification login
+      description: >
+        Denies a pending CLI login from the authenticated web session. The
+        waiting terminal receives an `access_denied` polling response.
+      security:
+        - bearerJWT: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DenyDeviceCodeRequest"
+      responses:
+        "200":
+          description: Device verification denied
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceApprovalResponse"
+        "400":
+          description: Invalid or expired verification code
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
+
   /v1/cli-auth/tokens:
     get:
       operationId: listCliTokens
@@ -3364,10 +3398,12 @@ components:
           type: string
         verification_uri:
           type: string
-          example: /auth/device
+          format: uri
+          example: https://app.agentclash.dev/auth/device
         verification_uri_complete:
           type: string
           format: uri
+          example: https://app.agentclash.dev/auth/device?user_code=ABCD-EFGH
         expires_in:
           type: integer
           format: int32
@@ -3390,6 +3426,13 @@ components:
           type: string
 
     ApproveDeviceCodeRequest:
+      type: object
+      required: [user_code]
+      properties:
+        user_code:
+          type: string
+
+    DenyDeviceCodeRequest:
       type: object
       required: [user_code]
       properties:

--- a/docs/frontend/design/page-inventory.md
+++ b/docs/frontend/design/page-inventory.md
@@ -6,8 +6,9 @@ Every page the frontend needs, mapped to the backend APIs that power it.
 
 | Page | Route | Backend API | Status |
 |---|---|---|---|
-| Login | `/auth/login` | WorkOS AuthKit redirect | Not built |
-| Auth callback | `/auth/callback` | WorkOS code exchange | Not built |
+| Login | `/auth/login` | WorkOS AuthKit redirect | Built |
+| Auth callback | `/auth/callback` | WorkOS code exchange | Built |
+| CLI device verification | `/auth/device` | `POST /v1/cli-auth/device/approve`, `POST /v1/cli-auth/device/deny` | Built |
 | Logout | `/auth/logout` | WorkOS session destroy | Not built |
 
 ## Dashboard

--- a/testing/codex-fix-cli-auth-flow.md
+++ b/testing/codex-fix-cli-auth-flow.md
@@ -1,0 +1,39 @@
+# codex/fix-cli-auth-flow - Test Contract
+
+## Functional Behavior
+- `agentclash auth login` validates an existing resolved token before starting a new browser/device login.
+- A valid stored token exits successfully with an "Already logged in as ..." message and does not create another device code.
+- A valid `AGENTCLASH_TOKEN` exits successfully, reports that authentication is coming from the environment, and does not write credentials.
+- `agentclash auth login --force` always starts a new device-code login and overwrites stored credentials only after the issued token validates.
+- The CLI always prints a browser URL and user code, tries to open the browser unless `--device` is used or the environment is headless, and supports a fallback URL from `verification_uri` plus `user_code`.
+- The polling loop only continues for expected pending states, handles `slow_down`, and fails clearly for denied, expired, malformed, repeated network, and unexpected API errors.
+- Backend CLI auth stays under `/v1/cli-auth/*`, returns absolute verification URLs, and adds `POST /v1/cli-auth/device/deny`.
+- Browser device approval asks the user to confirm the terminal code, supports cancel/deny, and preserves sign-in return to `/auth/device?user_code=...`.
+- Raw CLI tokens remain one-time terminal-only values: they are never placed in browser URLs, are consumed once by polling, and remain hash-only in `cli_tokens`.
+
+## Unit Tests
+- `cli/internal/auth`: login tests cover browser open, `--device`, URL fallback, missing URL/code, pending, slow_down, denied, expired, malformed token response, unexpected API errors, and repeated network failures.
+- `cli/cmd`: command tests cover valid stored token no-op, valid `AGENTCLASH_TOKEN` no-op, invalid stored token continuing into login, and `--force`.
+- `backend/internal/api`: route/manager tests cover absolute verification URLs and deny route behavior.
+- `web/src/lib/auth`: return-to tests preserve normalized device codes and reject unsafe paths.
+- Web component/action tests cover signed-out, signed-in, approved, denied/error states, plus approve/deny error mapping where practical.
+
+## Integration / Functional Tests
+- Backend repository integration tests cover approve -> first poll consumes raw token -> second poll cannot retrieve it, deny transitions, expired code rejection, and stale-code cleanup semantics. These may skip when `DATABASE_URL` is unset, matching existing repository tests.
+- Backend route tests continue proving `/v1/auth/session` is not shadowed by CLI auth routes.
+
+## Smoke Tests
+- `cd cli && go test ./...`
+- `cd backend && go test ./internal/api ./internal/repository`
+- `cd web && npm ci && npm test && npm run build`
+
+## E2E Tests
+- N/A as an automated browser-to-terminal E2E in this change. Manual smoke covers the user journey until a dedicated E2E harness exists.
+
+## Manual / cURL Tests
+- Fresh login: run `agentclash auth login`, verify the link opens, approve in browser, and confirm CLI saves credentials.
+- Already signed-in browser: run `agentclash auth login --force`, approve without another browser sign-in.
+- Headless flow: run `agentclash auth login --device`, manually open the printed URL, approve, and confirm completion.
+- Deny flow: run `agentclash auth login --force`, click cancel/deny in browser, and confirm CLI exits with authorization denied.
+- Expiry flow: start login, let the code expire, and confirm CLI reports expiry.
+- Session/token smoke: run `agentclash auth status`, `agentclash auth tokens list`, revoke the new token, and verify dashboard `/v1/auth/session` still works.

--- a/web/src/app/auth/device/actions.ts
+++ b/web/src/app/auth/device/actions.ts
@@ -3,42 +3,11 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { redirect } from "next/navigation";
 import { createApiClient } from "@/lib/api/client";
-import { ApiError } from "@/lib/api/errors";
 import {
   buildDeviceReturnTo,
   normalizeDeviceUserCode,
 } from "@/lib/auth/return-to";
-
-function buildDeviceStatusPath(
-  userCode: string,
-  updates: Record<string, string>,
-): string {
-  const url = new URL(buildDeviceReturnTo(userCode), "http://agentclash.local");
-  for (const [key, value] of Object.entries(updates)) {
-    url.searchParams.set(key, value);
-  }
-  return `${url.pathname}${url.search}`;
-}
-
-function mapApproveError(error: unknown): string {
-  if (error instanceof ApiError) {
-    const message = error.message.toLowerCase();
-    if (message.includes("expired")) {
-      return "expired_code";
-    }
-    if (message.includes("required")) {
-      return "missing_code";
-    }
-    if (message.includes("not found")) {
-      return "invalid_code";
-    }
-    if (error.status === 401) {
-      return "auth_required";
-    }
-  }
-
-  return "request_failed";
-}
+import { buildDeviceStatusPath, mapDeviceActionError } from "./status";
 
 export async function approveDeviceCodeAction(formData: FormData) {
   const userCode = normalizeDeviceUserCode(formData.get("user_code"));
@@ -58,8 +27,32 @@ export async function approveDeviceCodeAction(formData: FormData) {
       user_code: userCode,
     });
   } catch (error) {
-    redirect(buildDeviceStatusPath(userCode, { error: mapApproveError(error) }));
+    redirect(buildDeviceStatusPath(userCode, { error: mapDeviceActionError(error) }));
   }
 
   redirect(buildDeviceStatusPath(userCode, { status: "approved" }));
+}
+
+export async function denyDeviceCodeAction(formData: FormData) {
+  const userCode = normalizeDeviceUserCode(formData.get("user_code"));
+  if (!userCode) {
+    redirect(buildDeviceStatusPath("", { error: "missing_code" }));
+  }
+
+  const { user, accessToken } = await withAuth();
+  if (!user || !accessToken) {
+    const returnTo = buildDeviceReturnTo(userCode);
+    redirect(`/auth/login?returnTo=${encodeURIComponent(returnTo)}`);
+  }
+
+  const api = createApiClient(accessToken);
+  try {
+    await api.post<{ ok: boolean }>("/v1/cli-auth/device/deny", {
+      user_code: userCode,
+    });
+  } catch (error) {
+    redirect(buildDeviceStatusPath(userCode, { error: mapDeviceActionError(error) }));
+  }
+
+  redirect(buildDeviceStatusPath(userCode, { status: "denied" }));
 }

--- a/web/src/app/auth/device/device-code-form.tsx
+++ b/web/src/app/auth/device/device-code-form.tsx
@@ -7,17 +7,30 @@ import { SignInButton } from "../login/sign-in-button";
 
 interface DeviceCodeFormProps {
   approved?: boolean;
+  denied?: boolean;
   initialUserCode: string;
   isAuthenticated: boolean;
   approveAction: (formData: FormData) => void | Promise<void>;
+  denyAction: (formData: FormData) => void | Promise<void>;
 }
 
 function hasCompleteCode(userCode: string): boolean {
   return userCode.replace(/[^A-Z0-9]/g, "").length === 8;
 }
 
-function ApproveButton({ disabled }: { disabled: boolean }) {
+function ActionButton({
+  disabled,
+  label,
+  pendingLabel,
+  tone = "primary",
+}: {
+  disabled: boolean;
+  label: string;
+  pendingLabel: string;
+  tone?: "primary" | "secondary";
+}) {
   const { pending } = useFormStatus();
+  const isPrimary = tone === "primary";
 
   return (
     <button
@@ -30,30 +43,40 @@ function ApproveButton({ disabled }: { disabled: boolean }) {
         background:
           disabled || pending
             ? "rgba(255, 255, 255, 0.12)"
-            : "rgba(255, 255, 255, 0.9)",
-        color: disabled || pending ? "rgba(255, 255, 255, 0.45)" : "#060606",
+            : isPrimary
+              ? "rgba(255, 255, 255, 0.9)"
+              : "transparent",
+        color:
+          disabled || pending
+            ? "rgba(255, 255, 255, 0.45)"
+            : isPrimary
+              ? "#060606"
+              : "rgba(255, 255, 255, 0.72)",
         borderRadius: "8px",
         fontWeight: 600,
         fontSize: "0.95rem",
         textAlign: "center",
-        border: "none",
+        border: isPrimary ? "none" : "1px solid rgba(255, 255, 255, 0.16)",
         cursor: disabled || pending ? "not-allowed" : "pointer",
       }}
     >
-      {pending ? "Approving..." : "Approve CLI Login"}
+      {pending ? pendingLabel : label}
     </button>
   );
 }
 
 export function DeviceCodeForm({
   approved = false,
+  denied = false,
   initialUserCode,
   isAuthenticated,
   approveAction,
+  denyAction,
 }: DeviceCodeFormProps) {
   const [userCode, setUserCode] = useState(initialUserCode);
   const normalizedCode = normalizeDeviceUserCode(userCode);
   const isComplete = hasCompleteCode(normalizedCode);
+  const completed = approved || denied;
 
   return (
     <div>
@@ -84,7 +107,7 @@ export function DeviceCodeForm({
         }
         placeholder="ABCD-EFGH"
         maxLength={9}
-        disabled={approved}
+        disabled={completed}
         style={{
           display: "block",
           width: "100%",
@@ -109,8 +132,8 @@ export function DeviceCodeForm({
           marginBottom: "1.5rem",
         }}
       >
-        Paste the code from your terminal. The CLI will finish login after you
-        approve this request here.
+        Only approve this request if the code in your terminal matches exactly.
+        The CLI will finish login after you approve it here.
       </p>
 
       {approved ? (
@@ -127,11 +150,39 @@ export function DeviceCodeForm({
           Approval complete. Return to the terminal and wait for the CLI to
           confirm the session.
         </div>
+      ) : denied ? (
+        <div
+          style={{
+            borderRadius: "10px",
+            border: "1px solid rgba(255, 186, 73, 0.28)",
+            background: "rgba(255, 186, 73, 0.1)",
+            color: "rgba(255, 233, 191, 0.95)",
+            padding: "0.9rem 1rem",
+            fontSize: "0.95rem",
+          }}
+        >
+          Login cancelled. Return to the terminal to finish.
+        </div>
       ) : isAuthenticated ? (
-        <form action={approveAction}>
-          <input type="hidden" name="user_code" value={normalizedCode} />
-          <ApproveButton disabled={!isComplete} />
-        </form>
+        <div style={{ display: "grid", gap: "0.75rem" }}>
+          <form action={approveAction}>
+            <input type="hidden" name="user_code" value={normalizedCode} />
+            <ActionButton
+              disabled={!isComplete}
+              label="Approve CLI Login"
+              pendingLabel="Approving..."
+            />
+          </form>
+          <form action={denyAction}>
+            <input type="hidden" name="user_code" value={normalizedCode} />
+            <ActionButton
+              disabled={!isComplete}
+              label="Cancel CLI Login"
+              pendingLabel="Cancelling..."
+              tone="secondary"
+            />
+          </form>
+        </div>
       ) : (
         <SignInButton
           label="Sign In To Continue"

--- a/web/src/app/auth/device/page.tsx
+++ b/web/src/app/auth/device/page.tsx
@@ -1,6 +1,6 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { buildDeviceReturnTo, normalizeDeviceUserCode } from "@/lib/auth/return-to";
-import { approveDeviceCodeAction } from "./actions";
+import { approveDeviceCodeAction, denyDeviceCodeAction } from "./actions";
 import { DeviceCodeForm } from "./device-code-form";
 
 function getErrorMessage(errorCode: string | undefined): string | null {
@@ -24,10 +24,11 @@ function StatusMessage({
   tone,
   message,
 }: {
-  tone: "error" | "success";
+  tone: "error" | "success" | "warning";
   message: string;
 }) {
   const isError = tone === "error";
+  const isWarning = tone === "warning";
 
   return (
     <div
@@ -35,13 +36,19 @@ function StatusMessage({
         borderRadius: "10px",
         border: isError
           ? "1px solid rgba(255, 107, 107, 0.28)"
-          : "1px solid rgba(90, 181, 117, 0.28)",
+          : isWarning
+            ? "1px solid rgba(255, 186, 73, 0.28)"
+            : "1px solid rgba(90, 181, 117, 0.28)",
         background: isError
           ? "rgba(255, 107, 107, 0.1)"
-          : "rgba(90, 181, 117, 0.12)",
+          : isWarning
+            ? "rgba(255, 186, 73, 0.1)"
+            : "rgba(90, 181, 117, 0.12)",
         color: isError
           ? "rgba(255, 214, 214, 0.96)"
-          : "rgba(211, 255, 223, 0.95)",
+          : isWarning
+            ? "rgba(255, 233, 191, 0.95)"
+            : "rgba(211, 255, 223, 0.95)",
         padding: "0.9rem 1rem",
         fontSize: "0.95rem",
         marginBottom: "1rem",
@@ -66,8 +73,12 @@ export default async function DevicePage({
   const returnTo = buildDeviceReturnTo(userCode);
   const errorMessage = getErrorMessage(params.error);
   const approved = params.status === "approved";
+  const denied = params.status === "denied";
   const successMessage = approved
     ? "CLI login approved. Return to the terminal to finish signing in."
+    : null;
+  const deniedMessage = denied
+    ? "CLI login cancelled. Return to the terminal to finish."
     : null;
   const signedInAs = user?.email ?? user?.firstName ?? "your AgentClash account";
 
@@ -132,6 +143,9 @@ export default async function DevicePage({
           {successMessage ? (
             <StatusMessage tone="success" message={successMessage} />
           ) : null}
+          {deniedMessage ? (
+            <StatusMessage tone="warning" message={deniedMessage} />
+          ) : null}
 
           <div
             style={{
@@ -167,12 +181,14 @@ export default async function DevicePage({
 
           <DeviceCodeForm
             approved={approved}
+            denied={denied}
             initialUserCode={userCode}
             isAuthenticated={Boolean(user)}
             approveAction={approveDeviceCodeAction}
+            denyAction={denyDeviceCodeAction}
           />
 
-          {!approved ? (
+          {!approved && !denied ? (
             <p
               style={{
                 color: "rgba(255, 255, 255, 0.38)",

--- a/web/src/app/auth/device/status.test.ts
+++ b/web/src/app/auth/device/status.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { ApiError } from "@/lib/api/errors";
+import { buildDeviceStatusPath, mapDeviceActionError } from "./status";
+
+describe("buildDeviceStatusPath", () => {
+  it("preserves the normalized device code while adding status fields", () => {
+    expect(buildDeviceStatusPath("ab cd-1234", { status: "denied" })).toBe(
+      "/auth/device?user_code=ABCD-1234&status=denied",
+    );
+  });
+});
+
+describe("mapDeviceActionError", () => {
+  it("maps known backend errors to device page error codes", () => {
+    expect(
+      mapDeviceActionError(
+        new ApiError(400, "invalid_request", "device code expired"),
+      ),
+    ).toBe("expired_code");
+    expect(
+      mapDeviceActionError(
+        new ApiError(400, "invalid_request", "device code not found or expired"),
+      ),
+    ).toBe("expired_code");
+    expect(
+      mapDeviceActionError(
+        new ApiError(400, "invalid_request", "user_code is required"),
+      ),
+    ).toBe("missing_code");
+    expect(
+      mapDeviceActionError(new ApiError(401, "unauthorized", "auth required")),
+    ).toBe("auth_required");
+  });
+
+  it("falls back to a retryable request failure", () => {
+    expect(mapDeviceActionError(new Error("offline"))).toBe("request_failed");
+  });
+});

--- a/web/src/app/auth/device/status.ts
+++ b/web/src/app/auth/device/status.ts
@@ -1,0 +1,33 @@
+import { ApiError } from "@/lib/api/errors";
+import { buildDeviceReturnTo } from "@/lib/auth/return-to";
+
+export function buildDeviceStatusPath(
+  userCode: string,
+  updates: Record<string, string>,
+): string {
+  const url = new URL(buildDeviceReturnTo(userCode), "http://agentclash.local");
+  for (const [key, value] of Object.entries(updates)) {
+    url.searchParams.set(key, value);
+  }
+  return `${url.pathname}${url.search}`;
+}
+
+export function mapDeviceActionError(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.status === 401) {
+      return "auth_required";
+    }
+    const message = error.message.toLowerCase();
+    if (message.includes("expired")) {
+      return "expired_code";
+    }
+    if (message.includes("required")) {
+      return "missing_code";
+    }
+    if (message.includes("not found")) {
+      return "invalid_code";
+    }
+  }
+
+  return "request_failed";
+}


### PR DESCRIPTION
## Summary
- harden `agentclash auth login` from the terminal/user perspective: existing-token preflight, `--force`, env-token handling, browser URL fallback, strict polling, and clear denied/expired/error exits
- add backend support for cancelling pending CLI browser auth through `POST /v1/cli-auth/device/deny`, while keeping CLI auth under `/v1/cli-auth/*` and returning absolute verification URLs
- update the web device verification page so users confirm the terminal code and can approve or cancel the login request
- update OpenAPI/frontend docs and add the review-checkpoint test contract at `testing/codex-fix-cli-auth-flow.md`

## Review Checkpoint
- Contract: `testing/codex-fix-cli-auth-flow.md`
- Checkpoint workflow used across three implementation commits:
  - checkpoint 1: CLI login UX and polling
  - checkpoint 2: backend deny flow and repository coverage
  - checkpoint 3: web cancel flow and docs

## Tests
- `cd cli && go test ./...`
- `cd backend && go test ./internal/api ./internal/repository`
- `cd web && npm test`
- `cd web && npm run build`

## Notes
- `npm run build` passes with an existing unrelated warning for unused `ScorecardDimension` in `eval-spec-builder.tsx`.
- `npm ci` reported existing audit findings: 2 moderate and 2 high.
- Manual live-stack browser smoke tests are documented in the contract but not run here.