### PR TITLE
[codex] Build public docs foundation

### DIFF
--- a/testing/agentclash-docs-foundation.md
+++ b/testing/agentclash-docs-foundation.md
@@ -5,7 +5,7 @@ description: Review-checkpoint contract for the public docs implementation and A
 
 # Scope
 
-Implement a production-facing docs system for AgentClash inside the existing Next.js app at `/docs`, then extend it into a much more detailed A-to-Z docs surface that covers onboarding, core mental models, results interpretation, architecture, and contributor workflows. Add AI-ingest endpoints so the docs can be consumed as `llms.txt`, a bundled full-text export, and per-page markdown exports without introducing a separate docs framework.
+Implement a production-facing docs system for AgentClash inside the existing Next.js app at `/docs`, then extend it into a much more detailed A-to-Z docs surface that covers onboarding, core mental models, results interpretation, architecture, contributor workflows, and the currently shipped resource model for challenge packs, deployments, tools, artifacts, runtime profiles, provider accounts, model aliases, and secrets. Add AI-ingest endpoints so the docs can be consumed as `llms.txt`, a bundled full-text export, and per-page markdown exports without introducing a separate docs framework.
 
 # Functional expectations
 
@@ -15,8 +15,8 @@ Implement a production-facing docs system for AgentClash inside the existing Nex
 4. The docs shell includes a left-hand navigation for the shipped docs sections and highlights the current page.
 5. The docs shell is visually distinct from the blog and matches the current dark AgentClash aesthetic.
 6. The landing page header exposes a `Docs` entry so the new docs area is discoverable.
-7. Sitemap output includes the docs landing page, the shipped docs pages, and the new AI-ingest endpoints.
-8. Detailed docs content only documents features and workflows that are already grounded in the current repo, docs, or generated source readers. The shipped set for this phase includes:
+7. Sitemap output includes the docs landing page, the shipped docs pages, and the AI-ingest endpoints.
+8. Detailed docs content only documents features and workflows that are already grounded in the current repo, docs, examples, tests, or generated source readers. The shipped set for this phase includes:
    - product/docs landing
    - hosted quickstart
    - self-host quickstart
@@ -25,7 +25,11 @@ Implement a production-facing docs system for AgentClash inside the existing Nex
    - agents and deployments concept
    - challenge packs and inputs concept
    - replay and scorecards concept
+   - tools, network, and secrets concept
+   - artifacts concept
    - interpret results guide
+   - write a challenge pack guide
+   - configure runtime resources and deployments guide
    - use with AI tools guide
    - generated CLI reference
    - generated config reference
@@ -38,25 +42,35 @@ Implement a production-facing docs system for AgentClash inside the existing Nex
    - contributor setup
    - contributor codebase tour
    - contributor testing workflow
-9. The implementation must reuse the existing MDX/content pattern where practical instead of introducing a second docs framework dependency.
-10. `/docs` and nested docs routes are publicly reachable without tripping the AuthKit middleware redirect-URI requirement in a local environment with no WorkOS redirect env configured.
-11. The docs shell includes inline search/filtering across the shipped docs set.
-12. The docs shell includes a heading-based table of contents for pages that have section headings.
-13. At least two reference pages are generated from current source inputs rather than being fully hand-maintained.
-14. The app exposes `GET /llms.txt` as a concise machine-oriented index of the docs set with stable links.
-15. The app exposes `GET /llms-full.txt` as a single bundled plain-text/markdown export of the shipped docs set.
-16. The app exposes per-page markdown/plain-text exports under `/docs-md/...` for file-backed and generated docs pages.
-17. The AI-ingest surfaces point at AgentClash docs content and markdown exports without claiming first-party support or plugin integration from third-party assistant products.
-18. The implementation remains isolated in the docs worktree branch and updates the existing GitHub PR rather than opening a second PR.
+9. The revised docs must explicitly answer the current codebase-backed questions a new user would ask, including:
+   - what a challenge pack is
+   - how to validate and publish a challenge pack
+   - what a deployment is
+   - what runtime profiles, provider accounts, and model aliases do in deployment setup
+   - what a tool definition is versus a primitive implementation inside a challenge pack
+   - how outbound internet access is controlled
+   - how secrets are stored and where secret references resolve
+   - what artifacts are and how they participate in packs, runs, and downloads
+10. The implementation must reuse the existing MDX/content pattern where practical instead of introducing a second docs framework dependency.
+11. `/docs`, `/docs-md`, `/llms.txt`, and `/llms-full.txt` are publicly reachable without tripping the AuthKit middleware redirect-URI requirement in a local environment with no WorkOS redirect env configured.
+12. The docs shell includes inline search/filtering across the shipped docs set.
+13. The docs shell includes a heading-based table of contents for pages that have section headings.
+14. At least two reference pages are generated from current source inputs rather than being fully hand-maintained.
+15. The app exposes `GET /llms.txt` as a concise machine-oriented index of the docs set with stable links.
+16. The app exposes `GET /llms-full.txt` as a single bundled plain-text/markdown export of the shipped docs set.
+17. The app exposes per-page markdown/plain-text exports under `/docs-md/...` for file-backed and generated docs pages.
+18. The AI-ingest surfaces point at AgentClash docs content and markdown exports without claiming first-party support or plugin integration from third-party assistant products.
+19. The implementation remains isolated in the docs worktree branch and updates the existing GitHub PR rather than opening a second PR.
 
 # Tests to add or run
 
 1. Run `pnpm build` in `web/` to catch routing, metadata, and MDX compilation issues.
 2. Run the built app locally and verify that `/docs` returns successfully without the AuthKit redirect-URI runtime error.
 3. Verify that a generated reference page renders successfully.
-4. Verify that `/llms.txt` returns successfully and includes links into the shipped docs set.
-5. Verify that `/llms-full.txt` returns successfully and contains multiple concatenated docs sections.
-6. Verify that at least one nested `/docs-md/...` route returns markdown/plain text successfully.
+4. Verify that the new concept and guide pages render successfully.
+5. Verify that `/llms.txt` returns successfully and includes links into the shipped docs set.
+6. Verify that `/llms-full.txt` returns successfully and contains multiple concatenated docs sections.
+7. Verify that at least one nested `/docs-md/...` route returns markdown/plain text successfully.
 
 # Manual verification
 
@@ -67,9 +81,12 @@ Implement a production-facing docs system for AgentClash inside the existing Nex
 5. Confirm the landing page header links to `/docs`.
 6. Confirm docs URLs are emitted by the sitemap source.
 7. Confirm `/docs` is reachable locally even when WorkOS redirect configuration is absent.
-8. Confirm `/llms.txt` lists the docs index, the full bundle, and section-level markdown exports.
-9. Confirm `/llms-full.txt` contains readable bundled markdown for multiple pages.
-10. Confirm `/docs-md/getting-started/quickstart` returns a plain-text/markdown version of the quickstart page.
+8. Confirm `/docs/guides/write-a-challenge-pack` explains validate and publish flows grounded in the current CLI/API.
+9. Confirm `/docs/concepts/tools-network-and-secrets` explains primitive/composed tools, network controls, and secret references grounded in the current engine.
+10. Confirm `/docs/concepts/artifacts` explains upload, reference, and download behavior grounded in the current UI/API.
+11. Confirm `/llms.txt` lists the docs index, the full bundle, and section-level markdown exports.
+12. Confirm `/llms-full.txt` contains readable bundled markdown for multiple pages.
+13. Confirm `/docs-md/guides/write-a-challenge-pack` returns a plain-text/markdown version of the new guide.
 
 # Non-goals for this change
 
@@ -77,3 +94,4 @@ Implement a production-facing docs system for AgentClash inside the existing Nex
 2. Do not try to fully solve the broader public-marketing auth surface beyond making docs reachable.
 3. Do not publish roadmap or compare pages unless they are grounded in existing shipped behavior.
 4. Do not claim official first-party plugin or deep-link integration with ChatGPT, Codex, Claude Code, or similar tools; provide portable AI-friendly endpoints instead.
+5. Do not document speculative future challenge-pack or deployment behavior that is not visible in the current repo surface.

--- a/testing/agentclash-docs-foundation.md
+++ b/testing/agentclash-docs-foundation.md
@@ -1,0 +1,58 @@
+---
+title: AgentClash Docs Foundation Contract
+description: Review-checkpoint contract for the first public docs implementation in the web app.
+---
+
+# Scope
+
+Implement the first production-facing docs foundation for AgentClash inside the existing Next.js app at `/docs`, using the current MDX toolchain already present in `web/`, and extend that foundation so the docs are publicly reachable, easier to navigate, and less hand-maintained.
+
+# Functional expectations
+
+1. The web app exposes a dedicated docs experience at `/docs` with a docs home page and nested docs pages.
+2. Docs content is file-backed in the repo and stored separately from blog content.
+3. Docs pages support frontmatter with `title` and `description`.
+4. The docs shell includes a left-hand navigation for the initial docs sections and highlights the current page.
+5. The docs shell is visually distinct from the blog and matches the current dark AgentClash aesthetic.
+6. The landing page header exposes a `Docs` entry so the new docs area is discoverable.
+7. Sitemap output includes the docs landing page and the initial shipped docs pages.
+8. Initial docs content only documents features and workflows that are already grounded in the current repo:
+   - product/docs landing
+   - hosted quickstart
+   - self-host quickstart
+   - runs/evals concept
+   - first eval walkthrough
+   - generated CLI reference
+   - generated config reference
+   - architecture overview
+   - orchestration architecture
+   - frontend architecture
+   - contributor setup
+9. The implementation must reuse the existing MDX/content pattern where practical instead of introducing a second docs framework dependency in this first step.
+10. `/docs` and nested docs routes are publicly reachable without tripping the AuthKit middleware redirect-URI requirement in a local environment with no WorkOS redirect env configured.
+11. The docs shell includes inline search/filtering across the shipped docs set.
+12. The docs shell includes a heading-based table of contents for pages that have section headings.
+13. At least two reference pages are generated from current source inputs rather than being fully hand-maintained.
+14. The follow-up implementation remains isolated in the docs worktree branch and is prepared for a GitHub PR.
+
+# Tests to add or run
+
+1. Run `pnpm build` in `web/` to catch routing, metadata, and MDX compilation issues.
+2. Run the built app locally and verify that `/docs` returns successfully without the AuthKit redirect-URI runtime error.
+3. Verify that a generated reference page renders successfully.
+
+# Manual verification
+
+1. Open `/docs` and confirm the docs landing page renders.
+2. Open at least one nested page in each implemented section and confirm the sidebar navigation works.
+3. Confirm the docs search/filter surfaces relevant pages.
+4. Confirm the table of contents appears on a page with headings.
+5. Confirm the landing page header links to `/docs`.
+6. Confirm docs URLs are emitted by the sitemap source.
+7. Confirm `/docs` is reachable locally even when WorkOS redirect configuration is absent.
+
+# Non-goals for this change
+
+1. Do not add a new third-party docs framework in this pass.
+2. Do not try to fully solve the broader public-marketing auth surface beyond making docs reachable.
+3. Do not publish roadmap or compare pages unless they are grounded in existing shipped behavior.

--- a/testing/agentclash-docs-foundation.md
+++ b/testing/agentclash-docs-foundation.md
@@ -1,45 +1,62 @@
 ---
 title: AgentClash Docs Foundation Contract
-description: Review-checkpoint contract for the first public docs implementation in the web app.
+description: Review-checkpoint contract for the public docs implementation and AI-ingest exports in the web app.
 ---
 
 # Scope
 
-Implement the first production-facing docs foundation for AgentClash inside the existing Next.js app at `/docs`, using the current MDX toolchain already present in `web/`, and extend that foundation so the docs are publicly reachable, easier to navigate, and less hand-maintained.
+Implement a production-facing docs system for AgentClash inside the existing Next.js app at `/docs`, then extend it into a much more detailed A-to-Z docs surface that covers onboarding, core mental models, results interpretation, architecture, and contributor workflows. Add AI-ingest endpoints so the docs can be consumed as `llms.txt`, a bundled full-text export, and per-page markdown exports without introducing a separate docs framework.
 
 # Functional expectations
 
 1. The web app exposes a dedicated docs experience at `/docs` with a docs home page and nested docs pages.
 2. Docs content is file-backed in the repo and stored separately from blog content.
 3. Docs pages support frontmatter with `title` and `description`.
-4. The docs shell includes a left-hand navigation for the initial docs sections and highlights the current page.
+4. The docs shell includes a left-hand navigation for the shipped docs sections and highlights the current page.
 5. The docs shell is visually distinct from the blog and matches the current dark AgentClash aesthetic.
 6. The landing page header exposes a `Docs` entry so the new docs area is discoverable.
-7. Sitemap output includes the docs landing page and the initial shipped docs pages.
-8. Initial docs content only documents features and workflows that are already grounded in the current repo:
+7. Sitemap output includes the docs landing page, the shipped docs pages, and the new AI-ingest endpoints.
+8. Detailed docs content only documents features and workflows that are already grounded in the current repo, docs, or generated source readers. The shipped set for this phase includes:
    - product/docs landing
    - hosted quickstart
    - self-host quickstart
-   - runs/evals concept
    - first eval walkthrough
+   - runs and evals concept
+   - agents and deployments concept
+   - challenge packs and inputs concept
+   - replay and scorecards concept
+   - interpret results guide
+   - use with AI tools guide
    - generated CLI reference
    - generated config reference
    - architecture overview
    - orchestration architecture
+   - sandbox architecture
+   - data model architecture
+   - evidence loop architecture
    - frontend architecture
    - contributor setup
-9. The implementation must reuse the existing MDX/content pattern where practical instead of introducing a second docs framework dependency in this first step.
+   - contributor codebase tour
+   - contributor testing workflow
+9. The implementation must reuse the existing MDX/content pattern where practical instead of introducing a second docs framework dependency.
 10. `/docs` and nested docs routes are publicly reachable without tripping the AuthKit middleware redirect-URI requirement in a local environment with no WorkOS redirect env configured.
 11. The docs shell includes inline search/filtering across the shipped docs set.
 12. The docs shell includes a heading-based table of contents for pages that have section headings.
 13. At least two reference pages are generated from current source inputs rather than being fully hand-maintained.
-14. The follow-up implementation remains isolated in the docs worktree branch and is prepared for a GitHub PR.
+14. The app exposes `GET /llms.txt` as a concise machine-oriented index of the docs set with stable links.
+15. The app exposes `GET /llms-full.txt` as a single bundled plain-text/markdown export of the shipped docs set.
+16. The app exposes per-page markdown/plain-text exports under `/docs-md/...` for file-backed and generated docs pages.
+17. The AI-ingest surfaces point at AgentClash docs content and markdown exports without claiming first-party support or plugin integration from third-party assistant products.
+18. The implementation remains isolated in the docs worktree branch and updates the existing GitHub PR rather than opening a second PR.
 
 # Tests to add or run
 
 1. Run `pnpm build` in `web/` to catch routing, metadata, and MDX compilation issues.
 2. Run the built app locally and verify that `/docs` returns successfully without the AuthKit redirect-URI runtime error.
 3. Verify that a generated reference page renders successfully.
+4. Verify that `/llms.txt` returns successfully and includes links into the shipped docs set.
+5. Verify that `/llms-full.txt` returns successfully and contains multiple concatenated docs sections.
+6. Verify that at least one nested `/docs-md/...` route returns markdown/plain text successfully.
 
 # Manual verification
 
@@ -50,9 +67,13 @@ Implement the first production-facing docs foundation for AgentClash inside the 
 5. Confirm the landing page header links to `/docs`.
 6. Confirm docs URLs are emitted by the sitemap source.
 7. Confirm `/docs` is reachable locally even when WorkOS redirect configuration is absent.
+8. Confirm `/llms.txt` lists the docs index, the full bundle, and section-level markdown exports.
+9. Confirm `/llms-full.txt` contains readable bundled markdown for multiple pages.
+10. Confirm `/docs-md/getting-started/quickstart` returns a plain-text/markdown version of the quickstart page.
 
 # Non-goals for this change
 
 1. Do not add a new third-party docs framework in this pass.
 2. Do not try to fully solve the broader public-marketing auth surface beyond making docs reachable.
 3. Do not publish roadmap or compare pages unless they are grounded in existing shipped behavior.
+4. Do not claim official first-party plugin or deep-link integration with ChatGPT, Codex, Claude Code, or similar tools; provide portable AI-friendly endpoints instead.

--- a/web/content/docs/architecture/data-model.mdx
+++ b/web/content/docs/architecture/data-model.mdx
@@ -1,0 +1,67 @@
+---
+title: Data Model
+description: Learn the core entities behind workspaces, deployments, challenge packs, runs, and evidence in AgentClash.
+---
+
+The AgentClash data model exists to answer one question cleanly: what exactly was run, against what workload, and what evidence did it produce?
+
+## The core entities
+
+At a high level, the schema revolves around a small set of concepts:
+
+- workspaces: the ownership boundary for deployments and evaluation assets
+- deployments: the runnable agent targets attached to a workspace
+- challenge packs: repeatable workloads that define what should be attempted
+- runs: concrete execution attempts
+- replay events and artifacts: the evidence emitted while a run executes
+- scorecards and comparisons: the summarized judgments built from that evidence
+
+```mermaid
+flowchart TD
+  WS[Workspace]
+  WS --> DP[Deployment]
+  WS --> CP[Challenge pack]
+  DP --> RN[Run]
+  CP --> RN
+  RN --> EV[Replay events]
+  RN --> AR[Artifacts]
+  RN --> SC[Scorecards]
+```
+
+## Why the model is shaped this way
+
+The schema is not just there to persist app state. It is there to preserve comparability.
+
+If the system cannot answer these relationships clearly, the product falls apart:
+
+- which workspace owned the evaluated deployment
+- which workload definition the run used
+- which evidence belongs to that run
+- which summary or comparison was derived from that evidence
+
+That is why the data model follows the execution model closely instead of hiding it behind generic analytics tables.
+
+## What the schema needs to make cheap
+
+Three classes of queries matter in practice:
+
+- operator queries: what is currently running, stuck, or failing
+- reviewer queries: why did this run score the way it did
+- comparison queries: did the new deployment improve or regress on the same workload
+
+The current schema diagrams and domain notes in the repo are already organized around that shape. They optimize for traceability first, not just storage convenience.
+
+## Where to start in the repo
+
+The most useful entry points are:
+
+- `docs/database/schema-diagram.md` for the current entity map
+- `docs/domains/domains.md` for domain-level language and ownership boundaries
+- `backend/internal/api` for the read and write paths that expose those entities
+
+## See also
+
+- [Runs and Evals](../concepts/runs-and-evals)
+- [Challenge Packs and Inputs](../concepts/challenge-packs-and-inputs)
+- [Replay and Scorecards](../concepts/replay-and-scorecards)
+- [Overview](../architecture/overview)

--- a/web/content/docs/architecture/evidence-loop.mdx
+++ b/web/content/docs/architecture/evidence-loop.mdx
@@ -1,0 +1,59 @@
+---
+title: Evidence Loop
+description: See how AgentClash moves from execution events to replay, scorecards, and future evaluation improvement.
+---
+
+The evidence loop is the path that turns a finished run into something you can replay, score, compare, and learn from later.
+
+## Why this loop matters
+
+The hardest part of agent evaluation is not running one experiment. It is preserving enough evidence to make the next experiment smarter.
+
+AgentClash leans on a canonical event model so the same execution can feed multiple consumers:
+
+- a live or replayable timeline
+- artifacts and logs for detailed inspection
+- scorecards for compact judgments
+- future workload design when a failure is worth preserving
+
+```mermaid
+flowchart LR
+  EX[Execution] --> EV[Canonical events]
+  EV --> RP[Replay views]
+  EV --> AR[Artifacts and logs]
+  EV --> SC[Scorecards]
+  RP --> RV[Reviewer understanding]
+  SC --> CMP[Comparison decisions]
+  RV --> CP[Future challenge-pack improvements]
+  CMP --> CP
+```
+
+## The canonical event envelope is the hinge
+
+The replay docs in the repo make this explicit: if different subsystems emit ad-hoc logs, you cannot build a trustworthy replay or comparison layer on top. The canonical event envelope is the normalization step that keeps evidence portable.
+
+That gives AgentClash a cleaner stack:
+
+- execution code emits structured events
+- the UI can render those events as a timeline
+- scoring can summarize those events without losing the underlying trail
+- later analysis can reuse the same evidence instead of scraping logs again
+
+## Why scorecards should not replace evidence
+
+A scorecard is the summary, not the truth source. Treat it as the decision layer that sits on top of replay and artifacts. When there is disagreement about a result, the replay and artifact trail should still be there to settle it.
+
+That is the practical reason this loop exists. It keeps ranking and triage honest.
+
+## Where to start in the repo
+
+- `docs/replay/canonical-event-envelope.md` for the event model
+- `docs/evaluation/challenge-pack-v0.md` for how useful failures become future workloads
+- `web/src/app` for the frontend surfaces that consume replay and results
+
+## See also
+
+- [Replay and Scorecards](../concepts/replay-and-scorecards)
+- [Interpret Results](../guides/interpret-results)
+- [Data Model](../architecture/data-model)
+- [First Eval](../getting-started/first-eval)

