### PR TITLE
feat(ci): surface failure cluster trends

### DIFF
--- a/backend/db/queries/runs.sql
+++ b/backend/db/queries/runs.sql
@@ -210,7 +210,6 @@ WHERE r.id <> a.id
       SELECT 1
       FROM run_scorecards AS rs
       WHERE rs.run_id = r.id
-        AND rs.winning_run_agent_id IS NOT NULL
   )
 ORDER BY r.created_at DESC, r.id DESC
 LIMIT @result_limit;

--- a/backend/db/queries/runs.sql
+++ b/backend/db/queries/runs.sql
@@ -188,6 +188,33 @@ WHERE workspace_id = @workspace_id
 ORDER BY created_at DESC
 LIMIT @result_limit OFFSET @result_offset;
 
+-- name: ListRecentComparableScoredRunsBeforeRunID :many
+WITH anchor AS (
+    SELECT
+        runs.workspace_id,
+        runs.challenge_pack_version_id,
+        runs.created_at,
+        runs.id
+    FROM runs
+    WHERE runs.id = @run_id
+)
+SELECT r.*
+FROM runs AS r
+JOIN anchor AS a
+  ON r.workspace_id = a.workspace_id
+ AND r.challenge_pack_version_id = a.challenge_pack_version_id
+WHERE r.id <> a.id
+  AND r.status = 'completed'
+  AND (r.created_at, r.id) < (a.created_at, a.id)
+  AND EXISTS (
+      SELECT 1
+      FROM run_scorecards AS rs
+      WHERE rs.run_id = r.id
+        AND rs.winning_run_agent_id IS NOT NULL
+  )
+ORDER BY r.created_at DESC, r.id DESC
+LIMIT @result_limit;
+
 -- name: CountRunsByWorkspaceID :one
 SELECT count(*)
 FROM runs

--- a/backend/internal/api/failure_reviews.go
+++ b/backend/internal/api/failure_reviews.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/domain"
 	"github.com/agentclash/agentclash/backend/internal/failurereview"
