### PR TITLE
Add eval-session workflow fan-out orchestration

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -84,7 +84,7 @@ func main() {
 		repo,
 		api.NewTemporalRunWorkflowStarter(temporalClient),
 		budgetChecker,
-	)
+	).WithEvalSessionWorkflowStarter(api.NewTemporalEvalSessionWorkflowStarter(temporalClient))
 	providerRouter := provider.NewDefaultRouter(nil, provider.EnvCredentialResolver{})
 	insightsLimiter := ratelimit.NewLimiter(ratelimit.Config{
 		DefaultRPS:           10.0,

--- a/backend/internal/api/eval_session_service.go
+++ b/backend/internal/api/eval_session_service.go
@@ -309,6 +309,9 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 	if err != nil {
 		return CreateEvalSessionResult{}, fmt.Errorf("create eval session with queued runs: %w", err)
 	}
+	if err := m.evalSessionWorkflowStarter.StartEvalSessionWorkflow(ctx, createResult.Session.ID); err != nil {
+		return CreateEvalSessionResult{}, fmt.Errorf("start eval session workflow for session %s: %w", createResult.Session.ID, err)
+	}
 
 	runIDs := make([]uuid.UUID, 0, len(createResult.Runs))
 	for _, run := range createResult.Runs {

--- a/backend/internal/api/run_service.go
+++ b/backend/internal/api/run_service.go
@@ -32,12 +32,23 @@ type RunWorkflowStarter interface {
 	StartRunWorkflow(ctx context.Context, runID uuid.UUID) error
 }
 
+type EvalSessionWorkflowStarter interface {
+	StartEvalSessionWorkflow(ctx context.Context, evalSessionID uuid.UUID) error
+}
+
 type RunCreationManager struct {
-	authorizer      WorkspaceAuthorizer
-	repo            RunCreationRepository
-	workflowStarter RunWorkflowStarter
-	budgetChecker   budget.BudgetChecker
-	now             func() time.Time
+	authorizer                 WorkspaceAuthorizer
+	repo                       RunCreationRepository
+	workflowStarter            RunWorkflowStarter
+	evalSessionWorkflowStarter EvalSessionWorkflowStarter
+	budgetChecker              budget.BudgetChecker
+	now                        func() time.Time
+}
+
+type noopEvalSessionWorkflowStarter struct{}
+
+func (noopEvalSessionWorkflowStarter) StartEvalSessionWorkflow(context.Context, uuid.UUID) error {
+	return nil
 }
 
 func NewRunCreationManager(
@@ -50,12 +61,23 @@ func NewRunCreationManager(
 		budgetChecker = budget.NoopChecker{}
 	}
 	return &RunCreationManager{
-		authorizer:      authorizer,
-		repo:            repo,
-		workflowStarter: workflowStarter,
-		budgetChecker:   budgetChecker,
-		now:             time.Now,
+		authorizer:                 authorizer,
+		repo:                       repo,
+		workflowStarter:            workflowStarter,
+		evalSessionWorkflowStarter: noopEvalSessionWorkflowStarter{},
+		budgetChecker:              budgetChecker,
+		now:                        time.Now,
 	}
+}
+
+func (m *RunCreationManager) WithEvalSessionWorkflowStarter(starter EvalSessionWorkflowStarter) *RunCreationManager {
+	if starter == nil {
+		m.evalSessionWorkflowStarter = noopEvalSessionWorkflowStarter{}
+		return m
+	}
+
+	m.evalSessionWorkflowStarter = starter
+	return m
 }
 
 func (m *RunCreationManager) CreateRun(ctx context.Context, caller Caller, input CreateRunInput) (CreateRunResult, error) {

--- a/backend/internal/api/run_service_test.go
+++ b/backend/internal/api/run_service_test.go
@@ -329,6 +329,83 @@ func TestRunCreationManagerCreateEvalSessionCreatesQueuedRuns(t *testing.T) {
 	}
 }
 
+func TestRunCreationManagerCreateEvalSessionStartsEvalSessionWorkflow(t *testing.T) {
+	workspaceID := uuid.New()
+	challengePackVersionID := uuid.New()
+	challengeInputSetID := uuid.New()
+	buildVersionID := uuid.New()
+	deploymentID := uuid.New()
+	sessionID := uuid.New()
+	caller := Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}
+
+	repo := &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{ID: challengePackVersionID},
+		challengeInputSets: []repository.ChallengeInputSetSummary{
+			{ID: challengeInputSetID, ChallengePackVersionID: challengePackVersionID},
+		},
+		challengeIdentityIDs: []uuid.UUID{uuid.New()},
+		deploymentsByBuildVersion: []repository.BuildVersionRunnableDeployment{
+			{
+				AgentBuildVersionID: buildVersionID,
+				Deployment: repository.RunnableDeployment{
+					ID:                        deploymentID,
+					OrganizationID:            uuid.New(),
+					WorkspaceID:               workspaceID,
+					Name:                      "Support Agent Deployment",
+					AgentDeploymentSnapshotID: uuid.New(),
+				},
+			},
+		},
+		createEvalSessionWithRunsResult: repository.CreateEvalSessionWithQueuedRunsResult{
+			Session: domain.EvalSession{
+				ID:            sessionID,
+				Status:        domain.EvalSessionStatusQueued,
+				Repetitions:   1,
+				SchemaVersion: 1,
+			},
+			Runs: []domain.Run{
+				{ID: uuid.New(), EvalSessionID: &sessionID},
+			},
+		},
+	}
+	evalStarter := &fakeEvalSessionWorkflowStarter{}
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, &fakeRunWorkflowStarter{}, nil).
+		WithEvalSessionWorkflowStarter(evalStarter)
+
+	_, err := manager.CreateEvalSession(context.Background(), caller, CreateEvalSessionInput{
+		WorkspaceID:            workspaceID,
+		ChallengePackVersionID: challengePackVersionID,
+		Participants: []EvalSessionParticipantInput{
+			{AgentBuildVersionID: buildVersionID, Label: "Primary"},
+		},
+		ExecutionMode: "single_agent",
+		EvalSession: CreateEvalSessionConfigInput{
+			Repetitions: 1,
+			Aggregation: EvalSessionAggregationInput{
+				Method:             "mean",
+				ReportVariance:     true,
+				ConfidenceInterval: 0.95,
+			},
+			RoutingTaskSnapshot: EvalSessionRoutingTaskSnapshotInput{
+				Routing: json.RawMessage(`{"mode":"single_agent"}`),
+				Task:    json.RawMessage(`{"pack_version":"v1"}`),
+			},
+			SchemaVersion: 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateEvalSession returned error: %v", err)
+	}
+	if evalStarter.startedEvalSessionID != sessionID {
+		t.Fatalf("started eval session id = %s, want %s", evalStarter.startedEvalSessionID, sessionID)
+	}
+}
+
 func TestRunCreationManagerCreateEvalSessionRejectsUnresolvedBuildVersion(t *testing.T) {
 	workspaceID := uuid.New()
 	challengePackVersionID := uuid.New()
@@ -1167,19 +1244,19 @@ func TestRunCreationManagerSkipsInactiveSuiteCasesWhenExpandingSelections(t *tes
 }
 
 type fakeRunCreationRepository struct {
-	challengePackVersion           repository.RunnableChallengePackVersion
-	challengePackVersionErr        error
-	challengeInputSet              repository.ChallengeInputSet
-	challengeInputSetErr           error
-	challengeInputSets             []repository.ChallengeInputSetSummary
-	challengeIdentityIDs           []uuid.UUID
-	deployments                    []repository.RunnableDeployment
-	deploymentsByBuildVersion      []repository.BuildVersionRunnableDeployment
-	regressionSuites               map[uuid.UUID]repository.RegressionSuite
-	regressionCasesBySuite         map[uuid.UUID][]repository.RegressionCase
-	regressionCases                map[uuid.UUID]repository.RegressionCase
-	createResult                   repository.CreateQueuedRunResult
-	createParams                   *repository.CreateQueuedRunParams
+	challengePackVersion            repository.RunnableChallengePackVersion
+	challengePackVersionErr         error
+	challengeInputSet               repository.ChallengeInputSet
+	challengeInputSetErr            error
+	challengeInputSets              []repository.ChallengeInputSetSummary
+	challengeIdentityIDs            []uuid.UUID
+	deployments                     []repository.RunnableDeployment
+	deploymentsByBuildVersion       []repository.BuildVersionRunnableDeployment
+	regressionSuites                map[uuid.UUID]repository.RegressionSuite
+	regressionCasesBySuite          map[uuid.UUID][]repository.RegressionCase
+	regressionCases                 map[uuid.UUID]repository.RegressionCase
+	createResult                    repository.CreateQueuedRunResult
+	createParams                    *repository.CreateQueuedRunParams
 	createEvalSessionWithRunsResult repository.CreateEvalSessionWithQueuedRunsResult
 	createEvalSessionWithRunsParams *repository.CreateEvalSessionWithQueuedRunsParams
 }
@@ -1245,5 +1322,15 @@ type fakeRunWorkflowStarter struct {
 
 func (f *fakeRunWorkflowStarter) StartRunWorkflow(_ context.Context, runID uuid.UUID) error {
 	f.startedRunID = runID
+	return f.err
+}
+
+type fakeEvalSessionWorkflowStarter struct {
+	startedEvalSessionID uuid.UUID
+	err                  error
+}
+
+func (f *fakeEvalSessionWorkflowStarter) StartEvalSessionWorkflow(_ context.Context, evalSessionID uuid.UUID) error {
+	f.startedEvalSessionID = evalSessionID
 	return f.err
 }

--- a/backend/internal/api/temporal.go
+++ b/backend/internal/api/temporal.go
@@ -34,6 +34,25 @@ func (s TemporalRunWorkflowStarter) StartRunWorkflow(ctx context.Context, runID 
 	return err
 }
 
+type TemporalEvalSessionWorkflowStarter struct {
+	client TemporalClient
+}
+
+func NewTemporalEvalSessionWorkflowStarter(client TemporalClient) TemporalEvalSessionWorkflowStarter {
+	return TemporalEvalSessionWorkflowStarter{client: client}
+}
+
+func (s TemporalEvalSessionWorkflowStarter) StartEvalSessionWorkflow(ctx context.Context, evalSessionID uuid.UUID) error {
+	workflowID := fmt.Sprintf("%s/%s", workflow.EvalSessionWorkflowName, evalSessionID)
+	_, err := s.client.ExecuteWorkflow(ctx, temporalsdk.StartWorkflowOptions{
+		ID:        workflowID,
+		TaskQueue: workflow.RunWorkflowName,
+	}, workflow.EvalSessionWorkflowName, workflow.EvalSessionWorkflowInput{
+		EvalSessionID: evalSessionID,
+	})
+	return err
+}
+
 type TemporalPlaygroundWorkflowStarter struct {
 	client TemporalClient
 }

--- a/backend/internal/api/temporal.go
+++ b/backend/internal/api/temporal.go
@@ -27,7 +27,7 @@ func (s TemporalRunWorkflowStarter) StartRunWorkflow(ctx context.Context, runID 
 	workflowID := fmt.Sprintf("%s/%s", workflow.RunWorkflowName, runID)
 	_, err := s.client.ExecuteWorkflow(ctx, temporalsdk.StartWorkflowOptions{
 		ID:        workflowID,
-		TaskQueue: workflow.RunWorkflowName,
+		TaskQueue: workflow.WorkflowTaskQueue,
 	}, workflow.RunWorkflowName, workflow.RunWorkflowInput{
 		RunID: runID,
 	})
@@ -46,7 +46,7 @@ func (s TemporalEvalSessionWorkflowStarter) StartEvalSessionWorkflow(ctx context
 	workflowID := fmt.Sprintf("%s/%s", workflow.EvalSessionWorkflowName, evalSessionID)
 	_, err := s.client.ExecuteWorkflow(ctx, temporalsdk.StartWorkflowOptions{
 		ID:        workflowID,
-		TaskQueue: workflow.RunWorkflowName,
+		TaskQueue: workflow.WorkflowTaskQueue,
 	}, workflow.EvalSessionWorkflowName, workflow.EvalSessionWorkflowInput{
 		EvalSessionID: evalSessionID,
 	})
@@ -65,7 +65,7 @@ func (s TemporalPlaygroundWorkflowStarter) StartPlaygroundExperimentWorkflow(ctx
 	workflowID := fmt.Sprintf("%s/%s", workflow.PlaygroundExperimentWorkflowName, experimentID)
 	_, err := s.client.ExecuteWorkflow(ctx, temporalsdk.StartWorkflowOptions{
 		ID:        workflowID,
-		TaskQueue: workflow.RunWorkflowName,
+		TaskQueue: workflow.WorkflowTaskQueue,
 	}, workflow.PlaygroundExperimentWorkflowName, workflow.PlaygroundExperimentWorkflowInput{
 		ExperimentID: experimentID,
 	})

--- a/backend/internal/api/temporal_test.go
+++ b/backend/internal/api/temporal_test.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/workflow"
+	"github.com/google/uuid"
+	temporalsdk "go.temporal.io/sdk/client"
+)
+
+func TestTemporalEvalSessionWorkflowStarterStartEvalSessionWorkflow(t *testing.T) {
+	sessionID := uuid.New()
+	client := &fakeTemporalClient{}
+
+	err := NewTemporalEvalSessionWorkflowStarter(client).StartEvalSessionWorkflow(context.Background(), sessionID)
+	if err != nil {
+		t.Fatalf("StartEvalSessionWorkflow returned error: %v", err)
+	}
+
+	if client.workflowName != workflow.EvalSessionWorkflowName {
+		t.Fatalf("workflow name = %q, want %q", client.workflowName, workflow.EvalSessionWorkflowName)
+	}
+	if client.options.ID != workflow.EvalSessionWorkflowName+"/"+sessionID.String() {
+		t.Fatalf("workflow id = %q, want %q", client.options.ID, workflow.EvalSessionWorkflowName+"/"+sessionID.String())
+	}
+	if client.options.TaskQueue != workflow.RunWorkflowName {
+		t.Fatalf("task queue = %q, want %q", client.options.TaskQueue, workflow.RunWorkflowName)
+	}
+
+	input, ok := client.args[0].(workflow.EvalSessionWorkflowInput)
+	if !ok {
+		t.Fatalf("workflow input type = %T, want workflow.EvalSessionWorkflowInput", client.args[0])
+	}
+	if input.EvalSessionID != sessionID {
+		t.Fatalf("eval session id = %s, want %s", input.EvalSessionID, sessionID)
+	}
+}
+
+type fakeTemporalClient struct {
+	options      temporalsdk.StartWorkflowOptions
+	workflowName string
+	args         []interface{}
+}
+
+func (f *fakeTemporalClient) ExecuteWorkflow(_ context.Context, options temporalsdk.StartWorkflowOptions, workflowFn interface{}, args ...interface{}) (temporalsdk.WorkflowRun, error) {
+	f.options = options
+	name, _ := workflowFn.(string)
+	f.workflowName = name
+	f.args = append([]interface{}(nil), args...)
+	return nil, nil
+}
+
+func (f *fakeTemporalClient) SignalWorkflow(context.Context, string, string, string, interface{}) error {
+	return nil
+}

--- a/backend/internal/api/temporal_test.go
+++ b/backend/internal/api/temporal_test.go
@@ -24,8 +24,8 @@ func TestTemporalEvalSessionWorkflowStarterStartEvalSessionWorkflow(t *testing.T
 	if client.options.ID != workflow.EvalSessionWorkflowName+"/"+sessionID.String() {
 		t.Fatalf("workflow id = %q, want %q", client.options.ID, workflow.EvalSessionWorkflowName+"/"+sessionID.String())
 	}
-	if client.options.TaskQueue != workflow.RunWorkflowName {
-		t.Fatalf("task queue = %q, want %q", client.options.TaskQueue, workflow.RunWorkflowName)
+	if client.options.TaskQueue != workflow.WorkflowTaskQueue {
+		t.Fatalf("task queue = %q, want %q", client.options.TaskQueue, workflow.WorkflowTaskQueue)
 	}
 
 	input, ok := client.args[0].(workflow.EvalSessionWorkflowInput)

--- a/backend/internal/worker/config.go
+++ b/backend/internal/worker/config.go
@@ -124,7 +124,7 @@ func LoadConfigFromEnv() (Config, error) {
 		TemporalAddress:       temporalAddress,
 		TemporalNamespace:     temporalNamespace,
 		Identity:              identity,
-		TaskQueue:             workflow.RunWorkflowName,
+		TaskQueue:             workflow.WorkflowTaskQueue,
 		HostedCallbackBaseURL: hostedCallbackBaseURL,
 		HostedCallbackSecret:  hostedCallbackSecret,
 		ShutdownTimeout:       shutdownTimeout,

--- a/backend/internal/workflow/activities.go
+++ b/backend/internal/workflow/activities.go
@@ -17,6 +17,9 @@ import (
 )
 
 const (
+	loadEvalSessionActivityName              = "workflow.load_eval_session"
+	listEvalSessionRunsActivityName          = "workflow.list_eval_session_runs"
+	transitionEvalSessionStatusActivityName  = "workflow.transition_eval_session_status"
 	loadRunActivityName                      = "workflow.load_run"
 	listRunAgentsActivityName                = "workflow.list_run_agents"
 	loadRunAgentActivityName                 = "workflow.load_run_agent"
@@ -37,14 +40,16 @@ const (
 )
 
 const (
-	repositoryRunNotFoundErrorType       = "repository.ErrRunNotFound"
-	repositoryRunAgentNotFoundErrorType  = "repository.ErrRunAgentNotFound"
-	repositoryFrozenExecutionContextType = "repository.ErrFrozenExecutionContext"
-	repositoryTemporalIDConflictType     = "repository.ErrTemporalIDConflict"
-	repositoryInvalidTransitionType      = "repository.ErrInvalidTransition"
-	repositoryTransitionConflictType     = "repository.ErrTransitionConflict"
-	engineFailureErrorTypePrefix         = "engine."
-	providerFailureErrorTypePrefix       = "provider."
+	repositoryEvalSessionNotFoundErrorType = "repository.ErrEvalSessionNotFound"
+	repositoryRunNotFoundErrorType         = "repository.ErrRunNotFound"
+	repositoryRunAgentNotFoundErrorType    = "repository.ErrRunAgentNotFound"
+	repositoryFrozenExecutionContextType   = "repository.ErrFrozenExecutionContext"
+	repositoryTemporalIDConflictType       = "repository.ErrTemporalIDConflict"
+	repositoryIllegalSessionTransitionType = "repository.ErrIllegalSessionTransition"
+	repositoryInvalidTransitionType        = "repository.ErrInvalidTransition"
+	repositoryTransitionConflictType       = "repository.ErrTransitionConflict"
+	engineFailureErrorTypePrefix           = "engine."
+	providerFailureErrorTypePrefix         = "provider."
 )
 
 type FakeWorkHooks struct {
@@ -65,9 +70,23 @@ type PromptEvalInvoker interface {
 }
 
 type Activities struct {
-	repo        RunRepository
-	hooks       FakeWorkHooks
-	judgeClient provider.Client
+	repo            RunRepository
+	evalSessionRepo EvalSessionRepository
+	hooks           FakeWorkHooks
+	judgeClient     provider.Client
+}
+
+type LoadEvalSessionInput struct {
+	EvalSessionID uuid.UUID `json:"eval_session_id"`
+}
+
+type ListEvalSessionRunsInput struct {
+	EvalSessionID uuid.UUID `json:"eval_session_id"`
+}
+
+type TransitionEvalSessionStatusInput struct {
+	EvalSessionID uuid.UUID                `json:"eval_session_id"`
+	ToStatus      domain.EvalSessionStatus `json:"to_status"`
 }
 
 type LoadRunInput struct {
@@ -137,11 +156,46 @@ func NewActivities(repo RunRepository, hooks FakeWorkHooks, judgeClients ...prov
 	if len(judgeClients) > 0 {
 		judgeClient = judgeClients[0]
 	}
-	return &Activities{
-		repo:        repo,
-		hooks:       hooks,
-		judgeClient: judgeClient,
+	var evalSessionRepo EvalSessionRepository
+	if candidate, ok := repo.(EvalSessionRepository); ok {
+		evalSessionRepo = candidate
 	}
+	return &Activities{
+		repo:            repo,
+		evalSessionRepo: evalSessionRepo,
+		hooks:           hooks,
+		judgeClient:     judgeClient,
+	}
+}
+
+func (a *Activities) LoadEvalSession(ctx context.Context, input LoadEvalSessionInput) (domain.EvalSession, error) {
+	if a.evalSessionRepo == nil {
+		return domain.EvalSession{}, errors.New("eval session repository is not configured")
+	}
+
+	session, err := a.evalSessionRepo.GetEvalSessionByID(ctx, input.EvalSessionID)
+	return session, wrapActivityError(err)
+}
+
+func (a *Activities) ListEvalSessionRuns(ctx context.Context, input ListEvalSessionRunsInput) ([]domain.Run, error) {
+	if a.evalSessionRepo == nil {
+		return nil, errors.New("eval session repository is not configured")
+	}
+
+	runs, err := a.evalSessionRepo.ListRunsByEvalSessionID(ctx, input.EvalSessionID)
+	return runs, wrapActivityError(err)
+}
+
+func (a *Activities) TransitionEvalSessionStatus(ctx context.Context, input TransitionEvalSessionStatusInput) (domain.EvalSession, error) {
+	if a.evalSessionRepo == nil {
+		return domain.EvalSession{}, errors.New("eval session repository is not configured")
+	}
+
+	session, err := a.evalSessionRepo.TransitionEvalSessionStatus(ctx, repository.TransitionEvalSessionStatusParams{
+		EvalSessionID: input.EvalSessionID,
+		ToStatus:      input.ToStatus,
+	})
+	return session, wrapActivityError(err)
 }
 
 func (a *Activities) LoadRun(ctx context.Context, input LoadRunInput) (domain.Run, error) {
@@ -362,6 +416,8 @@ func wrapActivityError(err error) error {
 	}
 
 	switch {
+	case errors.Is(err, repository.ErrEvalSessionNotFound):
+		return temporal.NewNonRetryableApplicationError(err.Error(), repositoryEvalSessionNotFoundErrorType, err)
 	case errors.Is(err, repository.ErrRunNotFound):
 		return temporal.NewNonRetryableApplicationError(err.Error(), repositoryRunNotFoundErrorType, err)
 	case errors.Is(err, repository.ErrRunAgentNotFound):
@@ -370,6 +426,8 @@ func wrapActivityError(err error) error {
 		return temporal.NewNonRetryableApplicationError(err.Error(), repositoryFrozenExecutionContextType, err)
 	case errors.Is(err, repository.ErrTemporalIDConflict):
 		return temporal.NewNonRetryableApplicationError(err.Error(), repositoryTemporalIDConflictType, err)
+	case errors.Is(err, repository.ErrIllegalSessionTransition):
+		return temporal.NewNonRetryableApplicationError(err.Error(), repositoryIllegalSessionTransitionType, err)
 	case errors.Is(err, repository.ErrInvalidTransition):
 		return temporal.NewNonRetryableApplicationError(err.Error(), repositoryInvalidTransitionType, err)
 	case errors.Is(err, repository.ErrTransitionConflict):

--- a/backend/internal/workflow/eval_session_workflow.go
+++ b/backend/internal/workflow/eval_session_workflow.go
@@ -1,0 +1,146 @@
+package workflow
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/domain"
+	"github.com/google/uuid"
+	enumspb "go.temporal.io/api/enums/v1"
+	sdkworkflow "go.temporal.io/sdk/workflow"
+)
+
+var ErrEvalSessionHasNoRuns = errors.New("eval session must have at least one run")
+
+func EvalSessionWorkflow(ctx sdkworkflow.Context, input EvalSessionWorkflowInput) error {
+	ctx = sdkworkflow.WithActivityOptions(ctx, defaultActivityOptions)
+
+	err := runEvalSessionWorkflow(ctx, input)
+	if err == nil {
+		return nil
+	}
+
+	if isWorkflowCanceled(err) {
+		return markEvalSessionCancelled(ctx, input.EvalSessionID, err)
+	}
+	if shouldSkipEvalSessionFailureTransition(err) {
+		return err
+	}
+
+	return markEvalSessionFailed(ctx, input.EvalSessionID, err)
+}
+
+func runEvalSessionWorkflow(ctx sdkworkflow.Context, input EvalSessionWorkflowInput) error {
+	session, err := loadEvalSession(ctx, input.EvalSessionID)
+	if err != nil {
+		return err
+	}
+	if err := validateEvalSessionQueued(session); err != nil {
+		return err
+	}
+
+	if err := transitionEvalSessionStatus(ctx, input.EvalSessionID, domain.EvalSessionStatusRunning); err != nil {
+		return err
+	}
+
+	runs, err := listEvalSessionRuns(ctx, input.EvalSessionID)
+	if err != nil {
+		return err
+	}
+	if len(runs) == 0 {
+		return fmt.Errorf("%w: eval session %s", ErrEvalSessionHasNoRuns, input.EvalSessionID)
+	}
+
+	if err := executeEvalSessionRuns(ctx, runs); err != nil {
+		return err
+	}
+
+	return transitionEvalSessionStatus(ctx, input.EvalSessionID, domain.EvalSessionStatusAggregating)
+}
+
+func loadEvalSession(ctx sdkworkflow.Context, evalSessionID uuid.UUID) (domain.EvalSession, error) {
+	var session domain.EvalSession
+	err := sdkworkflow.ExecuteActivity(ctx, loadEvalSessionActivityName, LoadEvalSessionInput{
+		EvalSessionID: evalSessionID,
+	}).Get(ctx, &session)
+	return session, err
+}
+
+func listEvalSessionRuns(ctx sdkworkflow.Context, evalSessionID uuid.UUID) ([]domain.Run, error) {
+	var runs []domain.Run
+	err := sdkworkflow.ExecuteActivity(ctx, listEvalSessionRunsActivityName, ListEvalSessionRunsInput{
+		EvalSessionID: evalSessionID,
+	}).Get(ctx, &runs)
+	return runs, err
+}
+
+func transitionEvalSessionStatus(ctx sdkworkflow.Context, evalSessionID uuid.UUID, toStatus domain.EvalSessionStatus) error {
+	var session domain.EvalSession
+	return sdkworkflow.ExecuteActivity(ctx, transitionEvalSessionStatusActivityName, TransitionEvalSessionStatusInput{
+		EvalSessionID: evalSessionID,
+		ToStatus:      toStatus,
+	}).Get(ctx, &session)
+}
+
+func executeEvalSessionRuns(ctx sdkworkflow.Context, runs []domain.Run) error {
+	selector := sdkworkflow.NewSelector(ctx)
+	completedChildren := 0
+	childErrors := make(map[uuid.UUID]error, len(runs))
+
+	for _, run := range runs {
+		run := run
+		childCtx := sdkworkflow.WithChildOptions(ctx, sdkworkflow.ChildWorkflowOptions{
+			WorkflowID:        fmt.Sprintf("%s/%s", RunWorkflowName, run.ID),
+			ParentClosePolicy: enumspb.PARENT_CLOSE_POLICY_REQUEST_CANCEL,
+		})
+		future := sdkworkflow.ExecuteChildWorkflow(childCtx, RunWorkflowName, RunWorkflowInput{
+			RunID: run.ID,
+		})
+		selector.AddFuture(future, func(f sdkworkflow.Future) {
+			completedChildren++
+			if err := f.Get(ctx, nil); err != nil {
+				childErrors[run.ID] = err
+			}
+		})
+	}
+
+	for completedChildren < len(runs) {
+		selector.Select(ctx)
+	}
+
+	if len(childErrors) == len(runs) {
+		for _, err := range childErrors {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func markEvalSessionFailed(ctx sdkworkflow.Context, evalSessionID uuid.UUID, workflowErr error) error {
+	activityErr := transitionEvalSessionStatus(ctx, evalSessionID, domain.EvalSessionStatusFailed)
+	if activityErr != nil {
+		return fmt.Errorf("eval session workflow failed: %v; additionally failed to mark eval session failed: %w", workflowErr, activityErr)
+	}
+
+	return workflowErr
+}
+
+func markEvalSessionCancelled(ctx sdkworkflow.Context, evalSessionID uuid.UUID, workflowErr error) error {
+	disconnectedCtx, _ := sdkworkflow.NewDisconnectedContext(ctx)
+	disconnectedCtx = sdkworkflow.WithActivityOptions(disconnectedCtx, defaultActivityOptions)
+
+	activityErr := transitionEvalSessionStatus(disconnectedCtx, evalSessionID, domain.EvalSessionStatusCancelled)
+	if activityErr != nil {
+		return fmt.Errorf("eval session workflow cancelled: %v; additionally failed to mark eval session cancelled: %w", workflowErr, activityErr)
+	}
+
+	return workflowErr
+}
+
+func shouldSkipEvalSessionFailureTransition(err error) bool {
+	return errors.Is(err, ErrEvalSessionMustBeQueued) ||
+		hasApplicationErrorType(err, repositoryEvalSessionNotFoundErrorType) ||
+		hasApplicationErrorType(err, repositoryIllegalSessionTransitionType) ||
+		hasApplicationErrorType(err, repositoryTransitionConflictType)
+}

--- a/backend/internal/workflow/eval_session_workflow.go
+++ b/backend/internal/workflow/eval_session_workflow.go
@@ -141,6 +141,5 @@ func markEvalSessionCancelled(ctx sdkworkflow.Context, evalSessionID uuid.UUID, 
 func shouldSkipEvalSessionFailureTransition(err error) bool {
 	return errors.Is(err, ErrEvalSessionMustBeQueued) ||
 		hasApplicationErrorType(err, repositoryEvalSessionNotFoundErrorType) ||
-		hasApplicationErrorType(err, repositoryIllegalSessionTransitionType) ||
-		hasApplicationErrorType(err, repositoryTransitionConflictType)
+		hasApplicationErrorType(err, repositoryIllegalSessionTransitionType)
 }

--- a/backend/internal/workflow/register.go
+++ b/backend/internal/workflow/register.go
@@ -11,8 +11,12 @@ type Registrar interface {
 }
 
 func Register(registrar Registrar, activities *Activities) {
+	registrar.RegisterWorkflowWithOptions(EvalSessionWorkflow, sdkworkflow.RegisterOptions{Name: EvalSessionWorkflowName})
 	registrar.RegisterWorkflowWithOptions(RunWorkflow, sdkworkflow.RegisterOptions{Name: RunWorkflowName})
 	registrar.RegisterWorkflowWithOptions(RunAgentWorkflow, sdkworkflow.RegisterOptions{Name: RunAgentWorkflowName})
+	registrar.RegisterActivityWithOptions(activities.LoadEvalSession, sdkactivity.RegisterOptions{Name: loadEvalSessionActivityName})
+	registrar.RegisterActivityWithOptions(activities.ListEvalSessionRuns, sdkactivity.RegisterOptions{Name: listEvalSessionRunsActivityName})
+	registrar.RegisterActivityWithOptions(activities.TransitionEvalSessionStatus, sdkactivity.RegisterOptions{Name: transitionEvalSessionStatusActivityName})
 	registrar.RegisterActivityWithOptions(activities.LoadRun, sdkactivity.RegisterOptions{Name: loadRunActivityName})
 	registrar.RegisterActivityWithOptions(activities.ListRunAgents, sdkactivity.RegisterOptions{Name: listRunAgentsActivityName})
 	registrar.RegisterActivityWithOptions(activities.LoadRunAgent, sdkactivity.RegisterOptions{Name: loadRunAgentActivityName})

--- a/backend/internal/workflow/repository.go
+++ b/backend/internal/workflow/repository.go
@@ -15,10 +15,11 @@ import (
 )
 
 var (
-	ErrRunMustBeQueued      = errors.New("run must already be queued")
-	ErrRunHasNoAgents       = errors.New("run must have at least one run agent")
-	ErrRunAgentMustBeQueued = errors.New("run agent must already be queued")
-	ErrRunAgentRunMismatch  = errors.New("run agent does not belong to run")
+	ErrEvalSessionMustBeQueued = errors.New("eval session must already be queued")
+	ErrRunMustBeQueued         = errors.New("run must already be queued")
+	ErrRunHasNoAgents          = errors.New("run must have at least one run agent")
+	ErrRunAgentMustBeQueued    = errors.New("run agent must already be queued")
+	ErrRunAgentRunMismatch     = errors.New("run agent does not belong to run")
 )
 
 type RunRepository interface {
@@ -43,6 +44,12 @@ type RunRepository interface {
 	MarkHostedRunExecutionTimedOut(ctx context.Context, params repository.MarkHostedRunExecutionTimedOutParams) (repository.HostedRunExecution, error)
 }
 
+type EvalSessionRepository interface {
+	GetEvalSessionByID(ctx context.Context, id uuid.UUID) (domain.EvalSession, error)
+	ListRunsByEvalSessionID(ctx context.Context, evalSessionID uuid.UUID) ([]domain.Run, error)
+	TransitionEvalSessionStatus(ctx context.Context, params repository.TransitionEvalSessionStatusParams) (domain.EvalSession, error)
+}
+
 type HostedRunStarter interface {
 	Start(ctx context.Context, input HostedRunStartInput) (hostedruns.StartResponse, error)
 }
@@ -60,6 +67,14 @@ func validateRunQueued(run domain.Run) error {
 	}
 
 	return fmt.Errorf("%w: run %s is %s", ErrRunMustBeQueued, run.ID, run.Status)
+}
+
+func validateEvalSessionQueued(session domain.EvalSession) error {
+	if session.Status == domain.EvalSessionStatusQueued {
+		return nil
+	}
+
+	return fmt.Errorf("%w: eval session %s is %s", ErrEvalSessionMustBeQueued, session.ID, session.Status)
 }
 
 func validateRunAgentQueued(runAgent domain.RunAgent, runID uuid.UUID) error {

--- a/backend/internal/workflow/types.go
+++ b/backend/internal/workflow/types.go
@@ -3,11 +3,16 @@ package workflow
 import "github.com/google/uuid"
 
 const (
+	EvalSessionWorkflowName          = "EvalSessionWorkflow"
 	RunWorkflowName                  = "RunWorkflow"
 	RunAgentWorkflowName             = "RunAgentWorkflow"
 	PlaygroundExperimentWorkflowName = "PlaygroundExperimentWorkflow"
 	HostedRunEventSignal             = "hosted_run_event"
 )
+
+type EvalSessionWorkflowInput struct {
+	EvalSessionID uuid.UUID `json:"eval_session_id"`
+}
 
 type RunWorkflowInput struct {
 	RunID uuid.UUID `json:"run_id"`

--- a/backend/internal/workflow/types.go
+++ b/backend/internal/workflow/types.go
@@ -8,6 +8,7 @@ const (
 	RunAgentWorkflowName             = "RunAgentWorkflow"
 	PlaygroundExperimentWorkflowName = "PlaygroundExperimentWorkflow"
 	HostedRunEventSignal             = "hosted_run_event"
+	WorkflowTaskQueue                = RunWorkflowName
 )
 
 type EvalSessionWorkflowInput struct {

--- a/backend/internal/workflow/workflow_test.go
+++ b/backend/internal/workflow/workflow_test.go
@@ -17,10 +17,213 @@ import (
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/scoring"
 	"github.com/google/uuid"
+	sdkactivity "go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
+	sdkworkflow "go.temporal.io/sdk/workflow"
 )
+
+func TestEvalSessionWorkflowHappyPath(t *testing.T) {
+	sessionID := uuid.New()
+	firstRunID := uuid.New()
+	secondRunID := uuid.New()
+	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
+	repo.setEvalSession(
+		fixtureEvalSession(sessionID, domain.EvalSessionStatusQueued),
+		fixtureChildRun(firstRunID, sessionID),
+		fixtureChildRun(secondRunID, sessionID),
+	)
+
+	var started []uuid.UUID
+	var startedMu sync.Mutex
+	env := newEvalSessionWorkflowTestEnvironment(repo, nil, func(ctx sdkworkflow.Context, input RunWorkflowInput) error {
+		startedMu.Lock()
+		started = append(started, input.RunID)
+		startedMu.Unlock()
+		return nil
+	})
+	env.ExecuteWorkflow(EvalSessionWorkflow, EvalSessionWorkflowInput{EvalSessionID: sessionID})
+
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("EvalSessionWorkflow returned error: %v", err)
+	}
+	if got := repo.currentEvalSession(sessionID).Status; got != domain.EvalSessionStatusAggregating {
+		t.Fatalf("eval session status = %s, want %s", got, domain.EvalSessionStatusAggregating)
+	}
+	if got := repo.evalSessionStatusSequence(sessionID); !equalEvalSessionStatuses(got, []domain.EvalSessionStatus{
+		domain.EvalSessionStatusRunning,
+		domain.EvalSessionStatusAggregating,
+	}) {
+		t.Fatalf("eval session statuses = %v, want [running aggregating]", got)
+	}
+	sort.Slice(started, func(i, j int) bool { return started[i].String() < started[j].String() })
+	wantStarted := []uuid.UUID{firstRunID, secondRunID}
+	sort.Slice(wantStarted, func(i, j int) bool { return wantStarted[i].String() < wantStarted[j].String() })
+	if fmt.Sprint(started) != fmt.Sprint(wantStarted) {
+		t.Fatalf("started child runs = %v, want %v", started, wantStarted)
+	}
+}
+
+func TestEvalSessionWorkflowPartialChildFailureStillAggregates(t *testing.T) {
+	sessionID := uuid.New()
+	firstRunID := uuid.New()
+	secondRunID := uuid.New()
+	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
+	repo.setEvalSession(
+		fixtureEvalSession(sessionID, domain.EvalSessionStatusQueued),
+		fixtureChildRun(firstRunID, sessionID),
+		fixtureChildRun(secondRunID, sessionID),
+	)
+
+	env := newEvalSessionWorkflowTestEnvironment(repo, map[uuid.UUID]error{
+		secondRunID: errors.New("child failed"),
+	}, nil)
+	env.ExecuteWorkflow(EvalSessionWorkflow, EvalSessionWorkflowInput{EvalSessionID: sessionID})
+
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("EvalSessionWorkflow returned error: %v", err)
+	}
+	if got := repo.currentEvalSession(sessionID).Status; got != domain.EvalSessionStatusAggregating {
+		t.Fatalf("eval session status = %s, want %s", got, domain.EvalSessionStatusAggregating)
+	}
+}
+
+func TestEvalSessionWorkflowAllChildrenFailMarksSessionFailed(t *testing.T) {
+	sessionID := uuid.New()
+	firstRunID := uuid.New()
+	secondRunID := uuid.New()
+	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
+	repo.setEvalSession(
+		fixtureEvalSession(sessionID, domain.EvalSessionStatusQueued),
+		fixtureChildRun(firstRunID, sessionID),
+		fixtureChildRun(secondRunID, sessionID),
+	)
+
+	env := newEvalSessionWorkflowTestEnvironment(repo, map[uuid.UUID]error{
+		firstRunID:  errors.New("first child failed"),
+		secondRunID: errors.New("second child failed"),
+	}, nil)
+	env.ExecuteWorkflow(EvalSessionWorkflow, EvalSessionWorkflowInput{EvalSessionID: sessionID})
+
+	if err := env.GetWorkflowError(); err == nil {
+		t.Fatalf("expected workflow failure")
+	}
+	if got := repo.currentEvalSession(sessionID).Status; got != domain.EvalSessionStatusFailed {
+		t.Fatalf("eval session status = %s, want %s", got, domain.EvalSessionStatusFailed)
+	}
+	if got := repo.evalSessionStatusSequence(sessionID); !equalEvalSessionStatuses(got, []domain.EvalSessionStatus{
+		domain.EvalSessionStatusRunning,
+		domain.EvalSessionStatusFailed,
+	}) {
+		t.Fatalf("eval session statuses = %v, want [running failed]", got)
+	}
+}
+
+func TestEvalSessionWorkflowCancellationMarksSessionCancelled(t *testing.T) {
+	sessionID := uuid.New()
+	runID := uuid.New()
+	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
+	repo.setEvalSession(
+		fixtureEvalSession(sessionID, domain.EvalSessionStatusQueued),
+		fixtureChildRun(runID, sessionID),
+	)
+
+	env := newEvalSessionWorkflowTestEnvironment(repo, nil, func(ctx sdkworkflow.Context, input RunWorkflowInput) error {
+		return sdkworkflow.Await(ctx, func() bool { return false })
+	})
+	env.RegisterDelayedCallback(func() {
+		env.CancelWorkflow()
+	}, fakeStageDelay/2)
+	env.ExecuteWorkflow(EvalSessionWorkflow, EvalSessionWorkflowInput{EvalSessionID: sessionID})
+
+	err := env.GetWorkflowError()
+	if err == nil {
+		t.Fatalf("expected cancellation error")
+	}
+	if !temporal.IsCanceledError(err) {
+		t.Fatalf("workflow error = %v, want canceled error", err)
+	}
+	if got := repo.currentEvalSession(sessionID).Status; got != domain.EvalSessionStatusCancelled {
+		t.Fatalf("eval session status = %s, want %s", got, domain.EvalSessionStatusCancelled)
+	}
+}
+
+func TestEvalSessionWorkflowRequiresQueuedSession(t *testing.T) {
+	sessionID := uuid.New()
+	runID := uuid.New()
+	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
+	repo.setEvalSession(
+		fixtureEvalSession(sessionID, domain.EvalSessionStatusRunning),
+		fixtureChildRun(runID, sessionID),
+	)
+
+	env := newEvalSessionWorkflowTestEnvironment(repo, nil, nil)
+	env.ExecuteWorkflow(EvalSessionWorkflow, EvalSessionWorkflowInput{EvalSessionID: sessionID})
+
+	err := env.GetWorkflowError()
+	if err == nil {
+		t.Fatalf("expected workflow error")
+	}
+	if !strings.Contains(err.Error(), ErrEvalSessionMustBeQueued.Error()) {
+		t.Fatalf("workflow error = %v, want ErrEvalSessionMustBeQueued", err)
+	}
+	if got := repo.currentEvalSession(sessionID).Status; got != domain.EvalSessionStatusRunning {
+		t.Fatalf("eval session status = %s, want %s", got, domain.EvalSessionStatusRunning)
+	}
+}
+
+func TestEvalSessionWorkflowNoChildRunsFails(t *testing.T) {
+	sessionID := uuid.New()
+	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
+	repo.setEvalSession(fixtureEvalSession(sessionID, domain.EvalSessionStatusQueued))
+
+	env := newEvalSessionWorkflowTestEnvironment(repo, nil, nil)
+	env.ExecuteWorkflow(EvalSessionWorkflow, EvalSessionWorkflowInput{EvalSessionID: sessionID})
+
+	err := env.GetWorkflowError()
+	if err == nil {
+		t.Fatalf("expected workflow failure")
+	}
+	if !strings.Contains(err.Error(), ErrEvalSessionHasNoRuns.Error()) {
+		t.Fatalf("workflow error = %v, want ErrEvalSessionHasNoRuns", err)
+	}
+	if got := repo.currentEvalSession(sessionID).Status; got != domain.EvalSessionStatusFailed {
+		t.Fatalf("eval session status = %s, want %s", got, domain.EvalSessionStatusFailed)
+	}
+}
+
+func TestEvalSessionWorkflowWaitsForAllChildrenBeforeAggregating(t *testing.T) {
+	sessionID := uuid.New()
+	fastRunID := uuid.New()
+	slowRunID := uuid.New()
+	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
+	repo.setEvalSession(
+		fixtureEvalSession(sessionID, domain.EvalSessionStatusQueued),
+		fixtureChildRun(fastRunID, sessionID),
+		fixtureChildRun(slowRunID, sessionID),
+	)
+
+	env := newEvalSessionWorkflowTestEnvironment(repo, nil, func(ctx sdkworkflow.Context, input RunWorkflowInput) error {
+		if input.RunID == slowRunID {
+			return sdkworkflow.Sleep(ctx, 5*time.Second)
+		}
+		return nil
+	})
+	env.RegisterDelayedCallback(func() {
+		if got := repo.currentEvalSession(sessionID).Status; got != domain.EvalSessionStatusRunning {
+			t.Fatalf("eval session status before slow child completes = %s, want running", got)
+		}
+	}, time.Second)
+	env.ExecuteWorkflow(EvalSessionWorkflow, EvalSessionWorkflowInput{EvalSessionID: sessionID})
+
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("EvalSessionWorkflow returned error: %v", err)
+	}
+	if got := repo.currentEvalSession(sessionID).Status; got != domain.EvalSessionStatusAggregating {
+		t.Fatalf("eval session status = %s, want %s", got, domain.EvalSessionStatusAggregating)
+	}
+}
 
 func TestRunWorkflowHappyPath(t *testing.T) {
 	runID := uuid.New()
@@ -791,25 +994,62 @@ func newTestWorkflowEnvironment(repo *fakeRunRepository, hooks FakeWorkHooks) *t
 	return env
 }
 
+func newEvalSessionWorkflowTestEnvironment(
+	repo *fakeRunRepository,
+	childErrs map[uuid.UUID]error,
+	childWorkflow func(ctx sdkworkflow.Context, input RunWorkflowInput) error,
+) *testsuite.TestWorkflowEnvironment {
+	var suite testsuite.WorkflowTestSuite
+	suite.SetDisableRegistrationAliasing(true)
+
+	env := suite.NewTestWorkflowEnvironment()
+	env.SetStartWorkflowOptions(client.StartWorkflowOptions{
+		ID:        "test-eval-session-workflow",
+		TaskQueue: "workflow-test",
+	})
+
+	activities := NewActivities(repo, FakeWorkHooks{})
+	env.RegisterWorkflowWithOptions(EvalSessionWorkflow, sdkworkflow.RegisterOptions{Name: EvalSessionWorkflowName})
+	env.RegisterActivityWithOptions(activities.LoadEvalSession, sdkactivity.RegisterOptions{Name: loadEvalSessionActivityName})
+	env.RegisterActivityWithOptions(activities.ListEvalSessionRuns, sdkactivity.RegisterOptions{Name: listEvalSessionRunsActivityName})
+	env.RegisterActivityWithOptions(activities.TransitionEvalSessionStatus, sdkactivity.RegisterOptions{Name: transitionEvalSessionStatusActivityName})
+	if childWorkflow == nil {
+		childWorkflow = func(ctx sdkworkflow.Context, input RunWorkflowInput) error {
+			if childErrs != nil {
+				if err := childErrs[input.RunID]; err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+	}
+	env.RegisterWorkflowWithOptions(childWorkflow, sdkworkflow.RegisterOptions{Name: RunWorkflowName})
+
+	return env
+}
+
 type fakeRunRepository struct {
-	mu                  sync.Mutex
-	run                 domain.Run
-	runAgents           map[uuid.UUID]domain.RunAgent
-	executionContexts   map[uuid.UUID]repository.RunAgentExecutionContext
-	evaluationSpecs     map[string]repository.EvaluationSpecRecord
-	hostedExecutions    map[uuid.UUID]repository.HostedRunExecution
-	replays             map[uuid.UUID]repository.RunAgentReplay
-	runEvents           map[uuid.UUID][]repository.RunEvent
-	evaluations         map[uuid.UUID]scoring.RunAgentEvaluation
-	runScorecards       map[uuid.UUID]repository.RunScorecard
-	runAgentStatusErrs  map[string]error
-	buildReplayErr      error
-	recordRunEventErr   error
-	callLog             []string
-	runStatusCalls      []repository.TransitionRunStatusParams
-	runAgentStatusCalls []repository.TransitionRunAgentStatusParams
-	setTemporalIDsCalls []repository.SetRunTemporalIDsParams
-	buildReplayCalls    []uuid.UUID
+	mu                     sync.Mutex
+	run                    domain.Run
+	evalSessions           map[uuid.UUID]domain.EvalSession
+	evalSessionRuns        map[uuid.UUID][]domain.Run
+	runAgents              map[uuid.UUID]domain.RunAgent
+	executionContexts      map[uuid.UUID]repository.RunAgentExecutionContext
+	evaluationSpecs        map[string]repository.EvaluationSpecRecord
+	hostedExecutions       map[uuid.UUID]repository.HostedRunExecution
+	replays                map[uuid.UUID]repository.RunAgentReplay
+	runEvents              map[uuid.UUID][]repository.RunEvent
+	evaluations            map[uuid.UUID]scoring.RunAgentEvaluation
+	runScorecards          map[uuid.UUID]repository.RunScorecard
+	runAgentStatusErrs     map[string]error
+	buildReplayErr         error
+	recordRunEventErr      error
+	callLog                []string
+	runStatusCalls         []repository.TransitionRunStatusParams
+	evalSessionStatusCalls []repository.TransitionEvalSessionStatusParams
+	runAgentStatusCalls    []repository.TransitionRunAgentStatusParams
+	setTemporalIDsCalls    []repository.SetRunTemporalIDsParams
+	buildReplayCalls       []uuid.UUID
 }
 
 func newFakeRunRepository(run domain.Run, runAgents ...domain.RunAgent) *fakeRunRepository {
@@ -820,6 +1060,8 @@ func newFakeRunRepository(run domain.Run, runAgents ...domain.RunAgent) *fakeRun
 
 	return &fakeRunRepository{
 		run:                cloneRun(run),
+		evalSessions:       make(map[uuid.UUID]domain.EvalSession),
+		evalSessionRuns:    make(map[uuid.UUID][]domain.Run),
 		runAgents:          runAgentMap,
 		executionContexts:  make(map[uuid.UUID]repository.RunAgentExecutionContext),
 		evaluationSpecs:    make(map[string]repository.EvaluationSpecRecord),
@@ -830,6 +1072,74 @@ func newFakeRunRepository(run domain.Run, runAgents ...domain.RunAgent) *fakeRun
 		runScorecards:      make(map[uuid.UUID]repository.RunScorecard),
 		runAgentStatusErrs: make(map[string]error),
 	}
+}
+
+func (r *fakeRunRepository) setEvalSession(session domain.EvalSession, runs ...domain.Run) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.evalSessions[session.ID] = cloneEvalSession(session)
+	clonedRuns := make([]domain.Run, 0, len(runs))
+	for _, run := range runs {
+		clonedRuns = append(clonedRuns, cloneRun(run))
+	}
+	r.evalSessionRuns[session.ID] = clonedRuns
+}
+
+func (r *fakeRunRepository) GetEvalSessionByID(_ context.Context, id uuid.UUID) (domain.EvalSession, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	session, ok := r.evalSessions[id]
+	if !ok {
+		return domain.EvalSession{}, repository.ErrEvalSessionNotFound
+	}
+	r.callLog = append(r.callLog, fmt.Sprintf("GetEvalSessionByID:%s", id))
+	return cloneEvalSession(session), nil
+}
+
+func (r *fakeRunRepository) ListRunsByEvalSessionID(_ context.Context, evalSessionID uuid.UUID) ([]domain.Run, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.callLog = append(r.callLog, fmt.Sprintf("ListRunsByEvalSessionID:%s", evalSessionID))
+	runs := r.evalSessionRuns[evalSessionID]
+	cloned := make([]domain.Run, 0, len(runs))
+	for _, run := range runs {
+		cloned = append(cloned, cloneRun(run))
+	}
+	return cloned, nil
+}
+
+func (r *fakeRunRepository) TransitionEvalSessionStatus(_ context.Context, params repository.TransitionEvalSessionStatusParams) (domain.EvalSession, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	session, ok := r.evalSessions[params.EvalSessionID]
+	if !ok {
+		return domain.EvalSession{}, repository.ErrEvalSessionNotFound
+	}
+	if !session.Status.CanTransitionTo(params.ToStatus) {
+		return domain.EvalSession{}, repository.IllegalSessionTransitionError{
+			From: string(session.Status),
+			To:   string(params.ToStatus),
+		}
+	}
+
+	session.Status = params.ToStatus
+	now := time.Now().UTC()
+	if params.ToStatus == domain.EvalSessionStatusRunning {
+		session.StartedAt = &now
+	}
+	if params.ToStatus.Terminal() {
+		session.FinishedAt = &now
+	}
+	session.UpdatedAt = now
+	r.evalSessions[params.EvalSessionID] = session
+	r.evalSessionStatusCalls = append(r.evalSessionStatusCalls, params)
+	r.callLog = append(r.callLog, fmt.Sprintf("TransitionEvalSessionStatus:%s:%s", params.EvalSessionID, params.ToStatus))
+
+	return cloneEvalSession(session), nil
 }
 
 func (r *fakeRunRepository) GetRunByID(_ context.Context, id uuid.UUID) (domain.Run, error) {
@@ -1237,6 +1547,13 @@ func (r *fakeRunRepository) currentRun() domain.Run {
 	return cloneRun(r.run)
 }
 
+func (r *fakeRunRepository) currentEvalSession(id uuid.UUID) domain.EvalSession {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return cloneEvalSession(r.evalSessions[id])
+}
+
 func (r *fakeRunRepository) currentRunAgent(id uuid.UUID) domain.RunAgent {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -1275,6 +1592,20 @@ func (r *fakeRunRepository) runStatusTransitionCount() int {
 	defer r.mu.Unlock()
 
 	return len(r.runStatusCalls)
+}
+
+func (r *fakeRunRepository) evalSessionStatusSequence(id uuid.UUID) []domain.EvalSessionStatus {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	statuses := make([]domain.EvalSessionStatus, 0, len(r.evalSessionStatusCalls))
+	for _, call := range r.evalSessionStatusCalls {
+		if call.EvalSessionID == id {
+			statuses = append(statuses, call.ToStatus)
+		}
+	}
+
+	return statuses
 }
 
 func (r *fakeRunRepository) setTemporalIDsCount() int {
@@ -1323,6 +1654,25 @@ func fixtureRun(runID uuid.UUID, status domain.RunStatus) domain.Run {
 		CreatedAt:     createdAt,
 		UpdatedAt:     createdAt,
 	}
+}
+
+func fixtureEvalSession(sessionID uuid.UUID, status domain.EvalSessionStatus) domain.EvalSession {
+	now := time.Now().UTC()
+
+	return domain.EvalSession{
+		ID:            sessionID,
+		Status:        status,
+		Repetitions:   1,
+		SchemaVersion: 1,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+}
+
+func fixtureChildRun(runID uuid.UUID, sessionID uuid.UUID) domain.Run {
+	run := fixtureRun(runID, domain.RunStatusQueued)
+	run.EvalSessionID = &sessionID
+	return run
 }
 
 func hostedExecutionContext(runID uuid.UUID, runAgentID uuid.UUID) repository.RunAgentExecutionContext {
@@ -1501,6 +1851,23 @@ func cloneRun(run domain.Run) domain.Run {
 	return cloned
 }
 
+func cloneEvalSession(session domain.EvalSession) domain.EvalSession {
+	cloned := session
+	cloned.AggregationConfig.Document = cloneJSON(session.AggregationConfig.Document)
+	cloned.SuccessThresholdConfig.Document = cloneJSON(session.SuccessThresholdConfig.Document)
+	cloned.RoutingTaskSnapshot.Document = cloneJSON(session.RoutingTaskSnapshot.Document)
+	if session.StartedAt != nil {
+		startedAt := *session.StartedAt
+		cloned.StartedAt = &startedAt
+	}
+	if session.FinishedAt != nil {
+		finishedAt := *session.FinishedAt
+		cloned.FinishedAt = &finishedAt
+	}
+
+	return cloned
+}
+
 func cloneRunAgent(runAgent domain.RunAgent) domain.RunAgent {
 	cloned := runAgent
 	cloned.FailureReason = cloneStringPtr(runAgent.FailureReason)
@@ -1517,6 +1884,19 @@ func equalStringPtrs(left *string, right *string) bool {
 }
 
 func equalRunStatuses(left []domain.RunStatus, right []domain.RunStatus) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func equalEvalSessionStatuses(left []domain.EvalSessionStatus, right []domain.EvalSessionStatus) bool {
 	if len(left) != len(right) {
 		return false
 	}

--- a/backend/internal/workflow/workflow_test.go
+++ b/backend/internal/workflow/workflow_test.go
@@ -120,6 +120,36 @@ func TestEvalSessionWorkflowAllChildrenFailMarksSessionFailed(t *testing.T) {
 	}
 }
 
+func TestEvalSessionWorkflowRunTransitionConflictStillMarksSessionFailed(t *testing.T) {
+	sessionID := uuid.New()
+	firstRunID := uuid.New()
+	secondRunID := uuid.New()
+	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
+	repo.setEvalSession(
+		fixtureEvalSession(sessionID, domain.EvalSessionStatusQueued),
+		fixtureChildRun(firstRunID, sessionID),
+		fixtureChildRun(secondRunID, sessionID),
+	)
+
+	conflictErr := temporal.NewNonRetryableApplicationError(
+		"child run transition conflict",
+		repositoryTransitionConflictType,
+		errors.New("conflict"),
+	)
+	env := newEvalSessionWorkflowTestEnvironment(repo, map[uuid.UUID]error{
+		firstRunID:  conflictErr,
+		secondRunID: conflictErr,
+	}, nil)
+	env.ExecuteWorkflow(EvalSessionWorkflow, EvalSessionWorkflowInput{EvalSessionID: sessionID})
+
+	if err := env.GetWorkflowError(); err == nil {
+		t.Fatalf("expected workflow failure")
+	}
+	if got := repo.currentEvalSession(sessionID).Status; got != domain.EvalSessionStatusFailed {
+		t.Fatalf("eval session status = %s, want %s", got, domain.EvalSessionStatusFailed)
+	}
+}
+
 func TestEvalSessionWorkflowCancellationMarksSessionCancelled(t *testing.T) {
 	sessionID := uuid.New()
 	runID := uuid.New()

--- a/testing/codex-issue-361-eval-session-workflow.md
+++ b/testing/codex-issue-361-eval-session-workflow.md
@@ -1,0 +1,47 @@
+# codex/issue-361-eval-session-workflow — Test Contract
+
+## Functional Behavior
+- Creating an eval session starts exactly one durable parent workflow for the new session after the session and child runs are created transactionally.
+- The parent workflow loads the eval session, verifies it is still `queued`, records Temporal workflow metadata on the session, and transitions the session `queued -> running`.
+- The parent workflow launches one `RunWorkflow` child per attached child run using deterministic child workflow IDs derived from each run ID.
+- The parent workflow waits for every child workflow future to resolve before transitioning the session to `aggregating`.
+- If some child workflows fail but at least one child completes, the parent workflow still advances the session to `aggregating` and does not cancel successful children.
+- If every child workflow fails, the parent workflow marks the eval session `failed`.
+- Cancelling the parent workflow marks the eval session `cancelled` and requests cancellation for still-running children through Temporal parent-close semantics.
+- `repetitions = 1` behaves like a single-child fan-out: one child run is started and the session still reaches `aggregating` after that child settles.
+
+## Unit Tests
+- `TestRunCreationManagerCreateEvalSessionStartsEvalSessionWorkflow` — create path starts the parent workflow with the created session ID.
+- `TestTemporalEvalSessionWorkflowStarterStartEvalSessionWorkflow` — starter uses `EvalSessionWorkflow` name, task queue, and workflow ID format `EvalSessionWorkflow/<sessionID>`.
+- `TestEvalSessionWorkflowHappyPath` — queued session with two child runs transitions `queued -> running -> aggregating`.
+- `TestEvalSessionWorkflowAllChildrenFailMarksSessionFailed` — all child workflow failures mark the session failed and skip `aggregating`.
+- `TestEvalSessionWorkflowPartialChildFailureStillAggregates` — mixed child outcomes still reach `aggregating` after all children resolve.
+- `TestEvalSessionWorkflowCancellationMarksSessionCancelled` — cancellation marks the session cancelled.
+- `TestEvalSessionWorkflowRequiresQueuedSession` — non-queued sessions fail before transitions.
+- `TestEvalSessionWorkflowNoChildRunsFails` — empty child run set fails explicitly.
+
+## Integration / Functional Tests
+- Existing `CreateEvalSession` service tests verify the created session and child run IDs still come back unchanged when workflow start is added.
+- Workflow tests verify the parent workflow invokes existing `RunWorkflow` children rather than duplicating run-creation logic.
+
+## Smoke Tests
+- `cd backend && go test ./internal/api ./internal/workflow`
+- `cd backend && go test -short ./...`
+
+## E2E Tests
+- N/A — not applicable for this workflow-orchestration slice.
+
+## Manual / cURL Tests
+```bash
+curl -X POST http://localhost:8080/v1/eval-sessions \
+  -H "Content-Type: application/json" \
+  -H "X-User-Id: <user-id>" \
+  -H "X-Workspace-Id: <workspace-id>" \
+  -d @/tmp/eval-session-request.json
+# Expected: 201 Created with a queued eval session and attached child run ids.
+
+curl http://localhost:8080/v1/eval-sessions/<session-id> \
+  -H "X-User-Id: <user-id>" \
+  -H "X-Workspace-Id: <workspace-id>"
+# Expected after workers process the session: status advances to aggregating once all child runs are terminal.
+```

--- a/testing/codex-issue-361-eval-session-workflow.md
+++ b/testing/codex-issue-361-eval-session-workflow.md
@@ -2,7 +2,7 @@
 
 ## Functional Behavior
 - Creating an eval session starts exactly one durable parent workflow for the new session after the session and child runs are created transactionally.
-- The parent workflow loads the eval session, verifies it is still `queued`, records Temporal workflow metadata on the session, and transitions the session `queued -> running`.
+- The parent workflow loads the eval session, verifies it is still `queued`, and transitions the session `queued -> running`.
 - The parent workflow launches one `RunWorkflow` child per attached child run using deterministic child workflow IDs derived from each run ID.
 - The parent workflow waits for every child workflow future to resolve before transitioning the session to `aggregating`.
 - If some child workflows fail but at least one child completes, the parent workflow still advances the session to `aggregating` and does not cancel successful children.


### PR DESCRIPTION
## Summary
- implement the missing `EvalSessionWorkflow` prerequisite slice identified in the `#361` planning comment
- start a parent eval-session workflow from `CreateEvalSession`, then fan out one child `RunWorkflow` per attached run
- transition eval sessions through `queued -> running -> aggregating|failed|cancelled` and add workflow tests for happy path, partial failure, cancellation, no-child-runs, and the no-early-aggregation invariant

## Review Checkpoint
- Test contract: `testing/codex-issue-361-eval-session-workflow.md`
- Scratch checkpoint: `/tmp/reviewcheckpoint.json` (not committed)

## Validation
- `cd backend && go test ./internal/api ./internal/workflow`
- `cd backend && go vet ./...`
- `cd backend && go test -short ./...`

Refs #361
