### PR TITLE
feat(ci): validate manifest resource IDs against API

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,12 @@ AgentClash CI/CD gates the candidate agent revision against a repeatable workloa
 agentclash ci init .agentclash/ci.yaml
 agentclash ci validate .agentclash/ci.yaml
 export AGENTCLASH_WORKSPACE="your-workspace-id" # or pass -w
+agentclash ci validate .agentclash/ci.yaml --remote --json
 agentclash ci baseline --manifest .agentclash/ci.yaml --json
 agentclash ci should-run --changed-file prompts/system.md --json
 ```
 
-The current CLI can validate that manifest locally and resolve the exact baseline run that the gate will compare against. For pull request gates, prefer a locked `baseline.run_id`; update it only after a successful mainline run in a reviewed, auditable change.
+The current CLI validates that manifest locally by default, can optionally check referenced resource IDs against the selected workspace with `--remote`, and resolves the exact baseline run that the gate will compare against. For pull request gates, prefer a locked `baseline.run_id`; update it only after a successful mainline run in a reviewed, auditable change.
 
 Existing commands also work non-interactively with environment variables and explicit IDs:
 

--- a/cli/cmd/ci.go
+++ b/cli/cmd/ci.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -11,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	cliapi "github.com/agentclash/agentclash/cli/internal/api"
 	"github.com/agentclash/agentclash/cli/internal/output"
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/spf13/cobra"
@@ -25,6 +28,7 @@ func init() {
 	ciCmd.AddCommand(ciBaselineCmd)
 
 	ciInitCmd.Flags().Bool("force", false, "Overwrite an existing manifest")
+	ciValidateCmd.Flags().Bool("remote", false, "Validate manifest resource IDs against the selected workspace")
 	ciBaselineCmd.Flags().String("manifest", ".agentclash/ci.yaml", "Path to the AgentClash CI manifest")
 	ciShouldRunCmd.Flags().String("manifest", ".agentclash/ci.yaml", "Path to the AgentClash CI manifest")
 	ciShouldRunCmd.Flags().StringArray("changed-file", nil, "Changed file path; may be repeated")
@@ -87,7 +91,24 @@ var ciValidateCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		rc := GetRunContext(cmd)
+		remote, _ := cmd.Flags().GetBool("remote")
 		result, err := validateCIManifestFile(args[0])
+		if remote && err == nil {
+			workspaceID := RequireWorkspace(cmd)
+			remoteResult, remoteErr := validateCIManifestRemote(cmd, rc, workspaceID, args[0], *result.Manifest)
+			result.Remote = &remoteResult
+			if len(remoteResult.Errors) > 0 {
+				result.Errors = append(result.Errors, remoteResult.Errors...)
+			}
+			if !remoteResult.Valid {
+				result.Valid = false
+			}
+			if remoteErr != nil {
+				err = fmt.Errorf("remote ci manifest validation failed: %w", remoteErr)
+			} else if !remoteResult.Valid {
+				err = fmt.Errorf("ci manifest remote validation failed")
+			}
+		}
 		if rc.Output.IsStructured() {
 			if printErr := rc.Output.PrintRaw(result); printErr != nil {
 				return printErr
@@ -108,6 +129,10 @@ var ciValidateCmd = &cobra.Command{
 		rc.Output.PrintSuccess("AgentClash CI manifest is valid")
 		rc.Output.PrintDetail("Watched Paths", fmt.Sprintf("%d", len(result.Manifest.Trigger.Paths)))
 		rc.Output.PrintDetail("Evaluation", result.Manifest.Evaluation.ChallengePackVersionID)
+		if result.Remote != nil {
+			rc.Output.PrintDetail("Workspace", result.Remote.WorkspaceID)
+			rc.Output.PrintDetail("Remote Checks", fmt.Sprintf("%d", len(result.Remote.Checks)))
+		}
 		return nil
 	},
 }
@@ -279,10 +304,36 @@ type ciManifestRegressions struct {
 }
 
 type ciManifestValidationResult struct {
-	Path     string      `json:"path" yaml:"path"`
-	Valid    bool        `json:"valid" yaml:"valid"`
-	Errors   []string    `json:"errors,omitempty" yaml:"errors,omitempty"`
-	Manifest *ciManifest `json:"manifest,omitempty" yaml:"manifest,omitempty"`
+	Path     string                            `json:"path" yaml:"path"`
+	Valid    bool                              `json:"valid" yaml:"valid"`
+	Errors   []string                          `json:"errors,omitempty" yaml:"errors,omitempty"`
+	Manifest *ciManifest                       `json:"manifest,omitempty" yaml:"manifest,omitempty"`
+	Remote   *ciManifestRemoteValidationResult `json:"remote,omitempty" yaml:"remote,omitempty"`
+}
+
+type ciManifestRemoteValidationResult struct {
+	WorkspaceID string                  `json:"workspace_id" yaml:"workspace_id"`
+	Valid       bool                    `json:"valid" yaml:"valid"`
+	Checks      []ciManifestRemoteCheck `json:"checks" yaml:"checks"`
+	Errors      []string                `json:"errors,omitempty" yaml:"errors,omitempty"`
+}
+
+type ciManifestRemoteCheck struct {
+	Field    string `json:"field" yaml:"field"`
+	Resource string `json:"resource" yaml:"resource"`
+	ID       string `json:"id,omitempty" yaml:"id,omitempty"`
+	Valid    bool   `json:"valid" yaml:"valid"`
+	Code     string `json:"code,omitempty" yaml:"code,omitempty"`
+	Message  string `json:"message,omitempty" yaml:"message,omitempty"`
+}
+
+type ciRegressionCaseRemoteSummary struct {
+	ID                           string `json:"id"`
+	SuiteID                      string `json:"suite_id"`
+	WorkspaceID                  string `json:"workspace_id"`
+	Status                       string `json:"status"`
+	SourceChallengePackVersionID string `json:"source_challenge_pack_version_id"`
+	SourceChallengeInputSetID    string `json:"source_challenge_input_set_id"`
 }
 
 type ciShouldRunPathMatch struct {
@@ -389,6 +440,386 @@ func validateCIManifestFile(path string) (ciManifestValidationResult, error) {
 		return result, fmt.Errorf("ci manifest validation failed")
 	}
 	return result, nil
+}
+
+func validateCIManifestRemote(cmd *cobra.Command, rc *RunContext, workspaceID, manifestPath string, manifest ciManifest) (ciManifestRemoteValidationResult, error) {
+	result := ciManifestRemoteValidationResult{
+		WorkspaceID: workspaceID,
+		Valid:       true,
+	}
+
+	if _, err := validateCIManifestRemoteAgentBuild(cmd, rc, &result, workspaceID, manifest.Candidate.Build.AgentBuildID); err != nil {
+		result.addAPIError(err)
+		return result, err
+	}
+
+	if _, err := validateCIManifestRemoteListResource(cmd, rc, &result, workspaceID, "candidate.deployment.runtime_profile_id", "runtime_profile", manifest.Candidate.Deployment.RuntimeProfileID, "/v1/workspaces/%s/runtime-profiles"); err != nil {
+		result.addAPIError(err)
+		return result, err
+	}
+	var err error
+	var providerAccount map[string]any
+	if manifest.Candidate.Deployment.ProviderAccountID != "" {
+		providerAccount, err = validateCIManifestRemoteListResource(cmd, rc, &result, workspaceID, "candidate.deployment.provider_account_id", "provider_account", manifest.Candidate.Deployment.ProviderAccountID, "/v1/workspaces/%s/provider-accounts")
+		if err != nil {
+			result.addAPIError(err)
+			return result, err
+		}
+	}
+	var modelAlias map[string]any
+	if manifest.Candidate.Deployment.ModelAliasID != "" {
+		modelAlias, err = validateCIManifestRemoteListResource(cmd, rc, &result, workspaceID, "candidate.deployment.model_alias_id", "model_alias", manifest.Candidate.Deployment.ModelAliasID, "/v1/workspaces/%s/model-aliases")
+		if err != nil {
+			result.addAPIError(err)
+			return result, err
+		}
+	}
+	validateCIManifestRemoteModelProvider(&result, manifest, providerAccount, modelAlias)
+
+	packID, versionID, err := validateCIManifestRemoteChallengeVersion(cmd, rc, &result, workspaceID, manifest.Evaluation.ChallengePackVersionID)
+	if err != nil {
+		result.addAPIError(err)
+		return result, err
+	}
+	if err := validateCIManifestRemoteInputSet(cmd, rc, &result, workspaceID, versionID, manifest.Evaluation.InputSetID); err != nil {
+		result.addAPIError(err)
+		return result, err
+	}
+	var suites []regressionSuiteSummary
+	var selectedSuiteIDs []string
+	if len(manifest.Evaluation.RegressionSuites) > 0 || len(manifest.Evaluation.RegressionCases) > 0 {
+		suites, selectedSuiteIDs, err = validateCIManifestRemoteRegressionSuites(cmd, rc, &result, workspaceID, packID, manifest.Evaluation.RegressionSuites)
+		if err != nil {
+			result.addAPIError(err)
+			return result, err
+		}
+	}
+	if err := validateCIManifestRemoteRegressionCases(cmd, rc, &result, workspaceID, versionID, manifest.Evaluation.InputSetID, suites, selectedSuiteIDs, manifest.Evaluation.RegressionCases); err != nil {
+		result.addAPIError(err)
+		return result, err
+	}
+	if err := validateCIManifestRemoteBaseline(cmd, rc, &result, workspaceID, manifestPath, manifest); err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
+func validateCIManifestRemoteAgentBuild(cmd *cobra.Command, rc *RunContext, result *ciManifestRemoteValidationResult, workspaceID, id string) (map[string]any, error) {
+	field := "candidate.build.agent_build_id"
+	resp, err := rc.Client.Get(cmd.Context(), "/v1/agent-builds/"+id, nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		if ciRemoteAPIErrorCanBeFieldFailure(apiErr) {
+			result.addFailure(field, "agent_build", id, ciRemoteAPIErrorCode(apiErr), fmt.Sprintf("agent build %s is not accessible in workspace %s: %s", id, workspaceID, apiErr.Error()))
+			return nil, nil
+		}
+		return nil, apiErr
+	}
+
+	var build map[string]any
+	if err := resp.DecodeJSON(&build); err != nil {
+		return nil, err
+	}
+	if !ciRemoteWorkspaceMatches(result, field, "agent_build", id, mapString(build, "workspace_id"), workspaceID) {
+		return build, nil
+	}
+	result.addPass(field, "agent_build", id, "agent build is accessible in the selected workspace")
+	return build, nil
+}
+
+func validateCIManifestRemoteListResource(cmd *cobra.Command, rc *RunContext, result *ciManifestRemoteValidationResult, workspaceID, field, resource, id, pathTemplate string) (map[string]any, error) {
+	items, err := listCIManifestRemoteObjects(cmd, rc, fmt.Sprintf(pathTemplate, workspaceID), nil)
+	if err != nil {
+		return nil, err
+	}
+	item, ok := findCIManifestRemoteObjectByID(items, id)
+	if !ok {
+		result.addFailure(field, resource, id, "not_found", fmt.Sprintf("%s %s was not found in or is not accessible to workspace %s", resource, id, workspaceID))
+		return nil, nil
+	}
+	if !ciRemoteWorkspaceMatches(result, field, resource, id, mapString(item, "workspace_id"), workspaceID) {
+		return item, nil
+	}
+	result.addPass(field, resource, id, fmt.Sprintf("%s exists in the selected workspace", resource))
+	return item, nil
+}
+
+func validateCIManifestRemoteModelProvider(result *ciManifestRemoteValidationResult, manifest ciManifest, providerAccount map[string]any, modelAlias map[string]any) {
+	if providerAccount == nil || modelAlias == nil {
+		return
+	}
+	providerAccountID := strings.TrimSpace(manifest.Candidate.Deployment.ProviderAccountID)
+	aliasProviderID := strings.TrimSpace(mapString(modelAlias, "provider_account_id"))
+	if providerAccountID == "" || aliasProviderID == "" || aliasProviderID == providerAccountID {
+		return
+	}
+	result.addFailure(
+		"candidate.deployment.model_alias_id",
+		"model_alias",
+		manifest.Candidate.Deployment.ModelAliasID,
+		"incompatible",
+		fmt.Sprintf("model alias %s uses provider account %s, not candidate.deployment.provider_account_id %s", manifest.Candidate.Deployment.ModelAliasID, aliasProviderID, providerAccountID),
+	)
+}
+
+func validateCIManifestRemoteChallengeVersion(cmd *cobra.Command, rc *RunContext, result *ciManifestRemoteValidationResult, workspaceID, versionID string) (string, string, error) {
+	packs, err := listChallengePacksForWorkflow(cmd, rc, workspaceID)
+	if err != nil {
+		return "", "", err
+	}
+	for _, pack := range packs {
+		for _, version := range pack.Versions {
+			if version.ID == versionID {
+				result.addPass("evaluation.challenge_pack_version_id", "challenge_pack_version", versionID, "challenge pack version exists in the selected workspace")
+				return pack.ID, version.ID, nil
+			}
+		}
+	}
+	result.addFailure("evaluation.challenge_pack_version_id", "challenge_pack_version", versionID, "not_found", fmt.Sprintf("challenge pack version %s was not found in workspace %s", versionID, workspaceID))
+	return "", "", nil
+}
+
+func validateCIManifestRemoteInputSet(cmd *cobra.Command, rc *RunContext, result *ciManifestRemoteValidationResult, workspaceID, challengePackVersionID, inputSetID string) error {
+	if strings.TrimSpace(inputSetID) == "" {
+		return nil
+	}
+	if strings.TrimSpace(challengePackVersionID) == "" {
+		result.addFailure("evaluation.input_set_id", "challenge_input_set", inputSetID, "dependency_failed", "input set cannot be validated because evaluation.challenge_pack_version_id did not resolve")
+		return nil
+	}
+	inputSets, err := listChallengeInputSets(cmd, rc, workspaceID, challengePackVersionID)
+	if err != nil {
+		return err
+	}
+	for _, inputSet := range inputSets {
+		if inputSet.ID == inputSetID {
+			result.addPass("evaluation.input_set_id", "challenge_input_set", inputSetID, "input set exists for the selected challenge pack version")
+			return nil
+		}
+	}
+	result.addFailure("evaluation.input_set_id", "challenge_input_set", inputSetID, "not_found", fmt.Sprintf("input set %s was not found for challenge pack version %s", inputSetID, challengePackVersionID))
+	return nil
+}
+
+func validateCIManifestRemoteRegressionSuites(cmd *cobra.Command, rc *RunContext, result *ciManifestRemoteValidationResult, workspaceID, packID string, suiteIDs []string) ([]regressionSuiteSummary, []string, error) {
+	suites, err := listRegressionSuites(cmd, rc, workspaceID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(suiteIDs) == 0 {
+		return suites, nil, nil
+	}
+
+	var selected []string
+	byID := make(map[string]regressionSuiteSummary, len(suites))
+	for _, suite := range suites {
+		byID[suite.ID] = suite
+	}
+	for _, suiteID := range suiteIDs {
+		suite, ok := byID[suiteID]
+		if !ok {
+			result.addFailure("evaluation.regression_suites", "regression_suite", suiteID, "not_found", fmt.Sprintf("regression suite %s was not found in workspace %s", suiteID, workspaceID))
+			continue
+		}
+		if suite.WorkspaceID != "" && suite.WorkspaceID != workspaceID {
+			result.addFailure("evaluation.regression_suites", "regression_suite", suiteID, "wrong_workspace", fmt.Sprintf("regression suite %s belongs to workspace %s, not %s", suiteID, suite.WorkspaceID, workspaceID))
+			continue
+		}
+		if suite.Status != "" && suite.Status != "active" {
+			result.addFailure("evaluation.regression_suites", "regression_suite", suiteID, "inactive", fmt.Sprintf("regression suite %s status is %s, want active", suiteID, suite.Status))
+			continue
+		}
+		if packID != "" && suite.SourceChallengePackID != "" && suite.SourceChallengePackID != packID {
+			result.addFailure("evaluation.regression_suites", "regression_suite", suiteID, "incompatible", fmt.Sprintf("regression suite %s belongs to challenge pack %s, not %s", suiteID, suite.SourceChallengePackID, packID))
+			continue
+		}
+		selected = append(selected, suite.ID)
+		result.addPass("evaluation.regression_suites", "regression_suite", suiteID, "regression suite exists and is compatible with the selected workload")
+	}
+	return suites, selected, nil
+}
+
+func validateCIManifestRemoteRegressionCases(cmd *cobra.Command, rc *RunContext, result *ciManifestRemoteValidationResult, workspaceID, challengePackVersionID, inputSetID string, suites []regressionSuiteSummary, selectedSuiteIDs []string, caseIDs []string) error {
+	if len(caseIDs) == 0 {
+		return nil
+	}
+	searchSuiteIDs := selectedSuiteIDs
+	if len(searchSuiteIDs) == 0 {
+		for _, suite := range suites {
+			if suite.Status == "" || suite.Status == "active" {
+				searchSuiteIDs = append(searchSuiteIDs, suite.ID)
+			}
+		}
+	}
+	cases, err := listCIManifestRemoteRegressionCases(cmd, rc, workspaceID, searchSuiteIDs)
+	if err != nil {
+		return err
+	}
+	byID := make(map[string]ciRegressionCaseRemoteSummary, len(cases))
+	for _, regressionCase := range cases {
+		byID[regressionCase.ID] = regressionCase
+	}
+	for _, caseID := range caseIDs {
+		regressionCase, ok := byID[caseID]
+		if !ok {
+			result.addFailure("evaluation.regression_cases", "regression_case", caseID, "not_found", fmt.Sprintf("regression case %s was not found in the selected workspace or suites", caseID))
+			continue
+		}
+		if regressionCase.WorkspaceID != "" && regressionCase.WorkspaceID != workspaceID {
+			result.addFailure("evaluation.regression_cases", "regression_case", caseID, "wrong_workspace", fmt.Sprintf("regression case %s belongs to workspace %s, not %s", caseID, regressionCase.WorkspaceID, workspaceID))
+			continue
+		}
+		if regressionCase.Status != "" && regressionCase.Status != "active" {
+			result.addFailure("evaluation.regression_cases", "regression_case", caseID, "inactive", fmt.Sprintf("regression case %s status is %s, want active", caseID, regressionCase.Status))
+			continue
+		}
+		if challengePackVersionID != "" && regressionCase.SourceChallengePackVersionID != "" && regressionCase.SourceChallengePackVersionID != challengePackVersionID {
+			result.addFailure("evaluation.regression_cases", "regression_case", caseID, "incompatible", fmt.Sprintf("regression case %s belongs to challenge pack version %s, not %s", caseID, regressionCase.SourceChallengePackVersionID, challengePackVersionID))
+			continue
+		}
+		if inputSetID != "" && regressionCase.SourceChallengeInputSetID != "" && regressionCase.SourceChallengeInputSetID != inputSetID {
+			result.addFailure("evaluation.regression_cases", "regression_case", caseID, "incompatible", fmt.Sprintf("regression case %s belongs to input set %s, not %s", caseID, regressionCase.SourceChallengeInputSetID, inputSetID))
+			continue
+		}
+		result.addPass("evaluation.regression_cases", "regression_case", caseID, "regression case exists and is compatible with the selected workload")
+	}
+	return nil
+}
+
+func validateCIManifestRemoteBaseline(cmd *cobra.Command, rc *RunContext, result *ciManifestRemoteValidationResult, workspaceID, manifestPath string, manifest ciManifest) error {
+	field := "baseline.run_id"
+	resource := "run"
+	id := strings.TrimSpace(manifest.Baseline.RunID)
+	if id == "" {
+		field = "baseline.deployment_id"
+		resource = "agent_deployment"
+		id = strings.TrimSpace(manifest.Baseline.DeploymentID)
+	}
+	_, err := resolveCIManifestBaseline(cmd, rc, workspaceID, manifestPath, manifest, time.Now().UTC())
+	if err == nil {
+		result.addPass(field, resource, id, "baseline resolves to a completed run compatible with the selected workload")
+		return nil
+	}
+	if apiErr, ok := ciRemoteAPIError(err); ok && !ciRemoteAPIErrorCanBeFieldFailure(apiErr) {
+		result.addAPIError(err)
+		return err
+	}
+	result.addFailure(field, resource, id, "incompatible", err.Error())
+	return nil
+}
+
+func listCIManifestRemoteObjects(cmd *cobra.Command, rc *RunContext, path string, query url.Values) ([]map[string]any, error) {
+	resp, err := rc.Client.Get(cmd.Context(), path, query)
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return nil, apiErr
+	}
+	var result struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := resp.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+	return result.Items, nil
+}
+
+func listCIManifestRemoteRegressionCases(cmd *cobra.Command, rc *RunContext, workspaceID string, suiteIDs []string) ([]ciRegressionCaseRemoteSummary, error) {
+	var cases []ciRegressionCaseRemoteSummary
+	for _, suiteID := range suiteIDs {
+		resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+workspaceID+"/regression-suites/"+suiteID+"/cases", nil)
+		if err != nil {
+			return nil, err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return nil, apiErr
+		}
+		var result struct {
+			Items []ciRegressionCaseRemoteSummary `json:"items"`
+		}
+		if err := resp.DecodeJSON(&result); err != nil {
+			return nil, err
+		}
+		cases = append(cases, result.Items...)
+	}
+	return cases, nil
+}
+
+func findCIManifestRemoteObjectByID(items []map[string]any, id string) (map[string]any, bool) {
+	for _, item := range items {
+		if mapString(item, "id") == id {
+			return item, true
+		}
+	}
+	return nil, false
+}
+
+func ciRemoteWorkspaceMatches(result *ciManifestRemoteValidationResult, field, resource, id, resourceWorkspaceID, selectedWorkspaceID string) bool {
+	if resourceWorkspaceID == "" || selectedWorkspaceID == "" || resourceWorkspaceID == selectedWorkspaceID {
+		return true
+	}
+	result.addFailure(field, resource, id, "wrong_workspace", fmt.Sprintf("%s %s belongs to workspace %s, not %s", resource, id, resourceWorkspaceID, selectedWorkspaceID))
+	return false
+}
+
+func (r *ciManifestRemoteValidationResult) addPass(field, resource, id, message string) {
+	r.Checks = append(r.Checks, ciManifestRemoteCheck{
+		Field:    field,
+		Resource: resource,
+		ID:       id,
+		Valid:    true,
+		Code:     "ok",
+		Message:  message,
+	})
+}
+
+func (r *ciManifestRemoteValidationResult) addFailure(field, resource, id, code, message string) {
+	r.Valid = false
+	r.Checks = append(r.Checks, ciManifestRemoteCheck{
+		Field:    field,
+		Resource: resource,
+		ID:       id,
+		Valid:    false,
+		Code:     code,
+		Message:  message,
+	})
+	r.Errors = append(r.Errors, fmt.Sprintf("%s: %s", field, message))
+}
+
+func (r *ciManifestRemoteValidationResult) addAPIError(err error) {
+	r.Valid = false
+	r.Errors = append(r.Errors, fmt.Sprintf("remote API error: %v", err))
+}
+
+func ciRemoteAPIError(err error) (*cliapi.APIError, bool) {
+	var apiErr *cliapi.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr, true
+	}
+	return nil, false
+}
+
+func ciRemoteAPIErrorCanBeFieldFailure(apiErr *cliapi.APIError) bool {
+	switch apiErr.StatusCode {
+	case http.StatusBadRequest, http.StatusForbidden, http.StatusNotFound:
+		return true
+	default:
+		return false
+	}
+}
+
+func ciRemoteAPIErrorCode(apiErr *cliapi.APIError) string {
+	if apiErr.Code != "" {
+		return apiErr.Code
+	}
+	if apiErr.StatusCode > 0 {
+		return fmt.Sprintf("http_%d", apiErr.StatusCode)
+	}
+	return "api_error"
 }
 
 func validateCIManifest(manifest ciManifest) []string {

--- a/cli/cmd/ci.go
+++ b/cli/cmd/ci.go
@@ -494,7 +494,7 @@ func validateCIManifestRemote(cmd *cobra.Command, rc *RunContext, workspaceID, m
 			return result, err
 		}
 	}
-	if err := validateCIManifestRemoteRegressionCases(cmd, rc, &result, workspaceID, versionID, manifest.Evaluation.InputSetID, suites, selectedSuiteIDs, manifest.Evaluation.RegressionCases); err != nil {
+	if err := validateCIManifestRemoteRegressionCases(cmd, rc, &result, workspaceID, versionID, manifest.Evaluation.InputSetID, suites, selectedSuiteIDs, len(manifest.Evaluation.RegressionSuites) > 0, manifest.Evaluation.RegressionCases); err != nil {
 		result.addAPIError(err)
 		return result, err
 	}
@@ -642,8 +642,14 @@ func validateCIManifestRemoteRegressionSuites(cmd *cobra.Command, rc *RunContext
 	return suites, selected, nil
 }
 
-func validateCIManifestRemoteRegressionCases(cmd *cobra.Command, rc *RunContext, result *ciManifestRemoteValidationResult, workspaceID, challengePackVersionID, inputSetID string, suites []regressionSuiteSummary, selectedSuiteIDs []string, caseIDs []string) error {
+func validateCIManifestRemoteRegressionCases(cmd *cobra.Command, rc *RunContext, result *ciManifestRemoteValidationResult, workspaceID, challengePackVersionID, inputSetID string, suites []regressionSuiteSummary, selectedSuiteIDs []string, suiteScopeExplicit bool, caseIDs []string) error {
 	if len(caseIDs) == 0 {
+		return nil
+	}
+	if suiteScopeExplicit && len(selectedSuiteIDs) == 0 {
+		for _, caseID := range caseIDs {
+			result.addFailure("evaluation.regression_cases", "regression_case", caseID, "dependency_failed", "regression case cannot be validated because no explicit evaluation.regression_suites entry resolved")
+		}
 		return nil
 	}
 	searchSuiteIDs := selectedSuiteIDs
@@ -703,7 +709,11 @@ func validateCIManifestRemoteBaseline(cmd *cobra.Command, rc *RunContext, result
 		result.addPass(field, resource, id, "baseline resolves to a completed run compatible with the selected workload")
 		return nil
 	}
-	if apiErr, ok := ciRemoteAPIError(err); ok && !ciRemoteAPIErrorCanBeFieldFailure(apiErr) {
+	if apiErr, ok := ciRemoteAPIError(err); ok {
+		if ciRemoteAPIErrorCanBeFieldFailure(apiErr) {
+			result.addFailure(field, resource, id, ciRemoteAPIErrorCode(apiErr), err.Error())
+			return nil
+		}
 		result.addAPIError(err)
 		return err
 	}

--- a/cli/cmd/ci.go
+++ b/cli/cmd/ci.go
@@ -696,22 +696,15 @@ func validateCIManifestRemoteRegressionCases(cmd *cobra.Command, rc *RunContext,
 }
 
 func validateCIManifestRemoteBaseline(cmd *cobra.Command, rc *RunContext, result *ciManifestRemoteValidationResult, workspaceID, manifestPath string, manifest ciManifest) error {
-	field := "baseline.run_id"
-	resource := "run"
-	id := strings.TrimSpace(manifest.Baseline.RunID)
-	if id == "" {
-		field = "baseline.deployment_id"
-		resource = "agent_deployment"
-		id = strings.TrimSpace(manifest.Baseline.DeploymentID)
-	}
 	_, err := resolveCIManifestBaseline(cmd, rc, workspaceID, manifestPath, manifest, time.Now().UTC())
+	field, resource, id := ciManifestRemoteBaselineField(manifest, err)
 	if err == nil {
 		result.addPass(field, resource, id, "baseline resolves to a completed run compatible with the selected workload")
 		return nil
 	}
 	if apiErr, ok := ciRemoteAPIError(err); ok {
 		if ciRemoteAPIErrorCanBeFieldFailure(apiErr) {
-			result.addFailure(field, resource, id, ciRemoteAPIErrorCode(apiErr), err.Error())
+			result.addFailure(field, resource, id, ciRemoteAPIErrorCode(apiErr), apiErr.Error())
 			return nil
 		}
 		result.addAPIError(err)
@@ -721,27 +714,27 @@ func validateCIManifestRemoteBaseline(cmd *cobra.Command, rc *RunContext, result
 	return nil
 }
 
-func listCIManifestRemoteObjects(cmd *cobra.Command, rc *RunContext, path string, query url.Values) ([]map[string]any, error) {
-	resp, err := rc.Client.Get(cmd.Context(), path, query)
-	if err != nil {
-		return nil, err
+func ciManifestRemoteBaselineField(manifest ciManifest, err error) (string, string, string) {
+	if strings.TrimSpace(manifest.Baseline.RunAgentID) != "" && err != nil && strings.Contains(err.Error(), "baseline.run_agent_id") {
+		return "baseline.run_agent_id", "run_agent", strings.TrimSpace(manifest.Baseline.RunAgentID)
 	}
-	if apiErr := resp.ParseError(); apiErr != nil {
-		return nil, apiErr
+	if runID := strings.TrimSpace(manifest.Baseline.RunID); runID != "" {
+		return "baseline.run_id", "run", runID
 	}
-	var result struct {
-		Items []map[string]any `json:"items"`
-	}
-	if err := resp.DecodeJSON(&result); err != nil {
-		return nil, err
-	}
-	return result.Items, nil
+	return "baseline.deployment_id", "agent_deployment", strings.TrimSpace(manifest.Baseline.DeploymentID)
 }
 
-func listCIManifestRemoteRegressionCases(cmd *cobra.Command, rc *RunContext, workspaceID string, suiteIDs []string) ([]ciRegressionCaseRemoteSummary, error) {
-	var cases []ciRegressionCaseRemoteSummary
-	for _, suiteID := range suiteIDs {
-		resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+workspaceID+"/regression-suites/"+suiteID+"/cases", nil)
+const ciRemoteValidationPageLimit = 100
+
+func listCIManifestRemoteObjects(cmd *cobra.Command, rc *RunContext, path string, query url.Values) ([]map[string]any, error) {
+	var items []map[string]any
+	for offset := 0; ; offset += ciRemoteValidationPageLimit {
+		pageQuery := cloneURLValues(query)
+		pageQuery.Set("limit", fmt.Sprintf("%d", ciRemoteValidationPageLimit))
+		if offset > 0 {
+			pageQuery.Set("offset", fmt.Sprintf("%d", offset))
+		}
+		resp, err := rc.Client.Get(cmd.Context(), path, pageQuery)
 		if err != nil {
 			return nil, err
 		}
@@ -749,14 +742,60 @@ func listCIManifestRemoteRegressionCases(cmd *cobra.Command, rc *RunContext, wor
 			return nil, apiErr
 		}
 		var result struct {
-			Items []ciRegressionCaseRemoteSummary `json:"items"`
+			Items []map[string]any `json:"items"`
+			Total *int64           `json:"total,omitempty"`
 		}
 		if err := resp.DecodeJSON(&result); err != nil {
 			return nil, err
 		}
-		cases = append(cases, result.Items...)
+		items = append(items, result.Items...)
+		if result.Total == nil || len(result.Items) == 0 || len(result.Items) < ciRemoteValidationPageLimit || int64(len(items)) >= *result.Total {
+			break
+		}
+	}
+	return items, nil
+}
+
+func listCIManifestRemoteRegressionCases(cmd *cobra.Command, rc *RunContext, workspaceID string, suiteIDs []string) ([]ciRegressionCaseRemoteSummary, error) {
+	var cases []ciRegressionCaseRemoteSummary
+	for _, suiteID := range suiteIDs {
+		suiteCasesFetched := 0
+		for offset := 0; ; offset += ciRemoteValidationPageLimit {
+			query := url.Values{}
+			query.Set("limit", fmt.Sprintf("%d", ciRemoteValidationPageLimit))
+			if offset > 0 {
+				query.Set("offset", fmt.Sprintf("%d", offset))
+			}
+			resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+workspaceID+"/regression-suites/"+suiteID+"/cases", query)
+			if err != nil {
+				return nil, err
+			}
+			if apiErr := resp.ParseError(); apiErr != nil {
+				return nil, apiErr
+			}
+			var result struct {
+				Items []ciRegressionCaseRemoteSummary `json:"items"`
+				Total *int64                          `json:"total,omitempty"`
+			}
+			if err := resp.DecodeJSON(&result); err != nil {
+				return nil, err
+			}
+			cases = append(cases, result.Items...)
+			suiteCasesFetched += len(result.Items)
+			if result.Total == nil || len(result.Items) == 0 || len(result.Items) < ciRemoteValidationPageLimit || int64(suiteCasesFetched) >= *result.Total {
+				break
+			}
+		}
 	}
 	return cases, nil
+}
+
+func cloneURLValues(values url.Values) url.Values {
+	out := url.Values{}
+	for key, entries := range values {
+		out[key] = append([]string(nil), entries...)
+	}
+	return out
 }
 
 func findCIManifestRemoteObjectByID(items []map[string]any, id string) (map[string]any, bool) {

--- a/cli/cmd/ci_test.go
+++ b/cli/cmd/ci_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -455,6 +456,140 @@ regressions:
 				t.Fatalf("errors = %v, want %q", result.Errors, tt.want)
 			}
 		})
+	}
+}
+
+func TestCIValidateRemoteSuccess(t *testing.T) {
+	target := writeCIManifest(t, strings.Replace(sampleCIManifestYAML, "  max_age_days: 30\n", "", 1))
+	srv := fakeAPI(t, remoteCIValidateRoutes(t, nil))
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	result, err, _ := runCIValidateJSON(t, []string{"ci", "validate", target, "--remote", "-w", "ws-1", "--json"}, srv.URL)
+	if err != nil {
+		t.Fatalf("ci validate --remote error: %v", err)
+	}
+	if !result.Valid {
+		t.Fatalf("valid = false, errors = %v", result.Errors)
+	}
+	if result.Remote == nil || !result.Remote.Valid {
+		t.Fatalf("remote = %+v, want valid remote result", result.Remote)
+	}
+	for _, field := range []string{
+		"candidate.build.agent_build_id",
+		"candidate.deployment.runtime_profile_id",
+		"candidate.deployment.provider_account_id",
+		"candidate.deployment.model_alias_id",
+		"evaluation.challenge_pack_version_id",
+		"evaluation.input_set_id",
+		"evaluation.regression_suites",
+		"baseline.run_id",
+	} {
+		if !ciRemoteChecksContainField(result.Remote.Checks, field, true) {
+			t.Fatalf("remote checks missing valid field %q: %+v", field, result.Remote.Checks)
+		}
+	}
+}
+
+func TestCIValidateRemoteIsOptIn(t *testing.T) {
+	target := writeCIManifest(t, sampleCIManifestYAML)
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	result, err, _ := runCIValidateJSON(t, []string{"ci", "validate", target, "--json"}, srv.URL)
+	if err != nil {
+		t.Fatalf("ci validate --json error: %v", err)
+	}
+	if !result.Valid {
+		t.Fatalf("valid = false, errors = %v", result.Errors)
+	}
+	if called {
+		t.Fatal("offline ci validate made an API request without --remote")
+	}
+	if result.Remote != nil {
+		t.Fatalf("remote = %+v, want nil without --remote", result.Remote)
+	}
+}
+
+func TestCIValidateRemoteMissingResourceReportsField(t *testing.T) {
+	target := writeCIManifest(t, strings.Replace(sampleCIManifestYAML, "  max_age_days: 30\n", "", 1))
+	srv := fakeAPI(t, remoteCIValidateRoutes(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/runtime-profiles": jsonHandler(200, map[string]any{"items": []map[string]any{}}),
+	}))
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	result, err, _ := runCIValidateJSON(t, []string{"ci", "validate", target, "--remote", "-w", "ws-1", "--json"}, srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "ci manifest remote validation failed") {
+		t.Fatalf("error = %v, want remote validation failure", err)
+	}
+	if result.Valid || result.Remote == nil || result.Remote.Valid {
+		t.Fatalf("result = %+v, want invalid remote result", result)
+	}
+	if !ciRemoteChecksContainField(result.Remote.Checks, "candidate.deployment.runtime_profile_id", false) {
+		t.Fatalf("remote checks missing runtime failure: %+v", result.Remote.Checks)
+	}
+	if !strings.Contains(strings.Join(result.Errors, "\n"), "candidate.deployment.runtime_profile_id") {
+		t.Fatalf("errors = %v, want runtime field error", result.Errors)
+	}
+}
+
+func TestCIValidateRemoteWrongWorkspaceRunReportsField(t *testing.T) {
+	target := writeCIManifest(t, strings.Replace(sampleCIManifestYAML, "  max_age_days: 30\n", "", 1))
+	srv := fakeAPI(t, remoteCIValidateRoutes(t, map[string]http.HandlerFunc{
+		"GET /v1/runs/00000000-0000-0000-0000-000000000008": jsonHandler(200, map[string]any{
+			"id":                        "00000000-0000-0000-0000-000000000008",
+			"workspace_id":              "ws-other",
+			"status":                    "completed",
+			"challenge_pack_version_id": "00000000-0000-0000-0000-000000000005",
+			"challenge_input_set_id":    "00000000-0000-0000-0000-000000000006",
+			"created_at":                "2026-05-01T00:00:00Z",
+		}),
+	}))
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	result, err, _ := runCIValidateJSON(t, []string{"ci", "validate", target, "--remote", "-w", "ws-1", "--json"}, srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "ci manifest remote validation failed") {
+		t.Fatalf("error = %v, want remote validation failure", err)
+	}
+	if result.Remote == nil || result.Remote.Valid {
+		t.Fatalf("remote = %+v, want invalid remote result", result.Remote)
+	}
+	if !ciRemoteChecksContainField(result.Remote.Checks, "baseline.run_id", false) {
+		t.Fatalf("remote checks missing baseline failure: %+v", result.Remote.Checks)
+	}
+	if !strings.Contains(strings.Join(result.Errors, "\n"), "belongs to workspace ws-other") {
+		t.Fatalf("errors = %v, want wrong-workspace diagnostic", result.Errors)
+	}
+}
+
+func TestCIValidateRemoteAuthFailureIsAPIError(t *testing.T) {
+	target := writeCIManifest(t, strings.Replace(sampleCIManifestYAML, "  max_age_days: 30\n", "", 1))
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/agent-builds/00000000-0000-0000-0000-000000000001": jsonHandler(401, map[string]any{
+			"error": map[string]any{"code": "unauthorized", "message": "bad token"},
+		}),
+	})
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	result, err, _ := runCIValidateJSON(t, []string{"ci", "validate", target, "--remote", "-w", "ws-1", "--json"}, srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "remote ci manifest validation failed") {
+		t.Fatalf("error = %v, want API failure", err)
+	}
+	if result.Remote == nil || result.Remote.Valid {
+		t.Fatalf("remote = %+v, want invalid remote API result", result.Remote)
+	}
+	if !strings.Contains(strings.Join(result.Remote.Errors, "\n"), "remote API error") {
+		t.Fatalf("remote errors = %v, want distinct API error", result.Remote.Errors)
+	}
+	if len(result.Remote.Checks) != 0 {
+		t.Fatalf("checks = %+v, want no contract checks for auth failure", result.Remote.Checks)
 	}
 }
 
@@ -1257,6 +1392,100 @@ func runCIBaselineJSON(t *testing.T, args []string, apiURL string) ciBaselineJSO
 		t.Fatalf("json output parse error: %v\n---\n%s", err, out)
 	}
 	return result
+}
+
+func runCIValidateJSON(t *testing.T, args []string, apiURL string) (ciManifestValidationResult, error, string) {
+	t.Helper()
+	stdout := captureStdout(t)
+	err := executeCommand(t, args, apiURL)
+	out := stdout.finish()
+
+	var result ciManifestValidationResult
+	if decodeErr := json.Unmarshal([]byte(out), &result); decodeErr != nil {
+		t.Fatalf("json output parse error: %v\n---\n%s", decodeErr, out)
+	}
+	return result, err, out
+}
+
+func ciRemoteChecksContainField(checks []ciManifestRemoteCheck, field string, valid bool) bool {
+	for _, check := range checks {
+		if check.Field == field && check.Valid == valid {
+			return true
+		}
+	}
+	return false
+}
+
+func remoteCIValidateRoutes(t *testing.T, overrides map[string]http.HandlerFunc) map[string]http.HandlerFunc {
+	t.Helper()
+	routes := map[string]http.HandlerFunc{
+		"GET /v1/agent-builds/00000000-0000-0000-0000-000000000001": jsonHandler(200, map[string]any{
+			"id":           "00000000-0000-0000-0000-000000000001",
+			"workspace_id": "ws-1",
+			"name":         "Candidate build",
+		}),
+		"GET /v1/workspaces/ws-1/runtime-profiles": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":           "00000000-0000-0000-0000-000000000002",
+				"workspace_id": "ws-1",
+				"name":         "CI runtime",
+			}},
+		}),
+		"GET /v1/workspaces/ws-1/provider-accounts": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":           "00000000-0000-0000-0000-000000000003",
+				"workspace_id": "ws-1",
+				"name":         "CI provider",
+			}},
+		}),
+		"GET /v1/workspaces/ws-1/model-aliases": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":                  "00000000-0000-0000-0000-000000000004",
+				"workspace_id":        "ws-1",
+				"provider_account_id": "00000000-0000-0000-0000-000000000003",
+				"display_name":        "CI model",
+			}},
+		}),
+		"GET /v1/workspaces/ws-1/challenge-packs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":   "pack-1",
+				"name": "CI pack",
+				"versions": []map[string]any{{
+					"id":               "00000000-0000-0000-0000-000000000005",
+					"version_number":   1,
+					"lifecycle_status": "published",
+				}},
+			}},
+		}),
+		"GET /v1/workspaces/ws-1/challenge-pack-versions/00000000-0000-0000-0000-000000000005/input-sets": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":        "00000000-0000-0000-0000-000000000006",
+				"input_key": "default",
+				"name":      "Default",
+			}},
+		}),
+		"GET /v1/workspaces/ws-1/regression-suites": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":                       "00000000-0000-0000-0000-000000000007",
+				"workspace_id":             "ws-1",
+				"source_challenge_pack_id": "pack-1",
+				"name":                     "Critical regressions",
+				"status":                   "active",
+			}},
+		}),
+		"GET /v1/runs/00000000-0000-0000-0000-000000000008": jsonHandler(200, map[string]any{
+			"id":                        "00000000-0000-0000-0000-000000000008",
+			"workspace_id":              "ws-1",
+			"status":                    "completed",
+			"challenge_pack_version_id": "00000000-0000-0000-0000-000000000005",
+			"challenge_input_set_id":    "00000000-0000-0000-0000-000000000006",
+			"created_at":                "2026-05-01T00:00:00Z",
+		}),
+	}
+	for key, handler := range overrides {
+		routes[key] = handler
+	}
+	return routes
 }
 
 func runGit(t *testing.T, dir string, args ...string) string {

--- a/cli/cmd/ci_test.go
+++ b/cli/cmd/ci_test.go
@@ -593,6 +593,82 @@ func TestCIValidateRemoteAuthFailureIsAPIError(t *testing.T) {
 	}
 }
 
+func TestCIValidateRemotePreservesBaselineAPIErrorCode(t *testing.T) {
+	target := writeCIManifest(t, strings.Replace(sampleCIManifestYAML, "  max_age_days: 30\n", "", 1))
+	srv := fakeAPI(t, remoteCIValidateRoutes(t, map[string]http.HandlerFunc{
+		"GET /v1/runs/00000000-0000-0000-0000-000000000008": jsonHandler(404, map[string]any{
+			"error": map[string]any{"code": "run_not_found", "message": "run not found"},
+		}),
+	}))
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	result, err, _ := runCIValidateJSON(t, []string{"ci", "validate", target, "--remote", "-w", "ws-1", "--json"}, srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "ci manifest remote validation failed") {
+		t.Fatalf("error = %v, want remote validation failure", err)
+	}
+	var baselineCheck *ciManifestRemoteCheck
+	for i := range result.Remote.Checks {
+		if result.Remote.Checks[i].Field == "baseline.run_id" {
+			baselineCheck = &result.Remote.Checks[i]
+			break
+		}
+	}
+	if baselineCheck == nil {
+		t.Fatalf("checks = %+v, want baseline check", result.Remote.Checks)
+	}
+	if baselineCheck.Code != "run_not_found" {
+		t.Fatalf("baseline check code = %q, want run_not_found", baselineCheck.Code)
+	}
+}
+
+func TestCIValidateRemoteRegressionCasesStayScopedToExplicitSuites(t *testing.T) {
+	manifest := strings.Replace(sampleCIManifestYAML, "  max_age_days: 30\n", "", 1)
+	manifest = strings.Replace(manifest,
+		"  regression_suites:\n    - 00000000-0000-0000-0000-000000000007\n",
+		"  regression_suites:\n    - 00000000-0000-0000-0000-000000000007\n  regression_cases:\n    - case-1\n",
+		1,
+	)
+	target := writeCIManifest(t, manifest)
+	srv := fakeAPI(t, remoteCIValidateRoutes(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/regression-suites": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":                       "suite-other",
+				"workspace_id":             "ws-1",
+				"source_challenge_pack_id": "pack-1",
+				"name":                     "Other suite",
+				"status":                   "active",
+			}},
+		}),
+		"GET /v1/workspaces/ws-1/regression-suites/suite-other/cases": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":                               "case-1",
+				"suite_id":                         "suite-other",
+				"workspace_id":                     "ws-1",
+				"status":                           "active",
+				"source_challenge_pack_version_id": "00000000-0000-0000-0000-000000000005",
+				"source_challenge_input_set_id":    "00000000-0000-0000-0000-000000000006",
+			}},
+		}),
+	}))
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	result, err, _ := runCIValidateJSON(t, []string{"ci", "validate", target, "--remote", "-w", "ws-1", "--json"}, srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "ci manifest remote validation failed") {
+		t.Fatalf("error = %v, want remote validation failure", err)
+	}
+	if !ciRemoteChecksContainField(result.Remote.Checks, "evaluation.regression_suites", false) {
+		t.Fatalf("remote checks missing suite failure: %+v", result.Remote.Checks)
+	}
+	if !ciRemoteChecksContainField(result.Remote.Checks, "evaluation.regression_cases", false) {
+		t.Fatalf("remote checks missing scoped case failure: %+v", result.Remote.Checks)
+	}
+	if strings.Contains(strings.Join(result.Remote.Errors, "\n"), "regression case exists and is compatible") {
+		t.Fatalf("remote errors unexpectedly passed case from unselected suite: %v", result.Remote.Errors)
+	}
+}
+
 func TestCIShouldRunMatchesChangedPath(t *testing.T) {
 	target := writeCIManifest(t, sampleCIManifestYAML)
 	result := runCIShouldRunJSON(t, []string{

--- a/cli/cmd/ci_test.go
+++ b/cli/cmd/ci_test.go
@@ -669,6 +669,34 @@ func TestCIValidateRemoteRegressionCasesStayScopedToExplicitSuites(t *testing.T)
 	}
 }
 
+func TestCIValidateRemoteBaselineRunAgentReportsRunAgentField(t *testing.T) {
+	manifest := strings.Replace(sampleCIManifestYAML, "  max_age_days: 30\n", "", 1)
+	manifest = strings.Replace(manifest,
+		"  run_id: 00000000-0000-0000-0000-000000000008\n",
+		"  run_id: 00000000-0000-0000-0000-000000000008\n  run_agent_id: agent-missing\n",
+		1,
+	)
+	target := writeCIManifest(t, manifest)
+	srv := fakeAPI(t, remoteCIValidateRoutes(t, map[string]http.HandlerFunc{
+		"GET /v1/runs/00000000-0000-0000-0000-000000000008/agents": jsonHandler(200, map[string]any{
+			"items": []map[string]any{},
+		}),
+	}))
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	result, err, _ := runCIValidateJSON(t, []string{"ci", "validate", target, "--remote", "-w", "ws-1", "--json"}, srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "ci manifest remote validation failed") {
+		t.Fatalf("error = %v, want remote validation failure", err)
+	}
+	if !ciRemoteChecksContainField(result.Remote.Checks, "baseline.run_agent_id", false) {
+		t.Fatalf("remote checks missing run-agent failure: %+v", result.Remote.Checks)
+	}
+	if ciRemoteChecksContainField(result.Remote.Checks, "baseline.run_id", false) {
+		t.Fatalf("remote checks attributed run-agent failure to run id: %+v", result.Remote.Checks)
+	}
+}
+
 func TestCIShouldRunMatchesChangedPath(t *testing.T) {
 	target := writeCIManifest(t, sampleCIManifestYAML)
 	result := runCIShouldRunJSON(t, []string{

--- a/web/content/docs/guides/ci-cd-agent-gates.mdx
+++ b/web/content/docs/guides/ci-cd-agent-gates.mdx
@@ -56,7 +56,7 @@ regressions:
 
 The IDs in the generated file are placeholders. Replace them with workspace resources before using the manifest for a real gate.
 
-Local validation is always offline. Add `--remote` when you want the CLI to call the AgentClash API and verify that the manifest's agent build, runtime profile, provider account, model alias, challenge pack version, input set, regression suites or cases, and baseline are visible from the selected workspace. JSON output includes a `remote.checks[]` entry per referenced field, so CI can report whether a failure came from the local manifest contract or from an API/resource check.
+Local validation is always offline. Add `--remote` when you want the CLI to call the AgentClash API and verify that the manifest's agent build, runtime profile, provider account, model alias, challenge pack version, input set, regression suites or cases, and baseline are visible from the selected workspace. Because this makes real authenticated API calls, set `AGENTCLASH_API_URL`, `AGENTCLASH_TOKEN`, and `AGENTCLASH_WORKSPACE` in CI and expect normal API latency, rate limits, and token scoping rules. JSON output includes a `remote.checks[]` entry per referenced field, so CI can report whether a failure came from the local manifest contract or from an API/resource check.
 
 ## What each section means
 

--- a/web/content/docs/guides/ci-cd-agent-gates.mdx
+++ b/web/content/docs/guides/ci-cd-agent-gates.mdx
@@ -14,6 +14,7 @@ Create a repo-tracked manifest:
 ```bash
 agentclash ci init .agentclash/ci.yaml
 agentclash ci validate .agentclash/ci.yaml
