### PR TITLE
feat(failures): Run → Failures page (closes #320)

### DIFF
--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failure-detail-drawer.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failure-detail-drawer.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowUpRight, Play } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Badge } from "@/components/ui/badge";
+import type { FailureReviewItem } from "@/lib/api/types";
+import { cn } from "@/lib/utils";
+
+interface FailureDetailDrawerProps {
+  item: FailureReviewItem | null;
+  workspaceId: string;
+  onClose: () => void;
+}
+
+function humanize(value: string): string {
+  return value.replace(/_/g, " ");
+}
+
+export function FailureDetailDrawer({
+  item,
+  workspaceId,
+  onClose,
+}: FailureDetailDrawerProps) {
+  const open = item != null;
+
+  return (
+    <Sheet
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <SheetContent
+        side="right"
+        className="w-full sm:max-w-xl p-0 flex flex-col gap-0"
+      >
+        <SheetTitle className="sr-only">
+          {item ? `Failure: ${item.case_key}` : "Failure detail"}
+        </SheetTitle>
+        {item && <FailureDetailBody item={item} workspaceId={workspaceId} />}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function FailureDetailBody({
+  item,
+  workspaceId,
+}: {
+  item: FailureReviewItem;
+  workspaceId: string;
+}) {
+  const firstReplay = item.replay_step_refs[0];
+  const replayHref = firstReplay
+    ? `/workspaces/${workspaceId}/runs/${item.run_id}/agents/${item.run_agent_id}/replay?step=${firstReplay.sequence_number}`
+    : undefined;
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* Header */}
+      <div className="border-b border-border px-6 pt-6 pb-4">
+        <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.18em] text-muted-foreground mb-2">
+          <span>Failure review</span>
+          <span className="text-muted-foreground/50">·</span>
+          <span className="normal-case tracking-normal font-[family-name:var(--font-mono)] text-xs">
+            {item.challenge_key}
+          </span>
+        </div>
+        <h2 className="text-base font-medium text-foreground tracking-tight mb-1">
+          {item.case_key}
+        </h2>
+        {item.headline && (
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            {item.headline}
+          </p>
+        )}
+
+        <div className="flex flex-wrap items-center gap-1.5 mt-3">
+          <Badge variant="destructive">{humanize(item.failure_state)}</Badge>
+          <Badge variant="outline">{humanize(item.failure_class)}</Badge>
+          <Badge variant="secondary">{item.severity}</Badge>
+          <Badge variant="secondary">{humanize(item.evidence_tier)}</Badge>
+          {item.promotable && (
+            <Badge
+              variant="outline"
+              className="border-emerald-500/40 text-emerald-400"
+            >
+              Promotable
+            </Badge>
+          )}
+        </div>
+      </div>
+
+      {/* Scrollable body */}
+      <div className="flex-1 overflow-y-auto px-6 py-5 space-y-6">
+        {replayHref && (
+          <Link
+            href={replayHref}
+            className="group flex items-center justify-between gap-3 rounded-lg border border-border px-4 py-3 hover:border-foreground/25 hover:bg-muted/30 transition-colors"
+          >
+            <div className="flex items-center gap-3 min-w-0">
+              <Play className="size-4 text-foreground/70 shrink-0" />
+              <div className="min-w-0">
+                <div className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+                  Open replay
+                </div>
+                <div className="text-sm text-foreground font-[family-name:var(--font-mono)] truncate">
+                  step #{firstReplay?.sequence_number} ·{" "}
+                  {firstReplay?.event_type}
+                </div>
+              </div>
+            </div>
+            <ArrowUpRight className="size-4 text-muted-foreground group-hover:text-foreground" />
+          </Link>
+        )}
+
+        {item.detail && (
+          <Section title="Detail">
+            <p className="text-sm text-foreground/90 leading-relaxed whitespace-pre-wrap">
+              {item.detail}
+            </p>
+          </Section>
+        )}
+
+        {item.recommended_action && (
+          <Section title="Recommended action">
+            <p className="text-sm text-foreground/90 leading-relaxed whitespace-pre-wrap">
+              {item.recommended_action}
+            </p>
+          </Section>
+        )}
+
+        {item.failed_dimensions.length > 0 && (
+          <Section title="Failed dimensions">
+            <div className="flex flex-wrap gap-1.5">
+              {item.failed_dimensions.map((d) => (
+                <Badge
+                  key={d}
+                  variant="outline"
+                  className="font-[family-name:var(--font-mono)]"
+                >
+                  {d}
+                </Badge>
+              ))}
+            </div>
+          </Section>
+        )}
+
+        {item.failed_checks.length > 0 && (
+          <Section title="Failed checks">
+            <ul className="space-y-1.5">
+              {item.failed_checks.map((c, i) => (
+                <li
+                  key={i}
+                  className="font-[family-name:var(--font-mono)] text-xs text-foreground/85 bg-muted/40 border border-border rounded px-2 py-1.5"
+                >
+                  {c}
+                </li>
+              ))}
+            </ul>
+          </Section>
+        )}
+
+        {item.judge_refs.length > 0 && (
+          <Section title="Judge evidence">
+            <div className="divide-y divide-border border border-border rounded-lg overflow-hidden">
+              {item.judge_refs.map((j, i) => (
+                <div
+                  key={`${j.key}-${i}`}
+                  className="px-3 py-2.5 flex items-start gap-3"
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="font-[family-name:var(--font-mono)] text-xs text-foreground/90 truncate">
+                        {j.key}
+                      </span>
+                      <Badge variant="secondary">{j.kind}</Badge>
+                      {j.verdict && (
+                        <Badge
+                          variant="outline"
+                          className={cn(
+                            j.verdict === "fail" && "text-destructive",
+                          )}
+                        >
+                          {j.verdict}
+                        </Badge>
+                      )}
+                    </div>
+                    {j.reason && (
+                      <p className="text-xs text-muted-foreground mt-1 leading-snug">
+                        {j.reason}
+                      </p>
+                    )}
+                  </div>
+                  {j.normalized_score != null && (
+                    <span className="font-[family-name:var(--font-mono)] text-xs tabular-nums text-foreground/75">
+                      {(j.normalized_score * 100).toFixed(1)}
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          </Section>
+        )}
+
+        {item.metric_refs.length > 0 && (
+          <Section title="Metrics">
+            <div className="divide-y divide-border border border-border rounded-lg overflow-hidden">
+              {item.metric_refs.map((m, i) => (
+                <div
+                  key={`${m.key}-${i}`}
+                  className="px-3 py-2 flex items-center gap-3"
+                >
+                  <span className="font-[family-name:var(--font-mono)] text-xs text-foreground/90 flex-1 truncate">
+                    {m.key}
+                  </span>
+                  <Badge variant="secondary">{m.metric_type}</Badge>
+                  <span className="font-[family-name:var(--font-mono)] text-xs tabular-nums text-muted-foreground min-w-16 text-right">
+                    {formatMetric(m)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </Section>
+        )}
+
+        {item.replay_step_refs.length > 1 && (
+          <Section title="Other replay steps">
+            <div className="space-y-1.5">
+              {item.replay_step_refs.slice(1).map((r, i) => (
+                <Link
+                  key={i}
+                  href={`/workspaces/${workspaceId}/runs/${item.run_id}/agents/${item.run_agent_id}/replay?step=${r.sequence_number}`}
+                  className="flex items-center justify-between gap-3 rounded-md border border-border px-3 py-2 hover:bg-muted/30 transition-colors text-xs"
+                >
+                  <span className="font-[family-name:var(--font-mono)] text-foreground/85 truncate">
+                    #{r.sequence_number} · {r.event_type}
+                  </span>
+                  <ArrowUpRight className="size-3.5 text-muted-foreground" />
+                </Link>
+              ))}
+            </div>
+          </Section>
+        )}
+
+        {item.artifact_refs.length > 0 && (
+          <Section title="Artifacts">
+            <ul className="space-y-1">
+              {item.artifact_refs.map((a, i) => (
+                <li
+                  key={`${a.key}-${i}`}
+                  className="text-xs font-[family-name:var(--font-mono)] text-foreground/80 truncate"
+                >
+                  {a.key}
+                  {a.media_type && (
+                    <span className="text-muted-foreground ml-1.5">
+                      · {a.media_type}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </Section>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <h3 className="text-[10px] uppercase tracking-[0.2em] text-muted-foreground mb-2 font-medium">
+        {title}
+      </h3>
+      {children}
+    </div>
+  );
+}
+
+function formatMetric(m: {
+  numeric_value?: number;
+  boolean_value?: boolean;
+  text_value?: string;
+  unit?: string;
+}): string {
+  if (m.numeric_value != null) {
+    const v = m.numeric_value.toLocaleString(undefined, {
+      maximumFractionDigits: 4,
+    });
+    return m.unit ? `${v} ${m.unit}` : v;
+  }
+  if (m.boolean_value != null) return m.boolean_value ? "true" : "false";
+  if (m.text_value != null) return m.text_value;
+  return "—";
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.tsx
@@ -1,0 +1,654 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  Inbox,
+  Play,
+  X,
+} from "lucide-react";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import { listRunFailures } from "@/lib/api/failure-reviews";
+import type {
+  FailureReviewEvidenceTier,
+  FailureReviewFailureClass,
+  FailureReviewItem,
+  FailureReviewSeverity,
+  ListRunFailuresResponse,
+  RunAgent,
+} from "@/lib/api/types";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ErrorBoundary } from "@/components/ui/error-boundary";
+import { FailureDetailDrawer } from "./failure-detail-drawer";
+
+// --- Filter enums + labels ---
+
+const SEVERITY_OPTIONS: FailureReviewSeverity[] = [
+  "info",
+  "warning",
+  "blocking",
+];
+
+const FAILURE_CLASS_OPTIONS: FailureReviewFailureClass[] = [
+  "incorrect_final_output",
+  "tool_selection_error",
+  "tool_argument_error",
+  "retrieval_grounding_failure",
+  "policy_violation",
+  "timeout_or_budget_exhaustion",
+  "sandbox_failure",
+  "malformed_output",
+  "flaky_non_deterministic",
+  "insufficient_evidence",
+  "other",
+];
+
+const EVIDENCE_TIER_OPTIONS: FailureReviewEvidenceTier[] = [
+  "none",
+  "native_structured",
+  "hosted_structured",
+  "hosted_black_box",
+  "derived_summary",
+];
+
+function humanize(value: string): string {
+  return value.replace(/_/g, " ");
+}
+
+const severityVariant: Record<
+  FailureReviewSeverity,
+  "default" | "secondary" | "outline" | "destructive"
+> = {
+  info: "secondary",
+  warning: "outline",
+  blocking: "destructive",
+};
+
+const failureStateVariant: Record<
+  FailureReviewItem["failure_state"],
+  "default" | "secondary" | "outline" | "destructive"
+> = {
+  failed: "destructive",
+  warning: "outline",
+  flaky: "outline",
+  incomplete_evidence: "secondary",
+};
+
+// --- URL <-> state helpers ---
+
+interface Filters {
+  agentId?: string;
+  severity?: FailureReviewSeverity;
+  failureClass?: FailureReviewFailureClass;
+  evidenceTier?: FailureReviewEvidenceTier;
+}
+
+function parseFilters(params: URLSearchParams): Filters {
+  return {
+    agentId: params.get("agent") ?? undefined,
+    severity:
+      (params.get("severity") as FailureReviewSeverity | null) ?? undefined,
+    failureClass:
+      (params.get("class") as FailureReviewFailureClass | null) ?? undefined,
+    evidenceTier:
+      (params.get("tier") as FailureReviewEvidenceTier | null) ?? undefined,
+  };
+}
+
+function filtersToQuery(filters: Filters): string {
+  const sp = new URLSearchParams();
+  if (filters.agentId) sp.set("agent", filters.agentId);
+  if (filters.severity) sp.set("severity", filters.severity);
+  if (filters.failureClass) sp.set("class", filters.failureClass);
+  if (filters.evidenceTier) sp.set("tier", filters.evidenceTier);
+  const s = sp.toString();
+  return s ? `?${s}` : "";
+}
+
+function filtersEqual(a: Filters, b: Filters): boolean {
+  return (
+    a.agentId === b.agentId &&
+    a.severity === b.severity &&
+    a.failureClass === b.failureClass &&
+    a.evidenceTier === b.evidenceTier
+  );
+}
+
+// --- Component ---
+
+interface FailuresClientProps {
+  workspaceId: string;
+  runId: string;
+  runName: string;
+  agents: RunAgent[];
+  initialPage: ListRunFailuresResponse;
+  initialLimit: number;
+}
+
+export function FailuresClient(props: FailuresClientProps) {
+  return (
+    <ErrorBoundary>
+      <FailuresClientInner {...props} />
+    </ErrorBoundary>
+  );
+}
+
+function FailuresClientInner({
+  workspaceId,
+  runId,
+  agents,
+  initialPage,
+  initialLimit,
+}: FailuresClientProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { getAccessToken } = useAccessToken();
+
+  const urlFilters = useMemo(
+    () => parseFilters(searchParams),
+    [searchParams],
+  );
+
+  // Drive data from filters. Initial SSR page corresponds to "no filters".
+  const [items, setItems] = useState<FailureReviewItem[]>(initialPage.items);
+  const [cursor, setCursor] = useState<string | undefined>(
+    initialPage.next_cursor,
+  );
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<FailureReviewItem | null>(null);
+  const [, startTransition] = useTransition();
+
+  // Track the filter set currently reflected in `items` so we don't refetch
+  // the initial SSR page when the URL already matches empty filters.
+  const activeFiltersRef = useRef<Filters>({});
+
+  const anyFilterActive = useMemo(
+    () => !!(urlFilters.agentId || urlFilters.severity || urlFilters.failureClass || urlFilters.evidenceTier),
+    [urlFilters],
+  );
+
+  // Refetch when filters change. Skip the initial render if URL has no
+  // filters — SSR already covered it.
+  useEffect(() => {
+    if (filtersEqual(urlFilters, activeFiltersRef.current)) return;
+
+    let cancelled = false;
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      try {
+        const token = await getAccessToken();
+        const api = createApiClient(token);
+        const res = await listRunFailures(api, workspaceId, runId, {
+          limit: initialLimit,
+          signal: controller.signal,
+          ...urlFilters,
+        });
+        if (cancelled) return;
+        setItems(res.items);
+        setCursor(res.next_cursor);
+        activeFiltersRef.current = urlFilters;
+      } catch (err) {
+        if (cancelled) return;
+        if (err instanceof ApiError) {
+          setError(err.message);
+        } else if (err instanceof Error && err.name !== "AbortError") {
+          setError(err.message);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [urlFilters, workspaceId, runId, initialLimit, getAccessToken]);
+
+  const updateFilter = useCallback(
+    <K extends keyof Filters>(key: K, value: Filters[K]) => {
+      const next: Filters = { ...urlFilters, [key]: value };
+      const query = filtersToQuery(next);
+      startTransition(() => {
+        router.replace(
+          `/workspaces/${workspaceId}/runs/${runId}/failures${query}`,
+          { scroll: false },
+        );
+      });
+    },
+    [urlFilters, router, workspaceId, runId],
+  );
+
+  const clearFilters = useCallback(() => {
+    startTransition(() => {
+      router.replace(`/workspaces/${workspaceId}/runs/${runId}/failures`, {
+        scroll: false,
+      });
+    });
+  }, [router, workspaceId, runId]);
+
+  const loadMore = useCallback(async () => {
+    if (!cursor || loadingMore) return;
+    setLoadingMore(true);
+    setError(null);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      const res = await listRunFailures(api, workspaceId, runId, {
+        limit: initialLimit,
+        cursor,
+        ...urlFilters,
+      });
+      setItems((prev) => [...prev, ...res.items]);
+      setCursor(res.next_cursor);
+    } catch (err) {
+      if (err instanceof ApiError) setError(err.message);
+      else if (err instanceof Error) setError(err.message);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [cursor, loadingMore, getAccessToken, workspaceId, runId, initialLimit, urlFilters]);
+
+  const agentLabel = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const a of agents) map.set(a.id, a.label);
+    return map;
+  }, [agents]);
+
+  const groups = useMemo(() => groupByChallenge(items), [items]);
+
+  // Default-collapse the accordion when the list is large.
+  const largeList = items.length > 20;
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-lg font-semibold tracking-tight mb-1">Failures</h1>
+        <p className="text-sm text-muted-foreground">
+          Per-case failure review for this run. Use filters to narrow by agent,
+          severity, failure class, or evidence tier.
+        </p>
+      </header>
+
+      <FilterBar
+        agents={agents}
+        filters={urlFilters}
+        onChange={updateFilter}
+        onClear={anyFilterActive ? clearFilters : undefined}
+      />
+
+      {loading ? (
+        <ListSkeleton />
+      ) : error ? (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-6 text-center text-sm text-destructive">
+          <AlertTriangle className="size-5 mx-auto mb-2" />
+          {error}
+        </div>
+      ) : items.length === 0 ? (
+        <EmptyState
+          icon={<Inbox className="size-8" />}
+          title="No failures recorded for this run."
+          description={
+            anyFilterActive
+              ? "No failures match the current filters."
+              : "This run completed without any failed cases."
+          }
+          action={
+            anyFilterActive
+              ? { label: "Clear filters", onClick: clearFilters }
+              : undefined
+          }
+        />
+      ) : (
+        <div className="space-y-3">
+          {groups.map((group) => (
+            <ChallengeGroup
+              key={group.challengeKey}
+              challengeKey={group.challengeKey}
+              items={group.items}
+              agentLabels={agentLabel}
+              defaultOpen={!largeList}
+              workspaceId={workspaceId}
+              runId={runId}
+              onSelect={setSelected}
+            />
+          ))}
+
+          {cursor && (
+            <div className="flex justify-center pt-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={loadMore}
+                disabled={loadingMore}
+              >
+                {loadingMore ? "Loading…" : "Load more"}
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+
+      <FailureDetailDrawer
+        item={selected}
+        onClose={() => setSelected(null)}
+        workspaceId={workspaceId}
+      />
+    </div>
+  );
+}
+
+// --- Sub-components ---
+
+function FilterBar({
+  agents,
+  filters,
+  onChange,
+  onClear,
+}: {
+  agents: RunAgent[];
+  filters: Filters;
+  onChange: <K extends keyof Filters>(key: K, value: Filters[K]) => void;
+  onClear?: () => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-end gap-3 rounded-lg border border-border bg-card/40 p-3">
+      <FilterSelect
+        label="Agent"
+        value={filters.agentId ?? ""}
+        onChange={(v) => onChange("agentId", v || undefined)}
+        options={[
+          { value: "", label: "All agents" },
+          ...agents.map((a) => ({ value: a.id, label: a.label })),
+        ]}
+      />
+      <FilterSelect
+        label="Severity"
+        value={filters.severity ?? ""}
+        onChange={(v) =>
+          onChange(
+            "severity",
+            (v || undefined) as FailureReviewSeverity | undefined,
+          )
+        }
+        options={[
+          { value: "", label: "All severities" },
+          ...SEVERITY_OPTIONS.map((s) => ({ value: s, label: humanize(s) })),
+        ]}
+      />
+      <FilterSelect
+        label="Failure class"
+        value={filters.failureClass ?? ""}
+        onChange={(v) =>
+          onChange(
+            "failureClass",
+            (v || undefined) as FailureReviewFailureClass | undefined,
+          )
+        }
+        options={[
+          { value: "", label: "All classes" },
+          ...FAILURE_CLASS_OPTIONS.map((c) => ({
+            value: c,
+            label: humanize(c),
+          })),
+        ]}
+      />
+      <FilterSelect
+        label="Evidence tier"
+        value={filters.evidenceTier ?? ""}
+        onChange={(v) =>
+          onChange(
+            "evidenceTier",
+            (v || undefined) as FailureReviewEvidenceTier | undefined,
+          )
+        }
+        options={[
+          { value: "", label: "All tiers" },
+          ...EVIDENCE_TIER_OPTIONS.map((t) => ({
+            value: t,
+            label: humanize(t),
+          })),
+        ]}
+      />
+
+      {onClear && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onClear}
+          className="ml-auto"
+        >
+          <X className="size-3.5 mr-1" />
+          Clear
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function FilterSelect({
+  label,
+  value,
+  onChange,
+  options,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: { value: string; label: string }[];
+}) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+        {label}
+      </span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className={cn(
+          "h-8 rounded-md border border-input bg-transparent px-2.5 text-sm",
+          "focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 outline-none",
+          "dark:bg-input/30",
+        )}
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+interface ChallengeGroupProps {
+  challengeKey: string;
+  items: FailureReviewItem[];
+  agentLabels: Map<string, string>;
+  defaultOpen: boolean;
+  workspaceId: string;
+  runId: string;
+  onSelect: (item: FailureReviewItem) => void;
+}
+
+function ChallengeGroup({
+  challengeKey,
+  items,
+  agentLabels,
+  defaultOpen,
+  workspaceId,
+  runId,
+  onSelect,
+}: ChallengeGroupProps) {
+  const [open, setOpen] = useState(defaultOpen);
+  const blockingCount = items.filter((i) => i.severity === "blocking").length;
+
+  return (
+    <div className="rounded-lg border border-border overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="w-full flex items-center gap-2 px-4 py-2.5 text-left hover:bg-muted/40 transition-colors"
+      >
+        {open ? (
+          <ChevronDown className="size-4 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="size-4 text-muted-foreground" />
+        )}
+        <span className="font-medium text-sm truncate">{challengeKey}</span>
+        <span className="text-xs text-muted-foreground ml-2">
+          {items.length} failure{items.length === 1 ? "" : "s"}
+        </span>
+        {blockingCount > 0 && (
+          <Badge variant="destructive" className="ml-1">
+            {blockingCount} blocking
+          </Badge>
+        )}
+      </button>
+
+      {open && (
+        <ul className="divide-y divide-border border-t border-border">
+          {items.map((item) => (
+            <FailureRow
+              key={`${item.run_agent_id}:${item.item_key}`}
+              item={item}
+              agentLabel={agentLabels.get(item.run_agent_id) ?? "Agent"}
+              workspaceId={workspaceId}
+              runId={runId}
+              onSelect={onSelect}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function FailureRow({
+  item,
+  agentLabel,
+  workspaceId,
+  runId,
+  onSelect,
+}: {
+  item: FailureReviewItem;
+  agentLabel: string;
+  workspaceId: string;
+  runId: string;
+  onSelect: (item: FailureReviewItem) => void;
+}) {
+  const firstReplayStep = item.replay_step_refs[0]?.sequence_number;
+  const replayHref = firstReplayStep
+    ? `/workspaces/${workspaceId}/runs/${runId}/agents/${item.run_agent_id}/replay?step=${firstReplayStep}`
+    : undefined;
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => onSelect(item)}
+        className="w-full text-left px-4 py-3 hover:bg-muted/30 transition-colors flex flex-col gap-2"
+      >
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="font-medium text-sm truncate">{item.case_key}</span>
+          <span className="text-xs text-muted-foreground">· {agentLabel}</span>
+          <Badge variant={failureStateVariant[item.failure_state]}>
+            {humanize(item.failure_state)}
+          </Badge>
+          <Badge variant="outline">{humanize(item.failure_class)}</Badge>
+          <Badge variant={severityVariant[item.severity]}>{item.severity}</Badge>
+          <Badge variant="secondary">{humanize(item.evidence_tier)}</Badge>
+        </div>
+
+        {item.headline && (
+          <p className="text-sm text-foreground/90 line-clamp-2">
+            {item.headline}
+          </p>
+        )}
+
+        <div className="flex items-center gap-3 text-xs text-muted-foreground flex-wrap">
+          {item.failed_dimensions.length > 0 && (
+            <span>
+              Failed:{" "}
+              <span className="text-foreground/80 font-[family-name:var(--font-mono)]">
+                {item.failed_dimensions.join(", ")}
+              </span>
+            </span>
+          )}
+          {replayHref && (
+            <Link
+              href={replayHref}
+              onClick={(e) => e.stopPropagation()}
+              className="flex items-center gap-1 hover:text-foreground transition-colors"
+            >
+              <Play className="size-3" />
+              Replay step #{firstReplayStep}
+            </Link>
+          )}
+        </div>
+      </button>
+    </li>
+  );
+}
+
+function ListSkeleton() {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div
+          key={i}
+          className="rounded-lg border border-border p-4 space-y-3"
+        >
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-4 w-full" />
+          <div className="flex gap-2">
+            <Skeleton className="h-5 w-20" />
+            <Skeleton className="h-5 w-24" />
+            <Skeleton className="h-5 w-16" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface ChallengeGroupData {
+  challengeKey: string;
+  items: FailureReviewItem[];
+}
+
+function groupByChallenge(items: FailureReviewItem[]): ChallengeGroupData[] {
+  const groups = new Map<string, FailureReviewItem[]>();
+  for (const item of items) {
+    const key = item.challenge_key;
+    const existing = groups.get(key);
+    if (existing) existing.push(item);
+    else groups.set(key, [item]);
+  }
+  return Array.from(groups.entries()).map(([challengeKey, items]) => ({
+    challengeKey,
+    items,
+  }));
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/page.tsx
@@ -1,0 +1,76 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { redirect, notFound } from "next/navigation";
+import Link from "next/link";
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import { listRunFailures } from "@/lib/api/failure-reviews";
+import type {
+  ListRunFailuresResponse,
+  Run,
+  RunAgent,
+} from "@/lib/api/types";
+import { FailuresClient } from "./failures-client";
+
+const DEFAULT_LIMIT = 50;
+
+export default async function RunFailuresPage({
+  params,
+}: {
+  params: Promise<{ workspaceId: string; runId: string }>;
+}) {
+  const { accessToken } = await withAuth();
+  if (!accessToken) redirect("/auth/login");
+
+  const { workspaceId, runId } = await params;
+  const api = createApiClient(accessToken);
+
+  let run: Run;
+  let agents: RunAgent[];
+  let initialPage: ListRunFailuresResponse;
+  try {
+    const [runRes, agentsRes, firstPage] = await Promise.all([
+      api.get<Run>(`/v1/runs/${runId}`),
+      api.get<{ items: RunAgent[] }>(`/v1/runs/${runId}/agents`),
+      listRunFailures(api, workspaceId, runId, { limit: DEFAULT_LIMIT }),
+    ]);
+    run = runRes;
+    agents = agentsRes.items;
+    initialPage = firstPage;
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) {
+      notFound();
+    }
+    throw err;
+  }
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 mb-4">
+        <Link
+          href={`/workspaces/${workspaceId}/runs`}
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Runs
+        </Link>
+        <span className="text-muted-foreground/40">/</span>
+        <Link
+          href={`/workspaces/${workspaceId}/runs/${runId}`}
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {run.name}
+        </Link>
+        <span className="text-muted-foreground/40">/</span>
+        <span className="text-sm text-foreground">Failures</span>
+      </div>
+
+      <FailuresClient
+        workspaceId={workspaceId}
+        runId={runId}
+        runName={run.name}
+        agents={agents}
+        initialPage={initialPage}
+        initialLimit={DEFAULT_LIMIT}
+      />
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
@@ -32,6 +32,7 @@ import {
   XCircle,
   Loader2,
   AlertTriangle,
+  AlertOctagon,
 } from "lucide-react";
 import { ScorecardSummaryCard } from "./scorecard-summary-card";
 import { CompareRunPicker } from "./compare-run-picker";
@@ -313,6 +314,13 @@ export function RunDetailClient({
             workspaceId={workspaceId}
             runId={run.id}
           />
+          <Link
+            href={`/workspaces/${workspaceId}/runs/${run.id}/failures`}
+            className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 h-8 text-xs text-muted-foreground hover:text-foreground hover:bg-muted/40 transition-colors"
+          >
+            <AlertOctagon className="size-3.5" />
+            Failures
+          </Link>
         </div>
 
         {/* KPI strip */}

--- a/web/src/lib/api/failure-reviews.ts
+++ b/web/src/lib/api/failure-reviews.ts
@@ -1,0 +1,58 @@
+import type { ApiClient } from "./client";
+import type {
+  FailureReviewEvidenceTier,
+  FailureReviewFailureClass,
+  FailureReviewSeverity,
+  ListRunFailuresResponse,
+} from "./types";
+
+export interface ListRunFailuresParams {
+  agentId?: string;
+  severity?: FailureReviewSeverity;
+  failureClass?: FailureReviewFailureClass;
+  evidenceTier?: FailureReviewEvidenceTier;
+  challengeKey?: string;
+  caseKey?: string;
+  cursor?: string;
+  limit?: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * GET /v1/workspaces/{workspaceId}/runs/{runId}/failures
+ * Cursor-paginated list of failure review items for a completed run.
+ */
+export function listRunFailures(
+  api: ApiClient,
+  workspaceId: string,
+  runId: string,
+  params: ListRunFailuresParams = {},
+): Promise<ListRunFailuresResponse> {
+  const {
+    agentId,
+    severity,
+    failureClass,
+    evidenceTier,
+    challengeKey,
+    caseKey,
+    cursor,
+    limit,
+    signal,
+  } = params;
+  return api.get<ListRunFailuresResponse>(
+    `/v1/workspaces/${workspaceId}/runs/${runId}/failures`,
+    {
+      signal,
+      params: {
+        agent_id: agentId,
+        severity,
+        failure_class: failureClass,
+        evidence_tier: evidenceTier,
+        challenge_key: challengeKey,
+        case_key: caseKey,
+        cursor,
+        limit,
+      },
+    },
+  );
+}

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -33,5 +33,17 @@ export type {
   ReplaySummary,
   ReplayPagination,
   ReplayResponse,
+  FailureReviewItem,
+  FailureReviewFailureState,
+  FailureReviewFailureClass,
+  FailureReviewEvidenceTier,
+  FailureReviewPromotionMode,
+  FailureReviewSeverity,
+  FailureReviewReplayStepRef,
+  FailureReviewArtifactRef,
+  FailureReviewJudgeRef,
+  FailureReviewMetricRef,
+  ListRunFailuresResponse,
 } from "./types";
 export { AGENT_KINDS } from "./types";
+export { listRunFailures, type ListRunFailuresParams } from "./failure-reviews";

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -1039,6 +1039,103 @@ export interface PlaygroundExperimentComparison {
   per_case: PlaygroundCaseComparison[];
 }
 
+// --- Failure Review ---
+// Mirrors schemas under `FailureReview*` in docs/api-server/openapi.yaml.
+
+export type FailureReviewFailureState =
+  | "failed"
+  | "warning"
+  | "flaky"
+  | "incomplete_evidence";
+
+export type FailureReviewFailureClass =
+  | "incorrect_final_output"
+  | "tool_selection_error"
+  | "tool_argument_error"
+  | "retrieval_grounding_failure"
+  | "policy_violation"
+  | "timeout_or_budget_exhaustion"
+  | "sandbox_failure"
+  | "malformed_output"
+  | "flaky_non_deterministic"
+  | "insufficient_evidence"
+  | "other";
+
+export type FailureReviewEvidenceTier =
+  | "none"
+  | "native_structured"
+  | "hosted_structured"
+  | "hosted_black_box"
+  | "derived_summary";
+
+export type FailureReviewPromotionMode = "full_executable" | "output_only";
+
+export type FailureReviewSeverity = "info" | "warning" | "blocking";
+
+export interface FailureReviewReplayStepRef {
+  sequence_number: number;
+  event_type: string;
+  kind: string;
+}
+
+export interface FailureReviewArtifactRef {
+  key: string;
+  kind?: string;
+  path?: string;
+  media_type?: string;
+}
+
+export interface FailureReviewJudgeRef {
+  key: string;
+  kind: string;
+  verdict?: string;
+  state?: string;
+  normalized_score?: number;
+  reason?: string;
+  sequence_number?: number;
+  event_type?: string;
+}
+
+export interface FailureReviewMetricRef {
+  key: string;
+  metric_type: string;
+  state?: string;
+  reason?: string;
+  numeric_value?: number;
+  text_value?: string;
+  boolean_value?: boolean;
+  unit?: string;
+}
+
+export interface FailureReviewItem {
+  run_id: string;
+  run_agent_id: string;
+  challenge_identity_id?: string;
+  challenge_key: string;
+  case_key: string;
+  item_key: string;
+  failure_state: FailureReviewFailureState;
+  failed_dimensions: string[];
+  failed_checks: string[];
+  failure_class: FailureReviewFailureClass;
+  headline: string;
+  detail: string;
+  recommended_action: string;
+  promotable: boolean;
+  promotion_mode_available: FailureReviewPromotionMode[];
+  replay_step_refs: FailureReviewReplayStepRef[];
+  artifact_refs: FailureReviewArtifactRef[];
+  judge_refs: FailureReviewJudgeRef[];
+  metric_refs: FailureReviewMetricRef[];
+  evidence_tier: FailureReviewEvidenceTier;
+  severity: FailureReviewSeverity;
+}
+
+export interface ListRunFailuresResponse {
+  items: FailureReviewItem[];
+  next_cursor?: string;
+}
+
 // --- Errors ---
 
 /** Standard error envelope returned by all backend error responses. */


### PR DESCRIPTION
## Summary
- Adds the `Run → Failures` page under `/workspaces/{ws}/runs/{runId}/failures` that lists every `FailureReviewItem` returned by the backend shipped in #319.
- Server component fetches run metadata + the first page of failures; client component drives URL-bound filters (agent, severity, failure class, evidence tier), grouped-by-challenge accordion, cursor-based "load more", loading skeleton, empty state, and an `ErrorBoundary`.
- Row click opens a side-drawer with the full detail, failed checks/dimensions, judge refs, metric refs, artifact refs, and replay deep links.
- Wires a `Failures` button into the existing run detail header (not flagged — empty state handles zero-failure runs).

Closes #320.

## Files
- `web/src/lib/api/types.ts` — `FailureReviewItem` + enum/ref/response types.
- `web/src/lib/api/failure-reviews.ts` — typed `listRunFailures` fetcher.
- `web/src/lib/api/index.ts` — re-exports.
- `web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/page.tsx` — server page.
- `web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.tsx` — filters + list + pagination.
- `web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failure-detail-drawer.tsx` — side-drawer detail view.
- `web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx` — new Failures link in the header.

## Test plan
- [ ] `pnpm lint` clean (no new warnings).
- [ ] `npx tsc --noEmit` clean.
- [ ] Manual: run `./scripts/dev/start-local-stack.sh` + `pnpm dev`, open a completed run that has failures, confirm the Failures link in the header jumps to the new page.
- [ ] Toggle each filter, confirm the URL updates (`?agent=…&severity=…&class=…&tier=…`) and the list refetches.
- [ ] Copy the filtered URL into a new tab to confirm it rehydrates the same filter state.
- [ ] Expand/collapse challenge groups; verify auto-collapse when >20 failures.
- [ ] Click a row, confirm the drawer shows detail, failed checks, judge refs, metric refs, replay deep links.
- [ ] Follow a replay deep link and confirm it lands on the correct step in the replay view.
- [ ] If the run has >50 failures: confirm "Load more" appends the next page.
- [ ] Open a run with zero failures and confirm the empty state renders.

## Out of scope
- Promotion action / modal (subissue F).
- Suite navigation (subissue E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)