### PR TITLE
Docs: challenge pack depth, typography, and non-Mermaid diagrams

### DIFF
--- a/web/content/docs/architecture/data-model.mdx
+++ b/web/content/docs/architecture/data-model.mdx
@@ -16,17 +16,7 @@ At a high level, the schema revolves around a small set of concepts:
 - replay events and artifacts: the evidence emitted while a run executes
 - scorecards and comparisons: the summarized judgments built from that evidence
 
-```mermaid
-flowchart TD
-  WS[Workspace]
-  WS --> DP[Deployment]
-  WS --> CP[Challenge pack]
-  DP --> RN[Run]
-  CP --> RN
-  RN --> EV[Replay events]
-  RN --> AR[Artifacts]
-  RN --> SC[Scorecards]
-```
+<DiagramWorkspaceDataModel />
 
 ## Why the model is shaped this way
 

--- a/web/content/docs/architecture/evidence-loop.mdx
+++ b/web/content/docs/architecture/evidence-loop.mdx
@@ -16,17 +16,7 @@ AgentClash leans on a canonical event model so the same execution can feed multi
 - scorecards for compact judgments
 - future workload design when a failure is worth preserving
 
-```mermaid
-flowchart LR
-  EX[Execution] --> EV[Canonical events]
-  EV --> RP[Replay views]
-  EV --> AR[Artifacts and logs]
-  EV --> SC[Scorecards]
-  RP --> RV[Reviewer understanding]
-  SC --> CMP[Comparison decisions]
-  RV --> CP[Future challenge-pack improvements]
-  CMP --> CP
-```
+<DiagramEvidenceClosingLoop />
 
 ## The canonical event envelope is the hinge
 

--- a/web/content/docs/architecture/frontend.mdx
+++ b/web/content/docs/architecture/frontend.mdx
@@ -7,13 +7,7 @@ The web app is not just the dashboard. It currently carries the product landing 
 
 ## Route split
 
-```mermaid
-flowchart TD
-  Root[App Router] --> Public[Public pages]
-  Root --> Auth[Auth routes]
-  Root --> App[Authenticated workspace and org routes]
-  Root --> Docs[Docs routes]
-```
+<DiagramFrontendRouteSplit />
 
 ## Public pages
 

--- a/web/content/docs/architecture/orchestration.mdx
+++ b/web/content/docs/architecture/orchestration.mdx
@@ -7,15 +7,7 @@ AgentClash models long-running execution as workflow work, not as a single API r
 
 ## The runtime split
 
-```mermaid
-flowchart LR
-  BrowserOrCLI[Browser or CLI] --> API[API server]
-  API --> Temporal[Temporal]
-  Temporal --> Worker[Worker]
-  Worker --> Providers[Provider router]
-  Worker --> Sandbox[Sandbox provider]
-  Worker --> Events[Run event recorder]
-```
+<DiagramOrchestrationRuntimeSplit />
 
 ## What the API server does
 

--- a/web/content/docs/architecture/sandbox-layer.mdx
+++ b/web/content/docs/architecture/sandbox-layer.mdx
@@ -26,14 +26,7 @@ The main benefits are straightforward:
 - runtime setup is explicit and configurable through worker environment
 - the provider can be swapped later without rewriting the product model around runs and evidence
 
-```mermaid
-flowchart LR
-  API[API server] --> WF[Temporal workflow]
-  WF --> WK[Worker activity]
-  WK --> SB[Sandbox provider]
-  SB --> AG[Agent execution]
-  AG --> EV[Replay events and artifacts]
-```
+<DiagramSandboxBoundary />
 
 ## What this boundary protects
 

--- a/web/content/docs/challenge-packs/bundle-yaml-reference.mdx
+++ b/web/content/docs/challenge-packs/bundle-yaml-reference.mdx
@@ -1,0 +1,106 @@
+---
+title: Bundle YAML reference
+description: Structured reference for challenge-pack bundles as parsed by backend/internal/challengepack.
+---
+
+AgentClash challenge packs ship as **one YAML file** decoded into `challengepack.Bundle` (`backend/internal/challengepack/bundle.go`). Publication stores a JSON manifest combining the pack body with metadata for execution and scoring (`ManifestJSON` in the same file).
+
+## Top-level keys
+
+All keys listed here are persisted or validated somewhere in publish/validate—not decorative.
+
+### `pack` (required)
+
+Human metadata surfaced in API and CLI lists:
+
+- `slug` — required, workspace-unique branding string
+- `name` — required display name  
+- `family` — required grouping/category string  
+- `description` — optional
+
+### `version` (required)
+
+The executable spine of the bundle:
+
+| Field | Notes |
+| --- | --- |
+| `number` | Required positive integer (`int32`). Bumps when you materially change validators, tooling, sandbox, scores, etc. |
+| `execution_mode` | `native` **or** `prompt_eval`. Empty accepts as legacy but you should always set explicitly. See execution rules below. |
+| `tool_policy` | Arbitrary-shaped map mirrored into manifest `tool_policy`. **Must be omitted** when `execution_mode` is `prompt_eval` (validated in `ValidateBundle`). |
+| `filesystem` | Optional filesystem constraints blob (same manifest path as today). |
+| `sandbox` | Optional `SandboxConfig`. **Forbidden** when `execution_mode` is `prompt_eval`. |
+| `evaluation_spec` | Required scoring contract unmarshalled through scoring package strict decode (`scoring.StrictDecodeEvaluationSpec`). Typos surface at parse time rather than silently defaulting. |
+| `assets` | Version-scoped `AssetReference[]` keyed for cases and uploads. |
+
+`SandboxConfig` (`bundle.go`) currently supports:
+
+- `network_access` (bool)
+- `network_allowlist` (CIDR strings; invalid CIDR rejects publish)
+- `env_vars` (map of string literals—see [Sandbox & E2B](sandbox-and-e2b))
+- `additional_packages` (APT-style names constrained by regexp in validation)
+- `sandbox_template_id` (optional provider template override)
+
+Manifest JSON merges `sandbox_template_id` from `version.sandbox` into the serialized `version` block for backends that historically keyed off that field separately.
+
+### `tools` (optional)
+
+Optional map keyed by integration style; authoring today uses **`tools.custom`** as an array of composed tools (`validation.go`). **Must be empty** when mode is `prompt_eval`.
+
+See [Tools, primitives & policy](tools-primitives-and-policy).
+
+### `challenges` (required, non-empty)
+
+Each challenge includes:
+
+| Field | Required | Purpose |
+| --- | --- | --- |
+| `key` | yes | Stable id referenced by cases |
+| `title` | yes | Display |
+| `category` | yes | Stored metadata |
+| `difficulty` | yes | Stored metadata (`easy`/`medium`/… as free text unless your org standardizes it) |
+| `instructions` | often | Prompt body; mirrored into `definition.instructions` if missing there |
+| `definition` | optional | Extra JSON-compatible bag for product-specific authoring |
+| `assets` | optional | Challenge-scoped files |
+| `artifact_refs` | optional | Artifact key references validated against declared artifacts |
+
+### `input_sets` (required)
+
+Defines runnable **cases**:
+
+- **`key`** and **`name`** required on each set.
+- Prefer modern **`cases`** array. Legacy `items` aliases are normalized into `cases` during `normalizeBundle`; do not rely on `items` in new authoring.
+
+Cases are modeled by `CaseDefinition` with `challenge_key`, `case_key`, optional rich `inputs`/`expectations`, `artifacts`, `assets`, plus legacy **`payload`** for blob-only authoring.
+
+Deep dive: [Input sets & cases](input-sets-and-cases).
+
+## Execution mode compatibility
+
+Validated in `ValidateBundle`:
+
+When `execution_mode` is **`prompt_eval`**:
+
+- `tools` block must **not** be present
+- `version.sandbox` must **not** be present  
+- `version.tool_policy` must be **empty**
+
+When **`native`** you may populate sandbox, allowed tool kinds, and composed tools—the worker will hydrate the richer runtime path (`native_executor` flow).
+
+Choose `prompt_eval` for pure model-output workloads; promote to `native` when you rely on sandbox files, primitives, validators that read captured files (`file:` evidence), etc.
+
+## After publish — IDs returned
+
+Publishing returns stable identifiers referenced by runs (see authoring guide):
+
+- `challenge_pack_id`
+- `challenge_pack_version_id`
+- `evaluation_spec_id`
+- `input_set_ids`
+- Optional `bundle_artifact_id`
+
+Run creation binds `challenge_pack_version_id` specifically—YAML filenames stop mattering immediately after publish.
+
+## See also
+
+- [Evaluation spec reference](evaluation-spec-reference)
+- [Challenge packs and inputs — conceptual overview](../concepts/challenge-packs-and-inputs)