@@ -17,8 +18,9 @@ import (
 )
 
 const (
-	defaultRunFailurePageLimit = 50
-	maxRunFailurePageLimit     = 200
+	defaultRunFailurePageLimit         = 50
+	maxRunFailurePageLimit             = 200
+	defaultFailureClusterTrendRunLimit = 20
 )
 
 type ListRunFailuresInput struct {
@@ -60,6 +62,13 @@ func (m *RunReadManager) ListRunFailures(ctx context.Context, caller Caller, inp
 	}
 	filtered := failurereview.FilterItems(items, input.AgentID, input.Severity, input.FailureClass, input.EvidenceTier, input.ChallengeKey, input.CaseKey, input.FailureClusterKey)
 	clusters := failurereview.BuildClusterSummaries(filtered)
+	if len(clusters) > 0 {
+		historicalRuns, historyErr := m.failureClusterHistoryRuns(ctx, input)
+		if historyErr != nil {
+			return ListRunFailuresResult{}, historyErr
+		}
+		clusters = failurereview.AttachClusterHistory(clusters, historicalRuns)
+	}
 	page, next := failurereview.PaginateItems(filtered, input.Cursor, input.Limit)
 
 	var nextCursor *string
@@ -77,6 +86,38 @@ func (m *RunReadManager) ListRunFailures(ctx context.Context, caller Caller, inp
 		Clusters:   clusters,
 		NextCursor: nextCursor,
 	}, nil
+}
+
+func (m *RunReadManager) failureClusterHistoryRuns(ctx context.Context, input ListRunFailuresInput) ([]failurereview.ClusterHistoryRun, error) {
+	runs, err := m.repo.ListRecentComparableScoredRunsBeforeRunID(ctx, input.RunID, defaultFailureClusterTrendRunLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	historicalRuns := make([]failurereview.ClusterHistoryRun, 0, len(runs))
+	for _, run := range runs {
+		items, itemErr := m.repo.ListRunFailureReviewItems(ctx, run.ID, nil)
+		if itemErr != nil {
+			return nil, itemErr
+		}
+		filtered := failurereview.FilterItems(items, nil, input.Severity, input.FailureClass, input.EvidenceTier, input.ChallengeKey, input.CaseKey, nil)
+		historicalRuns = append(historicalRuns, failurereview.ClusterHistoryRun{
+			RunID:      run.ID,
+			ObservedAt: runObservedAt(run),
+			Clusters:   failurereview.BuildClusterSummaries(filtered),
+		})
+	}
+	return historicalRuns, nil
+}
+
+func runObservedAt(run domain.Run) time.Time {
+	if run.FinishedAt != nil {
+		return *run.FinishedAt
+	}
+	if run.StartedAt != nil {
+		return *run.StartedAt
+	}
+	return run.CreatedAt
 }
 
 type listRunFailuresResponse struct {

--- a/backend/internal/api/failure_reviews.go
+++ b/backend/internal/api/failure_reviews.go
@@ -62,7 +62,9 @@ func (m *RunReadManager) ListRunFailures(ctx context.Context, caller Caller, inp
 	}
 	filtered := failurereview.FilterItems(items, input.AgentID, input.Severity, input.FailureClass, input.EvidenceTier, input.ChallengeKey, input.CaseKey, input.FailureClusterKey)
 	clusters := failurereview.BuildClusterSummaries(filtered)
-	if len(clusters) > 0 {
+	// Cluster history is an expensive bounded scan. Return it on the first
+	// all-agent page where the trend scope matches the current cluster counts.
+	if len(clusters) > 0 && input.Cursor == nil && input.AgentID == nil {
 		historicalRuns, historyErr := m.failureClusterHistoryRuns(ctx, input)
 		if historyErr != nil {
 			return ListRunFailuresResult{}, historyErr

--- a/backend/internal/api/failure_reviews_test.go
+++ b/backend/internal/api/failure_reviews_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/domain"
 	"github.com/agentclash/agentclash/backend/internal/failurereview"
@@ -181,6 +182,62 @@ func TestListRunFailuresEndpointReturnsClusterSummariesBeforePagination(t *testi
 	}
 	if ticketACluster.RepresentativeFailureFingerprint == "" {
 		t.Fatalf("ticket-a representative fingerprint is empty")
+	}
+}
+
+func TestListRunFailuresEndpointEnrichesClustersWithHistory(t *testing.T) {
+	workspaceID := uuid.New()
+	runID := uuid.New()
+	priorRunID := uuid.New()
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	priorFinishedAt := now.Add(-24 * time.Hour)
+	currentItems := []failurereview.Item{
+		mustBuildFailureItem(t, runID, uuid.New(), "ticket-a", "case-a", "policy.filesystem"),
+		mustBuildFailureItem(t, runID, uuid.New(), "ticket-a", "case-a", "policy.filesystem"),
+	}
+	priorItems := []failurereview.Item{
+		mustBuildFailureItem(t, priorRunID, uuid.New(), "ticket-a", "case-a", "policy.filesystem"),
+	}
+
+	service := NewRunReadManager(NewCallerWorkspaceAuthorizer(), &fakeRunReadRepository{
+		run: domain.Run{
+			ID:          runID,
+			WorkspaceID: workspaceID,
+			CreatedAt:   now,
+		},
+		recentComparableRuns: []domain.Run{
+			{
+				ID:          priorRunID,
+				WorkspaceID: workspaceID,
+				FinishedAt:  &priorFinishedAt,
+				CreatedAt:   priorFinishedAt,
+			},
+		},
+		failureItemsByRunID: map[uuid.UUID][]failurereview.Item{
+			runID:      currentItems,
+			priorRunID: priorItems,
+		},
+	})
+
+	response := performListRunFailuresRequest(t, service, workspaceID, runID, url.Values{"limit": []string{"1"}})
+	if len(response.Clusters) != 1 {
+		t.Fatalf("clusters = %#v, want one historical cluster", response.Clusters)
+	}
+	history := response.Clusters[0].History
+	if history.Trend != failurereview.ClusterTrendIncreasing {
+		t.Fatalf("trend = %s, want increasing", history.Trend)
+	}
+	if history.WindowRunCount != 1 || history.PriorRunCount != 1 || history.PriorFailureCount != 1 {
+		t.Fatalf("history counts = %#v, want window=1 prior_runs=1 prior_failures=1", history)
+	}
+	if history.LastSeenRunID == nil || *history.LastSeenRunID != priorRunID {
+		t.Fatalf("last_seen_run_id = %v, want %s", history.LastSeenRunID, priorRunID)
+	}
+	if history.LastSeenAt == nil || !history.LastSeenAt.Equal(priorFinishedAt) {
+		t.Fatalf("last_seen_at = %v, want %s", history.LastSeenAt, priorFinishedAt)
+	}
+	if len(response.Items) != 1 {
+		t.Fatalf("page items = %d, want pagination unchanged", len(response.Items))
 	}
 }
 

--- a/backend/internal/api/failure_reviews_test.go
+++ b/backend/internal/api/failure_reviews_test.go
@@ -241,6 +241,37 @@ func TestListRunFailuresEndpointEnrichesClustersWithHistory(t *testing.T) {
 	}
 }
 
+func TestListRunFailuresEndpointSkipsClusterHistoryForCursorPages(t *testing.T) {
+	workspaceID := uuid.New()
+	runID := uuid.New()
+	repo := &fakeRunReadRepository{
+		run: domain.Run{
+			ID:          runID,
+			WorkspaceID: workspaceID,
+		},
+		failureItems:         []failurereview.Item{mustBuildFailureItem(t, runID, uuid.New(), "ticket-a", "case-a", "policy.filesystem")},
+		recentComparableRuns: []domain.Run{{ID: uuid.New(), WorkspaceID: workspaceID}},
+	}
+	service := NewRunReadManager(NewCallerWorkspaceAuthorizer(), repo)
+	cursor, err := failurereview.EncodeCursor(failurereview.CursorKey{ChallengeKey: "ticket-a"})
+	if err != nil {
+		t.Fatalf("EncodeCursor returned error: %v", err)
+	}
+
+	response := performListRunFailuresRequest(t, service, workspaceID, runID, url.Values{
+		"cursor": []string{cursor},
+	})
+	if repo.recentComparableRunCalls != 0 {
+		t.Fatalf("recent comparable run calls = %d, want 0 on cursor pages", repo.recentComparableRunCalls)
+	}
+	if len(response.Clusters) != 1 {
+		t.Fatalf("clusters = %#v, want one cluster without history", response.Clusters)
+	}
+	if response.Clusters[0].History != nil {
+		t.Fatalf("history = %#v, want omitted on cursor pages", response.Clusters[0].History)
+	}
+}
+
 func TestListRunFailuresEndpointFiltersByClusterKeyBeforePagination(t *testing.T) {
 	workspaceID := uuid.New()
 	runID := uuid.New()

--- a/backend/internal/api/run_reads.go
+++ b/backend/internal/api/run_reads.go
@@ -28,6 +28,7 @@ type RunReadRepository interface {
 	ListRunRegressionCoverageCasesByRunID(ctx context.Context, runID uuid.UUID) ([]repository.RunRegressionCoverageCase, error)
 	ListRunAgentsByRunID(ctx context.Context, runID uuid.UUID) ([]domain.RunAgent, error)
 	ListRunFailureReviewItems(ctx context.Context, runID uuid.UUID, agentID *uuid.UUID) ([]failurereview.Item, error)
+	ListRecentComparableScoredRunsBeforeRunID(ctx context.Context, runID uuid.UUID, limit int32) ([]domain.Run, error)
 	ListEvalSessionsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID, limit int32, offset int32) ([]domain.EvalSession, error)
 	ListRunsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID, limit int32, offset int32) ([]domain.Run, error)
 	CountRunsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (int64, error)

--- a/backend/internal/api/run_reads_test.go
+++ b/backend/internal/api/run_reads_test.go
@@ -426,6 +426,8 @@ type fakeRunReadRepository struct {
 	regressionCoverageCases []repository.RunRegressionCoverageCase
 	runAgents               []domain.RunAgent
 	failureItems            []failurereview.Item
+	failureItemsByRunID     map[uuid.UUID][]failurereview.Item
+	recentComparableRuns    []domain.Run
 	spendPolicies           []repository.SpendPolicyRow
 	providerAccount         repository.ProviderAccountRow
 	modelAlias              repository.ModelAliasRow
@@ -438,6 +440,7 @@ type fakeRunReadRepository struct {
 	getRunScorecardErr      error
 	listRunAgentsErr        error
 	listRunFailuresErr      error
+	listRecentRunsErr       error
 	listEvalSessionsErr     error
 	getProviderAccountErr   error
 	getModelAliasErr        error
@@ -487,8 +490,17 @@ func (f *fakeRunReadRepository) ListRunAgentsByRunID(_ context.Context, _ uuid.U
 	return f.runAgents, f.listRunAgentsErr
 }
 
-func (f *fakeRunReadRepository) ListRunFailureReviewItems(_ context.Context, _ uuid.UUID, _ *uuid.UUID) ([]failurereview.Item, error) {
+func (f *fakeRunReadRepository) ListRunFailureReviewItems(_ context.Context, runID uuid.UUID, _ *uuid.UUID) ([]failurereview.Item, error) {
+	if f.failureItemsByRunID != nil {
+		if items, ok := f.failureItemsByRunID[runID]; ok {
+			return append([]failurereview.Item(nil), items...), f.listRunFailuresErr
+		}
+	}
 	return f.failureItems, f.listRunFailuresErr
+}
+
+func (f *fakeRunReadRepository) ListRecentComparableScoredRunsBeforeRunID(_ context.Context, _ uuid.UUID, _ int32) ([]domain.Run, error) {
+	return append([]domain.Run(nil), f.recentComparableRuns...), f.listRecentRunsErr
 }
 
 func (f *fakeRunReadRepository) ListEvalSessionsByWorkspaceID(_ context.Context, _ uuid.UUID, _ int32, _ int32) ([]domain.EvalSession, error) {

--- a/backend/internal/api/run_reads_test.go
+++ b/backend/internal/api/run_reads_test.go
@@ -417,36 +417,37 @@ func TestListRunAgentsEndpointReturnsForbidden(t *testing.T) {
 }
 
 type fakeRunReadRepository struct {
-	run                     domain.Run
-	evalSession             repository.EvalSessionWithRuns
-	evalSessions            []domain.EvalSession
-	evalSessionRuns         map[uuid.UUID][]domain.Run
-	evalSessionResults      map[uuid.UUID]repository.EvalSessionAggregateRecord
-	runScorecard            repository.RunScorecard
-	regressionCoverageCases []repository.RunRegressionCoverageCase
-	runAgents               []domain.RunAgent
-	failureItems            []failurereview.Item
-	failureItemsByRunID     map[uuid.UUID][]failurereview.Item
-	recentComparableRuns    []domain.Run
-	spendPolicies           []repository.SpendPolicyRow
-	providerAccount         repository.ProviderAccountRow
-	modelAlias              repository.ModelAliasRow
-	modelCatalogEntry       repository.ModelCatalogEntryRow
-	workspaceSecrets        map[string]string
-	getRunErr               error
-	getEvalSessionErr       error
-	getEvalSessionResultErr error
-	listEvalSessionRunsErr  error
-	getRunScorecardErr      error
-	listRunAgentsErr        error
-	listRunFailuresErr      error
-	listRecentRunsErr       error
-	listEvalSessionsErr     error
-	getProviderAccountErr   error
-	getModelAliasErr        error
-	getModelCatalogErr      error
-	listSpendPoliciesErr    error
-	loadWorkspaceSecretsErr error
+	run                      domain.Run
+	evalSession              repository.EvalSessionWithRuns
+	evalSessions             []domain.EvalSession
+	evalSessionRuns          map[uuid.UUID][]domain.Run
+	evalSessionResults       map[uuid.UUID]repository.EvalSessionAggregateRecord
+	runScorecard             repository.RunScorecard
+	regressionCoverageCases  []repository.RunRegressionCoverageCase
+	runAgents                []domain.RunAgent
+	failureItems             []failurereview.Item
+	failureItemsByRunID      map[uuid.UUID][]failurereview.Item
+	recentComparableRuns     []domain.Run
+	recentComparableRunCalls int
+	spendPolicies            []repository.SpendPolicyRow
+	providerAccount          repository.ProviderAccountRow
+	modelAlias               repository.ModelAliasRow
+	modelCatalogEntry        repository.ModelCatalogEntryRow
+	workspaceSecrets         map[string]string
+	getRunErr                error
+	getEvalSessionErr        error
+	getEvalSessionResultErr  error
+	listEvalSessionRunsErr   error
+	getRunScorecardErr       error
+	listRunAgentsErr         error
+	listRunFailuresErr       error
+	listRecentRunsErr        error
+	listEvalSessionsErr      error
+	getProviderAccountErr    error
+	getModelAliasErr         error
+	getModelCatalogErr       error
+	listSpendPoliciesErr     error
+	loadWorkspaceSecretsErr  error
 }
 
 func (f *fakeRunReadRepository) GetRunByID(_ context.Context, _ uuid.UUID) (domain.Run, error) {
@@ -500,6 +501,7 @@ func (f *fakeRunReadRepository) ListRunFailureReviewItems(_ context.Context, run
 }
 
 func (f *fakeRunReadRepository) ListRecentComparableScoredRunsBeforeRunID(_ context.Context, _ uuid.UUID, _ int32) ([]domain.Run, error) {
+	f.recentComparableRunCalls++
 	return append([]domain.Run(nil), f.recentComparableRuns...), f.listRecentRunsErr
 }
 

--- a/backend/internal/failurereview/read_model.go
+++ b/backend/internal/failurereview/read_model.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/domain"
 	"github.com/google/uuid"
@@ -75,19 +76,45 @@ type Item struct {
 }
 
 type ClusterSummary struct {
-	FailureClusterKey                string       `json:"failure_cluster_key"`
-	RepresentativeFailureFingerprint string       `json:"representative_failure_fingerprint"`
-	Count                            int          `json:"count"`
-	PromotableCount                  int          `json:"promotable_count"`
-	Severity                         Severity     `json:"severity"`
-	FailureState                     FailureState `json:"failure_state"`
-	FailureClass                     FailureClass `json:"failure_class"`
-	EvidenceTier                     EvidenceTier `json:"evidence_tier"`
-	ChallengeKeys                    []string     `json:"challenge_keys"`
-	CaseKeys                         []string     `json:"case_keys"`
-	RunAgentIDs                      []string     `json:"run_agent_ids"`
-	Headline                         string       `json:"headline"`
-	RecommendedAction                string       `json:"recommended_action"`
+	FailureClusterKey                string         `json:"failure_cluster_key"`
+	RepresentativeFailureFingerprint string         `json:"representative_failure_fingerprint"`
+	Count                            int            `json:"count"`
+	PromotableCount                  int            `json:"promotable_count"`
+	Severity                         Severity       `json:"severity"`
+	FailureState                     FailureState   `json:"failure_state"`
+	FailureClass                     FailureClass   `json:"failure_class"`
+	EvidenceTier                     EvidenceTier   `json:"evidence_tier"`
+	ChallengeKeys                    []string       `json:"challenge_keys"`
+	CaseKeys                         []string       `json:"case_keys"`
+	RunAgentIDs                      []string       `json:"run_agent_ids"`
+	Headline                         string         `json:"headline"`
+	RecommendedAction                string         `json:"recommended_action"`
+	History                          ClusterHistory `json:"history"`
+}
+
+type ClusterTrend string
+
+const (
+	ClusterTrendNew        ClusterTrend = "new"
+	ClusterTrendRecurring  ClusterTrend = "recurring"
+	ClusterTrendIncreasing ClusterTrend = "increasing"
+	ClusterTrendDecreasing ClusterTrend = "decreasing"
+)
+
+type ClusterHistory struct {
+	Trend               ClusterTrend `json:"trend"`
+	WindowRunCount      int          `json:"window_run_count"`
+	PriorRunCount       int          `json:"prior_run_count"`
+	PriorFailureCount   int          `json:"prior_failure_count"`
+	LastSeenRunID       *uuid.UUID   `json:"last_seen_run_id,omitempty"`
+	LastSeenAt          *time.Time   `json:"last_seen_at,omitempty"`
+	LastRunFailureCount int          `json:"last_run_failure_count,omitempty"`
+}
+
+type ClusterHistoryRun struct {
+	RunID      uuid.UUID
+	ObservedAt time.Time
+	Clusters   []ClusterSummary
 }
 
 type ReplayStepRef struct {
@@ -416,6 +443,49 @@ func BuildClusterSummaries(items []Item) []ClusterSummary {
 		return summaries[i].FailureClusterKey < summaries[j].FailureClusterKey
 	})
 	return summaries
+}
+
+func AttachClusterHistory(summaries []ClusterSummary, historicalRuns []ClusterHistoryRun) []ClusterSummary {
+	enriched := append([]ClusterSummary(nil), summaries...)
+	for i := range enriched {
+		enriched[i].History = buildClusterHistory(enriched[i], historicalRuns)
+	}
+	return enriched
+}
+
+func buildClusterHistory(summary ClusterSummary, historicalRuns []ClusterHistoryRun) ClusterHistory {
+	history := ClusterHistory{
+		Trend:          ClusterTrendNew,
+		WindowRunCount: len(historicalRuns),
+	}
+	for _, run := range historicalRuns {
+		for _, historicalCluster := range run.Clusters {
+			if historicalCluster.FailureClusterKey != summary.FailureClusterKey {
+				continue
+			}
+			history.PriorRunCount++
+			history.PriorFailureCount += historicalCluster.Count
+			if history.LastSeenRunID == nil {
+				runID := run.RunID
+				observedAt := run.ObservedAt
+				history.LastSeenRunID = &runID
+				history.LastSeenAt = &observedAt
+				history.LastRunFailureCount = historicalCluster.Count
+			}
+			break
+		}
+	}
+	if history.PriorRunCount == 0 {
+		return history
+	}
+	if summary.Count > history.LastRunFailureCount {
+		history.Trend = ClusterTrendIncreasing
+	} else if summary.Count < history.LastRunFailureCount {
+		history.Trend = ClusterTrendDecreasing
+	} else {
+		history.Trend = ClusterTrendRecurring
+	}
+	return history
 }
 
 func EncodeCursor(key CursorKey) (string, error) {

--- a/backend/internal/failurereview/read_model.go
+++ b/backend/internal/failurereview/read_model.go
@@ -76,20 +76,20 @@ type Item struct {
 }
 
 type ClusterSummary struct {
-	FailureClusterKey                string         `json:"failure_cluster_key"`
-	RepresentativeFailureFingerprint string         `json:"representative_failure_fingerprint"`
-	Count                            int            `json:"count"`
-	PromotableCount                  int            `json:"promotable_count"`
-	Severity                         Severity       `json:"severity"`
-	FailureState                     FailureState   `json:"failure_state"`
-	FailureClass                     FailureClass   `json:"failure_class"`
-	EvidenceTier                     EvidenceTier   `json:"evidence_tier"`
-	ChallengeKeys                    []string       `json:"challenge_keys"`
-	CaseKeys                         []string       `json:"case_keys"`
-	RunAgentIDs                      []string       `json:"run_agent_ids"`
-	Headline                         string         `json:"headline"`
-	RecommendedAction                string         `json:"recommended_action"`
-	History                          ClusterHistory `json:"history"`
+	FailureClusterKey                string          `json:"failure_cluster_key"`
+	RepresentativeFailureFingerprint string          `json:"representative_failure_fingerprint"`
+	Count                            int             `json:"count"`
+	PromotableCount                  int             `json:"promotable_count"`
+	Severity                         Severity        `json:"severity"`
+	FailureState                     FailureState    `json:"failure_state"`
+	FailureClass                     FailureClass    `json:"failure_class"`
+	EvidenceTier                     EvidenceTier    `json:"evidence_tier"`
+	ChallengeKeys                    []string        `json:"challenge_keys"`
+	CaseKeys                         []string        `json:"case_keys"`
+	RunAgentIDs                      []string        `json:"run_agent_ids"`
+	Headline                         string          `json:"headline"`
+	RecommendedAction                string          `json:"recommended_action"`
+	History                          *ClusterHistory `json:"history,omitempty"`
 }
 
 type ClusterTrend string
@@ -108,7 +108,7 @@ type ClusterHistory struct {
 	PriorFailureCount   int          `json:"prior_failure_count"`
 	LastSeenRunID       *uuid.UUID   `json:"last_seen_run_id,omitempty"`
 	LastSeenAt          *time.Time   `json:"last_seen_at,omitempty"`
-	LastRunFailureCount int          `json:"last_run_failure_count,omitempty"`
+	LastRunFailureCount int          `json:"last_run_failure_count"`
 }
 
 type ClusterHistoryRun struct {
@@ -448,7 +448,8 @@ func BuildClusterSummaries(items []Item) []ClusterSummary {
 func AttachClusterHistory(summaries []ClusterSummary, historicalRuns []ClusterHistoryRun) []ClusterSummary {
 	enriched := append([]ClusterSummary(nil), summaries...)
 	for i := range enriched {
-		enriched[i].History = buildClusterHistory(enriched[i], historicalRuns)
+		history := buildClusterHistory(enriched[i], historicalRuns)
+		enriched[i].History = &history
 	}
 	return enriched
 }

--- a/backend/internal/failurereview/read_model_test.go
+++ b/backend/internal/failurereview/read_model_test.go
@@ -436,6 +436,9 @@ func TestAttachClusterHistoryLabelsNewAndRecurringTrends(t *testing.T) {
 				Count:             tt.currentCount,
 			}}, historicalRuns)
 			history := summaries[0].History
+			if history == nil {
+				t.Fatal("history = nil, want populated")
+			}
 
 			if history.Trend != tt.wantTrend {
 				t.Fatalf("trend = %s, want %s", history.Trend, tt.wantTrend)

--- a/backend/internal/failurereview/read_model_test.go
+++ b/backend/internal/failurereview/read_model_test.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/domain"
 	"github.com/google/uuid"
@@ -361,6 +362,117 @@ func TestBuildClusterSummariesGroupsAndSortsDeterministically(t *testing.T) {
 	if summaries[1].RepresentativeFailureFingerprint != "frf-b1" {
 		t.Fatalf("representative fingerprint = %q, want first matching fingerprint", summaries[1].RepresentativeFailureFingerprint)
 	}
+}
+
+func TestAttachClusterHistoryLabelsNewAndRecurringTrends(t *testing.T) {
+	t.Parallel()
+
+	mostRecent := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	older := mostRecent.Add(-24 * time.Hour)
+	mostRecentRunID := uuid.New()
+	olderRunID := uuid.New()
+
+	testCases := []struct {
+		name             string
+		currentCount     int
+		historicalCounts []int
+		wantTrend        ClusterTrend
+		wantPriorRuns    int
+		wantPriorFails   int
+		wantLastCount    int
+	}{
+		{
+			name:         "new",
+			currentCount: 1,
+			wantTrend:    ClusterTrendNew,
+		},
+		{
+			name:             "increasing",
+			currentCount:     3,
+			historicalCounts: []int{1, 2},
+			wantTrend:        ClusterTrendIncreasing,
+			wantPriorRuns:    2,
+			wantPriorFails:   3,
+			wantLastCount:    1,
+		},
+		{
+			name:             "decreasing",
+			currentCount:     1,
+			historicalCounts: []int{3},
+			wantTrend:        ClusterTrendDecreasing,
+			wantPriorRuns:    1,
+			wantPriorFails:   3,
+			wantLastCount:    3,
+		},
+		{
+			name:             "recurring",
+			currentCount:     2,
+			historicalCounts: []int{2},
+			wantTrend:        ClusterTrendRecurring,
+			wantPriorRuns:    1,
+			wantPriorFails:   2,
+			wantLastCount:    2,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			historicalRuns := []ClusterHistoryRun{
+				{
+					RunID:      mostRecentRunID,
+					ObservedAt: mostRecent,
+					Clusters:   historicalCluster("frc-target", tt.historicalCounts, 0),
+				},
+				{
+					RunID:      olderRunID,
+					ObservedAt: older,
+					Clusters:   historicalCluster("frc-target", tt.historicalCounts, 1),
+				},
+			}
+			summaries := AttachClusterHistory([]ClusterSummary{{
+				FailureClusterKey: "frc-target",
+				Count:             tt.currentCount,
+			}}, historicalRuns)
+			history := summaries[0].History
+
+			if history.Trend != tt.wantTrend {
+				t.Fatalf("trend = %s, want %s", history.Trend, tt.wantTrend)
+			}
+			if history.WindowRunCount != 2 {
+				t.Fatalf("window_run_count = %d, want 2", history.WindowRunCount)
+			}
+			if history.PriorRunCount != tt.wantPriorRuns || history.PriorFailureCount != tt.wantPriorFails {
+				t.Fatalf("prior counts = %d/%d, want %d/%d", history.PriorRunCount, history.PriorFailureCount, tt.wantPriorRuns, tt.wantPriorFails)
+			}
+			if tt.wantPriorRuns == 0 {
+				if history.LastSeenRunID != nil || history.LastSeenAt != nil {
+					t.Fatalf("last seen = %v/%v, want nils for new cluster", history.LastSeenRunID, history.LastSeenAt)
+				}
+				return
+			}
+			if history.LastSeenRunID == nil || *history.LastSeenRunID != mostRecentRunID {
+				t.Fatalf("last_seen_run_id = %v, want %s", history.LastSeenRunID, mostRecentRunID)
+			}
+			if history.LastSeenAt == nil || !history.LastSeenAt.Equal(mostRecent) {
+				t.Fatalf("last_seen_at = %v, want %s", history.LastSeenAt, mostRecent)
+			}
+			if history.LastRunFailureCount != tt.wantLastCount {
+				t.Fatalf("last_run_failure_count = %d, want %d", history.LastRunFailureCount, tt.wantLastCount)
+			}
+		})
+	}
+}
+
+func historicalCluster(key string, counts []int, index int) []ClusterSummary {
+	if index >= len(counts) {
+		return nil
+	}
+	return []ClusterSummary{{
+		FailureClusterKey: key,
+		Count:             counts[index],
+	}}
 }
 
 func TestBuildRunAgentItemsHandlesHostedBlackBoxEligibility(t *testing.T) {

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -2468,6 +2468,27 @@ func (r *Repository) ListRunsByWorkspaceID(ctx context.Context, workspaceID uuid
 	return runs, nil
 }
 
+func (r *Repository) ListRecentComparableScoredRunsBeforeRunID(ctx context.Context, runID uuid.UUID, limit int32) ([]domain.Run, error) {
+	rows, err := r.queries.ListRecentComparableScoredRunsBeforeRunID(ctx, repositorysqlc.ListRecentComparableScoredRunsBeforeRunIDParams{
+		RunID:       runID,
+		ResultLimit: limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list recent comparable scored runs before run id: %w", err)
+	}
+
+	runs := make([]domain.Run, 0, len(rows))
+	for _, row := range rows {
+		run, mapErr := mapRun(row)
+		if mapErr != nil {
+			return nil, fmt.Errorf("map run %s: %w", row.ID, mapErr)
+		}
+		runs = append(runs, run)
+	}
+
+	return runs, nil
+}
+
 func (r *Repository) CountRunsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (int64, error) {
 	count, err := r.queries.CountRunsByWorkspaceID(ctx, repositorysqlc.CountRunsByWorkspaceIDParams{
 		WorkspaceID: workspaceID,

--- a/backend/internal/repository/repository_integration_test.go
+++ b/backend/internal/repository/repository_integration_test.go
@@ -49,6 +49,41 @@ func TestRepositoryGetRunByID(t *testing.T) {
 	}
 }
 
+func TestRepositoryListRecentComparableScoredRunsBeforeRunID(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+	evaluationSpecID := insertEvaluationSpecRecord(t, ctx, db, fixture.challengePackVersionID, "cluster-trend", 1)
+	baseTime := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+
+	anchor, _ := createTestRun(t, ctx, repo, fixture, 1, "cluster-trend-anchor")
+	setRunForClusterTrendTest(t, ctx, db, anchor.ID, domain.RunStatusCompleted, baseTime)
+
+	priorScored, _ := createTestRun(t, ctx, repo, fixture, 1, "cluster-trend-prior")
+	setRunForClusterTrendTest(t, ctx, db, priorScored.ID, domain.RunStatusCompleted, baseTime.Add(-time.Hour))
+	insertRunScorecardRecord(t, ctx, db, priorScored.ID, evaluationSpecID, map[string]any{"status": "complete"})
+
+	unscored, _ := createTestRun(t, ctx, repo, fixture, 1, "cluster-trend-unscored")
+	setRunForClusterTrendTest(t, ctx, db, unscored.ID, domain.RunStatusCompleted, baseTime.Add(-2*time.Hour))
+
+	queuedScored, _ := createTestRun(t, ctx, repo, fixture, 1, "cluster-trend-queued")
+	setRunForClusterTrendTest(t, ctx, db, queuedScored.ID, domain.RunStatusQueued, baseTime.Add(-3*time.Hour))
+	insertRunScorecardRecord(t, ctx, db, queuedScored.ID, evaluationSpecID, map[string]any{"status": "complete"})
+
+	laterScored, _ := createTestRun(t, ctx, repo, fixture, 1, "cluster-trend-later")
+	setRunForClusterTrendTest(t, ctx, db, laterScored.ID, domain.RunStatusCompleted, baseTime.Add(time.Hour))
+	insertRunScorecardRecord(t, ctx, db, laterScored.ID, evaluationSpecID, map[string]any{"status": "complete"})
+
+	got, err := repo.ListRecentComparableScoredRunsBeforeRunID(ctx, anchor.ID, 10)
+	if err != nil {
+		t.Fatalf("ListRecentComparableScoredRunsBeforeRunID returned error: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != priorScored.ID {
+		t.Fatalf("recent comparable runs = %#v, want only prior scored completed run %s", got, priorScored.ID)
+	}
+}
+
 func TestRepositoryListRunRegressionCoverageCasesByRunID(t *testing.T) {
 	ctx := context.Background()
 	db := openTestDB(t)
@@ -3877,6 +3912,25 @@ func createTestRun(
 		t.Fatalf("CreateQueuedRun returned error: %v", err)
 	}
 	return result.Run, result.RunAgents
+}
+
+func setRunForClusterTrendTest(t *testing.T, ctx context.Context, db *pgxpool.Pool, runID uuid.UUID, status domain.RunStatus, observedAt time.Time) {
+	t.Helper()
+
+	var finishedAt *time.Time
+	if status == domain.RunStatusCompleted {
+		finishedAt = &observedAt
+	}
+	if _, err := db.Exec(ctx, `
+		UPDATE runs
+		SET status = $2,
+		    created_at = $3,
+		    started_at = $3,
+		    finished_at = $4
+		WHERE id = $1
+	`, runID, string(status), observedAt, finishedAt); err != nil {
+		t.Fatalf("set run %s for cluster trend test returned error: %v", runID, err)
+	}
 }
 
 func insertEvaluationSpecRecord(

--- a/backend/internal/repository/sqlc/querier.go
+++ b/backend/internal/repository/sqlc/querier.go
@@ -76,6 +76,7 @@ type Querier interface {
 	ListPlaygroundExperimentsByPlaygroundID(ctx context.Context, arg ListPlaygroundExperimentsByPlaygroundIDParams) ([]PlaygroundExperiment, error)
 	ListPlaygroundTestCasesByPlaygroundID(ctx context.Context, arg ListPlaygroundTestCasesByPlaygroundIDParams) ([]PlaygroundTestCase, error)
 	ListPlaygroundsByWorkspaceID(ctx context.Context, arg ListPlaygroundsByWorkspaceIDParams) ([]Playground, error)
+	ListRecentComparableScoredRunsBeforeRunID(ctx context.Context, arg ListRecentComparableScoredRunsBeforeRunIDParams) ([]Run, error)
 	ListRegressionCaseValidationStatsBySuiteID(ctx context.Context, arg ListRegressionCaseValidationStatsBySuiteIDParams) ([]ListRegressionCaseValidationStatsBySuiteIDRow, error)
 	ListRegressionCasesBySuiteID(ctx context.Context, arg ListRegressionCasesBySuiteIDParams) ([]ListRegressionCasesBySuiteIDRow, error)
 	ListRegressionSuitesByWorkspaceID(ctx context.Context, arg ListRegressionSuitesByWorkspaceIDParams) ([]WorkspaceRegressionSuite, error)

--- a/backend/internal/repository/sqlc/runs.sql.go
+++ b/backend/internal/repository/sqlc/runs.sql.go
@@ -309,7 +309,6 @@ WHERE r.id <> a.id
       SELECT 1
       FROM run_scorecards AS rs
       WHERE rs.run_id = r.id
-        AND rs.winning_run_agent_id IS NOT NULL
   )
 ORDER BY r.created_at DESC, r.id DESC
 LIMIT $1

--- a/backend/internal/repository/sqlc/runs.sql.go
+++ b/backend/internal/repository/sqlc/runs.sql.go
@@ -287,6 +287,84 @@ func (q *Queries) InsertRunStatusHistory(ctx context.Context, arg InsertRunStatu
 	return i, err
 }
 
+const listRecentComparableScoredRunsBeforeRunID = `-- name: ListRecentComparableScoredRunsBeforeRunID :many
+WITH anchor AS (
+    SELECT
+        runs.workspace_id,
+        runs.challenge_pack_version_id,
+        runs.created_at,
+        runs.id
+    FROM runs
+    WHERE runs.id = $2
+)
+SELECT r.id, r.organization_id, r.workspace_id, r.challenge_pack_version_id, r.challenge_input_set_id, r.created_by_user_id, r.name, r.status, r.execution_mode, r.temporal_workflow_id, r.temporal_run_id, r.execution_plan, r.queued_at, r.started_at, r.finished_at, r.cancelled_at, r.failed_at, r.created_at, r.updated_at, r.official_pack_mode, r.eval_session_id, r.race_context, r.race_context_min_step_gap, r.ci_metadata
+FROM runs AS r
+JOIN anchor AS a
+  ON r.workspace_id = a.workspace_id
+ AND r.challenge_pack_version_id = a.challenge_pack_version_id
+WHERE r.id <> a.id
+  AND r.status = 'completed'
+  AND (r.created_at, r.id) < (a.created_at, a.id)
+  AND EXISTS (
+      SELECT 1
+      FROM run_scorecards AS rs
+      WHERE rs.run_id = r.id
+        AND rs.winning_run_agent_id IS NOT NULL
+  )
+ORDER BY r.created_at DESC, r.id DESC
+LIMIT $1
+`
+
+type ListRecentComparableScoredRunsBeforeRunIDParams struct {
+	ResultLimit int32
+	RunID       uuid.UUID
+}
+
+func (q *Queries) ListRecentComparableScoredRunsBeforeRunID(ctx context.Context, arg ListRecentComparableScoredRunsBeforeRunIDParams) ([]Run, error) {
+	rows, err := q.db.Query(ctx, listRecentComparableScoredRunsBeforeRunID, arg.ResultLimit, arg.RunID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Run
+	for rows.Next() {
+		var i Run
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrganizationID,
+			&i.WorkspaceID,
+			&i.ChallengePackVersionID,
+			&i.ChallengeInputSetID,
+			&i.CreatedByUserID,
+			&i.Name,
+			&i.Status,
+			&i.ExecutionMode,
+			&i.TemporalWorkflowID,
+			&i.TemporalRunID,
+			&i.ExecutionPlan,
+			&i.QueuedAt,
+			&i.StartedAt,
+			&i.FinishedAt,
+			&i.CancelledAt,
+			&i.FailedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.OfficialPackMode,
+			&i.EvalSessionID,
+			&i.RaceContext,
+			&i.RaceContextMinStepGap,
+			&i.CiMetadata,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listRunCaseSelectionsByRunID = `-- name: ListRunCaseSelectionsByRunID :many
 SELECT id, run_id, challenge_identity_id, selection_origin, regression_case_id, selection_rank, created_at
 FROM run_case_selections

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -408,13 +408,16 @@ var runFailuresCmd = &cobra.Command{
 		rc.Output.PrintTable(cols, rows)
 		if len(result.Clusters) > 0 {
 			rc.Output.PrintDetail("Failure Clusters (filtered)", fmt.Sprintf("%d", len(result.Clusters)))
-			clusterCols := []output.Column{{Header: "Cluster"}, {Header: "Count"}, {Header: "Promotable"}, {Header: "Severity"}, {Header: "Class"}, {Header: "Challenges"}}
+			clusterCols := []output.Column{{Header: "Cluster"}, {Header: "Count"}, {Header: "Promotable"}, {Header: "Trend"}, {Header: "Prior Runs"}, {Header: "Severity"}, {Header: "Class"}, {Header: "Challenges"}}
 			clusterRows := make([][]string, len(result.Clusters))
 			for i, cluster := range result.Clusters {
+				history := mapObject(cluster, "history")
 				clusterRows[i] = []string{
 					str(cluster["failure_cluster_key"]),
 					str(cluster["count"]),
 					str(cluster["promotable_count"]),
+					mapString(history, "trend"),
+					mapString(history, "prior_run_count"),
 					str(cluster["severity"]),
 					str(cluster["failure_class"]),
 					joinMapStrings(cluster, "challenge_keys"),

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -6594,6 +6594,7 @@ components:
         - window_run_count
         - prior_run_count
         - prior_failure_count
+        - last_run_failure_count
       properties:
         trend:
           type: string
@@ -6638,7 +6639,6 @@ components:
         - run_agent_ids
         - headline
         - recommended_action
-        - history
       properties:
         failure_cluster_key:
           type: string
@@ -6679,6 +6679,7 @@ components:
         recommended_action:
           type: string
         history:
+          description: Present on first-page all-agent failure-cluster responses; omitted on cursor pages and agent-filtered views.
           $ref: "#/components/schemas/FailureReviewClusterHistory"
 
     ListRunFailuresResponse:

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -6587,6 +6587,41 @@ components:
           type: string
           enum: [info, warning, blocking]
 
+    FailureReviewClusterHistory:
+      type: object
+      required:
+        - trend
+        - window_run_count
+        - prior_run_count
+        - prior_failure_count
+      properties:
+        trend:
+          type: string
+          enum: [new, recurring, increasing, decreasing]
+          description: Directional label comparing the current cluster count with the most recent prior occurrence.
+        window_run_count:
+          type: integer
+          format: int32
+          description: Number of prior comparable scored runs scanned for this cluster.
+        prior_run_count:
+          type: integer
+          format: int32
+          description: Number of scanned prior runs where this cluster appeared.
+        prior_failure_count:
+          type: integer
+          format: int32
+          description: Total failures from this cluster across scanned prior runs.
+        last_seen_run_id:
+          type: string
+          format: uuid
+        last_seen_at:
+          type: string
+          format: date-time
+        last_run_failure_count:
+          type: integer
+          format: int32
+          description: Failure count from the most recent prior run containing this cluster.
+
     FailureReviewClusterSummary:
       type: object
       required:
@@ -6603,6 +6638,7 @@ components:
         - run_agent_ids
         - headline
         - recommended_action
+        - history
       properties:
         failure_cluster_key:
           type: string
@@ -6642,6 +6678,8 @@ components:
           type: string
         recommended_action:
           type: string
+        history:
+          $ref: "#/components/schemas/FailureReviewClusterHistory"
 
     ListRunFailuresResponse:
       type: object

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.test.tsx
@@ -121,6 +121,15 @@ function makeCluster(
     run_agent_ids: ["agent-1"],
     headline: "Filesystem write failures cluster together",
     recommended_action: "Promote one representative filesystem regression.",
+    history: {
+      trend: "increasing",
+      window_run_count: 10,
+      prior_run_count: 3,
+      prior_failure_count: 5,
+      last_seen_run_id: "run-prev",
+      last_seen_at: "2026-04-21T12:00:00Z",
+      last_run_failure_count: 1,
+    },
     ...overrides,
   };
 }
@@ -226,6 +235,10 @@ describe("FailuresClient", () => {
       expect(view.container.textContent).toContain("1 promotable");
       expect(view.container.textContent).toContain(
         "Filesystem write failures cluster together",
+      );
+      expect(view.container.textContent).toContain("increasing");
+      expect(view.container.textContent).toContain(
+        "3 prior runs · 5 prior failures",
       );
       expect(view.container.textContent).toContain("challenge-a, challenge-b");
       expect(view.container.textContent).toContain(

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.tsx
@@ -80,9 +80,13 @@ function compactList(values: string[], maxVisible = 3): string {
   return `${visible} +${values.length - maxVisible}`;
 }
 
-function clusterHistorySummary(cluster: FailureReviewClusterSummary): string {
-  const { history } = cluster;
+function clusterHistorySummary(
+  history: NonNullable<FailureReviewClusterSummary["history"]>,
+): string {
   if (history.prior_run_count === 0) {
+    if (history.window_run_count === 0) {
+      return "First scored run for this pack";
+    }
     const runLabel = history.window_run_count === 1 ? "run" : "runs";
     return `No prior matches in ${history.window_run_count} comparable ${runLabel}`;
   }
@@ -112,7 +116,7 @@ const failureStateVariant: Record<
 };
 
 const clusterTrendVariant: Record<
-  FailureReviewClusterSummary["history"]["trend"],
+  NonNullable<FailureReviewClusterSummary["history"]>["trend"],
   "default" | "secondary" | "outline" | "destructive"
 > = {
   new: "default",
@@ -463,6 +467,7 @@ function FailureClusterRollups({
       <ul className="divide-y divide-border">
         {clusters.map((cluster) => {
           const active = cluster.failure_cluster_key === activeClusterKey;
+          const history = cluster.history;
           return (
             <li key={cluster.failure_cluster_key}>
               <button
@@ -493,9 +498,11 @@ function FailureClusterRollups({
                     <Badge variant="secondary">
                       {humanize(cluster.evidence_tier)}
                     </Badge>
-                    <Badge variant={clusterTrendVariant[cluster.history.trend]}>
-                      {humanize(cluster.history.trend)}
-                    </Badge>
+                    {history && (
+                      <Badge variant={clusterTrendVariant[history.trend]}>
+                        {humanize(history.trend)}
+                      </Badge>
+                    )}
                     {active && <Badge>active</Badge>}
                   </div>
                   <div className="min-w-0">
@@ -509,12 +516,14 @@ function FailureClusterRollups({
                     )}
                   </div>
                   <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
-                    <span className="min-w-0 truncate">
-                      History:{" "}
-                      <span className="text-foreground/80">
-                        {clusterHistorySummary(cluster)}
+                    {history && (
+                      <span className="min-w-0 truncate">
+                        History:{" "}
+                        <span className="text-foreground/80">
+                          {clusterHistorySummary(history)}
+                        </span>
                       </span>
-                    </span>
+                    )}
                     <span className="min-w-0 truncate">
                       Challenges:{" "}
                       <span className="text-foreground/80">
@@ -546,14 +555,16 @@ function FailureClusterRollups({
                       promote
                     </div>
                   </div>
-                  <div className="rounded-md border border-border px-2.5 py-1 text-right">
-                    <div className="text-sm font-semibold tabular-nums">
-                      {cluster.history.prior_run_count}
+                  {history && (
+                    <div className="rounded-md border border-border px-2.5 py-1 text-right">
+                      <div className="text-sm font-semibold tabular-nums">
+                        {history.prior_run_count}
+                      </div>
+                      <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                        prior
+                      </div>
                     </div>
-                    <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-                      prior
-                    </div>
-                  </div>
+                  )}
                 </div>
               </button>
             </li>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.tsx
@@ -80,6 +80,18 @@ function compactList(values: string[], maxVisible = 3): string {
   return `${visible} +${values.length - maxVisible}`;
 }
 
+function clusterHistorySummary(cluster: FailureReviewClusterSummary): string {
+  const { history } = cluster;
+  if (history.prior_run_count === 0) {
+    const runLabel = history.window_run_count === 1 ? "run" : "runs";
+    return `No prior matches in ${history.window_run_count} comparable ${runLabel}`;
+  }
+  const lastSeen = history.last_seen_at
+    ? ` · last ${new Date(history.last_seen_at).toLocaleDateString()}`
+    : "";
+  return `${history.prior_run_count} prior runs · ${history.prior_failure_count} prior failures${lastSeen}`;
+}
+
 const severityVariant: Record<
   FailureReviewSeverity,
   "default" | "secondary" | "outline" | "destructive"
@@ -97,6 +109,16 @@ const failureStateVariant: Record<
   warning: "outline",
   flaky: "outline",
   incomplete_evidence: "secondary",
+};
+
+const clusterTrendVariant: Record<
+  FailureReviewClusterSummary["history"]["trend"],
+  "default" | "secondary" | "outline" | "destructive"
+> = {
+  new: "default",
+  recurring: "secondary",
+  increasing: "destructive",
+  decreasing: "outline",
 };
 
 // --- URL <-> state helpers ---
@@ -471,6 +493,9 @@ function FailureClusterRollups({
                     <Badge variant="secondary">
                       {humanize(cluster.evidence_tier)}
                     </Badge>
+                    <Badge variant={clusterTrendVariant[cluster.history.trend]}>
+                      {humanize(cluster.history.trend)}
+                    </Badge>
                     {active && <Badge>active</Badge>}
                   </div>
                   <div className="min-w-0">
@@ -484,6 +509,12 @@ function FailureClusterRollups({
                     )}
                   </div>
                   <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                    <span className="min-w-0 truncate">
+                      History:{" "}
+                      <span className="text-foreground/80">
+                        {clusterHistorySummary(cluster)}
+                      </span>
+                    </span>
                     <span className="min-w-0 truncate">
                       Challenges:{" "}
                       <span className="text-foreground/80">
@@ -513,6 +544,14 @@ function FailureClusterRollups({
                     </div>
                     <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
                       promote
+                    </div>
+                  </div>
+                  <div className="rounded-md border border-border px-2.5 py-1 text-right">
+                    <div className="text-sm font-semibold tabular-nums">
+                      {cluster.history.prior_run_count}
+                    </div>
+                    <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                      prior
                     </div>
                   </div>
                 </div>

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -1711,7 +1711,7 @@ export interface FailureReviewClusterHistory {
   prior_failure_count: number;
   last_seen_run_id?: string;
   last_seen_at?: string;
-  last_run_failure_count?: number;
+  last_run_failure_count: number;
 }
 
 export interface FailureReviewClusterSummary {

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -1698,6 +1698,22 @@ export interface FailureReviewItem {
   severity: FailureReviewSeverity;
 }
 
+export type FailureReviewClusterTrend =
+  | "new"
+  | "recurring"
+  | "increasing"
+  | "decreasing";
+
+export interface FailureReviewClusterHistory {
+  trend: FailureReviewClusterTrend;
+  window_run_count: number;
+  prior_run_count: number;
+  prior_failure_count: number;
+  last_seen_run_id?: string;
+  last_seen_at?: string;
+  last_run_failure_count?: number;
+}
+
 export interface FailureReviewClusterSummary {
   failure_cluster_key: string;
   representative_failure_fingerprint: string;
@@ -1712,6 +1728,7 @@ export interface FailureReviewClusterSummary {
   run_agent_ids: string[];
   headline: string;
   recommended_action: string;
+  history: FailureReviewClusterHistory;
 }
 
 export interface ListRunFailuresResponse {

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -1728,7 +1728,7 @@ export interface FailureReviewClusterSummary {
   run_agent_ids: string[];
   headline: string;
   recommended_action: string;
-  history: FailureReviewClusterHistory;
+  history?: FailureReviewClusterHistory;
 }
 
 export interface ListRunFailuresResponse {


### PR DESCRIPTION
## Summary
- derive bounded historical trend signal for failure clusters from recent comparable scored runs
- expose cluster history in the failure review API, OpenAPI schema, and TS types
- show trend and prior-run signal in the web failure cluster rollups and CLI cluster table
- cover trend helper, API enrichment, CLI, and web behavior with tests

## Review Checkpoint
- Contract: `/tmp/reviewcheckpoint-issue-82-cluster-trends-contract.md`
- Checkpoint: `/tmp/reviewcheckpoint-issue-82-cluster-trends.json`

## Tests
- `git diff --check`
- `go test ./internal/failurereview ./internal/api ./internal/repository`
- `go vet ./...`
- `go test ./...`
- `go test ./...` from `cli/`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run build`

Part of #82.
