### PR TITLE
[codex] Complete issue #149 eval session UI

### DIFF
--- a/backend/db/queries/agent_deployments.sql
+++ b/backend/db/queries/agent_deployments.sql
@@ -3,6 +3,7 @@ SELECT DISTINCT ON (ad.id)
     ad.id,
     ad.organization_id,
     ad.workspace_id,
+    ad.current_build_version_id,
     ad.name,
     ad.status,
     ad.created_at,

--- a/backend/internal/api/agent_deployments.go
+++ b/backend/internal/api/agent_deployments.go
@@ -44,14 +44,15 @@ func (m *AgentDeploymentReadManager) ListAgentDeployments(ctx context.Context, w
 }
 
 type agentDeploymentResponse struct {
-	ID               uuid.UUID  `json:"id"`
-	OrganizationID   uuid.UUID  `json:"organization_id"`
-	WorkspaceID      uuid.UUID  `json:"workspace_id"`
-	Name             string     `json:"name"`
-	Status           string     `json:"status"`
-	LatestSnapshotID *uuid.UUID `json:"latest_snapshot_id,omitempty"`
-	CreatedAt        time.Time  `json:"created_at"`
-	UpdatedAt        time.Time  `json:"updated_at"`
+	ID                    uuid.UUID  `json:"id"`
+	OrganizationID        uuid.UUID  `json:"organization_id"`
+	WorkspaceID           uuid.UUID  `json:"workspace_id"`
+	CurrentBuildVersionID uuid.UUID  `json:"current_build_version_id"`
+	Name                  string     `json:"name"`
+	Status                string     `json:"status"`
+	LatestSnapshotID      *uuid.UUID `json:"latest_snapshot_id,omitempty"`
+	CreatedAt             time.Time  `json:"created_at"`
+	UpdatedAt             time.Time  `json:"updated_at"`
 }
 
 type listAgentDeploymentsResponse struct {
@@ -81,14 +82,15 @@ func listAgentDeploymentsHandler(logger *slog.Logger, service AgentDeploymentRea
 		responseItems := make([]agentDeploymentResponse, 0, len(result.Deployments))
 		for _, deployment := range result.Deployments {
 			responseItems = append(responseItems, agentDeploymentResponse{
-				ID:               deployment.ID,
-				OrganizationID:   deployment.OrganizationID,
-				WorkspaceID:      deployment.WorkspaceID,
-				Name:             deployment.Name,
-				Status:           deployment.Status,
-				LatestSnapshotID: deployment.LatestSnapshotID,
-				CreatedAt:        deployment.CreatedAt,
-				UpdatedAt:        deployment.UpdatedAt,
+				ID:                    deployment.ID,
+				OrganizationID:        deployment.OrganizationID,
+				WorkspaceID:           deployment.WorkspaceID,
+				CurrentBuildVersionID: deployment.CurrentBuildVersionID,
+				Name:                  deployment.Name,
+				Status:                deployment.Status,
+				LatestSnapshotID:      deployment.LatestSnapshotID,
+				CreatedAt:             deployment.CreatedAt,
+				UpdatedAt:             deployment.UpdatedAt,
 			})
 		}
 

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -2301,14 +2301,15 @@ func (r *Repository) CountRunsByWorkspaceID(ctx context.Context, workspaceID uui
 }
 
 type AgentDeploymentSummary struct {
-	ID               uuid.UUID
-	OrganizationID   uuid.UUID
-	WorkspaceID      uuid.UUID
-	Name             string
-	Status           string
-	CreatedAt        time.Time
-	UpdatedAt        time.Time
-	LatestSnapshotID *uuid.UUID
+	ID                    uuid.UUID
+	OrganizationID        uuid.UUID
+	WorkspaceID           uuid.UUID
+	CurrentBuildVersionID uuid.UUID
+	Name                  string
+	Status                string
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
+	LatestSnapshotID      *uuid.UUID
 }
 
 func (r *Repository) ListActiveAgentDeploymentsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]AgentDeploymentSummary, error) {
@@ -2331,14 +2332,15 @@ func (r *Repository) ListActiveAgentDeploymentsByWorkspaceID(ctx context.Context
 		}
 
 		deployments = append(deployments, AgentDeploymentSummary{
-			ID:               row.ID,
-			OrganizationID:   row.OrganizationID,
-			WorkspaceID:      row.WorkspaceID,
-			Name:             row.Name,
-			Status:           row.Status,
-			CreatedAt:        createdAt,
-			UpdatedAt:        updatedAt,
-			LatestSnapshotID: cloneUUIDPtr(row.LatestSnapshotID),
+			ID:                    row.ID,
+			OrganizationID:        row.OrganizationID,
+			WorkspaceID:           row.WorkspaceID,
+			CurrentBuildVersionID: row.CurrentBuildVersionID,
+			Name:                  row.Name,
+			Status:                row.Status,
+			CreatedAt:             createdAt,
+			UpdatedAt:             updatedAt,
+			LatestSnapshotID:      cloneUUIDPtr(row.LatestSnapshotID),
 		})
 	}
 

--- a/backend/internal/repository/sqlc/agent_deployments.sql.go
+++ b/backend/internal/repository/sqlc/agent_deployments.sql.go
@@ -17,6 +17,7 @@ SELECT DISTINCT ON (ad.id)
     ad.id,
     ad.organization_id,
     ad.workspace_id,
+    ad.current_build_version_id,
     ad.name,
     ad.status,
     ad.created_at,
