### PR TITLE
Fix CLI silently swallowing command errors

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/Atharva-Kanherkar/agentclash/cli/cmd"
@@ -16,6 +17,7 @@ var (
 func main() {
 	cmd.SetVersionInfo(version, commit, date)
 	if err := cmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary
- print CLI command errors to stderr before exiting non-zero
- fixes `agentclash auth login` returning to the prompt with no explanation when the API request fails

## Test
- `cd cli && go test ./...`
- `cd cli && go run . auth login --force --api-url http://127.0.0.1:1` now prints the connection error before exiting