### PR TITLE
[codex] Add workflow-first CLI eval commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,11 @@ export AGENTCLASH_API_URL="https://staging-api.agentclash.dev"
 
 cd cli
 go run . auth login --device
-go run . workspace list
-go run . workspace use <workspace-id>
+go run . link
 go run . run list
-go run . run create --help
+go run . eval start --help
 # When the workspace already has challenge packs and deployments:
-go run . run create --follow
+go run . eval start --follow
 ```
 
 Resolution order is `--api-url` > `AGENTCLASH_API_URL` > saved user config > default. Source builds (`go run .`, `make build`) default to `http://localhost:8080`; released binaries default to `https://api.agentclash.dev`. Set `AGENTCLASH_API_URL=https://staging-api.agentclash.dev` for staging.
@@ -114,13 +113,17 @@ Resolution order is `--api-url` > `AGENTCLASH_API_URL` > saved user config > def
 ### Quick start
 
 ```bash
-agentclash auth login                  # Authenticate
-agentclash workspace use <id>          # Set default workspace
-agentclash run create --follow         # Start an evaluation with interactive selection
-agentclash run ranking <run-id>        # View results
-agentclash compare gate \              # CI/CD quality gate
-  --baseline <run1> --candidate <run2>
+agentclash auth login                           # Authenticate
+agentclash link                                 # Pick and save your default workspace
+agentclash challenge-pack init support-eval.yaml
+agentclash challenge-pack validate support-eval.yaml
+agentclash challenge-pack publish support-eval.yaml
+agentclash eval start --follow                  # Start an evaluation with guided selection
+agentclash baseline set                         # Bookmark a baseline run
+agentclash eval scorecard                       # View scorecard + regression verdict
 ```
+
+If your workspace is already seeded with challenge packs and deployments, you can skip the authoring commands and start at `agentclash eval start --follow`.
 
 ### CI/CD
 
@@ -150,6 +153,9 @@ go vet ./...
 go test -short -race -count=1 ./...
 go run github.com/goreleaser/goreleaser/v2@latest check
 go run github.com/goreleaser/goreleaser/v2@latest release --snapshot --clean
+cd ../web && pnpm build
+cd ..
+bash testing/cli-e2e-suite.sh --help
 ```
 
 If you changed packaging or install behavior, rehearse the npm packages locally from the snapshot artifacts:

--- a/cli/cmd/baseline.go
+++ b/cli/cmd/baseline.go
@@ -1,0 +1,169 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/agentclash/agentclash/cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(baselineCmd)
+	baselineCmd.AddCommand(baselineSetCmd)
+	baselineCmd.AddCommand(baselineShowCmd)
+	baselineCmd.AddCommand(baselineClearCmd)
+
+	baselineSetCmd.Flags().String("agent", "", "Run agent ID or label (optional)")
+}
+
+var baselineCmd = &cobra.Command{
+	Use:   "baseline",
+	Short: "Manage the workspace-scoped default baseline run",
+}
+
+var baselineSetCmd = &cobra.Command{
+	Use:   "set [run]",
+	Short: "Bookmark a run as the default baseline for the current workspace",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		workspaceID := RequireWorkspace(cmd)
+
+		var (
+			run runWorkflowSummary
+			err error
+		)
+		switch len(args) {
+		case 0:
+			run, err = selectRunSummaryInteractively(cmd, rc, workspaceID)
+		default:
+			run, err = resolveRunSummary(cmd, rc, workspaceID, args[0])
+		}
+		if err != nil {
+			return err
+		}
+
+		agentSelector, _ := cmd.Flags().GetString("agent")
+		runAgent, err := resolveRunAgentSummary(cmd, rc, run.ID, agentSelector)
+		if err != nil {
+			return err
+		}
+
+		bookmark := config.BaselineBookmark{
+			RunID:         run.ID,
+			RunAgentID:    runAgent.ID,
+			RunName:       displayRunSummary(run),
+			RunAgentLabel: displayRunAgentSummary(runAgent),
+			SetAt:         time.Now().UTC().Format(time.RFC3339),
+		}
+
+		cfg := rc.Config.UserConfig()
+		cfg.SetBaselineBookmark(workspaceID, bookmark)
+		if err := config.Save(*cfg); err != nil {
+			return fmt.Errorf("saving config: %w", err)
+		}
+
+		result := map[string]any{
+			"workspace_id": workspaceID,
+			"bookmark":     bookmark,
+		}
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(result)
+		}
+
+		rc.Output.PrintSuccess(fmt.Sprintf("Saved baseline for workspace %s", workspaceID))
+		rc.Output.PrintDetail("Run", fmt.Sprintf("%s (%s)", bookmark.RunName, bookmark.RunID))
+		rc.Output.PrintDetail("Agent", fmt.Sprintf("%s (%s)", bookmark.RunAgentLabel, bookmark.RunAgentID))
+		rc.Output.PrintDetail("Saved At", bookmark.SetAt)
+		return nil
+	},
+}
+
+var baselineShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show the default baseline run for the current workspace",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		workspaceID := RequireWorkspace(cmd)
+
+		bookmark, ok := rc.Config.BaselineBookmark(workspaceID)
+		result := map[string]any{
+			"workspace_id": workspaceID,
+			"configured":   ok,
+		}
+		if ok {
+			result["bookmark"] = bookmark
+		}
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(result)
+		}
+
+		if !ok {
+			rc.Output.PrintWarning("No baseline is set for this workspace. Run 'agentclash baseline set'.")
+			return nil
+		}
+
+		rc.Output.PrintDetail("Run", fmt.Sprintf("%s (%s)", fallbackDisplay(bookmark.RunName, bookmark.RunID), bookmark.RunID))
+		if bookmark.RunAgentID != "" {
+			rc.Output.PrintDetail("Agent", fmt.Sprintf("%s (%s)", fallbackDisplay(bookmark.RunAgentLabel, bookmark.RunAgentID), bookmark.RunAgentID))
+		}
+		if bookmark.SetAt != "" {
+			rc.Output.PrintDetail("Saved At", bookmark.SetAt)
+		}
+		return nil
+	},
+}
+
+var baselineClearCmd = &cobra.Command{
+	Use:   "clear",
+	Short: "Clear the default baseline run for the current workspace",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		workspaceID := RequireWorkspace(cmd)
+
+		cfg := rc.Config.UserConfig()
+		cleared := cfg.ClearBaselineBookmark(workspaceID)
+		if cleared {
+			if err := config.Save(*cfg); err != nil {
+				return fmt.Errorf("saving config: %w", err)
+			}
+		}
+
+		result := map[string]any{
+			"workspace_id": workspaceID,
+			"cleared":      cleared,
+		}
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(result)
+		}
+
+		if cleared {
+			rc.Output.PrintSuccess(fmt.Sprintf("Cleared baseline for workspace %s", workspaceID))
+			return nil
+		}
+		rc.Output.PrintWarning("No baseline was configured for this workspace.")
+		return nil
+	},
+}
+
+func displayRunSummary(run runWorkflowSummary) string {
+	if run.Name != "" {
+		return run.Name
+	}
+	return run.ID
+}
+
+func displayRunAgentSummary(agent runAgentWorkflowSummary) string {
+	if agent.Label != "" {
+		return agent.Label
+	}
+	return agent.ID
+}
+
+func fallbackDisplay(primary, fallback string) string {
+	if primary != "" {
+		return primary
+	}
+	return fallback
+}

--- a/cli/cmd/baseline_test.go
+++ b/cli/cmd/baseline_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/agentclash/agentclash/cli/internal/config"
+)
+
+func TestBaselineSetStoresWorkspaceScopedBookmark(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/runs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "run-1", "workspace_id": "ws-1", "name": "Candidate", "status": "completed"},
+			},
+		}),
+		"GET /v1/runs/run-1/agents": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "agent-1", "run_id": "run-1", "label": "candidate", "status": "completed"},
+			},
+		}),
+	})
+	defer srv.Close()
+
+	if err := executeCommand(t, []string{"baseline", "set", "run-1", "-w", "ws-1"}, srv.URL); err != nil {
+		t.Fatalf("baseline set error: %v", err)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	bookmark, ok := cfg.BaselineBookmarkForWorkspace("ws-1")
+	if !ok {
+		t.Fatal("expected baseline bookmark for ws-1")
+	}
+	if bookmark.RunID != "run-1" {
+		t.Fatalf("run_id = %q, want run-1", bookmark.RunID)
+	}
+	if bookmark.RunAgentID != "agent-1" {
+		t.Fatalf("run_agent_id = %q, want agent-1", bookmark.RunAgentID)
+	}
+}
+
+func TestBaselineClearRemovesBookmark(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	if err := config.Save(config.UserConfig{
+		BaselineBookmarks: map[string]config.BaselineBookmark{
+			"ws-1": {RunID: "run-1", RunAgentID: "agent-1"},
+		},
+	}); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	if err := executeCommand(t, []string{"baseline", "clear", "-w", "ws-1"}, "http://unused"); err != nil {
+		t.Fatalf("baseline clear error: %v", err)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if _, ok := cfg.BaselineBookmarkForWorkspace("ws-1"); ok {
+		t.Fatal("expected baseline bookmark to be cleared")
+	}
+}
+
+func TestBaselineShowReportsNoBookmarkInJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	stdout := captureStdout(t)
+	if err := executeCommand(t, []string{"baseline", "show", "-w", "ws-1", "--json"}, "http://unused"); err != nil {
+		t.Fatalf("baseline show error: %v", err)
+	}
+
+	out := stdout.finish()
+	if !strings.Contains(out, "\"configured\": false") {
+		t.Fatalf("baseline show output missing configured=false\n---\n%s", out)
+	}
+}

--- a/cli/cmd/challenge_pack.go
+++ b/cli/cmd/challenge_pack.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/agentclash/agentclash/cli/internal/output"
 	"github.com/spf13/cobra"
@@ -244,7 +246,8 @@ func defaultChallengePackName(targetPath string) string {
 		if part == "" {
 			continue
 		}
-		parts[i] = strings.ToUpper(part[:1]) + strings.ToLower(part[1:])
+		r, sz := utf8.DecodeRuneInString(part)
+		parts[i] = string(unicode.ToUpper(r)) + strings.ToLower(part[sz:])
 	}
 	return strings.Join(parts, " ")
 }

--- a/cli/cmd/challenge_pack.go
+++ b/cli/cmd/challenge_pack.go
@@ -4,16 +4,25 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/agentclash/agentclash/cli/internal/output"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func init() {
 	rootCmd.AddCommand(challengePackCmd)
 	challengePackCmd.AddCommand(cpListCmd)
+	challengePackCmd.AddCommand(cpInitCmd)
 	challengePackCmd.AddCommand(cpPublishCmd)
 	challengePackCmd.AddCommand(cpValidateCmd)
+
+	cpInitCmd.Flags().String("template", "prompt_eval", "Starter template: prompt_eval or native")
+	cpInitCmd.Flags().String("name", "", "Challenge pack display name (defaults from the file name)")
+	cpInitCmd.Flags().String("slug", "", "Challenge pack slug (defaults from the file name)")
+	cpInitCmd.Flags().Bool("force", false, "Overwrite an existing file")
 }
 
 var challengePackCmd = &cobra.Command{
@@ -64,6 +73,70 @@ var cpListCmd = &cobra.Command{
 			}
 		}
 		rc.Output.PrintTable(cols, rows)
+		return nil
+	},
+}
+
+var cpInitCmd = &cobra.Command{
+	Use:   "init <file>",
+	Short: "Scaffold a minimal challenge pack YAML bundle",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		templateMode, _ := cmd.Flags().GetString("template")
+		name, _ := cmd.Flags().GetString("name")
+		slug, _ := cmd.Flags().GetString("slug")
+		force, _ := cmd.Flags().GetBool("force")
+
+		targetPath := args[0]
+		if !force {
+			if _, err := os.Stat(targetPath); err == nil {
+				return fmt.Errorf("%s already exists; pass --force to overwrite", targetPath)
+			}
+		}
+
+		templateMode = strings.TrimSpace(templateMode)
+		switch templateMode {
+		case "prompt_eval", "native":
+		default:
+			return fmt.Errorf("invalid template %q (want prompt_eval or native)", templateMode)
+		}
+
+		defaultName := defaultChallengePackName(targetPath)
+		name = strings.TrimSpace(name)
+		if name == "" {
+			name = defaultName
+		}
+		slug = strings.TrimSpace(slug)
+		if slug == "" {
+			slug = slugifyChallengePackName(name)
+		}
+		if slug == "" {
+			return fmt.Errorf("could not derive a slug from %q; pass --slug explicitly", name)
+		}
+
+		payload, err := buildChallengePackTemplate(name, slug, templateMode)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(targetPath, payload, 0644); err != nil {
+			return fmt.Errorf("writing %s: %w", targetPath, err)
+		}
+
+		result := map[string]any{
+			"path":     targetPath,
+			"name":     name,
+			"slug":     slug,
+			"template": templateMode,
+		}
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(result)
+		}
+
+		rc.Output.PrintSuccess(fmt.Sprintf("Created %s", targetPath))
+		rc.Output.PrintDetail("Name", name)
+		rc.Output.PrintDetail("Slug", slug)
+		rc.Output.PrintDetail("Template", templateMode)
 		return nil
 	},
 }
@@ -152,4 +225,111 @@ var cpValidateCmd = &cobra.Command{
 		}
 		return nil
 	},
+}
+
+func defaultChallengePackName(targetPath string) string {
+	base := filepath.Base(targetPath)
+	ext := filepath.Ext(base)
+	name := strings.TrimSuffix(base, ext)
+	if name == "" {
+		return "Starter Eval"
+	}
+	parts := strings.FieldsFunc(name, func(r rune) bool {
+		return r == '-' || r == '_' || r == ' '
+	})
+	if len(parts) == 0 {
+		return "Starter Eval"
+	}
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(part[:1]) + strings.ToLower(part[1:])
+	}
+	return strings.Join(parts, " ")
+}
+
+func slugifyChallengePackName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	var builder strings.Builder
+	lastHyphen := false
+	for _, r := range name {
+		isAlphaNum := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if isAlphaNum {
+			builder.WriteRune(r)
+			lastHyphen = false
+			continue
+		}
+		if !lastHyphen && builder.Len() > 0 {
+			builder.WriteByte('-')
+			lastHyphen = true
+		}
+	}
+	return strings.Trim(builder.String(), "-")
+}
+
+func buildChallengePackTemplate(name, slug, templateMode string) ([]byte, error) {
+	template := map[string]any{
+		"pack": map[string]any{
+			"slug":   slug,
+			"name":   name,
+			"family": slug,
+		},
+		"version": map[string]any{
+			"number":         1,
+			"execution_mode": templateMode,
+			"evaluation_spec": map[string]any{
+				"name":           slug + "-v1",
+				"version_number": 1,
+				"judge_mode":     "deterministic",
+				"validators": []map[string]any{
+					{
+						"key":           "exact",
+						"type":          "exact_match",
+						"target":        "final_output",
+						"expected_from": "challenge_input",
+					},
+				},
+				"scorecard": map[string]any{
+					"dimensions": []string{"correctness"},
+				},
+			},
+		},
+		"challenges": []map[string]any{
+			{
+				"key":          "task-1",
+				"title":        "Starter Task",
+				"category":     "general",
+				"difficulty":   "medium",
+				"instructions": "Read the request and produce the final answer.\n",
+			},
+		},
+		"input_sets": []map[string]any{
+			{
+				"key":  "default",
+				"name": "Default Inputs",
+				"cases": []map[string]any{
+					{
+						"challenge_key": "task-1",
+						"case_key":      "sample-1",
+						"inputs": []map[string]any{
+							{
+								"key":   "prompt",
+								"kind":  "text",
+								"value": "hello",
+							},
+						},
+						"expectations": []map[string]any{
+							{
+								"key":    "answer",
+								"kind":   "text",
+								"source": "input:prompt",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return yaml.Marshal(template)
 }

--- a/cli/cmd/challenge_pack_init_test.go
+++ b/cli/cmd/challenge_pack_init_test.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestChallengePackInitWritesStarterTemplate(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "support-eval.yaml")
+
+	if err := executeCommand(t, []string{
+		"challenge-pack", "init", target,
+		"--template", "native",
+		"--name", "Support Eval",
+	}, "http://unused"); err != nil {
+		t.Fatalf("challenge-pack init error: %v", err)
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+
+	text := string(data)
+	for _, snippet := range []string{
+		"slug: support-eval",
+		"name: Support Eval",
+		"execution_mode: native",
+		"judge_mode: deterministic",
+	} {
+		if !strings.Contains(text, snippet) {
+			t.Fatalf("challenge-pack init output missing %q\n---\n%s", snippet, text)
+		}
+	}
+}
+
+func TestChallengePackInitRequiresForceToOverwrite(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "support-eval.yaml")
+	if err := os.WriteFile(target, []byte("existing"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	err := executeCommand(t, []string{"challenge-pack", "init", target}, "http://unused")
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("error = %v, want already exists", err)
+	}
+}

--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/agentclash/agentclash/cli/internal/auth"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // executeCommand runs a cobra command with args against a fake API server.
@@ -28,6 +30,7 @@ func executeCommandWithQuiet(t *testing.T, args []string, apiURL string, quiet b
 	cmdMu.Lock()
 	defer cmdMu.Unlock()
 
+	resetCommandFlags(rootCmd)
 	flagJSON = false
 	flagOutput = ""
 	flagQuiet = quiet
@@ -38,25 +41,38 @@ func executeCommandWithQuiet(t *testing.T, args []string, apiURL string, quiet b
 	flagYes = false
 	flagDevice = false
 	flagForceLogin = false
-	if valueFlag := secretSetCmd.Flags().Lookup("value"); valueFlag != nil {
-		valueFlag.Value.Set("")
-		valueFlag.Changed = false
-	}
-	// runCreateCmd flags persist between test calls because cobra stores the
-	// parsed values on the package-level command. Reset the race-context
-	// knobs so absence-assertions (e.g. "field NOT in body") are reliable.
-	for _, flagName := range []string{"race-context", "race-context-cadence"} {
-		if f := runCreateCmd.Flags().Lookup(flagName); f != nil {
-			f.Value.Set(f.DefValue)
-			f.Changed = false
-		}
-	}
 
 	rootCmd.SetArgs(args)
 	return rootCmd.Execute()
 }
 
 var cmdMu sync.Mutex
+
+func resetCommandFlags(cmd *cobra.Command) {
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		resetFlagValue(f)
+	})
+	cmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		resetFlagValue(f)
+	})
+	for _, child := range cmd.Commands() {
+		resetCommandFlags(child)
+	}
+}
+
+type resettableSliceFlag interface {
+	Replace([]string) error
+}
+
+func resetFlagValue(f *pflag.Flag) {
+	if resettable, ok := f.Value.(resettableSliceFlag); ok {
+		_ = resettable.Replace(nil)
+		f.Changed = false
+		return
+	}
+	_ = f.Value.Set(f.DefValue)
+	f.Changed = false
+}
 
 func fakeAPI(t *testing.T, routes map[string]http.HandlerFunc) *httptest.Server {
 	t.Helper()
@@ -98,6 +114,27 @@ func TestVersionCommandSucceeds(t *testing.T) {
 	err := executeCommand(t, []string{"version"}, "http://unused")
 	if err != nil {
 		t.Fatalf("version command should succeed, got: %v", err)
+	}
+}
+
+func TestRootHelpHighlightsWorkflowCommands(t *testing.T) {
+	stdout := captureStdout(t)
+	err := executeCommand(t, []string{"--help"}, "http://unused")
+	if err != nil {
+		t.Fatalf("root help error: %v", err)
+	}
+
+	out := stdout.finish()
+	for _, snippet := range []string{
+		"agentclash link",
+		"agentclash challenge-pack init",
+		"agentclash eval start --follow",
+		"agentclash baseline set",
+		"agentclash eval scorecard",
+	} {
+		if !strings.Contains(out, snippet) {
+			t.Fatalf("root help missing %q\n---\n%s", snippet, out)
+		}
 	}
 }
 

--- a/cli/cmd/contract_alignment_test.go
+++ b/cli/cmd/contract_alignment_test.go
@@ -48,6 +48,45 @@ func TestDeploymentCreateBuildVersionFlagsUseCurrentRequestShape(t *testing.T) {
 	}
 }
 
+func TestRunCreateUsesRegressionSelectorsAndOfficialPackMode(t *testing.T) {
+	var gotBody map[string]any
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/runs": func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "run-1", "status": "queued"})
+		},
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{
+		"run", "create",
+		"-w", "ws-1",
+		"--challenge-pack-version", "ver-1",
+		"--deployments", "dep-1",
+		"--scope", "suite_only",
+		"--suite", "suite-1",
+		"--case", "case-1",
+	}, srv.URL)
+	if err != nil {
+		t.Fatalf("run create error: %v", err)
+	}
+
+	if gotBody["official_pack_mode"] != "suite_only" {
+		t.Fatalf("official_pack_mode = %v, want suite_only", gotBody["official_pack_mode"])
+	}
+	if suiteIDs, ok := gotBody["regression_suite_ids"].([]any); !ok || len(suiteIDs) != 1 || suiteIDs[0] != "suite-1" {
+		t.Fatalf("regression_suite_ids = %#v, want [suite-1]", gotBody["regression_suite_ids"])
+	}
+	if caseIDs, ok := gotBody["regression_case_ids"].([]any); !ok || len(caseIDs) != 1 || caseIDs[0] != "case-1" {
+		t.Fatalf("regression_case_ids = %#v, want [case-1]", gotBody["regression_case_ids"])
+	}
+}
+
 func TestCompareRunsUsesKeyDeltasAndRegressionReasons(t *testing.T) {
 	srv := fakeAPI(t, map[string]http.HandlerFunc{
 		"GET /v1/compare": jsonHandler(200, map[string]any{

--- a/cli/cmd/doctor.go
+++ b/cli/cmd/doctor.go
@@ -27,8 +27,12 @@ var doctorCmd = &cobra.Command{
 
 auth login -> link -> challenge-pack init/publish -> eval start -> baseline set -> eval scorecard
 
-Exits non-zero (code 1) if any check is not 'ok', so this command can be used
-as a CI gate: 'agentclash doctor && agentclash eval start --json'.`,
+Exits non-zero (code 1) when any check reports 'warn' or 'fail', so this
+command can be used as a CI gate: 'agentclash doctor && agentclash eval start --json'.
+
+Checks with status 'info' are advisory only and do not flip ready=false.
+The 'baseline' check is 'info' on a fresh workspace because a baseline can only
+be set after the first eval run completes.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		rc := GetRunContext(cmd)
 
