### PR TITLE
feat(web): frontend compare/gate with regressions (#327)

### DIFF
--- a/testing/feat-327-frontend-regression-compare-gate.md
+++ b/testing/feat-327-frontend-regression-compare-gate.md
@@ -1,0 +1,188 @@
+# feat/327-frontend-regression-compare-gate — Test Contract
+
+Closes [#327](https://github.com/agentclash/agentclash/issues/327) — Regression
+workflow subissue I: frontend compare/gate with regressions.
+
+This contract is locked before implementation. It is the definition of "done"
+for this PR.
+
+## Scope
+
+Frontend-only. Backend APIs (regression coverage on Run, regression gate rules
+on release-gate policy, `regression_violations` on evaluation details) already
+exist from subissues E/G/H (#323, #325, #326) and must not be modified. No
+backend or OpenAPI changes.
+
+## Functional Behavior
+
+### Compare view (`compare/page.tsx`, `compare/compare-client.tsx`)
+
+1. When both `baselineRun.regression_coverage` and
+   `candidateRun.regression_coverage` are present on the two runs, render a
+   new **"Regression Coverage"** section beneath the existing Key Deltas
+   table and above Release Gates.
+2. The section renders one row per candidate-side regression suite, showing:
+   - Suite name
+   - Case count
+   - Candidate counters: `pass_count`, `fail_count`, derived
+     `warn_count = case_count - pass_count - fail_count` (clamped at ≥ 0)
+   - Delta vs baseline: `(candidate.fail_count - baseline.fail_count)` for the
+     same suite id. Suites present only on one side are marked "new" or
+     "baseline-only".
+   - If `candidate.fail_count > baseline.fail_count`, the row is highlighted
+     (red tint) and a "new failures" badge is shown. If equal or lower, no
+     highlight.
+3. A multi-select filter above the table lets the user restrict the table to
+   one or more `suite_id`s. Empty selection = show all suites.
+4. Each row has a caret/chevron that expands to show the suite's per-suite
+   detail: for candidate unmatched cases on that suite, list case title,
+   severity badge, and outcome. (If no per-case data is exposed by the
+   existing API, the expand-row shows the candidate vs baseline counts side
+   by side — "Candidate N pass / M fail" vs "Baseline N' pass / M' fail" —
+   and a text link to the full run.)
+5. The bottom of each row includes a small "Open suite" link routing to
+   `/workspaces/{workspaceId}/regression-suites/{suite.id}`.
+
+### "New blocking regression" alert banner
+
+6. When any `ReleaseGate` fetched for the comparison has verdict `fail` and
+   `evaluation_details.regression_violations` contains an entry whose `rule`
+   is `no_blocking_regression_failure` or
+   `no_new_blocking_failure_vs_baseline`, render a red alert banner at the
+   very top of the compare body (above Breadcrumb-adjacent title), with:
+   - Title: "New blocking regression"
+   - Summary line from the gate
+   - A link "View regression case" pointing to the first offending case
+     detail page (using `suite_id` + `regression_case_id` to build
+     `/workspaces/{workspaceId}/regression-suites/{suite_id}/cases/{regression_case_id}`)
+7. The banner is suppressed when no release gates exist or when none have
+   regression violations with those rules.
+
+### Release-gate editor (`compare/evaluate-release-gate-dialog.tsx`)
+
+8. Add a new **"Regression rules"** section above the JSON editor with the
+   following controls backed by `regression_gate_rules` on the policy:
+   - Toggle (checkbox): `no_blocking_regression_failure`
+   - Toggle: `no_new_blocking_failure_vs_baseline`
+   - Numeric input: `max_warning_regression_failures` (0 = disabled / null)
+   - Multi-select: `suite_ids` (empty = all suites; options sourced from
+     `GET /v1/workspaces/{workspaceId}/regression-suites`). Scope must be
+     restricted to active suites.
+9. Editing these controls writes the normalised rule object back into the
+   JSON editor (keeping JSON as the source of truth). Editing the JSON
+   manually keeps the inputs in sync on re-parse.
+10. If the user disables all three rule toggles and leaves suite scope empty,
+    `regression_gate_rules` is omitted from the submitted policy (to stay
+    compatible with existing policy fingerprints).
+
+### Release-gate evaluation result — violations list
+
+11. When an evaluation returns `evaluation_details.regression_violations`
+    (either in the dialog result or in an existing `GateCard`), render a
+    **"Regression violations"** sub-panel listing each violation with:
+    - Rule label (human-friendly: "Blocking failure", "New blocking vs
+      baseline", "Warning threshold exceeded")
+    - Severity badge
+    - Link to the case detail page using `suite_id` + `regression_case_id`
+    - Link to the scoring result deep link using
+      `/workspaces/{workspaceId}/runs/{candidateRunId}/agents/{candidateRunAgentId}/scorecard#{scoring_result_id}`
+      when `candidate_run_agent_id` is available on the comparison, else
+      fall back to the case page only.
+
+### Suite detail — Run History tab
+(`regression-suites/[suiteId]/suite-detail-client.tsx`)
+
+12. Replace the current "Run History coming soon" empty state with a table
+    populated from `GET /v1/workspaces/{workspaceId}/runs?limit=50` filtered
+    client-side to runs whose `regression_coverage.suites` contains the
+    current `suiteId`.
+13. For each matching run show: run name (link to run detail), status, the
+    candidate-side pass/fail/warn counts for this suite, finished-at
+    timestamp. Sort newest-first by `finished_at ?? created_at`.
+14. Empty state: "No runs have executed this suite yet."
+
+### Case detail — Recent Outcomes
+(`regression-suites/[suiteId]/cases/[caseId]/case-detail-client.tsx`)
+
+15. Replace the current empty state in the "Recent Outcomes" section with a
+    table sourced the same way as §12: runs whose regression_coverage
+    includes the case's `suite_id`.
+16. Per row: run name + link, finished-at timestamp, and — best-effort — a
+    badge indicating whether the case was among the run's `unmatched_cases`
+    (showing `pending` / `pass` / `fail` when available, else "executed"
+    with a link to the run). Current API does not expose per-case matched
+    outcome, so the fallback wording is intentional; see §18.
+17. Empty state: "This case has not executed in the last 50 runs."
+
+### Non-goals / out-of-scope
+
+18. Backend changes (e.g. adding a per-case run-history endpoint) are
+    out-of-scope per the issue. The "Recent Outcomes" panel is
+    deliberately best-effort for matched cases.
+19. Auto-promotion suggestions, failure clustering (Phase 4).
+20. Changes to run-creation flow (that is subissue G / issue 326's scope).
+
+## Unit Tests
+
+New or updated vitest unit tests under `web/src/lib/api/__tests__/`:
+
+- `release-gates.test.ts::listReleaseGates` — GET request hits
+  `/v1/release-gates` with the correct query params and Authorization header
+  and returns the typed response.
+- `release-gates.test.ts::evaluateReleaseGate` — POST request hits
+  `/v1/release-gates/evaluate` with the given policy and returns the typed
+  response, including `regression_violations` survival through the JSON
+  round-trip.
+- `release-gates.test.ts::normalizeRegressionGateRules` — local helper that
+  accepts the structured form values and emits `undefined` when all three
+  rule toggles are off and scope is empty; emits a canonical object
+  otherwise. Mirrors backend `normalizeRegressionGateRules` (non-negative
+  integer constraint) and trims empty suite ids.
+
+## Integration / Functional Tests
+
+Covered by the unit tests above plus the manual checks below. No new
+integration tests required; the existing
+`web/src/lib/api/__tests__/integration.test.ts` suite must still pass.
+
+## Smoke Tests
+
+- `cd web && pnpm lint` — clean.
+- `cd web && npx tsc --noEmit` — clean.
+- `cd web && pnpm vitest run src/lib/api` — all API unit tests pass.
+
+## E2E Tests
+
+N/A — no E2E harness exists for the compare view. Manual checks below.
+
+## Manual / cURL Tests
+
+Run `./scripts/dev/start-local-stack.sh` and open the web app.
+
+1. Create two comparable runs that include a shared regression suite (see
+   subissue G's seed). Navigate to
+   `/workspaces/{ws}/compare?baseline={a}&candidate={b}`. Assert the
+   "Regression Coverage" section renders with per-suite counts.
+2. With the Evaluate Release Gate dialog, enable
+   `no_blocking_regression_failure` via the new section, submit, and confirm:
+   - The returned gate card shows a "Regression violations" list.
+   - The compare view top-of-page shows the "New blocking regression"
+     banner.
+   - The "View regression case" link opens the correct case detail page.
+3. In the "Regression rules" section, toggle all rules off and empty the
+   suite scope, submit. Confirm the request body serialises without a
+   `regression_gate_rules` field (check via the browser devtools Network
+   tab payload).
+4. On a suite detail page, open the "Run History" tab and confirm runs that
+   included this suite appear with pass/fail counts; runs that did not are
+   absent.
+5. On a case detail page, scroll to "Recent Outcomes" and confirm runs that
+   executed the parent suite appear; otherwise the empty state is shown.
+
+## Validation checklist
+
+- [ ] `cd web && pnpm lint`
+- [ ] `cd web && npx tsc --noEmit`
+- [ ] `cd web && pnpm vitest run src/lib/api`
+- [ ] PR ≤ 1500 LOC (excluding `pnpm-lock.yaml`)
+- [ ] No backend / OpenAPI changes

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/compare-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/compare-client.tsx
@@ -319,6 +319,7 @@ export function CompareClient({
         workspaceId={workspaceId}
         baselineRunId={comparison.baseline_run_id}
         candidateRunId={comparison.candidate_run_id}
+        candidateRunAgentId={comparison.candidate_run_agent_id}
         gates={gates}
         loading={gatesLoading}
         onEvaluated={() => setRefreshCounter((c) => c + 1)}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/compare-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/compare-client.tsx
@@ -24,6 +24,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { scorePercent } from "@/lib/scores";
+import { RegressionCoverageSection } from "./regression-coverage-section";
 import { ReleaseGatesSection } from "./release-gates-section";
 
 // --- State badge ---
@@ -242,6 +243,13 @@ export function CompareClient({
             </div>
           </div>
         )}
+
+      {/* Regression Coverage */}
+      <RegressionCoverageSection
+        workspaceId={workspaceId}
+        baselineCoverage={baselineRun.regression_coverage}
+        candidateCoverage={candidateRun.regression_coverage}
+      />
 
       {/* Evidence quality notes */}
       {comparison.evidence_quality.missing_fields &&

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/compare-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/compare-client.tsx
@@ -1,10 +1,16 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+
 import type {
   ComparisonResponse,
   DeltaHighlight,
+  ReleaseGate,
   Run,
 } from "@/lib/api/types";
+import { createApiClient } from "@/lib/api/client";
+import { listReleaseGates } from "@/lib/api/release-gates";
 import { Badge } from "@/components/ui/badge";
 import {
   Table,
@@ -24,6 +30,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { scorePercent } from "@/lib/scores";
+import { RegressionAlertBanner } from "./regression-alert-banner";
 import { RegressionCoverageSection } from "./regression-coverage-section";
 import { ReleaseGatesSection } from "./release-gates-section";
 
@@ -121,8 +128,46 @@ export function CompareClient({
   const isNotComparable = comparison.state === "not_comparable";
   const isPartial = comparison.state === "partial_evidence";
 
+  const { getAccessToken } = useAccessToken();
+  const [gates, setGates] = useState<ReleaseGate[]>([]);
+  const [gatesLoading, setGatesLoading] = useState(true);
+  const [refreshCounter, setRefreshCounter] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setGatesLoading(true);
+      try {
+        const token = await getAccessToken();
+        const api = createApiClient(token);
+        const res = await listReleaseGates(
+          api,
+          comparison.baseline_run_id,
+          comparison.candidate_run_id,
+        );
+        if (!cancelled) setGates(res.release_gates ?? []);
+      } catch {
+        // Gates are supplementary — silently fail
+        if (!cancelled) setGates([]);
+      } finally {
+        if (!cancelled) setGatesLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    getAccessToken,
+    comparison.baseline_run_id,
+    comparison.candidate_run_id,
+    refreshCounter,
+  ]);
+
   return (
     <div className="space-y-6">
+      {/* "New blocking regression" banner */}
+      <RegressionAlertBanner workspaceId={workspaceId} gates={gates} />
+
       {/* Header: Baseline vs Candidate */}
       <div>
         <div className="flex items-center gap-3 mb-2">
@@ -271,8 +316,12 @@ export function CompareClient({
 
       {/* Release Gates */}
       <ReleaseGatesSection
+        workspaceId={workspaceId}
         baselineRunId={comparison.baseline_run_id}
         candidateRunId={comparison.candidate_run_id}
+        gates={gates}
+        loading={gatesLoading}
+        onEvaluated={() => setRefreshCounter((c) => c + 1)}
       />
     </div>
   );

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/evaluate-release-gate-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/evaluate-release-gate-dialog.tsx
@@ -1,12 +1,22 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";
+import { listRegressionSuites } from "@/lib/api/regression";
+import {
+  EMPTY_REGRESSION_GATE_RULES_DRAFT,
+  evaluateReleaseGate,
+  normalizeRegressionGateRules,
+  regressionGateRulesToDraft,
+  type RegressionGateRulesDraft,
+} from "@/lib/api/release-gates";
 import type {
+  RegressionGateRules,
+  RegressionSuite,
   ReleaseGate,
-  EvaluateReleaseGateResponse,
+  ReleaseGatePolicy,
 } from "@/lib/api/types";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -19,8 +29,11 @@ import {
   DialogFooter,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import { JsonField } from "@/components/ui/json-field";
 import { ShieldCheck, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { RegressionViolationsList } from "./regression-violations-list";
 import { VERDICT_CONFIG, outcomeColor } from "./verdict-config";
 
 const DEFAULT_POLICY = JSON.stringify(
@@ -47,56 +60,192 @@ interface EvaluateReleaseGateDialogProps {
   workspaceId: string;
   baselineRunId: string;
   candidateRunId: string;
+  candidateRunAgentId?: string;
   onEvaluated: () => void;
 }
 
+/**
+ * Re-serialise a parsed policy object with normalised regression rules
+ * merged in. Returns `undefined` if the input JSON is not a parseable
+ * object — caller can surface that via `jsonError`.
+ */
+function mergeRulesIntoJson(
+  raw: string,
+  rules: RegressionGateRules | undefined,
+): string | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return undefined;
+  }
+  const obj = { ...(parsed as Record<string, unknown>) };
+  if (rules) {
+    obj.regression_gate_rules = rules;
+  } else {
+    delete obj.regression_gate_rules;
+  }
+  return JSON.stringify(obj, null, 2);
+}
+
 export function EvaluateReleaseGateDialog({
+  workspaceId,
   baselineRunId,
   candidateRunId,
+  candidateRunAgentId,
   onEvaluated,
 }: EvaluateReleaseGateDialogProps) {
   const { getAccessToken } = useAccessToken();
   const [open, setOpen] = useState(false);
   const [policyJson, setPolicyJson] = useState(DEFAULT_POLICY);
+  const [rulesDraft, setRulesDraft] = useState<RegressionGateRulesDraft>(
+    { ...EMPTY_REGRESSION_GATE_RULES_DRAFT },
+  );
   const [jsonError, setJsonError] = useState<string>();
   const [evaluating, setEvaluating] = useState(false);
   const [apiError, setApiError] = useState<string>();
   const [result, setResult] = useState<ReleaseGate | null>(null);
+  const [suites, setSuites] = useState<RegressionSuite[]>([]);
+  const [suitesError, setSuitesError] = useState<string>();
+
+  // When the structured form changes, we write the normalised rules into
+  // the JSON text. `skipNextSyncRef` prevents the other direction — the
+  // effect below that hydrates rules from JSON — from firing on the same
+  // change, which would otherwise cause spurious re-renders.
+  const skipNextSyncRef = useRef(false);
 
   function handleOpenChange(next: boolean) {
     setOpen(next);
     if (next) {
-      // Reset state when opening
       setJsonError(undefined);
       setApiError(undefined);
       setResult(null);
     }
   }
 
+  // Fetch active suites for the suite scope multi-select on open.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = await getAccessToken();
+        const api = createApiClient(token);
+        const res = await listRegressionSuites(api, workspaceId, {
+          limit: 100,
+        });
+        if (!cancelled) {
+          setSuites(
+            (res.items ?? []).filter((s) => s.status === "active"),
+          );
+          setSuitesError(undefined);
+        }
+      } catch {
+        if (!cancelled) {
+          setSuitesError("Could not load regression suites.");
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, workspaceId, getAccessToken]);
+
+  // When the user edits the JSON by hand, mirror the regression_gate_rules
+  // field back into the structured form so the two views stay in sync.
+  useEffect(() => {
+    if (skipNextSyncRef.current) {
+      skipNextSyncRef.current = false;
+      return;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(policyJson);
+    } catch {
+      return;
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return;
+    }
+    const rawRules =
+      (parsed as { regression_gate_rules?: RegressionGateRules })
+        .regression_gate_rules;
+    const nextDraft = regressionGateRulesToDraft(rawRules);
+    setRulesDraft((prev) => {
+      if (
+        prev.noBlockingRegressionFailure === nextDraft.noBlockingRegressionFailure &&
+        prev.noNewBlockingFailureVsBaseline ===
+          nextDraft.noNewBlockingFailureVsBaseline &&
+        prev.maxWarningRegressionFailures ===
+          nextDraft.maxWarningRegressionFailures &&
+        prev.suiteIds.length === nextDraft.suiteIds.length &&
+        prev.suiteIds.every((id, i) => id === nextDraft.suiteIds[i])
+      ) {
+        return prev;
+      }
+      return nextDraft;
+    });
+  }, [policyJson]);
+
+  function updateDraft(mutate: (draft: RegressionGateRulesDraft) => void) {
+    setRulesDraft((prev) => {
+      const next = { ...prev, suiteIds: [...prev.suiteIds] };
+      mutate(next);
+      const merged = mergeRulesIntoJson(
+        policyJson,
+        normalizeRegressionGateRules(next),
+      );
+      if (merged !== undefined) {
+        skipNextSyncRef.current = true;
+        setPolicyJson(merged);
+      }
+      return next;
+    });
+  }
+
+  function toggleSuiteId(suiteId: string) {
+    updateDraft((d) => {
+      if (d.suiteIds.includes(suiteId)) {
+        d.suiteIds = d.suiteIds.filter((id) => id !== suiteId);
+      } else {
+        d.suiteIds = [...d.suiteIds, suiteId];
+      }
+    });
+  }
+
   async function handleEvaluate() {
     setJsonError(undefined);
     setApiError(undefined);
 
-    let policy: unknown;
+    let policy: ReleaseGatePolicy;
     try {
-      policy = JSON.parse(policyJson);
+      policy = JSON.parse(policyJson) as ReleaseGatePolicy;
     } catch {
       setJsonError("Invalid JSON. Please check the syntax.");
       return;
+    }
+
+    const normalisedRules = normalizeRegressionGateRules(rulesDraft);
+    if (normalisedRules) {
+      policy = { ...policy, regression_gate_rules: normalisedRules };
+    } else {
+      const rest = { ...policy };
+      delete (rest as { regression_gate_rules?: unknown }).regression_gate_rules;
+      policy = rest;
     }
 
     setEvaluating(true);
     try {
       const token = await getAccessToken();
       const api = createApiClient(token);
-      const res = await api.post<EvaluateReleaseGateResponse>(
-        "/v1/release-gates/evaluate",
-        {
-          baseline_run_id: baselineRunId,
-          candidate_run_id: candidateRunId,
-          policy,
-        },
-      );
+      const res = await evaluateReleaseGate(api, {
+        baseline_run_id: baselineRunId,
+        candidate_run_id: candidateRunId,
+        policy,
+      });
       setResult(res.release_gate);
       onEvaluated();
     } catch (err) {
@@ -113,6 +262,9 @@ export function EvaluateReleaseGateDialog({
   const resultConfig = result
     ? VERDICT_CONFIG[result.verdict] ?? VERDICT_CONFIG.insufficient_evidence
     : null;
+  const capInvalid =
+    rulesDraft.maxWarningRegressionFailures != null &&
+    rulesDraft.maxWarningRegressionFailures < 0;
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -120,7 +272,7 @@ export function EvaluateReleaseGateDialog({
         <ShieldCheck className="size-4 mr-1.5" />
         Evaluate Release Gate
       </DialogTrigger>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="sm:max-w-xl">
         <DialogHeader>
           <DialogTitle>Evaluate Release Gate</DialogTitle>
           <DialogDescription>
@@ -130,9 +282,125 @@ export function EvaluateReleaseGateDialog({
         </DialogHeader>
 
         <div className="space-y-4">
+          {/* Regression rules (structured) */}
+          <section className="rounded-lg border border-border bg-card/30 p-3 space-y-3">
+            <div>
+              <p className="text-sm font-medium">Regression rules</p>
+              <p className="text-xs text-muted-foreground">
+                Drive the policy&apos;s <code>regression_gate_rules</code>{" "}
+                block without editing JSON. Leaving everything off and the
+                scope empty omits the field entirely, preserving existing
+                policy fingerprints.
+              </p>
+            </div>
+
+            <ToggleRow
+              label="No blocking regression failure"
+              description="Fail the gate when any blocking regression case fails on the candidate."
+              checked={rulesDraft.noBlockingRegressionFailure}
+              disabled={evaluating}
+              onChange={(value) =>
+                updateDraft((d) => {
+                  d.noBlockingRegressionFailure = value;
+                })
+              }
+            />
+
+            <ToggleRow
+              label="No new blocking failure vs baseline"
+              description="Fail the gate only for blocking regression cases that passed on baseline but failed on candidate."
+              checked={rulesDraft.noNewBlockingFailureVsBaseline}
+              disabled={evaluating}
+              onChange={(value) =>
+                updateDraft((d) => {
+                  d.noNewBlockingFailureVsBaseline = value;
+                })
+              }
+            />
+
+            <div>
+              <label className="flex flex-col gap-1 text-xs font-medium">
+                Max warning regression failures
+                <Input
+                  type="number"
+                  min={0}
+                  step={1}
+                  disabled={evaluating}
+                  value={
+                    rulesDraft.maxWarningRegressionFailures == null
+                      ? ""
+                      : rulesDraft.maxWarningRegressionFailures
+                  }
+                  onChange={(e) => {
+                    const raw = e.target.value;
+                    updateDraft((d) => {
+                      if (raw === "") {
+                        d.maxWarningRegressionFailures = null;
+                        return;
+                      }
+                      const n = Number.parseInt(raw, 10);
+                      d.maxWarningRegressionFailures = Number.isFinite(n)
+                        ? n
+                        : null;
+                    });
+                  }}
+                  className={cn(capInvalid && "border-destructive")}
+                />
+              </label>
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                Leave blank to disable. 0 = allow no warning failures.
+              </p>
+              {capInvalid && (
+                <p className="mt-1 text-[11px] text-destructive">
+                  Must be zero or greater. Negative values are dropped at
+                  submit.
+                </p>
+              )}
+            </div>
+
+            <div>
+              <p className="text-xs font-medium mb-1">
+                Suite scope{" "}
+                <span className="text-muted-foreground font-normal">
+                  (empty = all suites)
+                </span>
+              </p>
+              {suitesError && (
+                <p className="text-[11px] text-destructive">{suitesError}</p>
+              )}
+              {suites.length === 0 && !suitesError ? (
+                <p className="text-[11px] text-muted-foreground">
+                  No active regression suites in this workspace.
+                </p>
+              ) : (
+                <div className="flex flex-wrap gap-1.5">
+                  {suites.map((suite) => {
+                    const active = rulesDraft.suiteIds.includes(suite.id);
+                    return (
+                      <button
+                        key={suite.id}
+                        type="button"
+                        disabled={evaluating}
+                        onClick={() => toggleSuiteId(suite.id)}
+                        className={cn(
+                          "rounded-full border px-2 py-0.5 text-xs transition-colors disabled:opacity-50",
+                          active
+                            ? "border-foreground bg-foreground text-background"
+                            : "border-border text-muted-foreground hover:border-foreground/40 hover:text-foreground",
+                        )}
+                      >
+                        {suite.name}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          </section>
+
           <JsonField
             label="Policy JSON"
-            description="Release gate policy with dimension thresholds. Leave as default for standard evaluation."
+            description="Release gate policy with dimension thresholds and optional regression_gate_rules (kept in sync with the controls above)."
             value={policyJson}
             onChange={setPolicyJson}
             error={jsonError}
@@ -204,6 +472,15 @@ export function EvaluateReleaseGateDialog({
                     ))}
                   </div>
                 )}
+
+              <RegressionViolationsList
+                workspaceId={workspaceId}
+                candidateRunId={candidateRunId}
+                candidateRunAgentId={candidateRunAgentId}
+                violations={
+                  result.evaluation_details?.regression_violations ?? []
+                }
+              />
             </div>
           )}
         </div>
@@ -221,5 +498,35 @@ export function EvaluateReleaseGateDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function ToggleRow({
+  label,
+  description,
+  checked,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  description: string;
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  return (
+    <label className="flex gap-2 cursor-pointer select-none">
+      <input
+        type="checkbox"
+        className="mt-0.5"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+      <div>
+        <p className="text-xs font-medium">{label}</p>
+        <p className="text-[11px] text-muted-foreground">{description}</p>
+      </div>
+    </label>
   );
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/evaluate-release-gate-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/evaluate-release-gate-dialog.tsx
@@ -44,6 +44,7 @@ const DEFAULT_POLICY = JSON.stringify(
 );
 
 interface EvaluateReleaseGateDialogProps {
+  workspaceId: string;
   baselineRunId: string;
   candidateRunId: string;
   onEvaluated: () => void;

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/regression-alert-banner.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/regression-alert-banner.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import Link from "next/link";
+import { AlertTriangle, ArrowRightCircle } from "lucide-react";
+
+import {
+  REGRESSION_BLOCKING_RULES,
+  regressionRuleLabel,
+} from "@/lib/api/release-gates";
+import type { ReleaseGate } from "@/lib/api/types";
+
+interface RegressionAlertBannerProps {
+  workspaceId: string;
+  gates: ReleaseGate[];
+}
+
+/**
+ * Renders the "New blocking regression" banner at the top of the compare
+ * page when any release gate evaluated for this comparison produced a
+ * blocking regression violation. Silent when there are no gates, or when
+ * no gate violates one of the two blocking regression rules.
+ */
+export function RegressionAlertBanner({
+  workspaceId,
+  gates,
+}: RegressionAlertBannerProps) {
+  const offending = gates.find((gate) => {
+    if (gate.verdict !== "fail") return false;
+    const violations = gate.evaluation_details.regression_violations ?? [];
+    return violations.some((v) => REGRESSION_BLOCKING_RULES.has(v.rule));
+  });
+  if (!offending) return null;
+
+  const violation = (offending.evaluation_details.regression_violations ?? [])
+    .find((v) => REGRESSION_BLOCKING_RULES.has(v.rule));
+  if (!violation) return null;
+
+  const caseHref = `/workspaces/${workspaceId}/regression-suites/${violation.suite_id}/cases/${violation.regression_case_id}`;
+
+  return (
+    <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3">
+      <div className="flex items-center gap-2 text-sm font-semibold text-red-300">
+        <AlertTriangle className="size-4" />
+        New blocking regression
+      </div>
+      <p className="mt-1 text-sm text-red-200/90">
+        {offending.summary ||
+          `A release gate failed on ${regressionRuleLabel(violation.rule)}.`}
+      </p>
+      <div className="mt-2 flex flex-wrap items-center gap-3 text-xs">
+        <span className="text-muted-foreground">
+          Gate: {offending.policy_key} v{offending.policy_version}
+        </span>
+        <span className="text-muted-foreground">
+          Rule: {regressionRuleLabel(violation.rule)}
+        </span>
+        <Link
+          href={caseHref}
+          className="inline-flex items-center gap-1 font-medium text-red-200 hover:text-red-100 transition-colors"
+        >
+          View regression case
+          <ArrowRightCircle className="size-3" />
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/regression-coverage-section.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/regression-coverage-section.tsx
@@ -1,0 +1,518 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  AlertTriangle,
+  ArrowRightCircle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Sparkles,
+  XCircle,
+} from "lucide-react";
+
+import type {
+  RunRegressionCoverage,
+  RunRegressionCoverageCase,
+  RunRegressionCoverageSuite,
+} from "@/lib/api/types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+
+interface RegressionCoverageSectionProps {
+  workspaceId: string;
+  baselineCoverage?: RunRegressionCoverage;
+  candidateCoverage?: RunRegressionCoverage;
+}
+
+interface CombinedSuiteRow {
+  id: string;
+  name: string;
+  candidate?: RunRegressionCoverageSuite;
+  baseline?: RunRegressionCoverageSuite;
+  candidateUnmatched: RunRegressionCoverageCase[];
+}
+
+function warnCount(suite: RunRegressionCoverageSuite | undefined): number {
+  if (!suite) return 0;
+  return Math.max(0, suite.case_count - suite.pass_count - suite.fail_count);
+}
+
+export function RegressionCoverageSection({
+  workspaceId,
+  baselineCoverage,
+  candidateCoverage,
+}: RegressionCoverageSectionProps) {
+  const rows = useMemo<CombinedSuiteRow[]>(() => {
+    const byId = new Map<string, CombinedSuiteRow>();
+
+    for (const suite of candidateCoverage?.suites ?? []) {
+      byId.set(suite.id, {
+        id: suite.id,
+        name: suite.name,
+        candidate: suite,
+        candidateUnmatched: [],
+      });
+    }
+    for (const suite of baselineCoverage?.suites ?? []) {
+      const existing = byId.get(suite.id);
+      if (existing) {
+        existing.baseline = suite;
+      } else {
+        byId.set(suite.id, {
+          id: suite.id,
+          name: suite.name,
+          baseline: suite,
+          candidateUnmatched: [],
+        });
+      }
+    }
+    for (const uc of candidateCoverage?.unmatched_cases ?? []) {
+      // Unmatched cases are not tied to a specific suite in the read model;
+      // surface them in a synthetic "unassigned" row so the operator can
+      // still see them rather than silently dropping the data.
+      const key = "__unmatched__";
+      const row = byId.get(key) ?? {
+        id: key,
+        name: "Unmatched cases",
+        candidateUnmatched: [],
+      };
+      row.candidateUnmatched.push(uc);
+      byId.set(key, row);
+    }
+    return Array.from(byId.values()).sort((a, b) => {
+      if (a.id === "__unmatched__") return 1;
+      if (b.id === "__unmatched__") return -1;
+      return a.name.localeCompare(b.name);
+    });
+  }, [baselineCoverage, candidateCoverage]);
+
+  const allSuiteIds = useMemo(
+    () => rows.filter((r) => r.id !== "__unmatched__").map((r) => r.id),
+    [rows],
+  );
+
+  const [selected, setSelected] = useState<string[]>([]);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const visibleRows = useMemo(() => {
+    if (selected.length === 0) return rows;
+    const set = new Set(selected);
+    return rows.filter(
+      (r) => r.id === "__unmatched__" || set.has(r.id),
+    );
+  }, [rows, selected]);
+
+  const totalCandidateFails = useMemo(
+    () =>
+      rows.reduce(
+        (acc, r) => acc + (r.candidate?.fail_count ?? 0),
+        0,
+      ),
+    [rows],
+  );
+  const totalBaselineFails = useMemo(
+    () =>
+      rows.reduce(
+        (acc, r) => acc + (r.baseline?.fail_count ?? 0),
+        0,
+      ),
+    [rows],
+  );
+  const netFailDelta = totalCandidateFails - totalBaselineFails;
+
+  const hasAnyCoverage =
+    (candidateCoverage?.suites?.length ?? 0) > 0 ||
+    (baselineCoverage?.suites?.length ?? 0) > 0 ||
+    (candidateCoverage?.unmatched_cases?.length ?? 0) > 0;
+
+  if (!hasAnyCoverage) return null;
+
+  function toggleSuite(id: string) {
+    setSelected((prev) =>
+      prev.includes(id) ? prev.filter((s) => s !== id) : [...prev, id],
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold">Regression Coverage</h2>
+        <span className="text-xs text-muted-foreground">
+          Candidate: {totalCandidateFails} failure
+          {totalCandidateFails === 1 ? "" : "s"}
+          {netFailDelta !== 0 && (
+            <>
+              {" "}
+              (
+              <span
+                className={cn(
+                  netFailDelta > 0 ? "text-red-400" : "text-emerald-400",
+                )}
+              >
+                {netFailDelta > 0 ? "+" : ""}
+                {netFailDelta} vs baseline
+              </span>
+              )
+            </>
+          )}
+        </span>
+      </div>
+
+      {allSuiteIds.length > 1 && (
+        <div className="mb-3 flex flex-wrap items-center gap-1.5">
+          <span className="text-xs text-muted-foreground">Filter:</span>
+          {rows
+            .filter((r) => r.id !== "__unmatched__")
+            .map((r) => {
+              const active = selected.includes(r.id);
+              return (
+                <button
+                  key={r.id}
+                  type="button"
+                  onClick={() => toggleSuite(r.id)}
+                  className={cn(
+                    "rounded-full border px-2 py-0.5 text-xs transition-colors",
+                    active
+                      ? "border-foreground bg-foreground text-background"
+                      : "border-border text-muted-foreground hover:border-foreground/40 hover:text-foreground",
+                  )}
+                >
+                  {r.name}
+                </button>
+              );
+            })}
+          {selected.length > 0 && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-6 px-2 text-xs"
+              onClick={() => setSelected([])}
+            >
+              Clear
+            </Button>
+          )}
+        </div>
+      )}
+
+      <div className="rounded-lg border border-border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-8" />
+              <TableHead>Suite</TableHead>
+              <TableHead className="text-right">Cases</TableHead>
+              <TableHead className="text-right">Pass</TableHead>
+              <TableHead className="text-right">Fail</TableHead>
+              <TableHead className="text-right">Warn</TableHead>
+              <TableHead className="text-right">Δ vs baseline</TableHead>
+              <TableHead />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {visibleRows.map((row) => (
+              <SuiteRow
+                key={row.id}
+                row={row}
+                expanded={expandedId === row.id}
+                onToggleExpand={() =>
+                  setExpandedId((prev) => (prev === row.id ? null : row.id))
+                }
+                workspaceId={workspaceId}
+              />
+            ))}
+            {visibleRows.length === 0 && (
+              <TableRow>
+                <TableCell
+                  colSpan={8}
+                  className="py-8 text-center text-sm text-muted-foreground"
+                >
+                  No suites match the current filter.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}
+
+function SuiteRow({
+  row,
+  expanded,
+  onToggleExpand,
+  workspaceId,
+}: {
+  row: CombinedSuiteRow;
+  expanded: boolean;
+  onToggleExpand: () => void;
+  workspaceId: string;
+}) {
+  const isUnmatched = row.id === "__unmatched__";
+  const candidate = row.candidate;
+  const baseline = row.baseline;
+  const cDelta =
+    (candidate?.fail_count ?? 0) - (baseline?.fail_count ?? 0);
+  const newFailures = cDelta > 0;
+  const baselineOnly = !candidate && !!baseline;
+  const candidateOnly = !baseline && !!candidate && !isUnmatched;
+
+  const ExpandIcon = expanded ? ChevronDown : ChevronRight;
+
+  return (
+    <>
+      <TableRow
+        className={cn(
+          newFailures && !isUnmatched && "bg-red-500/5",
+          baselineOnly && "text-muted-foreground",
+        )}
+      >
+        <TableCell className="p-2 align-middle">
+          <button
+            type="button"
+            onClick={onToggleExpand}
+            className="text-muted-foreground hover:text-foreground transition-colors"
+            aria-label={expanded ? "Collapse" : "Expand"}
+          >
+            <ExpandIcon className="size-4" />
+          </button>
+        </TableCell>
+        <TableCell className="align-middle">
+          <div className="flex items-center gap-2">
+            <span className="font-medium">{row.name}</span>
+            {newFailures && (
+              <Badge variant="destructive">
+                <AlertTriangle
+                  data-icon="inline-start"
+                  className="size-3"
+                />
+                New failures
+              </Badge>
+            )}
+            {candidateOnly && (
+              <Badge variant="outline">
+                <Sparkles data-icon="inline-start" className="size-3" />
+                New
+              </Badge>
+            )}
+            {baselineOnly && (
+              <Badge variant="outline">Baseline only</Badge>
+            )}
+          </div>
+        </TableCell>
+        <TableCell className="text-right font-[family-name:var(--font-mono)] text-sm">
+          {candidate?.case_count ??
+            row.candidateUnmatched.length ??
+            baseline?.case_count ??
+            0}
+        </TableCell>
+        <TableCell className="text-right">
+          <CountCell value={candidate?.pass_count ?? 0} tone="pass" />
+        </TableCell>
+        <TableCell className="text-right">
+          <CountCell value={candidate?.fail_count ?? 0} tone="fail" />
+        </TableCell>
+        <TableCell className="text-right">
+          <CountCell value={warnCount(candidate)} tone="warn" />
+        </TableCell>
+        <TableCell className="text-right font-[family-name:var(--font-mono)] text-sm">
+          {isUnmatched ? (
+            <span className="text-muted-foreground">—</span>
+          ) : cDelta > 0 ? (
+            <span className="text-red-400">+{cDelta}</span>
+          ) : cDelta < 0 ? (
+            <span className="text-emerald-400">{cDelta}</span>
+          ) : (
+            <span className="text-muted-foreground">0</span>
+          )}
+        </TableCell>
+        <TableCell className="text-right">
+          {!isUnmatched && (
+            <Link
+              href={`/workspaces/${workspaceId}/regression-suites/${row.id}`}
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Open suite
+              <ArrowRightCircle className="size-3" />
+            </Link>
+          )}
+        </TableCell>
+      </TableRow>
+
+      {expanded && (
+        <TableRow className="bg-muted/20">
+          <TableCell />
+          <TableCell colSpan={7} className="pt-2 pb-4">
+            <SuiteExpandedDetail
+              row={row}
+              workspaceId={workspaceId}
+            />
+          </TableCell>
+        </TableRow>
+      )}
+    </>
+  );
+}
+
+function CountCell({
+  value,
+  tone,
+}: {
+  value: number;
+  tone: "pass" | "fail" | "warn";
+}) {
+  const color =
+    value === 0
+      ? "text-muted-foreground"
+      : tone === "pass"
+        ? "text-emerald-400"
+        : tone === "fail"
+          ? "text-red-400"
+          : "text-amber-400";
+  const Icon = tone === "pass" ? CheckCircle2 : tone === "fail" ? XCircle : AlertTriangle;
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 font-[family-name:var(--font-mono)] text-sm",
+        color,
+      )}
+    >
+      {value > 0 && <Icon className="size-3" />}
+      {value}
+    </span>
+  );
+}
+
+function SuiteExpandedDetail({
+  row,
+  workspaceId,
+}: {
+  row: CombinedSuiteRow;
+  workspaceId: string;
+}) {
+  const candidate = row.candidate;
+  const baseline = row.baseline;
+
+  if (row.id === "__unmatched__") {
+    return (
+      <div className="space-y-2">
+        <p className="text-xs text-muted-foreground">
+          These regression cases were selected for the candidate run but did
+          not match any executed item. This usually means the underlying
+          challenge identity was skipped or filtered out.
+        </p>
+        <ul className="space-y-1 text-sm">
+          {row.candidateUnmatched.map((c) => (
+            <li
+              key={c.id}
+              className="flex items-center justify-between gap-2"
+            >
+              <span>{c.title}</span>
+              <Badge variant="outline">{c.outcome}</Badge>
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-3 text-xs sm:grid-cols-2">
+      <CountsColumn
+        label="Candidate"
+        suite={candidate}
+        link={
+          candidate
+            ? `/workspaces/${workspaceId}/regression-suites/${row.id}`
+            : null
+        }
+      />
+      <CountsColumn label="Baseline" suite={baseline} link={null} />
+    </div>
+  );
+}
+
+function CountsColumn({
+  label,
+  suite,
+  link,
+}: {
+  label: string;
+  suite: RunRegressionCoverageSuite | undefined;
+  link: string | null;
+}) {
+  return (
+    <div className="rounded-md border border-border bg-background/60 p-3">
+      <p className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground/80">
+        {label}
+      </p>
+      {suite ? (
+        <dl className="grid grid-cols-4 gap-2 text-center text-xs">
+          <Stat label="Cases" value={suite.case_count} />
+          <Stat label="Pass" value={suite.pass_count} tone="pass" />
+          <Stat label="Fail" value={suite.fail_count} tone="fail" />
+          <Stat label="Warn" value={warnCount(suite)} tone="warn" />
+        </dl>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          Not included in this run.
+        </p>
+      )}
+      {link && (
+        <Link
+          href={link}
+          className="mt-2 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          View suite
+          <ArrowRightCircle className="size-3" />
+        </Link>
+      )}
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone?: "pass" | "fail" | "warn";
+}) {
+  const color =
+    value === 0 || !tone
+      ? "text-foreground"
+      : tone === "pass"
+        ? "text-emerald-400"
+        : tone === "fail"
+          ? "text-red-400"
+          : "text-amber-400";
+  return (
+    <div>
+      <dt className="text-[10px] uppercase tracking-wide text-muted-foreground/80">
+        {label}
+      </dt>
+      <dd
+        className={cn(
+          "font-[family-name:var(--font-mono)] text-sm font-medium",
+          color,
+        )}
+      >
+        {value}
+      </dd>
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/regression-violations-list.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/regression-violations-list.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowRightCircle } from "lucide-react";
+
+import {
+  REGRESSION_BLOCKING_RULES,
+  regressionRuleLabel,
+} from "@/lib/api/release-gates";
+import type {
+  ReleaseGateRegressionViolation,
+  RegressionSeverity,
+} from "@/lib/api/types";
+import { Badge } from "@/components/ui/badge";
+
+const severityVariant: Record<
+  RegressionSeverity,
+  "default" | "outline" | "destructive"
+> = {
+  info: "outline",
+  warning: "default",
+  blocking: "destructive",
+};
+
+function severityBadge(severity: string) {
+  const variant =
+    severity === "blocking" || severity === "warning" || severity === "info"
+      ? severityVariant[severity as RegressionSeverity]
+      : "outline";
+  return <Badge variant={variant}>{severity}</Badge>;
+}
+
+interface RegressionViolationsListProps {
+  workspaceId: string;
+  candidateRunId?: string;
+  candidateRunAgentId?: string;
+  violations: ReleaseGateRegressionViolation[];
+}
+
+export function RegressionViolationsList({
+  workspaceId,
+  candidateRunId,
+  candidateRunAgentId,
+  violations,
+}: RegressionViolationsListProps) {
+  if (violations.length === 0) return null;
+
+  return (
+    <div className="mt-3 rounded-md border border-red-500/20 bg-red-500/5 p-3">
+      <p className="mb-2 text-xs font-medium uppercase tracking-wide text-red-300/90">
+        Regression violations
+      </p>
+      <ul className="space-y-2">
+        {violations.map((v, idx) => {
+          const isBlocking = REGRESSION_BLOCKING_RULES.has(v.rule);
+          const caseHref = `/workspaces/${workspaceId}/regression-suites/${v.suite_id}/cases/${v.regression_case_id}`;
+          const scorecardHref =
+            candidateRunId && candidateRunAgentId
+              ? `/workspaces/${workspaceId}/runs/${candidateRunId}/agents/${candidateRunAgentId}/scorecard#${v.evidence.scoring_result_id}`
+              : null;
+          return (
+            <li
+              key={`${v.rule}-${v.regression_case_id}-${idx}`}
+              className="flex flex-wrap items-center gap-2 text-xs"
+            >
+              <span className="font-medium text-foreground">
+                {regressionRuleLabel(v.rule)}
+              </span>
+              {severityBadge(v.severity)}
+              {isBlocking && (
+                <Badge variant="destructive">blocking rule</Badge>
+              )}
+              {typeof v.observed_count === "number" && (
+                <span className="text-muted-foreground">
+                  observed {v.observed_count}
+                </span>
+              )}
+              <Link
+                href={caseHref}
+                className="inline-flex items-center gap-1 text-foreground hover:underline underline-offset-4"
+              >
+                Open case
+                <ArrowRightCircle className="size-3" />
+              </Link>
+              {scorecardHref && (
+                <Link
+                  href={scorecardHref}
+                  className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Scoring result
+                  <ArrowRightCircle className="size-3" />
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/release-gates-section.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/release-gates-section.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { EvaluateReleaseGateDialog } from "./evaluate-release-gate-dialog";
 import { CiHint } from "./ci-hint";
+import { RegressionViolationsList } from "./regression-violations-list";
 import { VERDICT_CONFIG, outcomeColor } from "./verdict-config";
 
 function VerdictBadge({ verdict }: { verdict: ReleaseGateVerdict }) {
@@ -36,8 +37,20 @@ function EvidenceBadge({ status }: { status: string }) {
 
 // --- Gate card ---
 
-function GateCard({ gate }: { gate: ReleaseGate; workspaceId: string }) {
+function GateCard({
+  gate,
+  workspaceId,
+  candidateRunId,
+  candidateRunAgentId,
+}: {
+  gate: ReleaseGate;
+  workspaceId: string;
+  candidateRunId: string;
+  candidateRunAgentId?: string;
+}) {
   const [expanded, setExpanded] = useState(false);
+  const regressionViolations =
+    gate.evaluation_details.regression_violations ?? [];
 
   return (
     <div className="rounded-lg border border-border p-4">
@@ -125,6 +138,13 @@ function GateCard({ gate }: { gate: ReleaseGate; workspaceId: string }) {
           )}
         </div>
       )}
+
+      <RegressionViolationsList
+        workspaceId={workspaceId}
+        candidateRunId={candidateRunId}
+        candidateRunAgentId={candidateRunAgentId}
+        violations={regressionViolations}
+      />
     </div>
   );
 }
@@ -135,6 +155,7 @@ interface ReleaseGatesSectionProps {
   workspaceId: string;
   baselineRunId: string;
   candidateRunId: string;
+  candidateRunAgentId?: string;
   gates: ReleaseGate[];
   loading: boolean;
   onEvaluated: () => void;
@@ -144,6 +165,7 @@ export function ReleaseGatesSection({
   workspaceId,
   baselineRunId,
   candidateRunId,
+  candidateRunAgentId,
   gates,
   loading,
   onEvaluated,
@@ -156,6 +178,7 @@ export function ReleaseGatesSection({
           workspaceId={workspaceId}
           baselineRunId={baselineRunId}
           candidateRunId={candidateRunId}
+          candidateRunAgentId={candidateRunAgentId}
           onEvaluated={onEvaluated}
         />
       </div>
@@ -179,6 +202,8 @@ export function ReleaseGatesSection({
               key={gate.id}
               gate={gate}
               workspaceId={workspaceId}
+              candidateRunId={candidateRunId}
+              candidateRunAgentId={candidateRunAgentId}
             />
           ))}
         </div>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/release-gates-section.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/release-gates-section.tsx
@@ -1,13 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
-import { createApiClient } from "@/lib/api/client";
-import type {
-  ReleaseGate,
-  ReleaseGateVerdict,
-  ListReleaseGatesResponse,
-} from "@/lib/api/types";
+import { useState } from "react";
+import type { ReleaseGate, ReleaseGateVerdict } from "@/lib/api/types";
 import { Badge } from "@/components/ui/badge";
 import {
   Loader2,
@@ -42,7 +36,7 @@ function EvidenceBadge({ status }: { status: string }) {
 
 // --- Gate card ---
 
-function GateCard({ gate }: { gate: ReleaseGate }) {
+function GateCard({ gate }: { gate: ReleaseGate; workspaceId: string }) {
   const [expanded, setExpanded] = useState(false);
 
   return (
@@ -138,59 +132,31 @@ function GateCard({ gate }: { gate: ReleaseGate }) {
 // --- Main section ---
 
 interface ReleaseGatesSectionProps {
+  workspaceId: string;
   baselineRunId: string;
   candidateRunId: string;
+  gates: ReleaseGate[];
+  loading: boolean;
+  onEvaluated: () => void;
 }
 
 export function ReleaseGatesSection({
+  workspaceId,
   baselineRunId,
   candidateRunId,
+  gates,
+  loading,
+  onEvaluated,
 }: ReleaseGatesSectionProps) {
-  const { getAccessToken } = useAccessToken();
-  const [gates, setGates] = useState<ReleaseGate[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [refreshCounter, setRefreshCounter] = useState(0);
-
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      setLoading(true);
-      try {
-        const token = await getAccessToken();
-        const api = createApiClient(token);
-        const res = await api.get<ListReleaseGatesResponse>(
-          "/v1/release-gates",
-          {
-            params: {
-              baseline_run_id: baselineRunId,
-              candidate_run_id: candidateRunId,
-            },
-          },
-        );
-        if (!cancelled) setGates(res.release_gates ?? []);
-      } catch {
-        // Gates are supplementary — silently fail
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [getAccessToken, baselineRunId, candidateRunId, refreshCounter]);
-
-  function handleEvaluated() {
-    setRefreshCounter((c) => c + 1);
-  }
-
   return (
     <div>
       <div className="flex items-center justify-between mb-3">
         <h2 className="text-sm font-semibold">Release Gates</h2>
         <EvaluateReleaseGateDialog
+          workspaceId={workspaceId}
           baselineRunId={baselineRunId}
           candidateRunId={candidateRunId}
-          onEvaluated={handleEvaluated}
+          onEvaluated={onEvaluated}
         />
       </div>
 
@@ -209,7 +175,11 @@ export function ReleaseGatesSection({
       ) : (
         <div className="space-y-3">
           {gates.map((gate) => (
-            <GateCard key={gate.id} gate={gate} />
+            <GateCard
+              key={gate.id}
+              gate={gate}
+              workspaceId={workspaceId}
+            />
           ))}
         </div>
       )}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/cases/[caseId]/case-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/cases/[caseId]/case-detail-client.tsx
@@ -1,15 +1,15 @@
 "use client";
 
 import Link from "next/link";
-import { History, PlayCircle } from "lucide-react";
+import { PlayCircle } from "lucide-react";
 
 import type { RegressionCase, RegressionSuite } from "@/lib/api/types";
 import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
-import { EmptyState } from "@/components/ui/empty-state";
 import { PageHeader } from "@/components/ui/page-header";
 
 import { CaseStatusBadge, SeverityBadge } from "../../../badges";
+import { SuiteRunHistory } from "../../suite-run-history";
 import { EditCaseDialog } from "./edit-case-dialog";
 
 interface CaseDetailClientProps {
@@ -204,10 +204,16 @@ export function CaseDetailClient({
       )}
 
       <Section title="Recent Outcomes">
-        <EmptyState
-          icon={<History className="size-10" />}
-          title="No recent outcomes"
-          description="Run-history data will appear here once regression runs execute against this suite."
+        <p className="mb-2 text-xs text-muted-foreground">
+          Runs that executed the parent suite. Per-matched-case outcomes
+          are not exposed by the list-runs read model yet, so use the run
+          link to drill into the scorecard.
+        </p>
+        <SuiteRunHistory
+          workspaceId={workspaceId}
+          suiteId={suite.id}
+          emptyTitle="This case has not executed in the last 20 runs."
+          emptyDescription="Once the parent suite runs in this workspace, the most recent outcomes will appear here."
         />
       </Section>
     </div>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/suite-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/suite-detail-client.tsx
@@ -36,6 +36,7 @@ import {
   SuiteStatusBadge,
 } from "../badges";
 import { EditSuiteDialog } from "./edit-suite-dialog";
+import { SuiteRunHistory } from "./suite-run-history";
 
 type CaseStatusFilter = "all" | RegressionCaseStatus;
 type SeverityFilter = "all" | RegressionSeverity;
@@ -240,11 +241,7 @@ export function SuiteDetailClient({
         </TabsContent>
 
         <TabsContent value="history" className="pt-4">
-          <EmptyState
-            icon={<History className="size-10" />}
-            title="Run history coming soon"
-            description="Once regression runs execute against this suite, the latest outcomes will appear here."
-          />
+          <SuiteRunHistory workspaceId={workspaceId} suiteId={suite.id} />
         </TabsContent>
       </Tabs>
     </div>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/suite-run-history.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/suite-run-history.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { History, Loader2 } from "lucide-react";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+
+import { createApiClient } from "@/lib/api/client";
+import type { Run } from "@/lib/api/types";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+const WORKSPACE_RUN_SCAN_LIMIT = 20;
+
+interface SuiteRunHistoryEntry {
+  run: Run;
+  caseCount: number;
+  passCount: number;
+  failCount: number;
+  warnCount: number;
+}
+
+interface SuiteRunHistoryProps {
+  workspaceId: string;
+  suiteId: string;
+  emptyTitle?: string;
+  emptyDescription?: string;
+}
+
+export function SuiteRunHistory({
+  workspaceId,
+  suiteId,
+  emptyTitle,
+  emptyDescription,
+}: SuiteRunHistoryProps) {
+  const { getAccessToken } = useAccessToken();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+  const [entries, setEntries] = useState<SuiteRunHistoryEntry[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError(undefined);
+      try {
+        const token = await getAccessToken();
+        const api = createApiClient(token);
+        // The list endpoint does not include regression_coverage; fetch
+        // the most recent runs and then hydrate their detail in parallel.
+        // We cap at WORKSPACE_RUN_SCAN_LIMIT to keep the blast radius
+        // bounded.
+        const list = await api.get<{ items: Run[] }>(
+          `/v1/workspaces/${workspaceId}/runs`,
+          { params: { limit: WORKSPACE_RUN_SCAN_LIMIT, offset: 0 } },
+        );
+        const runs = list.items ?? [];
+        const details = await Promise.all(
+          runs.map((run) =>
+            api.get<Run>(`/v1/runs/${run.id}`).catch(() => null),
+          ),
+        );
+        if (cancelled) return;
+        const hydrated: SuiteRunHistoryEntry[] = [];
+        for (const run of details) {
+          if (!run) continue;
+          const coverage = run.regression_coverage;
+          if (!coverage) continue;
+          const suite = coverage.suites.find((s) => s.id === suiteId);
+          if (!suite) continue;
+          hydrated.push({
+            run,
+            caseCount: suite.case_count,
+            passCount: suite.pass_count,
+            failCount: suite.fail_count,
+            warnCount: Math.max(
+              0,
+              suite.case_count - suite.pass_count - suite.fail_count,
+            ),
+          });
+        }
+        hydrated.sort((a, b) => {
+          const aKey = a.run.finished_at ?? a.run.created_at;
+          const bKey = b.run.finished_at ?? b.run.created_at;
+          return bKey.localeCompare(aKey);
+        });
+        setEntries(hydrated);
+      } catch {
+        if (!cancelled) setError("Could not load run history.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [getAccessToken, workspaceId, suiteId]);
+
+  if (loading) {
+    return (
+      <div className="rounded-lg border border-border p-6 text-center">
+        <Loader2 className="size-5 animate-spin mx-auto mb-2 text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">Loading run history...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-md border border-destructive/20 bg-destructive/5 p-4 text-sm text-destructive">
+        {error}
+      </div>
+    );
+  }
+
+  if (entries.length === 0) {
+    return (
+      <EmptyState
+        icon={<History className="size-10" />}
+        title={emptyTitle ?? "No runs have executed this suite yet."}
+        description={
+          emptyDescription ??
+          `Scanned the last ${WORKSPACE_RUN_SCAN_LIMIT} workspace runs. Queue a run that includes this suite to see entries here.`
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-muted-foreground">
+        Showing runs among the last {WORKSPACE_RUN_SCAN_LIMIT} workspace runs
+        that included this suite.
+      </p>
+      <div className="rounded-lg border border-border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Run</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="text-right">Cases</TableHead>
+              <TableHead className="text-right">Pass</TableHead>
+              <TableHead className="text-right">Fail</TableHead>
+              <TableHead className="text-right">Warn</TableHead>
+              <TableHead>Finished</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {entries.map((entry) => (
+              <TableRow key={entry.run.id}>
+                <TableCell>
+                  <Link
+                    href={`/workspaces/${workspaceId}/runs/${entry.run.id}`}
+                    className="font-medium text-foreground hover:underline underline-offset-4"
+                  >
+                    {entry.run.name}
+                  </Link>
+                </TableCell>
+                <TableCell>
+                  <Badge variant="outline">{entry.run.status}</Badge>
+                </TableCell>
+                <TableCell className="text-right font-[family-name:var(--font-mono)] text-sm">
+                  {entry.caseCount}
+                </TableCell>
+                <TableCell className="text-right font-[family-name:var(--font-mono)] text-sm text-emerald-400">
+                  {entry.passCount}
+                </TableCell>
+                <TableCell className="text-right font-[family-name:var(--font-mono)] text-sm text-red-400">
+                  {entry.failCount}
+                </TableCell>
+                <TableCell className="text-right font-[family-name:var(--font-mono)] text-sm text-amber-400">
+                  {entry.warnCount}
+                </TableCell>
+                <TableCell className="text-xs text-muted-foreground">
+                  {entry.run.finished_at
+                    ? new Date(entry.run.finished_at).toLocaleString()
+                    : "—"}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/api/__tests__/release-gates.test.ts
+++ b/web/src/lib/api/__tests__/release-gates.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createApiClient } from "../client";
+import {
+  EMPTY_REGRESSION_GATE_RULES_DRAFT,
+  evaluateReleaseGate,
+  listReleaseGates,
+  normalizeRegressionGateRules,
+  regressionGateRulesToDraft,
+  regressionRuleLabel,
+} from "../release-gates";
+import type {
+  EvaluateReleaseGateResponse,
+  ListReleaseGatesResponse,
+} from "../types";
+
+vi.stubEnv("NEXT_PUBLIC_API_URL", "http://localhost:8080");
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("Release-gate API helpers", () => {
+  it("listReleaseGates hits /v1/release-gates with the correct query params", async () => {
+    const payload: ListReleaseGatesResponse = {
+      baseline_run_id: "b",
+      candidate_run_id: "c",
+      release_gates: [],
+    };
+    mockFetch.mockResolvedValueOnce(jsonResponse(payload));
+
+    const api = createApiClient("token");
+    const result = await listReleaseGates(api, "b", "c");
+
+    expect(result).toEqual(payload);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/v1/release-gates?baseline_run_id=b&candidate_run_id=c",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Bearer token",
+        }),
+      }),
+    );
+  });
+
+  it("evaluateReleaseGate posts the policy and preserves regression_violations in the response", async () => {
+    const payload: EvaluateReleaseGateResponse = {
+      baseline_run_id: "b",
+      candidate_run_id: "c",
+      release_gate: {
+        id: "gate-1",
+        run_comparison_id: "cmp-1",
+        policy_key: "default",
+        policy_version: 1,
+        policy_fingerprint: "fp",
+        policy_snapshot: {
+          policy_key: "default",
+          policy_version: 1,
+        },
+        verdict: "fail",
+        reason_code: "regression_blocking_failure",
+        summary: "blocking regression failure",
+        evidence_status: "sufficient",
+        evaluation_details: {
+          policy_key: "default",
+          policy_version: 1,
+          comparison_status: "comparable",
+          regression_violations: [
+            {
+              rule: "no_blocking_regression_failure",
+              severity: "blocking",
+              regression_case_id: "case-1",
+              suite_id: "suite-1",
+              evidence: {
+                scoring_result_id: "scoring-1",
+                scoring_result_type: "validator_result",
+              },
+            },
+          ],
+        },
+        generated_at: "2026-04-19T00:00:00Z",
+        updated_at: "2026-04-19T00:00:00Z",
+      },
+    };
+    mockFetch.mockResolvedValueOnce(jsonResponse(payload));
+
+    const api = createApiClient("token");
+    const result = await evaluateReleaseGate(api, {
+      baseline_run_id: "b",
+      candidate_run_id: "c",
+      policy: {
+        policy_key: "default",
+        policy_version: 1,
+        regression_gate_rules: {
+          no_blocking_regression_failure: true,
+        },
+      },
+    });
+
+    expect(result.release_gate.evaluation_details.regression_violations).toEqual(
+      [
+        {
+          rule: "no_blocking_regression_failure",
+          severity: "blocking",
+          regression_case_id: "case-1",
+          suite_id: "suite-1",
+          evidence: {
+            scoring_result_id: "scoring-1",
+            scoring_result_type: "validator_result",
+          },
+        },
+      ],
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/v1/release-gates/evaluate",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify({
+          baseline_run_id: "b",
+          candidate_run_id: "c",
+          policy: {
+            policy_key: "default",
+            policy_version: 1,
+            regression_gate_rules: {
+              no_blocking_regression_failure: true,
+            },
+          },
+        }),
+      }),
+    );
+  });
+});
+
+describe("normalizeRegressionGateRules", () => {
+  it("returns undefined for the empty draft so the policy fingerprint stays stable", () => {
+    expect(
+      normalizeRegressionGateRules({ ...EMPTY_REGRESSION_GATE_RULES_DRAFT }),
+    ).toBeUndefined();
+  });
+
+  it("omits zero-value flags and empties while keeping enabled rules", () => {
+    expect(
+      normalizeRegressionGateRules({
+        noBlockingRegressionFailure: true,
+        noNewBlockingFailureVsBaseline: false,
+        maxWarningRegressionFailures: null,
+        suiteIds: [],
+      }),
+    ).toEqual({
+      no_blocking_regression_failure: true,
+    });
+  });
+
+  it("preserves a non-negative warning cap and trims suite ids", () => {
+    expect(
+      normalizeRegressionGateRules({
+        noBlockingRegressionFailure: false,
+        noNewBlockingFailureVsBaseline: true,
+        maxWarningRegressionFailures: 3,
+        suiteIds: [" suite-1 ", "", "suite-2"],
+      }),
+    ).toEqual({
+      no_new_blocking_failure_vs_baseline: true,
+      max_warning_regression_failures: 3,
+      suite_ids: ["suite-1", "suite-2"],
+    });
+  });
+
+  it("drops a negative warning cap as if it were unset", () => {
+    expect(
+      normalizeRegressionGateRules({
+        noBlockingRegressionFailure: false,
+        noNewBlockingFailureVsBaseline: false,
+        maxWarningRegressionFailures: -1,
+        suiteIds: [],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("emits scope-only rules when the user only picks suites", () => {
+    expect(
+      normalizeRegressionGateRules({
+        noBlockingRegressionFailure: false,
+        noNewBlockingFailureVsBaseline: false,
+        maxWarningRegressionFailures: null,
+        suiteIds: ["suite-1"],
+      }),
+    ).toEqual({ suite_ids: ["suite-1"] });
+  });
+
+  it("round-trips through regressionGateRulesToDraft", () => {
+    const draft = regressionGateRulesToDraft({
+      no_blocking_regression_failure: true,
+      max_warning_regression_failures: 5,
+      suite_ids: ["suite-1", "suite-2"],
+    });
+    expect(draft).toEqual({
+      noBlockingRegressionFailure: true,
+      noNewBlockingFailureVsBaseline: false,
+      maxWarningRegressionFailures: 5,
+      suiteIds: ["suite-1", "suite-2"],
+    });
+    expect(normalizeRegressionGateRules(draft)).toEqual({
+      no_blocking_regression_failure: true,
+      max_warning_regression_failures: 5,
+      suite_ids: ["suite-1", "suite-2"],
+    });
+  });
+});
+
+describe("regressionRuleLabel", () => {
+  it("maps backend rule keys to human labels", () => {
+    expect(regressionRuleLabel("no_blocking_regression_failure")).toBe(
+      "Blocking regression failure",
+    );
+    expect(regressionRuleLabel("max_warning_regression_failures")).toBe(
+      "Warning threshold exceeded",
+    );
+  });
+
+  it("falls back to the raw key on unknown rules", () => {
+    expect(regressionRuleLabel("future_rule")).toBe("future_rule");
+  });
+});

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -52,6 +52,18 @@ export type {
   RegressionCase,
   RegressionSeverity,
   RegressionSuite,
+  RegressionGateRules,
+  ReleaseGate,
+  ReleaseGateEvaluationDetails,
+  ReleaseGateEvidenceStatus,
+  ReleaseGatePolicy,
+  ReleaseGateRegressionEvidence,
+  ReleaseGateRegressionViolation,
+  ReleaseGateReplayStepRef,
+  ReleaseGateVerdict,
+  ListReleaseGatesResponse,
+  EvaluateReleaseGateRequest,
+  EvaluateReleaseGateResponse,
 } from "./types";
 export { AGENT_KINDS } from "./types";
 export { listRunFailures, type ListRunFailuresParams } from "./failure-reviews";
@@ -65,3 +77,13 @@ export {
   type PromoteFailureResult,
   type PromotionOverridesInput,
 } from "./regression";
+export {
+  EMPTY_REGRESSION_GATE_RULES_DRAFT,
+  REGRESSION_BLOCKING_RULES,
+  evaluateReleaseGate,
+  listReleaseGates,
+  normalizeRegressionGateRules,
+  regressionGateRulesToDraft,
+  regressionRuleLabel,
+  type RegressionGateRulesDraft,
+} from "./release-gates";

--- a/web/src/lib/api/release-gates.ts
+++ b/web/src/lib/api/release-gates.ts
@@ -1,0 +1,130 @@
+import type { ApiClient } from "./client";
+import type {
+  EvaluateReleaseGateRequest,
+  EvaluateReleaseGateResponse,
+  ListReleaseGatesResponse,
+  RegressionGateRules,
+} from "./types";
+
+/**
+ * GET /v1/release-gates — list the release gates that have been evaluated
+ * against a given baseline/candidate pair.
+ */
+export function listReleaseGates(
+  api: ApiClient,
+  baselineRunId: string,
+  candidateRunId: string,
+  signal?: AbortSignal,
+): Promise<ListReleaseGatesResponse> {
+  return api.get<ListReleaseGatesResponse>("/v1/release-gates", {
+    signal,
+    params: {
+      baseline_run_id: baselineRunId,
+      candidate_run_id: candidateRunId,
+    },
+  });
+}
+
+/** POST /v1/release-gates/evaluate — evaluate a policy against a comparison. */
+export function evaluateReleaseGate(
+  api: ApiClient,
+  request: EvaluateReleaseGateRequest,
+  signal?: AbortSignal,
+): Promise<EvaluateReleaseGateResponse> {
+  return api.post<EvaluateReleaseGateResponse>(
+    "/v1/release-gates/evaluate",
+    request,
+    { signal },
+  );
+}
+
+export interface RegressionGateRulesDraft {
+  noBlockingRegressionFailure: boolean;
+  noNewBlockingFailureVsBaseline: boolean;
+  maxWarningRegressionFailures: number | null;
+  suiteIds: string[];
+}
+
+export const EMPTY_REGRESSION_GATE_RULES_DRAFT: RegressionGateRulesDraft = {
+  noBlockingRegressionFailure: false,
+  noNewBlockingFailureVsBaseline: false,
+  maxWarningRegressionFailures: null,
+  suiteIds: [],
+};
+
+/**
+ * Convert the structured UI form into the wire `RegressionGateRules` shape
+ * sent on a release-gate policy, or `undefined` when the draft represents
+ * the "unset" state. This mirrors backend `normalizeRegressionGateRules`
+ * in releasegate.go: non-negative integer for the cap, trimmed suite ids,
+ * and omission when every field is its zero value so we do not change
+ * the policy fingerprint of legacy policies.
+ */
+export function normalizeRegressionGateRules(
+  draft: RegressionGateRulesDraft,
+): RegressionGateRules | undefined {
+  const suiteIds = (draft.suiteIds ?? [])
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  const cap = draft.maxWarningRegressionFailures;
+  const hasCap = cap != null && Number.isFinite(cap) && cap >= 0;
+
+  const rulesOn =
+    draft.noBlockingRegressionFailure ||
+    draft.noNewBlockingFailureVsBaseline ||
+    hasCap;
+
+  if (!rulesOn && suiteIds.length === 0) {
+    return undefined;
+  }
+
+  const result: RegressionGateRules = {};
+  if (draft.noBlockingRegressionFailure) {
+    result.no_blocking_regression_failure = true;
+  }
+  if (draft.noNewBlockingFailureVsBaseline) {
+    result.no_new_blocking_failure_vs_baseline = true;
+  }
+  if (hasCap) {
+    result.max_warning_regression_failures = Math.trunc(cap);
+  }
+  if (suiteIds.length > 0) {
+    result.suite_ids = suiteIds;
+  }
+  return result;
+}
+
+/** Inverse of `normalizeRegressionGateRules` — used when hydrating the
+ * structured form from a policy JSON the user edited by hand. */
+export function regressionGateRulesToDraft(
+  rules: RegressionGateRules | undefined,
+): RegressionGateRulesDraft {
+  if (!rules) return { ...EMPTY_REGRESSION_GATE_RULES_DRAFT };
+  return {
+    noBlockingRegressionFailure:
+      rules.no_blocking_regression_failure === true,
+    noNewBlockingFailureVsBaseline:
+      rules.no_new_blocking_failure_vs_baseline === true,
+    maxWarningRegressionFailures:
+      typeof rules.max_warning_regression_failures === "number"
+        ? rules.max_warning_regression_failures
+        : null,
+    suiteIds: Array.isArray(rules.suite_ids) ? [...rules.suite_ids] : [],
+  };
+}
+
+export const REGRESSION_RULE_LABELS: Record<string, string> = {
+  no_blocking_regression_failure: "Blocking regression failure",
+  no_new_blocking_failure_vs_baseline: "New blocking failure vs baseline",
+  max_warning_regression_failures: "Warning threshold exceeded",
+};
+
+export function regressionRuleLabel(rule: string): string {
+  return REGRESSION_RULE_LABELS[rule] ?? rule;
+}
+
+export const REGRESSION_BLOCKING_RULES: ReadonlySet<string> = new Set([
+  "no_blocking_regression_failure",
+  "no_new_blocking_failure_vs_baseline",
+]);

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -913,13 +913,23 @@ export interface ReleaseGatePolicy {
   require_evidence_quality?: boolean;
   fail_on_candidate_failure?: boolean;
   fail_on_both_failed_differently?: boolean;
+  require_scorecard_pass?: boolean;
   required_dimensions?: string[];
   dimensions?: Record<string, DimensionThreshold>;
+  regression_gate_rules?: RegressionGateRules;
 }
 
 export interface DimensionThreshold {
   warn_delta?: number;
   fail_delta?: number;
+}
+
+/** Mirrors RegressionGateRules in backend/internal/releasegate/releasegate.go. */
+export interface RegressionGateRules {
+  no_blocking_regression_failure?: boolean;
+  no_new_blocking_failure_vs_baseline?: boolean;
+  max_warning_regression_failures?: number;
+  suite_ids?: string[];
 }
 
 export interface ReleaseGateEvaluationDetails {
@@ -931,6 +941,29 @@ export interface ReleaseGateEvaluationDetails {
   triggered_conditions?: string[];
   required_dimensions?: string[];
   dimension_results?: Record<string, DimensionEvaluation>;
+  regression_violations?: ReleaseGateRegressionViolation[];
+}
+
+/** Mirrors RegressionGateViolation in backend/internal/releasegate/regression_evaluator.go. */
+export interface ReleaseGateRegressionViolation {
+  rule: string; // "no_blocking_regression_failure" | "no_new_blocking_failure_vs_baseline" | "max_warning_regression_failures"
+  severity: string; // "info" | "warning" | "blocking"
+  regression_case_id: string;
+  suite_id: string;
+  observed_count?: number;
+  evidence: ReleaseGateRegressionEvidence;
+}
+
+export interface ReleaseGateRegressionEvidence {
+  scoring_result_id: string;
+  scoring_result_type: string;
+  replay_step_refs?: ReleaseGateReplayStepRef[];
+}
+
+export interface ReleaseGateReplayStepRef {
+  sequence_number: number;
+  event_type?: string;
+  kind?: string;
 }
 
 export interface DimensionEvaluation {


### PR DESCRIPTION
## Summary

Closes [#327](https://github.com/agentclash/agentclash/issues/327) — Regression workflow subissue **I**: frontend compare/gate with regressions. Frontend-only; no backend or OpenAPI changes.

- **Compare view** (`compare/compare-client.tsx`) now renders a **Regression Coverage** table per candidate suite with pass/fail/warn counts, Δ vs baseline, "New failures"/"New"/"Baseline only" badges, a per-suite multi-select filter, and deep links to each suite page. When a release gate has a blocking regression violation, a **New blocking regression** banner lands at the top with a deep link to the offending case.
- **Release-gate editor** (`evaluate-release-gate-dialog.tsx`) gains a structured **Regression rules** section (two toggles, a non-negative numeric cap, and an active-suite multi-select) backed by the new `normalizeRegressionGateRules` helper in `web/src/lib/api/release-gates.ts`. Toggling every rule off and clearing the scope omits `regression_gate_rules` from the submitted policy, preserving existing policy fingerprints. Evaluation results and existing gate cards both render a **Regression violations** sub-panel with deep links to the case detail and — when the comparison exposes `candidate_run_agent_id` — the scoring result anchor on the candidate scorecard.
- **Suite detail Run History** and **case detail Recent Outcomes** replace their placeholders with a shared `SuiteRunHistory` panel that hydrates the last 20 workspace runs (in parallel) and filters to those whose `regression_coverage` included the suite. Case-level outcomes remain best-effort — noted inline — because the list-runs read model does not yet expose per-matched-case status.
- **Types and fetchers**: `ReleaseGateRegressionViolation`, `ReleaseGateRegressionEvidence`, `ReleaseGateReplayStepRef`, and `RegressionGateRules` mirror `docs/api-server/openapi.yaml`; added `listReleaseGates`, `evaluateReleaseGate`, `normalizeRegressionGateRules`, `regressionGateRulesToDraft`, `regressionRuleLabel` with 10 new unit tests in `release-gates.test.ts` (92 api tests pass overall).

Implemented with the `/review-checkpoint` discipline — see `testing/feat-327-frontend-regression-compare-gate.md` for the locked test contract.

## Test plan

- [x] `cd web && pnpm lint` — clean
- [x] `cd web && npx tsc --noEmit` — clean
- [x] `cd web && pnpm test` — 116 passed / 3 skipped / 0 failed
- [x] Manual: create two comparable runs sharing a regression suite, open the compare page, and confirm the Regression Coverage section + banner + gate violations list render as described in the contract's Manual section.
- [x] Manual: toggle every rule off and empty the suite scope in the gate dialog; verify the submitted payload omits `regression_gate_rules` (browser devtools Network tab).
- [x] Manual: open a suite detail page and a case detail page; verify runs that executed the suite appear with pass/fail counts.