### PR TITLE
feat(ci): dedupe regression promotions by failure cluster

### DIFF
--- a/cli/cmd/ci_regressions.go
+++ b/cli/cmd/ci_regressions.go
@@ -268,7 +268,7 @@ func ciRunExistingPromotionCase(suiteID string, existing ciRunRegressionCaseSumm
 	return ciRunRegressionPromotionCase{
 		SuiteID:             suiteID,
 		CaseID:              existing.ID,
-		ChallengeIdentityID: firstNonEmptyString(existing.ChallengeIdentityID, failure.ChallengeIdentityID),
+		ChallengeIdentityID: failure.ChallengeIdentityID,
 		ChallengeKey:        failure.ChallengeKey,
 		FailureClusterKey:   failure.FailureClusterKey,
 		Status:              existing.Status,

--- a/cli/cmd/ci_regressions.go
+++ b/cli/cmd/ci_regressions.go
@@ -23,6 +23,7 @@ type ciRunRegressionPromotionCase struct {
 	CaseID              string `json:"case_id,omitempty" yaml:"case_id,omitempty"`
 	ChallengeIdentityID string `json:"challenge_identity_id,omitempty" yaml:"challenge_identity_id,omitempty"`
 	ChallengeKey        string `json:"challenge_key,omitempty" yaml:"challenge_key,omitempty"`
+	FailureClusterKey   string `json:"failure_cluster_key,omitempty" yaml:"failure_cluster_key,omitempty"`
 	Status              string `json:"status,omitempty" yaml:"status,omitempty"`
 	Created             bool   `json:"created" yaml:"created"`
 }
@@ -51,10 +52,11 @@ type ciRunFailureReviewItem struct {
 }
 
 type ciRunRegressionCaseSummary struct {
-	ID                  string `json:"id"`
-	Status              string `json:"status"`
-	ChallengeIdentityID string `json:"source_challenge_identity_id"`
-	Title               string `json:"title"`
+	ID                  string         `json:"id"`
+	Status              string         `json:"status"`
+	ChallengeIdentityID string         `json:"source_challenge_identity_id"`
+	Title               string         `json:"title"`
+	Metadata            map[string]any `json:"metadata"`
 }
 
 func promoteCIRunRegressionFailures(cmd *cobra.Command, rc *RunContext, workspaceID string, manifest ciManifest, result ciRunResult, releaseGate map[string]any) *ciRunRegressionPromotionResult {
@@ -109,7 +111,7 @@ func promoteCIRunRegressionFailures(cmd *cobra.Command, rc *RunContext, workspac
 			summary.Errors = append(summary.Errors, fmt.Sprintf("list regression cases for suite %s: %v", suiteID, err))
 			continue
 		}
-		existingByChallenge := ciRunExistingCaseByChallenge(existingCases)
+		existingByChallenge, existingByCluster := ciRunExistingCaseIndexes(existingCases)
 		for _, failure := range failures {
 			if !failure.Promotable {
 				summary.Skipped = append(summary.Skipped, ciRunRegressionPromotionSkip{
@@ -121,22 +123,16 @@ func promoteCIRunRegressionFailures(cmd *cobra.Command, rc *RunContext, workspac
 				})
 				continue
 			}
+			if existing, ok := ciRunFindExistingCase(failure, existingByChallenge, existingByCluster); ok {
+				summary.Existing = append(summary.Existing, ciRunExistingPromotionCase(suiteID, existing, failure))
+				continue
+			}
 			if strings.TrimSpace(failure.ChallengeIdentityID) == "" {
 				summary.Skipped = append(summary.Skipped, ciRunRegressionPromotionSkip{
 					SuiteID:      suiteID,
 					ChallengeKey: failure.ChallengeKey,
 					Reason:       "missing_challenge_identity",
 					Message:      "failure review item has no challenge identity id",
-				})
-				continue
-			}
-			if existing, ok := existingByChallenge[failure.ChallengeIdentityID]; ok {
-				summary.Existing = append(summary.Existing, ciRunRegressionPromotionCase{
-					SuiteID:             suiteID,
-					CaseID:              existing.ID,
-					ChallengeIdentityID: failure.ChallengeIdentityID,
-					ChallengeKey:        failure.ChallengeKey,
-					Status:              existing.Status,
 				})
 				continue
 			}
@@ -237,18 +233,46 @@ func listCIRunRegressionCases(cmd *cobra.Command, rc *RunContext, workspaceID, s
 	return result.Items, nil
 }
 
-func ciRunExistingCaseByChallenge(items []ciRunRegressionCaseSummary) map[string]ciRunRegressionCaseSummary {
-	out := make(map[string]ciRunRegressionCaseSummary)
+func ciRunExistingCaseIndexes(items []ciRunRegressionCaseSummary) (map[string]ciRunRegressionCaseSummary, map[string]ciRunRegressionCaseSummary) {
+	byChallenge := make(map[string]ciRunRegressionCaseSummary)
+	byCluster := make(map[string]ciRunRegressionCaseSummary)
 	for _, item := range items {
 		switch strings.TrimSpace(item.Status) {
 		case "archived", "rejected":
 			continue
 		}
 		if id := strings.TrimSpace(item.ChallengeIdentityID); id != "" {
-			out[id] = item
+			byChallenge[id] = item
+		}
+		if clusterKey := strings.TrimSpace(mapString(item.Metadata, "source_failure_cluster_key")); clusterKey != "" {
+			byCluster[clusterKey] = item
 		}
 	}
-	return out
+	return byChallenge, byCluster
+}
+
+func ciRunFindExistingCase(failure ciRunFailureReviewItem, byChallenge, byCluster map[string]ciRunRegressionCaseSummary) (ciRunRegressionCaseSummary, bool) {
+	if clusterKey := strings.TrimSpace(failure.FailureClusterKey); clusterKey != "" {
+		if existing, ok := byCluster[clusterKey]; ok {
+			return existing, true
+		}
+	}
+	if challengeIdentityID := strings.TrimSpace(failure.ChallengeIdentityID); challengeIdentityID != "" {
+		existing, ok := byChallenge[challengeIdentityID]
+		return existing, ok
+	}
+	return ciRunRegressionCaseSummary{}, false
+}
+
+func ciRunExistingPromotionCase(suiteID string, existing ciRunRegressionCaseSummary, failure ciRunFailureReviewItem) ciRunRegressionPromotionCase {
+	return ciRunRegressionPromotionCase{
+		SuiteID:             suiteID,
+		CaseID:              existing.ID,
+		ChallengeIdentityID: firstNonEmptyString(existing.ChallengeIdentityID, failure.ChallengeIdentityID),
+		ChallengeKey:        failure.ChallengeKey,
+		FailureClusterKey:   failure.FailureClusterKey,
+		Status:              existing.Status,
+	}
 }
 
 func ciRunPreferredPromotionMode(modes []string) string {
@@ -297,6 +321,7 @@ func promoteCIRunFailure(cmd *cobra.Command, rc *RunContext, workspaceID, suiteI
 		CaseID:              str(regressionCase["id"]),
 		ChallengeIdentityID: failure.ChallengeIdentityID,
 		ChallengeKey:        failure.ChallengeKey,
+		FailureClusterKey:   failure.FailureClusterKey,
 		Status:              firstNonEmptyString(str(regressionCase["status"]), caseStatus),
 		Created:             resp.StatusCode == 201,
 	}, nil

--- a/cli/cmd/ci_run_test.go
+++ b/cli/cmd/ci_run_test.go
@@ -525,6 +525,9 @@ func TestCIRunRegressionPromotionSkipsExistingCase(t *testing.T) {
 		"status":                       "proposed",
 		"source_challenge_identity_id": "challenge-1",
 		"title":                        "Existing proposal",
+		"metadata": map[string]any{
+			"source_failure_cluster_key": "frc-from-another-failure",
+		},
 	}})))
 	defer srv.Close()
 	t.Setenv("AGENTCLASH_TOKEN", "test-token")
@@ -542,6 +545,9 @@ func TestCIRunRegressionPromotionSkipsExistingCase(t *testing.T) {
 	}
 	if result.RegressionPromotions == nil || len(result.RegressionPromotions.Existing) != 1 || result.RegressionPromotions.Existing[0].CaseID != "case-existing" {
 		t.Fatalf("regression promotions = %+v, want existing case skip", result.RegressionPromotions)
+	}
+	if result.RegressionPromotions.Existing[0].ChallengeIdentityID != "challenge-1" {
+		t.Fatalf("existing challenge identity = %q, want current failure challenge identity", result.RegressionPromotions.Existing[0].ChallengeIdentityID)
 	}
 	if len(captures.PromotionBodies) != 0 {
 		t.Fatalf("promotion bodies = %+v, want no promote request for existing case", captures.PromotionBodies)
@@ -576,6 +582,9 @@ func TestCIRunRegressionPromotionSkipsExistingCaseByClusterKey(t *testing.T) {
 	}
 	if result.RegressionPromotions == nil || len(result.RegressionPromotions.Existing) != 1 || result.RegressionPromotions.Existing[0].CaseID != "case-existing-cluster" {
 		t.Fatalf("regression promotions = %+v, want existing cluster case", result.RegressionPromotions)
+	}
+	if result.RegressionPromotions.Existing[0].ChallengeIdentityID != "challenge-1" {
+		t.Fatalf("existing challenge identity = %q, want current failure challenge identity", result.RegressionPromotions.Existing[0].ChallengeIdentityID)
 	}
 	if result.RegressionPromotions.Existing[0].FailureClusterKey != "frc-test" {
 		t.Fatalf("existing failure cluster key = %q, want frc-test", result.RegressionPromotions.Existing[0].FailureClusterKey)

--- a/cli/cmd/ci_run_test.go
+++ b/cli/cmd/ci_run_test.go
@@ -548,6 +548,77 @@ func TestCIRunRegressionPromotionSkipsExistingCase(t *testing.T) {
 	}
 }
 
+func TestCIRunRegressionPromotionSkipsExistingCaseByClusterKey(t *testing.T) {
+	target := writeCIRunManifest(t)
+	captures := &ciRunRouteCaptures{}
+	srv := fakeAPI(t, ciRunRoutes(t, captures, ciRunRegressionPromotionRoutes(t, captures, "fail", []map[string]any{{
+		"id":                           "case-existing-cluster",
+		"status":                       "proposed",
+		"source_challenge_identity_id": "challenge-from-prior-pack-version",
+		"title":                        "Existing cluster proposal",
+		"metadata": map[string]any{
+			"source_failure_cluster_key": "frc-test",
+		},
+	}})))
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	result, err, _ := runCIRunJSON(t, []string{
+		"ci", "run",
+		"--manifest", target,
+		"-w", "ws-1",
+		"--json",
+		"--poll-interval", "1ms",
+		"--timeout", "1s",
+	}, srv.URL)
+	if got := exitCodeOf(t, err); got != gateExitFail {
+		t.Fatalf("exit code = %d, want gate fail %d", got, gateExitFail)
+	}
+	if result.RegressionPromotions == nil || len(result.RegressionPromotions.Existing) != 1 || result.RegressionPromotions.Existing[0].CaseID != "case-existing-cluster" {
+		t.Fatalf("regression promotions = %+v, want existing cluster case", result.RegressionPromotions)
+	}
+	if result.RegressionPromotions.Existing[0].FailureClusterKey != "frc-test" {
+		t.Fatalf("existing failure cluster key = %q, want frc-test", result.RegressionPromotions.Existing[0].FailureClusterKey)
+	}
+	if len(captures.PromotionBodies) != 0 {
+		t.Fatalf("promotion bodies = %+v, want no promote request for existing cluster case", captures.PromotionBodies)
+	}
+}
+
+func TestCIRunRegressionPromotionIgnoresArchivedClusterMatch(t *testing.T) {
+	target := writeCIRunManifest(t)
+	captures := &ciRunRouteCaptures{}
+	srv := fakeAPI(t, ciRunRoutes(t, captures, ciRunRegressionPromotionRoutes(t, captures, "fail", []map[string]any{{
+		"id":                           "case-archived-cluster",
+		"status":                       "archived",
+		"source_challenge_identity_id": "challenge-from-prior-pack-version",
+		"title":                        "Archived cluster proposal",
+		"metadata": map[string]any{
+			"source_failure_cluster_key": "frc-test",
+		},
+	}})))
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	result, err, _ := runCIRunJSON(t, []string{
+		"ci", "run",
+		"--manifest", target,
+		"-w", "ws-1",
+		"--json",
+		"--poll-interval", "1ms",
+		"--timeout", "1s",
+	}, srv.URL)
+	if got := exitCodeOf(t, err); got != gateExitFail {
+		t.Fatalf("exit code = %d, want gate fail %d", got, gateExitFail)
+	}
+	if result.RegressionPromotions == nil || len(result.RegressionPromotions.Created) != 1 || result.RegressionPromotions.Created[0].FailureClusterKey != "frc-test" {
+		t.Fatalf("regression promotions = %+v, want new case because archived cluster is ignored", result.RegressionPromotions)
+	}
+	if len(captures.PromotionBodies) != 1 {
+		t.Fatalf("promotion bodies = %+v, want one promote request", captures.PromotionBodies)
+	}
+}
+
 func TestCIRunAttachesGitHubActionsMetadata(t *testing.T) {
 	target := writeCIRunManifest(t)
 	captures := &ciRunRouteCaptures{}


### PR DESCRIPTION
## Summary
- index existing regression cases by metadata.source_failure_cluster_key in addition to source challenge identity
- report cluster-covered failures as existing so CI does not create duplicate regression proposals across reruns or pack rebuilds
- keep archived/rejected cases from blocking fresh proposals

Part of #82.

## Tests
- (cd cli && go test ./cmd)

## Review checkpoint
- Contract scratchpad: /tmp/reviewcheckpoint-issue-82-cluster-dedupe-contract.md
- Checkpoint scratchpad: /tmp/reviewcheckpoint-issue-82-cluster-dedupe.json