### PR TITLE
feat: race-context — live peer-standings injection (Phase 2 UI)

### DIFF
--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/hero.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/hero.tsx
@@ -99,6 +99,19 @@ export function Hero({
               value={scorecard.evaluation_spec_id.slice(0, 8)}
               mono
             />
+            {doc?.metric_summary?.run_total_tokens != null && (
+              <div className="flex items-baseline gap-1.5">
+                <span className="text-[9px] uppercase tracking-[0.18em] text-white/35">Tokens</span>
+                <span className="text-xs text-white/80 font-[family-name:var(--font-mono)]">
+                  {doc.metric_summary.run_total_tokens.toLocaleString()}
+                  {(doc.metric_summary.run_race_context_tokens ?? 0) > 0 && (
+                    <span className="text-white/40 ml-1">
+                      ({doc.metric_summary.run_agent_tokens?.toLocaleString() ?? 0} agent + {doc.metric_summary.run_race_context_tokens.toLocaleString()} context)
+                    </span>
+                  )}
+                </span>
+              </div>
+            )}
           </div>
 
           {/* Overall reason — full width, no cramping */}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/scorecard-summary-card.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/scorecard-summary-card.tsx
@@ -120,6 +120,18 @@ export function ScorecardSummaryCard({
           );
         })}
       </div>
+
+      {/* Token split */}
+      {scorecard.scorecard?.metric_summary?.run_total_tokens != null && (
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[10px] text-muted-foreground">
+          <span className="font-[family-name:var(--font-mono)]">{scorecard.scorecard.metric_summary.run_total_tokens.toLocaleString()} tokens</span>
+          {(scorecard.scorecard.metric_summary.run_race_context_tokens ?? 0) > 0 && (
+            <span className="text-muted-foreground/60 font-[family-name:var(--font-mono)]">
+              ({scorecard.scorecard.metric_summary.run_agent_tokens?.toLocaleString() ?? 0} agent + {scorecard.scorecard.metric_summary.run_race_context_tokens.toLocaleString()} context)
+            </span>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
@@ -54,6 +54,7 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
   >([]);
   const [officialPackMode, setOfficialPackMode] =
     useState<OfficialPackMode>("full");
+  const [raceContext, setRaceContext] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
   const [packs, setPacks] = useState<ChallengePack[]>([]);
@@ -136,9 +137,13 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
   }
 
   function toggleDeployment(id: string) {
-    setSelectedDeploymentIds((prev) =>
-      prev.includes(id) ? prev.filter((d) => d !== id) : [...prev, id],
-    );
+    setSelectedDeploymentIds((prev) => {
+      const next = prev.includes(id) ? prev.filter((d) => d !== id) : [...prev, id];
+      if (next.length < 2) {
+        setRaceContext(false);
+      }
+      return next;
+    });
   }
 
   function toggleRegressionSuite(id: string) {
@@ -296,6 +301,7 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
           selectedRegressionCaseIds.length > 0
             ? officialPackMode
             : undefined,
+        race_context: raceContext,
       };
       const result = await api.post<CreateRunResponse>("/v1/runs", request);
       toast.success("Run created");
@@ -322,6 +328,7 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
     setSelectedRegressionSuiteIds([]);
     setSelectedRegressionCaseIds([]);
     setOfficialPackMode("full");
+    setRaceContext(false);
     setRegressionLoadError(null);
     setRunnableVersions([]);
   }
@@ -619,6 +626,29 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
                 ))}
               </div>
             )}
+          </div>
+
+          {/* Race Context */}
+          <div className="flex items-start gap-3 rounded-lg border border-border p-3">
+            <input
+              type="checkbox"
+              id="race-context"
+              checked={raceContext}
+              onChange={(e) => setRaceContext(e.target.checked)}
+              disabled={selectedDeploymentIds.length < 2}
+              className="mt-1 rounded border-input disabled:opacity-50"
+            />
+            <div className="space-y-1">
+              <label
+                htmlFor="race-context"
+                className={`text-sm font-medium ${selectedDeploymentIds.length < 2 ? "opacity-50" : "cursor-pointer"}`}
+              >
+                Race context (agents see live peer standings)
+              </label>
+              <p className={`text-xs text-muted-foreground ${selectedDeploymentIds.length < 2 ? "opacity-50" : ""}`}>
+                Injects live peer progress updates into the agent&apos;s prompt mid-run. Requires at least 2 agents.
+              </p>
+            </div>
           </div>
 
           {/* Preview */}

