### PR TITLE
fix(agent-harnesses): allow long E2B process streams

### DIFF
--- a/backend/internal/sandbox/e2b/client.go
+++ b/backend/internal/sandbox/e2b/client.go
@@ -21,8 +21,9 @@ import (
 )
 
 type apiClient struct {
-	httpClient *http.Client
-	config     Config
+	httpClient       *http.Client
+	streamHTTPClient *http.Client
+	config           Config
 }
 
 type sandboxRecord struct {
@@ -36,8 +37,9 @@ type sandboxRecord struct {
 
 func newAPIClient(config Config) *apiClient {
 	return &apiClient{
-		httpClient: &http.Client{Timeout: config.requestTimeout()},
-		config:     config,
+		httpClient:       &http.Client{Timeout: config.requestTimeout()},
+		streamHTTPClient: &http.Client{},
+		config:           config,
 	}
 }
 
@@ -66,7 +68,7 @@ func (c *apiClient) filesystemClient(record sandboxRecord) filesystemconnect.Fil
 }
 
 func (c *apiClient) processClient(record sandboxRecord) processconnect.ProcessClient {
-	return processconnect.NewProcessClient(c.httpClient, c.envdBaseURL(record))
+	return processconnect.NewProcessClient(c.streamHTTPClient, c.envdBaseURL(record))
 }
 
 func (c *apiClient) readFile(ctx context.Context, record sandboxRecord, filePath string) ([]byte, error) {

--- a/backend/internal/sandbox/e2b/client_test.go
+++ b/backend/internal/sandbox/e2b/client_test.go
@@ -4,9 +4,21 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/sandbox"
 )
+
+func TestAPIClientUsesUntimedHTTPClientForProcessStreams(t *testing.T) {
+	client := newAPIClient(Config{RequestTimeout: 10 * time.Second})
+
+	if client.httpClient.Timeout != 10*time.Second {
+		t.Fatalf("control-plane timeout = %s, want 10s", client.httpClient.Timeout)
+	}
+	if client.streamHTTPClient.Timeout != 0 {
+		t.Fatalf("stream timeout = %s, want no total HTTP timeout", client.streamHTTPClient.Timeout)
+	}
+}
 
 func TestCreateSandboxRequestUsesCamelCaseInternetField(t *testing.T) {
 	payload, err := json.Marshal(createSandboxRequest{

--- a/testing/fix-e2b-process-stream-timeout.md
+++ b/testing/fix-e2b-process-stream-timeout.md
@@ -1,0 +1,30 @@
+# Fix E2B Process Stream Timeout — Test Contract
+
+## Functional Behavior
+
+- Long-running E2B process streams, including `codex exec`, must not be cut off by the provider HTTP client's default 30 second total request timeout.
+- E2B control-plane calls should continue using the configured request timeout.
+- Command execution should still be bounded by the `ExecRequest.Timeout` context passed to `session.Exec`.
+
+## Unit Tests
+
+- Add coverage proving the E2B API client keeps the configured timeout for control-plane requests.
+- Add coverage proving the E2B process stream client has no total `http.Client.Timeout`.
+
+## Integration / Functional Tests
+
+- `go test ./internal/sandbox/e2b`
+- `go test ./internal/sandbox/...`
+
+## Smoke Tests
+
+- `go test ./internal/workflow -run AgentHarness`
+- `go test ./internal/api -run AgentHarness`
+
+## E2E Tests
+
+- N/A — live harness testing already reproduced the stream timeout; this patch covers the client wiring that caused it.
+
+## Manual / cURL Tests
+
+- After deploy, rerun Agent Harness execution `agentclash/agentclash Codex` with an explicit no-clarification prompt and confirm it can stream beyond 30 seconds without `deadline_exceeded`.


### PR DESCRIPTION
## Summary

- live-tested the Agent Harness against `agentclash/agentclash`
- found a second timeout layer after #471: E2B process streams inherit `http.Client{Timeout: 30s}`
- split E2B clients so control-plane/file calls keep the configured timeout, while process streams are bounded by `ExecRequest.Timeout` instead of a total HTTP client timeout
- added a regression test for the stream client wiring

## Live Harness Evidence

Execution `1d50e796-4135-4ca3-af5d-943779750a07` got past the old Temporal 5s timeout and streamed Codex events for about 30 seconds, then failed with:

```text
e2b rpc failed: deadline_exceeded: context deadline exceeded (Client.Timeout or context cancellation while reading body)
```

That maps to `defaultRequestTimeout = 30 * time.Second` in the E2B provider client being used for the long-lived Connect process stream.

## Remaining Follow-Up

The current `agentclash/agentclash Codex` harness uses E2B's prebuilt `codex` template. It can run Codex, but the configured validator is `go test ./...`, and that template currently does not have `go` installed. After this PR deploys, we still need either a Codex+Go template or a validator that matches the selected template.

## Test Plan

- [x] `go test ./internal/sandbox/e2b`
- [x] `go test ./internal/sandbox/...`
- [x] `go test ./internal/workflow -run AgentHarness`
- [x] `go test ./internal/api -run AgentHarness`
- [x] `git diff --check`

## Review Checkpoint

Test contract: `testing/fix-e2b-process-stream-timeout.md`
