### PR TITLE
feat(cli): default released binaries to https://api.agentclash.dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,8 @@ go run . run create --follow
 Resolution order for the API base URL is:
 
 ```text
---api-url > AGENTCLASH_API_URL > saved user config > http://localhost:8080
+--api-url > AGENTCLASH_API_URL > saved user config > default
+  (source builds: http://localhost:8080; released binaries: https://api.agentclash.dev)
 ```
 
 Useful automation / CI env vars:

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ go run . run create --help
 go run . run create --follow
 ```
 
-Use `https://api.agentclash.dev` only when you intentionally want production. Resolution order is `--api-url` > `AGENTCLASH_API_URL` > saved user config > `http://localhost:8080`.
+Resolution order is `--api-url` > `AGENTCLASH_API_URL` > saved user config > default. Source builds (`go run .`, `make build`) default to `http://localhost:8080`; released binaries default to `https://api.agentclash.dev`. Set `AGENTCLASH_API_URL=https://staging-api.agentclash.dev` for staging.
 
 ### Quick start
 

--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -20,6 +20,7 @@ builds:
       - -X main.version={{.Version}}
       - -X main.commit={{.ShortCommit}}
       - -X main.date={{.Date}}
+      - -X github.com/agentclash/agentclash/cli/internal/config.defaultAPIURL=https://api.agentclash.dev
 
 archives:
   - id: archive

--- a/cli/internal/config/manager.go
+++ b/cli/internal/config/manager.go
@@ -5,10 +5,15 @@ import (
 	"os"
 )
 
-const (
-	defaultAPIURL = "http://localhost:8080"
-	defaultOutput = "table"
-)
+const defaultOutput = "table"
+
+// defaultAPIURL is the fallback API base URL when no --api-url flag,
+// AGENTCLASH_API_URL env var, or saved user config is set. Stamped to
+// https://api.agentclash.dev at release build time via
+// -X github.com/agentclash/agentclash/cli/internal/config.defaultAPIURL=...
+// in cli/.goreleaser.yaml. Source builds keep the localhost default so
+// `go run .` / `make build` talk to a local `make api-server`.
+var defaultAPIURL = "http://localhost:8080"
 
 // ValidOutputFormats lists the user-selectable values for --output / $AGENTCLASH_OUTPUT.
 var ValidOutputFormats = []string{"table", "json", "yaml"}

--- a/cli/internal/config/manager_test.go
+++ b/cli/internal/config/manager_test.go
@@ -111,6 +111,15 @@ func TestManagerDefaultValues(t *testing.T) {
 	}
 }
 
+func TestManagerDefaultSourceValue(t *testing.T) {
+	// Source builds (no -ldflags stamping) must default to localhost so
+	// `go run .` / `make build` talk to a local api server. Release builds
+	// override this via the ldflag in cli/.goreleaser.yaml.
+	if defaultAPIURL != "http://localhost:8080" {
+		t.Fatalf("source defaultAPIURL = %q, want %q (released builds override this via ldflags)", defaultAPIURL, "http://localhost:8080")
+	}
+}
+
 func TestManagerJSONFlagOverridesOutputFormat(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)


### PR DESCRIPTION
## Summary

- Released `agentclash` binaries now default to `https://api.agentclash.dev` via a GoReleaser ldflag, fixing the cold-start UX where a fresh install hit `connection refused` against localhost the moment a new user ran `agentclash auth login`.
- Source builds (`go run .`, `make build`) keep the localhost default so contributors running `make api-server` alongside don't need to export `AGENTCLASH_API_URL` on every shell.
- Resolution order is unchanged (`--api-url` > `AGENTCLASH_API_URL` > saved user config > default); a new `TestManagerDefaultSourceValue` anchors the dev default.

## Mechanism

`cli/internal/config/manager.go` promotes `defaultAPIURL` from `const` to `var` so Go's linker can stamp it. `cli/.goreleaser.yaml` adds `-X github.com/agentclash/agentclash/cli/internal/config.defaultAPIURL=https://api.agentclash.dev` to the builds' ldflags. GoReleaser's output flows unchanged into the Homebrew cask, npm platform packages (via `scripts/publish-npm/assemble.mjs`, which copies binaries verbatim), and GitHub release tarballs — no other pipeline step re-links.

## Test plan

- [x] `cd cli && go vet ./...`
- [x] `cd cli && go test -short -race -count=1 ./...` — all packages pass, including new `TestManagerDefaultSourceValue`
- [x] `cd cli && go build ./...`
- [x] Stamped build check: `go build -ldflags "-X .../config.defaultAPIURL=https://api.agentclash.dev" .` → `strings` shows `https://api.agentclash.dev` embedded
- [x] Unstamped build check: plain `go build .` → `strings` shows `http://localhost:8080` only, no `api.agentclash.dev`
- [ ] Post-merge: after Release Please cuts a tag and `.github/workflows/release-cli.yml` publishes, spot-check `agentclash workspace list` on a fresh install with no env/flag/config — expect a 401 against `api.agentclash.dev`, not connection refused to localhost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)