### PR TITLE
fix(ci): clarify npm trusted publishing failures

### DIFF
--- a/scripts/publish-npm/publish-one.sh
+++ b/scripts/publish-npm/publish-one.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Publish one or more npm package directories, tolerating E409 on rerun.
+# Publish one or more npm package directories, tolerating rerun races and
+# surfacing actionable Trusted Publishing/bootstrap guidance on failure.
 #
 # Usage:  publish-one.sh <label> <pkg_dir>...
 # Label is only used for log grouping ("platform" | "root").
@@ -18,7 +19,9 @@
 #     3. On failure → probe the registry (with retries, because the
 #        positive read may still be propagating). If it reports the
 #        expected version, treat the whole step as success.
-#     4. Otherwise → surface the original error.
+#     4. Otherwise → surface the original error, plus a clearer hint when
+#        the failure looks like missing npm bootstrap or Trusted Publishing
+#        setup for the package/workflow pair.
 
 set -euo pipefail
 
@@ -29,6 +32,9 @@ fi
 
 label="$1"
 shift
+
+conflict_pattern='E409|403 Forbidden.*cannot publish over|cannot publish over the previously'
+trusted_publishing_pattern='E404|404 Not Found|E403|403 Forbidden|do not have permission to access|you do not have permission'
 
 # Retry loop for the post-failure visibility probe.
 check_published() {
@@ -46,13 +52,40 @@ check_published() {
   return 1
 }
 
+package_exists() {
+  local name="$1"
+  local got
+  if got="$(npm view "${name}" version --silent 2>/dev/null)" && [ -n "${got}" ]; then
+    return 0
+  fi
+  return 1
+}
+
+explain_trusted_publishing_failure() {
+  local name="$1"
+  local version="$2"
+
+  if ! package_exists "${name}"; then
+    cat >&2 <<EOF
+${name} does not appear to exist on npm yet.
+npm Trusted Publishing cannot create first-time packages. Complete the one-time bootstrap in docs/cli-distribution.md ("npm setup (one-time)"), then rerun this release.
+EOF
+    return
+  fi
+
+  cat >&2 <<EOF
+${name} exists on npm, but ${name}@${version} never became visible after the failed publish attempt.
+Check Trusted Publishing for ${name} in the npm UI and confirm it is configured for repo agentclash/agentclash and workflow .github/workflows/release-cli.yml before rerunning the release.
+EOF
+}
+
 for pkg in "$@"; do
   name="$(jq -r .name "${pkg}/package.json")"
   version="$(jq -r .version "${pkg}/package.json")"
   echo "::group::npm publish (${label}) ${name}@${version}"
 
   # Capture both the exit code and stderr so we can discriminate the
-  # E409-already-published case from any other failure.
+  # rerun-conflict case from bootstrap / Trusted Publishing failures.
   tmp_stderr="$(mktemp)"
   set +e
   npm publish "${pkg}" --access=public --provenance 2>"${tmp_stderr}"
@@ -67,15 +100,31 @@ for pkg in "$@"; do
     continue
   fi
 
-  if grep -qE 'E409|403 Forbidden.*cannot publish over|cannot publish over the previously' "${tmp_stderr}"; then
-    echo "publish returned conflict for ${name}@${version}; verifying registry state..."
-    rm -f "${tmp_stderr}"
+  if grep -qE "${conflict_pattern}" "${tmp_stderr}"; then
+    echo "publish returned a registry-side error for ${name}@${version}; verifying registry state..."
     if check_published "${name}" "${version}"; then
+      rm -f "${tmp_stderr}"
       echo "${name}@${version} already on registry at the expected version; treating as success"
       echo "::endgroup::"
       continue
     fi
+
+    rm -f "${tmp_stderr}"
     echo "registry still does not report ${name}@${version} after ${NPM_VERIFY_ATTEMPTS:-12} attempts" >&2
+    exit 1
+  fi
+
+  if grep -qE "${trusted_publishing_pattern}" "${tmp_stderr}"; then
+    echo "publish returned a registry-side error for ${name}@${version}; verifying registry state..."
+    if check_published "${name}" "${version}"; then
+      rm -f "${tmp_stderr}"
+      echo "${name}@${version} already on registry at the expected version; treating as success"
+      echo "::endgroup::"
+      continue
+    fi
+
+    rm -f "${tmp_stderr}"
+    explain_trusted_publishing_failure "${name}" "${version}"
     exit 1
   fi
 

--- a/testing/codex-fix-main-release-cli-bootstrap-guard.md
+++ b/testing/codex-fix-main-release-cli-bootstrap-guard.md
@@ -1,0 +1,29 @@
+# codex/fix-main-release-cli-bootstrap-guard — Test Contract
+
+## Functional Behavior
+- `scripts/publish-npm/publish-one.sh` must keep treating reruns of an already-published version as success instead of failing the whole workflow.
+- If `npm publish` returns a 404- or permission-style error for a package, the script must probe the registry for the target `name@version` before deciding the publish truly failed.
+- If the target version is still missing and the package itself does not yet exist on npm, the script must fail with an explicit message that Trusted Publishing cannot create first-time packages and that maintainers need the one-time bootstrap in `docs/cli-distribution.md`.
+- If the package exists but publish still fails with a 404- or permission-style error, the script must fail with an explicit message pointing maintainers to Trusted Publishing configuration for `.github/workflows/release-cli.yml`.
+
+## Unit Tests
+- N/A — shell script change with focused command-level verification.
+
+## Integration / Functional Tests
+- `bash -n scripts/publish-npm/publish-one.sh`
+- Run the helper against a mocked `npm`/`jq` environment where publish succeeds.
+- Run the helper against a mocked environment where `npm publish` returns a conflict but the version is visible afterward; expect success.
+- Run the helper against a mocked environment where `npm publish` returns a 404 and the package is missing from npm; expect a targeted bootstrap error.
+- Run the helper against a mocked environment where `npm publish` returns a 404, the package exists, but the target version never appears; expect a targeted Trusted Publishing configuration error.
+
+## Smoke Tests
+- Confirm the script still prints grouped publish logs and exits non-zero for unrecoverable publish failures.
+- Confirm the script does not regress the existing post-failure visibility retry loop.
+
+## E2E Tests
+- N/A — no live npm publish should be triggered from local verification.
+
+## Manual / cURL Tests
+- `gh run view 24720436422 --log-failed`
+- `npm view @agentclash/cli-darwin-arm64 version --silent`
+- `npm view @agentclash/cli-darwin-arm64@0.3.0 version --silent`


### PR DESCRIPTION
## Summary
- keep rerun-safe registry verification for already-published npm releases
- probe registry state after 404/403 publish failures before treating the release as failed
- print actionable guidance for missing npm bootstrap vs misconfigured Trusted Publishing

## Verification
- bash -n scripts/publish-npm/publish-one.sh
- mocked success/conflict/E404/E403 publish scenarios against scripts/publish-npm/publish-one.sh