### PR TITLE
[codex] Brand login as AgentClash while preserving WorkOS AuthKit

### DIFF
--- a/docs/frontend/auth-login-workos.md
+++ b/docs/frontend/auth-login-workos.md
@@ -1,0 +1,54 @@
+# AgentClash Login and WorkOS AuthKit
+
+AgentClash uses WorkOS AuthKit for hosted authentication and keeps the visible
+login entry point inside the AgentClash app at `/auth/login`.
+
+## Current Approach
+
+- `/auth/login` owns the AgentClash-branded login page and call to action.
+- Submitting the login form calls `getSignInUrl({ returnTo })` and redirects to
+  hosted AuthKit.
+- `/auth/callback` continues to use `handleAuth`, so the WorkOS SDK owns the
+  authorization-code exchange and session cookie handling.
+- `returnTo` remains allowlisted through `sanitizeReturnTo`; unsupported or
+  unsafe values fall back to `/dashboard`.
+
+## WorkOS Research Notes
+
+- WorkOS recommends hosted AuthKit as the quickest Next.js integration. Its
+  callback route must match the configured redirect URI, and its SDK requires a
+  strong cookie password of at least 32 characters.
+- Hosted AuthKit keeps complex auth flows outside the app, including signup,
+  password reset, email verification, SSO routing, MFA enrollment, bot
+  protection, localization, and session handling.
+- WorkOS branding supports logos, favicons, colors, copy, page layout, and
+  custom CSS through the dashboard.
+- The default hosted AuthKit domain is a generated `*.authkit.app` host. A custom
+  production AuthKit domain can be configured through WorkOS DNS verification,
+  but it is a paid WorkOS add-on.
+- A fully custom, self-hosted login UI is possible through WorkOS User Management
+  APIs, but it also means AgentClash must implement more auth states directly:
+  password auth, signup, reset flows, verification codes, MFA challenges, org
+  selection, custom email links, and session handoff.
+
+## Production Checklist
+
+- Configure WorkOS Redirect URI to the deployed callback, for example
+  `https://agentclash.dev/auth/callback`.
+- Configure the WorkOS sign-in endpoint to the deployed login page, for example
+  `https://agentclash.dev/auth/login`.
+- Configure the WorkOS sign-out redirect location to an AgentClash-owned route.
+- Use WorkOS dashboard branding to match AgentClash copy, assets, colors, and
+  page layout while the app stays on the hosted AuthKit flow.
+- Budget for the custom-domain add-on before promising an `auth.agentclash.dev`
+  hosted AuthKit URL.
+
+## Sources
+
+- WorkOS AuthKit Next.js guide: https://workos.com/docs/authkit/nextjs
+- WorkOS Hosted UI guide: https://workos.com/docs/authkit/hosted-ui
+- WorkOS AuthKit branding: https://workos.com/docs/authkit/branding
+- WorkOS AuthKit custom domain: https://workos.com/docs/custom-domains/authkit
+- WorkOS pricing: https://workos.com/pricing
+- WorkOS AuthKit authentication API reference:
+  https://workos.com/docs/reference/authkit/authentication

--- a/testing/codex-agentclash-auth-login.md
+++ b/testing/codex-agentclash-auth-login.md
@@ -2,6 +2,7 @@
 
 ## Functional Behavior
 - `/auth/login` must present an AgentClash-owned login experience and must not expose "Sign in with WorkOS" as the primary call to action.
+- `/auth/login` must partition the page with the Framer Lightspeed-style WebGL visual on the left and the login panel on the right at desktop widths, with a responsive layout for smaller screens.
 - The login action must keep using the existing WorkOS AuthKit hosted authorization redirect through `getSignInUrl({ returnTo })` so password reset, email verification, SSO routing, MFA, bot protection, and session handling remain delegated to AuthKit.
 - Existing `returnTo` behavior must be preserved: unsafe values and unsupported paths fall back to `/dashboard`, and `/auth/device?user_code=...` remains supported for CLI device login.
 - The PR must document the WorkOS research outcome: hosted AuthKit can be branded on the free AuthKit tier, the default hosted domain remains `*.authkit.app`, custom AuthKit domains are a paid add-on, and fully headless custom UI is possible but broader than this safe branding PR.
