### PR TITLE
feat(ci): surface failure cluster rollups

### DIFF
--- a/backend/internal/api/failure_reviews.go
+++ b/backend/internal/api/failure_reviews.go
@@ -35,9 +35,10 @@ type ListRunFailuresInput struct {
 }
 
 type ListRunFailuresResult struct {
-	Run        domain.Run           `json:"-"`
-	Items      []failurereview.Item `json:"items"`
-	NextCursor *string              `json:"next_cursor,omitempty"`
+	Run        domain.Run                     `json:"-"`
+	Items      []failurereview.Item           `json:"items"`
+	Clusters   []failurereview.ClusterSummary `json:"clusters"`
+	NextCursor *string                        `json:"next_cursor,omitempty"`
 }
 
 func (m *RunReadManager) ListRunFailures(ctx context.Context, caller Caller, input ListRunFailuresInput) (ListRunFailuresResult, error) {
@@ -57,6 +58,7 @@ func (m *RunReadManager) ListRunFailures(ctx context.Context, caller Caller, inp
 		return ListRunFailuresResult{}, err
 	}
 	filtered := failurereview.FilterItems(items, input.AgentID, input.Severity, input.FailureClass, input.EvidenceTier, input.ChallengeKey, input.CaseKey)
+	clusters := failurereview.BuildClusterSummaries(filtered)
 	page, next := failurereview.PaginateItems(filtered, input.Cursor, input.Limit)
 
 	var nextCursor *string
@@ -71,13 +73,15 @@ func (m *RunReadManager) ListRunFailures(ctx context.Context, caller Caller, inp
 	return ListRunFailuresResult{
 		Run:        run,
 		Items:      page,
+		Clusters:   clusters,
 		NextCursor: nextCursor,
 	}, nil
 }
 
 type listRunFailuresResponse struct {
-	Items      []failurereview.Item `json:"items"`
-	NextCursor *string              `json:"next_cursor,omitempty"`
+	Items      []failurereview.Item           `json:"items"`
+	Clusters   []failurereview.ClusterSummary `json:"clusters"`
+	NextCursor *string                        `json:"next_cursor,omitempty"`
 }
 
 func listRunFailuresHandler(logger *slog.Logger, service RunReadService) http.HandlerFunc {
@@ -116,6 +120,7 @@ func listRunFailuresHandler(logger *slog.Logger, service RunReadService) http.Ha
 
 		writeJSON(w, http.StatusOK, listRunFailuresResponse{
 			Items:      result.Items,
+			Clusters:   result.Clusters,
 			NextCursor: result.NextCursor,
 		})
 	}

--- a/backend/internal/api/failure_reviews_test.go
+++ b/backend/internal/api/failure_reviews_test.go
@@ -142,6 +142,48 @@ func TestListRunFailuresEndpointFiltersByClassChallengeAndEvidenceTier(t *testin
 	}
 }
 