--- a/web/content/docs/architecture/frontend.mdx
+++ b/web/content/docs/architecture/frontend.mdx
@@ -1,0 +1,50 @@
+---
+title: Frontend Architecture
+description: "The Next.js app is doing three jobs at once: public marketing pages, authenticated product surfaces, and now a public docs experience."
+---
+
+The web app is not just the dashboard. It currently carries the product landing pages, AuthKit-based auth flows, authenticated workspace routes, the blog, and the docs surface.
+
+## Route split
+
+```mermaid
+flowchart TD
+  Root[App Router] --> Public[Public pages]
+  Root --> Auth[Auth routes]
+  Root --> App[Authenticated workspace and org routes]
+  Root --> Docs[Docs routes]
+```
+
+## Public pages
+
+The landing page, team page, blog, and docs live in the same Next.js app so they can share typography, branding, and deployment infrastructure. The docs implementation deliberately reuses the same MDX stack already used by the blog instead of adding a second docs framework right away.
+
+## Authenticated app routes
+
+The authenticated product surfaces live under workspace and organization routes and are guarded by WorkOS AuthKit. That split matters for docs because the docs surface needs to stay public even when local WorkOS env is not configured.
+
+## Docs-specific decision
+
+The docs route is now treated as public and bypasses the AuthKit middleware path. That keeps `/docs` reachable in local development and in environments where the docs should be browsable without login.
+
+## Why keep docs in the existing app
+
+For this stage of the product, keeping docs inside the current Next.js app is the pragmatic move:
+
+- no second frontend deployment stack
+- reuse of existing fonts, theme tokens, and MDX tooling
+- one place to link from product pages into docs
+
+If the docs surface later needs versioning, heavy search, or separate publishing workflows, moving to a more specialized framework still stays open.
+
+## Code pointers
+
+- `web/src/app`
+- `web/src/middleware.ts`
+- `web/src/lib/blog.ts`
+- `web/src/lib/docs.ts`
+
+## See also
+
+- [Architecture Overview](/docs/architecture/overview)
+- [Hosted Quickstart](/docs/getting-started/quickstart)

--- a/web/content/docs/architecture/orchestration.mdx
+++ b/web/content/docs/architecture/orchestration.mdx
@@ -1,0 +1,51 @@
+---
+title: Orchestration
+description: The API server accepts the request, but Temporal and the worker are what make long-running run execution survivable.
+---
+
+AgentClash models long-running execution as workflow work, not as a single API request that tries to stay alive forever.
+
+## The runtime split
+
+```mermaid
+flowchart LR
+  BrowserOrCLI[Browser or CLI] --> API[API server]
+  API --> Temporal[Temporal]
+  Temporal --> Worker[Worker]
+  Worker --> Providers[Provider router]
+  Worker --> Sandbox[Sandbox provider]
+  Worker --> Events[Run event recorder]
+```
+
+## What the API server does
+
+The API server handles authentication, authorization, request validation, and persistence setup. For run creation, it wires the request into a Temporal workflow starter rather than trying to execute the whole run inline inside the HTTP handler.
+
+That keeps the API server responsive and gives the platform a durable handoff point for work that may outlive the incoming request.
+
+## What the worker does
+
+The worker connects to Temporal, Postgres, the provider router, and the sandbox provider. It owns the expensive part of the system:
+
+- provider calls
+- sandbox-backed execution
+- event emission
+- result persistence
+
+The worker also decides whether sandbox execution is really available. In the current code, `SANDBOX_PROVIDER=unconfigured` is a valid boot mode, which is why local run creation can succeed even when full native execution is not available.
+
+## Why Temporal is load-bearing here
+
+Run execution is exactly the category of problem where retries, timeouts, cancellation, and partial progress stop being “nice to have” as soon as you leave toy demos. Temporal gives AgentClash a durable workflow backbone so the API server can enqueue work, the worker can resume it, and failures can be handled with explicit workflow semantics instead of improvised queue glue.
+
+## Code pointers
+
+- `backend/cmd/api-server/main.go`
+- `backend/cmd/worker/main.go`
+- `backend/internal/worker`
+- `backend/internal/workflow`
+
+## See also
+
+- [Architecture Overview](/docs/architecture/overview)
+- [Frontend Architecture](/docs/architecture/frontend)

--- a/web/content/docs/architecture/overview.mdx
+++ b/web/content/docs/architecture/overview.mdx
@@ -1,0 +1,71 @@
+---
+title: Architecture Overview
+description: AgentClash is a monorepo with a small number of load-bearing runtime components. This page names them and explains why they are split this way.
+---
+
+AgentClash has four main runtime surfaces:
+
+- a Next.js web app for the product UI
+- a Go API server for REST and WebSocket traffic
+- a Go worker that executes run workflows
+- a Go CLI that talks to the API directly
+
+## System sketch
+
+```text
+browser / CLI
+      |
+      v
+  API server  ----> Postgres
+      |
+      +----> Redis (optional event fanout)
+      |
+      v
+   Temporal  <----> worker
+                    |
+                    +----> provider router
+                    +----> sandbox provider (optional E2B)
+                    +----> artifact storage
+```
+
+## Why it is shaped this way
+
+Temporal is the backbone because long-running agent work is exactly the kind of thing that turns into retry, timeout, cancellation, and partial-progress pain if you try to improvise a one-off orchestrator. The API server stays relatively thin: validate the request, load context, enqueue or signal workflow work, and expose the resulting state. The worker owns the expensive and failure-prone part of the system: provider calls, sandboxed execution, event recording, and workflow activities.
+
+That split also keeps the user-facing web app simpler. The web app does not need to own the run engine. It just renders state, telemetry, and management flows on top of the API.
+
+## Runtime components
+
+### Web
+
+The web app lives in `web/` and is a Next.js app using App Router.
+
+### API server
+
+The API server entry point is `backend/cmd/api-server/main.go`. It loads config, opens Postgres and Temporal clients, initializes storage, auth, and managers, then starts the HTTP server.
+
+### Worker
+
+The worker entry point is `backend/cmd/worker/main.go`. It loads config, connects to Postgres and Temporal, wires the provider router and sandbox provider, and runs the Temporal worker loop.
+
+### CLI
+
+The CLI lives in `cli/`. The root Cobra command is defined in `cli/cmd/root.go`, and the user-facing workflows are grouped under `auth`, `workspace`, `run`, and `compare`.
+
+## Optional infrastructure
+
+- Redis enables event publishing and fanout.
+- E2B enables sandboxed native execution.
+- S3-compatible storage replaces local filesystem artifact storage in production.
+
+## Code pointers
+
+- `backend/cmd/api-server/main.go`
+- `backend/cmd/worker/main.go`
+- `cli/cmd/root.go`
+- `web/src/app`
+
+## See also
+
+- [Self-Host Starter](/docs/getting-started/self-host)
+- [Contributor Setup](/docs/contributing/setup)

--- a/web/content/docs/architecture/sandbox-layer.mdx
+++ b/web/content/docs/architecture/sandbox-layer.mdx
@@ -1,0 +1,68 @@
+---
+title: Sandbox Layer
+description: Understand why AgentClash isolates execution behind a sandbox provider boundary and how E2B fits today.
+---
+
+The sandbox layer is the execution boundary between AgentClash orchestration and the environment where an agent actually runs.
+
+## Why the sandbox boundary exists
+
+The workflow engine should decide what to run and when to retry. It should not directly own process isolation, filesystem risk, network policy, or provider-specific runtime setup. Those concerns change at a different rate and carry a different failure model.
+
+That is why the architecture keeps a boundary between orchestration and execution:
+
+- the API decides that a run should exist
+- Temporal workflows coordinate the lifecycle
+- the worker performs execution work
+- the sandbox provider supplies isolation for the runnable target
+
+## Why E2B is the current fit
+
+The current local-development and worker docs show E2B as the concrete provider in use today. That gives AgentClash a managed isolation layer without having to invent a bespoke container orchestration story inside the app itself.
+
+The main benefits are straightforward:
+
+- isolation is handled outside the web and API processes
+- runtime setup is explicit and configurable through worker environment
+- the provider can be swapped later without rewriting the product model around runs and evidence
+
+```mermaid
+flowchart LR
+  API[API server] --> WF[Temporal workflow]
+  WF --> WK[Worker activity]
+  WK --> SB[Sandbox provider]
+  SB --> AG[Agent execution]
+  AG --> EV[Replay events and artifacts]
+```
+
+## What this boundary protects
+
+This is not only about security. It is also about keeping failure domains honest.
+
+When a run fails, you want to know whether the issue belongs to:
+
+- the scheduler
+- the worker logic
+- the sandbox provider
+- the agent itself
+
+A clean sandbox boundary makes that diagnosis easier because provider setup and execution failures do not get mixed into the same code path as API concerns.
+
+## What to read in the code
+
+Start with these files and directories:
+
+- `backend/internal/worker/config.go` for sandbox-related environment surface
+- `backend/internal/worker` for worker-side execution behavior
+- `docs/worker/local-development.md` for how the local stack expects the provider to be configured
+
+## Why not bake execution directly into the web or API app
+
+Because that would collapse the concerns that need to stay separate. You would tie request handling, orchestration, and risky execution into the same operational surface. That is faster for a demo and worse for a real evaluation platform.
+
+## See also
+
+- [Orchestration](../architecture/orchestration)
+- [Evidence Loop](../architecture/evidence-loop)
+- [Self-Host](../getting-started/self-host)
+- [Config Reference](../reference/config)

--- a/web/content/docs/concepts/agents-and-deployments.mdx
+++ b/web/content/docs/concepts/agents-and-deployments.mdx
@@ -1,0 +1,68 @@
+---
+title: Agents and Deployments
+description: Understand how AgentClash turns an abstract agent idea into a concrete runnable target inside a workspace.
+---
+
+A deployment is the concrete runnable target that AgentClash can schedule into a run.
+
+<Callout type="warning">
+  The deployment surface is still evolving. Treat the current docs as a model
+  for how the system is shaped today, not a frozen 1.0 contract.
+</Callout>
+
+## Why AgentClash talks about deployments
+
+Most evaluation tools stop at the model name. AgentClash has to be stricter than that because it needs to run the same thing repeatedly, under the same constraints, and compare the resulting evidence. A deployment is the unit that gives the platform that stability.
+
+In practice, a deployment answers questions like these:
+
+- What agent should be invoked for this run?
+- Which workspace owns that runnable target?
+- Which credentials or backing provider settings are attached?
+- Which challenge packs is the deployment expected to handle?
+
+That is why the docs separate the idea of an "agent" from the thing the scheduler can actually execute. The agent is the product concept. The deployment is the runnable contract.
+
+## The lifecycle from workspace to run
+
+A typical flow looks like this:
+
+```mermaid
+flowchart LR
+  W[Workspace] --> D[Deployment]
+  D --> R[Run]
+  CP[Challenge pack] --> R
+  R --> EV[Replay events]
+  R --> SC[Scorecards]
+```
+
+The workspace owns the deployment. A run then combines that deployment with a challenge pack or other eval input. From there the worker executes the attempt, streams canonical events, and stores the evidence needed for scoring and replay.
+
+The important part is reproducibility. If two runs claim to compare the same deployment, they need to point at the same runnable target, not just the same marketing label.
+
+## What is stable today
+
+The repo already reflects the existence of workspaces, deployments, challenge packs, and runs. You can see this in the CLI flow and the current docs/build notes:
+
+- the CLI expects you to select a workspace before creating runs
+- local and staging walkthroughs assume challenge packs and deployments already exist
+- the current architecture separates orchestration from execution so a run can target a concrete deployment repeatedly
+
+What is still moving is the exact shape of the deployment surface, especially around provider-specific configuration and richer setup workflows.
+
+## How to think about provider configuration
+
+The clean mental model is this:
+
+- provider details are implementation details
+- the deployment is the stable runtime handle
+- the run binds that deployment to an input workload
+
+That keeps the user-facing evaluation model simple. You compare runs and evals. Under the hood, AgentClash still knows which runnable target produced those results.
+
+## See also
+
+- [Runs and Evals](../concepts/runs-and-evals)
+- [Challenge Packs and Inputs](../concepts/challenge-packs-and-inputs)
+- [First Eval](../getting-started/first-eval)
+- [CLI Reference](../reference/cli)

--- a/web/content/docs/concepts/agents-and-deployments.mdx
+++ b/web/content/docs/concepts/agents-and-deployments.mdx
@@ -1,68 +1,135 @@
 ---
 title: Agents and Deployments
-description: Understand how AgentClash turns an abstract agent idea into a concrete runnable target inside a workspace.
+description: Understand how AgentClash turns a build plus runtime/provider resources into a concrete deployment that can be scheduled into a run.
 ---
 
-A deployment is the concrete runnable target that AgentClash can schedule into a run.
+A deployment is the workspace-scoped runnable target that AgentClash can attach to a run.
 
-<Callout type="warning">
-  The deployment surface is still evolving. Treat the current docs as a model
-  for how the system is shaped today, not a frozen 1.0 contract.
-</Callout>
+## Why a deployment exists at all
 
-## Why AgentClash talks about deployments
+AgentClash is stricter than a typical playground because it has to compare like with like. A model name by itself is not enough. The scheduler needs a concrete object that says:
 
-Most evaluation tools stop at the model name. AgentClash has to be stricter than that because it needs to run the same thing repeatedly, under the same constraints, and compare the resulting evidence. A deployment is the unit that gives the platform that stability.
+- which build is being run
+- which build version is current
+- which runtime policy applies
+- which provider credentials or model mapping are attached
 
-In practice, a deployment answers questions like these:
+That concrete object is the deployment.
 
-- What agent should be invoked for this run?
-- Which workspace owns that runnable target?
-- Which credentials or backing provider settings are attached?
-- Which challenge packs is the deployment expected to handle?
+## The current creation contract
 
-That is why the docs separate the idea of an "agent" from the thing the scheduler can actually execute. The agent is the product concept. The deployment is the runnable contract.
+The current API schema for `CreateAgentDeploymentRequest` requires:
 
-## The lifecycle from workspace to run
+- `name`
+- `agent_build_id`
+- `build_version_id`
+- `runtime_profile_id`
 
-A typical flow looks like this:
+It also supports these optional fields:
+
+- `provider_account_id`
+- `model_alias_id`
+- `deployment_config`
+
+The OpenAPI description also says only ready build versions can be deployed.
 
 ```mermaid
 flowchart LR
-  W[Workspace] --> D[Deployment]
+  AB[Agent build] --> BV[Ready build version]
+  RP[Runtime profile] --> D[Deployment]
+  PA[Provider account] --> D
+  MA[Model alias] --> D
+  BV --> D
   D --> R[Run]
-  CP[Challenge pack] --> R
-  R --> EV[Replay events]
-  R --> SC[Scorecards]
 ```
 
-The workspace owns the deployment. A run then combines that deployment with a challenge pack or other eval input. From there the worker executes the attempt, streams canonical events, and stores the evidence needed for scoring and replay.
+## Runtime profiles are the execution envelope
 
-The important part is reproducibility. If two runs claim to compare the same deployment, they need to point at the same runnable target, not just the same marketing label.
+A runtime profile defines how aggressive or constrained execution should be. In the current API and web types, a runtime profile carries fields like:
 
-## What is stable today
+- `execution_target`
+- `trace_mode`
+- `max_iterations`
+- `max_tool_calls`
+- `step_timeout_seconds`
+- `run_timeout_seconds`
+- `profile_config`
 
-The repo already reflects the existence of workspaces, deployments, challenge packs, and runs. You can see this in the CLI flow and the current docs/build notes:
+That last field matters. The native executor reads runtime-profile sandbox overrides from `profile_config`, including things like filesystem roots and `allow_shell` or `allow_network` toggles.
 
-- the CLI expects you to select a workspace before creating runs
-- local and staging walkthroughs assume challenge packs and deployments already exist
-- the current architecture separates orchestration from execution so a run can target a concrete deployment repeatedly
+The clean mental model is:
 
-What is still moving is the exact shape of the deployment surface, especially around provider-specific configuration and richer setup workflows.
+- the challenge pack defines what the workload wants
+- the runtime profile defines execution ceilings and local overrides
+- the deployment binds those choices to a runnable target
 
-## How to think about provider configuration
+## Provider accounts are how credentials enter the system
 
-The clean mental model is this:
+A provider account is a workspace resource with:
 
-- provider details are implementation details
-- the deployment is the stable runtime handle
-- the run binds that deployment to an input workload
+- `provider_key`
+- `name`
+- `credential_reference`
+- optional `limits_config`
 
-That keeps the user-facing evaluation model simple. You compare runs and evals. Under the hood, AgentClash still knows which runnable target produced those results.
+The important detail is how credentials are stored.
+
+If you create a provider account with a raw `api_key`, the infrastructure manager stores that value as a workspace secret and rewrites the credential reference automatically to:
+
+```text
+workspace-secret://PROVIDER_<PROVIDER_KEY>_API_KEY
+```
+
+So the product already prefers indirection over plaintext credentials on the resource itself.
+
+## Model aliases are not just display sugar
+
+The user question usually comes out as “provider alias” or “model alias.” In the current product surface, the real resource is `model alias`.
+
+A model alias maps a workspace-friendly key to a model catalog entry, and can optionally be tied to a provider account. The current fields are:
+
+- `alias_key`
+- `display_name`
+- `model_catalog_entry_id`
+- optional `provider_account_id`
+
+That gives you a stable name inside the workspace even if the underlying provider model identifier is ugly or if you need multiple account-specific mappings.
+
+## A deployment is where these pieces come together
+
+A good way to think about the chain is:
+
+- agent build version: what logic is being deployed
+- runtime profile: how it is allowed to execute
+- provider account: which credentials or spend limits back external model calls
+- model alias: which model selection the deployment should use consistently
+- deployment: the runnable handle used by runs
+
+This is why the docs should not collapse deployment into “selected model.” The object is richer than that.
+
+## What the UI and CLI expose today
+
+The current repo already exposes the resource model across multiple surfaces:
+
+- CLI `deployment create` and `deployment list`
+- workspace pages for runtime profiles, provider accounts, model aliases, deployments, secrets, and tools
+- run creation UI that asks for challenge pack and deployment selection separately
+
+That separation is deliberate. A run is an execution event. A deployment is reusable infrastructure state.
+
+## What is stable versus still moving
+
+The stable part is the dependency chain and the API surface. The still-moving part is how richly each resource is edited in the UI and how much automation exists around them.
+
+So the right docs posture is:
+
+- document the current fields and flows precisely
+- avoid pretending the deployment UX is fully polished
+- treat the resource model itself as real and important
 
 ## See also
 
-- [Runs and Evals](../concepts/runs-and-evals)
+- [Configure Runtime Resources](../guides/configure-runtime-resources)
 - [Challenge Packs and Inputs](../concepts/challenge-packs-and-inputs)
-- [First Eval](../getting-started/first-eval)
+- [Tools, Network, and Secrets](../concepts/tools-network-and-secrets)
 - [CLI Reference](../reference/cli)

--- a/web/content/docs/concepts/artifacts.mdx
+++ b/web/content/docs/concepts/artifacts.mdx
@@ -1,0 +1,132 @@
+---
+title: Artifacts
+description: Understand workspace artifacts, pack assets, run evidence files, and how downloads are signed and delivered.
+---
+
+An artifact is a stored file object that AgentClash can keep at workspace scope, attach to runs, reference from challenge packs, and expose through signed downloads.
+
+## What an artifact is in the current product
+
+The current artifact response shape already tells you the core model:
+
+- `workspace_id`
+- optional `run_id`
+- optional `run_agent_id`
+- `artifact_type`
+- optional `content_type`
+- optional `size_bytes`
+- optional `checksum_sha256`
+- `visibility`
+- `metadata`
+- `created_at`
+
+That means artifacts are not only run outputs. They can exist before a run and be used as reusable workspace context.
+
+## There are two important artifact roles
+
+### 1. Workspace-managed files
+
+The workspace UI and API let you upload arbitrary files to the workspace artifact store.
+
+The current artifacts page describes them as files you can:
+
+- use as context in challenge packs
+- attach to runs
+
+That is the right mental model. Upload once, then reuse where it makes sense.
+
+### 2. Run evidence files
+
+Runs and replay events can also point at artifacts. Those become part of the evidence trail for later inspection, scoring, or failure review.
+
+That is why replay and failure-review models carry artifact references. Artifacts are part of the audit trail, not just incidental attachments.
+
+```mermaid
+flowchart LR
+  WA[Workspace artifact upload] --> CP[Challenge pack assets]
+  WA --> R[Run]
+  R --> EV[Replay events]
+  EV --> FR[Failure review]
+  CP --> SCORE[Scoring evidence]
+```
+
+## Challenge-pack assets and artifact refs
+
+Challenge packs do not embed giant blobs directly into YAML. They declare assets and then refer to them by key.
+
+The bundle model supports assets at multiple levels:
+
+- `version.assets`
+- `challenge.assets`
+- `case.assets`
+
+Each asset can carry:
+
+- `key`
+- `path`
+- `kind`
+- `media_type`
+- optional `artifact_id`
+
+Then other parts of the pack can reference those declared assets using:
+
+- `artifact_refs`
+- `artifact_key`
+- expectation sources like `artifact:<key>`
+
+Validation already checks that those references are real. If the key or artifact ID does not resolve, validation fails before publish.
+
+## The published bundle is itself tracked as an artifact
+
+When you publish a challenge pack, the response may include `bundle_artifact_id`.
+
+That is an important detail because it means the authored pack bundle is treated as a stored object of record. The product does not only store parsed rows; it can also retain the published source bundle as an artifact.
+
+## Upload and download flow
+
+The current API surface is:
+
+- `GET /v1/workspaces/{workspaceID}/artifacts`
+- `POST /v1/workspaces/{workspaceID}/artifacts`
+- `GET /v1/artifacts/{artifactID}/download`
+- public content route at `/artifacts/{artifactID}/content`
+
+The upload path is multipart and supports:
+
+- `file`
+- `artifact_type`
+- optional `run_id`
+- optional `run_agent_id`
+- optional `metadata`
+
+The download flow is intentionally indirect. The API returns a signed URL and expiry, then the actual file content is served through the public content endpoint. That keeps raw artifact content behind signed access rather than exposing direct permanent object URLs.
+
+## Visibility and metadata matter
+
+Artifacts also carry `visibility` and arbitrary JSON `metadata`.
+
+The current UI uses metadata to recover nicer names like `original_filename`. If no filename metadata exists, it falls back to showing the artifact ID prefix.
+
+That sounds minor, but it is a sign that metadata is a first-class part of the artifact model, not just a debug dump.
+
+## When to use artifacts versus inline YAML data
+
+Use inline bundle data when:
+
+- the value is small
+- it belongs directly in the challenge definition
+- you want the pack to stay self-contained
+
+Use artifacts when:
+
+- the file is large or binary
+- you want reuse across packs or runs
+- the same file should be downloadable later
+- the evidence trail should preserve it as a named object
+
+## See also
+
+- [Challenge Packs and Inputs](../concepts/challenge-packs-and-inputs)
+- [Write a Challenge Pack](../guides/write-a-challenge-pack)
+- [Evidence Loop](../architecture/evidence-loop)
+- [Data Model](../architecture/data-model)

