### PR TITLE
feat(ci): add reusable GitHub Actions gate

### DIFF
--- a/.github/actions/agentclash-ci/README.md
+++ b/.github/actions/agentclash-ci/README.md
@@ -1,0 +1,90 @@
+# AgentClash CI Gate Action
+
+Run a manifest-based AgentClash CI gate from GitHub Actions.
+
+This action is a thin wrapper around the published `agentclash` CLI:
+
+1. optionally install `agentclash` from npm
+2. validate the repo-tracked CI manifest
+3. run `agentclash ci should-run`
+4. run `agentclash ci run` when the manifest trigger matches
+5. expose result paths and gate outputs for artifact upload or downstream steps
+
+## Example
+
+```yaml
+name: AgentClash gate
+
+on:
+  pull_request:
+    paths:
+      - ".agentclash/**"
+      - "prompts/**"
+      - "tools/**"
+
+jobs:
+  agentclash:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - id: agentclash
+        uses: agentclash/agentclash/.github/actions/agentclash-ci@main
+        with:
+          token: ${{ secrets.AGENTCLASH_TOKEN }}
+          workspace: ${{ secrets.AGENTCLASH_WORKSPACE }}
+          manifest: .agentclash/ci.yaml
+
+      - name: Upload AgentClash gate artifacts
+        if: always() && steps.agentclash.outputs['should-run'] == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentclash-ci
+          path: |
+            ${{ steps.agentclash.outputs.result-file }}
+            ${{ steps.agentclash.outputs.artifact-dir }}/*.json
+```
+
+## Inputs
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `manifest` | `.agentclash/ci.yaml` | Path to the AgentClash CI manifest. |
+| `token` | `AGENTCLASH_TOKEN` | AgentClash API token. |
+| `workspace` | `AGENTCLASH_WORKSPACE` | AgentClash workspace ID. |
+| `api-url` | `https://api.agentclash.dev` | AgentClash API base URL. |
+| `install-cli` | `true` | Install `agentclash` from npm before running. |
+| `cli-version` | `latest` | npm version or tag for the `agentclash` package. |
+| `remote-validate` | `true` | Validate manifest resource IDs against the API. |
+| `skip-if-unmatched` | `true` | Skip `ci run` when manifest paths and labels do not match. |
+| `base` | pull request base branch | Base ref for `ci should-run`. |
+| `head` | `HEAD` | Head ref for `ci should-run`. |
+| `changed-files` | empty | Newline-separated files to pass directly to `ci should-run`. |
+| `labels` | empty | Comma-separated pull request labels. |
+| `artifact-dir` | `agentclash-artifacts` | Directory for `ci run` JSON artifacts. |
+| `result-file` | `agentclash-ci-result.json` | Top-level `ci run` JSON result path. |
+| `timeout` | CLI default | Optional `ci run` timeout, for example `30m` or `0`. |
+| `poll-interval` | CLI default | Optional `ci run` poll interval, for example `5s`. |
+| `follow` | `false` | Stream run events while waiting. |
+| `default-branch` | auto-detected | Default branch metadata override for `auto_on_main` regression promotion. |
+
+## Outputs
+
+| Output | Description |
+| --- | --- |
+| `should-run` | `true` when the manifest trigger matched and `ci run` was attempted. |
+| `skip-reason` | Reason returned by `ci should-run` when skipped. |
+| `run-id` | Candidate AgentClash run ID. |
+| `gate-verdict` | Release gate verdict from `ci run`. |
+| `exit-code` | Exit code returned by `agentclash ci run`, or `0` when skipped. |
+| `result-file` | Path to the top-level result JSON. |
+| `artifact-dir` | Directory containing stable AgentClash JSON artifacts. |
+
+The action preserves the CLI exit code. A blocking AgentClash gate fails the job with the same code that `agentclash ci run` returned.

