### PR TITLE
fix(auth): recover device login email from workos userinfo

### DIFF
--- a/backend/internal/api/auth_workos.go
+++ b/backend/internal/api/auth_workos.go
@@ -2,10 +2,13 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -17,6 +20,7 @@ import (
 
 const (
 	initialJWKSFetchTimeout = 10 * time.Second
+	workOSUserInfoTimeout   = 5 * time.Second
 
 	// defaultWorkOSIssuer is the default JWT issuer for WorkOS tokens.
 	// When a custom auth domain is configured in WorkOS, set WORKOS_ISSUER
@@ -41,11 +45,12 @@ type UserRepository interface {
 // WorkOSAuthenticator validates WorkOS AuthKit JWTs using the public JWKS
 // endpoint and resolves the token subject to an internal user.
 type WorkOSAuthenticator struct {
-	cachedSet jwk.Set
-	repo      UserRepository
-	logger    *slog.Logger
-	issuer    string
-	clientID  string
+	cachedSet  jwk.Set
+	repo       UserRepository
+	logger     *slog.Logger
+	issuer     string
+	clientID   string
+	httpClient *http.Client
 }
 
 // WorkOSAuthenticatorConfig holds the settings for constructing a WorkOSAuthenticator.
@@ -86,11 +91,12 @@ func newWorkOSAuthenticator(jwksURL, clientID, issuer string, repo UserRepositor
 	}
 
 	return &WorkOSAuthenticator{
-		cachedSet: jwk.NewCachedSet(cache, jwksURL),
-		repo:      repo,
-		logger:    logger,
-		issuer:    issuer,
-		clientID:  clientID,
+		cachedSet:  jwk.NewCachedSet(cache, jwksURL),
+		repo:       repo,
+		logger:     logger,
+		issuer:     issuer,
+		clientID:   clientID,
+		httpClient: &http.Client{Timeout: workOSUserInfoTimeout},
 	}, nil
 }
 
@@ -119,12 +125,25 @@ func (a *WorkOSAuthenticator) Authenticate(r *http.Request) (Caller, error) {
 		return Caller{}, fmt.Errorf("%w: token missing sub claim", ErrUnauthenticated)
 	}
 
-	// Extract email from JWT claims if available (WorkOS includes email in
-	// the token for AuthKit). Fall back to empty string if absent.
+	// Extract email from JWT claims if available. When AuthKit omits the
+	// claim, we can still recover it from WorkOS userinfo on demand.
 	email, _ := tok.Get("email")
 	emailStr, _ := email.(string)
 
-	user, err := a.resolveUser(r.Context(), workosUserID, emailStr)
+	loadEmail := func(ctx context.Context) (string, error) {
+		if emailStr != "" {
+			return emailStr, nil
+		}
+
+		fetchedEmail, err := a.lookupEmailFromUserInfo(ctx, tok.Issuer(), tokenStr)
+		if err != nil {
+			return "", err
+		}
+		emailStr = fetchedEmail
+		return emailStr, nil
+	}
+
+	user, err := a.resolveUser(r.Context(), workosUserID, emailStr, loadEmail)
 	if err != nil {
 		return Caller{}, err
 	}
@@ -177,24 +196,40 @@ func (a *WorkOSAuthenticator) Authenticate(r *http.Request) (Caller, error) {
 //     rows blocking the unique constraint and return the appropriate error.
 //
 // Note: WorkOS access tokens may not include an email claim unless JWT
-// Templates are configured. Steps 3-5 are skipped when email is absent.
-func (a *WorkOSAuthenticator) resolveUser(ctx context.Context, workosUserID, email string) (repository.User, error) {
+// templates are configured. When that happens, we fall back to WorkOS userinfo
+// before the email-dependent resolution steps.
+func (a *WorkOSAuthenticator) resolveUser(
+	ctx context.Context,
+	workosUserID, email string,
+	loadEmail func(context.Context) (string, error),
+) (repository.User, error) {
 	log := a.logger.With("workos_user_id", workosUserID, "email", email)
 
 	// Step 1: active user with this WorkOS ID.
 	user, err := a.repo.GetUserByWorkOSID(ctx, workosUserID)
 	if err == nil {
-		if user.Email == "" && email != "" {
-			backfilled, backfillErr := a.repo.BackfillUserEmail(ctx, repository.BackfillUserEmailInput{
-				UserID: user.ID,
-				Email:  email,
-			})
-			if backfillErr != nil {
-				log.ErrorContext(ctx, "resolve_user: failed to backfill missing email", "user_id", user.ID, "error", backfillErr)
-				return repository.User{}, fmt.Errorf("%w: %v", ErrUnauthenticated, backfillErr)
+		if user.Email == "" {
+			if email == "" && loadEmail != nil {
+				loadedEmail, loadErr := loadEmail(ctx)
+				if loadErr != nil {
+					log.WarnContext(ctx, "resolve_user: failed to fetch email from WorkOS userinfo", "user_id", user.ID, "error", loadErr)
+				} else {
+					email = loadedEmail
+				}
 			}
-			user = backfilled
-			log.InfoContext(ctx, "resolve_user: backfilled missing email from token claims", "user_id", user.ID)
+			if email != "" {
+				backfilled, backfillErr := a.repo.BackfillUserEmail(ctx, repository.BackfillUserEmailInput{
+					UserID: user.ID,
+					Email:  email,
+				})
+				if backfillErr != nil {
+					log.ErrorContext(ctx, "resolve_user: failed to backfill missing email", "user_id", user.ID, "error", backfillErr)
+					user.Email = email
+				} else {
+					user = backfilled
+					log.InfoContext(ctx, "resolve_user: backfilled missing email from trusted identity", "user_id", user.ID)
+				}
+			}
 		}
 		log.DebugContext(ctx, "resolve_user: found active user by workos_id", "user_id", user.ID)
 		return user, nil
@@ -219,7 +254,16 @@ func (a *WorkOSAuthenticator) resolveUser(ctx context.Context, workosUserID, ema
 
 	log.InfoContext(ctx, "resolve_user: no active or archived user with this workos_id")
 
-	// Steps 3 & 4: match by email (only when JWT includes email claim).
+	if email == "" && loadEmail != nil {
+		loadedEmail, loadErr := loadEmail(ctx)
+		if loadErr != nil {
+			log.WarnContext(ctx, "resolve_user: failed to fetch email from WorkOS userinfo", "error", loadErr)
+		} else {
+			email = loadedEmail
+		}
+	}
+
+	// Steps 3 & 4: match by email when we have one from claims or userinfo.
 	if email != "" {
 		existingUser, emailErr := a.repo.GetUserByEmail(ctx, email)
 		if emailErr == nil {
@@ -309,6 +353,59 @@ func (a *WorkOSAuthenticator) resolveUser(ctx context.Context, workosUserID, ema
 	}
 	log.InfoContext(ctx, "resolve_user: created new user", "user_id", user.ID)
 	return user, nil
+}
+
+func (a *WorkOSAuthenticator) lookupEmailFromUserInfo(ctx context.Context, issuer, token string) (string, error) {
+	userInfoURL, err := workOSUserInfoURL(issuer)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, userInfoURL, http.NoBody)
+	if err != nil {
+		return "", fmt.Errorf("create userinfo request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request userinfo: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return "", fmt.Errorf("userinfo returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var payload struct {
+		Email string `json:"email"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("decode userinfo response: %w", err)
+	}
+	return strings.TrimSpace(payload.Email), nil
+}
+
+func workOSUserInfoURL(issuer string) (string, error) {
+	if strings.TrimSpace(issuer) == "" {
+		return "", fmt.Errorf("missing WorkOS issuer")
+	}
+
+	parsed, err := url.Parse(issuer)
+	if err != nil {
+		return "", fmt.Errorf("parse issuer: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("issuer %q must include scheme and host", issuer)
+	}
+
+	return (&url.URL{
+		Scheme: parsed.Scheme,
+		Host:   parsed.Host,
+		Path:   "/oauth2/userinfo",
+	}).String(), nil
 }
 
 // bearerToken extracts a Bearer token from the Authorization header.

--- a/backend/internal/api/auth_workos_test.go
+++ b/backend/internal/api/auth_workos_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -81,6 +82,14 @@ func signTestJWT(t *testing.T, privKey *rsa.PrivateKey, claims map[string]interf
 		t.Fatalf("sign JWT: %v", err)
 	}
 	return string(signed)
+}
+
+func testUserInfoServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return server
 }
 
 // --- stub UserRepository for tests ---
@@ -343,8 +352,57 @@ func TestWorkOSAuthenticator_DoesNotOverwriteExistingEmail(t *testing.T) {
 	}
 }
 
+func TestWorkOSAuthenticator_BackfillFailureDoesNotBlockExistingUserAuth(t *testing.T) {
+	privKey, jwksServer := testJWKS(t)
+
+	var backfillCalls int
+	repo := stubUserRepo{
+		user: repository.User{
+			ID:           uuid.New(),
+			WorkOSUserID: "user_01ABC",
+			Email:        "",
+			DisplayName:  "Test User",
+		},
+		backfillCallCount: &backfillCalls,
+		backfillEmailErr:  errors.New("write failed"),
+	}
+
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", repo, authTestLogger)
+	if err != nil {
+		t.Fatalf("create authenticator: %v", err)
+	}
+
+	token := signTestJWT(t, privKey, map[string]interface{}{
+		"sub":   "user_01ABC",
+		"iss":   "https://api.workos.com",
+		"email": "new@example.com",
+		"iat":   time.Now().Unix(),
+		"exp":   time.Now().Add(5 * time.Minute).Unix(),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/session", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	caller, err := auth.Authenticate(req)
+	if err != nil {
+		t.Fatalf("authenticate: %v", err)
+	}
+	if caller.Email != "new@example.com" {
+		t.Fatalf("Email = %q, want %q", caller.Email, "new@example.com")
+	}
+	if backfillCalls != 1 {
+		t.Fatalf("backfill calls = %d, want 1", backfillCalls)
+	}
+}
+
 func TestWorkOSAuthenticator_NoEmailClaimLeavesExistingUserUnchanged(t *testing.T) {
 	privKey, jwksServer := testJWKS(t)
+	userInfoServer := testUserInfoServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want %s", r.Method, http.MethodPost)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"sub": "user_01ABC"})
+	})
 
 	var backfillCalls int
 	repo := stubUserRepo{
@@ -357,14 +415,14 @@ func TestWorkOSAuthenticator_NoEmailClaimLeavesExistingUserUnchanged(t *testing.
 		backfillCallCount: &backfillCalls,
 	}
 
-	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", repo, authTestLogger)
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", userInfoServer.URL, repo, authTestLogger)
 	if err != nil {
 		t.Fatalf("create authenticator: %v", err)
 	}
 
 	token := signTestJWT(t, privKey, map[string]interface{}{
 		"sub": "user_01ABC",
-		"iss": "https://api.workos.com",
+		"iss": userInfoServer.URL,
 		"iat": time.Now().Unix(),
 		"exp": time.Now().Add(5 * time.Minute).Unix(),
 	})
@@ -516,6 +574,12 @@ func TestWorkOSAuthenticator_FirstLoginCreatesUser(t *testing.T) {
 
 func TestWorkOSAuthenticator_FirstLoginNoEmail(t *testing.T) {
 	privKey, jwksServer := testJWKS(t)
+	userInfoServer := testUserInfoServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want %s", r.Method, http.MethodPost)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"sub": "user_01NOEMAIL"})
+	})
 
 	createdUserID := uuid.New()
 	repo := stubUserRepo{
@@ -527,7 +591,7 @@ func TestWorkOSAuthenticator_FirstLoginNoEmail(t *testing.T) {
 		},
 	}
 
-	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", repo, authTestLogger)
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", userInfoServer.URL, repo, authTestLogger)
 	if err != nil {
 		t.Fatalf("create authenticator: %v", err)
 	}
@@ -535,7 +599,7 @@ func TestWorkOSAuthenticator_FirstLoginNoEmail(t *testing.T) {
 	// JWT without email claim — simulates WorkOS AuthKit without JWT Templates.
 	token := signTestJWT(t, privKey, map[string]interface{}{
 		"sub": "user_01NOEMAIL",
-		"iss": "https://api.workos.com",
+		"iss": userInfoServer.URL,
 		"iat": time.Now().Unix(),
 		"exp": time.Now().Add(5 * time.Minute).Unix(),
 	})
@@ -552,6 +616,165 @@ func TestWorkOSAuthenticator_FirstLoginNoEmail(t *testing.T) {
 	}
 	if caller.Email != "" {
 		t.Errorf("Email = %q, want empty string", caller.Email)
+	}
+}
+
+func TestWorkOSAuthenticator_FallsBackToUserInfoEmailWhenClaimMissing(t *testing.T) {
+	privKey, jwksServer := testJWKS(t)
+
+	var userInfoCalls int
+	userInfoServer := testUserInfoServer(t, func(w http.ResponseWriter, r *http.Request) {
+		userInfoCalls++
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want %s", r.Method, http.MethodPost)
+		}
+		if got := r.Header.Get("Authorization"); got == "" || !strings.HasPrefix(got, "Bearer ") {
+			t.Fatalf("Authorization header = %q, want Bearer token", got)
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"sub":   "user_01ABC",
+			"email": "userinfo@example.com",
+		})
+	})
+
+	userID := uuid.New()
+	var backfillCalls int
+	var backfillEmail string
+	repo := stubUserRepo{
+		user: repository.User{
+			ID:           userID,
+			WorkOSUserID: "user_01ABC",
+			Email:        "",
+			DisplayName:  "Test User",
+		},
+		backfilledUser: repository.User{
+			ID:           userID,
+			WorkOSUserID: "user_01ABC",
+			Email:        "userinfo@example.com",
+			DisplayName:  "Test User",
+		},
+		backfillCallCount: &backfillCalls,
+		backfillEmail:     &backfillEmail,
+	}
+
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", userInfoServer.URL, repo, authTestLogger)
+	if err != nil {
+		t.Fatalf("create authenticator: %v", err)
+	}
+
+	token := signTestJWT(t, privKey, map[string]interface{}{
+		"sub": "user_01ABC",
+		"iss": userInfoServer.URL,
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(5 * time.Minute).Unix(),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/session", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	caller, err := auth.Authenticate(req)
+	if err != nil {
+		t.Fatalf("authenticate: %v", err)
+	}
+	if caller.Email != "userinfo@example.com" {
+		t.Fatalf("Email = %q, want %q", caller.Email, "userinfo@example.com")
+	}
+	if backfillCalls != 1 {
+		t.Fatalf("backfill calls = %d, want 1", backfillCalls)
+	}
+	if backfillEmail != "userinfo@example.com" {
+		t.Fatalf("backfill email = %q, want %q", backfillEmail, "userinfo@example.com")
+	}
+	if userInfoCalls != 1 {
+		t.Fatalf("userinfo calls = %d, want 1", userInfoCalls)
+	}
+}
+
+func TestWorkOSAuthenticator_UserInfoFailureDoesNotBlockExistingUserAuth(t *testing.T) {
+	privKey, jwksServer := testJWKS(t)
+
+	var userInfoCalls int
+	userInfoServer := testUserInfoServer(t, func(w http.ResponseWriter, r *http.Request) {
+		userInfoCalls++
+		http.Error(w, "upstream unavailable", http.StatusBadGateway)
+	})
+
+	var backfillCalls int
+	repo := stubUserRepo{
+		user: repository.User{
+			ID:           uuid.New(),
+			WorkOSUserID: "user_01ABC",
+			Email:        "",
+			DisplayName:  "Test User",
+		},
+		backfillCallCount: &backfillCalls,
+	}
+
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", userInfoServer.URL, repo, authTestLogger)
+	if err != nil {
+		t.Fatalf("create authenticator: %v", err)
+	}
+
+	token := signTestJWT(t, privKey, map[string]interface{}{
+		"sub": "user_01ABC",
+		"iss": userInfoServer.URL,
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(5 * time.Minute).Unix(),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/session", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	caller, err := auth.Authenticate(req)
+	if err != nil {
+		t.Fatalf("authenticate: %v", err)
+	}
+	if caller.Email != "" {
+		t.Fatalf("Email = %q, want empty string", caller.Email)
+	}
+	if backfillCalls != 0 {
+		t.Fatalf("backfill calls = %d, want 0", backfillCalls)
+	}
+	if userInfoCalls != 1 {
+		t.Fatalf("userinfo calls = %d, want 1", userInfoCalls)
+	}
+}
+
+func TestWorkOSUserInfoURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		issuer string
+		want   string
+	}{
+		{
+			name:   "root issuer",
+			issuer: "https://api.workos.com",
+			want:   "https://api.workos.com/oauth2/userinfo",
+		},
+		{
+			name:   "issuer with user management path",
+			issuer: "https://api.workos.com/user_management/client_123",
+			want:   "https://api.workos.com/oauth2/userinfo",
+		},
+		{
+			name:   "custom auth domain",
+			issuer: "https://auth.example.com/",
+			want:   "https://auth.example.com/oauth2/userinfo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := workOSUserInfoURL(tt.issuer)
+			if err != nil {
+				t.Fatalf("workOSUserInfoURL() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("workOSUserInfoURL() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/testing/codex-fix-device-login-email.md
+++ b/testing/codex-fix-device-login-email.md
@@ -1,0 +1,28 @@
+# codex/fix-device-login-email — Test Contract
+
+## Functional Behavior
+- A browser-authenticated user approving CLI device login should still end up with an email in backend auth/session responses even when the WorkOS access token omits the `email` claim.
+- The backend should fetch user identity from a trustworthy WorkOS source, not from a client-supplied JSON field.
+- Existing users with blank stored emails should be backfilled when WorkOS user info returns an email.
+- If the WorkOS userinfo lookup fails, an otherwise valid authenticated request should still succeed for existing users, and login should not regress beyond today's behavior.
+- CLI `auth login` should continue printing the best available identity, and device-login users with a recovered backend email should see the email instead of only `user_id`.
+
+## Unit Tests
+- `TestWorkOSAuthenticator_FallsBackToUserInfoEmailWhenClaimMissing` — fetches WorkOS userinfo with the bearer token, backfills the existing blank email, and returns the recovered email.
+- `TestWorkOSAuthenticator_UserInfoFailureDoesNotBlockExistingUserAuth` — logs in an existing user without failing auth when the WorkOS userinfo call errors.
+- `TestWorkOSUserInfoURL` — derives the correct `/oauth2/userinfo` endpoint from both root issuers and issuers that include a `/user_management/...` path.
+
+## Integration / Functional Tests
+- `cli/cmd` login fallback tests remain green, proving the CLI still prints email when `/v1/auth/session` includes it.
+- Protected device-approval auth continues to use the normal WorkOS-authenticated backend path with no public API trust change.
+
+## Smoke Tests
+- `cd backend && go test ./internal/api`
+- `cd cli && go test ./cmd ./internal/auth`
+
+## E2E Tests
+- N/A — not applicable for this change.
+
+## Manual / cURL Tests
+- Log in on staging with a WorkOS account whose backend user row has a blank email and run `agentclash auth login`; verify the success output shows the email instead of only the `user_id`.
+- Run `agentclash auth status` after the device login and verify the `Email` field is populated.


### PR DESCRIPTION
## Summary
- recover missing emails for WorkOS-authenticated requests by falling back to the WorkOS `userinfo` endpoint when the JWT omits the `email` claim
- backfill blank stored emails from that trusted WorkOS identity so CLI device login can show the email instead of only `user_id`
- keep authentication resilient when userinfo lookup or email backfill fails, and add regression coverage for the new path

## Testing
- `cd backend && go test ./internal/api`
- `cd cli && go test ./cmd ./internal/auth`
- `git diff --check`

## Contract
- `testing/codex-fix-device-login-email.md`
