### PR TITLE
feat(cli): add AgentClash CI manifest contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,14 @@ If your workspace is already seeded with challenge packs and deployments, you ca
 
 ### CI/CD
 
-All commands also work non-interactively with environment variables and explicit IDs:
+AgentClash CI/CD gates the candidate agent revision against a repeatable workload. Start by committing an explicit manifest that maps repo changes to the candidate build, deployment settings, challenge pack, baseline, and release gate:
+
+```bash
+agentclash ci init .agentclash/ci.yaml
+agentclash ci validate .agentclash/ci.yaml
+```
+
+The current CLI can validate that manifest locally. Existing commands also work non-interactively with environment variables and explicit IDs:
 
 ```bash
 export AGENTCLASH_API_URL="https://api.agentclash.dev"
@@ -139,6 +146,8 @@ agentclash run create \
 agentclash run list --json
 agentclash compare gate --baseline $BASE --candidate $CAND  # exit 1 = regression
 ```
+
+See [CI/CD Agent Gates](web/content/docs/guides/ci-cd-agent-gates.mdx) for the GitHub Actions sketch and the manifest contract.
 
 Run `agentclash --help` for the full command reference.
 

--- a/cli/cmd/ci.go
+++ b/cli/cmd/ci.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -195,7 +196,9 @@ func validateCIManifestFile(path string) (ciManifestValidationResult, error) {
 	}
 
 	var manifest ciManifest
-	if err := yaml.Unmarshal(data, &manifest); err != nil {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&manifest); err != nil {
 		result := ciManifestValidationResult{Path: path, Valid: false, Errors: []string{fmt.Sprintf("parse YAML: %v", err)}}
 		return result, fmt.Errorf("parse YAML: %w", err)
 	}
