### PR TITLE
feat: add Agent Harnesses for Codex on E2B

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -114,6 +114,7 @@ func main() {
 		logger,
 	)
 	agentDeploymentReadManager := api.NewAgentDeploymentReadManager(repo)
+	agentHarnessManager := api.NewAgentHarnessManager(authorizer, repo)
 	challengePackReadManager := api.NewChallengePackReadManager(repo)
 	challengePackAuthoringManager := api.NewChallengePackAuthoringManager(repo, artifactStore)
 	publicShareManager := api.NewPublicShareManager(authorizer, repo, cfg.FrontendURL)
@@ -180,6 +181,7 @@ func main() {
 		regressionManager,
 		hostedRunIngestionManager,
 		agentDeploymentReadManager,
+		agentHarnessManager,
 		challengePackReadManager,
 		challengePackAuthoringManager,
 		agentBuildManager,

--- a/backend/db/migrations/00032_agent_harnesses.sql
+++ b/backend/db/migrations/00032_agent_harnesses.sql
@@ -1,0 +1,43 @@
+-- +goose Up
+CREATE TABLE agent_harnesses (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id uuid NOT NULL REFERENCES organizations (id) ON DELETE CASCADE,
+    workspace_id uuid NOT NULL,
+    created_by_user_id uuid REFERENCES users (id) ON DELETE SET NULL,
+    name text NOT NULL,
+    slug text NOT NULL,
+    description text NOT NULL DEFAULT '',
+    status text NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'active', 'archived')),
+    harness_kind text NOT NULL DEFAULT 'codex_e2b' CHECK (harness_kind IN ('codex_e2b')),
+    task_prompt text NOT NULL,
+    codex_template text NOT NULL DEFAULT 'codex',
+    codex_model text,
+    auth_mode text NOT NULL CHECK (auth_mode IN ('chatgpt_device', 'api_key_secret', 'bring_your_own_env')),
+    openai_api_key_secret_name text,
+    e2b_api_key_secret_name text,
+    repository_url text,
+    base_branch text,
+    execution_config jsonb NOT NULL DEFAULT '{}'::jsonb,
+    evaluation_config jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    archived_at timestamptz,
+    UNIQUE (workspace_id, slug),
+    UNIQUE (id, organization_id, workspace_id),
+    FOREIGN KEY (workspace_id, organization_id) REFERENCES workspaces (id, organization_id) ON DELETE CASCADE,
+    CHECK (auth_mode <> 'api_key_secret' OR openai_api_key_secret_name IS NOT NULL)
+);
+
+CREATE INDEX agent_harnesses_workspace_status_updated_idx
+ON agent_harnesses (workspace_id, status, updated_at DESC)
+WHERE archived_at IS NULL;
+
+CREATE TRIGGER agent_harnesses_set_updated_at
+BEFORE UPDATE ON agent_harnesses
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+-- +goose Down
+DROP TRIGGER IF EXISTS agent_harnesses_set_updated_at ON agent_harnesses;
+DROP INDEX IF EXISTS agent_harnesses_workspace_status_updated_idx;
+DROP TABLE IF EXISTS agent_harnesses;

--- a/backend/internal/api/agent_harnesses.go
+++ b/backend/internal/api/agent_harnesses.go
@@ -1,0 +1,322 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+const (
+	AgentHarnessAuthModeChatGPTDevice   = "chatgpt_device"
+	AgentHarnessAuthModeAPIKeySecret    = "api_key_secret"
+	AgentHarnessAuthModeBringYourOwnEnv = "bring_your_own_env"
+	defaultCodexE2BTemplate             = "codex"
+)
+
+type AgentHarnessRepository interface {
+	GetOrganizationIDByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (uuid.UUID, error)
+	CreateAgentHarness(ctx context.Context, p repository.CreateAgentHarnessParams) (repository.AgentHarness, error)
+	GetAgentHarnessByID(ctx context.Context, id uuid.UUID) (repository.AgentHarness, error)
+	ListAgentHarnessesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]repository.AgentHarness, error)
+}
+
+type AgentHarnessService interface {
+	CreateAgentHarness(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateAgentHarnessInput) (repository.AgentHarness, error)
+	GetAgentHarness(ctx context.Context, caller Caller, id uuid.UUID) (repository.AgentHarness, error)
+	ListAgentHarnesses(ctx context.Context, caller Caller, workspaceID uuid.UUID) ([]repository.AgentHarness, error)
+}
+
+type AgentHarnessManager struct {
+	authorizer WorkspaceAuthorizer
+	repo       AgentHarnessRepository
+}
+
+func NewAgentHarnessManager(authorizer WorkspaceAuthorizer, repo AgentHarnessRepository) *AgentHarnessManager {
+	return &AgentHarnessManager{authorizer: authorizer, repo: repo}
+}
+
+type CreateAgentHarnessInput struct {
+	Name                   string          `json:"name"`
+	Description            string          `json:"description"`
+	TaskPrompt             string          `json:"task_prompt"`
+	CodexTemplate          string          `json:"codex_template"`
+	CodexModel             string          `json:"codex_model"`
+	AuthMode               string          `json:"auth_mode"`
+	OpenAIAPIKeySecretName string          `json:"openai_api_key_secret_name"`
+	E2BAPIKeySecretName    string          `json:"e2b_api_key_secret_name"`
+	RepositoryURL          string          `json:"repository_url"`
+	BaseBranch             string          `json:"base_branch"`
+	ExecutionConfig        json.RawMessage `json:"execution_config"`
+	EvaluationConfig       json.RawMessage `json:"evaluation_config"`
+}
+
+type AgentHarnessValidationError struct {
+	Code    string
+	Message string
+}
+
+func (e AgentHarnessValidationError) Error() string {
+	return e.Message
+}
+
+func (m *AgentHarnessManager) CreateAgentHarness(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateAgentHarnessInput) (repository.AgentHarness, error) {
+	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, workspaceID); err != nil {
+		return repository.AgentHarness{}, err
+	}
+	if err := validateAgentHarnessInput(input); err != nil {
+		return repository.AgentHarness{}, err
+	}
+
+	orgID, err := m.repo.GetOrganizationIDByWorkspaceID(ctx, workspaceID)
+	if err != nil {
+		return repository.AgentHarness{}, err
+	}
+
+	codexTemplate := strings.TrimSpace(input.CodexTemplate)
+	if codexTemplate == "" {
+		codexTemplate = defaultCodexE2BTemplate
+	}
+
+	return m.repo.CreateAgentHarness(ctx, repository.CreateAgentHarnessParams{
+		OrganizationID:         orgID,
+		WorkspaceID:            workspaceID,
+		CreatedByUserID:        &caller.UserID,
+		Name:                   strings.TrimSpace(input.Name),
+		Slug:                   generateSlug(input.Name),
+		Description:            strings.TrimSpace(input.Description),
+		TaskPrompt:             strings.TrimSpace(input.TaskPrompt),
+		CodexTemplate:          codexTemplate,
+		CodexModel:             optionalHarnessString(input.CodexModel),
+		AuthMode:               strings.TrimSpace(input.AuthMode),
+		OpenAIAPIKeySecretName: optionalHarnessString(input.OpenAIAPIKeySecretName),
+		E2BAPIKeySecretName:    optionalHarnessString(input.E2BAPIKeySecretName),
+		RepositoryURL:          optionalHarnessString(input.RepositoryURL),
+		BaseBranch:             optionalHarnessString(input.BaseBranch),
+		ExecutionConfig:        defaultJSON(input.ExecutionConfig),
+		EvaluationConfig:       defaultJSON(input.EvaluationConfig),
+	})
+}
+
+func (m *AgentHarnessManager) GetAgentHarness(ctx context.Context, caller Caller, id uuid.UUID) (repository.AgentHarness, error) {
+	harness, err := m.repo.GetAgentHarnessByID(ctx, id)
+	if err != nil {
+		return repository.AgentHarness{}, err
+	}
+	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, harness.WorkspaceID); err != nil {
+		return repository.AgentHarness{}, err
+	}
+	return harness, nil
+}
+
+func (m *AgentHarnessManager) ListAgentHarnesses(ctx context.Context, caller Caller, workspaceID uuid.UUID) ([]repository.AgentHarness, error) {
+	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, workspaceID); err != nil {
+		return nil, err
+	}
+	return m.repo.ListAgentHarnessesByWorkspaceID(ctx, workspaceID)
+}
+
+func validateAgentHarnessInput(input CreateAgentHarnessInput) error {
+	if strings.TrimSpace(input.Name) == "" {
+		return AgentHarnessValidationError{Code: "invalid_name", Message: "name is required"}
+	}
+	if strings.TrimSpace(input.TaskPrompt) == "" {
+		return AgentHarnessValidationError{Code: "invalid_task_prompt", Message: "task_prompt is required"}
+	}
+	switch strings.TrimSpace(input.AuthMode) {
+	case AgentHarnessAuthModeChatGPTDevice, AgentHarnessAuthModeAPIKeySecret, AgentHarnessAuthModeBringYourOwnEnv:
+	case "":
+		return AgentHarnessValidationError{Code: "invalid_auth_mode", Message: "auth_mode is required"}
+	default:
+		return AgentHarnessValidationError{Code: "invalid_auth_mode", Message: "auth_mode must be one of chatgpt_device, api_key_secret, bring_your_own_env"}
+	}
+	if strings.TrimSpace(input.AuthMode) == AgentHarnessAuthModeAPIKeySecret && strings.TrimSpace(input.OpenAIAPIKeySecretName) == "" {
+		return AgentHarnessValidationError{Code: "missing_openai_secret", Message: "openai_api_key_secret_name is required when auth_mode is api_key_secret"}
+	}
+	for field, raw := range map[string]json.RawMessage{
+		"execution_config":  input.ExecutionConfig,
+		"evaluation_config": input.EvaluationConfig,
+	} {
+		if len(raw) > 0 && !json.Valid(raw) {
+			return AgentHarnessValidationError{Code: "invalid_json", Message: fmt.Sprintf("%s must be valid JSON", field)}
+		}
+	}
+	return nil
+}
+
+func optionalHarnessString(value string) *string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}
+
+type agentHarnessResponse struct {
+	ID                     uuid.UUID       `json:"id"`
+	OrganizationID         uuid.UUID       `json:"organization_id"`
+	WorkspaceID            uuid.UUID       `json:"workspace_id"`
+	CreatedByUserID        *uuid.UUID      `json:"created_by_user_id,omitempty"`
+	Name                   string          `json:"name"`
+	Slug                   string          `json:"slug"`
+	Description            string          `json:"description"`
+	Status                 string          `json:"status"`
+	HarnessKind            string          `json:"harness_kind"`
+	TaskPrompt             string          `json:"task_prompt"`
+	CodexTemplate          string          `json:"codex_template"`
+	CodexModel             *string         `json:"codex_model,omitempty"`
+	AuthMode               string          `json:"auth_mode"`
+	OpenAIAPIKeySecretName *string         `json:"openai_api_key_secret_name,omitempty"`
+	E2BAPIKeySecretName    *string         `json:"e2b_api_key_secret_name,omitempty"`
+	RepositoryURL          *string         `json:"repository_url,omitempty"`
+	BaseBranch             *string         `json:"base_branch,omitempty"`
+	ExecutionConfig        json.RawMessage `json:"execution_config"`
+	EvaluationConfig       json.RawMessage `json:"evaluation_config"`
+	CreatedAt              time.Time       `json:"created_at"`
+	UpdatedAt              time.Time       `json:"updated_at"`
+}
+
+type listAgentHarnessesResponse struct {
+	Items []agentHarnessResponse `json:"items"`
+}
+
+func createAgentHarnessHandler(logger *slog.Logger, service AgentHarnessService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		workspaceID, err := uuid.Parse(chi.URLParam(r, "workspaceID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_workspace_id", "workspaceID must be a UUID")
+			return
+		}
+		var input CreateAgentHarnessInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_json", "request body must be JSON")
+			return
+		}
+		harness, err := service.CreateAgentHarness(r.Context(), caller, workspaceID, input)
+		if err != nil {
+			writeAgentHarnessError(w, logger, r, err)
+			return
+		}
+		writeJSON(w, http.StatusCreated, mapAgentHarnessResponse(harness))
+	}
+}
+
+func listAgentHarnessesHandler(logger *slog.Logger, service AgentHarnessService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		workspaceID, err := uuid.Parse(chi.URLParam(r, "workspaceID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_workspace_id", "workspaceID must be a UUID")
+			return
+		}
+		harnesses, err := service.ListAgentHarnesses(r.Context(), caller, workspaceID)
+		if err != nil {
+			writeAgentHarnessError(w, logger, r, err)
+			return
+		}
+		items := make([]agentHarnessResponse, 0, len(harnesses))
+		for _, harness := range harnesses {
+			items = append(items, mapAgentHarnessResponse(harness))
+		}
+		writeJSON(w, http.StatusOK, listAgentHarnessesResponse{Items: items})
+	}
+}
+
+func getAgentHarnessHandler(logger *slog.Logger, service AgentHarnessService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		harnessID, err := uuid.Parse(chi.URLParam(r, "harnessID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_harness_id", "harnessID must be a UUID")
+			return
+		}
+		harness, err := service.GetAgentHarness(r.Context(), caller, harnessID)
+		if err != nil {
+			writeAgentHarnessError(w, logger, r, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, mapAgentHarnessResponse(harness))
+	}
+}
+
+func mapAgentHarnessResponse(h repository.AgentHarness) agentHarnessResponse {
+	return agentHarnessResponse{
+		ID:                     h.ID,
+		OrganizationID:         h.OrganizationID,
+		WorkspaceID:            h.WorkspaceID,
+		CreatedByUserID:        h.CreatedByUserID,
+		Name:                   h.Name,
+		Slug:                   h.Slug,
+		Description:            h.Description,
+		Status:                 h.Status,
+		HarnessKind:            h.HarnessKind,
+		TaskPrompt:             h.TaskPrompt,
+		CodexTemplate:          h.CodexTemplate,
+		CodexModel:             h.CodexModel,
+		AuthMode:               h.AuthMode,
+		OpenAIAPIKeySecretName: h.OpenAIAPIKeySecretName,
+		E2BAPIKeySecretName:    h.E2BAPIKeySecretName,
+		RepositoryURL:          h.RepositoryURL,
+		BaseBranch:             h.BaseBranch,
+		ExecutionConfig:        h.ExecutionConfig,
+		EvaluationConfig:       h.EvaluationConfig,
+		CreatedAt:              h.CreatedAt,
+		UpdatedAt:              h.UpdatedAt,
+	}
+}
+
+func writeAgentHarnessError(w http.ResponseWriter, logger *slog.Logger, r *http.Request, err error) {
+	var validationErr AgentHarnessValidationError
+	switch {
+	case errors.As(err, &validationErr):
+		writeError(w, http.StatusBadRequest, validationErr.Code, validationErr.Message)
+	case errors.Is(err, repository.ErrAgentHarnessNotFound):
+		writeError(w, http.StatusNotFound, "not_found", "agent harness not found")
+	default:
+		if errors.Is(err, ErrUnauthenticated) || errors.Is(err, ErrCallerMissing) || errors.Is(err, ErrForbidden) {
+			writeAuthzError(w, err)
+			return
+		}
+		logger.Error("agent harness request failed",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"error", err,
+		)
+		writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+	}
+}
+
+type noopAgentHarnessService struct{}
+
+func (noopAgentHarnessService) CreateAgentHarness(context.Context, Caller, uuid.UUID, CreateAgentHarnessInput) (repository.AgentHarness, error) {
+	return repository.AgentHarness{}, errors.New("agent harness service is not configured")
+}
+
+func (noopAgentHarnessService) GetAgentHarness(context.Context, Caller, uuid.UUID) (repository.AgentHarness, error) {
+	return repository.AgentHarness{}, errors.New("agent harness service is not configured")
+}
+
+func (noopAgentHarnessService) ListAgentHarnesses(context.Context, Caller, uuid.UUID) ([]repository.AgentHarness, error) {
+	return nil, errors.New("agent harness service is not configured")
+}