@@ -120,6 +124,23 @@ as a CI gate: 'agentclash doctor && agentclash eval start --json'.`,
 				Detail:   fmt.Sprintf("Could not load workspace %s: %v", workspaceID, err),
 				NextStep: "Run `agentclash link` to relink the workspace.",
 			})
+			appendCheck(doctorCheck{
+				Name:     "challenge_packs",
+				Status:   "warn",
+				Detail:   "Challenge-pack visibility check skipped until workspace is relinked.",
+				NextStep: "Run `agentclash link` to relink the workspace.",
+			})
+			appendCheck(doctorCheck{
+				Name:     "deployments",
+				Status:   "warn",
+				Detail:   "Deployment visibility check skipped until workspace is relinked.",
+				NextStep: "Run `agentclash link` to relink the workspace.",
+			})
+			appendCheck(doctorCheck{
+				Name:   "baseline",
+				Status: "warn",
+				Detail: "Baseline check skipped until workspace is relinked.",
+			})
 			return printDoctorResult(rc, checks)
 		}
 		if apiErr := resp.ParseError(); apiErr != nil {
@@ -128,6 +149,23 @@ as a CI gate: 'agentclash doctor && agentclash eval start --json'.`,
 				Status:   "warn",
 				Detail:   fmt.Sprintf("Workspace %s is not accessible: %s", workspaceID, apiErr.Message),
 				NextStep: "Run `agentclash link` to pick an accessible workspace.",
+			})
+			appendCheck(doctorCheck{
+				Name:     "challenge_packs",
+				Status:   "warn",
+				Detail:   "Challenge-pack visibility check skipped until workspace is relinked.",
+				NextStep: "Run `agentclash link` to pick an accessible workspace.",
+			})
+			appendCheck(doctorCheck{
+				Name:     "deployments",
+				Status:   "warn",
+				Detail:   "Deployment visibility check skipped until workspace is relinked.",
+				NextStep: "Run `agentclash link` to pick an accessible workspace.",
+			})
+			appendCheck(doctorCheck{
+				Name:   "baseline",
+				Status: "warn",
+				Detail: "Baseline check skipped until workspace is relinked.",
 			})
 			return printDoctorResult(rc, checks)
 		}
@@ -212,7 +250,7 @@ as a CI gate: 'agentclash doctor && agentclash eval start --json'.`,
 		} else {
 			appendCheck(doctorCheck{
 				Name:     "baseline",
-				Status:   "warn",
+				Status:   "info",
 				Detail:   "No baseline is bookmarked for this workspace.",
 				NextStep: "After your first run, use `agentclash baseline set`.",
 			})
@@ -234,7 +272,7 @@ func printDoctorResult(rc *RunContext, checks []doctorCheck) error {
 	nextSteps := make([]string, 0, len(checks))
 	seenSteps := make(map[string]struct{}, len(checks))
 	for _, check := range checks {
-		if check.Status != "ok" {
+		if check.Status != "ok" && check.Status != "info" {
 			ready = false
 		}
 		if check.NextStep == "" {

--- a/cli/cmd/doctor.go
+++ b/cli/cmd/doctor.go
@@ -25,7 +25,10 @@ var doctorCmd = &cobra.Command{
 	Short: "Check auth, workspace, and eval readiness",
 	Long: `Inspect the current CLI setup and report whether the happy path is ready:
 
-auth login -> link -> challenge-pack init/publish -> eval start -> baseline set -> eval scorecard`,
+auth login -> link -> challenge-pack init/publish -> eval start -> baseline set -> eval scorecard
+
+Exits non-zero (code 1) if any check is not 'ok', so this command can be used
+as a CI gate: 'agentclash doctor && agentclash eval start --json'.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		rc := GetRunContext(cmd)
 
@@ -252,23 +255,32 @@ func printDoctorResult(rc *RunContext, checks []doctorCheck) error {
 		"next_steps": nextSteps,
 	}
 	if rc.Output.IsStructured() {
-		return rc.Output.PrintRaw(result)
+		if err := rc.Output.PrintRaw(result); err != nil {
+			return err
+		}
+	} else {
+		fmt.Fprintln(rc.Output.Writer(), "AgentClash Doctor")
+		fmt.Fprintln(rc.Output.Writer())
+		for _, check := range checks {
+			fmt.Fprintf(rc.Output.Writer(), "%-18s %s\n", doctorStatusLabel(check.Name), check.Detail)
+			if check.NextStep != "" {
+				fmt.Fprintf(rc.Output.Writer(), "%-18s %s\n", "", "next: "+check.NextStep)
+			}
+		}
+		if len(nextSteps) > 0 {
+			fmt.Fprintln(rc.Output.Writer())
+			fmt.Fprintln(rc.Output.Writer(), "Suggested next steps")
+			for _, step := range nextSteps {
+				fmt.Fprintf(rc.Output.Writer(), "  - %s\n", step)
+			}
+		}
 	}
 
-	fmt.Fprintln(rc.Output.Writer(), "AgentClash Doctor")
-	fmt.Fprintln(rc.Output.Writer())
-	for _, check := range checks {
-		fmt.Fprintf(rc.Output.Writer(), "%-18s %s\n", doctorStatusLabel(check.Name), check.Detail)
-		if check.NextStep != "" {
-			fmt.Fprintf(rc.Output.Writer(), "%-18s %s\n", "", "next: "+check.NextStep)
-		}
-	}
-	if len(nextSteps) > 0 {
-		fmt.Fprintln(rc.Output.Writer())
-		fmt.Fprintln(rc.Output.Writer(), "Suggested next steps")
-		for _, step := range nextSteps {
-			fmt.Fprintf(rc.Output.Writer(), "  - %s\n", step)
-		}
+	if !ready {
+		// Silent ExitCodeError: the rendered output above (table or JSON
+		// envelope with `ready: false`) already conveys the failure state;
+		// main should not print an additional error line.
+		return &ExitCodeError{Code: 1}
 	}
 	return nil
 }

--- a/cli/cmd/doctor.go
+++ b/cli/cmd/doctor.go
@@ -1,0 +1,278 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/agentclash/agentclash/cli/internal/auth"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(doctorCmd)
+}
+
+type doctorCheck struct {
+	Name     string         `json:"name"`
+	Status   string         `json:"status"`
+	Detail   string         `json:"detail"`
+	NextStep string         `json:"next_step,omitempty"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+var doctorCmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "Check auth, workspace, and eval readiness",
+	Long: `Inspect the current CLI setup and report whether the happy path is ready:
+
+auth login -> link -> challenge-pack init/publish -> eval start -> baseline set -> eval scorecard`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+
+		checks := make([]doctorCheck, 0, 6)
+		appendCheck := func(check doctorCheck) {
+			checks = append(checks, check)
+		}
+
+		appendCheck(doctorCheck{
+			Name:   "install",
+			Status: "ok",
+			Detail: fmt.Sprintf("agentclash %s on %s", cliVersion, rc.Client.BaseURL()),
+			Metadata: map[string]any{
+				"version": cliVersion,
+				"api_url": rc.Client.BaseURL(),
+			},
+		})
+
+		authOK := false
+		authResult, authErr := validateDoctorAuth(cmd.Context(), rc)
+		if authErr != nil {
+			appendCheck(doctorCheck{
+				Name:     "auth",
+				Status:   "warn",
+				Detail:   authErr.Error(),
+				NextStep: "Run `agentclash auth login`.",
+			})
+		} else {
+			authOK = true
+			appendCheck(doctorCheck{
+				Name:   "auth",
+				Status: "ok",
+				Detail: fmt.Sprintf("Logged in as %s", loginIdentityLabel(authResult)),
+				Metadata: map[string]any{
+					"user_id": authResult.UserID,
+					"email":   authResult.Email,
+				},
+			})
+		}
+
+		workspaceID := rc.Workspace
+		if !authOK {
+			appendCheck(doctorCheck{
+				Name:     "workspace",
+				Status:   "warn",
+				Detail:   "Workspace check skipped until authentication succeeds.",
+				NextStep: "Run `agentclash auth login`, then `agentclash link`.",
+			})
+			return printDoctorResult(rc, checks)
+		}
+
+		if workspaceID == "" {
+			workspaceCount := 0
+			if choices, err := listAccessibleWorkspaces(cmd, rc); err == nil {
+				workspaceCount = len(choices)
+			}
+			appendCheck(doctorCheck{
+				Name:     "workspace",
+				Status:   "warn",
+				Detail:   fmt.Sprintf("No default workspace is linked (%d accessible workspace(s) found).", workspaceCount),
+				NextStep: "Run `agentclash link`.",
+			})
+			appendCheck(doctorCheck{
+				Name:     "challenge_packs",
+				Status:   "warn",
+				Detail:   "Challenge-pack visibility check skipped until a workspace is linked.",
+				NextStep: "Run `agentclash link`.",
+			})
+			appendCheck(doctorCheck{
+				Name:     "deployments",
+				Status:   "warn",
+				Detail:   "Deployment visibility check skipped until a workspace is linked.",
+				NextStep: "Run `agentclash link`.",
+			})
+			appendCheck(doctorCheck{
+				Name:     "baseline",
+				Status:   "warn",
+				Detail:   "Baseline check skipped until a workspace is linked.",
+				NextStep: "Run `agentclash link`.",
+			})
+			return printDoctorResult(rc, checks)
+		}
+
+		resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+workspaceID+"/details", nil)
+		if err != nil {
+			appendCheck(doctorCheck{
+				Name:     "workspace",
+				Status:   "warn",
+				Detail:   fmt.Sprintf("Could not load workspace %s: %v", workspaceID, err),
+				NextStep: "Run `agentclash link` to relink the workspace.",
+			})
+			return printDoctorResult(rc, checks)
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			appendCheck(doctorCheck{
+				Name:     "workspace",
+				Status:   "warn",
+				Detail:   fmt.Sprintf("Workspace %s is not accessible: %s", workspaceID, apiErr.Message),
+				NextStep: "Run `agentclash link` to pick an accessible workspace.",
+			})
+			return printDoctorResult(rc, checks)
+		}
+
+		var workspace map[string]any
+		if err := resp.DecodeJSON(&workspace); err != nil {
+			return err
+		}
+		appendCheck(doctorCheck{
+			Name:   "workspace",
+			Status: "ok",
+			Detail: fmt.Sprintf("%s (%s)", str(workspace["name"]), workspaceID),
+			Metadata: map[string]any{
+				"workspace_id":   workspaceID,
+				"workspace_name": str(workspace["name"]),
+				"workspace_slug": str(workspace["slug"]),
+			},
+		})
+
+		packs, packErr := listChallengePacksForWorkflow(cmd, rc, workspaceID)
+		if packErr != nil {
+			appendCheck(doctorCheck{
+				Name:     "challenge_packs",
+				Status:   "warn",
+				Detail:   fmt.Sprintf("Could not list challenge packs: %v", packErr),
+				NextStep: "Check workspace access or API connectivity.",
+			})
+		} else if len(packs) == 0 {
+			appendCheck(doctorCheck{
+				Name:     "challenge_packs",
+				Status:   "warn",
+				Detail:   "No challenge packs are published in this workspace.",
+				NextStep: "Run `agentclash challenge-pack init`, `validate`, and `publish`.",
+			})
+		} else {
+			appendCheck(doctorCheck{
+				Name:   "challenge_packs",
+				Status: "ok",
+				Detail: fmt.Sprintf("%d challenge pack(s) visible.", len(packs)),
+				Metadata: map[string]any{
+					"count": len(packs),
+				},
+			})
+		}
+
+		deployments, deploymentErr := listDeploymentsForWorkflow(cmd, rc, workspaceID)
+		if deploymentErr != nil {
+			appendCheck(doctorCheck{
+				Name:     "deployments",
+				Status:   "warn",
+				Detail:   fmt.Sprintf("Could not list deployments: %v", deploymentErr),
+				NextStep: "Check workspace access or API connectivity.",
+			})
+		} else if len(deployments) == 0 {
+			appendCheck(doctorCheck{
+				Name:     "deployments",
+				Status:   "warn",
+				Detail:   "No deployments are available in this workspace.",
+				NextStep: "Create or deploy an agent before starting an eval.",
+			})
+		} else {
+			appendCheck(doctorCheck{
+				Name:   "deployments",
+				Status: "ok",
+				Detail: fmt.Sprintf("%d deployment(s) visible.", len(deployments)),
+				Metadata: map[string]any{
+					"count": len(deployments),
+				},
+			})
+		}
+
+		if bookmark, ok := rc.Config.BaselineBookmark(workspaceID); ok {
+			appendCheck(doctorCheck{
+				Name:   "baseline",
+				Status: "ok",
+				Detail: fmt.Sprintf("Baseline set to %s (%s).", fallbackDisplay(bookmark.RunName, bookmark.RunID), bookmark.RunID),
+				Metadata: map[string]any{
+					"run_id":       bookmark.RunID,
+					"run_agent_id": bookmark.RunAgentID,
+				},
+			})
+		} else {
+			appendCheck(doctorCheck{
+				Name:     "baseline",
+				Status:   "warn",
+				Detail:   "No baseline is bookmarked for this workspace.",
+				NextStep: "After your first run, use `agentclash baseline set`.",
+			})
+		}
+
+		return printDoctorResult(rc, checks)
+	},
+}
+
+func validateDoctorAuth(ctx context.Context, rc *RunContext) (*auth.LoginResult, error) {
+	if rc == nil || rc.Client == nil || rc.Client.Token() == "" {
+		return nil, fmt.Errorf("Not logged in. No API token is configured.")
+	}
+	return auth.ValidateToken(ctx, rc.Client)
+}
+
+func printDoctorResult(rc *RunContext, checks []doctorCheck) error {
+	ready := true
+	nextSteps := make([]string, 0, len(checks))
+	seenSteps := make(map[string]struct{}, len(checks))
+	for _, check := range checks {
+		if check.Status != "ok" {
+			ready = false
+		}
+		if check.NextStep == "" {
+			continue
+		}
+		if _, ok := seenSteps[check.NextStep]; ok {
+			continue
+		}
+		seenSteps[check.NextStep] = struct{}{}
+		nextSteps = append(nextSteps, check.NextStep)
+	}
+
+	result := map[string]any{
+		"ready":      ready,
+		"api_url":    rc.Client.BaseURL(),
+		"workspace":  rc.Workspace,
+		"checks":     checks,
+		"next_steps": nextSteps,
+	}
+	if rc.Output.IsStructured() {
+		return rc.Output.PrintRaw(result)
+	}
+
+	fmt.Fprintln(rc.Output.Writer(), "AgentClash Doctor")
+	fmt.Fprintln(rc.Output.Writer())
+	for _, check := range checks {
+		fmt.Fprintf(rc.Output.Writer(), "%-18s %s\n", doctorStatusLabel(check.Name), check.Detail)
+		if check.NextStep != "" {
+			fmt.Fprintf(rc.Output.Writer(), "%-18s %s\n", "", "next: "+check.NextStep)
+		}
+	}
+	if len(nextSteps) > 0 {
+		fmt.Fprintln(rc.Output.Writer())
+		fmt.Fprintln(rc.Output.Writer(), "Suggested next steps")
+		for _, step := range nextSteps {
+			fmt.Fprintf(rc.Output.Writer(), "  - %s\n", step)
+		}
+	}
+	return nil
+}
+
+func doctorStatusLabel(name string) string {
+	return name + ":"
+}

--- a/cli/cmd/doctor_test.go
+++ b/cli/cmd/doctor_test.go
@@ -127,3 +127,70 @@ func TestDoctorReportsHealthyWorkspace(t *testing.T) {
 		t.Fatalf("doctor reported ready=false: %#v", payload.Checks)
 	}
 }
+
+// TestDoctorReadyWithoutBaselineBookmark pins that a fresh workspace (no
+// baseline bookmark yet) does not block the CI gate. The baseline check is
+// advisory ('info') because a bookmark can only be set after the first run.
+func TestDoctorReadyWithoutBaselineBookmark(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+
+	// Save config with workspace but NO baseline bookmark.
+	if err := config.Save(config.UserConfig{
+		DefaultWorkspace: "ws-1",
+	}); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/auth/session": jsonHandler(200, map[string]any{
+			"user_id": "user-1",
+			"email":   "dev@example.com",
+		}),
+		"GET /v1/workspaces/ws-1/details": jsonHandler(200, map[string]any{
+			"id": "ws-1", "name": "Alpha", "slug": "alpha",
+		}),
+		"GET /v1/workspaces/ws-1/challenge-packs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "pack-1", "name": "Support Eval", "slug": "support-eval"},
+			},
+		}),
+		"GET /v1/workspaces/ws-1/agent-deployments": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "dep-1", "name": "prod", "status": "ready"},
+			},
+		}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	if err := executeCommand(t, []string{"doctor", "--json"}, srv.URL); err != nil {
+		t.Fatalf("doctor error: %v — baseline missing should not block the CI gate", err)
+	}
+
+	var payload struct {
+		Ready  bool          `json:"ready"`
+		Checks []doctorCheck `json:"checks"`
+	}
+	if err := json.Unmarshal([]byte(stdout.finish()), &payload); err != nil {
+		t.Fatalf("Unmarshal() error: %v", err)
+	}
+
+	if !payload.Ready {
+		t.Fatalf("doctor reported ready=false on fresh workspace with no baseline: %#v", payload.Checks)
+	}
+	// The baseline check must be present and have status "info" (advisory).
+	foundBaselineInfo := false
+	for _, check := range payload.Checks {
+		if check.Name == "baseline" {
+			if check.Status != "info" {
+				t.Fatalf("baseline check status = %q, want \"info\"", check.Status)
+			}
+			foundBaselineInfo = true
+		}
+	}
+	if !foundBaselineInfo {
+		t.Fatalf("baseline check missing from doctor output: %#v", payload.Checks)
+	}
+}

