### PR TITLE
[codex] Fix same-run agent scorecard comparison

### DIFF
--- a/backend/db/migrations/00030_same_run_agent_comparisons.sql
+++ b/backend/db/migrations/00030_same_run_agent_comparisons.sql
@@ -26,7 +26,30 @@ CHECK (
     )
 );
 
+ALTER TABLE run_comparisons
+DROP CONSTRAINT IF EXISTS run_comparisons_baseline_run_id_candidate_run_id_key;
+
+CREATE UNIQUE INDEX run_comparisons_cross_run_unique
+ON run_comparisons (baseline_run_id, candidate_run_id)
+WHERE baseline_run_id <> candidate_run_id;
+
+CREATE UNIQUE INDEX run_comparisons_same_run_agent_unique
+ON run_comparisons (
+    baseline_run_id,
+    candidate_run_id,
+    baseline_run_agent_id,
+    candidate_run_agent_id
+)
+WHERE baseline_run_id = candidate_run_id;
+
 -- +goose Down
+DROP INDEX IF EXISTS run_comparisons_same_run_agent_unique;
+DROP INDEX IF EXISTS run_comparisons_cross_run_unique;
+
+ALTER TABLE run_comparisons
+ADD CONSTRAINT run_comparisons_baseline_run_id_candidate_run_id_key
+UNIQUE (baseline_run_id, candidate_run_id);
+
 ALTER TABLE run_comparisons
 DROP CONSTRAINT IF EXISTS run_comparisons_distinct_runs_or_agents_check;
 

--- a/backend/db/migrations/00030_same_run_agent_comparisons.sql
+++ b/backend/db/migrations/00030_same_run_agent_comparisons.sql
@@ -1,0 +1,35 @@
+-- +goose Up
+DO $$
+DECLARE
+    constraint_name text;
+BEGIN
+    SELECT conname INTO constraint_name
+    FROM pg_constraint
+    WHERE conrelid = 'run_comparisons'::regclass
+      AND contype = 'c'
+      AND pg_get_constraintdef(oid) = 'CHECK ((baseline_run_id <> candidate_run_id))'
+    LIMIT 1;
+
+    IF constraint_name IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE run_comparisons DROP CONSTRAINT %I', constraint_name);
+    END IF;
+END $$;
+
+ALTER TABLE run_comparisons
+ADD CONSTRAINT run_comparisons_distinct_runs_or_agents_check
+CHECK (
+    baseline_run_id <> candidate_run_id
+    OR (
+        baseline_run_agent_id IS NOT NULL
+        AND candidate_run_agent_id IS NOT NULL
+        AND baseline_run_agent_id <> candidate_run_agent_id
+    )
+);
+
+-- +goose Down
+ALTER TABLE run_comparisons
+DROP CONSTRAINT IF EXISTS run_comparisons_distinct_runs_or_agents_check;
+
+ALTER TABLE run_comparisons
+ADD CONSTRAINT run_comparisons_check
+CHECK (baseline_run_id <> candidate_run_id);

--- a/backend/db/queries/run_comparisons.sql
+++ b/backend/db/queries/run_comparisons.sql
@@ -16,7 +16,7 @@ WHERE baseline_run_id = @baseline_run_id
   AND candidate_run_id = @candidate_run_id
 LIMIT 1;
 