+func TestListRunFailuresEndpointReturnsClusterSummariesBeforePagination(t *testing.T) {
+	workspaceID := uuid.New()
+	runID := uuid.New()
+	items := []failurereview.Item{
+		mustBuildFailureItem(t, runID, uuid.New(), "ticket-a", "case-a", "policy.filesystem"),
+		mustBuildFailureItem(t, runID, uuid.New(), "ticket-a", "case-a", "policy.filesystem"),
+		mustBuildFailureItem(t, runID, uuid.New(), "ticket-b", "case-b", "tool_argument.schema"),
+	}
+
+	service := NewRunReadManager(NewCallerWorkspaceAuthorizer(), &fakeRunReadRepository{
+		run: domain.Run{
+			ID:          runID,
+			WorkspaceID: workspaceID,
+		},
+		failureItems: items,
+	})
+
+	response := performListRunFailuresRequest(t, service, workspaceID, runID, url.Values{"limit": []string{"1"}})
+	if len(response.Items) != 1 {
+		t.Fatalf("page items = %d, want 1", len(response.Items))
+	}
+	if len(response.Clusters) != 2 {
+		t.Fatalf("clusters = %#v, want 2 summaries for full filtered result set", response.Clusters)
+	}
+	var ticketACluster *failurereview.ClusterSummary
+	for i := range response.Clusters {
+		if len(response.Clusters[i].ChallengeKeys) == 1 && response.Clusters[i].ChallengeKeys[0] == "ticket-a" {
+			ticketACluster = &response.Clusters[i]
+			break
+		}
+	}
+	if ticketACluster == nil {
+		t.Fatalf("clusters = %#v, want ticket-a cluster", response.Clusters)
+	}
+	if ticketACluster.Count != 2 || ticketACluster.PromotableCount != 2 {
+		t.Fatalf("ticket-a cluster counts = %d/%d, want 2/2", ticketACluster.Count, ticketACluster.PromotableCount)
+	}
+	if ticketACluster.RepresentativeFailureFingerprint == "" {
+		t.Fatalf("ticket-a representative fingerprint is empty")
+	}
+}
+
 func TestListRunFailuresEndpointRejectsMalformedQueryParams(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/failurereview/read_model.go
+++ b/backend/internal/failurereview/read_model.go
@@ -377,6 +377,8 @@ func BuildClusterSummaries(items []Item) []ClusterSummary {
 		if item.Promotable {
 			group.summary.PromotableCount++
 		}
+		// These fields are already part of the v1 cluster key; max-rank
+		// selection is defensive if a future identity version broadens clusters.
 		if severityRank(item.Severity) > severityRank(group.summary.Severity) {
 			group.summary.Severity = item.Severity
 		}

--- a/backend/internal/failurereview/read_model.go
+++ b/backend/internal/failurereview/read_model.go
@@ -74,6 +74,22 @@ type Item struct {
 	sortKey                CursorKey       `json:"-"`
 }
 
+type ClusterSummary struct {
+	FailureClusterKey                string       `json:"failure_cluster_key"`
+	RepresentativeFailureFingerprint string       `json:"representative_failure_fingerprint"`
+	Count                            int          `json:"count"`
+	PromotableCount                  int          `json:"promotable_count"`
+	Severity                         Severity     `json:"severity"`
+	FailureState                     FailureState `json:"failure_state"`
+	FailureClass                     FailureClass `json:"failure_class"`
+	EvidenceTier                     EvidenceTier `json:"evidence_tier"`
+	ChallengeKeys                    []string     `json:"challenge_keys"`
+	CaseKeys                         []string     `json:"case_keys"`
+	RunAgentIDs                      []string     `json:"run_agent_ids"`
+	Headline                         string       `json:"headline"`
+	RecommendedAction                string       `json:"recommended_action"`
+}
+
 type ReplayStepRef struct {
 	SequenceNumber int64  `json:"sequence_number"`
 	EventType      string `json:"event_type"`
@@ -183,6 +199,13 @@ type CursorKey struct {
 	ChallengeKey string
 	CaseKey      string
 	ItemKey      string
+}
+
+type clusterAccumulator struct {
+	summary       ClusterSummary
+	challengeKeys map[string]struct{}
+	caseKeys      map[string]struct{}
+	runAgentIDs   map[string]struct{}
 }
 
 const failureIdentitySchemaVersion = "failure_review_identity.v1"
@@ -314,6 +337,80 @@ func PaginateItems(items []Item, after *CursorKey, limit int) ([]Item, *CursorKe
 	}
 	next := ordered[end-1].sortKey
 	return page, &next
+}
+
+func BuildClusterSummaries(items []Item) []ClusterSummary {
+	if len(items) == 0 {
+		return []ClusterSummary{}
+	}
+	groups := map[string]*clusterAccumulator{}
+	for _, item := range items {
+		key := strings.TrimSpace(item.FailureClusterKey)
+		if key == "" {
+			key = "unclustered:" + item.FailureFingerprint
+		}
+		group := groups[key]
+		if group == nil {
+			group = &clusterAccumulator{
+				summary: ClusterSummary{
+					FailureClusterKey:                key,
+					RepresentativeFailureFingerprint: item.FailureFingerprint,
+					Severity:                         item.Severity,
+					FailureState:                     item.FailureState,
+					FailureClass:                     item.FailureClass,
+					EvidenceTier:                     item.EvidenceTier,
+					Headline:                         item.Headline,
+					RecommendedAction:                item.RecommendedAction,
+				},
+				challengeKeys: map[string]struct{}{},
+				caseKeys:      map[string]struct{}{},
+				runAgentIDs:   map[string]struct{}{},
+			}
+			groups[key] = group
+		}
+		if item.FailureFingerprint != "" && (group.summary.RepresentativeFailureFingerprint == "" || item.FailureFingerprint < group.summary.RepresentativeFailureFingerprint) {
+			group.summary.RepresentativeFailureFingerprint = item.FailureFingerprint
+			group.summary.Headline = item.Headline
+			group.summary.RecommendedAction = item.RecommendedAction
+		}
+		group.summary.Count++
+		if item.Promotable {
+			group.summary.PromotableCount++
+		}
+		if severityRank(item.Severity) > severityRank(group.summary.Severity) {
+			group.summary.Severity = item.Severity
+		}
+		if failureStateRank(item.FailureState) > failureStateRank(group.summary.FailureState) {
+			group.summary.FailureState = item.FailureState
+		}
+		if item.ChallengeKey != "" {
+			group.challengeKeys[item.ChallengeKey] = struct{}{}
+		}
+		if item.CaseKey != "" {
+			group.caseKeys[item.CaseKey] = struct{}{}
+		}
+		if item.RunAgentID != uuid.Nil {
+			group.runAgentIDs[item.RunAgentID.String()] = struct{}{}
+		}
+	}
+
+	summaries := make([]ClusterSummary, 0, len(groups))
+	for _, group := range groups {
+		group.summary.ChallengeKeys = sortedMapKeys(group.challengeKeys)
+		group.summary.CaseKeys = sortedMapKeys(group.caseKeys)
+		group.summary.RunAgentIDs = sortedMapKeys(group.runAgentIDs)
+		summaries = append(summaries, group.summary)
+	}
+	sort.SliceStable(summaries, func(i, j int) bool {
+		if severityRank(summaries[i].Severity) != severityRank(summaries[j].Severity) {
+			return severityRank(summaries[i].Severity) > severityRank(summaries[j].Severity)
+		}
+		if summaries[i].Count != summaries[j].Count {
+			return summaries[i].Count > summaries[j].Count
+		}
+		return summaries[i].FailureClusterKey < summaries[j].FailureClusterKey
+	})
+	return summaries
 }
 
 func EncodeCursor(key CursorKey) (string, error) {
@@ -866,6 +963,46 @@ func sortedReplayRefCopy(values []ReplayStepRef) []ReplayStepRef {
 		return copied[i].Kind < copied[j].Kind
 	})
 	return copied
+}
+
+func sortedMapKeys(values map[string]struct{}) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func severityRank(severity Severity) int {
+	switch severity {
+	case SeverityBlocking:
+		return 3
+	case SeverityWarning:
+		return 2
+	case SeverityInfo:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func failureStateRank(state FailureState) int {
+	switch state {
+	case FailureStateFailed:
+		return 4
+	case FailureStateFlaky:
+		return 3
+	case FailureStateWarning:
+		return 2
+	case FailureStateIncompleteEvidence:
+		return 1
+	default:
+		return 0
+	}
 }
 
 func dedupStrings(values *[]string) {

--- a/backend/internal/failurereview/read_model_test.go
+++ b/backend/internal/failurereview/read_model_test.go
@@ -2,6 +2,8 @@ package failurereview
 
 import (
 	"encoding/json"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -285,6 +287,79 @@ func TestFailureIdentityCanonicalizesSortedInputs(t *testing.T) {
 	}
 	if baseClusterKey != reversedClusterKey {
 		t.Fatalf("cluster key = %q, want canonical %q", reversedClusterKey, baseClusterKey)
+	}
+}
+
+func TestBuildClusterSummariesGroupsAndSortsDeterministically(t *testing.T) {
+	t.Parallel()
+
+	runAgentA := uuid.New()
+	runAgentB := uuid.New()
+	items := []Item{
+		{
+			RunAgentID:         runAgentA,
+			ChallengeKey:       "ticket-b",
+			CaseKey:            "case-b",
+			FailureFingerprint: "frf-b1",
+			FailureClusterKey:  "frc-b",
+			FailureState:       FailureStateFailed,
+			FailureClass:       FailureClassToolArgumentError,
+			EvidenceTier:       EvidenceTierNativeStructured,
+			Severity:           SeverityWarning,
+			Headline:           "ticket-b triggered tool_argument_error",
+			RecommendedAction:  "Inspect the replay around the failing tool call and correct the selection or arguments.",
+			Promotable:         true,
+		},
+		{
+			RunAgentID:         runAgentB,
+			ChallengeKey:       "ticket-a",
+			CaseKey:            "case-a",
+			FailureFingerprint: "frf-a",
+			FailureClusterKey:  "frc-a",
+			FailureState:       FailureStateFailed,
+			FailureClass:       FailureClassPolicyViolation,
+			EvidenceTier:       EvidenceTierNativeStructured,
+			Severity:           SeverityBlocking,
+			Headline:           "ticket-a triggered policy_violation",
+			RecommendedAction:  "Tighten the agent or tool policy before promoting this failure.",
+			Promotable:         true,
+		},
+		{
+			RunAgentID:         runAgentB,
+			ChallengeKey:       "ticket-b",
+			CaseKey:            "case-c",
+			FailureFingerprint: "frf-b2",
+			FailureClusterKey:  "frc-b",
+			FailureState:       FailureStateWarning,
+			FailureClass:       FailureClassToolArgumentError,
+			EvidenceTier:       EvidenceTierNativeStructured,
+			Severity:           SeverityWarning,
+			Headline:           "ticket-b triggered tool_argument_error",
+			RecommendedAction:  "Inspect the replay around the failing tool call and correct the selection or arguments.",
+			Promotable:         false,
+		},
+	}
+
+	summaries := BuildClusterSummaries(items)
+	if len(summaries) != 2 {
+		t.Fatalf("cluster count = %d, want 2: %#v", len(summaries), summaries)
+	}
+	if summaries[0].FailureClusterKey != "frc-a" {
+		t.Fatalf("first cluster = %q, want blocking cluster frc-a before warning cluster", summaries[0].FailureClusterKey)
+	}
+	if summaries[1].Count != 2 || summaries[1].PromotableCount != 1 {
+		t.Fatalf("frc-b counts = %d/%d, want count 2 promotable 1", summaries[1].Count, summaries[1].PromotableCount)
+	}
+	if !reflect.DeepEqual(summaries[1].CaseKeys, []string{"case-b", "case-c"}) {
+		t.Fatalf("case keys = %#v, want sorted case-b/case-c", summaries[1].CaseKeys)
+	}
+	wantRunAgentIDs := []string{runAgentA.String(), runAgentB.String()}
+	sort.Strings(wantRunAgentIDs)
+	if !reflect.DeepEqual(summaries[1].RunAgentIDs, wantRunAgentIDs) {
+		t.Fatalf("run agent ids = %#v, want sorted unique ids", summaries[1].RunAgentIDs)
+	}
+	if summaries[1].RepresentativeFailureFingerprint != "frf-b1" {
+		t.Fatalf("representative fingerprint = %q, want first matching fingerprint", summaries[1].RepresentativeFailureFingerprint)
 	}
 }
 

--- a/cli/cmd/cli_surface_gaps_test.go
+++ b/cli/cmd/cli_surface_gaps_test.go
@@ -159,15 +159,25 @@ func TestRegressionCaseUpdatePayload(t *testing.T) {
 }
 
 func TestRunFailuresForwardsFilters(t *testing.T) {
-	var gotAgent, gotClass, gotLimit string
+	var gotAgent, gotFailureClass, gotLimit string
 	srv := fakeAPI(t, map[string]http.HandlerFunc{
 		"GET /v1/workspaces/ws-123/runs/run-1/failures": func(w http.ResponseWriter, r *http.Request) {
 			gotAgent = r.URL.Query().Get("agent_id")
-			gotClass = r.URL.Query().Get("class")
+			gotFailureClass = r.URL.Query().Get("failure_class")
 			gotLimit = r.URL.Query().Get("limit")
 			jsonHandler(200, map[string]any{
 				"items": []map[string]any{
 					{"run_agent_id": "agent-1", "failure_state": "failed", "promotable": true},
+				},
+				"clusters": []map[string]any{
+					{
+						"failure_cluster_key": "frc-test",
+						"count":               1,
+						"promotable_count":    1,
+						"severity":            "blocking",
+						"failure_class":       "policy_violation",
+						"challenge_keys":      []string{"ticket-a"},
+					},
 				},
 			})(w, r)
 		},
@@ -183,8 +193,8 @@ func TestRunFailuresForwardsFilters(t *testing.T) {
 	}, srv.URL); err != nil {
 		t.Fatalf("run failures error: %v", err)
 	}
-	if gotAgent != "agent-1" || gotClass != "policy_violation" || gotLimit != "25" {
-		t.Fatalf("query = agent %q class %q limit %q", gotAgent, gotClass, gotLimit)
+	if gotAgent != "agent-1" || gotFailureClass != "policy_violation" || gotLimit != "25" {
+		t.Fatalf("query = agent %q failure_class %q limit %q", gotAgent, gotFailureClass, gotLimit)
 	}
 }
 

--- a/cli/cmd/response_helpers.go
+++ b/cli/cmd/response_helpers.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/agentclash/agentclash/cli/internal/api"
 )
@@ -36,6 +37,24 @@ func mapSlice(m map[string]any, keys ...string) []any {
 		return out
 	}
 	return nil
+}
+
+func mapStringSlice(m map[string]any, keys ...string) []string {
+	raw := mapSlice(m, keys...)
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, value := range raw {
+		if text := strings.TrimSpace(str(value)); text != "" {
+			out = append(out, text)
+		}
+	}
+	return out
+}
+
+func joinMapStrings(m map[string]any, key string) string {
+	return strings.Join(mapStringSlice(m, key), ", ")
 }
 
 func handleStatefulReadResponse(rc *RunContext, resp *api.Response, resource string) (bool, error) {

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -403,7 +403,7 @@ var runFailuresCmd = &cobra.Command{
 		}
 		rc.Output.PrintTable(cols, rows)
 		if len(result.Clusters) > 0 {
-			rc.Output.PrintDetail("Failure Clusters", fmt.Sprintf("%d", len(result.Clusters)))
+			rc.Output.PrintDetail("Failure Clusters (filtered)", fmt.Sprintf("%d", len(result.Clusters)))
 			clusterCols := []output.Column{{Header: "Cluster"}, {Header: "Count"}, {Header: "Promotable"}, {Header: "Severity"}, {Header: "Class"}, {Header: "Challenges"}}
 			clusterRows := make([][]string, len(result.Clusters))
 			for i, cluster := range result.Clusters {

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -357,7 +357,7 @@ var runFailuresCmd = &cobra.Command{
 			q.Set("severity", v)
 		}
 		if v, _ := cmd.Flags().GetString("class"); v != "" {
-			q.Set("class", v)
+			q.Set("failure_class", v)
 		}
 		if v, _ := cmd.Flags().GetString("evidence-tier"); v != "" {
 			q.Set("evidence_tier", v)
@@ -379,6 +379,7 @@ var runFailuresCmd = &cobra.Command{
 
 		var result struct {
 			Items      []map[string]any `json:"items"`
+			Clusters   []map[string]any `json:"clusters"`
 			NextCursor string           `json:"next_cursor,omitempty"`
 		}
 		if err := resp.DecodeJSON(&result); err != nil {
@@ -401,6 +402,22 @@ var runFailuresCmd = &cobra.Command{
 			}
 		}
 		rc.Output.PrintTable(cols, rows)
+		if len(result.Clusters) > 0 {
+			rc.Output.PrintDetail("Failure Clusters", fmt.Sprintf("%d", len(result.Clusters)))
+			clusterCols := []output.Column{{Header: "Cluster"}, {Header: "Count"}, {Header: "Promotable"}, {Header: "Severity"}, {Header: "Class"}, {Header: "Challenges"}}
+			clusterRows := make([][]string, len(result.Clusters))
+			for i, cluster := range result.Clusters {
+				clusterRows[i] = []string{
+					str(cluster["failure_cluster_key"]),
+					str(cluster["count"]),
+					str(cluster["promotable_count"]),
+					str(cluster["severity"]),
+					str(cluster["failure_class"]),
+					joinMapStrings(cluster, "challenge_keys"),
+				}
+			}
+			rc.Output.PrintTable(clusterCols, clusterRows)
+		}
 		if result.NextCursor != "" {
 			rc.Output.PrintDetail("Next Cursor", result.NextCursor)
 		}

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -6582,14 +6582,75 @@ components:
           type: string
           enum: [info, warning, blocking]
 
+    FailureReviewClusterSummary:
+      type: object
+      required:
+        - failure_cluster_key
+        - representative_failure_fingerprint
+        - count
+        - promotable_count
+        - severity
+        - failure_state
+        - failure_class
+        - evidence_tier
+        - challenge_keys
+        - case_keys
+        - run_agent_ids
+        - headline
+        - recommended_action
+      properties:
+        failure_cluster_key:
+          type: string
+          description: Deterministic grouping key shared by failure items with the same failure shape.
+        representative_failure_fingerprint:
+          type: string
+          description: Fingerprint of a representative failure item from this cluster.
+        count:
+          type: integer
+          format: int32
+        promotable_count:
+          type: integer
+          format: int32
+        severity:
+          type: string
+          enum: [info, warning, blocking]
+        failure_state:
+          $ref: "#/components/schemas/FailureReviewFailureState"
+        failure_class:
+          $ref: "#/components/schemas/FailureReviewFailureClass"
+        evidence_tier:
+          $ref: "#/components/schemas/FailureReviewEvidenceTier"
+        challenge_keys:
+          type: array
+          items:
+            type: string
+        case_keys:
+          type: array
+          items:
+            type: string
+        run_agent_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+        headline:
+          type: string
+        recommended_action:
+          type: string
+
     ListRunFailuresResponse:
       type: object
-      required: [items]
+      required: [items, clusters]
       properties:
         items:
           type: array
           items:
             $ref: "#/components/schemas/FailureReviewItem"
+        clusters:
+          type: array
+          description: Cluster summaries for the full filtered result set before item pagination.
+          items:
+            $ref: "#/components/schemas/FailureReviewClusterSummary"
         next_cursor:
           type: string
           description: Opaque base64url-encoded pagination cursor.

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -1698,8 +1698,25 @@ export interface FailureReviewItem {
   severity: FailureReviewSeverity;
 }
 
+export interface FailureReviewClusterSummary {
+  failure_cluster_key: string;
+  representative_failure_fingerprint: string;
+  count: number;
+  promotable_count: number;
+  severity: FailureReviewSeverity;
+  failure_state: FailureReviewFailureState;
+  failure_class: FailureReviewFailureClass;
+  evidence_tier: FailureReviewEvidenceTier;
+  challenge_keys: string[];
+  case_keys: string[];
+  run_agent_ids: string[];
+  headline: string;
+  recommended_action: string;
+}
+
 export interface ListRunFailuresResponse {
   items: FailureReviewItem[];
+  clusters: FailureReviewClusterSummary[];
   next_cursor?: string;
 }
 


### PR DESCRIPTION
## Summary
- add deterministic failure cluster summaries for run failure review items
- return clusters beside paginated failure items in the API and update OpenAPI/TypeScript contracts
- show filtered cluster summaries in `agentclash run failures` and fix `--class` to send `failure_class`

Part of #82.

## Release note
- `agentclash run failures --class` now correctly filters by failure class; previous builds sent the wrong query parameter and effectively ignored the filter.

## Tests
- (cd backend && go test ./internal/failurereview ./internal/api)
- (cd cli && go test ./cmd)

## Review checkpoint
- Contract scratchpad: /tmp/reviewcheckpoint-issue-82-cluster-rollups-contract.md
- Checkpoint scratchpad: /tmp/reviewcheckpoint-issue-82-cluster-rollups.json