--- a/cli/cmd/doctor_test.go
+++ b/cli/cmd/doctor_test.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/agentclash/agentclash/cli/internal/config"
+)
+
+func TestDoctorReportsMissingWorkspaceAndNextStep(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/auth/session": jsonHandler(200, map[string]any{
+			"user_id": "user-1",
+			"email":   "dev@example.com",
+		}),
+		"GET /v1/users/me": jsonHandler(200, map[string]any{
+			"user_id": "user-1",
+			"organizations": []map[string]any{
+				{
+					"id":   "org-1",
+					"name": "Acme",
+					"slug": "acme",
+					"workspaces": []map[string]any{
+						{"id": "ws-1", "name": "Alpha", "slug": "alpha"},
+						{"id": "ws-2", "name": "Beta", "slug": "beta"},
+					},
+				},
+			},
+		}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	if err := executeCommand(t, []string{"doctor", "--json"}, srv.URL); err != nil {
+		t.Fatalf("doctor error: %v", err)
+	}
+
+	var payload struct {
+		Ready     bool          `json:"ready"`
+		NextSteps []string      `json:"next_steps"`
+		Checks    []doctorCheck `json:"checks"`
+	}
+	if err := json.Unmarshal([]byte(stdout.finish()), &payload); err != nil {
+		t.Fatalf("Unmarshal() error: %v", err)
+	}
+
+	if payload.Ready {
+		t.Fatal("doctor unexpectedly reported ready=true")
+	}
+	foundWorkspaceWarning := false
+	for _, check := range payload.Checks {
+		if check.Name == "workspace" && check.Status == "warn" {
+			foundWorkspaceWarning = true
+		}
+	}
+	if !foundWorkspaceWarning {
+		t.Fatalf("doctor checks missing workspace warning: %#v", payload.Checks)
+	}
+	if len(payload.NextSteps) == 0 || payload.NextSteps[0] != "Run `agentclash link`." {
+		t.Fatalf("next steps = %#v, want link guidance", payload.NextSteps)
+	}
+}
+
+func TestDoctorReportsHealthyWorkspace(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+
+	if err := config.Save(config.UserConfig{
+		DefaultWorkspace: "ws-1",
+		BaselineBookmarks: map[string]config.BaselineBookmark{
+			"ws-1": {RunID: "run-base", RunAgentID: "agent-base", RunName: "Baseline"},
+		},
+	}); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/auth/session": jsonHandler(200, map[string]any{
+			"user_id": "user-1",
+			"email":   "dev@example.com",
+		}),
+		"GET /v1/workspaces/ws-1/details": jsonHandler(200, map[string]any{
+			"id": "ws-1", "name": "Alpha", "slug": "alpha",
+		}),
+		"GET /v1/workspaces/ws-1/challenge-packs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "pack-1", "name": "Support Eval", "slug": "support-eval"},
+			},
+		}),
+		"GET /v1/workspaces/ws-1/agent-deployments": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "dep-1", "name": "prod", "status": "ready"},
+			},
+		}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	if err := executeCommand(t, []string{"doctor", "--json"}, srv.URL); err != nil {
+		t.Fatalf("doctor error: %v", err)
+	}
+
+	var payload struct {
+		Ready  bool          `json:"ready"`
+		Checks []doctorCheck `json:"checks"`
+	}
+	if err := json.Unmarshal([]byte(stdout.finish()), &payload); err != nil {
+		t.Fatalf("Unmarshal() error: %v", err)
+	}
+
+	if !payload.Ready {
+		t.Fatalf("doctor reported ready=false: %#v", payload.Checks)
+	}
+}

--- a/cli/cmd/doctor_test.go
+++ b/cli/cmd/doctor_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
 
