### PR TITLE
fix(challengepack): reject mixed-challenge input sets

### DIFF
--- a/backend/internal/challengepack/bundle_test.go
+++ b/backend/internal/challengepack/bundle_test.go
@@ -2,6 +2,7 @@ package challengepack
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/agentclash/agentclash/backend/internal/scoring"
@@ -268,6 +269,78 @@ func TestValidateBundleRejectsDuplicateAssetKeys(t *testing.T) {
 	}
 	if !containsField(validationErrs, "version.assets[1].key") {
 		t.Fatalf("expected duplicate version asset key error, got %v", validationErrs)
+	}
+}
+
+func TestValidateBundleRejectsInputSetCasesAcrossMultipleChallenges(t *testing.T) {
+	err := ValidateBundle(Bundle{
+		Pack: PackMetadata{
+			Slug:   "support-eval",
+			Name:   "Support Eval",
+			Family: "support",
+		},
+		Version: VersionMetadata{
+			Number:         1,
+			EvaluationSpec: minimalSpec(),
+		},
+		Challenges: []ChallengeDefinition{
+			{Key: "ticket-1", Title: "Ticket One", Category: "support", Difficulty: "easy"},
+			{Key: "ticket-2", Title: "Ticket Two", Category: "support", Difficulty: "easy"},
+		},
+		InputSets: []InputSetDefinition{
+			{
+				Key:  "default",
+				Name: "Default",
+				Cases: []CaseDefinition{
+					{ChallengeKey: "ticket-1", CaseKey: "case-1"},
+					{ChallengeKey: "ticket-2", CaseKey: "case-2"},
+				},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("ValidateBundle returned nil error")
+	}
+
+	validationErrs, ok := err.(ValidationErrors)
+	if !ok {
+		t.Fatalf("error type = %T, want ValidationErrors", err)
+	}
+	if !containsField(validationErrs, "input_sets[0].cases[1].challenge_key") {
+		t.Fatalf("expected mixed challenge_key error, got %v", validationErrs)
+	}
+	if got := validationErrs.Error(); !strings.Contains(got, "same challenge") {
+		t.Fatalf("error = %q, want same challenge guidance", got)
+	}
+}
+
+func TestValidateBundleAllowsInputSetCasesForOneChallenge(t *testing.T) {
+	err := ValidateBundle(Bundle{
+		Pack: PackMetadata{
+			Slug:   "support-eval",
+			Name:   "Support Eval",
+			Family: "support",
+		},
+		Version: VersionMetadata{
+			Number:         1,
+			EvaluationSpec: minimalSpec(),
+		},
+		Challenges: []ChallengeDefinition{
+			{Key: "ticket-1", Title: "Ticket One", Category: "support", Difficulty: "easy"},
+		},
+		InputSets: []InputSetDefinition{
+			{
+				Key:  "default",
+				Name: "Default",
+				Cases: []CaseDefinition{
+					{ChallengeKey: "ticket-1", CaseKey: "case-1"},
+					{ChallengeKey: "ticket-1", CaseKey: "case-2"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ValidateBundle returned error: %v", err)
 	}
 }
 

--- a/backend/internal/challengepack/bundle_test.go
+++ b/backend/internal/challengepack/bundle_test.go
@@ -314,6 +314,51 @@ func TestValidateBundleRejectsInputSetCasesAcrossMultipleChallenges(t *testing.T
 	}
 }
 
+func TestValidateBundleRejectsInputSetMixedChallengesAfterMissingKey(t *testing.T) {
+	err := ValidateBundle(Bundle{
+		Pack: PackMetadata{
+			Slug:   "support-eval",
+			Name:   "Support Eval",
+			Family: "support",
+		},
+		Version: VersionMetadata{
+			Number:         1,
+			EvaluationSpec: minimalSpec(),
+		},
+		Challenges: []ChallengeDefinition{
+			{Key: "ticket-1", Title: "Ticket One", Category: "support", Difficulty: "easy"},
+			{Key: "ticket-2", Title: "Ticket Two", Category: "support", Difficulty: "easy"},
+		},
+		InputSets: []InputSetDefinition{
+			{
+				Key:  "default",
+				Name: "Default",
+				Cases: []CaseDefinition{
+					{CaseKey: "missing-challenge"},
+					{ChallengeKey: "ticket-1", CaseKey: "case-1"},
+					{ChallengeKey: "ticket-2", CaseKey: "case-2"},
+				},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("ValidateBundle returned nil error")
+	}
+
+	validationErrs, ok := err.(ValidationErrors)
+	if !ok {
+		t.Fatalf("error type = %T, want ValidationErrors", err)
+	}
+	for _, field := range []string{
+		"input_sets[0].cases[0].challenge_key",
+		"input_sets[0].cases[2].challenge_key",
+	} {
+		if !containsField(validationErrs, field) {
+			t.Fatalf("expected field %q in validation errors: %v", field, validationErrs)
+		}
+	}
+}
+
 func TestValidateBundleAllowsInputSetCasesForOneChallenge(t *testing.T) {
 	err := ValidateBundle(Bundle{
 		Pack: PackMetadata{

--- a/backend/internal/challengepack/validation.go
+++ b/backend/internal/challengepack/validation.go
@@ -130,11 +130,20 @@ func ValidateBundle(bundle Bundle) error {
 		}
 
 		caseKeys := map[string]struct{}{}
+		inputSetChallengeKey := ""
 		for caseIndex, item := range inputSet.Cases {
 			itemPath := fmt.Sprintf("%s.cases[%d]", path, caseIndex)
 			if item.ChallengeKey == "" {
 				errs = append(errs, ValidationError{Field: itemPath + ".challenge_key", Message: "is required"})
 			} else {
+				if inputSetChallengeKey == "" {
+					inputSetChallengeKey = item.ChallengeKey
+				} else if item.ChallengeKey != inputSetChallengeKey {
+					errs = append(errs, ValidationError{
+						Field:   itemPath + ".challenge_key",
+						Message: "must reference the same challenge as the other cases in this input set",
+					})
+				}
 				if _, exists := challengeKeys[item.ChallengeKey]; !exists {
 					errs = append(errs, ValidationError{Field: itemPath + ".challenge_key", Message: "must reference a declared challenge"})
 				}

--- a/testing/codex-issue-489-single-challenge-input-sets.md
+++ b/testing/codex-issue-489-single-challenge-input-sets.md
@@ -1,0 +1,23 @@
+# codex/issue-489-single-challenge-input-sets - Test Contract
+
+## Functional Behavior
+- `ValidateBundle` rejects an `input_sets[].cases[]` collection that references more than one distinct `challenge_key`.
+- The validation error is attached to the offending `input_sets[n].cases[m].challenge_key` field and explains that an input set must reference a single challenge.
+- Multiple cases for the same challenge in one input set remain valid.
+- Existing validation for missing, unknown, or duplicate case keys remains unchanged.
+
+## Unit Tests
+- `TestValidateBundleRejectsInputSetCasesAcrossMultipleChallenges` - mixed challenge keys in one input set return a validation error.
+- Existing challenge pack validation tests continue to pass.
+
+## Integration / Functional Tests
+- `cd backend && go test ./internal/challengepack`.
+
+## Smoke Tests
+- `cd backend && go test ./internal/challengepack -run TestValidateBundleRejectsInputSetCasesAcrossMultipleChallenges -count=1`.
+
+## E2E Tests
+N/A - this is a publish/validate-time schema guard covered by package tests.
+
+## Manual / cURL Tests
+N/A - no API route changes; `agentclash challenge-pack validate` will surface the same `ValidateBundle` error through existing API/CLI paths.

--- a/web/content/agent-skills/challenge-pack-skills/agentclash-challenge-pack-planner/SKILL.md
+++ b/web/content/agent-skills/challenge-pack-skills/agentclash-challenge-pack-planner/SKILL.md
@@ -42,7 +42,7 @@ Use this skill to produce the planning artifact that downstream skills can conve
    - `native` when the agent must use files, tools, sandbox policy, network, packages, artifacts, or code/file validators.
 3. Define one or more `challenges`. Each challenge should have a stable `key`, title, category, difficulty (`easy`, `medium`, `hard`, or `expert`), and instructions.
 4. Design cases before scoring. For each case, define a stable `case_key`, the `challenge_key` it targets, concrete inputs, expected outputs or expectations, and why the case exists.
-5. Group cases into `input_sets`: at minimum `smoke` or `default`; add `full`, `regression`, or `ci` only when their purpose and budget differ.
+5. Group cases into `input_sets`: at minimum `smoke` or `default`; add `full`, `regression`, or `ci` only when their purpose and budget differ. Each input set must contain cases for a single `challenge_key`; split mixed-challenge suites into separate input sets.
 6. Pick evidence sources. Decide whether success is visible in `final_output`, structured JSON, files, artifacts, tool behavior, metrics, or LLM-judge rationale.
 7. Choose scoring:
    - deterministic validators for exact, regex, JSON, numeric, token overlap, math, file, directory, or code-execution checks.

--- a/web/content/docs/challenge-packs/bundle-yaml-reference.mdx
+++ b/web/content/docs/challenge-packs/bundle-yaml-reference.mdx
@@ -69,6 +69,7 @@ Defines runnable **cases**:
 
 - **`key`** and **`name`** required on each set.
 - Prefer modern **`cases`** array. Legacy `items` aliases are normalized into `cases` during `normalizeBundle`; do not rely on `items` in new authoring.
+- All cases in a single input set must reference the same `challenge_key`; use separate input sets for separate challenges.
 
 Cases are modeled by `CaseDefinition` with `challenge_key`, `case_key`, optional rich `inputs`/`expectations`, `artifacts`, `assets`, plus legacy **`payload`** for blob-only authoring.
 

--- a/web/content/docs/challenge-packs/input-sets-and-cases.mdx
+++ b/web/content/docs/challenge-packs/input-sets-and-cases.mdx
@@ -10,6 +10,8 @@ Input sets are the unit AgentClash schedules per deployment/candidate. Each `inp
 - **`challenge_key`** — must reference an existing `challenges[].key`
 - **`case_key`** / legacy **`item_key`** — both accepted; normalization duplicates missing side from the other
 
+All cases in one `input_sets[]` entry must reference the same `challenge_key`; split mixed-challenge suites into separate input sets.
+
 `EffectiveKey()` chooses `case_key` when present for stored rows.
 
 ## Three authoring styles (coexist)

--- a/web/content/docs/guides/write-a-challenge-pack.mdx
+++ b/web/content/docs/guides/write-a-challenge-pack.mdx
@@ -72,6 +72,8 @@ input_sets:
 
 This is not a glamorous pack. It is a good pack skeleton because it matches the current parser shape.
 
+Keep every case in a single `input_sets[]` entry pointed at the same `challenge_key`. If a pack covers multiple challenges, split them into separate input sets so each run has one final-output contract to satisfy.
+
 ## 3. Add execution policy only when you need it
 
 If the pack is `native`, you can add runtime sections like `tool_policy`, `sandbox`, and `tools`.


### PR DESCRIPTION
## Summary
- reject input sets whose cases span more than one challenge_key
- keep multiple cases for the same challenge valid
- add focused validation tests for both paths

Fixes #489.

## Review Checkpoint
- Test contract: testing/codex-issue-489-single-challenge-input-sets.md
- Contract committed before implementation in 7faba767

## Local Tests
- cd backend && go test ./internal/challengepack -run 'TestValidateBundle(RejectsInputSetCasesAcrossMultipleChallenges|AllowsInputSetCasesForOneChallenge)' -count=1
- cd backend && go test ./internal/challengepack