### PR TITLE
fix(api): include challenge pack slug in list response

### DIFF
--- a/backend/internal/api/challenge_packs.go
+++ b/backend/internal/api/challenge_packs.go
@@ -247,6 +247,7 @@ func mapChallengePackValidationErrors(errs challengepack.ValidationErrors) []val
 type challengePackResponse struct {
 	ID          uuid.UUID                      `json:"id"`
 	Name        string                         `json:"name"`
+	Slug        string                         `json:"slug"`
 	Description *string                        `json:"description,omitempty"`
 	Versions    []challengePackVersionResponse `json:"versions"`
 	CreatedAt   time.Time                      `json:"created_at"`
@@ -307,6 +308,7 @@ func listChallengePacksHandler(logger *slog.Logger, service ChallengePackReadSer
 			responseItems = append(responseItems, challengePackResponse{
 				ID:          packWithVersions.Pack.ID,
 				Name:        packWithVersions.Pack.Name,
+				Slug:        packWithVersions.Pack.Slug,
 				Description: packWithVersions.Pack.Description,
 				Versions:    versions,
 				CreatedAt:   packWithVersions.Pack.CreatedAt,

--- a/backend/internal/api/challenge_packs_test.go
+++ b/backend/internal/api/challenge_packs_test.go
@@ -30,6 +30,7 @@ func (f *fakeChallengePackReadRepository) ListVisibleChallengePacks(_ context.Co
 		{
 			ID:        uuid.New(),
 			Name:      "Workspace Pack",
+			Slug:      "workspace-pack",
 			CreatedAt: time.Now().UTC(),
 			UpdatedAt: time.Now().UTC(),
 		},
@@ -149,6 +150,33 @@ func TestChallengePackReadManagerUsesWorkspaceFromContext(t *testing.T) {
 	}
 	if len(result.Packs) != 1 {
 		t.Fatalf("pack count = %d, want 1", len(result.Packs))
+	}
+}
+
+func TestListChallengePacksHandlerIncludesSlug(t *testing.T) {
+	workspaceID := uuid.New()
+	manager := NewChallengePackReadManager(&fakeChallengePackReadRepository{})
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	handler := listChallengePacksHandler(logger, manager)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/workspaces/"+workspaceID.String()+"/challenge-packs", nil)
+	req = req.WithContext(context.WithValue(req.Context(), workspaceIDContextKey{}, workspaceID))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var response listChallengePacksResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Items) != 1 {
+		t.Fatalf("item count = %d, want 1", len(response.Items))
+	}
+	if response.Items[0].Slug != "workspace-pack" {
+		t.Fatalf("slug = %q, want workspace-pack", response.Items[0].Slug)
 	}
 }
 

--- a/backend/internal/repository/challenge_pack_authoring.go
+++ b/backend/internal/repository/challenge_pack_authoring.go
@@ -32,7 +32,7 @@ type PublishedChallengePack struct {
 
 func (r *Repository) ListVisibleChallengePacks(ctx context.Context, workspaceID uuid.UUID) ([]ChallengePackSummary, error) {
 	rows, err := r.db.Query(ctx, `
-		SELECT id, name, description, created_at, updated_at
+		SELECT id, name, slug, description, created_at, updated_at
 		FROM challenge_packs
 		WHERE archived_at IS NULL
 		  AND (workspace_id IS NULL OR workspace_id = $1)
@@ -47,7 +47,7 @@ func (r *Repository) ListVisibleChallengePacks(ctx context.Context, workspaceID 
 	for rows.Next() {
 		var pack ChallengePackSummary
 		var createdAt, updatedAt time.Time
-		if err := rows.Scan(&pack.ID, &pack.Name, &pack.Description, &createdAt, &updatedAt); err != nil {
+		if err := rows.Scan(&pack.ID, &pack.Name, &pack.Slug, &pack.Description, &createdAt, &updatedAt); err != nil {
 			return nil, fmt.Errorf("scan visible challenge pack: %w", err)
 		}
 		pack.CreatedAt = createdAt

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -2497,6 +2497,7 @@ func (r *Repository) ListActiveAgentDeploymentsByWorkspaceID(ctx context.Context
 type ChallengePackSummary struct {
 	ID          uuid.UUID
 	Name        string
+	Slug        string
 	Description *string
 	CreatedAt   time.Time
 	UpdatedAt   time.Time

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -7902,12 +7902,14 @@ components:
 
     ChallengePack:
       type: object
-      required: [id, name, versions, created_at, updated_at]
+      required: [id, name, slug, versions, created_at, updated_at]
       properties:
         id:
           type: string
           format: uuid
         name:
+          type: string
+        slug:
           type: string
         description:
           type: string

--- a/testing/codex-issue-491-pack-slug-resolve.md
+++ b/testing/codex-issue-491-pack-slug-resolve.md
@@ -1,0 +1,27 @@
+# codex/issue-491-pack-slug-resolve - Test Contract
+
+## Functional Behavior
+- `GET /v1/workspaces/{workspaceID}/challenge-packs` includes each pack's durable `slug` alongside `id`, `name`, `description`, `versions`, and timestamps.
+- `agentclash eval start --pack <slug>` can resolve a published pack by exact slug because the CLI receives the slug field in the list response.
+- Existing ID and exact-name resolution behavior remains unchanged.
+
+## Unit Tests
+- `TestListChallengePacksHandlerIncludesSlug` - the challenge-pack list API response serializes a `slug` field.
+- Existing CLI eval selector tests continue to pass, including `TestEvalStartResolvesSelectorsAndCreatesRun`.
+
+## Integration / Functional Tests
+- `go test ./internal/api ./internal/repository ./cmd` from `cli/` or relevant module roots where applicable.
+
+## Smoke Tests
+- `cd cli && go test ./cmd -run TestEvalStartResolvesSelectorsAndCreatesRun -count=1`.
+- `cd backend && go test ./internal/api -run TestListChallengePacksHandlerIncludesSlug -count=1`.
+
+## E2E Tests
+N/A - this is a response shape and selector-resolution fix covered by API and CLI tests.
+
+## Manual / cURL Tests
+```bash
+curl -H "Authorization: Bearer $AGENTCLASH_TOKEN" \
+  "$AGENTCLASH_API_URL/v1/workspaces/$AGENTCLASH_WORKSPACE/challenge-packs"
+# Expected: each item contains "slug": "<pack-slug>".
+```

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -503,6 +503,7 @@ export interface ModelAlias {
 export interface ChallengePack {
   id: string;
   name: string;
+  slug: string;
   description?: string;
   versions: ChallengePackVersion[];
   created_at: string;


### PR DESCRIPTION
## Summary
- include challenge pack slug in the workspace challenge-pack list API response
- select slug from challenge_packs in the visible-pack repository query
- add a focused API handler test so CLI --pack slug resolution has the data it needs

Fixes #491.

## Review Checkpoint
- Test contract: testing/codex-issue-491-pack-slug-resolve.md
- Contract committed before implementation in 34ed8c0f

## Local Tests
- cd backend && go test ./internal/api -run TestListChallengePacksHandlerIncludesSlug -count=1
- cd cli && go test ./cmd -run TestEvalStartResolvesSelectorsAndCreatesRun -count=1
- cd backend && go test ./internal/api ./internal/repository
- cd cli && go test ./cmd