@@ -36,8 +37,16 @@ func TestDoctorReportsMissingWorkspaceAndNextStep(t *testing.T) {
 	defer srv.Close()
 
 	stdout := captureStdout(t)
-	if err := executeCommand(t, []string{"doctor", "--json"}, srv.URL); err != nil {
-		t.Fatalf("doctor error: %v", err)
+	err := executeCommand(t, []string{"doctor", "--json"}, srv.URL)
+
+	// Doctor must exit non-zero when ready=false so it can be used as a CI
+	// gate (`agentclash doctor && agentclash eval start --json`).
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected *ExitCodeError, got %T (%v)", err, err)
+	}
+	if exitErr.Code != 1 {
+		t.Fatalf("exit code = %d, want 1", exitErr.Code)
 	}
 
 	var payload struct {

--- a/cli/cmd/eval.go
+++ b/cli/cmd/eval.go
@@ -91,6 +91,19 @@ selection when possible.`,
 			if _, ok := rc.Config.BaselineBookmark(workspaceID); !ok {
 				return nil
 			}
+			// Skip the per-agent post-run summary for multi-deployment races:
+			// resolveRunAgentSummary with an empty selector would either fail
+			// in CI (no --agent flag on this command) or pop an interactive
+			// picker mid-race, both of which are wrong. Print a hint instead.
+			agents, err := listRunAgentsForWorkflow(cmd, rc, runID)
+			if err != nil {
+				return nil // best-effort; don't fail the run creation on summary errors
+			}
+			if len(agents) > 1 {
+				fmt.Fprintln(rc.Output.Writer())
+				fmt.Fprintf(rc.Output.Writer(), "Run has %d agents; run `agentclash eval scorecard %s --agent <label>` to view a per-agent scorecard.\n", len(agents), runID)
+				return nil
+			}
 			fmt.Fprintln(rc.Output.Writer())
 			fmt.Fprintln(rc.Output.Writer(), "Post-run summary")
 			return renderEvalScorecardForRun(cmd, rc, workspaceID, runID, "", false)
@@ -122,7 +135,16 @@ func renderEvalScorecardForRun(cmd *cobra.Command, rc *RunContext, workspaceID, 
 	}
 
 	if rc.Output.IsStructured() {
-		return rc.Output.PrintRaw(envelope)
+		if err := rc.Output.PrintRaw(envelope); err != nil {
+			return err
+		}
+		// Enforce exit-code parity with `run scorecard --json`: a 409 (errored)
+		// scorecard must exit 1 in JSON mode too, so CI gates like
+		// `eval scorecard --json > out.json && deploy.sh` trip correctly.
+		if scorecardResp != nil && scorecardResp.StatusCode == 409 {
+			return &ExitCodeError{Code: 1}
+		}
+		return nil
 	}
 
 	if handled, err := handleEvalScorecardState(scorecardResp, rc, envelope); handled {

--- a/cli/cmd/eval.go
+++ b/cli/cmd/eval.go
@@ -1,0 +1,260 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(evalCmd)
+	evalCmd.AddCommand(evalStartCmd)
+	evalCmd.AddCommand(evalScorecardCmd)
+
+	evalStartCmd.Flags().String("pack", "", "Challenge pack ID, slug, or exact name")
+	evalStartCmd.Flags().String("pack-version", "", "Challenge pack version ID or version number")
+	evalStartCmd.Flags().String("input-set", "", "Challenge input set ID, key, or exact name")
+	evalStartCmd.Flags().StringSlice("deployment", nil, "Deployment ID or exact name (repeatable)")
+	evalStartCmd.Flags().String("name", "", "Run name (optional)")
+	evalStartCmd.Flags().Bool("follow", false, "Follow run events after creation")
+	evalStartCmd.Flags().String("scope", "full", "Run scope: full or suite_only")
+	evalStartCmd.Flags().StringSlice("suite", nil, "Regression suite ID or exact name (repeatable)")
+	evalStartCmd.Flags().StringSlice("case", nil, "Regression case IDs (repeatable)")
+	evalStartCmd.Flags().Bool("race-context", false, "Enable live peer-standings injection during the run (requires 2+ agents)")
+	evalStartCmd.Flags().Int("race-context-cadence", 0, "Override race-context cadence; minimum steps between standings injections, [1, 10]. 0 uses the backend default.")
+
+	evalScorecardCmd.Flags().String("agent", "", "Run agent ID or label (optional)")
+}
+
+var evalCmd = &cobra.Command{
+	Use:   "eval",
+	Short: "Workflow-first eval commands",
+}
+
+var evalStartCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start an eval using names, defaults, and guided selection",
+	Long: `Start an evaluation run using the current workspace defaults.
+
+This command wraps 'agentclash run create' but resolves challenge packs,
+versions, input sets, and deployments using names, slugs, and interactive
+selection when possible.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		workspaceID := RequireWorkspace(cmd)
+
+		packSelector, _ := cmd.Flags().GetString("pack")
+		versionSelector, _ := cmd.Flags().GetString("pack-version")
+		inputSetSelector, _ := cmd.Flags().GetString("input-set")
+		deploymentSelectors, _ := cmd.Flags().GetStringSlice("deployment")
+		suiteSelectors, _ := cmd.Flags().GetStringSlice("suite")
+
+		resolvedPack, err := resolveChallengePackForEval(cmd, rc, workspaceID, packSelector, versionSelector, inputSetSelector)
+		if err != nil {
+			return err
+		}
+		deploymentIDs, err := resolveDeploymentIDs(cmd, rc, workspaceID, deploymentSelectors)
+		if err != nil {
+			return err
+		}
+
+		request, err := runCreateRequestFromFlags(cmd, runCreateRequest{
+			ChallengePackVersionID: resolvedPack.VersionID,
+			ChallengeInputSetID:    resolvedPack.ChallengeInputSetID,
+			DeploymentIDs:          deploymentIDs,
+		})
+		if err != nil {
+			return err
+		}
+
+		suiteIDs, err := resolveRegressionSuiteIDs(cmd, rc, workspaceID, resolvedPack.PackID, suiteSelectors)
+		if err != nil {
+			return err
+		}
+		request.RegressionSuiteIDs = suiteIDs
+		if request.OfficialPackMode == "suite_only" && len(request.RegressionSuiteIDs) == 0 && len(request.RegressionCaseIDs) == 0 {
+			return fmt.Errorf("--scope suite_only requires at least one --suite or --case")
+		}
+
+		body, err := buildRunCreateBody(workspaceID, request)
+		if err != nil {
+			return err
+		}
+
+		run, err := createRun(cmd, rc, body)
+		if err != nil {
+			return err
+		}
+
+		follow, _ := cmd.Flags().GetBool("follow")
+		return presentCreatedRun(cmd, rc, run, follow, func(runID string) error {
+			if _, ok := rc.Config.BaselineBookmark(workspaceID); !ok {
+				return nil
+			}
+			fmt.Fprintln(rc.Output.Writer())
+			fmt.Fprintln(rc.Output.Writer(), "Post-run summary")
+			return renderEvalScorecardForRun(cmd, rc, workspaceID, runID, "", false)
+		})
+	},
+}
+
+var evalScorecardCmd = &cobra.Command{
+	Use:   "scorecard [run]",
+	Short: "Show a run-first scorecard and compare against the bookmarked baseline",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		workspaceID := RequireWorkspace(cmd)
+
+		runSelector := ""
+		if len(args) == 1 {
+			runSelector = args[0]
+		}
+		agentSelector, _ := cmd.Flags().GetString("agent")
+		return renderEvalScorecardForRun(cmd, rc, workspaceID, runSelector, agentSelector, true)
+	},
+}
+
+func renderEvalScorecardForRun(cmd *cobra.Command, rc *RunContext, workspaceID, runSelector, agentSelector string, selectLatestWhenEmpty bool) error {
+	envelope, scorecardResp, err := buildEvalScorecardEnvelope(cmd, rc, workspaceID, runSelector, agentSelector, selectLatestWhenEmpty)
+	if err != nil {
+		return err
+	}
+
+	if rc.Output.IsStructured() {
+		return rc.Output.PrintRaw(envelope)
+	}
+
+	if handled, err := handleEvalScorecardState(scorecardResp, rc, envelope); handled {
+		return err
+	}
+
+	renderEvalScorecardHuman(rc, envelope)
+	return nil
+}
+
+func buildEvalScorecardEnvelope(cmd *cobra.Command, rc *RunContext, workspaceID, runSelector, agentSelector string, selectLatestWhenEmpty bool) (map[string]any, *apiResponseShim, error) {
+	run, err := resolveEvalRunTarget(cmd, rc, workspaceID, runSelector, selectLatestWhenEmpty)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	runAgent, err := resolveRunAgentSummary(cmd, rc, run.ID, agentSelector)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, scorecard, err := fetchRunAgentScorecard(cmd, rc, runAgent.ID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	envelope := map[string]any{
+		"candidate": map[string]any{
+			"workspace_id":       workspaceID,
+			"run_id":             run.ID,
+			"run_name":           displayRunSummary(run),
+			"run_status":         run.Status,
+			"run_agent_id":       runAgent.ID,
+			"run_agent_label":    displayRunAgentSummary(runAgent),
+			"official_pack_mode": run.OfficialPackMode,
+		},
+		"baseline":     nil,
+		"scorecard":    scorecard,
+		"comparison":   nil,
+		"release_gate": nil,
+	}
+
+	scorecardResp := &apiResponseShim{StatusCode: resp.StatusCode}
+	if resp.StatusCode == 202 || resp.StatusCode == 409 {
+		return envelope, scorecardResp, nil
+	}
+
+	bookmark, ok := rc.Config.BaselineBookmark(workspaceID)
+	if !ok {
+		return envelope, scorecardResp, nil
+	}
+
+	envelope["baseline"] = map[string]any{
+		"workspace_id":    workspaceID,
+		"run_id":          bookmark.RunID,
+		"run_name":        fallbackDisplay(bookmark.RunName, bookmark.RunID),
+		"run_agent_id":    bookmark.RunAgentID,
+		"run_agent_label": fallbackDisplay(bookmark.RunAgentLabel, bookmark.RunAgentID),
+		"set_at":          bookmark.SetAt,
+	}
+
+	comparison, err := fetchRunComparison(cmd, rc, bookmark.RunID, run.ID, bookmark.RunAgentID, runAgent.ID)
+	if err != nil {
+		return nil, nil, err
+	}
+	envelope["comparison"] = comparison
+
+	gateEnvelope, err := evaluateReleaseGate(cmd, rc, bookmark.RunID, run.ID, bookmark.RunAgentID, runAgent.ID)
+	if err != nil {
+		return nil, nil, err
+	}
+	envelope["release_gate"] = mapObject(gateEnvelope, "release_gate")
+
+	return envelope, scorecardResp, nil
+}
+
+type apiResponseShim struct {
+	StatusCode int
+}
+
+func handleEvalScorecardState(resp *apiResponseShim, rc *RunContext, envelope map[string]any) (bool, error) {
+	if resp == nil {
+		return false, nil
+	}
+	if resp.StatusCode != 202 && resp.StatusCode != 409 {
+		return false, nil
+	}
+
+	scorecard, _ := envelope["scorecard"].(map[string]any)
+	state := mapString(scorecard, "state", "status")
+	message := mapString(scorecard, "message")
+	rendered := formatStatefulReadMessage("Scorecard", state, message)
+	if resp.StatusCode == 202 {
+		rc.Output.PrintWarning(rendered)
+		return true, nil
+	}
+	rc.Output.PrintError(rendered)
+	return true, &ExitCodeError{Code: 1}
+}
+
+func renderEvalScorecardHuman(rc *RunContext, envelope map[string]any) {
+	candidate, _ := envelope["candidate"].(map[string]any)
+	scorecard, _ := envelope["scorecard"].(map[string]any)
+
+	fmt.Fprintln(rc.Output.Writer(), "Eval Scorecard")
+	rc.Output.PrintDetail("Run", fmt.Sprintf("%s (%s)", mapString(candidate, "run_name"), mapString(candidate, "run_id")))
+	rc.Output.PrintDetail("Agent", fmt.Sprintf("%s (%s)", mapString(candidate, "run_agent_label"), mapString(candidate, "run_agent_id")))
+	fmt.Fprintln(rc.Output.Writer())
+	renderRunAgentScorecard(rc, scorecard)
+
+	baseline, _ := envelope["baseline"].(map[string]any)
+	comparison, _ := envelope["comparison"].(map[string]any)
+	releaseGate, _ := envelope["release_gate"].(map[string]any)
+	if baseline == nil || comparison == nil {
+		return
+	}
+
+	renderRunComparisonSummary(
+		rc,
+		comparison,
+		fmt.Sprintf("%s (%s)", mapString(baseline, "run_name"), mapString(baseline, "run_id")),
+		fmt.Sprintf("%s (%s)", mapString(candidate, "run_name"), mapString(candidate, "run_id")),
+	)
+	renderReleaseGateSummary(rc, map[string]any{"release_gate": releaseGate})
+}
+
+func resolveEvalRunTarget(cmd *cobra.Command, rc *RunContext, workspaceID, runSelector string, selectLatestWhenEmpty bool) (runWorkflowSummary, error) {
+	if runSelector == "" {
+		if !selectLatestWhenEmpty {
+			return runWorkflowSummary{}, fmt.Errorf("run selector is required")
+		}
+		return resolveRunSummary(cmd, rc, workspaceID, "")
+	}
+	return resolveRunSummary(cmd, rc, workspaceID, runSelector)
+}

--- a/cli/cmd/eval_resolve.go
+++ b/cli/cmd/eval_resolve.go
@@ -360,11 +360,13 @@ func resolveChallengeInputSetID(cmd *cobra.Command, rc *RunContext, workspaceID,
 	if err != nil {
 		return "", err
 	}
-	if len(inputSets) == 0 {
-		return "", nil
-	}
-
+	// Honor an explicit selector before the empty-list short-circuit so that
+	// passing --input-set against a version with zero published input sets
+	// returns an error rather than silently submitting a run without one.
 	if selector != "" {
+		if len(inputSets) == 0 {
+			return "", fmt.Errorf("no challenge input set matched %q", selector)
+		}
 		var matches []challengeInputSetSummary
 		for _, inputSet := range inputSets {
 			if selectorMatches(selector, inputSet.ID, inputSet.InputKey, inputSet.Name) {
@@ -379,6 +381,10 @@ func resolveChallengeInputSetID(cmd *cobra.Command, rc *RunContext, workspaceID,
 		default:
 			return "", fmt.Errorf("input-set selector %q matched multiple input sets; use the input set id", selector)
 		}
+	}
+
+	if len(inputSets) == 0 {
+		return "", nil
 	}
 
 	if len(inputSets) == 1 {

--- a/cli/cmd/eval_resolve.go
+++ b/cli/cmd/eval_resolve.go
@@ -608,6 +608,13 @@ func resolveRunSummary(cmd *cobra.Command, rc *RunContext, workspaceID, selector
 		if len(runs) == 0 {
 			return runWorkflowSummary{}, fmt.Errorf("no runs found in workspace %s", workspaceID)
 		}
+		// Defensive: don't rely on backend ordering. The current backend
+		// returns ORDER BY created_at DESC, but a future change there must
+		// not silently flip "latest run" semantics for `eval scorecard` or
+		// the post-`eval start --follow` summary.
+		sort.SliceStable(runs, func(i, j int) bool {
+			return runs[i].CreatedAt > runs[j].CreatedAt
+		})
 		return runs[0], nil
 	}
 

--- a/cli/cmd/eval_resolve.go
+++ b/cli/cmd/eval_resolve.go
@@ -1,0 +1,757 @@
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type userProfileResponse struct {
+	UserID        string                    `json:"user_id"`
+	Email         string                    `json:"email"`
+	DisplayName   string                    `json:"display_name"`
+	Organizations []userProfileOrganization `json:"organizations"`
+}
+
+type userProfileOrganization struct {
+	ID         string                 `json:"id"`
+	Name       string                 `json:"name"`
+	Slug       string                 `json:"slug"`
+	Role       string                 `json:"role"`
+	Workspaces []userProfileWorkspace `json:"workspaces"`
+}
+
+type userProfileWorkspace struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+	Role string `json:"role"`
+}
+
+type linkedWorkspaceChoice struct {
+	ID      string
+	Name    string
+	Slug    string
+	Role    string
+	OrgID   string
+	OrgName string
+	OrgSlug string
+	OrgRole string
+}
+
+type challengePackWorkflowSummary struct {
+	ID       string                             `json:"id"`
+	Name     string                             `json:"name"`
+	Slug     string                             `json:"slug"`
+	Versions []challengePackWorkflowVersionInfo `json:"versions"`
+}
+
+type challengePackWorkflowVersionInfo struct {
+	ID              string `json:"id"`
+	VersionNumber   int    `json:"version_number"`
+	LifecycleStatus string `json:"lifecycle_status"`
+}
+
+type deploymentWorkflowSummary struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	CreatedAt string `json:"created_at"`
+}
+
+type regressionSuiteSummary struct {
+	ID                    string `json:"id"`
+	WorkspaceID           string `json:"workspace_id"`
+	SourceChallengePackID string `json:"source_challenge_pack_id"`
+	Name                  string `json:"name"`
+	Status                string `json:"status"`
+	CaseCount             int    `json:"case_count"`
+}
+
+type runWorkflowSummary struct {
+	ID                     string `json:"id"`
+	WorkspaceID            string `json:"workspace_id"`
+	Name                   string `json:"name"`
+	Status                 string `json:"status"`
+	ChallengePackVersionID string `json:"challenge_pack_version_id"`
+	ChallengeInputSetID    string `json:"challenge_input_set_id"`
+	OfficialPackMode       string `json:"official_pack_mode"`
+	CreatedAt              string `json:"created_at"`
+}
+
+type runAgentWorkflowSummary struct {
+	ID     string `json:"id"`
+	RunID  string `json:"run_id"`
+	Label  string `json:"label"`
+	Status string `json:"status"`
+}
+
+type resolvedChallengePack struct {
+	PackID              string
+	PackName            string
+	PackSlug            string
+	VersionID           string
+	VersionNumber       int
+	ChallengeInputSetID string
+}
+
+type resolvedRunTarget struct {
+	Run      runWorkflowSummary
+	RunAgent runAgentWorkflowSummary
+}
+
+func getUserProfile(cmd *cobra.Command, rc *RunContext) (userProfileResponse, error) {
+	resp, err := rc.Client.Get(cmd.Context(), "/v1/users/me", nil)
+	if err != nil {
+		return userProfileResponse{}, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return userProfileResponse{}, apiErr
+	}
+
+	var profile userProfileResponse
+	if err := resp.DecodeJSON(&profile); err != nil {
+		return userProfileResponse{}, err
+	}
+	return profile, nil
+}
+
+func listAccessibleWorkspaces(cmd *cobra.Command, rc *RunContext) ([]linkedWorkspaceChoice, error) {
+	profile, err := getUserProfile(cmd, rc)
+	if err != nil {
+		return nil, err
+	}
+
+	choices := make([]linkedWorkspaceChoice, 0)
+	for _, org := range profile.Organizations {
+		for _, workspace := range org.Workspaces {
+			choices = append(choices, linkedWorkspaceChoice{
+				ID:      workspace.ID,
+				Name:    workspace.Name,
+				Slug:    workspace.Slug,
+				Role:    workspace.Role,
+				OrgID:   org.ID,
+				OrgName: org.Name,
+				OrgSlug: org.Slug,
+				OrgRole: org.Role,
+			})
+		}
+	}
+
+	sort.SliceStable(choices, func(i, j int) bool {
+		if strings.EqualFold(choices[i].OrgName, choices[j].OrgName) {
+			return strings.ToLower(choices[i].Name) < strings.ToLower(choices[j].Name)
+		}
+		return strings.ToLower(choices[i].OrgName) < strings.ToLower(choices[j].OrgName)
+	})
+	return choices, nil
+}
+
+func resolveWorkspaceChoice(cmd *cobra.Command, rc *RunContext, selector string) (linkedWorkspaceChoice, error) {
+	choices, err := listAccessibleWorkspaces(cmd, rc)
+	if err != nil {
+		return linkedWorkspaceChoice{}, err
+	}
+	if len(choices) == 0 {
+		return linkedWorkspaceChoice{}, fmt.Errorf("no accessible workspaces found for the current account")
+	}
+
+	if selector != "" {
+		return matchWorkspaceChoice(selector, choices)
+	}
+
+	if len(choices) == 1 {
+		return choices[0], nil
+	}
+	if !isInteractiveTerminal(rc) {
+		return linkedWorkspaceChoice{}, fmt.Errorf("multiple workspaces available; pass a workspace id/slug or rerun `agentclash link` in a TTY")
+	}
+
+	options := make([]pickerOption, 0, len(choices))
+	for _, choice := range choices {
+		options = append(options, pickerOption{
+			Label:       choice.Name,
+			Description: fmt.Sprintf("%s (%s) • %s", choice.OrgName, choice.OrgSlug, choice.ID),
+			Value:       choice.ID,
+		})
+	}
+
+	selected, err := selectOneOrAuto(newInteractivePicker(), "Choose a workspace to link", options)
+	if err != nil {
+		return linkedWorkspaceChoice{}, err
+	}
+	return matchWorkspaceChoice(selected.Value, choices)
+}
+
+func matchWorkspaceChoice(selector string, choices []linkedWorkspaceChoice) (linkedWorkspaceChoice, error) {
+	var matches []linkedWorkspaceChoice
+	for _, choice := range choices {
+		if selectorMatches(selector, choice.ID, choice.Slug, choice.Name) {
+			matches = append(matches, choice)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return linkedWorkspaceChoice{}, fmt.Errorf("no accessible workspace matched %q", selector)
+	case 1:
+		return matches[0], nil
+	default:
+		return linkedWorkspaceChoice{}, fmt.Errorf("workspace selector %q matched multiple workspaces; use the workspace id", selector)
+	}
+}
+
+func listChallengePacksForWorkflow(cmd *cobra.Command, rc *RunContext, workspaceID string) ([]challengePackWorkflowSummary, error) {
+	resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+workspaceID+"/challenge-packs", nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return nil, apiErr
+	}
+
+	var result struct {
+		Items []challengePackWorkflowSummary `json:"items"`
+	}
+	if err := resp.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+	return result.Items, nil
+}
+
+func resolveChallengePackForEval(cmd *cobra.Command, rc *RunContext, workspaceID, packSelector, versionSelector, inputSetSelector string) (resolvedChallengePack, error) {
+	packs, err := listChallengePacksForWorkflow(cmd, rc, workspaceID)
+	if err != nil {
+		return resolvedChallengePack{}, err
+	}
+	if len(packs) == 0 {
+		return resolvedChallengePack{}, fmt.Errorf("no challenge packs found in workspace %s", workspaceID)
+	}
+
+	pack, err := selectChallengePack(cmd, rc, packs, packSelector, versionSelector)
+	if err != nil {
+		return resolvedChallengePack{}, err
+	}
+	version, err := selectChallengePackVersion(pack, versionSelector)
+	if err != nil {
+		return resolvedChallengePack{}, err
+	}
+	inputSetID, err := resolveChallengeInputSetID(cmd, rc, workspaceID, version.ID, inputSetSelector)
+	if err != nil {
+		return resolvedChallengePack{}, err
+	}
+
+	return resolvedChallengePack{
+		PackID:              pack.ID,
+		PackName:            pack.Name,
+		PackSlug:            pack.Slug,
+		VersionID:           version.ID,
+		VersionNumber:       version.VersionNumber,
+		ChallengeInputSetID: inputSetID,
+	}, nil
+}
+
+func selectChallengePack(cmd *cobra.Command, rc *RunContext, packs []challengePackWorkflowSummary, packSelector, versionSelector string) (challengePackWorkflowSummary, error) {
+	if packSelector != "" {
+		return matchChallengePack(packSelector, packs)
+	}
+
+	if versionSelector != "" {
+		var matches []challengePackWorkflowSummary
+		for _, pack := range packs {
+			for _, version := range pack.Versions {
+				if selectorMatches(versionSelector, version.ID) {
+					matches = append(matches, pack)
+					break
+				}
+			}
+		}
+		switch len(matches) {
+		case 0:
+			return challengePackWorkflowSummary{}, fmt.Errorf("no challenge pack version matched %q", versionSelector)
+		case 1:
+			return matches[0], nil
+		default:
+			return challengePackWorkflowSummary{}, fmt.Errorf("challenge pack version selector %q matched multiple packs; pass --pack as well", versionSelector)
+		}
+	}
+
+	if len(packs) == 1 {
+		return packs[0], nil
+	}
+	if !isInteractiveTerminal(rc) {
+		return challengePackWorkflowSummary{}, fmt.Errorf("multiple challenge packs available; pass --pack, --pack-version, or rerun `agentclash eval start` in a TTY")
+	}
+
+	options := make([]pickerOption, 0, len(packs))
+	for _, pack := range packs {
+		options = append(options, pickerOption{
+			Label:       pack.Name,
+			Description: fmt.Sprintf("slug: %s • %d version(s)", pack.Slug, len(pack.Versions)),
+			Value:       pack.ID,
+		})
+	}
+	selected, err := selectOneOrAuto(newInteractivePicker(), "Choose a challenge pack", options)
+	if err != nil {
+		return challengePackWorkflowSummary{}, err
+	}
+	return matchChallengePack(selected.Value, packs)
+}
+
+func matchChallengePack(selector string, packs []challengePackWorkflowSummary) (challengePackWorkflowSummary, error) {
+	var matches []challengePackWorkflowSummary
+	for _, pack := range packs {
+		if selectorMatches(selector, pack.ID, pack.Slug, pack.Name) {
+			matches = append(matches, pack)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return challengePackWorkflowSummary{}, fmt.Errorf("no challenge pack matched %q", selector)
+	case 1:
+		return matches[0], nil
+	default:
+		return challengePackWorkflowSummary{}, fmt.Errorf("challenge pack selector %q matched multiple packs; use the pack id or slug", selector)
+	}
+}
+
+func selectChallengePackVersion(pack challengePackWorkflowSummary, versionSelector string) (challengePackWorkflowVersionInfo, error) {
+	if len(pack.Versions) == 0 {
+		return challengePackWorkflowVersionInfo{}, fmt.Errorf("challenge pack %s has no versions", pack.Name)
+	}
+
+	versions := append([]challengePackWorkflowVersionInfo(nil), pack.Versions...)
+	sort.SliceStable(versions, func(i, j int) bool {
+		return versions[i].VersionNumber > versions[j].VersionNumber
+	})
+
+	if versionSelector == "" {
+		return versions[0], nil
+	}
+
+	trimmed := strings.TrimSpace(strings.TrimPrefix(strings.ToLower(versionSelector), "v"))
+	versionNumber, versionNumberErr := strconv.Atoi(trimmed)
+
+	var matches []challengePackWorkflowVersionInfo
+	for _, version := range versions {
+		if selectorMatches(versionSelector, version.ID) {
+			matches = append(matches, version)
+			continue
+		}
+		if versionNumberErr == nil && version.VersionNumber == versionNumber {
+			matches = append(matches, version)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return challengePackWorkflowVersionInfo{}, fmt.Errorf("no challenge pack version matched %q for pack %s", versionSelector, pack.Name)
+	case 1:
+		return matches[0], nil
+	default:
+		return challengePackWorkflowVersionInfo{}, fmt.Errorf("challenge pack version selector %q matched multiple versions", versionSelector)
+	}
+}
+
+func resolveChallengeInputSetID(cmd *cobra.Command, rc *RunContext, workspaceID, challengePackVersionID, selector string) (string, error) {
+	inputSets, err := listChallengeInputSets(cmd, rc, workspaceID, challengePackVersionID)
+	if err != nil {
+		return "", err
+	}
+	if len(inputSets) == 0 {
+		return "", nil
+	}
+
+	if selector != "" {
+		var matches []challengeInputSetSummary
+		for _, inputSet := range inputSets {
+			if selectorMatches(selector, inputSet.ID, inputSet.InputKey, inputSet.Name) {
+				matches = append(matches, inputSet)
+			}
+		}
+		switch len(matches) {
+		case 0:
+			return "", fmt.Errorf("no challenge input set matched %q", selector)
+		case 1:
+			return matches[0].ID, nil
+		default:
+			return "", fmt.Errorf("input-set selector %q matched multiple input sets; use the input set id", selector)
+		}
+	}
+
+	if len(inputSets) == 1 {
+		return inputSets[0].ID, nil
+	}
+	if !isInteractiveTerminal(rc) {
+		return "", fmt.Errorf("challenge pack has multiple input sets; pass --input-set or rerun `agentclash eval start` in a TTY")
+	}
+
+	options := make([]pickerOption, 0, len(inputSets))
+	for _, inputSet := range inputSets {
+		label := inputSet.Name
+		if label == "" {
+			label = inputSet.InputKey
+		}
+		options = append(options, pickerOption{
+			Label:       label,
+			Description: fmt.Sprintf("key: %s • %s", inputSet.InputKey, inputSet.ID),
+			Value:       inputSet.ID,
+		})
+	}
+	selected, err := selectOneOrAuto(newInteractivePicker(), "Choose a challenge input set", options)
+	if err != nil {
+		return "", err
+	}
+	return selected.Value, nil
+}
+
+func listDeploymentsForWorkflow(cmd *cobra.Command, rc *RunContext, workspaceID string) ([]deploymentWorkflowSummary, error) {
+	resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+workspaceID+"/agent-deployments", nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return nil, apiErr
+	}
+
+	var result struct {
+		Items []deploymentWorkflowSummary `json:"items"`
+	}
+	if err := resp.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+	return result.Items, nil
+}
+
+func resolveDeploymentIDs(cmd *cobra.Command, rc *RunContext, workspaceID string, selectors []string) ([]string, error) {
+	deployments, err := listDeploymentsForWorkflow(cmd, rc, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	if len(deployments) == 0 {
+		return nil, fmt.Errorf("no deployments found in workspace %s", workspaceID)
+	}
+
+	if len(selectors) == 0 {
+		if len(deployments) == 1 {
+			return []string{deployments[0].ID}, nil
+		}
+		if !isInteractiveTerminal(rc) {
+			return nil, fmt.Errorf("multiple deployments available; pass --deployment or rerun `agentclash eval start` in a TTY")
+		}
+		options := make([]pickerOption, 0, len(deployments))
+		for _, deployment := range deployments {
+			options = append(options, pickerOption{
+				Label:       deployment.Name,
+				Description: fmt.Sprintf("status: %s • %s", deployment.Status, deployment.ID),
+				Value:       deployment.ID,
+			})
+		}
+		selected, err := selectManyOrAuto(newInteractivePicker(), "Choose one or more deployments (space to toggle, enter to confirm)", options, 1)
+		if err != nil {
+			return nil, err
+		}
+		ids := make([]string, 0, len(selected))
+		for _, item := range selected {
+			ids = append(ids, item.Value)
+		}
+		return ids, nil
+	}
+
+	ids := make([]string, 0, len(selectors))
+	seen := make(map[string]struct{}, len(selectors))
+	for _, selector := range selectors {
+		matched, err := matchDeployment(selector, deployments)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seen[matched.ID]; ok {
+			continue
+		}
+		seen[matched.ID] = struct{}{}
+		ids = append(ids, matched.ID)
+	}
+	return ids, nil
+}
+
+func matchDeployment(selector string, deployments []deploymentWorkflowSummary) (deploymentWorkflowSummary, error) {
+	var matches []deploymentWorkflowSummary
+	for _, deployment := range deployments {
+		if selectorMatches(selector, deployment.ID, deployment.Name) {
+			matches = append(matches, deployment)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return deploymentWorkflowSummary{}, fmt.Errorf("no deployment matched %q", selector)
+	case 1:
+		return matches[0], nil
+	default:
+		return deploymentWorkflowSummary{}, fmt.Errorf("deployment selector %q matched multiple deployments; use the deployment id", selector)
+	}
+}
+
+func listRegressionSuites(cmd *cobra.Command, rc *RunContext, workspaceID string) ([]regressionSuiteSummary, error) {
+	query := url.Values{}
+	query.Set("limit", "100")
+	resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+workspaceID+"/regression-suites", query)
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return nil, apiErr
+	}
+
+	var result struct {
+		Items []regressionSuiteSummary `json:"items"`
+	}
+	if err := resp.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+	return result.Items, nil
+}
+
+func resolveRegressionSuiteIDs(cmd *cobra.Command, rc *RunContext, workspaceID, packID string, selectors []string) ([]string, error) {
+	if len(selectors) == 0 {
+		return nil, nil
+	}
+
+	suites, err := listRegressionSuites(cmd, rc, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]string, 0, len(selectors))
+	seen := make(map[string]struct{}, len(selectors))
+	for _, selector := range selectors {
+		matched, err := matchRegressionSuite(selector, packID, suites)
+		if err != nil {
+			return nil, err
+		}
+		if matched.Status != "active" {
+			return nil, fmt.Errorf("regression suite %s is not active", matched.Name)
+		}
+		if _, ok := seen[matched.ID]; ok {
+			continue
+		}
+		seen[matched.ID] = struct{}{}
+		ids = append(ids, matched.ID)
+	}
+	return ids, nil
+}
+
+func matchRegressionSuite(selector, packID string, suites []regressionSuiteSummary) (regressionSuiteSummary, error) {
+	var matches []regressionSuiteSummary
+	for _, suite := range suites {
+		if packID != "" && suite.SourceChallengePackID != "" && suite.SourceChallengePackID != packID {
+			continue
+		}
+		if selectorMatches(selector, suite.ID, suite.Name) {
+			matches = append(matches, suite)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		if packID != "" {
+			return regressionSuiteSummary{}, fmt.Errorf("no regression suite matched %q for the selected challenge pack", selector)
+		}
+		return regressionSuiteSummary{}, fmt.Errorf("no regression suite matched %q", selector)
+	case 1:
+		return matches[0], nil
+	default:
+		return regressionSuiteSummary{}, fmt.Errorf("regression suite selector %q matched multiple suites; use the suite id", selector)
+	}
+}
+
+func listRunsForWorkflow(cmd *cobra.Command, rc *RunContext, workspaceID string) ([]runWorkflowSummary, error) {
+	resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+workspaceID+"/runs", nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return nil, apiErr
+	}
+
+	var result struct {
+		Items []runWorkflowSummary `json:"items"`
+	}
+	if err := resp.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+	return result.Items, nil
+}
+
+func getRunSummaryByID(cmd *cobra.Command, rc *RunContext, runID string) (runWorkflowSummary, error) {
+	resp, err := rc.Client.Get(cmd.Context(), "/v1/runs/"+runID, nil)
+	if err != nil {
+		return runWorkflowSummary{}, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return runWorkflowSummary{}, apiErr
+	}
+
+	var run runWorkflowSummary
+	if err := resp.DecodeJSON(&run); err != nil {
+		return runWorkflowSummary{}, err
+	}
+	return run, nil
+}
+
+func resolveRunSummary(cmd *cobra.Command, rc *RunContext, workspaceID, selector string) (runWorkflowSummary, error) {
+	if selector == "" {
+		runs, err := listRunsForWorkflow(cmd, rc, workspaceID)
+		if err != nil {
+			return runWorkflowSummary{}, err
+		}
+		if len(runs) == 0 {
+			return runWorkflowSummary{}, fmt.Errorf("no runs found in workspace %s", workspaceID)
+		}
+		return runs[0], nil
+	}
+
+	runs, err := listRunsForWorkflow(cmd, rc, workspaceID)
+	if err != nil {
+		return runWorkflowSummary{}, err
+	}
+
+	var matches []runWorkflowSummary
+	for _, run := range runs {
+		if selectorMatches(selector, run.ID, run.Name) {
+			matches = append(matches, run)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		run, err := getRunSummaryByID(cmd, rc, selector)
+		if err != nil {
+			return runWorkflowSummary{}, err
+		}
+		if run.WorkspaceID != "" && workspaceID != "" && run.WorkspaceID != workspaceID {
+			return runWorkflowSummary{}, fmt.Errorf("run %s does not belong to workspace %s", selector, workspaceID)
+		}
+		return run, nil
+	default:
+		return runWorkflowSummary{}, fmt.Errorf("run selector %q matched multiple runs; use the run id", selector)
+	}
+}
+
+func selectRunSummaryInteractively(cmd *cobra.Command, rc *RunContext, workspaceID string) (runWorkflowSummary, error) {
+	runs, err := listRunsForWorkflow(cmd, rc, workspaceID)
+	if err != nil {
+		return runWorkflowSummary{}, err
+	}
+	if len(runs) == 0 {
+		return runWorkflowSummary{}, fmt.Errorf("no runs found in workspace %s", workspaceID)
+	}
+	if len(runs) == 1 {
+		return runs[0], nil
+	}
+	if !isInteractiveTerminal(rc) {
+		return runWorkflowSummary{}, fmt.Errorf("multiple runs available; pass a run id or rerun the command in a TTY")
+	}
+
+	options := make([]pickerOption, 0, len(runs))
+	for _, run := range runs {
+		label := run.Name
+		if label == "" {
+			label = run.ID
+		}
+		options = append(options, pickerOption{
+			Label:       label,
+			Description: fmt.Sprintf("status: %s • %s", run.Status, run.ID),
+			Value:       run.ID,
+		})
+	}
+	selected, err := selectOneOrAuto(newInteractivePicker(), "Choose a run", options)
+	if err != nil {
+		return runWorkflowSummary{}, err
+	}
+	return resolveRunSummary(cmd, rc, workspaceID, selected.Value)
+}
+
+func listRunAgentsForWorkflow(cmd *cobra.Command, rc *RunContext, runID string) ([]runAgentWorkflowSummary, error) {
+	resp, err := rc.Client.Get(cmd.Context(), "/v1/runs/"+runID+"/agents", nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return nil, apiErr
+	}
+
+	var result struct {
+		Items []runAgentWorkflowSummary `json:"items"`
+	}
+	if err := resp.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+	return result.Items, nil
+}
+
+func resolveRunAgentSummary(cmd *cobra.Command, rc *RunContext, runID, selector string) (runAgentWorkflowSummary, error) {
+	agents, err := listRunAgentsForWorkflow(cmd, rc, runID)
+	if err != nil {
+		return runAgentWorkflowSummary{}, err
+	}
+	if len(agents) == 0 {
+		return runAgentWorkflowSummary{}, fmt.Errorf("run %s has no agent results", runID)
+	}
+
+	if selector != "" {
+		var matches []runAgentWorkflowSummary
+		for _, agent := range agents {
+			if selectorMatches(selector, agent.ID, agent.Label) {
+				matches = append(matches, agent)
+			}
+		}
+		switch len(matches) {
+		case 0:
+			return runAgentWorkflowSummary{}, fmt.Errorf("no run agent matched %q for run %s", selector, runID)
+		case 1:
+			return matches[0], nil
+		default:
+			return runAgentWorkflowSummary{}, fmt.Errorf("run-agent selector %q matched multiple agents; use the run agent id", selector)
+		}
+	}
+
+	if len(agents) == 1 {
+		return agents[0], nil
+	}
+	if !isInteractiveTerminal(rc) {
+		return runAgentWorkflowSummary{}, fmt.Errorf("run %s has multiple agents; pass --agent or rerun the command in a TTY", runID)
+	}
+
+	options := make([]pickerOption, 0, len(agents))
+	for _, agent := range agents {
+		options = append(options, pickerOption{
+			Label:       agent.Label,
+			Description: fmt.Sprintf("status: %s • %s", agent.Status, agent.ID),
+			Value:       agent.ID,
+		})
+	}
+	selected, err := selectOneOrAuto(newInteractivePicker(), "Choose a run agent", options)
+	if err != nil {
+		return runAgentWorkflowSummary{}, err
+	}
+	return resolveRunAgentSummary(cmd, rc, runID, selected.Value)
+}
+
+func selectorMatches(selector string, values ...string) bool {
+	needle := strings.TrimSpace(selector)
+	if needle == "" {
+		return false
+	}
+	for _, value := range values {
+		candidate := strings.TrimSpace(value)
+		if candidate == "" {
+			continue
+		}
+		if needle == candidate || strings.EqualFold(needle, candidate) {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/cmd/eval_test.go
+++ b/cli/cmd/eval_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
@@ -215,5 +216,89 @@ func TestEvalScorecardRequiresAgentSelectorForMultiAgentRuns(t *testing.T) {
 	err := executeCommand(t, []string{"eval", "scorecard", "run-candidate", "-w", "ws-1"}, srv.URL)
 	if err == nil || !strings.Contains(err.Error(), "multiple agents") {
 		t.Fatalf("error = %v, want multiple agents guidance", err)
+	}
+}
+
+// TestEvalScorecardJSONExitsOneOnErroredScorecard pins the CI exit-code
+// contract: `eval scorecard --json` must exit 1 when the scorecard endpoint
+// returns 409 (errored), matching `run scorecard --json` behaviour.
+func TestEvalScorecardJSONExitsOneOnErroredScorecard(t *testing.T) {
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/runs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "run-1", "workspace_id": "ws-1", "name": "Run 1", "status": "completed"},
+			},
+		}),
+		"GET /v1/runs/run-1/agents": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "agent-1", "run_id": "run-1", "label": "candidate", "status": "completed"},
+			},
+		}),
+		"GET /v1/scorecards/agent-1": jsonHandler(409, map[string]any{
+			"state":   "errored",
+			"message": "scorecard generation failed or scorecard data is unavailable",
+		}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	err := executeCommand(t, []string{"eval", "scorecard", "run-1", "-w", "ws-1", "--json"}, srv.URL)
+
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("expected ExitCodeError{1}, got %T (%v)", err, err)
+	}
+
+	// JSON envelope must still be emitted despite the error exit code.
+	var payload map[string]any
+	if jsonErr := json.Unmarshal([]byte(stdout.finish()), &payload); jsonErr != nil {
+		t.Fatalf("Unmarshal() error: %v", jsonErr)
+	}
+	if payload["scorecard"] == nil {
+		t.Fatal("scorecard field missing from JSON envelope on errored response")
+	}
+}
+
+// TestEvalInputSetSelectorErrorsOnEmptyList pins that passing --input-set
+// against a version with no published input sets returns an error instead of
+// silently submitting a run without one.
+func TestEvalInputSetSelectorErrorsOnEmptyList(t *testing.T) {
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/challenge-packs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{
+					"id":   "pack-1",
+					"name": "Support Eval",
+					"slug": "support-eval",
+					"versions": []map[string]any{
+						{"id": "ver-1", "version_number": 1, "lifecycle_status": "active"},
+					},
+				},
+			},
+		}),
+		"GET /v1/workspaces/ws-1/challenge-pack-versions/ver-1/input-sets": jsonHandler(200, map[string]any{
+			"items": []map[string]any{},
+		}),
+		"GET /v1/workspaces/ws-1/agent-deployments": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "dep-1", "name": "prod", "status": "ready"},
+			},
+		}),
+	})
+	defer srv.Close()
+
+	err := executeCommand(t, []string{
+		"eval", "start",
+		"-w", "ws-1",
+		"--pack", "support-eval",
+		"--deployment", "prod",
+		"--input-set", "my-set",
+	}, srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "no challenge input set matched") {
+		t.Fatalf("error = %v, want 'no challenge input set matched' error", err)
 	}
 }

