### PR TITLE
feat(regression): surface maintenance status

### DIFF
--- a/backend/internal/api/regression_suites.go
+++ b/backend/internal/api/regression_suites.go
@@ -972,7 +972,7 @@ func buildRegressionCaseValidationResponse(stats *repository.RegressionCaseValid
 		RequiredRuns:          regressionValidationRequiredRuns,
 		RemainingRuns:         regressionValidationRequiredRuns,
 		RecommendedAction:     "Run this regression case in CI or suite-only mode to establish a reproduction signal.",
-		MaintenanceAction:     "Collect validation evidence before changing this case's suite role.",
+		MaintenanceAction:     "Schedule more reruns before changing this case's suite role.",
 	}
 	if stats == nil || stats.RunCount == 0 {
 		return response
@@ -1000,17 +1000,17 @@ func buildRegressionCaseValidationResponse(stats *repository.RegressionCaseValid
 		response.Status = regressionValidationStatusReproducing
 		response.MaintenanceStatus = regressionMaintenanceStatusKeepActive
 		response.RecommendedAction = "Failure reproduces at or above threshold; keep this case active in CI gates."
-		response.MaintenanceAction = "Keep this case active; it is still catching a reproducible agent failure."
+		response.MaintenanceAction = "Leave this case in the active gate set."
 	case stats.FailureCount == 0:
 		response.Status = regressionValidationStatusPassing
 		response.MaintenanceStatus = regressionMaintenanceStatusPruneCandidate
 		response.RecommendedAction = "No failures observed across the validation window; keep as a guardrail or archive if obsolete."
-		response.MaintenanceAction = "Review for pruning or downgrade to a non-blocking guardrail if the behavior is now stable."
+		response.MaintenanceAction = "Open a pruning review before archiving or downgrading it."
 	default:
 		response.Status = regressionValidationStatusFlaky
 		response.MaintenanceStatus = regressionMaintenanceStatusReviewFlaky
 		response.RecommendedAction = "Mixed outcomes are below the reproduction threshold; inspect replay evidence before making this case blocking."
-		response.MaintenanceAction = "Inspect recent replays before deciding whether to keep, mute, or rewrite this case."
+		response.MaintenanceAction = "Rewrite, split, or mute this case if replay evidence is nondeterministic."
 	}
 	return response
 }