+agentclash ci validate .agentclash/ci.yaml --remote --json
 agentclash ci baseline --manifest .agentclash/ci.yaml --json
 agentclash ci should-run --changed-file prompts/system.md --json
 ```
@@ -54,6 +55,8 @@ regressions:
 ```
 
 The IDs in the generated file are placeholders. Replace them with workspace resources before using the manifest for a real gate.
+
+Local validation is always offline. Add `--remote` when you want the CLI to call the AgentClash API and verify that the manifest's agent build, runtime profile, provider account, model alias, challenge pack version, input set, regression suites or cases, and baseline are visible from the selected workspace. JSON output includes a `remote.checks[]` entry per referenced field, so CI can report whether a failure came from the local manifest contract or from an API/resource check.
 
 ## What each section means
 
@@ -166,7 +169,11 @@ jobs:
       - run: npm i -g agentclash
 
       - name: Validate AgentClash CI manifest
-        run: agentclash ci validate .agentclash/ci.yaml
+        run: agentclash ci validate .agentclash/ci.yaml --remote
+        env:
+          AGENTCLASH_API_URL: https://api.agentclash.dev
+          AGENTCLASH_TOKEN: ${{ secrets.AGENTCLASH_TOKEN }}
+          AGENTCLASH_WORKSPACE: ${{ secrets.AGENTCLASH_WORKSPACE }}
 
       - name: Decide whether AgentClash gate should run
         id: should-run


### PR DESCRIPTION
## Summary
- add opt-in `agentclash ci validate --remote` API validation after local manifest validation passes
- return per-field `remote.checks[]` JSON results for candidate, workload, regression, and baseline references
- document offline vs remote validation in the README and CI/CD guide

Closes #500

## Review Checkpoint
- Contract: `/tmp/reviewcheckpoint-issue-500-contract.md`
- Checkpoint: `/tmp/reviewcheckpoint-issue-500.json`
- Final verdict: ready

## Tests
- `go test ./cmd -run 'TestCIValidate' -count=1`
- `go build ./...`
- `go vet ./...`
- `go test -short ./... -count=1`
- `go test -short -race -count=1 ./...`
- `go run . ci init /tmp/agentclash-ci-500.yaml --force`
- `go run . ci validate /tmp/agentclash-ci-500.yaml`