### PR TITLE
[codex] Replace web icons with Nourico vectors

### DIFF
--- a/testing/codex-nourico-icon-refactor.md
+++ b/testing/codex-nourico-icon-refactor.md
@@ -1,0 +1,33 @@
+# codex/nourico-icon-refactor - Test Contract
+
+## Functional Behavior
+- Every app import that previously consumed `lucide-react` should instead consume the local Nourico vector icon adapter.
+- The local adapter should render the Nourico SVG path from `https://framer.com/m/Nourico-EmNcpg.js@96vlh0u4IGtzvstHLNV1`.
+- Existing icon call sites should keep working with `className`, `style`, `aria-*`, `data-*`, `ref`, and standard SVG props.
+- Existing type-only icon references such as `LucideIcon` should remain source-compatible.
+- Spinner usages that attach `animate-spin` to `Loader2`-style icons should still animate the rendered SVG.
+- Non-lucide provider/logo icons from `@lobehub/icons` are out of scope unless they are explicitly part of a local lucide replacement path.
+
+## Unit Tests
+- N/A - this is a visual icon adapter refactor without existing dedicated icon unit tests.
+
+## Integration / Functional Tests
+- `npm run lint` from `web/` should pass.
+- `npm run build` from `web/` should pass.
+- `rg "from \"lucide-react\"|from 'lucide-react'" web/src` should return no source imports.
+
+## Smoke Tests
+- Start the web app and verify at least one page renders without module-resolution errors.
+- Verify interactive components that use icons, such as menus, dialogs, and table controls, do not crash at render time.
+
+## E2E Tests
+- N/A - no browser E2E suite is defined for this icon-only refactor.
+
+## Manual Tests
+```bash
+cd web
+npm run lint
+npm run build
+rg "from \"lucide-react\"|from 'lucide-react'" src
+```
+

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -19,7 +19,6 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "gray-matter": "^4.0.3",
-        "lucide-react": "^0.577.0",
         "next": "^15.5.15",
         "next-mdx-remote": "^6.0.0",
         "react": "19.2.3",
@@ -12990,15 +12989,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/lucide-react": {
-      "version": "0.577.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
-      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "gray-matter": "^4.0.3",
-    "lucide-react": "^0.577.0",
     "next": "^15.5.15",
     "next-mdx-remote": "^6.0.0",
     "react": "19.2.3",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
