### PR TITLE
[codex] Implement repeated-eval pass@k and comparison semantics

### DIFF
--- a/backend/internal/api/eval_session_reads_test.go
+++ b/backend/internal/api/eval_session_reads_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -106,6 +107,64 @@ func TestRunReadManagerGetEvalSessionReturnsStoredAggregateResult(t *testing.T) 
 	}
 	if !slices.Equal(result.EvidenceWarnings, []string{"partial evidence warning"}) {
 		t.Fatalf("evidence warnings = %v, want persisted warnings only", result.EvidenceWarnings)
+	}
+}
+
+func TestRunReadManagerGetEvalSessionReturnsStoredNoisyComparisonAggregateAsIs(t *testing.T) {
+	workspaceID := uuid.New()
+	sessionID := uuid.New()
+	caller := Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}
+
+	payload := []byte(`{
+		"schema_version":1,
+		"child_run_count":3,
+		"scored_child_count":3,
+		"participants":[
+			{"lane_index":0,"label":"Alpha","pass_at_k":{"effective_k":3,"by_k":{"3":{"n":3,"mean":0.57,"median":0.57,"std_dev":0.1,"min":0.4,"max":0.7,"high_variance":false,"high_variance_rule":"stddev/abs(mean)>0.15_or_range>0.10"}}},"metric_routing":{"source":"manual_override","reliability_weight":0.6,"reasoning":"manual override","primary_metric":"pass_pow_k","effective_k":3,"composite_agent_score":0.44}},
+			{"lane_index":1,"label":"Beta","pass_at_k":{"effective_k":3,"by_k":{"3":{"n":3,"mean":0.55,"median":0.55,"std_dev":0.1,"min":0.4,"max":0.7,"high_variance":false,"high_variance_rule":"stddev/abs(mean)>0.15_or_range>0.10"}}},"metric_routing":{"source":"manual_override","reliability_weight":0.6,"reasoning":"manual override","primary_metric":"pass_pow_k","effective_k":3,"composite_agent_score":0.43}}
+		],
+		"comparison":{"status":"no_clear_winner","reason_code":"interval_overlap","compared_metric":"pass_pow_k","effective_k":3}
+	}`)
+
+	manager := NewRunReadManager(NewCallerWorkspaceAuthorizer(), &fakeRunReadRepository{
+		evalSession: repository.EvalSessionWithRuns{
+			Session: domain.EvalSession{
+				ID:          sessionID,
+				Status:      domain.EvalSessionStatusCompleted,
+				Repetitions: 3,
+			},
+			Runs: []domain.Run{
+				{ID: uuid.New(), WorkspaceID: workspaceID, EvalSessionID: &sessionID, Status: domain.RunStatusCompleted},
+				{ID: uuid.New(), WorkspaceID: workspaceID, EvalSessionID: &sessionID, Status: domain.RunStatusCompleted},
+				{ID: uuid.New(), WorkspaceID: workspaceID, EvalSessionID: &sessionID, Status: domain.RunStatusCompleted},
+			},
+		},
+		evalSessionResults: map[uuid.UUID]repository.EvalSessionAggregateRecord{
+			sessionID: {
+				EvalSessionID: sessionID,
+				Aggregate:     payload,
+				Evidence:      []byte(`{"warnings":["comparison session top-level winner aggregate omitted because repeated-session evidence overlaps and no clear winner exists"]}`),
+			},
+		},
+	})
+
+	result, err := manager.GetEvalSession(context.Background(), caller, sessionID)
+	if err != nil {
+		t.Fatalf("GetEvalSession returned error: %v", err)
+	}
+	if string(result.AggregateResult) != string(payload) {
+		t.Fatalf("aggregate result = %s, want stored payload", result.AggregateResult)
+	}
+	if !slices.Equal(result.EvidenceWarnings, []string{"comparison session top-level winner aggregate omitted because repeated-session evidence overlaps and no clear winner exists"}) {
+		t.Fatalf("evidence warnings = %v, want persisted noisy-comparison warning", result.EvidenceWarnings)
+	}
+	if bytes.Contains(result.AggregateResult, []byte(`"overall"`)) {
+		t.Fatalf("aggregate result = %s, want no synthetic top-level overall", result.AggregateResult)
 	}
 }
 

--- a/backend/internal/api/eval_session_service.go
+++ b/backend/internal/api/eval_session_service.go
@@ -22,6 +22,7 @@ type EvalSessionAggregationInput struct {
 	Method             string
 	ReportVariance     bool
 	ConfidenceInterval float64
+	ReliabilityWeight  *float64
 }
 
 type EvalSessionSuccessThresholdInput struct {
@@ -330,6 +331,9 @@ func buildAggregationSnapshot(input CreateEvalSessionConfigInput) json.RawMessag
 		"method":              input.Aggregation.Method,
 		"report_variance":     input.Aggregation.ReportVariance,
 		"confidence_interval": input.Aggregation.ConfidenceInterval,
+	}
+	if input.Aggregation.ReliabilityWeight != nil {
+		payload["reliability_weight"] = *input.Aggregation.ReliabilityWeight
 	}
 	if input.ReliabilityWeights != nil {
 		reliabilityWeights := map[string]any{}

--- a/backend/internal/api/eval_sessions.go
+++ b/backend/internal/api/eval_sessions.go
@@ -332,6 +332,7 @@ func decodeEvalSessionAggregation(raw json.RawMessage) (EvalSessionAggregationIn
 		Method             json.RawMessage `json:"method"`
 		ReportVariance     json.RawMessage `json:"report_variance"`
 		ConfidenceInterval json.RawMessage `json:"confidence_interval"`
+		ReliabilityWeight  json.RawMessage `json:"reliability_weight"`
 	}
 
 	var body aggregationRequest
@@ -371,10 +372,25 @@ func decodeEvalSessionAggregation(raw json.RawMessage) (EvalSessionAggregationIn
 		})
 	}
 
+	var reliabilityWeight *float64
+	if len(bytes.TrimSpace(body.ReliabilityWeight)) > 0 {
+		value, ok := decodeRequiredFloat64(body.ReliabilityWeight)
+		if !ok || value < 0 || value > 1 {
+			details = append(details, evalSessionValidationDetail{
+				Field:   "eval_session.aggregation.reliability_weight",
+				Code:    "eval_session.aggregation.reliability_weight.invalid",
+				Message: "aggregation.reliability_weight must be a float between 0 and 1",
+			})
+		} else {
+			reliabilityWeight = &value
+		}
+	}
+
 	return EvalSessionAggregationInput{
 		Method:             method,
 		ReportVariance:     reportVariance,
 		ConfidenceInterval: confidenceInterval,
+		ReliabilityWeight:  reliabilityWeight,
 	}, details
 }
 

--- a/backend/internal/api/run_service_test.go
+++ b/backend/internal/api/run_service_test.go
@@ -406,6 +406,84 @@ func TestRunCreationManagerCreateEvalSessionStartsEvalSessionWorkflow(t *testing
 	}
 }
 