--- a/web/src/components/arena/live-event-ticker.tsx
+++ b/web/src/components/arena/live-event-ticker.tsx
@@ -91,32 +91,43 @@ export function LiveEventTicker({
             <li
               key={entry.id}
               className={cn(
-                "flex items-center gap-2 px-2 py-1.5 animate-in fade-in slide-in-from-bottom-1 duration-300",
+                "flex flex-col gap-1 px-2 py-1.5 animate-in fade-in slide-in-from-bottom-1 duration-300",
                 entry.error && "bg-destructive/5",
               )}
             >
-              <span className="shrink-0 tabular-nums text-muted-foreground/70">
-                {formatClock(entry.occurredAt)}
-              </span>
-              {entry.error ? (
-                <AlertTriangle className="size-3.5 shrink-0 text-destructive" />
-              ) : (
-                <Icon className="size-3.5 shrink-0 text-muted-foreground" />
-              )}
-              <span
-                className={cn(
-                  "min-w-0 flex-1 truncate",
-                  entry.error
-                    ? "text-destructive"
-                    : "text-foreground",
-                )}
-              >
-                {entry.headline}
-              </span>
-              {entry.detail && (
-                <span className="hidden sm:inline truncate max-w-[40%] text-muted-foreground">
-                  {entry.detail}
+              <div className="flex items-center gap-2 w-full">
+                <span className="shrink-0 tabular-nums text-muted-foreground/70">
+                  {formatClock(entry.occurredAt)}
                 </span>
+                {entry.error ? (
+                  <AlertTriangle className="size-3.5 shrink-0 text-destructive" />
+                ) : (
+                  <Icon className="size-3.5 shrink-0 text-muted-foreground" />
+                )}
+                <span
+                  className={cn(
+                    "min-w-0 flex-1 truncate",
+                    entry.error
+                      ? "text-destructive"
+                      : "text-foreground",
+                  )}
+                >
+                  {entry.headline}
+                </span>
+                {entry.kind !== "system" || entry.headline !== "Race standings injected" ? (
+                  entry.detail && (
+                    <span className="hidden sm:inline truncate max-w-[40%] text-muted-foreground">
+                      {entry.detail}
+                    </span>
+                  )
+                ) : null}
+              </div>
+              {entry.kind === "system" && entry.headline === "Race standings injected" && entry.detail && (
+                <div className="pl-[4.5rem] w-full">
+                  <pre className="text-[10px] text-muted-foreground whitespace-pre-wrap break-words font-[family-name:var(--font-mono)] bg-muted/30 p-2 rounded border border-border/50">
+                    {entry.detail}
+                  </pre>
+                </div>
               )}
             </li>
           );

--- a/web/src/components/arena/race-mode/race-lane.tsx
+++ b/web/src/components/arena/race-mode/race-lane.tsx
@@ -183,6 +183,15 @@ export function RaceLane({
           <div className="rm-stream">{lane.streamingOutput}</div>
         )}
 
+        {lane.ticker.filter(e => e.kind === "system" && e.headline === "Race standings injected").slice(-1).map(e => (
+          <div key={e.id} className="rm-stream !bg-emerald-500/[0.03] !border-emerald-500/20 !text-emerald-500/70 !max-h-none">
+            <div className="text-[10px] uppercase tracking-[0.16em] text-emerald-500/50 mb-1.5 font-sans">
+              Latest Race Standings Injected
+            </div>
+            {e.detail}
+          </div>
+        ))}
+
         {isFailed && agent.failure_reason && (
           <div className="rm-fail">
             <div className="rm-fail__ic" aria-hidden="true">

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -432,6 +432,8 @@ export interface Run {
   name: string;
   status: RunStatus;
   execution_mode: string; // "single_agent" | "comparison"
+  race_context: boolean;
+  race_context_min_step_gap?: number;
   temporal_workflow_id?: string;
   temporal_run_id?: string;
   queued_at?: string;
@@ -489,6 +491,8 @@ export interface CreateRunRequest {
   regression_suite_ids?: string[];
   regression_case_ids?: string[];
   official_pack_mode?: OfficialPackMode;
+  race_context?: boolean;
+  race_context_min_step_gap?: number;
 }
 
 /** POST /v1/runs response (201) */

--- a/web/src/lib/arena/event-formatter.ts
+++ b/web/src/lib/arena/event-formatter.ts
@@ -79,6 +79,7 @@ export function eventKind(event: RunEvent): ArenaEventKind {
     return "file";
   if (t.startsWith("grader.verification")) return "sandbox";
   if (t.startsWith("scoring.")) return "scoring";
+  if (t.startsWith("race.")) return "system";
   if (t.startsWith("system.")) return "system";
   return "unknown";
 }
@@ -224,6 +225,15 @@ export function summarizeEvent(event: RunEvent): TickerEntry | null {
     case "grader.verification.directory_listed":
     case "grader.verification.code_executed":
       return { ...base, headline: "Grader captured evidence" };
+
+    case "race.standings.injected": {
+      const p = payload<{ tokens_added?: number; triggered_by?: string; standings_snapshot?: string }>(event);
+      return {
+        ...base,
+        headline: "Race standings injected",
+        detail: p.standings_snapshot || (p.triggered_by ? `Trigger: ${p.triggered_by.replace(/_/g, " ")}` : undefined),
+      };
+    }
 
     case "scoring.started":
       return { ...base, headline: "Scoring started" };


### PR DESCRIPTION
## Summary
Implements Phase 2 (UI) for the race-context feature (#400).
- Adds a toggle on the Create Run page for "Race context" (disabled if < 2 agents).
- Renders the token split (`run_agent_tokens` and `run_race_context_tokens`) in the scorecard summary and run-detail views.
- Surfaces injected messages (`race.standings.injected`) on the agent timeline (LiveEventTicker) and in the Race Mode lane view.

Fixes #400