### PR TITLE
feat(web): live arena view for active runs

### DIFF
--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { createApiClient } from "@/lib/api/client";
-import { useRunEvents } from "@/hooks/use-run-events";
+import { useRunEvents, type RunEvent } from "@/hooks/use-run-events";
+import { useAgentArena, EMPTY_LANE } from "@/hooks/use-agent-arena";
 import type {
   Run,
   RunStatus,
@@ -27,17 +28,18 @@ import Link from "next/link";
 import {
   Trophy,
   Clock,
-  Play,
   CheckCircle2,
   XCircle,
   Loader2,
   AlertTriangle,
   AlertOctagon,
+  Radio,
 } from "lucide-react";
 import { ScorecardSummaryCard } from "./scorecard-summary-card";
 import { CompareRunPicker } from "./compare-run-picker";
 import { RunRankingInsightsCard } from "./run-ranking-insights-card";
 import { UploadArtifactDialog } from "@/components/artifacts/upload-artifact-dialog";
+import { LiveAgentLane } from "@/components/arena/live-agent-lane";
 
 // --- Status variant maps ---
 
@@ -53,18 +55,6 @@ const runStatusVariant: Record<
   completed: "default",
   failed: "destructive",
   cancelled: "secondary",
-};
-
-const agentStatusVariant: Record<
-  RunAgentStatus,
-  "default" | "secondary" | "outline" | "destructive"
-> = {
-  queued: "secondary",
-  ready: "secondary",
-  executing: "outline",
-  evaluating: "outline",
-  completed: "default",
-  failed: "destructive",
 };
 
 const ACTIVE_RUN_STATUSES: RunStatus[] = [
@@ -198,19 +188,26 @@ export function RunDetailClient({
     };
   }, [isActive, getAccessToken]);
 
+  // Live per-lane arena projection from the SSE event stream.
+  const { lanes: arenaLanes, handleEvent: handleArenaEvent } = useAgentArena();
+
   // Debounced refetch: collapse rapid SSE events into a single fetch.
   const fetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const debouncedFetchAll = useCallback(() => {
-    if (fetchTimerRef.current) clearTimeout(fetchTimerRef.current);
-    fetchTimerRef.current = setTimeout(fetchAll, 300);
-  }, [fetchAll]);
+  const handleSSEEvent = useCallback(
+    (event: RunEvent) => {
+      handleArenaEvent(event);
+      if (fetchTimerRef.current) clearTimeout(fetchTimerRef.current);
+      fetchTimerRef.current = setTimeout(fetchAll, 300);
+    },
+    [fetchAll, handleArenaEvent],
+  );
 
   // Live event streaming via SSE (graceful degradation: falls back to polling).
   const { connected: sseConnected } = useRunEvents({
     runId: run.id,
     token: sseToken,
     enabled: isActive,
-    onEvent: debouncedFetchAll,
+    onEvent: handleSSEEvent,
   });
 
   // Auto-refresh: 30s safety-net when SSE is connected, 5s polling otherwise.
@@ -313,6 +310,15 @@ export function RunDetailClient({
             )}
             {run.status}
           </Badge>
