### PR TITLE
feat(docs): expand CLI setup skill

### DIFF
--- a/testing/codex-issue-442-cli-setup-workflow.md
+++ b/testing/codex-issue-442-cli-setup-workflow.md
@@ -1,0 +1,37 @@
+# codex/issue-442-cli-setup-workflow - Test Contract
+
+## Functional Behavior
+- `web/content/agent-skills/agentclash-cli-setup/SKILL.md` remains an Agent Skills-compatible file with `name`, trigger-oriented `description`, and the three `metadata.agentclash.*` fields.
+- The CLI setup skill explains production-hosted defaults, device login, token/env behavior, workspace selection, `link`, config precedence, local/self-hosted overrides, troubleshooting, safety notes, and report-back format.
+- The workflow defaults to `AGENTCLASH_API_URL="https://api.agentclash.dev"` unless local or self-hosted behavior is explicit.
+- The skill is useful to a coding agent without root-repo access by including concrete commands, expected outputs, failure modes, and related `/docs-md/...` links.
+- The generated docs page, `/docs-md/...` export, `/llms.txt`, and `/llms-full.txt` continue to include the updated skill through the existing docs pipeline.
+
+## Unit Tests
+- `web/src/lib/docs.test.ts` continues to verify the `agentclash-cli-setup` page is generated from canonical `SKILL.md` content.
+- The docs test should assert at least one new CLI setup detail that distinguishes the expanded workflow from the prior scaffold.
+
+## Integration / Functional Tests
+- From `web/`, run `npm test -- docs.test.ts` and confirm all docs-generation tests pass.
+- From `web/`, run `npm run lint` and confirm lint passes.
+
+## Smoke Tests
+- `getDocBySlug(["agent-skills", "agentclash-cli-setup"])` contains production API default, config precedence, troubleshooting, and report-back guidance.
+- `buildLlmsFull("https://example.test")` includes the expanded CLI setup skill body.
+
+## E2E Tests
+N/A - this change updates static skill content and docs-generation coverage, not a browser workflow.
+
+## Manual / cURL Tests
+Manual reviewer checks:
+
+```bash
+sed -n '1,260p' web/content/agent-skills/agentclash-cli-setup/SKILL.md
+cd web
+npm test -- docs.test.ts
+npm run lint
+```
+
+Expected:
+- The skill documents the source-backed CLI setup workflow without requiring source-code access.
+- Tests and lint pass.

--- a/web/content/agent-skills/agentclash-cli-setup/SKILL.md
+++ b/web/content/agent-skills/agentclash-cli-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentclash-cli-setup
-description: Use when configuring the AgentClash CLI, authenticating with device login or tokens, selecting a workspace, linking local config, resolving API URL precedence, or diagnosing CLI access against production, local, or self-hosted backends.
+description: Use when configuring the AgentClash CLI, authenticating with device login or tokens, selecting a workspace, saving default config with link, creating project config with init, resolving API URL precedence, or diagnosing CLI access against production, local, or self-hosted backends.
 metadata:
   agentclash.role: setup
   agentclash.version: "1"
@@ -15,7 +15,7 @@ Configure an AgentClash CLI session that can reach the intended backend, authent
 ## Use When
 - A user asks to install, authenticate, verify, or repair AgentClash CLI access.
 - A coding agent needs AgentClash access but does not have the AgentClash source repo.
-- A user needs to switch workspaces, save a default workspace, or connect a local project to a workspace.
+- A user needs to switch workspaces, save a default workspace, or create project-local `.agentclash.yaml` config.
 - A CLI command fails because API URL, token, organization, workspace, or saved config precedence is unclear.
 - CI needs a non-interactive setup path with `AGENTCLASH_TOKEN`.
 
@@ -32,6 +32,7 @@ Configure an AgentClash CLI session that can reach the intended backend, authent
 - Organization ID if `workspace list` cannot infer one from saved config.
 - Workspace ID, workspace slug/name, or permission to choose one interactively with `agentclash link`.
 - Whether the command should mutate saved user config under `~/.config/agentclash/config.yaml`.
