### PR TITLE
feat(eval-sessions): add repeated-eval inspection reads and verification matrix

### DIFF
--- a/backend/db/queries/eval_sessions.sql
+++ b/backend/db/queries/eval_sessions.sql
@@ -32,6 +32,18 @@ FROM eval_sessions
 ORDER BY created_at DESC, id DESC
 LIMIT @result_limit OFFSET @result_offset;
 
+-- name: ListEvalSessionsByWorkspaceID :many
+SELECT *
+FROM eval_sessions
+WHERE EXISTS (
+    SELECT 1
+    FROM runs
+    WHERE runs.eval_session_id = eval_sessions.id
+      AND runs.workspace_id = @workspace_id
+)
+ORDER BY created_at DESC, id DESC
+LIMIT @result_limit OFFSET @result_offset;
+
 -- name: UpdateEvalSessionStatus :one
 UPDATE eval_sessions
 SET status = @to_status,

--- a/backend/internal/api/eval_session_reads.go
+++ b/backend/internal/api/eval_session_reads.go
@@ -1,0 +1,363 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/domain"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+type ListEvalSessionsInput struct {
+	WorkspaceID uuid.UUID
+	Limit       int32
+	Offset      int32
+}
+
+type EvalSessionSummary struct {
+	RunCounts EvalSessionRunCounts
+}
+
+type EvalSessionRunCounts struct {
+	Total        int `json:"total"`
+	Draft        int `json:"draft"`
+	Queued       int `json:"queued"`
+	Provisioning int `json:"provisioning"`
+	Running      int `json:"running"`
+	Scoring      int `json:"scoring"`
+	Completed    int `json:"completed"`
+	Failed       int `json:"failed"`
+	Cancelled    int `json:"cancelled"`
+}
+
+type GetEvalSessionResult struct {
+	Session          domain.EvalSession
+	Runs             []domain.Run
+	Summary          EvalSessionSummary
+	AggregateResult  json.RawMessage
+	EvidenceWarnings []string
+}
+
+type ListEvalSessionsResult struct {
+	Items []GetEvalSessionResult
+}
+
+type evalSessionChildRunResponse struct {
+	ID                     uuid.UUID        `json:"id"`
+	WorkspaceID            uuid.UUID        `json:"workspace_id"`
+	ChallengePackVersionID uuid.UUID        `json:"challenge_pack_version_id"`
+	ChallengeInputSetID    *uuid.UUID       `json:"challenge_input_set_id,omitempty"`
+	EvalSessionID          *uuid.UUID       `json:"eval_session_id,omitempty"`
+	OfficialPackMode       string           `json:"official_pack_mode"`
+	Name                   string           `json:"name"`
+	Status                 domain.RunStatus `json:"status"`
+	ExecutionMode          string           `json:"execution_mode"`
+	QueuedAt               *time.Time       `json:"queued_at,omitempty"`
+	StartedAt              *time.Time       `json:"started_at,omitempty"`
+	FinishedAt             *time.Time       `json:"finished_at,omitempty"`
+	CancelledAt            *time.Time       `json:"cancelled_at,omitempty"`
+	FailedAt               *time.Time       `json:"failed_at,omitempty"`
+	CreatedAt              time.Time        `json:"created_at"`
+	UpdatedAt              time.Time        `json:"updated_at"`
+	Links                  runLinksResponse `json:"links"`
+}
+
+type evalSessionSummaryResponse struct {
+	RunCounts EvalSessionRunCounts `json:"run_counts"`
+}
+
+type getEvalSessionResponse struct {
+	EvalSession      evalSessionResponse           `json:"eval_session"`
+	Runs             []evalSessionChildRunResponse `json:"runs"`
+	Summary          evalSessionSummaryResponse    `json:"summary"`
+	AggregateResult  json.RawMessage               `json:"aggregate_result"`
+	EvidenceWarnings []string                      `json:"evidence_warnings"`
+}
+
+type evalSessionListItemResponse struct {
+	EvalSession      evalSessionResponse        `json:"eval_session"`
+	Summary          evalSessionSummaryResponse `json:"summary"`
+	AggregateResult  json.RawMessage            `json:"aggregate_result"`
+	EvidenceWarnings []string                   `json:"evidence_warnings"`
+}
+
+type listEvalSessionsResponse struct {
+	Items  []evalSessionListItemResponse `json:"items"`
+	Limit  int32                         `json:"limit"`
+	Offset int32                         `json:"offset"`
+}
+
+func (m *RunReadManager) GetEvalSession(ctx context.Context, caller Caller, evalSessionID uuid.UUID) (GetEvalSessionResult, error) {
+	value, err := m.repo.GetEvalSessionWithRuns(ctx, evalSessionID)
+	if err != nil {
+		return GetEvalSessionResult{}, err
+	}
+
+	workspaceID, err := evalSessionWorkspaceID(value.Runs)
+	if err != nil {
+		return GetEvalSessionResult{}, err
+	}
+	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, workspaceID); err != nil {
+		return GetEvalSessionResult{}, err
+	}
+
+	return buildEvalSessionReadModel(value), nil
+}
+
+func (m *RunReadManager) ListEvalSessions(ctx context.Context, caller Caller, input ListEvalSessionsInput) (ListEvalSessionsResult, error) {
+	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, input.WorkspaceID); err != nil {
+		return ListEvalSessionsResult{}, err
+	}
+
+	sessions, err := m.repo.ListEvalSessionsByWorkspaceID(ctx, input.WorkspaceID, input.Limit, input.Offset)
+	if err != nil {
+		return ListEvalSessionsResult{}, fmt.Errorf("list eval sessions: %w", err)
+	}
+
+	items := make([]GetEvalSessionResult, 0, len(sessions))
+	for _, session := range sessions {
+		value, getErr := m.repo.GetEvalSessionWithRuns(ctx, session.ID)
+		if getErr != nil {
+			return ListEvalSessionsResult{}, fmt.Errorf("load eval session %s: %w", session.ID, getErr)
+		}
+		items = append(items, buildEvalSessionReadModel(value))
+	}
+
+	return ListEvalSessionsResult{Items: items}, nil
+}
+
+func buildEvalSessionReadModel(value repository.EvalSessionWithRuns) GetEvalSessionResult {
+	warnings := buildEvalSessionEvidenceWarnings(value.Session, value.Runs)
+	return GetEvalSessionResult{
+		Session:          value.Session,
+		Runs:             append([]domain.Run(nil), value.Runs...),
+		Summary:          EvalSessionSummary{RunCounts: summarizeEvalSessionRuns(value.Runs)},
+		AggregateResult:  nil,
+		EvidenceWarnings: warnings,
+	}
+}
+
+func summarizeEvalSessionRuns(runs []domain.Run) EvalSessionRunCounts {
+	summary := EvalSessionRunCounts{Total: len(runs)}
+	for _, run := range runs {
+		switch run.Status {
+		case domain.RunStatusDraft:
+			summary.Draft++
+		case domain.RunStatusQueued:
+			summary.Queued++
+		case domain.RunStatusProvisioning:
+			summary.Provisioning++
+		case domain.RunStatusRunning:
+			summary.Running++
+		case domain.RunStatusScoring:
+			summary.Scoring++
+		case domain.RunStatusCompleted:
+			summary.Completed++
+		case domain.RunStatusFailed:
+			summary.Failed++
+		case domain.RunStatusCancelled:
+			summary.Cancelled++
+		}
+	}
+	return summary
+}
+
+func buildEvalSessionEvidenceWarnings(session domain.EvalSession, runs []domain.Run) []string {
+	warnings := make([]string, 0, 3)
+	if len(runs) == 0 {
+		warnings = append(warnings, "no child runs are attached to this eval session")
+	} else if len(runs) != int(session.Repetitions) {
+		warnings = append(warnings, fmt.Sprintf("expected %d child runs but found %d", session.Repetitions, len(runs)))
+	}
+
+	switch session.Status {
+	case domain.EvalSessionStatusQueued, domain.EvalSessionStatusRunning:
+		warnings = append(warnings, "aggregate result unavailable: eval session has not reached aggregation yet")
+	default:
+		warnings = append(warnings, "aggregate result unavailable: session-level aggregation has not been persisted yet")
+	}
+
+	if len(runs) > 1 {
+		workspaceID := runs[0].WorkspaceID
+		for _, run := range runs[1:] {
+			if run.WorkspaceID != workspaceID {
+				warnings = append(warnings, "child runs span multiple workspaces; investigate persisted eval session attachments")
+				break
+			}
+		}
+	}
+
+	sort.Strings(warnings)
+	return warnings
+}
+
+func evalSessionWorkspaceID(runs []domain.Run) (uuid.UUID, error) {
+	if len(runs) == 0 {
+		return uuid.Nil, fmt.Errorf("eval session has no child runs")
+	}
+
+	workspaceID := runs[0].WorkspaceID
+	for _, run := range runs[1:] {
+		if run.WorkspaceID != workspaceID {
+			return uuid.Nil, fmt.Errorf("eval session child runs span multiple workspaces")
+		}
+	}
+	return workspaceID, nil
+}
+
+func getEvalSessionHandler(logger *slog.Logger, service RunReadService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		evalSessionID, err := uuid.Parse(chi.URLParam(r, "evalSessionID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_eval_session_id", "evalSessionID must be a valid UUID")
+			return
+		}
+
+		result, err := service.GetEvalSession(r.Context(), caller, evalSessionID)
+		if err != nil {
+			switch {
+			case errors.Is(err, repository.ErrEvalSessionNotFound):
+				writeError(w, http.StatusNotFound, "eval_session_not_found", "eval session not found")
+			case errors.Is(err, ErrForbidden):
+				writeAuthzError(w, err)
+			default:
+				logger.Error("get eval session request failed",
+					"method", r.Method,
+					"path", r.URL.Path,
+					"eval_session_id", evalSessionID,
+					"error", err,
+				)
+				writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+			}
+			return
+		}
+
+		writeJSON(w, http.StatusOK, buildGetEvalSessionResponse(result))
+	}
+}
+
+func listEvalSessionsHandler(logger *slog.Logger, service RunReadService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		workspaceID, err := parseRequiredUUIDQueryParam(r, "workspace_id")
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_workspace_id", err.Error())
+			return
+		}
+
+		limit := int32(20)
+		if raw := r.URL.Query().Get("limit"); raw != "" {
+			if parsed, parseErr := strconv.Atoi(raw); parseErr == nil && parsed > 0 {
+				limit = int32(parsed)
+			}
+		}
+		if limit > 100 {
+			limit = 100
+		}
+
+		offset := int32(0)
+		if raw := r.URL.Query().Get("offset"); raw != "" {
+			if parsed, parseErr := strconv.Atoi(raw); parseErr == nil && parsed >= 0 {
+				offset = int32(parsed)
+			}
+		}
+
+		result, err := service.ListEvalSessions(r.Context(), caller, ListEvalSessionsInput{
+			WorkspaceID: workspaceID,
+			Limit:       limit,
+			Offset:      offset,
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, ErrForbidden):
+				writeAuthzError(w, err)
+			default:
+				logger.Error("list eval sessions request failed",
+					"method", r.Method,
+					"path", r.URL.Path,
+					"workspace_id", workspaceID,
+					"error", err,
+				)
+				writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+			}
+			return
+		}
+
+		items := make([]evalSessionListItemResponse, 0, len(result.Items))
+		for _, item := range result.Items {
+			items = append(items, buildEvalSessionListItemResponse(item))
+		}
+
+		writeJSON(w, http.StatusOK, listEvalSessionsResponse{
+			Items:  items,
+			Limit:  limit,
+			Offset: offset,
+		})
+	}
+}
+
+func buildGetEvalSessionResponse(result GetEvalSessionResult) getEvalSessionResponse {
+	runs := make([]evalSessionChildRunResponse, 0, len(result.Runs))
+	for _, run := range result.Runs {
+		runs = append(runs, buildEvalSessionChildRunResponse(run))
+	}
+
+	return getEvalSessionResponse{
+		EvalSession:      buildEvalSessionResponse(result.Session),
+		Runs:             runs,
+		Summary:          evalSessionSummaryResponse{RunCounts: result.Summary.RunCounts},
+		AggregateResult:  result.AggregateResult,
+		EvidenceWarnings: append([]string(nil), result.EvidenceWarnings...),
+	}
+}
+
+func buildEvalSessionListItemResponse(result GetEvalSessionResult) evalSessionListItemResponse {
+	return evalSessionListItemResponse{
+		EvalSession:      buildEvalSessionResponse(result.Session),
+		Summary:          evalSessionSummaryResponse{RunCounts: result.Summary.RunCounts},
+		AggregateResult:  result.AggregateResult,
+		EvidenceWarnings: append([]string(nil), result.EvidenceWarnings...),
+	}
+}
+
+func buildEvalSessionChildRunResponse(run domain.Run) evalSessionChildRunResponse {
+	return evalSessionChildRunResponse{
+		ID:                     run.ID,
+		WorkspaceID:            run.WorkspaceID,
+		ChallengePackVersionID: run.ChallengePackVersionID,
+		ChallengeInputSetID:    run.ChallengeInputSetID,
+		EvalSessionID:          run.EvalSessionID,
+		OfficialPackMode:       string(run.OfficialPackMode),
+		Name:                   run.Name,
+		Status:                 run.Status,
+		ExecutionMode:          run.ExecutionMode,
+		QueuedAt:               run.QueuedAt,
+		StartedAt:              run.StartedAt,
+		FinishedAt:             run.FinishedAt,
+		CancelledAt:            run.CancelledAt,
+		FailedAt:               run.FailedAt,
+		CreatedAt:              run.CreatedAt,
+		UpdatedAt:              run.UpdatedAt,
+		Links:                  buildRunLinks(run.ID),
+	}
+}