@@ -10,6 +11,7 @@
 ## Unit Tests
 - `web/src/lib/auth/__tests__/return-to.test.ts` must continue to pass unchanged or with equivalent coverage.
 - Add or update focused tests for login UI rendering so the primary action says `Continue with AgentClash` and does not include `Sign in with WorkOS`.
+- Add focused coverage for the local Lightspeed visual wrapper so the left-side visual can render a canvas and degrade when WebGL is unavailable.
 - Add or update focused tests for `signInAction` if implementation behavior changes; otherwise keep existing server action behavior intact.
 
 ## Integration / Functional Tests

--- a/testing/codex-agentclash-auth-login.md
+++ b/testing/codex-agentclash-auth-login.md
@@ -1,0 +1,34 @@
+# Codex AgentClash Auth Login — Test Contract
+
+## Functional Behavior
+- `/auth/login` must present an AgentClash-owned login experience and must not expose "Sign in with WorkOS" as the primary call to action.
+- The login action must keep using the existing WorkOS AuthKit hosted authorization redirect through `getSignInUrl({ returnTo })` so password reset, email verification, SSO routing, MFA, bot protection, and session handling remain delegated to AuthKit.
+- Existing `returnTo` behavior must be preserved: unsafe values and unsupported paths fall back to `/dashboard`, and `/auth/device?user_code=...` remains supported for CLI device login.
+- The PR must document the WorkOS research outcome: hosted AuthKit can be branded on the free AuthKit tier, the default hosted domain remains `*.authkit.app`, custom AuthKit domains are a paid add-on, and fully headless custom UI is possible but broader than this safe branding PR.
+- No backend auth, token validation, CLI device login, or WorkOS callback semantics should change.
+
+## Unit Tests
+- `web/src/lib/auth/__tests__/return-to.test.ts` must continue to pass unchanged or with equivalent coverage.
+- Add or update focused tests for login UI rendering so the primary action says `Continue with AgentClash` and does not include `Sign in with WorkOS`.
+- Add or update focused tests for `signInAction` if implementation behavior changes; otherwise keep existing server action behavior intact.
+
+## Integration / Functional Tests
+- Run the relevant web test suite for auth/login and return-to behavior.
+- Run lint for touched frontend files where practical.
+
+## Smoke Tests
+- Start the Next.js app locally if practical and load `/auth/login` to confirm the page renders.
+- Confirm the page includes AgentClash branding and the login form submits to the existing server action.
+
+## E2E Tests
+- N/A — a full WorkOS hosted login round trip requires configured WorkOS credentials and an external identity flow.
+
+## Manual / cURL Tests
+```bash
+cd web
+npm run test -- src/lib/auth/__tests__/return-to.test.ts src/app/auth/login
+# Expected: tests pass.
+
+npm run lint -- src/app/auth/login src/lib/auth
+# Expected: lint passes for touched auth/login files.
+```

--- a/web/src/app/auth/login/lightspeed.test.tsx
+++ b/web/src/app/auth/login/lightspeed.test.tsx
@@ -1,0 +1,49 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LightSpeed } from "./lightspeed";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function render(element: React.ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(element);
+  });
+}
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  vi.restoreAllMocks();
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe("LightSpeed", () => {
+  it("renders the visual canvas shell", () => {
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
+
+    render(<LightSpeed paused />);
+
+    expect(
+      container?.querySelector('[data-testid="lightspeed-visual"]'),
+    ).toBeTruthy();
+    expect(
+      container?.querySelector('[data-testid="lightspeed-canvas"]'),
+    ).toBeTruthy();
+  });
+
+  it("shows a fallback when WebGL2 is unavailable", () => {
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
+
+    render(<LightSpeed />);
+
+    expect(container?.textContent).toContain("WebGL not supported");
+  });
+});

