### PR TITLE
fix: materialize artifact-backed pack assets in native sandbox

### DIFF
--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/agentclash/agentclash/backend/internal/sandbox"
 	"github.com/agentclash/agentclash/backend/internal/sandbox/e2b"
+	"github.com/agentclash/agentclash/backend/internal/storage"
 	"github.com/agentclash/agentclash/backend/internal/temporalutil"
 	workerapp "github.com/agentclash/agentclash/backend/internal/worker"
 	workflowpkg "github.com/agentclash/agentclash/backend/internal/workflow"
@@ -42,6 +43,21 @@ func main() {
 	defer temporalClient.Close()
 
 	repo := repository.New(db).WithCipher(cfg.SecretsCipher)
+
+	artifactStore, err := storage.NewStore(context.Background(), storage.Config{
+		Backend:          cfg.ArtifactStorage.Backend,
+		Bucket:           cfg.ArtifactStorage.Bucket,
+		FilesystemRoot:   cfg.ArtifactStorage.FilesystemRoot,
+		S3Region:         cfg.ArtifactStorage.S3Region,
+		S3Endpoint:       cfg.ArtifactStorage.S3Endpoint,
+		S3AccessKeyID:    cfg.ArtifactStorage.S3AccessKeyID,
+		S3SecretKey:      cfg.ArtifactStorage.S3SecretKey,
+		S3ForcePathStyle: cfg.ArtifactStorage.S3ForcePathStyle,
+	})
+	if err != nil {
+		logger.Error("failed to configure artifact storage", "error", err)
+		os.Exit(1)
+	}
 
 	// Redis event publishing (optional). The same client backs the
 	// race-context standings hash (issue #400) when Redis is available.
@@ -99,7 +115,9 @@ func main() {
 		providerRouter,
 		sandboxProvider,
 		workerapp.NewBufferedNativeObserverFactory(eventRecorder),
-	).WithSecretsLookup(repo).WithStandingsStore(standingsStore)
+	).WithSecretsLookup(repo).
+		WithAssetLoader(workerapp.NewArtifactAssetLoader(repo, artifactStore)).
+		WithStandingsStore(standingsStore)
 	promptEvalInvoker := workerapp.NewPromptEvalInvokerWithObserverFactory(
 		providerRouter,
 		workerapp.NewBufferedPromptEvalObserverFactory(eventRecorder),

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -116,7 +116,7 @@ func main() {
 		sandboxProvider,
 		workerapp.NewBufferedNativeObserverFactory(eventRecorder),
 	).WithSecretsLookup(repo).
-		WithAssetLoader(workerapp.NewArtifactAssetLoader(repo, artifactStore)).
+		WithAssetLoader(workerapp.NewArtifactAssetLoader(repo, artifactStore).WithMaxBytes(cfg.ArtifactStorage.MaxDownloadBytes)).
 		WithStandingsStore(standingsStore)
 	promptEvalInvoker := workerapp.NewPromptEvalInvokerWithObserverFactory(
 		providerRouter,

--- a/backend/internal/engine/executor_assets.go
+++ b/backend/internal/engine/executor_assets.go
@@ -1,0 +1,121 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/agentclash/agentclash/backend/internal/challengepack"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/sandbox"
+)
+
+type sandboxAssetLocation struct {
+	Field string
+	Asset challengepack.AssetReference
+}
+
+func (e NativeExecutor) stageArtifactBackedAssets(ctx context.Context, session sandbox.Session, executionContext repository.RunAgentExecutionContext) error {
+	assets, err := collectSandboxAssetLocations(executionContext)
+	if err != nil {
+		return NewFailure(StopReasonSandboxError, "decode challenge pack asset references", err)
+	}
+	if len(assets) == 0 {
+		return nil
+	}
+	if e.assetLoader == nil {
+		return NewFailure(StopReasonSandboxError, "artifact-backed challenge pack assets require an artifact loader", nil)
+	}
+
+	workspaceID := executionContext.Run.WorkspaceID
+	for _, item := range assets {
+		if item.Asset.ArtifactID == nil {
+			continue
+		}
+		if strings.TrimSpace(item.Asset.Path) == "" {
+			return NewFailure(StopReasonSandboxError, fmt.Sprintf("%s.path is required", item.Field), nil)
+		}
+
+		content, err := e.assetLoader.LoadAsset(ctx, workspaceID, *item.Asset.ArtifactID)
+		if err != nil {
+			return NewFailure(StopReasonSandboxError, fmt.Sprintf("load challenge pack asset %s", item.Field), err)
+		}
+		if err := session.UploadFile(ctx, item.Asset.Path, content.Content); err != nil {
+			return NewFailure(StopReasonSandboxError, fmt.Sprintf("upload challenge pack asset %s", item.Field), err)
+		}
+	}
+	return nil
+}
+
+func collectSandboxAssetLocations(executionContext repository.RunAgentExecutionContext) ([]sandboxAssetLocation, error) {
+	locations := make([]sandboxAssetLocation, 0)
+
+	manifestLocations, err := collectManifestAssetLocations(executionContext.ChallengePackVersion.Manifest)
+	if err != nil {
+		return nil, err
+	}
+	locations = append(locations, manifestLocations...)
+
+	if executionContext.ChallengeInputSet != nil {
+		for i, item := range executionContext.ChallengeInputSet.Cases {
+			for j, asset := range item.Assets {
+				if asset.ArtifactID == nil {
+					continue
+				}
+				locations = append(locations, sandboxAssetLocation{
+					Field: fmt.Sprintf("challenge_input_set.cases[%d].assets[%d]", i, j),
+					Asset: asset,
+				})
+			}
+		}
+	}
+
+	return locations, nil
+}
+
+func collectManifestAssetLocations(manifest json.RawMessage) ([]sandboxAssetLocation, error) {
+	if len(manifest) == 0 {
+		return nil, nil
+	}
+
+	type versionBlock struct {
+		Assets []challengepack.AssetReference `json:"assets"`
+	}
+	type challengeBlock struct {
+		Key    string                         `json:"key"`
+		Assets []challengepack.AssetReference `json:"assets"`
+	}
+	type manifestShape struct {
+		Version    versionBlock     `json:"version"`
+		Challenges []challengeBlock `json:"challenges"`
+	}
+
+	var decoded manifestShape
+	if err := json.Unmarshal(manifest, &decoded); err != nil {
+		return nil, err
+	}
+
+	locations := make([]sandboxAssetLocation, 0, len(decoded.Version.Assets))
+	for i, asset := range decoded.Version.Assets {
+		if asset.ArtifactID == nil {
+			continue
+		}
+		locations = append(locations, sandboxAssetLocation{
+			Field: fmt.Sprintf("version.assets[%d]", i),
+			Asset: asset,
+		})
+	}
+	for i, challenge := range decoded.Challenges {
+		for j, asset := range challenge.Assets {
+			if asset.ArtifactID == nil {
+				continue
+			}
+			locations = append(locations, sandboxAssetLocation{
+				Field: fmt.Sprintf("challenges[%d].assets[%d]", i, j),
+				Asset: asset,
+			})
+		}
+	}
+	return locations, nil
+}

--- a/backend/internal/engine/executor_assets_test.go
+++ b/backend/internal/engine/executor_assets_test.go
@@ -1,0 +1,161 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/challengepack"
+	"github.com/agentclash/agentclash/backend/internal/domain"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/sandbox"
+	"github.com/google/uuid"
+)
+
+func TestStageArtifactBackedAssetsUploadsManifestAndInputCaseAssets(t *testing.T) {
+	ctx := context.Background()
+	workspaceID := uuid.New()
+	versionAssetID := uuid.New()
+	challengeAssetID := uuid.New()
+	caseAssetID := uuid.New()
+
+	executionContext := repository.RunAgentExecutionContext{
+		Run: domain.Run{WorkspaceID: workspaceID},
+		ChallengePackVersion: repository.ChallengePackVersionExecutionContext{
+			Manifest: []byte(fmt.Sprintf(`{
+				"version": {
+					"assets": [
+						{"key": "global-data", "path": "/workspace/assets/global.csv", "artifact_id": %q}
+					]
+				},
+				"challenges": [
+					{
+						"key": "forecast",
+						"assets": [
+							{"key": "rubric", "path": "/workspace/assets/rubric.md", "artifact_id": %q}
+						]
+					}
+				]
+			}`, versionAssetID, challengeAssetID)),
+		},
+		ChallengeInputSet: &repository.ChallengeInputSetExecutionContext{
+			Cases: []repository.ChallengeCaseExecutionContext{
+				{
+					CaseKey: "forecast-case",
+					Assets: []challengepack.AssetReference{
+						{Key: "case-data", Path: "/workspace/cases/input.json", ArtifactID: &caseAssetID},
+					},
+				},
+			},
+		},
+	}
+
+	session := sandbox.NewFakeSession("asset-sandbox")
+	loader := fakeAssetLoader{
+		workspaceID: workspaceID,
+		content: map[uuid.UUID][]byte{
+			versionAssetID:   []byte("date,value\n2026-05-03,42\n"),
+			challengeAssetID: []byte("# Rubric\nUse the provided data.\n"),
+			caseAssetID:      []byte(`{"region":"apac"}`),
+		},
+	}
+
+	executor := NativeExecutor{}.WithAssetLoader(loader)
+	if err := executor.stageArtifactBackedAssets(ctx, session, executionContext); err != nil {
+		t.Fatalf("stageArtifactBackedAssets returned error: %v", err)
+	}
+
+	files := session.Files()
+	assertFileContent(t, files, "/workspace/assets/global.csv", "date,value\n2026-05-03,42\n")
+	assertFileContent(t, files, "/workspace/assets/rubric.md", "# Rubric\nUse the provided data.\n")
+	assertFileContent(t, files, "/workspace/cases/input.json", `{"region":"apac"}`)
+}
+
+func TestStageArtifactBackedAssetsSkipsInlineAssetsWithoutLoader(t *testing.T) {
+	executionContext := repository.RunAgentExecutionContext{
+		ChallengePackVersion: repository.ChallengePackVersionExecutionContext{
+			Manifest: []byte(`{
+				"version": {"assets": [{"key": "inline", "path": "/workspace/assets/inline.txt"}]},
+				"challenges": [{"key": "forecast", "assets": [{"key": "guide", "path": "/workspace/assets/guide.md"}]}]
+			}`),
+		},
+		ChallengeInputSet: &repository.ChallengeInputSetExecutionContext{
+			Cases: []repository.ChallengeCaseExecutionContext{
+				{
+					CaseKey: "forecast-case",
+					Assets: []challengepack.AssetReference{
+						{Key: "case-inline", Path: "/workspace/cases/inline.json"},
+					},
+				},
+			},
+		},
+	}
+
+	session := sandbox.NewFakeSession("inline-assets")
+	if err := (NativeExecutor{}).stageArtifactBackedAssets(context.Background(), session, executionContext); err != nil {
+		t.Fatalf("stageArtifactBackedAssets returned error: %v", err)
+	}
+	if files := session.Files(); len(files) != 0 {
+		t.Fatalf("uploaded files = %#v, want none", files)
+	}
+}
+
+func TestStageArtifactBackedAssetsFailsClosedWithoutLoader(t *testing.T) {
+	assetID := uuid.New()
+	executionContext := repository.RunAgentExecutionContext{
+		ChallengePackVersion: repository.ChallengePackVersionExecutionContext{
+			Manifest: []byte(fmt.Sprintf(`{
+				"version": {
+					"assets": [
+						{"key": "global-data", "path": "/workspace/assets/global.csv", "artifact_id": %q}
+					]
+				}
+			}`, assetID)),
+		},
+	}
+
+	session := sandbox.NewFakeSession("missing-loader")
+	err := (NativeExecutor{}).stageArtifactBackedAssets(context.Background(), session, executionContext)
+	if err == nil {
+		t.Fatal("stageArtifactBackedAssets returned nil error")
+	}
+	failure, ok := AsFailure(err)
+	if !ok {
+		t.Fatalf("error type = %T, want engine Failure", err)
+	}
+	if failure.StopReason != StopReasonSandboxError {
+		t.Fatalf("stop reason = %s, want sandbox_error", failure.StopReason)
+	}
+	if got := session.Files(); len(got) != 0 {
+		t.Fatalf("uploaded files = %#v, want none", got)
+	}
+}
+
+type fakeAssetLoader struct {
+	workspaceID uuid.UUID
+	content     map[uuid.UUID][]byte
+}
+
+func (l fakeAssetLoader) LoadAsset(_ context.Context, workspaceID uuid.UUID, artifactID uuid.UUID) (AssetContent, error) {
+	if workspaceID != l.workspaceID {
+		return AssetContent{}, fmt.Errorf("workspace = %s, want %s", workspaceID, l.workspaceID)
+	}
+	content, ok := l.content[artifactID]
+	if !ok {
+		return AssetContent{}, errors.New("asset not found")
+	}
+	return AssetContent{Content: append([]byte(nil), content...)}, nil
+}
+
+func assertFileContent(t *testing.T, files map[string][]byte, path string, want string) {
+	t.Helper()
+
+	got, ok := files[path]
+	if !ok {
+		t.Fatalf("file %s was not uploaded; files=%#v", path, files)
+	}
+	if string(got) != want {
+		t.Fatalf("file %s = %q, want %q", path, string(got), want)
+	}
+}