+          {isActive && sseConnected && (
+            <span
+              className="inline-flex items-center gap-1 rounded-md border border-primary/30 bg-primary/10 px-1.5 h-6 text-[10px] font-medium uppercase tracking-wider text-primary"
+              title="Streaming live events"
+            >
+              <Radio className="size-3 animate-pulse" />
+              Live
+            </span>
+          )}
           <Badge variant="outline">
             {run.execution_mode === "comparison"
               ? "Comparison"
@@ -382,105 +388,28 @@ export function RunDetailClient({
           }`}
         >
           {sortedAgents.map((agent) => {
-            const isFailed = agent.status === "failed";
-            const isRunning = ACTIVE_AGENT_STATUSES.includes(agent.status);
             const isWinner =
               ranking?.ranking?.winner?.run_agent_id === agent.id;
+            const laneState = arenaLanes[agent.id] ?? EMPTY_LANE;
+            const isTerminal =
+              agent.status === "completed" || agent.status === "failed";
+            const footer = isTerminal ? (
+              <ScorecardSummaryCard
+                scorecard={scorecards[agent.id] ?? null}
+                loading={!(agent.id in scorecards)}
+              />
+            ) : null;
 
             return (
-              <div
+              <LiveAgentLane
                 key={agent.id}
-                className={`rounded-lg border p-4 ${
-                  isWinner
-                    ? "border-emerald-500/40 bg-emerald-500/5"
-                    : isFailed
-                      ? "border-destructive/30 bg-destructive/5"
-                      : "border-border"
-                }`}
-              >
-                {/* Card header */}
-                <div className="flex items-center justify-between mb-2">
-                  <div className="flex items-center gap-2">
-                    {isWinner && (
-                      <Trophy className="size-4 text-emerald-400" />
-                    )}
-                    <span className="font-medium text-sm">{agent.label}</span>
-                    <span className="text-xs text-muted-foreground/50">
-                      #{agent.lane_index}
-                    </span>
-                  </div>
-                  <Badge
-                    variant={agentStatusVariant[agent.status] ?? "outline"}
-                  >
-                    {isRunning && (
-                      <Loader2
-                        data-icon="inline-start"
-                        className="size-3 animate-spin"
-                      />
-                    )}
-                    {agent.status}
-                  </Badge>
-                </div>
-
-                {/* Timing */}
-                <div className="flex gap-4 text-xs text-muted-foreground mb-2">
-                  {agent.started_at && (
-                    <span>
-                      {agent.finished_at
-                        ? formatDuration(agent.started_at, agent.finished_at)
-                        : `Running ${formatDuration(agent.started_at)}`}
-                    </span>
-                  )}
-                  {!agent.started_at && agent.queued_at && (
-                    <span>Queued</span>
-                  )}
-                </div>
-
-                {/* Failure reason — auto-expanded */}
-                {isFailed && agent.failure_reason && (
-                  <div className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2 text-xs text-destructive mb-2">
-                    <div className="flex items-center gap-1.5 font-medium mb-0.5">
-                      <XCircle className="size-3.5" />
-                      Failed
-                    </div>
-                    <p className="text-destructive/80">
-                      {agent.failure_reason}
-                    </p>
-                  </div>
-                )}
-
-                {/* Scorecard summary (inline) */}
-                {(agent.status === "completed" ||
-                  agent.status === "failed") && (
-                  <ScorecardSummaryCard
-                    scorecard={scorecards[agent.id] ?? null}
-                    loading={!(agent.id in scorecards)}
-                  />
-                )}
-
-                {/* Action links */}
-                <div className="flex gap-2 mt-2">
-                  <Link
-                    href={`/workspaces/${workspaceId}/runs/${run.id}/agents/${agent.id}/replay`}
-                    className="text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"
-                  >
-                    <Play className="size-3" />
-                    Replay
-                  </Link>
-                  <Link
-                    href={`/workspaces/${workspaceId}/runs/${run.id}/agents/${agent.id}/scorecard`}
-                    className="text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"
-                  >
-                    <CheckCircle2 className="size-3" />
-                    Scorecard
-                  </Link>
-                  <UploadArtifactDialog
-                    workspaceId={workspaceId}
-                    runId={run.id}
-                    runAgentId={agent.id}
-                  />
-                </div>
-              </div>
+                agent={agent}
+                lane={laneState}
+                isWinner={isWinner}
+                workspaceId={workspaceId}
+                runId={run.id}
+                footer={footer}
+              />
             );
           })}
         </div>

--- a/web/src/components/arena/live-agent-lane.tsx
+++ b/web/src/components/arena/live-agent-lane.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import Link from "next/link";
+import {
+  Loader2,
+  Trophy,
+  XCircle,
+  CheckCircle2,
+  Play,
+  BrainCircuit,
+  Wrench,
+  Terminal,
+  BarChart3,
+  Activity,
+  Hash,
+  Coins,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { UploadArtifactDialog } from "@/components/artifacts/upload-artifact-dialog";
+import { LiveEventTicker } from "@/components/arena/live-event-ticker";
+import { cn } from "@/lib/utils";
+import type { RunAgent, RunAgentStatus } from "@/lib/api/types";
+import type { ArenaLaneState } from "@/hooks/use-agent-arena";
+import type { ArenaEventKind } from "@/lib/arena/event-formatter";
+
+const AGENT_STATUS_VARIANT: Record<
+  RunAgentStatus,
+  "default" | "secondary" | "outline" | "destructive"
+> = {
+  queued: "secondary",
+  ready: "secondary",
+  executing: "outline",
+  evaluating: "outline",
+  completed: "default",
+  failed: "destructive",
+};
+
+const ACTIVE_STATUSES: RunAgentStatus[] = [
+  "queued",
+  "ready",
+  "executing",
+  "evaluating",
+];
+
+const NOW_DOING_ICON: Record<
+  ArenaEventKind,
+  React.ComponentType<{ className?: string }>
+> = {
+  model: BrainCircuit,
+  tool: Wrench,
+  sandbox: Terminal,
+  file: Terminal,
+  scoring: BarChart3,
+  system: Activity,
+  unknown: Activity,
+};
+
+function formatElapsed(start?: string, end?: string): string {
+  if (!start) return "\u2014";
+  const startMs = new Date(start).getTime();
+  const endMs = end ? new Date(end).getTime() : Date.now();
+  const ms = Math.max(0, endMs - startMs);
+  if (ms < 1000) return "<1s";
+  const secs = Math.floor(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  return `${mins}m ${secs % 60}s`;
+}
+
+function compactNumber(n: number): string {
+  if (n < 1000) return n.toString();
+  if (n < 1_000_000) return (n / 1000).toFixed(1).replace(/\.0$/, "") + "k";
+  return (n / 1_000_000).toFixed(1).replace(/\.0$/, "") + "M";
+}
+
+interface LiveAgentLaneProps {
+  agent: RunAgent;
+  lane: ArenaLaneState;
+  isWinner: boolean;
+  workspaceId: string;
+  runId: string;
+  /** Rendered below the live sections when the agent is terminal (e.g. scorecard). */
+  footer?: React.ReactNode;
+}
+
+export function LiveAgentLane({
+  agent,
+  lane,
+  isWinner,
+  workspaceId,
+  runId,
+  footer,
+}: LiveAgentLaneProps) {
+  const isActive = ACTIVE_STATUSES.includes(agent.status);
+  const isFailed = agent.status === "failed";
+  const isTerminal = !isActive;
+
+  const nowDoingIcon = lane.nowDoing
+    ? NOW_DOING_ICON[lane.nowDoing.kind] ?? Activity
+    : null;
+  const NowIcon = nowDoingIcon;
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border p-4 transition-colors",
+        isWinner
+          ? "border-emerald-500/40 bg-emerald-500/5"
+          : isFailed
+            ? "border-destructive/30 bg-destructive/5"
+            : isActive
+              ? "border-primary/40 bg-primary/5 shadow-sm"
+              : "border-border",
+      )}
+    >
+      {/* === Header === */}
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2 min-w-0">
+          {isWinner && (
+            <Trophy className="size-4 shrink-0 text-emerald-400" />
+          )}
+          <span className="font-medium text-sm truncate">{agent.label}</span>
+          <span className="text-xs text-muted-foreground/50">
+            #{agent.lane_index}
+          </span>
+        </div>
+        <Badge variant={AGENT_STATUS_VARIANT[agent.status] ?? "outline"}>
+          {isActive && (
+            <Loader2
+              data-icon="inline-start"
+              className="size-3 animate-spin"
+            />
+          )}
+          {agent.status}
+        </Badge>
+      </div>
+
+      {/* === Live metrics strip === */}
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground mb-3">
+        {agent.started_at && (
+          <span className="tabular-nums">
+            {formatElapsed(agent.started_at, agent.finished_at)}
+          </span>
+        )}
+        {lane.stepIndex > 0 && (
+          <span className="inline-flex items-center gap-1">
+            <Hash className="size-3" />
+            Step {lane.stepIndex}
+          </span>
+        )}
+        {lane.modelCalls > 0 && (
+          <span className="inline-flex items-center gap-1">
+            <BrainCircuit className="size-3" />
+            {lane.modelCalls}
+          </span>
+        )}
+        {lane.toolCalls > 0 && (
+          <span className="inline-flex items-center gap-1">
+            <Wrench className="size-3" />
+            {lane.toolCalls}
+          </span>
+        )}
+        {lane.totalTokens > 0 && (
+          <span className="inline-flex items-center gap-1">
+            <Coins className="size-3" />
+            {compactNumber(lane.totalTokens)} tok
+          </span>
+        )}
+      </div>
+
+      {/* === Now-doing banner === */}
+      {isActive && (
+        <div
+          className={cn(
+            "mb-3 flex items-center gap-2 rounded-md border px-2.5 py-1.5 text-xs",
+            lane.nowDoing
+              ? "border-primary/30 bg-primary/10 text-foreground"
+              : "border-border bg-muted/30 text-muted-foreground",
+          )}
+        >
+          <span className="relative flex size-2 shrink-0">
+            <span
+              className={cn(
+                "absolute inline-flex size-2 rounded-full opacity-75",
+                lane.nowDoing ? "animate-ping bg-primary" : "bg-muted-foreground/40",
+              )}
+            />
+            <span
+              className={cn(
+                "relative inline-flex size-2 rounded-full",
+                lane.nowDoing ? "bg-primary" : "bg-muted-foreground/60",
+              )}
+            />
+          </span>
+          {NowIcon && <NowIcon className="size-3.5 shrink-0" />}
+          <span className="min-w-0 flex-1 truncate font-medium">
+            {lane.nowDoing?.label ?? "Waiting for next action\u2026"}
+          </span>
+        </div>
+      )}
+
+      {/* === Streaming model output === */}
+      {isActive && lane.streamingOutput && (
+        <div className="mb-3">
+          <div className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground mb-1">
+            Streaming
+          </div>
+          <pre className="max-h-32 overflow-auto rounded-md bg-background border border-border px-2.5 py-1.5 text-xs font-[family-name:var(--font-mono)] whitespace-pre-wrap break-words">
+            {lane.streamingOutput}
+          </pre>
+        </div>
+      )}
+
+      {/* === Live ticker === */}
+      {(isActive || lane.ticker.length > 0) && (
+        <div className="mb-3">
+          <div className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground mb-1">
+            Activity
+          </div>
+          <LiveEventTicker entries={lane.ticker} />
+        </div>
+      )}
+
+      {/* === Failure banner === */}
+      {isFailed && agent.failure_reason && (
+        <div className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2 text-xs text-destructive mb-2">
+          <div className="flex items-center gap-1.5 font-medium mb-0.5">
+            <XCircle className="size-3.5" />
+            Failed
+          </div>
+          <p className="text-destructive/80">{agent.failure_reason}</p>
+        </div>
+      )}
+
+      {/* === Terminal-only footer (scorecard, etc.) === */}
+      {isTerminal && footer}
+
+      {/* === Action links === */}
+      <div className="flex gap-2 mt-2">
+        <Link
+          href={`/workspaces/${workspaceId}/runs/${runId}/agents/${agent.id}/replay`}
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"
+        >
+          <Play className="size-3" />
+          Replay
+        </Link>
+        <Link
+          href={`/workspaces/${workspaceId}/runs/${runId}/agents/${agent.id}/scorecard`}
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"
+        >
+          <CheckCircle2 className="size-3" />
+          Scorecard
+        </Link>
+        <UploadArtifactDialog
+          workspaceId={workspaceId}
+          runId={runId}
+          runAgentId={agent.id}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/arena/live-event-ticker.tsx
+++ b/web/src/components/arena/live-event-ticker.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import {
+  BrainCircuit,
+  Wrench,
+  Terminal,
+  FileCode,
+  BarChart3,
+  Activity,
+  AlertTriangle,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type {
+  ArenaEventKind,
+  TickerEntry,
+} from "@/lib/arena/event-formatter";
+
+const KIND_ICON: Record<
+  ArenaEventKind,
+  React.ComponentType<{ className?: string }>
+> = {
+  model: BrainCircuit,
+  tool: Wrench,
+  sandbox: Terminal,
+  file: FileCode,
+  scoring: BarChart3,
+  system: Activity,
+  unknown: Activity,
+};
+
+function formatClock(iso: string): string {
+  const d = new Date(iso);
+  const h = d.getHours().toString().padStart(2, "0");
+  const m = d.getMinutes().toString().padStart(2, "0");
+  const s = d.getSeconds().toString().padStart(2, "0");
+  return `${h}:${m}:${s}`;
+}
+
+interface LiveEventTickerProps {
+  entries: TickerEntry[];
+  /** How many most-recent entries to render. */
+  limit?: number;
+  /** Scroll to show the newest entry automatically. */
+  autoscroll?: boolean;
+  className?: string;
+}
+
+export function LiveEventTicker({
+  entries,
+  limit = 8,
+  autoscroll = true,
+  className,
+}: LiveEventTickerProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const recent = entries.slice(-limit);
+
+  useEffect(() => {
+    if (!autoscroll) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [autoscroll, recent.length]);
+
+  if (recent.length === 0) {
+    return (
+      <div
+        className={cn(
+          "rounded-md border border-dashed border-border/60 px-3 py-2 text-xs text-muted-foreground/70",
+          className,
+        )}
+      >
+        Waiting for activity&hellip;
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={scrollRef}
+      className={cn(
+        "max-h-40 overflow-y-auto rounded-md border border-border bg-muted/20 font-[family-name:var(--font-mono)] text-xs",
+        className,
+      )}
+    >
+      <ul className="divide-y divide-border/60">
+        {recent.map((entry) => {
+          const Icon = KIND_ICON[entry.kind] ?? Activity;
+          return (
+            <li
+              key={entry.id}
+              className={cn(
+                "flex items-center gap-2 px-2 py-1.5 animate-in fade-in slide-in-from-bottom-1 duration-300",
+                entry.error && "bg-destructive/5",
+              )}
+            >
+              <span className="shrink-0 tabular-nums text-muted-foreground/70">
+                {formatClock(entry.occurredAt)}
+              </span>
+              {entry.error ? (
+                <AlertTriangle className="size-3.5 shrink-0 text-destructive" />
+              ) : (
+                <Icon className="size-3.5 shrink-0 text-muted-foreground" />
+              )}
+              <span
+                className={cn(
+                  "min-w-0 flex-1 truncate",
+                  entry.error
+                    ? "text-destructive"
+                    : "text-foreground",
+                )}
+              >
+                {entry.headline}
+              </span>
+              {entry.detail && (
+                <span className="hidden sm:inline truncate max-w-[40%] text-muted-foreground">
+                  {entry.detail}
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/web/src/hooks/use-agent-arena.ts
+++ b/web/src/hooks/use-agent-arena.ts
@@ -1,0 +1,200 @@
+"use client";
+
+import { useCallback, useReducer } from "react";
+
+import type { RunEvent } from "@/hooks/use-run-events";
+import {
+  deriveNowDoing,
+  summarizeEvent,
+  type NowDoing,
+  type TickerEntry,
+} from "@/lib/arena/event-formatter";
+import type {
+  ModelCallCompletedPayload,
+  ModelOutputDeltaPayload,
+  RunCompletedPayload,
+  ScoringMetricPayload,
+} from "@/lib/arena/payload-types";
+
+/**
+ * Per-agent arena state. Populated incrementally from the SSE event stream
+ * — we never refetch this; it's a live "what is this lane doing right now"
+ * projection over the event log since the browser connected.
+ */
+export interface ArenaLaneState {
+  /** Current long-running action (model call, tool call, command). */
+  nowDoing: NowDoing | null;
+  /** Last seen step index from system.step.started. */
+  stepIndex: number;
+  /** Number of completed model calls since connection. */
+  modelCalls: number;
+  /** Number of completed tool calls since connection. */
+  toolCalls: number;
+  /** Aggregated total tokens from model.call.completed events. */
+  totalTokens: number;
+  /** Text accumulated from model.output.delta since the last model.call.started. */
+  streamingOutput: string;
+  /** Bounded ring buffer of ticker entries, oldest-first. */
+  ticker: TickerEntry[];
+  /** Latest metric outcome, if any. */
+  lastMetric?: {
+    key: string;
+    score?: number;
+    passed?: boolean;
+  };
+  /** Final output text if the run completed. */
+  finalOutput?: string;
+}
+
+const EMPTY_LANE: ArenaLaneState = {
+  nowDoing: null,
+  stepIndex: 0,
+  modelCalls: 0,
+  toolCalls: 0,
+  totalTokens: 0,
+  streamingOutput: "",
+  ticker: [],
+};
+
+const MAX_TICKER_ENTRIES = 40;
+const MAX_STREAMING_CHARS = 800;
+
+type ArenaState = Record<string, ArenaLaneState>;
+
+type ArenaAction =
+  | { type: "event"; event: RunEvent }
+  | { type: "reset" };
+
+function lane(state: ArenaState, agentID: string): ArenaLaneState {
+  return state[agentID] ?? EMPTY_LANE;
+}
+
+function clipOutput(value: string): string {
+  if (value.length <= MAX_STREAMING_CHARS) return value;
+  return "\u2026" + value.slice(value.length - MAX_STREAMING_CHARS + 1);
+}
+
+function applyEvent(
+  state: ArenaState,
+  event: RunEvent,
+): ArenaState {
+  const agentID = event.RunAgentID;
+  if (!agentID) return state;
+
+  const laneState: ArenaLaneState = { ...lane(state, agentID) };
+  const payload = (event.Payload ?? {}) as Record<string, unknown>;
+
+  // 1. Current "now doing" banner.
+  const now = deriveNowDoing(event);
+  if (now === "clear") {
+    // Only clear if the sequence matches (or is newer than) the banner, so a
+    // stale completion doesn't wipe a newly-started action.
+    if (
+      !laneState.nowDoing ||
+      event.SequenceNumber >= laneState.nowDoing.sequence
+    ) {
+      laneState.nowDoing = null;
+    }
+  } else if (now) {
+    laneState.nowDoing = now;
+    if (event.EventType === "model.call.started") {
+      laneState.streamingOutput = "";
+    }
+  }
+
+  // 2. Streaming model output.
+  if (event.EventType === "model.output.delta") {
+    const delta = payload as ModelOutputDeltaPayload;
+    if (delta.stream_kind === "text" && delta.text_delta) {
+      laneState.streamingOutput = clipOutput(
+        laneState.streamingOutput + delta.text_delta,
+      );
+    }
+  }
+
+  // 3. Counters.
+  if (event.EventType === "system.step.started") {
+    const step =
+      (payload.step_index as number | undefined) ??
+      event.Summary?.step_index;
+    if (typeof step === "number") {
+      laneState.stepIndex = Math.max(laneState.stepIndex, step);
+    }
+  }
+  if (event.EventType === "model.call.completed") {
+    const p = payload as ModelCallCompletedPayload;
+    laneState.modelCalls += 1;
+    const tokens = p.usage?.total_tokens;
+    if (typeof tokens === "number") {
+      laneState.totalTokens += tokens;
+    }
+  }
+  if (
+    event.EventType === "tool.call.completed" ||
+    event.EventType === "tool.call.failed"
+  ) {
+    laneState.toolCalls += 1;
+  }
+  if (event.EventType === "scoring.metric.recorded") {
+    const p = payload as ScoringMetricPayload;
+    if (p.metric_key) {
+      laneState.lastMetric = {
+        key: p.metric_key,
+        score: p.score,
+        passed: p.passed,
+      };
+    }
+  }
+  if (event.EventType === "system.run.completed") {
+    const p = payload as RunCompletedPayload;
+    if (p.final_output) laneState.finalOutput = p.final_output;
+  }
+
+  // 4. Ticker. Append meaningful entries, drop duplicates by event ID.
+  const entry = summarizeEvent(event);
+  if (entry && !laneState.ticker.some((e) => e.id === entry.id)) {
+    const next = [...laneState.ticker, entry];
+    if (next.length > MAX_TICKER_ENTRIES) {
+      next.splice(0, next.length - MAX_TICKER_ENTRIES);
+    }
+    laneState.ticker = next;
+  }
+
+  return { ...state, [agentID]: laneState };
+}
+
+function reducer(state: ArenaState, action: ArenaAction): ArenaState {
+  switch (action.type) {
+    case "event":
+      return applyEvent(state, action.event);
+    case "reset":
+      return {};
+  }
+}
+
+export interface UseAgentArenaResult {
+  lanes: ArenaState;
+  handleEvent: (event: RunEvent) => void;
+  reset: () => void;
+}
+
+/**
+ * Reducer-backed projection of the SSE event stream into per-agent arena
+ * state. The returned `handleEvent` is stable, so it's safe to pass as the
+ * `onEvent` callback for `useRunEvents`.
+ */
+export function useAgentArena(): UseAgentArenaResult {
+  const [lanes, dispatch] = useReducer(reducer, {});
+
+  const handleEvent = useCallback((event: RunEvent) => {
+    dispatch({ type: "event", event });
+  }, []);
+
+  const reset = useCallback(() => {
+    dispatch({ type: "reset" });
+  }, []);
+
+  return { lanes, handleEvent, reset };
+}
+
+export { EMPTY_LANE };

--- a/web/src/lib/arena/event-formatter.ts
+++ b/web/src/lib/arena/event-formatter.ts
@@ -1,0 +1,325 @@
+/**
+ * Pure helpers that turn a run event envelope into compact human-readable
+ * signals for the arena live view.
+ *
+ * Two outputs:
+ *   - `summarizeEvent` → a one-line entry for the live ticker (icon + headline).
+ *   - `deriveNowDoing` → a short "what is this agent doing right now" label,
+ *     emitted only for events that represent the start of a long-running
+ *     action (e.g. `model.call.started`, `tool.call.started`).
+ *
+ * These stay pure so they can be unit-tested without React.
+ */
+
+import type { RunEvent } from "@/hooks/use-run-events";
+import type {
+  ModelCallCompletedPayload,
+  ModelCallStartedPayload,
+  RunCompletedPayload,
+  RunFailedPayload,
+  SandboxCommandPayload,
+  SandboxFilePayload,
+  ScoringMetricPayload,
+  ToolCallPayload,
+} from "./payload-types";
+
+export type ArenaEventKind =
+  | "model"
+  | "tool"
+  | "sandbox"
+  | "file"
+  | "scoring"
+  | "system"
+  | "unknown";
+
+export interface TickerEntry {
+  id: string;
+  occurredAt: string;
+  kind: ArenaEventKind;
+  headline: string;
+  detail?: string;
+  /** True when the event terminated in an error. */
+  error?: boolean;
+}
+
+export interface NowDoing {
+  kind: ArenaEventKind;
+  label: string;
+  detail?: string;
+  /** Monotonic sequence number of the event that set this state. */
+  sequence: number;
+  startedAt: string;
+}
+
+function payload<T>(event: RunEvent): T {
+  return (event.Payload as T) ?? ({} as T);
+}
+
+function truncate(value: string | undefined, max = 80): string | undefined {
+  if (!value) return value;
+  const trimmed = value.replace(/\s+/g, " ").trim();
+  if (trimmed.length <= max) return trimmed;
+  return trimmed.slice(0, max - 1) + "\u2026";
+}
+
+function modelLabel(
+  providerKey?: string,
+  modelID?: string,
+): string {
+  if (providerKey && modelID) return `${providerKey}/${modelID}`;
+  return modelID || providerKey || "model";
+}
+
+export function eventKind(event: RunEvent): ArenaEventKind {
+  const t = event.EventType;
+  if (t.startsWith("model.")) return "model";
+  if (t.startsWith("tool.")) return "tool";
+  if (t.startsWith("sandbox.command")) return "sandbox";
+  if (t.startsWith("sandbox.file") || t.startsWith("grader.verification.file"))
+    return "file";
+  if (t.startsWith("grader.verification")) return "sandbox";
+  if (t.startsWith("scoring.")) return "scoring";
+  if (t.startsWith("system.")) return "system";
+  return "unknown";
+}
+
+/**
+ * Returns a compact ticker entry for the given event, or `null` when the
+ * event is too noisy to surface (e.g. individual stream-delta tokens).
+ */
+export function summarizeEvent(event: RunEvent): TickerEntry | null {
+  const kind = eventKind(event);
+  const base = {
+    id: event.EventID,
+    occurredAt: event.OccurredAt,
+    kind,
+  };
+
+  switch (event.EventType) {
+    case "system.run.started":
+      return { ...base, headline: "Run started" };
+
+    case "system.run.completed": {
+      const p = payload<RunCompletedPayload>(event);
+      return {
+        ...base,
+        headline: "Run completed",
+        detail:
+          p.total_tokens != null
+            ? `${p.step_count ?? 0} steps \u00b7 ${p.total_tokens} tokens`
+            : undefined,
+      };
+    }
+
+    case "system.run.failed": {
+      const p = payload<RunFailedPayload>(event);
+      return {
+        ...base,
+        headline: "Run failed",
+        detail: truncate(p.error),
+        error: true,
+      };
+    }
+
+    case "system.output.finalized":
+      return { ...base, headline: "Output finalized" };
+
+    case "system.step.started": {
+      const step =
+        (payload<{ step_index?: number }>(event).step_index ??
+          event.Summary?.step_index) as number | undefined;
+      return {
+        ...base,
+        headline: step != null ? `Step ${step} started` : "Step started",
+      };
+    }
+
+    case "system.step.completed":
+      return null; // noisy; step.started already covers it
+
+    case "model.call.started": {
+      const p = payload<ModelCallStartedPayload>(event);
+      return {
+        ...base,
+        headline: `Calling ${modelLabel(p.provider_key, p.provider_model_id ?? p.model)}`,
+      };
+    }
+
+    case "model.call.completed": {
+      const p = payload<ModelCallCompletedPayload>(event);
+      const tokens = p.usage?.total_tokens;
+      return {
+        ...base,
+        headline: `Model replied${p.finish_reason ? ` (${p.finish_reason})` : ""}`,
+        detail: tokens != null ? `${tokens} tokens` : truncate(p.output_text),
+      };
+    }
+
+    case "model.output.delta":
+      return null; // streamed token fragments are rendered separately
+
+    case "model.tool_calls.proposed":
+      return { ...base, headline: "Model proposed tool calls" };
+
+    case "tool.call.started": {
+      const p = payload<ToolCallPayload>(event);
+      return {
+        ...base,
+        headline: `Tool \u2192 ${p.tool_name ?? "unknown"}`,
+      };
+    }
+
+    case "tool.call.completed":
+    case "tool.call.failed": {
+      const p = payload<ToolCallPayload>(event);
+      const failed = event.EventType === "tool.call.failed" || p.result?.is_error;
+      return {
+        ...base,
+        headline: `${failed ? "Tool failed" : "Tool ok"}: ${p.tool_name ?? "unknown"}`,
+        detail: truncate(p.result?.content),
+        error: Boolean(failed),
+      };
+    }
+
+    case "sandbox.command.started": {
+      const p = payload<SandboxCommandPayload>(event);
+      return {
+        ...base,
+        headline: `$ ${truncate(p.command, 60) ?? "command"}`,
+      };
+    }
+
+    case "sandbox.command.completed":
+    case "sandbox.command.failed": {
+      const p = payload<SandboxCommandPayload>(event);
+      const failed =
+        event.EventType === "sandbox.command.failed" ||
+        (p.exit_code != null && p.exit_code !== 0);
+      return {
+        ...base,
+        headline: failed
+          ? `Command failed (exit ${p.exit_code ?? "?"})`
+          : `Command ok${p.duration_ms != null ? ` (${p.duration_ms}ms)` : ""}`,
+        detail: truncate(p.stderr || p.stdout),
+        error: failed,
+      };
+    }
+
+    case "sandbox.file.read": {
+      const p = payload<SandboxFilePayload>(event);
+      return { ...base, headline: `Read ${truncate(p.path, 60) ?? "file"}` };
+    }
+
+    case "sandbox.file.written": {
+      const p = payload<SandboxFilePayload>(event);
+      return { ...base, headline: `Wrote ${truncate(p.path, 60) ?? "file"}` };
+    }
+
+    case "sandbox.file.listed": {
+      const p = payload<SandboxFilePayload>(event);
+      return { ...base, headline: `Listed ${truncate(p.path, 60) ?? "dir"}` };
+    }
+
+    case "grader.verification.file_captured":
+    case "grader.verification.directory_listed":
+    case "grader.verification.code_executed":
+      return { ...base, headline: "Grader captured evidence" };
+
+    case "scoring.started":
+      return { ...base, headline: "Scoring started" };
+
+    case "scoring.metric.recorded": {
+      const p = payload<ScoringMetricPayload>(event);
+      const scorePct =
+        p.score != null ? `${Math.round(p.score * 100)}%` : undefined;
+      return {
+        ...base,
+        headline: `Metric ${p.metric_key ?? "?"}${scorePct ? `: ${scorePct}` : ""}`,
+        detail: p.passed == null ? undefined : p.passed ? "passed" : "failed",
+        error: p.passed === false,
+      };
+    }
+
+    case "scoring.completed":
+      return { ...base, headline: "Scoring completed" };
+
+    case "scoring.failed":
+      return { ...base, headline: "Scoring failed", error: true };
+
+    default:
+      return { ...base, headline: event.EventType };
+  }
+}
+
+/**
+ * Returns a "what is this agent actively doing" label for events that
+ * represent the *start* of a long-running action. Returns null for events
+ * that complete or terminate an action so callers know to clear the
+ * current-action slot.
+ */
+export function deriveNowDoing(event: RunEvent): NowDoing | "clear" | null {
+  switch (event.EventType) {
+    case "model.call.started": {
+      const p = payload<ModelCallStartedPayload>(event);
+      return {
+        kind: "model",
+        label: `Calling ${modelLabel(p.provider_key, p.provider_model_id ?? p.model)}`,
+        sequence: event.SequenceNumber,
+        startedAt: event.OccurredAt,
+      };
+    }
+
+    case "tool.call.started": {
+      const p = payload<ToolCallPayload>(event);
+      return {
+        kind: "tool",
+        label: `Tool: ${p.tool_name ?? "unknown"}`,
+        sequence: event.SequenceNumber,
+        startedAt: event.OccurredAt,
+      };
+    }
+
+    case "sandbox.command.started": {
+      const p = payload<SandboxCommandPayload>(event);
+      return {
+        kind: "sandbox",
+        label: `$ ${truncate(p.command, 60) ?? "command"}`,
+        sequence: event.SequenceNumber,
+        startedAt: event.OccurredAt,
+      };
+    }
+
+    case "scoring.started":
+      return {
+        kind: "scoring",
+        label: "Scoring",
+        sequence: event.SequenceNumber,
+        startedAt: event.OccurredAt,
+      };
+
+    case "system.step.started": {
+      const p = payload<{ step_index?: number }>(event);
+      const step = p.step_index ?? event.Summary?.step_index;
+      return {
+        kind: "system",
+        label: step != null ? `Step ${step}` : "Stepping",
+        sequence: event.SequenceNumber,
+        startedAt: event.OccurredAt,
+      };
+    }
+
+    case "model.call.completed":
+    case "tool.call.completed":
+    case "tool.call.failed":
+    case "sandbox.command.completed":
+    case "sandbox.command.failed":
+    case "scoring.completed":
+    case "scoring.failed":
+    case "system.run.completed":
+    case "system.run.failed":
+      return "clear";
+
+    default:
+      return null;
+  }
+}

--- a/web/src/lib/arena/payload-types.ts
+++ b/web/src/lib/arena/payload-types.ts
@@ -1,0 +1,124 @@
+/**
+ * Typed payload shapes for run event envelopes delivered over SSE.
+ *
+ * Mirrors the payload maps produced by the backend observers in
+ * `backend/internal/worker/native_event_observer.go`,
+ * `prompt_eval_event_observer.go`, and `backend/internal/runevents/hosted.go`.
+ *
+ * We keep these loose (`Partial`/optional fields) because:
+ *   1. Hosted-engine payloads don't share the exact native schema.
+ *   2. New event types can be added before the UI is updated.
+ *
+ * For arena rendering we only care about a small, resilient subset.
+ */
+
+export type RunEventType =
+  | "system.run.started"
+  | "system.run.completed"
+  | "system.run.failed"
+  | "system.output.finalized"
+  | "system.step.started"
+  | "system.step.completed"
+  | "model.call.started"
+  | "model.call.completed"
+  | "model.output.delta"
+  | "model.tool_calls.proposed"
+  | "tool.call.started"
+  | "tool.call.completed"
+  | "tool.call.failed"
+  | "sandbox.command.started"
+  | "sandbox.command.completed"
+  | "sandbox.command.failed"
+  | "sandbox.file.read"
+  | "sandbox.file.written"
+  | "sandbox.file.listed"
+  | "grader.verification.file_captured"
+  | "grader.verification.directory_listed"
+  | "grader.verification.code_executed"
+  | "scoring.started"
+  | "scoring.metric.recorded"
+  | "scoring.completed"
+  | "scoring.failed";
+
+export interface ModelCallStartedPayload {
+  provider_key?: string;
+  model?: string;
+  provider_model_id?: string;
+  message_count?: number;
+  tool_definition_count?: number;
+}
+
+export interface ModelCallCompletedPayload {
+  provider_key?: string;
+  provider_model_id?: string;
+  finish_reason?: string;
+  output_text?: string;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    total_tokens?: number;
+  };
+}
+
+export interface ModelOutputDeltaPayload {
+  provider_key?: string;
+  provider_model_id?: string;
+  stream_kind?: "text" | "tool_call" | string;
+  text_delta?: string;
+  tool_call_fragment?: {
+    index?: number;
+    id_fragment?: string;
+    name_fragment?: string;
+    arguments_fragment?: string;
+  };
+}
+
+export interface ToolCallPayload {
+  tool_call_id?: string;
+  tool_name?: string;
+  tool_category?: string;
+  resolved_tool_name?: string;
+  arguments?: unknown;
+  result?: {
+    content?: string;
+    is_error?: boolean;
+  };
+}
+
+export interface SandboxCommandPayload {
+  command?: string;
+  args?: string[];
+  cwd?: string;
+  exit_code?: number;
+  duration_ms?: number;
+  stdout?: string;
+  stderr?: string;
+}
+
+export interface SandboxFilePayload {
+  path?: string;
+  bytes?: number;
+}
+
+export interface StepPayload {
+  step_index?: number;
+}
+
+export interface ScoringMetricPayload {
+  metric_key?: string;
+  score?: number;
+  passed?: boolean;
+}
+
+export interface RunCompletedPayload {
+  final_output?: string;
+  step_count?: number;
+  tool_call_count?: number;
+  total_tokens?: number;
+}
+
+export interface RunFailedPayload {
+  error?: string;
+  stop_reason?: string;
+  step_index?: number;
+}


### PR DESCRIPTION
## Summary

The SSE run-event stream (`/v1/runs/{runID}/events/stream`) already delivers typed envelopes for every model call, tool call, sandbox command, grader verification, and scoring metric — the web was consuming these events but only using them as a debounced refetch trigger. All the rich payload content was discarded.

This PR turns each agent lane on the run-detail page into a live projection of that stream while the run is active.

## What you see per lane (when active)

- **Now-doing banner** with a pulsing dot, derived from `*.started` events: \"Calling openai/gpt-4o\", \"Tool: submit\", \"\$ npm test\", \"Step 3\".
- **Metrics strip** — elapsed, step count, model calls, tool calls, accumulated tokens.
- **Streaming output box** — fills in from `model.output.delta` text chunks, cleared on each new model call.
- **Activity ticker** — bounded (40-entry) ring buffer of events, auto-scrolling, most recent at bottom. Failed events highlighted.
- **LIVE pill** next to the run status badge when SSE is connected.

When an agent finishes, the live sections collapse and the existing \`ScorecardSummaryCard\` takes over via a \`footer\` prop on \`LiveAgentLane\`.

## Architecture

- \`web/src/lib/arena/payload-types.ts\` — typed payload shapes mirroring the backend observer payloads.
- \`web/src/lib/arena/event-formatter.ts\` — pure \`summarizeEvent()\` (ticker line) and \`deriveNowDoing()\` (current-action banner). Testable without React.
- \`web/src/hooks/use-agent-arena.ts\` — \`useReducer\`-backed projection. One stable \`handleEvent\` callback fed into \`useRunEvents\`, which also still triggers the debounced refetch.
- \`web/src/components/arena/live-event-ticker.tsx\` — autoscrolling monospace feed with fade-in per entry.
- \`web/src/components/arena/live-agent-lane.tsx\` — drop-in upgrade of the inline agent card in \`run-detail-client.tsx\`.

No backend changes. No new route (augmenting the existing run-detail page; \`LiveAgentLane\` is factored to make a later \`/arena\` spectator route trivial).

## Safety / correctness notes

- The debounced refetch stays intact — authoritative state (status transitions, ranking, scorecards, regression coverage) still comes from the API, not the reducer.
- Streaming-output accumulator is clipped to 800 chars to bound memory on long replies.
- Ticker ring buffer capped at 40 entries per lane.
- \`deriveNowDoing\` only clears the banner when the terminating event's sequence number is \u2265 the one that set it, so a late \`model.call.completed\` can't wipe a freshly-started \`tool.call.started\`.

## Test plan

- [ ] Start a comparison run with 2+ agents; verify each lane shows its own live ticker and now-doing banner independently.
- [ ] Watch model.output.delta streaming in the \"Streaming\" box; confirm it clears when the next model call starts.
- [ ] Kill and restore the SSE connection (toggle wifi) and verify the LIVE pill disappears / reappears and state catches up via debounced refetch.
- [ ] Complete a run and confirm scorecard renders in the lane footer and live sections collapse.
- [ ] \`npm run lint\` + \`npx tsc --noEmit\` both clean (verified locally).