### PR TITLE
Internal: run blind AgentClash harnesses for skill changes

### DIFF
--- a/.github/workflows/internal-agent-skills-harness.yml
+++ b/.github/workflows/internal-agent-skills-harness.yml
@@ -1,0 +1,127 @@
+name: Internal Agent Skills Harness
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "web/content/agent-skills/**/SKILL.md"
+      - ".github/workflows/internal-agent-skills-harness.yml"
+      - "scripts/internal-agent-skills/**"
+  workflow_dispatch:
+    inputs:
+      skills:
+        description: "JSON array of skill paths to evaluate. Leave empty to diff the current ref."
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: internal-agent-skills-harness-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect:
+    name: Detect Changed Skills
+    runs-on: ubuntu-latest
+    outputs:
+      skills: ${{ steps.changed.outputs.skills }}
+      count: ${{ steps.changed.outputs.count }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Detect changed SKILL.md files
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          DISPATCH_SKILLS: ${{ inputs.skills }}
+        run: |
+          set -euo pipefail
+          if [ -n "${DISPATCH_SKILLS}" ]; then
+            echo "skills=${DISPATCH_SKILLS}" >> "$GITHUB_OUTPUT"
+            node -e 'const skills = JSON.parse(process.env.DISPATCH_SKILLS); if (!Array.isArray(skills)) process.exit(1); console.log(`count=${skills.length}`)' >> "$GITHUB_OUTPUT"
+          else
+            node scripts/internal-agent-skills/detect-changed-skills.mjs
+          fi
+
+  harness:
+    name: Blind Skill Harness
+    needs: detect
+    if: ${{ needs.detect.outputs.count != '0' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      AGENTCLASH_API_URL: ${{ vars.AGENTCLASH_API_URL || 'https://api.agentclash.dev' }}
+      AGENTCLASH_TOKEN: ${{ secrets.AGENTCLASH_TOKEN }}
+      AGENTCLASH_WORKSPACE: ${{ secrets.AGENTCLASH_WORKSPACE }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      OPENAI_SECRET_NAME: OPENAI_API_KEY
+      CODEX_MODEL: ${{ vars.AGENTCLASH_SKILL_HARNESS_CODEX_MODEL }}
+      REPOSITORY_URL: https://github.com/${{ github.repository }}.git
+      BASE_BRANCH: ${{ github.head_ref || github.ref_name }}
+      RUN_LABEL: pr-${{ github.event.pull_request.number || github.run_number }}-${{ github.run_attempt }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
+
+      - name: Require internal harness secrets
+        run: |
+          set -euo pipefail
+          test -n "${AGENTCLASH_TOKEN}" || { echo "::error::Set AGENTCLASH_TOKEN for the internal skill harness."; exit 1; }
+          test -n "${AGENTCLASH_WORKSPACE}" || { echo "::error::Set AGENTCLASH_WORKSPACE for the internal skill harness."; exit 1; }
+          test -n "${OPENAI_API_KEY}" || { echo "::error::Set OPENAI_API_KEY for the internal skill harness."; exit 1; }
+
+      - name: Build AgentClash CLI
+        working-directory: cli
+        run: go build -o /tmp/agentclash .
+
+      - name: Verify AgentClash auth and sync OpenAI workspace secret
+        run: |
+          set -euo pipefail
+          /tmp/agentclash doctor
+          printf '%s' "${OPENAI_API_KEY}" | /tmp/agentclash secret set "${OPENAI_SECRET_NAME}"
+
+      - name: Prepare blind harness specs
+        env:
+          CHANGED_SKILLS_JSON: ${{ needs.detect.outputs.skills }}
+          OUT_DIR: .agentclash/skill-harnesses
+        run: node scripts/internal-agent-skills/prepare-skill-harnesses.mjs
+
+      - name: Run AgentClash harness for each changed skill
+        run: |
+          set -euo pipefail
+          jq -r '.harnesses[].spec' .agentclash/skill-harnesses/manifest.json | while read -r spec; do
+            echo "::group::AgentClash skill harness ${spec}"
+            /tmp/agentclash agent-harness create --from-file "${spec}" --json > "${spec}.create.json"
+            harness_id="$(jq -r '.id' "${spec}.create.json")"
+            test -n "${harness_id}" && test "${harness_id}" != "null"
+            /tmp/agentclash agent-harness run "${harness_id}" --follow --poll-interval 10s
+            echo "::endgroup::"
+          done
+
+  skipped-fork:
+    name: Fork Safety Skip
+    needs: detect
+    if: ${{ needs.detect.outputs.count != '0' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipping internal AgentClash skill harness for forked PR because secrets are unavailable."

--- a/scripts/internal-agent-skills/detect-changed-skills.mjs
+++ b/scripts/internal-agent-skills/detect-changed-skills.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const base = process.env.BASE_SHA || process.argv[2] || "";
+const head = process.env.HEAD_SHA || process.argv[3] || "HEAD";
+const outFile = process.env.GITHUB_OUTPUT || "";
+
+function git(args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function changedFiles() {
+  if (base) {
+    return git(["diff", "--name-only", `${base}...${head}`]);
+  }
+  return git(["diff", "--name-only", "HEAD~1", head]);
+}
+
+const files = changedFiles()
+  .split("\n")
+  .map((file) => file.trim())
+  .filter(Boolean)
+  .filter((file) => /^web\/content\/agent-skills\/.*\/SKILL\.md$/.test(file))
+  .filter((file) => existsSync(path.resolve(file)));
+
+const payload = JSON.stringify(files);
+console.log(payload);
+
+if (outFile) {
+  const fs = await import("node:fs");
+  fs.appendFileSync(outFile, `skills=${payload}\n`);
+  fs.appendFileSync(outFile, `count=${files.length}\n`);
+}

--- a/scripts/internal-agent-skills/prepare-skill-harnesses.mjs
+++ b/scripts/internal-agent-skills/prepare-skill-harnesses.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const skillsArg = process.env.CHANGED_SKILLS_JSON || process.argv[2] || "[]";
+const outDir = process.env.OUT_DIR || process.argv[3] || ".agentclash/skill-harnesses";
+const repoUrl = process.env.REPOSITORY_URL || "https://github.com/agentclash/agentclash.git";
+const baseBranch = process.env.BASE_BRANCH || "";
+const openAISecretName = process.env.OPENAI_SECRET_NAME || "OPENAI_API_KEY";
+const codexModel = process.env.CODEX_MODEL || "";
+const runLabel = process.env.RUN_LABEL || "local";
+
+function parseFrontmatter(content, file) {
+  if (!content.startsWith("---\n")) {
+    throw new Error(`${file}: missing YAML frontmatter`);
+  }
+  const end = content.indexOf("\n---", 4);
+  if (end === -1) {
+    throw new Error(`${file}: unterminated YAML frontmatter`);
+  }
+  const raw = content.slice(4, end).trim();
+  const fields = {};
+  let inMetadata = false;
+  for (const line of raw.split("\n")) {
+    if (/^\s*$/.test(line)) continue;
+    if (line === "metadata:") {
+      inMetadata = true;
+      continue;
+    }
+    const match = line.match(/^(\s*)([A-Za-z0-9_.-]+):\s*(.*)$/);
+    if (!match) continue;
+    const [, indent, key, rawValue] = match;
+    const value = rawValue.replace(/^["']|["']$/g, "");
+    if (inMetadata && indent.length > 0) {
+      fields[`metadata.${key}`] = value;
+    } else {
+      inMetadata = false;
+      fields[key] = value;
+    }
+  }
+  return fields;
+}
+
+function titleFromSkill(content) {
+  const match = content.match(/^#\s+(.+)$/m);
+  return match ? match[1].trim() : "";
+}
+
+function taskPrompt(skillPath, meta, title) {
+  const cliRequired = meta["metadata.agentclash.requires_cli"] === "true";
+  return `You are an isolated coding agent testing whether an AgentClash skill is self-contained.
+
+You know nothing about AgentClash or this repository. Do not inspect source code, tests, git history, GitHub issues, or docs outside the skill file. Read only this file:
+
+${skillPath}
+
+Use the skill exactly as a downstream coding agent would. Prepare an operational plan for a realistic user request that matches the skill description.
+
+Write your result as JSON to .agentclash/skill-eval-result.json with this shape:
+
+{
+  "skill_name": "${meta.name}",
+  "skill_title": "${title}",
+  "used_only_skill_file": true,
+  "would_use_cli": ${cliRequired},
+  "hosted_backend": "https://api.agentclash.dev or N/A",
+  "commands": ["ordered commands or N/A"],
+  "files_or_payloads": ["JSON/YAML/config payloads or N/A"],
+  "checks_before_mutation": ["read-only checks before create/update/delete/publish"],
+  "expected_outputs": ["success signals from the skill"],
+  "failure_modes": ["likely blockers and recovery steps"],
+  "report_back": "concise report-back text",
+  "blockers_or_confirmations": ["needed user confirmations or missing IDs/secrets"],
+  "confidence": "pass or fail",
+  "notes": "short explanation"
+}
+
+Rules:
+- Do not claim you inspected repo source.
+- Do not invent raw secret values.
+- If the skill requires CLI use, include AGENTCLASH_API_URL=https://api.agentclash.dev or an equivalent hosted production setup command.
+- If the skill is not self-contained, set confidence to "fail" and explain exactly what was missing.
+- Keep the JSON valid and do not wrap it in Markdown.`;
+}
+
+function validatorCommand(skillPath) {
+  return `node scripts/internal-agent-skills/validate-skill-harness-output.mjs ${JSON.stringify(skillPath)} .agentclash/skill-eval-result.json`;
+}
+
+const skills = JSON.parse(skillsArg);
+if (!Array.isArray(skills)) {
+  throw new Error("changed skills input must be a JSON array");
+}
+
+mkdirSync(outDir, { recursive: true });
+const manifest = [];
+
+for (const skillPath of skills) {
+  const content = readFileSync(skillPath, "utf8");
+  const meta = parseFrontmatter(content, skillPath);
+  if (!meta.name || !meta.description) {
+    throw new Error(`${skillPath}: frontmatter must include name and description`);
+  }
+  const title = titleFromSkill(content);
+  const slug = meta.name.replace(/[^a-z0-9-]+/gi, "-").toLowerCase();
+  const specPath = path.join(outDir, `${slug}.harness.json`);
+  const spec = {
+    name: `skill-self-test-${slug}-${runLabel}`.slice(0, 120),
+    description: `Internal blind self-containment test for ${skillPath}`,
+    task_prompt: taskPrompt(skillPath, meta, title),
+    codex_template: "codex",
+    auth_mode: "api_key_secret",
+    openai_api_key_secret_name: openAISecretName,
+    repository_url: repoUrl,
+    evaluation_config: {
+      validators: [
+        {
+          type: "command",
+          command: validatorCommand(skillPath),
+          required: true,
+          timeout_seconds: 60,
+        },
+      ],
+    },
+  };
+  if (baseBranch) {
+    spec.base_branch = baseBranch;
+  }
+  if (codexModel) {
+    spec.codex_model = codexModel;
+  }
+  writeFileSync(specPath, `${JSON.stringify(spec, null, 2)}\n`);
+  manifest.push({ skill: skillPath, name: meta.name, spec: specPath });
+}
+
+const manifestPath = path.join(outDir, "manifest.json");
+writeFileSync(manifestPath, `${JSON.stringify({ harnesses: manifest }, null, 2)}\n`);
+console.log(manifestPath);

--- a/scripts/internal-agent-skills/skill-harness-scripts.test.mjs
+++ b/scripts/internal-agent-skills/skill-harness-scripts.test.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const repo = process.cwd();
+const tmp = mkdtempSync(path.join(tmpdir(), "agentclash-skill-harness-"));
+const detectRepo = path.join(tmp, "detect-repo");
+mkdirSync(path.join(detectRepo, "web/content/agent-skills/detect-skill"), { recursive: true });
+execFileSync("git", ["init"], { cwd: detectRepo, stdio: "ignore" });
+execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: detectRepo });
+execFileSync("git", ["config", "user.name", "Test"], { cwd: detectRepo });
+writeFileSync(path.join(detectRepo, "README.md"), "root\n");
+execFileSync("git", ["add", "."], { cwd: detectRepo });
+execFileSync("git", ["commit", "-m", "initial"], { cwd: detectRepo, stdio: "ignore" });
+const baseSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: detectRepo, encoding: "utf8" }).trim();
+writeFileSync(
+  path.join(detectRepo, "web/content/agent-skills/detect-skill/SKILL.md"),
+  `---
+name: agentclash-detect-skill
+description: Use when testing detection.
+metadata:
+  agentclash.role: testing
+  agentclash.version: "1"
+  agentclash.requires_cli: "false"
+---
+
+# Detect Skill
+`,
+);
+execFileSync("git", ["add", "."], { cwd: detectRepo });
+execFileSync("git", ["commit", "-m", "add skill"], { cwd: detectRepo, stdio: "ignore" });
+const headSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: detectRepo, encoding: "utf8" }).trim();
+const detected = JSON.parse(
+  execFileSync("node", [path.join(repo, "scripts/internal-agent-skills/detect-changed-skills.mjs"), baseSha, headSha], {
+    cwd: detectRepo,
+    encoding: "utf8",
+  }),
+);
+assert.deepEqual(detected, ["web/content/agent-skills/detect-skill/SKILL.md"]);
+
+const skillDir = path.join(tmp, "web/content/agent-skills/example-skill");
+mkdirSync(skillDir, { recursive: true });
+const skillPath = path.join(skillDir, "SKILL.md");
+writeFileSync(
+  skillPath,
+  `---
+name: agentclash-example-skill
+description: Use when testing internal skill harnesses.
+metadata:
+  agentclash.role: testing
+  agentclash.version: "1"
+  agentclash.requires_cli: "true"
+---
+
+# Example Skill
+
+## Purpose
+Test skill.
+`,
+);
+
+const outDir = path.join(tmp, "out");
+const manifestPath = execFileSync(
+  "node",
+  ["scripts/internal-agent-skills/prepare-skill-harnesses.mjs", JSON.stringify([skillPath]), outDir],
+  {
+    cwd: repo,
+    env: {
+      ...process.env,
+      REPOSITORY_URL: "https://github.com/agentclash/agentclash.git",
+      BASE_BRANCH: "codex/test",
+      CODEX_MODEL: "codex-test-model",
+      RUN_LABEL: "unit",
+    },
+    encoding: "utf8",
+  },
+).trim();
+
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+assert.equal(manifest.harnesses.length, 1);
+const spec = JSON.parse(readFileSync(manifest.harnesses[0].spec, "utf8"));
+assert.equal(spec.auth_mode, "api_key_secret");
+assert.equal(spec.openai_api_key_secret_name, "OPENAI_API_KEY");
+assert.equal(spec.repository_url, "https://github.com/agentclash/agentclash.git");
+assert.equal(spec.base_branch, "codex/test");
+assert.equal(spec.codex_model, "codex-test-model");
+assert.match(spec.task_prompt, /Read only this file:/);
+assert.match(spec.task_prompt, /agentclash-example-skill/);
+assert.equal(spec.evaluation_config.validators[0].type, "command");
+assert.match(spec.evaluation_config.validators[0].command, /validate-skill-harness-output\.mjs/);
+
+const resultPath = path.join(tmp, "result.json");
+writeFileSync(
+  resultPath,
+  JSON.stringify({
+    skill_name: "agentclash-example-skill",
+    skill_title: "Example Skill",
+    used_only_skill_file: true,
+    would_use_cli: true,
+    hosted_backend: "https://api.agentclash.dev",
+    commands: ["export AGENTCLASH_API_URL=https://api.agentclash.dev", "agentclash doctor"],
+    files_or_payloads: ["N/A"],
+    checks_before_mutation: ["agentclash doctor"],
+    expected_outputs: ["doctor passes"],
+    failure_modes: ["auth missing"],
+    report_back: "ready",
+    blockers_or_confirmations: ["workspace id"],
+    confidence: "pass",
+    notes: "ok",
+  }),
+);
+execFileSync("node", ["scripts/internal-agent-skills/validate-skill-harness-output.mjs", skillPath, resultPath], {
+  cwd: repo,
+  encoding: "utf8",
+});
+
+writeFileSync(resultPath, JSON.stringify({ skill_name: "wrong" }));
+const failed = spawnSync("node", ["scripts/internal-agent-skills/validate-skill-harness-output.mjs", skillPath, resultPath], {
+  cwd: repo,
+  encoding: "utf8",
+});
+assert.notEqual(failed.status, 0);
+assert.match(failed.stderr, /skill_name/);
+
+console.log("internal agent skill harness script tests passed");

--- a/scripts/internal-agent-skills/validate-skill-harness-output.mjs
+++ b/scripts/internal-agent-skills/validate-skill-harness-output.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+
+const [skillPath, outputPath] = process.argv.slice(2);
+if (!skillPath || !outputPath) {
+  console.error("usage: validate-skill-harness-output.mjs <skill-path> <result-json>");
+  process.exit(2);
+}
+
+function parseFrontmatter(content, file) {
+  if (!content.startsWith("---\n")) {
+    throw new Error(`${file}: missing YAML frontmatter`);
+  }
+  const end = content.indexOf("\n---", 4);
+  if (end === -1) {
+    throw new Error(`${file}: unterminated YAML frontmatter`);
+  }
+  const raw = content.slice(4, end).trim();
+  const fields = {};
+  let inMetadata = false;
+  for (const line of raw.split("\n")) {
+    if (/^\s*$/.test(line)) continue;
+    if (line === "metadata:") {
+      inMetadata = true;
+      continue;
+    }
+    const match = line.match(/^(\s*)([A-Za-z0-9_.-]+):\s*(.*)$/);
+    if (!match) continue;
+    const [, indent, key, rawValue] = match;
+    const value = rawValue.replace(/^["']|["']$/g, "");
+    if (inMetadata && indent.length > 0) {
+      fields[`metadata.${key}`] = value;
+    } else {
+      inMetadata = false;
+      fields[key] = value;
+    }
+  }
+  return fields;
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function containsAny(values, patterns) {
+  const haystack = values.join("\n").toLowerCase();
+  return patterns.some((pattern) => haystack.includes(pattern));
+}
+
+const skillContent = readFileSync(skillPath, "utf8");
+const meta = parseFrontmatter(skillContent, skillPath);
+let result;
+try {
+  result = JSON.parse(readFileSync(outputPath, "utf8"));
+} catch (error) {
+  console.error(`result JSON is invalid: ${error.message}`);
+  process.exit(1);
+}
+
+const errors = [];
+if (result.skill_name !== meta.name) {
+  errors.push(`skill_name = ${JSON.stringify(result.skill_name)}, want ${JSON.stringify(meta.name)}`);
+}
+if (result.used_only_skill_file !== true) {
+  errors.push("used_only_skill_file must be true");
+}
+if (result.confidence !== "pass") {
+  errors.push('confidence must be "pass"');
+}
+
+const requiredArrays = [
+  "commands",
+  "checks_before_mutation",
+  "expected_outputs",
+  "failure_modes",
+  "blockers_or_confirmations",
+];
+for (const key of requiredArrays) {
+  if (!Array.isArray(result[key]) || result[key].length === 0) {
+    errors.push(`${key} must be a non-empty array`);
+  }
+}
+
+if (typeof result.report_back !== "string" || result.report_back.trim() === "") {
+  errors.push("report_back must be a non-empty string");
+}
+
+const requiresCLI = meta["metadata.agentclash.requires_cli"] === "true";
+if (requiresCLI) {
+  if (result.would_use_cli !== true) {
+    errors.push("would_use_cli must be true for CLI-backed skills");
+  }
+  if (!containsAny(asArray(result.commands), ["agentclash"])) {
+    errors.push("commands must include at least one agentclash command");
+  }
+  const hostedText = `${result.hosted_backend || ""}\n${asArray(result.commands).join("\n")}`;
+  if (!hostedText.includes("https://api.agentclash.dev")) {
+    errors.push("CLI-backed skills must preserve hosted production API setup");
+  }
+}
+
+const forbiddenSourceClaims = [
+  "i inspected the source",
+  "i read the codebase",
+  "from the repository source",
+  "cli/cmd/",
+  "backend/internal/",
+  "web/src/",
+];
+const combined = JSON.stringify(result).toLowerCase();
+for (const claim of forbiddenSourceClaims) {
+  if (combined.includes(claim)) {
+    errors.push(`result appears to rely on forbidden repo context: ${claim}`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error("skill harness output failed validation:");
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log(`skill harness output passed for ${meta.name}`);

--- a/testing/codex-internal-agent-skills-ci.md
+++ b/testing/codex-internal-agent-skills-ci.md
@@ -1,0 +1,29 @@
+# Codex Internal Agent Skills CI - Test Contract
+
+## Functional Behavior
+- Add an internal experimental GitHub Actions workflow that runs only when `web/content/agent-skills/**/SKILL.md` changes or when manually dispatched.
+- The workflow must run AgentClash, not just a local script, by creating and running an AgentClash `agent-harness` for each changed skill.
+- Each harness must simulate a coding agent that does not know the AgentClash repo and is instructed to rely only on the changed `SKILL.md`.
+- The workflow must use hosted production by default and read credentials from GitHub secrets or vars, without printing OpenAI or AgentClash tokens.
+- The workflow must support a fixed OpenAI secret name (`OPENAI_API_KEY`) and sync the GitHub `OPENAI_API_KEY` secret into the AgentClash workspace secret before creating harnesses.
+- Checks must be deterministic at the gate layer: the LLM writes a structured JSON artifact and a command validator checks schema, skill identity, required sections, CLI-hosted-backend expectations when applicable, and absence of repo-source dependency claims.
+- The harness generator must work for any new skill file, not hardcode deployment/runtime/build-specific terms.
+
+## Unit Tests
+- Add local tests for the harness-preparation script that verify changed skill detection, prompt generation, harness JSON shape, and validator command shape.
+- Add local tests for the validator script that cover passing JSON, missing fields, wrong skill identity, CLI-required hosted backend omissions, and invalid JSON.
+
+## Integration / Functional Tests
+- The workflow YAML should be syntactically valid and reference the checked-in scripts.
+- The script-generated harness specs should be usable with `agentclash agent-harness create --from-file`.
+
+## Smoke Tests
+- Run the new script tests locally.
+- Run a dry-run harness preparation command against one existing skill file.
+
+## E2E Tests
+N/A - the real AgentClash/OpenAI harness execution requires repository secrets and hosted infrastructure, so the PR should include deterministic dry-run coverage plus the GitHub Action wiring.
+
+## Manual / cURL Tests
+- Review `.github/workflows/internal-agent-skills-harness.yml` and confirm it only triggers for agent-skill changes and `workflow_dispatch`.
+- Review `scripts/internal-agent-skills/prepare-skill-harnesses.mjs` and `validate-skill-harness-output.mjs` to confirm the pass/fail contract is skill-generic.


### PR DESCRIPTION
## Summary
- Add an internal experimental GitHub Action for PRs that change `web/content/agent-skills/**/SKILL.md`.
- Detect changed skill files and create one AgentClash `agent-harness` per skill so a blind Codex agent reads only that `SKILL.md`.
- Make the LLM-driven run deterministic at the gate layer by requiring `.agentclash/skill-eval-result.json` and validating schema, skill identity, hosted CLI setup, and forbidden repo-source dependency claims with a command validator.
- Sync the GitHub `OPENAI_API_KEY` secret into the AgentClash workspace secret named `OPENAI_API_KEY` before harness creation.

## Determinism Strategy
The model output can vary, so the pass/fail contract does not depend on free-form prose. Each harness asks the agent to write a fixed JSON artifact. The checked-in validator enforces a stable rubric that is generated from each skill's frontmatter, so new skills do not need custom tests unless they need a stricter rubric later.

## Review Checkpoint
- Contract: `testing/codex-internal-agent-skills-ci.md`
- Workflow used: `/Users/atharva/.codex/skills/review-checkpoint/SKILL.md`
- Final verdict: ready

## Verification
- `node scripts/internal-agent-skills/skill-harness-scripts.test.mjs`
- `node --check scripts/internal-agent-skills/detect-changed-skills.mjs`
- `node --check scripts/internal-agent-skills/prepare-skill-harnesses.mjs`
- `node --check scripts/internal-agent-skills/validate-skill-harness-output.mjs`
- `node --check scripts/internal-agent-skills/skill-harness-scripts.test.mjs`
- `git diff --check`

## Required Internal Secrets
- `AGENTCLASH_TOKEN`
- `AGENTCLASH_WORKSPACE`
- `OPENAI_API_KEY`

Optional vars:
- `AGENTCLASH_API_URL` defaults to `https://api.agentclash.dev`
- `AGENTCLASH_SKILL_HARNESS_CODEX_MODEL` pins the Codex model when set
