### PR TITLE
feat(ci): run manifest gates from the CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ web/.data/
 web/.env.local
 cli/agentclash
 cli/dist/
+cli/cmd/ci-run-spec-*/
 
 # Runtime state emitted by Claude Code's scheduler / background runners.
 .claude/scheduled_tasks.lock

--- a/README.md
+++ b/README.md
@@ -134,11 +134,12 @@ agentclash ci init .agentclash/ci.yaml
 agentclash ci validate .agentclash/ci.yaml
 export AGENTCLASH_WORKSPACE="your-workspace-id" # or pass -w
 agentclash ci validate .agentclash/ci.yaml --remote --json
+agentclash ci run --manifest .agentclash/ci.yaml --json
 agentclash ci baseline --manifest .agentclash/ci.yaml --json
 agentclash ci should-run --changed-file prompts/system.md --json
 ```
 
-The current CLI validates that manifest locally by default, can optionally check referenced resource IDs against the selected workspace with `--remote`, and resolves the exact baseline run that the gate will compare against. For pull request gates, prefer a locked `baseline.run_id`; update it only after a successful mainline run in a reviewed, auditable change.
+The current CLI validates that manifest locally by default, can optionally check referenced resource IDs against the selected workspace with `--remote`, runs the manifest workflow with `ci run`, and resolves the exact baseline run that the gate will compare against. For pull request gates, prefer a locked `baseline.run_id`; update it only after a successful mainline run in a reviewed, auditable change.
 
 Existing commands also work non-interactively with environment variables and explicit IDs:
 

--- a/cli/cmd/ci_run.go
+++ b/cli/cmd/ci_run.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -47,7 +49,10 @@ Exit codes:
   10  invalid manifest or local candidate spec
   20  API/auth failure
   30  candidate run timed out
-  31  candidate run failed before gate evaluation`,
+  31  candidate run failed before gate evaluation
+
+Missing workspace configuration exits 10 for this command so --json callers
+still receive a machine-readable envelope.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		rc := GetRunContext(cmd)
@@ -67,16 +72,17 @@ Exit codes:
 }
 
 type ciRunResult struct {
-	ManifestPath     string                            `json:"manifest_path" yaml:"manifest_path"`
-	WorkspaceID      string                            `json:"workspace_id" yaml:"workspace_id"`
-	RemoteValidation *ciManifestRemoteValidationResult `json:"remote_validation,omitempty" yaml:"remote_validation,omitempty"`
-	Candidate        ciRunCandidateResult              `json:"candidate" yaml:"candidate"`
-	Baseline         ciBaselineRunResolution           `json:"baseline" yaml:"baseline"`
-	ReleaseGate      map[string]any                    `json:"release_gate,omitempty" yaml:"release_gate,omitempty"`
-	GateVerdict      string                            `json:"gate_verdict,omitempty" yaml:"gate_verdict,omitempty"`
-	FailureReason    string                            `json:"failure_reason,omitempty" yaml:"failure_reason,omitempty"`
-	ExitCode         int                               `json:"exit_code" yaml:"exit_code"`
-	Errors           []string                          `json:"errors,omitempty" yaml:"errors,omitempty"`
+	ManifestPath       string                            `json:"manifest_path" yaml:"manifest_path"`
+	WorkspaceID        string                            `json:"workspace_id" yaml:"workspace_id"`
+	RemoteValidation   *ciManifestRemoteValidationResult `json:"remote_validation,omitempty" yaml:"remote_validation,omitempty"`
+	Candidate          ciRunCandidateResult              `json:"candidate" yaml:"candidate"`
+	BaselineResolution ciBaselineResolution              `json:"baseline_resolution,omitempty" yaml:"baseline_resolution,omitempty"`
+	Baseline           ciBaselineRunResolution           `json:"baseline" yaml:"baseline"`
+	ReleaseGate        map[string]any                    `json:"release_gate,omitempty" yaml:"release_gate,omitempty"`
+	GateVerdict        string                            `json:"gate_verdict,omitempty" yaml:"gate_verdict,omitempty"`
+	FailureReason      string                            `json:"failure_reason,omitempty" yaml:"failure_reason,omitempty"`
+	ExitCode           int                               `json:"exit_code" yaml:"exit_code"`
+	Errors             []string                          `json:"errors,omitempty" yaml:"errors,omitempty"`
 }
 
 type ciRunCandidateResult struct {
@@ -91,8 +97,12 @@ type ciRunCandidateResult struct {
 }
 
 func executeCIRun(cmd *cobra.Command, rc *RunContext) (ciRunResult, error) {
-	workspaceID := RequireWorkspace(cmd)
 	manifestPath, _ := cmd.Flags().GetString("manifest")
+	workspaceID := strings.TrimSpace(rc.Workspace)
+	if workspaceID == "" {
+		msg := "no workspace specified. Run 'agentclash link' to choose a default workspace, or pass --workspace, set AGENTCLASH_WORKSPACE, or create .agentclash.yaml with 'agentclash init'."
+		return ciRunResult{ManifestPath: manifestPath, ExitCode: ciRunExitInvalidManifest, Errors: []string{msg}}, &ExitCodeError{Code: ciRunExitInvalidManifest, Message: msg}
+	}
 	follow, _ := cmd.Flags().GetBool("follow")
 	timeout, _ := cmd.Flags().GetDuration("timeout")
 	pollInterval, _ := cmd.Flags().GetDuration("poll-interval")
@@ -170,10 +180,14 @@ func executeCIRun(cmd *cobra.Command, rc *RunContext) (ciRunResult, error) {
 
 	baseline, err := resolveCIManifestBaseline(cmd, rc, workspaceID, manifestPath, manifest, time.Now().UTC())
 	if err != nil {
-		result.ExitCode = ciRunExitForError(err).(*ExitCodeError).Code
+		result.ExitCode = ciRunExitInvalidManifest
+		if ciRunIsAPIError(err) {
+			result.ExitCode = ciRunExitAPI
+		}
 		result.Errors = append(result.Errors, err.Error())
-		return result, err
+		return result, &ExitCodeError{Code: result.ExitCode, Message: err.Error()}
 	}
+	result.BaselineResolution = baseline
 	result.Baseline = baseline.Baseline
 
 	run, err := createCIRun(cmd, rc, workspaceID, manifest, result.Candidate.DeploymentID)
@@ -254,6 +268,9 @@ func createCIBuildVersion(cmd *cobra.Command, rc *RunContext, manifest ciManifes
 }
 
 func ciRunSpecBody(path string) (map[string]any, error) {
+	if err := validateCIRunSpecPath(path); err != nil {
+		return nil, err
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading candidate.build.spec_file: %w", err)
@@ -263,6 +280,17 @@ func ciRunSpecBody(path string) (map[string]any, error) {
 		return nil, fmt.Errorf("parsing candidate.build.spec_file: %w", err)
 	}
 	return body, nil
+}
+
+func validateCIRunSpecPath(path string) error {
+	if filepath.IsAbs(path) {
+		return fmt.Errorf("candidate.build.spec_file must be a relative path inside the repository")
+	}
+	cleaned := filepath.Clean(path)
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("candidate.build.spec_file must stay inside the repository")
+	}
+	return nil
 }
 
 func markCIBuildVersionReady(cmd *cobra.Command, rc *RunContext, versionID string) (map[string]any, error) {
@@ -369,8 +397,21 @@ func waitForCIRunCompletion(cmd *cobra.Command, rc *RunContext, runID string, ti
 			}
 		}
 		if sleepFor > 0 {
-			time.Sleep(sleepFor)
+			if err := sleepCIRunPoll(cmd.Context(), sleepFor); err != nil {
+				return run, err
+			}
 		}
+	}
+}
+
+func sleepCIRunPoll(ctx context.Context, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
 	}
 }
 
