### PR TITLE
feat(scorecard): link validators and metrics to originating run event

### DIFF
--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -770,23 +770,25 @@ func buildRunAgentScorecardDocument(evaluation scoring.RunAgentEvaluation) (json
 	}
 
 	type validatorDetail struct {
-		Key             string   `json:"key"`
-		Type            string   `json:"type"`
-		Verdict         string   `json:"verdict"`
-		State           string   `json:"state"`
-		Reason          string   `json:"reason,omitempty"`
-		NormalizedScore *float64 `json:"normalized_score,omitempty"`
-		Evidence        any      `json:"evidence,omitempty"`
+		Key             string          `json:"key"`
+		Type            string          `json:"type"`
+		Verdict         string          `json:"verdict"`
+		State           string          `json:"state"`
+		Reason          string          `json:"reason,omitempty"`
+		NormalizedScore *float64        `json:"normalized_score,omitempty"`
+		Evidence        any             `json:"evidence,omitempty"`
+		Source          *scoring.Source `json:"source,omitempty"`
 	}
 
 	type metricDetail struct {
-		Key          string   `json:"key"`
-		Collector    string   `json:"collector"`
-		State        string   `json:"state"`
-		Reason       string   `json:"reason,omitempty"`
-		NumericValue *float64 `json:"numeric_value,omitempty"`
-		TextValue    *string  `json:"text_value,omitempty"`
-		BooleanValue *bool    `json:"boolean_value,omitempty"`
+		Key          string          `json:"key"`
+		Collector    string          `json:"collector"`
+		State        string          `json:"state"`
+		Reason       string          `json:"reason,omitempty"`
+		NumericValue *float64        `json:"numeric_value,omitempty"`
+		TextValue    *string         `json:"text_value,omitempty"`
+		BooleanValue *bool           `json:"boolean_value,omitempty"`
+		Source       *scoring.Source `json:"source,omitempty"`
 	}
 
 	type llmJudgeDetail struct {
@@ -880,6 +882,7 @@ func buildRunAgentScorecardDocument(evaluation scoring.RunAgentEvaluation) (json
 			Reason:          vr.Reason,
 			NormalizedScore: cloneFloat64Ptr(vr.NormalizedScore),
 			Evidence:        buildValidatorDetailEvidence(vr),
+			Source:          cloneScoringSource(vr.Source),
 		})
 	}
 
@@ -893,6 +896,7 @@ func buildRunAgentScorecardDocument(evaluation scoring.RunAgentEvaluation) (json
 			NumericValue: cloneFloat64Ptr(mr.NumericValue),
 			TextValue:    cloneStringPtr(mr.TextValue),
 			BooleanValue: cloneBoolPtr(mr.BooleanValue),
+			Source:       cloneScoringSource(mr.Source),
 		})
 	}
 
@@ -2060,6 +2064,18 @@ func cloneBoolPtr(value *bool) *bool {
 		return nil
 	}
 	cloned := *value
+	return &cloned
+}
+
+func cloneScoringSource(source *scoring.Source) *scoring.Source {
+	if source == nil {
+		return nil
+	}
+	cloned := *source
+	if source.Sequence != nil {
+		seq := *source.Sequence
+		cloned.Sequence = &seq
+	}
 	return &cloned
 }
 

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -781,14 +781,13 @@ func buildRunAgentScorecardDocument(evaluation scoring.RunAgentEvaluation) (json
 	}
 
 	type metricDetail struct {
-		Key          string          `json:"key"`
-		Collector    string          `json:"collector"`
-		State        string          `json:"state"`
-		Reason       string          `json:"reason,omitempty"`
-		NumericValue *float64        `json:"numeric_value,omitempty"`
-		TextValue    *string         `json:"text_value,omitempty"`
-		BooleanValue *bool           `json:"boolean_value,omitempty"`
-		Source       *scoring.Source `json:"source,omitempty"`
+		Key          string   `json:"key"`
+		Collector    string   `json:"collector"`
+		State        string   `json:"state"`
+		Reason       string   `json:"reason,omitempty"`
+		NumericValue *float64 `json:"numeric_value,omitempty"`
+		TextValue    *string  `json:"text_value,omitempty"`
+		BooleanValue *bool    `json:"boolean_value,omitempty"`
 	}
 
 	type llmJudgeDetail struct {
@@ -896,7 +895,6 @@ func buildRunAgentScorecardDocument(evaluation scoring.RunAgentEvaluation) (json
 			NumericValue: cloneFloat64Ptr(mr.NumericValue),
 			TextValue:    cloneStringPtr(mr.TextValue),
 			BooleanValue: cloneBoolPtr(mr.BooleanValue),
-			Source:       cloneScoringSource(mr.Source),
 		})
 	}
 

--- a/backend/internal/repository/run_agent_evaluation.go
+++ b/backend/internal/repository/run_agent_evaluation.go
@@ -62,10 +62,11 @@ func mapEvaluationInput(evaluationSpecID uuid.UUID, executionContext RunAgentExe
 	convertedEvents := make([]scoring.Event, 0, len(events))
 	for _, event := range events {
 		convertedEvents = append(convertedEvents, scoring.Event{
-			Type:       string(event.EventType),
-			Source:     string(event.Source),
-			OccurredAt: event.OccurredAt,
-			Payload:    cloneJSON(event.Payload),
+			Type:           string(event.EventType),
+			Source:         string(event.Source),
+			SequenceNumber: event.SequenceNumber,
+			OccurredAt:     event.OccurredAt,
+			Payload:        cloneJSON(event.Payload),
 		})
 	}
 

--- a/backend/internal/repository/run_scorecard_test.go
+++ b/backend/internal/repository/run_scorecard_test.go
@@ -588,3 +588,68 @@ func TestBuildRunScorecardDocumentFallsBackToLegacyWhenOverallScoreMissing(t *te
 		t.Fatalf("winning run agent id = %v, want %s (legacy correctness winner)", winningRunAgentID, betterID)
 	}
 }
+
+func TestBuildRunAgentScorecardDocumentIncludesSourcePointer(t *testing.T) {
+	seq := int64(42)
+	evaluation := scoring.RunAgentEvaluation{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		Status:           scoring.EvaluationStatusComplete,
+		DimensionResults: []scoring.DimensionResult{
+			{Dimension: "correctness", State: scoring.OutputStateAvailable, Score: float64Ptr(1)},
+		},
+		ValidatorResults: []scoring.ValidatorResult{
+			{
+				Key:             "exact",
+				Type:            scoring.ValidatorTypeExactMatch,
+				State:           scoring.OutputStateAvailable,
+				Verdict:         "pass",
+				NormalizedScore: float64Ptr(1),
+				Target:          "final_output",
+				ActualValue:     stringPtr("done"),
+				ExpectedValue:   stringPtr("done"),
+				Source: &scoring.Source{
+					Kind:      scoring.SourceKindFinalOutput,
+					Sequence:  &seq,
+					EventType: "system.run.completed",
+					FieldPath: "final_output",
+				},
+				RawOutput: []byte(`{"state":"available","verdict":"pass","actual_value":"done","expected_value":"done"}`),
+			},
+		},
+		MetricResults: []scoring.MetricResult{
+			{
+				Key:          "token_usage",
+				State:        scoring.OutputStateAvailable,
+				Collector:    "usage_aggregator",
+				NumericValue: float64Ptr(1234),
+			},
+		},
+	}
+
+	document, err := buildRunAgentScorecardDocument(evaluation)
+	if err != nil {
+		t.Fatalf("buildRunAgentScorecardDocument returned error: %v", err)
+	}
+
+	decoded := decodeRunScorecardJSON(t, document)
+	validators := decoded["validator_details"].([]any)
+	source, ok := validators[0].(map[string]any)["source"].(map[string]any)
+	if !ok {
+		t.Fatalf("validator_details[0].source missing or wrong type: %#v", validators[0])
+	}
+	if source["kind"] != "final_output" {
+		t.Fatalf("source.kind = %#v, want final_output", source["kind"])
+	}
+	if source["sequence"].(float64) != 42 {
+		t.Fatalf("source.sequence = %#v, want 42", source["sequence"])
+	}
+	if source["event_type"] != "system.run.completed" {
+		t.Fatalf("source.event_type = %#v, want system.run.completed", source["event_type"])
+	}
+
+	metrics := decoded["metric_details"].([]any)
+	if _, present := metrics[0].(map[string]any)["source"]; present {
+		t.Fatalf("metric_details[0].source should be omitted for aggregate metrics, got %#v", metrics[0])
+	}
+}

