### PR TITLE
feat(web): SEO preview tree at /v2 with 22 marketing pages

### DIFF
--- a/web/src/app/v2/cloud/page.tsx
+++ b/web/src/app/v2/cloud/page.tsx
@@ -1,0 +1,289 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { PageHeader } from "@/components/marketing/page-header";
+import { SplitSection } from "@/components/marketing/split-section";
+import { FeatureGrid } from "@/components/marketing/feature-grid";
+import { ClosingCTA } from "@/components/marketing/closing-cta";
+import { DemoButton } from "@/components/marketing/demo-button";
+import { CodeCard } from "@/components/marketing/code-card";
+import { FAQBlock } from "@/components/marketing/faq-block";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+
+const PATH = "/v2/cloud";
+
+export const metadata: Metadata = {
+  title: "Managed agent evaluation — AgentClash Cloud (beta)",
+  description:
+    "Let us run the race engine. Durable orchestration, sandbox provisioning, replay archive, and hosted workspaces — so your team focuses on challenge packs and verdicts, not Temporal clusters.",
+  alternates: { canonical: PATH },
+  openGraph: {
+    title: "AgentClash Cloud — managed agent evaluation (beta)",
+    description:
+      "Hosted race engine with durable orchestration, sandbox provisioning, and replay archive. Private beta.",
+    url: PATH,
+  },
+};
+
+const FEATURES = [
+  {
+    label: "Orchestration",
+    title: "Durable runs, no ops surface.",
+    body: "Temporal-backed workflows survive node restarts, provider timeouts, and replays. You wire up challenge packs. We keep the graph alive.",
+  },
+  {
+    label: "Sandboxes",
+    title: "Ephemeral E2B environments, ready when you fire.",
+    body: "Each agent gets an isolated sandbox with pinned tools, network policy, and secrets. No cold starts you manage. No leaked filesystem state between races.",
+  },
+  {
+    label: "Replay archive",
+    title: "Every trace, forever.",
+    body: "Events, tool calls, model outputs, sandbox filesystems, stored and addressable by run ID. Replays never expire on your tier. Scrubbing a failure six months later just works.",
+  },
+  {
+    label: "Workspaces",
+    title: "Multi-tenant, WorkOS-backed.",
+    body: "Real org/workspace/role model backed by WorkOS AuthKit. SSO on request. Role-based access on challenge packs, runs, and secrets.",
+  },
+  {
+    label: "CI/CD",
+    title: "Gate merges on live races.",
+    body: "Drop the CLI into any CI. Block the PR when an agent regresses. Post verdict links to GitHub checks so reviewers see what failed without leaving the diff.",
+  },
+  {
+    label: "Support",
+    title: "Direct to the maintainers.",
+    body: "Beta customers get a shared Slack channel with the team that wrote the scoring pipeline. Bugs get fixed where they live — not escalated through tiers.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: "Is AgentClash Cloud generally available?",
+    answer:
+      "Not yet. We're onboarding a small group of design partners in private beta. Book a demo and we'll decide together whether it's a fit — if it is, you'll get a hosted workspace and direct access to the team.",
+  },
+  {
+    question: "What do you host vs. what do I run?",
+    answer:
+      "We host the control plane (API, Temporal worker, Postgres, replay archive, sandbox provisioning). You bring the challenge packs, provider keys, and CI workflows. The CLI talks to the hosted API; nothing about the race engine has to live on your infra.",
+  },
+  {
+    question: "Can I move between managed and self-hosted?",
+    answer:
+      "Yes. Everything you can do on managed cloud you can do self-hosted — same API, same CLI, same workflows. Export your runs and challenge packs whenever you want.",
+  },
+  {
+    question: "Where does my provider traffic go?",
+    answer:
+      "Straight from the sandbox to the model provider using the credentials you supply. We don't proxy model calls, and we don't store prompts or completions outside the replay archive you control.",
+  },
+  {
+    question: "What about security and compliance?",
+    answer:
+      "Sandboxes are isolated per-run. Auth is WorkOS AuthKit (SSO available on request). Data residency, retention, and audit logging details live on the /v2/security page.",
+  },
+  {
+    question: "How is pricing handled during beta?",
+    answer:
+      "Design partners collaborate with us on scope and usage during beta. We're honest about the fact that pricing will exist — we're not baiting and switching — but we want to figure it out alongside the first teams that actually use it.",
+  },
+];
+
+export default function CloudPage() {
+  return (
+    <>
+      <JsonLd
+        id="ld-cloud-product"
+        data={productSchema({
+          name: "AgentClash Cloud",
+          description:
+            "Managed AI agent evaluation platform. Hosted race engine with durable orchestration, sandbox provisioning, replay archive, and CI/CD integration.",
+          url: PATH,
+        })}
+      />
+      <JsonLd
+        id="ld-cloud-breadcrumbs"
+        data={breadcrumbSchema([
+          { name: "Home", url: "/v2" },
+          { name: "Managed cloud", url: PATH },
+        ])}
+      />
+      <MarketingShell>
+        <PageHeader
+          breadcrumbs={[
+            { label: "Home", href: "/v2" },
+            { label: "Managed cloud" },
+          ]}
+          eyebrow="AgentClash Cloud · Private beta"
+          title={
+            <>
+              The race engine.
+              <br />
+              <span className="text-white/40">Hosted for you.</span>
+            </>
+          }
+          subtitle={
+            <>
+              We run Temporal, Postgres, sandbox provisioning, and the
+              replay archive. You run the races. Private beta today —
+              book a call if your team would benefit from hosted
+              AI agent evaluation without operating durable infrastructure.
+            </>
+          }
+          cta={
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+              <DemoButton label="Book a demo" />
+              <Link
+                href="/v2/design-partners"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+              >
+                Design partner program
+                <ArrowRight className="size-4" />
+              </Link>
+              <Link
+                href="/v2/oss"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/[0.08] bg-white/[0.02] px-6 py-3 text-sm font-medium text-white/60 hover:text-white/90 hover:border-white/20 transition-colors"
+              >
+                Prefer self-host?
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
+          }
+          aside={
+            <CodeCard
+              title="Connect"
+              code={`# Point the CLI at the hosted API
+export AGENTCLASH_API_URL="https://api.agentclash.dev"
+
+# Device-flow login
+agentclash auth login --device
+
+# Fire your first race
+agentclash workspace use <your-workspace>
+agentclash run create --follow`}
+            />
+          }
+        />
+
+        <SplitSection
+          eyebrow="Why hosted"
+          title={
+            <>
+              Temporal is not
+              <br />
+              <span className="text-white/40">your product.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                Running durable workflow infrastructure is a real
+                engineering commitment. Postgres tuning, Temporal
+                upgrades, sandbox provisioning, replay storage — these
+                are not the part of agent evaluation your team wants
+                to own.
+              </p>
+              <p className="mt-4">
+                Managed cloud gives you the exact same API, CLI, and
+                scoring pipeline as the open-source engine. We operate
+                the boring parts so your team stays on what matters:
+                the challenge packs, the verdicts, and the regressions
+                that shouldn&apos;t have shipped.
+              </p>
+            </>
+          }
+          aside={
+            <div className="rounded-lg border border-white/[0.08] bg-white/[0.015] p-10">
+              <p className="text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] text-white/40">
+                What we run for you
+              </p>
+              <ul className="mt-6 space-y-3 text-[14px] text-white/70">
+                <li className="flex items-start gap-3">
+                  <span className="mt-2 size-1 shrink-0 rounded-full bg-white/50" />
+                  Temporal cluster + API server
+                </li>
+                <li className="flex items-start gap-3">
+                  <span className="mt-2 size-1 shrink-0 rounded-full bg-white/50" />
+                  Postgres with point-in-time recovery
+                </li>
+                <li className="flex items-start gap-3">
+                  <span className="mt-2 size-1 shrink-0 rounded-full bg-white/50" />
+                  Sandbox provisioning + lifecycle
+                </li>
+                <li className="flex items-start gap-3">
+                  <span className="mt-2 size-1 shrink-0 rounded-full bg-white/50" />
+                  Replay archive + event log
+                </li>
+                <li className="flex items-start gap-3">
+                  <span className="mt-2 size-1 shrink-0 rounded-full bg-white/50" />
+                  WorkOS auth + org/workspace model
+                </li>
+                <li className="flex items-start gap-3">
+                  <span className="mt-2 size-1 shrink-0 rounded-full bg-white/50" />
+                  Upgrades, patches, monitoring
+                </li>
+              </ul>
+            </div>
+          }
+        />
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Capabilities
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                Six things the cloud quietly handles.
+              </h2>
+            </div>
+            <div className="mt-20">
+              <FeatureGrid features={FEATURES} columns={3} />
+            </div>
+          </div>
+        </section>
+
+        <FAQBlock items={FAQ_ITEMS} schemaId="ld-cloud-faq" />
+
+        <ClosingCTA
+          title={
+            <>
+              Private beta is open.
+              <br />
+              <span className="text-white/40">Come talk to us.</span>
+            </>
+          }
+          body={
+            <p>
+              We spend the first call mapping your eval problem before we
+              touch the cloud. If hosted isn&apos;t the right fit we&apos;ll
+              point you at the self-host quickstart and call it a win.
+            </p>
+          }
+        >
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+            <DemoButton
+              label="Book a demo"
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
+            />
+            <Link
+              href="/v2/design-partners"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+            >
+              Design partner program
+              <ArrowRight className="size-4" />
+            </Link>
+          </div>
+        </ClosingCTA>
+      </MarketingShell>
+    </>
+  );
+}

--- a/web/src/app/v2/design-partners/page.tsx
+++ b/web/src/app/v2/design-partners/page.tsx
@@ -1,0 +1,318 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { PageHeader } from "@/components/marketing/page-header";
+import { SplitSection } from "@/components/marketing/split-section";
+import { FeatureGrid } from "@/components/marketing/feature-grid";
+import { ClosingCTA } from "@/components/marketing/closing-cta";
+import { DemoButton } from "@/components/marketing/demo-button";
+import { CodeCard } from "@/components/marketing/code-card";
+import { FAQBlock } from "@/components/marketing/faq-block";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+
+const PATH = "/v2/design-partners";
+
+export const metadata: Metadata = {
+  title: "Design partner program — AgentClash",
+  description:
+    "Work directly with the AgentClash maintainers during private beta. Roadmap influence, custom challenge-pack help, hosted workspaces, and no cost during beta. About ten partners total.",
+  alternates: { canonical: PATH },
+  openGraph: {
+    title: "AgentClash design partner program",
+    description:
+      "Small cohort of teams shipping agents to production. Direct Slack with maintainers, roadmap influence, hosted workspaces during beta.",
+    url: PATH,
+  },
+};
+
+const FEATURES = [
+  {
+    label: "Direct line",
+    title: "Shared Slack with maintainers.",
+    body: "You get a private channel with the engineers who wrote the scoring pipeline. Bugs get answered, not tiered. Feature questions get honest yes/no/when, not roadmap theater.",
+  },
+  {
+    label: "Roadmap influence",
+    title: "We publish what you asked for.",
+    body: "Design-partner asks land on the public roadmap with attribution (if you want it) and a shipping window. You see your own feedback turn into commits — and you see us say no when the right answer is no.",
+  },
+  {
+    label: "Hosted workspace",
+    title: "Private-beta managed cloud.",
+    body: "A hosted workspace on AgentClash Cloud during the beta — Temporal, Postgres, sandbox provisioning, replay archive, all operated by us. No cost during the beta window.",
+  },
+  {
+    label: "Pack authorship",
+    title: "We write the first pack with you.",
+    body: "The hardest part of agent eval is the first challenge pack. We sit on a call, walk your real task through rubric authorship, and hand you a working pack with tests passing. You own the file from there.",
+  },
+  {
+    label: "CI integrations",
+    title: "Early access to CI gating.",
+    body: "Early builds of the GitHub Checks integration, GitLab pipeline hooks, and nightly drift sweeps. Partners shape what 'block the merge' actually looks like in their own CI before it's public.",
+  },
+  {
+    label: "Case study",
+    title: "Optional. On your timeline.",
+    body: "A case study is available if and when it helps you — we'll draft it, you approve every word, you say when it publishes. If you'd rather stay unnamed, that's also fine. Your logo is never a condition.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: "Is there a cost during beta?",
+    answer:
+      "No. Managed cloud usage, sandbox minutes, replay storage, and direct support are free for design partners during private beta. When we turn on pricing, partners get early notice, migration help, and a grandfathered window — we're not baiting and switching.",
+  },
+  {
+    question: "Do I have to do a case study?",
+    answer:
+      "No. The case study is optional, drafted by us, approved by you, and published on your timeline. Many partners never do one; that's fine. Your feedback is the value — a logo on /customers is a bonus, not a gate.",
+  },
+  {
+    question: "What if we self-host?",
+    answer:
+      "Still eligible. Self-host partners get the same direct Slack, the same roadmap influence, and the same pack-authorship help. You miss the hosted workspace (because you don't need it), but the rest is identical. We work with both shapes.",
+  },
+  {
+    question: "How many partners are you onboarding?",
+    answer:
+      "Around ten in this cohort. The number is small on purpose — we promise every partner real weekly access to the maintainers, and the math only works if we keep the group tight. If the fit is right, we'd rather stretch the cohort than dilute the access.",
+  },
+  {
+    question: "How do I apply?",
+    answer:
+      "Book a 20-minute fit call from this page. We talk about your actual agent stack, the regression pain point, and whether the thing you need is in our next three months. If the fit is clear, we onboard immediately; if it isn't, we say so and often point you somewhere better.",
+  },
+];
+
+export default function DesignPartnersPage() {
+  return (
+    <>
+      <JsonLd
+        id="ld-partners-product"
+        data={productSchema({
+          name: "AgentClash — design partner program",
+          description:
+            "Private-beta design partner program. Direct access to AgentClash maintainers, roadmap influence, hosted workspaces, and pack-authorship help for teams shipping agents to production.",
+          url: PATH,
+        })}
+      />
+      <JsonLd
+        id="ld-partners-breadcrumbs"
+        data={breadcrumbSchema([
+          { name: "Home", url: "/v2" },
+          { name: "Design partners", url: PATH },
+        ])}
+      />
+      <MarketingShell>
+        <PageHeader
+          breadcrumbs={[
+            { label: "Home", href: "/v2" },
+            { label: "Design partners" },
+          ]}
+          eyebrow="Design partner program"
+          title={
+            <>
+              Build this with us.
+              <br />
+              <span className="text-white/40">Not for us.</span>
+            </>
+          }
+          subtitle={
+            <>
+              We&apos;re working directly with a small group of teams
+              shipping agents into production. Design partners get direct
+              access to the maintainers, shape the roadmap, and get a
+              hosted workspace during private beta. About ten partners
+              total.
+            </>
+          }
+          cta={
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+              <DemoButton label="Book a fit call" />
+              <Link
+                href="/v2/cloud"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+              >
+                Managed cloud
+                <ArrowRight className="size-4" />
+              </Link>
+              <Link
+                href="/v2/oss"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/[0.08] bg-white/[0.02] px-6 py-3 text-sm font-medium text-white/60 hover:text-white/90 hover:border-white/20 transition-colors"
+              >
+                Self-host instead
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
+          }
+          aside={
+            <CodeCard
+              title="Program shape"
+              code={`cohort:      ~10 teams
+window:      private beta
+cost:        $0 during beta
+cadence:     30 min weekly
+channel:     shared Slack
+commitment:  honest feedback`}
+            />
+          }
+        />
+
+        <SplitSection
+          eyebrow="Who this is for"
+          title={
+            <>
+              Teams shipping agents
+              <br />
+              <span className="text-white/40">to real users.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                The partner program exists to sharpen the product against
+                actual production pain. That means we&apos;re most useful
+                to teams who already have agents in front of real users
+                and a recurring regression story they&apos;re tired of
+                telling.
+              </p>
+              <p className="mt-4">
+                If you&apos;re still pre-prototype, we&apos;ll point you
+                at the open-source quickstart and revisit when you&apos;re
+                further along. The fit conversation on the first call is
+                honest — nobody benefits from the wrong match.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Ideal-fit profile"
+              code={`you:
+  - ship agents to production users
+  - have a recurring regression pain
+  - care about cost / latency / drift
+  - willing to talk weekly in beta
+
+your stack (any one is enough):
+  - OpenAI / Anthropic / Gemini / xAI
+  - tool-using agents in a loop
+  - CI that blocks merges
+
+not a fit (yet):
+  - pre-prototype, no real users
+  - one-shot completions, no tools
+  - no appetite for weekly feedback`}
+            />
+          }
+        />
+
+        <SplitSection
+          reverse
+          eyebrow="What we ask in return"
+          title={
+            <>
+              Small list.
+              <br />
+              <span className="text-white/40">No surprises.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                The partnership is a two-way street — not a discount in
+                exchange for a press release. We need honest signal about
+                what&apos;s working and what isn&apos;t, and we need it
+                while the product is still shaped like clay.
+              </p>
+              <p className="mt-4">
+                Everything below is the full list. No gotchas, no
+                mid-beta renegotiation, no hidden exclusivity. If any of
+                these don&apos;t fit your team, tell us on the first call
+                and we&apos;ll figure out whether a lighter arrangement
+                works.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="What we ask"
+              code={`1. honest feedback
+     say when something sucks.
+     say when something finally worked.
+
+2. 30 minutes weekly
+     we bring the agenda.
+     you bring the week's friction.
+
+3. pack re-run on new features
+     point your challenge pack at
+     new scoring features before GA.
+
+4. optional: logo on /customers
+     only if you opt in.
+     only when you're ready.`}
+            />
+          }
+        />
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                What you get
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                Six things the partnership quietly delivers.
+              </h2>
+            </div>
+            <div className="mt-20">
+              <FeatureGrid features={FEATURES} columns={3} />
+            </div>
+          </div>
+        </section>
+
+        <FAQBlock items={FAQ_ITEMS} schemaId="ld-partners-faq" />
+
+        <ClosingCTA
+          title={
+            <>
+              Twenty minutes.
+              <br />
+              <span className="text-white/40">Honest on both sides.</span>
+            </>
+          }
+          body={
+            <p>
+              The fit call is short on purpose. We talk about your actual
+              stack, your actual regression pain, and whether the thing
+              you need is in our next three months. If it isn&apos;t,
+              we&apos;ll say so.
+            </p>
+          }
+        >
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+            <DemoButton
+              label="Book the fit call"
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
+            />
+            <Link
+              href="/v2/methodology"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+            >
+              How we score
+              <ArrowRight className="size-4" />
+            </Link>
+          </div>
+        </ClosingCTA>
+      </MarketingShell>
+    </>
+  );
+}

--- a/web/src/app/v2/landing.tsx
+++ b/web/src/app/v2/landing.tsx
@@ -1,0 +1,2236 @@
+"use client";
+
+import type React from "react";
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { getCalApi } from "@calcom/embed-react";
+import { useAuth } from "@workos-inc/authkit-nextjs/components";
+import { ArrowRight, Calendar, ExternalLink, LogIn, Star } from "lucide-react";
+import {
+  Anthropic,
+  Gemini,
+  Mistral,
+  OpenAI,
+  OpenRouter,
+  XAI,
+} from "@lobehub/icons";
+
+const DEMO_LINK = "atharva-kanherkar-epgztu/agentclash-demo";
+const DEMO_BUTTON_CONFIG = JSON.stringify({ layout: "month_view" });
+
+function DemoPopupButton({ className }: { className: string }) {
+  return (
+    <button
+      type="button"
+      data-cal-link={DEMO_LINK}
+      data-cal-config={DEMO_BUTTON_CONFIG}
+      className={className}
+    >
+      <Calendar className="size-4" />
+      Book a demo
+    </button>
+  );
+}
+
+function ClashMark({
+  className = "",
+  animated = false,
+}: {
+  className?: string;
+  animated?: boolean;
+}) {
+  return (
+    <svg
+      viewBox="0 0 512 512"
+      className={className}
+      aria-label="AgentClash"
+      role="img"
+    >
+      <g className={animated ? "animate-clash-left" : undefined}>
+        <polygon
+          points="80,180 240,256 80,332"
+          fill="#ffffff"
+          opacity="0.95"
+        />
+      </g>
+      <g className={animated ? "animate-clash-right" : undefined}>
+        <polygon
+          points="432,180 272,256 432,332"
+          fill="#ffffff"
+          opacity="0.5"
+        />
+      </g>
+      <g className={animated ? "animate-clash-sparks" : undefined}>
+        <line
+          x1="256" y1="96" x2="256" y2="168"
+          stroke="#ffffff" strokeWidth="10" strokeLinecap="round" opacity="0.75"
+        />
+        <line
+          x1="256" y1="344" x2="256" y2="416"
+          stroke="#ffffff" strokeWidth="10" strokeLinecap="round" opacity="0.75"
+        />
+        <line
+          x1="186" y1="130" x2="216" y2="188"
+          stroke="#ffffff" strokeWidth="8" strokeLinecap="round" opacity="0.55"
+        />
+        <line
+          x1="326" y1="130" x2="296" y2="188"
+          stroke="#ffffff" strokeWidth="8" strokeLinecap="round" opacity="0.55"
+        />
+        <line
+          x1="186" y1="382" x2="216" y2="324"
+          stroke="#ffffff" strokeWidth="8" strokeLinecap="round" opacity="0.55"
+        />
+        <line
+          x1="326" y1="382" x2="296" y2="324"
+          stroke="#ffffff" strokeWidth="8" strokeLinecap="round" opacity="0.55"
+        />
+      </g>
+    </svg>
+  );
+}
+
+const PROVIDERS: Array<{ name: string; render: (size: number) => React.ReactNode }> = [
+  { name: "OpenAI", render: (size) => <OpenAI size={size} color="#74AA9C" /> },
+  { name: "Anthropic", render: (size) => <Anthropic size={size} color="#D97757" /> },
+  { name: "Gemini", render: (size) => <Gemini.Color size={size} /> },
+  { name: "xAI", render: (size) => <XAI size={size} color="#FFFFFF" /> },
+  { name: "Mistral", render: (size) => <Mistral.Color size={size} /> },
+  { name: "OpenRouter", render: (size) => <OpenRouter size={size} color="#6566F1" /> },
+];
+
+function DottedSpotlight({
+  children,
+  className = "",
+}: {
+  children?: React.ReactNode;
+  className?: string;
+}) {
+  const ref = useRef<HTMLElement | null>(null);
+  const [isActive, setIsActive] = useState(false);
+
+  function updatePosition(clientX: number, clientY: number) {
+    if (!ref.current) return;
+    const rect = ref.current.getBoundingClientRect();
+    ref.current.style.setProperty("--mx", `${clientX - rect.left}px`);
+    ref.current.style.setProperty("--my", `${clientY - rect.top}px`);
+  }
+
+  const cursorMask =
+    "radial-gradient(400px circle at var(--mx) var(--my), black 0%, black 20%, transparent 70%)";
+  const dotImage =
+    "radial-gradient(rgba(255,255,255,1) 1px, transparent 1px)";
+  const cursorBloom =
+    "radial-gradient(400px circle at var(--mx) var(--my), rgba(255,255,255,0.06) 0%, rgba(255,255,255,0.015) 35%, transparent 70%)";
+
+  return (
+    <section
+      ref={ref}
+      onMouseMove={(e) => {
+        updatePosition(e.clientX, e.clientY);
+        setIsActive(true);
+      }}
+      onMouseLeave={() => setIsActive(false)}
+      onTouchStart={(e) => {
+        const t = e.touches[0];
+        if (!t) return;
+        updatePosition(t.clientX, t.clientY);
+        setIsActive(true);
+      }}
+      onTouchMove={(e) => {
+        const t = e.touches[0];
+        if (!t) return;
+        updatePosition(t.clientX, t.clientY);
+      }}
+      onTouchEnd={() => setIsActive(false)}
+      onTouchCancel={() => setIsActive(false)}
+      className={`relative ${className}`}
+      style={{ ["--mx" as string]: "50%", ["--my" as string]: "50%" }}
+    >
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div
+          aria-hidden
+          className="animate-dots-breathe absolute inset-0"
+          style={{
+            backgroundImage: dotImage,
+            backgroundSize: "22px 22px",
+            maskImage:
+              "radial-gradient(ellipse 40% 60% at 50% 50%, black 0%, black 25%, transparent 80%)",
+            WebkitMaskImage:
+              "radial-gradient(ellipse 40% 60% at 50% 50%, black 0%, black 25%, transparent 80%)",
+          }}
+        />
+        <div
+          aria-hidden
+          className={`absolute inset-0 transition-opacity duration-500 ease-out ${isActive ? "opacity-100" : "opacity-0"}`}
+          style={{ backgroundImage: cursorBloom }}
+        />
+        <div
+          aria-hidden
+          className={`absolute inset-0 transition-opacity duration-500 ease-out ${isActive ? "opacity-90" : "opacity-0"}`}
+          style={{
+            backgroundImage: dotImage,
+            backgroundSize: "22px 22px",
+            maskImage: cursorMask,
+            WebkitMaskImage: cursorMask,
+          }}
+        />
+      </div>
+      <div className="relative">{children}</div>
+    </section>
+  );
+}
+
+function TargetGlyph() {
+  return (
+    <svg
+      viewBox="0 0 48 48"
+      className="size-7 text-white/90"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden
+    >
+      <circle cx="24" cy="24" r="19" opacity="0.32" />
+      <circle cx="24" cy="24" r="12" opacity="0.6" />
+      <circle cx="24" cy="24" r="5" opacity="0.9" />
+      <circle cx="24" cy="24" r="1.5" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
+function LineupGlyph() {
+  return (
+    <svg
+      viewBox="0 0 48 48"
+      className="size-7 text-white/90"
+      fill="currentColor"
+      aria-hidden
+    >
+      <polygon points="6,13 14,18 6,23" opacity="0.95" />
+      <polygon points="20,13 28,18 20,23" opacity="0.8" />
+      <polygon points="34,13 42,18 34,23" opacity="0.65" />
+      <polygon points="6,28 14,33 6,38" opacity="0.5" />
+      <polygon points="20,28 28,33 20,38" opacity="0.4" />
+      <polygon points="34,28 42,33 34,38" opacity="0.3" />
+    </svg>
+  );
+}
+
+function LightFlowArrows() {
+  const COUNT = 9;
+  const DURATION = 3.6;
+  return (
+    <div
+      className="flex flex-col items-center justify-center gap-5 py-8 sm:gap-7 sm:py-12"
+      aria-hidden
+    >
+      {Array.from({ length: COUNT }).map((_, i) => (
+        <svg
+          key={i}
+          viewBox="0 0 48 24"
+          className="animate-arrow-flow h-5 w-11 text-white"
+          style={{
+            animationDelay: `${(-(i / COUNT) * DURATION).toFixed(2)}s`,
+          }}
+          focusable="false"
+        >
+          <path
+            d="M6 7 L24 19 L42 7"
+            stroke="currentColor"
+            strokeWidth="2.25"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            fill="none"
+          />
+        </svg>
+      ))}
+    </div>
+  );
+}
+
+function TransparentFrame() {
+  const ys = [82, 118, 154, 190, 226];
+  const paths = ys.map((y) => `M -30 ${y} L 430 ${y}`);
+  return (
+    <div className="flex items-center justify-center py-4" aria-hidden>
+      <svg
+        viewBox="0 0 400 300"
+        className="w-full max-w-[440px]"
+        focusable="false"
+      >
+        <rect
+          x="80"
+          y="60"
+          width="240"
+          height="180"
+          rx="2"
+          fill="none"
+          stroke="rgba(255,255,255,0.35)"
+          strokeWidth="1.1"
+        />
+        <rect
+          x="92"
+          y="72"
+          width="216"
+          height="156"
+          rx="1"
+          fill="none"
+          stroke="rgba(255,255,255,0.08)"
+          strokeWidth="1"
+          strokeDasharray="2 5"
+        />
+
+        {ys.map((y, i) => (
+          <line
+            key={`tf-track-${i}`}
+            x1="-20"
+            y1={y}
+            x2="420"
+            y2={y}
+            stroke="rgba(255,255,255,0.05)"
+            strokeWidth="1"
+          />
+        ))}
+
+        {paths.map((d, i) => (
+          <line
+            key={`tf-streak-${i}`}
+            x1="-7"
+            y1="0"
+            x2="7"
+            y2="0"
+            stroke="white"
+            strokeWidth="2"
+            strokeLinecap="round"
+            className="animate-light-streak"
+            style={{
+              offsetPath: `path('${d}')`,
+              animationDelay: `${(-(i / paths.length) * 1.4).toFixed(2)}s`,
+            }}
+          />
+        ))}
+      </svg>
+    </div>
+  );
+}
+
+function ToolGlyph({ name }: { name: string }) {
+  const common = {
+    fill: "none",
+    stroke: "currentColor",
+    strokeWidth: 1.4,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+  };
+  switch (name) {
+    case "read_file":
+      return (
+        <g {...common}>
+          <path d="M 8 5 H 22 V 27 H 8 Z" />
+          <line x1="11" y1="11" x2="19" y2="11" />
+          <line x1="11" y1="15" x2="19" y2="15" />
+          <line x1="11" y1="19" x2="17" y2="19" />
+        </g>
+      );
+    case "write_file":
+      return (
+        <g {...common}>
+          <path d="M 6 5 H 18 V 27 H 6 Z" />
+          <path d="M 14 10 L 24 20 L 20 24 L 10 14 Z" />
+          <line x1="22" y1="22" x2="26" y2="26" />
+        </g>
+      );
+    case "search_text":
+      return (
+        <g {...common}>
+          <circle cx="13" cy="13" r="7" />
+          <line x1="19" y1="19" x2="25" y2="25" />
+          <line x1="9" y1="12" x2="17" y2="12" strokeWidth="1" opacity="0.55" />
+          <line x1="9" y1="15" x2="15" y2="15" strokeWidth="1" opacity="0.55" />
+        </g>
+      );
+    case "query_sql":
+      return (
+        <g {...common}>
+          <ellipse cx="16" cy="8" rx="9" ry="3" />
+          <path d="M 7 8 V 24 A 9 3 0 0 0 25 24 V 8" />
+          <path d="M 7 16 A 9 3 0 0 0 25 16" opacity="0.55" />
+        </g>
+      );
+    case "http_request":
+      return (
+        <g {...common}>
+          <circle cx="16" cy="16" r="11" />
+          <line x1="5" y1="16" x2="27" y2="16" opacity="0.6" />
+          <path d="M 16 5 Q 10 16 16 27 Q 22 16 16 5" opacity="0.7" />
+        </g>
+      );
+    case "run_tests":
+      return (
+        <g {...common}>
+          <rect x="5" y="5" width="22" height="22" rx="2" />
+          <path d="M 10 16 L 14 20 L 22 11" strokeWidth="1.8" />
+        </g>
+      );
+    case "build":
+      return (
+        <g {...common}>
+          <path d="M 16 4 L 19 7 L 19 11 L 23 13 L 23 19 L 19 21 L 19 25 L 16 28 L 13 25 L 13 21 L 9 19 L 9 13 L 13 11 L 13 7 Z" />
+          <circle cx="16" cy="16" r="3" />
+        </g>
+      );
+    case "exec":
+      return (
+        <g {...common}>
+          <rect x="4" y="7" width="24" height="18" rx="1.5" />
+          <path d="M 10 13 L 14 16 L 10 19" strokeWidth="1.6" />
+          <line x1="16" y1="19" x2="22" y2="19" strokeWidth="1.4" />
+        </g>
+      );
+    case "submit":
+      return (
+        <g {...common}>
+          <path d="M 16 24 L 16 6" strokeWidth="1.8" />
+          <path d="M 9 13 L 16 6 L 23 13" strokeWidth="1.8" />
+          <line x1="6" y1="28" x2="26" y2="28" strokeWidth="1.4" opacity="0.5" />
+        </g>
+      );
+    default:
+      return null;
+  }
+}
+
+function ToolPalette() {
+  const TOOLS = [
+    "read_file",
+    "write_file",
+    "search_text",
+    "query_sql",
+    "http_request",
+    "run_tests",
+    "build",
+    "exec",
+    "submit",
+  ];
+
+  const labelProps = {
+    fill: "white",
+    opacity: 0.5,
+    fontSize: 10,
+    fontFamily: "var(--font-mono), monospace",
+    letterSpacing: "0.14em",
+    textTransform: "uppercase" as const,
+  } as const;
+
+  const ringStroke = {
+    fill: "none",
+    stroke: "rgba(255,255,255,0.28)",
+    strokeWidth: 1.1,
+  } as const;
+
+  const LLM_YS = [60, 120, 180, 240, 300, 360];
+  const LLM_CX = 36;
+  const AGENT_CX = 624;
+  const AGENT_YS = [80, 160, 260, 340];
+
+  const MATRIX_X = 200;
+  const MATRIX_Y = 90;
+  const MATRIX_W = 260;
+  const MATRIX_H = 260;
+  const COL = [MATRIX_X + 35, MATRIX_X + 130, MATRIX_X + 225];
+  const ROW = [MATRIX_Y + 40, MATRIX_Y + 130, MATRIX_Y + 220];
+
+  const MERGE = { x: 172, y: 210 };
+  const SPLIT = { x: 492, y: 210 };
+
+  const convergePaths = LLM_YS.map((y) => `M 50 ${y} Q 100 ${y} ${MERGE.x} ${MERGE.y}`);
+  const intoMatrix = `M ${MERGE.x} ${MERGE.y} L ${MATRIX_X - 2} ${MERGE.y}`;
+  const outOfMatrix = `M ${MATRIX_X + MATRIX_W + 2} ${SPLIT.y} L ${SPLIT.x} ${SPLIT.y}`;
+  const divergePaths = AGENT_YS.map(
+    (y) => `M ${SPLIT.x} ${SPLIT.y} Q ${SPLIT.x + 50} ${y} ${AGENT_CX - 16} ${y}`,
+  );
+
+  const allFlowPaths = [
+    ...convergePaths,
+    intoMatrix,
+    outOfMatrix,
+    ...divergePaths,
+  ];
+
+  return (
+    <div className="flex items-center justify-center py-4" aria-hidden>
+      <svg
+        viewBox="0 0 660 420"
+        className="w-full max-w-[640px] text-white/75"
+        focusable="false"
+      >
+        <defs>
+          <marker
+            id="tool-arrow"
+            viewBox="0 0 10 10"
+            refX="8"
+            refY="5"
+            markerWidth="5"
+            markerHeight="5"
+            orient="auto"
+          >
+            <polygon points="0,0 10,5 0,10" fill="white" opacity="0.55" />
+          </marker>
+        </defs>
+
+        <text x={LLM_CX} y="26" textAnchor="middle" {...labelProps}>
+          llms
+        </text>
+        <text
+          x={MATRIX_X + MATRIX_W / 2}
+          y="26"
+          textAnchor="middle"
+          {...labelProps}
+        >
+          sandbox
+        </text>
+        <text x={AGENT_CX} y="26" textAnchor="middle" {...labelProps}>
+          agents
+        </text>
+
+        {LLM_YS.map((y, i) => {
+          const provider = PROVIDERS[i];
+          if (!provider) return null;
+          const size = 20;
+          return (
+            <g key={provider.name}>
+              <circle cx={LLM_CX} cy={y} r="14" {...ringStroke} />
+              <g transform={`translate(${LLM_CX - size / 2} ${y - size / 2})`}>
+                {provider.render(size)}
+              </g>
+            </g>
+          );
+        })}
+
+        <rect
+          x={MATRIX_X}
+          y={MATRIX_Y}
+          width={MATRIX_W}
+          height={MATRIX_H}
+          rx="14"
+          fill="none"
+          stroke="rgba(255,255,255,0.18)"
+          strokeWidth="1"
+          strokeDasharray="2 4"
+        />
+
+        {TOOLS.map((name, i) => {
+          const row = Math.floor(i / 3);
+          const col = i % 3;
+          return (
+            <g
+              key={name}
+              transform={`translate(${COL[col] - 16} ${ROW[row] - 16})`}
+            >
+              <ToolGlyph name={name} />
+            </g>
+          );
+        })}
+
+        {AGENT_YS.map((y, i) => (
+          <g key={`agent-${i}`}>
+            <circle cx={AGENT_CX} cy={y} r="13" {...ringStroke} />
+            <circle
+              cx={AGENT_CX}
+              cy={y}
+              r="3.5"
+              fill="rgba(255,255,255,0.35)"
+            />
+          </g>
+        ))}
+
+        {allFlowPaths.map((d, i) => (
+          <path
+            key={`tp-${i}`}
+            d={d}
+            fill="none"
+            stroke="rgba(255,255,255,0.14)"
+            strokeWidth="1.1"
+            markerEnd="url(#tool-arrow)"
+          />
+        ))}
+
+        {allFlowPaths.map((d, i) => (
+          <line
+            key={`ts-${i}`}
+            x1="-7"
+            y1="0"
+            x2="7"
+            y2="0"
+            stroke="white"
+            strokeWidth="2"
+            strokeLinecap="round"
+            className="animate-light-streak"
+            style={{
+              offsetPath: `path('${d}')`,
+              animationDelay: `${(-(i / allFlowPaths.length) * 1.4).toFixed(2)}s`,
+            }}
+          />
+        ))}
+      </svg>
+    </div>
+  );
+}
+
+function ScoringPipeline() {
+  const labelProps = {
+    fill: "#888888",
+    opacity: 0.8,
+    fontSize: 10,
+    fontFamily: "var(--font-mono), monospace",
+    letterSpacing: "0.1em",
+    textTransform: "uppercase" as const,
+  } as const;
+
+  const ringStroke = {
+    fill: "rgba(255,255,255,0.02)",
+    stroke: "rgba(255,255,255,0.22)",
+    strokeWidth: 1.2,
+  } as const;
+
+  const AGENT_X = 60;
+  const AGENT_YS = [40, 105, 170, 235, 300, 365];
+  const AGENT_R = 16;
+
+  const JUDGE_X = 300;
+  const JUDGES = [
+    { y: 85, label: "deterministic" },
+    { y: 165, label: "mathematic" },
+    { y: 245, label: "behavioural" },
+    { y: 325, label: "llm + aggregation" },
+  ];
+  const JUDGE_R = 16;
+
+  // 6 agents → 4 judges by nearest y, then 4 judges → verdict.
+  const paths = [
+    "M 76 40  Q 180 60  282 85",
+    "M 76 105 Q 180 95  282 85",
+    "M 76 170 Q 180 167 282 165",
+    "M 76 235 Q 180 240 282 245",
+    "M 76 300 Q 180 315 282 325",
+    "M 76 365 Q 180 345 282 325",
+    "M 318 85  Q 420 130 506 190",
+    "M 318 165 Q 420 180 506 202",
+    "M 318 245 Q 420 220 506 212",
+    "M 318 325 Q 420 270 506 222",
+  ];
+
+  return (
+    <div className="flex items-center justify-center py-4" aria-hidden>
+      <svg
+        viewBox="0 0 600 440"
+        className="w-full max-w-[580px]"
+        focusable="false"
+      >
+        <defs>
+          <filter id="soft-glow" x="-20%" y="-20%" width="140%" height="140%">
+            <feGaussianBlur stdDeviation="6" result="blur" />
+            <feComposite in="SourceGraphic" in2="blur" operator="over" />
+          </filter>
+        </defs>
+
+        <text
+          x="24"
+          y="210"
+          textAnchor="middle"
+          transform="rotate(-90 24 210)"
+          {...labelProps}
+        >
+          agents
+        </text>
+        <text x="300" y="46" textAnchor="middle" {...labelProps}>
+          judges
+        </text>
+        <text x="540" y="150" textAnchor="middle" {...labelProps}>
+          verdict
+        </text>
+
+        {AGENT_YS.map((y, i) => {
+          const provider = PROVIDERS[i];
+          if (!provider) return null;
+          const iconSize = 22;
+          return (
+            <g key={provider.name}>
+              <circle cx={AGENT_X} cy={y} r={AGENT_R} {...ringStroke} />
+              <g transform={`translate(${AGENT_X - iconSize / 2} ${y - iconSize / 2})`}>
+                {provider.render(iconSize)}
+              </g>
+            </g>
+          );
+        })}
+
+        {JUDGES.map((j) => (
+          <g key={j.label}>
+            <circle
+              cx={JUDGE_X}
+              cy={j.y}
+              r={JUDGE_R}
+              {...ringStroke}
+              filter="url(#soft-glow)"
+            />
+            <text
+              x={JUDGE_X + JUDGE_R + 10}
+              y={j.y + 4}
+              textAnchor="start"
+              fill="white"
+              opacity="0.55"
+              fontSize="10.5"
+              fontFamily="var(--font-mono), monospace"
+              letterSpacing="0.04em"
+            >
+              {j.label}
+            </text>
+          </g>
+        ))}
+
+        <circle
+          cx="540"
+          cy="205"
+          r="30"
+          {...ringStroke}
+          stroke="rgba(255,255,255,0.55)"
+          strokeWidth="1.5"
+          filter="url(#soft-glow)"
+          className="animate-results-glow"
+        />
+
+        {paths.map((d, i) => (
+          <path
+            key={`p-${i}`}
+            d={d}
+            fill="none"
+            stroke="rgba(255,255,255,0.15)"
+            strokeWidth="1.2"
+          />
+        ))}
+
+        {paths.map((d, i) => (
+          <line
+            key={`g-${i}`}
+            x1="-7"
+            y1="0"
+            x2="7"
+            y2="0"
+            stroke="white"
+            strokeWidth="2"
+            strokeLinecap="round"
+            className="animate-light-streak"
+            style={{
+              offsetPath: `path('${d}')`,
+              animationDelay: `${(-(i / paths.length) * 1.4).toFixed(2)}s`,
+            }}
+          />
+        ))}
+      </svg>
+    </div>
+  );
+}
+
+function SandboxLanes() {
+  const DURATION = 3.8;
+  return (
+    <div
+      className="flex flex-col items-stretch justify-center gap-3.5 py-6 sm:gap-4 sm:py-10"
+      aria-hidden
+    >
+      {PROVIDERS.map(({ name, render }, i) => (
+        <div
+          key={name}
+          className="relative h-12 overflow-hidden rounded-md border border-white/[0.14]"
+        >
+          <div
+            className="animate-sandbox-travel absolute inset-0 flex items-center justify-center"
+            style={{
+              animationDelay: `${(-(i / PROVIDERS.length) * DURATION).toFixed(2)}s`,
+            }}
+          >
+            {render(24)}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function FeedbackLoop() {
+  return (
+    <div className="flex items-center justify-center py-6 sm:py-10" aria-hidden>
+      <svg
+        viewBox="0 0 400 230"
+        className="w-full max-w-[480px]"
+        focusable="false"
+      >
+        <defs>
+          <marker
+            id="feedback-arrow-head"
+            viewBox="0 0 10 10"
+            refX="8"
+            refY="5"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto"
+          >
+            <polygon points="0,0 10,5 0,10" fill="white" opacity="0.7" />
+          </marker>
+        </defs>
+
+        <circle
+          cx="70"
+          cy="115"
+          r="38"
+          fill="#060606"
+          stroke="white"
+          strokeWidth="1.2"
+          opacity="0.85"
+        />
+        <text
+          x="70"
+          y="119"
+          textAnchor="middle"
+          fill="white"
+          opacity="0.85"
+          fontSize="10"
+          fontFamily="var(--font-mono), monospace"
+          letterSpacing="0.16em"
+        >
+          FAILURES
+        </text>
+
+        <circle
+          cx="330"
+          cy="115"
+          r="38"
+          fill="#060606"
+          stroke="white"
+          strokeWidth="1.2"
+          opacity="0.85"
+        />
+        <text
+          x="330"
+          y="119"
+          textAnchor="middle"
+          fill="white"
+          opacity="0.85"
+          fontSize="10"
+          fontFamily="var(--font-mono), monospace"
+          letterSpacing="0.16em"
+        >
+          EVALS
+        </text>
+
+        <path
+          d="M 100 93 Q 200 10 300 93"
+          stroke="white"
+          strokeWidth="1.25"
+          fill="none"
+          opacity="0.42"
+          markerEnd="url(#feedback-arrow-head)"
+        />
+        <circle r="3.2" fill="white" className="animate-travel-top" />
+
+        <path
+          d="M 300 137 Q 200 220 100 137"
+          stroke="white"
+          strokeWidth="1.25"
+          fill="none"
+          opacity="0.42"
+          markerEnd="url(#feedback-arrow-head)"
+        />
+        <circle r="3.2" fill="white" className="animate-travel-bottom" />
+      </svg>
+    </div>
+  );
+}
+
+function ComparisonMark({
+  kind,
+  highlight,
+}: {
+  kind: "yes" | "partial" | "no";
+  highlight?: boolean;
+}) {
+  if (kind === "yes") {
+    return (
+      <span
+        aria-label="supported"
+        className={`inline-block size-2 rounded-full ${
+          highlight ? "bg-white shadow-[0_0_12px_rgba(255,255,255,0.55)]" : "bg-white/70"
+        }`}
+      />
+    );
+  }
+  if (kind === "partial") {
+    return (
+      <span
+        aria-label="partial"
+        className="inline-block size-2 rounded-full border border-white/50"
+      />
+    );
+  }
+  return (
+    <span aria-label="not supported" className="block h-px w-3 bg-white/20" />
+  );
+}
+
+function TrackGlyph() {
+  return (
+    <svg
+      viewBox="0 0 48 48"
+      className="size-7 text-white/90"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      aria-hidden
+    >
+      <line x1="5" y1="24" x2="34" y2="24" opacity="0.45" />
+      <circle cx="10" cy="24" r="1.3" fill="currentColor" opacity="0.4" stroke="none" />
+      <circle cx="18" cy="24" r="1.3" fill="currentColor" opacity="0.65" stroke="none" />
+      <circle cx="26" cy="24" r="2" fill="currentColor" opacity="0.95" stroke="none" />
+      <line x1="36" y1="12" x2="36" y2="36" strokeWidth="1.2" opacity="0.55" />
+      <g fill="currentColor" stroke="none" opacity="0.9">
+        <rect x="37" y="12" width="3" height="3" />
+        <rect x="40" y="15" width="3" height="3" />
+        <rect x="37" y="18" width="3" height="3" />
+        <rect x="40" y="21" width="3" height="3" />
+        <rect x="37" y="24" width="3" height="3" />
+      </g>
+    </svg>
+  );
+}
+
+function ShippingConstellation() {
+  const CX = 300;
+  const CY = 300;
+  const R = 220;
+  const CENTER_R = 46;
+  const NODE_R = 26;
+  const PROVIDER_ICON_SIZE = 30;
+  const CLASH_SIZE = 68;
+  const DURATION = 1.4;
+  const COUNT = PROVIDERS.length;
+
+  const nodes = Array.from({ length: COUNT }, (_, i) => {
+    const angle = (i / COUNT) * Math.PI * 2 - Math.PI / 2;
+    return {
+      i,
+      x: CX + R * Math.cos(angle),
+      y: CY + R * Math.sin(angle),
+      cos: Math.cos(angle),
+      sin: Math.sin(angle),
+    };
+  });
+
+  const paths = nodes.map((n) => {
+    const startX = CX + (CENTER_R + 2) * n.cos;
+    const startY = CY + (CENTER_R + 2) * n.sin;
+    const endX = CX + (R - NODE_R - 4) * n.cos;
+    const endY = CY + (R - NODE_R - 4) * n.sin;
+    return `M ${startX.toFixed(1)} ${startY.toFixed(1)} L ${endX.toFixed(1)} ${endY.toFixed(1)}`;
+  });
+
+  return (
+    <div className="flex items-center justify-center py-6" aria-hidden>
+      <svg viewBox="0 0 600 600" className="w-full max-w-[560px]" focusable="false">
+        <defs>
+          <filter id="sc-center-glow" x="-50%" y="-50%" width="200%" height="200%">
+            <feGaussianBlur stdDeviation="10" result="blur" />
+            <feComposite in="SourceGraphic" in2="blur" operator="over" />
+          </filter>
+          <radialGradient id="sc-center-fill">
+            <stop offset="0%" stopColor="rgba(255,255,255,0.28)" />
+            <stop offset="70%" stopColor="rgba(255,255,255,0.04)" />
+            <stop offset="100%" stopColor="rgba(255,255,255,0)" />
+          </radialGradient>
+        </defs>
+
+        {/* Outer orbit guide */}
+        <circle
+          cx={CX}
+          cy={CY}
+          r={R}
+          fill="none"
+          stroke="rgba(255,255,255,0.06)"
+          strokeWidth="1"
+          strokeDasharray="2 6"
+        />
+
+        {/* Static connector lines */}
+        {paths.map((d, i) => (
+          <path
+            key={`sc-line-${i}`}
+            d={d}
+            fill="none"
+            stroke="rgba(255,255,255,0.12)"
+            strokeWidth="1"
+          />
+        ))}
+
+        {/* Central node — AgentClash */}
+        <circle
+          cx={CX}
+          cy={CY}
+          r={CENTER_R + 22}
+          fill="url(#sc-center-fill)"
+          className="animate-results-glow"
+        />
+        <circle
+          cx={CX}
+          cy={CY}
+          r={CENTER_R}
+          fill="#060606"
+          stroke="rgba(255,255,255,0.55)"
+          strokeWidth="1.4"
+          filter="url(#sc-center-glow)"
+        />
+        <svg
+          x={CX - CLASH_SIZE / 2}
+          y={CY - CLASH_SIZE / 2}
+          width={CLASH_SIZE}
+          height={CLASH_SIZE}
+          viewBox="0 0 512 512"
+        >
+          <polygon points="80,180 240,256 80,332" fill="#ffffff" opacity="0.95" />
+          <polygon points="432,180 272,256 432,332" fill="#ffffff" opacity="0.5" />
+        </svg>
+
+        {/* Outer nodes — model providers */}
+        {nodes.map((n) => {
+          const provider = PROVIDERS[n.i];
+          if (!provider) return null;
+          return (
+            <g key={`sc-node-${n.i}`}>
+              <circle
+                cx={n.x}
+                cy={n.y}
+                r={NODE_R + 8}
+                fill="none"
+                stroke="rgba(255,255,255,0.08)"
+                strokeWidth="1"
+              />
+              <circle
+                cx={n.x}
+                cy={n.y}
+                r={NODE_R}
+                fill="#060606"
+                stroke="rgba(255,255,255,0.32)"
+                strokeWidth="1.2"
+              />
+              <g
+                transform={`translate(${n.x - PROVIDER_ICON_SIZE / 2} ${
+                  n.y - PROVIDER_ICON_SIZE / 2
+                })`}
+              >
+                {provider.render(PROVIDER_ICON_SIZE)}
+              </g>
+            </g>
+          );
+        })}
+
+        {/* Light streaks radiating outward */}
+        {paths.map((d, i) => (
+          <line
+            key={`sc-streak-${i}`}
+            x1="-7"
+            y1="0"
+            x2="7"
+            y2="0"
+            stroke="white"
+            strokeWidth="2.2"
+            strokeLinecap="round"
+            className="animate-light-streak"
+            style={{
+              offsetPath: `path('${d}')`,
+              animationDelay: `${(-(i / COUNT) * DURATION).toFixed(2)}s`,
+            }}
+          />
+        ))}
+      </svg>
+    </div>
+  );
+}
+
+const FEATURE_GLYPH_CLASS = "size-7 text-white/90 shrink-0";
+const featureStroke = {
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 1.4,
+} as const;
+
+function ArtifactsGlyph() {
+  return (
+    <svg viewBox="0 0 48 48" className={FEATURE_GLYPH_CLASS} {...featureStroke} aria-hidden>
+      <rect x="10" y="9" width="20" height="26" rx="1" opacity="0.55" />
+      <rect x="14" y="13" width="20" height="26" rx="1" opacity="0.8" />
+      <line x1="18" y1="20" x2="30" y2="20" opacity="0.6" />
+      <line x1="18" y1="25" x2="30" y2="25" opacity="0.6" />
+      <line x1="18" y1="30" x2="26" y2="30" opacity="0.6" />
+    </svg>
+  );
+}
+
+function RagGlyph() {
+  return (
+    <svg viewBox="0 0 48 48" className={FEATURE_GLYPH_CLASS} {...featureStroke} aria-hidden>
+      <circle cx="12" cy="14" r="3" />
+      <circle cx="12" cy="24" r="3" />
+      <circle cx="12" cy="34" r="3" />
+      <circle cx="36" cy="24" r="4.5" />
+      <line x1="15" y1="14" x2="33" y2="22" opacity="0.5" />
+      <line x1="15" y1="24" x2="31" y2="24" opacity="0.55" />
+      <line x1="15" y1="34" x2="33" y2="26" opacity="0.5" />
+    </svg>
+  );
+}
+
+function KeysGlyph() {
+  return (
+    <svg viewBox="0 0 48 48" className={FEATURE_GLYPH_CLASS} {...featureStroke} aria-hidden>
+      <path d="M 24 6 L 38 12 V 22 C 38 32 32 38 24 42 C 16 38 10 32 10 22 V 12 Z" />
+      <circle cx="24" cy="22" r="3.5" opacity="0.85" />
+      <line x1="24" y1="25.5" x2="24" y2="32" strokeWidth="1.6" opacity="0.85" />
+    </svg>
+  );
+}
+
+function TracingGlyph() {
+  return (
+    <svg viewBox="0 0 48 48" className={FEATURE_GLYPH_CLASS} {...featureStroke} aria-hidden>
+      <line x1="8" y1="12" x2="26" y2="12" />
+      <line x1="12" y1="20" x2="32" y2="20" />
+      <line x1="16" y1="28" x2="38" y2="28" />
+      <line x1="12" y1="36" x2="30" y2="36" />
+      <circle cx="26" cy="12" r="2" fill="currentColor" opacity="0.7" stroke="none" />
+      <circle cx="32" cy="20" r="2" fill="currentColor" opacity="0.9" stroke="none" />
+      <circle cx="38" cy="28" r="2" fill="currentColor" opacity="0.75" stroke="none" />
+      <circle cx="30" cy="36" r="2" fill="currentColor" opacity="0.6" stroke="none" />
+    </svg>
+  );
+}
+
+function KnowledgeGlyph() {
+  return (
+    <svg viewBox="0 0 48 48" className={FEATURE_GLYPH_CLASS} {...featureStroke} aria-hidden>
+      <path
+        d="M 24 10 C 18 10 12 11 8 13 V 37 C 12 35 18 34 24 34 C 30 34 36 35 40 37 V 13 C 36 11 30 10 24 10 Z"
+        opacity="0.85"
+      />
+      <line x1="24" y1="10" x2="24" y2="34" opacity="0.45" />
+      <line x1="12" y1="17" x2="20" y2="17" opacity="0.35" />
+      <line x1="12" y1="22" x2="20" y2="22" opacity="0.35" />
+      <line x1="28" y1="17" x2="36" y2="17" opacity="0.35" />
+      <line x1="28" y1="22" x2="36" y2="22" opacity="0.35" />
+    </svg>
+  );
+}
+
+function RegressionGlyph() {
+  return (
+    <svg viewBox="0 0 48 48" className={FEATURE_GLYPH_CLASS} {...featureStroke} aria-hidden>
+      <path d="M 40 24 A 16 16 0 1 1 13 13" />
+      <polyline points="13,6 13,13 20,13" strokeLinejoin="round" />
+      <path d="M 17 22 L 22 27 L 32 17" strokeWidth="1.7" />
+    </svg>
+  );
+}
+
+function CompareGlyph() {
+  return (
+    <svg viewBox="0 0 48 48" className={FEATURE_GLYPH_CLASS} {...featureStroke} aria-hidden>
+      <rect x="7" y="10" width="14" height="28" rx="1" opacity="0.85" />
+      <rect x="27" y="18" width="14" height="20" rx="1" opacity="0.7" />
+      <line x1="10" y1="16" x2="18" y2="16" opacity="0.5" />
+      <line x1="10" y1="22" x2="18" y2="22" opacity="0.5" />
+      <line x1="30" y1="24" x2="38" y2="24" opacity="0.5" />
+      <line x1="30" y1="30" x2="38" y2="30" opacity="0.5" />
+    </svg>
+  );
+}
+
+function CiCdGlyph() {
+  return (
+    <svg viewBox="0 0 48 48" className={FEATURE_GLYPH_CLASS} {...featureStroke} aria-hidden>
+      <circle cx="10" cy="24" r="4" />
+      <circle cx="24" cy="24" r="4" opacity="0.85" />
+      <circle cx="38" cy="24" r="4" />
+      <line x1="14" y1="24" x2="20" y2="24" opacity="0.6" />
+      <line x1="28" y1="24" x2="34" y2="24" opacity="0.6" />
+      <path d="M 24 14 V 10 A 2 2 0 0 0 22 8" opacity="0.45" />
+      <path d="M 24 34 V 38 A 2 2 0 0 1 26 40" opacity="0.45" />
+    </svg>
+  );
+}
+
+const LANDING_USE_CASES: Array<{
+  label: string;
+  brief: string;
+  verdict: string;
+}> = [
+  {
+    label: "Autonomous coding",
+    brief:
+      "Two of ten tests are red in server/auth. Ship a PR that makes them green without changing the test shapes, the public types, or the migration files.",
+    verdict: "6 models · 3 passed · winner claude-sonnet-4.6 · 4m12s",
+  },
+  {
+    label: "Deep research",
+    brief:
+      "Compare how three recent papers model RLHF reward hacking. Cite every claim with paper + section. No fabricated citations — we check.",
+    verdict: "6 models · 4 passed · winner gpt-5.1 · 2m47s",
+  },
+  {
+    label: "SQL & data",
+    brief:
+      "Find the three slowest queries in the last 24h that touch the orders table. Return SQL plus explain plan. Schema is attached; warehouse is real.",
+    verdict: "6 models · 5 passed · winner gemini-ultra-2 · 1m58s",
+  },
+  {
+    label: "Support",
+    brief:
+      "Customer charged twice for the same subscription. Refund the duplicate, not the original. Confirm the active sub survived and email the customer the outcome.",
+    verdict: "6 models · 2 passed · winner claude-sonnet-4.6 · 1m22s",
+  },
+  {
+    label: "SRE",
+    brief:
+      "p99 on /checkout jumped at 14:03 UTC. Logs, traces, and the last two deploys are attached. Localise the cause. Do not restart anything.",
+    verdict: "6 models · 3 passed · winner gpt-5.1 · 3m04s",
+  },
+  {
+    label: "Codebase Q&A",
+    brief:
+      "Where is the rate limiter applied to the /runs endpoint? Give file paths, line numbers, and the call chain. Files you cite must actually exist.",
+    verdict: "6 models · 4 passed · winner claude-opus-4.7 · 0m54s",
+  },
+];
+
+const LANDING_FEATURES: Array<{
+  label: string;
+  title: string;
+  body: string;
+  glyph: React.ReactNode;
+}> = [
+  {
+    label: "Artifacts",
+    title: "Every run is a paper trail.",
+    body:
+      "Logs, output files, scorecards, diffs, agent manifests — everything an agent produced, sealed per run, addressable by ID. Inspect in the UI, stream from the API, or pipe to your own storage.",
+    glyph: <ArtifactsGlyph />,
+  },
+  {
+    label: "RAG testing",
+    title: "Retrieval and generation, judged together.",
+    body:
+      "Feed your corpus. Watch what each model retrieved before it answered. Grounding, faithfulness, and citation coverage scored as first-class axes — not left as an afterthought of the answer.",
+    glyph: <RagGlyph />,
+  },
+  {
+    label: "Key security",
+    title: "The agent never sees your keys.",
+    body:
+      "API keys, DB creds, OAuth tokens live in a scoped secret vault. Tools inject them into the sandbox at call time — never into the prompt, never into the trace, never into the replay. The agent uses the capability; it doesn't know the secret.",
+    glyph: <KeysGlyph />,
+  },
+  {
+    label: "Tracing",
+    title: "Tracing like never before.",
+    body:
+      "OpenTelemetry-native. Every think, every tool call, every observation, every byte — with span trees, causal chains, per-step cost and latency. Not a transcript dump. A forensic record.",
+    glyph: <TracingGlyph />,
+  },
+  {
+    label: "Knowledge sources",
+    title: "Your docs, wired in.",
+    body:
+      "Attach PDFs, wikis, Notion, codebases, your own APIs. Agents query them through a shared retriever with provenance on every fact — so when a model cites something, you can see exactly where it came from.",
+    glyph: <KnowledgeGlyph />,
+  },
+  {
+    label: "Regression suites",
+    title: "Every failure becomes a test.",
+    body:
+      "When a model flunks, the failing trace freezes into a permanent regression. Next week's race replays it. The suite sharpens itself — by the time a new model arrives, it walks into a track paved by every mistake the last one made.",
+    glyph: <RegressionGlyph />,
+  },
+  {
+    label: "Comparison",
+    title: "Diff two races, side by side.",
+    body:
+      "Same challenge, new model, or same model with a new prompt. See exactly what moved: completion, cost, latency, tool trajectory, scorecard axes. No guessing which upgrade mattered.",
+    glyph: <CompareGlyph />,
+  },
+  {
+    label: "CI/CD",
+    title: "Gate the merge on the race.",
+    body:
+      "Trigger races from GitHub Actions, a webhook, or the CLI. Fail the build when your agent regresses on the scorecard you care about. Eval moves from a dashboard you visit to a check that blocks bad code.",
+    glyph: <CiCdGlyph />,
+  },
+];
+
+type MarkKind = "yes" | "partial" | "no";
+
+const COMPARISON_COLUMNS: Array<{
+  name: string;
+  tag: string;
+  highlight?: boolean;
+}> = [
+  { name: "AgentClash", tag: "agent eval", highlight: true },
+  { name: "Braintrust", tag: "prompt eval" },
+  { name: "LangSmith", tag: "prompt eval" },
+  { name: "Promptfoo", tag: "prompt eval" },
+  { name: "Langfuse", tag: "prompt eval" },
+  { name: "Arize Phoenix", tag: "prompt eval" },
+  { name: "OpenAI Evals", tag: "prompt eval" },
+];
+
+const COMPARISON_ROWS: Array<{
+  label: string;
+  sub: string;
+  cells: readonly MarkKind[];
+}> = [
+  {
+    label: "Multi-turn agent loops",
+    sub: "Think → tool → observe → repeat, for minutes, with a fresh environment. Not one prompt → one response.",
+    cells: ["yes", "partial", "partial", "no", "partial", "partial", "partial"],
+  },
+  {
+    label: "Sandboxed tool execution",
+    sub: "A fresh microVM per agent — real files, real shell, real network, real side effects.",
+    cells: ["yes", "no", "no", "no", "no", "no", "no"],
+  },
+  {
+    label: "Head-to-head concurrent race",
+    sub: "Every model runs the same task at the same time, on the same budget. No staggered runs, no warm caches.",
+    cells: ["yes", "no", "no", "no", "no", "no", "no"],
+  },
+  {
+    label: "Trajectory scoring",
+    sub: "Judges the path, not just the final answer — tool-choice efficiency, recovery from error, scope discipline.",
+    cells: ["yes", "partial", "partial", "no", "partial", "partial", "no"],
+  },
+  {
+    label: "Cross-provider tool-call normalisation",
+    sub: "One schema across OpenAI, Anthropic, Gemini, xAI, Mistral, OpenRouter. Errors classified, retries sane.",
+    cells: ["yes", "partial", "partial", "partial", "partial", "partial", "no"],
+  },
+  {
+    label: "Four-vantage composite verdict",
+    sub: "Deterministic + mathematic + behavioural + LLM, with consensus aggregation and weights you control.",
+    cells: ["yes", "partial", "partial", "partial", "partial", "partial", "partial"],
+  },
+  {
+    label: "Failures auto-promote to regression",
+    sub: "Flunked traces freeze into permanent tests and replay in every future race, by default.",
+    cells: ["yes", "partial", "partial", "partial", "partial", "partial", "no"],
+  },
+];
+
+export default function HomePage() {
+  const { user, loading: authLoading } = useAuth();
+
+  useEffect(() => {
+    (async () => {
+      const cal = await getCalApi();
+      cal("ui", {
+        theme: "dark",
+        styles: { branding: { brandColor: "#ffffff" } },
+        hideEventTypeDetails: false,
+        layout: "month_view",
+      });
+    })();
+  }, []);
+
+  return (
+    <main className="main min-h-screen flex flex-col">
+      {/* ── Header ──────────────────────────────────────────────── */}
+      <header className="px-5 sm:px-12 py-5 sm:py-6 border-b border-white/[0.06]">
+        <div className="mx-auto flex max-w-[1440px] items-center justify-between">
+          <Link
+            href="/v2"
+            className="inline-flex items-center gap-2.5 text-white/90"
+          >
+            <ClashMark className="size-6" />
+            <span className="font-[family-name:var(--font-display)] text-xl tracking-[-0.01em]">
+              AgentClash
+            </span>
+          </Link>
+          <nav className="flex items-center gap-0.5 sm:gap-2 text-xs">
+            <a
+              href="#features"
+              className="hidden sm:inline-flex px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"
+            >
+              Features
+            </a>
+            <Link
+              href="/docs"
+              className="inline-flex px-2.5 sm:px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"
+            >
+              Docs
+            </Link>
+            <Link
+              href="/blog"
+              className="hidden sm:inline-flex px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"
+            >
+              Blog
+            </Link>
+            <a
+              href="https://github.com/agentclash/agentclash"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="GitHub"
+              className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.03] px-2 sm:px-3 py-1.5 text-white/60 hover:text-white/85 hover:border-white/15 transition-colors"
+            >
+              <Star className="size-3.5" />
+              <span className="hidden sm:inline">GitHub</span>
+            </a>
+            {authLoading ? (
+              <span className="inline-flex h-[30px] w-[40px] sm:w-[88px] rounded-md border border-white/[0.08] bg-white/[0.04]" />
+            ) : user ? (
+              <Link
+                href="/dashboard"
+                aria-label="Dashboard"
+                className="inline-flex items-center gap-1.5 rounded-md bg-white px-2 sm:px-3 py-1.5 font-medium text-[#060606] hover:bg-white/90 transition-colors"
+              >
+                <span className="hidden sm:inline">Dashboard</span>
+                <ArrowRight className="size-3" />
+              </Link>
+            ) : (
+              <Link
+                href="/auth/login"
+                aria-label="Sign in"
+                className="inline-flex items-center gap-1.5 rounded-md border border-white/15 bg-white/[0.04] px-2 sm:px-3 py-1.5 text-white/75 hover:text-white hover:border-white/25 transition-colors"
+              >
+                <LogIn className="size-3.5" />
+                <span className="hidden sm:inline">Sign in</span>
+              </Link>
+            )}
+          </nav>
+        </div>
+      </header>
+
+      {/* ── Hero ────────────────────────────────────────────────── */}
+      <DottedSpotlight className="px-8 sm:px-12 pt-32 pb-20 sm:pt-44 sm:pb-28">
+        <div className="mx-auto max-w-[1440px] grid gap-16 md:grid-cols-[1.5fr_1fr] md:gap-20 items-center">
+          <div>
+            <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+              <span className="inline-block size-1 rounded-full bg-white/60" />
+              AI agent evaluation platform
+            </p>
+            <h1 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.04em] leading-[0.95] text-[clamp(3rem,7vw,7.5rem)] max-w-[16ch]">
+              Ship the right agent.
+              <br />
+              <span className="text-white/40">Not the loudest one.</span>
+            </h1>
+
+            <p className="mt-10 max-w-[50ch] text-lg sm:text-xl leading-[1.5] text-white/55">
+              AgentClash is the open-source agent eval engine. Race your
+              models head-to-head on real tasks — same challenge, same
+              tools, same time budget, live scoring. Wire into CI so the
+              build fails the moment an agent regresses.
+            </p>
+
+            <div className="mt-10 flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+              {user ? (
+                <>
+                  <Link
+                    href="/dashboard"
+                    className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
+                  >
+                    Go to dashboard
+                    <ArrowRight className="size-4" />
+                  </Link>
+                  <a
+                    href="https://github.com/agentclash/agentclash"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+                  >
+                    <Star className="size-4" />
+                    View on GitHub
+                  </a>
+                </>
+              ) : (
+                <>
+                  <DemoPopupButton className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors" />
+                  <Link
+                    href="/auth/login"
+                    className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+                  >
+                    Get started
+                    <ArrowRight className="size-4" />
+                  </Link>
+                  <a
+                    href="https://github.com/agentclash/agentclash"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center justify-center gap-2 rounded-md border border-white/[0.08] bg-white/[0.02] px-6 py-3 text-sm font-medium text-white/60 hover:text-white/90 hover:border-white/20 transition-colors"
+                  >
+                    <Star className="size-4" />
+                    GitHub
+                  </a>
+                </>
+              )}
+            </div>
+
+            {/* Quiet CLI install strip — serves the self-host audience without
+                shouting over the primary CTAs. */}
+            <div className="mt-8 inline-flex items-center gap-3 rounded-md border border-white/[0.06] bg-white/[0.02] px-4 py-2.5 font-[family-name:var(--font-mono)] text-[12px] text-white/55">
+              <span className="text-white/30 select-none">$</span>
+              <code className="text-white/85">npm i -g agentclash</code>
+              <span className="text-white/20">·</span>
+              <Link href="/v2/oss" className="text-white/45 hover:text-white/80 transition-colors">
+                self-host
+              </Link>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-center">
+            <div className="flex aspect-square w-full max-w-[260px] md:max-w-[520px] items-center justify-center mx-auto">
+              <ClashMark
+                animated
+                className="w-full max-w-[200px] md:max-w-[360px] aspect-square"
+              />
+            </div>
+          </div>
+        </div>
+      </DottedSpotlight>
+
+      {/* ── Feature · Replay ────────────────────────────────────── */}
+      <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+        <div className="mx-auto max-w-[1440px] grid gap-16 md:grid-cols-2 md:gap-20 items-center">
+          <div>
+            <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2.25rem,5vw,4.5rem)] max-w-[20ch]">
+              Scrub the replay. See exactly where it got stuck.
+            </h2>
+            <p className="mt-10 max-w-[48ch] text-lg leading-[1.6] text-white/55">
+              Every think, every tool call, every observation is captured.
+              Step back to the moment a model went sideways — the prompt
+              it saw, the output it produced, the state it worked from. No
+              more guessing why one model won and another flunked.
+            </p>
+          </div>
+          <div>
+            <LightFlowArrows />
+          </div>
+        </div>
+      </section>
+
+      {/* ── Providers ───────────────────────────────────────────── */}
+      <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+        <div className="mx-auto max-w-[1440px]">
+          <div className="flex flex-col gap-10 md:flex-row md:items-end md:justify-between md:gap-16">
+            <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2.5rem,6vw,5.5rem)] max-w-[20ch]">
+              Any model.
+              <br />
+              <span className="text-white/40">Any provider.</span>
+            </h2>
+            <p className="max-w-[42ch] text-base leading-[1.6] text-white/50">
+              Normalised tool-calls, normalised errors, same scoring rules.
+              First-class adapters for the providers below, plus OpenRouter
+              for the long tail — three hundred more models, no extra code.
+            </p>
+          </div>
+
+          <ul className="mt-20 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-px border-y border-white/[0.06] bg-white/[0.06]">
+            {PROVIDERS.map(({ name, render }, i) => (
+              <li
+                key={name}
+                className="group relative flex flex-col items-center justify-center gap-4 overflow-hidden bg-[#060606] py-14 transition-colors hover:bg-white/[0.02]"
+              >
+                <div
+                  aria-hidden
+                  className="animate-provider-glow pointer-events-none absolute left-1/2 top-[44%] size-32 -translate-x-1/2 -translate-y-1/2 rounded-full transition-opacity duration-500 group-hover:opacity-[0.8]"
+                  style={{
+                    background:
+                      "radial-gradient(circle, rgba(255,255,255,0.18), transparent 70%)",
+                    animationDelay: `${(-(i / PROVIDERS.length) * 9).toFixed(2)}s`,
+                  }}
+                />
+                <div className="relative opacity-90 transition-opacity group-hover:opacity-100">
+                  {render(40)}
+                </div>
+                <span className="relative text-sm text-white/55 transition-colors group-hover:text-white/85">
+                  {name}
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          <p className="mt-8 text-sm text-white/40">
+            Plus 300 more via OpenRouter. New first-class providers landing
+            every month.
+          </p>
+        </div>
+      </section>
+
+      {/* ── Sandbox ─────────────────────────────────────────────── */}
+      <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+        <div className="mx-auto max-w-[1440px] grid gap-16 md:grid-cols-2 md:gap-20 items-center">
+          <div>
+            <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2.25rem,5vw,4.5rem)] max-w-[20ch]">
+              A fresh microVM for every agent.
+            </h2>
+            <p className="mt-10 max-w-[48ch] text-lg leading-[1.6] text-white/60">
+              Each racer boots into its own Firecracker microVM — isolated
+              filesystem, isolated network, no shared kernel. When the race
+              ends, the sandbox is torn down. The next one spins up clean.
+            </p>
+            <p className="mt-6 max-w-[48ch] text-lg leading-[1.6] text-white/60">
+              That isolation isn&apos;t just safety. It&apos;s what makes
+              the race fair. No model gets a warm cache. No prompt leaks
+              between lanes. The only variable in the race is the model.
+            </p>
+            <p className="mt-10 max-w-[48ch] text-sm text-white/40">
+              Powered by{" "}
+              <a
+                href="https://e2b.dev"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-white/65 underline decoration-white/20 underline-offset-4 transition-colors hover:text-white/90 hover:decoration-white/40"
+              >
+                E2B
+              </a>
+              &nbsp;— the sandbox infrastructure behind AI products at
+              Perplexity, Hugging Face, and Groq.
+            </p>
+          </div>
+          <div>
+            <SandboxLanes />
+          </div>
+        </div>
+      </section>
+
+      {/* ── Tool use ────────────────────────────────────────────── */}
+      <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+        <div className="mx-auto max-w-[1440px] grid gap-16 md:grid-cols-2 md:gap-20 items-center">
+          <div>
+            <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2.25rem,5vw,4.5rem)] max-w-[20ch]">
+              Real tools. Real effects.
+            </h2>
+            <p className="mt-10 max-w-[50ch] text-lg leading-[1.6] text-white/60">
+              Agents race with the same primitives a developer uses —
+              file I/O, data queries, HTTP, shell, test runners. Real
+              commands, real sandboxed effects, not a transcript of
+              imagined tool calls.
+            </p>
+
+            <p className="mt-10 max-w-[54ch] text-base leading-[1.6] text-white/55">
+              <span className="text-white/80">Compose your own.</span>{" "}
+              Every challenge is a single YAML file you commit next to
+              your code — tools, policy, scoring, starting state, all
+              declarative. No SDK to vendor, no plugin to build.
+            </p>
+            <p className="mt-6 max-w-[54ch] text-base leading-[1.6] text-white/55">
+              <span className="text-white/80">Bring your own APIs.</span>{" "}
+              Internal services, auth-gated endpoints, custom SDKs wrap
+              as higher-level tools —{" "}
+              <code className="font-[family-name:var(--font-mono)] text-white/75">
+                inventory_lookup
+              </code>
+              ,{" "}
+              <code className="font-[family-name:var(--font-mono)] text-white/75">
+                migrate_db
+              </code>
+              , whatever your domain needs. Credentials inject at call
+              time from a scoped vault; the agent never sees them.
+            </p>
+            <p className="mt-6 max-w-[54ch] text-sm text-white/45">
+              Fine-grained policy per pack: allowed tool kinds, shell
+              access, network access, max calls per run. Benchmark under
+              tight constraints, or unlock full-power for dev races.
+            </p>
+          </div>
+          <div>
+            <ToolPalette />
+          </div>
+        </div>
+      </section>
+
+      {/* ── Scoring ─────────────────────────────────────────────── */}
+      <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+        <div className="mx-auto max-w-[1440px] grid gap-16 md:grid-cols-2 md:gap-20 items-center">
+          <div>
+            <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2.25rem,5vw,4.5rem)] max-w-[20ch]">
+              One number is a lie.
+            </h2>
+            <p className="mt-10 max-w-[50ch] text-lg leading-[1.6] text-white/60">
+              Every run is judged from four independent vantage points,
+              with consensus aggregation across multiple judge models.
+              One composite verdict per eval session. Weights you control.
+            </p>
+
+            <dl className="mt-10 grid gap-x-10 gap-y-5 sm:grid-cols-2">
+              <div>
+                <dt className="text-[15px] font-medium text-white/90">
+                  Deterministic
+                </dt>
+                <dd className="mt-1 text-[13px] leading-[1.55] text-white/50">
+                  exact, regex, JSON Schema, code execution, file-tree
+                  assertions.
+                </dd>
+              </div>
+              <div>
+                <dt className="text-[15px] font-medium text-white/90">
+                  Mathematic
+                </dt>
+                <dd className="mt-1 text-[13px] leading-[1.55] text-white/50">
+                  math equivalence, BLEU, ROUGE, ChrF, token F1, numeric
+                  tolerance.
+                </dd>
+              </div>
+              <div>
+                <dt className="text-[15px] font-medium text-white/90">
+                  Behavioural
+                </dt>
+                <dd className="mt-1 text-[13px] leading-[1.55] text-white/50">
+                  recovery, exploration, scope adherence, confidence
+                  calibration &middot; plus latency, cost, reliability.
+                </dd>
+              </div>
+              <div>
+                <dt className="text-[15px] font-medium text-white/90">
+                  LLM + aggregation
+                </dt>
+                <dd className="mt-1 text-[13px] leading-[1.55] text-white/50">
+                  rubric, assertion, reference, pairwise &middot; median,
+                  mean, majority-vote, unanimous consensus.
+                </dd>
+              </div>
+            </dl>
+
+            <p className="mt-10 max-w-[52ch] text-sm text-white/45">
+              Grounded in a decade of open evaluation research. We
+              didn&apos;t invent the primitives; we wired them together
+              so you can run them all in one eval session.
+            </p>
+            <p className="mt-4 text-sm text-white/40">
+              Combined weighted, binary, or hybrid-with-gates — tuned to
+              the bar you&apos;d ship against.
+            </p>
+          </div>
+          <div>
+            <ScoringPipeline />
+          </div>
+        </div>
+      </section>
+
+      {/* ── Feature · Regression tests ──────────────────────────── */}
+      <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+        <div className="mx-auto max-w-[1440px] grid gap-16 md:grid-cols-2 md:gap-20 items-center">
+          <div>
+            <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,4rem)]">
+              Failures become your regression suite.
+            </h2>
+            <div className="mt-10 space-y-6">
+              <p className="text-lg leading-[1.6] text-white/60">
+                When a model flunks a challenge, the failing trace is
+                frozen into a permanent test. Next week&apos;s race
+                replays it. The following month&apos;s does too.
+              </p>
+              <p className="text-lg leading-[1.6] text-white/60">
+                Your eval suite sharpens itself with use. By the time a
+                new model arrives, it walks into a track that was paved
+                by every mistake the last model made.
+              </p>
+            </div>
+          </div>
+          <div>
+            <FeedbackLoop />
+          </div>
+        </div>
+      </section>
+
+      {/* ── How it works ────────────────────────────────────────── */}
+      <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+        <div className="mx-auto max-w-[1440px]">
+          <div className="flex flex-col gap-10 md:flex-row md:items-end md:justify-between md:gap-16">
+            <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2.5rem,6vw,5.5rem)] max-w-[20ch]">
+              From challenge to scoreboard.
+            </h2>
+            <p className="max-w-[38ch] text-base leading-[1.6] text-white/50">
+              Set up a head-to-head race in under a minute. Watch a verdict
+              arrive in the time it takes to finish a coffee.
+            </p>
+          </div>
+
+          <div className="relative mt-24">
+            <div
+              className="hidden md:block pointer-events-none absolute left-0 right-0 top-[32px] border-t border-dashed border-white/10"
+              aria-hidden
+            />
+
+            <div
+              className="hidden md:block pointer-events-none absolute left-0 right-0 top-[30px] h-[4px] overflow-hidden"
+              aria-hidden
+            >
+              {[0, 1].map((i) => (
+                <div
+                  key={i}
+                  className="animate-steps-streak absolute top-[1px] h-[2px] w-12 rounded-full bg-white"
+                  style={{
+                    animationDelay: `${(-(i / 2) * 4).toFixed(2)}s`,
+                  }}
+                />
+              ))}
+            </div>
+
+            {/* Mobile vertical connector — dashed line + streaks running
+                top to bottom through the stacked step rings. */}
+            <div
+              className="md:hidden pointer-events-none absolute top-[32px] bottom-0 left-[31px] border-l border-dashed border-white/10"
+              aria-hidden
+            />
+            <div
+              className="md:hidden pointer-events-none absolute top-0 bottom-0 left-[30px] w-[4px] overflow-hidden"
+              aria-hidden
+            >
+              {[0, 1].map((i) => (
+                <div
+                  key={i}
+                  className="animate-steps-streak-vertical absolute left-[1px] w-[2px] h-12 rounded-full bg-white"
+                  style={{
+                    animationDelay: `${(-(i / 2) * 4).toFixed(2)}s`,
+                  }}
+                />
+              ))}
+            </div>
+
+            <ol className="relative grid gap-20 md:grid-cols-3 md:gap-14">
+              {[
+                {
+                  n: "01",
+                  title: "Pick a challenge",
+                  body:
+                    "Write your own or pull from the library. Real tasks — a broken auth server, a SQL bug, a spec to implement — not trivia.",
+                  glyph: <TargetGlyph />,
+                },
+                {
+                  n: "02",
+                  title: "Pick your models",
+                  body:
+                    "Line up six or eight contestants across providers. Same tool policy, same time budget, same starting state.",
+                  glyph: <LineupGlyph />,
+                },
+                {
+                  n: "03",
+                  title: "Watch them race",
+                  body:
+                    "Live scoring as they work. Composite metric across completion, speed, token efficiency, and tool strategy.",
+                  glyph: <TrackGlyph />,
+                },
+              ].map((step) => (
+                <li key={step.n} className="relative">
+                  <div className="relative z-10 inline-flex size-16 items-center justify-center rounded-full border border-white/15 bg-[#060606]">
+                    {step.glyph}
+                  </div>
+                  <p className="mt-10 font-[family-name:var(--font-display)] text-6xl leading-none tracking-[-0.03em] text-white/15">
+                    {step.n}
+                  </p>
+                  <h3 className="mt-4 font-[family-name:var(--font-display)] text-3xl sm:text-4xl tracking-[-0.02em] leading-[1.08] text-white/95">
+                    {step.title}
+                  </h3>
+                  <p className="mt-5 max-w-[34ch] text-base leading-[1.65] text-white/55">
+                    {step.body}
+                  </p>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Use cases ───────────────────────────────────────────── */}
+      <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+        <div className="mx-auto max-w-[1440px]">
+          <div className="flex flex-col gap-10 md:flex-row md:items-end md:justify-between md:gap-16">
+            <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2.5rem,6vw,5.5rem)] max-w-[20ch]">
+              What teams race here.
+            </h2>
+            <p className="max-w-[44ch] text-base leading-[1.6] text-white/50">
+              Every race starts with a brief. Six we&apos;ve run recently,
+              the same six models on each, the verdict underneath.
+            </p>
+          </div>
+
+          <ul className="mt-24 grid grid-cols-1 gap-px border-y border-white/[0.06] bg-white/[0.06] md:grid-cols-2">
+            {LANDING_USE_CASES.map((useCase, i) => (
+              <li
+                key={useCase.label}
+                className="group relative flex flex-col bg-[#060606] px-8 py-12 sm:px-10 sm:py-14 transition-colors hover:bg-white/[0.015]"
+              >
+                <div className="flex items-center justify-between gap-4">
+                  <p className="text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                    Brief · {useCase.label}
+                  </p>
+                  <span
+                    aria-hidden
+                    className="font-[family-name:var(--font-mono)] text-[11px] tracking-[0.18em] tabular-nums text-white/25"
+                  >
+                    {String(i + 1).padStart(2, "0")} / 06
+                  </span>
+                </div>
+
+                <p className="mt-10 font-[family-name:var(--font-mono)] text-[15px] sm:text-[16px] leading-[1.65] text-white/85">
+                  <span aria-hidden className="text-white/30">&gt;&nbsp;</span>
+                  {useCase.brief}
+                </p>
+
+                <div className="mt-auto pt-12">
+                  <div className="border-t border-white/[0.06] pt-5">
+                    <p className="text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] text-white/35">
+                      Verdict
+                    </p>
+                    <p className="mt-2 font-[family-name:var(--font-mono)] text-[13px] leading-[1.55] text-white/65">
+                      {useCase.verdict}
+                    </p>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+
+          <p className="mt-10 text-[12px] font-[family-name:var(--font-mono)] uppercase tracking-[0.18em] text-white/35">
+            Sample briefs. Not staged. Winners shift when you change
+            the challenge, the budget, or the models on the grid.
+          </p>
+        </div>
+      </section>
+
+      {/* ── Comparison ──────────────────────────────────────────── */}
+      <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+        <div className="mx-auto max-w-[1440px]">
+          <div className="flex flex-col gap-10 md:flex-row md:items-end md:justify-between md:gap-16">
+            <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2.5rem,6vw,5.5rem)] max-w-[20ch]">
+              They test prompts.
+              <br />
+              <span className="text-white/40">We race agents.</span>
+            </h2>
+            <p className="max-w-[46ch] text-base leading-[1.6] text-white/50">
+              The tools below are excellent at prompt engineering — scoring
+              text a model produces from a single call. AgentClash is built
+              for the next problem over: evaluating agents that take actions,
+              use tools, and run for minutes at a time in a real sandbox.
+            </p>
+          </div>
+
+          {/* Mobile: stacked per-capability cards */}
+          <div className="md:hidden mt-16 space-y-10">
+            {COMPARISON_ROWS.map((row) => (
+              <div
+                key={`m-${row.label}`}
+                className="border-b border-white/[0.08] pb-8 last:border-b-0"
+              >
+                <p className="text-[16px] font-medium text-white/90 leading-[1.35]">
+                  {row.label}
+                </p>
+                <p className="mt-2 text-[13px] leading-[1.55] text-white/40">
+                  {row.sub}
+                </p>
+                <dl className="mt-5 grid grid-cols-1 gap-0">
+                  {COMPARISON_COLUMNS.map((col, j) => (
+                    <div
+                      key={col.name}
+                      className={`flex items-center justify-between gap-4 border-b border-white/[0.05] py-2.5 last:border-b-0 ${
+                        col.highlight ? "bg-white/[0.025] -mx-3 px-3 rounded" : ""
+                      }`}
+                    >
+                      <div className="flex flex-col">
+                        <dt
+                          className={`text-[13px] ${
+                            col.highlight
+                              ? "text-white/95 font-medium"
+                              : "text-white/60"
+                          }`}
+                        >
+                          {col.name}
+                        </dt>
+                        <span
+                          className={`text-[9px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] ${
+                            col.highlight ? "text-white/45" : "text-white/25"
+                          }`}
+                        >
+                          {col.tag}
+                        </span>
+                      </div>
+                      <dd>
+                        <ComparisonMark
+                          kind={row.cells[j]}
+                          highlight={col.highlight}
+                        />
+                      </dd>
+                    </div>
+                  ))}
+                </dl>
+              </div>
+            ))}
+          </div>
+
+          {/* Desktop: full matrix */}
+          <div className="hidden md:block mt-20 -mx-8 sm:mx-0 overflow-x-auto">
+            <div className="min-w-[1040px] px-8 sm:px-0">
+              {/* Header row */}
+              <div className="grid grid-cols-[1.7fr_repeat(7,minmax(0,1fr))] border-b border-white/[0.12]">
+                <div className="pb-5 pr-4">
+                  <p className="text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.18em] text-white/35">
+                    Capability
+                  </p>
+                </div>
+                {COMPARISON_COLUMNS.map((col) => (
+                  <div
+                    key={col.name}
+                    className="flex flex-col items-center justify-end gap-1 pb-5 px-2"
+                  >
+                    <span
+                      className={`text-center leading-tight ${
+                        col.highlight
+                          ? "text-[13px] font-[family-name:var(--font-display)] tracking-[-0.01em] text-white/95"
+                          : "text-[12px] font-[family-name:var(--font-mono)] uppercase tracking-[0.16em] text-white/45"
+                      }`}
+                    >
+                      {col.name}
+                    </span>
+                    <span
+                      className={`text-[9px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] ${
+                        col.highlight ? "text-white/30" : "text-white/25"
+                      }`}
+                    >
+                      {col.tag}
+                    </span>
+                  </div>
+                ))}
+              </div>
+
+              {/* Rows */}
+              {COMPARISON_ROWS.map((row) => (
+                <div
+                  key={row.label}
+                  className="grid grid-cols-[1.7fr_repeat(7,minmax(0,1fr))] border-b border-white/[0.05] last:border-b-0"
+                >
+                  <div className="py-7 pr-6">
+                    <p className="text-[15px] text-white/85">{row.label}</p>
+                    <p className="mt-1.5 text-[12px] leading-[1.5] text-white/40">
+                      {row.sub}
+                    </p>
+                  </div>
+                  {row.cells.map((mark, j) => (
+                    <div
+                      key={j}
+                      className={`flex items-center justify-center py-7 px-2 ${
+                        j === 0 ? "bg-white/[0.025]" : ""
+                      }`}
+                    >
+                      <ComparisonMark kind={mark} highlight={j === 0} />
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <p className="mt-10 text-[12px] font-[family-name:var(--font-mono)] text-white/35">
+            <span className="text-white/60">●</span>&nbsp;&nbsp;supported
+            &nbsp;·&nbsp; <span className="text-white/45">◐</span>
+            &nbsp;&nbsp;partial &nbsp;·&nbsp;
+            <span className="text-white/30">—</span>&nbsp;&nbsp;not a core
+            capability
+          </p>
+        </div>
+      </section>
+
+      {/* ── Features · shipping more ────────────────────────────── */}
+      <section
+        id="features"
+        className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48 scroll-mt-24"
+      >
+        <div className="mx-auto max-w-[1440px]">
+          <div className="grid gap-16 md:grid-cols-[1.3fr_1fr] md:gap-20 items-center">
+            <div>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.04em] leading-[0.95] text-[clamp(2.75rem,6.5vw,6.5rem)] max-w-[18ch]">
+                We&apos;re shipping more
+                <br />
+                <span className="text-white/40">than you think.</span>
+              </h2>
+              <p className="mt-10 max-w-[48ch] text-lg sm:text-xl leading-[1.5] text-white/55">
+                The race engine is the visible part. Under the hood sit eight
+                capabilities most teams quietly want from an eval platform
+                but rarely get in one place. Trust us — or better, scroll.
+              </p>
+            </div>
+            <div>
+              <ShippingConstellation />
+            </div>
+          </div>
+
+          <ul className="mt-24 grid grid-cols-1 gap-px border-y border-white/[0.06] bg-white/[0.06] sm:grid-cols-2 lg:grid-cols-4">
+            {LANDING_FEATURES.map((feature) => (
+              <li
+                key={feature.label}
+                className="group relative flex flex-col bg-[#060606] px-8 py-12 transition-colors hover:bg-white/[0.015]"
+              >
+                <div className="inline-flex size-12 items-center justify-center rounded-full border border-white/[0.12] bg-white/[0.02] transition-colors group-hover:border-white/25">
+                  {feature.glyph}
+                </div>
+
+                <p className="mt-8 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] text-white/40">
+                  {feature.label}
+                </p>
+
+                <h3 className="mt-3 font-[family-name:var(--font-display)] text-2xl leading-[1.15] tracking-[-0.02em] text-white/95">
+                  {feature.title}
+                </h3>
+
+                <p className="mt-4 text-[14px] leading-[1.65] text-white/55">
+                  {feature.body}
+                </p>
+              </li>
+            ))}
+          </ul>
+
+          <p className="mt-10 text-sm text-white/40">
+            Want something that isn&apos;t here?{" "}
+            <a
+              href="https://github.com/agentclash/agentclash/issues/new"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-white/70 underline decoration-white/20 underline-offset-4 transition-colors hover:text-white hover:decoration-white/50"
+            >
+              Open an issue
+            </a>
+            . We read every one.
+          </p>
+        </div>
+      </section>
+
+      {/* ── Why we built this ───────────────────────────────────── */}
+      <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+        <div className="mx-auto max-w-[1440px]">
+          <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2.5rem,6vw,5.5rem)] max-w-[22ch]">
+            We got tired of being lied to.
+          </h2>
+
+          <p className="mt-24 font-[family-name:var(--font-display)] font-normal tracking-[-0.02em] leading-[1.1] text-[clamp(1.875rem,4.2vw,3.5rem)] text-white/90 max-w-[30ch]">
+            It passed every eval we had. It failed in week one.
+          </p>
+
+          <p className="mt-16 font-[family-name:var(--font-display)] font-normal tracking-[-0.02em] leading-[1.15] text-[clamp(1.625rem,3.2vw,2.75rem)] text-white/60 max-w-[34ch]">
+            None of the benchmarks had touched our task.
+          </p>
+
+          <p className="mt-24 font-[family-name:var(--font-display)] font-normal tracking-[-0.025em] leading-[1.05] text-[clamp(2.125rem,5vw,4.25rem)] text-white/95 max-w-[30ch]">
+            The only eval you can trust is the one you ran yourself —
+            your task, every model, at the same time.
+          </p>
+
+          <p className="mt-16 font-[family-name:var(--font-display)] font-normal tracking-[-0.02em] leading-[1.15] text-[clamp(1.625rem,3.2vw,2.75rem)] text-white/90 max-w-[24ch]">
+            AgentClash is that eval.
+          </p>
+
+          <p className="mt-24 max-w-[56ch] text-[15px] leading-[1.7] text-white/50">
+            Pick your task the way your product actually runs it. Six
+            models race, live, on the same inputs with the same tools.
+            Scored on what matters in production — correctness, cost,
+            latency, behaviour under pressure. When one fails, the failing
+            trace becomes a test. Every mistake ratchets the eval tighter.
+          </p>
+
+          <p className="mt-20 font-[family-name:var(--font-display)] font-normal tracking-[-0.025em] leading-[1.05] text-[clamp(1.875rem,4.5vw,3.5rem)] text-white/95 max-w-[26ch]">
+            Your task. Your models. Your scoreboard.
+          </p>
+        </div>
+      </section>
+
+      {/* ── Closing CTA ─────────────────────────────────────────── */}
+      <section className="border-t border-white/[0.06] px-8 sm:px-12 py-40 sm:py-56">
+        <div className="mx-auto max-w-[1440px] grid gap-16 md:grid-cols-2 md:gap-20 items-center">
+          <div>
+            <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.04em] leading-[0.95] text-[clamp(2.75rem,6vw,6rem)] max-w-[16ch]">
+              Stop guessing.
+              <br />
+              <span className="text-white/40">Start racing.</span>
+            </h2>
+            <div className="mt-10 flex flex-col sm:flex-row sm:flex-wrap gap-3">
+              {user ? (
+                <Link
+                  href="/dashboard"
+                  className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
+                >
+                  Go to dashboard
+                  <ArrowRight className="size-4" />
+                </Link>
+              ) : (
+                <>
+                  <DemoPopupButton className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors" />
+                  <Link
+                    href="/auth/login"
+                    className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+                  >
+                    Start your first race
+                    <ArrowRight className="size-4" />
+                  </Link>
+                </>
+              )}
+              <a
+                href="https://github.com/agentclash/agentclash"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/[0.08] bg-white/[0.02] px-7 py-3 text-sm font-medium text-white/60 hover:text-white/90 hover:border-white/20 transition-colors"
+              >
+                <Star className="size-4" />
+                Star on GitHub
+                <ExternalLink className="size-3.5 text-white/40" />
+              </a>
+            </div>
+            <div className="mt-12 max-w-[46ch] border-t border-white/[0.08] pt-8">
+              <p className="font-[family-name:var(--font-display)] text-xl sm:text-2xl tracking-[-0.015em] leading-[1.3] text-white/85">
+                An eval engine you can&apos;t audit isn&apos;t an eval
+                engine.
+              </p>
+              <p className="mt-3 text-sm text-white/45">
+                Open source. Read the code, fork it, self-host it.
+              </p>
+            </div>
+          </div>
+          <div>
+            <TransparentFrame />
+          </div>
+        </div>
+      </section>
+
+      {/* ── Footer ──────────────────────────────────────────────── */}
+      <footer className="mt-auto border-t border-white/[0.06] px-8 sm:px-12 py-10">
+        <div className="mx-auto max-w-[1440px] flex flex-wrap items-center justify-between gap-4 text-[11px] font-[family-name:var(--font-mono)] text-white/35">
+          <div className="flex items-center gap-6">
+            <span className="font-medium text-white/55">AgentClash</span>
+            <span className="text-white/40">Beta</span>
+          </div>
+          <div className="flex items-center gap-5">
+            <a href="#features" className="hover:text-white/70 transition-colors">
+              Features
+            </a>
+            <Link href="/blog" className="hover:text-white/70 transition-colors">
+              Blog
+            </Link>
+            <Link href="/team" className="hover:text-white/70 transition-colors">
+              Team
+            </Link>
+            <a
+              href="https://github.com/agentclash/agentclash"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-white/70 transition-colors"
+            >
+              GitHub
+            </a>
+          </div>
+        </div>
+      </footer>
+    </main>
+  );
+}

--- a/web/src/app/v2/layout.tsx
+++ b/web/src/app/v2/layout.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { CalEmbedInit } from "@/components/marketing/cal-embed-init";
+
+// Preview marketing tree. Kept out of the production index so it can't
+// compete with / for brand queries until it's promoted.
+export const metadata: Metadata = {
+  title: {
+    default: "AgentClash — Head-to-head AI agent evaluation & regression testing",
+    template: "%s — AgentClash",
+  },
+  description:
+    "AgentClash is the open-source AI agent evaluation platform. Race models head-to-head on real tasks with the same tools, same constraints, and live scoring. Wire into CI to catch regressions before you ship.",
+  keywords: [
+    "AI agent evaluation",
+    "agent evaluation platform",
+    "agent regression testing",
+    "LLM evaluation",
+    "multi-turn agent evaluation",
+    "head-to-head AI benchmarks",
+    "CI agent testing",
+    "agent eval CI/CD",
+    "self-hosted agent evaluation",
+    "RAG agent evaluation",
+    "coding agent benchmarking",
+    "Agent Clash",
+    "AgentClash",
+  ],
+  robots: {
+    index: false,
+    follow: true,
+    googleBot: { index: false, follow: true },
+  },
+  alternates: {
+    canonical: "/v2",
+  },
+};
+
+export default function V2Layout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <CalEmbedInit />
+      {children}
+    </>
+  );
+}

--- a/web/src/app/v2/methodology/page.tsx
+++ b/web/src/app/v2/methodology/page.tsx
@@ -1,0 +1,311 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { PageHeader } from "@/components/marketing/page-header";
+import { SplitSection } from "@/components/marketing/split-section";
+import { FeatureGrid } from "@/components/marketing/feature-grid";
+import { ClosingCTA } from "@/components/marketing/closing-cta";
+import { DemoButton } from "@/components/marketing/demo-button";
+import { CodeCard } from "@/components/marketing/code-card";
+import { FAQBlock } from "@/components/marketing/faq-block";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+
+const PATH = "/v2/methodology";
+
+export const metadata: Metadata = {
+  title: "Evaluation methodology — AgentClash",
+  description:
+    "Four vantages per verdict: correctness, cost, latency, behavior. Explicit rubrics, explicit sandbox guarantees, explicit non-determinism handling. No hidden magic in the scoring pipeline.",
+  alternates: { canonical: PATH },
+  openGraph: {
+    title: "AgentClash evaluation methodology",
+    description:
+      "Four-vantage verdicts, trajectory-signature scoring, and explicit non-determinism handling.",
+    url: PATH,
+  },
+};
+
+const FEATURES = [
+  {
+    label: "Correctness",
+    title: "Rubric or ground-truth.",
+    body: "Every challenge pack declares how correctness is judged: a YAML rubric scored by a judge model, a hand-written ground-truth checker, or a mix. The choice is in the repo — you can read it, fork it, and argue with it.",
+  },
+  {
+    label: "Cost",
+    title: "Token-accurate, provider-aware.",
+    body: "Cost is measured from the provider's billed token counts, not estimated from heuristics. Per-run figures include input, output, cached, and tool-use tokens, broken down by model so cost regressions are attributable.",
+  },
+  {
+    label: "Latency",
+    title: "p50 and p95 wall-clock in sandbox.",
+    body: "Wall-clock from the first tool call to the terminal event, measured inside the sandbox so network variance between you and our control plane doesn't pollute the number. Distributions, not averages.",
+  },
+  {
+    label: "Behavior",
+    title: "Plan adherence and termination.",
+    body: "The trajectory scorer looks at plan adherence, tool-loop detection, self-correction patterns, and termination reason. A passing correctness score on a looping agent still fails behavior — and that shows up in the verdict.",
+  },
+  {
+    label: "Non-determinism",
+    title: "N-run cohorts, distributional.",
+    body: "Single runs are noise. Every race in a cohort is rerun N times with fresh seeds and sandbox state. The verdict is a distribution — you see pass rate, variance, and outliers rather than a single coin flip.",
+  },
+  {
+    label: "Transparency",
+    title: "Scorers are readable Go.",
+    body: "Every scorer lives as plain Go in the open-source repo. No binary blobs, no proprietary model weights gating your scores. If you disagree with how something is measured, you can fork the scorer and pin your own.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: "Who authors the rubrics?",
+    answer:
+      "You do. A challenge pack ships with a YAML rubric (or a ground-truth checker, or both), and the rubric is part of the pack repo — reviewable, versioned, and diffable. When we help design partners author their first pack, we draft it together on a call and hand you the editable file.",
+  },
+  {
+    question: "Are scorers deterministic?",
+    answer:
+      "Heuristic scorers (cost, latency, trajectory signature, termination reason) are fully deterministic — identical inputs yield identical scores. Judge-model scorers are non-deterministic by construction, which is why cohorts run N times and the verdict is reported as a distribution with variance, not a single number.",
+  },
+  {
+    question: "Agent-as-scorer or hand-written checks?",
+    answer:
+      "Both, and you pick per challenge pack. Judge-model scoring is the right tool when the answer space is open-ended (summaries, plans, code explanations). Hand-written checks are the right tool when the answer is testable (unit tests passing, a file created with specific contents). You can combine them — rubric score gated by a ground-truth precondition is a common pattern.",
+  },
+  {
+    question: "How is cost measured?",
+    answer:
+      "We read billed token counts from each provider response (input, output, cached tokens, and tool-use tokens where the provider breaks them out) and price them at the model's published rate. The resulting cost is attributable per step, per tool call, and per model — not a single aggregate at the end of the run.",
+  },
+  {
+    question: "Why trajectory signatures instead of output matching?",
+    answer:
+      "Model wording drifts between versions in ways that don't matter for behavior — a new model says the same thing differently. Signatures (the sequence of tools used, the plan shape, the termination reason) stay stable across those shifts, so your assertions still mean what you wrote them to mean six months later.",
+  },
+];
+
+export default function MethodologyPage() {
+  return (
+    <>
+      <JsonLd
+        id="ld-methodology-product"
+        data={productSchema({
+          name: "AgentClash — evaluation methodology",
+          description:
+            "Four-vantage verdicts (correctness, cost, latency, behavior) with explicit rubric authorship, sandbox guarantees, and non-determinism handling.",
+          url: PATH,
+        })}
+      />
+      <JsonLd
+        id="ld-methodology-breadcrumbs"
+        data={breadcrumbSchema([
+          { name: "Home", url: "/v2" },
+          { name: "Methodology", url: PATH },
+        ])}
+      />
+      <MarketingShell>
+        <PageHeader
+          breadcrumbs={[
+            { label: "Home", href: "/v2" },
+            { label: "Methodology" },
+          ]}
+          eyebrow="Evaluation methodology"
+          title={
+            <>
+              How we score.
+              <br />
+              <span className="text-white/40">On purpose.</span>
+            </>
+          }
+          subtitle={
+            <>
+              Four vantages — correctness, cost, latency, behavior — on
+              every race. Explicit rubric authorship, explicit sandbox
+              guarantees, explicit non-determinism handling. No hidden
+              magic in the scoring pipeline; every scorer is readable Go
+              you can fork.
+            </>
+          }
+          cta={
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+              <DemoButton label="Walk the rubric with us" />
+              <Link
+                href="/v2/platform/regression-testing"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+              >
+                Regression testing
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
+          }
+          aside={
+            <CodeCard
+              title="Verdict shape"
+              code={`verdict:
+  correctness:  0.82  (rubric: rag-qa.yaml)
+  cost:         $0.014 / run
+  latency:      p50 4.1s · p95 11.3s
+  behavior:     plan-adherent · terminated:success
+cohort:
+  runs:         25
+  pass_rate:    0.76
+  variance:     σ = 0.09`}
+            />
+          }
+        />
+
+        <SplitSection
+          eyebrow="The four-vantage verdict"
+          title={
+            <>
+              One number is a lie.
+              <br />
+              <span className="text-white/40">Four numbers are a verdict.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                Collapsing agent performance into a single leaderboard
+                number throws away the signal you actually need to ship.
+                An agent that scores 90% on correctness at ten times the
+                cost of the baseline is a regression, not a win.
+              </p>
+              <p className="mt-4">
+                Every AgentClash verdict carries correctness, cost,
+                latency, and behavior side by side. You can gate on any
+                one of them, or compose a pass criterion across all four.
+                The raw numbers stay attached to the run so you can argue
+                about them later.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="A rendered verdict"
+              code={`$ agentclash run show run_01H...
+
+  agent:         claude-4.6-sonnet
+  pack:          rag-qa-hard
+  correctness:   0.82  ✓ (threshold 0.75)
+  cost:          $0.014 ✓ (budget $0.05)
+  latency p95:   11.3s  ✓ (budget 15s)
+  behavior:      ✓ plan-adherent
+                 ✓ no-loops
+                 ✓ terminated:success
+
+  verdict:       ✓ pass`}
+            />
+          }
+        />
+
+        <SplitSection
+          reverse
+          eyebrow="Why rubrics beat string-match"
+          title={
+            <>
+              Assertions that survive
+              <br />
+              <span className="text-white/40">a model bump.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                A rubric spells out what makes an answer correct — the
+                facts it must contain, the reasoning steps it must take,
+                the errors it must avoid — in YAML your team writes and
+                reviews. That&apos;s a durable specification.
+              </p>
+              <p className="mt-4">
+                String-matching a reference answer breaks the first time a
+                new model says the same thing differently. Rubric scoring,
+                paired with trajectory signatures for behavior, holds up
+                across model swaps — which is the whole point of having a
+                regression suite.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="rag-qa.yaml"
+              code={`# packs/rag-qa-hard/rubric.yaml
+rubric:
+  must_include:
+    - cites source document
+    - names the customer tier
+  must_avoid:
+    - hallucinated policy numbers
+    - refusal on in-scope question
+  scoring:
+    judge: gpt-5-mini
+    scale: 0-1
+    rationale_required: true
+behavior:
+  expected_tools: [search, fetch]
+  terminated: success
+  max_tool_calls: 8`}
+            />
+          }
+        />
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Scoring pipeline
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                Six parts you can read, fork, and argue with.
+              </h2>
+            </div>
+            <div className="mt-20">
+              <FeatureGrid features={FEATURES} columns={3} />
+            </div>
+          </div>
+        </section>
+
+        <FAQBlock items={FAQ_ITEMS} schemaId="ld-methodology-faq" />
+
+        <ClosingCTA
+          title={
+            <>
+              Bring us a case
+              <br />
+              <span className="text-white/40">you can&apos;t score.</span>
+            </>
+          }
+          body={
+            <p>
+              We&apos;ll walk your actual task through the scoring
+              pipeline on a 30-minute call — rubric draft, trajectory
+              signature, cohort plan. If it doesn&apos;t fit, we&apos;ll
+              say so.
+            </p>
+          }
+        >
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+            <DemoButton
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
+            />
+            <Link
+              href="/v2/platform/regression-testing"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+            >
+              Regression testing
+              <ArrowRight className="size-4" />
+            </Link>
+          </div>
+        </ClosingCTA>
+      </MarketingShell>
+    </>
+  );
+}

--- a/web/src/app/v2/oss/page.tsx
+++ b/web/src/app/v2/oss/page.tsx
@@ -1,0 +1,342 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight, ExternalLink, Star } from "lucide-react";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { PageHeader } from "@/components/marketing/page-header";
+import { SplitSection } from "@/components/marketing/split-section";
+import { FeatureGrid } from "@/components/marketing/feature-grid";
+import { ClosingCTA } from "@/components/marketing/closing-cta";
+import { CodeCard } from "@/components/marketing/code-card";
+import { DemoButton } from "@/components/marketing/demo-button";
+import { FAQBlock } from "@/components/marketing/faq-block";
+import { JsonLd, breadcrumbSchema, productSchema } from "@/components/marketing/json-ld";
+
+const PATH = "/v2/oss";
+
+export const metadata: Metadata = {
+  title: "Open-source agent evaluation — self-host AgentClash",
+  description:
+    "AgentClash is open source under FSL-1.1-MIT. Install the CLI in seconds, self-host the race engine on your own infra, and read every line of the scoring pipeline. No vendor lock-in.",
+  alternates: { canonical: PATH },
+  openGraph: {
+    title: "Open-source agent evaluation — self-host AgentClash",
+    description:
+      "Install the CLI, self-host the race engine, read the scoring pipeline. AgentClash is open source under FSL-1.1-MIT.",
+    url: PATH,
+  },
+};
+
+const FEATURES = [
+  {
+    label: "Self-host",
+    title: "Run the whole race engine on your infra.",
+    body: "Go API server, Temporal worker, Postgres, optional E2B sandboxes. One docker-compose, or deploy as you'd deploy any Go service. No phone-home, no feature flags locked behind cloud.",
+  },
+  {
+    label: "CLI",
+    title: "agentclash — one binary, every channel.",
+    body: "Ships via npm, Homebrew, Winget, and POSIX/PowerShell install scripts from a single GoReleaser build. Authenticate, trigger races, stream live logs, gate CI.",
+  },
+  {
+    label: "FSL-1.1-MIT",
+    title: "Open source with a two-year clock.",
+    body: "Read the code, fork it, patch it, ship it. FSL becomes MIT two years after each release — durable open source without racing to the bottom on competing managed offerings.",
+  },
+  {
+    label: "Providers",
+    title: "Swap any model, bring any sandbox.",
+    body: "First-class adapters for OpenAI, Anthropic, Gemini, xAI, Mistral, and OpenRouter's long tail. Sandbox is an interface — E2B today, plug your own tomorrow.",
+  },
+  {
+    label: "Docs",
+    title: "Architecture notes that aren't marketing.",
+    body: "The docs ship with a full architecture overview: two-plane split, Temporal workflow hierarchy, event model, provider router, scoring pipeline. Written for people who read code.",
+  },
+  {
+    label: "AI-friendly",
+    title: "llms.txt out of the box.",
+    body: "Every doc page has a markdown mirror. llms.txt and llms-full.txt expose the full corpus so coding agents can answer real integration questions without hallucinating.",
+  },
+];
+
+const INSTALL_SNIPPETS: Array<{ title: string; language: string; code: string }> = [
+  {
+    title: "npm",
+    language: "shell",
+    code: "npm i -g agentclash\nagentclash auth login --device\nagentclash run create --follow",
+  },
+  {
+    title: "Homebrew",
+    language: "shell",
+    code: "brew install agentclash/tap/agentclash\nagentclash auth login --device\nagentclash run create --follow",
+  },
+  {
+    title: "Self-host",
+    language: "shell",
+    code: "git clone https://github.com/agentclash/agentclash\ncd agentclash\n./scripts/dev/start-local-stack.sh",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: "Is AgentClash actually open source?",
+    answer:
+      "Yes. The entire race engine — API server, Temporal worker, CLI, provider router, sandbox abstraction, scoring pipeline, and frontend — is public on GitHub under FSL-1.1-MIT, which converts to MIT two years after each release.",
+  },
+  {
+    question: "Do I need the cloud to use AgentClash?",
+    answer:
+      "No. You can run AgentClash entirely on your own infrastructure using docker-compose or any Go-friendly deployment target. The managed cloud exists for teams who want a hosted control plane without operating Temporal and Postgres themselves.",
+  },
+  {
+    question: "What does the CLI need to work?",
+    answer:
+      "An AgentClash API URL (your self-hosted server or the managed cloud) and an auth token. The CLI supports device-flow login, env vars for CI, and per-workspace configuration.",
+  },
+  {
+    question: "Which providers are supported?",
+    answer:
+      "First-class adapters for OpenAI, Anthropic, Google Gemini, xAI, Mistral, and OpenRouter (which gives you the long tail of 300+ models). Adding a new provider means implementing a small Client interface.",
+  },
+  {
+    question: "Why FSL-1.1-MIT instead of MIT or Apache-2.0?",
+    answer:
+      "FSL (Functional Source License) gives AgentClash maintainers two years of commercial protection before each release reverts to MIT. It's open source in every way that matters for users — read the code, run it, modify it — with guardrails against a competing vendor repackaging it verbatim.",
+  },
+  {
+    question: "How do I contribute?",
+    answer:
+      "Start with the Codebase Tour in the docs, open an issue describing your change, and submit a PR. The monorepo has a Go backend (API + Temporal worker), a Go CLI, and a Next.js frontend. Every CI run is public.",
+  },
+];
+
+export default function OSSPage() {
+  return (
+    <>
+      <JsonLd
+        id="ld-oss-product"
+        data={productSchema({
+          name: "AgentClash (open source)",
+          description:
+            "Open-source AI agent evaluation platform. Self-host the full race engine, or install the CLI and connect to the managed cloud.",
+          url: PATH,
+        })}
+      />
+      <JsonLd
+        id="ld-oss-breadcrumbs"
+        data={breadcrumbSchema([
+          { name: "Home", url: "/v2" },
+          { name: "Open source", url: PATH },
+        ])}
+      />
+      <MarketingShell>
+        <PageHeader
+          breadcrumbs={[
+            { label: "Home", href: "/v2" },
+            { label: "Open source" },
+          ]}
+          eyebrow="Open source · FSL-1.1-MIT"
+          title={
+            <>
+              An eval engine you can actually{" "}
+              <span className="text-white/40">audit.</span>
+            </>
+          }
+          subtitle={
+            <>
+              AgentClash is open-source AI agent evaluation infrastructure.
+              Star the repo, run the whole stack on your infra, or install
+              the CLI in seconds and connect to the managed cloud. No
+              vendor lock-in. No black-box scoring.
+            </>
+          }
+          cta={
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+              <a
+                href="https://github.com/agentclash/agentclash"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
+              >
+                <Star className="size-4" />
+                Star on GitHub
+                <ExternalLink className="size-3.5 text-black/40" />
+              </a>
+              <Link
+                href="/docs/getting-started/self-host"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+              >
+                Self-host quickstart
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
+          }
+          aside={
+            <CodeCard
+              title="Install"
+              code={`# Install the CLI
+npm i -g agentclash
+
+# Authenticate against a workspace
+agentclash auth login --device
+
+# Fire a race
+agentclash run create --follow`}
+            />
+          }
+        />
+
+        {/* Install paths */}
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-28 sm:py-40">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Install
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                One binary. Every channel.
+              </h2>
+              <p className="mt-8 text-lg leading-[1.6] text-white/55">
+                A single GoReleaser build feeds npm, Homebrew, Winget, and
+                POSIX/PowerShell install scripts — pick whichever matches
+                your runner.
+              </p>
+            </div>
+
+            <div className="mt-16 grid gap-6 md:grid-cols-3">
+              {INSTALL_SNIPPETS.map((snip) => (
+                <CodeCard
+                  key={snip.title}
+                  title={snip.title}
+                  language={snip.language}
+                  code={snip.code}
+                />
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Self-host vs managed */}
+        <SplitSection
+          eyebrow="Self-host or managed"
+          title={
+            <>
+              Bring your own infra. Or skip
+              <br />
+              <span className="text-white/40">that part entirely.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                Self-host when you want the scoring pipeline audited in
+                your own environment, when your challenge packs touch
+                sensitive data, or when you just enjoy running Temporal
+                clusters.
+              </p>
+              <p className="mt-4">
+                Use the managed cloud when you&apos;d rather focus on the
+                challenges themselves and let us run the durable
+                orchestration, sandbox provisioning, and replay archive.
+              </p>
+              <div className="mt-8 flex flex-col sm:flex-row gap-3">
+                <Link
+                  href="/v2/cloud"
+                  className="inline-flex items-center gap-2 text-[14px] text-white/80 hover:text-white border-b border-white/25 hover:border-white/60 transition-colors pb-1 w-fit"
+                >
+                  Managed cloud <ArrowRight className="size-3.5" />
+                </Link>
+                <Link
+                  href="/docs/architecture/overview"
+                  className="inline-flex items-center gap-2 text-[14px] text-white/60 hover:text-white/90 border-b border-white/15 hover:border-white/40 transition-colors pb-1 w-fit"
+                >
+                  Architecture overview <ArrowRight className="size-3.5" />
+                </Link>
+              </div>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="docker-compose up"
+              code={`# Clone and boot the full stack
+git clone https://github.com/agentclash/agentclash
+cd agentclash
+
+# Postgres, Temporal, API server, worker
+./scripts/dev/start-local-stack.sh
+
+# Health check
+curl http://localhost:8080/healthz`}
+            />
+          }
+        />
+
+        {/* What's in the box */}
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                What ships
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                Six pieces of real infrastructure.
+              </h2>
+            </div>
+            <div className="mt-20">
+              <FeatureGrid features={FEATURES} columns={3} />
+            </div>
+          </div>
+        </section>
+
+        <FAQBlock
+          eyebrow="FAQ"
+          title="Questions people actually ask."
+          items={FAQ_ITEMS}
+          schemaId="ld-oss-faq"
+        />
+
+        <ClosingCTA
+          title={
+            <>
+              Read the source.
+              <br />
+              <span className="text-white/40">Run the race.</span>
+            </>
+          }
+          body={
+            <p>
+              Star on GitHub to follow along, or fork it and race your own
+              models tonight.
+            </p>
+          }
+        >
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+            <a
+              href="https://github.com/agentclash/agentclash"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
+            >
+              <Star className="size-4" />
+              Star on GitHub
+              <ExternalLink className="size-3.5 text-black/40" />
+            </a>
+            <Link
+              href="/docs/getting-started/self-host"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+            >
+              Self-host quickstart
+              <ArrowRight className="size-4" />
+            </Link>
+            <DemoButton
+              label="Talk to a maintainer"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/[0.08] bg-white/[0.02] px-7 py-3 text-sm font-medium text-white/60 hover:text-white/90 hover:border-white/20 transition-colors"
+            />
+          </div>
+        </ClosingCTA>
+      </MarketingShell>
+    </>
+  );
+}

--- a/web/src/app/v2/page.tsx
+++ b/web/src/app/v2/page.tsx
@@ -1,0 +1,69 @@
+import type { Metadata } from "next";
+import HomePage from "./landing";
+import { JsonLd } from "@/components/marketing/json-ld";
+
+const SITE_URL = "https://agentclash.dev";
+
+const softwareApplicationSchema = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: "AgentClash",
+  alternateName: "Agent Clash",
+  applicationCategory: "DeveloperApplication",
+  applicationSubCategory: "AI agent evaluation platform",
+  operatingSystem: "Web, macOS, Linux, Windows",
+  description:
+    "Open-source AI agent evaluation platform. Race models head-to-head on real tasks with the same tools, same constraints, and live scoring. Wire into CI to catch regressions before you ship.",
+  url: `${SITE_URL}/v2`,
+  softwareVersion: "beta",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+  },
+};
+
+const organizationSchema = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "AgentClash",
+  alternateName: "Agent Clash",
+  url: SITE_URL,
+  logo: `${SITE_URL}/icon.svg`,
+  sameAs: [
+    "https://github.com/agentclash/agentclash",
+    "https://www.npmjs.com/package/agentclash",
+  ],
+};
+
+export const metadata: Metadata = {
+  title: "AgentClash — Head-to-head AI agent evaluation & regression testing",
+  description:
+    "Open-source AI agent evaluation platform. Race models head-to-head on real tasks — same tools, same constraints, live scoring. Wire into CI to catch regressions before you ship.",
+  openGraph: {
+    title: "AgentClash — AI agent evaluation platform",
+    description:
+      "Race AI agents head-to-head on real tasks. Open source. CI-native. Regressions never ship again.",
+    url: `${SITE_URL}/v2`,
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "AgentClash — AI agent evaluation platform",
+    description:
+      "Race AI agents head-to-head on real tasks. Open source. CI-native. Regressions never ship again.",
+  },
+  alternates: {
+    canonical: "/v2",
+  },
+};
+
+export default function V2RootPage() {
+  return (
+    <>
+      <JsonLd id="ld-software-application" data={softwareApplicationSchema} />
+      <JsonLd id="ld-organization" data={organizationSchema} />
+      <HomePage />
+    </>
+  );
+}

--- a/web/src/app/v2/platform/agent-evaluation/page.tsx
+++ b/web/src/app/v2/platform/agent-evaluation/page.tsx
@@ -1,0 +1,283 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { PageHeader } from "@/components/marketing/page-header";
+import { SplitSection } from "@/components/marketing/split-section";
+import { FeatureGrid } from "@/components/marketing/feature-grid";
+import { ClosingCTA } from "@/components/marketing/closing-cta";
+import { DemoButton } from "@/components/marketing/demo-button";
+import { CodeCard } from "@/components/marketing/code-card";
+import { FAQBlock } from "@/components/marketing/faq-block";
+import { ProviderStrip } from "@/components/marketing/provider-strip";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+
+const PATH = "/v2/platform/agent-evaluation";
+
+export const metadata: Metadata = {
+  title: "AI agent evaluation platform",
+  description:
+    "AgentClash is the open-source AI agent evaluation platform. Race agents head-to-head on real tasks with the same tools, same time budget, live scoring, and CI regression gates.",
+  alternates: { canonical: PATH },
+  openGraph: {
+    title: "AI agent evaluation platform — AgentClash",
+    description:
+      "Race AI agents head-to-head on real tasks. Same tools, same constraints, live scoring, CI regression gates.",
+    url: PATH,
+  },
+};
+
+const FEATURES = [
+  {
+    label: "Live",
+    title: "Watch every race in real time.",
+    body: "WebSocket event stream. Every think, tool call, observation, and scoring update appears the instant it happens — no batch post-processing.",
+  },
+  {
+    label: "Replay",
+    title: "Scrub back to where it broke.",
+    body: "Full trace replay of prompts, outputs, and sandbox state. Step back to the moment a model went sideways and see exactly what it saw.",
+  },
+  {
+    label: "Multi-vantage",
+    title: "Correctness, cost, latency, behaviour.",
+    body: "Verdicts score four vantage points on the same race so you can ship the model that wins on what your product actually optimizes for.",
+  },
+  {
+    label: "Tool-use",
+    title: "Real tools in a real sandbox.",
+    body: "Isolated ephemeral E2B environments with pinned tools, network policy, secrets — not mocked function stubs that let everyone pretend to pass.",
+  },
+  {
+    label: "Providers",
+    title: "Every major provider, normalized.",
+    body: "OpenAI, Anthropic, Gemini, xAI, Mistral, OpenRouter. Tool-call shapes and failure codes normalized so scoring is apples-to-apples.",
+  },
+  {
+    label: "CI",
+    title: "Block the merge, not the human.",
+    body: "Fire races from CI with one CLI command. Verdicts post as GitHub checks so regressions show up in the review, not in prod.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: "What is AI agent evaluation?",
+    answer:
+      "AI agent evaluation is the practice of running agents against realistic multi-step tasks — tool calls, sandbox actions, long-horizon reasoning — and scoring them on correctness, cost, latency, and behavior. It's distinct from prompt evaluation, which scores single responses from a single model.",
+  },
+  {
+    question: "How is AgentClash different from LangSmith or Braintrust?",
+    answer:
+      "LangSmith, Braintrust, Promptfoo, and Langfuse are excellent at prompt evaluation — scoring single-call outputs against references. AgentClash is built for the next problem over: agents that take actions, use tools, run for minutes at a time, and can regress in ways a single-turn eval can't catch.",
+  },
+  {
+    question: "What tasks should I race agents on?",
+    answer:
+      "Whatever your product actually does. Code review, SQL generation, customer support tickets, SRE runbooks, deep research. Challenge packs are small declarative bundles that describe the task, the tools, the scoring rubric, and the verdict pipeline.",
+  },
+  {
+    question: "Do I need to write my own scorer?",
+    answer:
+      "No. AgentClash ships with reference scorers for correctness, cost, latency, and behavior. You can drop in custom scorers as tool-calling agents themselves — useful when \"correct\" needs domain-specific judgment.",
+  },
+  {
+    question: "Is this open source?",
+    answer:
+      "Yes, under FSL-1.1-MIT. You can read the full scoring pipeline, fork it, and self-host the entire race engine. The managed cloud is an option, not a requirement.",
+  },
+];
+
+export default function AgentEvaluationPage() {
+  return (
+    <>
+      <JsonLd
+        id="ld-ae-product"
+        data={productSchema({
+          name: "AgentClash — AI agent evaluation platform",
+          description:
+            "Open-source AI agent evaluation platform. Race agents head-to-head on real tasks with the same tools, same constraints, live scoring, and CI regression gates.",
+          url: PATH,
+        })}
+      />
+      <JsonLd
+        id="ld-ae-breadcrumbs"
+        data={breadcrumbSchema([
+          { name: "Home", url: "/v2" },
+          { name: "Platform", url: "/v2/platform/agent-evaluation" },
+          { name: "Agent evaluation", url: PATH },
+        ])}
+      />
+      <MarketingShell>
+        <PageHeader
+          breadcrumbs={[
+            { label: "Home", href: "/v2" },
+            { label: "Platform" },
+            { label: "Agent evaluation" },
+          ]}
+          eyebrow="AI agent evaluation platform"
+          title={
+            <>
+              Agent eval that scores
+              <br />
+              <span className="text-white/40">the whole trajectory.</span>
+            </>
+          }
+          subtitle={
+            <>
+              AgentClash is the open-source AI agent evaluation platform.
+              Race models head-to-head on real multi-turn tasks — same
+              tools, same sandbox, same time budget — and gate CI on
+              verdicts that actually reflect production.
+            </>
+          }
+          cta={
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+              <DemoButton />
+              <Link
+                href="/v2/oss"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+              >
+                Self-host it
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
+          }
+          aside={
+            <CodeCard
+              title="A race in one file"
+              code={`# challenges/rag-qa.yaml
+name: rag-qa-short
+version: 1
+agents: [gpt-5, claude-4.5, gemini-2.5]
+tools: [search, fetch, quote]
+time_budget: 120s
+verdict:
+  - correctness: rubric
+  - cost: usd
+  - latency: p95
+  - behaviour: trajectory`}
+            />
+          }
+        />
+
+        <SplitSection
+          eyebrow="Agent eval vs. prompt eval"
+          title={
+            <>
+              Prompt eval scores text.
+              <br />
+              <span className="text-white/40">Agent eval scores outcomes.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                A single-turn prompt eval can tell you that a model said
+                the right thing once. It can&apos;t tell you whether an
+                agent followed a plan across eight tool calls, stayed
+                within a budget, handled a flaky search API, and
+                terminated correctly when the task was done.
+              </p>
+              <p className="mt-4">
+                AgentClash races whole trajectories. Each agent runs a
+                full multi-step task in an isolated sandbox against the
+                same tools — and we score what actually happened, not
+                what the model claimed it would do.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Trajectory, not transcript"
+              code={`think → tool:search("q") → observe
+      ↳ tool:fetch(doc-42)     → observe
+      ↳ tool:quote(p.7)        → observe
+      → answer
+
+verdict:
+  correctness  9.2 / 10
+  cost         $0.018
+  latency      12.4 s
+  behaviour    on-plan, no loops`}
+            />
+          }
+        />
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-40">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="grid gap-10 md:grid-cols-2 md:items-end md:gap-16">
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                Any model. Any provider.
+              </h2>
+              <p className="max-w-[42ch] text-[15px] leading-[1.65] text-white/55">
+                First-class adapters for every major provider plus
+                OpenRouter for the long tail — swap models without
+                touching your challenge packs.
+              </p>
+            </div>
+            <div className="mt-16">
+              <ProviderStrip />
+            </div>
+          </div>
+        </section>
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Capabilities
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                Six things an agent eval platform should quietly do well.
+              </h2>
+            </div>
+            <div className="mt-20">
+              <FeatureGrid features={FEATURES} columns={3} />
+            </div>
+          </div>
+        </section>
+
+        <FAQBlock
+          title="Agent evaluation, answered."
+          items={FAQ_ITEMS}
+          schemaId="ld-ae-faq"
+        />
+
+        <ClosingCTA
+          title={
+            <>
+              Score the trajectory.
+              <br />
+              <span className="text-white/40">Ship the right agent.</span>
+            </>
+          }
+          body={
+            <p>
+              Book a 20-minute call and we&apos;ll race your hardest task
+              against the six models you were going to compare yourself.
+            </p>
+          }
+        >
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+            <DemoButton
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
+            />
+            <Link
+              href="/v2/oss"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+            >
+              Self-host for free
+              <ArrowRight className="size-4" />
+            </Link>
+          </div>
+        </ClosingCTA>
+      </MarketingShell>
+    </>
+  );
+}

--- a/web/src/app/v2/platform/ci-cd-gating/page.tsx
+++ b/web/src/app/v2/platform/ci-cd-gating/page.tsx
@@ -1,0 +1,251 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { PageHeader } from "@/components/marketing/page-header";
+import { SplitSection } from "@/components/marketing/split-section";
+import { FeatureGrid } from "@/components/marketing/feature-grid";
+import { ClosingCTA } from "@/components/marketing/closing-cta";
+import { DemoButton } from "@/components/marketing/demo-button";
+import { CodeCard } from "@/components/marketing/code-card";
+import { FAQBlock } from "@/components/marketing/faq-block";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+
+const PATH = "/v2/platform/ci-cd-gating";
+
+export const metadata: Metadata = {
+  title: "Agent evaluation in CI/CD",
+  description:
+    "Block merges when agents regress. AgentClash runs full races from GitHub Actions, posts verdicts as checks, and fails the build on correctness, cost, or latency regressions.",
+  alternates: { canonical: PATH },
+  openGraph: {
+    title: "AI agent evaluation in CI/CD — AgentClash",
+    description:
+      "Fire full agent races from CI. Block merges on regressions. Post verdicts as GitHub checks.",
+    url: PATH,
+  },
+};
+
+const FEATURES = [
+  {
+    label: "GitHub checks",
+    title: "Verdicts inline in the PR.",
+    body: "Passing races turn the check green. Failing ones link directly to the failing replay, the diff on the trajectory, and the specific assertion that broke.",
+  },
+  {
+    label: "Budget gates",
+    title: "Cost and latency regress too.",
+    body: "Block a PR that makes the agent twice as expensive or twice as slow — even when the correctness rubric would still pass.",
+  },
+  {
+    label: "Matrix",
+    title: "Race three models in parallel.",
+    body: "Concurrent races across GPT, Claude, Gemini — matrix the verdict grid so you can see which model the change actually improved.",
+  },
+  {
+    label: "Artifacts",
+    title: "Every race is an artifact.",
+    body: "Replays, trajectories, and verdicts are addressable by run ID. Attach them to the PR. Link them from your release notes.",
+  },
+  {
+    label: "Zero glue",
+    title: "One CLI, any runner.",
+    body: "GitHub Actions, GitLab CI, CircleCI, Buildkite, Jenkins — same `agentclash run create` command. No provider-specific plugins.",
+  },
+  {
+    label: "Cheap by default",
+    title: "Short budgets for the PR loop.",
+    body: "Tight default time budgets in CI mean races finish in under two minutes. Nightly suites can still run the heavy ones.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: "How does AgentClash run in CI/CD?",
+    answer:
+      "Install the CLI (npm i -g agentclash), set AGENTCLASH_TOKEN and AGENTCLASH_WORKSPACE as secrets, and run `agentclash run create` as a job step. Verdicts post as GitHub checks; the CLI exits non-zero when the run fails its assertions.",
+  },
+  {
+    question: "What does a verdict check look like?",
+    answer:
+      "A GitHub check named after the challenge pack with the overall verdict, a link to the replay, and per-vantage details (correctness, cost, latency, behaviour). Click-through goes to the trajectory viewer with the failing assertion highlighted.",
+  },
+  {
+    question: "Can I block merges on cost and latency, not just correctness?",
+    answer:
+      "Yes. Challenge pack verdicts can include budget assertions: cost ceiling, latency p95, trajectory length. If the agent gets more expensive or slower, the check fails even if the answer is still right.",
+  },
+  {
+    question: "Which CI providers are supported?",
+    answer:
+      "Any CI that can run a shell command. GitHub Actions is the best-supported because the CLI posts checks and comments via the GitHub token, but the same command runs fine on GitLab, CircleCI, Buildkite, Jenkins, or a cron box.",
+  },
+  {
+    question: "Can I race multiple models per PR?",
+    answer:
+      "Yes — that's the default. Challenge packs name the lineup, and the races run concurrently in the background. The check fails if *any* required agent regresses.",
+  },
+];
+
+export default function CICDGatingPage() {
+  return (
+    <>
+      <JsonLd
+        id="ld-cicd-product"
+        data={productSchema({
+          name: "AgentClash — CI/CD agent eval gating",
+          description:
+            "Fire AI agent races from CI. Block merges on correctness, cost, or latency regressions. Post verdicts as GitHub checks.",
+          url: PATH,
+        })}
+      />
+      <JsonLd
+        id="ld-cicd-breadcrumbs"
+        data={breadcrumbSchema([
+          { name: "Home", url: "/v2" },
+          { name: "Platform", url: "/v2/platform/agent-evaluation" },
+          { name: "CI/CD gating", url: PATH },
+        ])}
+      />
+      <MarketingShell>
+        <PageHeader
+          breadcrumbs={[
+            { label: "Home", href: "/v2" },
+            { label: "Platform" },
+            { label: "CI/CD gating" },
+          ]}
+          eyebrow="Agent eval in CI/CD"
+          title={
+            <>
+              Fail the build,
+              <br />
+              <span className="text-white/40">not the user.</span>
+            </>
+          }
+          subtitle={
+            <>
+              Drop the AgentClash CLI into any CI. Every PR fires a real
+              race in a real sandbox and posts a verdict back as a GitHub
+              check. Merges block when the agent regresses on
+              correctness, cost, or latency.
+            </>
+          }
+          cta={
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+              <DemoButton />
+              <Link
+                href="/docs/guides/interpret-results"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+              >
+                Interpret the verdict
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
+          }
+          aside={
+            <CodeCard
+              title=".github/workflows/agent.yml"
+              code={`- name: Race agents
+  env:
+    AGENTCLASH_TOKEN: \${{ secrets.AGENTCLASH_TOKEN }}
+    AGENTCLASH_WORKSPACE: \${{ secrets.AGENTCLASH_WORKSPACE }}
+  run: |
+    npm i -g agentclash
+    agentclash run create \\
+      --pack coding-agents \\
+      --agents gpt-5,claude-4.5 \\
+      --follow`}
+            />
+          }
+        />
+
+        <SplitSection
+          eyebrow="Verdict → check"
+          title={
+            <>
+              Regressions show up
+              <br />
+              <span className="text-white/40">in the review.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                The CLI posts back to GitHub the same way your test
+                runner does — a check named after the challenge pack,
+                passing or failing, with a link to the failing
+                trajectory if there is one.
+              </p>
+              <p className="mt-4">
+                Reviewers see agent regressions in the same pane as unit
+                test failures. No one has to open a second tool, skim a
+                dashboard, or remember to look.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Check output"
+              code={`✓ coding-agents / correctness  9.1 → 9.3
+✓ coding-agents / cost         $0.018 → $0.017
+✗ coding-agents / latency      p95 14s → 22s
+✗ coding-agents / behaviour    looped on tool error
+
+  → replay: agentclash.dev/r/01H...`}
+            />
+          }
+        />
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                What CI gets
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                Six things the pipeline actually needs.
+              </h2>
+            </div>
+            <div className="mt-20">
+              <FeatureGrid features={FEATURES} columns={3} />
+            </div>
+          </div>
+        </section>
+
+        <FAQBlock items={FAQ_ITEMS} schemaId="ld-cicd-faq" />
+
+        <ClosingCTA
+          title={
+            <>
+              Land the PR, or block it.
+              <br />
+              <span className="text-white/40">Not the in-between.</span>
+            </>
+          }
+          body={
+            <p>
+              Most teams ship the CLI into CI on day one. Book a call
+              and we&apos;ll wire it up live against your repo.
+            </p>
+          }
+        >
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+            <DemoButton className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors" />
+            <Link
+              href="/v2/platform/regression-testing"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+            >
+              Regression testing
+              <ArrowRight className="size-4" />
+            </Link>
+          </div>
+        </ClosingCTA>
+      </MarketingShell>
+    </>
+  );
+}

--- a/web/src/app/v2/platform/multi-turn-evaluation/page.tsx
+++ b/web/src/app/v2/platform/multi-turn-evaluation/page.tsx
@@ -1,0 +1,245 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { PageHeader } from "@/components/marketing/page-header";
+import { SplitSection } from "@/components/marketing/split-section";
+import { FeatureGrid } from "@/components/marketing/feature-grid";
+import { ClosingCTA } from "@/components/marketing/closing-cta";
+import { DemoButton } from "@/components/marketing/demo-button";
+import { CodeCard } from "@/components/marketing/code-card";
+import { FAQBlock } from "@/components/marketing/faq-block";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+
+const PATH = "/v2/platform/multi-turn-evaluation";
+
+export const metadata: Metadata = {
+  title: "Multi-turn agent evaluation",
+  description:
+    "Score whole conversations and multi-step plans, not one-shot replies. AgentClash evaluates tool use, plan adherence, self-correction, and termination behavior across the full trajectory.",
+  alternates: { canonical: PATH },
+  openGraph: {
+    title: "Multi-turn agent evaluation — AgentClash",
+    description:
+      "Evaluate conversations and multi-step plans. Score tool use, plan adherence, self-correction, termination.",
+    url: PATH,
+  },
+};
+
+const FEATURES = [
+  {
+    label: "Plan adherence",
+    title: "Did it follow the plan it made?",
+    body: "Agents that state a plan and quietly drift from it are hard to catch. Plan-adherence scoring flags when the trajectory stops matching the stated intent.",
+  },
+  {
+    label: "Self-correction",
+    title: "Recover gracefully or flail?",
+    body: "When a tool returns an error, the good agents replan. The bad ones loop or bail. Self-correction is a first-class vantage in the verdict.",
+  },
+  {
+    label: "Termination",
+    title: "Stop when done. Stop when stuck.",
+    body: "An agent that runs to the time budget when the task finished in 3 steps costs you real money. Termination behavior gets scored on both sides.",
+  },
+  {
+    label: "Tool budget",
+    title: "Cheap for the task, not cheap overall.",
+    body: "Budget assertions are per-challenge-pack. Research tasks can afford 40 tool calls; a support reply shouldn't cross 6.",
+  },
+  {
+    label: "Memory",
+    title: "Long context, honestly tested.",
+    body: "Challenges can carry state across turns — ticket threads, codebase context, prior conversation. Score whether the agent actually used it.",
+  },
+  {
+    label: "Rubrics",
+    title: "Rubrics written by humans, scored by agents.",
+    body: "Scoring agents are themselves tool-calling agents, with their own prompts and rubrics — you can inspect, fork, and fine-tune them per challenge pack.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: "What is multi-turn agent evaluation?",
+    answer:
+      "Multi-turn evaluation scores an agent across an entire trajectory: multiple model calls, tool uses, observations, replans, and a termination condition. It's the right shape for real products, because real agents don't solve things in one shot.",
+  },
+  {
+    question: "How is this different from a chat benchmark?",
+    answer:
+      "A chat benchmark usually scores one-shot responses from a single model. Multi-turn agent evaluation scores plans, tool sequences, budget adherence, and termination behavior — the things that break in production but look fine in a single-turn transcript.",
+  },
+  {
+    question: "Can I bring my own rubric?",
+    answer:
+      "Yes. Rubrics are markdown-driven challenge-pack fields that a scoring agent consults. You can fork the default scorer, swap the scoring model, or write a domain-specific rubric from scratch.",
+  },
+  {
+    question: "How long can a race be?",
+    answer:
+      "Challenge packs set a time budget and a tool-call budget. Short races (under 60 seconds) work well in CI; longer research or SRE-style races can run for many minutes. Temporal keeps everything durable regardless of length.",
+  },
+  {
+    question: "How do you handle non-determinism?",
+    answer:
+      "Run the same challenge N times and score distributions, not single runs. The default pipeline captures every seed and lets you compare median / p90 verdicts across a cohort.",
+  },
+];
+
+export default function MultiTurnEvaluationPage() {
+  return (
+    <>
+      <JsonLd
+        id="ld-mt-product"
+        data={productSchema({
+          name: "AgentClash — multi-turn agent evaluation",
+          description:
+            "Evaluate whole agent trajectories — tool use, plan adherence, self-correction, and termination — not one-shot replies.",
+          url: PATH,
+        })}
+      />
+      <JsonLd
+        id="ld-mt-breadcrumbs"
+        data={breadcrumbSchema([
+          { name: "Home", url: "/v2" },
+          { name: "Platform", url: "/v2/platform/agent-evaluation" },
+          { name: "Multi-turn evaluation", url: PATH },
+        ])}
+      />
+      <MarketingShell>
+        <PageHeader
+          breadcrumbs={[
+            { label: "Home", href: "/v2" },
+            { label: "Platform" },
+            { label: "Multi-turn evaluation" },
+          ]}
+          eyebrow="Multi-turn agent evaluation"
+          title={
+            <>
+              The eight tool calls
+              <br />
+              <span className="text-white/40">between hello and done.</span>
+            </>
+          }
+          subtitle={
+            <>
+              Production agents fail in the middle, not at the start or
+              the end. AgentClash scores whole trajectories — plan
+              adherence, self-correction, tool budget, termination — so
+              the right model wins for the reason it won.
+            </>
+          }
+          cta={
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+              <DemoButton />
+              <Link
+                href="/v2/platform/agent-evaluation"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+              >
+                Platform overview
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
+          }
+          aside={
+            <CodeCard
+              title="A trajectory"
+              code={`turn 1  plan:   ["search", "fetch", "verify"]
+turn 2  tool:   search("arxiv 2506...")
+turn 3  obs:    3 results
+turn 4  tool:   fetch(doc-1)
+turn 5  tool:   fetch(doc-2)     ✗ 500
+turn 6  think:  "retry with fallback"
+turn 7  tool:   fetch(doc-1.alt) ✓
+turn 8  answer  verified: true   ✓`}
+            />
+          }
+        />
+
+        <SplitSection
+          eyebrow="Plan vs reality"
+          title={
+            <>
+              Plans are easy.
+              <br />
+              <span className="text-white/40">Following them is the job.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                Agents routinely state a plan and quietly deviate. A
+                single-turn eval never catches it; the first reply
+                already sounds fine. Plan-adherence scoring compares the
+                stated plan with the executed trajectory and flags
+                silent drift.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Plan adherence"
+              code={`stated plan:    [search, fetch, verify]
+executed:       [search, fetch, answer]
+                                 ↑
+adherence:      0.66 (skipped verify)
+verdict note:   unverified claim shipped
+                in final answer`}
+            />
+          }
+        />
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Capabilities
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                Six vantages for whole-trajectory scoring.
+              </h2>
+            </div>
+            <div className="mt-20">
+              <FeatureGrid features={FEATURES} columns={3} />
+            </div>
+          </div>
+        </section>
+
+        <FAQBlock items={FAQ_ITEMS} schemaId="ld-mt-faq" />
+
+        <ClosingCTA
+          title={
+            <>
+              One reply is easy.
+              <br />
+              <span className="text-white/40">An hour of them is the job.</span>
+            </>
+          }
+          body={
+            <p>
+              Bring a real multi-step task and we&apos;ll race three
+              models against it end-to-end.
+            </p>
+          }
+        >
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+            <DemoButton className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors" />
+            <Link
+              href="/v2/use-cases/coding-agents"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+            >
+              See a coding-agent race
+              <ArrowRight className="size-4" />
+            </Link>
+          </div>
+        </ClosingCTA>
+      </MarketingShell>
+    </>
+  );
+}

--- a/web/src/app/v2/platform/rag-evaluation/page.tsx
+++ b/web/src/app/v2/platform/rag-evaluation/page.tsx
@@ -1,0 +1,250 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { PageHeader } from "@/components/marketing/page-header";
+import { SplitSection } from "@/components/marketing/split-section";
+import { FeatureGrid } from "@/components/marketing/feature-grid";
+import { ClosingCTA } from "@/components/marketing/closing-cta";
+import { DemoButton } from "@/components/marketing/demo-button";
+import { CodeCard } from "@/components/marketing/code-card";
+import { FAQBlock } from "@/components/marketing/faq-block";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+
+const PATH = "/v2/platform/rag-evaluation";
+
+export const metadata: Metadata = {
+  title: "RAG agent evaluation",
+  description:
+    "Evaluate retrieval-augmented agents end-to-end: retrieval quality, grounding, answer correctness, and cost — all on the same race. Catch silent retrieval regressions before they ship.",
+  alternates: { canonical: PATH },
+  openGraph: {
+    title: "RAG agent evaluation — AgentClash",
+    description:
+      "End-to-end RAG evaluation: retrieval, grounding, correctness, cost. On the same trajectory.",
+    url: PATH,
+  },
+};
+
+const FEATURES = [
+  {
+    label: "Retrieval",
+    title: "Score what got fetched.",
+    body: "Recall and precision against a labeled corpus, plus trajectory-aware metrics: did the right doc arrive in the first three calls, or the eighth?",
+  },
+  {
+    label: "Grounding",
+    title: "Answers tied to sources.",
+    body: "Each claim in the final answer is traced to the specific retrieved chunk it came from. Unsourced claims flag the verdict regardless of correctness.",
+  },
+  {
+    label: "Correctness",
+    title: "Rubric-scored final answers.",
+    body: "Reference-free rubric scorers and reference-based scorers, both first-class. Mix them per challenge — ground-truth where you have it, rubric where you don't.",
+  },
+  {
+    label: "Budget",
+    title: "Cheap retrieval isn't free.",
+    body: "Token, embedding, and vector-DB call budgets are all first-class verdict vantages. A more-correct but 3×-more-expensive pipeline still regresses.",
+  },
+  {
+    label: "Reranking",
+    title: "Test with and without.",
+    body: "Matrix runs over reranker variants in the same race. Head-to-head verdicts tell you whether your fancy reranker was worth the latency.",
+  },
+  {
+    label: "Drift",
+    title: "Corpus changes. Agents notice.",
+    body: "Schedule nightly races against your index. When a retrieval-dependent challenge suddenly starts failing, you get a drift alert — before customers do.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: "What does 'RAG evaluation' cover?",
+    answer:
+      "Retrieval-augmented agent evaluation scores the whole retrieval+generation pipeline end-to-end: retrieval quality, grounding, answer correctness, cost, and drift. AgentClash scores these on the same trajectory, so you can see *which* part broke when a verdict dips.",
+  },
+  {
+    question: "Do I need to bring a ground-truth corpus?",
+    answer:
+      "Not necessarily. Reference-free rubric scorers work when you only have ground-truth answers; reference-based scorers work when you have labeled retrievals. Most teams have some of each, and AgentClash mixes them per challenge pack.",
+  },
+  {
+    question: "How does grounding scoring work?",
+    answer:
+      "The scorer inspects the final answer for claims, walks back through the trajectory to find the retrieved chunk that supports each claim, and flags any claim with no supporting retrieval. Grounding score is the ratio of supported claims.",
+  },
+  {
+    question: "Can I test reranker variants head-to-head?",
+    answer:
+      "Yes. Challenge packs can name a matrix of retrieval configurations, each racing concurrently. The verdict table shows you whether the reranker earned its latency.",
+  },
+  {
+    question: "What happens when the corpus changes?",
+    answer:
+      "Schedule a nightly regression race; AgentClash compares today's verdicts against the baseline and surfaces retrieval drift as a failing check. You find out before customers do.",
+  },
+];
+
+export default function RagEvaluationPage() {
+  return (
+    <>
+      <JsonLd
+        id="ld-rag-product"
+        data={productSchema({
+          name: "AgentClash — RAG agent evaluation",
+          description:
+            "Evaluate retrieval-augmented agents end-to-end: retrieval quality, grounding, answer correctness, and cost.",
+          url: PATH,
+        })}
+      />
+      <JsonLd
+        id="ld-rag-breadcrumbs"
+        data={breadcrumbSchema([
+          { name: "Home", url: "/v2" },
+          { name: "Platform", url: "/v2/platform/agent-evaluation" },
+          { name: "RAG evaluation", url: PATH },
+        ])}
+      />
+      <MarketingShell>
+        <PageHeader
+          breadcrumbs={[
+            { label: "Home", href: "/v2" },
+            { label: "Platform" },
+            { label: "RAG evaluation" },
+          ]}
+          eyebrow="RAG agent evaluation"
+          title={
+            <>
+              Retrieval, grounding,
+              <br />
+              <span className="text-white/40">the whole pipeline.</span>
+            </>
+          }
+          subtitle={
+            <>
+              Retrieval-augmented agents break in more places than
+              single-call models. AgentClash scores retrieval quality,
+              grounding, answer correctness, and cost on the same
+              trajectory so you know which part regressed when the
+              verdict drops.
+            </>
+          }
+          cta={
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+              <DemoButton />
+              <Link
+                href="/v2/use-cases/deep-research"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+              >
+                Deep research use case
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
+          }
+          aside={
+            <CodeCard
+              title="RAG verdict"
+              code={`retrieval:    recall    0.92  precision 0.71
+              first_doc@1          0.88
+grounding:    supported            0.94
+correctness:  rubric               9.1 / 10
+cost:         embed + gen         $0.014
+latency:      p95                  3.8 s`}
+            />
+          }
+        />
+
+        <SplitSection
+          eyebrow="Where RAG actually breaks"
+          title={
+            <>
+              Wrong chunk.
+              <br />
+              <span className="text-white/40">Confident answer.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                The worst RAG bugs aren&apos;t hallucinations — they&apos;re
+                confident answers grounded in the wrong chunk. A
+                single-turn correctness eval can give both cases the
+                same score.
+              </p>
+              <p className="mt-4">
+                AgentClash scores retrieval and grounding separately, on
+                the same run. When the overall verdict drops you can see
+                whether the retriever, the reranker, or the generator
+                was the weak link.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Where it went wrong"
+              code={`answer:        "Yes — policy allows it."
+grounding:     cited chunk #4
+chunk #4:      "Exceptions allowed only..."
+                  ↑
+grounding:     unsupported (cherry-picked)
+verdict:       ✗ hallucinated grounding`}
+            />
+          }
+        />
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                RAG vantages
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                Six things worth scoring separately.
+              </h2>
+            </div>
+            <div className="mt-20">
+              <FeatureGrid features={FEATURES} columns={3} />
+            </div>
+          </div>
+        </section>
+
+        <FAQBlock items={FAQ_ITEMS} schemaId="ld-rag-faq" />
+
+        <ClosingCTA
+          title={
+            <>
+              Know which part broke.
+              <br />
+              <span className="text-white/40">Before customers do.</span>
+            </>
+          }
+          body={
+            <p>
+              Send us your hardest RAG failure and we&apos;ll race three
+              pipelines against it — retriever, reranker, and generator
+              swapped independently.
+            </p>
+          }
+        >
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+            <DemoButton className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors" />
+            <Link
+              href="/v2/use-cases/deep-research"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+            >
+              Deep-research workflow
+              <ArrowRight className="size-4" />
+            </Link>
+          </div>
+        </ClosingCTA>
+      </MarketingShell>
+    </>
+  );
+}

--- a/web/src/app/v2/platform/regression-testing/page.tsx
+++ b/web/src/app/v2/platform/regression-testing/page.tsx
@@ -1,0 +1,290 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { PageHeader } from "@/components/marketing/page-header";
+import { SplitSection } from "@/components/marketing/split-section";
+import { FeatureGrid } from "@/components/marketing/feature-grid";
+import { ClosingCTA } from "@/components/marketing/closing-cta";
+import { DemoButton } from "@/components/marketing/demo-button";
+import { CodeCard } from "@/components/marketing/code-card";
+import { FAQBlock } from "@/components/marketing/faq-block";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+
+const PATH = "/v2/platform/regression-testing";
+
+export const metadata: Metadata = {
+  title: "AI agent regression testing",
+  description:
+    "Archive every failure as a regression test. Replay them on every model change. AgentClash turns each production near-miss into a permanent bar the next agent has to clear.",
+  alternates: { canonical: PATH },
+  openGraph: {
+    title: "AI agent regression testing — AgentClash",
+    description:
+      "Every failed trajectory becomes a permanent regression test. Catch model drift before it ships.",
+    url: PATH,
+  },
+};
+
+const FEATURES = [
+  {
+    label: "Auto-capture",
+    title: "Flunks become tests.",
+    body: "Any run whose verdict dips below your threshold freezes into a regression suite — with the exact prompt, tools, sandbox image, and expected trajectory signature.",
+  },
+  {
+    label: "Replay",
+    title: "Re-run on every model bump.",
+    body: "Swap GPT-5 for Claude 4.6, Gemini 3, or an internal fine-tune — your regression suite replays all of them against the archived traces with no code change.",
+  },
+  {
+    label: "Drift detection",
+    title: "Catch provider-side regressions.",
+    body: "Providers silently update models. Nightly regression races compare today's behavior against the archived baseline so drift surfaces the same day.",
+  },
+  {
+    label: "Signature",
+    title: "Behaviour beats string match.",
+    body: "Trajectory signatures — tools used, plan shape, termination reason — give you stable assertions even when model wording shifts between versions.",
+  },
+  {
+    label: "Budget aware",
+    title: "Regress costs and latency too.",
+    body: "A correct-but-5×-more-expensive agent is still a regression. Budget checks are first-class assertions alongside correctness.",
+  },
+  {
+    label: "CI native",
+    title: "Block the merge, not the hotfix.",
+    body: "Run regressions in CI on every PR. Block when a regression appears — post the failing trace and verdict straight into the GitHub check.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: "What is AI agent regression testing?",
+    answer:
+      "Agent regression testing replays a fixed set of known-hard tasks (usually archived from past failures) against a candidate agent, and fails the build if behavior regresses on correctness, cost, latency, or trajectory shape.",
+  },
+  {
+    question: "How does AgentClash build a regression suite?",
+    answer:
+      "Any run whose verdict drops below your threshold is automatically promoted into the regression suite for that challenge pack. You can also hand-curate cases from the replay UI. Each case stores the full input, tool set, sandbox image, and expected trajectory signature.",
+  },
+  {
+    question: "How do I keep regressions stable across model bumps?",
+    answer:
+      "We score against trajectory signatures (tools used, plan shape, termination conditions) instead of string-matching model output. This keeps assertions meaningful even when a new model says the same thing differently.",
+  },
+  {
+    question: "Can I run regressions in CI?",
+    answer:
+      "Yes. The CLI has a `regression run` command designed for CI: it blocks on verdict changes, posts results as a GitHub check, and links directly to the failing replay.",
+  },
+  {
+    question: "What about provider-side drift?",
+    answer:
+      "Providers ship silent model updates regularly. Schedule a nightly regression race and AgentClash will alert you when a baseline trajectory starts failing — that's the earliest signal you'll get that a provider shifted under you.",
+  },
+];
+
+export default function RegressionTestingPage() {
+  return (
+    <>
+      <JsonLd
+        id="ld-rt-product"
+        data={productSchema({
+          name: "AgentClash — agent regression testing",
+          description:
+            "Archive every agent failure as a replayable regression test. Block merges on drift, cost blowouts, and trajectory regressions.",
+          url: PATH,
+        })}
+      />
+      <JsonLd
+        id="ld-rt-breadcrumbs"
+        data={breadcrumbSchema([
+          { name: "Home", url: "/v2" },
+          { name: "Platform", url: "/v2/platform/agent-evaluation" },
+          { name: "Regression testing", url: PATH },
+        ])}
+      />
+      <MarketingShell>
+        <PageHeader
+          breadcrumbs={[
+            { label: "Home", href: "/v2" },
+            { label: "Platform" },
+            { label: "Regression testing" },
+          ]}
+          eyebrow="Agent regression testing"
+          title={
+            <>
+              Every failure becomes
+              <br />
+              <span className="text-white/40">a permanent test.</span>
+            </>
+          }
+          subtitle={
+            <>
+              Agents that passed yesterday regress quietly today — a new
+              model ship, a provider update, a subtle sandbox change.
+              AgentClash freezes every flunked trajectory into a
+              regression suite that replays on every model change and
+              blocks the merge when drift shows up.
+            </>
+          }
+          cta={
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+              <DemoButton />
+              <Link
+                href="/v2/platform/ci-cd-gating"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+              >
+                Wire into CI
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
+          }
+          aside={
+            <CodeCard
+              title="A regression case"
+              code={`# regressions/pr-42-sandbox-lock.yaml
+from_run: run_01H...
+tools: [fs, exec, git]
+expected_signature:
+  - tool_order: [git:status, fs:read, exec:go_test]
+  - terminated: success
+  - cost_max: $0.02
+  - p95_max: 14s`}
+            />
+          }
+        />
+
+        <SplitSection
+          eyebrow="Why archive flunks"
+          title={
+            <>
+              The hardest cases
+              <br />
+              <span className="text-white/40">rarely repeat themselves.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                A good eval set is rare and expensive to build by hand.
+                A failing agent run, on the other hand, is a naturally
+                curated hard case — it exposed a real weakness in the
+                shape of the model or the tooling.
+              </p>
+              <p className="mt-4">
+                Every time one of those happens in AgentClash, we freeze
+                it: the inputs, tools, sandbox image, and expected
+                trajectory signature. Your regression suite grows on its
+                own, weighted toward the cases that actually matter.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Flunk → regression"
+              code={`$ agentclash run show run_01H...
+
+  verdict:       ✗ failed
+  correctness:   3.1 / 10
+  behaviour:     looped_on_tool_error
+
+$ agentclash regression promote run_01H...
+  added to suite: rag-qa-hard
+  12 cases now guarded in CI`}
+            />
+          }
+        />
+
+        <SplitSection
+          reverse
+          eyebrow="Drift detection"
+          title={
+            <>
+              Providers ship quietly.
+              <br />
+              <span className="text-white/40">You find out loudly.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                Frontier models change behavior between versions — sometimes
+                between the same version. Nightly regression races replay
+                your archived suite against live endpoints so silent drift
+                surfaces as a red build, not a production incident.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Nightly drift sweep"
+              code={`# .github/workflows/nightly-drift.yml
+- name: Replay regression suite
+  run: |
+    agentclash regression run \\
+      --suite production-hard \\
+      --agents gpt-5,claude-4.5 \\
+      --alert-on drift`}
+            />
+          }
+        />
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Capabilities
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                Regression testing that survives model bumps.
+              </h2>
+            </div>
+            <div className="mt-20">
+              <FeatureGrid features={FEATURES} columns={3} />
+            </div>
+          </div>
+        </section>
+
+        <FAQBlock items={FAQ_ITEMS} schemaId="ld-rt-faq" />
+
+        <ClosingCTA
+          title={
+            <>
+              Ship upgrades.
+              <br />
+              <span className="text-white/40">Not regressions.</span>
+            </>
+          }
+          body={
+            <p>
+              Let us replay your last painful agent bug against three new
+              models so you can see where they break before you ship them.
+            </p>
+          }
+        >
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+            <DemoButton
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
+            />
+            <Link
+              href="/v2/platform/ci-cd-gating"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+            >
+              Gate your CI
+              <ArrowRight className="size-4" />
+            </Link>
+          </div>
+        </ClosingCTA>
+      </MarketingShell>
+    </>
+  );
+}

--- a/web/src/app/v2/platform/self-hosted/page.tsx
+++ b/web/src/app/v2/platform/self-hosted/page.tsx
@@ -1,0 +1,271 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight, Star, ExternalLink } from "lucide-react";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { PageHeader } from "@/components/marketing/page-header";
+import { SplitSection } from "@/components/marketing/split-section";
+import { FeatureGrid } from "@/components/marketing/feature-grid";
+import { ClosingCTA } from "@/components/marketing/closing-cta";
+import { DemoButton } from "@/components/marketing/demo-button";
+import { CodeCard } from "@/components/marketing/code-card";
+import { FAQBlock } from "@/components/marketing/faq-block";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+
+const PATH = "/v2/platform/self-hosted";
+
+export const metadata: Metadata = {
+  title: "Self-hosted agent evaluation",
+  description:
+    "Run AgentClash entirely on your own infra. Open-source under FSL-1.1-MIT. Bring your own Postgres, your own Temporal, your own sandbox provider — read every line of the scoring pipeline.",
+  alternates: { canonical: PATH },
+  openGraph: {
+    title: "Self-hosted agent evaluation — AgentClash",
+    description:
+      "Run the full agent-eval race engine on your own infra. Open source. No phone-home. No vendor lock-in.",
+    url: PATH,
+  },
+};
+
+const FEATURES = [
+  {
+    label: "docker-compose",
+    title: "One command to boot the stack.",
+    body: "Postgres, Temporal, API server, worker, all wired up by ./scripts/dev/start-local-stack.sh. From fresh clone to first race in under five minutes.",
+  },
+  {
+    label: "No phone-home",
+    title: "Your data, your network, your rules.",
+    body: "Nothing leaves your environment except the provider calls you authorize. No telemetry. No license server. No mandatory feature flags.",
+  },
+  {
+    label: "Swap sandboxes",
+    title: "E2B, Firecracker, bare VMs.",
+    body: "Sandbox is a Go interface. The default provider is E2B, but you can plug in Firecracker microVMs, your own Kubernetes jobs, or anything else that runs isolated code.",
+  },
+  {
+    label: "Own your data",
+    title: "Postgres + S3 you already run.",
+    body: "Event metadata lives in Postgres. Large replay payloads go to S3 or any S3-compatible blob store you point it at.",
+  },
+  {
+    label: "Same CLI",
+    title: "Managed parity, without the cloud.",
+    body: "The CLI, the API, the challenge pack format — all identical. A self-host user and a managed-cloud user hit the same endpoints, just at different URLs.",
+  },
+  {
+    label: "Auditable scoring",
+    title: "Read every scorer.",
+    body: "The scoring pipeline is plain Go, not an opaque SDK. Fork, patch, or replace any scorer. Audit exactly how every verdict was computed.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: "What do I need to self-host AgentClash?",
+    answer:
+      "Go 1.25+, Docker, the Temporal CLI, and a Postgres instance. The included docker-compose stands all of that up locally in one command. For production you'd run Temporal, Postgres, and the API/worker services as you'd run any Go service — Kubernetes, Nomad, plain VMs all work.",
+  },
+  {
+    question: "Can I bring my own sandbox provider?",
+    answer:
+      "Yes. The Sandbox interface has a small surface — provision, exec, filesystem I/O, teardown. The default implementation is E2B; a noop provider ships for environments where sandboxes are unconfigured. Your own provider can plug straight in.",
+  },
+  {
+    question: "What about auth in self-host?",
+    answer:
+      "Production uses WorkOS AuthKit. Local dev uses AUTH_MODE=dev, which reads an X-Dev-User-ID header — no setup required. You can also wire your own SSO into the same middleware hooks.",
+  },
+  {
+    question: "Is the scoring pipeline customizable?",
+    answer:
+      "Completely. Scorers are Go packages behind a small interface, and challenge packs reference them by name. Fork, patch, or write from scratch — nothing about the scoring is gated behind the managed product.",
+  },
+  {
+    question: "What license is AgentClash under?",
+    answer:
+      "FSL-1.1-MIT — Functional Source License with a two-year MIT future. Read the code, run it, modify it, self-host for your company. Each release converts to plain MIT two years after it ships.",
+  },
+];
+
+export default function SelfHostedPage() {
+  return (
+    <>
+      <JsonLd
+        id="ld-sh-product"
+        data={productSchema({
+          name: "AgentClash — self-hosted agent evaluation",
+          description:
+            "Self-host the open-source AgentClash race engine. FSL-1.1-MIT. Bring your own Postgres, Temporal, and sandbox provider.",
+          url: PATH,
+        })}
+      />
+      <JsonLd
+        id="ld-sh-breadcrumbs"
+        data={breadcrumbSchema([
+          { name: "Home", url: "/v2" },
+          { name: "Platform", url: "/v2/platform/agent-evaluation" },
+          { name: "Self-hosted", url: PATH },
+        ])}
+      />
+      <MarketingShell>
+        <PageHeader
+          breadcrumbs={[
+            { label: "Home", href: "/v2" },
+            { label: "Platform" },
+            { label: "Self-hosted" },
+          ]}
+          eyebrow="Self-hosted · FSL-1.1-MIT"
+          title={
+            <>
+              Your infra.
+              <br />
+              <span className="text-white/40">Your scoring pipeline.</span>
+            </>
+          }
+          subtitle={
+            <>
+              When your agents touch sensitive data, or you just want
+              the full scoring pipeline in reach of your debugger,
+              self-host AgentClash end-to-end. Same API, same CLI, same
+              challenge packs — no managed dependency.
+            </>
+          }
+          cta={
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+              <a
+                href="https://github.com/agentclash/agentclash"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
+              >
+                <Star className="size-4" />
+                Star on GitHub
+                <ExternalLink className="size-3.5 text-black/40" />
+              </a>
+              <Link
+                href="/docs/getting-started/self-host"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+              >
+                Self-host quickstart
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
+          }
+          aside={
+            <CodeCard
+              title="start-local-stack.sh"
+              code={`git clone https://github.com/agentclash/agentclash
+cd agentclash
+./scripts/dev/start-local-stack.sh
+
+# Postgres   → localhost:5432
+# Temporal   → localhost:7233
+# API        → localhost:8080
+# Worker     → connected`}
+            />
+          }
+        />
+
+        <SplitSection
+          eyebrow="Why self-host"
+          title={
+            <>
+              Some data shouldn&apos;t
+              <br />
+              <span className="text-white/40">leave your network.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                Agents that run against production data, internal tools,
+                or customer PII belong in your own environment. AgentClash
+                self-host is the same race engine as the managed cloud —
+                no feature gating, no telemetry phone-home.
+              </p>
+              <p className="mt-4">
+                You provide Postgres, Temporal, and whatever sandbox
+                provider matches your security model. The CLI points at
+                your API URL and everything else behaves identically.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Point CLI at your server"
+              code={`export AGENTCLASH_API_URL="https://eval.internal.corp"
+agentclash auth login --device
+
+# Everything else is the same
+agentclash workspace list
+agentclash run create --follow`}
+            />
+          }
+        />
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Self-host capabilities
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                Real infrastructure, not a demo.
+              </h2>
+            </div>
+            <div className="mt-20">
+              <FeatureGrid features={FEATURES} columns={3} />
+            </div>
+          </div>
+        </section>
+
+        <FAQBlock items={FAQ_ITEMS} schemaId="ld-sh-faq" />
+
+        <ClosingCTA
+          title={
+            <>
+              Read the source.
+              <br />
+              <span className="text-white/40">Run it tonight.</span>
+            </>
+          }
+          body={
+            <p>
+              The quickstart puts a full AgentClash stack on your
+              machine in about five minutes.
+            </p>
+          }
+        >
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+            <a
+              href="https://github.com/agentclash/agentclash"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
+            >
+              <Star className="size-4" />
+              Star on GitHub
+              <ExternalLink className="size-3.5 text-black/40" />
+            </a>
+            <Link
+              href="/docs/architecture/overview"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+            >
+              Architecture overview
+              <ArrowRight className="size-4" />
+            </Link>
+            <DemoButton
+              label="Talk to a maintainer"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/[0.08] bg-white/[0.02] px-7 py-3 text-sm font-medium text-white/60 hover:text-white/90 hover:border-white/20 transition-colors"
+            />
+          </div>
+        </ClosingCTA>
+      </MarketingShell>
+    </>
+  );
+}

--- a/web/src/app/v2/security/page.tsx
+++ b/web/src/app/v2/security/page.tsx
@@ -1,0 +1,313 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { PageHeader } from "@/components/marketing/page-header";
+import { SplitSection } from "@/components/marketing/split-section";
+import { FeatureGrid } from "@/components/marketing/feature-grid";
+import { ClosingCTA } from "@/components/marketing/closing-cta";
+import { DemoButton } from "@/components/marketing/demo-button";
+import { CodeCard } from "@/components/marketing/code-card";
+import { FAQBlock } from "@/components/marketing/faq-block";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+
+const PATH = "/v2/security";
+
+export const metadata: Metadata = {
+  title: "Security posture — AgentClash",
+  description:
+    "Sandbox isolation, explicit data flow, workspace-scoped secrets, and append-only audit. How AgentClash handles your prompts, provider keys, and replay archives.",
+  alternates: { canonical: PATH },
+  openGraph: {
+    title: "AgentClash security posture",
+    description:
+      "Sandbox isolation, explicit data flow, workspace-scoped secrets, and append-only audit trails.",
+    url: PATH,
+  },
+};
+
+const FEATURES = [
+  {
+    label: "Isolation",
+    title: "Per-run E2B microVMs.",
+    body: "Every agent runs inside an ephemeral E2B sandbox. Filesystem, process table, and network namespace are torn down when the race ends. No state leaks between runs, agents, or workspaces.",
+  },
+  {
+    label: "Secrets",
+    title: "Workspace-scoped, never logged.",
+    body: "Provider keys and sandbox secrets are encrypted at rest, scoped to a single workspace, and redacted from every event before it hits the replay archive. They're readable inside the sandbox and nowhere else.",
+  },
+  {
+    label: "AuthN / AuthZ",
+    title: "WorkOS AuthKit, RBAC, SSO.",
+    body: "Real org / workspace / role model backed by WorkOS AuthKit. Roles gate challenge packs, runs, and secrets at the manager layer — authorization is data-aware, not a middleware afterthought. SSO on request.",
+  },
+  {
+    label: "Provider calls",
+    title: "Straight from sandbox to provider.",
+    body: "Model traffic exits the sandbox with the keys you supplied and goes directly to the provider endpoint. We don't proxy your prompts, and we don't route completions through a shared service.",
+  },
+  {
+    label: "Network policy",
+    title: "Default deny, allowlist egress.",
+    body: "Sandboxes start with no network access. Each challenge pack declares the exact set of hosts its tools and provider calls are allowed to reach. Everything else is blocked at the sandbox boundary.",
+  },
+  {
+    label: "Audit",
+    title: "Append-only, sequence-numbered.",
+    body: "Run events are immutable envelopes with a database-assigned sequence number. You can replay the exact ordering of tool calls, model outputs, and state transitions months later without fear of retroactive edits.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: "Is AgentClash SOC 2 compliant?",
+    answer:
+      "SOC 2 Type II is being pursued during private beta. Design partners get the attestation path as it lands — controls, vendor inventory, and the independent audit timeline. If you need SOC 2 before you can onboard, tell us on the first call and we'll be honest about where we are.",
+  },
+  {
+    question: "Where does my provider traffic go?",
+    answer:
+      "Directly from the E2B sandbox to the model provider, using the API keys you supply. We don't proxy the call, we don't see the prompt or completion outside the replay archive you control, and we don't store provider credentials outside the encrypted workspace vault.",
+  },
+  {
+    question: "Can I self-host for zero-egress?",
+    answer:
+      "Yes. The open-source engine is the same code that runs our managed cloud — same API, same CLI, same scoring pipeline. Deploy it inside your VPC, point the sandbox provider at your own E2B tenant, and nothing leaves your environment. The /v2/oss page has the quickstart.",
+  },
+  {
+    question: "What do you log?",
+    answer:
+      "Run metadata: timestamps, sequence numbers, verdicts, token counts, tool call names. The full payloads (prompt contents, tool outputs, model completions) live in the replay archive you control — managed cloud customers get signed-URL access and retention knobs per workspace. Application logs never contain secrets or prompt bodies.",
+  },
+  {
+    question: "How are secrets stored?",
+    answer:
+      "Encrypted at rest with per-workspace keys, injected into the sandbox environment at boot, and wiped when the sandbox tears down. They never appear in run events, replay archives, or application logs — the event serializer redacts any value registered as a secret before it's persisted.",
+  },
+];
+
+export default function SecurityPage() {
+  return (
+    <>
+      <JsonLd
+        id="ld-security-product"
+        data={productSchema({
+          name: "AgentClash — security posture",
+          description:
+            "AI agent evaluation platform with sandbox isolation, workspace-scoped secrets, WorkOS-backed auth, and append-only audit.",
+          url: PATH,
+        })}
+      />
+      <JsonLd
+        id="ld-security-breadcrumbs"
+        data={breadcrumbSchema([
+          { name: "Home", url: "/v2" },
+          { name: "Security", url: PATH },
+        ])}
+      />
+      <MarketingShell>
+        <PageHeader
+          breadcrumbs={[
+            { label: "Home", href: "/v2" },
+            { label: "Security" },
+          ]}
+          eyebrow="Security posture"
+          title={
+            <>
+              Sandboxes, secrets,
+              <br />
+              <span className="text-white/40">and straight answers.</span>
+            </>
+          }
+          subtitle={
+            <>
+              AgentClash is built around sandbox isolation and explicit data
+              flow. Everything we run for you on managed cloud, and
+              everything you can run yourself on self-host, honors the same
+              model — the same boundaries, the same redaction, the same
+              append-only audit.
+            </>
+          }
+          cta={
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+              <DemoButton label="Talk to us" />
+              <Link
+                href="/v2/oss"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+              >
+                Self-host for zero egress
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
+          }
+          aside={
+            <CodeCard
+              title="Trust surface"
+              code={`isolation:       E2B microVM per run
+secrets:         workspace-scoped, redacted
+auth:            WorkOS AuthKit, RBAC, SSO
+network:         default deny + allowlist
+audit:           append-only, sequenced
+residency:       self-host = your VPC`}
+            />
+          }
+        />
+
+        <SplitSection
+          eyebrow="Data flow, in writing"
+          title={
+            <>
+              Every hop is
+              <br />
+              <span className="text-white/40">on the map.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                There&apos;s no hidden tier of infrastructure between your
+                sandbox and the model provider. A run has a fixed, short
+                list of components, and you can name each one — what it
+                does, what it sees, and what it stores.
+              </p>
+              <p className="mt-4">
+                The CLI submits to the API server. The API server submits a
+                Temporal workflow. The workflow activity provisions a
+                sandbox. The sandbox calls the provider with your keys.
+                Events are persisted, in order, to the replay archive you
+                control. That&apos;s the whole diagram.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Request path"
+              code={`[ you ]
+   │  agentclash run create
+   ▼
+[ CLI ] ──── HTTPS ────┐
+                       ▼
+             [ API server ]
+                  │ submit workflow
+                  ▼
+             [ Temporal ]
+                  │ activity
+                  ▼
+             [ Sandbox (E2B) ]
+                  │ your provider keys
+                  ▼
+             [ Model provider ]
+
+ events ──▶ [ Replay archive ]`}
+            />
+          }
+        />
+
+        <SplitSection
+          reverse
+          eyebrow="What leaves your environment"
+          title={
+            <>
+              Explicit about what we see.
+              <br />
+              <span className="text-white/40">And what we don&apos;t.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                On managed cloud we see run metadata — timestamps, token
+                counts, verdict scores, tool call names — because that&apos;s
+                what makes the race engine work. We do not see prompt
+                bodies, tool outputs, or model completions outside the
+                replay archive attached to your workspace.
+              </p>
+              <p className="mt-4">
+                On self-host, we see nothing. The whole system lives inside
+                your network. The same boundaries still apply internally —
+                redaction, sandbox isolation, immutable audit — they just
+                run on your iron.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Managed cloud visibility"
+              code={`we see (operational):
+  - run id, workspace id, actor
+  - start/end, status, verdict
+  - token counts, cost, latency
+  - tool names, sequence numbers
+
+we do not see:
+  - prompt bodies
+  - tool call arguments / outputs
+  - model completions
+  - secrets, provider keys
+
+retention knobs:
+  replay archive:  per workspace
+  metadata:        per workspace
+  secrets:         wiped on tear-down`}
+            />
+          }
+        />
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Controls
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                Six boundaries that hold the shape.
+              </h2>
+            </div>
+            <div className="mt-20">
+              <FeatureGrid features={FEATURES} columns={3} />
+            </div>
+          </div>
+        </section>
+
+        <FAQBlock items={FAQ_ITEMS} schemaId="ld-security-faq" />
+
+        <ClosingCTA
+          title={
+            <>
+              Questions we haven&apos;t answered?
+              <br />
+              <span className="text-white/40">Put them on the call.</span>
+            </>
+          }
+          body={
+            <p>
+              Security reviews are a conversation, not a checkbox. Bring
+              your vendor questionnaire, your threat model, your
+              compliance counsel — we&apos;ll walk the diagram with you.
+            </p>
+          }
+        >
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+            <DemoButton
+              label="Book a security call"
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
+            />
+            <Link
+              href="/v2/oss"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+            >
+              Self-host quickstart
+              <ArrowRight className="size-4" />
+            </Link>
+          </div>
+        </ClosingCTA>
+      </MarketingShell>
+    </>
+  );
+}

--- a/web/src/app/v2/use-cases/coding-agents/page.tsx
+++ b/web/src/app/v2/use-cases/coding-agents/page.tsx
@@ -1,0 +1,308 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { PageHeader } from "@/components/marketing/page-header";
+import { SplitSection } from "@/components/marketing/split-section";
+import { FeatureGrid } from "@/components/marketing/feature-grid";
+import { ClosingCTA } from "@/components/marketing/closing-cta";
+import { DemoButton } from "@/components/marketing/demo-button";
+import { CodeCard } from "@/components/marketing/code-card";
+import { FAQBlock } from "@/components/marketing/faq-block";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+
+const PATH = "/v2/use-cases/coding-agents";
+
+export const metadata: Metadata = {
+  title: "Evaluate coding agents",
+  description:
+    "Benchmark autonomous dev agents head-to-head on real repos. Score read-file, exec-test, and open-PR behaviors against SWE-bench-style tasks with AgentClash.",
+  alternates: { canonical: PATH },
+  openGraph: {
+    title: "Evaluate coding agents — AgentClash",
+    description:
+      "Race autonomous coding agents on real repos. Score behaviors that matter: read file, run tests, open PR.",
+    url: PATH,
+  },
+};
+
+const FEATURES = [
+  {
+    label: "Tools",
+    title: "Real fs, exec, git, http.",
+    body: "Agents get a sandboxed checkout with live filesystem, shell, and git. No mocked test harness — if the patch doesn't compile, the run fails the way it would in CI.",
+  },
+  {
+    label: "Behaviors",
+    title: "Score the plan, not the prose.",
+    body: "Did the agent read the failing test before editing? Did it run the suite before opening the PR? Trajectory signatures grade the method, not just the final diff.",
+  },
+  {
+    label: "Repos",
+    title: "Your codebase, not a toy.",
+    body: "Point AgentClash at a private monorepo or a seeded fixture. Same agent, same tools, same runtime — the only thing that changes is the task.",
+  },
+  {
+    label: "Patches",
+    title: "Apply, build, test, verdict.",
+    body: "Every run ends with a patch applied against the base commit and the full test suite green or red. No graders guessing if the agent was on the right track.",
+  },
+  {
+    label: "Budgets",
+    title: "Cost and latency as first-class.",
+    body: "A correct PR that burns 400k tokens and 11 minutes is still a bad PR. Budgets ride alongside correctness so you can pick the agent that ships.",
+  },
+  {
+    label: "Head-to-head",
+    title: "Race four agents at once.",
+    body: "Claude Code, Cursor, Aider, and a custom harness on the exact same task. Side-by-side replay of tool calls, diffs, and terminal output.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: "How is this different from SWE-bench?",
+    answer:
+      "SWE-bench is a fixed task set with a fixed harness. AgentClash is the harness: bring your own repos, your own tools, your own agents. You can run SWE-bench-style tasks on it, but you can also run your team's real tickets against the same scoring pipeline.",
+  },
+  {
+    question: "What tools do coding agents get?",
+    answer:
+      "Each run gets an E2B sandbox with filesystem access, a shell for exec calls (build, test, lint, run), git for branch and commit operations, and optional http for package installs or external APIs. The tool policy is per challenge pack so you can restrict what each agent is allowed to touch.",
+  },
+  {
+    question: "Can I evaluate my own internal coding agent?",
+    answer:
+      "Yes. AgentClash treats any agent that speaks the run protocol as a first-class competitor — OpenAI, Anthropic, a fine-tune, or a custom harness with its own tool router. Race it head-to-head against frontier models on the same tasks.",
+  },
+  {
+    question: "How do you grade a patch?",
+    answer:
+      "The sandbox applies the patch to the base commit, runs the build and test suite declared by the challenge pack, and captures the exit code. On top of that, trajectory signatures grade behaviors: did it read the failing test, did it re-run locally before submitting, did it avoid tool loops.",
+  },
+  {
+    question: "What about agents that can't finish in one turn?",
+    answer:
+      "Coding tasks are multi-turn by default. The run workflow persists tool state between turns and tails everything live. Long tasks get replayed end-to-end in the UI — you can scrub through a 40-step trajectory and see exactly where the agent got stuck.",
+  },
+];
+
+export default function CodingAgentsPage() {
+  return (
+    <>
+      <JsonLd
+        id="ld-coding-product"
+        data={productSchema({
+          name: "AgentClash — coding agent evaluation",
+          description:
+            "Race autonomous coding agents against each other on real repos. Score tool use, patch correctness, and cost in one pipeline.",
+          url: PATH,
+        })}
+      />
+      <JsonLd
+        id="ld-coding-breadcrumbs"
+        data={breadcrumbSchema([
+          { name: "Home", url: "/v2" },
+          { name: "Use cases", url: "/v2/use-cases/coding-agents" },
+          { name: "Coding agents", url: PATH },
+        ])}
+      />
+      <MarketingShell>
+        <PageHeader
+          breadcrumbs={[
+            { label: "Home", href: "/v2" },
+            { label: "Use cases" },
+            { label: "Coding agents" },
+          ]}
+          eyebrow="Coding agent evaluation"
+          title={
+            <>
+              Race coding agents
+              <br />
+              <span className="text-white/40">on your actual repo.</span>
+            </>
+          }
+          subtitle={
+            <>
+              Stop comparing agents on leaderboard screenshots. AgentClash
+              drops Claude Code, Cursor, Aider, and your own harness into
+              the same sandbox with your repo, your tools, and your tests —
+              then grades them on the patch, the plan, and the bill.
+            </>
+          }
+          cta={
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+              <DemoButton />
+              <Link
+                href="/v2/platform/agent-evaluation"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+              >
+                Evaluation primitives
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
+          }
+          aside={
+            <CodeCard
+              title="A coding task"
+              code={`# packs/fix-flaky-queue-test.yaml
+base: agentclash/monorepo@e3f1...
+tools: [fs, exec, git]
+task: |
+  The test in internal/queue/worker_test.go
+  flakes under -race. Find it, fix it, open
+  a PR against main.
+expected_signature:
+  - tool_order: [fs:read, exec:go_test, fs:write, git:commit]
+  - terminated: pr_opened
+  - cost_max: $0.08`}
+            />
+          }
+        />
+
+        <SplitSection
+          eyebrow="Trajectory over output"
+          title={
+            <>
+              A correct diff from a bad plan
+              <br />
+              <span className="text-white/40">is still a bad agent.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                Two agents can ship the same one-line fix. One reads the
+                failing test, runs it, edits the fix, and re-runs before
+                opening a PR. The other guesses, patches, and submits
+                without verifying. Both land green in CI — only one is
+                safe to put on your critical path.
+              </p>
+              <p className="mt-4">
+                AgentClash scores tool order, redundancy, recovery from
+                build errors, and unnecessary file reads. The verdict
+                isn&apos;t just &ldquo;tests pass&rdquo; — it&apos;s
+                &ldquo;this agent behaved like a senior engineer.&rdquo;
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Trajectory — agent A vs B"
+              code={`# agent_a.trajectory
+  1 tool: fs.read("worker_test.go")
+  2 tool: exec("go test -race ./internal/queue")
+  3 tool: fs.read("internal/queue/worker.go")
+  4 tool: fs.write("internal/queue/worker.go")
+  5 tool: exec("go test -race ./internal/queue")  → PASS
+  6 tool: git.commit; git.push; pr.open
+
+# agent_b.trajectory
+  1 tool: fs.write("internal/queue/worker.go")    ← no reads
+  2 tool: git.commit; git.push; pr.open
+
+  verdict_a:   ✓ 9.2 / 10   cost $0.04   4m12s
+  verdict_b:   ✗ 4.1 / 10   cost $0.01   0m38s`}
+            />
+          }
+        />
+
+        <SplitSection
+          reverse
+          eyebrow="Head-to-head"
+          title={
+            <>
+              Four agents, one task,
+              <br />
+              <span className="text-white/40">one replay to scrub.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                Point four providers at the same seeded repo and let them
+                go. Every tool call, stdout chunk, and patch hunk streams
+                into the UI in real time. When the race ends you get a
+                side-by-side replay with verdicts, cost, and a diff of
+                what each one actually shipped.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Race a new model"
+              code={`$ agentclash run create \\
+    --pack coding-swe-easy \\
+    --agents gpt-5.2,claude-4.6,aider-main,custom-harness \\
+    --follow
+
+  [00:41] claude-4.6    ✓ tests green, PR opened
+  [01:08] gpt-5.2       ✓ tests green, PR opened
+  [02:33] aider-main    ✗ build failure, gave up
+  [03:14] custom-harness✓ tests green, PR opened
+
+  leaderboard:
+    1. claude-4.6      9.4  $0.031  2m18s
+    2. custom-harness  9.1  $0.092  3m14s
+    3. gpt-5.2         8.6  $0.048  1m08s
+    4. aider-main      2.3  $0.004  2m33s`}
+            />
+          }
+        />
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Capabilities
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                Built for the agents that actually touch production code.
+              </h2>
+            </div>
+            <div className="mt-20">
+              <FeatureGrid features={FEATURES} columns={3} />
+            </div>
+          </div>
+        </section>
+
+        <FAQBlock items={FAQ_ITEMS} schemaId="ld-coding-faq" />
+
+        <ClosingCTA
+          title={
+            <>
+              Ship the agent
+              <br />
+              <span className="text-white/40">that reads the test first.</span>
+            </>
+          }
+          body={
+            <p>
+              Let us race your shortlist against a seeded copy of your
+              monorepo so you can see how each one handles a real ticket
+              before you let it touch main.
+            </p>
+          }
+        >
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+            <DemoButton
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
+            />
+            <Link
+              href="/v2/platform/ci-cd-gating"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+            >
+              Gate your CI
+              <ArrowRight className="size-4" />
+            </Link>
+          </div>
+        </ClosingCTA>
+      </MarketingShell>
+    </>
+  );
+}

--- a/web/src/app/v2/use-cases/deep-research/page.tsx
+++ b/web/src/app/v2/use-cases/deep-research/page.tsx
@@ -1,0 +1,308 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { PageHeader } from "@/components/marketing/page-header";
+import { SplitSection } from "@/components/marketing/split-section";
+import { FeatureGrid } from "@/components/marketing/feature-grid";
+import { ClosingCTA } from "@/components/marketing/closing-cta";
+import { DemoButton } from "@/components/marketing/demo-button";
+import { CodeCard } from "@/components/marketing/code-card";
+import { FAQBlock } from "@/components/marketing/faq-block";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+
+const PATH = "/v2/use-cases/deep-research";
+
+export const metadata: Metadata = {
+  title: "Evaluate deep research agents",
+  description:
+    "Evaluate deep research agents on multi-source retrieval, grounding, and verification. Score sub-query planning, citations, and cross-checks with AgentClash.",
+  alternates: { canonical: PATH },
+  openGraph: {
+    title: "Evaluate deep research agents — AgentClash",
+    description:
+      "Grade long-horizon research agents on source quality, citation fidelity, and cross-check behavior — not just output polish.",
+    url: PATH,
+  },
+};
+
+const FEATURES = [
+  {
+    label: "Sub-query planning",
+    title: "Score the research tree.",
+    body: "A good researcher decomposes the question before it starts searching. We grade the sub-query plan — breadth, ordering, and whether it revisits gaps — alongside the final answer.",
+  },
+  {
+    label: "Citations",
+    title: "Quote or it didn't happen.",
+    body: "Every claim needs a URL and a passage. We check that cited passages exist in the fetched page and actually support the claim — not just that a link was dropped next to it.",
+  },
+  {
+    label: "Cross-check",
+    title: "Two independent sources.",
+    body: "For load-bearing facts, grade whether the agent cross-verified against a second source — not two mirrors of the same press release.",
+  },
+  {
+    label: "Source quality",
+    title: "Primary over aggregator.",
+    body: "Agents that cite SEC filings, arXiv, or official docs score above agents that cite content farms. Domain-level scoring is part of the verdict.",
+  },
+  {
+    label: "Freshness",
+    title: "Date-aware grounding.",
+    body: "Old sources quietly poison answers about moving targets. We flag claims that cite pages older than the declared freshness window.",
+  },
+  {
+    label: "Budget",
+    title: "Depth inside a time box.",
+    body: "Deep research burns tokens. Budget budgets for search calls, fetch size, and wall-clock so you can find agents that go deep without going broke.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: "What is a deep research agent evaluation?",
+    answer:
+      "It grades an agent that plans sub-queries, browses, reads, and writes a cited report against a research question — on the quality of its process, not just the polish of its final paragraph. AgentClash scores plan shape, source quality, citation fidelity, and cross-checking behavior.",
+  },
+  {
+    question: "How do you grade citations?",
+    answer:
+      "For every claim the agent makes, we verify that the cited URL was actually fetched during the run, that the quoted passage exists on the fetched page, and that the passage semantically supports the claim. A link without a supporting passage is graded as an unsupported claim.",
+  },
+  {
+    question: "Can you catch hallucinated sources?",
+    answer:
+      "Yes. Citations that don't appear in the fetch history are hallucinations by definition — the agent couldn't have read them. Those cases are flagged and heavily penalized in the verdict.",
+  },
+  {
+    question: "How do you score cross-checking?",
+    answer:
+      "Load-bearing facts (numbers, names, dates, claims about living people) are extracted from the report and checked for independent secondary sources in the fetch trajectory. Two citations to the same press release don't count as a cross-check.",
+  },
+  {
+    question: "What tools do research agents get?",
+    answer:
+      "Search, fetch, quote, and citation. Search returns ranked results; fetch pulls the full page; quote extracts passages with offsets; citation binds a claim to a (url, passage) pair. The tool policy is configurable per pack.",
+  },
+];
+
+export default function DeepResearchPage() {
+  return (
+    <>
+      <JsonLd
+        id="ld-dr-product"
+        data={productSchema({
+          name: "AgentClash — deep research agent evaluation",
+          description:
+            "Grade long-horizon research agents on source quality, citation fidelity, and cross-check behavior.",
+          url: PATH,
+        })}
+      />
+      <JsonLd
+        id="ld-dr-breadcrumbs"
+        data={breadcrumbSchema([
+          { name: "Home", url: "/v2" },
+          { name: "Use cases", url: "/v2/use-cases/coding-agents" },
+          { name: "Deep research", url: PATH },
+        ])}
+      />
+      <MarketingShell>
+        <PageHeader
+          breadcrumbs={[
+            { label: "Home", href: "/v2" },
+            { label: "Use cases" },
+            { label: "Deep research" },
+          ]}
+          eyebrow="Deep research agents"
+          title={
+            <>
+              Grade the research,
+              <br />
+              <span className="text-white/40">not the prose.</span>
+            </>
+          }
+          subtitle={
+            <>
+              Deep research agents write beautiful reports. That&apos;s the
+              problem. AgentClash strips the polish and scores what&apos;s
+              underneath: the sub-query plan, the sources fetched, the
+              passages actually quoted, and whether the agent bothered to
+              cross-check the numbers.
+            </>
+          }
+          cta={
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+              <DemoButton />
+              <Link
+                href="/v2/platform/rag-evaluation"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+              >
+                RAG evaluation
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
+          }
+          aside={
+            <CodeCard
+              title="A research case"
+              code={`# packs/q1-earnings-rollup.yaml
+question: |
+  Summarize Q1-2026 cloud revenue for the
+  three hyperscalers. Flag any segment
+  reclassifications since Q4-2025.
+tools: [search, fetch, quote, citation]
+require:
+  - cross_check_min: 2
+  - primary_source_ratio: 0.6
+  - citation_fidelity: 0.95
+  - freshness_days_max: 60`}
+            />
+          }
+        />
+
+        <SplitSection
+          eyebrow="Plan → fetch → quote"
+          title={
+            <>
+              Good research has shape.
+              <br />
+              <span className="text-white/40">Most agents skip straight to prose.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                The first failure mode we see: an agent answers the
+                question from memory and back-fills a few links to make
+                it look grounded. The trajectory gives it away — writes
+                before reads, citations that weren&apos;t fetched, a
+                suspiciously short plan.
+              </p>
+              <p className="mt-4">
+                AgentClash scores the plan step explicitly. Did the agent
+                decompose the question into sub-queries? Did it visit
+                primary sources? Did it quote passages that actually
+                support the claims? Agents that skip the method get the
+                verdict they deserve.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Trajectory — grounded vs hallucinated"
+              code={`# agent_a.trajectory
+  plan: 6 sub-queries; primary > aggregator
+  1 tool: search("AWS Q1-2026 revenue 10-Q")
+  2 tool: fetch("https://ir.aws/.../10q")
+  3 tool: quote(§"Cloud segment revenue...")
+  4 tool: citation(claim_42, quote_1, source_2)
+  ...
+  verdict: ✓ 9.1 / 10   0 hallucinated citations
+
+# agent_b.trajectory
+  plan: 1 sub-query
+  1 tool: search("hyperscaler earnings")
+  2 output: <1200 words, 8 citations>
+  verdict: ✗ 3.4 / 10   4 citations not in fetch log`}
+            />
+          }
+        />
+
+        <SplitSection
+          reverse
+          eyebrow="Cross-check"
+          title={
+            <>
+              One source is a rumor.
+              <br />
+              <span className="text-white/40">Two is a fact.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                Numbers, names, and claims about living people need to
+                survive a second opinion. AgentClash extracts
+                load-bearing claims from the report and checks whether
+                each one was independently verified in the fetch
+                trajectory. Two links to the same wire story do not
+                count.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Claim extraction"
+              code={`$ agentclash run show run_01H... --claims
+
+  claim_17: "AWS Q1 op income $13.2B"
+    sources: [sec.gov/10q, reuters.com/...]
+    independent: ✓ 2 domains
+    cross_check: passed
+
+  claim_31: "Azure overtook AWS in API latency"
+    sources: [medium.com/@blogpost]
+    independent: ✗ 1 domain (opinion)
+    cross_check: failed
+    verdict_impact: -1.4`}
+            />
+          }
+        />
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Capabilities
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                Evaluate the research, not the executive summary.
+              </h2>
+            </div>
+            <div className="mt-20">
+              <FeatureGrid features={FEATURES} columns={3} />
+            </div>
+          </div>
+        </section>
+
+        <FAQBlock items={FAQ_ITEMS} schemaId="ld-dr-faq" />
+
+        <ClosingCTA
+          title={
+            <>
+              Ship researchers
+              <br />
+              <span className="text-white/40">that cite their work.</span>
+            </>
+          }
+          body={
+            <p>
+              Let us race three deep research agents against your
+              hardest question and show you the fetch trajectories,
+              claim-by-claim grounding, and cross-check verdicts.
+            </p>
+          }
+        >
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+            <DemoButton
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
+            />
+            <Link
+              href="/v2/platform/agent-evaluation"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+            >
+              Evaluation primitives
+              <ArrowRight className="size-4" />
+            </Link>
+          </div>
+        </ClosingCTA>
+      </MarketingShell>
+    </>
+  );
+}

--- a/web/src/app/v2/use-cases/sql-data-agents/page.tsx
+++ b/web/src/app/v2/use-cases/sql-data-agents/page.tsx
@@ -1,0 +1,307 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { PageHeader } from "@/components/marketing/page-header";
+import { SplitSection } from "@/components/marketing/split-section";
+import { FeatureGrid } from "@/components/marketing/feature-grid";
+import { ClosingCTA } from "@/components/marketing/closing-cta";
+import { DemoButton } from "@/components/marketing/demo-button";
+import { CodeCard } from "@/components/marketing/code-card";
+import { FAQBlock } from "@/components/marketing/faq-block";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+
+const PATH = "/v2/use-cases/sql-data-agents";
+
+export const metadata: Metadata = {
+  title: "Evaluate text-to-SQL and data agents",
+  description:
+    "Evaluate text-to-SQL and data analysis agents on correctness, schema awareness, and query economy. Benchmark analytics copilots with AgentClash.",
+  alternates: { canonical: PATH },
+  openGraph: {
+    title: "Evaluate SQL and data agents — AgentClash",
+    description:
+      "Grade text-to-SQL and analytics agents on rows returned, schema awareness, and query economy — not just whether the SQL parsed.",
+    url: PATH,
+  },
+};
+
+const FEATURES = [
+  {
+    label: "Row correctness",
+    title: "Did it return the right answer?",
+    body: "We execute the agent's query against the actual warehouse and diff the result set against the golden rows. No LLM judge, no exec-plan heuristic — real rows, real verdict.",
+  },
+  {
+    label: "Schema awareness",
+    title: "Introspect before you guess.",
+    body: "Good data agents inspect tables, columns, and foreign keys before writing a join. Trajectory signatures grade whether the agent looked before it leaped.",
+  },
+  {
+    label: "Query economy",
+    title: "One query beats a thousand.",
+    body: "An answer that takes 40 CTEs and a full-table scan is a worse answer. We score query shape — predicate pushdown, join order, scanned bytes — alongside correctness.",
+  },
+  {
+    label: "Dialect safety",
+    title: "Postgres isn't Snowflake.",
+    body: "Window functions, date types, and NULL handling diverge across dialects. Run the same prompt against multiple warehouses and see which agents actually respect the dialect.",
+  },
+  {
+    label: "Guardrails",
+    title: "No DROP on the way out.",
+    body: "Policy-enforced tool scopes let analytics agents read without breaking production. A SELECT-only sandbox is one line of pack config.",
+  },
+  {
+    label: "Replay",
+    title: "Every query, every row.",
+    body: "Scrub through the full trajectory — introspections, intermediate selects, the final query, and the rows returned — side by side with the golden answer.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: "How does AgentClash grade text-to-SQL correctness?",
+    answer:
+      "We execute both the agent's query and the reference query against the same warehouse snapshot and diff the result sets. Rows, types, and ordering are compared explicitly. Queries that parse but return the wrong rows fail — this catches a lot of silent failures that plan-based graders miss.",
+  },
+  {
+    question: "What about agents that rewrite the question?",
+    answer:
+      "Analytics agents often clarify or rephrase the user's request. The pack can specify allowed clarifications, and the verdict is graded against the canonical intent — not just the surface string. If the agent answers a different question, the verdict reflects that.",
+  },
+  {
+    question: "Can I evaluate against my own schema?",
+    answer:
+      "Yes. Point a pack at a warehouse snapshot (or a synthetic clone of your prod schema with seeded rows) and the sandbox exposes it as a read-only sql tool. No warehouse credentials leave the sandbox.",
+  },
+  {
+    question: "Does this work for Snowflake, BigQuery, Postgres?",
+    answer:
+      "Yes — the sql tool is dialect-agnostic at the interface level; the sandbox image controls which engine actually runs the query. Race the same prompt against Postgres, Snowflake, and BigQuery and see which agents respect each dialect's quirks.",
+  },
+  {
+    question: "How do you score query economy?",
+    answer:
+      "We capture the EXPLAIN output and the scanned-bytes cost reported by the warehouse. Two agents that return the same rows but scan 10× different data get different economy scores, which roll into the overall verdict.",
+  },
+];
+
+export default function SqlDataAgentsPage() {
+  return (
+    <>
+      <JsonLd
+        id="ld-sql-product"
+        data={productSchema({
+          name: "AgentClash — SQL and data agent evaluation",
+          description:
+            "Grade text-to-SQL and analytics agents on row correctness, schema awareness, and query economy.",
+          url: PATH,
+        })}
+      />
+      <JsonLd
+        id="ld-sql-breadcrumbs"
+        data={breadcrumbSchema([
+          { name: "Home", url: "/v2" },
+          { name: "Use cases", url: "/v2/use-cases/coding-agents" },
+          { name: "SQL and data agents", url: PATH },
+        ])}
+      />
+      <MarketingShell>
+        <PageHeader
+          breadcrumbs={[
+            { label: "Home", href: "/v2" },
+            { label: "Use cases" },
+            { label: "SQL and data agents" },
+          ]}
+          eyebrow="SQL and data agents"
+          title={
+            <>
+              Grade the rows,
+              <br />
+              <span className="text-white/40">not the SQL.</span>
+            </>
+          }
+          subtitle={
+            <>
+              A query that parses and a query that answers the question
+              are not the same thing. AgentClash runs text-to-SQL and
+              analytics agents against real warehouse snapshots and
+              scores them on rows returned, schema awareness, and the
+              shape of the query they chose.
+            </>
+          }
+          cta={
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+              <DemoButton />
+              <Link
+                href="/v2/platform/agent-evaluation"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+                >
+                Evaluation primitives
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
+          }
+          aside={
+            <CodeCard
+              title="A text-to-SQL case"
+              code={`# packs/revenue-cohort-rollup.yaml
+warehouse: snowflake://snap/prod-clone-2026-04-01
+tools: [sql, introspect, plot, cache]
+question: |
+  Top 5 customers by Q1-2026 net new ARR,
+  excluding self-serve and including only
+  accounts with > 12 months tenure.
+golden_rows: artifacts/gold/q1-ranks.parquet
+require:
+  - row_diff: exact
+  - introspected_tables_min: 3
+  - scanned_bytes_max: 8GB`}
+            />
+          }
+        />
+
+        <SplitSection
+          eyebrow="Inspect before you guess"
+          title={
+            <>
+              The best SQL agents
+              <br />
+              <span className="text-white/40">read the schema first.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                A common failure: the agent assumes
+                <code className="mx-1 rounded bg-white/[0.06] px-1.5 py-0.5 font-[family-name:var(--font-mono)] text-[13px] text-white/80">customers.tier</code>
+                is an enum when the real column is a foreign key to
+                <code className="mx-1 rounded bg-white/[0.06] px-1.5 py-0.5 font-[family-name:var(--font-mono)] text-[13px] text-white/80">plans.id</code>.
+                The query parses, the rows are wrong, nobody catches it
+                until a dashboard disagrees with finance.
+              </p>
+              <p className="mt-4">
+                We score
+                <code className="mx-1 rounded bg-white/[0.06] px-1.5 py-0.5 font-[family-name:var(--font-mono)] text-[13px] text-white/80">introspect</code>
+                calls explicitly: which tables were inspected, whether
+                foreign keys were loaded, whether sample rows were pulled
+                before the agent committed to a join. Agents that skip
+                the inspection step have their verdicts docked even when
+                the rows happen to come back right.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Trajectory — inspect vs guess"
+              code={`# agent_a.trajectory
+  1 tool: introspect("customers")
+  2 tool: introspect("plans")
+  3 tool: introspect("subscriptions")
+  4 tool: sql("SELECT ... FROM customers c
+               JOIN plans p ON p.id = c.plan_id
+               WHERE c.created_at < ...")
+  5 verify: rows match golden ✓
+
+# agent_b.trajectory
+  1 tool: sql("SELECT ... WHERE c.tier='enterprise'")
+     → ERROR: column "tier" does not exist
+  2 tool: sql("SELECT ... WHERE c.plan='enterprise'")
+     → returns 0 rows (wrong)
+  verdict: ✗ 2.1 / 10   no introspection, wrong rows`}
+            />
+          }
+        />
+
+        <SplitSection
+          reverse
+          eyebrow="Query economy"
+          title={
+            <>
+              Right rows, wrong bill.
+              <br />
+              <span className="text-white/40">Still a regression.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                A correct query that scans 2TB because the agent forgot a
+                partition predicate is a production incident waiting to
+                happen. AgentClash captures EXPLAIN output and scanned
+                bytes for every run, so you can see which agents write
+                queries that would survive a warehouse bill review.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Economy leaderboard"
+              code={`$ agentclash run show run_01H... --economy
+
+  agent                  rows  scan    cost    verdict
+  claude-4.6             ✓     0.8GB   $0.04   9.3
+  gpt-5.2                ✓     2.1GB   $0.11   8.7
+  custom-harness         ✓    14.2GB   $0.68   6.1   ← no partition
+  open-source-copilot    ✗     —       $0.02   3.2`}
+            />
+          }
+        />
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Capabilities
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                Benchmark SQL agents on the only thing that matters — the rows.
+              </h2>
+            </div>
+            <div className="mt-20">
+              <FeatureGrid features={FEATURES} columns={3} />
+            </div>
+          </div>
+        </section>
+
+        <FAQBlock items={FAQ_ITEMS} schemaId="ld-sql-faq" />
+
+        <ClosingCTA
+          title={
+            <>
+              Ship the analyst
+              <br />
+              <span className="text-white/40">that reads the schema.</span>
+            </>
+          }
+          body={
+            <p>
+              Let us race two text-to-SQL agents against a cloned
+              warehouse and your hardest ambiguous question — rows,
+              economy, and trajectory side by side.
+            </p>
+          }
+        >
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+            <DemoButton
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
+            />
+            <Link
+              href="/v2/platform/regression-testing"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+            >
+              Regression testing
+              <ArrowRight className="size-4" />
+            </Link>
+          </div>
+        </ClosingCTA>
+      </MarketingShell>
+    </>
+  );
+}

--- a/web/src/app/v2/use-cases/sre-agents/page.tsx
+++ b/web/src/app/v2/use-cases/sre-agents/page.tsx
@@ -1,0 +1,312 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { PageHeader } from "@/components/marketing/page-header";
+import { SplitSection } from "@/components/marketing/split-section";
+import { FeatureGrid } from "@/components/marketing/feature-grid";
+import { ClosingCTA } from "@/components/marketing/closing-cta";
+import { DemoButton } from "@/components/marketing/demo-button";
+import { CodeCard } from "@/components/marketing/code-card";
+import { FAQBlock } from "@/components/marketing/faq-block";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+
+const PATH = "/v2/use-cases/sre-agents";
+
+export const metadata: Metadata = {
+  title: "Evaluate SRE and on-call agents",
+  description:
+    "Evaluate SRE and on-call agents on incident triage, log analysis, and runbook execution. Replay past incidents against candidate agents with AgentClash.",
+  alternates: { canonical: PATH },
+  openGraph: {
+    title: "Evaluate SRE agents — AgentClash",
+    description:
+      "Replay past incidents against candidate on-call agents. Score log analysis, runbook traversal, mitigation verification.",
+    url: PATH,
+  },
+};
+
+const FEATURES = [
+  {
+    label: "Incident replay",
+    title: "Past pages become tests.",
+    body: "Freeze a real incident — the alert that fired, the logs, the metric window, the cluster state — and replay it against any agent. The verdict compares against what actually resolved it.",
+  },
+  {
+    label: "Log traversal",
+    title: "Score the grep.",
+    body: "Agents that pattern-match on the first stack trace they see miss root causes. We grade log query shape — time windows, label filters, distinct services sampled — alongside the final diagnosis.",
+  },
+  {
+    label: "Runbook discipline",
+    title: "Follow the doc.",
+    body: "Most incidents have a runbook; most bad on-calls skip it. Trajectory signatures verify step order, tool preconditions, and abort conditions from your runbook markdown.",
+  },
+  {
+    label: "Mitigation verify",
+    title: "Did the fix actually fix it?",
+    body: "After the agent declares mitigation, the sandbox checks the SLO window for the metric that fired the alert. A rollback that silences the pager but tanks latency fails.",
+  },
+  {
+    label: "Blast radius",
+    title: "Scoped tools, scoped risk.",
+    body: "kube, ssh, logs, metrics — each with its own allowlist. A candidate agent can triage without being able to delete a namespace. Policy violations are hard verdict failures.",
+  },
+  {
+    label: "Postmortem",
+    title: "Write the note.",
+    body: "After mitigation, grade the postmortem note the agent produces: timeline, root cause, blast radius, action items. Calibrated against your team's best postmortems.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: "How does AgentClash replay a past incident?",
+    answer:
+      "We freeze the inputs that an on-call would have seen at the moment the page fired: the alert payload, a time-bounded snapshot of logs and metrics, the cluster state (kubectl get / describe), and any relevant runbook links. The agent gets a sandbox with read access to those sources and whatever mitigation tools your policy allows.",
+  },
+  {
+    question: "What tools do SRE agents get?",
+    answer:
+      "logs (Loki-style query), metrics (Prom-style range query), kube (read + scoped write per policy), ssh (scoped per host pool), and runbook (structured markdown). Each tool has a per-pack allowlist — a triage-only pack can ban every write tool in one config line.",
+  },
+  {
+    question: "How do you verify mitigation actually worked?",
+    answer:
+      "Packs declare the SLO metric the alert was protecting. After the agent declares mitigation, the sandbox inspects the metric over the follow-up window. An action that silenced the alert but violated the real SLO fails the verdict — this catches cosmetic fixes.",
+  },
+  {
+    question: "Can agents execute destructive commands?",
+    answer:
+      "Only if the pack policy allows it, and only against the sandboxed cluster. Production credentials never enter the sandbox. For restricted modes, the entire kube write surface can be disabled — the agent can diagnose but not touch.",
+  },
+  {
+    question: "Does this integrate with my runbook repo?",
+    answer:
+      "Yes. Point the runbook tool at a directory of markdown files (or a Notion / Confluence export). Runbooks are first-class pack inputs — the verdict can require that the agent opened the right one before acting.",
+  },
+];
+
+export default function SreAgentsPage() {
+  return (
+    <>
+      <JsonLd
+        id="ld-sre-product"
+        data={productSchema({
+          name: "AgentClash — SRE and on-call agent evaluation",
+          description:
+            "Replay past incidents against candidate on-call agents. Grade log analysis, runbook traversal, and mitigation verification.",
+          url: PATH,
+        })}
+      />
+      <JsonLd
+        id="ld-sre-breadcrumbs"
+        data={breadcrumbSchema([
+          { name: "Home", url: "/v2" },
+          { name: "Use cases", url: "/v2/use-cases/coding-agents" },
+          { name: "SRE agents", url: PATH },
+        ])}
+      />
+      <MarketingShell>
+        <PageHeader
+          breadcrumbs={[
+            { label: "Home", href: "/v2" },
+            { label: "Use cases" },
+            { label: "SRE agents" },
+          ]}
+          eyebrow="SRE and on-call agents"
+          title={
+            <>
+              Replay the page.
+              <br />
+              <span className="text-white/40">Grade the on-call.</span>
+            </>
+          }
+          subtitle={
+            <>
+              Your best on-call reads the runbook, diffs the last deploy,
+              and verifies the SLO before going back to bed. AgentClash
+              replays past incidents against candidate agents with the
+              same logs, metrics, and cluster state, then scores the
+              parts that separate a triage from a rollback.
+            </>
+          }
+          cta={
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+              <DemoButton />
+              <Link
+                href="/v2/platform/multi-turn-evaluation"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+              >
+                Multi-turn evaluation
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
+          }
+          aside={
+            <CodeCard
+              title="An incident replay"
+              code={`# packs/incident-2026-03-12-p99.yaml
+alert: HighCheckoutP99@v2.checkout
+snapshot:
+  logs:    loki://snap/2026-03-12T14:00Z/+30m
+  metrics: prom://snap/2026-03-12T14:00Z/+30m
+  kube:    kube://snap/prod-us-east-1
+runbook: runbooks/checkout-p99.md
+tools: [logs, metrics, kube, ssh]
+slo: checkout_p99_ms < 450
+expected_signature:
+  - opened_runbook: ["checkout-p99.md"]
+  - diff_incident_deploy: true
+  - verify_slo_window: 15m`}
+            />
+          }
+        />
+
+        <SplitSection
+          eyebrow="Diff the incident"
+          title={
+            <>
+              Most P1s are caused
+              <br />
+              <span className="text-white/40">by the last deploy.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                A good on-call looks at the deploy pipeline before they
+                start reading stack traces. A bad on-call scrolls logs
+                for 40 minutes and reboots the wrong pod. AgentClash
+                tracks whether the agent correlated the alert window
+                against recent deploys, config changes, and feature-flag
+                flips — before it started hunting.
+              </p>
+              <p className="mt-4">
+                Trajectory signatures can require specific early moves:
+                open the runbook, pull the last 2 hours of deploys,
+                check saturation metrics. Agents that skip straight to
+                <code className="mx-1 rounded bg-white/[0.06] px-1.5 py-0.5 font-[family-name:var(--font-mono)] text-[13px] text-white/80">kubectl delete pod</code>
+                have their verdicts docked before the outcome is even
+                known.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Trajectory — triage vs flail"
+              code={`# agent_a.trajectory
+  1 tool: runbook.open("checkout-p99.md")
+  2 tool: kube.deploys(svc=checkout, last=2h)
+     → release r_92a (10m before alert)
+  3 tool: metrics(checkout_p99, window=45m)
+  4 tool: logs(svc=checkout, level=error, 20m)
+     → N+1 on ORDER_ITEMS after r_92a
+  5 tool: kube.rollback(release=r_91f)
+  6 verify: p99 < 450 for 15m → ✓
+  verdict: ✓ 9.5 / 10   MTTR 7m42s
+
+# agent_b.trajectory
+  1 tool: kube.delete pod checkout-7d...
+  2 tool: kube.delete pod checkout-7d...
+  3 (looped for 18m, alert re-fired)
+  verdict: ✗ 2.0 / 10   no runbook, no rollback`}
+            />
+          }
+        />
+
+        <SplitSection
+          reverse
+          eyebrow="Verify the SLO"
+          title={
+            <>
+              Silencing the pager
+              <br />
+              <span className="text-white/40">isn&apos;t the same as mitigation.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                Agents that reduce alert sensitivity, redirect traffic
+                away from the symptom, or roll back a healthy canary can
+                all make the page go away without fixing anything. Packs
+                declare the SLO the alert was protecting, and the
+                verdict inspects the metric window after mitigation. A
+                quiet pager with a broken SLO fails the run.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Verdict excerpt"
+              code={`$ agentclash run show run_01H... --verdict
+
+  opened_runbook:           ✓ checkout-p99.md
+  diff_last_deploy:         ✓ r_92a flagged
+  log_query_shape:          ✓ 0.91
+  mitigation_action:        ✓ rollback r_91f
+  slo_verified_15m:         ✓ p99 held < 450
+  postmortem_note_quality:  ✓ 0.88
+
+  overall: 9.3 / 10   candidate promoted to regression suite`}
+            />
+          }
+        />
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Capabilities
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                Evaluate on-call agents against the incidents you already survived.
+              </h2>
+            </div>
+            <div className="mt-20">
+              <FeatureGrid features={FEATURES} columns={3} />
+            </div>
+          </div>
+        </section>
+
+        <FAQBlock items={FAQ_ITEMS} schemaId="ld-sre-faq" />
+
+        <ClosingCTA
+          title={
+            <>
+              Ship the on-call
+              <br />
+              <span className="text-white/40">that opens the runbook.</span>
+            </>
+          }
+          body={
+            <p>
+              Let us replay your last three P1s against two candidate
+              agents and show you runbook discipline, mitigation shape,
+              and SLO verification side by side.
+            </p>
+          }
+        >
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+            <DemoButton
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
+            />
+            <Link
+              href="/v2/platform/regression-testing"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+            >
+              Regression testing
+              <ArrowRight className="size-4" />
+            </Link>
+          </div>
+        </ClosingCTA>
+      </MarketingShell>
+    </>
+  );
+}

--- a/web/src/app/v2/use-cases/support-agents/page.tsx
+++ b/web/src/app/v2/use-cases/support-agents/page.tsx
@@ -1,0 +1,305 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { PageHeader } from "@/components/marketing/page-header";
+import { SplitSection } from "@/components/marketing/split-section";
+import { FeatureGrid } from "@/components/marketing/feature-grid";
+import { ClosingCTA } from "@/components/marketing/closing-cta";
+import { DemoButton } from "@/components/marketing/demo-button";
+import { CodeCard } from "@/components/marketing/code-card";
+import { FAQBlock } from "@/components/marketing/faq-block";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+
+const PATH = "/v2/use-cases/support-agents";
+
+export const metadata: Metadata = {
+  title: "Evaluate customer support agents",
+  description:
+    "Evaluate customer support agents on ticket triage, tool use, and reply quality. Grade classify, gather, draft, and escalate on real ticket history.",
+  alternates: { canonical: PATH },
+  openGraph: {
+    title: "Evaluate customer support agents — AgentClash",
+    description:
+      "Race support agents on real ticket replays. Score intent classification, tool use, reply quality, and escalation discipline.",
+    url: PATH,
+  },
+};
+
+const FEATURES = [
+  {
+    label: "Intent",
+    title: "Classify before you reply.",
+    body: "Agents that skip classification and dive into a reply end up answering the wrong ticket. We grade intent tagging against the labeled ground truth from your resolved tickets.",
+  },
+  {
+    label: "CRM gather",
+    title: "Read the account first.",
+    body: "Plan, tenure, open balance, last five tickets — good agents pull context before drafting. Trajectory signatures catch the agents that reply from a cold start.",
+  },
+  {
+    label: "KB grounding",
+    title: "Cite the article, not a vibe.",
+    body: "Policy-bound replies must reference a real KB article. Cited articles that don't exist, or don't say what the agent claims, fail the verdict.",
+  },
+  {
+    label: "Escalation",
+    title: "Escalate when the rule says.",
+    body: "Churn risk, legal flag, VIP tier — these trigger human routing. We score whether the agent escalated when the rules said so, not just whether the final reply looked nice.",
+  },
+  {
+    label: "Tone",
+    title: "Empathy without theatrics.",
+    body: "Tone scoring is calibrated against your brand's resolved replies, not a generic helpfulness judge. Agents that over-apologize or over-explain get dinged.",
+  },
+  {
+    label: "Replay",
+    title: "Every ticket, every tool call.",
+    body: "Scrub through tool invocations, KB lookups, draft revisions, and the final reply against the actual resolution your team shipped.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: "How do you evaluate support agents without real customers?",
+    answer:
+      "AgentClash replays your historical ticket archive. Each case is seeded with the original ticket, the account state at the time, and the known-good resolution (either the reply your team sent or an annotated ideal). The agent gets the same tools your humans use — CRM, KB, billing, escalate — against a sandboxed clone.",
+  },
+  {
+    question: "What tools do support agents get?",
+    answer:
+      "crm for account lookup, kb for knowledge base search, billing for account and charge inspection, and escalate for routing to human tiers. The tool policy is defined per pack so you can test restricted agent personas (e.g. a tier-1 agent without billing access).",
+  },
+  {
+    question: "How do you score reply quality?",
+    answer:
+      "Replies are compared against the shipped resolution on factual correctness, policy compliance, and tone. For open-ended replies we use calibrated trajectory and content signatures; for policy-bound replies we check exact KB citations and escalation rules. The verdict is explainable: you see exactly which sub-score moved.",
+  },
+  {
+    question: "Can I test escalation rules?",
+    answer:
+      "Yes. Packs can declare escalation triggers (VIP tier, open balance > N, churn signal, legal flag) and the verdict fails any reply that should have escalated but didn't. This catches a class of silent failures where the agent writes a polite reply to a customer who needed a human 10 minutes ago.",
+  },
+  {
+    question: "Does this work with Zendesk, Intercom, Front?",
+    answer:
+      "Tool adapters are pluggable. The CRM tool is a thin interface; point it at a Zendesk export or an Intercom snapshot and the sandbox serves the same ticket and account state the live agent would have seen.",
+  },
+];
+
+export default function SupportAgentsPage() {
+  return (
+    <>
+      <JsonLd
+        id="ld-support-product"
+        data={productSchema({
+          name: "AgentClash — customer support agent evaluation",
+          description:
+            "Grade support agents on intent classification, tool use, reply quality, and escalation discipline against real ticket replays.",
+          url: PATH,
+        })}
+      />
+      <JsonLd
+        id="ld-support-breadcrumbs"
+        data={breadcrumbSchema([
+          { name: "Home", url: "/v2" },
+          { name: "Use cases", url: "/v2/use-cases/coding-agents" },
+          { name: "Support agents", url: PATH },
+        ])}
+      />
+      <MarketingShell>
+        <PageHeader
+          breadcrumbs={[
+            { label: "Home", href: "/v2" },
+            { label: "Use cases" },
+            { label: "Support agents" },
+          ]}
+          eyebrow="Support agent evaluation"
+          title={
+            <>
+              Replay tickets.
+              <br />
+              <span className="text-white/40">Score resolutions.</span>
+            </>
+          }
+          subtitle={
+            <>
+              A support agent that writes a polite reply to a churn-risk
+              customer is still a bad agent. AgentClash replays your
+              ticket history against candidate agents and scores the
+              parts that actually matter — classify intent, gather
+              context, draft the right reply, escalate when the rule
+              says so.
+            </>
+          }
+          cta={
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+              <DemoButton />
+              <Link
+                href="/v2/platform/multi-turn-evaluation"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+              >
+                Multi-turn evaluation
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
+          }
+          aside={
+            <CodeCard
+              title="A ticket replay"
+              code={`# packs/ticket-replay-2026-q1.yaml
+ticket: t_91a2...
+snapshot: crm://zendesk/2026-03-14T11:02Z
+tools: [crm, kb, billing, escalate]
+required_behaviors:
+  - classify_intent: billing_dispute
+  - gather: [account.plan, account.balance]
+  - cite_kb: ["refund-eligibility"]
+  - escalate_if: balance > $500`}
+            />
+          }
+        />
+
+        <SplitSection
+          eyebrow="Classify, then reply"
+          title={
+            <>
+              Most bad replies come
+              <br />
+              <span className="text-white/40">from skipped classification.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                The modal failure in support agent trajectories:
+                <code className="mx-1 rounded bg-white/[0.06] px-1.5 py-0.5 font-[family-name:var(--font-mono)] text-[13px] text-white/80">draft_reply</code>
+                is the first tool call. No intent tag, no account pull,
+                no KB lookup — just an apology and a generic next step.
+                The reply is fine English and wrong English.
+              </p>
+              <p className="mt-4">
+                Trajectory signatures grade the prep work explicitly. If
+                the pack says a billing dispute requires a balance check
+                and a refund-eligibility KB lookup, the verdict fails
+                replies that shipped without them — even if the prose
+                reads great.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Trajectory — classify vs wing it"
+              code={`# agent_a.trajectory
+  1 tool: classify_intent → "billing_dispute"
+  2 tool: crm.get(account) → tier=pro, bal=$612
+  3 tool: kb.search("refund eligibility")
+  4 tool: kb.read("refund-eligibility")
+  5 tool: escalate(tier=2, reason=balance>500)
+  6 tool: draft_reply(cite=["refund-eligibility"])
+  verdict: ✓ 9.0 / 10
+
+# agent_b.trajectory
+  1 tool: draft_reply("So sorry to hear this...")
+  verdict: ✗ 3.1 / 10   no classify, no escalate,
+          cited KB article not fetched`}
+            />
+          }
+        />
+
+        <SplitSection
+          reverse
+          eyebrow="Escalation discipline"
+          title={
+            <>
+              Polite isn&apos;t always right.
+              <br />
+              <span className="text-white/40">Some tickets need a human.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                Escalation rules exist because some tickets can&apos;t be
+                resolved by an agent — VIP tier, legal exposure, churn
+                signal, balance over threshold. AgentClash checks
+                whether the agent escalated when the rules said so, and
+                the verdict fails replies that resolved tickets that
+                should have been routed.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Verdict excerpt"
+              code={`$ agentclash run show run_01H... --verdict
+
+  intent_classification:    ✓ 1.0
+  context_gathering:        ✓ 0.92
+  kb_citation_fidelity:     ✓ 1.0
+  escalation_discipline:    ✗ 0.20  ← should have routed
+    reason: ticket had churn_flag=high
+            but agent resolved without escalate()
+  tone_calibration:         ✓ 0.87
+
+  overall: 6.4 / 10   flagged for review`}
+            />
+          }
+        />
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Capabilities
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                Evaluate support agents on the behaviors your best humans share.
+              </h2>
+            </div>
+            <div className="mt-20">
+              <FeatureGrid features={FEATURES} columns={3} />
+            </div>
+          </div>
+        </section>
+
+        <FAQBlock items={FAQ_ITEMS} schemaId="ld-support-faq" />
+
+        <ClosingCTA
+          title={
+            <>
+              Ship agents that know
+              <br />
+              <span className="text-white/40">when to hand off.</span>
+            </>
+          }
+          body={
+            <p>
+              Let us replay a month of your hardest tickets against two
+              candidate agents and show you intent, context, citation,
+              and escalation side by side.
+            </p>
+          }
+        >
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+            <DemoButton
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
+            />
+            <Link
+              href="/v2/platform/regression-testing"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+            >
+              Regression testing
+              <ArrowRight className="size-4" />
+            </Link>
+          </div>
+        </ClosingCTA>
+      </MarketingShell>
+    </>
+  );
+}

--- a/web/src/app/v2/vs/braintrust/page.tsx
+++ b/web/src/app/v2/vs/braintrust/page.tsx
@@ -1,0 +1,383 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { PageHeader } from "@/components/marketing/page-header";
+import { SplitSection } from "@/components/marketing/split-section";
+import { FeatureGrid } from "@/components/marketing/feature-grid";
+import {
+  ComparisonTable,
+  type ComparisonColumn,
+  type ComparisonRow,
+} from "@/components/marketing/comparison-table";
+import { ClosingCTA } from "@/components/marketing/closing-cta";
+import { DemoButton } from "@/components/marketing/demo-button";
+import { CodeCard } from "@/components/marketing/code-card";
+import { FAQBlock } from "@/components/marketing/faq-block";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+
+const PATH = "/v2/vs/braintrust";
+
+export const metadata: Metadata = {
+  title: "AgentClash vs Braintrust",
+  description:
+    "Braintrust is a polished SDK-first prompt-eval and experiment-tracking tool — great for hill-climbing a single prompt. AgentClash races multi-turn agent trajectories with real tools in a sandbox and gates CI on the verdict.",
+  alternates: { canonical: PATH },
+  openGraph: {
+    title: "AgentClash vs Braintrust — agent eval vs prompt iteration",
+    description:
+      "Braintrust hill-climbs a single prompt. AgentClash races whole trajectories with real tools. A direct comparison.",
+    url: PATH,
+  },
+};
+
+const COLUMNS: ComparisonColumn[] = [
+  { name: "AgentClash", tag: "Agent eval", highlight: true },
+  { name: "Braintrust", tag: "Prompt eval + experiments" },
+];
+
+const ROWS: ComparisonRow[] = [
+  {
+    label: "Multi-turn agent loops",
+    sub: "Scores plans, tool sequences, self-correction, and termination — not a single model call.",
+    cells: ["yes", "partial"],
+  },
+  {
+    label: "Sandboxed tool execution",
+    sub: "Ephemeral VM with real filesystems, subprocesses, and network-policy isolation.",
+    cells: ["yes", "no"],
+  },
+  {
+    label: "Head-to-head concurrent race",
+    sub: "N models on the same inputs, same budget, same scorer — in parallel.",
+    cells: ["yes", "partial"],
+  },
+  {
+    label: "Trajectory scoring",
+    sub: "Plan adherence, tool-order signature, termination reason. Not just the final string.",
+    cells: ["yes", "partial"],
+  },
+  {
+    label: "Failures as CI regressions",
+    sub: "Flunks freeze into a permanent regression suite that blocks future merges.",
+    cells: ["yes", "no"],
+  },
+  {
+    label: "Open source, self-hostable",
+    sub: "Race engine, scorers, and CLI available under FSL-1.1-MIT.",
+    cells: ["yes", "no"],
+  },
+  {
+    label: "Single-prompt hill climbing UX",
+    sub: "Scorecards, experiment diffs, and iterate-on-one-prompt workflows.",
+    cells: ["partial", "yes"],
+  },
+  {
+    label: "Custom scorers + LLM-as-judge SDK",
+    sub: "Rich SDK for writing dataset-based scorers and custom graders.",
+    cells: ["partial", "yes"],
+  },
+];
+
+const FEATURES = [
+  {
+    label: "Sandbox",
+    title: "Tool calls that actually execute.",
+    body: "Each agent runs in an isolated E2B environment. No mocked tool stubs, no memorized outputs — the scorer sees what the tool actually returned.",
+  },
+  {
+    label: "Race",
+    title: "Concurrent competition, not sequential trials.",
+    body: "Fire all your candidates at the same inputs with the same time budget in parallel. The verdict is a true ranking, not a sequence of experiment rows you line up by eye.",
+  },
+  {
+    label: "Trajectory",
+    title: "Score the path, not just the output.",
+    body: "Plan shape, tool-order signature, self-correction, termination reason. Two models can reach the same string via very different competence.",
+  },
+  {
+    label: "Provider-neutral",
+    title: "Every major provider, normalized.",
+    body: "OpenAI, Anthropic, Gemini, xAI, Mistral, OpenRouter. Tool-call shapes and failure codes normalized, so verdicts are apples-to-apples.",
+  },
+  {
+    label: "CI native",
+    title: "Regressions block the merge.",
+    body: "A CLI designed for CI: posts verdicts as GitHub checks, blocks the PR when a trajectory regresses, links straight to the failing replay.",
+  },
+  {
+    label: "Open",
+    title: "Read the scorer. Fork the engine.",
+    body: "Everything under FSL-1.1-MIT. The full race engine, scoring pipeline, and CLI are self-hostable — cloud is a convenience, not a lock-in.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: "When should I use Braintrust instead?",
+    answer:
+      "If your primary workflow is iterating on a single prompt with a scorecard — comparing temperatures, tweaking system prompts, hill-climbing against a golden dataset — Braintrust has the best UX in the category. AgentClash is built for a different shape of problem: multi-turn agents with tool use, where the unit of evaluation is a trajectory, not a completion.",
+  },
+  {
+    question: "Can I migrate from Braintrust?",
+    answer:
+      "Yes, gradually. Your golden datasets map into AgentClash challenge packs, but you'll want to upgrade them to describe tools, sandbox images, and trajectory rubrics instead of just input/reference pairs. Most teams run both: Braintrust for single-prompt iteration, AgentClash for agent-level CI gates.",
+  },
+  {
+    question: "Do you support custom scorers?",
+    answer:
+      "Yes. AgentClash ships reference scorers for correctness, cost, latency, and behavior, and lets you drop in custom scorers as tool-calling agents themselves. The SDK surface is smaller than Braintrust's today — if you need a rich LLM-judge authoring workflow right now, Braintrust is ahead.",
+  },
+  {
+    question: "Is AgentClash open source?",
+    answer:
+      "Yes, under FSL-1.1-MIT. Every part of the race engine, scorer pipeline, and CLI is self-hostable. Managed cloud is an option, not a requirement.",
+  },
+  {
+    question: "How is the CI story different?",
+    answer:
+      "Braintrust leans on SDK invocations during your test runs. AgentClash ships a first-class CLI that spawns durable workflows, waits on verdicts, and posts GitHub checks — the flunk archive becomes a regression suite automatically, so the next model ships against a higher bar than the last.",
+  },
+];
+
+export default function VsBraintrustPage() {
+  return (
+    <>
+      <JsonLd
+        id="ld-vs-braintrust-product"
+        data={productSchema({
+          name: "AgentClash vs Braintrust",
+          description:
+            "Side-by-side comparison of AgentClash (agent evaluation, trajectory scoring, CI gates) against Braintrust (SDK-first prompt eval, experiment tracking, custom scorers).",
+          url: PATH,
+        })}
+      />
+      <JsonLd
+        id="ld-vs-braintrust-breadcrumbs"
+        data={breadcrumbSchema([
+          { name: "Home", url: "/v2" },
+          { name: "Compare", url: "/v2/vs/braintrust" },
+          { name: "Braintrust", url: PATH },
+        ])}
+      />
+      <MarketingShell>
+        <PageHeader
+          breadcrumbs={[
+            { label: "Home", href: "/v2" },
+            { label: "Compare" },
+            { label: "Braintrust" },
+          ]}
+          eyebrow="AgentClash vs Braintrust"
+          title={
+            <>
+              Races and regressions.
+              <br />
+              <span className="text-white/40">Not experiment rows.</span>
+            </>
+          }
+          subtitle={
+            <>
+              Braintrust is one of the cleanest SDK-first prompt-eval tools
+              you can buy — great for iterating on a single prompt with a
+              scorecard. AgentClash races whole agent trajectories with
+              real tools, concurrent, in a sandbox, and gates CI on the
+              verdict. Different shape of problem.
+            </>
+          }
+          cta={
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+              <DemoButton />
+              <Link
+                href="/v2/oss"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+              >
+                Self-host
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
+          }
+          aside={
+            <CodeCard
+              title="Braintrust — typical experiment"
+              language="typescript"
+              code={`import { Eval } from "braintrust";
+import { LLMClassifier } from "autoevals";
+
+Eval("rag-qa", {
+  data: () => dataset,
+  task: async ({ input }) => {
+    return await chain({ question: input });
+  },
+  scores: [LLMClassifier("correct", {
+    prompt: "Did the answer cite p.7?",
+  })],
+});`}
+            />
+          }
+        />
+
+        <SplitSection
+          eyebrow="Where Braintrust shines"
+          title={
+            <>
+              Iterate on a prompt.
+              <br />
+              <span className="text-white/40">With a polished scorecard.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                If the unit of work is a single prompt — system message,
+                few-shot examples, temperature — Braintrust has the most
+                polished experiment-tracking UX in the category. Custom
+                scorers are a pleasure to write, the diff view is tasteful,
+                and hill-climbing a golden dataset feels right.
+              </p>
+              <p className="mt-4">
+                AgentClash doesn&apos;t try to out-prompt-eval Braintrust.
+                If your job is to get one prompt 2% better against a
+                reference set, keep using it.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Braintrust — experiment SDK"
+              language="typescript"
+              code={`import { initExperiment } from "braintrust";
+
+const exp = initExperiment("prompt-a-vs-b");
+
+for (const row of goldenSet) {
+  const out = await llm(row.input);
+  exp.log({
+    input: row.input,
+    output: out,
+    expected: row.expected,
+    scores: { exact: row.expected === out ? 1 : 0 },
+  });
+}`}
+            />
+          }
+        />
+
+        <SplitSection
+          reverse
+          eyebrow="Where AgentClash wins"
+          title={
+            <>
+              Trajectories.
+              <br />
+              <span className="text-white/40">Concurrent. In a sandbox.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                Experiments are sequential by design. Trajectories
+                are not. When an agent makes eight tool calls, handles a
+                flaky search, and decides to terminate — that whole path
+                is the unit of evaluation. Racing it head-to-head against
+                three other providers is what tells you who to ship.
+              </p>
+              <p className="mt-4">
+                AgentClash does that in a real sandbox, not a mock harness.
+                Tools execute. Files change. Subprocesses run. The verdict
+                is based on what actually happened.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="AgentClash — race + verdict"
+              code={`$ agentclash run create \\
+    --pack sql-refactor \\
+    --agents gpt-5,claude-4.5,gemini-2.5,grok-4 \\
+    --follow
+
+  gpt-5       ● on-plan   9.1  $0.019  11.2s
+  claude-4.5  ● on-plan   8.8  $0.014  13.8s
+  gemini-2.5  ◐ loop:2    6.4  $0.022  24.1s
+  grok-4      ● on-plan   8.2  $0.011  10.4s
+
+verdict → winner: grok-4 (cost-weighted)`}
+            />
+          }
+        />
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Side by side
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                What each tool is actually good at.
+              </h2>
+            </div>
+            <div className="mt-16">
+              <ComparisonTable columns={COLUMNS} rows={ROWS} />
+            </div>
+          </div>
+        </section>
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Where AgentClash pulls ahead
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                Six things an experiment tracker can&apos;t do.
+              </h2>
+            </div>
+            <div className="mt-20">
+              <FeatureGrid features={FEATURES} columns={3} />
+            </div>
+          </div>
+        </section>
+
+        <FAQBlock
+          title="Braintrust vs AgentClash, answered."
+          items={FAQ_ITEMS}
+          schemaId="ld-vs-braintrust-faq"
+        />
+
+        <ClosingCTA
+          title={
+            <>
+              Keep your scorecards.
+              <br />
+              <span className="text-white/40">Race your agents.</span>
+            </>
+          }
+          body={
+            <p>
+              We&apos;ll set up a head-to-head race on your hardest
+              multi-turn task in 20 minutes. If an experiment row would
+              have told you the same thing, we&apos;ll say so out loud.
+            </p>
+          }
+        >
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+            <DemoButton className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors" />
+            <Link
+              href="/v2/platform/agent-evaluation"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+            >
+              Platform overview
+              <ArrowRight className="size-4" />
+            </Link>
+          </div>
+        </ClosingCTA>
+      </MarketingShell>
+    </>
+  );
+}

--- a/web/src/app/v2/vs/langfuse/page.tsx
+++ b/web/src/app/v2/vs/langfuse/page.tsx
@@ -1,0 +1,381 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { PageHeader } from "@/components/marketing/page-header";
+import { SplitSection } from "@/components/marketing/split-section";
+import { FeatureGrid } from "@/components/marketing/feature-grid";
+import {
+  ComparisonTable,
+  type ComparisonColumn,
+  type ComparisonRow,
+} from "@/components/marketing/comparison-table";
+import { ClosingCTA } from "@/components/marketing/closing-cta";
+import { DemoButton } from "@/components/marketing/demo-button";
+import { CodeCard } from "@/components/marketing/code-card";
+import { FAQBlock } from "@/components/marketing/faq-block";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+
+const PATH = "/v2/vs/langfuse";
+
+export const metadata: Metadata = {
+  title: "AgentClash vs Langfuse",
+  description:
+    "Langfuse is an excellent OSS LLM observability platform — production traces, cost attribution, dataset grading. AgentClash is built one room over: racing multi-turn agents with real tools and gating CI on the verdict.",
+  alternates: { canonical: PATH },
+  openGraph: {
+    title: "AgentClash vs Langfuse — agent eval vs LLM observability",
+    description:
+      "Langfuse traces production LLM calls. AgentClash races pre-merge agent trajectories in a sandbox. A direct comparison.",
+    url: PATH,
+  },
+};
+
+const COLUMNS: ComparisonColumn[] = [
+  { name: "AgentClash", tag: "Agent eval", highlight: true },
+  { name: "Langfuse", tag: "LLM observability + evals" },
+];
+
+const ROWS: ComparisonRow[] = [
+  {
+    label: "Multi-turn agent loops",
+    sub: "Scores plans, tool calls, self-correction, and termination — not a single LLM call.",
+    cells: ["yes", "partial"],
+  },
+  {
+    label: "Sandboxed tool execution",
+    sub: "Ephemeral VM with real filesystem, subprocesses, and network-policy isolation.",
+    cells: ["yes", "no"],
+  },
+  {
+    label: "Head-to-head concurrent race",
+    sub: "N models on the same inputs, same budget, same scorer — a single verdict.",
+    cells: ["yes", "no"],
+  },
+  {
+    label: "Trajectory scoring",
+    sub: "Plan adherence, tool-order signatures, self-correction, termination reason.",
+    cells: ["yes", "partial"],
+  },
+  {
+    label: "CI regression gate",
+    sub: "Flunked runs freeze into a permanent regression suite the next model has to clear.",
+    cells: ["yes", "partial"],
+  },
+  {
+    label: "Cross-provider tool normalization",
+    sub: "One challenge pack runs on OpenAI, Anthropic, Gemini, xAI, Mistral without code changes.",
+    cells: ["yes", "partial"],
+  },
+  {
+    label: "Production trace ingestion",
+    sub: "High-volume SDK ingest of every LLM call from your live app.",
+    cells: ["partial", "yes"],
+  },
+  {
+    label: "Cost & token attribution dashboards",
+    sub: "Production spend analytics sliced by user, feature, or trace.",
+    cells: ["partial", "yes"],
+  },
+];
+
+const FEATURES = [
+  {
+    label: "Sandbox",
+    title: "Tools that actually execute.",
+    body: "Agents run in ephemeral E2B environments with real filesystems, subprocesses, and network policy. Observability platforms trace what happened; sandboxes produce what should happen.",
+  },
+  {
+    label: "Race",
+    title: "Concurrent, same-budget competition.",
+    body: "Fire N providers at the same inputs in parallel. The verdict is a single ranking — not a pile of traces to cross-filter after the fact.",
+  },
+  {
+    label: "Trajectory",
+    title: "Score the path, not the token stream.",
+    body: "Tool-order signature, plan adherence, self-correction, termination reason. A trace viewer shows you the what; trajectory scoring tells you which agent to ship.",
+  },
+  {
+    label: "CI native",
+    title: "Block merges on behavior drift.",
+    body: "`agentclash regression run` posts verdicts as GitHub checks and links straight to the failing replay. Flunks become permanent regressions.",
+  },
+  {
+    label: "Durable",
+    title: "Temporal-backed workflows.",
+    body: "Long-running agent runs survive provider 503s, node restarts, and flaky tools. Replays work months later because events are durably stored.",
+  },
+  {
+    label: "Provider-neutral",
+    title: "Every major provider, normalized.",
+    body: "OpenAI, Anthropic, Gemini, xAI, Mistral, OpenRouter. Tool-call shapes and failure codes normalized, so scoring is apples-to-apples across the board.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: "When should I use Langfuse instead?",
+    answer:
+      "If your primary job is production observability — ingesting every LLM call your app makes, attributing cost, debugging latency, and running lightweight dataset evals against traced outputs — Langfuse is an excellent, open-source choice. AgentClash doesn't try to replace its trace ingestion or its cost dashboards.",
+  },
+  {
+    question: "Can I migrate from Langfuse?",
+    answer:
+      "Partially. Langfuse dataset evals can be lifted into AgentClash challenge packs, but you'll want to upgrade them to describe tools, sandboxes, and trajectory rubrics. The trace ingestion story stays where it is — most teams run Langfuse for production observability and add AgentClash for pre-merge agent evaluation.",
+  },
+  {
+    question: "Does AgentClash do production observability?",
+    answer:
+      "Not as its primary job. We emit durable events for every race and ship a full replay viewer, but we're not built to be the firehose for every LLM call your live app makes. If that's what you need, keep Langfuse.",
+  },
+  {
+    question: "Is AgentClash open source?",
+    answer:
+      "Yes, under FSL-1.1-MIT. The race engine, scoring pipeline, and CLI are fully self-hostable. Managed cloud is an option, not a requirement.",
+  },
+  {
+    question: "What's the CI story?",
+    answer:
+      "The CLI is designed for CI. `agentclash run create` kicks off durable workflows, `agentclash regression run` gates the PR, and verdicts post as GitHub checks that link to the failing replay. Flunks freeze into a permanent regression suite, so the next model ships against a higher bar than the last.",
+  },
+];
+
+export default function VsLangfusePage() {
+  return (
+    <>
+      <JsonLd
+        id="ld-vs-langfuse-product"
+        data={productSchema({
+          name: "AgentClash vs Langfuse",
+          description:
+            "Side-by-side comparison of AgentClash (agent evaluation, trajectory scoring, CI gates) against Langfuse (OSS LLM observability, production trace ingestion, cost attribution).",
+          url: PATH,
+        })}
+      />
+      <JsonLd
+        id="ld-vs-langfuse-breadcrumbs"
+        data={breadcrumbSchema([
+          { name: "Home", url: "/v2" },
+          { name: "Compare", url: "/v2/vs/langfuse" },
+          { name: "Langfuse", url: PATH },
+        ])}
+      />
+      <MarketingShell>
+        <PageHeader
+          breadcrumbs={[
+            { label: "Home", href: "/v2" },
+            { label: "Compare" },
+            { label: "Langfuse" },
+          ]}
+          eyebrow="AgentClash vs Langfuse"
+          title={
+            <>
+              Pre-merge verdicts.
+              <br />
+              <span className="text-white/40">Not post-hoc traces.</span>
+            </>
+          }
+          subtitle={
+            <>
+              Langfuse is an excellent OSS LLM observability platform — it
+              ingests traces from your live app, attributes cost, and runs
+              lightweight dataset evals. AgentClash is built one room over:
+              racing multi-turn agents with real tools in a sandbox and
+              gating CI on the trajectory verdict.
+            </>
+          }
+          cta={
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+              <DemoButton />
+              <Link
+                href="/v2/oss"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+              >
+                Self-host
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
+          }
+          aside={
+            <CodeCard
+              title="Langfuse — trace ingest"
+              language="python"
+              code={`from langfuse import Langfuse
+
+lf = Langfuse()
+
+trace = lf.trace(name="answer-question")
+gen = trace.generation(
+    name="rag",
+    model="gpt-4o",
+    input={"q": question, "docs": docs},
+)
+reply = llm.complete(question, docs)
+gen.end(output=reply, usage={"input": 412, "output": 87})`}
+            />
+          }
+        />
+
+        <SplitSection
+          eyebrow="Where Langfuse shines"
+          title={
+            <>
+              Live traces.
+              <br />
+              <span className="text-white/40">Cost attribution. Trends.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                Langfuse does the hardest part of LLM observability well:
+                ingest every call from your live app, link them into
+                session traces, attribute spend, and flag latency tails.
+                For teams whose top problem is &quot;what is my production
+                LLM actually doing,&quot; it&apos;s one of the cleanest
+                open-source answers on the market.
+              </p>
+              <p className="mt-4">
+                AgentClash doesn&apos;t try to be a trace ingestion
+                pipeline. If that&apos;s your primary job, keep Langfuse —
+                it&apos;s the right tool.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Langfuse — OTel ingest"
+              language="shell"
+              code={`# OpenTelemetry sidecar sends
+# every LLM call to Langfuse
+export LANGFUSE_PUBLIC_KEY="pk-lf-..."
+export LANGFUSE_SECRET_KEY="sk-lf-..."
+export OTEL_EXPORTER_OTLP_ENDPOINT=\\
+  https://cloud.langfuse.com/api/public/otel
+
+# Your app runs unchanged; traces stream
+# into the Langfuse dashboard`}
+            />
+          }
+        />
+
+        <SplitSection
+          reverse
+          eyebrow="Where AgentClash wins"
+          title={
+            <>
+              Score the agent.
+              <br />
+              <span className="text-white/40">Before it reaches prod.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                Observability is a post-mortem tool — useful, necessary,
+                and one step too late. The job AgentClash is built for is
+                the one before prod: racing three or five agents against
+                the same real task, in a sandbox, and deciding which one
+                earns the merge.
+              </p>
+              <p className="mt-4">
+                Flunked runs archive into a regression suite automatically.
+                The next model change runs against a higher bar than the
+                last one shipped against — that&apos;s the loop observability
+                can&apos;t close on its own.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="AgentClash — verdict + regression"
+              code={`$ agentclash run create \\
+    --pack support-triage \\
+    --agents gpt-5,claude-4.5,gemini-2.5 \\
+    --follow
+
+  gpt-5       ● on-plan   9.4  $0.012  8.1s
+  claude-4.5  ● on-plan   9.1  $0.010  9.4s
+  gemini-2.5  ✗ failed    3.2  $0.018  32.0s
+
+$ agentclash regression promote run_01HX...
+  added to suite: support-triage-hard`}
+            />
+          }
+        />
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Side by side
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                What each tool is actually good at.
+              </h2>
+            </div>
+            <div className="mt-16">
+              <ComparisonTable columns={COLUMNS} rows={ROWS} />
+            </div>
+          </div>
+        </section>
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Where AgentClash pulls ahead
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                Six things trace ingestion can&apos;t do for you.
+              </h2>
+            </div>
+            <div className="mt-20">
+              <FeatureGrid features={FEATURES} columns={3} />
+            </div>
+          </div>
+        </section>
+
+        <FAQBlock
+          title="Langfuse vs AgentClash, answered."
+          items={FAQ_ITEMS}
+          schemaId="ld-vs-langfuse-faq"
+        />
+
+        <ClosingCTA
+          title={
+            <>
+              Keep your observability.
+              <br />
+              <span className="text-white/40">Add a CI verdict.</span>
+            </>
+          }
+          body={
+            <p>
+              Langfuse tells you what your production agent did. AgentClash
+              tells you which candidate agent deserves to replace it. We&apos;ll
+              set up the race on your hardest task in 20 minutes.
+            </p>
+          }
+        >
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+            <DemoButton className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors" />
+            <Link
+              href="/v2/platform/agent-evaluation"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+            >
+              Platform overview
+              <ArrowRight className="size-4" />
+            </Link>
+          </div>
+        </ClosingCTA>
+      </MarketingShell>
+    </>
+  );
+}

--- a/web/src/app/v2/vs/langsmith/page.tsx
+++ b/web/src/app/v2/vs/langsmith/page.tsx
@@ -1,0 +1,380 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { PageHeader } from "@/components/marketing/page-header";
+import { SplitSection } from "@/components/marketing/split-section";
+import { FeatureGrid } from "@/components/marketing/feature-grid";
+import {
+  ComparisonTable,
+  type ComparisonColumn,
+  type ComparisonRow,
+} from "@/components/marketing/comparison-table";
+import { ClosingCTA } from "@/components/marketing/closing-cta";
+import { DemoButton } from "@/components/marketing/demo-button";
+import { CodeCard } from "@/components/marketing/code-card";
+import { FAQBlock } from "@/components/marketing/faq-block";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+
+const PATH = "/v2/vs/langsmith";
+
+export const metadata: Metadata = {
+  title: "AgentClash vs LangSmith",
+  description:
+    "LangSmith is a first-class trace viewer and prompt-eval platform for LangChain apps. AgentClash scores multi-turn agent trajectories head-to-head with real tools in a real sandbox. Honest comparison.",
+  alternates: { canonical: PATH },
+  openGraph: {
+    title: "AgentClash vs LangSmith — agent eval vs prompt eval",
+    description:
+      "LangSmith traces single calls. AgentClash races whole trajectories with real tools. A direct comparison.",
+    url: PATH,
+  },
+};
+
+const COLUMNS: ComparisonColumn[] = [
+  { name: "AgentClash", tag: "Agent eval", highlight: true },
+  { name: "LangSmith", tag: "Prompt eval + traces" },
+];
+
+const ROWS: ComparisonRow[] = [
+  {
+    label: "Multi-turn agent loops",
+    sub: "Races a plan, tool calls, self-correction, and termination — not a single call.",
+    cells: ["yes", "partial"],
+  },
+  {
+    label: "Sandboxed tool execution",
+    sub: "Ephemeral VM with pinned tools, network policy, and isolated filesystem.",
+    cells: ["yes", "no"],
+  },
+  {
+    label: "Head-to-head concurrent race",
+    sub: "N models on the same inputs, same time budget, same scorer — side by side.",
+    cells: ["yes", "no"],
+  },
+  {
+    label: "Trajectory scoring",
+    sub: "Plan adherence, tool-order signatures, self-correction, termination behavior.",
+    cells: ["yes", "partial"],
+  },
+  {
+    label: "Cross-provider tool normalization",
+    sub: "Same challenge pack runs on OpenAI, Anthropic, Gemini, xAI, Mistral without code changes.",
+    cells: ["yes", "partial"],
+  },
+  {
+    label: "Flunks promoted into CI regression gate",
+    sub: "Failed runs freeze into a permanent regression suite the next model has to clear.",
+    cells: ["yes", "no"],
+  },
+  {
+    label: "LangChain / LangGraph trace viewer",
+    sub: "Rich production-trace observability for LangChain apps.",
+    cells: ["partial", "yes"],
+  },
+  {
+    label: "Prompt dataset + single-call grading",
+    sub: "Classic prompt-eval UX over reference datasets.",
+    cells: ["partial", "yes"],
+  },
+];
+
+const FEATURES = [
+  {
+    label: "Sandbox",
+    title: "Real tools, not stubbed functions.",
+    body: "Each agent runs in an isolated E2B environment with real filesystems, real subprocesses, and real network policy. Tool mocks let every model fake the same answer; sandboxes make them earn it.",
+  },
+  {
+    label: "Race",
+    title: "Concurrent, same-inputs, same-budget.",
+    body: "Fire five providers at the same task with the same tools and the same time budget. The verdict is a fair, reproducible ranking — not a single trace you eyeball after the fact.",
+  },
+  {
+    label: "Trajectory",
+    title: "Score the whole path, not the last token.",
+    body: "Tool-order signature, plan adherence, self-correction, termination reason. If one model loops on a 500 and another recovers, the verdict shows it.",
+  },
+  {
+    label: "Provider-neutral",
+    title: "Not tied to LangChain.",
+    body: "Challenge packs run against OpenAI, Anthropic, Gemini, xAI, Mistral, and OpenRouter with normalized tool-call shapes. Zero framework lock-in.",
+  },
+  {
+    label: "CI gate",
+    title: "Block the merge on behavior regression.",
+    body: "A CLI `regression run` posts verdicts as a GitHub check. When a trajectory shape drifts, reviewers see it in the diff — not in prod a week later.",
+  },
+  {
+    label: "Drift",
+    title: "Catch silent provider updates.",
+    body: "Nightly races replay archived trajectories against live endpoints. You find out the day a frontier model changed, not after a customer does.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: "When should I use LangSmith instead?",
+    answer:
+      "If you're LangChain-native and your primary need is production trace observability, cost attribution across chains, and dataset-driven single-call evals — LangSmith is the right tool. AgentClash does not replace its trace viewer or its LangChain integrations.",
+  },
+  {
+    question: "Can I migrate from LangSmith?",
+    answer:
+      "Partially. Prompt-eval datasets from LangSmith can be wrapped into AgentClash challenge packs, but you'll want to upgrade them to describe tools, sandboxes, and verdict rubrics. The LangChain trace data stays where it is — most teams keep LangSmith for production observability and add AgentClash for pre-merge agent evaluation.",
+  },
+  {
+    question: "Do I have to drop LangChain to use AgentClash?",
+    answer:
+      "No. Your application code can keep using LangChain. AgentClash exercises your agent through its provider interface — it only cares that a model returns tool calls it can execute in a sandbox. Most teams run both: LangSmith for production traces, AgentClash for pre-merge races.",
+  },
+  {
+    question: "Why a race instead of a dataset eval?",
+    answer:
+      "Datasets grade single outputs against a reference. Agents don't produce single outputs — they produce trajectories. Two models can reach the same answer via very different plans, and only one can be trusted to do it when the task gets harder. Racing exposes that delta.",
+  },
+  {
+    question: "Is AgentClash open source?",
+    answer:
+      "Yes, under FSL-1.1-MIT. The race engine, scoring pipeline, and CLI are fully self-hostable. Managed cloud is an option, not a requirement.",
+  },
+];
+
+export default function VsLangSmithPage() {
+  return (
+    <>
+      <JsonLd
+        id="ld-vs-langsmith-product"
+        data={productSchema({
+          name: "AgentClash vs LangSmith",
+          description:
+            "Side-by-side comparison of AgentClash (agent evaluation, trajectory scoring, CI gates) against LangSmith (prompt-eval datasets, LangChain trace observability).",
+          url: PATH,
+        })}
+      />
+      <JsonLd
+        id="ld-vs-langsmith-breadcrumbs"
+        data={breadcrumbSchema([
+          { name: "Home", url: "/v2" },
+          { name: "Compare", url: "/v2/vs/langsmith" },
+          { name: "LangSmith", url: PATH },
+        ])}
+      />
+      <MarketingShell>
+        <PageHeader
+          breadcrumbs={[
+            { label: "Home", href: "/v2" },
+            { label: "Compare" },
+            { label: "LangSmith" },
+          ]}
+          eyebrow="AgentClash vs LangSmith"
+          title={
+            <>
+              Agent eval.
+              <br />
+              <span className="text-white/40">Not another trace viewer.</span>
+            </>
+          }
+          subtitle={
+            <>
+              LangSmith is the canonical trace + prompt-eval platform for
+              LangChain apps — and it&apos;s very good at that job. AgentClash is
+              built for the problem one step over: racing multi-turn agents
+              on real tools in a real sandbox and gating CI on the verdict.
+            </>
+          }
+          cta={
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+              <DemoButton />
+              <Link
+                href="/v2/oss"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+              >
+                Self-host
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
+          }
+          aside={
+            <CodeCard
+              title="LangSmith — typical eval"
+              language="python"
+              code={`# prompt-eval with a reference dataset
+from langsmith import Client, evaluate
+
+client = Client()
+
+def target(inputs):
+    return chain.invoke(inputs)
+
+evaluate(
+    target,
+    data="qa-golden-v3",
+    evaluators=[exact_match, llm_judge],
+    experiment_prefix="gpt-4o-vs-4o-mini",
+)`}
+            />
+          }
+        />
+
+        <SplitSection
+          eyebrow="Where LangSmith shines"
+          title={
+            <>
+              Production traces.
+              <br />
+              <span className="text-white/40">Dataset-driven prompt eval.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                If you&apos;re already on LangChain or LangGraph, LangSmith is
+                hard to beat for trace observability. You can see every chain
+                step, cost-attribute tokens to specific nodes, and grade
+                reference datasets with the LLM-judge UX that shipped the
+                category.
+              </p>
+              <p className="mt-4">
+                That&apos;s a real job, and AgentClash doesn&apos;t try to
+                replace it. If your primary need is production observability
+                for LangChain apps, LangSmith is the right tool — keep it.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="LangSmith — trace a chain"
+              language="python"
+              code={`from langsmith import traceable
+
+@traceable(run_type="chain")
+def answer(question: str) -> str:
+    docs = retriever.invoke(question)
+    return llm.invoke({"q": question, "docs": docs})
+
+# Every run shows up in the LangSmith trace tree
+answer("who signed the charter?")`}
+            />
+          }
+        />
+
+        <SplitSection
+          reverse
+          eyebrow="Where AgentClash wins"
+          title={
+            <>
+              Whole trajectories.
+              <br />
+              <span className="text-white/40">Scored head-to-head.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                Agents don&apos;t produce single answers — they produce
+                trajectories. Plan, eight tool calls, one recovered error,
+                one terminated budget. A dataset eval can&apos;t tell you
+                which of three models followed the plan under load.
+              </p>
+              <p className="mt-4">
+                AgentClash races them concurrently in isolated sandboxes
+                with real tools, then scores trajectory shape, correctness,
+                cost, and latency. Every flunked run freezes into a
+                regression the next model has to clear.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="AgentClash — race + verdict"
+              code={`$ agentclash run create \\
+    --pack rag-qa-hard \\
+    --agents gpt-5,claude-4.5,gemini-2.5 \\
+    --follow
+
+  gpt-5       ● on-plan    9.1  $0.019  11.2s
+  claude-4.5  ● on-plan    8.8  $0.014  13.8s
+  gemini-2.5  ◐ looped:2   6.4  $0.022  24.1s
+
+verdict → winner: claude-4.5 (cost-weighted)`}
+            />
+          }
+        />
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Side by side
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                What each tool is actually good at.
+              </h2>
+            </div>
+            <div className="mt-16">
+              <ComparisonTable columns={COLUMNS} rows={ROWS} />
+            </div>
+          </div>
+        </section>
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Why teams add AgentClash
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                Six things a trace viewer can&apos;t do for you.
+              </h2>
+            </div>
+            <div className="mt-20">
+              <FeatureGrid features={FEATURES} columns={3} />
+            </div>
+          </div>
+        </section>
+
+        <FAQBlock
+          title="LangSmith vs AgentClash, answered."
+          items={FAQ_ITEMS}
+          schemaId="ld-vs-langsmith-faq"
+        />
+
+        <ClosingCTA
+          title={
+            <>
+              Keep your traces.
+              <br />
+              <span className="text-white/40">Race your agents.</span>
+            </>
+          }
+          body={
+            <p>
+              Bring us your hardest multi-turn task. We&apos;ll race it
+              against three frontier models in a sandbox and show you the
+              trajectory delta LangSmith&apos;s dataset graders can&apos;t
+              surface.
+            </p>
+          }
+        >
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+            <DemoButton className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors" />
+            <Link
+              href="/v2/platform/agent-evaluation"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+            >
+              Platform overview
+              <ArrowRight className="size-4" />
+            </Link>
+          </div>
+        </ClosingCTA>
+      </MarketingShell>
+    </>
+  );
+}

--- a/web/src/app/v2/vs/openai-evals/page.tsx
+++ b/web/src/app/v2/vs/openai-evals/page.tsx
@@ -1,0 +1,378 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { PageHeader } from "@/components/marketing/page-header";
+import { SplitSection } from "@/components/marketing/split-section";
+import { FeatureGrid } from "@/components/marketing/feature-grid";
+import {
+  ComparisonTable,
+  type ComparisonColumn,
+  type ComparisonRow,
+} from "@/components/marketing/comparison-table";
+import { ClosingCTA } from "@/components/marketing/closing-cta";
+import { DemoButton } from "@/components/marketing/demo-button";
+import { CodeCard } from "@/components/marketing/code-card";
+import { FAQBlock } from "@/components/marketing/faq-block";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+
+const PATH = "/v2/vs/openai-evals";
+
+export const metadata: Metadata = {
+  title: "AgentClash vs OpenAI Evals",
+  description:
+    "OpenAI Evals is a free, bare-bones OSS eval framework optimized for OpenAI models and text grading. AgentClash races multi-turn agent trajectories across every major provider with real tools in a sandbox and gates CI on the verdict.",
+  alternates: { canonical: PATH },
+  openGraph: {
+    title: "AgentClash vs OpenAI Evals — agent eval vs text-grading CLI",
+    description:
+      "OpenAI Evals grades single OpenAI completions. AgentClash races multi-provider agent trajectories with real tools. A direct comparison.",
+    url: PATH,
+  },
+};
+
+const COLUMNS: ComparisonColumn[] = [
+  { name: "AgentClash", tag: "Agent eval", highlight: true },
+  { name: "OpenAI Evals", tag: "OSS text-grading CLI" },
+];
+
+const ROWS: ComparisonRow[] = [
+  {
+    label: "Multi-turn agent loops",
+    sub: "Scores plans, tool sequences, self-correction, and termination — not a single call.",
+    cells: ["yes", "partial"],
+  },
+  {
+    label: "Sandboxed tool execution",
+    sub: "Ephemeral VM with real filesystem, subprocesses, and network-policy isolation.",
+    cells: ["yes", "no"],
+  },
+  {
+    label: "Cross-provider head-to-head",
+    sub: "OpenAI, Anthropic, Gemini, xAI, Mistral, OpenRouter — normalized tool-call shapes.",
+    cells: ["yes", "no"],
+  },
+  {
+    label: "Trajectory scoring",
+    sub: "Plan adherence, tool-order signature, termination reason — not string match.",
+    cells: ["yes", "no"],
+  },
+  {
+    label: "Live event stream + replay",
+    sub: "WebSocket tailing while the run happens; full replay months later.",
+    cells: ["yes", "no"],
+  },
+  {
+    label: "Flunk → CI regression gate",
+    sub: "Failed runs freeze into a regression suite the next model must clear.",
+    cells: ["yes", "no"],
+  },
+  {
+    label: "Free + barebones text-grading",
+    sub: "Classic `oaieval` CLI for comparing completions on reference datasets.",
+    cells: ["partial", "yes"],
+  },
+  {
+    label: "OpenAI-first completion format",
+    sub: "Direct wiring to OpenAI's APIs, optimized for their model set.",
+    cells: ["partial", "yes"],
+  },
+];
+
+const FEATURES = [
+  {
+    label: "Sandbox",
+    title: "Real tools, not stubbed functions.",
+    body: "Every agent gets an ephemeral E2B environment — real filesystem, real subprocesses, real network policy. Text-grading CLIs can only score what a completion said; sandboxes test what the agent did.",
+  },
+  {
+    label: "Providers",
+    title: "Not OpenAI-only.",
+    body: "First-class adapters for OpenAI, Anthropic, Gemini, xAI, Mistral, and OpenRouter. Tool-call shapes and failure codes normalized, so a challenge pack runs across every provider without code changes.",
+  },
+  {
+    label: "Trajectory",
+    title: "Score the path, not the string.",
+    body: "Tool-order signatures, plan adherence, self-correction, termination. A grader that string-matches a completion cannot tell you the model looped three times to say it.",
+  },
+  {
+    label: "Live",
+    title: "Watch it run in real time.",
+    body: "WebSocket event stream: every think, tool call, observation, and scoring update in the browser as it happens. No batch log parsing after the fact.",
+  },
+  {
+    label: "CI gate",
+    title: "Block the merge on drift.",
+    body: "CLI ships a `regression run` command designed for CI — verdicts post as GitHub checks and link straight to the failing replay.",
+  },
+  {
+    label: "Durable",
+    title: "Temporal-backed workflows.",
+    body: "Long-running agent runs survive provider 503s, node restarts, and flaky tools. Replays work months later because events are durably persisted.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: "When should I use OpenAI Evals instead?",
+    answer:
+      "If you only ship on OpenAI, your tests are mostly reference text-grading (`completion == expected` or a rubric), and you want a free, simple, hackable framework — OpenAI Evals is the right starting point. AgentClash is built for the next shape of problem: multi-turn agents with real tool use, raced across every major provider.",
+  },
+  {
+    question: "Can I migrate from OpenAI Evals?",
+    answer:
+      "Yes. OpenAI Evals YAML registry entries map naturally into AgentClash challenge packs — both are declarative and describe inputs + graders. You'll want to enrich them with tool specs, sandbox images, and trajectory rubrics to get the agent-eval benefits. Most teams keep OpenAI Evals for quick text-grading experiments and add AgentClash for the CI gate.",
+  },
+  {
+    question: "Does AgentClash only score OpenAI models?",
+    answer:
+      "No — the opposite. First-class adapters for OpenAI, Anthropic, Gemini, xAI, Mistral, and OpenRouter. The whole point is that one challenge pack runs across providers with normalized tool-call shapes and failure codes, so the verdict is apples-to-apples.",
+  },
+  {
+    question: "Is AgentClash free?",
+    answer:
+      "The engine is open source under FSL-1.1-MIT — free to run, fork, and self-host. A managed cloud is available for teams that don't want to operate Temporal and Postgres themselves; it's an option, not a requirement.",
+  },
+  {
+    question: "What do I lose by leaving OpenAI Evals?",
+    answer:
+      "The built-in OpenAI-shaped registry, the shared CLI muscle memory if your team already uses it, and some text-grading presets. You gain real tool execution, trajectory scoring, multi-provider racing, durable orchestration, and a CI regression story. It's a trade — worth it once your tests are agent-shaped, not completion-shaped.",
+  },
+];
+
+export default function VsOpenAIEvalsPage() {
+  return (
+    <>
+      <JsonLd
+        id="ld-vs-openai-evals-product"
+        data={productSchema({
+          name: "AgentClash vs OpenAI Evals",
+          description:
+            "Side-by-side comparison of AgentClash (multi-provider agent evaluation, trajectory scoring, CI gates) against OpenAI Evals (OSS text-grading CLI optimized for OpenAI models).",
+          url: PATH,
+        })}
+      />
+      <JsonLd
+        id="ld-vs-openai-evals-breadcrumbs"
+        data={breadcrumbSchema([
+          { name: "Home", url: "/v2" },
+          { name: "Compare", url: "/v2/vs/openai-evals" },
+          { name: "OpenAI Evals", url: PATH },
+        ])}
+      />
+      <MarketingShell>
+        <PageHeader
+          breadcrumbs={[
+            { label: "Home", href: "/v2" },
+            { label: "Compare" },
+            { label: "OpenAI Evals" },
+          ]}
+          eyebrow="AgentClash vs OpenAI Evals"
+          title={
+            <>
+              Cross-provider races.
+              <br />
+              <span className="text-white/40">Not OpenAI-only text grading.</span>
+            </>
+          }
+          subtitle={
+            <>
+              OpenAI Evals is a free, bare-bones OSS framework — perfect
+              when you only ship on OpenAI and your tests are text-grading
+              against a reference. AgentClash is built for the next shape:
+              multi-turn agents with real tools, raced across every major
+              provider, gating CI on the trajectory verdict.
+            </>
+          }
+          cta={
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+              <DemoButton />
+              <Link
+                href="/v2/oss"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+              >
+                Self-host
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
+          }
+          aside={
+            <CodeCard
+              title="OpenAI Evals — oaieval CLI"
+              language="shell"
+              code={`$ oaieval gpt-4o-mini match \\
+    --registry_path ./evals \\
+    --record_path ./results.jsonl
+
+# runs the "match" grader against
+# reference completions and dumps a
+# line-delimited JSON result file`}
+            />
+          }
+        />
+
+        <SplitSection
+          eyebrow="Where OpenAI Evals shines"
+          title={
+            <>
+              Free. Simple.
+              <br />
+              <span className="text-white/40">OpenAI-native.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                OpenAI Evals is one of the most honest options on the
+                market: a small YAML registry, a `oaieval` CLI, and a
+                handful of canonical graders. If you ship exclusively on
+                OpenAI and your eval needs are &quot;grade completions
+                against a reference dataset,&quot; it does that job well
+                and it&apos;s free.
+              </p>
+              <p className="mt-4">
+                AgentClash doesn&apos;t try to out-cheap a GitHub repo. If
+                that&apos;s your workflow, keep it — it&apos;s a good
+                starting point.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="OpenAI Evals — registry entry"
+              language="yaml"
+              code={`# evals/qa-match.yaml
+qa-match:
+  id: qa-match.v0
+  metrics: [accuracy]
+  description: Short-answer match eval
+
+qa-match.v0:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: qa/test.jsonl`}
+            />
+          }
+        />
+
+        <SplitSection
+          reverse
+          eyebrow="Where AgentClash wins"
+          title={
+            <>
+              Multi-provider.
+              <br />
+              <span className="text-white/40">Multi-turn. Sandboxed.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                Completions grading is one-shot. Real agents make eight
+                tool calls, recover from a flaky API, and terminate on
+                budget. Measuring them needs a sandbox, a concurrent race,
+                and a trajectory-aware scorer — not a string comparison.
+              </p>
+              <p className="mt-4">
+                AgentClash races agents from OpenAI, Anthropic, Gemini,
+                xAI, Mistral, and OpenRouter on the same challenge pack
+                with normalized tool-call shapes, and gates CI on the
+                verdict. Flunks freeze into a regression suite the next
+                model has to clear.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="AgentClash — cross-provider race"
+              code={`$ agentclash run create \\
+    --pack code-review-hard \\
+    --agents gpt-5,claude-4.5,gemini-2.5,grok-4 \\
+    --follow
+
+  gpt-5       ● on-plan   9.2  $0.021  12.8s
+  claude-4.5  ● on-plan   9.0  $0.016  14.1s
+  gemini-2.5  ◐ loop:1    7.1  $0.024  22.4s
+  grok-4      ● on-plan   8.4  $0.012  11.0s
+
+verdict → winner: grok-4 (cost-weighted)`}
+            />
+          }
+        />
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Side by side
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                What each tool is actually good at.
+              </h2>
+            </div>
+            <div className="mt-16">
+              <ComparisonTable columns={COLUMNS} rows={ROWS} />
+            </div>
+          </div>
+        </section>
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Where AgentClash pulls ahead
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                Six things a text-grading CLI can&apos;t do.
+              </h2>
+            </div>
+            <div className="mt-20">
+              <FeatureGrid features={FEATURES} columns={3} />
+            </div>
+          </div>
+        </section>
+
+        <FAQBlock
+          title="OpenAI Evals vs AgentClash, answered."
+          items={FAQ_ITEMS}
+          schemaId="ld-vs-openai-evals-faq"
+        />
+
+        <ClosingCTA
+          title={
+            <>
+              Outgrow text grading.
+              <br />
+              <span className="text-white/40">Race real agents.</span>
+            </>
+          }
+          body={
+            <p>
+              Bring us one task that OpenAI Evals can&apos;t tell you the
+              answer to — something multi-turn, tool-using, or
+              cross-provider. We&apos;ll race it in a sandbox in 20 minutes
+              and show you the delta.
+            </p>
+          }
+        >
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+            <DemoButton className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors" />
+            <Link
+              href="/v2/platform/agent-evaluation"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+            >
+              Platform overview
+              <ArrowRight className="size-4" />
+            </Link>
+          </div>
+        </ClosingCTA>
+      </MarketingShell>
+    </>
+  );
+}

--- a/web/src/app/v2/vs/promptfoo/page.tsx
+++ b/web/src/app/v2/vs/promptfoo/page.tsx
@@ -1,0 +1,378 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { PageHeader } from "@/components/marketing/page-header";
+import { SplitSection } from "@/components/marketing/split-section";
+import { FeatureGrid } from "@/components/marketing/feature-grid";
+import {
+  ComparisonTable,
+  type ComparisonColumn,
+  type ComparisonRow,
+} from "@/components/marketing/comparison-table";
+import { ClosingCTA } from "@/components/marketing/closing-cta";
+import { DemoButton } from "@/components/marketing/demo-button";
+import { CodeCard } from "@/components/marketing/code-card";
+import { FAQBlock } from "@/components/marketing/faq-block";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+
+const PATH = "/v2/vs/promptfoo";
+
+export const metadata: Metadata = {
+  title: "AgentClash vs Promptfoo",
+  description:
+    "Promptfoo is a great OSS CLI for git-committed prompt evals and red-teaming presets. AgentClash is built for the problem one step over: multi-turn agents with real tools, raced head-to-head, gating CI on trajectory verdicts.",
+  alternates: { canonical: PATH },
+  openGraph: {
+    title: "AgentClash vs Promptfoo — agent eval vs prompt-config CLI",
+    description:
+      "Promptfoo evaluates YAML-described prompts in your repo. AgentClash races multi-turn agent trajectories with real tools. A direct comparison.",
+    url: PATH,
+  },
+};
+
+const COLUMNS: ComparisonColumn[] = [
+  { name: "AgentClash", tag: "Agent eval", highlight: true },
+  { name: "Promptfoo", tag: "OSS prompt-eval CLI" },
+];
+
+const ROWS: ComparisonRow[] = [
+  {
+    label: "Multi-turn agent loops",
+    sub: "Scores plans, tool sequences, self-correction, and termination — not a single call.",
+    cells: ["yes", "partial"],
+  },
+  {
+    label: "Sandboxed tool execution",
+    sub: "Ephemeral VM with real filesystem, subprocesses, and network-policy isolation.",
+    cells: ["yes", "no"],
+  },
+  {
+    label: "Durable orchestration for long runs",
+    sub: "Temporal-backed workflows that survive provider timeouts, retries, and restarts.",
+    cells: ["yes", "no"],
+  },
+  {
+    label: "Head-to-head concurrent race",
+    sub: "N models, same inputs, same budget, same scorer — a verdict, not a matrix.",
+    cells: ["yes", "partial"],
+  },
+  {
+    label: "Trajectory scoring",
+    sub: "Plan adherence, tool-order signatures, self-correction, termination reason.",
+    cells: ["yes", "partial"],
+  },
+  {
+    label: "Flunk → regression suite",
+    sub: "Failed runs promote into a permanent regression bar the next model has to clear.",
+    cells: ["yes", "no"],
+  },
+  {
+    label: "Git-committed YAML eval configs",
+    sub: "Declarative prompt configs that live in your repo and diff cleanly in PRs.",
+    cells: ["partial", "yes"],
+  },
+  {
+    label: "Red-teaming + jailbreak presets",
+    sub: "Canonical prompt-injection, PII, and jailbreak test suites out of the box.",
+    cells: ["partial", "yes"],
+  },
+];
+
+const FEATURES = [
+  {
+    label: "Sandbox",
+    title: "Real tools executing in isolation.",
+    body: "Each agent gets an ephemeral E2B environment with pinned tools, network policy, and secrets. Promptfoo-style providers fake the runtime; sandboxes make the runtime real.",
+  },
+  {
+    label: "Durable",
+    title: "Temporal under the hood.",
+    body: "Agent runs survive provider 503s, flaky tools, and node restarts. Replays work months later because events are durably persisted, not inferred from stdout.",
+  },
+  {
+    label: "Race",
+    title: "Same-time, same-budget competition.",
+    body: "Fire N providers at the same task concurrently. The verdict is a ranking, not a per-row pass/fail that you eyeball across a console dump.",
+  },
+  {
+    label: "Trajectory",
+    title: "Score the path, not the completion.",
+    body: "Tool-order signatures, plan adherence, termination reason. A string-match assertion will not catch the model that looped three times to get there.",
+  },
+  {
+    label: "CI gate",
+    title: "Regressions block the merge.",
+    body: "`agentclash regression run` posts verdicts as a GitHub check and links to the failing replay. Flunks freeze into the regression suite automatically.",
+  },
+  {
+    label: "Multi-tenant",
+    title: "Workspaces, SSO, role-based access.",
+    body: "Built for teams beyond one engineer's laptop. WorkOS-backed auth, per-workspace secrets, shared runs, and durable replay archive.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: "When should I use Promptfoo instead?",
+    answer:
+      "If you're a solo engineer or a small team that wants git-committed prompt evals running locally in a tight feedback loop, and your tests are mostly string assertions and red-team presets — Promptfoo is an excellent fit. It's free, fast, and gets out of your way. AgentClash is a heavier, team-shaped tool for the next problem: scoring full agent trajectories with real tools under durable orchestration.",
+  },
+  {
+    question: "Can I migrate from Promptfoo?",
+    answer:
+      "Yes. Promptfoo YAML configs map cleanly to AgentClash challenge packs — both are declarative, git-friendly, and describe inputs + graders. You'll want to enrich them with tool specs, sandbox images, and trajectory rubrics to get the agent-eval benefits. Teams often keep Promptfoo for quick local prompt iteration and add AgentClash for the CI gate.",
+  },
+  {
+    question: "Does AgentClash work from the CLI?",
+    answer:
+      "Yes. `agentclash run create`, `agentclash run follow`, and `agentclash regression run` are first-class commands. Runs can be fired from a developer laptop, a CI workflow, or a scheduled cron. The CLI ships via Homebrew, Winget, install scripts, and npm.",
+  },
+  {
+    question: "What about red-teaming?",
+    answer:
+      "Promptfoo has the category-leading library of red-team presets. AgentClash is focused on agent behavior under real tool-use and isn't a drop-in replacement for its jailbreak suite. If safety-scanning prompts is your primary job, keep Promptfoo; add AgentClash when you need to race real agent trajectories.",
+  },
+  {
+    question: "Is AgentClash open source?",
+    answer:
+      "Yes, under FSL-1.1-MIT. The full race engine, scorer pipeline, and CLI are self-hostable. Managed cloud is an option for teams that don't want to run Temporal and Postgres themselves.",
+  },
+];
+
+export default function VsPromptfooPage() {
+  return (
+    <>
+      <JsonLd
+        id="ld-vs-promptfoo-product"
+        data={productSchema({
+          name: "AgentClash vs Promptfoo",
+          description:
+            "Side-by-side comparison of AgentClash (agent evaluation, trajectory scoring, durable orchestration) against Promptfoo (OSS CLI for git-committed prompt-eval configs and red-team presets).",
+          url: PATH,
+        })}
+      />
+      <JsonLd
+        id="ld-vs-promptfoo-breadcrumbs"
+        data={breadcrumbSchema([
+          { name: "Home", url: "/v2" },
+          { name: "Compare", url: "/v2/vs/promptfoo" },
+          { name: "Promptfoo", url: PATH },
+        ])}
+      />
+      <MarketingShell>
+        <PageHeader
+          breadcrumbs={[
+            { label: "Home", href: "/v2" },
+            { label: "Compare" },
+            { label: "Promptfoo" },
+          ]}
+          eyebrow="AgentClash vs Promptfoo"
+          title={
+            <>
+              Sandboxes and verdicts.
+              <br />
+              <span className="text-white/40">Not local YAML asserts.</span>
+            </>
+          }
+          subtitle={
+            <>
+              Promptfoo is one of the best OSS prompt-eval CLIs on the
+              market — fast, git-native, and great at red-team presets.
+              AgentClash is built for the next problem: racing multi-turn
+              agents in a sandbox, with durable orchestration, and gating
+              CI on the trajectory verdict.
+            </>
+          }
+          cta={
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+              <DemoButton />
+              <Link
+                href="/v2/oss"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+              >
+                Self-host
+                <ArrowRight className="size-4" />
+              </Link>
+            </div>
+          }
+          aside={
+            <CodeCard
+              title="Promptfoo — typical config"
+              language="yaml"
+              code={`# promptfooconfig.yaml
+prompts:
+  - "Summarize: {{text}}"
+providers:
+  - openai:gpt-4o-mini
+  - anthropic:claude-3-5-sonnet
+tests:
+  - vars: { text: "..." }
+    assert:
+      - type: contains
+        value: "charter"
+      - type: llm-rubric
+        value: "concise, no speculation"`}
+            />
+          }
+        />
+
+        <SplitSection
+          eyebrow="Where Promptfoo shines"
+          title={
+            <>
+              Fast local loops.
+              <br />
+              <span className="text-white/40">Diffable prompt configs.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                Promptfoo nails the &quot;evals in my repo&quot; workflow.
+                Config in YAML, runs in seconds, diffs like code, and comes
+                with a mature red-team preset library. For a solo engineer
+                or a tight team iterating on prompts, it&apos;s hard to
+                beat on feedback latency.
+              </p>
+              <p className="mt-4">
+                AgentClash doesn&apos;t replace that. If your unit of work
+                is a prompt + a set of string asserts in CI, keep using
+                Promptfoo — it&apos;s great at that job.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="Promptfoo — CLI"
+              language="shell"
+              code={`$ promptfoo eval
+
+┌────────────────┬───────┬────────┐
+│ provider       │ pass  │ rubric │
+├────────────────┼───────┼────────┤
+│ gpt-4o-mini    │ 12/14 │  8.2   │
+│ claude-3-5     │ 13/14 │  9.1   │
+└────────────────┴───────┴────────┘`}
+            />
+          }
+        />
+
+        <SplitSection
+          reverse
+          eyebrow="Where AgentClash wins"
+          title={
+            <>
+              Agents using real tools.
+              <br />
+              <span className="text-white/40">Under durable orchestration.</span>
+            </>
+          }
+          body={
+            <>
+              <p>
+                Promptfoo is single-call-shaped by design. A multi-turn
+                agent that runs for 90 seconds, calls five tools, recovers
+                from one failure, and terminates on budget is a different
+                unit of evaluation entirely.
+              </p>
+              <p className="mt-4">
+                AgentClash runs those trajectories in ephemeral sandboxes
+                with real tools, under Temporal-backed durable workflows.
+                The verdict scores plan adherence, correctness, cost, and
+                latency — and the flunks feed a CI regression gate.
+              </p>
+            </>
+          }
+          aside={
+            <CodeCard
+              title="AgentClash — challenge pack"
+              code={`$ agentclash run create \\
+    --pack sre-runbook \\
+    --agents gpt-5,claude-4.5,gemini-2.5 \\
+    --follow
+
+  gpt-5       ● on-plan   9.3  $0.031  22.1s
+  claude-4.5  ● on-plan   9.0  $0.020  24.5s
+  gemini-2.5  ◐ loop:1    6.8  $0.034  41.2s
+
+verdict → winner: claude-4.5 (cost-weighted)`}
+            />
+          }
+        />
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Side by side
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                What each tool is actually good at.
+              </h2>
+            </div>
+            <div className="mt-16">
+              <ComparisonTable columns={COLUMNS} rows={ROWS} />
+            </div>
+          </div>
+        </section>
+
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[52ch]">
+              <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+                <span className="inline-block size-1 rounded-full bg-white/60" />
+                Where AgentClash pulls ahead
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+                Six things a prompt CLI can&apos;t do for you.
+              </h2>
+            </div>
+            <div className="mt-20">
+              <FeatureGrid features={FEATURES} columns={3} />
+            </div>
+          </div>
+        </section>
+
+        <FAQBlock
+          title="Promptfoo vs AgentClash, answered."
+          items={FAQ_ITEMS}
+          schemaId="ld-vs-promptfoo-faq"
+        />
+
+        <ClosingCTA
+          title={
+            <>
+              Keep your prompt evals.
+              <br />
+              <span className="text-white/40">Race your agents.</span>
+            </>
+          }
+          body={
+            <p>
+              Ship Promptfoo for local prompt iteration. Bring AgentClash
+              in for the CI gate that actually fires real tools in a
+              sandbox and blocks the merge when a trajectory regresses.
+            </p>
+          }
+        >
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+            <DemoButton className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors" />
+            <Link
+              href="/v2/platform/agent-evaluation"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+            >
+              Platform overview
+              <ArrowRight className="size-4" />
+            </Link>
+          </div>
+        </ClosingCTA>
+      </MarketingShell>
+    </>
+  );
+}

--- a/web/src/components/marketing/cal-embed-init.tsx
+++ b/web/src/components/marketing/cal-embed-init.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { getCalApi } from "@calcom/embed-react";
+
+export function CalEmbedInit() {
+  useEffect(() => {
+    (async () => {
+      const cal = await getCalApi();
+      cal("ui", {
+        theme: "dark",
+        styles: { branding: { brandColor: "#ffffff" } },
+        hideEventTypeDetails: false,
+        layout: "month_view",
+      });
+    })();
+  }, []);
+
+  return null;
+}

--- a/web/src/components/marketing/clash-mark.tsx
+++ b/web/src/components/marketing/clash-mark.tsx
@@ -1,0 +1,21 @@
+export function ClashMark({ className = "" }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 512 512"
+      className={className}
+      aria-label="AgentClash"
+      role="img"
+    >
+      <polygon points="80,180 240,256 80,332" fill="#ffffff" opacity="0.95" />
+      <polygon points="432,180 272,256 432,332" fill="#ffffff" opacity="0.5" />
+      <g>
+        <line x1="256" y1="96" x2="256" y2="168" stroke="#ffffff" strokeWidth="10" strokeLinecap="round" opacity="0.75" />
+        <line x1="256" y1="344" x2="256" y2="416" stroke="#ffffff" strokeWidth="10" strokeLinecap="round" opacity="0.75" />
+        <line x1="186" y1="130" x2="216" y2="188" stroke="#ffffff" strokeWidth="8" strokeLinecap="round" opacity="0.55" />
+        <line x1="326" y1="130" x2="296" y2="188" stroke="#ffffff" strokeWidth="8" strokeLinecap="round" opacity="0.55" />
+        <line x1="186" y1="382" x2="216" y2="324" stroke="#ffffff" strokeWidth="8" strokeLinecap="round" opacity="0.55" />
+        <line x1="326" y1="382" x2="296" y2="324" stroke="#ffffff" strokeWidth="8" strokeLinecap="round" opacity="0.55" />
+      </g>
+    </svg>
+  );
+}

--- a/web/src/components/marketing/closing-cta.tsx
+++ b/web/src/components/marketing/closing-cta.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+
+type Props = {
+  title: ReactNode;
+  body?: ReactNode;
+  children: ReactNode;
+};
+
+export function ClosingCTA({ title, body, children }: Props) {
+  return (
+    <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+      <div className="mx-auto max-w-[1440px] grid gap-16 md:grid-cols-[1.3fr_1fr] md:gap-20 items-center">
+        <div>
+          <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.04em] leading-[0.98] text-[clamp(2.5rem,5.5vw,5rem)] max-w-[16ch]">
+            {title}
+          </h2>
+          {body ? (
+            <div className="mt-8 max-w-[52ch] text-[15px] sm:text-lg leading-[1.6] text-white/55">
+              {body}
+            </div>
+          ) : null}
+          <div className="mt-10">{children}</div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/marketing/code-card.tsx
+++ b/web/src/components/marketing/code-card.tsx
@@ -1,0 +1,25 @@
+type Props = {
+  title?: string;
+  language?: string;
+  code: string;
+};
+
+export function CodeCard({ title, language = "shell", code }: Props) {
+  return (
+    <div className="rounded-lg border border-white/[0.08] bg-white/[0.02] overflow-hidden">
+      <div className="flex items-center justify-between border-b border-white/[0.06] px-4 py-2.5">
+        <span className="text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] text-white/40">
+          {title ?? language}
+        </span>
+        <div className="flex items-center gap-1.5">
+          <span className="size-2 rounded-full bg-white/15" />
+          <span className="size-2 rounded-full bg-white/15" />
+          <span className="size-2 rounded-full bg-white/15" />
+        </div>
+      </div>
+      <pre className="overflow-x-auto px-5 py-4 font-[family-name:var(--font-mono)] text-[13px] leading-[1.7] text-white/75">
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+}

--- a/web/src/components/marketing/comparison-mark.tsx
+++ b/web/src/components/marketing/comparison-mark.tsx
@@ -1,0 +1,34 @@
+export type MarkKind = "yes" | "partial" | "no";
+
+export function ComparisonMark({
+  kind,
+  highlight = false,
+}: {
+  kind: MarkKind;
+  highlight?: boolean;
+}) {
+  if (kind === "yes") {
+    return (
+      <span
+        className={
+          highlight ? "text-white text-lg font-medium" : "text-white/70 text-base"
+        }
+        aria-label="supported"
+      >
+        ●
+      </span>
+    );
+  }
+  if (kind === "partial") {
+    return (
+      <span className="text-white/45 text-base" aria-label="partial">
+        ◐
+      </span>
+    );
+  }
+  return (
+    <span className="text-white/25 text-base" aria-label="not a core capability">
+      —
+    </span>
+  );
+}

--- a/web/src/components/marketing/comparison-table.tsx
+++ b/web/src/components/marketing/comparison-table.tsx
@@ -1,0 +1,148 @@
+import { ComparisonMark, type MarkKind } from "./comparison-mark";
+
+export type ComparisonColumn = {
+  name: string;
+  tag: string;
+  highlight?: boolean;
+};
+
+export type ComparisonRow = {
+  label: string;
+  sub: string;
+  cells: MarkKind[];
+};
+
+type Props = {
+  columns: ComparisonColumn[];
+  rows: ComparisonRow[];
+};
+
+export function ComparisonTable({ columns, rows }: Props) {
+  const gridTemplate = `grid-cols-[1.7fr_repeat(${columns.length},minmax(0,1fr))]`;
+
+  return (
+    <div>
+      {/* Mobile: stacked per-capability cards */}
+      <div className="md:hidden space-y-10">
+        {rows.map((row) => (
+          <div
+            key={`m-${row.label}`}
+            className="border-b border-white/[0.08] pb-8 last:border-b-0"
+          >
+            <p className="text-[16px] font-medium text-white/90 leading-[1.35]">
+              {row.label}
+            </p>
+            <p className="mt-2 text-[13px] leading-[1.55] text-white/40">
+              {row.sub}
+            </p>
+            <dl className="mt-5 grid grid-cols-1 gap-0">
+              {columns.map((col, j) => (
+                <div
+                  key={col.name}
+                  className={`flex items-center justify-between gap-4 border-b border-white/[0.05] py-2.5 last:border-b-0 ${
+                    col.highlight ? "bg-white/[0.025] -mx-3 px-3 rounded" : ""
+                  }`}
+                >
+                  <div className="flex flex-col">
+                    <dt
+                      className={`text-[13px] ${
+                        col.highlight
+                          ? "text-white/95 font-medium"
+                          : "text-white/60"
+                      }`}
+                    >
+                      {col.name}
+                    </dt>
+                    <span
+                      className={`text-[9px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] ${
+                        col.highlight ? "text-white/45" : "text-white/25"
+                      }`}
+                    >
+                      {col.tag}
+                    </span>
+                  </div>
+                  <dd>
+                    <ComparisonMark
+                      kind={row.cells[j]}
+                      highlight={col.highlight}
+                    />
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        ))}
+      </div>
+
+      {/* Desktop: full matrix */}
+      <div className="hidden md:block -mx-8 sm:mx-0 overflow-x-auto">
+        <div className="min-w-[1040px] px-8 sm:px-0">
+          <div className={`grid ${gridTemplate} border-b border-white/[0.12]`}>
+            <div className="pb-5 pr-4">
+              <p className="text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.18em] text-white/35">
+                Capability
+              </p>
+            </div>
+            {columns.map((col) => (
+              <div
+                key={col.name}
+                className="flex flex-col items-center justify-end gap-1 pb-5 px-2"
+              >
+                <span
+                  className={`text-center leading-tight ${
+                    col.highlight
+                      ? "text-[13px] font-[family-name:var(--font-display)] tracking-[-0.01em] text-white/95"
+                      : "text-[12px] font-[family-name:var(--font-mono)] uppercase tracking-[0.16em] text-white/45"
+                  }`}
+                >
+                  {col.name}
+                </span>
+                <span
+                  className={`text-[9px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] ${
+                    col.highlight ? "text-white/30" : "text-white/25"
+                  }`}
+                >
+                  {col.tag}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          {rows.map((row) => (
+            <div
+              key={row.label}
+              className={`grid ${gridTemplate} border-b border-white/[0.05] last:border-b-0`}
+            >
+              <div className="py-7 pr-6">
+                <p className="text-[15px] text-white/85">{row.label}</p>
+                <p className="mt-1.5 text-[12px] leading-[1.5] text-white/40">
+                  {row.sub}
+                </p>
+              </div>
+              {row.cells.map((mark, j) => (
+                <div
+                  key={j}
+                  className={`flex items-center justify-center py-7 px-2 ${
+                    columns[j]?.highlight ? "bg-white/[0.025]" : ""
+                  }`}
+                >
+                  <ComparisonMark
+                    kind={mark}
+                    highlight={columns[j]?.highlight ?? false}
+                  />
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <p className="mt-10 text-[12px] font-[family-name:var(--font-mono)] text-white/35">
+        <span className="text-white/60">●</span>&nbsp;&nbsp;supported
+        &nbsp;·&nbsp; <span className="text-white/45">◐</span>
+        &nbsp;&nbsp;partial &nbsp;·&nbsp;
+        <span className="text-white/30">—</span>&nbsp;&nbsp;not a core capability
+      </p>
+    </div>
+  );
+}

--- a/web/src/components/marketing/cta-strip.tsx
+++ b/web/src/components/marketing/cta-strip.tsx
@@ -1,0 +1,96 @@
+import Link from "next/link";
+import { ArrowRight, Star } from "lucide-react";
+import { DemoButton } from "./demo-button";
+
+type Variant = "demo-first" | "cli-first" | "github-first";
+
+type Props = {
+  variant?: Variant;
+  primaryLabel?: string;
+  primaryHref?: string;
+  secondaryLabel?: string;
+  secondaryHref?: string;
+  showGithub?: boolean;
+};
+
+export function CTAStrip({
+  variant = "demo-first",
+  primaryLabel,
+  primaryHref,
+  secondaryLabel,
+  secondaryHref,
+  showGithub = true,
+}: Props) {
+  const primaryCTA =
+    variant === "demo-first" ? (
+      <DemoButton />
+    ) : primaryHref ? (
+      <Link
+        href={primaryHref}
+        className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
+      >
+        {primaryLabel ?? "Get started"}
+        <ArrowRight className="size-4" />
+      </Link>
+    ) : null;
+
+  const secondaryCTA = secondaryHref ? (
+    <Link
+      href={secondaryHref}
+      className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+    >
+      {secondaryLabel ?? "Learn more"}
+      <ArrowRight className="size-4" />
+    </Link>
+  ) : variant === "demo-first" ? (
+    <Link
+      href="/auth/login"
+      className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
+    >
+      Get started
+      <ArrowRight className="size-4" />
+    </Link>
+  ) : null;
+
+  return (
+    <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
+      {primaryCTA}
+      {secondaryCTA}
+      {showGithub ? (
+        <a
+          href="https://github.com/agentclash/agentclash"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center justify-center gap-2 rounded-md border border-white/[0.08] bg-white/[0.02] px-6 py-3 text-sm font-medium text-white/60 hover:text-white/90 hover:border-white/20 transition-colors"
+        >
+          <Star className="size-4" />
+          GitHub
+        </a>
+      ) : null}
+    </div>
+  );
+}
+
+export function CLIInstallStrip({
+  command = "npm i -g agentclash",
+  learnMoreHref = "/v2/oss",
+  learnMoreLabel = "self-host",
+}: {
+  command?: string;
+  learnMoreHref?: string;
+  learnMoreLabel?: string;
+}) {
+  return (
+    <div className="inline-flex items-center gap-3 rounded-md border border-white/[0.06] bg-white/[0.02] px-4 py-2.5 font-[family-name:var(--font-mono)] text-[12px] text-white/55">
+      <span className="text-white/30 select-none">$</span>
+      <code className="text-white/85">{command}</code>
+      <span className="text-white/20">·</span>
+      <Link
+        href={learnMoreHref}
+        className="text-white/45 hover:text-white/80 transition-colors"
+      >
+        {learnMoreLabel}
+      </Link>
+    </div>
+  );
+}

--- a/web/src/components/marketing/demo-button.tsx
+++ b/web/src/components/marketing/demo-button.tsx
@@ -1,0 +1,26 @@
+import { Calendar } from "lucide-react";
+
+const DEMO_LINK = "atharva-kanherkar-epgztu/agentclash-demo";
+const DEMO_BUTTON_CONFIG = JSON.stringify({ layout: "month_view" });
+
+type Props = {
+  className?: string;
+  label?: string;
+};
+
+export function DemoButton({
+  className = "inline-flex items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors",
+  label = "Book a demo",
+}: Props) {
+  return (
+    <button
+      type="button"
+      data-cal-link={DEMO_LINK}
+      data-cal-config={DEMO_BUTTON_CONFIG}
+      className={className}
+    >
+      <Calendar className="size-4" />
+      {label}
+    </button>
+  );
+}

--- a/web/src/components/marketing/faq-block.tsx
+++ b/web/src/components/marketing/faq-block.tsx
@@ -1,0 +1,45 @@
+import { JsonLd, faqSchema } from "./json-ld";
+
+export type FAQ = { question: string; answer: string };
+
+type Props = {
+  title?: string;
+  eyebrow?: string;
+  items: FAQ[];
+  schemaId: string;
+};
+
+export function FAQBlock({
+  title = "Frequently asked",
+  eyebrow = "FAQ",
+  items,
+  schemaId,
+}: Props) {
+  return (
+    <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
+      <JsonLd id={schemaId} data={faqSchema(items)} />
+      <div className="mx-auto max-w-[1100px]">
+        <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+          <span className="inline-block size-1 rounded-full bg-white/60" />
+          {eyebrow}
+        </p>
+        <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2.25rem,5vw,4rem)] max-w-[22ch]">
+          {title}
+        </h2>
+
+        <dl className="mt-16 divide-y divide-white/[0.08] border-y border-white/[0.08]">
+          {items.map((qa) => (
+            <div key={qa.question} className="py-8">
+              <dt className="font-[family-name:var(--font-display)] text-[18px] sm:text-[22px] leading-[1.3] tracking-[-0.01em] text-white/90">
+                {qa.question}
+              </dt>
+              <dd className="mt-3 max-w-[68ch] text-[14px] sm:text-[15px] leading-[1.7] text-white/55">
+                {qa.answer}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/marketing/feature-grid.tsx
+++ b/web/src/components/marketing/feature-grid.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from "react";
+
+export type FeatureItem = {
+  label: string;
+  title: string;
+  body: string;
+  glyph?: ReactNode;
+};
+
+type Props = {
+  features: FeatureItem[];
+  columns?: 2 | 3 | 4;
+};
+
+const gridCols: Record<2 | 3 | 4, string> = {
+  2: "sm:grid-cols-2",
+  3: "sm:grid-cols-2 lg:grid-cols-3",
+  4: "sm:grid-cols-2 lg:grid-cols-4",
+};
+
+export function FeatureGrid({ features, columns = 3 }: Props) {
+  return (
+    <ul
+      className={`grid grid-cols-1 ${gridCols[columns]} gap-px border-y border-white/[0.06] bg-white/[0.06]`}
+    >
+      {features.map((feature) => (
+        <li
+          key={feature.label}
+          className="group relative flex flex-col bg-[#060606] px-8 py-12 transition-colors hover:bg-white/[0.015]"
+        >
+          {feature.glyph ? (
+            <div className="inline-flex size-12 items-center justify-center rounded-full border border-white/[0.12] bg-white/[0.02] transition-colors group-hover:border-white/25">
+              {feature.glyph}
+            </div>
+          ) : (
+            <div className="inline-flex size-12 items-center justify-center rounded-full border border-white/[0.12] bg-white/[0.02]">
+              <span className="block size-1.5 rounded-full bg-white/70" />
+            </div>
+          )}
+
+          <p className="mt-8 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] text-white/40">
+            {feature.label}
+          </p>
+
+          <h3 className="mt-3 font-[family-name:var(--font-display)] text-2xl leading-[1.15] tracking-[-0.02em] text-white/95">
+            {feature.title}
+          </h3>
+
+          <p className="mt-4 text-[14px] leading-[1.65] text-white/55">
+            {feature.body}
+          </p>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/web/src/components/marketing/json-ld.tsx
+++ b/web/src/components/marketing/json-ld.tsx
@@ -1,0 +1,70 @@
+type Props = {
+  id: string;
+  data: Record<string, unknown> | Record<string, unknown>[];
+};
+
+export function JsonLd({ id, data }: Props) {
+  return (
+    <script
+      id={id}
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}
+
+export const SITE_URL = "https://agentclash.dev";
+
+export function breadcrumbSchema(
+  items: Array<{ name: string; url: string }>,
+): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.name,
+      item: item.url.startsWith("http") ? item.url : `${SITE_URL}${item.url}`,
+    })),
+  };
+}
+
+export function faqSchema(
+  qa: Array<{ question: string; answer: string }>,
+): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: qa.map(({ question, answer }) => ({
+      "@type": "Question",
+      name: question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: answer,
+      },
+    })),
+  };
+}
+
+export function productSchema({
+  name,
+  description,
+  url,
+}: {
+  name: string;
+  description: string;
+  url: string;
+}): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name,
+    alternateName: "Agent Clash",
+    applicationCategory: "DeveloperApplication",
+    operatingSystem: "Web, macOS, Linux, Windows",
+    description,
+    url: url.startsWith("http") ? url : `${SITE_URL}${url}`,
+    offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+  };
+}

--- a/web/src/components/marketing/marketing-footer.tsx
+++ b/web/src/components/marketing/marketing-footer.tsx
@@ -1,0 +1,127 @@
+import Link from "next/link";
+
+const COLUMNS: Array<{
+  heading: string;
+  links: Array<{ href: string; label: string; external?: boolean }>;
+}> = [
+  {
+    heading: "Product",
+    links: [
+      { href: "/v2/platform/agent-evaluation", label: "Agent evaluation" },
+      { href: "/v2/platform/regression-testing", label: "Regression testing" },
+      { href: "/v2/platform/ci-cd-gating", label: "CI/CD gating" },
+      { href: "/v2/platform/multi-turn-evaluation", label: "Multi-turn evals" },
+      { href: "/v2/platform/rag-evaluation", label: "RAG evaluation" },
+      { href: "/v2/platform/self-hosted", label: "Self-hosted" },
+    ],
+  },
+  {
+    heading: "Use cases",
+    links: [
+      { href: "/v2/use-cases/coding-agents", label: "Coding agents" },
+      { href: "/v2/use-cases/deep-research", label: "Deep research" },
+      { href: "/v2/use-cases/sql-data-agents", label: "SQL & data" },
+      { href: "/v2/use-cases/support-agents", label: "Support agents" },
+      { href: "/v2/use-cases/sre-agents", label: "SRE agents" },
+    ],
+  },
+  {
+    heading: "Compare",
+    links: [
+      { href: "/v2/vs/langsmith", label: "vs LangSmith" },
+      { href: "/v2/vs/braintrust", label: "vs Braintrust" },
+      { href: "/v2/vs/promptfoo", label: "vs Promptfoo" },
+      { href: "/v2/vs/langfuse", label: "vs Langfuse" },
+      { href: "/v2/vs/openai-evals", label: "vs OpenAI Evals" },
+    ],
+  },
+  {
+    heading: "Company",
+    links: [
+      { href: "/v2/cloud", label: "Managed cloud" },
+      { href: "/v2/oss", label: "Open source" },
+      { href: "/v2/security", label: "Security" },
+      { href: "/v2/methodology", label: "Methodology" },
+      { href: "/v2/design-partners", label: "Design partners" },
+      { href: "/blog", label: "Blog" },
+      { href: "/docs", label: "Docs" },
+      { href: "/team", label: "Team" },
+      { href: "https://github.com/agentclash/agentclash", label: "GitHub", external: true },
+    ],
+  },
+];
+
+export function MarketingFooter() {
+  return (
+    <footer className="mt-auto border-t border-white/[0.06] px-8 sm:px-12 pt-20 pb-10">
+      <div className="mx-auto max-w-[1440px]">
+        <div className="grid gap-12 sm:grid-cols-2 lg:grid-cols-4">
+          {COLUMNS.map((col) => (
+            <div key={col.heading}>
+              <p className="text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] text-white/35">
+                {col.heading}
+              </p>
+              <ul className="mt-5 space-y-3 text-[13px] text-white/55">
+                {col.links.map((link) =>
+                  link.external ? (
+                    <li key={link.href}>
+                      <a
+                        href={link.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="hover:text-white/90 transition-colors"
+                      >
+                        {link.label}
+                      </a>
+                    </li>
+                  ) : (
+                    <li key={link.href}>
+                      <Link
+                        href={link.href}
+                        className="hover:text-white/90 transition-colors"
+                      >
+                        {link.label}
+                      </Link>
+                    </li>
+                  ),
+                )}
+              </ul>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-16 flex flex-wrap items-center justify-between gap-4 border-t border-white/[0.06] pt-8 text-[11px] font-[family-name:var(--font-mono)] text-white/35">
+          <div className="flex items-center gap-6">
+            <span className="font-medium text-white/55">AgentClash</span>
+            <span className="text-white/40">Beta · FSL-1.1-MIT</span>
+          </div>
+          <div className="flex items-center gap-5">
+            <Link href="/docs" className="hover:text-white/70 transition-colors">
+              Docs
+            </Link>
+            <a
+              href="/llms.txt"
+              className="hover:text-white/70 transition-colors"
+            >
+              llms.txt
+            </a>
+            <a
+              href="/llms-full.txt"
+              className="hover:text-white/70 transition-colors"
+            >
+              llms-full.txt
+            </a>
+            <a
+              href="https://github.com/agentclash/agentclash"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-white/70 transition-colors"
+            >
+              GitHub
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/web/src/components/marketing/marketing-header.tsx
+++ b/web/src/components/marketing/marketing-header.tsx
@@ -1,0 +1,90 @@
+import Link from "next/link";
+import { ArrowRight, LogIn, Star } from "lucide-react";
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { ClashMark } from "./clash-mark";
+
+type NavLink = { href: string; label: string; external?: boolean };
+
+const DEFAULT_NAV: NavLink[] = [
+  { href: "/v2/platform/agent-evaluation", label: "Platform" },
+  { href: "/v2/use-cases/coding-agents", label: "Use cases" },
+  { href: "/v2/oss", label: "Open source" },
+  { href: "/docs", label: "Docs" },
+  { href: "/blog", label: "Blog" },
+];
+
+type Props = {
+  nav?: NavLink[];
+};
+
+export async function MarketingHeader({ nav = DEFAULT_NAV }: Props) {
+  const { user } = await withAuth();
+
+  return (
+    <header className="px-5 sm:px-12 py-5 sm:py-6 border-b border-white/[0.06]">
+      <div className="mx-auto flex max-w-[1440px] items-center justify-between">
+        <Link
+          href="/v2"
+          className="inline-flex items-center gap-2.5 text-white/90"
+        >
+          <ClashMark className="size-6" />
+          <span className="font-[family-name:var(--font-display)] text-xl tracking-[-0.01em]">
+            AgentClash
+          </span>
+        </Link>
+        <nav className="flex items-center gap-0.5 sm:gap-2 text-xs">
+          {nav.map((item) =>
+            item.external ? (
+              <a
+                key={item.href}
+                href={item.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hidden sm:inline-flex px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"
+              >
+                {item.label}
+              </a>
+            ) : (
+              <Link
+                key={item.href}
+                href={item.href}
+                className="hidden md:inline-flex px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"
+              >
+                {item.label}
+              </Link>
+            ),
+          )}
+          <a
+            href="https://github.com/agentclash/agentclash"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="GitHub"
+            className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.03] px-2 sm:px-3 py-1.5 text-white/60 hover:text-white/85 hover:border-white/15 transition-colors"
+          >
+            <Star className="size-3.5" />
+            <span className="hidden sm:inline">GitHub</span>
+          </a>
+          {user ? (
+            <Link
+              href="/dashboard"
+              aria-label="Dashboard"
+              className="inline-flex items-center gap-1.5 rounded-md bg-white px-2 sm:px-3 py-1.5 font-medium text-[#060606] hover:bg-white/90 transition-colors"
+            >
+              <span className="hidden sm:inline">Dashboard</span>
+              <ArrowRight className="size-3" />
+            </Link>
+          ) : (
+            <Link
+              href="/auth/login"
+              aria-label="Sign in"
+              className="inline-flex items-center gap-1.5 rounded-md border border-white/15 bg-white/[0.04] px-2 sm:px-3 py-1.5 text-white/75 hover:text-white hover:border-white/25 transition-colors"
+            >
+              <LogIn className="size-3.5" />
+              <span className="hidden sm:inline">Sign in</span>
+            </Link>
+          )}
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/web/src/components/marketing/marketing-shell.tsx
+++ b/web/src/components/marketing/marketing-shell.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+import { MarketingHeader } from "./marketing-header";
+import { MarketingFooter } from "./marketing-footer";
+
+type Props = {
+  children: ReactNode;
+};
+
+export function MarketingShell({ children }: Props) {
+  return (
+    <main className="main min-h-screen flex flex-col">
+      <MarketingHeader />
+      {children}
+      <MarketingFooter />
+    </main>
+  );
+}

--- a/web/src/components/marketing/page-header.tsx
+++ b/web/src/components/marketing/page-header.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+
+export type Breadcrumb = { label: string; href?: string };
+
+type Props = {
+  eyebrow: string;
+  title: ReactNode;
+  subtitle: ReactNode;
+  breadcrumbs?: Breadcrumb[];
+  cta?: ReactNode;
+  aside?: ReactNode;
+};
+
+export function PageHeader({
+  eyebrow,
+  title,
+  subtitle,
+  breadcrumbs,
+  cta,
+  aside,
+}: Props) {
+  return (
+    <section className="px-8 sm:px-12 pt-28 pb-20 sm:pt-40 sm:pb-28 border-b border-white/[0.06]">
+      <div className="mx-auto max-w-[1440px]">
+        {breadcrumbs && breadcrumbs.length > 0 ? (
+          <nav
+            aria-label="Breadcrumb"
+            className="mb-10 flex flex-wrap items-center gap-1.5 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.18em] text-white/35"
+          >
+            {breadcrumbs.map((crumb, i) => (
+              <span key={`${crumb.label}-${i}`} className="flex items-center gap-1.5">
+                {crumb.href ? (
+                  <Link
+                    href={crumb.href}
+                    className="hover:text-white/70 transition-colors"
+                  >
+                    {crumb.label}
+                  </Link>
+                ) : (
+                  <span className="text-white/55">{crumb.label}</span>
+                )}
+                {i < breadcrumbs.length - 1 ? (
+                  <ChevronRight className="size-3 text-white/25" />
+                ) : null}
+              </span>
+            ))}
+          </nav>
+        ) : null}
+
+        <div className="grid gap-16 md:grid-cols-[1.5fr_1fr] md:gap-20 items-start">
+          <div>
+            <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+              <span className="inline-block size-1 rounded-full bg-white/60" />
+              {eyebrow}
+            </p>
+            <h1 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.04em] leading-[0.98] text-[clamp(2.75rem,6vw,5.75rem)] max-w-[18ch]">
+              {title}
+            </h1>
+            <div className="mt-10 max-w-[56ch] text-lg sm:text-xl leading-[1.55] text-white/55">
+              {subtitle}
+            </div>
+            {cta ? <div className="mt-10">{cta}</div> : null}
+          </div>
+
+          {aside ? (
+            <div className="flex items-start justify-center">{aside}</div>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/marketing/provider-strip.tsx
+++ b/web/src/components/marketing/provider-strip.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+import {
+  Anthropic,
+  Gemini,
+  Mistral,
+  OpenAI,
+  OpenRouter,
+  XAI,
+} from "@lobehub/icons";
+
+type Provider = { name: string; render: (size: number) => ReactNode };
+
+const PROVIDERS: Provider[] = [
+  { name: "OpenAI", render: (size) => <OpenAI size={size} color="#74AA9C" /> },
+  { name: "Anthropic", render: (size) => <Anthropic size={size} color="#D97757" /> },
+  { name: "Gemini", render: (size) => <Gemini.Color size={size} /> },
+  { name: "xAI", render: (size) => <XAI size={size} color="#FFFFFF" /> },
+  { name: "Mistral", render: (size) => <Mistral.Color size={size} /> },
+  { name: "OpenRouter", render: (size) => <OpenRouter size={size} color="#6566F1" /> },
+];
+
+export function ProviderStrip() {
+  return (
+    <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-px border-y border-white/[0.06] bg-white/[0.06]">
+      {PROVIDERS.map(({ name, render }) => (
+        <li
+          key={name}
+          className="flex flex-col items-center justify-center gap-3 bg-[#060606] px-6 py-10 text-white/70"
+        >
+          <div className="flex h-10 items-center justify-center">
+            {render(32)}
+          </div>
+          <p className="text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/40">
+            {name}
+          </p>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/web/src/components/marketing/section-heading.tsx
+++ b/web/src/components/marketing/section-heading.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+
+type Props = {
+  eyebrow?: string;
+  title: ReactNode;
+  body?: ReactNode;
+  align?: "left" | "center";
+  size?: "md" | "lg";
+  className?: string;
+};
+
+export function SectionHeading({
+  eyebrow,
+  title,
+  body,
+  align = "left",
+  size = "md",
+  className = "",
+}: Props) {
+  const alignClass = align === "center" ? "mx-auto text-center" : "";
+  const titleSize =
+    size === "lg"
+      ? "text-[clamp(2.75rem,6.5vw,6rem)]"
+      : "text-[clamp(2.25rem,5vw,4.5rem)]";
+
+  return (
+    <div className={`${alignClass} ${className}`}>
+      {eyebrow ? (
+        <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+          <span className="inline-block size-1 rounded-full bg-white/60" />
+          {eyebrow}
+        </p>
+      ) : null}
+      <h2
+        className={`font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] ${titleSize} max-w-[22ch] ${
+          align === "center" ? "mx-auto" : ""
+        }`}
+      >
+        {title}
+      </h2>
+      {body ? (
+        <div
+          className={`mt-8 max-w-[52ch] text-lg leading-[1.6] text-white/55 ${
+            align === "center" ? "mx-auto" : ""
+          }`}
+        >
+          {body}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/components/marketing/split-section.tsx
+++ b/web/src/components/marketing/split-section.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react";
+
+type Props = {
+  eyebrow?: string;
+  title: ReactNode;
+  body: ReactNode;
+  aside?: ReactNode;
+  reverse?: boolean;
+  id?: string;
+};
+
+export function SplitSection({
+  eyebrow,
+  title,
+  body,
+  aside,
+  reverse = false,
+  id,
+}: Props) {
+  return (
+    <section
+      id={id}
+      className="border-t border-white/[0.06] px-8 sm:px-12 py-28 sm:py-40"
+    >
+      <div className="mx-auto max-w-[1440px] grid gap-16 md:grid-cols-2 md:gap-20 items-center">
+        <div className={reverse ? "md:order-2" : ""}>
+          {eyebrow ? (
+            <p className="mb-6 inline-flex items-center gap-2 text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/45">
+              <span className="inline-block size-1 rounded-full bg-white/60" />
+              {eyebrow}
+            </p>
+          ) : null}
+          <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2rem,4.5vw,3.75rem)] max-w-[22ch]">
+            {title}
+          </h2>
+          <div className="mt-8 max-w-[52ch] text-[15px] sm:text-lg leading-[1.65] text-white/55">
+            {body}
+          </div>
+        </div>
+        <div className={reverse ? "md:order-1" : ""}>{aside}</div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Parallel marketing tree at `/v2/*` that lets us validate SEO and distribution improvements end-to-end without touching the live landing. The preview is `noindex`; `/`, `landing.tsx`, and `layout.tsx` are byte-identical to `main`.

- **22 pages**: `/v2` homepage (category-led with CLI install strip + JSON-LD), `/v2/oss`, `/v2/cloud`, six `/v2/platform/*` SEO landings (agent-evaluation, regression-testing, ci-cd-gating, multi-turn-evaluation, self-hosted, rag-evaluation), five `/v2/use-cases/*` (coding-agents, deep-research, sql-data-agents, support-agents, sre-agents), five `/v2/vs/*` honest comparison pages (langsmith, braintrust, promptfoo, langfuse, openai-evals), three trust pages (security, methodology, design-partners).
- **18 shared components** under `web/src/components/marketing/`: MarketingShell/header/footer, PageHeader, SplitSection, FeatureGrid, ComparisonTable, FAQBlock, ClosingCTA, CodeCard, ProviderStrip, JsonLd helper with Breadcrumb/FAQ/Product schema builders, CalEmbedInit.
- **SEO**: per-page title/description/canonical via Metadata API; SoftwareApplication + Organization + BreadcrumbList + FAQPage JSON-LD on every page; brand-defense for "Agent Clash" (spaced variant); llms.txt/llms-full.txt promoted from footer.

## Design preservation

Same fonts, same dark theme, same section rhythm as the current landing. `/v2/landing.tsx` is a verbatim copy of `/landing.tsx` with three surgical edits: logo href `/` → `/v2`, category eyebrow above the voice H1, CLI install strip below the hero CTAs.

## Verification

- `npx tsc --noEmit` — clean
- `pnpm lint` — clean
- `git diff main -- web/src/app/landing.tsx web/src/app/page.tsx web/src/app/layout.tsx` — zero bytes

## Test plan

- [ ] Visit `/v2` — hero shows the new category eyebrow, voice H1 intact, CLI install strip renders, primary CTAs work
- [ ] Click through every nav link in the `/v2` footer (each column) — all 22 pages load without 404
- [ ] Open each page's HTML `<head>` — confirm unique title/description and `<script type="application/ld+json">` tags
- [ ] Confirm the `/v2` tree is `noindex` via `robots` meta tag in layout
- [ ] Compare `/` (unchanged) vs `/v2` side by side — visual parity on shared sections
- [ ] "Book a demo" opens Cal.com popup on `/v2`, `/v2/oss`, `/v2/cloud`, `/v2/platform/agent-evaluation`
- [ ] Mobile nav behaves on `/v2` sister pages (header collapses correctly)
- [ ] Run Lighthouse / Rich Results Test on a handful of pages to confirm JSON-LD validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)