### PR TITLE
feat(web): first-run onboarding for workspaces

### DIFF
--- a/docs/frontend/architecture/onboarding.md
+++ b/docs/frontend/architecture/onboarding.md
@@ -1,0 +1,45 @@
+# Workspace Onboarding
+
+The workspace Runs page renders a dismissible `WorkspaceWelcome` card (see
+`web/src/components/onboarding/workspace-welcome.tsx`) with a 3-step checklist:
+
+1. Deploy two agents
+2. Pick a challenge pack
+3. Run your first clash
+
+Step completion is derived from the server-rendered counts already fetched on
+the Runs page (`GET /v1/workspaces/:id/agent-deployments`, `/challenge-packs`,
+`/runs`). The card auto-hides when all three are complete or when the user
+dismisses it.
+
+## Persistence
+
+Dismissal is stored in localStorage and scoped per-workspace:
+
+| Key | Meaning |
+|---|---|
+| `agentclash:onboarding:dismissed:<workspaceId>` | `"1"` if the user clicked the × |
+| `agentclash:onboarding:first_run_seen:<workspaceId>` | `"1"` after the first-run success toast has fired |
+
+`useOnboardingState(workspaceId)` is an SSR-safe `useSyncExternalStore` hook
+that listens for both the `storage` event (cross-tab) and a
+`agentclash:onboarding:sync` custom event (same-tab, cross-component).
+
+## Development reset
+
+To replay onboarding while developing:
+
+- Use the **Restart onboarding** entry in the user menu (top-right avatar) — it
+  calls `restartOnboarding(workspaceId)` from `use-onboarding-state.ts`.
+- Or, in devtools:
+  ```js
+  localStorage.removeItem("agentclash:onboarding:dismissed:<workspaceId>");
+  localStorage.removeItem("agentclash:onboarding:first_run_seen:<workspaceId>");
+  ```
+
+## Glossary tooltips
+
+Plain-language definitions for terms like "deployment", "challenge pack",
+"input set" live in `web/src/components/onboarding/glossary.ts` and render via
+`GlossaryTerm` — a small `(?)` tooltip trigger. Used on the Runs page header
+and the Create-Run dialog labels.

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/builds-list-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/builds-list-client.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Bot } from "lucide-react";
+import type { AgentBuild } from "@/lib/api/types";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { CreateBuildDialog } from "./create-build-dialog";
+
+const statusVariant: Record<
+  string,
+  "default" | "secondary" | "destructive" | "outline"
+> = {
+  active: "default",
+  archived: "secondary",
+};
+
+interface BuildsListClientProps {
+  workspaceId: string;
+  builds: AgentBuild[];
+}
+
+export function BuildsListClient({
+  workspaceId,
+  builds,
+}: BuildsListClientProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-lg font-semibold tracking-tight">Agent Builds</h1>
+        <CreateBuildDialog
+          workspaceId={workspaceId}
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+        />
+      </div>
+
+      {builds.length === 0 ? (
+        <EmptyState
+          icon={<Bot className="size-10" />}
+          title="No agent builds yet"
+          description="A build is the spec for one agent — prompt, tools, and behavior."
+          action={{
+            label: "New build",
+            onClick: () => setDialogOpen(true),
+          }}
+        />
+      ) : (
+        <div className="rounded-lg border border-border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Slug</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Created</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {builds.map((build) => (
+                <TableRow key={build.id}>
+                  <TableCell>
+                    <Link
+                      href={`/workspaces/${workspaceId}/builds/${build.id}`}
+                      className="font-medium text-foreground hover:underline underline-offset-4"
+                    >
+                      {build.name}
+                    </Link>
+                    {build.description && (
+                      <p className="text-xs text-muted-foreground mt-0.5 truncate max-w-xs">
+                        {build.description}
+                      </p>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <code className="text-xs font-[family-name:var(--font-mono)] text-muted-foreground">
+                      {build.slug}
+                    </code>
+                  </TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={statusVariant[build.lifecycle_status] ?? "outline"}
+                    >
+                      {build.lifecycle_status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {new Date(build.created_at).toLocaleDateString()}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/create-build-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/create-build-dialog.tsx
@@ -21,12 +21,23 @@ import { Loader2, Plus } from "lucide-react";
 
 interface CreateBuildDialogProps {
   workspaceId: string;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
-export function CreateBuildDialog({ workspaceId }: CreateBuildDialogProps) {
+export function CreateBuildDialog({
+  workspaceId,
+  open: controlledOpen,
+  onOpenChange: controlledOnOpenChange,
+}: CreateBuildDialogProps) {
   const router = useRouter();
   const { getAccessToken } = useAccessToken();
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = controlledOpen ?? internalOpen;
+  const setOpen = (next: boolean) => {
+    if (controlledOpen === undefined) setInternalOpen(next);
+    controlledOnOpenChange?.(next);
+  };
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [submitting, setSubmitting] = useState(false);

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/page.tsx
@@ -1,25 +1,8 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { redirect } from "next/navigation";
-import Link from "next/link";
 import { createApiClient } from "@/lib/api/client";
 import type { AgentBuild } from "@/lib/api/types";
-import { Badge } from "@/components/ui/badge";
-import { EmptyState } from "@/components/ui/empty-state";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { Bot } from "lucide-react";
-import { CreateBuildDialog } from "./create-build-dialog";
-
-const statusVariant: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
-  active: "default",
-  archived: "secondary",
-};
+import { BuildsListClient } from "./builds-list-client";
 
 export default async function BuildsPage({
   params,
@@ -36,65 +19,5 @@ export default async function BuildsPage({
     `/v1/workspaces/${workspaceId}/agent-builds`,
   );
 
-  return (
-    <div>
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-lg font-semibold tracking-tight">Agent Builds</h1>
-        <CreateBuildDialog workspaceId={workspaceId} />
-      </div>
-
-      {builds.length === 0 ? (
-        <EmptyState
-          icon={<Bot className="size-10" />}
-          title="No agent builds yet"
-          description="Create your first agent build to define how an AI agent behaves."
-        />
-      ) : (
-        <div className="rounded-lg border border-border">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Name</TableHead>
-                <TableHead>Slug</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Created</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {builds.map((build) => (
-                <TableRow key={build.id}>
-                  <TableCell>
-                    <Link
-                      href={`/workspaces/${workspaceId}/builds/${build.id}`}
-                      className="font-medium text-foreground hover:underline underline-offset-4"
-                    >
-                      {build.name}
-                    </Link>
-                    {build.description && (
-                      <p className="text-xs text-muted-foreground mt-0.5 truncate max-w-xs">
-                        {build.description}
-                      </p>
-                    )}
-                  </TableCell>
-                  <TableCell>
-                    <code className="text-xs font-[family-name:var(--font-mono)] text-muted-foreground">
-                      {build.slug}
-                    </code>
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant={statusVariant[build.lifecycle_status] ?? "outline"}>
-                      {build.lifecycle_status}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">
-                    {new Date(build.created_at).toLocaleDateString()}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
-      )}
-    </div>
-  );
+  return <BuildsListClient workspaceId={workspaceId} builds={builds} />;
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/challenge-packs-list-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/challenge-packs-list-client.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Package } from "lucide-react";
+import type { ChallengePack } from "@/lib/api/types";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { PublishPackDialog } from "./publish-pack-dialog";
+
+const lifecycleVariant: Record<string, "default" | "secondary" | "outline"> = {
+  runnable: "default",
+  draft: "outline",
+  deprecated: "secondary",
+  archived: "secondary",
+};
+
+interface ChallengePacksListClientProps {
+  workspaceId: string;
+  packs: ChallengePack[];
+}
+
+export function ChallengePacksListClient({
+  workspaceId,
+  packs,
+}: ChallengePacksListClientProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-lg font-semibold tracking-tight">
+            Challenge Packs
+          </h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Benchmark definitions that agents are tested against.
+          </p>
+        </div>
+        <PublishPackDialog
+          workspaceId={workspaceId}
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+        />
+      </div>
+
+      {packs.length === 0 ? (
+        <EmptyState
+          icon={<Package className="size-10" />}
+          title="No challenge packs"
+          description="A pack is the task your agents will attempt — inputs, expected outputs, and scoring."
+          action={{
+            label: "Publish a pack",
+            onClick: () => setDialogOpen(true),
+          }}
+        />
+      ) : (
+        <div className="rounded-lg border border-border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Description</TableHead>
+                <TableHead>Versions</TableHead>
+                <TableHead>Latest Status</TableHead>
+                <TableHead>Created</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {packs.map((pack) => {
+                const latestVersion =
+                  pack.versions.length > 0
+                    ? pack.versions.reduce((a, b) =>
+                        a.version_number > b.version_number ? a : b,
+                      )
+                    : null;
+
+                return (
+                  <TableRow key={pack.id}>
+                    <TableCell>
+                      <Link
+                        href={`/workspaces/${workspaceId}/challenge-packs/${pack.id}`}
+                        className="font-medium text-foreground hover:underline underline-offset-4"
+                      >
+                        {pack.name}
+                      </Link>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-sm max-w-xs truncate">
+                      {pack.description ?? "—"}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-sm">
+                      {pack.versions.length}
+                    </TableCell>
+                    <TableCell>
+                      {latestVersion ? (
+                        <Badge
+                          variant={
+                            lifecycleVariant[latestVersion.lifecycle_status] ??
+                            "outline"
+                          }
+                        >
+                          {latestVersion.lifecycle_status}
+                        </Badge>
+                      ) : (
+                        <span className="text-muted-foreground text-sm">
+                          {"—"}
+                        </span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-sm">
+                      {new Date(pack.created_at).toLocaleDateString()}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/page.tsx
@@ -1,27 +1,8 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { redirect } from "next/navigation";
-import Link from "next/link";
 import { createApiClient } from "@/lib/api/client";
 import type { ChallengePack } from "@/lib/api/types";
-import { Badge } from "@/components/ui/badge";
-import { EmptyState } from "@/components/ui/empty-state";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { Package } from "lucide-react";
-import { PublishPackDialog } from "./publish-pack-dialog";
-
-const lifecycleVariant: Record<string, "default" | "secondary" | "outline"> = {
-  runnable: "default",
-  draft: "outline",
-  deprecated: "secondary",
-  archived: "secondary",
-};
+import { ChallengePacksListClient } from "./challenge-packs-list-client";
 
 export default async function ChallengePacksPage({
   params,
@@ -38,89 +19,5 @@ export default async function ChallengePacksPage({
     `/v1/workspaces/${workspaceId}/challenge-packs`,
   );
 
-  return (
-    <div>
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-lg font-semibold tracking-tight">
-            Challenge Packs
-          </h1>
-          <p className="text-sm text-muted-foreground mt-0.5">
-            Benchmark definitions that agents are tested against.
-          </p>
-        </div>
-        <PublishPackDialog workspaceId={workspaceId} />
-      </div>
-
-      {packs.length === 0 ? (
-        <EmptyState
-          icon={<Package className="size-10" />}
-          title="No challenge packs"
-          description="Publish your first challenge pack to define benchmarks for agent evaluation."
-        />
-      ) : (
-        <div className="rounded-lg border border-border">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Name</TableHead>
-                <TableHead>Description</TableHead>
-                <TableHead>Versions</TableHead>
-                <TableHead>Latest Status</TableHead>
-                <TableHead>Created</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {packs.map((pack) => {
-                const latestVersion =
-                  pack.versions.length > 0
-                    ? pack.versions.reduce((a, b) =>
-                        a.version_number > b.version_number ? a : b,
-                      )
-                    : null;
-
-                return (
-                  <TableRow key={pack.id}>
-                    <TableCell>
-                      <Link
-                        href={`/workspaces/${workspaceId}/challenge-packs/${pack.id}`}
-                        className="font-medium text-foreground hover:underline underline-offset-4"
-                      >
-                        {pack.name}
-                      </Link>
-                    </TableCell>
-                    <TableCell className="text-muted-foreground text-sm max-w-xs truncate">
-                      {pack.description ?? "\u2014"}
-                    </TableCell>
-                    <TableCell className="text-muted-foreground text-sm">
-                      {pack.versions.length}
-                    </TableCell>
-                    <TableCell>
-                      {latestVersion ? (
-                        <Badge
-                          variant={
-                            lifecycleVariant[latestVersion.lifecycle_status] ??
-                            "outline"
-                          }
-                        >
-                          {latestVersion.lifecycle_status}
-                        </Badge>
-                      ) : (
-                        <span className="text-muted-foreground text-sm">
-                          {"\u2014"}
-                        </span>
-                      )}
-                    </TableCell>
-                    <TableCell className="text-muted-foreground text-sm">
-                      {new Date(pack.created_at).toLocaleDateString()}
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
-        </div>
-      )}
-    </div>
-  );
+  return <ChallengePacksListClient workspaceId={workspaceId} packs={packs} />;
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/publish-pack-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/publish-pack-dialog.tsx
@@ -24,12 +24,23 @@ import { CheckCircle2, Loader2, Plus, XCircle } from "lucide-react";
 
 interface PublishPackDialogProps {
   workspaceId: string;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
-export function PublishPackDialog({ workspaceId }: PublishPackDialogProps) {
+export function PublishPackDialog({
+  workspaceId,
+  open: controlledOpen,
+  onOpenChange: controlledOnOpenChange,
+}: PublishPackDialogProps) {
   const router = useRouter();
   const { getAccessToken } = useAccessToken();
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = controlledOpen ?? internalOpen;
+  const setOpen = (next: boolean) => {
+    if (controlledOpen === undefined) setInternalOpen(next);
+    controlledOnOpenChange?.(next);
+  };
   const [yaml, setYaml] = useState("");
   const [validating, setValidating] = useState(false);
   const [publishing, setPublishing] = useState(false);

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/deployments/create-deployment-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/deployments/create-deployment-dialog.tsx
@@ -30,15 +30,24 @@ import { Loader2, Plus } from "lucide-react";
 
 interface CreateDeploymentDialogProps {
   workspaceId: string;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export function CreateDeploymentDialog({
   workspaceId,
+  open: controlledOpen,
+  onOpenChange: controlledOnOpenChange,
 }: CreateDeploymentDialogProps) {
   const router = useRouter();
   const { getAccessToken } = useAccessToken();
 
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = controlledOpen ?? internalOpen;
+  const setOpen = (next: boolean) => {
+    if (controlledOpen === undefined) setInternalOpen(next);
+    controlledOnOpenChange?.(next);
+  };
   const [name, setName] = useState("");
   const [selectedBuildId, setSelectedBuildId] = useState("");
   const [selectedVersionId, setSelectedVersionId] = useState("");

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/deployments/deployments-list-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/deployments/deployments-list-client.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState } from "react";
+import { Rocket } from "lucide-react";
+import type { AgentDeployment } from "@/lib/api/types";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { CreateDeploymentDialog } from "./create-deployment-dialog";
+
+const statusVariant: Record<string, "default" | "secondary" | "outline"> = {
+  active: "default",
+  paused: "outline",
+  archived: "secondary",
+};
+
+interface DeploymentsListClientProps {
+  workspaceId: string;
+  deployments: AgentDeployment[];
+}
+
+export function DeploymentsListClient({
+  workspaceId,
+  deployments,
+}: DeploymentsListClientProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-lg font-semibold tracking-tight">Deployments</h1>
+        <CreateDeploymentDialog
+          workspaceId={workspaceId}
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+        />
+      </div>
+
+      {deployments.length === 0 ? (
+        <EmptyState
+          icon={<Rocket className="size-10" />}
+          title="No deployments yet"
+          description="A deployment wires a build to a model and a runtime. You'll need two to run a clash."
+          action={{
+            label: "Deploy your first agent",
+            onClick: () => setDialogOpen(true),
+          }}
+        />
+      ) : (
+        <div className="rounded-lg border border-border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Created</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {deployments.map((d) => (
+                <TableRow key={d.id}>
+                  <TableCell className="font-medium">{d.name}</TableCell>
+                  <TableCell>
+                    <Badge variant={statusVariant[d.status] ?? "outline"}>
+                      {d.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {new Date(d.created_at).toLocaleDateString()}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/deployments/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/deployments/page.tsx
@@ -2,24 +2,7 @@ import { withAuth } from "@workos-inc/authkit-nextjs";
 import { redirect } from "next/navigation";
 import { createApiClient } from "@/lib/api/client";
 import type { AgentDeployment } from "@/lib/api/types";
-import { Badge } from "@/components/ui/badge";
-import { EmptyState } from "@/components/ui/empty-state";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { Rocket } from "lucide-react";
-import { CreateDeploymentDialog } from "./create-deployment-dialog";
-
-const statusVariant: Record<string, "default" | "secondary" | "outline"> = {
-  active: "default",
-  paused: "outline",
-  archived: "secondary",
-};
+import { DeploymentsListClient } from "./deployments-list-client";
 
 export default async function DeploymentsPage({
   params,
@@ -37,46 +20,9 @@ export default async function DeploymentsPage({
   );
 
   return (
-    <div>
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-lg font-semibold tracking-tight">Deployments</h1>
-        <CreateDeploymentDialog workspaceId={workspaceId} />
-      </div>
-
-      {deployments.length === 0 ? (
-        <EmptyState
-          icon={<Rocket className="size-10" />}
-          title="No deployments yet"
-          description="Deploy an agent build version to make it runnable against challenge packs."
-        />
-      ) : (
-        <div className="rounded-lg border border-border">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Name</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Created</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {deployments.map((d) => (
-                <TableRow key={d.id}>
-                  <TableCell className="font-medium">{d.name}</TableCell>
-                  <TableCell>
-                    <Badge variant={statusVariant[d.status] ?? "outline"}>
-                      {d.status}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">
-                    {new Date(d.created_at).toLocaleDateString()}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
-      )}
-    </div>
+    <DeploymentsListClient
+      workspaceId={workspaceId}
+      deployments={deployments}
+    />
   );
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.test.tsx
@@ -114,6 +114,7 @@ vi.mock("@/components/ui/dialog", async () => {
 vi.mock("lucide-react", () => ({
   Loader2: () => React.createElement("span", null, "loader"),
   Plus: () => React.createElement("span", null, "plus"),
+  HelpCircle: () => React.createElement("span", null, "help"),
 }));
 
 async function flushPromises() {

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
@@ -27,18 +27,30 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { GlossaryTerm } from "@/components/onboarding/glossary-term";
 import { toast } from "sonner";
 import { Loader2, Plus } from "lucide-react";
 
 interface CreateRunDialogProps {
   workspaceId: string;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
-export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
+export function CreateRunDialog({
+  workspaceId,
+  open: controlledOpen,
+  onOpenChange: controlledOnOpenChange,
+}: CreateRunDialogProps) {
   const router = useRouter();
   const { getAccessToken } = useAccessToken();
 
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = controlledOpen ?? internalOpen;
+  const setOpen = (next: boolean) => {
+    if (controlledOpen === undefined) setInternalOpen(next);
+    controlledOnOpenChange?.(next);
+  };
   const [name, setName] = useState("");
   const [selectedPackId, setSelectedPackId] = useState("");
   const [selectedVersionId, setSelectedVersionId] = useState("");
@@ -378,7 +390,7 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
           {/* Challenge Pack */}
           <div>
             <label className="mb-1.5 block text-sm font-medium">
-              Challenge Pack
+              <GlossaryTerm term="challenge-pack">Challenge Pack</GlossaryTerm>
             </label>
             <select
               aria-label="Challenge Pack"
@@ -429,7 +441,7 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
           {/* Input Set */}
           <div>
             <label className="mb-1.5 block text-sm font-medium">
-              Input Set
+              <GlossaryTerm term="input-set">Input Set</GlossaryTerm>
             </label>
             {!selectedVersionId ? (
               <p className="text-sm text-muted-foreground">
@@ -481,7 +493,11 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
 
           <div className="space-y-3 rounded-lg border border-border bg-muted/20 p-3">
             <div>
-              <p className="text-sm font-medium">Regression Coverage</p>
+              <p className="text-sm font-medium">
+                <GlossaryTerm term="regression-coverage">
+                  Regression Coverage
+                </GlossaryTerm>
+              </p>
               <p className="text-xs text-muted-foreground">
                 Optionally add regression suites or specific cases to this run.
               </p>
@@ -567,7 +583,9 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
 
                 <div>
                   <label className="mb-1.5 block text-sm font-medium">
-                    Official Pack Mode
+                    <GlossaryTerm term="official-pack-mode">
+                      Official Pack Mode
+                    </GlossaryTerm>
                   </label>
                   <select
                     aria-label="Official Pack Mode"
@@ -593,7 +611,7 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
           {/* Agent Deployments (multi-select) */}
           <div>
             <label className="mb-1.5 block text-sm font-medium">
-              Agent Deployments
+              <GlossaryTerm term="deployment">Agent Deployments</GlossaryTerm>
             </label>
             {loading ? (
               <p className="text-sm text-muted-foreground">Loading...</p>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/page.tsx
@@ -1,12 +1,13 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { redirect } from "next/navigation";
 import { createApiClient } from "@/lib/api/client";
-import type { ListEvalSessionsResponse, Run } from "@/lib/api/types";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { RunList } from "./run-list";
-import { CreateRunDialog } from "./create-run-dialog";
-import { CreateEvalSessionDialog } from "./create-eval-session-dialog";
-import { EvalSessionList } from "./eval-session-list";
+import type {
+  AgentDeployment,
+  ChallengePack,
+  ListEvalSessionsResponse,
+  Run,
+} from "@/lib/api/types";
+import { RunsPageClient } from "./runs-page-client";
 
 export default async function RunsPage({
   params,
@@ -19,56 +20,36 @@ export default async function RunsPage({
   const { workspaceId } = await params;
 
   const api = createApiClient(accessToken);
-  const [runsResponse, evalSessionsResponse] = await Promise.all([
-    api.get<{
-      items: Run[];
-      total: number;
-      limit: number;
-      offset: number;
-    }>(`/v1/workspaces/${workspaceId}/runs`, {
-      params: { limit: 20, offset: 0 },
-    }),
-    api.get<ListEvalSessionsResponse>("/v1/eval-sessions", {
-      params: { workspace_id: workspaceId, limit: 20, offset: 0 },
-    }),
-  ]);
+  const [runsResponse, evalSessionsResponse, deploymentsResponse, packsResponse] =
+    await Promise.all([
+      api.get<{ items: Run[]; total: number; limit: number; offset: number }>(
+        `/v1/workspaces/${workspaceId}/runs`,
+        { params: { limit: 20, offset: 0 } },
+      ),
+      api.get<ListEvalSessionsResponse>("/v1/eval-sessions", {
+        params: { workspace_id: workspaceId, limit: 20, offset: 0 },
+      }),
+      api.get<{ items: AgentDeployment[] }>(
+        `/v1/workspaces/${workspaceId}/agent-deployments`,
+      ),
+      api.get<{ items: ChallengePack[] }>(
+        `/v1/workspaces/${workspaceId}/challenge-packs`,
+      ),
+    ]);
+
+  const activeDeploymentsCount = deploymentsResponse.items.filter(
+    (d) => d.status === "active",
+  ).length;
+  const packsCount = packsResponse.items.length;
 
   return (
-    <div>
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-lg font-semibold tracking-tight">Runs</h1>
-          <p className="text-sm text-muted-foreground mt-0.5">
-            Benchmark single runs and repeated eval sessions against challenge packs.
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <CreateEvalSessionDialog workspaceId={workspaceId} />
-          <CreateRunDialog workspaceId={workspaceId} />
-        </div>
-      </div>
-
-      <Tabs defaultValue="runs" className="w-full">
-        <TabsList variant="line">
-          <TabsTrigger value="runs">Runs</TabsTrigger>
-          <TabsTrigger value="eval-sessions">Eval Sessions</TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="runs" className="pt-4">
-          <RunList
-            workspaceId={workspaceId}
-            initialRuns={runsResponse.items}
-            initialTotal={runsResponse.total}
-          />
-        </TabsContent>
-
-        <TabsContent value="eval-sessions" className="pt-4">
-          <EvalSessionList
-            workspaceId={workspaceId}
-            initialSessions={evalSessionsResponse.items}
-          />
-        </TabsContent>
-      </Tabs>
-    </div>
+    <RunsPageClient
+      workspaceId={workspaceId}
+      initialRuns={runsResponse.items}
+      initialTotal={runsResponse.total}
+      initialSessions={evalSessionsResponse.items}
+      deploymentsCount={activeDeploymentsCount}
+      packsCount={packsCount}
+    />
   );
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/run-list.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/run-list.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { toast } from "sonner";
 import { createApiClient } from "@/lib/api/client";
 import type { Run, RunStatus } from "@/lib/api/types";
 import { Badge } from "@/components/ui/badge";
@@ -18,6 +19,7 @@ import {
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import { Play, ChevronLeft, ChevronRight, GitCompare } from "lucide-react";
+import { useOnboardingState } from "@/components/onboarding/use-onboarding-state";
 import { runStatusVariant } from "./status-variant";
 
 const ACTIVE_STATUSES: RunStatus[] = [
@@ -26,6 +28,7 @@ const ACTIVE_STATUSES: RunStatus[] = [
   "running",
   "scoring",
 ];
+const TERMINAL_STATUSES: RunStatus[] = ["completed", "failed", "cancelled"];
 const PAGE_SIZE = 20;
 const POLL_INTERVAL_MS = 5000;
 
@@ -33,12 +36,14 @@ interface RunListProps {
   workspaceId: string;
   initialRuns: Run[];
   initialTotal: number;
+  onOpenCreateRun?: () => void;
 }
 
 export function RunList({
   workspaceId,
   initialRuns,
   initialTotal,
+  onOpenCreateRun,
 }: RunListProps) {
   const { getAccessToken } = useAccessToken();
   const router = useRouter();
@@ -50,6 +55,32 @@ export function RunList({
   const hasActiveRuns = runs.some((r) =>
     ACTIVE_STATUSES.includes(r.status),
   );
+
+  const { firstRunSeen, markFirstRunSeen } = useOnboardingState(workspaceId);
+
+  // First-run success toast: fires once when a workspace's first run reaches
+  // a terminal state. Gated on `total <= 1` so returning users with a long
+  // history don't see a stray toast if they happen to have their first run
+  // cached in view.
+  useEffect(() => {
+    if (firstRunSeen) return;
+    if (total > 1) return;
+    const terminal = runs.find((r) => TERMINAL_STATUSES.includes(r.status));
+    if (!terminal) return;
+    const timer = setTimeout(() => {
+      toast.success("First clash complete.", {
+        description:
+          "Open the replay to see how each agent approached the task.",
+        action: {
+          label: "View replay",
+          onClick: () =>
+            router.push(`/workspaces/${workspaceId}/runs/${terminal.id}`),
+        },
+      });
+      markFirstRunSeen();
+    }, 250);
+    return () => clearTimeout(timer);
+  }, [runs, total, firstRunSeen, markFirstRunSeen, router, workspaceId]);
 
   const fetchRuns = useCallback(
     async (currentOffset: number) => {
@@ -124,7 +155,15 @@ export function RunList({
       <EmptyState
         icon={<Play className="size-10" />}
         title="No runs yet"
-        description="Create a run to benchmark your agent deployments against challenge packs."
+        description="Compare two agents on the same task with the same tools, then watch the replay step by step."
+        action={
+          onOpenCreateRun
+            ? {
+                label: "Run your first clash",
+                onClick: onOpenCreateRun,
+              }
+            : undefined
+        }
       />
     );
   }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/runs-page-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/runs-page-client.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { WorkspaceWelcome } from "@/components/onboarding/workspace-welcome";
+import { GlossaryTerm } from "@/components/onboarding/glossary-term";
+import type { EvalSessionListItem, Run } from "@/lib/api/types";
+import { RunList } from "./run-list";
+import { CreateRunDialog } from "./create-run-dialog";
+import { CreateEvalSessionDialog } from "./create-eval-session-dialog";
+import { EvalSessionList } from "./eval-session-list";
+
+interface RunsPageClientProps {
+  workspaceId: string;
+  initialRuns: Run[];
+  initialTotal: number;
+  initialSessions: EvalSessionListItem[];
+  deploymentsCount: number;
+  packsCount: number;
+}
+
+export function RunsPageClient({
+  workspaceId,
+  initialRuns,
+  initialTotal,
+  initialSessions,
+  deploymentsCount,
+  packsCount,
+}: RunsPageClientProps) {
+  const [createRunOpen, setCreateRunOpen] = useState(false);
+  const openCreateRun = () => setCreateRunOpen(true);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-lg font-semibold tracking-tight">Runs</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Benchmark single{" "}
+            <GlossaryTerm term="clash">clashes</GlossaryTerm> and repeated eval
+            sessions against{" "}
+            <GlossaryTerm term="challenge-pack">challenge packs</GlossaryTerm>.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <CreateEvalSessionDialog workspaceId={workspaceId} />
+          <CreateRunDialog
+            workspaceId={workspaceId}
+            open={createRunOpen}
+            onOpenChange={setCreateRunOpen}
+          />
+        </div>
+      </div>
+
+      <WorkspaceWelcome
+        workspaceId={workspaceId}
+        deploymentsCount={deploymentsCount}
+        packsCount={packsCount}
+        runsCount={initialTotal}
+        onOpenCreateRun={openCreateRun}
+      />
+
+      <Tabs defaultValue="runs" className="w-full">
+        <TabsList variant="line">
+          <TabsTrigger value="runs">Runs</TabsTrigger>
+          <TabsTrigger value="eval-sessions">Eval Sessions</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="runs" className="pt-4">
+          <RunList
+            workspaceId={workspaceId}
+            initialRuns={initialRuns}
+            initialTotal={initialTotal}
+            onOpenCreateRun={openCreateRun}
+          />
+        </TabsContent>
+
+        <TabsContent value="eval-sessions" className="pt-4">
+          <EvalSessionList
+            workspaceId={workspaceId}
+            initialSessions={initialSessions}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/web/src/components/app-shell/top-bar.tsx
+++ b/web/src/components/app-shell/top-bar.tsx
@@ -95,6 +95,7 @@ export function TopBar({
           avatarUrl={avatarUrl}
           orgName={orgName}
           orgSlug={orgSlug}
+          workspaceId={workspaceId}
         />
       </div>
     </header>

--- a/web/src/components/app-shell/user-menu.tsx
+++ b/web/src/components/app-shell/user-menu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
+import { toast } from "sonner";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   DropdownMenu,
@@ -9,8 +10,9 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { LogOut, Settings2 } from "lucide-react";
+import { LogOut, Settings2, Sparkles } from "lucide-react";
 import Link from "next/link";
+import { restartOnboarding } from "@/components/onboarding/use-onboarding-state";
 
 interface UserMenuProps {
   displayName?: string;
@@ -18,6 +20,7 @@ interface UserMenuProps {
   avatarUrl?: string;
   orgName?: string;
   orgSlug?: string;
+  workspaceId?: string;
 }
 
 export function UserMenu({
@@ -26,8 +29,15 @@ export function UserMenu({
   avatarUrl,
   orgName,
   orgSlug,
+  workspaceId,
 }: UserMenuProps) {
   const { signOut } = useAuth();
+
+  function handleRestartOnboarding() {
+    if (!workspaceId) return;
+    restartOnboarding(workspaceId);
+    toast.success("Onboarding restarted.");
+  }
   const initials = (displayName || email || "U")
     .split(" ")
     .map((w) => w[0])
@@ -67,6 +77,12 @@ export function UserMenu({
             >
               <Settings2 className="size-4" />
               Organization Settings
+            </DropdownMenuItem>
+          )}
+          {workspaceId && (
+            <DropdownMenuItem onClick={handleRestartOnboarding}>
+              <Sparkles className="size-4" />
+              Restart onboarding
             </DropdownMenuItem>
           )}
           <DropdownMenuItem onClick={() => signOut()}>

--- a/web/src/components/onboarding/glossary-term.tsx
+++ b/web/src/components/onboarding/glossary-term.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { HelpCircle } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { GLOSSARY, type GlossaryTermKey } from "./glossary";
+
+interface GlossaryTermProps {
+  term: GlossaryTermKey;
+  children?: ReactNode;
+  className?: string;
+}
+
+export function GlossaryTerm({ term, children, className }: GlossaryTermProps) {
+  const entry = GLOSSARY[term];
+
+  return (
+    <span className={className}>
+      {children ?? entry.label}
+      <TooltipProvider delay={150}>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                aria-label={`What is ${entry.label}?`}
+                className="ml-1 inline-flex size-3.5 translate-y-[-1px] items-center justify-center rounded-full align-middle text-muted-foreground/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+              />
+            }
+          >
+            <HelpCircle className="size-3.5" />
+          </TooltipTrigger>
+          <TooltipContent side="top" className="max-w-xs leading-relaxed">
+            {entry.definition}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </span>
+  );
+}

--- a/web/src/components/onboarding/glossary.ts
+++ b/web/src/components/onboarding/glossary.ts
@@ -1,0 +1,75 @@
+export type GlossaryTermKey =
+  | "agent"
+  | "build"
+  | "deployment"
+  | "challenge-pack"
+  | "input-set"
+  | "clash"
+  | "comparison-mode"
+  | "replay"
+  | "score"
+  | "regression-coverage"
+  | "official-pack-mode";
+
+export interface GlossaryEntry {
+  label: string;
+  definition: string;
+}
+
+export const GLOSSARY: Record<GlossaryTermKey, GlossaryEntry> = {
+  agent: {
+    label: "Agent",
+    definition:
+      "A configured AI model that competes on a task. Agents call tools to get things done.",
+  },
+  build: {
+    label: "Build",
+    definition:
+      "The spec for how an agent behaves — its prompt, tools, and output format.",
+  },
+  deployment: {
+    label: "Deployment",
+    definition:
+      "A live agent ready to run. It wires a build to a model and a runtime profile.",
+  },
+  "challenge-pack": {
+    label: "Challenge Pack",
+    definition:
+      "The task your agents will attempt. Bundles inputs, expected outputs, and scoring.",
+  },
+  "input-set": {
+    label: "Input Set",
+    definition:
+      "One versioned batch of test inputs inside a challenge pack.",
+  },
+  clash: {
+    label: "Clash",
+    definition:
+      "One head-to-head where each agent solves the same challenge under the same constraints.",
+  },
+  "comparison-mode": {
+    label: "Comparison Mode",
+    definition:
+      "Two or more agents run the same inputs side by side so the scoreboard can rank them.",
+  },
+  replay: {
+    label: "Replay",
+    definition:
+      "The step-by-step trace of what each agent did, thought, and called — so you can see why it won or failed.",
+  },
+  score: {
+    label: "Score",
+    definition:
+      "Completion, speed, token efficiency, and tool strategy combined. Higher is better.",
+  },
+  "regression-coverage": {
+    label: "Regression Coverage",
+    definition:
+      "Known-tricky cases layered on top of the pack to make sure nothing broke.",
+  },
+  "official-pack-mode": {
+    label: "Official Pack Mode",
+    definition:
+      "Whether the run includes the full official pack plus regressions, or only the selected regressions.",
+  },
+};

--- a/web/src/components/onboarding/use-onboarding-state.test.ts
+++ b/web/src/components/onboarding/use-onboarding-state.test.ts
@@ -1,0 +1,169 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  onboardingStorageKeys,
+  restartOnboarding,
+  useOnboardingState,
+  type OnboardingState,
+} from "./use-onboarding-state";
+
+const WORKSPACE_ID = "ws-test-1";
+
+function renderHook(): {
+  state: () => OnboardingState;
+  cleanup: () => void;
+} {
+  const captured: { current: OnboardingState | null } = { current: null };
+
+  function Probe() {
+    const value = useOnboardingState(WORKSPACE_ID);
+    React.useEffect(() => {
+      captured.current = value;
+    });
+    return null;
+  }
+
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+
+  act(() => {
+    root.render(React.createElement(Probe));
+  });
+
+  return {
+    state: () => {
+      if (!captured.current) throw new Error("hook not mounted");
+      return captured.current;
+    },
+    cleanup: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+function installLocalStorage(): Storage {
+  const store = new Map<string, string>();
+  const impl: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key) => (store.has(key) ? (store.get(key) as string) : null),
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    setItem: (key, value) => {
+      store.set(key, String(value));
+    },
+  };
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: impl,
+  });
+  return impl;
+}
+
+describe("useOnboardingState", () => {
+  beforeEach(() => {
+    installLocalStorage();
+  });
+
+  it("starts with both flags false when nothing is persisted", () => {
+    const { state, cleanup } = renderHook();
+    try {
+      expect(state().dismissed).toBe(false);
+      expect(state().firstRunSeen).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("persists dismissal to localStorage and reflects it in state", () => {
+    const { state, cleanup } = renderHook();
+    try {
+      act(() => {
+        state().dismiss();
+      });
+      expect(state().dismissed).toBe(true);
+      expect(
+        window.localStorage.getItem(
+          onboardingStorageKeys.dismissed(WORKSPACE_ID),
+        ),
+      ).toBe("1");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("markFirstRunSeen is independent of dismissal", () => {
+    const { state, cleanup } = renderHook();
+    try {
+      act(() => {
+        state().markFirstRunSeen();
+      });
+      expect(state().firstRunSeen).toBe(true);
+      expect(state().dismissed).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("restore clears both flags", () => {
+    window.localStorage.setItem(
+      onboardingStorageKeys.dismissed(WORKSPACE_ID),
+      "1",
+    );
+    window.localStorage.setItem(
+      onboardingStorageKeys.firstRunSeen(WORKSPACE_ID),
+      "1",
+    );
+    const { state, cleanup } = renderHook();
+    try {
+      expect(state().dismissed).toBe(true);
+      expect(state().firstRunSeen).toBe(true);
+      act(() => {
+        state().restore();
+      });
+      expect(state().dismissed).toBe(false);
+      expect(state().firstRunSeen).toBe(false);
+      expect(
+        window.localStorage.getItem(
+          onboardingStorageKeys.dismissed(WORKSPACE_ID),
+        ),
+      ).toBeNull();
+      expect(
+        window.localStorage.getItem(
+          onboardingStorageKeys.firstRunSeen(WORKSPACE_ID),
+        ),
+      ).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("restartOnboarding clears flags and mounted hooks pick up the change", () => {
+    const { state, cleanup } = renderHook();
+    try {
+      act(() => {
+        state().dismiss();
+        state().markFirstRunSeen();
+      });
+      expect(state().dismissed).toBe(true);
+      expect(state().firstRunSeen).toBe(true);
+      act(() => {
+        restartOnboarding(WORKSPACE_ID);
+      });
+      expect(state().dismissed).toBe(false);
+      expect(state().firstRunSeen).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/web/src/components/onboarding/use-onboarding-state.ts
+++ b/web/src/components/onboarding/use-onboarding-state.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+
+const KEY_PREFIX = "agentclash:onboarding";
+const SYNC_EVENT = "agentclash:onboarding:sync";
+
+export const onboardingStorageKeys = {
+  dismissed: (workspaceId: string) => `${KEY_PREFIX}:dismissed:${workspaceId}`,
+  firstRunSeen: (workspaceId: string) =>
+    `${KEY_PREFIX}:first_run_seen:${workspaceId}`,
+};
+
+function readFlag(key: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(key) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writeFlag(key: string, value: boolean) {
+  if (typeof window === "undefined") return;
+  try {
+    if (value) window.localStorage.setItem(key, "1");
+    else window.localStorage.removeItem(key);
+  } catch {
+    return;
+  }
+  window.dispatchEvent(new CustomEvent(SYNC_EVENT));
+}
+
+function subscribe(onChange: () => void): () => void {
+  window.addEventListener("storage", onChange);
+  window.addEventListener(SYNC_EVENT, onChange);
+  return () => {
+    window.removeEventListener("storage", onChange);
+    window.removeEventListener(SYNC_EVENT, onChange);
+  };
+}
+
+const serverSnapshot = () => false;
+
+export interface OnboardingState {
+  dismissed: boolean;
+  firstRunSeen: boolean;
+  dismiss: () => void;
+  restore: () => void;
+  markFirstRunSeen: () => void;
+}
+
+export function useOnboardingState(workspaceId: string): OnboardingState {
+  const dismissed = useSyncExternalStore(
+    subscribe,
+    () => readFlag(onboardingStorageKeys.dismissed(workspaceId)),
+    serverSnapshot,
+  );
+  const firstRunSeen = useSyncExternalStore(
+    subscribe,
+    () => readFlag(onboardingStorageKeys.firstRunSeen(workspaceId)),
+    serverSnapshot,
+  );
+
+  const dismiss = useCallback(() => {
+    writeFlag(onboardingStorageKeys.dismissed(workspaceId), true);
+  }, [workspaceId]);
+
+  const restore = useCallback(() => {
+    writeFlag(onboardingStorageKeys.dismissed(workspaceId), false);
+    writeFlag(onboardingStorageKeys.firstRunSeen(workspaceId), false);
+  }, [workspaceId]);
+
+  const markFirstRunSeen = useCallback(() => {
+    writeFlag(onboardingStorageKeys.firstRunSeen(workspaceId), true);
+  }, [workspaceId]);
+
+  return { dismissed, firstRunSeen, dismiss, restore, markFirstRunSeen };
+}
+
+export function restartOnboarding(workspaceId: string) {
+  writeFlag(onboardingStorageKeys.dismissed(workspaceId), false);
+  writeFlag(onboardingStorageKeys.firstRunSeen(workspaceId), false);
+}

--- a/web/src/components/onboarding/workspace-welcome.tsx
+++ b/web/src/components/onboarding/workspace-welcome.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import Link from "next/link";
+import { Check, Play, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useOnboardingState } from "./use-onboarding-state";
+
+interface WorkspaceWelcomeProps {
+  workspaceId: string;
+  deploymentsCount: number;
+  packsCount: number;
+  runsCount: number;
+  onOpenCreateRun: () => void;
+}
+
+export function WorkspaceWelcome({
+  workspaceId,
+  deploymentsCount,
+  packsCount,
+  runsCount,
+  onOpenCreateRun,
+}: WorkspaceWelcomeProps) {
+  const { dismissed, dismiss } = useOnboardingState(workspaceId);
+
+  const step1Done = deploymentsCount >= 2;
+  const step2Done = packsCount >= 1;
+  const step3Done = runsCount >= 1;
+  const allDone = step1Done && step2Done && step3Done;
+
+  if (dismissed) return null;
+  // Once the user has a run, the page shows its usual content — the welcome
+  // retires itself even if they never clicked dismiss.
+  if (allDone) return null;
+
+  const steps: Array<{
+    title: string;
+    description: string;
+    done: boolean;
+    href?: string;
+    onClick?: () => void;
+    cta: string;
+  }> = [
+    {
+      title: "Deploy two agents",
+      description:
+        "The competitors you'll compare. A deployment is a model wired to a runtime.",
+      done: step1Done,
+      href: `/workspaces/${workspaceId}/deployments`,
+      cta: step1Done ? "Manage deployments" : "Go to deployments",
+    },
+    {
+      title: "Pick a challenge pack",
+      description:
+        "The task each agent will attempt. Publish your own or browse the catalog.",
+      done: step2Done,
+      href: `/workspaces/${workspaceId}/challenge-packs`,
+      cta: step2Done ? "Browse packs" : "Browse packs",
+    },
+    {
+      title: "Run your first clash",
+      description:
+        "Start the head-to-head and open the replay to see each step.",
+      done: step3Done,
+      onClick: onOpenCreateRun,
+      cta: "Run your first clash",
+    },
+  ];
+
+  const firstIncomplete = steps.findIndex((s) => !s.done);
+
+  return (
+    <section
+      role="region"
+      aria-label="Getting started with AgentClash"
+      className="relative mb-6 rounded-xl border border-border bg-card/50 p-6 animate-in fade-in-0 duration-200"
+    >
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="Dismiss onboarding"
+        className="absolute right-3 top-3 inline-flex size-7 items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+      >
+        <X className="size-4" />
+      </button>
+
+      <div className="mb-5 max-w-2xl pr-8">
+        <h2 className="text-base font-semibold tracking-tight text-foreground">
+          Get started with AgentClash
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          AgentClash compares agents by making them solve the same task with
+          the same tools and constraints. Live scores and replays show you
+          which agent actually performs better.
+        </p>
+      </div>
+
+      <ol className="mb-5 space-y-1.5">
+        {steps.map((step, i) => {
+          const emphasized = i === firstIncomplete;
+          return (
+            <li
+              key={step.title}
+              className={cn(
+                "flex items-start gap-3 rounded-lg border px-3 py-2.5 transition-colors",
+                step.done
+                  ? "border-transparent bg-muted/10"
+                  : emphasized
+                    ? "border-border/80 bg-muted/30"
+                    : "border-transparent",
+              )}
+            >
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full",
+                  step.done
+                    ? "bg-foreground text-background"
+                    : emphasized
+                      ? "border border-foreground/40 bg-background text-foreground"
+                      : "border border-border text-muted-foreground",
+                )}
+              >
+                {step.done ? (
+                  <Check className="size-3" />
+                ) : (
+                  <span className="text-[10px] font-semibold leading-none">
+                    {i + 1}
+                  </span>
+                )}
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span
+                    className={cn(
+                      "text-sm font-medium",
+                      step.done
+                        ? "text-muted-foreground"
+                        : "text-foreground",
+                    )}
+                  >
+                    {step.done && (
+                      <span className="sr-only">Completed: </span>
+                    )}
+                    {step.title}
+                  </span>
+                </div>
+                {!step.done && (
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    {step.description}
+                  </p>
+                )}
+                {emphasized && !step.done && (
+                  <div className="mt-2">
+                    {step.onClick ? (
+                      <Button
+                        size="xs"
+                        variant="outline"
+                        onClick={step.onClick}
+                      >
+                        {step.cta}
+                      </Button>
+                    ) : step.href ? (
+                      <Button
+                        size="xs"
+                        variant="outline"
+                        render={<Link href={step.href} />}
+                      >
+                        {step.cta}
+                      </Button>
+                    ) : null}
+                  </div>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Button size="sm" onClick={onOpenCreateRun}>
+          <Play data-icon="inline-start" className="size-4" />
+          Run your first clash
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          render={
+            <Link href="/manifesto" target="_blank" rel="noreferrer" />
+          }
+        >
+          How it works →
+        </Button>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- Dismissible welcome card on the Runs page with a 3-step checklist (deploy two agents → pick a challenge pack → run your first clash), driven by server-fetched counts so each row flips to ✓ as the user makes progress.
- Action-oriented empty states on Runs, Deployments, Challenge Packs, and Builds — each CTA opens the right Create/Publish dialog, which required threading optional controlled `open`/`onOpenChange` props through the four dialogs and splitting each page into a thin `*-list-client.tsx` that owns the dialog state.
- Plain-language `GlossaryTerm` tooltips on jargon labels (Challenge Pack, Input Set, Agent Deployments, Regression Coverage, Official Pack Mode) and in the Runs subtitle.
- "Restart onboarding" entry in the user menu, and a one-time "First clash complete — View replay" sonner toast the first time a workspace's only run reaches a terminal state.
- `useOnboardingState(workspaceId)` hook, SSR-safe via `useSyncExternalStore`, backed by two per-workspace localStorage keys and synced cross-tab + same-tab via `storage` / custom events.

## Test plan
- [ ] `cd web && pnpm lint` passes
- [ ] `cd web && npx tsc --noEmit` passes
- [ ] `cd web && pnpm exec vitest run` passes (161 passed, 3 pre-existing skipped)
- [ ] Fresh workspace (via `/onboard`) shows the welcome card with 0/3 checklist
- [ ] After `make db-seed`, the welcome shows ✓ on Deploy and Pack but not Run
- [ ] Clicking the × dismisses the welcome; reload keeps it dismissed
- [ ] User menu → "Restart onboarding" brings it back immediately (no reload)
- [ ] Dismiss in one tab → welcome disappears in another (storage event)
- [ ] Dismissal is per-workspace (workspace A dismissed ≠ workspace B dismissed)
- [ ] "Run your first clash" opens the existing `CreateRunDialog`
- [ ] Deployments / Challenge Packs / Builds empty-state CTAs open the matching Create/Publish dialog
- [ ] Glossary `(?)` icons are keyboard-focusable (Tab → Enter / Space)
- [ ] First-run toast fires once when a workspace's only run completes; doesn't re-fire on reload
- [ ] Mobile (≤640px) — card stacks, CTAs wrap, no horizontal scroll
- [ ] Dark mode — semantic tokens render correctly (default for the app)

## Out of scope (follow-ups)
- Backend `starter-content` endpoint so "Use sample setup" can one-click provision two deployments + a pack.
- DB-backed onboarding preference so dismissal survives cleared browser storage.
- Help (`?`) menu in the top bar as a durable home for docs + restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)