### PR TITLE
feat(cli): expose regression and artifact surfaces

### DIFF
--- a/cli/cmd/artifact.go
+++ b/cli/cmd/artifact.go
@@ -15,6 +15,7 @@ import (
 
 func init() {
 	rootCmd.AddCommand(artifactCmd)
+	artifactCmd.AddCommand(artifactListCmd)
 	artifactCmd.AddCommand(artifactUploadCmd)
 	artifactCmd.AddCommand(artifactDownloadCmd)
 
@@ -30,6 +31,49 @@ func init() {
 var artifactCmd = &cobra.Command{
 	Use:   "artifact",
 	Short: "Upload and download artifacts",
+}
+
+var artifactListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List artifacts in the workspace",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		wsID := RequireWorkspace(cmd)
+
+		resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+wsID+"/artifacts", nil)
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+
+		var result struct {
+			Items []map[string]any `json:"items"`
+		}
+		if err := resp.DecodeJSON(&result); err != nil {
+			return err
+		}
+
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(result)
+		}
+
+		cols := []output.Column{{Header: "ID"}, {Header: "Type"}, {Header: "Size"}, {Header: "Run"}, {Header: "Run Agent"}, {Header: "Created"}}
+		rows := make([][]string, len(result.Items))
+		for i, item := range result.Items {
+			rows[i] = []string{
+				str(item["id"]),
+				mapString(item, "artifact_type", "type"),
+				str(item["size_bytes"]),
+				str(item["run_id"]),
+				str(item["run_agent_id"]),
+				str(item["created_at"]),
+			}
+		}
+		rc.Output.PrintTable(cols, rows)
+		return nil
+	},
 }
 
 var artifactUploadCmd = &cobra.Command{

--- a/cli/cmd/cli_surface_gaps_test.go
+++ b/cli/cmd/cli_surface_gaps_test.go
@@ -1,0 +1,220 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestArtifactListCallsWorkspaceEndpoint(t *testing.T) {
+	var called bool
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-123/artifacts": captureHandler(t, &called, 200, map[string]any{
+			"items": []map[string]any{
+				{"id": "art-1", "artifact_type": "trace", "size_bytes": 42, "created_at": "now"},
+			},
+		}),
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{"artifact", "list", "-w", "ws-123"}, srv.URL); err != nil {
+		t.Fatalf("artifact list error: %v", err)
+	}
+	if !called {
+		t.Fatal("GET /v1/workspaces/ws-123/artifacts was not called")
+	}
+}
+
+func TestReleaseGateListForwardsComparisonFilters(t *testing.T) {
+	var gotBaseline, gotCandidate string
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/release-gates": func(w http.ResponseWriter, r *http.Request) {
+			gotBaseline = r.URL.Query().Get("baseline_run_id")
+			gotCandidate = r.URL.Query().Get("candidate_run_id")
+			jsonHandler(200, map[string]any{
+				"baseline_run_id":  "run-b",
+				"candidate_run_id": "run-c",
+				"release_gates": []map[string]any{
+					{"id": "gate-1", "verdict": "pass", "policy_key": "default"},
+				},
+			})(w, r)
+		},
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{"release-gate", "list", "--baseline", "run-b", "--candidate", "run-c"}, srv.URL); err != nil {
+		t.Fatalf("release-gate list error: %v", err)
+	}
+	if gotBaseline != "run-b" || gotCandidate != "run-c" {
+		t.Fatalf("query = baseline %q candidate %q, want run-b/run-c", gotBaseline, gotCandidate)
+	}
+}
+
+func TestRegressionSuiteCommandsCallExpectedEndpoints(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		key  string
+	}{
+		{"list", []string{"regression-suite", "list", "-w", "ws-123"}, "GET /v1/workspaces/ws-123/regression-suites"},
+		{"get", []string{"regression-suite", "get", "suite-1", "-w", "ws-123"}, "GET /v1/workspaces/ws-123/regression-suites/suite-1"},
+		{"cases", []string{"regression-suite", "cases", "suite-1", "-w", "ws-123"}, "GET /v1/workspaces/ws-123/regression-suites/suite-1/cases"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var called bool
+			routes := map[string]http.HandlerFunc{
+				tc.key: captureHandler(t, &called, 200, map[string]any{
+					"id": "suite-1",
+					"items": []map[string]any{
+						{"id": "suite-1", "name": "Suite", "status": "active"},
+					},
+				}),
+			}
+			srv := fakeAPI(t, routes)
+			defer srv.Close()
+
+			t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+			if err := executeCommand(t, tc.args, srv.URL); err != nil {
+				t.Fatalf("%s error: %v", tc.name, err)
+			}
+			if !called {
+				t.Fatalf("%s was not called", tc.key)
+			}
+		})
+	}
+}
+
+func TestRegressionSuiteCreateAndUpdatePayloads(t *testing.T) {
+	var createBody, updateBody map[string]any
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/workspaces/ws-123/regression-suites": func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&createBody); err != nil {
+				t.Fatalf("decode create body: %v", err)
+			}
+			jsonHandler(201, map[string]any{"id": "suite-1", "name": "New Suite"})(w, r)
+		},
+		"PATCH /v1/workspaces/ws-123/regression-suites/suite-1": func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&updateBody); err != nil {
+				t.Fatalf("decode update body: %v", err)
+			}
+			jsonHandler(200, map[string]any{"id": "suite-1", "name": "Renamed"})(w, r)
+		},
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"regression-suite", "create", "-w", "ws-123",
+		"--source-challenge-pack-id", "pack-1",
+		"--name", "New Suite",
+		"--description", "desc",
+		"--default-gate-severity", "blocking",
+	}, srv.URL); err != nil {
+		t.Fatalf("create error: %v", err)
+	}
+	if createBody["source_challenge_pack_id"] != "pack-1" || createBody["default_gate_severity"] != "blocking" {
+		t.Fatalf("unexpected create body: %#v", createBody)
+	}
+
+	if err := executeCommand(t, []string{
+		"regression-suite", "update", "suite-1", "-w", "ws-123",
+		"--name", "Renamed",
+		"--status", "archived",
+	}, srv.URL); err != nil {
+		t.Fatalf("update error: %v", err)
+	}
+	if updateBody["name"] != "Renamed" || updateBody["status"] != "archived" {
+		t.Fatalf("unexpected update body: %#v", updateBody)
+	}
+}
+
+func TestRegressionCaseUpdatePayload(t *testing.T) {
+	var gotBody map[string]any
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"PATCH /v1/workspaces/ws-123/regression-cases/case-1": func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			jsonHandler(200, map[string]any{"id": "case-1", "title": "Policy regression"})(w, r)
+		},
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"regression-suite", "case", "update", "case-1", "-w", "ws-123",
+		"--title", "Policy regression",
+		"--severity", "warning",
+	}, srv.URL); err != nil {
+		t.Fatalf("case update error: %v", err)
+	}
+	if gotBody["title"] != "Policy regression" || gotBody["severity"] != "warning" {
+		t.Fatalf("unexpected body: %#v", gotBody)
+	}
+}
+
+func TestRunFailuresForwardsFilters(t *testing.T) {
+	var gotAgent, gotClass, gotLimit string
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-123/runs/run-1/failures": func(w http.ResponseWriter, r *http.Request) {
+			gotAgent = r.URL.Query().Get("agent_id")
+			gotClass = r.URL.Query().Get("class")
+			gotLimit = r.URL.Query().Get("limit")
+			jsonHandler(200, map[string]any{
+				"items": []map[string]any{
+					{"run_agent_id": "agent-1", "failure_state": "failed", "promotable": true},
+				},
+			})(w, r)
+		},
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"run", "failures", "run-1", "-w", "ws-123",
+		"--agent", "agent-1",
+		"--class", "policy_violation",
+		"--limit", "25",
+	}, srv.URL); err != nil {
+		t.Fatalf("run failures error: %v", err)
+	}
+	if gotAgent != "agent-1" || gotClass != "policy_violation" || gotLimit != "25" {
+		t.Fatalf("query = agent %q class %q limit %q", gotAgent, gotClass, gotLimit)
+	}
+}
+
+func TestRunPromoteFailurePayload(t *testing.T) {
+	var gotBody map[string]any
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/workspaces/ws-123/runs/run-1/failures/challenge-1/promote": func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			jsonHandler(201, map[string]any{
+				"case":    map[string]any{"id": "case-1"},
+				"created": true,
+			})(w, r)
+		},
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"run", "promote-failure", "run-1", "challenge-1", "-w", "ws-123",
+		"--run-agent", "agent-1",
+		"--suite", "suite-1",
+		"--promotion-mode", "output_only",
+		"--title", "Policy regression",
+		"--severity", "blocking",
+	}, srv.URL); err != nil {
+		t.Fatalf("promote failure error: %v", err)
+	}
+	if gotBody["run_agent_id"] != "agent-1" || gotBody["suite_id"] != "suite-1" || gotBody["promotion_mode"] != "output_only" {
+		t.Fatalf("unexpected body: %#v", gotBody)
+	}
+}

