### PR TITLE
fix(web): redirect /workspaces/{id} in middleware to avoid React #310

### DIFF
--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -7,6 +7,8 @@ import { authkitMiddleware } from "@workos-inc/authkit-nextjs";
 
 const authkit = authkitMiddleware();
 
+const WORKSPACE_ROOT_PATTERN = /^\/workspaces\/[^/]+\/?$/;
+
 export default function middleware(
   request: NextRequest,
   event: NextFetchEvent,
@@ -22,6 +24,12 @@ export default function middleware(
     request.nextUrl.pathname.startsWith("/share/")
   ) {
     return NextResponse.next();
+  }
+
+  if (WORKSPACE_ROOT_PATTERN.test(request.nextUrl.pathname)) {
+    const url = request.nextUrl.clone();
+    url.pathname = `${request.nextUrl.pathname.replace(/\/$/, "")}/runs`;
+    return NextResponse.redirect(url, 307);
   }
 
   return authkit(request, event);


### PR DESCRIPTION
## Summary
- Hitting `/workspaces/{id}` in production threw `Minified React error #310` ("Rendered more hooks than during the previous render") just before the URL settled on `/workspaces/{id}/runs`. After the redirect landed, the page rendered fine; loading `/runs` directly never threw.
- Root cause was the page-level `next/navigation` `redirect()` racing with the workspace layout's auth data fetch. Under RSC streaming, the layout shell — including the inner `<AuthKitProvider initialAuth={…}>` (introduced by #413) nested inside the root `<AuthKitProvider>` — reached the client before the redirect resolved, then transitioned into `/runs`. The doubled `AuthKitProvider` / `useEffect`/`getAuth` cycle gave that transition a hooks-order surface that fired `#310` inside `WorkspaceDataProvider`'s `useMemo`.
- Short-circuit `/workspaces/{id}` (optional trailing slash) to `/workspaces/{id}/runs` in `web/src/middleware.ts` as a 307 before any RSC rendering. The existing `page.tsx` `redirect()` stays as a defensive fallback.

## Test plan
- [ ] Open `/workspaces/{id}` on the preview deployment — Network tab shows a single 307 to `/workspaces/{id}/runs`, console is clean (no `#310`)
- [ ] Open `/workspaces/{id}/runs` directly — still works (regression check on the original target)
- [ ] Sidebar logo link (`href={\`/workspaces/${workspaceId}\`}`) client-routes through cleanly
- [ ] Trailing slash: `/workspaces/{id}/` also redirects to `/runs`
- [ ] Deeper paths still load: `/workspaces/{id}/builds`, `/deployments`, `/settings`, `/runs/{runId}`, etc.
- [ ] Public bypasses still work: `/docs`, `/share`, `/llms.txt`
- [ ] Unauthenticated user hits `/workspaces/{id}` — middleware 307 → `/runs`, then AuthKit middleware redirects to login (no redirect loop)
- [ ] 403 case: signed-in user without membership/org access lands on `/runs` and sees the existing 403 panel from `WorkspaceLayout`
- [x] `npx tsc --noEmit` exits 0
- [x] `pnpm lint` exits 0
- [x] `pnpm test` — 170 passed, 3 skipped
- [x] `pnpm build` succeeds

## Followup (out of scope)
The double-nested `AuthKitProvider` from #413 is still suspicious — every protected page load now triggers two `getAuth` server actions (one from the unseeded outer provider, one effectively no-op from the seeded inner). Worth tracking as a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)