### PR TITLE
docs: ROADMAP.md + move enterprise POV to vision/

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,81 @@
+# AgentClash Roadmap
+
+Last updated: 2026-04-21
+
+This file is the source of truth for what AgentClash is building, who it's for, and in what order. It exists to prevent scope drift — every feature, marketing surface, and doc should trace back to a specific tier below.
+
+## Current positioning
+
+**Git-bisect for agent behavior.** Race two agent configs on the same task, see exactly where they diverged — tool call, retrieval, latency, final answer — step by step. Built for engineers at AI startups shipping agents who hit the Promptfoo-gave-me-a-score-I-can't-debug wall.
+
+Not "a governed decision artifact." Not "the benchmark control room." Not yet. Those come later if the engineer wedge earns the right.
+
+## v1 — Engineer Dev Tool (next 12 weeks)
+
+**Audience:** Engineers at AI startups shipping agents. Series A to Series B scale. Bottom-up, self-serve, OSS-first.
+
+**Ship list:**
+
+- [ ] `agentclash race --a v1.yaml --b v2.yaml --task my-task.yaml` CLI subcommand
+- [ ] `run_share_tokens` migration + public read handler for `/r/<id>` URLs with redaction config
+- [ ] Next.js `/r/[id]` route: two-column synchronized-scroll replay, first-divergence highlighted (divergence = first step where tool-call name / normalized args / final-answer text differ)
+- [ ] `task.yaml` schema: Promptfoo-compatible baseline + `agentclash:` extension fields (sandbox, tool policy, expected artifacts) — RFC as PR this week
+- [ ] Landing page copy: lead with "git-bisect for agent behavior" (or equivalent), demote governance/enterprise framing
+- [ ] 1 pre-baked public demo (e.g., Sonnet 4.7 vs Opus 4.7 on the knowledge-agent task) on the landing page
+- [ ] Homebrew cask + curl installer verified end-to-end before launch
+
+**Success criteria (all three, 12 weeks, across 3 launch waves):**
+
+- 15+ engineers at 10+ different companies (not the founder) have run `agentclash race` on their own agent configs
+- 5+ screen-share observation sessions with real users on real agents
+- 3+ unsolicited public mentions (HN/Twitter/Discord) from people the founder doesn't know
+
+**Failure signals (any = stop + re-diagnose):**
+
+- Wave 1 usage drops to zero within 2 weeks with no inbound questions
+- Founder cannot find 5 engineers willing to screen-share across all three waves
+- Observation sessions reveal the diff replay doesn't actually explain real-codebase failures
+- Acid test failure: the founder's own prod failure (the one that seeded this product) would not have been caught by Approach A alone → vNext Prod Trace Ingest becomes v1
+
+## vNext — Workflow Depth (months 4–9, if v1 earns it)
+
+Only unlocked by v1 success signals. Order within vNext is pulled by screen-share observation feedback, not pushed by founder intuition.
+
+- OpenTelemetry GenAI trace ingest → diff prod run vs known-good offline run (the "origin story second half" — failures offline eval misses)
+- CI/GitHub Actions integration: run your challenge pack on every PR, block merges on regression
+- Team workspace concept: multiple engineers sharing task libraries + eval histories
+- Judge library: common LLM-judge rubrics for correctness, faithfulness, tool-use quality
+- Replay annotations + shareable post-mortems
+
+## v3 — Enterprise / Governance (year 2+, only if pulled)
+
+Vision doc: `docs/vision/enterprise-future.md` (the John Menon POV).
+
+This tier exists as a direction, not a roadmap driver. It does not get implementation attention until there are ≥20 paying engineer-tier customers, ≥3 unsolicited inbound requests from enterprise buyers, and a clear ACV/CAC model that funds the multi-quarter buildout.
+
+Features that belong here (and explicitly do NOT belong in v1/vNext):
+
+- Evidence tier labeling (black_box / structured_trace / native_full_replay)
+- Release gate policies (correctness regression thresholds, cost/latency budgets)
+- Exportable evidence bundles for security/finance/procurement
+- Vendor comparison governance (native + hosted agent side-by-side with evidence-quality scoring)
+- SOC 2, private deployment, SSO, audit logs
+- Challenge pack versioning + immutable environment snapshots for audit
+
+If you find yourself tempted to build any of the above while in v1 or vNext: stop. Move the feature request to `docs/vision/enterprise-future.md`, close the tab, and ship the engineer thing.
+
+## What NOT to ship — explicit do-not-build list
+
+Things the founder instinct will want to build that are wrong for v1:
+
+- Authentication/team flows (v1 uses share tokens, nothing else)
+- Billing/paid tiers (no paid tier until ≥10 engineers are using it weekly and ask how to pay)
+- Evidence tiering, governance, release gates (v3 — see vision doc)
+- Multi-agent orchestration, agent frameworks, agent marketplaces (scope creep)
+- Polished admin dashboards (everything lives on the public `/r/<id>` URL for v1)
+- Cross-run aggregation UI beyond what already ships (pass@k UI is enough for v1)
+- Writing more positioning docs. When tempted, write a competitor UX teardown or a `task.yaml` schema refinement PR instead.
+
+## Design decision log
+
+- **2026-04-21** — Moved `docs/product/enterprise-user-pov.md` to `docs/vision/enterprise-future.md`. Rationale: founder had written enterprise positioning without any enterprise conversations. v1 refocused on bottom-up engineer wedge. Source: `/office-hours` session design doc at `~/.gstack/projects/agentclash-agentclash/atharva-feat-323-regression-suites-frontend-design-20260421-140445.md`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,7 +17,8 @@ Not "a governed decision artifact." Not "the benchmark control room." Not yet. T
 **Ship list:**
 
 - [ ] `agentclash race --a v1.yaml --b v2.yaml --task my-task.yaml` CLI subcommand