--- a/cli/cmd/regression_suite.go
+++ b/cli/cmd/regression_suite.go
@@ -1,0 +1,284 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/agentclash/agentclash/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(regressionSuiteCmd)
+	regressionSuiteCmd.AddCommand(regressionSuiteListCmd)
+	regressionSuiteCmd.AddCommand(regressionSuiteGetCmd)
+	regressionSuiteCmd.AddCommand(regressionSuiteCreateCmd)
+	regressionSuiteCmd.AddCommand(regressionSuiteUpdateCmd)
+	regressionSuiteCmd.AddCommand(regressionSuiteCasesCmd)
+	regressionSuiteCmd.AddCommand(regressionCaseCmd)
+	regressionCaseCmd.AddCommand(regressionCaseUpdateCmd)
+
+	regressionSuiteCreateCmd.Flags().String("from-file", "", "JSON file with regression suite create payload")
+	regressionSuiteCreateCmd.Flags().String("source-challenge-pack-id", "", "Source challenge pack ID")
+	regressionSuiteCreateCmd.Flags().String("name", "", "Suite name")
+	regressionSuiteCreateCmd.Flags().String("description", "", "Suite description")
+	regressionSuiteCreateCmd.Flags().String("default-gate-severity", "", "Default gate severity: info, warning, or blocking")
+
+	regressionSuiteUpdateCmd.Flags().String("from-file", "", "JSON file with regression suite patch payload")
+	regressionSuiteUpdateCmd.Flags().String("name", "", "Suite name")
+	regressionSuiteUpdateCmd.Flags().String("description", "", "Suite description")
+	regressionSuiteUpdateCmd.Flags().String("status", "", "Suite status: active or archived")
+	regressionSuiteUpdateCmd.Flags().String("default-gate-severity", "", "Default gate severity: info, warning, or blocking")
+
+	regressionCaseUpdateCmd.Flags().String("from-file", "", "JSON file with regression case patch payload")
+	regressionCaseUpdateCmd.Flags().String("title", "", "Case title")
+	regressionCaseUpdateCmd.Flags().String("description", "", "Case description")
+	regressionCaseUpdateCmd.Flags().String("status", "", "Case status: active, muted, or archived")
+	regressionCaseUpdateCmd.Flags().String("severity", "", "Case severity: info, warning, or blocking")
+}
+
+var regressionSuiteCmd = &cobra.Command{
+	Use:     "regression-suite",
+	Aliases: []string{"regression-suites"},
+	Short:   "Manage regression suites and cases",
+}
+
+var regressionSuiteListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List regression suites",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		wsID := RequireWorkspace(cmd)
+
+		resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+wsID+"/regression-suites", nil)
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+
+		var result struct {
+			Items []map[string]any `json:"items"`
+		}
+		if err := resp.DecodeJSON(&result); err != nil {
+			return err
+		}
+
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(result)
+		}
+
+		renderRegressionSuitesTable(rc, result.Items)
+		return nil
+	},
+}
+
+var regressionSuiteGetCmd = &cobra.Command{
+	Use:   "get <suiteId>",
+	Short: "Get a regression suite",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		wsID := RequireWorkspace(cmd)
+		resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+wsID+"/regression-suites/"+args[0], nil)
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+
+		var suite map[string]any
+		if err := resp.DecodeJSON(&suite); err != nil {
+			return err
+		}
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(suite)
+		}
+		renderRegressionSuiteDetail(rc, suite)
+		return nil
+	},
+}
+
+var regressionSuiteCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a regression suite",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		wsID := RequireWorkspace(cmd)
+		body, err := loadBodyFromFileOrFlags(cmd)
+		if err != nil {
+			return err
+		}
+		setFlagIfChanged(cmd, body, "source-challenge-pack-id", "source_challenge_pack_id")
+		setFlagIfChanged(cmd, body, "name", "name")
+		setFlagIfChanged(cmd, body, "description", "description")
+		setFlagIfChanged(cmd, body, "default-gate-severity", "default_gate_severity")
+
+		resp, err := rc.Client.Post(cmd.Context(), "/v1/workspaces/"+wsID+"/regression-suites", body)
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+
+		var suite map[string]any
+		if err := resp.DecodeJSON(&suite); err != nil {
+			return err
+		}
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(suite)
+		}
+		rc.Output.PrintSuccess(fmt.Sprintf("Created regression suite %s (%s)", str(suite["name"]), str(suite["id"])))
+		return nil
+	},
+}
+
+var regressionSuiteUpdateCmd = &cobra.Command{
+	Use:   "update <suiteId>",
+	Short: "Update a regression suite",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		wsID := RequireWorkspace(cmd)
+		body, err := loadBodyFromFileOrFlags(cmd)
+		if err != nil {
+			return err
+		}
+		setFlagIfChanged(cmd, body, "name", "name")
+		setFlagIfChanged(cmd, body, "description", "description")
+		setFlagIfChanged(cmd, body, "status", "status")
+		setFlagIfChanged(cmd, body, "default-gate-severity", "default_gate_severity")
+
+		resp, err := rc.Client.Patch(cmd.Context(), "/v1/workspaces/"+wsID+"/regression-suites/"+args[0], body)
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+
+		var suite map[string]any
+		if err := resp.DecodeJSON(&suite); err != nil {
+			return err
+		}
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(suite)
+		}
+		rc.Output.PrintSuccess(fmt.Sprintf("Updated regression suite %s", args[0]))
+		return nil
+	},
+}
+
+var regressionSuiteCasesCmd = &cobra.Command{
+	Use:   "cases <suiteId>",
+	Short: "List regression cases in a suite",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		wsID := RequireWorkspace(cmd)
+		resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+wsID+"/regression-suites/"+args[0]+"/cases", nil)
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+
+		var result struct {
+			Items []map[string]any `json:"items"`
+		}
+		if err := resp.DecodeJSON(&result); err != nil {
+			return err
+		}
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(result)
+		}
+		renderRegressionCasesTable(rc, result.Items)
+		return nil
+	},
+}
+
+var regressionCaseCmd = &cobra.Command{
+	Use:   "case",
+	Short: "Manage individual regression cases",
+}
+
+var regressionCaseUpdateCmd = &cobra.Command{
+	Use:   "update <caseId>",
+	Short: "Update a regression case",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		wsID := RequireWorkspace(cmd)
+		body, err := loadBodyFromFileOrFlags(cmd)
+		if err != nil {
+			return err
+		}
+		setFlagIfChanged(cmd, body, "title", "title")
+		setFlagIfChanged(cmd, body, "description", "description")
+		setFlagIfChanged(cmd, body, "status", "status")
+		setFlagIfChanged(cmd, body, "severity", "severity")
+
+		resp, err := rc.Client.Patch(cmd.Context(), "/v1/workspaces/"+wsID+"/regression-cases/"+args[0], body)
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+
+		var regressionCase map[string]any
+		if err := resp.DecodeJSON(&regressionCase); err != nil {
+			return err
+		}
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(regressionCase)
+		}
+		rc.Output.PrintSuccess(fmt.Sprintf("Updated regression case %s", args[0]))
+		return nil
+	},
+}
+
+func renderRegressionSuitesTable(rc *RunContext, items []map[string]any) {
+	cols := []output.Column{{Header: "ID"}, {Header: "Name"}, {Header: "Status"}, {Header: "Cases"}, {Header: "Severity"}, {Header: "Created"}}
+	rows := make([][]string, len(items))
+	for i, item := range items {
+		rows[i] = []string{
+			str(item["id"]),
+			str(item["name"]),
+			output.StatusColor(str(item["status"])),
+			str(item["case_count"]),
+			str(item["default_gate_severity"]),
+			str(item["created_at"]),
+		}
+	}
+	rc.Output.PrintTable(cols, rows)
+}
+
+func renderRegressionCasesTable(rc *RunContext, items []map[string]any) {
+	cols := []output.Column{{Header: "ID"}, {Header: "Title"}, {Header: "Status"}, {Header: "Severity"}, {Header: "Class"}, {Header: "Created"}}
+	rows := make([][]string, len(items))
+	for i, item := range items {
+		rows[i] = []string{
+			str(item["id"]),
+			str(item["title"]),
+			output.StatusColor(str(item["status"])),
+			str(item["severity"]),
+			str(item["failure_class"]),
+			str(item["created_at"]),
+		}
+	}
+	rc.Output.PrintTable(cols, rows)
+}
+
+func renderRegressionSuiteDetail(rc *RunContext, suite map[string]any) {
+	rc.Output.PrintDetail("ID", str(suite["id"]))
+	rc.Output.PrintDetail("Name", str(suite["name"]))
+	rc.Output.PrintDetail("Status", output.StatusColor(str(suite["status"])))
+	rc.Output.PrintDetail("Source Challenge Pack", str(suite["source_challenge_pack_id"]))
+	rc.Output.PrintDetail("Default Gate Severity", str(suite["default_gate_severity"]))
+	rc.Output.PrintDetail("Cases", str(suite["case_count"]))
+	rc.Output.PrintDetail("Created", str(suite["created_at"]))
+}

