### PR TITLE
fix(auth): show user identity after cli login

### DIFF
--- a/backend/internal/api/auth_workos.go
+++ b/backend/internal/api/auth_workos.go
@@ -31,6 +31,7 @@ type UserRepository interface {
 	GetActiveWorkspaceMembershipsByUserID(ctx context.Context, userID uuid.UUID) ([]repository.WorkspaceMembershipRow, error)
 	GetActiveOrganizationMembershipsByUserID(ctx context.Context, userID uuid.UUID) ([]repository.OrgMembershipRow, error)
 	CreateUser(ctx context.Context, input repository.CreateUserInput) (repository.User, error)
+	BackfillUserEmail(ctx context.Context, input repository.BackfillUserEmailInput) (repository.User, error)
 	LinkWorkOSUser(ctx context.Context, userID uuid.UUID, workosUserID string) (repository.User, error)
 	RelinkWorkOSUser(ctx context.Context, userID uuid.UUID, workosUserID string) (repository.User, error)
 	IsUserArchivedByWorkOSID(ctx context.Context, workosUserID string) (bool, error)
@@ -183,6 +184,18 @@ func (a *WorkOSAuthenticator) resolveUser(ctx context.Context, workosUserID, ema
 	// Step 1: active user with this WorkOS ID.
 	user, err := a.repo.GetUserByWorkOSID(ctx, workosUserID)
 	if err == nil {
+		if user.Email == "" && email != "" {
+			backfilled, backfillErr := a.repo.BackfillUserEmail(ctx, repository.BackfillUserEmailInput{
+				UserID: user.ID,
+				Email:  email,
+			})
+			if backfillErr != nil {
+				log.ErrorContext(ctx, "resolve_user: failed to backfill missing email", "user_id", user.ID, "error", backfillErr)
+				return repository.User{}, fmt.Errorf("%w: %v", ErrUnauthenticated, backfillErr)
+			}
+			user = backfilled
+			log.InfoContext(ctx, "resolve_user: backfilled missing email from token claims", "user_id", user.ID)
+		}
 		log.DebugContext(ctx, "resolve_user: found active user by workos_id", "user_id", user.ID)
 		return user, nil
 	}

--- a/backend/internal/api/auth_workos_test.go
+++ b/backend/internal/api/auth_workos_test.go
@@ -90,10 +90,15 @@ type stubUserRepo struct {
 	memberships       []repository.WorkspaceMembershipRow
 	orgMemberships    []repository.OrgMembershipRow
 	createdUser       repository.User
+	backfilledUser    repository.User
 	err               error
 	membershipErr     error
 	orgMembershipErr  error
 	createUserErr     error
+	backfillEmailErr  error
+	backfillEmail     *string
+	backfillUserID    *uuid.UUID
+	backfillCallCount *int
 }
 
 func (s stubUserRepo) GetUserByWorkOSID(_ context.Context, _ string) (repository.User, error) {
@@ -130,6 +135,29 @@ func (s stubUserRepo) CreateUser(_ context.Context, input repository.CreateUserI
 		Email:        input.Email,
 		DisplayName:  input.DisplayName,
 	}, nil
+}
+
+func (s stubUserRepo) BackfillUserEmail(_ context.Context, input repository.BackfillUserEmailInput) (repository.User, error) {
+	if s.backfillCallCount != nil {
+		*s.backfillCallCount = *s.backfillCallCount + 1
+	}
+	if s.backfillEmail != nil {
+		*s.backfillEmail = input.Email
+	}
+	if s.backfillUserID != nil {
+		*s.backfillUserID = input.UserID
+	}
+	if s.backfillEmailErr != nil {
+		return repository.User{}, s.backfillEmailErr
+	}
+	if s.backfilledUser.ID != uuid.Nil {
+		return s.backfilledUser, nil
+	}
+	user := s.user
+	if user.Email == "" {
+		user.Email = input.Email
+	}
+	return user, nil
 }
 
 func (s stubUserRepo) GetUserByEmail(_ context.Context, _ string) (repository.User, error) {
@@ -210,6 +238,149 @@ func TestWorkOSAuthenticator_ValidToken(t *testing.T) {
 	}
 	if m, ok := caller.WorkspaceMemberships[workspaceID]; !ok || m.Role != "workspace_admin" {
 		t.Errorf("membership for workspace %v = %+v, want role workspace_admin", workspaceID, m)
+	}
+}
+
+func TestWorkOSAuthenticator_BackfillsMissingEmailForExistingUser(t *testing.T) {
+	privKey, jwksServer := testJWKS(t)
+
+	userID := uuid.New()
+	var backfillCalls int
+	var backfillEmail string
+	var backfillUserID uuid.UUID
+
+	repo := stubUserRepo{
+		user: repository.User{
+			ID:           userID,
+			WorkOSUserID: "user_01ABC",
+			Email:        "",
+			DisplayName:  "Test User",
+		},
+		backfilledUser: repository.User{
+			ID:           userID,
+			WorkOSUserID: "user_01ABC",
+			Email:        "new@example.com",
+			DisplayName:  "Test User",
+		},
+		backfillCallCount: &backfillCalls,
+		backfillEmail:     &backfillEmail,
+		backfillUserID:    &backfillUserID,
+	}
+
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", repo, authTestLogger)
+	if err != nil {
+		t.Fatalf("create authenticator: %v", err)
+	}
+
+	token := signTestJWT(t, privKey, map[string]interface{}{
+		"sub":   "user_01ABC",
+		"iss":   "https://api.workos.com",
+		"email": "new@example.com",
+		"iat":   time.Now().Unix(),
+		"exp":   time.Now().Add(5 * time.Minute).Unix(),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/session", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	caller, err := auth.Authenticate(req)
+	if err != nil {
+		t.Fatalf("authenticate: %v", err)
+	}
+	if caller.Email != "new@example.com" {
+		t.Fatalf("Email = %q, want %q", caller.Email, "new@example.com")
+	}
+	if backfillCalls != 1 {
+		t.Fatalf("backfill calls = %d, want 1", backfillCalls)
+	}
+	if backfillEmail != "new@example.com" {
+		t.Fatalf("backfill email = %q, want %q", backfillEmail, "new@example.com")
+	}
+	if backfillUserID != userID {
+		t.Fatalf("backfill user_id = %v, want %v", backfillUserID, userID)
+	}
+}
+
+func TestWorkOSAuthenticator_DoesNotOverwriteExistingEmail(t *testing.T) {
+	privKey, jwksServer := testJWKS(t)
+
+	var backfillCalls int
+	repo := stubUserRepo{
+		user: repository.User{
+			ID:           uuid.New(),
+			WorkOSUserID: "user_01ABC",
+			Email:        "stored@example.com",
+			DisplayName:  "Test User",
+		},
+		backfillCallCount: &backfillCalls,
+	}
+
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", repo, authTestLogger)
+	if err != nil {
+		t.Fatalf("create authenticator: %v", err)
+	}
+
+	token := signTestJWT(t, privKey, map[string]interface{}{
+		"sub":   "user_01ABC",
+		"iss":   "https://api.workos.com",
+		"email": "new@example.com",
+		"iat":   time.Now().Unix(),
+		"exp":   time.Now().Add(5 * time.Minute).Unix(),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/session", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	caller, err := auth.Authenticate(req)
+	if err != nil {
+		t.Fatalf("authenticate: %v", err)
+	}
+	if caller.Email != "stored@example.com" {
+		t.Fatalf("Email = %q, want %q", caller.Email, "stored@example.com")
+	}
+	if backfillCalls != 0 {
+		t.Fatalf("backfill calls = %d, want 0", backfillCalls)
+	}
+}
+
+func TestWorkOSAuthenticator_NoEmailClaimLeavesExistingUserUnchanged(t *testing.T) {
+	privKey, jwksServer := testJWKS(t)
+
+	var backfillCalls int
+	repo := stubUserRepo{
+		user: repository.User{
+			ID:           uuid.New(),
+			WorkOSUserID: "user_01ABC",
+			Email:        "",
+			DisplayName:  "Test User",
+		},
+		backfillCallCount: &backfillCalls,
+	}
+
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", repo, authTestLogger)
+	if err != nil {
+		t.Fatalf("create authenticator: %v", err)
+	}
+
+	token := signTestJWT(t, privKey, map[string]interface{}{
+		"sub": "user_01ABC",
+		"iss": "https://api.workos.com",
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(5 * time.Minute).Unix(),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/session", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	caller, err := auth.Authenticate(req)
+	if err != nil {
+		t.Fatalf("authenticate: %v", err)
+	}
+	if caller.Email != "" {
+		t.Fatalf("Email = %q, want empty string", caller.Email)
+	}
+	if backfillCalls != 0 {
+		t.Fatalf("backfill calls = %d, want 0", backfillCalls)
 	}
 }
 

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -2480,6 +2480,11 @@ type CreateUserInput struct {
 	DisplayName  string
 }
 
+type BackfillUserEmailInput struct {
+	UserID uuid.UUID
+	Email  string
+}
+
 type UserMeOrgRow struct {
 	ID   uuid.UUID
 	Name string
@@ -2708,6 +2713,33 @@ func (r *Repository) CreateUser(ctx context.Context, input CreateUserInput) (Use
 			return User{}, fmt.Errorf("%w: constraint=%s detail=%s", ErrUserAlreadyExists, pgErr.ConstraintName, pgErr.Detail)
 		}
 		return User{}, fmt.Errorf("create user: %w", err)
+	}
+	return user, nil
+}
+
+func (r *Repository) BackfillUserEmail(ctx context.Context, input BackfillUserEmailInput) (User, error) {
+	email := strings.TrimSpace(input.Email)
+
+	var user User
+	err := r.db.QueryRow(ctx, `
+		UPDATE users
+		SET
+			email = CASE
+				WHEN COALESCE(email, '') = '' AND $2 <> '' THEN $2
+				ELSE email
+			END,
+			updated_at = CASE
+				WHEN COALESCE(email, '') = '' AND $2 <> '' THEN now()
+				ELSE updated_at
+			END
+		WHERE id = $1 AND archived_at IS NULL
+		RETURNING id, workos_user_id, COALESCE(email, ''), COALESCE(display_name, '')
+	`, input.UserID, email).Scan(&user.ID, &user.WorkOSUserID, &user.Email, &user.DisplayName)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return User{}, ErrUserNotFound
+		}
+		return User{}, fmt.Errorf("backfill user email: %w", err)
 	}
 	return user, nil
 }

--- a/backend/internal/repository/repository_integration_test.go
+++ b/backend/internal/repository/repository_integration_test.go
@@ -546,6 +546,39 @@ func TestRepositoryListOrgMembershipsScansTimestamps(t *testing.T) {
 	}
 }
 
+func TestRepositoryBackfillUserEmailOnlyFillsMissingEmail(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	if _, err := db.Exec(ctx, `UPDATE users SET email = '' WHERE id = $1`, fixture.userID); err != nil {
+		t.Fatalf("clear user email returned error: %v", err)
+	}
+
+	backfilled, err := repo.BackfillUserEmail(ctx, repository.BackfillUserEmailInput{
+		UserID: fixture.userID,
+		Email:  "restored@example.com",
+	})
+	if err != nil {
+		t.Fatalf("BackfillUserEmail returned error: %v", err)
+	}
+	if backfilled.Email != "restored@example.com" {
+		t.Fatalf("email = %q, want %q", backfilled.Email, "restored@example.com")
+	}
+
+	preserved, err := repo.BackfillUserEmail(ctx, repository.BackfillUserEmailInput{
+		UserID: fixture.userID,
+		Email:  "new@example.com",
+	})
+	if err != nil {
+		t.Fatalf("BackfillUserEmail second call returned error: %v", err)
+	}
+	if preserved.Email != "restored@example.com" {
+		t.Fatalf("email after second call = %q, want %q", preserved.Email, "restored@example.com")
+	}
+}
+
 func TestRepositoryPublishChallengePackBundle(t *testing.T) {
 	ctx := context.Background()
 	db := openTestDB(t)

--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/agentclash/agentclash/cli/internal/auth"
 	"github.com/agentclash/agentclash/cli/internal/output"
@@ -57,10 +58,7 @@ For CI/CD, set the AGENTCLASH_TOKEN environment variable instead.`,
 					})
 				}
 
-				name := result.Display
-				if name == "" {
-					name = result.Email
-				}
+				name := loginIdentityLabel(result)
 				if envTokenSet {
 					rc.Output.PrintSuccess(fmt.Sprintf("Already logged in as %s using AGENTCLASH_TOKEN", name))
 				} else {
@@ -99,13 +97,22 @@ For CI/CD, set the AGENTCLASH_TOKEN environment variable instead.`,
 			})
 		}
 
-		name := result.Display
-		if name == "" {
-			name = result.Email
-		}
+		name := loginIdentityLabel(result)
 		rc.Output.PrintSuccess(fmt.Sprintf("Logged in as %s", name))
 		return nil
 	},
+}
+
+func loginIdentityLabel(result *auth.LoginResult) string {
+	if result == nil {
+		return "authenticated user"
+	}
+	for _, candidate := range []string{result.Display, result.Email, result.UserID} {
+		if value := strings.TrimSpace(candidate); value != "" {
+			return value
+		}
+	}
+	return "authenticated user"
 }
 
 func authSource(envTokenSet bool) string {

--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -17,6 +17,11 @@ import (
 // API endpoints were called. Output formatting is tested in the output package.
 func executeCommand(t *testing.T, args []string, apiURL string) error {
 	t.Helper()
+	return executeCommandWithQuiet(t, args, apiURL, true)
+}
+
+func executeCommandWithQuiet(t *testing.T, args []string, apiURL string, quiet bool) error {
+	t.Helper()
 
 	// Cobra retains global flag state. Use a mutex to serialize test execution
 	// and reset flags before each call.
@@ -25,7 +30,7 @@ func executeCommand(t *testing.T, args []string, apiURL string) error {
 
 	flagJSON = false
 	flagOutput = ""
-	flagQuiet = true // suppress output in tests
+	flagQuiet = quiet
 	flagVerbose = false
 	flagNoColor = true
 	flagWorkspace = ""
@@ -570,6 +575,109 @@ func TestAuthLoginForceStartsDeviceFlowWhenStoredTokenValid(t *testing.T) {
 	}
 	if creds.Token != "clitok_forced" {
 		t.Fatalf("saved token = %q, want clitok_forced", creds.Token)
+	}
+}
+
+func TestAuthLoginFallsBackToEmailWhenDisplayNameMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("AGENTCLASH_TOKEN", "")
+
+	stderr := captureStderr(t)
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/cli-auth/device": jsonHandler(201, map[string]any{
+			"device_code":               "dc_test",
+			"user_code":                 "ABCD-EFGH",
+			"verification_uri":          "https://agentclash.dev/auth/device",
+			"verification_uri_complete": "https://agentclash.dev/auth/device?user_code=ABCD-EFGH",
+			"expires_in":                60,
+			"interval":                  1,
+		}),
+		"POST /v1/cli-auth/device/token": jsonHandler(200, map[string]any{
+			"token": "clitok_new",
+		}),
+		"GET /v1/auth/session": jsonHandler(200, map[string]any{
+			"user_id": "user-1",
+			"email":   "dev@example.com",
+		}),
+	})
+	defer srv.Close()
+
+	if err := executeCommandWithQuiet(t, []string{"auth", "login", "--device"}, srv.URL, false); err != nil {
+		t.Fatalf("auth login error: %v", err)
+	}
+
+	output := stderr.finish()
+	if !strings.Contains(output, "Logged in as dev@example.com") {
+		t.Fatalf("stderr = %q, want email fallback in success output", output)
+	}
+}
+
+func TestAuthLoginFallsBackToUserIDWhenIdentityMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("AGENTCLASH_TOKEN", "")
+
+	stderr := captureStderr(t)
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/cli-auth/device": jsonHandler(201, map[string]any{
+			"device_code":               "dc_test",
+			"user_code":                 "ABCD-EFGH",
+			"verification_uri":          "https://agentclash.dev/auth/device",
+			"verification_uri_complete": "https://agentclash.dev/auth/device?user_code=ABCD-EFGH",
+			"expires_in":                60,
+			"interval":                  1,
+		}),
+		"POST /v1/cli-auth/device/token": jsonHandler(200, map[string]any{
+			"token": "clitok_new",
+		}),
+		"GET /v1/auth/session": jsonHandler(200, map[string]any{
+			"user_id": "user-1",
+		}),
+	})
+	defer srv.Close()
+
+	if err := executeCommandWithQuiet(t, []string{"auth", "login", "--device"}, srv.URL, false); err != nil {
+		t.Fatalf("auth login error: %v", err)
+	}
+
+	output := stderr.finish()
+	if !strings.Contains(output, "Logged in as user-1") {
+		t.Fatalf("stderr = %q, want user_id fallback in success output", output)
+	}
+}
+
+func TestAuthLoginAlreadyAuthenticatedFallsBackToUserIDWhenIdentityMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("AGENTCLASH_TOKEN", "")
+	if err := auth.SaveCredentials(auth.Credentials{Token: "stored-token"}); err != nil {
+		t.Fatalf("SaveCredentials() error = %v", err)
+	}
+
+	stderr := captureStderr(t)
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/auth/session": func(w http.ResponseWriter, r *http.Request) {
+			if got := r.Header.Get("Authorization"); got != "Bearer stored-token" {
+				t.Fatalf("Authorization header = %q, want Bearer stored-token", got)
+			}
+			jsonHandler(200, map[string]any{
+				"user_id": "user-1",
+			})(w, r)
+		},
+	})
+	defer srv.Close()
+
+	if err := executeCommandWithQuiet(t, []string{"auth", "login", "--device"}, srv.URL, false); err != nil {
+		t.Fatalf("auth login error: %v", err)
+	}
+
+	output := stderr.finish()
+	if !strings.Contains(output, "Already logged in as user-1") {
+		t.Fatalf("stderr = %q, want user_id fallback in already-authenticated output", output)
 	}
 }
 

