### PR TITLE
Tighten regression workflow gaps before H and I

### DIFF
--- a/backend/db/queries/regression_suites.sql
+++ b/backend/db/queries/regression_suites.sql
@@ -49,6 +49,11 @@ SELECT count(*)
 FROM workspace_regression_suites
 WHERE workspace_id = @workspace_id;
 
+-- name: CountRegressionCasesBySuiteID :one
+SELECT count(*)
+FROM workspace_regression_cases
+WHERE suite_id = @suite_id;
+
 -- name: PatchRegressionSuite :one
 UPDATE workspace_regression_suites
 SET name = COALESCE(sqlc.narg('name'), name),
@@ -210,3 +215,10 @@ INSERT INTO workspace_regression_promotions (
     @promotion_snapshot
 )
 RETURNING *;
+
+-- name: GetLatestRegressionPromotionByCaseID :one
+SELECT *
+FROM workspace_regression_promotions
+WHERE workspace_regression_case_id = @workspace_regression_case_id
+ORDER BY created_at DESC, id DESC
+LIMIT 1;

--- a/backend/db/queries/runs.sql
+++ b/backend/db/queries/runs.sql
@@ -71,6 +71,7 @@ WITH winning_run_agent AS (
 selected_regression_cases AS (
     SELECT DISTINCT ON (rcs.regression_case_id)
         rcs.regression_case_id,
+        rcs.challenge_identity_id,
         c.title AS regression_case_title,
         s.id AS suite_id,
         s.name AS suite_name
@@ -85,7 +86,7 @@ selected_regression_cases AS (
 ),
 winning_case_outcomes AS (
     SELECT
-        jr.regression_case_id,
+        jr.challenge_identity_id,
         CASE
             WHEN bool_or(jr.verdict = 'fail') THEN 'fail'
             WHEN bool_or(jr.verdict = 'pass') THEN 'pass'
@@ -94,8 +95,8 @@ winning_case_outcomes AS (
     FROM judge_results AS jr
     JOIN winning_run_agent AS wra
       ON jr.run_agent_id = wra.winning_run_agent_id
-    WHERE jr.regression_case_id IS NOT NULL
-    GROUP BY jr.regression_case_id
+    WHERE jr.challenge_identity_id IS NOT NULL
+    GROUP BY jr.challenge_identity_id
 )
 SELECT
     src.regression_case_id,
@@ -105,7 +106,7 @@ SELECT
     COALESCE(wco.outcome, 'pending') AS outcome
 FROM selected_regression_cases AS src
 LEFT JOIN winning_case_outcomes AS wco
-  ON wco.regression_case_id = src.regression_case_id
+  ON wco.challenge_identity_id = src.challenge_identity_id
 ORDER BY src.suite_name ASC NULLS LAST, src.regression_case_title ASC, src.regression_case_id ASC;
 
 -- name: GetRunByID :one

--- a/backend/db/queries/runs.sql
+++ b/backend/db/queries/runs.sql
@@ -85,6 +85,8 @@ selected_regression_cases AS (
     ORDER BY rcs.regression_case_id, rcs.selection_rank ASC, rcs.created_at ASC
 ),
 winning_case_outcomes AS (
+    -- Group by challenge_identity_id so overlapping regression selections for
+    -- the same challenge share the winning run-agent outcome.
     SELECT
         jr.challenge_identity_id,
         CASE

--- a/backend/internal/api/failure_reviews.go
+++ b/backend/internal/api/failure_reviews.go
@@ -153,11 +153,17 @@ func listRunFailuresInputFromRequest(r *http.Request) (ListRunFailuresInput, err
 		input.Severity = &value
 	}
 	if raw := strings.TrimSpace(query.Get("failure_class")); raw != "" {
-		value := failurereview.FailureClass(raw)
+		value, parseErr := parseFailureClass(raw)
+		if parseErr != nil {
+			return ListRunFailuresInput{}, parseErr
+		}
 		input.FailureClass = &value
 	}
 	if raw := strings.TrimSpace(query.Get("evidence_tier")); raw != "" {
-		value := failurereview.EvidenceTier(raw)
+		value, parseErr := parseEvidenceTier(raw)
+		if parseErr != nil {
+			return ListRunFailuresInput{}, parseErr
+		}
 		input.EvidenceTier = &value
 	}
 	if raw := strings.TrimSpace(query.Get("challenge_key")); raw != "" {
@@ -196,6 +202,38 @@ func parseFailureSeverity(raw string) (failurereview.Severity, error) {
 		return failurereview.Severity(strings.TrimSpace(raw)), nil
 	default:
 		return "", errors.New("severity must be one of info, warning, blocking")
+	}
+}
+
+func parseFailureClass(raw string) (failurereview.FailureClass, error) {
+	switch failurereview.FailureClass(strings.TrimSpace(raw)) {
+	case failurereview.FailureClassIncorrectFinalOutput,
+		failurereview.FailureClassToolSelectionError,
+		failurereview.FailureClassToolArgumentError,
+		failurereview.FailureClassRetrievalGrounding,
+		failurereview.FailureClassPolicyViolation,
+		failurereview.FailureClassTimeoutOrBudget,
+		failurereview.FailureClassSandboxFailure,
+		failurereview.FailureClassMalformedOutput,
+		failurereview.FailureClassFlakyNonDeterministic,
+		failurereview.FailureClassInsufficientEvidence,
+		failurereview.FailureClassOther:
+		return failurereview.FailureClass(strings.TrimSpace(raw)), nil
+	default:
+		return "", errors.New("failure_class must be a valid failure review class")
+	}
+}
+
+func parseEvidenceTier(raw string) (failurereview.EvidenceTier, error) {
+	switch failurereview.EvidenceTier(strings.TrimSpace(raw)) {
+	case failurereview.EvidenceTierNone,
+		failurereview.EvidenceTierNativeStructured,
+		failurereview.EvidenceTierHostedStructured,
+		failurereview.EvidenceTierHostedBlackBox,
+		failurereview.EvidenceTierDerivedSummary:
+		return failurereview.EvidenceTier(strings.TrimSpace(raw)), nil
+	default:
+		return "", errors.New("evidence_tier must be one of none, native_structured, hosted_structured, hosted_black_box, derived_summary")
 	}
 }
 

--- a/backend/internal/api/failure_reviews.go
+++ b/backend/internal/api/failure_reviews.go
@@ -206,7 +206,8 @@ func parseFailureSeverity(raw string) (failurereview.Severity, error) {
 }
 
 func parseFailureClass(raw string) (failurereview.FailureClass, error) {
-	switch failurereview.FailureClass(strings.TrimSpace(raw)) {
+	trimmed := strings.TrimSpace(raw)
+	switch failurereview.FailureClass(trimmed) {
 	case failurereview.FailureClassIncorrectFinalOutput,
 		failurereview.FailureClassToolSelectionError,
 		failurereview.FailureClassToolArgumentError,
@@ -218,20 +219,21 @@ func parseFailureClass(raw string) (failurereview.FailureClass, error) {
 		failurereview.FailureClassFlakyNonDeterministic,
 		failurereview.FailureClassInsufficientEvidence,
 		failurereview.FailureClassOther:
-		return failurereview.FailureClass(strings.TrimSpace(raw)), nil
+		return failurereview.FailureClass(trimmed), nil
 	default:
 		return "", errors.New("failure_class must be a valid failure review class")
 	}
 }
 
 func parseEvidenceTier(raw string) (failurereview.EvidenceTier, error) {
-	switch failurereview.EvidenceTier(strings.TrimSpace(raw)) {
+	trimmed := strings.TrimSpace(raw)
+	switch failurereview.EvidenceTier(trimmed) {
 	case failurereview.EvidenceTierNone,
 		failurereview.EvidenceTierNativeStructured,
 		failurereview.EvidenceTierHostedStructured,
 		failurereview.EvidenceTierHostedBlackBox,
 		failurereview.EvidenceTierDerivedSummary:
-		return failurereview.EvidenceTier(strings.TrimSpace(raw)), nil
+		return failurereview.EvidenceTier(trimmed), nil
 	default:
 		return "", errors.New("evidence_tier must be one of none, native_structured, hosted_structured, hosted_black_box, derived_summary")
 	}

--- a/backend/internal/api/failure_reviews_test.go
+++ b/backend/internal/api/failure_reviews_test.go
@@ -161,6 +161,14 @@ func TestListRunFailuresEndpointRejectsMalformedQueryParams(t *testing.T) {
 			query: url.Values{"severity": []string{"severe"}},
 		},
 		{
+			name:  "bad failure class",
+			query: url.Values{"failure_class": []string{"mystery_failure"}},
+		},
+		{
+			name:  "bad evidence tier",
+			query: url.Values{"evidence_tier": []string{"semi_structured"}},
+		},
+		{
 			name:  "bad cursor",
 			query: url.Values{"cursor": []string{"{not-json"}},
 		},

--- a/backend/internal/api/regression_suites.go
+++ b/backend/internal/api/regression_suites.go
@@ -464,9 +464,22 @@ type regressionSuiteResponse struct {
 	Status                domain.RegressionSuiteStatus `json:"status"`
 	SourceMode            string                       `json:"source_mode"`
 	DefaultGateSeverity   domain.RegressionSeverity    `json:"default_gate_severity"`
+	CaseCount             int                          `json:"case_count"`
 	CreatedByUserID       uuid.UUID                    `json:"created_by_user_id"`
 	CreatedAt             time.Time                    `json:"created_at"`
 	UpdatedAt             time.Time                    `json:"updated_at"`
+}
+
+type regressionPromotionResponse struct {
+	ID                        uuid.UUID       `json:"id"`
+	WorkspaceRegressionCaseID uuid.UUID       `json:"workspace_regression_case_id"`
+	SourceRunID               uuid.UUID       `json:"source_run_id"`
+	SourceRunAgentID          uuid.UUID       `json:"source_run_agent_id"`
+	SourceEventRefs           json.RawMessage `json:"source_event_refs"`
+	PromotedByUserID          uuid.UUID       `json:"promoted_by_user_id"`
+	PromotionReason           string          `json:"promotion_reason"`
+	PromotionSnapshot         json.RawMessage `json:"promotion_snapshot"`
+	CreatedAt                 time.Time       `json:"created_at"`
 }
 
 type regressionCaseResponse struct {
@@ -493,6 +506,7 @@ type regressionCaseResponse struct {
 	ExpectedContract             json.RawMessage                `json:"expected_contract"`
 	ValidatorOverrides           json.RawMessage                `json:"validator_overrides,omitempty"`
 	Metadata                     json.RawMessage                `json:"metadata"`
+	LatestPromotion              *regressionPromotionResponse   `json:"latest_promotion,omitempty"`
 	CreatedAt                    time.Time                      `json:"created_at"`
 	UpdatedAt                    time.Time                      `json:"updated_at"`
 }
@@ -849,6 +863,7 @@ func buildRegressionSuiteResponse(suite repository.RegressionSuite) regressionSu
 		Status:                suite.Status,
 		SourceMode:            suite.SourceMode,
 		DefaultGateSeverity:   suite.DefaultGateSeverity,
+		CaseCount:             suite.CaseCount,
 		CreatedByUserID:       suite.CreatedByUserID,
 		CreatedAt:             suite.CreatedAt,
 		UpdatedAt:             suite.UpdatedAt,
@@ -856,6 +871,21 @@ func buildRegressionSuiteResponse(suite repository.RegressionSuite) regressionSu
 }
 
 func buildRegressionCaseResponse(regressionCase repository.RegressionCase) regressionCaseResponse {
+	var latestPromotion *regressionPromotionResponse
+	if regressionCase.LatestPromotion != nil {
+		latestPromotion = &regressionPromotionResponse{
+			ID:                        regressionCase.LatestPromotion.ID,
+			WorkspaceRegressionCaseID: regressionCase.LatestPromotion.WorkspaceRegressionCaseID,
+			SourceRunID:               regressionCase.LatestPromotion.SourceRunID,
+			SourceRunAgentID:          regressionCase.LatestPromotion.SourceRunAgentID,
+			SourceEventRefs:           regressionCase.LatestPromotion.SourceEventRefs,
+			PromotedByUserID:          regressionCase.LatestPromotion.PromotedByUserID,
+			PromotionReason:           regressionCase.LatestPromotion.PromotionReason,
+			PromotionSnapshot:         regressionCase.LatestPromotion.PromotionSnapshot,
+			CreatedAt:                 regressionCase.LatestPromotion.CreatedAt,
+		}
+	}
+
 	return regressionCaseResponse{
 		ID:                           regressionCase.ID,
 		SuiteID:                      regressionCase.SuiteID,
@@ -880,6 +910,7 @@ func buildRegressionCaseResponse(regressionCase repository.RegressionCase) regre
 		ExpectedContract:             regressionCase.ExpectedContract,
 		ValidatorOverrides:           regressionCase.ValidatorOverrides,
 		Metadata:                     regressionCase.Metadata,
+		LatestPromotion:              latestPromotion,
 		CreatedAt:                    regressionCase.CreatedAt,
 		UpdatedAt:                    regressionCase.UpdatedAt,
 	}

--- a/backend/internal/api/regression_suites_test.go
+++ b/backend/internal/api/regression_suites_test.go
@@ -550,6 +550,7 @@ func TestRegressionSuiteEndpointsRoundTrip(t *testing.T) {
 	caseID := uuid.New()
 	createdAt := time.Date(2026, 4, 19, 10, 0, 0, 0, time.UTC)
 	updatedAt := createdAt.Add(5 * time.Minute)
+	promotionCreatedAt := updatedAt.Add(2 * time.Minute)
 
 	service := &fakeRegressionService{
 		suite: repository.RegressionSuite{
@@ -561,6 +562,7 @@ func TestRegressionSuiteEndpointsRoundTrip(t *testing.T) {
 			Status:                domain.RegressionSuiteStatusActive,
 			SourceMode:            "derived_only",
 			DefaultGateSeverity:   domain.RegressionSeverityWarning,
+			CaseCount:             1,
 			CreatedByUserID:       userID,
 			CreatedAt:             createdAt,
 			UpdatedAt:             updatedAt,
@@ -583,8 +585,19 @@ func TestRegressionSuiteEndpointsRoundTrip(t *testing.T) {
 			PayloadSnapshot:              json.RawMessage(`{"payload":"snapshot"}`),
 			ExpectedContract:             json.RawMessage(`{"contract":"expected"}`),
 			Metadata:                     json.RawMessage(`{"origin":"test"}`),
-			CreatedAt:                    createdAt,
-			UpdatedAt:                    updatedAt,
+			LatestPromotion: &repository.RegressionPromotion{
+				ID:                        uuid.New(),
+				WorkspaceRegressionCaseID: caseID,
+				SourceRunID:               uuid.New(),
+				SourceRunAgentID:          uuid.New(),
+				SourceEventRefs:           json.RawMessage(`[{"sequence_number":7}]`),
+				PromotedByUserID:          userID,
+				PromotionReason:           "Captured from failure review",
+				PromotionSnapshot:         json.RawMessage(`{"request":{"title":"Case one"}}`),
+				CreatedAt:                 promotionCreatedAt,
+			},
+			CreatedAt: createdAt,
+			UpdatedAt: updatedAt,
 		},
 	}
 
@@ -659,6 +672,9 @@ func TestRegressionSuiteEndpointsRoundTrip(t *testing.T) {
 	if len(listResponse.Items) != 1 || listResponse.Items[0].Status != domain.RegressionSuiteStatusArchived {
 		t.Fatalf("list suites = %+v, want archived item", listResponse.Items)
 	}
+	if listResponse.Items[0].CaseCount != 1 {
+		t.Fatalf("suite case_count = %d, want 1", listResponse.Items[0].CaseCount)
+	}
 
 	casesRec := httptest.NewRecorder()
 	casesReq := httptest.NewRequest(http.MethodGet, "/v1/workspaces/"+workspaceID.String()+"/regression-suites/"+suiteID.String()+"/cases", nil)
@@ -689,6 +705,12 @@ func TestRegressionSuiteEndpointsRoundTrip(t *testing.T) {
 	}
 	if patchedCase.Status != domain.RegressionCaseStatusMuted {
 		t.Fatalf("patched case status = %s, want muted", patchedCase.Status)
+	}
+	if patchedCase.LatestPromotion == nil {
+		t.Fatal("patched case latest_promotion = nil, want populated promotion metadata")
+	}
+	if patchedCase.LatestPromotion.PromotionReason != "Captured from failure review" {
+		t.Fatalf("latest promotion reason = %q, want captured promotion reason", patchedCase.LatestPromotion.PromotionReason)
 	}
 	if service.patchSuiteInput == nil || service.patchCaseInput == nil {
 		t.Fatalf("expected patch inputs to be captured")

--- a/backend/internal/failurereview/read_model.go
+++ b/backend/internal/failurereview/read_model.go
@@ -46,28 +46,28 @@ const (
 )
 
 type Item struct {
-	RunID                  uuid.UUID        `json:"run_id"`
-	RunAgentID             uuid.UUID        `json:"run_agent_id"`
-	ChallengeIdentityID    *uuid.UUID       `json:"challenge_identity_id,omitempty"`
-	ChallengeKey           string           `json:"challenge_key"`
-	CaseKey                string           `json:"case_key"`
-	ItemKey                string           `json:"item_key"`
-	FailureState           FailureState     `json:"failure_state"`
-	FailedDimensions       []string         `json:"failed_dimensions"`
-	FailedChecks           []string         `json:"failed_checks"`
-	FailureClass           FailureClass     `json:"failure_class"`
-	Headline               string           `json:"headline"`
-	Detail                 string           `json:"detail"`
-	RecommendedAction      string           `json:"recommended_action"`
-	Promotable             bool             `json:"promotable"`
-	PromotionModeAvailable []PromotionMode  `json:"promotion_mode_available"`
-	ReplayStepRefs         []ReplayStepRef  `json:"replay_step_refs"`
-	ArtifactRefs           []ArtifactRef    `json:"artifact_refs"`
-	JudgeRefs              []JudgeRef       `json:"judge_refs"`
-	MetricRefs             []MetricRef      `json:"metric_refs"`
-	EvidenceTier           EvidenceTier     `json:"evidence_tier"`
-	Severity               Severity         `json:"severity"`
-	sortKey                CursorKey        `json:"-"`
+	RunID                  uuid.UUID       `json:"run_id"`
+	RunAgentID             uuid.UUID       `json:"run_agent_id"`
+	ChallengeIdentityID    *uuid.UUID      `json:"challenge_identity_id,omitempty"`
+	ChallengeKey           string          `json:"challenge_key"`
+	CaseKey                string          `json:"case_key"`
+	ItemKey                string          `json:"item_key"`
+	FailureState           FailureState    `json:"failure_state"`
+	FailedDimensions       []string        `json:"failed_dimensions"`
+	FailedChecks           []string        `json:"failed_checks"`
+	FailureClass           FailureClass    `json:"failure_class"`
+	Headline               string          `json:"headline"`
+	Detail                 string          `json:"detail"`
+	RecommendedAction      string          `json:"recommended_action"`
+	Promotable             bool            `json:"promotable"`
+	PromotionModeAvailable []PromotionMode `json:"promotion_mode_available"`
+	ReplayStepRefs         []ReplayStepRef `json:"replay_step_refs"`
+	ArtifactRefs           []ArtifactRef   `json:"artifact_refs"`
+	JudgeRefs              []JudgeRef      `json:"judge_refs"`
+	MetricRefs             []MetricRef     `json:"metric_refs"`
+	EvidenceTier           EvidenceTier    `json:"evidence_tier"`
+	Severity               Severity        `json:"severity"`
+	sortKey                CursorKey       `json:"-"`
 }
 
 type ReplayStepRef struct {
@@ -112,6 +112,7 @@ type RunAgentInput struct {
 	RunAgentLabel        string
 	DeploymentType       string
 	ChallengePackStatus  string
+	HasChallengeInputSet bool
 	ToolPolicy           json.RawMessage
 	Cases                []CaseContext
 	Scorecard            json.RawMessage
@@ -327,15 +328,15 @@ func DecodeCursor(raw string) (CursorKey, error) {
 }
 
 type itemGroup struct {
-	RunID           uuid.UUID
-	RunAgentID      uuid.UUID
-	Case            CaseContext
-	ChallengeID     *uuid.UUID
-	JudgeRefs       []JudgeRef
-	MetricRefs      []MetricRef
-	FailedChecks    []string
-	ReplayStepRefs  []ReplayStepRef
-	OnlyLLMJudges   bool
+	RunID          uuid.UUID
+	RunAgentID     uuid.UUID
+	Case           CaseContext
+	ChallengeID    *uuid.UUID
+	JudgeRefs      []JudgeRef
+	MetricRefs     []MetricRef
+	FailedChecks   []string
+	ReplayStepRefs []ReplayStepRef
+	OnlyLLMJudges  bool
 }
 
 type scorecardDocument struct {
@@ -458,10 +459,10 @@ func finalizeGroup(group *itemGroup, input RunAgentInput, scorecard scorecardDoc
 
 	promotable := input.RunStatus == domain.RunStatusCompleted && group.ChallengeID != nil && evidenceTier != EvidenceTierNone
 	promotionModes := make([]PromotionMode, 0, 2)
-	if promotable && (evidenceTier == EvidenceTierNativeStructured || evidenceTier == EvidenceTierHostedStructured) && input.ChallengePackStatus == "runnable" {
+	if promotable && input.HasChallengeInputSet && (evidenceTier == EvidenceTierNativeStructured || evidenceTier == EvidenceTierHostedStructured) && input.ChallengePackStatus == "runnable" {
 		promotionModes = append(promotionModes, PromotionModeFullExecutable)
 	}
-	if promotable && finalOutputRef != nil {
+	if promotable && input.HasChallengeInputSet && finalOutputRef != nil {
 		promotionModes = append(promotionModes, PromotionModeOutputOnly)
 		group.ReplayStepRefs = append(group.ReplayStepRefs, *finalOutputRef)
 		dedupReplayRefs(&group.ReplayStepRefs)

--- a/backend/internal/failurereview/read_model_test.go
+++ b/backend/internal/failurereview/read_model_test.go
@@ -48,11 +48,12 @@ func TestBuildRunAgentItemsComputesPromotionEligibilityAndRefs(t *testing.T) {
 	})
 
 	items, err := BuildRunAgentItems(RunAgentInput{
-		RunID:               runID,
-		RunStatus:           domain.RunStatusCompleted,
-		RunAgentID:          runAgentID,
-		DeploymentType:      "native",
-		ChallengePackStatus: "runnable",
+		RunID:                runID,
+		RunStatus:            domain.RunStatusCompleted,
+		RunAgentID:           runAgentID,
+		DeploymentType:       "native",
+		ChallengePackStatus:  "runnable",
+		HasChallengeInputSet: true,
 		Cases: []CaseContext{
 			{
 				ChallengeIdentityID: challengeID,
@@ -136,11 +137,12 @@ func TestBuildRunAgentItemsHandlesHostedBlackBoxEligibility(t *testing.T) {
 	verdict := "fail"
 
 	items, err := BuildRunAgentItems(RunAgentInput{
-		RunID:               runID,
-		RunStatus:           domain.RunStatusCompleted,
-		RunAgentID:          runAgentID,
-		DeploymentType:      "hosted_external",
-		ChallengePackStatus: "archived",
+		RunID:                runID,
+		RunStatus:            domain.RunStatusCompleted,
+		RunAgentID:           runAgentID,
+		DeploymentType:       "hosted_external",
+		ChallengePackStatus:  "archived",
+		HasChallengeInputSet: true,
 		Cases: []CaseContext{
 			{
 				ChallengeIdentityID: challengeID,
@@ -181,6 +183,51 @@ func TestBuildRunAgentItemsHandlesHostedBlackBoxEligibility(t *testing.T) {
 	}
 	if item.Severity != SeverityWarning {
 		t.Fatalf("severity = %s, want %s for hosted black-box evidence", item.Severity, SeverityWarning)
+	}
+}
+
+func TestBuildRunAgentItemsSkipsOutputOnlyPromotionWithoutChallengeInputSet(t *testing.T) {
+	t.Parallel()
+
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	challengeID := uuid.New()
+	verdict := "fail"
+
+	items, err := BuildRunAgentItems(RunAgentInput{
+		RunID:                runID,
+		RunStatus:            domain.RunStatusCompleted,
+		RunAgentID:           runAgentID,
+		DeploymentType:       "native",
+		ChallengePackStatus:  "runnable",
+		HasChallengeInputSet: false,
+		Cases: []CaseContext{
+			{
+				ChallengeIdentityID: challengeID,
+				ChallengeKey:        "ticket-no-input-set",
+				CaseKey:             "case-z",
+				ItemKey:             "prompt.txt",
+			},
+		},
+		JudgeResults: []JudgeResult{
+			{
+				ChallengeIdentityID: &challengeID,
+				Key:                 "policy.filesystem",
+				Verdict:             &verdict,
+			},
+		},
+		Events: []Event{
+			{SequenceNumber: 4, EventType: "system.output.finalized", Payload: mustJSON(t, map[string]any{"final_output": "oops"})},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildRunAgentItems returned error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("item count = %d, want 1", len(items))
+	}
+	if len(items[0].PromotionModeAvailable) != 0 {
+		t.Fatalf("promotion modes = %#v, want none when challenge input set is unavailable", items[0].PromotionModeAvailable)
 	}
 }
 

--- a/backend/internal/failurereview/read_model_test.go
+++ b/backend/internal/failurereview/read_model_test.go
@@ -231,6 +231,58 @@ func TestBuildRunAgentItemsSkipsOutputOnlyPromotionWithoutChallengeInputSet(t *t
 	}
 }
 
+func TestBuildRunAgentItemsSkipsFullExecutablePromotionWithoutChallengeInputSet(t *testing.T) {
+	t.Parallel()
+
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	challengeID := uuid.New()
+	verdict := "fail"
+
+	items, err := BuildRunAgentItems(RunAgentInput{
+		RunID:                runID,
+		RunStatus:            domain.RunStatusCompleted,
+		RunAgentID:           runAgentID,
+		DeploymentType:       "native",
+		ChallengePackStatus:  "runnable",
+		HasChallengeInputSet: false,
+		Cases: []CaseContext{
+			{
+				ChallengeIdentityID: challengeID,
+				ChallengeKey:        "ticket-native-no-input-set",
+				CaseKey:             "case-y",
+				ItemKey:             "prompt.txt",
+			},
+		},
+		Scorecard: mustJSON(t, map[string]any{
+			"validator_details": []any{
+				map[string]any{
+					"key":     "policy.filesystem",
+					"type":    "exact_match",
+					"verdict": "fail",
+					"state":   "available",
+				},
+			},
+		}),
+		JudgeResults: []JudgeResult{
+			{
+				ChallengeIdentityID: &challengeID,
+				Key:                 "policy.filesystem",
+				Verdict:             &verdict,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildRunAgentItems returned error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("item count = %d, want 1", len(items))
+	}
+	if len(items[0].PromotionModeAvailable) != 0 {
+		t.Fatalf("promotion modes = %#v, want none without a challenge input set", items[0].PromotionModeAvailable)
+	}
+}
+
 func TestAssembleFailureReviewItemBuildsRefsAndFailedChecks(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/repository/failure_review.go
+++ b/backend/internal/repository/failure_review.go
@@ -61,19 +61,20 @@ func (r *Repository) ListRunFailureReviewItems(ctx context.Context, runID uuid.U
 		}
 
 		runAgentItems, err := failurereview.BuildRunAgentItems(failurereview.RunAgentInput{
-			RunID:               executionContext.Run.ID,
-			RunStatus:           executionContext.Run.Status,
-			RunAgentID:          runAgent.ID,
-			RunAgentLabel:       runAgent.Label,
-			DeploymentType:      executionContext.Deployment.DeploymentType,
-			ChallengePackStatus: challengePackStatus,
-			ToolPolicy:          executionContext.ChallengePackVersion.Manifest,
-			Cases:               mapFailureReviewCases(executionContext.ChallengeInputSet),
-			Scorecard:           scorecard.Scorecard,
-			JudgeResults:        mapFailureReviewJudgeResults(judgeResults),
-			MetricResults:       mapFailureReviewMetricResults(metricResults),
-			LLMJudgeResults:     mapFailureReviewLLMJudgeResults(llmJudgeResults),
-			Events:              mapFailureReviewEvents(runEvents),
+			RunID:                executionContext.Run.ID,
+			RunStatus:            executionContext.Run.Status,
+			RunAgentID:           runAgent.ID,
+			RunAgentLabel:        runAgent.Label,
+			DeploymentType:       executionContext.Deployment.DeploymentType,
+			ChallengePackStatus:  challengePackStatus,
+			HasChallengeInputSet: executionContext.ChallengeInputSet != nil,
+			ToolPolicy:           executionContext.ChallengePackVersion.Manifest,
+			Cases:                mapFailureReviewCases(executionContext.ChallengeInputSet),
+			Scorecard:            scorecard.Scorecard,
+			JudgeResults:         mapFailureReviewJudgeResults(judgeResults),
+			MetricResults:        mapFailureReviewMetricResults(metricResults),
+			LLMJudgeResults:      mapFailureReviewLLMJudgeResults(llmJudgeResults),
+			Events:               mapFailureReviewEvents(runEvents),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("build failure review items for %s: %w", runAgent.ID, err)

--- a/backend/internal/repository/regression.go
+++ b/backend/internal/repository/regression.go
@@ -25,6 +25,7 @@ type RegressionSuite struct {
 	Status                domain.RegressionSuiteStatus
 	SourceMode            string
 	DefaultGateSeverity   domain.RegressionSeverity
+	CaseCount             int
 	CreatedByUserID       uuid.UUID
 	CreatedAt             time.Time
 	UpdatedAt             time.Time
@@ -54,6 +55,7 @@ type RegressionCase struct {
 	ExpectedContract             json.RawMessage
 	ValidatorOverrides           json.RawMessage
 	Metadata                     json.RawMessage
+	LatestPromotion              *RegressionPromotion
 	CreatedAt                    time.Time
 	UpdatedAt                    time.Time
 }
@@ -205,6 +207,10 @@ func (r *Repository) GetRegressionSuiteByID(ctx context.Context, id uuid.UUID) (
 	if err != nil {
 		return RegressionSuite{}, fmt.Errorf("map regression suite: %w", err)
 	}
+	suite.CaseCount, err = r.countRegressionCasesBySuiteID(ctx, suite.ID)
+	if err != nil {
+		return RegressionSuite{}, err
+	}
 	return suite, nil
 }
 
@@ -223,6 +229,10 @@ func (r *Repository) ListRegressionSuitesByWorkspaceID(ctx context.Context, work
 		suite, mapErr := mapRegressionSuite(row)
 		if mapErr != nil {
 			return nil, fmt.Errorf("map regression suite %s: %w", row.ID, mapErr)
+		}
+		suite.CaseCount, mapErr = r.countRegressionCasesBySuiteID(ctx, suite.ID)
+		if mapErr != nil {
+			return nil, mapErr
 		}
 		suites = append(suites, suite)
 	}
@@ -302,6 +312,10 @@ func (r *Repository) PatchRegressionSuite(ctx context.Context, params PatchRegre
 	if err != nil {
 		return RegressionSuite{}, fmt.Errorf("map regression suite: %w", err)
 	}
+	suite.CaseCount, err = r.countRegressionCasesBySuiteID(ctx, suite.ID)
+	if err != nil {
+		return RegressionSuite{}, err
+	}
 	return suite, nil
 }
 
@@ -365,6 +379,10 @@ func (r *Repository) GetRegressionCaseByID(ctx context.Context, id uuid.UUID) (R
 	if err != nil {
 		return RegressionCase{}, fmt.Errorf("map regression case: %w", err)
 	}
+	regressionCase.LatestPromotion, err = r.latestRegressionPromotionByCaseID(ctx, regressionCase.ID)
+	if err != nil {
+		return RegressionCase{}, err
+	}
 	return regressionCase, nil
 }
 
@@ -381,6 +399,10 @@ func (r *Repository) ListRegressionCasesBySuiteID(ctx context.Context, suiteID u
 		regressionCase, mapErr := mapRegressionCaseFromListRow(row)
 		if mapErr != nil {
 			return nil, fmt.Errorf("map regression case %s: %w", row.ID, mapErr)
+		}
+		regressionCase.LatestPromotion, mapErr = r.latestRegressionPromotionByCaseID(ctx, regressionCase.ID)
+		if mapErr != nil {
+			return nil, mapErr
 		}
 		cases = append(cases, regressionCase)
 	}
@@ -666,6 +688,34 @@ func challengeInputSetID(inputSet *ChallengeInputSetExecutionContext) *uuid.UUID
 	return &id
 }
 
+func (r *Repository) countRegressionCasesBySuiteID(ctx context.Context, suiteID uuid.UUID) (int, error) {
+	count, err := r.queries.CountRegressionCasesBySuiteID(ctx, repositorysqlc.CountRegressionCasesBySuiteIDParams{
+		SuiteID: suiteID,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("count regression cases by suite id: %w", err)
+	}
+	return int(count), nil
+}
+
+func (r *Repository) latestRegressionPromotionByCaseID(ctx context.Context, caseID uuid.UUID) (*RegressionPromotion, error) {
+	row, err := r.queries.GetLatestRegressionPromotionByCaseID(ctx, repositorysqlc.GetLatestRegressionPromotionByCaseIDParams{
+		WorkspaceRegressionCaseID: caseID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get latest regression promotion by case id: %w", err)
+	}
+
+	promotion, err := mapRegressionPromotion(row)
+	if err != nil {
+		return nil, fmt.Errorf("map latest regression promotion: %w", err)
+	}
+	return &promotion, nil
+}
+
 func mapRegressionSuite(row repositorysqlc.WorkspaceRegressionSuite) (RegressionSuite, error) {
 	status, err := domain.ParseRegressionSuiteStatus(row.Status)
 	if err != nil {
@@ -693,6 +743,7 @@ func mapRegressionSuite(row repositorysqlc.WorkspaceRegressionSuite) (Regression
 		Status:                status,
 		SourceMode:            row.SourceMode,
 		DefaultGateSeverity:   defaultGateSeverity,
+		CaseCount:             0,
 		CreatedByUserID:       row.CreatedByUserID,
 		CreatedAt:             createdAt,
 		UpdatedAt:             updatedAt,
@@ -745,6 +796,7 @@ func mapRegressionCase(row regressionCaseFields) (RegressionCase, error) {
 		ExpectedContract:             cloneJSON(row.expectedContract),
 		ValidatorOverrides:           cloneJSON(row.validatorOverrides),
 		Metadata:                     cloneJSON(row.metadata),
+		LatestPromotion:              nil,
 		CreatedAt:                    createdAt,
 		UpdatedAt:                    updatedAt,
 	}, nil

--- a/backend/internal/repository/repository_integration_test.go
+++ b/backend/internal/repository/repository_integration_test.go
@@ -357,6 +357,159 @@ func TestRepositoryListRunRegressionCoverageCasesByRunIDReturnsPendingWithoutSco
 	}
 }
 
+func TestRepositoryListRunRegressionCoverageCasesByRunIDFansOutOutcomeToOverlappingSelections(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+	queries := repositorysqlc.New(db)
+
+	firstSuiteID := uuid.New()
+	secondSuiteID := uuid.New()
+	firstCaseID := uuid.New()
+	secondCaseID := uuid.New()
+
+	for _, suiteSeed := range []struct {
+		id   uuid.UUID
+		name string
+	}{
+		{id: firstSuiteID, name: "Primary Coverage"},
+		{id: secondSuiteID, name: "Secondary Coverage"},
+	} {
+		if _, err := db.Exec(ctx, `
+			INSERT INTO workspace_regression_suites (
+				id,
+				workspace_id,
+				source_challenge_pack_id,
+				name,
+				description,
+				status,
+				source_mode,
+				default_gate_severity,
+				created_by_user_id
+			)
+			SELECT
+				$1,
+				$2,
+				cp.id,
+				$3,
+				'',
+				'active',
+				'derived_only',
+				'warning',
+				$4
+			FROM challenge_pack_versions cpv
+			JOIN challenge_packs cp ON cp.id = cpv.challenge_pack_id
+			WHERE cpv.id = $5
+		`, suiteSeed.id, fixture.workspaceID, suiteSeed.name, fixture.userID, fixture.challengePackVersionID); err != nil {
+			t.Fatalf("insert regression suite %s returned error: %v", suiteSeed.name, err)
+		}
+	}
+
+	if _, err := db.Exec(ctx, `
+		INSERT INTO workspace_regression_cases (
+			id,
+			suite_id,
+			title,
+			description,
+			status,
+			severity,
+			promotion_mode,
+			source_run_id,
+			source_run_agent_id,
+			source_challenge_pack_version_id,
+			source_challenge_input_set_id,
+			source_challenge_identity_id,
+			source_case_key,
+			source_item_key,
+			evidence_tier,
+			failure_class,
+			failure_summary,
+			payload_snapshot,
+			expected_contract,
+			metadata
+		)
+		VALUES
+			($1, $2, 'Regression A', '', 'active', 'warning', 'full_executable', $3, $4, $5, $6, $7, 'case-a', 'prompt.txt', 'native_structured', 'incorrect_final_output', '', '{}'::jsonb, '{}'::jsonb, '{}'::jsonb),
+			($8, $9, 'Regression B', '', 'active', 'warning', 'full_executable', $3, $4, $5, $6, $7, 'case-a', 'prompt.txt', 'native_structured', 'incorrect_final_output', '', '{}'::jsonb, '{}'::jsonb, '{}'::jsonb)
+	`, firstCaseID, firstSuiteID, fixture.runID, fixture.primaryRunAgentID, fixture.challengePackVersionID, fixture.challengeInputSetID, fixture.firstChallengeIdentityID, secondCaseID, secondSuiteID); err != nil {
+		t.Fatalf("insert overlapping regression cases returned error: %v", err)
+	}
+
+	if _, err := db.Exec(ctx, `
+		INSERT INTO run_case_selections (
+			id,
+			run_id,
+			challenge_identity_id,
+			selection_origin,
+			regression_case_id,
+			selection_rank
+		)
+		VALUES
+			($1, $2, $3, 'regression_case', $4, 1),
+			($5, $2, $3, 'regression_case', $6, 2)
+	`, uuid.New(), fixture.runID, fixture.firstChallengeIdentityID, firstCaseID, uuid.New(), secondCaseID); err != nil {
+		t.Fatalf("insert overlapping selections returned error: %v", err)
+	}
+
+	specRecord, err := repo.CreateEvaluationSpec(ctx, repository.CreateEvaluationSpecParams{
+		ChallengePackVersionID: fixture.challengePackVersionID,
+		Name:                   "overlapping-regression-coverage-spec",
+		VersionNumber:          1,
+		JudgeMode:              "deterministic",
+		Definition: []byte(`{
+			"name":"overlapping-regression-coverage-spec",
+			"version_number":1,
+			"judge_mode":"deterministic",
+			"validators":[{"key":"exact","type":"exact_match","target":"final_output","expected_from":"challenge_input"}],
+			"scorecard":{"dimensions":["correctness"]}
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateEvaluationSpec returned error: %v", err)
+	}
+
+	if _, err := queries.UpsertRunScorecard(ctx, repositorysqlc.UpsertRunScorecardParams{
+		RunID:             fixture.runID,
+		EvaluationSpecID:  specRecord.ID,
+		WinningRunAgentID: &fixture.primaryRunAgentID,
+		Scorecard:         []byte(`{"status":"complete","winning_run_agent_id":"` + fixture.primaryRunAgentID.String() + `"}`),
+	}); err != nil {
+		t.Fatalf("UpsertRunScorecard returned error: %v", err)
+	}
+
+	if _, err := db.Exec(ctx, `
+		INSERT INTO judge_results (
+			id,
+			run_agent_id,
+			evaluation_spec_id,
+			challenge_identity_id,
+			regression_case_id,
+			judge_key,
+			verdict,
+			normalized_score,
+			raw_output
+		)
+		VALUES ($1, $2, $3, $4, $5, 'exact', 'fail', 0.0, '{}'::jsonb)
+	`, uuid.New(), fixture.primaryRunAgentID, specRecord.ID, fixture.firstChallengeIdentityID, firstCaseID); err != nil {
+		t.Fatalf("insert judge result returned error: %v", err)
+	}
+
+	coverageCases, err := repo.ListRunRegressionCoverageCasesByRunID(ctx, fixture.runID)
+	if err != nil {
+		t.Fatalf("ListRunRegressionCoverageCasesByRunID returned error: %v", err)
+	}
+	if len(coverageCases) != 2 {
+		t.Fatalf("coverage case count = %d, want 2", len(coverageCases))
+	}
+
+	for _, coverageCase := range coverageCases {
+		if coverageCase.Outcome != repository.RunRegressionCoverageOutcomeFail {
+			t.Fatalf("coverage case %s outcome = %q, want fail for all overlapping selections", coverageCase.RegressionCaseID, coverageCase.Outcome)
+		}
+	}
+}
+
 func TestRepositoryListOrgMembershipsScansTimestamps(t *testing.T) {
 	ctx := context.Background()
 	db := openTestDB(t)

--- a/backend/internal/repository/sqlc/querier.go
+++ b/backend/internal/repository/sqlc/querier.go
@@ -12,6 +12,7 @@ import (
 
 type Querier interface {
 	ApplyHostedRunEvent(ctx context.Context, arg ApplyHostedRunEventParams) (HostedRunExecution, error)
+	CountRegressionCasesBySuiteID(ctx context.Context, arg CountRegressionCasesBySuiteIDParams) (int64, error)
 	CountRegressionSuitesByWorkspaceID(ctx context.Context, arg CountRegressionSuitesByWorkspaceIDParams) (int64, error)
 	CountRunsByWorkspaceID(ctx context.Context, arg CountRunsByWorkspaceIDParams) (int64, error)
 	CreateAgentBuild(ctx context.Context, arg CreateAgentBuildParams) (AgentBuild, error)
@@ -36,6 +37,7 @@ type Querier interface {
 	GetEvaluationSpecByChallengePackVersionAndVersion(ctx context.Context, arg GetEvaluationSpecByChallengePackVersionAndVersionParams) (EvaluationSpec, error)
 	GetEvaluationSpecByID(ctx context.Context, arg GetEvaluationSpecByIDParams) (EvaluationSpec, error)
 	GetHostedRunExecutionByRunAgentID(ctx context.Context, arg GetHostedRunExecutionByRunAgentIDParams) (HostedRunExecution, error)
+	GetLatestRegressionPromotionByCaseID(ctx context.Context, arg GetLatestRegressionPromotionByCaseIDParams) (WorkspaceRegressionPromotion, error)
 	GetLatestVersionNumberForBuild(ctx context.Context, arg GetLatestVersionNumberForBuildParams) (int32, error)
 	GetPlaygroundByID(ctx context.Context, arg GetPlaygroundByIDParams) (Playground, error)
 	GetPlaygroundExperimentByID(ctx context.Context, arg GetPlaygroundExperimentByIDParams) (PlaygroundExperiment, error)

--- a/backend/internal/repository/sqlc/regression_suites.sql.go
+++ b/backend/internal/repository/sqlc/regression_suites.sql.go
@@ -12,6 +12,23 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const countRegressionCasesBySuiteID = `-- name: CountRegressionCasesBySuiteID :one
+SELECT count(*)
+FROM workspace_regression_cases
+WHERE suite_id = $1
+`
+
+type CountRegressionCasesBySuiteIDParams struct {
+	SuiteID uuid.UUID
+}
+
+func (q *Queries) CountRegressionCasesBySuiteID(ctx context.Context, arg CountRegressionCasesBySuiteIDParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countRegressionCasesBySuiteID, arg.SuiteID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const countRegressionSuitesByWorkspaceID = `-- name: CountRegressionSuitesByWorkspaceID :one
 SELECT count(*)
 FROM workspace_regression_suites
@@ -281,6 +298,35 @@ func (q *Queries) CreateRegressionSuite(ctx context.Context, arg CreateRegressio
 		&i.CreatedByUserID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getLatestRegressionPromotionByCaseID = `-- name: GetLatestRegressionPromotionByCaseID :one
+SELECT id, workspace_regression_case_id, source_run_id, source_run_agent_id, source_event_refs, promoted_by_user_id, promotion_reason, promotion_snapshot, created_at
+FROM workspace_regression_promotions
+WHERE workspace_regression_case_id = $1
+ORDER BY created_at DESC, id DESC
+LIMIT 1
+`
+
+type GetLatestRegressionPromotionByCaseIDParams struct {
+	WorkspaceRegressionCaseID uuid.UUID
+}
+
+func (q *Queries) GetLatestRegressionPromotionByCaseID(ctx context.Context, arg GetLatestRegressionPromotionByCaseIDParams) (WorkspaceRegressionPromotion, error) {
+	row := q.db.QueryRow(ctx, getLatestRegressionPromotionByCaseID, arg.WorkspaceRegressionCaseID)
+	var i WorkspaceRegressionPromotion
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceRegressionCaseID,
+		&i.SourceRunID,
+		&i.SourceRunAgentID,
+		&i.SourceEventRefs,
+		&i.PromotedByUserID,
+		&i.PromotionReason,
+		&i.PromotionSnapshot,
+		&i.CreatedAt,
 	)
 	return i, err
 }

--- a/backend/internal/repository/sqlc/runs.sql.go
+++ b/backend/internal/repository/sqlc/runs.sql.go
@@ -331,6 +331,8 @@ selected_regression_cases AS (
     ORDER BY rcs.regression_case_id, rcs.selection_rank ASC, rcs.created_at ASC
 ),
 winning_case_outcomes AS (
+    -- Group by challenge_identity_id so overlapping regression selections for
+    -- the same challenge share the winning run-agent outcome.
     SELECT
         jr.challenge_identity_id,
         CASE

--- a/backend/internal/repository/sqlc/runs.sql.go
+++ b/backend/internal/repository/sqlc/runs.sql.go
@@ -317,6 +317,7 @@ WITH winning_run_agent AS (
 selected_regression_cases AS (
     SELECT DISTINCT ON (rcs.regression_case_id)
         rcs.regression_case_id,
+        rcs.challenge_identity_id,
         c.title AS regression_case_title,
         s.id AS suite_id,
         s.name AS suite_name
@@ -331,7 +332,7 @@ selected_regression_cases AS (
 ),
 winning_case_outcomes AS (
     SELECT
-        jr.regression_case_id,
+        jr.challenge_identity_id,
         CASE
             WHEN bool_or(jr.verdict = 'fail') THEN 'fail'
             WHEN bool_or(jr.verdict = 'pass') THEN 'pass'
@@ -340,8 +341,8 @@ winning_case_outcomes AS (
     FROM judge_results AS jr
     JOIN winning_run_agent AS wra
       ON jr.run_agent_id = wra.winning_run_agent_id
-    WHERE jr.regression_case_id IS NOT NULL
-    GROUP BY jr.regression_case_id
+    WHERE jr.challenge_identity_id IS NOT NULL
+    GROUP BY jr.challenge_identity_id
 )
 SELECT
     src.regression_case_id,
@@ -351,7 +352,7 @@ SELECT
     COALESCE(wco.outcome, 'pending') AS outcome
 FROM selected_regression_cases AS src
 LEFT JOIN winning_case_outcomes AS wco
-  ON wco.regression_case_id = src.regression_case_id
+  ON wco.challenge_identity_id = src.challenge_identity_id
 ORDER BY src.suite_name ASC NULLS LAST, src.regression_case_title ASC, src.regression_case_id ASC
 `
 

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -5124,6 +5124,7 @@ components:
           status,
           source_mode,
           default_gate_severity,
+          case_count,
           created_by_user_id,
           created_at,
           updated_at,
@@ -5149,6 +5150,8 @@ components:
           enum: [derived_only, mixed_manual]
         default_gate_severity:
           $ref: "#/components/schemas/RegressionSeverity"
+        case_count:
+          type: integer
         created_by_user_id:
           type: string
           format: uuid
@@ -5245,6 +5248,8 @@ components:
         metadata:
           type: object
           additionalProperties: true
+        latest_promotion:
+          $ref: "#/components/schemas/RegressionPromotion"
         created_at:
           type: string
           format: date-time

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/cases/[caseId]/case-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/cases/[caseId]/case-detail-client.tsx
@@ -141,7 +141,19 @@ export function CaseDetailClient({
           </MetaRow>
           <MetaRow label="Promoted At">
             <span className="text-muted-foreground">
-              {new Date(c.created_at).toLocaleString()}
+              {new Date(
+                c.latest_promotion?.created_at ?? c.created_at,
+              ).toLocaleString()}
+            </span>
+          </MetaRow>
+          <MetaRow label="Promoted By">
+            <span className="font-[family-name:var(--font-mono)] text-xs text-muted-foreground">
+              {c.latest_promotion?.promoted_by_user_id ?? "\u2014"}
+            </span>
+          </MetaRow>
+          <MetaRow label="Event Refs">
+            <span className="text-muted-foreground">
+              {c.latest_promotion?.source_event_refs?.length ?? 0}
             </span>
           </MetaRow>
         </dl>
@@ -150,11 +162,16 @@ export function CaseDetailClient({
             {c.failure_summary}
           </p>
         )}
-        <p className="mt-3 text-xs text-muted-foreground">
-          Promoter, promotion reason, and detailed audit trail live on the
-          promotions record and will surface once subissue F lands the
-          promote-from-failure action.
-        </p>
+        {c.latest_promotion?.promotion_reason && (
+          <div className="mt-3 rounded-md border border-border bg-background/60 p-3">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground/80">
+              Promotion Reason
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground whitespace-pre-wrap">
+              {c.latest_promotion.promotion_reason}
+            </p>
+          </div>
+        )}
       </Section>
 
       <Section title="Payload Snapshot">
@@ -174,6 +191,15 @@ export function CaseDetailClient({
       {Object.keys(c.metadata ?? {}).length > 0 && (
         <Section title="Metadata">
           <JsonViewer value={c.metadata} defaultOpen={false} />
+        </Section>
+      )}
+
+      {c.latest_promotion && (
+        <Section title="Promotion Snapshot">
+          <JsonViewer
+            value={c.latest_promotion.promotion_snapshot}
+            defaultOpen={false}
+          />
         </Section>
       )}
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/regression-suites-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/regression-suites-client.tsx
@@ -210,6 +210,7 @@ function RegressionSuitesInner({
                 <TableRow>
                   <TableHead>Name</TableHead>
                   <TableHead>Source Pack</TableHead>
+                  <TableHead>Cases</TableHead>
                   <TableHead>Status</TableHead>
                   <TableHead>Default Severity</TableHead>
                   <TableHead>Updated</TableHead>
@@ -220,7 +221,7 @@ function RegressionSuitesInner({
                 {visible.length === 0 ? (
                   <TableRow>
                     <TableCell
-                      colSpan={6}
+                      colSpan={7}
                       className="py-8 text-center text-sm text-muted-foreground"
                     >
                       No suites match the current filter.
@@ -259,6 +260,9 @@ function RegressionSuitesInner({
                               {"\u2014"}
                             </span>
                           )}
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {suite.case_count}
                         </TableCell>
                         <TableCell>
                           <SuiteStatusBadge status={suite.status} />

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/promote-failure-dialog.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/promote-failure-dialog.test.tsx
@@ -305,6 +305,7 @@ describe("PromoteFailureDialog", () => {
           status: "active",
           source_mode: "derived_only",
           default_gate_severity: "warning",
+          case_count: 3,
           created_by_user_id: "user-1",
           created_at: "2026-04-19T00:00:00Z",
           updated_at: "2026-04-19T00:00:00Z",

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.test.tsx
@@ -1,0 +1,409 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CreateRunDialog } from "./create-run-dialog";
+
+const {
+  mockPush,
+  mockRefresh,
+  mockGetAccessToken,
+  mockCreateApiClient,
+  toast,
+} = vi.hoisted(() => {
+  return {
+    mockPush: vi.fn(),
+    mockRefresh: vi.fn(),
+    mockGetAccessToken: vi.fn(),
+    mockCreateApiClient: vi.fn(),
+    toast: Object.assign(vi.fn(), {
+      success: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+}));
+
+vi.mock("@workos-inc/authkit-nextjs/components", () => ({
+  useAccessToken: () => ({ getAccessToken: mockGetAccessToken }),
+}));
+
+vi.mock("sonner", () => ({
+  toast,
+}));
+
+vi.mock("@/lib/api/client", () => ({
+  createApiClient: (...args: unknown[]) => mockCreateApiClient(...args),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => {
+    return React.createElement("button", props, children);
+  },
+}));
+
+vi.mock("@/components/ui/dialog", async () => {
+  const React = await import("react");
+
+  const DialogOpenContext = React.createContext(false);
+  const DialogToggleContext = React.createContext<(open: boolean) => void>(
+    () => {},
+  );
+
+  return {
+    Dialog: ({
+      open,
+      onOpenChange,
+      children,
+    }: {
+      open: boolean;
+      onOpenChange: (open: boolean) => void;
+      children: React.ReactNode;
+    }) => {
+      return React.createElement(
+        DialogOpenContext.Provider,
+        { value: open },
+        React.createElement(
+          DialogToggleContext.Provider,
+          { value: onOpenChange },
+          children,
+        ),
+      );
+    },
+    DialogTrigger: ({
+      render,
+      children,
+    }: {
+      render?: React.ReactElement;
+      children?: React.ReactNode;
+    }) => {
+      const setOpen = React.useContext(DialogToggleContext);
+      const element = render ?? React.createElement("button");
+      return React.cloneElement(element, {
+        onClick: () => setOpen(true),
+        children,
+      });
+    },
+    DialogContent: ({ children }: { children: React.ReactNode }) => {
+      const open = React.useContext(DialogOpenContext);
+      return open
+        ? React.createElement("div", { "data-testid": "dialog-content" }, children)
+        : null;
+    },
+    DialogDescription: ({ children }: { children: React.ReactNode }) => {
+      return React.createElement("p", null, children);
+    },
+    DialogFooter: ({ children }: { children: React.ReactNode }) => {
+      return React.createElement("div", null, children);
+    },
+    DialogHeader: ({ children }: { children: React.ReactNode }) => {
+      return React.createElement("div", null, children);
+    },
+    DialogTitle: ({ children }: { children: React.ReactNode }) => {
+      return React.createElement("h1", null, children);
+    },
+  };
+});
+
+vi.mock("lucide-react", () => ({
+  Loader2: () => React.createElement("span", null, "loader"),
+  Plus: () => React.createElement("span", null, "plus"),
+}));
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function waitFor(assertion: () => void, attempts = 30) {
+  let lastError: unknown;
+  for (let index = 0; index < attempts; index += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await flushPromises();
+    }
+  }
+  throw lastError;
+}
+
+function clickElement(element: Element) {
+  element.dispatchEvent(
+    new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+}
+
+function changeSelect(element: HTMLSelectElement, value: string) {
+  element.value = value;
+  element.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+function findButton(text: string) {
+  const buttons = Array.from(document.querySelectorAll("button"));
+  const button = buttons.find((candidate) =>
+    candidate.textContent?.includes(text),
+  );
+  if (!button) {
+    throw new Error(`Button with text ${text} not found`);
+  }
+  return button;
+}
+
+function findCheckboxByLabel(text: string) {
+  const labels = Array.from(document.querySelectorAll("label"));
+  const label = labels.find((candidate) =>
+    candidate.textContent?.includes(text),
+  );
+  if (!label) {
+    throw new Error(`Checkbox label ${text} not found`);
+  }
+  const checkbox = label.querySelector('input[type="checkbox"]');
+  if (!(checkbox instanceof HTMLInputElement)) {
+    throw new Error(`Checkbox for ${text} not found`);
+  }
+  return checkbox;
+}
+
+function renderDialog() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+
+  act(() => {
+    root.render(React.createElement(CreateRunDialog, { workspaceId: "ws-1" }));
+  });
+
+  return {
+    container,
+    cleanup: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+function buildApiMock() {
+  const post = vi.fn().mockResolvedValue({ id: "run-1" });
+  const get = vi.fn(async (url: string) => {
+    if (url === "/v1/workspaces/ws-1/challenge-packs") {
+      return {
+        items: [
+          {
+            id: "pack-1",
+            name: "Support Pack",
+            versions: [
+              {
+                id: "version-1",
+                version_number: 1,
+                lifecycle_status: "runnable",
+              },
+            ],
+          },
+        ],
+      };
+    }
+    if (url === "/v1/workspaces/ws-1/agent-deployments") {
+      return {
+        items: [
+          { id: "deploy-1", name: "Primary Agent", status: "active" },
+          { id: "deploy-2", name: "Archived Agent", status: "archived" },
+        ],
+      };
+    }
+    if (url === "/v1/workspaces/ws-1/regression-suites/suite-1/cases") {
+      return {
+        items: [
+          {
+            id: "case-1",
+            suite_id: "suite-1",
+            workspace_id: "ws-1",
+            title: "Filesystem Regression",
+            description: "",
+            status: "active",
+            severity: "blocking",
+            promotion_mode: "full_executable",
+            source_challenge_pack_version_id: "version-1",
+            source_challenge_identity_id: "challenge-1",
+            source_case_key: "case-a",
+            evidence_tier: "native_structured",
+            failure_class: "policy_violation",
+            failure_summary: "Attempted forbidden write",
+            payload_snapshot: {},
+            expected_contract: {},
+            metadata: {},
+            created_at: "2026-04-19T00:00:00Z",
+            updated_at: "2026-04-19T00:00:00Z",
+          },
+        ],
+      };
+    }
+    throw new Error(`Unexpected GET ${url}`);
+  });
+  const paginated = vi.fn(async (url: string) => {
+    if (url === "/v1/workspaces/ws-1/regression-suites") {
+      return {
+        items: [
+          {
+            id: "suite-1",
+            workspace_id: "ws-1",
+            source_challenge_pack_id: "pack-1",
+            name: "Regression Suite",
+            description: "Focused failures",
+            status: "active",
+            source_mode: "derived_only",
+            default_gate_severity: "warning",
+            case_count: 1,
+            created_by_user_id: "user-1",
+            created_at: "2026-04-19T00:00:00Z",
+            updated_at: "2026-04-19T00:00:00Z",
+          },
+        ],
+        total: 1,
+        limit: 100,
+        offset: 0,
+      };
+    }
+    throw new Error(`Unexpected paginated ${url}`);
+  });
+
+  return { get, paginated, post };
+}
+
+describe("CreateRunDialog", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    mockPush.mockReset();
+    mockRefresh.mockReset();
+    mockGetAccessToken.mockReset();
+    mockCreateApiClient.mockReset();
+    toast.mockReset();
+    toast.success.mockReset();
+    toast.error.mockReset();
+
+    mockGetAccessToken.mockResolvedValue("token");
+  });
+
+  it("submits regression selections and official pack mode in the create run request", async () => {
+    const api = buildApiMock();
+    mockCreateApiClient.mockReturnValue(api);
+
+    const view = renderDialog();
+    try {
+      clickElement(findButton("New Run"));
+
+      await waitFor(() => {
+        expect(api.get).toHaveBeenCalledWith(
+          "/v1/workspaces/ws-1/challenge-packs",
+        );
+      });
+
+      const packSelect = document.querySelector(
+        'select[aria-label="Challenge Pack"]',
+      );
+      if (!(packSelect instanceof HTMLSelectElement)) {
+        throw new Error("Challenge Pack select not found");
+      }
+      changeSelect(packSelect, "pack-1");
+
+      await waitFor(() => {
+        expect(api.get).toHaveBeenCalledWith(
+          "/v1/workspaces/ws-1/regression-suites/suite-1/cases",
+        );
+      });
+
+      clickElement(findCheckboxByLabel("Primary Agent"));
+      clickElement(findCheckboxByLabel("Regression Suite"));
+      clickElement(findCheckboxByLabel("Filesystem Regression"));
+
+      const officialPackModeSelect = document.querySelector(
+        'select[aria-label="Official Pack Mode"]',
+      );
+      if (!(officialPackModeSelect instanceof HTMLSelectElement)) {
+        throw new Error("Official Pack Mode select not found");
+      }
+      changeSelect(officialPackModeSelect, "suite_only");
+
+      clickElement(findButton("Create Run"));
+
+      await waitFor(() => {
+        expect(api.post).toHaveBeenCalledWith("/v1/runs", {
+          workspace_id: "ws-1",
+          challenge_pack_version_id: "version-1",
+          challenge_input_set_id: undefined,
+          name: undefined,
+          agent_deployment_ids: ["deploy-1"],
+          regression_suite_ids: ["suite-1"],
+          regression_case_ids: ["case-1"],
+          official_pack_mode: "suite_only",
+        });
+      });
+    } finally {
+      view.cleanup();
+    }
+  });
+
+  it("resets official pack mode back to full when regression selections are cleared", async () => {
+    const api = buildApiMock();
+    mockCreateApiClient.mockReturnValue(api);
+
+    const view = renderDialog();
+    try {
+      clickElement(findButton("New Run"));
+
+      await waitFor(() => {
+        expect(api.get).toHaveBeenCalledWith(
+          "/v1/workspaces/ws-1/challenge-packs",
+        );
+      });
+
+      const packSelect = document.querySelector(
+        'select[aria-label="Challenge Pack"]',
+      );
+      if (!(packSelect instanceof HTMLSelectElement)) {
+        throw new Error("Challenge Pack select not found");
+      }
+      changeSelect(packSelect, "pack-1");
+
+      await waitFor(() => {
+        expect(api.get).toHaveBeenCalledWith(
+          "/v1/workspaces/ws-1/regression-suites/suite-1/cases",
+        );
+      });
+
+      const suiteCheckbox = findCheckboxByLabel("Regression Suite");
+      clickElement(suiteCheckbox);
+
+      const officialPackModeSelect = document.querySelector(
+        'select[aria-label="Official Pack Mode"]',
+      );
+      if (!(officialPackModeSelect instanceof HTMLSelectElement)) {
+        throw new Error("Official Pack Mode select not found");
+      }
+      changeSelect(officialPackModeSelect, "suite_only");
+      expect(officialPackModeSelect.value).toBe("suite_only");
+
+      clickElement(suiteCheckbox);
+
+      await waitFor(() => {
+        expect(officialPackModeSelect.value).toBe("full");
+        expect(officialPackModeSelect.disabled).toBe(true);
+      });
+    } finally {
+      view.cleanup();
+    }
+  });
+});

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { createApiClient } from "@/lib/api/client";
@@ -71,6 +71,7 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
   const [regressionLoadError, setRegressionLoadError] = useState<string | null>(
     null,
   );
+  const fetchedSuiteCaseIdsRef = useRef<Set<string>>(new Set());
 
   const loadData = useCallback(async () => {
     setLoading(true);
@@ -158,13 +159,16 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
     );
     const missingSuiteIds = eligibleSuites
       .map((suite) => suite.id)
-      .filter((suiteId) => suiteCases[suiteId] == null);
+      .filter((suiteId) => !fetchedSuiteCaseIdsRef.current.has(suiteId));
 
     if (missingSuiteIds.length === 0) return;
 
     let cancelled = false;
     setLoadingRegression(true);
     setRegressionLoadError(null);
+    for (const suiteId of missingSuiteIds) {
+      fetchedSuiteCaseIdsRef.current.add(suiteId);
+    }
 
     (async () => {
       try {
@@ -193,6 +197,9 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
         });
       } catch (err) {
         if (cancelled) return;
+        for (const suiteId of missingSuiteIds) {
+          fetchedSuiteCaseIdsRef.current.delete(suiteId);
+        }
         setRegressionLoadError(
           err instanceof ApiError ? err.message : "Failed to load regression cases",
         );
@@ -204,7 +211,7 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
     return () => {
       cancelled = true;
     };
-  }, [getAccessToken, open, regressionSuites, selectedPackId, suiteCases, workspaceId]);
+  }, [getAccessToken, open, regressionSuites, selectedPackId, workspaceId]);
 
   useEffect(() => {
     if (selectedRegressionSuiteIds.length === 0 && selectedRegressionCaseIds.length === 0) {
@@ -317,6 +324,7 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
               Challenge Pack
             </label>
             <select
+              aria-label="Challenge Pack"
               value={selectedPackId}
               onChange={(e) => handlePackChange(e.target.value)}
               disabled={loading}
@@ -342,6 +350,7 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
               </span>
             </label>
             <select
+              aria-label="Challenge Pack Version"
               value={selectedVersionId}
               onChange={(e) => setSelectedVersionId(e.target.value)}
               disabled={!selectedPackId}
@@ -468,6 +477,7 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
                     Official Pack Mode
                   </label>
                   <select
+                    aria-label="Official Pack Mode"
                     value={officialPackMode}
                     onChange={(e) =>
                       setOfficialPackMode(e.target.value as OfficialPackMode)

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
@@ -9,7 +9,12 @@ import type {
   AgentDeployment,
   ChallengePack,
   ChallengePackVersion,
+  CreateRunRequest,
   CreateRunResponse,
+  ListRegressionCasesResponse,
+  OfficialPackMode,
+  RegressionCase,
+  RegressionSuite,
 } from "@/lib/api/types";
 import { Button } from "@/components/ui/button";
 import {
@@ -40,6 +45,14 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
   const [selectedDeploymentIds, setSelectedDeploymentIds] = useState<string[]>(
     [],
   );
+  const [selectedRegressionSuiteIds, setSelectedRegressionSuiteIds] = useState<
+    string[]
+  >([]);
+  const [selectedRegressionCaseIds, setSelectedRegressionCaseIds] = useState<
+    string[]
+  >([]);
+  const [officialPackMode, setOfficialPackMode] =
+    useState<OfficialPackMode>("full");
   const [submitting, setSubmitting] = useState(false);
 
   const [packs, setPacks] = useState<ChallengePack[]>([]);
@@ -47,7 +60,17 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
     ChallengePackVersion[]
   >([]);
   const [deployments, setDeployments] = useState<AgentDeployment[]>([]);
+  const [regressionSuites, setRegressionSuites] = useState<RegressionSuite[]>(
+    [],
+  );
+  const [suiteCases, setSuiteCases] = useState<Record<string, RegressionCase[]>>(
+    {},
+  );
   const [loading, setLoading] = useState(false);
+  const [loadingRegression, setLoadingRegression] = useState(false);
+  const [regressionLoadError, setRegressionLoadError] = useState<string | null>(
+    null,
+  );
 
   const loadData = useCallback(async () => {
     setLoading(true);
@@ -62,8 +85,20 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
           `/v1/workspaces/${workspaceId}/agent-deployments`,
         ),
       ]);
+      const suites: RegressionSuite[] = [];
+      let offset = 0;
+      while (true) {
+        const page = await api.paginated<RegressionSuite>(
+          `/v1/workspaces/${workspaceId}/regression-suites`,
+          { limit: 100, offset },
+        );
+        suites.push(...page.items);
+        offset += page.limit;
+        if (suites.length >= page.total || page.items.length === 0) break;
+      }
       setPacks(packsRes.items);
       setDeployments(deploymentsRes.items.filter((d) => d.status === "active"));
+      setRegressionSuites(suites.filter((suite) => suite.status === "active"));
     } catch {
       toast.error("Failed to load data");
     } finally {
@@ -78,6 +113,10 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
   function handlePackChange(packId: string) {
     setSelectedPackId(packId);
     setSelectedVersionId("");
+    setSelectedRegressionSuiteIds([]);
+    setSelectedRegressionCaseIds([]);
+    setOfficialPackMode("full");
+    setRegressionLoadError(null);
     if (packId) {
       const pack = packs.find((p) => p.id === packId);
       const runnable = (pack?.versions ?? []).filter(
@@ -96,6 +135,83 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
     );
   }
 
+  function toggleRegressionSuite(id: string) {
+    setSelectedRegressionSuiteIds((prev) =>
+      prev.includes(id) ? prev.filter((suiteId) => suiteId !== id) : [...prev, id],
+    );
+  }
+
+  function toggleRegressionCase(id: string) {
+    setSelectedRegressionCaseIds((prev) =>
+      prev.includes(id) ? prev.filter((caseId) => caseId !== id) : [...prev, id],
+    );
+  }
+
+  useEffect(() => {
+    if (!open || !selectedPackId) {
+      setRegressionLoadError(null);
+      return;
+    }
+
+    const eligibleSuites = regressionSuites.filter(
+      (suite) => suite.source_challenge_pack_id === selectedPackId,
+    );
+    const missingSuiteIds = eligibleSuites
+      .map((suite) => suite.id)
+      .filter((suiteId) => suiteCases[suiteId] == null);
+
+    if (missingSuiteIds.length === 0) return;
+
+    let cancelled = false;
+    setLoadingRegression(true);
+    setRegressionLoadError(null);
+
+    (async () => {
+      try {
+        const token = await getAccessToken();
+        const api = createApiClient(token);
+        const caseEntries = await Promise.all(
+          missingSuiteIds.map(async (suiteId) => {
+            const response = await api.get<ListRegressionCasesResponse>(
+              `/v1/workspaces/${workspaceId}/regression-suites/${suiteId}/cases`,
+            );
+            return [
+              suiteId,
+              response.items.filter((regressionCase) => regressionCase.status === "active"),
+            ] as const;
+          }),
+        );
+
+        if (cancelled) return;
+
+        setSuiteCases((prev) => {
+          const next = { ...prev };
+          for (const [suiteId, cases] of caseEntries) {
+            next[suiteId] = cases;
+          }
+          return next;
+        });
+      } catch (err) {
+        if (cancelled) return;
+        setRegressionLoadError(
+          err instanceof ApiError ? err.message : "Failed to load regression cases",
+        );
+      } finally {
+        if (!cancelled) setLoadingRegression(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [getAccessToken, open, regressionSuites, selectedPackId, suiteCases, workspaceId]);
+
+  useEffect(() => {
+    if (selectedRegressionSuiteIds.length === 0 && selectedRegressionCaseIds.length === 0) {
+      setOfficialPackMode("full");
+    }
+  }, [selectedRegressionCaseIds, selectedRegressionSuiteIds]);
+
   async function handleCreate() {
     if (!selectedVersionId || selectedDeploymentIds.length === 0) return;
 
@@ -103,13 +219,27 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
     try {
       const token = await getAccessToken();
       const api = createApiClient(token);
-      const result = await api.post<CreateRunResponse>("/v1/runs", {
+      const request: CreateRunRequest = {
         workspace_id: workspaceId,
         challenge_pack_version_id: selectedVersionId,
         challenge_input_set_id: inputSetId.trim() || undefined,
         name: name.trim() || undefined,
         agent_deployment_ids: selectedDeploymentIds,
-      });
+        regression_suite_ids:
+          selectedRegressionSuiteIds.length > 0
+            ? selectedRegressionSuiteIds
+            : undefined,
+        regression_case_ids:
+          selectedRegressionCaseIds.length > 0
+            ? selectedRegressionCaseIds
+            : undefined,
+        official_pack_mode:
+          selectedRegressionSuiteIds.length > 0 ||
+          selectedRegressionCaseIds.length > 0
+            ? officialPackMode
+            : undefined,
+      };
+      const result = await api.post<CreateRunResponse>("/v1/runs", request);
       toast.success("Run created");
       setOpen(false);
       resetForm();
@@ -130,12 +260,21 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
     setSelectedVersionId("");
     setInputSetId("");
     setSelectedDeploymentIds([]);
+    setSelectedRegressionSuiteIds([]);
+    setSelectedRegressionCaseIds([]);
+    setOfficialPackMode("full");
+    setRegressionLoadError(null);
     setRunnableVersions([]);
   }
 
   const executionMode =
     selectedDeploymentIds.length > 1 ? "comparison" : "single_agent";
   const canSubmit = selectedVersionId && selectedDeploymentIds.length > 0;
+  const eligibleRegressionSuites = regressionSuites.filter(
+    (suite) => suite.source_challenge_pack_id === selectedPackId,
+  );
+  const regressionSelectionCount =
+    selectedRegressionSuiteIds.length + selectedRegressionCaseIds.length;
 
   const selectClass =
     "block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:opacity-50";
@@ -238,6 +377,116 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
             />
           </div>
 
+          <div className="space-y-3 rounded-lg border border-border bg-muted/20 p-3">
+            <div>
+              <p className="text-sm font-medium">Regression Coverage</p>
+              <p className="text-xs text-muted-foreground">
+                Optionally add regression suites or specific cases to this run.
+              </p>
+            </div>
+
+            {!selectedPackId ? (
+              <p className="text-sm text-muted-foreground">
+                Select a challenge pack to load matching regression suites.
+              </p>
+            ) : loadingRegression ? (
+              <p className="text-sm text-muted-foreground">
+                Loading regression suites and cases...
+              </p>
+            ) : regressionLoadError ? (
+              <p className="text-sm text-destructive">{regressionLoadError}</p>
+            ) : eligibleRegressionSuites.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No active regression suites are linked to this challenge pack yet.
+              </p>
+            ) : (
+              <div className="space-y-3">
+                <div className="space-y-2 rounded-lg border border-input p-2">
+                  {eligibleRegressionSuites.map((suite) => {
+                    const cases = suiteCases[suite.id] ?? [];
+                    return (
+                      <div key={suite.id} className="space-y-2 rounded-md border border-border/60 p-2">
+                        <label className="flex items-start gap-2 text-sm cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={selectedRegressionSuiteIds.includes(suite.id)}
+                            onChange={() => toggleRegressionSuite(suite.id)}
+                            className="mt-0.5 rounded border-input"
+                          />
+                          <span className="flex-1">
+                            <span className="font-medium text-foreground">
+                              {suite.name}
+                            </span>
+                            <span className="ml-2 text-xs text-muted-foreground">
+                              {suite.case_count} case{suite.case_count === 1 ? "" : "s"}
+                            </span>
+                            {suite.description && (
+                              <span className="mt-0.5 block text-xs text-muted-foreground">
+                                {suite.description}
+                              </span>
+                            )}
+                          </span>
+                        </label>
+
+                        {cases.length > 0 && (
+                          <div className="space-y-1 border-l border-border pl-4">
+                            {cases.map((regressionCase) => (
+                              <label
+                                key={regressionCase.id}
+                                className="flex items-start gap-2 text-sm cursor-pointer"
+                              >
+                                <input
+                                  type="checkbox"
+                                  checked={selectedRegressionCaseIds.includes(regressionCase.id)}
+                                  onChange={() => toggleRegressionCase(regressionCase.id)}
+                                  className="mt-0.5 rounded border-input"
+                                />
+                                <span className="flex-1">
+                                  <span className="text-foreground">
+                                    {regressionCase.title}
+                                  </span>
+                                  <span className="ml-2 text-xs text-muted-foreground">
+                                    {regressionCase.severity}
+                                  </span>
+                                  {regressionCase.failure_summary && (
+                                    <span className="mt-0.5 block text-xs text-muted-foreground">
+                                      {regressionCase.failure_summary}
+                                    </span>
+                                  )}
+                                </span>
+                              </label>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+
+                <div>
+                  <label className="mb-1.5 block text-sm font-medium">
+                    Official Pack Mode
+                  </label>
+                  <select
+                    value={officialPackMode}
+                    onChange={(e) =>
+                      setOfficialPackMode(e.target.value as OfficialPackMode)
+                    }
+                    disabled={regressionSelectionCount === 0}
+                    className={selectClass}
+                  >
+                    <option value="full">
+                      Full - run official pack plus selected regressions
+                    </option>
+                    <option value="suite_only">
+                      Suite only - run only the selected regressions
+                    </option>
+                  </select>
+                </div>
+              </div>
+            )}
+          </div>
+
           {/* Agent Deployments (multi-select) */}
           <div>
             <label className="mb-1.5 block text-sm font-medium">
@@ -284,6 +533,20 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
                   : "single-agent"}{" "}
                 mode
               </span>
+              {regressionSelectionCount > 0 && (
+                <>
+                  {" "}with{" "}
+                  <span className="text-foreground font-medium">
+                    {regressionSelectionCount} regression selection
+                    {regressionSelectionCount === 1 ? "" : "s"}
+                  </span>{" "}
+                  in{" "}
+                  <span className="text-foreground font-medium">
+                    {officialPackMode === "suite_only" ? "suite-only" : "full"}
+                  </span>{" "}
+                  mode
+                </>
+              )}
               .
             </div>
           )}

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -384,6 +384,7 @@ export interface Run {
   workspace_id: string;
   challenge_pack_version_id: string;
   challenge_input_set_id?: string;
+  official_pack_mode: OfficialPackMode;
   name: string;
   status: RunStatus;
   execution_mode: string; // "single_agent" | "comparison"
@@ -412,6 +413,8 @@ export type RunStatus =
   | "failed"
   | "cancelled";
 
+export type OfficialPackMode = "full" | "suite_only";
+
 /** POST /v1/runs request */
 export interface CreateRunRequest {
   workspace_id: string;
@@ -419,6 +422,9 @@ export interface CreateRunRequest {
   challenge_input_set_id?: string;
   name?: string;
   agent_deployment_ids: string[];
+  regression_suite_ids?: string[];
+  regression_case_ids?: string[];
+  official_pack_mode?: OfficialPackMode;
 }
 
 /** POST /v1/runs response (201) */
@@ -427,6 +433,7 @@ export interface CreateRunResponse {
   workspace_id: string;
   challenge_pack_version_id: string;
   challenge_input_set_id?: string;
+  official_pack_mode: OfficialPackMode;
   status: RunStatus;
   execution_mode: string;
   created_at: string;
@@ -1150,6 +1157,18 @@ export type RegressionPromotionMode =
   | "manual";
 export type RegressionSourceMode = "derived_only" | "mixed_manual";
 
+export interface RegressionPromotion {
+  id: string;
+  workspace_regression_case_id: string;
+  source_run_id: string;
+  source_run_agent_id: string;
+  source_event_refs: unknown[];
+  promoted_by_user_id: string;
+  promotion_reason: string;
+  promotion_snapshot: Record<string, unknown>;
+  created_at: string;
+}
+
 /** GET /v1/workspaces/{ws}/regression-suites list item, POST response, PATCH response */
 export interface RegressionSuite {
   id: string;
@@ -1160,6 +1179,7 @@ export interface RegressionSuite {
   status: RegressionSuiteStatus;
   source_mode: RegressionSourceMode;
   default_gate_severity: RegressionSeverity;
+  case_count: number;
   created_by_user_id: string;
   created_at: string;
   updated_at: string;
@@ -1190,6 +1210,7 @@ export interface RegressionCase {
   expected_contract: Record<string, unknown>;
   validator_overrides?: Record<string, unknown> | null;
   metadata: Record<string, unknown>;
+  latest_promotion?: RegressionPromotion;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary
- add the missing regression run-composition UI in `New Run`, including `regression_suite_ids`, `regression_case_ids`, and `official_pack_mode`
- surface suite `case_count` and case `latest_promotion` metadata end-to-end in the backend API, OpenAPI, and frontend regression pages
- tighten failure-review handling by validating `failure_class` / `evidence_tier` query params and suppressing promotion modes when the run has no challenge input set
- fan out regression coverage outcomes across overlapping selections on the same challenge identity so duplicate selected cases do not stay stuck as `pending`

## Why now
This is the pre-H / pre-I tightening pass before #326 and #327. I audited the current backend, frontend, and issue scope with parallel subagents first, then closed the gaps still left on `main` so H/I can build on a tighter base.

## Notes
- `New Run` can now target active regression suites/cases for the selected pack and switch between `full` and `suite_only`
- regression suite list now shows case counts
- regression case detail now shows latest promotion audit metadata instead of the stale placeholder copy
- failure promotion no longer advertises promotable modes that would 500 later because the run lacks a challenge input set

## Verification
- `go test ./...`
- `pnpm -C web exec vitest run src/lib/api/__tests__/regression.test.ts "src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/promote-failure-dialog.test.tsx"`
- `pnpm -C web exec tsc --noEmit`
- `pnpm -C web exec eslint "src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx" "src/app/(workspace)/workspaces/[workspaceId]/regression-suites/regression-suites-client.tsx" "src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/cases/[caseId]/case-detail-client.tsx" "src/lib/api/types.ts" "src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/promote-failure-dialog.test.tsx"`