--- a/backend/internal/engine/executor_sandbox.go
+++ b/backend/internal/engine/executor_sandbox.go
@@ -30,6 +30,9 @@ func (e NativeExecutor) prepareSandbox(ctx context.Context, executionContext rep
 	if err := stageSandboxInputs(ctx, session, executionContext); err != nil {
 		return nil, cleanupSandboxOnError(session, err)
 	}
+	if err := e.stageArtifactBackedAssets(ctx, session, executionContext); err != nil {
+		return nil, cleanupSandboxOnError(session, err)
+	}
 	return session, nil
 }
 

--- a/backend/internal/engine/native_executor.go
+++ b/backend/internal/engine/native_executor.go
@@ -145,11 +145,24 @@ type SecretsLookup interface {
 	LoadWorkspaceSecrets(ctx context.Context, workspaceID uuid.UUID) (map[string]string, error)
 }
 
+type AssetContent struct {
+	Content     []byte
+	ContentType string
+}
+
+// AssetLoader resolves artifact-backed challenge-pack assets before the
+// native sandbox starts executing. *worker.ArtifactAssetLoader is the
+// production implementation; tests can substitute an in-memory fake.
+type AssetLoader interface {
+	LoadAsset(ctx context.Context, workspaceID uuid.UUID, artifactID uuid.UUID) (AssetContent, error)
+}
+
 type NativeExecutor struct {
 	client              provider.Client
 	sandboxProvider     sandbox.Provider
 	observer            Observer
 	secretsLookup       SecretsLookup
+	assetLoader         AssetLoader
 	standingsStore      racecontext.Store
 	maxRetryAttempts    int
 	initialRetryBackoff time.Duration
@@ -184,6 +197,14 @@ func (e NativeExecutor) WithStandingsStore(store racecontext.Store) NativeExecut
 // secrets path.
 func (e NativeExecutor) WithSecretsLookup(lookup SecretsLookup) NativeExecutor {
 	e.secretsLookup = lookup
+	return e
+}
+
+// WithAssetLoader attaches artifact storage for challenge-pack assets declared
+// with artifact_id. Executors without a loader fail closed when such assets are
+// present, because otherwise the pack would start without its promised data.
+func (e NativeExecutor) WithAssetLoader(loader AssetLoader) NativeExecutor {
+	e.assetLoader = loader
 	return e
 }
 

--- a/backend/internal/worker/artifact_asset_loader.go
+++ b/backend/internal/worker/artifact_asset_loader.go
@@ -2,9 +2,12 @@ package worker
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/agentclash/agentclash/backend/internal/engine"
 	"github.com/agentclash/agentclash/backend/internal/repository"
@@ -12,17 +15,27 @@ import (
 	"github.com/google/uuid"
 )
 
+const defaultArtifactAssetMaxBytes int64 = 100 << 20
+
 type ArtifactRepository interface {
 	GetArtifactByID(ctx context.Context, artifactID uuid.UUID) (repository.Artifact, error)
 }
 
 type ArtifactAssetLoader struct {
-	repo  ArtifactRepository
-	store storage.Store
+	repo     ArtifactRepository
+	store    storage.Store
+	maxBytes int64
 }
 
 func NewArtifactAssetLoader(repo ArtifactRepository, store storage.Store) ArtifactAssetLoader {
-	return ArtifactAssetLoader{repo: repo, store: store}
+	return ArtifactAssetLoader{repo: repo, store: store, maxBytes: defaultArtifactAssetMaxBytes}
+}
+
+func (l ArtifactAssetLoader) WithMaxBytes(maxBytes int64) ArtifactAssetLoader {
+	if maxBytes > 0 {
+		l.maxBytes = maxBytes
+	}
+	return l
 }
 
 func (l ArtifactAssetLoader) LoadAsset(ctx context.Context, workspaceID uuid.UUID, artifactID uuid.UUID) (engine.AssetContent, error) {
@@ -43,16 +56,29 @@ func (l ArtifactAssetLoader) LoadAsset(ctx context.Context, workspaceID uuid.UUI
 	if artifact.StorageBucket != "" && artifact.StorageBucket != l.store.Bucket() {
 		return engine.AssetContent{}, fmt.Errorf("artifact %s is stored in bucket %q, worker is configured for %q", artifactID, artifact.StorageBucket, l.store.Bucket())
 	}
+	maxBytes := l.effectiveMaxBytes()
+	if artifact.SizeBytes != nil && *artifact.SizeBytes > maxBytes {
+		return engine.AssetContent{}, fmt.Errorf("artifact %s is %d bytes, above sandbox asset limit %d", artifactID, *artifact.SizeBytes, maxBytes)
+	}
 
 	reader, metadata, err := l.store.OpenObject(ctx, artifact.StorageKey)
 	if err != nil {
 		return engine.AssetContent{}, fmt.Errorf("open artifact object %q: %w", artifact.StorageKey, err)
 	}
 	defer reader.Close()
+	if metadata.SizeBytes > maxBytes {
+		return engine.AssetContent{}, fmt.Errorf("artifact object %q is %d bytes, above sandbox asset limit %d", artifact.StorageKey, metadata.SizeBytes, maxBytes)
+	}
 
-	content, err := io.ReadAll(reader)
+	content, err := io.ReadAll(io.LimitReader(reader, maxBytes+1))
 	if err != nil {
 		return engine.AssetContent{}, fmt.Errorf("read artifact object %q: %w", artifact.StorageKey, err)
+	}
+	if int64(len(content)) > maxBytes {
+		return engine.AssetContent{}, fmt.Errorf("artifact object %q exceeded sandbox asset limit %d", artifact.StorageKey, maxBytes)
+	}
+	if err := verifyArtifactChecksum(artifact, content); err != nil {
+		return engine.AssetContent{}, err
 	}
 
 	contentType := metadata.ContentType
@@ -64,4 +90,24 @@ func (l ArtifactAssetLoader) LoadAsset(ctx context.Context, workspaceID uuid.UUI
 		Content:     content,
 		ContentType: contentType,
 	}, nil
+}
+
+func (l ArtifactAssetLoader) effectiveMaxBytes() int64 {
+	if l.maxBytes <= 0 {
+		return defaultArtifactAssetMaxBytes
+	}
+	return l.maxBytes
+}
+
+func verifyArtifactChecksum(artifact repository.Artifact, content []byte) error {
+	if artifact.ChecksumSHA256 == nil || strings.TrimSpace(*artifact.ChecksumSHA256) == "" {
+		return nil
+	}
+	sum := sha256.Sum256(content)
+	got := hex.EncodeToString(sum[:])
+	want := strings.TrimSpace(*artifact.ChecksumSHA256)
+	if !strings.EqualFold(got, want) {
+		return fmt.Errorf("artifact %s checksum mismatch: got %s, want %s", artifact.ID, got, want)
+	}
+	return nil
 }

--- a/backend/internal/worker/artifact_asset_loader.go
+++ b/backend/internal/worker/artifact_asset_loader.go
@@ -1,0 +1,67 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/agentclash/agentclash/backend/internal/engine"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/storage"
+	"github.com/google/uuid"
+)
+
+type ArtifactRepository interface {
+	GetArtifactByID(ctx context.Context, artifactID uuid.UUID) (repository.Artifact, error)
+}
+
+type ArtifactAssetLoader struct {
+	repo  ArtifactRepository
+	store storage.Store
+}
+
+func NewArtifactAssetLoader(repo ArtifactRepository, store storage.Store) ArtifactAssetLoader {
+	return ArtifactAssetLoader{repo: repo, store: store}
+}
+
+func (l ArtifactAssetLoader) LoadAsset(ctx context.Context, workspaceID uuid.UUID, artifactID uuid.UUID) (engine.AssetContent, error) {
+	if l.repo == nil {
+		return engine.AssetContent{}, errors.New("artifact repository is not configured")
+	}
+	if l.store == nil {
+		return engine.AssetContent{}, errors.New("artifact storage is not configured")
+	}
+
+	artifact, err := l.repo.GetArtifactByID(ctx, artifactID)
+	if err != nil {
+		return engine.AssetContent{}, fmt.Errorf("get artifact %s: %w", artifactID, err)
+	}
+	if artifact.WorkspaceID != workspaceID {
+		return engine.AssetContent{}, fmt.Errorf("artifact %s belongs to workspace %s, not %s", artifactID, artifact.WorkspaceID, workspaceID)
+	}
+	if artifact.StorageBucket != "" && artifact.StorageBucket != l.store.Bucket() {
+		return engine.AssetContent{}, fmt.Errorf("artifact %s is stored in bucket %q, worker is configured for %q", artifactID, artifact.StorageBucket, l.store.Bucket())
+	}
+
+	reader, metadata, err := l.store.OpenObject(ctx, artifact.StorageKey)
+	if err != nil {
+		return engine.AssetContent{}, fmt.Errorf("open artifact object %q: %w", artifact.StorageKey, err)
+	}
+	defer reader.Close()
+
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		return engine.AssetContent{}, fmt.Errorf("read artifact object %q: %w", artifact.StorageKey, err)
+	}
+
+	contentType := metadata.ContentType
+	if artifact.ContentType != nil && *artifact.ContentType != "" {
+		contentType = *artifact.ContentType
+	}
+
+	return engine.AssetContent{
+		Content:     content,
+		ContentType: contentType,
+	}, nil
+}