--- a/cli/cmd/release_gate.go
+++ b/cli/cmd/release_gate.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"net/url"
+
+	"github.com/agentclash/agentclash/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(releaseGateCmd)
+	releaseGateCmd.AddCommand(releaseGateListCmd)
+
+	releaseGateListCmd.Flags().String("baseline", "", "Baseline run ID")
+	releaseGateListCmd.Flags().String("candidate", "", "Candidate run ID")
+}
+
+var releaseGateCmd = &cobra.Command{
+	Use:     "release-gate",
+	Aliases: []string{"release-gates"},
+	Short:   "Inspect evaluated release gates",
+}
+
+var releaseGateListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List evaluated release gates",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+
+		q := url.Values{}
+		if baseline, _ := cmd.Flags().GetString("baseline"); baseline != "" {
+			q.Set("baseline_run_id", baseline)
+		}
+		if candidate, _ := cmd.Flags().GetString("candidate"); candidate != "" {
+			q.Set("candidate_run_id", candidate)
+		}
+
+		resp, err := rc.Client.Get(cmd.Context(), "/v1/release-gates", q)
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+
+		var result map[string]any
+		if err := resp.DecodeJSON(&result); err != nil {
+			return err
+		}
+
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(result)
+		}
+
+		gates := mapSlice(result, "release_gates", "items")
+		cols := []output.Column{{Header: "ID"}, {Header: "Verdict"}, {Header: "Policy"}, {Header: "Reason"}, {Header: "Generated"}}
+		rows := make([][]string, len(gates))
+		for i, item := range gates {
+			gate, _ := item.(map[string]any)
+			rows[i] = []string{
+				str(gate["id"]),
+				output.StatusColor(str(gate["verdict"])),
+				mapString(gate, "policy_key"),
+				mapString(gate, "reason_code"),
+				mapString(gate, "generated_at", "created_at"),
+			}
+		}
+		rc.Output.PrintTable(cols, rows)
+		return nil
+	},
+}

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -22,6 +22,8 @@ func init() {
 	runCmd.AddCommand(runAgentsCmd)
 	runCmd.AddCommand(runEventsCmd)
 	runCmd.AddCommand(runScorecardCmd)
+	runCmd.AddCommand(runFailuresCmd)
+	runCmd.AddCommand(runPromoteFailureCmd)
 
 	runCreateCmd.Flags().String("challenge-pack-version", "", "Challenge pack version ID (optional in a TTY; prompted when omitted)")
 	runCreateCmd.Flags().StringSlice("deployments", nil, "Agent deployment IDs (optional in a TTY; prompted when omitted)")
@@ -35,6 +37,20 @@ func init() {
 	runCreateCmd.Flags().Int("race-context-cadence", 0, "Override race-context cadence; minimum steps between standings injections, [1, 10]. 0 uses the backend default.")
 
 	runRankingCmd.Flags().String("sort-by", "", "Sort by: composite, correctness, reliability, latency, cost")
+	runFailuresCmd.Flags().String("agent", "", "Filter by run agent ID")
+	runFailuresCmd.Flags().String("severity", "", "Filter by severity: info, warning, or blocking")
+	runFailuresCmd.Flags().String("class", "", "Filter by failure class")
+	runFailuresCmd.Flags().String("evidence-tier", "", "Filter by evidence tier")
+	runFailuresCmd.Flags().String("cursor", "", "Pagination cursor")
+	runFailuresCmd.Flags().Int("limit", 0, "Maximum failures to return")
+
+	runPromoteFailureCmd.Flags().String("from-file", "", "JSON file with promotion payload")
+	runPromoteFailureCmd.Flags().String("run-agent", "", "Run agent ID")
+	runPromoteFailureCmd.Flags().String("suite", "", "Regression suite ID")
+	runPromoteFailureCmd.Flags().String("promotion-mode", "", "Promotion mode: full_executable or output_only")
+	runPromoteFailureCmd.Flags().String("title", "", "Regression case title")
+	runPromoteFailureCmd.Flags().String("failure-summary", "", "Failure summary")
+	runPromoteFailureCmd.Flags().String("severity", "", "Case severity: info, warning, or blocking")
 }
 
 var runCmd = &cobra.Command{
@@ -322,6 +338,114 @@ var runScorecardCmd = &cobra.Command{
 			return rc.Output.PrintRaw(scorecard)
 		}
 		renderRunAgentScorecard(rc, scorecard)
+		return nil
+	},
+}
+
+var runFailuresCmd = &cobra.Command{
+	Use:   "failures <runId>",
+	Short: "List failure review items for a run",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		wsID := RequireWorkspace(cmd)
+		q := url.Values{}
+		if v, _ := cmd.Flags().GetString("agent"); v != "" {
+			q.Set("agent_id", v)
+		}
+		if v, _ := cmd.Flags().GetString("severity"); v != "" {
+			q.Set("severity", v)
+		}
+		if v, _ := cmd.Flags().GetString("class"); v != "" {
+			q.Set("class", v)
+		}
+		if v, _ := cmd.Flags().GetString("evidence-tier"); v != "" {
+			q.Set("evidence_tier", v)
+		}
+		if v, _ := cmd.Flags().GetString("cursor"); v != "" {
+			q.Set("cursor", v)
+		}
+		if v, _ := cmd.Flags().GetInt("limit"); v > 0 {
+			q.Set("limit", fmt.Sprintf("%d", v))
+		}
+
+		resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+wsID+"/runs/"+args[0]+"/failures", q)
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+
+		var result struct {
+			Items      []map[string]any `json:"items"`
+			NextCursor string           `json:"next_cursor,omitempty"`
+		}
+		if err := resp.DecodeJSON(&result); err != nil {
+			return err
+		}
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(result)
+		}
+
+		cols := []output.Column{{Header: "Agent"}, {Header: "Challenge"}, {Header: "State"}, {Header: "Severity"}, {Header: "Class"}, {Header: "Promotable"}}
+		rows := make([][]string, len(result.Items))
+		for i, item := range result.Items {
+			rows[i] = []string{
+				str(item["run_agent_id"]),
+				mapString(item, "challenge_identity_id", "challenge_key"),
+				output.StatusColor(str(item["failure_state"])),
+				str(item["severity"]),
+				str(item["failure_class"]),
+				str(item["promotable"]),
+			}
+		}
+		rc.Output.PrintTable(cols, rows)
+		if result.NextCursor != "" {
+			rc.Output.PrintDetail("Next Cursor", result.NextCursor)
+		}
+		return nil
+	},
+}
+
+var runPromoteFailureCmd = &cobra.Command{
+	Use:   "promote-failure <runId> <challengeIdentityId>",
+	Short: "Promote a run failure into a regression case",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		wsID := RequireWorkspace(cmd)
+		body, err := loadBodyFromFileOrFlags(cmd)
+		if err != nil {
+			return err
+		}
+		setFlagIfChanged(cmd, body, "run-agent", "run_agent_id")
+		setFlagIfChanged(cmd, body, "suite", "suite_id")
+		setFlagIfChanged(cmd, body, "promotion-mode", "promotion_mode")
+		setFlagIfChanged(cmd, body, "title", "title")
+		setFlagIfChanged(cmd, body, "failure-summary", "failure_summary")
+		setFlagIfChanged(cmd, body, "severity", "severity")
+
+		resp, err := rc.Client.Post(cmd.Context(), "/v1/workspaces/"+wsID+"/runs/"+args[0]+"/failures/"+args[1]+"/promote", body)
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+
+		var result map[string]any
+		if err := resp.DecodeJSON(&result); err != nil {
+			return err
+		}
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(result)
+		}
+		if regressionCase := mapObject(result, "case"); regressionCase != nil {
+			rc.Output.PrintSuccess(fmt.Sprintf("Promoted failure to regression case %s", str(regressionCase["id"])))
+			return nil
+		}
+		rc.Output.PrintSuccess("Promoted failure")
 		return nil
 	},
 }