+func TestRunCreationManagerCreateEvalSessionPersistsAggregationReliabilityWeight(t *testing.T) {
+	workspaceID := uuid.New()
+	challengePackVersionID := uuid.New()
+	challengeInputSetID := uuid.New()
+	buildVersionID := uuid.New()
+	deploymentID := uuid.New()
+	sessionID := uuid.New()
+	caller := Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}
+
+	repo := &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{ID: challengePackVersionID},
+		challengeInputSets: []repository.ChallengeInputSetSummary{
+			{ID: challengeInputSetID, ChallengePackVersionID: challengePackVersionID},
+		},
+		challengeIdentityIDs: []uuid.UUID{uuid.New()},
+		deploymentsByBuildVersion: []repository.BuildVersionRunnableDeployment{
+			{
+				AgentBuildVersionID: buildVersionID,
+				Deployment: repository.RunnableDeployment{
+					ID:                        deploymentID,
+					OrganizationID:            uuid.New(),
+					WorkspaceID:               workspaceID,
+					Name:                      "Support Agent Deployment",
+					AgentDeploymentSnapshotID: uuid.New(),
+				},
+			},
+		},
+		createEvalSessionWithRunsResult: repository.CreateEvalSessionWithQueuedRunsResult{
+			Session: domain.EvalSession{
+				ID:            sessionID,
+				Status:        domain.EvalSessionStatusQueued,
+				Repetitions:   1,
+				SchemaVersion: 1,
+			},
+			Runs: []domain.Run{
+				{ID: uuid.New(), EvalSessionID: &sessionID},
+			},
+		},
+	}
+
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, &fakeRunWorkflowStarter{}, nil)
+	reliabilityWeight := 0.85
+
+	_, err := manager.CreateEvalSession(context.Background(), caller, CreateEvalSessionInput{
+		WorkspaceID:            workspaceID,
+		ChallengePackVersionID: challengePackVersionID,
+		Participants: []EvalSessionParticipantInput{
+			{AgentBuildVersionID: buildVersionID, Label: "Primary"},
+		},
+		ExecutionMode: "single_agent",
+		EvalSession: CreateEvalSessionConfigInput{
+			Repetitions: 1,
+			Aggregation: EvalSessionAggregationInput{
+				Method:             "mean",
+				ReportVariance:     true,
+				ConfidenceInterval: 0.95,
+				ReliabilityWeight:  &reliabilityWeight,
+			},
+			RoutingTaskSnapshot: EvalSessionRoutingTaskSnapshotInput{
+				Routing: json.RawMessage(`{"mode":"single_agent"}`),
+				Task:    json.RawMessage(`{"pack_version":"v1"}`),
+			},
+			SchemaVersion: 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateEvalSession returned error: %v", err)
+	}
+	if got := string(repo.createEvalSessionWithRunsParams.Session.AggregationConfig); got != `{"confidence_interval":0.95,"method":"mean","reliability_weight":0.85,"report_variance":true,"schema_version":1}` {
+		t.Fatalf("aggregation config = %s, want reliability_weight persisted", got)
+	}
+}
+
 func TestRunCreationManagerCreateEvalSessionRejectsUnresolvedBuildVersion(t *testing.T) {
 	workspaceID := uuid.New()
 	challengePackVersionID := uuid.New()

--- a/backend/internal/api/runs_test.go
+++ b/backend/internal/api/runs_test.go
@@ -437,6 +437,144 @@ func TestCreateEvalSessionEndpointRejectsWeightedMeanWithoutWeights(t *testing.T
 	}
 }
 
+func TestCreateEvalSessionEndpointAcceptsAggregationReliabilityWeight(t *testing.T) {
+	userID := uuid.New()
+	workspaceID := uuid.New()
+	service := &fakeRunCreationService{
+		evalSessionResult: CreateEvalSessionResult{
+			Session: domain.EvalSession{
+				ID:          uuid.New(),
+				Status:      domain.EvalSessionStatusQueued,
+				Repetitions: 2,
+				AggregationConfig: domain.EvalSessionSnapshot{Document: []byte(
+					`{"schema_version":1,"method":"mean","report_variance":true,"confidence_interval":0.95,"reliability_weight":0.85}`,
+				)},
+				SuccessThresholdConfig: domain.EvalSessionSnapshot{Document: []byte(`{"schema_version":1}`)},
+				RoutingTaskSnapshot:    domain.EvalSessionSnapshot{Document: []byte(`{"schema_version":1,"routing":{"mode":"single_agent"},"task":{"pack_version":"v1"}}`)},
+				SchemaVersion:          1,
+				CreatedAt:              time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
+				UpdatedAt:              time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
+			},
+			RunIDs: []uuid.UUID{uuid.New(), uuid.New()},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/eval-sessions", bytes.NewBufferString(`{
+		"workspace_id":"`+workspaceID.String()+`",
+		"challenge_pack_version_id":"`+uuid.New().String()+`",
+		"participants":[{"agent_build_version_id":"`+uuid.New().String()+`","label":"Primary"}],
+		"execution_mode":"single_agent",
+		"eval_session":{
+			"repetitions":2,
+			"aggregation":{"method":"mean","report_variance":true,"confidence_interval":0.95,"reliability_weight":0.85},
+			"routing_task_snapshot":{"routing":{"mode":"single_agent"},"task":{"pack_version":"v1"}},
+			"schema_version":1
+		}
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(headerUserID, userID.String())
+	req.Header.Set(headerWorkspaceMemberships, workspaceID.String()+":workspace_member")
+	recorder := httptest.NewRecorder()
+
+	newRouter("dev", nil,
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		nil,
+		0,
+		service,
+		&fakeRunReadService{},
+		&fakeReplayReadService{},
+		stubHostedRunIngestionService{},
+		nil,
+		stubAgentDeploymentReadService{},
+		stubChallengePackReadService{},
+		stubAgentBuildService{},
+		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+	if service.evalSessionInput.EvalSession.Aggregation.ReliabilityWeight == nil {
+		t.Fatal("reliability weight = nil, want 0.85")
+	}
+	if got := *service.evalSessionInput.EvalSession.Aggregation.ReliabilityWeight; got != 0.85 {
+		t.Fatalf("reliability weight = %.2f, want 0.85", got)
+	}
+}
+
+func TestCreateEvalSessionEndpointRejectsInvalidAggregationReliabilityWeight(t *testing.T) {
+	workspaceID := uuid.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/eval-sessions", bytes.NewBufferString(`{
+		"workspace_id":"`+workspaceID.String()+`",
+		"challenge_pack_version_id":"`+uuid.New().String()+`",
+		"participants":[{"agent_build_version_id":"`+uuid.New().String()+`","label":"Primary"}],
+		"execution_mode":"single_agent",
+		"eval_session":{
+			"repetitions":2,
+			"aggregation":{"method":"mean","report_variance":true,"confidence_interval":0.95,"reliability_weight":1.25},
+			"routing_task_snapshot":{"routing":{"mode":"single_agent"},"task":{"pack_version":"v1"}},
+			"schema_version":1
+		}
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(headerUserID, uuid.New().String())
+	req.Header.Set(headerWorkspaceMemberships, workspaceID.String()+":workspace_member")
+	recorder := httptest.NewRecorder()
+
+	newRouter("dev", nil,
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		nil,
+		0,
+		&fakeRunCreationService{},
+		&fakeRunReadService{},
+		&fakeReplayReadService{},
+		stubHostedRunIngestionService{},
+		nil,
+		stubAgentDeploymentReadService{},
+		stubChallengePackReadService{},
+		stubAgentBuildService{},
+		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusUnprocessableEntity)
+	}
+
+	var response evalSessionValidationEnvelope
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode validation response: %v", err)
+	}
+	if len(response.Errors) != 1 || response.Errors[0].Code != "eval_session.aggregation.reliability_weight.invalid" {
+		t.Fatalf("validation errors = %+v, want eval_session.aggregation.reliability_weight.invalid", response.Errors)
+	}
+}
+
 func TestCreateEvalSessionEndpointAcceptsNullOptionalObjects(t *testing.T) {
 	userID := uuid.New()
 	workspaceID := uuid.New()

--- a/backend/internal/repository/eval_session_aggregation.go
+++ b/backend/internal/repository/eval_session_aggregation.go
@@ -587,7 +587,7 @@ func deriveEvalSessionChallengeSuccess(results []JudgeResultRecord, threshold fl
 				}
 			}
 		}
-		if result.NormalizedScore != nil {
+		if result.NormalizedScore != nil && !verdictSeen {
 			scores = append(scores, *result.NormalizedScore)
 		}
 	}
@@ -1075,6 +1075,8 @@ func buildEvalSessionRepeatedComparison(
 	comparison.RunnerUpLabel = runnerUp.Label
 
 	if leader.Routing.PrimaryMetric != runnerUp.Routing.PrimaryMetric {
+		// Participants in one eval session currently share a single aggregate behavior,
+		// so routing mismatches should be unreachable unless per-participant routing is added later.
 		comparison.ReasonCode = "metric_routing_mismatch"
 		return comparison
 	}

--- a/backend/internal/repository/eval_session_aggregation.go
+++ b/backend/internal/repository/eval_session_aggregation.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/domain"
 	repositorysqlc "github.com/Atharva-Kanherkar/agentclash/backend/internal/repository/sqlc"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -19,6 +21,7 @@ const (
 	evalSessionAggregateSchemaVersion     = 1
 	evalSessionAggregateIntervalEstimator = "normal_95"
 	evalSessionHighVarianceRule           = "stddev/abs(mean)>0.15_or_range>0.10"
+	evalSessionDefaultSuccessThreshold    = 0.8
 )
 
 type EvalSessionAggregateRecord struct {
@@ -50,14 +53,68 @@ type evalSessionAggregateDocument struct {
 	TopLevelSource   string                                `json:"top_level_source,omitempty"`
 	Overall          *evalSessionMetricAggregate           `json:"overall,omitempty"`
 	Dimensions       map[string]evalSessionMetricAggregate `json:"dimensions,omitempty"`
+	TaskSuccess      []evalSessionTaskSuccess              `json:"task_success,omitempty"`
+	PassAtK          *evalSessionPassMetricSeries          `json:"pass_at_k,omitempty"`
+	PassPowK         *evalSessionPassMetricSeries          `json:"pass_pow_k,omitempty"`
+	MetricRouting    *evalSessionMetricRouting             `json:"metric_routing,omitempty"`
 	Participants     []evalSessionParticipantAggregate     `json:"participants,omitempty"`
+	Comparison       *evalSessionRepeatedComparison        `json:"comparison,omitempty"`
 }
 
 type evalSessionParticipantAggregate struct {
-	LaneIndex  int32                                 `json:"lane_index"`
-	Label      string                                `json:"label"`
-	Overall    *evalSessionMetricAggregate           `json:"overall,omitempty"`
-	Dimensions map[string]evalSessionMetricAggregate `json:"dimensions,omitempty"`
+	LaneIndex     int32                                 `json:"lane_index"`
+	Label         string                                `json:"label"`
+	Overall       *evalSessionMetricAggregate           `json:"overall,omitempty"`
+	Dimensions    map[string]evalSessionMetricAggregate `json:"dimensions,omitempty"`
+	TaskSuccess   []evalSessionTaskSuccess              `json:"task_success,omitempty"`
+	PassAtK       *evalSessionPassMetricSeries          `json:"pass_at_k,omitempty"`
+	PassPowK      *evalSessionPassMetricSeries          `json:"pass_pow_k,omitempty"`
+	MetricRouting *evalSessionMetricRouting             `json:"metric_routing,omitempty"`
+}
+
+type evalSessionTaskSuccess struct {
+	TaskKey             string             `json:"task_key"`
+	ChallengeIdentityID *uuid.UUID         `json:"challenge_identity_id,omitempty"`
+	ChallengeKey        string             `json:"challenge_key,omitempty"`
+	Title               string             `json:"title,omitempty"`
+	ObservedTrials      int                `json:"observed_trials"`
+	SuccessfulTrials    int                `json:"successful_trials"`
+	SuccessRate         float64            `json:"success_rate"`
+	Source              string             `json:"source"`
+	PassAtK             map[string]float64 `json:"pass_at_k,omitempty"`
+	PassPowK            map[string]float64 `json:"pass_pow_k,omitempty"`
+}
+
+type evalSessionPassMetricSeries struct {
+	EffectiveK int                                   `json:"effective_k"`
+	ByK        map[string]evalSessionMetricAggregate `json:"by_k,omitempty"`
+}
+
+type evalSessionMetricRouting struct {
+	Source              string                        `json:"source"`
+	ReliabilityWeight   float64                       `json:"reliability_weight"`
+	Reasoning           string                        `json:"reasoning"`
+	PrimaryMetric       string                        `json:"primary_metric"`
+	EffectiveK          int                           `json:"effective_k"`
+	CompositeAgentScore float64                       `json:"composite_agent_score"`
+	CompositeInterval   *evalSessionAggregateInterval `json:"composite_interval,omitempty"`
+}
+
+type evalSessionRepeatedComparison struct {
+	Status            string                        `json:"status"`
+	ReasonCode        string                        `json:"reason_code,omitempty"`
+	ComparedMetric    string                        `json:"compared_metric,omitempty"`
+	EffectiveK        int                           `json:"effective_k"`
+	WinnerLaneIndex   *int32                        `json:"winner_lane_index,omitempty"`
+	WinnerLabel       string                        `json:"winner_label,omitempty"`
+	LeaderLaneIndex   *int32                        `json:"leader_lane_index,omitempty"`
+	LeaderLabel       string                        `json:"leader_label,omitempty"`
+	LeaderValue       *float64                      `json:"leader_value,omitempty"`
+	LeaderInterval    *evalSessionAggregateInterval `json:"leader_interval,omitempty"`
+	RunnerUpLaneIndex *int32                        `json:"runner_up_lane_index,omitempty"`
+	RunnerUpLabel     string                        `json:"runner_up_label,omitempty"`
+	RunnerUpValue     *float64                      `json:"runner_up_value,omitempty"`
+	RunnerUpInterval  *evalSessionAggregateInterval `json:"runner_up_interval,omitempty"`
 }
 
 type evalSessionMetricAggregate struct {
@@ -84,8 +141,9 @@ type evalSessionAggregateEvidence struct {
 }
 
 type evalSessionAggregateSource struct {
-	RunID    uuid.UUID
-	Document runScorecardDocument
+	RunID              uuid.UUID
+	Document           runScorecardDocument
+	ParticipantSources []evalSessionAggregateParticipantSource
 }
 
 type evalSessionParticipantKey struct {
@@ -93,10 +151,76 @@ type evalSessionParticipantKey struct {
 	Label     string
 }
 
+type evalSessionAggregateParticipantSource struct {
+	Key          evalSessionParticipantKey
+	Agent        runScorecardAgentSummary
+	TaskOutcomes []evalSessionAggregateTaskOutcome
+}
+
+type evalSessionAggregateTaskOutcome struct {
+	TaskKey             string
+	ChallengeIdentityID *uuid.UUID
+	ChallengeKey        string
+	Title               string
+	Success             bool
+	Source              string
+}
+
 type evalSessionParticipantAccumulator struct {
-	Key        evalSessionParticipantKey
-	Overall    []float64
-	Dimensions map[string][]float64
+	Key          evalSessionParticipantKey
+	Overall      []float64
+	Dimensions   map[string][]float64
+	TaskOutcomes map[string]*evalSessionTaskOutcomeAccumulator
+}
+
+type evalSessionTaskOutcomeAccumulator struct {
+	TaskKey             string
+	ChallengeIdentityID *uuid.UUID
+	ChallengeKey        string
+	Title               string
+	Source              string
+	Outcomes            []bool
+}
+
+type evalSessionAggregateBehavior struct {
+	KValues                 []int
+	EffectiveK              int
+	SuccessThreshold        float64
+	RequireAllDimensions    []string
+	ManualReliabilityWeight *float64
+	TaskProperties          evalSessionRoutingTaskProperties
+}
+
+type evalSessionAggregateConfigSnapshot struct {
+	Method             string   `json:"method"`
+	ReportVariance     bool     `json:"report_variance"`
+	ConfidenceInterval float64  `json:"confidence_interval"`
+	ReliabilityWeight  *float64 `json:"reliability_weight,omitempty"`
+}
+
+type evalSessionSuccessThresholdSnapshot struct {
+	MinPassRate          *float64 `json:"min_pass_rate,omitempty"`
+	RequireAllDimensions []string `json:"require_all_dimensions,omitempty"`
+}
+
+type evalSessionRoutingTaskDocument struct {
+	Task json.RawMessage `json:"task"`
+}
+
+type evalSessionRoutingTaskProperties struct {
+	HasSideEffects bool
+	Autonomy       string
+	StepCount      int
+	OutputType     string
+}
+
+type evalSessionComparableParticipant struct {
+	Index     int
+	LaneIndex int32
+	Label     string
+	PassAtK   evalSessionMetricAggregate
+	PassPowK  evalSessionMetricAggregate
+	Routing   evalSessionMetricRouting
 }
 
 func (r *Repository) GetEvalSessionResultBySessionID(ctx context.Context, evalSessionID uuid.UUID) (EvalSessionAggregateRecord, error) {
@@ -138,8 +262,13 @@ func (r *Repository) UpsertEvalSessionAggregate(ctx context.Context, params Upse
 }
 
 func (r *Repository) AggregateEvalSession(ctx context.Context, evalSessionID uuid.UUID) (EvalSessionAggregateRecord, error) {
-	if _, err := r.GetEvalSessionByID(ctx, evalSessionID); err != nil {
+	session, err := r.GetEvalSessionByID(ctx, evalSessionID)
+	if err != nil {
 		return EvalSessionAggregateRecord{}, err
+	}
+	behavior, err := buildEvalSessionAggregateBehavior(session)
+	if err != nil {
+		return EvalSessionAggregateRecord{}, fmt.Errorf("build eval session aggregate behavior: %w", err)
 	}
 
 	runs, err := r.ListRunsByEvalSessionID(ctx, evalSessionID)
@@ -149,6 +278,7 @@ func (r *Repository) AggregateEvalSession(ctx context.Context, evalSessionID uui
 
 	missingScorecardRunIDs := make([]uuid.UUID, 0)
 	sources := make([]evalSessionAggregateSource, 0, len(runs))
+	warnings := make([]string, 0)
 	for _, run := range runs {
 		scorecard, scorecardErr := r.GetRunScorecardByRunID(ctx, run.ID)
 		switch {
@@ -157,9 +287,15 @@ func (r *Repository) AggregateEvalSession(ctx context.Context, evalSessionID uui
 			if err := json.Unmarshal(scorecard.Scorecard, &document); err != nil {
 				return EvalSessionAggregateRecord{}, fmt.Errorf("decode run scorecard %s: %w", run.ID, err)
 			}
+			participantSources, participantWarnings, err := r.buildEvalSessionAggregateParticipantSources(ctx, run.ID, document, behavior)
+			if err != nil {
+				return EvalSessionAggregateRecord{}, fmt.Errorf("build eval session participant sources for run %s: %w", run.ID, err)
+			}
+			warnings = append(warnings, participantWarnings...)
 			sources = append(sources, evalSessionAggregateSource{
-				RunID:    run.ID,
-				Document: document,
+				RunID:              run.ID,
+				Document:           document,
+				ParticipantSources: participantSources,
 			})
 		case errors.Is(scorecardErr, ErrRunScorecardNotFound):
 			missingScorecardRunIDs = append(missingScorecardRunIDs, run.ID)
@@ -168,7 +304,7 @@ func (r *Repository) AggregateEvalSession(ctx context.Context, evalSessionID uui
 		}
 	}
 
-	aggregate, evidence, scoredChildCount, err := buildEvalSessionAggregatePayload(len(runs), sources, missingScorecardRunIDs)
+	aggregate, evidence, scoredChildCount, err := buildEvalSessionAggregatePayload(len(runs), sources, missingScorecardRunIDs, behavior, warnings)
 	if err != nil {
 		return EvalSessionAggregateRecord{}, err
 	}
@@ -183,7 +319,328 @@ func (r *Repository) AggregateEvalSession(ctx context.Context, evalSessionID uui
 	})
 }
 
-func buildEvalSessionAggregatePayload(childRunCount int, sources []evalSessionAggregateSource, missingScorecardRunIDs []uuid.UUID) (json.RawMessage, json.RawMessage, int, error) {
+func buildEvalSessionAggregateBehavior(session domain.EvalSession) (evalSessionAggregateBehavior, error) {
+	behavior := evalSessionAggregateBehavior{
+		KValues:          evalSessionKValues(int(session.Repetitions)),
+		EffectiveK:       max(int(session.Repetitions), 1),
+		SuccessThreshold: evalSessionDefaultSuccessThreshold,
+	}
+
+	if len(strings.TrimSpace(string(session.AggregationConfig.Document))) > 0 {
+		var aggregation evalSessionAggregateConfigSnapshot
+		if err := json.Unmarshal(session.AggregationConfig.Document, &aggregation); err != nil {
+			return evalSessionAggregateBehavior{}, fmt.Errorf("decode aggregation config: %w", err)
+		}
+		behavior.ManualReliabilityWeight = cloneFloat64Ptr(aggregation.ReliabilityWeight)
+	}
+
+	if len(strings.TrimSpace(string(session.SuccessThresholdConfig.Document))) > 0 {
+		var threshold evalSessionSuccessThresholdSnapshot
+		if err := json.Unmarshal(session.SuccessThresholdConfig.Document, &threshold); err != nil {
+			return evalSessionAggregateBehavior{}, fmt.Errorf("decode success threshold config: %w", err)
+		}
+		if threshold.MinPassRate != nil {
+			behavior.SuccessThreshold = *threshold.MinPassRate
+		}
+		behavior.RequireAllDimensions = uniqueSortedStrings(append([]string(nil), threshold.RequireAllDimensions...))
+	}
+
+	taskProperties, err := buildEvalSessionRoutingTaskProperties(session.RoutingTaskSnapshot.Document)
+	if err != nil {
+		return evalSessionAggregateBehavior{}, err
+	}
+	behavior.TaskProperties = taskProperties
+
+	return behavior, nil
+}
+
+func buildEvalSessionRoutingTaskProperties(payload json.RawMessage) (evalSessionRoutingTaskProperties, error) {
+	if len(strings.TrimSpace(string(payload))) == 0 || string(payload) == "{}" {
+		return evalSessionRoutingTaskProperties{}, nil
+	}
+
+	var document map[string]any
+	if err := json.Unmarshal(payload, &document); err != nil {
+		return evalSessionRoutingTaskProperties{}, fmt.Errorf("decode routing task snapshot: %w", err)
+	}
+	taskBody, ok := mapValue(document["task"])
+	if !ok {
+		return evalSessionRoutingTaskProperties{}, nil
+	}
+	properties, ok := mapValue(taskBody["task_properties"])
+	if !ok {
+		return evalSessionRoutingTaskProperties{}, nil
+	}
+
+	return evalSessionRoutingTaskProperties{
+		HasSideEffects: boolValue(properties["has_side_effects"]),
+		Autonomy:       strings.ToLower(stringValue(properties["autonomy"])),
+		StepCount:      intValue(properties["step_count"]),
+		OutputType:     strings.ToLower(stringValue(properties["output_type"])),
+	}, nil
+}
+
+func evalSessionKValues(repetitions int) []int {
+	set := map[int]struct{}{
+		1:  {},
+		3:  {},
+		5:  {},
+		10: {},
+	}
+	if repetitions > 0 {
+		set[repetitions] = struct{}{}
+	}
+	values := make([]int, 0, len(set))
+	for value := range set {
+		values = append(values, value)
+	}
+	sort.Ints(values)
+	return values
+}
+
+func mapValue(value any) (map[string]any, bool) {
+	result, ok := value.(map[string]any)
+	return result, ok
+}
+
+func boolValue(value any) bool {
+	result, ok := value.(bool)
+	return ok && result
+}
+
+func stringValue(value any) string {
+	result, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(result)
+}
+
+func intValue(value any) int {
+	switch typed := value.(type) {
+	case float64:
+		return int(typed)
+	case float32:
+		return int(typed)
+	case int:
+		return typed
+	case int32:
+		return int(typed)
+	case int64:
+		return int(typed)
+	default:
+		return 0
+	}
+}
+
+func (r *Repository) buildEvalSessionAggregateParticipantSources(
+	ctx context.Context,
+	runID uuid.UUID,
+	document runScorecardDocument,
+	behavior evalSessionAggregateBehavior,
+) ([]evalSessionAggregateParticipantSource, []string, error) {
+	participantSources := make([]evalSessionAggregateParticipantSource, 0, len(document.Agents))
+	warnings := make([]string, 0)
+
+	for _, agent := range document.Agents {
+		participantSource := evalSessionAggregateParticipantSource{
+			Key: evalSessionParticipantKey{
+				LaneIndex: agent.LaneIndex,
+				Label:     agent.Label,
+			},
+			Agent: agent,
+		}
+
+		if agent.HasScorecard {
+			taskOutcomes, taskWarnings, err := r.loadEvalSessionParticipantTaskOutcomes(ctx, document.EvaluationSpecID, agent, behavior)
+			if err != nil {
+				return nil, nil, fmt.Errorf("resolve participant %q (lane %d) task outcomes: %w", agent.Label, agent.LaneIndex, err)
+			}
+			participantSource.TaskOutcomes = taskOutcomes
+			for _, warning := range taskWarnings {
+				warnings = append(warnings, fmt.Sprintf("run %s participant %q (lane %d): %s", runID, agent.Label, agent.LaneIndex, warning))
+			}
+		}
+
+		participantSources = append(participantSources, participantSource)
+	}
+
+	return participantSources, warnings, nil
+}
+
+func (r *Repository) loadEvalSessionParticipantTaskOutcomes(
+	ctx context.Context,
+	evaluationSpecID uuid.UUID,
+	agent runScorecardAgentSummary,
+	behavior evalSessionAggregateBehavior,
+) ([]evalSessionAggregateTaskOutcome, []string, error) {
+	warnings := make([]string, 0)
+	challengeMetadata := map[uuid.UUID]ChallengeDefinitionExecutionContext{}
+
+	executionContext, err := r.GetRunAgentExecutionContextByID(ctx, agent.RunAgentID)
+	if err == nil {
+		challengeMetadata = buildEvalSessionChallengeMetadata(executionContext)
+	} else {
+		warnings = append(warnings, fmt.Sprintf("challenge metadata unavailable (%v); task summaries will fall back to challenge ids when possible", err))
+	}
+
+	if evaluationSpecID != uuid.Nil {
+		judgeResults, err := r.ListJudgeResultsByRunAgentAndEvaluationSpec(ctx, agent.RunAgentID, evaluationSpecID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("list judge results: %w", err)
+		}
+		taskOutcomes := deriveEvalSessionChallengeTaskOutcomes(judgeResults, challengeMetadata, behavior.SuccessThreshold)
+		if len(taskOutcomes) > 0 {
+			return taskOutcomes, warnings, nil
+		}
+	}
+
+	fallback, ok := deriveEvalSessionSuiteFallbackOutcome(agent, behavior)
+	if ok {
+		warnings = append(warnings, "challenge-level task outcomes unavailable; using suite-level scorecard fallback")
+		return []evalSessionAggregateTaskOutcome{fallback}, warnings, nil
+	}
+
+	warnings = append(warnings, "task outcomes unavailable; neither challenge-level judge results nor suite-level scorecard fallback could be resolved")
+	return nil, warnings, nil
+}
+
+func buildEvalSessionChallengeMetadata(executionContext RunAgentExecutionContext) map[uuid.UUID]ChallengeDefinitionExecutionContext {
+	metadata := make(map[uuid.UUID]ChallengeDefinitionExecutionContext, len(executionContext.ChallengePackVersion.Challenges))
+	for _, challenge := range executionContext.ChallengePackVersion.Challenges {
+		metadata[challenge.ChallengeIdentityID] = challenge
+	}
+	return metadata
+}
+
+func deriveEvalSessionChallengeTaskOutcomes(
+	results []JudgeResultRecord,
+	challengeMetadata map[uuid.UUID]ChallengeDefinitionExecutionContext,
+	threshold float64,
+) []evalSessionAggregateTaskOutcome {
+	grouped := map[uuid.UUID][]JudgeResultRecord{}
+	for _, result := range results {
+		if result.ChallengeIdentityID == nil {
+			continue
+		}
+		grouped[*result.ChallengeIdentityID] = append(grouped[*result.ChallengeIdentityID], result)
+	}
+
+	challengeIDs := make([]uuid.UUID, 0, len(grouped))
+	for challengeID := range grouped {
+		challengeIDs = append(challengeIDs, challengeID)
+	}
+	sort.Slice(challengeIDs, func(i, j int) bool {
+		left, leftOK := challengeMetadata[challengeIDs[i]]
+		right, rightOK := challengeMetadata[challengeIDs[j]]
+		switch {
+		case leftOK && rightOK && left.ExecutionOrder != right.ExecutionOrder:
+			return left.ExecutionOrder < right.ExecutionOrder
+		case leftOK && rightOK && left.ChallengeKey != right.ChallengeKey:
+			return left.ChallengeKey < right.ChallengeKey
+		default:
+			return challengeIDs[i].String() < challengeIDs[j].String()
+		}
+	})
+
+	outcomes := make([]evalSessionAggregateTaskOutcome, 0, len(challengeIDs))
+	for _, challengeID := range challengeIDs {
+		success, source, ok := deriveEvalSessionChallengeSuccess(grouped[challengeID], threshold)
+		if !ok {
+			continue
+		}
+		taskKey := challengeID.String()
+		challengeKey := ""
+		title := ""
+		if challenge, ok := challengeMetadata[challengeID]; ok {
+			if strings.TrimSpace(challenge.ChallengeKey) != "" {
+				taskKey = challenge.ChallengeKey
+				challengeKey = challenge.ChallengeKey
+			}
+			title = strings.TrimSpace(challenge.Title)
+		}
+		challengeIDCopy := challengeID
+		outcomes = append(outcomes, evalSessionAggregateTaskOutcome{
+			TaskKey:             taskKey,
+			ChallengeIdentityID: &challengeIDCopy,
+			ChallengeKey:        challengeKey,
+			Title:               title,
+			Success:             success,
+			Source:              source,
+		})
+	}
+
+	return outcomes
+}
+
+func deriveEvalSessionChallengeSuccess(results []JudgeResultRecord, threshold float64) (bool, string, bool) {
+	verdictSeen := false
+	scores := make([]float64, 0, len(results))
+
+	for _, result := range results {
+		if result.Verdict != nil {
+			verdict := strings.ToLower(strings.TrimSpace(*result.Verdict))
+			if verdict != "" {
+				verdictSeen = true
+				if verdict != "pass" {
+					return false, "judge_results_verdict", true
+				}
+			}
+		}
+		if result.NormalizedScore != nil {
+			scores = append(scores, *result.NormalizedScore)
+		}
+	}
+
+	if verdictSeen {
+		return true, "judge_results_verdict", true
+	}
+	if len(scores) > 0 {
+		return kahanMean(scores) >= threshold, "judge_results_threshold", true
+	}
+	return false, "", false
+}
+
+func deriveEvalSessionSuiteFallbackOutcome(agent runScorecardAgentSummary, behavior evalSessionAggregateBehavior) (evalSessionAggregateTaskOutcome, bool) {
+	if agent.Passed != nil {
+		return evalSessionAggregateTaskOutcome{
+			TaskKey: "suite",
+			Title:   "Suite-level fallback",
+			Success: *agent.Passed,
+			Source:  "scorecard_passed",
+		}, true
+	}
+	if agent.OverallScore == nil {
+		return evalSessionAggregateTaskOutcome{}, false
+	}
+
+	success := *agent.OverallScore >= behavior.SuccessThreshold
+	if success && len(behavior.RequireAllDimensions) > 0 {
+		dimensions := evalSessionAggregateDimensions(agent)
+		for _, dimension := range behavior.RequireAllDimensions {
+			score, ok := dimensions[dimension]
+			if !ok || score < behavior.SuccessThreshold {
+				success = false
+				break
+			}
+		}
+	}
+
+	return evalSessionAggregateTaskOutcome{
+		TaskKey: "suite",
+		Title:   "Suite-level fallback",
+		Success: success,
+		Source:  "scorecard_threshold",
+	}, true
+}
+
+func buildEvalSessionAggregatePayload(
+	childRunCount int,
+	sources []evalSessionAggregateSource,
+	missingScorecardRunIDs []uuid.UUID,
+	behavior evalSessionAggregateBehavior,
+	extraWarnings []string,
+) (json.RawMessage, json.RawMessage, int, error) {
 	if len(sources) == 0 {
 		return nil, nil, 0, ErrEvalSessionAggregateUnavailable
 	}
@@ -195,36 +652,24 @@ func buildEvalSessionAggregatePayload(childRunCount int, sources []evalSessionAg
 		return missingScorecardRunIDs[i].String() < missingScorecardRunIDs[j].String()
 	})
 
-	warnings := make([]string, 0)
-	topLevelOverall := make([]float64, 0, len(sources))
-	topLevelDimensions := map[string][]float64{}
+	warnings := append([]string(nil), extraWarnings...)
 	participantAccumulators := map[evalSessionParticipantKey]*evalSessionParticipantAccumulator{}
 	insufficientEvidence := false
 
 	for _, source := range sources {
-		selectedAgent, ok := selectEvalSessionAggregateAgent(source.Document)
-		if ok {
-			if selectedAgent.OverallScore != nil {
-				topLevelOverall = append(topLevelOverall, *selectedAgent.OverallScore)
-			}
-			for key, value := range evalSessionAggregateDimensions(selectedAgent) {
-				topLevelDimensions[key] = append(topLevelDimensions[key], value)
-			}
-		} else {
-			warnings = append(warnings, fmt.Sprintf("run %s did not expose a sole or winning agent summary for top-level aggregation", source.RunID))
-		}
-
-		for _, agent := range source.Document.Agents {
+		for _, participantSource := range defaultEvalSessionParticipantSources(source) {
+			agent := participantSource.Agent
 			if !agent.HasScorecard {
 				warnings = append(warnings, fmt.Sprintf("run %s participant %q (lane %d) has no scorecard", source.RunID, agent.Label, agent.LaneIndex))
 				continue
 			}
-			key := evalSessionParticipantKey{LaneIndex: agent.LaneIndex, Label: agent.Label}
+			key := participantSource.Key
 			accumulator, ok := participantAccumulators[key]
 			if !ok {
 				accumulator = &evalSessionParticipantAccumulator{
-					Key:        key,
-					Dimensions: map[string][]float64{},
+					Key:          key,
+					Dimensions:   map[string][]float64{},
+					TaskOutcomes: map[string]*evalSessionTaskOutcomeAccumulator{},
 				}
 				participantAccumulators[key] = accumulator
 			}
@@ -233,6 +678,42 @@ func buildEvalSessionAggregatePayload(childRunCount int, sources []evalSessionAg
 			}
 			for dimKey, value := range evalSessionAggregateDimensions(agent) {
 				accumulator.Dimensions[dimKey] = append(accumulator.Dimensions[dimKey], value)
+			}
+			for _, taskOutcome := range participantSource.TaskOutcomes {
+				taskKey := strings.TrimSpace(taskOutcome.TaskKey)
+				if taskKey == "" {
+					if taskOutcome.ChallengeIdentityID != nil {
+						taskKey = taskOutcome.ChallengeIdentityID.String()
+					} else {
+						taskKey = "suite"
+					}
+				}
+				taskAccumulator, ok := accumulator.TaskOutcomes[taskKey]
+				if !ok {
+					taskAccumulator = &evalSessionTaskOutcomeAccumulator{
+						TaskKey:             taskKey,
+						ChallengeIdentityID: cloneUUIDPtr(taskOutcome.ChallengeIdentityID),
+						ChallengeKey:        taskOutcome.ChallengeKey,
+						Title:               taskOutcome.Title,
+						Source:              taskOutcome.Source,
+					}
+					accumulator.TaskOutcomes[taskKey] = taskAccumulator
+				}
+				if taskAccumulator.ChallengeIdentityID == nil {
+					taskAccumulator.ChallengeIdentityID = cloneUUIDPtr(taskOutcome.ChallengeIdentityID)
+				}
+				if strings.TrimSpace(taskAccumulator.ChallengeKey) == "" {
+					taskAccumulator.ChallengeKey = taskOutcome.ChallengeKey
+				}
+				if strings.TrimSpace(taskAccumulator.Title) == "" {
+					taskAccumulator.Title = taskOutcome.Title
+				}
+				if taskAccumulator.Source == "" {
+					taskAccumulator.Source = taskOutcome.Source
+				} else if taskOutcome.Source != "" && taskAccumulator.Source != taskOutcome.Source {
+					taskAccumulator.Source = "mixed"
+				}
+				taskAccumulator.Outcomes = append(taskAccumulator.Outcomes, taskOutcome.Success)
 			}
 		}
 	}
@@ -248,32 +729,6 @@ func buildEvalSessionAggregatePayload(childRunCount int, sources []evalSessionAg
 		SchemaVersion:    evalSessionAggregateSchemaVersion,
 		ChildRunCount:    childRunCount,
 		ScoredChildCount: len(sources),
-		TopLevelSource:   "sole_agent_or_winner",
-	}
-
-	if len(topLevelOverall) > 0 {
-		overall := buildEvalSessionMetricAggregate(topLevelOverall)
-		document.Overall = &overall
-		if len(topLevelOverall) < len(sources) {
-			warnings = append(warnings, fmt.Sprintf("overall aggregate uses %d of %d scored child runs", len(topLevelOverall), len(sources)))
-		}
-		if len(topLevelOverall) < 2 {
-			insufficientEvidence = true
-		}
-	}
-	if len(topLevelDimensions) > 0 {
-		document.Dimensions = map[string]evalSessionMetricAggregate{}
-		keys := sortedMetricKeys(topLevelDimensions)
-		for _, key := range keys {
-			values := topLevelDimensions[key]
-			document.Dimensions[key] = buildEvalSessionMetricAggregate(values)
-			if len(values) < len(sources) {
-				warnings = append(warnings, fmt.Sprintf("dimension %q aggregate uses %d of %d scored child runs", key, len(values), len(sources)))
-			}
-			if len(values) < 2 {
-				insufficientEvidence = true
-			}
-		}
 	}
 
 	participantKeys := make([]evalSessionParticipantKey, 0, len(participantAccumulators))
@@ -316,7 +771,40 @@ func buildEvalSessionAggregatePayload(childRunCount int, sources []evalSessionAg
 				}
 			}
 		}
+		if len(accumulator.TaskOutcomes) > 0 {
+			participant.TaskSuccess = buildEvalSessionTaskSuccess(accumulator.TaskOutcomes, behavior.KValues)
+			participant.PassAtK = buildEvalSessionPassMetricSeries(participant.TaskSuccess, behavior.KValues, behavior.EffectiveK, "pass_at_k")
+			participant.PassPowK = buildEvalSessionPassMetricSeries(participant.TaskSuccess, behavior.KValues, behavior.EffectiveK, "pass_pow_k")
+			participant.MetricRouting = buildEvalSessionMetricRouting(behavior, participant.PassAtK, participant.PassPowK)
+			for _, task := range participant.TaskSuccess {
+				if task.ObservedTrials < len(sources) {
+					warnings = append(warnings, fmt.Sprintf("participant %q (lane %d) task %q uses %d of %d scored child runs", key.Label, key.LaneIndex, task.TaskKey, task.ObservedTrials, len(sources)))
+				}
+			}
+		}
 		document.Participants = append(document.Participants, participant)
+	}
+
+	if len(document.Participants) == 1 {
+		participant := document.Participants[0]
+		document.TopLevelSource = "sole_participant"
+		document.Overall = participant.Overall
+		document.Dimensions = participant.Dimensions
+		document.TaskSuccess = participant.TaskSuccess
+		document.PassAtK = participant.PassAtK
+		document.PassPowK = participant.PassPowK
+		document.MetricRouting = participant.MetricRouting
+	} else if len(document.Participants) > 1 {
+		document.Comparison = buildEvalSessionRepeatedComparison(document.Participants, behavior.EffectiveK, len(sources))
+		if document.Comparison != nil && document.Comparison.Status == "clear_winner" && document.Comparison.WinnerLaneIndex != nil {
+			if winner, ok := evalSessionParticipantByLane(document.Participants, *document.Comparison.WinnerLaneIndex); ok {
+				document.TopLevelSource = "repeated_clear_winner"
+				document.Overall = winner.Overall
+				document.Dimensions = winner.Dimensions
+			}
+		} else {
+			warnings = append(warnings, buildEvalSessionComparisonOmissionWarning(document.Comparison))
+		}
 	}
 
 	if insufficientEvidence {
@@ -337,19 +825,348 @@ func buildEvalSessionAggregatePayload(childRunCount int, sources []evalSessionAg
 	return aggregateJSON, evidenceJSON, len(sources), nil
 }
 
-func selectEvalSessionAggregateAgent(document runScorecardDocument) (runScorecardAgentSummary, bool) {
-	if len(document.Agents) == 1 {
-		return document.Agents[0], true
+func defaultEvalSessionParticipantSources(source evalSessionAggregateSource) []evalSessionAggregateParticipantSource {
+	if len(source.ParticipantSources) > 0 {
+		return append([]evalSessionAggregateParticipantSource(nil), source.ParticipantSources...)
 	}
-	if document.WinningRunAgentID == nil {
-		return runScorecardAgentSummary{}, false
+	participants := make([]evalSessionAggregateParticipantSource, 0, len(source.Document.Agents))
+	for _, agent := range source.Document.Agents {
+		participants = append(participants, evalSessionAggregateParticipantSource{
+			Key: evalSessionParticipantKey{
+				LaneIndex: agent.LaneIndex,
+				Label:     agent.Label,
+			},
+			Agent: agent,
+		})
 	}
-	for _, agent := range document.Agents {
-		if agent.RunAgentID == *document.WinningRunAgentID {
-			return agent, true
+	return participants
+}
+
+func buildEvalSessionTaskSuccess(
+	taskOutcomes map[string]*evalSessionTaskOutcomeAccumulator,
+	kValues []int,
+) []evalSessionTaskSuccess {
+	taskKeys := make([]string, 0, len(taskOutcomes))
+	for taskKey := range taskOutcomes {
+		taskKeys = append(taskKeys, taskKey)
+	}
+	sort.Strings(taskKeys)
+
+	results := make([]evalSessionTaskSuccess, 0, len(taskKeys))
+	for _, taskKey := range taskKeys {
+		taskOutcome := taskOutcomes[taskKey]
+		if len(taskOutcome.Outcomes) == 0 {
+			continue
+		}
+		successfulTrials := 0
+		for _, outcome := range taskOutcome.Outcomes {
+			if outcome {
+				successfulTrials++
+			}
+		}
+		observedTrials := len(taskOutcome.Outcomes)
+		successRate := float64(successfulTrials) / float64(observedTrials)
+		taskResult := evalSessionTaskSuccess{
+			TaskKey:             taskOutcome.TaskKey,
+			ChallengeIdentityID: cloneUUIDPtr(taskOutcome.ChallengeIdentityID),
+			ChallengeKey:        taskOutcome.ChallengeKey,
+			Title:               taskOutcome.Title,
+			ObservedTrials:      observedTrials,
+			SuccessfulTrials:    successfulTrials,
+			SuccessRate:         successRate,
+			Source:              taskOutcome.Source,
+			PassAtK:             map[string]float64{},
+			PassPowK:            map[string]float64{},
+		}
+		for _, k := range kValues {
+			key := strconv.Itoa(k)
+			taskResult.PassAtK[key] = 1 - math.Pow(1-successRate, float64(k))
+			taskResult.PassPowK[key] = math.Pow(successRate, float64(k))
+		}
+		results = append(results, taskResult)
+	}
+
+	return results
+}
+
+func buildEvalSessionPassMetricSeries(
+	taskSuccess []evalSessionTaskSuccess,
+	kValues []int,
+	effectiveK int,
+	metric string,
+) *evalSessionPassMetricSeries {
+	if len(taskSuccess) == 0 {
+		return nil
+	}
+
+	series := &evalSessionPassMetricSeries{
+		EffectiveK: effectiveK,
+		ByK:        map[string]evalSessionMetricAggregate{},
+	}
+	for _, k := range kValues {
+		key := strconv.Itoa(k)
+		values := make([]float64, 0, len(taskSuccess))
+		for _, task := range taskSuccess {
+			switch metric {
+			case "pass_pow_k":
+				if value, ok := task.PassPowK[key]; ok {
+					values = append(values, value)
+				}
+			default:
+				if value, ok := task.PassAtK[key]; ok {
+					values = append(values, value)
+				}
+			}
+		}
+		if len(values) == 0 {
+			continue
+		}
+		series.ByK[key] = buildEvalSessionMetricAggregate(values)
+	}
+
+	if len(series.ByK) == 0 {
+		return nil
+	}
+	return series
+}
+
+func buildEvalSessionMetricRouting(
+	behavior evalSessionAggregateBehavior,
+	passAtK *evalSessionPassMetricSeries,
+	passPowK *evalSessionPassMetricSeries,
+) *evalSessionMetricRouting {
+	passAtAggregate, ok := evalSessionPassMetricAggregateForK(passAtK, behavior.EffectiveK)
+	if !ok {
+		return nil
+	}
+	passPowAggregate, ok := evalSessionPassMetricAggregateForK(passPowK, behavior.EffectiveK)
+	if !ok {
+		return nil
+	}
+
+	source, weight, reasoning := resolveEvalSessionReliabilityWeight(behavior)
+	primaryMetric := "pass_at_k"
+	if weight >= 0.5 {
+		primaryMetric = "pass_pow_k"
+	}
+
+	routing := &evalSessionMetricRouting{
+		Source:              source,
+		ReliabilityWeight:   weight,
+		Reasoning:           reasoning,
+		PrimaryMetric:       primaryMetric,
+		EffectiveK:          behavior.EffectiveK,
+		CompositeAgentScore: ((1 - weight) * passAtAggregate.Mean) + (weight * passPowAggregate.Mean),
+	}
+	if passAtAggregate.Interval != nil && passPowAggregate.Interval != nil {
+		routing.CompositeInterval = &evalSessionAggregateInterval{
+			Estimator: evalSessionAggregateIntervalEstimator,
+			Lower:     ((1 - weight) * passAtAggregate.Interval.Lower) + (weight * passPowAggregate.Interval.Lower),
+			Upper:     ((1 - weight) * passAtAggregate.Interval.Upper) + (weight * passPowAggregate.Interval.Upper),
 		}
 	}
-	return runScorecardAgentSummary{}, false
+	return routing
+}
+
+func resolveEvalSessionReliabilityWeight(behavior evalSessionAggregateBehavior) (string, float64, string) {
+	if behavior.ManualReliabilityWeight != nil {
+		weight := clamp01(*behavior.ManualReliabilityWeight)
+		return "manual_override", weight, fmt.Sprintf("manual override from eval_session.aggregation.reliability_weight=%s", strconv.FormatFloat(weight, 'f', -1, 64))
+	}
+
+	weight := 0.0
+	reasons := make([]string, 0, 4)
+	props := behavior.TaskProperties
+
+	if props.HasSideEffects {
+		weight += 0.35
+		reasons = append(reasons, "task has side effects")
+	}
+	switch props.Autonomy {
+	case "full":
+		weight += 0.30
+		reasons = append(reasons, "task is fully autonomous")
+	case "semi":
+		weight += 0.15
+		reasons = append(reasons, "task is semi-autonomous")
+	}
+	switch {
+	case props.StepCount > 3:
+		weight += 0.25
+		reasons = append(reasons, fmt.Sprintf("task compounds reliability across %d steps", props.StepCount))
+	case props.StepCount > 1:
+		weight += 0.10
+		reasons = append(reasons, fmt.Sprintf("task spans %d sequential steps", props.StepCount))
+	}
+	if props.OutputType == "action" {
+		weight += 0.10
+		reasons = append(reasons, "task output is an action, not a reviewable artifact")
+	}
+
+	weight = clamp01(weight)
+	if len(reasons) == 0 {
+		return "default", weight, "no reliability-sensitive task_properties were provided; defaulting toward capability-first pass@k"
+	}
+	return "task_properties", weight, strings.Join(reasons, "; ")
+}
+
+func evalSessionPassMetricAggregateForK(series *evalSessionPassMetricSeries, k int) (evalSessionMetricAggregate, bool) {
+	if series == nil {
+		return evalSessionMetricAggregate{}, false
+	}
+	aggregate, ok := series.ByK[strconv.Itoa(k)]
+	return aggregate, ok
+}
+
+func buildEvalSessionRepeatedComparison(
+	participants []evalSessionParticipantAggregate,
+	effectiveK int,
+	scoredChildCount int,
+) *evalSessionRepeatedComparison {
+	if len(participants) < 2 {
+		return nil
+	}
+
+	comparables := make([]evalSessionComparableParticipant, 0, len(participants))
+	for idx, participant := range participants {
+		if participant.MetricRouting == nil {
+			continue
+		}
+		passAtAggregate, passAtOK := evalSessionPassMetricAggregateForK(participant.PassAtK, effectiveK)
+		passPowAggregate, passPowOK := evalSessionPassMetricAggregateForK(participant.PassPowK, effectiveK)
+		if !passAtOK || !passPowOK {
+			continue
+		}
+		comparables = append(comparables, evalSessionComparableParticipant{
+			Index:     idx,
+			LaneIndex: participant.LaneIndex,
+			Label:     participant.Label,
+			PassAtK:   passAtAggregate,
+			PassPowK:  passPowAggregate,
+			Routing:   *participant.MetricRouting,
+		})
+	}
+
+	comparison := &evalSessionRepeatedComparison{
+		Status:     "insufficient_evidence",
+		ReasonCode: "participant_metrics_unavailable",
+		EffectiveK: effectiveK,
+	}
+	if len(comparables) < 2 {
+		return comparison
+	}
+
+	sort.Slice(comparables, func(i, j int) bool {
+		if comparables[i].Routing.CompositeAgentScore != comparables[j].Routing.CompositeAgentScore {
+			return comparables[i].Routing.CompositeAgentScore > comparables[j].Routing.CompositeAgentScore
+		}
+		if comparables[i].LaneIndex != comparables[j].LaneIndex {
+			return comparables[i].LaneIndex < comparables[j].LaneIndex
+		}
+		return comparables[i].Label < comparables[j].Label
+	})
+
+	leader := comparables[0]
+	runnerUp := comparables[1]
+	comparison.ComparedMetric = leader.Routing.PrimaryMetric
+	comparison.LeaderLaneIndex = &leader.LaneIndex
+	comparison.LeaderLabel = leader.Label
+	comparison.RunnerUpLaneIndex = &runnerUp.LaneIndex
+	comparison.RunnerUpLabel = runnerUp.Label
+
+	if leader.Routing.PrimaryMetric != runnerUp.Routing.PrimaryMetric {
+		comparison.ReasonCode = "metric_routing_mismatch"
+		return comparison
+	}
+
+	leaderAggregate, leaderValue := evalSessionComparisonMetric(leader, leader.Routing.PrimaryMetric)
+	runnerUpAggregate, runnerUpValue := evalSessionComparisonMetric(runnerUp, runnerUp.Routing.PrimaryMetric)
+	comparison.LeaderValue = &leaderValue
+	comparison.RunnerUpValue = &runnerUpValue
+	comparison.LeaderInterval = cloneEvalSessionAggregateInterval(leaderAggregate.Interval)
+	comparison.RunnerUpInterval = cloneEvalSessionAggregateInterval(runnerUpAggregate.Interval)
+
+	if scoredChildCount < 2 {
+		comparison.ReasonCode = "scored_child_runs_insufficient"
+		return comparison
+	}
+	if leaderAggregate.N < 2 || runnerUpAggregate.N < 2 || leaderAggregate.Interval == nil || runnerUpAggregate.Interval == nil {
+		comparison.ReasonCode = "task_evidence_insufficient"
+		return comparison
+	}
+	if intervalsOverlap(leaderAggregate.Interval, runnerUpAggregate.Interval) {
+		comparison.Status = "no_clear_winner"
+		comparison.ReasonCode = "interval_overlap"
+		return comparison
+	}
+
+	comparison.Status = "clear_winner"
+	comparison.ReasonCode = "non_overlapping_intervals"
+	comparison.WinnerLaneIndex = &leader.LaneIndex
+	comparison.WinnerLabel = leader.Label
+	return comparison
+}
+
+func evalSessionComparisonMetric(
+	participant evalSessionComparableParticipant,
+	metric string,
+) (evalSessionMetricAggregate, float64) {
+	if metric == "pass_pow_k" {
+		return participant.PassPowK, participant.PassPowK.Mean
+	}
+	return participant.PassAtK, participant.PassAtK.Mean
+}
+
+func evalSessionParticipantByLane(
+	participants []evalSessionParticipantAggregate,
+	laneIndex int32,
+) (evalSessionParticipantAggregate, bool) {
+	for _, participant := range participants {
+		if participant.LaneIndex == laneIndex {
+			return participant, true
+		}
+	}
+	return evalSessionParticipantAggregate{}, false
+}
+
+func buildEvalSessionComparisonOmissionWarning(comparison *evalSessionRepeatedComparison) string {
+	if comparison == nil {
+		return "comparison session top-level winner aggregate omitted because repeated-session comparison evidence is unavailable"
+	}
+	switch comparison.Status {
+	case "no_clear_winner":
+		return "comparison session top-level winner aggregate omitted because repeated-session evidence overlaps and no clear winner exists"
+	case "insufficient_evidence":
+		return "comparison session top-level winner aggregate omitted because repeated-session evidence is insufficient"
+	default:
+		return "comparison session top-level winner aggregate omitted because repeated-session comparison is not definitive"
+	}
+}
+
+func cloneEvalSessionAggregateInterval(interval *evalSessionAggregateInterval) *evalSessionAggregateInterval {
+	if interval == nil {
+		return nil
+	}
+	cloned := *interval
+	return &cloned
+}
+
+func intervalsOverlap(left, right *evalSessionAggregateInterval) bool {
+	if left == nil || right == nil {
+		return true
+	}
+	return left.Lower <= right.Upper && right.Lower <= left.Upper
+}
+
+func clamp01(value float64) float64 {
+	switch {
+	case value < 0:
+		return 0
+	case value > 1:
+		return 1
+	default:
+		return value
+	}
 }
 
 func evalSessionAggregateDimensions(agent runScorecardAgentSummary) map[string]float64 {

--- a/backend/internal/repository/eval_session_aggregation_integration_test.go
+++ b/backend/internal/repository/eval_session_aggregation_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/Atharva-Kanherkar/agentclash/backend/internal/domain"
 	"github.com/Atharva-Kanherkar/agentclash/backend/internal/repository"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -51,8 +52,11 @@ func TestRepositoryAggregateEvalSessionPersistsAndUpsertsSingleRow(t *testing.T)
 	repo := repository.New(db)
 
 	session, err := repo.CreateEvalSession(ctx, repository.CreateEvalSessionParams{
-		Repetitions:   1,
-		SchemaVersion: 1,
+		Repetitions:            1,
+		AggregationConfig:      []byte(`{"schema_version":1,"reliability_weight":0.85}`),
+		SuccessThresholdConfig: []byte(`{"schema_version":1,"min_pass_rate":0.8}`),
+		RoutingTaskSnapshot:    []byte(`{"schema_version":1,"routing":{"mode":"single_agent"},"task":{"task_properties":{"has_side_effects":true,"autonomy":"full","step_count":4,"output_type":"action"}}}`),
+		SchemaVersion:          1,
 	})
 	if err != nil {
 		t.Fatalf("CreateEvalSession returned error: %v", err)
@@ -86,6 +90,7 @@ func TestRepositoryAggregateEvalSessionPersistsAndUpsertsSingleRow(t *testing.T)
 		"dimension_deltas": map[string]any{},
 		"evidence_quality": map[string]any{},
 	})
+	insertJudgeResultRecordWithVerdict(t, ctx, db, fixture.primaryRunAgentID, evaluationSpecID, fixture.firstChallengeIdentityID, "exact", "pass", 1.0)
 
 	first, err := repo.AggregateEvalSession(ctx, session.ID)
 	if err != nil {
@@ -104,6 +109,21 @@ func TestRepositoryAggregateEvalSessionPersistsAndUpsertsSingleRow(t *testing.T)
 	}
 	if string(stored.Aggregate) != string(first.Aggregate) {
 		t.Fatalf("stored aggregate = %s, want %s", stored.Aggregate, first.Aggregate)
+	}
+
+	firstAggregate := decodeJSONObject(t, first.Aggregate)
+	if firstAggregate["pass_at_k"] == nil || firstAggregate["pass_pow_k"] == nil {
+		t.Fatalf("aggregate = %#v, want top-level pass metrics", firstAggregate)
+	}
+	if firstAggregate["task_success"] == nil {
+		t.Fatalf("aggregate = %#v, want task_success", firstAggregate)
+	}
+	metricRouting, ok := firstAggregate["metric_routing"].(map[string]any)
+	if !ok {
+		t.Fatalf("metric_routing = %#v, want object", firstAggregate["metric_routing"])
+	}
+	if metricRouting["source"] != "manual_override" {
+		t.Fatalf("metric_routing.source = %#v, want manual_override", metricRouting["source"])
 	}
 
 	insertRunScorecardRecord(t, ctx, db, fixture.runID, evaluationSpecID, map[string]any{
@@ -148,6 +168,107 @@ func TestRepositoryAggregateEvalSessionPersistsAndUpsertsSingleRow(t *testing.T)
 	}
 }
 
+func TestRepositoryAggregateEvalSessionPersistsComparisonSemantics(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	session, err := repo.CreateEvalSession(ctx, repository.CreateEvalSessionParams{
+		Repetitions:            3,
+		AggregationConfig:      []byte(`{"schema_version":1,"reliability_weight":0.6}`),
+		SuccessThresholdConfig: []byte(`{"schema_version":1,"min_pass_rate":0.8}`),
+		RoutingTaskSnapshot:    []byte(`{"schema_version":1,"routing":{"mode":"comparison"},"task":{"task_properties":{"has_side_effects":true,"autonomy":"semi","step_count":3,"output_type":"action"}}}`),
+		SchemaVersion:          1,
+	})
+	if err != nil {
+		t.Fatalf("CreateEvalSession returned error: %v", err)
+	}
+
+	evaluationSpecID := insertEvaluationSpecRecord(t, ctx, db, fixture.challengePackVersionID, "eval-session-comparison", 1)
+	secondChallengeIdentityID := lookupChallengeIdentityID(t, ctx, db, "second-ticket")
+
+	for i := 0; i < 3; i++ {
+		run, runAgents := createTestRun(t, ctx, repo, fixture, 2, "comparison")
+		if err := repo.AttachRunToEvalSession(ctx, run.ID, session.ID); err != nil {
+			t.Fatalf("AttachRunToEvalSession(%d) returned error: %v", i, err)
+		}
+
+		insertRunScorecardRecord(t, ctx, db, run.ID, evaluationSpecID, map[string]any{
+			"schema_version":       "2026-04-14",
+			"run_id":               run.ID,
+			"evaluation_spec_id":   evaluationSpecID,
+			"winning_run_agent_id": runAgents[0].ID,
+			"winner_determination": map[string]any{"strategy": "overall_score", "status": "winner", "reason_code": "score"},
+			"agents": []map[string]any{
+				{
+					"run_agent_id":      runAgents[0].ID,
+					"lane_index":        0,
+					"label":             runAgents[0].Label,
+					"status":            string(domain.RunAgentStatusCompleted),
+					"has_scorecard":     true,
+					"overall_score":     0.95,
+					"correctness_score": 0.95,
+					"dimensions": map[string]any{
+						"correctness": map[string]any{"state": "available", "score": 0.95},
+					},
+				},
+				{
+					"run_agent_id":      runAgents[1].ID,
+					"lane_index":        1,
+					"label":             runAgents[1].Label,
+					"status":            string(domain.RunAgentStatusCompleted),
+					"has_scorecard":     true,
+					"overall_score":     0.25,
+					"correctness_score": 0.25,
+					"dimensions": map[string]any{
+						"correctness": map[string]any{"state": "available", "score": 0.25},
+					},
+				},
+			},
+			"dimension_deltas": map[string]any{},
+			"evidence_quality": map[string]any{},
+		})
+
+		insertJudgeResultRecordWithVerdict(t, ctx, db, runAgents[0].ID, evaluationSpecID, fixture.firstChallengeIdentityID, "exact", "pass", 1.0)
+		insertJudgeResultRecordWithVerdict(t, ctx, db, runAgents[0].ID, evaluationSpecID, secondChallengeIdentityID, "contains", "pass", 1.0)
+		insertJudgeResultRecordWithVerdict(t, ctx, db, runAgents[1].ID, evaluationSpecID, fixture.firstChallengeIdentityID, "exact", "fail", 0.0)
+		insertJudgeResultRecordWithVerdict(t, ctx, db, runAgents[1].ID, evaluationSpecID, secondChallengeIdentityID, "contains", "fail", 0.0)
+	}
+
+	record, err := repo.AggregateEvalSession(ctx, session.ID)
+	if err != nil {
+		t.Fatalf("AggregateEvalSession returned error: %v", err)
+	}
+
+	aggregate := decodeJSONObject(t, record.Aggregate)
+	participants, ok := aggregate["participants"].([]any)
+	if !ok || len(participants) != 2 {
+		t.Fatalf("participants = %#v, want two items", aggregate["participants"])
+	}
+	comparison, ok := aggregate["comparison"].(map[string]any)
+	if !ok {
+		t.Fatalf("comparison = %#v, want object", aggregate["comparison"])
+	}
+	if comparison["status"] != "clear_winner" {
+		t.Fatalf("comparison.status = %#v, want clear_winner", comparison["status"])
+	}
+	if aggregate["top_level_source"] != "repeated_clear_winner" {
+		t.Fatalf("top_level_source = %#v, want repeated_clear_winner", aggregate["top_level_source"])
+	}
+	if aggregate["overall"] == nil {
+		t.Fatalf("aggregate = %#v, want top-level overall for clear winner", aggregate)
+	}
+
+	firstParticipant, ok := participants[0].(map[string]any)
+	if !ok {
+		t.Fatalf("first participant = %#v, want object", participants[0])
+	}
+	if firstParticipant["pass_at_k"] == nil || firstParticipant["metric_routing"] == nil {
+		t.Fatalf("first participant = %#v, want pass metrics and routing", firstParticipant)
+	}
+}
+
 func insertRunScorecardRecord(
 	t *testing.T,
 	ctx context.Context,
@@ -177,4 +298,48 @@ func insertRunScorecardRecord(
 	`, uuid.New(), runID, evaluationSpecID, payload); err != nil {
 		t.Fatalf("insert run scorecard returned error: %v", err)
 	}
+}
+
+func insertJudgeResultRecordWithVerdict(
+	t *testing.T,
+	ctx context.Context,
+	db *pgxpool.Pool,
+	runAgentID uuid.UUID,
+	evaluationSpecID uuid.UUID,
+	challengeIdentityID uuid.UUID,
+	judgeKey string,
+	verdict string,
+	normalizedScore float64,
+) {
+	t.Helper()
+
+	if _, err := db.Exec(ctx, `
+		INSERT INTO judge_results (
+			id,
+			run_agent_id,
+			evaluation_spec_id,
+			challenge_identity_id,
+			judge_key,
+			verdict,
+			normalized_score,
+			raw_output
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	`, uuid.New(), runAgentID, evaluationSpecID, challengeIdentityID, judgeKey, verdict, normalizedScore, []byte(`{"state":"available"}`)); err != nil {
+		t.Fatalf("insert judge result returned error: %v", err)
+	}
+}
+
+func lookupChallengeIdentityID(t *testing.T, ctx context.Context, db *pgxpool.Pool, challengeKey string) uuid.UUID {
+	t.Helper()
+
+	var challengeIdentityID uuid.UUID
+	if err := db.QueryRow(ctx, `
+		SELECT id
+		FROM challenge_identities
+		WHERE challenge_key = $1
+	`, challengeKey).Scan(&challengeIdentityID); err != nil {
+		t.Fatalf("lookup challenge identity returned error: %v", err)
+	}
+	return challengeIdentityID
 }

--- a/backend/internal/repository/eval_session_aggregation_test.go
+++ b/backend/internal/repository/eval_session_aggregation_test.go
@@ -303,6 +303,14 @@ func TestDeriveEvalSessionChallengeSuccessSupportsBinaryAndContinuousModes(t *te
 		t.Fatalf("binary failure = (%v,%q,%v), want (false,judge_results_verdict,true)", falseResult, source, ok)
 	}
 
+	verdictWithScore, source, ok := deriveEvalSessionChallengeSuccess([]JudgeResultRecord{
+		{Verdict: &passVerdict, NormalizedScore: float64Ptr(0.1)},
+		{Verdict: &passVerdict, NormalizedScore: float64Ptr(0.2)},
+	}, 0.8)
+	if !ok || !verdictWithScore || source != "judge_results_verdict" {
+		t.Fatalf("verdict precedence = (%v,%q,%v), want (true,judge_results_verdict,true)", verdictWithScore, source, ok)
+	}
+
 	continuous, source, ok := deriveEvalSessionChallengeSuccess([]JudgeResultRecord{
 		{NormalizedScore: float64Ptr(0.7)},
 		{NormalizedScore: float64Ptr(0.9)},
@@ -462,6 +470,63 @@ func TestBuildEvalSessionAggregatePayloadComparisonInsufficientEvidence(t *testi
 	}
 	if !slices.Contains(evidence.Warnings, "comparison session top-level winner aggregate omitted because repeated-session evidence is insufficient") {
 		t.Fatalf("warnings = %v, want insufficient-evidence omission warning", evidence.Warnings)
+	}
+}
+
+func TestBuildEvalSessionRepeatedComparisonHandlesMetricRoutingMismatchDefensively(t *testing.T) {
+	comparison := buildEvalSessionRepeatedComparison([]evalSessionParticipantAggregate{
+		{
+			LaneIndex: 0,
+			Label:     "Alpha",
+			PassAtK: &evalSessionPassMetricSeries{
+				EffectiveK: 3,
+				ByK: map[string]evalSessionMetricAggregate{
+					"3": buildEvalSessionMetricAggregate([]float64{0.9, 0.8}),
+				},
+			},
+			PassPowK: &evalSessionPassMetricSeries{
+				EffectiveK: 3,
+				ByK: map[string]evalSessionMetricAggregate{
+					"3": buildEvalSessionMetricAggregate([]float64{0.7, 0.6}),
+				},
+			},
+			MetricRouting: &evalSessionMetricRouting{
+				PrimaryMetric:       "pass_at_k",
+				EffectiveK:          3,
+				CompositeAgentScore: 0.85,
+			},
+		},
+		{
+			LaneIndex: 1,
+			Label:     "Beta",
+			PassAtK: &evalSessionPassMetricSeries{
+				EffectiveK: 3,
+				ByK: map[string]evalSessionMetricAggregate{
+					"3": buildEvalSessionMetricAggregate([]float64{0.8, 0.7}),
+				},
+			},
+			PassPowK: &evalSessionPassMetricSeries{
+				EffectiveK: 3,
+				ByK: map[string]evalSessionMetricAggregate{
+					"3": buildEvalSessionMetricAggregate([]float64{0.6, 0.5}),
+				},
+			},
+			MetricRouting: &evalSessionMetricRouting{
+				PrimaryMetric:       "pass_pow_k",
+				EffectiveK:          3,
+				CompositeAgentScore: 0.75,
+			},
+		},
+	}, 3, 3)
+
+	if comparison == nil {
+		t.Fatal("comparison = nil, want defensive mismatch result")
+	}
+	if comparison.Status != "insufficient_evidence" {
+		t.Fatalf("status = %q, want insufficient_evidence", comparison.Status)
+	}
+	if comparison.ReasonCode != "metric_routing_mismatch" {
+		t.Fatalf("reason_code = %q, want metric_routing_mismatch", comparison.ReasonCode)
 	}
 }
 

--- a/backend/internal/repository/eval_session_aggregation_test.go
+++ b/backend/internal/repository/eval_session_aggregation_test.go
@@ -3,58 +3,55 @@ package repository
 import (
 	"encoding/json"
 	"errors"
+	"math"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
 )
 
 func TestBuildEvalSessionAggregatePayloadIsDeterministicAcrossRunOrder(t *testing.T) {
-	firstRunID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
-	secondRunID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	first := evalSessionTestSource(
+		"11111111-1111-1111-1111-111111111111",
+		evalSessionTestParticipant(
+			"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+			0,
+			"Primary",
+			0.80,
+			map[string]float64{"custom": 0.60},
+			evalSessionTestTask("task-a", true),
+		),
+	)
+	second := evalSessionTestSource(
+		"22222222-2222-2222-2222-222222222222",
+		evalSessionTestParticipant(
+			"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+			0,
+			"Primary",
+			0.90,
+			map[string]float64{"custom": 0.70},
+			evalSessionTestTask("task-a", false),
+		),
+	)
 
-	first := evalSessionAggregateSource{
-		RunID: firstRunID,
-		Document: runScorecardDocument{
-			Agents: []runScorecardAgentSummary{
-				{
-					RunAgentID:       uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
-					LaneIndex:        0,
-					Label:            "Primary",
-					HasScorecard:     true,
-					OverallScore:     float64Ptr(0.80),
-					CorrectnessScore: float64Ptr(0.75),
-					Dimensions: map[string]comparisonScorecardDimensionInfo{
-						"custom": {Score: float64Ptr(0.60)},
-					},
-				},
-			},
-		},
-	}
-	second := evalSessionAggregateSource{
-		RunID: secondRunID,
-		Document: runScorecardDocument{
-			Agents: []runScorecardAgentSummary{
-				{
-					RunAgentID:       uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
-					LaneIndex:        0,
-					Label:            "Primary",
-					HasScorecard:     true,
-					OverallScore:     float64Ptr(0.90),
-					CorrectnessScore: float64Ptr(0.85),
-					Dimensions: map[string]comparisonScorecardDimensionInfo{
-						"custom": {Score: float64Ptr(0.70)},
-					},
-				},
-			},
-		},
-	}
-
-	leftAggregate, leftEvidence, _, err := buildEvalSessionAggregatePayload(2, []evalSessionAggregateSource{first, second}, nil)
+	leftAggregate, leftEvidence, _, err := buildEvalSessionAggregatePayload(
+		2,
+		[]evalSessionAggregateSource{first, second},
+		nil,
+		evalSessionTestBehavior(),
+		nil,
+	)
 	if err != nil {
 		t.Fatalf("buildEvalSessionAggregatePayload returned error: %v", err)
 	}
-	rightAggregate, rightEvidence, _, err := buildEvalSessionAggregatePayload(2, []evalSessionAggregateSource{second, first}, nil)
+	rightAggregate, rightEvidence, _, err := buildEvalSessionAggregatePayload(
+		2,
+		[]evalSessionAggregateSource{second, first},
+		nil,
+		evalSessionTestBehavior(),
+		nil,
+	)
 	if err != nil {
 		t.Fatalf("buildEvalSessionAggregatePayload returned error: %v", err)
 	}
@@ -68,26 +65,25 @@ func TestBuildEvalSessionAggregatePayloadIsDeterministicAcrossRunOrder(t *testin
 }
 
 func TestBuildEvalSessionAggregatePayloadCapturesMissingScorecardsAndPartialCoverage(t *testing.T) {
-	runID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
-	missingRunID := uuid.MustParse("44444444-4444-4444-4444-444444444444")
-
-	aggregateJSON, evidenceJSON, scoredChildCount, err := buildEvalSessionAggregatePayload(2, []evalSessionAggregateSource{
-		{
-			RunID: runID,
-			Document: runScorecardDocument{
-				Agents: []runScorecardAgentSummary{
-					{
-						RunAgentID:       uuid.MustParse("cccccccc-cccc-cccc-cccc-cccccccccccc"),
-						LaneIndex:        0,
-						Label:            "Primary",
-						HasScorecard:     true,
-						OverallScore:     float64Ptr(0.88),
-						CorrectnessScore: float64Ptr(0.81),
-					},
-				},
-			},
+	aggregateJSON, evidenceJSON, scoredChildCount, err := buildEvalSessionAggregatePayload(
+		2,
+		[]evalSessionAggregateSource{
+			evalSessionTestSource(
+				"33333333-3333-3333-3333-333333333333",
+				evalSessionTestParticipant(
+					"cccccccc-cccc-cccc-cccc-cccccccccccc",
+					0,
+					"Primary",
+					0.88,
+					map[string]float64{"correctness": 0.81},
+					evalSessionTestTask("task-a", true),
+				),
+			),
 		},
-	}, []uuid.UUID{missingRunID})
+		[]uuid.UUID{uuid.MustParse("44444444-4444-4444-4444-444444444444")},
+		evalSessionTestBehavior(),
+		nil,
+	)
 	if err != nil {
 		t.Fatalf("buildEvalSessionAggregatePayload returned error: %v", err)
 	}
@@ -110,8 +106,8 @@ func TestBuildEvalSessionAggregatePayloadCapturesMissingScorecardsAndPartialCove
 	if err := json.Unmarshal(evidenceJSON, &evidence); err != nil {
 		t.Fatalf("unmarshal evidence: %v", err)
 	}
-	if !slices.Contains(evidence.MissingScorecardRunIDs, missingRunID) {
-		t.Fatalf("missing scorecard ids = %v, want %s", evidence.MissingScorecardRunIDs, missingRunID)
+	if !slices.Contains(evidence.MissingScorecardRunIDs, uuid.MustParse("44444444-4444-4444-4444-444444444444")) {
+		t.Fatalf("missing scorecard ids = %v, want included run", evidence.MissingScorecardRunIDs)
 	}
 	if !slices.Contains(evidence.Warnings, "confidence intervals require at least 2 scored child runs") {
 		t.Fatalf("warnings = %v, want insufficient evidence warning", evidence.Warnings)
@@ -122,9 +118,350 @@ func TestBuildEvalSessionAggregatePayloadCapturesMissingScorecardsAndPartialCove
 }
 
 func TestBuildEvalSessionAggregatePayloadRejectsMissingScoredChildren(t *testing.T) {
-	_, _, _, err := buildEvalSessionAggregatePayload(2, nil, nil)
+	_, _, _, err := buildEvalSessionAggregatePayload(2, nil, nil, evalSessionTestBehavior(), nil)
 	if !errors.Is(err, ErrEvalSessionAggregateUnavailable) {
 		t.Fatalf("error = %v, want ErrEvalSessionAggregateUnavailable", err)
+	}
+}
+
+func TestBuildEvalSessionAggregatePayloadComputesPassMetricsAndK1Equivalence(t *testing.T) {
+	aggregateJSON, _, _, err := buildEvalSessionAggregatePayload(
+		3,
+		[]evalSessionAggregateSource{
+			evalSessionTestSource(
+				"55555555-5555-5555-5555-555555555551",
+				evalSessionTestParticipant(
+					"dddddddd-dddd-dddd-dddd-dddddddddddd",
+					0,
+					"Primary",
+					0.80,
+					map[string]float64{"correctness": 0.80},
+					evalSessionTestTask("task-a", true),
+					evalSessionTestTask("task-b", false),
+				),
+			),
+			evalSessionTestSource(
+				"55555555-5555-5555-5555-555555555552",
+				evalSessionTestParticipant(
+					"eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+					0,
+					"Primary",
+					0.90,
+					map[string]float64{"correctness": 0.90},
+					evalSessionTestTask("task-a", true),
+					evalSessionTestTask("task-b", false),
+				),
+			),
+			evalSessionTestSource(
+				"55555555-5555-5555-5555-555555555553",
+				evalSessionTestParticipant(
+					"ffffffff-ffff-ffff-ffff-ffffffffffff",
+					0,
+					"Primary",
+					0.70,
+					map[string]float64{"correctness": 0.70},
+					evalSessionTestTask("task-a", false),
+					evalSessionTestTask("task-b", false),
+				),
+			),
+		},
+		nil,
+		evalSessionTestBehavior(),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("buildEvalSessionAggregatePayload returned error: %v", err)
+	}
+
+	var aggregate evalSessionAggregateDocument
+	if err := json.Unmarshal(aggregateJSON, &aggregate); err != nil {
+		t.Fatalf("unmarshal aggregate: %v", err)
+	}
+	if aggregate.PassAtK == nil || aggregate.PassPowK == nil || aggregate.MetricRouting == nil {
+		t.Fatalf("top-level pass metrics/routing missing: %#v", aggregate)
+	}
+	if len(aggregate.TaskSuccess) != 2 {
+		t.Fatalf("task_success length = %d, want 2", len(aggregate.TaskSuccess))
+	}
+
+	taskA := aggregate.TaskSuccess[0]
+	taskB := aggregate.TaskSuccess[1]
+	if taskA.TaskKey != "task-a" || taskB.TaskKey != "task-b" {
+		t.Fatalf("task ordering = %#v, want task-a/task-b", aggregate.TaskSuccess)
+	}
+
+	if math.Abs(taskA.SuccessRate-(2.0/3.0)) > 1e-9 {
+		t.Fatalf("task-a success rate = %f, want %f", taskA.SuccessRate, 2.0/3.0)
+	}
+	if taskA.PassAtK["1"] != taskA.SuccessRate || taskA.PassPowK["1"] != taskA.SuccessRate {
+		t.Fatalf("task-a k=1 equivalence failed: %#v", taskA)
+	}
+	if taskB.SuccessRate != 0 || taskB.PassAtK["1"] != 0 || taskB.PassPowK["1"] != 0 {
+		t.Fatalf("task-b rates = %#v, want zeros", taskB)
+	}
+
+	passAt1 := aggregate.PassAtK.ByK["1"].Mean
+	passAt3 := aggregate.PassAtK.ByK["3"].Mean
+	passAt5 := aggregate.PassAtK.ByK["5"].Mean
+	passAt10 := aggregate.PassAtK.ByK["10"].Mean
+	passPow1 := aggregate.PassPowK.ByK["1"].Mean
+	passPow3 := aggregate.PassPowK.ByK["3"].Mean
+	passPow5 := aggregate.PassPowK.ByK["5"].Mean
+	passPow10 := aggregate.PassPowK.ByK["10"].Mean
+
+	if math.Abs(passAt1-passPow1) > 1e-9 {
+		t.Fatalf("suite k=1 mismatch: pass@1=%f pass^1=%f", passAt1, passPow1)
+	}
+	if !(passAt1 <= passAt3 && passAt3 <= passAt5 && passAt5 <= passAt10) {
+		t.Fatalf("pass@k should be monotonic increasing: %f %f %f %f", passAt1, passAt3, passAt5, passAt10)
+	}
+	if !(passPow1 >= passPow3 && passPow3 >= passPow5 && passPow5 >= passPow10) {
+		t.Fatalf("pass^k should be monotonic decreasing: %f %f %f %f", passPow1, passPow3, passPow5, passPow10)
+	}
+	if aggregate.MetricRouting.PrimaryMetric != "pass_at_k" {
+		t.Fatalf("primary metric = %q, want pass_at_k", aggregate.MetricRouting.PrimaryMetric)
+	}
+}
+
+func TestResolveEvalSessionReliabilityWeightInfersFromTaskProperties(t *testing.T) {
+	source, weight, reasoning := resolveEvalSessionReliabilityWeight(evalSessionAggregateBehavior{
+		TaskProperties: evalSessionRoutingTaskProperties{
+			HasSideEffects: true,
+			Autonomy:       "full",
+			StepCount:      4,
+			OutputType:     "action",
+		},
+	})
+
+	if source != "task_properties" {
+		t.Fatalf("source = %q, want task_properties", source)
+	}
+	if math.Abs(weight-1.0) > 1e-9 {
+		t.Fatalf("weight = %f, want 1.0", weight)
+	}
+	for _, fragment := range []string{"side effects", "fully autonomous", "4 steps", "action"} {
+		if !strings.Contains(reasoning, fragment) {
+			t.Fatalf("reasoning = %q, want fragment %q", reasoning, fragment)
+		}
+	}
+}
+
+func TestBuildEvalSessionMetricRoutingUsesManualOverride(t *testing.T) {
+	manualWeight := 0.85
+	routing := buildEvalSessionMetricRouting(
+		evalSessionAggregateBehavior{
+			EffectiveK:              3,
+			ManualReliabilityWeight: &manualWeight,
+			TaskProperties:          evalSessionRoutingTaskProperties{HasSideEffects: true, Autonomy: "full", StepCount: 5, OutputType: "action"},
+		},
+		&evalSessionPassMetricSeries{
+			EffectiveK: 3,
+			ByK: map[string]evalSessionMetricAggregate{
+				"3": buildEvalSessionMetricAggregate([]float64{0.9, 0.8}),
+			},
+		},
+		&evalSessionPassMetricSeries{
+			EffectiveK: 3,
+			ByK: map[string]evalSessionMetricAggregate{
+				"3": buildEvalSessionMetricAggregate([]float64{0.6, 0.5}),
+			},
+		},
+	)
+	if routing == nil {
+		t.Fatal("routing = nil, want value")
+	}
+	if routing.Source != "manual_override" {
+		t.Fatalf("source = %q, want manual_override", routing.Source)
+	}
+	if routing.ReliabilityWeight != manualWeight {
+		t.Fatalf("weight = %f, want %f", routing.ReliabilityWeight, manualWeight)
+	}
+	if routing.PrimaryMetric != "pass_pow_k" {
+		t.Fatalf("primary metric = %q, want pass_pow_k", routing.PrimaryMetric)
+	}
+	if !strings.Contains(routing.Reasoning, "manual override") {
+		t.Fatalf("reasoning = %q, want manual override explanation", routing.Reasoning)
+	}
+}
+
+func TestDeriveEvalSessionChallengeSuccessSupportsBinaryAndContinuousModes(t *testing.T) {
+	failVerdict := "fail"
+	passVerdict := "pass"
+	trueResult, source, ok := deriveEvalSessionChallengeSuccess([]JudgeResultRecord{
+		{Verdict: &passVerdict},
+		{Verdict: &passVerdict},
+	}, 0.8)
+	if !ok || !trueResult || source != "judge_results_verdict" {
+		t.Fatalf("binary success = (%v,%q,%v), want (true,judge_results_verdict,true)", trueResult, source, ok)
+	}
+
+	falseResult, source, ok := deriveEvalSessionChallengeSuccess([]JudgeResultRecord{
+		{Verdict: &passVerdict},
+		{Verdict: &failVerdict},
+	}, 0.8)
+	if !ok || falseResult || source != "judge_results_verdict" {
+		t.Fatalf("binary failure = (%v,%q,%v), want (false,judge_results_verdict,true)", falseResult, source, ok)
+	}
+
+	continuous, source, ok := deriveEvalSessionChallengeSuccess([]JudgeResultRecord{
+		{NormalizedScore: float64Ptr(0.7)},
+		{NormalizedScore: float64Ptr(0.9)},
+	}, 0.8)
+	if !ok || !continuous || source != "judge_results_threshold" {
+		t.Fatalf("continuous success = (%v,%q,%v), want (true,judge_results_threshold,true)", continuous, source, ok)
+	}
+}
+
+func TestDeriveEvalSessionSuiteFallbackOutcomeEnforcesRequiredDimensions(t *testing.T) {
+	outcome, ok := deriveEvalSessionSuiteFallbackOutcome(runScorecardAgentSummary{
+		OverallScore:     float64Ptr(0.90),
+		CorrectnessScore: float64Ptr(0.90),
+		ReliabilityScore: float64Ptr(0.70),
+	}, evalSessionAggregateBehavior{
+		SuccessThreshold:     0.8,
+		RequireAllDimensions: []string{"correctness", "reliability"},
+	})
+	if !ok {
+		t.Fatal("fallback outcome unresolved, want resolved")
+	}
+	if outcome.Success {
+		t.Fatalf("fallback success = true, want false because reliability dimension misses threshold")
+	}
+
+	passedOutcome, ok := deriveEvalSessionSuiteFallbackOutcome(runScorecardAgentSummary{
+		Passed: boolPtr(true),
+	}, evalSessionAggregateBehavior{SuccessThreshold: 0.8})
+	if !ok || !passedOutcome.Success || passedOutcome.Source != "scorecard_passed" {
+		t.Fatalf("passed fallback = %#v, want scorecard_passed success", passedOutcome)
+	}
+}
+
+func TestBuildEvalSessionAggregatePayloadComparisonClearWinner(t *testing.T) {
+	aggregateJSON, evidenceJSON, _, err := buildEvalSessionAggregatePayload(
+		3,
+		[]evalSessionAggregateSource{
+			evalSessionTestComparisonSource("66666666-6666-6666-6666-666666666661", true, false),
+			evalSessionTestComparisonSource("66666666-6666-6666-6666-666666666662", true, false),
+			evalSessionTestComparisonSource("66666666-6666-6666-6666-666666666663", true, false),
+		},
+		nil,
+		evalSessionAggregateBehavior{KValues: []int{1, 3, 5, 10}, EffectiveK: 3, SuccessThreshold: 0.8},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("buildEvalSessionAggregatePayload returned error: %v", err)
+	}
+
+	var aggregate evalSessionAggregateDocument
+	if err := json.Unmarshal(aggregateJSON, &aggregate); err != nil {
+		t.Fatalf("unmarshal aggregate: %v", err)
+	}
+	if aggregate.Comparison == nil {
+		t.Fatal("comparison = nil, want clear winner result")
+	}
+	if aggregate.Comparison.Status != "clear_winner" {
+		t.Fatalf("comparison status = %q, want clear_winner", aggregate.Comparison.Status)
+	}
+	if aggregate.Comparison.WinnerLaneIndex == nil || *aggregate.Comparison.WinnerLaneIndex != 0 {
+		t.Fatalf("winner lane index = %v, want 0", aggregate.Comparison.WinnerLaneIndex)
+	}
+	if aggregate.TopLevelSource != "repeated_clear_winner" {
+		t.Fatalf("top_level_source = %q, want repeated_clear_winner", aggregate.TopLevelSource)
+	}
+	if aggregate.Overall == nil {
+		t.Fatal("top-level overall missing for clear winner comparison")
+	}
+
+	var evidence evalSessionAggregateEvidence
+	if err := json.Unmarshal(evidenceJSON, &evidence); err != nil {
+		t.Fatalf("unmarshal evidence: %v", err)
+	}
+	for _, warning := range evidence.Warnings {
+		if strings.Contains(warning, "top-level winner aggregate omitted") {
+			t.Fatalf("warnings = %v, want no omission warning for clear winner", evidence.Warnings)
+		}
+	}
+}
+
+func TestBuildEvalSessionAggregatePayloadComparisonNoClearWinner(t *testing.T) {
+	aggregateJSON, evidenceJSON, _, err := buildEvalSessionAggregatePayload(
+		3,
+		[]evalSessionAggregateSource{
+			evalSessionTestOverlapSource("77777777-7777-7777-7777-777777777771",
+				map[string]bool{"task-a": true, "task-b": true, "task-c": false},
+				map[string]bool{"task-a": true, "task-b": false, "task-c": false},
+			),
+			evalSessionTestOverlapSource("77777777-7777-7777-7777-777777777772",
+				map[string]bool{"task-a": true, "task-b": false, "task-c": false},
+				map[string]bool{"task-a": true, "task-b": true, "task-c": false},
+			),
+			evalSessionTestOverlapSource("77777777-7777-7777-7777-777777777773",
+				map[string]bool{"task-a": true, "task-b": false, "task-c": false},
+				map[string]bool{"task-a": false, "task-b": false, "task-c": false},
+			),
+		},
+		nil,
+		evalSessionAggregateBehavior{KValues: []int{1, 3, 5, 10}, EffectiveK: 3, SuccessThreshold: 0.8},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("buildEvalSessionAggregatePayload returned error: %v", err)
+	}
+
+	var aggregate evalSessionAggregateDocument
+	if err := json.Unmarshal(aggregateJSON, &aggregate); err != nil {
+		t.Fatalf("unmarshal aggregate: %v", err)
+	}
+	if aggregate.Comparison == nil || aggregate.Comparison.Status != "no_clear_winner" {
+		t.Fatalf("comparison = %#v, want no_clear_winner", aggregate.Comparison)
+	}
+	if aggregate.TopLevelSource != "" || aggregate.Overall != nil {
+		t.Fatalf("top-level winner summary should be omitted for noisy comparison: %#v", aggregate)
+	}
+
+	var evidence evalSessionAggregateEvidence
+	if err := json.Unmarshal(evidenceJSON, &evidence); err != nil {
+		t.Fatalf("unmarshal evidence: %v", err)
+	}
+	if !slices.Contains(evidence.Warnings, "comparison session top-level winner aggregate omitted because repeated-session evidence overlaps and no clear winner exists") {
+		t.Fatalf("warnings = %v, want noisy-comparison omission warning", evidence.Warnings)
+	}
+}
+
+func TestBuildEvalSessionAggregatePayloadComparisonInsufficientEvidence(t *testing.T) {
+	aggregateJSON, evidenceJSON, _, err := buildEvalSessionAggregatePayload(
+		1,
+		[]evalSessionAggregateSource{
+			evalSessionTestComparisonSource("88888888-8888-8888-8888-888888888881", true, false),
+		},
+		nil,
+		evalSessionAggregateBehavior{KValues: []int{1, 3, 5, 10}, EffectiveK: 1, SuccessThreshold: 0.8},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("buildEvalSessionAggregatePayload returned error: %v", err)
+	}
+
+	var aggregate evalSessionAggregateDocument
+	if err := json.Unmarshal(aggregateJSON, &aggregate); err != nil {
+		t.Fatalf("unmarshal aggregate: %v", err)
+	}
+	if aggregate.Comparison == nil || aggregate.Comparison.Status != "insufficient_evidence" {
+		t.Fatalf("comparison = %#v, want insufficient_evidence", aggregate.Comparison)
+	}
+	if aggregate.Comparison.ReasonCode != "scored_child_runs_insufficient" {
+		t.Fatalf("reason code = %q, want scored_child_runs_insufficient", aggregate.Comparison.ReasonCode)
+	}
+	if aggregate.TopLevelSource != "" || aggregate.Overall != nil {
+		t.Fatalf("top-level winner summary should be omitted: %#v", aggregate)
+	}
+
+	var evidence evalSessionAggregateEvidence
+	if err := json.Unmarshal(evidenceJSON, &evidence); err != nil {
+		t.Fatalf("unmarshal evidence: %v", err)
+	}
+	if !slices.Contains(evidence.Warnings, "comparison session top-level winner aggregate omitted because repeated-session evidence is insufficient") {
+		t.Fatalf("warnings = %v, want insufficient-evidence omission warning", evidence.Warnings)
 	}
 }
 
@@ -134,4 +471,121 @@ func TestBuildEvalSessionMetricAggregateReturnsZeroValueForEmptyInput(t *testing
 	if aggregate != (evalSessionMetricAggregate{}) {
 		t.Fatalf("aggregate = %#v, want zero value", aggregate)
 	}
+}
+
+func evalSessionTestBehavior() evalSessionAggregateBehavior {
+	return evalSessionAggregateBehavior{
+		KValues:          []int{1, 3, 5, 10},
+		EffectiveK:       3,
+		SuccessThreshold: 0.8,
+	}
+}
+
+func evalSessionTestSource(runID string, participants ...evalSessionAggregateParticipantSource) evalSessionAggregateSource {
+	agents := make([]runScorecardAgentSummary, 0, len(participants))
+	for _, participant := range participants {
+		agents = append(agents, participant.Agent)
+	}
+	return evalSessionAggregateSource{
+		RunID:              uuid.MustParse(runID),
+		Document:           runScorecardDocument{Agents: agents},
+		ParticipantSources: participants,
+	}
+}
+
+func evalSessionTestParticipant(
+	runAgentID string,
+	laneIndex int32,
+	label string,
+	overall float64,
+	dimensions map[string]float64,
+	tasks ...evalSessionAggregateTaskOutcome,
+) evalSessionAggregateParticipantSource {
+	agent := runScorecardAgentSummary{
+		RunAgentID:   uuid.MustParse(runAgentID),
+		LaneIndex:    laneIndex,
+		Label:        label,
+		HasScorecard: true,
+		OverallScore: float64Ptr(overall),
+		Dimensions:   map[string]comparisonScorecardDimensionInfo{},
+	}
+	for key, value := range dimensions {
+		agent.Dimensions[key] = comparisonScorecardDimensionInfo{Score: float64Ptr(value)}
+	}
+	return evalSessionAggregateParticipantSource{
+		Key: evalSessionParticipantKey{
+			LaneIndex: laneIndex,
+			Label:     label,
+		},
+		Agent:        agent,
+		TaskOutcomes: tasks,
+	}
+}
+
+func evalSessionTestTask(taskKey string, success bool) evalSessionAggregateTaskOutcome {
+	return evalSessionAggregateTaskOutcome{
+		TaskKey: taskKey,
+		Success: success,
+		Source:  "judge_results_verdict",
+	}
+}
+
+func evalSessionTestComparisonSource(runID string, alphaSuccess bool, betaSuccess bool) evalSessionAggregateSource {
+	return evalSessionTestSource(
+		runID,
+		evalSessionTestParticipant(
+			runIDToRunAgentID(runID, "00000000-0000-0000-0000-000000000001"),
+			0,
+			"Alpha",
+			0.95,
+			map[string]float64{"correctness": 0.95},
+			evalSessionTestTask("task-a", alphaSuccess),
+			evalSessionTestTask("task-b", alphaSuccess),
+			evalSessionTestTask("task-c", alphaSuccess),
+		),
+		evalSessionTestParticipant(
+			runIDToRunAgentID(runID, "00000000-0000-0000-0000-000000000002"),
+			1,
+			"Beta",
+			0.30,
+			map[string]float64{"correctness": 0.30},
+			evalSessionTestTask("task-a", betaSuccess),
+			evalSessionTestTask("task-b", betaSuccess),
+			evalSessionTestTask("task-c", betaSuccess),
+		),
+	)
+}
+
+func evalSessionTestOverlapSource(runID string, alpha map[string]bool, beta map[string]bool) evalSessionAggregateSource {
+	return evalSessionTestSource(
+		runID,
+		evalSessionTestParticipant(
+			runIDToRunAgentID(runID, "00000000-0000-0000-0000-000000000011"),
+			0,
+			"Alpha",
+			0.70,
+			map[string]float64{"correctness": 0.70},
+			evalSessionTestTask("task-a", alpha["task-a"]),
+			evalSessionTestTask("task-b", alpha["task-b"]),
+			evalSessionTestTask("task-c", alpha["task-c"]),
+		),
+		evalSessionTestParticipant(
+			runIDToRunAgentID(runID, "00000000-0000-0000-0000-000000000022"),
+			1,
+			"Beta",
+			0.68,
+			map[string]float64{"correctness": 0.68},
+			evalSessionTestTask("task-a", beta["task-a"]),
+			evalSessionTestTask("task-b", beta["task-b"]),
+			evalSessionTestTask("task-c", beta["task-c"]),
+		),
+	)
+}
+
+func runIDToRunAgentID(runID string, suffix string) string {
+	return runID[:24] + suffix[24:]
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }

--- a/backend/internal/repository/eval_sessions_integration_test.go
+++ b/backend/internal/repository/eval_sessions_integration_test.go
@@ -165,7 +165,7 @@ func TestRepositoryCreateEvalSessionSnapshotRoundTrip(t *testing.T) {
 
 	session, err := repo.CreateEvalSession(ctx, repository.CreateEvalSessionParams{
 		Repetitions:            3,
-		AggregationConfig:      []byte(`{"schema_version":1,"aggregation":"mean","weights":{"pass":0.8,"latency":0.2}}`),
+		AggregationConfig:      []byte(`{"schema_version":1,"aggregation":"mean","weights":{"pass":0.8,"latency":0.2},"reliability_weight":0.85}`),
 		SuccessThresholdConfig: []byte(`{"schema_version":1,"min_pass_rate":0.67,"require_all_dimensions":["correctness"]}`),
 		RoutingTaskSnapshot:    []byte(`{"schema_version":1,"routing":{"mode":"comparison"},"task":{"pack_version":"v1","input_set":"default"}}`),
 		SchemaVersion:          1,
@@ -183,7 +183,7 @@ func TestRepositoryCreateEvalSessionSnapshotRoundTrip(t *testing.T) {
 	if session.SchemaVersion != 1 {
 		t.Fatalf("session schema version = %d, want 1", session.SchemaVersion)
 	}
-	if !jsonEqual(session.AggregationConfig.Document, []byte(`{"schema_version":1,"aggregation":"mean","weights":{"pass":0.8,"latency":0.2}}`)) {
+	if !jsonEqual(session.AggregationConfig.Document, []byte(`{"schema_version":1,"aggregation":"mean","weights":{"pass":0.8,"latency":0.2},"reliability_weight":0.85}`)) {
 		t.Fatalf("aggregation config = %s, want preserved nested snapshot", session.AggregationConfig.Document)
 	}
 

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -4993,6 +4993,11 @@ components:
           type: number
           exclusiveMinimum: 0
           exclusiveMaximum: 1
+        reliability_weight:
+          type: number
+          minimum: 0
+          maximum: 1
+          description: Optional explicit override for repeated-eval routing weight.
 
     EvalSessionSuccessThresholdConfig:
       type: object
@@ -5243,10 +5248,22 @@ components:
           type: object
           additionalProperties:
             $ref: "#/components/schemas/EvalSessionMetricAggregate"
+        task_success:
+          type: array
+          items:
+            $ref: "#/components/schemas/EvalSessionTaskSuccess"
+        pass_at_k:
+          $ref: "#/components/schemas/EvalSessionPassMetricSeries"
+        pass_pow_k:
+          $ref: "#/components/schemas/EvalSessionPassMetricSeries"
+        metric_routing:
+          $ref: "#/components/schemas/EvalSessionMetricRouting"
         participants:
           type: array
           items:
             $ref: "#/components/schemas/EvalSessionParticipantAggregate"
+        comparison:
+          $ref: "#/components/schemas/EvalSessionRepeatedComparison"
 
     EvalSessionParticipantAggregate:
       type: object
@@ -5262,6 +5279,110 @@ components:
           type: object
           additionalProperties:
             $ref: "#/components/schemas/EvalSessionMetricAggregate"
+        task_success:
+          type: array
+          items:
+            $ref: "#/components/schemas/EvalSessionTaskSuccess"
+        pass_at_k:
+          $ref: "#/components/schemas/EvalSessionPassMetricSeries"
+        pass_pow_k:
+          $ref: "#/components/schemas/EvalSessionPassMetricSeries"
+        metric_routing:
+          $ref: "#/components/schemas/EvalSessionMetricRouting"
+
+    EvalSessionTaskSuccess:
+      type: object
+      required: [task_key, observed_trials, successful_trials, success_rate, source]
+      properties:
+        task_key:
+          type: string
+        challenge_identity_id:
+          type: string
+          format: uuid
+        challenge_key:
+          type: string
+        title:
+          type: string
+        observed_trials:
+          type: integer
+        successful_trials:
+          type: integer
+        success_rate:
+          type: number
+        source:
+          type: string
+        pass_at_k:
+          type: object
+          additionalProperties:
+            type: number
+        pass_pow_k:
+          type: object
+          additionalProperties:
+            type: number
+
+    EvalSessionPassMetricSeries:
+      type: object
+      required: [effective_k]
+      properties:
+        effective_k:
+          type: integer
+        by_k:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/EvalSessionMetricAggregate"
+
+    EvalSessionMetricRouting:
+      type: object
+      required: [source, reliability_weight, reasoning, primary_metric, effective_k, composite_agent_score]
+      properties:
+        source:
+          type: string
+        reliability_weight:
+          type: number
+        reasoning:
+          type: string
+        primary_metric:
+          type: string
+        effective_k:
+          type: integer
+        composite_agent_score:
+          type: number
+        composite_interval:
+          $ref: "#/components/schemas/EvalSessionAggregateInterval"
+
+    EvalSessionRepeatedComparison:
+      type: object
+      required: [status, effective_k]
+      properties:
+        status:
+          type: string
+          enum: [clear_winner, no_clear_winner, insufficient_evidence]
+        reason_code:
+          type: string
+        compared_metric:
+          type: string
+        effective_k:
+          type: integer
+        winner_lane_index:
+          type: integer
+        winner_label:
+          type: string
+        leader_lane_index:
+          type: integer
+        leader_label:
+          type: string
+        leader_value:
+          type: number
+        leader_interval:
+          $ref: "#/components/schemas/EvalSessionAggregateInterval"
+        runner_up_lane_index:
+          type: integer
+        runner_up_label:
+          type: string
+        runner_up_value:
+          type: number
+        runner_up_interval:
+          $ref: "#/components/schemas/EvalSessionAggregateInterval"
 
     EvalSessionMetricAggregate:
       type: object

--- a/research-docs/issues/issue-362-passk-comparison-plan.md
+++ b/research-docs/issues/issue-362-passk-comparison-plan.md
@@ -1,0 +1,304 @@
+# Issue 362 Research And Locked Design
+
+Status: locked
+Issue: `#362`
+Parent: `#149`
+Locked on: `2026-04-21`
+
+## Goal
+
+Implement repeated-eval `pass@k`, `pass^k`, metric routing, composite `AgentScore`, and comparison semantics that refuse to overstate noisy winners.
+
+This document is the pre-implementation decision record. The implementation contract will be created separately under `testing/` and treated as immutable during coding.
+
+## Research Inputs
+
+### Open Source Codebases
+
+1. OpenAI HumanEval repository
+   - Repo: `https://github.com/openai/human-eval`
+   - Raw implementation: `https://raw.githubusercontent.com/openai/human-eval/master/human_eval/evaluation.py`
+   - Relevant takeaway:
+     - `pass@k` is treated as a probability over repeated samples.
+     - The codebase uses a dedicated estimator because it evaluates multiple generated completions per problem and aggregates over problems.
+
+### SOTA OSS Codebases
+
+1. EvalPlus
+   - Repo: `https://github.com/evalplus/evalplus`
+   - Raw implementation: `https://raw.githubusercontent.com/evalplus/evalplus/master/evalplus/evaluate.py`
+   - Relevant takeaway:
+     - rigorous task-level evaluation matters more than headline means
+     - `pass@k` remains the primary repeated-sampling summary for code tasks
+     - hidden-test rigor changes the usefulness of any reported pass metric
+
+### Engineering Blogs
+
+1. Anthropic, "Demystifying evals for AI agents"
+   - URL: `https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents`
+   - Relevant takeaway:
+     - use repeated trials for nondeterministic agents
+     - `pass@k` answers capability ceiling
+     - `pass^k` answers reliability floor
+     - the metric to emphasize depends on deployment context, especially side effects, autonomy, and whether one success is enough
+
+### Research Papers
+
+1. Chen et al., "Evaluating Large Language Models Trained on Code"
+   - URL: `https://arxiv.org/abs/2107.03374`
+   - Relevant takeaway:
+     - repeated sampling changes measured capability materially
+     - `pass@k` should be computed per task, then aggregated
+
+2. Bjarnason et al., "On Randomness in Agentic Evals"
+   - URL: `https://arxiv.org/abs/2602.07150`
+   - Relevant takeaway:
+     - small apparent improvements are often noise without repeated runs
+     - agentic evals should report performance envelopes, not just a single central estimate
+     - `pass@k` and `pass^k` are recommended together for nondeterministic agents
+
+## Current Repo Constraints
+
+1. `#361` already persists eval-session aggregate documents in `eval_session_results`.
+2. Current aggregate output is run-level only:
+   - mean, median, stddev, min, max, interval
+   - participant aggregates by lane/label
+   - top-level aggregate chosen from sole agent or per-run winner
+3. Current repeated-eval storage already includes the inputs needed for `#362`:
+   - `success_threshold_config`
+   - `routing_task_snapshot`
+   - child run membership
+   - per-run scorecards
+   - per-run-agent `judge_results`
+   - per-run-agent execution-context challenge metadata
+4. There is no existing eval-session comparison surface beyond the current winner-derived aggregate behavior.
+5. Challenge-level scoring truth exists in `judge_results`, not in the run scorecard aggregate.
+
+## Locked Decisions
+
+### 1. Request Surface
+
+Decision:
+- Add optional `eval_session.aggregation.reliability_weight`.
+- Keep `routing_task_snapshot` as the source of inferred task properties.
+
+Why:
+- Manual override is explicitly required by `#362` and by the parent issue examples.
+- Making the override explicit in `aggregation` is clearer and more discoverable than hiding it inside the opaque routing snapshot.
+- `routing_task_snapshot` already exists and is flexible enough to carry task metadata without adding a second new typed structure in this issue.
+
+Locked shape:
+- `eval_session.aggregation.reliability_weight`: optional float in `[0, 1]`
+- inferred task properties are read from `routing_task_snapshot.task.task_properties`
+- supported properties in this issue:
+  - `has_side_effects` bool
+  - `autonomy` string: `human`, `semi`, `full`
+  - `step_count` integer
+  - `output_type` string: `artifact`, `action`
+
+### 2. Pass Metric Estimator
+
+Decision:
+- Treat repeated eval-session child runs as independent Bernoulli trials.
+- Compute per-task empirical success rate `p = successes / observed_trials`.
+- Compute:
+  - `pass@k = 1 - (1 - p)^k`
+  - `pass^k = p^k`
+
+Why:
+- HumanEval's combinatorial estimator is appropriate for its generated-completions setting.
+- This repository stores actual repeated trials for the same task, so the direct Bernoulli estimator matches the data model better.
+- This keeps the implementation explainable and aligned with Anthropic's agent-eval framing.
+
+Locked `k` set:
+- Always compute `{1, 3, 5, 10}`.
+- Also compute `session.repetitions` if it is not already in the set.
+- Routing/comparison semantics use `effective_k = session.repetitions`.
+
+### 3. Task Unit
+
+Decision:
+- Use `challenge_identity_id` as the per-task unit.
+- Resolve display metadata from execution context challenge definitions.
+
+Why:
+- Challenge identity is the stable challenge-level key already persisted alongside judge results.
+- The current scoring persistence does not carry challenge-level dimension aggregates or case-key-scoped score verdicts.
+- Using challenge identity avoids inventing a new persistence layer in `#362`.
+
+Fallback:
+- If no challenge-level task outcomes can be resolved for a participant, fall back to a synthetic suite task derived from the run-agent scorecard.
+- Emit an evidence warning when fallback is used.
+
+### 4. Task Success Derivation
+
+Decision:
+- Prefer challenge-level `judge_results` when available.
+- Binary mode:
+  - if any verdict-bearing judge says `fail`, the task fails
+  - otherwise, if at least one verdict-bearing judge exists and none fail, the task passes
+- Continuous mode:
+  - if no verdict-bearing judges exist but normalized scores exist, use the mean normalized score for that challenge
+  - compare that mean against the configured threshold
+- Fallback suite mode:
+  - use scorecard `passed` when present
+  - otherwise use scorecard `overall_score` against the configured threshold
+
+Threshold rule:
+- configured threshold = `success_threshold.min_pass_rate` when present
+- otherwise default threshold = `0.8`
+
+Known limitation, locked:
+- `success_threshold.require_all_dimensions` will only be enforced in the suite-level scorecard fallback path.
+- This issue will not recompute per-challenge dimension results from raw evaluator internals.
+
+Why:
+- The repo already stores challenge-level judge outputs but not challenge-level dimension scores.
+- Recomputing full per-challenge dimensions would turn `#362` into a much larger scoring-engine refactor.
+
+### 5. Metric Routing
+
+Decision:
+- Use the routing heuristic already sketched in `#149`.
+
+Locked weight formula:
+- `+0.35` if `has_side_effects`
+- `+0.25` if `step_count > 3`
+- `+0.10` if `step_count > 1 && step_count <= 3`
+- `+0.30` if `autonomy == "full"`
+- `+0.15` if `autonomy == "semi"`
+- `+0.10` if `output_type == "action"`
+- clamp final weight to `1.0`
+
+Primary metric rule:
+- `pass^k` when `reliability_weight >= 0.5`
+- otherwise `pass@k`
+
+Composite:
+- `AgentScore = (1 - w) * pass@k + w * pass^k`
+- use the suite-level `effective_k` means for the score
+
+Reasoning output:
+- persist human-readable reasoning listing the factors that contributed to the inferred weight
+- if manual override is used, state that explicitly and skip inference-based reasoning
+
+### 6. Comparison Semantics
+
+Decision:
+- Add repeated-eval participant comparison semantics into the eval-session aggregate document.
+- Do not reuse the old "winner of each child run" heuristic as the final repeated-session verdict.
+
+Locked comparison rule:
+- comparison operates on the `effective_k` suite-level metric for each participant
+- compare the top two participants by `AgentScore`
+- emit:
+  - `clear_winner` only when both sides have sufficient evidence and their chosen primary-metric intervals do not overlap
+  - `no_clear_winner` when evidence exists but intervals overlap
+  - `insufficient_evidence` when there are too few scored child runs or too few resolved tasks
+
+Why:
+- This directly addresses the issue's requirement to stop declaring noisy winners as definitive.
+- It keeps the semantics additive to the current aggregate document rather than introducing a separate endpoint in this issue.
+
+### 7. Top-Level Aggregate Behavior
+
+Decision:
+- Single-agent sessions keep a top-level aggregate.
+- Comparison sessions only expose winner-derived top-level `overall` and `dimensions` when the repeated-session comparison is `clear_winner`.
+- Otherwise:
+  - omit winner-derived top-level aggregate fields
+  - keep participant aggregates
+  - emit evidence warnings explaining why the top-level winner summary is absent
+
+Why:
+- The current top-level winner aggregation can overstate noisy comparison outcomes.
+- Preserving participant aggregates keeps the read model useful without encoding a misleading winner.
+
+### 8. Output Shape
+
+Decision:
+- Extend `aggregate_result` rather than adding a new endpoint.
+
+Locked additions:
+- participant-level:
+  - `pass_at_k`
+  - `pass_pow_k`
+  - `metric_routing`
+- top-level:
+  - single-agent mirrors of those fields when applicable
+  - repeated-session `comparison` block for multi-participant sessions
+
+OpenAPI will be updated to describe the richer aggregate document instead of leaving it effectively opaque.
+
+## Implementation Plan
+
+### Step 1. Config And Aggregate Schema
+
+- extend eval-session aggregation config validation and persistence to accept optional `reliability_weight`
+- extend aggregate document types for:
+  - pass metrics
+  - task summaries
+  - routing metadata
+  - comparison summary
+
+### Step 2. Task Outcome Extraction
+
+- add repository-side helpers that:
+  - load run agents for a child run
+  - load execution context for challenge metadata
+  - load challenge-level judge results
+  - derive per-task success outcomes
+
+### Step 3. Pass Metrics And Routing
+
+- compute per-task success rate and `k` series
+- compute suite-level aggregates over task-level probabilities
+- compute routing weight, primary metric, and `AgentScore`
+
+### Step 4. Comparison Semantics
+
+- derive repeated-session comparison summary from participant routing + suite metrics
+- remove winner-derived top-level comparison output when repeated evidence is insufficient
+
+### Step 5. Read Surface And OpenAPI
+
+- surface the richer aggregate document through the existing eval-session read endpoints
+- update OpenAPI to describe:
+  - `reliability_weight`
+  - pass metrics
+  - routing metadata
+  - comparison semantics
+
+### Step 6. Tests
+
+- repository unit tests for:
+  - Bernoulli pass metric math at `k = 1, 3, 5, 10`
+  - monotonicity
+  - routing inference and manual override precedence
+  - clear winner vs overlap vs insufficient evidence
+  - binary and continuous task-success derivation
+- integration tests for persisted aggregate documents
+- API/read-model tests for surfaced aggregate output and warnings
+
+## Explicit Non-Goals For This Issue
+
+1. No new top-level eval-session comparison endpoint.
+2. No full per-challenge dimension recomputation engine.
+3. No typed task-properties schema migration.
+4. No Vibe Eval auto-classification work from `#172`.
+
+## Files Likely To Change
+
+- `backend/internal/api/eval_sessions.go`
+- `backend/internal/api/eval_session_service.go`
+- `backend/internal/api/eval_session_reads.go`
+- `backend/internal/api/eval_session_reads_test.go`
+- `backend/internal/repository/eval_session_aggregation.go`
+- `backend/internal/repository/eval_session_aggregation_test.go`
+- `backend/internal/repository/eval_session_aggregation_integration_test.go`
+- `docs/api-server/openapi.yaml`
+- `testing/codex-issue-362-passk-comparisons.md`
+
+## Lock Rule
+
+No implementation code should be edited against `#362` until the review-checkpoint contract is written from this locked design.

--- a/testing/codex-issue-362-passk-comparisons.md
+++ b/testing/codex-issue-362-passk-comparisons.md
@@ -1,0 +1,141 @@
+# codex/issue-362-passk-comparisons — Test Contract
+
+Locked from: `research-docs/issues/issue-362-passk-comparison-plan.md`
+
+## Functional Behavior
+
+- Extend repeated-eval config decoding and persistence to accept optional `eval_session.aggregation.reliability_weight` as a float in `[0, 1]`.
+- Preserve backward compatibility for existing eval-session requests that omit `reliability_weight`.
+- Keep inferred task metadata flowing through the existing `routing_task_snapshot` document rather than introducing a new typed storage object.
+- Compute repeated-eval task outcomes per participant using challenge-level `judge_results` grouped by `challenge_identity_id`.
+- When challenge-level task outcomes cannot be resolved for a participant, fall back to a synthetic suite-level task derived from the run-agent scorecard and emit evidence warnings.
+- Compute participant-level `pass@k` and `pass^k` for `k = 1, 3, 5, 10`, plus `session.repetitions` when it is not already in that set.
+- Ensure `k = 1` yields the same rate for `pass@k`, `pass^k`, and the observed task success rate.
+- Use `success_threshold.min_pass_rate` as the continuous task-success threshold when provided; otherwise default to `0.8`.
+- Prefer manual `aggregation.reliability_weight` over inferred routing weight when supplied.
+- Infer routing weight from persisted task properties using the locked heuristic for:
+  - `has_side_effects`
+  - `autonomy`
+  - `step_count`
+  - `output_type`
+- Persist and surface `metric_routing` with:
+  - `source`
+  - `reliability_weight`
+  - `reasoning`
+  - `primary_metric`
+  - `effective_k`
+  - `composite_agent_score`
+- For single-agent sessions, surface top-level pass metrics and routing metadata in `aggregate_result`.
+- For comparison sessions, surface per-participant pass metrics and a repeated-session `comparison` block.
+- The repeated-session `comparison` block must return:
+  - `clear_winner` only when evidence is sufficient and the effective-k primary-metric intervals do not overlap
+  - `no_clear_winner` when evidence exists but the primary-metric intervals overlap
+  - `insufficient_evidence` when scored child runs or resolved tasks are insufficient
+- Comparison sessions must not surface a winner-derived top-level aggregate when the repeated-session comparison is `no_clear_winner` or `insufficient_evidence`.
+- Update the eval-session read model and OpenAPI description to expose the richer aggregate document shape.
+
+## Unit Tests
+
+- Config decoding tests for:
+  - valid `aggregation.reliability_weight`
+  - invalid `aggregation.reliability_weight`
+  - backward-compatible requests without the new field
+- Repository aggregation tests for:
+  - `pass@k` and `pass^k` at `k = 1, 3, 5, 10`
+  - monotonic increase for `pass@k`
+  - monotonic decrease for `pass^k`
+  - `k = 1` equivalence with observed task success rate
+  - binary verdict-driven task success
+  - continuous score threshold-driven task success
+  - suite-level fallback task success when challenge-level evidence is unavailable
+  - inferred routing weights for side effects, autonomy, step count, and output type
+  - manual override precedence over inferred routing
+  - clear winner comparison
+  - overlapping-interval no-clear-winner comparison
+  - insufficient-evidence comparison
+  - omission of comparison-session top-level winner summary when evidence is insufficient
+
+## Integration / Functional Tests
+
+- Repository integration test proving the persisted eval-session aggregate document includes:
+  - pass metrics
+  - task summaries
+  - metric routing
+  - comparison semantics when the session has multiple participants
+- Repository integration test proving `aggregation.reliability_weight` persists through create -> read.
+- API/read-model test proving eval-session reads surface the richer aggregate document without leaking synthetic top-level winner output for noisy comparison sessions.
+- API/read-model test proving evidence warnings are returned when the aggregate falls back to suite-level task derivation or lacks enough evidence for a definitive repeated-session comparison.
+
+## Smoke Tests
+
+- `cd /home/atharva/agentclash-issue-362/backend && go test ./internal/api ./internal/repository`
+- `cd /home/atharva/agentclash-issue-362/backend && go test ./...`
+- `cd /home/atharva/agentclash-issue-362/backend && go vet ./...`
+- `cd /home/atharva/agentclash-issue-362 && npx @redocly/cli lint docs/api-server/openapi.yaml`
+
+## E2E Tests
+
+- N/A — this slice is backend aggregation, API read-surface, and schema work, not a browser or CLI journey.
+
+## Manual / cURL Tests
+
+```bash
+cd /home/atharva/agentclash-issue-362
+
+curl -i -X POST http://localhost:8080/v1/eval-sessions \
+  -H "Content-Type: application/json" \
+  -H "X-Agentclash-User-Id: <user-id>" \
+  -H "X-Agentclash-Workspace-Memberships: <workspace-id>:workspace_admin" \
+  -d '{
+    "workspace_id": "<workspace-id>",
+    "challenge_pack_version_id": "<pack-version-id>",
+    "challenge_input_set_id": "<input-set-id>",
+    "participants": [
+      {
+        "agent_build_version_id": "<baseline-build-version-id>",
+        "label": "Baseline"
+      },
+      {
+        "agent_build_version_id": "<candidate-build-version-id>",
+        "label": "Candidate"
+      }
+    ],
+    "execution_mode": "comparison",
+    "name": "Issue 362 repeated eval",
+    "eval_session": {
+      "repetitions": 5,
+      "aggregation": {
+        "method": "mean",
+        "report_variance": true,
+        "confidence_interval": 0.95,
+        "reliability_weight": 0.85
+      },
+      "success_threshold": {
+        "min_pass_rate": 0.8
+      },
+      "routing_task_snapshot": {
+        "routing": { "mode": "comparison" },
+        "task": {
+          "pack_version": "v1",
+          "task_properties": {
+            "has_side_effects": true,
+            "autonomy": "full",
+            "step_count": 4,
+            "output_type": "action"
+          }
+        }
+      },
+      "schema_version": 1
+    }
+  }'
+
+curl -i http://localhost:8080/v1/eval-sessions/<eval-session-id> \
+  -H "X-Agentclash-User-Id: <user-id>" \
+  -H "X-Agentclash-Workspace-Memberships: <workspace-id>:workspace_admin"
+
+# Expected:
+# - create request accepts optional aggregation.reliability_weight
+# - read response returns aggregate_result with participant pass metrics,
+#   metric_routing, and comparison semantics
+# - noisy comparisons do not expose a definitive top-level winner summary
+```


### PR DESCRIPTION
## Summary
- implement issue #362 repeated-eval aggregation semantics, including `task_success`, `pass@k`, `pass^k`, `metric_routing`, and composite `AgentScore`
- derive task outcomes from persisted challenge `judge_results` with a scorecard fallback, and suppress noisy top-level comparison winners unless repeated-session evidence is clear
- plumb optional `aggregation.reliability_weight`, update the eval-session read surface and OpenAPI contract, and add focused repository/API coverage

## Locked design artifacts
- `research-docs/issues/issue-362-passk-comparison-plan.md`
- `testing/codex-issue-362-passk-comparisons.md`

## Validation
- `cd backend && go test ./internal/repository ./internal/api`
- `cd backend && go test ./...`
- `cd backend && go vet ./...`
- `npx @redocly/cli lint docs/api-server/openapi.yaml`

Closes #362
