### PR TITLE
feat(cli): add --repetitions flag to eval start

### DIFF
--- a/cli/cmd/eval.go
+++ b/cli/cmd/eval.go
@@ -22,6 +22,7 @@ func init() {
 	evalStartCmd.Flags().StringSlice("case", nil, "Regression case IDs (repeatable)")
 	evalStartCmd.Flags().Bool("race-context", false, "Enable live peer-standings injection during the run (requires 2+ agents)")
 	evalStartCmd.Flags().Int("race-context-cadence", 0, "Override race-context cadence; minimum steps between standings injections, [1, 10]. 0 uses the backend default.")
+	evalStartCmd.Flags().Int("repetitions", 1, "Repeat the eval N times in a multi-run eval session, [1, 100]. >=2 routes through /v1/eval-sessions and unlocks pass@K + pass^K aggregation.")
 
 	evalScorecardCmd.Flags().String("agent", "", "Run agent ID or label (optional)")
 }
@@ -76,6 +77,26 @@ selection when possible.`,
 			return fmt.Errorf("--scope suite_only requires at least one --suite or --case")
 		}
 
+		repetitions, _ := cmd.Flags().GetInt("repetitions")
+		if repetitions < evalSessionMinRepetitions || repetitions > evalSessionMaxRepetitions {
+			return fmt.Errorf("--repetitions must be between %d and %d", evalSessionMinRepetitions, evalSessionMaxRepetitions)
+		}
+		follow, _ := cmd.Flags().GetBool("follow")
+		if repetitions >= 2 {
+			if follow {
+				return fmt.Errorf("--follow is not supported with --repetitions >= 2; tail individual runs with 'agentclash run list' instead")
+			}
+			body, err := buildEvalSessionBody(workspaceID, request, repetitions)
+			if err != nil {
+				return err
+			}
+			result, err := createEvalSession(cmd, rc, body)
+			if err != nil {
+				return err
+			}
+			return presentCreatedEvalSession(rc, result)
+		}
+
 		body, err := buildRunCreateBody(workspaceID, request)
 		if err != nil {
 			return err
@@ -86,7 +107,6 @@ selection when possible.`,
 			return err
 		}
 