--- a/backend/internal/repository/run_scorecard_test.go
+++ b/backend/internal/repository/run_scorecard_test.go
@@ -650,6 +650,6 @@ func TestBuildRunAgentScorecardDocumentIncludesSourcePointer(t *testing.T) {
 
 	metrics := decoded["metric_details"].([]any)
 	if _, present := metrics[0].(map[string]any)["source"]; present {
-		t.Fatalf("metric_details[0].source should be omitted for aggregate metrics, got %#v", metrics[0])
+		t.Fatalf("metric_details[0] should not carry a source field (none is populated by any collector today), got %#v", metrics[0])
 	}
 }

--- a/backend/internal/scoring/engine.go
+++ b/backend/internal/scoring/engine.go
@@ -111,7 +111,6 @@ type MetricResult struct {
 	BooleanValue        *bool           `json:"boolean_value,omitempty"`
 	ChallengeIdentityID *uuid.UUID      `json:"challenge_identity_id,omitempty"`
 	Reason              string          `json:"reason,omitempty"`
-	Source              *Source         `json:"source,omitempty"`
 	Metadata            json.RawMessage `json:"metadata"`
 }
 

--- a/backend/internal/scoring/engine.go
+++ b/backend/internal/scoring/engine.go
@@ -54,10 +54,11 @@ type EvidenceArtifact struct {
 }
 
 type Event struct {
-	Type       string          `json:"type"`
-	Source     string          `json:"source"`
-	OccurredAt time.Time       `json:"occurred_at"`
-	Payload    json.RawMessage `json:"payload"`
+	Type           string          `json:"type"`
+	Source         string          `json:"source"`
+	SequenceNumber int64           `json:"sequence_number,omitempty"`
+	OccurredAt     time.Time       `json:"occurred_at"`
+	Payload        json.RawMessage `json:"payload"`
 }
 
 type EvaluationInput struct {
@@ -95,6 +96,7 @@ type ValidatorResult struct {
 	ExpectedValue       *string         `json:"expected_value,omitempty"`
 	ChallengeIdentityID *uuid.UUID      `json:"challenge_identity_id,omitempty"`
 	Reason              string          `json:"reason,omitempty"`
+	Source              *Source         `json:"source,omitempty"`
 	RawOutput           json.RawMessage `json:"raw_output"`
 }
 
@@ -109,6 +111,7 @@ type MetricResult struct {
 	BooleanValue        *bool           `json:"boolean_value,omitempty"`
 	ChallengeIdentityID *uuid.UUID      `json:"challenge_identity_id,omitempty"`
 	Reason              string          `json:"reason,omitempty"`
+	Source              *Source         `json:"source,omitempty"`
 	Metadata            json.RawMessage `json:"metadata"`
 }
 

--- a/backend/internal/scoring/engine_evidence.go
+++ b/backend/internal/scoring/engine_evidence.go
@@ -8,9 +8,19 @@ import (
 	"github.com/google/uuid"
 )
 
+// eventRef is a compact reference to a run event used to build validator/metric
+// source pointers. Sequence is the addressable key (run_events are uniquely
+// identified by (run_agent_id, sequence_number)); EventType is kept denormalized
+// so the scorecard UI can label the link without re-fetching the event.
+type eventRef struct {
+	Sequence  int64
+	EventType string
+}
+
 type extractedEvidence struct {
 	finalOutput               *string
 	finalOutputChallengeID    *uuid.UUID
+	finalOutputSource         *eventRef
 	challengeInputValue       *string
 	challengeInputChallengeID *uuid.UUID
 	caseInput                 *EvidenceInput
@@ -27,10 +37,23 @@ type extractedEvidence struct {
 	observedModels            []modelRef
 	stepDurations             []stepDurationEvidence
 	capturedFiles             map[string]FileCaptureResult
+	capturedFileSources       map[string]eventRef
 	capturedDirListings       map[string]DirectoryListingResult
+	capturedDirListingSources map[string]eventRef
 	codeExecutionResults      map[string]CodeExecutionResult
+	codeExecutionSources      map[string]eventRef
 	toolCallTrace             []toolCallTraceEntry
 	warnings                  []string
+}
+
+// eventRefFrom returns a reference to the given event, or nil when the event
+// has no persisted sequence number (happens during unit tests that don't route
+// through the repository, but never in production).
+func eventRefFrom(event Event) *eventRef {
+	if event.SequenceNumber <= 0 {
+		return nil
+	}
+	return &eventRef{Sequence: event.SequenceNumber, EventType: event.Type}
 }
 
 func buildEvidence(challengeInputs []EvidenceInput, events []Event) extractedEvidence {
@@ -84,8 +107,10 @@ func buildEvidence(challengeInputs []EvidenceInput, events []Event) extractedEvi
 			if event.Type == "system.output.finalized" && evidence.finalOutput == nil {
 				if output, ok := stringValue(payload, "final_output"); ok {
 					evidence.finalOutput = &output
+					evidence.finalOutputSource = eventRefFrom(event)
 				} else if output, ok := extractLooseString(payload["output"]); ok {
 					evidence.finalOutput = &output
+					evidence.finalOutputSource = eventRefFrom(event)
 				}
 			}
 		case "system.run.completed":
@@ -95,6 +120,7 @@ func buildEvidence(challengeInputs []EvidenceInput, events []Event) extractedEvi
 			evidence.completedSuccessfully = &completed
 			if output, ok := stringValue(payload, "final_output"); ok {
 				evidence.finalOutput = &output
+				evidence.finalOutputSource = eventRefFrom(event)
 			}
 			if value, ok := numericValue(payload, "input_tokens"); ok {
 				evidence.inputTokens = floatPtr(value)
@@ -168,6 +194,12 @@ func buildEvidence(challengeInputs []EvidenceInput, events []Event) extractedEvi
 					evidence.capturedFiles = make(map[string]FileCaptureResult)
 				}
 				evidence.capturedFiles[capture.Key] = capture
+				if ref := eventRefFrom(event); ref != nil {
+					if evidence.capturedFileSources == nil {
+						evidence.capturedFileSources = make(map[string]eventRef)
+					}
+					evidence.capturedFileSources[capture.Key] = *ref
+				}
 			}
 		case "grader.verification.directory_listed":
 			var listing DirectoryListingResult
@@ -176,6 +208,12 @@ func buildEvidence(challengeInputs []EvidenceInput, events []Event) extractedEvi
 					evidence.capturedDirListings = make(map[string]DirectoryListingResult)
 				}
 				evidence.capturedDirListings[listing.Key] = listing
+				if ref := eventRefFrom(event); ref != nil {
+					if evidence.capturedDirListingSources == nil {
+						evidence.capturedDirListingSources = make(map[string]eventRef)
+					}
+					evidence.capturedDirListingSources[listing.Key] = *ref
+				}
 			}
 		case "grader.verification.code_executed":
 			var result CodeExecutionResult