@@ -235,6 +238,12 @@ func validateCIManifest(manifest ciManifest) []string {
 	}
 	if strings.TrimSpace(manifest.Evaluation.ChallengePackVersionID) == "" {
 		errors = append(errors, "evaluation.challenge_pack_version_id is required")
+	}
+	if hasBlankString(manifest.Evaluation.RegressionSuites) {
+		errors = append(errors, "evaluation.regression_suites cannot include blank entries")
+	}
+	if hasBlankString(manifest.Evaluation.RegressionCases) {
+		errors = append(errors, "evaluation.regression_cases cannot include blank entries")
 	}
 	if strings.TrimSpace(manifest.Baseline.RunID) == "" && strings.TrimSpace(manifest.Baseline.DeploymentID) == "" {
 		errors = append(errors, "baseline.run_id or baseline.deployment_id is required")

--- a/cli/cmd/ci.go
+++ b/cli/cmd/ci.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/agentclash/agentclash/cli/internal/output"
@@ -41,6 +42,11 @@ var ciInitCmd = &cobra.Command{
 				return fmt.Errorf("%s already exists; pass --force to overwrite", target)
 			} else if !os.IsNotExist(err) {
 				return fmt.Errorf("checking %s: %w", target, err)
+			}
+		}
+		if parent := filepath.Dir(target); parent != "." {
+			if err := os.MkdirAll(parent, 0o755); err != nil {
+				return fmt.Errorf("creating parent directory for %s: %w", target, err)
 			}
 		}
 		if err := os.WriteFile(target, []byte(sampleCIManifestYAML), 0o644); err != nil {

--- a/cli/cmd/ci.go
+++ b/cli/cmd/ci.go
@@ -1,0 +1,276 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/agentclash/agentclash/cli/internal/output"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+func init() {
+	rootCmd.AddCommand(ciCmd)
+	ciCmd.AddCommand(ciInitCmd)
+	ciCmd.AddCommand(ciValidateCmd)
+
+	ciInitCmd.Flags().Bool("force", false, "Overwrite an existing manifest")
+}
+
+var ciCmd = &cobra.Command{
+	Use:   "ci",
+	Short: "Manage AgentClash CI manifests",
+	Long: `Manage AgentClash CI manifests for main-product agent evaluation.
+
+The CI manifest is a repo-tracked contract that maps source changes to a
+candidate agent build version, deployment settings, evaluation workload,
+baseline, release gate, and regression promotion policy.`,
+}
+
+var ciInitCmd = &cobra.Command{
+	Use:   "init <file>",
+	Short: "Write a sample AgentClash CI manifest",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		target := args[0]
+		force, _ := cmd.Flags().GetBool("force")
+		if !force {
+			if _, err := os.Stat(target); err == nil {
+				return fmt.Errorf("%s already exists; pass --force to overwrite", target)
+			} else if !os.IsNotExist(err) {
+				return fmt.Errorf("checking %s: %w", target, err)
+			}
+		}
+		if err := os.WriteFile(target, []byte(sampleCIManifestYAML), 0o644); err != nil {
+			return fmt.Errorf("writing %s: %w", target, err)
+		}
+
+		result := map[string]any{
+			"path":  target,
+			"valid": true,
+		}
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(result)
+		}
+		rc.Output.PrintSuccess(fmt.Sprintf("Created %s", target))
+		rc.Output.PrintDetail("Next", fmt.Sprintf("agentclash ci validate %s", target))
+		return nil
+	},
+}
+
+var ciValidateCmd = &cobra.Command{
+	Use:   "validate <file>",
+	Short: "Validate an AgentClash CI manifest",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		result, err := validateCIManifestFile(args[0])
+		if rc.Output.IsStructured() {
+			if printErr := rc.Output.PrintRaw(result); printErr != nil {
+				return printErr
+			}
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+
+		if err != nil {
+			rc.Output.PrintError("AgentClash CI manifest is invalid")
+			for _, msg := range result.Errors {
+				fmt.Fprintf(os.Stderr, "  - %s\n", output.SanitizeLine(msg))
+			}
+			return err
+		}
+		rc.Output.PrintSuccess("AgentClash CI manifest is valid")
+		rc.Output.PrintDetail("Watched Paths", fmt.Sprintf("%d", len(result.Manifest.Trigger.Paths)))
+		rc.Output.PrintDetail("Evaluation", result.Manifest.Evaluation.ChallengePackVersionID)
+		return nil
+	},
+}
+
+type ciManifest struct {
+	Version     int                   `yaml:"version" json:"version"`
+	Trigger     ciManifestTrigger     `yaml:"trigger" json:"trigger"`
+	Candidate   ciManifestCandidate   `yaml:"candidate" json:"candidate"`
+	Evaluation  ciManifestEvaluation  `yaml:"evaluation" json:"evaluation"`
+	Baseline    ciManifestBaseline    `yaml:"baseline" json:"baseline"`
+	Gate        ciManifestGate        `yaml:"gate" json:"gate"`
+	Regressions ciManifestRegressions `yaml:"regressions" json:"regressions"`
+}
+
+type ciManifestTrigger struct {
+	Paths  []string `yaml:"paths" json:"paths"`
+	Labels []string `yaml:"labels,omitempty" json:"labels,omitempty"`
+}
+
+type ciManifestCandidate struct {
+	Build      ciManifestCandidateBuild      `yaml:"build" json:"build"`
+	Deployment ciManifestCandidateDeployment `yaml:"deployment" json:"deployment"`
+}
+
+type ciManifestCandidateBuild struct {
+	AgentBuildID string `yaml:"agent_build_id" json:"agent_build_id"`
+	SpecFile     string `yaml:"spec_file" json:"spec_file"`
+}
+
+type ciManifestCandidateDeployment struct {
+	Name              string `yaml:"name,omitempty" json:"name,omitempty"`
+	RuntimeProfileID  string `yaml:"runtime_profile_id" json:"runtime_profile_id"`
+	ProviderAccountID string `yaml:"provider_account_id,omitempty" json:"provider_account_id,omitempty"`
+	ModelAliasID      string `yaml:"model_alias_id,omitempty" json:"model_alias_id,omitempty"`
+}
+
+type ciManifestEvaluation struct {
+	ChallengePackVersionID string   `yaml:"challenge_pack_version_id" json:"challenge_pack_version_id"`
+	InputSetID             string   `yaml:"input_set_id,omitempty" json:"input_set_id,omitempty"`
+	RegressionSuites       []string `yaml:"regression_suites,omitempty" json:"regression_suites,omitempty"`
+	RegressionCases        []string `yaml:"regression_cases,omitempty" json:"regression_cases,omitempty"`
+}
+
+type ciManifestBaseline struct {
+	RunID        string `yaml:"run_id,omitempty" json:"run_id,omitempty"`
+	DeploymentID string `yaml:"deployment_id,omitempty" json:"deployment_id,omitempty"`
+}
+
+type ciManifestGate struct {
+	FailOn     string `yaml:"fail_on" json:"fail_on"`
+	PolicyFile string `yaml:"policy_file,omitempty" json:"policy_file,omitempty"`
+}
+
+type ciManifestRegressions struct {
+	PromoteFailures string `yaml:"promote_failures" json:"promote_failures"`
+}
+
+type ciManifestValidationResult struct {
+	Path     string      `json:"path" yaml:"path"`
+	Valid    bool        `json:"valid" yaml:"valid"`
+	Errors   []string    `json:"errors,omitempty" yaml:"errors,omitempty"`
+	Manifest *ciManifest `json:"manifest,omitempty" yaml:"manifest,omitempty"`
+}
+
+const sampleCIManifestYAML = `version: 1
+trigger:
+  paths:
+    - .agentclash/agent.json
+    - prompts/**
+    - tools/**
+  labels:
+    - agentclash/eval
+candidate:
+  build:
+    agent_build_id: 00000000-0000-0000-0000-000000000001
+    spec_file: .agentclash/agent.json
+  deployment:
+    name: pr-candidate
+    runtime_profile_id: 00000000-0000-0000-0000-000000000002
+    provider_account_id: 00000000-0000-0000-0000-000000000003
+    model_alias_id: 00000000-0000-0000-0000-000000000004
+evaluation:
+  challenge_pack_version_id: 00000000-0000-0000-0000-000000000005
+  input_set_id: 00000000-0000-0000-0000-000000000006
+  regression_suites:
+    - 00000000-0000-0000-0000-000000000007
+baseline:
+  run_id: 00000000-0000-0000-0000-000000000008
+gate:
+  fail_on: regression
+regressions:
+  promote_failures: proposed
+`
+
+func validateCIManifestFile(path string) (ciManifestValidationResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		result := ciManifestValidationResult{Path: path, Valid: false, Errors: []string{fmt.Sprintf("read manifest: %v", err)}}
+		return result, fmt.Errorf("read manifest: %w", err)
+	}
+
+	var manifest ciManifest
+	if err := yaml.Unmarshal(data, &manifest); err != nil {
+		result := ciManifestValidationResult{Path: path, Valid: false, Errors: []string{fmt.Sprintf("parse YAML: %v", err)}}
+		return result, fmt.Errorf("parse YAML: %w", err)
+	}
+
+	errors := validateCIManifest(manifest)
+	result := ciManifestValidationResult{
+		Path:     path,
+		Valid:    len(errors) == 0,
+		Errors:   errors,
+		Manifest: &manifest,
+	}
+	if len(errors) > 0 {
+		return result, fmt.Errorf("ci manifest validation failed")
+	}
+	return result, nil
+}
+
+func validateCIManifest(manifest ciManifest) []string {
+	var errors []string
+	if manifest.Version != 1 {
+		errors = append(errors, "version must be 1")
+	}
+	if len(nonEmptyStrings(manifest.Trigger.Paths)) == 0 {
+		errors = append(errors, "trigger.paths must include at least one path glob")
+	}
+	if hasBlankString(manifest.Trigger.Paths) {
+		errors = append(errors, "trigger.paths cannot include blank entries")
+	}
+	if strings.TrimSpace(manifest.Candidate.Build.AgentBuildID) == "" {
+		errors = append(errors, "candidate.build.agent_build_id is required")
+	}
+	if strings.TrimSpace(manifest.Candidate.Build.SpecFile) == "" {
+		errors = append(errors, "candidate.build.spec_file is required")
+	}
+	if strings.TrimSpace(manifest.Candidate.Deployment.RuntimeProfileID) == "" {
+		errors = append(errors, "candidate.deployment.runtime_profile_id is required")
+	}
+	if strings.TrimSpace(manifest.Evaluation.ChallengePackVersionID) == "" {
+		errors = append(errors, "evaluation.challenge_pack_version_id is required")
+	}
+	if strings.TrimSpace(manifest.Baseline.RunID) == "" && strings.TrimSpace(manifest.Baseline.DeploymentID) == "" {
+		errors = append(errors, "baseline.run_id or baseline.deployment_id is required")
+	}
+	if failOn := strings.TrimSpace(manifest.Gate.FailOn); failOn == "" {
+		errors = append(errors, "gate.fail_on is required")
+	} else if !allowedCIManifestValue(failOn, "regression", "warning", "insufficient_evidence") {
+		errors = append(errors, "gate.fail_on must be one of regression, warning, insufficient_evidence")
+	}
+	if promote := strings.TrimSpace(manifest.Regressions.PromoteFailures); promote == "" {
+		errors = append(errors, "regressions.promote_failures is required")
+	} else if !allowedCIManifestValue(promote, "disabled", "proposed", "auto_on_main") {
+		errors = append(errors, "regressions.promote_failures must be one of disabled, proposed, auto_on_main")
+	}
+	return errors
+}
+
+func allowedCIManifestValue(value string, allowed ...string) bool {
+	for _, candidate := range allowed {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func nonEmptyStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+func hasBlankString(values []string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/cmd/ci_test.go
+++ b/cli/cmd/ci_test.go
@@ -1,0 +1,282 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCIInitWritesSampleManifest(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "agentclash-ci.yaml")
+
+	if err := executeCommand(t, []string{"ci", "init", target}, "http://unused"); err != nil {
+		t.Fatalf("ci init error: %v", err)
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	text := string(data)
+	for _, snippet := range []string{
+		"version: 1",
+		"trigger:",
+		"candidate:",
+		"evaluation:",
+		"baseline:",
+		"gate:",
+		"regressions:",
+	} {
+		if !strings.Contains(text, snippet) {
+			t.Fatalf("ci init output missing %q\n---\n%s", snippet, text)
+		}
+	}
+}
+
+func TestCIInitRequiresForceToOverwrite(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "agentclash-ci.yaml")
+	if err := os.WriteFile(target, []byte("existing"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	err := executeCommand(t, []string{"ci", "init", target}, "http://unused")
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("error = %v, want already exists", err)
+	}
+
+	if err := executeCommand(t, []string{"ci", "init", target, "--force"}, "http://unused"); err != nil {
+		t.Fatalf("ci init --force error: %v", err)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if !strings.Contains(string(data), "agentclash/eval") {
+		t.Fatalf("forced manifest did not replace file\n---\n%s", string(data))
+	}
+}
+
+func TestCIValidateAcceptsValidManifest(t *testing.T) {
+	target := writeCIManifest(t, sampleCIManifestYAML)
+
+	if err := executeCommand(t, []string{"ci", "validate", target}, "http://unused"); err != nil {
+		t.Fatalf("ci validate error: %v", err)
+	}
+}
+
+func TestCIValidateJSONOutput(t *testing.T) {
+	target := writeCIManifest(t, sampleCIManifestYAML)
+	stdout := captureStdout(t)
+
+	err := executeCommand(t, []string{"ci", "validate", target, "--json"}, "http://unused")
+	out := stdout.finish()
+	if err != nil {
+		t.Fatalf("ci validate --json error: %v", err)
+	}
+
+	var result struct {
+		Valid bool `json:"valid"`
+	}
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("json output parse error: %v", err)
+	}
+	if !result.Valid {
+		t.Fatal("json output valid = false, want true")
+	}
+}
+
+func TestCIValidateRejectsInvalidManifests(t *testing.T) {
+	tests := []struct {
+		name     string
+		manifest string
+		want     string
+	}{
+		{
+			name: "missing trigger paths",
+			manifest: `version: 1
+trigger: {}
+candidate:
+  build:
+    agent_build_id: build-1
+    spec_file: .agentclash/agent.json
+  deployment:
+    runtime_profile_id: runtime-1
+evaluation:
+  challenge_pack_version_id: pack-version-1
+baseline:
+  run_id: run-1
+gate:
+  fail_on: regression
+regressions:
+  promote_failures: proposed
+`,
+			want: "trigger.paths",
+		},
+		{
+			name: "missing candidate build",
+			manifest: `version: 1
+trigger:
+  paths:
+    - .agentclash/agent.json
+candidate:
+  build:
+    spec_file: .agentclash/agent.json
+  deployment:
+    runtime_profile_id: runtime-1
+evaluation:
+  challenge_pack_version_id: pack-version-1
+baseline:
+  run_id: run-1
+gate:
+  fail_on: regression
+regressions:
+  promote_failures: proposed
+`,
+			want: "candidate.build.agent_build_id",
+		},
+		{
+			name: "missing candidate deployment",
+			manifest: `version: 1
+trigger:
+  paths:
+    - .agentclash/agent.json
+candidate:
+  build:
+    agent_build_id: build-1
+    spec_file: .agentclash/agent.json
+evaluation:
+  challenge_pack_version_id: pack-version-1
+baseline:
+  run_id: run-1
+gate:
+  fail_on: regression
+regressions:
+  promote_failures: proposed
+`,
+			want: "candidate.deployment.runtime_profile_id",
+		},
+		{
+			name: "missing challenge pack version",
+			manifest: `version: 1
+trigger:
+  paths:
+    - .agentclash/agent.json
+candidate:
+  build:
+    agent_build_id: build-1
+    spec_file: .agentclash/agent.json
+  deployment:
+    runtime_profile_id: runtime-1
+evaluation: {}
+baseline:
+  run_id: run-1
+gate:
+  fail_on: regression
+regressions:
+  promote_failures: proposed
+`,
+			want: "evaluation.challenge_pack_version_id",
+		},
+		{
+			name: "missing baseline",
+			manifest: `version: 1
+trigger:
+  paths:
+    - .agentclash/agent.json
+candidate:
+  build:
+    agent_build_id: build-1
+    spec_file: .agentclash/agent.json
+  deployment:
+    runtime_profile_id: runtime-1
+evaluation:
+  challenge_pack_version_id: pack-version-1
+baseline: {}
+gate:
+  fail_on: regression
+regressions:
+  promote_failures: proposed
+`,
+			want: "baseline.run_id or baseline.deployment_id",
+		},
+		{
+			name: "invalid gate fail mode",
+			manifest: `version: 1
+trigger:
+  paths:
+    - .agentclash/agent.json
+candidate:
+  build:
+    agent_build_id: build-1
+    spec_file: .agentclash/agent.json
+  deployment:
+    runtime_profile_id: runtime-1
+evaluation:
+  challenge_pack_version_id: pack-version-1
+baseline:
+  run_id: run-1
+gate:
+  fail_on: whatever
+regressions:
+  promote_failures: proposed
+`,
+			want: "gate.fail_on",
+		},
+		{
+			name: "invalid regression promotion mode",
+			manifest: `version: 1
+trigger:
+  paths:
+    - .agentclash/agent.json
+candidate:
+  build:
+    agent_build_id: build-1
+    spec_file: .agentclash/agent.json
+  deployment:
+    runtime_profile_id: runtime-1
+evaluation:
+  challenge_pack_version_id: pack-version-1
+baseline:
+  run_id: run-1
+gate:
+  fail_on: regression
+regressions:
+  promote_failures: always
+`,
+			want: "regressions.promote_failures",
+		},
+		{
+			name:     "invalid yaml",
+			manifest: "version: [",
+			want:     "parse YAML",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := writeCIManifest(t, tt.manifest)
+			err := executeCommand(t, []string{"ci", "validate", target}, "http://unused")
+			if err == nil {
+				t.Fatal("expected ci validate to fail")
+			}
+			if !strings.Contains(err.Error(), "ci manifest validation failed") && !strings.Contains(err.Error(), "parse YAML") {
+				t.Fatalf("error = %v, want validation or parse failure", err)
+			}
+			result, _ := validateCIManifestFile(target)
+			if len(result.Errors) == 0 || !strings.Contains(strings.Join(result.Errors, "\n"), tt.want) {
+				t.Fatalf("errors = %v, want %q", result.Errors, tt.want)
+			}
+		})
+	}
+}
+
+func writeCIManifest(t *testing.T, text string) string {
+	t.Helper()
+	target := filepath.Join(t.TempDir(), "agentclash-ci.yaml")
+	if err := os.WriteFile(target, []byte(text), 0o644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+	return target
+}

--- a/cli/cmd/ci_test.go
+++ b/cli/cmd/ci_test.go
@@ -35,6 +35,18 @@ func TestCIInitWritesSampleManifest(t *testing.T) {
 	}
 }
 
+func TestCIInitCreatesParentDirectories(t *testing.T) {
+	target := filepath.Join(t.TempDir(), ".agentclash", "ci.yaml")
+
+	if err := executeCommand(t, []string{"ci", "init", target}, "http://unused"); err != nil {
+		t.Fatalf("ci init error: %v", err)
+	}
+
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("Stat(%q) error: %v", target, err)
+	}
+}
+
 func TestCIInitRequiresForceToOverwrite(t *testing.T) {
 	target := filepath.Join(t.TempDir(), "agentclash-ci.yaml")
 	if err := os.WriteFile(target, []byte("existing"), 0o644); err != nil {

--- a/cli/cmd/ci_test.go
+++ b/cli/cmd/ci_test.go
@@ -264,6 +264,82 @@ regressions:
 			manifest: "version: [",
 			want:     "parse YAML",
 		},
+		{
+			name: "unknown manifest field",
+			manifest: `version: 1
+trigger:
+  paths:
+    - .agentclash/agent.json
+candidate:
+  build:
+    agent_build_id: build-1
+    spec_file: .agentclash/agent.json
+  deployment:
+    runtime_profile_id: runtime-1
+evaluation:
+  challenge_pack_version_id: pack-version-1
+  regression_sweets:
+    - suite-1
+baseline:
+  run_id: run-1
+gate:
+  fail_on: regression
+regressions:
+  promote_failures: proposed
+`,
+			want: "regression_sweets",
+		},
+		{
+			name: "blank regression suite",
+			manifest: `version: 1
+trigger:
+  paths:
+    - .agentclash/agent.json
+candidate:
+  build:
+    agent_build_id: build-1
+    spec_file: .agentclash/agent.json
+  deployment:
+    runtime_profile_id: runtime-1
+evaluation:
+  challenge_pack_version_id: pack-version-1
+  regression_suites:
+    - suite-1
+    - "   "
+baseline:
+  run_id: run-1
+gate:
+  fail_on: regression
+regressions:
+  promote_failures: proposed
+`,
+			want: "evaluation.regression_suites",
+		},
+		{
+			name: "blank regression case",
+			manifest: `version: 1
+trigger:
+  paths:
+    - .agentclash/agent.json
+candidate:
+  build:
+    agent_build_id: build-1
+    spec_file: .agentclash/agent.json
+  deployment:
+    runtime_profile_id: runtime-1
+evaluation:
+  challenge_pack_version_id: pack-version-1
+  regression_cases:
+    - ""
+baseline:
+  run_id: run-1
+gate:
+  fail_on: regression
+regressions:
+  promote_failures: proposed
+`,
+			want: "evaluation.regression_cases",
+		},
 	}
 
 	for _, tt := range tests {

--- a/testing/codex-ci-cd-agentclash-gates.md
+++ b/testing/codex-ci-cd-agentclash-gates.md
@@ -1,0 +1,54 @@
+# Codex CI CD AgentClash Gates — Test Contract
+
+## Functional Behavior
+
+- The CLI exposes an `agentclash ci` command group for main-product CI/CD integration.
+- `agentclash ci init <file>` writes a sample AgentClash CI manifest without overwriting existing files unless `--force` is passed.
+- `agentclash ci validate <file>` validates a YAML manifest that describes:
+  - watched source paths that should trigger AgentClash CI
+  - the candidate agent build spec and deployment resource IDs
+  - the evaluation workload using a challenge pack version, optional input set, and optional regression suites/cases
+  - the baseline run or deployment reference used for comparison
+  - release gate and regression promotion policy
+- Validation succeeds for a well-formed manifest and prints structured JSON when `--json` is used.
+- Validation fails with a nonzero exit when required sections or IDs are missing, path globs are blank, enum values are invalid, or the manifest is not valid YAML.
+- The feature remains scoped to main-product CI. It must not depend on experimental agent harnesses.
+
+## Unit Tests
+
+- CLI tests cover `ci init` creating a manifest with expected top-level sections.
+- CLI tests cover `ci init` refusing to overwrite unless `--force` is present.
+- CLI tests cover `ci validate` accepting a valid manifest.
+- CLI tests cover `ci validate` rejecting missing `trigger.paths`.
+- CLI tests cover `ci validate` rejecting missing candidate build/deployment resource fields.
+- CLI tests cover `ci validate` rejecting a missing evaluation challenge pack version.
+- CLI tests cover `ci validate` rejecting a missing baseline reference.
+- CLI tests cover invalid enum values for release gate failure mode and regression promotion mode.
+
+## Integration / Functional Tests
+
+- N/A — this PR is limited to local CLI manifest parsing/validation and docs. It does not create backend records or call the AgentClash API for CI orchestration.
+
+## Smoke Tests
+
+- From `cli/`, `go test ./cmd -run 'TestCI' -count=1` passes.
+- From `cli/`, `go test -short ./cmd -count=1` passes.
+- From `cli/`, `go build ./...` passes.
+
+## E2E Tests
+
+- N/A — full GitHub Actions orchestration will be a follow-up once the manifest contract is merged.
+
+## Manual / cURL Tests
+
+```bash
+cd cli
+go run . ci init /tmp/agentclash-ci.yaml --force
+go run . ci validate /tmp/agentclash-ci.yaml
+go run . ci validate /tmp/agentclash-ci.yaml --json
+```
+
+Expected:
+- `ci init` creates the file and reports success.
+- `ci validate` prints a success message for the generated manifest.
+- `ci validate --json` prints a JSON object with `valid: true`.

--- a/testing/codex-ci-cd-agentclash-gates.md
+++ b/testing/codex-ci-cd-agentclash-gates.md
@@ -4,6 +4,7 @@
 
 - The CLI exposes an `agentclash ci` command group for main-product CI/CD integration.
 - `agentclash ci init <file>` writes a sample AgentClash CI manifest without overwriting existing files unless `--force` is passed.
+- `agentclash ci init <file>` creates missing parent directories for the target manifest path so the documented `.agentclash/ci.yaml` quickstart works in a fresh repository.
 - `agentclash ci validate <file>` validates a YAML manifest that describes:
   - watched source paths that should trigger AgentClash CI
   - the candidate agent build spec and deployment resource IDs
@@ -11,17 +12,20 @@
   - the baseline run or deployment reference used for comparison
   - release gate and regression promotion policy
 - Validation succeeds for a well-formed manifest and prints structured JSON when `--json` is used.
-- Validation fails with a nonzero exit when required sections or IDs are missing, path globs are blank, enum values are invalid, or the manifest is not valid YAML.
+- Validation fails with a nonzero exit when required sections or IDs are missing, path globs are blank, regression suite/case IDs are blank, enum values are invalid, unknown manifest fields are present, or the manifest is not valid YAML.
 - The feature remains scoped to main-product CI. It must not depend on experimental agent harnesses.
 
 ## Unit Tests
 
 - CLI tests cover `ci init` creating a manifest with expected top-level sections.
+- CLI tests cover `ci init` creating missing parent directories for nested manifest paths.
 - CLI tests cover `ci init` refusing to overwrite unless `--force` is present.
 - CLI tests cover `ci validate` accepting a valid manifest.
 - CLI tests cover `ci validate` rejecting missing `trigger.paths`.
+- CLI tests cover `ci validate` rejecting unknown manifest fields so typoed contract keys fail fast.
 - CLI tests cover `ci validate` rejecting missing candidate build/deployment resource fields.
 - CLI tests cover `ci validate` rejecting a missing evaluation challenge pack version.
+- CLI tests cover `ci validate` rejecting blank regression suite and regression case entries.
 - CLI tests cover `ci validate` rejecting a missing baseline reference.
 - CLI tests cover invalid enum values for release gate failure mode and regression promotion mode.
 

--- a/web/content/docs/guides/ci-cd-agent-gates.mdx
+++ b/web/content/docs/guides/ci-cd-agent-gates.mdx
@@ -71,7 +71,7 @@ release gate = decision policy
 
 ## GitHub Actions sketch
 
-The first shipped CLI surface validates the manifest. Full orchestration will be a follow-up command built on the same file. Until then, teams can validate the contract and keep using the existing explicit run and gate commands.
+The first shipped CLI surface validates the manifest. Full orchestration will be a follow-up command built on the same file. Until then, teams can validate the contract and keep using the existing explicit run and gate commands. The workflow below repeats selected manifest IDs as GitHub variables only because `agentclash ci run` does not exist yet; once it does, the manifest should be the single source of truth.
 
 ```yaml
 name: AgentClash gate

--- a/web/content/docs/guides/ci-cd-agent-gates.mdx
+++ b/web/content/docs/guides/ci-cd-agent-gates.mdx
@@ -1,0 +1,167 @@
+---
+title: CI/CD Agent Gates
+description: Use a repo-tracked AgentClash CI manifest to define which agent revision, workload, baseline, and gate a pull request should run.
+---
+
+AgentClash CI should gate an agent revision, not only a prompt diff.
+
+Prompt-focused tools can usually watch `prompts/**` and rerun a prompt eval. AgentClash's main product model is richer: an agent change can touch instructions, workflow code, tool bindings, model aliases, runtime limits, output schemas, guardrails, or retrieval configuration. The CI contract therefore needs to name the candidate agent build, deployment settings, challenge workload, baseline, and gate policy explicitly.
+
+## The manifest is the contract
+
+Create a repo-tracked manifest:
+
+```bash
+agentclash ci init .agentclash/ci.yaml
+agentclash ci validate .agentclash/ci.yaml
+```
+
+The generated manifest has this shape:
+
+```yaml
+version: 1
+trigger:
+  paths:
+    - .agentclash/agent.json
+    - prompts/**
+    - tools/**
+  labels:
+    - agentclash/eval
+candidate:
+  build:
+    agent_build_id: 00000000-0000-0000-0000-000000000001
+    spec_file: .agentclash/agent.json
+  deployment:
+    name: pr-candidate
+    runtime_profile_id: 00000000-0000-0000-0000-000000000002
+    provider_account_id: 00000000-0000-0000-0000-000000000003
+    model_alias_id: 00000000-0000-0000-0000-000000000004
+evaluation:
+  challenge_pack_version_id: 00000000-0000-0000-0000-000000000005
+  input_set_id: 00000000-0000-0000-0000-000000000006
+  regression_suites:
+    - 00000000-0000-0000-0000-000000000007
+baseline:
+  run_id: 00000000-0000-0000-0000-000000000008
+gate:
+  fail_on: regression
+regressions:
+  promote_failures: proposed
+```
+
+The IDs in the generated file are placeholders. Replace them with workspace resources before using the manifest for a real gate.
+
+## What each section means
+
+- `trigger` says which repository paths and optional labels should cause the workflow to run.
+- `candidate.build` names the existing AgentClash build and the source-backed build-version spec to test.
+- `candidate.deployment` names the runtime resources used for the candidate deployment.
+- `evaluation` names the workload: challenge pack version, optional input set, and optional regression suites or cases.
+- `baseline` names the locked reference run or deployment.
+- `gate` names the release-gate failure threshold.
+- `regressions` controls whether failed cases should only be reported, proposed for promotion, or eventually auto-promoted on main.
+
+The important distinction is:
+
+```text
+agent build/deployment = thing under test
+challenge pack/regression suite = workload used to test it
+release gate = decision policy
+```
+
+## GitHub Actions sketch
+
+The first shipped CLI surface validates the manifest. Full orchestration will be a follow-up command built on the same file. Until then, teams can validate the contract and keep using the existing explicit run and gate commands.
+
+```yaml
+name: AgentClash gate
+
+on:
+  pull_request:
+    paths:
+      - ".agentclash/**"
+      - "prompts/**"
+      - "tools/**"
+
+jobs:
+  agentclash:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - run: npm i -g agentclash
+
+      - name: Validate AgentClash CI manifest
+        run: agentclash ci validate .agentclash/ci.yaml
+
+      - name: Create candidate run
+        id: candidate
+        run: |
+          RUN_JSON=$(agentclash run create \
+            --challenge-pack-version "$AGENTCLASH_CHALLENGE_PACK_VERSION" \
+            --deployments "$AGENTCLASH_CANDIDATE_DEPLOYMENT" \
+            --json)
+          echo "run_id=$(echo "$RUN_JSON" | jq -r '.id')" >> "$GITHUB_OUTPUT"
+        env:
+          AGENTCLASH_API_URL: https://api.agentclash.dev
+          AGENTCLASH_TOKEN: ${{ secrets.AGENTCLASH_TOKEN }}
+          AGENTCLASH_WORKSPACE: ${{ secrets.AGENTCLASH_WORKSPACE }}
+          AGENTCLASH_CHALLENGE_PACK_VERSION: ${{ vars.AGENTCLASH_CHALLENGE_PACK_VERSION }}
+          AGENTCLASH_CANDIDATE_DEPLOYMENT: ${{ vars.AGENTCLASH_CANDIDATE_DEPLOYMENT }}
+
+      - name: Evaluate release gate
+        run: |
+          agentclash compare gate \
+            --baseline "$AGENTCLASH_BASELINE_RUN" \
+            --candidate "${{ steps.candidate.outputs.run_id }}"
+        env:
+          AGENTCLASH_API_URL: https://api.agentclash.dev
+          AGENTCLASH_TOKEN: ${{ secrets.AGENTCLASH_TOKEN }}
+          AGENTCLASH_WORKSPACE: ${{ secrets.AGENTCLASH_WORKSPACE }}
+          AGENTCLASH_BASELINE_RUN: ${{ vars.AGENTCLASH_BASELINE_RUN }}
+```
+
+## Regression promotion policy
+
+Do not auto-promote every PR failure by default. A bad run, flaky dependency, or weak evaluator could pollute the regression suite.
+
+Use this conservative progression:
+
+```yaml
+regressions:
+  promote_failures: disabled
+```
+
+Report failures only.
+
+```yaml
+regressions:
+  promote_failures: proposed
+```
+
+Record promotion candidates for review.
+
+```yaml
+regressions:
+  promote_failures: auto_on_main
+```
+
+Only a future main-branch workflow should auto-promote high-confidence failures after the gate has proven useful.
+
+## Current limits
+
+- `agentclash ci validate` validates the manifest shape locally; it does not check that IDs exist in the API.
+- There is not yet an `agentclash ci run` wrapper that creates the candidate build version, deployment, run, gate, and PR report in one command.
+- PR metadata such as repository, pull request number, branch, and commit SHA is not yet attached to runs by the CLI.
+- Automatic regression promotion should remain opt-in and conservative.
+
+## See also
+
+- [Agents and Deployments](../concepts/agents-and-deployments)
+- [Challenge Packs and Inputs](../concepts/challenge-packs-and-inputs)
+- [Eval Workflows and Gates](../challenge-packs/eval-workflows-and-gates)

--- a/web/src/lib/docs.test.ts
+++ b/web/src/lib/docs.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildLlmsFull,
   buildLlmsIndex,
+  DOCS_NAV,
   getAllDocMarkdownPaths,
   getDocBySlug,
 } from "./docs";
@@ -144,6 +145,17 @@ describe("agent skill docs", () => {
     expect(paths).toContain("/docs-md/agent-skills/agent-build-skills");
     for (const slug of skillSlugs) {
       expect(paths).toContain(`/docs-md/agent-skills/${slug}`);
+    }
+  });
+
+  it("resolves every docs navigation item", () => {
+    for (const section of DOCS_NAV) {
+      for (const item of section.items) {
+        const doc = getDocBySlug(item.slug);
+
+        expect(doc, item.href).not.toBeNull();
+        expect(doc?.href).toBe(item.href);
+      }
     }
   });
 

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -275,6 +275,13 @@ export const DOCS_NAV: DocNavSection[] = [
         href: "/docs/guides/interpret-results",
       },
       {
+        title: "CI/CD Agent Gates",
+        description:
+          "Define the agent revision, workload, baseline, and release gate a pull request should run.",
+        slug: ["guides", "ci-cd-agent-gates"],
+        href: "/docs/guides/ci-cd-agent-gates",
+      },
+      {
         title: "Use with AI Tools",
         description:
           "Use llms.txt, the full bundle, and per-page markdown exports with assistants and coding agents.",


### PR DESCRIPTION
## Summary

- Add `agentclash ci init` and `agentclash ci validate` for a repo-tracked main-product CI manifest.
- Define the v1 manifest shape for trigger paths, candidate agent build/deployment resources, evaluation workload, baseline, release gate, and regression promotion policy.
- Document the AgentClash CI positioning: gate deployable agent revisions against challenge workloads, not experimental agent harnesses or prompt-only diffs.

## Review Checkpoint

Test contract: `testing/codex-ci-cd-agentclash-gates.md`

Implemented in reviewed steps:
- Step 0: lock test contract
- Step 1: add CLI manifest init/validation and tests
- Step 2: add docs guide, docs nav entry, and README CI/CD update

## Validation

- `cd cli && go test ./cmd -run 'TestCI' -count=1`
- `cd cli && go test -short ./cmd -count=1`
- `cd cli && go build ./...`
- `cd web && npm test -- src/lib/docs.test.ts`
- `cd cli && go run . ci init /tmp/agentclash-ci.yaml --force`
- `cd cli && go run . ci validate /tmp/agentclash-ci.yaml`
- `cd cli && go run . ci validate /tmp/agentclash-ci.yaml --json`

## Notes

This PR intentionally stops at the manifest contract and local validation. Full `agentclash ci run` orchestration, PR check reporting, API-backed ID validation, PR metadata on runs, and automatic regression promotion are follow-up work.