--- a/testing/codex-cli-surface-gaps.md
+++ b/testing/codex-cli-surface-gaps.md
@@ -1,0 +1,44 @@
+# codex/cli-surface-gaps - Test Contract
+
+## Functional Behavior
+- `agentclash artifact list` calls `GET /v1/workspaces/{workspaceID}/artifacts` and prints a table with artifact identity, type, size, creation time, and related run/run-agent IDs when available.
+- `agentclash release-gate list` calls `GET /v1/release-gates`, supports `--baseline` and `--candidate` query filters, and prints evaluated gate history with verdict, policy, reason, and generation time.
+- `agentclash regression-suite` exposes CLI access to the existing regression-suite API:
+  - `list` calls `GET /v1/workspaces/{workspaceID}/regression-suites`.
+  - `get <suiteId>` calls `GET /v1/workspaces/{workspaceID}/regression-suites/{suiteID}`.
+  - `create` accepts either `--from-file` JSON or flags and calls `POST /v1/workspaces/{workspaceID}/regression-suites`.
+  - `update <suiteId>` accepts either `--from-file` JSON or changed flags and calls `PATCH /v1/workspaces/{workspaceID}/regression-suites/{suiteID}`.
+  - `cases <suiteId>` calls `GET /v1/workspaces/{workspaceID}/regression-suites/{suiteID}/cases`.
+  - `case update <caseId>` accepts either `--from-file` JSON or changed flags and calls `PATCH /v1/workspaces/{workspaceID}/regression-cases/{caseID}`.
+- `agentclash run failures <runId>` calls `GET /v1/workspaces/{workspaceID}/runs/{runID}/failures` and forwards optional filter flags.
+- `agentclash run promote-failure <runId> <challengeIdentityId>` calls `POST /v1/workspaces/{workspaceID}/runs/{runID}/failures/{challengeIdentityID}/promote` with either `--from-file` JSON or changed flags.
+- All new commands preserve structured output with `--json` / `--output`, keep human tables concise, and use existing helpers/patterns.
+
+## Unit Tests
+- Add CLI command tests using `fakeAPI` for:
+  - `artifact list` endpoint and workspace behavior.
+  - `release-gate list` query forwarding.
+  - regression suite list/get/create/update/cases/case-update endpoints and payloads.
+  - run failures list filter forwarding and promote-failure payload.
+
+## Integration / Functional Tests
+- `go test ./cmd -run '(Artifact|ReleaseGate|Regression|RunFailure|PromoteFailure)' -count=1` passes.
+- `go test ./cmd -count=1` passes.
+
+## Smoke Tests
+- `go build ./...` passes from `cli/`.
+- `go vet ./...` passes from `cli/`.
+
+## E2E Tests
+- N/A - this CLI surface patch is covered by command-level fake API tests. Live staging smoke remains optional because it requires credentials and seeded workspace data.
+
+## Manual / cURL Tests
+```bash
+cd cli
+go run . artifact list --workspace ws_123 --json
+go run . release-gate list --baseline run_base --candidate run_candidate --json
+go run . regression-suite list --workspace ws_123 --json
+go run . run failures run_123 --workspace ws_123 --json
+```
+
+Expected: each command calls the documented backend endpoint, emits valid JSON under `--json`, and returns backend errors without swallowing them.