--- a/web/content/docs/concepts/challenge-packs-and-inputs.mdx
+++ b/web/content/docs/concepts/challenge-packs-and-inputs.mdx
@@ -1,71 +1,164 @@
 ---
 title: Challenge Packs and Inputs
-description: Learn how AgentClash groups tasks, examples, and scoring context into repeatable evaluation workloads.
+description: Learn what a challenge pack really is in AgentClash, how the bundle is structured, and how inputs become runnable cases.
 ---
 
-A challenge pack is the repeatable workload definition that tells AgentClash what to run, against which inputs, and how to interpret the resulting evidence.
+A challenge pack is a versioned YAML bundle that defines the workload, scoring contract, execution policy, and input sets for a repeatable evaluation.
 
-## Why challenge packs exist
+## What makes it a challenge pack instead of a prompt
 
-A single prompt or one-off run is not enough to tell you whether an agent is improving. AgentClash needs a package of work that can be rerun, compared, and discussed without argument about the setup. That is what the challenge pack is for.
+A challenge pack is not just a task description. In the current repo, a runnable pack carries enough structure for AgentClash to do four jobs consistently:
 
-From the current evaluation docs, the load-bearing idea is not just "a scenario". It is a bundle that includes the task definition, the input set, and the scoring context around that task. That gives you three useful properties:
+- execute the same workload again later
+- attach one or more deployments to that workload
+- score the result using a versioned evaluation spec
+- preserve the relationship between a failed case and the evidence that exposed it
 
-- repeatability: the same workload can be rerun after code or prompt changes
-- comparability: two deployments can be graded against the same workload
-- traceability: when a run fails, you can tie the failure back to a concrete case
+That is why the API does not ask you to start a run with a loose prompt blob. It asks for a `challenge_pack_version_id`.
 
-## Pack, scenario, and input are different things
+## The current bundle shape
 
-These terms are easy to blur together, so keep them separate:
+The parser in `backend/internal/challengepack/bundle.go` expects a YAML bundle with these top-level sections:
 
-- challenge pack: the top-level container for a repeatable eval workload
-- scenario: the task pattern or rules an agent is being judged against
-- input: the concrete example or case that turns a scenario into an actual run attempt
+- `pack`: human metadata like `slug`, `name`, and `family`
+- `version`: the executable version block
+- `tools`: optional pack-defined composed tools
+- `challenges`: the workload definitions
+- `input_sets`: the concrete runnable cases
+
+A pack becomes runnable through its `version` block. That block currently carries the load-bearing execution data:
+
+- `number`: the pack version number
+- `execution_mode`: `native` or `prompt_eval`
+- `tool_policy`: allowed tool kinds and runtime toggles
+- `filesystem`: optional filesystem constraints
+- `sandbox`: network, env, package, and template configuration
+- `evaluation_spec`: the scoring contract
+- `assets`: version-scoped files or artifact references
 
 ```mermaid
 flowchart TD
-  CP[Challenge pack]
-  CP --> S1[Scenario A]
-  CP --> S2[Scenario B]
-  S1 --> I1[Input 1]
-  S1 --> I2[Input 2]
-  S2 --> I3[Input 3]
-  I1 --> R1[Run attempt]
-  I2 --> R2[Run attempt]
-  I3 --> R3[Run attempt]
+  P[pack metadata]
+  V[version]
+  V --> ES[evaluation_spec]
+  V --> SB[sandbox]
+  V --> TP[tool_policy]
+  V --> AS[version assets]
+  C[challenges] --> IS[input_sets]
+  IS --> CASES[cases]
+  V --> RUN[run execution]
+  CASES --> RUN
+  ES --> SCORE[scorecards]
 ```
 
-When you look at results, this distinction matters. A weak score can come from one bad input, one brittle scenario, or a deployment that underperforms across the whole pack.
+## Challenge, input set, case, and asset are different things
 
-## What the pack needs to carry
+These terms are easy to blur together. Do not blur them.
 
-The current challenge-pack design notes point toward a few pieces that matter in practice:
+- challenge pack: the entire versioned bundle
+- challenge: one task definition inside the bundle
+- input set: one named collection of runnable cases for that pack version
+- case: one concrete workload item tied to a challenge via `challenge_key`
+- asset: a file-like dependency declared by key and path, optionally backed by a stored artifact ID
 
-- metadata so humans know what the workload is supposed to test
-- the input set that actually drives the run fan-out
-- scoring or judgment context so results can be turned into something comparable
-- enough structure to promote good examples into regression workloads later
+The bundle model in the repo uses `input_sets[].cases[]` as the main execution unit. A case can carry:
 
-That last part matters more than it sounds. In a serious eval system, good challenge packs are built from real failures, not invented in isolation.
+- `payload`
+- structured `inputs`
+- structured `expectations`
+- `artifacts`
+- case-local `assets`
 
-## How this shows up in a run
+That makes cases more expressive than a single flat prompt. They can reference files, expected outputs, and evaluator inputs without inventing an ad-hoc schema per benchmark.
 
-A run is where the abstract pack becomes concrete. The run binds:
+## The evaluation spec is part of the pack, not global product config
 
-- one deployment
-- one workload definition
-- one concrete execution attempt per input or case
+The current evaluation docs are explicit about this. The scoring contract lives inside the pack version’s manifest. That means the pack defines:
 
-That means you can ask precise questions later:
+- validator keys and types
+- metrics and collectors
+- runtime limits
+- pricing rows used for cost scoring
+- scorecard dimensions and normalization thresholds
 
-- Did this deployment fail one input or the whole pack?
-- Did the replay show a sandbox failure, tool failure, or agent reasoning failure?
-- Did a new build improve the median score but regress one important scenario?
+This matters because AgentClash needs scorecards to remain auditable. When a run is scored, the product can persist the exact `evaluation_spec_id` that was used. The publish response already returns that ID.
+
+## Execution mode matters
+
+Two execution modes are visible in the current code and examples:
+
+- `prompt_eval`: lighter-weight packs that focus on prompt-style evaluation
+- `native`: packs that can carry sandbox, tool, and execution policy for richer runs
+
+You should choose the simpler mode unless the workload really needs a sandbox, files, or tool execution.
+
+## Sandbox, tool policy, and internet access belong to the pack version
+
+This is one of the most important design choices in the repo.
+
+The pack version can say what the evaluator is allowed to do:
+
+- which tool kinds are allowed
+- whether shell or network access is enabled
+- what network CIDRs are allowed
+- which additional packages should exist in the sandbox
+- which env vars are injected as literal values
+
+In other words, the pack is not only content. It is also policy.
+
+## Assets and artifact-backed packs
+
+The version block, challenge blocks, and case blocks can all reference assets. Each asset has a `key` and `path`, and may also carry `media_type`, `kind`, or `artifact_id`.
+
+That gives you two useful authoring patterns:
+
+- check small fixtures into the pack and refer to them by path
+- attach previously uploaded workspace artifacts and refer to them by `artifact_id`
+
+Validation already checks that asset references are real. If a case or expectation points at an artifact key that was never declared, publish-time validation fails.
+
+## Publish and validate are first-class workflow steps
+
+The API and CLI already expose the authoring loop directly:
+
+- validate with `POST /v1/workspaces/{workspaceID}/challenge-packs/validate`
+- publish with `POST /v1/workspaces/{workspaceID}/challenge-packs`
+- list packs with `GET /v1/workspaces/{workspaceID}/challenge-packs`
+- list published input sets with `GET /v1/workspaces/{workspaceID}/challenge-pack-versions/{versionID}/input-sets`
+
+The CLI mirrors that with:
+
+```bash
+agentclash challenge-pack validate <file>
+agentclash challenge-pack publish <file>
+agentclash challenge-pack list
+```
+
+Publish returns more than a pack ID. It returns:
+
+- `challenge_pack_id`
+- `challenge_pack_version_id`
+- `evaluation_spec_id`
+- `input_set_ids`
+- optional `bundle_artifact_id`
+
+That tells you the pack bundle is treated as a concrete artifact of record, not just transient YAML.
+
+## How a pack becomes a run
+
+A run binds:
+
+- one `challenge_pack_version_id`
+- one or more deployment IDs
+- optionally one selected input set
+
+From there the worker resolves the pack manifest, execution policy, assets, and scoring contract into the runtime path.
+
+That is why challenge packs are foundational in AgentClash. They are the unit that makes two runs comparable without hand-waving.
 
 ## See also
 
-- [First Eval](../getting-started/first-eval)
-- [Replay and Scorecards](../concepts/replay-and-scorecards)
-- [Interpret Results](../guides/interpret-results)
-- [Runs and Evals](../concepts/runs-and-evals)
+- [Write a Challenge Pack](../guides/write-a-challenge-pack)
+- [Agents and Deployments](../concepts/agents-and-deployments)
+- [Tools, Network, and Secrets](../concepts/tools-network-and-secrets)
+- [Artifacts](../concepts/artifacts)

--- a/web/content/docs/concepts/challenge-packs-and-inputs.mdx
+++ b/web/content/docs/concepts/challenge-packs-and-inputs.mdx
@@ -1,0 +1,71 @@
+---
+title: Challenge Packs and Inputs
+description: Learn how AgentClash groups tasks, examples, and scoring context into repeatable evaluation workloads.
+---
+
+A challenge pack is the repeatable workload definition that tells AgentClash what to run, against which inputs, and how to interpret the resulting evidence.
+
+## Why challenge packs exist
+
+A single prompt or one-off run is not enough to tell you whether an agent is improving. AgentClash needs a package of work that can be rerun, compared, and discussed without argument about the setup. That is what the challenge pack is for.
+
+From the current evaluation docs, the load-bearing idea is not just "a scenario". It is a bundle that includes the task definition, the input set, and the scoring context around that task. That gives you three useful properties:
+
+- repeatability: the same workload can be rerun after code or prompt changes
+- comparability: two deployments can be graded against the same workload
+- traceability: when a run fails, you can tie the failure back to a concrete case
+
+## Pack, scenario, and input are different things
+
+These terms are easy to blur together, so keep them separate:
+
+- challenge pack: the top-level container for a repeatable eval workload
+- scenario: the task pattern or rules an agent is being judged against
+- input: the concrete example or case that turns a scenario into an actual run attempt
+
+```mermaid
+flowchart TD
+  CP[Challenge pack]
+  CP --> S1[Scenario A]
+  CP --> S2[Scenario B]
+  S1 --> I1[Input 1]
+  S1 --> I2[Input 2]
+  S2 --> I3[Input 3]
+  I1 --> R1[Run attempt]
+  I2 --> R2[Run attempt]
+  I3 --> R3[Run attempt]
+```
+
+When you look at results, this distinction matters. A weak score can come from one bad input, one brittle scenario, or a deployment that underperforms across the whole pack.
+
+## What the pack needs to carry
+
+The current challenge-pack design notes point toward a few pieces that matter in practice:
+
+- metadata so humans know what the workload is supposed to test
+- the input set that actually drives the run fan-out
+- scoring or judgment context so results can be turned into something comparable
+- enough structure to promote good examples into regression workloads later
+
+That last part matters more than it sounds. In a serious eval system, good challenge packs are built from real failures, not invented in isolation.
+
+## How this shows up in a run
+
+A run is where the abstract pack becomes concrete. The run binds:
+
+- one deployment
+- one workload definition
+- one concrete execution attempt per input or case
+
+That means you can ask precise questions later:
+
+- Did this deployment fail one input or the whole pack?
+- Did the replay show a sandbox failure, tool failure, or agent reasoning failure?
+- Did a new build improve the median score but regress one important scenario?
+
+## See also
+
+- [First Eval](../getting-started/first-eval)
+- [Replay and Scorecards](../concepts/replay-and-scorecards)
+- [Interpret Results](../guides/interpret-results)
+- [Runs and Evals](../concepts/runs-and-evals)

--- a/web/content/docs/concepts/replay-and-scorecards.mdx
+++ b/web/content/docs/concepts/replay-and-scorecards.mdx
@@ -1,0 +1,58 @@
+---
+title: Replay and Scorecards
+description: Understand how run events become a readable timeline, a defensible score, and a reusable evidence trail.
+---
+
+Replay is the ordered event history of a run. Scorecards are the condensed judgments and summaries built from that evidence.
+
+## Why AgentClash stores both
+
+If you only keep a final score, you lose the explanation. If you only keep raw logs, nobody can compare anything quickly. AgentClash needs both because the product is about arguing from evidence, not from vibes.
+
+The canonical event envelope work in the repo makes that boundary explicit. Execution emits structured events. The frontend and downstream analysis layers can replay those events as a timeline. Scorecards then turn the same evidence into something compact enough to rank, filter, and compare.
+
+## Replay is the source of truth
+
+Think of replay as the forensic record. It answers questions like:
+
+- what happened first
+- when the agent called a tool
+- when the sandbox or infrastructure layer failed
+- when artifacts or outputs were produced
+- what the final terminal state was
+
+That is why replay data should be preserved even when the top-line score looks obvious. The run may still teach you something the score alone cannot show.
+
+## Scorecards are the decision layer
+
+A scorecard should make a run legible in seconds. The exact schema will keep evolving, but the purpose is stable:
+
+- summarize whether the run passed, failed, or degraded
+- attach the evidence that justifies that judgment
+- make comparisons across runs possible without rereading the full trace
+
+```mermaid
+flowchart LR
+  EV[Canonical events] --> RP[Replay timeline]
+  EV --> SC[Scorecard]
+  RP --> UI[Run detail view]
+  SC --> CMP[Compare and ranking views]
+```
+
+## How to use both together
+
+The fastest useful workflow is:
+
+1. start with the scorecard to see whether the run is healthy
+2. move to the replay timeline to understand why
+3. inspect artifacts when the failure is ambiguous or multi-step
+4. compare against another run only after you trust the evidence on each side
+
+That sequence sounds basic, but it prevents a common failure mode: overreacting to a single score change without checking whether the underlying run actually exercised the same path.
+
+## See also
+
+- [Interpret Results](../guides/interpret-results)
+- [Evidence Loop](../architecture/evidence-loop)
+- [Challenge Packs and Inputs](../concepts/challenge-packs-and-inputs)
+- [Data Model](../architecture/data-model)

--- a/web/content/docs/concepts/runs-and-evals.mdx
+++ b/web/content/docs/concepts/runs-and-evals.mdx
@@ -1,0 +1,31 @@
+---
+title: Runs and Evals
+description: The product language around runs and evals is easy to blur. The current codebase makes one distinction especially important.
+---
+
+A **run** is the concrete execution object you create, stream, rank, compare, and inspect in AgentClash today.
+
+In the current user-facing product surface, `run` is the first-class noun:
+
+- `agentclash run create`
+- `agentclash run list`
+- `agentclash run ranking`
+- `agentclash compare gate --baseline <RUN_ID> --candidate <RUN_ID>`
+
+A run is not just one model token stream. It is the container for a scored evaluation attempt inside a workspace, including the challenge pack version, selected agent deployments, lifecycle timestamps, and ranking output.
+
+The word **eval** is broader. People use it to mean “the experiment I am trying to run” or “the graded set of results I care about.” That is reasonable, but if you are reading the code or the CLI, you should anchor on this:
+
+- **Run** = the concrete resource you create and query.
+- **Eval** = the broader exercise or outcome you are trying to measure.
+
+There are also places in the codebase that refer to eval sessions, but the main shipped workflow today still revolves around runs and ranked run results. If you keep that in your head, the CLI and API are much easier to follow.
+
+## Practical rule of thumb
+
+Use **run** when you are talking about a real resource ID. Use **eval** when you are talking about the experiment design or the larger testing loop.
+
+## See also
+
+- [Hosted Quickstart](/docs/getting-started/quickstart)
+- [CLI Reference](/docs/reference/cli)

--- a/web/content/docs/concepts/tools-network-and-secrets.mdx
+++ b/web/content/docs/concepts/tools-network-and-secrets.mdx
@@ -1,0 +1,169 @@
+---
+title: Tools, Network, and Secrets
+description: Learn the difference between workspace tools, pack-defined tools, and engine primitives, and how network and secret handling are constrained.
+---
+
+AgentClash has more than one “tool” layer. If you do not separate them mentally, the rest of the runtime model gets confusing fast.
+
+## There are three different layers to know
+
+### 1. Workspace tool resources
+
+The workspace API already exposes first-class `tools` resources with fields like:
+
+- `name`
+- `tool_kind`
+- `capability_key`
+- `definition`
+- `lifecycle_status`
+
+These are infrastructure resources that live alongside runtime profiles, provider accounts, and model aliases.
+
+### 2. Pack-defined composed tools
+
+Inside a challenge pack, the optional top-level `tools` block lets a pack author define custom tool interfaces that the evaluated agent can see.
+
+Those definitions are pack-local. They are part of the authored benchmark bundle.
+
+### 3. Engine primitives
+
+At the bottom are the built-in executor primitives, like `http_request`. These are the concrete operations the runtime knows how to execute safely.
+
+A pack-defined tool can delegate to a primitive. That is the key distinction.
+
+## Primitive versus composed tool
+
+The current validation code expects composed tools to look roughly like this:
+
+```yaml
+tools:
+  custom:
+    - name: check_inventory
+      description: Check inventory by SKU
+      parameters:
+        type: object
+        properties:
+          sku:
+            type: string
+      implementation:
+        primitive: http_request
+        args:
+          method: GET
+          url: https://api.example.com/inventory/${sku}
+          headers:
+            Authorization: Bearer ${secrets.INVENTORY_API_KEY}
+```
+
+What this means:
+
+- `check_inventory` is the tool name the agent sees
+- `http_request` is the engine primitive that actually runs
+- `args` is the templated mapping from tool parameters to primitive inputs
+
+So when people ask “primitive tools vs actual tools,” the clean answer is:
+
+- primitives are built-in executor operations
+- composed tools are the author-defined tool contracts that delegate to those primitives
+- workspace tool resources are a separate infrastructure surface
+
+## Validation is strict on purpose
+
+The current parser and tests already reject several dangerous or ambiguous cases:
+
+- unknown template placeholders like `${missing}`
+- self-referencing tools where a tool delegates to itself
+- delegation cycles across composed tools
+- invalid JSON-schema parameter definitions
+- missing primitive names or missing args blocks
+
+That strictness is good. A benchmark bundle should fail at publish time rather than fail mysteriously at run time.
+
+## Tool kinds are a separate gate from tool names
+
+The sandbox policy also carries `allowed_tool_kinds`. That means the pack can say which broad categories are available, for example:
+
+- `file`
+- `shell`
+- `network`
+
+This is different from a specific composed-tool name. A pack might define `check_inventory`, but the runtime still checks whether the underlying kind is allowed.
+
+## Internet access is not automatic
+
+The current runtime does not treat network as free ambient capability.
+
+There are at least three control points visible in the repo:
+
+- the sandbox/tool policy starts with network disabled by default
+- the pack can enable outbound networking through `sandbox.network_access` and related policy toggles
+- the `http_request` primitive validates the target URL and CIDR allowlist before making a request
+
+The current `http_request.py` helper does all of this:
+
+- allows only `http` and `https`
+- rejects missing hosts
+- resolves DNS and checks resolved addresses
+- blocks private, loopback, link-local, reserved, and multicast addresses unless explicitly allowlisted
+- enforces request and response body limits
+- sanitizes error handling so secret-bearing values do not leak back to the agent
+
+So the current answer to “how can you call the external internet?” is:
+
+- use a tool path that ultimately delegates to a network-capable primitive like `http_request`
+- enable network access in the pack/runtime policy
+- keep the destination within the permitted network rules
+
+## Secrets live outside the pack
+
+The product already exposes workspace-scoped secrets as a first-class surface.
+
+You can:
+
+- list secret keys
+- set a secret value
+- delete a secret
+
+The list endpoint intentionally returns metadata only. Secret values never come back out.
+
+The CLI surface is:
+
+```bash
+agentclash secret list
+agentclash secret set <KEY>
+agentclash secret delete <KEY>
+```
+
+## Where secret references resolve
+
+There are two distinct secret-reference patterns in the current code:
+
+- `workspace-secret://KEY` for provider credential resolution
+- `${secrets.KEY}` inside composed-tool argument templates
+
+These are not interchangeable.
+
+`workspace-secret://KEY` is used when the provider layer resolves account credentials.
+
+`${secrets.KEY}` is used during composed-tool argument substitution. The engine then decides whether the target primitive is allowed to receive secret-bearing args.
+
+## Only hardened primitives can accept `${secrets.*}`
+
+This is a security boundary, not a convenience feature.
+
+The current `primitive_secrets.go` file says only secret-safe primitives may receive `${secrets.*}` substitutions, and today that allowlist intentionally includes only `http_request`.
+
+The reason is straightforward:
+
+- secrets must not end up in argv
+- secrets must not land in readable sandbox files
+- secrets must not come back in response headers or stderr
+- secrets must not be echoed into the agent context accidentally
+
+That is also why sandbox `env_vars` are literal-only. The executor explicitly rejects `${...}` placeholders there, and the code comment tells pack authors to use `http_request` headers instead when remote authentication is needed.
+
+## See also
+
+- [Write a Challenge Pack](../guides/write-a-challenge-pack)
+- [Configure Runtime Resources](../guides/configure-runtime-resources)
+- [Sandbox Layer](../architecture/sandbox-layer)
+- [Artifacts](../concepts/artifacts)

