### PR TITLE
[codex] Fix live arena SSE and add commentary booth

### DIFF
--- a/testing/codex-live-view-commentary-sidebar.md
+++ b/testing/codex-live-view-commentary-sidebar.md
@@ -1,0 +1,41 @@
+# codex/live-view-commentary-sidebar — Test Contract
+
+## Functional Behavior
+- The run detail live arena must consume SSE envelopes emitted by the backend's snake_case wire format and project them into per-agent lane state correctly.
+- When a run is live and SSE events arrive, each lane should update its now-doing banner, activity ticker, streaming output, counters, and step indicator instead of remaining stuck in an idle state.
+- A commentator sidebar can be enabled from the run detail UI with a toggle and disabled again without changing challenge pack configuration.
+- When enabled, the commentator sidebar should derive short commentary entries from live run events and show them newest-last in a bounded feed.
+- The commentator feed should work for comparison and single-agent runs, handle repeated events without duplicate entries, and degrade gracefully when no commentary has been generated yet.
+- Existing run detail features such as scorecards, ranking, replay links, and polling fallback should continue to work.
+
+## Unit Tests
+- `normalizeRunEvent` converts snake_case SSE payloads into the camel/Pascal-shaped event object consumed by the live arena code.
+- `normalizeRunEvent` preserves already-normalized event objects so existing callers do not regress.
+- Commentator helpers produce commentary for meaningful arena events and suppress noisy events like token deltas.
+- Commentator state stays bounded and deduplicates by event ID.
+
+## Integration / Functional Tests
+- The run detail live event pipeline accepts a backend-shaped SSE event and updates the rendered live arena lane.
+- Toggling commentary on shows the sidebar and toggling it off hides it.
+- When commentary is enabled and live events arrive, rendered commentary text reflects those events.
+
+## Smoke Tests
+- `npm test -- --runInBand` or targeted Vitest runs for the new arena/commentary tests pass.
+- `npm run lint` passes for the touched web files.
+
+## E2E Tests
+- N/A — not applicable for this change. No browser automation suite is currently being added.
+
+## Manual / cURL Tests
+```bash
+cd web
+npm test -- src/hooks/use-run-events.test.ts src/hooks/use-agent-commentary.test.ts src/app/'(workspace)'/workspaces/'[workspaceId]'/runs/'[runId]'/run-detail-client.test.tsx
+npm run lint -- src/hooks/use-run-events.ts src/hooks/use-agent-commentary.ts src/components/arena/live-commentary-sidebar.tsx src/app/'(workspace)'/workspaces/'[workspaceId]'/runs/'[runId]'/run-detail-client.tsx
+```
+
+Manual UI steps:
+1. Start a live run in the web app.
+2. Open the run detail page and confirm the "Live" badge appears.
+3. Verify an active lane advances from "Waiting for next action…" into model/tool/scoring activity as SSE events arrive.
+4. Enable the commentator toggle and confirm a sidebar appears with short play-by-play commentary.
+5. Disable the toggle and confirm the sidebar disappears while the live lanes continue updating.

--- a/testing/codex-live-view-commentary-sidebar.md
+++ b/testing/codex-live-view-commentary-sidebar.md
@@ -5,6 +5,9 @@
 - When a run is live and SSE events arrive, each lane should update its now-doing banner, activity ticker, streaming output, counters, and step indicator instead of remaining stuck in an idle state.
 - A commentator sidebar can be enabled from the run detail UI with a toggle and disabled again without changing challenge pack configuration.
 - When enabled, the commentator sidebar should derive short commentary entries from live run events and show them newest-last in a bounded feed.
+- When commentary is disabled, the feed should stop accumulating hidden history and should reopen as a fresh feed the next time the user enables it.
+- The sidebar should render the same bounded number of commentary entries that the commentary store retains rather than silently hiding half of them.
+- Commentary timestamps should be displayed in UTC and labeled accordingly so backend event times are not reinterpreted in the browser's local timezone.
 - The commentator feed should work for comparison and single-agent runs, handle repeated events without duplicate entries, and degrade gracefully when no commentary has been generated yet.
 - Existing run detail features such as scorecards, ranking, replay links, and polling fallback should continue to work.
 
@@ -13,11 +16,13 @@
 - `normalizeRunEvent` preserves already-normalized event objects so existing callers do not regress.
 - Commentator helpers produce commentary for meaningful arena events and suppress noisy events like token deltas.
 - Commentator state stays bounded and deduplicates by event ID.
+- The commentary sidebar renders all entries up to `MAX_COMMENTARY_ENTRIES` and labels timestamps as UTC.
 
 ## Integration / Functional Tests
 - The run detail live event pipeline accepts a backend-shaped SSE event and updates the rendered live arena lane.
 - Toggling commentary on shows the sidebar and toggling it off hides it.
 - When commentary is enabled and live events arrive, rendered commentary text reflects those events.
+- Toggling commentary off clears the feed and hidden SSE events do not repopulate commentary until the user opts back in.
 
 ## Smoke Tests
 - `npm test -- --runInBand` or targeted Vitest runs for the new arena/commentary tests pass.
@@ -30,7 +35,8 @@
 ```bash
 cd web
 npm test -- src/hooks/use-run-events.test.ts src/hooks/use-agent-commentary.test.ts src/app/'(workspace)'/workspaces/'[workspaceId]'/runs/'[runId]'/run-detail-client.test.tsx
-npm run lint -- src/hooks/use-run-events.ts src/hooks/use-agent-commentary.ts src/components/arena/live-commentary-sidebar.tsx src/app/'(workspace)'/workspaces/'[workspaceId]'/runs/'[runId]'/run-detail-client.tsx
+npm test -- src/components/arena/live-commentary-sidebar.test.tsx
+npm run lint -- src/hooks/use-run-events.ts src/hooks/use-agent-commentary.ts src/components/arena/live-commentary-sidebar.tsx src/components/arena/live-commentary-sidebar.test.tsx src/app/'(workspace)'/workspaces/'[workspaceId]'/runs/'[runId]'/run-detail-client.tsx
 ```
 
 Manual UI steps:
@@ -38,4 +44,6 @@ Manual UI steps:
 2. Open the run detail page and confirm the "Live" badge appears.
 3. Verify an active lane advances from "Waiting for next action…" into model/tool/scoring activity as SSE events arrive.
 4. Enable the commentator toggle and confirm a sidebar appears with short play-by-play commentary.