--- a/web/content/docs/challenge-packs/eval-workflows-and-gates.mdx
+++ b/web/content/docs/challenge-packs/eval-workflows-and-gates.mdx
@@ -67,4 +67,4 @@ This page is for **people driving hosted or staging workspaces** from the CLI. S
 
 - [Runs and evals](../concepts/runs-and-evals)
 - [Interpret results](../guides/interpret-results)
-- [CLI reference](../reference/cli) (generated)
+- [CLI reference](../reference/cli)

--- a/web/content/docs/challenge-packs/eval-workflows-and-gates.mdx
+++ b/web/content/docs/challenge-packs/eval-workflows-and-gates.mdx
@@ -1,0 +1,70 @@
+---
+title: Eval workflows & gates
+description: CLI-first eval commands, baselines, scorecards, comparisons, and release gates as implemented in cli/cmd.
+---
+
+Challenge packs are useless until a **run** binds a `challenge_pack_version_id` to one or more **deployments**. The product ships a workflow-oriented CLI path so you rarely hand-copy UUIDs.
+
+## Happy path commands
+
+From `cli/cmd/eval.go`, `baseline.go`, `compare.go`, `release_gate.go`:
+
+```bash
+agentclash eval start --follow
+agentclash baseline set [run_id] [--agent <label>]
+agentclash eval scorecard [run_id] [--agent <label>] [--json]
+agentclash compare runs --baseline <run> --candidate <run>
+agentclash compare gate --baseline <run> --candidate <run>
+agentclash release-gate list [--baseline ... --candidate ...]
+```
+
+### `eval start`
+
+Key flags (see `eval.go` / `eval_resolve.go`):
+
+| Flag | Purpose |
+| --- | --- |
+| `--pack` | Pack id, slug, or exact name |
+| `--pack-version` | Version id or integer |
+| `--input-set` | Disambiguates when multiple sets published |
+| `--deployment` | Repeatable; accepts id or exact name |
+| `--follow` | Stream run events after creation |
+| `--scope` | `full` vs `suite_only` regression scoping |
+| `--suite` / `--case` | Target regression fixtures |
+| `--race-context` | Peer standings injection (multi-agent) |
+
+Non-interactive environments must supply enough disambiguators—resolver errors spell out what’s missing.
+
+### `eval scorecard`
+
+Prints the latest candidate scorecard and, when configured, enriches with **baseline + comparison + release gate** envelopes in one JSON payload for CI (`eval_test.go` asserts those keys).
+
+Omitting `run_id` uses deterministic “latest relevant run” semantics documented in tests—do not assume hidden state in automation; pass explicit ids in CI.
+
+### Baseline bookmarks
+
+`baseline set|show|clear` stores a **workspace-scoped** pointer to a run (and optional specific `run_agent`). This unlocks diff language inside `eval scorecard` without retyping ids.
+
+`doctor` treats missing baseline as **informational** only—CI gates should not fail solely because no baseline exists yet.
+
+## Compare & release gates
+
+- `compare runs` hits comparison APIs with explicit baseline/candidate pair (optional agent ids).  
+- `compare gate` posts to `/v1/release-gates/evaluate` with those ids—response includes `policy_snapshot`, `evaluation_details`, timestamps (see `compare.go` long help).
+- `release-gate list` surfaces historical evaluations with optional filters.
+
+Gate outcomes use structured status codes (documented in `compare.go` help text) for scripting.
+
+## Relationship to `run create`
+
+`run create` still exists for power users, but product messaging steers new usage to `eval start` (`run.go` long help cross-links). Pick one style per automation story to avoid divergent flag semantics.
+
+## Docs for consumers vs operators
+
+This page is for **people driving hosted or staging workspaces** from the CLI. Self-host operators should still read [Self-host quickstart](../getting-started/self-host) for bringing up Postgres + Temporal + worker parity.
+
+## See also
+
+- [Runs and evals](../concepts/runs-and-evals)
+- [Interpret results](../guides/interpret-results)
+- [CLI reference](../reference/cli) (generated)

--- a/web/content/docs/challenge-packs/evaluation-spec-reference.mdx
+++ b/web/content/docs/challenge-packs/evaluation-spec-reference.mdx
@@ -1,0 +1,145 @@
+---
+title: Evaluation spec reference
+description: Validators, metrics, behavioral signals, runtime limits, and scorecard semantics from backend/internal/scoring.
+---
+
+Pack-local `evaluation_spec` is unmarshalled into `scoring.EvaluationSpec` (`backend/internal/scoring/spec.go`) via strict decoding. This page maps fields to enums and collectors actually implemented—not aspirational placeholders.
+
+For LLM graders see the dedicated guide: [LLM judges](llm-judges).
+
+## Judge mode (`judge_mode`)
+
+Top-level discriminator on how scoring composes deterministic pieces with judges:
+
+| Value | Constant |
+| --- | --- |
+| `deterministic` | `JudgeModeDeterministic` |
+| `llm_judge` | `JudgeModeLLMJudge` |
+| `hybrid` | `JudgeModeHybrid` |
+
+Invalid values fail validation early.
+
+## Validators (`validators[]`)
+
+Each entry is a `ValidatorDeclaration`:
+
+- **`key`** — unique within spec; also forbidden to collide with metrics or judges
+- **`type`** — enumerated `ValidatorType` (snippet below)
+- **`target`** — evidence reference (validators require supported references—see Evidence references section)
+- **`expected_from`** — often required depending on validator type (`RequiresExpectedFrom` in `spec.go`)
+- **`config`** — type-specific strict JSON validated in `validation.go`
+
+### Implemented validator types
+
+From `ValidatorType*` constants:
+
+`exact_match`, `contains`, `regex_match`, `json_schema`, `json_path_match`, `boolean_assert`, `fuzzy_match`, `numeric_match`, `normalized_match`, `token_f1`, `math_equivalence`, `bleu_score`, `rouge_score`, `chrf_score`, `file_content_match`, `file_exists`, `file_json_schema`, `directory_structure`, `code_execution`
+
+File-ish validators gate on sandbox artifacts (see **File validators**: `IsFileValidator()` distinguishes these).
+
+Always check `requires_expected_from`: e.g., `file_exists`, `directory_structure`, and `code_execution` can rely on config/paths without `expected_from`.
+
+## Metrics (`metrics[]`)
+
+`MetricDeclaration` requires:
+
+| Field | Notes |
+| --- | --- |
+| `key` | Unique within spec |
+| `type` | `numeric`, `text`, or `boolean` |
+| `collector` | Implemented switch in `engine_metrics.go` |
+| `unit` | Stored for dashboards/score normalization |
+
+Collectors wired today (verbatim keys):
+
+`run_total_latency_ms`, `run_ttft_ms`, `run_input_tokens`, `run_output_tokens`, `run_total_tokens`, `run_agent_tokens`, `run_race_context_tokens`, `run_model_cost_usd`, `run_completed_successfully`, `run_failure_count`, behavioral scores (`behavioral_recovery_score`, … ), `validator_pass_rate`
+
+Declaring a collector that does not exist will fail silently only if evidence missing—prefer copying keys from tests in `backend/internal/scoring/engine_metrics.go`.
+
+## Behavioral panel (`behavioral`)
+
+Optional `behavioral.signals[]` referencing `behavioral.signal` enums:
+
+- `recovery_behavior`
+- `exploration_efficiency`
+- `error_cascade`
+- `scope_adherence`
+- `confidence_calibration`
+
+Each signal supports `weight`, optional `gate`, `pass_threshold` for hardened evaluation sessions.
+
+## Post-execution sandbox captures (`post_execution_checks`)
+
+Declare file/directory grabs before sandbox teardown (`post_execution.go`):
+
+| `type` | Meaning |
+| --- | --- |
+| `file_capture` | Persist file bytes up to configured max |
+| `directory_listing` | Snapshot structure |
+
+Captured evidence is exposed to graders through `file:<path>` style references downstream—pair with validators that target those artifacts.
+
+Defaults: ~1 MiB per file, aggregate caps enforced per run (`DefaultMaxFileSizeBytes`, `DefaultMaxTotalCaptureBytes`).
+
+## Scorecard (`scorecard`)
+
+`ScorecardDeclaration` holds:
+
+### Dimensions (`dimensions`)
+
+Each dimension may be a plain string shorthand (historical compatibility) **or** an expanded object specifying:
+
+- **`key`** — dimension name (`correctness`, `latency`, `cost`, `behavioral`, custom)
+- **`source`** — dispatcher: `validators`, `metric`, `reliability`, `latency`, `cost`, `behavioral`, `llm_judge`
+- **`validators[]`**, **`metric`**, **`judge_key`** — depending on `source`
+- **`weight`**, **`normalization`** — linear normalize against target/max envelopes
+- **`gate`**, **`pass_threshold`** — hard fail semantics (see Strategies)
+
+Built-in shortcut keys normalize during `normalizeEvaluationSpec` (`validation.go`): correctness/ reliability/ latency / cost / behavioral auto-fill sensible sources.
+
+### Strategy (`strategy`)
+
+| Strategy | Semantics sketch |
+| --- | --- |
+| `weighted` | Weighted mean; gated dims may still veto pass verdict |
+| `binary` | All dimensions treated as gates; scorecard-level `pass_threshold` is rejected (prevents ambiguity) |
+| `hybrid` | Gates AND aggregate over non-gate dims must clear optional `scorecard.pass_threshold` |
+
+See doc comments on `ScoringStrategy` in `spec.go` for nuanced behavior—especially hybrid vs weighted gate interplay.
+
+### `scorecard.pass_threshold`
+
+Optional inclusive overall score cutoff (documented extensively in struct comment). Forbidden for pure `binary`.
+
+### Judge budgets (`scorecard.judge_limits`)
+
+Caps LLM-as-judge spend per run (`MaxSamplesPerJudge`, `MaxCallsUSD`, `MaxTokens`). Hard-coded ceilings (`JudgeMaxSamplesCeiling`) still clamp pack-authored overrides.
+
+### Legacy normalization (`normalization`)
+
+`latency.target_ms`, `cost.target_usd` migrate into dimension-level normalization automatically for older specs—still accepted.
+
+## Runtime limits (`runtime_limits`)
+
+`max_total_tokens`, `max_cost_usd`, `max_duration_ms`—enforced upstream of sandbox/model loops; surfaced for UI + scoring fallbacks.
+
+## Pricing (`pricing.models[]`)
+
+Pricing rows describing per-million token economics for **`run_model_cost_usd`** normalization. Matches `ProviderKey`/`ProviderModelID` tuples your workspace deployments actually use—misaligned rows produce weak cost dims but do not invalidate the pack.
+
+## Evidence references validators understand
+
+Validated by `isSupportedEvidenceReference`:
+
+- Absolute shortcuts: `final_output`, `run.final_output`, `challenge_input`, `case.payload`
+- Dotted accessors: `case.payload.*`, `case.inputs.*`, `case.expectations.*`, `artifact.*`
+- Sandbox artifacts: prefix `file:` with non-empty remainder
+- Literals: `literal:…`
+
+Prefer explicit paths whenever you refactor input schema—ambiguous references fail validate instead of drifting silently.
+
+## See also
+
+- [LLM judges](llm-judges)
+- [Write a challenge pack](../guides/write-a-challenge-pack)
+- Historical v0 evaluation contract notes live in the monorepo file `docs/evaluation/challenge-pack-v0.md` (developer-oriented, not mirrored on the docs site).

