### PR TITLE
fix: simplify Agent Harness creation

### DIFF
--- a/testing/codex-simplify-agent-harness-ui.md
+++ b/testing/codex-simplify-agent-harness-ui.md
@@ -1,0 +1,41 @@
+# codex/simplify-agent-harness-ui - Test Contract
+
+## Functional Behavior
+- Agent Harness creation should be task-first, not a raw backend config form.
+- The create dialog should not show OpenAI Secret, Description, E2B Template, Codex Model, or Evaluation Config fields.
+- The visible create flow should collect only the essentials currently needed by users:
+  - repository URL
+  - base branch
+  - task prompt
+- The harness name should be generated from the repository URL when possible, otherwise from the task prompt.
+- The OpenAI API key secret should be automatically selected from existing workspace secrets:
+  - prefer `OPENAI_API_KEY`
+  - otherwise use the first secret whose key contains both `OPENAI` and `KEY`
+  - otherwise block submit and direct the user to add `OPENAI_API_KEY` under Secrets
+- Hidden backend defaults should still be sent:
+  - `auth_mode: "api_key_secret"`
+  - `openai_api_key_secret_name`
+  - `codex_template: "codex"`
+  - default evaluation config with command validator and LLM judge
+
+## Unit Tests
+- `CreateAgentHarnessDialog` fetches workspace secrets and posts a valid harness payload using the inferred OpenAI secret.
+- `CreateAgentHarnessDialog` disables creation when no OpenAI secret is available.
+- `CreateAgentHarnessDialog` tests should not depend on hidden raw config fields.
+
+## Integration / Functional Tests
+- Web TypeScript compiles with the simplified dialog and existing API types.
+- Existing Agent Harness list/run UI still compiles.
+
+## Smoke Tests
+- From `web/`: `npm test -- --run agent-harnesses`
+- From `web/`: `npx tsc --noEmit`
+
+## E2E Tests
+- N/A - this is a UI simplification for the existing create flow.
+
+## Manual / cURL Tests
+- Open Agent Harnesses in the workspace UI.
+- Click New Harness.
+- Confirm the form shows repository, branch, and task fields only.
+- Confirm creation uses the workspace `OPENAI_API_KEY` secret automatically.

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/create-agent-harness-dialog.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/create-agent-harness-dialog.test.tsx
@@ -4,11 +4,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CreateAgentHarnessDialog } from "./create-agent-harness-dialog";
 