-5. Disable the toggle and confirm the sidebar disappears while the live lanes continue updating.
+5. Disable the toggle and confirm the sidebar disappears, the feed resets, and the live lanes continue updating.
+6. Re-enable commentary and confirm the feed starts empty until new commentary-worthy events arrive.
+7. Confirm commentary timestamps are labeled `UTC`.

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.test.tsx
@@ -141,7 +141,7 @@ describe("RunDetailClient", () => {
     });
   });
 
-  it("toggles commentary and updates both the live lane and sidebar on incoming events", async () => {
+  it("toggles commentary, updates live state, and resets hidden commentary history", async () => {
     const { container, cleanup } = renderClient();
     await flushPromises();
 
@@ -178,6 +178,45 @@ describe("RunDetailClient", () => {
     expect(container.textContent).toContain("Calling openai/gpt-5.4-mini");
     expect(container.textContent).toContain(
       "Alpha checks in with openai/gpt-5.4-mini.",
+    );
+    expect(container.textContent).toContain("12:01:00 UTC");
+
+    act(() => {
+      clickElement(toggle!);
+    });
+
+    expect(container.textContent).not.toContain("Live sidebar callouts");
+
+    act(() => {
+      latestOnEvent?.({
+        EventID: "evt-hidden-tool",
+        SchemaVersion: "2026-03-15",
+        RunID: "run-1",
+        RunAgentID: "agent-1",
+        SequenceNumber: 13,
+        EventType: "tool.call.started",
+        Source: "native_engine",
+        OccurredAt: "2026-04-22T12:01:10Z",
+        Payload: {
+          tool_name: "search_query",
+        },
+        Summary: {},
+      });
+    });
+
+    expect(container.textContent).toContain("Tool: search_query");
+
+    act(() => {
+      clickElement(toggle!);
+    });
+
+    expect(container.textContent).toContain("Live sidebar callouts");
+    expect(container.textContent).toContain("Waiting for the next call");
+    expect(container.textContent).not.toContain(
+      "Alpha checks in with openai/gpt-5.4-mini.",
+    );
+    expect(container.textContent).not.toContain(
+      "Alpha reaches for search_query.",
     );
 
     cleanup();

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.test.tsx
@@ -1,0 +1,185 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { RunEvent } from "@/hooks/use-run-events";
+
+import { RunDetailClient } from "./run-detail-client";
+
+const { mockGetAccessToken, mockUseRunEvents, mockCreateApiClient } =
+  vi.hoisted(() => ({
+    mockGetAccessToken: vi.fn(),
+    mockUseRunEvents: vi.fn(),
+    mockCreateApiClient: vi.fn(),
+  }));
+
+let latestOnEvent: ((event: RunEvent) => void) | undefined;
+
+vi.mock("@workos-inc/authkit-nextjs/components", () => ({
+  useAccessToken: () => ({ getAccessToken: mockGetAccessToken }),
+}));
+
+vi.mock("@/hooks/use-run-events", async () => {
+  const actual = await vi.importActual<typeof import("@/hooks/use-run-events")>(
+    "@/hooks/use-run-events",
+  );
+
+  return {
+    ...actual,
+    useRunEvents: (options: {
+      onEvent?: (event: RunEvent) => void;
+    }) => {
+      latestOnEvent = options.onEvent;
+      return mockUseRunEvents(options);
+    },
+  };
+});
+
+vi.mock("@/lib/api/client", () => ({
+  createApiClient: (...args: unknown[]) => mockCreateApiClient(...args),
+}));
+
+vi.mock("./compare-run-picker", () => ({
+  CompareRunPicker: () => React.createElement("div", null, "compare-picker"),
+}));
+
+vi.mock("./scorecard-summary-card", () => ({
+  ScorecardSummaryCard: () =>
+    React.createElement("div", null, "scorecard-summary"),
+}));
+
+vi.mock("./run-ranking-insights-card", () => ({
+  RunRankingInsightsCard: () =>
+    React.createElement("div", null, "ranking-insights"),
+}));
+
+vi.mock("@/components/artifacts/upload-artifact-dialog", () => ({
+  UploadArtifactDialog: () =>
+    React.createElement("button", { type: "button" }, "upload-artifact"),
+}));
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function clickElement(element: Element) {
+  element.dispatchEvent(
+    new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+}
+
+function renderClient() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+
+  act(() => {
+    root.render(
+      React.createElement(RunDetailClient, {
+        workspaceId: "ws-1",
+        initialRun: {
+          id: "run-1",
+          workspace_id: "ws-1",
+          challenge_pack_version_id: "cpv-1",
+          official_pack_mode: "full",
+          name: "Live Arena Run",
+          status: "running",
+          execution_mode: "comparison",
+          created_at: "2026-04-22T12:00:00Z",
+          updated_at: "2026-04-22T12:00:00Z",
+          started_at: "2026-04-22T12:00:05Z",
+          links: {
+            self: "/v1/runs/run-1",
+            agents: "/v1/runs/run-1/agents",
+          },
+        },
+        initialAgents: [
+          {
+            id: "agent-1",
+            run_id: "run-1",
+            lane_index: 0,
+            label: "Alpha",
+            agent_deployment_id: "dep-1",
+            agent_deployment_snapshot_id: "snap-1",
+            status: "executing",
+            started_at: "2026-04-22T12:00:05Z",
+            created_at: "2026-04-22T12:00:00Z",
+            updated_at: "2026-04-22T12:00:05Z",
+          },
+        ],
+      }),
+    );
+  });
+
+  return {
+    container,
+    cleanup() {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+describe("RunDetailClient", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    latestOnEvent = undefined;
+    mockGetAccessToken.mockReset();
+    mockUseRunEvents.mockReset();
+    mockCreateApiClient.mockReset();
+    mockGetAccessToken.mockResolvedValue("token-123");
+    mockUseRunEvents.mockReturnValue({ connected: true, error: null });
+    mockCreateApiClient.mockReturnValue({
+      get: vi.fn(),
+    });
+  });
+
+  it("toggles commentary and updates both the live lane and sidebar on incoming events", async () => {
+    const { container, cleanup } = renderClient();
+    await flushPromises();
+
+    const toggle = Array.from(container.querySelectorAll("button")).find(
+      (element) => element.textContent?.includes("Commentary Off"),
+    );
+    expect(toggle).toBeTruthy();
+
+    act(() => {
+      clickElement(toggle!);
+    });
+
+    expect(container.textContent).toContain("Commentary On");
+    expect(container.textContent).toContain("Live sidebar callouts");
+
+    act(() => {
+      latestOnEvent?.({
+        EventID: "evt-model-1",
+        SchemaVersion: "2026-03-15",
+        RunID: "run-1",
+        RunAgentID: "agent-1",
+        SequenceNumber: 12,
+        EventType: "model.call.started",
+        Source: "native_engine",
+        OccurredAt: "2026-04-22T12:01:00Z",
+        Payload: {
+          provider_key: "openai",
+          provider_model_id: "gpt-5.4-mini",
+        },
+        Summary: {},
+      });
+    });
+
+    expect(container.textContent).toContain("Calling openai/gpt-5.4-mini");
+    expect(container.textContent).toContain(
+      "Alpha checks in with openai/gpt-5.4-mini.",
+    );
+
+    cleanup();
+  });
+});

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
@@ -197,6 +197,7 @@ export function RunDetailClient({
   const {
     entries: commentaryEntries,
     handleEvent: handleCommentaryEvent,
+    reset: resetCommentary,
   } = useAgentCommentary(agents);
 
   // Debounced refetch: collapse rapid SSE events into a single fetch.
@@ -204,11 +205,13 @@ export function RunDetailClient({
   const handleSSEEvent = useCallback(
     (event: RunEvent) => {
       handleArenaEvent(event);
-      handleCommentaryEvent(event);
+      if (showCommentary) {
+        handleCommentaryEvent(event);
+      }
       if (fetchTimerRef.current) clearTimeout(fetchTimerRef.current);
       fetchTimerRef.current = setTimeout(fetchAll, 300);
     },
-    [fetchAll, handleArenaEvent, handleCommentaryEvent],
+    [fetchAll, handleArenaEvent, handleCommentaryEvent, showCommentary],
   );
 
   useEffect(() => {
@@ -350,7 +353,12 @@ export function RunDetailClient({
           <Button
             variant={showCommentary ? "default" : "outline"}
             size="sm"
-            onClick={() => setShowCommentary((current) => !current)}
+            onClick={() =>
+              setShowCommentary((current) => {
+                if (current) resetCommentary();
+                return !current;
+              })
+            }
             aria-pressed={showCommentary}
           >
             <MessageSquareText className="size-3.5" />

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
@@ -2,9 +2,17 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
-import { createApiClient } from "@/lib/api/client";
-import { useRunEvents, type RunEvent } from "@/hooks/use-run-events";
+
+import { LiveAgentLane } from "@/components/arena/live-agent-lane";
+import { LiveCommentarySidebar } from "@/components/arena/live-commentary-sidebar";
+import { UploadArtifactDialog } from "@/components/artifacts/upload-artifact-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { useAgentArena, EMPTY_LANE } from "@/hooks/use-agent-arena";
+import { useAgentCommentary } from "@/hooks/use-agent-commentary";
+import { useRunEvents, type RunEvent } from "@/hooks/use-run-events";
+import { createApiClient } from "@/lib/api/client";
+import { scorePercent } from "@/lib/scores";
 import type {
   Run,
   RunStatus,
@@ -14,8 +22,6 @@ import type {
   RankingItem,
   ScorecardResponse,
 } from "@/lib/api/types";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import {
   Table,
   TableBody,
@@ -34,12 +40,12 @@ import {
   AlertTriangle,
   AlertOctagon,
   Radio,
+  MessageSquareText,
 } from "lucide-react";
-import { ScorecardSummaryCard } from "./scorecard-summary-card";
+
 import { CompareRunPicker } from "./compare-run-picker";
 import { RunRankingInsightsCard } from "./run-ranking-insights-card";
-import { UploadArtifactDialog } from "@/components/artifacts/upload-artifact-dialog";
-import { LiveAgentLane } from "@/components/arena/live-agent-lane";
+import { ScorecardSummaryCard } from "./scorecard-summary-card";
 
 // --- Status variant maps ---
 
@@ -100,9 +106,6 @@ function buildSortOptions(
   }));
   return [...LEGACY_SORT_OPTIONS, ...custom];
 }
-
-import { scorePercent } from "@/lib/scores";
-
 // --- Helpers ---
 
 function formatDuration(start: string, end?: string): string {
@@ -155,6 +158,7 @@ export function RunDetailClient({
   const [scorecards, setScorecards] = useState<
     Record<string, ScorecardResponse | null>
   >({});
+  const [showCommentary, setShowCommentary] = useState(false);
 
   const isActive =
     ACTIVE_RUN_STATUSES.includes(run.status) ||
@@ -190,17 +194,28 @@ export function RunDetailClient({
 
   // Live per-lane arena projection from the SSE event stream.
   const { lanes: arenaLanes, handleEvent: handleArenaEvent } = useAgentArena();
+  const {
+    entries: commentaryEntries,
+    handleEvent: handleCommentaryEvent,
+  } = useAgentCommentary(agents);
 
   // Debounced refetch: collapse rapid SSE events into a single fetch.
   const fetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const handleSSEEvent = useCallback(
     (event: RunEvent) => {
       handleArenaEvent(event);
+      handleCommentaryEvent(event);
       if (fetchTimerRef.current) clearTimeout(fetchTimerRef.current);
       fetchTimerRef.current = setTimeout(fetchAll, 300);
     },
-    [fetchAll, handleArenaEvent],
+    [fetchAll, handleArenaEvent, handleCommentaryEvent],
   );
+
+  useEffect(() => {
+    return () => {
+      if (fetchTimerRef.current) clearTimeout(fetchTimerRef.current);
+    };
+  }, []);
 
   // Live event streaming via SSE (graceful degradation: falls back to polling).
   const { connected: sseConnected } = useRunEvents({
@@ -332,6 +347,15 @@ export function RunDetailClient({
             workspaceId={workspaceId}
             runId={run.id}
           />
+          <Button
+            variant={showCommentary ? "default" : "outline"}
+            size="sm"
+            onClick={() => setShowCommentary((current) => !current)}
+            aria-pressed={showCommentary}
+          >
+            <MessageSquareText className="size-3.5" />
+            Commentary {showCommentary ? "On" : "Off"}
+          </Button>
           <Link
             href={`/workspaces/${workspaceId}/runs/${run.id}/failures`}
             className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 h-8 text-xs text-muted-foreground hover:text-foreground hover:bg-muted/40 transition-colors"
@@ -383,35 +407,53 @@ export function RunDetailClient({
       <div>
         <h2 className="text-sm font-semibold mb-3">Agent Lanes</h2>
         <div
-          className={`grid gap-3 ${
-            agents.length === 1 ? "grid-cols-1" : "grid-cols-1 md:grid-cols-2"
+          className={`grid gap-4 ${
+            showCommentary
+              ? "grid-cols-1 xl:grid-cols-[minmax(0,2fr)_minmax(18rem,24rem)]"
+              : "grid-cols-1"
           }`}
         >
-          {sortedAgents.map((agent) => {
-            const isWinner =
-              ranking?.ranking?.winner?.run_agent_id === agent.id;
-            const laneState = arenaLanes[agent.id] ?? EMPTY_LANE;
-            const isTerminal =
-              agent.status === "completed" || agent.status === "failed";
-            const footer = isTerminal ? (
-              <ScorecardSummaryCard
-                scorecard={scorecards[agent.id] ?? null}
-                loading={!(agent.id in scorecards)}
-              />
-            ) : null;
+          <div
+            className={`grid gap-3 ${
+              agents.length === 1
+                ? "grid-cols-1"
+                : "grid-cols-1 md:grid-cols-2"
+            }`}
+          >
+            {sortedAgents.map((agent) => {
+              const isWinner =
+                ranking?.ranking?.winner?.run_agent_id === agent.id;
+              const laneState = arenaLanes[agent.id] ?? EMPTY_LANE;
+              const isTerminal =
+                agent.status === "completed" || agent.status === "failed";
+              const footer = isTerminal ? (
+                <ScorecardSummaryCard
+                  scorecard={scorecards[agent.id] ?? null}
+                  loading={!(agent.id in scorecards)}
+                />
+              ) : null;
 
-            return (
-              <LiveAgentLane
-                key={agent.id}
-                agent={agent}
-                lane={laneState}
-                isWinner={isWinner}
-                workspaceId={workspaceId}
-                runId={run.id}
-                footer={footer}
+              return (
+                <LiveAgentLane
+                  key={agent.id}
+                  agent={agent}
+                  lane={laneState}
+                  isWinner={isWinner}
+                  workspaceId={workspaceId}
+                  runId={run.id}
+                  footer={footer}
+                />
+              );
+            })}
+          </div>
+          {showCommentary && (
+            <div className="xl:sticky xl:top-4 xl:self-start">
+              <LiveCommentarySidebar
+                entries={commentaryEntries}
+                isActive={isActive}
               />
-            );
-          })}
+            </div>
+          )}
         </div>
       </div>
 

--- a/web/src/components/arena/live-commentary-sidebar.test.tsx
+++ b/web/src/components/arena/live-commentary-sidebar.test.tsx
@@ -1,0 +1,78 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  MAX_COMMENTARY_ENTRIES,
+  type CommentaryEntry,
+} from "@/hooks/use-agent-commentary";
+
+import { LiveCommentarySidebar } from "./live-commentary-sidebar";
+
+function makeEntry(index: number): CommentaryEntry {
+  return {
+    id: `entry-${index}`,
+    occurredAt: `2026-04-22T23:15:${String(index).padStart(2, "0")}Z`,
+    agentId: "agent-1",
+    agentLabel: "Alpha",
+    line: `Commentary line ${index}`,
+    tone: "neutral",
+  };
+}
+
+function renderSidebar(entries: CommentaryEntry[]) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+
+  act(() => {
+    root.render(
+      React.createElement(LiveCommentarySidebar, {
+        entries,
+        isActive: true,
+      }),
+    );
+  });
+
+  return {
+    container,
+    cleanup() {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+describe("LiveCommentarySidebar", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders every available entry up to the bounded commentary limit", () => {
+    const entries = Array.from(
+      { length: MAX_COMMENTARY_ENTRIES },
+      (_, index) => makeEntry(index),
+    );
+
+    const { container, cleanup } = renderSidebar(entries);
+
+    expect(container.querySelectorAll("article")).toHaveLength(
+      MAX_COMMENTARY_ENTRIES,
+    );
+    expect(container.textContent).toContain(
+      `Commentary line ${MAX_COMMENTARY_ENTRIES - 1}`,
+    );
+
+    cleanup();
+  });
+
+  it("formats backend timestamps in UTC and labels them clearly", () => {
+    const { container, cleanup } = renderSidebar([makeEntry(3)]);
+
+    expect(container.textContent).toContain("23:15:03 UTC");
+
+    cleanup();
+  });
+});

--- a/web/src/components/arena/live-commentary-sidebar.tsx
+++ b/web/src/components/arena/live-commentary-sidebar.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import {
+  AudioLines,
+  AlertTriangle,
+  CircleDot,
+  Sparkles,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { CommentaryEntry } from "@/hooks/use-agent-commentary";
+
+interface LiveCommentarySidebarProps {
+  entries: CommentaryEntry[];
+  isActive: boolean;
+  className?: string;
+}
+
+function formatClock(iso: string): string {
+  const d = new Date(iso);
+  const h = d.getHours().toString().padStart(2, "0");
+  const m = d.getMinutes().toString().padStart(2, "0");
+  const s = d.getSeconds().toString().padStart(2, "0");
+  return `${h}:${m}:${s}`;
+}
+
+const TONE_STYLES: Record<CommentaryEntry["tone"], string> = {
+  neutral:
+    "border-slate-300/70 bg-white/80 text-slate-700 dark:border-slate-700 dark:bg-slate-950/60 dark:text-slate-200",
+  positive:
+    "border-emerald-300/70 bg-emerald-50/80 text-emerald-800 dark:border-emerald-900/80 dark:bg-emerald-950/40 dark:text-emerald-200",
+  warning:
+    "border-amber-300/70 bg-amber-50/80 text-amber-900 dark:border-amber-900/80 dark:bg-amber-950/40 dark:text-amber-200",
+};
+
+export function LiveCommentarySidebar({
+  entries,
+  isActive,
+  className,
+}: LiveCommentarySidebarProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const recent = entries.slice(-12);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [recent.length]);
+
+  return (
+    <aside
+      className={cn(
+        "rounded-2xl border border-amber-400/25 bg-[linear-gradient(180deg,rgba(255,251,235,0.95),rgba(255,255,255,0.95))] p-4 shadow-sm dark:border-amber-500/15 dark:bg-[linear-gradient(180deg,rgba(69,26,3,0.28),rgba(2,6,23,0.92))]",
+        className,
+      )}
+    >
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div>
+          <div className="mb-1 inline-flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.18em] text-amber-700/80 dark:text-amber-300/80">
+            <AudioLines className="size-3" />
+            Commentary Booth
+          </div>
+          <h3 className="text-sm font-semibold tracking-tight">
+            Live sidebar callouts
+          </h3>
+          <p className="mt-1 text-xs text-muted-foreground">
+            A lightweight play-by-play generated from the live arena stream.
+          </p>
+        </div>
+        <Badge variant={isActive ? "default" : "outline"}>
+          {isActive ? "On Air" : "Idle"}
+        </Badge>
+      </div>
+
+      {recent.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-amber-300/60 bg-white/60 px-3 py-4 text-sm text-muted-foreground dark:border-amber-900/70 dark:bg-slate-950/40">
+          <div className="mb-1 flex items-center gap-2 font-medium text-foreground">
+            <Sparkles className="size-4 text-amber-600 dark:text-amber-300" />
+            Waiting for the next call
+          </div>
+          <p className="text-xs leading-5">
+            Turn commentary on during a live run to watch the sidebar narrate
+            model calls, tool usage, scoring beats, and finishes.
+          </p>
+        </div>
+      ) : (
+        <div
+          ref={scrollRef}
+          className="max-h-[34rem] space-y-2 overflow-y-auto pr-1"
+        >
+          {recent.map((entry) => (
+            <article
+              key={entry.id}
+              className={cn(
+                "rounded-xl border px-3 py-2.5 backdrop-blur-sm",
+                TONE_STYLES[entry.tone],
+              )}
+            >
+              <div className="mb-1 flex items-center gap-2 text-[11px] uppercase tracking-[0.12em] text-current/70">
+                {entry.tone === "warning" ? (
+                  <AlertTriangle className="size-3.5" />
+                ) : (
+                  <CircleDot className="size-3.5" />
+                )}
+                <span className="truncate">{entry.agentLabel}</span>
+                <span className="ml-auto shrink-0 tabular-nums">
+                  {formatClock(entry.occurredAt)}
+                </span>
+              </div>
+              <p className="text-sm leading-5 text-foreground dark:text-inherit">
+                {entry.line}
+              </p>
+              {entry.detail && (
+                <p className="mt-1 text-xs leading-5 text-current/75">
+                  {entry.detail}
+                </p>
+              )}
+            </article>
+          ))}
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/web/src/components/arena/live-commentary-sidebar.tsx
+++ b/web/src/components/arena/live-commentary-sidebar.tsx
@@ -10,7 +10,10 @@ import {
 
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
-import type { CommentaryEntry } from "@/hooks/use-agent-commentary";
+import {
+  MAX_COMMENTARY_ENTRIES,
+  type CommentaryEntry,
+} from "@/hooks/use-agent-commentary";
 
 interface LiveCommentarySidebarProps {
   entries: CommentaryEntry[];
@@ -20,10 +23,10 @@ interface LiveCommentarySidebarProps {
 
 function formatClock(iso: string): string {
   const d = new Date(iso);
-  const h = d.getHours().toString().padStart(2, "0");
-  const m = d.getMinutes().toString().padStart(2, "0");
-  const s = d.getSeconds().toString().padStart(2, "0");
-  return `${h}:${m}:${s}`;
+  const h = d.getUTCHours().toString().padStart(2, "0");
+  const m = d.getUTCMinutes().toString().padStart(2, "0");
+  const s = d.getUTCSeconds().toString().padStart(2, "0");
+  return `${h}:${m}:${s} UTC`;
 }
 
 const TONE_STYLES: Record<CommentaryEntry["tone"], string> = {
@@ -41,7 +44,7 @@ export function LiveCommentarySidebar({
   className,
 }: LiveCommentarySidebarProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
-  const recent = entries.slice(-12);
+  const recent = entries.slice(-MAX_COMMENTARY_ENTRIES);
 
   useEffect(() => {
     const el = scrollRef.current;

--- a/web/src/hooks/use-agent-commentary.test.ts
+++ b/web/src/hooks/use-agent-commentary.test.ts
@@ -1,0 +1,173 @@
+import React, { act, useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { RunAgent } from "@/lib/api/types";
+import type { RunEvent } from "@/hooks/use-run-events";
+
+import {
+  buildCommentaryEntry,
+  MAX_COMMENTARY_ENTRIES,
+  useAgentCommentary,
+  type UseAgentCommentaryResult,
+} from "./use-agent-commentary";
+
+const agents: RunAgent[] = [
+  {
+    id: "agent-1",
+    run_id: "run-1",
+    lane_index: 0,
+    label: "Alpha",
+    agent_deployment_id: "dep-1",
+    agent_deployment_snapshot_id: "snap-1",
+    status: "executing",
+    created_at: "2026-04-22T12:00:00Z",
+    updated_at: "2026-04-22T12:00:00Z",
+  },
+];
+
+function makeEvent(
+  overrides: Partial<RunEvent> = {},
+): RunEvent {
+  return {
+    EventID: "evt-1",
+    SchemaVersion: "2026-03-15",
+    RunID: "run-1",
+    RunAgentID: "agent-1",
+    SequenceNumber: 1,
+    EventType: "system.run.started",
+    Source: "native_engine",
+    OccurredAt: "2026-04-22T12:00:00Z",
+    Payload: {},
+    Summary: {},
+    ...overrides,
+  };
+}
+
+function HookHarness({
+  onReady,
+}: {
+  onReady: (value: UseAgentCommentaryResult) => void;
+}) {
+  const result = useAgentCommentary(agents);
+
+  useEffect(() => {
+    onReady(result);
+  }, [onReady, result]);
+
+  return null;
+}
+
+function renderHarness(onReady: (value: UseAgentCommentaryResult) => void) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+
+  act(() => {
+    root.render(React.createElement(HookHarness, { onReady }));
+  });
+
+  return {
+    cleanup() {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+describe("buildCommentaryEntry", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("creates commentary for meaningful live events", () => {
+    const entry = buildCommentaryEntry(
+      makeEvent({
+        EventID: "evt-tool",
+        EventType: "tool.call.started",
+        Payload: { tool_name: "search_query" },
+      }),
+      "Alpha",
+    );
+
+    expect(entry?.line).toContain("Alpha reaches for search_query");
+    expect(entry?.tone).toBe("neutral");
+  });
+
+  it("suppresses noisy delta events", () => {
+    const entry = buildCommentaryEntry(
+      makeEvent({
+        EventID: "evt-delta",
+        EventType: "model.output.delta",
+        Payload: { text_delta: "hi" },
+      }),
+      "Alpha",
+    );
+
+    expect(entry).toBeNull();
+  });
+});
+
+describe("useAgentCommentary", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("deduplicates entries by event id", () => {
+    let current: UseAgentCommentaryResult | null = null;
+    const { cleanup } = renderHarness((value) => {
+      current = value;
+    });
+
+    act(() => {
+      current?.handleEvent(
+        makeEvent({
+          EventID: "evt-dup",
+          EventType: "tool.call.started",
+          Payload: { tool_name: "search_query" },
+        }),
+      );
+      current?.handleEvent(
+        makeEvent({
+          EventID: "evt-dup",
+          EventType: "tool.call.started",
+          Payload: { tool_name: "search_query" },
+        }),
+      );
+    });
+
+    expect(current?.entries).toHaveLength(1);
+    cleanup();
+  });
+
+  it("keeps the commentary feed bounded", () => {
+    let current: UseAgentCommentaryResult | null = null;
+    const { cleanup } = renderHarness((value) => {
+      current = value;
+    });
+
+    act(() => {
+      for (let index = 0; index < MAX_COMMENTARY_ENTRIES + 3; index += 1) {
+        current?.handleEvent(
+          makeEvent({
+            EventID: `evt-${index}`,
+            SequenceNumber: index + 1,
+            OccurredAt: `2026-04-22T12:00:${String(index).padStart(2, "0")}Z`,
+            EventType: "system.step.started",
+            Summary: { step_index: index + 1 },
+          }),
+        );
+      }
+    });
+
+    expect(current?.entries).toHaveLength(MAX_COMMENTARY_ENTRIES);
+    expect(current?.entries[0]?.id).toBe("evt-3");
+    expect(current?.entries.at(-1)?.id).toBe(
+      `evt-${MAX_COMMENTARY_ENTRIES + 2}`,
+    );
+
+    cleanup();
+  });
+});

--- a/web/src/hooks/use-agent-commentary.ts
+++ b/web/src/hooks/use-agent-commentary.ts
@@ -1,0 +1,259 @@
+"use client";
+
+import { useCallback, useReducer } from "react";
+
+import type { RunAgent } from "@/lib/api/types";
+import type { RunEvent } from "@/hooks/use-run-events";
+import type {
+  ModelCallStartedPayload,
+  RunFailedPayload,
+  SandboxCommandPayload,
+  ScoringMetricPayload,
+  ToolCallPayload,
+} from "@/lib/arena/payload-types";
+
+export interface CommentaryEntry {
+  id: string;
+  occurredAt: string;
+  agentId: string;
+  agentLabel: string;
+  line: string;
+  detail?: string;
+  tone: "neutral" | "positive" | "warning";
+}
+
+export const MAX_COMMENTARY_ENTRIES = 24;
+
+type CommentaryAction =
+  | { type: "event"; event: RunEvent; agentLabel: string }
+  | { type: "reset" };
+
+function truncate(value: string | undefined, max = 96): string | undefined {
+  if (!value) return value;
+  const trimmed = value.replace(/\s+/g, " ").trim();
+  if (trimmed.length <= max) return trimmed;
+  return trimmed.slice(0, max - 1) + "\u2026";
+}
+
+function modelLabel(
+  providerKey?: string,
+  modelID?: string,
+): string {
+  if (providerKey && modelID) return `${providerKey}/${modelID}`;
+  return modelID || providerKey || "its model";
+}
+
+function shortAgentLabel(runAgentID: string): string {
+  if (!runAgentID) return "An agent";
+  return `Agent ${runAgentID.slice(0, 8)}`;
+}
+
+function payload<T>(event: RunEvent): T {
+  return (event.Payload as T) ?? ({} as T);
+}
+
+export function buildCommentaryEntry(
+  event: RunEvent,
+  agentLabel: string,
+): CommentaryEntry | null {
+  const label = agentLabel || shortAgentLabel(event.RunAgentID);
+
+  switch (event.EventType) {
+    case "system.run.started":
+      return {
+        id: event.EventID,
+        occurredAt: event.OccurredAt,
+        agentId: event.RunAgentID,
+        agentLabel: label,
+        line: `${label} is out of the gate.`,
+        tone: "neutral",
+      };
+
+    case "system.step.started": {
+      const stepIndex =
+        (event.Summary?.step_index as number | undefined) ??
+        (payload<{ step_index?: number }>(event).step_index);
+      return {
+        id: event.EventID,
+        occurredAt: event.OccurredAt,
+        agentId: event.RunAgentID,
+        agentLabel: label,
+        line:
+          stepIndex != null
+            ? `${label} moves into step ${stepIndex}.`
+            : `${label} lines up the next step.`,
+        tone: "neutral",
+      };
+    }
+
+    case "model.call.started": {
+      const p = payload<ModelCallStartedPayload>(event);
+      return {
+        id: event.EventID,
+        occurredAt: event.OccurredAt,
+        agentId: event.RunAgentID,
+        agentLabel: label,
+        line: `${label} checks in with ${modelLabel(
+          p.provider_key,
+          p.provider_model_id ?? p.model,
+        )}.`,
+        tone: "neutral",
+      };
+    }
+
+    case "tool.call.started": {
+      const p = payload<ToolCallPayload>(event);
+      return {
+        id: event.EventID,
+        occurredAt: event.OccurredAt,
+        agentId: event.RunAgentID,
+        agentLabel: label,
+        line: `${label} reaches for ${p.tool_name ?? "a tool"}.`,
+        tone: "neutral",
+      };
+    }
+
+    case "tool.call.completed": {
+      const p = payload<ToolCallPayload>(event);
+      return {
+        id: event.EventID,
+        occurredAt: event.OccurredAt,
+        agentId: event.RunAgentID,
+        agentLabel: label,
+        line: `${label} gets a result back from ${p.tool_name ?? "that tool"}.`,
+        detail: truncate(p.result?.content),
+        tone: p.result?.is_error ? "warning" : "positive",
+      };
+    }
+
+    case "tool.call.failed": {
+      const p = payload<ToolCallPayload>(event);
+      return {
+        id: event.EventID,
+        occurredAt: event.OccurredAt,
+        agentId: event.RunAgentID,
+        agentLabel: label,
+        line: `${label} hits a snag in ${p.tool_name ?? "a tool call"}.`,
+        detail: truncate(p.result?.content),
+        tone: "warning",
+      };
+    }
+
+    case "sandbox.command.started": {
+      const p = payload<SandboxCommandPayload>(event);
+      return {
+        id: event.EventID,
+        occurredAt: event.OccurredAt,
+        agentId: event.RunAgentID,
+        agentLabel: label,
+        line: `${label} drops into the sandbox.`,
+        detail: truncate(p.command, 72),
+        tone: "neutral",
+      };
+    }
+
+    case "scoring.started":
+      return {
+        id: event.EventID,
+        occurredAt: event.OccurredAt,
+        agentId: event.RunAgentID,
+        agentLabel: label,
+        line: `${label} heads to scoring.`,
+        tone: "neutral",
+      };
+
+    case "scoring.metric.recorded": {
+      const p = payload<ScoringMetricPayload>(event);
+      const score =
+        p.score != null ? `${Math.round(p.score * 100)}%` : undefined;
+      return {
+        id: event.EventID,
+        occurredAt: event.OccurredAt,
+        agentId: event.RunAgentID,
+        agentLabel: label,
+        line: `${label} posts ${
+          p.metric_key ?? "a metric"
+        }${score ? ` at ${score}` : ""}.`,
+        detail:
+          p.passed == null ? undefined : p.passed ? "Passed" : "Failed",
+        tone: p.passed === false ? "warning" : "positive",
+      };
+    }
+
+    case "system.run.completed":
+      return {
+        id: event.EventID,
+        occurredAt: event.OccurredAt,
+        agentId: event.RunAgentID,
+        agentLabel: label,
+        line: `${label} crosses the line with a final answer.`,
+        tone: "positive",
+      };
+
+    case "system.run.failed": {
+      const p = payload<RunFailedPayload>(event);
+      return {
+        id: event.EventID,
+        occurredAt: event.OccurredAt,
+        agentId: event.RunAgentID,
+        agentLabel: label,
+        line: `${label} drops out of the live run.`,
+        detail: truncate(p.error ?? p.stop_reason),
+        tone: "warning",
+      };
+    }
+
+    default:
+      return null;
+  }
+}
+
+function reducer(
+  state: CommentaryEntry[],
+  action: CommentaryAction,
+): CommentaryEntry[] {
+  switch (action.type) {
+    case "event": {
+      const entry = buildCommentaryEntry(action.event, action.agentLabel);
+      if (!entry || state.some((item) => item.id === entry.id)) {
+        return state;
+      }
+      const next = [...state, entry];
+      if (next.length > MAX_COMMENTARY_ENTRIES) {
+        next.splice(0, next.length - MAX_COMMENTARY_ENTRIES);
+      }
+      return next;
+    }
+
+    case "reset":
+      return [];
+  }
+}
+
+export interface UseAgentCommentaryResult {
+  entries: CommentaryEntry[];
+  handleEvent: (event: RunEvent) => void;
+  reset: () => void;
+}
+
+export function useAgentCommentary(
+  agents: RunAgent[],
+): UseAgentCommentaryResult {
+  const [entries, dispatch] = useReducer(reducer, []);
+
+  const handleEvent = useCallback(
+    (event: RunEvent) => {
+      const agentLabel =
+        agents.find((agent) => agent.id === event.RunAgentID)?.label ??
+        shortAgentLabel(event.RunAgentID);
+      dispatch({ type: "event", event, agentLabel });
+    },
+    [agents],
+  );
+
+  const reset = useCallback(() => {
+    dispatch({ type: "reset" });
+  }, []);
+
+  return { entries, handleEvent, reset };
+}

--- a/web/src/hooks/use-run-events.test.ts
+++ b/web/src/hooks/use-run-events.test.ts
@@ -1,0 +1,175 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  normalizeRunEvent,
+  useRunEvents,
+  type RunEvent,
+} from "./use-run-events";
+
+vi.stubEnv("NEXT_PUBLIC_API_URL", "https://api.agentclash.test");
+
+type EventListener = (event: MessageEvent) => void;
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  url: string;
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  close = vi.fn();
+  private listeners = new Map<string, EventListener[]>();
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const next = this.listeners.get(type) ?? [];
+    next.push(listener);
+    this.listeners.set(type, next);
+  }
+
+  emit(type: string, data: unknown) {
+    const event = { data: JSON.stringify(data) } as MessageEvent;
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+vi.stubGlobal("EventSource", MockEventSource as unknown as typeof EventSource);
+
+function HookHarness({
+  onEvent,
+}: {
+  onEvent: (event: RunEvent) => void;
+}) {
+  useRunEvents({
+    runId: "run-1",
+    token: "token-123",
+    enabled: true,
+    onEvent,
+  });
+  return null;
+}
+
+function renderHarness(onEvent: (event: RunEvent) => void) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+
+  act(() => {
+    root.render(React.createElement(HookHarness, { onEvent }));
+  });
+
+  return {
+    cleanup() {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+describe("normalizeRunEvent", () => {
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    document.body.innerHTML = "";
+  });
+
+  it("converts snake_case SSE envelopes into the frontend event shape", () => {
+    const event = normalizeRunEvent({
+      event_id: "evt-1",
+      schema_version: "2026-03-15",
+      run_id: "run-1",
+      run_agent_id: "agent-1",
+      sequence_number: 7,
+      event_type: "tool.call.started",
+      source: "native_engine",
+      occurred_at: "2026-04-22T12:00:00Z",
+      payload: { tool_name: "search_query" },
+      summary: { step_index: 3 },
+    });
+
+    expect(event).toEqual({
+      EventID: "evt-1",
+      SchemaVersion: "2026-03-15",
+      RunID: "run-1",
+      RunAgentID: "agent-1",
+      SequenceNumber: 7,
+      EventType: "tool.call.started",
+      Source: "native_engine",
+      OccurredAt: "2026-04-22T12:00:00Z",
+      Payload: { tool_name: "search_query" },
+      Summary: { step_index: 3 },
+    });
+  });
+
+  it("preserves already-normalized event objects", () => {
+    const event = normalizeRunEvent({
+      EventID: "evt-2",
+      SchemaVersion: "2026-03-15",
+      RunID: "run-1",
+      RunAgentID: "agent-2",
+      SequenceNumber: 9,
+      EventType: "system.run.completed",
+      Source: "worker_scoring",
+      OccurredAt: "2026-04-22T12:05:00Z",
+      Payload: { final_output: "done" },
+      Summary: { status: "completed" },
+    });
+
+    expect(event?.EventType).toBe("system.run.completed");
+    expect(event?.RunAgentID).toBe("agent-2");
+    expect(event?.Summary).toEqual({ status: "completed" });
+  });
+});
+
+describe("useRunEvents", () => {
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    document.body.innerHTML = "";
+  });
+
+  it("normalizes incoming run_event messages before invoking onEvent", () => {
+    const seen: RunEvent[] = [];
+    const { cleanup } = renderHarness((event) => {
+      seen.push(event);
+    });
+
+    const source = MockEventSource.instances[0];
+    expect(source?.url).toContain("/v1/runs/run-1/events/stream?token=token-123");
+
+    act(() => {
+      source.emit("run_event", {
+        event_id: "evt-9",
+        schema_version: "2026-03-15",
+        run_id: "run-1",
+        run_agent_id: "agent-9",
+        sequence_number: 11,
+        event_type: "model.call.started",
+        source: "native_engine",
+        occurred_at: "2026-04-22T12:10:00Z",
+        payload: {
+          provider_key: "openai",
+          provider_model_id: "gpt-5.4-mini",
+        },
+        summary: {},
+      });
+    });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({
+      EventID: "evt-9",
+      RunAgentID: "agent-9",
+      SequenceNumber: 11,
+      EventType: "model.call.started",
+    });
+
+    cleanup();
+  });
+});

--- a/web/src/hooks/use-run-events.ts
+++ b/web/src/hooks/use-run-events.ts
@@ -27,6 +27,75 @@ interface UseRunEventsResult {
   error: string | null;
 }
 
+function recordFromUnknown(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function stringField(
+  record: Record<string, unknown>,
+  ...keys: string[]
+): string {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string") return value;
+  }
+  return "";
+}
+
+function numberField(
+  record: Record<string, unknown>,
+  ...keys: string[]
+): number {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "string" && value.trim() !== "") {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  return 0;
+}
+
+function unknownField(
+  record: Record<string, unknown>,
+  ...keys: string[]
+): unknown {
+  for (const key of keys) {
+    if (key in record) return record[key];
+  }
+  return undefined;
+}
+
+export function normalizeRunEvent(value: unknown): RunEvent | null {
+  const record = recordFromUnknown(value);
+  if (!record) return null;
+
+  const summary = recordFromUnknown(
+    unknownField(record, "Summary", "summary"),
+  );
+
+  return {
+    EventID: stringField(record, "EventID", "event_id"),
+    SchemaVersion: stringField(record, "SchemaVersion", "schema_version"),
+    RunID: stringField(record, "RunID", "run_id"),
+    RunAgentID: stringField(record, "RunAgentID", "run_agent_id"),
+    SequenceNumber: numberField(
+      record,
+      "SequenceNumber",
+      "sequence_number",
+    ),
+    EventType: stringField(record, "EventType", "event_type"),
+    Source: stringField(record, "Source", "source"),
+    OccurredAt: stringField(record, "OccurredAt", "occurred_at"),
+    Payload: unknownField(record, "Payload", "payload") ?? {},
+    Summary: summary ?? {},
+  };
+}
+
 export function useRunEvents({
   runId,
   token,
@@ -56,8 +125,8 @@ export function useRunEvents({
 
     es.addEventListener("run_event", (e: MessageEvent) => {
       try {
-        const event: RunEvent = JSON.parse(e.data);
-        onEventRef.current?.(event);
+        const event = normalizeRunEvent(JSON.parse(e.data));
+        if (event) onEventRef.current?.(event);
       } catch {
         // Malformed event data, skip
       }


### PR DESCRIPTION
## What changed
- normalize incoming run SSE envelopes in the web client so the live arena consumes the backend's snake_case event wire format
- add focused tests for SSE normalization and the run-detail live event path
- add an optional commentary booth sidebar on the run detail page, enabled with a toggle and fed from the same live event stream
- add commentary helpers and UI for bounded, deduplicated play-by-play updates without any challenge-pack configuration changes

## Why
The live arena could show the run as `Live` while each lane stayed stuck because the frontend was reading `EventID`/`RunAgentID`/`EventType`, but the backend SSE stream is emitted as `event_id`/`run_agent_id`/`event_type`. As a result, events parsed but the live lane reducer saw empty fields and never advanced lane state.

## User impact
- live agent lanes now update correctly during active runs
- users can opt into a sidebar commentator feed for quick play-by-play context
- no backend contract or challenge-pack config changes are required

## Validation
- `cd web && npm test -- src/hooks/use-run-events.test.ts src/hooks/use-agent-commentary.test.ts 'src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.test.tsx'`
- `cd web && npm run lint -- src/hooks/use-run-events.ts src/hooks/use-run-events.test.ts src/hooks/use-agent-commentary.ts src/hooks/use-agent-commentary.test.ts src/components/arena/live-commentary-sidebar.tsx 'src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx' 'src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.test.tsx'`

## Notes
- manual browser smoke testing was not run in this pass