--- a/backend/internal/api/eval_session_reads.go
+++ b/backend/internal/api/eval_session_reads.go
@@ -102,12 +102,14 @@ func (m *RunReadManager) GetEvalSession(ctx context.Context, caller Caller, eval
 		return GetEvalSessionResult{}, err
 	}
 
-	workspaceID, err := evalSessionWorkspaceID(value.Runs)
-	if err != nil {
-		return GetEvalSessionResult{}, err
-	}
-	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, workspaceID); err != nil {
-		return GetEvalSessionResult{}, err
+	if len(value.Runs) > 0 {
+		workspaceID, err := evalSessionWorkspaceID(value.Runs)
+		if err != nil {
+			return GetEvalSessionResult{}, err
+		}
+		if err := m.authorizer.AuthorizeWorkspace(ctx, caller, workspaceID); err != nil {
+			return GetEvalSessionResult{}, err
+		}
 	}
 
 	return buildEvalSessionReadModel(value), nil
@@ -125,11 +127,14 @@ func (m *RunReadManager) ListEvalSessions(ctx context.Context, caller Caller, in
 
 	items := make([]GetEvalSessionResult, 0, len(sessions))
 	for _, session := range sessions {
-		value, getErr := m.repo.GetEvalSessionWithRuns(ctx, session.ID)
-		if getErr != nil {
-			return ListEvalSessionsResult{}, fmt.Errorf("load eval session %s: %w", session.ID, getErr)
+		runs, runErr := m.repo.ListRunsByEvalSessionID(ctx, session.ID)
+		if runErr != nil {
+			return ListEvalSessionsResult{}, fmt.Errorf("load runs for eval session %s: %w", session.ID, runErr)
 		}
-		items = append(items, buildEvalSessionReadModel(value))
+		items = append(items, buildEvalSessionReadModel(repository.EvalSessionWithRuns{
+			Session: session,
+			Runs:    runs,
+		}))
 	}
 
 	return ListEvalSessionsResult{Items: items}, nil

--- a/backend/internal/api/eval_session_reads_test.go
+++ b/backend/internal/api/eval_session_reads_test.go
@@ -1,0 +1,289 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/domain"
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+func TestRunReadManagerGetEvalSessionReturnsAuthorizedSession(t *testing.T) {
+	workspaceID := uuid.New()
+	sessionID := uuid.New()
+	runID := uuid.New()
+	caller := Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}
+
+	manager := NewRunReadManager(NewCallerWorkspaceAuthorizer(), &fakeRunReadRepository{
+		evalSession: repository.EvalSessionWithRuns{
+			Session: domain.EvalSession{
+				ID:          sessionID,
+				Status:      domain.EvalSessionStatusQueued,
+				Repetitions: 2,
+			},
+			Runs: []domain.Run{
+				{
+					ID:            runID,
+					WorkspaceID:   workspaceID,
+					EvalSessionID: &sessionID,
+					Status:        domain.RunStatusQueued,
+					CreatedAt:     time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
+					UpdatedAt:     time.Date(2026, 4, 20, 12, 1, 0, 0, time.UTC),
+				},
+			},
+		},
+	})
+
+	result, err := manager.GetEvalSession(context.Background(), caller, sessionID)
+	if err != nil {
+		t.Fatalf("GetEvalSession returned error: %v", err)
+	}
+	if result.Session.ID != sessionID {
+		t.Fatalf("session id = %s, want %s", result.Session.ID, sessionID)
+	}
+	if result.Summary.RunCounts.Queued != 1 {
+		t.Fatalf("queued run count = %d, want 1", result.Summary.RunCounts.Queued)
+	}
+	if !slices.Contains(result.EvidenceWarnings, "aggregate result unavailable: eval session has not reached aggregation yet") {
+		t.Fatalf("evidence warnings = %v, want aggregate unavailable warning", result.EvidenceWarnings)
+	}
+}
+
+func TestRunReadManagerGetEvalSessionRejectsForbiddenWorkspaceAccess(t *testing.T) {
+	workspaceID := uuid.New()
+	manager := NewRunReadManager(NewCallerWorkspaceAuthorizer(), &fakeRunReadRepository{
+		evalSession: repository.EvalSessionWithRuns{
+			Session: domain.EvalSession{
+				ID:          uuid.New(),
+				Status:      domain.EvalSessionStatusQueued,
+				Repetitions: 1,
+			},
+			Runs: []domain.Run{
+				{
+					ID:          uuid.New(),
+					WorkspaceID: workspaceID,
+					Status:      domain.RunStatusQueued,
+				},
+			},
+		},
+	})
+
+	_, err := manager.GetEvalSession(context.Background(), Caller{
+		UserID:               uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{},
+	}, uuid.New())
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("error = %v, want ErrForbidden", err)
+	}
+}
+
+func TestGetEvalSessionEndpointReturnsDetail(t *testing.T) {
+	userID := uuid.New()
+	workspaceID := uuid.New()
+	sessionID := uuid.New()
+	runID := uuid.New()
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/eval-sessions/"+sessionID.String(), nil)
+	req.Header.Set(headerUserID, userID.String())
+	req.Header.Set(headerWorkspaceMemberships, workspaceID.String()+":workspace_member")
+	recorder := httptest.NewRecorder()
+
+	newRouter("dev", nil,
+		testLogger(t),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		nil,
+		0,
+		stubRunCreationService{},
+		&fakeRunReadService{
+			getEvalSessionResult: GetEvalSessionResult{
+				Session: domain.EvalSession{
+					ID:          sessionID,
+					Status:      domain.EvalSessionStatusQueued,
+					Repetitions: 2,
+					CreatedAt:   time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
+					UpdatedAt:   time.Date(2026, 4, 20, 12, 1, 0, 0, time.UTC),
+				},
+				Runs: []domain.Run{
+					{
+						ID:               runID,
+						WorkspaceID:      workspaceID,
+						EvalSessionID:    &sessionID,
+						OfficialPackMode: domain.OfficialPackModeFull,
+						Name:             "Repeated Eval [1/2]",
+						Status:           domain.RunStatusQueued,
+						ExecutionMode:    "single_agent",
+						CreatedAt:        time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
+						UpdatedAt:        time.Date(2026, 4, 20, 12, 1, 0, 0, time.UTC),
+					},
+				},
+				Summary: EvalSessionSummary{
+					RunCounts: EvalSessionRunCounts{Total: 1, Queued: 1},
+				},
+				EvidenceWarnings: []string{"aggregate result unavailable: eval session has not reached aggregation yet"},
+			},
+		},
+		&fakeReplayReadService{},
+		stubHostedRunIngestionService{},
+		nil,
+		stubAgentDeploymentReadService{},
+		stubChallengePackReadService{},
+		stubAgentBuildService{},
+		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+
+	var response getEvalSessionResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.EvalSession.ID != sessionID {
+		t.Fatalf("session id = %s, want %s", response.EvalSession.ID, sessionID)
+	}
+	if len(response.Runs) != 1 || response.Runs[0].ID != runID {
+		t.Fatalf("runs = %#v, want one run %s", response.Runs, runID)
+	}
+	if response.Summary.RunCounts.Queued != 1 {
+		t.Fatalf("queued run count = %d, want 1", response.Summary.RunCounts.Queued)
+	}
+	if string(response.AggregateResult) != "null" {
+		t.Fatalf("aggregate_result = %s, want null", string(response.AggregateResult))
+	}
+}
+
+func TestListEvalSessionsEndpointRequiresWorkspaceID(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/v1/eval-sessions", nil)
+	req.Header.Set(headerUserID, uuid.New().String())
+	recorder := httptest.NewRecorder()
+
+	newRouter("dev", nil,
+		testLogger(t),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		nil,
+		0,
+		stubRunCreationService{},
+		&fakeRunReadService{},
+		&fakeReplayReadService{},
+		stubHostedRunIngestionService{},
+		nil,
+		stubAgentDeploymentReadService{},
+		stubChallengePackReadService{},
+		stubAgentBuildService{},
+		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+	}
+}
+
+func TestListEvalSessionsEndpointReturnsItems(t *testing.T) {
+	userID := uuid.New()
+	workspaceID := uuid.New()
+	sessionID := uuid.New()
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/eval-sessions?workspace_id="+workspaceID.String()+"&limit=5", nil)
+	req.Header.Set(headerUserID, userID.String())
+	req.Header.Set(headerWorkspaceMemberships, workspaceID.String()+":workspace_member")
+	recorder := httptest.NewRecorder()
+
+	newRouter("dev", nil,
+		testLogger(t),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		nil,
+		0,
+		stubRunCreationService{},
+		&fakeRunReadService{
+			listEvalSessionsResult: ListEvalSessionsResult{
+				Items: []GetEvalSessionResult{
+					{
+						Session: domain.EvalSession{
+							ID:          sessionID,
+							Status:      domain.EvalSessionStatusQueued,
+							Repetitions: 3,
+						},
+						Summary: EvalSessionSummary{
+							RunCounts: EvalSessionRunCounts{Total: 3, Queued: 3},
+						},
+						EvidenceWarnings: []string{"aggregate result unavailable: eval session has not reached aggregation yet"},
+					},
+				},
+			},
+		},
+		&fakeReplayReadService{},
+		stubHostedRunIngestionService{},
+		nil,
+		stubAgentDeploymentReadService{},
+		stubChallengePackReadService{},
+		stubAgentBuildService{},
+		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+
+	var response listEvalSessionsResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(response.Items) != 1 {
+		t.Fatalf("item count = %d, want 1", len(response.Items))
+	}
+	if response.Items[0].EvalSession.ID != sessionID {
+		t.Fatalf("session id = %s, want %s", response.Items[0].EvalSession.ID, sessionID)
+	}
+	if response.Items[0].Summary.RunCounts.Queued != 3 {
+		t.Fatalf("queued run count = %d, want 3", response.Items[0].Summary.RunCounts.Queued)
+	}
+}

--- a/backend/internal/api/eval_session_reads_test.go
+++ b/backend/internal/api/eval_session_reads_test.go
@@ -61,6 +61,37 @@ func TestRunReadManagerGetEvalSessionReturnsAuthorizedSession(t *testing.T) {
 	}
 }
 
+func TestRunReadManagerGetEvalSessionAllowsZeroRunSession(t *testing.T) {
+	sessionID := uuid.New()
+	manager := NewRunReadManager(NewCallerWorkspaceAuthorizer(), &fakeRunReadRepository{
+		evalSession: repository.EvalSessionWithRuns{
+			Session: domain.EvalSession{
+				ID:          sessionID,
+				Status:      domain.EvalSessionStatusQueued,
+				Repetitions: 1,
+			},
+			Runs: nil,
+		},
+	})
+
+	result, err := manager.GetEvalSession(context.Background(), Caller{
+		UserID:               uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{},
+	}, sessionID)
+	if err != nil {
+		t.Fatalf("GetEvalSession returned error: %v", err)
+	}
+	if result.Session.ID != sessionID {
+		t.Fatalf("session id = %s, want %s", result.Session.ID, sessionID)
+	}
+	if result.Summary.RunCounts.Total != 0 {
+		t.Fatalf("total run count = %d, want 0", result.Summary.RunCounts.Total)
+	}
+	if !slices.Contains(result.EvidenceWarnings, "no child runs are attached to this eval session") {
+		t.Fatalf("evidence warnings = %v, want missing child run warning", result.EvidenceWarnings)
+	}
+}
+
 func TestRunReadManagerGetEvalSessionRejectsForbiddenWorkspaceAccess(t *testing.T) {
 	workspaceID := uuid.New()
 	manager := NewRunReadManager(NewCallerWorkspaceAuthorizer(), &fakeRunReadRepository{
@@ -86,6 +117,51 @@ func TestRunReadManagerGetEvalSessionRejectsForbiddenWorkspaceAccess(t *testing.
 	}, uuid.New())
 	if !errors.Is(err, ErrForbidden) {
 		t.Fatalf("error = %v, want ErrForbidden", err)
+	}
+}
+
+func TestRunReadManagerListEvalSessionsUsesListedSessionsWithoutRefetching(t *testing.T) {
+	workspaceID := uuid.New()
+	firstSessionID := uuid.New()
+	secondSessionID := uuid.New()
+	manager := NewRunReadManager(NewCallerWorkspaceAuthorizer(), &fakeRunReadRepository{
+		evalSessions: []domain.EvalSession{
+			{ID: firstSessionID, Status: domain.EvalSessionStatusQueued, Repetitions: 1},
+			{ID: secondSessionID, Status: domain.EvalSessionStatusQueued, Repetitions: 2},
+		},
+		evalSessionRuns: map[uuid.UUID][]domain.Run{
+			firstSessionID: {
+				{ID: uuid.New(), WorkspaceID: workspaceID, Status: domain.RunStatusQueued},
+			},
+			secondSessionID: {
+				{ID: uuid.New(), WorkspaceID: workspaceID, Status: domain.RunStatusQueued},
+				{ID: uuid.New(), WorkspaceID: workspaceID, Status: domain.RunStatusQueued},
+			},
+		},
+		getEvalSessionErr: errors.New("should not refetch session rows"),
+	})
+
+	result, err := manager.ListEvalSessions(context.Background(), Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}, ListEvalSessionsInput{
+		WorkspaceID: workspaceID,
+		Limit:       10,
+		Offset:      0,
+	})
+	if err != nil {
+		t.Fatalf("ListEvalSessions returned error: %v", err)
+	}
+	if len(result.Items) != 2 {
+		t.Fatalf("item count = %d, want 2", len(result.Items))
+	}
+	if result.Items[0].Summary.RunCounts.Total != 1 {
+		t.Fatalf("first item total runs = %d, want 1", result.Items[0].Summary.RunCounts.Total)
+	}
+	if result.Items[1].Summary.RunCounts.Total != 2 {
+		t.Fatalf("second item total runs = %d, want 2", result.Items[1].Summary.RunCounts.Total)
 	}
 }
 

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -63,7 +63,9 @@ func registerProtectedRoutes(
 	// POST /v1/runs resolves workspace access from the JSON body, so authz stays in the run-creation service
 	// instead of URL-param middleware. The run read endpoints below also resolve authz in the service layer
 	// because the workspace boundary is owned by the persisted run row rather than the URL shape.
+	router.Get("/eval-sessions", listEvalSessionsHandler(logger, runReadService))
 	router.Post("/eval-sessions", createEvalSessionHandler(logger, runCreationService))
+	router.Get("/eval-sessions/{evalSessionID}", getEvalSessionHandler(logger, runReadService))
 	router.Post("/runs", createRunHandler(logger, runCreationService))
 	router.Get("/runs/{runID}", getRunHandler(logger, runReadService))
 	router.Get("/runs/{runID}/ranking", getRunRankingHandler(logger, runReadService))

--- a/backend/internal/api/run_events_sse_test.go
+++ b/backend/internal/api/run_events_sse_test.go
@@ -164,12 +164,20 @@ func (f *fakeSSERunReadService) GetRun(context.Context, Caller, uuid.UUID) (GetR
 	return GetRunResult{}, nil
 }
 
+func (f *fakeSSERunReadService) GetEvalSession(context.Context, Caller, uuid.UUID) (GetEvalSessionResult, error) {
+	return GetEvalSessionResult{}, nil
+}
+
 func (f *fakeSSERunReadService) GetRunRanking(context.Context, Caller, uuid.UUID, GetRunRankingInput) (GetRunRankingResult, error) {
 	return GetRunRankingResult{}, nil
 }
 
 func (f *fakeSSERunReadService) GenerateRunRankingInsights(context.Context, Caller, uuid.UUID, GenerateRunRankingInsightsInput) (GenerateRunRankingInsightsResult, error) {
 	return GenerateRunRankingInsightsResult{}, nil
+}
+
+func (f *fakeSSERunReadService) ListEvalSessions(context.Context, Caller, ListEvalSessionsInput) (ListEvalSessionsResult, error) {
+	return ListEvalSessionsResult{}, nil
 }
 
 func (f *fakeSSERunReadService) ListRunAgents(context.Context, Caller, uuid.UUID) (ListRunAgentsResult, error) {

--- a/backend/internal/api/run_reads.go
+++ b/backend/internal/api/run_reads.go
@@ -20,10 +20,12 @@ import (
 
 type RunReadRepository interface {
 	GetRunByID(ctx context.Context, id uuid.UUID) (domain.Run, error)
+	GetEvalSessionWithRuns(ctx context.Context, id uuid.UUID) (repository.EvalSessionWithRuns, error)
 	GetRunScorecardByRunID(ctx context.Context, runID uuid.UUID) (repository.RunScorecard, error)
 	ListRunRegressionCoverageCasesByRunID(ctx context.Context, runID uuid.UUID) ([]repository.RunRegressionCoverageCase, error)
 	ListRunAgentsByRunID(ctx context.Context, runID uuid.UUID) ([]domain.RunAgent, error)
 	ListRunFailureReviewItems(ctx context.Context, runID uuid.UUID, agentID *uuid.UUID) ([]failurereview.Item, error)
+	ListEvalSessionsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID, limit int32, offset int32) ([]domain.EvalSession, error)
 	ListRunsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID, limit int32, offset int32) ([]domain.Run, error)
 	CountRunsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (int64, error)
 	GetProviderAccountByID(ctx context.Context, id uuid.UUID) (repository.ProviderAccountRow, error)
@@ -35,8 +37,10 @@ type RunReadRepository interface {
 
 type RunReadService interface {
 	GetRun(ctx context.Context, caller Caller, runID uuid.UUID) (GetRunResult, error)
+	GetEvalSession(ctx context.Context, caller Caller, evalSessionID uuid.UUID) (GetEvalSessionResult, error)
 	GetRunRanking(ctx context.Context, caller Caller, runID uuid.UUID, input GetRunRankingInput) (GetRunRankingResult, error)
 	GenerateRunRankingInsights(ctx context.Context, caller Caller, runID uuid.UUID, input GenerateRunRankingInsightsInput) (GenerateRunRankingInsightsResult, error)
+	ListEvalSessions(ctx context.Context, caller Caller, input ListEvalSessionsInput) (ListEvalSessionsResult, error)
 	ListRunAgents(ctx context.Context, caller Caller, runID uuid.UUID) (ListRunAgentsResult, error)
 	ListRunFailures(ctx context.Context, caller Caller, input ListRunFailuresInput) (ListRunFailuresResult, error)
 	ListRuns(ctx context.Context, caller Caller, input ListRunsInput) (ListRunsResult, error)

--- a/backend/internal/api/run_reads.go
+++ b/backend/internal/api/run_reads.go
@@ -21,6 +21,7 @@ import (
 type RunReadRepository interface {
 	GetRunByID(ctx context.Context, id uuid.UUID) (domain.Run, error)
 	GetEvalSessionWithRuns(ctx context.Context, id uuid.UUID) (repository.EvalSessionWithRuns, error)
+	ListRunsByEvalSessionID(ctx context.Context, evalSessionID uuid.UUID) ([]domain.Run, error)
 	GetRunScorecardByRunID(ctx context.Context, runID uuid.UUID) (repository.RunScorecard, error)
 	ListRunRegressionCoverageCasesByRunID(ctx context.Context, runID uuid.UUID) ([]repository.RunRegressionCoverageCase, error)
 	ListRunAgentsByRunID(ctx context.Context, runID uuid.UUID) ([]domain.RunAgent, error)

--- a/backend/internal/api/run_reads_test.go
+++ b/backend/internal/api/run_reads_test.go
@@ -410,6 +410,7 @@ type fakeRunReadRepository struct {
 	run                     domain.Run
 	evalSession             repository.EvalSessionWithRuns
 	evalSessions            []domain.EvalSession
+	evalSessionRuns         map[uuid.UUID][]domain.Run
 	runScorecard            repository.RunScorecard
 	regressionCoverageCases []repository.RunRegressionCoverageCase
 	runAgents               []domain.RunAgent
@@ -421,6 +422,7 @@ type fakeRunReadRepository struct {
 	workspaceSecrets        map[string]string
 	getRunErr               error
 	getEvalSessionErr       error
+	listEvalSessionRunsErr  error
 	getRunScorecardErr      error
 	listRunAgentsErr        error
 	listRunFailuresErr      error
@@ -438,6 +440,13 @@ func (f *fakeRunReadRepository) GetRunByID(_ context.Context, _ uuid.UUID) (doma
 
 func (f *fakeRunReadRepository) GetEvalSessionWithRuns(_ context.Context, _ uuid.UUID) (repository.EvalSessionWithRuns, error) {
 	return f.evalSession, f.getEvalSessionErr
+}
+
+func (f *fakeRunReadRepository) ListRunsByEvalSessionID(_ context.Context, evalSessionID uuid.UUID) ([]domain.Run, error) {
+	if f.listEvalSessionRunsErr != nil {
+		return nil, f.listEvalSessionRunsErr
+	}
+	return append([]domain.Run(nil), f.evalSessionRuns[evalSessionID]...), nil
 }
 
 func (f *fakeRunReadRepository) GetRunScorecardByRunID(_ context.Context, _ uuid.UUID) (repository.RunScorecard, error) {

--- a/backend/internal/api/run_reads_test.go
+++ b/backend/internal/api/run_reads_test.go
@@ -408,6 +408,8 @@ func TestListRunAgentsEndpointReturnsForbidden(t *testing.T) {
 
 type fakeRunReadRepository struct {
 	run                     domain.Run
+	evalSession             repository.EvalSessionWithRuns
+	evalSessions            []domain.EvalSession
 	runScorecard            repository.RunScorecard
 	regressionCoverageCases []repository.RunRegressionCoverageCase
 	runAgents               []domain.RunAgent
@@ -418,9 +420,11 @@ type fakeRunReadRepository struct {
 	modelCatalogEntry       repository.ModelCatalogEntryRow
 	workspaceSecrets        map[string]string
 	getRunErr               error
+	getEvalSessionErr       error
 	getRunScorecardErr      error
 	listRunAgentsErr        error
 	listRunFailuresErr      error
+	listEvalSessionsErr     error
 	getProviderAccountErr   error
 	getModelAliasErr        error
 	getModelCatalogErr      error
@@ -430,6 +434,10 @@ type fakeRunReadRepository struct {
 
 func (f *fakeRunReadRepository) GetRunByID(_ context.Context, _ uuid.UUID) (domain.Run, error) {
 	return f.run, f.getRunErr
+}
+
+func (f *fakeRunReadRepository) GetEvalSessionWithRuns(_ context.Context, _ uuid.UUID) (repository.EvalSessionWithRuns, error) {
+	return f.evalSession, f.getEvalSessionErr
 }
 
 func (f *fakeRunReadRepository) GetRunScorecardByRunID(_ context.Context, _ uuid.UUID) (repository.RunScorecard, error) {
@@ -446,6 +454,10 @@ func (f *fakeRunReadRepository) ListRunAgentsByRunID(_ context.Context, _ uuid.U
 
 func (f *fakeRunReadRepository) ListRunFailureReviewItems(_ context.Context, _ uuid.UUID, _ *uuid.UUID) ([]failurereview.Item, error) {
 	return f.failureItems, f.listRunFailuresErr
+}
+
+func (f *fakeRunReadRepository) ListEvalSessionsByWorkspaceID(_ context.Context, _ uuid.UUID, _ int32, _ int32) ([]domain.EvalSession, error) {
+	return append([]domain.EvalSession(nil), f.evalSessions...), f.listEvalSessionsErr
 }
 
 func (f *fakeRunReadRepository) ListRunsByWorkspaceID(_ context.Context, _ uuid.UUID, _ int32, _ int32) ([]domain.Run, error) {
@@ -477,20 +489,28 @@ func (f *fakeRunReadRepository) LoadWorkspaceSecrets(_ context.Context, _ uuid.U
 }
 
 type fakeRunReadService struct {
-	getRunResult          GetRunResult
-	getRunErr             error
-	getRunRankingResult   GetRunRankingResult
-	getRunRankingErr      error
-	insightsResult        GenerateRunRankingInsightsResult
-	insightsErr           error
-	listRunAgentsResult   ListRunAgentsResult
-	listRunAgentsErr      error
-	listRunFailuresResult ListRunFailuresResult
-	listRunFailuresErr    error
+	getRunResult           GetRunResult
+	getRunErr              error
+	getEvalSessionResult   GetEvalSessionResult
+	getEvalSessionErr      error
+	getRunRankingResult    GetRunRankingResult
+	getRunRankingErr       error
+	insightsResult         GenerateRunRankingInsightsResult
+	insightsErr            error
+	listEvalSessionsResult ListEvalSessionsResult
+	listEvalSessionsErr    error
+	listRunAgentsResult    ListRunAgentsResult
+	listRunAgentsErr       error
+	listRunFailuresResult  ListRunFailuresResult
+	listRunFailuresErr     error
 }
 
 func (f *fakeRunReadService) GetRun(_ context.Context, _ Caller, _ uuid.UUID) (GetRunResult, error) {
 	return f.getRunResult, f.getRunErr
+}
+
+func (f *fakeRunReadService) GetEvalSession(_ context.Context, _ Caller, _ uuid.UUID) (GetEvalSessionResult, error) {
+	return f.getEvalSessionResult, f.getEvalSessionErr
 }
 
 func (f *fakeRunReadService) GetRunRanking(_ context.Context, _ Caller, _ uuid.UUID, _ GetRunRankingInput) (GetRunRankingResult, error) {
@@ -499,6 +519,10 @@ func (f *fakeRunReadService) GetRunRanking(_ context.Context, _ Caller, _ uuid.U
 
 func (f *fakeRunReadService) GenerateRunRankingInsights(_ context.Context, _ Caller, _ uuid.UUID, _ GenerateRunRankingInsightsInput) (GenerateRunRankingInsightsResult, error) {
 	return f.insightsResult, f.insightsErr
+}
+
+func (f *fakeRunReadService) ListEvalSessions(_ context.Context, _ Caller, _ ListEvalSessionsInput) (ListEvalSessionsResult, error) {
+	return f.listEvalSessionsResult, f.listEvalSessionsErr
 }
 
 func (f *fakeRunReadService) ListRunAgents(_ context.Context, _ Caller, _ uuid.UUID) (ListRunAgentsResult, error) {

--- a/backend/internal/api/server_test.go
+++ b/backend/internal/api/server_test.go
@@ -30,12 +30,20 @@ func (stubRunReadService) GetRun(_ context.Context, _ Caller, _ uuid.UUID) (GetR
 	return GetRunResult{}, errors.New("not implemented")
 }
 
+func (stubRunReadService) GetEvalSession(_ context.Context, _ Caller, _ uuid.UUID) (GetEvalSessionResult, error) {
+	return GetEvalSessionResult{}, errors.New("not implemented")
+}
+
 func (stubRunReadService) GetRunRanking(_ context.Context, _ Caller, _ uuid.UUID, _ GetRunRankingInput) (GetRunRankingResult, error) {
 	return GetRunRankingResult{}, errors.New("not implemented")
 }
 
 func (stubRunReadService) GenerateRunRankingInsights(_ context.Context, _ Caller, _ uuid.UUID, _ GenerateRunRankingInsightsInput) (GenerateRunRankingInsightsResult, error) {
 	return GenerateRunRankingInsightsResult{}, errors.New("not implemented")
+}
+
+func (stubRunReadService) ListEvalSessions(_ context.Context, _ Caller, _ ListEvalSessionsInput) (ListEvalSessionsResult, error) {
+	return ListEvalSessionsResult{}, errors.New("not implemented")
 }
 
 func (stubRunReadService) ListRunAgents(_ context.Context, _ Caller, _ uuid.UUID) (ListRunAgentsResult, error) {

--- a/backend/internal/repository/eval_sessions.go
+++ b/backend/internal/repository/eval_sessions.go
@@ -131,6 +131,35 @@ func (r *Repository) ListEvalSessions(ctx context.Context, limit int32, offset i
 	return sessions, nil
 }
 
+func (r *Repository) ListEvalSessionsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID, limit int32, offset int32) ([]domain.EvalSession, error) {
+	if limit < 0 {
+		limit = 0
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	rows, err := r.queries.ListEvalSessionsByWorkspaceID(ctx, repositorysqlc.ListEvalSessionsByWorkspaceIDParams{
+		WorkspaceID:  workspaceID,
+		ResultLimit:  limit,
+		ResultOffset: offset,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list eval sessions by workspace: %w", err)
+	}
+
+	sessions := make([]domain.EvalSession, 0, len(rows))
+	for _, row := range rows {
+		session, mapErr := mapEvalSession(row)
+		if mapErr != nil {
+			return nil, fmt.Errorf("map eval session %s: %w", row.ID, mapErr)
+		}
+		sessions = append(sessions, session)
+	}
+
+	return sessions, nil
+}
+
 func (r *Repository) TransitionEvalSessionStatus(ctx context.Context, params TransitionEvalSessionStatusParams) (domain.EvalSession, error) {
 	if !params.ToStatus.Valid() {
 		return domain.EvalSession{}, fmt.Errorf("%w: %q", domain.ErrInvalidEvalSessionStatus, params.ToStatus)

--- a/backend/internal/repository/eval_sessions.go
+++ b/backend/internal/repository/eval_sessions.go
@@ -81,26 +81,35 @@ func (r *Repository) GetEvalSessionWithRuns(ctx context.Context, id uuid.UUID) (
 		return EvalSessionWithRuns{}, err
 	}
 
-	rows, err := r.queries.ListRunsByEvalSessionID(ctx, repositorysqlc.ListRunsByEvalSessionIDParams{
-		EvalSessionID: &id,
-	})
+	runs, err := r.ListRunsByEvalSessionID(ctx, id)
 	if err != nil {
-		return EvalSessionWithRuns{}, fmt.Errorf("list runs by eval session id: %w", err)
-	}
-
-	runs := make([]domain.Run, 0, len(rows))
-	for _, row := range rows {
-		run, mapErr := mapRun(row)
-		if mapErr != nil {
-			return EvalSessionWithRuns{}, fmt.Errorf("map run %s: %w", row.ID, mapErr)
-		}
-		runs = append(runs, run)
+		return EvalSessionWithRuns{}, err
 	}
 
 	return EvalSessionWithRuns{
 		Session: session,
 		Runs:    runs,
 	}, nil
+}
+
+func (r *Repository) ListRunsByEvalSessionID(ctx context.Context, id uuid.UUID) ([]domain.Run, error) {
+	rows, err := r.queries.ListRunsByEvalSessionID(ctx, repositorysqlc.ListRunsByEvalSessionIDParams{
+		EvalSessionID: &id,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list runs by eval session id: %w", err)
+	}
+
+	runs := make([]domain.Run, 0, len(rows))
+	for _, row := range rows {
+		run, mapErr := mapRun(row)
+		if mapErr != nil {
+			return nil, fmt.Errorf("map run %s: %w", row.ID, mapErr)
+		}
+		runs = append(runs, run)
+	}
+
+	return runs, nil
 }
 
 func (r *Repository) ListEvalSessions(ctx context.Context, limit int32, offset int32) ([]domain.EvalSession, error) {

--- a/backend/internal/repository/sqlc/eval_sessions.sql.go
+++ b/backend/internal/repository/sqlc/eval_sessions.sql.go
@@ -190,6 +190,57 @@ func (q *Queries) ListEvalSessions(ctx context.Context, arg ListEvalSessionsPara
 	return items, nil
 }
 
+const listEvalSessionsByWorkspaceID = `-- name: ListEvalSessionsByWorkspaceID :many
+SELECT id, status, repetitions, aggregation_config, success_threshold_config, routing_task_snapshot, schema_version, created_at, started_at, finished_at, updated_at
+FROM eval_sessions
+WHERE EXISTS (
+    SELECT 1
+    FROM runs
+    WHERE runs.eval_session_id = eval_sessions.id
+      AND runs.workspace_id = $1
+)
+ORDER BY created_at DESC, id DESC
+LIMIT $3 OFFSET $2
+`
+
+type ListEvalSessionsByWorkspaceIDParams struct {
+	WorkspaceID  uuid.UUID
+	ResultOffset int32
+	ResultLimit  int32
+}
+
+func (q *Queries) ListEvalSessionsByWorkspaceID(ctx context.Context, arg ListEvalSessionsByWorkspaceIDParams) ([]EvalSession, error) {
+	rows, err := q.db.Query(ctx, listEvalSessionsByWorkspaceID, arg.WorkspaceID, arg.ResultOffset, arg.ResultLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []EvalSession
+	for rows.Next() {
+		var i EvalSession
+		if err := rows.Scan(
+			&i.ID,
+			&i.Status,
+			&i.Repetitions,
+			&i.AggregationConfig,
+			&i.SuccessThresholdConfig,
+			&i.RoutingTaskSnapshot,
+			&i.SchemaVersion,
+			&i.CreatedAt,
+			&i.StartedAt,
+			&i.FinishedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listRunsByEvalSessionID = `-- name: ListRunsByEvalSessionID :many
 SELECT id, organization_id, workspace_id, challenge_pack_version_id, challenge_input_set_id, created_by_user_id, name, status, execution_mode, temporal_workflow_id, temporal_run_id, execution_plan, queued_at, started_at, finished_at, cancelled_at, failed_at, created_at, updated_at, official_pack_mode, eval_session_id
 FROM runs

--- a/backend/internal/repository/sqlc/querier.go
+++ b/backend/internal/repository/sqlc/querier.go
@@ -66,6 +66,7 @@ type Querier interface {
 	ListChallengeInputSetsByVersionID(ctx context.Context, arg ListChallengeInputSetsByVersionIDParams) ([]ListChallengeInputSetsByVersionIDRow, error)
 	ListChallengePacks(ctx context.Context) ([]ListChallengePacksRow, error)
 	ListEvalSessions(ctx context.Context, arg ListEvalSessionsParams) ([]EvalSession, error)
+	ListEvalSessionsByWorkspaceID(ctx context.Context, arg ListEvalSessionsByWorkspaceIDParams) ([]EvalSession, error)
 	ListJudgeResultsByRunAgentAndEvaluationSpec(ctx context.Context, arg ListJudgeResultsByRunAgentAndEvaluationSpecParams) ([]ListJudgeResultsByRunAgentAndEvaluationSpecRow, error)
 	ListLLMJudgeResultsByRunAgentAndEvaluationSpec(ctx context.Context, arg ListLLMJudgeResultsByRunAgentAndEvaluationSpecParams) ([]LlmJudgeResult, error)
 	ListMetricResultsByRunAgentAndEvaluationSpec(ctx context.Context, arg ListMetricResultsByRunAgentAndEvaluationSpecParams) ([]ListMetricResultsByRunAgentAndEvaluationSpecRow, error)

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -1841,6 +1841,50 @@ paths:
                 $ref: "#/components/schemas/CreateRunErrorResponse"
 
   /v1/eval-sessions:
+    get:
+      operationId: listEvalSessions
+      tags: [EvalSessions]
+      summary: List eval sessions for a workspace
+      description: >
+        Lists recent eval sessions for the requested workspace, including child-run
+        summary counts and aggregation-readiness warnings.
+      security:
+        - bearerJWT: []
+      parameters:
+        - in: query
+          name: workspace_id
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - in: query
+          name: limit
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+        - in: query
+          name: offset
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        "200":
+          description: Eval sessions for the workspace
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListEvalSessionsResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
     post:
       operationId: createEvalSession
       tags: [EvalSessions]
@@ -1884,6 +1928,43 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EvalSessionValidationEnvelope"
+
+  /v1/eval-sessions/{evalSessionID}:
+    get:
+      operationId: getEvalSession
+      tags: [EvalSessions]
+      summary: Get eval session details
+      description: >
+        Returns the eval session, attached child runs, child-run summary counts,
+        and aggregation-readiness warnings for inspection workflows.
+      security:
+        - bearerJWT: []
+      parameters:
+        - in: path
+          name: evalSessionID
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Eval session details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EvalSessionDetail"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          description: Eval session not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
 
   /v1/runs/{runID}:
     get:
@@ -5061,6 +5142,143 @@ components:
           type: string
         message:
           type: string
+
+    ListEvalSessionsResponse:
+      type: object
+      required: [items, limit, offset]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/EvalSessionListItem"
+        limit:
+          type: integer
+        offset:
+          type: integer
+
+    EvalSessionListItem:
+      type: object
+      required: [eval_session, summary, aggregate_result, evidence_warnings]
+      properties:
+        eval_session:
+          $ref: "#/components/schemas/EvalSessionResponse"
+        summary:
+          $ref: "#/components/schemas/EvalSessionRunSummary"
+        aggregate_result:
+          $ref: "#/components/schemas/EvalSessionAggregateResult"
+        evidence_warnings:
+          type: array
+          items:
+            type: string
+
+    EvalSessionDetail:
+      type: object
+      required: [eval_session, runs, summary, aggregate_result, evidence_warnings]
+      properties:
+        eval_session:
+          $ref: "#/components/schemas/EvalSessionResponse"
+        runs:
+          type: array
+          items:
+            $ref: "#/components/schemas/EvalSessionChildRun"
+        summary:
+          $ref: "#/components/schemas/EvalSessionRunSummary"
+        aggregate_result:
+          $ref: "#/components/schemas/EvalSessionAggregateResult"
+        evidence_warnings:
+          type: array
+          items:
+            type: string
+
+    EvalSessionRunSummary:
+      type: object
+      required: [run_counts]
+      properties:
+        run_counts:
+          $ref: "#/components/schemas/EvalSessionRunCounts"
+
+    EvalSessionRunCounts:
+      type: object
+      required: [total, draft, queued, provisioning, running, scoring, completed, failed, cancelled]
+      properties:
+        total:
+          type: integer
+        draft:
+          type: integer
+        queued:
+          type: integer
+        provisioning:
+          type: integer
+        running:
+          type: integer
+        scoring:
+          type: integer
+        completed:
+          type: integer
+        failed:
+          type: integer
+        cancelled:
+          type: integer
+
+    EvalSessionAggregateResult:
+      description: Reserved for future aggregated session result documents. Null until aggregation persistence lands.
+      anyOf:
+        - type: object
+          additionalProperties: true
+        - type: "null"
+
+    EvalSessionChildRun:
+      type: object
+      required:
+        [id, workspace_id, challenge_pack_version_id, official_pack_mode, name, status, execution_mode, created_at, updated_at, links]
+      properties:
+        id:
+          type: string
+          format: uuid
+        workspace_id:
+          type: string
+          format: uuid
+        challenge_pack_version_id:
+          type: string
+          format: uuid
+        challenge_input_set_id:
+          type: string
+          format: uuid
+        eval_session_id:
+          type: string
+          format: uuid
+        official_pack_mode:
+          type: string
+          enum: [full, suite_only]
+        name:
+          type: string
+        status:
+          $ref: "#/components/schemas/RunStatus"
+        execution_mode:
+          type: string
+        queued_at:
+          type: string
+          format: date-time
+        started_at:
+          type: string
+          format: date-time
+        finished_at:
+          type: string
+          format: date-time
+        cancelled_at:
+          type: string
+          format: date-time
+        failed_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        links:
+          $ref: "#/components/schemas/RunLinks"
 
     CreateRunResponse:
       type: object

--- a/scripts/smoke/eval-session-read.sh
+++ b/scripts/smoke/eval-session-read.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${ROOT_DIR}/backend"
+
+if [[ -f "${BACKEND_DIR}/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${BACKEND_DIR}/.env"
+  set +a
+elif [[ -f "${BACKEND_DIR}/.env.example" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${BACKEND_DIR}/.env.example"
+  set +a
+fi
+
+export API_BASE_URL="${API_BASE_URL:-http://localhost:8080}"
+export WORKSPACE_ID="${WORKSPACE_ID:-22222222-2222-2222-2222-222222222222}"
+export USER_ID="${USER_ID:-33333333-3333-3333-3333-333333333333}"
+export CHALLENGE_PACK_VERSION_ID="${CHALLENGE_PACK_VERSION_ID:-55555555-5555-5555-5555-555555555555}"
+export CHALLENGE_INPUT_SET_ID="${CHALLENGE_INPUT_SET_ID:-abababab-abab-abab-abab-abababababab}"
+export AGENT_BUILD_VERSION_ID="${AGENT_BUILD_VERSION_ID:-dddddddd-dddd-dddd-dddd-dddddddddddd}"
+export REPETITIONS="${REPETITIONS:-3}"
+export SECOND_REPETITIONS="${SECOND_REPETITIONS:-}"
+export EXPECT_STATUS="${EXPECT_STATUS:-queued}"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "$1 is required" >&2
+    exit 1
+  fi
+}
+
+require_cmd curl
+require_cmd jq
+
+create_session() {
+  local repetitions="$1"
+  local name="$2"
+
+  curl -fsS \
+    -X POST "${API_BASE_URL}/v1/eval-sessions" \
+    -H "Content-Type: application/json" \
+    -H "X-Agentclash-User-Id: ${USER_ID}" \
+    -H "X-Agentclash-Workspace-Memberships: ${WORKSPACE_ID}:workspace_admin" \
+    -d '{
+      "workspace_id": "'"${WORKSPACE_ID}"'",
+      "challenge_pack_version_id": "'"${CHALLENGE_PACK_VERSION_ID}"'",
+      "challenge_input_set_id": "'"${CHALLENGE_INPUT_SET_ID}"'",
+      "participants": [
+        {
+          "agent_build_version_id": "'"${AGENT_BUILD_VERSION_ID}"'",
+          "label": "Primary"
+        }
+      ],
+      "execution_mode": "single_agent",
+      "name": "'"${name}"'",
+      "eval_session": {
+        "repetitions": '"${repetitions}"',
+        "aggregation": {
+          "method": "mean",
+          "report_variance": true,
+          "confidence_interval": 0.95
+        },
+        "routing_task_snapshot": {
+          "routing": { "mode": "single_agent" },
+          "task": { "pack_version": "v1", "input_set": "default" }
+        },
+        "schema_version": 1
+      }
+    }'
+}
+
+inspect_session() {
+  local session_id="$1"
+  local expected_repetitions="$2"
+  local detail_file="/tmp/agentclash-eval-session-${session_id}.json"
+
+  curl -fsS \
+    -H "X-Agentclash-User-Id: ${USER_ID}" \
+    -H "X-Agentclash-Workspace-Memberships: ${WORKSPACE_ID}:workspace_admin" \
+    "${API_BASE_URL}/v1/eval-sessions/${session_id}" >"${detail_file}"
+
+  local status
+  status="$(jq -r '.eval_session.status' "${detail_file}")"
+  local total_runs
+  total_runs="$(jq -r '.summary.run_counts.total' "${detail_file}")"
+  local queued_runs
+  queued_runs="$(jq -r '.summary.run_counts.queued' "${detail_file}")"
+  local listed_runs
+  listed_runs="$(jq -r '.runs | length' "${detail_file}")"
+  local aggregate_is_null
+  aggregate_is_null="$(jq -r '.aggregate_result == null' "${detail_file}")"
+  local warning_present
+  warning_present="$(jq -r '[.evidence_warnings[]? | contains("aggregate result unavailable")] | any' "${detail_file}")"
+
+  if [[ "${status}" != "${EXPECT_STATUS}" ]]; then
+    echo "eval session ${session_id} status = ${status}, want ${EXPECT_STATUS}" >&2
+    cat "${detail_file}" >&2
+    exit 1
+  fi
+
+  if [[ "${total_runs}" != "${expected_repetitions}" ]]; then
+    echo "eval session ${session_id} total runs = ${total_runs}, want ${expected_repetitions}" >&2
+    cat "${detail_file}" >&2
+    exit 1
+  fi
+
+  if [[ "${queued_runs}" != "${expected_repetitions}" && "${EXPECT_STATUS}" == "queued" ]]; then
+    echo "eval session ${session_id} queued runs = ${queued_runs}, want ${expected_repetitions}" >&2
+    cat "${detail_file}" >&2
+    exit 1
+  fi
+
+  if [[ "${listed_runs}" != "${expected_repetitions}" ]]; then
+    echo "eval session ${session_id} run list length = ${listed_runs}, want ${expected_repetitions}" >&2
+    cat "${detail_file}" >&2
+    exit 1
+  fi
+
+  if [[ "${aggregate_is_null}" != "true" ]]; then
+    echo "eval session ${session_id} aggregate_result should be null" >&2
+    cat "${detail_file}" >&2
+    exit 1
+  fi
+
+  if [[ "${warning_present}" != "true" ]]; then
+    echo "eval session ${session_id} missing aggregate-result evidence warning" >&2
+    cat "${detail_file}" >&2
+    exit 1
+  fi
+}
+
+echo "==> Checking API health"
+curl -fsS "${API_BASE_URL}/healthz" >/dev/null
+
+echo "==> Seeding local eval-session fixture"
+"${ROOT_DIR}/scripts/dev/seed-local-run-fixture.sh" >/dev/null
+
+echo "==> Creating primary eval session"
+first_response="$(create_session "${REPETITIONS}" "Scale verification primary")"
+first_session_id="$(jq -r '.eval_session.id' <<<"${first_response}")"
+if [[ -z "${first_session_id}" || "${first_session_id}" == "null" ]]; then
+  echo "failed to parse primary eval session id" >&2
+  echo "${first_response}" >&2
+  exit 1
+fi
+
+inspect_session "${first_session_id}" "${REPETITIONS}"
+
+second_session_id=""
+if [[ -n "${SECOND_REPETITIONS}" ]]; then
+  echo "==> Creating secondary eval session"
+  second_response="$(create_session "${SECOND_REPETITIONS}" "Scale verification secondary")"
+  second_session_id="$(jq -r '.eval_session.id' <<<"${second_response}")"
+  if [[ -z "${second_session_id}" || "${second_session_id}" == "null" ]]; then
+    echo "failed to parse secondary eval session id" >&2
+    echo "${second_response}" >&2
+    exit 1
+  fi
+  inspect_session "${second_session_id}" "${SECOND_REPETITIONS}"
+fi
+
+echo "==> Listing eval sessions"
+list_file="/tmp/agentclash-eval-session-list.json"
+curl -fsS \
+  -H "X-Agentclash-User-Id: ${USER_ID}" \
+  -H "X-Agentclash-Workspace-Memberships: ${WORKSPACE_ID}:workspace_admin" \
+  "${API_BASE_URL}/v1/eval-sessions?workspace_id=${WORKSPACE_ID}&limit=10" >"${list_file}"
+
+first_present="$(jq --arg id "${first_session_id}" '[.items[].eval_session.id == $id] | any' "${list_file}")"
+if [[ "${first_present}" != "true" ]]; then
+  echo "primary eval session ${first_session_id} missing from list response" >&2
+  cat "${list_file}" >&2
+  exit 1
+fi
+
+if [[ -n "${second_session_id}" ]]; then
+  second_present="$(jq --arg id "${second_session_id}" '[.items[].eval_session.id == $id] | any' "${list_file}")"
+  if [[ "${second_present}" != "true" ]]; then
+    echo "secondary eval session ${second_session_id} missing from list response" >&2
+    cat "${list_file}" >&2
+    exit 1
+  fi
+fi
+
+echo "==> Eval session read smoke passed"
+echo "    first_session_id: ${first_session_id}"
+if [[ -n "${second_session_id}" ]]; then
+  echo "    second_session_id: ${second_session_id}"
+fi

--- a/testing/codex-issue-149-repeated-eval-verification-matrix.md
+++ b/testing/codex-issue-149-repeated-eval-verification-matrix.md
@@ -1,0 +1,48 @@
+# #149 Repeated-Eval Verification Matrix
+
+This matrix is the trust contract for repeated eval sessions. It separates low-cost deterministic coverage that should stay green in everyday development from opt-in manual scale checks that prove the session read surfaces remain trustworthy as repetition counts grow.
+
+## Read Surfaces Under Test
+- `POST /v1/eval-sessions`
+- `GET /v1/eval-sessions/{evalSessionID}`
+- `GET /v1/eval-sessions?workspace_id={workspaceID}&limit={n}`
+- `./scripts/smoke/eval-session-read.sh`
+
+## Expected Invariants
+- Every created eval session has exactly `repetitions` attached child runs.
+- Child runs are returned in deterministic creation order.
+- `summary.run_counts.total` equals the number of attached child runs.
+- Freshly created sessions surface queued child-run counts explicitly.
+- `aggregate_result` remains `null` until session-level aggregation persistence lands.
+- `evidence_warnings` explain missing aggregate evidence instead of leaving the field ambiguous.
+- Single-run mode (`repetitions=1`) uses the same read surfaces and summary math as repeated mode.
+
+## CI Matrix
+| Tier | Repetitions | Coverage | Expected Outcome |
+|---|---:|---|---|
+| Single-run compatibility | 1 | API/repository tests plus local smoke when needed | Session read returns one child run, `total=1`, `queued=1`, `aggregate_result=null`, and an aggregate-evidence warning. |
+| Small repeated run | 3 | API/repository tests plus `REPETITIONS=3 ./scripts/smoke/eval-session-read.sh` | Session read returns three child runs, ordered consistently, with `total=3`, `queued=3`. |
+| Small comparison-style inspection | 3 then 5 | `REPETITIONS=3 SECOND_REPETITIONS=5 ./scripts/smoke/eval-session-read.sh` | List read shows both sessions so a developer can inspect session-vs-session state side by side without querying raw tables. |
+
+## Manual Scale Matrix
+| Tier | Repetitions | Command | Expected Outcome |
+|---|---:|---|---|
+| Medium | 10 | `REPETITIONS=10 ./scripts/smoke/eval-session-read.sh` | Detail and list reads remain responsive; summary counts stay exact; warnings remain deterministic. |
+| Medium-high | 30 | `REPETITIONS=30 ./scripts/smoke/eval-session-read.sh` | No missing runs; no ordering drift; list surface still includes the created session. |
+| Large | 50 | `REPETITIONS=50 ./scripts/smoke/eval-session-read.sh` | Same invariants as medium, used as the default manual stress rehearsal. |
+| Very large | 100 | `REPETITIONS=100 ./scripts/smoke/eval-session-read.sh` | Used sparingly to prove attachment/read paths hold at the top end of the planned scale tier. |
+
+## Manual Checklist
+1. Start the local stack with `./scripts/dev/start-local-stack.sh`.
+2. Run the CI-matrix smoke commands above and confirm the script reports success.
+3. Run one medium or larger repetition tier and confirm:
+   - detail read returns the requested repetition count
+   - list read contains the created session
+   - `aggregate_result` is still `null`
+   - `evidence_warnings` explains the missing aggregate result
+4. Run the two-session smoke command (`REPETITIONS=3 SECOND_REPETITIONS=5`) and confirm both sessions appear in list order for side-by-side inspection.
+5. Shut the local stack back down when finished.
+
+## Notes
+- Until `#361` lands, the read-model contract intentionally reports `aggregate_result: null` and uses `evidence_warnings` to make that absence explicit.
+- When `#361` and `#362` land, extend this matrix rather than replacing it so single-run compatibility and scale-tier inspection stay locked.

--- a/testing/codex-issue-363-scale-aware-verification.md
+++ b/testing/codex-issue-363-scale-aware-verification.md
@@ -1,0 +1,101 @@
+# codex/issue-363-scale-aware-verification — Test Contract
+
+## Functional Behavior
+- Add authenticated eval-session read surfaces that let a developer inspect repeated-eval state after creation without querying raw tables.
+- Expose a stable `GET /v1/eval-sessions/{evalSessionID}` read path that returns:
+  - the eval-session metadata and locked config snapshots
+  - child runs in deterministic creation order
+  - a session summary block that reports child-run counts by status
+  - an `aggregate_result` field that is `null` until aggregation work lands, while remaining shape-stable for future issues
+  - `evidence_warnings` that explain missing aggregate/session evidence instead of failing silently
+- Expose a stable `GET /v1/eval-sessions` list path that returns recent sessions with enough metadata to inspect scale-tier coverage and status at a glance.
+- Keep the read-model response compatible with future aggregation work from `#361` and metric-routing/comparison work from `#362` by avoiding issue-specific ad hoc fields.
+- Add a scriptable smoke flow that exercises create -> inspect for eval sessions against a local stack.
+- Add a written repeated-eval verification matrix under `testing/` for parent issue `#149` that covers:
+  - `repetitions=1`
+  - `repetitions=3-5`
+  - `repetitions=10-30`
+  - `repetitions=50-100`
+- Split low-cost deterministic CI checks from opt-in/manual higher-scale checks.
+- Make single-run compatibility explicit in the verification matrix rather than implied.
+
+## Unit Tests
+- API handler tests for:
+  - listing eval sessions
+  - fetching one eval session with child runs
+  - 404 on missing eval session
+  - auth failure behavior matching existing protected endpoints
+- Read-model/manager tests for:
+  - deterministic run ordering
+  - summary counts by status
+  - `aggregate_result` remaining `null` when no aggregated document exists yet
+  - evidence warnings when aggregation/read evidence is not yet available
+  - list pagination defaults or limit handling, if introduced
+
+## Integration / Functional Tests
+- Repository integration test that creates an eval session with queued runs, reads it back through the new read path, and verifies session metadata plus child-run ordering/status counts.
+- API integration test proving a create -> get flow returns the same locked eval-session config snapshots that were persisted.
+- Functional verification that the smoke script can create a session, fetch the session detail, and confirm the expected queued-run counts.
+
+## Smoke Tests
+- `cd /Users/atharva/agentclash-issue-363/backend && go test -short -race -count=1 ./internal/api ./internal/repository`
+- `cd /Users/atharva/agentclash-issue-363/backend && go test -short -race -count=1 ./...`
+- With the local stack running:
+  - `cd /Users/atharva/agentclash-issue-363 && ./scripts/smoke/eval-session-create.sh`
+  - `cd /Users/atharva/agentclash-issue-363 && ./scripts/smoke/eval-session-read.sh`
+
+## E2E Tests
+- N/A — not applicable for this slice because the user-facing work is backend/API verification plus scriptable smoke coverage, not a browser workflow.
+
+## Manual / cURL Tests
+```bash
+# Start the local stack only if needed for API verification
+cd /Users/atharva/agentclash-issue-363
+
+# Create a session
+curl -i -X POST http://localhost:8080/v1/eval-sessions \
+  -H "Content-Type: application/json" \
+  -H "X-Agentclash-User-Id: <user-id>" \
+  -H "X-Agentclash-Workspace-Memberships: <workspace-id>:workspace_admin" \
+  -d '{
+    "workspace_id": "<workspace-id>",
+    "challenge_pack_version_id": "<pack-version-id>",
+    "challenge_input_set_id": "<input-set-id>",
+    "participants": [
+      {
+        "agent_build_version_id": "<agent-build-version-id>",
+        "label": "Primary"
+      }
+    ],
+    "execution_mode": "single_agent",
+    "name": "Verification matrix sanity check",
+    "eval_session": {
+      "repetitions": 3,
+      "aggregation": {
+        "method": "mean",
+        "report_variance": true,
+        "confidence_interval": 0.95
+      },
+      "routing_task_snapshot": {
+        "routing": { "mode": "single_agent" },
+        "task": { "pack_version": "v1", "input_set": "default" }
+      },
+      "schema_version": 1
+    }
+  }'
+
+# Inspect the detail read model
+curl -i http://localhost:8080/v1/eval-sessions/<eval-session-id> \
+  -H "X-Agentclash-User-Id: <user-id>" \
+  -H "X-Agentclash-Workspace-Memberships: <workspace-id>:workspace_admin"
+
+# Inspect the list read model
+curl -i "http://localhost:8080/v1/eval-sessions?limit=10" \
+  -H "X-Agentclash-User-Id: <user-id>" \
+  -H "X-Agentclash-Workspace-Memberships: <workspace-id>:workspace_admin"
+
+# Expected:
+# - detail response returns eval_session metadata, ordered child runs, summary counts, aggregate_result=null, and non-empty evidence_warnings
+# - list response includes the created session
+# - the summary block reports queued child runs for a freshly created session
+```


### PR DESCRIPTION
## Summary
- add stable eval-session read surfaces for list/detail inspection, including child-run summary counts, `aggregate_result: null`, and explicit evidence warnings until aggregation persistence lands
- add a workspace-filtered eval-session list query plus backend tests covering auth, ordering, and the new response shape
- add a live curl smoke script and a written `#149` repeated-eval verification matrix across single, small, medium, and large repetition tiers
- document the new read endpoints in OpenAPI

## Why
Issue #363 is the trust layer for repeated eval sessions. `main` could create eval sessions, but developers still had to infer state from raw tables or child runs. This PR adds a stable inspection path plus an explicit verification matrix so repeated-eval support is inspectable and testable before aggregation math lands.

## Notes
- `aggregate_result` is intentionally `null` for now. The field is present and documented so `#361` can populate it later without reshaping the read API.
- `evidence_warnings` explicitly call out missing aggregate evidence instead of leaving that absence ambiguous.

## Test Contract
- locked contract: `testing/codex-issue-363-scale-aware-verification.md`
- verification matrix: `testing/codex-issue-149-repeated-eval-verification-matrix.md`

## Validation
- [x] `cd backend && go test ./internal/api ./internal/repository`
- [x] `cd backend && go test ./...`
- [x] `bash -n scripts/smoke/eval-session-read.sh`
- [x] `npx @redocly/cli lint docs/api-server/openapi.yaml` (passes with pre-existing warnings only)
- [x] `./scripts/smoke/eval-session-create.sh`
- [x] `SECOND_REPETITIONS=5 ./scripts/smoke/eval-session-read.sh`

Closes #363