--- a/web/src/app/auth/login/lightspeed.tsx
+++ b/web/src/app/auth/login/lightspeed.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const FRAGMENT_SHADER = `#version 300 es
+precision highp float;
+out vec4 O;
+uniform float time;
+uniform vec2 resolution;
+uniform float intensity;
+uniform float particleCount;
+uniform vec3 colorShift;
+
+#define FC gl_FragCoord.xy
+#define R  resolution
+#define T  time
+
+float rnd(float a) {
+  vec2 p = fract(a * vec2(12.9898, 78.233));
+  p += dot(p, p*345.);
+  return fract(p.x * p.y);
+}
+
+vec3 hue(float a) {
+  return colorShift * (.6+.6*cos(6.3*(a)+vec3(0,83,21)));
+}
+
+vec3 pattern(vec2 uv) {
+  vec3 col = vec3(0.);
+  for (float i=.0; i<particleCount; i++) {
+    float a = rnd(i);
+    vec2 n = vec2(a, fract(a*34.56));
+    vec2 p = sin(n*(T+7.) + T*.5);
+    float d = dot(uv-p, uv-p);
+    col += (intensity * .00125)/d * hue(dot(uv,uv) + i*.125 + T);
+  }
+  return col;
+}
+
+void main(void) {
+  vec2 uv = (FC - .5 * R) / min(R.x, R.y);
+  vec3 col = vec3(0.);
+  float s = 2.4;
+  float a = atan(uv.x, uv.y);
+  float b = length(uv);
+  uv = vec2(a * 5. / 6.28318, .05 / tan(b) + T);
+  uv = fract(uv) - .5;
+  col += pattern(uv * s);
+  O = vec4(col, 1.);
+}`;
+
+const VERTEX_SHADER = `#version 300 es
+precision highp float;
+in vec2 position;
+void main(){
+  gl_Position = vec4(position, 0.0, 1.0);
+}`;
+
+type LightSpeedProps = {
+  paused?: boolean;
+  speed?: number;
+  intensity?: number;
+  particleCount?: number;
+  colorR?: number;
+  colorG?: number;
+  colorB?: number;
+  quality?: "low" | "medium" | "high";
+};
+
+type Uniforms = {
+  time: WebGLUniformLocation | null;
+  resolution: WebGLUniformLocation | null;
+  intensity: WebGLUniformLocation | null;
+  particleCount: WebGLUniformLocation | null;
+  colorShift: WebGLUniformLocation | null;
+};
+
+const qualitySettings = {
+  low: { dpr: 0.5, targetFps: 30 },
+  medium: { dpr: 1, targetFps: 60 },
+  high: { dpr: 1.5, targetFps: 60 },
+};
+
+export function LightSpeed({
+  paused = false,
+  speed = 1,
+  intensity = 1,
+  particleCount = 20,
+  colorR = 1,
+  colorG = 1,
+  colorB = 1,
+  quality = "medium",
+}: LightSpeedProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const glRef = useRef<WebGL2RenderingContext | null>(null);
+  const programRef = useRef<WebGLProgram | null>(null);
+  const vboRef = useRef<WebGLBuffer | null>(null);
+  const uniformsRef = useRef<Uniforms>({
+    time: null,
+    resolution: null,
+    intensity: null,
+    particleCount: null,
+    colorShift: null,
+  });
+  const rafRef = useRef(0);
+  const lastFrameRef = useRef(0);
+  const [webglOk, setWebglOk] = useState(true);
+  const currentQuality = qualitySettings[quality] ?? qualitySettings.medium;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const gl = canvas.getContext("webgl2", {
+      alpha: false,
+      antialias: false,
+      depth: false,
+      stencil: false,
+      powerPreference: "high-performance",
+    });
+
+    if (!gl) {
+      setWebglOk(false);
+      return;
+    }
+
+    const compileShader = (type: number, source: string) => {
+      const shader = gl.createShader(type);
+      if (!shader) throw new Error("Unable to create shader");
+
+      gl.shaderSource(shader, source);
+      gl.compileShader(shader);
+      if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        const message = gl.getShaderInfoLog(shader) ?? "Shader compile error";
+        gl.deleteShader(shader);
+        throw new Error(message);
+      }
+
+      return shader;
+    };
+
+    const linkProgram = (vertex: WebGLShader, fragment: WebGLShader) => {
+      const program = gl.createProgram();
+      if (!program) throw new Error("Unable to create WebGL program");
+
+      gl.attachShader(program, vertex);
+      gl.attachShader(program, fragment);
+      gl.linkProgram(program);
+      if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+        const message = gl.getProgramInfoLog(program) ?? "Program link error";
+        gl.deleteProgram(program);
+        throw new Error(message);
+      }
+
+      return program;
+    };
+
+    try {
+      const vertex = compileShader(gl.VERTEX_SHADER, VERTEX_SHADER);
+      const fragment = compileShader(gl.FRAGMENT_SHADER, FRAGMENT_SHADER);
+      const program = linkProgram(vertex, fragment);
+      programRef.current = program;
+      glRef.current = gl;
+      gl.useProgram(program);
+
+      const vbo = gl.createBuffer();
+      vboRef.current = vbo;
+      gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+      gl.bufferData(
+        gl.ARRAY_BUFFER,
+        new Float32Array([-1, 1, -1, -1, 1, 1, 1, -1]),
+        gl.STATIC_DRAW,
+      );
+
+      const position = gl.getAttribLocation(program, "position");
+      gl.enableVertexAttribArray(position);
+      gl.vertexAttribPointer(position, 2, gl.FLOAT, false, 0, 0);
+
+      uniformsRef.current = {
+        time: gl.getUniformLocation(program, "time"),
+        resolution: gl.getUniformLocation(program, "resolution"),
+        intensity: gl.getUniformLocation(program, "intensity"),
+        particleCount: gl.getUniformLocation(program, "particleCount"),
+        colorShift: gl.getUniformLocation(program, "colorShift"),
+      };
+      setWebglOk(true);
+    } catch {
+      setWebglOk(false);
+      return;
+    }
+
+    const resize = () => {
+      const dpr = Math.max(
+        1,
+        Math.min(window.devicePixelRatio || 1, currentQuality.dpr),
+      );
+      const cssW = canvas.clientWidth || canvas.parentElement?.clientWidth || 1;
+      const cssH =
+        canvas.clientHeight || canvas.parentElement?.clientHeight || 1;
+      canvas.width = Math.floor(cssW * dpr);
+      canvas.height = Math.floor(cssH * dpr);
+      gl.viewport(0, 0, canvas.width, canvas.height);
+      gl.uniform2f(uniformsRef.current.resolution, canvas.width, canvas.height);
+    };
+
+    const observer =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(resize);
+    observer?.observe(canvas);
+    window.addEventListener("resize", resize);
+    resize();
+
+    const start = performance.now();
+    const loop = (timestamp: number) => {
+      rafRef.current = requestAnimationFrame(loop);
+      if (paused) return;
+
+      const delta = timestamp - lastFrameRef.current;
+      const targetFrameTime = 1000 / currentQuality.targetFps;
+      if (delta < targetFrameTime) return;
+
+      lastFrameRef.current = timestamp - (delta % targetFrameTime);
+      const now = (timestamp - start) * 0.001 * (speed || 1);
+      const program = programRef.current;
+      if (!program) return;
+
+      gl.useProgram(program);
+      gl.uniform1f(uniformsRef.current.time, now);
+      gl.uniform1f(uniformsRef.current.intensity, intensity);
+      gl.uniform1f(uniformsRef.current.particleCount, particleCount);
+      gl.uniform3f(uniformsRef.current.colorShift, colorR, colorG, colorB);
+      gl.clearColor(0, 0, 0, 1);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+    };
+
+    rafRef.current = requestAnimationFrame(loop);
+
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+      observer?.disconnect();
+      window.removeEventListener("resize", resize);
+
+      const program = programRef.current;
+      if (program) {
+        const shaders = gl.getAttachedShaders(program) ?? [];
+        shaders.forEach((shader) => gl.deleteShader(shader));
+        gl.deleteProgram(program);
+      }
+      if (vboRef.current) gl.deleteBuffer(vboRef.current);
+    };
+  }, [
+    colorB,
+    colorG,
+    colorR,
+    currentQuality.dpr,
+    currentQuality.targetFps,
+    intensity,
+    particleCount,
+    paused,
+    speed,
+  ]);
+
+  return (
+    <div
+      aria-label="Lightspeed visual"
+      className="relative h-full min-h-[260px] w-full min-w-[100px] overflow-hidden bg-black"
+      data-testid="lightspeed-visual"
+    >
+      {!webglOk && (
+        <div className="absolute inset-0 grid place-items-center px-6 text-center text-neutral-200">
+          <div className="max-w-md">
+            <h2 className="text-xl font-semibold">WebGL not supported</h2>
+            <p className="mt-2 text-sm text-white/70">
+              Your browser or device does not support WebGL 2.0.
+            </p>
+          </div>
+        </div>
+      )}
+      <canvas
+        ref={canvasRef}
+        className="absolute inset-0 block h-full w-full"
+        data-testid="lightspeed-canvas"
+      />
+    </div>
+  );
+}

