### PR TITLE
Skills: challenge pack YAML authoring

### DIFF
--- a/scripts/internal-agent-skills/prepare-skill-harnesses.mjs
+++ b/scripts/internal-agent-skills/prepare-skill-harnesses.mjs
@@ -9,6 +9,7 @@ const baseBranch = process.env.BASE_BRANCH || "";
 const openAISecretName = process.env.OPENAI_SECRET_NAME || "OPENAI_API_KEY";
 const codexModel = process.env.CODEX_MODEL || "";
 const runLabel = process.env.RUN_LABEL || "local";
+const safeRunLabel = runLabel.replace(/[^a-z0-9-]+/gi, "-").replace(/^-+|-+$/g, "") || "local";
 
 function parseFrontmatter(content, file) {
   if (!content.startsWith("---\n")) {
@@ -105,7 +106,7 @@ for (const skillPath of skills) {
   const slug = meta.name.replace(/[^a-z0-9-]+/gi, "-").toLowerCase();
   const specPath = path.join(outDir, `${slug}.harness.json`);
   const spec = {
-    name: `skill-self-test-${slug}-${runLabel}`.slice(0, 120),
+    name: `skill-self-test-${safeRunLabel}-${slug}`.slice(0, 120),
     description: `Internal blind self-containment test for ${skillPath}`,
     task_prompt: taskPrompt(skillPath, meta, title),
     codex_template: "codex",

--- a/scripts/internal-agent-skills/skill-harness-scripts.test.mjs
+++ b/scripts/internal-agent-skills/skill-harness-scripts.test.mjs
@@ -82,6 +82,7 @@ const manifestPath = execFileSync(
 const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
 assert.equal(manifest.harnesses.length, 1);
 const spec = JSON.parse(readFileSync(manifest.harnesses[0].spec, "utf8"));
+assert.match(spec.name, /^skill-self-test-unit-agentclash-example-skill$/);
 assert.equal(spec.auth_mode, "api_key_secret");
 assert.equal(spec.openai_api_key_secret_name, "OPENAI_API_KEY");
 assert.equal(spec.repository_url, "https://github.com/agentclash/agentclash.git");
@@ -91,6 +92,40 @@ assert.match(spec.task_prompt, /Read only this file:/);
 assert.match(spec.task_prompt, /agentclash-example-skill/);
 assert.equal(spec.evaluation_config.validators[0].type, "command");
 assert.match(spec.evaluation_config.validators[0].command, /validate-skill-harness-output\.mjs/);
+
+const longSkillDir = path.join(tmp, "web/content/agent-skills/very-long-skill");
+mkdirSync(longSkillDir, { recursive: true });
+const longSkillPath = path.join(longSkillDir, "SKILL.md");
+writeFileSync(
+  longSkillPath,
+  `---
+name: agentclash-challenge-pack-yaml-author-with-extra-long-name
+description: Use when testing long harness names.
+metadata:
+  agentclash.role: testing
+  agentclash.version: "1"
+  agentclash.requires_cli: "false"
+---
+
+# Long Skill
+`,
+);
+const longOutDir = path.join(tmp, "long-out");
+const longManifestPath = execFileSync(
+  "node",
+  ["scripts/internal-agent-skills/prepare-skill-harnesses.mjs", JSON.stringify([longSkillPath]), longOutDir],
+  {
+    cwd: repo,
+    env: {
+      ...process.env,
+      RUN_LABEL: "run-123456789-1",
+    },
+    encoding: "utf8",
+  },
+).trim();
+const longManifest = JSON.parse(readFileSync(longManifestPath, "utf8"));
+const longSpec = JSON.parse(readFileSync(longManifest.harnesses[0].spec, "utf8"));
+assert.match(longSpec.name.slice(0, 60), /^skill-self-test-run-123456789-1-/);
 
 const resultPath = path.join(tmp, "result.json");
 writeFileSync(

--- a/testing/codex-issue-447-challenge-pack-yaml-author-skill.md
+++ b/testing/codex-issue-447-challenge-pack-yaml-author-skill.md
@@ -1,0 +1,33 @@
+# Codex Issue 447 Challenge Pack YAML Author Skill - Test Contract
+
+## Functional Behavior
+- Expand `web/content/agent-skills/challenge-pack-skills/agentclash-challenge-pack-yaml-author/SKILL.md` for issue #447.
+- The skill must let an agent write or edit challenge-pack YAML without reading AgentClash source code.
+- The skill must document the exact current bundle shape: `pack`, `version`, optional `tools`, `challenges`, and `input_sets`.
+- The skill must describe required fields, execution modes, case/input/expectation shapes, validation commands, common validation failures, and handoff to publish.
+- Examples must use hosted production by default and must avoid unsupported fields or tool kinds.
+
+## Unit Tests
+- `web/src/lib/docs.test.ts` should include assertions for the YAML author skill's source-backed details.
+- Existing docs tests must pass.
+
+## Integration / Functional Tests
+- The docs generator must discover the updated nested skill page at `/docs-md/agent-skills/challenge-pack-skills/agentclash-challenge-pack-yaml-author`.
+- `llms.txt` and `llms-full.txt` inclusion must remain covered by existing docs tests.
+
+## Smoke Tests
+- Run `npm test -- src/lib/docs.test.ts` from `web/`.
+- Run `git diff --check`.
+- Run a keyword sanity pass for `pack`, `version`, `challenges`, `input_sets`, `evaluation_spec`, `prompt_eval`, `native`, and `agentclash challenge-pack validate`.
+
+## E2E Tests
+- N/A - this is a skill documentation/content change. The internal blind skill harness should run on the PR because `SKILL.md` changes.
+
+## Manual / cURL Tests
+- Manually inspect the skill against:
+  - `backend/internal/challengepack/bundle.go`
+  - `backend/internal/challengepack/validation.go`
+  - `backend/internal/scoring/spec.go`
+  - `cli/cmd/challenge_pack.go`
+  - `web/content/docs/guides/write-a-challenge-pack.mdx`
+- Confirm the skill does not claim unsupported `allowed_tool_kinds` values such as `shell`.

--- a/web/content/agent-skills/challenge-pack-skills/agentclash-challenge-pack-yaml-author/SKILL.md
+++ b/web/content/agent-skills/challenge-pack-skills/agentclash-challenge-pack-yaml-author/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentclash-challenge-pack-yaml-author
-description: Use when writing or editing AgentClash challenge pack YAML, including tasks, cases, input sets, scoring blocks, tools, sandbox settings, assets, and metadata.
+description: Use when writing or editing AgentClash challenge pack YAML, including pack/version metadata, execution mode, challenges, cases, input sets, scoring blocks, tools, sandbox settings, assets, and validation handoff.
 metadata:
   agentclash.role: challenge-pack-authoring
   agentclash.version: "1"
@@ -10,49 +10,294 @@ metadata:
 # AgentClash Challenge Pack YAML Author
 
 ## Purpose
-Create valid challenge pack YAML from a planned evaluation.
+Write challenge-pack YAML that matches the current AgentClash parser and validators, without requiring access to the AgentClash source repo.
+
+Use this skill after planning. The output should be a concrete YAML file plus the exact validation commands a coding agent should run before publish.
 
 ## Use When
-- A pack outline needs to become a concrete YAML file.
-- An existing pack needs structural edits.
-- The agent needs a checklist for fields to fill without source-code access.
+- A challenge-pack plan needs to become valid YAML.
+- An existing pack YAML needs source-compatible edits.
+- A coding agent needs the exact YAML object shape for `pack`, `version`, `challenges`, `input_sets`, scoring, tools, sandbox, assets, cases, inputs, and expectations.
+- The agent will later hand the file to `agentclash-challenge-pack-validation-publish`.
 
-## Inputs Needed
-- Pack plan.
-- Case payloads and expected outputs.
-- Selected scoring and judge strategy.
-- Tool, artifact, sandbox, and secret requirements.
+## Do Not Use When
+- The user only has a vague eval idea; use `agentclash-challenge-pack-planner` first.
+- The YAML is finished and only needs validation or publish; use `agentclash-challenge-pack-validation-publish`.
+- The task is to start runs or choose deployments; use `agentclash-eval-runner` or deployment skills.
 
 ## Environment
+Use hosted production unless the user intentionally points at another backend.
+
 ```bash
 export AGENTCLASH_API_URL="https://api.agentclash.dev"
 ```
 
-## Procedure
-1. Fill metadata and pack identity first.
-2. Add tasks and cases with stable names.
-3. Group cases into input sets that match the intended run modes.
-4. Add scoring dimensions and connect them to evidence sources.
-5. Add tools, sandbox policy, assets, and artifacts only when required.
-6. Hand off to validation before publication.
+## CLI Commands
+Start from the CLI template when possible, then edit the YAML.
 
-## Commands
 ```bash
-agentclash challenge-pack init <pack-name>
-agentclash challenge-pack validate path/to/pack.yaml
+agentclash challenge-pack init support-eval.yaml --template prompt_eval --name "Support Eval" --slug support-eval
+agentclash challenge-pack init native-files.yaml --template native --name "Native Files" --slug native-files
+agentclash challenge-pack validate support-eval.yaml
+agentclash challenge-pack validate support-eval.yaml --json
 ```
 
-## Fill-In Checklist
-- Pack identity and description.
-- Task instructions.
-- Case payload schema.
-- Input set names and membership.
-- Scoring dimensions.
-- Validator or judge references.
-- Tool definitions.
-- Sandbox/network policy.
-- Artifact expectations.
+Human validation output prints `Challenge pack is valid` or `Challenge pack has errors`. Use `--json` when a coding agent needs structured fields such as `valid` and `errors`.
+
+## YAML Skeleton
+These are the top-level fields accepted by the bundle parser:
+
+```yaml
+pack:
+  slug: support-eval
+  name: Support Eval
+  family: support
+  description: Evaluates concise customer support answers.
+
+version:
+  number: 1
+  execution_mode: prompt_eval
+  evaluation_spec:
+    name: Support Eval Scoring
+    version_number: 1
+    judge_mode: deterministic
+    validators:
+      - key: mentions_refund_policy
+        type: contains
+        target: final_output
+        expected_from: literal:refund policy
+    scorecard:
+      strategy: weighted
+      dimensions:
+        - key: correctness
+          source: validators
+          weight: 1
+
+challenges:
+  - key: refund-question
+    title: Refund Policy Question
+    category: support
+    difficulty: easy
+    instructions: Answer the customer in a concise, helpful tone.
+
+input_sets:
+  - key: smoke
+    name: Smoke
+    description: Fast validation cases.
+    cases:
+      - challenge_key: refund-question
+        case_key: basic-refund
+        payload:
+          customer_message: Can I get a refund after 14 days?
+        inputs:
+          - key: prompt
+            kind: text
+            value: Can I get a refund after 14 days?
+        expectations:
+          - key: expected_policy
+            kind: text
+            source: input:prompt
+```
+
+## Required Fields
+- `pack.slug`, `pack.name`, and `pack.family` are required.
+- `version.number` must be greater than zero.
+- `version.execution_mode` should be explicit: use `prompt_eval` or `native`.
+- `version.evaluation_spec.validators` must contain at least one validator.
+- Every challenge needs `key`, `title`, `category`, and `difficulty`.
+- `difficulty` must be `easy`, `medium`, `hard`, or `expert`.
+- Every input set needs `key`, `name`, and at least one `cases` entry.
+- Every case needs `challenge_key` referencing a declared challenge and a stable `case_key`.
+- Use `cases`, not legacy `items`, in new YAML.
+
+## Execution Modes
+Use `prompt_eval` for prompt-style tasks where the agent only needs the prompt and final output.
+
+`prompt_eval` cannot use:
+- top-level `tools`
+- `version.tool_policy`
+- `version.sandbox`
+
+Use `native` when the challenge needs files, tools, network policy, package installation, file validators, directory checks, code execution, or sandbox behavior.
+
+## Native Tools And Sandbox
+Only include these blocks for `native` packs.
+
+```yaml
+tools:
+  custom:
+    - name: lookup_order
+      description: Looks up an order by ID.
+      parameters:
+        type: object
+        properties:
+          order_id:
+            type: string
+        required:
+          - order_id
+      implementation:
+        primitive: http_request
+        args:
+          method: GET
+          url: "https://example.test/orders/${order_id}"
+          headers:
+            Authorization: "Bearer ${secrets.ORDER_API_KEY}"
+
+version:
+  number: 1
+  execution_mode: native
+  tool_policy:
+    allowed_tool_kinds:
+      - browser
+      - file
+      - network
+  sandbox:
+    network_access: true
+    network_allowlist:
+      - 203.0.113.0/24
+    env_vars:
+      DATASET_MODE: fixture
+    additional_packages:
+      - jq
+```
+
+Supported `version.tool_policy.allowed_tool_kinds` values are exactly `browser`, `build`, `data`, `file`, and `network`. Do not use `shell` as an allowed tool kind.
+
+For `tools.custom`, each tool needs `name`, `parameters`, and `implementation`. Non-`mock` implementations need `implementation.primitive` and `implementation.args`. Template placeholders in `args` use `${parameter_name}` for declared parameters and may reference `${secrets.SECRET_KEY}` when the runtime provides that secret; never paste raw secret values into YAML.
+
+Sandbox rules:
+- `network_allowlist` entries must be valid CIDR ranges.
+- `env_vars` keys must look like shell env names, for example `DATASET_MODE`.
+- `additional_packages` entries must be valid apt-style package names.
+- Never put raw secrets in YAML. Name required secret keys in notes and configure them through the workspace/runtime/provider flow.
+
+## Assets, Inputs, Expectations, And Artifacts
+Assets may appear on `version`, challenges, or cases. Each asset list must use unique `key` values, and every asset needs `path`.
+
+```yaml
+version:
+  assets:
+    - key: policy_pdf
+      kind: file
+      path: assets/policy.pdf
+      media_type: application/pdf
+
+challenges:
+  - key: summarize-policy
+    title: Summarize Policy
+    category: documents
+    difficulty: medium
+    artifact_refs:
+      - key: policy_pdf
+
+input_sets:
+  - key: full
+    name: Full
+    cases:
+      - challenge_key: summarize-policy
+        case_key: policy-summary
+        inputs:
+          - key: source_doc
+            kind: file
+            artifact_key: policy_pdf
+            path: assets/policy.pdf
+        expectations:
+          - key: summary_requirements
+            kind: text
+            value: Mention refund window and exclusions.
+```
+
+Case input fields are `key`, `kind`, optional `value`, optional `artifact_key`, and optional `path`.
+
+Case expectation fields are `key`, `kind`, optional `value`, optional `artifact_key`, and optional `source`. Supported `source` values are empty, `input:<case-input-key>`, or `artifact:<version-asset-key>`, for example `source: input:prompt`.
+
+## Evaluation Spec
+`evaluation_spec` controls scoring. Keep deterministic checks deterministic, and use LLM judges only when subjective quality is genuinely needed.
+
+```yaml
+evaluation_spec:
+  name: Support Eval Scoring
+  version_number: 1
+  judge_mode: hybrid
+  validators:
+    - key: has_json
+      type: json_schema
+      target: final_output
+      expected_from: 'literal:{"type":"object","required":["answer"]}'
+  llm_judges:
+    - key: helpfulness
+      mode: rubric
+      model: gpt-4.1
+      rubric: Judge whether the answer is helpful, grounded, and concise.
+      context_from:
+        - challenge_input
+        - final_output
+  scorecard:
+    strategy: hybrid
+    dimensions:
+      - key: schema_gate
+        source: validators
+        weight: 1
+        gate: true
+        pass_threshold: 1
+      - key: helpfulness
+        source: llm_judge
+        judge_key: helpfulness
+        weight: 1
+```
+
+Supported `judge_mode` values are `deterministic`, `llm_judge`, and `hybrid`.
+
+Supported validator types include `exact_match`, `contains`, `regex_match`, `json_schema`, `json_path_match`, `boolean_assert`, `fuzzy_match`, `numeric_match`, `normalized_match`, `token_f1`, `math_equivalence`, `bleu_score`, `rouge_score`, `chrf_score`, `file_content_match`, `file_exists`, `file_json_schema`, `directory_structure`, and `code_execution`.
+
+Evidence references accepted by validators and judges include `final_output`, `run.final_output`, `challenge_input`, `case.payload`, `case.payload.<path>`, `case.inputs.<path>`, `case.expectations.<path>`, `artifact.<path>`, `file:<post_execution_check_key>`, and `literal:<value>`.
+
+File validators require a `file:` target. `code_execution` validators must target a `post_execution_checks` entry of type `file_capture`.
+
+For `judge_mode: deterministic`, omit `llm_judges`. For `judge_mode: llm_judge`, include at least one judge. For `judge_mode: hybrid`, include validators and at least one judge; hybrid scorecards need a gated dimension.
+
+## Authoring Procedure
+1. Start with `agentclash challenge-pack init ... --template prompt_eval` or `--template native`.
+2. Fill `pack` metadata with stable slug/name/family.
+3. Set `version.number: 1` for a new pack and choose `execution_mode`.
+4. Write challenges before cases so every `case.challenge_key` can reference a real challenge.
+5. Add input sets by run purpose: `smoke`, `ci`, `regression`, `full`, or similar.
+6. Add deterministic validators first; add LLM judges only when deterministic evidence cannot capture quality.
+7. Add native-only tools, sandbox, files, assets, and artifact refs only when the execution mode is `native`.
+8. Run validation with and without `--json`.
+9. Hand off to publication only after validation passes.
+
+## Common Validation Failures
+- Missing `pack.family`, `challenge.category`, or `case_key`.
+- Case `challenge_key` does not match any challenge `key`.
+- `difficulty` is not one of `easy`, `medium`, `hard`, or `expert`.
+- A `prompt_eval` pack includes `tools`, `tool_policy`, or `sandbox`.
+- `allowed_tool_kinds` contains unsupported values such as `shell`.
+- Asset or artifact reference keys are missing, duplicated, or point at undeclared version assets.
+- Case expectation `source` is not empty, `input:<case-input-key>`, or `artifact:<version-asset-key>`.
+- File validators do not use a `file:` evidence target.
+- `judge_mode` conflicts with the presence or absence of `llm_judges`.
+
+## Report Back Format
+```text
+YAML file:
+Execution mode:
+Challenges:
+Input sets:
+Scoring mode:
+Native tools/sandbox/assets:
+Validation command:
+Validation result:
+Ready for publish: <yes/no>
+Next skill: agentclash-challenge-pack-validation-publish
+Open issues:
+```
 
 ## Related Skills
+- `agentclash-challenge-pack-planner`
 - `agentclash-challenge-pack-input-sets`
+- `agentclash-challenge-pack-scoring-validators`
+- `agentclash-challenge-pack-llm-judges`
+- `agentclash-challenge-pack-tools-sandbox`
+- `agentclash-challenge-pack-artifacts`
 - `agentclash-challenge-pack-validation-publish`

--- a/web/content/agent-skills/challenge-pack-skills/agentclash-challenge-pack-yaml-author/SKILL.md
+++ b/web/content/agent-skills/challenge-pack-skills/agentclash-challenge-pack-yaml-author/SKILL.md
@@ -237,6 +237,8 @@ evaluation_spec:
     dimensions:
       - key: schema_gate
         source: validators
+        validators:
+          - has_json
         weight: 1
         gate: true
         pass_threshold: 1
@@ -255,6 +257,10 @@ Evidence references accepted by validators and judges include `final_output`, `r
 File validators require a `file:` target. `code_execution` validators must target a `post_execution_checks` entry of type `file_capture`.
 
 For `judge_mode: deterministic`, omit `llm_judges`. For `judge_mode: llm_judge`, include at least one judge. For `judge_mode: hybrid`, include validators and at least one judge; hybrid scorecards need a gated dimension.
+
+For scorecard dimensions with `source: validators`, omit the `validators` list only when the dimension should score every validator. Add `validators: [<validator_key>]` when the dimension should cover a specific subset.
+
+Do not put `${secrets.*}` references in LLM judge `rubric`, `assertion`, or `prompt` text. Secrets are allowed in native tool implementation args when the runtime provides them, but judge prompt text rejects secret references.
 
 ## Authoring Procedure
 1. Start with `agentclash challenge-pack init ... --template prompt_eval` or `--template native`.

--- a/web/src/lib/docs.test.ts
+++ b/web/src/lib/docs.test.ts
@@ -162,6 +162,34 @@ describe("agent skill docs", () => {
     );
   });
 
+  it("generates the challenge pack yaml author skill with source-backed details", () => {
+    const doc = getDocBySlug([
+      "agent-skills",
+      "challenge-pack-skills",
+      "agentclash-challenge-pack-yaml-author",
+    ]);
+
+    expect(doc?.title).toBe("Challenge Pack YAML Author Skill");
+    expect(doc?.content).toContain(
+      "agentclash challenge-pack init support-eval.yaml --template prompt_eval",
+    );
+    expect(doc?.content).toContain(
+      "agentclash challenge-pack validate support-eval.yaml --json",
+    );
+    expect(doc?.content).toContain("`pack`, `version`, `challenges`, `input_sets`");
+    expect(doc?.content).toContain("case_key");
+    expect(doc?.content).toContain("source: input:prompt");
+    expect(doc?.content).toContain(
+      "Supported `version.tool_policy.allowed_tool_kinds` values are exactly `browser`, `build`, `data`, `file`, and `network`",
+    );
+    expect(doc?.content).toContain("Do not use `shell` as an allowed tool kind");
+    expect(doc?.content).toContain(
+      "`prompt_eval` cannot use:\n- top-level `tools`\n- `version.tool_policy`\n- `version.sandbox`",
+    );
+    expect(doc?.content).toContain("`version.evaluation_spec.validators`");
+    expect(doc?.content).toContain("judge_mode: hybrid");
+  });
+
   it("includes the index and every skill in markdown paths", () => {
     const paths = getAllDocMarkdownPaths();
 


### PR DESCRIPTION
## Summary

Closes #447.

Expands the challenge pack YAML author skill from a scaffold into source-backed guidance for coding agents that do not have the AgentClash repo locally. The skill now documents:

- exact top-level bundle shape: `pack`, `version`, optional `tools`, `challenges`, `input_sets`
- CLI template and validation commands, including when `--json` is required for structured output
- required fields and prompt_eval/native restrictions
- supported native `allowed_tool_kinds` from the backend validator: `browser`, `build`, `data`, `file`, `network`
- case/input/expectation and asset/artifact reference shapes
- scoring `evaluation_spec`, validator types, evidence references, LLM judge shape, and common validation failures

## Review checkpoint

Contract committed first in `testing/codex-issue-447-challenge-pack-yaml-author-skill.md`.

Self-review notes:

- reviewed against `cli/cmd/challenge_pack.go`
- reviewed against `backend/internal/challengepack/bundle.go`
- reviewed against `backend/internal/challengepack/validation.go`
- reviewed against `backend/internal/scoring/spec.go`
- reviewed against `backend/internal/scoring/validation.go`
- reviewed against `backend/internal/scoring/validation_judges.go`

I corrected alignment issues during checkpoint review before commit:

- validator examples use `expected_from`, not stale `expected`
- custom tool template placeholders use `${parameter_name}`
- LLM judge examples include required `mode`, `context_from`, scorecard `judge_key`, and gated `pass_threshold`
- skill explicitly says `shell` is not a supported `allowed_tool_kinds` value

## Tests

- `npm test -- src/lib/docs.test.ts` from `web/`
- `go test ./internal/challengepack ./internal/scoring` from `backend/`
- `git diff --check`