--- a/web/content/docs/challenge-packs/index.mdx
+++ b/web/content/docs/challenge-packs/index.mdx
@@ -1,0 +1,30 @@
+---
+title: Challenge pack documentation
+description: Deep, consumer-facing YAML and runtime reference keyed to the parsers, validators, and workers in this repository.
+---
+
+These pages complement the short concept guide [Challenge packs and inputs](../concepts/challenge-packs-and-inputs). They spell out everything a benchmark author needs to publish a pack that survives server-side parsing, validation, and execution.
+
+Everything here is keyed to shipped code paths—not roadmap language. When behavior changes upstream, validate again with:
+
+```bash
+agentclash challenge-pack validate your-pack.yaml
+```
+
+## What's covered
+
+| Topic | Use when you… | Anchor in repo |
+| --- | --- | --- |
+| [Bundle YAML reference](bundle-yaml-reference) | Need the authoritative field list and `prompt_eval` vs `native` rules | `backend/internal/challengepack/bundle.go`, `validation.go` |
+| [Evaluation spec reference](evaluation-spec-reference) | Choose validator types, wire `target`/`expected_from`, add metrics | `backend/internal/scoring/spec.go`, `validation.go`, `engine_*.go` |
+| [LLM judges](llm-judges) | Add rubrics, assertions, pairwise comparison, budgets | `backend/internal/scoring/spec.go`, `validation_judges.go` |
+| [Tools, primitives & policy](tools-primitives-and-policy) | Decide `allowed_tool_kinds`, map composed tools → primitives | `backend/internal/engine/primitive_tools.go`, `tool_registry.go`, `sandbox/sandbox.go` |
+| [Sandbox & E2B](sandbox-and-e2b) | Tune network_allowlist, template id, sandbox provider | `backend/internal/challengepack/bundle.go`, `sandbox/e2b/`, worker config |
+| [Input sets & cases](input-sets-and-cases) | Model fixtures, typed inputs and expectations | `challengepack/bundle.go` (`CaseDefinition`), `StoredCaseDocument` |
+| [Eval workflows & gates](eval-workflows-and-gates) | Chain `eval start`, baselines, scorecards, comparisons | `cli/cmd/eval.go`, `baseline.go`, `compare.go` |
+
+## See also
+
+- [Write a challenge pack](../guides/write-a-challenge-pack) — minimal happy-path checklist
+- [Tools, network, and secrets](../concepts/tools-network-and-secrets) — mental model overview
+- [Sandbox layer](../architecture/sandbox-layer) — provider boundary explanation

--- a/web/content/docs/challenge-packs/input-sets-and-cases.mdx
+++ b/web/content/docs/challenge-packs/input-sets-and-cases.mdx
@@ -1,0 +1,77 @@
+---
+title: Input sets & cases
+description: How cases bind challenges, structured inputs, expectations, assets, and legacy payloads—grounded in challengepack.CaseDefinition.
+---
+
+Input sets are the unit AgentClash schedules per deployment/candidate. Each `input_sets[]` entry contains **`cases[]`** (`CaseDefinition` in `backend/internal/challengepack/bundle.go`).
+
+## Case identity
+
+- **`challenge_key`** — must reference an existing `challenges[].key`
+- **`case_key`** / legacy **`item_key`** — both accepted; normalization duplicates missing side from the other
+
+`EffectiveKey()` chooses `case_key` when present for stored rows.
+
+## Three authoring styles (coexist)
+
+1. **Legacy payload-only** — fill `payload` map; omit structured inputs/expectations  
+2. **Structured eval** — `inputs[]` + `expectations[]` with explicit `kind` fields  
+3. **Artifact heavy** — `assets[]` + `artifacts[]` referencing declared version/challenge assets
+
+`IsLegacyPayloadOnly` detects style (1) for storage compatibility.
+
+### Stored document shape
+
+When modern fields exist, `StoredPayload()` marshals `StoredCaseDocument` JSON with `schema_version: 1`, preserving:
+
+- `payload`
+- `inputs`
+- `expectations`
+- `artifacts`
+- `assets`
+
+This is what scoring + replay pull back—not the raw YAML fragment.
+
+## Case inputs (`inputs[]`)
+
+`CaseInput` fields:
+
+| Field | Role |
+| --- | --- |
+| `key` | Stable id for templates / UI |
+| `kind` | Drives rendering + validator binding (`text`, `artifact`, etc.—product-specific kinds should match worker expectations) |
+| `value` | Inline scalar/object |
+| `artifact_key` | Pull bytes from declared asset map |
+| `path` | Optional relative path inside asset bundle |
+
+Validators can address values through `case.inputs.<key>` evidence paths.
+
+## Expectations (`expectations[]`)
+
+`CaseExpectation` parallels inputs:
+
+- `key`, `kind`, `value`, `artifact_key`, plus **`source`** telling graders where dynamic gold values originate (`input:prompt` pattern seen in CLI template packs)
+
+Use expectations for:
+
+- deterministic string compares
+- supplying LLM judge `reference_from` bindings
+- filesystem validators comparing outputs to expected files
+
+## Assets on cases
+
+Case-level `assets[]` references use the same `AssetReference` structure as version-level entries (key, path, optional `artifact_id`). Validation ensures cross-references exist before publish succeeds.
+
+## Input set metadata
+
+Optional `description` on an input set is preserved for UI/discovery; there is no behavioral magic—selection happens by id/key at run creation time.
+
+## Choosing input set at run time
+
+CLI `eval start` accepts `--input-set` when multiple sets exist; otherwise TTY flows prompt. API consumers pass the chosen `input_set_id` when creating runs (see OpenAPI `CreateRun` family).
+
+## See also
+
+- [Bundle YAML reference](bundle-yaml-reference)
+- [Evaluation spec — evidence references](evaluation-spec-reference)
+- [Artifacts concept](../concepts/artifacts)