@@ -393,7 +434,7 @@ func ciRunTerminalStatus(status string) (terminal bool, success bool) {
 	switch strings.ToLower(strings.TrimSpace(status)) {
 	case "completed", "succeeded", "success":
 		return true, true
-	case "failed", "error", "errored", "canceled", "cancelled":
+	case "failed", "error", "errored", "canceled", "cancelled", "aborted", "timed_out", "timeout", "expired":
 		return true, false
 	default:
 		return false, false
@@ -440,7 +481,7 @@ func evaluateCIRunReleaseGate(cmd *cobra.Command, rc *RunContext, baselineRunID,
 	}
 	var raw map[string]any
 	if err := resp.DecodeJSON(&raw); err != nil {
-		return nil, releaseGateVerdict{}, fmt.Errorf("decoding release gate response: %w", err)
+		return nil, releaseGateVerdict{}, fmt.Errorf("decoding raw release gate response: %w", err)
 	}
 	return raw, verdict, nil
 }

--- a/cli/cmd/ci_run.go
+++ b/cli/cmd/ci_run.go
@@ -1,0 +1,517 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	cliapi "github.com/agentclash/agentclash/cli/internal/api"
+	"github.com/agentclash/agentclash/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	ciCmd.AddCommand(ciRunCmd)
+
+	ciRunCmd.Flags().String("manifest", ".agentclash/ci.yaml", "Path to the AgentClash CI manifest")
+	ciRunCmd.Flags().Bool("follow", false, "Stream run events while waiting for the candidate run")
+	ciRunCmd.Flags().Duration("timeout", 30*time.Minute, "Maximum time to wait for the candidate run; 0 disables the timeout")
+	ciRunCmd.Flags().Duration("poll-interval", 5*time.Second, "Polling interval while waiting for run completion")
+}
+
+const (
+	ciRunExitInvalidManifest = 10
+	ciRunExitAPI             = 20
+	ciRunExitTimeout         = 30
+	ciRunExitRunFailed       = 31
+)
+
+var ciRunCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Run the AgentClash CI workflow described by a manifest",
+	Long: `Run the AgentClash CI workflow described by a manifest.
+
+The command validates the manifest, creates a candidate build version and
+deployment, starts the manifest workload, waits for the candidate run to finish,
+resolves the baseline, and evaluates the release gate. It is intended for
+GitHub Actions and other non-interactive CI jobs after checkout and auth setup.
+
+Exit codes:
+  0   pass
+  1   release gate failed
+  2   release gate warning
+  3   insufficient gate evidence
+  10  invalid manifest or local candidate spec
+  20  API/auth failure
+  30  candidate run timed out
+  31  candidate run failed before gate evaluation`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		result, err := executeCIRun(cmd, rc)
+		if rc.Output.IsStructured() {
+			if printErr := rc.Output.PrintRaw(result); printErr != nil {
+				return printErr
+			}
+		} else {
+			renderCIRunResult(rc, result, err)
+		}
+		if err != nil {
+			return ciRunExitForError(err)
+		}
+		return nil
+	},
+}
+
+type ciRunResult struct {
+	ManifestPath     string                            `json:"manifest_path" yaml:"manifest_path"`
+	WorkspaceID      string                            `json:"workspace_id" yaml:"workspace_id"`
+	RemoteValidation *ciManifestRemoteValidationResult `json:"remote_validation,omitempty" yaml:"remote_validation,omitempty"`
+	Candidate        ciRunCandidateResult              `json:"candidate" yaml:"candidate"`
+	Baseline         ciBaselineRunResolution           `json:"baseline" yaml:"baseline"`
+	ReleaseGate      map[string]any                    `json:"release_gate,omitempty" yaml:"release_gate,omitempty"`
+	GateVerdict      string                            `json:"gate_verdict,omitempty" yaml:"gate_verdict,omitempty"`
+	FailureReason    string                            `json:"failure_reason,omitempty" yaml:"failure_reason,omitempty"`
+	ExitCode         int                               `json:"exit_code" yaml:"exit_code"`
+	Errors           []string                          `json:"errors,omitempty" yaml:"errors,omitempty"`
+}
+
+type ciRunCandidateResult struct {
+	AgentBuildID   string `json:"agent_build_id" yaml:"agent_build_id"`
+	BuildVersionID string `json:"build_version_id,omitempty" yaml:"build_version_id,omitempty"`
+	DeploymentID   string `json:"deployment_id,omitempty" yaml:"deployment_id,omitempty"`
+	RunID          string `json:"run_id,omitempty" yaml:"run_id,omitempty"`
+	RunAgentID     string `json:"run_agent_id,omitempty" yaml:"run_agent_id,omitempty"`
+	RunStatus      string `json:"run_status,omitempty" yaml:"run_status,omitempty"`
+	RunURL         string `json:"run_url,omitempty" yaml:"run_url,omitempty"`
+	DeploymentName string `json:"deployment_name,omitempty" yaml:"deployment_name,omitempty"`
+}
+
+func executeCIRun(cmd *cobra.Command, rc *RunContext) (ciRunResult, error) {
+	workspaceID := RequireWorkspace(cmd)
+	manifestPath, _ := cmd.Flags().GetString("manifest")
+	follow, _ := cmd.Flags().GetBool("follow")
+	timeout, _ := cmd.Flags().GetDuration("timeout")
+	pollInterval, _ := cmd.Flags().GetDuration("poll-interval")
+	if timeout < 0 {
+		err := fmt.Errorf("--timeout must be greater than or equal to 0")
+		return ciRunResult{ManifestPath: manifestPath, WorkspaceID: workspaceID, ExitCode: ciRunExitInvalidManifest, Errors: []string{err.Error()}}, &ExitCodeError{Code: ciRunExitInvalidManifest, Message: err.Error()}
+	}
+	if pollInterval <= 0 {
+		err := fmt.Errorf("--poll-interval must be greater than 0")
+		return ciRunResult{ManifestPath: manifestPath, WorkspaceID: workspaceID, ExitCode: ciRunExitInvalidManifest, Errors: []string{err.Error()}}, &ExitCodeError{Code: ciRunExitInvalidManifest, Message: err.Error()}
+	}
+
+	result := ciRunResult{
+		ManifestPath: manifestPath,
+		WorkspaceID:  workspaceID,
+	}
+
+	validation, err := validateCIManifestFile(manifestPath)
+	if err != nil {
+		result.ExitCode = ciRunExitInvalidManifest
+		result.Errors = append(result.Errors, validation.Errors...)
+		return result, &ExitCodeError{Code: ciRunExitInvalidManifest, Message: err.Error()}
+	}
+	manifest := *validation.Manifest
+	result.Candidate.AgentBuildID = manifest.Candidate.Build.AgentBuildID
+	result.Candidate.DeploymentName = ciRunDeploymentName(manifest)
+
+	remoteValidation, remoteErr := validateCIManifestRemote(cmd, rc, workspaceID, manifestPath, manifest)
+	result.RemoteValidation = &remoteValidation
+	if remoteErr != nil {
+		result.ExitCode = ciRunExitForError(remoteErr).(*ExitCodeError).Code
+		result.Errors = append(result.Errors, remoteValidation.Errors...)
+		return result, remoteErr
+	}
+	if !remoteValidation.Valid {
+		result.ExitCode = ciRunExitInvalidManifest
+		result.Errors = append(result.Errors, remoteValidation.Errors...)
+		return result, &ExitCodeError{Code: ciRunExitInvalidManifest, Message: "ci manifest remote validation failed"}
+	}
+
+	buildVersion, err := createCIBuildVersion(cmd, rc, manifest)
+	if err != nil {
+		result.ExitCode = ciRunExitAPI
+		if !ciRunIsAPIError(err) {
+			result.ExitCode = ciRunExitInvalidManifest
+		}
+		result.Errors = append(result.Errors, err.Error())
+		if result.ExitCode == ciRunExitInvalidManifest {
+			return result, &ExitCodeError{Code: ciRunExitInvalidManifest, Message: err.Error()}
+		}
+		return result, err
+	}
+	result.Candidate.BuildVersionID = mapString(buildVersion, "id")
+
+	readyVersion, err := markCIBuildVersionReady(cmd, rc, result.Candidate.BuildVersionID)
+	if err != nil {
+		result.ExitCode = ciRunExitAPI
+		result.Errors = append(result.Errors, err.Error())
+		return result, err
+	}
+	if id := mapString(readyVersion, "id"); id != "" {
+		result.Candidate.BuildVersionID = id
+	}
+
+	deployment, err := createCIDeployment(cmd, rc, workspaceID, manifest, result.Candidate.BuildVersionID)
+	if err != nil {
+		result.ExitCode = ciRunExitAPI
+		result.Errors = append(result.Errors, err.Error())
+		return result, err
+	}
+	result.Candidate.DeploymentID = mapString(deployment, "id")
+	if name := mapString(deployment, "name"); name != "" {
+		result.Candidate.DeploymentName = name
+	}
+
+	baseline, err := resolveCIManifestBaseline(cmd, rc, workspaceID, manifestPath, manifest, time.Now().UTC())
+	if err != nil {
+		result.ExitCode = ciRunExitForError(err).(*ExitCodeError).Code
+		result.Errors = append(result.Errors, err.Error())
+		return result, err
+	}
+	result.Baseline = baseline.Baseline
+
+	run, err := createCIRun(cmd, rc, workspaceID, manifest, result.Candidate.DeploymentID)
+	if err != nil {
+		result.ExitCode = ciRunExitAPI
+		result.Errors = append(result.Errors, err.Error())
+		return result, err
+	}
+	result.Candidate.RunID = mapString(run, "id")
+	result.Candidate.RunStatus = mapString(run, "status")
+	result.Candidate.RunURL = ciRunLink(run)
+
+	if follow && !rc.Output.IsStructured() {
+		fmt.Fprintln(os.Stderr)
+		if err := streamRunEvents(cmd, rc, result.Candidate.RunID); err != nil {
+			result.ExitCode = ciRunExitAPI
+			result.Errors = append(result.Errors, err.Error())
+			return result, err
+		}
+	}
+
+	completedRun, err := waitForCIRunCompletion(cmd, rc, result.Candidate.RunID, timeout, pollInterval)
+	if err != nil {
+		result.Candidate.RunStatus = mapString(completedRun, "status")
+		if link := ciRunLink(completedRun); link != "" {
+			result.Candidate.RunURL = link
+		}
+		result.ExitCode = ciRunExitForError(err).(*ExitCodeError).Code
+		result.Errors = append(result.Errors, err.Error())
+		return result, err
+	}
+	result.Candidate.RunStatus = mapString(completedRun, "status")
+	if link := ciRunLink(completedRun); link != "" {
+		result.Candidate.RunURL = link
+	}
+
+	candidateAgent, err := resolveCIRunCandidateAgent(cmd, rc, result.Candidate.RunID, result.Candidate.DeploymentID)
+	if err != nil {
+		result.ExitCode = ciRunExitAPI
+		result.Errors = append(result.Errors, err.Error())
+		return result, err
+	}
+	result.Candidate.RunAgentID = candidateAgent.ID
+
+	gateEnvelope, gateVerdict, err := evaluateCIRunReleaseGate(cmd, rc, result.Baseline.RunID, result.Candidate.RunID, result.Baseline.RunAgentID, result.Candidate.RunAgentID)
+	if err != nil {
+		result.ExitCode = ciRunExitAPI
+		result.Errors = append(result.Errors, err.Error())
+		return result, err
+	}
+	result.ReleaseGate, _ = gateEnvelope["release_gate"].(map[string]any)
+	result.GateVerdict = gateVerdict.ReleaseGate.Verdict
+	result.FailureReason = ciRunGateFailureReason(result.ReleaseGate)
+	result.ExitCode = ciRunExitCodeForGate(result.GateVerdict)
+	if result.ExitCode != 0 {
+		return result, &ExitCodeError{Code: result.ExitCode}
+	}
+	return result, nil
+}
+
+func createCIBuildVersion(cmd *cobra.Command, rc *RunContext, manifest ciManifest) (map[string]any, error) {
+	body, err := ciRunSpecBody(manifest.Candidate.Build.SpecFile)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := rc.Client.Post(cmd.Context(), "/v1/agent-builds/"+manifest.Candidate.Build.AgentBuildID+"/versions", body)
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return nil, apiErr
+	}
+	var version map[string]any
+	if err := resp.DecodeJSON(&version); err != nil {
+		return nil, err
+	}
+	return version, nil
+}
+
+func ciRunSpecBody(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading candidate.build.spec_file: %w", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(data, &body); err != nil {
+		return nil, fmt.Errorf("parsing candidate.build.spec_file: %w", err)
+	}
+	return body, nil
+}
+
+func markCIBuildVersionReady(cmd *cobra.Command, rc *RunContext, versionID string) (map[string]any, error) {
+	if strings.TrimSpace(versionID) == "" {
+		return nil, fmt.Errorf("created build version response did not include id")
+	}
+	resp, err := rc.Client.Post(cmd.Context(), "/v1/agent-build-versions/"+versionID+"/ready", nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return nil, apiErr
+	}
+	var version map[string]any
+	if err := resp.DecodeJSON(&version); err != nil {
+		return nil, err
+	}
+	return version, nil
+}
+
+func createCIDeployment(cmd *cobra.Command, rc *RunContext, workspaceID string, manifest ciManifest, buildVersionID string) (map[string]any, error) {
+	body := map[string]any{
+		"name":               ciRunDeploymentName(manifest),
+		"agent_build_id":     manifest.Candidate.Build.AgentBuildID,
+		"build_version_id":   buildVersionID,
+		"runtime_profile_id": manifest.Candidate.Deployment.RuntimeProfileID,
+	}
+	if manifest.Candidate.Deployment.ProviderAccountID != "" {
+		body["provider_account_id"] = manifest.Candidate.Deployment.ProviderAccountID
+	}
+	if manifest.Candidate.Deployment.ModelAliasID != "" {
+		body["model_alias_id"] = manifest.Candidate.Deployment.ModelAliasID
+	}
+	resp, err := rc.Client.Post(cmd.Context(), "/v1/workspaces/"+workspaceID+"/agent-deployments", body)
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return nil, apiErr
+	}
+	var deployment map[string]any
+	if err := resp.DecodeJSON(&deployment); err != nil {
+		return nil, err
+	}
+	return deployment, nil
+}
+
+func ciRunDeploymentName(manifest ciManifest) string {
+	if name := strings.TrimSpace(manifest.Candidate.Deployment.Name); name != "" {
+		return name
+	}
+	return fmt.Sprintf("agentclash-ci-%d", time.Now().UTC().Unix())
+}
+
+func createCIRun(cmd *cobra.Command, rc *RunContext, workspaceID string, manifest ciManifest, deploymentID string) (map[string]any, error) {
+	request := runCreateRequest{
+		ChallengePackVersionID: manifest.Evaluation.ChallengePackVersionID,
+		ChallengeInputSetID:    manifest.Evaluation.InputSetID,
+		DeploymentIDs:          []string{deploymentID},
+		OfficialPackMode:       "full",
+		RegressionSuiteIDs:     manifest.Evaluation.RegressionSuites,
+		RegressionCaseIDs:      manifest.Evaluation.RegressionCases,
+		Name:                   ciRunName(manifest),
+	}
+	body, err := buildRunCreateBody(workspaceID, request)
+	if err != nil {
+		return nil, err
+	}
+	return createRun(cmd, rc, body)
+}
+
+func ciRunName(manifest ciManifest) string {
+	if name := strings.TrimSpace(manifest.Candidate.Deployment.Name); name != "" {
+		return "CI gate: " + name
+	}
+	return "CI gate"
+}
+
+func waitForCIRunCompletion(cmd *cobra.Command, rc *RunContext, runID string, timeout, pollInterval time.Duration) (map[string]any, error) {
+	var deadline time.Time
+	if timeout > 0 {
+		deadline = time.Now().Add(timeout)
+	}
+	for {
+		run, err := getCIRun(cmd, rc, runID)
+		if err != nil {
+			return run, err
+		}
+		terminal, ok := ciRunTerminalStatus(mapString(run, "status"))
+		if terminal {
+			if ok {
+				return run, nil
+			}
+			return run, &ExitCodeError{Code: ciRunExitRunFailed, Message: fmt.Sprintf("candidate run %s finished with status %s", runID, mapString(run, "status"))}
+		}
+		if !deadline.IsZero() && !time.Now().Before(deadline) {
+			return run, &ExitCodeError{Code: ciRunExitTimeout, Message: fmt.Sprintf("timed out waiting for candidate run %s", runID)}
+		}
+		sleepFor := pollInterval
+		if !deadline.IsZero() {
+			remaining := time.Until(deadline)
+			if remaining < sleepFor {
+				sleepFor = remaining
+			}
+		}
+		if sleepFor > 0 {
+			time.Sleep(sleepFor)
+		}
+	}
+}
+
+func getCIRun(cmd *cobra.Command, rc *RunContext, runID string) (map[string]any, error) {
+	resp, err := rc.Client.Get(cmd.Context(), "/v1/runs/"+runID, nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return nil, apiErr
+	}
+	var run map[string]any
+	if err := resp.DecodeJSON(&run); err != nil {
+		return nil, err
+	}
+	return run, nil
+}
+
+func ciRunTerminalStatus(status string) (terminal bool, success bool) {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "completed", "succeeded", "success":
+		return true, true
+	case "failed", "error", "errored", "canceled", "cancelled":
+		return true, false
+	default:
+		return false, false
+	}
+}
+
+func resolveCIRunCandidateAgent(cmd *cobra.Command, rc *RunContext, runID, deploymentID string) (runAgentWorkflowSummary, error) {
+	agents, err := listRunAgentsForWorkflow(cmd, rc, runID)
+	if err != nil {
+		return runAgentWorkflowSummary{}, err
+	}
+	for _, agent := range agents {
+		if agent.AgentDeploymentID == deploymentID {
+			return agent, nil
+		}
+	}
+	if len(agents) == 1 {
+		return agents[0], nil
+	}
+	return runAgentWorkflowSummary{}, fmt.Errorf("candidate run %s has no agent for deployment %s", runID, deploymentID)
+}
+
+func evaluateCIRunReleaseGate(cmd *cobra.Command, rc *RunContext, baselineRunID, candidateRunID, baselineAgentID, candidateAgentID string) (map[string]any, releaseGateVerdict, error) {
+	body := map[string]any{
+		"baseline_run_id":  baselineRunID,
+		"candidate_run_id": candidateRunID,
+	}
+	if baselineAgentID != "" {
+		body["baseline_run_agent_id"] = baselineAgentID
+	}
+	if candidateAgentID != "" {
+		body["candidate_run_agent_id"] = candidateAgentID
+	}
+	resp, err := rc.Client.Post(cmd.Context(), "/v1/release-gates/evaluate", body)
+	if err != nil {
+		return nil, releaseGateVerdict{}, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return nil, releaseGateVerdict{}, apiErr
+	}
+	var verdict releaseGateVerdict
+	if err := resp.DecodeJSON(&verdict); err != nil {
+		return nil, releaseGateVerdict{}, fmt.Errorf("decoding release gate response: %w", err)
+	}
+	var raw map[string]any
+	if err := resp.DecodeJSON(&raw); err != nil {
+		return nil, releaseGateVerdict{}, fmt.Errorf("decoding release gate response: %w", err)
+	}
+	return raw, verdict, nil
+}
+
+func ciRunExitCodeForGate(verdict string) int {
+	switch verdict {
+	case "pass":
+		return gateExitPass
+	case "warn":
+		return gateExitWarn
+	case "fail":
+		return gateExitFail
+	case "insufficient_evidence":
+		return gateExitInsufficientEvidence
+	default:
+		return gateExitFail
+	}
+}
+
+func ciRunGateFailureReason(releaseGate map[string]any) string {
+	if releaseGate == nil {
+		return ""
+	}
+	if reason := mapString(releaseGate, "reason_code"); reason != "" {
+		return reason
+	}
+	return mapString(releaseGate, "summary")
+}
+
+func ciRunLink(run map[string]any) string {
+	return mapString(run, "url", "web_url", "html_url")
+}
+
+func ciRunExitForError(err error) error {
+	var exitErr *ExitCodeError
+	if errors.As(err, &exitErr) {
+		return exitErr
+	}
+	if ciRunIsAPIError(err) {
+		return &ExitCodeError{Code: ciRunExitAPI, Message: err.Error()}
+	}
+	return &ExitCodeError{Code: 1, Message: err.Error()}
+}
+
+func ciRunIsAPIError(err error) bool {
+	var apiErr *cliapi.APIError
+	return errors.As(err, &apiErr)
+}
+
+func renderCIRunResult(rc *RunContext, result ciRunResult, err error) {
+	if err != nil {
+		rc.Output.PrintError("AgentClash CI run failed")
+		for _, msg := range result.Errors {
+			fmt.Fprintf(os.Stderr, "  - %s\n", output.SanitizeLine(msg))
+		}
+		return
+	}
+	rc.Output.PrintSuccess("AgentClash CI run completed")
+	rc.Output.PrintDetail("Run", result.Candidate.RunID)
+	if result.Candidate.RunURL != "" {
+		rc.Output.PrintDetail("Run URL", result.Candidate.RunURL)
+	}
+	rc.Output.PrintDetail("Candidate Agent", result.Candidate.RunAgentID)
+	rc.Output.PrintDetail("Baseline", result.Baseline.RunID)
+	rc.Output.PrintDetail("Gate", result.GateVerdict)
+	switch result.GateVerdict {
+	case "pass":
+		rc.Output.PrintDetail("Next", "merge or promote when ready")
+	case "warn", "insufficient_evidence":
+		rc.Output.PrintDetail("Next", "review gate evidence before merging")
+	case "fail":
+		rc.Output.PrintDetail("Next", "fix the regression before merging")
+	}
+}