### PR DESCRIPTION
## Summary

This PR fills CLI gaps for backend/UI surfaces that already exist in AgentClash:

- Adds `agentclash artifact list`.
- Adds `agentclash release-gate list`.
- Adds `agentclash regression-suite list|get|create|update|cases`.
- Adds `agentclash regression-suite case update`.
- Adds `agentclash run failures`.
- Adds `agentclash run promote-failure`.
- Adds fake API command tests and a review-checkpoint contract at `testing/codex-cli-surface-gaps.md`.

## Product Flow

```mermaid
flowchart LR
  User[CLI user / coding agent] --> CLI[agentclash CLI]
  CLI --> API[AgentClash API]
  API --> DB[(Postgres)]
  API --> Storage[(Artifact storage)]

  CLI --> Artifacts[artifact list]
  CLI --> Failures[run failures]
  CLI --> Regression[regression-suite commands]
  CLI --> Gates[release-gate list]

  Failures --> Regression
  Regression --> FutureRuns[future regression eval runs]
  Gates --> CI[CI / promotion decisions]
```

The CLI now exposes more of the existing evaluation loop from the terminal: inspect artifacts, inspect failures, promote failures into regression coverage, inspect regression suites/cases, and read evaluated release gates.

## Code Shape

```mermaid
flowchart TD
  Cobra[Cobra commands] --> Context[RunContext]
  Context --> Client[internal/api Client]
  Client --> ExistingRoutes[Existing backend routes]

  subgraph New CLI commands
    A[artifact list]
    R[regression-suite *]
    F[run failures]
    P[run promote-failure]
    G[release-gate list]
  end

  A --> Client
  R --> Client
  F --> Client
  P --> Client
  G --> Client

  ExistingRoutes --> JSON[JSON response]
  JSON --> Structured[--json / --output]
  JSON --> Tables[human tables]
```