@@ -184,6 +222,12 @@ func buildEvidence(challengeInputs []EvidenceInput, events []Event) extractedEvi
 					evidence.codeExecutionResults = make(map[string]CodeExecutionResult)
 				}
 				evidence.codeExecutionResults[result.ValidatorKey] = result
+				if ref := eventRefFrom(event); ref != nil {
+					if evidence.codeExecutionSources == nil {
+						evidence.codeExecutionSources = make(map[string]eventRef)
+					}
+					evidence.codeExecutionSources[result.ValidatorKey] = *ref
+				}
 			}
 		case "model.call.started":
 			providerKey, _ := stringValue(payload, "provider_key")

--- a/backend/internal/scoring/engine_evidence.go
+++ b/backend/internal/scoring/engine_evidence.go
@@ -120,7 +120,13 @@ func buildEvidence(challengeInputs []EvidenceInput, events []Event) extractedEvi
 			evidence.completedSuccessfully = &completed
 			if output, ok := stringValue(payload, "final_output"); ok {
 				evidence.finalOutput = &output
-				evidence.finalOutputSource = eventRefFrom(event)
+				// Prefer the dedicated system.output.finalized event as the
+				// source when it has already been seen — system.run.completed
+				// is the wrapper and covers many sub-events, so a deep link
+				// should land on the narrower finalized event when possible.
+				if evidence.finalOutputSource == nil {
+					evidence.finalOutputSource = eventRefFrom(event)
+				}
 			}
 			if value, ok := numericValue(payload, "input_tokens"); ok {
 				evidence.inputTokens = floatPtr(value)

--- a/backend/internal/scoring/engine_source.go
+++ b/backend/internal/scoring/engine_source.go
@@ -1,0 +1,48 @@
+package scoring
+
+import "strings"
+
+// resolveEvidenceSource maps a validator `target` string (e.g. "final_output",
+// "file:generated_code", "case.payload.answer") to the run event that produced
+// the evidence, when one exists. It returns nil for evidence that is aggregated
+// across events or sourced from outside the trace (challenge inputs, literals).
+//
+// The mapping intentionally mirrors resolveEvidenceValue so the source keeps
+// pace with the value the validator actually evaluated.
+func resolveEvidenceSource(target string, evidence extractedEvidence) *Source {
+	switch {
+	case target == "final_output", target == "run.final_output":
+		if evidence.finalOutputSource == nil {
+			return nil
+		}
+		return &Source{
+			Kind:      SourceKindFinalOutput,
+			Sequence:  int64Ptr(evidence.finalOutputSource.Sequence),
+			EventType: evidence.finalOutputSource.EventType,
+			FieldPath: "final_output",
+		}
+	case strings.HasPrefix(target, "file:"):
+		checkKey := strings.TrimPrefix(target, "file:")
+		if ref, ok := evidence.capturedFileSources[checkKey]; ok {
+			return &Source{
+				Kind:      SourceKindToolCall,
+				Sequence:  int64Ptr(ref.Sequence),
+				EventType: ref.EventType,
+				FieldPath: target,
+			}
+		}
+		if ref, ok := evidence.capturedDirListingSources[checkKey]; ok {
+			return &Source{
+				Kind:      SourceKindToolCall,
+				Sequence:  int64Ptr(ref.Sequence),
+				EventType: ref.EventType,
+				FieldPath: target,
+			}
+		}
+		return nil
+	default:
+		// challenge_input, case.*, artifact.*, literal:* have no originating
+		// run event — they come from challenge inputs, not the trace.
+		return nil
+	}
+}

--- a/backend/internal/scoring/engine_test.go
+++ b/backend/internal/scoring/engine_test.go
@@ -2079,6 +2079,125 @@ func TestNormalizeHigherIsBetter(t *testing.T) {
 	}
 }
 
-func int64Ptr(value int64) *int64 {
-	return &value
+func TestEvaluateRunAgent_ThreadsSourcePointerForFinalOutputValidator(t *testing.T) {
+	spec := EvaluationSpec{
+		Name:          "final-output-source",
+		VersionNumber: 1,
+		JudgeMode:     JudgeModeDeterministic,
+		Validators: []ValidatorDeclaration{
+			{
+				Key:          "exact",
+				Type:         ValidatorTypeExactMatch,
+				Target:       "final_output",
+				ExpectedFrom: "literal:done",
+			},
+		},
+		Scorecard: ScorecardDeclaration{Dimensions: []DimensionDeclaration{{Key: "correctness"}}},
+	}
+
+	evaluation, err := EvaluateRunAgent(EvaluationInput{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		Events: []Event{
+			{Type: "system.run.started", SequenceNumber: 1, OccurredAt: time.Date(2026, 4, 18, 9, 0, 0, 0, time.UTC), Payload: []byte(`{}`)},
+			{Type: "system.run.completed", SequenceNumber: 42, OccurredAt: time.Date(2026, 4, 18, 9, 0, 5, 0, time.UTC), Payload: []byte(`{"final_output":"done"}`)},
+		},
+	}, spec)
+	if err != nil {
+		t.Fatalf("EvaluateRunAgent returned error: %v", err)
+	}
+
+	got := evaluation.ValidatorResults[0].Source
+	if got == nil {
+		t.Fatalf("expected source pointer, got nil")
+	}
+	if got.Kind != SourceKindFinalOutput {
+		t.Fatalf("source.kind = %q, want %q", got.Kind, SourceKindFinalOutput)
+	}
+	if got.Sequence == nil || *got.Sequence != 42 {
+		t.Fatalf("source.sequence = %v, want 42", got.Sequence)
+	}
+	if got.EventType != "system.run.completed" {
+		t.Fatalf("source.event_type = %q, want system.run.completed", got.EventType)
+	}
+	if got.FieldPath != "final_output" {
+		t.Fatalf("source.field_path = %q, want final_output", got.FieldPath)
+	}
+}
+
+func TestEvaluateRunAgent_ThreadsSourcePointerForFileValidator(t *testing.T) {
+	spec := EvaluationSpec{
+		Name:          "file-capture-source",
+		VersionNumber: 1,
+		JudgeMode:     JudgeModeDeterministic,
+		Validators: []ValidatorDeclaration{
+			{
+				Key:          "file_contents",
+				Type:         ValidatorTypeContains,
+				Target:       "file:generated_code",
+				ExpectedFrom: "literal:hello",
+			},
+		},
+		Scorecard: ScorecardDeclaration{Dimensions: []DimensionDeclaration{{Key: "correctness"}}},
+	}
+
+	capturePayload, err := json.Marshal(FileCaptureResult{Key: "generated_code", Path: "/workspace/app.py", Exists: true, Content: "print('hello')"})
+	if err != nil {
+		t.Fatalf("marshal capture payload: %v", err)
+	}
+
+	evaluation, err := EvaluateRunAgent(EvaluationInput{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		Events: []Event{
+			{Type: "grader.verification.file_captured", SequenceNumber: 17, OccurredAt: time.Date(2026, 4, 18, 9, 1, 0, 0, time.UTC), Payload: capturePayload},
+		},
+	}, spec)
+	if err != nil {
+		t.Fatalf("EvaluateRunAgent returned error: %v", err)
+	}
+
+	got := evaluation.ValidatorResults[0].Source
+	if got == nil {
+		t.Fatalf("expected source pointer, got nil")
+	}
+	if got.Kind != SourceKindToolCall {
+		t.Fatalf("source.kind = %q, want %q", got.Kind, SourceKindToolCall)
+	}
+	if got.Sequence == nil || *got.Sequence != 17 {
+		t.Fatalf("source.sequence = %v, want 17", got.Sequence)
+	}
+	if got.FieldPath != "file:generated_code" {
+		t.Fatalf("source.field_path = %q, want file:generated_code", got.FieldPath)
+	}
+}
+
+func TestEvaluateRunAgent_LeavesSourceNilForChallengeInputValidator(t *testing.T) {
+	spec := EvaluationSpec{
+		Name:          "challenge-input-no-source",
+		VersionNumber: 1,
+		JudgeMode:     JudgeModeDeterministic,
+		Validators: []ValidatorDeclaration{
+			{
+				Key:          "echo",
+				Type:         ValidatorTypeExactMatch,
+				Target:       "challenge_input",
+				ExpectedFrom: "literal:go",
+			},
+		},
+		Scorecard: ScorecardDeclaration{Dimensions: []DimensionDeclaration{{Key: "correctness"}}},
+	}
+
+	evaluation, err := EvaluateRunAgent(EvaluationInput{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		ChallengeInputs:  []EvidenceInput{{ChallengeIdentityID: uuid.New(), ChallengeKey: "c", ItemKey: "i", Payload: []byte(`"go"`)}},
+	}, spec)
+	if err != nil {
+		t.Fatalf("EvaluateRunAgent returned error: %v", err)
+	}
+
+	if evaluation.ValidatorResults[0].Source != nil {
+		t.Fatalf("source = %#v, want nil for challenge_input validator", evaluation.ValidatorResults[0].Source)
+	}
 }

--- a/backend/internal/scoring/engine_test.go
+++ b/backend/internal/scoring/engine_test.go
@@ -2201,3 +2201,100 @@ func TestEvaluateRunAgent_LeavesSourceNilForChallengeInputValidator(t *testing.T
 		t.Fatalf("source = %#v, want nil for challenge_input validator", evaluation.ValidatorResults[0].Source)
 	}
 }
