### PR TITLE
Fix Agent Harness diff capture and validator workdirs

### DIFF
--- a/backend/internal/workflow/agent_harness_execution_workflow.go
+++ b/backend/internal/workflow/agent_harness_execution_workflow.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -188,7 +188,8 @@ func (a *Activities) ExecuteAgentHarnessExecution(ctx context.Context, input Exe
 	}
 
 	workdir := agentHarnessWorkspaceDir
-	if harness.RepositoryURL != nil && strings.TrimSpace(*harness.RepositoryURL) != "" {
+	hasRepository := harness.RepositoryURL != nil && strings.TrimSpace(*harness.RepositoryURL) != ""
+	if hasRepository {
 		clone := []string{"git", "clone", strings.TrimSpace(*harness.RepositoryURL), workdir}
 		if result, err := a.execHarnessCommand(ctx, execution.ID, session, "repository.clone", clone, "", timeout, env); err != nil {
 			return err
@@ -216,20 +217,22 @@ func (a *Activities) ExecuteAgentHarnessExecution(ctx context.Context, input Exe
 		return fmt.Errorf("codex exec failed with exit code %d", codexResult.ExitCode)
 	}
 
-	if result, err := a.execHarnessCommand(ctx, execution.ID, session, "git.add_intent", []string{"git", "add", "--intent-to-add", "--all"}, workdir, 60*time.Second, env); err != nil {
-		return err
-	} else if result.ExitCode != 0 {
-		return fmt.Errorf("git add intent failed with exit code %d", result.ExitCode)
-	}
-	if result, err := a.execHarnessCommand(ctx, execution.ID, session, "git.diff", []string{"git", "diff", "--binary"}, workdir, 60*time.Second, env); err != nil {
-		return err
-	} else {
-		_ = a.recordAgentHarnessEvent(ctx, execution.ID, "artifact.git_diff", "worker", map[string]any{"diff": result.Stdout})
-	}
-	if result, err := a.execHarnessCommand(ctx, execution.ID, session, "git.changed_files", []string{"git", "status", "--short"}, workdir, 60*time.Second, env); err != nil {
-		return err
-	} else {
-		_ = a.recordAgentHarnessEvent(ctx, execution.ID, "artifact.changed_files", "worker", map[string]any{"changed_files": result.Stdout})
+	if hasRepository {
+		if result, err := a.execHarnessCommand(ctx, execution.ID, session, "git.add_intent", []string{"git", "add", "--intent-to-add", "--all"}, workdir, 60*time.Second, env); err != nil {
+			return err
+		} else if result.ExitCode != 0 {
+			return fmt.Errorf("git add intent failed with exit code %d", result.ExitCode)
+		}
+		if result, err := a.execHarnessCommand(ctx, execution.ID, session, "git.diff", []string{"git", "diff", "--binary"}, workdir, 60*time.Second, env); err != nil {
+			return err
+		} else {
+			_ = a.recordAgentHarnessEvent(ctx, execution.ID, "artifact.git_diff", "worker", map[string]any{"diff": result.Stdout})
+		}
+		if result, err := a.execHarnessCommand(ctx, execution.ID, session, "git.changed_files", []string{"git", "status", "--short"}, workdir, 60*time.Second, env); err != nil {
+			return err
+		} else {
+			_ = a.recordAgentHarnessEvent(ctx, execution.ID, "artifact.changed_files", "worker", map[string]any{"changed_files": result.Stdout})
+		}
 	}
 
 	if _, err := a.TransitionAgentHarnessExecutionStatus(ctx, TransitionAgentHarnessExecutionStatusInput{
@@ -365,8 +368,7 @@ func (a *Activities) evaluateCommandValidator(ctx context.Context, executionID u
 		_ = a.recordAgentHarnessEvent(ctx, executionID, "validator.command.failed", "worker", map[string]any{"index": index, "error": err.Error()})
 		return false, err
 	}
-	workdir := strings.TrimSpace(validator.WorkingDirectory)
-	workdir = agentHarnessValidatorWorkdir(defaultWorkdir, workdir)
+	workdir := agentHarnessValidatorWorkdir(defaultWorkdir, validator.WorkingDirectory)
 	timeout := defaultTimeout
 	if validator.TimeoutSeconds > 0 {
 		timeout = time.Duration(validator.TimeoutSeconds) * time.Second
@@ -400,10 +402,10 @@ func agentHarnessValidatorWorkdir(defaultWorkdir string, configured string) stri
 	if workdir == "" {
 		return defaultWorkdir
 	}
-	if path.IsAbs(workdir) {
-		return path.Clean(workdir)
+	if filepath.IsAbs(workdir) {
+		return filepath.Clean(workdir)
 	}
-	return path.Join(defaultWorkdir, workdir)
+	return filepath.Join(defaultWorkdir, workdir)
 }
 
 func decodeAgentHarnessEvaluationConfig(raw json.RawMessage) (agentHarnessEvaluationConfig, error) {

--- a/backend/internal/workflow/agent_harness_execution_workflow.go
+++ b/backend/internal/workflow/agent_harness_execution_workflow.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path"
 	"strings"
 	"time"
 
@@ -215,6 +216,11 @@ func (a *Activities) ExecuteAgentHarnessExecution(ctx context.Context, input Exe
 		return fmt.Errorf("codex exec failed with exit code %d", codexResult.ExitCode)
 	}
 
+	if result, err := a.execHarnessCommand(ctx, execution.ID, session, "git.add_intent", []string{"git", "add", "--intent-to-add", "--all"}, workdir, 60*time.Second, env); err != nil {
+		return err
+	} else if result.ExitCode != 0 {
+		return fmt.Errorf("git add intent failed with exit code %d", result.ExitCode)
+	}
 	if result, err := a.execHarnessCommand(ctx, execution.ID, session, "git.diff", []string{"git", "diff", "--binary"}, workdir, 60*time.Second, env); err != nil {
 		return err
 	} else {
@@ -360,15 +366,13 @@ func (a *Activities) evaluateCommandValidator(ctx context.Context, executionID u
 		return false, err
 	}
 	workdir := strings.TrimSpace(validator.WorkingDirectory)
-	if workdir == "" {
-		workdir = defaultWorkdir
-	}
+	workdir = agentHarnessValidatorWorkdir(defaultWorkdir, workdir)
 	timeout := defaultTimeout
 	if validator.TimeoutSeconds > 0 {
 		timeout = time.Duration(validator.TimeoutSeconds) * time.Second
 	}
 
-	result, err := a.execHarnessCommand(ctx, executionID, session, "validator.command.exec", []string{"sh", "-lc", command}, workdir, timeout, env)
+	result, err := a.execHarnessCommand(ctx, executionID, session, "validator.command.exec", []string{"bash", "-lc", command}, workdir, timeout, env)
 	payload := map[string]any{
 		"index":             index,
 		"command":           command,
@@ -389,6 +393,17 @@ func (a *Activities) evaluateCommandValidator(ctx context.Context, executionID u
 	payload["error"] = err.Error()
 	_ = a.recordAgentHarnessEvent(ctx, executionID, "validator.command.failed", "worker", payload)
 	return false, err
+}
+
+func agentHarnessValidatorWorkdir(defaultWorkdir string, configured string) string {
+	workdir := strings.TrimSpace(configured)
+	if workdir == "" {
+		return defaultWorkdir
+	}
+	if path.IsAbs(workdir) {
+		return path.Clean(workdir)
+	}
+	return path.Join(defaultWorkdir, workdir)
 }
 
 func decodeAgentHarnessEvaluationConfig(raw json.RawMessage) (agentHarnessEvaluationConfig, error) {

--- a/backend/internal/workflow/agent_harness_execution_workflow_test.go
+++ b/backend/internal/workflow/agent_harness_execution_workflow_test.go
@@ -220,6 +220,59 @@ func TestExecuteAgentHarnessExecutionFailsRequiredValidator(t *testing.T) {
 	}
 }
 
+func TestExecuteAgentHarnessExecutionWithoutRepositorySkipsGitArtifactCapture(t *testing.T) {
+	workspaceID := uuid.New()
+	harnessID := uuid.New()
+	executionID := uuid.New()
+	openAISecret := "OPENAI_API_KEY"
+	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
+	repo.setAgentHarness(repository.AgentHarness{
+		ID:                     harnessID,
+		OrganizationID:         uuid.New(),
+		WorkspaceID:            workspaceID,
+		TaskPrompt:             "write a file without a repository",
+		CodexTemplate:          "codex",
+		AuthMode:               "api_key_secret",
+		OpenAIAPIKeySecretName: &openAISecret,
+		ExecutionConfig:        json.RawMessage(`{"timeout_seconds":120}`),
+	})
+	repo.setAgentHarnessExecution(repository.AgentHarnessExecution{
+		ID:                      executionID,
+		WorkspaceID:             workspaceID,
+		AgentHarnessID:          harnessID,
+		Status:                  string(repository.AgentHarnessExecutionStatusRunning),
+		ExecutionConfigSnapshot: json.RawMessage(`{"timeout_seconds":120}`),
+	})
+	repo.setWorkspaceSecrets(workspaceID, map[string]string{openAISecret: "sk-test"})
+
+	session := sandbox.NewFakeSession("sandbox-1")
+	session.SetExecFunc(func(request sandbox.ExecRequest, _ map[string][]byte) (sandbox.ExecResult, error) {
+		switch {
+		case len(request.Command) >= 2 && request.Command[0] == "codex" && request.Command[1] == "exec":
+			if request.WorkingDirectory != "/" {
+				t.Fatalf("codex workdir = %q, want root for no-repo harness", request.WorkingDirectory)
+			}
+			return sandbox.ExecResult{ExitCode: 0, Stdout: `{"type":"final","message":"done"}`}, nil
+		default:
+			t.Fatalf("unexpected command for no-repo harness: %#v", request.Command)
+			return sandbox.ExecResult{}, nil
+		}
+	})
+	provider := &sandbox.FakeProvider{NextSession: session}
+	activities := NewActivities(repo, FakeWorkHooks{}).WithSandboxProvider(provider)
+
+	err := activities.ExecuteAgentHarnessExecution(context.Background(), ExecuteAgentHarnessExecutionInput{ExecutionID: executionID})
+	if err != nil {
+		t.Fatalf("ExecuteAgentHarnessExecution error: %v", err)
+	}
+
+	for _, call := range session.ExecCalls() {
+		if len(call.Command) > 0 && call.Command[0] == "git" {
+			t.Fatalf("no-repo harness should not run git artifact commands, saw %#v", call.Command)
+		}
+	}
+}
+
 func TestAgentHarnessTimeoutDefaults(t *testing.T) {
 	if got := agentHarnessTimeout(nil); got != 30*time.Minute {
 		t.Fatalf("default timeout = %s, want 30m", got)

--- a/backend/internal/workflow/agent_harness_execution_workflow_test.go
+++ b/backend/internal/workflow/agent_harness_execution_workflow_test.go
@@ -29,7 +29,7 @@ func TestExecuteAgentHarnessExecutionRunsCodexAndRecordsTrace(t *testing.T) {
 		RepositoryURL:          stringPtr("https://github.com/acme/repo"),
 		BaseBranch:             stringPtr("main"),
 		ExecutionConfig:        json.RawMessage(`{"timeout_seconds":120}`),
-		EvaluationConfig:       json.RawMessage(`{"validators":[{"type":"command","command":"go test ./...","timeout_seconds":60}]}`),
+		EvaluationConfig:       json.RawMessage(`{"validators":[{"type":"command","command":"go test ./...","working_directory":"backend","timeout_seconds":60}]}`),
 	})
 	repo.setAgentHarnessExecution(repository.AgentHarnessExecution{
 		ID:                      executionID,
@@ -57,11 +57,16 @@ func TestExecuteAgentHarnessExecutionRunsCodexAndRecordsTrace(t *testing.T) {
 				t.Fatalf("codex command = %#v, want -C workspace", request.Command)
 			}
 			return sandbox.ExecResult{ExitCode: 0, Stdout: `{"type":"final","message":"done"}`}, nil
+		case len(request.Command) >= 3 && request.Command[0] == "git" && request.Command[1] == "add" && request.Command[2] == "--intent-to-add":
+			return sandbox.ExecResult{ExitCode: 0}, nil
 		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "diff":
 			return sandbox.ExecResult{ExitCode: 0, Stdout: "diff --git a/file b/file"}, nil
 		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "status":
 			return sandbox.ExecResult{ExitCode: 0, Stdout: " M file"}, nil
-		case len(request.Command) >= 3 && request.Command[0] == "sh" && request.Command[1] == "-lc" && request.Command[2] == "go test ./...":
+		case len(request.Command) >= 3 && request.Command[0] == "bash" && request.Command[1] == "-lc" && request.Command[2] == "go test ./...":
+			if request.WorkingDirectory != agentHarnessWorkspaceDir+"/backend" {
+				t.Fatalf("validator workdir = %q, want backend under workspace", request.WorkingDirectory)
+			}
 			return sandbox.ExecResult{ExitCode: 0, Stdout: "ok"}, nil
 		default:
 			t.Fatalf("unexpected command: %#v", request.Command)
@@ -88,6 +93,18 @@ func TestExecuteAgentHarnessExecutionRunsCodexAndRecordsTrace(t *testing.T) {
 	}
 	if session.DestroyCalls() != 1 {
 		t.Fatalf("destroy calls = %d, want 1", session.DestroyCalls())
+	}
+	calls := session.ExecCalls()
+	addIntentIndex := commandIndex(calls, "git", "add", "--intent-to-add")
+	diffIndex := commandIndex(calls, "git", "diff", "--binary")
+	if addIntentIndex == -1 {
+		t.Fatal("expected git add --intent-to-add before diff capture")
+	}
+	if diffIndex == -1 {
+		t.Fatal("expected git diff --binary capture")
+	}
+	if addIntentIndex > diffIndex {
+		t.Fatalf("git add --intent-to-add call index = %d, diff index = %d; want add before diff", addIntentIndex, diffIndex)
 	}
 	if got := len(repo.agentHarnessEvents[executionID]); got < 8 {
 		t.Fatalf("recorded events = %d, want at least 8", got)
@@ -157,13 +174,15 @@ func TestExecuteAgentHarnessExecutionFailsRequiredValidator(t *testing.T) {
 			return sandbox.ExecResult{ExitCode: 0}, nil
 		case len(request.Command) >= 2 && request.Command[0] == "codex" && request.Command[1] == "exec":
 			return sandbox.ExecResult{ExitCode: 0, Stdout: `{"type":"final","message":"done"}`}, nil
+		case len(request.Command) >= 3 && request.Command[0] == "git" && request.Command[1] == "add" && request.Command[2] == "--intent-to-add":
+			return sandbox.ExecResult{ExitCode: 0}, nil
 		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "diff":
 			return sandbox.ExecResult{ExitCode: 0}, nil
 		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "status":
 			return sandbox.ExecResult{ExitCode: 0}, nil
-		case len(request.Command) >= 3 && request.Command[0] == "sh" && request.Command[1] == "-lc" && request.Command[2] == "go test ./...":
+		case len(request.Command) >= 3 && request.Command[0] == "bash" && request.Command[1] == "-lc" && request.Command[2] == "go test ./...":
 			return sandbox.ExecResult{ExitCode: 0, Stdout: "ok"}, nil
-		case len(request.Command) >= 3 && request.Command[0] == "sh" && request.Command[1] == "-lc" && request.Command[2] == "npm test":
+		case len(request.Command) >= 3 && request.Command[0] == "bash" && request.Command[1] == "-lc" && request.Command[2] == "npm test":
 			return sandbox.ExecResult{ExitCode: 1, Stderr: "failed"}, nil
 		default:
 			t.Fatalf("unexpected command: %#v", request.Command)
@@ -227,6 +246,47 @@ func TestAgentHarnessExecutionActivityOptionsUseHarnessTimeout(t *testing.T) {
 	}
 }
 
+func TestAgentHarnessValidatorWorkdir(t *testing.T) {
+	tests := []struct {
+		name           string
+		defaultWorkdir string
+		configured     string
+		want           string
+	}{
+		{
+			name:           "empty uses default",
+			defaultWorkdir: "/workspace",
+			configured:     "",
+			want:           "/workspace",
+		},
+		{
+			name:           "relative joins default",
+			defaultWorkdir: "/workspace",
+			configured:     "cli",
+			want:           "/workspace/cli",
+		},
+		{
+			name:           "relative cleans path",
+			defaultWorkdir: "/workspace/repo",
+			configured:     "./backend/../cli",
+			want:           "/workspace/repo/cli",
+		},
+		{
+			name:           "absolute preserved",
+			defaultWorkdir: "/workspace",
+			configured:     "/tmp/project",
+			want:           "/tmp/project",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := agentHarnessValidatorWorkdir(tt.defaultWorkdir, tt.configured); got != tt.want {
+				t.Fatalf("agentHarnessValidatorWorkdir(%q, %q) = %q, want %q", tt.defaultWorkdir, tt.configured, got, tt.want)
+			}
+		})
+	}
+}
+
 func containsString(values []string, target string) bool {
 	for _, value := range values {
 		if value == target {
@@ -234,4 +294,23 @@ func containsString(values []string, target string) bool {
 		}
 	}
 	return false
+}
+
+func commandIndex(calls []sandbox.ExecRequest, parts ...string) int {
+	for index, call := range calls {
+		if len(call.Command) < len(parts) {
+			continue
+		}
+		matches := true
+		for partIndex, part := range parts {
+			if call.Command[partIndex] != part {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return index
+		}
+	}
+	return -1
 }

--- a/testing/fix-agent-harness-diff-and-validator-workdir.md
+++ b/testing/fix-agent-harness-diff-and-validator-workdir.md
@@ -1,0 +1,34 @@
+# Fix Agent Harness Diff And Validator Workdir — Test Contract
+
+## Functional Behavior
+
+- Agent Harness artifact diff capture includes newly created untracked files after Codex runs.
+- Existing modified files continue to appear in the captured binary diff.
+- Command validators with no `working_directory` still run in the execution default workdir.
+- Command validators with a relative `working_directory` run relative to the cloned repository workdir.
+- Command validators with an absolute `working_directory` continue to run exactly there.
+
+## Unit Tests
+
+- `TestExecuteAgentHarnessExecutionRunsCodexAndRecordsTrace` — verifies the harness runs Codex, records artifacts, and validators still pass.
+- New test coverage verifies `git add --intent-to-add --all` happens before `git diff --binary`.
+- New test coverage verifies relative validator working directories resolve under the default repository workdir.
+- New test coverage verifies absolute validator working directories are preserved.
+
+## Integration / Functional Tests
+
+- Backend workflow tests should pass for the Agent Harness execution activity.
+- No database migration is required.
+
+## Smoke Tests
+
+- Run the focused backend workflow tests from `backend/`.
+- Optionally start a new Agent Harness execution with validators pointed at module directories and confirm it reaches scoring without the root-module failure.
+
+## E2E Tests
+
+N/A — this change is backend workflow plumbing and covered by activity-level tests.
+
+## Manual / cURL Tests
+
+N/A — no HTTP API surface changes.

--- a/testing/fix-agent-harness-diff-and-validator-workdir.md
+++ b/testing/fix-agent-harness-diff-and-validator-workdir.md
@@ -7,6 +7,7 @@
 - Command validators with no `working_directory` still run in the execution default workdir.
 - Command validators with a relative `working_directory` run relative to the cloned repository workdir.
 - Command validators with an absolute `working_directory` continue to run exactly there.
+- Command validators run through bash so coding template shell initialization and common developer commands work.
 
 ## Unit Tests
 
@@ -14,6 +15,7 @@
 - New test coverage verifies `git add --intent-to-add --all` happens before `git diff --binary`.
 - New test coverage verifies relative validator working directories resolve under the default repository workdir.
 - New test coverage verifies absolute validator working directories are preserved.
+- Existing workflow tests verify command validators execute via bash.
 
 ## Integration / Functional Tests
 


### PR DESCRIPTION
## Summary
- capture untracked new files in Agent Harness git diff artifacts by intent-adding before diffing
- resolve relative validator working directories under the cloned repository workspace
- run command validators through bash to match the E2B coding template shell environment

## Testing
- cd backend && go test ./internal/workflow

## Retry notes
The latest hosted retry got past Codex execution and created the requested docs file. The remaining failure was validator configuration/runtime plumbing: the root repo is not a Go module, new untracked files were absent from the diff artifact, and validators were launched through sh. This PR fixes the reusable harness-side pieces; a future harness config should use module-specific validators such as backend and cli workdirs.