--- a/backend/internal/worker/artifact_asset_loader_test.go
+++ b/backend/internal/worker/artifact_asset_loader_test.go
@@ -1,0 +1,118 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/storage"
+	"github.com/google/uuid"
+)
+
+func TestArtifactAssetLoaderReadsWorkspaceArtifactFromStorage(t *testing.T) {
+	workspaceID := uuid.New()
+	artifactID := uuid.New()
+	contentType := "text/csv"
+	repo := fakeArtifactRepository{
+		artifacts: map[uuid.UUID]repository.Artifact{
+			artifactID: {
+				ID:            artifactID,
+				WorkspaceID:   workspaceID,
+				StorageBucket: "asset-bucket",
+				StorageKey:    "workspaces/ws/assets/data.csv",
+				ContentType:   &contentType,
+			},
+		},
+	}
+	store := fakeArtifactStorage{
+		bucket: "asset-bucket",
+		objects: map[string]fakeStoredObject{
+			"workspaces/ws/assets/data.csv": {
+				content:     []byte("name,value\nalpha,1\n"),
+				contentType: "application/octet-stream",
+			},
+		},
+	}
+
+	got, err := NewArtifactAssetLoader(repo, store).LoadAsset(context.Background(), workspaceID, artifactID)
+	if err != nil {
+		t.Fatalf("LoadAsset returned error: %v", err)
+	}
+	if string(got.Content) != "name,value\nalpha,1\n" {
+		t.Fatalf("content = %q, want storage bytes", string(got.Content))
+	}
+	if got.ContentType != contentType {
+		t.Fatalf("content type = %q, want %q", got.ContentType, contentType)
+	}
+}
+
+func TestArtifactAssetLoaderRejectsCrossWorkspaceArtifact(t *testing.T) {
+	requestWorkspaceID := uuid.New()
+	artifactWorkspaceID := uuid.New()
+	artifactID := uuid.New()
+	repo := fakeArtifactRepository{
+		artifacts: map[uuid.UUID]repository.Artifact{
+			artifactID: {
+				ID:            artifactID,
+				WorkspaceID:   artifactWorkspaceID,
+				StorageBucket: "asset-bucket",
+				StorageKey:    "workspaces/other/assets/data.csv",
+			},
+		},
+	}
+	store := fakeArtifactStorage{bucket: "asset-bucket"}
+
+	if _, err := NewArtifactAssetLoader(repo, store).LoadAsset(context.Background(), requestWorkspaceID, artifactID); err == nil {
+		t.Fatal("LoadAsset returned nil error")
+	}
+}
+
+type fakeArtifactRepository struct {
+	artifacts map[uuid.UUID]repository.Artifact
+}
+
+func (r fakeArtifactRepository) GetArtifactByID(_ context.Context, artifactID uuid.UUID) (repository.Artifact, error) {
+	artifact, ok := r.artifacts[artifactID]
+	if !ok {
+		return repository.Artifact{}, repository.ErrArtifactNotFound
+	}
+	return artifact, nil
+}
+
+type fakeStoredObject struct {
+	content     []byte
+	contentType string
+}
+
+type fakeArtifactStorage struct {
+	bucket  string
+	objects map[string]fakeStoredObject
+}
+
+func (s fakeArtifactStorage) Bucket() string {
+	return s.bucket
+}
+
+func (s fakeArtifactStorage) PutObject(context.Context, storage.PutObjectInput) (storage.ObjectMetadata, error) {
+	return storage.ObjectMetadata{}, errors.New("not implemented")
+}
+
+func (s fakeArtifactStorage) OpenObject(_ context.Context, key string) (io.ReadCloser, storage.ObjectMetadata, error) {
+	object, ok := s.objects[key]
+	if !ok {
+		return nil, storage.ObjectMetadata{}, storage.ErrObjectNotFound
+	}
+	return io.NopCloser(bytes.NewReader(object.content)), storage.ObjectMetadata{
+		Bucket:      s.bucket,
+		Key:         key,
+		SizeBytes:   int64(len(object.content)),
+		ContentType: object.contentType,
+	}, nil
+}
+
+func (s fakeArtifactStorage) DeleteObject(context.Context, string) error {
+	return errors.New("not implemented")
+}