--- a/.github/actions/agentclash-ci/action.yml
+++ b/.github/actions/agentclash-ci/action.yml
@@ -1,0 +1,122 @@
+name: AgentClash CI Gate
+description: Run an AgentClash manifest-based CI gate in GitHub Actions.
+
+branding:
+  icon: check-circle
+  color: green
+
+inputs:
+  manifest:
+    description: Path to the AgentClash CI manifest.
+    required: false
+    default: .agentclash/ci.yaml
+  token:
+    description: AgentClash API token. Defaults to AGENTCLASH_TOKEN when omitted.
+    required: false
+  workspace:
+    description: AgentClash workspace ID. Defaults to AGENTCLASH_WORKSPACE when omitted.
+    required: false
+  api-url:
+    description: AgentClash API base URL.
+    required: false
+    default: https://api.agentclash.dev
+  install-cli:
+    description: Install the published agentclash npm package before running.
+    required: false
+    default: "true"
+  cli-version:
+    description: npm version or tag for the agentclash package.
+    required: false
+    default: latest
+  remote-validate:
+    description: Validate manifest resource IDs against the AgentClash API.
+    required: false
+    default: "true"
+  skip-if-unmatched:
+    description: Skip ci run when manifest paths and labels do not match the change set.
+    required: false
+    default: "true"
+  base:
+    description: Base git ref for deriving changed files. Defaults to the pull request base branch when available.
+    required: false
+  head:
+    description: Head git ref for deriving changed files. Defaults to HEAD.
+    required: false
+  changed-files:
+    description: Newline-separated changed files. When set, these are passed directly to ci should-run.
+    required: false
+  labels:
+    description: Comma-separated pull request labels that may force the gate.
+    required: false
+  artifact-dir:
+    description: Directory for AgentClash CI JSON artifacts.
+    required: false
+    default: agentclash-artifacts
+  result-file:
+    description: Path for the top-level ci run JSON result.
+    required: false
+    default: agentclash-ci-result.json
+  timeout:
+    description: Optional ci run timeout, for example 30m or 0.
+    required: false
+  poll-interval:
+    description: Optional ci run poll interval, for example 5s.
+    required: false
+  follow:
+    description: Stream run events while waiting for the candidate run.
+    required: false
+    default: "false"
+  default-branch:
+    description: Optional default branch metadata override for auto_on_main regression promotion.
+    required: false
+
+outputs:
+  should-run:
+    description: Whether the manifest trigger matched and ci run was attempted.
+    value: ${{ steps.agentclash.outputs['should-run'] }}
+  skip-reason:
+    description: Reason returned by ci should-run when the gate is skipped.
+    value: ${{ steps.agentclash.outputs['skip-reason'] }}
+  run-id:
+    description: Candidate AgentClash run ID when ci run starts.
+    value: ${{ steps.agentclash.outputs['run-id'] }}
+  gate-verdict:
+    description: Release gate verdict from ci run.
+    value: ${{ steps.agentclash.outputs['gate-verdict'] }}
+  exit-code:
+    description: Exit code returned by agentclash ci run, or 0 when skipped.
+    value: ${{ steps.agentclash.outputs['exit-code'] }}
+  result-file:
+    description: Path to the top-level ci run JSON result.
+    value: ${{ steps.agentclash.outputs['result-file'] }}
+  artifact-dir:
+    description: Directory containing AgentClash CI JSON artifacts.
+    value: ${{ steps.agentclash.outputs['artifact-dir'] }}
+
+runs:
+  using: composite
+  steps:
+    - id: agentclash
+      name: Run AgentClash CI gate
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        INPUT_MANIFEST: ${{ inputs.manifest }}
+        INPUT_TOKEN: ${{ inputs.token }}
+        INPUT_WORKSPACE: ${{ inputs.workspace }}
+        INPUT_API_URL: ${{ inputs.api-url }}
+        INPUT_INSTALL_CLI: ${{ inputs.install-cli }}
+        INPUT_CLI_VERSION: ${{ inputs.cli-version }}
+        INPUT_REMOTE_VALIDATE: ${{ inputs.remote-validate }}
+        INPUT_SKIP_IF_UNMATCHED: ${{ inputs.skip-if-unmatched }}
+        INPUT_BASE: ${{ inputs.base }}
+        INPUT_HEAD: ${{ inputs.head }}
+        INPUT_CHANGED_FILES: ${{ inputs.changed-files }}
+        INPUT_LABELS: ${{ inputs.labels }}
+        INPUT_ARTIFACT_DIR: ${{ inputs.artifact-dir }}
+        INPUT_RESULT_FILE: ${{ inputs.result-file }}
+        INPUT_TIMEOUT: ${{ inputs.timeout }}
+        INPUT_POLL_INTERVAL: ${{ inputs.poll-interval }}
+        INPUT_FOLLOW: ${{ inputs.follow }}
+        INPUT_DEFAULT_BRANCH: ${{ inputs.default-branch }}
+      run: '"${ACTION_PATH}/run.sh"'

