### PR TITLE
Add guided build authoring UX for non-expert users

### DIFF
--- a/docs/product/guided-build-authoring-ux.md
+++ b/docs/product/guided-build-authoring-ux.md
@@ -1,0 +1,29 @@
+# Guided Build Authoring UX Notes
+
+## Research Summary
+
+The strongest OSS products converge on the same beginner-first pattern:
+
+- Dify pushes new users toward templates first, not blank DSL. Its docs explicitly recommend creating applications from templates for beginners and only then dropping to blank or DSL import. Source: [Create Application - Dify Docs](https://docs.dify.ai/versions/3-0-x/en/user-guide/application-orchestrate/creating-an-application)
+- Flowise splits the product into progressively more advanced layers. `Assistant` is described as the most beginner-friendly way to create an AI agent, while `Agentflow` is the superset for complex orchestration. Source: [Flowise Introduction](https://docs.flowiseai.com/)
+- n8n’s simplest agent builder asks for a compact form: name, description, system prompt, preferred model, and tool access. More complex workflow agents live separately. Source: [n8n Chat Hub](https://docs.n8n.io/advanced-ai/chat-hub/)
+- Langflow focuses agent setup around a single Agent component with model choice, tool connections, and instructions instead of asking the user to author a JSON bundle directly. Source: [Use Langflow agents](https://docs.langflow.org/agents)
+- LibreChat exposes tools and OpenAPI actions through dedicated forms and menus rather than making users hand-author the whole internal representation. Source: [LibreChat Agents](https://www.librechat.ai/docs/features/agents)
+
+## What This Means For AgentClash
+
+For UI-first users, raw JSON spec editing is an advanced mode, not the primary authoring surface.
+
+The product should therefore:
+
+1. Start with templates and opinionated starters.
+2. Expose the highest-value agent choices in plain language.
+3. Keep raw JSON available as an expert escape hatch.
+4. Preserve the same underlying product layer and API contracts so advanced and beginner users are editing the same artifact.
+
+## UX Chosen In This PR
+
+- `New Version` opens with starter templates instead of immediately creating a blank JSON draft.
+- Build version editing defaults to a guided mode for role, mission, success criteria, input shape, tool strategy, memory style, and output contract.
+- An `Advanced JSON` tab remains available and stays synchronized with the guided surface.
+- The implementation writes back into the existing spec objects instead of introducing a second authoring system.

--- a/testing/codex-guided-build-authoring.md
+++ b/testing/codex-guided-build-authoring.md
@@ -1,0 +1,49 @@
+# codex/guided-build-authoring — Test Contract
+
+## Functional Behavior
+- Creating a new build version should no longer drop users straight into a blank JSON-only draft. The flow should offer starter templates with plain-English descriptions and create the version from the selected template.
+- Editing a draft build version should expose a guided authoring experience for non-expert users while keeping the same underlying product layer and API payloads.
+- The guided experience should let users edit the highest-value agent settings in plain language, at minimum:
+  - agent kind
+  - role / mission / instructions
+  - success criteria
+  - output contract choice
+  - a small set of execution preferences that map back into the existing JSON specs
+- The editor must preserve an advanced JSON mode so experienced users can still inspect and directly edit the raw spec objects.
+- Switching between guided mode and JSON mode must keep user edits in sync rather than forcing users to choose one forever.
+- Existing versions that already contain valid JSON specs should load into the new editor without losing their current data.
+- Validation and mark-ready behavior must keep working against the same backend endpoints.
+
+## Unit Tests
+- `CreateVersionButton` dialog tests:
+  - opening the flow shows template choices before creation
+  - creating from a starter template sends seeded spec JSON instead of only empty defaults
+  - creating from “blank” remains possible
+- `VersionEditor` tests:
+  - guided fields hydrate from an existing version payload
+  - editing guided fields updates the saved PATCH payload correctly
+  - guided output mode changes generate the expected `output_schema`
+  - JSON mode still renders and saves raw spec edits
+  - switching modes preserves edits
+
+## Integration / Functional Tests
+- The builds UI should still create a version, navigate to the version page, save a draft, validate it, and mark it ready without backend changes.
+- The resulting PATCH payload should remain compatible with the current `/v1/agent-build-versions/{id}` API contract.
+
+## Smoke Tests
+- `pnpm vitest run` for the touched build authoring tests passes.
+- `pnpm exec tsc --noEmit` passes for the web app.
+- `pnpm exec eslint` passes for the touched files.
+
+## E2E Tests
+- N/A — not applicable for this change in this session.
+
+## Manual / cURL Tests
+- Manual UI flow:
+  1. Open a workspace build page.
+  2. Click `New Version`.
+  3. Confirm a template picker appears with guided starter options.
+  4. Choose a template and verify the created version lands on the version page with the guided editor visible by default.
+  5. Edit mission/instructions/output choice in guided mode, save, refresh, and confirm the values persist.
+  6. Switch to JSON mode and confirm the underlying spec objects reflect the guided selections.
+  7. Validate and mark the version ready.

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/create-version-button.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/create-version-button.test.tsx
@@ -1,0 +1,228 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CreateVersionButton } from "./create-version-button";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const {
+  mockPush,
+  mockGetAccessToken,
+  mockCreateApiClient,
+  toast,
+} = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockGetAccessToken: vi.fn(),
+  mockCreateApiClient: vi.fn(),
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("@workos-inc/authkit-nextjs/components", () => ({
+  useAccessToken: () => ({ getAccessToken: mockGetAccessToken }),
+}));
+
+vi.mock("sonner", () => ({
+  toast,
+}));
+
+vi.mock("@/lib/api/client", () => ({
+  createApiClient: (...args: unknown[]) => mockCreateApiClient(...args),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
+    React.createElement("button", props, children),
+}));
+
+vi.mock("@/components/ui/dialog", async () => {
+  const React = await import("react");
+  const DialogOpenContext = React.createContext(false);
+  const DialogToggleContext = React.createContext<(open: boolean) => void>(
+    () => {},
+  );
+
+  return {
+    Dialog: ({
+      open,
+      onOpenChange,
+      children,
+    }: {
+      open: boolean;
+      onOpenChange: (open: boolean) => void;
+      children: React.ReactNode;
+    }) =>
+      React.createElement(
+        DialogOpenContext.Provider,
+        { value: open },
+        React.createElement(
+          DialogToggleContext.Provider,
+          { value: onOpenChange },
+          children,
+        ),
+      ),
+    DialogTrigger: ({
+      render,
+      children,
+    }: {
+      render?: React.ReactElement;
+      children?: React.ReactNode;
+    }) => {
+      const setOpen = React.useContext(DialogToggleContext);
+      const element = render ?? React.createElement("button");
+      return React.cloneElement(element, {
+        onClick: () => setOpen(true),
+        ...(children === undefined ? {} : { children }),
+      });
+    },
+    DialogContent: ({ children }: { children: React.ReactNode }) => {
+      const open = React.useContext(DialogOpenContext);
+      return open
+        ? React.createElement("div", { "data-testid": "dialog" }, children)
+        : null;
+    },
+    DialogHeader: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", null, children),
+    DialogTitle: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("h1", null, children),
+    DialogDescription: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("p", null, children),
+  };
+});
+
+vi.mock("lucide-react", () => ({
+  Loader2: () => React.createElement("span", null, "loader"),
+  Plus: () => React.createElement("span", null, "plus"),
+  Sparkles: () => React.createElement("span", null, "sparkles"),
+}));
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function clickElement(element: Element) {
+  element.dispatchEvent(
+    new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+}
+
+function findButton(text: string) {
+  const button = Array.from(document.querySelectorAll("button")).find((candidate) =>
+    candidate.textContent?.includes(text),
+  );
+  if (!button) throw new Error(`Button with text ${text} not found`);
+  return button;
+}
+
+function renderComponent() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+
+  act(() => {
+    root.render(
+      React.createElement(CreateVersionButton, {
+        buildId: "build-1",
+        workspaceId: "ws-1",
+      }),
+    );
+  });
+
+  return {
+    cleanup: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+describe("CreateVersionButton", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    mockPush.mockReset();
+    mockGetAccessToken.mockReset();
+    mockCreateApiClient.mockReset();
+    toast.success.mockReset();
+    toast.error.mockReset();
+  });
+
+  it("shows starter templates before creating a version", async () => {
+    mockGetAccessToken.mockResolvedValue("token");
+    const post = vi.fn().mockResolvedValue({ id: "version-1", version_number: 4 });
+    mockCreateApiClient.mockReturnValue({ post });
+
+    const { cleanup } = renderComponent();
+
+    act(() => {
+      clickElement(findButton("New Version"));
+    });
+
+    expect(document.body.textContent).toContain(
+      "Start With a Guided Version Template",
+    );
+    expect(document.body.textContent).toContain("Research Analyst");
+    expect(document.body.textContent).toContain("Blank Starter");
+
+    act(() => {
+      clickElement(findButton("Research Analyst"));
+    });
+    await flushPromises();
+
+    expect(post).toHaveBeenCalledWith(
+      "/v1/agent-builds/build-1/versions",
+      expect.objectContaining({
+        agent_kind: "llm_agent",
+        workflow_spec: expect.objectContaining({
+          tool_strategy: "prefer_tools_first",
+        }),
+      }),
+    );
+    expect(mockPush).toHaveBeenCalledWith(
+      "/workspaces/ws-1/builds/build-1/versions/version-1",
+    );
+    expect(toast.success).toHaveBeenCalledWith("Created version 4");
+
+    cleanup();
+  });
+
+  it("still supports creating from the blank starter", async () => {
+    mockGetAccessToken.mockResolvedValue("token");
+    const post = vi.fn().mockResolvedValue({ id: "version-2", version_number: 1 });
+    mockCreateApiClient.mockReturnValue({ post });
+
+    const { cleanup } = renderComponent();
+
+    act(() => {
+      clickElement(findButton("New Version"));
+    });
+    act(() => {
+      clickElement(findButton("Blank Starter"));
+    });
+    await flushPromises();
+
+    expect(post).toHaveBeenCalledWith(
+      "/v1/agent-builds/build-1/versions",
+      expect.objectContaining({
+        policy_spec: {},
+        output_schema: {},
+      }),
+    );
+
+    cleanup();
+  });
+});

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/create-version-button.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/create-version-button.tsx
@@ -7,8 +7,18 @@ import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";
 import type { AgentBuildVersion } from "@/lib/api/types";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { toast } from "sonner";
-import { Loader2, Plus } from "lucide-react";
+import { Loader2, Plus, Sparkles } from "lucide-react";
+
+import { guidedTemplates, versionPayloadFromTemplate } from "./versions/[versionId]/guided-authoring";
 
 interface CreateVersionButtonProps {
   buildId: string;
@@ -21,22 +31,20 @@ export function CreateVersionButton({
 }: CreateVersionButtonProps) {
   const router = useRouter();
   const { getAccessToken } = useAccessToken();
-  const [creating, setCreating] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [creatingTemplateID, setCreatingTemplateID] = useState<string | null>(null);
 
-  async function handleCreate() {
-    setCreating(true);
+  async function handleCreate(templateID: string) {
+    setCreatingTemplateID(templateID);
     try {
       const token = await getAccessToken();
       const api = createApiClient(token);
       const version = await api.post<AgentBuildVersion>(
         `/v1/agent-builds/${buildId}/versions`,
-        {
-          agent_kind: "llm_agent",
-          interface_spec: {},
-          policy_spec: { instructions: "" },
-        },
+        versionPayloadFromTemplate(templateID),
       );
       toast.success(`Created version ${version.version_number}`);
+      setOpen(false);
       router.push(
         `/workspaces/${workspaceId}/builds/${buildId}/versions/${version.id}`,
       );
@@ -47,20 +55,61 @@ export function CreateVersionButton({
         toast.error("Failed to create version");
       }
     } finally {
-      setCreating(false);
+      setCreatingTemplateID(null);
     }
   }
 
   return (
-    <Button size="sm" onClick={handleCreate} disabled={creating}>
-      {creating ? (
-        <Loader2 className="size-4 animate-spin" />
-      ) : (
-        <>
-          <Plus data-icon="inline-start" className="size-4" />
-          New Version
-        </>
-      )}
-    </Button>
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger
+        render={
+          <Button size="sm">
+            <Plus data-icon="inline-start" className="size-4" />
+            New Version
+          </Button>
+        }
+      />
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Start With a Guided Version Template</DialogTitle>
+          <DialogDescription>
+            Beginners should not have to invent a full spec sheet from scratch.
+            Pick a starter, land in the guided editor, and drop to JSON only if
+            you need the advanced layer.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-3 md:grid-cols-2">
+          {guidedTemplates.map((template) => {
+            const creating = creatingTemplateID === template.id;
+            const isBlank = template.id === "blank";
+
+            return (
+              <button
+                key={template.id}
+                type="button"
+                onClick={() => handleCreate(template.id)}
+                disabled={creatingTemplateID !== null}
+                className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-4 text-left transition hover:border-white/[0.16] hover:bg-white/[0.04] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-2">
+                    {!isBlank ? <Sparkles className="size-4" /> : null}
+                    <span className="text-sm font-medium">{template.name}</span>
+                  </div>
+                  {creating ? <Loader2 className="size-4 animate-spin" /> : null}
+                </div>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  {template.summary}
+                </p>
+                <p className="mt-3 text-xs uppercase tracking-[0.14em] text-muted-foreground">
+                  {isBlank ? "Start blank" : "Use starter"}
+                </p>
+              </button>
+            );
+          })}
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/guided-authoring.test.ts
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/guided-authoring.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  guidedStateFromVersion,
+  specsFromGuidedState,
+  versionPayloadFromTemplate,
+} from "./guided-authoring";
+
+describe("versionPayloadFromTemplate", () => {
+  it("creates a starter payload for research analyst", () => {
+    const payload = versionPayloadFromTemplate("research_analyst");
+
+    expect(payload.agent_kind).toBe("llm_agent");
+    expect(payload.policy_spec).toMatchObject({
+      role: "You are a meticulous research analyst.",
+    });
+    expect(payload.workflow_spec).toMatchObject({
+      tool_strategy: "prefer_tools_first",
+    });
+    expect(payload.output_schema).toMatchObject({
+      type: "object",
+      required: ["answer", "summary"],
+    });
+  });
+});
+
+describe("guidedStateFromVersion", () => {
+  it("hydrates guided fields from an existing version", () => {
+    const guided = guidedStateFromVersion({
+      agent_kind: "workflow_agent",
+      interface_spec: { primary_input: "support_ticket" },
+      policy_spec: {
+        role: "You are a triage agent.",
+        system_prompt: "Stay calm.",
+        instructions: "Classify the issue.",
+        success_conditions: "Return urgency and next step.",
+      },
+      reasoning_spec: {},
+      memory_spec: { strategy: "session" },
+      workflow_spec: { tool_strategy: "prefer_tools_first" },
+      guardrail_spec: {},
+      model_spec: {},
+      output_schema: {
+        type: "object",
+        properties: {
+          answer: { type: "string" },
+          summary: { type: "string" },
+          citations: { type: "array", items: { type: "string" } },
+        },
+      },
+      trace_contract: {},
+      publication_spec: {},
+    });
+
+    expect(guided).toMatchObject({
+      agentKind: "workflow_agent",
+      primaryInput: "support_ticket",
+      toolStrategy: "prefer_tools_first",
+      memoryMode: "session",
+      outputMode: "answer_summary_citations",
+    });
+  });
+
+  it("treats unknown output schema as custom", () => {
+    const guided = guidedStateFromVersion({
+      agent_kind: "llm_agent",
+      interface_spec: {},
+      policy_spec: { instructions: "Do the thing." },
+      reasoning_spec: {},
+      memory_spec: {},
+      workflow_spec: {},
+      guardrail_spec: {},
+      model_spec: {},
+      output_schema: { type: "object", properties: { verdict: { type: "boolean" } } },
+      trace_contract: {},
+      publication_spec: {},
+    });
+
+    expect(guided.outputMode).toBe("custom");
+  });
+});
+
+describe("specsFromGuidedState", () => {
+  it("preserves unknown keys while writing guided fields", () => {
+    const updated = specsFromGuidedState(
+      {
+        agentKind: "llm_agent",
+        role: "You are a reviewer.",
+        systemPrompt: "Be brief.",
+        instructions: "Inspect the diff.",
+        successConditions: "Return the highest priority issue first.",
+        primaryInput: "pull_request_diff",
+        toolStrategy: "use_when_helpful",
+        memoryMode: "extended",
+        outputMode: "answer_object",
+      },
+      {
+        agent_kind: "workflow_agent",
+        interface_spec: { primary_input: "old_value", untouched: true },
+        policy_spec: { legacy: "keep-me" },
+        reasoning_spec: {},
+        memory_spec: { another_key: "keep-me" },
+        workflow_spec: { untouched: true },
+        guardrail_spec: {},
+        model_spec: {},
+        output_schema: { existing: "keep-me" },
+        trace_contract: {},
+        publication_spec: {},
+      },
+    );
+
+    expect(updated.agent_kind).toBe("llm_agent");
+    expect(updated.interface_spec).toMatchObject({
+      primary_input: "pull_request_diff",
+      untouched: true,
+    });
+    expect(updated.policy_spec).toMatchObject({
+      legacy: "keep-me",
+      role: "You are a reviewer.",
+      instructions: "Inspect the diff.",
+    });
+    expect(updated.memory_spec).toMatchObject({
+      another_key: "keep-me",
+      strategy: "extended",
+    });
+    expect(updated.output_schema).toMatchObject({
+      existing: "keep-me",
+      type: "object",
+      properties: {
+        answer: { type: "string" },
+      },
+    });
+  });
+});

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/guided-authoring.ts
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/guided-authoring.ts
@@ -1,0 +1,360 @@
+import type { AgentBuildVersion, AgentKind } from "@/lib/api/types";
+
+export type OutputMode =
+  | "freeform_text"
+  | "answer_object"
+  | "answer_summary_citations"
+  | "custom";
+
+export type ToolStrategy =
+  | "manual_only"
+  | "use_when_helpful"
+  | "prefer_tools_first";
+
+export type MemoryMode = "none" | "session" | "extended";
+
+export interface GuidedTemplate {
+  id: string;
+  name: string;
+  summary: string;
+  guided: GuidedAuthoringState;
+}
+
+export interface GuidedAuthoringState {
+  agentKind: AgentKind;
+  role: string;
+  systemPrompt: string;
+  instructions: string;
+  successConditions: string;
+  primaryInput: string;
+  toolStrategy: ToolStrategy;
+  memoryMode: MemoryMode;
+  outputMode: OutputMode;
+}
+
+export type EditableSpecs = Pick<
+  AgentBuildVersion,
+  | "agent_kind"
+  | "interface_spec"
+  | "policy_spec"
+  | "reasoning_spec"
+  | "memory_spec"
+  | "workflow_spec"
+  | "guardrail_spec"
+  | "model_spec"
+  | "output_schema"
+  | "trace_contract"
+  | "publication_spec"
+>;
+
+const blankGuidedState: GuidedAuthoringState = {
+  agentKind: "llm_agent",
+  role: "",
+  systemPrompt: "",
+  instructions: "",
+  successConditions: "",
+  primaryInput: "user_request",
+  toolStrategy: "use_when_helpful",
+  memoryMode: "none",
+  outputMode: "freeform_text",
+};
+
+export const guidedTemplates: GuidedTemplate[] = [
+  {
+    id: "blank",
+    name: "Blank Starter",
+    summary: "Start clean, but with guided fields instead of a raw JSON wall.",
+    guided: blankGuidedState,
+  },
+  {
+    id: "general_assistant",
+    name: "General Assistant",
+    summary: "A safe default for broad task execution with tools when they help.",
+    guided: {
+      agentKind: "llm_agent",
+      role: "You are a practical AI teammate for a product team.",
+      systemPrompt:
+        "Favor clear, direct answers. Use tools when they materially improve accuracy.",
+      instructions:
+        "Understand the user's goal, gather what you need, and complete the task with concise explanations and concrete next steps.",
+      successConditions:
+        "The final answer is correct, actionable, and easy for a non-expert to use immediately.",
+      primaryInput: "user_request",
+      toolStrategy: "use_when_helpful",
+      memoryMode: "session",
+      outputMode: "answer_object",
+    },
+  },
+  {
+    id: "research_analyst",
+    name: "Research Analyst",
+    summary: "Good for synthesis, comparison, and evidence-backed recommendations.",
+    guided: {
+      agentKind: "llm_agent",
+      role: "You are a meticulous research analyst.",
+      systemPrompt:
+        "Prioritize evidence, call out uncertainty, and avoid overstating conclusions.",
+      instructions:
+        "Investigate the request, compare competing options, and produce a recommendation backed by traceable evidence.",
+      successConditions:
+        "The final answer includes the recommendation, key supporting evidence, and the main uncertainty or risk to watch.",
+      primaryInput: "research_question",
+      toolStrategy: "prefer_tools_first",
+      memoryMode: "session",
+      outputMode: "answer_summary_citations",
+    },
+  },
+  {
+    id: "support_triage",
+    name: "Support Triage",
+    summary: "Classify urgency, explain the issue, and suggest a next action.",
+    guided: {
+      agentKind: "workflow_agent",
+      role: "You are a support triage agent for incoming customer issues.",
+      systemPrompt:
+        "Stay calm, categorize the issue, and surface the next best action quickly.",
+      instructions:
+        "Read the incoming report, determine urgency, summarize the core problem, and recommend the next operational step.",
+      successConditions:
+        "The result clearly labels urgency, explains why, and suggests an actionable next step.",
+      primaryInput: "support_ticket",
+      toolStrategy: "use_when_helpful",
+      memoryMode: "none",
+      outputMode: "answer_object",
+    },
+  },
+  {
+    id: "structured_extractor",
+    name: "Structured Extractor",
+    summary: "Turn messy text into a dependable structured response payload.",
+    guided: {
+      agentKind: "programmatic_agent",
+      role: "You are a structured extraction agent.",
+      systemPrompt:
+        "Return only what the schema calls for and avoid speculative fields.",
+      instructions:
+        "Read the input carefully and extract the required fields into a structured response.",
+      successConditions:
+        "The response is structured, faithful to the source, and contains no invented values.",
+      primaryInput: "source_document",
+      toolStrategy: "manual_only",
+      memoryMode: "none",
+      outputMode: "answer_object",
+    },
+  },
+];
+
+export function getGuidedTemplate(templateID: string): GuidedTemplate {
+  return (
+    guidedTemplates.find((template) => template.id === templateID) ??
+    guidedTemplates[0]
+  );
+}
+
+export function guidedStateFromVersion(
+  version: EditableSpecs,
+): GuidedAuthoringState {
+  const policySpec = asObject(version.policy_spec);
+  const interfaceSpec = asObject(version.interface_spec);
+  const workflowSpec = asObject(version.workflow_spec);
+  const memorySpec = asObject(version.memory_spec);
+
+  return {
+    agentKind: isAgentKind(version.agent_kind)
+      ? version.agent_kind
+      : blankGuidedState.agentKind,
+    role: readString(policySpec.role),
+    systemPrompt: readString(policySpec.system_prompt),
+    instructions: readString(policySpec.instructions),
+    successConditions: readString(policySpec.success_conditions),
+    primaryInput:
+      readString(interfaceSpec.primary_input) || blankGuidedState.primaryInput,
+    toolStrategy: parseToolStrategy(workflowSpec.tool_strategy),
+    memoryMode: parseMemoryMode(memorySpec.strategy),
+    outputMode: inferOutputMode(version.output_schema),
+  };
+}
+
+export function specsFromGuidedState(
+  guided: GuidedAuthoringState,
+  existing: EditableSpecs,
+): EditableSpecs {
+  const policySpec = writeStringKeys(asObject(existing.policy_spec), {
+    role: guided.role,
+    system_prompt: guided.systemPrompt,
+    instructions: guided.instructions,
+    success_conditions: guided.successConditions,
+  });
+
+  const interfaceSpec = writeStringKeys(asObject(existing.interface_spec), {
+    primary_input: guided.primaryInput,
+  });
+
+  const workflowSpec = writeStringKeys(asObject(existing.workflow_spec), {
+    tool_strategy: guided.toolStrategy,
+  });
+
+  const memorySpec = writeStringKeys(asObject(existing.memory_spec), {
+    strategy: guided.memoryMode,
+  });
+
+  return {
+    ...existing,
+    agent_kind: guided.agentKind,
+    policy_spec: policySpec,
+    interface_spec: interfaceSpec,
+    workflow_spec: workflowSpec,
+    memory_spec: memorySpec,
+    output_schema: outputSchemaForMode(
+      guided.outputMode,
+      asObject(existing.output_schema),
+    ),
+  };
+}
+
+export function versionPayloadFromTemplate(templateID: string): EditableSpecs {
+  const template = getGuidedTemplate(templateID);
+  return specsFromGuidedState(template.guided, {
+    agent_kind: template.guided.agentKind,
+    interface_spec: {},
+    policy_spec: {},
+    reasoning_spec: {},
+    memory_spec: {},
+    workflow_spec: {},
+    guardrail_spec: {},
+    model_spec: {},
+    output_schema: {},
+    trace_contract: {},
+    publication_spec: {},
+  });
+}
+
+function outputSchemaForMode(
+  mode: OutputMode,
+  existing: Record<string, unknown>,
+): Record<string, unknown> {
+  switch (mode) {
+    case "freeform_text":
+      return {};
+    case "answer_object":
+      return {
+        ...existing,
+        type: "object",
+        properties: {
+          answer: { type: "string" },
+        },
+        required: ["answer"],
+      };
+    case "answer_summary_citations":
+      return {
+        ...existing,
+        type: "object",
+        properties: {
+          answer: { type: "string" },
+          summary: { type: "string" },
+          citations: {
+            type: "array",
+            items: { type: "string" },
+          },
+        },
+        required: ["answer", "summary"],
+      };
+    case "custom":
+      return existing;
+    default:
+      return existing;
+  }
+}
+
+function inferOutputMode(outputSchema: unknown): OutputMode {
+  const schema = asObject(outputSchema);
+  if (Object.keys(schema).length === 0) {
+    return "freeform_text";
+  }
+
+  const properties = asObject(schema.properties);
+  if (
+    schema.type === "object" &&
+    isStringSchema(properties.answer) &&
+    Object.keys(properties).length === 1
+  ) {
+    return "answer_object";
+  }
+
+  if (
+    schema.type === "object" &&
+    isStringSchema(properties.answer) &&
+    isStringSchema(properties.summary) &&
+    isStringArraySchema(properties.citations)
+  ) {
+    return "answer_summary_citations";
+  }
+
+  return "custom";
+}
+
+function isStringSchema(value: unknown): boolean {
+  const schema = asObject(value);
+  return schema.type === "string";
+}
+
+function isStringArraySchema(value: unknown): boolean {
+  const schema = asObject(value);
+  const items = asObject(schema.items);
+  return schema.type === "array" && items.type === "string";
+}
+
+function asObject(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return { ...(value as Record<string, unknown>) };
+}
+
+function writeStringKeys(
+  base: Record<string, unknown>,
+  values: Record<string, string>,
+): Record<string, unknown> {
+  const next = { ...base };
+  for (const [key, value] of Object.entries(values)) {
+    const trimmed = value.trim();
+    if (trimmed) {
+      next[key] = trimmed;
+    } else {
+      delete next[key];
+    }
+  }
+  return next;
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function parseToolStrategy(value: unknown): ToolStrategy {
+  if (
+    value === "manual_only" ||
+    value === "use_when_helpful" ||
+    value === "prefer_tools_first"
+  ) {
+    return value;
+  }
+  return blankGuidedState.toolStrategy;
+}
+
+function parseMemoryMode(value: unknown): MemoryMode {
+  if (value === "none" || value === "session" || value === "extended") {
+    return value;
+  }
+  return blankGuidedState.memoryMode;
+}
+
+function isAgentKind(value: string): value is AgentKind {
+  return (
+    value === "llm_agent" ||
+    value === "workflow_agent" ||
+    value === "programmatic_agent" ||
+    value === "multi_agent_system" ||
+    value === "hosted_external"
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/version-editor.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/version-editor.test.tsx
@@ -1,0 +1,339 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { VersionEditor } from "./version-editor";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const {
+  mockRefresh,
+  mockGetAccessToken,
+  mockCreateApiClient,
+  toast,
+} = vi.hoisted(() => ({
+  mockRefresh: vi.fn(),
+  mockGetAccessToken: vi.fn(),
+  mockCreateApiClient: vi.fn(),
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mockRefresh }),
+}));
+
+vi.mock("@workos-inc/authkit-nextjs/components", () => ({
+  useAccessToken: () => ({ getAccessToken: mockGetAccessToken }),
+}));
+
+vi.mock("sonner", () => ({
+  toast,
+}));
+
+vi.mock("@/lib/api/client", () => ({
+  createApiClient: (...args: unknown[]) => mockCreateApiClient(...args),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
+    React.createElement("button", props, children),
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children: React.ReactNode }) =>
+    React.createElement("span", null, children),
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) =>
+    React.createElement("input", props),
+}));
+
+vi.mock("@/components/ui/json-field", () => ({
+  JsonField: ({
+    label,
+    value,
+    onChange,
+  }: {
+    label: string;
+    value: string;
+    onChange: (value: string) => void;
+  }) =>
+    React.createElement("textarea", {
+      "data-json-label": label,
+      value,
+      onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) =>
+        onChange(event.target.value),
+    }),
+}));
+
+vi.mock("@/components/ui/tabs", async () => {
+  const React = await import("react");
+  const TabsValueContext = React.createContext("guided");
+  const TabsChangeContext = React.createContext<(value: string) => void>(() => {});
+
+  return {
+    Tabs: ({
+      value,
+      onValueChange,
+      children,
+    }: {
+      value: string;
+      onValueChange: (value: string) => void;
+      children: React.ReactNode;
+    }) =>
+      React.createElement(
+        TabsValueContext.Provider,
+        { value },
+        React.createElement(
+          TabsChangeContext.Provider,
+          { value: onValueChange },
+          children,
+        ),
+      ),
+    TabsList: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", null, children),
+    TabsTrigger: ({
+      value,
+      children,
+    }: {
+      value: string;
+      children: React.ReactNode;
+    }) => {
+      const setValue = React.useContext(TabsChangeContext);
+      return React.createElement(
+        "button",
+        { onClick: () => setValue(value) },
+        children,
+      );
+    },
+    TabsContent: ({
+      value,
+      children,
+    }: {
+      value: string;
+      children: React.ReactNode;
+    }) => {
+      const active = React.useContext(TabsValueContext);
+      return active === value ? React.createElement("div", null, children) : null;
+    },
+  };
+});
+
+vi.mock("lucide-react", () => ({
+  CheckCircle: () => React.createElement("span", null, "ready"),
+  Loader2: () => React.createElement("span", null, "loader"),
+  Save: () => React.createElement("span", null, "save"),
+  ShieldCheck: () => React.createElement("span", null, "validate"),
+  Sparkles: () => React.createElement("span", null, "sparkles"),
+}));
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function clickElement(element: Element) {
+  element.dispatchEvent(
+    new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+}
+
+function changeInput(
+  element: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement,
+  value: string,
+) {
+  const prototype = Object.getPrototypeOf(element) as {
+    value?: PropertyDescriptor;
+  };
+  const descriptor =
+    Object.getOwnPropertyDescriptor(prototype, "value") ??
+    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value") ??
+    Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value") ??
+    Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, "value");
+  descriptor?.set?.call(element, value);
+  element.dispatchEvent(new window.Event("input", { bubbles: true, cancelable: true }));
+  element.dispatchEvent(new window.Event("change", { bubbles: true, cancelable: true }));
+}
+
+function findButton(text: string) {
+  const button = Array.from(document.querySelectorAll("button")).find((candidate) =>
+    candidate.textContent?.includes(text),
+  );
+  if (!button) throw new Error(`Button with text ${text} not found`);
+  return button;
+}
+
+function findTextAreaByLabel(label: string) {
+  const labels = Array.from(document.querySelectorAll("label"));
+  const labelNode = labels.find((candidate) =>
+    candidate.textContent?.includes(label),
+  );
+  if (!labelNode) throw new Error(`Label ${label} not found`);
+  const textArea = labelNode.parentElement?.querySelector("textarea");
+  if (!(textArea instanceof HTMLTextAreaElement)) {
+    throw new Error(`Textarea for ${label} not found`);
+  }
+  return textArea;
+}
+
+function findInputByLabel(label: string) {
+  const labels = Array.from(document.querySelectorAll("label"));
+  const labelNode = labels.find((candidate) =>
+    candidate.textContent?.includes(label),
+  );
+  if (!labelNode) throw new Error(`Label ${label} not found`);
+  const input = labelNode.parentElement?.querySelector("input");
+  if (!(input instanceof HTMLInputElement)) {
+    throw new Error(`Input for ${label} not found`);
+  }
+  return input;
+}
+
+function findJsonField(label: string) {
+  const field = Array.from(
+    document.querySelectorAll("textarea[data-json-label]"),
+  ).find((candidate) => candidate.getAttribute("data-json-label")?.includes(label));
+  if (!(field instanceof HTMLTextAreaElement)) {
+    throw new Error(`JSON field ${label} not found`);
+  }
+  return field;
+}
+
+function renderEditor() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+
+  act(() => {
+    root.render(
+      React.createElement(VersionEditor, {
+        version: {
+          id: "version-1",
+          agent_build_id: "build-1",
+          version_number: 2,
+          version_status: "draft",
+          agent_kind: "workflow_agent",
+          interface_spec: { primary_input: "support_ticket" },
+          policy_spec: {
+            role: "You are a triage assistant.",
+            instructions: "Classify the issue and recommend the next step.",
+            success_conditions: "Return urgency and owner.",
+          },
+          reasoning_spec: {},
+          memory_spec: { strategy: "session" },
+          workflow_spec: { tool_strategy: "prefer_tools_first" },
+          guardrail_spec: {},
+          model_spec: {},
+          output_schema: {
+            type: "object",
+            properties: {
+              answer: { type: "string" },
+            },
+            required: ["answer"],
+          },
+          trace_contract: {},
+          publication_spec: {},
+          tools: [],
+          knowledge_sources: [],
+          created_at: "2026-04-20T00:00:00Z",
+        },
+      }),
+    );
+  });
+
+  return {
+    cleanup: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+describe("VersionEditor", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    mockRefresh.mockReset();
+    mockGetAccessToken.mockReset();
+    mockCreateApiClient.mockReset();
+    toast.success.mockReset();
+    toast.error.mockReset();
+  });
+
+  it("hydrates guided fields and saves guided edits through the existing patch API", async () => {
+    mockGetAccessToken.mockResolvedValue("token");
+    const patch = vi.fn().mockResolvedValue(undefined);
+    const post = vi.fn().mockResolvedValue({ valid: true, errors: [] });
+    mockCreateApiClient.mockReturnValue({ patch, post });
+
+    const { cleanup } = renderEditor();
+
+    expect(findTextAreaByLabel("Role").value).toContain("triage assistant");
+    expect(findInputByLabel("Primary Input Field").value).toBe("support_ticket");
+
+    act(() => {
+      changeTextArea(
+        findTextAreaByLabel("Mission / Instructions"),
+        "Investigate the report and assign severity.",
+      );
+    });
+    act(() => {
+      changeInput(findInputByLabel("Primary Input Field"), "incident_report");
+    });
+    await flushPromises();
+    act(() => {
+      clickElement(findButton("Save Draft"));
+    });
+    await flushPromises();
+
+    expect(patch).toHaveBeenCalledWith(
+      "/v1/agent-build-versions/version-1",
+      expect.objectContaining({
+        agent_kind: "workflow_agent",
+        policy_spec: expect.objectContaining({
+          instructions: "Investigate the report and assign severity.",
+        }),
+        interface_spec: expect.objectContaining({
+          primary_input: "incident_report",
+        }),
+      }),
+    );
+    expect(toast.success).toHaveBeenCalledWith("Saved");
+
+    cleanup();
+  });
+
+  it("keeps guided edits visible in advanced JSON mode", () => {
+    const { cleanup } = renderEditor();
+
+    act(() => {
+      changeTextArea(
+        findTextAreaByLabel("Mission / Instructions"),
+        "Summarize the issue and route it to the right team.",
+      );
+    });
+    act(() => {
+      clickElement(findButton("Advanced JSON"));
+    });
+
+    expect(findJsonField("Policy Spec").value).toContain(
+      "Summarize the issue and route it to the right team.",
+    );
+
+    cleanup();
+  });
+});
+
+function changeTextArea(element: HTMLTextAreaElement, value: string) {
+  changeInput(element, value);
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/version-editor.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/version-editor.tsx
@@ -1,24 +1,107 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";
 import type {
   AgentBuildVersion,
+  AgentKind,
   ValidationResult,
 } from "@/lib/api/types";
 import { AGENT_KINDS } from "@/lib/api/types";
-import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { JsonField } from "@/components/ui/json-field";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { toast } from "sonner";
-import { Loader2, Save, ShieldCheck, CheckCircle } from "lucide-react";
+import {
+  CheckCircle,
+  Loader2,
+  Save,
+  ShieldCheck,
+  Sparkles,
+} from "lucide-react";
+
+import {
+  type EditableSpecs,
+  type GuidedAuthoringState,
+  guidedStateFromVersion,
+  guidedTemplates,
+  specsFromGuidedState,
+  versionPayloadFromTemplate,
+} from "./guided-authoring";
 
 interface VersionEditorProps {
   version: AgentBuildVersion;
 }
+
+const specFields = [
+  {
+    key: "policy_spec",
+    label: "Policy Spec",
+    description: 'Must contain an "instructions" field.',
+    required: true as const,
+  },
+  {
+    key: "interface_spec",
+    label: "Interface Spec",
+    description: "How the agent expects the primary task input to be shaped.",
+    required: true as const,
+  },
+  {
+    key: "model_spec",
+    label: "Model Spec",
+    description: "Optional model-time hints that stay with the build version.",
+    required: false as const,
+  },
+  {
+    key: "reasoning_spec",
+    label: "Reasoning Spec",
+    description: "Optional reasoning preferences for advanced runs.",
+    required: false as const,
+  },
+  {
+    key: "memory_spec",
+    label: "Memory Spec",
+    description: "How much context the agent should try to carry forward.",
+    required: false as const,
+  },
+  {
+    key: "workflow_spec",
+    label: "Workflow Spec",
+    description: "Execution preferences such as tool strategy or orchestration hints.",
+    required: false as const,
+  },
+  {
+    key: "guardrail_spec",
+    label: "Guardrail Spec",
+    description: "Optional safety and escalation rules.",
+    required: false as const,
+  },
+  {
+    key: "output_schema",
+    label: "Output Schema",
+    description: "The final answer contract shown to the agent at run time.",
+    required: false as const,
+  },
+  {
+    key: "trace_contract",
+    label: "Trace Contract",
+    description: "Optional run telemetry contract.",
+    required: false as const,
+  },
+  {
+    key: "publication_spec",
+    label: "Publication Spec",
+    description: "Optional publishing or surfacing metadata.",
+    required: false as const,
+  },
+] as const;
+
+type SpecKey = (typeof specFields)[number]["key"];
 
 function jsonStr(val: unknown): string {
   if (val === null || val === undefined) return "";
@@ -26,72 +109,237 @@ function jsonStr(val: unknown): string {
   return JSON.stringify(val, null, 2);
 }
 
-const specFields = [
-  { key: "policy_spec", label: "Policy Spec", description: "Must contain an \"instructions\" field.", required: true as const },
-  { key: "interface_spec", label: "Interface Spec", description: undefined, required: true as const },
-  { key: "model_spec", label: "Model Spec", description: undefined, required: false as const },
-  { key: "reasoning_spec", label: "Reasoning Spec", description: undefined, required: false as const },
-  { key: "memory_spec", label: "Memory Spec", description: undefined, required: false as const },
-  { key: "workflow_spec", label: "Workflow Spec", description: undefined, required: false as const },
-  { key: "guardrail_spec", label: "Guardrail Spec", description: undefined, required: false as const },
-  { key: "output_schema", label: "Output Schema", description: undefined, required: false as const },
-  { key: "trace_contract", label: "Trace Contract", description: undefined, required: false as const },
-  { key: "publication_spec", label: "Publication Spec", description: undefined, required: false as const },
-] as const;
+function safeParseSpec(raw: string): unknown {
+  const trimmed = raw.trim();
+  if (!trimmed) return {};
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return {};
+  }
+}
 
-type SpecKey = (typeof specFields)[number]["key"];
+function versionToEditableSpecs(version: AgentBuildVersion): EditableSpecs {
+  return {
+    agent_kind: version.agent_kind,
+    interface_spec: version.interface_spec,
+    policy_spec: version.policy_spec,
+    reasoning_spec: version.reasoning_spec,
+    memory_spec: version.memory_spec,
+    workflow_spec: version.workflow_spec,
+    guardrail_spec: version.guardrail_spec,
+    model_spec: version.model_spec,
+    output_schema: version.output_schema,
+    trace_contract: version.trace_contract,
+    publication_spec: version.publication_spec,
+  };
+}
 
-export function VersionEditor({
-  version,
-}: VersionEditorProps) {
+function specsFromStrings(
+  agentKind: AgentKind,
+  specs: Record<SpecKey, string>,
+): EditableSpecs {
+  return {
+    agent_kind: agentKind,
+    interface_spec: safeParseSpec(specs.interface_spec),
+    policy_spec: safeParseSpec(specs.policy_spec),
+    reasoning_spec: safeParseSpec(specs.reasoning_spec),
+    memory_spec: safeParseSpec(specs.memory_spec),
+    workflow_spec: safeParseSpec(specs.workflow_spec),
+    guardrail_spec: safeParseSpec(specs.guardrail_spec),
+    model_spec: safeParseSpec(specs.model_spec),
+    output_schema: safeParseSpec(specs.output_schema),
+    trace_contract: safeParseSpec(specs.trace_contract),
+    publication_spec: safeParseSpec(specs.publication_spec),
+  };
+}
+
+function guidedFieldTextAreaClassName(error?: string): string {
+  return [
+    "block w-full rounded-lg border bg-transparent px-3 py-2 text-sm leading-relaxed placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50 resize-y disabled:opacity-50 disabled:cursor-not-allowed",
+    error
+      ? "border-destructive focus:border-destructive focus:ring-destructive/50"
+      : "border-input focus:border-ring",
+  ].join(" ");
+}
+
+interface GuidedTextAreaProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  description: string;
+  disabled?: boolean;
+  rows?: number;
+  error?: string;
+}
+
+function GuidedTextArea({
+  label,
+  value,
+  onChange,
+  description,
+  disabled,
+  rows = 4,
+  error,
+}: GuidedTextAreaProps) {
+  return (
+    <div className="space-y-1.5">
+      <label className="block text-sm font-medium">{label}</label>
+      <p className="text-xs text-muted-foreground">{description}</p>
+      <textarea
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        disabled={disabled}
+        rows={rows}
+        className={guidedFieldTextAreaClassName(error)}
+      />
+      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+    </div>
+  );
+}
+
+interface GuidedSelectProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  description: string;
+  disabled?: boolean;
+  options: Array<{ value: string; label: string }>;
+}
+
+function GuidedSelect({
+  label,
+  value,
+  onChange,
+  description,
+  disabled,
+  options,
+}: GuidedSelectProps) {
+  return (
+    <div className="space-y-1.5">
+      <label className="block text-sm font-medium">{label}</label>
+      <p className="text-xs text-muted-foreground">{description}</p>
+      <select
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        disabled={disabled}
+        className="block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+export function VersionEditor({ version }: VersionEditorProps) {
   const router = useRouter();
   const { getAccessToken } = useAccessToken();
 
   const isLocked = version.version_status === "ready";
+  const originalSpecs = useMemo(() => versionToEditableSpecs(version), [version]);
 
-  const [agentKind, setAgentKind] = useState(version.agent_kind);
+  const [agentKind, setAgentKind] = useState<AgentKind>(
+    AGENT_KINDS.includes(version.agent_kind as AgentKind)
+      ? (version.agent_kind as AgentKind)
+      : "llm_agent",
+  );
   const [specs, setSpecs] = useState<Record<SpecKey, string>>(() => {
     const initial: Record<string, string> = {};
-    for (const f of specFields) {
-      initial[f.key] = jsonStr(
-        version[f.key as keyof AgentBuildVersion],
-      );
+    for (const field of specFields) {
+      initial[field.key] = jsonStr(version[field.key as keyof AgentBuildVersion]);
     }
     return initial as Record<SpecKey, string>;
   });
+  const [guided, setGuided] = useState<GuidedAuthoringState>(() =>
+    guidedStateFromVersion(originalSpecs),
+  );
+  const [activeTab, setActiveTab] = useState<"guided" | "json">("guided");
 
   const [saving, setSaving] = useState(false);
   const [validating, setValidating] = useState(false);
   const [markingReady, setMarkingReady] = useState(false);
-  const [validationErrors, setValidationErrors] = useState<
-    Record<string, string>
-  >({});
+  const [validationErrors, setValidationErrors] = useState<Record<string, string>>(
+    {},
+  );
+
+  function syncSpecsFromEditable(next: EditableSpecs) {
+    setAgentKind(
+      AGENT_KINDS.includes(next.agent_kind as AgentKind)
+        ? (next.agent_kind as AgentKind)
+        : "llm_agent",
+    );
+    setSpecs({
+      policy_spec: jsonStr(next.policy_spec),
+      interface_spec: jsonStr(next.interface_spec),
+      model_spec: jsonStr(next.model_spec),
+      reasoning_spec: jsonStr(next.reasoning_spec),
+      memory_spec: jsonStr(next.memory_spec),
+      workflow_spec: jsonStr(next.workflow_spec),
+      guardrail_spec: jsonStr(next.guardrail_spec),
+      output_schema: jsonStr(next.output_schema),
+      trace_contract: jsonStr(next.trace_contract),
+      publication_spec: jsonStr(next.publication_spec),
+    });
+    setGuided(guidedStateFromVersion(next));
+  }
+
+  function clearValidationError(field: string) {
+    if (!validationErrors[field]) return;
+    setValidationErrors((prev) => {
+      const next = { ...prev };
+      delete next[field];
+      return next;
+    });
+  }
 
   function updateSpec(key: SpecKey, value: string) {
     setSpecs((prev) => ({ ...prev, [key]: value }));
-    // Clear validation error for this field when edited
-    if (validationErrors[key]) {
-      setValidationErrors((prev) => {
-        const next = { ...prev };
-        delete next[key];
-        return next;
-      });
-    }
+    clearValidationError(key);
+  }
+
+  function updateGuided(
+    updates: Partial<GuidedAuthoringState>,
+    nextAgentKind?: AgentKind,
+  ) {
+    const merged: GuidedAuthoringState = {
+      ...guided,
+      ...updates,
+      agentKind: nextAgentKind ?? guided.agentKind,
+    };
+    const base = specsFromStrings(nextAgentKind ?? agentKind, specs);
+    const nextSpecs = specsFromGuidedState(merged, {
+      ...originalSpecs,
+      ...base,
+    });
+    syncSpecsFromEditable(nextSpecs);
+    clearValidationError("policy_spec");
+    clearValidationError("interface_spec");
+  }
+
+  function applyTemplate(templateID: string) {
+    const templateSpecs = versionPayloadFromTemplate(templateID);
+    syncSpecsFromEditable(templateSpecs);
+    toast.success("Applied guided starter");
   }
 
   function buildRequestBody() {
     const body: Record<string, unknown> = { agent_kind: agentKind };
-    for (const f of specFields) {
-      const raw = specs[f.key].trim();
+    for (const field of specFields) {
+      const raw = specs[field.key].trim();
       if (raw) {
         try {
-          body[f.key] = JSON.parse(raw);
+          body[field.key] = JSON.parse(raw);
         } catch {
-          toast.error(`Invalid JSON in ${f.label}`);
+          toast.error(`Invalid JSON in ${field.label}`);
+          setActiveTab("json");
           return null;
         }
-      } else if (f.required) {
-        body[f.key] = {};
+      } else if (field.required) {
+        body[field.key] = {};
       }
     }
     return body;
@@ -128,8 +376,8 @@ export function VersionEditor({
         toast.success("Validation passed");
       } else {
         const errorMap: Record<string, string> = {};
-        for (const e of result.errors) {
-          errorMap[e.field] = e.message;
+        for (const error of result.errors) {
+          errorMap[error.field] = error.message;
         }
         setValidationErrors(errorMap);
         toast.error(`${result.errors.length} validation error(s)`);
@@ -154,7 +402,7 @@ export function VersionEditor({
     } catch (err) {
       if (err instanceof ApiError && err.code === "validation_failed") {
         toast.error("Cannot mark ready — fix validation errors first");
-        handleValidate();
+        void handleValidate();
       } else {
         toast.error(
           err instanceof ApiError ? err.message : "Failed to mark ready",
@@ -165,14 +413,16 @@ export function VersionEditor({
     }
   }
 
+  const outputModeHelp =
+    guided.outputMode === "custom"
+      ? "This version already uses a custom output schema. Switch to JSON to fine-tune it, or pick a guided preset below to replace it."
+      : "Pick the shape of the final answer contract without hand-authoring JSON.";
+
   return (
-    <div className="max-w-3xl">
-      {/* Header */}
-      <div className="flex items-center justify-between mb-6">
+    <div className="max-w-4xl space-y-6">
+      <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <h2 className="text-sm font-semibold">
-            Version {version.version_number}
-          </h2>
+          <h2 className="text-sm font-semibold">Version {version.version_number}</h2>
           <Badge
             variant={
               version.version_status === "ready"
@@ -185,7 +435,7 @@ export function VersionEditor({
             {version.version_status}
           </Badge>
         </div>
-        {!isLocked && (
+        {!isLocked ? (
           <div className="flex items-center gap-2">
             <Button
               variant="outline"
@@ -228,53 +478,290 @@ export function VersionEditor({
               )}
             </Button>
           </div>
-        )}
+        ) : null}
       </div>
 
-      {isLocked && (
-        <div className="mb-6 rounded-lg border border-white/[0.06] bg-white/[0.02] p-3 text-sm text-muted-foreground">
+      {isLocked ? (
+        <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-3 text-sm text-muted-foreground">
           This version is locked. Fields cannot be edited after marking as ready.
         </div>
-      )}
+      ) : null}
 
-      {/* Agent Kind */}
-      <div className="mb-6">
-        <label className="mb-1.5 block text-sm font-medium">Agent Kind</label>
-        <select
-          value={agentKind}
-          onChange={(e) => setAgentKind(e.target.value)}
-          disabled={isLocked}
-          className="block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:opacity-50 disabled:cursor-not-allowed"
+      <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-5">
+        <div className="mb-4 flex items-start justify-between gap-4">
+          <div>
+            <p className="text-sm font-semibold">Authoring Mode</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Guided mode is the beginner-first surface. JSON mode stays available
+              as the advanced escape hatch and both stay in sync.
+            </p>
+          </div>
+          <div className="rounded-full border border-white/[0.08] bg-white/[0.03] px-3 py-1 text-xs text-muted-foreground">
+            Same API payloads, less manual JSON
+          </div>
+        </div>
+
+        <Tabs
+          value={activeTab}
+          onValueChange={(value) => setActiveTab(value as "guided" | "json")}
+          className="gap-4"
         >
-          {AGENT_KINDS.map((kind) => (
-            <option key={kind} value={kind}>
-              {kind}
-            </option>
-          ))}
-        </select>
-        {validationErrors.agent_kind && (
-          <p className="mt-1 text-xs text-destructive">
-            {validationErrors.agent_kind}
-          </p>
-        )}
-      </div>
+          <TabsList variant="default">
+            <TabsTrigger value="guided">
+              <Sparkles className="size-4" />
+              Guided
+            </TabsTrigger>
+            <TabsTrigger value="json">Advanced JSON</TabsTrigger>
+          </TabsList>
 
-      {/* Spec fields */}
-      <div className="space-y-5">
-        {specFields.map((f) => (
-          <JsonField
-            key={f.key}
-            label={
-              f.label +
-              (f.required ? "" : " (optional)")
-            }
-            description={f.description}
-            value={specs[f.key]}
-            onChange={(v) => updateSpec(f.key, v)}
-            error={validationErrors[f.key]}
-            disabled={isLocked}
-          />
-        ))}
+          <TabsContent value="guided" className="space-y-6">
+            <div className="rounded-xl border border-white/[0.06] bg-black/[0.12] p-4">
+              <div className="mb-3">
+                <p className="text-sm font-semibold">Starter Templates</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Borrow the strongest beginner pattern from tools like Dify and
+                  Flowise: start from a template, then tune it in plain language.
+                </p>
+              </div>
+              <div className="grid gap-3 md:grid-cols-2">
+                {guidedTemplates.map((template) => (
+                  <button
+                    key={template.id}
+                    type="button"
+                    onClick={() => applyTemplate(template.id)}
+                    disabled={isLocked}
+                    className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-4 text-left transition hover:border-white/[0.16] hover:bg-white/[0.04] disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-sm font-medium">{template.name}</span>
+                      <span className="text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
+                        Apply
+                      </span>
+                    </div>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      {template.summary}
+                    </p>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-1.5">
+                <label className="block text-sm font-medium">Agent Kind</label>
+                <p className="text-xs text-muted-foreground">
+                  Pick the closest execution style, then tune the rest in plain
+                  language below.
+                </p>
+                <select
+                  value={agentKind}
+                  onChange={(event) => {
+                    const next = event.target.value as AgentKind;
+                    updateGuided({ agentKind: next }, next);
+                    clearValidationError("agent_kind");
+                  }}
+                  disabled={isLocked}
+                  className="block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {AGENT_KINDS.map((kind) => (
+                    <option key={kind} value={kind}>
+                      {kind}
+                    </option>
+                  ))}
+                </select>
+                {validationErrors.agent_kind ? (
+                  <p className="text-xs text-destructive">
+                    {validationErrors.agent_kind}
+                  </p>
+                ) : null}
+              </div>
+
+              <div className="space-y-1.5">
+                <label className="block text-sm font-medium">
+                  Primary Input Field
+                </label>
+                <p className="text-xs text-muted-foreground">
+                  Name the main thing this agent receives, like
+                  <code className="mx-1 rounded bg-white/[0.06] px-1.5 py-0.5">
+                    user_request
+                  </code>
+                  or
+                  <code className="mx-1 rounded bg-white/[0.06] px-1.5 py-0.5">
+                    support_ticket
+                  </code>
+                  .
+                </p>
+                <Input
+                  value={guided.primaryInput}
+                  onChange={(event) =>
+                    updateGuided({ primaryInput: event.target.value })
+                  }
+                  disabled={isLocked}
+                />
+                {validationErrors.interface_spec ? (
+                  <p className="text-xs text-destructive">
+                    {validationErrors.interface_spec}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+
+            <GuidedTextArea
+              label="Role"
+              value={guided.role}
+              onChange={(value) => updateGuided({ role: value })}
+              description="Who the agent is and the lens it should bring to the task."
+              disabled={isLocked}
+              rows={3}
+            />
+
+            <GuidedTextArea
+              label="Mission / Instructions"
+              value={guided.instructions}
+              onChange={(value) => updateGuided({ instructions: value })}
+              description="The core job to do. This writes directly into policy_spec.instructions, which the backend already validates."
+              disabled={isLocked}
+              rows={5}
+              error={validationErrors.policy_spec}
+            />
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <GuidedTextArea
+                label="System Prompt Add-On"
+                value={guided.systemPrompt}
+                onChange={(value) => updateGuided({ systemPrompt: value })}
+                description="Extra steering that should always sit around the mission."
+                disabled={isLocked}
+                rows={4}
+              />
+              <GuidedTextArea
+                label="Success Criteria"
+                value={guided.successConditions}
+                onChange={(value) => updateGuided({ successConditions: value })}
+                description="What a great result must include before the agent is done."
+                disabled={isLocked}
+                rows={4}
+              />
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <GuidedSelect
+                label="Tool Strategy"
+                value={guided.toolStrategy}
+                onChange={(value) =>
+                  updateGuided({
+                    toolStrategy: value as GuidedAuthoringState["toolStrategy"],
+                  })
+                }
+                description="Tell the runtime whether this agent should stay manual, use tools opportunistically, or reach for tools first."
+                disabled={isLocked}
+                options={[
+                  { value: "manual_only", label: "Manual only" },
+                  { value: "use_when_helpful", label: "Use tools when helpful" },
+                  { value: "prefer_tools_first", label: "Prefer tools first" },
+                ]}
+              />
+
+              <GuidedSelect
+                label="Memory Style"
+                value={guided.memoryMode}
+                onChange={(value) =>
+                  updateGuided({
+                    memoryMode: value as GuidedAuthoringState["memoryMode"],
+                  })
+                }
+                description="A small hint for how much context the build version expects to keep around."
+                disabled={isLocked}
+                options={[
+                  { value: "none", label: "Fresh every run" },
+                  { value: "session", label: "Remember this session" },
+                  { value: "extended", label: "Keep a longer working memory" },
+                ]}
+              />
+            </div>
+
+            <div className="rounded-xl border border-white/[0.06] bg-black/[0.12] p-4">
+              <div className="mb-3">
+                <p className="text-sm font-semibold">Output Contract</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {outputModeHelp}
+                </p>
+              </div>
+              <div className="grid gap-3 md:grid-cols-3">
+                {[
+                  {
+                    value: "freeform_text",
+                    label: "Freeform Text",
+                    body: "No schema. Best for conversational or exploratory outputs.",
+                  },
+                  {
+                    value: "answer_object",
+                    label: "Structured Answer",
+                    body: "A simple JSON object with a required answer field.",
+                  },
+                  {
+                    value: "answer_summary_citations",
+                    label: "Answer + Evidence",
+                    body: "Adds a summary and citations array for evidence-heavy tasks.",
+                  },
+                ].map((option) => {
+                  const active = guided.outputMode === option.value;
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() =>
+                        updateGuided({
+                          outputMode: option.value as GuidedAuthoringState["outputMode"],
+                        })
+                      }
+                      disabled={isLocked}
+                      className={[
+                        "rounded-xl border p-4 text-left transition disabled:cursor-not-allowed disabled:opacity-50",
+                        active
+                          ? "border-foreground/40 bg-white/[0.06]"
+                          : "border-white/[0.08] bg-white/[0.02] hover:border-white/[0.16] hover:bg-white/[0.04]",
+                      ].join(" ")}
+                    >
+                      <p className="text-sm font-medium">{option.label}</p>
+                      <p className="mt-2 text-sm text-muted-foreground">
+                        {option.body}
+                      </p>
+                    </button>
+                  );
+                })}
+              </div>
+              {guided.outputMode === "custom" ? (
+                <p className="mt-3 text-xs text-amber-300/90">
+                  This draft currently has a custom output schema. Guided presets
+                  will replace it once you choose one.
+                </p>
+              ) : null}
+            </div>
+          </TabsContent>
+
+          <TabsContent value="json" className="space-y-5">
+            <div className="rounded-xl border border-white/[0.06] bg-black/[0.12] p-4 text-sm text-muted-foreground">
+              Advanced mode keeps every raw spec editable for power users, CLI
+              parity, and edge cases. It is still fully supported; it just is not
+              the first thing a new user sees anymore.
+            </div>
+
+            <div className="space-y-5">
+              {specFields.map((field) => (
+                <JsonField
+                  key={field.key}
+                  label={field.label + (field.required ? "" : " (optional)")}
+                  description={field.description}
+                  value={specs[field.key]}
+                  onChange={(value) => updateSpec(field.key, value)}
+                  error={validationErrors[field.key]}
+                  disabled={isLocked}
+                />
+              ))}
+            </div>
+          </TabsContent>
+        </Tabs>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a research note on beginner-friendly OSS agent authoring patterns and apply that direction to AgentClash builds
- replace the immediate blank-version creation path with a template-first starter dialog
- rebuild the build version editor around a guided mode plus synced advanced JSON mode so users can author agent behavior without hand-writing spec blobs first

## Why
The current build version UX drops UI-first users straight into raw JSON fields for `policy_spec`, `workflow_spec`, `output_schema`, and related objects. Strong OSS products like Dify, Flowise, Langflow, n8n, and LibreChat consistently put templates, guided forms, and tool/model selection ahead of raw DSL editing. This PR brings AgentClash closer to that beginner-first pattern while preserving the same underlying product layer and API payloads.

## What changed
- `New Version` now opens a template picker with blank, assistant, research, triage, and extractor starters
- added a guided authoring model that maps plain-language fields back into the existing spec JSON objects without throwing away unknown keys
- version editing now defaults to a guided tab for role, mission, success criteria, input shape, tool strategy, memory style, and output contract
- advanced JSON remains available and synchronized for power users
- added focused tests for template creation, guided mapping, and guided/editor synchronization

## Verification
- `cd web && pnpm vitest run 'src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/create-version-button.test.tsx' 'src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/guided-authoring.test.ts' 'src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/version-editor.test.tsx'`
- `cd web && pnpm exec tsc --noEmit`
- `cd web && pnpm exec eslint 'src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/create-version-button.tsx' 'src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/create-version-button.test.tsx' 'src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/guided-authoring.ts' 'src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/guided-authoring.test.ts' 'src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/version-editor.tsx' 'src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/version-editor.test.tsx'`

## Notes
- the test contract is in `testing/codex-guided-build-authoring.md`
- manual browser verification steps are documented there but were not run live in this session
