### PR TITLE
fix(agent-harnesses): prevent Codex execution activity timeout

### DIFF
--- a/backend/internal/api/agent_harnesses.go
+++ b/backend/internal/api/agent_harnesses.go
@@ -43,12 +43,12 @@ type AgentHarnessService interface {
 }
 
 type AgentHarnessExecutionWorkflowStarter interface {
-	StartAgentHarnessExecutionWorkflow(ctx context.Context, executionID uuid.UUID) error
+	StartAgentHarnessExecutionWorkflow(ctx context.Context, executionID uuid.UUID, timeoutSeconds int) error
 }
 
 type noopAgentHarnessExecutionWorkflowStarter struct{}
 
-func (noopAgentHarnessExecutionWorkflowStarter) StartAgentHarnessExecutionWorkflow(context.Context, uuid.UUID) error {
+func (noopAgentHarnessExecutionWorkflowStarter) StartAgentHarnessExecutionWorkflow(context.Context, uuid.UUID, int) error {
 	return nil
 }
 
@@ -178,7 +178,7 @@ func (m *AgentHarnessManager) StartAgentHarnessExecution(ctx context.Context, ca
 	if err != nil {
 		return repository.AgentHarnessExecution{}, err
 	}
-	if err := m.workflowStarter.StartAgentHarnessExecutionWorkflow(ctx, execution.ID); err != nil {
+	if err := m.workflowStarter.StartAgentHarnessExecutionWorkflow(ctx, execution.ID, agentHarnessExecutionTimeoutSeconds(execution.ExecutionConfigSnapshot)); err != nil {
 		reason := err.Error()
 		_, _ = m.repo.TransitionAgentHarnessExecutionStatus(ctx, repository.TransitionAgentHarnessExecutionStatusParams{
 			ExecutionID: execution.ID,
@@ -264,6 +264,14 @@ func optionalHarnessString(value string) *string {
 		return nil
 	}
 	return &trimmed
+}
+
+func agentHarnessExecutionTimeoutSeconds(raw json.RawMessage) int {
+	var config struct {
+		TimeoutSeconds int `json:"timeout_seconds,omitempty"`
+	}
+	_ = json.Unmarshal(raw, &config)
+	return config.TimeoutSeconds
 }
 
 type agentHarnessResponse struct {

--- a/backend/internal/api/agent_harnesses_test.go
+++ b/backend/internal/api/agent_harnesses_test.go
@@ -236,7 +236,8 @@ func TestAgentHarnessExecutionManagerStartSnapshotsHarness(t *testing.T) {
 	harness.ExecutionConfig = json.RawMessage(`{"timeout_seconds":600}`)
 	harness.EvaluationConfig = json.RawMessage(`{"validators":[{"type":"command"}]}`)
 	repo := &fakeAgentHarnessRepo{organizationID: harness.OrganizationID, harness: harness}
-	manager := NewAgentHarnessManager(NewCallerWorkspaceAuthorizer(), repo)
+	starter := &fakeAgentHarnessWorkflowStarter{}
+	manager := NewAgentHarnessManager(NewCallerWorkspaceAuthorizer(), repo, starter)
 
 	execution, err := manager.StartAgentHarnessExecution(context.Background(), testAgentHarnessCaller(workspaceID), workspaceID, harness.ID, StartAgentHarnessExecutionInput{})
 	if err != nil {
@@ -254,6 +255,9 @@ func TestAgentHarnessExecutionManagerStartSnapshotsHarness(t *testing.T) {
 	}
 	if string(repo.createdExecution.EvaluationConfigSnapshot) != string(harness.EvaluationConfig) {
 		t.Fatalf("evaluation snapshot = %s", repo.createdExecution.EvaluationConfigSnapshot)
+	}
+	if starter.timeoutSeconds != 600 {
+		t.Fatalf("workflow timeout seconds = %d, want 600", starter.timeoutSeconds)
 	}
 	var snapshot agentHarnessResponse
 	if err := json.Unmarshal(repo.createdExecution.HarnessSnapshot, &snapshot); err != nil {
@@ -291,7 +295,7 @@ func TestAgentHarnessExecutionManagerMarksFailedWhenWorkflowStartFails(t *testin
 	harness := testAgentHarnessRecord(workspaceID, "Codex execution harness")
 	repo := &fakeAgentHarnessRepo{organizationID: harness.OrganizationID, harness: harness}
 	starterErr := errors.New("temporal unavailable")
-	manager := NewAgentHarnessManager(NewCallerWorkspaceAuthorizer(), repo, fakeAgentHarnessWorkflowStarter{err: starterErr})
+	manager := NewAgentHarnessManager(NewCallerWorkspaceAuthorizer(), repo, &fakeAgentHarnessWorkflowStarter{err: starterErr})
 
 	_, err := manager.StartAgentHarnessExecution(context.Background(), testAgentHarnessCaller(workspaceID), workspaceID, harness.ID, StartAgentHarnessExecutionInput{})
 	if !errors.Is(err, starterErr) {
@@ -606,9 +610,11 @@ func (f *fakeAgentHarnessService) ListAgentHarnessExecutions(_ context.Context, 
 }
 
 type fakeAgentHarnessWorkflowStarter struct {
-	err error
+	err            error
+	timeoutSeconds int
 }
 
-func (f fakeAgentHarnessWorkflowStarter) StartAgentHarnessExecutionWorkflow(context.Context, uuid.UUID) error {
+func (f *fakeAgentHarnessWorkflowStarter) StartAgentHarnessExecutionWorkflow(_ context.Context, _ uuid.UUID, timeoutSeconds int) error {
+	f.timeoutSeconds = timeoutSeconds
 	return f.err
 }

--- a/backend/internal/api/temporal.go
+++ b/backend/internal/api/temporal.go
@@ -61,13 +61,14 @@ func NewTemporalAgentHarnessExecutionWorkflowStarter(client TemporalClient) Temp
 	return TemporalAgentHarnessExecutionWorkflowStarter{client: client}
 }
 
-func (s TemporalAgentHarnessExecutionWorkflowStarter) StartAgentHarnessExecutionWorkflow(ctx context.Context, executionID uuid.UUID) error {
+func (s TemporalAgentHarnessExecutionWorkflowStarter) StartAgentHarnessExecutionWorkflow(ctx context.Context, executionID uuid.UUID, timeoutSeconds int) error {
 	workflowID := fmt.Sprintf("%s/%s", workflow.AgentHarnessExecutionWorkflowName, executionID)
 	_, err := s.client.ExecuteWorkflow(ctx, temporalsdk.StartWorkflowOptions{
 		ID:        workflowID,
 		TaskQueue: workflow.WorkflowTaskQueue,
 	}, workflow.AgentHarnessExecutionWorkflowName, workflow.AgentHarnessExecutionWorkflowInput{
-		ExecutionID: executionID,
+		ExecutionID:    executionID,
+		TimeoutSeconds: timeoutSeconds,
 	})
 	return err
 }

--- a/backend/internal/api/temporal_test.go
+++ b/backend/internal/api/temporal_test.go
@@ -41,7 +41,7 @@ func TestTemporalAgentHarnessExecutionWorkflowStarter(t *testing.T) {
 	executionID := uuid.New()
 	client := &fakeTemporalClient{}
 
-	err := NewTemporalAgentHarnessExecutionWorkflowStarter(client).StartAgentHarnessExecutionWorkflow(context.Background(), executionID)
+	err := NewTemporalAgentHarnessExecutionWorkflowStarter(client).StartAgentHarnessExecutionWorkflow(context.Background(), executionID, 600)
 	if err != nil {
 		t.Fatalf("StartAgentHarnessExecutionWorkflow returned error: %v", err)
 	}
@@ -58,6 +58,9 @@ func TestTemporalAgentHarnessExecutionWorkflowStarter(t *testing.T) {
 	}
 	if input.ExecutionID != executionID {
 		t.Fatalf("execution id = %s, want %s", input.ExecutionID, executionID)
+	}
+	if input.TimeoutSeconds != 600 {
+		t.Fatalf("timeout seconds = %d, want 600", input.TimeoutSeconds)
 	}
 }
 

--- a/backend/internal/workflow/agent_harness_execution_workflow.go
+++ b/backend/internal/workflow/agent_harness_execution_workflow.go
@@ -15,7 +15,11 @@ import (
 	sdkworkflow "go.temporal.io/sdk/workflow"
 )
 
-const agentHarnessWorkspaceDir = "/workspace"
+const (
+	agentHarnessWorkspaceDir          = "/workspace"
+	agentHarnessActivityTimeoutBuffer = 2 * time.Minute
+	defaultAgentHarnessTimeoutSeconds = 1800
+)
 
 var (
 	ErrAgentHarnessRepositoryMissing = errors.New("agent harness repository is not configured")
@@ -73,7 +77,7 @@ func AgentHarnessExecutionWorkflow(ctx sdkworkflow.Context, input AgentHarnessEx
 	if err := transitionAgentHarnessExecutionStatus(ctx, input.ExecutionID, repository.AgentHarnessExecutionStatusRunning, nil); err != nil {
 		return err
 	}
-	if err := executeAgentHarnessExecution(ctx, input.ExecutionID); err != nil {
+	if err := executeAgentHarnessExecution(ctx, input.ExecutionID, input.TimeoutSeconds); err != nil {
 		return markAgentHarnessExecutionFailed(ctx, input.ExecutionID, err)
 	}
 	if err := transitionAgentHarnessExecutionStatus(ctx, input.ExecutionID, repository.AgentHarnessExecutionStatusCompleted, nil); err != nil {
@@ -91,10 +95,18 @@ func transitionAgentHarnessExecutionStatus(ctx sdkworkflow.Context, executionID 
 	}).Get(ctx, &execution)
 }
 
-func executeAgentHarnessExecution(ctx sdkworkflow.Context, executionID uuid.UUID) error {
-	return sdkworkflow.ExecuteActivity(ctx, executeAgentHarnessExecutionActivityName, ExecuteAgentHarnessExecutionInput{
+func executeAgentHarnessExecution(ctx sdkworkflow.Context, executionID uuid.UUID, timeoutSeconds int) error {
+	executeCtx := sdkworkflow.WithActivityOptions(ctx, agentHarnessExecutionActivityOptions(timeoutSeconds))
+	return sdkworkflow.ExecuteActivity(executeCtx, executeAgentHarnessExecutionActivityName, ExecuteAgentHarnessExecutionInput{
 		ExecutionID: executionID,
 	}).Get(ctx, nil)
+}
+
+func agentHarnessExecutionActivityOptions(timeoutSeconds int) sdkworkflow.ActivityOptions {
+	return sdkworkflow.ActivityOptions{
+		StartToCloseTimeout: agentHarnessTimeoutFromSeconds(timeoutSeconds) + agentHarnessActivityTimeoutBuffer,
+		RetryPolicy:         defaultActivityOptions.RetryPolicy,
+	}
 }
 
 func markAgentHarnessExecutionFailed(ctx sdkworkflow.Context, executionID uuid.UUID, cause error) error {
@@ -466,12 +478,16 @@ func agentHarnessEnv(h agentHarnessSnapshot, secrets map[string]string) (map[str
 }
 
 func agentHarnessTimeout(raw json.RawMessage) time.Duration {
-	cfg := agentHarnessExecutionConfig{TimeoutSeconds: 1800}
+	cfg := agentHarnessExecutionConfig{TimeoutSeconds: defaultAgentHarnessTimeoutSeconds}
 	_ = json.Unmarshal(raw, &cfg)
-	if cfg.TimeoutSeconds <= 0 {
-		cfg.TimeoutSeconds = 1800
+	return agentHarnessTimeoutFromSeconds(cfg.TimeoutSeconds)
+}
+
+func agentHarnessTimeoutFromSeconds(timeoutSeconds int) time.Duration {
+	if timeoutSeconds <= 0 {
+		timeoutSeconds = defaultAgentHarnessTimeoutSeconds
 	}
-	return time.Duration(cfg.TimeoutSeconds) * time.Second
+	return time.Duration(timeoutSeconds) * time.Second
 }
 
 func derefString(value *string) string {

--- a/backend/internal/workflow/agent_harness_execution_workflow_test.go
+++ b/backend/internal/workflow/agent_harness_execution_workflow_test.go
@@ -210,6 +210,23 @@ func TestAgentHarnessTimeoutDefaults(t *testing.T) {
 	}
 }
 
+func TestAgentHarnessExecutionActivityOptionsUseHarnessTimeout(t *testing.T) {
+	options := agentHarnessExecutionActivityOptions(120)
+	want := 120*time.Second + agentHarnessActivityTimeoutBuffer
+	if options.StartToCloseTimeout != want {
+		t.Fatalf("start to close timeout = %s, want %s", options.StartToCloseTimeout, want)
+	}
+	if options.RetryPolicy == nil || options.RetryPolicy.MaximumAttempts != 1 {
+		t.Fatalf("retry policy maximum attempts = %#v, want 1", options.RetryPolicy)
+	}
+
+	defaultOptions := agentHarnessExecutionActivityOptions(0)
+	defaultWant := 30*time.Minute + agentHarnessActivityTimeoutBuffer
+	if defaultOptions.StartToCloseTimeout != defaultWant {
+		t.Fatalf("default start to close timeout = %s, want %s", defaultOptions.StartToCloseTimeout, defaultWant)
+	}
+}
+
 func containsString(values []string, target string) bool {
 	for _, value := range values {
 		if value == target {

--- a/backend/internal/workflow/types.go
+++ b/backend/internal/workflow/types.go
@@ -26,7 +26,8 @@ type RunAgentWorkflowInput struct {
 }
 
 type AgentHarnessExecutionWorkflowInput struct {
-	ExecutionID uuid.UUID `json:"execution_id"`
+	ExecutionID    uuid.UUID `json:"execution_id"`
+	TimeoutSeconds int       `json:"timeout_seconds,omitempty"`
 }
 
 type PlaygroundExperimentWorkflowInput struct {

--- a/testing/fix-agent-harness-activity-timeout.md
+++ b/testing/fix-agent-harness-activity-timeout.md
@@ -1,0 +1,40 @@
+# Fix Agent Harness Activity Timeout — Test Contract
+
+## Functional Behavior
+
+- Agent Harness executions must not use the shared 5 second bookkeeping activity timeout for the long-running sandbox/Codex/evaluation activity.
+- The execution activity timeout must come from `execution_config.timeout_seconds` when configured.
+- When no harness timeout is configured, the execution activity must use the existing Agent Harness default of 30 minutes.
+- Short status-transition activities should keep the existing default activity options.
+- The API-observed failure mode, `workflow.execute_agent_harness_execution` failing with `activity StartToClose timeout` a few seconds after `codex.exec.started`, should not happen for ordinary long-running Codex work.
+
+## Unit Tests
+
+- Add workflow-level coverage proving `workflow.execute_agent_harness_execution` receives a StartToClose timeout derived from `execution_config.timeout_seconds`.
+- Keep `TestAgentHarnessTimeoutDefaults` passing for default and explicit timeout parsing.
+- Existing Agent Harness activity tests must continue to pass.
+
+## Integration / Functional Tests
+
+- `go test ./internal/workflow -run AgentHarness`
+- `go test ./internal/api -run AgentHarness`
+
+## Smoke Tests
+
+- `go test ./internal/workflow`
+
+## E2E Tests
+
+- N/A — this change adjusts Temporal activity options and is covered by workflow/unit tests.
+
+## Manual / cURL Tests
+
+- Confirm via hosted API that the affected workspace has `PROVIDER_OPENAI_API_KEY` configured:
+
+```bash
+curl -H "Authorization: Bearer $AGENTCLASH_TOKEN" \
+  https://api.agentclash.dev/v1/workspaces/511e2d3e-9076-4db3-b9f2-5ef54ab591d5/secrets
+# Expected: metadata includes PROVIDER_OPENAI_API_KEY
+```
+
+- After deployment, start the harness again and expect it to remain running beyond 5 seconds instead of failing with `activity StartToClose timeout`.


### PR DESCRIPTION
## Summary

- diagnose the hosted failure as a Temporal `StartToClose` timeout on `workflow.execute_agent_harness_execution`, not a missing OpenAI secret
- thread Agent Harness `timeout_seconds` into the Temporal workflow input
- run the long-running sandbox/Codex/evaluation activity with the harness timeout plus a small buffer, while keeping status transitions on the shared 5s activity timeout
- add regression coverage for timeout propagation and activity options

## API diagnosis

Using the hosted API for workspace `511e2d3e-9076-4db3-b9f2-5ef54ab591d5`:

- the harness uses `openai_api_key_secret_name: PROVIDER_OPENAI_API_KEY`
- `/v1/workspaces/.../secrets` includes `PROVIDER_OPENAI_API_KEY`, so the needed token already exists as a workspace secret
- the latest failed execution has `error_message: activity StartToClose timeout`
- the timeline stops right after `codex.exec.started`, around 5-6 seconds after run start, matching the shared `defaultActivityTimeout = 5 * time.Second`

So the blocker was not another token. The execution activity itself was being killed too early.

## Test Plan

- [x] `go test ./internal/workflow -run AgentHarness`
- [x] `go test ./internal/api -run AgentHarness`
- [x] `go test ./internal/api -run TemporalAgentHarness`
- [x] `go test ./internal/workflow`
- [x] `go test ./internal/api`
- [x] `git diff --check`

## Review Checkpoint

Test contract: `testing/fix-agent-harness-activity-timeout.md`
