### PR TITLE
[codex] Fix CLI auth identity label source

### DIFF
--- a/backend/internal/api/auth_workos.go
+++ b/backend/internal/api/auth_workos.go
@@ -35,11 +35,16 @@ type UserRepository interface {
 	GetActiveWorkspaceMembershipsByUserID(ctx context.Context, userID uuid.UUID) ([]repository.WorkspaceMembershipRow, error)
 	GetActiveOrganizationMembershipsByUserID(ctx context.Context, userID uuid.UUID) ([]repository.OrgMembershipRow, error)
 	CreateUser(ctx context.Context, input repository.CreateUserInput) (repository.User, error)
-	BackfillUserEmail(ctx context.Context, input repository.BackfillUserEmailInput) (repository.User, error)
+	BackfillUserProfile(ctx context.Context, input repository.BackfillUserProfileInput) (repository.User, error)
 	LinkWorkOSUser(ctx context.Context, userID uuid.UUID, workosUserID string) (repository.User, error)
 	RelinkWorkOSUser(ctx context.Context, userID uuid.UUID, workosUserID string) (repository.User, error)
 	IsUserArchivedByWorkOSID(ctx context.Context, workosUserID string) (bool, error)
 	IsUserArchivedByEmail(ctx context.Context, email string) (bool, error)
+}
+
+type workOSIdentity struct {
+	Email       string
+	DisplayName string
 }
 
 // WorkOSAuthenticator validates WorkOS AuthKit JWTs using the public JWKS
@@ -125,25 +130,31 @@ func (a *WorkOSAuthenticator) Authenticate(r *http.Request) (Caller, error) {
 		return Caller{}, fmt.Errorf("%w: token missing sub claim", ErrUnauthenticated)
 	}
 
