### PR TITLE
fix(scoring): support run tool call count collector

### DIFF
--- a/backend/internal/scoring/engine_evidence.go
+++ b/backend/internal/scoring/engine_evidence.go
@@ -295,6 +295,9 @@ func buildEvidence(challengeInputs []EvidenceInput, events []Event) extractedEvi
 			evidence.totalTokens = floatPtr(*evidence.inputTokens + *evidence.outputTokens)
 		}
 	}
+	// Prefer the terminal run summary when present. Older or synthetic event
+	// streams may only have individual tool-call events, so use the trace as a
+	// best-effort fallback instead of leaving the collector unsupported.
 	if evidence.toolCallCount == nil && len(evidence.toolCallTrace) > 0 {
 		evidence.toolCallCount = floatPtr(float64(len(evidence.toolCallTrace)))
 	}

--- a/backend/internal/scoring/engine_evidence.go
+++ b/backend/internal/scoring/engine_evidence.go
@@ -43,23 +43,24 @@ type extractedEvidence struct {
 	inputTokens                    *float64
 	outputTokens                   *float64
 	totalTokens                    *float64
+	toolCallCount                  *float64
 	// raceContextTokens is the estimated prompt-side token spend from
 	// race-context standings injections (issue #400). It is accumulated
 	// from race.standings.injected events and must stay separate from
 	// model-authored totals so billable-spend metrics are not inflated
 	// by observational injections.
-	raceContextTokens float64
-	modelUsage                     []pricedUsage
-	observedModels                 []modelRef
-	stepDurations                  []stepDurationEvidence
-	capturedFiles                  map[string]FileCaptureResult
-	capturedFileSources            map[string]eventRef
-	capturedDirListings            map[string]DirectoryListingResult
-	capturedDirListingSources      map[string]eventRef
-	codeExecutionResults           map[string]CodeExecutionResult
-	codeExecutionSources           map[string]eventRef
-	toolCallTrace                  []toolCallTraceEntry
-	warnings                       []string
+	raceContextTokens         float64
+	modelUsage                []pricedUsage
+	observedModels            []modelRef
+	stepDurations             []stepDurationEvidence
+	capturedFiles             map[string]FileCaptureResult
+	capturedFileSources       map[string]eventRef
+	capturedDirListings       map[string]DirectoryListingResult
+	capturedDirListingSources map[string]eventRef
+	codeExecutionResults      map[string]CodeExecutionResult
+	codeExecutionSources      map[string]eventRef
+	toolCallTrace             []toolCallTraceEntry
+	warnings                  []string
 }
 
 // eventRefFrom returns a reference to the given event, or nil when the event
@@ -155,6 +156,9 @@ func buildEvidence(challengeInputs []EvidenceInput, events []Event) extractedEvi
 			}
 			if value, ok := numericValue(payload, "total_tokens"); ok {
 				evidence.totalTokens = floatPtr(value)
+			}
+			if value, ok := numericValue(payload, "tool_call_count"); ok {
+				evidence.toolCallCount = floatPtr(value)
 			}
 			if value, ok := usageValue(payload, "input_tokens"); ok && evidence.inputTokens == nil {
 				evidence.inputTokens = floatPtr(value)
@@ -290,6 +294,9 @@ func buildEvidence(challengeInputs []EvidenceInput, events []Event) extractedEvi
 		} else if evidence.inputTokens != nil && evidence.outputTokens != nil {
 			evidence.totalTokens = floatPtr(*evidence.inputTokens + *evidence.outputTokens)
 		}