--- a/.github/actions/agentclash-ci/run.sh
+++ b/.github/actions/agentclash-ci/run.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+bool_true() {
+  local value
+  value="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')"
+  case "$value" in
+    1 | true | yes | y | on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+write_output() {
+  local key="$1"
+  local value="$2"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    printf '%s=%s\n' "$key" "$value" >>"$GITHUB_OUTPUT"
+  fi
+}
+
+append_summary() {
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    printf '%s\n' "$1" >>"$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+json_get() {
+  local file="$1"
+  local path="$2"
+  python3 - "$file" "$path" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    value = json.load(handle)
+
+for part in sys.argv[2].split("."):
+    if not part:
+        continue
+    if isinstance(value, dict):
+        value = value.get(part)
+    else:
+        value = None
+    if value is None:
+        break
+
+if isinstance(value, bool):
+    print("true" if value else "false")
+elif value is None:
+    print("")
+else:
+    print(value)
+PY
+}
+
+manifest="${INPUT_MANIFEST:-.agentclash/ci.yaml}"
+artifact_dir="${INPUT_ARTIFACT_DIR:-agentclash-artifacts}"
+result_file="${INPUT_RESULT_FILE:-agentclash-ci-result.json}"
+should_run_file="${RUNNER_TEMP:-/tmp}/agentclash-should-run.json"
+
+write_output "result-file" "$result_file"
+write_output "artifact-dir" "$artifact_dir"
+
+if [[ -n "${INPUT_TOKEN:-}" ]]; then
+  export AGENTCLASH_TOKEN="$INPUT_TOKEN"
+fi
+if [[ -n "${INPUT_WORKSPACE:-}" ]]; then
+  export AGENTCLASH_WORKSPACE="$INPUT_WORKSPACE"
+fi
+export AGENTCLASH_API_URL="${INPUT_API_URL:-${AGENTCLASH_API_URL:-https://api.agentclash.dev}}"
+
+if bool_true "${INPUT_INSTALL_CLI:-true}"; then
+  npm install --global "agentclash@${INPUT_CLI_VERSION:-latest}"
+fi
+
+if bool_true "${INPUT_REMOTE_VALIDATE:-true}"; then
+  agentclash ci validate "$manifest" --remote
+else
+  agentclash ci validate "$manifest"
+fi
+
+should_args=(ci should-run --manifest "$manifest" --json)
+if [[ -n "${INPUT_CHANGED_FILES:-}" ]]; then
+  while IFS= read -r changed_file; do
+    [[ -z "$changed_file" ]] && continue
+    should_args+=(--changed-file "$changed_file")
+  done <<<"${INPUT_CHANGED_FILES}"
+else
+  base="${INPUT_BASE:-}"
+  head="${INPUT_HEAD:-}"
+  if [[ -z "$base" && -n "${GITHUB_BASE_REF:-}" ]]; then
+    base="origin/${GITHUB_BASE_REF}"
+  fi
+  if [[ -z "$head" ]]; then
+    head="HEAD"
+  fi
+  if [[ -n "$base" ]]; then
+    should_args+=(--base "$base" --head "$head")
+  fi
+fi
+if [[ -n "${INPUT_LABELS:-}" ]]; then
+  should_args+=(--labels "${INPUT_LABELS}")
+fi
+
+agentclash "${should_args[@]}" >"$should_run_file"
+should_run="$(json_get "$should_run_file" should_run)"
+skip_reason="$(json_get "$should_run_file" reason)"
+write_output "should-run" "$should_run"
+write_output "skip-reason" "$skip_reason"
+
+skip_if_unmatched=false
+if bool_true "${INPUT_SKIP_IF_UNMATCHED:-true}"; then
+  skip_if_unmatched=true
+fi
+
+if [[ "$should_run" != "true" && "$skip_if_unmatched" == "true" ]]; then
+  write_output "exit-code" "0"
+  append_summary "## AgentClash CI"
+  append_summary ""
+  append_summary "Skipped: ${skip_reason:-manifest trigger did not match this change set}"
+  exit 0
+fi
+
+run_args=(ci run --manifest "$manifest" --json --artifact-dir "$artifact_dir")
+if [[ -n "${INPUT_TIMEOUT:-}" ]]; then
+  run_args+=(--timeout "${INPUT_TIMEOUT}")
+fi
+if [[ -n "${INPUT_POLL_INTERVAL:-}" ]]; then
+  run_args+=(--poll-interval "${INPUT_POLL_INTERVAL}")
+fi
+if bool_true "${INPUT_FOLLOW:-false}"; then
+  run_args+=(--follow)
+fi
+if [[ -n "${INPUT_DEFAULT_BRANCH:-}" ]]; then
+  run_args+=(--ci-default-branch "${INPUT_DEFAULT_BRANCH}")
+fi
+
+set +e
+agentclash "${run_args[@]}" >"$result_file"
+status=$?
+set -e
+
+write_output "exit-code" "$status"
+if [[ -s "$result_file" ]]; then
+  cat "$result_file"
+  write_output "run-id" "$(json_get "$result_file" candidate.run_id)"
+  write_output "gate-verdict" "$(json_get "$result_file" gate_verdict)"
+else
+  write_output "run-id" ""
+  write_output "gate-verdict" ""
+fi
+exit "$status"

--- a/README.md
+++ b/README.md
@@ -143,6 +143,16 @@ The current CLI validates that manifest locally by default, can optionally check
 
 Set `regressions.promote_failures: proposed` when failing CI gates should create reviewable regression candidates in the manifest's `evaluation.regression_suites`. The CLI deduplicates against existing non-archived/non-rejected cases and reports created, existing, skipped, blocked, and error outcomes in JSON and GitHub summaries. Use `disabled` to report only, or `auto_on_main` for protected default-branch workflows that may create active cases after refusing pull request and non-default-branch events.
 
+For GitHub Actions, use the reusable [`agentclash-ci`](.github/actions/agentclash-ci) action to install the CLI, validate the manifest, skip unrelated changes, run the gate, and expose artifact paths:
+
+```yaml
+- id: agentclash
+  uses: agentclash/agentclash/.github/actions/agentclash-ci@main
+  with:
+    token: ${{ secrets.AGENTCLASH_TOKEN }}
+    workspace: ${{ secrets.AGENTCLASH_WORKSPACE }}
+```
+
 Existing commands also work non-interactively with environment variables and explicit IDs:
 
 ```bash

--- a/web/content/docs/guides/ci-cd-agent-gates.mdx
+++ b/web/content/docs/guides/ci-cd-agent-gates.mdx
@@ -143,6 +143,8 @@ agentclash ci should-run \
 
 The manifest is the single source of truth for the candidate revision, workload, baseline, and gate. A pull request workflow can validate it, decide whether it should run for the changed files, then let `agentclash ci run` create the candidate build version, deployment, run, and release-gate evaluation.
 
+Use the reusable AgentClash action when you want the standard GitHub integration without rewriting the shell glue:
+
 ```yaml
 name: AgentClash gate
 
@@ -166,48 +168,25 @@ jobs:
         with:
           node-version: "22"
 
-      - run: npm i -g agentclash
-
-      - name: Validate AgentClash CI manifest
-        run: agentclash ci validate .agentclash/ci.yaml --remote
-        env:
-          AGENTCLASH_API_URL: https://api.agentclash.dev
-          AGENTCLASH_TOKEN: ${{ secrets.AGENTCLASH_TOKEN }}
-          AGENTCLASH_WORKSPACE: ${{ secrets.AGENTCLASH_WORKSPACE }}
-
-      - name: Decide whether AgentClash gate should run
-        id: should-run
-        run: |
-          SHOULD_RUN=$(agentclash ci should-run --json | jq -r '.should_run')
-          echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
-
       - name: Run AgentClash CI gate
-        if: steps.should-run.outputs.should_run == 'true'
         id: agentclash
-        run: |
-          set +e
-          agentclash ci run --manifest .agentclash/ci.yaml --json \
-            --artifact-dir agentclash-artifacts \
-            > agentclash-ci-result.json
-          status=$?
-          cat agentclash-ci-result.json
-          echo "run_id=$(jq -r '.candidate.run_id' agentclash-ci-result.json)" >> "$GITHUB_OUTPUT"
-          echo "gate_verdict=$(jq -r '.gate_verdict' agentclash-ci-result.json)" >> "$GITHUB_OUTPUT"
-          exit "$status"
-        env:
-          AGENTCLASH_API_URL: https://api.agentclash.dev
-          AGENTCLASH_TOKEN: ${{ secrets.AGENTCLASH_TOKEN }}
-          AGENTCLASH_WORKSPACE: ${{ secrets.AGENTCLASH_WORKSPACE }}
+        uses: agentclash/agentclash/.github/actions/agentclash-ci@main
+        with:
+          token: ${{ secrets.AGENTCLASH_TOKEN }}
+          workspace: ${{ secrets.AGENTCLASH_WORKSPACE }}
+          manifest: .agentclash/ci.yaml
 
       - name: Upload AgentClash gate artifacts
-        if: always() && steps.should-run.outputs.should_run == 'true'
+        if: always() && steps.agentclash.outputs['should-run'] == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: agentclash-ci
           path: |
-            agentclash-ci-result.json
-            agentclash-artifacts/*.json
+            ${{ steps.agentclash.outputs.result-file }}
+            ${{ steps.agentclash.outputs.artifact-dir }}/*.json
 ```
+
+The action installs the published `agentclash` npm package by default, runs `ci validate --remote`, runs `ci should-run`, skips unrelated changes, runs `ci run` when matched, and exposes `should-run`, `skip-reason`, `run-id`, `gate-verdict`, `exit-code`, `result-file`, and `artifact-dir` outputs. It preserves the CLI exit code, so a blocking gate fails the workflow normally.
 
 `agentclash ci run` exits nonzero when the gate verdict should block CI, when the candidate run times out, or when the manifest/API setup is invalid. In GitHub Actions, it automatically attaches repository, pull request, branch, default branch, commit, workflow, event, and workflow-run URL metadata to the AgentClash run. It also appends a reviewer-friendly Markdown section when the `$GITHUB_STEP_SUMMARY` environment variable is set. Pass `--summary-file <path>` for another Markdown destination, or `--github-step-summary=false` to disable the automatic GitHub summary.
 


### PR DESCRIPTION
## Summary
- add a reusable composite GitHub Action at `.github/actions/agentclash-ci`
- wrap `agentclash ci validate`, `ci should-run`, and `ci run` with stable GitHub outputs and exit-code preservation
- document the short action-based PR gate workflow and artifact upload contract

Closes #52

## Review checkpoint
Contract: `/tmp/reviewcheckpoint-issue-52-contract.md`
Checkpoint: `/tmp/reviewcheckpoint-issue-52.json`

Implemented in small commits:
1. `feat(ci): step 1 - add GitHub action wrapper`
2. `docs(ci): step 2 - document GitHub action gate`

## Tests
- `bash -n .github/actions/agentclash-ci/run.sh`
- `ruby -e 'require "yaml"; data = YAML.load_file(".github/actions/agentclash-ci/action.yml"); abort("missing outputs") unless data["outputs"] && data["runs"]'`
- fake `agentclash` dry runs for skip path and failing-gate path, including outputs and exit-code preservation
- `cd web && npm ci --ignore-scripts && npm run lint && npm test -- --run` (removed `node_modules` afterward)
- `git diff --check`