--- a/web/content/docs/challenge-packs/llm-judges.mdx
+++ b/web/content/docs/challenge-packs/llm-judges.mdx
@@ -1,0 +1,83 @@
+---
+title: LLM judges
+description: LLM-as-judge declarations, rubric/assertion modes, consensus, budgets, evidence wiring—straight from scoring/spec.go and validation_judges.go.
+---
+
+Agents can be scored by **deterministic validators** alone, pure **LLM judges**, or **`hybrid`** combining both—the tri-state lives in `judge_mode` on `EvaluationSpec` (`backend/internal/scoring/spec.go`).
+
+Judge bodies live in **`evaluation_spec.llm_judges[]`** (`LLMJudgeDeclaration`). Dimensions that consume judges set `source: llm_judge` and **`judge_key`** referencing exactly one declaration (1:1 mapping by design).
+
+## Supported grader modes (`mode`)
+
+| Mode | Typical use |
+| --- | --- |
+| `rubric` | Structured numeric rubric graded each sample |
+| `assertion` | Yes/no factual checks; aggregates via majority/unanimous |
+| `n_wise` | Single prompt ranks all competing agents simultaneously |
+| `reference` | Rubric calibrated against gold text from resolved evidence |
+
+`IsNumeric` / `IsBooleanScope` helpers govern which consensus math applies.
+
+## Required fields by mode
+
+Validation (`validation_judges.go`) enforces:
+
+- **`rubric`** — non-empty rubric string
+- **`reference`** — rubric + `reference_from` evidence reference (must pass `isSupportedEvidenceReference`)
+- **`assertion`** — non-empty natural-language assertion; optional `expect` bool flips desired polarity
+- **`n_wise`** — non-empty ranking `prompt`; optional `position_debiasing` combats ordering bias across samples
+
+## Model fan-out
+
+Exactly **one** of:
+
+- `model` — single model id string (resolved by worker/provider wiring)
+- `models` — non-empty list for multi-model judging
+
+If `len(models) > 1`, you must include **`consensus`** with:
+
+- `aggregation` — `median`, `mean`, `majority_vote`, or `unanimous`
+- Optional `min_agreement_threshold`, `flag_on_disagreement`
+
+Boolean-scope modes restrict some aggregations (assertions cannot be mean-averaged nonsensically—validator enforces compatibility).
+
+## Samples & ceilings
+
+- `samples` — per-model repeat count; `0` normalizes to `JudgeDefaultSamples` (3)
+- Hard cap `JudgeMaxSamplesCeiling` (10) applied even if the pack requests more—cost attack guard
+
+## Evidence conditioning (`context_from[]`)
+
+Each entry must be a supported evidence reference (same family as validator `target` strings). The workflow evaluator stitches these fragments into the judge envelope before the LLM call.
+
+## Optional controls
+
+| Field | Role |
+| --- | --- |
+| `output_schema` | JSON Schema for parser validation of model output |
+| `score_scale` | `{min,max}` normalization (defaults 1..5 when omitted) |
+| `anti_gaming_clauses` | Pack-supplied safety copy **appended** to defaults (never replaces base mitigations) |
+| `timeout_ms` | Per-judge activity budget (clamped by outer Temporal activity timeout) |
+
+## Scorecard wiring
+
+1. Declare judges under `llm_judges`.
+2. Add a dimension with `source: llm_judge` and `judge_key` matching a judge `key`.
+3. Keep **keys unique across validators, metrics, and judges**—collisions are validation errors (namespace collision prevents ambiguous evidence routing).
+
+## Budgets & cost isolation
+
+`scorecard.judge_limits` tracks **judge** spend separately from agent model spend covered by `runtime_limits`. This split is intentional (see Q7 discussion embedded in `JudgeLimits` comments in `spec.go`): agent overages should not hide judge runaway.
+
+When cumulative judge calls exceed configured USD/token budgets, remaining samples downgrade to `unable_to_judge` states feeding scorecard `OutputStateUnavailable` paths.
+
+## Practical authoring tips
+
+- Start with **`rubric`** + single `model` + default samples; add `models`+`consensus` only after deterministic dims stabilise.
+- Use **`reference`** when you already store golden answers in `case.expectations` or artifacts—keeps judges aligned to ground truth.
+- Assertions excel as **binary gates** (`gate: true` on the dimension) while numeric rubrics express partial credit.
+
+## See also
+
+- [Evaluation spec reference](evaluation-spec-reference)
+- [Interpret results](../guides/interpret-results)

--- a/web/content/docs/challenge-packs/sandbox-and-e2b.mdx
+++ b/web/content/docs/challenge-packs/sandbox-and-e2b.mdx
@@ -21,7 +21,7 @@ Struct `SandboxConfig` (`challengepack/bundle.go`):
 
 ## Worker configuration knobs
 
-From environment / `backend/internal/worker/config.go` (also mirrored in generated [Config reference](../reference/config)):
+From environment / `backend/internal/worker/config.go` (mirror of the searchable [Config reference](../reference/config) tables):
 
 | Variable | Effect |
 | --- | --- |

--- a/web/content/docs/challenge-packs/sandbox-and-e2b.mdx
+++ b/web/content/docs/challenge-packs/sandbox-and-e2b.mdx
@@ -1,0 +1,59 @@
+---
+title: Sandbox & E2B
+description: Pack sandbox fields, worker sandbox provider selection, and how native execution reaches E2B today.
+---
+
+Native runs execute agent tool calls inside an isolated **sandbox provider** implementing `sandbox.Provider` (`backend/internal/sandbox/sandbox.go`). Production commonly uses **E2B** (`backend/internal/sandbox/e2b/provider.go`); local development may run **unconfigured** no-op providers so queues drain without real VMs.
+
+## Pack-level `version.sandbox`
+
+Struct `SandboxConfig` (`challengepack/bundle.go`):
+
+| Field | Purpose |
+| --- | --- |
+| `network_access` | Boolean gate paired with tool policy network tools |
+| `network_allowlist` | CIDR strings; invalid entries fail `ValidateBundle` |
+| `env_vars` | Literal environment injection into sandbox (secret placeholders rejected during native executor setup) |
+| `additional_packages` | APT package names (`aptPackagePattern` validation) |
+| `sandbox_template_id` | Optional override of default E2B template id per pack version |
+
+**Remember:** entire `sandbox` block is illegal for `prompt_eval` packs.
+
+## Worker configuration knobs
+
+From environment / `backend/internal/worker/config.go` (also mirrored in generated [Config reference](../reference/config)):
+
+| Variable | Effect |
+| --- | --- |
+| `SANDBOX_PROVIDER` | `e2b` vs `unconfigured` (noop) |
+| `E2B_API_KEY` | Credentials |
+| `E2B_TEMPLATE_ID` | Default template when pack omits `sandbox_template_id` |
+| `E2B_API_BASE_URL` | Optional API override |
+| `E2B_REQUEST_TIMEOUT` | HTTP budget for control-plane calls |
+
+Misconfiguration does not rewrite your YAML—it causes clear worker errors or `/doctor` warnings when local sandboxes cannot start.
+
+## Tool policy vs network flags
+
+Even if `http_request` is allowed by `allowed_tool_kinds: [network]`, outbound traffic still respects:
+
+- global sandbox network toggles
+- CIDR allowlists
+- provider-level enforcement inside E2B machines
+
+Think of **tool policy** as “model may ask” and **sandbox** as “infrastructure may permit”.
+
+## Secrets & environment
+
+Native executor refuses `${secrets.*}` inside `sandbox.env_vars` because files and process listings could leak them; keep secrets in tool args that go through hardened paths (notably `http_request` header sanitation—see `primitive_secrets.go` comments).
+
+## Failure modes to expect
+
+- **Template drift** — changing `additional_packages` without rebuilding templates can cause first-run apt noise; pin templates when stable.
+- **Allowlist too tight** — model receives policy errors from `http_request` if DNS resolves but CIDR blocks egress.
+- **No provider** — `SANDBOX_PROVIDER=unconfigured` means native runs **do not** execute real tools; useful for API-only integration tests, misleading if you expect live sandboxes.
+
+## See also
+
+- [Architecture — Sandbox layer](../architecture/sandbox-layer)
+- [Tools, primitives & policy](tools-primitives-and-policy)

