### PR TITLE
feat(web): replace comparison matrix with 1v1 fight card

### DIFF
--- a/web/src/app/landing.tsx
+++ b/web/src/app/landing.tsx
@@ -16,6 +16,7 @@ import {
 } from "@lobehub/icons";
 import { LuminousGrid } from "@/components/marketing/luminous-grid";
 import { PricingBlock } from "@/components/marketing/pricing-block";
+import { ComparisonFightCard } from "@/components/marketing/comparison-fight-card";
 import { ExpandedCardsBlock } from "@/components/marketing/expanded-cards-block";
 import { TrackBox } from "@/components/marketing/track-box";
 
@@ -787,36 +788,6 @@ function FeedbackLoop() {
   );
 }
 
-function ComparisonMark({
-  kind,
-  highlight,
-}: {
-  kind: "yes" | "partial" | "no";
-  highlight?: boolean;
-}) {
-  if (kind === "yes") {
-    return (
-      <span
-        aria-label="supported"
-        className={`inline-block size-2 rounded-full ${
-          highlight ? "bg-white shadow-[0_0_12px_rgba(255,255,255,0.55)]" : "bg-white/70"
-        }`}
-      />
-    );
-  }
-  if (kind === "partial") {
-    return (
-      <span
-        aria-label="partial"
-        className="inline-block size-2 rounded-full border border-white/50"
-      />
-    );
-  }
-  return (
-    <span aria-label="not supported" className="block h-px w-3 bg-white/20" />
-  );
-}
-
 function TrackGlyph() {
   return (
     <svg
@@ -1195,64 +1166,6 @@ const LANDING_FEATURES: Array<{
     body:
       "Trigger races from GitHub Actions, a webhook, or the CLI. Fail the build when your agent regresses on the scorecard you care about. Eval moves from a dashboard you visit to a check that blocks bad code.",
     glyph: <CiCdGlyph />,
-  },
-];
-
-type MarkKind = "yes" | "partial" | "no";
-
-const COMPARISON_COLUMNS: Array<{
-  name: string;
-  tag: string;
-  highlight?: boolean;
-}> = [
-  { name: "AgentClash", tag: "agent eval", highlight: true },
-  { name: "Braintrust", tag: "prompt eval" },
-  { name: "LangSmith", tag: "prompt eval" },
-  { name: "Promptfoo", tag: "prompt eval" },
-  { name: "Langfuse", tag: "prompt eval" },
-  { name: "Arize Phoenix", tag: "prompt eval" },
-  { name: "OpenAI Evals", tag: "prompt eval" },
-];
-
-const COMPARISON_ROWS: Array<{
-  label: string;
-  sub: string;
-  cells: readonly MarkKind[];
-}> = [
-  {
-    label: "Multi-turn agent loops",
-    sub: "Think → tool → observe → repeat, for minutes, with a fresh environment. Not one prompt → one response.",
-    cells: ["yes", "partial", "partial", "no", "partial", "partial", "partial"],
-  },
-  {
-    label: "Sandboxed tool execution",
-    sub: "A fresh microVM per agent — real files, real shell, real network, real side effects.",
-    cells: ["yes", "no", "no", "no", "no", "no", "no"],
-  },
-  {
-    label: "Head-to-head concurrent race",
-    sub: "Every model runs the same task at the same time, on the same budget. No staggered runs, no warm caches.",
-    cells: ["yes", "no", "no", "no", "no", "no", "no"],
-  },
-  {
-    label: "Trajectory scoring",
-    sub: "Judges the path, not just the final answer — tool-choice efficiency, recovery from error, scope discipline.",
-    cells: ["yes", "partial", "partial", "no", "partial", "partial", "no"],
-  },
-  {
-    label: "Cross-provider tool-call normalisation",
-    sub: "One schema across OpenAI, Anthropic, Gemini, xAI, Mistral, OpenRouter. Errors classified, retries sane.",
-    cells: ["yes", "partial", "partial", "partial", "partial", "partial", "no"],
-  },
-  {
-    label: "Four-vantage composite verdict",
-    sub: "Deterministic + mathematic + behavioural + LLM, with consensus aggregation and weights you control.",
-    cells: ["yes", "partial", "partial", "partial", "partial", "partial", "partial"],
-  },
-  {
-    label: "Failures auto-promote to regression",
-    sub: "Flunked traces freeze into permanent tests and replay in every future race, by default.",
-    cells: ["yes", "partial", "partial", "partial", "partial", "partial", "no"],
   },
 ];
 
@@ -1815,127 +1728,9 @@ export default function HomePage() {
             </p>
           </div>
 
-          {/* Mobile: stacked per-capability cards */}
-          <div className="md:hidden mt-16 space-y-10">
-            {COMPARISON_ROWS.map((row) => (
-              <div
-                key={`m-${row.label}`}
-                className="border-b border-white/[0.08] pb-8 last:border-b-0"
-              >
-                <p className="text-[16px] font-medium text-white/90 leading-[1.35]">
-                  {row.label}
-                </p>
-                <p className="mt-2 text-[13px] leading-[1.55] text-white/40">
-                  {row.sub}
-                </p>
-                <dl className="mt-5 grid grid-cols-1 gap-0">
-                  {COMPARISON_COLUMNS.map((col, j) => (
-                    <div
-                      key={col.name}
-                      className={`flex items-center justify-between gap-4 border-b border-white/[0.05] py-2.5 last:border-b-0 ${
-                        col.highlight ? "bg-white/[0.025] -mx-3 px-3 rounded" : ""
-                      }`}
-                    >
-                      <div className="flex flex-col">
-                        <dt
-                          className={`text-[13px] ${
-                            col.highlight
-                              ? "text-white/95 font-medium"
-                              : "text-white/60"
-                          }`}
-                        >
-                          {col.name}
-                        </dt>
-                        <span
-                          className={`text-[9px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] ${
-                            col.highlight ? "text-white/45" : "text-white/25"
-                          }`}
-                        >
-                          {col.tag}
-                        </span>
-                      </div>
-                      <dd>
-                        <ComparisonMark
-                          kind={row.cells[j]}
-                          highlight={col.highlight}
-                        />
-                      </dd>
-                    </div>
-                  ))}
-                </dl>
-              </div>
-            ))}
+          <div className="mt-16 sm:mt-20">
+            <ComparisonFightCard />
           </div>
-
-          {/* Desktop: full matrix */}
-          <div className="hidden md:block mt-20 -mx-8 sm:mx-0 overflow-x-auto">
-            <div className="min-w-[1040px] px-8 sm:px-0">
-              {/* Header row */}
-              <div className="grid grid-cols-[1.7fr_repeat(7,minmax(0,1fr))] border-b border-white/[0.12]">
-                <div className="pb-5 pr-4">
-                  <p className="text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.18em] text-white/35">
-                    Capability
-                  </p>
-                </div>
-                {COMPARISON_COLUMNS.map((col) => (
-                  <div
-                    key={col.name}
-                    className="flex flex-col items-center justify-end gap-1 pb-5 px-2"
-                  >
-                    <span
-                      className={`text-center leading-tight ${
-                        col.highlight
-                          ? "text-[13px] font-[family-name:var(--font-display)] tracking-[-0.01em] text-white/95"
-                          : "text-[12px] font-[family-name:var(--font-mono)] uppercase tracking-[0.16em] text-white/45"
-                      }`}
-                    >
-                      {col.name}
-                    </span>
-                    <span
-                      className={`text-[9px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] ${
-                        col.highlight ? "text-white/30" : "text-white/25"
-                      }`}
-                    >
-                      {col.tag}
-                    </span>
-                  </div>
-                ))}
-              </div>
-
-              {/* Rows */}
-              {COMPARISON_ROWS.map((row) => (
-                <div
-                  key={row.label}
-                  className="grid grid-cols-[1.7fr_repeat(7,minmax(0,1fr))] border-b border-white/[0.05] last:border-b-0"
-                >
-                  <div className="py-7 pr-6">
-                    <p className="text-[15px] text-white/85">{row.label}</p>
-                    <p className="mt-1.5 text-[12px] leading-[1.5] text-white/40">
-                      {row.sub}
-                    </p>
-                  </div>
-                  {row.cells.map((mark, j) => (
-                    <div
-                      key={j}
-                      className={`flex items-center justify-center py-7 px-2 ${
-                        j === 0 ? "bg-white/[0.025]" : ""
-                      }`}
-                    >
-                      <ComparisonMark kind={mark} highlight={j === 0} />
-                    </div>
-                  ))}
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <p className="mt-10 text-[12px] font-[family-name:var(--font-mono)] text-white/35">
-            <span className="text-white/60">●</span>&nbsp;&nbsp;supported
-            &nbsp;·&nbsp; <span className="text-white/45">◐</span>
-            &nbsp;&nbsp;partial &nbsp;·&nbsp;
-            <span className="text-white/30">—</span>&nbsp;&nbsp;not a core
-            capability
-          </p>
         </div>
       </section>
 

--- a/web/src/components/marketing/comparison-fight-card.tsx
+++ b/web/src/components/marketing/comparison-fight-card.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+type Stat = {
+  label: string;
+  body: string;
+};
+
+type Opponent = {
+  name: string;
+  tag: string;
+  stats: Stat[];
+  verdict: string;
+};
+
+const AGENTCLASH = {
+  name: "AgentClash",
+  tag: "agent race engine",
+  stats: [
+    {
+      label: "Strengths",
+      body: "Multi-turn loops in real microVMs. Head-to-head races on a shared budget. Trajectory scoring on the path, not just the answer.",
+    },
+    {
+      label: "Best for",
+      body: "Picking the right agent for a real task — and gating CI on the result.",
+    },
+    {
+      label: "The edge",
+      body: "Same challenge, same tools, same clock. Failures auto-promote to regressions.",
+    },
+  ],
+  verdict: "We race agents. Live, and on the same budget.",
+};
+
+const OPPONENTS: Opponent[] = [
+  {
+    name: "Braintrust",
+    tag: "prompt eval",
+    stats: [
+      {
+        label: "Strengths",
+        body: "Clean eval primitives. Dataset versioning. Solid scoring helpers for one-shot completions.",
+      },
+      {
+        label: "Best for",
+        body: "Scoring text a model produces from a single prompt, at scale.",
+      },
+      {
+        label: "Where it breaks",
+        body: "No sandboxed tool execution. No multi-turn agent loops. No concurrent race on a shared budget.",
+      },
+    ],
+    verdict: "Built to grade text. Stops where agents start.",
+  },
+  {
+    name: "LangSmith",
+    tag: "prompt tracing + eval",
+    stats: [
+      {
+        label: "Strengths",
+        body: "Deep tracing inside the LangChain ecosystem. Rich span trees, prompt playground, dataset capture.",
+      },
+      {
+        label: "Best for",
+        body: "Debugging LangChain pipelines and prompt regressions inside that ecosystem.",
+      },
+      {
+        label: "Where it breaks",
+        body: "LangChain-shaped. No microVM sandbox. No agent-vs-agent race on shared inputs.",
+      },
+    ],
+    verdict: "A trace viewer for LangChain. Not a race engine.",
+  },
+  {
+    name: "Langfuse",
+    tag: "open-source observability",
+    stats: [
+      {
+        label: "Strengths",
+        body: "Open-source, self-hostable. Generous tracing, prompt management, cost tracking.",
+      },
+      {
+        label: "Best for",
+        body: "LLM observability without a vendor lock-in.",
+      },
+      {
+        label: "Where it breaks",
+        body: "No native agent racing. No sandbox provisioning. No trajectory scoring.",
+      },
+    ],
+    verdict: "Watches your LLM. Doesn't evaluate your agent.",
+  },
+  {
+    name: "Arize Phoenix",
+    tag: "LLM observability",
+    stats: [
+      {
+        label: "Strengths",
+        body: "Deep telemetry, drift detection, OpenTelemetry-native, production-grade dashboards.",
+      },
+      {
+        label: "Best for",
+        body: "Monitoring LLM apps already in production.",
+      },
+      {
+        label: "Where it breaks",
+        body: "Observation-only. No eval orchestration. Doesn't run agents — only watches them.",
+      },
+    ],
+    verdict: "Watches your agents. Doesn't race them.",
+  },
+];
+
+export function ComparisonFightCard() {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const opponent = OPPONENTS[activeIndex];
+
+  const goPrev = () => {
+    setActiveIndex((i) => (i - 1 + OPPONENTS.length) % OPPONENTS.length);
+  };
+  const goNext = () => {
+    setActiveIndex((i) => (i + 1) % OPPONENTS.length);
+  };
+
+  return (
+    <div>
+      {/* Tab strip */}
+      <div
+        role="tablist"
+        aria-label="Choose competitor"
+        className="-mx-1 flex flex-wrap items-center gap-1.5 sm:gap-2"
+      >
+        {OPPONENTS.map((o, i) => {
+          const active = i === activeIndex;
+          return (
+            <button
+              key={o.name}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => setActiveIndex(i)}
+              className={`group inline-flex items-center gap-2 rounded-full border px-4 py-2 text-[13px] transition-all ${
+                active
+                  ? "border-white/30 bg-white/[0.06] text-white/95"
+                  : "border-white/[0.08] bg-white/[0.015] text-white/55 hover:border-white/15 hover:text-white/80"
+              }`}
+            >
+              <span
+                aria-hidden
+                className={`text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] ${
+                  active ? "text-white/55" : "text-white/30"
+                }`}
+              >
+                vs
+              </span>
+              <span className="font-[family-name:var(--font-display)] tracking-[-0.005em]">
+                {o.name}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Fight card */}
+      <article
+        key={opponent.name}
+        className="mt-10 overflow-hidden rounded-2xl border border-white/[0.08] bg-[#0a0a0a]"
+      >
+        {/* Header bar */}
+        <header className="grid grid-cols-[1fr_auto_1fr] items-center gap-4 border-b border-white/[0.08] px-5 py-5 sm:px-8 sm:py-6">
+          <div className="flex flex-col items-start">
+            <span className="text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/30">
+              {opponent.tag}
+            </span>
+            <h3 className="mt-2 font-[family-name:var(--font-display)] text-2xl tracking-[-0.01em] text-white/70 sm:text-[28px]">
+              {opponent.name}
+            </h3>
+          </div>
+
+          <div className="flex flex-col items-center justify-center">
+            <span
+              aria-hidden
+              className="font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.32em] text-white/30"
+            >
+              vs
+            </span>
+            <span
+              aria-hidden
+              className="mt-1 inline-block size-1.5 rounded-full bg-white/30"
+            />
+          </div>
+
+          <div className="flex flex-col items-end text-right">
+            <span className="text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/55">
+              {AGENTCLASH.tag}
+            </span>
+            <h3 className="mt-2 font-[family-name:var(--font-display)] text-2xl tracking-[-0.01em] text-white/95 sm:text-[28px]">
+              {AGENTCLASH.name}
+            </h3>
+          </div>
+        </header>
+
+        {/* Body — opponent left, AgentClash right */}
+        <div className="grid grid-cols-1 md:grid-cols-2">
+          <div className="bg-white/[0.012] p-7 sm:p-9 md:border-r md:border-white/[0.06]">
+            <ul className="space-y-7">
+              {opponent.stats.map((s) => (
+                <li key={s.label}>
+                  <p className="text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/35">
+                    {s.label}
+                  </p>
+                  <p className="mt-2 text-[14.5px] leading-[1.55] text-white/55">
+                    {s.body}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="relative bg-white/[0.025] p-7 sm:p-9">
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-y-0 left-0 w-px bg-gradient-to-b from-transparent via-white/40 to-transparent"
+            />
+            <ul className="space-y-7">
+              {AGENTCLASH.stats.map((s) => (
+                <li key={s.label}>
+                  <p className="text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/55">
+                    {s.label}
+                  </p>
+                  <p className="mt-2 text-[14.5px] leading-[1.55] text-white/85">
+                    {s.body}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        {/* Verdict bar */}
+        <footer className="grid grid-cols-1 border-t border-white/[0.08] md:grid-cols-2">
+          <div className="bg-white/[0.012] px-7 py-5 sm:px-9 md:border-r md:border-white/[0.06]">
+            <p className="text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/30">
+              Verdict
+            </p>
+            <p className="mt-1.5 text-[14px] leading-[1.5] text-white/55">
+              {opponent.verdict}
+            </p>
+          </div>
+          <div className="bg-white/[0.025] px-7 py-5 sm:px-9">
+            <p className="text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/55">
+              Verdict
+            </p>
+            <p className="mt-1.5 text-[14px] leading-[1.5] text-white/90">
+              {AGENTCLASH.verdict}
+            </p>
+          </div>
+        </footer>
+      </article>
+
+      {/* Prev / next + count */}
+      <div className="mt-6 flex items-center justify-between">
+        <p className="text-[12px] font-[family-name:var(--font-mono)] text-white/35">
+          {String(activeIndex + 1).padStart(2, "0")}
+          <span className="text-white/20"> / </span>
+          {String(OPPONENTS.length).padStart(2, "0")}
+        </p>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            aria-label="Previous competitor"
+            onClick={goPrev}
+            className="inline-flex size-9 items-center justify-center rounded-full border border-white/[0.08] bg-white/[0.015] text-white/55 transition-colors hover:border-white/20 hover:text-white/85"
+          >
+            <ChevronLeft className="size-4" />
+          </button>
+          <button
+            type="button"
+            aria-label="Next competitor"
+            onClick={goNext}
+            className="inline-flex size-9 items-center justify-center rounded-full border border-white/[0.08] bg-white/[0.015] text-white/55 transition-colors hover:border-white/20 hover:text-white/85"
+          >
+            <ChevronRight className="size-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/marketing/comparison-fight-card.tsx
+++ b/web/src/components/marketing/comparison-fight-card.tsx
@@ -2,6 +2,18 @@
 
 import { useState } from "react";
 
+const NOISE_SVG_URI =
+  "data:image/svg+xml;utf8," +
+  encodeURIComponent(
+    "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 240 240'>" +
+      "<filter id='n'>" +
+      "<feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/>" +
+      "<feColorMatrix values='0 0 0 0 1  0 0 0 0 1  0 0 0 0 1  0 0 0 0.6 0'/>" +
+      "</filter>" +
+      "<rect width='100%' height='100%' filter='url(#n)'/>" +
+      "</svg>",
+  );
+
 type Matchup = {
   name: string;
   tag: string;
@@ -123,6 +135,22 @@ export function ComparisonFightCard() {
           key={m.name}
           className="relative overflow-hidden rounded-3xl border border-white/[0.08] bg-white/[0.025] p-8 backdrop-blur-2xl backdrop-saturate-150 motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-2 motion-safe:duration-500 sm:p-12 lg:p-16"
         >
+          {/* dark green tint */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0"
+            style={{ backgroundColor: "rgba(14, 48, 32, 0.32)" }}
+          />
+          {/* film-grain noise (overlay-blended with the green tint behind) */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 opacity-[0.18] mix-blend-overlay"
+            style={{
+              backgroundImage: `url("${NOISE_SVG_URI}")`,
+              backgroundSize: "240px 240px",
+              backgroundRepeat: "repeat",
+            }}
+          />
           {/* top edge highlight */}
           <div
             aria-hidden

--- a/web/src/components/marketing/comparison-fight-card.tsx
+++ b/web/src/components/marketing/comparison-fight-card.tsx
@@ -89,53 +89,92 @@ export function ComparisonFightCard() {
         })}
       </div>
 
-      {/* Poster */}
-      <div
-        key={m.name}
-        className="mt-16 grid gap-16 motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-2 motion-safe:duration-500 sm:mt-20 md:grid-cols-[0.85fr_1.15fr] md:gap-20 lg:gap-28"
-      >
-        {/* Opponent — dim, smaller */}
-        <div className="md:pt-3">
-          <h3 className="font-[family-name:var(--font-display)] text-2xl tracking-[-0.01em] text-white/55 sm:text-[28px]">
-            {m.name}
-          </h3>
-          <p className="mt-1.5 text-[13.5px] leading-[1.5] text-white/30">
-            {m.tag}
-          </p>
-          <p className="mt-10 font-[family-name:var(--font-display)] tracking-[-0.035em] leading-[0.96] text-white/35 text-[clamp(2.25rem,4.6vw,4rem)]">
-            {m.claim}
-          </p>
-          <p className="mt-6 max-w-[26ch] text-[15px] leading-[1.55] text-white/30">
-            {m.limit}
-          </p>
-        </div>
-
-        {/* AgentClash — bright, larger, with soft glow */}
-        <div className="relative md:pl-12 lg:pl-16">
+      {/* Glass poster */}
+      <div className="relative mt-16 sm:mt-20">
+        {/* Decorative gradient blobs that the backdrop-blur picks up */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute -inset-12 -z-10 overflow-hidden sm:-inset-20"
+        >
           <div
-            aria-hidden
-            className="pointer-events-none absolute -inset-x-8 -inset-y-10 -z-10 hidden md:block"
+            className="absolute left-[8%] top-1/2 size-[28rem] -translate-y-1/2 rounded-full opacity-70 blur-3xl"
             style={{
               background:
-                "radial-gradient(58% 60% at 28% 50%, rgba(255,255,255,0.05) 0%, transparent 72%)",
+                "radial-gradient(circle, rgba(126,184,230,0.18) 0%, transparent 70%)",
             }}
           />
           <div
-            aria-hidden
-            className="pointer-events-none absolute inset-y-2 left-0 hidden w-px bg-gradient-to-b from-white/0 via-white/35 to-white/0 md:block"
+            className="absolute right-[6%] top-[18%] size-[26rem] rounded-full opacity-60 blur-3xl"
+            style={{
+              background:
+                "radial-gradient(circle, rgba(255,255,255,0.10) 0%, transparent 70%)",
+            }}
           />
-          <h3 className="font-[family-name:var(--font-display)] text-2xl tracking-[-0.01em] text-white/95 sm:text-[28px]">
-            AgentClash
-          </h3>
-          <p className="mt-1.5 text-[13.5px] leading-[1.5] text-white/55">
-            agent race engine
-          </p>
-          <p className="mt-10 font-[family-name:var(--font-display)] tracking-[-0.035em] leading-[0.94] text-white/95 text-[clamp(2.75rem,6.4vw,5.75rem)]">
-            {m.counter}
-          </p>
-          <p className="mt-6 max-w-[34ch] text-[16px] leading-[1.55] text-white/65">
-            {m.edge}
-          </p>
+          <div
+            className="absolute right-[20%] bottom-[10%] size-[20rem] rounded-full opacity-50 blur-3xl"
+            style={{
+              background:
+                "radial-gradient(circle, rgba(180,150,255,0.12) 0%, transparent 70%)",
+            }}
+          />
+        </div>
+
+        <div
+          key={m.name}
+          className="relative overflow-hidden rounded-3xl border border-white/[0.08] bg-white/[0.025] p-8 backdrop-blur-2xl backdrop-saturate-150 motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-2 motion-safe:duration-500 sm:p-12 lg:p-16"
+        >
+          {/* top edge highlight */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/25 to-transparent"
+          />
+          {/* inner glow on AgentClash side */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-y-0 right-0 hidden w-2/3 md:block"
+            style={{
+              background:
+                "radial-gradient(60% 70% at 80% 50%, rgba(255,255,255,0.04) 0%, transparent 75%)",
+            }}
+          />
+
+          <div className="relative grid gap-16 md:grid-cols-[0.85fr_1.15fr] md:gap-20 lg:gap-28">
+            {/* Opponent — dim, smaller */}
+            <div className="md:pt-3">
+              <h3 className="font-[family-name:var(--font-display)] text-2xl tracking-[-0.01em] text-white/55 sm:text-[28px]">
+                {m.name}
+              </h3>
+              <p className="mt-1.5 text-[13.5px] leading-[1.5] text-white/30">
+                {m.tag}
+              </p>
+              <p className="mt-10 font-[family-name:var(--font-display)] tracking-[-0.035em] leading-[0.96] text-white/35 text-[clamp(2.25rem,4.6vw,4rem)]">
+                {m.claim}
+              </p>
+              <p className="mt-6 max-w-[26ch] text-[15px] leading-[1.55] text-white/30">
+                {m.limit}
+              </p>
+            </div>
+
+            {/* AgentClash — bright, larger */}
+            <div className="relative md:pl-12 lg:pl-16">
+              <div
+                aria-hidden
+                className="pointer-events-none absolute inset-y-2 left-0 hidden w-px bg-gradient-to-b from-white/0 via-white/35 to-white/0 md:block"
+              />
+              <h3 className="font-[family-name:var(--font-display)] text-2xl tracking-[-0.01em] text-white/95 sm:text-[28px]">
+                AgentClash
+              </h3>
+              <p className="mt-1.5 text-[13.5px] leading-[1.5] text-white/55">
+                agent race engine
+              </p>
+              <p className="mt-10 font-[family-name:var(--font-display)] tracking-[-0.035em] leading-[0.94] text-white/95 text-[clamp(2.75rem,6.4vw,5.75rem)]">
+                {m.counter}
+              </p>
+              <p className="mt-6 max-w-[34ch] text-[16px] leading-[1.55] text-white/65">
+                {m.edge}
+              </p>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/web/src/components/marketing/comparison-fight-card.tsx
+++ b/web/src/components/marketing/comparison-fight-card.tsx
@@ -56,11 +56,11 @@ export function ComparisonFightCard() {
 
   return (
     <div>
-      {/* Tab strip — editorial, not pills */}
+      {/* Tab strip — editorial underline */}
       <div
         role="tablist"
         aria-label="Choose competitor"
-        className="flex flex-wrap items-baseline gap-x-7 gap-y-4 border-b border-white/[0.08] pb-5 sm:gap-x-10"
+        className="flex flex-wrap items-baseline gap-x-7 gap-y-4 border-b border-white/[0.08] sm:gap-x-10"
       >
         {OPPONENTS.map((o, i) => {
           const active = i === activeIndex;
@@ -71,26 +71,17 @@ export function ComparisonFightCard() {
               role="tab"
               aria-selected={active}
               onClick={() => setActiveIndex(i)}
-              className={`group relative inline-flex items-baseline gap-2.5 pb-3 transition-colors -mb-[22px] ${
-                active
-                  ? "text-white/95"
-                  : "text-white/40 hover:text-white/75"
+              className={`group relative inline-flex items-baseline gap-2.5 pb-4 transition-colors ${
+                active ? "text-white/95" : "text-white/40 hover:text-white/75"
               }`}
             >
-              <span
-                className={`text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.24em] ${
-                  active ? "text-white/55" : "text-white/30"
-                }`}
-              >
-                vs
-              </span>
               <span className="font-[family-name:var(--font-display)] text-[18px] tracking-[-0.01em] sm:text-xl">
                 {o.name}
               </span>
               {active && (
                 <span
                   aria-hidden
-                  className="absolute inset-x-0 bottom-0 h-px bg-white"
+                  className="absolute inset-x-0 -bottom-px h-px bg-white"
                 />
               )}
             </button>
@@ -101,16 +92,17 @@ export function ComparisonFightCard() {
       {/* Poster */}
       <div
         key={m.name}
-        className="mt-14 grid gap-14 sm:mt-16 md:grid-cols-[0.9fr_1.1fr] md:gap-20 lg:gap-24"
+        className="mt-16 grid gap-16 motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-2 motion-safe:duration-500 sm:mt-20 md:grid-cols-[0.85fr_1.15fr] md:gap-20 lg:gap-28"
       >
         {/* Opponent — dim, smaller */}
-        <div className="md:pt-2">
-          <div className="flex items-baseline gap-3 text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.24em] text-white/30">
-            <span className="text-white/45">{m.name}</span>
-            <span className="text-white/15">·</span>
-            <span>{m.tag}</span>
-          </div>
-          <p className="mt-7 font-[family-name:var(--font-display)] tracking-[-0.035em] leading-[0.96] text-white/35 text-[clamp(2.5rem,5vw,4.5rem)]">
+        <div className="md:pt-3">
+          <h3 className="font-[family-name:var(--font-display)] text-2xl tracking-[-0.01em] text-white/55 sm:text-[28px]">
+            {m.name}
+          </h3>
+          <p className="mt-1.5 text-[13.5px] leading-[1.5] text-white/30">
+            {m.tag}
+          </p>
+          <p className="mt-10 font-[family-name:var(--font-display)] tracking-[-0.035em] leading-[0.96] text-white/35 text-[clamp(2.25rem,4.6vw,4rem)]">
             {m.claim}
           </p>
           <p className="mt-6 max-w-[26ch] text-[15px] leading-[1.55] text-white/30">
@@ -118,18 +110,27 @@ export function ComparisonFightCard() {
           </p>
         </div>
 
-        {/* AgentClash — bright, larger */}
+        {/* AgentClash — bright, larger, with soft glow */}
         <div className="relative md:pl-12 lg:pl-16">
           <div
             aria-hidden
-            className="hidden md:block pointer-events-none absolute inset-y-2 left-0 w-px bg-gradient-to-b from-white/0 via-white/30 to-white/0"
+            className="pointer-events-none absolute -inset-x-8 -inset-y-10 -z-10 hidden md:block"
+            style={{
+              background:
+                "radial-gradient(58% 60% at 28% 50%, rgba(255,255,255,0.05) 0%, transparent 72%)",
+            }}
           />
-          <div className="flex items-baseline gap-3 text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.24em] text-white/55">
-            <span className="text-white/85">AgentClash</span>
-            <span className="text-white/25">·</span>
-            <span>agent race engine</span>
-          </div>
-          <p className="mt-7 font-[family-name:var(--font-display)] tracking-[-0.035em] leading-[0.94] text-white/95 text-[clamp(3rem,6.5vw,6rem)]">
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-y-2 left-0 hidden w-px bg-gradient-to-b from-white/0 via-white/35 to-white/0 md:block"
+          />
+          <h3 className="font-[family-name:var(--font-display)] text-2xl tracking-[-0.01em] text-white/95 sm:text-[28px]">
+            AgentClash
+          </h3>
+          <p className="mt-1.5 text-[13.5px] leading-[1.5] text-white/55">
+            agent race engine
+          </p>
+          <p className="mt-10 font-[family-name:var(--font-display)] tracking-[-0.035em] leading-[0.94] text-white/95 text-[clamp(2.75rem,6.4vw,5.75rem)]">
             {m.counter}
           </p>
           <p className="mt-6 max-w-[34ch] text-[16px] leading-[1.55] text-white/65">
@@ -139,34 +140,32 @@ export function ComparisonFightCard() {
       </div>
 
       {/* Counter + nav */}
-      <div className="mt-14 flex items-center justify-between border-t border-white/[0.06] pt-6">
-        <p className="text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/35">
+      <div className="mt-16 flex items-center justify-between border-t border-white/[0.06] pt-6">
+        <p className="font-[family-name:var(--font-mono)] text-[12px] text-white/40">
           {String(activeIndex + 1).padStart(2, "0")}
           <span className="text-white/15"> / </span>
           {String(OPPONENTS.length).padStart(2, "0")}
         </p>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-5 text-[13px]">
           <button
             type="button"
             aria-label="Previous competitor"
             onClick={goPrev}
-            className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.22em] text-white/45 transition-colors hover:text-white/85"
+            className="font-[family-name:var(--font-display)] text-white/50 transition-colors hover:text-white/95"
           >
             ← prev
           </button>
-          <span aria-hidden className="text-white/15">
-            ·
-          </span>
           <button
             type="button"
             aria-label="Next competitor"
             onClick={goNext}
-            className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.22em] text-white/45 transition-colors hover:text-white/85"
+            className="font-[family-name:var(--font-display)] text-white/50 transition-colors hover:text-white/95"
           >
             next →
           </button>
         </div>
       </div>
+
     </div>
   );
 }

--- a/web/src/components/marketing/comparison-fight-card.tsx
+++ b/web/src/components/marketing/comparison-fight-card.tsx
@@ -1,137 +1,66 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
 
-type Stat = {
-  label: string;
-  body: string;
-};
-
-type Opponent = {
+type Matchup = {
   name: string;
   tag: string;
-  stats: Stat[];
-  verdict: string;
+  claim: string;
+  limit: string;
+  counter: string;
+  edge: string;
 };
 
-const AGENTCLASH = {
-  name: "AgentClash",
-  tag: "agent race engine",
-  stats: [
-    {
-      label: "Strengths",
-      body: "Multi-turn loops in real microVMs. Head-to-head races on a shared budget. Trajectory scoring on the path, not just the answer.",
-    },
-    {
-      label: "Best for",
-      body: "Picking the right agent for a real task — and gating CI on the result.",
-    },
-    {
-      label: "The edge",
-      body: "Same challenge, same tools, same clock. Failures auto-promote to regressions.",
-    },
-  ],
-  verdict: "We race agents. Live, and on the same budget.",
-};
-
-const OPPONENTS: Opponent[] = [
+const OPPONENTS: Matchup[] = [
   {
     name: "Braintrust",
     tag: "prompt eval",
-    stats: [
-      {
-        label: "Strengths",
-        body: "Clean eval primitives. Dataset versioning. Solid scoring helpers for one-shot completions.",
-      },
-      {
-        label: "Best for",
-        body: "Scoring text a model produces from a single prompt, at scale.",
-      },
-      {
-        label: "Where it breaks",
-        body: "No sandboxed tool execution. No multi-turn agent loops. No concurrent race on a shared budget.",
-      },
-    ],
-    verdict: "Built to grade text. Stops where agents start.",
+    claim: "Grades text.",
+    limit: "Stops where agents start.",
+    counter: "Grades the whole loop.",
+    edge: "Multi-turn, sandboxed, scored on the path — not just the answer.",
   },
   {
     name: "LangSmith",
-    tag: "prompt tracing + eval",
-    stats: [
-      {
-        label: "Strengths",
-        body: "Deep tracing inside the LangChain ecosystem. Rich span trees, prompt playground, dataset capture.",
-      },
-      {
-        label: "Best for",
-        body: "Debugging LangChain pipelines and prompt regressions inside that ecosystem.",
-      },
-      {
-        label: "Where it breaks",
-        body: "LangChain-shaped. No microVM sandbox. No agent-vs-agent race on shared inputs.",
-      },
-    ],
-    verdict: "A trace viewer for LangChain. Not a race engine.",
+    tag: "prompt tracing",
+    claim: "Traces LangChain.",
+    limit: "One ecosystem. One agent at a time.",
+    counter: "Races any provider.",
+    edge: "Six adapters, head-to-head, on a shared budget.",
   },
   {
     name: "Langfuse",
     tag: "open-source observability",
-    stats: [
-      {
-        label: "Strengths",
-        body: "Open-source, self-hostable. Generous tracing, prompt management, cost tracking.",
-      },
-      {
-        label: "Best for",
-        body: "LLM observability without a vendor lock-in.",
-      },
-      {
-        label: "Where it breaks",
-        body: "No native agent racing. No sandbox provisioning. No trajectory scoring.",
-      },
-    ],
-    verdict: "Watches your LLM. Doesn't evaluate your agent.",
+    claim: "Watches your LLM.",
+    limit: "No execution. No verdict.",
+    counter: "Runs the race.",
+    edge: "Observability is a side effect. The verdict is the point.",
   },
   {
     name: "Arize Phoenix",
     tag: "LLM observability",
-    stats: [
-      {
-        label: "Strengths",
-        body: "Deep telemetry, drift detection, OpenTelemetry-native, production-grade dashboards.",
-      },
-      {
-        label: "Best for",
-        body: "Monitoring LLM apps already in production.",
-      },
-      {
-        label: "Where it breaks",
-        body: "Observation-only. No eval orchestration. Doesn't run agents — only watches them.",
-      },
-    ],
-    verdict: "Watches your agents. Doesn't race them.",
+    claim: "Monitors what shipped.",
+    limit: "Tells you it broke. After.",
+    counter: "Decides what ships.",
+    edge: "Picked on the real task before it ever reaches prod.",
   },
 ];
 
 export function ComparisonFightCard() {
   const [activeIndex, setActiveIndex] = useState(0);
-  const opponent = OPPONENTS[activeIndex];
+  const m = OPPONENTS[activeIndex];
 
-  const goPrev = () => {
+  const goPrev = () =>
     setActiveIndex((i) => (i - 1 + OPPONENTS.length) % OPPONENTS.length);
-  };
-  const goNext = () => {
-    setActiveIndex((i) => (i + 1) % OPPONENTS.length);
-  };
+  const goNext = () => setActiveIndex((i) => (i + 1) % OPPONENTS.length);
 
   return (
     <div>
-      {/* Tab strip */}
+      {/* Tab strip — editorial, not pills */}
       <div
         role="tablist"
         aria-label="Choose competitor"
-        className="-mx-1 flex flex-wrap items-center gap-1.5 sm:gap-2"
+        className="flex flex-wrap items-baseline gap-x-7 gap-y-4 border-b border-white/[0.08] pb-5 sm:gap-x-10"
       >
         {OPPONENTS.map((o, i) => {
           const active = i === activeIndex;
@@ -142,148 +71,99 @@ export function ComparisonFightCard() {
               role="tab"
               aria-selected={active}
               onClick={() => setActiveIndex(i)}
-              className={`group inline-flex items-center gap-2 rounded-full border px-4 py-2 text-[13px] transition-all ${
+              className={`group relative inline-flex items-baseline gap-2.5 pb-3 transition-colors -mb-[22px] ${
                 active
-                  ? "border-white/30 bg-white/[0.06] text-white/95"
-                  : "border-white/[0.08] bg-white/[0.015] text-white/55 hover:border-white/15 hover:text-white/80"
+                  ? "text-white/95"
+                  : "text-white/40 hover:text-white/75"
               }`}
             >
               <span
-                aria-hidden
-                className={`text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] ${
+                className={`text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.24em] ${
                   active ? "text-white/55" : "text-white/30"
                 }`}
               >
                 vs
               </span>
-              <span className="font-[family-name:var(--font-display)] tracking-[-0.005em]">
+              <span className="font-[family-name:var(--font-display)] text-[18px] tracking-[-0.01em] sm:text-xl">
                 {o.name}
               </span>
+              {active && (
+                <span
+                  aria-hidden
+                  className="absolute inset-x-0 bottom-0 h-px bg-white"
+                />
+              )}
             </button>
           );
         })}
       </div>
 
-      {/* Fight card */}
-      <article
-        key={opponent.name}
-        className="mt-10 overflow-hidden rounded-2xl border border-white/[0.08] bg-[#0a0a0a]"
+      {/* Poster */}
+      <div
+        key={m.name}
+        className="mt-14 grid gap-14 sm:mt-16 md:grid-cols-[0.9fr_1.1fr] md:gap-20 lg:gap-24"
       >
-        {/* Header bar */}
-        <header className="grid grid-cols-[1fr_auto_1fr] items-center gap-4 border-b border-white/[0.08] px-5 py-5 sm:px-8 sm:py-6">
-          <div className="flex flex-col items-start">
-            <span className="text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/30">
-              {opponent.tag}
-            </span>
-            <h3 className="mt-2 font-[family-name:var(--font-display)] text-2xl tracking-[-0.01em] text-white/70 sm:text-[28px]">
-              {opponent.name}
-            </h3>
+        {/* Opponent — dim, smaller */}
+        <div className="md:pt-2">
+          <div className="flex items-baseline gap-3 text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.24em] text-white/30">
+            <span className="text-white/45">{m.name}</span>
+            <span className="text-white/15">·</span>
+            <span>{m.tag}</span>
           </div>
-
-          <div className="flex flex-col items-center justify-center">
-            <span
-              aria-hidden
-              className="font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.32em] text-white/30"
-            >
-              vs
-            </span>
-            <span
-              aria-hidden
-              className="mt-1 inline-block size-1.5 rounded-full bg-white/30"
-            />
-          </div>
-
-          <div className="flex flex-col items-end text-right">
-            <span className="text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/55">
-              {AGENTCLASH.tag}
-            </span>
-            <h3 className="mt-2 font-[family-name:var(--font-display)] text-2xl tracking-[-0.01em] text-white/95 sm:text-[28px]">
-              {AGENTCLASH.name}
-            </h3>
-          </div>
-        </header>
-
-        {/* Body — opponent left, AgentClash right */}
-        <div className="grid grid-cols-1 md:grid-cols-2">
-          <div className="bg-white/[0.012] p-7 sm:p-9 md:border-r md:border-white/[0.06]">
-            <ul className="space-y-7">
-              {opponent.stats.map((s) => (
-                <li key={s.label}>
-                  <p className="text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/35">
-                    {s.label}
-                  </p>
-                  <p className="mt-2 text-[14.5px] leading-[1.55] text-white/55">
-                    {s.body}
-                  </p>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          <div className="relative bg-white/[0.025] p-7 sm:p-9">
-            <div
-              aria-hidden
-              className="pointer-events-none absolute inset-y-0 left-0 w-px bg-gradient-to-b from-transparent via-white/40 to-transparent"
-            />
-            <ul className="space-y-7">
-              {AGENTCLASH.stats.map((s) => (
-                <li key={s.label}>
-                  <p className="text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/55">
-                    {s.label}
-                  </p>
-                  <p className="mt-2 text-[14.5px] leading-[1.55] text-white/85">
-                    {s.body}
-                  </p>
-                </li>
-              ))}
-            </ul>
-          </div>
+          <p className="mt-7 font-[family-name:var(--font-display)] tracking-[-0.035em] leading-[0.96] text-white/35 text-[clamp(2.5rem,5vw,4.5rem)]">
+            {m.claim}
+          </p>
+          <p className="mt-6 max-w-[26ch] text-[15px] leading-[1.55] text-white/30">
+            {m.limit}
+          </p>
         </div>
 
-        {/* Verdict bar */}
-        <footer className="grid grid-cols-1 border-t border-white/[0.08] md:grid-cols-2">
-          <div className="bg-white/[0.012] px-7 py-5 sm:px-9 md:border-r md:border-white/[0.06]">
-            <p className="text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/30">
-              Verdict
-            </p>
-            <p className="mt-1.5 text-[14px] leading-[1.5] text-white/55">
-              {opponent.verdict}
-            </p>
+        {/* AgentClash — bright, larger */}
+        <div className="relative md:pl-12 lg:pl-16">
+          <div
+            aria-hidden
+            className="hidden md:block pointer-events-none absolute inset-y-2 left-0 w-px bg-gradient-to-b from-white/0 via-white/30 to-white/0"
+          />
+          <div className="flex items-baseline gap-3 text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.24em] text-white/55">
+            <span className="text-white/85">AgentClash</span>
+            <span className="text-white/25">·</span>
+            <span>agent race engine</span>
           </div>
-          <div className="bg-white/[0.025] px-7 py-5 sm:px-9">
-            <p className="text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/55">
-              Verdict
-            </p>
-            <p className="mt-1.5 text-[14px] leading-[1.5] text-white/90">
-              {AGENTCLASH.verdict}
-            </p>
-          </div>
-        </footer>
-      </article>
+          <p className="mt-7 font-[family-name:var(--font-display)] tracking-[-0.035em] leading-[0.94] text-white/95 text-[clamp(3rem,6.5vw,6rem)]">
+            {m.counter}
+          </p>
+          <p className="mt-6 max-w-[34ch] text-[16px] leading-[1.55] text-white/65">
+            {m.edge}
+          </p>
+        </div>
+      </div>
 
-      {/* Prev / next + count */}
-      <div className="mt-6 flex items-center justify-between">
-        <p className="text-[12px] font-[family-name:var(--font-mono)] text-white/35">
+      {/* Counter + nav */}
+      <div className="mt-14 flex items-center justify-between border-t border-white/[0.06] pt-6">
+        <p className="text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.22em] text-white/35">
           {String(activeIndex + 1).padStart(2, "0")}
-          <span className="text-white/20"> / </span>
+          <span className="text-white/15"> / </span>
           {String(OPPONENTS.length).padStart(2, "0")}
         </p>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-3">
           <button
             type="button"
             aria-label="Previous competitor"
             onClick={goPrev}
-            className="inline-flex size-9 items-center justify-center rounded-full border border-white/[0.08] bg-white/[0.015] text-white/55 transition-colors hover:border-white/20 hover:text-white/85"
+            className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.22em] text-white/45 transition-colors hover:text-white/85"
           >
-            <ChevronLeft className="size-4" />
+            ← prev
           </button>
+          <span aria-hidden className="text-white/15">
+            ·
+          </span>
           <button
             type="button"
             aria-label="Next competitor"
             onClick={goNext}
-            className="inline-flex size-9 items-center justify-center rounded-full border border-white/[0.08] bg-white/[0.015] text-white/55 transition-colors hover:border-white/20 hover:text-white/85"
+            className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.22em] text-white/45 transition-colors hover:text-white/85"
           >
-            <ChevronRight className="size-4" />
+            next →
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Replaces the 7×7 capability matrix in the comparison section with a tabbed 1v1 fight card.
- Four opponents — Braintrust, LangSmith, Langfuse, Arize Phoenix — pick one, see a split card: opponent dim on the left, AgentClash lit on the right, with \`Strengths · Best for · Where it breaks · Verdict\`.
- Drops the matrix's seven capability rows × seven columns; keeps the same heading (\"They test prompts. We race agents.\") and intro copy.
- New \`ComparisonFightCard\` component lives at \`web/src/components/marketing/comparison-fight-card.tsx\`. Local \`ComparisonMark\` helper, \`COMPARISON_COLUMNS\`, \`COMPARISON_ROWS\`, and \`MarkKind\` removed from \`landing.tsx\`.
- Shorter section overall — addresses landing page length while leaning into the AgentClash combat brand.
- \`v2/landing.tsx\` left untouched.

## Test plan
- [ ] \`cd web && npx tsc --noEmit\` clean
- [ ] \`cd web && pnpm lint\` clean
- [ ] Visual: tabs cycle competitors; prev/next chevrons wrap correctly; counter (\`01 / 04\`) updates
- [ ] Mobile: header bar wraps cleanly, body stacks single-column
- [ ] Confirm page is materially shorter than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)