### PR TITLE
[codex] Browser primitives and smoke pack

### DIFF
--- a/backend/internal/challengepack/browser_pack_test.go
+++ b/backend/internal/challengepack/browser_pack_test.go
@@ -1,0 +1,24 @@
+package challengepack
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseBrowserNavigationSmokePack(t *testing.T) {
+	content, err := os.ReadFile("../../../examples/challenge-packs/browser-navigation-smoke.yaml")
+	if err != nil {
+		t.Fatalf("read browser smoke pack: %v", err)
+	}
+	bundle, err := ParseYAML(content)
+	if err != nil {
+		t.Fatalf("ParseYAML returned error: %v", err)
+	}
+	if bundle.Pack.Slug != "browser-navigation-smoke" {
+		t.Fatalf("slug = %q, want browser-navigation-smoke", bundle.Pack.Slug)
+	}
+	kinds, ok := bundle.Version.ToolPolicy["allowed_tool_kinds"].([]any)
+	if !ok || len(kinds) != 1 || kinds[0] != "browser" {
+		t.Fatalf("allowed_tool_kinds = %#v, want [browser]", bundle.Version.ToolPolicy["allowed_tool_kinds"])
+	}
+}

--- a/backend/internal/engine/executor_builders.go
+++ b/backend/internal/engine/executor_builders.go
@@ -13,18 +13,27 @@ import (
 )
 
 const (
-	submitToolName      = "submit"
-	readFileToolName    = "read_file"
-	writeFileToolName   = "write_file"
-	listFilesToolName   = "list_files"
-	searchFilesToolName = "search_files"
-	searchTextToolName  = "search_text"
-	queryJSONToolName   = "query_json"
-	querySQLToolName    = "query_sql"
-	httpRequestToolName = "http_request"
-	runTestsToolName    = "run_tests"
-	buildToolName       = "build"
-	execToolName        = "exec"
+	submitToolName            = "submit"
+	readFileToolName          = "read_file"
+	writeFileToolName         = "write_file"
+	listFilesToolName         = "list_files"
+	searchFilesToolName       = "search_files"
+	searchTextToolName        = "search_text"
+	queryJSONToolName         = "query_json"
+	querySQLToolName          = "query_sql"
+	httpRequestToolName       = "http_request"
+	browserStartToolName      = "browser_start"
+	browserOpenToolName       = "browser_open"
+	browserInfoToolName       = "browser_info"
+	browserScreenshotToolName = "browser_screenshot"
+	browserClickToolName      = "browser_click"
+	browserTypeToolName       = "browser_type"
+	browserKeyToolName        = "browser_key"
+	browserEvalToolName       = "browser_eval"
+	browserStopToolName       = "browser_stop"
+	runTestsToolName          = "run_tests"
+	buildToolName             = "build"
+	execToolName              = "exec"
 )
 
 func toolMessage(result provider.ToolResult) provider.Message {
@@ -200,6 +209,8 @@ func (e NativeExecutor) executeToolCalls(
 	networkAllowlist []string,
 	toolCallsUsedSoFar int,
 	toolCalls []provider.ToolCall,
+	runAgentID string,
+	workspaceSecrets map[string]string,
 ) ([]provider.Message, string, bool, int, error) {
 	toolMessages := make([]provider.Message, 0, len(toolCalls))
 	toolCallsUsed := 0
@@ -243,6 +254,8 @@ func (e NativeExecutor) executeToolCalls(
 			ToolPolicy:       toolPolicy,
 			NetworkAllowlist: append([]string(nil), networkAllowlist...),
 			Registry:         registry,
+			RunAgentID:       runAgentID,
+			WorkspaceSecrets: cloneStringMap(workspaceSecrets),
 		})
 		if hardErr != nil {
 			return nil, "", false, toolCallsUsed, hardErr

--- a/backend/internal/engine/native_executor.go
+++ b/backend/internal/engine/native_executor.go
@@ -334,7 +334,17 @@ func (e NativeExecutor) Execute(ctx context.Context, executionContext repository
 			return Result{}, NewFailure(StopReasonProviderError, "assistant response did not contain a tool call or submit action", nil)
 		}
 
-		toolMessages, finalOutput, completed, toolCallCount, toolErr := e.executeToolCalls(runCtx, session, registry, sandboxRequest.ToolPolicy, sandboxRequest.NetworkAllowlist, state.toolCallCount, response.ToolCalls)
+		toolMessages, finalOutput, completed, toolCallCount, toolErr := e.executeToolCalls(
+			runCtx,
+			session,
+			registry,
+			sandboxRequest.ToolPolicy,
+			sandboxRequest.NetworkAllowlist,
+			state.toolCallCount,
+			response.ToolCalls,
+			executionContext.RunAgent.ID.String(),
+			workspaceSecrets,
+		)
 		state.toolCallCount += toolCallCount
 		if toolErr != nil {
 			return Result{}, toolErr

--- a/backend/internal/engine/native_executor_test.go
+++ b/backend/internal/engine/native_executor_test.go
@@ -487,6 +487,8 @@ func TestNativeExecutorDoesNotDuplicateCompletedErrorToolMessages(t *testing.T) 
 			ID:   "call-completed-error",
 			Name: "fail_complete",
 		}},
+		"",
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("executeToolCalls returned error: %v", err)

--- a/backend/internal/engine/primitive_browser.go
+++ b/backend/internal/engine/primitive_browser.go
@@ -1,0 +1,379 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/sandbox"
+)
+
+const (
+	browserToolTimeoutDefault = 60 * time.Second
+	browserToolTimeoutMax     = 180 * time.Second
+	browserAPIKeySecretName   = "BROWSER_USE_API_KEY"
+)
+
+func browserPrimitiveTools() map[string]Tool {
+	return map[string]Tool{
+		browserStartToolName: primitiveTool{
+			name:        browserStartToolName,
+			description: "Start an isolated Browser Use cloud browser for this run agent.",
+			parameters:  json.RawMessage(`{"type":"object","properties":{"timeout_minutes":{"type":"integer","minimum":1,"maximum":240},"proxy_country_code":{"type":"string"},"profile_name":{"type":"string"}},"additionalProperties":false}`),
+			execute:     executeBrowserStartTool,
+		},
+		browserOpenToolName: primitiveTool{
+			name:        browserOpenToolName,
+			description: "Open a URL in the run agent's isolated browser session and wait for the page to load.",
+			parameters:  json.RawMessage(`{"type":"object","properties":{"url":{"type":"string"},"timeout_seconds":{"type":"integer","minimum":1,"maximum":60}},"required":["url"],"additionalProperties":false}`),
+			execute:     executeBrowserOpenTool,
+		},
+		browserInfoToolName: primitiveTool{
+			name:        browserInfoToolName,
+			description: "Return the current browser page URL, title, viewport, scroll, and page dimensions.",
+			parameters:  json.RawMessage(`{"type":"object","additionalProperties":false}`),
+			execute:     executeBrowserInfoTool,
+		},
+		browserScreenshotToolName: primitiveTool{
+			name:        browserScreenshotToolName,
+			description: "Capture a browser screenshot to a sandbox file path.",
+			parameters:  json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"},"full_page":{"type":"boolean"}},"additionalProperties":false}`),
+			execute:     executeBrowserScreenshotTool,
+		},
+		browserClickToolName: primitiveTool{
+			name:        browserClickToolName,
+			description: "Click browser viewport coordinates.",
+			parameters:  json.RawMessage(`{"type":"object","properties":{"x":{"type":"number"},"y":{"type":"number"},"button":{"type":"string"},"clicks":{"type":"integer","minimum":1}},"required":["x","y"],"additionalProperties":false}`),
+			execute:     executeBrowserClickTool,
+		},
+		browserTypeToolName: primitiveTool{
+			name:        browserTypeToolName,
+			description: "Type text into the focused browser element.",
+			parameters:  json.RawMessage(`{"type":"object","properties":{"text":{"type":"string"}},"required":["text"],"additionalProperties":false}`),
+			execute:     executeBrowserTypeTool,
+		},
+		browserKeyToolName: primitiveTool{
+			name:        browserKeyToolName,
+			description: "Press a key in the browser, optionally with CDP modifier bits.",
+			parameters:  json.RawMessage(`{"type":"object","properties":{"key":{"type":"string"},"modifiers":{"type":"integer","minimum":0}},"required":["key"],"additionalProperties":false}`),
+			execute:     executeBrowserKeyTool,
+		},
+		browserEvalToolName: primitiveTool{
+			name:        browserEvalToolName,
+			description: "Evaluate JavaScript in the current browser tab and return the JSON-serializable value.",
+			parameters:  json.RawMessage(`{"type":"object","properties":{"expression":{"type":"string"}},"required":["expression"],"additionalProperties":false}`),
+			execute:     executeBrowserEvalTool,
+		},
+		browserStopToolName: primitiveTool{
+			name:        browserStopToolName,
+			description: "Stop the run agent's Browser Use cloud browser session.",
+			parameters:  json.RawMessage(`{"type":"object","additionalProperties":false}`),
+			execute:     executeBrowserStopTool,
+		},
+	}
+}
+
+func executeBrowserStartTool(ctx context.Context, request ToolExecutionRequest) (ToolExecutionResult, error) {
+	var args struct {
+		TimeoutMinutes   int    `json:"timeout_minutes"`
+		ProxyCountryCode string `json:"proxy_country_code"`
+		ProfileName      string `json:"profile_name"`
+	}
+	if err := decodeToolArguments(browserStartToolName, request.Args, &args); err != nil {
+		return ToolExecutionResult{Content: encodeToolErrorMessage(err.Error()), IsError: true}, nil
+	}
+	timeout := args.TimeoutMinutes
+	if timeout <= 0 {
+		timeout = 60
+	}
+	code := fmt.Sprintf(`
+import json, os
+from admin import daemon_alive, start_remote_daemon
+name = os.environ.get("BU_NAME", "default")
+payload = {"ok": True, "name": name, "already_running": daemon_alive(name)}
+if not payload["already_running"]:
+    browser = start_remote_daemon(name, timeout=%d, profileName=%s, proxyCountryCode=%s)
+    payload["browser_id"] = browser.get("id")
+    payload["live_url"] = browser.get("liveUrl")
+print(json.dumps(payload))
+`, timeout, pyLiteral(strings.TrimSpace(args.ProfileName)), pyLiteralOrDefault(strings.TrimSpace(args.ProxyCountryCode), "us"))
+	return executeBrowserPython(ctx, request, browserStartToolName, code, false)
+}
+
+func executeBrowserOpenTool(ctx context.Context, request ToolExecutionRequest) (ToolExecutionResult, error) {
+	var args struct {
+		URL            string `json:"url"`
+		TimeoutSeconds int    `json:"timeout_seconds"`
+	}
+	if err := decodeToolArguments(browserOpenToolName, request.Args, &args); err != nil {
+		return ToolExecutionResult{Content: encodeToolErrorMessage(err.Error()), IsError: true}, nil
+	}
+	if strings.TrimSpace(args.URL) == "" {
+		return ToolExecutionResult{Content: encodeToolErrorMessage("url is required"), IsError: true}, nil
+	}
+	timeout := args.TimeoutSeconds
+	if timeout <= 0 {
+		timeout = 15
+	}
+	code := fmt.Sprintf(`
+import json
+url = %s
+loaded = wait_for_load(0.1)
+new_tab(url)
+loaded = wait_for_load(%d)
+print(json.dumps({"ok": True, "loaded": loaded, "page": page_info()}))
+`, pyLiteral(args.URL), timeout)
+	return executeBrowserHarness(ctx, request, browserOpenToolName, code, true)
+}
+
+func executeBrowserInfoTool(ctx context.Context, request ToolExecutionRequest) (ToolExecutionResult, error) {
+	if err := decodeToolArguments(browserInfoToolName, request.Args, &struct{}{}); err != nil {
+		return ToolExecutionResult{Content: encodeToolErrorMessage(err.Error()), IsError: true}, nil
+	}
+	return executeBrowserHarness(ctx, request, browserInfoToolName, `import json
+print(json.dumps({"ok": True, "page": page_info()}))
+`, true)
+}
+
+func executeBrowserScreenshotTool(ctx context.Context, request ToolExecutionRequest) (ToolExecutionResult, error) {
+	var args struct {
+		Path     string `json:"path"`
+		FullPage bool   `json:"full_page"`
+	}
+	if err := decodeToolArguments(browserScreenshotToolName, request.Args, &args); err != nil {
+		return ToolExecutionResult{Content: encodeToolErrorMessage(err.Error()), IsError: true}, nil
+	}
+	screenshotPath := strings.TrimSpace(args.Path)
+	if screenshotPath == "" {
+		screenshotPath = "/workspace/browser-screenshot.png"
+	}
+	if _, err := validateSandboxPath(screenshotPath); err != nil {
+		return ToolExecutionResult{Content: encodeToolErrorMessage(err.Error()), IsError: true}, nil
+	}
+	code := fmt.Sprintf(`import json
+path = capture_screenshot(%s, full=%t)
+print(json.dumps({"ok": True, "path": path, "page": page_info()}))
+`, pyLiteral(screenshotPath), args.FullPage)
+	return executeBrowserHarness(ctx, request, browserScreenshotToolName, code, true)
+}
+
+func executeBrowserClickTool(ctx context.Context, request ToolExecutionRequest) (ToolExecutionResult, error) {
+	var args struct {
+		X      float64 `json:"x"`
+		Y      float64 `json:"y"`
+		Button string  `json:"button"`
+		Clicks int     `json:"clicks"`
+	}
+	if err := decodeToolArguments(browserClickToolName, request.Args, &args); err != nil {
+		return ToolExecutionResult{Content: encodeToolErrorMessage(err.Error()), IsError: true}, nil
+	}
+	if args.Clicks <= 0 {
+		args.Clicks = 1
+	}
+	if strings.TrimSpace(args.Button) == "" {
+		args.Button = "left"
+	}
+	code := fmt.Sprintf(`import json, time
+click_at_xy(%f, %f, button=%s, clicks=%d)
+time.sleep(0.25)
+print(json.dumps({"ok": True, "page": page_info()}))
+`, args.X, args.Y, pyLiteral(args.Button), args.Clicks)
+	return executeBrowserHarness(ctx, request, browserClickToolName, code, true)
+}
+
+func executeBrowserTypeTool(ctx context.Context, request ToolExecutionRequest) (ToolExecutionResult, error) {
+	var args struct {
+		Text string `json:"text"`
+	}
+	if err := decodeToolArguments(browserTypeToolName, request.Args, &args); err != nil {
+		return ToolExecutionResult{Content: encodeToolErrorMessage(err.Error()), IsError: true}, nil
+	}
+	code := fmt.Sprintf(`import json
+type_text(%s)
+print(json.dumps({"ok": True, "page": page_info()}))
+`, pyLiteral(args.Text))
+	return executeBrowserHarness(ctx, request, browserTypeToolName, code, true)
+}
+
+func executeBrowserKeyTool(ctx context.Context, request ToolExecutionRequest) (ToolExecutionResult, error) {
+	var args struct {
+		Key       string `json:"key"`
+		Modifiers int    `json:"modifiers"`
+	}
+	if err := decodeToolArguments(browserKeyToolName, request.Args, &args); err != nil {
+		return ToolExecutionResult{Content: encodeToolErrorMessage(err.Error()), IsError: true}, nil
+	}
+	if strings.TrimSpace(args.Key) == "" {
+		return ToolExecutionResult{Content: encodeToolErrorMessage("key is required"), IsError: true}, nil
+	}
+	code := fmt.Sprintf(`import json
+press_key(%s, modifiers=%d)
+print(json.dumps({"ok": True, "page": page_info()}))
+`, pyLiteral(args.Key), args.Modifiers)
+	return executeBrowserHarness(ctx, request, browserKeyToolName, code, true)
+}
+
+func executeBrowserEvalTool(ctx context.Context, request ToolExecutionRequest) (ToolExecutionResult, error) {
+	var args struct {
+		Expression string `json:"expression"`
+	}
+	if err := decodeToolArguments(browserEvalToolName, request.Args, &args); err != nil {
+		return ToolExecutionResult{Content: encodeToolErrorMessage(err.Error()), IsError: true}, nil
+	}
+	if strings.TrimSpace(args.Expression) == "" {
+		return ToolExecutionResult{Content: encodeToolErrorMessage("expression is required"), IsError: true}, nil
+	}
+	code := fmt.Sprintf(`import json
+value = js(%s)
+print(json.dumps({"ok": True, "value": value, "page": page_info()}))
+`, pyLiteral(args.Expression))
+	return executeBrowserHarness(ctx, request, browserEvalToolName, code, true)
+}
+
+func executeBrowserStopTool(ctx context.Context, request ToolExecutionRequest) (ToolExecutionResult, error) {
+	if err := decodeToolArguments(browserStopToolName, request.Args, &struct{}{}); err != nil {
+		return ToolExecutionResult{Content: encodeToolErrorMessage(err.Error()), IsError: true}, nil
+	}
+	code := `import json, os
+from admin import stop_remote_daemon
+name = os.environ.get("BU_NAME", "default")
+stop_remote_daemon(name)
+print(json.dumps({"ok": True, "stopped": True, "name": name}))
+`
+	return executeBrowserPython(ctx, request, browserStopToolName, code, false)
+}
+
+func executeBrowserHarness(ctx context.Context, request ToolExecutionRequest, toolName string, code string, ensureRemote bool) (ToolExecutionResult, error) {
+	return executeBrowserPython(ctx, request, toolName, browserShellScript(code, ensureRemote), true)
+}
+
+func executeBrowserPython(ctx context.Context, request ToolExecutionRequest, toolName string, code string, isShell bool) (ToolExecutionResult, error) {
+	if !allowsBrowserTools(request.ToolPolicy) {
+		return policyDeniedToolResult("browser tools are not allowed in this runtime"), nil
+	}
+	command := []string{"python3", "-c", code}
+	if isShell {
+		command = []string{"sh", "-lc", code}
+	}
+	result, err := request.Session.Exec(ctx, sandbox.ExecRequest{
+		Command:          command,
+		WorkingDirectory: defaultSandboxWorkingDirectory,
+		Environment:      browserEnvironment(request),
+		Timeout:          browserToolTimeoutDefault,
+	})
+	if err != nil {
+		return ToolExecutionResult{}, NewFailure(StopReasonSandboxError, "execute browser harness", err)
+	}
+	if result.ExitCode != 0 {
+		message := strings.TrimSpace(scrubStderrSecrets(result.Stderr))
+		if message == "" {
+			message = fmt.Sprintf("browser harness exited with code %d", result.ExitCode)
+		}
+		return ToolExecutionResult{Content: encodeToolErrorMessage(message), IsError: true}, nil
+	}
+	payload, ok := lastJSONObject(result.Stdout)
+	if !ok {
+		payload = map[string]any{
+			"ok":     true,
+			"stdout": strings.TrimSpace(result.Stdout),
+		}
+	}
+	if okValue, _ := payload["ok"].(bool); !okValue {
+		content, err := toolJSONOutput(ctx, request, toolName, payload)
+		if err != nil {
+			return ToolExecutionResult{}, err
+		}
+		return ToolExecutionResult{Content: content, IsError: true}, nil
+	}
+	content, err := toolJSONOutput(ctx, request, toolName, payload)
+	if err != nil {
+		return ToolExecutionResult{}, err
+	}
+	return ToolExecutionResult{Content: content}, nil
+}
+
+func browserShellScript(code string, ensureRemote bool) string {
+	var builder strings.Builder
+	if ensureRemote {
+		builder.WriteString(`python3 <<'PY'
+import os
+from admin import daemon_alive, start_remote_daemon
+name = os.environ.get("BU_NAME", "default")
+if not daemon_alive(name):
+    start_remote_daemon(name, timeout=60)
+PY
+`)
+	}
+	builder.WriteString("browser-harness <<'PY'\n")
+	builder.WriteString(code)
+	if !strings.HasSuffix(code, "\n") {
+		builder.WriteString("\n")
+	}
+	builder.WriteString("PY\n")
+	return builder.String()
+}
+
+func browserEnvironment(request ToolExecutionRequest) map[string]string {
+	env := map[string]string{
+		"BU_NAME": browserSessionName(request),
+	}
+	if key := strings.TrimSpace(request.WorkspaceSecrets[browserAPIKeySecretName]); key != "" {
+		env[browserAPIKeySecretName] = key
+	}
+	return env
+}
+
+func browserSessionName(request ToolExecutionRequest) string {
+	name := strings.TrimSpace(request.RunAgentID)
+	if name == "" && request.Session != nil {
+		name = request.Session.ID()
+	}
+	if name == "" {
+		name = "default"
+	}
+	var builder strings.Builder
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			builder.WriteRune(r)
+		} else {
+			builder.WriteRune('-')
+		}
+	}
+	cleaned := strings.Trim(builder.String(), "-_")
+	if cleaned == "" {
+		return "default"
+	}
+	return cleaned
+}
+
+func pyLiteral(value string) string {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return `""`
+	}
+	return string(encoded)
+}
+
+func pyLiteralOrDefault(value string, fallback string) string {
+	if value == "" {
+		value = fallback
+	}
+	return pyLiteral(value)
+}
+
+func lastJSONObject(stdout string) (map[string]any, bool) {
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" || !strings.HasPrefix(line, "{") {
+			continue
+		}
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(line), &payload); err == nil {
+			return payload, true
+		}
+	}
+	return nil, false
+}