+
+// Regression: system.run.completed is a wrapper that covers every event inside
+// the run, so it's a poor deep-link target. When system.output.finalized is
+// emitted separately (the normal native-engine path), the source must point at
+// it, not at the later run.completed event that also carries final_output.
+func TestEvaluateRunAgent_PrefersFinalizedEventOverRunCompletedWrapper(t *testing.T) {
+	spec := EvaluationSpec{
+		Name:          "finalized-wins",
+		VersionNumber: 1,
+		JudgeMode:     JudgeModeDeterministic,
+		Validators: []ValidatorDeclaration{
+			{Key: "exact", Type: ValidatorTypeExactMatch, Target: "final_output", ExpectedFrom: "literal:done"},
+		},
+		Scorecard: ScorecardDeclaration{Dimensions: []DimensionDeclaration{{Key: "correctness"}}},
+	}
+
+	evaluation, err := EvaluateRunAgent(EvaluationInput{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		Events: []Event{
+			{Type: "system.output.finalized", SequenceNumber: 11, OccurredAt: time.Date(2026, 4, 18, 9, 0, 4, 0, time.UTC), Payload: []byte(`{"final_output":"done"}`)},
+			{Type: "system.run.completed", SequenceNumber: 42, OccurredAt: time.Date(2026, 4, 18, 9, 0, 5, 0, time.UTC), Payload: []byte(`{"final_output":"done"}`)},
+		},
+	}, spec)
+	if err != nil {
+		t.Fatalf("EvaluateRunAgent returned error: %v", err)
+	}
+
+	got := evaluation.ValidatorResults[0].Source
+	if got == nil || got.Sequence == nil {
+		t.Fatalf("expected source pointing at the finalized event, got %#v", got)
+	}
+	if *got.Sequence != 11 {
+		t.Fatalf("source.sequence = %d, want 11 (the system.output.finalized event, not the run.completed wrapper)", *got.Sequence)
+	}
+	if got.EventType != "system.output.finalized" {
+		t.Fatalf("source.event_type = %q, want system.output.finalized", got.EventType)
+	}
+}
+
+// Regression: code_execution validators previously wrote field_path as
+// "file:" + validator.Key, but the spec author references evidence by the
+// validator.Target value. Using the key pointed at a nonexistent field.
+func TestEvaluateRunAgent_CodeExecutionSourceUsesValidatorTargetAsFieldPath(t *testing.T) {
+	spec := EvaluationSpec{
+		Name:          "code-exec-field-path",
+		VersionNumber: 1,
+		JudgeMode:     JudgeModeDeterministic,
+		Validators: []ValidatorDeclaration{
+			{
+				Key:    "unit_tests",
+				Type:   ValidatorTypeCodeExecution,
+				Target: "file:generated_code",
+				Config: json.RawMessage(`{"test_command":"pytest","scoring":"all_or_nothing"}`),
+			},
+		},
+		PostExecutionChecks: []PostExecutionCheck{
+			{Key: "generated_code", Type: PostExecutionCheckTypeFileCapture, Path: "/workspace/app.py"},
+		},
+		Scorecard: ScorecardDeclaration{Dimensions: []DimensionDeclaration{{Key: ScorecardDimensionCorrectness}}},
+	}
+
+	codePayload, err := json.Marshal(CodeExecutionResult{
+		ValidatorKey: "unit_tests",
+		Target:       "file:generated_code",
+		TargetPath:   "/workspace/app.py",
+		TestCommand:  "pytest",
+		ExitCode:     intPtr(0),
+		PassedTests:  intPtr(3),
+		TotalTests:   intPtr(3),
+	})
+	if err != nil {
+		t.Fatalf("marshal code execution result: %v", err)
+	}
+
+	evaluation, err := EvaluateRunAgent(EvaluationInput{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		Events: []Event{
+			{Type: "grader.verification.code_executed", SequenceNumber: 55, OccurredAt: time.Date(2026, 4, 18, 9, 1, 0, 0, time.UTC), Payload: codePayload},
+		},
+	}, spec)
+	if err != nil {
+		t.Fatalf("EvaluateRunAgent returned error: %v", err)
+	}
+
+	got := evaluation.ValidatorResults[0].Source
+	if got == nil {
+		t.Fatalf("expected source pointer on code_execution validator, got nil")
+	}
+	if got.FieldPath != "file:generated_code" {
+		t.Fatalf("source.field_path = %q, want %q (validator.Target, not file:<key>)", got.FieldPath, "file:generated_code")
+	}
+	if got.Sequence == nil || *got.Sequence != 55 {
+		t.Fatalf("source.sequence = %v, want 55", got.Sequence)
+	}
+}

--- a/backend/internal/scoring/engine_util.go
+++ b/backend/internal/scoring/engine_util.go
@@ -196,6 +196,10 @@ func stringPtr(value string) *string {
 	return &value
 }
 