--- a/backend/internal/api/regression_suites.go
+++ b/backend/internal/api/regression_suites.go
@@ -524,6 +524,7 @@ type regressionCaseResponse struct {
 
 type regressionCaseValidationResponse struct {
 	Status                string     `json:"status"`
+	MaintenanceStatus     string     `json:"maintenance_status"`
 	RunCount              int        `json:"run_count"`
 	FailureCount          int        `json:"failure_count"`
 	PassCount             int        `json:"pass_count"`
@@ -534,6 +535,7 @@ type regressionCaseValidationResponse struct {
 	LastOutcome           *string    `json:"last_outcome,omitempty"`
 	LastValidatedAt       *time.Time `json:"last_validated_at,omitempty"`
 	RecommendedAction     string     `json:"recommended_action"`
+	MaintenanceAction     string     `json:"maintenance_action"`
 }
 
 type listRegressionSuitesResponse struct {
@@ -955,15 +957,22 @@ const (
 	regressionValidationStatusReproducing      = "reproducing"
 	regressionValidationStatusPassing          = "passing"
 	regressionValidationStatusFlaky            = "flaky"
+
+	regressionMaintenanceStatusNeedsSignal    = "needs_signal"
+	regressionMaintenanceStatusKeepActive     = "keep_active"
+	regressionMaintenanceStatusPruneCandidate = "prune_candidate"
+	regressionMaintenanceStatusReviewFlaky    = "review_flaky"
 )
 
 func buildRegressionCaseValidationResponse(stats *repository.RegressionCaseValidationStats) regressionCaseValidationResponse {
 	response := regressionCaseValidationResponse{
 		Status:                regressionValidationStatusNotValidated,
+		MaintenanceStatus:     regressionMaintenanceStatusNeedsSignal,
 		ReproductionThreshold: regressionValidationReproductionThreshold,
 		RequiredRuns:          regressionValidationRequiredRuns,
 		RemainingRuns:         regressionValidationRequiredRuns,
 		RecommendedAction:     "Run this regression case in CI or suite-only mode to establish a reproduction signal.",
+		MaintenanceAction:     "Collect validation evidence before changing this case's suite role.",
 	}
 	if stats == nil || stats.RunCount == 0 {
 		return response
@@ -984,16 +993,24 @@ func buildRegressionCaseValidationResponse(stats *repository.RegressionCaseValid
 	switch {
 	case stats.RunCount < regressionValidationRequiredRuns:
 		response.Status = regressionValidationStatusCollectingSignal
+		response.MaintenanceStatus = regressionMaintenanceStatusNeedsSignal
 		response.RecommendedAction = fmt.Sprintf("Collect %d more scored run(s) before treating this case as statistically validated.", response.RemainingRuns)
+		response.MaintenanceAction = "Keep this case in evidence-gathering mode until the validation window is full."
 	case stats.ReproductionRate >= regressionValidationReproductionThreshold:
 		response.Status = regressionValidationStatusReproducing
+		response.MaintenanceStatus = regressionMaintenanceStatusKeepActive
 		response.RecommendedAction = "Failure reproduces at or above threshold; keep this case active in CI gates."
+		response.MaintenanceAction = "Keep this case active; it is still catching a reproducible agent failure."
 	case stats.FailureCount == 0:
 		response.Status = regressionValidationStatusPassing
+		response.MaintenanceStatus = regressionMaintenanceStatusPruneCandidate
 		response.RecommendedAction = "No failures observed across the validation window; keep as a guardrail or archive if obsolete."
+		response.MaintenanceAction = "Review for pruning or downgrade to a non-blocking guardrail if the behavior is now stable."
 	default:
 		response.Status = regressionValidationStatusFlaky
+		response.MaintenanceStatus = regressionMaintenanceStatusReviewFlaky
 		response.RecommendedAction = "Mixed outcomes are below the reproduction threshold; inspect replay evidence before making this case blocking."
+		response.MaintenanceAction = "Inspect recent replays before deciding whether to keep, mute, or rewrite this case."
 	}
 	return response
 }

--- a/backend/internal/api/regression_suites_test.go
+++ b/backend/internal/api/regression_suites_test.go
@@ -718,6 +718,12 @@ func TestRegressionSuiteEndpointsRoundTrip(t *testing.T) {
 	if validation.Status != regressionValidationStatusReproducing {
 		t.Fatalf("validation status = %q, want %q", validation.Status, regressionValidationStatusReproducing)
 	}
+	if validation.MaintenanceStatus != regressionMaintenanceStatusKeepActive {
+		t.Fatalf("maintenance status = %q, want %q", validation.MaintenanceStatus, regressionMaintenanceStatusKeepActive)
+	}
+	if validation.MaintenanceAction == "" {
+		t.Fatal("maintenance action is empty")
+	}
 	if validation.RunCount != 5 || validation.FailureCount != 3 || validation.PassCount != 2 {
 		t.Fatalf("validation counts = %+v, want 5/3/2", validation)
 	}
@@ -809,15 +815,17 @@ func TestRegressionFailureProvenanceFromMetadata(t *testing.T) {
 func TestBuildRegressionCaseValidationResponse(t *testing.T) {
 	validatedAt := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
 	tests := []struct {
-		name   string
-		stats  *repository.RegressionCaseValidationStats
-		status string
-		rate   *float64
+		name              string
+		stats             *repository.RegressionCaseValidationStats
+		status            string
+		maintenanceStatus string
+		rate              *float64
 	}{
 		{
-			name:   "not validated",
-			stats:  nil,
-			status: regressionValidationStatusNotValidated,
+			name:              "not validated",
+			stats:             nil,
+			status:            regressionValidationStatusNotValidated,
+			maintenanceStatus: regressionMaintenanceStatusNeedsSignal,
 		},
 		{
 			name: "collecting signal",
@@ -829,8 +837,9 @@ func TestBuildRegressionCaseValidationResponse(t *testing.T) {
 				LastOutcome:      "fail",
 				LastValidatedAt:  &validatedAt,
 			},
-			status: regressionValidationStatusCollectingSignal,
-			rate:   float64Ptr(2.0 / 3.0),
+			status:            regressionValidationStatusCollectingSignal,
+			maintenanceStatus: regressionMaintenanceStatusNeedsSignal,
+			rate:              float64Ptr(2.0 / 3.0),
 		},
 		{
 			name: "reproducing",
@@ -842,8 +851,9 @@ func TestBuildRegressionCaseValidationResponse(t *testing.T) {
 				LastOutcome:      "pass",
 				LastValidatedAt:  &validatedAt,
 			},
-			status: regressionValidationStatusReproducing,
-			rate:   float64Ptr(0.6),
+			status:            regressionValidationStatusReproducing,
+			maintenanceStatus: regressionMaintenanceStatusKeepActive,
+			rate:              float64Ptr(0.6),
 		},
 		{
 			name: "passing",
@@ -855,8 +865,9 @@ func TestBuildRegressionCaseValidationResponse(t *testing.T) {
 				LastOutcome:      "pass",
 				LastValidatedAt:  &validatedAt,
 			},
-			status: regressionValidationStatusPassing,
-			rate:   float64Ptr(0),
+			status:            regressionValidationStatusPassing,
+			maintenanceStatus: regressionMaintenanceStatusPruneCandidate,
+			rate:              float64Ptr(0),
 		},
 		{
 			name: "flaky",
@@ -868,8 +879,9 @@ func TestBuildRegressionCaseValidationResponse(t *testing.T) {
 				LastOutcome:      "fail",
 				LastValidatedAt:  &validatedAt,
 			},
-			status: regressionValidationStatusFlaky,
-			rate:   float64Ptr(0.4),
+			status:            regressionValidationStatusFlaky,
+			maintenanceStatus: regressionMaintenanceStatusReviewFlaky,
+			rate:              float64Ptr(0.4),
 		},
 	}
 
@@ -878,6 +890,12 @@ func TestBuildRegressionCaseValidationResponse(t *testing.T) {
 			got := buildRegressionCaseValidationResponse(tt.stats)
 			if got.Status != tt.status {
 				t.Fatalf("status = %q, want %q", got.Status, tt.status)
+			}
+			if got.MaintenanceStatus != tt.maintenanceStatus {
+				t.Fatalf("maintenance status = %q, want %q", got.MaintenanceStatus, tt.maintenanceStatus)
+			}
+			if got.MaintenanceAction == "" {
+				t.Fatal("maintenance action is empty")
 			}
 			if got.RequiredRuns != regressionValidationRequiredRuns {
 				t.Fatalf("required_runs = %d, want %d", got.RequiredRuns, regressionValidationRequiredRuns)

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -6892,6 +6892,7 @@ components:
       required:
         [
           status,
+          maintenance_status,
           run_count,
           failure_count,
           pass_count,
@@ -6899,6 +6900,7 @@ components:
           required_runs,
           remaining_runs,
           recommended_action,
+          maintenance_action,
         ]
       properties:
         status:
@@ -6911,6 +6913,16 @@ components:
               passing,
               flaky,
             ]
+        maintenance_status:
+          type: string
+          enum:
+            [
+              needs_signal,
+              keep_active,
+              prune_candidate,
+              review_flaky,
+            ]
+          description: Operational maintenance bucket derived from validation status.
         run_count:
           type: integer
           minimum: 0
@@ -6943,6 +6955,8 @@ components:
           type: string
           format: date-time
         recommended_action:
+          type: string
+        maintenance_action:
           type: string
 
     RegressionPromotion:

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/cases/[caseId]/case-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/cases/[caseId]/case-detail-client.tsx
@@ -10,6 +10,7 @@ import { PageHeader } from "@/components/ui/page-header";
 
 import {
   CaseStatusBadge,
+  MaintenanceBadge,
   SeverityBadge,
   ValidationBadge,
 } from "../../../badges";
@@ -97,6 +98,9 @@ export function CaseDetailClient({
           <MetaRow label="Status">
             <ValidationBadge status={c.validation.status} />
           </MetaRow>
+          <MetaRow label="Maintenance">
+            <MaintenanceBadge status={c.validation.maintenance_status} />
+          </MetaRow>
           <MetaRow label="Scored Runs">
             <span className="text-muted-foreground">
               {c.validation.run_count} ({c.validation.failure_count} fail /{" "}
@@ -130,6 +134,9 @@ export function CaseDetailClient({
         </dl>
         <p className="mt-3 text-sm text-muted-foreground">
           {c.validation.recommended_action}
+        </p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {c.validation.maintenance_action}
         </p>
       </Section>
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/suite-detail-client.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/suite-detail-client.test.tsx
@@ -115,8 +115,7 @@ function makeCase(overrides: Partial<RegressionCase> = {}): RegressionCase {
       last_validated_at: "2026-04-22T12:30:00Z",
       recommended_action:
         "Failure reproduces at or above threshold; keep this case active in CI gates.",
-      maintenance_action:
-        "Keep this case active; it is still catching a reproducible agent failure.",
+      maintenance_action: "Leave this case in the active gate set.",
     },
     created_at: "2026-04-22T12:00:00Z",
     updated_at: "2026-04-22T12:00:00Z",
@@ -184,8 +183,60 @@ describe("regression provenance UI", () => {
       expect(view.container.textContent).toContain("3 fail");
       expect(view.container.textContent).toContain("60% / 60%");
       expect(view.container.textContent).toContain(
-        "Keep this case active; it is still catching a reproducible agent failure.",
+        "Leave this case in the active gate set.",
       );
+    } finally {
+      view.cleanup();
+    }
+  });
+
+  it("renders maintenance variants in the suite case list", () => {
+    const view = render(
+      <SuiteDetailClient
+        workspaceId="ws-1"
+        suite={suite}
+        cases={[
+          makeCase({
+            id: "case-needs-signal",
+            title: "Needs signal",
+            validation: {
+              ...makeCase().validation,
+              status: "collecting_signal",
+              maintenance_status: "needs_signal",
+              maintenance_action:
+                "Keep this case in evidence-gathering mode until the validation window is full.",
+            },
+          }),
+          makeCase({
+            id: "case-prune",
+            title: "Prune candidate",
+            validation: {
+              ...makeCase().validation,
+              status: "passing",
+              maintenance_status: "prune_candidate",
+              maintenance_action:
+                "Open a pruning review before archiving or downgrading it.",
+            },
+          }),
+          makeCase({
+            id: "case-flaky",
+            title: "Review flaky",
+            validation: {
+              ...makeCase().validation,
+              status: "flaky",
+              maintenance_status: "review_flaky",
+              maintenance_action:
+                "Rewrite, split, or mute this case if replay evidence is nondeterministic.",
+            },
+          }),
+        ]}
+        sourcePack={sourcePack}
+      />,
+    );
+    try {
+      expect(view.container.textContent).toContain("needs signal");
+      expect(view.container.textContent).toContain("prune candidate");
+      expect(view.container.textContent).toContain("review flaky");
     } finally {
       view.cleanup();
     }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/suite-detail-client.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/suite-detail-client.test.tsx
@@ -103,6 +103,7 @@ function makeCase(overrides: Partial<RegressionCase> = {}): RegressionCase {
     },
     validation: {
       status: "reproducing",
+      maintenance_status: "keep_active",
       run_count: 5,
       failure_count: 3,
       pass_count: 2,
@@ -114,6 +115,8 @@ function makeCase(overrides: Partial<RegressionCase> = {}): RegressionCase {
       last_validated_at: "2026-04-22T12:30:00Z",
       recommended_action:
         "Failure reproduces at or above threshold; keep this case active in CI gates.",
+      maintenance_action:
+        "Keep this case active; it is still catching a reproducible agent failure.",
     },
     created_at: "2026-04-22T12:00:00Z",
     updated_at: "2026-04-22T12:00:00Z",
@@ -153,6 +156,7 @@ describe("regression provenance UI", () => {
       expect(view.container.textContent).toContain("ticket-1");
       expect(view.container.textContent).toContain("frc-test-cluster");
       expect(view.container.textContent).toContain("reproducing");
+      expect(view.container.textContent).toContain("keep active");
       expect(view.container.textContent).toContain("60% repro");
     } finally {
       view.cleanup();
@@ -175,8 +179,13 @@ describe("regression provenance UI", () => {
       expect(view.container.textContent).toContain("Failure Fingerprint");
       expect(view.container.textContent).toContain("frf-test-fingerprint");
       expect(view.container.textContent).toContain("Validation");
+      expect(view.container.textContent).toContain("Maintenance");
+      expect(view.container.textContent).toContain("keep active");
       expect(view.container.textContent).toContain("3 fail");
       expect(view.container.textContent).toContain("60% / 60%");
+      expect(view.container.textContent).toContain(
+        "Keep this case active; it is still catching a reproducible agent failure.",
+      );
     } finally {
       view.cleanup();
     }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/suite-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/suite-detail-client.tsx
@@ -33,6 +33,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import {
   CaseStatusBadge,
+  MaintenanceBadge,
   SeverityBadge,
   SuiteStatusBadge,
   ValidationBadge,
@@ -334,7 +335,10 @@ function CaseValidationSummary({
 
   return (
     <div className="flex flex-col items-start gap-1">
-      <ValidationBadge status={validation.status} />
+      <div className="flex flex-wrap gap-1">
+        <ValidationBadge status={validation.status} />
+        <MaintenanceBadge status={validation.maintenance_status} />
+      </div>
       <span className="text-xs text-muted-foreground">{detail}</span>
     </div>
   );

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/badges.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/badges.tsx
@@ -1,5 +1,6 @@
 import { Badge } from "@/components/ui/badge";
 import type {
+  RegressionCaseMaintenanceStatus,
   RegressionCaseValidationStatus,
   RegressionCaseStatus,
   RegressionSeverity,
@@ -53,6 +54,23 @@ const validationLabel: Record<RegressionCaseValidationStatus, string> = {
   flaky: "flaky",
 };
 
+const maintenanceVariant: Record<
+  RegressionCaseMaintenanceStatus,
+  "default" | "outline" | "secondary" | "destructive"
+> = {
+  needs_signal: "outline",
+  keep_active: "default",
+  prune_candidate: "secondary",
+  review_flaky: "destructive",
+};
+
+const maintenanceLabel: Record<RegressionCaseMaintenanceStatus, string> = {
+  needs_signal: "needs signal",
+  keep_active: "keep active",
+  prune_candidate: "prune candidate",
+  review_flaky: "review flaky",
+};
+
 export function SuiteStatusBadge({ status }: { status: RegressionSuiteStatus }) {
   return <Badge variant={suiteStatusVariant[status]}>{status}</Badge>;
 }
@@ -71,4 +89,14 @@ export function ValidationBadge({
   status: RegressionCaseValidationStatus;
 }) {
   return <Badge variant={validationVariant[status]}>{validationLabel[status]}</Badge>;
+}
+
+export function MaintenanceBadge({
+  status,
+}: {
+  status: RegressionCaseMaintenanceStatus;
+}) {
+  return (
+    <Badge variant={maintenanceVariant[status]}>{maintenanceLabel[status]}</Badge>
+  );
 }

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -1759,6 +1759,11 @@ export type RegressionCaseValidationStatus =
   | "reproducing"
   | "passing"
   | "flaky";
+export type RegressionCaseMaintenanceStatus =
+  | "needs_signal"
+  | "keep_active"
+  | "prune_candidate"
+  | "review_flaky";
 
 export interface RegressionPromotion {
   id: string;
@@ -1774,6 +1779,7 @@ export interface RegressionPromotion {
 
 export interface RegressionCaseValidation {
   status: RegressionCaseValidationStatus;
+  maintenance_status: RegressionCaseMaintenanceStatus;
   run_count: number;
   failure_count: number;
   pass_count: number;
@@ -1784,6 +1790,7 @@ export interface RegressionCaseValidation {
   last_outcome?: "pass" | "fail";
   last_validated_at?: string;
   recommended_action: string;
+  maintenance_action: string;
 }
 
 /** GET /v1/workspaces/{ws}/regression-suites list item, POST response, PATCH response */


### PR DESCRIPTION
## Summary
- add deterministic maintenance status/action fields to regression case validation responses
- document the fields in OpenAPI and TypeScript API types
- show maintenance badges and actions in regression suite/case views
- cover API mapping and UI rendering with tests

## Review Checkpoint
- Contract: `/tmp/reviewcheckpoint-issue-82-regression-maintenance-contract.md`
- Checkpoint: `/tmp/reviewcheckpoint-issue-82-regression-maintenance.json`

## Tests
- `git diff --check`
- `go test ./internal/api`
- `go vet ./...`
- `go test ./...`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run build`

Part of #82.