--- a/backend/internal/api/agent_harnesses.go
+++ b/backend/internal/api/agent_harnesses.go
@@ -31,7 +31,7 @@ type AgentHarnessRepository interface {
 
 type AgentHarnessService interface {
 	CreateAgentHarness(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateAgentHarnessInput) (repository.AgentHarness, error)
-	GetAgentHarness(ctx context.Context, caller Caller, id uuid.UUID) (repository.AgentHarness, error)
+	GetAgentHarness(ctx context.Context, caller Caller, workspaceID uuid.UUID, id uuid.UUID) (repository.AgentHarness, error)
 	ListAgentHarnesses(ctx context.Context, caller Caller, workspaceID uuid.UUID) ([]repository.AgentHarness, error)
 }
 
@@ -106,13 +106,16 @@ func (m *AgentHarnessManager) CreateAgentHarness(ctx context.Context, caller Cal
 	})
 }
 
-func (m *AgentHarnessManager) GetAgentHarness(ctx context.Context, caller Caller, id uuid.UUID) (repository.AgentHarness, error) {
+func (m *AgentHarnessManager) GetAgentHarness(ctx context.Context, caller Caller, workspaceID uuid.UUID, id uuid.UUID) (repository.AgentHarness, error) {
+	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, workspaceID); err != nil {
+		return repository.AgentHarness{}, err
+	}
 	harness, err := m.repo.GetAgentHarnessByID(ctx, id)
 	if err != nil {
 		return repository.AgentHarness{}, err
 	}
-	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, harness.WorkspaceID); err != nil {
-		return repository.AgentHarness{}, err
+	if harness.WorkspaceID != workspaceID {
+		return repository.AgentHarness{}, repository.ErrAgentHarnessNotFound
 	}
 	return harness, nil
 }
@@ -195,9 +198,9 @@ func createAgentHarnessHandler(logger *slog.Logger, service AgentHarnessService)
 			writeAuthzError(w, err)
 			return
 		}
-		workspaceID, err := uuid.Parse(chi.URLParam(r, "workspaceID"))
+		workspaceID, err := WorkspaceIDFromContext(r.Context())
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "invalid_workspace_id", "workspaceID must be a UUID")
+			writeAuthzError(w, err)
 			return
 		}
 		var input CreateAgentHarnessInput
@@ -221,9 +224,9 @@ func listAgentHarnessesHandler(logger *slog.Logger, service AgentHarnessService)
 			writeAuthzError(w, err)
 			return
 		}
-		workspaceID, err := uuid.Parse(chi.URLParam(r, "workspaceID"))
+		workspaceID, err := WorkspaceIDFromContext(r.Context())
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "invalid_workspace_id", "workspaceID must be a UUID")
+			writeAuthzError(w, err)
 			return
 		}
 		harnesses, err := service.ListAgentHarnesses(r.Context(), caller, workspaceID)
@@ -246,12 +249,17 @@ func getAgentHarnessHandler(logger *slog.Logger, service AgentHarnessService) ht
 			writeAuthzError(w, err)
 			return
 		}
+		workspaceID, err := WorkspaceIDFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
 		harnessID, err := uuid.Parse(chi.URLParam(r, "harnessID"))
 		if err != nil {
 			writeError(w, http.StatusBadRequest, "invalid_harness_id", "harnessID must be a UUID")
 			return
 		}
