### PR TITLE
[codex] Refactor playground comparison workspace

### DIFF
--- a/backend/internal/api/playgrounds.go
+++ b/backend/internal/api/playgrounds.go
@@ -144,6 +144,7 @@ type BatchExperimentModelEntry struct {
 	Name              string
 	ProviderAccountID uuid.UUID
 	ModelAliasID      uuid.UUID
+	RequestConfig     json.RawMessage
 }
 
 func (m *PlaygroundManager) CreatePlayground(ctx context.Context, caller Caller, input CreatePlaygroundInput) (repository.Playground, error) {
@@ -356,12 +357,16 @@ func (m *PlaygroundManager) CreatePlaygroundExperiment(ctx context.Context, call
 func (m *PlaygroundManager) BatchCreatePlaygroundExperiments(ctx context.Context, caller Caller, input BatchCreatePlaygroundExperimentsInput) ([]repository.PlaygroundExperiment, error) {
 	experiments := make([]repository.PlaygroundExperiment, 0, len(input.Models))
 	for _, model := range input.Models {
+		requestConfig := input.RequestConfig
+		if len(model.RequestConfig) > 0 {
+			requestConfig = model.RequestConfig
+		}
 		experiment, err := m.CreatePlaygroundExperiment(ctx, caller, CreatePlaygroundExperimentInput{
 			PlaygroundID:      input.PlaygroundID,
 			Name:              model.Name,
 			ProviderAccountID: model.ProviderAccountID,
 			ModelAliasID:      model.ModelAliasID,
-			RequestConfig:     input.RequestConfig,
+			RequestConfig:     requestConfig,
 		})
 		if err != nil {
 			// If one fails, still return the successfully created ones.
@@ -465,9 +470,10 @@ type batchPlaygroundExperimentRequest struct {
 }
 
 type batchExperimentModelEntry struct {
-	ProviderAccountID string `json:"provider_account_id"`
-	ModelAliasID      string `json:"model_alias_id"`
-	Name              string `json:"name"`
+	ProviderAccountID string          `json:"provider_account_id"`
+	ModelAliasID      string          `json:"model_alias_id"`
+	Name              string          `json:"name"`
+	RequestConfig     json.RawMessage `json:"request_config"`
 }
 
 type playgroundResponse struct {
@@ -868,6 +874,7 @@ func batchCreatePlaygroundExperimentsHandler(logger *slog.Logger, service Playgr
 				Name:              entry.Name,
 				ProviderAccountID: providerAccountID,
 				ModelAliasID:      modelAliasID,
+				RequestConfig:     entry.RequestConfig,
 			})
 		}
 		experiments, err := service.BatchCreatePlaygroundExperiments(r.Context(), caller, BatchCreatePlaygroundExperimentsInput{

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -7835,6 +7835,9 @@ components:
               model_alias_id:
                 type: string
                 format: uuid
+              request_config:
+                type: ["object", "null"]
+                additionalProperties: true
         request_config:
           type: ["object", "null"]
           additionalProperties: true

--- a/testing/codex-refactor-playground-side-by-side.md
+++ b/testing/codex-refactor-playground-side-by-side.md
@@ -1,0 +1,31 @@
+# codex/refactor-playground-side-by-side - Test Contract
+
+## Functional Behavior
+- Playground detail opens as a side-by-side comparison workspace, not a tabbed prompt/eval/experiment split.
+- Two model lanes are visible on the first screen with provider, model, label, temperature, timeout, trace mode, tools, knowledge, and run controls.
+- The shared prompt, system prompt, evaluation config, and test cases remain editable from the same workspace.
+- Launching the comparison creates a batch of two experiments with each lane's provider, model, label, and request config.
+- Completed baseline/candidate results can be selected and compared without leaving the side-by-side view.
+- Existing backend behavior is preserved: playground save, test case CRUD, experiment polling, and comparison query params continue to work.
+
+## Unit Tests
+- TypeScript compile/lint should catch prop and type regressions in the refactored playground components.
+- Existing component tests should remain green where they overlap shared UI primitives.
+
+## Integration / Functional Tests
+- `PlaygroundDetailClient` should render with existing server-provided props and not require new backend endpoints.
+- Experiment launch payloads should remain compatible with `/v1/playgrounds/{id}/experiments/batch`.
+- Comparison query params should continue to drive `/v1/playground-experiments/compare`.
+
+## Smoke Tests
+- `cd web && pnpm lint`
+- `cd web && pnpm test -- --run`
+
+## E2E Tests
+- N/A - no browser automation suite exists for this playground flow in the repo.
+
+## Manual Tests
+- Open a playground detail page and verify the first visible layout is two comparison lanes.
+- Edit prompt/system/evaluation/test cases from the same page.
+- Select two completed experiments and verify per-case outputs are displayed side by side.
+- Launch a two-lane comparison and verify the page returns to the comparison workspace with polling active.

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/page.tsx
@@ -4,12 +4,13 @@ import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";
 import type {
   ModelAlias,
+  KnowledgeSource,
   Playground,
   PlaygroundExperiment,
   PlaygroundExperimentComparison,
-  PlaygroundExperimentResult,
   PlaygroundTestCase,
   ProviderAccount,
+  WorkspaceTool,
 } from "@/lib/api/types";
 import { PlaygroundDetailClient } from "./playground-detail-client";
 
@@ -18,13 +19,13 @@ export default async function PlaygroundDetailPage({
   searchParams,
 }: {
   params: Promise<{ workspaceId: string; playgroundId: string }>;
-  searchParams: Promise<{ experiment?: string; baseline?: string; candidate?: string }>;
+  searchParams: Promise<{ baseline?: string; candidate?: string }>;
 }) {
   const { accessToken } = await withAuth();
   if (!accessToken) redirect("/auth/login");
 
   const { workspaceId, playgroundId } = await params;
-  const { experiment, baseline, candidate } = await searchParams;
+  const { baseline, candidate } = await searchParams;
   const api = createApiClient(accessToken);
 
   let playground: Playground;
@@ -32,21 +33,35 @@ export default async function PlaygroundDetailPage({
   let experiments: PlaygroundExperiment[];
   let providerAccounts: ProviderAccount[];
   let modelAliases: ModelAlias[];
+  let tools: WorkspaceTool[];
+  let knowledgeSources: KnowledgeSource[];
 
   try {
-    const [playgroundRes, testCasesRes, experimentsRes, providerAccountsRes, modelAliasesRes] =
+    const [
+      playgroundRes,
+      testCasesRes,
+      experimentsRes,
+      providerAccountsRes,
+      modelAliasesRes,
+      toolsRes,
+      knowledgeSourcesRes,
+    ] =
       await Promise.all([
         api.get<Playground>(`/v1/playgrounds/${playgroundId}`),
         api.get<{ items: PlaygroundTestCase[] }>(`/v1/playgrounds/${playgroundId}/test-cases`),
         api.get<{ items: PlaygroundExperiment[] }>(`/v1/playgrounds/${playgroundId}/experiments`),
         api.get<{ items: ProviderAccount[] }>(`/v1/workspaces/${workspaceId}/provider-accounts`),
         api.get<{ items: ModelAlias[] }>(`/v1/workspaces/${workspaceId}/model-aliases`),
+        api.get<{ items: WorkspaceTool[] }>(`/v1/workspaces/${workspaceId}/tools`),
+        api.get<{ items: KnowledgeSource[] }>(`/v1/workspaces/${workspaceId}/knowledge-sources`),
       ]);
     playground = playgroundRes;
     testCases = testCasesRes.items;
     experiments = experimentsRes.items;
     providerAccounts = providerAccountsRes.items;
     modelAliases = modelAliasesRes.items;
+    tools = toolsRes.items;
+    knowledgeSources = knowledgeSourcesRes.items;
   } catch (err) {
     const message = err instanceof ApiError ? err.message : "Failed to load playground";
     return (
@@ -56,24 +71,15 @@ export default async function PlaygroundDetailPage({
     );
   }
 
-  const [selectedResults, comparison] = await Promise.all([
-    experiment
-      ? api
-          .get<{ items: PlaygroundExperimentResult[] }>(
-            `/v1/playground-experiments/${experiment}/results`,
-          )
-          .then((res) => res.items)
-          .catch(() => null)
-      : Promise.resolve(null),
+  const comparison =
     baseline && candidate
-      ? api
+      ? await api
           .get<PlaygroundExperimentComparison>(
             "/v1/playground-experiments/compare",
             { params: { baseline, candidate } },
           )
           .catch(() => null)
-      : Promise.resolve(null),
-  ]);
+      : null;
 
   return (
     <div>
@@ -84,8 +90,8 @@ export default async function PlaygroundDetailPage({
         experiments={experiments}
         providerAccounts={providerAccounts}
         modelAliases={modelAliases}
-        selectedExperimentResults={selectedResults}
-        selectedExperimentId={experiment ?? null}
+        tools={tools}
+        knowledgeSources={knowledgeSources}
         comparison={comparison}
         baselineExperimentId={baseline ?? null}
         candidateExperimentId={candidate ?? null}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/playground-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/playground-detail-client.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { createApiClient } from "@/lib/api/client";
 import type {
+  KnowledgeSource,
   ModelAlias,
   Playground,
   PlaygroundExperiment,
@@ -12,20 +13,107 @@ import type {
   PlaygroundExperimentResult,
   PlaygroundTestCase,
   ProviderAccount,
+  WorkspaceTool,
 } from "@/lib/api/types";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 import { PageHeader } from "@/components/ui/page-header";
 import { ConfirmProvider, useConfirm } from "@/components/ui/confirm-dialog";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useExperimentPolling } from "@/hooks/use-experiment-polling";
-import { PromptEditor } from "./components/prompt-editor";
 import { TestCasePanel } from "./components/test-case-panel";
-import { ExperimentLauncher } from "./components/experiment-launcher";
-import { ExperimentList } from "./components/experiment-list";
 import { ComparisonPanel } from "./components/comparison-panel";
 import { EvalSpecBuilder } from "./components/eval-spec-builder";
-import { Trash2 } from "lucide-react";
+import { KpiStrip } from "./components/kpi-strip";
+import {
+  ArrowRightLeft,
+  Bot,
+  Brain,
+  Database,
+  Loader2,
+  MessageSquareText,
+  Rocket,
+  Settings2,
+  SlidersHorizontal,
+  Trash2,
+  Wrench,
+} from "lucide-react";
+
+type TraceMode = "required" | "best_effort" | "disabled";
+
+interface LaneConfig {
+  label: string;
+  providerAccountId: string;
+  modelAliasId: string;
+  temperature: string;
+  timeoutMs: string;
+  traceMode: TraceMode;
+  toolIds: string[];
+  knowledgeSourceIds: string[];
+}
+
+function makeLaneConfig(
+  label: string,
+  providerAccounts: ProviderAccount[],
+  modelAliases: ModelAlias[],
+): LaneConfig {
+  return {
+    label,
+    providerAccountId: providerAccounts[0]?.id ?? "",
+    modelAliasId: modelAliases[0]?.id ?? "",
+    temperature: "0.2",
+    timeoutMs: "120000",
+    traceMode: "required",
+    toolIds: [],
+    knowledgeSourceIds: [],
+  };
+}
+
+function statusVariant(
+  status: string,
+): "default" | "secondary" | "destructive" | "outline" {
+  switch (status) {
+    case "completed":
+      return "default";
+    case "running":
+    case "queued":
+      return "secondary";
+    case "failed":
+      return "destructive";
+    default:
+      return "outline";
+  }
+}
+
+function formatPercent(value: number | null | undefined): string {
+  if (value == null) return "N/A";
+  return `${Math.round(value * 100)}%`;
+}
+
+function experimentTitle(
+  experiment: PlaygroundExperiment | undefined,
+  fallback: string,
+): string {
+  return experiment?.name || fallback;
+}
+
+function parseTimeout(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 120000;
+}
+
+function parseTemperature(value: string): number {
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed)) return 0.2;
+  return Math.min(2, Math.max(0, parsed));
+}
 
 export function PlaygroundDetailClient(props: {
   workspaceId: string;
@@ -34,25 +122,15 @@ export function PlaygroundDetailClient(props: {
   experiments: PlaygroundExperiment[];
   providerAccounts: ProviderAccount[];
   modelAliases: ModelAlias[];
-  selectedExperimentResults: PlaygroundExperimentResult[] | null;
-  selectedExperimentId: string | null;
+  tools: WorkspaceTool[];
+  knowledgeSources: KnowledgeSource[];
   comparison: PlaygroundExperimentComparison | null;
   baselineExperimentId: string | null;
   candidateExperimentId: string | null;
 }) {
   return (
     <ConfirmProvider>
-      <PlaygroundDetailInner
-        workspaceId={props.workspaceId}
-        playground={props.playground}
-        testCases={props.testCases}
-        initialExperiments={props.experiments}
-        providerAccounts={props.providerAccounts}
-        modelAliases={props.modelAliases}
-        comparison={props.comparison}
-        baselineExperimentId={props.baselineExperimentId}
-        candidateExperimentId={props.candidateExperimentId}
-      />
+      <PlaygroundDetailInner {...props} />
     </ConfirmProvider>
   );
 }
@@ -61,9 +139,11 @@ function PlaygroundDetailInner({
   workspaceId,
   playground,
   testCases,
-  initialExperiments,
+  experiments: initialExperiments,
   providerAccounts,
   modelAliases,
+  tools,
+  knowledgeSources,
   comparison,
   baselineExperimentId,
   candidateExperimentId,
@@ -71,9 +151,11 @@ function PlaygroundDetailInner({
   workspaceId: string;
   playground: Playground;
   testCases: PlaygroundTestCase[];
-  initialExperiments: PlaygroundExperiment[];
+  experiments: PlaygroundExperiment[];
   providerAccounts: ProviderAccount[];
   modelAliases: ModelAlias[];
+  tools: WorkspaceTool[];
+  knowledgeSources: KnowledgeSource[];
   comparison: PlaygroundExperimentComparison | null;
   baselineExperimentId: string | null;
   candidateExperimentId: string | null;
@@ -81,48 +163,72 @@ function PlaygroundDetailInner({
   const router = useRouter();
   const confirm = useConfirm();
   const { getAccessToken } = useAccessToken();
-  const [activeTab, setActiveTab] = useState("editor");
   const [error, setError] = useState<string | null>(null);
   const [evalSpec, setEvalSpec] = useState<unknown>(playground.evaluation_spec);
+  const [name, setName] = useState(playground.name);
+  const [promptTemplate, setPromptTemplate] = useState(playground.prompt_template);
+  const [systemPrompt, setSystemPrompt] = useState(playground.system_prompt);
+  const [saving, setSaving] = useState(false);
+  const [launching, setLaunching] = useState(false);
+  const [baselineLane, setBaselineLane] = useState(() =>
+    makeLaneConfig("Baseline", providerAccounts, modelAliases),
+  );
+  const [candidateLane, setCandidateLane] = useState(() =>
+    makeLaneConfig("Candidate", providerAccounts, modelAliases),
+  );
 
   const { experiments, resultsByExperimentId, isPolling, fetchResultsForExperiment } =
     useExperimentPolling({
       playgroundId: playground.id,
       initialExperiments,
-      enabled: activeTab === "experiments" || activeTab === "compare",
+      enabled: true,
     });
 
-  const completedCount = experiments.filter(
-    (e) => e.status === "completed",
-  ).length;
-
-  const api = useCallback(
-    async () => {
-      const token = await getAccessToken();
-      return createApiClient(token);
-    },
-    [getAccessToken],
+  const completedExperiments = useMemo(
+    () => experiments.filter((experiment) => experiment.status === "completed"),
+    [experiments],
+  );
+  const newestCompleted = completedExperiments[0];
+  const secondNewestCompleted = completedExperiments[1];
+  const [baselineSelection, setBaselineSelection] = useState(
+    baselineExperimentId ?? newestCompleted?.id ?? "",
+  );
+  const [candidateSelection, setCandidateSelection] = useState(
+    candidateExperimentId ?? secondNewestCompleted?.id ?? "",
   );
 
-  async function handleSavePlayground(data: {
-    name: string;
-    promptTemplate: string;
-    systemPrompt: string;
-    evaluationSpec: unknown;
-  }) {
+  const baselineExperiment = experiments.find((e) => e.id === baselineSelection);
+  const candidateExperiment = experiments.find((e) => e.id === candidateSelection);
+  const baselineResults = baselineSelection
+    ? (resultsByExperimentId[baselineSelection] ?? [])
+    : [];
+  const candidateResults = candidateSelection
+    ? (resultsByExperimentId[candidateSelection] ?? [])
+    : [];
+  const completedCount = completedExperiments.length;
+
+  const api = useCallback(async () => {
+    const token = await getAccessToken();
+    return createApiClient(token);
+  }, [getAccessToken]);
+
+  async function handleSavePlayground() {
     setError(null);
+    setSaving(true);
     try {
       const client = await api();
       await client.patch(`/v1/playgrounds/${playground.id}`, {
-        name: data.name,
-        prompt_template: data.promptTemplate,
-        system_prompt: data.systemPrompt,
+        name,
+        prompt_template: promptTemplate,
+        system_prompt: systemPrompt,
         evaluation_spec: evalSpec,
       });
       router.refresh();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save playground");
       throw err;
+    } finally {
+      setSaving(false);
     }
   }
 
@@ -200,59 +306,62 @@ function PlaygroundDetailInner({
     }
   }
 
-  async function handleLaunchSingle(data: {
-    name: string;
-    providerAccountId: string;
-    modelAliasId: string;
-  }) {
+  function laneRequestConfig(lane: LaneConfig) {
+    return {
+      trace_mode: lane.traceMode,
+      step_timeout_ms: parseTimeout(lane.timeoutMs),
+      temperature: parseTemperature(lane.temperature),
+      tools: lane.toolIds.map((toolId) => ({ tool_id: toolId })),
+      knowledge_sources: lane.knowledgeSourceIds.map((knowledgeSourceId) => ({
+        knowledge_source_id: knowledgeSourceId,
+      })),
+    };
+  }
+
+  async function handleLaunchComparison() {
     setError(null);
+    setLaunching(true);
     try {
       const client = await api();
-      await client.post(`/v1/playgrounds/${playground.id}/experiments`, {
-        name: data.name,
-        provider_account_id: data.providerAccountId,
-        model_alias_id: data.modelAliasId,
-        request_config: { trace_mode: "required", step_timeout_ms: 120000 },
+      await client.post(`/v1/playgrounds/${playground.id}/experiments/batch`, {
+        models: [
+          {
+            provider_account_id: baselineLane.providerAccountId,
+            model_alias_id: baselineLane.modelAliasId,
+            name: baselineLane.label,
+            request_config: laneRequestConfig(baselineLane),
+          },
+          {
+            provider_account_id: candidateLane.providerAccountId,
+            model_alias_id: candidateLane.modelAliasId,
+            name: candidateLane.label,
+            request_config: laneRequestConfig(candidateLane),
+          },
+        ],
+        request_config: {
+          baseline: laneRequestConfig(baselineLane),
+          candidate: laneRequestConfig(candidateLane),
+        },
       });
       router.refresh();
-      setActiveTab("experiments");
     } catch (err) {
       setError(
-        err instanceof Error ? err.message : "Failed to launch experiment",
+        err instanceof Error ? err.message : "Failed to launch comparison",
       );
       throw err;
+    } finally {
+      setLaunching(false);
     }
   }
 
-  async function handleLaunchBatch(data: {
-    models: {
-      providerAccountId: string;
-      modelAliasId: string;
-      name: string;
-    }[];
-  }) {
-    setError(null);
-    try {
-      const client = await api();
-      await client.post(
-        `/v1/playgrounds/${playground.id}/experiments/batch`,
-        {
-          models: data.models.map((m) => ({
-            provider_account_id: m.providerAccountId,
-            model_alias_id: m.modelAliasId,
-            name: m.name,
-          })),
-          request_config: { trace_mode: "required", step_timeout_ms: 120000 },
-        },
-      );
-      router.refresh();
-      setActiveTab("experiments");
-    } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Failed to launch experiments",
-      );
-      throw err;
-    }
+  function handleCompareSelection() {
+    if (!baselineSelection || !candidateSelection) return;
+    const params = new URLSearchParams();
+    params.set("baseline", baselineSelection);
+    params.set("candidate", candidateSelection);
+    router.push(
+      `/workspaces/${workspaceId}/playgrounds/${playground.id}?${params.toString()}`,
+    );
   }
 
   return (
@@ -284,83 +393,557 @@ function PlaygroundDetailInner({
         </div>
       )}
 
-      <Tabs value={activeTab} onValueChange={(v) => v && setActiveTab(v as string)}>
-        <TabsList>
-          <TabsTrigger value="editor">Editor</TabsTrigger>
-          <TabsTrigger value="test-cases">
-            Test Cases
-            {testCases.length > 0 && (
-              <Badge variant="secondary" className="ml-1.5 text-[10px] px-1.5 py-0">
-                {testCases.length}
-              </Badge>
-            )}
-          </TabsTrigger>
-          <TabsTrigger value="experiments">
-            Experiments
-            {experiments.length > 0 && (
-              <Badge variant="secondary" className="ml-1.5 text-[10px] px-1.5 py-0">
-                {experiments.length}
-              </Badge>
-            )}
-            {isPolling && (
-              <span className="ml-1 size-1.5 rounded-full bg-emerald-500 animate-pulse" />
-            )}
-          </TabsTrigger>
-          <TabsTrigger value="compare" disabled={completedCount < 2}>
-            Compare
-          </TabsTrigger>
-        </TabsList>
+      <section className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_360px]">
+        <div className="space-y-5">
+          <div className="rounded-lg border border-border bg-card">
+            <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-4 py-3">
+              <div className="flex items-center gap-2">
+                <ArrowRightLeft className="size-4 text-primary" />
+                <div>
+                  <h2 className="text-sm font-semibold">Side-by-side chat comparison</h2>
+                  <p className="text-xs text-muted-foreground">
+                    Run two configured lanes against the same prompt, cases, and scorecard.
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                {isPolling && (
+                  <Badge variant="secondary" className="gap-1">
+                    <span className="size-1.5 rounded-full bg-emerald-500" />
+                    polling
+                  </Badge>
+                )}
+                <Button
+                  onClick={handleLaunchComparison}
+                  disabled={
+                    launching ||
+                    testCases.length === 0 ||
+                    !baselineLane.providerAccountId ||
+                    !baselineLane.modelAliasId ||
+                    !candidateLane.providerAccountId ||
+                    !candidateLane.modelAliasId
+                  }
+                >
+                  {launching ? (
+                    <Loader2 className="mr-2 size-4 animate-spin" />
+                  ) : (
+                    <Rocket className="mr-2 size-4" />
+                  )}
+                  {launching ? "Running..." : "Run comparison"}
+                </Button>
+              </div>
+            </div>
 
-        <TabsContent value="editor">
-          <PromptEditor
-            name={playground.name}
-            promptTemplate={playground.prompt_template}
-            systemPrompt={playground.system_prompt}
-            evaluationSpec={evalSpec}
+            <div className="grid gap-0 lg:grid-cols-2">
+              <ComparisonLane
+                title="Baseline"
+                accent="border-l-blue-500"
+                lane={baselineLane}
+                onChange={setBaselineLane}
+                providerAccounts={providerAccounts}
+                modelAliases={modelAliases}
+                tools={tools}
+                knowledgeSources={knowledgeSources}
+                selectedExperimentId={baselineSelection}
+                onSelectExperiment={(id) => {
+                  setBaselineSelection(id);
+                  void fetchResultsForExperiment(id);
+                }}
+                experiments={completedExperiments}
+                experiment={baselineExperiment}
+                results={baselineResults}
+              />
+              <ComparisonLane
+                title="Candidate"
+                accent="border-l-emerald-500"
+                lane={candidateLane}
+                onChange={setCandidateLane}
+                providerAccounts={providerAccounts}
+                modelAliases={modelAliases}
+                tools={tools}
+                knowledgeSources={knowledgeSources}
+                selectedExperimentId={candidateSelection}
+                onSelectExperiment={(id) => {
+                  setCandidateSelection(id);
+                  void fetchResultsForExperiment(id);
+                }}
+                experiments={completedExperiments}
+                experiment={candidateExperiment}
+                results={candidateResults}
+              />
+            </div>
+          </div>
+
+          {completedCount >= 2 && (
+            <div className="rounded-lg border border-border bg-card p-4">
+              <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h2 className="text-sm font-semibold">Scorecard comparison</h2>
+                  <p className="text-xs text-muted-foreground">
+                    Compare saved runs by case, output, and score deltas.
+                  </p>
+                </div>
+                <Button
+                  variant="secondary"
+                  onClick={handleCompareSelection}
+                  disabled={
+                    !baselineSelection ||
+                    !candidateSelection ||
+                    baselineSelection === candidateSelection
+                  }
+                >
+                  <ArrowRightLeft className="mr-2 size-4" />
+                  Compare selected
+                </Button>
+              </div>
+              <ComparisonPanel
+                workspaceId={workspaceId}
+                playgroundId={playground.id}
+                experiments={experiments}
+                comparison={comparison}
+                initialBaselineId={baselineSelection}
+                initialCandidateId={candidateSelection}
+              />
+            </div>
+          )}
+        </div>
+
+        <aside className="space-y-4">
+          <SharedPromptPanel
+            name={name}
+            onNameChange={setName}
+            systemPrompt={systemPrompt}
+            onSystemPromptChange={setSystemPrompt}
+            promptTemplate={promptTemplate}
+            onPromptTemplateChange={setPromptTemplate}
+            saving={saving}
             onSave={handleSavePlayground}
-            evalSpecBuilder={
-              <EvalSpecBuilder value={evalSpec} onChange={setEvalSpec} />
-            }
           />
-        </TabsContent>
 
-        <TabsContent value="test-cases">
-          <TestCasePanel
-            testCases={testCases}
-            onCreateTestCase={handleCreateTestCase}
-            onUpdateTestCase={handleUpdateTestCase}
-            onDeleteTestCase={handleDeleteTestCase}
-          />
-        </TabsContent>
+          <div className="rounded-lg border border-border bg-card p-4">
+            <div className="mb-3 flex items-center gap-2">
+              <Brain className="size-4 text-primary" />
+              <h2 className="text-sm font-semibold">Evaluation config</h2>
+            </div>
+            <EvalSpecBuilder value={evalSpec} onChange={setEvalSpec} />
+          </div>
 
-        <TabsContent value="experiments">
-          <div className="space-y-6">
-            <ExperimentLauncher
-              providerAccounts={providerAccounts}
-              modelAliases={modelAliases}
-              onLaunchSingle={handleLaunchSingle}
-              onLaunchBatch={handleLaunchBatch}
-            />
-            <ExperimentList
-              experiments={experiments}
-              resultsByExperimentId={resultsByExperimentId}
-              isPolling={isPolling}
-              onFetchResults={fetchResultsForExperiment}
+          <div className="rounded-lg border border-border bg-card p-4">
+            <div className="mb-3 flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2">
+                <MessageSquareText className="size-4 text-primary" />
+                <h2 className="text-sm font-semibold">Test cases</h2>
+              </div>
+              <Badge variant="secondary">{testCases.length}</Badge>
+            </div>
+            <TestCasePanel
+              testCases={testCases}
+              onCreateTestCase={handleCreateTestCase}
+              onUpdateTestCase={handleUpdateTestCase}
+              onDeleteTestCase={handleDeleteTestCase}
             />
           </div>
-        </TabsContent>
+        </aside>
+      </section>
+    </div>
+  );
+}
 
-        <TabsContent value="compare">
-          <ComparisonPanel
-            workspaceId={workspaceId}
-            playgroundId={playground.id}
-            experiments={experiments}
-            comparison={comparison}
-            initialBaselineId={baselineExperimentId}
-            initialCandidateId={candidateExperimentId}
+function SharedPromptPanel({
+  name,
+  onNameChange,
+  systemPrompt,
+  onSystemPromptChange,
+  promptTemplate,
+  onPromptTemplateChange,
+  saving,
+  onSave,
+}: {
+  name: string;
+  onNameChange: (value: string) => void;
+  systemPrompt: string;
+  onSystemPromptChange: (value: string) => void;
+  promptTemplate: string;
+  onPromptTemplateChange: (value: string) => void;
+  saving: boolean;
+  onSave: () => Promise<void>;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="mb-3 flex items-center gap-2">
+        <Settings2 className="size-4 text-primary" />
+        <h2 className="text-sm font-semibold">Shared prompt</h2>
+      </div>
+      <div className="space-y-3">
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-muted-foreground">Name</label>
+          <Input value={name} onChange={(e) => onNameChange(e.target.value)} />
+        </div>
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-muted-foreground">
+            System prompt
+          </label>
+          <textarea
+            value={systemPrompt}
+            onChange={(e) => onSystemPromptChange(e.target.value)}
+            spellCheck={false}
+            className="min-h-20 w-full resize-y rounded-lg border border-input bg-transparent px-3 py-2 text-sm leading-relaxed focus:outline-none focus:ring-2 focus:ring-ring/50"
           />
-        </TabsContent>
-      </Tabs>
+        </div>
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-muted-foreground">
+            Prompt template
+          </label>
+          <textarea
+            value={promptTemplate}
+            onChange={(e) => onPromptTemplateChange(e.target.value)}
+            spellCheck={false}
+            className="min-h-36 w-full resize-y rounded-lg border border-input bg-transparent px-3 py-2 text-sm leading-relaxed focus:outline-none focus:ring-2 focus:ring-ring/50"
+          />
+        </div>
+        <Button onClick={() => void onSave()} disabled={saving} className="w-full">
+          {saving && <Loader2 className="mr-2 size-4 animate-spin" />}
+          {saving ? "Saving..." : "Save prompt and evaluation"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ComparisonLane({
+  title,
+  accent,
+  lane,
+  onChange,
+  providerAccounts,
+  modelAliases,
+  tools,
+  knowledgeSources,
+  selectedExperimentId,
+  onSelectExperiment,
+  experiments,
+  experiment,
+  results,
+}: {
+  title: string;
+  accent: string;
+  lane: LaneConfig;
+  onChange: (lane: LaneConfig) => void;
+  providerAccounts: ProviderAccount[];
+  modelAliases: ModelAlias[];
+  tools: WorkspaceTool[];
+  knowledgeSources: KnowledgeSource[];
+  selectedExperimentId: string;
+  onSelectExperiment: (experimentId: string) => void;
+  experiments: PlaygroundExperiment[];
+  experiment: PlaygroundExperiment | undefined;
+  results: PlaygroundExperimentResult[];
+}) {
+  function patch(update: Partial<LaneConfig>) {
+    onChange({ ...lane, ...update });
+  }
+
+  return (
+    <div className={`border-l-4 ${accent} border-t border-border p-4 first:border-t-0 lg:border-t-0 lg:first:border-r`}>
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Bot className="size-4 text-primary" />
+          <h3 className="text-sm font-semibold">{title}</h3>
+        </div>
+        {experiment && (
+          <Badge variant={statusVariant(experiment.status)}>{experiment.status}</Badge>
+        )}
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <div className="space-y-1.5 md:col-span-2">
+          <label className="text-xs font-medium text-muted-foreground">Lane label</label>
+          <Input
+            value={lane.label}
+            onChange={(e) => patch({ label: e.target.value })}
+            placeholder={title}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-muted-foreground">Provider</label>
+          <Select
+            value={lane.providerAccountId}
+            onValueChange={(value) => value && patch({ providerAccountId: value })}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Select provider" />
+            </SelectTrigger>
+            <SelectContent>
+              {providerAccounts.map((account) => (
+                <SelectItem key={account.id} value={account.id}>
+                  {account.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-muted-foreground">Model</label>
+          <Select
+            value={lane.modelAliasId}
+            onValueChange={(value) => value && patch({ modelAliasId: value })}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Select model" />
+            </SelectTrigger>
+            <SelectContent>
+              {modelAliases.map((alias) => (
+                <SelectItem key={alias.id} value={alias.id}>
+                  {alias.display_name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="mt-4 rounded-md border border-border bg-muted/20 p-3">
+        <div className="mb-3 flex items-center gap-2">
+          <SlidersHorizontal className="size-3.5 text-muted-foreground" />
+          <span className="text-xs font-semibold uppercase text-muted-foreground">
+            Config
+          </span>
+        </div>
+        <div className="grid gap-3 md:grid-cols-3">
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-muted-foreground">
+              Temperature
+            </label>
+            <Input
+              type="number"
+              min="0"
+              max="2"
+              step="0.1"
+              value={lane.temperature}
+              onChange={(e) => patch({ temperature: e.target.value })}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-muted-foreground">
+              Timeout ms
+            </label>
+            <Input
+              type="number"
+              min="1000"
+              step="1000"
+              value={lane.timeoutMs}
+              onChange={(e) => patch({ timeoutMs: e.target.value })}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-muted-foreground">
+              Trace mode
+            </label>
+            <Select
+              value={lane.traceMode}
+              onValueChange={(value) => patch({ traceMode: value as TraceMode })}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="required">required</SelectItem>
+                <SelectItem value="best_effort">best_effort</SelectItem>
+                <SelectItem value="disabled">disabled</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </div>
+
+      <ResourceChecklist
+        icon={<Wrench className="size-3.5" />}
+        title="Tools"
+        emptyLabel="No tools registered"
+        items={tools.map((tool) => ({
+          id: tool.id,
+          label: tool.name,
+          meta: tool.capability_key,
+        }))}
+        selectedIds={lane.toolIds}
+        onChange={(toolIds) => patch({ toolIds })}
+      />
+
+      <ResourceChecklist
+        icon={<Database className="size-3.5" />}
+        title="Knowledge"
+        emptyLabel="No knowledge sources connected"
+        items={knowledgeSources.map((source) => ({
+          id: source.id,
+          label: source.name,
+          meta: source.source_kind,
+        }))}
+        selectedIds={lane.knowledgeSourceIds}
+        onChange={(knowledgeSourceIds) => patch({ knowledgeSourceIds })}
+      />
+
+      <div className="mt-4 space-y-3 border-t border-border pt-4">
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-muted-foreground">
+            Compare saved run
+          </label>
+          <Select
+            value={selectedExperimentId}
+            onValueChange={(value) => value && onSelectExperiment(value)}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Select completed run" />
+            </SelectTrigger>
+            <SelectContent>
+              {experiments.map((item) => (
+                <SelectItem key={item.id} value={item.id}>
+                  {item.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <LaneResults
+          title={experimentTitle(experiment, title)}
+          experiment={experiment}
+          results={results}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ResourceChecklist({
+  icon,
+  title,
+  emptyLabel,
+  items,
+  selectedIds,
+  onChange,
+}: {
+  icon: ReactNode;
+  title: string;
+  emptyLabel: string;
+  items: { id: string; label: string; meta: string }[];
+  selectedIds: string[];
+  onChange: (ids: string[]) => void;
+}) {
+  function toggle(id: string) {
+    onChange(
+      selectedIds.includes(id)
+        ? selectedIds.filter((selectedId) => selectedId !== id)
+        : [...selectedIds, id],
+    );
+  }
+
+  return (
+    <div className="mt-4 rounded-md border border-border bg-muted/20 p-3">
+      <div className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase text-muted-foreground">
+        {icon}
+        {title}
+      </div>
+      {items.length === 0 ? (
+        <p className="text-xs text-muted-foreground">{emptyLabel}</p>
+      ) : (
+        <div className="grid gap-2">
+          {items.map((item) => (
+            <label
+              key={item.id}
+              className="flex min-h-9 items-center gap-2 rounded-md border border-border bg-background px-2 py-1.5 text-xs"
+            >
+              <input
+                type="checkbox"
+                checked={selectedIds.includes(item.id)}
+                onChange={() => toggle(item.id)}
+                className="size-3.5 accent-primary"
+              />
+              <span className="min-w-0 flex-1 truncate font-medium">{item.label}</span>
+              <code className="truncate text-[11px] text-muted-foreground">
+                {item.meta}
+              </code>
+            </label>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LaneResults({
+  title,
+  experiment,
+  results,
+}: {
+  title: string;
+  experiment: PlaygroundExperiment | undefined;
+  results: PlaygroundExperimentResult[];
+}) {
+  if (!experiment) {
+    return (
+      <div className="rounded-md border border-dashed border-border p-4 text-center text-sm text-muted-foreground">
+        Select or run an experiment to see chat output here.
+      </div>
+    );
+  }
+
+  if (results.length === 0) {
+    return (
+      <div className="rounded-md border border-border p-4 text-center text-sm text-muted-foreground">
+        Results are not available yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <h4 className="text-sm font-medium">{title}</h4>
+        <p className="text-xs text-muted-foreground">
+          {results.length} case{results.length === 1 ? "" : "s"}
+        </p>
+      </div>
+      {results.map((result) => (
+        <div key={result.id} className="rounded-md border border-border bg-background p-3">
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <span className="truncate text-sm font-medium">{result.case_key}</span>
+            <Badge variant={statusVariant(result.status)}>{result.status}</Badge>
+          </div>
+          <KpiStrip
+            latencyMs={result.latency_ms}
+            totalTokens={result.total_tokens}
+            costUsd={result.cost_usd}
+            dimensions={result.dimension_scores}
+          />
+          <div className="mt-3 space-y-3">
+            <div>
+              <p className="mb-1 text-xs font-medium uppercase text-muted-foreground">
+                User
+              </p>
+              <pre className="max-h-32 overflow-auto whitespace-pre-wrap rounded-md bg-muted/50 p-3 text-xs leading-relaxed">
+                {result.rendered_prompt}
+              </pre>
+            </div>
+            <div>
+              <p className="mb-1 text-xs font-medium uppercase text-muted-foreground">
+                Assistant
+              </p>
+              <pre className="max-h-40 overflow-auto whitespace-pre-wrap rounded-md bg-muted/50 p-3 text-xs leading-relaxed">
+                {result.actual_output || result.error_message || "No output"}
+              </pre>
+            </div>
+            {Object.keys(result.dimension_scores ?? {}).length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {Object.entries(result.dimension_scores).map(([dimension, score]) => (
+                  <Badge key={dimension} variant="outline">
+                    {dimension}: {formatPercent(score)}
+                  </Badge>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -319,6 +319,27 @@ export interface RuntimeProfile {
   updated_at: string;
 }
 
+/** GET /v1/workspaces/{id}/tools list item */
+export interface WorkspaceTool {
+  id: string;
+  name: string;
+  slug: string;
+  tool_kind: string;
+  capability_key: string;
+  lifecycle_status: string;
+  created_at: string;
+}
+
+/** GET /v1/workspaces/{id}/knowledge-sources list item */
+export interface KnowledgeSource {
+  id: string;
+  name: string;
+  slug: string;
+  source_kind: string;
+  lifecycle_status: string;
+  created_at: string;
+}
+
 /** GET /v1/workspaces/{id}/provider-accounts list item */
 export interface ProviderAccount {
   id: string;


### PR DESCRIPTION
## Summary
- Refactor playground detail into a side-by-side comparison workspace with baseline and candidate lanes
- Add visible lane controls for provider, model, label, temperature, timeout, trace mode, tools, and knowledge sources
- Keep shared prompt, evaluation config, and test case editing on the same screen
- Allow batch playground experiments to carry per-model `request_config` and document it in OpenAPI

## Impact
This makes the playground feel like a comparison chat workspace instead of separate prompt/eval/playground tabs, while preserving the existing playground, experiment, polling, and comparison endpoints.

## Validation
- `cd web && pnpm lint`
- `cd web && pnpm exec tsc --noEmit`
- `cd web && pnpm test`
- `cd backend && go test ./internal/api`

## Notes
Tool, knowledge, and temperature controls are now captured in lane `request_config`; the current playground executor still actively consumes trace mode and timeout.