--- a/backend/internal/engine/primitive_browser.go
+++ b/backend/internal/engine/primitive_browser.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/sandbox"
+	"github.com/google/uuid"
 )
 
 const (
@@ -98,7 +99,7 @@ if not payload["already_running"]:
     payload["browser_id"] = browser.get("id")
     payload["live_url"] = browser.get("liveUrl")
 print(json.dumps(payload))
-`, timeout, pyLiteral(strings.TrimSpace(args.ProfileName)), pyLiteralOrDefault(strings.TrimSpace(args.ProxyCountryCode), "us"))
+`, timeout, pyOptionalString(strings.TrimSpace(args.ProfileName)), pyLiteralOrDefault(strings.TrimSpace(args.ProxyCountryCode), "us"))
 	return executeBrowserPython(ctx, request, browserStartToolName, code, false)
 }
 
@@ -147,7 +148,7 @@ func executeBrowserScreenshotTool(ctx context.Context, request ToolExecutionRequ
 	}
 	screenshotPath := strings.TrimSpace(args.Path)
 	if screenshotPath == "" {
-		screenshotPath = "/workspace/browser-screenshot.png"
+		screenshotPath = fmt.Sprintf("/workspace/browser-screenshot-%s.png", uuid.NewString())
 	}
 	if _, err := validateSandboxPath(screenshotPath); err != nil {
 		return ToolExecutionResult{Content: encodeToolErrorMessage(err.Error()), IsError: true}, nil
@@ -267,7 +268,7 @@ func executeBrowserPython(ctx context.Context, request ToolExecutionRequest, too
 		return ToolExecutionResult{}, NewFailure(StopReasonSandboxError, "execute browser harness", err)
 	}
 	if result.ExitCode != 0 {
-		message := strings.TrimSpace(scrubStderrSecrets(result.Stderr))
+		message := strings.TrimSpace(scrubStderrSecretsWithValues(result.Stderr, request.WorkspaceSecrets[browserAPIKeySecretName]))
 		if message == "" {
 			message = fmt.Sprintf("browser harness exited with code %d", result.ExitCode)
 		}
@@ -359,6 +360,13 @@ func pyLiteral(value string) string {
 func pyLiteralOrDefault(value string, fallback string) string {
 	if value == "" {
 		value = fallback
+	}
+	return pyLiteral(value)
+}
+
+func pyOptionalString(value string) string {
+	if value == "" {
+		return "None"
 	}
 	return pyLiteral(value)
 }

--- a/backend/internal/engine/primitive_browser_test.go
+++ b/backend/internal/engine/primitive_browser_test.go
@@ -1,0 +1,118 @@
+package engine
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/sandbox"
+)
+
+func TestBrowserTools_VisibleOnlyWhenBrowserKindAllowed(t *testing.T) {
+	withoutBrowser, err := buildToolRegistry(sandbox.ToolPolicy{AllowedToolKinds: []string{toolKindFile}}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("buildToolRegistry without browser returned error: %v", err)
+	}
+	if _, ok := withoutBrowser.Resolve(browserOpenToolName); ok {
+		t.Fatalf("browser_open should not be visible without browser tool kind")
+	}
+
+	withBrowser, err := buildToolRegistry(sandbox.ToolPolicy{AllowedToolKinds: []string{toolKindBrowser}}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("buildToolRegistry with browser returned error: %v", err)
+	}
+	for _, name := range []string{browserStartToolName, browserOpenToolName, browserInfoToolName, browserScreenshotToolName, browserClickToolName, browserTypeToolName, browserKeyToolName, browserEvalToolName, browserStopToolName} {
+		if _, ok := withBrowser.Resolve(name); !ok {
+			t.Fatalf("%s should be visible with browser tool kind", name)
+		}
+	}
+}
+
+func TestBrowserOpenTool_ExecutesHarnessWithRunAgentNamespace(t *testing.T) {
+	session := sandbox.NewFakeSession("sandbox-id")
+	session.SetExecFunc(func(request sandbox.ExecRequest, _ map[string][]byte) (sandbox.ExecResult, error) {
+		if request.Command[0] != "sh" {
+			t.Fatalf("expected shell command, got %#v", request.Command)
+		}
+		if got := request.Environment["BU_NAME"]; got != "run-agent-123" {
+			t.Fatalf("BU_NAME = %q, want run-agent-123", got)
+		}
+		if got := request.Environment[browserAPIKeySecretName]; got != "secret-key" {
+			t.Fatalf("BROWSER_USE_API_KEY = %q, want secret-key", got)
+		}
+		if !strings.Contains(request.Command[2], "start_remote_daemon(name") {
+			t.Fatalf("browser_open should ensure remote daemon before harness, command=%s", request.Command[2])
+		}
+		if !strings.Contains(request.Command[2], "new_tab(url)") {
+			t.Fatalf("browser_open should navigate via browser-harness helpers, command=%s", request.Command[2])
+		}
+		return sandbox.ExecResult{
+			ExitCode: 0,
+			Stdout:   "https://live.browser-use.example\n{\"ok\":true,\"loaded\":true,\"page\":{\"url\":\"https://example.com\",\"title\":\"Example\"}}\n",
+		}, nil
+	})
+
+	result, err := executeBrowserOpenTool(t.Context(), ToolExecutionRequest{
+		Args:             json.RawMessage(`{"url":"https://example.com"}`),
+		Session:          session,
+		ToolPolicy:       sandbox.ToolPolicy{AllowedToolKinds: []string{toolKindBrowser}},
+		RunAgentID:       "run-agent-123",
+		WorkspaceSecrets: map[string]string{browserAPIKeySecretName: "secret-key"},
+	})
+	if err != nil {
+		t.Fatalf("executeBrowserOpenTool returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got %#v", result)
+	}
+	if !strings.Contains(result.Content, `"url":"https://example.com"`) {
+		t.Fatalf("expected page URL in structured content, got %s", result.Content)
+	}
+}
+
+func TestBrowserOpenTool_DeniedWithoutBrowserKind(t *testing.T) {
+	session := sandbox.NewFakeSession("browser-denied")
+	session.SetExecFunc(func(sandbox.ExecRequest, map[string][]byte) (sandbox.ExecResult, error) {
+		t.Fatal("browser tool should not execute when policy denies browser kind")
+		return sandbox.ExecResult{}, nil
+	})
+
+	result, err := executeBrowserOpenTool(t.Context(), ToolExecutionRequest{
+		Args:       json.RawMessage(`{"url":"https://example.com"}`),
+		Session:    session,
+		ToolPolicy: sandbox.ToolPolicy{AllowedToolKinds: []string{toolKindFile}},
+	})
+	if err != nil {
+		t.Fatalf("executeBrowserOpenTool returned error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected policy denial, got %#v", result)
+	}
+	if !strings.Contains(result.Content, "browser tools are not allowed") {
+		t.Fatalf("denial content = %s", result.Content)
+	}
+}
+
+func TestBrowserEvalTool_ReturnsStructuredResult(t *testing.T) {
+	session := sandbox.NewFakeSession("browser-eval")
+	session.SetExecResult(sandbox.ExecResult{
+		ExitCode: 0,
+		Stdout:   "{\"ok\":true,\"value\":\"AgentClash\",\"page\":{\"url\":\"https://example.com\"}}\n",
+	})
+
+	result, err := executeBrowserEvalTool(t.Context(), ToolExecutionRequest{
+		Args:       json.RawMessage(`{"expression":"document.title"}`),
+		Session:    session,
+		ToolPolicy: sandbox.ToolPolicy{AllowedToolKinds: []string{toolKindBrowser}},
+		RunAgentID: "run-agent-123",
+	})
+	if err != nil {
+		t.Fatalf("executeBrowserEvalTool returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got %#v", result)
+	}
+	if !strings.Contains(result.Content, `"value":"AgentClash"`) {
+		t.Fatalf("expected eval value in result, got %s", result.Content)
+	}
+}

--- a/backend/internal/engine/primitive_browser_test.go
+++ b/backend/internal/engine/primitive_browser_test.go
@@ -70,6 +70,59 @@ func TestBrowserOpenTool_ExecutesHarnessWithRunAgentNamespace(t *testing.T) {
 	}
 }
 
+func TestBrowserStartTool_OmitsProfileNameAsPythonNone(t *testing.T) {
+	session := sandbox.NewFakeSession("browser-start")
+	session.SetExecResult(sandbox.ExecResult{ExitCode: 0, Stdout: `{"ok":true}`})
+
+	result, err := executeBrowserStartTool(t.Context(), ToolExecutionRequest{
+		Args:       json.RawMessage(`{}`),
+		Session:    session,
+		ToolPolicy: sandbox.ToolPolicy{AllowedToolKinds: []string{toolKindBrowser}},
+		RunAgentID: "run-agent-123",
+	})
+	if err != nil {
+		t.Fatalf("executeBrowserStartTool returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got %#v", result)
+	}
+	calls := session.ExecCalls()
+	if len(calls) != 1 {
+		t.Fatalf("exec call count = %d, want 1", len(calls))
+	}
+	if !strings.Contains(calls[0].Command[2], "profileName=None") {
+		t.Fatalf("expected omitted profile_name to be Python None, command=%s", calls[0].Command[2])
+	}
+}
+
+func TestBrowserScreenshotTool_DefaultPathIsUnique(t *testing.T) {
+	session := sandbox.NewFakeSession("browser-screenshot")
+	session.SetExecResult(sandbox.ExecResult{ExitCode: 0, Stdout: `{"ok":true}`})
+	request := ToolExecutionRequest{
+		Args:       json.RawMessage(`{}`),
+		Session:    session,
+		ToolPolicy: sandbox.ToolPolicy{AllowedToolKinds: []string{toolKindBrowser}},
+		RunAgentID: "run-agent-123",
+	}
+
+	if _, err := executeBrowserScreenshotTool(t.Context(), request); err != nil {
+		t.Fatalf("first executeBrowserScreenshotTool returned error: %v", err)
+	}
+	if _, err := executeBrowserScreenshotTool(t.Context(), request); err != nil {
+		t.Fatalf("second executeBrowserScreenshotTool returned error: %v", err)
+	}
+	calls := session.ExecCalls()
+	if len(calls) != 2 {
+		t.Fatalf("exec call count = %d, want 2", len(calls))
+	}
+	if calls[0].Command[2] == calls[1].Command[2] {
+		t.Fatalf("default screenshot commands reused the same path: %s", calls[0].Command[2])
+	}
+	if !strings.Contains(calls[0].Command[2], "/workspace/browser-screenshot-") || !strings.Contains(calls[1].Command[2], "/workspace/browser-screenshot-") {
+		t.Fatalf("default screenshot commands should use unique browser-screenshot paths: %#v", calls)
+	}
+}
+
 func TestBrowserOpenTool_DeniedWithoutBrowserKind(t *testing.T) {
 	session := sandbox.NewFakeSession("browser-denied")
 	session.SetExecFunc(func(sandbox.ExecRequest, map[string][]byte) (sandbox.ExecResult, error) {
@@ -90,6 +143,33 @@ func TestBrowserOpenTool_DeniedWithoutBrowserKind(t *testing.T) {
 	}
 	if !strings.Contains(result.Content, "browser tools are not allowed") {
 		t.Fatalf("denial content = %s", result.Content)
+	}
+}
+
+func TestBrowserTool_ScrubsRawBrowserAPIKeyFromStderr(t *testing.T) {
+	session := sandbox.NewFakeSession("browser-secret-stderr")
+	session.SetExecResult(sandbox.ExecResult{
+		ExitCode: 1,
+		Stderr:   "Traceback: request failed for key bu_secret_value",
+	})
+
+	result, err := executeBrowserInfoTool(t.Context(), ToolExecutionRequest{
+		Session:          session,
+		ToolPolicy:       sandbox.ToolPolicy{AllowedToolKinds: []string{toolKindBrowser}},
+		RunAgentID:       "run-agent-123",
+		WorkspaceSecrets: map[string]string{browserAPIKeySecretName: "bu_secret_value"},
+	})
+	if err != nil {
+		t.Fatalf("executeBrowserInfoTool returned error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected tool error")
+	}
+	if strings.Contains(result.Content, "bu_secret_value") {
+		t.Fatalf("raw browser API key leaked in content: %s", result.Content)
+	}
+	if !strings.Contains(result.Content, redactedHeaderMarker) {
+		t.Fatalf("expected redaction marker in content: %s", result.Content)
 	}
 }
 

--- a/backend/internal/engine/primitive_secrets.go
+++ b/backend/internal/engine/primitive_secrets.go
@@ -130,22 +130,22 @@ var sensitiveResponseHeaders = map[string]struct{}{
 	"cookie":     {},
 	"set-cookie": {},
 	// Common vendor / custom auth headers.
-	"x-api-key":            {},
-	"x-apikey":             {},
-	"api-key":              {},
-	"apikey":               {},
-	"x-auth-token":         {},
-	"x-access-token":       {},
-	"x-access-key":         {},
-	"x-secret-key":         {},
-	"x-session-token":      {},
-	"x-session-id":         {},
-	"x-csrf-token":         {},
-	"x-xsrf-token":         {},
+	"x-api-key":       {},
+	"x-apikey":        {},
+	"api-key":         {},
+	"apikey":          {},
+	"x-auth-token":    {},
+	"x-access-token":  {},
+	"x-access-key":    {},
+	"x-secret-key":    {},
+	"x-session-token": {},
+	"x-session-id":    {},
+	"x-csrf-token":    {},
+	"x-xsrf-token":    {},
 	// AWS SigV4 / STS.
 	"x-amz-security-token": {},
 	// Google Cloud user credential headers.
-	"x-goog-api-key":         {},
+	"x-goog-api-key":                 {},
 	"x-goog-iam-authorization-token": {},
 	// Bare token-style names some APIs use.
 	"token": {},
@@ -210,6 +210,18 @@ func scrubStderrSecrets(stderr string) string {
 	scrubbed := stderr
 	for _, pattern := range stderrSecretPatterns {
 		scrubbed = pattern.ReplaceAllString(scrubbed, redactedHeaderMarker)
+	}
+	return scrubbed
+}
+
+func scrubStderrSecretsWithValues(stderr string, values ...string) string {
+	scrubbed := scrubStderrSecrets(stderr)
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		scrubbed = strings.ReplaceAll(scrubbed, value, redactedHeaderMarker)
 	}
 	return scrubbed
 }

--- a/backend/internal/engine/primitive_tools.go
+++ b/backend/internal/engine/primitive_tools.go
@@ -81,6 +81,12 @@ func nativePrimitiveTools(toolPolicy sandbox.ToolPolicy) map[string]Tool {
 		}
 	}
 
+	if allowsBrowserTools(toolPolicy) {
+		for name, tool := range browserPrimitiveTools() {
+			tools[name] = tool
+		}
+	}
+
 	if allowsBuildTools(toolPolicy) {
 		tools[runTestsToolName] = primitiveTool{
 			name:        runTestsToolName,

--- a/backend/internal/engine/tool_registry.go
+++ b/backend/internal/engine/tool_registry.go
@@ -497,6 +497,8 @@ func (t *composedTool) Execute(ctx context.Context, request ToolExecutionRequest
 		NetworkAllowlist: append([]string(nil), request.NetworkAllowlist...),
 		Registry:         request.Registry,
 		DelegationChain:  chain,
+		RunAgentID:       request.RunAgentID,
+		WorkspaceSecrets: cloneStringMap(request.WorkspaceSecrets),
 	})
 	if execErr != nil {
 		return ToolExecutionResult{}, execErr

--- a/backend/internal/engine/tool_registry.go
+++ b/backend/internal/engine/tool_registry.go
@@ -46,6 +46,8 @@ type ToolExecutionRequest struct {
 	NetworkAllowlist []string
 	Registry         *Registry
 	DelegationChain  []string
+	RunAgentID       string
+	WorkspaceSecrets map[string]string
 }
 
 type ToolExecutionResult struct {

--- a/backend/internal/engine/tool_registry_test.go
+++ b/backend/internal/engine/tool_registry_test.go
@@ -138,6 +138,8 @@ func TestRegistryResolve_ReturnsStructuredUnknownToolErrorPath(t *testing.T) {
 			ID:   "call-unknown",
 			Name: "does_not_exist",
 		}},
+		"",
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("executeToolCalls returned error: %v", err)

--- a/backend/internal/engine/tool_registry_test.go
+++ b/backend/internal/engine/tool_registry_test.go
@@ -671,6 +671,70 @@ func (p passthroughPrimitive) Execute(_ context.Context, req ToolExecutionReques
 	return ToolExecutionResult{Content: string(req.Args)}, nil
 }
 
+type capturingPrimitive struct {
+	name string
+	seen *ToolExecutionRequest
+}
+
+func (p capturingPrimitive) Name() string {
+	return p.name
+}
+
+func (p capturingPrimitive) Description() string {
+	return "capture"
+}
+
+func (p capturingPrimitive) Parameters() json.RawMessage {
+	return json.RawMessage(`{"type":"object"}`)
+}
+
+func (p capturingPrimitive) Category() ToolCategory {
+	return ToolCategoryPrimitive
+}
+
+func (p capturingPrimitive) Execute(_ context.Context, req ToolExecutionRequest) (ToolExecutionResult, error) {
+	copied := req
+	copied.NetworkAllowlist = append([]string(nil), req.NetworkAllowlist...)
+	copied.DelegationChain = append([]string(nil), req.DelegationChain...)
+	copied.WorkspaceSecrets = cloneStringMap(req.WorkspaceSecrets)
+	*p.seen = copied
+	return ToolExecutionResult{Content: `{"ok":true}`}, nil
+}
+
+func TestComposedTool_ForwardsRunAgentAndWorkspaceSecrets(t *testing.T) {
+	tool, _, err := newManifestCustomTool(manifestCustomToolConfig{
+		Name:           "browser_wrapper",
+		Description:    "browser wrapper",
+		Parameters:     json.RawMessage(`{"type":"object"}`),
+		Implementation: json.RawMessage(`{"primitive":"capture","args":{}}`),
+	}, nil)
+	if err != nil {
+		t.Fatalf("create composed tool: %v", err)
+	}
+
+	var seen ToolExecutionRequest
+	registry := &Registry{
+		primitives: map[string]Tool{"capture": capturingPrimitive{name: "capture", seen: &seen}},
+	}
+	result, execErr := tool.Execute(t.Context(), ToolExecutionRequest{
+		Registry:         registry,
+		RunAgentID:       "run-agent-123",
+		WorkspaceSecrets: map[string]string{browserAPIKeySecretName: "secret-key"},
+	})
+	if execErr != nil {
+		t.Fatalf("Execute returned error: %v", execErr)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.Content)
+	}
+	if seen.RunAgentID != "run-agent-123" {
+		t.Fatalf("RunAgentID = %q, want run-agent-123", seen.RunAgentID)
+	}
+	if seen.WorkspaceSecrets[browserAPIKeySecretName] != "secret-key" {
+		t.Fatalf("workspace secret was not forwarded")
+	}
+}
+
 func TestComposedTool_ChainsComposedToComposed(t *testing.T) {
 	inner, _, err := newManifestCustomTool(manifestCustomToolConfig{
 		Name:           "inner",

--- a/examples/challenge-packs/browser-navigation-smoke.yaml
+++ b/examples/challenge-packs/browser-navigation-smoke.yaml
@@ -1,0 +1,88 @@
+pack:
+  slug: browser-navigation-smoke
+  name: Browser Navigation Smoke
+  family: browser
+  description: Minimal browser-use benchmark for navigating a live page and extracting visible page state.
+
+version:
+  number: 1
+  execution_mode: native
+  sandbox:
+    network_access: true
+  tool_policy:
+    allowed_tool_kinds:
+      - browser
+  evaluation_spec:
+    name: browser-navigation-smoke-v1
+    version_number: 1
+    judge_mode: deterministic
+    validators:
+      - key: final_output_shape
+        type: json_schema
+        target: final_output
+        expected_from: "literal:{\"type\":\"object\",\"required\":[\"url\",\"title\",\"observations\"],\"properties\":{\"url\":{\"type\":\"string\",\"pattern\":\"^https://example\\\\.com/?$\"},\"title\":{\"type\":\"string\",\"minLength\":1},\"observations\":{\"type\":\"array\",\"minItems\":2,\"items\":{\"type\":\"string\",\"minLength\":3}}}}"
+      - key: mentions_example_domain
+        type: contains
+        target: final_output
+        expected_from: literal:Example Domain
+      - key: completed
+        type: json_path_match
+        target: final_output
+        expected_from: "literal:{\"path\":\"$.completed\",\"comparator\":\"equals\",\"value\":true}"
+    metrics:
+      - key: run_completed
+        type: boolean
+        collector: run_completed_successfully
+      - key: latency_ms
+        type: numeric
+        collector: run_total_latency_ms
+        unit: ms
+      - key: browser_tool_calls
+        type: numeric
+        collector: run_tool_call_count
+    scorecard:
+      dimensions:
+        - key: correctness
+          source: validators
+          gate: true
+          pass_threshold: 1
+        - key: latency
+          source: latency
+          better_direction: lower
+          normalization:
+            target: 30000
+            max: 120000
+
+challenges:
+  - key: inspect-example-domain
+    title: Inspect Example Domain
+    category: browser
+    difficulty: easy
+    instructions: |
+      Use the browser tools to open https://example.com/ and inspect the page.
+      Submit a JSON object with this shape:
+
+      {
+        "url": "https://example.com/",
+        "title": "<page title>",
+        "observations": ["<visible fact 1>", "<visible fact 2>"],
+        "completed": true
+      }
+
+      The observations must be based on the rendered browser page, not a direct
+      HTTP request.
+
+input_sets:
+  - key: default
+    name: Default
+    cases:
+      - challenge_key: inspect-example-domain
+        case_key: example-com
+        inputs:
+          - key: target_url
+            kind: text
+            value: https://example.com/
+        expectations:
+          - key: title
+            kind: text
+            value: Example Domain

--- a/testing/codex-browser-primitives-pack.md
+++ b/testing/codex-browser-primitives-pack.md
@@ -1,0 +1,36 @@
+# codex/browser-primitives-pack — Test Contract
+
+## Functional Behavior
+- Native agents see browser tools only when `tool_policy.allowed_tool_kinds` allows `browser`.
+- Browser tools execute Browser Use browser-harness commands inside the sandbox with `BU_NAME` set to the run-agent ID.
+- Browser tools inject `BROWSER_USE_API_KEY` from workspace secrets when available without requiring literal sandbox env vars.
+- Browser tool results are structured JSON with useful fields for navigation state, screenshots, action success, and errors.
+- Browser tools return policy-denied tool results when browser access is not allowed.
+- A starter browser challenge pack demonstrates how to score a simple browser navigation task.
+
+## Unit Tests
+- `TestBrowserTools_VisibleOnlyWhenBrowserKindAllowed` — registry exposes browser tools only for browser-enabled policies.
+- `TestBrowserOpenTool_ExecutesHarnessWithRunAgentNamespace` — command environment includes `BU_NAME` and browser secret.
+- `TestBrowserOpenTool_DeniedWithoutBrowserKind` — policy denial returns a tool error instead of executing.
+- `TestBrowserEvalTool_ReturnsStructuredResult` — successful harness stdout is wrapped as structured JSON.
+
+## Integration / Functional Tests
+- `go test ./internal/engine -run Browser -count=1` from `backend/` passes.
+- `go test ./internal/challengepack -run Browser -count=1` from `backend/` passes.
+
+## Smoke Tests
+- Parse the starter browser challenge pack with the challenge-pack parser.
+
+## E2E Tests
+- N/A — this PR adds primitives and a sample pack. Live Browser Use cloud execution requires `BROWSER_USE_API_KEY` and should be smoke-tested manually in staging.
+
+## Manual / cURL Tests
+```bash
+export AGENTCLASH_API_URL="https://staging-api.agentclash.dev"
+export BROWSER_USE_API_KEY="..."
+cd cli
+go run . challenge-pack publish ../examples/challenge-packs/browser-navigation-smoke.yaml
+go run . run create --follow
+```
+
+Expected: a browser-enabled run can call browser tools and submit a scored final answer.


### PR DESCRIPTION
## Summary
- add browser primitives for Browser Use browser-harness: start, open, info, screenshot, click, type, key, eval, and stop
- pass run-agent ID and workspace secrets into tool execution so browser sessions use isolated `BU_NAME`s and `BROWSER_USE_API_KEY`
- add focused tests for registry gating, policy denial, secret/env injection, and structured results
- add a starter browser navigation smoke challenge pack

## Issue
Closes #395

## Stacked On
- #396

## Validation
- `go test ./internal/engine -run Browser -count=1`
- `go test ./internal/challengepack -run Browser -count=1`
- `go test ./internal/engine ./internal/challengepack`

## Notes
Live cloud-browser execution still needs a staging workspace with `BROWSER_USE_API_KEY` stored as a workspace secret.
