### PR TITLE
feat(ci): define baseline resolution flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ AgentClash CI/CD gates the candidate agent revision against a repeatable workloa
 ```bash
 agentclash ci init .agentclash/ci.yaml
 agentclash ci validate .agentclash/ci.yaml
+export AGENTCLASH_WORKSPACE="your-workspace-id" # or pass -w
 agentclash ci baseline --manifest .agentclash/ci.yaml --json
 agentclash ci should-run --changed-file prompts/system.md --json
 ```

--- a/README.md
+++ b/README.md
@@ -132,10 +132,13 @@ AgentClash CI/CD gates the candidate agent revision against a repeatable workloa
 ```bash
 agentclash ci init .agentclash/ci.yaml
 agentclash ci validate .agentclash/ci.yaml
+agentclash ci baseline --manifest .agentclash/ci.yaml --json
 agentclash ci should-run --changed-file prompts/system.md --json
 ```
 
-The current CLI can validate that manifest locally. Existing commands also work non-interactively with environment variables and explicit IDs:
+The current CLI can validate that manifest locally and resolve the exact baseline run that the gate will compare against. For pull request gates, prefer a locked `baseline.run_id`; update it only after a successful mainline run in a reviewed, auditable change.
+
+Existing commands also work non-interactively with environment variables and explicit IDs:
 
 ```bash
 export AGENTCLASH_API_URL="https://api.agentclash.dev"

--- a/cli/cmd/ci.go
+++ b/cli/cmd/ci.go
@@ -532,8 +532,12 @@ func resolveCIBaselineDeployment(cmd *cobra.Command, rc *RunContext, workspaceID
 		return runs[i].CreatedAt > runs[j].CreatedAt
 	})
 
+	var newestRejectedCandidate error
 	for _, run := range runs {
 		if err := validateCIBaselineRun(workspaceID, manifest, run, now); err != nil {
+			if newestRejectedCandidate == nil {
+				newestRejectedCandidate = err
+			}
 			continue
 		}
 		agents, err := listRunAgentsForWorkflow(cmd, rc, run.ID)
@@ -550,27 +554,50 @@ func resolveCIBaselineDeployment(cmd *cobra.Command, rc *RunContext, workspaceID
 			return buildCIBaselineRunResolution(run, agent.ID, deploymentID, now), nil
 		}
 	}
+	if newestRejectedCandidate != nil {
+		return ciBaselineRunResolution{}, fmt.Errorf("no completed compatible baseline run found for baseline.deployment_id %s; newest rejected baseline candidate: %w", deploymentID, newestRejectedCandidate)
+	}
 	return ciBaselineRunResolution{}, fmt.Errorf("no completed compatible baseline run found for baseline.deployment_id %s", deploymentID)
 }
 
 func listCIBaselineRuns(cmd *cobra.Command, rc *RunContext, workspaceID string) ([]runWorkflowSummary, error) {
-	query := url.Values{}
-	query.Set("limit", "100")
-	resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+workspaceID+"/runs", query)
-	if err != nil {
-		return nil, err
-	}
-	if apiErr := resp.ParseError(); apiErr != nil {
-		return nil, apiErr
-	}
+	const pageLimit = 100
 
-	var result struct {
-		Items []runWorkflowSummary `json:"items"`
+	var runs []runWorkflowSummary
+	for offset := 0; ; offset += pageLimit {
+		query := url.Values{}
+		query.Set("limit", fmt.Sprintf("%d", pageLimit))
+		if offset > 0 {
+			query.Set("offset", fmt.Sprintf("%d", offset))
+		}
+		resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+workspaceID+"/runs", query)
+		if err != nil {
+			return nil, err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return nil, apiErr
+		}
+
+		var result struct {
+			Items []runWorkflowSummary `json:"items"`
+			Total int64                `json:"total"`
+		}
+		if err := resp.DecodeJSON(&result); err != nil {
+			return nil, err
+		}
+
+		runs = append(runs, result.Items...)
+		if len(result.Items) == 0 {
+			break
+		}
+		if result.Total > 0 && int64(len(runs)) >= result.Total {
+			break
+		}
+		if len(result.Items) < pageLimit {
+			break
+		}
 	}
-	if err := resp.DecodeJSON(&result); err != nil {
-		return nil, err
-	}
-	return result.Items, nil
+	return runs, nil
 }
 
 func validateCIBaselineRun(workspaceID string, manifest ciManifest, run runWorkflowSummary, now time.Time) error {

--- a/cli/cmd/ci.go
+++ b/cli/cmd/ci.go
@@ -3,10 +3,13 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/agentclash/agentclash/cli/internal/output"
 	"github.com/bmatcuk/doublestar/v4"
@@ -19,8 +22,10 @@ func init() {
 	ciCmd.AddCommand(ciInitCmd)
 	ciCmd.AddCommand(ciValidateCmd)
 	ciCmd.AddCommand(ciShouldRunCmd)
+	ciCmd.AddCommand(ciBaselineCmd)
 
 	ciInitCmd.Flags().Bool("force", false, "Overwrite an existing manifest")
+	ciBaselineCmd.Flags().String("manifest", ".agentclash/ci.yaml", "Path to the AgentClash CI manifest")
 	ciShouldRunCmd.Flags().String("manifest", ".agentclash/ci.yaml", "Path to the AgentClash CI manifest")
 	ciShouldRunCmd.Flags().StringArray("changed-file", nil, "Changed file path; may be repeated")
 	ciShouldRunCmd.Flags().StringSlice("labels", nil, "Pull request labels; may be comma-separated or repeated")
@@ -167,6 +172,55 @@ changed files from git diff.`,
 	},
 }
 
