### PR TITLE
refactor(docs): update documentation UI to match clean dark theme

### DIFF
--- a/web/src/components/docs/docs-search.tsx
+++ b/web/src/components/docs/docs-search.tsx
@@ -80,7 +80,7 @@ export function DocsSearch() {
             // small delay to allow clicking a result
             setTimeout(() => setIsOpen(false), 200);
           }}
-          placeholder="Search InsForge docs..."
+          placeholder="Search AgentClash docs..."
           className="h-9 w-full rounded-md border border-zinc-800 bg-zinc-900/50 pl-10 pr-10 text-sm text-zinc-200 outline-none transition-colors placeholder:text-zinc-500 focus:border-emerald-500/50 focus:bg-zinc-900"
         />
         <div className="pointer-events-none absolute right-3 flex items-center gap-1 text-[10px] text-zinc-500">

--- a/web/src/components/docs/docs-search.tsx
+++ b/web/src/components/docs/docs-search.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Search, Command } from "lucide-react";
+import type { DocSearchItem } from "@/lib/docs";
+
+export function DocsSearch() {
+  const [query, setQuery] = useState("");
+  const [searchItems, setSearchItems] = useState<DocSearchItem[]>([]);
+  const [searchState, setSearchState] = useState<
+    "idle" | "loading" | "ready" | "error"
+  >("idle");
+  const [isOpen, setIsOpen] = useState(false);
+
+  const normalized = query.trim().toLowerCase();
+  const tokens = normalized.split(/\s+/).filter(Boolean);
+  const matches =
+    tokens.length === 0
+      ? []
+      : searchItems
+          .filter((item) =>
+            tokens.every((token) => item.searchText.includes(token)),
+          )
+          .slice(0, 12);
+
+  useEffect(() => {
+    if (searchState !== "loading") return;
+
+    let cancelled = false;
+
+    fetch("/docs/search.json", {
+      headers: {
+        Accept: "application/json",
+      },
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to load docs search index: ${response.status}`);
+        }
+        return response.json() as Promise<DocSearchItem[]>;
+      })
+      .then((items) => {
+        if (cancelled) return;
+        setSearchItems(items);
+        setSearchState("ready");
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setSearchState("error");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [searchState]);
+
+  const ensureSearchLoaded = () => {
+    if (searchState === "idle" || searchState === "error") {
+      setSearchState("loading");
+    }
+  };
+
+  return (
+    <div className="relative w-full max-w-[24rem]">
+      <div className="relative flex items-center">
+        <Search className="pointer-events-none absolute left-3 size-4 text-zinc-400" />
+        <input
+          value={query}
+          onChange={(event) => {
+            ensureSearchLoaded();
+            setQuery(event.target.value);
+            setIsOpen(true);
+          }}
+          onFocus={() => {
+            ensureSearchLoaded();
+            setIsOpen(true);
+          }}
+          onBlur={() => {
+            // small delay to allow clicking a result
+            setTimeout(() => setIsOpen(false), 200);
+          }}
+          placeholder="Search InsForge docs..."
+          className="h-9 w-full rounded-md border border-zinc-800 bg-zinc-900/50 pl-10 pr-10 text-sm text-zinc-200 outline-none transition-colors placeholder:text-zinc-500 focus:border-emerald-500/50 focus:bg-zinc-900"
+        />
+        <div className="pointer-events-none absolute right-3 flex items-center gap-1 text-[10px] text-zinc-500">
+          <Command className="size-3" />
+          <span>K</span>
+        </div>
+      </div>
+
+      {isOpen && tokens.length > 0 && (
+        <div className="absolute top-12 left-0 right-0 z-50 rounded-lg border border-zinc-800 bg-zinc-900 p-2 shadow-2xl">
+          <div className="space-y-1">
+            {matches.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className="block rounded-md px-3 py-2 transition-colors hover:bg-zinc-800"
+                onClick={() => setIsOpen(false)}
+              >
+                <span className="block text-sm font-medium text-zinc-200">{item.title}</span>
+                <span className="mt-1 block truncate text-xs text-zinc-500">
+                  {item.description}
+                </span>
+              </Link>
+            ))}
+            {searchState === "loading" && (
+              <p className="px-3 py-2 text-sm text-zinc-500">Loading docs index...</p>
+            )}
+            {searchState === "error" && (
+              <p className="px-3 py-2 text-sm text-zinc-500">Search is temporarily unavailable.</p>
+            )}
+            {searchState === "ready" && matches.length === 0 && (
+              <p className="px-3 py-2 text-sm text-zinc-500">No results found.</p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/docs/docs-shell.tsx
+++ b/web/src/components/docs/docs-shell.tsx
@@ -1,9 +1,12 @@
+"use client";
+
 import type { ReactNode } from "react";
 import Link from "next/link";
-import { ArrowUpRight, BookOpenText } from "lucide-react";
+import { Copy, Sparkles, Moon } from "lucide-react";
 import type { DocHeading, DocNavSection } from "@/lib/docs";
 import { DocsSidebar } from "@/components/docs/docs-sidebar";
 import { DocsToc } from "@/components/docs/docs-toc";
+import { DocsSearch } from "@/components/docs/docs-search";
 
 export function DocsShell({
   currentHref,
@@ -23,72 +26,78 @@ export function DocsShell({
   children: ReactNode;
 }) {
   return (
-    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,rgba(212,255,79,0.09),transparent_24%),radial-gradient(circle_at_top_right,rgba(255,255,255,0.06),transparent_18%),#050505] text-white">
-      <header className="border-b border-white/[0.08] bg-black/20 backdrop-blur">
-        <div className="mx-auto flex w-full max-w-[1440px] items-center justify-between gap-4 px-6 py-4 sm:px-8">
-          <div className="flex items-center gap-3">
-            <div className="flex size-10 items-center justify-center rounded-2xl border border-white/[0.08] bg-white/[0.03]">
-              <BookOpenText className="size-4 text-lime-200" />
-            </div>
-            <div>
-              <Link
-                href="/docs"
-                className="font-[family-name:var(--font-display)] text-xl tracking-[-0.02em] text-white/95"
-              >
-                AgentClash Docs
+    <main className="min-h-screen bg-[#060606] text-zinc-300">
+      <header className="sticky top-0 z-40 border-b border-zinc-800/60 bg-[#060606]/90 backdrop-blur">
+        <div className="flex h-16 w-full items-center justify-between gap-4 px-6">
+          <div className="flex items-center gap-6">
+            <Link href="/" className="flex items-center gap-2 text-zinc-100">
+              <Sparkles className="size-5" />
+              <span className="font-semibold tracking-tight">AgentClash</span>
+            </Link>
+            <nav className="hidden items-center gap-6 text-sm font-medium text-zinc-400 md:flex">
+              <Link href="/docs" className="text-zinc-100 relative">
+                Docs
+                <span className="absolute -bottom-[22px] left-0 right-0 h-0.5 bg-emerald-500" />
               </Link>
-              <p className="text-xs text-white/35">
-                Product, reference, and contributor docs in one place.
-              </p>
-            </div>
+              <Link href="#" className="hover:text-zinc-100 transition-colors">SDK & Examples</Link>
+              <Link href="#" className="hover:text-zinc-100 transition-colors">API Reference</Link>
+            </nav>
           </div>
 
-          <div className="flex items-center gap-2 text-xs">
-            <Link
-              href="/"
-              className="rounded-full border border-white/[0.08] bg-white/[0.03] px-3 py-2 text-white/65 transition-colors hover:border-white/15 hover:text-white/90"
-            >
-              Product
-            </Link>
+          <div className="flex flex-1 items-center justify-end gap-4 md:flex-none">
+            <DocsSearch />
             <a
-              href="https://github.com/agentclash/agentclash"
+              href="https://cal.com/agentclash/demo"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 rounded-full border border-white/[0.08] bg-white/[0.03] px-3 py-2 text-white/65 transition-colors hover:border-white/15 hover:text-white/90"
+              className="hidden rounded-full bg-emerald-600 px-4 py-1.5 text-sm font-medium text-white transition-colors hover:bg-emerald-700 sm:block"
             >
-              GitHub
-              <ArrowUpRight className="size-3" />
+              Get Started &rarr;
             </a>
+            <button className="flex size-8 items-center justify-center rounded-md text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100">
+              <Moon className="size-4" />
+            </button>
           </div>
         </div>
       </header>
 
-      <div className="mx-auto grid w-full max-w-[1440px] gap-12 px-6 py-10 sm:px-8 lg:grid-cols-[280px_minmax(0,1fr)] lg:gap-16 lg:py-14 xl:grid-cols-[280px_minmax(0,1fr)_220px] xl:items-start">
-        <aside className="lg:sticky lg:top-8 lg:h-fit">
+      <div className="mx-auto flex w-full max-w-[1536px] items-start px-6 lg:px-8">
+        <aside className="sticky top-16 hidden h-[calc(100vh-4rem)] w-64 shrink-0 overflow-y-auto border-r border-zinc-800/60 pt-8 lg:block">
           <DocsSidebar sections={sections} currentHref={currentHref} />
         </aside>
 
-        <section className="min-w-0">
-          <div className="rounded-[32px] border border-white/[0.08] bg-white/[0.03] px-6 py-8 shadow-[0_24px_80px_rgba(0,0,0,0.32)] sm:px-10 sm:py-10">
-            <div className="max-w-3xl">
-              <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.18em] text-lime-200/70">
+        <section className="flex-1 min-w-0 pb-20 pt-8 lg:px-12 lg:pt-12">
+          <div className="mx-auto max-w-[800px]">
+            <div className="mb-8">
+              <p className="mb-2 text-sm font-medium text-emerald-500">
                 {sectionTitle ?? "Documentation"}
               </p>
-              <h1 className="mt-4 font-[family-name:var(--font-display)] text-4xl tracking-[-0.04em] text-white sm:text-5xl">
-                {title}
-              </h1>
-              <p className="mt-4 max-w-2xl text-base leading-7 text-white/55 sm:text-lg">
+              <div className="flex items-start justify-between gap-4">
+                <h1 className="text-3xl font-bold tracking-tight text-zinc-100 sm:text-4xl">
+                  {title}
+                </h1>
+                <button 
+                  onClick={() => navigator.clipboard.writeText(window.location.href)}
+                  className="hidden items-center gap-2 rounded-md border border-zinc-800 px-3 py-1.5 text-xs font-medium text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100 sm:flex"
+                >
+                  <Copy className="size-3.5" />
+                  Copy page
+                </button>
+              </div>
+              <p className="mt-4 text-lg text-zinc-400">
                 {description}
               </p>
             </div>
 
-            <div className="mt-10 border-t border-white/[0.08] pt-8">
+            <div className="prose prose-invert prose-zinc max-w-none prose-headings:text-zinc-100 prose-a:text-emerald-500 prose-a:no-underline hover:prose-a:underline prose-code:text-zinc-200 prose-pre:bg-zinc-900 prose-pre:border prose-pre:border-zinc-800">
               {children}
             </div>
           </div>
         </section>
 
-        <DocsToc headings={headings} />
+        <div className="hidden w-64 shrink-0 xl:block">
+          <DocsToc headings={headings} />
+        </div>
       </div>
     </main>
   );

--- a/web/src/components/docs/docs-shell.tsx
+++ b/web/src/components/docs/docs-shell.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactNode } from "react";
 import Link from "next/link";
-import { Copy, Sparkles, Moon } from "lucide-react";
+import { Copy, Sparkles } from "lucide-react";
 import type { DocHeading, DocNavSection } from "@/lib/docs";
 import { DocsSidebar } from "@/components/docs/docs-sidebar";
 import { DocsToc } from "@/components/docs/docs-toc";
@@ -39,8 +39,8 @@ export function DocsShell({
                 Docs
                 <span className="absolute -bottom-[22px] left-0 right-0 h-0.5 bg-emerald-500" />
               </Link>
-              <Link href="#" className="hover:text-zinc-100 transition-colors">SDK & Examples</Link>
-              <Link href="#" className="hover:text-zinc-100 transition-colors">API Reference</Link>
+              <span className="cursor-not-allowed text-zinc-600">SDK & Examples</span>
+              <span className="cursor-not-allowed text-zinc-600">API Reference</span>
             </nav>
           </div>
 
@@ -54,9 +54,6 @@ export function DocsShell({
             >
               Get Started &rarr;
             </a>
-            <button className="flex size-8 items-center justify-center rounded-md text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100">
-              <Moon className="size-4" />
-            </button>
           </div>
         </div>
       </header>

--- a/web/src/components/docs/docs-sidebar.tsx
+++ b/web/src/components/docs/docs-sidebar.tsx
@@ -14,18 +14,18 @@ export function DocsSidebar({
   return (
     <div className="flex flex-col gap-8 pb-10">
       <div className="space-y-2 px-1">
-        <a href="#" className="flex items-center gap-3 rounded-md px-2 py-1.5 text-sm font-medium text-zinc-400 transition-colors hover:bg-zinc-800/50 hover:text-zinc-100">
+        <div className="flex cursor-not-allowed items-center gap-3 rounded-md px-2 py-1.5 text-sm font-medium text-zinc-600">
           <MessageSquare className="size-4" />
           Community
-        </a>
+        </div>
         <Link href="/blog" className="flex items-center gap-3 rounded-md px-2 py-1.5 text-sm font-medium text-zinc-400 transition-colors hover:bg-zinc-800/50 hover:text-zinc-100">
           <BookOpen className="size-4" />
           Blog
         </Link>
-        <a href="#" className="flex items-center gap-3 rounded-md px-2 py-1.5 text-sm font-medium text-zinc-400 transition-colors hover:bg-zinc-800/50 hover:text-zinc-100">
+        <div className="flex cursor-not-allowed items-center gap-3 rounded-md px-2 py-1.5 text-sm font-medium text-zinc-600">
           <Map className="size-4" />
           Roadmap
-        </a>
+        </div>
         <a href="https://github.com/agentclash/agentclash" target="_blank" rel="noopener noreferrer" className="flex items-center gap-3 rounded-md px-2 py-1.5 text-sm font-medium text-zinc-400 transition-colors hover:bg-zinc-800/50 hover:text-zinc-100">
           <Github className="size-4" />
           GitHub

--- a/web/src/components/docs/docs-sidebar.tsx
+++ b/web/src/components/docs/docs-sidebar.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import Link from "next/link";
-import { Search } from "lucide-react";
-import type { DocNavSection, DocSearchItem } from "@/lib/docs";
+import { MessageSquare, BookOpen, Map, Github } from "lucide-react";
+import type { DocNavSection } from "@/lib/docs";
 
 export function DocsSidebar({
   sections,
@@ -12,180 +11,54 @@ export function DocsSidebar({
   sections: DocNavSection[];
   currentHref: string;
 }) {
-  const [query, setQuery] = useState("");
-  const [searchItems, setSearchItems] = useState<DocSearchItem[]>([]);
-  const [searchState, setSearchState] = useState<
-    "idle" | "loading" | "ready" | "error"
-  >("idle");
-  const normalized = query.trim().toLowerCase();
-  const tokens = normalized.split(/\s+/).filter(Boolean);
-  const matches =
-    tokens.length === 0
-      ? []
-      : searchItems
-          .filter((item) =>
-            tokens.every((token) => item.searchText.includes(token)),
-          )
-          .slice(0, 12);
-
-  useEffect(() => {
-    if (searchState !== "loading") return;
-
-    let cancelled = false;
-
-    fetch("/docs/search.json", {
-      headers: {
-        Accept: "application/json",
-      },
-    })
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error(`Failed to load docs search index: ${response.status}`);
-        }
-        return response.json() as Promise<DocSearchItem[]>;
-      })
-      .then((items) => {
-        if (cancelled) return;
-        setSearchItems(items);
-        setSearchState("ready");
-      })
-      .catch(() => {
-        if (cancelled) return;
-        setSearchState("error");
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [searchState]);
-
-  const ensureSearchLoaded = () => {
-    if (searchState === "idle" || searchState === "error") {
-      setSearchState("loading");
-    }
-  };
-
   return (
-    <div className="rounded-[28px] border border-white/[0.08] bg-white/[0.03] p-4 sm:p-5">
-      <div className="relative">
-        <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-white/30" />
-        <input
-          value={query}
-          onChange={(event) => {
-            ensureSearchLoaded();
-            setQuery(event.target.value);
-          }}
-          onFocus={ensureSearchLoaded}
-          placeholder="Search docs"
-          className="h-11 w-full rounded-2xl border border-white/[0.08] bg-black/20 pl-10 pr-4 text-sm text-white outline-none transition-colors placeholder:text-white/28 focus:border-lime-200/30"
-        />
+    <div className="flex flex-col gap-8 pb-10">
+      <div className="space-y-2 px-1">
+        <a href="#" className="flex items-center gap-3 rounded-md px-2 py-1.5 text-sm font-medium text-zinc-400 transition-colors hover:bg-zinc-800/50 hover:text-zinc-100">
+          <MessageSquare className="size-4" />
+          Community
+        </a>
+        <Link href="/blog" className="flex items-center gap-3 rounded-md px-2 py-1.5 text-sm font-medium text-zinc-400 transition-colors hover:bg-zinc-800/50 hover:text-zinc-100">
+          <BookOpen className="size-4" />
+          Blog
+        </Link>
+        <a href="#" className="flex items-center gap-3 rounded-md px-2 py-1.5 text-sm font-medium text-zinc-400 transition-colors hover:bg-zinc-800/50 hover:text-zinc-100">
+          <Map className="size-4" />
+          Roadmap
+        </a>
+        <a href="https://github.com/agentclash/agentclash" target="_blank" rel="noopener noreferrer" className="flex items-center gap-3 rounded-md px-2 py-1.5 text-sm font-medium text-zinc-400 transition-colors hover:bg-zinc-800/50 hover:text-zinc-100">
+          <Github className="size-4" />
+          GitHub
+        </a>
       </div>
 
-      {tokens.length > 0 ? (
-        <div className="mt-4">
-          <p className="px-1 text-[11px] uppercase tracking-[0.18em] text-white/30">
-            Search Results
-          </p>
-          <div className="mt-2 space-y-1">
-            {matches.map((item) => {
-              const active = currentHref === item.href;
-              return (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  className={`block rounded-2xl px-3 py-2.5 transition-colors ${
-                    active
-                      ? "bg-lime-300/[0.12] text-lime-100"
-                      : "text-white/68 hover:bg-white/[0.04] hover:text-white"
-                  }`}
-                >
-                  <span className="block text-sm font-medium">{item.title}</span>
-                  <span
-                    className={`mt-1 block text-xs leading-5 ${
-                      active ? "text-lime-100/70" : "text-white/42"
+      <div className="space-y-6">
+        {sections.map((section) => (
+          <div key={section.title} className="px-1">
+            <h4 className="mb-2 px-2 text-xs font-semibold text-zinc-100">
+              {section.title}
+            </h4>
+            <div className="space-y-0.5">
+              {section.items.map((item) => {
+                const active = currentHref === item.href;
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    className={`block rounded-md px-2 py-1.5 text-sm transition-colors ${
+                      active
+                        ? "bg-emerald-500/10 font-medium text-emerald-400"
+                        : "text-zinc-400 hover:bg-zinc-800/50 hover:text-zinc-100"
                     }`}
                   >
-                    {item.description}
-                  </span>
-                </Link>
-              );
-            })}
-            {searchState === "loading" && (
-              <p className="px-3 py-3 text-sm text-white/40">
-                Loading docs index...
-              </p>
-            )}
-            {searchState === "error" && (
-              <p className="px-3 py-3 text-sm text-white/40">
-                Search is temporarily unavailable.
-              </p>
-            )}
-            {matches.length === 0 && (
-              <p className="px-3 py-3 text-sm text-white/40">
-                {searchState === "ready"
-                  ? "No docs matched that query."
-                  : "Keep typing to search the docs."}
-              </p>
-            )}
-          </div>
-        </div>
-      ) : (
-        <div className="mt-5 space-y-5">
-          <Link
-            href="/docs"
-            className={`block rounded-2xl px-3 py-2.5 transition-colors ${
-              currentHref === "/docs"
-                ? "bg-lime-300/[0.12] text-lime-100"
-                : "text-white/70 hover:bg-white/[0.04] hover:text-white"
-            }`}
-          >
-            <span className="block text-sm font-medium">Overview</span>
-            <span
-              className={`mt-1 block text-xs leading-5 ${
-                currentHref === "/docs" ? "text-lime-100/70" : "text-white/45"
-              }`}
-            >
-              Start here if you want the shortest path to understanding the product.
-            </span>
-          </Link>
-
-          {sections.map((section) => (
-            <div key={section.title}>
-              <p className="px-3 text-[11px] uppercase tracking-[0.18em] text-white/30">
-                {section.title}
-              </p>
-              <div className="mt-2 space-y-1">
-                {section.items.map((item) => {
-                  const active = currentHref === item.href;
-
-                  return (
-                    <Link
-                      key={item.href}
-                      href={item.href}
-                      className={`block rounded-2xl px-3 py-2.5 transition-colors ${
-                        active
-                          ? "bg-lime-300/[0.12] text-lime-100"
-                          : "text-white/68 hover:bg-white/[0.04] hover:text-white"
-                      }`}
-                    >
-                      <span className="block text-sm font-medium">
-                        {item.title}
-                      </span>
-                      <span
-                        className={`mt-1 block text-xs leading-5 ${
-                          active ? "text-lime-100/70" : "text-white/42"
-                        }`}
-                      >
-                        {item.description}
-                      </span>
-                    </Link>
-                  );
-                })}
-              </div>
+                    {item.title}
+                  </Link>
+                );
+              })}
             </div>
-          ))}
-        </div>
-      )}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/web/src/components/docs/docs-toc.tsx
+++ b/web/src/components/docs/docs-toc.tsx
@@ -5,17 +5,17 @@ export function DocsToc({ headings }: { headings: DocHeading[] }) {
 
   return (
     <aside className="hidden xl:block">
-      <div className="sticky top-8 rounded-[28px] border border-white/[0.08] bg-white/[0.03] p-5">
-        <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.18em] text-white/30">
-          On This Page
+      <div className="sticky top-24 pt-8">
+        <p className="mb-4 text-xs font-semibold text-zinc-100">
+          On this page
         </p>
-        <div className="mt-4 space-y-2">
+        <div className="space-y-3 border-l border-zinc-800/60 pl-4">
           {headings.map((heading) => (
             <a
               key={heading.id}
               href={`#${heading.id}`}
-              className={`block text-sm leading-6 text-white/52 transition-colors hover:text-white ${
-                heading.level === 3 ? "pl-4" : ""
+              className={`block text-sm text-zinc-400 transition-colors hover:text-zinc-100 ${
+                heading.level === 3 ? "pl-3" : ""
               }`}
             >
               {heading.text}


### PR DESCRIPTION
## Summary
- Changes the docs shell layout to remove rounded boxed borders and match a flat slate/black style with green accents.
- Simplifies sidebar structure to be a plain list with clean typography and hover states, matching the new look.
- Introduces `DocsSearch` component, decoupling it from the sidebar and moving it to the top navigation header alongside the new nav links.
- Removes the previous gradient blobs in favor of a clean, distraction-free reading experience.

## Test plan
- Run `pnpm run lint` and verify success.
- Check the docs pages manually to ensure the new dark, flat design renders correctly.