@@ -38,14 +39,15 @@ type ListActiveAgentDeploymentsByWorkspaceIDParams struct {
 }
 
 type ListActiveAgentDeploymentsByWorkspaceIDRow struct {
-	ID               uuid.UUID
-	OrganizationID   uuid.UUID
-	WorkspaceID      uuid.UUID
-	Name             string
-	Status           string
-	CreatedAt        pgtype.Timestamptz
-	UpdatedAt        pgtype.Timestamptz
-	LatestSnapshotID *uuid.UUID
+	ID                    uuid.UUID
+	OrganizationID        uuid.UUID
+	WorkspaceID           uuid.UUID
+	CurrentBuildVersionID uuid.UUID
+	Name                  string
+	Status                string
+	CreatedAt             pgtype.Timestamptz
+	UpdatedAt             pgtype.Timestamptz
+	LatestSnapshotID      *uuid.UUID
 }
 
 func (q *Queries) ListActiveAgentDeploymentsByWorkspaceID(ctx context.Context, arg ListActiveAgentDeploymentsByWorkspaceIDParams) ([]ListActiveAgentDeploymentsByWorkspaceIDRow, error) {
@@ -61,6 +63,7 @@ func (q *Queries) ListActiveAgentDeploymentsByWorkspaceID(ctx context.Context, a
 			&i.ID,
 			&i.OrganizationID,
 			&i.WorkspaceID,
+			&i.CurrentBuildVersionID,
 			&i.Name,
 			&i.Status,
 			&i.CreatedAt,

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -7529,7 +7529,7 @@ components:
 
     AgentDeployment:
       type: object
-      required: [id, organization_id, workspace_id, name, status, created_at, updated_at]
+      required: [id, organization_id, workspace_id, current_build_version_id, name, status, created_at, updated_at]
       properties:
         id:
           type: string
@@ -7538,6 +7538,9 @@ components:
           type: string
           format: uuid
         workspace_id:
+          type: string
+          format: uuid
+        current_build_version_id:
           type: string
           format: uuid
         name:

--- a/testing/issue-149-eval-session-ui.md
+++ b/testing/issue-149-eval-session-ui.md
@@ -1,0 +1,60 @@
+# Issue 149 Eval Session UI Contract
+
+## Goal
+
+Complete the missing user-facing product surface for repeated statistical evals from issue `#149` on top of the already-landed backend/API implementation.
+
+## Functional Expectations
+
+1. Workspace users can create an eval session from the web app without hand-writing JSON.
+2. The create flow captures the repeated-eval concepts that are missing from the current UI:
+   - participant selection by deployed agent
+   - repetitions
+   - aggregation method
+   - variance reporting
+   - confidence interval
+   - optional reliability weight override
+   - optional success threshold
+   - optional routing/task snapshot fields needed by the backend contract
+3. The runs area surfaces eval sessions as first-class objects instead of hiding them behind raw API calls.
+4. Users can open an eval session detail screen and inspect:
+   - eval session status and core configuration
+   - child runs
+   - run-count summary
+   - evidence warnings
+   - aggregate result when present
+5. Aggregate result rendering covers the important repeated-eval semantics already produced by the backend:
+   - overall and per-dimension aggregates
+   - pass@k and pass^k
+   - metric routing and composite agent score
+   - participant aggregates for comparison sessions
+   - repeated-session comparison outcome when present
+6. The UI links cleanly back to underlying child runs so existing replay/scorecard flows remain reachable.
+7. Existing single-run creation and run detail flows remain unchanged and working.
+
+## Implementation Scope
+
+1. Add frontend API types for eval-session create/list/detail responses.
+2. Add a web create flow for eval sessions from the workspace runs area.
+3. Add a list/read surface for eval sessions in the workspace UI.
+4. Add an eval-session detail page and aggregate result presentation components.
+5. Add focused frontend tests for the new create flow and detail rendering helpers/components.
+
+## Tests To Add Or Run
+
+1. Add or update frontend tests for eval-session creation request shaping and validation UX.
+2. Add frontend tests for aggregate-result rendering logic or helper formatting.
+3. Run targeted web tests covering:
+   - `create-run-dialog.test.tsx` if touched
+   - any new eval-session dialog/detail tests
+   - any shared API type/client tests touched by the change
+4. Run targeted backend eval-session tests only if an interface contract needs validation during integration.
+
+## Manual Verification
+
+1. Open the workspace runs page and verify both single-run and eval-session creation actions are visible.
+2. Create a single-agent repeated eval session and confirm navigation to its detail page.
+3. Create a comparison repeated eval session and confirm multiple participants are represented in the detail view.
+4. Confirm detail view shows configuration, child runs, warnings, aggregate stats, pass metrics, and routing guidance when present.
+5. Confirm child-run links open the existing run detail pages.
+6. Confirm the existing single-run creation path still posts to `/v1/runs` and navigates to the run page.

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sessions/[evalSessionId]/eval-session-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sessions/[evalSessionId]/eval-session-detail-client.tsx
@@ -1,0 +1,521 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import {
+  AlertTriangle,
+  FlaskConical,
+  GitCompare,
+  Sigma,
+} from "lucide-react";
+
+import { createApiClient } from "@/lib/api/client";
+import type {
+  EvalSessionDetail,
+  EvalSessionMetricAggregate,
+  EvalSessionParticipantAggregate,
+  EvalSessionStatus,
+} from "@/lib/api/types";
+import {
+  deriveEvalSessionMode,
+  deriveEvalSessionTitle,
+  formatEvalSessionMetricName,
+  formatEvalSessionRange,
+  formatEvalSessionRate,
+  formatEvalSessionValue,
+  passMetricAggregateForEffectiveK,
+  sortedAggregateDimensions,
+} from "@/lib/eval-sessions";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { evalSessionStatusVariant, runStatusVariant } from "../../runs/status-variant";
+
+const ACTIVE_STATUSES: EvalSessionStatus[] = ["queued", "running", "aggregating"];
+const POLL_INTERVAL_MS = 5000;
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-lg border border-border bg-card/40 p-4">
+      <div className="mb-4">
+        <h2 className="text-sm font-semibold tracking-tight">{title}</h2>
+        {description ? (
+          <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+        ) : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-background/70 p-4">
+      <div className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
+        {label}
+      </div>
+      <div className="mt-2 text-xl font-semibold tracking-tight">{value}</div>
+      {hint ? <div className="mt-1 text-xs text-muted-foreground">{hint}</div> : null}
+    </div>
+  );
+}
+
+function MetricAggregateCard({
+  label,
+  aggregate,
+}: {
+  label: string;
+  aggregate?: EvalSessionMetricAggregate | null;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-background/70 p-4">
+      <div className="text-sm font-medium">{label}</div>
+      <div className="mt-2 text-2xl font-semibold tracking-tight">
+        {formatEvalSessionValue(aggregate?.mean)}
+      </div>
+      <div className="mt-2 grid gap-1 text-xs text-muted-foreground">
+        <div>Median: {formatEvalSessionValue(aggregate?.median)}</div>
+        <div>Std dev: {formatEvalSessionValue(aggregate?.std_dev)}</div>
+        <div>Range: {formatEvalSessionValue(aggregate?.min)} - {formatEvalSessionValue(aggregate?.max)}</div>
+        <div>Interval: {formatEvalSessionRange(aggregate)}</div>
+      </div>
+    </div>
+  );
+}
+
+function ParticipantCard({
+  participant,
+}: {
+  participant: EvalSessionParticipantAggregate;
+}) {
+  const passAtAggregate = passMetricAggregateForEffectiveK(participant.pass_at_k);
+  const passPowAggregate = passMetricAggregateForEffectiveK(participant.pass_pow_k);
+
+  return (
+    <div className="rounded-lg border border-border bg-background/70 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold">{participant.label}</h3>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Lane {participant.lane_index}
+          </p>
+        </div>
+        {participant.metric_routing ? (
+          <Badge variant="outline">
+            {participant.metric_routing.primary_metric === "pass_pow_k"
+              ? "Primary: pass^k"
+              : "Primary: pass@k"}
+          </Badge>
+        ) : null}
+      </div>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-3">
+        <MetricAggregateCard label="Overall" aggregate={participant.overall} />
+        <MetricAggregateCard label="pass@k" aggregate={passAtAggregate} />
+        <MetricAggregateCard label="pass^k" aggregate={passPowAggregate} />
+      </div>
+
+      {participant.metric_routing ? (
+        <div className="mt-4 rounded-lg border border-border bg-card/60 p-3 text-sm">
+          <div className="font-medium">Metric routing</div>
+          <div className="mt-2 text-muted-foreground">
+            {participant.metric_routing.reasoning}
+          </div>
+          <div className="mt-3 grid gap-2 text-xs text-muted-foreground md:grid-cols-3">
+            <div>
+              Reliability weight:{" "}
+              {formatEvalSessionRate(participant.metric_routing.reliability_weight)}
+            </div>
+            <div>Effective k: {participant.metric_routing.effective_k}</div>
+            <div>
+              Composite AgentScore:{" "}
+              {formatEvalSessionRate(participant.metric_routing.composite_agent_score)}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function EvalSessionDetailClient({
+  workspaceId,
+  initialDetail,
+}: {
+  workspaceId: string;
+  initialDetail: EvalSessionDetail;
+}) {
+  const { getAccessToken } = useAccessToken();
+  const [detail, setDetail] = useState(initialDetail);
+
+  const fetchDetail = useCallback(async () => {
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      const nextDetail = await api.get<EvalSessionDetail>(
+        `/v1/eval-sessions/${detail.eval_session.id}`,
+      );
+      setDetail(nextDetail);
+    } catch {
+      // Keep the current data on background refresh failures.
+    }
+  }, [detail.eval_session.id, getAccessToken]);
+
+  const isActive = ACTIVE_STATUSES.includes(detail.eval_session.status);
+
+  useEffect(() => {
+    if (!isActive) return;
+    const interval = setInterval(fetchDetail, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [fetchDetail, isActive]);
+
+  const aggregateResult = detail.aggregate_result;
+  const title = deriveEvalSessionTitle(detail);
+  const executionMode = deriveEvalSessionMode(detail.runs, aggregateResult);
+  const passAtAggregate = passMetricAggregateForEffectiveK(aggregateResult?.pass_at_k);
+  const passPowAggregate = passMetricAggregateForEffectiveK(aggregateResult?.pass_pow_k);
+  const dimensions = sortedAggregateDimensions(aggregateResult);
+  const taskProperties =
+    detail.eval_session.routing_task_snapshot.task.task_properties;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3 text-sm text-muted-foreground">
+        <Link
+          href={`/workspaces/${workspaceId}/runs`}
+          className="hover:text-foreground transition-colors"
+        >
+          Runs
+        </Link>
+        <span>/</span>
+        <span className="text-foreground">{title}</span>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
+          <Badge
+            variant={evalSessionStatusVariant[detail.eval_session.status] ?? "outline"}
+          >
+            {detail.eval_session.status}
+          </Badge>
+          {executionMode ? (
+            <Badge variant="outline">
+              {executionMode === "comparison" ? "Comparison Session" : "Single-Agent Session"}
+            </Badge>
+          ) : null}
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-4">
+          <StatCard
+            label="Repetitions"
+            value={String(detail.eval_session.repetitions)}
+            hint="Independent child runs requested for this session"
+          />
+          <StatCard
+            label="Child Runs"
+            value={String(detail.summary.run_counts.total)}
+            hint={`${detail.summary.run_counts.completed} completed · ${detail.summary.run_counts.failed} failed`}
+          />
+          <StatCard
+            label="Effective k"
+            value={
+              aggregateResult?.metric_routing?.effective_k != null
+                ? String(aggregateResult.metric_routing.effective_k)
+                : "—"
+            }
+            hint="k used for pass@k / pass^k summaries"
+          />
+          <StatCard
+            label="Primary Metric"
+            value={
+              aggregateResult?.metric_routing?.primary_metric === "pass_pow_k"
+                ? "pass^k"
+                : aggregateResult?.metric_routing?.primary_metric === "pass_at_k"
+                  ? "pass@k"
+                  : "—"
+            }
+            hint="Chosen by metric routing guidance"
+          />
+        </div>
+      </div>
+
+      {detail.evidence_warnings.length > 0 ? (
+        <Section
+          title="Evidence Warnings"
+          description="Warnings are carried through from the session read model and aggregate evidence document."
+        >
+          <div className="space-y-2">
+            {detail.evidence_warnings.map((warning) => (
+              <div
+                key={warning}
+                className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-100"
+              >
+                <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+                <span>{warning}</span>
+              </div>
+            ))}
+          </div>
+        </Section>
+      ) : null}
+
+      <Section
+        title="Configuration"
+        description="The session config is the exact snapshot persisted with the repeated eval request."
+      >
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2 text-sm">
+            <div>
+              <span className="text-muted-foreground">Aggregation method:</span>{" "}
+              {detail.eval_session.aggregation_config.method}
+            </div>
+            <div>
+              <span className="text-muted-foreground">Variance reporting:</span>{" "}
+              {detail.eval_session.aggregation_config.report_variance ? "On" : "Off"}
+            </div>
+            <div>
+              <span className="text-muted-foreground">Confidence interval:</span>{" "}
+              {formatEvalSessionRate(detail.eval_session.aggregation_config.confidence_interval)}
+            </div>
+            <div>
+              <span className="text-muted-foreground">Reliability weight override:</span>{" "}
+              {formatEvalSessionRate(
+                detail.eval_session.aggregation_config.reliability_weight,
+              )}
+            </div>
+            <div>
+              <span className="text-muted-foreground">Success threshold:</span>{" "}
+              {formatEvalSessionRate(
+                "min_pass_rate" in detail.eval_session.success_threshold_config
+                  ? detail.eval_session.success_threshold_config.min_pass_rate
+                  : undefined,
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-2 text-sm">
+            <div className="font-medium">Task properties</div>
+            <div>
+              <span className="text-muted-foreground">Side effects:</span>{" "}
+              {taskProperties?.has_side_effects ? "Yes" : "No / unspecified"}
+            </div>
+            <div>
+              <span className="text-muted-foreground">Autonomy:</span>{" "}
+              {taskProperties?.autonomy ?? "Unspecified"}
+            </div>
+            <div>
+              <span className="text-muted-foreground">Step count:</span>{" "}
+              {taskProperties?.step_count ?? "Unspecified"}
+            </div>
+            <div>
+              <span className="text-muted-foreground">Output type:</span>{" "}
+              {taskProperties?.output_type ?? "Unspecified"}
+            </div>
+          </div>
+        </div>
+      </Section>
+
+      <Section
+        title="Aggregate Result"
+        description="Session-level statistics built from the child run scorecards."
+      >
+        {aggregateResult ? (
+          <div className="space-y-4">
+            <div className="grid gap-3 md:grid-cols-3">
+              <MetricAggregateCard label="Overall" aggregate={aggregateResult.overall} />
+              <MetricAggregateCard label="pass@k" aggregate={passAtAggregate} />
+              <MetricAggregateCard label="pass^k" aggregate={passPowAggregate} />
+            </div>
+
+            {aggregateResult.metric_routing ? (
+              <div className="rounded-lg border border-border bg-card/60 p-4">
+                <div className="flex items-center gap-2 text-sm font-medium">
+                  <Sigma className="size-4" />
+                  Metric Routing
+                </div>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  {aggregateResult.metric_routing.reasoning}
+                </p>
+                <div className="mt-3 grid gap-2 text-sm md:grid-cols-4">
+                  <div>
+                    <span className="text-muted-foreground">Source:</span>{" "}
+                    {formatEvalSessionMetricName(aggregateResult.metric_routing.source)}
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Reliability weight:</span>{" "}
+                    {formatEvalSessionRate(aggregateResult.metric_routing.reliability_weight)}
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Primary metric:</span>{" "}
+                    {aggregateResult.metric_routing.primary_metric === "pass_pow_k"
+                      ? "pass^k"
+                      : "pass@k"}
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">AgentScore:</span>{" "}
+                    {formatEvalSessionRate(
+                      aggregateResult.metric_routing.composite_agent_score,
+                    )}
+                  </div>
+                </div>
+              </div>
+            ) : null}
+
+            {aggregateResult.comparison ? (
+              <div className="rounded-lg border border-border bg-card/60 p-4">
+                <div className="flex items-center gap-2 text-sm font-medium">
+                  <GitCompare className="size-4" />
+                  Repeated-session comparison
+                </div>
+                <div className="mt-3 grid gap-2 text-sm md:grid-cols-4">
+                  <div>
+                    <span className="text-muted-foreground">Status:</span>{" "}
+                    {formatEvalSessionMetricName(aggregateResult.comparison.status)}
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Reason:</span>{" "}
+                    {aggregateResult.comparison.reason_code
+                      ? formatEvalSessionMetricName(aggregateResult.comparison.reason_code)
+                      : "—"}
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Compared metric:</span>{" "}
+                    {aggregateResult.comparison.compared_metric === "pass_pow_k"
+                      ? "pass^k"
+                      : aggregateResult.comparison.compared_metric === "pass_at_k"
+                        ? "pass@k"
+                        : "—"}
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Winner:</span>{" "}
+                    {aggregateResult.comparison.winner_label ?? "No clear winner"}
+                  </div>
+                </div>
+              </div>
+            ) : null}
+
+            {dimensions.length > 0 ? (
+              <div className="rounded-lg border border-border">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Dimension</TableHead>
+                      <TableHead>Mean</TableHead>
+                      <TableHead>Median</TableHead>
+                      <TableHead>Std Dev</TableHead>
+                      <TableHead>Range</TableHead>
+                      <TableHead>Interval</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {dimensions.map(([key, aggregate]) => (
+                      <TableRow key={key}>
+                        <TableCell className="font-medium">
+                          {formatEvalSessionMetricName(key)}
+                        </TableCell>
+                        <TableCell>{formatEvalSessionValue(aggregate.mean)}</TableCell>
+                        <TableCell>{formatEvalSessionValue(aggregate.median)}</TableCell>
+                        <TableCell>{formatEvalSessionValue(aggregate.std_dev)}</TableCell>
+                        <TableCell>
+                          {formatEvalSessionValue(aggregate.min)} - {formatEvalSessionValue(aggregate.max)}
+                        </TableCell>
+                        <TableCell>{formatEvalSessionRange(aggregate)}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            ) : null}
+
+            {aggregateResult.participants?.length ? (
+              <div className="space-y-3">
+                <div className="text-sm font-medium">Participants</div>
+                <div className="grid gap-3 xl:grid-cols-2">
+                  {aggregateResult.participants.map((participant) => (
+                    <ParticipantCard
+                      key={`${participant.lane_index}-${participant.label}`}
+                      participant={participant}
+                    />
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        ) : (
+          <div className="flex items-start gap-3 rounded-lg border border-dashed border-border p-4 text-sm text-muted-foreground">
+            <FlaskConical className="size-4 shrink-0" />
+            <span>
+              Aggregate output is not available yet. The session may still be running, aggregating, or waiting on persisted results.
+            </span>
+          </div>
+        )}
+      </Section>
+
+      <Section
+        title="Child Runs"
+        description="Each repeated eval session fans out into regular child runs that still use the existing run detail, replay, and scorecard flows."
+      >
+        <div className="rounded-lg border border-border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Mode</TableHead>
+                <TableHead>Created</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {detail.runs.map((run) => (
+                <TableRow key={run.id}>
+                  <TableCell>
+                    <Link
+                      href={`/workspaces/${workspaceId}/runs/${run.id}`}
+                      className="font-medium text-foreground hover:underline underline-offset-4"
+                    >
+                      {run.name}
+                    </Link>
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={runStatusVariant[run.status] ?? "outline"}>
+                      {run.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {run.execution_mode === "comparison" ? "Comparison" : "Single Agent"}
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {new Date(run.created_at).toLocaleString()}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </Section>
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sessions/[evalSessionId]/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sessions/[evalSessionId]/page.tsx
@@ -1,0 +1,36 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { notFound, redirect } from "next/navigation";
+
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import type { EvalSessionDetail } from "@/lib/api/types";
+import { EvalSessionDetailClient } from "./eval-session-detail-client";
+
+export default async function EvalSessionPage({
+  params,
+}: {
+  params: Promise<{ workspaceId: string; evalSessionId: string }>;
+}) {
+  const { accessToken } = await withAuth();
+  if (!accessToken) redirect("/auth/login");
+
+  const { workspaceId, evalSessionId } = await params;
+  const api = createApiClient(accessToken);
+
+  let detail: EvalSessionDetail;
+  try {
+    detail = await api.get<EvalSessionDetail>(`/v1/eval-sessions/${evalSessionId}`);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) {
+      notFound();
+    }
+    throw err;
+  }
+
+  return (
+    <EvalSessionDetailClient
+      workspaceId={workspaceId}
+      initialDetail={detail}
+    />
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-eval-session-dialog.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-eval-session-dialog.test.tsx
@@ -1,0 +1,372 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CreateEvalSessionDialog } from "./create-eval-session-dialog";
+
+const {
+  mockPush,
+  mockRefresh,
+  mockGetAccessToken,
+  mockCreateApiClient,
+  toast,
+} = vi.hoisted(() => {
+  return {
+    mockPush: vi.fn(),
+    mockRefresh: vi.fn(),
+    mockGetAccessToken: vi.fn(),
+    mockCreateApiClient: vi.fn(),
+    toast: Object.assign(vi.fn(), {
+      success: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+}));
+
+vi.mock("@workos-inc/authkit-nextjs/components", () => ({
+  useAccessToken: () => ({ getAccessToken: mockGetAccessToken }),
+}));
+
+vi.mock("sonner", () => ({
+  toast,
+}));
+
+vi.mock("@/lib/api/client", () => ({
+  createApiClient: (...args: unknown[]) => mockCreateApiClient(...args),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
+    React.createElement("button", props, children),
+}));
+
+vi.mock("@/components/ui/dialog", async () => {
+  const React = await import("react");
+
+  const DialogOpenContext = React.createContext(false);
+  const DialogToggleContext = React.createContext<(open: boolean) => void>(
+    () => {},
+  );
+
+  return {
+    Dialog: ({
+      open,
+      onOpenChange,
+      children,
+    }: {
+      open: boolean;
+      onOpenChange: (open: boolean) => void;
+      children: React.ReactNode;
+    }) =>
+      React.createElement(
+        DialogOpenContext.Provider,
+        { value: open },
+        React.createElement(
+          DialogToggleContext.Provider,
+          { value: onOpenChange },
+          children,
+        ),
+      ),
+    DialogTrigger: ({
+      render,
+      children,
+    }: {
+      render?: React.ReactElement;
+      children?: React.ReactNode;
+    }) => {
+      const setOpen = React.useContext(DialogToggleContext);
+      const element = render ?? React.createElement("button");
+      return React.cloneElement(element, {
+        onClick: () => setOpen(true),
+        children,
+      });
+    },
+    DialogContent: ({ children }: { children: React.ReactNode }) => {
+      const open = React.useContext(DialogOpenContext);
+      return open
+        ? React.createElement("div", { "data-testid": "dialog-content" }, children)
+        : null;
+    },
+    DialogDescription: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("p", null, children),
+    DialogFooter: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", null, children),
+    DialogHeader: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", null, children),
+    DialogTitle: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("h1", null, children),
+  };
+});
+
+vi.mock("lucide-react", () => ({
+  Loader2: () => React.createElement("span", null, "loader"),
+  Sigma: () => React.createElement("span", null, "sigma"),
+}));
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function waitFor(assertion: () => void, attempts = 30) {
+  let lastError: unknown;
+  for (let index = 0; index < attempts; index += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await flushPromises();
+    }
+  }
+  throw lastError;
+}
+
+function clickElement(element: Element) {
+  act(() => {
+    element.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+  });
+}
+
+function changeSelect(element: HTMLSelectElement, value: string) {
+  act(() => {
+    element.value = value;
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+}
+
+function findButton(text: string) {
+  const button = Array.from(document.querySelectorAll("button")).find((candidate) =>
+    candidate.textContent?.includes(text),
+  );
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Button with text ${text} not found`);
+  }
+  return button;
+}
+
+function findSelectForLabel(text: string) {
+  const label = Array.from(document.querySelectorAll("label")).find((candidate) =>
+    candidate.textContent?.includes(text),
+  );
+  const select = label?.parentElement?.querySelector("select");
+  if (!(select instanceof HTMLSelectElement)) {
+    throw new Error(`Select for ${text} not found`);
+  }
+  return select;
+}
+
+function findCheckboxByLabel(text: string) {
+  const label = Array.from(document.querySelectorAll("label")).find((candidate) =>
+    candidate.textContent?.includes(text),
+  );
+  const checkbox = label?.querySelector('input[type="checkbox"]');
+  if (!(checkbox instanceof HTMLInputElement)) {
+    throw new Error(`Checkbox for ${text} not found`);
+  }
+  return checkbox;
+}
+
+function renderDialog() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+
+  act(() => {
+    root.render(
+      React.createElement(CreateEvalSessionDialog, { workspaceId: "ws-1" }),
+    );
+  });
+
+  return {
+    cleanup: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+function buildApiMock(status = 201) {
+  const postWithMeta = vi.fn().mockResolvedValue({
+    status,
+    data:
+      status === 422
+        ? {
+            errors: [
+              {
+                field: "eval_session.repetitions",
+                code: "eval_session.repetitions.invalid",
+                message: "repetitions must be an integer between 1 and 100",
+              },
+            ],
+          }
+        : {
+            eval_session: {
+              id: "session-1",
+            },
+            run_ids: ["run-1"],
+          },
+  });
+
+  const get = vi.fn(async (url: string) => {
+    if (url === "/v1/workspaces/ws-1/challenge-packs") {
+      return {
+        items: [
+          {
+            id: "pack-1",
+            name: "Support Pack",
+            versions: [
+              {
+                id: "version-1",
+                version_number: 1,
+                lifecycle_status: "runnable",
+              },
+            ],
+          },
+        ],
+      };
+    }
+
+    if (url === "/v1/workspaces/ws-1/agent-deployments") {
+      return {
+        items: [
+          {
+            id: "deploy-1",
+            name: "Primary Agent",
+            status: "active",
+            current_build_version_id: "build-version-1",
+          },
+        ],
+      };
+    }
+
+    if (
+      url === "/v1/workspaces/ws-1/challenge-pack-versions/version-1/input-sets"
+    ) {
+      return {
+        items: [],
+      };
+    }
+
+    throw new Error(`Unexpected GET ${url}`);
+  });
+
+  return { get, postWithMeta };
+}
+
+beforeEach(() => {
+  // These component tests drive React through manual DOM events rather than RTL.
+  // Mark the environment explicitly so React's act() warnings stay actionable.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  document.body.innerHTML = "";
+  mockPush.mockReset();
+  mockRefresh.mockReset();
+  mockGetAccessToken.mockReset();
+  mockGetAccessToken.mockResolvedValue("token");
+  mockCreateApiClient.mockReset();
+  toast.success.mockReset();
+  toast.error.mockReset();
+});
+
+describe("CreateEvalSessionDialog", () => {
+  it("submits a repeated-eval request using deployment build version ids", async () => {
+    const api = buildApiMock();
+    mockCreateApiClient.mockReturnValue(api);
+
+    const view = renderDialog();
+    try {
+      clickElement(findButton("New Eval Session"));
+      await flushPromises();
+
+      changeSelect(findSelectForLabel("Challenge Pack"), "pack-1");
+      await flushPromises();
+
+      clickElement(findCheckboxByLabel("Primary Agent"));
+      await flushPromises();
+
+      clickElement(findButton("Create Eval Session"));
+
+      await waitFor(() => {
+        expect(api.postWithMeta).toHaveBeenCalledTimes(1);
+      });
+
+      const [, request] = api.postWithMeta.mock.calls[0];
+      expect(request).toMatchObject({
+        workspace_id: "ws-1",
+        challenge_pack_version_id: "version-1",
+        execution_mode: "single_agent",
+        participants: [
+          {
+            agent_build_version_id: "build-version-1",
+            label: "Primary Agent",
+          },
+        ],
+        eval_session: {
+          repetitions: 5,
+          aggregation: {
+            method: "median",
+            report_variance: true,
+            confidence_interval: 0.95,
+          },
+          routing_task_snapshot: {
+            routing: {},
+            task: {},
+          },
+          schema_version: 1,
+        },
+      });
+      expect(mockPush).toHaveBeenCalledWith(
+        "/workspaces/ws-1/eval-sessions/session-1",
+      );
+      expect(toast.success).toHaveBeenCalledWith("Eval session created");
+    } finally {
+      view.cleanup();
+    }
+  });
+
+  it("surfaces validation errors returned by the eval-session API", async () => {
+    const api = buildApiMock(422);
+    mockCreateApiClient.mockReturnValue(api);
+
+    const view = renderDialog();
+    try {
+      clickElement(findButton("New Eval Session"));
+      await flushPromises();
+
+      changeSelect(findSelectForLabel("Challenge Pack"), "pack-1");
+      await flushPromises();
+
+      clickElement(findCheckboxByLabel("Primary Agent"));
+      await flushPromises();
+
+      clickElement(findButton("Create Eval Session"));
+
+      await waitFor(() => {
+        expect(api.postWithMeta).toHaveBeenCalledTimes(1);
+      });
+
+      expect(toast.error).toHaveBeenCalledWith(
+        "repetitions must be an integer between 1 and 100",
+      );
+      expect(mockPush).not.toHaveBeenCalled();
+    } finally {
+      view.cleanup();
+    }
+  });
+});

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-eval-session-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-eval-session-dialog.tsx
@@ -1,0 +1,653 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { Loader2, Sigma } from "lucide-react";
+import { toast } from "sonner";
+
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import type {
+  AgentDeployment,
+  ChallengeInputSetSummary,
+  ChallengePack,
+  ChallengePackVersion,
+  CreateEvalSessionRequest,
+  CreateEvalSessionResponse,
+  EvalSessionValidationEnvelope,
+  EvalSessionTaskProperties,
+} from "@/lib/api/types";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+interface CreateEvalSessionDialogProps {
+  workspaceId: string;
+}
+
+function collectTaskProperties(
+  input: EvalSessionTaskProperties,
+): EvalSessionTaskProperties | undefined {
+  const properties: EvalSessionTaskProperties = {};
+  if (input.has_side_effects) properties.has_side_effects = true;
+  if (input.autonomy) properties.autonomy = input.autonomy;
+  if (input.step_count != null) properties.step_count = input.step_count;
+  if (input.output_type) properties.output_type = input.output_type;
+  return Object.keys(properties).length > 0 ? properties : undefined;
+}
+
+export function CreateEvalSessionDialog({
+  workspaceId,
+}: CreateEvalSessionDialogProps) {
+  const router = useRouter();
+  const { getAccessToken } = useAccessToken();
+
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [selectedPackId, setSelectedPackId] = useState("");
+  const [selectedVersionId, setSelectedVersionId] = useState("");
+  const [inputSetId, setInputSetId] = useState("");
+  const [selectedDeploymentIds, setSelectedDeploymentIds] = useState<string[]>([]);
+  const [participantLabels, setParticipantLabels] = useState<Record<string, string>>(
+    {},
+  );
+  const [repetitions, setRepetitions] = useState("5");
+  const [aggregationMethod, setAggregationMethod] = useState<"median" | "mean">(
+    "median",
+  );
+  const [reportVariance, setReportVariance] = useState(true);
+  const [confidenceInterval, setConfidenceInterval] = useState("0.95");
+  const [reliabilityWeight, setReliabilityWeight] = useState("");
+  const [minPassRate, setMinPassRate] = useState("");
+  const [hasSideEffects, setHasSideEffects] = useState(false);
+  const [autonomy, setAutonomy] = useState<"" | "human" | "semi" | "full">("");
+  const [stepCount, setStepCount] = useState("");
+  const [outputType, setOutputType] = useState<"" | "artifact" | "action">("");
+  const [submitting, setSubmitting] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [loadingInputSets, setLoadingInputSets] = useState(false);
+
+  const [packs, setPacks] = useState<ChallengePack[]>([]);
+  const [runnableVersions, setRunnableVersions] = useState<ChallengePackVersion[]>(
+    [],
+  );
+  const [inputSets, setInputSets] = useState<ChallengeInputSetSummary[]>([]);
+  const [deployments, setDeployments] = useState<AgentDeployment[]>([]);
+
+  const deploymentById = Object.fromEntries(
+    deployments.map((deployment) => [deployment.id, deployment]),
+  );
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      const [packsResponse, deploymentsResponse] = await Promise.all([
+        api.get<{ items: ChallengePack[] }>(
+          `/v1/workspaces/${workspaceId}/challenge-packs`,
+        ),
+        api.get<{ items: AgentDeployment[] }>(
+          `/v1/workspaces/${workspaceId}/agent-deployments`,
+        ),
+      ]);
+      setPacks(packsResponse.items);
+      setDeployments(
+        deploymentsResponse.items.filter((deployment) => deployment.status === "active"),
+      );
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Failed to load data");
+    } finally {
+      setLoading(false);
+    }
+  }, [getAccessToken, workspaceId]);
+
+  useEffect(() => {
+    if (open) void loadData();
+  }, [loadData, open]);
+
+  useEffect(() => {
+    if (!open || !selectedVersionId) {
+      setInputSetId("");
+      setInputSets([]);
+      setLoadingInputSets(false);
+      return;
+    }
+
+    let cancelled = false;
+    setInputSetId("");
+    setInputSets([]);
+    setLoadingInputSets(true);
+
+    void (async () => {
+      try {
+        const token = await getAccessToken();
+        const api = createApiClient(token);
+        const response = await api.get<{ items: ChallengeInputSetSummary[] }>(
+          `/v1/workspaces/${workspaceId}/challenge-pack-versions/${selectedVersionId}/input-sets`,
+        );
+
+        if (cancelled) return;
+        setInputSets(response.items);
+        if (response.items.length === 1) {
+          setInputSetId(response.items[0].id);
+        }
+      } catch (err) {
+        if (cancelled) return;
+        toast.error(
+          err instanceof ApiError ? err.message : "Failed to load input sets",
+        );
+      } finally {
+        if (!cancelled) setLoadingInputSets(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [getAccessToken, open, selectedVersionId, workspaceId]);
+
+  function resetForm() {
+    setName("");
+    setSelectedPackId("");
+    setSelectedVersionId("");
+    setInputSetId("");
+    setSelectedDeploymentIds([]);
+    setParticipantLabels({});
+    setRepetitions("5");
+    setAggregationMethod("median");
+    setReportVariance(true);
+    setConfidenceInterval("0.95");
+    setReliabilityWeight("");
+    setMinPassRate("");
+    setHasSideEffects(false);
+    setAutonomy("");
+    setStepCount("");
+    setOutputType("");
+    setRunnableVersions([]);
+    setInputSets([]);
+  }
+
+  function handlePackChange(packId: string) {
+    setSelectedPackId(packId);
+    setSelectedVersionId("");
+    setInputSetId("");
+    setInputSets([]);
+    if (!packId) {
+      setRunnableVersions([]);
+      return;
+    }
+    const pack = packs.find((candidate) => candidate.id === packId);
+    const versions = (pack?.versions ?? []).filter(
+      (version) => version.lifecycle_status === "runnable",
+    );
+    setRunnableVersions(versions);
+    if (versions.length === 1) {
+      setSelectedVersionId(versions[0].id);
+    }
+  }
+
+  function toggleDeployment(deploymentId: string) {
+    const deployment = deploymentById[deploymentId];
+    if (!deployment) return;
+
+    setSelectedDeploymentIds((current) =>
+      current.includes(deploymentId)
+        ? current.filter((id) => id !== deploymentId)
+        : [...current, deploymentId],
+    );
+    setParticipantLabels((current) => ({
+      ...current,
+      [deploymentId]: current[deploymentId] ?? deployment.name,
+    }));
+  }
+
+  async function handleCreate() {
+    if (!selectedVersionId || selectedDeploymentIds.length === 0) return;
+
+    const parsedRepetitions = Number.parseInt(repetitions, 10);
+    const parsedConfidenceInterval = Number.parseFloat(confidenceInterval);
+    if (
+      Number.isNaN(parsedRepetitions) ||
+      parsedRepetitions < 1 ||
+      parsedRepetitions > 100
+    ) {
+      toast.error("Repetitions must be between 1 and 100.");
+      return;
+    }
+    if (
+      Number.isNaN(parsedConfidenceInterval) ||
+      parsedConfidenceInterval <= 0 ||
+      parsedConfidenceInterval >= 1
+    ) {
+      toast.error("Confidence interval must be between 0 and 1.");
+      return;
+    }
+
+    const parsedReliabilityWeight =
+      reliabilityWeight.trim() === ""
+        ? undefined
+        : Number.parseFloat(reliabilityWeight);
+    if (
+      parsedReliabilityWeight != null &&
+      (Number.isNaN(parsedReliabilityWeight) ||
+        parsedReliabilityWeight < 0 ||
+        parsedReliabilityWeight > 1)
+    ) {
+      toast.error("Reliability weight must be between 0 and 1.");
+      return;
+    }
+
+    const parsedMinPassRate =
+      minPassRate.trim() === "" ? undefined : Number.parseFloat(minPassRate);
+    if (
+      parsedMinPassRate != null &&
+      (Number.isNaN(parsedMinPassRate) ||
+        parsedMinPassRate < 0 ||
+        parsedMinPassRate > 1)
+    ) {
+      toast.error("Success threshold must be between 0 and 1.");
+      return;
+    }
+
+    const parsedStepCount =
+      stepCount.trim() === "" ? undefined : Number.parseInt(stepCount, 10);
+    if (parsedStepCount != null && (Number.isNaN(parsedStepCount) || parsedStepCount < 1)) {
+      toast.error("Step count must be at least 1 when provided.");
+      return;
+    }
+
+    const taskProperties = collectTaskProperties({
+      has_side_effects: hasSideEffects,
+      autonomy: autonomy || undefined,
+      step_count: parsedStepCount,
+      output_type: outputType || undefined,
+    });
+
+    const request: CreateEvalSessionRequest = {
+      workspace_id: workspaceId,
+      challenge_pack_version_id: selectedVersionId,
+      challenge_input_set_id: inputSetId.trim() || undefined,
+      participants: selectedDeploymentIds.map((deploymentId) => ({
+        agent_build_version_id:
+          deploymentById[deploymentId].current_build_version_id,
+        label: participantLabels[deploymentId]?.trim() || deploymentById[deploymentId].name,
+      })),
+      execution_mode:
+        selectedDeploymentIds.length > 1 ? "comparison" : "single_agent",
+      name: name.trim() || undefined,
+      eval_session: {
+        repetitions: parsedRepetitions,
+        aggregation: {
+          method: aggregationMethod,
+          report_variance: reportVariance,
+          confidence_interval: parsedConfidenceInterval,
+          reliability_weight: parsedReliabilityWeight,
+        },
+        success_threshold:
+          parsedMinPassRate != null
+            ? {
+                min_pass_rate: parsedMinPassRate,
+              }
+            : null,
+        routing_task_snapshot: {
+          routing: {},
+          task: taskProperties ? { task_properties: taskProperties } : {},
+        },
+        schema_version: 1,
+      },
+    };
+
+    setSubmitting(true);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      const response = await api.postWithMeta<
+        CreateEvalSessionResponse | EvalSessionValidationEnvelope
+      >("/v1/eval-sessions", request, {
+        allowedStatuses: [422],
+      });
+
+      if (response.status === 422) {
+        const body = response.data as EvalSessionValidationEnvelope;
+        const message = body.errors
+          .slice(0, 3)
+          .map((error) => error.message)
+          .join(" ");
+        toast.error(message || "Eval session configuration is invalid.");
+        return;
+      }
+
+      const body = response.data as CreateEvalSessionResponse;
+      toast.success("Eval session created");
+      setOpen(false);
+      resetForm();
+      router.push(
+        `/workspaces/${workspaceId}/eval-sessions/${body.eval_session.id}`,
+      );
+      router.refresh();
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError ? err.message : "Failed to create eval session",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const requiresInputSetSelection = inputSets.length > 1;
+  const canSubmit =
+    Boolean(selectedVersionId) &&
+    selectedDeploymentIds.length > 0 &&
+    !loadingInputSets &&
+    (!requiresInputSetSelection || Boolean(inputSetId));
+
+  const selectClass =
+    "block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:opacity-50";
+  const inputClass =
+    "block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/50";
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger render={<Button size="sm" variant="outline" />}>
+        <Sigma data-icon="inline-start" className="size-4" />
+        New Eval Session
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>New Eval Session</DialogTitle>
+          <DialogDescription>
+            Create a repeated eval session that fans out child runs and aggregates the result statistically.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-[70vh] space-y-4 overflow-y-auto py-2">
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">
+              Name{" "}
+              <span className="font-normal text-muted-foreground">(optional)</span>
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="Auto-generated if empty"
+              className={inputClass}
+            />
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">Challenge Pack</label>
+            <select
+              value={selectedPackId}
+              onChange={(event) => handlePackChange(event.target.value)}
+              className={selectClass}
+              disabled={loading}
+            >
+              <option value="">Select a challenge pack</option>
+              {packs.map((pack) => (
+                <option key={pack.id} value={pack.id}>
+                  {pack.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">Runnable Version</label>
+            <select
+              value={selectedVersionId}
+              onChange={(event) => setSelectedVersionId(event.target.value)}
+              className={selectClass}
+              disabled={!selectedPackId || runnableVersions.length === 0}
+            >
+              <option value="">Select a runnable version</option>
+              {runnableVersions.map((version) => (
+                <option key={version.id} value={version.id}>
+                  Version {version.version_number}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">
+              Input Set{" "}
+              <span className="font-normal text-muted-foreground">
+                ({loadingInputSets ? "loading" : inputSets.length || "default"})
+              </span>
+            </label>
+            <select
+              value={inputSetId}
+              onChange={(event) => setInputSetId(event.target.value)}
+              className={selectClass}
+              disabled={!selectedVersionId || loadingInputSets || inputSets.length === 0}
+            >
+              <option value="">
+                {inputSets.length === 0 ? "Default / auto-select" : "Select an input set"}
+              </option>
+              {inputSets.map((inputSet) => (
+                <option key={inputSet.id} value={inputSet.id}>
+                  {inputSet.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="space-y-3 rounded-lg border border-border p-4">
+            <div>
+              <h3 className="text-sm font-medium">Participants</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Select one or more active deployments. The current build version for each deployment will be used as the eval-session participant.
+              </p>
+            </div>
+
+            <div className="space-y-3">
+              {deployments.map((deployment) => {
+                const checked = selectedDeploymentIds.includes(deployment.id);
+                return (
+                  <div
+                    key={deployment.id}
+                    className="rounded-lg border border-border bg-background/60 p-3"
+                  >
+                    <label className="flex items-center gap-3 text-sm font-medium">
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => toggleDeployment(deployment.id)}
+                        className="size-4 rounded border-border accent-primary"
+                      />
+                      <span>{deployment.name}</span>
+                    </label>
+                    {checked ? (
+                      <div className="mt-3">
+                        <label className="mb-1.5 block text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
+                          Participant label
+                        </label>
+                        <input
+                          type="text"
+                          value={participantLabels[deployment.id] ?? deployment.name}
+                          onChange={(event) =>
+                            setParticipantLabels((current) => ({
+                              ...current,
+                              [deployment.id]: event.target.value,
+                            }))
+                          }
+                          className={inputClass}
+                        />
+                      </div>
+                    ) : null}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <label className="mb-1.5 block text-sm font-medium">Repetitions</label>
+              <input
+                type="number"
+                min="1"
+                max="100"
+                value={repetitions}
+                onChange={(event) => setRepetitions(event.target.value)}
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium">Aggregation method</label>
+              <select
+                value={aggregationMethod}
+                onChange={(event) =>
+                  setAggregationMethod(event.target.value as "median" | "mean")
+                }
+                className={selectClass}
+              >
+                <option value="median">Median</option>
+                <option value="mean">Mean</option>
+              </select>
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium">Confidence interval</label>
+              <input
+                type="number"
+                min="0.01"
+                max="0.99"
+                step="0.01"
+                value={confidenceInterval}
+                onChange={(event) => setConfidenceInterval(event.target.value)}
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium">
+                Reliability weight override{" "}
+                <span className="font-normal text-muted-foreground">(optional)</span>
+              </label>
+              <input
+                type="number"
+                min="0"
+                max="1"
+                step="0.05"
+                value={reliabilityWeight}
+                onChange={(event) => setReliabilityWeight(event.target.value)}
+                placeholder="Leave blank to infer from task properties"
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium">
+                Success threshold{" "}
+                <span className="font-normal text-muted-foreground">(optional)</span>
+              </label>
+              <input
+                type="number"
+                min="0"
+                max="1"
+                step="0.05"
+                value={minPassRate}
+                onChange={(event) => setMinPassRate(event.target.value)}
+                placeholder="Example: 0.8"
+                className={inputClass}
+              />
+            </div>
+            <div className="flex items-end">
+              <label className="flex items-center gap-3 rounded-lg border border-border bg-background/60 px-3 py-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={reportVariance}
+                  onChange={(event) => setReportVariance(event.target.checked)}
+                  className="size-4 rounded border-border accent-primary"
+                />
+                Report variance and high-variance dimensions
+              </label>
+            </div>
+          </div>
+
+          <div className="space-y-3 rounded-lg border border-border p-4">
+            <div>
+              <h3 className="text-sm font-medium">Metric routing hints</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                These optional task properties help the backend decide whether pass@k or pass^k should be emphasized.
+              </p>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <label className="flex items-center gap-3 rounded-lg border border-border bg-background/60 px-3 py-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={hasSideEffects}
+                  onChange={(event) => setHasSideEffects(event.target.checked)}
+                  className="size-4 rounded border-border accent-primary"
+                />
+                Task has side effects
+              </label>
+
+              <div>
+                <label className="mb-1.5 block text-sm font-medium">Autonomy</label>
+                <select
+                  value={autonomy}
+                  onChange={(event) =>
+                    setAutonomy(event.target.value as "" | "human" | "semi" | "full")
+                  }
+                  className={selectClass}
+                >
+                  <option value="">Unspecified</option>
+                  <option value="human">Human-reviewed</option>
+                  <option value="semi">Semi-autonomous</option>
+                  <option value="full">Fully autonomous</option>
+                </select>
+              </div>
+
+              <div>
+                <label className="mb-1.5 block text-sm font-medium">Step count</label>
+                <input
+                  type="number"
+                  min="1"
+                  value={stepCount}
+                  onChange={(event) => setStepCount(event.target.value)}
+                  placeholder="Optional"
+                  className={inputClass}
+                />
+              </div>
+
+              <div>
+                <label className="mb-1.5 block text-sm font-medium">Output type</label>
+                <select
+                  value={outputType}
+                  onChange={(event) =>
+                    setOutputType(event.target.value as "" | "artifact" | "action")
+                  }
+                  className={selectClass}
+                >
+                  <option value="">Unspecified</option>
+                  <option value="artifact">Artifact</option>
+                  <option value="action">Action</option>
+                </select>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button onClick={handleCreate} disabled={!canSubmit || submitting}>
+            {submitting ? <Loader2 className="size-4 animate-spin" /> : null}
+            Create Eval Session
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/eval-session-list.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/eval-session-list.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { FlaskConical } from "lucide-react";
+
+import { createApiClient } from "@/lib/api/client";
+import type {
+  EvalSessionListItem,
+  EvalSessionStatus,
+  ListEvalSessionsResponse,
+} from "@/lib/api/types";
+import {
+  formatEvalSessionMetricName,
+  shortEvalSessionId,
+} from "@/lib/eval-sessions";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { evalSessionStatusVariant } from "./status-variant";
+
+const ACTIVE_STATUSES: EvalSessionStatus[] = ["queued", "running", "aggregating"];
+const PAGE_SIZE = 20;
+const POLL_INTERVAL_MS = 5000;
+
+interface EvalSessionListProps {
+  workspaceId: string;
+  initialSessions: EvalSessionListItem[];
+}
+
+function formatPrimaryMetric(item: EvalSessionListItem): string {
+  const primaryMetric = item.aggregate_result?.metric_routing?.primary_metric;
+  if (primaryMetric === "pass_at_k") return "pass@k";
+  if (primaryMetric === "pass_pow_k") return "pass^k";
+  return "—";
+}
+
+function formatRunSummary(item: EvalSessionListItem): string {
+  const counts = item.summary.run_counts;
+  if (counts.total === 0) return "No child runs";
+  if (counts.completed === counts.total) return `${counts.completed}/${counts.total} completed`;
+  if (counts.failed > 0) return `${counts.completed}/${counts.total} completed · ${counts.failed} failed`;
+  if (counts.running > 0 || counts.queued > 0 || counts.provisioning > 0 || counts.scoring > 0) {
+    return `${counts.completed}/${counts.total} completed · ${counts.running + counts.queued + counts.provisioning + counts.scoring} active`;
+  }
+  if (counts.cancelled > 0) return `${counts.completed}/${counts.total} completed · ${counts.cancelled} cancelled`;
+  return `${counts.completed}/${counts.total} completed`;
+}
+
+export function EvalSessionList({
+  workspaceId,
+  initialSessions,
+}: EvalSessionListProps) {
+  const { getAccessToken } = useAccessToken();
+  const [sessions, setSessions] = useState(initialSessions);
+
+  const fetchSessions = useCallback(async () => {
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      const response = await api.get<ListEvalSessionsResponse>("/v1/eval-sessions", {
+        params: {
+          workspace_id: workspaceId,
+          limit: PAGE_SIZE,
+          offset: 0,
+        },
+      });
+      setSessions(response.items);
+    } catch {
+      // Keep the current data when background refresh fails.
+    }
+  }, [getAccessToken, workspaceId]);
+
+  const hasActiveSessions = sessions.some((item) =>
+    ACTIVE_STATUSES.includes(item.eval_session.status),
+  );
+
+  useEffect(() => {
+    if (!hasActiveSessions) return;
+    const interval = setInterval(fetchSessions, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [fetchSessions, hasActiveSessions]);
+
+  if (sessions.length === 0) {
+    return (
+      <EmptyState
+        icon={<FlaskConical className="size-10" />}
+        title="No eval sessions yet"
+        description="Create a repeated eval session to aggregate multiple benchmark runs into one reliable result."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-muted-foreground">
+        Recent eval sessions with repeated-run aggregation, pass metrics, and session-level evidence warnings.
+      </p>
+
+      <div className="rounded-lg border border-border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Session</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Repetitions</TableHead>
+              <TableHead>Runs</TableHead>
+              <TableHead>Primary Metric</TableHead>
+              <TableHead>Created</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {sessions.map((item) => {
+              const warningCount = item.evidence_warnings.length;
+              return (
+                <TableRow key={item.eval_session.id}>
+                  <TableCell>
+                    <Link
+                      href={`/workspaces/${workspaceId}/eval-sessions/${item.eval_session.id}`}
+                      className="font-medium text-foreground hover:underline underline-offset-4"
+                    >
+                      Eval Session {shortEvalSessionId(item.eval_session.id)}
+                    </Link>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      {warningCount > 0
+                        ? `${warningCount} warning${warningCount === 1 ? "" : "s"}`
+                        : "No evidence warnings"}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={evalSessionStatusVariant[item.eval_session.status] ?? "outline"}
+                    >
+                      {item.eval_session.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {item.eval_session.repetitions}
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {formatRunSummary(item)}
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {formatPrimaryMetric(item) === "—"
+                      ? "—"
+                      : formatEvalSessionMetricName(formatPrimaryMetric(item))}
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {new Date(item.eval_session.created_at).toLocaleDateString()}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/page.tsx
@@ -1,9 +1,12 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { redirect } from "next/navigation";
 import { createApiClient } from "@/lib/api/client";
-import type { Run } from "@/lib/api/types";
+import type { ListEvalSessionsResponse, Run } from "@/lib/api/types";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { RunList } from "./run-list";
 import { CreateRunDialog } from "./create-run-dialog";
+import { CreateEvalSessionDialog } from "./create-eval-session-dialog";
+import { EvalSessionList } from "./eval-session-list";
 
 export default async function RunsPage({
   params,
@@ -16,14 +19,19 @@ export default async function RunsPage({
   const { workspaceId } = await params;
 
   const api = createApiClient(accessToken);
-  const res = await api.get<{
-    items: Run[];
-    total: number;
-    limit: number;
-    offset: number;
-  }>(`/v1/workspaces/${workspaceId}/runs`, {
-    params: { limit: 20, offset: 0 },
-  });
+  const [runsResponse, evalSessionsResponse] = await Promise.all([
+    api.get<{
+      items: Run[];
+      total: number;
+      limit: number;
+      offset: number;
+    }>(`/v1/workspaces/${workspaceId}/runs`, {
+      params: { limit: 20, offset: 0 },
+    }),
+    api.get<ListEvalSessionsResponse>("/v1/eval-sessions", {
+      params: { workspace_id: workspaceId, limit: 20, offset: 0 },
+    }),
+  ]);
 
   return (
     <div>
@@ -31,17 +39,36 @@ export default async function RunsPage({
         <div>
           <h1 className="text-lg font-semibold tracking-tight">Runs</h1>
           <p className="text-sm text-muted-foreground mt-0.5">
-            Benchmark runs pitting agents against challenge packs.
+            Benchmark single runs and repeated eval sessions against challenge packs.
           </p>
         </div>
-        <CreateRunDialog workspaceId={workspaceId} />
+        <div className="flex items-center gap-2">
+          <CreateEvalSessionDialog workspaceId={workspaceId} />
+          <CreateRunDialog workspaceId={workspaceId} />
+        </div>
       </div>
 
-      <RunList
-        workspaceId={workspaceId}
-        initialRuns={res.items}
-        initialTotal={res.total}
-      />
+      <Tabs defaultValue="runs" className="w-full">
+        <TabsList variant="line">
+          <TabsTrigger value="runs">Runs</TabsTrigger>
+          <TabsTrigger value="eval-sessions">Eval Sessions</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="runs" className="pt-4">
+          <RunList
+            workspaceId={workspaceId}
+            initialRuns={runsResponse.items}
+            initialTotal={runsResponse.total}
+          />
+        </TabsContent>
+
+        <TabsContent value="eval-sessions" className="pt-4">
+          <EvalSessionList
+            workspaceId={workspaceId}
+            initialSessions={evalSessionsResponse.items}
+          />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/status-variant.ts
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/status-variant.ts
@@ -1,4 +1,4 @@
-import type { RunStatus } from "@/lib/api/types";
+import type { EvalSessionStatus, RunStatus } from "@/lib/api/types";
 
 export const runStatusVariant: Record<
   RunStatus,
@@ -9,6 +9,18 @@ export const runStatusVariant: Record<
   provisioning: "secondary",
   running: "outline",
   scoring: "outline",
+  completed: "default",
+  failed: "destructive",
+  cancelled: "secondary",
+};
+
+export const evalSessionStatusVariant: Record<
+  EvalSessionStatus,
+  "default" | "secondary" | "outline" | "destructive"
+> = {
+  queued: "secondary",
+  running: "outline",
+  aggregating: "outline",
   completed: "default",
   failed: "destructive",
   cancelled: "secondary",

--- a/web/src/lib/__tests__/eval-sessions.test.ts
+++ b/web/src/lib/__tests__/eval-sessions.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveEvalSessionMode,
+  deriveEvalSessionTitle,
+  formatEvalSessionValue,
+  passMetricAggregateForEffectiveK,
+  sortedAggregateDimensions,
+} from "../eval-sessions";
+import type { EvalSessionDetail, EvalSessionPassMetricSeries } from "../api/types";
+
+describe("eval session helpers", () => {
+  it("derives a title from the first child run name", () => {
+    const detail = {
+      eval_session: { id: "session-12345678" },
+      runs: [{ name: "Repeated Eval [1/5]", execution_mode: "single_agent" }],
+    } as EvalSessionDetail;
+
+    expect(deriveEvalSessionTitle(detail)).toBe("Repeated Eval");
+  });
+
+  it("falls back to a short session id when no child run name exists", () => {
+    const detail = {
+      eval_session: { id: "session-12345678" },
+      runs: [],
+    } as EvalSessionDetail;
+
+    expect(deriveEvalSessionTitle(detail)).toBe("Eval Session session-");
+  });
+
+  it("derives comparison mode from runs before aggregate fallback", () => {
+    expect(
+      deriveEvalSessionMode(
+        [{ execution_mode: "comparison" }],
+        { participants: [{ lane_index: 0, label: "A" }] },
+      ),
+    ).toBe("comparison");
+  });
+
+  it("falls back to aggregate participant count when run mode is absent", () => {
+    expect(
+      deriveEvalSessionMode([], {
+        participants: [
+          { lane_index: 0, label: "A" },
+          { lane_index: 1, label: "B" },
+        ],
+      }),
+    ).toBe("comparison");
+  });
+
+  it("formats probability-like values as percentages", () => {
+    expect(formatEvalSessionValue(0.845)).toBe("84.5%");
+  });
+
+  it("formats larger scalar values as fixed decimals", () => {
+    expect(formatEvalSessionValue(3.5)).toBe("3.50");
+  });
+
+  it("returns the metric aggregate for the effective k", () => {
+    const series: EvalSessionPassMetricSeries = {
+      effective_k: 5,
+      by_k: {
+        "1": {
+          n: 5,
+          mean: 0.4,
+          median: 0.4,
+          std_dev: 0.1,
+          min: 0.3,
+          max: 0.5,
+          high_variance: false,
+          high_variance_rule: "rule",
+        },
+        "5": {
+          n: 5,
+          mean: 0.9,
+          median: 0.9,
+          std_dev: 0.05,
+          min: 0.8,
+          max: 1,
+          high_variance: false,
+          high_variance_rule: "rule",
+        },
+      },
+    };
+
+    expect(passMetricAggregateForEffectiveK(series)?.mean).toBe(0.9);
+  });
+
+  it("sorts aggregate dimensions alphabetically", () => {
+    const entries = sortedAggregateDimensions({
+      schema_version: 1,
+      child_run_count: 2,
+      scored_child_count: 2,
+      dimensions: {
+        reliability: {
+          n: 2,
+          mean: 0.8,
+          median: 0.8,
+          std_dev: 0.1,
+          min: 0.7,
+          max: 0.9,
+          high_variance: false,
+          high_variance_rule: "rule",
+        },
+        correctness: {
+          n: 2,
+          mean: 0.9,
+          median: 0.9,
+          std_dev: 0.05,
+          min: 0.85,
+          max: 0.95,
+          high_variance: false,
+          high_variance_rule: "rule",
+        },
+      },
+    });
+
+    expect(entries.map(([key]) => key)).toEqual(["correctness", "reliability"]);
+  });
+});

--- a/web/src/lib/api/__tests__/deployments.test.ts
+++ b/web/src/lib/api/__tests__/deployments.test.ts
@@ -26,6 +26,7 @@ describe("Deployment API calls", () => {
           id: "dep-1",
           organization_id: "org-1",
           workspace_id: "ws-1",
+          current_build_version_id: "ver-1",
           name: "prod-deploy",
           status: "active",
           created_at: "2026-04-12T00:00:00Z",

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -272,6 +272,7 @@ export interface AgentDeployment {
   id: string;
   organization_id: string;
   workspace_id: string;
+  current_build_version_id: string;
   name: string;
   status: string; // "active" | "paused" | "archived"
   latest_snapshot_id?: string;
@@ -471,6 +472,248 @@ export interface CreateRunResponse {
     self: string;
     agents: string;
   };
+}
+
+// --- Eval Sessions ---
+
+export type EvalSessionStatus =
+  | "queued"
+  | "running"
+  | "aggregating"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export type EvalSessionAggregationMethod = "median" | "mean" | "weighted_mean";
+
+export interface EvalSessionAggregationConfig {
+  schema_version?: number;
+  method: EvalSessionAggregationMethod;
+  report_variance: boolean;
+  confidence_interval: number;
+  reliability_weight?: number;
+}
+
+export interface EvalSessionSuccessThresholdConfig {
+  schema_version?: number;
+  min_pass_rate: number;
+  require_all_dimensions?: string[];
+}
+
+export interface EvalSessionTaskProperties {
+  has_side_effects?: boolean;
+  autonomy?: "human" | "semi" | "full";
+  step_count?: number;
+  output_type?: "artifact" | "action";
+}
+
+export interface EvalSessionRoutingTaskSnapshot {
+  schema_version?: number;
+  routing: Record<string, unknown>;
+  task: Record<string, unknown> & {
+    task_properties?: EvalSessionTaskProperties;
+  };
+}
+
+export interface EvalSessionResponse {
+  id: string;
+  status: EvalSessionStatus;
+  repetitions: number;
+  aggregation_config: EvalSessionAggregationConfig;
+  success_threshold_config: EvalSessionSuccessThresholdConfig | Record<string, never>;
+  routing_task_snapshot: EvalSessionRoutingTaskSnapshot;
+  schema_version: number;
+  created_at: string;
+  started_at?: string;
+  finished_at?: string;
+  updated_at: string;
+}
+
+export interface EvalSessionParticipantInput {
+  agent_build_version_id: string;
+  label: string;
+}
+
+export interface CreateEvalSessionConfig {
+  repetitions: number;
+  aggregation: EvalSessionAggregationConfig;
+  success_threshold?: EvalSessionSuccessThresholdConfig | null;
+  routing_task_snapshot: EvalSessionRoutingTaskSnapshot;
+  schema_version: number;
+}
+
+export interface CreateEvalSessionRequest {
+  workspace_id: string;
+  challenge_pack_version_id: string;
+  challenge_input_set_id?: string;
+  participants: EvalSessionParticipantInput[];
+  execution_mode?: "single_agent" | "comparison";
+  name?: string;
+  eval_session: CreateEvalSessionConfig;
+}
+
+export interface CreateEvalSessionResponse {
+  eval_session: EvalSessionResponse;
+  run_ids: string[];
+}
+
+export interface EvalSessionValidationDetail {
+  field: string;
+  code: string;
+  message: string;
+}
+
+export interface EvalSessionValidationEnvelope {
+  errors: EvalSessionValidationDetail[];
+}
+
+export interface EvalSessionRunCounts {
+  total: number;
+  draft: number;
+  queued: number;
+  provisioning: number;
+  running: number;
+  scoring: number;
+  completed: number;
+  failed: number;
+  cancelled: number;
+}
+
+export interface EvalSessionRunSummary {
+  run_counts: EvalSessionRunCounts;
+}
+
+export interface EvalSessionChildRun {
+  id: string;
+  workspace_id: string;
+  challenge_pack_version_id: string;
+  challenge_input_set_id?: string;
+  eval_session_id?: string;
+  official_pack_mode: OfficialPackMode;
+  name: string;
+  status: RunStatus;
+  execution_mode: string;
+  queued_at?: string;
+  started_at?: string;
+  finished_at?: string;
+  cancelled_at?: string;
+  failed_at?: string;
+  created_at: string;
+  updated_at: string;
+  links: {
+    self: string;
+    agents: string;
+  };
+}
+
+export interface EvalSessionAggregateInterval {
+  estimator: string;
+  lower: number;
+  upper: number;
+}
+
+export interface EvalSessionMetricAggregate {
+  n: number;
+  mean: number;
+  median: number;
+  std_dev: number;
+  min: number;
+  max: number;
+  interval?: EvalSessionAggregateInterval;
+  high_variance: boolean;
+  high_variance_rule: string;
+}
+
+export interface EvalSessionPassMetricSeries {
+  effective_k: number;
+  by_k: Record<string, EvalSessionMetricAggregate>;
+}
+
+export interface EvalSessionMetricRouting {
+  source: string;
+  reliability_weight: number;
+  reasoning: string;
+  primary_metric: "pass_at_k" | "pass_pow_k";
+  effective_k: number;
+  composite_agent_score: number;
+  composite_interval?: EvalSessionAggregateInterval;
+}
+
+export interface EvalSessionTaskSuccess {
+  task_key: string;
+  challenge_identity_id?: string;
+  challenge_key?: string;
+  title?: string;
+  observed_trials: number;
+  successful_trials: number;
+  success_rate: number;
+  source: string;
+  pass_at_k?: Record<string, number>;
+  pass_pow_k?: Record<string, number>;
+}
+
+export interface EvalSessionParticipantAggregate {
+  lane_index: number;
+  label: string;
+  overall?: EvalSessionMetricAggregate;
+  dimensions?: Record<string, EvalSessionMetricAggregate>;
+  task_success?: EvalSessionTaskSuccess[];
+  pass_at_k?: EvalSessionPassMetricSeries;
+  pass_pow_k?: EvalSessionPassMetricSeries;
+  metric_routing?: EvalSessionMetricRouting;
+}
+
+export interface EvalSessionRepeatedComparison {
+  status: string;
+  reason_code?: string;
+  compared_metric?: string;
+  effective_k: number;
+  winner_lane_index?: number;
+  winner_label?: string;
+  leader_lane_index?: number;
+  leader_label?: string;
+  leader_value?: number;
+  leader_interval?: EvalSessionAggregateInterval;
+  runner_up_lane_index?: number;
+  runner_up_label?: string;
+  runner_up_value?: number;
+  runner_up_interval?: EvalSessionAggregateInterval;
+}
+
+export interface EvalSessionAggregateResult {
+  schema_version: number;
+  child_run_count: number;
+  scored_child_count: number;
+  top_level_source?: string;
+  overall?: EvalSessionMetricAggregate;
+  dimensions?: Record<string, EvalSessionMetricAggregate>;
+  task_success?: EvalSessionTaskSuccess[];
+  pass_at_k?: EvalSessionPassMetricSeries;
+  pass_pow_k?: EvalSessionPassMetricSeries;
+  metric_routing?: EvalSessionMetricRouting;
+  participants?: EvalSessionParticipantAggregate[];
+  comparison?: EvalSessionRepeatedComparison;
+}
+
+export interface EvalSessionListItem {
+  eval_session: EvalSessionResponse;
+  summary: EvalSessionRunSummary;
+  aggregate_result: EvalSessionAggregateResult | null;
+  evidence_warnings: string[];
+}
+
+export interface ListEvalSessionsResponse {
+  items: EvalSessionListItem[];
+  limit: number;
+  offset: number;
+}
+
+export interface EvalSessionDetail {
+  eval_session: EvalSessionResponse;
+  runs: EvalSessionChildRun[];
+  summary: EvalSessionRunSummary;
+  aggregate_result: EvalSessionAggregateResult | null;
+  evidence_warnings: string[];
 }
 
 // --- Run Agents ---

--- a/web/src/lib/eval-sessions.ts
+++ b/web/src/lib/eval-sessions.ts
@@ -1,0 +1,79 @@
+import type {
+  EvalSessionAggregateResult,
+  EvalSessionDetail,
+  EvalSessionMetricAggregate,
+  EvalSessionPassMetricSeries,
+} from "@/lib/api/types";
+
+function stripRepeatedRunSuffix(value: string): string {
+  return value.replace(/\s*\[\d+\/\d+\]\s*$/, "").trim();
+}
+
+export function shortEvalSessionId(id: string): string {
+  return id.slice(0, 8);
+}
+
+export function deriveEvalSessionTitle(detail: Pick<EvalSessionDetail, "eval_session" | "runs">): string {
+  const firstRunName = detail.runs[0]?.name?.trim();
+  if (firstRunName) {
+    const baseName = stripRepeatedRunSuffix(firstRunName);
+    if (baseName) return baseName;
+  }
+  return `Eval Session ${shortEvalSessionId(detail.eval_session.id)}`;
+}
+
+export function deriveEvalSessionMode(
+  runs: Array<{ execution_mode?: string }> | undefined,
+  aggregateResult?: EvalSessionAggregateResult | null,
+): "single_agent" | "comparison" | null {
+  const runMode = runs?.find((run) => run.execution_mode)?.execution_mode;
+  if (runMode === "single_agent" || runMode === "comparison") {
+    return runMode;
+  }
+  if ((aggregateResult?.participants?.length ?? 0) > 1) {
+    return "comparison";
+  }
+  if ((aggregateResult?.participants?.length ?? 0) === 1) {
+    return "single_agent";
+  }
+  return null;
+}
+
+export function formatEvalSessionMetricName(value: string): string {
+  return value
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+export function formatEvalSessionValue(value?: number | null): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  if (Math.abs(value) <= 1) return `${(value * 100).toFixed(1)}%`;
+  return value.toFixed(2);
+}
+
+export function formatEvalSessionRate(value?: number | null): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+export function formatEvalSessionRange(
+  aggregate?: Pick<EvalSessionMetricAggregate, "interval"> | null,
+): string {
+  if (!aggregate?.interval) return "—";
+  return `${formatEvalSessionValue(aggregate.interval.lower)} - ${formatEvalSessionValue(aggregate.interval.upper)}`;
+}
+
+export function passMetricAggregateForEffectiveK(
+  series?: EvalSessionPassMetricSeries | null,
+): EvalSessionMetricAggregate | null {
+  if (!series) return null;
+  return series.by_k[String(series.effective_k)] ?? null;
+}
+
+export function sortedAggregateDimensions(
+  aggregateResult?: EvalSessionAggregateResult | null,
+): Array<[string, EvalSessionMetricAggregate]> {
+  return Object.entries(aggregateResult?.dimensions ?? {}).sort(([left], [right]) =>
+    left.localeCompare(right),
+  );
+}


### PR DESCRIPTION
## Summary

Completes the remaining user-facing surface for repeated statistical evals in issue #149.

This PR adds a first-class eval-session experience in the web app, threads the missing deployment build-version identity needed by the new create flow, and aligns the API docs with the shipped payload.

Closes #149.

## What Changed

- added a `New Eval Session` flow from the runs area for repeated evals
- added form support for repetitions, aggregation settings, optional success threshold, optional reliability weight override, routing/task properties, and participant selection from active deployments
- added an `Eval Sessions` tab in the runs area with recent-session list polling and aggregate summaries
- added an eval-session detail page with status, config snapshot, warnings, aggregate scorecards, pass@k, pass^k, metric routing guidance, comparison summaries, participant breakdowns, and child-run links
- exposed `current_build_version_id` in the agent-deployment list response so the UI can construct eval-session participants correctly
- updated frontend types, helper coverage, targeted tests, and OpenAPI docs

## Why

The backend workflow, aggregation, and read APIs for repeated eval sessions were already in place, but the product surface for issue #149 was still largely missing. Users could not create, discover, or inspect eval sessions from the web app, which left the issue incomplete from an end-user perspective.

## User Impact

Users can now:

- configure repeated eval sessions from the workspace UI instead of hand-writing API requests
- compare aggregated repeated-run results directly in the product
- inspect pass metrics and routing guidance to understand when pass@k vs pass^k is emphasized
- drill into the underlying child runs using the existing run detail flow

## Validation

- `go test ./internal/api ./internal/repository ./internal/workflow -run 'AgentDeployment|EvalSession'`
- `pnpm vitest run 'src/lib/api/__tests__/deployments.test.ts' 'src/lib/__tests__/eval-sessions.test.ts' 'src/app/(workspace)/workspaces/[workspaceId]/runs/create-eval-session-dialog.test.tsx'`
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint 'src/app/(workspace)/workspaces/[workspaceId]/runs/create-eval-session-dialog.tsx' 'src/app/(workspace)/workspaces/[workspaceId]/runs/eval-session-list.tsx' 'src/app/(workspace)/workspaces/[workspaceId]/runs/page.tsx' 'src/app/(workspace)/workspaces/[workspaceId]/eval-sessions/[evalSessionId]/page.tsx' 'src/app/(workspace)/workspaces/[workspaceId]/eval-sessions/[evalSessionId]/eval-session-detail-client.tsx' 'src/lib/eval-sessions.ts' 'src/lib/api/types.ts'`

## Notes

Manual browser validation against a live workspace was not run in this session; validation relied on targeted tests, typecheck, lint, and the existing production build check run during development of the change.