-const { mockGetAccessToken, mockCreateApiClient, mockMutate, toast } =
+const { mockGetAccessToken, mockCreateApiClient, mockMutate, mockSecrets, toast } =
   vi.hoisted(() => ({
     mockGetAccessToken: vi.fn(),
     mockCreateApiClient: vi.fn(),
     mockMutate: vi.fn(),
+    mockSecrets: vi.fn(),
     toast: Object.assign(vi.fn(), {
       success: vi.fn(),
       error: vi.fn(),
@@ -27,6 +28,11 @@ vi.mock("@/lib/api/swr", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/api/swr")>();
   return {
     ...actual,
+    useApiListQuery: () => ({
+      data: { items: mockSecrets() },
+      isLoading: false,
+      error: null,
+    }),
     useApiMutator: () => ({ mutate: mockMutate }),
   };
 });
@@ -46,32 +52,6 @@ vi.mock("@/components/ui/button", () => ({
 vi.mock("@/components/ui/input", () => ({
   Input: (props: React.InputHTMLAttributes<HTMLInputElement>) =>
     React.createElement("input", props),
-}));
-
-vi.mock("@/components/ui/json-field", () => ({
-  JsonField: ({
-    label,
-    value,
-    onChange,
-    error,
-  }: {
-    label: string;
-    value: string;
-    onChange: (value: string) => void;
-    error?: string;
-  }) =>
-    React.createElement(
-      "label",
-      null,
-      label,
-      React.createElement("textarea", {
-        "aria-label": label,
-        value,
-        onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) =>
-          onChange(event.target.value),
-      }),
-      error ? React.createElement("span", null, error) : null,
-    ),
 }));
 
 vi.mock("@/components/ui/dialog", async () => {
@@ -130,6 +110,8 @@ vi.mock("@/components/ui/dialog", async () => {
 });
 
 vi.mock("lucide-react", () => ({
+  GitBranch: () => React.createElement("span", null, "branch"),
+  Github: () => React.createElement("span", null, "github"),
   Loader2: () => React.createElement("span", null, "loader"),
   Plus: () => React.createElement("span", null, "plus"),
 }));
@@ -205,16 +187,23 @@ describe("CreateAgentHarnessDialog", () => {
     document.body.innerHTML = "";
     vi.clearAllMocks();
     mockGetAccessToken.mockResolvedValue("token");
+    mockSecrets.mockReturnValue([
+      {
+        key: "OPENAI_API_KEY",
+        created_at: "2026-05-01T00:00:00Z",
+        updated_at: "2026-05-01T00:00:00Z",
+      },
+    ]);
   });
 
-  it("posts Codex/E2B harness payload with API-key secret auth", async () => {
+  it("posts Codex/E2B harness payload using the inferred OpenAI secret", async () => {
     const post = vi.fn().mockResolvedValue({ id: "harness-1" });
     mockCreateApiClient.mockReturnValue({ post });
     const rendered = renderDialog();
 
     clickButton("New Harness");
-    changeInput(0, "Codex long runner");
-    changeInput(1, "OPENAI_API_KEY");
+    changeInput(0, "https://github.com/acme/agent-app");
+    changeInput(1, "main");
     changeTextarea(0, "Implement the requested feature and run tests.");
     clickButton("Create Harness");
     await flushPromises();
@@ -222,7 +211,7 @@ describe("CreateAgentHarnessDialog", () => {
     expect(post).toHaveBeenCalledWith(
       "/v1/workspaces/ws-1/agent-harnesses",
       expect.objectContaining({
-        name: "Codex long runner",
+        name: "acme/agent-app Codex",
         task_prompt: "Implement the requested feature and run tests.",
         codex_template: "codex",
         auth_mode: "api_key_secret",
@@ -237,13 +226,14 @@ describe("CreateAgentHarnessDialog", () => {
     rendered.cleanup();
   });
 
-  it("blocks API-key auth without an OpenAI secret", async () => {
+  it("disables creation when no OpenAI secret is available", async () => {
+    mockSecrets.mockReturnValue([]);
     const post = vi.fn();
     mockCreateApiClient.mockReturnValue({ post });
     const rendered = renderDialog();
 
     clickButton("New Harness");
-    changeInput(0, "Codex long runner");
+    changeInput(0, "https://github.com/acme/agent-app");
     changeTextarea(0, "Implement the requested feature.");
     const submit = findButton("Create Harness");
     await flushPromises();

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/create-agent-harness-dialog.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/create-agent-harness-dialog.test.tsx
@@ -41,6 +41,15 @@ vi.mock("sonner", () => ({
   toast,
 }));
 
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) =>
+    React.createElement("a", { href, ...props }, children),
+}));
+
 vi.mock("@/components/ui/button", () => ({
   Button: ({
     children,
@@ -223,6 +232,26 @@ describe("CreateAgentHarnessDialog", () => {
       }),
     );
     expect(mockMutate).toHaveBeenCalled();
+    rendered.cleanup();
+  });
+
+  it("falls back to the task prompt for names when the repo URL has no owner and repo path", async () => {
+    const post = vi.fn().mockResolvedValue({ id: "harness-1" });
+    mockCreateApiClient.mockReturnValue({ post });
+    const rendered = renderDialog();
+
+    clickButton("New Harness");
+    changeInput(0, "https://github.com");
+    changeTextarea(0, "Implement the requested feature and run tests.");
+    clickButton("Create Harness");
+    await flushPromises();
+
+    expect(post).toHaveBeenCalledWith(
+      "/v1/workspaces/ws-1/agent-harnesses",
+      expect.objectContaining({
+        name: "Implement the requested feature Codex",
+      }),
+    );
     rendered.cleanup();
   });
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/create-agent-harness-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/create-agent-harness-dialog.tsx
@@ -1,11 +1,16 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";
-import type { AgentHarness, CreateAgentHarnessRequest } from "@/lib/api/types";
-import { useApiMutator } from "@/lib/api/swr";
+import type {
+  AgentHarness,
+  CreateAgentHarnessRequest,
+  WorkspaceSecret,
+} from "@/lib/api/types";
+import { useApiListQuery, useApiMutator } from "@/lib/api/swr";
 import { workspaceResourceKeys } from "@/lib/workspace-resource";
 import { Button } from "@/components/ui/button";
 import {
@@ -18,24 +23,24 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import { JsonField } from "@/components/ui/json-field";
 import { toast } from "sonner";
-import { Loader2, Plus } from "lucide-react";
+import { GitBranch, Github, Loader2, Plus } from "lucide-react";
 
-const defaultEvaluationConfig = `{
-  "validators": [
+const defaultEvaluationConfig = {
+  validators: [
     {
-      "type": "command",
-      "command": "go test ./..."
-    }
+      type: "command",
+      command: "go test ./...",
+    },
   ],
-  "llm_judges": [
+  llm_judges: [
     {
-      "key": "autonomy",
-      "rubric": "Did the coding agent complete the task with coherent, tested changes?"
-    }
-  ]
-}`;
+      key: "autonomy",
+      rubric:
+        "Did the coding agent complete the task with coherent, tested changes?",
+    },
+  ],
+};
 
 export function CreateAgentHarnessDialog({
   workspaceId,
@@ -44,41 +49,33 @@ export function CreateAgentHarnessDialog({
 }) {
   const { getAccessToken } = useAccessToken();
   const { mutate } = useApiMutator();
+  const { data: secretsData, isLoading: secretsLoading } =
+    useApiListQuery<WorkspaceSecret>(
+      `/v1/workspaces/${workspaceId}/secrets`,
+    );
   const [open, setOpen] = useState(false);
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
   const [taskPrompt, setTaskPrompt] = useState("");
-  const [openAISecret, setOpenAISecret] = useState("");
   const [repositoryURL, setRepositoryURL] = useState("");
   const [baseBranch, setBaseBranch] = useState("main");
-  const [codexTemplate, setCodexTemplate] = useState("codex");
-  const [codexModel, setCodexModel] = useState("");
-  const [evaluationConfig, setEvaluationConfig] = useState(
-    defaultEvaluationConfig,
-  );
-  const [jsonError, setJsonError] = useState<string | undefined>();
   const [submitting, setSubmitting] = useState(false);
 
   async function handleCreate() {
-    const parsedEvaluationConfig = parseEvaluationConfig();
-    if (parsedEvaluationConfig === undefined) return;
-    if (!name.trim() || !taskPrompt.trim()) return;
-    if (!openAISecret.trim()) {
-      toast.error("OpenAI secret is required for API-key auth");
+    const openAISecret = inferOpenAISecret(secretsData?.items ?? []);
+    if (!repositoryURL.trim() || !taskPrompt.trim()) return;
+    if (!openAISecret) {
+      toast.error("Add OPENAI_API_KEY under workspace Secrets first");
       return;
     }
 
     const payload: CreateAgentHarnessRequest = {
-      name: name.trim(),
-      description: description.trim() || undefined,
+      name: buildHarnessName(repositoryURL, taskPrompt),
       task_prompt: taskPrompt.trim(),
-      codex_template: codexTemplate.trim() || "codex",
-      codex_model: codexModel.trim() || undefined,
+      codex_template: "codex",
       auth_mode: "api_key_secret",
-      openai_api_key_secret_name: openAISecret.trim() || undefined,
+      openai_api_key_secret_name: openAISecret,
       repository_url: repositoryURL.trim() || undefined,
       base_branch: baseBranch.trim() || undefined,
-      evaluation_config: parsedEvaluationConfig,
+      evaluation_config: defaultEvaluationConfig,
     };
 
     setSubmitting(true);
@@ -89,7 +86,7 @@ export function CreateAgentHarnessDialog({
         `/v1/workspaces/${workspaceId}/agent-harnesses`,
         payload,
       );
-      toast.success(`Created "${name.trim()}"`);
+      toast.success(`Created "${payload.name}"`);
       setOpen(false);
       resetForm();
       await mutate(workspaceResourceKeys.agentHarnesses(workspaceId));
@@ -102,38 +99,18 @@ export function CreateAgentHarnessDialog({
     }
   }
 
-  function parseEvaluationConfig(): unknown | undefined {
-    if (!evaluationConfig.trim()) {
-      setJsonError(undefined);
-      return {};
-    }
-    try {
-      const parsed = JSON.parse(evaluationConfig);
-      setJsonError(undefined);
-      return parsed;
-    } catch {
-      setJsonError("Evaluation config must be valid JSON.");
-      return undefined;
-    }
-  }
-
   function resetForm() {
-    setName("");
-    setDescription("");
     setTaskPrompt("");
-    setOpenAISecret("");
     setRepositoryURL("");
     setBaseBranch("main");
-    setCodexTemplate("codex");
-    setCodexModel("");
-    setEvaluationConfig(defaultEvaluationConfig);
-    setJsonError(undefined);
   }
 
+  const openAISecret = inferOpenAISecret(secretsData?.items ?? []);
   const canSubmit =
-    name.trim() &&
+    repositoryURL.trim() &&
     taskPrompt.trim() &&
-    openAISecret.trim();
+    openAISecret &&
+    !secretsLoading;
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -145,68 +122,27 @@ export function CreateAgentHarnessDialog({
         <DialogHeader>
           <DialogTitle>New Agent Harness</DialogTitle>
           <DialogDescription>
-            Define a Codex-on-E2B coding task and its evaluation hooks.
+            Point Codex at a repo and describe the work.
           </DialogDescription>
         </DialogHeader>
 
-        <div className="max-h-[68vh] space-y-4 overflow-y-auto py-2">
+        <div className="space-y-4 py-2">
           <div className="grid gap-4 md:grid-cols-2">
             <div>
-              <label className="mb-1.5 block text-sm font-medium">Name</label>
-              <Input
-                value={name}
-                onChange={(event) => setName(event.target.value)}
-                placeholder="Codex repo autonomy check"
-                autoFocus
-              />
-            </div>
-            <div>
-              <label className="mb-1.5 block text-sm font-medium">
-                OpenAI Secret
-              </label>
-              <Input
-                value={openAISecret}
-                onChange={(event) => setOpenAISecret(event.target.value)}
-                placeholder="OPENAI_API_KEY"
-              />
-            </div>
-          </div>
-
-          <div>
-            <label className="mb-1.5 block text-sm font-medium">
-              Description
-            </label>
-            <Input
-              value={description}
-              onChange={(event) => setDescription(event.target.value)}
-              placeholder="Long-running task harness for repository changes"
-            />
-          </div>
-
-          <div>
-            <label className="mb-1.5 block text-sm font-medium">Task</label>
-            <textarea
-              value={taskPrompt}
-              onChange={(event) => setTaskPrompt(event.target.value)}
-              spellCheck={false}
-              className="min-h-28 w-full resize-y rounded-lg border border-input bg-transparent px-3 py-2 text-sm leading-relaxed focus:outline-none focus:ring-2 focus:ring-ring/50"
-              placeholder="Clone the repository, implement the requested change, run tests, and summarize the diff."
-            />
-          </div>
-
-          <div className="grid gap-4 md:grid-cols-2">
-            <div>
-              <label className="mb-1.5 block text-sm font-medium">
+              <label className="mb-1.5 flex items-center gap-2 text-sm font-medium">
+                <Github className="size-4 text-muted-foreground" />
                 Repository URL
               </label>
               <Input
                 value={repositoryURL}
                 onChange={(event) => setRepositoryURL(event.target.value)}
                 placeholder="https://github.com/org/repo"
+                autoFocus
               />
             </div>
             <div>
-              <label className="mb-1.5 block text-sm font-medium">
+              <label className="mb-1.5 flex items-center gap-2 text-sm font-medium">
+                <GitBranch className="size-4 text-muted-foreground" />
                 Base Branch
               </label>
               <Input
@@ -217,37 +153,29 @@ export function CreateAgentHarnessDialog({
             </div>
           </div>
 
-          <div className="grid gap-4 md:grid-cols-2">
-            <div>
-              <label className="mb-1.5 block text-sm font-medium">
-                E2B Template
-              </label>
-              <Input
-                value={codexTemplate}
-                onChange={(event) => setCodexTemplate(event.target.value)}
-                placeholder="codex"
-              />
-            </div>
-            <div>
-              <label className="mb-1.5 block text-sm font-medium">
-                Codex Model
-              </label>
-              <Input
-                value={codexModel}
-                onChange={(event) => setCodexModel(event.target.value)}
-                placeholder="Use Codex default"
-              />
-            </div>
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">Task</label>
+            <textarea
+              value={taskPrompt}
+              onChange={(event) => setTaskPrompt(event.target.value)}
+              spellCheck={false}
+              className="min-h-36 w-full resize-y rounded-lg border border-input bg-transparent px-3 py-2 text-sm leading-relaxed focus:outline-none focus:ring-2 focus:ring-ring/50"
+              placeholder="Implement the requested change, run the relevant tests, and summarize the diff."
+            />
           </div>
 
-          <JsonField
-            label="Evaluation Config"
-            value={evaluationConfig}
-            onChange={setEvaluationConfig}
-            error={jsonError}
-            rows={8}
-            description="Validators and LLM judges stored with the harness."
-          />
+          {!secretsLoading && !openAISecret ? (
+            <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-200">
+              Add an <code className="font-[family-name:var(--font-mono)]">OPENAI_API_KEY</code>{" "}
+              workspace secret before creating a Codex harness.{" "}
+              <Link
+                href={`/workspaces/${workspaceId}/secrets`}
+                className="font-medium underline underline-offset-4"
+              >
+                Open Secrets
+              </Link>
+            </div>
+          ) : null}
         </div>
 
         <DialogFooter>
@@ -263,4 +191,27 @@ export function CreateAgentHarnessDialog({
       </DialogContent>
     </Dialog>
   );
+}
+
+function inferOpenAISecret(secrets: WorkspaceSecret[]): string | undefined {
+  const exact = secrets.find((secret) => secret.key === "OPENAI_API_KEY");
+  if (exact) return exact.key;
+  return secrets.find((secret) => {
+    const key = secret.key.toUpperCase();
+    return key.includes("OPENAI") && key.includes("KEY");
+  })?.key;
+}
+
+function buildHarnessName(repositoryURL: string, taskPrompt: string): string {
+  const repoName = repositoryURL
+    .trim()
+    .replace(/\.git$/i, "")
+    .split("/")
+    .filter(Boolean)
+    .slice(-2)
+    .join("/");
+  if (repoName) {
+    return `${repoName} Codex`;
+  }
+  return `${taskPrompt.trim().split(/\s+/).slice(0, 4).join(" ")} Codex`;
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/create-agent-harness-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/create-agent-harness-dialog.tsx
@@ -60,7 +60,6 @@ export function CreateAgentHarnessDialog({
   const [submitting, setSubmitting] = useState(false);
 
   async function handleCreate() {
-    const openAISecret = inferOpenAISecret(secretsData?.items ?? []);
     if (!repositoryURL.trim() || !taskPrompt.trim()) return;
     if (!openAISecret) {
       toast.error("Add OPENAI_API_KEY under workspace Secrets first");
@@ -203,15 +202,27 @@ function inferOpenAISecret(secrets: WorkspaceSecret[]): string | undefined {
 }
 
 function buildHarnessName(repositoryURL: string, taskPrompt: string): string {
-  const repoName = repositoryURL
-    .trim()
-    .replace(/\.git$/i, "")
-    .split("/")
-    .filter(Boolean)
-    .slice(-2)
-    .join("/");
+  const repoName = parseRepositoryName(repositoryURL);
   if (repoName) {
     return `${repoName} Codex`;
   }
   return `${taskPrompt.trim().split(/\s+/).slice(0, 4).join(" ")} Codex`;
+}
+
+function parseRepositoryName(repositoryURL: string): string | undefined {
+  const trimmed = repositoryURL.trim().replace(/\.git$/i, "");
+  const scpPath = trimmed.match(/^[^@]+@[^:]+:(.+)$/)?.[1];
+  if (scpPath) {
+    const segments = scpPath.split("/").filter(Boolean);
+    return segments.length >= 2 ? segments.slice(-2).join("/") : undefined;
+  }
+
+  try {
+    const url = new URL(trimmed);
+    const segments = url.pathname.split("/").filter(Boolean);
+    return segments.length >= 2 ? segments.slice(-2).join("/") : undefined;
+  } catch {
+    const segments = trimmed.split("/").filter(Boolean);
+    return segments.length >= 2 ? segments.slice(-2).join("/") : undefined;
+  }
 }


### PR DESCRIPTION
## Summary
- Simplify the Agent Harness create dialog to repo URL, base branch, and task only
- Infer the OpenAI API key secret from existing workspace secrets instead of asking users to type it
- Keep Codex/E2B defaults and evaluator config hidden while preserving the backend payload
- Filed follow-up #468 for replacing the repo URL field with a GitHub-connected picker

## Tests
- npm test -- --run agent-harnesses
- npx tsc --noEmit
- npx eslint src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/create-agent-harness-dialog.tsx src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/create-agent-harness-dialog.test.tsx
- git diff --check