-- [ ] `run_share_tokens` migration + public read handler for `/r/<id>` URLs with redaction config
+- [ ] `agentclash login` CLI flow wiring into existing auth (producer is authenticated — every early user is an email address we can ask for a screen-share). Reuse existing auth, do not rewrite.
+- [ ] `run_share_tokens` migration + anonymous-read handler for `/r/<id>` URLs. Default-public on race completion; `--private` CLI flag suppresses token mint. No redaction UI in v1.
 - [ ] Next.js `/r/[id]` route: two-column synchronized-scroll replay, first-divergence highlighted (divergence = first step where tool-call name / normalized args / final-answer text differ)
 - [ ] `task.yaml` schema: Promptfoo-compatible baseline + `agentclash:` extension fields (sandbox, tool policy, expected artifacts) — RFC as PR this week
 - [ ] Landing page copy: lead with "git-bisect for agent behavior" (or equivalent), demote governance/enterprise framing
@@ -68,7 +69,7 @@ If you find yourself tempted to build any of the above while in v1 or vNext: sto
 
 Things the founder instinct will want to build that are wrong for v1:
 
-- Authentication/team flows (v1 uses share tokens, nothing else)
+- Team workspaces, org membership, role-based access (v1 producer flow uses the existing single-user auth; consumer flow is anonymous via share token)
 - Billing/paid tiers (no paid tier until ≥10 engineers are using it weekly and ask how to pay)
 - Evidence tiering, governance, release gates (v3 — see vision doc)
 - Multi-agent orchestration, agent frameworks, agent marketplaces (scope creep)
@@ -79,3 +80,4 @@ Things the founder instinct will want to build that are wrong for v1:
 ## Design decision log
 
 - **2026-04-21** — Moved `docs/product/enterprise-user-pov.md` to `docs/vision/enterprise-future.md`. Rationale: founder had written enterprise positioning without any enterprise conversations. v1 refocused on bottom-up engineer wedge. Source: `/office-hours` session design doc at `~/.gstack/projects/agentclash-agentclash/atharva-feat-323-regression-suites-frontend-design-20260421-140445.md`.
+- **2026-04-21 (correction)** — Producer flow (CLI user running `agentclash race`) is authenticated via existing auth. Consumer flow (public `/r/<id>` URL) is anonymous via share token. Initial design proposed skipping auth entirely; founder pushed back — login is already built, and every early CLI user becomes an email address we can ask for a screen-share, which is more valuable than shaving 15 seconds off first-run friction. Precedent: `promptfoo share` works the same way (login to produce, public to view).

--- a/docs/vision/enterprise-future.md
+++ b/docs/vision/enterprise-future.md
@@ -1,10 +1,10 @@
-# Enterprise User POV
+# Enterprise User POV — Future Vision
 
-Status: narrative product and positioning doc
+Status: **v3 vision doc — not current roadmap.** Moved from `docs/product/` on 2026-04-21 as part of the v1 refocus on engineer dev-tool positioning. See `docs/ROADMAP.md` for the v1/vNext/v3 split and what drives roadmap today vs later.
 
 Last updated: 2026-03-15
 