-		follow, _ := cmd.Flags().GetBool("follow")
 		return presentCreatedRun(cmd, rc, run, follow, func(runID string) error {
 			if _, ok := rc.Config.BaselineBookmark(workspaceID); !ok {
 				return nil

--- a/cli/cmd/eval_session_helpers.go
+++ b/cli/cmd/eval_session_helpers.go
@@ -1,0 +1,136 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/agentclash/agentclash/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+const (
+	evalSessionMinRepetitions = 1
+	evalSessionMaxRepetitions = 100
+)
+
+// buildEvalSessionBody constructs the JSON body for POST /v1/eval-sessions.
+// The shape mirrors backend/internal/api/eval_sessions.go and the example
+// payload in backend/internal/api/runs_test.go. Defaults match the lightest
+// path through decodeEvalSessionConfig: aggregation method "mean", schema
+// version 1, and a routing_task_snapshot whose routing.mode tracks the
+// caller-provided execution_mode.
+//
+// The eval-session API does not accept regression_suite_ids,
+// regression_case_ids, race_context, or race_context_min_step_gap. The CLI
+// errors loudly when those are combined with --repetitions >= 2 rather than
+// silently dropping them.
+func buildEvalSessionBody(workspaceID string, request runCreateRequest, repetitions int) (map[string]any, error) {
+	if request.ChallengePackVersionID == "" {
+		return nil, fmt.Errorf("challenge pack version is required")
+	}
+	if len(request.DeploymentIDs) == 0 {
+		return nil, fmt.Errorf("at least one deployment is required")
+	}
+	if repetitions < evalSessionMinRepetitions || repetitions > evalSessionMaxRepetitions {
+		return nil, fmt.Errorf("--repetitions must be between %d and %d", evalSessionMinRepetitions, evalSessionMaxRepetitions)
+	}
+	// Surface unsupported flag combinations early. The eval-session endpoint
+	// has no field for any of these today; staying loud now beats a confusing
+	// "why did my regression suite get ignored?" later.
+	if len(request.RegressionSuiteIDs) > 0 || len(request.RegressionCaseIDs) > 0 || request.OfficialPackMode == "suite_only" {
+		return nil, fmt.Errorf("--scope suite_only / --suite / --case are not supported with --repetitions >= 2")
+	}
+	if request.RaceContext || request.RaceContextCadence > 0 {
+		return nil, fmt.Errorf("--race-context flags are not supported with --repetitions >= 2")
+	}
+
+	executionMode := "single_agent"
+	if len(request.DeploymentIDs) > 1 {
+		executionMode = "multi_agent"
+	}
+
+	participants := make([]map[string]any, 0, len(request.DeploymentIDs))
+	for i, deploymentID := range request.DeploymentIDs {
+		label := "Primary"
+		if i > 0 {
+			label = fmt.Sprintf("Participant %d", i+1)
+		}
+		participants = append(participants, map[string]any{
+			"agent_deployment_id": deploymentID,
+			"label":               label,
+		})
+	}
+
+	body := map[string]any{
+		"workspace_id":              workspaceID,
+		"challenge_pack_version_id": request.ChallengePackVersionID,
+		"participants":              participants,
+		"execution_mode":            executionMode,
+		"eval_session": map[string]any{
+			"repetitions": repetitions,
+			"aggregation": map[string]any{
+				"method":              "mean",
+				"report_variance":     true,
+				"confidence_interval": 0.95,
+			},
+			"routing_task_snapshot": map[string]any{
+				"routing": map[string]any{"mode": executionMode},
+				"task":    map[string]any{"pack_version": "v1"},
+			},
+			"schema_version": 1,
+		},
+	}
+	if request.Name != "" {
+		body["name"] = request.Name
+	}
+	if request.ChallengeInputSetID != "" {
+		body["challenge_input_set_id"] = request.ChallengeInputSetID
+	}
+	return body, nil
+}
+
+// createEvalSession POSTs the body to /v1/eval-sessions and returns the parsed
+// response. The shape matches createEvalSessionResponse on the backend:
+// `{eval_session: {...}, run_ids: [...]}`.
+func createEvalSession(cmd *cobra.Command, rc *RunContext, body map[string]any) (map[string]any, error) {
+	sp := output.NewSpinner("Creating eval session...", flagQuiet)
+	resp, err := rc.Client.Post(cmd.Context(), "/v1/eval-sessions", body)
+	if err != nil {
+		sp.StopWithError("Failed to create eval session")
+		return nil, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		sp.StopWithError("Failed to create eval session")
+		return nil, apiErr
+	}
+
+	var result map[string]any
+	if err := resp.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+
+	session, _ := result["eval_session"].(map[string]any)
+	sp.StopWithSuccess(fmt.Sprintf("Created eval session %s", str(session["id"])))
+	return result, nil
+}
+
+// presentCreatedEvalSession renders the eval-session response. In structured
+// output mode it prints the raw envelope. In human mode it prints session
+// metadata plus each child run ID one per line so the user can `agentclash run
+// follow` whichever they want.
+func presentCreatedEvalSession(rc *RunContext, result map[string]any) error {
+	if rc.Output.IsStructured() {
+		return rc.Output.PrintRaw(result)
+	}
+
+	session, _ := result["eval_session"].(map[string]any)
+	rc.Output.PrintDetail("Eval Session ID", str(session["id"]))
+	rc.Output.PrintDetail("Status", output.StatusColor(str(session["status"])))
+	rc.Output.PrintDetail("Repetitions", str(session["repetitions"]))
+
+	runIDs, _ := result["run_ids"].([]any)
+	rc.Output.PrintDetail("Run IDs", fmt.Sprintf("%d", len(runIDs)))
+	for _, id := range runIDs {
+		fmt.Fprintf(rc.Output.Writer(), "  - %s\n", str(id))
+	}
+	return nil
+}

--- a/cli/cmd/eval_session_test.go
+++ b/cli/cmd/eval_session_test.go
@@ -1,0 +1,325 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestBuildEvalSessionBody_HappyPath_SingleDeployment(t *testing.T) {
+	body, err := buildEvalSessionBody("ws-1", runCreateRequest{
+		ChallengePackVersionID: "pv-1",
+		ChallengeInputSetID:    "is-1",
+		DeploymentIDs:          []string{"dep-1"},
+		Name:                   "boardroom-tier1",
+		OfficialPackMode:       "full",
+	}, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := body["workspace_id"]; got != "ws-1" {
+		t.Errorf("workspace_id = %v, want ws-1", got)
+	}
+	if got := body["challenge_pack_version_id"]; got != "pv-1" {
+		t.Errorf("challenge_pack_version_id = %v, want pv-1", got)
+	}
+	if got := body["challenge_input_set_id"]; got != "is-1" {
+		t.Errorf("challenge_input_set_id = %v, want is-1", got)
+	}
+	if got := body["execution_mode"]; got != "single_agent" {
+		t.Errorf("execution_mode = %v, want single_agent", got)
+	}
+	if got := body["name"]; got != "boardroom-tier1" {
+		t.Errorf("name = %v, want boardroom-tier1", got)
+	}
+
+	participants, ok := body["participants"].([]map[string]any)
+	if !ok || len(participants) != 1 {
+		t.Fatalf("participants = %#v, want one entry", body["participants"])
+	}
+	if participants[0]["agent_deployment_id"] != "dep-1" {
+		t.Errorf("agent_deployment_id = %v, want dep-1", participants[0]["agent_deployment_id"])
+	}
+	if participants[0]["label"] != "Primary" {
+		t.Errorf("label = %v, want Primary", participants[0]["label"])
+	}
+
+	session, ok := body["eval_session"].(map[string]any)
+	if !ok {
+		t.Fatalf("eval_session missing or wrong type: %#v", body["eval_session"])
+	}
+	if session["repetitions"] != 3 {
+		t.Errorf("repetitions = %v, want 3", session["repetitions"])
+	}
+	if session["schema_version"] != 1 {
+		t.Errorf("schema_version = %v, want 1", session["schema_version"])
+	}
+	aggregation, ok := session["aggregation"].(map[string]any)
+	if !ok || aggregation["method"] != "mean" {
+		t.Errorf("aggregation = %#v, want method=mean", session["aggregation"])
+	}
+	routing, ok := session["routing_task_snapshot"].(map[string]any)
+	if !ok {
+		t.Fatalf("routing_task_snapshot missing: %#v", session["routing_task_snapshot"])
+	}
+	if mode := routing["routing"].(map[string]any)["mode"]; mode != "single_agent" {
+		t.Errorf("routing.mode = %v, want single_agent", mode)
+	}
+}
+
+func TestBuildEvalSessionBody_MultiDeployment_LabelsAndMode(t *testing.T) {
+	body, err := buildEvalSessionBody("ws-1", runCreateRequest{
+		ChallengePackVersionID: "pv-1",
+		DeploymentIDs:          []string{"dep-a", "dep-b", "dep-c"},
+	}, 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := body["execution_mode"]; got != "multi_agent" {
+		t.Errorf("execution_mode = %v, want multi_agent", got)
+	}
+	participants := body["participants"].([]map[string]any)
+	if len(participants) != 3 {
+		t.Fatalf("len(participants) = %d, want 3", len(participants))
+	}
+	wantLabels := []string{"Primary", "Participant 2", "Participant 3"}
+	for i, want := range wantLabels {
+		if got := participants[i]["label"]; got != want {
+			t.Errorf("participants[%d].label = %v, want %s", i, got, want)
+		}
+	}
+}
+
+func TestBuildEvalSessionBody_RangeValidation(t *testing.T) {
+	cases := []struct {
+		name        string
+		repetitions int
+		wantErr     string
+	}{
+		{"zero", 0, "must be between"},
+		{"negative", -1, "must be between"},
+		{"too_large", 101, "must be between"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildEvalSessionBody("ws-1", runCreateRequest{
+				ChallengePackVersionID: "pv-1",
+				DeploymentIDs:          []string{"dep-1"},
+			}, tc.repetitions)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("err = %v, want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuildEvalSessionBody_RejectsUnsupportedFlags(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(*runCreateRequest)
+		wantErr string
+	}{
+		{
+			name:    "regression_suites",
+			mutate:  func(r *runCreateRequest) { r.RegressionSuiteIDs = []string{"suite-1"} },
+			wantErr: "suite_only / --suite / --case",
+		},
+		{
+			name:    "regression_cases",
+			mutate:  func(r *runCreateRequest) { r.RegressionCaseIDs = []string{"case-1"} },
+			wantErr: "suite_only / --suite / --case",
+		},
+		{
+			name:    "scope_suite_only",
+			mutate:  func(r *runCreateRequest) { r.OfficialPackMode = "suite_only" },
+			wantErr: "suite_only / --suite / --case",
+		},
+		{
+			name:    "race_context",
+			mutate:  func(r *runCreateRequest) { r.RaceContext = true },
+			wantErr: "race-context",
+		},
+		{
+			name:    "race_context_cadence",
+			mutate:  func(r *runCreateRequest) { r.RaceContextCadence = 5 },
+			wantErr: "race-context",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := runCreateRequest{
+				ChallengePackVersionID: "pv-1",
+				DeploymentIDs:          []string{"dep-1"},
+			}
+			tc.mutate(&req)
+			_, err := buildEvalSessionBody("ws-1", req, 3)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("err = %v, want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// End-to-end: executeCommand invokes the full CLI surface, the fake server
+// captures requests, and we verify the dispatch goes to the right endpoint
+// and carries the right body.
+
+func evalStartFakeRoutes(t *testing.T, captured *map[string]any) map[string]http.HandlerFunc {
+	t.Helper()
+	return map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/challenge-packs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{
+					"id":   "pack-1",
+					"name": "Test Pack",
+					"slug": "test-pack",
+					"versions": []map[string]any{
+						{"id": "pv-1", "version_number": 1, "lifecycle_status": "ready"},
+					},
+				},
+			},
+		}),
+		"GET /v1/workspaces/ws-1/challenge-pack-versions/pv-1/input-sets": jsonHandler(200, map[string]any{
+			"items": []map[string]any{},
+		}),
+		"GET /v1/workspaces/ws-1/agent-deployments": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "dep-1", "name": "claude-sonnet", "status": "ready", "created_at": "now"},
+			},
+		}),
+		"POST /v1/eval-sessions": func(w http.ResponseWriter, r *http.Request) {
+			body := map[string]any{}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode eval-session body: %v", err)
+			}
+			if captured != nil {
+				*captured = body
+			}
+			jsonHandler(201, map[string]any{
+				"eval_session": map[string]any{
+					"id":          "session-1",
+					"status":      "queued",
+					"repetitions": 3,
+				},
+				"run_ids": []string{"run-1", "run-2", "run-3"},
+			})(w, r)
+		},
+		"POST /v1/runs": func(w http.ResponseWriter, r *http.Request) {
+			if captured != nil {
+				(*captured)["__hit_runs"] = true
+			}
+			jsonHandler(201, map[string]any{
+				"id":     "run-1",
+				"status": "queued",
+			})(w, r)
+		},
+	}
+}
+
+func TestEvalStart_Repetitions_RoutesToEvalSessions(t *testing.T) {
+	captured := map[string]any{}
+	srv := fakeAPI(t, evalStartFakeRoutes(t, &captured))
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"eval", "start", "-w", "ws-1",
+		"--pack", "test-pack",
+		"--deployment", "dep-1",
+		"--repetitions", "3",
+	}, srv.URL); err != nil {
+		t.Fatalf("eval start error: %v", err)
+	}
+
+	if _, hit := captured["__hit_runs"]; hit {
+		t.Fatal("POST /v1/runs was called; expected POST /v1/eval-sessions")
+	}
+	if captured["challenge_pack_version_id"] != "pv-1" {
+		t.Errorf("challenge_pack_version_id = %v, want pv-1", captured["challenge_pack_version_id"])
+	}
+	session, ok := captured["eval_session"].(map[string]any)
+	if !ok {
+		t.Fatalf("eval_session missing in body: %#v", captured["eval_session"])
+	}
+	if r, ok := session["repetitions"].(float64); !ok || int(r) != 3 {
+		t.Errorf("repetitions = %v, want 3", session["repetitions"])
+	}
+	aggregation, _ := session["aggregation"].(map[string]any)
+	if aggregation["method"] != "mean" {
+		t.Errorf("aggregation.method = %v, want mean", aggregation["method"])
+	}
+}
+
+func TestEvalStart_NoRepetitions_RoutesToRunsEndpoint(t *testing.T) {
+	captured := map[string]any{}
+	srv := fakeAPI(t, evalStartFakeRoutes(t, &captured))
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"eval", "start", "-w", "ws-1",
+		"--pack", "test-pack",
+		"--deployment", "dep-1",
+	}, srv.URL); err != nil {
+		t.Fatalf("eval start error: %v", err)
+	}
+
+	if hit, _ := captured["__hit_runs"].(bool); !hit {
+		t.Fatal("POST /v1/runs was not called; expected default behavior")
+	}
+	if _, ok := captured["eval_session"]; ok {
+		t.Fatal("eval_session payload leaked into /v1/runs path")
+	}
+}
+
+func TestEvalStart_Repetitions_RejectsFollow(t *testing.T) {
+	srv := fakeAPI(t, evalStartFakeRoutes(t, nil))
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{
+		"eval", "start", "-w", "ws-1",
+		"--pack", "test-pack",
+		"--deployment", "dep-1",
+		"--repetitions", "5",
+		"--follow",
+	}, srv.URL)
+	if err == nil {
+		t.Fatal("expected error when combining --repetitions and --follow")
+	}
+	if !strings.Contains(err.Error(), "--follow is not supported") {
+		t.Errorf("err = %v, want --follow guidance", err)
+	}
+}
+
+func TestEvalStart_Repetitions_RangeValidationE2E(t *testing.T) {
+	cases := []struct {
+		name        string
+		repetitions string
+	}{
+		{"zero", "0"},
+		{"too_large", "101"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := fakeAPI(t, evalStartFakeRoutes(t, nil))
+			defer srv.Close()
+
+			t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+			err := executeCommand(t, []string{
+				"eval", "start", "-w", "ws-1",
+				"--pack", "test-pack",
+				"--deployment", "dep-1",
+				"--repetitions", tc.repetitions,
+			}, srv.URL)
+			if err == nil {
+				t.Fatal("expected error for out-of-range --repetitions")
+			}
+			if !strings.Contains(err.Error(), "must be between") {
+				t.Errorf("err = %v, want range message", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `--repetitions N` to `agentclash eval start` to make multi-run eval sessions reachable from terminal.
- N=1 (default) keeps current `/v1/runs` behavior unchanged.
- N in `[2, 100]` POSTs to `/v1/eval-sessions` with sensible defaults (`mean` aggregation, 95% CI, schema_version 1) so `pass@K` and `pass^K` aggregation surface (already in the backend at `backend/internal/repository/eval_session_aggregation.go`) is usable without hand-rolling the API call.
- Unsupported flag combinations (`--suite`, `--case`, `--scope suite_only`, `--race-context`, `--follow`) error loudly with `--repetitions >= 2` since the eval-session endpoint has no field for them.

## Why

Today the only way to get multi-trial reliability metrics is to call the API directly. For something like the Boardroom Analytics pack, where the killer eval is exactly the kind of confounder challenge where `pass^K` is the metric you actually want, that's a meaningful friction. This wires the existing backend feature into the CLI without a backend change.

## Test plan

- [x] `cd cli && go vet ./...`
- [x] `cd cli && go test -short -race -count=1 ./...` (full suite green)
- [x] New unit tests cover: happy-path body shape (single + multi deployment), range validation `[1, 100]`, unsupported-flag rejection, and end-to-end dispatch for `K=1` vs `K>=2`.
- [ ] Maintainer smoke after merge:
  ```bash
  agentclash eval start --pack boardroom-analytics --deployment <id> --repetitions 3 --json \
    | jq '.eval_session.repetitions, (.run_ids | length)'
  ```
  Expected: `3` and `3`.

## Notes for reviewer

- All changes live in `cli/cmd/`. No backend changes; the `/v1/eval-sessions` endpoint already accepts every field the CLI sends (validated against the example payload in `backend/internal/api/runs_test.go:449-459`).
- Conventional commit prefix `feat(cli):` so Release Please opens a release PR for the CLI on merge.
- Self-review against locked expectations (gitignored test contract): all clauses covered. One acceptable rough edge: `--scope suite_only --repetitions 3` shows the existing "requires --suite or --case" error before the K>=2 unsupported-flag error. Two-step feedback for one mistake; not worth re-ordering validation today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)