### PR TITLE
[codex] Let GitHub harnesses open draft PRs

### DIFF
--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -83,6 +83,18 @@ func main() {
 			RequestTimeout: cfg.Sandbox.E2B.RequestTimeout,
 		})
 	}
+	var githubClient workflowpkg.GitHubPullRequestClient
+	if cfg.GitHubAppID > 0 && cfg.GitHubAppPrivateKey != "" {
+		githubClient, err = workflowpkg.NewGitHubAppClient(workflowpkg.GitHubAppClientConfig{
+			AppID:         cfg.GitHubAppID,
+			PrivateKeyPEM: cfg.GitHubAppPrivateKey,
+			HTTPClient:    httpClient,
+		})
+		if err != nil {
+			logger.Error("failed to configure github app client", "error", err)
+			os.Exit(1)
+		}
+	}
 	nativeModelInvoker := workerapp.NewNativeModelInvokerWithObserverFactory(
 		providerRouter,
 		sandboxProvider,
@@ -92,7 +104,7 @@ func main() {
 		providerRouter,
 		workerapp.NewBufferedPromptEvalObserverFactory(eventRecorder),
 	).WithSecretsLookup(repo)
-	temporalWorker := workerapp.NewTemporalWorker(temporalClient, cfg, repo, providerRouter, sandboxProvider, workflowpkg.FakeWorkHooks{
+	temporalWorker := workerapp.NewTemporalWorker(temporalClient, cfg, repo, providerRouter, sandboxProvider, githubClient, workflowpkg.FakeWorkHooks{
 		HostedRunStarter:   hostedRunClient,
 		NativeModelInvoker: nativeModelInvoker,
 		PromptEvalInvoker:  promptEvalInvoker,

--- a/backend/internal/worker/config.go
+++ b/backend/internal/worker/config.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -34,6 +35,8 @@ type Config struct {
 	TaskQueue             string
 	HostedCallbackBaseURL string
 	HostedCallbackSecret  string
+	GitHubAppID           int64
+	GitHubAppPrivateKey   string
 	ShutdownTimeout       time.Duration
 	Sandbox               SandboxConfig
 	SecretsCipher         *secrets.AESGCMCipher
@@ -77,6 +80,10 @@ func LoadConfigFromEnv() (Config, error) {
 		return Config{}, err
 	}
 	hostedCallbackSecret, err := envOrDefault("HOSTED_RUN_CALLBACK_SECRET", defaultHostedCallbackSecret)
+	if err != nil {
+		return Config{}, err
+	}
+	githubAppID, err := optionalInt64Env("GITHUB_APP_ID")
 	if err != nil {
 		return Config{}, err
 	}
@@ -127,6 +134,8 @@ func LoadConfigFromEnv() (Config, error) {
 		TaskQueue:             workflow.WorkflowTaskQueue,
 		HostedCallbackBaseURL: hostedCallbackBaseURL,
 		HostedCallbackSecret:  hostedCallbackSecret,
+		GitHubAppID:           githubAppID,
+		GitHubAppPrivateKey:   normalizePEMEnv(os.Getenv("GITHUB_APP_PRIVATE_KEY")),
 		ShutdownTimeout:       shutdownTimeout,
 		Sandbox: SandboxConfig{
 			Provider: sandboxProvider,
@@ -193,6 +202,25 @@ func optionalEnv(key string) (string, error) {
 		return "", nil
 	}
 	return value, nil
+}
+
+func optionalInt64Env(key string) (int64, error) {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return 0, nil
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %s must be an integer", ErrInvalidConfig, key)
+	}
+	if parsed <= 0 {
+		return 0, fmt.Errorf("%w: %s must be greater than zero", ErrInvalidConfig, key)
+	}
+	return parsed, nil
+}
+
+func normalizePEMEnv(value string) string {
+	return strings.ReplaceAll(value, `\n`, "\n")
 }
 
 func durationEnvOrDefault(key string, fallback time.Duration) (time.Duration, error) {

--- a/backend/internal/worker/config_test.go
+++ b/backend/internal/worker/config_test.go
@@ -22,6 +22,8 @@ func TestLoadConfigFromEnvUsesDefaultsWhenUnset(t *testing.T) {
 	unsetEnv(t, "E2B_API_BASE_URL")
 	unsetEnv(t, "E2B_REQUEST_TIMEOUT")
 	unsetEnv(t, "AGENTCLASH_SECRETS_MASTER_KEY")
+	unsetEnv(t, "GITHUB_APP_ID")
+	unsetEnv(t, "GITHUB_APP_PRIVATE_KEY")
 
 	cfg, err := LoadConfigFromEnv()
 	if err != nil {
@@ -48,6 +50,9 @@ func TestLoadConfigFromEnvUsesDefaultsWhenUnset(t *testing.T) {
 	}
 	if cfg.Sandbox.Provider != "unconfigured" {
 		t.Fatalf("Sandbox.Provider = %q, want unconfigured", cfg.Sandbox.Provider)
+	}
+	if cfg.GitHubAppID != 0 || cfg.GitHubAppPrivateKey != "" {
+		t.Fatalf("github app config = %d/%q, want empty", cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
 	}
 }
 
@@ -91,6 +96,8 @@ func TestLoadConfigFromEnvOverrides(t *testing.T) {
 	t.Setenv("E2B_TEMPLATE_ID", "tmpl")
 	t.Setenv("E2B_API_BASE_URL", "https://api.example.com")
 	t.Setenv("E2B_REQUEST_TIMEOUT", "45s")
+	t.Setenv("GITHUB_APP_ID", "123")
+	t.Setenv("GITHUB_APP_PRIVATE_KEY", "-----BEGIN KEY-----\\nabc\\n-----END KEY-----")
 
 	cfg, err := LoadConfigFromEnv()
 	if err != nil {
@@ -120,6 +127,24 @@ func TestLoadConfigFromEnvOverrides(t *testing.T) {
 	}
 	if cfg.Sandbox.E2B.RequestTimeout != 45*time.Second {
 		t.Fatalf("RequestTimeout = %s, want %s", cfg.Sandbox.E2B.RequestTimeout, 45*time.Second)
+	}
+	if cfg.GitHubAppID != 123 {
+		t.Fatalf("GitHubAppID = %d, want 123", cfg.GitHubAppID)
+	}
+	if cfg.GitHubAppPrivateKey != "-----BEGIN KEY-----\nabc\n-----END KEY-----" {
+		t.Fatalf("GitHubAppPrivateKey was not normalized")
+	}
+}
+
+func TestLoadConfigFromEnvRejectsInvalidGitHubAppID(t *testing.T) {
+	t.Setenv("GITHUB_APP_ID", "abc")
+
+	_, err := LoadConfigFromEnv()
+	if err == nil {
+		t.Fatalf("LoadConfigFromEnv returned nil error")
+	}
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("error = %v, want ErrInvalidConfig", err)
 	}
 }
 

--- a/backend/internal/worker/service.go
+++ b/backend/internal/worker/service.go
@@ -27,13 +27,16 @@ func NewTemporalWorker(
 	repo *repository.Repository,
 	playgroundClient provider.Client,
 	sandboxProvider sandbox.Provider,
+	githubClient workflowpkg.GitHubPullRequestClient,
 	executionHooks workflowpkg.FakeWorkHooks,
 ) sdkworker.Worker {
 	temporalWorker := sdkworker.New(client, cfg.TaskQueue, sdkworker.Options{
 		Identity: cfg.Identity,
 	})
 
-	activities := workflowpkg.NewActivities(repo, executionHooks, playgroundClient).WithSandboxProvider(sandboxProvider)
+	activities := workflowpkg.NewActivities(repo, executionHooks, playgroundClient).
+		WithSandboxProvider(sandboxProvider).
+		WithGitHubPullRequestClient(githubClient)
 	workflowpkg.Register(temporalWorker, activities)
 	workflowpkg.RegisterPlayground(temporalWorker, workflowpkg.NewPlaygroundActivities(repo, playgroundClient, repo))
 

--- a/backend/internal/workflow/activities.go
+++ b/backend/internal/workflow/activities.go
@@ -81,6 +81,7 @@ type Activities struct {
 	hooks            FakeWorkHooks
 	judgeClient      provider.Client
 	sandboxProvider  sandbox.Provider
+	githubClient     GitHubPullRequestClient
 }
 
 type LoadEvalSessionInput struct {
@@ -191,6 +192,11 @@ func (a *Activities) WithSandboxProvider(provider sandbox.Provider) *Activities 
 		return a
 	}
 	a.sandboxProvider = provider
+	return a
+}
+
+func (a *Activities) WithGitHubPullRequestClient(client GitHubPullRequestClient) *Activities {
+	a.githubClient = client
 	return a
 }
 

--- a/backend/internal/workflow/agent_harness_execution_workflow.go
+++ b/backend/internal/workflow/agent_harness_execution_workflow.go
@@ -197,16 +197,24 @@ func (a *Activities) ExecuteAgentHarnessExecution(ctx context.Context, input Exe
 
 	workdir := agentHarnessWorkspaceDir
 	hasRepository := harness.RepositoryURL != nil && strings.TrimSpace(*harness.RepositoryURL) != ""
+	gitEnv := env
+	var gitHubToken string
 	if hasRepository {
+		if isStructuredGitHubHarness(harness) {
+			gitEnv, gitHubToken, err = a.prepareGitHubGitAuth(ctx, execution.ID, session, harness, env)
+			if err != nil {
+				return err
+			}
+		}
 		clone := []string{"git", "clone", strings.TrimSpace(*harness.RepositoryURL), workdir}
-		if result, err := a.execHarnessCommand(ctx, execution.ID, session, "repository.clone", clone, "", timeout, env); err != nil {
+		if result, err := a.execHarnessCommand(ctx, execution.ID, session, "repository.clone", clone, "", timeout, gitEnv); err != nil {
 			return err
 		} else if result.ExitCode != 0 {
 			return fmt.Errorf("repository clone failed with exit code %d", result.ExitCode)
 		}
 		if harness.BaseBranch != nil && strings.TrimSpace(*harness.BaseBranch) != "" {
 			checkout := []string{"git", "checkout", strings.TrimSpace(*harness.BaseBranch)}
-			if result, err := a.execHarnessCommand(ctx, execution.ID, session, "repository.checkout", checkout, workdir, timeout, env); err != nil {
+			if result, err := a.execHarnessCommand(ctx, execution.ID, session, "repository.checkout", checkout, workdir, timeout, gitEnv); err != nil {
 				return err
 			} else if result.ExitCode != 0 {
 				return fmt.Errorf("repository checkout failed with exit code %d", result.ExitCode)
@@ -236,10 +244,17 @@ func (a *Activities) ExecuteAgentHarnessExecution(ctx context.Context, input Exe
 		} else {
 			_ = a.recordAgentHarnessEvent(ctx, execution.ID, "artifact.git_diff", "worker", map[string]any{"diff": result.Stdout})
 		}
+		changedFiles := ""
 		if result, err := a.execHarnessCommand(ctx, execution.ID, session, "git.changed_files", []string{"git", "status", "--short"}, workdir, 60*time.Second, env); err != nil {
 			return err
 		} else {
+			changedFiles = result.Stdout
 			_ = a.recordAgentHarnessEvent(ctx, execution.ID, "artifact.changed_files", "worker", map[string]any{"changed_files": result.Stdout})
+		}
+		if isStructuredGitHubHarness(harness) {
+			if err := a.createGitHubPullRequest(ctx, execution.ID, session, harness, workdir, timeout, gitEnv, gitHubToken, changedFiles); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -291,7 +306,7 @@ func (a *Activities) agentHarnessSnapshot(ctx context.Context, execution reposit
 }
 
 func (a *Activities) verifyAgentHarnessGitHubAccess(ctx context.Context, executionID uuid.UUID, harness agentHarnessSnapshot) error {
-	if derefString(harness.RepositoryProvider) != "github" || harness.GitHubRepositoryID == nil {
+	if !isStructuredGitHubHarness(harness) {
 		return nil
 	}
 	_, err := a.agentHarnessRepo.GetWorkspaceGitHubRepository(ctx, harness.WorkspaceID, *harness.GitHubRepositoryID, harness.GitHubInstallationID)
@@ -307,6 +322,106 @@ func (a *Activities) verifyAgentHarnessGitHubAccess(ctx context.Context, executi
 		return fmt.Errorf("%w: github repository access was revoked or removed", repository.ErrGitHubRepositoryNotInstalled)
 	}
 	return err
+}
+
+func (a *Activities) prepareGitHubGitAuth(ctx context.Context, executionID uuid.UUID, session sandbox.Session, harness agentHarnessSnapshot, baseEnv map[string]string) (map[string]string, string, error) {
+	if a.githubClient == nil || harness.GitHubInstallationID == nil {
+		_ = a.recordAgentHarnessEvent(ctx, executionID, "github.pull_request.skipped", "worker", map[string]any{"reason": "github_app_client_not_configured"})
+		return baseEnv, "", nil
+	}
+	token, err := a.githubClient.CreateInstallationToken(ctx, *harness.GitHubInstallationID)
+	if err != nil {
+		return nil, "", fmt.Errorf("create github installation token: %w", err)
+	}
+	askpassPath := "/tmp/agentclash-git-askpass.sh"
+	askpass := []byte("#!/bin/sh\ncase \"$1\" in\n*Username*) echo x-access-token ;;\n*) echo \"$GITHUB_TOKEN\" ;;\nesac\n")
+	if err := session.WriteFile(ctx, askpassPath, askpass); err != nil {
+		return nil, "", fmt.Errorf("write github askpass helper: %w", err)
+	}
+	authEnv := maputil.CloneStringMap(baseEnv)
+	authEnv["GIT_ASKPASS"] = askpassPath
+	authEnv["GIT_TERMINAL_PROMPT"] = "0"
+	authEnv["GITHUB_TOKEN"] = token
+	if result, err := a.execHarnessCommand(ctx, executionID, session, "github.git_auth.prepare", []string{"chmod", "700", askpassPath}, "", 30*time.Second, baseEnv); err != nil {
+		return nil, "", err
+	} else if result.ExitCode != 0 {
+		return nil, "", fmt.Errorf("github git auth prepare failed with exit code %d", result.ExitCode)
+	}
+	return authEnv, token, nil
+}
+
+func (a *Activities) createGitHubPullRequest(ctx context.Context, executionID uuid.UUID, session sandbox.Session, harness agentHarnessSnapshot, workdir string, timeout time.Duration, gitEnv map[string]string, token string, changedFiles string) error {
+	if strings.TrimSpace(changedFiles) == "" {
+		return a.recordAgentHarnessEvent(ctx, executionID, "github.pull_request.skipped", "worker", map[string]any{"reason": "no_changes"})
+	}
+	if a.githubClient == nil || token == "" {
+		return a.recordAgentHarnessEvent(ctx, executionID, "github.pull_request.skipped", "worker", map[string]any{"reason": "github_app_client_not_configured"})
+	}
+	owner, repo, ok := parseGitHubFullName(derefString(harness.RepositoryFullName))
+	if !ok {
+		return a.recordAgentHarnessEvent(ctx, executionID, "github.pull_request.skipped", "worker", map[string]any{"reason": "missing_repository_full_name"})
+	}
+	baseBranch := strings.TrimSpace(derefString(harness.BaseBranch))
+	if baseBranch == "" {
+		baseBranch = "main"
+	}
+	branch := "agentclash/harness/" + strings.ReplaceAll(executionID.String()[:8], "-", "")
+	pushURL := "https://github.com/" + owner + "/" + repo + ".git"
+	commands := []struct {
+		event   string
+		command []string
+	}{
+		{"git.config_user_email", []string{"git", "config", "user.email", "agentclash[bot]@users.noreply.github.com"}},
+		{"git.config_user_name", []string{"git", "config", "user.name", "agentclash[bot]"}},
+		{"git.create_branch", []string{"git", "checkout", "-B", branch}},
+		{"git.add_all", []string{"git", "add", "--all"}},
+		{"git.commit", []string{"git", "-c", "core.hooksPath=/dev/null", "commit", "-m", "AgentClash harness changes"}},
+		{"git.push_branch", []string{"git", "-c", "core.hooksPath=/dev/null", "-c", "credential.helper=", "push", pushURL, "HEAD:refs/heads/" + branch}},
+	}
+	for _, step := range commands {
+		stepEnv := map[string]string(nil)
+		if step.event == "git.push_branch" {
+			stepEnv = gitEnv
+		}
+		if result, err := a.execHarnessCommand(ctx, executionID, session, step.event, step.command, workdir, timeout, stepEnv); err != nil {
+			return err
+		} else if result.ExitCode != 0 {
+			return fmt.Errorf("%s failed with exit code %d", step.event, result.ExitCode)
+		}
+	}
+	pr, err := a.githubClient.CreatePullRequest(ctx, CreateGitHubPullRequestInput{
+		Token: token,
+		Owner: owner,
+		Repo:  repo,
+		Title: "AgentClash harness changes",
+		Head:  owner + ":" + branch,
+		Base:  baseBranch,
+		Body:  "Created automatically by an AgentClash agent harness execution.\n\nExecution: " + executionID.String(),
+		Draft: true,
+	})
+	if err != nil {
+		return fmt.Errorf("create github pull request: %w", err)
+	}
+	return a.recordAgentHarnessEvent(ctx, executionID, "github.pull_request.created", "worker", map[string]any{
+		"number": pr.Number,
+		"url":    pr.HTMLURL,
+		"state":  pr.State,
+		"draft":  pr.Draft,
+		"branch": branch,
+		"base":   baseBranch,
+	})
+}
+
+func isStructuredGitHubHarness(harness agentHarnessSnapshot) bool {
+	return derefString(harness.RepositoryProvider) == "github" && harness.GitHubRepositoryID != nil
+}
+
+func parseGitHubFullName(fullName string) (string, string, bool) {
+	parts := strings.Split(strings.TrimSpace(fullName), "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
 }
 
 func (a *Activities) execHarnessCommand(ctx context.Context, executionID uuid.UUID, session sandbox.Session, eventType string, command []string, workdir string, timeout time.Duration, env map[string]string) (sandbox.ExecResult, error) {

--- a/backend/internal/workflow/agent_harness_execution_workflow_test.go
+++ b/backend/internal/workflow/agent_harness_execution_workflow_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -329,6 +330,220 @@ func TestExecuteAgentHarnessExecutionFailsEarlyWhenGitHubAccessRevoked(t *testin
 	}
 }
 
+func TestExecuteAgentHarnessExecutionCreatesDraftPullRequestForGitHubHarness(t *testing.T) {
+	workspaceID := uuid.New()
+	harnessID := uuid.New()
+	executionID := uuid.New()
+	openAISecret := "OPENAI_API_KEY"
+	repositoryID := int64(100)
+	installationID := int64(42)
+	provider := "github"
+	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
+	repo.githubRepo = repository.GitHubInstallationRepository{
+		GitHubInstallationID: installationID,
+		GitHubRepositoryID:   repositoryID,
+		FullName:             "acme/repo",
+		DefaultBranch:        "main",
+		Status:               "active",
+	}
+	repo.setAgentHarness(repository.AgentHarness{
+		ID:                     harnessID,
+		OrganizationID:         uuid.New(),
+		WorkspaceID:            workspaceID,
+		TaskPrompt:             "make a sample change",
+		CodexTemplate:          "codex",
+		AuthMode:               "api_key_secret",
+		OpenAIAPIKeySecretName: &openAISecret,
+		RepositoryURL:          stringPtr("https://github.com/acme/repo"),
+		RepositoryProvider:     &provider,
+		GitHubRepositoryID:     &repositoryID,
+		GitHubInstallationID:   &installationID,
+		RepositoryFullName:     stringPtr("acme/repo"),
+		BaseBranch:             stringPtr("main"),
+	})
+	repo.setAgentHarnessExecution(repository.AgentHarnessExecution{
+		ID:                      executionID,
+		WorkspaceID:             workspaceID,
+		AgentHarnessID:          harnessID,
+		Status:                  string(repository.AgentHarnessExecutionStatusRunning),
+		ExecutionConfigSnapshot: json.RawMessage(`{"timeout_seconds":120}`),
+	})
+	repo.setWorkspaceSecrets(workspaceID, map[string]string{openAISecret: "sk-test"})
+
+	session := sandbox.NewFakeSession("sandbox-1")
+	session.SetExecFunc(func(request sandbox.ExecRequest, _ map[string][]byte) (sandbox.ExecResult, error) {
+		if containsString(request.Command, "ghs_test_token") {
+			t.Fatalf("command leaked github token: %#v", request.Command)
+		}
+		switch {
+		case len(request.Command) >= 2 && request.Command[0] == "chmod":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "clone":
+			if request.Environment["GITHUB_TOKEN"] != "ghs_test_token" {
+				t.Fatalf("clone env missing github token")
+			}
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "checkout" && request.Command[2] == "main":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case len(request.Command) >= 2 && request.Command[0] == "codex" && request.Command[1] == "exec":
+			if _, ok := request.Environment["GITHUB_TOKEN"]; ok {
+				t.Fatal("codex env must not include github token")
+			}
+			return sandbox.ExecResult{ExitCode: 0, Stdout: `{"type":"final","message":"done"}`}, nil
+		case len(request.Command) >= 3 && request.Command[0] == "git" && request.Command[1] == "add" && request.Command[2] == "--intent-to-add":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "diff":
+			return sandbox.ExecResult{ExitCode: 0, Stdout: "diff --git a/README.md b/README.md"}, nil
+		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "status":
+			return sandbox.ExecResult{ExitCode: 0, Stdout: " M README.md\n"}, nil
+		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "config":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case len(request.Command) >= 3 && request.Command[0] == "git" && request.Command[1] == "checkout" && request.Command[2] == "-B":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "add":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case isGitSubcommand(request.Command, "commit"):
+			if !containsString(request.Command, "core.hooksPath=/dev/null") {
+				t.Fatalf("commit command did not disable hooks: %#v", request.Command)
+			}
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case isGitSubcommand(request.Command, "push"):
+			if request.Environment["GITHUB_TOKEN"] != "ghs_test_token" {
+				t.Fatalf("push env missing github token")
+			}
+			if !containsString(request.Command, "core.hooksPath=/dev/null") || !containsString(request.Command, "credential.helper=") {
+				t.Fatalf("push command did not disable hooks and credential helpers: %#v", request.Command)
+			}
+			if !containsString(request.Command, "https://github.com/acme/repo.git") {
+				t.Fatalf("push command did not use explicit github url: %#v", request.Command)
+			}
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		default:
+			t.Fatalf("unexpected command: %#v", request.Command)
+			return sandbox.ExecResult{}, nil
+		}
+	})
+	providerStub := &sandbox.FakeProvider{NextSession: session}
+	githubClient := &fakeGitHubPullRequestClient{token: "ghs_test_token"}
+	activities := NewActivities(repo, FakeWorkHooks{}).
+		WithSandboxProvider(providerStub).
+		WithGitHubPullRequestClient(githubClient)
+
+	err := activities.ExecuteAgentHarnessExecution(context.Background(), ExecuteAgentHarnessExecutionInput{ExecutionID: executionID})
+	if err != nil {
+		t.Fatalf("ExecuteAgentHarnessExecution error: %v", err)
+	}
+	if githubClient.tokenInstallationID != installationID {
+		t.Fatalf("token installation id = %d, want %d", githubClient.tokenInstallationID, installationID)
+	}
+	if githubClient.pullRequestInput.Owner != "acme" || githubClient.pullRequestInput.Repo != "repo" {
+		t.Fatalf("pull request repo = %s/%s, want acme/repo", githubClient.pullRequestInput.Owner, githubClient.pullRequestInput.Repo)
+	}
+	if !githubClient.pullRequestInput.Draft {
+		t.Fatal("pull request should be draft")
+	}
+	if githubClient.pullRequestInput.Head != "acme:agentclash/harness/"+strings.ReplaceAll(executionID.String()[:8], "-", "") {
+		t.Fatalf("pull request head = %q", githubClient.pullRequestInput.Head)
+	}
+	var sawPREvent bool
+	for _, event := range repo.agentHarnessEvents[executionID] {
+		if event.EventType == "github.pull_request.created" {
+			sawPREvent = true
+			break
+		}
+	}
+	if !sawPREvent {
+		t.Fatal("expected github.pull_request.created event")
+	}
+}
+
+func TestExecuteAgentHarnessExecutionSkipsPullRequestWhenNoChanges(t *testing.T) {
+	workspaceID := uuid.New()
+	harnessID := uuid.New()
+	executionID := uuid.New()
+	openAISecret := "OPENAI_API_KEY"
+	repositoryID := int64(100)
+	installationID := int64(42)
+	provider := "github"
+	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
+	repo.githubRepo = repository.GitHubInstallationRepository{
+		GitHubInstallationID: installationID,
+		GitHubRepositoryID:   repositoryID,
+		FullName:             "acme/repo",
+		DefaultBranch:        "main",
+		Status:               "active",
+	}
+	repo.setAgentHarness(repository.AgentHarness{
+		ID:                     harnessID,
+		OrganizationID:         uuid.New(),
+		WorkspaceID:            workspaceID,
+		TaskPrompt:             "make a sample change",
+		CodexTemplate:          "codex",
+		AuthMode:               "api_key_secret",
+		OpenAIAPIKeySecretName: &openAISecret,
+		RepositoryURL:          stringPtr("https://github.com/acme/repo"),
+		RepositoryProvider:     &provider,
+		GitHubRepositoryID:     &repositoryID,
+		GitHubInstallationID:   &installationID,
+		RepositoryFullName:     stringPtr("acme/repo"),
+		BaseBranch:             stringPtr("main"),
+	})
+	repo.setAgentHarnessExecution(repository.AgentHarnessExecution{
+		ID:                      executionID,
+		WorkspaceID:             workspaceID,
+		AgentHarnessID:          harnessID,
+		Status:                  string(repository.AgentHarnessExecutionStatusRunning),
+		ExecutionConfigSnapshot: json.RawMessage(`{"timeout_seconds":120}`),
+	})
+	repo.setWorkspaceSecrets(workspaceID, map[string]string{openAISecret: "sk-test"})
+
+	session := sandbox.NewFakeSession("sandbox-1")
+	session.SetExecFunc(func(request sandbox.ExecRequest, _ map[string][]byte) (sandbox.ExecResult, error) {
+		switch {
+		case len(request.Command) >= 2 && request.Command[0] == "chmod":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "clone":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "checkout" && request.Command[2] == "main":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case len(request.Command) >= 2 && request.Command[0] == "codex" && request.Command[1] == "exec":
+			return sandbox.ExecResult{ExitCode: 0, Stdout: `{"type":"final","message":"done"}`}, nil
+		case len(request.Command) >= 3 && request.Command[0] == "git" && request.Command[1] == "add" && request.Command[2] == "--intent-to-add":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "diff":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "status":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		default:
+			t.Fatalf("unexpected command: %#v", request.Command)
+			return sandbox.ExecResult{}, nil
+		}
+	})
+	providerStub := &sandbox.FakeProvider{NextSession: session}
+	githubClient := &fakeGitHubPullRequestClient{token: "ghs_test_token"}
+	activities := NewActivities(repo, FakeWorkHooks{}).
+		WithSandboxProvider(providerStub).
+		WithGitHubPullRequestClient(githubClient)
+
+	err := activities.ExecuteAgentHarnessExecution(context.Background(), ExecuteAgentHarnessExecutionInput{ExecutionID: executionID})
+	if err != nil {
+		t.Fatalf("ExecuteAgentHarnessExecution error: %v", err)
+	}
+	if githubClient.pullRequestInput.Owner != "" {
+		t.Fatalf("pull request was created unexpectedly: %#v", githubClient.pullRequestInput)
+	}
+	var sawSkip bool
+	for _, event := range repo.agentHarnessEvents[executionID] {
+		if event.EventType == "github.pull_request.skipped" {
+			sawSkip = true
+			break
+		}
+	}
+	if !sawSkip {
+		t.Fatal("expected github.pull_request.skipped event")
+	}
+}
+
 func TestAgentHarnessTimeoutDefaults(t *testing.T) {
 	if got := agentHarnessTimeout(nil); got != 30*time.Minute {
 		t.Fatalf("default timeout = %s, want 30m", got)
@@ -405,6 +620,18 @@ func containsString(values []string, target string) bool {
 	return false
 }
 
+func isGitSubcommand(command []string, subcommand string) bool {
+	if len(command) == 0 || command[0] != "git" {
+		return false
+	}
+	for _, part := range command[1:] {
+		if part == subcommand {
+			return true
+		}
+	}
+	return false
+}
+
 func commandIndex(calls []sandbox.ExecRequest, parts ...string) int {
 	for index, call := range calls {
 		if len(call.Command) < len(parts) {
@@ -422,4 +649,20 @@ func commandIndex(calls []sandbox.ExecRequest, parts ...string) int {
 		}
 	}
 	return -1
+}
+
+type fakeGitHubPullRequestClient struct {
+	token               string
+	tokenInstallationID int64
+	pullRequestInput    CreateGitHubPullRequestInput
+}
+
+func (f *fakeGitHubPullRequestClient) CreateInstallationToken(_ context.Context, installationID int64) (string, error) {
+	f.tokenInstallationID = installationID
+	return f.token, nil
+}
+
+func (f *fakeGitHubPullRequestClient) CreatePullRequest(_ context.Context, input CreateGitHubPullRequestInput) (GitHubPullRequest, error) {
+	f.pullRequestInput = input
+	return GitHubPullRequest{Number: 12, HTMLURL: "https://github.com/acme/repo/pull/12", State: "open", Draft: true}, nil
 }

--- a/backend/internal/workflow/github_app_client.go
+++ b/backend/internal/workflow/github_app_client.go
@@ -1,0 +1,189 @@
+package workflow
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type GitHubPullRequestClient interface {
+	CreateInstallationToken(ctx context.Context, installationID int64) (string, error)
+	CreatePullRequest(ctx context.Context, input CreateGitHubPullRequestInput) (GitHubPullRequest, error)
+}
+
+type GitHubAppClientConfig struct {
+	AppID         int64
+	PrivateKeyPEM string
+	APIBaseURL    string
+	HTTPClient    *http.Client
+}
+
+type CreateGitHubPullRequestInput struct {
+	Token string
+	Owner string
+	Repo  string
+	Title string
+	Head  string
+	Base  string
+	Body  string
+	Draft bool
+}
+
+type GitHubPullRequest struct {
+	Number  int    `json:"number"`
+	HTMLURL string `json:"html_url"`
+	State   string `json:"state"`
+	Draft   bool   `json:"draft"`
+}
+
+type githubAppClient struct {
+	appID      int64
+	privateKey *rsa.PrivateKey
+	apiBaseURL string
+	httpClient *http.Client
+}
+
+type githubAccessTokenResponse struct {
+	Token string `json:"token"`
+}
+
+func NewGitHubAppClient(config GitHubAppClientConfig) (GitHubPullRequestClient, error) {
+	if config.AppID <= 0 {
+		return nil, errors.New("github app id is required")
+	}
+	key, err := parseGitHubAppPrivateKey(config.PrivateKeyPEM)
+	if err != nil {
+		return nil, err
+	}
+	apiBaseURL := strings.TrimRight(config.APIBaseURL, "/")
+	if apiBaseURL == "" {
+		apiBaseURL = "https://api.github.com"
+	}
+	httpClient := config.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &githubAppClient{
+		appID:      config.AppID,
+		privateKey: key,
+		apiBaseURL: apiBaseURL,
+		httpClient: httpClient,
+	}, nil
+}
+
+func parseGitHubAppPrivateKey(raw string) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(raw))
+	if block == nil {
+		return nil, errors.New("github app private key is not PEM")
+	}
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	key, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("github app private key is not RSA")
+	}
+	return key, nil
+}
+
+func (c *githubAppClient) CreateInstallationToken(ctx context.Context, installationID int64) (string, error) {
+	var response githubAccessTokenResponse
+	if err := c.doJSON(ctx, http.MethodPost, fmt.Sprintf("/app/installations/%d/access_tokens", installationID), "", bytes.NewReader([]byte(`{}`)), &response); err != nil {
+		return "", err
+	}
+	if response.Token == "" {
+		return "", errors.New("github installation token response was empty")
+	}
+	return response.Token, nil
+}
+
+func (c *githubAppClient) CreatePullRequest(ctx context.Context, input CreateGitHubPullRequestInput) (GitHubPullRequest, error) {
+	var response GitHubPullRequest
+	body, err := json.Marshal(map[string]any{
+		"title": input.Title,
+		"head":  input.Head,
+		"base":  input.Base,
+		"body":  input.Body,
+		"draft": input.Draft,
+	})
+	if err != nil {
+		return GitHubPullRequest{}, err
+	}
+	path := fmt.Sprintf("/repos/%s/%s/pulls", input.Owner, input.Repo)
+	if err := c.doJSON(ctx, http.MethodPost, path, input.Token, bytes.NewReader(body), &response); err != nil {
+		return GitHubPullRequest{}, err
+	}
+	return response, nil
+}
+
+func (c *githubAppClient) doJSON(ctx context.Context, method string, path string, bearerToken string, body io.Reader, out any) error {
+	token := bearerToken
+	if token == "" {
+		appToken, err := c.appJWT()
+		if err != nil {
+			return err
+		}
+		token = appToken
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.apiBaseURL+path, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("Authorization", "Bearer "+token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		payload, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("github api %s %s returned %d: %s", method, path, resp.StatusCode, strings.TrimSpace(string(payload)))
+	}
+	if out == nil {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func (c *githubAppClient) appJWT() (string, error) {
+	now := time.Now().UTC()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	claims, err := json.Marshal(map[string]any{
+		"iat": now.Add(-time.Minute).Unix(),
+		"exp": now.Add(9 * time.Minute).Unix(),
+		"iss": c.appID,
+	})
+	if err != nil {
+		return "", err
+	}
+	payload := base64.RawURLEncoding.EncodeToString(claims)
+	signingInput := header + "." + payload
+	digest := sha256.Sum256([]byte(signingInput))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, c.privateKey, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", err
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}


### PR DESCRIPTION
## Summary

- adds a worker-side GitHub App client for short-lived installation tokens and draft pull request creation
- uses GitHub App auth for structured GitHub harness clone/push while keeping the installation token out of the Codex process environment
- pushes harness changes to a generated `agentclash/harness/<execution>` branch and creates a draft PR instead of leaving only local sandbox changes
- hardens the authenticated push path by using an explicit GitHub repository URL and disabling repo-local hooks and credential helpers during commit/push

## Security notes

- The GitHub installation token is only supplied to git clone/push through `GIT_ASKPASS` and `GITHUB_TOKEN`.
- The token is not embedded in command arrays or AgentClash event payloads.
- `codex exec` receives the existing model API env only, not `GITHUB_TOKEN`.
- The worker never pushes to the base branch; it creates a generated branch and opens a draft PR.
- Push uses `https://github.com/<owner>/<repo>.git` rather than repo-local `origin`, so an agent cannot retarget the authenticated push by editing git remote config.
- Commit and push run with `core.hooksPath=/dev/null`; push also clears repo-local credential helpers.

## GitHub App configuration needed after merge/deploy

Update the AgentClash GitHub App permissions, then approve the permission update on the installation:

- Metadata: read-only
- Contents: read and write
- Pull requests: read and write

The current installed app only has `metadata: read` and `contents: read`, so live PR creation will fail until the permission change is approved.

## Tests

- `cd backend && go test ./internal/workflow ./internal/worker`
- `cd backend && go test ./...`

## Local / live stack notes

- Live GitHub PR creation was not run from the local stack because the production GitHub App still needs the write permission approval above.
- Unit coverage verifies the local execution path: clone/push get the installation token, Codex does not, no token appears in command arrays, no-change runs skip PR creation, and changed runs create a draft PR event.