--- a/testing/codex-fix-cli-login-identity.md
+++ b/testing/codex-fix-cli-login-identity.md
@@ -1,0 +1,37 @@
+# codex/fix-cli-login-identity — Test Contract
+
+## Functional Behavior
+- `agentclash auth login` must never print a blank identity after a successful login.
+- Human-readable auth success messages must use this fallback order: `display_name`, then `email`, then `user_id`.
+- The same fallback must apply to both fresh login and already-authenticated login paths.
+- When a valid WorkOS-authenticated request includes a non-empty email and the stored user record for that same WorkOS identity has a blank email, the backend must backfill the stored email before returning the caller/session identity.
+- Existing non-empty stored emails must not be overwritten by the WorkOS authenticator.
+- Auth structured output and `auth status` shape stay unchanged apart from any expected email now being present because of backend backfill.
+
+## Unit Tests
+- `TestWorkOSAuthenticator_BackfillsMissingEmailForExistingUser` — existing WorkOS-linked user with blank stored email gets email backfilled from JWT claims.
+- `TestWorkOSAuthenticator_DoesNotOverwriteExistingEmail` — existing non-empty stored email is preserved even when JWT includes a different email.
+- `TestWorkOSAuthenticator_NoEmailClaimLeavesExistingUserUnchanged` — no claim means no backfill call and current behavior stays intact.
+- `TestAuthLoginSkipsDeviceFlowWhenStoredTokenValid` — success output still works for the already-authenticated path.
+- `TestAuthLoginSkipsDeviceFlowWhenEnvTokenValid` — env-token path still works.
+- `TestAuthLoginFallsBackToEmailWhenDisplayNameMissing` — fresh login prints email when display name is blank.
+- `TestAuthLoginFallsBackToUserIDWhenIdentityMissing` — fresh login prints user ID when display name and email are blank.
+- `TestAuthLoginAlreadyAuthenticatedFallsBackToUserIDWhenIdentityMissing` — cached-token path prints user ID when display name and email are blank.
+
+## Integration / Functional Tests
+- `go test ./backend/internal/api -run 'TestWorkOSAuthenticator_(BackfillsMissingEmailForExistingUser|DoesNotOverwriteExistingEmail|NoEmailClaimLeavesExistingUserUnchanged)'`
+- `go test ./cli/cmd -run 'TestAuthLogin(SkipsDeviceFlowWhenStoredTokenValid|SkipsDeviceFlowWhenEnvTokenValid|FallsBackToEmailWhenDisplayNameMissing|FallsBackToUserIDWhenIdentityMissing|AlreadyAuthenticatedFallsBackToUserIDWhenIdentityMissing)'`
+
+## Smoke Tests
+- `go test ./backend/internal/api ./cli/cmd`
+- `go test ./backend/internal/repository ./cli/internal/auth`
+
+## E2E Tests
+- N/A — not applicable for this fix; coverage is backend auth plus CLI command tests.
+
+## Manual / cURL Tests
+- Manual:
+  - Run `go run . auth login --device` from `cli/` against staging or local services and confirm the success line shows a name, email, or user ID instead of `Logged in as`.
+  - Run `go run . auth status` afterward and confirm the command still prints the same fields/format as before.
+- cURL:
+  - N/A — this fix is best verified through existing Go auth tests and the CLI login flow rather than standalone curl commands.


### PR DESCRIPTION
## Summary
- backfill missing email for existing WorkOS-linked users when a valid token now includes it
- make CLI login success messages fall back from display name to email to user ID
- add backend, repository, and CLI coverage for the login identity regression

## Testing
- `cd backend && go test ./internal/api ./internal/repository`
- `cd cli && go test ./cmd ./internal/auth`
- `git diff --check`

## Contract
- `testing/codex-fix-cli-login-identity.md`
