### PR TITLE
feat(web): add race mode toggle for live run view

### DIFF
--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.test.tsx
@@ -19,6 +19,13 @@ vi.mock("@workos-inc/authkit-nextjs/components", () => ({
   useAccessToken: () => ({ getAccessToken: mockGetAccessToken }),
 }));
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn(), refresh: vi.fn() }),
+  usePathname: () =>
+    "/workspaces/workspace-1/runs/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
 vi.mock("@/hooks/use-run-events", async () => {
   const actual = await vi.importActual<typeof import("@/hooks/use-run-events")>(
     "@/hooks/use-run-events",

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
@@ -5,11 +5,13 @@ import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 
 import { LiveAgentLane } from "@/components/arena/live-agent-lane";
 import { LiveCommentarySidebar } from "@/components/arena/live-commentary-sidebar";
+import { RaceModeArena } from "@/components/arena/race-mode";
 import { UploadArtifactDialog } from "@/components/artifacts/upload-artifact-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useAgentArena, EMPTY_LANE } from "@/hooks/use-agent-arena";
 import { useAgentCommentary } from "@/hooks/use-agent-commentary";
+import { useArenaMode } from "@/hooks/use-arena-mode";
 import { useRunEvents, type RunEvent } from "@/hooks/use-run-events";
 import { createApiClient } from "@/lib/api/client";
 import { scorePercent } from "@/lib/scores";
@@ -41,6 +43,7 @@ import {
   AlertOctagon,
   Radio,
   MessageSquareText,
+  Flag,
 } from "lucide-react";
 
 import { CompareRunPicker } from "./compare-run-picker";
@@ -159,6 +162,7 @@ export function RunDetailClient({
     Record<string, ScorecardResponse | null>
   >({});
   const [showCommentary, setShowCommentary] = useState(false);
+  const [arenaMode, setArenaMode] = useArenaMode();
 
   const isActive =
     ACTIVE_RUN_STATUSES.includes(run.status) ||
@@ -364,6 +368,22 @@ export function RunDetailClient({
             <MessageSquareText className="size-3.5" />
             Commentary {showCommentary ? "On" : "Off"}
           </Button>
+          <Button
+            variant={arenaMode === "race" ? "default" : "outline"}
+            size="sm"
+            onClick={() =>
+              setArenaMode(arenaMode === "race" ? "dev" : "race")
+            }
+            aria-pressed={arenaMode === "race"}
+            title={
+              arenaMode === "race"
+                ? "Switch to development (classic) view"
+                : "Switch to race mode — the broadcast view"
+            }
+          >
+            <Flag className="size-3.5" />
+            {arenaMode === "race" ? "Race Mode" : "Dev Mode"}
+          </Button>
           <Link
             href={`/workspaces/${workspaceId}/runs/${run.id}/failures`}
             className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 h-8 text-xs text-muted-foreground hover:text-foreground hover:bg-muted/40 transition-colors"
@@ -414,55 +434,82 @@ export function RunDetailClient({
       {/* === Agent Lanes === */}
       <div>
         <h2 className="text-sm font-semibold mb-3">Agent Lanes</h2>
-        <div
-          className={`grid gap-4 ${
-            showCommentary
-              ? "grid-cols-1 xl:grid-cols-[minmax(0,2fr)_minmax(18rem,24rem)]"
-              : "grid-cols-1"
-          }`}
-        >
+        {arenaMode === "race" ? (
+          <RaceModeArena
+            agents={sortedAgents}
+            lanes={arenaLanes}
+            workspaceId={workspaceId}
+            runId={run.id}
+            winnerAgentId={ranking?.ranking?.winner?.run_agent_id}
+            showCommentary={showCommentary}
+            commentaryEntries={commentaryEntries}
+            isActive={isActive}
+            laneFooters={Object.fromEntries(
+              sortedAgents
+                .filter(
+                  (a) => a.status === "completed" || a.status === "failed",
+                )
+                .map((a) => [
+                  a.id,
+                  <ScorecardSummaryCard
+                    key={a.id}
+                    scorecard={scorecards[a.id] ?? null}
+                    loading={!(a.id in scorecards)}
+                  />,
+                ]),
+            )}
+          />
+        ) : (
           <div
-            className={`grid gap-3 ${
-              agents.length === 1
-                ? "grid-cols-1"
-                : "grid-cols-1 md:grid-cols-2"
+            className={`grid gap-4 ${
+              showCommentary
+                ? "grid-cols-1 xl:grid-cols-[minmax(0,2fr)_minmax(18rem,24rem)]"
+                : "grid-cols-1"
             }`}
           >
-            {sortedAgents.map((agent) => {
-              const isWinner =
-                ranking?.ranking?.winner?.run_agent_id === agent.id;
-              const laneState = arenaLanes[agent.id] ?? EMPTY_LANE;
-              const isTerminal =
-                agent.status === "completed" || agent.status === "failed";
-              const footer = isTerminal ? (
-                <ScorecardSummaryCard
-                  scorecard={scorecards[agent.id] ?? null}
-                  loading={!(agent.id in scorecards)}
-                />
-              ) : null;
+            <div
+              className={`grid gap-3 ${
+                agents.length === 1
+                  ? "grid-cols-1"
+                  : "grid-cols-1 md:grid-cols-2"
+              }`}
+            >
+              {sortedAgents.map((agent) => {
+                const isWinner =
+                  ranking?.ranking?.winner?.run_agent_id === agent.id;
+                const laneState = arenaLanes[agent.id] ?? EMPTY_LANE;
+                const isTerminal =
+                  agent.status === "completed" || agent.status === "failed";
+                const footer = isTerminal ? (
+                  <ScorecardSummaryCard
+                    scorecard={scorecards[agent.id] ?? null}
+                    loading={!(agent.id in scorecards)}
+                  />
+                ) : null;
 
-              return (
-                <LiveAgentLane
-                  key={agent.id}
-                  agent={agent}
-                  lane={laneState}
-                  isWinner={isWinner}
-                  workspaceId={workspaceId}
-                  runId={run.id}
-                  footer={footer}
-                />
-              );
-            })}
-          </div>
-          {showCommentary && (
-            <div className="xl:sticky xl:top-4 xl:self-start">
-              <LiveCommentarySidebar
-                entries={commentaryEntries}
-                isActive={isActive}
-              />
+                return (
+                  <LiveAgentLane
+                    key={agent.id}
+                    agent={agent}
+                    lane={laneState}
+                    isWinner={isWinner}
+                    workspaceId={workspaceId}
+                    runId={run.id}
+                    footer={footer}
+                  />
+                );
+              })}
             </div>
-          )}
-        </div>
+            {showCommentary && (
+              <div className="xl:sticky xl:top-4 xl:self-start">
+                <LiveCommentarySidebar
+                  entries={commentaryEntries}
+                  isActive={isActive}
+                />
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       {run.regression_coverage &&

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,5 +1,12 @@
 import type { Metadata } from "next";
-import { Instrument_Serif, DM_Sans, IBM_Plex_Mono, Geist } from "next/font/google";
+import {
+  Instrument_Serif,
+  DM_Sans,
+  IBM_Plex_Mono,
+  Geist,
+  Geist_Mono,
+  Fraunces,
+} from "next/font/google";
 import { Analytics } from "@vercel/analytics/react";
 import { AuthKitProvider } from "@workos-inc/authkit-nextjs/components";
 import { Toaster } from "@/components/ui/sonner";
@@ -23,6 +30,19 @@ const ibmPlexMono = IBM_Plex_Mono({
   subsets: ["latin"],
   variable: "--font-mono",
   weight: ["400", "500"],
+});
+
+// Race-mode typography — loaded eagerly so the toggle is instant when flipped.
+const fraunces = Fraunces({
+  subsets: ["latin"],
+  variable: "--font-race-display",
+  style: ["normal", "italic"],
+  axes: ["SOFT", "WONK", "opsz"],
+});
+
+const geistMono = Geist_Mono({
+  subsets: ["latin"],
+  variable: "--font-race-mono",
 });
 
 const siteUrl = "https://agentclash.dev";
@@ -96,7 +116,7 @@ export default function RootLayout({
   return (
     <html lang="en" className={cn("dark font-sans", geist.variable)}>
       <body
-        className={`${instrumentSerif.variable} ${dmSans.variable} ${ibmPlexMono.variable}`}
+        className={`${instrumentSerif.variable} ${dmSans.variable} ${ibmPlexMono.variable} ${fraunces.variable} ${geistMono.variable}`}
       >
         <AuthKitProvider>{children}</AuthKitProvider>
         <Toaster position="bottom-right" />

--- a/web/src/components/arena/race-mode/index.tsx
+++ b/web/src/components/arena/race-mode/index.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useMemo } from "react";
+
+import type { RunAgent } from "@/lib/api/types";
+import type { ArenaLaneState } from "@/hooks/use-agent-arena";
+import { EMPTY_LANE } from "@/hooks/use-agent-arena";
+import type { CommentaryEntry } from "@/hooks/use-agent-commentary";
+
+import { RaceCommentary } from "./race-commentary";
+import { RaceLane } from "./race-lane";
+import { RaceTrack } from "./race-track";
+
+import "./race-mode.css";
+
+interface RaceModeArenaProps {
+  agents: RunAgent[];
+  lanes: Record<string, ArenaLaneState>;
+  workspaceId: string;
+  runId: string;
+  winnerAgentId?: string;
+  showCommentary: boolean;
+  commentaryEntries: CommentaryEntry[];
+  isActive: boolean;
+  /** Map of agent.id → terminal-only footer node (scorecard, etc.). */
+  laneFooters?: Record<string, React.ReactNode>;
+}
+
+export function RaceModeArena({
+  agents,
+  lanes,
+  workspaceId,
+  runId,
+  winnerAgentId,
+  showCommentary,
+  commentaryEntries,
+  isActive,
+  laneFooters,
+}: RaceModeArenaProps) {
+  const ranked = useMemo(() => rankAgents(agents, lanes), [agents, lanes]);
+
+  return (
+    <div className="race-mode-root">
+      <RaceTrack
+        agents={agents}
+        lanes={lanes}
+        winnerAgentId={winnerAgentId}
+      />
+
+      <div
+        className={`rm-grid${showCommentary ? " rm-grid--with-booth" : ""}`}
+      >
+        <div className="rm-lanes">
+          {ranked.map(({ agent, position }) => (
+            <RaceLane
+              key={agent.id}
+              agent={agent}
+              lane={lanes[agent.id] ?? EMPTY_LANE}
+              position={position}
+              isWinner={
+                winnerAgentId
+                  ? agent.id === winnerAgentId
+                  : position === 1 && agent.status !== "failed"
+              }
+              workspaceId={workspaceId}
+              runId={runId}
+              footer={laneFooters?.[agent.id] ?? null}
+            />
+          ))}
+        </div>
+        {showCommentary && (
+          <RaceCommentary
+            entries={commentaryEntries}
+            isActive={isActive}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function rankAgents(
+  agents: RunAgent[],
+  lanes: Record<string, ArenaLaneState>,
+): { agent: RunAgent; position: number }[] {
+  const sorted = [...agents].sort((a, b) => {
+    const aFailed = a.status === "failed" ? 1 : 0;
+    const bFailed = b.status === "failed" ? 1 : 0;
+    if (aFailed !== bFailed) return aFailed - bFailed;
+    const aStep = lanes[a.id]?.stepIndex ?? 0;
+    const bStep = lanes[b.id]?.stepIndex ?? 0;
+    if (aStep !== bStep) return bStep - aStep;
+    const aCalls = lanes[a.id]?.modelCalls ?? 0;
+    const bCalls = lanes[b.id]?.modelCalls ?? 0;
+    if (aCalls !== bCalls) return bCalls - aCalls;
+    return a.lane_index - b.lane_index;
+  });
+  return sorted.map((agent, i) => ({ agent, position: i + 1 }));
+}

--- a/web/src/components/arena/race-mode/index.tsx
+++ b/web/src/components/arena/race-mode/index.tsx
@@ -10,6 +10,7 @@ import type { CommentaryEntry } from "@/hooks/use-agent-commentary";
 import { RaceCommentary } from "./race-commentary";
 import { RaceLane } from "./race-lane";
 import { RaceTrack } from "./race-track";
+import { computeTargetSteps, deriveLeader, rankAgents } from "./utils";
 
 import "./race-mode.css";
 
@@ -37,13 +38,19 @@ export function RaceModeArena({
   isActive,
   laneFooters,
 }: RaceModeArenaProps) {
+  // Compute once; track + every lane row render against the same numbers.
   const ranked = useMemo(() => rankAgents(agents, lanes), [agents, lanes]);
+  const targetSteps = useMemo(
+    () => computeTargetSteps(agents, lanes),
+    [agents, lanes],
+  );
 
   return (
     <div className="race-mode-root">
       <RaceTrack
-        agents={agents}
+        ranked={ranked}
         lanes={lanes}
+        targetSteps={targetSteps}
         winnerAgentId={winnerAgentId}
       />
 
@@ -57,11 +64,8 @@ export function RaceModeArena({
               agent={agent}
               lane={lanes[agent.id] ?? EMPTY_LANE}
               position={position}
-              isWinner={
-                winnerAgentId
-                  ? agent.id === winnerAgentId
-                  : position === 1 && agent.status !== "failed"
-              }
+              isWinner={deriveLeader(agent, position, winnerAgentId)}
+              targetSteps={targetSteps}
               workspaceId={workspaceId}
               runId={runId}
               footer={laneFooters?.[agent.id] ?? null}
@@ -77,23 +81,4 @@ export function RaceModeArena({
       </div>
     </div>
   );
-}
-
-function rankAgents(
-  agents: RunAgent[],
-  lanes: Record<string, ArenaLaneState>,
-): { agent: RunAgent; position: number }[] {
-  const sorted = [...agents].sort((a, b) => {
-    const aFailed = a.status === "failed" ? 1 : 0;
-    const bFailed = b.status === "failed" ? 1 : 0;
-    if (aFailed !== bFailed) return aFailed - bFailed;
-    const aStep = lanes[a.id]?.stepIndex ?? 0;
-    const bStep = lanes[b.id]?.stepIndex ?? 0;
-    if (aStep !== bStep) return bStep - aStep;
-    const aCalls = lanes[a.id]?.modelCalls ?? 0;
-    const bCalls = lanes[b.id]?.modelCalls ?? 0;
-    if (aCalls !== bCalls) return bCalls - aCalls;
-    return a.lane_index - b.lane_index;
-  });
-  return sorted.map((agent, i) => ({ agent, position: i + 1 }));
 }

--- a/web/src/components/arena/race-mode/race-commentary.tsx
+++ b/web/src/components/arena/race-mode/race-commentary.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import {
+  MAX_COMMENTARY_ENTRIES,
+  type CommentaryEntry,
+} from "@/hooks/use-agent-commentary";
+
+interface RaceCommentaryProps {
+  entries: CommentaryEntry[];
+  isActive: boolean;
+}
+
+export function RaceCommentary({ entries, isActive }: RaceCommentaryProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const recent = entries.slice(-MAX_COMMENTARY_ENTRIES);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [recent.length]);
+
+  return (
+    <aside className="rm-booth" aria-label="Commentary booth">
+      <header className="rm-booth__head">
+        <div>
+          <h2 className="rm-booth__title">Commentary</h2>
+          <div className="rm-booth__sub">
+            <span>
+              {recent.length} / {MAX_COMMENTARY_ENTRIES} transmissions
+            </span>
+          </div>
+        </div>
+        <div
+          className={`rm-onair${isActive ? "" : " rm-onair--off"}`}
+          aria-label={isActive ? "on air" : "off air"}
+        >
+          <span className="rm-onair__led" />
+          {isActive ? "On Air" : "Off"}
+        </div>
+      </header>
+
+      {recent.length === 0 ? (
+        <div className="rm-xmits--empty">
+          {isActive
+            ? "Standing by. Transmissions appear here as events arrive."
+            : "Commentary is off."}
+        </div>
+      ) : (
+        <div ref={scrollRef} className="rm-xmits">
+          {recent.map((entry) => {
+            const cls = [
+              "rm-xmit",
+              entry.tone === "positive" && "rm-xmit--positive",
+              entry.tone === "warning" && "rm-xmit--warning",
+            ]
+              .filter(Boolean)
+              .join(" ");
+            return (
+              <article key={entry.id} className={cls}>
+                <div className="rm-xmit__head">
+                  <span className="rm-xmit__caller" title={entry.agentLabel}>
+                    {entry.agentLabel}
+                  </span>
+                  <span className="rm-xmit__time">
+                    {formatClock(entry.occurredAt)}
+                  </span>
+                </div>
+                <div className="rm-xmit__line">{entry.line}</div>
+                {entry.detail && (
+                  <div className="rm-xmit__detail">{entry.detail}</div>
+                )}
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </aside>
+  );
+}
+
+function formatClock(iso: string): string {
+  const d = new Date(iso);
+  const h = d.getUTCHours().toString().padStart(2, "0");
+  const m = d.getUTCMinutes().toString().padStart(2, "0");
+  const s = d.getUTCSeconds().toString().padStart(2, "0");
+  return `${h}:${m}:${s}`;
+}

--- a/web/src/components/arena/race-mode/race-lane.tsx
+++ b/web/src/components/arena/race-mode/race-lane.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Play, CheckCircle2, Upload } from "lucide-react";
 
@@ -13,13 +14,13 @@ const ACTIVE_STATUSES: RunAgentStatus[] = [
   "evaluating",
 ];
 
-const TARGET_STEPS = 12;
-
 interface RaceLaneProps {
   agent: RunAgent;
   lane: ArenaLaneState;
   position: number;
   isWinner: boolean;
+  /** Shared across track + lane — parent computes once. */
+  targetSteps: number;
   workspaceId: string;
   runId: string;
   /** Terminal-only content (e.g. scorecard summary). */
@@ -31,12 +32,17 @@ export function RaceLane({
   lane,
   position,
   isWinner,
+  targetSteps,
   workspaceId,
   runId,
   footer,
 }: RaceLaneProps) {
   const isActive = ACTIVE_STATUSES.includes(agent.status);
   const isFailed = agent.status === "failed";
+
+  // Keep the elapsed clock ticking between SSE events. One timer per live
+  // lane, cleared the moment it goes terminal.
+  useElapsedTick(isActive && !agent.finished_at);
 
   const laneClass = [
     "rm-lane",
@@ -48,7 +54,7 @@ export function RaceLane({
     .join(" ");
 
   const stepCount = Math.max(lane.stepIndex, 0);
-  const stepProgress = Math.min(stepCount, TARGET_STEPS);
+  const stepProgress = Math.min(stepCount, targetSteps);
 
   return (
     <article className={laneClass}>
@@ -75,7 +81,9 @@ export function RaceLane({
               {lane.stepIndex > 0 && (
                 <>
                   <span className="rm-dot" />
-                  <span>step {lane.stepIndex}</span>
+                  <span>
+                    step {lane.stepIndex} / {targetSteps}
+                  </span>
                 </>
               )}
               {lane.modelCalls > 0 && (
@@ -92,9 +100,9 @@ export function RaceLane({
           </div>
         </header>
 
-        {/* Step progress — 12 segments */}
+        {/* Step progress — targetSteps segments, agreeing with the track */}
         <div className="rm-lane__steps" aria-label="Step progress">
-          {Array.from({ length: TARGET_STEPS }).map((_, i) => {
+          {Array.from({ length: targetSteps }).map((_, i) => {
             let cls = "rm-step";
             if (i < stepProgress - 1) cls += " rm-step--done";
             else if (i === stepProgress - 1 && isActive)
@@ -212,6 +220,16 @@ export function RaceLane({
       </div>
     </article>
   );
+}
+
+/** Forces a re-render every second while active so elapsed never freezes. */
+function useElapsedTick(enabled: boolean): void {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!enabled) return;
+    const id = window.setInterval(() => setTick((n) => n + 1), 1000);
+    return () => window.clearInterval(id);
+  }, [enabled]);
 }
 
 function formatElapsed(start?: string, end?: string): string {

--- a/web/src/components/arena/race-mode/race-lane.tsx
+++ b/web/src/components/arena/race-mode/race-lane.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import Link from "next/link";
+import { Play, CheckCircle2, Upload } from "lucide-react";
+
+import type { RunAgent, RunAgentStatus } from "@/lib/api/types";
+import type { ArenaLaneState } from "@/hooks/use-agent-arena";
+
+const ACTIVE_STATUSES: RunAgentStatus[] = [
+  "queued",
+  "ready",
+  "executing",
+  "evaluating",
+];
+
+const TARGET_STEPS = 12;
+
+interface RaceLaneProps {
+  agent: RunAgent;
+  lane: ArenaLaneState;
+  position: number;
+  isWinner: boolean;
+  workspaceId: string;
+  runId: string;
+  /** Terminal-only content (e.g. scorecard summary). */
+  footer?: React.ReactNode;
+}
+
+export function RaceLane({
+  agent,
+  lane,
+  position,
+  isWinner,
+  workspaceId,
+  runId,
+  footer,
+}: RaceLaneProps) {
+  const isActive = ACTIVE_STATUSES.includes(agent.status);
+  const isFailed = agent.status === "failed";
+
+  const laneClass = [
+    "rm-lane",
+    isActive && "rm-lane--active",
+    isWinner && "rm-lane--winner",
+    isFailed && "rm-lane--failed",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const stepCount = Math.max(lane.stepIndex, 0);
+  const stepProgress = Math.min(stepCount, TARGET_STEPS);
+
+  return (
+    <article className={laneClass}>
+      <div className="rm-lane__rank">
+        <span className="rm-lane__rank-pos">{position}</span>
+        <span className="rm-lane__delta">
+          #{agent.lane_index} · {agent.status}
+        </span>
+      </div>
+
+      <div className="rm-lane__content">
+        <header className="rm-lane__head">
+          <div>
+            <h3 className="rm-lane__name">
+              {agent.label}
+              {isWinner && (
+                <span className="rm-lane__leader-tag">Leader</span>
+              )}
+            </h3>
+            <div className="rm-lane__meta">
+              {agent.started_at && (
+                <span>{formatElapsed(agent.started_at, agent.finished_at)}</span>
+              )}
+              {lane.stepIndex > 0 && (
+                <>
+                  <span className="rm-dot" />
+                  <span>step {lane.stepIndex}</span>
+                </>
+              )}
+              {lane.modelCalls > 0 && (
+                <>
+                  <span className="rm-dot" />
+                  <span>{lane.modelCalls} model calls</span>
+                </>
+              )}
+            </div>
+          </div>
+          <div className="rm-lane__status">
+            <span className="rm-lane__status-pulse" />
+            {agent.status}
+          </div>
+        </header>
+
+        {/* Step progress — 12 segments */}
+        <div className="rm-lane__steps" aria-label="Step progress">
+          {Array.from({ length: TARGET_STEPS }).map((_, i) => {
+            let cls = "rm-step";
+            if (i < stepProgress - 1) cls += " rm-step--done";
+            else if (i === stepProgress - 1 && isActive)
+              cls += " rm-step--current";
+            else if (i === stepProgress - 1 && !isActive)
+              cls += " rm-step--done";
+            return <span key={i} className={cls} />;
+          })}
+        </div>
+
+        <div className="rm-tele">
+          <div className="rm-tele__item">
+            <label>Elapsed</label>
+            <div className="rm-val">
+              {agent.started_at
+                ? formatElapsed(agent.started_at, agent.finished_at)
+                : "—"}
+            </div>
+          </div>
+          <div className="rm-tele__item">
+            <label>Model calls</label>
+            <div className="rm-val">{lane.modelCalls}</div>
+          </div>
+          <div className="rm-tele__item">
+            <label>Tool calls</label>
+            <div className="rm-val">{lane.toolCalls}</div>
+          </div>
+          <div className="rm-tele__item">
+            <label>Tokens</label>
+            <div className="rm-val">{compactNumber(lane.totalTokens)}</div>
+          </div>
+          <div className="rm-tele__item">
+            <label>Score</label>
+            <div
+              className={
+                lane.lastMetric?.score != null
+                  ? "rm-val rm-val--go"
+                  : "rm-val"
+              }
+            >
+              {lane.lastMetric?.score != null
+                ? lane.lastMetric.score.toFixed(2)
+                : "—"}
+            </div>
+          </div>
+        </div>
+
+        {isActive && (
+          <div className="rm-now">
+            <span className="rm-now__tag">
+              <span className="rm-wave" aria-hidden="true">
+                <span />
+                <span />
+                <span />
+                <span />
+                <span />
+              </span>
+              Now
+            </span>
+            <div className="rm-now__text">
+              {lane.nowDoing ? (
+                <>
+                  <span>{lane.nowDoing.label}</span>
+                  {lane.nowDoing.detail && (
+                    <span className="rm-now__obj" title={lane.nowDoing.detail}>
+                      {lane.nowDoing.detail}
+                    </span>
+                  )}
+                </>
+              ) : (
+                <span>Standing by…</span>
+              )}
+            </div>
+          </div>
+        )}
+
+        {isActive && lane.streamingOutput && (
+          <div className="rm-stream">{lane.streamingOutput}</div>
+        )}
+
+        {isFailed && agent.failure_reason && (
+          <div className="rm-fail">
+            <div className="rm-fail__ic" aria-hidden="true">
+              !
+            </div>
+            <div className="rm-fail__body">
+              <strong>Failed</strong>
+              <p>{agent.failure_reason}</p>
+            </div>
+          </div>
+        )}
+
+        {!isActive && footer}
+
+        <footer className="rm-lane__foot">
+          <Link
+            href={`/workspaces/${workspaceId}/runs/${runId}/agents/${agent.id}/replay`}
+          >
+            <Play className="size-3" />
+            Replay
+          </Link>
+          <Link
+            href={`/workspaces/${workspaceId}/runs/${runId}/agents/${agent.id}/scorecard`}
+          >
+            <CheckCircle2 className="size-3" />
+            Scorecard
+          </Link>
+          <Link
+            href={`/workspaces/${workspaceId}/runs/${runId}?upload=${agent.id}`}
+          >
+            <Upload className="size-3" />
+            Upload
+          </Link>
+        </footer>
+      </div>
+    </article>
+  );
+}
+
+function formatElapsed(start?: string, end?: string): string {
+  if (!start) return "—";
+  const startMs = new Date(start).getTime();
+  const endMs = end ? new Date(end).getTime() : Date.now();
+  const ms = Math.max(0, endMs - startMs);
+  if (ms < 1000) return "<1s";
+  const secs = Math.floor(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  return `${mins}m ${secs % 60}s`;
+}
+
+function compactNumber(n: number): string {
+  if (n < 1000) return n.toString();
+  if (n < 1_000_000)
+    return (n / 1000).toFixed(1).replace(/\.0$/, "") + "k";
+  return (n / 1_000_000).toFixed(1).replace(/\.0$/, "") + "M";
+}

--- a/web/src/components/arena/race-mode/race-mode.css
+++ b/web/src/components/arena/race-mode/race-mode.css
@@ -366,8 +366,6 @@
   border: 1px solid var(--rm-rule-weak);
   font-variant-numeric: tabular-nums;
 }
-.rm-lane__delta--up { color: var(--rm-go); background: var(--rm-go-bg); border-color: rgba(109, 191, 145, 0.2); }
-.rm-lane__delta--down { color: var(--rm-danger); background: var(--rm-danger-bg); border-color: rgba(229, 97, 79, 0.2); }
 
 .rm-lane__content { display: flex; flex-direction: column; min-width: 0; }
 

--- a/web/src/components/arena/race-mode/race-mode.css
+++ b/web/src/components/arena/race-mode/race-mode.css
@@ -1,0 +1,813 @@
+/* ==========================================================
+   RACE MODE
+   Scoped under .race-mode-root so nothing leaks into dev UI.
+   Signal-lime accent on near-black with editorial serif display.
+   ========================================================== */
+
+.race-mode-root {
+  /* Palette (scoped overrides) */
+  --rm-bg: #050506;
+  --rm-bg-raised: #0c0c0d;
+  --rm-bg-elevated: #141416;
+  --rm-bg-input: #08080a;
+
+  --rm-text-1: rgba(255, 255, 255, 0.98);
+  --rm-text-2: rgba(255, 255, 255, 0.64);
+  --rm-text-3: rgba(255, 255, 255, 0.40);
+  --rm-text-4: rgba(255, 255, 255, 0.22);
+
+  --rm-rule-weak: rgba(255, 255, 255, 0.05);
+  --rm-rule: rgba(255, 255, 255, 0.09);
+  --rm-rule-strong: rgba(255, 255, 255, 0.18);
+  --rm-rule-signal: rgba(191, 255, 60, 0.34);
+
+  --rm-signal: #c7ff3c;
+  --rm-signal-hi: #dfff7a;
+  --rm-signal-bg: rgba(191, 255, 60, 0.08);
+  --rm-signal-glow: rgba(191, 255, 60, 0.40);
+  --rm-signal-ink: #0b1800;
+
+  --rm-go: #6dbf91;
+  --rm-go-bg: rgba(109, 191, 145, 0.08);
+  --rm-go-glow: rgba(109, 191, 145, 0.4);
+
+  --rm-danger: #e5614f;
+  --rm-danger-bg: rgba(229, 97, 79, 0.08);
+
+  --rm-warn: #f2c879;
+  --rm-warn-bg: rgba(242, 200, 121, 0.08);
+
+  /* Fonts — loaded at root layout level as CSS vars */
+  --rm-font-display: var(--font-race-display), ui-serif, Georgia, serif;
+  --rm-font-mono: var(--font-race-mono), ui-monospace, "SF Mono", monospace;
+  --rm-font-body: var(--font-sans), ui-sans-serif, system-ui, sans-serif;
+
+  background: var(--rm-bg);
+  color: var(--rm-text-1);
+  font-family: var(--rm-font-body);
+  border-radius: 12px;
+  border: 1px solid var(--rm-rule);
+  overflow: hidden;
+  position: relative;
+}
+
+/* Subtle ambient lime halos — anchored to corners, not a full wash */
+.race-mode-root::before {
+  content: "";
+  position: absolute; inset: 0;
+  background:
+    radial-gradient(ellipse 36rem 22rem at 8% -4%, rgba(199, 255, 60, 0.05), transparent 60%),
+    radial-gradient(ellipse 30rem 22rem at 92% 104%, rgba(199, 255, 60, 0.035), transparent 60%);
+  pointer-events: none;
+  z-index: 0;
+}
+.race-mode-root > * { position: relative; z-index: 1; }
+
+/* =========================================================
+   RACE TRACK — unified horizontal timeline
+   ========================================================= */
+
+.rm-track {
+  padding: 24px 28px 22px;
+  border-bottom: 1px solid var(--rm-rule);
+  background:
+    radial-gradient(ellipse 60rem 18rem at 100% 50%, rgba(199, 255, 60, 0.04), transparent 60%);
+}
+
+.rm-track__head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  margin-bottom: 20px;
+  padding-bottom: 12px;
+  border-bottom: 1px dashed var(--rm-rule-weak);
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.rm-track__title {
+  font-family: var(--rm-font-display);
+  font-style: italic;
+  font-weight: 500;
+  font-size: 20px;
+  color: var(--rm-text-1);
+  letter-spacing: -0.01em;
+  font-variation-settings: "opsz" 72, "SOFT" 100, "WONK" 1;
+  margin: 0;
+}
+
+.rm-track__meta {
+  font-family: var(--rm-font-mono);
+  font-size: 11px;
+  color: var(--rm-text-3);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-variant-numeric: tabular-nums;
+  display: inline-flex; gap: 12px; align-items: center;
+}
+.rm-track__meta .rm-sep { color: var(--rm-text-4); }
+.rm-track__meta .rm-finish {
+  color: var(--rm-text-2);
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.rm-track__meta .rm-finish::after {
+  content: "";
+  width: 10px; height: 10px;
+  background:
+    linear-gradient(45deg, var(--rm-text-1) 25%, transparent 25%, transparent 75%, var(--rm-text-1) 75%),
+    linear-gradient(45deg, var(--rm-text-1) 25%, transparent 25%, transparent 75%, var(--rm-text-1) 75%) 5px 5px,
+    var(--rm-text-4);
+  background-size: 10px 10px;
+  border-radius: 1px;
+  opacity: 0.8;
+}
+
+.rm-track__body { display: flex; flex-direction: column; gap: 10px; }
+
+.rm-track-row {
+  display: grid;
+  grid-template-columns: 28px minmax(96px, 140px) 1fr 92px;
+  gap: 14px;
+  align-items: center;
+  height: 34px;
+}
+
+.rm-track-row__pos {
+  font-family: var(--rm-font-display);
+  font-style: italic;
+  font-weight: 500;
+  font-size: 22px;
+  color: var(--rm-text-1);
+  letter-spacing: -0.03em;
+  font-variant-numeric: tabular-nums lining-nums;
+  font-variation-settings: "opsz" 72, "SOFT" 100, "WONK" 1;
+}
+.rm-track-row--leader .rm-track-row__pos { color: var(--rm-go); }
+.rm-track-row--failed .rm-track-row__pos { color: var(--rm-text-4); }
+
+.rm-track-row__name {
+  font-family: var(--rm-font-mono);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--rm-text-1);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.rm-track-row--failed .rm-track-row__name { color: var(--rm-text-3); }
+
+.rm-track-row__lane {
+  position: relative;
+  height: 18px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      transparent 0,
+      transparent calc(8.333% - 1px),
+      rgba(255, 255, 255, 0.08) calc(8.333% - 1px),
+      rgba(255, 255, 255, 0.08) 8.333%
+    ),
+    rgba(255, 255, 255, 0.03);
+  border-left: 1px solid var(--rm-rule);
+  border-right: 2px solid var(--rm-text-2);
+  border-radius: 2px;
+}
+/* Finish line — real checkered pattern */
+.rm-track-row__lane::after {
+  content: "";
+  position: absolute;
+  top: 0; right: -2px; bottom: 0;
+  width: 8px;
+  background:
+    linear-gradient(45deg, var(--rm-text-1) 25%, transparent 25%, transparent 75%, var(--rm-text-1) 75%),
+    linear-gradient(45deg, var(--rm-text-1) 25%, transparent 25%, transparent 75%, var(--rm-text-1) 75%) 3px 3px,
+    var(--rm-bg);
+  background-size: 6px 6px;
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.rm-track-row__fill {
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  background: linear-gradient(90deg, rgba(199, 255, 60, 0.04), var(--rm-signal-bg) 60%, var(--rm-signal-bg));
+  border-right: 1px solid var(--rm-signal);
+  box-shadow: 4px 0 24px var(--rm-signal-glow);
+  transition: width 0.6s cubic-bezier(.2,.8,.2,1);
+}
+.rm-track-row--leader .rm-track-row__fill {
+  background: linear-gradient(90deg, rgba(109, 191, 145, 0.04), rgba(109, 191, 145, 0.14) 60%, rgba(109, 191, 145, 0.18));
+  border-right: 1px solid var(--rm-go);
+  box-shadow: 4px 0 24px var(--rm-go-glow);
+}
+.rm-track-row--failed .rm-track-row__fill {
+  background: linear-gradient(90deg, rgba(229, 97, 79, 0.04), rgba(229, 97, 79, 0.12));
+  border-right: 1px dashed var(--rm-danger);
+  box-shadow: none;
+}
+
+.rm-track-row__dot {
+  position: absolute;
+  top: 50%; transform: translate(-50%, -50%);
+  width: 14px; height: 14px;
+  border-radius: 99px;
+  background: var(--rm-signal);
+  box-shadow:
+    0 0 0 3px var(--rm-bg),
+    0 0 18px var(--rm-signal-glow),
+    0 0 36px var(--rm-signal-glow);
+  z-index: 2;
+  animation: rm-dot-pulse 1.6s ease-in-out infinite;
+}
+@keyframes rm-dot-pulse {
+  0%, 100% { box-shadow: 0 0 0 3px var(--rm-bg), 0 0 18px var(--rm-signal-glow), 0 0 36px var(--rm-signal-glow); }
+  50%      { box-shadow: 0 0 0 3px var(--rm-bg), 0 0 26px var(--rm-signal-glow), 0 0 52px var(--rm-signal-glow); }
+}
+.rm-track-row--leader .rm-track-row__dot {
+  background: var(--rm-go);
+  box-shadow:
+    0 0 0 3px var(--rm-bg),
+    0 0 22px var(--rm-go-glow),
+    0 0 44px var(--rm-go-glow);
+  animation: none;
+}
+.rm-track-row--leader .rm-track-row__dot::before {
+  content: "";
+  position: absolute;
+  inset: -3px;
+  border-radius: 99px;
+  border: 1px solid var(--rm-go);
+  animation: rm-orbit 2.2s ease-in-out infinite;
+}
+@keyframes rm-orbit {
+  0%, 100% { transform: scale(1);   opacity: 1; }
+  50%      { transform: scale(1.6); opacity: 0; }
+}
+.rm-track-row--failed .rm-track-row__dot {
+  background: transparent;
+  border: 1px solid var(--rm-danger);
+  box-shadow: 0 0 0 3px var(--rm-bg);
+  animation: none;
+}
+.rm-track-row--failed .rm-track-row__dot::before,
+.rm-track-row--failed .rm-track-row__dot::after {
+  content: "";
+  position: absolute;
+  top: 50%; left: 50%;
+  width: 8px; height: 1.5px;
+  background: var(--rm-danger);
+}
+.rm-track-row--failed .rm-track-row__dot::before { transform: translate(-50%, -50%) rotate(45deg); }
+.rm-track-row--failed .rm-track-row__dot::after  { transform: translate(-50%, -50%) rotate(-45deg); }
+
+.rm-track-row__wake {
+  position: absolute;
+  top: 50%; transform: translateY(-50%);
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--rm-signal));
+  opacity: 0.6;
+  z-index: 1;
+  pointer-events: none;
+}
+.rm-track-row--leader .rm-track-row__wake {
+  background: linear-gradient(90deg, transparent, var(--rm-go));
+}
+.rm-track-row--failed .rm-track-row__wake { display: none; }
+
+.rm-track-row__step {
+  font-family: var(--rm-font-mono);
+  font-size: 12px;
+  color: var(--rm-text-1);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+  display: flex; align-items: center; gap: 8px;
+  justify-content: flex-end;
+}
+
+/* =========================================================
+   LANE — full-bleed row, watermark rank, racing stripe
+   ========================================================= */
+
+.rm-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0;
+}
+.rm-grid--with-booth {
+  grid-template-columns: minmax(0, 1fr) 360px;
+}
+@media (max-width: 1200px) {
+  .rm-grid--with-booth { grid-template-columns: 1fr; }
+}
+
+.rm-lanes { display: flex; flex-direction: column; }
+
+.rm-lane {
+  position: relative;
+  padding: 22px 24px 20px 0;
+  border-bottom: 1px solid var(--rm-rule-weak);
+  transition: background 0.25s ease;
+  display: grid;
+  grid-template-columns: 132px 1fr;
+  gap: 20px;
+}
+.rm-lane:last-child { border-bottom: 0; }
+.rm-lane::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 3px;
+  background: var(--rm-text-4);
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+.rm-lane--active::before { background: var(--rm-signal); box-shadow: 0 0 24px var(--rm-signal-glow); }
+.rm-lane--winner::before { background: var(--rm-go); box-shadow: 0 0 24px var(--rm-go-glow); }
+.rm-lane--failed::before { background: var(--rm-danger); box-shadow: none; }
+
+.rm-lane--active {
+  background: radial-gradient(ellipse 40rem 12rem at 0% 50%, rgba(199, 255, 60, 0.05), transparent 55%);
+}
+.rm-lane--winner {
+  background: radial-gradient(ellipse 42rem 14rem at 0% 50%, rgba(109, 191, 145, 0.07), transparent 55%);
+}
+.rm-lane--failed { opacity: 0.78; }
+.rm-lane--failed:hover { opacity: 1; }
+
+.rm-lane__rank {
+  position: relative;
+  padding-left: 24px;
+  display: flex; flex-direction: column; justify-content: center;
+  gap: 10px;
+}
+.rm-lane__rank-pos {
+  font-family: var(--rm-font-display);
+  font-style: italic;
+  font-weight: 500;
+  font-size: 112px;
+  line-height: 0.85;
+  color: var(--rm-text-1);
+  letter-spacing: -0.04em;
+  font-variant-numeric: tabular-nums lining-nums;
+  font-variation-settings: "opsz" 144, "SOFT" 100, "WONK" 1;
+  text-shadow: 0 0 36px rgba(0, 0, 0, 0.5);
+}
+.rm-lane--active .rm-lane__rank-pos { color: var(--rm-signal); text-shadow: 0 0 44px var(--rm-signal-glow); }
+.rm-lane--winner .rm-lane__rank-pos { color: var(--rm-go); text-shadow: 0 0 44px var(--rm-go-glow); }
+.rm-lane--failed .rm-lane__rank-pos { color: var(--rm-text-4); text-shadow: none; }
+
+.rm-lane__delta {
+  font-family: var(--rm-font-mono);
+  font-size: 11px;
+  color: var(--rm-text-3);
+  letter-spacing: 0.04em;
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 3px 8px;
+  border-radius: 3px;
+  align-self: flex-start;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--rm-rule-weak);
+  font-variant-numeric: tabular-nums;
+}
+.rm-lane__delta--up { color: var(--rm-go); background: var(--rm-go-bg); border-color: rgba(109, 191, 145, 0.2); }
+.rm-lane__delta--down { color: var(--rm-danger); background: var(--rm-danger-bg); border-color: rgba(229, 97, 79, 0.2); }
+
+.rm-lane__content { display: flex; flex-direction: column; min-width: 0; }
+
+.rm-lane__head {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 16px;
+  align-items: start;
+  margin-bottom: 14px;
+}
+
+.rm-lane__name {
+  font-family: var(--rm-font-display);
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.1;
+  letter-spacing: -0.015em;
+  color: var(--rm-text-1);
+  display: flex; align-items: center; gap: 10px;
+  font-variation-settings: "opsz" 72, "SOFT" 80, "WONK" 1;
+  margin: 0;
+}
+.rm-lane__leader-tag {
+  font-family: var(--rm-font-mono);
+  font-weight: 500;
+  font-size: 10px;
+  color: var(--rm-go);
+  background: var(--rm-go-bg);
+  padding: 3px 8px;
+  border-radius: 4px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.rm-lane__meta {
+  margin-top: 4px;
+  font-family: var(--rm-font-mono);
+  font-size: 11.5px;
+  color: var(--rm-text-3);
+  letter-spacing: 0.01em;
+  display: flex; align-items: center; gap: 10px;
+  flex-wrap: wrap;
+}
+.rm-lane__meta .rm-dot { width: 2px; height: 2px; background: var(--rm-text-4); border-radius: 99px; }
+
+.rm-lane__status {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 5px 12px;
+  border-radius: 999px;
+  background: var(--rm-bg-input);
+  border: 1px solid var(--rm-rule);
+  font-family: var(--rm-font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--rm-text-2);
+  white-space: nowrap;
+}
+.rm-lane__status-pulse {
+  width: 6px; height: 6px; border-radius: 99px;
+  background: var(--rm-signal);
+  box-shadow: 0 0 6px var(--rm-signal-glow);
+  animation: rm-breathe 1.5s ease-in-out infinite;
+}
+@keyframes rm-breathe {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.5; transform: scale(1.35); }
+}
+.rm-lane--winner .rm-lane__status { color: var(--rm-go); border-color: rgba(109, 191, 145, 0.28); }
+.rm-lane--winner .rm-lane__status-pulse { background: var(--rm-go); box-shadow: 0 0 6px var(--rm-go-glow); animation: none; }
+.rm-lane--failed .rm-lane__status { color: var(--rm-danger); border-color: rgba(229, 97, 79, 0.28); }
+.rm-lane--failed .rm-lane__status-pulse { background: var(--rm-danger); animation: none; }
+
+.rm-lane__steps {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+  gap: 3px;
+  margin-bottom: 14px;
+}
+.rm-step {
+  height: 4px;
+  border-radius: 2px;
+  background: var(--rm-rule);
+  transition: background 0.3s ease;
+}
+.rm-step--done { background: var(--rm-signal); }
+.rm-step--current {
+  background: var(--rm-signal);
+  animation: rm-step-pulse 1.4s ease-in-out infinite;
+}
+@keyframes rm-step-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
+}
+.rm-lane--winner .rm-step--done,
+.rm-lane--winner .rm-step--current { background: var(--rm-go); }
+.rm-lane--failed .rm-step--done { background: var(--rm-danger); }
+.rm-lane--failed .rm-step--current { background: var(--rm-danger); animation: none; }
+
+.rm-tele {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 18px;
+  padding: 14px 0;
+  border-top: 1px solid var(--rm-rule-weak);
+  border-bottom: 1px solid var(--rm-rule-weak);
+}
+.rm-tele__item label {
+  display: block;
+  font-family: var(--rm-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--rm-text-3);
+  margin-bottom: 6px;
+}
+.rm-tele__item .rm-val {
+  font-family: var(--rm-font-mono);
+  font-weight: 500;
+  font-size: 20px;
+  line-height: 1;
+  color: var(--rm-text-1);
+  letter-spacing: -0.01em;
+  font-variant-numeric: tabular-nums;
+}
+.rm-tele__item .rm-val--go { color: var(--rm-go); }
+.rm-tele__item .rm-val .rm-unit {
+  font-size: 11px;
+  color: var(--rm-text-3);
+  margin-left: 3px;
+  font-weight: 400;
+}
+
+.rm-now {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 14px 0 10px;
+}
+.rm-now__tag {
+  display: inline-flex; align-items: center; gap: 7px;
+  font-family: var(--rm-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--rm-signal);
+  padding: 4px 9px;
+  border: 1px solid var(--rm-rule-signal);
+  border-radius: 999px;
+  background: var(--rm-signal-bg);
+}
+.rm-wave {
+  display: inline-flex; align-items: center; gap: 2px; height: 10px;
+}
+.rm-wave span {
+  display: inline-block;
+  width: 2px; background: var(--rm-signal); border-radius: 1px;
+  animation: rm-wave 1.05s ease-in-out infinite;
+}
+.rm-wave span:nth-child(1) { height: 35%; animation-delay: 0s; }
+.rm-wave span:nth-child(2) { height: 80%; animation-delay: 0.1s; }
+.rm-wave span:nth-child(3) { height: 55%; animation-delay: 0.2s; }
+.rm-wave span:nth-child(4) { height: 100%; animation-delay: 0.3s; }
+.rm-wave span:nth-child(5) { height: 45%; animation-delay: 0.4s; }
+@keyframes rm-wave {
+  0%, 100% { transform: scaleY(0.3); opacity: 0.6; }
+  50%      { transform: scaleY(1); opacity: 1; }
+}
+
+.rm-now__text {
+  font-family: var(--rm-font-body);
+  font-weight: 500;
+  font-size: 14px;
+  color: var(--rm-text-1);
+  line-height: 1.35;
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  min-width: 0;
+}
+.rm-now__obj {
+  font-family: var(--rm-font-mono);
+  font-weight: 500;
+  font-size: 12px;
+  color: var(--rm-signal);
+  background: var(--rm-signal-bg);
+  border: 1px solid var(--rm-rule-signal);
+  padding: 2px 7px;
+  border-radius: 4px;
+  max-width: 360px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+
+.rm-stream {
+  position: relative;
+  margin-top: 12px;
+  padding: 12px 16px;
+  background: var(--rm-bg-input);
+  border: 1px solid var(--rm-rule-weak);
+  border-radius: 6px;
+  font-family: var(--rm-font-mono);
+  font-size: 12.5px;
+  line-height: 1.65;
+  color: var(--rm-text-2);
+  max-height: 108px;
+  overflow: hidden;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.rm-stream::after {
+  content: "";
+  position: absolute; inset: auto 0 0 0; height: 28px;
+  background: linear-gradient(180deg, transparent, var(--rm-bg-input));
+  pointer-events: none;
+}
+
+.rm-fail {
+  margin-top: 12px;
+  padding: 12px 14px;
+  background: var(--rm-danger-bg);
+  border: 1px solid rgba(229, 97, 79, 0.2);
+  border-radius: 6px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+  align-items: start;
+}
+.rm-fail__ic {
+  width: 18px; height: 18px;
+  border-radius: 999px;
+  background: rgba(229, 97, 79, 0.15);
+  color: var(--rm-danger);
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 12px; font-weight: 600;
+  margin-top: 2px;
+}
+.rm-fail__body strong {
+  display: block;
+  font-family: var(--rm-font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--rm-danger);
+  margin-bottom: 4px;
+  font-weight: 600;
+}
+.rm-fail__body p {
+  margin: 0;
+  font-size: 13px;
+  color: var(--rm-text-2);
+  line-height: 1.55;
+}
+
+.rm-lane__foot {
+  display: flex; align-items: center; gap: 20px;
+  padding-top: 12px;
+  margin-top: 12px;
+  border-top: 1px solid var(--rm-rule-weak);
+  font-family: var(--rm-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--rm-text-3);
+}
+.rm-lane__foot a {
+  color: var(--rm-text-3);
+  text-decoration: none;
+  display: inline-flex; align-items: center; gap: 6px;
+  transition: color 0.15s ease;
+}
+.rm-lane__foot a:hover { color: var(--rm-text-1); }
+
+/* =========================================================
+   COMMENTARY BOOTH
+   ========================================================= */
+
+.rm-booth {
+  background: var(--rm-bg-raised);
+  border-left: 1px solid var(--rm-rule);
+  display: flex; flex-direction: column;
+  overflow: hidden;
+}
+.rm-booth__head {
+  padding: 20px 22px;
+  border-bottom: 1px solid var(--rm-rule);
+  display: flex; align-items: start; justify-content: space-between;
+  gap: 12px;
+}
+.rm-booth__title {
+  font-family: var(--rm-font-display);
+  font-style: italic;
+  font-weight: 500;
+  font-size: 28px;
+  line-height: 0.95;
+  margin: 0 0 6px;
+  letter-spacing: -0.02em;
+  color: var(--rm-text-1);
+  font-variation-settings: "opsz" 144, "SOFT" 100, "WONK" 1;
+}
+.rm-booth__sub {
+  font-family: var(--rm-font-mono);
+  font-size: 11px;
+  color: var(--rm-text-3);
+  letter-spacing: 0.02em;
+  display: inline-flex; align-items: center; gap: 8px;
+}
+.rm-onair {
+  display: inline-flex; align-items: center; gap: 7px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--rm-rule-signal);
+  background: var(--rm-signal-bg);
+  font-family: var(--rm-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--rm-signal);
+  flex-shrink: 0;
+}
+.rm-onair--off {
+  border-color: var(--rm-rule);
+  background: transparent;
+  color: var(--rm-text-3);
+}
+.rm-onair__led {
+  width: 7px; height: 7px; border-radius: 99px;
+  background: var(--rm-signal);
+  box-shadow: 0 0 8px var(--rm-signal-glow);
+  animation: rm-breathe 1.3s ease-in-out infinite;
+}
+.rm-onair--off .rm-onair__led {
+  background: var(--rm-text-4);
+  box-shadow: none;
+  animation: none;
+}
+
+.rm-xmits {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 0;
+  max-height: 34rem;
+  scrollbar-width: thin;
+  scrollbar-color: var(--rm-rule-strong) transparent;
+}
+.rm-xmits::-webkit-scrollbar { width: 4px; }
+.rm-xmits::-webkit-scrollbar-thumb { background: var(--rm-rule-strong); border-radius: 99px; }
+
+.rm-xmit {
+  padding: 12px 22px;
+  border-bottom: 1px solid var(--rm-rule-weak);
+  transition: background 0.15s ease;
+  animation: rm-xmit-in 0.4s cubic-bezier(.2,.8,.2,1);
+}
+@keyframes rm-xmit-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: none; }
+}
+.rm-xmit:last-child { border-bottom: 0; }
+.rm-xmit:hover { background: var(--rm-bg-elevated); }
+.rm-xmit__head {
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 6px;
+}
+.rm-xmit__caller {
+  font-family: var(--rm-font-mono);
+  font-weight: 500;
+  font-size: 10.5px;
+  color: var(--rm-signal);
+  background: var(--rm-signal-bg);
+  border: 1px solid var(--rm-rule-signal);
+  padding: 2px 7px;
+  border-radius: 4px;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  max-width: 180px;
+  overflow: hidden; text-overflow: ellipsis;
+}
+.rm-xmit--positive .rm-xmit__caller {
+  color: var(--rm-go);
+  border-color: rgba(109, 191, 145, 0.25);
+  background: var(--rm-go-bg);
+}
+.rm-xmit--warning .rm-xmit__caller {
+  color: var(--rm-warn);
+  border-color: rgba(242, 200, 121, 0.28);
+  background: var(--rm-warn-bg);
+}
+.rm-xmit__time {
+  margin-left: auto;
+  font-family: var(--rm-font-mono);
+  font-size: 10.5px;
+  color: var(--rm-text-4);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+}
+.rm-xmit__line {
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--rm-text-1);
+  font-weight: 500;
+}
+.rm-xmit__detail {
+  margin-top: 4px;
+  font-family: var(--rm-font-mono);
+  font-size: 11.5px;
+  color: var(--rm-text-3);
+  letter-spacing: 0.01em;
+  line-height: 1.5;
+}
+
+.rm-xmits--empty {
+  padding: 20px 22px;
+  font-family: var(--rm-font-mono);
+  font-size: 11px;
+  color: var(--rm-text-3);
+  letter-spacing: 0.02em;
+  line-height: 1.6;
+  text-transform: uppercase;
+}
+
+/* =========================================================
+   Reduced motion
+   ========================================================= */
+@media (prefers-reduced-motion: reduce) {
+  .race-mode-root *,
+  .race-mode-root *::before,
+  .race-mode-root *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+}
+
+/* Mobile */
+@media (max-width: 720px) {
+  .rm-lane { grid-template-columns: 72px 1fr; padding-right: 14px; }
+  .rm-lane__rank { padding-left: 14px; }
+  .rm-lane__rank-pos { font-size: 64px; }
+  .rm-tele { grid-template-columns: repeat(3, 1fr); gap: 12px; }
+  .rm-tele__item:nth-child(n+4) { display: none; }
+  .rm-lane__head { grid-template-columns: 1fr; }
+  .rm-track-row { grid-template-columns: 22px minmax(72px, 110px) 1fr 64px; gap: 10px; }
+}

--- a/web/src/components/arena/race-mode/race-track.tsx
+++ b/web/src/components/arena/race-mode/race-track.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useMemo } from "react";
+import type { RunAgent } from "@/lib/api/types";
+import type { ArenaLaneState } from "@/hooks/use-agent-arena";
+
+/**
+ * Unified horizontal timeline — all agents plotted on the same 0→N-step axis,
+ * racing against each other. Position is derived from each agent's live
+ * stepIndex; failed agents stop at their last-seen step.
+ *
+ * We don't know the challenge's total step count from the client, so we scale
+ * against max(observed stepIndex, DEFAULT_TARGET) — the track grows early and
+ * compresses as the run progresses.
+ */
+
+const DEFAULT_TARGET_STEPS = 12;
+
+interface RaceTrackProps {
+  agents: RunAgent[];
+  lanes: Record<string, ArenaLaneState>;
+  winnerAgentId?: string;
+}
+
+export function RaceTrack({ agents, lanes, winnerAgentId }: RaceTrackProps) {
+  const ordered = useMemo(() => rankAgents(agents, lanes), [agents, lanes]);
+  const targetSteps = useMemo(() => {
+    let max = DEFAULT_TARGET_STEPS;
+    for (const a of agents) {
+      const lane = lanes[a.id];
+      if (lane && lane.stepIndex > max) max = lane.stepIndex;
+    }
+    return max;
+  }, [agents, lanes]);
+
+  const activeCount = agents.filter(
+    (a) => a.status === "executing" || a.status === "evaluating",
+  ).length;
+
+  const maxStep = Math.max(
+    ...agents.map((a) => lanes[a.id]?.stepIndex ?? 0),
+    0,
+  );
+
+  return (
+    <section className="rm-track" aria-label="Race track">
+      <div className="rm-track__head">
+        <h2 className="rm-track__title">Lap progress</h2>
+        <div className="rm-track__meta">
+          <span>
+            {agents.length} {agents.length === 1 ? "lane" : "lanes"}
+          </span>
+          <span className="rm-sep">·</span>
+          <span>
+            {activeCount > 0
+              ? `${activeCount} active`
+              : maxStep > 0
+                ? `step ${maxStep} / ${targetSteps}`
+                : "standing by"}
+          </span>
+          <span className="rm-sep">·</span>
+          <span className="rm-finish">finish</span>
+        </div>
+      </div>
+      <div className="rm-track__body">
+        {ordered.map(({ agent, position }) => {
+          const lane = lanes[agent.id];
+          const step = lane?.stepIndex ?? 0;
+          const pct = clamp((step / Math.max(targetSteps, 1)) * 100, 0, 100);
+          const isLeader = winnerAgentId
+            ? agent.id === winnerAgentId
+            : position === 1 &&
+              (agent.status === "executing" || agent.status === "evaluating");
+          const isFailed = agent.status === "failed";
+
+          const rowClass = [
+            "rm-track-row",
+            isLeader && "rm-track-row--leader",
+            isFailed && "rm-track-row--failed",
+          ]
+            .filter(Boolean)
+            .join(" ");
+
+          const wakeLeft = Math.max(pct - 18, 0);
+          const wakeWidth = Math.min(pct, 18);
+
+          return (
+            <div key={agent.id} className={rowClass}>
+              <span className="rm-track-row__pos">{position}</span>
+              <span className="rm-track-row__name" title={agent.label}>
+                {agent.label}
+              </span>
+              <div className="rm-track-row__lane">
+                <div
+                  className="rm-track-row__fill"
+                  style={{ width: `${pct}%` }}
+                />
+                {!isFailed && wakeWidth > 0 && (
+                  <span
+                    className="rm-track-row__wake"
+                    style={{
+                      left: `${wakeLeft}%`,
+                      width: `${wakeWidth}%`,
+                    }}
+                  />
+                )}
+                <span
+                  className="rm-track-row__dot"
+                  style={{ left: `${pct}%` }}
+                />
+              </div>
+              <span className="rm-track-row__step">
+                {isFailed ? "DNF" : `${step}/${targetSteps}`}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.min(Math.max(n, lo), hi);
+}
+
+/**
+ * Ranks agents by: (1) non-failed first, (2) higher stepIndex first,
+ * (3) more model calls as tiebreak, (4) lane_index ascending.
+ */
+function rankAgents(
+  agents: RunAgent[],
+  lanes: Record<string, ArenaLaneState>,
+): { agent: RunAgent; position: number }[] {
+  const sorted = [...agents].sort((a, b) => {
+    const aFailed = a.status === "failed" ? 1 : 0;
+    const bFailed = b.status === "failed" ? 1 : 0;
+    if (aFailed !== bFailed) return aFailed - bFailed;
+    const aStep = lanes[a.id]?.stepIndex ?? 0;
+    const bStep = lanes[b.id]?.stepIndex ?? 0;
+    if (aStep !== bStep) return bStep - aStep;
+    const aCalls = lanes[a.id]?.modelCalls ?? 0;
+    const bCalls = lanes[b.id]?.modelCalls ?? 0;
+    if (aCalls !== bCalls) return bCalls - aCalls;
+    return a.lane_index - b.lane_index;
+  });
+  return sorted.map((agent, i) => ({ agent, position: i + 1 }));
+}

--- a/web/src/components/arena/race-mode/race-track.tsx
+++ b/web/src/components/arena/race-mode/race-track.tsx
@@ -1,44 +1,39 @@
 "use client";
 
-import { useMemo } from "react";
 import type { RunAgent } from "@/lib/api/types";
 import type { ArenaLaneState } from "@/hooks/use-agent-arena";
+import { deriveLeader } from "./utils";
 
 /**
  * Unified horizontal timeline — all agents plotted on the same 0→N-step axis,
  * racing against each other. Position is derived from each agent's live
  * stepIndex; failed agents stop at their last-seen step.
  *
- * We don't know the challenge's total step count from the client, so we scale
- * against max(observed stepIndex, DEFAULT_TARGET) — the track grows early and
- * compresses as the run progresses.
+ * The parent (`RaceModeArena`) computes `ranked` + `targetSteps` once and
+ * passes them down so the track and the lane rows always agree on the
+ * denominator.
  */
 
-const DEFAULT_TARGET_STEPS = 12;
-
 interface RaceTrackProps {
-  agents: RunAgent[];
+  ranked: { agent: RunAgent; position: number }[];
   lanes: Record<string, ArenaLaneState>;
+  targetSteps: number;
   winnerAgentId?: string;
 }
 
-export function RaceTrack({ agents, lanes, winnerAgentId }: RaceTrackProps) {
-  const ordered = useMemo(() => rankAgents(agents, lanes), [agents, lanes]);
-  const targetSteps = useMemo(() => {
-    let max = DEFAULT_TARGET_STEPS;
-    for (const a of agents) {
-      const lane = lanes[a.id];
-      if (lane && lane.stepIndex > max) max = lane.stepIndex;
-    }
-    return max;
-  }, [agents, lanes]);
-
-  const activeCount = agents.filter(
-    (a) => a.status === "executing" || a.status === "evaluating",
+export function RaceTrack({
+  ranked,
+  lanes,
+  targetSteps,
+  winnerAgentId,
+}: RaceTrackProps) {
+  const agentCount = ranked.length;
+  const activeCount = ranked.filter(
+    ({ agent }) =>
+      agent.status === "executing" || agent.status === "evaluating",
   ).length;
-
-  const maxStep = Math.max(
-    ...agents.map((a) => lanes[a.id]?.stepIndex ?? 0),
+  const maxStep = ranked.reduce(
+    (m, { agent }) => Math.max(m, lanes[agent.id]?.stepIndex ?? 0),
     0,
   );
 
@@ -48,7 +43,7 @@ export function RaceTrack({ agents, lanes, winnerAgentId }: RaceTrackProps) {
         <h2 className="rm-track__title">Lap progress</h2>
         <div className="rm-track__meta">
           <span>
-            {agents.length} {agents.length === 1 ? "lane" : "lanes"}
+            {agentCount} {agentCount === 1 ? "lane" : "lanes"}
           </span>
           <span className="rm-sep">·</span>
           <span>
@@ -63,14 +58,11 @@ export function RaceTrack({ agents, lanes, winnerAgentId }: RaceTrackProps) {
         </div>
       </div>
       <div className="rm-track__body">
-        {ordered.map(({ agent, position }) => {
+        {ranked.map(({ agent, position }) => {
           const lane = lanes[agent.id];
           const step = lane?.stepIndex ?? 0;
           const pct = clamp((step / Math.max(targetSteps, 1)) * 100, 0, 100);
-          const isLeader = winnerAgentId
-            ? agent.id === winnerAgentId
-            : position === 1 &&
-              (agent.status === "executing" || agent.status === "evaluating");
+          const isLeader = deriveLeader(agent, position, winnerAgentId);
           const isFailed = agent.status === "failed";
 
           const rowClass = [
@@ -122,27 +114,4 @@ export function RaceTrack({ agents, lanes, winnerAgentId }: RaceTrackProps) {
 
 function clamp(n: number, lo: number, hi: number): number {
   return Math.min(Math.max(n, lo), hi);
-}
-
-/**
- * Ranks agents by: (1) non-failed first, (2) higher stepIndex first,
- * (3) more model calls as tiebreak, (4) lane_index ascending.
- */
-function rankAgents(
-  agents: RunAgent[],
-  lanes: Record<string, ArenaLaneState>,
-): { agent: RunAgent; position: number }[] {
-  const sorted = [...agents].sort((a, b) => {
-    const aFailed = a.status === "failed" ? 1 : 0;
-    const bFailed = b.status === "failed" ? 1 : 0;
-    if (aFailed !== bFailed) return aFailed - bFailed;
-    const aStep = lanes[a.id]?.stepIndex ?? 0;
-    const bStep = lanes[b.id]?.stepIndex ?? 0;
-    if (aStep !== bStep) return bStep - aStep;
-    const aCalls = lanes[a.id]?.modelCalls ?? 0;
-    const bCalls = lanes[b.id]?.modelCalls ?? 0;
-    if (aCalls !== bCalls) return bCalls - aCalls;
-    return a.lane_index - b.lane_index;
-  });
-  return sorted.map((agent, i) => ({ agent, position: i + 1 }));
 }

--- a/web/src/components/arena/race-mode/utils.ts
+++ b/web/src/components/arena/race-mode/utils.ts
@@ -1,0 +1,68 @@
+import type { ArenaLaneState } from "@/hooks/use-agent-arena";
+import type { RunAgent } from "@/lib/api/types";
+
+/**
+ * Minimum number of segments we render on the step progress bar and on the
+ * race track before either scales up to accommodate the live maximum. 12 is
+ * a reasonable visual baseline — short enough to show meaningful segments on
+ * a 3-step run, large enough not to feel sparse on typical runs.
+ */
+export const MIN_TARGET_STEPS = 12;
+
+/**
+ * Target step count for display. Track + lane must agree on this value or the
+ * two panels render the same agent at different percentages.
+ */
+export function computeTargetSteps(
+  agents: RunAgent[],
+  lanes: Record<string, ArenaLaneState>,
+): number {
+  let max = MIN_TARGET_STEPS;
+  for (const a of agents) {
+    const lane = lanes[a.id];
+    if (lane && lane.stepIndex > max) max = lane.stepIndex;
+  }
+  return max;
+}
+
+/**
+ * Ranks agents by: (1) non-failed first, (2) higher stepIndex first,
+ * (3) more model calls as tiebreak, (4) lane_index ascending.
+ *
+ * Used by both `RaceTrack` and `RaceModeArena` — must live in exactly one
+ * place so the two views never disagree on who's ahead.
+ */
+export function rankAgents(
+  agents: RunAgent[],
+  lanes: Record<string, ArenaLaneState>,
+): { agent: RunAgent; position: number }[] {
+  const sorted = [...agents].sort((a, b) => {
+    const aFailed = a.status === "failed" ? 1 : 0;
+    const bFailed = b.status === "failed" ? 1 : 0;
+    if (aFailed !== bFailed) return aFailed - bFailed;
+    const aStep = lanes[a.id]?.stepIndex ?? 0;
+    const bStep = lanes[b.id]?.stepIndex ?? 0;
+    if (aStep !== bStep) return bStep - aStep;
+    const aCalls = lanes[a.id]?.modelCalls ?? 0;
+    const bCalls = lanes[b.id]?.modelCalls ?? 0;
+    if (aCalls !== bCalls) return bCalls - aCalls;
+    return a.lane_index - b.lane_index;
+  });
+  return sorted.map((agent, i) => ({ agent, position: i + 1 }));
+}
+
+/**
+ * A single source of truth for "is this lane the leader?". Before the run
+ * finishes (no winnerAgentId), we only flag position-1 as leader when the
+ * agent is actually racing — otherwise a queued-but-first-in-order agent
+ * would wear the green leader stripe before it's even started.
+ */
+export function deriveLeader(
+  agent: RunAgent,
+  position: number,
+  winnerAgentId: string | undefined,
+): boolean {
+  if (winnerAgentId) return agent.id === winnerAgentId;
+  if (position !== 1) return false;
+  return agent.status === "executing" || agent.status === "evaluating";
+}

--- a/web/src/hooks/use-arena-mode.ts
+++ b/web/src/hooks/use-arena-mode.ts
@@ -1,0 +1,80 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+export type ArenaMode = "dev" | "race";
+
+const STORAGE_KEY = "agentclash:arena-mode";
+const STORAGE_EVENT = "agentclash:arena-mode:changed";
+
+function isArenaMode(v: unknown): v is ArenaMode {
+  return v === "dev" || v === "race";
+}
+
+function readStoredMode(): ArenaMode | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const v = window.localStorage.getItem(STORAGE_KEY);
+    return isArenaMode(v) ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+function subscribeStorage(cb: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  // Cross-tab updates (real storage event) AND same-tab (our custom event).
+  window.addEventListener("storage", cb);
+  window.addEventListener(STORAGE_EVENT, cb);
+  return () => {
+    window.removeEventListener("storage", cb);
+    window.removeEventListener(STORAGE_EVENT, cb);
+  };
+}
+
+/**
+ * Resolves arena mode with URL > localStorage > "dev" precedence.
+ *
+ * URL param (?mode=race) is the shareable source of truth; localStorage
+ * carries the user's preference across sessions. Setting the mode updates
+ * both — and dispatches a same-tab event so peer consumers of this hook
+ * re-render.
+ */
+export function useArenaMode(): [ArenaMode, (next: ArenaMode) => void] {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const storedMode = useSyncExternalStore(
+    subscribeStorage,
+    readStoredMode,
+    () => null,
+  );
+
+  const urlMode = searchParams.get("mode");
+  const mode: ArenaMode = isArenaMode(urlMode)
+    ? urlMode
+    : (storedMode ?? "dev");
+
+  const setMode = useCallback(
+    (next: ArenaMode) => {
+      try {
+        window.localStorage.setItem(STORAGE_KEY, next);
+        window.dispatchEvent(new Event(STORAGE_EVENT));
+      } catch {
+        // localStorage unavailable — URL is still the source of truth.
+      }
+      const params = new URLSearchParams(searchParams.toString());
+      if (next === "race") params.set("mode", "race");
+      else params.delete("mode");
+      const query = params.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname, {
+        scroll: false,
+      });
+    },
+    [pathname, router, searchParams],
+  );
+
+  return [mode, setMode];
+}


### PR DESCRIPTION
## Summary

Introduces a broadcast-style **Race Mode** for the live run detail view, selectable via a toggle next to the existing Commentary button. The old UI (Dev Mode) stays the default and is untouched — race mode is strictly additive.

**What's new when race mode is on:**
- Unified race-track timeline — all agents plotted on the same step axis with glowing position dots, trailing wakes, and a real checkered finish line
- Redesigned lane rows — full-bleed F1-live-timing style, huge watermark rank numeral (Fraunces italic), racing-stripe left edge that glows for active/leader/failed
- On-air commentary booth — editorial serif title, caller-ID pills, transmission feed styling
- Signal-lime accent palette (#c7ff3c) + near-black canvas, scoped under .race-mode-root so nothing leaks

**What's unchanged:**
- Existing navbar, layout, header, KPI strip, regression coverage, and ranking tables are untouched
- Dev Mode is the default; nothing renders differently unless the user opts in
- SSE stream + useAgentArena + useAgentCommentary hooks are reused — no new backend contracts

**How the toggle works:**
- Button shows "Dev Mode" by default, "Race Mode" when active
- Persists to localStorage (cross-session) and ?mode=race URL param (shareable links)
- useSyncExternalStore keeps multiple tabs in sync via a same-tab event

## Files

- web/src/hooks/use-arena-mode.ts — new hook (URL > localStorage > "dev")
- web/src/components/arena/race-mode/ — new directory (index, race-track, race-lane, race-commentary, race-mode.css)
- web/src/app/layout.tsx — load Fraunces (variable, opsz/SOFT/WONK axes) and Geist Mono via next/font
- web/src/app/(workspace)/.../run-detail-client.tsx — toggle button + conditional render of the arena section
- web/src/app/(workspace)/.../run-detail-client.test.tsx — mock next/navigation so the new hook works under vitest

## Test plan

- [x] Load a completed run — UI looks identical to before (Dev Mode is default)
- [x] Click "Dev Mode" button → flips to "Race Mode", lanes section swaps to the new view
- [x] Active runs: race track dots animate, step progress bars fill, now-doing waveforms pulse
- [x] Leader's dot has the green orbit ring; failed agents show as a red X at DNF position
- [x] Toggle "Commentary On" in race mode → booth appears on the right with on-air LED
- [x] Refresh page with ?mode=race in URL → race mode is active immediately
- [x] Open in a second tab → mode stays in sync via storage event
- [x] pnpm build, npx tsc --noEmit, pnpm lint, pnpm test run all pass

Generated with [Claude Code](https://claude.com/claude-code)