+- Whether the current repository should get project-local `.agentclash.yaml` config with `agentclash init`.
 
 ## Environment
 Use hosted production by default:
@@ -88,14 +89,17 @@ Saved user config lives at:
 ~/.config/agentclash/config.yaml
 ```
 
+Project-local config lives in `.agentclash.yaml` and is discovered by walking up from the current directory. It can store `workspace_id` and `org_id`.
+
 ## Procedure
 1. Choose the backend. For normal hosted work, export `AGENTCLASH_API_URL="https://api.agentclash.dev"` first.
 2. Verify the CLI is callable with `agentclash version` or, from the repo `cli/` directory, `go run . version`.
 3. Authenticate. Prefer `agentclash auth login --device` for remote shells; use `AGENTCLASH_TOKEN` for CI.
 4. Check the authenticated identity with `agentclash auth status`.
-5. Select a workspace with `agentclash link` for the guided flow, or `agentclash workspace use <workspace-id>` when the ID is already known.
-6. Run `agentclash doctor` to verify install, auth, workspace, challenge-pack visibility, deployment visibility, and baseline readiness.
-7. Report the effective backend, auth state, workspace, doctor result, and the next command the user should run.
+5. Select a workspace with `agentclash link` for the guided flow, or `agentclash workspace use <workspace-id>` when the ID is already known. Both commands write saved user config.
+6. If this repository should carry its own workspace binding, run `agentclash init --workspace-id <workspace-id> --org-id <organization-id>` from the project root.
+7. Run `agentclash doctor` to verify install, auth, workspace, challenge-pack visibility, deployment visibility, and baseline readiness.
+8. Report the effective backend, auth state, workspace, doctor result, and the next command the user should run.
 
 ## Commands
 Hosted production, interactive setup:
@@ -127,6 +131,12 @@ agentclash workspace get <workspace-id>
 agentclash workspace use <workspace-id>
 ```
 