--- a/backend/internal/worker/artifact_asset_loader_test.go
+++ b/backend/internal/worker/artifact_asset_loader_test.go
@@ -3,8 +3,11 @@ package worker
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/agentclash/agentclash/backend/internal/repository"
@@ -16,14 +19,19 @@ func TestArtifactAssetLoaderReadsWorkspaceArtifactFromStorage(t *testing.T) {
 	workspaceID := uuid.New()
 	artifactID := uuid.New()
 	contentType := "text/csv"
+	content := []byte("name,value\nalpha,1\n")
+	checksum := sha256Hex(content)
+	sizeBytes := int64(len(content))
 	repo := fakeArtifactRepository{
 		artifacts: map[uuid.UUID]repository.Artifact{
 			artifactID: {
-				ID:            artifactID,
-				WorkspaceID:   workspaceID,
-				StorageBucket: "asset-bucket",
-				StorageKey:    "workspaces/ws/assets/data.csv",
-				ContentType:   &contentType,
+				ID:             artifactID,
+				WorkspaceID:    workspaceID,
+				StorageBucket:  "asset-bucket",
+				StorageKey:     "workspaces/ws/assets/data.csv",
+				ContentType:    &contentType,
+				SizeBytes:      &sizeBytes,
+				ChecksumSHA256: &checksum,
 			},
 		},
 	}
@@ -31,7 +39,7 @@ func TestArtifactAssetLoaderReadsWorkspaceArtifactFromStorage(t *testing.T) {
 		bucket: "asset-bucket",
 		objects: map[string]fakeStoredObject{
 			"workspaces/ws/assets/data.csv": {
-				content:     []byte("name,value\nalpha,1\n"),
+				content:     content,
 				contentType: "application/octet-stream",
 			},
 		},
@@ -63,10 +71,108 @@ func TestArtifactAssetLoaderRejectsCrossWorkspaceArtifact(t *testing.T) {
 			},
 		},
 	}
