### PR TITLE
feat(web): surface failure cluster rollups

### DIFF
--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.test.tsx
@@ -1,0 +1,287 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  FailureReviewClusterSummary,
+  FailureReviewItem,
+  ListRunFailuresResponse,
+  RunAgent,
+} from "@/lib/api/types";
+
+import { FailuresClient } from "./failures-client";
+
+const {
+  mockReplace,
+  mockGetAccessToken,
+  mockCreateApiClient,
+  mockListRunFailures,
+  searchState,
+} = vi.hoisted(() => ({
+  mockReplace: vi.fn(),
+  mockGetAccessToken: vi.fn(),
+  mockCreateApiClient: vi.fn(),
+  mockListRunFailures: vi.fn(),
+  searchState: { params: new URLSearchParams() },
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  useSearchParams: () => searchState.params,
+}));
+
+vi.mock("@workos-inc/authkit-nextjs/components", () => ({
+  useAccessToken: () => ({ getAccessToken: mockGetAccessToken }),
+}));
+
+vi.mock("@/lib/api/client", () => ({
+  createApiClient: (...args: unknown[]) => mockCreateApiClient(...args),
+}));
+
+vi.mock("@/lib/api/failure-reviews", () => ({
+  listRunFailures: (...args: unknown[]) => mockListRunFailures(...args),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) =>
+    React.createElement("a", { href, ...props }, children),
+}));
+
+vi.mock("./failure-detail-drawer", () => ({
+  FailureDetailDrawer: () => null,
+}));
+
+vi.mock("./promote-failure-dialog", () => ({
+  PromoteFailureDialog: () => null,
+}));
+
+const agents: RunAgent[] = [
+  {
+    id: "agent-1",
+    run_id: "run-1",
+    lane_index: 0,
+    label: "Alpha",
+    agent_deployment_id: "deployment-1",
+    agent_deployment_snapshot_id: "snapshot-1",
+    status: "completed",
+    started_at: "2026-04-22T12:00:05Z",
+    finished_at: "2026-04-22T12:01:05Z",
+    created_at: "2026-04-22T12:00:00Z",
+    updated_at: "2026-04-22T12:01:05Z",
+  },
+];
+
+function makeItem(overrides: Partial<FailureReviewItem> = {}): FailureReviewItem {
+  return {
+    run_id: "run-1",
+    run_agent_id: "agent-1",
+    challenge_identity_id: "challenge-identity-1",
+    challenge_key: "challenge-a",
+    case_key: "case-a",
+    item_key: "item-a",
+    failure_fingerprint: "fingerprint-a",
+    failure_cluster_key: "cluster-a",
+    failure_state: "failed",
+    failed_dimensions: ["correctness"],
+    failed_checks: ["capture.files"],
+    failure_class: "policy_violation",
+    headline: "Filesystem write regression",
+    detail: "The model attempted a forbidden file write.",
+    recommended_action: "Add a regression case for filesystem access.",
+    promotable: true,
+    promotion_mode_available: ["full_executable", "output_only"],
+    replay_step_refs: [],
+    artifact_refs: [],
+    judge_refs: [],
+    metric_refs: [],
+    evidence_tier: "native_structured",
+    severity: "blocking",
+    ...overrides,
+  };
+}
+
+function makeCluster(
+  overrides: Partial<FailureReviewClusterSummary> = {},
+): FailureReviewClusterSummary {
+  return {
+    failure_cluster_key: "cluster-a",
+    representative_failure_fingerprint: "fingerprint-a",
+    count: 2,
+    promotable_count: 1,
+    severity: "blocking",
+    failure_state: "failed",
+    failure_class: "policy_violation",
+    evidence_tier: "native_structured",
+    challenge_keys: ["challenge-a", "challenge-b"],
+    case_keys: ["case-a", "case-b", "case-c", "case-d"],
+    run_agent_ids: ["agent-1"],
+    headline: "Filesystem write failures cluster together",
+    recommended_action: "Promote one representative filesystem regression.",
+    ...overrides,
+  };
+}
+
+function makePage(
+  overrides: Partial<ListRunFailuresResponse> = {},
+): ListRunFailuresResponse {
+  return {
+    items: [makeItem()],
+    clusters: [makeCluster()],
+    ...overrides,
+  };
+}
+
+function renderClient(
+  props: Partial<React.ComponentProps<typeof FailuresClient>> = {},
+) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+
+  const render = (
+    nextProps: Partial<React.ComponentProps<typeof FailuresClient>> = {},
+  ) => {
+    act(() => {
+      root.render(
+        React.createElement(FailuresClient, {
+          workspaceId: "ws-1",
+          runId: "run-1",
+          runName: "Run One",
+          agents,
+          initialPage: makePage(),
+          initialLimit: 50,
+          sourceChallengePackId: "pack-1",
+          sourceChallengePackName: "Source Pack",
+          ...props,
+          ...nextProps,
+        }),
+      );
+    });
+  };
+
+  render();
+
+  return {
+    container,
+    render,
+    cleanup() {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function waitFor(assertion: () => void, attempts = 20) {
+  let lastError: unknown;
+  for (let index = 0; index < attempts; index += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await flushPromises();
+    }
+  }
+  throw lastError;
+}
+
+describe("FailuresClient", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    searchState.params = new URLSearchParams();
+    mockReplace.mockReset();
+    mockGetAccessToken.mockReset();
+    mockCreateApiClient.mockReset();
+    mockListRunFailures.mockReset();
+    mockGetAccessToken.mockResolvedValue("token-123");
+    mockCreateApiClient.mockReturnValue({ client: true });
+  });
+
+  it("renders failure cluster rollups from the initial page", () => {
+    const view = renderClient();
+    try {
+      expect(view.container.textContent).toContain("Failure clusters");
+      expect(view.container.textContent).toContain("2 failures");
+      expect(view.container.textContent).toContain("1 promotable");
+      expect(view.container.textContent).toContain(
+        "Filesystem write failures cluster together",
+      );
+      expect(view.container.textContent).toContain("challenge-a, challenge-b");
+      expect(view.container.textContent).toContain(
+        "case-a, case-b, case-c +1",
+      );
+    } finally {
+      view.cleanup();
+    }
+  });
+
+  it("refreshes cluster rollups when filters change", async () => {
+    mockListRunFailures.mockResolvedValue(
+      makePage({
+        items: [
+          makeItem({
+            challenge_key: "challenge-filtered",
+            case_key: "case-filtered",
+            item_key: "item-filtered",
+            failure_class: "tool_selection_error",
+            headline: "Wrong tool selected",
+          }),
+        ],
+        clusters: [
+          makeCluster({
+            failure_cluster_key: "cluster-filtered",
+            count: 1,
+            promotable_count: 1,
+            failure_class: "tool_selection_error",
+            headline: "Filtered tool selection failures",
+            challenge_keys: ["challenge-filtered"],
+            case_keys: ["case-filtered"],
+          }),
+        ],
+      }),
+    );
+
+    const view = renderClient();
+    try {
+      searchState.params = new URLSearchParams("severity=blocking");
+      view.render();
+
+      await waitFor(() => {
+        expect(mockListRunFailures).toHaveBeenCalledWith(
+          { client: true },
+          "ws-1",
+          "run-1",
+          expect.objectContaining({
+            limit: 50,
+            severity: "blocking",
+          }),
+        );
+      });
+
+      await waitFor(() => {
+        expect(view.container.textContent).toContain(
+          "Filtered tool selection failures",
+        );
+      });
+      expect(view.container.textContent).not.toContain(
+        "Filesystem write failures cluster together",
+      );
+      expect(view.container.textContent).toContain("1 failure");
+      expect(view.container.textContent).toContain("challenge-filtered");
+    } finally {
+      view.cleanup();
+    }
+  });
+});

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.tsx
@@ -23,6 +23,7 @@ import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";
 import { listRunFailures } from "@/lib/api/failure-reviews";
 import type {
+  FailureReviewClusterSummary,
   FailureReviewEvidenceTier,
   FailureReviewFailureClass,
   FailureReviewItem,
@@ -71,6 +72,11 @@ const EVIDENCE_TIER_OPTIONS: FailureReviewEvidenceTier[] = [
 
 function humanize(value: string): string {
   return value.replace(/_/g, " ");
+}
+
+function compactList(values: string[], maxVisible = 3): string {
+  if (values.length <= maxVisible) return values.join(", ");
+  return `${values.slice(0, maxVisible).join(", ")} +${values.length - maxVisible}`;
 }
 
 const severityVariant: Record<
@@ -173,6 +179,9 @@ function FailuresClientInner({
 
   // Drive data from filters. Initial SSR page corresponds to "no filters".
   const [items, setItems] = useState<FailureReviewItem[]>(initialPage.items);
+  const [clusters, setClusters] = useState<FailureReviewClusterSummary[]>(
+    initialPage.clusters ?? [],
+  );
   const [cursor, setCursor] = useState<string | undefined>(
     initialPage.next_cursor,
   );
@@ -213,6 +222,7 @@ function FailuresClientInner({
         });
         if (cancelled) return;
         setItems(res.items);
+        setClusters(res.clusters ?? []);
         setCursor(res.next_cursor);
         activeFiltersRef.current = urlFilters;
       } catch (err) {
@@ -268,6 +278,7 @@ function FailuresClientInner({
         ...urlFilters,
       });
       setItems((prev) => [...prev, ...res.items]);
+      setClusters(res.clusters ?? []);
       setCursor(res.next_cursor);
     } catch (err) {
       if (err instanceof ApiError) setError(err.message);
@@ -329,6 +340,8 @@ function FailuresClientInner({
         />
       ) : (
         <div className="space-y-3">
+          {clusters.length > 0 && <FailureClusterRollups clusters={clusters} />}
+
           {groups.map((group) => (
             <ChallengeGroup
               key={group.challengeKey}
@@ -377,6 +390,98 @@ function FailuresClientInner({
 }
 
 // --- Sub-components ---
+
+function FailureClusterRollups({
+  clusters,
+}: {
+  clusters: FailureReviewClusterSummary[];
+}) {
+  const totalFailures = clusters.reduce((sum, cluster) => sum + cluster.count, 0);
+  const totalPromotable = clusters.reduce(
+    (sum, cluster) => sum + cluster.promotable_count,
+    0,
+  );
+
+  return (
+    <section className="rounded-lg border border-border bg-card/40">
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
+        <div className="min-w-0">
+          <h2 className="text-sm font-semibold">Failure clusters</h2>
+          <p className="text-xs text-muted-foreground">
+            {clusters.length} cluster{clusters.length === 1 ? "" : "s"} ·{" "}
+            {totalFailures} failure{totalFailures === 1 ? "" : "s"} ·{" "}
+            {totalPromotable} promotable
+          </p>
+        </div>
+      </div>
+      <ul className="divide-y divide-border">
+        {clusters.map((cluster) => (
+          <li
+            key={cluster.failure_cluster_key}
+            className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-center"
+          >
+            <div className="min-w-0 space-y-2">
+              <div className="flex min-w-0 flex-wrap items-center gap-2">
+                <Badge variant={severityVariant[cluster.severity]}>
+                  {cluster.severity}
+                </Badge>
+                <Badge variant={failureStateVariant[cluster.failure_state]}>
+                  {humanize(cluster.failure_state)}
+                </Badge>
+                <Badge variant="outline">{humanize(cluster.failure_class)}</Badge>
+                <Badge variant="secondary">
+                  {humanize(cluster.evidence_tier)}
+                </Badge>
+              </div>
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium">
+                  {cluster.headline || humanize(cluster.failure_class)}
+                </p>
+                {cluster.recommended_action && (
+                  <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+                    {cluster.recommended_action}
+                  </p>
+                )}
+              </div>
+              <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                <span className="min-w-0 truncate">
+                  Challenges:{" "}
+                  <span className="text-foreground/80">
+                    {compactList(cluster.challenge_keys)}
+                  </span>
+                </span>
+                <span className="min-w-0 truncate">
+                  Cases:{" "}
+                  <span className="text-foreground/80">
+                    {compactList(cluster.case_keys)}
+                  </span>
+                </span>
+              </div>
+            </div>
+            <div className="flex items-center gap-2 md:justify-end">
+              <div className="rounded-md border border-border px-2.5 py-1 text-right">
+                <div className="text-sm font-semibold tabular-nums">
+                  {cluster.count}
+                </div>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                  failures
+                </div>
+              </div>
+              <div className="rounded-md border border-border px-2.5 py-1 text-right">
+                <div className="text-sm font-semibold tabular-nums">
+                  {cluster.promotable_count}
+                </div>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                  promote
+                </div>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
 
 function FilterBar({
   agents,


### PR DESCRIPTION
## Summary
- render failure cluster rollups on the run failures page from `ListRunFailuresResponse.clusters`
- refresh cluster summaries when failure filters refetch or pagination returns a newer response
- add component tests for initial cluster render and filter-driven cluster refresh

## Review checkpoint
- Contract: `/tmp/reviewcheckpoint-issue-82-cluster-ui-contract.md`
- Final verdict: ready

## Tests
- `npx tsc --noEmit`
- `npm run lint`
- `npm test`
- `npm run build`

Part of #82.