+Project-local config for a repository:
+
+```bash
+agentclash init --workspace-id <workspace-id> --org-id <organization-id>
+```
+
 CI or non-interactive setup:
 
 ```bash
@@ -155,8 +165,9 @@ agentclash --api-url http://localhost:8080 doctor
 ## Expected Output
 - `auth login --device` prints a verification URL or confirms an existing valid login.
 - `auth status` shows the authenticated user and accessible organization/workspace counts.
-- `link` saves the selected workspace and organization in user config and prints the next suggested command.
+- `link` saves the selected workspace and organization in user config and prints the next suggested command. It does not write `.agentclash.yaml`.
 - `workspace use <workspace-id>` validates access and saves `default_workspace`; it also saves `default_org` when the workspace details include an organization ID.
+- `init --workspace-id <workspace-id> --org-id <organization-id>` writes project-local `.agentclash.yaml` in the current directory.
 - `doctor` prints the effective API URL, workspace, setup checks, and suggested next steps. In JSON mode, `ready: true` means no `warn` or `fail` checks remain.
 
 ## Failure Modes

--- a/web/content/agent-skills/agentclash-cli-setup/SKILL.md
+++ b/web/content/agent-skills/agentclash-cli-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentclash-cli-setup
-description: Use when configuring the AgentClash CLI, authenticating, selecting a workspace, linking a project, or diagnosing CLI access against production or local backends.
+description: Use when configuring the AgentClash CLI, authenticating with device login or tokens, selecting a workspace, linking local config, resolving API URL precedence, or diagnosing CLI access against production, local, or self-hosted backends.
 metadata:
   agentclash.role: setup
   agentclash.version: "1"
@@ -10,83 +10,186 @@ metadata:
 # AgentClash CLI Setup
 
 ## Purpose
-Configure a local AgentClash CLI session that can talk to the intended backend and workspace.
+Configure an AgentClash CLI session that can reach the intended backend, authenticate safely, resolve the right workspace, and pass `agentclash doctor` before a user starts authoring packs or running evals.
 
 ## Use When
-- A user asks to install, authenticate, or verify the AgentClash CLI.
-- A user needs to switch workspaces or connect a repo to a workspace.
-- A CLI command fails because the API URL, token, or workspace context is unclear.
+- A user asks to install, authenticate, verify, or repair AgentClash CLI access.
+- A coding agent needs AgentClash access but does not have the AgentClash source repo.
+- A user needs to switch workspaces, save a default workspace, or connect a local project to a workspace.
+- A CLI command fails because API URL, token, organization, workspace, or saved config precedence is unclear.
+- CI needs a non-interactive setup path with `AGENTCLASH_TOKEN`.
 
 ## Do Not Use When
-- The task is only to read scorecards or replay evidence from an already configured CLI.
-- The user is asking for production release automation rather than setup.
+- The CLI is already configured and the task is to run an eval or inspect a scorecard.
+- The user needs to author challenge pack YAML; use `agentclash-challenge-pack-yaml-author` after setup passes.
+- The user is making a release decision or CI gate from completed runs; use `agentclash-ci-release-gate`.
+- The task requires changing AgentClash CLI source code rather than using the CLI.
 
 ## Inputs Needed
-- Target backend: production or local.
-- Workspace ID or enough context to choose one from `workspace list`.
-- Whether browser-based device auth is acceptable.
+- Backend target: hosted production, local development, or self-hosted.
+- Whether the CLI is installed as `agentclash` or run from source with `go run .` inside `cli/`.
+- Whether browser/device login is acceptable, or whether `AGENTCLASH_TOKEN` must be used.
+- Organization ID if `workspace list` cannot infer one from saved config.
+- Workspace ID, workspace slug/name, or permission to choose one interactively with `agentclash link`.
+- Whether the command should mutate saved user config under `~/.config/agentclash/config.yaml`.
 
 ## Environment
-Use production by default; only override for local or self-hosted work:
+Use hosted production by default:
 
 ```bash
 export AGENTCLASH_API_URL="https://api.agentclash.dev"
 ```
 
-Resolution order for the API base URL:
+Use a local backend only when the user is explicitly running the API server locally:
+
+```bash
+export AGENTCLASH_API_URL="http://localhost:8080"
+```
+
+For CI or other non-interactive shells, provide a token through the environment instead of running browser login:
+
+```bash
+export AGENTCLASH_TOKEN="<token>"
+export AGENTCLASH_WORKSPACE="<workspace-id>"
+```
+
+Do not print token values in chat, logs, docs, or committed files.
+
+## Config And Precedence
+API URL resolution:
 
 ```text
---api-url > AGENTCLASH_API_URL > saved user config > http://localhost:8080
+--api-url > AGENTCLASH_API_URL > saved user config > default
+```
+
+The source-build default is `http://localhost:8080`. Released CLI builds stamp the production default at release time, but skills should still set `AGENTCLASH_API_URL="https://api.agentclash.dev"` explicitly for hosted workflows so copied commands behave the same in source and released builds.
+
+Workspace resolution:
+
+```text
+--workspace / -w > AGENTCLASH_WORKSPACE > project .agentclash.yaml > saved user config
+```
+
+Organization resolution for commands that need an org:
+
+```text
+AGENTCLASH_ORG > project .agentclash.yaml > saved user config
+```
+
+Auth token resolution:
+
+```text
+AGENTCLASH_TOKEN > stored CLI credentials
+```
+
+Saved user config lives at:
+
+```text
+~/.config/agentclash/config.yaml
 ```
 
 ## Procedure
-1. Confirm the backend target.
-2. Authenticate with device login unless a token is already provided.
-3. List workspaces and select the intended workspace.
-4. Link the current project when the workflow benefits from repo-local workspace context.
-5. Run `doctor` and report the effective API URL, workspace, and any warnings.
+1. Choose the backend. For normal hosted work, export `AGENTCLASH_API_URL="https://api.agentclash.dev"` first.
+2. Verify the CLI is callable with `agentclash version` or, from the repo `cli/` directory, `go run . version`.
+3. Authenticate. Prefer `agentclash auth login --device` for remote shells; use `AGENTCLASH_TOKEN` for CI.
+4. Check the authenticated identity with `agentclash auth status`.
+5. Select a workspace with `agentclash link` for the guided flow, or `agentclash workspace use <workspace-id>` when the ID is already known.
+6. Run `agentclash doctor` to verify install, auth, workspace, challenge-pack visibility, deployment visibility, and baseline readiness.
+7. Report the effective backend, auth state, workspace, doctor result, and the next command the user should run.
 
 ## Commands