-	store := fakeArtifactStorage{bucket: "asset-bucket"}
+	openCalls := 0
+	store := fakeArtifactStorage{bucket: "asset-bucket", openCalls: &openCalls}
 
 	if _, err := NewArtifactAssetLoader(repo, store).LoadAsset(context.Background(), requestWorkspaceID, artifactID); err == nil {
 		t.Fatal("LoadAsset returned nil error")
+	}
+}
+
+func TestArtifactAssetLoaderRejectsArtifactAboveLimitBeforeOpeningStorage(t *testing.T) {
+	workspaceID := uuid.New()
+	artifactID := uuid.New()
+	sizeBytes := int64(11)
+	repo := fakeArtifactRepository{
+		artifacts: map[uuid.UUID]repository.Artifact{
+			artifactID: {
+				ID:            artifactID,
+				WorkspaceID:   workspaceID,
+				StorageBucket: "asset-bucket",
+				StorageKey:    "workspaces/ws/assets/large.bin",
+				SizeBytes:     &sizeBytes,
+			},
+		},
+	}
+	openCalls := 0
+	store := fakeArtifactStorage{bucket: "asset-bucket", openCalls: &openCalls}
+
+	_, err := NewArtifactAssetLoader(repo, store).WithMaxBytes(10).LoadAsset(context.Background(), workspaceID, artifactID)
+	if err == nil {
+		t.Fatal("LoadAsset returned nil error")
+	}
+	if !strings.Contains(err.Error(), "above sandbox asset limit") {
+		t.Fatalf("error = %v, want size limit", err)
+	}
+	if openCalls != 0 {
+		t.Fatalf("OpenObject calls = %d, want 0", openCalls)
+	}
+}
+
+func TestArtifactAssetLoaderRejectsObjectStreamAboveLimit(t *testing.T) {
+	workspaceID := uuid.New()
+	artifactID := uuid.New()
+	sizeBytes := int64(10)
+	repo := fakeArtifactRepository{
+		artifacts: map[uuid.UUID]repository.Artifact{
+			artifactID: {
+				ID:            artifactID,
+				WorkspaceID:   workspaceID,
+				StorageBucket: "asset-bucket",
+				StorageKey:    "workspaces/ws/assets/large.bin",
+				SizeBytes:     &sizeBytes,
+			},
+		},
+	}
+	store := fakeArtifactStorage{
+		bucket: "asset-bucket",
+		objects: map[string]fakeStoredObject{
+			"workspaces/ws/assets/large.bin": {
+				content:   []byte("01234567890"),
+				sizeBytes: 10,
+			},
+		},
+	}
+
+	_, err := NewArtifactAssetLoader(repo, store).WithMaxBytes(10).LoadAsset(context.Background(), workspaceID, artifactID)
+	if err == nil {
+		t.Fatal("LoadAsset returned nil error")
+	}
+	if !strings.Contains(err.Error(), "exceeded sandbox asset limit") {
+		t.Fatalf("error = %v, want stream size limit", err)
+	}
+}
+
+func TestArtifactAssetLoaderRejectsChecksumMismatch(t *testing.T) {
+	workspaceID := uuid.New()
+	artifactID := uuid.New()
+	badChecksum := sha256Hex([]byte("different content"))
+	repo := fakeArtifactRepository{
+		artifacts: map[uuid.UUID]repository.Artifact{
+			artifactID: {
+				ID:             artifactID,
+				WorkspaceID:    workspaceID,
+				StorageBucket:  "asset-bucket",
+				StorageKey:     "workspaces/ws/assets/data.csv",
+				ChecksumSHA256: &badChecksum,
+			},
+		},
+	}
+	store := fakeArtifactStorage{
+		bucket: "asset-bucket",
+		objects: map[string]fakeStoredObject{
+			"workspaces/ws/assets/data.csv": {
+				content: []byte("name,value\nalpha,1\n"),
+			},
+		},
+	}
+
+	_, err := NewArtifactAssetLoader(repo, store).LoadAsset(context.Background(), workspaceID, artifactID)
+	if err == nil {
+		t.Fatal("LoadAsset returned nil error")
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("error = %v, want checksum mismatch", err)
 	}
 }
 
@@ -85,11 +191,13 @@ func (r fakeArtifactRepository) GetArtifactByID(_ context.Context, artifactID uu
 type fakeStoredObject struct {
 	content     []byte
 	contentType string
+	sizeBytes   int64
 }
 
 type fakeArtifactStorage struct {
-	bucket  string
-	objects map[string]fakeStoredObject
+	bucket    string
+	objects   map[string]fakeStoredObject
+	openCalls *int
 }
 
 func (s fakeArtifactStorage) Bucket() string {
@@ -101,18 +209,30 @@ func (s fakeArtifactStorage) PutObject(context.Context, storage.PutObjectInput) 
 }
 
 func (s fakeArtifactStorage) OpenObject(_ context.Context, key string) (io.ReadCloser, storage.ObjectMetadata, error) {
+	if s.openCalls != nil {
+		(*s.openCalls)++
+	}
 	object, ok := s.objects[key]
 	if !ok {
 		return nil, storage.ObjectMetadata{}, storage.ErrObjectNotFound
 	}
+	sizeBytes := object.sizeBytes
+	if sizeBytes == 0 {
+		sizeBytes = int64(len(object.content))
+	}
 	return io.NopCloser(bytes.NewReader(object.content)), storage.ObjectMetadata{
 		Bucket:      s.bucket,
 		Key:         key,
-		SizeBytes:   int64(len(object.content)),
+		SizeBytes:   sizeBytes,
 		ContentType: object.contentType,
 	}, nil
 }
 
 func (s fakeArtifactStorage) DeleteObject(context.Context, string) error {
 	return errors.New("not implemented")
+}
+
+func sha256Hex(content []byte) string {
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])
 }