--- a/web/content/docs/challenge-packs/tools-primitives-and-policy.mdx
+++ b/web/content/docs/challenge-packs/tools-primitives-and-policy.mdx
@@ -1,0 +1,102 @@
+---
+title: Tools, primitives & policy
+description: How tool_policy and tools.custom map to engine primitives in backend/internal/engine and sandbox.ToolPolicy.
+---
+
+AgentClash stacks **three** tool notions (also summarized in [Tools, network, and secrets](../concepts/tools-network-and-secrets)):
+
+1. **Workspace tool resources** — org-level infrastructure objects (not covered by pack YAML)
+2. **Pack composed tools** — `tools.custom[]` entries expanding to JSON Schema + implementation
+3. **Engine primitives** — concrete executors registered in `nativePrimitiveTools` (`backend/internal/engine/primitive_tools.go`)
+
+Only (2)+(3) are pack-controlled.
+
+## Tool policy shape
+
+`version.tool_policy` JSON eventually hydrates `sandbox.ToolPolicy` (`backend/internal/sandbox/sandbox.go`):
+
+- **`allowed_tool_kinds`** — list controlling capability groups
+- **`allow_shell`** — separate bool gating the `exec` primitive
+
+### Recognized kind strings
+
+Validated set (`supportedToolKinds` in `challengepack/validation.go`):
+
+`browser`, `build`, `data`, `file`, `network`
+
+**Shell is not a kind**—enable it with `allow_shell: true`.
+
+### Empty allowlist semantics
+
+`allowsToolKind` treats an **empty** `allowed_tool_kinds` as “allow everything” (per `primitive_helpers.go`). In practice, prefer explicit lists so validation errors catch typos early.
+
+### Mode guardrails
+
+`prompt_eval` packs **must omit** `tool_policy` entirely—see [Bundle YAML reference](bundle-yaml-reference).
+
+## Built-in primitive names
+
+Declared in `executor_builders.go`, registered in `nativePrimitiveTools`:
+
+| Primitive | Gated by |
+| --- | --- |
+| `submit` | Always available (final answer) |
+| `read_file`, `write_file`, `list_files`, `search_files`, `search_text` | `file` kind |
+| `query_json`, `query_sql` | `data` kind |
+| `http_request` | `network` kind (+ runtime network flags) |
+| `run_tests`, `build` | `build` kind |
+| `exec` | `allow_shell` |
+
+Browser tooling exists in policy (`toolKindBrowser`)—ensure your template + worker build includes whatever browser bridge your pack expects before relying on it in production.
+
+## Composed tools (`tools.custom[]`)
+
+Each item:
+
+```yaml
+tools:
+  custom:
+    - name: call_support_api
+      description: Fetch ticket JSON
+      parameters:
+        type: object
+        properties:
+          ticket_id: { type: string }
+        required: [ticket_id]
+        additionalProperties: false
+      implementation:
+        primitive: http_request
+        args:
+          method: GET
+          url: https://api.example.com/tickets/${ticket_id}
+          headers:
+            Authorization: Bearer ${secrets.SUPPORT_TOKEN}
+```
+
+Validation highlights (`validateComposedToolConfig`):
+
+- Non-mock tools require **`implementation.primitive`** not equal to the composed name (prevents self-delegation footgun)
+- **`implementation.args`** object required; templates validated for placeholder safety
+- Parameters must be JSON Schema passing `templateutil.ValidateToolParameterSchema`
+- Custom graph cannot contain **cycles** or depth > 8 delegation jumps
+
+### Mock implementations
+
+Set `implementation.type: mock` to skip primitive resolution—useful for dry-run packs or policy-only testing. Mocks bypass cycle detection.
+
+### Workspace tools vs pack tools
+
+Pack tools are **not** the same records as API `tools` resources—they are bundle-local contracts interpreted entirely inside the worker.
+
+## Secret placeholders
+
+Composed `args` may reference `${secrets.NAME}` which resolve through workspace secret stores—**never** place secret material inline. Sandbox `env_vars` explicitly reject secret placeholders (see native executor sandbox guard) because environment leaks are too easy; prefer header injection on `http_request`.
+
+## Provider visibility
+
+`buildToolRegistry` lifts final OpenAI/Anthropic/etc. tool definitions from the registry’s **visible** map—only tools allowed by policy + manifest appear to the model.
+
+## See also
+
+- [Sandbox & E2B](sandbox-and-e2b) for network pairing with `http_request`
+- `backend/internal/challengepack/tools_validation_test.go` for edge-case fixtures

--- a/web/content/docs/concepts/agents-and-deployments.mdx
+++ b/web/content/docs/concepts/agents-and-deployments.mdx
@@ -33,15 +33,7 @@ It also supports these optional fields:
 
 The OpenAPI description also says only ready build versions can be deployed.
 
-```mermaid
-flowchart LR
-  AB[Agent build] --> BV[Ready build version]
-  RP[Runtime profile] --> D[Deployment]
-  PA[Provider account] --> D
-  MA[Model alias] --> D
-  BV --> D
-  D --> R[Run]
-```
+<DiagramAgentsToRun />
 
 ## Runtime profiles are the execution envelope
 

--- a/web/content/docs/concepts/artifacts.mdx
+++ b/web/content/docs/concepts/artifacts.mdx
@@ -41,14 +41,7 @@ Runs and replay events can also point at artifacts. Those become part of the evi
 
 That is why replay and failure-review models carry artifact references. Artifacts are part of the audit trail, not just incidental attachments.
 
-```mermaid
-flowchart LR
-  WA[Workspace artifact upload] --> CP[Challenge pack assets]
-  WA --> R[Run]
-  R --> EV[Replay events]
-  EV --> FR[Failure review]
-  CP --> SCORE[Scoring evidence]
-```
+<DiagramArtifactFlow />
 
 ## Challenge-pack assets and artifact refs
 

--- a/web/content/docs/concepts/challenge-packs-and-inputs.mdx
+++ b/web/content/docs/concepts/challenge-packs-and-inputs.mdx
@@ -5,6 +5,8 @@ description: Learn what a challenge pack really is in AgentClash, how the bundle
 
 A challenge pack is a versioned YAML bundle that defines the workload, scoring contract, execution policy, and input sets for a repeatable evaluation.
 
+For field-by-field YAML, scoring enums, judge modes, primitives, sandbox flags, and CLI eval flows, use the **[challenge pack reference hub](../challenge-packs)**—it is written for pack authors who need repo-accurate depth, not a marketing overview.
+
 ## What makes it a challenge pack instead of a prompt
 
 A challenge pack is not just a task description. In the current repo, a runnable pack carries enough structure for AgentClash to do four jobs consistently:

--- a/web/content/docs/concepts/challenge-packs-and-inputs.mdx
+++ b/web/content/docs/concepts/challenge-packs-and-inputs.mdx
@@ -38,20 +38,7 @@ A pack becomes runnable through its `version` block. That block currently carrie
 - `evaluation_spec`: the scoring contract
 - `assets`: version-scoped files or artifact references
 
-```mermaid
-flowchart TD
-  P[pack metadata]
-  V[version]
-  V --> ES[evaluation_spec]
-  V --> SB[sandbox]
-  V --> TP[tool_policy]
-  V --> AS[version assets]
-  C[challenges] --> IS[input_sets]
-  IS --> CASES[cases]
-  V --> RUN[run execution]
-  CASES --> RUN
-  ES --> SCORE[scorecards]
-```
+<DiagramChallengePackBundleShape />
 
 ## Challenge, input set, case, and asset are different things
 

--- a/web/content/docs/concepts/replay-and-scorecards.mdx
+++ b/web/content/docs/concepts/replay-and-scorecards.mdx
@@ -31,13 +31,7 @@ A scorecard should make a run legible in seconds. The exact schema will keep evo
 - attach the evidence that justifies that judgment
 - make comparisons across runs possible without rereading the full trace
 
-```mermaid
-flowchart LR
-  EV[Canonical events] --> RP[Replay timeline]
-  EV --> SC[Scorecard]
-  RP --> UI[Run detail view]
-  SC --> CMP[Compare and ranking views]
-```
+<DiagramReplayVsScorecards />
 
 ## How to use both together
 

--- a/web/content/docs/contributing/codebase-tour.mdx
+++ b/web/content/docs/contributing/codebase-tour.mdx
@@ -20,15 +20,7 @@ If you only remember one thing, remember this: the web app is not the whole prod
 
 A useful mental path through the repo is:
 
-```mermaid
-flowchart LR
-  WEB[web/] --> API[backend/internal/api]
-  API --> WF[Temporal workflows]
-  WF --> WRK[backend/internal/worker]
-  WRK --> SB[Sandbox provider]
-  WRK --> EV[Replay events and artifacts]
-  CLI[cli/] --> API
-```
+<DiagramCodebaseTourShortcuts />
 
 That is the shortest route from "user action" to "why did this run behave that way".
 

--- a/web/content/docs/guides/write-a-challenge-pack.mdx
+++ b/web/content/docs/guides/write-a-challenge-pack.mdx
@@ -229,6 +229,7 @@ Do not assume that adding `http_request` is enough. You also need the relevant s
 
 ## See also
 
+- [Challenge pack reference](../challenge-packs)
 - [Challenge Packs and Inputs](../concepts/challenge-packs-and-inputs)
 - [Tools, Network, and Secrets](../concepts/tools-network-and-secrets)
 - [Artifacts](../concepts/artifacts)