--- a/web/src/app/auth/login/page.tsx
+++ b/web/src/app/auth/login/page.tsx
@@ -2,6 +2,7 @@ import { withAuth } from "@workos-inc/authkit-nextjs";
 import { redirect } from "next/navigation";
 import { sanitizeReturnTo } from "@/lib/auth/return-to";
 import { ClashMark } from "@/components/marketing/clash-mark";
+import { LightSpeed } from "./lightspeed";
 import { SignInButton } from "./sign-in-button";
 
 export default async function LoginPage({
@@ -15,10 +16,22 @@ export default async function LoginPage({
   if (user) redirect(returnTo);
 
   return (
-    <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[#060606] px-5 py-12 text-white">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_50%_0%,rgba(255,255,255,0.14),transparent_34%),linear-gradient(180deg,rgba(255,255,255,0.05),transparent_36%)]" />
-      <div className="relative grid w-full max-w-5xl gap-10 lg:grid-cols-[1fr_380px] lg:items-center">
-        <section className="max-w-2xl">
+    <main className="grid min-h-screen bg-[#060606] text-white lg:grid-cols-[minmax(0,1fr)_480px]">
+      <section className="relative min-h-[42vh] overflow-hidden border-b border-white/10 lg:min-h-screen lg:border-b-0 lg:border-r">
+        <LightSpeed intensity={1.2} particleCount={24} quality="medium" />
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_42%_45%,transparent_0,rgba(0,0,0,0.22)_42%,rgba(0,0,0,0.72)_100%)]" />
+        <div className="absolute bottom-6 left-5 right-5 sm:bottom-8 sm:left-8 lg:bottom-10 lg:left-10">
+          <p className="font-mono text-[0.68rem] uppercase tracking-[0.22em] text-white/40">
+            Agent evaluation at lightspeed
+          </p>
+          <h1 className="mt-3 max-w-xl font-[family-name:var(--font-display)] text-4xl leading-[0.98] text-white sm:text-5xl lg:text-6xl">
+            Sign in to the arena.
+          </h1>
+        </div>
+      </section>
+
+      <section className="flex min-h-[58vh] items-center justify-center px-5 py-10 lg:min-h-screen lg:px-10">
+        <div className="w-full max-w-[380px]">
           <div className="mb-8 flex items-center gap-3">
             <ClashMark className="size-10" />
             <span className="font-mono text-xs uppercase tracking-[0.24em] text-white/45">
@@ -26,57 +39,43 @@ export default async function LoginPage({
             </span>
           </div>
 
-          <h1 className="font-[family-name:var(--font-display)] text-5xl leading-[0.95] text-white sm:text-6xl">
-            Sign in to the arena.
-          </h1>
-          <p className="mt-5 max-w-xl text-base leading-7 text-white/60">
-            Run head-to-head agent evaluations, inspect replays, and keep your
-            workspace experiments moving from one secure AgentClash account.
-          </p>
+          <div className="rounded-lg border border-white/10 bg-white/[0.045] p-6 shadow-[0_30px_120px_rgba(0,0,0,0.42)] backdrop-blur">
+            <div className="mb-6">
+              <p className="font-mono text-[0.68rem] uppercase tracking-[0.2em] text-white/38">
+                Secure login
+              </p>
+              <h2 className="mt-3 text-2xl font-semibold text-white">
+                Welcome back
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-white/48">
+                Continue to your AgentClash dashboard.
+              </p>
+            </div>
 
-          <div className="mt-10 grid max-w-xl gap-3 border-l border-white/12 pl-5 text-sm text-white/48 sm:grid-cols-3 sm:border-l-0 sm:pl-0">
-            <div>
-              <p className="font-mono text-[0.68rem] uppercase tracking-[0.18em] text-white/35">
-                Evaluate
-              </p>
-              <p className="mt-2 text-white/60">Same task, same tools.</p>
-            </div>
-            <div>
-              <p className="font-mono text-[0.68rem] uppercase tracking-[0.18em] text-white/35">
-                Replay
-              </p>
-              <p className="mt-2 text-white/60">Every move preserved.</p>
-            </div>
-            <div>
-              <p className="font-mono text-[0.68rem] uppercase tracking-[0.18em] text-white/35">
-                Decide
-              </p>
-              <p className="mt-2 text-white/60">Evidence over vibes.</p>
-            </div>
-          </div>
-        </section>
+            <SignInButton returnTo={returnTo} />
 
-        <div className="rounded-lg border border-white/10 bg-white/[0.045] p-6 shadow-[0_30px_120px_rgba(0,0,0,0.42)] backdrop-blur">
-          <div className="mb-6">
-            <p className="font-mono text-[0.68rem] uppercase tracking-[0.2em] text-white/38">
-              Secure login
-            </p>
-            <h2 className="mt-3 text-2xl font-semibold text-white">
-              Welcome back
-            </h2>
-            <p className="mt-2 text-sm leading-6 text-white/48">
-              Continue to your AgentClash dashboard.
+            <p className="mt-5 text-center text-xs leading-5 text-white/35">
+              Authentication is protected by AgentClash&apos;s configured
+              identity provider.
             </p>
           </div>
 
-          <SignInButton returnTo={returnTo} />
-
-          <p className="mt-5 text-center text-xs leading-5 text-white/35">
-            Authentication is protected by AgentClash&apos;s configured identity
-            provider.
-          </p>
+          <div className="mt-7 grid gap-3 border-l border-white/12 pl-5 text-sm text-white/48">
+            <p>
+              <span className="text-white/70">Evaluate:</span> same task, same
+              tools.
+            </p>
+            <p>
+              <span className="text-white/70">Replay:</span> every move
+              preserved.
+            </p>
+            <p>
+              <span className="text-white/70">Decide:</span> evidence over
+              vibes.
+            </p>
+          </div>
         </div>
-      </div>
+      </section>
     </main>
   );
 }

--- a/web/src/app/auth/login/page.tsx
+++ b/web/src/app/auth/login/page.tsx
@@ -1,6 +1,7 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { redirect } from "next/navigation";
 import { sanitizeReturnTo } from "@/lib/auth/return-to";
+import { ClashMark } from "@/components/marketing/clash-mark";
 import { SignInButton } from "./sign-in-button";
 
 export default async function LoginPage({
@@ -14,50 +15,68 @@ export default async function LoginPage({
   if (user) redirect(returnTo);
 
   return (
-    <div
-      style={{
-        minHeight: "100vh",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: "2rem",
-      }}
-    >
-      <div style={{ width: "100%", maxWidth: "420px" }}>
-        <div style={{ textAlign: "center", marginBottom: "2.5rem" }}>
-          <h1
-            style={{
-              fontFamily: "var(--font-display), serif",
-              fontSize: "2rem",
-              letterSpacing: "-0.02em",
-              color: "rgba(255, 255, 255, 0.9)",
-              margin: 0,
-            }}
-          >
-            AgentClash
+    <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[#060606] px-5 py-12 text-white">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_50%_0%,rgba(255,255,255,0.14),transparent_34%),linear-gradient(180deg,rgba(255,255,255,0.05),transparent_36%)]" />
+      <div className="relative grid w-full max-w-5xl gap-10 lg:grid-cols-[1fr_380px] lg:items-center">
+        <section className="max-w-2xl">
+          <div className="mb-8 flex items-center gap-3">
+            <ClashMark className="size-10" />
+            <span className="font-mono text-xs uppercase tracking-[0.24em] text-white/45">
+              AgentClash
+            </span>
+          </div>
+
+          <h1 className="font-[family-name:var(--font-display)] text-5xl leading-[0.95] text-white sm:text-6xl">
+            Sign in to the arena.
           </h1>
-          <p
-            style={{
-              color: "rgba(255, 255, 255, 0.4)",
-              fontSize: "0.875rem",
-              marginTop: "0.5rem",
-            }}
-          >
-            Sign in to your account
+          <p className="mt-5 max-w-xl text-base leading-7 text-white/60">
+            Run head-to-head agent evaluations, inspect replays, and keep your
+            workspace experiments moving from one secure AgentClash account.
+          </p>
+
+          <div className="mt-10 grid max-w-xl gap-3 border-l border-white/12 pl-5 text-sm text-white/48 sm:grid-cols-3 sm:border-l-0 sm:pl-0">
+            <div>
+              <p className="font-mono text-[0.68rem] uppercase tracking-[0.18em] text-white/35">
+                Evaluate
+              </p>
+              <p className="mt-2 text-white/60">Same task, same tools.</p>
+            </div>
+            <div>
+              <p className="font-mono text-[0.68rem] uppercase tracking-[0.18em] text-white/35">
+                Replay
+              </p>
+              <p className="mt-2 text-white/60">Every move preserved.</p>
+            </div>
+            <div>
+              <p className="font-mono text-[0.68rem] uppercase tracking-[0.18em] text-white/35">
+                Decide
+              </p>
+              <p className="mt-2 text-white/60">Evidence over vibes.</p>
+            </div>
+          </div>
+        </section>
+
+        <div className="rounded-lg border border-white/10 bg-white/[0.045] p-6 shadow-[0_30px_120px_rgba(0,0,0,0.42)] backdrop-blur">
+          <div className="mb-6">
+            <p className="font-mono text-[0.68rem] uppercase tracking-[0.2em] text-white/38">
+              Secure login
+            </p>
+            <h2 className="mt-3 text-2xl font-semibold text-white">
+              Welcome back
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-white/48">
+              Continue to your AgentClash dashboard.
+            </p>
+          </div>
+
+          <SignInButton returnTo={returnTo} />
+
+          <p className="mt-5 text-center text-xs leading-5 text-white/35">
+            Authentication is protected by AgentClash&apos;s configured identity
+            provider.
           </p>
         </div>
-
-        <div
-          style={{
-            background: "rgba(255, 255, 255, 0.03)",
-            border: "1px solid rgba(255, 255, 255, 0.08)",
-            borderRadius: "12px",
-            padding: "2rem",
-          }}
-        >
-          <SignInButton returnTo={returnTo} />
-        </div>
       </div>
-    </div>
+    </main>
   );
 }

--- a/web/src/app/auth/login/sign-in-button.test.tsx
+++ b/web/src/app/auth/login/sign-in-button.test.tsx
@@ -1,0 +1,47 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SignInButton } from "./sign-in-button";
+
+vi.mock("./actions", () => ({
+  signInAction: vi.fn(),
+}));
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function render(element: React.ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(element);
+  });
+}
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe("SignInButton", () => {
+  it("brands the hosted auth handoff as AgentClash", () => {
+    render(<SignInButton />);
+
+    expect(container?.textContent).toContain("Continue with AgentClash");
+    expect(container?.textContent).not.toContain("Sign in with WorkOS");
+  });
+
+  it("preserves the sanitized return target in the form", () => {
+    render(<SignInButton returnTo="/auth/device?user_code=ABCD-1234" />);
+
+    const input = container?.querySelector<HTMLInputElement>(
+      'input[name="returnTo"]',
+    );
+    expect(input?.value).toBe("/auth/device?user_code=ABCD-1234");
+  });
+});

--- a/web/src/app/auth/login/sign-in-button.tsx
+++ b/web/src/app/auth/login/sign-in-button.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ArrowRight } from "lucide-react";
 import { signInAction } from "./actions";
 
 interface SignInButtonProps {
@@ -8,7 +9,7 @@ interface SignInButtonProps {
 }
 
 export function SignInButton({
-  label = "Sign in with WorkOS",
+  label = "Continue with AgentClash",
   returnTo = "/dashboard",
 }: SignInButtonProps) {
   return (
@@ -16,21 +17,13 @@ export function SignInButton({
       <input type="hidden" name="returnTo" value={returnTo} />
       <button
         type="submit"
-        style={{
-          display: "block",
-          width: "100%",
-          padding: "0.75rem 1rem",
-          background: "rgba(255, 255, 255, 0.9)",
-          color: "#060606",
-          borderRadius: "8px",
-          fontWeight: 500,
-          fontSize: "0.9375rem",
-          textAlign: "center",
-          border: "none",
-          cursor: "pointer",
-        }}
+        className="group flex h-11 w-full items-center justify-center gap-2 rounded-lg border border-white/80 bg-white px-4 text-sm font-semibold text-neutral-950 shadow-[0_20px_60px_rgba(255,255,255,0.14)] transition hover:bg-white/90 focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-white/30 active:translate-y-px"
       >
-        {label}
+        <span>{label}</span>
+        <ArrowRight
+          aria-hidden="true"
+          className="size-4 transition-transform group-hover:translate-x-0.5"
+        />
       </button>
     </form>
   );


### PR DESCRIPTION
## Summary

- Rebrands `/auth/login` into an AgentClash-owned login experience with a `Continue with AgentClash` CTA.
- Partitions the login page: Framer Lightspeed-inspired WebGL visual on the left, login panel on the right.
- Keeps the existing hosted WorkOS AuthKit redirect/session flow intact through `getSignInUrl({ returnTo })` and `handleAuth`.
- Adds focused login button and Lightspeed visual coverage, including WebGL fallback behavior.
- Documents the WorkOS research outcome in `docs/frontend/auth-login-workos.md`.
- Adds the review-checkpoint contract at `testing/codex-agentclash-auth-login.md`.

## WorkOS research notes

- Hosted AuthKit is the recommended low-lift Next.js path and continues to own signup, password reset, email verification, SSO routing, MFA, bot protection, localization, and session handling.
- WorkOS dashboard branding can customize hosted AuthKit assets, colors, copy, layout, and CSS.
- The default hosted domain remains a generated `*.authkit.app` URL. A production custom AuthKit domain is available through WorkOS DNS verification, but it is a paid add-on.
- Fully self-hosted custom UI is possible through WorkOS User Management APIs, but that would require implementing additional auth states directly in AgentClash and is intentionally outside this safe branding PR.

Sources reviewed:
- https://workos.com/docs/authkit/nextjs
- https://workos.com/docs/authkit/hosted-ui
- https://workos.com/docs/authkit/branding
- https://workos.com/docs/custom-domains/authkit
- https://workos.com/pricing
- https://workos.com/docs/reference/authkit/authentication
- https://framer.com/m/Lightspeed-o3LM.js@LDifcJbnX2IvcgG0JuMw

## Validation

- `cd web && npm run test -- src/lib/auth/__tests__/return-to.test.ts src/app/auth/login`
- `cd web && npm run lint -- src/app/auth/login src/lib/auth`
- Local smoke: `npm run dev -- --hostname 127.0.0.1 --port 3100`, then `/auth/login` rendered the split layout markers, `Lightspeed visual`, and `Continue with AgentClash`.

Review checkpoint verdict: ready.
