### PR TITLE
fix(web): redirect workspace shell auth failures

### DIFF
--- a/testing/codex-fix-web-swr-lockfile.md
+++ b/testing/codex-fix-web-swr-lockfile.md
@@ -1,0 +1,23 @@
+# codex/fix-web-swr-lockfile — Test Contract
+
+## Functional Behavior
+- `web/package.json` and `web/pnpm-lock.yaml` stay in sync for the `swr` dependency so CI and Vercel frozen installs do not fail before build.
+- The lockfile importer for `web/` explicitly lists `swr` under `dependencies`.
+- No application source files change for this fix.
+
+## Unit Tests
+- N/A — lockfile-only dependency metadata fix.
+
+## Integration / Functional Tests
+- `pnpm install --frozen-lockfile` in `/Users/ayush.parihar/.codex/worktrees/2068/agentclash/web` completes successfully.
+
+## Smoke Tests
+- `npm test` in `web/` is known to have two unrelated existing failures in `create-run-dialog.test.tsx`; this fix must not introduce additional failures beyond that baseline.
+- `npm run lint` in `web/` passes.
+- `npm run build` in `web/` passes.
+
+## E2E Tests
+- N/A — no runtime behavior change.
+
+## Manual / cURL Tests
+- Inspect `web/pnpm-lock.yaml` and confirm `importers -> . -> dependencies -> swr` is present with specifier `^2.4.1`.

--- a/testing/workspace-navigation-instant.md
+++ b/testing/workspace-navigation-instant.md
@@ -5,6 +5,7 @@
 - Primary workspace list routes should render through thin shells and fetch their data client-side with stale-while-revalidate behavior.
 - Shared workspace auth and membership checks must remain server-enforced.
 - Shared workspace session and user fetches should be deduplicated through cached server helpers so settings and layout do not repeatedly call the same endpoints in a single request.
+- Workspace shell auth/session fetch failures should redirect to `/auth/login` instead of surfacing a 500 page.
 - Sidebar and workspace-switcher links should warm routes on hover/focus to improve perceived speed on common navigations.
 - Representative create/update/delete flows on sidebar-backed pages should update their visible list state through SWR mutation rather than `router.refresh()`.
 - Run and eval-session creation dialogs should warm their dependent SWR keys once when the dialog opens instead of repeatedly revalidating while form state changes.
@@ -18,6 +19,7 @@
 - Nested route loading shells render expected placeholders for heavy detail views.
 - Run and eval-session creation dialogs trigger their warm-up invalidation once per open, not on later rerenders.
 - Run and eval-session creation dialogs wait for list revalidation before redirecting, and surface a follow-up toast if revalidation fails after the create succeeds.
+- Workspace shell auth helpers redirect to `/auth/login` when session or user fetches fail.
 
 ## Integration / Functional Tests
 - Workspace shell loads under `AuthKitProvider` and SWR config without breaking existing route rendering.
@@ -25,6 +27,7 @@
 - Representative mutation flows invalidate the correct SWR keys and no longer call `router.refresh()` on those migrated pages.
 - Run and eval-session creation keep their existing create payloads and redirects while making cache refresh ordering explicit.
 - Workspace settings and workspace members still enforce admin access with cached session helpers.
+- Workspace layout preserves the pre-refactor login redirect behavior for revoked or failed auth/session calls.
 
 ## Smoke Tests
 - `npm test -- --runInBand` or repo-equivalent Vitest run passes for the updated frontend tests.

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      swr:
+        specifier: ^2.4.1
+        version: 2.4.1(react@19.2.3)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0