--- a/web/content/docs/index.mdx
+++ b/web/content/docs/index.mdx
@@ -13,4 +13,5 @@ These docs are layered for three kinds of readers:
 
 The current public surface is still early. This docs pass only covers behavior that is already visible in the repo today: the CLI, the local stack, the current run model, and the main runtime components.
 
-Start with the hosted quickstart if you want the shortest path to a real command sequence. Start with self-host if you want the full local stack on your machine. Start with architecture if you are here to hack on the code.
+Start with the hosted quickstart if you want the shortest path to a real command sequence. Start with self-host if you want the full local stack on your machine. Start with architecture if you are here to hack on the code. For **challenge pack YAML, scoring, tooling, sandboxes, judges, and CLI eval flows**, start at [Challenge pack reference](/docs/challenge-packs).
+

--- a/web/content/docs/reference/cli.mdx
+++ b/web/content/docs/reference/cli.mdx
@@ -1,0 +1,6 @@
+---
+title: CLI Reference
+description: Commands, flags, and command groups generated from the current Cobra CLI source.
+---
+
+Intro-oriented readers should still start from [Hosted quickstart](../getting-started/quickstart); this page focuses on mechanically listing what `cli/cmd` exposes after each docs rebuild. For repo layout around the CLI, see [Codebase tour](../contributing/codebase-tour).

--- a/web/content/docs/reference/config.mdx
+++ b/web/content/docs/reference/config.mdx
@@ -1,0 +1,6 @@
+---
+title: Config Reference
+description: Environment variables and config precedence generated from the current source readers.
+---
+
+Pack-authored sandbox settings live in YAML (see [Sandbox & E2B](../challenge-packs/sandbox-and-e2b)); the tables appended below cover **worker and API runtime** knobs discovered from checked-in Go config readers and `.env.example`.

--- a/web/src/app/docs/[[...slug]]/page.tsx
+++ b/web/src/app/docs/[[...slug]]/page.tsx
@@ -59,7 +59,7 @@ export default async function DocsPage({ params }: Props) {
                 key={section.title}
                 className="rounded-[24px] border border-white/[0.08] bg-black/20 p-5"
               >
-                <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.18em] text-white/30">
+                <p className="text-[11px] font-semibold uppercase tracking-wider text-zinc-400">
                   {section.title}
                 </p>
                 <p className="mt-3 text-sm leading-6 text-white/45">