+Hosted production, interactive setup:
+
 ```bash
 export AGENTCLASH_API_URL="https://api.agentclash.dev"
+agentclash version
 agentclash auth login --device
-agentclash workspace list
-agentclash workspace use <workspace-id>
-agentclash link --workspace <workspace-id>
+agentclash auth status
+agentclash link
 agentclash doctor
 ```
 
-For local backend work:
+Hosted production when the workspace ID is already known:
+
+```bash
+export AGENTCLASH_API_URL="https://api.agentclash.dev"
+agentclash auth login --device
+agentclash workspace use <workspace-id>
+agentclash doctor
+```
+
+Workspace discovery when an organization must be explicit:
+
+```bash
+export AGENTCLASH_API_URL="https://api.agentclash.dev"
+agentclash workspace list --org <organization-id>
+agentclash workspace get <workspace-id>
+agentclash workspace use <workspace-id>
+```
+
+CI or non-interactive setup:
+
+```bash
+export AGENTCLASH_API_URL="https://api.agentclash.dev"
+export AGENTCLASH_TOKEN="<token>"
+export AGENTCLASH_WORKSPACE="<workspace-id>"
+agentclash doctor --json
+```
+
+Local development from the CLI module:
+
+```bash
+cd cli
+export AGENTCLASH_API_URL="http://localhost:8080"
+go run . auth login --device
+go run . link
+go run . doctor
+```
+
+One-off backend override without changing saved config:
 
 ```bash
 agentclash --api-url http://localhost:8080 doctor
 ```
 
 ## Expected Output
-- Auth succeeds or prints a device verification URL.
-- `workspace list` shows accessible workspaces.
-- `doctor` reports the resolved API URL and workspace context.
+- `auth login --device` prints a verification URL or confirms an existing valid login.
+- `auth status` shows the authenticated user and accessible organization/workspace counts.
+- `link` saves the selected workspace and organization in user config and prints the next suggested command.
+- `workspace use <workspace-id>` validates access and saves `default_workspace`; it also saves `default_org` when the workspace details include an organization ID.
+- `doctor` prints the effective API URL, workspace, setup checks, and suggested next steps. In JSON mode, `ready: true` means no `warn` or `fail` checks remain.
 
 ## Failure Modes
-- `401` or `403`: token is missing, expired, or does not belong to the selected workspace.
-- Empty workspace list: wrong account or backend.
-- Commands unexpectedly hit localhost: `AGENTCLASH_API_URL` and saved config are missing.
+- `AGENTCLASH_TOKEN is set but could not be validated`: the environment token is present and takes precedence, but it is wrong for this backend. Unset or replace `AGENTCLASH_TOKEN`, then rerun `agentclash auth login --device` or `agentclash auth status`.
+- `Not logged in. No API token is configured.`: run `agentclash auth login --device` for interactive work, or set `AGENTCLASH_TOKEN` for CI.
+- Commands unexpectedly hit `http://localhost:8080`: set `AGENTCLASH_API_URL="https://api.agentclash.dev"` or pass `--api-url`; source builds default to localhost.
+- `organization ID required`: pass `--org <organization-id>` or set a default organization through `agentclash link`, `agentclash workspace use`, or config.
+- `no workspace specified`: run `agentclash link`, pass `--workspace <workspace-id>`, set `AGENTCLASH_WORKSPACE`, or create project config with `agentclash init`.
+- `Workspace <id> is not accessible`: the saved or env workspace does not belong to the current token/backend. Run `agentclash link` or update `AGENTCLASH_WORKSPACE`.
+- `doctor` reports no challenge packs: setup is valid, but the workspace needs `agentclash challenge-pack init`, `validate`, and `publish` before evals are useful.
+- `doctor` reports no deployments: setup is valid, but an agent deployment must be created before starting evals.
+- `doctor` reports no baseline: this is advisory on a fresh workspace; set one after the first completed eval with `agentclash baseline set`.
 
 ## Safety Notes
