### PR TITLE
chore: add review-checkpoint branch contract

### DIFF
--- a/testing/codex-review-checkpoint-main-default.md
+++ b/testing/codex-review-checkpoint-main-default.md
@@ -1,0 +1,27 @@
+# Review Checkpoint Contract
+
+Task: create a fresh isolated branch from `main`, avoid the dirty primary checkout, and open a draft PR for this workflow setup.
+
+## Functional Expectations
+
+1. Work must happen in a fresh git worktree based on local `main`, not in `/home/atharva/agentclash`.
+2. The branch must be newly created for this task and must start from the current local `main` commit.
+3. A draft PR must be opened from that branch to `main`.
+4. The workflow must remain review-checkpoint compliant:
+   - contract created before further changes
+   - checkpoint scratch updated after each implementation step
+   - self-review and cumulative-review recorded before commit
+5. The request to persist "do not write on main unless explicitly asked" must be attempted via agentic-memory; if that path is unavailable, the blocker must be reported explicitly instead of pretending it succeeded.
+
+## Tests And Verification
+
+- Confirm the fresh worktree path with `pwd`.
+- Confirm branch ancestry with `git branch --show-current` and `git rev-parse HEAD main`.
+- Confirm repo diff for this branch with `git status --short`.
+- Confirm PR creation by capturing the resulting PR URL.
+
+## Manual Verification
+
+- Verify the worktree is separate from the dirty main checkout.
+- Verify the branch name is `codex/review-checkpoint-main-default`.
+- Verify the final PR is a draft PR targeting `main`.


### PR DESCRIPTION
## Summary
- create a fresh worktree branch from local main for isolated work
- add the review-checkpoint contract file for this workflow setup
- keep the primary dirty checkout untouched

## Verification
- verified the worktree path is separate from the main checkout
- verified branch codex/review-checkpoint-main-default started at the current local main commit
- verified the working tree was clean after commit

## Note
- attempted to persist the default do-not-write-on-main-unless-explicitly-asked preference via agentic-memory, but that MCP is currently blocked by an invalid API key in this environment