### PR TITLE
feat: add Composio workspace tool adapter

### DIFF
--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -79,7 +79,7 @@ func main() {
 		providerRouter,
 		sandboxProvider,
 		workerapp.NewBufferedNativeObserverFactory(eventRecorder),
-	).WithSecretsLookup(repo)
+	).WithSecretsLookup(repo).WithWorkspaceToolLookup(repo)
 	promptEvalInvoker := workerapp.NewPromptEvalInvokerWithObserverFactory(
 		providerRouter,
 		workerapp.NewBufferedPromptEvalObserverFactory(eventRecorder),

--- a/backend/internal/engine/executor_sandbox.go
+++ b/backend/internal/engine/executor_sandbox.go
@@ -90,6 +90,48 @@ func (e NativeExecutor) loadWorkspaceSecrets(ctx context.Context, workspaceID uu
 	return loaded, nil
 }
 
+func (e NativeExecutor) loadWorkspaceTools(ctx context.Context, workspaceID uuid.UUID, bindings []repository.AgentBuildVersionToolBinding) ([]workspaceToolBinding, error) {
+	if len(bindings) == 0 {
+		return nil, nil
+	}
+	if e.workspaceToolLookup == nil {
+		return nil, fmt.Errorf("workspace tool lookup is not configured")
+	}
+
+	toolIDs := make([]uuid.UUID, 0, len(bindings))
+	seen := make(map[uuid.UUID]struct{}, len(bindings))
+	for _, binding := range bindings {
+		if _, ok := seen[binding.ToolID]; ok {
+			continue
+		}
+		seen[binding.ToolID] = struct{}{}
+		toolIDs = append(toolIDs, binding.ToolID)
+	}
+
+	rows, err := e.workspaceToolLookup.ListToolsByIDs(ctx, workspaceID, toolIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	toolByID := make(map[uuid.UUID]repository.ToolRow, len(rows))
+	for _, row := range rows {
+		toolByID[row.ID] = row
+	}
+
+	out := make([]workspaceToolBinding, 0, len(bindings))
+	for _, binding := range bindings {
+		row, ok := toolByID[binding.ToolID]
+		if !ok {
+			return nil, fmt.Errorf("workspace tool %s is not available in this workspace", binding.ToolID)
+		}
+		out = append(out, workspaceToolBinding{
+			Tool:    row,
+			Binding: binding,
+		})
+	}
+	return out, nil
+}
+
 func sandboxTTL(executionContext repository.RunAgentExecutionContext) time.Duration {
 	timeout := runTimeout(executionContext)
 	if timeout <= 0 {

--- a/backend/internal/engine/native_executor.go
+++ b/backend/internal/engine/native_executor.go
@@ -119,11 +119,18 @@ type SecretsLookup interface {
 	LoadWorkspaceSecrets(ctx context.Context, workspaceID uuid.UUID) (map[string]string, error)
 }
 
+// WorkspaceToolLookup resolves workspace-scoped tool records referenced by
+// frozen agent-build tool bindings at run start.
+type WorkspaceToolLookup interface {
+	ListToolsByIDs(ctx context.Context, workspaceID uuid.UUID, ids []uuid.UUID) ([]repository.ToolRow, error)
+}
+
 type NativeExecutor struct {
 	client              provider.Client
 	sandboxProvider     sandbox.Provider
 	observer            Observer
 	secretsLookup       SecretsLookup
+	workspaceToolLookup WorkspaceToolLookup
 	maxRetryAttempts    int
 	initialRetryBackoff time.Duration
 }
@@ -148,6 +155,13 @@ func NewNativeExecutor(client provider.Client, sandboxProvider sandbox.Provider,
 // secrets path.
 func (e NativeExecutor) WithSecretsLookup(lookup SecretsLookup) NativeExecutor {
 	e.secretsLookup = lookup
+	return e
+}
+
+// WithWorkspaceToolLookup attaches a workspace-tool source used to resolve
+// bound tool IDs from the frozen deployment snapshot at run start.
+func (e NativeExecutor) WithWorkspaceToolLookup(lookup WorkspaceToolLookup) NativeExecutor {
+	e.workspaceToolLookup = lookup
 	return e
 }
 
@@ -198,6 +212,16 @@ func (e NativeExecutor) Execute(ctx context.Context, executionContext repository
 	workspaceSecrets, err := e.loadWorkspaceSecrets(ctx, executionContext.Run.WorkspaceID)
 	if err != nil {
 		return Result{}, NewFailure(StopReasonSandboxError, fmt.Sprintf("load workspace secrets: %v", err), err)
+	}
+	workspaceTools, err := e.loadWorkspaceTools(ctx, executionContext.Run.WorkspaceID, executionContext.Deployment.AgentBuildVersion.Tools)
+	if err != nil {
+		return Result{}, provider.NewFailure(
+			executionContext.Deployment.ProviderAccount.ProviderKey,
+			provider.FailureCodeInvalidRequest,
+			"load workspace tools",
+			false,
+			err,
+		)
 	}
 
 	session, err := e.prepareSandbox(ctx, executionContext, sandboxRequest)
@@ -252,6 +276,7 @@ func (e NativeExecutor) Execute(ctx context.Context, executionContext repository
 		executionContext.ChallengePackVersion.Manifest,
 		executionContext.Deployment.SnapshotConfig,
 		workspaceSecrets,
+		workspaceTools...,
 	)
 	if err != nil {
 		return Result{}, provider.NewFailure(

--- a/backend/internal/engine/tool_registry.go
+++ b/backend/internal/engine/tool_registry.go
@@ -20,6 +20,7 @@ const (
 	ToolCategoryPrimitive ToolCategory = "primitive"
 	ToolCategoryComposed  ToolCategory = "composed"
 	ToolCategoryMock      ToolCategory = "mock"
+	ToolCategoryWorkspace ToolCategory = "workspace"
 
 	ToolFailureOriginPolicy     ToolFailureOrigin = "policy"
 	ToolFailureOriginResolution ToolFailureOrigin = "resolution"
@@ -75,6 +76,7 @@ type Registry struct {
 	primitives map[string]Tool
 	composed   map[string]Tool
 	mocks      map[string]Tool
+	workspace  map[string]Tool
 	visible    map[string]Tool
 }
 
@@ -98,6 +100,9 @@ func (r *Registry) resolveAny(name string) (Tool, bool) {
 		return tool, true
 	}
 	if tool, ok := r.mocks[name]; ok {
+		return tool, true
+	}
+	if tool, ok := r.workspace[name]; ok {
 		return tool, true
 	}
 	return nil, false
@@ -151,7 +156,7 @@ type snapshotToolOverrides struct {
 	Denied []string `json:"denied"`
 }
 
-func buildToolRegistry(toolPolicy sandbox.ToolPolicy, manifest json.RawMessage, snapshotConfig json.RawMessage, secrets map[string]string) (*Registry, error) {
+func buildToolRegistry(toolPolicy sandbox.ToolPolicy, manifest json.RawMessage, snapshotConfig json.RawMessage, secrets map[string]string, workspaceBindings ...workspaceToolBinding) (*Registry, error) {
 	primitives := nativePrimitiveTools(toolPolicy)
 	visible := make(map[string]Tool, len(primitives))
 	for name, tool := range primitives {
@@ -175,6 +180,7 @@ func buildToolRegistry(toolPolicy sandbox.ToolPolicy, manifest json.RawMessage, 
 
 	composed := map[string]Tool{}
 	mocks := map[string]Tool{}
+	workspace := map[string]Tool{}
 
 	for _, custom := range manifestTools.Custom {
 		tool, disabledReason, err := newManifestCustomTool(custom, secrets)
@@ -206,6 +212,36 @@ func buildToolRegistry(toolPolicy sandbox.ToolPolicy, manifest json.RawMessage, 
 		visible[name] = tool
 	}
 
+	for _, binding := range workspaceBindings {
+		if !allowsWorkspaceTool(toolPolicy, binding.Tool.ToolKind) {
+			slog.Default().Warn("disabling workspace tool from registry build", "tool_id", binding.Tool.ID, "tool_name", binding.Tool.Name, "tool_kind", binding.Tool.ToolKind, "reason", "tool kind is not allowed in this runtime")
+			continue
+		}
+
+		tool, err := newWorkspaceTool(binding)
+		if err != nil {
+			return nil, err
+		}
+		name := tool.Name()
+		if _, exists := primitives[name]; exists {
+			return nil, fmt.Errorf("tool %q is already defined", name)
+		}
+		if _, exists := composed[name]; exists {
+			return nil, fmt.Errorf("tool %q is already defined", name)
+		}
+		if _, exists := mocks[name]; exists {
+			return nil, fmt.Errorf("tool %q is already defined", name)
+		}
+		if _, exists := workspace[name]; exists {
+			return nil, fmt.Errorf("tool %q is already defined", name)
+		}
+		if tool.Category() != ToolCategoryWorkspace {
+			return nil, fmt.Errorf("tool %q has unsupported category %q", name, tool.Category())
+		}
+		workspace[name] = tool
+		visible[name] = tool
+	}
+
 	for {
 		removed := 0
 		for name, tool := range composed {
@@ -216,11 +252,13 @@ func buildToolRegistry(toolPolicy sandbox.ToolPolicy, manifest json.RawMessage, 
 			if _, exists := primitives[ct.primitive]; !exists {
 				if _, exists := composed[ct.primitive]; !exists {
 					if _, exists := mocks[ct.primitive]; !exists {
-						slog.Default().Warn("disabling composed tool with missing delegate", "tool_name", name, "delegate", ct.primitive)
-						delete(composed, name)
-						delete(visible, name)
-						removed++
-						continue
+						if _, exists := workspace[ct.primitive]; !exists {
+							slog.Default().Warn("disabling composed tool with missing delegate", "tool_name", name, "delegate", ct.primitive)
+							delete(composed, name)
+							delete(visible, name)
+							removed++
+							continue
+						}
 					}
 				}
 			}
@@ -265,6 +303,7 @@ func buildToolRegistry(toolPolicy sandbox.ToolPolicy, manifest json.RawMessage, 
 		primitives: primitives,
 		composed:   composed,
 		mocks:      mocks,
+		workspace:  workspace,
 		visible:    visible,
 	}, nil
 }

--- a/backend/internal/engine/workspace_tools.go
+++ b/backend/internal/engine/workspace_tools.go
@@ -1,0 +1,330 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/sandbox"
+	"github.com/agentclash/agentclash/backend/internal/templateutil"
+)
+
+const (
+	composioExecuteCapability = "composio.execute"
+	defaultComposioBaseURL    = "https://backend.composio.dev"
+)
+
+type workspaceToolBinding struct {
+	Tool    repository.ToolRow
+	Binding repository.AgentBuildVersionToolBinding
+}
+
+type workspaceToolConfig struct {
+	ToolSlug            string          `json:"tool_slug"`
+	CredentialReference string          `json:"credential_reference"`
+	Description         string          `json:"description"`
+	Parameters          json.RawMessage `json:"parameters"`
+	BaseURL             string          `json:"base_url"`
+	Version             string          `json:"version"`
+	UserID              string          `json:"user_id"`
+	ConnectedAccountID  string          `json:"connected_account_id"`
+}
+
+type workspaceToolBindingConfig struct {
+	ToolName           string `json:"tool_name"`
+	Version            string `json:"version"`
+	UserID             string `json:"user_id"`
+	ConnectedAccountID string `json:"connected_account_id"`
+}
+
+type composioWorkspaceTool struct {
+	name                string
+	description         string
+	parameters          json.RawMessage
+	toolSlug            string
+	credentialReference string
+	baseURL             string
+	version             string
+	userID              string
+	connectedAccountID  string
+	httpClient          *http.Client
+	credentials         provider.CredentialResolver
+}
+
+func allowsWorkspaceTool(toolPolicy sandbox.ToolPolicy, toolKind string) bool {
+	if !allowsToolKind(toolPolicy, toolKind) {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(toolKind), toolKindNetwork) && !toolPolicy.AllowNetwork {
+		return false
+	}
+	return true
+}
+
+func newWorkspaceTool(binding workspaceToolBinding) (Tool, error) {
+	definition, err := decodeWorkspaceToolConfig(binding.Tool)
+	if err != nil {
+		return nil, err
+	}
+	bindingConfig, err := decodeWorkspaceToolBindingConfig(binding.Binding)
+	if err != nil {
+		return nil, err
+	}
+
+	name := strings.TrimSpace(bindingConfig.ToolName)
+	if name == "" {
+		name = strings.TrimSpace(binding.Tool.Slug)
+	}
+	if name == "" {
+		name = strings.TrimSpace(binding.Tool.Name)
+	}
+	if name == "" {
+		return nil, fmt.Errorf("workspace tool %s must declare a visible tool name", binding.Tool.ID)
+	}
+
+	description := strings.TrimSpace(definition.Description)
+	if description == "" {
+		description = strings.TrimSpace(binding.Tool.Name)
+	}
+	if description == "" {
+		description = fmt.Sprintf("Execute workspace tool %s", strings.TrimSpace(definition.ToolSlug))
+	}
+
+	parameters := cloneJSON(definition.Parameters)
+	if len(parameters) == 0 {
+		parameters = json.RawMessage(`{"type":"object","additionalProperties":true}`)
+	}
+	if err := templateutil.ValidateToolParameterSchema(parameters); err != nil {
+		return nil, fmt.Errorf("workspace tool %q has invalid parameters schema: %w", name, err)
+	}
+
+	userID := strings.TrimSpace(bindingConfig.UserID)
+	if userID == "" {
+		userID = strings.TrimSpace(definition.UserID)
+	}
+	connectedAccountID := strings.TrimSpace(bindingConfig.ConnectedAccountID)
+	if connectedAccountID == "" {
+		connectedAccountID = strings.TrimSpace(definition.ConnectedAccountID)
+	}
+	if userID == "" && connectedAccountID == "" {
+		return nil, fmt.Errorf("workspace tool %q must declare user_id or connected_account_id", name)
+	}
+
+	version := strings.TrimSpace(bindingConfig.Version)
+	if version == "" {
+		version = strings.TrimSpace(definition.Version)
+	}
+	baseURL := strings.TrimSpace(definition.BaseURL)
+	if baseURL == "" {
+		baseURL = defaultComposioBaseURL
+	}
+
+	switch strings.TrimSpace(binding.Tool.CapabilityKey) {
+	case composioExecuteCapability:
+		return &composioWorkspaceTool{
+			name:                name,
+			description:         description,
+			parameters:          parameters,
+			toolSlug:            strings.TrimSpace(definition.ToolSlug),
+			credentialReference: strings.TrimSpace(definition.CredentialReference),
+			baseURL:             baseURL,
+			version:             version,
+			userID:              userID,
+			connectedAccountID:  connectedAccountID,
+			httpClient:          provider.NewDefaultHTTPClient(),
+			credentials:         provider.EnvCredentialResolver{},
+		}, nil
+	default:
+		return nil, fmt.Errorf("workspace tool %q uses unsupported capability %q", name, binding.Tool.CapabilityKey)
+	}
+}
+
+func decodeWorkspaceToolConfig(tool repository.ToolRow) (workspaceToolConfig, error) {
+	var config workspaceToolConfig
+	raw := bytes.TrimSpace(tool.Definition)
+	if len(raw) == 0 {
+		raw = []byte(`{}`)
+	}
+	if err := json.Unmarshal(raw, &config); err != nil {
+		return workspaceToolConfig{}, fmt.Errorf("decode workspace tool %q definition: %w", tool.Name, err)
+	}
+	if strings.TrimSpace(config.ToolSlug) == "" {
+		return workspaceToolConfig{}, fmt.Errorf("workspace tool %q definition must include tool_slug", tool.Name)
+	}
+	if strings.TrimSpace(config.CredentialReference) == "" {
+		return workspaceToolConfig{}, fmt.Errorf("workspace tool %q definition must include credential_reference", tool.Name)
+	}
+	return config, nil
+}
+
+func decodeWorkspaceToolBindingConfig(binding repository.AgentBuildVersionToolBinding) (workspaceToolBindingConfig, error) {
+	var config workspaceToolBindingConfig
+	raw := bytes.TrimSpace(binding.BindingConfig)
+	if len(raw) == 0 {
+		raw = []byte(`{}`)
+	}
+	if err := json.Unmarshal(raw, &config); err != nil {
+		return workspaceToolBindingConfig{}, fmt.Errorf("decode workspace tool binding %s config: %w", binding.ToolID, err)
+	}
+	return config, nil
+}
+
+func (t *composioWorkspaceTool) Name() string {
+	return t.name
+}
+
+func (t *composioWorkspaceTool) Description() string {
+	return t.description
+}
+
+func (t *composioWorkspaceTool) Parameters() json.RawMessage {
+	return cloneJSON(t.parameters)
+}
+
+func (t *composioWorkspaceTool) Category() ToolCategory {
+	return ToolCategoryWorkspace
+}
+
+func (t *composioWorkspaceTool) Execute(ctx context.Context, request ToolExecutionRequest) (ToolExecutionResult, error) {
+	arguments, err := decodeWorkspaceToolArguments(request.Args)
+	if err != nil {
+		return ToolExecutionResult{
+			Content: marshalWorkspaceToolPayload(map[string]any{"error": err.Error()}),
+			IsError: true,
+		}, nil
+	}
+
+	apiKey, err := t.credentials.Resolve(ctx, t.credentialReference)
+	if err != nil {
+		return ToolExecutionResult{
+			Content: marshalWorkspaceToolPayload(map[string]any{"error": err.Error()}),
+			IsError: true,
+		}, nil
+	}
+
+	requestBody := map[string]any{
+		"arguments": arguments,
+	}
+	if t.userID != "" {
+		requestBody["user_id"] = t.userID
+	}
+	if t.connectedAccountID != "" {
+		requestBody["connected_account_id"] = t.connectedAccountID
+	}
+	if t.version != "" {
+		requestBody["version"] = t.version
+	}
+
+	payload, err := json.Marshal(requestBody)
+	if err != nil {
+		return ToolExecutionResult{
+			Content: marshalWorkspaceToolPayload(map[string]any{"error": "failed to encode Composio request payload"}),
+			IsError: true,
+		}, nil
+	}
+
+	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, composioExecuteURL(t.baseURL, t.toolSlug), bytes.NewReader(payload))
+	if err != nil {
+		return ToolExecutionResult{
+			Content: marshalWorkspaceToolPayload(map[string]any{"error": fmt.Sprintf("failed to create Composio request: %v", err)}),
+			IsError: true,
+		}, nil
+	}
+	httpRequest.Header.Set("Content-Type", "application/json")
+	httpRequest.Header.Set("x-api-key", apiKey)
+
+	client := t.httpClient
+	if client == nil {
+		client = provider.NewDefaultHTTPClient()
+	}
+
+	response, err := client.Do(httpRequest)
+	if err != nil {
+		return ToolExecutionResult{
+			Content: marshalWorkspaceToolPayload(map[string]any{"error": fmt.Sprintf("Composio request failed: %v", err)}),
+			IsError: true,
+		}, nil
+	}
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+	if err != nil {
+		return ToolExecutionResult{
+			Content: marshalWorkspaceToolPayload(map[string]any{"error": fmt.Sprintf("failed to read Composio response: %v", err)}),
+			IsError: true,
+		}, nil
+	}
+
+	content, decoded, ok := normalizeWorkspaceToolResponse(body)
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		errorPayload := map[string]any{
+			"status_code": response.StatusCode,
+		}
+		if ok {
+			errorPayload["response"] = decoded
+		} else {
+			errorPayload["body"] = strings.TrimSpace(string(body))
+		}
+		return ToolExecutionResult{
+			Content: marshalWorkspaceToolPayload(errorPayload),
+			IsError: true,
+		}, nil
+	}
+
+	if ok {
+		if successful, exists := decoded["successful"]; exists {
+			if successFlag, ok := successful.(bool); ok && !successFlag {
+				return ToolExecutionResult{Content: content, IsError: true}, nil
+			}
+		}
+	}
+
+	return ToolExecutionResult{Content: content}, nil
+}
+
+func decodeWorkspaceToolArguments(raw json.RawMessage) (map[string]any, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return map[string]any{}, nil
+	}
+	var arguments map[string]any
+	if err := json.Unmarshal(raw, &arguments); err != nil {
+		return nil, fmt.Errorf("arguments must be a valid JSON object")
+	}
+	if arguments == nil {
+		return map[string]any{}, nil
+	}
+	return arguments, nil
+}
+
+func composioExecuteURL(baseURL string, toolSlug string) string {
+	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if strings.HasSuffix(base, "/api/v3") {
+		return base + "/tools/execute/" + url.PathEscape(strings.TrimSpace(toolSlug))
+	}
+	return base + "/api/v3/tools/execute/" + url.PathEscape(strings.TrimSpace(toolSlug))
+}
+
+func normalizeWorkspaceToolResponse(body []byte) (string, map[string]any, bool) {
+	var decoded map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(body), &decoded); err == nil && decoded != nil {
+		return marshalWorkspaceToolPayload(decoded), decoded, true
+	}
+	return marshalWorkspaceToolPayload(map[string]any{
+		"body": strings.TrimSpace(string(body)),
+	}), nil, false
+}
+
+func marshalWorkspaceToolPayload(payload any) string {
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return `{"error":"failed to encode workspace tool payload"}`
+	}
+	return string(encoded)
+}

--- a/backend/internal/engine/workspace_tools_test.go
+++ b/backend/internal/engine/workspace_tools_test.go
@@ -1,0 +1,304 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/sandbox"
+	"github.com/google/uuid"
+)
+
+type fakeWorkspaceToolLookup struct {
+	rows            map[uuid.UUID]repository.ToolRow
+	calls           int
+	lastWorkspaceID uuid.UUID
+	lastToolIDs     []uuid.UUID
+}
+
+func (f *fakeWorkspaceToolLookup) ListToolsByIDs(_ context.Context, workspaceID uuid.UUID, ids []uuid.UUID) ([]repository.ToolRow, error) {
+	f.calls++
+	f.lastWorkspaceID = workspaceID
+	f.lastToolIDs = append([]uuid.UUID(nil), ids...)
+
+	rows := make([]repository.ToolRow, 0, len(ids))
+	for _, id := range ids {
+		row, ok := f.rows[id]
+		if !ok {
+			continue
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+func TestBuildToolRegistry_IncludesWorkspaceTools(t *testing.T) {
+	workspaceID := uuid.New()
+	toolID := uuid.New()
+
+	registry, err := buildToolRegistry(
+		sandbox.ToolPolicy{AllowedToolKinds: []string{toolKindNetwork}, AllowNetwork: true},
+		[]byte(`{"challenge":"fixture"}`),
+		nil,
+		nil,
+		workspaceToolBinding{
+			Tool: repository.ToolRow{
+				ID:            toolID,
+				WorkspaceID:   &workspaceID,
+				Name:          "GitHub Create Issue",
+				Slug:          "github_create_issue",
+				ToolKind:      toolKindNetwork,
+				CapabilityKey: composioExecuteCapability,
+				Definition:    []byte(`{"tool_slug":"github_create_issue","credential_reference":"env://COMPOSIO_API_KEY","description":"Create a GitHub issue","parameters":{"type":"object","properties":{"title":{"type":"string"}}},"user_id":"user-123"}`),
+			},
+			Binding: repository.AgentBuildVersionToolBinding{
+				ToolID:        toolID,
+				BindingConfig: []byte(`{"tool_name":"github_create_issue"}`),
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("buildToolRegistry returned error: %v", err)
+	}
+
+	assertRegistryVisibleTools(t, registry, "github_create_issue", httpRequestToolName, submitToolName)
+	tool, ok := registry.Resolve("github_create_issue")
+	if !ok {
+		t.Fatalf("workspace tool was not visible")
+	}
+	if tool.Category() != ToolCategoryWorkspace {
+		t.Fatalf("tool category = %q, want workspace", tool.Category())
+	}
+}
+
+func TestComposioWorkspaceTool_Execute(t *testing.T) {
+	t.Setenv("COMPOSIO_API_KEY", "test-composio-key")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/v3/tools/execute/github_create_issue" {
+			t.Fatalf("path = %s, want Composio execute path", r.URL.Path)
+		}
+		if got := r.Header.Get("x-api-key"); got != "test-composio-key" {
+			t.Fatalf("x-api-key = %q, want test-composio-key", got)
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		if payload["user_id"] != "user-123" {
+			t.Fatalf("user_id = %#v, want user-123", payload["user_id"])
+		}
+		arguments, ok := payload["arguments"].(map[string]any)
+		if !ok {
+			t.Fatalf("arguments = %#v, want object", payload["arguments"])
+		}
+		if arguments["title"] != "Bug report" {
+			t.Fatalf("arguments.title = %#v, want Bug report", arguments["title"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"issue_number":42},"successful":true,"log_id":"log_123"}`))
+	}))
+	defer server.Close()
+
+	tool, err := newWorkspaceTool(workspaceToolBinding{
+		Tool: repository.ToolRow{
+			ID:            uuid.New(),
+			Name:          "GitHub Create Issue",
+			Slug:          "github_create_issue",
+			ToolKind:      toolKindNetwork,
+			CapabilityKey: composioExecuteCapability,
+			Definition:    []byte(fmt.Sprintf(`{"tool_slug":"github_create_issue","credential_reference":"env://COMPOSIO_API_KEY","base_url":%q,"user_id":"user-123"}`, server.URL)),
+		},
+	})
+	if err != nil {
+		t.Fatalf("newWorkspaceTool returned error: %v", err)
+	}
+
+	result, err := tool.Execute(t.Context(), ToolExecutionRequest{
+		Args: json.RawMessage(`{"title":"Bug report"}`),
+	})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error payload: %s", result.Content)
+	}
+	if !strings.Contains(result.Content, `"issue_number":42`) {
+		t.Fatalf("result content = %s, want issue_number", result.Content)
+	}
+}
+
+func TestComposioWorkspaceTool_MarksUnsuccessfulResponseAsError(t *testing.T) {
+	t.Setenv("COMPOSIO_API_KEY", "test-composio-key")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"successful":false,"error":"connection missing"}`))
+	}))
+	defer server.Close()
+
+	tool, err := newWorkspaceTool(workspaceToolBinding{
+		Tool: repository.ToolRow{
+			ID:            uuid.New(),
+			Name:          "GitHub Create Issue",
+			Slug:          "github_create_issue",
+			ToolKind:      toolKindNetwork,
+			CapabilityKey: composioExecuteCapability,
+			Definition:    []byte(fmt.Sprintf(`{"tool_slug":"github_create_issue","credential_reference":"env://COMPOSIO_API_KEY","base_url":%q,"user_id":"user-123"}`, server.URL)),
+		},
+	})
+	if err != nil {
+		t.Fatalf("newWorkspaceTool returned error: %v", err)
+	}
+
+	result, err := tool.Execute(t.Context(), ToolExecutionRequest{Args: json.RawMessage(`{"title":"Bug report"}`)})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected tool error for unsuccessful response")
+	}
+	if !strings.Contains(result.Content, `"successful":false`) {
+		t.Fatalf("error content = %s, want unsuccessful response payload", result.Content)
+	}
+}
+
+func TestNativeExecutor_RegistersAndExecutesWorkspaceTool(t *testing.T) {
+	t.Setenv("COMPOSIO_API_KEY", "test-composio-key")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v3/tools/execute/github_create_issue" {
+			t.Fatalf("path = %s, want Composio execute path", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"issue_number":77},"successful":true}`))
+	}))
+	defer server.Close()
+
+	workspaceID := uuid.New()
+	toolID := uuid.New()
+	lookup := &fakeWorkspaceToolLookup{
+		rows: map[uuid.UUID]repository.ToolRow{
+			toolID: {
+				ID:            toolID,
+				WorkspaceID:   &workspaceID,
+				Name:          "GitHub Create Issue",
+				Slug:          "github_create_issue",
+				ToolKind:      toolKindNetwork,
+				CapabilityKey: composioExecuteCapability,
+				Definition:    []byte(fmt.Sprintf(`{"tool_slug":"github_create_issue","credential_reference":"env://COMPOSIO_API_KEY","base_url":%q,"user_id":"user-123","parameters":{"type":"object","properties":{"title":{"type":"string"}}}}`, server.URL)),
+			},
+		},
+	}
+
+	session := sandbox.NewFakeSession("native-workspace-tool")
+	client := &scriptedProviderClient{
+		t: t,
+		steps: []providerStep{
+			{
+				validate: func(t *testing.T, request provider.Request) {
+					names := toolDefinitionNames(request.Tools)
+					if !slices.Contains(names, "github_create_issue") {
+						t.Fatalf("tool definitions = %#v, want github_create_issue", names)
+					}
+					if !slices.Contains(names, submitToolName) {
+						t.Fatalf("tool definitions = %#v, want submit", names)
+					}
+				},
+				response: provider.Response{
+					ProviderKey:     "openai",
+					ProviderModelID: "gpt-4.1",
+					FinishReason:    "tool_calls",
+					ToolCalls: []provider.ToolCall{
+						{
+							ID:        "call-composio",
+							Name:      "github_create_issue",
+							Arguments: []byte(`{"title":"Bug report"}`),
+						},
+					},
+				},
+			},
+			{
+				validate: func(t *testing.T, request provider.Request) {
+					last := request.Messages[len(request.Messages)-1]
+					if last.Role != "tool" || last.ToolCallID != "call-composio" {
+						t.Fatalf("last message = %#v, want tool result for call-composio", last)
+					}
+					if last.IsError {
+						t.Fatalf("tool result unexpectedly marked as error")
+					}
+					if !strings.Contains(last.Content, `"issue_number":77`) {
+						t.Fatalf("tool result = %s, want issue_number", last.Content)
+					}
+				},
+				response: provider.Response{
+					ProviderKey:     "openai",
+					ProviderModelID: "gpt-4.1",
+					FinishReason:    "tool_calls",
+					ToolCalls: []provider.ToolCall{
+						{
+							ID:        "call-submit",
+							Name:      submitToolName,
+							Arguments: []byte(`{"answer":"opened issue"}`),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executionContext := nativeExecutionContext()
+	executionContext.Run.WorkspaceID = workspaceID
+	executionContext.ChallengePackVersion.Manifest = []byte(`{"tool_policy":{"allowed_tool_kinds":["network"],"allow_network":true}}`)
+	executionContext.Deployment.AgentBuildVersion.Tools = []repository.AgentBuildVersionToolBinding{
+		{
+			ToolID:        toolID,
+			BindingRole:   "default",
+			BindingConfig: []byte(`{"tool_name":"github_create_issue"}`),
+		},
+	}
+
+	executor := NewNativeExecutor(client, &sandbox.FakeProvider{NextSession: session}, NoopObserver{}).WithWorkspaceToolLookup(lookup)
+	result, err := executor.Execute(context.Background(), executionContext)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.StopReason != StopReasonCompleted {
+		t.Fatalf("stop reason = %s, want completed", result.StopReason)
+	}
+	if result.FinalOutput != "opened issue" {
+		t.Fatalf("final output = %q, want opened issue", result.FinalOutput)
+	}
+	if lookup.calls != 1 {
+		t.Fatalf("workspace lookup calls = %d, want 1", lookup.calls)
+	}
+	if lookup.lastWorkspaceID != workspaceID {
+		t.Fatalf("workspace lookup workspace_id = %s, want %s", lookup.lastWorkspaceID, workspaceID)
+	}
+}
+
+func toolDefinitionNames(definitions []provider.ToolDefinition) []string {
+	names := make([]string, 0, len(definitions))
+	for _, definition := range definitions {
+		names = append(names, definition.Name)
+	}
+	return names
+}

--- a/backend/internal/repository/infrastructure.go
+++ b/backend/internal/repository/infrastructure.go
@@ -273,18 +273,18 @@ func (r *Repository) ArchiveProviderAccount(ctx context.Context, id uuid.UUID) e
 // --------------------------------------------------------------------------
 
 type ModelCatalogEntryRow struct {
-	ID                          uuid.UUID
-	ProviderKey                 string
-	ProviderModelID             string
-	DisplayName                 string
-	ModelFamily                 string
-	Modality                    string
-	LifecycleStatus             string
-	Metadata                    json.RawMessage
-	InputCostPerMillionTokens   float64
-	OutputCostPerMillionTokens  float64
-	CreatedAt                   time.Time
-	UpdatedAt                   time.Time
+	ID                         uuid.UUID
+	ProviderKey                string
+	ProviderModelID            string
+	DisplayName                string
+	ModelFamily                string
+	Modality                   string
+	LifecycleStatus            string
+	Metadata                   json.RawMessage
+	InputCostPerMillionTokens  float64
+	OutputCostPerMillionTokens float64
+	CreatedAt                  time.Time
+	UpdatedAt                  time.Time
 }
 
 func (r *Repository) GetModelCatalogEntryByID(ctx context.Context, id uuid.UUID) (ModelCatalogEntryRow, error) {
@@ -611,6 +611,45 @@ func (r *Repository) ListToolsByWorkspaceID(ctx context.Context, workspaceID uui
 	return result, nil
 }
 
+func (r *Repository) ListToolsByIDs(ctx context.Context, workspaceID uuid.UUID, ids []uuid.UUID) ([]ToolRow, error) {
+	if len(ids) == 0 {
+		return []ToolRow{}, nil
+	}
+
+	rows, err := r.db.Query(ctx, `
+		SELECT id, organization_id, workspace_id, name, slug, tool_kind, capability_key, definition, lifecycle_status, created_at, updated_at
+		FROM tools
+		WHERE workspace_id = $1
+		  AND archived_at IS NULL
+		  AND id = ANY($2::uuid[])
+		ORDER BY name
+	`, workspaceID, ids)
+	if err != nil {
+		return nil, fmt.Errorf("list tools by ids: %w", err)
+	}
+	defer rows.Close()
+
+	var result []ToolRow
+	for rows.Next() {
+		var row ToolRow
+		var createdAt, updatedAt pgtype.Timestamptz
+		if err := rows.Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.Name, &row.Slug, &row.ToolKind,
+			&row.CapabilityKey, &row.Definition, &row.LifecycleStatus, &createdAt, &updatedAt); err != nil {
+			return nil, fmt.Errorf("scan tool: %w", err)
+		}
+		row.CreatedAt = createdAt.Time
+		row.UpdatedAt = updatedAt.Time
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate tools by ids: %w", err)
+	}
+	if result == nil {
+		result = []ToolRow{}
+	}
+	return result, nil
+}
+
 // --------------------------------------------------------------------------
 // Knowledge Sources
 // --------------------------------------------------------------------------
@@ -914,10 +953,10 @@ func isDuplicateSlug(err error) bool {
 
 // GetWorkspaceID methods implement WorkspaceOwned for authorization checks.
 func (r RuntimeProfileRow) GetWorkspaceID() *uuid.UUID  { return r.WorkspaceID }
-func (r ProviderAccountRow) GetWorkspaceID() *uuid.UUID  { return r.WorkspaceID }
-func (r ModelAliasRow) GetWorkspaceID() *uuid.UUID       { return r.WorkspaceID }
-func (r ToolRow) GetWorkspaceID() *uuid.UUID             { return r.WorkspaceID }
-func (r KnowledgeSourceRow) GetWorkspaceID() *uuid.UUID  { return r.WorkspaceID }
+func (r ProviderAccountRow) GetWorkspaceID() *uuid.UUID { return r.WorkspaceID }
+func (r ModelAliasRow) GetWorkspaceID() *uuid.UUID      { return r.WorkspaceID }
+func (r ToolRow) GetWorkspaceID() *uuid.UUID            { return r.WorkspaceID }
+func (r KnowledgeSourceRow) GetWorkspaceID() *uuid.UUID { return r.WorkspaceID }
 
 func defaultStr(v, fallback string) string {
 	if v == "" {

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -3801,15 +3801,15 @@ type AgentBuildVersion struct {
 }
 
 type AgentBuildVersionToolBinding struct {
-	ToolID        uuid.UUID
-	BindingRole   string
-	BindingConfig json.RawMessage
+	ToolID        uuid.UUID       `json:"tool_id"`
+	BindingRole   string          `json:"binding_role"`
+	BindingConfig json.RawMessage `json:"binding_config"`
 }
 
 type AgentBuildVersionKnowledgeSourceBinding struct {
-	KnowledgeSourceID uuid.UUID
-	BindingRole       string
-	BindingConfig     json.RawMessage
+	KnowledgeSourceID uuid.UUID       `json:"knowledge_source_id"`
+	BindingRole       string          `json:"binding_role"`
+	BindingConfig     json.RawMessage `json:"binding_config"`
 }
 
 type AgentDeploymentRow struct {

--- a/backend/internal/repository/run_agent_execution_context.go
+++ b/backend/internal/repository/run_agent_execution_context.go
@@ -106,6 +106,7 @@ type AgentBuildVersionExecutionContext struct {
 	OutputSchema    json.RawMessage
 	TraceContract   json.RawMessage
 	PublicationSpec json.RawMessage
+	Tools           []AgentBuildVersionToolBinding
 }
 
 type RuntimeProfileExecutionContext struct {
@@ -497,6 +498,7 @@ func decodeAgentBuildVersionExecutionContext(buildVersionID uuid.UUID, payload [
 		OutputSchema    json.RawMessage `json:"output_schema"`
 		TraceContract   json.RawMessage `json:"trace_contract"`
 		PublicationSpec json.RawMessage `json:"publication_spec"`
+		Tools           []AgentBuildVersionToolBinding
 	}
 
 	if err := json.Unmarshal(agentSpecJSON, &decoded); err != nil {
@@ -517,6 +519,7 @@ func decodeAgentBuildVersionExecutionContext(buildVersionID uuid.UUID, payload [
 		OutputSchema:    defaultExecutionContextJSON(decoded.OutputSchema),
 		TraceContract:   defaultExecutionContextJSON(decoded.TraceContract),
 		PublicationSpec: defaultExecutionContextJSON(decoded.PublicationSpec),
+		Tools:           normalizeToolBindings(decoded.Tools),
 	}, nil
 }
 

--- a/backend/internal/repository/run_agent_execution_context_test.go
+++ b/backend/internal/repository/run_agent_execution_context_test.go
@@ -1,0 +1,50 @@
+package repository
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestDecodeAgentBuildVersionExecutionContext_DecodesFrozenToolBindings(t *testing.T) {
+	buildVersionID := uuid.New()
+	toolID := uuid.New()
+
+	payload := []byte(fmt.Sprintf(`{
+		"agent_kind":"llm_agent",
+		"policy_spec":{"instructions":"Use tools"},
+		"tools":[
+			{
+				"tool_id":"%s",
+				"binding_config":{"tool_name":"github_create_issue"}
+			}
+		]
+	}`, toolID))
+
+	executionContext, err := decodeAgentBuildVersionExecutionContext(buildVersionID, payload)
+	if err != nil {
+		t.Fatalf("decodeAgentBuildVersionExecutionContext returned error: %v", err)
+	}
+	if executionContext.ID != buildVersionID {
+		t.Fatalf("build version id = %s, want %s", executionContext.ID, buildVersionID)
+	}
+	if len(executionContext.Tools) != 1 {
+		t.Fatalf("tool binding count = %d, want 1", len(executionContext.Tools))
+	}
+	if executionContext.Tools[0].ToolID != toolID {
+		t.Fatalf("tool id = %s, want %s", executionContext.Tools[0].ToolID, toolID)
+	}
+	if executionContext.Tools[0].BindingRole != "default" {
+		t.Fatalf("binding role = %q, want default", executionContext.Tools[0].BindingRole)
+	}
+
+	var bindingConfig map[string]any
+	if err := json.Unmarshal(executionContext.Tools[0].BindingConfig, &bindingConfig); err != nil {
+		t.Fatalf("decode binding config: %v", err)
+	}
+	if bindingConfig["tool_name"] != "github_create_issue" {
+		t.Fatalf("binding_config.tool_name = %#v, want github_create_issue", bindingConfig["tool_name"])
+	}
+}

--- a/backend/internal/worker/native_model.go
+++ b/backend/internal/worker/native_model.go
@@ -14,6 +14,7 @@ type NativeModelInvoker struct {
 	sandboxProvider sandbox.Provider
 	observerFactory NativeObserverFactory
 	secretsLookup   engine.SecretsLookup
+	toolLookup      engine.WorkspaceToolLookup
 }
 
 func NewNativeModelInvoker(client provider.Client, sandboxProvider sandbox.Provider) NativeModelInvoker {
@@ -43,6 +44,13 @@ func (i NativeModelInvoker) WithSecretsLookup(lookup engine.SecretsLookup) Nativ
 	return i
 }
 
+// WithWorkspaceToolLookup returns an invoker that propagates workspace tool
+// lookup to every NativeExecutor it constructs.
+func (i NativeModelInvoker) WithWorkspaceToolLookup(lookup engine.WorkspaceToolLookup) NativeModelInvoker {
+	i.toolLookup = lookup
+	return i
+}
+
 func (i NativeModelInvoker) InvokeNativeModel(ctx context.Context, executionContext repository.RunAgentExecutionContext) (engine.Result, error) {
 	observer := engine.Observer(engine.NoopObserver{})
 	if i.observerFactory != nil {
@@ -58,6 +66,9 @@ func (i NativeModelInvoker) InvokeNativeModel(ctx context.Context, executionCont
 	executor := engine.NewNativeExecutor(i.client, i.sandboxProvider, observer)
 	if i.secretsLookup != nil {
 		executor = executor.WithSecretsLookup(i.secretsLookup)
+	}
+	if i.toolLookup != nil {
+		executor = executor.WithWorkspaceToolLookup(i.toolLookup)
 	}
 	return executor.Execute(ctx, executionContext)
 }

--- a/testing/codex-composio-adapter.md
+++ b/testing/codex-composio-adapter.md
@@ -1,0 +1,35 @@
+# Review Checkpoint Contract
+
+Task: add a Composio workspace-tool adapter for native AgentClash eval runs on a fresh branch from `main`.
+
+## Functional Expectations
+
+1. Native execution must be able to expose bound workspace tools to the model in addition to existing primitive, composed, and mock tools.
+2. The native runtime must load workspace-tool bindings from the frozen `source_agent_spec.tools` payload and resolve the referenced workspace tool records by ID at run start.
+3. A new runtime tool category for workspace tools must be recorded in the tool registry and emitted in native tool-execution events.
+4. Support one capability initially: `capability_key = "composio.execute"`.
+5. The Composio adapter must use direct tool execution, not Tool Router sessions or MCP:
+   - `POST /api/v3/tools/execute/{tool_slug}`
+   - `x-api-key` header for auth
+   - request body supports `arguments` plus `user_id` or `connected_account_id`, with optional `version`
+6. The workspace tool definition contract for `composio.execute` must support:
+   - required: `tool_slug`, `credential_reference`
+   - at least one auth selector: `user_id` or `connected_account_id` in definition or binding config
+   - optional: `description`, `parameters`, `base_url`, `version`
+   - optional binding override: `tool_name`
+7. Workspace tool execution must return structured JSON content to the model. Non-2xx responses or JSON payloads with `successful: false` must be marked as tool errors.
+8. Prompt-eval execution must remain unchanged and tool-less.
+
+## Tests To Add Or Run
+
+- `go test ./internal/engine ./internal/repository ./internal/worker`
+- Add engine coverage for workspace-tool registration and Composio execution against an `httptest` server.
+- Add repository coverage for decoding frozen tool bindings from `source_agent_spec`.
+- Add native executor or worker coverage proving a bound Composio workspace tool is visible and executable in a native run.
+
+## Manual Verification
+
+- Verify the worktree path is `/tmp/agentclash-composio-adapter`.
+- Verify the branch is `codex/composio-adapter`.
+- Verify the final PR targets `main`.
+- Verify the main checkout at `/home/atharva/agentclash` remains untouched.


### PR DESCRIPTION
## Summary
- load frozen workspace tool bindings from source agent specs into native execution
- add a workspace tool registry category and a Composio direct-execution adapter for \
- cover the path with repository decode tests plus registry, direct adapter, and native executor engine tests

## Tested
- env GOCACHE=/tmp/agentclash-go-cache go test ./internal/engine
- env GOCACHE=/tmp/agentclash-go-cache go test ./internal/repository
- env GOCACHE=/tmp/agentclash-go-cache go test ./internal/worker

## Notes
- workspace tool definitions are still resolved by ID at run start because deployment snapshots currently freeze bindings, not full tool definitions
- prompt-eval execution is unchanged