-	// Extract email from JWT claims if available. When AuthKit omits the
-	// claim, we can still recover it from WorkOS userinfo on demand.
-	email, _ := tok.Get("email")
-	emailStr, _ := email.(string)
-
-	loadEmail := func(ctx context.Context) (string, error) {
-		if emailStr != "" {
-			return emailStr, nil
+	// Extract identity claims from the JWT when present. AuthKit tokens can omit
+	// profile claims, so WorkOS userinfo is queried on demand when a missing
+	// email or display name would affect user resolution.
+	identity := identityFromToken(tok)
+	userInfoLoaded := false
+	loadIdentity := func(ctx context.Context) (workOSIdentity, error) {
+		if identity.Email != "" && identity.DisplayName != "" {
+			return identity, nil
 		}
-
-		fetchedEmail, err := a.lookupEmailFromUserInfo(ctx, tok.Issuer(), tokenStr)
-		if err != nil {
-			return "", err
+		if userInfoLoaded {
+			return identity, nil
 		}
-		emailStr = fetchedEmail
-		return emailStr, nil
+		userInfoLoaded = true
+
+		fetchedIdentity, err := a.lookupIdentityFromUserInfo(ctx, tok.Issuer(), tokenStr)
+		if fetchedIdentity.Email != "" && identity.Email == "" {
+			identity.Email = fetchedIdentity.Email
+		}
+		if fetchedIdentity.DisplayName != "" && identity.DisplayName == "" {
+			identity.DisplayName = fetchedIdentity.DisplayName
+		}
+		return identity, err
 	}
 
-	user, err := a.resolveUser(r.Context(), workosUserID, emailStr, loadEmail)
+	user, err := a.resolveUser(r.Context(), workosUserID, identity, loadIdentity)
 	if err != nil {
 		return Caller{}, err
 	}
@@ -200,36 +211,24 @@ func (a *WorkOSAuthenticator) Authenticate(r *http.Request) (Caller, error) {
 // before the email-dependent resolution steps.
 func (a *WorkOSAuthenticator) resolveUser(
 	ctx context.Context,
-	workosUserID, email string,
-	loadEmail func(context.Context) (string, error),
+	workosUserID string,
+	identity workOSIdentity,
+	loadIdentity func(context.Context) (workOSIdentity, error),
 ) (repository.User, error) {
-	log := a.logger.With("workos_user_id", workosUserID, "email", email)
+	log := a.logger.With("workos_user_id", workosUserID, "email", identity.Email)
 
 	// Step 1: active user with this WorkOS ID.
 	user, err := a.repo.GetUserByWorkOSID(ctx, workosUserID)
 	if err == nil {
-		if user.Email == "" {
-			if email == "" && loadEmail != nil {
-				loadedEmail, loadErr := loadEmail(ctx)
-				if loadErr != nil {
-					log.WarnContext(ctx, "resolve_user: failed to fetch email from WorkOS userinfo", "user_id", user.ID, "error", loadErr)
-				} else {
-					email = loadedEmail
-				}
+		if needsIdentityForUser(user, identity) && loadIdentity != nil {
+			loadedIdentity, loadErr := loadIdentity(ctx)
+			if loadErr != nil {
+				log.WarnContext(ctx, "resolve_user: failed to fetch identity from WorkOS userinfo", "user_id", user.ID, "error", loadErr)
 			}
-			if email != "" {
-				backfilled, backfillErr := a.repo.BackfillUserEmail(ctx, repository.BackfillUserEmailInput{
-					UserID: user.ID,
-					Email:  email,
-				})
-				if backfillErr != nil {
-					log.ErrorContext(ctx, "resolve_user: failed to backfill missing email", "user_id", user.ID, "error", backfillErr)
-					user.Email = email
-				} else {
-					user = backfilled
-					log.InfoContext(ctx, "resolve_user: backfilled missing email from trusted identity", "user_id", user.ID)
-				}
-			}
+			identity = loadedIdentity
+		}
+		if user.Email == "" || user.DisplayName == "" {
+			user = a.backfillMissingUserProfile(ctx, log, user, identity)
 		}
 		log.DebugContext(ctx, "resolve_user: found active user by workos_id", "user_id", user.ID)
 		return user, nil
@@ -254,18 +253,16 @@ func (a *WorkOSAuthenticator) resolveUser(
 
 	log.InfoContext(ctx, "resolve_user: no active or archived user with this workos_id")
 
-	if email == "" && loadEmail != nil {
-		loadedEmail, loadErr := loadEmail(ctx)
+	if identity.Email == "" && loadIdentity != nil {
+		loadedIdentity, loadErr := loadIdentity(ctx)
+		identity = loadedIdentity
 		if loadErr != nil {
 			log.WarnContext(ctx, "resolve_user: failed to fetch email from WorkOS userinfo", "error", loadErr)
-		} else {
-			email = loadedEmail
 		}
 	}
-
 	// Steps 3 & 4: match by email when we have one from claims or userinfo.
-	if email != "" {
-		existingUser, emailErr := a.repo.GetUserByEmail(ctx, email)
+	if identity.Email != "" {
+		existingUser, emailErr := a.repo.GetUserByEmail(ctx, identity.Email)
 		if emailErr == nil {
 			if strings.HasPrefix(existingUser.WorkOSUserID, "pending:") {
 				// Step 3: stub user from invite — link the real WorkOS ID.
@@ -278,7 +275,14 @@ func (a *WorkOSAuthenticator) resolveUser(
 					return repository.User{}, fmt.Errorf("link workos user to invited stub: %w", linkErr)
 				}
 				log.InfoContext(ctx, "resolve_user: linked workos_id to stub", "user_id", linked.ID)
-				return linked, nil
+				if needsIdentityForUser(linked, identity) && loadIdentity != nil {
+					loadedIdentity, loadErr := loadIdentity(ctx)
+					identity = loadedIdentity
+					if loadErr != nil {
+						log.WarnContext(ctx, "resolve_user: failed to fetch profile from WorkOS userinfo", "user_id", linked.ID, "error", loadErr)
+					}
+				}
+				return a.backfillMissingUserProfile(ctx, log, linked, identity), nil
 			}
 
 			// Step 4: existing user with a different real WorkOS ID. The JWT
@@ -293,14 +297,21 @@ func (a *WorkOSAuthenticator) resolveUser(
 				return repository.User{}, fmt.Errorf("re-link workos user: %w", relinkErr)
 			}
 			log.InfoContext(ctx, "resolve_user: re-linked workos_id to existing user", "user_id", relinked.ID)
-			return relinked, nil
+			if needsIdentityForUser(relinked, identity) && loadIdentity != nil {
+				loadedIdentity, loadErr := loadIdentity(ctx)
+				identity = loadedIdentity
+				if loadErr != nil {
+					log.WarnContext(ctx, "resolve_user: failed to fetch profile from WorkOS userinfo", "user_id", relinked.ID, "error", loadErr)
+				}
+			}
+			return a.backfillMissingUserProfile(ctx, log, relinked, identity), nil
 		}
 		if !errors.Is(emailErr, repository.ErrUserNotFound) {
 			log.ErrorContext(ctx, "resolve_user: unexpected error looking up by email", "error", emailErr)
 		}
 
 		// Step 5: check if an archived user holds this email.
-		archivedByEmail, archiveByEmailErr := a.repo.IsUserArchivedByEmail(ctx, email)
+		archivedByEmail, archiveByEmailErr := a.repo.IsUserArchivedByEmail(ctx, identity.Email)
 		if archiveByEmailErr != nil {
 			log.ErrorContext(ctx, "resolve_user: error checking archived status by email", "error", archiveByEmailErr)
 		}
@@ -311,10 +322,18 @@ func (a *WorkOSAuthenticator) resolveUser(
 	}
 
 	// Step 6: truly new user — auto-create.
+	if identity.DisplayName == "" && loadIdentity != nil {
+		loadedIdentity, loadErr := loadIdentity(ctx)
+		identity = loadedIdentity
+		if loadErr != nil {
+			log.WarnContext(ctx, "resolve_user: failed to fetch profile from WorkOS userinfo", "error", loadErr)
+		}
+	}
 	log.InfoContext(ctx, "resolve_user: creating new user")
 	user, err = a.repo.CreateUser(ctx, repository.CreateUserInput{
 		WorkOSUserID: workosUserID,
-		Email:        email,
+		Email:        identity.Email,
+		DisplayName:  identity.DisplayName,
 	})
 	if err != nil {
 		if !errors.Is(err, repository.ErrUserAlreadyExists) {
@@ -324,8 +343,8 @@ func (a *WorkOSAuthenticator) resolveUser(
 
 		// Constraint conflict — likely a race condition. Try email-based recovery.
 		log.WarnContext(ctx, "resolve_user: create hit unique constraint, recovering", "create_error", err)
-		if email != "" {
-			existing, lookupErr := a.repo.GetUserByEmail(ctx, email)
+		if identity.Email != "" {
+			existing, lookupErr := a.repo.GetUserByEmail(ctx, identity.Email)
 			if lookupErr == nil {
 				relinked, relinkErr := a.repo.RelinkWorkOSUser(ctx, existing.ID, workosUserID)
 				if relinkErr != nil {
@@ -334,7 +353,7 @@ func (a *WorkOSAuthenticator) resolveUser(
 					return repository.User{}, fmt.Errorf("re-link workos user after conflict: %w", relinkErr)
 				}
 				log.InfoContext(ctx, "resolve_user: re-linked after conflict", "user_id", relinked.ID)
-				return relinked, nil
+				return a.backfillMissingUserProfile(ctx, log, relinked, identity), nil
 			}
 		}
 
@@ -355,37 +374,122 @@ func (a *WorkOSAuthenticator) resolveUser(
 	return user, nil
 }
 
-func (a *WorkOSAuthenticator) lookupEmailFromUserInfo(ctx context.Context, issuer, token string) (string, error) {
+func (a *WorkOSAuthenticator) backfillMissingUserProfile(ctx context.Context, log *slog.Logger, user repository.User, identity workOSIdentity) repository.User {
+	input := repository.BackfillUserProfileInput{UserID: user.ID}
+	if user.Email == "" {
+		input.Email = identity.Email
+	}
+	if user.DisplayName == "" {
+		input.DisplayName = identity.DisplayName
+	}
+	if input.Email == "" && input.DisplayName == "" {
+		return user
+	}
+
+	backfilled, err := a.repo.BackfillUserProfile(ctx, input)
+	if err != nil {
+		log.ErrorContext(ctx, "resolve_user: failed to backfill missing profile", "user_id", user.ID, "error", err)
+		if user.Email == "" && input.Email != "" {
+			user.Email = input.Email
+		}
+		if user.DisplayName == "" && input.DisplayName != "" {
+			user.DisplayName = input.DisplayName
+		}
+		return user
+	}
+
+	log.InfoContext(ctx, "resolve_user: backfilled missing profile from trusted identity", "user_id", user.ID)
+	return backfilled
+}
+
+func needsIdentityForUser(user repository.User, identity workOSIdentity) bool {
+	return (user.Email == "" && identity.Email == "") || (user.DisplayName == "" && identity.DisplayName == "")
+}
+
+func (a *WorkOSAuthenticator) lookupIdentityFromUserInfo(ctx context.Context, issuer, token string) (workOSIdentity, error) {
 	userInfoURL, err := workOSUserInfoURL(issuer)
 	if err != nil {
-		return "", err
+		return workOSIdentity{}, err
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, userInfoURL, http.NoBody)
 	if err != nil {
-		return "", fmt.Errorf("create userinfo request: %w", err)
+		return workOSIdentity{}, fmt.Errorf("create userinfo request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := a.httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("request userinfo: %w", err)
+		return workOSIdentity{}, fmt.Errorf("request userinfo: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return "", fmt.Errorf("userinfo returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return workOSIdentity{}, fmt.Errorf("userinfo returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
 	var payload struct {
-		Email string `json:"email"`
+		Email       string `json:"email"`
+		DisplayName string `json:"display_name"`
+		Name        string `json:"name"`
+		FirstName   string `json:"first_name"`
+		LastName    string `json:"last_name"`
+		GivenName   string `json:"given_name"`
+		FamilyName  string `json:"family_name"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return "", fmt.Errorf("decode userinfo response: %w", err)
+		return workOSIdentity{}, fmt.Errorf("decode userinfo response: %w", err)
 	}
-	return strings.TrimSpace(payload.Email), nil
+	firstName := firstNonEmpty(payload.FirstName, payload.GivenName)
+	lastName := firstNonEmpty(payload.LastName, payload.FamilyName)
+	return workOSIdentity{
+		Email:       strings.TrimSpace(payload.Email),
+		DisplayName: displayNameFromParts(payload.DisplayName, payload.Name, firstName, lastName),
+	}, nil
+}
+
+func identityFromToken(tok jwt.Token) workOSIdentity {
+	return workOSIdentity{
+		Email: strings.TrimSpace(tokenStringClaim(tok, "email")),
+		DisplayName: displayNameFromParts(
+			tokenStringClaim(tok, "display_name"),
+			tokenStringClaim(tok, "name"),
+			firstNonEmpty(tokenStringClaim(tok, "first_name"), tokenStringClaim(tok, "given_name")),
+			firstNonEmpty(tokenStringClaim(tok, "last_name"), tokenStringClaim(tok, "family_name")),
+		),
+	}
+}
+
+func tokenStringClaim(tok jwt.Token, key string) string {
+	value, ok := tok.Get(key)
+	if !ok {
+		return ""
+	}
+	str, _ := value.(string)
+	return strings.TrimSpace(str)
+}
+
+func displayNameFromParts(displayName, name, firstName, lastName string) string {
+	if displayName = strings.TrimSpace(displayName); displayName != "" {
+		return displayName
+	}
+	if name = strings.TrimSpace(name); name != "" {
+		return name
+	}
+	firstName = strings.TrimSpace(firstName)
+	lastName = strings.TrimSpace(lastName)
+	return strings.TrimSpace(strings.Join([]string{firstName, lastName}, " "))
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func workOSUserInfoURL(issuer string) (string, error) {

--- a/backend/internal/api/auth_workos_test.go
+++ b/backend/internal/api/auth_workos_test.go
@@ -95,19 +95,20 @@ func testUserInfoServer(t *testing.T, handler http.HandlerFunc) *httptest.Server
 // --- stub UserRepository for tests ---
 
 type stubUserRepo struct {
-	user              repository.User
-	memberships       []repository.WorkspaceMembershipRow
-	orgMemberships    []repository.OrgMembershipRow
-	createdUser       repository.User
-	backfilledUser    repository.User
-	err               error
-	membershipErr     error
-	orgMembershipErr  error
-	createUserErr     error
-	backfillEmailErr  error
-	backfillEmail     *string
-	backfillUserID    *uuid.UUID
-	backfillCallCount *int
+	user                repository.User
+	memberships         []repository.WorkspaceMembershipRow
+	orgMemberships      []repository.OrgMembershipRow
+	createdUser         repository.User
+	backfilledUser      repository.User
+	err                 error
+	membershipErr       error
+	orgMembershipErr    error
+	createUserErr       error
+	backfillEmailErr    error
+	backfillEmail       *string
+	backfillDisplayName *string
+	backfillUserID      *uuid.UUID
+	backfillCallCount   *int
 }
 
 func (s stubUserRepo) GetUserByWorkOSID(_ context.Context, _ string) (repository.User, error) {
@@ -146,12 +147,15 @@ func (s stubUserRepo) CreateUser(_ context.Context, input repository.CreateUserI
 	}, nil
 }
 
-func (s stubUserRepo) BackfillUserEmail(_ context.Context, input repository.BackfillUserEmailInput) (repository.User, error) {
+func (s stubUserRepo) BackfillUserProfile(_ context.Context, input repository.BackfillUserProfileInput) (repository.User, error) {
 	if s.backfillCallCount != nil {
 		*s.backfillCallCount = *s.backfillCallCount + 1
 	}
 	if s.backfillEmail != nil {
 		*s.backfillEmail = input.Email
+	}
+	if s.backfillDisplayName != nil {
+		*s.backfillDisplayName = input.DisplayName
 	}
 	if s.backfillUserID != nil {
 		*s.backfillUserID = input.UserID
@@ -165,6 +169,9 @@ func (s stubUserRepo) BackfillUserEmail(_ context.Context, input repository.Back
 	user := s.user
 	if user.Email == "" {
 		user.Email = input.Email
+	}
+	if user.DisplayName == "" {
+		user.DisplayName = input.DisplayName
 	}
 	return user, nil
 }
@@ -687,6 +694,108 @@ func TestWorkOSAuthenticator_FallsBackToUserInfoEmailWhenClaimMissing(t *testing
 	}
 	if userInfoCalls != 1 {
 		t.Fatalf("userinfo calls = %d, want 1", userInfoCalls)
+	}
+}
+
+func TestWorkOSAuthenticator_BackfillsMissingIdentityFromUserInfo(t *testing.T) {
+	privKey, jwksServer := testJWKS(t)
+
+	userInfoServer := testUserInfoServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want %s", r.Method, http.MethodPost)
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"sub":          "user_01ABC",
+			"email":        "userinfo@example.com",
+			"display_name": "Dev User",
+		})
+	})
+
+	userID := uuid.New()
+	var backfillCalls int
+	repo := stubUserRepo{
+		user: repository.User{
+			ID:           userID,
+			WorkOSUserID: "user_01ABC",
+			Email:        "",
+			DisplayName:  "",
+		},
+		backfillCallCount: &backfillCalls,
+	}
+
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", userInfoServer.URL, repo, authTestLogger)
+	if err != nil {
+		t.Fatalf("create authenticator: %v", err)
+	}
+
+	token := signTestJWT(t, privKey, map[string]interface{}{
+		"sub": "user_01ABC",
+		"iss": userInfoServer.URL,
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(5 * time.Minute).Unix(),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/session", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	caller, err := auth.Authenticate(req)
+	if err != nil {
+		t.Fatalf("authenticate: %v", err)
+	}
+	if caller.Email != "userinfo@example.com" {
+		t.Fatalf("Email = %q, want %q", caller.Email, "userinfo@example.com")
+	}
+	if caller.DisplayName != "Dev User" {
+		t.Fatalf("DisplayName = %q, want %q", caller.DisplayName, "Dev User")
+	}
+	if backfillCalls != 1 {
+		t.Fatalf("backfill calls = %d, want 1", backfillCalls)
+	}
+}
+
+func TestWorkOSAuthenticator_FirstLoginStoresDisplayNameFromUserInfo(t *testing.T) {
+	privKey, jwksServer := testJWKS(t)
+
+	userInfoServer := testUserInfoServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want %s", r.Method, http.MethodPost)
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"sub":        "user_01NEW",
+			"email":      "new@example.com",
+			"first_name": "Dev",
+			"last_name":  "User",
+		})
+	})
+
+	repo := stubUserRepo{
+		err: repository.ErrUserNotFound,
+	}
+
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", userInfoServer.URL, repo, authTestLogger)
+	if err != nil {
+		t.Fatalf("create authenticator: %v", err)
+	}
+
+	token := signTestJWT(t, privKey, map[string]interface{}{
+		"sub": "user_01NEW",
+		"iss": userInfoServer.URL,
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(5 * time.Minute).Unix(),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/session", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	caller, err := auth.Authenticate(req)
+	if err != nil {
+		t.Fatalf("authenticate: %v", err)
+	}
+	if caller.Email != "new@example.com" {
+		t.Fatalf("Email = %q, want %q", caller.Email, "new@example.com")
+	}
+	if caller.DisplayName != "Dev User" {
+		t.Fatalf("DisplayName = %q, want %q", caller.DisplayName, "Dev User")
 	}
 }
 

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -2485,6 +2485,12 @@ type BackfillUserEmailInput struct {
 	Email  string
 }
 
+type BackfillUserProfileInput struct {
+	UserID      uuid.UUID
+	Email       string
+	DisplayName string
+}
+
 type UserMeOrgRow struct {
 	ID   uuid.UUID
 	Name string
@@ -2718,7 +2724,15 @@ func (r *Repository) CreateUser(ctx context.Context, input CreateUserInput) (Use
 }
 
 func (r *Repository) BackfillUserEmail(ctx context.Context, input BackfillUserEmailInput) (User, error) {
+	return r.BackfillUserProfile(ctx, BackfillUserProfileInput{
+		UserID: input.UserID,
+		Email:  input.Email,
+	})
+}
+
+func (r *Repository) BackfillUserProfile(ctx context.Context, input BackfillUserProfileInput) (User, error) {
 	email := strings.TrimSpace(input.Email)
+	displayName := strings.TrimSpace(input.DisplayName)
 
 	var user User
 	err := r.db.QueryRow(ctx, `
@@ -2728,18 +2742,23 @@ func (r *Repository) BackfillUserEmail(ctx context.Context, input BackfillUserEm
 				WHEN COALESCE(email, '') = '' AND $2 <> '' THEN $2
 				ELSE email
 			END,
+			display_name = CASE
+				WHEN COALESCE(display_name, '') = '' AND $3 <> '' THEN $3
+				ELSE display_name
+			END,
 			updated_at = CASE
-				WHEN COALESCE(email, '') = '' AND $2 <> '' THEN now()
+				WHEN (COALESCE(email, '') = '' AND $2 <> '')
+					OR (COALESCE(display_name, '') = '' AND $3 <> '') THEN now()
 				ELSE updated_at
 			END
 		WHERE id = $1 AND archived_at IS NULL
 		RETURNING id, workos_user_id, COALESCE(email, ''), COALESCE(display_name, '')
-	`, input.UserID, email).Scan(&user.ID, &user.WorkOSUserID, &user.Email, &user.DisplayName)
+	`, input.UserID, email, displayName).Scan(&user.ID, &user.WorkOSUserID, &user.Email, &user.DisplayName)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return User{}, ErrUserNotFound
 		}
-		return User{}, fmt.Errorf("backfill user email: %w", err)
+		return User{}, fmt.Errorf("backfill user profile: %w", err)
 	}
 	return user, nil
 }

--- a/backend/internal/repository/repository_integration_test.go
+++ b/backend/internal/repository/repository_integration_test.go
@@ -579,6 +579,47 @@ func TestRepositoryBackfillUserEmailOnlyFillsMissingEmail(t *testing.T) {
 	}
 }
 
+func TestRepositoryBackfillUserProfileOnlyFillsMissingFields(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	if _, err := db.Exec(ctx, `UPDATE users SET email = '', display_name = '' WHERE id = $1`, fixture.userID); err != nil {
+		t.Fatalf("clear user profile returned error: %v", err)
+	}
+
+	backfilled, err := repo.BackfillUserProfile(ctx, repository.BackfillUserProfileInput{
+		UserID:      fixture.userID,
+		Email:       "restored@example.com",
+		DisplayName: "Restored User",
+	})
+	if err != nil {
+		t.Fatalf("BackfillUserProfile returned error: %v", err)
+	}
+	if backfilled.Email != "restored@example.com" {
+		t.Fatalf("email = %q, want %q", backfilled.Email, "restored@example.com")
+	}
+	if backfilled.DisplayName != "Restored User" {
+		t.Fatalf("display_name = %q, want %q", backfilled.DisplayName, "Restored User")
+	}
+
+	preserved, err := repo.BackfillUserProfile(ctx, repository.BackfillUserProfileInput{
+		UserID:      fixture.userID,
+		Email:       "new@example.com",
+		DisplayName: "New User",
+	})
+	if err != nil {
+		t.Fatalf("BackfillUserProfile second call returned error: %v", err)
+	}
+	if preserved.Email != "restored@example.com" {
+		t.Fatalf("email after second call = %q, want %q", preserved.Email, "restored@example.com")
+	}
+	if preserved.DisplayName != "Restored User" {
+		t.Fatalf("display_name after second call = %q, want %q", preserved.DisplayName, "Restored User")
+	}
+}
+
 func TestRepositoryPublishChallengePackBundle(t *testing.T) {
 	ctx := context.Background()
 	db := openTestDB(t)

--- a/testing/issue-423-auth-login-identity-label.md
+++ b/testing/issue-423-auth-login-identity-label.md
@@ -1,0 +1,41 @@
+# Issue 423 Contract: CLI Auth Login Human Identity Label
+
+## Scope
+
+Fix issue #423 so normal WorkOS-backed CLI sessions expose a human-readable identity label to the CLI. The preferred label source is `display_name`, then `email`, with `user_id` remaining only a last-resort fallback.
+
+## Functional Expectations
+
+- WorkOS authentication should populate `Caller.Email` from a verified WorkOS JWT email claim or `/oauth2/userinfo` when the stored user row is missing email.
+- WorkOS authentication should populate `Caller.DisplayName` from verified WorkOS identity/profile data when available.
+- New auto-created WorkOS users should store any available display name and email.
+- Existing active WorkOS users with missing email and/or display name should be backfilled opportunistically from verified WorkOS identity/profile data.
+- Stub-user link and existing-user relink flows should preserve existing profile fields and should backfill missing email/display name when verified identity/profile data is available.
+- `/v1/auth/session` should continue to return `user_id` for automation and should include `email`/`display_name` when known.
+- CLI fallback order remains display name -> email -> user ID.
+
+## Tests To Add Or Run
+
+- Add backend auth unit tests covering:
+  - WorkOS userinfo containing email and name for an existing user missing both fields.
+  - New WorkOS user creation stores email and display name from userinfo/profile data.
+  - Existing user with display name already set keeps that display name.
+  - CLI-token session path returns the stored display name/email after backfill.
+- Run targeted backend auth tests:
+  - `go test ./internal/api -run 'TestWorkOS|TestCLIToken|TestSession'`
+- Run targeted CLI auth tests:
+  - `cd cli && go test ./cmd ./internal/auth -run 'Auth|Login|Status'`
+- Run broader validation if targeted tests pass:
+  - `go test ./internal/api ./internal/repository`
+  - `cd cli && go test -short ./...`
+
+## Manual Verification
+
+- With a logged-in CLI token, `agentclash auth status --json` should include at least one of `email` or `display_name` for a normal WorkOS account once backend data has been backfilled.
+- `agentclash auth login --device` should print a human-readable account label when the backend session provides one.
+
+## Out Of Scope
+
+- Changing CLI auth fallback behavior beyond preserving display name -> email -> user ID.
+- Reworking WorkOS token issuance or CLI device-login UX.
+- Data migration for historical users beyond opportunistic backfill during authenticated requests.


### PR DESCRIPTION
## Summary

Fixes #423.

This fixes the `auth login` success label showing the internal user UUID for normal WorkOS-backed CLI sessions. The CLI already prefers `display_name`, then `email`, then `user_id`; the bug was that WorkOS auth was not reliably populating `email` or `display_name` into the session identity.

## What changed

- Added WorkOS identity extraction for `email`, `display_name`, `name`, and first/last name variants from JWT claims or `/oauth2/userinfo`.
- Added repository profile backfill so missing `email` and `display_name` can be filled without overwriting existing values.
- Passed display name/email into new WorkOS user creation and opportunistic backfill for existing/link/relink flows.
- Added a review-checkpoint contract under `testing/` for issue #423.

## Validation

- `cd backend && go test ./internal/api -run 'TestWorkOSAuthenticator_(BackfillsMissingEmailForExistingUser|FallsBackToUserInfoEmailWhenClaimMissing|BackfillsMissingIdentityFromUserInfo|FirstLoginStoresDisplayNameFromUserInfo|BackfillFailureDoesNotBlockExistingUserAuth|UserInfoFailureDoesNotBlockExistingUserAuth)'`\n- `cd backend && go test ./internal/api ./internal/repository`\n- `cd cli && go test ./cmd ./internal/auth`