--- a/backend/internal/worker/config.go
+++ b/backend/internal/worker/config.go
@@ -25,6 +25,7 @@ const (
 	defaultHostedCallbackSecret   = "agentclash-dev-hosted-callback-secret"
 	defaultArtifactStorageBackend = "filesystem"
 	defaultArtifactStorageBucket  = "agentclash-dev-artifacts"
+	defaultArtifactMaxAssetBytes  = 100 << 20
 )
 
 var ErrInvalidConfig = errors.New("invalid worker config")
@@ -55,6 +56,7 @@ type ArtifactStorageConfig struct {
 	S3AccessKeyID    string
 	S3SecretKey      string
 	S3ForcePathStyle bool
+	MaxDownloadBytes int64
 }
 
 type SandboxConfig struct {
@@ -139,6 +141,10 @@ func LoadConfigFromEnv() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	artifactMaxDownloadBytes, err := int64EnvOrDefault("ARTIFACT_SANDBOX_ASSET_MAX_BYTES", defaultArtifactMaxAssetBytes)
+	if err != nil {
+		return Config{}, err
+	}
 	if sandboxProvider != "unconfigured" && sandboxProvider != "e2b" {
 		return Config{}, fmt.Errorf("%w: SANDBOX_PROVIDER must be one of unconfigured or e2b", ErrInvalidConfig)
 	}
@@ -177,6 +183,7 @@ func LoadConfigFromEnv() (Config, error) {
 			S3AccessKeyID:    os.Getenv("ARTIFACT_STORAGE_S3_ACCESS_KEY_ID"),
 			S3SecretKey:      os.Getenv("ARTIFACT_STORAGE_S3_SECRET_ACCESS_KEY"),
 			S3ForcePathStyle: artifactS3ForcePathStyle,
+			MaxDownloadBytes: artifactMaxDownloadBytes,
 		},
 		Sandbox: SandboxConfig{
 			Provider: sandboxProvider,
@@ -249,6 +256,24 @@ func optionalInt64Env(key string) (int64, error) {
 	value := strings.TrimSpace(os.Getenv(key))
 	if value == "" {
 		return 0, nil
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %s must be an integer", ErrInvalidConfig, key)
+	}
+	if parsed <= 0 {
+		return 0, fmt.Errorf("%w: %s must be greater than zero", ErrInvalidConfig, key)
+	}
+	return parsed, nil
+}
+
+func int64EnvOrDefault(key string, fallback int64) (int64, error) {
+	value, ok := os.LookupEnv(key)
+	if !ok {
+		return fallback, nil
+	}
+	if value == "" {
+		return 0, fmt.Errorf("%w: %s cannot be empty", ErrInvalidConfig, key)
 	}
 	parsed, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {

--- a/backend/internal/worker/config.go
+++ b/backend/internal/worker/config.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -15,13 +16,15 @@ import (
 )
 
 const (
-	defaultDatabaseURL           = "postgres://agentclash:agentclash@localhost:5432/agentclash?sslmode=disable"
-	defaultTemporalTarget        = "localhost:7233"
-	defaultNamespace             = "default"
-	defaultAppEnvironment        = "development"
-	defaultShutdownTime          = 10 * time.Second
-	defaultHostedCallbackBaseURL = "http://localhost:8080"
-	defaultHostedCallbackSecret  = "agentclash-dev-hosted-callback-secret"
+	defaultDatabaseURL            = "postgres://agentclash:agentclash@localhost:5432/agentclash?sslmode=disable"
+	defaultTemporalTarget         = "localhost:7233"
+	defaultNamespace              = "default"
+	defaultAppEnvironment         = "development"
+	defaultShutdownTime           = 10 * time.Second
+	defaultHostedCallbackBaseURL  = "http://localhost:8080"
+	defaultHostedCallbackSecret   = "agentclash-dev-hosted-callback-secret"
+	defaultArtifactStorageBackend = "filesystem"
+	defaultArtifactStorageBucket  = "agentclash-dev-artifacts"
 )
 
 var ErrInvalidConfig = errors.New("invalid worker config")
@@ -38,8 +41,20 @@ type Config struct {
 	GitHubAppID           int64
 	GitHubAppPrivateKey   string
 	ShutdownTimeout       time.Duration
+	ArtifactStorage       ArtifactStorageConfig
 	Sandbox               SandboxConfig
 	SecretsCipher         *secrets.AESGCMCipher
+}
+
+type ArtifactStorageConfig struct {
+	Backend          string
+	Bucket           string
+	FilesystemRoot   string
+	S3Region         string
+	S3Endpoint       string
+	S3AccessKeyID    string
+	S3SecretKey      string
+	S3ForcePathStyle bool
 }
 
 type SandboxConfig struct {
@@ -108,6 +123,22 @@ func LoadConfigFromEnv() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	artifactStorageBackend, err := envOrDefault("ARTIFACT_STORAGE_BACKEND", defaultArtifactStorageBackend)
+	if err != nil {
+		return Config{}, err
+	}
+	artifactStorageBucket, err := envOrDefault("ARTIFACT_STORAGE_BUCKET", defaultArtifactStorageBucket)
+	if err != nil {
+		return Config{}, err
+	}
+	artifactFilesystemRoot, err := envOrDefault("ARTIFACT_STORAGE_FILESYSTEM_ROOT", filepath.Join(os.TempDir(), "agentclash-artifacts"))
+	if err != nil {
+		return Config{}, err
+	}
+	artifactS3ForcePathStyle, err := boolEnvOrDefault("ARTIFACT_STORAGE_S3_FORCE_PATH_STYLE", true)
+	if err != nil {
+		return Config{}, err
+	}
 	if sandboxProvider != "unconfigured" && sandboxProvider != "e2b" {
 		return Config{}, fmt.Errorf("%w: SANDBOX_PROVIDER must be one of unconfigured or e2b", ErrInvalidConfig)
 	}
@@ -137,6 +168,16 @@ func LoadConfigFromEnv() (Config, error) {
 		GitHubAppID:           githubAppID,
 		GitHubAppPrivateKey:   normalizePEMEnv(os.Getenv("GITHUB_APP_PRIVATE_KEY")),
 		ShutdownTimeout:       shutdownTimeout,
+		ArtifactStorage: ArtifactStorageConfig{
+			Backend:          artifactStorageBackend,
+			Bucket:           artifactStorageBucket,
+			FilesystemRoot:   artifactFilesystemRoot,
+			S3Region:         os.Getenv("ARTIFACT_STORAGE_S3_REGION"),
+			S3Endpoint:       os.Getenv("ARTIFACT_STORAGE_S3_ENDPOINT"),
+			S3AccessKeyID:    os.Getenv("ARTIFACT_STORAGE_S3_ACCESS_KEY_ID"),
+			S3SecretKey:      os.Getenv("ARTIFACT_STORAGE_S3_SECRET_ACCESS_KEY"),
+			S3ForcePathStyle: artifactS3ForcePathStyle,
+		},
 		Sandbox: SandboxConfig{
 			Provider: sandboxProvider,
 			E2B: E2BConfig{
@@ -215,6 +256,22 @@ func optionalInt64Env(key string) (int64, error) {
 	}
 	if parsed <= 0 {
 		return 0, fmt.Errorf("%w: %s must be greater than zero", ErrInvalidConfig, key)
+	}
+	return parsed, nil
+}
+
+func boolEnvOrDefault(key string, fallback bool) (bool, error) {
+	value, ok := os.LookupEnv(key)
+	if !ok {
+		return fallback, nil
+	}
+	if value == "" {
+		return false, fmt.Errorf("%w: %s cannot be empty", ErrInvalidConfig, key)
+	}
+
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, fmt.Errorf("%w: %s must be a boolean", ErrInvalidConfig, key)
 	}
 	return parsed, nil
 }

--- a/backend/internal/worker/config_test.go
+++ b/backend/internal/worker/config_test.go
@@ -24,6 +24,14 @@ func TestLoadConfigFromEnvUsesDefaultsWhenUnset(t *testing.T) {
 	unsetEnv(t, "AGENTCLASH_SECRETS_MASTER_KEY")
 	unsetEnv(t, "GITHUB_APP_ID")
 	unsetEnv(t, "GITHUB_APP_PRIVATE_KEY")
+	unsetEnv(t, "ARTIFACT_STORAGE_BACKEND")
+	unsetEnv(t, "ARTIFACT_STORAGE_BUCKET")
+	unsetEnv(t, "ARTIFACT_STORAGE_FILESYSTEM_ROOT")
+	unsetEnv(t, "ARTIFACT_STORAGE_S3_REGION")
+	unsetEnv(t, "ARTIFACT_STORAGE_S3_ENDPOINT")
+	unsetEnv(t, "ARTIFACT_STORAGE_S3_ACCESS_KEY_ID")
+	unsetEnv(t, "ARTIFACT_STORAGE_S3_SECRET_ACCESS_KEY")
+	unsetEnv(t, "ARTIFACT_STORAGE_S3_FORCE_PATH_STYLE")
 
 	cfg, err := LoadConfigFromEnv()
 	if err != nil {
@@ -53,6 +61,18 @@ func TestLoadConfigFromEnvUsesDefaultsWhenUnset(t *testing.T) {
 	}
 	if cfg.GitHubAppID != 0 || cfg.GitHubAppPrivateKey != "" {
 		t.Fatalf("github app config = %d/%q, want empty", cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
+	}
+	if cfg.ArtifactStorage.Backend != defaultArtifactStorageBackend {
+		t.Fatalf("ArtifactStorage.Backend = %q, want %q", cfg.ArtifactStorage.Backend, defaultArtifactStorageBackend)
+	}
+	if cfg.ArtifactStorage.Bucket != defaultArtifactStorageBucket {
+		t.Fatalf("ArtifactStorage.Bucket = %q, want %q", cfg.ArtifactStorage.Bucket, defaultArtifactStorageBucket)
+	}
+	if cfg.ArtifactStorage.FilesystemRoot == "" {
+		t.Fatalf("ArtifactStorage.FilesystemRoot was empty")
+	}
+	if !cfg.ArtifactStorage.S3ForcePathStyle {
+		t.Fatalf("ArtifactStorage.S3ForcePathStyle = false, want true")
 	}
 }
 
@@ -98,6 +118,14 @@ func TestLoadConfigFromEnvOverrides(t *testing.T) {
 	t.Setenv("E2B_REQUEST_TIMEOUT", "45s")
 	t.Setenv("GITHUB_APP_ID", "123")
 	t.Setenv("GITHUB_APP_PRIVATE_KEY", "-----BEGIN KEY-----\\nabc\\n-----END KEY-----")
+	t.Setenv("ARTIFACT_STORAGE_BACKEND", "s3")
+	t.Setenv("ARTIFACT_STORAGE_BUCKET", "prod-assets")
+	t.Setenv("ARTIFACT_STORAGE_FILESYSTEM_ROOT", "/var/lib/agentclash-artifacts")
+	t.Setenv("ARTIFACT_STORAGE_S3_REGION", "ap-south-1")
+	t.Setenv("ARTIFACT_STORAGE_S3_ENDPOINT", "https://s3.example.com")
+	t.Setenv("ARTIFACT_STORAGE_S3_ACCESS_KEY_ID", "access-key")
+	t.Setenv("ARTIFACT_STORAGE_S3_SECRET_ACCESS_KEY", "secret-key")
+	t.Setenv("ARTIFACT_STORAGE_S3_FORCE_PATH_STYLE", "false")
 
 	cfg, err := LoadConfigFromEnv()
 	if err != nil {
@@ -133,6 +161,24 @@ func TestLoadConfigFromEnvOverrides(t *testing.T) {
 	}
 	if cfg.GitHubAppPrivateKey != "-----BEGIN KEY-----\nabc\n-----END KEY-----" {
 		t.Fatalf("GitHubAppPrivateKey was not normalized")
+	}
+	if cfg.ArtifactStorage.Backend != "s3" {
+		t.Fatalf("ArtifactStorage.Backend = %q, want s3", cfg.ArtifactStorage.Backend)
+	}
+	if cfg.ArtifactStorage.Bucket != "prod-assets" {
+		t.Fatalf("ArtifactStorage.Bucket = %q, want prod-assets", cfg.ArtifactStorage.Bucket)
+	}
+	if cfg.ArtifactStorage.FilesystemRoot != "/var/lib/agentclash-artifacts" {
+		t.Fatalf("ArtifactStorage.FilesystemRoot = %q, want override", cfg.ArtifactStorage.FilesystemRoot)
+	}
+	if cfg.ArtifactStorage.S3Region != "ap-south-1" || cfg.ArtifactStorage.S3Endpoint != "https://s3.example.com" {
+		t.Fatalf("S3 endpoint config = %q/%q, want overrides", cfg.ArtifactStorage.S3Region, cfg.ArtifactStorage.S3Endpoint)
+	}
+	if cfg.ArtifactStorage.S3AccessKeyID != "access-key" || cfg.ArtifactStorage.S3SecretKey != "secret-key" {
+		t.Fatalf("S3 credentials were not loaded")
+	}
+	if cfg.ArtifactStorage.S3ForcePathStyle {
+		t.Fatalf("ArtifactStorage.S3ForcePathStyle = true, want false")
 	}
 }
 

--- a/backend/internal/worker/config_test.go
+++ b/backend/internal/worker/config_test.go
@@ -32,6 +32,7 @@ func TestLoadConfigFromEnvUsesDefaultsWhenUnset(t *testing.T) {
 	unsetEnv(t, "ARTIFACT_STORAGE_S3_ACCESS_KEY_ID")
 	unsetEnv(t, "ARTIFACT_STORAGE_S3_SECRET_ACCESS_KEY")
 	unsetEnv(t, "ARTIFACT_STORAGE_S3_FORCE_PATH_STYLE")
+	unsetEnv(t, "ARTIFACT_SANDBOX_ASSET_MAX_BYTES")
 
 	cfg, err := LoadConfigFromEnv()
 	if err != nil {
@@ -73,6 +74,9 @@ func TestLoadConfigFromEnvUsesDefaultsWhenUnset(t *testing.T) {
 	}
 	if !cfg.ArtifactStorage.S3ForcePathStyle {
 		t.Fatalf("ArtifactStorage.S3ForcePathStyle = false, want true")
+	}
+	if cfg.ArtifactStorage.MaxDownloadBytes != defaultArtifactMaxAssetBytes {
+		t.Fatalf("ArtifactStorage.MaxDownloadBytes = %d, want %d", cfg.ArtifactStorage.MaxDownloadBytes, defaultArtifactMaxAssetBytes)
 	}
 }
 
@@ -126,6 +130,7 @@ func TestLoadConfigFromEnvOverrides(t *testing.T) {
 	t.Setenv("ARTIFACT_STORAGE_S3_ACCESS_KEY_ID", "access-key")
 	t.Setenv("ARTIFACT_STORAGE_S3_SECRET_ACCESS_KEY", "secret-key")
 	t.Setenv("ARTIFACT_STORAGE_S3_FORCE_PATH_STYLE", "false")
+	t.Setenv("ARTIFACT_SANDBOX_ASSET_MAX_BYTES", "2048")
 
 	cfg, err := LoadConfigFromEnv()
 	if err != nil {
@@ -179,6 +184,21 @@ func TestLoadConfigFromEnvOverrides(t *testing.T) {
 	}
 	if cfg.ArtifactStorage.S3ForcePathStyle {
 		t.Fatalf("ArtifactStorage.S3ForcePathStyle = true, want false")
+	}
+	if cfg.ArtifactStorage.MaxDownloadBytes != 2048 {
+		t.Fatalf("ArtifactStorage.MaxDownloadBytes = %d, want 2048", cfg.ArtifactStorage.MaxDownloadBytes)
+	}
+}
+
+func TestLoadConfigFromEnvRejectsInvalidArtifactSandboxAssetMaxBytes(t *testing.T) {
+	t.Setenv("ARTIFACT_SANDBOX_ASSET_MAX_BYTES", "0")
+
+	_, err := LoadConfigFromEnv()
+	if err == nil {
+		t.Fatalf("LoadConfigFromEnv returned nil error")
+	}
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("error = %v, want ErrInvalidConfig", err)
 	}
 }
 

--- a/backend/internal/worker/native_model.go
+++ b/backend/internal/worker/native_model.go
@@ -15,6 +15,7 @@ type NativeModelInvoker struct {
 	sandboxProvider sandbox.Provider
 	observerFactory NativeObserverFactory
 	secretsLookup   engine.SecretsLookup
+	assetLoader     engine.AssetLoader
 	standingsStore  racecontext.Store
 }
 
@@ -45,6 +46,13 @@ func (i NativeModelInvoker) WithSecretsLookup(lookup engine.SecretsLookup) Nativ
 	return i
 }
 
+// WithAssetLoader returns an invoker that lets native executors materialize
+// artifact-backed challenge-pack assets into the sandbox before execution.
+func (i NativeModelInvoker) WithAssetLoader(loader engine.AssetLoader) NativeModelInvoker {
+	i.assetLoader = loader
+	return i
+}
+
 // WithStandingsStore attaches the race-context standings source so that
 // runs with race_context: true get live peer-standings injection. See
 // issue #400. Passing nil (or not calling this) leaves injection inert.
@@ -68,6 +76,9 @@ func (i NativeModelInvoker) InvokeNativeModel(ctx context.Context, executionCont
 	executor := engine.NewNativeExecutor(i.client, i.sandboxProvider, observer)
 	if i.secretsLookup != nil {
 		executor = executor.WithSecretsLookup(i.secretsLookup)
+	}
+	if i.assetLoader != nil {
+		executor = executor.WithAssetLoader(i.assetLoader)
 	}
 	if i.standingsStore != nil {
 		executor = executor.WithStandingsStore(i.standingsStore)

--- a/testing/codex-issue-488-materialize-pack-assets.md
+++ b/testing/codex-issue-488-materialize-pack-assets.md
@@ -1,0 +1,30 @@
+# codex/issue-488-materialize-pack-assets - Test Contract
+
+## Functional Behavior
+- Native sandbox preparation materializes every artifact-backed `version.assets[]` entry at its declared `path` before the agent runs.
+- Native sandbox preparation materializes every artifact-backed `challenges[].assets[]` entry from the challenge-pack manifest at its declared `path`.
+- Native sandbox preparation materializes every artifact-backed asset on the selected input set's cases at its declared `path`.
+- Asset bytes are loaded from artifact storage by `artifact_id`, scoped to the run workspace, and uploaded unchanged into the sandbox.
+- Assets without `artifact_id` keep existing behavior and are not fetched from artifact storage.
+- If a run references an artifact-backed asset but the worker has no asset loader, sandbox preparation fails closed with `sandbox_error`.
+- If artifact metadata belongs to a different workspace or the object cannot be opened, sandbox preparation fails before the agent step starts.
+
+## Unit Tests
+- `backend/internal/engine`: test that artifact-backed version, challenge, and input-case assets are uploaded to their declared sandbox paths.
+- `backend/internal/engine`: test that inline/non-artifact assets do not require an asset loader.
+- `backend/internal/engine`: test that artifact-backed assets without a loader fail with `StopReasonSandboxError`.
+- `backend/internal/worker`: test that the worker artifact asset loader reads bytes from storage and rejects cross-workspace artifact IDs.
+- `backend/internal/worker`: test worker config loads artifact storage defaults and env overrides.
+
+## Integration / Functional Tests
+- `backend/cmd/worker` must compile with artifact storage initialization and native invoker wiring.
+- `backend/internal/worker` must compile with `NewNativeModelInvoker...WithAssetLoader(...)` propagation into `engine.NativeExecutor`.
+
+## Smoke Tests
+- `go test ./internal/engine ./internal/worker ./cmd/worker` from `backend/`.
+
+## E2E Tests
+- N/A - this is a backend staging path covered by unit tests and compile checks; a real E2E would require external sandbox and artifact services.
+
+## Manual / cURL Tests
+- N/A - no HTTP API behavior changes; publish-time validation already accepted `version.assets[].artifact_id`.


### PR DESCRIPTION
Fixes #488

## Summary
- stage artifact-backed version/challenge/current input-case assets into native sandboxes before agent execution
- add worker artifact asset loader backed by repository metadata plus configured artifact storage
- load worker artifact storage config from the same ARTIFACT_STORAGE_* env vars as the API server

## Review Checkpoint
- locked expectations in testing/codex-issue-488-materialize-pack-assets.md before implementation
- final checkpoint verdict: ready

## Tests
- cd backend && go test ./internal/engine ./internal/worker ./cmd/worker