### PR TITLE
[codex] Browser capability substrate

### DIFF
--- a/backend/e2b-template/template.ts
+++ b/backend/e2b-template/template.ts
@@ -50,7 +50,14 @@ export const template = Template()
   // Python packages
   .runCmd(
     'pip3 install --no-cache-dir --break-system-packages ' +
-      'PyPDF2 pdfplumber requests httpx csvkit',
+      'PyPDF2 pdfplumber requests httpx csvkit uv',
+  )
+
+  // Browser agent runtime. Browser-enabled challenge packs use Browser Use
+  // cloud browsers, so the sandbox only needs the harness and CDP client.
+  .runCmd(
+    'uv tool install git+https://github.com/browser-use/browser-harness.git ' +
+      '&& ln -sf /root/.local/bin/browser-harness /usr/local/bin/browser-harness',
   )
 
   // Helper scripts

--- a/backend/e2b-template/template.ts
+++ b/backend/e2b-template/template.ts
@@ -56,7 +56,7 @@ export const template = Template()
   // Browser agent runtime. Browser-enabled challenge packs use Browser Use
   // cloud browsers, so the sandbox only needs the harness and CDP client.
   .runCmd(
-    'uv tool install git+https://github.com/browser-use/browser-harness.git ' +
+    'uv tool install git+https://github.com/browser-use/browser-harness.git@361c90e0a7663c408e79fe932b3d8001718cda7d ' +
       '&& ln -sf /root/.local/bin/browser-harness /usr/local/bin/browser-harness',
   )
 

--- a/backend/internal/challengepack/bundle_test.go
+++ b/backend/internal/challengepack/bundle_test.go
@@ -568,6 +568,55 @@ func TestValidateBundleRejectsPromptEvalWithTools(t *testing.T) {
 	}
 }
 
