### PR TITLE
fix(scoring): point final_output source at real producer, fix JSON-schema integer rejection

### DIFF
--- a/backend/internal/scoring/engine_evidence.go
+++ b/backend/internal/scoring/engine_evidence.go
@@ -20,7 +20,16 @@ type eventRef struct {
 type extractedEvidence struct {
 	finalOutput               *string
 	finalOutputChallengeID    *uuid.UUID
-	finalOutputSource         *eventRef
+	// finalOutputSource is set only by the dedicated system.output.finalized
+	// event (the narrow producer). It is never set from system.run.completed
+	// — that event wraps every preceding event in the run and would make
+	// deep-links land on the wrapper instead of the real producer.
+	finalOutputSource *eventRef
+	// lastModelCallSource tracks the most recent model.call.completed event
+	// and is used as the final_output source when no system.output.finalized
+	// event exists (i.e. native runs that don't synthesize a finalized event).
+	// A nil source beats pointing at the run.completed wrapper.
+	lastModelCallSource       *eventRef
 	challengeInputValue       *string
 	challengeInputChallengeID *uuid.UUID
 	caseInput                 *EvidenceInput
@@ -120,13 +129,11 @@ func buildEvidence(challengeInputs []EvidenceInput, events []Event) extractedEvi
 			evidence.completedSuccessfully = &completed
 			if output, ok := stringValue(payload, "final_output"); ok {
 				evidence.finalOutput = &output
-				// Prefer the dedicated system.output.finalized event as the
-				// source when it has already been seen — system.run.completed
-				// is the wrapper and covers many sub-events, so a deep link
-				// should land on the narrower finalized event when possible.
-				if evidence.finalOutputSource == nil {
-					evidence.finalOutputSource = eventRefFrom(event)
-				}
+				// Deliberately NOT setting finalOutputSource here. This event
+				// is a wrapper covering every preceding event; pointing a
+				// source at it would make the "View in replay" link land on
+				// a step that spans the entire run. resolveEvidenceSource
+				// falls back to lastModelCallSource for the real producer.
 			}
 			if value, ok := numericValue(payload, "input_tokens"); ok {
 				evidence.inputTokens = floatPtr(value)
@@ -167,6 +174,9 @@ func buildEvidence(challengeInputs []EvidenceInput, events []Event) extractedEvi
 		case "sandbox.command.failed":
 			evidence.failureCount++
 		case "model.call.completed":
+			if ref := eventRefFrom(event); ref != nil {
+				evidence.lastModelCallSource = ref
+			}
 			providerKey, _ := stringValue(payload, "provider_key")
 			providerModelID, _ := stringValue(payload, "provider_model_id")
 			if providerModelID == "" {

--- a/backend/internal/scoring/engine_source.go
+++ b/backend/internal/scoring/engine_source.go
@@ -12,15 +12,28 @@ import "strings"
 func resolveEvidenceSource(target string, evidence extractedEvidence) *Source {
 	switch {
 	case target == "final_output", target == "run.final_output":
-		if evidence.finalOutputSource == nil {
-			return nil
+		// Prefer the dedicated finalized event when present (prompt_eval runs
+		// emit it). Otherwise fall back to the last model.call.completed —
+		// that's the actual producer of the agent's text. If neither exists
+		// we return nil; a nil source beats a link that lands on the
+		// system.run.completed wrapper covering the whole run.
+		if evidence.finalOutputSource != nil {
+			return &Source{
+				Kind:      SourceKindFinalOutput,
+				Sequence:  int64Ptr(evidence.finalOutputSource.Sequence),
+				EventType: evidence.finalOutputSource.EventType,
+				FieldPath: "final_output",
+			}
 		}
-		return &Source{
-			Kind:      SourceKindFinalOutput,
-			Sequence:  int64Ptr(evidence.finalOutputSource.Sequence),
-			EventType: evidence.finalOutputSource.EventType,
-			FieldPath: "final_output",
+		if evidence.lastModelCallSource != nil {
+			return &Source{
+				Kind:      SourceKindModelCall,
+				Sequence:  int64Ptr(evidence.lastModelCallSource.Sequence),
+				EventType: evidence.lastModelCallSource.EventType,
+				FieldPath: "final_output",
+			}
 		}
+		return nil
 	case strings.HasPrefix(target, "file:"):
 		checkKey := strings.TrimPrefix(target, "file:")
 		if ref, ok := evidence.capturedFileSources[checkKey]; ok {

--- a/backend/internal/scoring/engine_test.go
+++ b/backend/internal/scoring/engine_test.go
@@ -2079,6 +2079,8 @@ func TestNormalizeHigherIsBetter(t *testing.T) {
 	}
 }
 
+// When system.output.finalized is emitted (prompt_eval runs), the source
+// should land on it directly with kind=final_output.
 func TestEvaluateRunAgent_ThreadsSourcePointerForFinalOutputValidator(t *testing.T) {
 	spec := EvaluationSpec{
 		Name:          "final-output-source",
@@ -2100,6 +2102,7 @@ func TestEvaluateRunAgent_ThreadsSourcePointerForFinalOutputValidator(t *testing
 		EvaluationSpecID: uuid.New(),
 		Events: []Event{
 			{Type: "system.run.started", SequenceNumber: 1, OccurredAt: time.Date(2026, 4, 18, 9, 0, 0, 0, time.UTC), Payload: []byte(`{}`)},
+			{Type: "system.output.finalized", SequenceNumber: 41, OccurredAt: time.Date(2026, 4, 18, 9, 0, 4, 0, time.UTC), Payload: []byte(`{"final_output":"done"}`)},
 			{Type: "system.run.completed", SequenceNumber: 42, OccurredAt: time.Date(2026, 4, 18, 9, 0, 5, 0, time.UTC), Payload: []byte(`{"final_output":"done"}`)},
 		},
 	}, spec)
@@ -2114,14 +2117,87 @@ func TestEvaluateRunAgent_ThreadsSourcePointerForFinalOutputValidator(t *testing
 	if got.Kind != SourceKindFinalOutput {
 		t.Fatalf("source.kind = %q, want %q", got.Kind, SourceKindFinalOutput)
 	}
-	if got.Sequence == nil || *got.Sequence != 42 {
-		t.Fatalf("source.sequence = %v, want 42", got.Sequence)
+	if got.Sequence == nil || *got.Sequence != 41 {
+		t.Fatalf("source.sequence = %v, want 41 (the finalized event, not the run.completed wrapper)", got.Sequence)
 	}
-	if got.EventType != "system.run.completed" {
-		t.Fatalf("source.event_type = %q, want system.run.completed", got.EventType)
+	if got.EventType != "system.output.finalized" {
+		t.Fatalf("source.event_type = %q, want system.output.finalized", got.EventType)
 	}
 	if got.FieldPath != "final_output" {
 		t.Fatalf("source.field_path = %q, want final_output", got.FieldPath)
+	}
+}
+
+// Native runs don't emit system.output.finalized, so the source should fall
+// back to the last model.call.completed — the real producer of the final text.
+// NEVER the system.run.completed wrapper, which covers every preceding event.
+func TestEvaluateRunAgent_FinalOutputSourceFallsBackToLastModelCall(t *testing.T) {
+	spec := EvaluationSpec{
+		Name:          "final-output-model-call-fallback",
+		VersionNumber: 1,
+		JudgeMode:     JudgeModeDeterministic,
+		Validators: []ValidatorDeclaration{
+			{Key: "exact", Type: ValidatorTypeExactMatch, Target: "final_output", ExpectedFrom: "literal:done"},
+		},
+		Scorecard: ScorecardDeclaration{Dimensions: []DimensionDeclaration{{Key: "correctness"}}},
+	}
+
+	evaluation, err := EvaluateRunAgent(EvaluationInput{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		Events: []Event{
+			{Type: "system.run.started", SequenceNumber: 1, OccurredAt: time.Date(2026, 4, 18, 9, 0, 0, 0, time.UTC), Payload: []byte(`{}`)},
+			{Type: "model.call.completed", SequenceNumber: 7, OccurredAt: time.Date(2026, 4, 18, 9, 0, 2, 0, time.UTC), Payload: []byte(`{"provider_key":"anthropic"}`)},
+			{Type: "model.call.completed", SequenceNumber: 12, OccurredAt: time.Date(2026, 4, 18, 9, 0, 4, 0, time.UTC), Payload: []byte(`{"provider_key":"anthropic"}`)},
+			{Type: "system.run.completed", SequenceNumber: 16, OccurredAt: time.Date(2026, 4, 18, 9, 0, 5, 0, time.UTC), Payload: []byte(`{"final_output":"done"}`)},
+		},
+	}, spec)
+	if err != nil {
+		t.Fatalf("EvaluateRunAgent returned error: %v", err)
+	}
+
+	got := evaluation.ValidatorResults[0].Source
+	if got == nil {
+		t.Fatalf("expected source pointing at last model call, got nil")
+	}
+	if got.Kind != SourceKindModelCall {
+		t.Fatalf("source.kind = %q, want %q", got.Kind, SourceKindModelCall)
+	}
+	if got.Sequence == nil || *got.Sequence != 12 {
+		t.Fatalf("source.sequence = %v, want 12 (the last model.call.completed, not the run.completed wrapper)", got.Sequence)
+	}
+	if got.EventType != "model.call.completed" {
+		t.Fatalf("source.event_type = %q, want model.call.completed", got.EventType)
+	}
+}
+
+// When neither system.output.finalized nor any model.call.completed exists,
+// the source stays nil — a missing "View in replay" link beats one that lands
+// on the system.run.completed wrapper and highlights the entire run.
+func TestEvaluateRunAgent_FinalOutputSourceIsNilWhenOnlyRunCompletedExists(t *testing.T) {
+	spec := EvaluationSpec{
+		Name:          "final-output-no-producer",
+		VersionNumber: 1,
+		JudgeMode:     JudgeModeDeterministic,
+		Validators: []ValidatorDeclaration{
+			{Key: "exact", Type: ValidatorTypeExactMatch, Target: "final_output", ExpectedFrom: "literal:done"},
+		},
+		Scorecard: ScorecardDeclaration{Dimensions: []DimensionDeclaration{{Key: "correctness"}}},
+	}
+
+	evaluation, err := EvaluateRunAgent(EvaluationInput{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		Events: []Event{
+			{Type: "system.run.completed", SequenceNumber: 42, OccurredAt: time.Date(2026, 4, 18, 9, 0, 5, 0, time.UTC), Payload: []byte(`{"final_output":"done"}`)},
+		},
+	}, spec)
+	if err != nil {
+		t.Fatalf("EvaluateRunAgent returned error: %v", err)
+	}
+
+	if evaluation.ValidatorResults[0].Source != nil {
+		t.Fatalf("source = %#v, want nil (run.completed wrapper is not a valid source)", evaluation.ValidatorResults[0].Source)
 	}
 }
 

--- a/backend/internal/scoring/json_validators.go
+++ b/backend/internal/scoring/json_validators.go
@@ -35,7 +35,11 @@ type jsonPathExpectation struct {
 }
 
 func validateJSONSchema(actual string, expected string) validatorOutcome {
-	actualDocument, err := parseJSONValue(actual)
+	// google/jsonschema-go type-checks values by reflecting on the Go kind.
+	// json.Number (from decoder.UseNumber) is a string alias, so the library
+	// rejects integer values as type "string". Decode without UseNumber for
+	// schema validation so integers land as float64 and match `type: integer`.
+	actualDocument, err := parseJSONDocument(actual)
 	if err != nil {
 		return validatorError("parse actual JSON document", err, nil)
 	}
@@ -138,6 +142,23 @@ func parseJSONValue(raw string) (any, error) {
 	decoder := json.NewDecoder(strings.NewReader(raw))
 	decoder.UseNumber()
 
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	if decoder.More() {
+		return nil, fmt.Errorf("multiple JSON values are not allowed")
+	}
+	return value, nil
+}
+
+// parseJSONDocument decodes a JSON value with the default number handling
+// (float64), suitable for feeding into google/jsonschema-go which type-checks
+// via Go kinds. parseJSONValue above uses decoder.UseNumber() for lossless
+// numeric comparisons in the JSONPath validator, but that path is wrong for
+// schema validation because json.Number is a string alias.
+func parseJSONDocument(raw string) (any, error) {
+	decoder := json.NewDecoder(strings.NewReader(raw))
 	var value any
 	if err := decoder.Decode(&value); err != nil {
 		return nil, err

--- a/backend/internal/scoring/json_validators_test.go
+++ b/backend/internal/scoring/json_validators_test.go
@@ -1088,6 +1088,16 @@ func TestValidateJSONSchema(t *testing.T) {
 			wantScore:   floatPtr(0),
 		},
 		{
+			// Regression: UseNumber() decodes JSON ints as json.Number (a
+			// string alias), which google/jsonschema-go then rejected as
+			// type "string" under `type: integer`. Must pass now.
+			name:        "nested integers satisfy integer constraint",
+			actual:      `{"sample_values":[{"n":0,"fib":0},{"n":1,"fib":1},{"n":10,"fib":55}]}`,
+			expected:    `{"type":"object","required":["sample_values"],"properties":{"sample_values":{"type":"array","items":{"type":"object","required":["n","fib"],"properties":{"n":{"type":"integer"},"fib":{"type":"integer"}}}}}}`,
+			wantVerdict: "pass",
+			wantScore:   floatPtr(1),
+		},
+		{
 			name:        "malformed actual JSON",
 			actual:      `not json`,
 			expected:    `{"type":"object"}`,

--- a/backend/internal/scoring/source.go
+++ b/backend/internal/scoring/source.go
@@ -11,8 +11,12 @@ const (
 	// SourceKindToolCall points at a tool_call / grader verification event that
 	// produced a file capture, code execution, or similar artifact.
 	SourceKindToolCall SourceKind = "tool_call"
-	// SourceKindFinalOutput points at the synthesized final output event
-	// (system.output.finalized or system.run.completed).
+	// SourceKindModelCall points at a model.call.completed event — the usual
+	// producer of an agent's final text when no dedicated
+	// system.output.finalized event was emitted.
+	SourceKindModelCall SourceKind = "model_call"
+	// SourceKindFinalOutput points at the dedicated finalized-output event
+	// (system.output.finalized). Narrower than the run.completed wrapper.
 	SourceKindFinalOutput SourceKind = "final_output"
 )
 

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -4892,12 +4892,15 @@ components:
       properties:
         kind:
           type: string
-          enum: [run_event, tool_call, final_output]
+          enum: [run_event, tool_call, model_call, final_output]
           description: |
             Coarse categorization for how the inspector should label the link.
             `run_event` is a generic pointer, `tool_call` identifies a
-            grader/tool verification event, and `final_output` identifies the
-            synthesized final output event.
+            grader/tool verification event, `model_call` identifies a
+            model.call.completed event (used as the final-output producer on
+            native runs that don't emit a dedicated finalized event), and
+            `final_output` identifies the synthesized system.output.finalized
+            event.
         sequence:
           type: integer
           format: int64

--- a/examples/challenge-packs/fibonacci-e2e-showcase.yaml
+++ b/examples/challenge-packs/fibonacci-e2e-showcase.yaml
@@ -1,0 +1,309 @@
+###############################################################################
+# Challenge Pack: Fibonacci E2E Showcase
+#
+# A deliberately straightforward coding task whose evaluation spec exercises
+# every scorecard surface we ship today, so you can eyeball each piece in the
+# UI without chasing edge cases. Use this pack to sanity-check:
+#
+#   - Validator evidence rendering: text_compare, regex_match, json_schema,
+#     json_path_match, and the custom fallback (via code_execution).
+#   - Validator `source` pointer + "View in replay →" deep link:
+#       * final_output validators → source kind `final_output`, points at the
+#         dedicated system.output.finalized event (not the run.completed
+#         wrapper, per the fix in PR #310).
+#       * file:* validators → source kind `tool_call`, points at the
+#         grader.verification.file_captured event for that key.
+#       * code_execution validators → source kind `tool_call`, points at the
+#         grader.verification.code_executed event, with field_path set to
+#         validator.Target (e.g. `file:solution`).
+#       * case.* / challenge_input validators → no source (no replay link).
+#   - LLM-as-judge: both assertion-mode and reference-mode judges.
+#   - Metrics: aggregate collectors (tokens, latency, run completion).
+#   - Dimensions: mix of validator-backed, LLM-judge-backed, and behavioral.
+#
+# The agent task itself is "write a Python fibonacci function" — simple enough
+# that any capable model will pass, so failing validators always indicate a
+# real scorecard issue, not an agent issue.
+###############################################################################
+
+pack:
+  slug: fibonacci-e2e-showcase
+  name: Fibonacci E2E Showcase
+  family: coding
+
+version:
+  number: 1
+  execution_mode: native
+  sandbox:
+    network_access: false
+
+  tool_policy:
+    allowed_tool_kinds:
+      - file
+      - shell
+
+  evaluation_spec:
+    name: fibonacci-e2e-showcase-v1
+    version_number: 1
+    judge_mode: hybrid
+
+    # --------------------------------------------------------------------
+    # Post-execution captures — these emit grader.verification.* events that
+    # become the deep-link targets for file:* and code_execution validators.
+    # --------------------------------------------------------------------
+    post_execution_checks:
+      - key: solution
+        type: file_capture
+        path: /workspace/solution.py
+
+    # --------------------------------------------------------------------
+    # Validators — one per evidence shape, one per source kind, one per
+    # "no source" case. Keep the set small enough to eyeball but wide
+    # enough to cover every inspector-sheet branch.
+    # --------------------------------------------------------------------
+    validators:
+      # === final_output validators ==========================================
+      # On prompt_eval runs the source kind is `final_output` (the dedicated
+      # finalized event); on native runs it's `model_call` (the last
+      # model.call.completed — the real producer). The scorecard should never
+      # point at the system.run.completed wrapper.
+
+      # Evidence: regex_match with case-insensitive flag — "Fibonacci" or
+      # "fibonacci" anywhere in the final output both pass.
+      - key: final_output_mentions_fibonacci
+        type: regex_match
+        target: final_output
+        expected_from: "literal:(?i)fibonacci"
+
+      # Evidence: regex_match (matches inspector's highlighted-segment render)
+      - key: final_output_complexity_has_big_o
+        type: regex_match
+        target: final_output
+        expected_from: "literal:O\\([0-9a-zA-Z ^]+\\)"
+
+      # Evidence: json_schema — validates the structured summary shape.
+      - key: final_output_schema
+        type: json_schema
+        target: final_output
+        expected_from: "literal:{\"type\":\"object\",\"required\":[\"approach\",\"complexity\",\"sample_values\",\"explanation\"],\"properties\":{\"approach\":{\"type\":\"string\",\"enum\":[\"iterative\",\"recursive\",\"memoized\"]},\"complexity\":{\"type\":\"object\",\"required\":[\"time\",\"space\"],\"properties\":{\"time\":{\"type\":\"string\"},\"space\":{\"type\":\"string\"}}},\"sample_values\":{\"type\":\"array\",\"minItems\":3,\"items\":{\"type\":\"object\",\"required\":[\"n\",\"fib\"],\"properties\":{\"n\":{\"type\":\"integer\"},\"fib\":{\"type\":\"integer\"}}}},\"explanation\":{\"type\":\"string\",\"minLength\":40}}}"
+
+      # Evidence: json_path_match (existence comparator)
+      - key: final_output_has_approach
+        type: json_path_match
+        target: final_output
+        expected_from: "literal:{\"path\":\"$.approach\",\"comparator\":\"exists\"}"
+
+      # Evidence: json_path_match (equality comparator) — also verifies fib(10)
+      - key: final_output_fib_10_correct
+        type: json_path_match
+        target: final_output
+        expected_from: "literal:{\"path\":\"$.sample_values[2].fib\",\"comparator\":\"equals\",\"value\":55}"
+
+      # === file: validators — source.kind = tool_call =======================
+
+      # Evidence: text_compare (file contents vs literal needle)
+      - key: solution_defines_function
+        type: file_content_match
+        target: file:solution
+        expected_from: "literal:def fibonacci"
+        config:
+          mode: contains
+
+      # Evidence: regex_match on captured file — exercises the source pointer
+      # for a file validator in addition to another regex evidence block.
+      - key: solution_returns_an_int
+        type: regex_match
+        target: file:solution
+        expected_from: "literal:return\\s+\\w+"
+
+      # === code_execution — source.kind = tool_call, evidence = custom ======
+
+      # Runs the agent's captured file against a smoke test. The code
+      # execution event carries stdout/stderr/exit_code into raw_output,
+      # which the inspector surfaces as the "custom" evidence shape.
+      - key: tests_pass
+        type: code_execution
+        target: file:solution
+        config:
+          test_command: "python3 -c \"import sys; sys.path.insert(0,'/workspace'); from solution import fibonacci; assert fibonacci(0)==0; assert fibonacci(1)==1; assert fibonacci(10)==55; print('OK')\""
+          scoring: all_or_nothing
+
+      # === case.* validator — source is nil, no replay link =================
+
+      # Reads the expected approach list from case expectations. This validator
+      # targets case evidence, so the scorecard should NOT render a "View in
+      # replay →" link for it — it has no originating run event.
+      - key: approach_is_allowed
+        type: contains
+        target: "case.expectations.allowed_approaches"
+        expected_from: "case.payload.submitted_approach_hint"
+
+    # --------------------------------------------------------------------
+    # Metrics — all aggregate, all intentionally leave `source` nil (we
+    # dropped MetricResult.Source in the fix-up pass because no collector
+    # populates it).
+    # --------------------------------------------------------------------
+    metrics:
+      - key: completed
+        type: boolean
+        collector: run_completed_successfully
+      - key: total_latency_ms
+        type: numeric
+        collector: run_total_latency_ms
+        unit: ms
+      - key: total_tokens
+        type: numeric
+        collector: run_total_tokens
+
+    # --------------------------------------------------------------------
+    # LLM judges — one assertion-mode, one reference-mode, so the judge
+    # inspector shows both shapes.
+    # --------------------------------------------------------------------
+    llm_judges:
+      - key: code_quality
+        mode: reference
+        model: claude-sonnet-4-6
+        samples: 2
+        context_from:
+          - final_output
+          - case.expectations.reference_solution
+        reference_from: case.expectations.reference_solution
+        rubric: |
+          Score the submitted solution from 1 to 5 against the reference.
+          Reward clean, idiomatic Python with correct edge cases for n=0 and
+          n=1. Penalize unbounded recursion without memoization, shadowed
+          builtins, or missing type hints on the public function signature.
+
+      - key: explanation_clarity
+        mode: assertion
+        model: claude-haiku-4-5-20251001
+        samples: 3
+        context_from:
+          - final_output
+        assertion: |
+          The `explanation` field in the final output describes the chosen
+          approach in plain language, names the time/space complexity, and
+          justifies the complexity — not just restates it. One-sentence
+          descriptions that just say "it uses a loop" should fail.
+
+    runtime_limits:
+      max_duration_ms: 180000
+      max_total_tokens: 24000
+
+    # --------------------------------------------------------------------
+    # Scorecard — mix dimensions across validator / llm_judge / behavioral
+    # so the dimensions deck shows variety. `correctness` gates the run.
+    # --------------------------------------------------------------------
+    scorecard:
+      strategy: hybrid
+      judge_limits:
+        max_samples_per_judge: 3
+        max_tokens: 8000
+      dimensions:
+        - key: correctness
+          source: validators
+          validators:
+            - final_output_schema
+            - final_output_has_approach
+            - final_output_fib_10_correct
+            - solution_defines_function
+            - solution_returns_an_int
+            - tests_pass
+          better_direction: higher
+          gate: true
+          pass_threshold: 1.0
+          weight: 0.5
+
+        - key: output_contract
+          source: validators
+          validators:
+            - final_output_mentions_fibonacci
+            - final_output_complexity_has_big_o
+            - approach_is_allowed
+          better_direction: higher
+          weight: 0.1
+
+        - key: code_quality
+          source: llm_judge
+          judge_key: code_quality
+          better_direction: higher
+          weight: 0.25
+
+        - key: explanation_clarity
+          source: llm_judge
+          judge_key: explanation_clarity
+          better_direction: higher
+          weight: 0.15
+
+      pass_threshold: 0.7
+
+# --------------------------------------------------------------------
+# The challenge — one case, deliberately solvable, with an ambiguous
+# "submitted_approach_hint" that flows into the case.* validator above.
+# --------------------------------------------------------------------
+challenges:
+  - key: fibonacci-function
+    title: Implement a fibonacci function in Python
+    category: coding
+    difficulty: easy
+    instructions: |
+      Write a Python module at `/workspace/solution.py` that exports a
+      `fibonacci(n)` function returning the n-th Fibonacci number (with
+      fib(0) = 0 and fib(1) = 1). Any correct algorithm is fine, but prefer
+      iterative or memoized over naive recursive.
+
+      After writing the file, emit a single final JSON answer that matches
+      this shape exactly (no surrounding prose, no code fences):
+
+          {
+            "approach": "iterative" | "recursive" | "memoized",
+            "complexity": { "time": "O(n)", "space": "O(1)" },
+            "sample_values": [
+              { "n": 0, "fib": 0 },
+              { "n": 1, "fib": 1 },
+              { "n": 10, "fib": 55 }
+            ],
+            "explanation": "Plain-language description of the approach, the time/space complexity, and why that complexity holds. At least a few sentences."
+          }
+
+      The `explanation` must actually justify the complexity, not just
+      restate it. The `sample_values` list must include at least n=0, n=1,
+      and n=10 with correct fibonacci numbers.
+
+input_sets:
+  - key: default
+    name: Default Input Set
+    cases:
+      - challenge_key: fibonacci-function
+        case_key: iterative-preferred
+        payload:
+          submitted_approach_hint: "iterative"
+        expectations:
+          - key: allowed_approaches
+            kind: text
+            value: "iterative, memoized, recursive"
+          - key: reference_solution
+            kind: text
+            value: |
+              Reference implementation (iterative, O(n) time, O(1) space):
+
+                  def fibonacci(n: int) -> int:
+                      if n < 0:
+                          raise ValueError("n must be non-negative")
+                      a, b = 0, 1
+                      for _ in range(n):
+                          a, b = b, a + b
+                      return a
+
+              The final-output JSON should look like:
+
+                  {
+                    "approach": "iterative",
+                    "complexity": {"time": "O(n)", "space": "O(1)"},
+                    "sample_values": [
+                      {"n": 0, "fib": 0},
+                      {"n": 1, "fib": 1},
+                      {"n": 10, "fib": 55}
+                    ],
+                    "explanation": "Walks two running values up to n, so each step is O(1) and the total is O(n). We only hold two integers at any time, so space is O(1)."
+                  }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/inspector-sheet.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/inspector-sheet.tsx
@@ -613,6 +613,7 @@ function Stat({ label, value }: { label: string; value: string }) {
 const sourceKindLabel: Record<ScorecardSource["kind"], string> = {
   run_event: "Run event",
   tool_call: "Tool call",
+  model_call: "Model call",
   final_output: "Final output",
 };
 

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -673,7 +673,7 @@ export interface ValidatorDetail {
 }
 
 export interface ScorecardSource {
-  kind: "run_event" | "tool_call" | "final_output";
+  kind: "run_event" | "tool_call" | "model_call" | "final_output";
   sequence?: number;
   event_type?: string;
   field_path?: string;


### PR DESCRIPTION
## Summary
Two production issues surfaced when @Atharva-Kanherkar ran the E2E pack against live models on main:

1. **Every model's final_output deep-link landed on `system.run.completed` (the run-wide wrapper step)** instead of the step that actually produced the final text. The previous fix guarded against overwriting a finalized-event source, but on **native** runs no `system.output.finalized` event is ever emitted, so the wrapper was still the only candidate.

2. **`json_schema` validators rejected valid integer values as type "string".** The scoring engine parses JSON with `decoder.UseNumber()` — useful for numeric-precision comparisons in JSONPath, but incompatible with `google/jsonschema-go`, which reflects on the Go kind and sees `json.Number` (a string alias) as type `string` instead of `integer`/`number`.

Also picks up the pack-quality issue: `contains: "fibonacci"` on an agent whose output contains `Fibonacci` fails case-sensitively.

## Fix 1 — final_output source points at the real producer

Rejected the superficial fix ("emit `system.output.finalized` from the native observer to mirror prompt_eval"). That would be a synthetic sibling event solely to game the existing resolver — the real problem is that `system.run.completed` is a wrapper and should never be used as a source.

Instead:

- `extractedEvidence` now tracks `lastModelCallSource` on every `model.call.completed`.
- `resolveEvidenceSource("final_output", …)` prefers `finalOutputSource` (set only by `system.output.finalized`) → else `lastModelCallSource` (the actual producer of the agent's text) → else `nil`.
- `system.run.completed` **never** sets `finalOutputSource`. A missing "View in replay →" link beats one that highlights the entire run.
- New `SourceKindModelCall = "model_call"` kind so the UI labels these honestly. Threaded through OpenAPI (`enum: [run_event, tool_call, model_call, final_output]`), TS types, and the inspector's `sourceKindLabel`.

Regression tests:
- `TestEvaluateRunAgent_ThreadsSourcePointerForFinalOutputValidator` — finalized event wins when both are present (sequence=41 not 42).
- `TestEvaluateRunAgent_FinalOutputSourceFallsBackToLastModelCall` — native run with two model calls picks the last one (seq 12, not the wrapper at seq 16).
- `TestEvaluateRunAgent_FinalOutputSourceIsNilWhenOnlyRunCompletedExists` — wrapper-only input returns nil source.

## Fix 2 — JSON-schema validator accepts integers again

- New `parseJSONDocument` helper decodes without `UseNumber` and is used **only** for schema validation. `parseJSONValue` (with `UseNumber`) stays on the JSONPath path so numeric precision there is preserved.
- Added a regression test in `TestValidateJSONSchema`: a nested `{"sample_values":[{"n":0,"fib":0},…]}` document satisfies a schema with `type: integer` on `n` and `fib`.

## Fix 3 — pack case-insensitivity

`final_output_mentions_fibonacci` is now a `regex_match` with `(?i)fibonacci` rather than a case-sensitive `contains`.

## Validation
- `go test -short -race -count=1 ./internal/scoring/... ./internal/repository/... ./internal/workflow/...` — all green.
- `npx tsc --noEmit`, `npx vitest run src/components/replay/` — green.
- `challengepack.ParseYAML` + `ValidateBundle` re-validated against the updated pack.

## Test plan
- [ ] Re-run any deployed agent against the fibonacci-e2e-showcase pack. Verify the scorecard inspector's "View in replay →" card for final_output validators labels as **Model call** (not "Run event") and the link lands on the last `model.call.completed` step, not the wrapper.
- [ ] Verify `final_output_schema` validator now passes for outputs that use integer `n` / `fib` values.
- [ ] Verify `final_output_mentions_fibonacci` passes regardless of capitalization.