## Architectural Decision

No backend changes were made. The backend and UI already had these surfaces; the missing piece was CLI access.

I kept the CLI implementation as thin endpoint adapters because that is the existing CLI pattern in this repo:

- The CLI resolves workspace/API/auth context.
- The CLI maps flags to the existing JSON/query shapes.
- The backend remains the source of truth for authorization and domain validation.
- Structured output preserves backend payloads for automation.
- Human output uses compact tables for quick terminal inspection.

```mermaid
sequenceDiagram
  participant U as User / agent
  participant C as CLI command
  participant A as API route
  participant D as Domain service

  U->>C: agentclash run failures <runId>
  C->>C: resolve workspace + flags
  C->>A: GET /v1/workspaces/{ws}/runs/{run}/failures
  A->>D: authorize + read failure review model
  D-->>A: failure review items
  A-->>C: JSON envelope
  C-->>U: JSON or table output
```

## Review Checkpoint

- Contract: `testing/codex-cli-surface-gaps.md`
- Checkpoint verdict: ready

## Tests

Local checks:

- `go test ./cmd -run '(Artifact|ReleaseGate|Regression|RunFailures|RunPromoteFailure)' -count=1` - passed
- `go test ./cmd -count=1` - passed
- `go build ./...` - passed
- `go test ./...` - passed
- `go vet ./...` - passed
- `go test -short -race -count=1 ./...` - passed

Production API smoke checks with local CLI, read-only only:

- `AGENTCLASH_API_URL=https://api.agentclash.dev go run . auth status --json` - passed; authenticated workspace available
- `AGENTCLASH_API_URL=https://api.agentclash.dev go run . artifact list --workspace <workspace> --json` - passed; returned artifact items
- `AGENTCLASH_API_URL=https://api.agentclash.dev go run . regression-suite list --workspace <workspace> --json` - passed; returned one regression suite
- `AGENTCLASH_API_URL=https://api.agentclash.dev go run . regression-suite cases <suite> --workspace <workspace> --json` - passed; returned one regression case
- `AGENTCLASH_API_URL=https://api.agentclash.dev go run . run failures <run> --workspace <workspace> --json` - passed; returned one failure review item
- `AGENTCLASH_API_URL=https://api.agentclash.dev go run . release-gate list --baseline <run> --candidate <run> --workspace <workspace> --json` - passed; returned a valid empty `release_gates` array

I did not run mutating production smoke checks for `create`, `update`, or `promote-failure`; those are covered by fake API tests so we do not alter real workspace data.