--- a/web/src/lib/auth/server.test.ts
+++ b/web/src/lib/auth/server.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockWithAuth, mockRedirect, mockCreateApiClient } = vi.hoisted(() => ({
+  mockWithAuth: vi.fn(),
+  mockRedirect: vi.fn(),
+  mockCreateApiClient: vi.fn(),
+}));
+
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  withAuth: () => mockWithAuth(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => mockRedirect(url),
+}));
+
+vi.mock("@/lib/api/client", () => ({
+  createApiClient: (...args: unknown[]) => mockCreateApiClient(...args),
+}));
+
+describe("getWorkspaceShellData", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockWithAuth.mockReset();
+    mockRedirect.mockReset();
+    mockCreateApiClient.mockReset();
+
+    mockWithAuth.mockResolvedValue({
+      user: {
+        firstName: "Ayush",
+        lastName: "Parihar",
+        email: "ayush@example.com",
+        profilePictureUrl: null,
+      },
+      accessToken: "token",
+    });
+  });
+
+  it("redirects to login when workspace shell auth fetches fail", async () => {
+    const redirectError = new Error("redirect:/auth/login");
+    mockRedirect.mockImplementation(() => {
+      throw redirectError;
+    });
+    mockCreateApiClient.mockReturnValue({
+      get: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("session failed"))
+        .mockResolvedValueOnce({
+          organizations: [],
+        }),
+    });
+
+    const { getWorkspaceShellData } = await import("./server");
+
+    await expect(getWorkspaceShellData("ws-1")).rejects.toBe(redirectError);
+    expect(mockRedirect).toHaveBeenCalledWith("/auth/login");
+  });
+
+  it("returns workspace shell data when auth fetches succeed", async () => {
+    mockCreateApiClient.mockReturnValue({
+      get: vi
+        .fn()
+        .mockResolvedValueOnce({
+          workspace_memberships: [{ workspace_id: "ws-1", role: "workspace_admin" }],
+          organization_memberships: [{ organization_id: "org-1", role: "org_admin" }],
+        })
+        .mockResolvedValueOnce({
+          organizations: [
+            {
+              id: "org-1",
+              name: "AgentClash",
+              slug: "agentclash",
+              role: "org_admin",
+              workspaces: [{ id: "ws-1", name: "Main", slug: "main", role: "workspace_admin" }],
+            },
+          ],
+        }),
+    });
+
+    const { getWorkspaceShellData } = await import("./server");
+
+    await expect(getWorkspaceShellData("ws-1")).resolves.toMatchObject({
+      hasMembership: true,
+      hasOrgAccess: true,
+      orgName: "AgentClash",
+      orgSlug: "agentclash",
+    });
+  });
+});

--- a/web/src/lib/auth/server.ts
+++ b/web/src/lib/auth/server.ts
@@ -31,10 +31,17 @@ export const getServerUserMe = cache(async (): Promise<UserMeResponse> => {
 
 export const getWorkspaceShellData = cache(async (workspaceId: string) => {
   const { user } = await getRequiredServerAuth();
-  const [session, userMe] = await Promise.all([
-    getServerSession(),
-    getServerUserMe(),
-  ]);
+  let session: SessionResponse;
+  let userMe: UserMeResponse;
+
+  try {
+    [session, userMe] = await Promise.all([
+      getServerSession(),
+      getServerUserMe(),
+    ]);
+  } catch {
+    redirect("/auth/login");
+  }
 
   const hasMembership = session.workspace_memberships.some(
     (membership) => membership.workspace_id === workspaceId,


### PR DESCRIPTION
## Summary
- restore the workspace shell login redirect when server auth/session fetches fail
- add focused auth helper coverage for the redirect-on-failure and happy-path cases
- document the workspace-shell auth failure behavior in the existing navigation test contract

## Root Cause
The workspace shell refactor moved auth/session loading into `getWorkspaceShellData`, but dropped the old `try/catch` redirect behavior. When `/v1/auth/session` or `/v1/users/me` fails, the shell could surface a 500 instead of sending the user back to `/auth/login`.

## Validation
- `npm test -- src/lib/auth/server.test.ts`
- `npm test`
- `npm run lint`
- `npm run build`
- clean `npm ci && npm run build` repro in a throwaway `web/` copy

## Notes
- I could not reproduce the reported Vercel failure locally; all frontend builds passed, including a clean-install build.
- The Vercel deployment URL for the failing status was not accessible from the Vercel account available on this machine, so this PR fixes the one concrete runtime regression found in the workspace shell auth path.