### PR TITLE
feat(web): live github contribution heatmap on landing OSS section

### DIFF
--- a/web/src/app/landing.tsx
+++ b/web/src/app/landing.tsx
@@ -15,6 +15,8 @@ import {
   XAI,
 } from "@lobehub/icons";
 import { LuminousGrid } from "@/components/marketing/luminous-grid";
+import { RepoStreakClient } from "@/components/marketing/repo-streak-client";
+import type { StreakData } from "@/lib/github-streak";
 
 const DEMO_LINK = "atharva-kanherkar-epgztu/agentclash-demo";
 const DEMO_BUTTON_CONFIG = JSON.stringify({ layout: "month_view" });
@@ -1251,7 +1253,11 @@ const COMPARISON_ROWS: Array<{
   },
 ];
 
-export default function HomePage() {
+export default function HomePage({
+  streak,
+}: {
+  streak?: StreakData | null;
+}) {
   const { user, loading: authLoading } = useAuth();
 
   useEffect(() => {
@@ -2112,6 +2118,39 @@ export default function HomePage() {
           </div>
         </div>
       </section>
+
+      {/* ── OSS pulse ───────────────────────────────────────────── */}
+      {streak && (
+        <section className="border-t border-white/[0.06] px-8 sm:px-12 py-24 sm:py-32">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-[60ch]">
+              <p className="font-mono text-[0.66rem] uppercase tracking-[0.28em] text-white/45">
+                Open source pulse
+              </p>
+              <h2 className="mt-4 font-[family-name:var(--font-display)] font-normal tracking-[-0.025em] leading-[1.05] text-[clamp(1.875rem,4.5vw,3.25rem)] text-white/95">
+                Built in the open.
+                <br />
+                <span className="text-white/40">A year of commits.</span>
+              </h2>
+              <p className="mt-5 max-w-[52ch] text-base leading-[1.55] text-white/55">
+                Live data from the{" "}
+                <a
+                  href={`https://github.com/${streak.owner}/${streak.repo}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-white/85 underline-offset-4 hover:underline"
+                >
+                  {streak.owner}/{streak.repo}
+                </a>{" "}
+                repo. Hover any cell to see the day&apos;s landmark commit.
+              </p>
+            </div>
+            <div className="mt-12">
+              <RepoStreakClient data={streak} />
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* ── Footer ──────────────────────────────────────────────── */}
       <footer className="mt-auto border-t border-white/[0.06] px-8 sm:px-12 py-10">

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,9 +1,11 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { redirect } from "next/navigation";
+import { fetchRepoStreak } from "@/lib/github-streak";
 import HomePage from "./landing";
 
 export default async function RootPage() {
   const { user } = await withAuth();
   if (user) redirect("/dashboard");
-  return <HomePage />;
+  const streak = await fetchRepoStreak("agentclash", "agentclash");
+  return <HomePage streak={streak} />;
 }

--- a/web/src/components/marketing/repo-streak-client.tsx
+++ b/web/src/components/marketing/repo-streak-client.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import type { StreakData, StreakDay } from "@/lib/github-streak";
+
+type HoverState = {
+  day: StreakDay;
+  x: number; // viewport coords
+  y: number;
+} | null;
+
+const CELL = 12;
+const GAP = 3;
+const COL_STRIDE = CELL + GAP;
+const ROW_STRIDE = CELL + GAP;
+
+const MONTH_LABELS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+function bucketFor(count: number): 0 | 1 | 2 | 3 | 4 {
+  if (count === 0) return 0;
+  if (count <= 2) return 1;
+  if (count <= 5) return 2;
+  if (count <= 10) return 3;
+  return 4;
+}
+
+// Bucket fills tuned against the page's near-black background and the existing
+// luminous-grid blue. Lowest level keeps the cell visible without competing
+// with the rest of the page.
+const FILL = ["#171a22", "#1f3a5a", "#2e6aa3", "#4f9bdb", "#7eb8e6"] as const;
+
+const TIER_DOT: Record<string, string> = {
+  breaking: "#ff8a4c",
+  feat: "#7eb8e6",
+  fix: "#cfd5e0",
+};
+
+export function RepoStreakClient({ data }: { data: StreakData }) {
+  const [hover, setHover] = useState<HoverState>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+
+  const { weeks, monthMarks, totalWeeks } = useMemo(() => {
+    // Pad to start on a Sunday so columns are aligned weeks.
+    const first = new Date(`${data.days[0].date}T00:00:00Z`);
+    const padDays = first.getUTCDay(); // 0=Sun
+    const padded: (StreakDay | null)[] = [
+      ...Array.from({ length: padDays }, () => null),
+      ...data.days,
+    ];
+    const weeks: (StreakDay | null)[][] = [];
+    for (let i = 0; i < padded.length; i += 7) {
+      weeks.push(padded.slice(i, i + 7));
+    }
+    // Tail-pad final column to 7 cells so the grid is rectangular.
+    const last = weeks[weeks.length - 1];
+    while (last.length < 7) last.push(null);
+
+    const monthMarks: { x: number; label: string }[] = [];
+    let lastMonth = -1;
+    weeks.forEach((week, col) => {
+      const firstReal = week.find((d): d is StreakDay => d !== null);
+      if (!firstReal) return;
+      const month = new Date(`${firstReal.date}T00:00:00Z`).getUTCMonth();
+      if (month !== lastMonth) {
+        monthMarks.push({ x: col * COL_STRIDE, label: MONTH_LABELS[month] });
+        lastMonth = month;
+      }
+    });
+
+    return { weeks, monthMarks, totalWeeks: weeks.length };
+  }, [data]);
+
+  const width = totalWeeks * COL_STRIDE - GAP;
+  const height = 7 * ROW_STRIDE - GAP;
+
+  return (
+    <div className="relative">
+      <div className="mb-6 flex flex-wrap items-baseline gap-x-8 gap-y-2 text-sm">
+        <div className="font-mono text-[0.7rem] uppercase tracking-[0.22em] text-white/40">
+          {data.owner}/{data.repo}
+        </div>
+        <Stat label="commits / yr" value={data.totalCommits.toLocaleString()} />
+        <Stat label="active days" value={`${data.activeDays}`} />
+        <Stat label="longest streak" value={`${data.longestStreak}d`} />
+        <Stat
+          label="busiest"
+          value={
+            data.busiest.count > 0
+              ? `${data.busiest.count} on ${formatShort(data.busiest.date)}`
+              : "—"
+          }
+        />
+      </div>
+
+      <div
+        className="relative overflow-x-auto"
+        onMouseLeave={() => setHover(null)}
+      >
+        <svg
+          viewBox={`-26 -16 ${width + 32} ${height + 22}`}
+          className="block min-w-[680px] w-full"
+          role="img"
+          aria-label={`Commit activity heatmap for ${data.owner}/${data.repo}`}
+        >
+          {monthMarks.map((m) => (
+            <text
+              key={`${m.x}-${m.label}`}
+              x={m.x}
+              y={-4}
+              fill="rgba(255,255,255,0.35)"
+              fontFamily="var(--font-mono)"
+              fontSize="9"
+              letterSpacing="0.12em"
+            >
+              {m.label.toUpperCase()}
+            </text>
+          ))}
+          {["Mon", "Wed", "Fri"].map((label, i) => (
+            <text
+              key={label}
+              x={-8}
+              y={ROW_STRIDE * (i * 2 + 1) + CELL * 0.75}
+              textAnchor="end"
+              fill="rgba(255,255,255,0.3)"
+              fontFamily="var(--font-mono)"
+              fontSize="8"
+              letterSpacing="0.1em"
+            >
+              {label.toUpperCase()}
+            </text>
+          ))}
+          {weeks.map((week, col) =>
+            week.map((day, row) => {
+              if (!day) return null;
+              const x = col * COL_STRIDE;
+              const y = row * ROW_STRIDE;
+              const fill = FILL[bucketFor(day.count)];
+              const tier = day.landmark?.tier;
+              return (
+                <g
+                  key={`${col}-${row}`}
+                  onMouseEnter={(e) => {
+                    setHover({
+                      day,
+                      x: e.clientX,
+                      y: e.clientY,
+                    });
+                  }}
+                  onMouseMove={(e) => {
+                    setHover((h) =>
+                      h && h.day.date === day.date
+                        ? { day, x: e.clientX, y: e.clientY }
+                        : h,
+                    );
+                  }}
+                  style={{ cursor: day.count > 0 ? "pointer" : "default" }}
+                >
+                  <rect
+                    x={x}
+                    y={y}
+                    width={CELL}
+                    height={CELL}
+                    rx={2.5}
+                    fill={fill}
+                    stroke={
+                      hover?.day.date === day.date
+                        ? "rgba(255,255,255,0.5)"
+                        : "transparent"
+                    }
+                    strokeWidth={1}
+                  />
+                  {tier && tier !== "misc" && (
+                    <circle
+                      cx={x + CELL - 2.5}
+                      cy={y + 2.5}
+                      r={1.6}
+                      fill={TIER_DOT[tier]}
+                    />
+                  )}
+                </g>
+              );
+            }),
+          )}
+        </svg>
+      </div>
+
+      <div className="mt-5 flex flex-wrap items-center justify-between gap-y-3 font-mono text-[0.65rem] uppercase tracking-[0.18em] text-white/35">
+        <div className="flex items-center gap-3">
+          <span>Less</span>
+          <div className="flex items-center gap-1">
+            {FILL.map((c, i) => (
+              <span
+                key={c}
+                aria-hidden
+                style={{
+                  width: 11,
+                  height: 11,
+                  borderRadius: 2,
+                  background: c,
+                  display: "inline-block",
+                }}
+              >
+                <span className="sr-only">level {i}</span>
+              </span>
+            ))}
+          </div>
+          <span>More</span>
+        </div>
+        <div className="flex items-center gap-4">
+          <LegendDot color={TIER_DOT.feat} label="feat" />
+          <LegendDot color={TIER_DOT.fix} label="fix" />
+          <LegendDot color={TIER_DOT.breaking} label="breaking" />
+        </div>
+      </div>
+
+      {hover && (
+        <div
+          ref={tooltipRef}
+          role="tooltip"
+          style={{
+            position: "fixed",
+            left: hover.x + 14,
+            top: hover.y + 14,
+            zIndex: 50,
+            pointerEvents: "none",
+          }}
+          className="max-w-[320px] rounded-md border border-white/15 bg-[#0b0e14]/95 px-3 py-2 text-xs leading-snug text-white/85 shadow-lg backdrop-blur"
+        >
+          <div className="font-mono text-[0.62rem] uppercase tracking-[0.2em] text-white/45">
+            {formatLong(hover.day.date)}
+          </div>
+          <div className="mt-1 text-[0.78rem] text-white">
+            {hover.day.count === 0
+              ? "No commits"
+              : hover.day.count === 1
+                ? "1 commit"
+                : `${hover.day.count} commits`}
+          </div>
+          {hover.day.landmark && (
+            <div className="mt-2 border-t border-white/10 pt-2">
+              <div className="font-mono text-[0.6rem] uppercase tracking-[0.18em] text-white/40">
+                {hover.day.landmark.tier}
+              </div>
+              <div className="mt-0.5 line-clamp-3 text-[0.78rem] text-white/85">
+                {hover.day.landmark.message}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline gap-2">
+      <span className="font-[family-name:var(--font-display)] text-2xl tracking-[-0.02em] text-white">
+        {value}
+      </span>
+      <span className="font-mono text-[0.62rem] uppercase tracking-[0.2em] text-white/40">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function LegendDot({ color, label }: { color: string; label: string }) {
+  return (
+    <span className="flex items-center gap-1.5">
+      <span
+        aria-hidden
+        style={{
+          width: 6,
+          height: 6,
+          borderRadius: 999,
+          background: color,
+          display: "inline-block",
+        }}
+      />
+      {label}
+    </span>
+  );
+}
+
+function formatLong(iso: string): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  return d.toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+function formatShort(iso: string): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}

--- a/web/src/lib/github-streak.ts
+++ b/web/src/lib/github-streak.ts
@@ -1,0 +1,201 @@
+/*
+ * GitHub commit-streak data for the landing page.
+ *
+ * Fetches the last ~371 days of commits from a public repository, aggregates
+ * them into a daily calendar, and tags each day with its most "landmark"
+ * commit based on conventional-commit prefixes. Cached for one hour at the
+ * Next.js fetch layer so we don't hammer the GitHub API on every render.
+ */
+
+const DAYS_BACK = 371;
+const REVALIDATE_SECONDS = 60 * 60;
+
+export type StreakLandmarkTier = "breaking" | "feat" | "fix" | "misc";
+
+export type StreakLandmark = {
+  message: string;
+  sha: string;
+  url: string;
+  tier: StreakLandmarkTier;
+};
+
+export type StreakDay = {
+  date: string; // YYYY-MM-DD (UTC)
+  count: number;
+  landmark?: StreakLandmark;
+};
+
+export type StreakData = {
+  owner: string;
+  repo: string;
+  days: StreakDay[]; // chronological, length ~371
+  totalCommits: number;
+  activeDays: number;
+  longestStreak: number;
+  busiest: { date: string; count: number };
+  rangeStart: string;
+  rangeEnd: string;
+};
+
+type GhCommit = {
+  sha: string;
+  html_url: string;
+  commit: {
+    author: { date: string } | null;
+    committer: { date: string } | null;
+    message: string;
+  };
+};
+
+function classify(message: string): StreakLandmarkTier | null {
+  const subject = message.split("\n", 1)[0];
+  if (/^[a-z]+(?:\([^)]+\))?!:/i.test(subject)) return "breaking";
+  if (/BREAKING CHANGE/.test(message)) return "breaking";
+  if (/^feat(?:\([^)]+\))?:/i.test(subject)) return "feat";
+  if (/^fix(?:\([^)]+\))?:/i.test(subject)) return "fix";
+  return null;
+}
+
+const TIER_PRIORITY: Record<StreakLandmarkTier, number> = {
+  breaking: 3,
+  feat: 2,
+  fix: 1,
+  misc: 0,
+};
+
+function emptyDayMap(rangeStart: Date, rangeEnd: Date): string[] {
+  const dates: string[] = [];
+  const cursor = new Date(
+    Date.UTC(
+      rangeStart.getUTCFullYear(),
+      rangeStart.getUTCMonth(),
+      rangeStart.getUTCDate(),
+    ),
+  );
+  const end = new Date(
+    Date.UTC(
+      rangeEnd.getUTCFullYear(),
+      rangeEnd.getUTCMonth(),
+      rangeEnd.getUTCDate(),
+    ),
+  );
+  while (cursor.getTime() <= end.getTime()) {
+    dates.push(cursor.toISOString().slice(0, 10));
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+  return dates;
+}
+
+export async function fetchRepoStreak(
+  owner: string,
+  repo: string,
+): Promise<StreakData | null> {
+  const now = new Date();
+  const start = new Date(now);
+  start.setUTCDate(start.getUTCDate() - (DAYS_BACK - 1));
+  const sinceISO = new Date(
+    Date.UTC(
+      start.getUTCFullYear(),
+      start.getUTCMonth(),
+      start.getUTCDate(),
+    ),
+  ).toISOString();
+
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  const token = process.env.GITHUB_TOKEN;
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const commits: GhCommit[] = [];
+  for (let page = 1; page <= 30; page++) {
+    const url = `https://api.github.com/repos/${owner}/${repo}/commits?per_page=100&since=${encodeURIComponent(sinceISO)}&page=${page}`;
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        headers,
+        next: { revalidate: REVALIDATE_SECONDS },
+      });
+    } catch {
+      return null;
+    }
+    if (!res.ok) {
+      if (page === 1) return null;
+      break;
+    }
+    const batch = (await res.json()) as GhCommit[];
+    if (!Array.isArray(batch) || batch.length === 0) break;
+    commits.push(...batch);
+    if (batch.length < 100) break;
+  }
+
+  const dates = emptyDayMap(start, now);
+  const dayIndex = new Map<string, StreakDay>();
+  for (const date of dates) dayIndex.set(date, { date, count: 0 });
+
+  for (const c of commits) {
+    const iso = c.commit.author?.date ?? c.commit.committer?.date;
+    if (!iso) continue;
+    const date = iso.slice(0, 10);
+    const day = dayIndex.get(date);
+    if (!day) continue;
+    day.count++;
+
+    const subject = c.commit.message.split("\n", 1)[0]?.trim() ?? "";
+    const tier = classify(c.commit.message) ?? "misc";
+    const candidate: StreakLandmark = {
+      message: subject,
+      sha: c.sha,
+      url: c.html_url,
+      tier,
+    };
+    if (
+      !day.landmark ||
+      TIER_PRIORITY[candidate.tier] > TIER_PRIORITY[day.landmark.tier]
+    ) {
+      day.landmark = candidate;
+    }
+  }
+
+  const days = dates.map((d) => dayIndex.get(d)!);
+
+  let longestStreak = 0;
+  let currentStreak = 0;
+  let totalCommits = 0;
+  let activeDays = 0;
+  let busiest = { date: days[0]?.date ?? "", count: 0 };
+  for (const day of days) {
+    totalCommits += day.count;
+    if (day.count > 0) {
+      activeDays++;
+      currentStreak++;
+      if (currentStreak > longestStreak) longestStreak = currentStreak;
+    } else {
+      currentStreak = 0;
+    }
+    if (day.count > busiest.count) {
+      busiest = { date: day.date, count: day.count };
+    }
+  }
+
+  // Strip landmark from days where the tier is "misc" — we only want the chip
+  // to surface intentional, narratable commits.
+  for (const day of days) {
+    if (day.landmark && day.landmark.tier === "misc") {
+      delete day.landmark;
+    }
+  }
+
+  return {
+    owner,
+    repo,
+    days,
+    totalCommits,
+    activeDays,
+    longestStreak,
+    busiest,
+    rangeStart: days[0]?.date ?? "",
+    rangeEnd: days[days.length - 1]?.date ?? "",
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a GitHub-style commit heatmap to the landing page, mounted in a new section between the closing CTA and the footer (under the existing OSS messaging).
- Pulls the **last 371 days** of commits from `agentclash/agentclash` via the GitHub REST API on the server (cached 1 hour via Next.js `fetch` revalidate). No new dependencies. Optional `GITHUB_TOKEN` env raises the rate limit but isn't required for build.
- Each day cell tags its most "landmark" commit using conventional-commit prefixes — `feat!:` (breaking) > `feat:` > `fix:` — and surfaces it in a custom hover tooltip with date, commit count, tier, and short subject. Days with only "misc" commits show count only.
- Header strip shows live stats: total commits, active days, longest streak, busiest day. SVG grid uses the page's existing blue (`#7eb8e6`) for the highest bucket so it sits in the same palette as the luminous-grid hero.
- Render path: server `page.tsx` calls `fetchRepoStreak()` and passes data as a prop into the client `landing.tsx`, which mounts `<RepoStreakClient />`. If the GitHub fetch fails (network/rate-limit/private repo), the section is omitted entirely — landing page never breaks.

## Files
- `web/src/lib/github-streak.ts` — fetch + aggregate (server-only)
- `web/src/components/marketing/repo-streak-client.tsx` — interactive SVG heatmap + tooltip
- `web/src/app/page.tsx` — wires the server fetch
- `web/src/app/landing.tsx` — accepts the new `streak` prop and renders the section

## Test plan
- [ ] `pnpm dev`, scroll to the bottom of `/`, confirm the heatmap renders with real data
- [ ] Hover a busy day with a `feat:` commit — tooltip shows date, count, tier, message
- [ ] Hover a quiet day — tooltip shows "No commits"
- [ ] Hover a `feat!:` day — tooltip tier reads "breaking", cell has the orange dot
- [ ] Resize to mobile — heatmap scrolls horizontally without overflowing the viewport
- [ ] Visit `/` while temporarily breaking network access — section is omitted, rest of landing renders normally
- [ ] CI: `pnpm lint`, `npx tsc --noEmit`, `pnpm vitest run` all green (verified locally: 190/190 tests pass)