--- a/web/content/docs/contributing/codebase-tour.mdx
+++ b/web/content/docs/contributing/codebase-tour.mdx
@@ -1,0 +1,72 @@
+---
+title: Codebase Tour
+description: Map the main AgentClash modules before you start changing workflows, APIs, or the web UI.
+---
+
+This repo is easier to navigate if you follow the runtime path instead of reading directories alphabetically.
+
+## Start with the product surfaces
+
+The main user-facing modules are:
+
+- `web/`: the Next.js product site, authenticated app, and docs surface
+- `cli/`: the standalone Go CLI used against local or hosted backends
+- `backend/`: API and worker-side Go services
+- `docs/`: deeper architecture, build-order, replay, and local-development notes
+
+If you only remember one thing, remember this: the web app is not the whole product. AgentClash is a multi-service system with a CLI and a workflow engine behind it.
+
+## Follow a run from request to evidence
+
+A useful mental path through the repo is:
+
+```mermaid
+flowchart LR
+  WEB[web/] --> API[backend/internal/api]
+  API --> WF[Temporal workflows]
+  WF --> WRK[backend/internal/worker]
+  WRK --> SB[Sandbox provider]
+  WRK --> EV[Replay events and artifacts]
+  CLI[cli/] --> API
+```
+
+That is the shortest route from "user action" to "why did this run behave that way".
+
+## Where to look for common tasks
+
+### I need to change the web UX
+
+Start in `web/src/app` for routes and page entry points, then `web/src/components` for the shared UI.
+
+### I need to change auth or API behavior
+
+Start in `backend/internal/api` and trace the handler path from request shape to domain logic.
+
+### I need to change execution behavior
+
+Start in `backend/internal/worker` and the orchestration docs so you understand what the workflow owns versus what the activity owns.
+
+### I need to change local or hosted CLI behavior
+
+Start in `cli/cmd` for command surface and `cli/internal` for config and supporting behavior.
+
+### I need product context before I code
+
+Start in `docs/` instead of guessing. The build-order, domain, replay, and database notes are there for a reason.
+
+## A practical reading order for new contributors
+
+1. Read [Setup](../contributing/setup).
+2. Read [Overview](../architecture/overview).
+3. Read [Orchestration](../architecture/orchestration).
+4. Skim `docs/domains/domains.md` and `docs/database/schema-diagram.md`.
+5. Only then start changing handlers, workflows, or UI.
+
+That order is faster than diving straight into implementation files without the system model in your head.
+
+## See also
+
+- [Setup](../contributing/setup)
+- [Testing](../contributing/testing)
+- [Overview](../architecture/overview)
+- [Frontend](../architecture/frontend)

--- a/web/content/docs/contributing/setup.mdx
+++ b/web/content/docs/contributing/setup.mdx
@@ -1,0 +1,63 @@
+---
+title: Contributor Setup
+description: Clone the repo, bring up the local stack, and pick the fastest development loop for the part of AgentClash you are changing.
+---
+
+If you are touching backend workflows or the web product, start the full local stack. If you are only changing the CLI, point the CLI at staging and skip the backend entirely.
+
+## Full-stack local development
+
+### 1. Clone the repo and start the stack
+
+```bash
+git clone https://github.com/agentclash/agentclash.git
+cd agentclash
+./scripts/dev/start-local-stack.sh
+```
+
+That script starts PostgreSQL, Redis, Temporal, the API server, and the worker.
+
+### 2. Start the web app
+
+```bash
+cd web
+pnpm install
+pnpm dev
+```
+
+### 3. Seed local data
+
+```bash
+cd ..
+./scripts/dev/seed-local-run-fixture.sh
+./scripts/dev/curl-create-run.sh
+```
+
+## Faster loop for CLI-only work
+
+If you only need the CLI:
+
+```bash
+export AGENTCLASH_API_URL="https://staging-api.agentclash.dev"
+cd cli
+go run . auth login --device
+go run . workspace list
+go run . workspace use <WORKSPACE_ID>
+go run . run list
+```
+
+This is the fastest way to change the CLI without also running the API server and worker locally.
+
+## What lives where
+
+- `backend/cmd/api-server` — API entry point
+- `backend/cmd/worker` — worker entry point
+- `cli/` — Cobra CLI
+- `web/` — Next.js app
+- `docs/` — existing internal markdown docs and references
+- `testing/` — review contracts, test notes, and issue-specific validation docs
+
+## See also
+
+- [Self-Host Starter](/docs/getting-started/self-host)
+- [Architecture Overview](/docs/architecture/overview)

--- a/web/content/docs/contributing/testing.mdx
+++ b/web/content/docs/contributing/testing.mdx
@@ -1,0 +1,78 @@
+---
+title: Testing
+description: Choose the smallest useful validation loop and use review checkpoints to keep implementation work scoped.
+---
+
+Testing in AgentClash should match the surface you changed. Do not default to the biggest possible loop.
+
+## Pick the smallest loop that can prove the change
+
+A useful rule is:
+
+- docs or web route changes: start with `pnpm build` in `web/`
+- CLI changes: use the `cli/` module commands and tests
+- packaging changes: rehearse the release flow instead of guessing
+- workflow or backend changes: validate the specific service path you touched
+
+For CLI work, the repo already gives you a concrete baseline:
+
+```bash
+cd cli
+go build ./...
+go vet ./...
+go test -short -race -count=1 ./...
+go run github.com/goreleaser/goreleaser/v2@latest check
+go run github.com/goreleaser/goreleaser/v2@latest release --snapshot --clean
+```
+
+## Use review checkpoints for implementation work
+
+When the change is more than a one-line fix, lock the contract before you start coding.
+
+The review-checkpoint workflow is simple:
+
+1. create `testing/<branch-or-task>.md`
+2. write the scope, functional expectations, tests, manual verification, and non-goals
+3. treat that contract as fixed until requirements explicitly change
+4. after each implementation step, update `/tmp/reviewcheckpoint.json`
+5. run the scoped verification listed in the contract before you declare the work ready
+
+This does two things well:
+
+- it prevents scope drift
+- it makes agent-assisted changes auditable instead of magical
+
+<Callout type="note">
+  Keep `/tmp/reviewcheckpoint.json` local scratch only. It is a working review log,
+  not repo content.
+</Callout>
+
+## What to record in each checkpoint
+
+A good checkpoint update includes:
+
+- the current step number
+- which files changed
+- which contract items were addressed
+- self-review result for that step
+- cumulative review result across all steps so far
+- unresolved risks
+
+That cumulative review matters. It is how you catch drift after several small edits have accumulated.
+
+## Manual verification still matters
+
+Not every useful check is a unit test. For docs, routing, and UI work, manual verification is often part of the contract. Be explicit about it.
+
+Examples:
+
+- opening a docs route and confirming it renders
+- confirming a public route bypasses auth middleware correctly
+- verifying a generated reference page actually contains generated content
+
+## See also
+
+- [Codebase Tour](../contributing/codebase-tour)
+- [Setup](../contributing/setup)
+- [CLI Reference](../reference/cli)
+- [Config Reference](../reference/config)

--- a/web/content/docs/getting-started/first-eval.mdx
+++ b/web/content/docs/getting-started/first-eval.mdx
@@ -1,0 +1,75 @@
+---
+title: First Eval Walkthrough
+description: Use the current seeded local path to create a run, stream events, and inspect ranking output without inventing setup that is not in the repo.
+---
+
+This walkthrough sticks to what the repo already supports today: seed local data, create a run, stream events, and inspect the result.
+
+## 1. Bring up the local stack
+
+From the repo root:
+
+```bash
+./scripts/dev/start-local-stack.sh
+```
+
+If you want the browser UI too:
+
+```bash
+cd web
+pnpm install
+pnpm dev
+```
+
+## 2. Seed a runnable fixture
+
+Back in the repo root:
+
+```bash
+./scripts/dev/seed-local-run-fixture.sh
+```
+
+That script seeds enough data to create a local run through the API.
+
+## 3. Create the run
+
+You can hit the API directly:
+
+```bash
+./scripts/dev/curl-create-run.sh
+```
+
+Or, if you are using the CLI against a prepared workspace, create and follow the run there:
+
+```bash
+agentclash run create --follow
+```
+
+## 4. Inspect the result
+
+Once you have a run ID, inspect its status and ranking:
+
+```bash
+agentclash run get <RUN_ID>
+agentclash run ranking <RUN_ID>
+```
+
+If the web app is running, open the workspace run detail view in the browser and inspect the replay and scorecard surfaces from there.
+
+## What you should see
+
+- a run record created in the workspace
+- event streaming during execution when you follow the run
+- a ranking view once the backend has enough completed run-agent results to score
+
+<Callout type="warning">
+  Without a real sandbox provider such as E2B, the native model-backed path can
+  still stall or fail after run creation. That is expected in the unconfigured
+  local setup.
+</Callout>
+
+## See also
+
+- [Self-Host Starter](/docs/getting-started/self-host)
+- [Runs and Evals](/docs/concepts/runs-and-evals)
+- [Architecture Overview](/docs/architecture/overview)

--- a/web/content/docs/getting-started/quickstart.mdx
+++ b/web/content/docs/getting-started/quickstart.mdx
@@ -1,0 +1,68 @@
+---
+title: Hosted Quickstart
+description: Validate the CLI against the hosted staging backend, set a workspace, and get to your first runnable command in a few minutes.
+---
+
+This path is for people changing the CLI or trying the product without booting the whole stack locally.
+
+<Callout type="note">
+  The hosted quickstart assumes your workspace already has challenge packs and
+  deployments. If it does not, stop after `workspace use` and you have still
+  verified auth, connectivity, and workspace selection.
+</Callout>
+
+## 1. Install the CLI
+
+```bash
+npm i -g agentclash
+```
+
+## 2. Point the CLI at staging and log in
+
+```bash
+export AGENTCLASH_API_URL="https://staging-api.agentclash.dev"
+agentclash auth login --device
+```
+
+Use `--device` when you are in a remote shell or do not want the CLI to open a browser automatically.
+
+## 3. Pick a workspace
+
+```bash
+agentclash workspace list
+agentclash workspace use <WORKSPACE_ID>
+```
+
+The CLI resolves the API base URL in this order:
+
+```text
+--api-url > AGENTCLASH_API_URL > saved user config > http://localhost:8080
+```
+
+## 4. Inspect what is already there
+
+```bash
+agentclash run list
+agentclash run create --help
+```
+
+If the workspace is already seeded with challenge packs and agent deployments, create and follow a run:
+
+```bash
+agentclash run create --follow
+```
+
+## Verification
+
+You should now have:
+
+- a valid CLI login
+- a default workspace saved locally
+- a working connection to the hosted API
+- either a created run or enough context to see what the workspace is missing
+
+## See also
+
+- [Self-Host](/docs/getting-started/self-host)
+- [Runs and Evals](/docs/concepts/runs-and-evals)
+- [CLI Reference](/docs/reference/cli)

--- a/web/content/docs/getting-started/self-host.mdx
+++ b/web/content/docs/getting-started/self-host.mdx
@@ -1,0 +1,84 @@
+---
+title: Self-Host Starter
+description: Bring up the local AgentClash stack with the repo’s existing scripts and understand which dependencies are mandatory versus optional.
+---
+
+This is the shortest honest path to a local AgentClash environment today. It is based on the repo’s existing development scripts, not an imagined one-click installer.
+
+<Callout type="warning">
+  The repo does not currently ship a Helm chart or a polished production
+  installer. What it does ship is a local stack script plus documented Railway
+  deployment building blocks for the backend.
+</Callout>
+
+## Prerequisites
+
+- Go `1.25+`
+- Docker
+- Temporal CLI
+- Node.js `20+`
+- `pnpm`
+- `psql`
+
+## 1. Start the local stack
+
+From the repo root:
+
+```bash
+./scripts/dev/start-local-stack.sh
+```
+
+This script starts PostgreSQL and Redis, applies migrations, launches the Temporal dev server if needed, then starts the API server and worker. Logs are written under `/tmp/agentclash-local-stack/`.
+
+## 2. Start the web app
+
+```bash
+cd web
+pnpm install
+pnpm dev
+```
+
+The web app runs at `http://localhost:3000`.
+
+## 3. Seed a runnable fixture
+
+Back in the repo root:
+
+```bash
+./scripts/dev/seed-local-run-fixture.sh
+./scripts/dev/curl-create-run.sh
+```
+
+Without a real sandbox provider such as E2B, native runs can still be created, but the model-backed execution path will not complete successfully.
+
+## Required vs optional services
+
+- Required: PostgreSQL, Temporal, API server, worker
+- Optional: Redis for event fanout and rate limiting
+- Optional: E2B for sandboxed native execution
+- Optional: S3-compatible storage for production artifact storage
+
+## Production notes
+
+The repo’s documented production building blocks today are:
+
+- Railway for the API server and worker
+- Temporal Cloud for orchestration
+- Vercel for `web/`
+- S3-compatible storage for artifacts
+
+## Verification
+
+You should be able to hit:
+
+```bash
+curl http://localhost:8080/healthz
+```
+
+Then open `http://localhost:3000`.
+
+## See also
+
+- [Hosted Quickstart](/docs/getting-started/quickstart)
+- [Architecture Overview](/docs/architecture/overview)
+- [Contributor Setup](/docs/contributing/setup)

--- a/web/content/docs/guides/configure-runtime-resources.mdx
+++ b/web/content/docs/guides/configure-runtime-resources.mdx
@@ -1,0 +1,223 @@
+---
+title: Configure Runtime Resources
+description: Create secrets, provider accounts, model aliases, runtime profiles, and deployments in the order the current product expects.
+---
+
+Goal: assemble the resource chain that turns a ready build version into a runnable deployment.
+
+Prerequisites:
+
+- You already selected a workspace.
+- You already have an `agent_build_id` and a ready `build_version_id`.
+- You have the provider credential you intend to use.
+
+## 1. Store provider credentials as workspace secrets
+
+If you already want explicit secret management, set the secret first:
+
+```bash
+printf '%s' "$OPENAI_API_KEY" | agentclash secret set OPENAI_API_KEY
+agentclash secret list
+```
+
+The list endpoint returns metadata only. Secret values are not exposed back to you.
+
+## 2. Inspect the model catalog
+
+Model aliases point at model catalog entries, so fetch the catalog first:
+
+```bash
+agentclash infra model-catalog list
+agentclash infra model-catalog get <MODEL_CATALOG_ENTRY_ID>
+```
+
+This gives you the model entry ID you will use when creating the alias.
+
+## 3. Create a provider account
+
+You have two current patterns.
+
+### Pattern A: reference an existing workspace secret
+
+`provider-account.json`:
+
+```json
+{
+  "provider_key": "openai",
+  "name": "OpenAI Workspace Account",
+  "credential_reference": "workspace-secret://OPENAI_API_KEY",
+  "limits_config": {
+    "rpm": 60
+  }
+}
+```
+
+Create it:
+
+```bash
+agentclash infra provider-account create --from-file provider-account.json
+```
+
+### Pattern B: pass `api_key` directly on creation
+
+```json
+{
+  "provider_key": "openai",
+  "name": "OpenAI Workspace Account",
+  "api_key": "<PASTE_KEY_HERE>"
+}
+```
+
+The current infrastructure manager does not keep that raw value on the account row. It stores the key as a workspace secret and rewrites the provider account to use a `workspace-secret://...` credential reference automatically.
+
+## 4. Create a runtime profile
+
+A runtime profile controls execution target and limits.
+
+`runtime-profile.json`:
+
+```json
+{
+  "name": "default-native",
+  "execution_target": "native",
+  "trace_mode": "full",
+  "max_iterations": 24,
+  "max_tool_calls": 32,
+  "step_timeout_seconds": 120,
+  "run_timeout_seconds": 1800,
+  "profile_config": {
+    "sandbox": {
+      "allow_shell": true,
+      "allow_network": false
+    }
+  }
+}
+```
+
+Create it:
+
+```bash
+agentclash infra runtime-profile create --from-file runtime-profile.json
+```
+
+## 5. Create a model alias
+
+A model alias gives the workspace a stable handle for one model catalog entry.
+
+`model-alias.json`:
+
+```json
+{
+  "alias_key": "primary-chat",
+  "display_name": "Primary Chat Model",
+  "model_catalog_entry_id": "<MODEL_CATALOG_ENTRY_ID>",
+  "provider_account_id": "<PROVIDER_ACCOUNT_ID>"
+}
+```
+
+Create it:
+
+```bash
+agentclash infra model-alias create --from-file model-alias.json
+```
+
+Use aliases when you want deployment configuration and playgrounds to refer to a stable workspace label instead of a raw provider model identifier.
+
+## 6. Create the deployment
+
+The current deployment create contract requires:
+
+- `name`
+- `agent_build_id`
+- `build_version_id`
+- `runtime_profile_id`
+
+Optional but commonly useful:
+
+- `provider_account_id`
+- `model_alias_id`
+
+Fast path with flags:
+
+```bash
+agentclash deployment create \
+  --name support-bot-staging \
+  --agent-build-id <AGENT_BUILD_ID> \
+  --build-version-id <BUILD_VERSION_ID> \
+  --runtime-profile-id <RUNTIME_PROFILE_ID> \
+  --provider-account-id <PROVIDER_ACCOUNT_ID> \
+  --model-alias-id <MODEL_ALIAS_ID>
+```
+
+JSON-file path if you want the full request shape:
+
+```json
+{
+  "name": "support-bot-staging",
+  "agent_build_id": "<AGENT_BUILD_ID>",
+  "build_version_id": "<BUILD_VERSION_ID>",
+  "runtime_profile_id": "<RUNTIME_PROFILE_ID>",
+  "provider_account_id": "<PROVIDER_ACCOUNT_ID>",
+  "model_alias_id": "<MODEL_ALIAS_ID>",
+  "deployment_config": {}
+}
+```
+
+Then:
+
+```bash
+agentclash deployment create --from-file deployment.json
+```
+
+## 7. List what you created
+
+```bash
+agentclash infra runtime-profile list
+agentclash infra provider-account list
+agentclash infra model-alias list
+agentclash deployment list
+```
+
+At that point the workspace has a real runnable target the run-creation flow can select.
+
+## Where tools fit
+
+Workspace tools are their own infra resource surface:
+
+```bash
+agentclash infra tool list
+agentclash infra tool create --from-file tool.json
+```
+
+That is separate from pack-defined composed tools. Do not mix those up in your mental model.
+
+## Verification
+
+You should now have:
+
+- a workspace secret for provider credentials
+- a provider account that resolves credentials indirectly
+- a runtime profile defining execution limits
+- a model alias pointing at a model catalog entry
+- a deployment that can be selected during run creation
+
+## Troubleshooting
+
+### Deployment creation fails because the build version is not deployable
+
+The current API requires a ready build version. Mark the build version ready before deploying it.
+
+### I do not know which model alias to create
+
+Start from `agentclash infra model-catalog list`, then create the alias only after you know which catalog entry and provider account you want to bind.
+
+### I passed an API key directly and now cannot see it again
+
+That is expected. Raw provider keys are stored as workspace secrets and the account keeps only a credential reference.
+
+## See also
+
+- [Agents and Deployments](../concepts/agents-and-deployments)
+- [Tools, Network, and Secrets](../concepts/tools-network-and-secrets)
+- [Config Reference](../reference/config)
+- [CLI Reference](../reference/cli)

--- a/web/content/docs/guides/interpret-results.mdx
+++ b/web/content/docs/guides/interpret-results.mdx
@@ -1,0 +1,115 @@
+---
+title: Interpret Results
+description: Read AgentClash run output from top-line score to raw replay evidence without getting lost.
+---
+
+Goal: turn a finished run or eval into a decision you can defend.
+
+Prerequisites:
+
+- You have a run or eval to inspect.
+- You understand the basic difference between a run and an eval.
+- You know which challenge pack or workload the result came from.
+
+## Start with the top-line state
+
+Before you read the full timeline, answer three simple questions:
+
+1. Did the run complete, fail, or time out?
+2. Which deployment produced the result?
+3. Which challenge pack or input set was this run judged against?
+
+If you skip this step, you will mix together infrastructure problems, workload problems, and actual agent regressions.
+
+## Read the score before the trace
+
+The scorecard or summary view is the fastest way to orient yourself. Use it to identify:
+
+- the overall outcome
+- the dimension that changed since the last comparable run
+- any obvious outlier input or scenario
+- whether the run generated enough evidence to trust the outcome
+
+<Callout type="info">
+  A score change is only actionable when the underlying workload is comparable.
+  Always confirm you are looking at the same deployment class and challenge pack.
+</Callout>
+
+## Use the replay timeline to explain the result
+
+Once you know what changed, move to the replay or event timeline.
+
+A useful reading order is:
+
+1. find the first non-trivial event after run start
+2. follow tool calls or sandbox transitions in order
+3. locate the first irreversible failure or divergence
+4. inspect any terminal event that explains why scoring ended where it did
+
+You are looking for the earliest point where the run stopped being healthy. That might be an agent reasoning mistake, but it might just as easily be a sandbox issue, a bad callback, or a missing artifact.
+
+## Separate agent failures from platform failures
+
+This distinction matters for every comparison review.
+
+Treat these as different buckets:
+
+- agent failure: the deployment ran, but the behavior was wrong or weak
+- scenario failure: the workload or scoring context exposed a gap or ambiguity
+- platform failure: orchestration, sandbox, callback, artifact, or infrastructure issues broke the run
+
+Only the first bucket should drive model or prompt claims directly.
+
+## Compare runs only after you trust each side
+
+When you compare two runs, make sure both have:
+
+- the same or intentionally different deployment target
+- the same workload definition
+- enough replay evidence to justify the score
+- no obvious infrastructure corruption hiding behind the final state
+
+If one side is missing replay evidence or has an incomplete artifact trail, the comparison is weak even if the ranking UI still renders.
+
+## What to do with a useful failure
+
+A good failure is not just something to fix. It is something to preserve.
+
+When a run reveals a real gap:
+
+1. capture the replay and artifacts that make the issue obvious
+2. tie the failure back to the scenario or input that exposed it
+3. promote it into a repeatable challenge-pack case when the product surface supports it
+4. rerun after the fix so the score change is evidence-backed, not anecdotal
+
+That is the core loop behind serious evaluation work.
+
+## Verification
+
+You should now be able to look at one run and answer:
+
+- what failed
+- where it failed first
+- whether the failure belongs to the agent, workload, or platform
+- what evidence you would preserve for future regression testing
+
+## Troubleshooting
+
+### The score changed, but I cannot explain why
+
+Open the replay view and find the first event where the run diverged from the baseline. If you cannot find one, the run may be missing evidence or you may be comparing different workloads.
+
+### The run failed before any meaningful agent work happened
+
+Treat that as a platform or setup issue first. Check orchestration, sandbox configuration, callbacks, and artifacts before concluding the deployment regressed.
+
+### Two runs disagree, but both look messy
+
+Do not force a ranking conclusion. Clean the workload, rerun under the same conditions, and compare again.
+
+## See also
+
+- [Replay and Scorecards](../concepts/replay-and-scorecards)
+- [Runs and Evals](../concepts/runs-and-evals)
+- [Evidence Loop](../architecture/evidence-loop)
+- [First Eval](../getting-started/first-eval)