-      lucide-react:
-        specifier: ^0.577.0
-        version: 0.577.0(react@19.2.3)
       next:
         specifier: ^15.5.15
         version: 15.5.15(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -4144,11 +4141,6 @@ packages:
 
   lucide-react@0.562.0:
     resolution: {integrity: sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  lucide-react@0.577.0:
-    resolution: {integrity: sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -10525,10 +10517,6 @@ snapshots:
       react: 19.2.3
 
   lucide-react@0.562.0(react@19.2.3):
-    dependencies:
-      react: 19.2.3
-
-  lucide-react@0.577.0(react@19.2.3):
     dependencies:
       react: 19.2.3
 

--- a/web/src/app/(org)/orgs/[orgSlug]/members/invite-member-dialog.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/members/invite-member-dialog.tsx
@@ -17,7 +17,7 @@ import {
   DialogFooter,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { UserPlus, Loader2 } from "lucide-react";
+import { UserPlus, Loader2 } from "@/components/ui/nourico-icons";
 import { toast } from "sonner";
 
 interface InviteMemberDialogProps {

--- a/web/src/app/(org)/orgs/[orgSlug]/members/org-members-client.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/members/org-members-client.tsx
@@ -23,7 +23,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { PaginationControls } from "@/components/ui/pagination-controls";
-import { MoreHorizontal } from "lucide-react";
+import { MoreHorizontal } from "@/components/ui/nourico-icons";
 import { toast } from "sonner";
 import { InviteMemberDialog } from "./invite-member-dialog";
 

--- a/web/src/app/(org)/orgs/[orgSlug]/members/org-members-loader.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/members/org-members-loader.tsx
@@ -4,7 +4,7 @@ import type { OrgMember } from "@/lib/api/types";
 import { useOrgContext } from "../org-context";
 import { useOrgFetch } from "../use-org-fetch";
 import { OrgMembersClient } from "./org-members-client";
-import { Loader2 } from "lucide-react";
+import { Loader2 } from "@/components/ui/nourico-icons";
 
 export function OrgMembersLoader() {
   const { orgId, isAdmin, currentUserId } = useOrgContext();

--- a/web/src/app/(org)/orgs/[orgSlug]/org-settings-sidebar.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/org-settings-sidebar.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
-import { Settings2, Users, Layers, ArrowLeft } from "lucide-react";
+import { Settings2, Users, Layers, ArrowLeft } from "@/components/ui/nourico-icons";
 
 interface OrgSettingsSidebarProps {
   orgSlug: string;

--- a/web/src/app/(org)/orgs/[orgSlug]/settings/org-general-settings.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/settings/org-general-settings.tsx
@@ -17,7 +17,7 @@ import {
   DialogFooter,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { Loader2, AlertTriangle } from "lucide-react";
+import { Loader2, AlertTriangle } from "@/components/ui/nourico-icons";
 import { toast } from "sonner";
 
 interface OrgGeneralSettingsProps {

--- a/web/src/app/(org)/orgs/[orgSlug]/settings/org-settings-gate.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/settings/org-settings-gate.tsx
@@ -7,7 +7,7 @@ import { createApiClient } from "@/lib/api/client";
 import type { Organization } from "@/lib/api/types";
 import { useOrgContext } from "../org-context";
 import { OrgGeneralSettings } from "./org-general-settings";
-import { Loader2, AlertTriangle } from "lucide-react";
+import { Loader2, AlertTriangle } from "@/components/ui/nourico-icons";
 
 export function OrgSettingsGate({ orgSlug }: { orgSlug: string }) {
   const { orgId, isAdmin } = useOrgContext();

--- a/web/src/app/(org)/orgs/[orgSlug]/workspaces/org-workspaces-client.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/workspaces/org-workspaces-client.tsx
@@ -26,7 +26,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { PaginationControls } from "@/components/ui/pagination-controls";
-import { Plus, Loader2 } from "lucide-react";
+import { Plus, Loader2 } from "@/components/ui/nourico-icons";
 import { toast } from "sonner";
 import Link from "next/link";
 

--- a/web/src/app/(org)/orgs/[orgSlug]/workspaces/org-workspaces-loader.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/workspaces/org-workspaces-loader.tsx
@@ -4,7 +4,7 @@ import type { OrgWorkspace } from "@/lib/api/types";
 import { useOrgContext } from "../org-context";
 import { useOrgFetch } from "../use-org-fetch";
 import { OrgWorkspacesClient } from "./org-workspaces-client";
-import { Loader2 } from "lucide-react";
+import { Loader2 } from "@/components/ui/nourico-icons";
 
 export function OrgWorkspacesLoader() {
   const { orgId, isAdmin } = useOrgContext();

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/artifacts/artifacts-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/artifacts/artifacts-client.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/components/ui/table";
 import { UploadArtifactDialog } from "@/components/artifacts/upload-artifact-dialog";
 import { DownloadArtifactButton } from "@/components/artifacts/download-artifact-button";
-import { FileArchive } from "lucide-react";
+import { FileArchive } from "@/components/ui/nourico-icons";
 
 function formatBytes(bytes: number | undefined | null): string {
   if (bytes == null || bytes === 0) return "\u2014";

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/create-version-button.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/create-version-button.test.tsx
@@ -100,7 +100,7 @@ vi.mock("@/components/ui/dialog", async () => {
   };
 });
 
-vi.mock("lucide-react", () => ({
+vi.mock("@/components/ui/nourico-icons", () => ({
   Loader2: () => React.createElement("span", null, "loader"),
   Plus: () => React.createElement("span", null, "plus"),
   Sparkles: () => React.createElement("span", null, "sparkles"),

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/create-version-button.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/create-version-button.tsx
@@ -16,7 +16,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { toast } from "sonner";
-import { Loader2, Plus, Sparkles } from "lucide-react";
+import { Loader2, Plus, Sparkles } from "@/components/ui/nourico-icons";
 
 import { guidedTemplates, versionPayloadFromTemplate } from "./versions/[versionId]/guided-authoring";
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/page.tsx
@@ -13,7 +13,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Layers } from "lucide-react";
+import { Layers } from "@/components/ui/nourico-icons";
 import { CreateVersionButton } from "./create-version-button";
 
 const versionStatusVariant: Record<string, "default" | "secondary" | "destructive" | "outline"> = {

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/version-editor.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/version-editor.test.tsx
@@ -126,7 +126,7 @@ vi.mock("@/components/ui/tabs", async () => {
   };
 });
 
-vi.mock("lucide-react", () => ({
+vi.mock("@/components/ui/nourico-icons", () => ({
   CheckCircle: () => React.createElement("span", null, "ready"),
   Loader2: () => React.createElement("span", null, "loader"),
   Save: () => React.createElement("span", null, "save"),

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/version-editor.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/[buildId]/versions/[versionId]/version-editor.tsx
@@ -23,7 +23,7 @@ import {
   Save,
   ShieldCheck,
   Sparkles,
-} from "lucide-react";
+} from "@/components/ui/nourico-icons";
 
 import {
   type EditableSpecs,

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/builds-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/builds-client.tsx
@@ -14,7 +14,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Bot } from "lucide-react";
+import { Bot } from "@/components/ui/nourico-icons";
 import { CreateBuildDialog } from "./create-build-dialog";
 
 const statusVariant: Record<string, "default" | "secondary" | "destructive" | "outline"> = {

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/builds/create-build-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/builds/create-build-dialog.tsx
@@ -18,7 +18,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { toast } from "sonner";
-import { Loader2, Plus } from "lucide-react";
+import { Loader2, Plus } from "@/components/ui/nourico-icons";
 
 interface CreateBuildDialogProps {
   workspaceId: string;

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/[packId]/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/[packId]/page.tsx
@@ -14,7 +14,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Layers } from "lucide-react";
+import { Layers } from "@/components/ui/nourico-icons";
 
 const lifecycleVariant: Record<string, "default" | "secondary" | "outline"> = {
   runnable: "default",

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/challenge-packs-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/challenge-packs-client.tsx
@@ -14,7 +14,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Package } from "lucide-react";
+import { Package } from "@/components/ui/nourico-icons";
 import { PublishPackDialog } from "./publish-pack-dialog";
 
 const lifecycleVariant: Record<string, "default" | "secondary" | "outline"> = {

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/publish-pack-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/publish-pack-dialog.tsx
@@ -21,7 +21,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { toast } from "sonner";
-import { CheckCircle2, Loader2, Plus, XCircle, Maximize2, Minimize2 } from "lucide-react";
+import { CheckCircle2, Loader2, Plus, XCircle, Maximize2, Minimize2 } from "@/components/ui/nourico-icons";
 import Editor from "@monaco-editor/react";
 
 interface PublishPackDialogProps {

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/ci-hint.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/ci-hint.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronDown, ChevronRight, Terminal, Copy, Check } from "lucide-react";
+import { ChevronDown, ChevronRight, Terminal, Copy, Check } from "@/components/ui/nourico-icons";
 
 interface CiHintProps {
   baselineRunId: string;

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/compare-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/compare-client.tsx
@@ -27,7 +27,7 @@ import {
   ArrowUpRight,
   ArrowDownRight,
   Minus,
-} from "lucide-react";
+} from "@/components/ui/nourico-icons";
 import Link from "next/link";
 import { scorePercent } from "@/lib/scores";
 import { RegressionAlertBanner } from "./regression-alert-banner";

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/evaluate-release-gate-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/evaluate-release-gate-dialog.tsx
@@ -31,7 +31,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { JsonField } from "@/components/ui/json-field";
-import { ShieldCheck, Loader2 } from "lucide-react";
+import { ShieldCheck, Loader2 } from "@/components/ui/nourico-icons";
 import { cn } from "@/lib/utils";
 import { RegressionViolationsList } from "./regression-violations-list";
 import { VERDICT_CONFIG, outcomeColor } from "./verdict-config";

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/regression-alert-banner.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/regression-alert-banner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { AlertTriangle, ArrowRightCircle } from "lucide-react";
+import { AlertTriangle, ArrowRightCircle } from "@/components/ui/nourico-icons";
 
 import {
   REGRESSION_BLOCKING_RULES,

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/regression-coverage-section.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/regression-coverage-section.tsx
@@ -10,7 +10,7 @@ import {
   ChevronRight,
   Sparkles,
   XCircle,
-} from "lucide-react";
+} from "@/components/ui/nourico-icons";
 
 import type {
   RunRegressionCoverage,

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/regression-violations-list.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/regression-violations-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowRightCircle } from "lucide-react";
+import { ArrowRightCircle } from "@/components/ui/nourico-icons";
 
 import {
   REGRESSION_BLOCKING_RULES,

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/release-gates-section.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/release-gates-section.tsx
@@ -7,7 +7,7 @@ import {
   Loader2,
   ChevronDown,
   ChevronRight,
-} from "lucide-react";
+} from "@/components/ui/nourico-icons";
 import { EvaluateReleaseGateDialog } from "./evaluate-release-gate-dialog";
 import { CiHint } from "./ci-hint";
 import { RegressionViolationsList } from "./regression-violations-list";

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/compare/verdict-config.ts
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/compare/verdict-config.ts
@@ -5,7 +5,7 @@ import {
   ShieldX,
   ShieldQuestion,
   type LucideIcon,
-} from "lucide-react";
+} from "@/components/ui/nourico-icons";
 
 export interface VerdictStyle {
   variant: "default" | "secondary" | "destructive" | "outline";

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/comparisons/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/comparisons/page.tsx
@@ -1,4 +1,4 @@
-import { GitCompare } from "lucide-react";
+import { GitCompare } from "@/components/ui/nourico-icons";
 import { ComparisonsLanding } from "./comparisons-landing";
 
 export default async function ComparisonsPage({

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/deployments/create-deployment-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/deployments/create-deployment-dialog.tsx
@@ -27,7 +27,7 @@ import {
 } from "@/components/ui/dialog";
 import { JsonField } from "@/components/ui/json-field";
 import { toast } from "sonner";
-import { Loader2, Plus } from "lucide-react";
+import { Loader2, Plus } from "@/components/ui/nourico-icons";
 
 interface CreateDeploymentDialogProps {
   workspaceId: string;

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/deployments/deployments-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/deployments/deployments-client.tsx
@@ -13,7 +13,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Rocket } from "lucide-react";
+import { Rocket } from "@/components/ui/nourico-icons";
 import { CreateDeploymentDialog } from "./create-deployment-dialog";
 
 const statusVariant: Record<string, "default" | "secondary" | "outline"> = {

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sessions/[evalSessionId]/eval-session-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/eval-sessions/[evalSessionId]/eval-session-detail-client.tsx
@@ -8,7 +8,7 @@ import {
   FlaskConical,
   GitCompare,
   Sigma,
-} from "lucide-react";
+} from "@/components/ui/nourico-icons";
 
 import { createApiClient } from "@/lib/api/client";
 import type {

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/knowledge-sources/knowledge-sources-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/knowledge-sources/knowledge-sources-client.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { CreateResourceDialog } from "@/components/infra/create-resource-dialog";
-import { Database } from "lucide-react";
+import { Database } from "@/components/ui/nourico-icons";
 
 interface KnowledgeSource {
   id: string;

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/model-aliases/model-aliases-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/model-aliases/model-aliases-client.tsx
@@ -9,7 +9,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { CreateResourceDialog } from "@/components/infra/create-resource-dialog";
 import { DeleteResourceButton } from "@/components/infra/delete-resource-button";
-import { Tag } from "lucide-react";
+import { Tag } from "@/components/ui/nourico-icons";
 
 export function ModelAliasesClient({ workspaceId }: { workspaceId: string }) {
   const { data, error, isLoading } = useApiListQuery<ModelAlias>(

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/comparison-panel.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/comparison-panel.tsx
@@ -17,7 +17,7 @@ import {
   ArrowDownRight,
   Minus,
   GitCompare,
-} from "lucide-react";
+} from "@/components/ui/nourico-icons";
 import type {
   PlaygroundExperiment,
   PlaygroundExperimentComparison,

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/eval-spec-builder.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/eval-spec-builder.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Plus, Trash2, Code2 } from "lucide-react";
+import { Plus, Trash2, Code2 } from "@/components/ui/nourico-icons";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/experiment-launcher.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/experiment-launcher.tsx
@@ -11,7 +11,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ToggleGroup } from "@/components/ui/toggle-group";
-import { Loader2, Plus, Trash2, Rocket } from "lucide-react";
+import { Loader2, Plus, Trash2, Rocket } from "@/components/ui/nourico-icons";
 import type { ModelAlias, ProviderAccount } from "@/lib/api/types";
 
 interface ModelEntry {

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/experiment-list.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/experiment-list.tsx
@@ -12,7 +12,7 @@ import {
   ChevronRight,
   FlaskConical,
   Loader2,
-} from "lucide-react";
+} from "@/components/ui/nourico-icons";
 import type {
   PlaygroundExperiment,
   PlaygroundExperimentResult,

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/experiment-results.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/experiment-results.tsx
@@ -2,7 +2,7 @@
 
 import { Badge } from "@/components/ui/badge";
 import { KpiStrip } from "./kpi-strip";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle } from "@/components/ui/nourico-icons";
 import type { PlaygroundExperimentResult } from "@/lib/api/types";
 
 function statusVariant(

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/kpi-strip.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/kpi-strip.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Clock, Coins, Hash } from "lucide-react";
+import { Clock, Coins, Hash } from "@/components/ui/nourico-icons";
 import { Skeleton } from "@/components/ui/skeleton";
 import { scoreColor } from "@/lib/scores";
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/prompt-editor.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/prompt-editor.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Loader2 } from "lucide-react";
+import { Loader2 } from "@/components/ui/nourico-icons";
 
 interface PromptEditorProps {
   name: string;

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/test-case-panel.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/test-case-panel.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { JsonField } from "@/components/ui/json-field";
 import { EmptyState } from "@/components/ui/empty-state";
-import { Loader2, Plus, Trash2, ClipboardList } from "lucide-react";
+import { Loader2, Plus, Trash2, ClipboardList } from "@/components/ui/nourico-icons";
 import type { PlaygroundTestCase } from "@/lib/api/types";
 
 function prettyJSON(value: unknown): string {

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/playground-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/playground-detail-client.tsx
@@ -25,7 +25,7 @@ import { ExperimentLauncher } from "./components/experiment-launcher";
 import { ExperimentList } from "./components/experiment-list";
 import { ComparisonPanel } from "./components/comparison-panel";
 import { EvalSpecBuilder } from "./components/eval-spec-builder";
-import { Trash2 } from "lucide-react";
+import { Trash2 } from "@/components/ui/nourico-icons";
 
 export function PlaygroundDetailClient(props: {
   workspaceId: string;

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/playgrounds-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/playgrounds-client.tsx
@@ -20,7 +20,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { PageHeader } from "@/components/ui/page-header";
-import { FlaskConical, Loader2, Plus } from "lucide-react";
+import { FlaskConical, Loader2, Plus } from "@/components/ui/nourico-icons";
 import { EvalSpecBuilder } from "./[playgroundId]/components/eval-spec-builder";
 
 const defaultEvalSpec = {

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/provider-accounts/provider-accounts-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/provider-accounts/provider-accounts-client.tsx
@@ -9,7 +9,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { CreateResourceDialog } from "@/components/infra/create-resource-dialog";
 import { DeleteResourceButton } from "@/components/infra/delete-resource-button";
-import { Key } from "lucide-react";
+import { Key } from "@/components/ui/nourico-icons";
 
 const statusVariant: Record<string, "default" | "secondary" | "outline" | "destructive"> = {
   active: "default",

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/cases/[caseId]/case-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/cases/[caseId]/case-detail-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { PlayCircle } from "lucide-react";
+import { PlayCircle } from "@/components/ui/nourico-icons";
 
 import type { RegressionCase, RegressionSuite } from "@/lib/api/types";
 import { Badge } from "@/components/ui/badge";

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/cases/[caseId]/edit-case-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/cases/[caseId]/edit-case-dialog.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { toast } from "sonner";
-import { Loader2, Pencil } from "lucide-react";
+import { Loader2, Pencil } from "@/components/ui/nourico-icons";
 
 import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/edit-suite-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/edit-suite-dialog.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { toast } from "sonner";
-import { Loader2, Pencil } from "lucide-react";
+import { Loader2, Pencil } from "@/components/ui/nourico-icons";
 
 import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/suite-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/suite-detail-client.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useMemo, useState } from "react";
-import { History, ListChecks } from "lucide-react";
+import { History, ListChecks } from "@/components/ui/nourico-icons";
 
 import type {
   ChallengePack,

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/suite-run-history.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/suite-run-history.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { History, Loader2 } from "lucide-react";
+import { History, Loader2 } from "@/components/ui/nourico-icons";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 
 import { createApiClient } from "@/lib/api/client";

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/create-suite-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/create-suite-dialog.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { toast } from "sonner";
-import { Loader2, Plus } from "lucide-react";
+import { Loader2, Plus } from "@/components/ui/nourico-icons";
 
 import { createApiClient } from "@/lib/api/client";
 import { useApiMutator } from "@/lib/api/swr";

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/regression-suites-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/regression-suites-client.tsx
@@ -5,7 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { toast } from "sonner";
-import { MoreHorizontal, ShieldAlert } from "lucide-react";
+import { MoreHorizontal, ShieldAlert } from "@/components/ui/nourico-icons";
 
 import { createApiClient } from "@/lib/api/client";
 import { useApiListQuery, useApiMutator, usePaginatedApiQuery } from "@/lib/api/swr";

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/release-gates/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/release-gates/page.tsx
@@ -1,4 +1,4 @@
-import { ShieldCheck } from "lucide-react";
+import { ShieldCheck } from "@/components/ui/nourico-icons";
 import { ReleaseGatesLanding } from "./release-gates-landing";
 
 export default async function ReleaseGatesPage({

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/replay/replay-viewer-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/replay/replay-viewer-client.tsx
@@ -26,7 +26,7 @@ import {
   Terminal,
   BarChart3,
   Layers,
-} from "lucide-react";
+} from "@/components/ui/nourico-icons";
 
 const POLL_MS = 5000;
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/copy-markdown.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/copy-markdown.tsx
@@ -6,7 +6,7 @@ import type {
   RunAgent,
   ScorecardResponse,
 } from "@/lib/api/types";
-import { Clipboard, Check } from "lucide-react";
+import { Clipboard, Check } from "@/components/ui/nourico-icons";
 import { parseJudgePayload, sortDimensionKeys } from "./utils";
 import { cn } from "@/lib/utils";
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/dimensions-deck.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/dimensions-deck.tsx
@@ -2,7 +2,7 @@
 
 import type { ScorecardResponse } from "@/lib/api/types";
 import { Panel, PanelHeader } from "./panel";
-import { Gauge, ArrowUp, ArrowDown } from "lucide-react";
+import { Gauge, ArrowUp, ArrowDown } from "@/components/ui/nourico-icons";
 import { cn } from "@/lib/utils";
 import { barColor, scoreColor } from "@/lib/scores";
 import { humanizeKey, sortDimensionKeys } from "./utils";

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/evidence-panels.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/evidence-panels.tsx
@@ -11,7 +11,7 @@ import {
   Bot,
   FlaskConical,
   ChevronRight,
-} from "lucide-react";
+} from "@/components/ui/nourico-icons";
 import { cn } from "@/lib/utils";
 import { scoreColor } from "@/lib/scores";
 import { StateDot, normalizeState } from "./state-dot";

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/hero.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/hero.tsx
@@ -8,7 +8,7 @@ import type {
 import { ScoreMeter } from "./score-meter";
 import { Panel } from "./panel";
 import { formatDuration, formatTimestamp, sortDimensionKeys } from "./utils";
-import { CheckCircle2, XCircle, AlertTriangle, Clock } from "lucide-react";
+import { CheckCircle2, XCircle, AlertTriangle, Clock } from "@/components/ui/nourico-icons";
 
 export function Hero({
   run,

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/inspector-sheet.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/inspector-sheet.tsx
@@ -16,7 +16,7 @@ import { scoreColor } from "@/lib/scores";
 import { cn } from "@/lib/utils";
 import { humanizeKey, parseJudgePayload, type JudgeCall } from "./utils";
 import { StateDot, normalizeState } from "./state-dot";
-import { AlertTriangle, ArrowUpRight, XCircle } from "lucide-react";
+import { AlertTriangle, ArrowUpRight, XCircle } from "@/components/ui/nourico-icons";
 import { JudgeSampleCard } from "./judge-sample-card";
 import { ValidatorEvidenceView } from "./validator-evidence";
 import Link from "next/link";

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/judge-sample-card.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/judge-sample-card.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { cn } from "@/lib/utils";
-import { Quote, Check, X, Code2 } from "lucide-react";
+import { Quote, Check, X, Code2 } from "@/components/ui/nourico-icons";
 import { scoreColor } from "@/lib/scores";
 import type { JudgeCall } from "./utils";
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/rank-strip.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/rank-strip.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import type { RankingItem, RunRankingResponse } from "@/lib/api/types";
 import { Panel, PanelHeader } from "./panel";
-import { Trophy } from "lucide-react";
+import { Trophy } from "@/components/ui/nourico-icons";
 import { cn } from "@/lib/utils";
 import { scoreColor } from "@/lib/scores";
 import { signedDelta } from "./utils";

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/scorecard-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/scorecard-client.tsx
@@ -11,7 +11,7 @@ import type {
   ScorecardResponse,
 } from "@/lib/api/types";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { Loader2, AlertTriangle } from "lucide-react";
+import { Loader2, AlertTriangle } from "@/components/ui/nourico-icons";
 
 import { Hero } from "./components/hero";
 import { RankStrip } from "./components/rank-strip";

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/compare-run-picker.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/compare-run-picker.tsx
@@ -15,7 +15,7 @@ import {
   DialogDescription,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { GitCompare, Loader2 } from "lucide-react";
+import { GitCompare, Loader2 } from "@/components/ui/nourico-icons";
 import { runStatusVariant } from "../status-variant";
 
 interface CompareRunPickerProps {

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failure-detail-drawer.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failure-detail-drawer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowUpRight, Play } from "lucide-react";
+import { ArrowUpRight, Play } from "@/components/ui/nourico-icons";
 import {
   Sheet,
   SheetContent,

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.tsx
@@ -17,7 +17,7 @@ import {
   Inbox,
   Play,
   X,
-} from "lucide-react";
+} from "@/components/ui/nourico-icons";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/promote-failure-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/promote-failure-dialog.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
-import { ChevronDown, ChevronRight, Loader2 } from "lucide-react";
+import { ChevronDown, ChevronRight, Loader2 } from "@/components/ui/nourico-icons";
 import { toast } from "sonner";
 
 import { createApiClient } from "@/lib/api/client";

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
@@ -45,7 +45,7 @@ import {
   Radio,
   MessageSquareText,
   Flag,
-} from "lucide-react";
+} from "@/components/ui/nourico-icons";
 
 import { CompareRunPicker } from "./compare-run-picker";
 import { Panel } from "./agents/[runAgentId]/scorecard/components/panel";

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/scorecard-summary-card.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/scorecard-summary-card.tsx
@@ -11,7 +11,7 @@ import {
   CheckCircle2,
   XCircle,
   BarChart3,
-} from "lucide-react";
+} from "@/components/ui/nourico-icons";
 import { scorePercent, scoreColor } from "@/lib/scores";
 
 const LEGACY_DIM_META: Record<

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-eval-session-dialog.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-eval-session-dialog.test.tsx
@@ -121,7 +121,7 @@ vi.mock("@/components/ui/dialog", async () => {
   };
 });
 
-vi.mock("lucide-react", () => ({
+vi.mock("@/components/ui/nourico-icons", () => ({
   Loader2: () => React.createElement("span", null, "loader"),
   Sigma: () => React.createElement("span", null, "sigma"),
 }));

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-eval-session-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-eval-session-dialog.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
-import { Loader2, Sigma } from "lucide-react";
+import { Loader2, Sigma } from "@/components/ui/nourico-icons";
 import { toast } from "sonner";
 
 import { createApiClient } from "@/lib/api/client";

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.test.tsx
@@ -127,7 +127,7 @@ vi.mock("@/components/ui/dialog", async () => {
   };
 });
 
-vi.mock("lucide-react", () => ({
+vi.mock("@/components/ui/nourico-icons", () => ({
   Loader2: () => React.createElement("span", null, "loader"),
   Plus: () => React.createElement("span", null, "plus"),
 }));

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
@@ -30,7 +30,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { toast } from "sonner";
-import { Loader2, Plus } from "lucide-react";
+import { Loader2, Plus } from "@/components/ui/nourico-icons";
 
 interface CreateRunDialogProps {
   workspaceId: string;

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/eval-session-list.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/eval-session-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { FlaskConical } from "lucide-react";
+import { FlaskConical } from "@/components/ui/nourico-icons";
 
 import type {
   EvalSessionListItem,

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/run-list.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/run-list.tsx
@@ -18,7 +18,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
-import { Play, ChevronLeft, ChevronRight, GitCompare } from "lucide-react";
+import { Play, ChevronLeft, ChevronRight, GitCompare } from "@/components/ui/nourico-icons";
 import { runStatusVariant } from "./status-variant";
 
 const ACTIVE_STATUSES: RunStatus[] = [

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runtime-profiles/runtime-profiles-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runtime-profiles/runtime-profiles-client.tsx
@@ -8,7 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { CreateResourceDialog } from "@/components/infra/create-resource-dialog";
-import { Settings2 } from "lucide-react";
+import { Settings2 } from "@/components/ui/nourico-icons";
 
 export function RuntimeProfilesClient({ workspaceId }: { workspaceId: string }) {
   const { data, error, isLoading } = useApiListQuery<RuntimeProfile>(

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/secrets/delete-secret-button.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/secrets/delete-secret-button.tsx
@@ -8,7 +8,7 @@ import { ApiError } from "@/lib/api/errors";
 import { workspaceResourceKeys } from "@/lib/workspace-resource";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
-import { Loader2, Trash2 } from "lucide-react";
+import { Loader2, Trash2 } from "@/components/ui/nourico-icons";
 
 interface DeleteSecretButtonProps {
   workspaceId: string;

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/secrets/secrets-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/secrets/secrets-client.tsx
@@ -12,7 +12,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Lock } from "lucide-react";
+import { Lock } from "@/components/ui/nourico-icons";
 import { UpsertSecretDialog } from "./upsert-secret-dialog";
 import { DeleteSecretButton } from "./delete-secret-button";
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/secrets/upsert-secret-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/secrets/upsert-secret-dialog.tsx
@@ -17,7 +17,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { toast } from "sonner";
-import { Loader2, Plus } from "lucide-react";
+import { Loader2, Plus } from "@/components/ui/nourico-icons";
 
 const SECRET_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/settings/members/ws-invite-member-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/settings/members/ws-invite-member-dialog.tsx
@@ -17,7 +17,7 @@ import {
   DialogFooter,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { UserPlus, Loader2 } from "lucide-react";
+import { UserPlus, Loader2 } from "@/components/ui/nourico-icons";
 import { toast } from "sonner";
 
 const ROLE_OPTIONS: { value: WorkspaceRole; label: string }[] = [

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/settings/members/ws-members-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/settings/members/ws-members-client.tsx
@@ -27,7 +27,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { PaginationControls } from "@/components/ui/pagination-controls";
-import { MoreHorizontal } from "lucide-react";
+import { MoreHorizontal } from "@/components/ui/nourico-icons";
 import { toast } from "sonner";
 import { WsInviteMemberDialog } from "./ws-invite-member-dialog";
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/settings/ws-general-settings.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/settings/ws-general-settings.tsx
@@ -17,7 +17,7 @@ import {
   DialogFooter,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { Loader2, AlertTriangle } from "lucide-react";
+import { Loader2, AlertTriangle } from "@/components/ui/nourico-icons";
 import { toast } from "sonner";
 import Link from "next/link";
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/tools/tools-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/tools/tools-client.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { CreateResourceDialog } from "@/components/infra/create-resource-dialog";
-import { Wrench } from "lucide-react";
+import { Wrench } from "@/components/ui/nourico-icons";
 
 interface Tool {
   id: string;

--- a/web/src/app/auth/login/sign-in-button.tsx
+++ b/web/src/app/auth/login/sign-in-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowRight } from "lucide-react";
+import { ArrowRight } from "@/components/ui/nourico-icons";
 import { signInAction } from "./actions";
 
 interface SignInButtonProps {

--- a/web/src/app/landing.tsx
+++ b/web/src/app/landing.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { getCalApi } from "@calcom/embed-react";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
-import { ArrowRight, Calendar, ExternalLink, LogIn, Star } from "lucide-react";
+import { ArrowRight, Calendar, ExternalLink, LogIn, Star } from "@/components/ui/nourico-icons";
 import {
   Anthropic,
   Gemini,

--- a/web/src/app/onboard/onboarding-wizard.tsx
+++ b/web/src/app/onboard/onboarding-wizard.tsx
@@ -8,7 +8,7 @@ import { ApiError } from "@/lib/api/errors";
 import type { OnboardResult } from "@/lib/api/types";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
-import { Loader2, ArrowRight, Sparkles } from "lucide-react";
+import { Loader2, ArrowRight, Sparkles } from "@/components/ui/nourico-icons";
 
 type Step = "org" | "workspace";
 

--- a/web/src/app/v2/cloud/page.tsx
+++ b/web/src/app/v2/cloud/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight } from "@/components/ui/nourico-icons";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { PageHeader } from "@/components/marketing/page-header";
 import { SplitSection } from "@/components/marketing/split-section";

--- a/web/src/app/v2/design-partners/page.tsx
+++ b/web/src/app/v2/design-partners/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight } from "@/components/ui/nourico-icons";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { PageHeader } from "@/components/marketing/page-header";
 import { SplitSection } from "@/components/marketing/split-section";

--- a/web/src/app/v2/landing.tsx
+++ b/web/src/app/v2/landing.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { getCalApi } from "@calcom/embed-react";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
-import { ArrowRight, Calendar, ExternalLink, LogIn, Star } from "lucide-react";
+import { ArrowRight, Calendar, ExternalLink, LogIn, Star } from "@/components/ui/nourico-icons";
 import {
   Anthropic,
   Gemini,

--- a/web/src/app/v2/methodology/page.tsx
+++ b/web/src/app/v2/methodology/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight } from "@/components/ui/nourico-icons";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { PageHeader } from "@/components/marketing/page-header";
 import { SplitSection } from "@/components/marketing/split-section";

--- a/web/src/app/v2/oss/page.tsx
+++ b/web/src/app/v2/oss/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight, ExternalLink, Star } from "lucide-react";
+import { ArrowRight, ExternalLink, Star } from "@/components/ui/nourico-icons";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { PageHeader } from "@/components/marketing/page-header";
 import { SplitSection } from "@/components/marketing/split-section";

--- a/web/src/app/v2/platform/agent-evaluation/page.tsx
+++ b/web/src/app/v2/platform/agent-evaluation/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight } from "@/components/ui/nourico-icons";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { PageHeader } from "@/components/marketing/page-header";
 import { SplitSection } from "@/components/marketing/split-section";

--- a/web/src/app/v2/platform/ci-cd-gating/page.tsx
+++ b/web/src/app/v2/platform/ci-cd-gating/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight } from "@/components/ui/nourico-icons";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { PageHeader } from "@/components/marketing/page-header";
 import { SplitSection } from "@/components/marketing/split-section";

--- a/web/src/app/v2/platform/multi-turn-evaluation/page.tsx
+++ b/web/src/app/v2/platform/multi-turn-evaluation/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight } from "@/components/ui/nourico-icons";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { PageHeader } from "@/components/marketing/page-header";
 import { SplitSection } from "@/components/marketing/split-section";

--- a/web/src/app/v2/platform/rag-evaluation/page.tsx
+++ b/web/src/app/v2/platform/rag-evaluation/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight } from "@/components/ui/nourico-icons";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { PageHeader } from "@/components/marketing/page-header";
 import { SplitSection } from "@/components/marketing/split-section";

--- a/web/src/app/v2/platform/regression-testing/page.tsx
+++ b/web/src/app/v2/platform/regression-testing/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight } from "@/components/ui/nourico-icons";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { PageHeader } from "@/components/marketing/page-header";
 import { SplitSection } from "@/components/marketing/split-section";

--- a/web/src/app/v2/platform/self-hosted/page.tsx
+++ b/web/src/app/v2/platform/self-hosted/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight, Star, ExternalLink } from "lucide-react";
+import { ArrowRight, Star, ExternalLink } from "@/components/ui/nourico-icons";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { PageHeader } from "@/components/marketing/page-header";
 import { SplitSection } from "@/components/marketing/split-section";

--- a/web/src/app/v2/security/page.tsx
+++ b/web/src/app/v2/security/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight } from "@/components/ui/nourico-icons";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { PageHeader } from "@/components/marketing/page-header";
 import { SplitSection } from "@/components/marketing/split-section";

--- a/web/src/app/v2/use-cases/coding-agents/page.tsx
+++ b/web/src/app/v2/use-cases/coding-agents/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight } from "@/components/ui/nourico-icons";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { PageHeader } from "@/components/marketing/page-header";
 import { SplitSection } from "@/components/marketing/split-section";

--- a/web/src/app/v2/use-cases/deep-research/page.tsx
+++ b/web/src/app/v2/use-cases/deep-research/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight } from "@/components/ui/nourico-icons";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { PageHeader } from "@/components/marketing/page-header";
 import { SplitSection } from "@/components/marketing/split-section";

--- a/web/src/app/v2/use-cases/sql-data-agents/page.tsx
+++ b/web/src/app/v2/use-cases/sql-data-agents/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight } from "@/components/ui/nourico-icons";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { PageHeader } from "@/components/marketing/page-header";
 import { SplitSection } from "@/components/marketing/split-section";

--- a/web/src/app/v2/use-cases/sre-agents/page.tsx
+++ b/web/src/app/v2/use-cases/sre-agents/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight } from "@/components/ui/nourico-icons";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { PageHeader } from "@/components/marketing/page-header";
 import { SplitSection } from "@/components/marketing/split-section";

--- a/web/src/app/v2/use-cases/support-agents/page.tsx
+++ b/web/src/app/v2/use-cases/support-agents/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight } from "@/components/ui/nourico-icons";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { PageHeader } from "@/components/marketing/page-header";
 import { SplitSection } from "@/components/marketing/split-section";

--- a/web/src/app/v2/vs/braintrust/page.tsx
+++ b/web/src/app/v2/vs/braintrust/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight } from "@/components/ui/nourico-icons";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { PageHeader } from "@/components/marketing/page-header";
 import { SplitSection } from "@/components/marketing/split-section";

--- a/web/src/app/v2/vs/langfuse/page.tsx
+++ b/web/src/app/v2/vs/langfuse/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight } from "@/components/ui/nourico-icons";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { PageHeader } from "@/components/marketing/page-header";
 import { SplitSection } from "@/components/marketing/split-section";

--- a/web/src/app/v2/vs/langsmith/page.tsx
+++ b/web/src/app/v2/vs/langsmith/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight } from "@/components/ui/nourico-icons";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { PageHeader } from "@/components/marketing/page-header";
 import { SplitSection } from "@/components/marketing/split-section";

--- a/web/src/app/v2/vs/openai-evals/page.tsx
+++ b/web/src/app/v2/vs/openai-evals/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight } from "@/components/ui/nourico-icons";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { PageHeader } from "@/components/marketing/page-header";
 import { SplitSection } from "@/components/marketing/split-section";

--- a/web/src/app/v2/vs/promptfoo/page.tsx
+++ b/web/src/app/v2/vs/promptfoo/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight } from "@/components/ui/nourico-icons";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { PageHeader } from "@/components/marketing/page-header";
 import { SplitSection } from "@/components/marketing/split-section";

--- a/web/src/components/app-shell/nav-items.ts
+++ b/web/src/components/app-shell/nav-items.ts
@@ -16,7 +16,7 @@ import {
   Lock,
   Cog,
   type LucideIcon,
-} from "lucide-react";
+} from "@/components/ui/nourico-icons";
 
 export interface NavItem {
   label: string;

--- a/web/src/components/app-shell/sidebar.tsx
+++ b/web/src/components/app-shell/sidebar.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { navSections } from "./nav-items";
-import { PanelLeftClose, PanelLeft } from "lucide-react";
+import { PanelLeftClose, PanelLeft } from "@/components/ui/nourico-icons";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,

--- a/web/src/components/app-shell/user-menu.tsx
+++ b/web/src/components/app-shell/user-menu.tsx
@@ -9,7 +9,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { LogOut, Settings2 } from "lucide-react";
+import { LogOut, Settings2 } from "@/components/ui/nourico-icons";
 import Link from "next/link";
 
 interface UserMenuProps {

--- a/web/src/components/app-shell/workspace-switcher.tsx
+++ b/web/src/components/app-shell/workspace-switcher.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter, usePathname } from "next/navigation";
-import { ChevronsUpDown, Check } from "lucide-react";
+import { ChevronsUpDown, Check } from "@/components/ui/nourico-icons";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,

--- a/web/src/components/arena/live-agent-lane.tsx
+++ b/web/src/components/arena/live-agent-lane.tsx
@@ -14,7 +14,7 @@ import {
   Activity,
   Hash,
   Coins,
-} from "lucide-react";
+} from "@/components/ui/nourico-icons";
 
 import { Badge } from "@/components/ui/badge";
 import { UploadArtifactDialog } from "@/components/artifacts/upload-artifact-dialog";

--- a/web/src/components/arena/live-commentary-sidebar.tsx
+++ b/web/src/components/arena/live-commentary-sidebar.tsx
@@ -6,7 +6,7 @@ import {
   AlertTriangle,
   CircleDot,
   Sparkles,
-} from "lucide-react";
+} from "@/components/ui/nourico-icons";
 
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";

--- a/web/src/components/arena/live-event-ticker.tsx
+++ b/web/src/components/arena/live-event-ticker.tsx
@@ -9,7 +9,7 @@ import {
   BarChart3,
   Activity,
   AlertTriangle,
-} from "lucide-react";
+} from "@/components/ui/nourico-icons";
 
 import { cn } from "@/lib/utils";
 import type {

--- a/web/src/components/arena/race-mode/race-lane.tsx
+++ b/web/src/components/arena/race-mode/race-lane.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { Play, CheckCircle2, Upload } from "lucide-react";
+import { Play, CheckCircle2, Upload } from "@/components/ui/nourico-icons";
 
 import type { RunAgent, RunAgentStatus } from "@/lib/api/types";
 import type { ArenaLaneState } from "@/hooks/use-agent-arena";

--- a/web/src/components/artifacts/download-artifact-button.tsx
+++ b/web/src/components/artifacts/download-artifact-button.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { downloadArtifact } from "@/lib/api/artifacts";
-import { Download, Loader2 } from "lucide-react";
+import { Download, Loader2 } from "@/components/ui/nourico-icons";
 
 interface DownloadArtifactButtonProps {
   artifactId: string;

--- a/web/src/components/artifacts/upload-artifact-dialog.tsx
+++ b/web/src/components/artifacts/upload-artifact-dialog.tsx
@@ -17,7 +17,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { JsonField } from "@/components/ui/json-field";
-import { Upload, Loader2, CheckCircle2, FileUp } from "lucide-react";
+import { Upload, Loader2, CheckCircle2, FileUp } from "@/components/ui/nourico-icons";
 
 const ARTIFACT_TYPE_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
 

--- a/web/src/components/docs/callout.tsx
+++ b/web/src/components/docs/callout.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { AlertTriangle, Info, NotebookPen } from "lucide-react";
+import { AlertTriangle, Info, NotebookPen } from "@/components/ui/nourico-icons";
 
 type CalloutType = "info" | "warning" | "note";
 

--- a/web/src/components/docs/docs-search.tsx
+++ b/web/src/components/docs/docs-search.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { Search, Command } from "lucide-react";
+import { Search, Command } from "@/components/ui/nourico-icons";
 import type { DocSearchItem } from "@/lib/docs";
 
 export function DocsSearch() {

--- a/web/src/components/docs/docs-shell.tsx
+++ b/web/src/components/docs/docs-shell.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactNode } from "react";
 import Link from "next/link";
-import { Copy, Sparkles } from "lucide-react";
+import { Copy, Sparkles } from "@/components/ui/nourico-icons";
 import type { DocHeading, DocNavSection } from "@/lib/docs";
 import { DocsSidebar } from "@/components/docs/docs-sidebar";
 import { DocsToc } from "@/components/docs/docs-toc";

--- a/web/src/components/docs/docs-sidebar.tsx
+++ b/web/src/components/docs/docs-sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { MessageSquare, BookOpen, Map, Github } from "lucide-react";
+import { MessageSquare, BookOpen, Map, Github } from "@/components/ui/nourico-icons";
 import type { DocNavSection } from "@/lib/docs";
 
 export function DocsSidebar({

--- a/web/src/components/infra/create-resource-dialog.test.tsx
+++ b/web/src/components/infra/create-resource-dialog.test.tsx
@@ -106,7 +106,7 @@ vi.mock("@/components/ui/dialog", async () => {
   };
 });
 
-vi.mock("lucide-react", () => ({
+vi.mock("@/components/ui/nourico-icons", () => ({
   Loader2: () => React.createElement("span", null, "loader"),
   Plus: () => React.createElement("span", null, "plus"),
 }));

--- a/web/src/components/infra/create-resource-dialog.tsx
+++ b/web/src/components/infra/create-resource-dialog.tsx
@@ -17,7 +17,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { toast } from "sonner";
-import { Loader2, Plus } from "lucide-react";
+import { Loader2, Plus } from "@/components/ui/nourico-icons";
 
 interface Field {
   key: string;

--- a/web/src/components/infra/delete-resource-button.tsx
+++ b/web/src/components/infra/delete-resource-button.tsx
@@ -16,7 +16,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { toast } from "sonner";
-import { Loader2, Trash2 } from "lucide-react";
+import { Loader2, Trash2 } from "@/components/ui/nourico-icons";
 
 interface DeleteResourceButtonProps {
   endpoint: string;

--- a/web/src/components/marketing/cta-strip.tsx
+++ b/web/src/components/marketing/cta-strip.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowRight, Star } from "lucide-react";
+import { ArrowRight, Star } from "@/components/ui/nourico-icons";
 import { DemoButton } from "./demo-button";
 
 type Variant = "demo-first" | "cli-first" | "github-first";

--- a/web/src/components/marketing/demo-button.tsx
+++ b/web/src/components/marketing/demo-button.tsx
@@ -1,4 +1,4 @@
-import { Calendar } from "lucide-react";
+import { Calendar } from "@/components/ui/nourico-icons";
 
 const DEMO_LINK = "atharva-kanherkar-epgztu/agentclash-demo";
 const DEMO_BUTTON_CONFIG = JSON.stringify({ layout: "month_view" });

--- a/web/src/components/marketing/marketing-header.tsx
+++ b/web/src/components/marketing/marketing-header.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowRight, LogIn, Star } from "lucide-react";
+import { ArrowRight, LogIn, Star } from "@/components/ui/nourico-icons";
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { ClashMark } from "./clash-mark";
 

--- a/web/src/components/marketing/page-header.tsx
+++ b/web/src/components/marketing/page-header.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import Link from "next/link";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight } from "@/components/ui/nourico-icons";
 
 export type Breadcrumb = { label: string; href?: string };
 

--- a/web/src/components/replay/replay-step-card.tsx
+++ b/web/src/components/replay/replay-step-card.tsx
@@ -15,7 +15,7 @@ import {
   Activity,
   ChevronRight,
   ChevronDown,
-} from "lucide-react";
+} from "@/components/ui/nourico-icons";
 import { DownloadArtifactButton } from "@/components/artifacts/download-artifact-button";
 
 const stepIcon: Record<ReplayStepType, React.ComponentType<{ className?: string }>> = {

--- a/web/src/components/replay/replay-timeline.tsx
+++ b/web/src/components/replay/replay-timeline.tsx
@@ -6,7 +6,7 @@ import { ReplayStepCard } from "./replay-step-card";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Panel } from "@/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/panel";
-import { Loader2, ListTree } from "lucide-react";
+import { Loader2, ListTree } from "@/components/ui/nourico-icons";
 import { findHighlightIndex } from "./replay-highlight";
 
 interface ReplayTimelineProps {

--- a/web/src/components/share/create-public-share-button.tsx
+++ b/web/src/components/share/create-public-share-button.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
-import { Copy, Loader2, Share2 } from "lucide-react";
+import { Copy, Loader2, Share2 } from "@/components/ui/nourico-icons";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";

--- a/web/src/components/share/public-share-renderers.tsx
+++ b/web/src/components/share/public-share-renderers.tsx
@@ -12,7 +12,7 @@ import {
   Trophy,
   Wrench,
   XCircle,
-} from "lucide-react";
+} from "@/components/ui/nourico-icons";
 
 import {
   DimensionsDeck,

--- a/web/src/components/ui/breadcrumb.tsx
+++ b/web/src/components/ui/breadcrumb.tsx
@@ -3,7 +3,7 @@ import { mergeProps } from "@base-ui/react/merge-props"
 import { useRender } from "@base-ui/react/use-render"
 
 import { cn } from "@/lib/utils"
-import { ChevronRightIcon, MoreHorizontalIcon } from "lucide-react"
+import { ChevronRightIcon, MoreHorizontalIcon } from "@/components/ui/nourico-icons"
 
 function Breadcrumb({ className, ...props }: React.ComponentProps<"nav">) {
   return (

--- a/web/src/components/ui/data-table.tsx
+++ b/web/src/components/ui/data-table.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
-import { ArrowUpDown, ArrowUp, ArrowDown, ChevronLeft, ChevronRight } from "lucide-react";
+import { ArrowUpDown, ArrowUp, ArrowDown, ChevronLeft, ChevronRight } from "@/components/ui/nourico-icons";
 
 // ---------------------------------------------------------------------------
 // Types

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -5,7 +5,7 @@ import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
-import { XIcon } from "lucide-react"
+import { XIcon } from "@/components/ui/nourico-icons"
 
 function Dialog({ ...props }: DialogPrimitive.Root.Props) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import { Menu as MenuPrimitive } from "@base-ui/react/menu"
 
 import { cn } from "@/lib/utils"
-import { ChevronRightIcon, CheckIcon } from "lucide-react"
+import { ChevronRightIcon, CheckIcon } from "@/components/ui/nourico-icons"
 
 function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
   return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />

--- a/web/src/components/ui/error-boundary.tsx
+++ b/web/src/components/ui/error-boundary.tsx
@@ -2,7 +2,7 @@
 
 import { Component, type ErrorInfo, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle } from "@/components/ui/nourico-icons";
 
 interface ErrorBoundaryProps {
   children: ReactNode;

--- a/web/src/components/ui/loading-spinner.tsx
+++ b/web/src/components/ui/loading-spinner.tsx
@@ -1,4 +1,4 @@
-import { Loader2 } from "lucide-react";
+import { Loader2 } from "@/components/ui/nourico-icons";
 import { cn } from "@/lib/utils";
 
 const sizeMap = {

--- a/web/src/components/ui/nourico-icons.tsx
+++ b/web/src/components/ui/nourico-icons.tsx
@@ -1,0 +1,170 @@
+import * as React from "react";
+
+export type LucideIcon = React.ForwardRefExoticComponent<
+  Omit<NouricoIconProps, "ref"> & React.RefAttributes<SVGSVGElement>
+>;
+
+export type NouricoIconProps = React.SVGProps<SVGSVGElement> & {
+  absoluteStrokeWidth?: boolean;
+  size?: string | number;
+  strokeWidth?: string | number;
+};
+
+const NouricoIcon = React.forwardRef<SVGSVGElement, NouricoIconProps>(
+  (
+    {
+      absoluteStrokeWidth,
+      children,
+      color = "currentColor",
+      fill = "none",
+      height,
+      size = 24,
+      stroke = "currentColor",
+      strokeWidth = 1.5,
+      width,
+      ...props
+    },
+    ref,
+  ) => {
+    void absoluteStrokeWidth;
+
+    return (
+      <svg
+        ref={ref}
+        width={width ?? size}
+        height={height ?? size}
+        viewBox="0 0 24 24"
+        fill={fill}
+        stroke={stroke === "currentColor" ? color : stroke}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+        role="presentation"
+        aria-hidden={props["aria-label"] ? undefined : true}
+        {...props}
+      >
+        <path d="M3.361 16.104c-.481-3.393-.481-4.815 0-8.208C3.595 6.248 5.406 5 7.563 5h.217c1.378 0 2.655.721 3.368 1.9l2.49 4.122c.505.836 1.79.475 1.786-.501l-.016-4.489C15.406 5.463 15.867 5 16.437 5c2.157 0 3.968 1.248 4.202 2.896.374 2.639.458 3.726.249 6.016a2.92 2.92 0 0 1-.721 1.661l-1.571 1.791c-1.633 1.86-4.572 1.719-6.018-.29l-2.229-3.094c-.565-.785-1.804-.391-1.812.576l-.029 3.507A.946.946 0 0 1 7.563 19c-2.157 0-3.968-1.248-4.202-2.896Z" />
+        {children}
+      </svg>
+    );
+  },
+);
+
+NouricoIcon.displayName = "NouricoIcon";
+
+export { NouricoIcon };
+export default NouricoIcon;
+
+export const Activity = NouricoIcon;
+export const AlertCircle = NouricoIcon;
+export const AlertOctagon = NouricoIcon;
+export const AlertTriangle = NouricoIcon;
+export const ArrowDown = NouricoIcon;
+export const ArrowDownRight = NouricoIcon;
+export const ArrowLeft = NouricoIcon;
+export const ArrowRight = NouricoIcon;
+export const ArrowRightCircle = NouricoIcon;
+export const ArrowUp = NouricoIcon;
+export const ArrowUpDown = NouricoIcon;
+export const ArrowUpRight = NouricoIcon;
+export const AudioLines = NouricoIcon;
+export const BarChart3 = NouricoIcon;
+export const BookOpen = NouricoIcon;
+export const Bot = NouricoIcon;
+export const BrainCircuit = NouricoIcon;
+export const Calendar = NouricoIcon;
+export const Check = NouricoIcon;
+export const CheckCircle = NouricoIcon;
+export const CheckCircle2 = NouricoIcon;
+export const CheckIcon = NouricoIcon;
+export const ChevronDown = NouricoIcon;
+export const ChevronDownIcon = NouricoIcon;
+export const ChevronLeft = NouricoIcon;
+export const ChevronRight = NouricoIcon;
+export const ChevronRightIcon = NouricoIcon;
+export const ChevronUpIcon = NouricoIcon;
+export const ChevronsUpDown = NouricoIcon;
+export const CircleCheckIcon = NouricoIcon;
+export const CircleDot = NouricoIcon;
+export const Clipboard = NouricoIcon;
+export const ClipboardCheck = NouricoIcon;
+export const ClipboardList = NouricoIcon;
+export const Clock = NouricoIcon;
+export const Code2 = NouricoIcon;
+export const Cog = NouricoIcon;
+export const Coins = NouricoIcon;
+export const Command = NouricoIcon;
+export const Copy = NouricoIcon;
+export const Database = NouricoIcon;
+export const DollarSign = NouricoIcon;
+export const Download = NouricoIcon;
+export const ExternalLink = NouricoIcon;
+export const FileArchive = NouricoIcon;
+export const FileCode = NouricoIcon;
+export const FileUp = NouricoIcon;
+export const Flag = NouricoIcon;
+export const FlaskConical = NouricoIcon;
+export const Gauge = NouricoIcon;
+export const GitCompare = NouricoIcon;
+export const Github = NouricoIcon;
+export const Hash = NouricoIcon;
+export const History = NouricoIcon;
+export const Inbox = NouricoIcon;
+export const Info = NouricoIcon;
+export const InfoIcon = NouricoIcon;
+export const Key = NouricoIcon;
+export const Layers = NouricoIcon;
+export const ListChecks = NouricoIcon;
+export const ListTree = NouricoIcon;
+export const Loader2 = NouricoIcon;
+export const Loader2Icon = NouricoIcon;
+export const Lock = NouricoIcon;
+export const LogIn = NouricoIcon;
+export const LogOut = NouricoIcon;
+export const Map = NouricoIcon;
+export const Maximize2 = NouricoIcon;
+export const MessageSquare = NouricoIcon;
+export const MessageSquareText = NouricoIcon;
+export const Minimize2 = NouricoIcon;
+export const Minus = NouricoIcon;
+export const MoreHorizontal = NouricoIcon;
+export const MoreHorizontalIcon = NouricoIcon;
+export const NotebookPen = NouricoIcon;
+export const OctagonXIcon = NouricoIcon;
+export const Package = NouricoIcon;
+export const PackageOpen = NouricoIcon;
+export const PanelLeft = NouricoIcon;
+export const PanelLeftClose = NouricoIcon;
+export const Pencil = NouricoIcon;
+export const Play = NouricoIcon;
+export const PlayCircle = NouricoIcon;
+export const Plus = NouricoIcon;
+export const Quote = NouricoIcon;
+export const Radio = NouricoIcon;
+export const Rocket = NouricoIcon;
+export const Save = NouricoIcon;
+export const Search = NouricoIcon;
+export const Settings2 = NouricoIcon;
+export const Share2 = NouricoIcon;
+export const Shield = NouricoIcon;
+export const ShieldAlert = NouricoIcon;
+export const ShieldCheck = NouricoIcon;
+export const ShieldQuestion = NouricoIcon;
+export const ShieldX = NouricoIcon;
+export const Sigma = NouricoIcon;
+export const Sparkles = NouricoIcon;
+export const Star = NouricoIcon;
+export const Tag = NouricoIcon;
+export const Target = NouricoIcon;
+export const Terminal = NouricoIcon;
+export const Trash2 = NouricoIcon;
+export const TriangleAlertIcon = NouricoIcon;
+export const Trophy = NouricoIcon;
+export const Upload = NouricoIcon;
+export const UserPlus = NouricoIcon;
+export const Users = NouricoIcon;
+export const Wrench = NouricoIcon;
+export const X = NouricoIcon;
+export const XCircle = NouricoIcon;
+export const XIcon = NouricoIcon;
+export const Zap = NouricoIcon;

--- a/web/src/components/ui/pagination-controls.tsx
+++ b/web/src/components/ui/pagination-controls.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight } from "@/components/ui/nourico-icons";
 
 interface PaginationControlsProps {
   offset: number;

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import { Select as SelectPrimitive } from "@base-ui/react/select"
 
 import { cn } from "@/lib/utils"
-import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "@/components/ui/nourico-icons"
 
 const Select = SelectPrimitive.Root
 

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -5,7 +5,7 @@ import { Dialog as SheetPrimitive } from "@base-ui/react/dialog"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
-import { XIcon } from "lucide-react"
+import { XIcon } from "@/components/ui/nourico-icons"
 
 function Sheet({ ...props }: SheetPrimitive.Root.Props) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />

--- a/web/src/components/ui/sonner.tsx
+++ b/web/src/components/ui/sonner.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Toaster as Sonner, type ToasterProps } from "sonner"
-import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "@/components/ui/nourico-icons"
 
 const Toaster = ({ ...props }: ToasterProps) => {
   return (


### PR DESCRIPTION
## What changed

- Added a local Nourico SVG icon adapter based on the Framer vector at `https://framer.com/m/Nourico-EmNcpg.js@96vlh0u4IGtzvstHLNV1`.
- Repointed all web source imports from `lucide-react` to `@/components/ui/nourico-icons`.
- Exported the existing icon names from the adapter so current call sites keep their component API and SVG props.
- Updated icon-related test mocks to target the local adapter.
- Removed the direct `lucide-react` dependency from the web package and lockfiles.
- Added a review-checkpoint test contract for the refactor.

## Impact

All app-level lucide icons now render the Nourico vector through one local primitive. Transitive `lucide-react` copies remain only where third-party LobeHub packages depend on them internally.

## Validation

- `cd web && npm run lint`
- `cd web && npm run build`
- `cd web && npm run test -- --run`
- `rg 'from "lucide-react"|from '\''lucide-react'\''|vi\.mock\("lucide-react"' web/src -g '*.tsx' -g '*.ts'`
- `git diff --check`

Note: `npm run build` still prints existing WorkOS Edge Runtime warnings; the build exits successfully.