-- Do not print tokens in chat or commit them to files.
-- Prefer small workspaces and smoke checks for exploratory work.
-- Ask before changing a user's saved production config.
+- Never paste, print, or commit `AGENTCLASH_TOKEN` or provider secrets.
+- Ask before changing saved user config when the user is sharing a machine or switching production workspaces.
+- Prefer `--api-url` for one-off local/self-hosted checks so saved production config is not accidentally changed.
+- Prefer `doctor --json` in automation because it returns a machine-readable `ready` field and exits non-zero when setup warnings remain.
+- Run read-only commands (`auth status`, `workspace list`, `doctor`) before write or publish commands.
 
 ## Report Back Format
 ```text
-Backend: <url>
+Backend: <effective API URL>
+Auth: <ok | action needed> (<source: AGENTCLASH_TOKEN | stored credentials | none>)
 Workspace: <workspace-id or none>
-Auth: <ok or action needed>
-Doctor: <summary>
-Next command: <command>
+Doctor: <ready | warnings> - <short check summary>
+Next command: <single recommended command>
+Notes: <config precedence, local override, or token caveat if relevant>
 ```
 
 ## Related Docs
 - `/docs-md/getting-started/quickstart`
+- `/docs-md/guides/use-with-ai-tools`
 - `/docs-md/reference/cli`
 - `/docs-md/reference/config`
+- `/docs-md/agent-skills`

--- a/web/src/lib/docs.test.ts
+++ b/web/src/lib/docs.test.ts
@@ -61,6 +61,7 @@ describe("agent skill docs", () => {
     expect(doc?.content).toContain(
       "AGENTCLASH_TOKEN > stored CLI credentials",
     );
+    expect(doc?.content).toContain("agentclash init --workspace-id");
     expect(doc?.content).toContain("doctor --json");
   });
 

--- a/web/src/lib/docs.test.ts
+++ b/web/src/lib/docs.test.ts
@@ -55,6 +55,13 @@ describe("agent skill docs", () => {
     expect(doc?.content).toContain("## Full SKILL.md");
     expect(doc?.content).toContain("name: agentclash-cli-setup");
     expect(doc?.content).toContain('AGENTCLASH_API_URL="https://api.agentclash.dev"');
+    expect(doc?.content).toContain(
+      "Workspace resolution:",
+    );
+    expect(doc?.content).toContain(
+      "AGENTCLASH_TOKEN > stored CLI credentials",
+    );
+    expect(doc?.content).toContain("doctor --json");
   });
 
   it("generates nested challenge pack and agent build skill pages", () => {
@@ -109,5 +116,6 @@ describe("agent skill docs", () => {
     expect(bundle).toContain("# CLI Setup Skill");
     expect(bundle).toContain("# Challenge Pack YAML Author Skill");
     expect(bundle).toContain("name: agentclash-cli-setup");
+    expect(bundle).toContain("Commands unexpectedly hit `http://localhost:8080`");
   });
 });


### PR DESCRIPTION
## Summary
- Expands `agentclash-cli-setup` into a source-backed operating skill for hosted production, local, and self-hosted CLI setup.
- Documents device login, `AGENTCLASH_TOKEN`, workspace linking/selection, API URL/workspace/org/token precedence, `doctor` readiness, troubleshooting, safety notes, and report-back format.
- Adds docs tests proving the expanded CLI setup details render in the generated skill page and `llms-full.txt`.

Closes #442
Refs #440

## Review Checkpoint
Test contract: `testing/codex-issue-442-cli-setup-workflow.md`

Checkpoint summary:
- Step 0: committed the issue #442 test contract before implementation.
- Step 1: expanded the CLI setup skill and docs assertions.
- Final verdict: ready.
- Blocking issues: none.

## Validation
- `cd web && npm test -- docs.test.ts` - passed, 7 tests.
- `cd web && npm run lint` - passed.

## Notes
- This PR intentionally leaves unrelated local worktree files out of scope.
- The checkpoint scratchpad stayed in `/tmp/reviewcheckpoint.json` and was not committed.