-		harness, err := service.GetAgentHarness(r.Context(), caller, harnessID)
+		harness, err := service.GetAgentHarness(r.Context(), caller, workspaceID, harnessID)
 		if err != nil {
 			writeAgentHarnessError(w, logger, r, err)
 			return
@@ -291,6 +299,8 @@ func writeAgentHarnessError(w http.ResponseWriter, logger *slog.Logger, r *http.
 	switch {
 	case errors.As(err, &validationErr):
 		writeError(w, http.StatusBadRequest, validationErr.Code, validationErr.Message)
+	case errors.Is(err, repository.ErrAgentHarnessSlugConflict):
+		writeError(w, http.StatusConflict, "agent_harness_slug_conflict", "an agent harness with this name already exists in the workspace")
 	case errors.Is(err, repository.ErrAgentHarnessNotFound):
 		writeError(w, http.StatusNotFound, "not_found", "agent harness not found")
 	default:
@@ -313,7 +323,7 @@ func (noopAgentHarnessService) CreateAgentHarness(context.Context, Caller, uuid.
 	return repository.AgentHarness{}, errors.New("agent harness service is not configured")
 }
 
-func (noopAgentHarnessService) GetAgentHarness(context.Context, Caller, uuid.UUID) (repository.AgentHarness, error) {
+func (noopAgentHarnessService) GetAgentHarness(context.Context, Caller, uuid.UUID, uuid.UUID) (repository.AgentHarness, error) {
 	return repository.AgentHarness{}, errors.New("agent harness service is not configured")
 }
 

--- a/backend/internal/api/agent_harnesses_test.go
+++ b/backend/internal/api/agent_harnesses_test.go
@@ -1,0 +1,269 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+func TestAgentHarnessManagerCreateValidatesRequiredFields(t *testing.T) {
+	workspaceID := uuid.New()
+	caller := testAgentHarnessCaller(workspaceID)
+	manager := NewAgentHarnessManager(NewCallerWorkspaceAuthorizer(), &fakeAgentHarnessRepo{
+		organizationID: uuid.New(),
+	})
+
+	tests := []struct {
+		name  string
+		input CreateAgentHarnessInput
+		code  string
+	}{
+		{
+			name: "name required",
+			input: CreateAgentHarnessInput{
+				TaskPrompt: "Do the task",
+				AuthMode:   AgentHarnessAuthModeChatGPTDevice,
+			},
+			code: "invalid_name",
+		},
+		{
+			name: "task prompt required",
+			input: CreateAgentHarnessInput{
+				Name:     "Codex harness",
+				AuthMode: AgentHarnessAuthModeChatGPTDevice,
+			},
+			code: "invalid_task_prompt",
+		},
+		{
+			name: "known auth mode required",
+			input: CreateAgentHarnessInput{
+				Name:       "Codex harness",
+				TaskPrompt: "Do the task",
+				AuthMode:   "oauth_magic",
+			},
+			code: "invalid_auth_mode",
+		},
+		{
+			name: "api key auth needs secret",
+			input: CreateAgentHarnessInput{
+				Name:       "Codex harness",
+				TaskPrompt: "Do the task",
+				AuthMode:   AgentHarnessAuthModeAPIKeySecret,
+			},
+			code: "missing_openai_secret",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := manager.CreateAgentHarness(context.Background(), caller, workspaceID, tc.input)
+			var validationErr AgentHarnessValidationError
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("error type = %T, want AgentHarnessValidationError", err)
+			}
+			if validationErr.Code != tc.code {
+				t.Fatalf("code = %q, want %q", validationErr.Code, tc.code)
+			}
+		})
+	}
+}
+
+func TestAgentHarnessManagerCreatePersistsHarnessDefaults(t *testing.T) {
+	workspaceID := uuid.New()
+	orgID := uuid.New()
+	repo := &fakeAgentHarnessRepo{organizationID: orgID}
+	manager := NewAgentHarnessManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	harness, err := manager.CreateAgentHarness(context.Background(), testAgentHarnessCaller(workspaceID), workspaceID, CreateAgentHarnessInput{
+		Name:                   " Codex Long Runner ",
+		Description:            "  checks long tasks  ",
+		TaskPrompt:             "  implement the requested change  ",
+		AuthMode:               AgentHarnessAuthModeAPIKeySecret,
+		OpenAIAPIKeySecretName: " OPENAI_API_KEY ",
+		E2BAPIKeySecretName:    " E2B_API_KEY ",
+		RepositoryURL:          " https://github.com/acme/repo ",
+		BaseBranch:             " main ",
+		EvaluationConfig:       json.RawMessage(`{"validators":[{"type":"command","command":"go test ./..."}]}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentHarness error: %v", err)
+	}
+
+	if harness.OrganizationID != orgID {
+		t.Fatalf("organization_id = %s, want %s", harness.OrganizationID, orgID)
+	}
+	if harness.Name != "Codex Long Runner" {
+		t.Fatalf("name = %q", harness.Name)
+	}
+	if harness.Slug != "codex-long-runner" {
+		t.Fatalf("slug = %q", harness.Slug)
+	}
+	if harness.CodexTemplate != "codex" {
+		t.Fatalf("codex_template = %q, want codex", harness.CodexTemplate)
+	}
+	if harness.OpenAIAPIKeySecretName == nil || *harness.OpenAIAPIKeySecretName != "OPENAI_API_KEY" {
+		t.Fatalf("openai secret = %#v", harness.OpenAIAPIKeySecretName)
+	}
+	if string(repo.created.EvaluationConfig) == "{}" {
+		t.Fatal("evaluation_config was not persisted")
+	}
+}
+
+func TestAgentHarnessRoutesCreateAndList(t *testing.T) {
+	workspaceID := uuid.New()
+	service := &fakeAgentHarnessService{
+		harnesses: []repository.AgentHarness{
+			testAgentHarnessRecord(workspaceID, "Existing harness"),
+		},
+	}
+	router := chi.NewRouter()
+	router.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := context.WithValue(r.Context(), callerContextKey{}, testAgentHarnessCaller(workspaceID))
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	})
+	router.Post("/v1/workspaces/{workspaceID}/agent-harnesses", createAgentHarnessHandler(slog.Default(), service))
+	router.Get("/v1/workspaces/{workspaceID}/agent-harnesses", listAgentHarnessesHandler(slog.Default(), service))
+
+	createReq := httptest.NewRequest(http.MethodPost, "/v1/workspaces/"+workspaceID.String()+"/agent-harnesses", bytes.NewBufferString(`{
+		"name": "Codex autonomy check",
+		"task_prompt": "Make the requested change and run tests.",
+		"auth_mode": "chatgpt_device",
+		"evaluation_config": {"llm_judges": [{"key": "autonomy"}]}
+	}`))
+	createRec := httptest.NewRecorder()
+	router.ServeHTTP(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, body %s", createRec.Code, createRec.Body.String())
+	}
+	if service.createdInput.AuthMode != AgentHarnessAuthModeChatGPTDevice {
+		t.Fatalf("auth_mode = %q", service.createdInput.AuthMode)
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/v1/workspaces/"+workspaceID.String()+"/agent-harnesses", nil)
+	listRec := httptest.NewRecorder()
+	router.ServeHTTP(listRec, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("list status = %d", listRec.Code)
+	}
+	var listed listAgentHarnessesResponse
+	if err := json.Unmarshal(listRec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(listed.Items) != 1 || listed.Items[0].Name != "Existing harness" {
+		t.Fatalf("items = %#v", listed.Items)
+	}
+}
+
+func testAgentHarnessCaller(workspaceID uuid.UUID) Caller {
+	return Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_admin"},
+		},
+		OrganizationMemberships: map[uuid.UUID]OrganizationMembership{},
+	}
+}
+
+func testAgentHarnessRecord(workspaceID uuid.UUID, name string) repository.AgentHarness {
+	now := time.Now().UTC()
+	return repository.AgentHarness{
+		ID:               uuid.New(),
+		OrganizationID:   uuid.New(),
+		WorkspaceID:      workspaceID,
+		Name:             name,
+		Slug:             generateSlug(name),
+		Description:      "description",
+		Status:           "draft",
+		HarnessKind:      "codex_e2b",
+		TaskPrompt:       "Do the task",
+		CodexTemplate:    "codex",
+		AuthMode:         AgentHarnessAuthModeChatGPTDevice,
+		ExecutionConfig:  json.RawMessage(`{}`),
+		EvaluationConfig: json.RawMessage(`{}`),
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+}
+
+type fakeAgentHarnessRepo struct {
+	organizationID uuid.UUID
+	created        repository.CreateAgentHarnessParams
+}
+
+func (f *fakeAgentHarnessRepo) GetOrganizationIDByWorkspaceID(context.Context, uuid.UUID) (uuid.UUID, error) {
+	return f.organizationID, nil
+}
+
+func (f *fakeAgentHarnessRepo) CreateAgentHarness(_ context.Context, p repository.CreateAgentHarnessParams) (repository.AgentHarness, error) {
+	f.created = p
+	now := time.Now().UTC()
+	return repository.AgentHarness{
+		ID:                     uuid.New(),
+		OrganizationID:         p.OrganizationID,
+		WorkspaceID:            p.WorkspaceID,
+		CreatedByUserID:        p.CreatedByUserID,
+		Name:                   p.Name,
+		Slug:                   p.Slug,
+		Description:            p.Description,
+		Status:                 "draft",
+		HarnessKind:            "codex_e2b",
+		TaskPrompt:             p.TaskPrompt,
+		CodexTemplate:          p.CodexTemplate,
+		CodexModel:             p.CodexModel,
+		AuthMode:               p.AuthMode,
+		OpenAIAPIKeySecretName: p.OpenAIAPIKeySecretName,
+		E2BAPIKeySecretName:    p.E2BAPIKeySecretName,
+		RepositoryURL:          p.RepositoryURL,
+		BaseBranch:             p.BaseBranch,
+		ExecutionConfig:        p.ExecutionConfig,
+		EvaluationConfig:       p.EvaluationConfig,
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}, nil
+}
+
+func (f *fakeAgentHarnessRepo) GetAgentHarnessByID(context.Context, uuid.UUID) (repository.AgentHarness, error) {
+	return repository.AgentHarness{}, repository.ErrAgentHarnessNotFound
+}
+
+func (f *fakeAgentHarnessRepo) ListAgentHarnessesByWorkspaceID(context.Context, uuid.UUID) ([]repository.AgentHarness, error) {
+	return nil, nil
+}
+
+type fakeAgentHarnessService struct {
+	harnesses    []repository.AgentHarness
+	createdInput CreateAgentHarnessInput
+}
+
+func (f *fakeAgentHarnessService) CreateAgentHarness(_ context.Context, _ Caller, workspaceID uuid.UUID, input CreateAgentHarnessInput) (repository.AgentHarness, error) {
+	f.createdInput = input
+	return testAgentHarnessRecord(workspaceID, input.Name), nil
+}
+
+func (f *fakeAgentHarnessService) GetAgentHarness(_ context.Context, _ Caller, id uuid.UUID) (repository.AgentHarness, error) {
+	for _, harness := range f.harnesses {
+		if harness.ID == id {
+			return harness, nil
+		}
+	}
+	return repository.AgentHarness{}, repository.ErrAgentHarnessNotFound
+}
+
+func (f *fakeAgentHarnessService) ListAgentHarnesses(context.Context, Caller, uuid.UUID) ([]repository.AgentHarness, error) {
+	return f.harnesses, nil
+}

--- a/backend/internal/api/agent_harnesses_test.go
+++ b/backend/internal/api/agent_harnesses_test.go
@@ -133,11 +133,13 @@ func TestAgentHarnessRoutesCreateAndList(t *testing.T) {
 	router.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := context.WithValue(r.Context(), callerContextKey{}, testAgentHarnessCaller(workspaceID))
+			ctx = context.WithValue(ctx, workspaceIDContextKey{}, workspaceID)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	})
 	router.Post("/v1/workspaces/{workspaceID}/agent-harnesses", createAgentHarnessHandler(slog.Default(), service))
 	router.Get("/v1/workspaces/{workspaceID}/agent-harnesses", listAgentHarnessesHandler(slog.Default(), service))
+	router.Get("/v1/workspaces/{workspaceID}/agent-harnesses/{harnessID}", getAgentHarnessHandler(slog.Default(), service))
 
 	createReq := httptest.NewRequest(http.MethodPost, "/v1/workspaces/"+workspaceID.String()+"/agent-harnesses", bytes.NewBufferString(`{
 		"name": "Codex autonomy check",
@@ -166,6 +168,64 @@ func TestAgentHarnessRoutesCreateAndList(t *testing.T) {
 	}
 	if len(listed.Items) != 1 || listed.Items[0].Name != "Existing harness" {
 		t.Fatalf("items = %#v", listed.Items)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/v1/workspaces/"+workspaceID.String()+"/agent-harnesses/"+service.harnesses[0].ID.String(), nil)
+	getRec := httptest.NewRecorder()
+	router.ServeHTTP(getRec, getReq)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("get status = %d, body %s", getRec.Code, getRec.Body.String())
+	}
+}
+
+func TestAgentHarnessRouteReturnsConflictOnDuplicateSlug(t *testing.T) {
+	workspaceID := uuid.New()
+	service := &fakeAgentHarnessService{createErr: repository.ErrAgentHarnessSlugConflict}
+	router := chi.NewRouter()
+	router.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := context.WithValue(r.Context(), callerContextKey{}, testAgentHarnessCaller(workspaceID))
+			ctx = context.WithValue(ctx, workspaceIDContextKey{}, workspaceID)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	})
+	router.Post("/v1/workspaces/{workspaceID}/agent-harnesses", createAgentHarnessHandler(slog.Default(), service))
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/workspaces/"+workspaceID.String()+"/agent-harnesses", bytes.NewBufferString(`{
+		"name": "Codex autonomy check",
+		"task_prompt": "Make the requested change and run tests.",
+		"auth_mode": "chatgpt_device"
+	}`))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d; body %s", rec.Code, http.StatusConflict, rec.Body.String())
+	}
+}
+
+func TestAgentHarnessManagerGetChecksWorkspaceBeforeFetch(t *testing.T) {
+	workspaceID := uuid.New()
+	repo := &fakeAgentHarnessRepo{organizationID: uuid.New()}
+	manager := NewAgentHarnessManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	_, err := manager.GetAgentHarness(context.Background(), testAgentHarnessCaller(uuid.New()), workspaceID, uuid.New())
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("error = %v, want ErrForbidden", err)
+	}
+	if repo.getByIDCalls != 0 {
+		t.Fatalf("GetAgentHarnessByID calls = %d, want 0", repo.getByIDCalls)
+	}
+}
+
+func TestAgentHarnessManagerGetReturnsNotFoundForWorkspaceMismatch(t *testing.T) {
+	workspaceID := uuid.New()
+	harness := testAgentHarnessRecord(uuid.New(), "Other workspace harness")
+	repo := &fakeAgentHarnessRepo{organizationID: uuid.New(), harness: harness}
+	manager := NewAgentHarnessManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	_, err := manager.GetAgentHarness(context.Background(), testAgentHarnessCaller(workspaceID), workspaceID, harness.ID)
+	if !errors.Is(err, repository.ErrAgentHarnessNotFound) {
+		t.Fatalf("error = %v, want ErrAgentHarnessNotFound", err)
 	}
 }
 
@@ -203,6 +263,8 @@ func testAgentHarnessRecord(workspaceID uuid.UUID, name string) repository.Agent
 type fakeAgentHarnessRepo struct {
 	organizationID uuid.UUID
 	created        repository.CreateAgentHarnessParams
+	harness        repository.AgentHarness
+	getByIDCalls   int
 }
 
 func (f *fakeAgentHarnessRepo) GetOrganizationIDByWorkspaceID(context.Context, uuid.UUID) (uuid.UUID, error) {
@@ -237,7 +299,11 @@ func (f *fakeAgentHarnessRepo) CreateAgentHarness(_ context.Context, p repositor
 	}, nil
 }
 
-func (f *fakeAgentHarnessRepo) GetAgentHarnessByID(context.Context, uuid.UUID) (repository.AgentHarness, error) {
+func (f *fakeAgentHarnessRepo) GetAgentHarnessByID(_ context.Context, id uuid.UUID) (repository.AgentHarness, error) {
+	f.getByIDCalls++
+	if f.harness.ID == id {
+		return f.harness, nil
+	}
 	return repository.AgentHarness{}, repository.ErrAgentHarnessNotFound
 }
 
@@ -248,14 +314,18 @@ func (f *fakeAgentHarnessRepo) ListAgentHarnessesByWorkspaceID(context.Context, 
 type fakeAgentHarnessService struct {
 	harnesses    []repository.AgentHarness
 	createdInput CreateAgentHarnessInput
+	createErr    error
 }
 
 func (f *fakeAgentHarnessService) CreateAgentHarness(_ context.Context, _ Caller, workspaceID uuid.UUID, input CreateAgentHarnessInput) (repository.AgentHarness, error) {
 	f.createdInput = input
+	if f.createErr != nil {
+		return repository.AgentHarness{}, f.createErr
+	}
 	return testAgentHarnessRecord(workspaceID, input.Name), nil
 }
 
-func (f *fakeAgentHarnessService) GetAgentHarness(_ context.Context, _ Caller, id uuid.UUID) (repository.AgentHarness, error) {
+func (f *fakeAgentHarnessService) GetAgentHarness(_ context.Context, _ Caller, _ uuid.UUID, id uuid.UUID) (repository.AgentHarness, error) {
 	for _, harness := range f.harnesses {
 		if harness.ID == id {
 			return harness, nil

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -22,6 +22,7 @@ func registerProtectedRoutes(
 	releaseGateService ReleaseGateService,
 	regressionService RegressionService,
 	agentDeploymentReadService AgentDeploymentReadService,
+	agentHarnessService AgentHarnessService,
 	challengePackReadService ChallengePackReadService,
 	challengePackAuthoringService ChallengePackAuthoringService,
 	agentBuildService AgentBuildService,
@@ -121,6 +122,9 @@ func registerProtectedRoutes(
 	router.Get("/playground-experiments/compare", comparePlaygroundExperimentsHandler(logger, playgroundService))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Get("/workspaces/{workspaceID}/agent-deployments", listAgentDeploymentsHandler(logger, agentDeploymentReadService))
+	router.Post("/workspaces/{workspaceID}/agent-harnesses", createAgentHarnessHandler(logger, agentHarnessService))
+	router.Get("/workspaces/{workspaceID}/agent-harnesses", listAgentHarnessesHandler(logger, agentHarnessService))
+	router.Get("/agent-harnesses/{harnessID}", getAgentHarnessHandler(logger, agentHarnessService))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Get("/workspaces/{workspaceID}/challenge-packs", listChallengePacksHandler(logger, challengePackReadService))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -122,9 +122,12 @@ func registerProtectedRoutes(
 	router.Get("/playground-experiments/compare", comparePlaygroundExperimentsHandler(logger, playgroundService))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Get("/workspaces/{workspaceID}/agent-deployments", listAgentDeploymentsHandler(logger, agentDeploymentReadService))
-	router.Post("/workspaces/{workspaceID}/agent-harnesses", createAgentHarnessHandler(logger, agentHarnessService))
-	router.Get("/workspaces/{workspaceID}/agent-harnesses", listAgentHarnessesHandler(logger, agentHarnessService))
-	router.Get("/agent-harnesses/{harnessID}", getAgentHarnessHandler(logger, agentHarnessService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Post("/workspaces/{workspaceID}/agent-harnesses", createAgentHarnessHandler(logger, agentHarnessService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Get("/workspaces/{workspaceID}/agent-harnesses", listAgentHarnessesHandler(logger, agentHarnessService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Get("/workspaces/{workspaceID}/agent-harnesses/{harnessID}", getAgentHarnessHandler(logger, agentHarnessService))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Get("/workspaces/{workspaceID}/challenge-packs", listChallengePacksHandler(logger, challengePackReadService))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -38,6 +38,7 @@ type routerOptions struct {
 	regressionService          RegressionService
 	hostedRunIngestionService  HostedRunIngestionService
 	agentDeploymentReadService AgentDeploymentReadService
+	agentHarnessService        AgentHarnessService
 	challengePackReadService   ChallengePackReadService
 	challengePackAuthoringSvc  ChallengePackAuthoringService
 	agentBuildService          AgentBuildService
@@ -70,6 +71,7 @@ func NewServer(
 	regressionService RegressionService,
 	hostedRunIngestionService HostedRunIngestionService,
 	agentDeploymentReadService AgentDeploymentReadService,
+	agentHarnessService AgentHarnessService,
 	challengePackReadService ChallengePackReadService,
 	challengePackAuthoringService ChallengePackAuthoringService,
 	agentBuildService AgentBuildService,
@@ -103,6 +105,7 @@ func NewServer(
 		regressionService:          regressionService,
 		hostedRunIngestionService:  hostedRunIngestionService,
 		agentDeploymentReadService: agentDeploymentReadService,
+		agentHarnessService:        agentHarnessService,
 		challengePackReadService:   challengePackReadService,
 		challengePackAuthoringSvc:  challengePackAuthoringService,
 		agentBuildService:          agentBuildService,
@@ -244,6 +247,7 @@ func buildRouter(opts routerOptions) http.Handler {
 	hostedRunIngestionService := opts.hostedRunIngestionService
 	compareReadService := opts.compareReadService
 	agentDeploymentReadService := opts.agentDeploymentReadService
+	agentHarnessService := opts.agentHarnessService
 	challengePackReadService := opts.challengePackReadService
 	agentBuildService := opts.agentBuildService
 	releaseGateService := opts.releaseGateService
@@ -286,6 +290,9 @@ func buildRouter(opts routerOptions) http.Handler {
 	}
 	if challengePackAuthoringService == nil {
 		challengePackAuthoringService = noopChallengePackAuthoringService{}
+	}
+	if agentHarnessService == nil {
+		agentHarnessService = noopAgentHarnessService{}
 	}
 	if regressionService == nil {
 		regressionService = noopRegressionService{}
@@ -349,7 +356,7 @@ func buildRouter(opts routerOptions) http.Handler {
 	router.Route("/v1", func(r chi.Router) {
 		r.Use(authenticateRequest(logger, authenticator))
 		r.Use(rateLimiter.Middleware("default", extractWorkspaceID))
-		registerProtectedRoutes(r, logger, authorizer, playgroundService, artifactService, artifactMaxUploadBytes, runCreationService, runReadService, replayReadService, compareReadService, releaseGateService, regressionService, agentDeploymentReadService, challengePackReadService, challengePackAuthoringService, agentBuildService, userService, orgService, wsService, orgMembershipService, wsMembershipService, onboardingService, infraService, workspaceSecretsService, cliAuthService, publicShareService, billingService)
+		registerProtectedRoutes(r, logger, authorizer, playgroundService, artifactService, artifactMaxUploadBytes, runCreationService, runReadService, replayReadService, compareReadService, releaseGateService, regressionService, agentDeploymentReadService, agentHarnessService, challengePackReadService, challengePackAuthoringService, agentBuildService, userService, orgService, wsService, orgMembershipService, wsMembershipService, onboardingService, infraService, workspaceSecretsService, cliAuthService, publicShareService, billingService)
 	})
 
 	return router

--- a/backend/internal/repository/agent_harnesses.go
+++ b/backend/internal/repository/agent_harnesses.go
@@ -1,0 +1,154 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+var ErrAgentHarnessNotFound = errors.New("agent harness not found")
+
+type AgentHarness struct {
+	ID                     uuid.UUID
+	OrganizationID         uuid.UUID
+	WorkspaceID            uuid.UUID
+	CreatedByUserID        *uuid.UUID
+	Name                   string
+	Slug                   string
+	Description            string
+	Status                 string
+	HarnessKind            string
+	TaskPrompt             string
+	CodexTemplate          string
+	CodexModel             *string
+	AuthMode               string
+	OpenAIAPIKeySecretName *string
+	E2BAPIKeySecretName    *string
+	RepositoryURL          *string
+	BaseBranch             *string
+	ExecutionConfig        json.RawMessage
+	EvaluationConfig       json.RawMessage
+	CreatedAt              time.Time
+	UpdatedAt              time.Time
+	ArchivedAt             *time.Time
+}
+
+type CreateAgentHarnessParams struct {
+	OrganizationID         uuid.UUID
+	WorkspaceID            uuid.UUID
+	CreatedByUserID        *uuid.UUID
+	Name                   string
+	Slug                   string
+	Description            string
+	TaskPrompt             string
+	CodexTemplate          string
+	CodexModel             *string
+	AuthMode               string
+	OpenAIAPIKeySecretName *string
+	E2BAPIKeySecretName    *string
+	RepositoryURL          *string
+	BaseBranch             *string
+	ExecutionConfig        json.RawMessage
+	EvaluationConfig       json.RawMessage
+}
+
+func (r *Repository) CreateAgentHarness(ctx context.Context, p CreateAgentHarnessParams) (AgentHarness, error) {
+	row := r.db.QueryRow(ctx, `
+INSERT INTO agent_harnesses (
+    organization_id, workspace_id, created_by_user_id, name, slug, description,
+    task_prompt, codex_template, codex_model, auth_mode, openai_api_key_secret_name,
+    e2b_api_key_secret_name, repository_url, base_branch, execution_config, evaluation_config
+) VALUES (
+    $1, $2, $3, $4, $5, $6,
+    $7, $8, $9, $10, $11,
+    $12, $13, $14, $15, $16
+)
+RETURNING id, organization_id, workspace_id, created_by_user_id, name, slug, description,
+    status, harness_kind, task_prompt, codex_template, codex_model, auth_mode,
+    openai_api_key_secret_name, e2b_api_key_secret_name, repository_url, base_branch,
+    execution_config, evaluation_config, created_at, updated_at, archived_at`,
+		p.OrganizationID, p.WorkspaceID, p.CreatedByUserID, p.Name, p.Slug, p.Description,
+		p.TaskPrompt, p.CodexTemplate, p.CodexModel, p.AuthMode, p.OpenAIAPIKeySecretName,
+		p.E2BAPIKeySecretName, p.RepositoryURL, p.BaseBranch, p.ExecutionConfig, p.EvaluationConfig,
+	)
+	return scanAgentHarness(row)
+}
+
+func (r *Repository) GetAgentHarnessByID(ctx context.Context, id uuid.UUID) (AgentHarness, error) {
+	row := r.db.QueryRow(ctx, `
+SELECT id, organization_id, workspace_id, created_by_user_id, name, slug, description,
+    status, harness_kind, task_prompt, codex_template, codex_model, auth_mode,
+    openai_api_key_secret_name, e2b_api_key_secret_name, repository_url, base_branch,
+    execution_config, evaluation_config, created_at, updated_at, archived_at
+FROM agent_harnesses
+WHERE id = $1 AND archived_at IS NULL`, id)
+	return scanAgentHarness(row)
+}
+
+func (r *Repository) ListAgentHarnessesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]AgentHarness, error) {
+	rows, err := r.db.Query(ctx, `
+SELECT id, organization_id, workspace_id, created_by_user_id, name, slug, description,
+    status, harness_kind, task_prompt, codex_template, codex_model, auth_mode,
+    openai_api_key_secret_name, e2b_api_key_secret_name, repository_url, base_branch,
+    execution_config, evaluation_config, created_at, updated_at, archived_at
+FROM agent_harnesses
+WHERE workspace_id = $1 AND archived_at IS NULL
+ORDER BY updated_at DESC, id DESC`, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	harnesses := make([]AgentHarness, 0)
+	for rows.Next() {
+		harness, scanErr := scanAgentHarness(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		harnesses = append(harnesses, harness)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return harnesses, nil
+}
+
+type agentHarnessScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanAgentHarness(scanner agentHarnessScanner) (AgentHarness, error) {
+	var h AgentHarness
+	err := scanner.Scan(
+		&h.ID,
+		&h.OrganizationID,
+		&h.WorkspaceID,
+		&h.CreatedByUserID,
+		&h.Name,
+		&h.Slug,
+		&h.Description,
+		&h.Status,
+		&h.HarnessKind,
+		&h.TaskPrompt,
+		&h.CodexTemplate,
+		&h.CodexModel,
+		&h.AuthMode,
+		&h.OpenAIAPIKeySecretName,
+		&h.E2BAPIKeySecretName,
+		&h.RepositoryURL,
+		&h.BaseBranch,
+		&h.ExecutionConfig,
+		&h.EvaluationConfig,
+		&h.CreatedAt,
+		&h.UpdatedAt,
+		&h.ArchivedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return AgentHarness{}, ErrAgentHarnessNotFound
+	}
+	return h, err
+}

--- a/backend/internal/repository/agent_harnesses.go
+++ b/backend/internal/repository/agent_harnesses.go
@@ -4,13 +4,18 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
-var ErrAgentHarnessNotFound = errors.New("agent harness not found")
+var (
+	ErrAgentHarnessNotFound     = errors.New("agent harness not found")
+	ErrAgentHarnessSlugConflict = errors.New("agent harness slug already exists in workspace")
+)
 
 type AgentHarness struct {
 	ID                     uuid.UUID
@@ -75,7 +80,14 @@ RETURNING id, organization_id, workspace_id, created_by_user_id, name, slug, des
 		p.TaskPrompt, p.CodexTemplate, p.CodexModel, p.AuthMode, p.OpenAIAPIKeySecretName,
 		p.E2BAPIKeySecretName, p.RepositoryURL, p.BaseBranch, p.ExecutionConfig, p.EvaluationConfig,
 	)
-	return scanAgentHarness(row)
+	harness, err := scanAgentHarness(row)
+	if err != nil {
+		if isAgentHarnessSlugConflict(err) {
+			return AgentHarness{}, ErrAgentHarnessSlugConflict
+		}
+		return AgentHarness{}, err
+	}
+	return harness, nil
 }
 
 func (r *Repository) GetAgentHarnessByID(ctx context.Context, id uuid.UUID) (AgentHarness, error) {
@@ -151,4 +163,9 @@ func scanAgentHarness(scanner agentHarnessScanner) (AgentHarness, error) {
 		return AgentHarness{}, ErrAgentHarnessNotFound
 	}
 	return h, err
+}
+
+func isAgentHarnessSlugConflict(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505" && strings.Contains(pgErr.ConstraintName, "slug")
 }

--- a/cli/cmd/agent_harness.go
+++ b/cli/cmd/agent_harness.go
@@ -1,0 +1,250 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/agentclash/agentclash/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(agentHarnessCmd)
+	agentHarnessCmd.AddCommand(agentHarnessListCmd)
+	agentHarnessCmd.AddCommand(agentHarnessCreateCmd)
+	agentHarnessCmd.AddCommand(agentHarnessGetCmd)
+
+	agentHarnessCreateCmd.Flags().String("from-file", "", "JSON file with agent harness spec")
+	agentHarnessCreateCmd.Flags().String("name", "", "Harness name")
+	agentHarnessCreateCmd.Flags().String("description", "", "Harness description")
+	agentHarnessCreateCmd.Flags().String("task", "", "Task prompt for the coding harness")
+	agentHarnessCreateCmd.Flags().String("codex-template", "codex", "E2B template with Codex installed")
+	agentHarnessCreateCmd.Flags().String("codex-model", "", "Codex model override")
+	agentHarnessCreateCmd.Flags().String("auth-mode", "chatgpt_device", "Codex auth mode: chatgpt_device, api_key_secret, bring_your_own_env")
+	agentHarnessCreateCmd.Flags().String("openai-api-key-secret", "", "Workspace secret name containing OPENAI_API_KEY")
+	agentHarnessCreateCmd.Flags().String("e2b-api-key-secret", "E2B_API_KEY", "Workspace secret name containing E2B_API_KEY")
+	agentHarnessCreateCmd.Flags().String("repository-url", "", "Repository URL for the harness task")
+	agentHarnessCreateCmd.Flags().String("base-branch", "", "Base branch for repository work")
+	agentHarnessCreateCmd.Flags().String("execution-config", "", "Inline JSON execution config")
+	agentHarnessCreateCmd.Flags().String("evaluation-config", "", "Inline JSON evaluation config")
+	agentHarnessCreateCmd.Flags().String("evaluation-config-file", "", "JSON file with validators and LLM judges")
+}
+
+var agentHarnessCmd = &cobra.Command{
+	Use:     "agent-harness",
+	Aliases: []string{"harness"},
+	Short:   "Manage coding-agent harnesses",
+	Long: `Manage Agent Harnesses: workspace-scoped coding-agent task definitions.
+
+Agent Harnesses are not challenge packs. They store a task prompt, Codex/E2B
+execution settings, and reusable evaluation config for long-running autonomous
+coding checks.`,
+}
+
+var agentHarnessListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List agent harnesses",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		wsID := RequireWorkspace(cmd)
+
+		resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+wsID+"/agent-harnesses", nil)
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+
+		var result struct {
+			Items []map[string]any `json:"items"`
+		}
+		if err := resp.DecodeJSON(&result); err != nil {
+			return err
+		}
+
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(result)
+		}
+
+		cols := []output.Column{{Header: "ID"}, {Header: "Name"}, {Header: "Auth"}, {Header: "Template"}, {Header: "Status"}, {Header: "Updated"}}
+		rows := make([][]string, len(result.Items))
+		for i, item := range result.Items {
+			rows[i] = []string{
+				str(item["id"]),
+				str(item["name"]),
+				str(item["auth_mode"]),
+				str(item["codex_template"]),
+				output.StatusColor(str(item["status"])),
+				str(item["updated_at"]),
+			}
+		}
+		rc.Output.PrintTable(cols, rows)
+		return nil
+	},
+}
+
+var agentHarnessGetCmd = &cobra.Command{
+	Use:   "get <id>",
+	Short: "Get an agent harness",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+
+		resp, err := rc.Client.Get(cmd.Context(), "/v1/agent-harnesses/"+args[0], nil)
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+
+		var harness map[string]any
+		if err := resp.DecodeJSON(&harness); err != nil {
+			return err
+		}
+
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(harness)
+		}
+
+		rc.Output.PrintDetail("ID", str(harness["id"]))
+		rc.Output.PrintDetail("Name", str(harness["name"]))
+		rc.Output.PrintDetail("Auth", str(harness["auth_mode"]))
+		rc.Output.PrintDetail("Codex Template", str(harness["codex_template"]))
+		rc.Output.PrintDetail("Repository", str(harness["repository_url"]))
+		rc.Output.PrintDetail("Status", output.StatusColor(str(harness["status"])))
+		rc.Output.PrintDetail("Task", str(harness["task_prompt"]))
+		return nil
+	},
+}
+
+var agentHarnessCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create an agent harness",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		wsID := RequireWorkspace(cmd)
+
+		body, err := buildAgentHarnessCreateBody(cmd)
+		if err != nil {
+			return err
+		}
+
+		resp, err := rc.Client.Post(cmd.Context(), "/v1/workspaces/"+wsID+"/agent-harnesses", body)
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+
+		var harness map[string]any
+		if err := resp.DecodeJSON(&harness); err != nil {
+			return err
+		}
+
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(harness)
+		}
+
+		rc.Output.PrintSuccess(fmt.Sprintf("Created agent harness %s (%s)", str(harness["name"]), str(harness["id"])))
+		rc.Output.PrintDetail("Auth", str(harness["auth_mode"]))
+		rc.Output.PrintDetail("Codex Template", str(harness["codex_template"]))
+		return nil
+	},
+}
+
+func buildAgentHarnessCreateBody(cmd *cobra.Command) (map[string]any, error) {
+	if fromFile, _ := cmd.Flags().GetString("from-file"); fromFile != "" {
+		data, err := os.ReadFile(fromFile)
+		if err != nil {
+			return nil, fmt.Errorf("reading file: %w", err)
+		}
+		var body map[string]any
+		if err := json.Unmarshal(data, &body); err != nil {
+			return nil, fmt.Errorf("parsing file: %w", err)
+		}
+		return body, nil
+	}
+
+	missing := requiredAgentHarnessCreateFlags(cmd)
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("missing required flags when --from-file is not used: %s", strings.Join(missing, ", "))
+	}
+
+	body := make(map[string]any)
+	setFlagIfChanged(cmd, body, "name", "name")
+	setFlagIfChanged(cmd, body, "description", "description")
+	setFlagIfChanged(cmd, body, "task", "task_prompt")
+	setFlagIfChanged(cmd, body, "codex-model", "codex_model")
+	setFlagIfChanged(cmd, body, "openai-api-key-secret", "openai_api_key_secret_name")
+	setFlagIfChanged(cmd, body, "repository-url", "repository_url")
+	setFlagIfChanged(cmd, body, "base-branch", "base_branch")
+	codexTemplate, _ := cmd.Flags().GetString("codex-template")
+	body["codex_template"] = codexTemplate
+	authMode, _ := cmd.Flags().GetString("auth-mode")
+	body["auth_mode"] = authMode
+	if e2bSecret, _ := cmd.Flags().GetString("e2b-api-key-secret"); strings.TrimSpace(e2bSecret) != "" {
+		body["e2b_api_key_secret_name"] = e2bSecret
+	}
+
+	if err := setJSONFlag(cmd, body, "execution-config", "execution_config"); err != nil {
+		return nil, err
+	}
+	if err := setJSONFlag(cmd, body, "evaluation-config", "evaluation_config"); err != nil {
+		return nil, err
+	}
+	if evalFile, _ := cmd.Flags().GetString("evaluation-config-file"); evalFile != "" {
+		value, err := readJSONFile(evalFile)
+		if err != nil {
+			return nil, err
+		}
+		body["evaluation_config"] = value
+	}
+
+	return body, nil
+}
+
+func requiredAgentHarnessCreateFlags(cmd *cobra.Command) []string {
+	required := []string{"name", "task", "auth-mode"}
+	authMode, _ := cmd.Flags().GetString("auth-mode")
+	if strings.TrimSpace(authMode) == "api_key_secret" {
+		required = append(required, "openai-api-key-secret")
+	}
+	missing := make([]string, 0, len(required))
+	for _, flagName := range required {
+		value, _ := cmd.Flags().GetString(flagName)
+		if strings.TrimSpace(value) == "" {
+			missing = append(missing, "--"+flagName)
+		}
+	}
+	return missing
+}
+
+func setJSONFlag(cmd *cobra.Command, body map[string]any, flagName, jsonKey string) error {
+	if !cmd.Flags().Changed(flagName) {
+		return nil
+	}
+	raw, _ := cmd.Flags().GetString(flagName)
+	var value any
+	if err := json.Unmarshal([]byte(raw), &value); err != nil {
+		return fmt.Errorf("--%s must be valid JSON: %w", flagName, err)
+	}
+	body[jsonKey] = value
+	return nil
+}
+
+func readJSONFile(path string) (any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading file: %w", err)
+	}
+	var value any
+	if err := json.Unmarshal(data, &value); err != nil {
+		return nil, fmt.Errorf("parsing file: %w", err)
+	}
+	return value, nil
+}

--- a/cli/cmd/agent_harness.go
+++ b/cli/cmd/agent_harness.go
@@ -92,8 +92,9 @@ var agentHarnessGetCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		rc := GetRunContext(cmd)
+		wsID := RequireWorkspace(cmd)
 
-		resp, err := rc.Client.Get(cmd.Context(), "/v1/agent-harnesses/"+args[0], nil)
+		resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+wsID+"/agent-harnesses/"+args[0], nil)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/agent_harness_test.go
+++ b/cli/cmd/agent_harness_test.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestAgentHarnessListCallsCorrectEndpoint(t *testing.T) {
+	var called bool
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-123/agent-harnesses": captureHandler(t, &called, 200, map[string]any{
+			"items": []map[string]any{
+				{"id": "harness-1", "name": "Codex", "auth_mode": "chatgpt_device", "codex_template": "codex", "status": "draft"},
+			},
+		}),
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{"--workspace", "ws-123", "agent-harness", "list"}, srv.URL)
+	if err != nil {
+		t.Fatalf("agent-harness list error: %v", err)
+	}
+	if !called {
+		t.Fatal("GET /v1/workspaces/ws-123/agent-harnesses was not called")
+	}
+}
+
+func TestAgentHarnessGetCallsCorrectEndpoint(t *testing.T) {
+	var called bool
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/agent-harnesses/harness-123": captureHandler(t, &called, 200, map[string]any{
+			"id": "harness-123", "name": "Codex", "auth_mode": "chatgpt_device", "codex_template": "codex", "status": "draft",
+		}),
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{"agent-harness", "get", "harness-123"}, srv.URL)
+	if err != nil {
+		t.Fatalf("agent-harness get error: %v", err)
+	}
+	if !called {
+		t.Fatal("GET /v1/agent-harnesses/harness-123 was not called")
+	}
+}
+
+func TestAgentHarnessCreateBuildsCodexE2BPayload(t *testing.T) {
+	var called bool
+	var gotBody map[string]any
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/workspaces/ws-123/agent-harnesses": func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{
+				"id": "harness-1", "name": gotBody["name"], "auth_mode": gotBody["auth_mode"], "codex_template": gotBody["codex_template"],
+			})
+		},
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{
+		"--workspace", "ws-123",
+		"agent-harness", "create",
+		"--name", "Codex long runner",
+		"--task", "Implement the feature and run tests.",
+		"--auth-mode", "api_key_secret",
+		"--openai-api-key-secret", "OPENAI_API_KEY",
+		"--e2b-api-key-secret", "E2B_API_KEY",
+		"--repository-url", "https://github.com/acme/repo",
+		"--base-branch", "main",
+		"--evaluation-config", `{"validators":[{"type":"command","command":"go test ./..."}]}`,
+	}, srv.URL)
+	if err != nil {
+		t.Fatalf("agent-harness create error: %v", err)
+	}
+	if !called {
+		t.Fatal("POST /v1/workspaces/ws-123/agent-harnesses was not called")
+	}
+	if gotBody["task_prompt"] != "Implement the feature and run tests." {
+		t.Fatalf("task_prompt = %v", gotBody["task_prompt"])
+	}
+	if gotBody["auth_mode"] != "api_key_secret" {
+		t.Fatalf("auth_mode = %v", gotBody["auth_mode"])
+	}
+	if gotBody["openai_api_key_secret_name"] != "OPENAI_API_KEY" {
+		t.Fatalf("openai_api_key_secret_name = %v", gotBody["openai_api_key_secret_name"])
+	}
+	if gotBody["codex_template"] != "codex" {
+		t.Fatalf("codex_template = %v", gotBody["codex_template"])
+	}
+	evalConfig, ok := gotBody["evaluation_config"].(map[string]any)
+	if !ok || evalConfig["validators"] == nil {
+		t.Fatalf("evaluation_config = %#v", gotBody["evaluation_config"])
+	}
+}
+
+func TestAgentHarnessCreateRequiresOpenAISecretForAPIKeyMode(t *testing.T) {
+	err := executeCommand(t, []string{
+		"--workspace", "ws-123",
+		"agent-harness", "create",
+		"--name", "Codex long runner",
+		"--task", "Implement the feature.",
+		"--auth-mode", "api_key_secret",
+	}, "http://unused")
+	if err == nil {
+		t.Fatal("expected missing OpenAI secret error")
+	}
+}

--- a/cli/cmd/agent_harness_test.go
+++ b/cli/cmd/agent_harness_test.go
@@ -30,19 +30,19 @@ func TestAgentHarnessListCallsCorrectEndpoint(t *testing.T) {
 func TestAgentHarnessGetCallsCorrectEndpoint(t *testing.T) {
 	var called bool
 	srv := fakeAPI(t, map[string]http.HandlerFunc{
-		"GET /v1/agent-harnesses/harness-123": captureHandler(t, &called, 200, map[string]any{
+		"GET /v1/workspaces/ws-123/agent-harnesses/harness-123": captureHandler(t, &called, 200, map[string]any{
 			"id": "harness-123", "name": "Codex", "auth_mode": "chatgpt_device", "codex_template": "codex", "status": "draft",
 		}),
 	})
 	defer srv.Close()
 
 	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
-	err := executeCommand(t, []string{"agent-harness", "get", "harness-123"}, srv.URL)
+	err := executeCommand(t, []string{"--workspace", "ws-123", "agent-harness", "get", "harness-123"}, srv.URL)
 	if err != nil {
 		t.Fatalf("agent-harness get error: %v", err)
 	}
 	if !called {
-		t.Fatal("GET /v1/agent-harnesses/harness-123 was not called")
+		t.Fatal("GET /v1/workspaces/ws-123/agent-harnesses/harness-123 was not called")
 	}
 }
 

--- a/docs/agent-harnesses-codex-e2b.md
+++ b/docs/agent-harnesses-codex-e2b.md
@@ -1,0 +1,65 @@
+# Agent Harnesses: Codex on E2B
+
+Agent Harnesses are workspace-scoped coding-agent task definitions. They are not
+challenge packs: users describe a task, choose a harness runtime, and attach
+evaluation config that can later be scored with AgentClash validators and LLM
+judges.
+
+## Research Summary
+
+- E2B provides a prebuilt `codex` sandbox template with filesystem, terminal,
+  and git access. Their Codex guide shows `e2b sbx create codex` for interactive
+  use and `codex exec --full-auto --skip-git-repo-check` for headless execution
+  inside the sandbox. Source: https://e2b.dev/docs/agents/codex
+- E2B's coding-agent guide frames this as the intended isolation model for
+  autonomous coding agents: create an isolated sandbox, let the agent work with
+  terminal/filesystem/git, then extract a diff or structured output. Source:
+  https://e2b.dev/docs/use-cases/coding-agents
+- Codex CLI supports ChatGPT login, device-code login for headless machines, and
+  API-key login. The OpenAI Codex CLI auth docs recommend ChatGPT login where
+  available, while API-key auth is the reliable non-interactive option when a
+  worker cannot complete an OAuth/device flow itself. Source:
+  https://www.mintlify.com/openai/codex/authentication
+- Codex exec mode is intended for automation. The docs describe JSON output,
+  schema-constrained final messages, `--full-auto`, and API keys as CI-friendly
+  execution pieces. Source:
+  https://www.mintlify.com/openai/codex/advanced/exec-mode
+- Codex cloud itself runs background tasks in isolated cloud environments and
+  can create PRs from connected repositories, but this PR models the CLI-on-E2B
+  path because AgentClash needs to orchestrate and score runs itself. Source:
+  https://developers.openai.com/codex/cloud
+
+## Product Shape
+
+The first implementation stores a `codex_e2b` harness with:
+
+- the human task prompt
+- E2B template ID, defaulting to `codex`
+- optional Codex model override
+- auth mode:
+  - `chatgpt_device` for user-assisted ChatGPT login
+  - `api_key_secret` for workspace-secret-backed API execution
+  - `bring_your_own_env` for externally prepared sandboxes
+- optional repository URL and base branch
+- JSON `execution_config`
+- JSON `evaluation_config` for validators, LLM judges, metrics, and scoring
+
+The execution worker should set both `OPENAI_API_KEY` and `CODEX_API_KEY` from
+the configured OpenAI secret when running the E2B Codex template. The Codex CLI
+docs emphasize `OPENAI_API_KEY`; E2B's Codex example uses `CODEX_API_KEY`.
+Setting both avoids coupling AgentClash to a template-specific environment name.
+
+## Next Execution Step
+
+A follow-up worker can turn a persisted harness into an execution by:
+
+1. Resolving the workspace secrets for E2B and OpenAI.
+2. Creating an E2B sandbox from `codex_template`.
+3. Cloning `repository_url` at `base_branch` when provided.
+4. Running `codex exec --full-auto --skip-git-repo-check --json`.
+5. Persisting stdout/stderr, JSONL events, final message, and git diff as
+   artifacts.
+6. Feeding artifacts plus `evaluation_config` into the existing scoring layer.
+
+This keeps challenge packs optional for coding-harness evaluations while still
+letting AgentClash reuse validators and LLM judges.

--- a/testing/codex-agent-harnesses.md
+++ b/testing/codex-agent-harnesses.md
@@ -1,0 +1,70 @@
+# codex/agent-harnesses - Test Contract
+
+## Functional Behavior
+- Agent Harnesses are a workspace-scoped abstraction distinct from challenge packs.
+- Users can create and list harness definitions that describe a long-running coding-agent task without uploading a challenge-pack bundle.
+- A Codex/E2B harness records:
+  - `name`
+  - `description`
+  - `task_prompt`
+  - `codex_template` defaulting to `codex`
+  - `codex_model`
+  - `auth_mode`, one of `chatgpt_device`, `api_key_secret`, or `bring_your_own_env`
+  - optional `openai_api_key_secret_name`
+  - optional `e2b_api_key_secret_name`
+  - optional `repository_url`
+  - optional `base_branch`
+  - `evaluation_config` JSON for future reuse of validators, LLM judges, and scoring dimensions
+- API creation rejects empty names, empty task prompts, unsupported auth modes, and API-key auth without an OpenAI secret name.
+- API list/get routes enforce workspace authorization.
+- CLI exposes `agent-harness list`, `agent-harness create`, and `agent-harness get`.
+- Workspace navigation exposes "Agent Harnesses" as its own page, not under challenge-pack authoring.
+- The Agent Harnesses UI can list existing harnesses and submit a create form using the new API.
+
+## Unit Tests
+- `TestAgentHarnessManager_CreateValidatesRequiredFields` - rejects invalid input and auth-mode/secret mismatches.
+- `TestAgentHarnessManager_CreatePersistsHarness` - stores defaults and config fields through the repository contract.
+- `TestAgentHarnessRoutes_CreateAndList` - verifies API request/response shape and workspace authorization behavior.
+- CLI command tests cover request body construction for create and table/json rendering for list/get.
+- Web tests cover the create dialog payload, auth-mode controls, and list rendering.
+
+## Integration / Functional Tests
+- Repository SQL compiles through `sqlc` generated code and Go build.
+- Backend route registration compiles and remains compatible with existing route middleware.
+- Web TypeScript compiles with the new API types and page route.
+- Existing challenge-pack routes and run creation are unchanged by the new abstraction.
+
+## Smoke Tests
+- From `backend/`: `go test ./internal/api ./internal/domain ./internal/repository`.
+- From `cli/`: `go test ./cmd`.
+- From `web/`: `npm test -- --run agent-harnesses` or the closest focused Vitest target available.
+- From repo root where feasible: `go test ./...` in changed Go modules.
+
+## E2E Tests
+- N/A for this PR: the execution worker that provisions an E2B sandbox and runs `codex exec` is intentionally left behind a persisted config boundary. The harness definition stores enough Codex/E2B config for that worker to be added next without challenge-pack authoring.
+
+## Manual / cURL Tests
+```bash
+curl -X POST http://localhost:8080/v1/workspaces/$WORKSPACE_ID/agent-harnesses \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "name": "Codex long-running repo task",
+    "description": "Checks whether Codex can autonomously complete a multi-step change.",
+    "task_prompt": "Clone the repository, implement the requested feature, run tests, and summarize the diff.",
+    "auth_mode": "api_key_secret",
+    "openai_api_key_secret_name": "OPENAI_API_KEY",
+    "e2b_api_key_secret_name": "E2B_API_KEY",
+    "repository_url": "https://github.com/example/repo",
+    "base_branch": "main",
+    "evaluation_config": {
+      "validators": [{"type": "command", "command": "go test ./..."}],
+      "llm_judges": [{"key": "autonomy", "rubric": "Did the agent complete the task without manual intervention?"}]
+    }
+  }'
+# Expected: 201 with an agent harness object, auth_mode api_key_secret, codex_template codex.
+
+curl http://localhost:8080/v1/workspaces/$WORKSPACE_ID/agent-harnesses \
+  -H "Authorization: Bearer $TOKEN"
+# Expected: 200 with {"items":[...]} including the created harness.
+```

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import type { AgentHarness } from "@/lib/api/types";
+import { useApiListQuery } from "@/lib/api/swr";
+import { WorkspaceListLoading } from "@/components/app-shell/workspace-loading";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import { PageHeader } from "@/components/ui/page-header";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { PackageCheck } from "lucide-react";
+import { CreateAgentHarnessDialog } from "./create-agent-harness-dialog";
+
+const authLabel: Record<string, string> = {
+  chatgpt_device: "ChatGPT device",
+  api_key_secret: "API key secret",
+  bring_your_own_env: "Environment",
+};
+
+const statusVariant: Record<string, "default" | "secondary" | "outline"> = {
+  active: "default",
+  draft: "outline",
+  archived: "secondary",
+};
+
+export function AgentHarnessesClient({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const { data, error, isLoading } = useApiListQuery<AgentHarness>(
+    `/v1/workspaces/${workspaceId}/agent-harnesses`,
+  );
+  const harnesses = data?.items ?? [];
+
+  return (
+    <div>
+      <PageHeader
+        title="Agent Harnesses"
+        breadcrumbs={[{ label: "Agent Harnesses" }]}
+        actions={<CreateAgentHarnessDialog workspaceId={workspaceId} />}
+      />
+
+      {isLoading && !data ? (
+        <WorkspaceListLoading rows={6} />
+      ) : error ? (
+        <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-4 text-sm text-destructive">
+          Failed to load agent harnesses.
+        </div>
+      ) : harnesses.length === 0 ? (
+        <EmptyState
+          icon={<PackageCheck className="size-10" />}
+          title="No agent harnesses yet"
+          description="Create a Codex harness to evaluate long-running autonomous coding tasks without writing a challenge pack."
+        />
+      ) : (
+        <div className="rounded-lg border border-border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Auth</TableHead>
+                <TableHead>Codex</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Updated</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {harnesses.map((harness) => (
+                <TableRow key={harness.id}>
+                  <TableCell>
+                    <div className="font-medium">{harness.name}</div>
+                    <div className="max-w-xl truncate text-xs text-muted-foreground">
+                      {harness.task_prompt}
+                    </div>
+                  </TableCell>
+                  <TableCell>{authLabel[harness.auth_mode] ?? harness.auth_mode}</TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {harness.codex_model
+                      ? `${harness.codex_template} / ${harness.codex_model}`
+                      : harness.codex_template}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={statusVariant[harness.status] ?? "outline"}>
+                      {harness.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {new Date(harness.updated_at).toLocaleString()}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/create-agent-harness-dialog.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/create-agent-harness-dialog.test.tsx
@@ -1,0 +1,267 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CreateAgentHarnessDialog } from "./create-agent-harness-dialog";
+
+const { mockGetAccessToken, mockCreateApiClient, mockMutate, toast } =
+  vi.hoisted(() => ({
+    mockGetAccessToken: vi.fn(),
+    mockCreateApiClient: vi.fn(),
+    mockMutate: vi.fn(),
+    toast: Object.assign(vi.fn(), {
+      success: vi.fn(),
+      error: vi.fn(),
+    }),
+  }));
+
+vi.mock("@workos-inc/authkit-nextjs/components", () => ({
+  useAccessToken: () => ({ getAccessToken: mockGetAccessToken }),
+}));
+
+vi.mock("@/lib/api/client", () => ({
+  createApiClient: (...args: unknown[]) => mockCreateApiClient(...args),
+}));
+
+vi.mock("@/lib/api/swr", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api/swr")>();
+  return {
+    ...actual,
+    useApiMutator: () => ({ mutate: mockMutate }),
+  };
+});
+
+vi.mock("sonner", () => ({
+  toast,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
+    React.createElement("button", props, children),
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) =>
+    React.createElement("input", props),
+}));
+
+vi.mock("@/components/ui/json-field", () => ({
+  JsonField: ({
+    label,
+    value,
+    onChange,
+    error,
+  }: {
+    label: string;
+    value: string;
+    onChange: (value: string) => void;
+    error?: string;
+  }) =>
+    React.createElement(
+      "label",
+      null,
+      label,
+      React.createElement("textarea", {
+        "aria-label": label,
+        value,
+        onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) =>
+          onChange(event.target.value),
+      }),
+      error ? React.createElement("span", null, error) : null,
+    ),
+}));
+
+vi.mock("@/components/ui/dialog", async () => {
+  const React = await import("react");
+  const DialogOpenContext = React.createContext(false);
+  const DialogToggleContext = React.createContext<(open: boolean) => void>(
+    () => {},
+  );
+
+  return {
+    Dialog: ({
+      open,
+      onOpenChange,
+      children,
+    }: {
+      open: boolean;
+      onOpenChange: (open: boolean) => void;
+      children: React.ReactNode;
+    }) =>
+      React.createElement(
+        DialogOpenContext.Provider,
+        { value: open },
+        React.createElement(
+          DialogToggleContext.Provider,
+          { value: onOpenChange },
+          children,
+        ),
+      ),
+    DialogTrigger: ({
+      render,
+      children,
+    }: {
+      render?: React.ReactElement;
+      children?: React.ReactNode;
+    }) => {
+      const setOpen = React.useContext(DialogToggleContext);
+      const element = render ?? React.createElement("button");
+      return React.cloneElement(element, {
+        onClick: () => setOpen(true),
+        children,
+      });
+    },
+    DialogContent: ({ children }: { children: React.ReactNode }) => {
+      const open = React.useContext(DialogOpenContext);
+      return open ? React.createElement("div", null, children) : null;
+    },
+    DialogDescription: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("p", null, children),
+    DialogFooter: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", null, children),
+    DialogHeader: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", null, children),
+    DialogTitle: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("h1", null, children),
+  };
+});
+
+vi.mock("lucide-react", () => ({
+  Loader2: () => React.createElement("span", null, "loader"),
+  Plus: () => React.createElement("span", null, "plus"),
+}));
+
+function renderDialog() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  act(() => {
+    root.render(
+      React.createElement(CreateAgentHarnessDialog, { workspaceId: "ws-1" }),
+    );
+  });
+  return {
+    cleanup: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function clickButton(text: string) {
+  const button = findButton(text);
+  act(() => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+function findButton(text: string) {
+  const button = Array.from(document.querySelectorAll("button")).find((item) =>
+    item.textContent?.includes(text),
+  );
+  if (!button) throw new Error(`button ${text} not found`);
+  return button;
+}
+
+function changeInput(index: number, value: string) {
+  const input = document.querySelectorAll("input")[index];
+  const descriptor = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  );
+  act(() => {
+    descriptor?.set?.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+}
+
+function changeSelect(value: string) {
+  const select = document.querySelector("select");
+  if (!select) throw new Error("select not found");
+  act(() => {
+    select.value = value;
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+}
+
+function changeTextarea(index: number, value: string) {
+  const textarea = document.querySelectorAll("textarea")[index];
+  const descriptor = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "value",
+  );
+  act(() => {
+    descriptor?.set?.call(textarea, value);
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    textarea.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+}
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe("CreateAgentHarnessDialog", () => {
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+    mockGetAccessToken.mockResolvedValue("token");
+  });
+
+  it("posts Codex/E2B harness payload with API-key secret auth", async () => {
+    const post = vi.fn().mockResolvedValue({ id: "harness-1" });
+    mockCreateApiClient.mockReturnValue({ post });
+    const rendered = renderDialog();
+
+    clickButton("New Harness");
+    changeInput(0, "Codex long runner");
+    changeSelect("api_key_secret");
+    changeTextarea(0, "Implement the requested feature and run tests.");
+    changeInput(6, "OPENAI_API_KEY");
+    clickButton("Create Harness");
+    await flushPromises();
+
+    expect(post).toHaveBeenCalledWith(
+      "/v1/workspaces/ws-1/agent-harnesses",
+      expect.objectContaining({
+        name: "Codex long runner",
+        task_prompt: "Implement the requested feature and run tests.",
+        codex_template: "codex",
+        auth_mode: "api_key_secret",
+        openai_api_key_secret_name: "OPENAI_API_KEY",
+        e2b_api_key_secret_name: "E2B_API_KEY",
+        evaluation_config: expect.objectContaining({
+          validators: expect.any(Array),
+          llm_judges: expect.any(Array),
+        }),
+      }),
+    );
+    expect(mockMutate).toHaveBeenCalled();
+    rendered.cleanup();
+  });
+
+  it("blocks API-key auth without an OpenAI secret", async () => {
+    const post = vi.fn();
+    mockCreateApiClient.mockReturnValue({ post });
+    const rendered = renderDialog();
+
+    clickButton("New Harness");
+    changeInput(0, "Codex long runner");
+    changeSelect("api_key_secret");
+    changeTextarea(0, "Implement the requested feature.");
+    const submit = findButton("Create Harness");
+    await flushPromises();
+
+    expect(submit.hasAttribute("disabled")).toBe(true);
+    expect(post).not.toHaveBeenCalled();
+    rendered.cleanup();
+  });
+});

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/create-agent-harness-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/create-agent-harness-dialog.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+import { useState } from "react";
+import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
+import { createApiClient } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/errors";
+import type {
+  AgentHarness,
+  AgentHarnessAuthMode,
+  CreateAgentHarnessRequest,
+} from "@/lib/api/types";
+import { useApiMutator } from "@/lib/api/swr";
+import { workspaceResourceKeys } from "@/lib/workspace-resource";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { JsonField } from "@/components/ui/json-field";
+import { toast } from "sonner";
+import { Loader2, Plus } from "lucide-react";
+
+const defaultEvaluationConfig = `{
+  "validators": [
+    {
+      "type": "command",
+      "command": "go test ./..."
+    }
+  ],
+  "llm_judges": [
+    {
+      "key": "autonomy",
+      "rubric": "Did the coding agent complete the task with coherent, tested changes?"
+    }
+  ]
+}`;
+
+export function CreateAgentHarnessDialog({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const { getAccessToken } = useAccessToken();
+  const { mutate } = useApiMutator();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [taskPrompt, setTaskPrompt] = useState("");
+  const [authMode, setAuthMode] =
+    useState<AgentHarnessAuthMode>("chatgpt_device");
+  const [openAISecret, setOpenAISecret] = useState("");
+  const [e2bSecret, setE2bSecret] = useState("E2B_API_KEY");
+  const [repositoryURL, setRepositoryURL] = useState("");
+  const [baseBranch, setBaseBranch] = useState("main");
+  const [codexTemplate, setCodexTemplate] = useState("codex");
+  const [codexModel, setCodexModel] = useState("");
+  const [evaluationConfig, setEvaluationConfig] = useState(
+    defaultEvaluationConfig,
+  );
+  const [jsonError, setJsonError] = useState<string | undefined>();
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleCreate() {
+    const parsedEvaluationConfig = parseEvaluationConfig();
+    if (parsedEvaluationConfig === undefined) return;
+    if (!name.trim() || !taskPrompt.trim()) return;
+    if (authMode === "api_key_secret" && !openAISecret.trim()) {
+      toast.error("OpenAI secret is required for API-key auth");
+      return;
+    }
+
+    const payload: CreateAgentHarnessRequest = {
+      name: name.trim(),
+      description: description.trim() || undefined,
+      task_prompt: taskPrompt.trim(),
+      codex_template: codexTemplate.trim() || "codex",
+      codex_model: codexModel.trim() || undefined,
+      auth_mode: authMode,
+      openai_api_key_secret_name: openAISecret.trim() || undefined,
+      e2b_api_key_secret_name: e2bSecret.trim() || undefined,
+      repository_url: repositoryURL.trim() || undefined,
+      base_branch: baseBranch.trim() || undefined,
+      evaluation_config: parsedEvaluationConfig,
+    };
+
+    setSubmitting(true);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      await api.post<AgentHarness>(
+        `/v1/workspaces/${workspaceId}/agent-harnesses`,
+        payload,
+      );
+      toast.success(`Created "${name.trim()}"`);
+      setOpen(false);
+      resetForm();
+      await mutate(workspaceResourceKeys.agentHarnesses(workspaceId));
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError ? err.message : "Failed to create harness",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function parseEvaluationConfig(): unknown | undefined {
+    if (!evaluationConfig.trim()) {
+      setJsonError(undefined);
+      return {};
+    }
+    try {
+      const parsed = JSON.parse(evaluationConfig);
+      setJsonError(undefined);
+      return parsed;
+    } catch {
+      setJsonError("Evaluation config must be valid JSON.");
+      return undefined;
+    }
+  }
+
+  function resetForm() {
+    setName("");
+    setDescription("");
+    setTaskPrompt("");
+    setAuthMode("chatgpt_device");
+    setOpenAISecret("");
+    setE2bSecret("E2B_API_KEY");
+    setRepositoryURL("");
+    setBaseBranch("main");
+    setCodexTemplate("codex");
+    setCodexModel("");
+    setEvaluationConfig(defaultEvaluationConfig);
+    setJsonError(undefined);
+  }
+
+  const selectClass =
+    "block w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/50";
+  const canSubmit =
+    name.trim() &&
+    taskPrompt.trim() &&
+    (authMode !== "api_key_secret" || openAISecret.trim());
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger render={<Button size="sm" />}>
+        <Plus data-icon="inline-start" className="size-4" />
+        New Harness
+      </DialogTrigger>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>New Agent Harness</DialogTitle>
+          <DialogDescription>
+            Define a Codex-on-E2B coding task and its evaluation hooks.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-[68vh] space-y-4 overflow-y-auto py-2">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <label className="mb-1.5 block text-sm font-medium">Name</label>
+              <Input
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="Codex repo autonomy check"
+                autoFocus
+              />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium">
+                Auth Mode
+              </label>
+              <select
+                value={authMode}
+                onChange={(event) =>
+                  setAuthMode(event.target.value as AgentHarnessAuthMode)
+                }
+                className={selectClass}
+              >
+                <option value="chatgpt_device">ChatGPT device login</option>
+                <option value="api_key_secret">API key from workspace secret</option>
+                <option value="bring_your_own_env">Bring your own environment</option>
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">
+              Description
+            </label>
+            <Input
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder="Long-running task harness for repository changes"
+            />
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">Task</label>
+            <textarea
+              value={taskPrompt}
+              onChange={(event) => setTaskPrompt(event.target.value)}
+              spellCheck={false}
+              className="min-h-28 w-full resize-y rounded-lg border border-input bg-transparent px-3 py-2 text-sm leading-relaxed focus:outline-none focus:ring-2 focus:ring-ring/50"
+              placeholder="Clone the repository, implement the requested change, run tests, and summarize the diff."
+            />
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <label className="mb-1.5 block text-sm font-medium">
+                Repository URL
+              </label>
+              <Input
+                value={repositoryURL}
+                onChange={(event) => setRepositoryURL(event.target.value)}
+                placeholder="https://github.com/org/repo"
+              />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium">
+                Base Branch
+              </label>
+              <Input
+                value={baseBranch}
+                onChange={(event) => setBaseBranch(event.target.value)}
+                placeholder="main"
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <label className="mb-1.5 block text-sm font-medium">
+                E2B Template
+              </label>
+              <Input
+                value={codexTemplate}
+                onChange={(event) => setCodexTemplate(event.target.value)}
+                placeholder="codex"
+              />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium">
+                Codex Model
+              </label>
+              <Input
+                value={codexModel}
+                onChange={(event) => setCodexModel(event.target.value)}
+                placeholder="Use Codex default"
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <label className="mb-1.5 block text-sm font-medium">
+                OpenAI Secret
+              </label>
+              <Input
+                value={openAISecret}
+                onChange={(event) => setOpenAISecret(event.target.value)}
+                placeholder={
+                  authMode === "api_key_secret" ? "OPENAI_API_KEY" : "Optional"
+                }
+              />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium">
+                E2B Secret
+              </label>
+              <Input
+                value={e2bSecret}
+                onChange={(event) => setE2bSecret(event.target.value)}
+                placeholder="E2B_API_KEY"
+              />
+            </div>
+          </div>
+
+          <JsonField
+            label="Evaluation Config"
+            value={evaluationConfig}
+            onChange={setEvaluationConfig}
+            error={jsonError}
+            rows={8}
+            description="Validators and LLM judges stored with the harness."
+          />
+        </div>
+
+        <DialogFooter>
+          <Button onClick={handleCreate} disabled={!canSubmit || submitting}>
+            {submitting ? (
+              <Loader2 data-icon="inline-start" className="size-4 animate-spin" />
+            ) : (
+              <Plus data-icon="inline-start" className="size-4" />
+            )}
+            {submitting ? "Creating..." : "Create Harness"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/page.tsx
@@ -1,0 +1,10 @@
+import { AgentHarnessesClient } from "./agent-harnesses-client";
+
+export default async function AgentHarnessesPage({
+  params,
+}: {
+  params: Promise<{ workspaceId: string }>;
+}) {
+  const { workspaceId } = await params;
+  return <AgentHarnessesClient workspaceId={workspaceId} />;
+}

--- a/web/src/components/app-shell/nav-items.ts
+++ b/web/src/components/app-shell/nav-items.ts
@@ -1,6 +1,7 @@
 import {
   Bot,
   Rocket,
+  PackageCheck,
   PackageOpen,
   Play,
   FlaskConical,
@@ -42,6 +43,11 @@ export const navSections: NavSection[] = [
         label: "Deployments",
         href: (id) => `/workspaces/${id}/deployments`,
         icon: Rocket,
+      },
+      {
+        label: "Agent Harnesses",
+        href: (id) => `/workspaces/${id}/agent-harnesses`,
+        icon: PackageCheck,
       },
     ],
   },

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -305,6 +305,54 @@ export interface AgentDeploymentCreateResponse {
   updated_at: string;
 }
 
+// --- Agent Harnesses ---
+
+export type AgentHarnessAuthMode =
+  | "chatgpt_device"
+  | "api_key_secret"
+  | "bring_your_own_env";
+
+/** GET /v1/workspaces/{id}/agent-harnesses list item, POST response */
+export interface AgentHarness {
+  id: string;
+  organization_id: string;
+  workspace_id: string;
+  created_by_user_id?: string;
+  name: string;
+  slug: string;
+  description: string;
+  status: string;
+  harness_kind: "codex_e2b";
+  task_prompt: string;
+  codex_template: string;
+  codex_model?: string;
+  auth_mode: AgentHarnessAuthMode;
+  openai_api_key_secret_name?: string;
+  e2b_api_key_secret_name?: string;
+  repository_url?: string;
+  base_branch?: string;
+  execution_config: unknown;
+  evaluation_config: unknown;
+  created_at: string;
+  updated_at: string;
+}
+
+/** POST /v1/workspaces/{id}/agent-harnesses request */
+export interface CreateAgentHarnessRequest {
+  name: string;
+  description?: string;
+  task_prompt: string;
+  codex_template?: string;
+  codex_model?: string;
+  auth_mode: AgentHarnessAuthMode;
+  openai_api_key_secret_name?: string;
+  e2b_api_key_secret_name?: string;
+  repository_url?: string;
+  base_branch?: string;
+  execution_config?: unknown;
+  evaluation_config?: unknown;
+}
+
 // --- Infrastructure Resources ---
 
 /** GET /v1/workspaces/{id}/runtime-profiles list item */

--- a/web/src/lib/workspace-resource.ts
+++ b/web/src/lib/workspace-resource.ts
@@ -9,6 +9,8 @@ export const workspaceResourceKeys = {
     apiQueryKey(`/v1/workspaces/${workspaceId}/agent-builds`),
   deployments: (workspaceId: string): ApiQueryKey =>
     apiQueryKey(`/v1/workspaces/${workspaceId}/agent-deployments`),
+  agentHarnesses: (workspaceId: string): ApiQueryKey =>
+    apiQueryKey(`/v1/workspaces/${workspaceId}/agent-harnesses`),
   challengePacks: (workspaceId: string): ApiQueryKey =>
     apiQueryKey(`/v1/workspaces/${workspaceId}/challenge-packs`),
   runs: (workspaceId: string, offset = 0): ApiQueryKey =>


### PR DESCRIPTION
## Summary
- Adds a first-class workspace-scoped Agent Harnesses abstraction, separate from challenge packs.
- Persists Codex-on-E2B harness config: task prompt, auth mode, E2B template, OpenAI/E2B secret names, repository metadata, and evaluation JSON for validators/LLM judges.
- Exposes backend API routes, CLI `agent-harness` commands, and a workspace UI page/create dialog.
- Documents the Codex/E2B research and the next execution-worker boundary in `docs/agent-harnesses-codex-e2b.md`.

## Review Checkpoint
- Test contract: `testing/codex-agent-harnesses.md`
- Checkpoint file used locally: `/tmp/reviewcheckpoint.json`
- Final verdict: ready

## Verification
- `cd backend && go test ./...`
- `cd cli && go test ./...`
- `cd web && npm test -- --run agent-harnesses`
- `cd web && npx tsc --noEmit`

## Notes
This PR intentionally creates the durable harness/config surface first. The follow-up execution worker can provision E2B, run `codex exec --full-auto --skip-git-repo-check --json`, persist artifacts/diffs, and feed those artifacts into the existing scoring layer without requiring users to author challenge packs.