--- a/web/content/docs/guides/use-with-ai-tools.mdx
+++ b/web/content/docs/guides/use-with-ai-tools.mdx
@@ -1,0 +1,93 @@
+---
+title: Use with AI Tools
+description: Feed AgentClash docs into ChatGPT, Codex, Claude Code, and similar tools using llms.txt and markdown exports.
+---
+
+Goal: give an assistant or coding agent enough AgentClash context to answer questions, draft workflows, or transform the docs into internal runbooks.
+
+Prerequisites:
+
+- You can open or paste URLs into the assistant you are using.
+- You know whether you want the full docs bundle or just one page.
+
+## Pick the right docs export
+
+AgentClash now exposes three AI-friendly surfaces:
+
+- `/llms.txt`: a compact index of the shipped docs set
+- `/llms-full.txt`: one bundled markdown-oriented export of the full docs corpus
+- `/docs-md/...`: page-level markdown exports that mirror `/docs/...`
+
+Use them differently:
+
+- use `llms.txt` when the tool needs a map first
+- use `llms-full.txt` when you want one-shot context for a larger prompt
+- use `/docs-md/...` when you only need one focused page, like quickstart or config
+
+## Fastest workflow in ChatGPT, Codex, or Claude Code
+
+1. Start with `https://agentclash.dev/llms.txt`.
+2. If the tool can fetch URLs directly, give it that URL first.
+3. If the tool cannot fetch URLs, open the file yourself and paste the contents.
+4. Ask the tool which page it needs next.
+5. Feed the relevant `/docs-md/...` page or the full bundle, depending on scope.
+
+That keeps the context tight. Do not dump the full bundle into every prompt by default.
+
+## Good prompt patterns
+
+Use prompts that ask the model to stay anchored to the supplied docs. Examples:
+
+```text
+Using https://agentclash.dev/llms.txt, tell me which docs pages I should read to self-host AgentClash and understand the worker architecture.
+```
+
+```text
+Use the markdown from https://agentclash.dev/docs-md/guides/interpret-results and turn it into a short incident-review checklist for my eval team.
+```
+
+```text
+Use https://agentclash.dev/llms-full.txt as the product docs corpus and answer only from that material: what is the difference between a run, an eval, and a challenge pack?
+```
+
+## When to use page-level exports instead of the full bundle
+
+Prefer page-level exports when:
+
+- you are debugging one subsystem
+- you want tighter answers with lower token cost
+- the assistant tends to over-generalize when given too much context
+
+Prefer the full bundle when:
+
+- you want a holistic onboarding summary
+- you are asking for a docs-wide rewrite or glossary
+- you are building internal retrieval or indexing pipelines
+
+## Verification
+
+You should now be able to hand any of these URLs to a tool and get grounded answers:
+
+- `https://agentclash.dev/llms.txt`
+- `https://agentclash.dev/llms-full.txt`
+- `https://agentclash.dev/docs-md/getting-started/quickstart`
+
+## Troubleshooting
+
+### The assistant cannot open URLs
+
+Open the relevant endpoint yourself and paste the content directly.
+
+### The answer is too vague
+
+Use a narrower `/docs-md/...` page instead of the full bundle.
+
+### The answer mixes product claims with guesses
+
+Tell the tool to answer only from the supplied docs export and cite the page title it used.
+
+## See also
+
+- [Quickstart](../getting-started/quickstart)
+- [Config Reference](../reference/config)
+- [Codebase Tour](../contributing/codebase-tour)

--- a/web/content/docs/guides/write-a-challenge-pack.mdx
+++ b/web/content/docs/guides/write-a-challenge-pack.mdx
@@ -1,0 +1,216 @@
+---
+title: Write a Challenge Pack
+description: Author a challenge-pack bundle in YAML, validate it against the current parser, and publish it into a workspace.
+---
+
+Goal: write a pack that the current AgentClash parser, validator, and publish flow will accept.
+
+Prerequisites:
+
+- You have the CLI installed and logged in.
+- You selected a workspace with `agentclash workspace use <WORKSPACE_ID>`.
+- You know whether the pack should be `prompt_eval` or `native`.
+
+## 1. Start from the current minimum shape
+
+This is the smallest honest starting point based on the current bundle parser and tests:
+
+```yaml
+pack:
+  slug: support-eval
+  name: Support Eval
+  family: support
+
+version:
+  number: 1
+  execution_mode: prompt_eval
+  evaluation_spec:
+    name: support-v1
+    version_number: 1
+    judge_mode: deterministic
+    validators:
+      - key: exact
+        type: exact_match
+        target: final_output
+        expected_from: challenge_input
+    scorecard:
+      dimensions: [correctness]
+
+challenges:
+  - key: ticket-1
+    title: Ticket One
+    category: support
+    difficulty: medium
+    instructions: |
+      Read the request and produce the final answer.
+
+input_sets:
+  - key: default
+    name: Default Inputs
+    cases:
+      - challenge_key: ticket-1
+        case_key: sample-1
+        inputs:
+          - key: prompt
+            kind: text
+            value: hello
+        expectations:
+          - key: answer
+            kind: text
+            source: input:prompt
+```
+
+This is not a glamorous pack. It is a good pack skeleton because it matches the current parser shape.
+
+## 2. Add execution policy only when you need it
+
+If the pack is `native`, you can add runtime sections like `tool_policy`, `sandbox`, and `tools`.
+
+Example:
+
+```yaml
+version:
+  number: 2
+  execution_mode: native
+  tool_policy:
+    allowed_tool_kinds:
+      - file
+      - shell
+      - network
+  sandbox:
+    network_access: true
+    network_allowlist:
+      - 203.0.113.0/24
+  evaluation_spec:
+    name: support-v2
+    version_number: 2
+    judge_mode: hybrid
+    validators:
+      - key: exact
+        type: exact_match
+        target: final_output
+        expected_from: challenge_input
+    scorecard:
+      dimensions: [correctness]
+
+tools:
+  custom:
+    - name: check_inventory
+      description: Check inventory by SKU
+      parameters:
+        type: object
+        properties:
+          sku:
+            type: string
+      implementation:
+        primitive: http_request
+        args:
+          method: GET
+          url: https://api.example.com/inventory/${sku}
+          headers:
+            Authorization: Bearer ${secrets.INVENTORY_API_KEY}
+```
+
+Use these sections deliberately.
+
+- `tool_policy` decides what kinds of tools are even available.
+- `sandbox.network_access` and `network_allowlist` control outbound networking.
+- `tools.custom` defines the tool contract the agent sees.
+- `implementation.primitive` picks the executor primitive that actually runs.
+
+## 3. Add assets when inputs should point at files
+
+If the pack needs files, declare them as assets instead of hardcoding mystery paths all over the bundle.
+
+Example:
+
+```yaml
+version:
+  number: 1
+  execution_mode: native
+  assets:
+    - key: fixtures
+      path: fixtures/workspace.zip
+      media_type: application/zip
+```
+
+You can also back an asset with an uploaded artifact by setting `artifact_id` instead of only relying on a repository path.
+
+Then cases and expectations can refer to those assets by key.
+
+## 4. Validate before you publish
+
+The current CLI command is:
+
+```bash
+agentclash challenge-pack validate support-eval.yaml
+```
+
+This calls the workspace-scoped validation endpoint and checks the same parser and validation logic the publish path uses.
+
+Typical failures the current code will catch early:
+
+- unknown placeholders like `${missing}`
+- invalid CIDR entries in `network_allowlist`
+- self-referencing or cyclic composed tools
+- invalid tool parameter schemas
+- unknown artifact keys or nonexistent stored artifact IDs
+
+## 5. Publish the bundle
+
+Once validation passes:
+
+```bash
+agentclash challenge-pack publish support-eval.yaml
+```
+
+The publish response returns concrete IDs, including:
+
+- `challenge_pack_id`
+- `challenge_pack_version_id`
+- `evaluation_spec_id`
+- `input_set_ids`
+- optional `bundle_artifact_id`
+
+Those IDs matter later because run creation asks for a pack version, not a filename.
+
+## 6. Confirm the workspace can see it
+
+```bash
+agentclash challenge-pack list
+```
+
+If the pack published cleanly, it should show up in the workspace list with its versions.
+
+## Verification
+
+You should now have:
+
+- a bundle YAML file the current parser accepts
+- a successful `validate` result
+- a published pack version ID you can use in run creation
+
+## Troubleshooting
+
+### Validation says a tool placeholder is unknown
+
+Your `implementation.args` template is referencing a variable that is not declared by the tool parameter schema or available template context.
+
+### Validation says a tool references itself or forms a cycle
+
+Your composed tool graph is recursive. Break the cycle and delegate to a primitive or a non-cyclic tool chain.
+
+### Validation says an artifact key is missing
+
+You referenced an asset or artifact key in a case or expectation that was never declared in the pack.
+
+### The pack needs internet access
+
+Do not assume that adding `http_request` is enough. You also need the relevant sandbox/network policy in the pack and runtime path.
+
+## See also
+
+- [Challenge Packs and Inputs](../concepts/challenge-packs-and-inputs)
+- [Tools, Network, and Secrets](../concepts/tools-network-and-secrets)
+- [Artifacts](../concepts/artifacts)
+- [CLI Reference](../reference/cli)

--- a/web/content/docs/index.mdx
+++ b/web/content/docs/index.mdx
@@ -1,0 +1,16 @@
+---
+title: AgentClash Documentation
+description: Run agents head-to-head on real tasks, inspect the telemetry, and understand the system without wading through roadmap fiction.
+---
+
+AgentClash runs agents against the same task, with the same tools and time budget, then shows you who finished, who stalled, and where the run broke.
+
+These docs are layered for three kinds of readers:
+
+- evaluators deciding whether the product is worth trying
+- users who need to configure a workspace and run real comparisons
+- contributors who want to understand the stack and change it safely
+
+The current public surface is still early. This docs pass only covers behavior that is already visible in the repo today: the CLI, the local stack, the current run model, and the main runtime components.
+
+Start with the hosted quickstart if you want the shortest path to a real command sequence. Start with self-host if you want the full local stack on your machine. Start with architecture if you are here to hack on the code.