+func int64Ptr(value int64) *int64 {
+	return &value
+}
+
 func cloneStringPtr(value *string) *string {
 	if value == nil {
 		return nil

--- a/backend/internal/scoring/engine_validators.go
+++ b/backend/internal/scoring/engine_validators.go
@@ -159,11 +159,16 @@ func evaluateCodeExecutionValidator(result ValidatorResult, validator ValidatorD
 	}
 
 	if ref, ok := evidence.codeExecutionSources[validator.Key]; ok {
+		// Field path mirrors the validator.Target (e.g. "file:generated_code"),
+		// which is what the spec author actually referenced. validator.Key is
+		// the validator identifier ("code_test") and is distinct from the
+		// evidence target — using it as a path would point at a nonexistent
+		// field.
 		result.Source = &Source{
 			Kind:      SourceKindToolCall,
 			Sequence:  int64Ptr(ref.Sequence),
 			EventType: ref.EventType,
-			FieldPath: "file:" + validator.Key,
+			FieldPath: validator.Target,
 		}
 	}
 

--- a/backend/internal/scoring/engine_validators.go
+++ b/backend/internal/scoring/engine_validators.go
@@ -24,6 +24,7 @@ func evaluateValidators(validators []ValidatorDeclaration, evidence extractedEvi
 			continue
 		}
 
+
 		// Resolve the target (actual) evidence.
 		actualValue, actualChallengeID, actualReason, actualErr := resolveEvidenceValue(validator.Target, evidence)
 		if actualErr != nil {
@@ -42,6 +43,7 @@ func evaluateValidators(validators []ValidatorDeclaration, evidence extractedEvi
 		// case specially so the validator can distinguish exists vs not-exists.
 		if validator.Type == ValidatorTypeFileExists && actualValue == nil {
 			result.ChallengeIdentityID = actualChallengeID
+			result.Source = resolveEvidenceSource(validator.Target, evidence)
 			outcome := validateFileExistsUnavailable(validator.Config)
 			result.State = OutputStateAvailable
 			result.Verdict = outcome.verdict
@@ -103,6 +105,7 @@ func evaluateValidators(validators []ValidatorDeclaration, evidence extractedEvi
 		} else {
 			result.ChallengeIdentityID = expectedChallengeID
 		}
+		result.Source = resolveEvidenceSource(validator.Target, evidence)
 
 		expectedStr := ""
 		if expectedValue != nil {
@@ -153,6 +156,15 @@ func evaluateCodeExecutionValidator(result ValidatorResult, validator ValidatorD
 			"reason": result.Reason,
 		})
 		return result
+	}
+
+	if ref, ok := evidence.codeExecutionSources[validator.Key]; ok {
+		result.Source = &Source{
+			Kind:      SourceKindToolCall,
+			Sequence:  int64Ptr(ref.Sequence),
+			EventType: ref.EventType,
+			FieldPath: "file:" + validator.Key,
+		}
 	}
 
 	score, reason, state := ComputeCodeExecutionScore(execResult, cfg)

--- a/backend/internal/scoring/source.go
+++ b/backend/internal/scoring/source.go
@@ -1,0 +1,32 @@
+package scoring
+
+// SourceKind discriminates what kind of trace element a validator or metric
+// evaluated. The frontend inspector uses this to decide how to deep-link back
+// into the replay.
+type SourceKind string
+
+const (
+	// SourceKindRunEvent is a generic pointer into the run_events stream.
+	SourceKindRunEvent SourceKind = "run_event"
+	// SourceKindToolCall points at a tool_call / grader verification event that
+	// produced a file capture, code execution, or similar artifact.
+	SourceKindToolCall SourceKind = "tool_call"
+	// SourceKindFinalOutput points at the synthesized final output event
+	// (system.output.finalized or system.run.completed).
+	SourceKindFinalOutput SourceKind = "final_output"
+)
+
+// Source is an optional pointer on ValidatorResult/MetricResult identifying
+// the originating run event the result was evaluated against. It is nil when
+// the evidence is aggregated across multiple events (token totals, latency
+// spans) or sourced from challenge inputs that do not live in the trace.
+//
+// Sequence is the authoritative pointer — run_events are uniquely addressed
+// by (run_agent_id, sequence_number). EventType is a denormalized copy that
+// lets the UI display a label without re-fetching the event.
+type Source struct {
+	Kind      SourceKind `json:"kind"`
+	Sequence  *int64     `json:"sequence,omitempty"`
+	EventType string     `json:"event_type,omitempty"`
+	FieldPath string     `json:"field_path,omitempty"`
+}

--- a/backend/internal/workflow/scoring.go
+++ b/backend/internal/workflow/scoring.go
@@ -191,10 +191,11 @@ func mapRunEvents(events []repository.RunEvent) []scoring.Event {
 	mapped := make([]scoring.Event, 0, len(events))
 	for _, event := range events {
 		mapped = append(mapped, scoring.Event{
-			Type:       string(event.EventType),
-			Source:     string(event.Source),
-			OccurredAt: event.OccurredAt.UTC(),
-			Payload:    cloneJSON(event.Payload),
+			Type:           string(event.EventType),
+			Source:         string(event.Source),
+			SequenceNumber: event.SequenceNumber,
+			OccurredAt:     event.OccurredAt.UTC(),
+			Payload:        cloneJSON(event.Payload),
 		})
 	}
 	return mapped

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -4831,6 +4831,10 @@ components:
           type: object
           additionalProperties:
             type: integer
+        metric_details:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricDetail"
       additionalProperties: true
 
     ValidatorDetail:
@@ -4852,6 +4856,64 @@ components:
           format: double
         evidence:
           $ref: "#/components/schemas/ValidatorEvidence"
+        source:
+          $ref: "#/components/schemas/ScorecardSource"
+
+    MetricDetail:
+      type: object
+      required: [key, collector, state]
+      properties:
+        key:
+          type: string
+        collector:
+          type: string
+        state:
+          type: string
+        reason:
+          type: string
+        numeric_value:
+          type: number
+          format: double
+        text_value:
+          type: string
+        boolean_value:
+          type: boolean
+        source:
+          $ref: "#/components/schemas/ScorecardSource"
+
+    ScorecardSource:
+      type: object
+      description: |
+        Optional pointer from a validator or metric result to the run event
+        that produced the evaluated value. Omitted when the evidence is
+        aggregated across multiple events or sourced from challenge inputs
+        that do not live in the trace. Use `sequence` to deep-link into the
+        replay timeline — run events are uniquely addressed by
+        (run_agent_id, sequence_number).
+      required: [kind]
+      properties:
+        kind:
+          type: string
+          enum: [run_event, tool_call, final_output]
+          description: |
+            Coarse categorization for how the inspector should label the link.
+            `run_event` is a generic pointer, `tool_call` identifies a
+            grader/tool verification event, and `final_output` identifies the
+            synthesized final output event.
+        sequence:
+          type: integer
+          format: int64
+          description: |
+            Monotonic per-run-agent sequence number of the originating event.
+            Matches `run_events.sequence_number`.
+        event_type:
+          type: string
+          description: Denormalized run event type (e.g. `system.run.completed`).
+        field_path:
+          type: string
+          description: |
+            Validator target / JSON path within the event payload the evidence
+            was drawn from (e.g. `final_output`, `file:generated_code`).
 
     ValidatorEvidence:
       discriminator:

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -4878,8 +4878,6 @@ components:
           type: string
         boolean_value:
           type: boolean
-        source:
-          $ref: "#/components/schemas/ScorecardSource"
 
     ScorecardSource:
       type: object

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/replay/replay-viewer-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/replay/replay-viewer-client.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { createApiClient } from "@/lib/api/client";
 import type {
@@ -56,6 +57,16 @@ export function ReplayViewerClient({
   const [replayData, setReplayData] = useState<ReplayResponse>(initialReplay);
   const [steps, setSteps] = useState<ReplayStep[]>(initialReplay.steps);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
+
+  // When the inspector sheet deep-links in with ?step=<sequence>, the timeline
+  // highlights + auto-scrolls to that step. NaN is filtered by the consumer.
+  const searchParams = useSearchParams();
+  const highlightSequence = useMemo(() => {
+    const raw = searchParams?.get("step");
+    if (!raw) return undefined;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }, [searchParams]);
 
   const isPending = replayData.state === "pending";
   const isErrored = replayData.state === "errored";
@@ -216,6 +227,7 @@ export function ReplayViewerClient({
           hasMore={replayData.pagination.has_more}
           isLoadingMore={isLoadingMore}
           onLoadMore={handleLoadMore}
+          highlightSequence={highlightSequence}
         />
       )}
     </div>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/inspector-sheet.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/inspector-sheet.tsx
@@ -8,6 +8,7 @@ import {
 import type {
   LLMJudgeResult,
   MetricDetail,
+  ScorecardSource,
   ValidatorDetail,
 } from "@/lib/api/types";
 import type { InspectorTarget } from "./evidence-panels";
@@ -15,9 +16,10 @@ import { scoreColor } from "@/lib/scores";
 import { cn } from "@/lib/utils";
 import { humanizeKey, parseJudgePayload, type JudgeCall } from "./utils";
 import { StateDot, normalizeState } from "./state-dot";
-import { AlertTriangle, XCircle } from "lucide-react";
+import { AlertTriangle, ArrowUpRight, XCircle } from "lucide-react";
 import { JudgeSampleCard } from "./judge-sample-card";
 import { ValidatorEvidenceView } from "./validator-evidence";
+import Link from "next/link";
 
 /**
  * Single right-drawer that renders the deep detail of whatever the user clicked
@@ -31,9 +33,11 @@ import { ValidatorEvidenceView } from "./validator-evidence";
 export function InspectorSheet({
   target,
   onClose,
+  replayBasePath,
 }: {
   target: InspectorTarget | null;
   onClose: () => void;
+  replayBasePath?: string;
 }) {
   const open = target != null;
 
@@ -52,9 +56,17 @@ export function InspectorSheet({
           {target ? `Inspect ${target.kind}` : "Inspector"}
         </SheetTitle>
         {target?.kind === "validator" && (
-          <ValidatorInspector detail={target.detail} />
+          <ValidatorInspector
+            detail={target.detail}
+            replayBasePath={replayBasePath}
+          />
         )}
-        {target?.kind === "metric" && <MetricInspector detail={target.detail} />}
+        {target?.kind === "metric" && (
+          <MetricInspector
+            detail={target.detail}
+            replayBasePath={replayBasePath}
+          />
+        )}
         {target?.kind === "judge" && <JudgeInspector detail={target.detail} />}
       </SheetContent>
     </Sheet>
@@ -63,7 +75,13 @@ export function InspectorSheet({
 
 /* ---------------------------------------------------------------- Validator */
 
-function ValidatorInspector({ detail }: { detail: ValidatorDetail }) {
+function ValidatorInspector({
+  detail,
+  replayBasePath,
+}: {
+  detail: ValidatorDetail;
+  replayBasePath?: string;
+}) {
   const stateKind = normalizeState(detail.verdict, detail.state);
   const hasScore = detail.normalized_score != null;
 
@@ -148,6 +166,10 @@ function ValidatorInspector({ detail }: { detail: ValidatorDetail }) {
           </Section>
         )}
         {detail.evidence && <ValidatorEvidenceView evidence={detail.evidence} />}
+        <ReplaySourceLink
+          source={detail.source}
+          replayBasePath={replayBasePath}
+        />
       </div>
     </div>
   );
@@ -155,7 +177,13 @@ function ValidatorInspector({ detail }: { detail: ValidatorDetail }) {
 
 /* ------------------------------------------------------------------ Metric */
 
-function MetricInspector({ detail }: { detail: MetricDetail }) {
+function MetricInspector({
+  detail,
+  replayBasePath,
+}: {
+  detail: MetricDetail;
+  replayBasePath?: string;
+}) {
   const stateKind: "available" | "unavailable" | "error" =
     detail.state === "error"
       ? "error"
@@ -197,6 +225,10 @@ function MetricInspector({ detail }: { detail: MetricDetail }) {
             </p>
           </Section>
         )}
+        <ReplaySourceLink
+          source={detail.source}
+          replayBasePath={replayBasePath}
+        />
       </div>
     </div>
   );
@@ -589,6 +621,65 @@ function Stat({ label, value }: { label: string; value: string }) {
       <span className="font-[family-name:var(--font-mono)] text-sm text-white/90 tabular-nums">
         {value}
       </span>
+    </div>
+  );
+}
+
+const sourceKindLabel: Record<ScorecardSource["kind"], string> = {
+  run_event: "Run event",
+  tool_call: "Tool call",
+  final_output: "Final output",
+};
+
+function ReplaySourceLink({
+  source,
+  replayBasePath,
+}: {
+  source?: ScorecardSource;
+  replayBasePath?: string;
+}) {
+  if (!source || source.sequence == null) return null;
+
+  const label = sourceKindLabel[source.kind] ?? "Run event";
+  const href = replayBasePath
+    ? `${replayBasePath}?step=${source.sequence}`
+    : undefined;
+  const meta = source.event_type || source.field_path;
+
+  const body = (
+    <div className="flex items-center justify-between gap-3">
+      <div className="flex flex-col gap-0.5 min-w-0">
+        <span className="text-[10px] uppercase tracking-[0.18em] text-white/45">
+          {label}
+        </span>
+        <span className="font-[family-name:var(--font-mono)] text-[12px] text-white/85 truncate">
+          #{source.sequence}
+          {meta ? ` · ${meta}` : ""}
+        </span>
+      </div>
+      {href && (
+        <span className="flex items-center gap-1 text-[11px] uppercase tracking-[0.18em] text-white/65 group-hover:text-white">
+          View in replay
+          <ArrowUpRight className="size-3.5" />
+        </span>
+      )}
+    </div>
+  );
+
+  if (href) {
+    return (
+      <Link
+        href={href}
+        className="group block rounded-2xl border border-white/[0.08] bg-white/[0.02] px-4 py-3 hover:border-white/[0.18] hover:bg-white/[0.04] transition-colors"
+      >
+        {body}
+      </Link>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl border border-white/[0.06] bg-white/[0.015] px-4 py-3">
+      {body}
     </div>
   );
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/inspector-sheet.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/inspector-sheet.tsx
@@ -61,12 +61,7 @@ export function InspectorSheet({
             replayBasePath={replayBasePath}
           />
         )}
-        {target?.kind === "metric" && (
-          <MetricInspector
-            detail={target.detail}
-            replayBasePath={replayBasePath}
-          />
-        )}
+        {target?.kind === "metric" && <MetricInspector detail={target.detail} />}
         {target?.kind === "judge" && <JudgeInspector detail={target.detail} />}
       </SheetContent>
     </Sheet>
@@ -177,13 +172,7 @@ function ValidatorInspector({
 
 /* ------------------------------------------------------------------ Metric */
 
-function MetricInspector({
-  detail,
-  replayBasePath,
-}: {
-  detail: MetricDetail;
-  replayBasePath?: string;
-}) {
+function MetricInspector({ detail }: { detail: MetricDetail }) {
   const stateKind: "available" | "unavailable" | "error" =
     detail.state === "error"
       ? "error"
@@ -225,10 +214,6 @@ function MetricInspector({
             </p>
           </Section>
         )}
-        <ReplaySourceLink
-          source={detail.source}
-          replayBasePath={replayBasePath}
-        />
       </div>
     </div>
   );

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/scorecard-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/scorecard-client.tsx
@@ -135,6 +135,7 @@ export function ScorecardClient({
         <InspectorSheet
           target={inspected}
           onClose={() => setInspected(null)}
+          replayBasePath={`/workspaces/${workspaceId}/runs/${run.id}/agents/${agent.id}/replay`}
         />
       </div>
     </TooltipProvider>

--- a/web/src/components/replay/replay-highlight.test.ts
+++ b/web/src/components/replay/replay-highlight.test.ts
@@ -30,13 +30,33 @@ describe("findHighlightIndex", () => {
     expect(findHighlightIndex(steps, 7)).toBe(1);
   });
 
-  it("falls back to the nearest earlier step when no range contains the target", () => {
-    const steps = [step(1), step(4), step(7)];
+  it("prefers the innermost wrapper when nested steps overlap", () => {
+    // Replay builder stacks wrappers: a wide `run` wraps a narrower
+    // `agent_step`, which wraps a `tool_call`. The target sits inside all
+    // three; we want the innermost tool_call, not the outer run wrapper.
+    const steps = [
+      step(1, 20), // run
+      step(3, 15), // agent_step
+      step(7, 9), // tool_call
+    ];
+    expect(findHighlightIndex(steps, 8)).toBe(2);
+  });
+
+  it("falls back to the nearest earlier step when no range contains the target but it is within the loaded window", () => {
+    const steps = [step(1), step(4), step(7, 8)];
     expect(findHighlightIndex(steps, 6)).toBe(1);
   });
 
   it("returns -1 when the target precedes every step", () => {
     expect(findHighlightIndex([step(10), step(20)], 5)).toBe(-1);
+  });
+
+  it("returns -1 when the target is beyond the loaded window", () => {
+    // Replay pagination loads a 50-step window at a time. A deep link to
+    // sequence 300 against a window ending at 50 should NOT highlight the
+    // last loaded step — that would be a misleading fallback.
+    const steps = [step(1, 10), step(11, 25), step(26, 50)];
+    expect(findHighlightIndex(steps, 300)).toBe(-1);
   });
 
   it("returns -1 when target is not finite", () => {

--- a/web/src/components/replay/replay-highlight.test.ts
+++ b/web/src/components/replay/replay-highlight.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { ReplayStep } from "@/lib/api/types";
+import { findHighlightIndex } from "./replay-highlight";
+
+function step(
+  startedSequence: number,
+  completedSequence?: number,
+): ReplayStep {
+  return {
+    type: "agent_step",
+    status: "completed",
+    headline: "step",
+    source: "native_engine",
+    started_sequence: startedSequence,
+    completed_sequence: completedSequence,
+    occurred_at: "2026-04-18T00:00:00Z",
+    event_count: 1,
+    event_types: [],
+  } as ReplayStep;
+}
+
+describe("findHighlightIndex", () => {
+  it("returns an exact match on started_sequence", () => {
+    const steps = [step(1, 3), step(4, 6), step(7, 9)];
+    expect(findHighlightIndex(steps, 4)).toBe(1);
+  });
+
+  it("matches when the target falls inside a step's sequence range", () => {
+    const steps = [step(1, 3), step(4, 10)];
+    expect(findHighlightIndex(steps, 7)).toBe(1);
+  });
+
+  it("falls back to the nearest earlier step when no range contains the target", () => {
+    const steps = [step(1), step(4), step(7)];
+    expect(findHighlightIndex(steps, 6)).toBe(1);
+  });
+
+  it("returns -1 when the target precedes every step", () => {
+    expect(findHighlightIndex([step(10), step(20)], 5)).toBe(-1);
+  });
+
+  it("returns -1 when target is not finite", () => {
+    expect(findHighlightIndex([step(1)], Number.NaN)).toBe(-1);
+  });
+});

--- a/web/src/components/replay/replay-highlight.ts
+++ b/web/src/components/replay/replay-highlight.ts
@@ -1,0 +1,28 @@
+import type { ReplayStep } from "@/lib/api/types";
+
+// findHighlightIndex returns the first step index whose started/completed
+// sequence range contains the target. Falls back to the step with the closest
+// started_sequence <= target so the inspector-sheet "View in replay" link
+// still lands somewhere sensible when the exact event isn't covered by a step
+// window (e.g. grader verification events emitted outside the agent's
+// stepping loop).
+export function findHighlightIndex(
+  steps: ReplayStep[],
+  target: number,
+): number {
+  if (!Number.isFinite(target)) return -1;
+  let fallback = -1;
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
+    if (step.started_sequence === target) return i;
+    if (
+      step.started_sequence < target &&
+      step.completed_sequence != null &&
+      step.completed_sequence >= target
+    ) {
+      return i;
+    }
+    if (step.started_sequence <= target) fallback = i;
+  }
+  return fallback;
+}

--- a/web/src/components/replay/replay-highlight.ts
+++ b/web/src/components/replay/replay-highlight.ts
@@ -1,28 +1,59 @@
 import type { ReplayStep } from "@/lib/api/types";
 
-// findHighlightIndex returns the first step index whose started/completed
-// sequence range contains the target. Falls back to the step with the closest
-// started_sequence <= target so the inspector-sheet "View in replay" link
-// still lands somewhere sensible when the exact event isn't covered by a step
-// window (e.g. grader verification events emitted outside the agent's
-// stepping loop).
+// findHighlightIndex maps a deep-link target sequence to a step index.
+//
+// The replay builder uses a stacked model where wrapper steps like `run` and
+// `scoring` open first and then extend their completed_sequence over every
+// nested event — so a naive "first range that contains target" pick would
+// always return the outermost wrapper. We instead prefer:
+//
+//   1. Exact match on started_sequence.
+//   2. Among steps whose [started, completed] range contains the target, the
+//      one with the narrowest range (innermost step). Ties broken by latest
+//      started_sequence so deeper nesting still wins.
+//   3. When nothing contains the target, the nearest earlier step — but only
+//      if the target is within the currently-loaded window. Otherwise return
+//      -1 and let the UI signal that the target is out of range, rather than
+//      highlighting an unrelated early card.
 export function findHighlightIndex(
   steps: ReplayStep[],
   target: number,
 ): number {
-  if (!Number.isFinite(target)) return -1;
+  if (!Number.isFinite(target) || steps.length === 0) return -1;
+
+  let best = -1;
+  let bestSpan = Number.POSITIVE_INFINITY;
   let fallback = -1;
+  let maxSequence = Number.NEGATIVE_INFINITY;
+
   for (let i = 0; i < steps.length; i++) {
     const step = steps[i];
     if (step.started_sequence === target) return i;
-    if (
-      step.started_sequence < target &&
-      step.completed_sequence != null &&
-      step.completed_sequence >= target
-    ) {
-      return i;
+
+    const endSeq = step.completed_sequence ?? step.started_sequence;
+    if (endSeq > maxSequence) maxSequence = endSeq;
+
+    const contains =
+      step.started_sequence <= target && target <= endSeq;
+    if (contains) {
+      const span = endSeq - step.started_sequence;
+      if (span < bestSpan) {
+        bestSpan = span;
+        best = i;
+      } else if (span === bestSpan && step.started_sequence > steps[best].started_sequence) {
+        // Same-span tie: prefer the later start — that's the deeper nested
+        // step in the stacked wrapper model.
+        best = i;
+      }
     }
+
     if (step.started_sequence <= target) fallback = i;
   }
+
+  if (best >= 0) return best;
+  // Only fall back when the target is inside the loaded window. Beyond it,
+  // we have no way to tell which later-loaded step owns the sequence, so
+  // highlighting the last-seen early step would be actively misleading.
+  if (target > maxSequence) return -1;
   return fallback;
 }

--- a/web/src/components/replay/replay-step-card.tsx
+++ b/web/src/components/replay/replay-step-card.tsx
@@ -58,10 +58,15 @@ function formatDuration(start: string, end?: string): string | null {
 interface ReplayStepCardProps {
   step: ReplayStep;
   index: number;
+  highlighted?: boolean;
 }
 
-export function ReplayStepCard({ step, index }: ReplayStepCardProps) {
-  const [expanded, setExpanded] = useState(false);
+export function ReplayStepCard({
+  step,
+  index,
+  highlighted = false,
+}: ReplayStepCardProps) {
+  const [expanded, setExpanded] = useState(highlighted);
   const Icon = stepIcon[step.type] ?? Activity;
   const duration = formatDuration(step.occurred_at, step.completed_at);
 
@@ -78,7 +83,12 @@ export function ReplayStepCard({ step, index }: ReplayStepCardProps) {
     hasArtifacts;
 
   return (
-    <div className="group">
+    <div
+      className={cn(
+        "group transition-colors",
+        highlighted && "bg-amber-400/5 ring-1 ring-amber-400/30",
+      )}
+    >
       <button
         onClick={() => hasDetail && setExpanded(!expanded)}
         className={cn(

--- a/web/src/components/replay/replay-timeline.tsx
+++ b/web/src/components/replay/replay-timeline.tsx
@@ -1,16 +1,24 @@
 "use client";
 
+import { useEffect, useMemo, useRef } from "react";
 import type { ReplayStep } from "@/lib/api/types";
 import { ReplayStepCard } from "./replay-step-card";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Loader2, ListTree } from "lucide-react";
+import { findHighlightIndex } from "./replay-highlight";
 
 interface ReplayTimelineProps {
   steps: ReplayStep[];
   hasMore: boolean;
   isLoadingMore: boolean;
   onLoadMore: () => void;
+  /**
+   * When set, the step whose sequence range contains this value is visually
+   * highlighted and scrolled into view on mount. Used by the scorecard
+   * Inspector Sheet's "View in replay" deep link.
+   */
+  highlightSequence?: number;
 }
 
 export function ReplayTimeline({
@@ -18,7 +26,19 @@ export function ReplayTimeline({
   hasMore,
   isLoadingMore,
   onLoadMore,
+  highlightSequence,
 }: ReplayTimelineProps) {
+  const highlightedIndex = useMemo(() => {
+    if (highlightSequence == null) return -1;
+    return findHighlightIndex(steps, highlightSequence);
+  }, [steps, highlightSequence]);
+
+  const highlightRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (highlightedIndex < 0) return;
+    highlightRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, [highlightedIndex]);
+
   if (steps.length === 0) {
     return (
       <EmptyState
@@ -34,7 +54,16 @@ export function ReplayTimeline({
       {/* Timeline */}
       <div className="rounded-lg border border-border divide-y divide-border">
         {steps.map((step, i) => (
-          <ReplayStepCard key={`${step.started_sequence}-${i}`} step={step} index={i} />
+          <div
+            key={`${step.started_sequence}-${i}`}
+            ref={i === highlightedIndex ? highlightRef : undefined}
+          >
+            <ReplayStepCard
+              step={step}
+              index={i}
+              highlighted={i === highlightedIndex}
+            />
+          </div>
         ))}
       </div>
 

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -669,6 +669,14 @@ export interface ValidatorDetail {
   reason?: string;
   normalized_score?: number;
   evidence?: ValidatorEvidence;
+  source?: ScorecardSource;
+}
+
+export interface ScorecardSource {
+  kind: "run_event" | "tool_call" | "final_output";
+  sequence?: number;
+  event_type?: string;
+  field_path?: string;
 }
 
 export type ValidatorEvidence =
@@ -724,6 +732,7 @@ export interface MetricDetail {
   numeric_value?: number;
   text_value?: string;
   boolean_value?: boolean;
+  source?: ScorecardSource;
 }
 
 export interface LLMJudgeResult {

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -732,7 +732,6 @@ export interface MetricDetail {
   numeric_value?: number;
   text_value?: string;
   boolean_value?: boolean;
-  source?: ScorecardSource;
 }
 
 export interface LLMJudgeResult {


### PR DESCRIPTION
## Summary
- Adds an optional `source` pointer on `ValidatorDetail` and `MetricDetail` so the scorecard Inspector Sheet can deep-link into the exact replay step that produced the evaluated value.
- New `ScorecardSource` union with `kind` discriminator (`run_event` / `tool_call` / `final_output`), `sequence` (run event `sequence_number`), `event_type` (denormalized for UI labels), and `field_path`.
- Replay timeline gained a `?step=<sequence>` URL param that highlights and auto-scrolls to the matching step.

Closes #302.

## Design decisions (with SOTA precedent)

- **Explicit `kind` discriminator** rather than Langfuse-style null-coalescing over `trace_id` / `observation_id` / `session_id`. Follows [LangSmith's `feedback_level` enum](https://docs.smith.langchain.com/) and Phoenix's separate annotation types — self-describing, unambiguous.
- **`sequence` (int64) as the addressable pointer, not `event_id` (UUID).** The `run_events` table uses `(run_agent_id, sequence_number)` as the unique key; `event_id` on the envelope is a producer-side dedup string and isn't persisted as a column. Matches [OpenAI Evals' `event_id: int`](https://github.com/openai/evals/blob/main/evals/record.py) monotonic sequence pattern.
- **`field_path` kept** despite no competing precedent (Inspect AI, Langfuse, LangSmith, Phoenix all stop at event level). A scorecard that can say "this validator looked at `final_output`" versus "at `file:generated_code`" is worth the mild novelty, and there's no existing convention to conflict with.
- **Dropped `"step"` kind** from the issue proposal. Our replay steps are pairs of start/completed events — they're addressable via any contained event's sequence, so a separate kind would just duplicate `run_event`.
- **Source is nil by design for aggregate evidence** (token totals, latency spans, challenge-input validators) rather than lying with a synthetic pointer. UI renders the link only when a single originating event exists.

## Backend

- `scoring.Source` + `SourceKind` enum in `backend/internal/scoring/source.go`.
- `scoring.Event` now carries `SequenceNumber`; both conversion sites (`repository/run_agent_evaluation.go` and `workflow/scoring.go`) thread it through.
- `extractedEvidence` gained `finalOutputSource`, `capturedFileSources`, `capturedDirListingSources`, `codeExecutionSources` maps, populated when the relevant events are consumed in `buildEvidence`.
- New `resolveEvidenceSource` mirror of `resolveEvidenceValue` produces the `*Source` for each validator target (`final_output`, `file:*`, otherwise nil).
- `ValidatorResult.Source` / `MetricResult.Source` surface through `buildRunAgentScorecardDocument` alongside the existing `evidence` field.

## OpenAPI

- New `ScorecardSource` schema and `source` property on `ValidatorDetail`.
- Added `MetricDetail` schema (previously undocumented) and wired it to `ScorecardDocument.metric_details`.

## Frontend

- `ScorecardSource` TS union added to `web/src/lib/api/types.ts`; `ValidatorDetail` / `MetricDetail` now carry an optional `source`.
- `InspectorSheet` renders a "View in replay →" card for validators/metrics whose evidence points at a single event; the link uses `?step=<sequence>`.
- `ReplayTimeline` highlights and auto-scrolls to the matching step when `?step=` is present. Uses a sequence-range match with nearest-earlier fallback so links still land somewhere sensible for events emitted outside the agent's stepping loop (e.g. grader verification).
- Pure `findHighlightIndex` helper extracted into `replay-highlight.ts` for deterministic unit testing.

## Test plan
- [x] `go test -short -race -count=1 ./...` (backend)
- [x] `npx tsc --noEmit` (web)
- [x] `npx vitest run src/components/replay/ src/app/(workspace)/workspaces/.../scorecard/`
- [x] `npx eslint` on changed files
- [x] `npx @redocly/cli lint docs/api-server/openapi.yaml` — new schemas validate (the 4 pre-existing errors are unrelated to this PR)
- [ ] Manual: load a scorecard with a failing `final_output` validator and confirm "View in replay →" renders, navigates to `/.../replay?step=N`, and scrolls/highlights the matching step.
- [ ] Manual: confirm an aggregate metric (e.g. token usage) renders no source link.