+var ciBaselineCmd = &cobra.Command{
+	Use:   "baseline",
+	Short: "Resolve the baseline selected by an AgentClash CI manifest",
+	Long: `Resolve the baseline selected by an AgentClash CI manifest.
+
+For pull request gates, prefer a locked baseline.run_id. A deployment baseline
+is resolved to the newest completed, workload-compatible run whose participant
+used baseline.deployment_id. The result explains the source, refresh policy, and
+the exact run id that downstream gate commands should compare against.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		workspaceID := RequireWorkspace(cmd)
+		manifestPath, _ := cmd.Flags().GetString("manifest")
+
+		validation, err := validateCIManifestFile(manifestPath)
+		if err != nil {
+			return err
+		}
+		resolution, err := resolveCIManifestBaseline(cmd, rc, workspaceID, manifestPath, *validation.Manifest, time.Now().UTC())
+		if err != nil {
+			return err
+		}
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(resolution)
+		}
+
+		rc.Output.PrintSuccess("Resolved AgentClash CI baseline")
+		rc.Output.PrintDetail("Strategy", resolution.Strategy)
+		rc.Output.PrintDetail("Source", resolution.Source)
+		rc.Output.PrintDetail("Run", resolution.Baseline.RunID)
+		if resolution.Baseline.RunAgentID != "" {
+			rc.Output.PrintDetail("Run Agent", resolution.Baseline.RunAgentID)
+		}
+		if resolution.Baseline.DeploymentID != "" {
+			rc.Output.PrintDetail("Deployment", resolution.Baseline.DeploymentID)
+		}
+		rc.Output.PrintDetail("Reason", resolution.Reason)
+		rc.Output.PrintDetail("Refresh", fmt.Sprintf("%s - %s", resolution.Refresh.Mode, resolution.Refresh.NextAction))
+		if resolution.Baseline.AgeDays > 0 {
+			rc.Output.PrintDetail("Age", fmt.Sprintf("%d day(s)", resolution.Baseline.AgeDays))
+		}
+		for _, warning := range resolution.Warnings {
+			rc.Output.PrintWarning(warning)
+		}
+		return nil
+	},
+}
+
 type ciManifest struct {
 	Version     int                   `yaml:"version" json:"version"`
 	Trigger     ciManifestTrigger     `yaml:"trigger" json:"trigger"`
@@ -208,7 +262,10 @@ type ciManifestEvaluation struct {
 
 type ciManifestBaseline struct {
 	RunID        string `yaml:"run_id,omitempty" json:"run_id,omitempty"`
+	RunAgentID   string `yaml:"run_agent_id,omitempty" json:"run_agent_id,omitempty"`
 	DeploymentID string `yaml:"deployment_id,omitempty" json:"deployment_id,omitempty"`
+	Refresh      string `yaml:"refresh,omitempty" json:"refresh,omitempty"`
+	MaxAgeDays   int    `yaml:"max_age_days,omitempty" json:"max_age_days,omitempty"`
 }
 
 type ciManifestGate struct {
@@ -244,6 +301,36 @@ type ciShouldRunResult struct {
 	MatchedLabels    []string               `json:"matched_labels,omitempty" yaml:"matched_labels,omitempty"`
 }
 
+type ciBaselineResolution struct {
+	ManifestPath string                      `json:"manifest_path" yaml:"manifest_path"`
+	WorkspaceID  string                      `json:"workspace_id" yaml:"workspace_id"`
+	Strategy     string                      `json:"strategy" yaml:"strategy"`
+	Source       string                      `json:"source" yaml:"source"`
+	Reason       string                      `json:"reason" yaml:"reason"`
+	Baseline     ciBaselineRunResolution     `json:"baseline" yaml:"baseline"`
+	Refresh      ciBaselineRefreshResolution `json:"refresh" yaml:"refresh"`
+	Warnings     []string                    `json:"warnings,omitempty" yaml:"warnings,omitempty"`
+}
+
+type ciBaselineRunResolution struct {
+	RunID                  string `json:"run_id" yaml:"run_id"`
+	RunAgentID             string `json:"run_agent_id,omitempty" yaml:"run_agent_id,omitempty"`
+	DeploymentID           string `json:"deployment_id,omitempty" yaml:"deployment_id,omitempty"`
+	RunName                string `json:"run_name,omitempty" yaml:"run_name,omitempty"`
+	Status                 string `json:"status" yaml:"status"`
+	ChallengePackVersionID string `json:"challenge_pack_version_id,omitempty" yaml:"challenge_pack_version_id,omitempty"`
+	InputSetID             string `json:"input_set_id,omitempty" yaml:"input_set_id,omitempty"`
+	CreatedAt              string `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	FinishedAt             string `json:"finished_at,omitempty" yaml:"finished_at,omitempty"`
+	AgeDays                int    `json:"age_days,omitempty" yaml:"age_days,omitempty"`
+}
+
+type ciBaselineRefreshResolution struct {
+	Mode       string `json:"mode" yaml:"mode"`
+	Branch     string `json:"branch,omitempty" yaml:"branch,omitempty"`
+	NextAction string `json:"next_action" yaml:"next_action"`
+}
+
 const sampleCIManifestYAML = `version: 1
 trigger:
   paths:
@@ -268,6 +355,8 @@ evaluation:
     - 00000000-0000-0000-0000-000000000007
 baseline:
   run_id: 00000000-0000-0000-0000-000000000008
+  refresh: manual
+  max_age_days: 30
 gate:
   fail_on: regression
 regressions:
@@ -334,6 +423,18 @@ func validateCIManifest(manifest ciManifest) []string {
 	if strings.TrimSpace(manifest.Baseline.RunID) == "" && strings.TrimSpace(manifest.Baseline.DeploymentID) == "" {
 		errors = append(errors, "baseline.run_id or baseline.deployment_id is required")
 	}
+	if strings.TrimSpace(manifest.Baseline.RunID) != "" && strings.TrimSpace(manifest.Baseline.DeploymentID) != "" {
+		errors = append(errors, "baseline.run_id and baseline.deployment_id are mutually exclusive")
+	}
+	if strings.TrimSpace(manifest.Baseline.RunAgentID) != "" && strings.TrimSpace(manifest.Baseline.RunID) == "" {
+		errors = append(errors, "baseline.run_agent_id requires baseline.run_id")
+	}
+	if refresh := strings.TrimSpace(manifest.Baseline.Refresh); refresh != "" && !allowedCIManifestValue(refresh, "manual", "propose", "auto_on_main") {
+		errors = append(errors, "baseline.refresh must be one of manual, propose, auto_on_main")
+	}
+	if manifest.Baseline.MaxAgeDays < 0 {
+		errors = append(errors, "baseline.max_age_days must be greater than or equal to 0")
+	}
 	if failOn := strings.TrimSpace(manifest.Gate.FailOn); failOn == "" {
 		errors = append(errors, "gate.fail_on is required")
 	} else if !allowedCIManifestValue(failOn, "regression", "warning", "insufficient_evidence") {
@@ -345,6 +446,195 @@ func validateCIManifest(manifest ciManifest) []string {
 		errors = append(errors, "regressions.promote_failures must be one of disabled, proposed, auto_on_main")
 	}
 	return errors
+}
+
+func resolveCIManifestBaseline(cmd *cobra.Command, rc *RunContext, workspaceID, manifestPath string, manifest ciManifest, now time.Time) (ciBaselineResolution, error) {
+	mode := ciBaselineRefreshMode(manifest.Baseline.Refresh)
+	resolution := ciBaselineResolution{
+		ManifestPath: manifestPath,
+		WorkspaceID:  workspaceID,
+		Refresh: ciBaselineRefreshResolution{
+			Mode:       mode,
+			Branch:     "main",
+			NextAction: ciBaselineRefreshNextAction(mode),
+		},
+	}
+
+	runID := strings.TrimSpace(manifest.Baseline.RunID)
+	deploymentID := strings.TrimSpace(manifest.Baseline.DeploymentID)
+	switch {
+	case runID != "":
+		run, err := getRunSummaryByID(cmd, rc, runID)
+		if err != nil {
+			return resolution, fmt.Errorf("resolving baseline.run_id %s: %w", runID, err)
+		}
+		if err := validateCIBaselineRun(workspaceID, manifest, run, now); err != nil {
+			return resolution, err
+		}
+
+		runAgentID := strings.TrimSpace(manifest.Baseline.RunAgentID)
+		if runAgentID != "" {
+			agent, err := resolveRunAgentSummary(cmd, rc, run.ID, runAgentID)
+			if err != nil {
+				return resolution, fmt.Errorf("resolving baseline.run_agent_id %s: %w", runAgentID, err)
+			}
+			runAgentID = agent.ID
+		}
+
+		resolution.Strategy = "locked_run"
+		resolution.Source = "baseline.run_id"
+		resolution.Reason = "baseline.run_id pins the exact accepted run for pull request gates"
+		resolution.Baseline = buildCIBaselineRunResolution(run, runAgentID, "", now)
+		return resolution, nil
+
+	case deploymentID != "":
+		resolved, err := resolveCIBaselineDeployment(cmd, rc, workspaceID, manifest, deploymentID, now)
+		if err != nil {
+			return resolution, err
+		}
+		resolution.Strategy = "deployment_latest_completed"
+		resolution.Source = "baseline.deployment_id"
+		resolution.Reason = "baseline.deployment_id resolved to the newest completed compatible run for that deployment"
+		resolution.Baseline = resolved
+		resolution.Warnings = append(resolution.Warnings, "deployment baselines move when a newer compatible run exists; use baseline.run_id for fully locked PR gates")
+		return resolution, nil
+
+	default:
+		return resolution, fmt.Errorf("baseline.run_id or baseline.deployment_id is required")
+	}
+}
+
+func ciBaselineRefreshMode(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "manual"
+	}
+	return value
+}
+
+func ciBaselineRefreshNextAction(mode string) string {
+	switch mode {
+	case "propose":
+		return "after a successful mainline run, open a reviewed change that updates baseline.run_id"
+	case "auto_on_main":
+		return "after a successful protected mainline run, automation may update baseline.run_id with an auditable commit"
+	default:
+		return "after a successful mainline run, update baseline.run_id intentionally in a reviewed change"
+	}
+}
+
+func resolveCIBaselineDeployment(cmd *cobra.Command, rc *RunContext, workspaceID string, manifest ciManifest, deploymentID string, now time.Time) (ciBaselineRunResolution, error) {
+	runs, err := listCIBaselineRuns(cmd, rc, workspaceID)
+	if err != nil {
+		return ciBaselineRunResolution{}, fmt.Errorf("listing runs for baseline.deployment_id %s: %w", deploymentID, err)
+	}
+	sort.SliceStable(runs, func(i, j int) bool {
+		return runs[i].CreatedAt > runs[j].CreatedAt
+	})
+
+	for _, run := range runs {
+		if err := validateCIBaselineRun(workspaceID, manifest, run, now); err != nil {
+			continue
+		}
+		agents, err := listRunAgentsForWorkflow(cmd, rc, run.ID)
+		if err != nil {
+			return ciBaselineRunResolution{}, fmt.Errorf("listing agents for baseline candidate run %s: %w", run.ID, err)
+		}
+		for _, agent := range agents {
+			if agent.AgentDeploymentID != deploymentID {
+				continue
+			}
+			if agent.Status != "" && agent.Status != "completed" {
+				continue
+			}
+			return buildCIBaselineRunResolution(run, agent.ID, deploymentID, now), nil
+		}
+	}
+	return ciBaselineRunResolution{}, fmt.Errorf("no completed compatible baseline run found for baseline.deployment_id %s", deploymentID)
+}
+
+func listCIBaselineRuns(cmd *cobra.Command, rc *RunContext, workspaceID string) ([]runWorkflowSummary, error) {
+	query := url.Values{}
+	query.Set("limit", "100")
+	resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+workspaceID+"/runs", query)
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return nil, apiErr
+	}
+
+	var result struct {
+		Items []runWorkflowSummary `json:"items"`
+	}
+	if err := resp.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+	return result.Items, nil
+}
+
+func validateCIBaselineRun(workspaceID string, manifest ciManifest, run runWorkflowSummary, now time.Time) error {
+	if run.WorkspaceID != "" && workspaceID != "" && run.WorkspaceID != workspaceID {
+		return fmt.Errorf("baseline run %s belongs to workspace %s, not %s", run.ID, run.WorkspaceID, workspaceID)
+	}
+	if run.Status != "completed" {
+		return fmt.Errorf("baseline run %s status is %s, want completed", run.ID, run.Status)
+	}
+	if run.ChallengePackVersionID != "" && manifest.Evaluation.ChallengePackVersionID != "" && run.ChallengePackVersionID != manifest.Evaluation.ChallengePackVersionID {
+		return fmt.Errorf("baseline run %s uses challenge pack version %s, not %s", run.ID, run.ChallengePackVersionID, manifest.Evaluation.ChallengePackVersionID)
+	}
+	if manifest.Evaluation.InputSetID != "" && run.ChallengeInputSetID != manifest.Evaluation.InputSetID {
+		return fmt.Errorf("baseline run %s uses input set %s, not %s", run.ID, run.ChallengeInputSetID, manifest.Evaluation.InputSetID)
+	}
+	if err := validateCIBaselineAge(manifest.Baseline.MaxAgeDays, run, now); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateCIBaselineAge(maxAgeDays int, run runWorkflowSummary, now time.Time) error {
+	if maxAgeDays <= 0 {
+		return nil
+	}
+	timestamp, ok := ciBaselineRunTimestamp(run)
+	if !ok {
+		return fmt.Errorf("baseline run %s has no created_at or finished_at timestamp for max_age_days", run.ID)
+	}
+	if now.Sub(timestamp) > time.Duration(maxAgeDays)*24*time.Hour {
+		return fmt.Errorf("baseline run %s is older than baseline.max_age_days (%d)", run.ID, maxAgeDays)
+	}
+	return nil
+}
+
+func ciBaselineRunTimestamp(run runWorkflowSummary) (time.Time, bool) {
+	for _, raw := range []string{run.FinishedAt, run.CreatedAt} {
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		parsed, err := time.Parse(time.RFC3339, raw)
+		if err == nil {
+			return parsed, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func buildCIBaselineRunResolution(run runWorkflowSummary, runAgentID string, deploymentID string, now time.Time) ciBaselineRunResolution {
+	out := ciBaselineRunResolution{
+		RunID:                  run.ID,
+		RunAgentID:             runAgentID,
+		DeploymentID:           deploymentID,
+		RunName:                run.Name,
+		Status:                 run.Status,
+		ChallengePackVersionID: run.ChallengePackVersionID,
+		InputSetID:             run.ChallengeInputSetID,
+		CreatedAt:              run.CreatedAt,
+		FinishedAt:             run.FinishedAt,
+	}
+	if timestamp, ok := ciBaselineRunTimestamp(run); ok {
+		out.AgeDays = int(now.Sub(timestamp).Hours() / 24)
+	}
+	return out
 }
 
 func allowedCIManifestValue(value string, allowed ...string) bool {

--- a/cli/cmd/ci.go
+++ b/cli/cmd/ci.go
@@ -180,7 +180,8 @@ var ciBaselineCmd = &cobra.Command{
 For pull request gates, prefer a locked baseline.run_id. A deployment baseline
 is resolved to the newest completed, workload-compatible run whose participant
 used baseline.deployment_id. The result explains the source, refresh policy, and
-the exact run id that downstream gate commands should compare against.`,
+max_age_days staleness policy, and the exact run id that downstream gate
+commands should compare against.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		rc := GetRunContext(cmd)
@@ -528,9 +529,7 @@ func resolveCIBaselineDeployment(cmd *cobra.Command, rc *RunContext, workspaceID
 	if err != nil {
 		return ciBaselineRunResolution{}, fmt.Errorf("listing runs for baseline.deployment_id %s: %w", deploymentID, err)
 	}
-	sort.SliceStable(runs, func(i, j int) bool {
-		return runs[i].CreatedAt > runs[j].CreatedAt
-	})
+	sort.SliceStable(runs, func(i, j int) bool { return ciBaselineRunNewer(runs[i], runs[j]) })
 
 	var newestRejectedCandidate error
 	for _, run := range runs {
@@ -544,20 +543,43 @@ func resolveCIBaselineDeployment(cmd *cobra.Command, rc *RunContext, workspaceID
 		if err != nil {
 			return ciBaselineRunResolution{}, fmt.Errorf("listing agents for baseline candidate run %s: %w", run.ID, err)
 		}
+		matchedDeployment := false
 		for _, agent := range agents {
 			if agent.AgentDeploymentID != deploymentID {
 				continue
 			}
-			if agent.Status != "" && agent.Status != "completed" {
+			matchedDeployment = true
+			if agent.Status != "completed" {
+				if newestRejectedCandidate == nil {
+					newestRejectedCandidate = fmt.Errorf("baseline run %s agent %s for baseline.deployment_id %s status is %q, want completed", run.ID, agent.ID, deploymentID, agent.Status)
+				}
 				continue
 			}
 			return buildCIBaselineRunResolution(run, agent.ID, deploymentID, now), nil
+		}
+		if !matchedDeployment && newestRejectedCandidate == nil {
+			newestRejectedCandidate = fmt.Errorf("baseline run %s has no agent for baseline.deployment_id %s", run.ID, deploymentID)
 		}
 	}
 	if newestRejectedCandidate != nil {
 		return ciBaselineRunResolution{}, fmt.Errorf("no completed compatible baseline run found for baseline.deployment_id %s; newest rejected baseline candidate: %w", deploymentID, newestRejectedCandidate)
 	}
 	return ciBaselineRunResolution{}, fmt.Errorf("no completed compatible baseline run found for baseline.deployment_id %s", deploymentID)
+}
+
+func ciBaselineRunNewer(a, b runWorkflowSummary) bool {
+	aTimestamp, aOK := ciBaselineRunTimestamp(a)
+	bTimestamp, bOK := ciBaselineRunTimestamp(b)
+	if aOK && bOK && !aTimestamp.Equal(bTimestamp) {
+		return aTimestamp.After(bTimestamp)
+	}
+	if aOK != bOK {
+		return aOK
+	}
+	if a.CreatedAt != b.CreatedAt {
+		return a.CreatedAt > b.CreatedAt
+	}
+	return a.ID > b.ID
 }
 
 func listCIBaselineRuns(cmd *cobra.Command, rc *RunContext, workspaceID string) ([]runWorkflowSummary, error) {

--- a/cli/cmd/ci.go
+++ b/cli/cmd/ci.go
@@ -328,7 +328,6 @@ type ciBaselineRunResolution struct {
 
 type ciBaselineRefreshResolution struct {
 	Mode       string `json:"mode" yaml:"mode"`
-	Branch     string `json:"branch,omitempty" yaml:"branch,omitempty"`
 	NextAction string `json:"next_action" yaml:"next_action"`
 }
 
@@ -456,7 +455,6 @@ func resolveCIManifestBaseline(cmd *cobra.Command, rc *RunContext, workspaceID, 
 		WorkspaceID:  workspaceID,
 		Refresh: ciBaselineRefreshResolution{
 			Mode:       mode,
-			Branch:     "main",
 			NextAction: ciBaselineRefreshNextAction(mode),
 		},
 	}
@@ -524,6 +522,8 @@ func ciBaselineRefreshNextAction(mode string) string {
 	}
 }
 
+const ciBaselineDeploymentRejectionLimit = 3
+
 func resolveCIBaselineDeployment(cmd *cobra.Command, rc *RunContext, workspaceID string, manifest ciManifest, deploymentID string, now time.Time) (ciBaselineRunResolution, error) {
 	runs, err := listCIBaselineRuns(cmd, rc, workspaceID)
 	if err != nil {
@@ -531,11 +531,19 @@ func resolveCIBaselineDeployment(cmd *cobra.Command, rc *RunContext, workspaceID
 	}
 	sort.SliceStable(runs, func(i, j int) bool { return ciBaselineRunNewer(runs[i], runs[j]) })
 
-	var newestRejectedCandidate error
+	var rejectedCandidates []string
+	recordRejection := func(err error) {
+		if err == nil || len(rejectedCandidates) >= ciBaselineDeploymentRejectionLimit {
+			return
+		}
+		rejectedCandidates = append(rejectedCandidates, err.Error())
+	}
+
 	for _, run := range runs {
 		if err := validateCIBaselineRun(workspaceID, manifest, run, now); err != nil {
-			if newestRejectedCandidate == nil {
-				newestRejectedCandidate = err
+			recordRejection(err)
+			if ciBaselineRunExhaustsFreshWindow(manifest.Baseline.MaxAgeDays, run, now) {
+				break
 			}
 			continue
 		}
@@ -550,19 +558,17 @@ func resolveCIBaselineDeployment(cmd *cobra.Command, rc *RunContext, workspaceID
 			}
 			matchedDeployment = true
 			if agent.Status != "completed" {
-				if newestRejectedCandidate == nil {
-					newestRejectedCandidate = fmt.Errorf("baseline run %s agent %s for baseline.deployment_id %s status is %q, want completed", run.ID, agent.ID, deploymentID, agent.Status)
-				}
+				recordRejection(fmt.Errorf("baseline run %s agent %s for baseline.deployment_id %s status is %s, want completed", run.ID, agent.ID, deploymentID, ciBaselineStatusForError(agent.Status)))
 				continue
 			}
 			return buildCIBaselineRunResolution(run, agent.ID, deploymentID, now), nil
 		}
-		if !matchedDeployment && newestRejectedCandidate == nil {
-			newestRejectedCandidate = fmt.Errorf("baseline run %s has no agent for baseline.deployment_id %s", run.ID, deploymentID)
+		if !matchedDeployment {
+			recordRejection(fmt.Errorf("baseline run %s has no agent for baseline.deployment_id %s", run.ID, deploymentID))
 		}
 	}
-	if newestRejectedCandidate != nil {
-		return ciBaselineRunResolution{}, fmt.Errorf("no completed compatible baseline run found for baseline.deployment_id %s; newest rejected baseline candidate: %w", deploymentID, newestRejectedCandidate)
+	if len(rejectedCandidates) > 0 {
+		return ciBaselineRunResolution{}, fmt.Errorf("no completed compatible baseline run found for baseline.deployment_id %s; newest rejected baseline candidates: %s", deploymentID, strings.Join(rejectedCandidates, "; "))
 	}
 	return ciBaselineRunResolution{}, fmt.Errorf("no completed compatible baseline run found for baseline.deployment_id %s", deploymentID)
 }
@@ -653,6 +659,25 @@ func validateCIBaselineAge(maxAgeDays int, run runWorkflowSummary, now time.Time
 		return fmt.Errorf("baseline run %s is older than baseline.max_age_days (%d)", run.ID, maxAgeDays)
 	}
 	return nil
+}
+
+func ciBaselineRunExhaustsFreshWindow(maxAgeDays int, run runWorkflowSummary, now time.Time) bool {
+	if maxAgeDays <= 0 {
+		return false
+	}
+	timestamp, ok := ciBaselineRunTimestamp(run)
+	if !ok {
+		return true
+	}
+	return now.Sub(timestamp) > time.Duration(maxAgeDays)*24*time.Hour
+}
+
+func ciBaselineStatusForError(status string) string {
+	status = strings.TrimSpace(status)
+	if status == "" {
+		return "<missing>"
+	}
+	return fmt.Sprintf("%q", status)
 }
 
 func ciBaselineRunTimestamp(run runWorkflowSummary) (time.Time, bool) {

--- a/cli/cmd/ci_test.go
+++ b/cli/cmd/ci_test.go
@@ -1099,6 +1099,68 @@ func TestCIBaselineRejectsNonCompletedDeploymentAgent(t *testing.T) {
 	}
 }
 
+func TestCIBaselineReportsNewestDeploymentRejections(t *testing.T) {
+	manifest := strings.Replace(sampleCIManifestYAML, "  run_id: 00000000-0000-0000-0000-000000000008\n  refresh: manual\n  max_age_days: 30\n", "  deployment_id: dep-base\n  refresh: manual\n", 1)
+	target := writeCIManifest(t, manifest)
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/runs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{
+					"id":                        "run-missing-agent",
+					"workspace_id":              "ws-1",
+					"status":                    "completed",
+					"challenge_pack_version_id": "00000000-0000-0000-0000-000000000005",
+					"challenge_input_set_id":    "00000000-0000-0000-0000-000000000006",
+					"created_at":                "2026-05-04T00:00:00Z",
+				},
+				{
+					"id":                        "run-empty-agent-status",
+					"workspace_id":              "ws-1",
+					"status":                    "completed",
+					"challenge_pack_version_id": "00000000-0000-0000-0000-000000000005",
+					"challenge_input_set_id":    "00000000-0000-0000-0000-000000000006",
+					"created_at":                "2026-05-03T00:00:00Z",
+				},
+			},
+		}),
+		"GET /v1/runs/run-missing-agent/agents": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":                  "agent-other",
+				"run_id":              "run-missing-agent",
+				"status":              "completed",
+				"agent_deployment_id": "dep-other",
+			}},
+		}),
+		"GET /v1/runs/run-empty-agent-status/agents": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":                  "agent-empty",
+				"run_id":              "run-empty-agent-status",
+				"agent_deployment_id": "dep-base",
+			}},
+		}),
+	})
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	err := executeCommand(t, []string{
+		"ci", "baseline",
+		"--manifest", target,
+		"-w", "ws-1",
+	}, srv.URL)
+	if err == nil {
+		t.Fatal("error = nil, want deployment rejection diagnostics")
+	}
+	for _, snippet := range []string{
+		"newest rejected baseline candidates",
+		"baseline run run-missing-agent has no agent for baseline.deployment_id dep-base",
+		"baseline run run-empty-agent-status agent agent-empty for baseline.deployment_id dep-base status is <missing>, want completed",
+	} {
+		if !strings.Contains(err.Error(), snippet) {
+			t.Fatalf("error missing %q:\n%v", snippet, err)
+		}
+	}
+}
+
 func TestCIBaselineRejectsMissingDeploymentMatch(t *testing.T) {
 	manifest := strings.Replace(sampleCIManifestYAML, "  run_id: 00000000-0000-0000-0000-000000000008\n  refresh: manual\n  max_age_days: 30\n", "  deployment_id: dep-base\n  refresh: manual\n", 1)
 	target := writeCIManifest(t, manifest)

--- a/cli/cmd/ci_test.go
+++ b/cli/cmd/ci_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -213,6 +214,102 @@ regressions:
   promote_failures: proposed
 `,
 			want: "baseline.run_id or baseline.deployment_id",
+		},
+		{
+			name: "conflicting baseline selectors",
+			manifest: `version: 1
+trigger:
+  paths:
+    - .agentclash/agent.json
+candidate:
+  build:
+    agent_build_id: build-1
+    spec_file: .agentclash/agent.json
+  deployment:
+    runtime_profile_id: runtime-1
+evaluation:
+  challenge_pack_version_id: pack-version-1
+baseline:
+  run_id: run-1
+  deployment_id: dep-1
+gate:
+  fail_on: regression
+regressions:
+  promote_failures: proposed
+`,
+			want: "baseline.run_id and baseline.deployment_id",
+		},
+		{
+			name: "run agent without fixed run",
+			manifest: `version: 1
+trigger:
+  paths:
+    - .agentclash/agent.json
+candidate:
+  build:
+    agent_build_id: build-1
+    spec_file: .agentclash/agent.json
+  deployment:
+    runtime_profile_id: runtime-1
+evaluation:
+  challenge_pack_version_id: pack-version-1
+baseline:
+  deployment_id: dep-1
+  run_agent_id: agent-1
+gate:
+  fail_on: regression
+regressions:
+  promote_failures: proposed
+`,
+			want: "baseline.run_agent_id requires baseline.run_id",
+		},
+		{
+			name: "invalid baseline refresh mode",
+			manifest: `version: 1
+trigger:
+  paths:
+    - .agentclash/agent.json
+candidate:
+  build:
+    agent_build_id: build-1
+    spec_file: .agentclash/agent.json
+  deployment:
+    runtime_profile_id: runtime-1
+evaluation:
+  challenge_pack_version_id: pack-version-1
+baseline:
+  run_id: run-1
+  refresh: surprise
+gate:
+  fail_on: regression
+regressions:
+  promote_failures: proposed
+`,
+			want: "baseline.refresh",
+		},
+		{
+			name: "negative max age",
+			manifest: `version: 1
+trigger:
+  paths:
+    - .agentclash/agent.json
+candidate:
+  build:
+    agent_build_id: build-1
+    spec_file: .agentclash/agent.json
+  deployment:
+    runtime_profile_id: runtime-1
+evaluation:
+  challenge_pack_version_id: pack-version-1
+baseline:
+  run_id: run-1
+  max_age_days: -1
+gate:
+  fail_on: regression
+regressions:
+  promote_failures: proposed
+`,
+			want: "baseline.max_age_days",
 		},
 		{
 			name: "invalid gate fail mode",
@@ -645,6 +742,213 @@ func TestCIShouldRunDerivesDeletedFilesFromGitDiff(t *testing.T) {
 	}
 }
 
+func TestCIBaselineResolvesFixedRun(t *testing.T) {
+	target := writeCIManifest(t, strings.Replace(sampleCIManifestYAML, "  max_age_days: 30\n", "", 1))
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/runs/00000000-0000-0000-0000-000000000008": jsonHandler(200, map[string]any{
+			"id":                        "00000000-0000-0000-0000-000000000008",
+			"workspace_id":              "ws-1",
+			"name":                      "Locked mainline",
+			"status":                    "completed",
+			"challenge_pack_version_id": "00000000-0000-0000-0000-000000000005",
+			"challenge_input_set_id":    "00000000-0000-0000-0000-000000000006",
+			"created_at":                "2026-05-01T00:00:00Z",
+		}),
+	})
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	result := runCIBaselineJSON(t, []string{
+		"ci", "baseline",
+		"--manifest", target,
+		"-w", "ws-1",
+		"--json",
+	}, srv.URL)
+
+	if result.Strategy != "locked_run" || result.Source != "baseline.run_id" {
+		t.Fatalf("strategy/source = %q/%q, want locked_run/baseline.run_id", result.Strategy, result.Source)
+	}
+	if result.Baseline.RunID != "00000000-0000-0000-0000-000000000008" {
+		t.Fatalf("run_id = %q, want manifest run", result.Baseline.RunID)
+	}
+	if result.Refresh.Mode != "manual" {
+		t.Fatalf("refresh mode = %q, want manual", result.Refresh.Mode)
+	}
+}
+
+func TestCIBaselineResolvesFixedRunAgent(t *testing.T) {
+	manifest := strings.Replace(sampleCIManifestYAML, "  max_age_days: 30\n", "", 1)
+	manifest = strings.Replace(manifest, "  run_id: 00000000-0000-0000-0000-000000000008\n", "  run_id: run-base\n  run_agent_id: agent-base\n", 1)
+	target := writeCIManifest(t, manifest)
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/runs/run-base": jsonHandler(200, map[string]any{
+			"id":                        "run-base",
+			"workspace_id":              "ws-1",
+			"status":                    "completed",
+			"challenge_pack_version_id": "00000000-0000-0000-0000-000000000005",
+			"challenge_input_set_id":    "00000000-0000-0000-0000-000000000006",
+			"created_at":                "2026-05-01T00:00:00Z",
+		}),
+		"GET /v1/runs/run-base/agents": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":                  "agent-base",
+				"run_id":              "run-base",
+				"label":               "baseline",
+				"status":              "completed",
+				"agent_deployment_id": "dep-base",
+			}},
+		}),
+	})
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	result := runCIBaselineJSON(t, []string{
+		"ci", "baseline",
+		"--manifest", target,
+		"-w", "ws-1",
+		"--json",
+	}, srv.URL)
+
+	if result.Baseline.RunAgentID != "agent-base" {
+		t.Fatalf("run_agent_id = %q, want agent-base", result.Baseline.RunAgentID)
+	}
+}
+
+func TestCIBaselineResolvesDeploymentBaseline(t *testing.T) {
+	manifest := strings.Replace(sampleCIManifestYAML, "  run_id: 00000000-0000-0000-0000-000000000008\n  refresh: manual\n  max_age_days: 30\n", "  deployment_id: dep-base\n  refresh: manual\n", 1)
+	target := writeCIManifest(t, manifest)
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/runs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{
+					"id":                        "run-old",
+					"workspace_id":              "ws-1",
+					"status":                    "completed",
+					"challenge_pack_version_id": "00000000-0000-0000-0000-000000000005",
+					"challenge_input_set_id":    "00000000-0000-0000-0000-000000000006",
+					"created_at":                "2026-05-01T00:00:00Z",
+				},
+				{
+					"id":                        "run-new",
+					"workspace_id":              "ws-1",
+					"status":                    "completed",
+					"challenge_pack_version_id": "00000000-0000-0000-0000-000000000005",
+					"challenge_input_set_id":    "00000000-0000-0000-0000-000000000006",
+					"created_at":                "2026-05-03T00:00:00Z",
+				},
+			},
+		}),
+		"GET /v1/runs/run-new/agents": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":                  "agent-new",
+				"run_id":              "run-new",
+				"status":              "completed",
+				"agent_deployment_id": "dep-base",
+			}},
+		}),
+	})
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	result := runCIBaselineJSON(t, []string{
+		"ci", "baseline",
+		"--manifest", target,
+		"-w", "ws-1",
+		"--json",
+	}, srv.URL)
+
+	if result.Strategy != "deployment_latest_completed" {
+		t.Fatalf("strategy = %q, want deployment_latest_completed", result.Strategy)
+	}
+	if result.Baseline.RunID != "run-new" || result.Baseline.RunAgentID != "agent-new" || result.Baseline.DeploymentID != "dep-base" {
+		t.Fatalf("baseline = %+v, want run-new/agent-new/dep-base", result.Baseline)
+	}
+}
+
+func TestCIBaselineRejectsStaleRun(t *testing.T) {
+	manifest := strings.Replace(sampleCIManifestYAML, "  run_id: 00000000-0000-0000-0000-000000000008\n", "  run_id: run-old\n", 1)
+	manifest = strings.Replace(manifest, "  max_age_days: 30\n", "  max_age_days: 1\n", 1)
+	target := writeCIManifest(t, manifest)
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/runs/run-old": jsonHandler(200, map[string]any{
+			"id":                        "run-old",
+			"workspace_id":              "ws-1",
+			"status":                    "completed",
+			"challenge_pack_version_id": "00000000-0000-0000-0000-000000000005",
+			"challenge_input_set_id":    "00000000-0000-0000-0000-000000000006",
+			"created_at":                "2000-01-01T00:00:00Z",
+		}),
+	})
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	err := executeCommand(t, []string{
+		"ci", "baseline",
+		"--manifest", target,
+		"-w", "ws-1",
+	}, srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "older than baseline.max_age_days") {
+		t.Fatalf("error = %v, want stale baseline error", err)
+	}
+}
+
+func TestCIBaselineRejectsInaccessibleRun(t *testing.T) {
+	manifest := strings.Replace(sampleCIManifestYAML, "  max_age_days: 30\n", "", 1)
+	target := writeCIManifest(t, manifest)
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/runs/00000000-0000-0000-0000-000000000008": jsonHandler(404, map[string]any{
+			"error": map[string]any{"code": "run_not_found", "message": "run not found"},
+		}),
+	})
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	err := executeCommand(t, []string{
+		"ci", "baseline",
+		"--manifest", target,
+		"-w", "ws-1",
+	}, srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "run_not_found") {
+		t.Fatalf("error = %v, want inaccessible run error", err)
+	}
+}
+
+func TestCIBaselineRejectsMissingDeploymentMatch(t *testing.T) {
+	manifest := strings.Replace(sampleCIManifestYAML, "  run_id: 00000000-0000-0000-0000-000000000008\n  refresh: manual\n  max_age_days: 30\n", "  deployment_id: dep-base\n  refresh: manual\n", 1)
+	target := writeCIManifest(t, manifest)
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/runs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":                        "run-1",
+				"workspace_id":              "ws-1",
+				"status":                    "completed",
+				"challenge_pack_version_id": "00000000-0000-0000-0000-000000000005",
+				"challenge_input_set_id":    "00000000-0000-0000-0000-000000000006",
+				"created_at":                "2026-05-03T00:00:00Z",
+			}},
+		}),
+		"GET /v1/runs/run-1/agents": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":                  "agent-other",
+				"run_id":              "run-1",
+				"status":              "completed",
+				"agent_deployment_id": "dep-other",
+			}},
+		}),
+	})
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	err := executeCommand(t, []string{
+		"ci", "baseline",
+		"--manifest", target,
+		"-w", "ws-1",
+	}, srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "no completed compatible baseline run") {
+		t.Fatalf("error = %v, want missing deployment match", err)
+	}
+}
+
 func writeCIManifest(t *testing.T, text string) string {
 	t.Helper()
 	target := filepath.Join(t.TempDir(), "agentclash-ci.yaml")
@@ -662,6 +966,19 @@ type ciShouldRunJSONResult struct {
 	MatchedLabels []string               `json:"matched_labels"`
 }
 
+type ciBaselineJSONResult struct {
+	Strategy string `json:"strategy"`
+	Source   string `json:"source"`
+	Baseline struct {
+		RunID        string `json:"run_id"`
+		RunAgentID   string `json:"run_agent_id"`
+		DeploymentID string `json:"deployment_id"`
+	} `json:"baseline"`
+	Refresh struct {
+		Mode string `json:"mode"`
+	} `json:"refresh"`
+}
+
 func runCIShouldRunJSON(t *testing.T, args []string) ciShouldRunJSONResult {
 	t.Helper()
 	stdout := captureStdout(t)
@@ -672,6 +989,22 @@ func runCIShouldRunJSON(t *testing.T, args []string) ciShouldRunJSONResult {
 	}
 
 	var result ciShouldRunJSONResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("json output parse error: %v\n---\n%s", err, out)
+	}
+	return result
+}
+
+func runCIBaselineJSON(t *testing.T, args []string, apiURL string) ciBaselineJSONResult {
+	t.Helper()
+	stdout := captureStdout(t)
+	err := executeCommand(t, args, apiURL)
+	out := stdout.finish()
+	if err != nil {
+		t.Fatalf("executeCommand() error: %v", err)
+	}
+
+	var result ciBaselineJSONResult
 	if err := json.Unmarshal([]byte(out), &result); err != nil {
 		t.Fatalf("json output parse error: %v\n---\n%s", err, out)
 	}

--- a/cli/cmd/ci_test.go
+++ b/cli/cmd/ci_test.go
@@ -865,6 +865,78 @@ func TestCIBaselineResolvesDeploymentBaseline(t *testing.T) {
 	}
 }
 
+func TestCIBaselineResolvesDeploymentBaselineAcrossPages(t *testing.T) {
+	manifest := strings.Replace(sampleCIManifestYAML, "  run_id: 00000000-0000-0000-0000-000000000008\n  refresh: manual\n  max_age_days: 30\n", "  deployment_id: dep-base\n  refresh: manual\n", 1)
+	target := writeCIManifest(t, manifest)
+	var offsets []string
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/runs": func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("limit"); got != "100" {
+				t.Errorf("limit = %q, want 100", got)
+			}
+			offset := r.URL.Query().Get("offset")
+			offsets = append(offsets, offset)
+			w.Header().Set("Content-Type", "application/json")
+			switch offset {
+			case "":
+				items := make([]map[string]any, 100)
+				for i := range items {
+					items[i] = map[string]any{
+						"id":                        "run-incompatible",
+						"workspace_id":              "ws-1",
+						"status":                    "completed",
+						"challenge_pack_version_id": "other-pack-version",
+						"challenge_input_set_id":    "00000000-0000-0000-0000-000000000006",
+						"created_at":                "2026-05-03T00:00:00Z",
+					}
+				}
+				json.NewEncoder(w).Encode(map[string]any{"items": items, "total": 101, "limit": 100, "offset": 0})
+			case "100":
+				json.NewEncoder(w).Encode(map[string]any{
+					"items": []map[string]any{{
+						"id":                        "run-new",
+						"workspace_id":              "ws-1",
+						"status":                    "completed",
+						"challenge_pack_version_id": "00000000-0000-0000-0000-000000000005",
+						"challenge_input_set_id":    "00000000-0000-0000-0000-000000000006",
+						"created_at":                "2026-05-04T00:00:00Z",
+					}},
+					"total":  101,
+					"limit":  100,
+					"offset": 100,
+				})
+			default:
+				t.Errorf("offset = %q, want empty or 100", offset)
+				w.WriteHeader(http.StatusNotFound)
+			}
+		},
+		"GET /v1/runs/run-new/agents": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":                  "agent-new",
+				"run_id":              "run-new",
+				"status":              "completed",
+				"agent_deployment_id": "dep-base",
+			}},
+		}),
+	})
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	result := runCIBaselineJSON(t, []string{
+		"ci", "baseline",
+		"--manifest", target,
+		"-w", "ws-1",
+		"--json",
+	}, srv.URL)
+
+	if got := strings.Join(offsets, ","); got != ",100" {
+		t.Fatalf("offsets = %q, want first page then offset 100", got)
+	}
+	if result.Baseline.RunID != "run-new" || result.Baseline.RunAgentID != "agent-new" {
+		t.Fatalf("baseline = %+v, want paged run-new/agent-new", result.Baseline)
+	}
+}
+
 func TestCIBaselineRejectsStaleRun(t *testing.T) {
 	manifest := strings.Replace(sampleCIManifestYAML, "  run_id: 00000000-0000-0000-0000-000000000008\n", "  run_id: run-old\n", 1)
 	manifest = strings.Replace(manifest, "  max_age_days: 30\n", "  max_age_days: 1\n", 1)
@@ -910,6 +982,34 @@ func TestCIBaselineRejectsInaccessibleRun(t *testing.T) {
 	}, srv.URL)
 	if err == nil || !strings.Contains(err.Error(), "run_not_found") {
 		t.Fatalf("error = %v, want inaccessible run error", err)
+	}
+}
+
+func TestCIBaselineRejectsStaleDeploymentCandidate(t *testing.T) {
+	manifest := strings.Replace(sampleCIManifestYAML, "  run_id: 00000000-0000-0000-0000-000000000008\n  refresh: manual\n  max_age_days: 30\n", "  deployment_id: dep-base\n  refresh: manual\n  max_age_days: 1\n", 1)
+	target := writeCIManifest(t, manifest)
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/runs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":                        "run-old",
+				"workspace_id":              "ws-1",
+				"status":                    "completed",
+				"challenge_pack_version_id": "00000000-0000-0000-0000-000000000005",
+				"challenge_input_set_id":    "00000000-0000-0000-0000-000000000006",
+				"created_at":                "2000-01-01T00:00:00Z",
+			}},
+		}),
+	})
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	err := executeCommand(t, []string{
+		"ci", "baseline",
+		"--manifest", target,
+		"-w", "ws-1",
+	}, srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "older than baseline.max_age_days") {
+		t.Fatalf("error = %v, want stale deployment baseline error", err)
 	}
 }
 

--- a/cli/cmd/ci_test.go
+++ b/cli/cmd/ci_test.go
@@ -865,6 +865,56 @@ func TestCIBaselineResolvesDeploymentBaseline(t *testing.T) {
 	}
 }
 
+func TestCIBaselineResolvesDeploymentBaselineByFinishedAt(t *testing.T) {
+	manifest := strings.Replace(sampleCIManifestYAML, "  run_id: 00000000-0000-0000-0000-000000000008\n  refresh: manual\n  max_age_days: 30\n", "  deployment_id: dep-base\n  refresh: manual\n", 1)
+	target := writeCIManifest(t, manifest)
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/runs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{
+					"id":                        "run-created-newer",
+					"workspace_id":              "ws-1",
+					"status":                    "completed",
+					"challenge_pack_version_id": "00000000-0000-0000-0000-000000000005",
+					"challenge_input_set_id":    "00000000-0000-0000-0000-000000000006",
+					"created_at":                "2026-05-04T00:00:00Z",
+					"finished_at":               "2026-05-04T00:10:00Z",
+				},
+				{
+					"id":                        "run-finished-newer",
+					"workspace_id":              "ws-1",
+					"status":                    "completed",
+					"challenge_pack_version_id": "00000000-0000-0000-0000-000000000005",
+					"challenge_input_set_id":    "00000000-0000-0000-0000-000000000006",
+					"created_at":                "2026-05-03T00:00:00Z",
+					"finished_at":               "2026-05-04T00:20:00Z",
+				},
+			},
+		}),
+		"GET /v1/runs/run-finished-newer/agents": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":                  "agent-finished-newer",
+				"run_id":              "run-finished-newer",
+				"status":              "completed",
+				"agent_deployment_id": "dep-base",
+			}},
+		}),
+	})
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	result := runCIBaselineJSON(t, []string{
+		"ci", "baseline",
+		"--manifest", target,
+		"-w", "ws-1",
+		"--json",
+	}, srv.URL)
+
+	if result.Baseline.RunID != "run-finished-newer" || result.Baseline.RunAgentID != "agent-finished-newer" {
+		t.Fatalf("baseline = %+v, want newest finished run", result.Baseline)
+	}
+}
+
 func TestCIBaselineResolvesDeploymentBaselineAcrossPages(t *testing.T) {
 	manifest := strings.Replace(sampleCIManifestYAML, "  run_id: 00000000-0000-0000-0000-000000000008\n  refresh: manual\n  max_age_days: 30\n", "  deployment_id: dep-base\n  refresh: manual\n", 1)
 	target := writeCIManifest(t, manifest)
@@ -1010,6 +1060,42 @@ func TestCIBaselineRejectsStaleDeploymentCandidate(t *testing.T) {
 	}, srv.URL)
 	if err == nil || !strings.Contains(err.Error(), "older than baseline.max_age_days") {
 		t.Fatalf("error = %v, want stale deployment baseline error", err)
+	}
+}
+
+func TestCIBaselineRejectsNonCompletedDeploymentAgent(t *testing.T) {
+	manifest := strings.Replace(sampleCIManifestYAML, "  run_id: 00000000-0000-0000-0000-000000000008\n  refresh: manual\n  max_age_days: 30\n", "  deployment_id: dep-base\n  refresh: manual\n", 1)
+	target := writeCIManifest(t, manifest)
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/runs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":                        "run-1",
+				"workspace_id":              "ws-1",
+				"status":                    "completed",
+				"challenge_pack_version_id": "00000000-0000-0000-0000-000000000005",
+				"challenge_input_set_id":    "00000000-0000-0000-0000-000000000006",
+				"created_at":                "2026-05-03T00:00:00Z",
+			}},
+		}),
+		"GET /v1/runs/run-1/agents": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":                  "agent-running",
+				"run_id":              "run-1",
+				"status":              "running",
+				"agent_deployment_id": "dep-base",
+			}},
+		}),
+	})
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	err := executeCommand(t, []string{
+		"ci", "baseline",
+		"--manifest", target,
+		"-w", "ws-1",
+	}, srv.URL)
+	if err == nil || !strings.Contains(err.Error(), `status is "running", want completed`) {
+		t.Fatalf("error = %v, want non-completed agent baseline error", err)
 	}
 }
 

--- a/cli/cmd/compare.go
+++ b/cli/cmd/compare.go
@@ -23,6 +23,8 @@ func init() {
 
 	compareGateCmd.Flags().String("baseline", "", "Baseline run ID (required)")
 	compareGateCmd.Flags().String("candidate", "", "Candidate run ID (required)")
+	compareGateCmd.Flags().String("baseline-agent", "", "Baseline run agent ID (optional)")
+	compareGateCmd.Flags().String("candidate-agent", "", "Candidate run agent ID (optional)")
 	compareGateCmd.MarkFlagRequired("baseline")
 	compareGateCmd.MarkFlagRequired("candidate")
 }
@@ -173,10 +175,18 @@ This makes the command usable as a CI/CD quality gate.`,
 		rc := GetRunContext(cmd)
 		baseline, _ := cmd.Flags().GetString("baseline")
 		candidate, _ := cmd.Flags().GetString("candidate")
+		baselineAgent, _ := cmd.Flags().GetString("baseline-agent")
+		candidateAgent, _ := cmd.Flags().GetString("candidate-agent")
 
 		body := map[string]any{
 			"baseline_run_id":  baseline,
 			"candidate_run_id": candidate,
+		}
+		if baselineAgent != "" {
+			body["baseline_run_agent_id"] = baselineAgent
+		}
+		if candidateAgent != "" {
+			body["candidate_run_agent_id"] = candidateAgent
 		}
 
 		resp, err := rc.Client.Post(cmd.Context(), "/v1/release-gates/evaluate", body)

--- a/cli/cmd/compare_test.go
+++ b/cli/cmd/compare_test.go
@@ -13,8 +13,8 @@ import (
 
 func TestCompareGateReturnsExitCodeByVerdict(t *testing.T) {
 	cases := []struct {
-		verdict string
-		wantErr bool
+		verdict  string
+		wantErr  bool
 		wantCode int
 	}{
 		{"pass", false, 0},
@@ -117,6 +117,41 @@ func TestCompareGateStructuredOutputPreservesFullPayload(t *testing.T) {
 	}
 }
 
+func TestCompareGateForwardsAgentRefs(t *testing.T) {
+	var gotBody map[string]any
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/release-gates/evaluate": func(w http.ResponseWriter, r *http.Request) {
+			json.NewDecoder(r.Body).Decode(&gotBody)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			json.NewEncoder(w).Encode(map[string]any{
+				"release_gate": map[string]any{
+					"verdict":         "pass",
+					"summary":         "ok",
+					"reason_code":     "all_pass",
+					"evidence_status": "complete",
+				},
+			})
+		},
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{
+		"compare", "gate",
+		"--baseline", "run-b",
+		"--candidate", "run-c",
+		"--baseline-agent", "agent-b",
+		"--candidate-agent", "agent-c",
+	}, srv.URL)
+	if err != nil {
+		t.Fatalf("compare gate error: %v", err)
+	}
+	if gotBody["baseline_run_agent_id"] != "agent-b" || gotBody["candidate_run_agent_id"] != "agent-c" {
+		t.Fatalf("body = %#v, want both agent refs", gotBody)
+	}
+}
+
 func TestCompareGateSanitizesHostileSummary(t *testing.T) {
 	// A compromised backend can't be allowed to:
 	// (1) move the cursor / clear the screen / smuggle OSC hyperlinks, or
@@ -162,11 +197,11 @@ func TestCompareGateSanitizesHostileSummary(t *testing.T) {
 }
 
 type streamCapture struct {
-	t       *testing.T
-	target  **os.File
+	t        *testing.T
+	target   **os.File
 	original *os.File
-	r, w    *os.File
-	done    chan string
+	r, w     *os.File
+	done     chan string
 }
 
 func captureStdout(t *testing.T) *streamCapture {

--- a/cli/cmd/eval_resolve.go
+++ b/cli/cmd/eval_resolve.go
@@ -81,13 +81,15 @@ type runWorkflowSummary struct {
 	ChallengeInputSetID    string `json:"challenge_input_set_id"`
 	OfficialPackMode       string `json:"official_pack_mode"`
 	CreatedAt              string `json:"created_at"`
+	FinishedAt             string `json:"finished_at"`
 }
 
 type runAgentWorkflowSummary struct {
-	ID     string `json:"id"`
-	RunID  string `json:"run_id"`
-	Label  string `json:"label"`
-	Status string `json:"status"`
+	ID                string `json:"id"`
+	RunID             string `json:"run_id"`
+	Label             string `json:"label"`
+	Status            string `json:"status"`
+	AgentDeploymentID string `json:"agent_deployment_id"`
 }
 
 type resolvedChallengePack struct {

--- a/web/content/docs/guides/ci-cd-agent-gates.mdx
+++ b/web/content/docs/guides/ci-cd-agent-gates.mdx
@@ -14,6 +14,7 @@ Create a repo-tracked manifest:
 ```bash
 agentclash ci init .agentclash/ci.yaml
 agentclash ci validate .agentclash/ci.yaml
+agentclash ci baseline --manifest .agentclash/ci.yaml --json
 agentclash ci should-run --changed-file prompts/system.md --json
 ```
 
@@ -44,6 +45,8 @@ evaluation:
     - 00000000-0000-0000-0000-000000000007
 baseline:
   run_id: 00000000-0000-0000-0000-000000000008
+  refresh: manual
+  max_age_days: 30
 gate:
   fail_on: regression
 regressions:
@@ -58,7 +61,7 @@ The IDs in the generated file are placeholders. Replace them with workspace reso
 - `candidate.build` names the existing AgentClash build and the source-backed build-version spec to test.
 - `candidate.deployment` names the runtime resources used for the candidate deployment.
 - `evaluation` names the workload: challenge pack version, optional input set, and optional regression suites or cases.
-- `baseline` names the locked reference run or deployment.
+- `baseline` names the locked reference run or deployment, plus explicit refresh and staleness rules.
 - `gate` names the release-gate failure threshold.
 - `regressions` controls whether failed cases should only be reported, proposed for promotion, or eventually auto-promoted on main.
 
@@ -71,6 +74,37 @@ release gate = decision policy
 ```
 
 If you are deciding what the workload should contain, use [CI/CD Workload Recipes](/docs/guides/ci-cd-workload-recipes) for coding, research, support/ops, and long-horizon agent patterns.
+
+## Baseline strategy and refresh
+
+For pull request gates, prefer `baseline.run_id`. It pins the exact accepted mainline run, so every reviewer can see what changed when the baseline moves. Add `baseline.run_agent_id` only when the locked run has multiple participants and the gate must compare against one specific agent lane.
+
+Use `baseline.deployment_id` only when the team intentionally wants a moving selector. `agentclash ci baseline` resolves it to the newest completed run in the workspace that matches the manifest workload and includes that deployment. The command prints the exact resolved `run_id` and `run_agent_id` so downstream automation still compares against concrete IDs.
+
+Use `baseline.max_age_days` when a stale baseline should block the gate. The resolver checks the chosen run's `finished_at` or `created_at` timestamp and fails instead of silently comparing against old behavior.
+
+Refreshes are explicit:
+
+```yaml
+baseline:
+  run_id: 00000000-0000-0000-0000-000000000008
+  refresh: manual
+  max_age_days: 30
+```
+
+- `manual`: after a successful mainline run, update `baseline.run_id` in a reviewed change.
+- `propose`: automation may propose the new baseline, but a human still reviews the manifest change.
+- `auto_on_main`: a protected mainline workflow may update the manifest with an auditable commit after the gate passes.
+
+Resolve the baseline before running a gate:
+
+```bash
+agentclash ci baseline \
+  --manifest .agentclash/ci.yaml \
+  --json
+```
+
+The JSON includes `strategy`, `source`, `baseline.run_id`, optional `baseline.run_agent_id`, `refresh.mode`, and `refresh.next_action`.
 
 ## Decide whether CI should run
 
@@ -104,7 +138,7 @@ agentclash ci should-run \
 
 ## GitHub Actions sketch
 
-The first shipped CLI surface validates the manifest. Full orchestration will be a follow-up command built on the same file. Until then, teams can validate the contract and keep using the existing explicit run and gate commands. The workflow below repeats selected manifest IDs as GitHub variables only because `agentclash ci run` does not exist yet; once it does, the manifest should be the single source of truth.
+The shipped CI surface validates the manifest, resolves the baseline, and decides whether a gate should run. Full orchestration will be a follow-up command built on the same file. Until then, teams can validate the contract and keep using the existing explicit run and gate commands. The workflow below repeats selected candidate IDs as GitHub variables only because `agentclash ci run` does not exist yet; once it does, the manifest should be the single source of truth.
 
 ```yaml
 name: AgentClash gate
@@ -140,6 +174,18 @@ jobs:
           SHOULD_RUN=$(agentclash ci should-run --json | jq -r '.should_run')
           echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve AgentClash baseline
+        if: steps.should-run.outputs.should_run == 'true'
+        id: baseline
+        run: |
+          BASELINE_JSON=$(agentclash ci baseline --json)
+          echo "run_id=$(echo "$BASELINE_JSON" | jq -r '.baseline.run_id')" >> "$GITHUB_OUTPUT"
+          echo "run_agent_id=$(echo "$BASELINE_JSON" | jq -r '.baseline.run_agent_id // ""')" >> "$GITHUB_OUTPUT"
+        env:
+          AGENTCLASH_API_URL: https://api.agentclash.dev
+          AGENTCLASH_TOKEN: ${{ secrets.AGENTCLASH_TOKEN }}
+          AGENTCLASH_WORKSPACE: ${{ secrets.AGENTCLASH_WORKSPACE }}
+
       - name: Create candidate run
         if: steps.should-run.outputs.should_run == 'true'
         id: candidate
@@ -159,14 +205,19 @@ jobs:
       - name: Evaluate release gate
         if: steps.should-run.outputs.should_run == 'true'
         run: |
-          agentclash compare gate \
-            --baseline "$AGENTCLASH_BASELINE_RUN" \
+          args=(
+            compare gate
+            --baseline "${{ steps.baseline.outputs.run_id }}"
             --candidate "${{ steps.candidate.outputs.run_id }}"
+          )
+          if [ -n "${{ steps.baseline.outputs.run_agent_id }}" ]; then
+            args+=(--baseline-agent "${{ steps.baseline.outputs.run_agent_id }}")
+          fi
+          agentclash "${args[@]}"
         env:
           AGENTCLASH_API_URL: https://api.agentclash.dev
           AGENTCLASH_TOKEN: ${{ secrets.AGENTCLASH_TOKEN }}
           AGENTCLASH_WORKSPACE: ${{ secrets.AGENTCLASH_WORKSPACE }}
-          AGENTCLASH_BASELINE_RUN: ${{ vars.AGENTCLASH_BASELINE_RUN }}
 ```
 
 ## Regression promotion policy
@@ -199,6 +250,7 @@ Only a future main-branch workflow should auto-promote high-confidence failures 
 ## Current limits
 
 - `agentclash ci validate` validates the manifest shape locally; it does not check that IDs exist in the API.
+- `agentclash ci baseline` checks and resolves only the baseline; full API-backed validation for every manifest resource is still separate follow-up work.
 - `agentclash ci should-run` only decides whether a gate should run; it does not create runs or evaluate gates.
 - There is not yet an `agentclash ci run` wrapper that creates the candidate build version, deployment, run, gate, and PR report in one command.
 - PR metadata such as repository, pull request number, branch, and commit SHA is not yet attached to runs by the CLI.

--- a/web/content/docs/guides/ci-cd-agent-gates.mdx
+++ b/web/content/docs/guides/ci-cd-agent-gates.mdx
@@ -220,6 +220,8 @@ jobs:
           AGENTCLASH_WORKSPACE: ${{ secrets.AGENTCLASH_WORKSPACE }}
 ```
 
+For multi-agent candidate runs, also pass `--candidate-agent <run-agent-id>` for the candidate participant you intend to gate.
+
 ## Regression promotion policy
 
 Do not auto-promote every PR failure by default. A bad run, flaky dependency, or weak evaluator could pollute the regression suite.

--- a/web/content/docs/guides/ci-cd-agent-gates.mdx
+++ b/web/content/docs/guides/ci-cd-agent-gates.mdx
@@ -194,7 +194,12 @@ jobs:
             --challenge-pack-version "$AGENTCLASH_CHALLENGE_PACK_VERSION" \
             --deployments "$AGENTCLASH_CANDIDATE_DEPLOYMENT" \
             --json)
-          echo "run_id=$(echo "$RUN_JSON" | jq -r '.id')" >> "$GITHUB_OUTPUT"
+          RUN_ID=$(echo "$RUN_JSON" | jq -r '.id')
+          CANDIDATE_AGENT_ID=$(agentclash run agents "$RUN_ID" --json \
+            | jq -r --arg dep "$AGENTCLASH_CANDIDATE_DEPLOYMENT" '.items[] | select(.agent_deployment_id == $dep) | .id' \
+            | head -n 1)
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "run_agent_id=$CANDIDATE_AGENT_ID" >> "$GITHUB_OUTPUT"
         env:
           AGENTCLASH_API_URL: https://api.agentclash.dev
           AGENTCLASH_TOKEN: ${{ secrets.AGENTCLASH_TOKEN }}
@@ -213,6 +218,9 @@ jobs:
           if [ -n "${{ steps.baseline.outputs.run_agent_id }}" ]; then
             args+=(--baseline-agent "${{ steps.baseline.outputs.run_agent_id }}")
           fi
+          if [ -n "${{ steps.candidate.outputs.run_agent_id }}" ]; then
+            args+=(--candidate-agent "${{ steps.candidate.outputs.run_agent_id }}")
+          fi
           agentclash "${args[@]}"
         env:
           AGENTCLASH_API_URL: https://api.agentclash.dev
@@ -220,7 +228,7 @@ jobs:
           AGENTCLASH_WORKSPACE: ${{ secrets.AGENTCLASH_WORKSPACE }}
 ```
 
-For multi-agent candidate runs, also pass `--candidate-agent <run-agent-id>` for the candidate participant you intend to gate.
+For multi-agent candidate runs, resolve the candidate lane with `agentclash run agents <run-id> --json` and pass `--candidate-agent <run-agent-id>` for the participant you intend to gate.
 
 ## Regression promotion policy
 

--- a/web/content/docs/guides/ci-cd-workload-recipes.mdx
+++ b/web/content/docs/guides/ci-cd-workload-recipes.mdx
@@ -151,13 +151,15 @@ evaluation:
     - 00000000-0000-0000-0000-000000000007
 baseline:
   run_id: 00000000-0000-0000-0000-000000000008
+  refresh: manual
+  max_age_days: 30
 gate:
   fail_on: regression
 regressions:
   promote_failures: proposed
 ```
 
-The exact IDs should come from your AgentClash workspace. The process should be explicit: update the candidate when the agent changes, update the workload when the eval strategy changes, and update the baseline only after the new mainline behavior is accepted.
+The exact IDs should come from your AgentClash workspace. The process should be explicit: update the candidate when the agent changes, update the workload when the eval strategy changes, and update the baseline only after the new mainline behavior is accepted. Use `agentclash ci baseline --manifest .agentclash/ci.yaml --json` in CI to print the exact baseline run used and why.
 
 ## See Also
 


### PR DESCRIPTION
## Summary

- Adds `agentclash ci baseline` to resolve the baseline selected by a CI manifest.
- Recommends locked `baseline.run_id` for PR gates, while supporting `baseline.deployment_id` as a deterministic latest-compatible completed-run selector.
- Adds explicit `baseline.refresh`, optional `baseline.run_agent_id`, and `baseline.max_age_days` handling.
- Lets `agentclash compare gate` forward optional baseline/candidate run-agent IDs.
- Documents the baseline refresh process in README and CI/CD docs.

Closes #505.

## Review Checkpoint

Contract: `/tmp/reviewcheckpoint-issue-505-contract.md`

Implemented in reviewed increments:
- Step 1: CLI baseline resolver and tests.
- Step 2: compare gate agent-ref flags and test.
- Step 3: baseline strategy, refresh, and GitHub Actions docs.
- Final checkpoint verdict: ready.

## Validation

- `cd cli && go test ./cmd -run 'TestCI' -count=1`
- `cd cli && go test ./cmd -run 'TestCompareGate|TestCI' -count=1`
- `cd cli && go test -short ./cmd -count=1`
- `cd cli && go build ./...`
- `cd cli && go vet ./...`
- `cd cli && go test -short -race -count=1 ./...`
- `cd cli && go run . ci init /tmp/agentclash-ci-505.yaml --force`
- `cd cli && go run . ci validate /tmp/agentclash-ci-505.yaml`
- `cd cli && go run . ci validate /tmp/agentclash-ci-505.yaml --json`
- `git diff --check`

## Notes

`web/node_modules` is absent in this fresh worktree, so local web docs tests were not run. GitHub Frontend CI should cover docs navigation/build.

This PR intentionally resolves only baselines. Full manifest API validation remains #500, and full one-command orchestration remains #499.
