### PR TITLE
[codex] fix workspace auth hydration after login

### DIFF
--- a/testing/workspace-navigation-instant.md
+++ b/testing/workspace-navigation-instant.md
@@ -3,6 +3,7 @@
 ## Functional Behavior
 - Workspace sidebar navigation should respond immediately by showing a loading shell instead of waiting on the next server-rendered page payload.
 - Primary workspace list routes should render through thin shells and fetch their data client-side with stale-while-revalidate behavior.
+- Protected workspace and org routes should hydrate AuthKit from server-provided auth state so client components do not start from an anonymous auth context after login.
 - Shared workspace auth and membership checks must remain server-enforced.
 - Shared workspace session and user fetches should be deduplicated through cached server helpers so settings and layout do not repeatedly call the same endpoints in a single request.
 - Workspace shell auth/session fetch failures should redirect to `/auth/login` instead of surfacing a 500 page.
@@ -23,6 +24,7 @@
 
 ## Integration / Functional Tests
 - Workspace shell loads under `AuthKitProvider` and SWR config without breaking existing route rendering.
+- The first client-side workspace data fetch after login does not emit an unauthorized `401` caused by missing hydration state.
 - `runs`, `builds`, `deployments`, `challenge-packs`, `playgrounds`, `regression-suites`, `runtime-profiles`, `provider-accounts`, `model-aliases`, `tools`, `knowledge-sources`, `artifacts`, and `secrets` fetch via SWR and render their empty/table states correctly.
 - Representative mutation flows invalidate the correct SWR keys and no longer call `router.refresh()` on those migrated pages.
 - Run and eval-session creation keep their existing create payloads and redirects while making cache refresh ordering explicit.
@@ -33,12 +35,14 @@
 - `npm test -- --runInBand` or repo-equivalent Vitest run passes for the updated frontend tests.
 - `npm run build` for `web/` completes successfully.
 - Opening the app and clicking between primary sidebar destinations shows a loading shell immediately and then hydrated data.
+- Logging in and landing on the default workspace route does not show a first-load `401` or a React crash before data appears.
 
 ## E2E Tests
 - N/A — there is no dedicated browser E2E suite in this change.
 
 ## Manual / cURL Tests
 - Manual: start the frontend, open a workspace, and click between `Runs`, `Builds`, `Deployments`, `Challenge Packs`, `Playgrounds`, and `Secrets`; confirm the page body swaps to a skeleton immediately instead of pausing on the previous page.
+- Manual: sign in from a fresh browser session and let the app redirect to the default workspace route; confirm the first list load does not make an unauthorized request or surface a React hook-order crash.
 - Manual: hover or focus major sidebar links, then click them; confirm repeated visits feel warmer than the first navigation.
 - Manual: create a build, deployment, challenge pack, run, eval session, regression suite, artifact upload, and secret; confirm each affected list updates without a full page refresh.
 - Manual: open the run and eval-session dialogs, interact with multiple fields, and confirm dependent data is warmed once on open rather than re-fetching on every keystroke.

--- a/web/src/app/(org)/orgs/[orgSlug]/layout.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/layout.tsx
@@ -1,6 +1,7 @@
-import { withAuth } from "@workos-inc/authkit-nextjs";
 import { redirect, notFound } from "next/navigation";
+import { AuthenticatedAppProviders } from "@/app/providers";
 import { createApiClient } from "@/lib/api/client";
+import { getRequiredServerAuth, toInitialAuth } from "@/lib/auth/server";
 import type { UserMeResponse, SessionResponse } from "@/lib/api/types";
 import { OrgSettingsSidebar } from "./org-settings-sidebar";
 import { OrgProvider } from "./org-context";