--- name: UpsertRunComparison :one
+-- name: UpsertCrossRunComparison :one
 INSERT INTO run_comparisons (
     baseline_run_id,
     candidate_run_id,
@@ -38,9 +38,56 @@ VALUES (
     @summary
 )
 ON CONFLICT (baseline_run_id, candidate_run_id)
+WHERE baseline_run_id <> candidate_run_id
 DO UPDATE SET
     baseline_run_agent_id = EXCLUDED.baseline_run_agent_id,
     candidate_run_agent_id = EXCLUDED.candidate_run_agent_id,
+    status = EXCLUDED.status,
+    reason_code = EXCLUDED.reason_code,
+    source_fingerprint = EXCLUDED.source_fingerprint,
+    summary = EXCLUDED.summary
+RETURNING
+    id,
+    baseline_run_id,
+    candidate_run_id,
+    baseline_run_agent_id,
+    candidate_run_agent_id,
+    status,
+    reason_code,
+    source_fingerprint,
+    summary,
+    created_at,
+    updated_at;
+
+-- name: UpsertSameRunAgentComparison :one
+INSERT INTO run_comparisons (
+    baseline_run_id,
+    candidate_run_id,
+    baseline_run_agent_id,
+    candidate_run_agent_id,
+    status,
+    reason_code,
+    source_fingerprint,
+    summary
+)
+VALUES (
+    @baseline_run_id,
+    @candidate_run_id,
+    sqlc.narg('baseline_run_agent_id'),
+    sqlc.narg('candidate_run_agent_id'),
+    @status,
+    sqlc.narg('reason_code'),
+    @source_fingerprint,
+    @summary
+)
+ON CONFLICT (
+    baseline_run_id,
+    candidate_run_id,
+    baseline_run_agent_id,
+    candidate_run_agent_id
+)
+WHERE baseline_run_id = candidate_run_id
+DO UPDATE SET
     status = EXCLUDED.status,
     reason_code = EXCLUDED.reason_code,
     source_fingerprint = EXCLUDED.source_fingerprint,

--- a/backend/internal/api/compare_reads.go
+++ b/backend/internal/api/compare_reads.go
@@ -256,20 +256,8 @@ func invalidCompareRequest(message string) error {
 }
 
 func isCompareValidationError(err error) bool {
-	if errors.Is(err, ErrInvalidCompareRequest) {
-		return true
-	}
-	switch err.Error() {
-	case "baseline_run_id is required",
-		"candidate_run_id is required",
-		"baseline_run_id and candidate_run_id must differ",
-		"baseline and candidate run ids must differ",
-		"same-run comparison requires baseline and candidate run agent ids",
-		"baseline and candidate run agent ids must differ for same-run comparison":
-		return true
-	default:
-		return false
-	}
+	return errors.Is(err, ErrInvalidCompareRequest) ||
+		errors.Is(err, repository.ErrInvalidRunComparisonParams)
 }
 
 func buildGetRunComparisonResponse(result GetRunComparisonResult, r *http.Request) getRunComparisonResponse {

--- a/backend/internal/api/compare_reads.go
+++ b/backend/internal/api/compare_reads.go
@@ -40,6 +40,8 @@ const (
 	ComparisonReadStateNotComparable   ComparisonReadState = "not_comparable"
 )
 
+var ErrInvalidCompareRequest = errors.New("invalid compare request")
+
 type GetRunComparisonResult struct {
 	BaselineRun       domain.Run
 	CandidateRun      domain.Run
@@ -64,13 +66,18 @@ func NewCompareReadManager(authorizer WorkspaceAuthorizer, repo CompareReadRepos
 
 func (m *CompareReadManager) GetRunComparison(ctx context.Context, caller Caller, input GetRunComparisonInput) (GetRunComparisonResult, error) {
 	if input.BaselineRunID == uuid.Nil {
-		return GetRunComparisonResult{}, errors.New("baseline_run_id is required")
+		return GetRunComparisonResult{}, invalidCompareRequest("baseline_run_id is required")
 	}
 	if input.CandidateRunID == uuid.Nil {
-		return GetRunComparisonResult{}, errors.New("candidate_run_id is required")
+		return GetRunComparisonResult{}, invalidCompareRequest("candidate_run_id is required")
 	}
 	if input.BaselineRunID == input.CandidateRunID {
-		return GetRunComparisonResult{}, errors.New("baseline_run_id and candidate_run_id must differ")
+		if input.BaselineRunAgentID == nil || input.CandidateRunAgentID == nil {
+			return GetRunComparisonResult{}, invalidCompareRequest("same-run comparison requires baseline_run_agent_id and candidate_run_agent_id")
+		}
+		if *input.BaselineRunAgentID == *input.CandidateRunAgentID {
+			return GetRunComparisonResult{}, invalidCompareRequest("baseline_run_agent_id and candidate_run_agent_id must differ for same-run comparison")
+		}
 	}
 
 	baselineRun, err := m.repo.GetRunByID(ctx, input.BaselineRunID)
@@ -221,6 +228,8 @@ func getRunComparisonHandler(logger *slog.Logger, service CompareReadService) ht
 		result, err := service.GetRunComparison(r.Context(), caller, input)
 		if err != nil {
 			switch {
+			case isCompareValidationError(err):
+				writeError(w, http.StatusBadRequest, "invalid_compare_request", err.Error())
 			case errors.Is(err, repository.ErrRunNotFound):
 				writeError(w, http.StatusNotFound, "run_not_found", "run not found")
 			case errors.Is(err, ErrForbidden):
@@ -239,6 +248,27 @@ func getRunComparisonHandler(logger *slog.Logger, service CompareReadService) ht
 		}
 
 		writeJSON(w, http.StatusOK, buildGetRunComparisonResponse(result, r))
+	}
+}
+
+func invalidCompareRequest(message string) error {
+	return fmt.Errorf("%w: %s", ErrInvalidCompareRequest, message)
+}
+
+func isCompareValidationError(err error) bool {
+	if errors.Is(err, ErrInvalidCompareRequest) {
+		return true
+	}
+	switch err.Error() {
+	case "baseline_run_id is required",
+		"candidate_run_id is required",
+		"baseline_run_id and candidate_run_id must differ",
+		"baseline and candidate run ids must differ",
+		"same-run comparison requires baseline and candidate run agent ids",
+		"baseline and candidate run agent ids must differ for same-run comparison":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/backend/internal/api/compare_reads_test.go
+++ b/backend/internal/api/compare_reads_test.go
@@ -67,6 +67,115 @@ func TestCompareReadManagerReturnsPartialEvidenceState(t *testing.T) {
 	}
 }
 
+func TestCompareReadManagerAllowsSameRunDifferentExplicitAgents(t *testing.T) {
+	workspaceID := uuid.New()
+	runID := uuid.New()
+	baselineRunAgentID := uuid.New()
+	candidateRunAgentID := uuid.New()
+	repo := &fakeCompareReadRepository{
+		runs: map[uuid.UUID]domain.Run{
+			runID: {ID: runID, WorkspaceID: workspaceID},
+		},
+		comparison: repository.RunComparison{
+			ID:                  uuid.New(),
+			BaselineRunID:       runID,
+			CandidateRunID:      runID,
+			BaselineRunAgentID:  &baselineRunAgentID,
+			CandidateRunAgentID: &candidateRunAgentID,
+			Status:              repository.RunComparisonStatusComparable,
+			Summary: []byte(`{
+				"schema_version":"2026-03-17",
+				"status":"comparable",
+				"baseline_refs":{"run_id":"` + runID.String() + `","run_agent_id":"` + baselineRunAgentID.String() + `"},
+				"candidate_refs":{"run_id":"` + runID.String() + `","run_agent_id":"` + candidateRunAgentID.String() + `"},
+				"failure_divergence":{"candidate_failed_baseline_succeeded":false,"candidate_succeeded_baseline_failed":false,"both_failed_differently":false},
+				"replay_summary_divergence":{"state":"available"},
+				"evidence_quality":{}
+			}`),
+			UpdatedAt: time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC),
+		},
+	}
+	manager := NewCompareReadManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	_, err := manager.GetRunComparison(context.Background(), Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}, GetRunComparisonInput{
+		BaselineRunID:       runID,
+		CandidateRunID:      runID,
+		BaselineRunAgentID:  &baselineRunAgentID,
+		CandidateRunAgentID: &candidateRunAgentID,
+	})
+	if err != nil {
+		t.Fatalf("GetRunComparison returned error: %v", err)
+	}
+	if repo.buildCalls != 1 {
+		t.Fatalf("BuildRunComparison calls = %d, want 1", repo.buildCalls)
+	}
+	if repo.buildParams.BaselineRunID != runID || repo.buildParams.CandidateRunID != runID {
+		t.Fatalf("BuildRunComparison run ids = (%s, %s), want same run %s", repo.buildParams.BaselineRunID, repo.buildParams.CandidateRunID, runID)
+	}
+}
+
+func TestCompareReadManagerRejectsSameRunSameAgent(t *testing.T) {
+	workspaceID := uuid.New()
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	repo := &fakeCompareReadRepository{
+		runs: map[uuid.UUID]domain.Run{
+			runID: {ID: runID, WorkspaceID: workspaceID},
+		},
+	}
+	manager := NewCompareReadManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	_, err := manager.GetRunComparison(context.Background(), Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}, GetRunComparisonInput{
+		BaselineRunID:       runID,
+		CandidateRunID:      runID,
+		BaselineRunAgentID:  &runAgentID,
+		CandidateRunAgentID: &runAgentID,
+	})
+	if err == nil {
+		t.Fatal("GetRunComparison returned nil error, want validation error")
+	}
+	if repo.buildCalls != 0 {
+		t.Fatalf("BuildRunComparison calls = %d, want 0", repo.buildCalls)
+	}
+}
+
+func TestCompareReadManagerRejectsSameRunWithoutExplicitAgents(t *testing.T) {
+	workspaceID := uuid.New()
+	runID := uuid.New()
+	repo := &fakeCompareReadRepository{
+		runs: map[uuid.UUID]domain.Run{
+			runID: {ID: runID, WorkspaceID: workspaceID},
+		},
+	}
+	manager := NewCompareReadManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	_, err := manager.GetRunComparison(context.Background(), Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}, GetRunComparisonInput{
+		BaselineRunID:  runID,
+		CandidateRunID: runID,
+	})
+	if err == nil {
+		t.Fatal("GetRunComparison returned nil error, want validation error")
+	}
+	if repo.buildCalls != 0 {
+		t.Fatalf("BuildRunComparison calls = %d, want 0", repo.buildCalls)
+	}
+}
+
 func TestGetRunComparisonEndpointReturnsJSONPayload(t *testing.T) {
 	workspaceID := uuid.New()
 	baselineRunID := uuid.New()
@@ -139,6 +248,51 @@ func TestGetRunComparisonEndpointReturnsJSONPayload(t *testing.T) {
 	}
 }
 
+func TestGetRunComparisonEndpointMapsValidationErrorsToBadRequest(t *testing.T) {
+	workspaceID := uuid.New()
+	baselineRunID := uuid.New()
+	candidateRunID := uuid.New()
+	req := httptest.NewRequest(http.MethodGet, "/v1/compare?baseline_run_id="+baselineRunID.String()+"&candidate_run_id="+candidateRunID.String(), nil)
+	req.Header.Set(headerUserID, uuid.New().String())
+	req.Header.Set(headerWorkspaceMemberships, workspaceID.String()+":workspace_member")
+	recorder := httptest.NewRecorder()
+
+	newRouter("dev", nil,
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		nil,
+		0,
+		stubRunCreationService{},
+		stubRunReadService{},
+		stubReplayReadService{},
+		stubHostedRunIngestionService{},
+		&fakeCompareReadService{err: errors.New("baseline_run_id and candidate_run_id must differ")},
+		stubAgentDeploymentReadService{},
+		stubChallengePackReadService{},
+		stubAgentBuildService{},
+		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusBadRequest, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "invalid_compare_request") {
+		t.Fatalf("body = %s, want invalid_compare_request", recorder.Body.String())
+	}
+}
+
 func TestCompareViewerEndpointReturnsHTMLShell(t *testing.T) {
 	workspaceID := uuid.New()
 	baselineRunID := uuid.New()
@@ -193,9 +347,11 @@ func TestCompareViewerEndpointReturnsHTMLShell(t *testing.T) {
 }
 
 type fakeCompareReadRepository struct {
-	runs       map[uuid.UUID]domain.Run
-	comparison repository.RunComparison
-	err        error
+	runs        map[uuid.UUID]domain.Run
+	comparison  repository.RunComparison
+	err         error
+	buildCalls  int
+	buildParams repository.BuildRunComparisonParams
 }
 
 func (f *fakeCompareReadRepository) GetRunByID(_ context.Context, id uuid.UUID) (domain.Run, error) {
@@ -206,7 +362,9 @@ func (f *fakeCompareReadRepository) GetRunByID(_ context.Context, id uuid.UUID) 
 	return run, nil
 }
 
-func (f *fakeCompareReadRepository) BuildRunComparison(_ context.Context, _ repository.BuildRunComparisonParams) (repository.RunComparison, error) {
+func (f *fakeCompareReadRepository) BuildRunComparison(_ context.Context, params repository.BuildRunComparisonParams) (repository.RunComparison, error) {
+	f.buildCalls++
+	f.buildParams = params
 	if f.err != nil {
 		return repository.RunComparison{}, f.err
 	}

--- a/backend/internal/api/compare_reads_test.go
+++ b/backend/internal/api/compare_reads_test.go
@@ -267,7 +267,7 @@ func TestGetRunComparisonEndpointMapsValidationErrorsToBadRequest(t *testing.T) 
 		stubRunReadService{},
 		stubReplayReadService{},
 		stubHostedRunIngestionService{},
-		&fakeCompareReadService{err: errors.New("baseline_run_id and candidate_run_id must differ")},
+		&fakeCompareReadService{err: invalidCompareRequest("baseline_run_id and candidate_run_id must differ")},
 		stubAgentDeploymentReadService{},
 		stubChallengePackReadService{},
 		stubAgentBuildService{},

--- a/backend/internal/repository/errors.go
+++ b/backend/internal/repository/errors.go
@@ -18,6 +18,7 @@ var (
 	ErrRunScorecardNotFound            = errors.New("run scorecard not found")
 	ErrPublicShareLinkNotFound         = errors.New("public share link not found")
 	ErrRunComparisonNotFound           = errors.New("run comparison not found")
+	ErrInvalidRunComparisonParams      = errors.New("invalid run comparison params")
 	ErrRegressionSuiteNotFound         = errors.New("regression suite not found")
 	ErrRegressionCaseNotFound          = errors.New("regression case not found")
 	ErrRegressionSuiteNameConflict     = errors.New("regression suite name already exists in workspace")

--- a/backend/internal/repository/repository_integration_test.go
+++ b/backend/internal/repository/repository_integration_test.go
@@ -2934,7 +2934,7 @@ func TestRepositoryBuildRunComparisonExplicitParticipantSelectionWithinSameRun(t
 	fixture := seedFixture(t, ctx, db)
 	repo := repository.New(db)
 
-	run, runAgents := createTestRun(t, ctx, repo, fixture, 2, "same-run")
+	run, runAgents := createTestRun(t, ctx, repo, fixture, 3, "same-run")
 	evaluationSpecID := insertEvaluationSpecRecord(t, ctx, db, fixture.challengePackVersionID, "compare-same-run", 1)
 
 	insertRunAgentScorecardRecord(t, ctx, db, runAgents[0].ID, evaluationSpecID, scorecardFixture{
@@ -2948,6 +2948,12 @@ func TestRepositoryBuildRunComparisonExplicitParticipantSelectionWithinSameRun(t
 		Reliability: float64Ptr(0.84),
 		Latency:     float64Ptr(0.33),
 		Cost:        float64Ptr(0.22),
+	})
+	insertRunAgentScorecardRecord(t, ctx, db, runAgents[2].ID, evaluationSpecID, scorecardFixture{
+		Correctness: float64Ptr(0.66),
+		Reliability: float64Ptr(0.74),
+		Latency:     float64Ptr(0.43),
+		Cost:        float64Ptr(0.32),
 	})
 	insertReplaySummaryRecord(t, ctx, db, runAgents[0].ID, replaySummaryFixture{
 		Status:            "completed",
@@ -2973,8 +2979,21 @@ func TestRepositoryBuildRunComparisonExplicitParticipantSelectionWithinSameRun(t
 		TerminalStatus:    "completed",
 		TerminalEventType: "system.run.completed",
 	})
+	insertReplaySummaryRecord(t, ctx, db, runAgents[2].ID, replaySummaryFixture{
+		Status:            "completed",
+		Headline:          "Second candidate lane",
+		Events:            12,
+		ReplaySteps:       6,
+		ModelCalls:        4,
+		ToolCalls:         1,
+		Outputs:           1,
+		ScoringEvents:     1,
+		TerminalStatus:    "completed",
+		TerminalEventType: "system.run.completed",
+	})
 	insertJudgeResultRecord(t, ctx, db, runAgents[0].ID, evaluationSpecID, fixture.firstChallengeIdentityID, "exact")
 	insertJudgeResultRecord(t, ctx, db, runAgents[1].ID, evaluationSpecID, fixture.firstChallengeIdentityID, "exact")
+	insertJudgeResultRecord(t, ctx, db, runAgents[2].ID, evaluationSpecID, fixture.firstChallengeIdentityID, "exact")
 
 	comparison, err := repo.BuildRunComparison(ctx, repository.BuildRunComparisonParams{
 		BaselineRunID:       run.ID,
@@ -2994,6 +3013,31 @@ func TestRepositoryBuildRunComparisonExplicitParticipantSelectionWithinSameRun(t
 	}
 	if comparison.CandidateRunAgentID == nil || *comparison.CandidateRunAgentID != runAgents[1].ID {
 		t.Fatalf("candidate selected run agent = %v, want %s", comparison.CandidateRunAgentID, runAgents[1].ID)
+	}
+
+	secondComparison, err := repo.BuildRunComparison(ctx, repository.BuildRunComparisonParams{
+		BaselineRunID:       run.ID,
+		CandidateRunID:      run.ID,
+		BaselineRunAgentID:  &runAgents[0].ID,
+		CandidateRunAgentID: &runAgents[2].ID,
+	})
+	if err != nil {
+		t.Fatalf("second BuildRunComparison returned error: %v", err)
+	}
+	if secondComparison.ID == comparison.ID {
+		t.Fatalf("same-run comparisons reused row id %s for different candidate agents", comparison.ID)
+	}
+
+	var storedRows int
+	if err := db.QueryRow(ctx, `
+		SELECT count(*)
+		FROM run_comparisons
+		WHERE baseline_run_id = $1 AND candidate_run_id = $1
+	`, run.ID).Scan(&storedRows); err != nil {
+		t.Fatalf("count same-run comparisons: %v", err)
+	}
+	if storedRows != 2 {
+		t.Fatalf("stored same-run comparisons = %d, want 2 distinct agent-pair rows", storedRows)
 	}
 }
 

--- a/backend/internal/repository/repository_integration_test.go
+++ b/backend/internal/repository/repository_integration_test.go
@@ -2928,6 +2928,75 @@ func TestRepositoryBuildRunComparisonExplicitParticipantSelectionForMultiAgentRu
 	}
 }
 
+func TestRepositoryBuildRunComparisonExplicitParticipantSelectionWithinSameRun(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	run, runAgents := createTestRun(t, ctx, repo, fixture, 2, "same-run")
+	evaluationSpecID := insertEvaluationSpecRecord(t, ctx, db, fixture.challengePackVersionID, "compare-same-run", 1)
+
+	insertRunAgentScorecardRecord(t, ctx, db, runAgents[0].ID, evaluationSpecID, scorecardFixture{
+		Correctness: float64Ptr(0.71),
+		Reliability: float64Ptr(0.88),
+		Latency:     float64Ptr(0.39),
+		Cost:        float64Ptr(0.26),
+	})
+	insertRunAgentScorecardRecord(t, ctx, db, runAgents[1].ID, evaluationSpecID, scorecardFixture{
+		Correctness: float64Ptr(0.76),
+		Reliability: float64Ptr(0.84),
+		Latency:     float64Ptr(0.33),
+		Cost:        float64Ptr(0.22),
+	})
+	insertReplaySummaryRecord(t, ctx, db, runAgents[0].ID, replaySummaryFixture{
+		Status:            "completed",
+		Headline:          "Baseline lane",
+		Events:            9,
+		ReplaySteps:       4,
+		ModelCalls:        2,
+		ToolCalls:         1,
+		Outputs:           1,
+		ScoringEvents:     1,
+		TerminalStatus:    "completed",
+		TerminalEventType: "system.run.completed",
+	})
+	insertReplaySummaryRecord(t, ctx, db, runAgents[1].ID, replaySummaryFixture{
+		Status:            "completed",
+		Headline:          "Candidate lane",
+		Events:            11,
+		ReplaySteps:       5,
+		ModelCalls:        3,
+		ToolCalls:         1,
+		Outputs:           1,
+		ScoringEvents:     1,
+		TerminalStatus:    "completed",
+		TerminalEventType: "system.run.completed",
+	})
+	insertJudgeResultRecord(t, ctx, db, runAgents[0].ID, evaluationSpecID, fixture.firstChallengeIdentityID, "exact")
+	insertJudgeResultRecord(t, ctx, db, runAgents[1].ID, evaluationSpecID, fixture.firstChallengeIdentityID, "exact")
+
+	comparison, err := repo.BuildRunComparison(ctx, repository.BuildRunComparisonParams{
+		BaselineRunID:       run.ID,
+		CandidateRunID:      run.ID,
+		BaselineRunAgentID:  &runAgents[0].ID,
+		CandidateRunAgentID: &runAgents[1].ID,
+	})
+	if err != nil {
+		t.Fatalf("BuildRunComparison returned error: %v", err)
+	}
+
+	if comparison.Status != repository.RunComparisonStatusComparable {
+		t.Fatalf("comparison status = %s, want comparable", comparison.Status)
+	}
+	if comparison.BaselineRunAgentID == nil || *comparison.BaselineRunAgentID != runAgents[0].ID {
+		t.Fatalf("baseline selected run agent = %v, want %s", comparison.BaselineRunAgentID, runAgents[0].ID)
+	}
+	if comparison.CandidateRunAgentID == nil || *comparison.CandidateRunAgentID != runAgents[1].ID {
+		t.Fatalf("candidate selected run agent = %v, want %s", comparison.CandidateRunAgentID, runAgents[1].ID)
+	}
+}
+
 func TestRepositoryBuildRunComparisonEvaluationSpecMismatch(t *testing.T) {
 	ctx := context.Background()
 	db := openTestDB(t)

--- a/backend/internal/repository/run_comparison.go
+++ b/backend/internal/repository/run_comparison.go
@@ -176,6 +176,10 @@ type selectedRunComparisonParticipant struct {
 }
 
 func (r *Repository) GetRunComparisonByRunIDs(ctx context.Context, baselineRunID uuid.UUID, candidateRunID uuid.UUID) (RunComparison, error) {
+	if baselineRunID == candidateRunID {
+		return RunComparison{}, fmt.Errorf("%w: same-run comparison lookup requires run agent ids", ErrInvalidRunComparisonParams)
+	}
+
 	row, err := r.queries.GetRunComparisonByRunIDs(ctx, repositorysqlc.GetRunComparisonByRunIDsParams{
 		BaselineRunID:  baselineRunID,
 		CandidateRunID: candidateRunID,
@@ -298,10 +302,10 @@ func (r *Repository) BuildRunComparison(ctx context.Context, params BuildRunComp
 func validateBuildRunComparisonParams(params BuildRunComparisonParams) error {
 	if params.BaselineRunID == params.CandidateRunID {
 		if params.BaselineRunAgentID == nil || params.CandidateRunAgentID == nil {
-			return fmt.Errorf("same-run comparison requires baseline and candidate run agent ids")
+			return fmt.Errorf("%w: same-run comparison requires baseline and candidate run agent ids", ErrInvalidRunComparisonParams)
 		}
 		if *params.BaselineRunAgentID == *params.CandidateRunAgentID {
-			return fmt.Errorf("baseline and candidate run agent ids must differ for same-run comparison")
+			return fmt.Errorf("%w: baseline and candidate run agent ids must differ for same-run comparison", ErrInvalidRunComparisonParams)
 		}
 	}
 	return nil
@@ -878,7 +882,7 @@ func (r *Repository) upsertRunComparisonRecord(
 	fingerprint string,
 	summary json.RawMessage,
 ) (RunComparison, error) {
-	row, err := r.queries.UpsertRunComparison(ctx, repositorysqlc.UpsertRunComparisonParams{
+	params := repositorysqlc.UpsertCrossRunComparisonParams{
 		BaselineRunID:       baselineRunID,
 		CandidateRunID:      candidateRunID,
 		BaselineRunAgentID:  cloneUUIDPtr(baselineRunAgentID),
@@ -887,7 +891,16 @@ func (r *Repository) upsertRunComparisonRecord(
 		ReasonCode:          cloneStringPtr(reasonCode),
 		SourceFingerprint:   fingerprint,
 		Summary:             cloneJSON(summary),
-	})
+	}
+	var (
+		row repositorysqlc.RunComparison
+		err error
+	)
+	if baselineRunID == candidateRunID {
+		row, err = r.queries.UpsertSameRunAgentComparison(ctx, repositorysqlc.UpsertSameRunAgentComparisonParams(params))
+	} else {
+		row, err = r.queries.UpsertCrossRunComparison(ctx, params)
+	}
 	if err != nil {
 		return RunComparison{}, fmt.Errorf("upsert run comparison: %w", err)
 	}

--- a/backend/internal/repository/run_comparison.go
+++ b/backend/internal/repository/run_comparison.go
@@ -196,8 +196,8 @@ func (r *Repository) GetRunComparisonByRunIDs(ctx context.Context, baselineRunID
 }
 
 func (r *Repository) BuildRunComparison(ctx context.Context, params BuildRunComparisonParams) (RunComparison, error) {
-	if params.BaselineRunID == params.CandidateRunID {
-		return RunComparison{}, fmt.Errorf("baseline and candidate run ids must differ")
+	if err := validateBuildRunComparisonParams(params); err != nil {
+		return RunComparison{}, err
 	}
 
 	baselineRun, err := r.GetRunByID(ctx, params.BaselineRunID)
@@ -293,6 +293,18 @@ func (r *Repository) BuildRunComparison(ctx context.Context, params BuildRunComp
 		fingerprint,
 		summary,
 	)
+}
+
+func validateBuildRunComparisonParams(params BuildRunComparisonParams) error {
+	if params.BaselineRunID == params.CandidateRunID {
+		if params.BaselineRunAgentID == nil || params.CandidateRunAgentID == nil {
+			return fmt.Errorf("same-run comparison requires baseline and candidate run agent ids")
+		}
+		if *params.BaselineRunAgentID == *params.CandidateRunAgentID {
+			return fmt.Errorf("baseline and candidate run agent ids must differ for same-run comparison")
+		}
+	}
+	return nil
 }
 
 func (r *Repository) resolveRunComparisonParticipants(

--- a/backend/internal/repository/run_comparison_test.go
+++ b/backend/internal/repository/run_comparison_test.go
@@ -5,7 +5,52 @@ import (
 	"math"
 	"strings"
 	"testing"
+
+	"github.com/google/uuid"
 )
+
+func TestValidateBuildRunComparisonParamsAllowsSameRunDifferentAgents(t *testing.T) {
+	runID := uuid.New()
+	baselineRunAgentID := uuid.New()
+	candidateRunAgentID := uuid.New()
+
+	err := validateBuildRunComparisonParams(BuildRunComparisonParams{
+		BaselineRunID:       runID,
+		CandidateRunID:      runID,
+		BaselineRunAgentID:  &baselineRunAgentID,
+		CandidateRunAgentID: &candidateRunAgentID,
+	})
+	if err != nil {
+		t.Fatalf("validateBuildRunComparisonParams returned error: %v", err)
+	}
+}
+
+func TestValidateBuildRunComparisonParamsRejectsSameRunSameAgent(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+
+	err := validateBuildRunComparisonParams(BuildRunComparisonParams{
+		BaselineRunID:       runID,
+		CandidateRunID:      runID,
+		BaselineRunAgentID:  &runAgentID,
+		CandidateRunAgentID: &runAgentID,
+	})
+	if err == nil {
+		t.Fatal("validateBuildRunComparisonParams returned nil error, want validation error")
+	}
+}
+
+func TestValidateBuildRunComparisonParamsRejectsSameRunWithoutExplicitAgents(t *testing.T) {
+	runID := uuid.New()
+
+	err := validateBuildRunComparisonParams(BuildRunComparisonParams{
+		BaselineRunID:  runID,
+		CandidateRunID: runID,
+	})
+	if err == nil {
+		t.Fatal("validateBuildRunComparisonParams returned nil error, want validation error")
+	}
+}
 
 // Phase 4: the legacy 4-dim hardcoded comparison map is replaced by a walk
 // over the union of baseline + candidate scorecard dimension keys. A custom

--- a/backend/internal/repository/run_comparison_test.go
+++ b/backend/internal/repository/run_comparison_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"encoding/json"
+	"errors"
 	"math"
 	"strings"
 	"testing"
@@ -49,6 +50,17 @@ func TestValidateBuildRunComparisonParamsRejectsSameRunWithoutExplicitAgents(t *
 	})
 	if err == nil {
 		t.Fatal("validateBuildRunComparisonParams returned nil error, want validation error")
+	}
+}
+
+func TestValidateBuildRunComparisonParamsErrorUsesSentinel(t *testing.T) {
+	runID := uuid.New()
+	err := validateBuildRunComparisonParams(BuildRunComparisonParams{
+		BaselineRunID:  runID,
+		CandidateRunID: runID,
+	})
+	if !errors.Is(err, ErrInvalidRunComparisonParams) {
+		t.Fatalf("error = %v, want ErrInvalidRunComparisonParams", err)
 	}
 }
 

--- a/backend/internal/repository/sqlc/querier.go
+++ b/backend/internal/repository/sqlc/querier.go
@@ -102,6 +102,7 @@ type Querier interface {
 	UpdatePlaygroundTestCase(ctx context.Context, arg UpdatePlaygroundTestCaseParams) (PlaygroundTestCase, error)
 	UpdateRunAgentStatus(ctx context.Context, arg UpdateRunAgentStatusParams) (RunAgent, error)
 	UpdateRunStatus(ctx context.Context, arg UpdateRunStatusParams) (Run, error)
+	UpsertCrossRunComparison(ctx context.Context, arg UpsertCrossRunComparisonParams) (RunComparison, error)
 	UpsertEvalSessionResult(ctx context.Context, arg UpsertEvalSessionResultParams) (EvalSessionResult, error)
 	UpsertJudgeResult(ctx context.Context, arg UpsertJudgeResultParams) (UpsertJudgeResultRow, error)
 	UpsertLLMJudgeResult(ctx context.Context, arg UpsertLLMJudgeResultParams) (LlmJudgeResult, error)
@@ -110,8 +111,8 @@ type Querier interface {
 	UpsertRunAgentReplayIndex(ctx context.Context, arg UpsertRunAgentReplayIndexParams) (RunAgentReplay, error)
 	UpsertRunAgentReplaySummary(ctx context.Context, arg UpsertRunAgentReplaySummaryParams) (RunAgentReplay, error)
 	UpsertRunAgentScorecard(ctx context.Context, arg UpsertRunAgentScorecardParams) (UpsertRunAgentScorecardRow, error)
-	UpsertRunComparison(ctx context.Context, arg UpsertRunComparisonParams) (RunComparison, error)
 	UpsertRunScorecard(ctx context.Context, arg UpsertRunScorecardParams) (RunScorecard, error)
+	UpsertSameRunAgentComparison(ctx context.Context, arg UpsertSameRunAgentComparisonParams) (RunComparison, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/backend/internal/repository/sqlc/run_comparisons.sql.go
+++ b/backend/internal/repository/sqlc/run_comparisons.sql.go
@@ -54,7 +54,7 @@ func (q *Queries) GetRunComparisonByRunIDs(ctx context.Context, arg GetRunCompar
 	return i, err
 }
 
-const upsertRunComparison = `-- name: UpsertRunComparison :one
+const upsertCrossRunComparison = `-- name: UpsertCrossRunComparison :one
 INSERT INTO run_comparisons (
     baseline_run_id,
     candidate_run_id,
@@ -76,6 +76,7 @@ VALUES (
     $8
 )
 ON CONFLICT (baseline_run_id, candidate_run_id)
+WHERE baseline_run_id <> candidate_run_id
 DO UPDATE SET
     baseline_run_agent_id = EXCLUDED.baseline_run_agent_id,
     candidate_run_agent_id = EXCLUDED.candidate_run_agent_id,
@@ -97,7 +98,7 @@ RETURNING
     updated_at
 `
 
-type UpsertRunComparisonParams struct {
+type UpsertCrossRunComparisonParams struct {
 	BaselineRunID       uuid.UUID
 	CandidateRunID      uuid.UUID
 	BaselineRunAgentID  *uuid.UUID
@@ -108,8 +109,94 @@ type UpsertRunComparisonParams struct {
 	Summary             []byte
 }
 
-func (q *Queries) UpsertRunComparison(ctx context.Context, arg UpsertRunComparisonParams) (RunComparison, error) {
-	row := q.db.QueryRow(ctx, upsertRunComparison,
+func (q *Queries) UpsertCrossRunComparison(ctx context.Context, arg UpsertCrossRunComparisonParams) (RunComparison, error) {
+	row := q.db.QueryRow(ctx, upsertCrossRunComparison,
+		arg.BaselineRunID,
+		arg.CandidateRunID,
+		arg.BaselineRunAgentID,
+		arg.CandidateRunAgentID,
+		arg.Status,
+		arg.ReasonCode,
+		arg.SourceFingerprint,
+		arg.Summary,
+	)
+	var i RunComparison
+	err := row.Scan(
+		&i.ID,
+		&i.BaselineRunID,
+		&i.CandidateRunID,
+		&i.BaselineRunAgentID,
+		&i.CandidateRunAgentID,
+		&i.Status,
+		&i.ReasonCode,
+		&i.SourceFingerprint,
+		&i.Summary,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const upsertSameRunAgentComparison = `-- name: UpsertSameRunAgentComparison :one
+INSERT INTO run_comparisons (
+    baseline_run_id,
+    candidate_run_id,
+    baseline_run_agent_id,
+    candidate_run_agent_id,
+    status,
+    reason_code,
+    source_fingerprint,
+    summary
+)
+VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    $6,
+    $7,
+    $8
+)
+ON CONFLICT (
+    baseline_run_id,
+    candidate_run_id,
+    baseline_run_agent_id,
+    candidate_run_agent_id
+)
+WHERE baseline_run_id = candidate_run_id
+DO UPDATE SET
+    status = EXCLUDED.status,
+    reason_code = EXCLUDED.reason_code,
+    source_fingerprint = EXCLUDED.source_fingerprint,
+    summary = EXCLUDED.summary
+RETURNING
+    id,
+    baseline_run_id,
+    candidate_run_id,
+    baseline_run_agent_id,
+    candidate_run_agent_id,
+    status,
+    reason_code,
+    source_fingerprint,
+    summary,
+    created_at,
+    updated_at
+`
+
+type UpsertSameRunAgentComparisonParams struct {
+	BaselineRunID       uuid.UUID
+	CandidateRunID      uuid.UUID
+	BaselineRunAgentID  *uuid.UUID
+	CandidateRunAgentID *uuid.UUID
+	Status              string
+	ReasonCode          *string
+	SourceFingerprint   string
+	Summary             []byte
+}
+
+func (q *Queries) UpsertSameRunAgentComparison(ctx context.Context, arg UpsertSameRunAgentComparisonParams) (RunComparison, error) {
+	row := q.db.QueryRow(ctx, upsertSameRunAgentComparison,
 		arg.BaselineRunID,
 		arg.CandidateRunID,
 		arg.BaselineRunAgentID,

--- a/testing/issue-424-eval-scorecard-same-run-500.md
+++ b/testing/issue-424-eval-scorecard-same-run-500.md
@@ -1,0 +1,41 @@
+# Issue 424 Contract: Same-Run Agent Comparison
+
+## Scope
+
+Fix issue #424 so `eval scorecard` and `compare runs` do not return HTTP 500 when comparing two different agents from the same multi-agent run.
+
+## Functional Expectations
+
+- `GET /v1/compare` should allow equal `baseline_run_id` and `candidate_run_id` when both explicit run-agent IDs are provided and the run-agent IDs differ.
+- Same-run same-agent comparison should be rejected as a client error, not as an internal server error.
+- Same-run comparison without enough explicit agent identity should still be rejected clearly because run-level comparison is ambiguous.
+- The API handler should map validation failures from compare input to HTTP 400 with a machine-readable error code.
+- The CLI should keep calling the compare endpoint for `eval scorecard` and `compare runs`; it should benefit from the backend behavior without a workflow-specific workaround.
+- Cross-run comparison behavior should remain unchanged.
+
+## Tests To Add Or Run
+
+- Add backend API tests for the compare read manager:
+  - same run plus two different run-agent IDs reaches `BuildRunComparison`.
+  - same run plus the same run-agent ID returns a validation/client error before repository comparison.
+  - same run without explicit agent IDs returns a validation/client error before repository comparison.
+- Add or update handler tests so compare validation errors return HTTP 400 instead of HTTP 500.
+- Run targeted backend tests:
+  - `cd backend && go test ./internal/api -run 'TestCompare|TestGetRunComparison'`
+- Run targeted CLI tests:
+  - `cd cli && go test ./cmd -run 'TestEvalScorecard|TestCompareRuns'`
+- Run broader touched-package validation:
+  - `cd backend && go test ./internal/api ./internal/repository`
+  - `cd cli && go test ./cmd`
+
+## Manual Verification
+
+- For a real multi-agent run, this should no longer return HTTP 500:
+  - `agentclash compare runs --baseline <run> --baseline-agent <agent-a> --candidate <same-run> --candidate-agent <agent-b> --json`
+- `agentclash eval scorecard <run> --agent <non-baseline-label> --json` should either return a valid comparison or a non-internal, actionable client error.
+
+## Out Of Scope
+
+- Rebuilding scorecard comparison semantics.
+- Changing the CLI output schema beyond avoiding internal errors.
+- Supporting same-run run-level comparison without explicit agent IDs.


### PR DESCRIPTION
## Summary

Fixes #424.

This fixes the compare path used by `agentclash eval scorecard` when the bookmarked baseline and selected candidate are two different agents from the same multi-agent run. That workflow should compare the two run agents, not fail before explicit agent IDs are considered.

## What changed

- Allows same `baseline_run_id` and `candidate_run_id` when explicit baseline/candidate run-agent IDs are present and different.
- Rejects same-run same-agent and same-run ambiguous comparisons as `400 invalid_compare_request` instead of `500 internal_error`.
- Adds a DB migration replacing the old `baseline_run_id <> candidate_run_id` check with a distinct-run-or-distinct-agent check.
- Adds review-checkpoint contract coverage under `testing/`.

## Validation

- `cd backend && go test ./internal/api -run 'TestCompare|TestGetRunComparison'`\n- `cd backend && go test ./internal/repository -run 'TestValidateBuildRunComparisonParams|TestRepositoryBuildRunComparison'`\n- `cd cli && go test ./cmd -run 'TestEvalScorecard|TestCompareRuns'`\n- `cd backend && go test ./internal/api ./internal/repository`\n- `cd cli && go test ./cmd`\n\nNote: repository integration tests that require `DATABASE_URL` are skipped locally in this environment; the same-run integration case is included for database-backed CI validation.