+	}
+	if evidence.toolCallCount == nil && len(evidence.toolCallTrace) > 0 {
+		evidence.toolCallCount = floatPtr(float64(len(evidence.toolCallTrace)))
 	}
 	for _, usage := range usageByModel {
 		if usage.TotalTokens == 0 && (usage.InputTokens > 0 || usage.OutputTokens > 0) {

--- a/backend/internal/scoring/engine_metrics.go
+++ b/backend/internal/scoring/engine_metrics.go
@@ -91,6 +91,14 @@ func collectMetric(metric MetricDeclaration, evidence extractedEvidence, validat
 			"state":     OutputStateAvailable,
 			"collector": metric.Collector,
 		})
+	case "run_tool_call_count":
+		if evidence.toolCallCount == nil {
+			return unavailableMetric("tool call count is unavailable", metric)
+		}
+		return OutputStateAvailable, floatPtr(*evidence.toolCallCount), nil, nil, "", mustMarshalJSON(map[string]any{
+			"state":     OutputStateAvailable,
+			"collector": metric.Collector,
+		})
 	case "run_agent_tokens":
 		if evidence.totalTokens == nil {
 			return unavailableMetric("agent token usage is unavailable", metric)

--- a/backend/internal/scoring/engine_test.go
+++ b/backend/internal/scoring/engine_test.go
@@ -124,6 +124,58 @@ func TestEvaluateRunAgentCollectsToolCallCountFromRunCompleted(t *testing.T) {
 	}
 }
 
+func TestEvaluateRunAgentCollectsToolCallCountFromToolTraceFallback(t *testing.T) {
+	spec := EvaluationSpec{
+		Name:          "fixture",
+		VersionNumber: 1,
+		JudgeMode:     JudgeModeDeterministic,
+		Validators: []ValidatorDeclaration{
+			{
+				Key:          "exact",
+				Type:         ValidatorTypeExactMatch,
+				Target:       "final_output",
+				ExpectedFrom: "challenge_input",
+			},
+		},
+		Metrics: []MetricDeclaration{
+			{Key: "tool_calls", Type: MetricTypeNumeric, Collector: "run_tool_call_count"},
+		},
+		Scorecard: ScorecardDeclaration{
+			Dimensions: []DimensionDeclaration{{Key: "reliability"}},
+		},
+	}
+
+	evaluation, err := EvaluateRunAgent(EvaluationInput{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		ChallengeInputs: []EvidenceInput{
+			{
+				ChallengeIdentityID: uuid.New(),
+				ItemKey:             "expected.txt",
+				Payload:             []byte(`"done"`),
+			},
+		},
+		Events: []Event{
+			{Type: "tool.call.completed", OccurredAt: time.Date(2026, 3, 16, 9, 0, 1, 0, time.UTC), Payload: []byte(`{"tool_name":"read_file","arguments":{"path":"/workspace/a.txt"},"result":{"content":"ok"}}`)},
+			{Type: "tool.call.failed", OccurredAt: time.Date(2026, 3, 16, 9, 0, 2, 0, time.UTC), Payload: []byte(`{"tool_name":"query_sql","arguments":{"path":"/workspace/db.sqlite"},"failure_origin":"primitive","result":{"is_error":true,"content":"table missing"}}`)},
+		},
+	}, spec)
+	if err != nil {
+		t.Fatalf("EvaluateRunAgent returned error: %v", err)
+	}
+
+	if len(evaluation.MetricResults) != 1 {
+		t.Fatalf("metric count = %d, want 1", len(evaluation.MetricResults))
+	}
+	metric := evaluation.MetricResults[0]
+	if metric.State != OutputStateAvailable {
+		t.Fatalf("metric state = %s, want available; reason = %q", metric.State, metric.Reason)
+	}
+	if metric.NumericValue == nil || *metric.NumericValue != 2 {
+		t.Fatalf("tool call count = %v, want 2", metric.NumericValue)
+	}
+}
+
 func TestEvaluateRunAgentReturnsPartialWhenEvidenceIsMissing(t *testing.T) {
 	spec := EvaluationSpec{
 		Name:          "fixture",

--- a/backend/internal/scoring/engine_test.go
+++ b/backend/internal/scoring/engine_test.go
@@ -73,6 +73,57 @@ func TestEvaluateRunAgentCompletesWithDeterministicEvidence(t *testing.T) {
 	}
 }
 
+func TestEvaluateRunAgentCollectsToolCallCountFromRunCompleted(t *testing.T) {
+	spec := EvaluationSpec{
+		Name:          "fixture",
+		VersionNumber: 1,
+		JudgeMode:     JudgeModeDeterministic,
+		Validators: []ValidatorDeclaration{
+			{
+				Key:          "exact",
+				Type:         ValidatorTypeExactMatch,
+				Target:       "final_output",
+				ExpectedFrom: "challenge_input",
+			},
+		},
+		Metrics: []MetricDeclaration{
+			{Key: "tool_calls", Type: MetricTypeNumeric, Collector: "run_tool_call_count"},
+		},
+		Scorecard: ScorecardDeclaration{
+			Dimensions: []DimensionDeclaration{{Key: "reliability"}},
+		},
+	}
+
+	evaluation, err := EvaluateRunAgent(EvaluationInput{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		ChallengeInputs: []EvidenceInput{
+			{
+				ChallengeIdentityID: uuid.New(),
+				ItemKey:             "expected.txt",
+				Payload:             []byte(`"done"`),
+			},
+		},
+		Events: []Event{
+			{Type: "system.run.completed", OccurredAt: time.Date(2026, 3, 16, 9, 0, 2, 0, time.UTC), Payload: []byte(`{"final_output":"done","tool_call_count":4}`)},
+		},
+	}, spec)
+	if err != nil {
+		t.Fatalf("EvaluateRunAgent returned error: %v", err)
+	}
+
+	if len(evaluation.MetricResults) != 1 {
+		t.Fatalf("metric count = %d, want 1", len(evaluation.MetricResults))
+	}
+	metric := evaluation.MetricResults[0]
+	if metric.State != OutputStateAvailable {
+		t.Fatalf("metric state = %s, want available; reason = %q", metric.State, metric.Reason)
+	}
+	if metric.NumericValue == nil || *metric.NumericValue != 4 {
+		t.Fatalf("tool call count = %v, want 4", metric.NumericValue)
+	}
+}
+
 func TestEvaluateRunAgentReturnsPartialWhenEvidenceIsMissing(t *testing.T) {
 	spec := EvaluationSpec{
 		Name:          "fixture",

--- a/testing/codex-issue-490-tool-call-count-collector.md
+++ b/testing/codex-issue-490-tool-call-count-collector.md
@@ -1,0 +1,23 @@
+# codex/issue-490-tool-call-count-collector - Test Contract
+
+## Functional Behavior
+- Metrics with `collector: run_tool_call_count` return an available numeric value when run evidence includes `tool_call_count` on `system.run.completed`.
+- The collector does not produce `collector "run_tool_call_count" is not supported`.
+- Existing collectors such as `run_total_tokens`, `run_total_latency_ms`, and `run_completed_successfully` remain unchanged.
+- If explicit terminal `tool_call_count` is absent, the collector may fall back to observed tool-call events when available.
+
+## Unit Tests
+- `TestEvaluateRunAgentCollectsToolCallCountFromRunCompleted` - evaluates a run with `tool_call_count` in terminal evidence and records the numeric metric.
+- Existing scoring metric tests continue to pass.
+
+## Integration / Functional Tests
+- `cd backend && go test ./internal/scoring`.
+
+## Smoke Tests
+- `cd backend && go test ./internal/scoring -run TestEvaluateRunAgentCollectsToolCallCountFromRunCompleted -count=1`.
+
+## E2E Tests
+N/A - this is a deterministic scoring-engine collector fix covered by unit tests.
+
+## Manual / cURL Tests
+N/A - no API route changes; pack authors validate this by running a pack that declares `collector: run_tool_call_count` and observing an available numeric scorecard metric.

--- a/web/content/docs/challenge-packs/evaluation-spec-reference.mdx
+++ b/web/content/docs/challenge-packs/evaluation-spec-reference.mdx
@@ -52,7 +52,7 @@ Always check `requires_expected_from`: e.g., `file_exists`, `directory_structure
 
 Collectors wired today (verbatim keys):
 
-`run_total_latency_ms`, `run_ttft_ms`, `run_input_tokens`, `run_output_tokens`, `run_total_tokens`, `run_agent_tokens`, `run_race_context_tokens`, `run_model_cost_usd`, `run_completed_successfully`, `run_failure_count`, behavioral scores (`behavioral_recovery_score`, … ), `validator_pass_rate`
+`run_total_latency_ms`, `run_ttft_ms`, `run_input_tokens`, `run_output_tokens`, `run_total_tokens`, `run_agent_tokens`, `run_race_context_tokens`, `run_model_cost_usd`, `run_completed_successfully`, `run_failure_count`, `run_tool_call_count`, behavioral scores (`behavioral_recovery_score`, … ), `validator_pass_rate`
 
 Declaring a collector that does not exist will fail silently only if evidence missing—prefer copying keys from tests in `backend/internal/scoring/engine_metrics.go`.
 


### PR DESCRIPTION
## Summary
- extract tool_call_count from system.run.completed scoring evidence
- implement the run_tool_call_count metric collector
- fall back to observed tool-call events when explicit terminal evidence is absent
- add a focused scoring regression test

Fixes #490.

## Review Checkpoint
- Test contract: testing/codex-issue-490-tool-call-count-collector.md
- Contract committed before implementation in 6dcc2956

## Local Tests
- cd backend && go test ./internal/scoring -run TestEvaluateRunAgentCollectsToolCallCountFromRunCompleted -count=1
- cd backend && go test ./internal/scoring