### PR TITLE
[codex] Add frontend billing UX

### DIFF
--- a/backend/internal/api/billing.go
+++ b/backend/internal/api/billing.go
@@ -25,6 +25,7 @@ import (
 type BillingService interface {
 	ListPlans(ctx context.Context, caller Caller) (ListBillingPlansResult, error)
 	GetOrganizationBilling(ctx context.Context, caller Caller, orgID uuid.UUID) (repository.BillingOverview, error)
+	StartTrial(ctx context.Context, caller Caller, orgID uuid.UUID, input StartBillingTrialInput) (repository.BillingOverview, error)
 	CreateCheckout(ctx context.Context, caller Caller, orgID uuid.UUID, input CreateBillingCheckoutInput) (CreateBillingCheckoutResult, error)
 	CreatePortal(ctx context.Context, caller Caller, orgID uuid.UUID) (CreateBillingPortalResult, error)
 	GetWorkspaceEntitlements(ctx context.Context, caller Caller, workspaceID uuid.UUID) (WorkspaceEntitlementsResult, error)
@@ -106,6 +107,11 @@ type CreateBillingCheckoutInput struct {
 	ReturnURL     string `json:"return_url"`
 }
 
+type StartBillingTrialInput struct {
+	PlanKey       string `json:"plan_key"`
+	BillingPeriod string `json:"billing_period"`
+}
+
 type CreateBillingCheckoutResult struct {
 	CheckoutIntentID uuid.UUID `json:"checkout_intent_id"`
 	CheckoutURL      string    `json:"checkout_url"`
@@ -147,6 +153,42 @@ func (m *BillingManager) ListPlans(_ context.Context, _ Caller) (ListBillingPlan
 
 func (m *BillingManager) GetOrganizationBilling(ctx context.Context, caller Caller, orgID uuid.UUID) (repository.BillingOverview, error) {
 	if err := m.orgAuthz.AuthorizeOrganizationAdmin(ctx, caller, orgID); err != nil {
+		return repository.BillingOverview{}, err
+	}
+	return m.repo.GetBillingOverview(ctx, orgID)
+}
+
+func (m *BillingManager) StartTrial(ctx context.Context, caller Caller, orgID uuid.UUID, input StartBillingTrialInput) (repository.BillingOverview, error) {
+	if err := m.orgAuthz.AuthorizeOrganizationAdmin(ctx, caller, orgID); err != nil {
+		return repository.BillingOverview{}, err
+	}
+	current, err := m.repo.GetOrganizationEntitlements(ctx, orgID)
+	if err != nil {
+		return repository.BillingOverview{}, err
+	}
+	if current.PlanKey != billingpkg.PlanFree {
+		return repository.BillingOverview{}, validationError("trial_not_available", "trial is only available from the Free plan")
+	}
+	planKey := strings.TrimSpace(input.PlanKey)
+	if planKey != billingpkg.PlanPro && planKey != billingpkg.PlanTeam {
+		return repository.BillingOverview{}, validationError("invalid_plan_key", "plan_key must be pro or team")
+	}
+	plan, _ := billingpkg.PlanByKey(planKey)
+	period := strings.TrimSpace(input.BillingPeriod)
+	if period == "" {
+		period = billingpkg.PeriodMonthly
+	}
+	if err := billingpkg.ValidateBillingPeriod(plan, period); err != nil {
+		return repository.BillingOverview{}, validationError("invalid_billing_period", err.Error())
+	}
+	seatQuantity := plan.DefaultSeats
+	if seatQuantity < plan.MinimumSeats {
+		seatQuantity = plan.MinimumSeats
+	}
+	expiresAt := m.now().UTC().Add(45 * 24 * time.Hour)
+	entitlements := billingpkg.MaterializeEntitlements(plan, period, seatQuantity, billingpkg.EntitlementStatusTrialing)
+	entitlements.ExpiresAt = &expiresAt
+	if err := m.repo.UpsertOrganizationEntitlements(ctx, orgID, entitlements, nil, &expiresAt); err != nil {
 		return repository.BillingOverview{}, err
 	}
 	return m.repo.GetBillingOverview(ctx, orgID)
@@ -840,6 +882,7 @@ func registerBillingRoutes(router chi.Router, logger *slog.Logger, service Billi
 	}
 	router.Get("/billing/plans", listBillingPlansHandler(logger, service))
 	router.Get("/organizations/{organizationID}/billing", getOrganizationBillingHandler(logger, service))
+	router.Post("/organizations/{organizationID}/billing/trial", startBillingTrialHandler(logger, service))
 	router.Post("/organizations/{organizationID}/billing/checkout", createBillingCheckoutHandler(logger, service))
 	router.Post("/organizations/{organizationID}/billing/portal", createBillingPortalHandler(logger, service))
 	router.Get("/workspaces/{workspaceID}/entitlements", getWorkspaceEntitlementsHandler(logger, service))
@@ -880,6 +923,32 @@ func getOrganizationBillingHandler(logger *slog.Logger, service BillingService) 
 			return
 		}
 		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func startBillingTrialHandler(logger *slog.Logger, service BillingService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		orgID, err := uuid.Parse(chi.URLParam(r, "organizationID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_organization_id", "organization ID is malformed")
+			return
+		}
+		var input StartBillingTrialInput
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&input); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request_body", "request body must be valid JSON")
+			return
+		}
+		result, err := service.StartTrial(r.Context(), caller, orgID, input)
+		if err != nil {
+			writeBillingServiceError(w, logger, err)
+			return
+		}
+		writeJSON(w, http.StatusCreated, result)
 	}
 }
 
@@ -977,6 +1046,9 @@ func (noopBillingService) ListPlans(context.Context, Caller) (ListBillingPlansRe
 	return ListBillingPlansResult{Items: billingpkg.Catalog()}, nil
 }
 func (noopBillingService) GetOrganizationBilling(context.Context, Caller, uuid.UUID) (repository.BillingOverview, error) {
+	return repository.BillingOverview{}, errors.New("billing service is not configured")
+}
+func (noopBillingService) StartTrial(context.Context, Caller, uuid.UUID, StartBillingTrialInput) (repository.BillingOverview, error) {
 	return repository.BillingOverview{}, errors.New("billing service is not configured")
 }
 func (noopBillingService) CreateCheckout(context.Context, Caller, uuid.UUID, CreateBillingCheckoutInput) (CreateBillingCheckoutResult, error) {

--- a/backend/internal/api/billing_test.go
+++ b/backend/internal/api/billing_test.go
@@ -311,6 +311,67 @@ func TestCreateBillingCheckoutHandlerDecodesSnakeCaseJSON(t *testing.T) {
 	}
 }
 
+func TestBillingManagerStartTrialMaterializesSelectedPlan(t *testing.T) {
+	workspaceID := uuid.New()
+	repo := newFakeBillingRepository(workspaceID)
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	manager := NewBillingManager(NewCallerOrganizationAuthorizer(), NewCallerWorkspaceAuthorizer(), repo, BillingManagerConfig{
+		WebhookSecret: "secret",
+	})
+	manager.now = func() time.Time { return now }
+	caller := Caller{
+		UserID: uuid.New(),
+		OrganizationMemberships: map[uuid.UUID]OrganizationMembership{
+			repo.orgID: {OrganizationID: repo.orgID, Role: "org_admin"},
+		},
+	}
+
+	overview, err := manager.StartTrial(context.Background(), caller, repo.orgID, StartBillingTrialInput{
+		PlanKey:       billingpkg.PlanTeam,
+		BillingPeriod: billingpkg.PeriodMonthly,
+	})
+	if err != nil {
+		t.Fatalf("StartTrial returned error: %v", err)
+	}
+	if overview.Entitlements.PlanKey != billingpkg.PlanTeam {
+		t.Fatalf("plan = %q, want team", overview.Entitlements.PlanKey)
+	}
+	if overview.Entitlements.Status != billingpkg.EntitlementStatusTrialing {
+		t.Fatalf("status = %q, want trialing", overview.Entitlements.Status)
+	}
+	if overview.Entitlements.ExpiresAt == nil || !overview.Entitlements.ExpiresAt.Equal(now.Add(45*24*time.Hour)) {
+		t.Fatalf("expires_at = %v, want %v", overview.Entitlements.ExpiresAt, now.Add(45*24*time.Hour))
+	}
+	assertIntPtr(t, "team trial model limit", overview.Entitlements.MaxModelsPerRace, 12)
+}
+
+func TestBillingManagerStartTrialRejectsExistingPaidPlan(t *testing.T) {
+	workspaceID := uuid.New()
+	repo := newFakeBillingRepository(workspaceID)
+	repo.entitlements = billingpkg.MaterializeEntitlements(billingpkg.MustPlan(billingpkg.PlanPro), billingpkg.PeriodMonthly, 5, billingpkg.EntitlementStatusTrialing)
+	manager := NewBillingManager(NewCallerOrganizationAuthorizer(), NewCallerWorkspaceAuthorizer(), repo, BillingManagerConfig{
+		WebhookSecret: "secret",
+	})
+	caller := Caller{
+		UserID: uuid.New(),
+		OrganizationMemberships: map[uuid.UUID]OrganizationMembership{
+			repo.orgID: {OrganizationID: repo.orgID, Role: "org_admin"},
+		},
+	}
+
+	_, err := manager.StartTrial(context.Background(), caller, repo.orgID, StartBillingTrialInput{
+		PlanKey:       billingpkg.PlanTeam,
+		BillingPeriod: billingpkg.PeriodMonthly,
+	})
+	var validationErr validationErrorEnvelope
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error = %v, want validation error", err)
+	}
+	if validationErr.Code != "trial_not_available" {
+		t.Fatalf("code = %q, want trial_not_available", validationErr.Code)
+	}
+}
+
 func TestBillingManagerCreateCheckoutUsesDodoAPIWhenConfigured(t *testing.T) {
 	workspaceID := uuid.New()
 	repo := newFakeBillingRepository(workspaceID)

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -768,6 +768,38 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /v1/organizations/{organizationID}/billing/trial:
+    post:
+      operationId: startBillingTrial
+      tags: [Billing]
+      summary: Start a 45-day billing trial
+      description: Requires org_admin role. Only Free organizations can start a trial.
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/OrganizationID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/StartBillingTrialRequest"
+      responses:
+        "201":
+          description: Billing trial started
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BillingOverviewResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
   /v1/organizations/{organizationID}/billing/checkout:
     post:
       operationId: createBillingCheckout
@@ -4699,6 +4731,18 @@ components:
           $ref: "#/components/schemas/BillingEntitlements"
         subscription:
           $ref: "#/components/schemas/BillingSubscriptionResponse"
+
+    StartBillingTrialRequest:
+      type: object
+      required: [plan_key]
+      properties:
+        plan_key:
+          type: string
+          enum: [pro, team]
+        billing_period:
+          type: string
+          enum: [monthly, yearly]
+          default: monthly
 
     CreateBillingCheckoutRequest:
       type: object

--- a/web/src/app/(org)/orgs/[orgSlug]/billing/billing-settings-client.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/billing/billing-settings-client.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import { useApiQuery } from "@/lib/api/swr";
+import type {
+  BillingOverviewResponse,
+  BillingPlan,
+  BillingPlansResponse,
+  CreateBillingCheckoutResponse,
+  CreateBillingPortalResponse,
+} from "@/lib/api/types";
+import {
+  billingStatusLabel,
+  formatBillingDate,
+  formatBillingLimit,
+  isFreeActive,
+  planLabel,
+} from "@/lib/billing";
+import { useOrgContext } from "../org-context";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Loader2, RefreshCw } from "lucide-react";
+import { toast } from "sonner";
+
+function LimitRow({ label, value }: { label: string; value?: number | null }) {
+  return (
+    <div className="flex items-center justify-between gap-4 rounded-md border border-white/[0.06] px-3 py-2">
+      <span className="text-sm text-muted-foreground">{label}</span>
+      <span className="text-sm font-medium">{formatBillingLimit(value)}</span>
+    </div>
+  );
+}
+
+function PlanCard({
+  plan,
+  currentPlan,
+  trialAvailable,
+  busyAction,
+  onStartTrial,
+  onCheckout,
+}: {
+  plan: BillingPlan;
+  currentPlan: string;
+  trialAvailable: boolean;
+  busyAction: string | null;
+  onStartTrial: (plan: BillingPlan) => void;
+  onCheckout: (plan: BillingPlan) => void;
+}) {
+  const isCurrent = plan.key === currentPlan;
+  const busy = busyAction === plan.key;
+  const canTrial = trialAvailable && (plan.key === "pro" || plan.key === "team");
+  const canCheckout = plan.key !== "free" && plan.key !== "enterprise";
+
+  return (
+    <div className="flex min-h-56 flex-col rounded-lg border border-white/[0.08] bg-white/[0.02] p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold">{plan.display_name}</h3>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {plan.key === "free"
+              ? "Stay on Free while you evaluate."
+              : plan.key === "enterprise"
+                ? "Custom limits and billing terms."
+                : "Start a 45-day trial or create checkout."}
+          </p>
+        </div>
+        {isCurrent && <Badge variant="secondary">Current</Badge>}
+      </div>
+
+      <div className="mt-4 space-y-2">
+        <LimitRow label="Seats" value={plan.limits.seats.value} />
+        <LimitRow
+          label="Runs / workspace"
+          value={plan.limits.races_per_workspace_month.value}
+        />
+        <LimitRow
+          label="Models / run"
+          value={plan.limits.max_models_per_race.value}
+        />
+      </div>
+
+      <div className="mt-auto flex flex-wrap gap-2 pt-4">
+        {canTrial && (
+          <Button
+            size="sm"
+            disabled={busy}
+            onClick={() => onStartTrial(plan)}
+          >
+            {busy ? <Loader2 className="size-4 animate-spin" /> : "Start Trial"}
+          </Button>
+        )}
+        {canCheckout && (
+          <Button
+            size="sm"
+            variant={canTrial ? "outline" : "default"}
+            disabled={busy}
+            onClick={() => onCheckout(plan)}
+          >
+            Checkout
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function BillingSettingsClient() {
+  const { orgId } = useOrgContext();
+  const { getAccessToken } = useAccessToken();
+  const { data: overview, error, isLoading, mutate } =
+    useApiQuery<BillingOverviewResponse>(`/v1/organizations/${orgId}/billing`);
+  const { data: plansData } = useApiQuery<BillingPlansResponse>("/v1/billing/plans");
+  const [busyAction, setBusyAction] = useState<string | null>(null);
+
+  const plans = useMemo(
+    () => (plansData?.items ?? []).filter((plan) => plan.key !== "enterprise"),
+    [plansData],
+  );
+  const entitlements = overview?.entitlements;
+  const trialAvailable = isFreeActive(entitlements);
+
+  async function startTrial(plan: BillingPlan) {
+    setBusyAction(plan.key);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token ?? undefined);
+      await api.post<BillingOverviewResponse>(
+        `/v1/organizations/${orgId}/billing/trial`,
+        {
+          plan_key: plan.key,
+          billing_period: "monthly",
+        },
+      );
+      toast.success(`${plan.display_name} trial started`);
+      await mutate();
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Failed to start trial");
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  async function createCheckout(plan: BillingPlan) {
+    setBusyAction(plan.key);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token ?? undefined);
+      const result = await api.post<CreateBillingCheckoutResponse>(
+        `/v1/organizations/${orgId}/billing/checkout`,
+        {
+          plan_key: plan.key,
+          billing_period: "monthly",
+          seat_quantity: Math.max(plan.minimum_seats, plan.default_seats),
+          return_url: window.location.href,
+        },
+      );
+      window.location.assign(result.checkout_url);
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Failed to create checkout");
+      setBusyAction(null);
+    }
+  }
+
+  async function openPortal() {
+    setBusyAction("portal");
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token ?? undefined);
+      const result = await api.post<CreateBillingPortalResponse>(
+        `/v1/organizations/${orgId}/billing/portal`,
+      );
+      window.location.assign(result.portal_url);
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Failed to open billing portal");
+      setBusyAction(null);
+    }
+  }
+
+  if (isLoading && !overview) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="size-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error || !overview || !entitlements) {
+    return (
+      <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-4 text-sm text-destructive">
+        Failed to load billing.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-lg font-semibold tracking-tight">Billing</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Review your plan, trial status, and usage limits.
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={busyAction === "portal"}
+          onClick={openPortal}
+        >
+          {busyAction === "portal" ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            "Manage Billing"
+          )}
+        </Button>
+      </div>
+
+      <section className="rounded-lg border border-white/[0.08] bg-white/[0.02] p-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-xs font-medium uppercase text-muted-foreground">
+              Current plan
+            </p>
+            <div className="mt-1 flex items-center gap-2">
+              <h2 className="text-xl font-semibold">
+                {planLabel(entitlements.plan_key)}
+              </h2>
+              <Badge
+                variant={
+                  entitlements.status === "expired" ||
+                  entitlements.status === "inactive"
+                    ? "destructive"
+                    : "secondary"
+                }
+              >
+                {billingStatusLabel(entitlements.status)}
+              </Badge>
+            </div>
+          </div>
+          {entitlements.expires_at && (
+            <div className="text-right text-sm">
+              <p className="text-muted-foreground">Trial ends</p>
+              <p className="font-medium">
+                {formatBillingDate(entitlements.expires_at)}
+              </p>
+            </div>
+          )}
+        </div>
+        <div className="mt-4 grid gap-2 sm:grid-cols-2">
+          <LimitRow label="Seats" value={entitlements.seats_limit} />
+          <LimitRow label="Workspaces" value={entitlements.workspaces_limit} />
+          <LimitRow
+            label="Runs / workspace / month"
+            value={entitlements.races_per_workspace_month}
+          />
+          <LimitRow
+            label="Concurrent runs"
+            value={entitlements.concurrent_races}
+          />
+          <LimitRow
+            label="Models / run"
+            value={entitlements.max_models_per_race}
+          />
+          <LimitRow
+            label="Replay retention days"
+            value={entitlements.replay_retention_days}
+          />
+        </div>
+      </section>
+
+      {trialAvailable && (
+        <section className="rounded-lg border border-primary/20 bg-primary/5 p-4">
+          <div className="flex items-start gap-3">
+            <RefreshCw className="mt-0.5 size-4 text-primary" />
+            <div>
+              <h2 className="text-sm font-semibold">Try a paid plan for 45 days</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Pick the plan you want to evaluate. The trial grants only that
+                plan&apos;s limits and expires automatically after 45 days.
+              </p>
+            </div>
+          </div>
+        </section>
+      )}
+
+      <section>
+        <h2 className="mb-3 text-sm font-semibold">Plans</h2>
+        <div className="grid gap-3 lg:grid-cols-3">
+          {plans.map((plan) => (
+            <PlanCard
+              key={plan.key}
+              plan={plan}
+              currentPlan={entitlements.plan_key}
+              trialAvailable={trialAvailable}
+              busyAction={busyAction}
+              onStartTrial={startTrial}
+              onCheckout={createCheckout}
+            />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web/src/app/(org)/orgs/[orgSlug]/billing/page.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/billing/page.tsx
@@ -1,0 +1,5 @@
+import { BillingSettingsClient } from "./billing-settings-client";
+
+export default function OrgBillingPage() {
+  return <BillingSettingsClient />;
+}

--- a/web/src/app/(org)/orgs/[orgSlug]/layout.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/layout.tsx
@@ -5,6 +5,7 @@ import { getRequiredServerAuth, toInitialAuth } from "@/lib/auth/server";
 import type { UserMeResponse, SessionResponse } from "@/lib/api/types";
 import { OrgSettingsSidebar } from "./org-settings-sidebar";
 import { OrgProvider } from "./org-context";
+import { TrialUpgradePrompt } from "@/components/billing/trial-upgrade-prompt";
 
 export default async function OrgLayout({
   children,
@@ -52,6 +53,11 @@ export default async function OrgLayout({
             orgSlug={orgSlug}
             orgName={org.name}
             isAdmin={isAdmin}
+          />
+          <TrialUpgradePrompt
+            orgId={org.id}
+            orgSlug={org.slug}
+            isOrgAdmin={isAdmin}
           />
           <main className="flex-1 overflow-y-auto p-6 max-w-4xl">
             {children}

--- a/web/src/app/(org)/orgs/[orgSlug]/org-settings-sidebar.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/org-settings-sidebar.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
-import { Settings2, Users, Layers, ArrowLeft } from "lucide-react";
+import { Settings2, Users, Layers, ArrowLeft, CreditCard } from "lucide-react";
 
 interface OrgSettingsSidebarProps {
   orgSlug: string;
@@ -18,6 +18,11 @@ const navItems = (orgSlug: string, isAdmin: boolean) => [
           label: "General",
           href: `/orgs/${orgSlug}/settings`,
           icon: Settings2,
+        },
+        {
+          label: "Billing",
+          href: `/orgs/${orgSlug}/billing`,
+          icon: CreditCard,
         },
       ]
     : []),

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/publish-pack-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/publish-pack-dialog.tsx
@@ -5,6 +5,7 @@ import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { createApiClient } from "@/lib/api/client";
 import { useApiMutator } from "@/lib/api/swr";
 import { ApiError } from "@/lib/api/errors";
+import { billingGateToastMessage } from "@/lib/billing";
 import { workspaceResourceKeys } from "@/lib/workspace-resource";
 import type {
   ValidateChallengePackResponse,
@@ -107,7 +108,7 @@ export function PublishPackDialog({ workspaceId }: PublishPackDialogProps) {
       return result;
     } catch (err) {
       if (err instanceof ApiError) {
-        toast.error(err.message);
+        toast.error(billingGateToastMessage(err) ?? err.message);
       } else {
         toast.error("Failed to publish challenge pack");
       }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/layout.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/layout.tsx
@@ -2,6 +2,8 @@ import { AuthenticatedAppProviders } from "@/app/providers";
 import { getRequiredInitialAuth, getWorkspaceShellData } from "@/lib/auth/server";
 import { Sidebar } from "@/components/app-shell/sidebar";
 import { TopBar } from "@/components/app-shell/top-bar";
+import { TrialUpgradePrompt } from "@/components/billing/trial-upgrade-prompt";
+import { WorkspaceBillingBanner } from "@/components/billing/workspace-billing-banner";
 
 export default async function WorkspaceLayout({
   children,
@@ -17,7 +19,9 @@ export default async function WorkspaceLayout({
     userMe,
     hasMembership,
     hasOrgAccess,
+    orgId,
     orgName,
+    orgRole,
     orgSlug,
   } = await getWorkspaceShellData(workspaceId);
 
@@ -54,6 +58,12 @@ export default async function WorkspaceLayout({
             orgName={orgName}
             orgSlug={orgSlug}
           />
+          <TrialUpgradePrompt
+            orgId={orgId}
+            orgSlug={orgSlug}
+            isOrgAdmin={orgRole === "org_admin"}
+          />
+          <WorkspaceBillingBanner workspaceId={workspaceId} orgSlug={orgSlug} />
           <main className="flex-1 overflow-y-auto p-6">{children}</main>
         </div>
       </div>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-eval-session-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-eval-session-dialog.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import { createApiClient } from "@/lib/api/client";
 import { useApiMutator } from "@/lib/api/swr";
 import { ApiError } from "@/lib/api/errors";
+import { billingGateToastMessage } from "@/lib/billing";
 import { workspaceMutationKeys, workspaceResourceKeys } from "@/lib/workspace-resource";
 import type {
   AgentDeployment,
@@ -364,7 +365,8 @@ export function CreateEvalSessionDialog({
       router.push(`/workspaces/${workspaceId}/eval-sessions/${body.eval_session.id}`);
     } catch (err) {
       toast.error(
-        err instanceof ApiError ? err.message : "Failed to create eval session",
+        billingGateToastMessage(err) ??
+          (err instanceof ApiError ? err.message : "Failed to create eval session"),
       );
     } finally {
       setSubmitting(false);

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
@@ -6,6 +6,7 @@ import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { createApiClient } from "@/lib/api/client";
 import { useApiMutator } from "@/lib/api/swr";
 import { ApiError } from "@/lib/api/errors";
+import { billingGateToastMessage } from "@/lib/billing";
 import { workspaceMutationKeys, workspaceResourceKeys } from "@/lib/workspace-resource";
 import type {
   AgentDeployment,
@@ -323,7 +324,8 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
       router.push(`/workspaces/${workspaceId}/runs/${result.id}`);
     } catch (err) {
       toast.error(
-        err instanceof ApiError ? err.message : "Failed to create run",
+        billingGateToastMessage(err) ??
+          (err instanceof ApiError ? err.message : "Failed to create run"),
       );
     } finally {
       setSubmitting(false);

--- a/web/src/components/billing/trial-upgrade-prompt.tsx
+++ b/web/src/components/billing/trial-upgrade-prompt.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import { useApiQuery } from "@/lib/api/swr";
+import type {
+  BillingOverviewResponse,
+  BillingPlan,
+  BillingPlansResponse,
+} from "@/lib/api/types";
+import { isFreeActive } from "@/lib/billing";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+interface TrialUpgradePromptProps {
+  orgId?: string;
+  orgSlug?: string;
+  isOrgAdmin?: boolean;
+}
+
+function storageKey(orgId: string) {
+  return `agentclash:billing-trial-prompt-dismissed:${orgId}`;
+}
+
+export function TrialUpgradePrompt({
+  orgId,
+  orgSlug,
+  isOrgAdmin = false,
+}: TrialUpgradePromptProps) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { getAccessToken } = useAccessToken();
+  const [dismissed, setDismissed] = useState(true);
+  const [busyPlan, setBusyPlan] = useState<string | null>(null);
+  const shouldFetch = Boolean(orgId && isOrgAdmin);
+  const { data: overview, mutate } = useApiQuery<BillingOverviewResponse>(
+    shouldFetch ? `/v1/organizations/${orgId}/billing` : null,
+  );
+  const { data: plansData } = useApiQuery<BillingPlansResponse>(
+    shouldFetch ? "/v1/billing/plans" : null,
+  );
+
+  useEffect(() => {
+    if (!orgId || !isOrgAdmin) return;
+    setDismissed(window.localStorage.getItem(storageKey(orgId)) === "true");
+  }, [isOrgAdmin, orgId]);
+
+  const trialPlans = useMemo(
+    () => (plansData?.items ?? []).filter((plan) => plan.key === "pro" || plan.key === "team"),
+    [plansData],
+  );
+  const onBillingPage = pathname.includes("/billing");
+  const open =
+    Boolean(orgId && isOrgAdmin) &&
+    !dismissed &&
+    !onBillingPage &&
+    isFreeActive(overview?.entitlements);
+
+  function dismiss() {
+    if (orgId) window.localStorage.setItem(storageKey(orgId), "true");
+    setDismissed(true);
+  }
+
+  async function startTrial(plan: BillingPlan) {
+    if (!orgId) return;
+    setBusyPlan(plan.key);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token ?? undefined);
+      await api.post<BillingOverviewResponse>(
+        `/v1/organizations/${orgId}/billing/trial`,
+        { plan_key: plan.key, billing_period: "monthly" },
+      );
+      toast.success(`${plan.display_name} trial started`);
+      dismiss();
+      await mutate();
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Failed to start trial");
+    } finally {
+      setBusyPlan(null);
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) dismiss();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Try AgentClash with higher limits</DialogTitle>
+          <DialogDescription>
+            You are on Free. You can keep using Free, or start a 45-day trial
+            for the plan you want to evaluate.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-2">
+          {trialPlans.map((plan) => (
+            <button
+              key={plan.key}
+              type="button"
+              disabled={Boolean(busyPlan)}
+              onClick={() => startTrial(plan)}
+              className="rounded-lg border border-white/[0.08] bg-white/[0.03] p-3 text-left transition-colors hover:bg-white/[0.06] disabled:opacity-60"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-sm font-medium">
+                  Start {plan.display_name} trial
+                </span>
+                {busyPlan === plan.key && (
+                  <Loader2 className="size-4 animate-spin" />
+                )}
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {plan.limits.max_models_per_race.value ?? "Unlimited"} models
+                per run, {plan.limits.concurrent_races.value ?? "unlimited"}{" "}
+                concurrent runs.
+              </p>
+            </button>
+          ))}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={dismiss} disabled={Boolean(busyPlan)}>
+            Keep Free
+          </Button>
+          {orgSlug && (
+            <Button
+              variant="secondary"
+              disabled={Boolean(busyPlan)}
+              onClick={() => {
+                dismiss();
+                router.push(`/orgs/${orgSlug}/billing`);
+              }}
+            >
+              View Plans
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/billing/workspace-billing-banner.tsx
+++ b/web/src/components/billing/workspace-billing-banner.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import Link from "next/link";
+import { useApiQuery } from "@/lib/api/swr";
+import type { WorkspaceEntitlementsResponse } from "@/lib/api/types";
+import {
+  billingStatusLabel,
+  formatBillingDate,
+  formatBillingLimit,
+  planLabel,
+} from "@/lib/billing";
+import { Badge } from "@/components/ui/badge";
+
+export function WorkspaceBillingBanner({
+  workspaceId,
+  orgSlug,
+}: {
+  workspaceId: string;
+  orgSlug?: string;
+}) {
+  const { data } = useApiQuery<WorkspaceEntitlementsResponse>(
+    `/v1/workspaces/${workspaceId}/entitlements`,
+  );
+  const entitlements = data?.entitlements;
+  if (!entitlements) return null;
+
+  const shouldShow =
+    entitlements.plan_key === "free" ||
+    entitlements.status === "trialing" ||
+    entitlements.status === "expired" ||
+    entitlements.status === "inactive";
+
+  if (!shouldShow) return null;
+
+  const usage = data?.usage;
+  const limit = entitlements.races_per_workspace_month;
+  const billingHref = orgSlug ? `/orgs/${orgSlug}/billing` : undefined;
+
+  return (
+    <div className="border-b border-white/[0.06] bg-white/[0.025] px-4 py-2">
+      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+        <Badge variant={entitlements.status === "expired" ? "destructive" : "secondary"}>
+          {planLabel(entitlements.plan_key)} {billingStatusLabel(entitlements.status)}
+        </Badge>
+        {usage && (
+          <span>
+            {usage.race_count} / {formatBillingLimit(limit)} runs used this month
+          </span>
+        )}
+        {entitlements.expires_at && (
+          <span>Trial ends {formatBillingDate(entitlements.expires_at)}</span>
+        )}
+        {billingHref && (
+          <Link
+            href={billingHref}
+            className="ml-auto font-medium text-foreground underline underline-offset-4"
+          >
+            Billing
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/api/__tests__/client.test.ts
+++ b/web/src/lib/api/__tests__/client.test.ts
@@ -118,6 +118,40 @@ describe("createApiClient", () => {
     }
   });
 
+  it("preserves billing gate error metadata", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          error: {
+            code: "quota_exceeded",
+            message: "quota exhausted",
+            plan_key: "free",
+            upgrade_target: "pro",
+            limit: 25,
+            used: 25,
+            remaining: 0,
+            reset_at: "2026-05-01T00:00:00Z",
+          },
+        },
+        402,
+      ),
+    );
+
+    const api = createApiClient("token");
+
+    await expect(api.post("/v1/runs", {})).rejects.toMatchObject({
+      name: "ApiError",
+      status: 402,
+      code: "quota_exceeded",
+      planKey: "free",
+      upgradeTarget: "pro",
+      limit: 25,
+      used: 25,
+      remaining: 0,
+      resetAt: "2026-05-01T00:00:00Z",
+    });
+  });
+
   it("throws ApiError on non-JSON error response", async () => {
     mockFetch.mockResolvedValueOnce(
       new Response("Internal Server Error", { status: 500 }),

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -60,7 +60,15 @@ function buildUrl(
 async function parseErrorResponse(res: Response): Promise<ApiError> {
   try {
     const body = (await res.json()) as ApiErrorResponse;
-    return new ApiError(res.status, body.error.code, body.error.message);
+    return new ApiError(res.status, body.error.code, body.error.message, {
+      planKey: body.error.plan_key,
+      upgradeTarget: body.error.upgrade_target,
+      limit: body.error.limit,
+      used: body.error.used,
+      remaining: body.error.remaining,
+      resetAt: body.error.reset_at,
+      expiresAt: body.error.expires_at,
+    });
   } catch {
     return new ApiError(res.status, "unknown", res.statusText || "Request failed");
   }

--- a/web/src/lib/api/errors.ts
+++ b/web/src/lib/api/errors.ts
@@ -5,12 +5,39 @@
 export class ApiError extends Error {
   readonly code: string;
   readonly status: number;
+  readonly planKey?: string;
+  readonly upgradeTarget?: string;
+  readonly limit?: number | null;
+  readonly used?: number;
+  readonly remaining?: number | null;
+  readonly resetAt?: string;
+  readonly expiresAt?: string;
 
-  constructor(status: number, code: string, message: string) {
+  constructor(
+    status: number,
+    code: string,
+    message: string,
+    details: {
+      planKey?: string;
+      upgradeTarget?: string;
+      limit?: number | null;
+      used?: number;
+      remaining?: number | null;
+      resetAt?: string;
+      expiresAt?: string;
+    } = {},
+  ) {
     super(message);
     this.name = "ApiError";
     this.code = code;
     this.status = status;
+    this.planKey = details.planKey;
+    this.upgradeTarget = details.upgradeTarget;
+    this.limit = details.limit;
+    this.used = details.used;
+    this.remaining = details.remaining;
+    this.resetAt = details.resetAt;
+    this.expiresAt = details.expiresAt;
   }
 }
 

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -64,6 +64,23 @@ export type {
   ListReleaseGatesResponse,
   EvaluateReleaseGateRequest,
   EvaluateReleaseGateResponse,
+  BillingPlanKey,
+  BillingPeriod,
+  BillingStatus,
+  BillingLimit,
+  BillingPlanLimits,
+  BillingPlan,
+  BillingPlansResponse,
+  EffectiveEntitlements,
+  BillingSubscription,
+  BillingOverviewResponse,
+  StartBillingTrialRequest,
+  CreateBillingCheckoutRequest,
+  CreateBillingCheckoutResponse,
+  CreateBillingPortalResponse,
+  BillingGateDecision,
+  WorkspaceUsageSnapshot,
+  WorkspaceEntitlementsResponse,
 } from "./types";
 export { AGENT_KINDS } from "./types";
 export { listRunFailures, type ListRunFailuresParams } from "./failure-reviews";

--- a/web/src/lib/api/swr.ts
+++ b/web/src/lib/api/swr.ts
@@ -29,23 +29,23 @@ export function createSWRApiFetcher(
 }
 
 export function useApiQuery<T>(
-  path: string,
+  path: string | null,
   params?: ApiQueryParams,
   config?: SWRConfiguration<T>,
 ): SWRResponse<T> {
-  return useSWR<T>(apiQueryKey(path, params), config);
+  return useSWR<T>(path ? apiQueryKey(path, params) : null, config);
 }
 
 export function useApiListQuery<T>(
-  path: string,
+  path: string | null,
   params?: ApiQueryParams,
   config?: SWRConfiguration<{ items: T[] }>,
 ): SWRResponse<{ items: T[] }> {
-  return useSWR<{ items: T[] }>(apiQueryKey(path, params), config);
+  return useSWR<{ items: T[] }>(path ? apiQueryKey(path, params) : null, config);
 }
 
 export function usePaginatedApiQuery<T>(
-  path: string,
+  path: string | null,
   params?: ApiQueryParams,
   config?: SWRConfiguration<{
     items: T[];
@@ -64,7 +64,7 @@ export function usePaginatedApiQuery<T>(
     total: number;
     limit: number;
     offset: number;
-  }>(apiQueryKey(path, params), config);
+  }>(path ? apiQueryKey(path, params) : null, config);
 }
 
 export function useApiMutator() {

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -1628,6 +1628,141 @@ export interface ListRegressionCasesResponse {
   items: RegressionCase[];
 }
 
+// --- Billing ---
+
+export type BillingPlanKey = "free" | "pro" | "team" | "enterprise";
+export type BillingPeriod = "monthly" | "yearly" | "custom";
+export type BillingStatus = "active" | "trialing" | "expired" | "inactive" | string;
+
+export interface BillingLimit {
+  value?: number;
+  per_seat?: boolean;
+  unlimited?: boolean;
+  custom?: boolean;
+}
+
+export interface BillingPlanLimits {
+  seats: BillingLimit;
+  workspaces: BillingLimit;
+  races_per_workspace_month: BillingLimit;
+  max_models_per_race: BillingLimit;
+  replay_retention_days: BillingLimit;
+  concurrent_races: BillingLimit;
+}
+
+export interface BillingPlan {
+  key: BillingPlanKey;
+  display_name: string;
+  minimum_seats: number;
+  default_seats: number;
+  billing_periods: BillingPeriod[];
+  limits: BillingPlanLimits;
+  feature_flags: Record<string, boolean>;
+  upgrade_target?: BillingPlanKey;
+  dodo_product_ids?: Partial<Record<BillingPeriod, string>>;
+}
+
+export interface BillingPlansResponse {
+  items: BillingPlan[];
+}
+
+export interface EffectiveEntitlements {
+  plan_key: BillingPlanKey;
+  billing_period: BillingPeriod;
+  status: BillingStatus;
+  seat_quantity: number;
+  seats_limit?: number | null;
+  workspaces_limit?: number | null;
+  races_per_workspace_month?: number | null;
+  max_models_per_race?: number | null;
+  replay_retention_days?: number | null;
+  concurrent_races?: number | null;
+  feature_flags: Record<string, boolean>;
+  upgrade_target?: BillingPlanKey;
+  expires_at?: string;
+}
+
+export interface BillingSubscription {
+  id: string;
+  organization_id: string;
+  dodo_subscription_id: string;
+  dodo_customer_id?: string;
+  dodo_product_id: string;
+  plan_key: BillingPlanKey;
+  billing_period: BillingPeriod;
+  status: BillingStatus;
+  next_billing_date?: string;
+  cancel_at_next_billing_date: boolean;
+  cancelled_at?: string;
+  expires_at?: string;
+  trial_period_days?: number;
+  seat_quantity: number;
+  addon_quantities: unknown;
+  latest_dodo_event_at?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface BillingOverviewResponse {
+  entitlements: EffectiveEntitlements;
+  subscription?: BillingSubscription;
+}
+
+export interface StartBillingTrialRequest {
+  plan_key: "pro" | "team";
+  billing_period?: BillingPeriod;
+}
+
+export interface CreateBillingCheckoutRequest {
+  plan_key: "pro" | "team" | "enterprise";
+  billing_period: BillingPeriod;
+  seat_quantity: number;
+  return_url: string;
+}
+
+export interface CreateBillingCheckoutResponse {
+  checkout_intent_id: string;
+  checkout_url: string;
+  plan_key: BillingPlanKey;
+  billing_period: BillingPeriod;
+  seat_quantity: number;
+}
+
+export interface CreateBillingPortalResponse {
+  portal_url: string;
+}
+
+export interface BillingGateDecision {
+  allowed: boolean;
+  code?: string;
+  message?: string;
+  plan_key: BillingPlanKey;
+  upgrade_target?: BillingPlanKey;
+  limit?: number | null;
+  used?: number;
+  remaining?: number | null;
+  reset_at?: string;
+  expires_at?: string;
+}
+
+export interface WorkspaceUsageSnapshot {
+  workspace_id: string;
+  race_count: number;
+  active_runs: number;
+  window_start: string;
+  window_end: string;
+}
+
+export interface WorkspaceEntitlementsResponse {
+  organization_id: string;
+  workspace_id: string;
+  entitlements: EffectiveEntitlements;
+  usage: WorkspaceUsageSnapshot;
+  gates: {
+    run: BillingGateDecision;
+  };
+}
+
 // --- Errors ---
 
 /** Standard error envelope returned by all backend error responses. */
@@ -1635,5 +1770,12 @@ export interface ApiErrorResponse {
   error: {
     code: string;
     message: string;
+    plan_key?: BillingPlanKey;
+    upgrade_target?: BillingPlanKey;
+    limit?: number | null;
+    used?: number;
+    remaining?: number | null;
+    reset_at?: string;
+    expires_at?: string;
   };
 }

--- a/web/src/lib/auth/server.ts
+++ b/web/src/lib/auth/server.ts
@@ -65,10 +65,14 @@ export const getWorkspaceShellData = cache(async (workspaceId: string) => {
 
   let orgName: string | undefined;
   let orgSlug: string | undefined;
+  let orgId: string | undefined;
+  let orgRole: string | undefined;
   for (const organization of userMe.organizations) {
     if (organization.workspaces.some((workspace) => workspace.id === workspaceId)) {
       orgName = organization.name;
       orgSlug = organization.slug;
+      orgId = organization.id;
+      orgRole = organization.role;
       break;
     }
   }
@@ -79,7 +83,9 @@ export const getWorkspaceShellData = cache(async (workspaceId: string) => {
     userMe,
     hasMembership,
     hasOrgAccess,
+    orgId,
     orgName,
+    orgRole,
     orgSlug,
   };
 });

--- a/web/src/lib/billing.test.ts
+++ b/web/src/lib/billing.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { ApiError } from "@/lib/api/errors";
+import {
+  billingGateToastMessage,
+  formatBillingLimit,
+  isFreeActive,
+} from "@/lib/billing";
+
+describe("billing helpers", () => {
+  it("detects active Free entitlements", () => {
+    expect(
+      isFreeActive({
+        plan_key: "free",
+        billing_period: "monthly",
+        status: "active",
+        seat_quantity: 1,
+        feature_flags: {},
+      }),
+    ).toBe(true);
+
+    expect(
+      isFreeActive({
+        plan_key: "pro",
+        billing_period: "monthly",
+        status: "trialing",
+        seat_quantity: 5,
+        feature_flags: {},
+      }),
+    ).toBe(false);
+  });
+
+  it("formats unlimited limits", () => {
+    expect(formatBillingLimit(null)).toBe("Unlimited");
+    expect(formatBillingLimit(2500)).toBe("2,500");
+  });
+
+  it("maps billing gate errors to upgrade copy", () => {
+    const message = billingGateToastMessage(
+      new ApiError(402, "quota_exceeded", "quota exhausted", {
+        planKey: "free",
+        upgradeTarget: "pro",
+        limit: 25,
+        used: 25,
+      }),
+    );
+
+    expect(message).toContain("Free");
+    expect(message).toContain("25");
+    expect(message).toContain("Start a trial");
+  });
+});

--- a/web/src/lib/billing.ts
+++ b/web/src/lib/billing.ts
@@ -1,0 +1,92 @@
+import { ApiError } from "@/lib/api/errors";
+import type { EffectiveEntitlements } from "@/lib/api/types";
+
+const planLabels: Record<string, string> = {
+  free: "Free",
+  pro: "Pro",
+  team: "Team",
+  enterprise: "Enterprise",
+};
+
+export function planLabel(planKey?: string): string {
+  if (!planKey) return "your plan";
+  return planLabels[planKey] ?? planKey;
+}
+
+export function billingStatusLabel(status?: string): string {
+  switch (status) {
+    case "trialing":
+      return "Trial";
+    case "active":
+      return "Active";
+    case "expired":
+      return "Expired";
+    case "inactive":
+      return "Inactive";
+    default:
+      return status ?? "Unknown";
+  }
+}
+
+export function formatBillingDate(value?: string): string {
+  if (!value) return "";
+  return new Date(value).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function formatBillingLimit(value?: number | null): string {
+  return value == null ? "Unlimited" : new Intl.NumberFormat().format(value);
+}
+
+export function isFreeActive(entitlements?: EffectiveEntitlements): boolean {
+  return entitlements?.plan_key === "free" && entitlements.status === "active";
+}
+
+export function isBillingGateError(err: unknown): err is ApiError {
+  return (
+    err instanceof ApiError &&
+    [
+      "plan_limit_exceeded",
+      "quota_exceeded",
+      "concurrency_limit_exceeded",
+      "seat_limit_exceeded",
+      "workspace_limit_exceeded",
+      "feature_not_entitled",
+      "entitlement_expired",
+      "entitlement_inactive",
+    ].includes(err.code)
+  );
+}
+
+export function billingGateToastMessage(err: unknown): string | null {
+  if (!isBillingGateError(err)) return null;
+
+  const current = planLabel(err.planKey);
+  const upgrade = planLabel(err.upgradeTarget);
+  const reset = err.resetAt ? ` Resets ${formatBillingDate(err.resetAt)}.` : "";
+  const expiry = err.expiresAt ? ` Trial ended ${formatBillingDate(err.expiresAt)}.` : "";
+
+  switch (err.code) {
+    case "feature_not_entitled":
+      return `${current} does not include this feature. Start a trial or upgrade to ${upgrade}.`;
+    case "quota_exceeded":
+      return `${current} has used ${err.used ?? "all"} of ${formatBillingLimit(err.limit)} monthly runs.${reset} Start a trial or upgrade to continue.`;
+    case "concurrency_limit_exceeded":
+      return `${current} allows ${formatBillingLimit(err.limit)} concurrent run${err.limit === 1 ? "" : "s"}. Try again after one finishes, or upgrade to ${upgrade}.`;
+    case "plan_limit_exceeded":
+      return `${current} allows up to ${formatBillingLimit(err.limit)} models per run. Start a trial or upgrade to ${upgrade}.`;
+    case "seat_limit_exceeded":
+      return `${current} has reached its seat limit. Start a trial or upgrade to ${upgrade}.`;
+    case "workspace_limit_exceeded":
+      return `${current} has reached its workspace limit. Start a trial or upgrade to ${upgrade}.`;
+    case "entitlement_expired":
+      return `${current} access has expired.${expiry} Add billing to continue.`;
+    case "entitlement_inactive":
+      return `${current} billing is inactive. Add billing to continue.`;
+    default:
+      return err.message;
+  }
+}


### PR DESCRIPTION
## Summary

Adds the frontend billing UX stacked on top of PR #434:

- organization Billing page with current plan/status, limits, trial expiry, plans, checkout, and billing portal actions
- dismissible 45-day trial prompt for eligible Free org admins
- workspace billing banner showing Free/trial/expired state and monthly run usage
- billing-aware error copy for run creation, eval session creation, and private challenge pack publishing
- typed billing API models and preserved billing gate metadata on `ApiError`
- small `POST /v1/organizations/{organizationID}/billing/trial` endpoint so the trial UI can actually grant exact Pro/Team trial entitlements without Dodo being connected

## Why

PR #434 makes backend entitlements enforceable. This PR makes that visible and understandable in the app before the backend branch goes to production, so users are not surprised by Free-plan limits and admins have a clear path to start a trial or checkout.

## Base / stack

This is intentionally stacked on `codex/issue-432-billing-entitlements` and should land after #434.

## Validation

- `go test ./internal/api -run 'TestBillingManagerStartTrial|TestBillingManagerProcessesSignedDodoWebhook|TestBillingGateHTTPStatus' -count=1`
- `go test ./internal/billing ./internal/api ./internal/repository -count=1`
- `go test -short -race -count=1 ./...`
- `npm test -- --run src/lib/billing.test.ts src/lib/api/__tests__/client.test.ts`
- `npm test`
- `npm run lint`
- `npm run build`
- `git diff --check`
