### PR TITLE
feat(ci): filter failures by cluster key

### DIFF
--- a/backend/internal/api/failure_reviews.go
+++ b/backend/internal/api/failure_reviews.go
@@ -22,16 +22,17 @@ const (
 )
 
 type ListRunFailuresInput struct {
-	WorkspaceID  uuid.UUID
-	RunID        uuid.UUID
-	AgentID      *uuid.UUID
-	Severity     *failurereview.Severity
-	FailureClass *failurereview.FailureClass
-	EvidenceTier *failurereview.EvidenceTier
-	ChallengeKey *string
-	CaseKey      *string
-	Cursor       *failurereview.CursorKey
-	Limit        int
+	WorkspaceID       uuid.UUID
+	RunID             uuid.UUID
+	AgentID           *uuid.UUID
+	Severity          *failurereview.Severity
+	FailureClass      *failurereview.FailureClass
+	EvidenceTier      *failurereview.EvidenceTier
+	ChallengeKey      *string
+	CaseKey           *string
+	FailureClusterKey *string
+	Cursor            *failurereview.CursorKey
+	Limit             int
 }
 
 type ListRunFailuresResult struct {
@@ -57,7 +58,7 @@ func (m *RunReadManager) ListRunFailures(ctx context.Context, caller Caller, inp
 	if err != nil {
 		return ListRunFailuresResult{}, err
 	}
-	filtered := failurereview.FilterItems(items, input.AgentID, input.Severity, input.FailureClass, input.EvidenceTier, input.ChallengeKey, input.CaseKey)
+	filtered := failurereview.FilterItems(items, input.AgentID, input.Severity, input.FailureClass, input.EvidenceTier, input.ChallengeKey, input.CaseKey, input.FailureClusterKey)
 	clusters := failurereview.BuildClusterSummaries(filtered)
 	page, next := failurereview.PaginateItems(filtered, input.Cursor, input.Limit)
 
@@ -176,6 +177,9 @@ func listRunFailuresInputFromRequest(r *http.Request) (ListRunFailuresInput, err
 	}
 	if raw := strings.TrimSpace(query.Get("case_key")); raw != "" {
 		input.CaseKey = &raw
+	}
+	if raw := strings.TrimSpace(query.Get("failure_cluster_key")); raw != "" {
+		input.FailureClusterKey = &raw
 	}
 	if raw := strings.TrimSpace(query.Get("limit")); raw != "" {
 		parsed, parseErr := strconv.Atoi(raw)

--- a/backend/internal/api/failure_reviews_test.go
+++ b/backend/internal/api/failure_reviews_test.go
@@ -184,6 +184,45 @@ func TestListRunFailuresEndpointReturnsClusterSummariesBeforePagination(t *testi
 	}
 }
 
+func TestListRunFailuresEndpointFiltersByClusterKeyBeforePagination(t *testing.T) {
+	workspaceID := uuid.New()
+	runID := uuid.New()
+	items := []failurereview.Item{
+		mustBuildFailureItem(t, runID, uuid.New(), "ticket-a", "case-a", "policy.filesystem"),
+		mustBuildFailureItem(t, runID, uuid.New(), "ticket-a", "case-a", "policy.filesystem"),
+		mustBuildFailureItem(t, runID, uuid.New(), "ticket-b", "case-b", "tool_argument.schema"),
+	}
+	targetClusterKey := items[0].FailureClusterKey
+
+	service := NewRunReadManager(NewCallerWorkspaceAuthorizer(), &fakeRunReadRepository{
+		run: domain.Run{
+			ID:          runID,
+			WorkspaceID: workspaceID,
+		},
+		failureItems: items,
+	})
+
+	response := performListRunFailuresRequest(t, service, workspaceID, runID, url.Values{
+		"failure_cluster_key": []string{targetClusterKey},
+		"limit":               []string{"1"},
+	})
+	if len(response.Items) != 1 {
+		t.Fatalf("page items = %d, want 1", len(response.Items))
+	}
+	if response.Items[0].FailureClusterKey != targetClusterKey {
+		t.Fatalf("item cluster key = %q, want %q", response.Items[0].FailureClusterKey, targetClusterKey)
+	}
+	if len(response.Clusters) != 1 {
+		t.Fatalf("clusters = %#v, want 1 filtered cluster summary", response.Clusters)
+	}
+	if response.Clusters[0].FailureClusterKey != targetClusterKey {
+		t.Fatalf("cluster key = %q, want %q", response.Clusters[0].FailureClusterKey, targetClusterKey)
+	}
+	if response.Clusters[0].Count != 2 {
+		t.Fatalf("cluster count = %d, want full filtered count before pagination", response.Clusters[0].Count)
+	}
+}
+
 func TestListRunFailuresEndpointRejectsMalformedQueryParams(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/failurereview/read_model.go
+++ b/backend/internal/failurereview/read_model.go
@@ -281,7 +281,7 @@ func BuildRunAgentItems(input RunAgentInput) ([]Item, error) {
 	return items, nil
 }
 
-func FilterItems(items []Item, agentID *uuid.UUID, severity *Severity, failureClass *FailureClass, evidenceTier *EvidenceTier, challengeKey, caseKey *string) []Item {
+func FilterItems(items []Item, agentID *uuid.UUID, severity *Severity, failureClass *FailureClass, evidenceTier *EvidenceTier, challengeKey, caseKey, clusterKey *string) []Item {
 	filtered := make([]Item, 0, len(items))
 	for _, item := range items {
 		if agentID != nil && item.RunAgentID != *agentID {
@@ -300,6 +300,9 @@ func FilterItems(items []Item, agentID *uuid.UUID, severity *Severity, failureCl
 			continue
 		}
 		if caseKey != nil && item.CaseKey != *caseKey {
+			continue
+		}
+		if clusterKey != nil && item.FailureClusterKey != *clusterKey {
 			continue
 		}
 		filtered = append(filtered, item)

--- a/cli/cmd/cli_surface_gaps_test.go
+++ b/cli/cmd/cli_surface_gaps_test.go
@@ -159,11 +159,12 @@ func TestRegressionCaseUpdatePayload(t *testing.T) {
 }
 
 func TestRunFailuresForwardsFilters(t *testing.T) {
-	var gotAgent, gotFailureClass, gotLimit string
+	var gotAgent, gotFailureClass, gotCluster, gotLimit string
 	srv := fakeAPI(t, map[string]http.HandlerFunc{
 		"GET /v1/workspaces/ws-123/runs/run-1/failures": func(w http.ResponseWriter, r *http.Request) {
 			gotAgent = r.URL.Query().Get("agent_id")
 			gotFailureClass = r.URL.Query().Get("failure_class")
+			gotCluster = r.URL.Query().Get("failure_cluster_key")
 			gotLimit = r.URL.Query().Get("limit")
 			jsonHandler(200, map[string]any{
 				"items": []map[string]any{
@@ -189,12 +190,13 @@ func TestRunFailuresForwardsFilters(t *testing.T) {
 		"run", "failures", "run-1", "-w", "ws-123",
 		"--agent", "agent-1",
 		"--class", "policy_violation",
+		"--cluster", "frc-test",
 		"--limit", "25",
 	}, srv.URL); err != nil {
 		t.Fatalf("run failures error: %v", err)
 	}
-	if gotAgent != "agent-1" || gotFailureClass != "policy_violation" || gotLimit != "25" {
-		t.Fatalf("query = agent %q failure_class %q limit %q", gotAgent, gotFailureClass, gotLimit)
+	if gotAgent != "agent-1" || gotFailureClass != "policy_violation" || gotCluster != "frc-test" || gotLimit != "25" {
+		t.Fatalf("query = agent %q failure_class %q cluster %q limit %q", gotAgent, gotFailureClass, gotCluster, gotLimit)
 	}
 }
 

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -41,6 +41,7 @@ func init() {
 	runFailuresCmd.Flags().String("severity", "", "Filter by severity: info, warning, or blocking")
 	runFailuresCmd.Flags().String("class", "", "Filter by failure class")
 	runFailuresCmd.Flags().String("evidence-tier", "", "Filter by evidence tier")
+	runFailuresCmd.Flags().String("cluster", "", "Filter by failure cluster key")
 	runFailuresCmd.Flags().String("cursor", "", "Pagination cursor")
 	runFailuresCmd.Flags().Int("limit", 0, "Maximum failures to return")
 
@@ -361,6 +362,9 @@ var runFailuresCmd = &cobra.Command{
 		}
 		if v, _ := cmd.Flags().GetString("evidence-tier"); v != "" {
 			q.Set("evidence_tier", v)
+		}
+		if v, _ := cmd.Flags().GetString("cluster"); v != "" {
+			q.Set("failure_cluster_key", v)
 		}
 		if v, _ := cmd.Flags().GetString("cursor"); v != "" {
 			q.Set("cursor", v)

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -2392,6 +2392,11 @@ paths:
           description: Limit results to a single case key.
           schema:
             type: string
+        - name: failure_cluster_key
+          in: query
+          description: Limit results to a single derived failure cluster key.
+          schema:
+            type: string
         - name: cursor
           in: query
           description: Opaque base64url-encoded pagination cursor returned by a previous response.

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.test.tsx
@@ -348,6 +348,26 @@ describe("FailuresClient", () => {
           }),
         );
       });
+
+      await waitFor(() => {
+        const activeClusterButton = view.container.querySelector(
+          'button[aria-pressed="true"]',
+        );
+        expect(activeClusterButton).toBeTruthy();
+      });
+
+      mockReplace.mockReset();
+      const activeClusterButton = view.container.querySelector(
+        'button[aria-pressed="true"]',
+      );
+      act(() => {
+        clickElement(activeClusterButton!);
+      });
+
+      expect(mockReplace).toHaveBeenCalledWith(
+        "/workspaces/ws-1/runs/run-1/failures",
+        { scroll: false },
+      );
     } finally {
       view.cleanup();
     }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.test.tsx
@@ -197,6 +197,15 @@ async function waitFor(assertion: () => void, attempts = 20) {
   throw lastError;
 }
 
+function clickElement(element: Element) {
+  element.dispatchEvent(
+    new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+}
+
 describe("FailuresClient", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
@@ -280,6 +289,65 @@ describe("FailuresClient", () => {
       );
       expect(view.container.textContent).toContain("1 failure");
       expect(view.container.textContent).toContain("challenge-filtered");
+    } finally {
+      view.cleanup();
+    }
+  });
+
+  it("sets the cluster filter from a cluster rollup", async () => {
+    mockListRunFailures.mockResolvedValue(
+      makePage({
+        items: [
+          makeItem({
+            failure_cluster_key: "cluster-a",
+          }),
+        ],
+        clusters: [
+          makeCluster({
+            failure_cluster_key: "cluster-a",
+            count: 1,
+            promotable_count: 1,
+            challenge_keys: ["challenge-a"],
+            case_keys: ["case-a"],
+          }),
+        ],
+      }),
+    );
+
+    const view = renderClient();
+    try {
+      const clusterButton = Array.from(
+        view.container.querySelectorAll("button"),
+      ).find((button) =>
+        button.textContent?.includes(
+          "Filesystem write failures cluster together",
+        ),
+      );
+      expect(clusterButton).toBeTruthy();
+
+      act(() => {
+        clickElement(clusterButton!);
+      });
+
+      expect(mockReplace).toHaveBeenCalledWith(
+        "/workspaces/ws-1/runs/run-1/failures?cluster=cluster-a",
+        { scroll: false },
+      );
+
+      searchState.params = new URLSearchParams("cluster=cluster-a");
+      view.render();
+
+      await waitFor(() => {
+        expect(mockListRunFailures).toHaveBeenCalledWith(
+          { client: true },
+          "ws-1",
+          "run-1",
+          expect.objectContaining({
+            failureClusterKey: "cluster-a",
+            limit: 50,
+          }),
+        );
+      });
     } finally {
       view.cleanup();
     }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.tsx
@@ -76,7 +76,8 @@ function humanize(value: string): string {
 
 function compactList(values: string[], maxVisible = 3): string {
   if (values.length <= maxVisible) return values.join(", ");
-  return `${values.slice(0, maxVisible).join(", ")} +${values.length - maxVisible}`;
+  const visible = values.slice(0, maxVisible).join(", ");
+  return `${visible} +${values.length - maxVisible}`;
 }
 
 const severityVariant: Record<
@@ -105,6 +106,7 @@ interface Filters {
   severity?: FailureReviewSeverity;
   failureClass?: FailureReviewFailureClass;
   evidenceTier?: FailureReviewEvidenceTier;
+  failureClusterKey?: string;
 }
 
 function parseFilters(params: URLSearchParams): Filters {
@@ -116,6 +118,7 @@ function parseFilters(params: URLSearchParams): Filters {
       (params.get("class") as FailureReviewFailureClass | null) ?? undefined,
     evidenceTier:
       (params.get("tier") as FailureReviewEvidenceTier | null) ?? undefined,
+    failureClusterKey: params.get("cluster") ?? undefined,
   };
 }
 
@@ -125,6 +128,7 @@ function filtersToQuery(filters: Filters): string {
   if (filters.severity) sp.set("severity", filters.severity);
   if (filters.failureClass) sp.set("class", filters.failureClass);
   if (filters.evidenceTier) sp.set("tier", filters.evidenceTier);
+  if (filters.failureClusterKey) sp.set("cluster", filters.failureClusterKey);
   const s = sp.toString();
   return s ? `?${s}` : "";
 }
@@ -134,7 +138,8 @@ function filtersEqual(a: Filters, b: Filters): boolean {
     a.agentId === b.agentId &&
     a.severity === b.severity &&
     a.failureClass === b.failureClass &&
-    a.evidenceTier === b.evidenceTier
+    a.evidenceTier === b.evidenceTier &&
+    a.failureClusterKey === b.failureClusterKey
   );
 }
 
@@ -197,7 +202,14 @@ function FailuresClientInner({
   const activeFiltersRef = useRef<Filters>({});
 
   const anyFilterActive = useMemo(
-    () => !!(urlFilters.agentId || urlFilters.severity || urlFilters.failureClass || urlFilters.evidenceTier),
+    () =>
+      !!(
+        urlFilters.agentId ||
+        urlFilters.severity ||
+        urlFilters.failureClass ||
+        urlFilters.evidenceTier ||
+        urlFilters.failureClusterKey
+      ),
     [urlFilters],
   );
 
@@ -340,7 +352,15 @@ function FailuresClientInner({
         />
       ) : (
         <div className="space-y-3">
-          {clusters.length > 0 && <FailureClusterRollups clusters={clusters} />}
+          {clusters.length > 0 && (
+            <FailureClusterRollups
+              clusters={clusters}
+              activeClusterKey={urlFilters.failureClusterKey}
+              onSelectCluster={(clusterKey) =>
+                updateFilter("failureClusterKey", clusterKey)
+              }
+            />
+          )}
 
           {groups.map((group) => (
             <ChallengeGroup
@@ -393,8 +413,12 @@ function FailuresClientInner({
 
 function FailureClusterRollups({
   clusters,
+  activeClusterKey,
+  onSelectCluster,
 }: {
   clusters: FailureReviewClusterSummary[];
+  activeClusterKey?: string;
+  onSelectCluster: (clusterKey: string) => void;
 }) {
   const totalFailures = clusters.reduce((sum, cluster) => sum + cluster.count, 0);
   const totalPromotable = clusters.reduce(
@@ -415,69 +439,83 @@ function FailureClusterRollups({
         </div>
       </div>
       <ul className="divide-y divide-border">
-        {clusters.map((cluster) => (
-          <li
-            key={cluster.failure_cluster_key}
-            className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-center"
-          >
-            <div className="min-w-0 space-y-2">
-              <div className="flex min-w-0 flex-wrap items-center gap-2">
-                <Badge variant={severityVariant[cluster.severity]}>
-                  {cluster.severity}
-                </Badge>
-                <Badge variant={failureStateVariant[cluster.failure_state]}>
-                  {humanize(cluster.failure_state)}
-                </Badge>
-                <Badge variant="outline">{humanize(cluster.failure_class)}</Badge>
-                <Badge variant="secondary">
-                  {humanize(cluster.evidence_tier)}
-                </Badge>
-              </div>
-              <div className="min-w-0">
-                <p className="truncate text-sm font-medium">
-                  {cluster.headline || humanize(cluster.failure_class)}
-                </p>
-                {cluster.recommended_action && (
-                  <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
-                    {cluster.recommended_action}
-                  </p>
+        {clusters.map((cluster) => {
+          const active = cluster.failure_cluster_key === activeClusterKey;
+          return (
+            <li key={cluster.failure_cluster_key}>
+              <button
+                type="button"
+                aria-pressed={active}
+                onClick={() => onSelectCluster(cluster.failure_cluster_key)}
+                className={cn(
+                  "grid w-full gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/40",
+                  "md:grid-cols-[minmax(0,1fr)_auto] md:items-center",
+                  active && "bg-muted/50",
                 )}
-              </div>
-              <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
-                <span className="min-w-0 truncate">
-                  Challenges:{" "}
-                  <span className="text-foreground/80">
-                    {compactList(cluster.challenge_keys)}
-                  </span>
-                </span>
-                <span className="min-w-0 truncate">
-                  Cases:{" "}
-                  <span className="text-foreground/80">
-                    {compactList(cluster.case_keys)}
-                  </span>
-                </span>
-              </div>
-            </div>
-            <div className="flex items-center gap-2 md:justify-end">
-              <div className="rounded-md border border-border px-2.5 py-1 text-right">
-                <div className="text-sm font-semibold tabular-nums">
-                  {cluster.count}
+              >
+                <div className="min-w-0 space-y-2">
+                  <div className="flex min-w-0 flex-wrap items-center gap-2">
+                    <Badge variant={severityVariant[cluster.severity]}>
+                      {cluster.severity}
+                    </Badge>
+                    <Badge variant={failureStateVariant[cluster.failure_state]}>
+                      {humanize(cluster.failure_state)}
+                    </Badge>
+                    <Badge variant="outline">
+                      {humanize(cluster.failure_class)}
+                    </Badge>
+                    <Badge variant="secondary">
+                      {humanize(cluster.evidence_tier)}
+                    </Badge>
+                    {active && <Badge>active</Badge>}
+                  </div>
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium">
+                      {cluster.headline || humanize(cluster.failure_class)}
+                    </p>
+                    {cluster.recommended_action && (
+                      <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+                        {cluster.recommended_action}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                    <span className="min-w-0 truncate">
+                      Challenges:{" "}
+                      <span className="text-foreground/80">
+                        {compactList(cluster.challenge_keys)}
+                      </span>
+                    </span>
+                    <span className="min-w-0 truncate">
+                      Cases:{" "}
+                      <span className="text-foreground/80">
+                        {compactList(cluster.case_keys)}
+                      </span>
+                    </span>
+                  </div>
                 </div>
-                <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-                  failures
+                <div className="flex items-center gap-2 md:justify-end">
+                  <div className="rounded-md border border-border px-2.5 py-1 text-right">
+                    <div className="text-sm font-semibold tabular-nums">
+                      {cluster.count}
+                    </div>
+                    <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                      failures
+                    </div>
+                  </div>
+                  <div className="rounded-md border border-border px-2.5 py-1 text-right">
+                    <div className="text-sm font-semibold tabular-nums">
+                      {cluster.promotable_count}
+                    </div>
+                    <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                      promote
+                    </div>
+                  </div>
                 </div>
-              </div>
-              <div className="rounded-md border border-border px-2.5 py-1 text-right">
-                <div className="text-sm font-semibold tabular-nums">
-                  {cluster.promotable_count}
-                </div>
-                <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-                  promote
-                </div>
-              </div>
-            </div>
-          </li>
-        ))}
+              </button>
+            </li>
+          );
+        })}
       </ul>
     </section>
   );

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.tsx
@@ -418,7 +418,7 @@ function FailureClusterRollups({
 }: {
   clusters: FailureReviewClusterSummary[];
   activeClusterKey?: string;
-  onSelectCluster: (clusterKey: string) => void;
+  onSelectCluster: (clusterKey: string | undefined) => void;
 }) {
   const totalFailures = clusters.reduce((sum, cluster) => sum + cluster.count, 0);
   const totalPromotable = clusters.reduce(
@@ -446,7 +446,11 @@ function FailureClusterRollups({
               <button
                 type="button"
                 aria-pressed={active}
-                onClick={() => onSelectCluster(cluster.failure_cluster_key)}
+                onClick={() =>
+                  onSelectCluster(
+                    active ? undefined : cluster.failure_cluster_key,
+                  )
+                }
                 className={cn(
                   "grid w-full gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/40",
                   "md:grid-cols-[minmax(0,1fr)_auto] md:items-center",

--- a/web/src/lib/api/__tests__/failure-reviews.test.ts
+++ b/web/src/lib/api/__tests__/failure-reviews.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createApiClient } from "../client";
+import { listRunFailures } from "../failure-reviews";
+
+vi.stubEnv("NEXT_PUBLIC_API_URL", "http://localhost:8080");
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("failure review API", () => {
+  it("serializes the failure cluster filter", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ items: [], clusters: [] }));
+
+    const api = createApiClient("token");
+    await listRunFailures(api, "ws-1", "run-1", {
+      failureClusterKey: "frc-test",
+      limit: 25,
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/v1/workspaces/ws-1/runs/run-1/failures?failure_cluster_key=frc-test&limit=25",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+});

--- a/web/src/lib/api/failure-reviews.ts
+++ b/web/src/lib/api/failure-reviews.ts
@@ -13,6 +13,7 @@ export interface ListRunFailuresParams {
   evidenceTier?: FailureReviewEvidenceTier;
   challengeKey?: string;
   caseKey?: string;
+  failureClusterKey?: string;
   cursor?: string;
   limit?: number;
   signal?: AbortSignal;
@@ -35,6 +36,7 @@ export function listRunFailures(
     evidenceTier,
     challengeKey,
     caseKey,
+    failureClusterKey,
     cursor,
     limit,
     signal,
@@ -50,6 +52,7 @@ export function listRunFailures(
         evidence_tier: evidenceTier,
         challenge_key: challengeKey,
         case_key: caseKey,
+        failure_cluster_key: failureClusterKey,
         cursor,
         limit,
       },


### PR DESCRIPTION
## Summary
- add `failure_cluster_key` filtering to the run failures API before pagination and cluster summaries
- expose the filter in OpenAPI, the web API helper, and `agentclash run failures --cluster`
- make web failure cluster rollups clickable URL filters

## Review checkpoint
- Contract: `/tmp/reviewcheckpoint-issue-82-cluster-filter-contract.md`
- Final verdict: ready

## Tests
- `go test ./internal/api`
- `go test ./internal/failurereview ./internal/api`
- `go test ./cmd`
- `go build ./...` (cli)
- `go vet ./...` (cli)
- `go test -short -race -count=1 ./...` (cli)
- `npx tsc --noEmit` (web)
- `npm run lint` (web)
- `npm test` (web)
- `npm run build` (web)

Part of #82.