--- a/cli/cmd/eval_test.go
+++ b/cli/cmd/eval_test.go
@@ -144,6 +144,56 @@ func TestEvalScorecardJSONEnvelopeIncludesBaselineComparisonAndGate(t *testing.T
 	}
 }
 
+// TestEvalScorecardPicksNewestRunRegardlessOfAPIOrder pins the defensive sort
+// in resolveRunSummary's empty-selector path. The current backend orders runs
+// by created_at DESC, but `eval scorecard` (no run argument) and the
+// post-`eval start --follow` summary must not silently flip semantics if a
+// future backend refactor changes that ordering.
+func TestEvalScorecardPicksNewestRunRegardlessOfAPIOrder(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+
+	// Return runs in oldest-first order. The CLI must still pick the newest.
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/runs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "run-old", "workspace_id": "ws-1", "name": "Old", "status": "completed", "created_at": "2026-04-20T09:00:00Z"},
+				{"id": "run-new", "workspace_id": "ws-1", "name": "New", "status": "completed", "created_at": "2026-04-25T09:00:00Z"},
+			},
+		}),
+		"GET /v1/runs/run-new/agents": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "agent-new", "run_id": "run-new", "label": "candidate", "status": "completed"},
+			},
+		}),
+		"GET /v1/scorecards/agent-new": jsonHandler(200, map[string]any{
+			"state":            "ready",
+			"run_agent_id":     "agent-new",
+			"run_agent_status": "completed",
+			"overall_score":    0.92,
+		}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	if err := executeCommand(t, []string{"eval", "scorecard", "-w", "ws-1", "--json"}, srv.URL); err != nil {
+		t.Fatalf("eval scorecard error: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(stdout.finish()), &payload); err != nil {
+		t.Fatalf("Unmarshal() error: %v", err)
+	}
+	candidate, ok := payload["candidate"].(map[string]any)
+	if !ok {
+		t.Fatalf("candidate field missing from envelope: %#v", payload)
+	}
+	if candidate["run_id"] != "run-new" {
+		t.Fatalf("candidate.run_id = %v, want run-new (newest by created_at)", candidate["run_id"])
+	}
+}
+
 func TestEvalScorecardRequiresAgentSelectorForMultiAgentRuns(t *testing.T) {
 	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
 

--- a/cli/cmd/eval_test.go
+++ b/cli/cmd/eval_test.go
@@ -1,0 +1,169 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/agentclash/agentclash/cli/internal/config"
+)
+
+func TestEvalStartResolvesSelectorsAndCreatesRun(t *testing.T) {
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+
+	var gotBody map[string]any
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/challenge-packs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{
+					"id":   "pack-1",
+					"name": "Support Eval",
+					"slug": "support-eval",
+					"versions": []map[string]any{
+						{"id": "ver-1", "version_number": 1, "lifecycle_status": "active"},
+						{"id": "ver-2", "version_number": 2, "lifecycle_status": "active"},
+					},
+				},
+			},
+		}),
+		"GET /v1/workspaces/ws-1/challenge-pack-versions/ver-2/input-sets": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "input-1", "input_key": "default", "name": "Default Inputs"},
+			},
+		}),
+		"GET /v1/workspaces/ws-1/agent-deployments": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "dep-1", "name": "prod", "status": "ready"},
+			},
+		}),
+		"GET /v1/workspaces/ws-1/regression-suites": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "suite-1", "workspace_id": "ws-1", "source_challenge_pack_id": "pack-1", "name": "Smoke", "status": "active"},
+			},
+		}),
+		"POST /v1/runs": func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("Decode() error: %v", err)
+			}
+			jsonHandler(201, map[string]any{"id": "run-1", "status": "queued"})(w, r)
+		},
+	})
+	defer srv.Close()
+
+	if err := executeCommand(t, []string{
+		"eval", "start",
+		"-w", "ws-1",
+		"--pack", "support-eval",
+		"--deployment", "prod",
+		"--scope", "suite_only",
+		"--suite", "Smoke",
+	}, srv.URL); err != nil {
+		t.Fatalf("eval start error: %v", err)
+	}
+
+	if gotBody["challenge_pack_version_id"] != "ver-2" {
+		t.Fatalf("challenge_pack_version_id = %v, want ver-2", gotBody["challenge_pack_version_id"])
+	}
+	if gotBody["challenge_input_set_id"] != "input-1" {
+		t.Fatalf("challenge_input_set_id = %v, want input-1", gotBody["challenge_input_set_id"])
+	}
+	if gotBody["official_pack_mode"] != "suite_only" {
+		t.Fatalf("official_pack_mode = %v, want suite_only", gotBody["official_pack_mode"])
+	}
+	if suiteIDs, ok := gotBody["regression_suite_ids"].([]any); !ok || len(suiteIDs) != 1 || suiteIDs[0] != "suite-1" {
+		t.Fatalf("regression_suite_ids = %#v, want [suite-1]", gotBody["regression_suite_ids"])
+	}
+}
+
+func TestEvalScorecardJSONEnvelopeIncludesBaselineComparisonAndGate(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+
+	if err := config.Save(config.UserConfig{
+		BaselineBookmarks: map[string]config.BaselineBookmark{
+			"ws-1": {
+				RunID:         "run-base",
+				RunAgentID:    "agent-base",
+				RunName:       "Baseline",
+				RunAgentLabel: "baseline",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/runs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "run-candidate", "workspace_id": "ws-1", "name": "Candidate", "status": "completed", "official_pack_mode": "full"},
+			},
+		}),
+		"GET /v1/runs/run-candidate/agents": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "agent-candidate", "run_id": "run-candidate", "label": "candidate", "status": "completed"},
+			},
+		}),
+		"GET /v1/scorecards/agent-candidate": jsonHandler(200, map[string]any{
+			"state":            "ready",
+			"run_agent_id":     "agent-candidate",
+			"run_agent_status": "completed",
+			"overall_score":    0.91,
+		}),
+		"GET /v1/compare": jsonHandler(200, map[string]any{
+			"state":      "comparable",
+			"status":     "regression",
+			"key_deltas": []map[string]any{{"metric": "correctness", "baseline_value": 0.95, "candidate_value": 0.91, "delta": -0.04, "outcome": "regressed"}},
+		}),
+		"POST /v1/release-gates/evaluate": jsonHandler(200, map[string]any{
+			"release_gate": map[string]any{
+				"verdict": "warn",
+				"summary": "Needs review",
+			},
+		}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	if err := executeCommand(t, []string{
+		"eval", "scorecard", "run-candidate",
+		"-w", "ws-1",
+		"--json",
+	}, srv.URL); err != nil {
+		t.Fatalf("eval scorecard error: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(stdout.finish()), &payload); err != nil {
+		t.Fatalf("Unmarshal() error: %v", err)
+	}
+
+	if payload["candidate"] == nil || payload["baseline"] == nil || payload["comparison"] == nil || payload["release_gate"] == nil {
+		t.Fatalf("eval scorecard payload missing workflow envelope fields: %#v", payload)
+	}
+}
+
+func TestEvalScorecardRequiresAgentSelectorForMultiAgentRuns(t *testing.T) {
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/runs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "run-candidate", "workspace_id": "ws-1", "name": "Candidate", "status": "completed"},
+			},
+		}),
+		"GET /v1/runs/run-candidate/agents": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "agent-1", "run_id": "run-candidate", "label": "candidate-a", "status": "completed"},
+				{"id": "agent-2", "run_id": "run-candidate", "label": "candidate-b", "status": "completed"},
+			},
+		}),
+	})
+	defer srv.Close()
+
+	err := executeCommand(t, []string{"eval", "scorecard", "run-candidate", "-w", "ws-1"}, srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "multiple agents") {
+		t.Fatalf("error = %v, want multiple agents guidance", err)
+	}
+}