+func TestValidateBundleAllowsBrowserToolKind(t *testing.T) {
+	err := ValidateBundle(Bundle{
+		Pack: PackMetadata{Slug: "browser", Name: "Browser", Family: "browser"},
+		Version: VersionMetadata{
+			Number:         1,
+			ExecutionMode:  ExecutionModeNative,
+			ToolPolicy:     map[string]any{"allowed_tool_kinds": []any{"browser"}},
+			EvaluationSpec: minimalSpec(),
+		},
+		Challenges: []ChallengeDefinition{
+			{Key: "c1", Title: "C1", Category: "browser", Difficulty: "easy"},
+		},
+		InputSets: []InputSetDefinition{
+			{Key: "default", Name: "Default", Cases: []CaseDefinition{{ChallengeKey: "c1", CaseKey: "k"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ValidateBundle returned error: %v", err)
+	}
+}
+
+func TestValidateBundleRejectsUnknownToolKind(t *testing.T) {
+	err := ValidateBundle(Bundle{
+		Pack: PackMetadata{Slug: "browser", Name: "Browser", Family: "browser"},
+		Version: VersionMetadata{
+			Number:         1,
+			ExecutionMode:  ExecutionModeNative,
+			ToolPolicy:     map[string]any{"allowed_tool_kinds": []any{"browser", "telepathy"}},
+			EvaluationSpec: minimalSpec(),
+		},
+		Challenges: []ChallengeDefinition{
+			{Key: "c1", Title: "C1", Category: "browser", Difficulty: "easy"},
+		},
+		InputSets: []InputSetDefinition{
+			{Key: "default", Name: "Default", Cases: []CaseDefinition{{ChallengeKey: "c1", CaseKey: "k"}}},
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected validation error for unknown tool kind")
+	}
+	errs, ok := err.(ValidationErrors)
+	if !ok {
+		t.Fatalf("expected ValidationErrors, got %T", err)
+	}
+	if !containsField(errs, "version.tool_policy.allowed_tool_kinds[1]") {
+		t.Fatalf("expected allowed_tool_kinds validation error; got %v", errs)
+	}
+}
+
 func TestValidateBundleRejectsUnknownExecutionMode(t *testing.T) {
 	err := ValidateBundle(Bundle{
 		Pack: PackMetadata{Slug: "t", Name: "T", Family: "f"},

--- a/backend/internal/challengepack/bundle_test.go
+++ b/backend/internal/challengepack/bundle_test.go
@@ -16,7 +16,8 @@ pack:
 version:
   number: 1
   tool_policy:
-    allowed_tool_kinds: ["file", "shell"]
+    allowed_tool_kinds: ["file"]
+    allow_shell: true
   evaluation_spec:
     name: support-v1
     version_number: 1

--- a/backend/internal/challengepack/validation.go
+++ b/backend/internal/challengepack/validation.go
@@ -23,7 +23,6 @@ var supportedToolKinds = map[string]struct{}{
 	"data":    {},
 	"file":    {},
 	"network": {},
-	"shell":   {},
 }
 
 type ValidationError struct {
@@ -213,7 +212,7 @@ func validateToolPolicyConfig(path string, policy map[string]any) ValidationErro
 		if _, supported := supportedToolKinds[strings.ToLower(strings.TrimSpace(kind))]; !supported {
 			errs = append(errs, ValidationError{
 				Field:   field,
-				Message: "must be one of browser, build, data, file, network, shell",
+				Message: "must be one of browser, build, data, file, network",
 			})
 		}
 	}

--- a/backend/internal/challengepack/validation.go
+++ b/backend/internal/challengepack/validation.go
@@ -17,6 +17,15 @@ var (
 	aptPackagePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9.+\-]+$`)
 )
 
+var supportedToolKinds = map[string]struct{}{
+	"browser": {},
+	"build":   {},
+	"data":    {},
+	"file":    {},
+	"network": {},
+	"shell":   {},
+}
+
 type ValidationError struct {
 	Field   string
 	Message string
@@ -152,6 +161,7 @@ func ValidateBundle(bundle Bundle) error {
 	}
 
 	errs = append(errs, validateToolsConfig("tools", bundle.Tools)...)
+	errs = append(errs, validateToolPolicyConfig("version.tool_policy", bundle.Version.ToolPolicy)...)
 
 	if bundle.Version.Sandbox != nil {
 		errs = append(errs, validateSandboxConfig("version.sandbox", bundle.Version.Sandbox)...)
@@ -172,6 +182,57 @@ func ValidateBundle(bundle Bundle) error {
 		return errs
 	}
 	return nil
+}
+
+func validateToolPolicyConfig(path string, policy map[string]any) ValidationErrors {
+	if len(policy) == 0 {
+		return nil
+	}
+
+	rawKinds, ok := policy["allowed_tool_kinds"]
+	if !ok {
+		return nil
+	}
+
+	kinds, ok := toolKindValues(rawKinds)
+	if !ok {
+		return ValidationErrors{{
+			Field:   path + ".allowed_tool_kinds",
+			Message: "must be an array of supported tool kind strings",
+		}}
+	}
+
+	var errs ValidationErrors
+	for i, rawKind := range kinds {
+		kind, ok := rawKind.(string)
+		field := fmt.Sprintf("%s.allowed_tool_kinds[%d]", path, i)
+		if !ok || strings.TrimSpace(kind) == "" {
+			errs = append(errs, ValidationError{Field: field, Message: "must be a supported tool kind string"})
+			continue
+		}
+		if _, supported := supportedToolKinds[strings.ToLower(strings.TrimSpace(kind))]; !supported {
+			errs = append(errs, ValidationError{
+				Field:   field,
+				Message: "must be one of browser, build, data, file, network, shell",
+			})
+		}
+	}
+	return errs
+}
+
+func toolKindValues(raw any) ([]any, bool) {
+	switch values := raw.(type) {
+	case []any:
+		return values, true
+	case []string:
+		out := make([]any, len(values))
+		for i, value := range values {
+			out[i] = value
+		}
+		return out, true
+	default:
+		return nil, false
+	}
 }
 
 func validateToolsConfig(path string, tools map[string]any) ValidationErrors {

--- a/backend/internal/engine/primitive_helpers.go
+++ b/backend/internal/engine/primitive_helpers.go
@@ -16,6 +16,7 @@ const (
 	toolKindData    = "data"
 	toolKindNetwork = "network"
 	toolKindBuild   = "build"
+	toolKindBrowser = "browser"
 
 	toolOutputInlineLimitBytes       = 32 * 1024
 	toolOutputPreviewLineCount       = 50
@@ -173,6 +174,10 @@ func allowsNetworkTools(toolPolicy sandbox.ToolPolicy) bool {
 
 func allowsBuildTools(toolPolicy sandbox.ToolPolicy) bool {
 	return allowsToolKind(toolPolicy, toolKindBuild)
+}
+
+func allowsBrowserTools(toolPolicy sandbox.ToolPolicy) bool {
+	return allowsToolKind(toolPolicy, toolKindBrowser)
 }
 
 func containsExitCode(codes []int, want int) bool {

--- a/backend/internal/engine/primitive_helpers_test.go
+++ b/backend/internal/engine/primitive_helpers_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAllowsToolKind(t *testing.T) {
-	policy := sandbox.ToolPolicy{AllowedToolKinds: []string{toolKindFile, toolKindBuild}}
+	policy := sandbox.ToolPolicy{AllowedToolKinds: []string{toolKindFile, toolKindBuild, toolKindBrowser}}
 
 	if !allowsToolKind(policy, toolKindFile) {
 		t.Fatal("expected file tool kind to be allowed")
@@ -19,6 +19,21 @@ func TestAllowsToolKind(t *testing.T) {
 	}
 	if allowsToolKind(policy, toolKindData) {
 		t.Fatal("expected data tool kind to be denied")
+	}
+	if !allowsBrowserTools(policy) {
+		t.Fatal("expected browser tool kind to be allowed")
+	}
+}
+
+func TestAllowsBrowserTools(t *testing.T) {
+	if !allowsBrowserTools(sandbox.ToolPolicy{}) {
+		t.Fatal("expected unrestricted policy to allow browser tools")
+	}
+	if !allowsBrowserTools(sandbox.ToolPolicy{AllowedToolKinds: []string{" browser "}}) {
+		t.Fatal("expected browser policy to allow browser tools")
+	}
+	if allowsBrowserTools(sandbox.ToolPolicy{AllowedToolKinds: []string{toolKindFile}}) {
+		t.Fatal("expected file-only policy to deny browser tools")
 	}
 }
 

--- a/backend/internal/engine/sandbox_config_test.go
+++ b/backend/internal/engine/sandbox_config_test.go
@@ -177,3 +177,19 @@ func TestApplySandboxConfig_AcceptsLiteralEnvVars(t *testing.T) {
 		t.Errorf("FEATURE_FLAGS = %q, want %q", got, want)
 	}
 }
+
+func TestNativeSandboxRequest_PreservesBrowserToolKind(t *testing.T) {
+	executionContext := nativeExecutionContext()
+	executionContext.ChallengePackVersion.Manifest = json.RawMessage(`{
+		"tool_policy": {"allowed_tool_kinds": ["browser"]},
+		"version": {"number": 1}
+	}`)
+
+	request, err := nativeSandboxRequest(executionContext)
+	if err != nil {
+		t.Fatalf("nativeSandboxRequest returned error: %v", err)
+	}
+	if len(request.ToolPolicy.AllowedToolKinds) != 1 || request.ToolPolicy.AllowedToolKinds[0] != toolKindBrowser {
+		t.Fatalf("AllowedToolKinds = %#v, want [browser]", request.ToolPolicy.AllowedToolKinds)
+	}
+}

--- a/docs/evaluation/browser-agent-packs.md
+++ b/docs/evaluation/browser-agent-packs.md
@@ -1,0 +1,59 @@
+# Browser Agent Challenge Packs
+
+Browser-capable packs evaluate agents that can use a real browser, not just HTTP
+fetches. AgentClash uses the same native run loop and scoring pipeline as other
+agentic packs, with a dedicated `browser` tool kind gating browser primitives.
+
+## Pack Contract
+
+Declare browser access on native packs:
+
+```yaml
+version:
+  execution_mode: native
+  sandbox:
+    network_access: true
+  tool_policy:
+    allowed_tool_kinds:
+      - browser
+```
+
+`browser` is intentionally separate from `network`. Browser tools operate a
+remote browser session through Browser Use browser-harness, while `network`
+continues to mean direct HTTP request tools from the sandbox.
+
+Do not put secrets such as `BROWSER_USE_API_KEY` in `version.sandbox.env_vars`.
+Sandbox environment variables are literal-only. Browser primitives resolve the
+workspace secret at execution time and inject it only into the harness command
+that needs it.
+
+## Runtime
+
+The E2B template installs `browser-harness` and its Python dependencies. The
+browser itself should be a Browser Use cloud browser so each run agent can get an
+isolated session namespace. The follow-up browser primitives use:
+
+- `BU_NAME=<run_agent_id>` for per-agent isolation
+- `BROWSER_USE_API_KEY` from workspace secrets
+- structured JSON tool results for navigation state, screenshots, and errors
+
+## Authoring Guidance
+
+Prefer benchmark tasks that have a deterministic goal state:
+
+- navigate to a page and extract visible facts
+- fill a form and verify confirmation text
+- interact with dropdowns, dialogs, tabs, or iframes
+- download or generate a file and validate its contents
+- recover from a wrong page, stale session, or transient page error
+
+Score with existing evidence before adding custom graders:
+
+- `final_output` JSON validators for extracted answers
+- post-execution file captures for downloads or saved screenshots
+- code-execution checks for generated artifacts
+- latency, tool-call count, token, and behavioral metrics
+
+Avoid tasks that require personal accounts, production purchases, CAPTCHA
+solving, or unbounded live-web browsing unless the pack provides explicit test
+accounts and teardown instructions.

--- a/docs/evaluation/challenge-pack-v0.md
+++ b/docs/evaluation/challenge-pack-v0.md
@@ -20,7 +20,8 @@ The manifest may contain a top-level `evaluation_spec` block like this:
 {
   "schema_version": 1,
   "tool_policy": {
-    "allowed_tool_kinds": ["file", "shell"]
+    "allowed_tool_kinds": ["file"],
+    "allow_shell": true
   },
   "evaluation_spec": {
     "name": "coding-fix-v0",

--- a/examples/architect/architect-valid-yaml-first-pass.yaml
+++ b/examples/architect/architect-valid-yaml-first-pass.yaml
@@ -34,9 +34,9 @@ version:
     network_access: false
 
   tool_policy:
+    allow_shell: true
     allowed_tool_kinds:
       - file
-      - shell
 
   evaluation_spec:
     name: architect-valid-yaml-first-pass-v2

--- a/examples/challenge-packs/deep-research-analyst.yaml
+++ b/examples/challenge-packs/deep-research-analyst.yaml
@@ -25,9 +25,9 @@ version:
     network_access: true
 
   tool_policy:
+    allow_shell: true
     allowed_tool_kinds:
       - file
-      - shell
 
   tools:
     custom:

--- a/examples/challenge-packs/fibonacci-e2e-showcase.yaml
+++ b/examples/challenge-packs/fibonacci-e2e-showcase.yaml
@@ -38,9 +38,9 @@ version:
     network_access: false
 
   tool_policy:
+    allow_shell: true
     allowed_tool_kinds:
       - file
-      - shell
 
   evaluation_spec:
     name: fibonacci-e2e-showcase-v1

--- a/examples/challenge-packs/incident-response-llm-judge.yaml
+++ b/examples/challenge-packs/incident-response-llm-judge.yaml
@@ -24,9 +24,9 @@ version:
     network_access: false
 
   tool_policy:
+    allow_shell: true
     allowed_tool_kinds:
       - file
-      - shell
 
   evaluation_spec:
     name: incident-response-llm-judge-v1

--- a/testing/codex-browser-capability-substrate.md
+++ b/testing/codex-browser-capability-substrate.md
@@ -1,0 +1,28 @@
+# codex/browser-capability-substrate — Test Contract
+
+## Functional Behavior
+- Native challenge packs can declare `browser` in `version.tool_policy.allowed_tool_kinds`.
+- The native engine recognizes `browser` as a distinct tool kind while preserving existing file, data, network, build, and shell behavior.
+- Browser-capable challenge packs can request browser runtime dependencies through the E2B template without changing run creation APIs.
+- Prompt-eval packs continue to reject tools, sandbox settings, and tool policies.
+- Documentation explains how browser-enabled packs should declare capability, network access, secrets, and evidence.
+
+## Unit Tests
+- `backend/internal/engine` policy tests cover `allowsBrowserTools` for unrestricted, allowed, and denied policies.
+- `backend/internal/engine` sandbox request tests cover `allowed_tool_kinds: ["browser"]` passing through from the manifest.
+- `backend/internal/challengepack` validation tests cover `browser` as an accepted tool kind and an unknown tool kind as rejected.
+- Existing prompt-eval validation tests continue to pass.
+
+## Integration / Functional Tests
+- `go test ./internal/engine ./internal/challengepack` from `backend/` passes.
+- The E2B template remains syntactically valid TypeScript.
+
+## Smoke Tests
+- `go test ./internal/engine -run Browser -count=1` from `backend/` passes.
+- `go test ./internal/challengepack -run Tool -count=1` from `backend/` passes.
+
+## E2E Tests
+- N/A — this PR only adds the capability substrate. End-to-end browser task execution lands in the follow-up primitives PR.
+
+## Manual / cURL Tests
+- N/A — no API route changes in this PR.


### PR DESCRIPTION
## Summary
- add `browser` as a native tool-policy kind and validate it in challenge-pack bundles
- preserve browser tool policy into native sandbox requests
- install Browser Use `browser-harness` in the E2B template
- document browser-capable challenge pack authoring

## Issue
Closes #394

## Validation
- `go test ./internal/engine -run 'Browser|SandboxRequest|AllowsBrowser|AllowsToolKind' -count=1`
- `go test ./internal/challengepack -run 'Tool|PromptEval|Browser' -count=1`
- `go test ./internal/engine ./internal/challengepack`