@@ -12,8 +13,9 @@ export default async function OrgLayout({
   children: React.ReactNode;
   params: Promise<{ orgSlug: string }>;
 }) {
-  const { user, accessToken } = await withAuth();
-  if (!user) redirect("/auth/login");
+  const auth = await getRequiredServerAuth();
+  const { accessToken } = auth;
+  const initialAuth = toInitialAuth(auth);
 
   const { orgSlug } = await params;
 
@@ -35,25 +37,27 @@ export default async function OrgLayout({
   const isAdmin = org.role === "org_admin";
 
   return (
-    <OrgProvider
-      value={{
-        orgId: org.id,
-        orgSlug: org.slug,
-        orgName: org.name,
-        isAdmin,
-        currentUserId: session.user_id,
-      }}
-    >
-      <div className="flex min-h-screen">
-        <OrgSettingsSidebar
-          orgSlug={orgSlug}
-          orgName={org.name}
-          isAdmin={isAdmin}
-        />
-        <main className="flex-1 overflow-y-auto p-6 max-w-4xl">
-          {children}
-        </main>
-      </div>
-    </OrgProvider>
+    <AuthenticatedAppProviders initialAuth={initialAuth}>
+      <OrgProvider
+        value={{
+          orgId: org.id,
+          orgSlug: org.slug,
+          orgName: org.name,
+          isAdmin,
+          currentUserId: session.user_id,
+        }}
+      >
+        <div className="flex min-h-screen">
+          <OrgSettingsSidebar
+            orgSlug={orgSlug}
+            orgName={org.name}
+            isAdmin={isAdmin}
+          />
+          <main className="flex-1 overflow-y-auto p-6 max-w-4xl">
+            {children}
+          </main>
+        </div>
+      </OrgProvider>
+    </AuthenticatedAppProviders>
   );
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/layout.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/layout.tsx
@@ -1,4 +1,5 @@
-import { getWorkspaceShellData } from "@/lib/auth/server";
+import { AuthenticatedAppProviders } from "@/app/providers";
+import { getRequiredInitialAuth, getWorkspaceShellData } from "@/lib/auth/server";
 import { Sidebar } from "@/components/app-shell/sidebar";
 import { TopBar } from "@/components/app-shell/top-bar";
 
@@ -10,6 +11,7 @@ export default async function WorkspaceLayout({
   params: Promise<{ workspaceId: string }>;
 }) {
   const { workspaceId } = await params;
+  const initialAuth = await getRequiredInitialAuth();
   const {
     user,
     userMe,
@@ -39,20 +41,22 @@ export default async function WorkspaceLayout({
   }
 
   return (
-    <div className="flex h-screen overflow-hidden">
-      <Sidebar workspaceId={workspaceId} />
-      <div className="flex flex-1 flex-col overflow-hidden">
-        <TopBar
-          workspaceId={workspaceId}
-          organizations={userMe.organizations}
-          displayName={user.firstName ? `${user.firstName} ${user.lastName ?? ""}`.trim() : undefined}
-          email={user.email ?? undefined}
-          avatarUrl={user.profilePictureUrl ?? undefined}
-          orgName={orgName}
-          orgSlug={orgSlug}
-        />
-        <main className="flex-1 overflow-y-auto p-6">{children}</main>
+    <AuthenticatedAppProviders initialAuth={initialAuth}>
+      <div className="flex h-screen overflow-hidden">
+        <Sidebar workspaceId={workspaceId} />
+        <div className="flex flex-1 flex-col overflow-hidden">
+          <TopBar
+            workspaceId={workspaceId}
+            organizations={userMe.organizations}
+            displayName={user.firstName ? `${user.firstName} ${user.lastName ?? ""}`.trim() : undefined}
+            email={user.email ?? undefined}
+            avatarUrl={user.profilePictureUrl ?? undefined}
+            orgName={orgName}
+            orgSlug={orgSlug}
+          />
+          <main className="flex-1 overflow-y-auto p-6">{children}</main>
+        </div>
       </div>
-    </div>
+    </AuthenticatedAppProviders>
   );
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.test.tsx
@@ -432,6 +432,7 @@ describe("CreateRunDialog", () => {
           regression_suite_ids: ["suite-1"],
           regression_case_ids: ["case-1"],
           official_pack_mode: "suite_only",
+          race_context: false,
         });
       });
     } finally {
@@ -674,6 +675,7 @@ describe("CreateRunDialog", () => {
           regression_suite_ids: undefined,
           regression_case_ids: undefined,
           official_pack_mode: undefined,
+          race_context: false,
         });
       });
     } finally {

--- a/web/src/app/onboard/page.tsx
+++ b/web/src/app/onboard/page.tsx
@@ -1,12 +1,13 @@
-import { withAuth } from "@workos-inc/authkit-nextjs";
 import { redirect } from "next/navigation";
+import { AuthenticatedAppProviders } from "@/app/providers";
 import { getServerApiClient } from "@/lib/api/server";
+import { getRequiredServerAuth, toInitialAuth } from "@/lib/auth/server";
 import type { SessionResponse } from "@/lib/api/types";
 import { OnboardingWizard } from "./onboarding-wizard";
 
 export default async function OnboardPage() {
-  const { user } = await withAuth();
-  if (!user) redirect("/auth/login");
+  const auth = await getRequiredServerAuth();
+  const initialAuth = toInitialAuth(auth);
 
   // Check if already onboarded — fetch outside redirect logic.
   let session: SessionResponse | null = null;
@@ -32,5 +33,9 @@ export default async function OnboardPage() {
     }
   }
 
-  return <OnboardingWizard />;
+  return (
+    <AuthenticatedAppProviders initialAuth={initialAuth}>
+      <OnboardingWizard />
+    </AuthenticatedAppProviders>
+  );
 }

--- a/web/src/app/providers.tsx
+++ b/web/src/app/providers.tsx
@@ -1,32 +1,45 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 import { AuthKitProvider, useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import type { NoUserInfo, UserInfo } from "@workos-inc/authkit-nextjs";
 import { SWRConfig } from "swr";
 import { createSWRApiFetcher } from "@/lib/api/swr";
 
+export type InitialAuth = Omit<UserInfo | NoUserInfo, "accessToken">;
+
 function WorkspaceDataProvider({ children }: { children: ReactNode }) {
   const { getAccessToken } = useAccessToken();
+  const swrConfig = useMemo(
+    () => ({
+      fetcher: createSWRApiFetcher(getAccessToken),
+      keepPreviousData: true,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: true,
+      dedupingInterval: 2_000,
+      shouldRetryOnError: false,
+    }),
+    [getAccessToken],
+  );
 
   return (
-    <SWRConfig
-      value={{
-        fetcher: createSWRApiFetcher(getAccessToken),
-        keepPreviousData: true,
-        revalidateOnFocus: false,
-        revalidateOnReconnect: true,
-        dedupingInterval: 2_000,
-        shouldRetryOnError: false,
-      }}
-    >
-      {children}
-    </SWRConfig>
+    <SWRConfig value={swrConfig}>{children}</SWRConfig>
   );
 }
 
 export function AppProviders({ children }: { children: ReactNode }) {
+  return <AuthKitProvider>{children}</AuthKitProvider>;
+}
+
+export function AuthenticatedAppProviders({
+  children,
+  initialAuth,
+}: {
+  children: ReactNode;
+  initialAuth: InitialAuth;
+}) {
   return (
-    <AuthKitProvider>
+    <AuthKitProvider initialAuth={initialAuth}>
       <WorkspaceDataProvider>{children}</WorkspaceDataProvider>
     </AuthKitProvider>
   );

--- a/web/src/lib/auth/server.ts
+++ b/web/src/lib/auth/server.ts
@@ -1,8 +1,11 @@
 import { cache } from "react";
 import { withAuth } from "@workos-inc/authkit-nextjs";
+import type { NoUserInfo, UserInfo } from "@workos-inc/authkit-nextjs";
 import { redirect } from "next/navigation";
 import { createApiClient, type ApiClient } from "@/lib/api/client";
 import type { SessionResponse, UserMeResponse } from "@/lib/api/types";
+
+export type InitialAuth = Omit<UserInfo | NoUserInfo, "accessToken">;
 
 export const getServerAuth = cache(async () => withAuth());
 
@@ -13,6 +16,16 @@ export const getRequiredServerAuth = cache(async () => {
   }
   return auth;
 });
+
+export function toInitialAuth(auth: UserInfo | NoUserInfo): InitialAuth {
+  const initialAuth = { ...auth } as Partial<UserInfo | NoUserInfo>;
+  Reflect.deleteProperty(initialAuth, "accessToken");
+  return initialAuth as InitialAuth;
+}
+
+export const getRequiredInitialAuth = cache(
+  async (): Promise<InitialAuth> => toInitialAuth(await getRequiredServerAuth()),
+);
 
 export const getServerApiClient = cache(async (): Promise<ApiClient> => {
   const { accessToken } = await getRequiredServerAuth();


### PR DESCRIPTION
## What changed
- seed AuthKit on protected workspace, org, and onboarding routes from server auth
- keep SWR-backed protected client trees under an authenticated provider from first paint
- update the workspace navigation test contract for the first-load auth regression
- align stale run-dialog test expectations with the current `race_context: false` payload

## Why
The workspace navigation refactor moved protected list pages to client-side SWR fetching. After login, those pages could mount before AuthKit had hydrated user/session state on the client, so the first request to routes like `/workspaces/:id/runs` could go out without a bearer token, return `401`, and leave the page in a broken state.

## Impact
- login to workspace should no longer hit an initial unauthorized fetch on the first protected page load
- the runs page should stop crashing during the login -> workspace redirect path
- protected org and onboarding client flows now start from the same server-authenticated state

## Root cause
Protected routes were rendered under a plain client `AuthKitProvider` with no `initialAuth`, while the new SWR fetcher depended on `useAccessToken()` immediately on mount.

## Validation
- `npx eslint src`
- `npm test`
- `npm run build`