-Purpose: show how the best version of AgentClash should feel to a large-enterprise buyer, and why it solves a decision problem that observability-only or eval-only products leave fragmented.
+Purpose: show how the best version of AgentClash should feel to a large-enterprise buyer, and why it solves a decision problem that observability-only or eval-only products leave fragmented. **This is where AgentClash is aimed in 2–3 years once the bottom-up engineer wedge has earned pull upmarket. It is not a brief for what to build next quarter.**
 
 Note on competitor references: the positioning links in this doc were checked on 2026-03-15 and reflect how those products currently describe themselves publicly.
 
@@ -136,6 +136,8 @@ flowchart LR
 
     A --> B --> C --> D --> E --> F --> G --> H
 ```
+
+
 
 ### 4. John watches the run live
 
@@ -279,6 +281,8 @@ sequenceDiagram
     ReleaseGate->>John: Ship or block with replayable evidence
 ```
 
+
+
 ## What John Can Do Here That Point Tools Do Not Solve End To End
 
 - John can compare native and hosted agents inside one benchmark contract instead of comparing disconnected traces and eval jobs.
@@ -308,7 +312,8 @@ That is the level to build for.
 
 Current public positioning references checked on 2026-03-15:
 
-- Arize Phoenix: <https://phoenix.arize.com/>
-- Braintrust evals overview: <https://www.braintrust.dev/docs/guides/evals/overview>
-- LangSmith: <https://www.langchain.com/langsmith>
-- OpenTelemetry GenAI semantic conventions: <https://opentelemetry.io/docs/specs/semconv/gen-ai/>
+- Arize Phoenix: [https://phoenix.arize.com/](https://phoenix.arize.com/)
+- Braintrust evals overview: [https://www.braintrust.dev/docs/guides/evals/overview](https://www.braintrust.dev/docs/guides/evals/overview)
+- LangSmith: [https://www.langchain.com/langsmith](https://www.langchain.com/langsmith)
+- OpenTelemetry GenAI semantic conventions: [https://opentelemetry.io/docs/specs/semconv/gen-ai/](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
+


### PR DESCRIPTION
## Summary

- Add `docs/ROADMAP.md` with explicit v1 / vNext / v3 tier split and a do-not-build list
- Move `docs/product/enterprise-user-pov.md` → `docs/vision/enterprise-future.md` (preserving local edits)
- Update the moved file's header so readers know it's a v3 vision doc, not a current roadmap driver

## Why

Output of an `/office-hours` session on 2026-04-21. Short version: the enterprise "John Menon" positioning was written without any enterprise conversations, while the actual validated pain (Promptfoo-hides-why-the-score-moved, agent blew up in prod) is an engineer problem at AI startups. v1 refocuses AgentClash as a bottom-up engineer dev tool — **"git-bisect for agent behavior"** — for the next 12 weeks. Enterprise positioning stays in the repo as a direction, not as a roadmap driver.

## What's in ROADMAP.md

- **v1 (12 weeks):** `agentclash race` CLI, share-token public replay URLs, two-column synchronized-scroll diff replay, Promptfoo-compatible `task.yaml` schema, landing page copy swap, 1 pre-baked demo
- **vNext (months 4–9, if v1 earns it):** OTel GenAI trace ingest, CI integration, team workspaces, judge library
- **v3 (year 2+, only if pulled):** evidence tiering, release gates, evidence bundles, SOC 2 — the John Menon product
- **Success + failure signals** per tier
- **Explicit do-not-build list** to resist scope drift

Full session design doc (not in repo, local to my machine): `~/.gstack/projects/agentclash-agentclash/atharva-feat-323-regression-suites-frontend-design-20260421-140445.md`

## Test plan

- [ ] ROADMAP.md renders cleanly in GitHub's markdown viewer
- [ ] Links between ROADMAP.md and docs/vision/enterprise-future.md resolve
- [ ] No stale references to `docs/product/enterprise-user-pov.md` elsewhere in the repo (grep pre-merge)
- [ ] Next design/PM-facing doc that reaches for the John Menon framing gets pointed at docs/vision/ and ROADMAP.md's v3 tier

## Not in this PR (explicitly deferred)

- Landing page copy rewrite (Assignment step 3 — separate PR on web/)
- `task.yaml` schema RFC (Assignment step 2 — separate PR/issue)
- The actual Weekend Wedge ship (Approach A — separate branch once acid test is answered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)