--- a/web/src/app/docs-md/[[...slug]]/route.ts
+++ b/web/src/app/docs-md/[[...slug]]/route.ts
@@ -1,0 +1,28 @@
+import { getDocBySlug, renderDocMarkdown } from "@/lib/docs";
+
+type Context = {
+  params: Promise<{
+    slug?: string[];
+  }>;
+};
+
+export async function GET(_request: Request, context: Context) {
+  const params = await context.params;
+  const slug = params.slug ?? [];
+  const doc = getDocBySlug(slug);
+
+  if (!doc) {
+    return new Response("Not found", {
+      status: 404,
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+      },
+    });
+  }
+
+  return new Response(renderDocMarkdown(doc), {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
+}

--- a/web/src/app/docs/[[...slug]]/page.tsx
+++ b/web/src/app/docs/[[...slug]]/page.tsx
@@ -9,7 +9,6 @@ import {
   getAllDocSlugs,
   getDocBySlug,
   getDocNeighbors,
-  getDocsSearchIndex,
 } from "@/lib/docs";
 
 type Props = {
@@ -37,7 +36,6 @@ export default async function DocsPage({ params }: Props) {
   if (!doc) notFound();
 
   const isHome = doc.href === "/docs";
-  const searchItems = getDocsSearchIndex();
   const neighbors = getDocNeighbors(doc.href);
 
   return (
@@ -47,7 +45,6 @@ export default async function DocsPage({ params }: Props) {
       description={doc.description}
       sectionTitle={doc.sectionTitle}
       sections={DOCS_NAV}
-      searchItems={searchItems}
       headings={doc.headings}
     >
       <div className="prose-agentclash-docs">

--- a/web/src/app/docs/[[...slug]]/page.tsx
+++ b/web/src/app/docs/[[...slug]]/page.tsx
@@ -1,0 +1,127 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { MDXRemote } from "next-mdx-remote/rsc";
+import { DocsShell } from "@/components/docs/docs-shell";
+import { docsMDXComponents } from "@/components/docs/mdx-components";
+import {
+  DOCS_NAV,
+  getAllDocSlugs,
+  getDocBySlug,
+  getDocNeighbors,
+  getDocsSearchIndex,
+} from "@/lib/docs";
+
+type Props = {
+  params: Promise<{ slug?: string[] }>;
+};
+
+export function generateStaticParams() {
+  return getAllDocSlugs().map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug = [] } = await params;
+  const doc = getDocBySlug(slug);
+  if (!doc) return {};
+
+  return {
+    title: `${doc.title} — AgentClash Docs`,
+    description: doc.description,
+  };
+}
+
+export default async function DocsPage({ params }: Props) {
+  const { slug = [] } = await params;
+  const doc = getDocBySlug(slug);
+  if (!doc) notFound();
+
+  const isHome = doc.href === "/docs";
+  const searchItems = getDocsSearchIndex();
+  const neighbors = getDocNeighbors(doc.href);
+
+  return (
+    <DocsShell
+      currentHref={doc.href}
+      title={doc.title}
+      description={doc.description}
+      sectionTitle={doc.sectionTitle}
+      sections={DOCS_NAV}
+      searchItems={searchItems}
+      headings={doc.headings}
+    >
+      <div className="prose-agentclash-docs">
+        <MDXRemote source={doc.content} components={docsMDXComponents} />
+      </div>
+
+      {isHome && (
+        <div className="mt-12 border-t border-white/[0.08] pt-8">
+          <div className="grid gap-4 xl:grid-cols-2">
+            {DOCS_NAV.map((section) => (
+              <section
+                key={section.title}
+                className="rounded-[24px] border border-white/[0.08] bg-black/20 p-5"
+              >
+                <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.18em] text-white/30">
+                  {section.title}
+                </p>
+                <p className="mt-3 text-sm leading-6 text-white/45">
+                  {section.description}
+                </p>
+                <div className="mt-5 space-y-3">
+                  {section.items.map((item) => (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      className="block rounded-2xl border border-white/[0.08] bg-white/[0.03] px-4 py-3 transition-colors hover:border-white/15 hover:bg-white/[0.04]"
+                    >
+                      <span className="block text-sm font-medium text-white/90">
+                        {item.title}
+                      </span>
+                      <span className="mt-1 block text-xs leading-5 text-white/45">
+                        {item.description}
+                      </span>
+                    </Link>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {!isHome && (neighbors.previous || neighbors.next) && (
+        <div className="mt-12 grid gap-4 border-t border-white/[0.08] pt-8 sm:grid-cols-2">
+          {neighbors.previous ? (
+            <Link
+              href={neighbors.previous.href}
+              className="rounded-[24px] border border-white/[0.08] bg-black/20 px-5 py-4 transition-colors hover:border-white/15"
+            >
+              <span className="block text-[11px] uppercase tracking-[0.18em] text-white/30">
+                Previous
+              </span>
+              <span className="mt-2 block text-sm font-medium text-white/88">
+                {neighbors.previous.title}
+              </span>
+            </Link>
+          ) : (
+            <div />
+          )}
+          {neighbors.next && (
+            <Link
+              href={neighbors.next.href}
+              className="rounded-[24px] border border-white/[0.08] bg-black/20 px-5 py-4 text-left transition-colors hover:border-white/15"
+            >
+              <span className="block text-[11px] uppercase tracking-[0.18em] text-white/30">
+                Next
+              </span>
+              <span className="mt-2 block text-sm font-medium text-white/88">
+                {neighbors.next.title}
+              </span>
+            </Link>
+          )}
+        </div>
+      )}
+    </DocsShell>
+  );
+}

--- a/web/src/app/docs/search.json/route.ts
+++ b/web/src/app/docs/search.json/route.ts
@@ -1,11 +1,10 @@
-import { buildLlmsIndex } from "@/lib/docs";
+import { getDocsSearchIndex } from "@/lib/docs";
 
 export const revalidate = 3600;
 
 export function GET() {
-  return new Response(buildLlmsIndex(), {
+  return Response.json(getDocsSearchIndex(), {
     headers: {
-      "Content-Type": "text/plain; charset=utf-8",
       "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
     },
   });

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -86,6 +86,54 @@ body {
   background: rgba(255, 255, 255, 0.12);
 }
 
+/* Clash mark — the two-agent logo collision. Single allowed motion on the
+   landing page; everything else is static. */
+@keyframes clash-left {
+  0% { transform: translateX(-24px); }
+  18% { transform: translateX(0); }
+  23% { transform: translateX(4px); }
+  30% { transform: translateX(0); }
+  100% { transform: translateX(0); }
+}
+
+@keyframes clash-right {
+  0% { transform: translateX(24px); }
+  18% { transform: translateX(0); }
+  23% { transform: translateX(-4px); }
+  30% { transform: translateX(0); }
+  100% { transform: translateX(0); }
+}
+
+@keyframes clash-sparks {
+  0%, 13% { opacity: 0; transform: scale(0.88); }
+  18% { opacity: 1; transform: scale(1); }
+  28% { opacity: 0.55; }
+  38% { opacity: 0; transform: scale(0.9); }
+  100% { opacity: 0; transform: scale(0.88); }
+}
+
+.animate-clash-left {
+  animation: clash-left 4.5s cubic-bezier(0.16, 1, 0.3, 1) infinite;
+}
+
+.animate-clash-right {
+  animation: clash-right 4.5s cubic-bezier(0.16, 1, 0.3, 1) infinite;
+}
+
+.animate-clash-sparks {
+  animation: clash-sparks 4.5s ease-out infinite;
+  transform-origin: center;
+  transform-box: fill-box;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-clash-left,
+  .animate-clash-right,
+  .animate-clash-sparks {
+    animation: none;
+  }
+}
+
 /* Blog prose */
 .prose-agentclash {
   font-size: 15px;
@@ -178,6 +226,138 @@ body {
   border: none;
   border-top: 1px solid rgba(255, 255, 255, 0.08);
   margin: 2rem 0;
+}
+
+/* Docs prose */
+.prose-agentclash-docs {
+  max-width: 72ch;
+  font-size: 15px;
+  line-height: 1.8;
+  color: rgba(255, 255, 255, 0.68);
+}
+
+.prose-agentclash-docs h2 {
+  margin-top: 2.75rem;
+  margin-bottom: 0.85rem;
+  font-family: var(--font-display), serif;
+  font-size: 1.65rem;
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.prose-agentclash-docs h3 {
+  margin-top: 2rem;
+  margin-bottom: 0.65rem;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.84);
+}
+
+.prose-agentclash-docs p,
+.prose-agentclash-docs ul,
+.prose-agentclash-docs ol,
+.prose-agentclash-docs pre,
+.prose-agentclash-docs blockquote {
+  margin-bottom: 1.2rem;
+}
+
+.prose-agentclash-docs ul,
+.prose-agentclash-docs ol {
+  padding-left: 1.3rem;
+}
+
+.prose-agentclash-docs li {
+  margin-bottom: 0.4rem;
+}
+
+.prose-agentclash-docs a {
+  color: rgba(222, 255, 170, 0.92);
+  text-decoration: underline;
+  text-decoration-color: rgba(222, 255, 170, 0.24);
+  text-underline-offset: 3px;
+  transition: color 0.15s, text-decoration-color 0.15s;
+}
+
+.prose-agentclash-docs a:hover {
+  color: rgba(236, 255, 205, 1);
+  text-decoration-color: rgba(236, 255, 205, 0.44);
+}
+
+.prose-agentclash-docs strong {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.prose-agentclash-docs code {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.84em;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.05);
+  padding: 0.16em 0.38em;
+  border-radius: 0.45rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.prose-agentclash-docs pre {
+  overflow-x: auto;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 1rem;
+  padding: 1rem 1.15rem;
+}
+
+.prose-agentclash-docs pre code {
+  border: none;
+  background: transparent;
+  padding: 0;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.prose-agentclash-docs blockquote {
+  border-left: 2px solid rgba(212, 255, 79, 0.34);
+  padding-left: 1rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.prose-agentclash-docs hr {
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  margin: 2.25rem 0;
+}
+
+.prose-agentclash-docs table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1.5rem;
+  overflow: hidden;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.prose-agentclash-docs thead {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.prose-agentclash-docs th,
+.prose-agentclash-docs td {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 0.8rem 0.9rem;
+  text-align: left;
+  vertical-align: top;
+  font-size: 0.9rem;
+}
+
+.prose-agentclash-docs th {
+  color: rgba(255, 255, 255, 0.82);
+  font-weight: 600;
+}
+
+.prose-agentclash-docs td {
+  color: rgba(255, 255, 255, 0.64);
+}
+
+.prose-agentclash-docs tr:last-child td {
+  border-bottom: none;
 }
 
 @theme inline {

--- a/web/src/app/landing.tsx
+++ b/web/src/app/landing.tsx
@@ -7,7 +7,13 @@ import { ArrowRight, Calendar, ExternalLink, LogIn, Star } from "lucide-react";
 
 const DEMO_URL = "https://cal.com/agentclash/demo";
 
-function ClashMark({ className = "" }: { className?: string }) {
+function ClashMark({
+  className = "",
+  animated = false,
+}: {
+  className?: string;
+  animated?: boolean;
+}) {
   return (
     <svg
       viewBox="0 0 512 512"
@@ -15,40 +21,46 @@ function ClashMark({ className = "" }: { className?: string }) {
       aria-label="AgentClash"
       role="img"
     >
-      <polygon
-        points="80,180 240,256 80,332"
-        fill="#ffffff"
-        opacity="0.95"
-      />
-      <polygon
-        points="432,180 272,256 432,332"
-        fill="#ffffff"
-        opacity="0.5"
-      />
-      <line
-        x1="256" y1="96" x2="256" y2="168"
-        stroke="#ffffff" strokeWidth="10" strokeLinecap="round" opacity="0.75"
-      />
-      <line
-        x1="256" y1="344" x2="256" y2="416"
-        stroke="#ffffff" strokeWidth="10" strokeLinecap="round" opacity="0.75"
-      />
-      <line
-        x1="186" y1="130" x2="216" y2="188"
-        stroke="#ffffff" strokeWidth="8" strokeLinecap="round" opacity="0.55"
-      />
-      <line
-        x1="326" y1="130" x2="296" y2="188"
-        stroke="#ffffff" strokeWidth="8" strokeLinecap="round" opacity="0.55"
-      />
-      <line
-        x1="186" y1="382" x2="216" y2="324"
-        stroke="#ffffff" strokeWidth="8" strokeLinecap="round" opacity="0.55"
-      />
-      <line
-        x1="326" y1="382" x2="296" y2="324"
-        stroke="#ffffff" strokeWidth="8" strokeLinecap="round" opacity="0.55"
-      />
+      <g className={animated ? "animate-clash-left" : undefined}>
+        <polygon
+          points="80,180 240,256 80,332"
+          fill="#ffffff"
+          opacity="0.95"
+        />
+      </g>
+      <g className={animated ? "animate-clash-right" : undefined}>
+        <polygon
+          points="432,180 272,256 432,332"
+          fill="#ffffff"
+          opacity="0.5"
+        />
+      </g>
+      <g className={animated ? "animate-clash-sparks" : undefined}>
+        <line
+          x1="256" y1="96" x2="256" y2="168"
+          stroke="#ffffff" strokeWidth="10" strokeLinecap="round" opacity="0.75"
+        />
+        <line
+          x1="256" y1="344" x2="256" y2="416"
+          stroke="#ffffff" strokeWidth="10" strokeLinecap="round" opacity="0.75"
+        />
+        <line
+          x1="186" y1="130" x2="216" y2="188"
+          stroke="#ffffff" strokeWidth="8" strokeLinecap="round" opacity="0.55"
+        />
+        <line
+          x1="326" y1="130" x2="296" y2="188"
+          stroke="#ffffff" strokeWidth="8" strokeLinecap="round" opacity="0.55"
+        />
+        <line
+          x1="186" y1="382" x2="216" y2="324"
+          stroke="#ffffff" strokeWidth="8" strokeLinecap="round" opacity="0.55"
+        />
+        <line
+          x1="326" y1="382" x2="296" y2="324"
+          stroke="#ffffff" strokeWidth="8" strokeLinecap="round" opacity="0.55"
+        />
+      </g>
     </svg>
   );
 }
@@ -123,6 +135,12 @@ export default function HomePage() {
             </span>
           </Link>
           <nav className="flex items-center gap-1 sm:gap-2 text-xs">
+            <Link
+              href="/docs"
+              className="hidden sm:inline-flex px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"
+            >
+              Docs
+            </Link>
             <Link
               href="/blog"
               className="hidden sm:inline-flex px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"
@@ -234,7 +252,10 @@ export default function HomePage() {
           </div>
 
           <div className="hidden md:flex items-center justify-center">
-            <ClashMark className="w-full max-w-[360px] aspect-square" />
+            <ClashMark
+              animated
+              className="w-full max-w-[360px] aspect-square"
+            />
           </div>
         </div>
       </section>

--- a/web/src/app/llms-full.txt/route.ts
+++ b/web/src/app/llms-full.txt/route.ts
@@ -1,9 +1,12 @@
 import { buildLlmsFull } from "@/lib/docs";
 
+export const revalidate = 3600;
+
 export function GET() {
   return new Response(buildLlmsFull(), {
     headers: {
       "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
     },
   });
 }

--- a/web/src/app/llms-full.txt/route.ts
+++ b/web/src/app/llms-full.txt/route.ts
@@ -1,0 +1,9 @@
+import { buildLlmsFull } from "@/lib/docs";
+
+export function GET() {
+  return new Response(buildLlmsFull(), {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/web/src/app/llms.txt/route.ts
+++ b/web/src/app/llms.txt/route.ts
@@ -1,0 +1,9 @@
+import { buildLlmsIndex } from "@/lib/docs";
+
+export function GET() {
+  return new Response(buildLlmsIndex(), {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -1,35 +1,54 @@
 import type { MetadataRoute } from "next";
 import { getAllPosts } from "@/lib/blog";
-import { getAllDocPaths } from "@/lib/docs";
+import { DOCS_ORIGIN, getAllDocMarkdownPaths, getAllDocPaths } from "@/lib/docs";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const posts = getAllPosts().map((post) => ({
-    url: `https://agentclash.dev/blog/${post.slug}`,
+    url: `${DOCS_ORIGIN}/blog/${post.slug}`,
     lastModified: new Date(post.date),
     changeFrequency: "monthly" as const,
     priority: 0.7,
   }));
   const docs = getAllDocPaths().map((docPath) => ({
-    url: `https://agentclash.dev${docPath}`,
+    url: `${DOCS_ORIGIN}${docPath}`,
     lastModified: new Date(),
     changeFrequency: "weekly" as const,
     priority: docPath === "/docs" ? 0.85 : 0.75,
   }));
+  const markdownDocs = getAllDocMarkdownPaths().map((docPath) => ({
+    url: `${DOCS_ORIGIN}${docPath}`,
+    lastModified: new Date(),
+    changeFrequency: "weekly" as const,
+    priority: docPath === "/docs-md" ? 0.5 : 0.4,
+  }));
 
   return [
     {
-      url: "https://agentclash.dev",
+      url: DOCS_ORIGIN,
       lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 1,
     },
     {
-      url: "https://agentclash.dev/blog",
+      url: `${DOCS_ORIGIN}/blog`,
       lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 0.8,
     },
+    {
+      url: `${DOCS_ORIGIN}/llms.txt`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.6,
+    },
+    {
+      url: `${DOCS_ORIGIN}/llms-full.txt`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.55,
+    },
     ...docs,
+    ...markdownDocs,
     ...posts,
   ];
 }

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from "next";
 import { getAllPosts } from "@/lib/blog";
+import { getAllDocPaths } from "@/lib/docs";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const posts = getAllPosts().map((post) => ({
@@ -7,6 +8,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
     lastModified: new Date(post.date),
     changeFrequency: "monthly" as const,
     priority: 0.7,
+  }));
+  const docs = getAllDocPaths().map((docPath) => ({
+    url: `https://agentclash.dev${docPath}`,
+    lastModified: new Date(),
+    changeFrequency: "weekly" as const,
+    priority: docPath === "/docs" ? 0.85 : 0.75,
   }));
 
   return [
@@ -22,6 +29,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "weekly",
       priority: 0.8,
     },
+    ...docs,
     ...posts,
   ];
 }

--- a/web/src/components/docs/callout.tsx
+++ b/web/src/components/docs/callout.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+import { AlertTriangle, Info, NotebookPen } from "lucide-react";
+
+type CalloutType = "info" | "warning" | "note";
+
+const styles: Record<
+  CalloutType,
+  {
+    icon: typeof Info;
+    className: string;
+    label: string;
+  }
+> = {
+  info: {
+    icon: Info,
+    label: "Info",
+    className:
+      "border-lime-300/25 bg-lime-300/[0.08] text-lime-50/90 [&_strong]:text-lime-50",
+  },
+  warning: {
+    icon: AlertTriangle,
+    label: "Warning",
+    className:
+      "border-amber-300/25 bg-amber-300/[0.08] text-amber-50/90 [&_strong]:text-amber-50",
+  },
+  note: {
+    icon: NotebookPen,
+    label: "Note",
+    className:
+      "border-sky-300/20 bg-sky-300/[0.07] text-sky-50/90 [&_strong]:text-sky-50",
+  },
+};
+
+export function Callout({
+  type = "info",
+  children,
+}: {
+  type?: CalloutType;
+  children: ReactNode;
+}) {
+  const style = styles[type];
+  const Icon = style.icon;
+
+  return (
+    <div
+      className={`my-6 rounded-2xl border px-4 py-4 sm:px-5 ${style.className}`}
+    >
+      <div className="flex items-start gap-3">
+        <Icon className="mt-0.5 size-4 shrink-0" />
+        <div className="min-w-0 text-sm leading-7">
+          <p className="mb-1 font-medium tracking-[-0.01em]">{style.label}</p>
+          <div>{children}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/docs/docs-shell.tsx
+++ b/web/src/components/docs/docs-shell.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import Link from "next/link";
 import { ArrowUpRight, BookOpenText } from "lucide-react";
-import type { DocHeading, DocNavSection, DocSearchItem } from "@/lib/docs";
+import type { DocHeading, DocNavSection } from "@/lib/docs";
 import { DocsSidebar } from "@/components/docs/docs-sidebar";
 import { DocsToc } from "@/components/docs/docs-toc";
 
@@ -11,7 +11,6 @@ export function DocsShell({
   description,
   sectionTitle,
   sections,
-  searchItems,
   headings,
   children,
 }: {
@@ -20,7 +19,6 @@ export function DocsShell({
   description: string;
   sectionTitle?: string;
   sections: DocNavSection[];
-  searchItems: DocSearchItem[];
   headings: DocHeading[];
   children: ReactNode;
 }) {
@@ -67,11 +65,7 @@ export function DocsShell({
 
       <div className="mx-auto grid w-full max-w-[1440px] gap-12 px-6 py-10 sm:px-8 lg:grid-cols-[280px_minmax(0,1fr)] lg:gap-16 lg:py-14 xl:grid-cols-[280px_minmax(0,1fr)_220px] xl:items-start">
         <aside className="lg:sticky lg:top-8 lg:h-fit">
-          <DocsSidebar
-            sections={sections}
-            currentHref={currentHref}
-            searchItems={searchItems}
-          />
+          <DocsSidebar sections={sections} currentHref={currentHref} />
         </aside>
 
         <section className="min-w-0">

--- a/web/src/components/docs/docs-shell.tsx
+++ b/web/src/components/docs/docs-shell.tsx
@@ -1,0 +1,101 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { ArrowUpRight, BookOpenText } from "lucide-react";
+import type { DocHeading, DocNavSection, DocSearchItem } from "@/lib/docs";
+import { DocsSidebar } from "@/components/docs/docs-sidebar";
+import { DocsToc } from "@/components/docs/docs-toc";
+
+export function DocsShell({
+  currentHref,
+  title,
+  description,
+  sectionTitle,
+  sections,
+  searchItems,
+  headings,
+  children,
+}: {
+  currentHref: string;
+  title: string;
+  description: string;
+  sectionTitle?: string;
+  sections: DocNavSection[];
+  searchItems: DocSearchItem[];
+  headings: DocHeading[];
+  children: ReactNode;
+}) {
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,rgba(212,255,79,0.09),transparent_24%),radial-gradient(circle_at_top_right,rgba(255,255,255,0.06),transparent_18%),#050505] text-white">
+      <header className="border-b border-white/[0.08] bg-black/20 backdrop-blur">
+        <div className="mx-auto flex w-full max-w-[1440px] items-center justify-between gap-4 px-6 py-4 sm:px-8">
+          <div className="flex items-center gap-3">
+            <div className="flex size-10 items-center justify-center rounded-2xl border border-white/[0.08] bg-white/[0.03]">
+              <BookOpenText className="size-4 text-lime-200" />
+            </div>
+            <div>
+              <Link
+                href="/docs"
+                className="font-[family-name:var(--font-display)] text-xl tracking-[-0.02em] text-white/95"
+              >
+                AgentClash Docs
+              </Link>
+              <p className="text-xs text-white/35">
+                Product, reference, and contributor docs in one place.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 text-xs">
+            <Link
+              href="/"
+              className="rounded-full border border-white/[0.08] bg-white/[0.03] px-3 py-2 text-white/65 transition-colors hover:border-white/15 hover:text-white/90"
+            >
+              Product
+            </Link>
+            <a
+              href="https://github.com/agentclash/agentclash"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 rounded-full border border-white/[0.08] bg-white/[0.03] px-3 py-2 text-white/65 transition-colors hover:border-white/15 hover:text-white/90"
+            >
+              GitHub
+              <ArrowUpRight className="size-3" />
+            </a>
+          </div>
+        </div>
+      </header>
+
+      <div className="mx-auto grid w-full max-w-[1440px] gap-12 px-6 py-10 sm:px-8 lg:grid-cols-[280px_minmax(0,1fr)] lg:gap-16 lg:py-14 xl:grid-cols-[280px_minmax(0,1fr)_220px] xl:items-start">
+        <aside className="lg:sticky lg:top-8 lg:h-fit">
+          <DocsSidebar
+            sections={sections}
+            currentHref={currentHref}
+            searchItems={searchItems}
+          />
+        </aside>
+
+        <section className="min-w-0">
+          <div className="rounded-[32px] border border-white/[0.08] bg-white/[0.03] px-6 py-8 shadow-[0_24px_80px_rgba(0,0,0,0.32)] sm:px-10 sm:py-10">
+            <div className="max-w-3xl">
+              <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.18em] text-lime-200/70">
+                {sectionTitle ?? "Documentation"}
+              </p>
+              <h1 className="mt-4 font-[family-name:var(--font-display)] text-4xl tracking-[-0.04em] text-white sm:text-5xl">
+                {title}
+              </h1>
+              <p className="mt-4 max-w-2xl text-base leading-7 text-white/55 sm:text-lg">
+                {description}
+              </p>
+            </div>
+
+            <div className="mt-10 border-t border-white/[0.08] pt-8">
+              {children}
+            </div>
+          </div>
+        </section>
+
+        <DocsToc headings={headings} />
+      </div>
+    </main>
+  );
+}

--- a/web/src/components/docs/docs-sidebar.tsx
+++ b/web/src/components/docs/docs-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Search } from "lucide-react";
 import type { DocNavSection, DocSearchItem } from "@/lib/docs";
@@ -8,13 +8,15 @@ import type { DocNavSection, DocSearchItem } from "@/lib/docs";
 export function DocsSidebar({
   sections,
   currentHref,
-  searchItems,
 }: {
   sections: DocNavSection[];
   currentHref: string;
-  searchItems: DocSearchItem[];
 }) {
   const [query, setQuery] = useState("");
+  const [searchItems, setSearchItems] = useState<DocSearchItem[]>([]);
+  const [searchState, setSearchState] = useState<
+    "idle" | "loading" | "ready" | "error"
+  >("idle");
   const normalized = query.trim().toLowerCase();
   const tokens = normalized.split(/\s+/).filter(Boolean);
   const matches =
@@ -26,13 +28,54 @@ export function DocsSidebar({
           )
           .slice(0, 12);
 
+  useEffect(() => {
+    if (searchState !== "loading") return;
+
+    let cancelled = false;
+
+    fetch("/docs/search.json", {
+      headers: {
+        Accept: "application/json",
+      },
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to load docs search index: ${response.status}`);
+        }
+        return response.json() as Promise<DocSearchItem[]>;
+      })
+      .then((items) => {
+        if (cancelled) return;
+        setSearchItems(items);
+        setSearchState("ready");
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setSearchState("error");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [searchState]);
+
+  const ensureSearchLoaded = () => {
+    if (searchState === "idle" || searchState === "error") {
+      setSearchState("loading");
+    }
+  };
+
   return (
     <div className="rounded-[28px] border border-white/[0.08] bg-white/[0.03] p-4 sm:p-5">
       <div className="relative">
         <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-white/30" />
         <input
           value={query}
-          onChange={(event) => setQuery(event.target.value)}
+          onChange={(event) => {
+            ensureSearchLoaded();
+            setQuery(event.target.value);
+          }}
+          onFocus={ensureSearchLoaded}
           placeholder="Search docs"
           className="h-11 w-full rounded-2xl border border-white/[0.08] bg-black/20 pl-10 pr-4 text-sm text-white outline-none transition-colors placeholder:text-white/28 focus:border-lime-200/30"
         />
@@ -67,9 +110,21 @@ export function DocsSidebar({
                 </Link>
               );
             })}
+            {searchState === "loading" && (
+              <p className="px-3 py-3 text-sm text-white/40">
+                Loading docs index...
+              </p>
+            )}
+            {searchState === "error" && (
+              <p className="px-3 py-3 text-sm text-white/40">
+                Search is temporarily unavailable.
+              </p>
+            )}
             {matches.length === 0 && (
               <p className="px-3 py-3 text-sm text-white/40">
-                No docs matched that query.
+                {searchState === "ready"
+                  ? "No docs matched that query."
+                  : "Keep typing to search the docs."}
               </p>
             )}
           </div>

--- a/web/src/components/docs/docs-sidebar.tsx
+++ b/web/src/components/docs/docs-sidebar.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Search } from "lucide-react";
+import type { DocNavSection, DocSearchItem } from "@/lib/docs";
+
+export function DocsSidebar({
+  sections,
+  currentHref,
+  searchItems,
+}: {
+  sections: DocNavSection[];
+  currentHref: string;
+  searchItems: DocSearchItem[];
+}) {
+  const [query, setQuery] = useState("");
+  const normalized = query.trim().toLowerCase();
+  const tokens = normalized.split(/\s+/).filter(Boolean);
+  const matches =
+    tokens.length === 0
+      ? []
+      : searchItems
+          .filter((item) =>
+            tokens.every((token) => item.searchText.includes(token)),
+          )
+          .slice(0, 12);
+
+  return (
+    <div className="rounded-[28px] border border-white/[0.08] bg-white/[0.03] p-4 sm:p-5">
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-white/30" />
+        <input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search docs"
+          className="h-11 w-full rounded-2xl border border-white/[0.08] bg-black/20 pl-10 pr-4 text-sm text-white outline-none transition-colors placeholder:text-white/28 focus:border-lime-200/30"
+        />
+      </div>
+
+      {tokens.length > 0 ? (
+        <div className="mt-4">
+          <p className="px-1 text-[11px] uppercase tracking-[0.18em] text-white/30">
+            Search Results
+          </p>
+          <div className="mt-2 space-y-1">
+            {matches.map((item) => {
+              const active = currentHref === item.href;
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={`block rounded-2xl px-3 py-2.5 transition-colors ${
+                    active
+                      ? "bg-lime-300/[0.12] text-lime-100"
+                      : "text-white/68 hover:bg-white/[0.04] hover:text-white"
+                  }`}
+                >
+                  <span className="block text-sm font-medium">{item.title}</span>
+                  <span
+                    className={`mt-1 block text-xs leading-5 ${
+                      active ? "text-lime-100/70" : "text-white/42"
+                    }`}
+                  >
+                    {item.description}
+                  </span>
+                </Link>
+              );
+            })}
+            {matches.length === 0 && (
+              <p className="px-3 py-3 text-sm text-white/40">
+                No docs matched that query.
+              </p>
+            )}
+          </div>
+        </div>
+      ) : (
+        <div className="mt-5 space-y-5">
+          <Link
+            href="/docs"
+            className={`block rounded-2xl px-3 py-2.5 transition-colors ${
+              currentHref === "/docs"
+                ? "bg-lime-300/[0.12] text-lime-100"
+                : "text-white/70 hover:bg-white/[0.04] hover:text-white"
+            }`}
+          >
+            <span className="block text-sm font-medium">Overview</span>
+            <span
+              className={`mt-1 block text-xs leading-5 ${
+                currentHref === "/docs" ? "text-lime-100/70" : "text-white/45"
+              }`}
+            >
+              Start here if you want the shortest path to understanding the product.
+            </span>
+          </Link>
+
+          {sections.map((section) => (
+            <div key={section.title}>
+              <p className="px-3 text-[11px] uppercase tracking-[0.18em] text-white/30">
+                {section.title}
+              </p>
+              <div className="mt-2 space-y-1">
+                {section.items.map((item) => {
+                  const active = currentHref === item.href;
+
+                  return (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      className={`block rounded-2xl px-3 py-2.5 transition-colors ${
+                        active
+                          ? "bg-lime-300/[0.12] text-lime-100"
+                          : "text-white/68 hover:bg-white/[0.04] hover:text-white"
+                      }`}
+                    >
+                      <span className="block text-sm font-medium">
+                        {item.title}
+                      </span>
+                      <span
+                        className={`mt-1 block text-xs leading-5 ${
+                          active ? "text-lime-100/70" : "text-white/42"
+                        }`}
+                      >
+                        {item.description}
+                      </span>
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/docs/docs-toc.tsx
+++ b/web/src/components/docs/docs-toc.tsx
@@ -1,0 +1,28 @@
+import type { DocHeading } from "@/lib/docs";
+
+export function DocsToc({ headings }: { headings: DocHeading[] }) {
+  if (headings.length === 0) return null;
+
+  return (
+    <aside className="hidden xl:block">
+      <div className="sticky top-8 rounded-[28px] border border-white/[0.08] bg-white/[0.03] p-5">
+        <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.18em] text-white/30">
+          On This Page
+        </p>
+        <div className="mt-4 space-y-2">
+          {headings.map((heading) => (
+            <a
+              key={heading.id}
+              href={`#${heading.id}`}
+              className={`block text-sm leading-6 text-white/52 transition-colors hover:text-white ${
+                heading.level === 3 ? "pl-4" : ""
+              }`}
+            >
+              {heading.text}
+            </a>
+          ))}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/web/src/components/docs/mdx-components.tsx
+++ b/web/src/components/docs/mdx-components.tsx
@@ -1,0 +1,51 @@
+import {
+  Children,
+  isValidElement,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+} from "react";
+import { Callout } from "@/components/docs/callout";
+import { slugify } from "@/lib/docs";
+
+function flattenText(children: ReactNode): string {
+  return Children.toArray(children)
+    .map((child) => {
+      if (typeof child === "string" || typeof child === "number") {
+        return String(child);
+      }
+
+      if (isValidElement<{ children?: ReactNode }>(child)) {
+        return flattenText(child.props.children);
+      }
+
+      return "";
+    })
+    .join(" ");
+}
+
+function DocsHeading({
+  level,
+  children,
+  ...props
+}: ComponentPropsWithoutRef<"h2"> & {
+  level: 2 | 3;
+}) {
+  const id = slugify(flattenText(children));
+  const Tag = level === 2 ? "h2" : "h3";
+
+  return (
+    <Tag id={id} {...props}>
+      {children}
+    </Tag>
+  );
+}
+
+export const docsMDXComponents = {
+  Callout,
+  h2: (props: ComponentPropsWithoutRef<"h2">) => (
+    <DocsHeading level={2} {...props} />
+  ),
+  h3: (props: ComponentPropsWithoutRef<"h3">) => (
+    <DocsHeading level={3} {...props} />
+  ),
+};

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -543,6 +543,87 @@ function parseGoField(block: string, field: string) {
   return normalizeWhitespace(match?.[1] ?? match?.[2] ?? "");
 }
 
+function findMatchingGoBrace(source: string, braceStart: number) {
+  let depth = 0;
+  let quote: '"' | "'" | "`" | null = null;
+  let escaped = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let i = braceStart; i < source.length; i += 1) {
+    const char = source[i];
+    const next = source[i + 1];
+
+    if (inLineComment) {
+      if (char === "\n") {
+        inLineComment = false;
+      }
+      continue;
+    }
+
+    if (inBlockComment) {
+      if (char === "*" && next === "/") {
+        inBlockComment = false;
+        i += 1;
+      }
+      continue;
+    }
+
+    if (quote === "`") {
+      if (char === "`") {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === "/" && next === "/") {
+      inLineComment = true;
+      i += 1;
+      continue;
+    }
+
+    if (char === "/" && next === "*") {
+      inBlockComment = true;
+      i += 1;
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return i;
+      }
+    }
+  }
+
+  return -1;
+}
+
 function extractCommandBlocks(source: string) {
   const blocks: Array<{ id: string; block: string }> = [];
   const pattern = /var\s+(\w+)\s*=\s*&cobra\.Command\s*{/g;
@@ -551,21 +632,8 @@ function extractCommandBlocks(source: string) {
   while ((match = pattern.exec(source))) {
     const id = match[1];
     const braceStart = pattern.lastIndex - 1;
-    let depth = 0;
-    let end = braceStart;
-
-    for (let i = braceStart; i < source.length; i += 1) {
-      const char = source[i];
-      if (char === "{") {
-        depth += 1;
-      } else if (char === "}") {
-        depth -= 1;
-        if (depth === 0) {
-          end = i;
-          break;
-        }
-      }
-    }
+    const end = findMatchingGoBrace(source, braceStart);
+    if (end === -1) continue;
 
     blocks.push({ id, block: source.slice(braceStart + 1, end) });
   }
@@ -575,6 +643,10 @@ function extractCommandBlocks(source: string) {
 
 function parseCobraCommands() {
   const commands = new Map<string, ParsedCommand>();
+  if (!fs.existsSync(CLI_CMD_DIR)) {
+    return commands;
+  }
+
   const files = fs
     .readdirSync(CLI_CMD_DIR)
     .filter((entry) => entry.endsWith(".go"))
@@ -784,6 +856,8 @@ function resolveFallback(value: string, consts: Map<string, string>) {
 }
 
 function collectEnvRowsFromGo(filePath: string, sourceLabel: string) {
+  if (!fs.existsSync(filePath)) return [];
+
   const source = fs.readFileSync(filePath, "utf-8");
   const consts = parseConstMap(source);
   const rows = new Map<string, EnvRow>();

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -158,13 +158,41 @@ export const DOCS_NAV: DocNavSection[] = [
         slug: ["concepts", "replay-and-scorecards"],
         href: "/docs/concepts/replay-and-scorecards",
       },
+      {
+        title: "Tools, Network, and Secrets",
+        description:
+          "See how pack-defined tools delegate to primitives, how outbound internet is controlled, and where secrets resolve.",
+        slug: ["concepts", "tools-network-and-secrets"],
+        href: "/docs/concepts/tools-network-and-secrets",
+      },
+      {
+        title: "Artifacts",
+        description:
+          "Understand stored files, pack assets, run evidence, and signed downloads.",
+        slug: ["concepts", "artifacts"],
+        href: "/docs/concepts/artifacts",
+      },
     ],
   },
   {
     title: "Guides",
     description:
-      "Task-oriented walkthroughs for reading results and using the docs with AI tools.",
+      "Task-oriented walkthroughs for authoring packs, setting up deployments, reading results, and using the docs with AI tools.",
     items: [
+      {
+        title: "Write a Challenge Pack",
+        description:
+          "Author a bundle YAML file, validate it, publish it, and understand the IDs AgentClash returns.",
+        slug: ["guides", "write-a-challenge-pack"],
+        href: "/docs/guides/write-a-challenge-pack",
+      },
+      {
+        title: "Configure Runtime Resources",
+        description:
+          "Create secrets, provider accounts, model aliases, runtime profiles, and deployments in the order the product expects.",
+        slug: ["guides", "configure-runtime-resources"],
+        href: "/docs/guides/configure-runtime-resources",
+      },
       {
         title: "Interpret Results",
         description:
@@ -810,7 +838,7 @@ function collectBackendExampleRows() {
 }
 
 function renderEnvTable(title: string, rows: EnvRow[]) {
-  const lines = [`## ${title}`, "", "| Variable | Default | Description |", "| --- | --- | --- |"]; 
+  const lines = [`## ${title}`, "", "| Variable | Default | Description |", "| --- | --- | --- |"];
 
   for (const row of rows) {
     lines.push(

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -28,6 +28,8 @@ const CLI_CONFIG_FILE = path.join(
 );
 const BACKEND_ENV_FILE = path.join(REPO_ROOT, "backend", ".env.example");
 
+export const DOCS_ORIGIN = "https://agentclash.dev";
+
 export type DocNavItem = {
   title: string;
   description: string;
@@ -135,6 +137,48 @@ export const DOCS_NAV: DocNavSection[] = [
         slug: ["concepts", "runs-and-evals"],
         href: "/docs/concepts/runs-and-evals",
       },
+      {
+        title: "Agents and Deployments",
+        description:
+          "See how runnable agent targets are modeled before they can participate in an eval.",
+        slug: ["concepts", "agents-and-deployments"],
+        href: "/docs/concepts/agents-and-deployments",
+      },
+      {
+        title: "Challenge Packs and Inputs",
+        description:
+          "Understand how tasks, input sets, and scoring context are grouped into repeatable workloads.",
+        slug: ["concepts", "challenge-packs-and-inputs"],
+        href: "/docs/concepts/challenge-packs-and-inputs",
+      },
+      {
+        title: "Replay and Scorecards",
+        description:
+          "Learn how canonical events become timelines, evidence, and comparison-ready outputs.",
+        slug: ["concepts", "replay-and-scorecards"],
+        href: "/docs/concepts/replay-and-scorecards",
+      },
+    ],
+  },
+  {
+    title: "Guides",
+    description:
+      "Task-oriented walkthroughs for reading results and using the docs with AI tools.",
+    items: [
+      {
+        title: "Interpret Results",
+        description:
+          "Read timelines, scorecards, and ranking changes without getting lost in raw event volume.",
+        slug: ["guides", "interpret-results"],
+        href: "/docs/guides/interpret-results",
+      },
+      {
+        title: "Use with AI Tools",
+        description:
+          "Use llms.txt, the full bundle, and per-page markdown exports with assistants and coding agents.",
+        slug: ["guides", "use-with-ai-tools"],
+        href: "/docs/guides/use-with-ai-tools",
+      },
     ],
   },
   {
@@ -178,6 +222,27 @@ export const DOCS_NAV: DocNavSection[] = [
         href: "/docs/architecture/orchestration",
       },
       {
+        title: "Sandbox Layer",
+        description:
+          "Why execution is isolated behind a provider boundary and how E2B fits today.",
+        slug: ["architecture", "sandbox-layer"],
+        href: "/docs/architecture/sandbox-layer",
+      },
+      {
+        title: "Data Model",
+        description:
+          "The core entities behind workspaces, deployments, challenge packs, runs, and evidence.",
+        slug: ["architecture", "data-model"],
+        href: "/docs/architecture/data-model",
+      },
+      {
+        title: "Evidence Loop",
+        description:
+          "How run events, artifacts, and scorecards move from execution into replay and review.",
+        slug: ["architecture", "evidence-loop"],
+        href: "/docs/architecture/evidence-loop",
+      },
+      {
         title: "Frontend",
         description:
           "How the Next.js app is split between public product pages, authenticated app routes, and docs.",
@@ -196,6 +261,20 @@ export const DOCS_NAV: DocNavSection[] = [
           "Clone the repo, boot the local stack, and choose the fastest dev loop for your task.",
         slug: ["contributing", "setup"],
         href: "/docs/contributing/setup",
+      },
+      {
+        title: "Codebase Tour",
+        description:
+          "Map the top-level modules before you start changing APIs, workflows, or the web app.",
+        slug: ["contributing", "codebase-tour"],
+        href: "/docs/contributing/codebase-tour",
+      },
+      {
+        title: "Testing",
+        description:
+          "Pick the smallest useful validation loop and use review checkpoints for scoped changes.",
+        slug: ["contributing", "testing"],
+        href: "/docs/contributing/testing",
       },
     ],
   },
@@ -731,7 +810,7 @@ function collectBackendExampleRows() {
 }
 
 function renderEnvTable(title: string, rows: EnvRow[]) {
-  const lines = [`## ${title}`, "", "| Variable | Default | Description |", "| --- | --- | --- |"];
+  const lines = [`## ${title}`, "", "| Variable | Default | Description |", "| --- | --- | --- |"]; 
 
   for (const row of rows) {
     lines.push(
@@ -789,6 +868,49 @@ function uniqueSlugs(slugs: string[][]) {
   });
 }
 
+function docHrefToMarkdownHref(href: string, origin: string) {
+  if (href === "/docs") {
+    return `${origin}/docs-md`;
+  }
+
+  if (href.startsWith("/docs/")) {
+    return `${origin}/docs-md${href.slice("/docs".length)}`;
+  }
+
+  return href.startsWith("http") ? href : `${origin}${href}`;
+}
+
+function renderCallout(type: string, body: string) {
+  const label = type.charAt(0).toUpperCase() + type.slice(1);
+  const lines = body
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (lines.length === 0) {
+    return `> ${label}`;
+  }
+
+  return [
+    `> ${label}: ${lines[0]}`,
+    ...lines.slice(1).map((line) => `> ${line}`),
+  ].join("\n");
+}
+
+function normalizeMarkdownForExport(content: string, origin: string) {
+  return content
+    .replace(/<Callout type="(info|warning|note)">([\s\S]*?)<\/Callout>/g, (_, type, body) =>
+      renderCallout(type, body),
+    )
+    .replace(/\]\((\/docs(?:\/[^)\s]*)?)\)/g, (_, href) => `](${docHrefToMarkdownHref(href, origin)})`)
+    .trim();
+}
+
+export function getDocMarkdownPath(slug: string[] = []) {
+  return slug.length === 0 ? "/docs-md" : `/docs-md/${slug.join("/")}`;
+}
+
 export function flattenDocsNav() {
   return DOCS_NAV.flatMap((section) => section.items);
 }
@@ -832,6 +954,10 @@ export function getAllDocPaths() {
   return getAllDocSlugs().map((slug) => slugToHref(slug));
 }
 
+export function getAllDocMarkdownPaths() {
+  return getAllDocSlugs().map((slug) => getDocMarkdownPath(slug));
+}
+
 export function getDocsSearchIndex(): DocSearchItem[] {
   return getAllDocSlugs()
     .map((slug) => getDocBySlug(slug))
@@ -844,4 +970,74 @@ export function getDocsSearchIndex(): DocSearchItem[] {
         .map((heading) => heading.text)
         .join(" ")} ${stripInlineMarkdown(doc.content).slice(0, 900)}`.toLowerCase(),
     }));
+}
+
+export function renderDocMarkdown(doc: DocPage, origin = DOCS_ORIGIN) {
+  const lines = [
+    `# ${doc.title}`,
+    "",
+    doc.description,
+    "",
+    `Source: ${origin}${doc.href}`,
+    `Markdown export: ${origin}${getDocMarkdownPath(doc.slug)}`,
+    "",
+    normalizeMarkdownForExport(doc.content, origin),
+  ];
+
+  return lines.join("\n").trim();
+}
+
+export function buildLlmsIndex(origin = DOCS_ORIGIN) {
+  const lines = [
+    "# AgentClash",
+    "",
+    "> AgentClash runs agents against repeatable challenge packs, captures replay evidence, and shows where a run won, failed, or drifted.",
+    "",
+    "Use this index when you want the shortest machine-readable map of the public docs. Fetch `/llms-full.txt` for the bundled corpus, or use the `/docs-md/...` links below for page-level markdown exports.",
+    "",
+    "## Core entrypoints",
+    "",
+    `- [Docs home](${origin}/docs-md) - overview, navigation, and starting points.`,
+    `- [Quickstart](${origin}/docs-md/getting-started/quickstart) - fastest path to a real run.`,
+    `- [Self-Host](${origin}/docs-md/getting-started/self-host) - local stack and service dependencies.`,
+    `- [First Eval](${origin}/docs-md/getting-started/first-eval) - end-to-end walkthrough of one eval path.`,
+    `- [CLI Reference](${origin}/docs-md/reference/cli) - generated command reference.`,
+    `- [Config Reference](${origin}/docs-md/reference/config) - generated environment and precedence reference.`,
+    `- [Full bundle](${origin}/llms-full.txt) - all shipped docs in one file.`,
+    "",
+  ];
+
+  for (const section of DOCS_NAV) {
+    lines.push(`## ${section.title}`, "");
+    for (const item of section.items) {
+      lines.push(
+        `- [${item.title}](${origin}${getDocMarkdownPath(item.slug)}) - ${item.description}`,
+      );
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n").trim();
+}
+
+export function buildLlmsFull(origin = DOCS_ORIGIN) {
+  const orderedSlugs = uniqueSlugs([[], ...flattenDocsNav().map((item) => item.slug)]);
+  const docs = orderedSlugs
+    .map((slug) => getDocBySlug(slug))
+    .filter((doc): doc is DocPage => Boolean(doc));
+
+  const lines = [
+    "# AgentClash Docs Bundle",
+    "",
+    `Canonical docs home: ${origin}/docs`,
+    `Machine-readable index: ${origin}/llms.txt`,
+    "",
+    "This file concatenates the currently shipped AgentClash docs pages into one markdown-oriented bundle for assistants, coding agents, and local retrieval pipelines.",
+  ];
+
+  for (const doc of docs) {
+    lines.push("", "---", "", renderDocMarkdown(doc, origin));
+  }
+
+  return lines.join("\n").trim();
 }

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -1,0 +1,847 @@
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+
+const CONTENT_DIR = path.join(process.cwd(), "content", "docs");
+const REPO_ROOT = path.join(process.cwd(), "..");
+const CLI_CMD_DIR = path.join(REPO_ROOT, "cli", "cmd");
+const API_CONFIG_FILE = path.join(
+  REPO_ROOT,
+  "backend",
+  "internal",
+  "api",
+  "config.go",
+);
+const WORKER_CONFIG_FILE = path.join(
+  REPO_ROOT,
+  "backend",
+  "internal",
+  "worker",
+  "config.go",
+);
+const CLI_CONFIG_FILE = path.join(
+  REPO_ROOT,
+  "cli",
+  "internal",
+  "config",
+  "manager.go",
+);
+const BACKEND_ENV_FILE = path.join(REPO_ROOT, "backend", ".env.example");
+
+export type DocNavItem = {
+  title: string;
+  description: string;
+  slug: string[];
+  href: string;
+};
+
+export type DocNavSection = {
+  title: string;
+  description: string;
+  items: DocNavItem[];
+};
+
+export type DocHeading = {
+  id: string;
+  text: string;
+  level: number;
+};
+
+export type DocSearchItem = {
+  title: string;
+  description: string;
+  href: string;
+  searchText: string;
+};
+
+export type DocPage = {
+  slug: string[];
+  href: string;
+  title: string;
+  description: string;
+  content: string;
+  sectionTitle?: string;
+  headings: DocHeading[];
+};
+
+type GeneratedDocDefinition = {
+  title: string;
+  description: string;
+  sectionTitle: string;
+  buildContent: () => string;
+};
+
+type ParsedFlag = {
+  name: string;
+  shorthand?: string;
+  description: string;
+  defaultValue?: string;
+  required?: boolean;
+  persistent?: boolean;
+};
+
+type ParsedCommand = {
+  id: string;
+  use: string;
+  short: string;
+  flags: ParsedFlag[];
+  children: string[];
+};
+
+type EnvRow = {
+  name: string;
+  defaultValue?: string;
+  source: string;
+  description: string;
+};
+
+export const DOCS_NAV: DocNavSection[] = [
+  {
+    title: "Getting Started",
+    description: "Get from first login to a real run, locally or against staging.",
+    items: [
+      {
+        title: "Quickstart",
+        description:
+          "Use the hosted backend and validate auth, workspace access, and run creation.",
+        slug: ["getting-started", "quickstart"],
+        href: "/docs/getting-started/quickstart",
+      },
+      {
+        title: "Self-Host",
+        description:
+          "Bring up the local stack with Postgres, Temporal, API server, worker, and web app.",
+        slug: ["getting-started", "self-host"],
+        href: "/docs/getting-started/self-host",
+      },
+      {
+        title: "First Eval",
+        description:
+          "Walk through the current happy path from seeded data to live run events and ranking output.",
+        slug: ["getting-started", "first-eval"],
+        href: "/docs/getting-started/first-eval",
+      },
+    ],
+  },
+  {
+    title: "Concepts",
+    description:
+      "The mental models that matter before you start comparing agents.",
+    items: [
+      {
+        title: "Runs and Evals",
+        description:
+          "Understand the difference between a run, a ranked result set, and the broader eval concept.",
+        slug: ["concepts", "runs-and-evals"],
+        href: "/docs/concepts/runs-and-evals",
+      },
+    ],
+  },
+  {
+    title: "Reference",
+    description:
+      "Reference surfaces generated from current source readers where possible.",
+    items: [
+      {
+        title: "CLI",
+        description:
+          "Commands, flags, and command groups generated from the Cobra source tree.",
+        slug: ["reference", "cli"],
+        href: "/docs/reference/cli",
+      },
+      {
+        title: "Config",
+        description:
+          "Current environment surface pulled from the API, worker, CLI, and example config sources.",
+        slug: ["reference", "config"],
+        href: "/docs/reference/config",
+      },
+    ],
+  },
+  {
+    title: "Architecture",
+    description:
+      "System boundaries, runtime components, and why the stack is shaped this way.",
+    items: [
+      {
+        title: "Overview",
+        description:
+          "Web, API, worker, Postgres, Temporal, sandbox, and artifact storage in one picture.",
+        slug: ["architecture", "overview"],
+        href: "/docs/architecture/overview",
+      },
+      {
+        title: "Orchestration",
+        description:
+          "How API requests become Temporal workflows and how the worker executes them.",
+        slug: ["architecture", "orchestration"],
+        href: "/docs/architecture/orchestration",
+      },
+      {
+        title: "Frontend",
+        description:
+          "How the Next.js app is split between public product pages, authenticated app routes, and docs.",
+        slug: ["architecture", "frontend"],
+        href: "/docs/architecture/frontend",
+      },
+    ],
+  },
+  {
+    title: "Contributing",
+    description: "Get the repo running and understand where to start making changes.",
+    items: [
+      {
+        title: "Setup",
+        description:
+          "Clone the repo, boot the local stack, and choose the fastest dev loop for your task.",
+        slug: ["contributing", "setup"],
+        href: "/docs/contributing/setup",
+      },
+    ],
+  },
+];
+
+const GENERATED_DOCS: Record<string, GeneratedDocDefinition> = {
+  "reference/cli": {
+    title: "CLI Reference",
+    description:
+      "Commands, flags, and command groups generated from the current Cobra CLI source.",
+    sectionTitle: "Reference",
+    buildContent: renderCLIReference,
+  },
+  "reference/config": {
+    title: "Config Reference",
+    description:
+      "Environment variables and config precedence generated from the current source readers.",
+    sectionTitle: "Reference",
+    buildContent: renderConfigReference,
+  },
+};
+
+const CONFIG_DESCRIPTIONS: Record<string, string> = {
+  AGENTCLASH_API_URL: "Override the CLI API base URL.",
+  AGENTCLASH_DEV_ORG_MEMBERSHIPS:
+    "Inject development org memberships into the CLI dev-auth path.",
+  AGENTCLASH_DEV_USER_ID: "Inject a development user ID for CLI dev mode.",
+  AGENTCLASH_DEV_WORKSPACE_MEMBERSHIPS:
+    "Inject development workspace memberships into the CLI dev-auth path.",
+  AGENTCLASH_ORG: "Override the default organization ID for CLI commands.",
+  AGENTCLASH_TOKEN: "Provide a CLI token directly, mainly for CI or automation.",
+  AGENTCLASH_WORKSPACE:
+    "Override the default workspace ID for CLI commands.",
+  API_SERVER_BIND_ADDRESS: "Bind address for the API server process.",
+  APP_ENV: "Select development, staging, or production behavior.",
+  ARTIFACT_MAX_UPLOAD_BYTES:
+    "Upper bound for artifact upload size accepted by the API server.",
+  ARTIFACT_SIGNED_URL_TTL_SECONDS:
+    "Expiry window for signed artifact URLs returned by the API server.",
+  ARTIFACT_SIGNING_SECRET:
+    "Signing secret for artifact URL generation; required outside local filesystem dev mode.",
+  ARTIFACT_STORAGE_BACKEND:
+    "Choose filesystem or S3-compatible artifact storage.",
+  ARTIFACT_STORAGE_BUCKET: "Artifact bucket or logical container name.",
+  ARTIFACT_STORAGE_FILESYSTEM_ROOT:
+    "Local artifact root when the filesystem backend is in use.",
+  ARTIFACT_STORAGE_S3_ACCESS_KEY_ID:
+    "Access key for S3-compatible artifact storage.",
+  ARTIFACT_STORAGE_S3_ENDPOINT:
+    "Optional custom endpoint for S3-compatible artifact storage.",
+  ARTIFACT_STORAGE_S3_FORCE_PATH_STYLE:
+    "Toggle path-style addressing for S3-compatible storage.",
+  ARTIFACT_STORAGE_S3_REGION: "Region for S3-compatible artifact storage.",
+  ARTIFACT_STORAGE_S3_SECRET_ACCESS_KEY:
+    "Secret key for S3-compatible artifact storage.",
+  AUTH_MODE: "Select dev headers or WorkOS-backed authentication for the API.",
+  CORS_ALLOWED_ORIGINS:
+    "Allowed browser origins for the API in WorkOS mode.",
+  DATABASE_URL: "Postgres connection string.",
+  E2B_API_BASE_URL: "Optional E2B API base URL override.",
+  E2B_API_KEY: "API key for the E2B sandbox provider.",
+  E2B_REQUEST_TIMEOUT: "Timeout for E2B sandbox API calls.",
+  E2B_TEMPLATE_ID: "Template ID for the E2B sandbox provider.",
+  FRONTEND_URL: "Public web origin used in emails and CLI auth links.",
+  HOSTED_RUN_CALLBACK_BASE_URL:
+    "Base URL the worker uses when calling hosted-run callback endpoints.",
+  HOSTED_RUN_CALLBACK_SECRET:
+    "Shared secret for hosted-run callback authentication.",
+  REDIS_URL: "Enable Redis-backed event fanout and related features.",
+  RESEND_API_KEY: "Enable invite email sending through Resend.",
+  RESEND_FROM_EMAIL: "Sender address for invite emails.",
+  SANDBOX_PROVIDER:
+    "Choose unconfigured or e2b for native sandbox execution.",
+  TEMPORAL_HOST_PORT: "Temporal frontend address.",
+  TEMPORAL_NAMESPACE: "Temporal namespace used by the API and worker.",
+  WORKER_IDENTITY: "Logical worker identity label.",
+  WORKER_SHUTDOWN_TIMEOUT:
+    "Graceful shutdown timeout for the worker process.",
+  WORKOS_CLIENT_ID: "WorkOS client ID used when the API is in workos auth mode.",
+  WORKOS_ISSUER:
+    "Optional WorkOS issuer override for JWT validation.",
+};
+
+function sortEntries(a: fs.Dirent, b: fs.Dirent) {
+  if (a.isDirectory() && !b.isDirectory()) return -1;
+  if (!a.isDirectory() && b.isDirectory()) return 1;
+  return a.name.localeCompare(b.name);
+}
+
+function slugToHref(slug: string[]) {
+  return slug.length === 0 ? "/docs" : `/docs/${slug.join("/")}`;
+}
+
+function slugKey(slug: string[]) {
+  return slug.join("/");
+}
+
+function docPathForSlug(slug: string[]) {
+  if (slug.length === 0) {
+    return path.join(CONTENT_DIR, "index.mdx");
+  }
+
+  return path.join(CONTENT_DIR, ...slug) + ".mdx";
+}
+
+function readSlugs(dir: string, prefix: string[] = []): string[][] {
+  if (!fs.existsSync(dir)) return [];
+
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .sort(sortEntries)
+    .flatMap((entry) => {
+      if (entry.isDirectory()) {
+        return readSlugs(path.join(dir, entry.name), [...prefix, entry.name]);
+      }
+
+      if (!entry.isFile() || !entry.name.endsWith(".mdx")) {
+        return [];
+      }
+
+      const stem = entry.name.replace(/\.mdx$/, "");
+      if (stem === "index") {
+        return [prefix];
+      }
+
+      return [[...prefix, stem]];
+    });
+}
+
+function normalizeWhitespace(value: string) {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function stripInlineMarkdown(value: string) {
+  return normalizeWhitespace(
+    value
+      .replace(/`([^`]+)`/g, "$1")
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+      .replace(/[*_~>#]/g, "")
+      .replace(/<[^>]+>/g, ""),
+  );
+}
+
+export function slugify(value: string) {
+  return stripInlineMarkdown(value)
+    .toLowerCase()
+    .replace(/&/g, "and")
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+}
+
+export function extractHeadings(content: string): DocHeading[] {
+  return content
+    .split(/\r?\n/)
+    .flatMap((line) => {
+      const match = /^(##|###)\s+(.+)$/.exec(line.trim());
+      if (!match) return [];
+
+      const text = stripInlineMarkdown(match[2]);
+      if (!text) return [];
+
+      return [
+        {
+          id: slugify(text),
+          text,
+          level: match[1].length,
+        },
+      ];
+    });
+}
+
+function findSectionTitle(href: string) {
+  for (const section of DOCS_NAV) {
+    if (section.items.some((item) => item.href === href)) {
+      return section.title;
+    }
+  }
+
+  return undefined;
+}
+
+function createDocPage(
+  slug: string[],
+  title: string,
+  description: string,
+  content: string,
+  sectionTitle?: string,
+): DocPage {
+  return {
+    slug,
+    href: slugToHref(slug),
+    title,
+    description,
+    content,
+    sectionTitle,
+    headings: extractHeadings(content),
+  };
+}
+
+function getFileDocBySlug(slug: string[]) {
+  const filePath = docPathForSlug(slug);
+  if (!fs.existsSync(filePath)) return null;
+
+  const raw = fs.readFileSync(filePath, "utf-8");
+  const { data, content } = matter(raw);
+  const href = slugToHref(slug);
+
+  return createDocPage(
+    slug,
+    data.title as string,
+    data.description as string,
+    content,
+    findSectionTitle(href),
+  );
+}
+
+function getGeneratedDocBySlug(slug: string[]) {
+  const key = slugKey(slug);
+  const generated = GENERATED_DOCS[key];
+  if (!generated) return null;
+
+  return createDocPage(
+    slug,
+    generated.title,
+    generated.description,
+    generated.buildContent(),
+    generated.sectionTitle,
+  );
+}
+
+function parseGoField(block: string, field: string) {
+  const match = block.match(
+    new RegExp(`${field}:\\s*(?:"([^"]*)"|\`([\\s\\S]*?)\`)`),
+  );
+
+  return normalizeWhitespace(match?.[1] ?? match?.[2] ?? "");
+}
+
+function extractCommandBlocks(source: string) {
+  const blocks: Array<{ id: string; block: string }> = [];
+  const pattern = /var\s+(\w+)\s*=\s*&cobra\.Command\s*{/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(source))) {
+    const id = match[1];
+    const braceStart = pattern.lastIndex - 1;
+    let depth = 0;
+    let end = braceStart;
+
+    for (let i = braceStart; i < source.length; i += 1) {
+      const char = source[i];
+      if (char === "{") {
+        depth += 1;
+      } else if (char === "}") {
+        depth -= 1;
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+
+    blocks.push({ id, block: source.slice(braceStart + 1, end) });
+  }
+
+  return blocks;
+}
+
+function parseCobraCommands() {
+  const commands = new Map<string, ParsedCommand>();
+  const files = fs
+    .readdirSync(CLI_CMD_DIR)
+    .filter((entry) => entry.endsWith(".go"))
+    .map((entry) => fs.readFileSync(path.join(CLI_CMD_DIR, entry), "utf-8"));
+
+  for (const source of files) {
+    for (const { id, block } of extractCommandBlocks(source)) {
+      const use = parseGoField(block, "Use");
+      if (!use) continue;
+
+      commands.set(id, {
+        id,
+        use,
+        short: parseGoField(block, "Short"),
+        flags: [],
+        children: [],
+      });
+    }
+  }
+
+  for (const source of files) {
+    const lines = source.split(/\r?\n/);
+    for (const line of lines) {
+      const addMatch = line.match(/(\w+)\.AddCommand\(([^)]+)\)/);
+      if (addMatch) {
+        const parent = commands.get(addMatch[1]);
+        if (parent) {
+          for (const childID of addMatch[2]
+            .split(",")
+            .map((value) => value.trim())
+            .filter(Boolean)) {
+            if (commands.has(childID) && !parent.children.includes(childID)) {
+              parent.children.push(childID);
+            }
+          }
+        }
+      }
+
+      const flagMatch = line.match(/(\w+)\.(Persistent)?Flags\(\)\.(\w+)\((.*)\)/);
+      if (flagMatch) {
+        const command = commands.get(flagMatch[1]);
+        if (!command) continue;
+
+        const method = flagMatch[3];
+        const stringLiterals = [...flagMatch[4].matchAll(/"([^"]*)"/g)].map(
+          (value) => value[1],
+        );
+        if (stringLiterals.length < 2) continue;
+
+        const flag: ParsedFlag = {
+          name: stringLiterals[0],
+          description: stringLiterals[stringLiterals.length - 1],
+          persistent: Boolean(flagMatch[2]),
+        };
+
+        if (method.endsWith("P") && stringLiterals[1]) {
+          flag.shorthand = stringLiterals[1];
+        }
+
+        if (method.includes("Var")) {
+          if (stringLiterals.length >= 4) {
+            flag.defaultValue = stringLiterals[stringLiterals.length - 2];
+          }
+        } else if (stringLiterals.length >= 3) {
+          flag.defaultValue = stringLiterals[stringLiterals.length - 2];
+        }
+
+        command.flags.push(flag);
+      }
+
+      const requiredMatch = line.match(/(\w+)\.MarkFlagRequired\("([^"]+)"\)/);
+      if (requiredMatch) {
+        const command = commands.get(requiredMatch[1]);
+        if (!command) continue;
+
+        const flag = command.flags.find((item) => item.name === requiredMatch[2]);
+        if (flag) {
+          flag.required = true;
+        }
+      }
+    }
+  }
+
+  for (const command of commands.values()) {
+    command.children.sort((a, b) => {
+      const left = commands.get(a)?.use ?? a;
+      const right = commands.get(b)?.use ?? b;
+      return left.localeCompare(right);
+    });
+    command.flags.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  return commands;
+}
+
+function formatFlag(flag: ParsedFlag) {
+  const pieces = [`\`--${flag.name}\``];
+  if (flag.shorthand) {
+    pieces.push(`(\`-${flag.shorthand}\`)`);
+  }
+  if (flag.required) {
+    pieces.push("(required)");
+  }
+  if (flag.defaultValue) {
+    pieces.push(`default: \`${flag.defaultValue}\``);
+  }
+
+  return `${pieces.join(" ")} — ${flag.description}`;
+}
+
+function renderCommandSection(
+  commandID: string,
+  commands: Map<string, ParsedCommand>,
+  depth: number,
+  seen = new Set<string>(),
+): string[] {
+  const command = commands.get(commandID);
+  if (!command || seen.has(commandID)) return [];
+  seen.add(commandID);
+
+  const heading = "#".repeat(Math.min(depth, 6));
+  const lines = [`${heading} \`${command.use}\``, ""];
+
+  if (command.short) {
+    lines.push(command.short, "");
+  }
+
+  if (command.flags.length > 0) {
+    lines.push("Flags", "");
+    for (const flag of command.flags) {
+      lines.push(`- ${formatFlag(flag)}`);
+    }
+    lines.push("");
+  }
+
+  for (const childID of command.children) {
+    lines.push(...renderCommandSection(childID, commands, depth + 1, seen));
+  }
+
+  return lines;
+}
+
+function renderCLIReference() {
+  const commands = parseCobraCommands();
+  const root = commands.get("rootCmd");
+  const lines = [
+    "This page is generated from the Cobra command definitions in `cli/cmd`.",
+    "",
+    "## Global flags",
+    "",
+  ];
+
+  if (root?.flags.length) {
+    for (const flag of root.flags.filter((item) => item.persistent)) {
+      lines.push(`- ${formatFlag(flag)}`);
+    }
+  } else {
+    lines.push("- No persistent flags were discovered.");
+  }
+
+  lines.push("", "## Command groups", "");
+
+  for (const childID of root?.children ?? []) {
+    lines.push(...renderCommandSection(childID, commands, 3));
+  }
+
+  lines.push(
+    "## Source pointers",
+    "",
+    "- `cli/cmd/root.go`",
+    "- `cli/cmd/auth.go`",
+    "- `cli/cmd/workspace.go`",
+    "- `cli/cmd/run.go`",
+    "- `cli/cmd/compare.go`",
+  );
+
+  return lines.join("\n");
+}
+
+function parseConstMap(source: string) {
+  const values = new Map<string, string>();
+  const constBlocks = [...source.matchAll(/const\s*\(([\s\S]*?)\)/g)].map(
+    (match) => match[1],
+  );
+
+  for (const block of constBlocks) {
+    for (const line of block.split(/\r?\n/)) {
+      const trimmed = line.trim().replace(/,$/, "");
+      if (!trimmed || trimmed.startsWith("//")) continue;
+      const match = trimmed.match(/^(\w+)\s*=\s*(.+)$/);
+      if (match) {
+        values.set(match[1], normalizeWhitespace(match[2]));
+      }
+    }
+  }
+
+  for (const match of source.matchAll(/^const\s+(\w+)\s*=\s*(.+)$/gm)) {
+    values.set(match[1], normalizeWhitespace(match[2].replace(/,$/, "")));
+  }
+
+  return values;
+}
+
+function resolveFallback(value: string, consts: Map<string, string>) {
+  const trimmed = normalizeWhitespace(value);
+  return consts.get(trimmed) ?? trimmed;
+}
+
+function collectEnvRowsFromGo(filePath: string, sourceLabel: string) {
+  const source = fs.readFileSync(filePath, "utf-8");
+  const consts = parseConstMap(source);
+  const rows = new Map<string, EnvRow>();
+
+  const addRow = (name: string, defaultValue?: string) => {
+    rows.set(name, {
+      name,
+      defaultValue,
+      source: sourceLabel,
+      description:
+        CONFIG_DESCRIPTIONS[name] ?? `Read by ${sourceLabel.toLowerCase()}.`,
+    });
+  };
+
+  for (const match of source.matchAll(
+    /(?:envOrDefault|boolEnvOrDefault|int64EnvOrDefault|durationEnvOrDefault|durationSecondsEnvOrDefault)\("([^"]+)",\s*([^)]+)\)/g,
+  )) {
+    addRow(match[1], resolveFallback(match[2], consts));
+  }
+
+  for (const match of source.matchAll(/(?:os\.(?:Getenv|LookupEnv)|optionalEnv)\("([^"]+)"\)/g)) {
+    addRow(match[1]);
+  }
+
+  return [...rows.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function collectBackendExampleRows() {
+  if (!fs.existsSync(BACKEND_ENV_FILE)) return [];
+
+  const rows = new Map<string, EnvRow>();
+  const source = fs.readFileSync(BACKEND_ENV_FILE, "utf-8");
+
+  for (const line of source.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const separator = trimmed.indexOf("=");
+    if (separator <= 0) continue;
+
+    const name = trimmed.slice(0, separator);
+    const defaultValue = trimmed.slice(separator + 1);
+    rows.set(name, {
+      name,
+      defaultValue,
+      source: "backend/.env.example",
+      description:
+        CONFIG_DESCRIPTIONS[name] ?? "Present in the backend example environment file.",
+    });
+  }
+
+  return [...rows.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function renderEnvTable(title: string, rows: EnvRow[]) {
+  const lines = [`## ${title}`, "", "| Variable | Default | Description |", "| --- | --- | --- |"];
+
+  for (const row of rows) {
+    lines.push(
+      `| \`${row.name}\` | ${row.defaultValue ? `\`${row.defaultValue}\`` : "—"} | ${row.description} |`,
+    );
+  }
+
+  lines.push("");
+  return lines;
+}
+
+function renderConfigReference() {
+  const apiRows = collectEnvRowsFromGo(API_CONFIG_FILE, "backend/internal/api/config.go");
+  const workerRows = collectEnvRowsFromGo(
+    WORKER_CONFIG_FILE,
+    "backend/internal/worker/config.go",
+  );
+  const cliRows = collectEnvRowsFromGo(
+    CLI_CONFIG_FILE,
+    "cli/internal/config/manager.go",
+  );
+  const backendExampleRows = collectBackendExampleRows();
+
+  const lines = [
+    "This page is generated from the config readers in the API server, worker, CLI, and the checked-in backend example environment file.",
+    "",
+    "## CLI precedence",
+    "",
+    "- API URL: `--api-url > AGENTCLASH_API_URL > saved user config > http://localhost:8080`",
+    "- Workspace: `--workspace > AGENTCLASH_WORKSPACE > project config > user config`",
+    "- Output format: `--json > --output > user config > table`",
+    "",
+    ...renderEnvTable("API Server Environment", apiRows),
+    ...renderEnvTable("Worker Environment", workerRows),
+    ...renderEnvTable("CLI Environment", cliRows),
+    ...renderEnvTable("Backend Example Environment", backendExampleRows),
+    "## Source pointers",
+    "",
+    "- `backend/internal/api/config.go`",
+    "- `backend/internal/worker/config.go`",
+    "- `cli/internal/config/manager.go`",
+    "- `backend/.env.example`",
+  ];
+
+  return lines.join("\n");
+}
+
+function uniqueSlugs(slugs: string[][]) {
+  const seen = new Set<string>();
+  return slugs.filter((slug) => {
+    const key = slugKey(slug);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function flattenDocsNav() {
+  return DOCS_NAV.flatMap((section) => section.items);
+}
+
+export function getOrderedDocs() {
+  return [
+    {
+      title: "Overview",
+      href: "/docs",
+    },
+    ...flattenDocsNav().map((item) => ({
+      title: item.title,
+      href: item.href,
+    })),
+  ];
+}
+
+export function getDocNeighbors(currentHref: string) {
+  const ordered = getOrderedDocs();
+  const index = ordered.findIndex((item) => item.href === currentHref);
+  if (index === -1) return { previous: null, next: null };
+
+  return {
+    previous: ordered[index - 1] ?? null,
+    next: ordered[index + 1] ?? null,
+  };
+}
+
+export function getDocBySlug(slug: string[] = []): DocPage | null {
+  return getGeneratedDocBySlug(slug) ?? getFileDocBySlug(slug);
+}
+
+export function getAllDocSlugs() {
+  const generatedSlugs = Object.keys(GENERATED_DOCS).map((value) =>
+    value.split("/"),
+  );
+  return uniqueSlugs([...readSlugs(CONTENT_DIR), ...generatedSlugs]);
+}
+
+export function getAllDocPaths() {
+  return getAllDocSlugs().map((slug) => slugToHref(slug));
+}
+
+export function getDocsSearchIndex(): DocSearchItem[] {
+  return getAllDocSlugs()
+    .map((slug) => getDocBySlug(slug))
+    .filter((doc): doc is DocPage => Boolean(doc))
+    .map((doc) => ({
+      title: doc.title,
+      description: doc.description,
+      href: doc.href,
+      searchText: `${doc.title} ${doc.description} ${doc.headings
+        .map((heading) => heading.text)
+        .join(" ")} ${stripInlineMarkdown(doc.content).slice(0, 900)}`.toLowerCase(),
+    }));
+}

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,6 +1,25 @@
+import {
+  NextResponse,
+  type NextFetchEvent,
+  type NextRequest,
+} from "next/server";
 import { authkitMiddleware } from "@workos-inc/authkit-nextjs";
 
-export default authkitMiddleware();
+const authkit = authkitMiddleware();
+
+export default function middleware(
+  request: NextRequest,
+  event: NextFetchEvent,
+) {
+  if (
+    request.nextUrl.pathname === "/docs" ||
+    request.nextUrl.pathname.startsWith("/docs/")
+  ) {
+    return NextResponse.next();
+  }
+
+  return authkit(request, event);
+}
 
 export const config = {
   matcher: [

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -13,7 +13,11 @@ export default function middleware(
 ) {
   if (
     request.nextUrl.pathname === "/docs" ||
-    request.nextUrl.pathname.startsWith("/docs/")
+    request.nextUrl.pathname.startsWith("/docs/") ||
+    request.nextUrl.pathname === "/docs-md" ||
+    request.nextUrl.pathname.startsWith("/docs-md/") ||
+    request.nextUrl.pathname === "/llms.txt" ||
+    request.nextUrl.pathname === "/llms-full.txt"
   ) {
     return NextResponse.next();
   }


### PR DESCRIPTION
## What changed

This PR adds the first production-facing docs foundation inside the existing Next.js app at `/docs`.

It includes:
- a dedicated docs route with a dark docs shell
- file-backed docs content under `web/content/docs`
- public `/docs` access by bypassing the AuthKit middleware path for docs routes
- inline docs search/filtering in the sidebar
- heading-based table of contents and next/previous doc navigation
- expanded docs content for quickstart, self-hosting, first eval, concepts, architecture, and contributor setup
- generated reference pages for the CLI and config surface from current source inputs
- sitemap coverage for the new docs pages

## Why it changed

The repo had internal docs and a small MDX/blog setup, but no coherent public docs surface. The initial foundation solved routing and styling, but `/docs` was still blocked locally by the AuthKit middleware and the reference pages were still hand-maintained.

This PR closes that gap by making docs publicly reachable, improving navigation, and generating key reference pages from the current source tree instead of relying on stale prose.

## User and developer impact

- visitors can browse `/docs` without login
- docs are now discoverable from the landing page
- contributors have a grounded starting point for public docs inside the existing web app
- CLI/config reference stays closer to the code because it is generated at render time from current source inputs

## Validation

- `pnpm build` in `web/`
- ran the built app locally with `next start -p 3101`
- verified `GET /docs` returns `200`
- verified `GET /docs/reference/config` renders generated config content
- verified `sitemap.xml` includes new docs routes such as `/docs/reference/config`, `/docs/getting-started/first-eval`, and `/docs/architecture/orchestration`

## Notes

- the new `agentclash-docs` skill was saved outside the repo and is not part of this PR
- generated reference currently covers CLI and config; API/schema generation can be layered on later