--- a/cli/cmd/ci_run.go
+++ b/cli/cmd/ci_run.go
@@ -76,7 +76,7 @@ type ciRunResult struct {
 	WorkspaceID        string                            `json:"workspace_id" yaml:"workspace_id"`
 	RemoteValidation   *ciManifestRemoteValidationResult `json:"remote_validation,omitempty" yaml:"remote_validation,omitempty"`
 	Candidate          ciRunCandidateResult              `json:"candidate" yaml:"candidate"`
-	BaselineResolution ciBaselineResolution              `json:"baseline_resolution,omitempty" yaml:"baseline_resolution,omitempty"`
+	BaselineResolution *ciBaselineResolution             `json:"baseline_resolution,omitempty" yaml:"baseline_resolution,omitempty"`
 	Baseline           ciBaselineRunResolution           `json:"baseline" yaml:"baseline"`
 	ReleaseGate        map[string]any                    `json:"release_gate,omitempty" yaml:"release_gate,omitempty"`
 	GateVerdict        string                            `json:"gate_verdict,omitempty" yaml:"gate_verdict,omitempty"`
@@ -133,9 +133,9 @@ func executeCIRun(cmd *cobra.Command, rc *RunContext) (ciRunResult, error) {
 	remoteValidation, remoteErr := validateCIManifestRemote(cmd, rc, workspaceID, manifestPath, manifest)
 	result.RemoteValidation = &remoteValidation
 	if remoteErr != nil {
-		result.ExitCode = ciRunExitForError(remoteErr).(*ExitCodeError).Code
+		result.ExitCode = ciRunExitAPI
 		result.Errors = append(result.Errors, remoteValidation.Errors...)
-		return result, remoteErr
+		return result, &ExitCodeError{Code: result.ExitCode, Message: remoteErr.Error()}
 	}
 	if !remoteValidation.Valid {
 		result.ExitCode = ciRunExitInvalidManifest
@@ -146,14 +146,11 @@ func executeCIRun(cmd *cobra.Command, rc *RunContext) (ciRunResult, error) {
 	buildVersion, err := createCIBuildVersion(cmd, rc, manifest)
 	if err != nil {
 		result.ExitCode = ciRunExitAPI
-		if !ciRunIsAPIError(err) {
+		if ciRunIsSpecError(err) {
 			result.ExitCode = ciRunExitInvalidManifest
 		}
 		result.Errors = append(result.Errors, err.Error())
-		if result.ExitCode == ciRunExitInvalidManifest {
-			return result, &ExitCodeError{Code: ciRunExitInvalidManifest, Message: err.Error()}
-		}
-		return result, err
+		return result, &ExitCodeError{Code: result.ExitCode, Message: err.Error()}
 	}
 	result.Candidate.BuildVersionID = mapString(buildVersion, "id")
 
@@ -187,7 +184,7 @@ func executeCIRun(cmd *cobra.Command, rc *RunContext) (ciRunResult, error) {
 		result.Errors = append(result.Errors, err.Error())
 		return result, &ExitCodeError{Code: result.ExitCode, Message: err.Error()}
 	}
-	result.BaselineResolution = baseline
+	result.BaselineResolution = &baseline
 	result.Baseline = baseline.Baseline
 
 	run, err := createCIRun(cmd, rc, workspaceID, manifest, result.Candidate.DeploymentID)
@@ -269,17 +266,34 @@ func createCIBuildVersion(cmd *cobra.Command, rc *RunContext, manifest ciManifes
 
 func ciRunSpecBody(path string) (map[string]any, error) {
 	if err := validateCIRunSpecPath(path); err != nil {
-		return nil, err
+		return nil, &ciRunSpecError{err: err}
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("reading candidate.build.spec_file: %w", err)
+		return nil, &ciRunSpecError{err: fmt.Errorf("reading candidate.build.spec_file: %w", err)}
 	}
 	var body map[string]any
 	if err := json.Unmarshal(data, &body); err != nil {
-		return nil, fmt.Errorf("parsing candidate.build.spec_file: %w", err)
+		return nil, &ciRunSpecError{err: fmt.Errorf("parsing candidate.build.spec_file: %w", err)}
 	}
 	return body, nil
+}
+
+type ciRunSpecError struct {
+	err error
+}
+
+func (e *ciRunSpecError) Error() string {
+	return e.err.Error()
+}
+
+func (e *ciRunSpecError) Unwrap() error {
+	return e.err
+}
+
+func ciRunIsSpecError(err error) bool {
+	var specErr *ciRunSpecError
+	return errors.As(err, &specErr)
 }
 
 func validateCIRunSpecPath(path string) error {

--- a/cli/cmd/ci_run_test.go
+++ b/cli/cmd/ci_run_test.go
@@ -32,6 +32,12 @@ func TestCIRunCreatesCandidateRunAndEvaluatesPassingGate(t *testing.T) {
 	if result.Baseline.RunID != "00000000-0000-0000-0000-000000000008" {
 		t.Fatalf("baseline run = %q, want manifest baseline", result.Baseline.RunID)
 	}
+	if result.BaselineResolution.Strategy != "locked_run" {
+		t.Fatalf("baseline strategy = %q, want locked_run", result.BaselineResolution.Strategy)
+	}
+	if result.BaselineResolution.Source != "baseline.run_id" || result.BaselineResolution.Refresh.Mode != "manual" {
+		t.Fatalf("baseline resolution = %+v, want source and refresh policy", result.BaselineResolution)
+	}
 	if captures.BuildVersionBody["agent_kind"] != "llm_agent" {
 		t.Fatalf("build version body = %+v, want spec payload", captures.BuildVersionBody)
 	}
@@ -74,6 +80,35 @@ regressions: {}
 	}
 	if result.ExitCode != ciRunExitInvalidManifest || !strings.Contains(strings.Join(result.Errors, "\n"), "trigger.paths") {
 		t.Fatalf("result = %+v, want invalid manifest errors", result)
+	}
+}
+
+func TestCIRunMissingWorkspaceReturnsJSONExitCode(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("AGENTCLASH_WORKSPACE", "")
+	target := writeCIRunManifest(t)
+
+	result, err, _ := runCIRunJSON(t, []string{"ci", "run", "--manifest", target, "--json"}, "http://unused")
+	if got := exitCodeOf(t, err); got != ciRunExitInvalidManifest {
+		t.Fatalf("exit code = %d, want invalid manifest %d (err %v)", got, ciRunExitInvalidManifest, err)
+	}
+	if result.ExitCode != ciRunExitInvalidManifest || !strings.Contains(strings.Join(result.Errors, "\n"), "no workspace specified") {
+		t.Fatalf("result = %+v, want workspace error", result)
+	}
+}
+
+func TestCIRunRejectsUnsafeSpecFilePaths(t *testing.T) {
+	for _, path := range []string{
+		"/tmp/agent.json",
+		"../agent.json",
+		".",
+		"..",
+	} {
+		t.Run(path, func(t *testing.T) {
+			if err := validateCIRunSpecPath(path); err == nil {
+				t.Fatalf("validateCIRunSpecPath(%q) error = nil, want rejection", path)
+			}
+		})
 	}
 }
 
@@ -149,7 +184,11 @@ type ciRunRouteCaptures struct {
 
 func writeCIRunManifest(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp(".", "ci-run-spec-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp(spec) error: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
 	specPath := filepath.Join(dir, "agent.json")
 	if err := os.WriteFile(specPath, []byte(`{"agent_kind":"llm_agent","prompt_spec":{"system":"be useful"}}`), 0o644); err != nil {
 		t.Fatalf("WriteFile(spec) error: %v", err)

--- a/cli/cmd/ci_run_test.go
+++ b/cli/cmd/ci_run_test.go
@@ -1,0 +1,261 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCIRunCreatesCandidateRunAndEvaluatesPassingGate(t *testing.T) {
+	target := writeCIRunManifest(t)
+	captures := &ciRunRouteCaptures{}
+	srv := fakeAPI(t, ciRunRoutes(t, captures, nil))
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	result, err, _ := runCIRunJSON(t, []string{"ci", "run", "--manifest", target, "-w", "ws-1", "--json", "--poll-interval", "1ms", "--timeout", "1s"}, srv.URL)
+	if err != nil {
+		t.Fatalf("ci run error: %v", err)
+	}
+
+	if result.ExitCode != 0 || result.GateVerdict != "pass" {
+		t.Fatalf("result = %+v, want passing gate", result)
+	}
+	if result.Candidate.BuildVersionID != "version-candidate" || result.Candidate.DeploymentID != "dep-candidate" || result.Candidate.RunID != "run-candidate" || result.Candidate.RunAgentID != "agent-candidate" {
+		t.Fatalf("candidate = %+v, want created version/deployment/run/agent ids", result.Candidate)
+	}
+	if result.Baseline.RunID != "00000000-0000-0000-0000-000000000008" {
+		t.Fatalf("baseline run = %q, want manifest baseline", result.Baseline.RunID)
+	}
+	if captures.BuildVersionBody["agent_kind"] != "llm_agent" {
+		t.Fatalf("build version body = %+v, want spec payload", captures.BuildVersionBody)
+	}
+	if captures.DeploymentBody["build_version_id"] != "version-candidate" || captures.DeploymentBody["runtime_profile_id"] != "00000000-0000-0000-0000-000000000002" {
+		t.Fatalf("deployment body = %+v, want manifest deployment resources", captures.DeploymentBody)
+	}
+	if deployments, ok := captures.RunBody["agent_deployment_ids"].([]any); !ok || len(deployments) != 1 || deployments[0] != "dep-candidate" {
+		t.Fatalf("run body deployments = %#v, want dep-candidate", captures.RunBody["agent_deployment_ids"])
+	}
+	if captures.RunBody["challenge_pack_version_id"] != "00000000-0000-0000-0000-000000000005" {
+		t.Fatalf("run body = %+v, want manifest challenge pack version", captures.RunBody)
+	}
+	if captures.GateBody["baseline_run_id"] != "00000000-0000-0000-0000-000000000008" || captures.GateBody["candidate_run_agent_id"] != "agent-candidate" {
+		t.Fatalf("gate body = %+v, want baseline and candidate ids", captures.GateBody)
+	}
+}
+
+func TestCIRunRejectsInvalidManifestBeforeAPIWrites(t *testing.T) {
+	target := writeCIManifest(t, `version: 1
+trigger: {}
+candidate: {}
+evaluation: {}
+baseline: {}
+gate: {}
+regressions: {}
+`)
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	result, err, _ := runCIRunJSON(t, []string{"ci", "run", "--manifest", target, "-w", "ws-1", "--json"}, srv.URL)
+	if got := exitCodeOf(t, err); got != ciRunExitInvalidManifest {
+		t.Fatalf("exit code = %d, want invalid manifest %d (err %v)", got, ciRunExitInvalidManifest, err)
+	}
+	if called {
+		t.Fatal("ci run made an API request after invalid local manifest validation")
+	}
+	if result.ExitCode != ciRunExitInvalidManifest || !strings.Contains(strings.Join(result.Errors, "\n"), "trigger.paths") {
+		t.Fatalf("result = %+v, want invalid manifest errors", result)
+	}
+}
+
+func TestCIRunGateFailReturnsGateExitCode(t *testing.T) {
+	target := writeCIRunManifest(t)
+	captures := &ciRunRouteCaptures{}
+	srv := fakeAPI(t, ciRunRoutes(t, captures, map[string]http.HandlerFunc{
+		"POST /v1/release-gates/evaluate": ciRunGateHandler(t, captures, "fail"),
+	}))
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	result, err, _ := runCIRunJSON(t, []string{"ci", "run", "--manifest", target, "-w", "ws-1", "--json", "--poll-interval", "1ms", "--timeout", "1s"}, srv.URL)
+	if got := exitCodeOf(t, err); got != gateExitFail {
+		t.Fatalf("exit code = %d, want gate failure %d (err %v)", got, gateExitFail, err)
+	}
+	if result.GateVerdict != "fail" || result.ExitCode != gateExitFail || result.FailureReason != "regression_detected" {
+		t.Fatalf("result = %+v, want failing gate result", result)
+	}
+}
+
+func TestCIRunTimeoutDoesNotEvaluateGate(t *testing.T) {
+	target := writeCIRunManifest(t)
+	captures := &ciRunRouteCaptures{}
+	srv := fakeAPI(t, ciRunRoutes(t, captures, map[string]http.HandlerFunc{
+		"GET /v1/runs/run-candidate": jsonHandler(200, map[string]any{
+			"id":      "run-candidate",
+			"status":  "running",
+			"web_url": "https://app.agentclash.dev/runs/run-candidate",
+		}),
+	}))
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	result, err, _ := runCIRunJSON(t, []string{"ci", "run", "--manifest", target, "-w", "ws-1", "--json", "--poll-interval", "1ms", "--timeout", "1ms"}, srv.URL)
+	if got := exitCodeOf(t, err); got != ciRunExitTimeout {
+		t.Fatalf("exit code = %d, want timeout %d (err %v)", got, ciRunExitTimeout, err)
+	}
+	if result.ExitCode != ciRunExitTimeout || result.Candidate.RunStatus != "running" {
+		t.Fatalf("result = %+v, want running timeout result", result)
+	}
+	if captures.GateBody != nil {
+		t.Fatalf("gate body = %+v, want no gate evaluation after timeout", captures.GateBody)
+	}
+}
+
+func TestCIRunAPIErrorUsesAPIExitCode(t *testing.T) {
+	target := writeCIRunManifest(t)
+	captures := &ciRunRouteCaptures{}
+	srv := fakeAPI(t, ciRunRoutes(t, captures, map[string]http.HandlerFunc{
+		"POST /v1/agent-builds/00000000-0000-0000-0000-000000000001/versions": jsonHandler(500, map[string]any{
+			"error": map[string]any{"code": "internal_error", "message": "boom"},
+		}),
+	}))
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	result, err, _ := runCIRunJSON(t, []string{"ci", "run", "--manifest", target, "-w", "ws-1", "--json", "--poll-interval", "1ms", "--timeout", "1s"}, srv.URL)
+	if got := exitCodeOf(t, err); got != ciRunExitAPI {
+		t.Fatalf("exit code = %d, want API %d (err %v)", got, ciRunExitAPI, err)
+	}
+	if result.ExitCode != ciRunExitAPI || !strings.Contains(strings.Join(result.Errors, "\n"), "internal_error") {
+		t.Fatalf("result = %+v, want API error details", result)
+	}
+}
+
+type ciRunRouteCaptures struct {
+	BuildVersionBody map[string]any
+	DeploymentBody   map[string]any
+	RunBody          map[string]any
+	GateBody         map[string]any
+}
+
+func writeCIRunManifest(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "agent.json")
+	if err := os.WriteFile(specPath, []byte(`{"agent_kind":"llm_agent","prompt_spec":{"system":"be useful"}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(spec) error: %v", err)
+	}
+	manifest := strings.Replace(sampleCIManifestYAML, "    spec_file: .agentclash/agent.json", "    spec_file: "+specPath, 1)
+	manifest = strings.Replace(manifest, "  max_age_days: 30\n", "", 1)
+	return writeCIManifest(t, manifest)
+}
+
+func runCIRunJSON(t *testing.T, args []string, apiURL string) (ciRunResult, error, string) {
+	t.Helper()
+	stdout := captureStdout(t)
+	err := executeCommand(t, args, apiURL)
+	out := stdout.finish()
+	var result ciRunResult
+	if decodeErr := json.Unmarshal([]byte(out), &result); decodeErr != nil {
+		t.Fatalf("json output parse error: %v\n---\n%s", decodeErr, out)
+	}
+	return result, err, out
+}
+
+func ciRunRoutes(t *testing.T, captures *ciRunRouteCaptures, overrides map[string]http.HandlerFunc) map[string]http.HandlerFunc {
+	t.Helper()
+	routes := remoteCIValidateRoutes(t, map[string]http.HandlerFunc{
+		"POST /v1/agent-builds/00000000-0000-0000-0000-000000000001/versions": func(w http.ResponseWriter, r *http.Request) {
+			decodeJSONBody(t, r, &captures.BuildVersionBody)
+			jsonHandler(201, map[string]any{"id": "version-candidate", "version_status": "draft"})(w, r)
+		},
+		"POST /v1/agent-build-versions/version-candidate/ready": jsonHandler(200, map[string]any{
+			"id":             "version-candidate",
+			"version_status": "ready",
+		}),
+		"POST /v1/workspaces/ws-1/agent-deployments": func(w http.ResponseWriter, r *http.Request) {
+			decodeJSONBody(t, r, &captures.DeploymentBody)
+			jsonHandler(201, map[string]any{
+				"id":      "dep-candidate",
+				"name":    "pr-candidate",
+				"status":  "active",
+				"web_url": "https://app.agentclash.dev/deployments/dep-candidate",
+			})(w, r)
+		},
+		"POST /v1/runs": func(w http.ResponseWriter, r *http.Request) {
+			decodeJSONBody(t, r, &captures.RunBody)
+			jsonHandler(201, map[string]any{
+				"id":      "run-candidate",
+				"status":  "queued",
+				"web_url": "https://app.agentclash.dev/runs/run-candidate",
+			})(w, r)
+		},
+		"GET /v1/runs/run-candidate": jsonHandler(200, map[string]any{
+			"id":      "run-candidate",
+			"status":  "completed",
+			"web_url": "https://app.agentclash.dev/runs/run-candidate",
+		}),
+		"GET /v1/runs/run-candidate/agents": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":                  "agent-candidate",
+				"run_id":              "run-candidate",
+				"label":               "candidate",
+				"status":              "completed",
+				"agent_deployment_id": "dep-candidate",
+			}},
+		}),
+		"POST /v1/release-gates/evaluate": ciRunGateHandler(t, captures, "pass"),
+	})
+	for key, handler := range overrides {
+		routes[key] = handler
+	}
+	return routes
+}
+
+func ciRunGateHandler(t *testing.T, captures *ciRunRouteCaptures, verdict string) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		decodeJSONBody(t, r, &captures.GateBody)
+		reason := "gate_passed"
+		summary := "candidate passed"
+		if verdict != "pass" {
+			reason = "regression_detected"
+			summary = "candidate regressed"
+		}
+		jsonHandler(200, map[string]any{
+			"release_gate": map[string]any{
+				"verdict":         verdict,
+				"reason_code":     reason,
+				"summary":         summary,
+				"evidence_status": verdict,
+			},
+		})(w, r)
+	}
+}
+
+func decodeJSONBody(t *testing.T, r *http.Request, target *map[string]any) {
+	t.Helper()
+	var body map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+	*target = body
+}
+
+func exitCodeOf(t *testing.T, err error) int {
+	t.Helper()
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected *ExitCodeError, got %T (%v)", err, err)
+	}
+	return exitErr.Code
+}

--- a/cli/cmd/ci_run_test.go
+++ b/cli/cmd/ci_run_test.go
@@ -32,8 +32,8 @@ func TestCIRunCreatesCandidateRunAndEvaluatesPassingGate(t *testing.T) {
 	if result.Baseline.RunID != "00000000-0000-0000-0000-000000000008" {
 		t.Fatalf("baseline run = %q, want manifest baseline", result.Baseline.RunID)
 	}
-	if result.BaselineResolution.Strategy != "locked_run" {
-		t.Fatalf("baseline strategy = %q, want locked_run", result.BaselineResolution.Strategy)
+	if result.BaselineResolution == nil || result.BaselineResolution.Strategy != "locked_run" {
+		t.Fatalf("baseline resolution = %+v, want locked_run", result.BaselineResolution)
 	}
 	if result.BaselineResolution.Source != "baseline.run_id" || result.BaselineResolution.Refresh.Mode != "manual" {
 		t.Fatalf("baseline resolution = %+v, want source and refresh policy", result.BaselineResolution)
@@ -81,6 +81,9 @@ regressions: {}
 	if result.ExitCode != ciRunExitInvalidManifest || !strings.Contains(strings.Join(result.Errors, "\n"), "trigger.paths") {
 		t.Fatalf("result = %+v, want invalid manifest errors", result)
 	}
+	if result.BaselineResolution != nil {
+		t.Fatalf("baseline_resolution = %+v, want omitted on early failure", result.BaselineResolution)
+	}
 }
 
 func TestCIRunMissingWorkspaceReturnsJSONExitCode(t *testing.T) {
@@ -109,6 +112,42 @@ func TestCIRunRejectsUnsafeSpecFilePaths(t *testing.T) {
 				t.Fatalf("validateCIRunSpecPath(%q) error = nil, want rejection", path)
 			}
 		})
+	}
+}
+
+func TestCIRunRemoteDecodeErrorUsesAPIExitCode(t *testing.T) {
+	target := writeCIRunManifest(t)
+	captures := &ciRunRouteCaptures{}
+	srv := fakeAPI(t, ciRunRoutes(t, captures, map[string]http.HandlerFunc{
+		"GET /v1/agent-builds/00000000-0000-0000-0000-000000000001": invalidJSONHandler(200),
+	}))
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	result, err, _ := runCIRunJSON(t, []string{"ci", "run", "--manifest", target, "-w", "ws-1", "--json"}, srv.URL)
+	if got := exitCodeOf(t, err); got != ciRunExitAPI {
+		t.Fatalf("exit code = %d, want API %d (err %v)", got, ciRunExitAPI, err)
+	}
+	if result.ExitCode != ciRunExitAPI {
+		t.Fatalf("result = %+v, want API exit code", result)
+	}
+}
+
+func TestCIRunBuildVersionDecodeErrorUsesAPIExitCode(t *testing.T) {
+	target := writeCIRunManifest(t)
+	captures := &ciRunRouteCaptures{}
+	srv := fakeAPI(t, ciRunRoutes(t, captures, map[string]http.HandlerFunc{
+		"POST /v1/agent-builds/00000000-0000-0000-0000-000000000001/versions": invalidJSONHandler(201),
+	}))
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	result, err, _ := runCIRunJSON(t, []string{"ci", "run", "--manifest", target, "-w", "ws-1", "--json"}, srv.URL)
+	if got := exitCodeOf(t, err); got != ciRunExitAPI {
+		t.Fatalf("exit code = %d, want API %d (err %v)", got, ciRunExitAPI, err)
+	}
+	if result.ExitCode != ciRunExitAPI {
+		t.Fatalf("result = %+v, want API exit code", result)
 	}
 }
 
@@ -196,6 +235,14 @@ func writeCIRunManifest(t *testing.T) string {
 	manifest := strings.Replace(sampleCIManifestYAML, "    spec_file: .agentclash/agent.json", "    spec_file: "+specPath, 1)
 	manifest = strings.Replace(manifest, "  max_age_days: 30\n", "", 1)
 	return writeCIManifest(t, manifest)
+}
+
+func invalidJSONHandler(status int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(`{`))
+	}
 }
 
 func runCIRunJSON(t *testing.T, args []string, apiURL string) (ciRunResult, error, string) {

--- a/web/content/docs/guides/ci-cd-agent-gates.mdx
+++ b/web/content/docs/guides/ci-cd-agent-gates.mdx
@@ -141,7 +141,7 @@ agentclash ci should-run \
 
 ## GitHub Actions sketch
 
-The shipped CI surface validates the manifest, resolves the baseline, and decides whether a gate should run. Full orchestration will be a follow-up command built on the same file. Until then, teams can validate the contract and keep using the existing explicit run and gate commands. The workflow below repeats selected candidate IDs as GitHub variables only because `agentclash ci run` does not exist yet; once it does, the manifest should be the single source of truth.
+The manifest is the single source of truth for the candidate revision, workload, baseline, and gate. A pull request workflow can validate it, decide whether it should run for the changed files, then let `agentclash ci run` create the candidate build version, deployment, run, and release-gate evaluation.
 
 ```yaml
 name: AgentClash gate
@@ -181,61 +181,21 @@ jobs:
           SHOULD_RUN=$(agentclash ci should-run --json | jq -r '.should_run')
           echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
 
-      - name: Resolve AgentClash baseline
+      - name: Run AgentClash CI gate
         if: steps.should-run.outputs.should_run == 'true'
-        id: baseline
+        id: agentclash
         run: |
-          BASELINE_JSON=$(agentclash ci baseline --json)
-          echo "run_id=$(echo "$BASELINE_JSON" | jq -r '.baseline.run_id')" >> "$GITHUB_OUTPUT"
-          echo "run_agent_id=$(echo "$BASELINE_JSON" | jq -r '.baseline.run_agent_id // ""')" >> "$GITHUB_OUTPUT"
-        env:
-          AGENTCLASH_API_URL: https://api.agentclash.dev
-          AGENTCLASH_TOKEN: ${{ secrets.AGENTCLASH_TOKEN }}
-          AGENTCLASH_WORKSPACE: ${{ secrets.AGENTCLASH_WORKSPACE }}
-
-      - name: Create candidate run
-        if: steps.should-run.outputs.should_run == 'true'
-        id: candidate
-        run: |
-          RUN_JSON=$(agentclash run create \
-            --challenge-pack-version "$AGENTCLASH_CHALLENGE_PACK_VERSION" \
-            --deployments "$AGENTCLASH_CANDIDATE_DEPLOYMENT" \
-            --json)
-          RUN_ID=$(echo "$RUN_JSON" | jq -r '.id')
-          CANDIDATE_AGENT_ID=$(agentclash run agents "$RUN_ID" --json \
-            | jq -r --arg dep "$AGENTCLASH_CANDIDATE_DEPLOYMENT" '.items[] | select(.agent_deployment_id == $dep) | .id' \
-            | head -n 1)
-          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
-          echo "run_agent_id=$CANDIDATE_AGENT_ID" >> "$GITHUB_OUTPUT"
-        env:
-          AGENTCLASH_API_URL: https://api.agentclash.dev
-          AGENTCLASH_TOKEN: ${{ secrets.AGENTCLASH_TOKEN }}
-          AGENTCLASH_WORKSPACE: ${{ secrets.AGENTCLASH_WORKSPACE }}
-          AGENTCLASH_CHALLENGE_PACK_VERSION: ${{ vars.AGENTCLASH_CHALLENGE_PACK_VERSION }}
-          AGENTCLASH_CANDIDATE_DEPLOYMENT: ${{ vars.AGENTCLASH_CANDIDATE_DEPLOYMENT }}
-
-      - name: Evaluate release gate
-        if: steps.should-run.outputs.should_run == 'true'
-        run: |
-          args=(
-            compare gate
-            --baseline "${{ steps.baseline.outputs.run_id }}"
-            --candidate "${{ steps.candidate.outputs.run_id }}"
-          )
-          if [ -n "${{ steps.baseline.outputs.run_agent_id }}" ]; then
-            args+=(--baseline-agent "${{ steps.baseline.outputs.run_agent_id }}")
-          fi
-          if [ -n "${{ steps.candidate.outputs.run_agent_id }}" ]; then
-            args+=(--candidate-agent "${{ steps.candidate.outputs.run_agent_id }}")
-          fi
-          agentclash "${args[@]}"
+          agentclash ci run --manifest .agentclash/ci.yaml --json \
+            | tee agentclash-ci-result.json
+          echo "run_id=$(jq -r '.candidate.run_id' agentclash-ci-result.json)" >> "$GITHUB_OUTPUT"
+          echo "gate_verdict=$(jq -r '.gate_verdict' agentclash-ci-result.json)" >> "$GITHUB_OUTPUT"
         env:
           AGENTCLASH_API_URL: https://api.agentclash.dev
           AGENTCLASH_TOKEN: ${{ secrets.AGENTCLASH_TOKEN }}
           AGENTCLASH_WORKSPACE: ${{ secrets.AGENTCLASH_WORKSPACE }}
 ```
 
-For multi-agent candidate runs, resolve the candidate lane with `agentclash run agents <run-id> --json` and pass `--candidate-agent <run-agent-id>` for the participant you intend to gate.
+`agentclash ci run` exits nonzero when the gate verdict should block CI, when the candidate run times out, or when the manifest/API setup is invalid.
 
 ## Regression promotion policy
 
@@ -266,11 +226,11 @@ Only a future main-branch workflow should auto-promote high-confidence failures 
 
 ## Current limits
 
-- `agentclash ci validate` validates the manifest shape locally; it does not check that IDs exist in the API.
-- `agentclash ci baseline` checks and resolves only the baseline; full API-backed validation for every manifest resource is still separate follow-up work.
-- `agentclash ci should-run` only decides whether a gate should run; it does not create runs or evaluate gates.
-- There is not yet an `agentclash ci run` wrapper that creates the candidate build version, deployment, run, gate, and PR report in one command.
+- `agentclash ci validate` validates the manifest shape locally; pass `--remote` for API-backed resource checks.
+- `agentclash ci should-run` only decides whether a gate should run; `agentclash ci run` performs the orchestration.
+- `agentclash ci run` creates a one-off candidate deployment for the manifest build version; cleanup/retention policy is still a follow-up.
 - PR metadata such as repository, pull request number, branch, and commit SHA is not yet attached to runs by the CLI.
+- PR comments, check-run summaries, and uploaded JSON artifacts are still follow-up work.
 - Automatic regression promotion should remain opt-in and conservative.
 
 ## See also

--- a/web/content/docs/guides/ci-cd-agent-gates.mdx
+++ b/web/content/docs/guides/ci-cd-agent-gates.mdx
@@ -185,10 +185,14 @@ jobs:
         if: steps.should-run.outputs.should_run == 'true'
         id: agentclash
         run: |
+          set +e
           agentclash ci run --manifest .agentclash/ci.yaml --json \
-            | tee agentclash-ci-result.json
+            > agentclash-ci-result.json
+          status=$?
+          cat agentclash-ci-result.json
           echo "run_id=$(jq -r '.candidate.run_id' agentclash-ci-result.json)" >> "$GITHUB_OUTPUT"
           echo "gate_verdict=$(jq -r '.gate_verdict' agentclash-ci-result.json)" >> "$GITHUB_OUTPUT"
+          exit "$status"
         env:
           AGENTCLASH_API_URL: https://api.agentclash.dev
           AGENTCLASH_TOKEN: ${{ secrets.AGENTCLASH_TOKEN }}


### PR DESCRIPTION
## Summary
- add `agentclash ci run` to execute the manifest gate end to end
- create/ready the candidate build version, create a candidate deployment, start the workload run, wait for completion, resolve baseline, and evaluate release gate
- emit stable JSON and documented CI exit codes for pass, gate fail/warn/insufficient evidence, invalid manifest, API failure, timeout, and failed candidate run
- update README and CI/CD guide to show the single-command GitHub Actions flow

Closes #499

## Review Checkpoint
- Contract: `/tmp/reviewcheckpoint-issue-499-contract.md`
- Checkpoint: `/tmp/reviewcheckpoint-issue-499.json`
- Final verdict: ready

## Tests
- `go test ./cmd -run 'TestCIRun' -count=1`
- `go build ./...`
- `go vet ./...`
- `go test -short ./... -count=1`
- `go test -short -race -count=1 ./...`
- `go run . ci run --help`