--- a/web/src/components/docs/docs-diagram-presets.tsx
+++ b/web/src/components/docs/docs-diagram-presets.tsx
@@ -151,7 +151,7 @@ export function DiagramAgentsToRun() {
             <Pill>Agent build</Pill>
             <ArrowD />
             <Pill>Ready build version</Pill>
-            <ArrowR className="self-end md:hidden" />
+            <ArrowD className="md:hidden" />
           </div>
           <div className="flex flex-col items-center gap-2 md:items-start">
             <Pill>Runtime profile</Pill>

--- a/web/src/components/docs/docs-diagram-presets.tsx
+++ b/web/src/components/docs/docs-diagram-presets.tsx
@@ -1,0 +1,362 @@
+import { ArrowDown, ArrowRight } from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+function DiagramFrame({
+  caption,
+  children,
+}: {
+  caption?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <figure className="not-prose my-10 overflow-x-auto rounded-2xl border border-zinc-800/95 bg-[radial-gradient(ellipse_at_top,_#1a2620_0%,_#09090b_58%)] p-6 shadow-[0_28px_64px_-32px_rgba(0,0,0,.85)]">
+      <figcaption className="sr-only">{caption ?? "Diagram"}</figcaption>
+      <div className="min-w-0">{children}</div>
+    </figure>
+  );
+}
+
+function Pill({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex max-w-[18rem] items-center justify-center rounded-lg border px-3 py-1.5 text-center text-[13px] font-medium leading-snug text-zinc-100",
+        "border-emerald-500/25 bg-emerald-500/[0.07] shadow-sm shadow-black/30",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+function ArrowR({ className }: { className?: string }) {
+  return (
+    <ArrowRight className={cn("size-[18px] shrink-0 text-emerald-500/45", className)} aria-hidden />
+  );
+}
+
+function ArrowD({ className }: { className?: string }) {
+  return (
+    <ArrowDown className={cn("size-[18px] shrink-0 text-emerald-500/45", className)} aria-hidden />
+  );
+}
+
+function RowArrowRow({ pills }: { pills: readonly string[] }) {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-3 md:flex-nowrap md:justify-start">
+      {pills.map((label, i) => (
+        <span key={`${label}-${i}`} className="flex shrink-0 items-center gap-x-3">
+          {i > 0 ? <ArrowR /> : null}
+          <Pill>{label}</Pill>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function DiagramOrchestrationRuntimeSplit() {
+  return (
+    <DiagramFrame caption="API request into Temporal workflows and worker responsibilities">
+      <div className="flex flex-col gap-6">
+        <RowArrowRow pills={["Browser or CLI", "API server", "Temporal", "Worker"]} />
+        <div className="flex flex-col gap-6 border-t border-zinc-800/80 pt-6">
+          <p className="text-center text-xs font-semibold uppercase tracking-wider text-zinc-500 md:text-left">
+            Worker surfaces
+          </p>
+          <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-3 md:flex-nowrap md:justify-start">
+            <Pill>Provider router</Pill>
+            <ArrowR />
+            <Pill>Sandbox provider</Pill>
+            <ArrowR />
+            <Pill>Run event recorder</Pill>
+          </div>
+        </div>
+      </div>
+    </DiagramFrame>
+  );
+}
+
+export function DiagramSandboxBoundary() {
+  return (
+    <DiagramFrame caption="Sandbox execution path inside worker activities">
+      <RowArrowRow
+        pills={[
+          "API server",
+          "Temporal workflow",
+          "Worker activity",
+          "Sandbox provider",
+          "Agent execution",
+          "Replay events and artifacts",
+        ]}
+      />
+    </DiagramFrame>
+  );
+}
+
+export function DiagramFrontendRouteSplit() {
+  return (
+    <DiagramFrame caption="Next.js App Router high-level segmentation">
+      <div className="mx-auto flex max-w-xl flex-col items-center gap-5">
+        <Pill>App Router root</Pill>
+        <ArrowD />
+        <div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2">
+          <Pill>Public pages</Pill>
+          <Pill>Auth routes</Pill>
+          <Pill>Authenticated workspace and org routes</Pill>
+          <Pill>Docs routes</Pill>
+        </div>
+      </div>
+    </DiagramFrame>
+  );
+}
+
+export function DiagramWorkspaceDataModel() {
+  return (
+    <DiagramFrame caption="Core relational edges between workspace entities">
+      <div className="mx-auto flex max-w-lg flex-col items-center gap-4">
+        <Pill>Workspace</Pill>
+        <ArrowD />
+        <div className="flex w-full flex-wrap items-center justify-center gap-6 md:justify-between md:gap-16">
+          <Pill>Deployment</Pill>
+          <span className="text-xs uppercase tracking-[0.2em] text-zinc-600">and</span>
+          <Pill>Challenge pack</Pill>
+        </div>
+        <ArrowD />
+        <Pill className="ring-[1px] ring-emerald-400/35">Run</Pill>
+        <ArrowD />
+        <div className="flex w-full max-w-xl flex-wrap justify-center gap-3 md:gap-6">
+          <Pill>Replay events</Pill>
+          <Pill>Artifacts</Pill>
+          <Pill>Scorecards</Pill>
+        </div>
+      </div>
+    </DiagramFrame>
+  );
+}
+
+export function DiagramAgentsToRun() {
+  return (
+    <DiagramFrame caption="Builds and runtime credentials join the same deployment boundary">
+      <div className="mx-auto flex max-w-2xl flex-col gap-10">
+        <div className="grid gap-10 md:grid-cols-2 md:gap-14">
+          <div className="flex flex-col items-center gap-3 md:items-start">
+            <Pill>Agent build</Pill>
+            <ArrowD />
+            <Pill>Ready build version</Pill>
+            <ArrowR className="self-end md:hidden" />
+          </div>
+          <div className="flex flex-col items-center gap-2 md:items-start">
+            <Pill>Runtime profile</Pill>
+            <Pill>Provider account</Pill>
+            <Pill>Model alias</Pill>
+          </div>
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <div className="hidden h-[2rem] border-l border-dashed border-emerald-500/30 md:block" aria-hidden />
+          <p className="text-center text-[11px] uppercase tracking-[0.18em] text-zinc-500">
+            feed deployment
+          </p>
+          <ArrowD />
+          <Pill className="ring-[1px] ring-emerald-400/35">Deployment</Pill>
+          <ArrowD />
+          <Pill>Run</Pill>
+        </div>
+        <p className="text-center text-[12px] leading-relaxed text-zinc-500">
+          Ready build versions and runtime configuration rows converge on the same Deployment—the
+          object runs once your challenge pack binds through run submission.
+        </p>
+      </div>
+    </DiagramFrame>
+  );
+}
+
+export function DiagramArtifactFlow() {
+  return (
+    <DiagramFrame caption="Workspace uploads feed pack assets and runs; replay and scoring consume both">
+      <div className="mx-auto flex max-w-xl flex-col items-center gap-8 md:max-w-none">
+        <Pill className="max-w-none">Workspace artifact upload</Pill>
+        <div className="flex w-full flex-col gap-10 md:flex-row md:justify-center md:gap-24">
+          <div className="flex flex-col items-center gap-3 md:flex-1">
+            <ArrowD />
+            <Pill>Challenge pack assets</Pill>
+            <ArrowD />
+            <Pill>Scoring evidence</Pill>
+          </div>
+          <div className="flex flex-col items-center gap-3 md:flex-1">
+            <ArrowD />
+            <Pill>Run</Pill>
+            <ArrowD />
+            <Pill>Replay events</Pill>
+            <ArrowD />
+            <Pill>Failure review</Pill>
+          </div>
+        </div>
+      </div>
+    </DiagramFrame>
+  );
+}
+
+export function DiagramReplayVsScorecards() {
+  return (
+    <DiagramFrame caption="Canonical events branching into granular replay versus aggregate scores">
+      <div className="mx-auto flex max-w-2xl flex-col gap-14 md:flex-row md:items-start md:justify-between md:gap-10">
+        <div className="flex flex-1 flex-col items-center gap-3 md:items-start">
+          <Pill>Canonical events</Pill>
+          <ArrowD />
+          <Pill>Replay timeline</Pill>
+          <ArrowD />
+          <Pill>Run detail view</Pill>
+        </div>
+        <div className="hidden w-px self-stretch bg-zinc-800 md:block md:mx-10" aria-hidden />
+        <div className="flex flex-1 flex-col items-center gap-3 md:items-start">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-500/70 md:-mt-[1rem] md:pb-10">
+            also
+          </span>
+          <Pill className="-mt-[0.5rem] md:mt-0">Canonical events</Pill>
+          <ArrowD />
+          <Pill>Scorecard</Pill>
+          <ArrowD />
+          <Pill>Compare and ranking views</Pill>
+        </div>
+      </div>
+    </DiagramFrame>
+  );
+}
+
+export function DiagramEvidenceClosingLoop() {
+  return (
+    <DiagramFrame caption="Execution evidence branching into qualitative and quantitative rails">
+      <div className="mx-auto grid max-w-5xl gap-16 md:grid-cols-[1fr_18px_1fr] md:items-start md:gap-12 md:justify-items-start">
+        <div className="flex flex-col gap-10">
+          <RowArrowRow pills={["Execution", "Canonical events"]} />
+          <RowArrowRow pills={["Replay views"]} />
+          <RowArrowRow pills={["Reviewer understanding"]} />
+        </div>
+        <div className="hidden min-h-[300px] w-px shrink-0 self-stretch bg-zinc-800 md:block md:rounded-full" aria-hidden />
+        <div className="flex flex-col gap-10">
+          <div className="flex flex-wrap gap-x-3 gap-y-3">
+            <Pill>Canonical events</Pill>
+            <ArrowR />
+            <Pill>Artifacts and logs</Pill>
+          </div>
+          <div className="flex flex-wrap gap-x-3 gap-y-3">
+            <Pill>Canonical events</Pill>
+            <ArrowR />
+            <Pill>Scorecards</Pill>
+          </div>
+          <div className="rounded-2xl border border-dashed border-zinc-800/95 bg-black/35 p-6">
+            <p className="mb-6 text-[11px] font-semibold uppercase tracking-wider text-zinc-400">
+              Convergent outcomes
+            </p>
+            <div className="flex flex-col gap-8">
+              <div className="flex flex-wrap gap-x-3 gap-y-3">
+                <Pill>Reviewer understanding</Pill>
+              </div>
+              <div className="flex flex-wrap gap-x-3 gap-y-3">
+                <Pill>Comparison decisions</Pill>
+              </div>
+              <ArrowD />
+              <RowArrowRow pills={["Future challenge-pack improvements"]} />
+            </div>
+            <p className="mt-6 text-[12px] leading-relaxed text-zinc-500">
+              Review and comparison tighten the authored packs you ship next, turning observed drifts into explicit benchmark updates.
+            </p>
+          </div>
+        </div>
+      </div>
+    </DiagramFrame>
+  );
+}
+
+export function DiagramCodebaseTourShortcuts() {
+  return (
+    <DiagramFrame caption="Thin slice from web and CLI typed surfaces toward worker-hosted execution">
+      <div className="flex flex-col gap-10 md:gap-12">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-6">
+          <Pill className="text-emerald-200/95">web/</Pill>
+          <ArrowR />
+          <Pill>backend/internal/api</Pill>
+        </div>
+
+        <div className="-mx-2 border-y border-white/14 py-6 md:border-0 md:py-0">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-6">
+            <Pill className="text-emerald-200/95">CLI</Pill>
+            <ArrowR />
+            <Pill>backend/internal/api</Pill>
+          </div>
+        </div>
+
+        <RowArrowRow pills={["backend/internal/api", "Temporal workflows"]} />
+        <RowArrowRow pills={["Temporal workflows", "backend/internal/worker"]} />
+
+        <div className="flex flex-col gap-6 border-t border-zinc-800/80 pt-8">
+          <p className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
+            Worker tails
+          </p>
+          <div className="flex flex-wrap gap-x-3 gap-y-4">
+            <Pill>Sandbox provider</Pill>
+            <ArrowR />
+            <Pill>Replay events and artifacts</Pill>
+          </div>
+        </div>
+      </div>
+    </DiagramFrame>
+  );
+}
+
+export function DiagramChallengePackBundleShape() {
+  return (
+    <DiagramFrame caption="Pack versioning ties policy, sandbox, scoring, and cases into runs">
+      <div className="mx-auto grid max-w-5xl gap-16">
+        <div className="grid gap-x-14 gap-y-12 md:grid-cols-[1fr_auto_1fr] md:items-start">
+          <div className="flex flex-col gap-14">
+            <div className="flex flex-col gap-14 md:flex-row md:justify-between">
+              <div className="flex flex-col items-start gap-2">
+                <Pill>Pack metadata</Pill>
+              </div>
+              <ArrowR className="hidden shrink-0 self-center rotate-[-12deg] md:inline" />
+              <div className="flex flex-col items-start gap-2">
+                <Pill className="ring-[1px] ring-emerald-400/35">Version</Pill>
+                <ArrowD />
+                <div className="mt-8 flex flex-col gap-3">
+                  <Pill>Evaluation spec</Pill>
+                  <Pill>Sandbox</Pill>
+                  <Pill>Tool policy</Pill>
+                  <Pill>Version assets</Pill>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="mx-auto hidden h-px min-h-[18rem] min-w-[2px] self-stretch bg-zinc-800 md:block md:rounded-full" aria-hidden />
+          <div className="flex flex-col items-start gap-3">
+            <Pill>Challenges</Pill>
+            <ArrowD />
+            <Pill>Input sets</Pill>
+            <ArrowD />
+            <Pill>Cases</Pill>
+          </div>
+        </div>
+
+        <div className="flex flex-col items-center gap-6 border-t border-zinc-800/80 pt-12 md:flex-row md:flex-wrap md:justify-center md:gap-10">
+          <RowArrowRow pills={["Cases", "Run execution"]} />
+          <span className="hidden text-[11px] uppercase tracking-[0.2em] text-zinc-600 md:inline">
+            —
+          </span>
+          <div className="flex flex-col items-center gap-2">
+            <Pill>Evaluation spec</Pill>
+            <ArrowD />
+            <Pill className="ring-[1px] ring-emerald-400/30">Scorecards</Pill>
+          </div>
+        </div>
+      </div>
+    </DiagramFrame>
+  );
+}

--- a/web/src/components/docs/docs-shell.tsx
+++ b/web/src/components/docs/docs-shell.tsx
@@ -70,7 +70,7 @@ export function DocsShell({
                 {sectionTitle ?? "Documentation"}
               </p>
               <div className="flex items-start justify-between gap-4">
-                <h1 className="text-3xl font-bold tracking-tight text-zinc-100 sm:text-4xl">
+                <h1 className="font-sans text-3xl font-semibold tracking-tight text-zinc-100 antialiased sm:text-[2.125rem] sm:leading-tight">
                   {title}
                 </h1>
                 <button 
@@ -86,7 +86,7 @@ export function DocsShell({
               </p>
             </div>
 
-            <div className="prose prose-invert prose-zinc max-w-none prose-headings:text-zinc-100 prose-a:text-emerald-500 prose-a:no-underline hover:prose-a:underline prose-code:text-zinc-200 prose-pre:bg-zinc-900 prose-pre:border prose-pre:border-zinc-800">
+            <div className="prose prose-invert prose-zinc max-w-none prose-headings:font-sans prose-headings:tracking-tight prose-headings:text-zinc-100 prose-headings:not-italic prose-p:leading-relaxed prose-strong:text-zinc-200 prose-a:text-emerald-500 prose-a:no-underline hover:prose-a:underline prose-code:font-normal prose-code:text-zinc-200 prose-pre:bg-zinc-900 prose-pre:border prose-pre:border-zinc-800">
               {children}
             </div>
           </div>

--- a/web/src/components/docs/mdx-components.tsx
+++ b/web/src/components/docs/mdx-components.tsx
@@ -6,6 +6,18 @@ import {
 } from "react";
 import { Callout } from "@/components/docs/callout";
 import { CopyableCodeBlock } from "@/components/docs/copyable-code-block";
+import {
+  DiagramAgentsToRun,
+  DiagramArtifactFlow,
+  DiagramChallengePackBundleShape,
+  DiagramCodebaseTourShortcuts,
+  DiagramEvidenceClosingLoop,
+  DiagramFrontendRouteSplit,
+  DiagramOrchestrationRuntimeSplit,
+  DiagramReplayVsScorecards,
+  DiagramSandboxBoundary,
+  DiagramWorkspaceDataModel,
+} from "@/components/docs/docs-diagram-presets";
 import { slugify } from "@/lib/docs";
 import { cn } from "@/lib/utils";
 
@@ -55,6 +67,16 @@ function DocsHeading({
 
 export const docsMDXComponents = {
   Callout,
+  DiagramAgentsToRun,
+  DiagramArtifactFlow,
+  DiagramChallengePackBundleShape,
+  DiagramCodebaseTourShortcuts,
+  DiagramEvidenceClosingLoop,
+  DiagramFrontendRouteSplit,
+  DiagramOrchestrationRuntimeSplit,
+  DiagramReplayVsScorecards,
+  DiagramSandboxBoundary,
+  DiagramWorkspaceDataModel,
   h2: (props: ComponentPropsWithoutRef<"h2">) => (
     <DocsHeading level={2} {...props} />
   ),

--- a/web/src/components/docs/mdx-components.tsx
+++ b/web/src/components/docs/mdx-components.tsx
@@ -7,6 +7,7 @@ import {
 import { Callout } from "@/components/docs/callout";
 import { CopyableCodeBlock } from "@/components/docs/copyable-code-block";
 import { slugify } from "@/lib/docs";
+import { cn } from "@/lib/utils";
 
 function flattenText(children: ReactNode): string {
   return Children.toArray(children)
@@ -27,6 +28,7 @@ function flattenText(children: ReactNode): string {
 function DocsHeading({
   level,
   children,
+  className,
   ...props
 }: ComponentPropsWithoutRef<"h2"> & {
   level: 2 | 3;
@@ -35,7 +37,17 @@ function DocsHeading({
   const Tag = level === 2 ? "h2" : "h3";
 
   return (
-    <Tag id={id} {...props}>
+    <Tag
+      id={id}
+      {...props}
+      className={cn(
+        "scroll-mt-28 font-sans font-semibold tracking-tight text-zinc-100 not-italic antialiased",
+        level === 2
+          ? "mt-14 border-b border-zinc-800 pb-3 text-xl"
+          : "mt-10 text-[1.0625rem] leading-snug",
+        className,
+      )}
+    >
       {children}
     </Tag>
   );

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -445,22 +445,7 @@ export const DOCS_NAV: DocNavSection[] = [
   },
 ];
 
-const GENERATED_DOCS: Record<string, GeneratedDocDefinition> = {
-  "reference/cli": {
-    title: "CLI Reference",
-    description:
-      "Commands, flags, and command groups generated from the current Cobra CLI source.",
-    sectionTitle: "Reference",
-    buildContent: renderCLIReference,
-  },
-  "reference/config": {
-    title: "Config Reference",
-    description:
-      "Environment variables and config precedence generated from the current source readers.",
-    sectionTitle: "Reference",
-    buildContent: renderConfigReference,
-  },
-};
+const GENERATED_DOCS: Record<string, GeneratedDocDefinition> = {};
 
 const AGENT_SKILL_CATEGORIES: Record<
   string,
@@ -1411,6 +1396,28 @@ export function getDocNeighbors(currentHref: string) {
 }
 
 export function getDocBySlug(slug: string[] = []): DocPage | null {
+  const key = slugKey(slug);
+
+  // Reference bodies are synthesized from repo sources (`render*` below). Checked-in
+  // `reference/*.mdx` gives linters/crawlers an on-disk slug and lets us prepend prose.
+  if (key === "reference/cli") {
+    const file = getFileDocBySlug(slug);
+    if (!file) return null;
+    return {
+      ...file,
+      content: `${file.content.trim()}\n\n${renderCLIReference()}`,
+    };
+  }
+
+  if (key === "reference/config") {
+    const file = getFileDocBySlug(slug);
+    if (!file) return null;
+    return {
+      ...file,
+      content: `${file.content.trim()}\n\n${renderConfigReference()}`,
+    };
+  }
+
   return getGeneratedDocBySlug(slug) ?? getFileDocBySlug(slug);
 }
 

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -186,6 +186,69 @@ export const DOCS_NAV: DocNavSection[] = [
     ],
   },
   {
+    title: "Challenge packs",
+    description:
+      "YAML reference grounded in backend/parser/scoring/enforcement paths—meant for pack authors publishing real workloads.",
+    items: [
+      {
+        title: "Reference overview",
+        description:
+          "Map of every challenge-pack documentation page and where each topic is enforced in Go.",
+        slug: ["challenge-packs"],
+        href: "/docs/challenge-packs",
+      },
+      {
+        title: "Bundle YAML reference",
+        description:
+          "Top-level bundle keys, manifests, constraints for prompt_eval versus native.",
+        slug: ["challenge-packs", "bundle-yaml-reference"],
+        href: "/docs/challenge-packs/bundle-yaml-reference",
+      },
+      {
+        title: "Evaluation spec",
+        description:
+          "Validators, targets, metric collectors, scorecard dimensions, strategies, post-execution captures.",
+        slug: ["challenge-packs", "evaluation-spec-reference"],
+        href: "/docs/challenge-packs/evaluation-spec-reference",
+      },
+      {
+        title: "LLM judges",
+        description:
+          "Rubric, assertion, n_wise, and reference modes plus consensus keys and budgets.",
+        slug: ["challenge-packs", "llm-judges"],
+        href: "/docs/challenge-packs/llm-judges",
+      },
+      {
+        title: "Tools, primitives & policy",
+        description:
+          "allowed_tool_kinds, built-in primitives, composed tools to http_request mocks and cycles.",
+        slug: ["challenge-packs", "tools-primitives-and-policy"],
+        href: "/docs/challenge-packs/tools-primitives-and-policy",
+      },
+      {
+        title: "Sandbox & E2B",
+        description:
+          "Pack sandbox block, outbound network CIDR lists, sandbox provider env, no-op modes.",
+        slug: ["challenge-packs", "sandbox-and-e2b"],
+        href: "/docs/challenge-packs/sandbox-and-e2b",
+      },
+      {
+        title: "Input sets & cases",
+        description:
+          "Case inputs expectations artifacts legacy payloads and how payloads are persisted.",
+        slug: ["challenge-packs", "input-sets-and-cases"],
+        href: "/docs/challenge-packs/input-sets-and-cases",
+      },
+      {
+        title: "Eval workflows & gates",
+        description:
+          "CLI eval start baseline scorecard compare gates and regression scope flags grounded in Cobra.",
+        slug: ["challenge-packs", "eval-workflows-and-gates"],
+        href: "/docs/challenge-packs/eval-workflows-and-gates",
+      },
+    ],
+  },
+  {
     title: "Guides",
     description:
       "Task-oriented walkthroughs for authoring packs, setting up deployments, reading results, and using the docs with AI tools.",


### PR DESCRIPTION
## Summary

- Adds a **Challenge packs** docs hub with deeper reference pages (bundle YAML, evaluation spec, judges, tools/primitives/policy, sandbox, input sets/cases, eval workflows/gates).
- Tweaks docs **heading typography** for clearer hierarchy (`mdx-components`, docs shell prose).
- Replaces fenced **`mermaid`** blocks—which do not render in the current MDX pipeline—with **styled React diagrams** (`docs-diagram-presets.tsx`): pill nodes, emerald accent, radial frame, Lucide arrows. Registered via `docsMDXComponents`.

## Verification

- `cd web && pnpm exec tsc --noEmit && pnpm build`