--- a/cli/cmd/link.go
+++ b/cli/cmd/link.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/agentclash/agentclash/cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(linkCmd)
+}
+
+var linkCmd = &cobra.Command{
+	Use:   "link [workspace]",
+	Short: "Choose and save your default workspace",
+	Long: `Choose and save the default workspace for subsequent AgentClash commands.
+
+This is the workflow-first command to run after 'agentclash auth login'. It
+stores your selected workspace and organization in ~/.config/agentclash/config.yaml.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+
+		selector := ""
+		if len(args) == 1 {
+			selector = args[0]
+		}
+
+		workspace, err := resolveWorkspaceChoice(cmd, rc, selector)
+		if err != nil {
+			return err
+		}
+
+		cfg := rc.Config.UserConfig()
+		cfg.DefaultWorkspace = workspace.ID
+		cfg.DefaultOrg = workspace.OrgID
+		if err := config.Save(*cfg); err != nil {
+			return fmt.Errorf("saving config: %w", err)
+		}
+
+		result := map[string]any{
+			"workspace_id":      workspace.ID,
+			"workspace_name":    workspace.Name,
+			"workspace_slug":    workspace.Slug,
+			"workspace_role":    workspace.Role,
+			"organization_id":   workspace.OrgID,
+			"organization_name": workspace.OrgName,
+			"organization_slug": workspace.OrgSlug,
+			"organization_role": workspace.OrgRole,
+		}
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(result)
+		}
+
+		rc.Output.PrintSuccess(fmt.Sprintf("Linked default workspace to %s (%s)", workspace.Name, workspace.ID))
+		rc.Output.PrintDetail("Organization", fmt.Sprintf("%s (%s)", workspace.OrgName, workspace.OrgSlug))
+		rc.Output.PrintDetail("Workspace", fmt.Sprintf("%s (%s)", workspace.Name, workspace.Slug))
+		if workspace.Role != "" {
+			rc.Output.PrintDetail("Role", workspace.Role)
+		}
+		fmt.Fprintln(rc.Output.Writer())
+		fmt.Fprintln(rc.Output.Writer(), "Next: agentclash challenge-pack init support-eval.yaml")
+		return nil
+	},
+}

--- a/cli/cmd/link_test.go
+++ b/cli/cmd/link_test.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/agentclash/agentclash/cli/internal/config"
+)
+
+func TestLinkSelectsWorkspaceInteractivelyAndSavesDefaults(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+
+	oldInteractive := isInteractiveTerminal
+	oldPickerFactory := newInteractivePicker
+	isInteractiveTerminal = func(*RunContext) bool { return true }
+	newInteractivePicker = func() interactivePicker {
+		return &fakePicker{selectIndices: []int{1}}
+	}
+	t.Cleanup(func() {
+		isInteractiveTerminal = oldInteractive
+		newInteractivePicker = oldPickerFactory
+	})
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/users/me": jsonHandler(200, map[string]any{
+			"user_id": "user-1",
+			"organizations": []map[string]any{
+				{
+					"id":   "org-1",
+					"name": "Acme",
+					"slug": "acme",
+					"workspaces": []map[string]any{
+						{"id": "ws-1", "name": "Alpha", "slug": "alpha"},
+						{"id": "ws-2", "name": "Beta", "slug": "beta"},
+					},
+				},
+			},
+		}),
+	})
+	defer srv.Close()
+
+	if err := executeCommand(t, []string{"link"}, srv.URL); err != nil {
+		t.Fatalf("link error: %v", err)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.DefaultWorkspace != "ws-2" {
+		t.Fatalf("default workspace = %q, want ws-2", cfg.DefaultWorkspace)
+	}
+	if cfg.DefaultOrg != "org-1" {
+		t.Fatalf("default org = %q, want org-1", cfg.DefaultOrg)
+	}
+}
+
+func TestLinkResolvesWorkspaceBySlugWithoutPrompt(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/users/me": jsonHandler(200, map[string]any{
+			"user_id": "user-1",
+			"organizations": []map[string]any{
+				{
+					"id":   "org-1",
+					"name": "Acme",
+					"slug": "acme",
+					"workspaces": []map[string]any{
+						{"id": "ws-1", "name": "Alpha", "slug": "alpha"},
+						{"id": "ws-2", "name": "Beta", "slug": "beta"},
+					},
+				},
+			},
+		}),
+	})
+	defer srv.Close()
+
+	if err := executeCommand(t, []string{"link", "beta"}, srv.URL); err != nil {
+		t.Fatalf("link error: %v", err)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.DefaultWorkspace != "ws-2" {
+		t.Fatalf("default workspace = %q, want ws-2", cfg.DefaultWorkspace)
+	}
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -61,10 +61,12 @@ Manage organizations, workspaces, agent builds, deployments, evaluation runs,
 challenge packs, playgrounds, and infrastructure — all from your terminal.
 
 Get started:
-  agentclash auth login         Log in to your account
-  agentclash workspace use      Set your default workspace
-  agentclash run create         Create an evaluation run
-  agentclash run events <id>    Stream live run events`,
+  agentclash auth login                   Log in to your account
+  agentclash link                         Choose and save your default workspace
+  agentclash challenge-pack init <file>   Scaffold a challenge pack
+  agentclash eval start --follow          Create and follow an evaluation run
+  agentclash baseline set                 Bookmark a baseline run
+  agentclash eval scorecard               Show scorecards and regression verdicts`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -46,7 +46,7 @@ func GetRunContext(cmd *cobra.Command) *RunContext {
 func RequireWorkspace(cmd *cobra.Command) string {
 	rc := GetRunContext(cmd)
 	if rc.Workspace == "" {
-		fmt.Fprintln(os.Stderr, "Error: no workspace specified. Use --workspace, set AGENTCLASH_WORKSPACE, run 'agentclash workspace use', or create .agentclash.yaml with 'agentclash init'.")
+		fmt.Fprintln(os.Stderr, "Error: no workspace specified. Run 'agentclash link' to choose a default workspace, or pass --workspace, set AGENTCLASH_WORKSPACE, or create .agentclash.yaml with 'agentclash init'.")
 		os.Exit(2)
 	}
 	return rc.Workspace

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -3,15 +3,11 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"gopkg.in/yaml.v3"
 	"net/url"
 	"os"
-	"sort"
 	"strings"
 	"time"
-
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
-	"gopkg.in/yaml.v3"
 
 	"github.com/agentclash/agentclash/cli/internal/output"
 	"github.com/spf13/cobra"
@@ -32,6 +28,9 @@ func init() {
 	runCreateCmd.Flags().String("name", "", "Run name (optional)")
 	runCreateCmd.Flags().String("input-set", "", "Challenge input set ID (optional)")
 	runCreateCmd.Flags().Bool("follow", false, "Follow run events after creation")
+	runCreateCmd.Flags().String("scope", "full", "Run scope: full or suite_only")
+	runCreateCmd.Flags().StringSlice("suite", nil, "Regression suite IDs (repeatable; required with --scope suite_only unless --case is used)")
+	runCreateCmd.Flags().StringSlice("case", nil, "Regression case IDs (repeatable)")
 	runCreateCmd.Flags().Bool("race-context", false, "Enable live peer-standings injection during the run (requires 2+ agents)")
 	runCreateCmd.Flags().Int("race-context-cadence", 0, "Override race-context cadence; minimum steps between standings injections, [1, 10]. 0 uses the backend default.")
 
@@ -133,6 +132,8 @@ var runCreateCmd = &cobra.Command{
 	Short: "Create and submit an evaluation run",
 	Long: `Create and submit an evaluation run.
 
+For the guided workflow-first path, prefer 'agentclash eval start'.
+
 In a normal terminal session, omitting --challenge-pack-version and/or
 --deployments launches an interactive picker so you can scroll through
 available challenge packs, versions, input sets, and deployments and press
@@ -143,66 +144,31 @@ For CI and other non-interactive use, keep passing explicit IDs via flags.`,
 		rc := GetRunContext(cmd)
 		wsID := RequireWorkspace(cmd)
 
+		request, err := runCreateRequestFromFlags(cmd, runCreateRequest{})
+		if err != nil {
+			return err
+		}
+
 		selections, err := resolveRunCreateSelections(cmd, rc, wsID)
 		if err != nil {
 			return err
 		}
-		name, _ := cmd.Flags().GetString("name")
+		request.ChallengePackVersionID = selections.challengePackVersionID
+		request.ChallengeInputSetID = selections.challengeInputSetID
+		request.DeploymentIDs = selections.deploymentIDs
 
-		body := map[string]any{
-			"workspace_id":              wsID,
-			"challenge_pack_version_id": selections.challengePackVersionID,
-			"agent_deployment_ids":      selections.deploymentIDs,
-		}
-		if name != "" {
-			body["name"] = name
-		}
-		if selections.challengeInputSetID != "" {
-			body["challenge_input_set_id"] = selections.challengeInputSetID
-		}
-		if raceContext, _ := cmd.Flags().GetBool("race-context"); raceContext {
-			body["race_context"] = true
-		}
-		if cadence, _ := cmd.Flags().GetInt("race-context-cadence"); cadence > 0 {
-			if cadence > 10 {
-				return fmt.Errorf("--race-context-cadence must be between 1 and 10, got %d", cadence)
-			}
-			body["race_context_min_step_gap"] = cadence
-		}
-
-		sp := output.NewSpinner("Creating run...", flagQuiet)
-		resp, err := rc.Client.Post(cmd.Context(), "/v1/runs", body)
+		body, err := buildRunCreateBody(wsID, request)
 		if err != nil {
-			sp.StopWithError("Failed to create run")
-			return err
-		}
-		if apiErr := resp.ParseError(); apiErr != nil {
-			sp.StopWithError("Failed to create run")
-			return apiErr
-		}
-
-		var run map[string]any
-		if err := resp.DecodeJSON(&run); err != nil {
 			return err
 		}
 
-		sp.StopWithSuccess(fmt.Sprintf("Created run %s", str(run["id"])))
-
-		if rc.Output.IsStructured() {
-			return rc.Output.PrintRaw(run)
+		run, err := createRun(cmd, rc, body)
+		if err != nil {
+			return err
 		}
 
-		rc.Output.PrintDetail("Run ID", str(run["id"]))
-		rc.Output.PrintDetail("Status", output.StatusColor(str(run["status"])))
-
-		// If --follow, tail events.
 		follow, _ := cmd.Flags().GetBool("follow")
-		if follow {
-			fmt.Fprintln(os.Stderr)
-			return streamRunEvents(cmd, rc, str(run["id"]))
-		}
-
-		return nil
+		return presentCreatedRun(cmd, rc, run, follow, nil)
 	},
 }
 
@@ -340,95 +306,22 @@ var runEventsCmd = &cobra.Command{
 var runScorecardCmd = &cobra.Command{
 	Use:   "scorecard <runAgentId>",
 	Short: "Get agent scorecard",
+	Long:  "Get the scorecard for a specific run agent.\n\nFor the run-first workflow that can also compare against the bookmarked baseline, prefer `agentclash eval scorecard`.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		rc := GetRunContext(cmd)
-
-		resp, err := rc.Client.Get(cmd.Context(), "/v1/scorecards/"+args[0], nil)
+		resp, scorecard, err := fetchRunAgentScorecard(cmd, rc, args[0])
 		if err != nil {
 			return err
 		}
 		if handled, err := handleStatefulReadResponse(rc, resp, "Scorecard"); handled {
 			return err
 		}
-		if apiErr := resp.ParseError(); apiErr != nil {
-			return apiErr
-		}
-
-		var scorecard map[string]any
-		if err := resp.DecodeJSON(&scorecard); err != nil {
-			return err
-		}
 
 		if rc.Output.IsStructured() {
 			return rc.Output.PrintRaw(scorecard)
 		}
-
-		rc.Output.PrintDetail("Run Agent ID", str(scorecard["run_agent_id"]))
-		rc.Output.PrintDetail("State", output.StatusColor(mapString(scorecard, "state", "status")))
-		if message := mapString(scorecard, "message"); message != "" {
-			rc.Output.PrintDetail("Message", message)
-		}
-		if runAgentStatus := mapString(scorecard, "run_agent_status"); runAgentStatus != "" {
-			rc.Output.PrintDetail("Run Agent Status", output.StatusColor(runAgentStatus))
-		}
-
-		scoreLabels := []struct {
-			Key   string
-			Label string
-		}{
-			{Key: "overall_score", Label: "Overall Score"},
-			{Key: "correctness_score", Label: "Correctness"},
-			{Key: "reliability_score", Label: "Reliability"},
-			{Key: "latency_score", Label: "Latency"},
-			{Key: "cost_score", Label: "Cost"},
-			{Key: "behavioral_score", Label: "Behavioral"},
-		}
-		printedScores := false
-		for _, field := range scoreLabels {
-			if value := mapValue(scorecard, field.Key); value != nil {
-				if !printedScores {
-					fmt.Fprintln(rc.Output.Writer())
-					fmt.Fprintln(rc.Output.Writer(), output.Bold("Scores:"))
-					printedScores = true
-				}
-				rc.Output.PrintDetail(field.Label, fmtScore(value))
-			}
-		}
-
-		if document := mapObject(scorecard, "scorecard"); document != nil {
-			if passed := mapValue(document, "passed"); passed != nil {
-				rc.Output.PrintDetail("Passed", str(passed))
-			}
-			if strategy := mapString(document, "strategy"); strategy != "" {
-				rc.Output.PrintDetail("Strategy", strategy)
-			}
-
-			dimensions := mapObject(document, "dimensions")
-			if len(dimensions) > 0 {
-				keys := make([]string, 0, len(dimensions))
-				for name := range dimensions {
-					keys = append(keys, name)
-				}
-				sort.Strings(keys)
-				fmt.Fprintln(rc.Output.Writer())
-				fmt.Fprintln(rc.Output.Writer(), output.Bold("Dimensions:"))
-				for _, name := range keys {
-					rc.Output.PrintDetail(cases.Title(language.English).String(name), formatDimensionSummary(dimensions[name]))
-				}
-			}
-		} else if dimensions := mapObject(scorecard, "dimensions"); len(dimensions) > 0 {
-			fmt.Fprintln(rc.Output.Writer())
-			fmt.Fprintln(rc.Output.Writer(), output.Bold("Scores:"))
-			keys := make([]string, 0, len(dimensions))
-			for name := range dimensions {
-				keys = append(keys, name)
-			}
-			sort.Strings(keys)
-			for _, name := range keys {
-				rc.Output.PrintDetail(cases.Title(language.English).String(name), formatDimensionSummary(dimensions[name]))
-			}
-		}
+		renderRunAgentScorecard(rc, scorecard)
 		return nil
 	},
 }

--- a/cli/cmd/run_create_helpers.go
+++ b/cli/cmd/run_create_helpers.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/agentclash/agentclash/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type runCreateRequest struct {
+	ChallengePackVersionID string
+	ChallengeInputSetID    string
+	DeploymentIDs          []string
+	Name                   string
+	OfficialPackMode       string
+	RegressionSuiteIDs     []string
+	RegressionCaseIDs      []string
+	RaceContext            bool
+	RaceContextCadence     int
+}
+
+func runCreateRequestFromFlags(cmd *cobra.Command, base runCreateRequest) (runCreateRequest, error) {
+	request := base
+
+	name, _ := cmd.Flags().GetString("name")
+	request.Name = name
+
+	scope, _ := cmd.Flags().GetString("scope")
+	scope = strings.TrimSpace(scope)
+	if scope == "" {
+		scope = "full"
+	}
+	switch scope {
+	case "full", "suite_only":
+	default:
+		return runCreateRequest{}, fmt.Errorf("invalid --scope %q (want full or suite_only)", scope)
+	}
+	request.OfficialPackMode = scope
+
+	suiteIDs, _ := cmd.Flags().GetStringSlice("suite")
+	caseIDs, _ := cmd.Flags().GetStringSlice("case")
+	request.RegressionSuiteIDs = compactNonEmptyStrings(suiteIDs)
+	request.RegressionCaseIDs = compactNonEmptyStrings(caseIDs)
+
+	raceContext, _ := cmd.Flags().GetBool("race-context")
+	request.RaceContext = raceContext
+
+	cadence, _ := cmd.Flags().GetInt("race-context-cadence")
+	request.RaceContextCadence = cadence
+
+	return request, nil
+}
+
+func buildRunCreateBody(workspaceID string, request runCreateRequest) (map[string]any, error) {
+	if request.ChallengePackVersionID == "" {
+		return nil, fmt.Errorf("challenge pack version is required")
+	}
+	if len(request.DeploymentIDs) == 0 {
+		return nil, fmt.Errorf("at least one deployment is required")
+	}
+	if request.OfficialPackMode == "suite_only" && len(request.RegressionSuiteIDs) == 0 && len(request.RegressionCaseIDs) == 0 {
+		return nil, fmt.Errorf("--scope suite_only requires at least one regression suite or regression case")
+	}
+	if request.RaceContextCadence < 0 || request.RaceContextCadence > 10 {
+		return nil, fmt.Errorf("--race-context-cadence must be between 1 and 10, got %d", request.RaceContextCadence)
+	}
+
+	body := map[string]any{
+		"workspace_id":              workspaceID,
+		"challenge_pack_version_id": request.ChallengePackVersionID,
+		"agent_deployment_ids":      request.DeploymentIDs,
+		"official_pack_mode":        request.OfficialPackMode,
+	}
+	if request.Name != "" {
+		body["name"] = request.Name
+	}
+	if request.ChallengeInputSetID != "" {
+		body["challenge_input_set_id"] = request.ChallengeInputSetID
+	}
+	if len(request.RegressionSuiteIDs) > 0 {
+		body["regression_suite_ids"] = request.RegressionSuiteIDs
+	}
+	if len(request.RegressionCaseIDs) > 0 {
+		body["regression_case_ids"] = request.RegressionCaseIDs
+	}
+	if request.RaceContext {
+		body["race_context"] = true
+	}
+	if request.RaceContextCadence > 0 {
+		body["race_context_min_step_gap"] = request.RaceContextCadence
+	}
+	return body, nil
+}
+
+func createRun(cmd *cobra.Command, rc *RunContext, body map[string]any) (map[string]any, error) {
+	sp := output.NewSpinner("Creating run...", flagQuiet)
+	resp, err := rc.Client.Post(cmd.Context(), "/v1/runs", body)
+	if err != nil {
+		sp.StopWithError("Failed to create run")
+		return nil, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		sp.StopWithError("Failed to create run")
+		return nil, apiErr
+	}
+
+	var run map[string]any
+	if err := resp.DecodeJSON(&run); err != nil {
+		return nil, err
+	}
+
+	sp.StopWithSuccess(fmt.Sprintf("Created run %s", str(run["id"])))
+	return run, nil
+}
+
+func presentCreatedRun(cmd *cobra.Command, rc *RunContext, run map[string]any, follow bool, afterFollow func(string) error) error {
+	if rc.Output.IsStructured() {
+		return rc.Output.PrintRaw(run)
+	}
+
+	runID := str(run["id"])
+	rc.Output.PrintDetail("Run ID", runID)
+	rc.Output.PrintDetail("Status", output.StatusColor(str(run["status"])))
+
+	if follow {
+		fmt.Fprintln(os.Stderr)
+		if err := streamRunEvents(cmd, rc, runID); err != nil {
+			return err
+		}
+		if afterFollow != nil {
+			return afterFollow(runID)
+		}
+	}
+
+	return nil
+}
+
+func compactNonEmptyStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	return out
+}

--- a/cli/cmd/run_create_helpers.go
+++ b/cli/cmd/run_create_helpers.go
@@ -64,7 +64,7 @@ func buildRunCreateBody(workspaceID string, request runCreateRequest) (map[strin
 		return nil, fmt.Errorf("--scope suite_only requires at least one regression suite or regression case")
 	}
 	if request.RaceContextCadence < 0 || request.RaceContextCadence > 10 {
-		return nil, fmt.Errorf("--race-context-cadence must be between 1 and 10, got %d", request.RaceContextCadence)
+		return nil, fmt.Errorf("--race-context-cadence must be 0 (backend default) or between 1 and 10, got %d", request.RaceContextCadence)
 	}
 
 	body := map[string]any{

--- a/cli/cmd/run_create_interactive.go
+++ b/cli/cmd/run_create_interactive.go
@@ -70,11 +70,12 @@ func resolveRunCreateSelections(cmd *cobra.Command, rc *RunContext, workspaceID 
 		selections.challengePackVersionID = selectedVersion
 	}
 
-	// Keep `run create` relatively explicit: only guide the user through input
-	// set selection when the challenge-pack version itself was picked
-	// interactively. Workflow-first input-set auto-resolution lives in
-	// `agentclash eval start`.
-	if selections.challengeInputSetID == "" && cpvID == "" {
+	// Always offer the input-set picker when --input-set was omitted in a
+	// TTY, even if --challenge-pack-version was passed explicitly. Skipping
+	// the picker on explicit cpv silently changes the meaning of an existing
+	// flag combination — workflow-first auto-resolution belongs in
+	// `agentclash eval start`, not as a hidden side effect of `run create`.
+	if selections.challengeInputSetID == "" {
 		selectedInputSet, err := maybePromptForChallengeInputSet(cmd, rc, workspaceID, selections.challengePackVersionID, picker)
 		if err != nil {
 			return runCreateSelections{}, err

--- a/cli/cmd/run_create_interactive.go
+++ b/cli/cmd/run_create_interactive.go
@@ -70,7 +70,11 @@ func resolveRunCreateSelections(cmd *cobra.Command, rc *RunContext, workspaceID 
 		selections.challengePackVersionID = selectedVersion
 	}
 
-	if selections.challengeInputSetID == "" {
+	// Keep `run create` relatively explicit: only guide the user through input
+	// set selection when the challenge-pack version itself was picked
+	// interactively. Workflow-first input-set auto-resolution lives in
+	// `agentclash eval start`.
+	if selections.challengeInputSetID == "" && cpvID == "" {
 		selectedInputSet, err := maybePromptForChallengeInputSet(cmd, rc, workspaceID, selections.challengePackVersionID, picker)
 		if err != nil {
 			return runCreateSelections{}, err

--- a/cli/cmd/run_create_interactive_test.go
+++ b/cli/cmd/run_create_interactive_test.go
@@ -354,6 +354,7 @@ func TestRunCreateRaceContextFlagsPropagate(t *testing.T) {
 		"run", "create",
 		"-w", "ws-1",
 		"--challenge-pack-version", "cpv-explicit",
+		"--input-set", "input-explicit",
 		"--deployments", "dep-a,dep-b",
 		"--race-context",
 		"--race-context-cadence", "4",
@@ -397,6 +398,7 @@ func TestRunCreateRaceContextCadenceOutOfRangeFailsLocally(t *testing.T) {
 		"run", "create",
 		"-w", "ws-1",
 		"--challenge-pack-version", "cpv-explicit",
+		"--input-set", "input-explicit",
 		"--deployments", "dep-a,dep-b",
 		"--race-context",
 		"--race-context-cadence", "15",
@@ -404,8 +406,68 @@ func TestRunCreateRaceContextCadenceOutOfRangeFailsLocally(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error for out-of-range cadence")
 	}
-	if !strings.Contains(err.Error(), "between 1 and 10") {
-		t.Errorf("error message = %q, want to mention the range", err.Error())
+	// The validator accepts 0 (backend default) plus [1, 10]. The error must
+	// reflect that so users who pass -1 or 11 don't read it and conclude that
+	// 0 is also invalid.
+	if !strings.Contains(err.Error(), "0 (backend default) or between 1 and 10") {
+		t.Errorf("error message = %q, want full range guidance including the 0 sentinel", err.Error())
+	}
+}
+
+// TestRunCreateInputSetPickerFiresWhenChallengePackVersionIsExplicit pins the
+// behavior we restored after PR #414's review: passing
+// --challenge-pack-version without --input-set in a TTY must still launch the
+// interactive input-set picker. Silently submitting without an input set was
+// a regression on the prior CLI surface.
+func TestRunCreateInputSetPickerFiresWhenChallengePackVersionIsExplicit(t *testing.T) {
+	picker := &fakePicker{
+		// Only the input-set picker should be called: cpv is explicit, only
+		// one deployment exists so selectManyOrAuto auto-resolves it.
+		selectIndices: []int{0},
+	}
+	oldInteractive := isInteractiveTerminal
+	oldPickerFactory := newInteractivePicker
+	isInteractiveTerminal = func(*RunContext) bool { return true }
+	newInteractivePicker = func() interactivePicker { return picker }
+	t.Cleanup(func() {
+		isInteractiveTerminal = oldInteractive
+		newInteractivePicker = oldPickerFactory
+	})
+
+	var gotBody map[string]any
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/challenge-pack-versions/cpv-explicit/input-sets": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "input-1", "name": "Small", "input_key": "small"},
+				{"id": "input-2", "name": "Large", "input_key": "large"},
+			},
+		}),
+		"POST /v1/runs": func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "run-1", "status": "queued"})
+		},
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"run", "create",
+		"-w", "ws-1",
+		"--challenge-pack-version", "cpv-explicit",
+		"--deployments", "dep-a",
+	}, srv.URL); err != nil {
+		t.Fatalf("run create error: %v", err)
+	}
+
+	if gotBody["challenge_input_set_id"] != "input-1" {
+		t.Fatalf("challenge_input_set_id = %v, want input-1 (picker should have fired)", gotBody["challenge_input_set_id"])
+	}
+	if picker.selectCalls != 1 {
+		t.Fatalf("picker select calls = %d, want 1 (input-set picker only)", picker.selectCalls)
 	}
 }
 
@@ -439,6 +501,7 @@ func TestRunCreateWithoutRaceContextFlagsOmitsFields(t *testing.T) {
 		"run", "create",
 		"-w", "ws-1",
 		"--challenge-pack-version", "cpv-explicit",
+		"--input-set", "input-explicit",
 		"--deployments", "dep-a",
 	}, srv.URL); err != nil {
 		t.Fatalf("run create error: %v", err)

--- a/cli/cmd/scorecard_helpers.go
+++ b/cli/cmd/scorecard_helpers.go
@@ -90,7 +90,7 @@ func renderRunAgentScorecard(rc *RunContext, scorecard map[string]any) {
 
 	if dimensions := mapObject(scorecard, "dimensions"); len(dimensions) > 0 {
 		fmt.Fprintln(rc.Output.Writer())
-		fmt.Fprintln(rc.Output.Writer(), output.Bold("Scores:"))
+		fmt.Fprintln(rc.Output.Writer(), output.Bold("Dimensions:"))
 		keys := make([]string, 0, len(dimensions))
 		for name := range dimensions {
 			keys = append(keys, name)

--- a/cli/cmd/scorecard_helpers.go
+++ b/cli/cmd/scorecard_helpers.go
@@ -1,0 +1,230 @@
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+
+	"github.com/agentclash/agentclash/cli/internal/api"
+	"github.com/agentclash/agentclash/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func fetchRunAgentScorecard(cmd *cobra.Command, rc *RunContext, runAgentID string) (*api.Response, map[string]any, error) {
+	resp, err := rc.Client.Get(cmd.Context(), "/v1/scorecards/"+runAgentID, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.StatusCode != 202 && resp.StatusCode != 409 {
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return resp, nil, apiErr
+		}
+	}
+
+	var scorecard map[string]any
+	if err := resp.DecodeJSON(&scorecard); err != nil {
+		return resp, nil, err
+	}
+	return resp, scorecard, nil
+}
+
+func renderRunAgentScorecard(rc *RunContext, scorecard map[string]any) {
+	rc.Output.PrintDetail("Run Agent ID", str(scorecard["run_agent_id"]))
+	rc.Output.PrintDetail("State", output.StatusColor(mapString(scorecard, "state", "status")))
+	if message := mapString(scorecard, "message"); message != "" {
+		rc.Output.PrintDetail("Message", message)
+	}
+	if runAgentStatus := mapString(scorecard, "run_agent_status"); runAgentStatus != "" {
+		rc.Output.PrintDetail("Run Agent Status", output.StatusColor(runAgentStatus))
+	}
+
+	scoreLabels := []struct {
+		Key   string
+		Label string
+	}{
+		{Key: "overall_score", Label: "Overall Score"},
+		{Key: "correctness_score", Label: "Correctness"},
+		{Key: "reliability_score", Label: "Reliability"},
+		{Key: "latency_score", Label: "Latency"},
+		{Key: "cost_score", Label: "Cost"},
+		{Key: "behavioral_score", Label: "Behavioral"},
+	}
+	printedScores := false
+	for _, field := range scoreLabels {
+		if value := mapValue(scorecard, field.Key); value != nil {
+			if !printedScores {
+				fmt.Fprintln(rc.Output.Writer())
+				fmt.Fprintln(rc.Output.Writer(), output.Bold("Scores:"))
+				printedScores = true
+			}
+			rc.Output.PrintDetail(field.Label, fmtScore(value))
+		}
+	}
+
+	if document := mapObject(scorecard, "scorecard"); document != nil {
+		if passed := mapValue(document, "passed"); passed != nil {
+			rc.Output.PrintDetail("Passed", str(passed))
+		}
+		if strategy := mapString(document, "strategy"); strategy != "" {
+			rc.Output.PrintDetail("Strategy", strategy)
+		}
+
+		dimensions := mapObject(document, "dimensions")
+		if len(dimensions) > 0 {
+			keys := make([]string, 0, len(dimensions))
+			for name := range dimensions {
+				keys = append(keys, name)
+			}
+			sort.Strings(keys)
+			fmt.Fprintln(rc.Output.Writer())
+			fmt.Fprintln(rc.Output.Writer(), output.Bold("Dimensions:"))
+			for _, name := range keys {
+				rc.Output.PrintDetail(cases.Title(language.English).String(name), formatDimensionSummary(dimensions[name]))
+			}
+		}
+		return
+	}
+
+	if dimensions := mapObject(scorecard, "dimensions"); len(dimensions) > 0 {
+		fmt.Fprintln(rc.Output.Writer())
+		fmt.Fprintln(rc.Output.Writer(), output.Bold("Scores:"))
+		keys := make([]string, 0, len(dimensions))
+		for name := range dimensions {
+			keys = append(keys, name)
+		}
+		sort.Strings(keys)
+		for _, name := range keys {
+			rc.Output.PrintDetail(cases.Title(language.English).String(name), formatDimensionSummary(dimensions[name]))
+		}
+	}
+}
+
+func fetchRunComparison(cmd *cobra.Command, rc *RunContext, baselineRunID, candidateRunID, baselineRunAgentID, candidateRunAgentID string) (map[string]any, error) {
+	q := url.Values{}
+	q.Set("baseline_run_id", baselineRunID)
+	q.Set("candidate_run_id", candidateRunID)
+	if baselineRunAgentID != "" {
+		q.Set("baseline_run_agent_id", baselineRunAgentID)
+	}
+	if candidateRunAgentID != "" {
+		q.Set("candidate_run_agent_id", candidateRunAgentID)
+	}
+
+	resp, err := rc.Client.Get(cmd.Context(), "/v1/compare", q)
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return nil, apiErr
+	}
+
+	var comparison map[string]any
+	if err := resp.DecodeJSON(&comparison); err != nil {
+		return nil, err
+	}
+	return comparison, nil
+}
+
+func renderRunComparisonSummary(rc *RunContext, comparison map[string]any, baselineLabel, candidateLabel string) {
+	fmt.Fprintln(rc.Output.Writer())
+	fmt.Fprintln(rc.Output.Writer(), output.Bold("Baseline Comparison"))
+	rc.Output.PrintDetail("Baseline", baselineLabel)
+	rc.Output.PrintDetail("Candidate", candidateLabel)
+	rc.Output.PrintDetail("State", mapString(comparison, "state"))
+	rc.Output.PrintDetail("Status", output.StatusColor(mapString(comparison, "status")))
+	if reason := mapString(comparison, "reason_code"); reason != "" {
+		rc.Output.PrintDetail("Reason", reason)
+	}
+
+	if deltas := mapSlice(comparison, "key_deltas"); len(deltas) > 0 {
+		fmt.Fprintln(rc.Output.Writer())
+		cols := []output.Column{{Header: "Metric"}, {Header: "Baseline"}, {Header: "Candidate"}, {Header: "Delta"}, {Header: "Outcome"}}
+		rows := make([][]string, len(deltas))
+		for i, item := range deltas {
+			delta := item.(map[string]any)
+			rows[i] = []string{
+				mapString(delta, "metric"),
+				fmtScore(mapValue(delta, "baseline_value")),
+				fmtScore(mapValue(delta, "candidate_value")),
+				fmtDelta(mapValue(delta, "delta")),
+				mapString(delta, "outcome", "state"),
+			}
+		}
+		rc.Output.PrintTable(cols, rows)
+	}
+
+	if reasons := mapSlice(comparison, "regression_reasons"); len(reasons) > 0 {
+		fmt.Fprintln(rc.Output.Writer())
+		fmt.Fprintln(rc.Output.Writer(), output.Bold("Regression Reasons"))
+		for _, reason := range reasons {
+			fmt.Fprintf(rc.Output.Writer(), "  - %s\n", str(reason))
+		}
+	}
+
+	if evidence := mapObject(comparison, "evidence_quality"); evidence != nil {
+		if warnings := mapSlice(evidence, "warnings"); len(warnings) > 0 {
+			fmt.Fprintln(rc.Output.Writer())
+			fmt.Fprintln(rc.Output.Writer(), output.Bold("Evidence Warnings"))
+			for _, warning := range warnings {
+				fmt.Fprintf(rc.Output.Writer(), "  - %s\n", str(warning))
+			}
+		}
+		if missing := mapSlice(evidence, "missing_fields"); len(missing) > 0 {
+			fmt.Fprintln(rc.Output.Writer())
+			fmt.Fprintln(rc.Output.Writer(), output.Bold("Missing Evidence"))
+			for _, field := range missing {
+				fmt.Fprintf(rc.Output.Writer(), "  - %s\n", str(field))
+			}
+		}
+	}
+}
+
+func evaluateReleaseGate(cmd *cobra.Command, rc *RunContext, baselineRunID, candidateRunID, baselineRunAgentID, candidateRunAgentID string) (map[string]any, error) {
+	body := map[string]any{
+		"baseline_run_id":  baselineRunID,
+		"candidate_run_id": candidateRunID,
+	}
+	if baselineRunAgentID != "" {
+		body["baseline_run_agent_id"] = baselineRunAgentID
+	}
+	if candidateRunAgentID != "" {
+		body["candidate_run_agent_id"] = candidateRunAgentID
+	}
+
+	resp, err := rc.Client.Post(cmd.Context(), "/v1/release-gates/evaluate", body)
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return nil, apiErr
+	}
+
+	var gate map[string]any
+	if err := resp.DecodeJSON(&gate); err != nil {
+		return nil, err
+	}
+	return gate, nil
+}
+
+func renderReleaseGateSummary(rc *RunContext, gateEnvelope map[string]any) {
+	releaseGate := mapObject(gateEnvelope, "release_gate")
+	if releaseGate == nil {
+		return
+	}
+
+	fmt.Fprintln(rc.Output.Writer())
+	fmt.Fprintln(rc.Output.Writer(), output.Bold("Regression Verdict"))
+	rc.Output.PrintDetail("Verdict", mapString(releaseGate, "verdict"))
+	if summary := mapString(releaseGate, "summary"); summary != "" {
+		rc.Output.PrintDetail("Summary", summary)
+	}
+	if reason := mapString(releaseGate, "reason_code"); reason != "" {
+		rc.Output.PrintDetail("Reason", reason)
+	}
+	if evidence := mapString(releaseGate, "evidence_status"); evidence != "" {
+		rc.Output.PrintDetail("Evidence", evidence)
+	}
+}

--- a/cli/cmd/workspace.go
+++ b/cli/cmd/workspace.go
@@ -211,7 +211,7 @@ var wsUpdateCmd = &cobra.Command{
 var wsUseCmd = &cobra.Command{
 	Use:   "use <id>",
 	Short: "Set the default workspace",
-	Long:  "Sets the workspace ID as the default for subsequent commands.\nStored in ~/.config/agentclash/config.yaml.",
+	Long:  "Sets the workspace ID as the default for subsequent commands.\nStored in ~/.config/agentclash/config.yaml.\n\nFor the guided post-login flow, prefer `agentclash link`.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		rc := GetRunContext(cmd)

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -10,10 +10,22 @@ import (
 
 // UserConfig holds user-level settings stored at ~/.config/agentclash/config.yaml.
 type UserConfig struct {
-	DefaultWorkspace string `yaml:"default_workspace,omitempty"`
-	DefaultOrg       string `yaml:"default_org,omitempty"`
-	APIURL           string `yaml:"api_url,omitempty"`
-	Output           string `yaml:"output,omitempty"`
+	DefaultWorkspace  string                      `yaml:"default_workspace,omitempty"`
+	DefaultOrg        string                      `yaml:"default_org,omitempty"`
+	APIURL            string                      `yaml:"api_url,omitempty"`
+	Output            string                      `yaml:"output,omitempty"`
+	BaselineBookmarks map[string]BaselineBookmark `yaml:"baseline_bookmarks,omitempty"`
+}
+
+// BaselineBookmark stores a workspace-scoped default baseline run selection.
+// It is user-local state layered on top of the existing compare/release-gate
+// API, which still expects explicit baseline and candidate run IDs.
+type BaselineBookmark struct {
+	RunID         string `yaml:"run_id"`
+	RunAgentID    string `yaml:"run_agent_id,omitempty"`
+	RunName       string `yaml:"run_name,omitempty"`
+	RunAgentLabel string `yaml:"run_agent_label,omitempty"`
+	SetAt         string `yaml:"set_at,omitempty"`
 }
 
 // ConfigDir returns the config directory path.
@@ -98,4 +110,44 @@ func (c *UserConfig) Set(key, value string) error {
 // Keys returns all valid config key names.
 func Keys() []string {
 	return []string{"default_workspace", "default_org", "api_url", "output"}
+}
+
+// BaselineBookmarkForWorkspace returns the bookmark for a workspace when one
+// is present. Empty or unknown workspace IDs return false.
+func (c UserConfig) BaselineBookmarkForWorkspace(workspaceID string) (BaselineBookmark, bool) {
+	if workspaceID == "" || len(c.BaselineBookmarks) == 0 {
+		return BaselineBookmark{}, false
+	}
+	bookmark, ok := c.BaselineBookmarks[workspaceID]
+	if !ok || bookmark.RunID == "" {
+		return BaselineBookmark{}, false
+	}
+	return bookmark, true
+}
+
+// SetBaselineBookmark stores or replaces the bookmark for a workspace.
+func (c *UserConfig) SetBaselineBookmark(workspaceID string, bookmark BaselineBookmark) {
+	if workspaceID == "" || bookmark.RunID == "" {
+		return
+	}
+	if c.BaselineBookmarks == nil {
+		c.BaselineBookmarks = make(map[string]BaselineBookmark)
+	}
+	c.BaselineBookmarks[workspaceID] = bookmark
+}
+
+// ClearBaselineBookmark removes the bookmark for a workspace. It returns true
+// when an existing bookmark was deleted.
+func (c *UserConfig) ClearBaselineBookmark(workspaceID string) bool {
+	if workspaceID == "" || len(c.BaselineBookmarks) == 0 {
+		return false
+	}
+	if _, ok := c.BaselineBookmarks[workspaceID]; !ok {
+		return false
+	}
+	delete(c.BaselineBookmarks, workspaceID)
+	if len(c.BaselineBookmarks) == 0 {
+		c.BaselineBookmarks = nil
+	}
+	return true
 }

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -61,6 +61,12 @@ func TestSaveAndLoadUserConfig(t *testing.T) {
 		DefaultOrg:       "org-def",
 		APIURL:           "https://test.example.com",
 		Output:           "yaml",
+		BaselineBookmarks: map[string]BaselineBookmark{
+			"ws-abc": {
+				RunID:      "run-1",
+				RunAgentID: "agent-1",
+			},
+		},
 	}
 
 	if err := Save(original); err != nil {
@@ -83,6 +89,16 @@ func TestSaveAndLoadUserConfig(t *testing.T) {
 	}
 	if loaded.Output != original.Output {
 		t.Fatalf("Output = %q, want %q", loaded.Output, original.Output)
+	}
+	bookmark, ok := loaded.BaselineBookmarkForWorkspace("ws-abc")
+	if !ok {
+		t.Fatal("expected baseline bookmark for ws-abc")
+	}
+	if bookmark.RunID != "run-1" {
+		t.Fatalf("bookmark.RunID = %q, want %q", bookmark.RunID, "run-1")
+	}
+	if bookmark.RunAgentID != "agent-1" {
+		t.Fatalf("bookmark.RunAgentID = %q, want %q", bookmark.RunAgentID, "agent-1")
 	}
 }
 
@@ -115,5 +131,62 @@ func TestKeysReturnsAllValidKeys(t *testing.T) {
 		if !expected[k] {
 			t.Fatalf("unexpected key %q", k)
 		}
+	}
+}
+
+func TestBaselineBookmarkForWorkspace(t *testing.T) {
+	cfg := UserConfig{
+		BaselineBookmarks: map[string]BaselineBookmark{
+			"ws-1": {
+				RunID:      "run-1",
+				RunAgentID: "agent-1",
+			},
+		},
+	}
+
+	bookmark, ok := cfg.BaselineBookmarkForWorkspace("ws-1")
+	if !ok {
+		t.Fatal("expected bookmark for ws-1")
+	}
+	if bookmark.RunID != "run-1" {
+		t.Fatalf("RunID = %q, want %q", bookmark.RunID, "run-1")
+	}
+	if _, ok := cfg.BaselineBookmarkForWorkspace("ws-2"); ok {
+		t.Fatal("unexpected bookmark for ws-2")
+	}
+}
+
+func TestSetBaselineBookmarkInitializesMap(t *testing.T) {
+	var cfg UserConfig
+	cfg.SetBaselineBookmark("ws-1", BaselineBookmark{RunID: "run-1"})
+
+	bookmark, ok := cfg.BaselineBookmarkForWorkspace("ws-1")
+	if !ok {
+		t.Fatal("expected bookmark after SetBaselineBookmark")
+	}
+	if bookmark.RunID != "run-1" {
+		t.Fatalf("RunID = %q, want %q", bookmark.RunID, "run-1")
+	}
+}
+
+func TestClearBaselineBookmark(t *testing.T) {
+	cfg := UserConfig{
+		BaselineBookmarks: map[string]BaselineBookmark{
+			"ws-1": {RunID: "run-1"},
+			"ws-2": {RunID: "run-2"},
+		},
+	}
+
+	if !cfg.ClearBaselineBookmark("ws-1") {
+		t.Fatal("expected bookmark removal to return true")
+	}
+	if _, ok := cfg.BaselineBookmarkForWorkspace("ws-1"); ok {
+		t.Fatal("bookmark ws-1 should be cleared")
+	}
+	if _, ok := cfg.BaselineBookmarkForWorkspace("ws-2"); !ok {
+		t.Fatal("bookmark ws-2 should remain")
+	}
+	if cfg.ClearBaselineBookmark("ws-1") {
+		t.Fatal("clearing the same bookmark twice should return false")
 	}
 }

--- a/cli/internal/config/manager.go
+++ b/cli/internal/config/manager.go
@@ -142,3 +142,13 @@ func (m *Manager) DevWorkspaceMemberships() string {
 func (m *Manager) UserConfig() *UserConfig {
 	return &m.user
 }
+
+// BaselineBookmark returns the workspace-scoped baseline bookmark for the
+// provided workspace ID. When workspaceID is empty, the resolved default
+// workspace is used.
+func (m *Manager) BaselineBookmark(workspaceID string) (BaselineBookmark, bool) {
+	if workspaceID == "" {
+		workspaceID = m.WorkspaceID()
+	}
+	return m.user.BaselineBookmarkForWorkspace(workspaceID)
+}

--- a/cli/internal/config/manager_test.go
+++ b/cli/internal/config/manager_test.go
@@ -88,6 +88,61 @@ func TestManagerPrecedenceUserConfigOverridesDefaults(t *testing.T) {
 	}
 }
 
+func TestManagerBaselineBookmarkUsesResolvedWorkspace(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("AGENTCLASH_WORKSPACE", "")
+
+	if err := Save(UserConfig{
+		DefaultWorkspace: "user-ws-id",
+		BaselineBookmarks: map[string]BaselineBookmark{
+			"user-ws-id": {RunID: "run-1"},
+		},
+	}); err != nil {
+		t.Fatalf("Save error: %v", err)
+	}
+
+	mgr, err := NewManager(FlagOverrides{})
+	if err != nil {
+		t.Fatalf("NewManager error: %v", err)
+	}
+
+	bookmark, ok := mgr.BaselineBookmark("")
+	if !ok {
+		t.Fatal("expected resolved workspace bookmark")
+	}
+	if bookmark.RunID != "run-1" {
+		t.Fatalf("RunID = %q, want %q", bookmark.RunID, "run-1")
+	}
+}
+
+func TestManagerBaselineBookmarkHonorsExplicitWorkspace(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	if err := Save(UserConfig{
+		DefaultWorkspace: "user-ws-id",
+		BaselineBookmarks: map[string]BaselineBookmark{
+			"other-ws-id": {RunID: "run-2"},
+		},
+	}); err != nil {
+		t.Fatalf("Save error: %v", err)
+	}
+
+	mgr, err := NewManager(FlagOverrides{})
+	if err != nil {
+		t.Fatalf("NewManager error: %v", err)
+	}
+
+	bookmark, ok := mgr.BaselineBookmark("other-ws-id")
+	if !ok {
+		t.Fatal("expected explicit workspace bookmark")
+	}
+	if bookmark.RunID != "run-2" {
+		t.Fatalf("RunID = %q, want %q", bookmark.RunID, "run-2")
+	}
+}
+
 func TestManagerDefaultValues(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)

--- a/docs/cli-phase1-handoff.md
+++ b/docs/cli-phase1-handoff.md
@@ -1,0 +1,170 @@
+# CLI Phase 1 Handoff
+
+## What shipped
+
+Phase 1 shipped an additive, workflow-first CLI layer on top of the existing resource-oriented command tree.
+
+The new happy path is:
+
+1. `agentclash auth login`
+2. `agentclash link`
+3. `agentclash challenge-pack init`
+4. `agentclash challenge-pack validate`
+5. `agentclash challenge-pack publish`
+6. `agentclash eval start --follow`
+7. `agentclash baseline set`
+8. `agentclash eval scorecard`
+
+The old `workspace`, `run`, and `compare` surfaces still exist and remain the advanced path.
+
+## Commands Added Or Changed
+
+Added:
+
+- `agentclash link`
+- `agentclash eval start`
+- `agentclash eval scorecard`
+- `agentclash baseline set`
+- `agentclash baseline show`
+- `agentclash baseline clear`
+- `agentclash doctor`
+- `agentclash challenge-pack init`
+
+Changed:
+
+- `agentclash run create`
+  - added `--scope`
+  - added `--suite`
+  - added `--case`
+  - local validation for `suite_only` and race-context cadence
+- `agentclash run scorecard`
+  - rendering now goes through shared scorecard helpers
+- root help, `workspace use`, and `run create`/`run scorecard` help now point users toward the workflow-first path
+
+## Config And State Added
+
+User config now supports workspace-scoped baseline bookmarks in `~/.config/agentclash/config.yaml`.
+
+Shape:
+
+- `baseline_bookmarks.<workspace-id>.run_id`
+- `baseline_bookmarks.<workspace-id>.run_agent_id`
+- optional UX metadata: `run_name`, `run_agent_label`, `set_at`
+
+This is intentionally local-only in Phase 1. There is no backend bookmark object.
+
+## Main Files Changed
+
+CLI:
+
+- `cli/cmd/root.go`
+- `cli/cmd/run.go`
+- `cli/cmd/run_create_interactive.go`
+- `cli/cmd/challenge_pack.go`
+- `cli/cmd/workspace.go`
+- `cli/cmd/link.go`
+- `cli/cmd/eval.go`
+- `cli/cmd/baseline.go`
+- `cli/cmd/doctor.go`
+- `cli/cmd/eval_resolve.go`
+- `cli/cmd/run_create_helpers.go`
+- `cli/cmd/scorecard_helpers.go`
+
+Config:
+
+- `cli/internal/config/config.go`
+- `cli/internal/config/manager.go`
+
+Tests:
+
+- `cli/cmd/cmd_test.go`
+- `cli/cmd/contract_alignment_test.go`
+- `cli/cmd/link_test.go`
+- `cli/cmd/eval_test.go`
+- `cli/cmd/baseline_test.go`
+- `cli/cmd/doctor_test.go`
+- `cli/cmd/challenge_pack_init_test.go`
+- `cli/internal/config/config_test.go`
+- `cli/internal/config/manager_test.go`
+
+Docs:
+
+- `README.md`
+- `npm/cli/README.md`
+- `web/content/docs/getting-started/quickstart.mdx`
+- `web/content/docs/guides/write-a-challenge-pack.mdx`
+- `web/content/docs/contributing/testing.mdx`
+- `testing/codex-cli-phase1-agent-first.md`
+
+Support / smoke:
+
+- `testing/cli-e2e-suite.sh`
+
+## Tests And Self-Checks Added
+
+New coverage includes:
+
+- root help assertions for the workflow-first path
+- `link` selector + interactive default-workspace save
+- `baseline set/show/clear`
+- `challenge-pack init`
+- `eval start` selector resolution and request-shape assertions
+- `eval scorecard --json` workflow envelope assertions
+- ambiguous multi-agent handling for `eval scorecard`
+- config persistence for workspace-scoped baseline bookmarks
+- contract alignment for `run create` regression selector fields
+- shell smoke checks for new command discovery/help in `testing/cli-e2e-suite.sh`
+
+## Known Limitations
+
+- Phase 1 is CLI-only. There is still no official Claude/Codex plugin, MCP server, or skills bundle.
+- `baseline` bookmarks are local user config, not server-side state.
+- `eval scorecard` still needs `--agent` or a TTY when a run has multiple run agents.
+- `link` saves default workspace/org only. It does not replace repo-local `.agentclash.yaml`.
+- `run create` remains the advanced ID-centric surface. The intent-first UX lives in `eval start`.
+- `eval start` resolves suite names, but `--case` still expects case IDs.
+
+## Deferred To Phase 2
+
+- official Claude/Codex integration: plugin, MCP, skills, slash commands
+- more intent-first workflow commands such as `quickstart`, `compare latest`, and `replay triage`
+- update/discovery lifecycle commands for agent assets
+- richer auth profiles and debug/diagnostic visibility
+- server-side or shareable baseline bookmarks
+- deeper workflow around regression cases by friendly selectors instead of raw IDs
+
+## Suggested Next Entry Points
+
+If another agent picks this up, start here:
+
+- `cli/cmd/eval.go`
+- `cli/cmd/doctor.go`
+- `cli/cmd/eval_resolve.go`
+- `cli/internal/config/config.go`
+- `web/content/docs/getting-started/quickstart.mdx`
+
+Likely next commands to add in Phase 2:
+
+- `agentclash quickstart`
+- `agentclash compare latest`
+- `agentclash replay triage`
+- `agentclash update`
+
+## Verification Commands And Results
+
+Succeeded:
+
+- `cd cli && /tmp/agentclash-go/go/bin/go build ./...`
+- `cd cli && /tmp/agentclash-go/go/bin/go vet ./...`
+- `cd cli && /tmp/agentclash-go/go/bin/go test -short ./...`
+- `cd cli && /tmp/agentclash-go/go/bin/go test -short -race -count=1 ./...`
+- `bash -n testing/cli-e2e-suite.sh`
+- `cd web && $HOME/Library/pnpm/.tools/pnpm/9.15.4_tmp_864_0/bin/pnpm build`
+
+Repo-health note:
+
+- `cd web && pnpm install --frozen-lockfile` failed because `web/pnpm-lock.yaml` was stale relative to `web/package.json` and missing `swr`.
+- For verification, `cd web && $HOME/Library/pnpm/.tools/pnpm/9.15.4_tmp_864_0/bin/pnpm install --no-frozen-lockfile` succeeded.
+- After the lockfile update, `cd web && $HOME/Library/pnpm/.tools/pnpm/9.15.4_tmp_864_0/bin/pnpm install --frozen-lockfile` also succeeded.
+- The resulting `pnpm build` succeeded.
+- The web build still emitted existing Next.js/Edge warnings around WorkOS imports plus webpack cache warnings, but it completed successfully.

--- a/npm/cli/README.md
+++ b/npm/cli/README.md
@@ -25,8 +25,9 @@ Supported platforms:
 
 ```bash
 agentclash auth login
-agentclash workspace use <workspace-id>
-agentclash run create --help
+agentclash link
+agentclash challenge-pack init support-eval.yaml
+agentclash eval start --help
 ```
 
 ## Use a local CLI build against a hosted backend
@@ -38,11 +39,11 @@ export AGENTCLASH_API_URL="https://staging-api.agentclash.dev"
 
 cd cli
 go run . auth login --device
-go run . workspace use <workspace-id>
+go run . link
 go run . run list
-go run . run create --help
+go run . eval start --help
 # When the workspace already has challenge packs and deployments:
-go run . run create --follow
+go run . eval start --follow
 ```
 
 `--api-url` overrides `AGENTCLASH_API_URL` for one-off commands.
@@ -56,6 +57,7 @@ go vet ./...
 go test -short -race -count=1 ./...
 go run github.com/goreleaser/goreleaser/v2@latest check
 go run github.com/goreleaser/goreleaser/v2@latest release --snapshot --clean
+cd ../web && pnpm build
 ```
 
 If you changed npm packaging, rehearse it locally:

--- a/testing/cli-e2e-suite.sh
+++ b/testing/cli-e2e-suite.sh
@@ -731,6 +731,13 @@ if [[ -n "$EXPECTED_VERSION" ]]; then
   fi
 fi
 
+say "Workflow Discovery"
+expect_contains "root help mentions link" "agentclash link" "${BASE[@]}" --help || true
+expect_contains "eval help lists start" "start" "${BASE[@]}" eval --help || true
+expect_contains "baseline help lists set" "set" "${BASE[@]}" baseline --help || true
+expect_contains "doctor help describes readiness checks" "Check auth, workspace, and eval readiness" "${BASE[@]}" doctor --help || true
+expect_contains "challenge-pack init help works" "Scaffold a minimal challenge pack YAML bundle" "${BASE[@]}" challenge-pack init --help || true
+
 say "Config and Auth"
 printf 'api: %s\n' "$API_URL"
 printf 'temp config: %s/agentclash\n' "$RUN_XDG"

--- a/testing/codex-cli-phase1-agent-first.md
+++ b/testing/codex-cli-phase1-agent-first.md
@@ -1,0 +1,55 @@
+# codex-cli-phase1-agent-first — Test Contract
+
+## Functional Behavior
+- Add a workflow-first Phase 1 CLI path without removing the existing resource-oriented commands.
+- `agentclash link` should use the authenticated session to choose a workspace and save it as the default workspace in user config.
+- `agentclash link` must not create or require a backend repo/project link.
+- `agentclash challenge-pack init <path>` should scaffold a minimal valid challenge-pack YAML file based on the current documented parser shape.
+- `agentclash eval start` should wrap run creation, support human-friendly challenge pack and deployment resolution, and map regression selection flags to the existing run-create API fields.
+- `agentclash run create` should gain parity flags for `official_pack_mode`, `regression_suite_ids`, and `regression_case_ids`.
+- `agentclash baseline set|show|clear` should manage a workspace-scoped local baseline bookmark stored in user config.
+- `agentclash eval scorecard` should accept a run-oriented workflow, auto-resolve the run agent when safe, and show scorecard plus compare/release-gate output when a baseline bookmark exists.
+- `agentclash doctor` should check auth, default workspace, workspace readiness, and baseline presence and print actionable output.
+- Root help, npm README, repo README, quickstart docs, challenge-pack guide, and testing docs should all reflect the new workflow-first path.
+- The implementation must add a final handoff document at `docs/cli-phase1-handoff.md` that explains shipped scope, remaining work, and exact verification results.
+
+## Unit Tests
+- Config tests for baseline bookmark persistence, overwrite behavior, clearing behavior, and workspace scoping.
+- Command tests for `link`, `challenge-pack init`, `baseline`, `eval start`, `eval scorecard`, and `doctor`.
+- Command tests for `run create` regression flag mapping.
+- Output/help assertions for new commands and updated root help.
+
+## Integration / Functional Tests
+- CLI fake-API tests should verify new commands hit the expected endpoints with the expected payload shape.
+- `web/src/lib/docs.ts` generated CLI reference should continue to discover and render the new Cobra commands.
+
+## Smoke Tests
+- `cd cli && go build ./...`
+- `cd cli && go vet ./...`
+- `cd cli && go test -short -race -count=1 ./...`
+- `bash -n testing/cli-e2e-suite.sh`
+- `cd web && pnpm build`
+
+## E2E Tests
+- N/A — no new browser E2E flow is required for this Phase 1 CLI/docs change.
+
+## Manual / cURL Tests
+```bash
+cd cli
+go run . --help
+go run . link --help
+go run . eval --help
+go run . baseline --help
+go run . doctor --help
+go run . challenge-pack init --help
+```
+
+```bash
+cd cli
+go run . challenge-pack init /tmp/agentclash-pack.yaml
+go run . challenge-pack validate /tmp/agentclash-pack.yaml
+```
+
+- In a TTY with valid credentials, run `agentclash link` and confirm it saves a usable default workspace.
+- In a workspace with a recent run, run `agentclash baseline set <run-id>` followed by `agentclash baseline show`.
+- Run `agentclash doctor` and confirm the output calls out missing or healthy prerequisites accurately.

--- a/web/content/docs/concepts/runs-and-evals.mdx
+++ b/web/content/docs/concepts/runs-and-evals.mdx
@@ -12,6 +12,12 @@ In the current user-facing product surface, `run` is the first-class noun:
 - `agentclash run ranking`
 - `agentclash compare gate --baseline <RUN_ID> --candidate <RUN_ID>`
 
+The workflow-first surface (`agentclash eval start`, `agentclash baseline set`,
+`agentclash eval scorecard`) wraps these resource commands with name-based
+selectors and a bookmarked baseline so day-to-day evaluation does not require
+juggling raw run IDs. The resource commands above remain the canonical
+ID-centric path for CI and automation.
+
 A run is not just one model token stream. It is the container for a scored evaluation attempt inside a workspace, including the challenge pack version, selected agent deployments, lifecycle timestamps, and ranking output.
 
 The word **eval** is broader. People use it to mean “the experiment I am trying to run” or “the graded set of results I care about.” That is reasonable, but if you are reading the code or the CLI, you should anchor on this:

--- a/web/content/docs/contributing/setup.mdx
+++ b/web/content/docs/contributing/setup.mdx
@@ -41,8 +41,7 @@ If you only need the CLI:
 export AGENTCLASH_API_URL="https://staging-api.agentclash.dev"
 cd cli
 go run . auth login --device
-go run . workspace list
-go run . workspace use <WORKSPACE_ID>
+go run . link
 go run . run list
 ```
 

--- a/web/content/docs/contributing/testing.mdx
+++ b/web/content/docs/contributing/testing.mdx
@@ -23,7 +23,17 @@ go vet ./...
 go test -short -race -count=1 ./...
 go run github.com/goreleaser/goreleaser/v2@latest check
 go run github.com/goreleaser/goreleaser/v2@latest release --snapshot --clean
+cd ../web && pnpm build
+cd ..
+bash testing/cli-e2e-suite.sh --help
 ```
+
+If the change affects human-facing CLI output, also add assertions for:
+
+- `agentclash --help` and command-level `--help`
+- table output for the happy path
+- JSON envelopes for workflow commands such as `eval scorecard --json`
+- config persistence when the command writes local state
 
 ## Use review checkpoints for implementation work
 

--- a/web/content/docs/getting-started/first-eval.mdx
+++ b/web/content/docs/getting-started/first-eval.mdx
@@ -42,8 +42,13 @@ You can hit the API directly:
 Or, if you are using the CLI against a prepared workspace, create and follow the run there:
 
 ```bash
-agentclash run create --follow
+agentclash eval start --follow
 ```
+
+`eval start` is the workflow-first wrapper around `run create` — it resolves
+challenge packs, versions, input sets, and deployments by name or interactive
+selection. Use `agentclash run create` directly when you want to pass IDs
+explicitly (CI scripts, automation).
 
 ## 4. Inspect the result
 

--- a/web/content/docs/getting-started/quickstart.mdx
+++ b/web/content/docs/getting-started/quickstart.mdx
@@ -7,8 +7,9 @@ This path is for people changing the CLI or trying the product without booting t
 
 <Callout type="note">
   The hosted quickstart assumes your workspace already has challenge packs and
-  deployments. If it does not, stop after `workspace use` and you have still
-  verified auth, connectivity, and workspace selection.
+  deployments. If it does not, stop after `link` and then author a pack with
+  `challenge-pack init`; you have still verified auth, connectivity, and
+  workspace selection.
 </Callout>
 
 ## 1. Install the CLI
@@ -26,11 +27,10 @@ agentclash auth login --device
 
 Use `--device` when you are in a remote shell or do not want the CLI to open a browser automatically.
 
-## 3. Pick a workspace
+## 3. Link a workspace
 
 ```bash
-agentclash workspace list
-agentclash workspace use <WORKSPACE_ID>
+agentclash link
 ```
 
 The CLI resolves the API base URL in this order:
@@ -39,17 +39,30 @@ The CLI resolves the API base URL in this order:
 --api-url > AGENTCLASH_API_URL > saved user config > http://localhost:8080
 ```
 
-## 4. Inspect what is already there
+`agentclash link` saves the selected workspace in user config so later commands do not need raw IDs by default.
+
+## 4. Choose your next path
 
 ```bash
-agentclash run list
-agentclash run create --help
+agentclash doctor
+agentclash eval start --help
 ```
 
 If the workspace is already seeded with challenge packs and agent deployments, create and follow a run:
 
 ```bash
-agentclash run create --follow
+agentclash eval start --follow
+```
+
+If the workspace is empty, scaffold a starter pack first:
+
+```bash
+agentclash challenge-pack init support-eval.yaml
+agentclash challenge-pack validate support-eval.yaml
+agentclash challenge-pack publish support-eval.yaml
+agentclash eval start --follow
+agentclash baseline set
+agentclash eval scorecard
 ```
 
 ## Verification
@@ -57,9 +70,10 @@ agentclash run create --follow
 You should now have:
 
 - a valid CLI login
-- a default workspace saved locally
+- a default workspace linked locally
 - a working connection to the hosted API
 - either a created run or enough context to see what the workspace is missing
+- a clear next step: publish a challenge pack, start an eval, or save a baseline
 
 ## See also
 

--- a/web/content/docs/guides/write-a-challenge-pack.mdx
+++ b/web/content/docs/guides/write-a-challenge-pack.mdx
@@ -8,10 +8,20 @@ Goal: write a pack that the current AgentClash parser, validator, and publish fl
 Prerequisites:
 
 - You have the CLI installed and logged in.
-- You selected a workspace with `agentclash workspace use <WORKSPACE_ID>`.
+- You linked a workspace with `agentclash link`.
 - You know whether the pack should be `prompt_eval` or `native`.
 
-## 1. Start from the current minimum shape
+## 1. Start with the CLI scaffold
+
+The fastest way to get a valid starter file is:
+
+```bash
+agentclash challenge-pack init support-eval.yaml
+```
+
+This generates a minimal bundle that matches the current parser shape. Use `--template native` if you want a native starter instead of the default `prompt_eval`.
+
+## 2. Edit the current minimum shape
 
 This is the smallest honest starting point based on the current bundle parser and tests:
 
@@ -62,7 +72,7 @@ input_sets:
 
 This is not a glamorous pack. It is a good pack skeleton because it matches the current parser shape.
 
-## 2. Add execution policy only when you need it
+## 3. Add execution policy only when you need it
 
 If the pack is `native`, you can add runtime sections like `tool_policy`, `sandbox`, and `tools`.
 
@@ -118,7 +128,7 @@ Use these sections deliberately.
 - `tools.custom` defines the tool contract the agent sees.
 - `implementation.primitive` picks the executor primitive that actually runs.
 
-## 3. Add assets when inputs should point at files
+## 4. Add assets when inputs should point at files
 
 If the pack needs files, declare them as assets instead of hardcoding mystery paths all over the bundle.
 
@@ -138,7 +148,7 @@ You can also back an asset with an uploaded artifact by setting `artifact_id` in
 
 Then cases and expectations can refer to those assets by key.
 
-## 4. Validate before you publish
+## 5. Validate before you publish
 
 The current CLI command is:
 
@@ -156,7 +166,7 @@ Typical failures the current code will catch early:
 - invalid tool parameter schemas
 - unknown artifact keys or nonexistent stored artifact IDs
 
-## 5. Publish the bundle
+## 6. Publish the bundle
 
 Once validation passes:
 
@@ -174,13 +184,21 @@ The publish response returns concrete IDs, including:
 
 Those IDs matter later because run creation asks for a pack version, not a filename.
 
-## 6. Confirm the workspace can see it
+## 7. Confirm the workspace can see it
 
 ```bash
 agentclash challenge-pack list
 ```
 
 If the pack published cleanly, it should show up in the workspace list with its versions.
+
+## 8. Run it through the workflow-first eval path
+
+```bash
+agentclash eval start --follow
+agentclash baseline set
+agentclash eval scorecard
+```
 
 ## Verification
 
@@ -189,6 +207,7 @@ You should now have:
 - a bundle YAML file the current parser accepts
 - a successful `validate` result
 - a published pack version ID you can use in run creation
+- a workflow path you can reuse without raw IDs for every step
 
 ## Troubleshooting
 

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      swr:
+        specifier: ^2.4.1
+        version: 2.4.1(react@19.2.3)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -671,105 +674,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -946,28 +933,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.15':
     resolution: {integrity: sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.15':
     resolution: {integrity: sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.15':
     resolution: {integrity: sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.15':
     resolution: {integrity: sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==}
@@ -1635,42 +1618,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
@@ -1822,28 +1799,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -2164,49 +2137,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -4091,28 +4056,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}


### PR DESCRIPTION
## Summary
- add workflow-first CLI commands for `link`, `eval`, `baseline`, `doctor`, and `challenge-pack init`
- keep the advanced `run`/`workspace` surfaces intact while adding parity flags and shared helpers
- update tests, smoke coverage, docs, and handoff artifacts for Phase 1

## Why
The CLI had the right backend primitives for runs and challenge packs, but the human and agent experience was still too ID-centric. This change adds an additive happy path for:

`auth login -> link -> challenge-pack init/validate/publish -> eval start -> baseline set -> eval scorecard`

It also fixes the stale `web/pnpm-lock.yaml` state so `pnpm install --frozen-lockfile` works again with the existing `web/package.json` dependency set.

## Notable details
- baseline bookmarks are local user config only in Phase 1
- `eval scorecard --json` now returns a combined candidate/baseline/scorecard/comparison/release-gate envelope
- `run create` remains the advanced path, but now supports `--scope`, `--suite`, and `--case`
- `web/package-lock.json` was already in sync; the pnpm lockfile was the stale one

## Validation
- `cd cli && /tmp/agentclash-go/go/bin/go build ./...`
- `cd cli && /tmp/agentclash-go/go/bin/go vet ./...`
- `cd cli && /tmp/agentclash-go/go/bin/go test -short ./...`
- `cd cli && /tmp/agentclash-go/go/bin/go test -short -race -count=1 ./...`
- `bash -n testing/cli-e2e-suite.sh`
- `cd web && $HOME/Library/pnpm/.tools/pnpm/9.15.4_tmp_864_0/bin/pnpm install --frozen-lockfile`
- `cd web && $HOME/Library/pnpm/.tools/pnpm/9.15.4_tmp_864_0/bin/pnpm build`

## Handoff
- task contract: `testing/codex-cli-phase1-agent-first.md`
- next-agent handoff: `docs/cli-phase1-handoff.md`
