### PR TITLE
feat(regression): capture production failures

### DIFF
--- a/backend/internal/api/regression_suites.go
+++ b/backend/internal/api/regression_suites.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -26,9 +27,13 @@ type RegressionRepository interface {
 	ListRegressionSuitesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID, limit, offset int32) ([]repository.RegressionSuite, error)
 	CountRegressionSuitesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (int64, error)
 	PatchRegressionSuite(ctx context.Context, params repository.PatchRegressionSuiteParams) (repository.RegressionSuite, error)
+	CreateRegressionCase(ctx context.Context, params repository.CreateRegressionCaseParams) (repository.RegressionCase, error)
 	GetRegressionCaseByID(ctx context.Context, id uuid.UUID) (repository.RegressionCase, error)
 	ListRegressionCasesBySuiteID(ctx context.Context, suiteID uuid.UUID) ([]repository.RegressionCase, error)
 	PatchRegressionCase(ctx context.Context, params repository.PatchRegressionCaseParams) (repository.RegressionCase, error)
+	GetRunnableChallengePackVersionByID(ctx context.Context, id uuid.UUID) (repository.RunnableChallengePackVersion, error)
+	GetChallengeInputSetByID(ctx context.Context, id uuid.UUID) (repository.ChallengeInputSet, error)
+	ListChallengeIdentityIDsByPackVersionID(ctx context.Context, challengePackVersionID uuid.UUID) ([]uuid.UUID, error)
 	GetRunByID(ctx context.Context, id uuid.UUID) (domain.Run, error)
 	ListRunFailureReviewItems(ctx context.Context, runID uuid.UUID, agentID *uuid.UUID) ([]failurereview.Item, error)
 	GetRunAgentExecutionContextByID(ctx context.Context, runAgentID uuid.UUID) (repository.RunAgentExecutionContext, error)
@@ -45,6 +50,7 @@ type RegressionService interface {
 	ListRegressionCases(ctx context.Context, caller Caller, input ListRegressionCasesInput) ([]repository.RegressionCase, error)
 	PatchRegressionCase(ctx context.Context, caller Caller, input PatchRegressionCaseInput) (repository.RegressionCase, error)
 	PromoteFailure(ctx context.Context, caller Caller, input PromoteFailureInput) (PromoteFailureResult, error)
+	CaptureProductionFailure(ctx context.Context, caller Caller, input CaptureProductionFailureInput) (repository.RegressionCase, error)
 }
 
 type CreateRegressionSuiteInput struct {
@@ -97,6 +103,30 @@ type PromoteFailureInput struct {
 	Request             domain.PromotionRequest
 }
 
+type CaptureProductionFailureInput struct {
+	WorkspaceID                  uuid.UUID
+	SuiteID                      uuid.UUID
+	SourceChallengePackVersionID uuid.UUID
+	SourceChallengeInputSetID    *uuid.UUID
+	SourceChallengeIdentityID    uuid.UUID
+	SourceCaseKey                string
+	SourceItemKey                *string
+	Title                        string
+	FailureSummary               string
+	FailureClass                 string
+	EvidenceTier                 string
+	Severity                     *domain.RegressionSeverity
+	PromotionMode                *domain.RegressionPromotionMode
+	PayloadSnapshot              json.RawMessage
+	ExpectedContract             json.RawMessage
+	ValidatorOverrides           json.RawMessage
+	Metadata                     json.RawMessage
+	IncidentID                   string
+	ExternalURL                  string
+	Source                       string
+	ObservedAt                   *time.Time
+}
+
 type PromoteFailureResult struct {
 	Case    repository.RegressionCase
 	Created bool
@@ -123,6 +153,8 @@ var (
 	ErrFailurePromotionModeUnavailable = errors.New("promotion mode unavailable for failure review item")
 	ErrRegressionSuiteArchived         = errors.New("regression suite is archived")
 	ErrRegressionSuitePackMismatch     = errors.New("regression suite source pack does not match run pack")
+	ErrRegressionChallengeMismatch     = errors.New("challenge identity does not belong to challenge pack version")
+	ErrRegressionInputSetMismatch      = errors.New("challenge input set does not belong to challenge pack version")
 )
 
 func NewRegressionManager(authorizer WorkspaceAuthorizer, repo RegressionRepository) *RegressionManager {
@@ -360,6 +392,109 @@ func (m *RegressionManager) PromoteFailure(ctx context.Context, caller Caller, i
 	}, nil
 }
 
+func (m *RegressionManager) CaptureProductionFailure(ctx context.Context, caller Caller, input CaptureProductionFailureInput) (repository.RegressionCase, error) {
+	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, input.WorkspaceID, ActionManageRegressions); err != nil {
+		return repository.RegressionCase{}, err
+	}
+
+	suite, err := m.repo.GetRegressionSuiteByID(ctx, input.SuiteID)
+	if err != nil {
+		return repository.RegressionCase{}, err
+	}
+	if suite.WorkspaceID != input.WorkspaceID {
+		return repository.RegressionCase{}, repository.ErrRegressionSuiteNotFound
+	}
+	if suite.Status != domain.RegressionSuiteStatusActive {
+		return repository.RegressionCase{}, ErrRegressionSuiteArchived
+	}
+
+	version, err := m.repo.GetRunnableChallengePackVersionByID(ctx, input.SourceChallengePackVersionID)
+	if err != nil {
+		return repository.RegressionCase{}, err
+	}
+	if version.WorkspaceID != nil && *version.WorkspaceID != input.WorkspaceID {
+		return repository.RegressionCase{}, repository.ErrChallengePackVersionNotFound
+	}
+	if version.ChallengePackID != suite.SourceChallengePackID {
+		return repository.RegressionCase{}, ErrRegressionSuitePackMismatch
+	}
+	if input.SourceChallengeInputSetID != nil {
+		inputSet, err := m.repo.GetChallengeInputSetByID(ctx, *input.SourceChallengeInputSetID)
+		if err != nil {
+			return repository.RegressionCase{}, err
+		}
+		if inputSet.ChallengePackVersionID != input.SourceChallengePackVersionID {
+			return repository.RegressionCase{}, ErrRegressionInputSetMismatch
+		}
+	}
+	if err := m.ensureChallengeIdentityInVersion(ctx, input.SourceChallengePackVersionID, input.SourceChallengeIdentityID); err != nil {
+		return repository.RegressionCase{}, err
+	}
+
+	failureClass := strings.TrimSpace(input.FailureClass)
+	if failureClass == "" {
+		failureClass = string(failurereview.FailureClassOther)
+	}
+	evidenceTier := strings.TrimSpace(input.EvidenceTier)
+	if evidenceTier == "" {
+		evidenceTier = string(failurereview.EvidenceTierHostedBlackBox)
+	}
+	severity := domain.DefaultPromotionSeverityForFailureClass(failureClass)
+	if input.Severity != nil {
+		severity = *input.Severity
+	}
+	promotionMode := domain.RegressionPromotionModeOutputOnly
+	if input.PromotionMode != nil {
+		promotionMode = *input.PromotionMode
+	}
+
+	metadata, err := productionFailureMetadata(input, failureClass)
+	if err != nil {
+		return repository.RegressionCase{}, err
+	}
+	sourceItemKey := ""
+	if input.SourceItemKey != nil {
+		sourceItemKey = *input.SourceItemKey
+	}
+
+	return m.repo.CreateRegressionCase(ctx, repository.CreateRegressionCaseParams{
+		SuiteID:                      input.SuiteID,
+		Title:                        strings.TrimSpace(input.Title),
+		Description:                  "",
+		Status:                       domain.RegressionCaseStatusProposed,
+		Severity:                     severity,
+		PromotionMode:                promotionMode,
+		SourceRunID:                  nil,
+		SourceRunAgentID:             nil,
+		SourceReplayID:               nil,
+		SourceChallengePackVersionID: input.SourceChallengePackVersionID,
+		SourceChallengeInputSetID:    cloneUUIDPtr(input.SourceChallengeInputSetID),
+		SourceChallengeIdentityID:    input.SourceChallengeIdentityID,
+		SourceCaseKey:                strings.TrimSpace(input.SourceCaseKey),
+		SourceItemKey:                optionalStringPtr(sourceItemKey),
+		EvidenceTier:                 evidenceTier,
+		FailureClass:                 failureClass,
+		FailureSummary:               strings.TrimSpace(input.FailureSummary),
+		PayloadSnapshot:              input.PayloadSnapshot,
+		ExpectedContract:             input.ExpectedContract,
+		ValidatorOverrides:           input.ValidatorOverrides,
+		Metadata:                     metadata,
+	})
+}
+
+func (m *RegressionManager) ensureChallengeIdentityInVersion(ctx context.Context, versionID, challengeIdentityID uuid.UUID) error {
+	ids, err := m.repo.ListChallengeIdentityIDsByPackVersionID(ctx, versionID)
+	if err != nil {
+		return err
+	}
+	for _, id := range ids {
+		if id == challengeIdentityID {
+			return nil
+		}
+	}
+	return ErrRegressionChallengeMismatch
+}
+
 func (m *RegressionManager) findFailureReviewItem(ctx context.Context, runID, challengeIdentityID uuid.UUID, runAgentID *uuid.UUID) (failurereview.Item, error) {
 	items, err := m.repo.ListRunFailureReviewItems(ctx, runID, nil)
 	if err != nil {
@@ -452,6 +587,75 @@ func expectedContractSubset(definition json.RawMessage) (json.RawMessage, error)
 		return nil, err
 	}
 	return encoded, nil
+}
+
+func productionFailureMetadata(input CaptureProductionFailureInput, failureClass string) (json.RawMessage, error) {
+	metadata := map[string]any{}
+	trimmed := strings.TrimSpace(string(input.Metadata))
+	if trimmed != "" && trimmed != "null" {
+		if err := json.Unmarshal([]byte(trimmed), &metadata); err != nil {
+			return nil, fmt.Errorf("decode production failure metadata: %w", err)
+		}
+	}
+
+	source := strings.TrimSpace(input.Source)
+	if source == "" {
+		source = "production"
+	}
+	incidentID := strings.TrimSpace(input.IncidentID)
+	externalURL := strings.TrimSpace(input.ExternalURL)
+	sourceCaseKey := strings.TrimSpace(input.SourceCaseKey)
+
+	metadata["origin"] = "production_failure"
+	metadata["source"] = source
+	metadata["source_challenge_pack_version_id"] = input.SourceChallengePackVersionID.String()
+	metadata["source_challenge_identity_id"] = input.SourceChallengeIdentityID.String()
+	metadata["source_case_key"] = sourceCaseKey
+	metadata["source_failure_fingerprint"] = productionFailureFingerprint(input, failureClass)
+	metadata["source_failure_cluster_key"] = productionFailureClusterKey(input, failureClass)
+	if input.SourceChallengeInputSetID != nil {
+		metadata["source_challenge_input_set_id"] = input.SourceChallengeInputSetID.String()
+	}
+	if incidentID != "" {
+		metadata["production_incident_id"] = incidentID
+	}
+	if externalURL != "" {
+		metadata["production_external_url"] = externalURL
+	}
+	if input.ObservedAt != nil {
+		metadata["production_observed_at"] = input.ObservedAt.UTC().Format(time.RFC3339)
+	}
+
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		return nil, fmt.Errorf("marshal production failure metadata: %w", err)
+	}
+	return encoded, nil
+}
+
+func productionFailureFingerprint(input CaptureProductionFailureInput, failureClass string) string {
+	incidentID := strings.TrimSpace(input.IncidentID)
+	if incidentID == "" {
+		incidentID = strings.TrimSpace(input.FailureSummary)
+	}
+	hash := sha256.Sum256([]byte(strings.Join([]string{
+		input.SourceChallengePackVersionID.String(),
+		input.SourceChallengeIdentityID.String(),
+		strings.TrimSpace(input.SourceCaseKey),
+		strings.TrimSpace(input.Source),
+		failureClass,
+		incidentID,
+	}, "\x00")))
+	return fmt.Sprintf("prod:%x", hash[:16])
+}
+
+func productionFailureClusterKey(input CaptureProductionFailureInput, failureClass string) string {
+	hash := sha256.Sum256([]byte(strings.Join([]string{
+		input.SourceChallengePackVersionID.String(),
+		input.SourceChallengeIdentityID.String(),
+		failureClass,
+	}, "\x00")))
+	return fmt.Sprintf("prod-cluster:%x", hash[:16])
 }
 
 func optionalStringPtr(value string) *string {
@@ -807,6 +1011,143 @@ func listRegressionCasesHandler(logger *slog.Logger, service RegressionService) 
 	}
 }
 
+func captureProductionFailureHandler(logger *slog.Logger, service RegressionService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		workspaceID, err := workspaceIDFromURLParam("workspaceID")(r)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_workspace_id", "workspace ID is malformed")
+			return
+		}
+		suiteID, err := regressionSuiteIDFromURLParam("suiteID")(r)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_regression_suite_id", err.Error())
+			return
+		}
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+
+		var req struct {
+			SourceChallengePackVersionID uuid.UUID       `json:"source_challenge_pack_version_id"`
+			SourceChallengeInputSetID    *uuid.UUID      `json:"source_challenge_input_set_id,omitempty"`
+			SourceChallengeIdentityID    uuid.UUID       `json:"source_challenge_identity_id"`
+			SourceCaseKey                string          `json:"source_case_key"`
+			SourceItemKey                *string         `json:"source_item_key,omitempty"`
+			Title                        string          `json:"title"`
+			FailureSummary               string          `json:"failure_summary"`
+			FailureClass                 string          `json:"failure_class,omitempty"`
+			EvidenceTier                 string          `json:"evidence_tier,omitempty"`
+			Severity                     *string         `json:"severity,omitempty"`
+			PromotionMode                *string         `json:"promotion_mode,omitempty"`
+			PayloadSnapshot              json.RawMessage `json:"payload_snapshot"`
+			ExpectedContract             json.RawMessage `json:"expected_contract,omitempty"`
+			ValidatorOverrides           json.RawMessage `json:"validator_overrides,omitempty"`
+			Metadata                     json.RawMessage `json:"metadata,omitempty"`
+			IncidentID                   string          `json:"incident_id,omitempty"`
+			ExternalURL                  string          `json:"external_url,omitempty"`
+			Source                       string          `json:"source,omitempty"`
+			ObservedAt                   *time.Time      `json:"observed_at,omitempty"`
+		}
+		if err := decodeJSON(r, &req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "request body must be valid JSON")
+			return
+		}
+		if req.SourceChallengePackVersionID == uuid.Nil {
+			writeError(w, http.StatusBadRequest, "validation_error", "source_challenge_pack_version_id is required")
+			return
+		}
+		if req.SourceChallengeIdentityID == uuid.Nil {
+			writeError(w, http.StatusBadRequest, "validation_error", "source_challenge_identity_id is required")
+			return
+		}
+		if strings.TrimSpace(req.SourceCaseKey) == "" {
+			writeError(w, http.StatusBadRequest, "validation_error", "source_case_key is required")
+			return
+		}
+		if strings.TrimSpace(req.Title) == "" {
+			writeError(w, http.StatusBadRequest, "validation_error", "title is required")
+			return
+		}
+		if strings.TrimSpace(req.FailureSummary) == "" {
+			writeError(w, http.StatusBadRequest, "validation_error", "failure_summary is required")
+			return
+		}
+
+		payloadSnapshot, ok := regressionJSONObject(w, req.PayloadSnapshot, "payload_snapshot", true)
+		if !ok {
+			return
+		}
+		expectedContract, ok := regressionJSONObject(w, req.ExpectedContract, "expected_contract", false)
+		if !ok {
+			return
+		}
+		metadata, ok := regressionJSONObject(w, req.Metadata, "metadata", false)
+		if !ok {
+			return
+		}
+		validatorOverrides, err := domain.ValidatePromotionOverrides(req.ValidatorOverrides)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_promotion_overrides", err.Error())
+			return
+		}
+
+		var severity *domain.RegressionSeverity
+		if req.Severity != nil {
+			parsed, parseErr := domain.ParseRegressionSeverity(*req.Severity)
+			if parseErr != nil {
+				writeError(w, http.StatusBadRequest, "validation_error", "severity must be info, warning, or blocking")
+				return
+			}
+			severity = &parsed
+		}
+
+		var promotionMode *domain.RegressionPromotionMode
+		if req.PromotionMode != nil {
+			parsed, parseErr := domain.ParseRegressionPromotionMode(*req.PromotionMode)
+			if parseErr != nil {
+				writeError(w, http.StatusBadRequest, "validation_error", "promotion_mode must be full_executable, output_only, or manual")
+				return
+			}
+			promotionMode = &parsed
+		}
+
+		regressionCase, err := service.CaptureProductionFailure(r.Context(), caller, CaptureProductionFailureInput{
+			WorkspaceID:                  workspaceID,
+			SuiteID:                      suiteID,
+			SourceChallengePackVersionID: req.SourceChallengePackVersionID,
+			SourceChallengeInputSetID:    cloneUUIDPtr(req.SourceChallengeInputSetID),
+			SourceChallengeIdentityID:    req.SourceChallengeIdentityID,
+			SourceCaseKey:                req.SourceCaseKey,
+			SourceItemKey:                cloneStringPtr(req.SourceItemKey),
+			Title:                        req.Title,
+			FailureSummary:               req.FailureSummary,
+			FailureClass:                 req.FailureClass,
+			EvidenceTier:                 req.EvidenceTier,
+			Severity:                     severity,
+			PromotionMode:                promotionMode,
+			PayloadSnapshot:              payloadSnapshot,
+			ExpectedContract:             expectedContract,
+			ValidatorOverrides:           validatorOverrides,
+			Metadata:                     metadata,
+			IncidentID:                   req.IncidentID,
+			ExternalURL:                  req.ExternalURL,
+			Source:                       req.Source,
+			ObservedAt:                   req.ObservedAt,
+		})
+		if err != nil {
+			handleRegressionError(w, logger, err)
+			return
+		}
+		writeJSON(w, http.StatusCreated, buildRegressionCaseResponse(regressionCase))
+	}
+}
+
 func patchRegressionCaseHandler(logger *slog.Logger, service RegressionService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		caller, err := CallerFromContext(r.Context())
@@ -878,6 +1219,23 @@ func patchRegressionCaseHandler(logger *slog.Logger, service RegressionService) 
 		}
 		writeJSON(w, http.StatusOK, buildRegressionCaseResponse(regressionCase))
 	}
+}
+
+func regressionJSONObject(w http.ResponseWriter, raw json.RawMessage, field string, required bool) (json.RawMessage, bool) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		if required {
+			writeError(w, http.StatusBadRequest, "validation_error", field+" is required")
+			return nil, false
+		}
+		return nil, true
+	}
+	var value map[string]any
+	if err := json.Unmarshal([]byte(trimmed), &value); err != nil {
+		writeError(w, http.StatusBadRequest, "validation_error", field+" must be a JSON object")
+		return nil, false
+	}
+	return json.RawMessage(trimmed), true
 }
 
 func buildRegressionSuiteResponse(suite repository.RegressionSuite) regressionSuiteResponse {
@@ -1086,6 +1444,10 @@ func handleRegressionError(w http.ResponseWriter, logger *slog.Logger, err error
 		writeError(w, http.StatusNotFound, "regression_case_not_found", "regression case not found")
 	case errors.Is(err, repository.ErrRunNotFound):
 		writeError(w, http.StatusNotFound, "run_not_found", "run not found")
+	case errors.Is(err, repository.ErrChallengePackVersionNotFound):
+		writeError(w, http.StatusNotFound, "challenge_pack_version_not_found", "challenge pack version not found")
+	case errors.Is(err, repository.ErrChallengeInputSetNotFound):
+		writeError(w, http.StatusNotFound, "challenge_input_set_not_found", "challenge input set not found")
 	case errors.Is(err, ErrFailureReviewItemNotFound):
 		writeError(w, http.StatusNotFound, "failure_review_item_not_found", "failure review item not found")
 	case errors.Is(err, ErrChallengePackNotFound):
@@ -1103,7 +1465,11 @@ func handleRegressionError(w http.ResponseWriter, logger *slog.Logger, err error
 	case errors.Is(err, ErrRegressionSuiteArchived):
 		writeError(w, http.StatusBadRequest, "regression_suite_archived", "regression suite must be active to accept promotions")
 	case errors.Is(err, ErrRegressionSuitePackMismatch):
-		writeError(w, http.StatusBadRequest, "regression_suite_pack_mismatch", "regression suite source pack must match the run source pack")
+		writeError(w, http.StatusBadRequest, "regression_suite_pack_mismatch", "regression suite source pack must match the failure source pack")
+	case errors.Is(err, ErrRegressionChallengeMismatch):
+		writeError(w, http.StatusBadRequest, "challenge_identity_mismatch", "challenge identity must belong to the challenge pack version")
+	case errors.Is(err, ErrRegressionInputSetMismatch):
+		writeError(w, http.StatusBadRequest, "challenge_input_set_mismatch", "challenge input set must belong to the challenge pack version")
 	case errors.Is(err, domain.ErrInvalidPromotionOverrides):
 		writeError(w, http.StatusBadRequest, "invalid_promotion_overrides", err.Error())
 	case errors.Is(err, repository.ErrTransitionConflict):

--- a/backend/internal/api/regression_suites.go
+++ b/backend/internal/api/regression_suites.go
@@ -152,7 +152,7 @@ var (
 	ErrFailurePromotionNotAllowed      = errors.New("failure review item is not promotable")
 	ErrFailurePromotionModeUnavailable = errors.New("promotion mode unavailable for failure review item")
 	ErrRegressionSuiteArchived         = errors.New("regression suite is archived")
-	ErrRegressionSuitePackMismatch     = errors.New("regression suite source pack does not match run pack")
+	ErrRegressionSuitePackMismatch     = errors.New("regression suite source pack does not match failure source pack")
 	ErrRegressionChallengeMismatch     = errors.New("challenge identity does not belong to challenge pack version")
 	ErrRegressionInputSetMismatch      = errors.New("challenge input set does not belong to challenge pack version")
 )
@@ -598,10 +598,7 @@ func productionFailureMetadata(input CaptureProductionFailureInput, failureClass
 		}
 	}
 
-	source := strings.TrimSpace(input.Source)
-	if source == "" {
-		source = "production"
-	}
+	source := productionFailureSource(input.Source)
 	incidentID := strings.TrimSpace(input.IncidentID)
 	externalURL := strings.TrimSpace(input.ExternalURL)
 	sourceCaseKey := strings.TrimSpace(input.SourceCaseKey)
@@ -642,7 +639,7 @@ func productionFailureFingerprint(input CaptureProductionFailureInput, failureCl
 		input.SourceChallengePackVersionID.String(),
 		input.SourceChallengeIdentityID.String(),
 		strings.TrimSpace(input.SourceCaseKey),
-		strings.TrimSpace(input.Source),
+		productionFailureSource(input.Source),
 		failureClass,
 		incidentID,
 	}, "\x00")))
@@ -656,6 +653,14 @@ func productionFailureClusterKey(input CaptureProductionFailureInput, failureCla
 		failureClass,
 	}, "\x00")))
 	return fmt.Sprintf("prod-cluster:%x", hash[:16])
+}
+
+func productionFailureSource(raw string) string {
+	source := strings.TrimSpace(raw)
+	if source == "" {
+		return "production"
+	}
+	return source
 }
 
 func optionalStringPtr(value string) *string {
@@ -1078,6 +1083,24 @@ func captureProductionFailureHandler(logger *slog.Logger, service RegressionServ
 			writeError(w, http.StatusBadRequest, "validation_error", "failure_summary is required")
 			return
 		}
+		failureClass := strings.TrimSpace(req.FailureClass)
+		if failureClass != "" {
+			parsed, parseErr := parseFailureClass(failureClass)
+			if parseErr != nil {
+				writeError(w, http.StatusBadRequest, "validation_error", parseErr.Error())
+				return
+			}
+			failureClass = string(parsed)
+		}
+		evidenceTier := strings.TrimSpace(req.EvidenceTier)
+		if evidenceTier != "" {
+			parsed, parseErr := parseEvidenceTier(evidenceTier)
+			if parseErr != nil {
+				writeError(w, http.StatusBadRequest, "validation_error", parseErr.Error())
+				return
+			}
+			evidenceTier = string(parsed)
+		}
 
 		payloadSnapshot, ok := regressionJSONObject(w, req.PayloadSnapshot, "payload_snapshot", true)
 		if !ok {
@@ -1127,8 +1150,8 @@ func captureProductionFailureHandler(logger *slog.Logger, service RegressionServ
 			SourceItemKey:                cloneStringPtr(req.SourceItemKey),
 			Title:                        req.Title,
 			FailureSummary:               req.FailureSummary,
-			FailureClass:                 req.FailureClass,
-			EvidenceTier:                 req.EvidenceTier,
+			FailureClass:                 failureClass,
+			EvidenceTier:                 evidenceTier,
 			Severity:                     severity,
 			PromotionMode:                promotionMode,
 			PayloadSnapshot:              payloadSnapshot,

--- a/backend/internal/api/regression_suites_test.go
+++ b/backend/internal/api/regression_suites_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -548,6 +549,262 @@ func TestRegressionManagerPromoteFailureResolvesDuplicateChallengeIdentityWithRu
 	}
 }
 
+func TestRegressionManagerCaptureProductionFailureCreatesProposedCase(t *testing.T) {
+	workspaceID := uuid.New()
+	suiteID := uuid.New()
+	challengePackID := uuid.New()
+	versionID := uuid.New()
+	inputSetID := uuid.New()
+	challengeIdentityID := uuid.New()
+	observedAt := time.Date(2026, 5, 5, 10, 30, 0, 0, time.UTC)
+
+	repo := &fakeRegressionRepository{
+		suite: repository.RegressionSuite{
+			ID:                    suiteID,
+			WorkspaceID:           workspaceID,
+			SourceChallengePackID: challengePackID,
+			Status:                domain.RegressionSuiteStatusActive,
+		},
+		challengePackVersion: repository.RunnableChallengePackVersion{
+			ID:              versionID,
+			ChallengePackID: challengePackID,
+			WorkspaceID:     &workspaceID,
+		},
+		challengeInputSet: repository.ChallengeInputSet{
+			ID:                     inputSetID,
+			ChallengePackVersionID: versionID,
+		},
+		challengeIdentityIDs: []uuid.UUID{challengeIdentityID},
+		createCaseResult:     repository.RegressionCase{WorkspaceID: workspaceID},
+	}
+	manager := NewRegressionManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	regressionCase, err := manager.CaptureProductionFailure(context.Background(), Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: RoleWorkspaceMember},
+		},
+	}, CaptureProductionFailureInput{
+		WorkspaceID:                  workspaceID,
+		SuiteID:                      suiteID,
+		SourceChallengePackVersionID: versionID,
+		SourceChallengeInputSetID:    &inputSetID,
+		SourceChallengeIdentityID:    challengeIdentityID,
+		SourceCaseKey:                "prod-incident-123",
+		Title:                        "Production tool schema incident",
+		FailureSummary:               "Agent emitted an invalid tool argument in production.",
+		FailureClass:                 "tool_argument_error",
+		PayloadSnapshot:              json.RawMessage(`{"ticket":"example"}`),
+		ExpectedContract:             json.RawMessage(`{"validators":[]}`),
+		Metadata:                     json.RawMessage(`{"origin":"caller","team":"support"}`),
+		IncidentID:                   "INC-123",
+		ExternalURL:                  "https://example.test/incidents/INC-123",
+		ObservedAt:                   &observedAt,
+	})
+	if err != nil {
+		t.Fatalf("CaptureProductionFailure returned error: %v", err)
+	}
+	if regressionCase.ID == uuid.Nil {
+		t.Fatal("expected created regression case")
+	}
+	if repo.createCaseInput == nil {
+		t.Fatal("expected create case input")
+	}
+	if repo.createCaseInput.Status != domain.RegressionCaseStatusProposed {
+		t.Fatalf("status = %s, want proposed", repo.createCaseInput.Status)
+	}
+	if repo.createCaseInput.PromotionMode != domain.RegressionPromotionModeOutputOnly {
+		t.Fatalf("promotion mode = %s, want output_only", repo.createCaseInput.PromotionMode)
+	}
+	if repo.createCaseInput.Severity != domain.RegressionSeverityWarning {
+		t.Fatalf("severity = %s, want warning", repo.createCaseInput.Severity)
+	}
+	if repo.createCaseInput.SourceRunID != nil || repo.createCaseInput.SourceRunAgentID != nil {
+		t.Fatalf("source run fields = %v/%v, want nil", repo.createCaseInput.SourceRunID, repo.createCaseInput.SourceRunAgentID)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(repo.createCaseInput.Metadata, &metadata); err != nil {
+		t.Fatalf("metadata unmarshal: %v", err)
+	}
+	if metadata["origin"] != "production_failure" {
+		t.Fatalf("metadata origin = %#v, want production_failure", metadata["origin"])
+	}
+	if metadata["team"] != "support" || metadata["production_incident_id"] != "INC-123" {
+		t.Fatalf("metadata = %#v, want caller and incident fields", metadata)
+	}
+	if metadata["source_failure_fingerprint"] == "" || metadata["source_failure_cluster_key"] == "" {
+		t.Fatalf("metadata = %#v, want generated failure keys", metadata)
+	}
+}
+
+func TestRegressionManagerCaptureProductionFailureRejectsInvalidSources(t *testing.T) {
+	workspaceID := uuid.New()
+	suiteID := uuid.New()
+	challengePackID := uuid.New()
+	versionID := uuid.New()
+	inputSetID := uuid.New()
+	challengeIdentityID := uuid.New()
+
+	baseRepo := func() *fakeRegressionRepository {
+		return &fakeRegressionRepository{
+			suite: repository.RegressionSuite{
+				ID:                    suiteID,
+				WorkspaceID:           workspaceID,
+				SourceChallengePackID: challengePackID,
+				Status:                domain.RegressionSuiteStatusActive,
+			},
+			challengePackVersion: repository.RunnableChallengePackVersion{
+				ID:              versionID,
+				ChallengePackID: challengePackID,
+				WorkspaceID:     &workspaceID,
+			},
+			challengeInputSet: repository.ChallengeInputSet{
+				ID:                     inputSetID,
+				ChallengePackVersionID: versionID,
+			},
+			challengeIdentityIDs: []uuid.UUID{challengeIdentityID},
+		}
+	}
+	baseInput := CaptureProductionFailureInput{
+		WorkspaceID:                  workspaceID,
+		SuiteID:                      suiteID,
+		SourceChallengePackVersionID: versionID,
+		SourceChallengeInputSetID:    &inputSetID,
+		SourceChallengeIdentityID:    challengeIdentityID,
+		SourceCaseKey:                "prod-incident-123",
+		Title:                        "Production incident",
+		FailureSummary:               "Agent failed in production.",
+		PayloadSnapshot:              json.RawMessage(`{"ticket":"example"}`),
+	}
+
+	testCases := []struct {
+		name    string
+		mutate  func(*fakeRegressionRepository, *CaptureProductionFailureInput)
+		wantErr error
+	}{
+		{
+			name: "archived suite",
+			mutate: func(repo *fakeRegressionRepository, _ *CaptureProductionFailureInput) {
+				repo.suite.Status = domain.RegressionSuiteStatusArchived
+			},
+			wantErr: ErrRegressionSuiteArchived,
+		},
+		{
+			name: "pack mismatch",
+			mutate: func(repo *fakeRegressionRepository, _ *CaptureProductionFailureInput) {
+				repo.challengePackVersion.ChallengePackID = uuid.New()
+			},
+			wantErr: ErrRegressionSuitePackMismatch,
+		},
+		{
+			name: "input set mismatch",
+			mutate: func(repo *fakeRegressionRepository, _ *CaptureProductionFailureInput) {
+				repo.challengeInputSet.ChallengePackVersionID = uuid.New()
+			},
+			wantErr: ErrRegressionInputSetMismatch,
+		},
+		{
+			name: "missing identity",
+			mutate: func(repo *fakeRegressionRepository, _ *CaptureProductionFailureInput) {
+				repo.challengeIdentityIDs = []uuid.UUID{uuid.New()}
+			},
+			wantErr: ErrRegressionChallengeMismatch,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := baseRepo()
+			input := baseInput
+			tc.mutate(repo, &input)
+			manager := NewRegressionManager(NewCallerWorkspaceAuthorizer(), repo)
+			_, err := manager.CaptureProductionFailure(context.Background(), Caller{
+				UserID: uuid.New(),
+				WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+					workspaceID: {WorkspaceID: workspaceID, Role: RoleWorkspaceMember},
+				},
+			}, input)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("CaptureProductionFailure error = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestCaptureProductionFailureEndpointCreatesProposedCase(t *testing.T) {
+	workspaceID := uuid.New()
+	userID := uuid.New()
+	suiteID := uuid.New()
+	versionID := uuid.New()
+	inputSetID := uuid.New()
+	challengeIdentityID := uuid.New()
+	service := &fakeRegressionService{
+		regressionCase: repository.RegressionCase{
+			WorkspaceID:   workspaceID,
+			Severity:      domain.RegressionSeverityBlocking,
+			PromotionMode: domain.RegressionPromotionModeManual,
+			EvidenceTier:  "hosted_black_box",
+			FailureClass:  "tool_argument_error",
+			CreatedAt:     time.Now().UTC(),
+			UpdatedAt:     time.Now().UTC(),
+		},
+	}
+	router := buildRouter(routerOptions{
+		authMode:                   "dev",
+		logger:                     testLogger(t),
+		authenticator:              NewDevelopmentAuthenticator(),
+		authorizer:                 NewCallerWorkspaceAuthorizer(),
+		runCreationService:         stubRunCreationService{},
+		runReadService:             stubRunReadService{},
+		replayReadService:          stubReplayReadService{},
+		hostedRunIngestionService:  stubHostedRunIngestionService{},
+		compareReadService:         stubCompareReadService{},
+		agentDeploymentReadService: stubAgentDeploymentReadService{},
+		challengePackReadService:   stubChallengePackReadService{},
+		agentBuildService:          stubAgentBuildService{},
+		releaseGateService:         noopReleaseGateService{},
+		regressionService:          service,
+	})
+
+	body := fmt.Sprintf(`{
+		"source_challenge_pack_version_id":"%s",
+		"source_challenge_input_set_id":"%s",
+		"source_challenge_identity_id":"%s",
+		"source_case_key":"prod-incident-123",
+		"title":"Production tool schema incident",
+		"failure_summary":"Agent emitted an invalid tool argument in production.",
+		"failure_class":"tool_argument_error",
+		"evidence_tier":"hosted_black_box",
+		"severity":"blocking",
+		"promotion_mode":"manual",
+		"payload_snapshot":{"ticket":"example"},
+		"expected_contract":{"validators":[]},
+		"metadata":{"incident_id":"INC-123"}
+	}`, versionID, inputSetID, challengeIdentityID)
+	req := httptest.NewRequest(http.MethodPost, "/v1/workspaces/"+workspaceID.String()+"/regression-suites/"+suiteID.String()+"/production-failures", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(headerUserID, userID.String())
+	req.Header.Set(headerWorkspaceMemberships, workspaceID.String()+":workspace_member")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201, body=%s", rec.Code, rec.Body.String())
+	}
+	if service.captureInput == nil {
+		t.Fatal("expected capture input")
+	}
+	if service.captureInput.SuiteID != suiteID || service.captureInput.SourceChallengePackVersionID != versionID {
+		t.Fatalf("capture input = %+v, want suite/version", service.captureInput)
+	}
+	if service.captureInput.Severity == nil || *service.captureInput.Severity != domain.RegressionSeverityBlocking {
+		t.Fatalf("severity = %v, want blocking", service.captureInput.Severity)
+	}
+	if service.captureInput.PromotionMode == nil || *service.captureInput.PromotionMode != domain.RegressionPromotionModeManual {
+		t.Fatalf("promotion mode = %v, want manual", service.captureInput.PromotionMode)
+	}
+}
+
 func TestRegressionSuiteEndpointsRoundTrip(t *testing.T) {
 	workspaceID := uuid.New()
 	userID := uuid.New()
@@ -995,35 +1252,44 @@ func TestRegressionSuitePatchReturnsConflictOnTransitionConflict(t *testing.T) {
 }
 
 type fakeRegressionRepository struct {
-	challengePacks      []repository.ChallengePackSummary
-	challengePacksErr   error
-	suite               repository.RegressionSuite
-	suiteErr            error
-	regressionCase      repository.RegressionCase
-	regressionCaseErr   error
-	listSuites          []repository.RegressionSuite
-	listSuitesErr       error
-	listCases           []repository.RegressionCase
-	listCasesErr        error
-	countSuites         int64
-	countSuitesErr      error
-	patchSuiteResult    repository.RegressionSuite
-	patchSuiteErr       error
-	patchCaseResult     repository.RegressionCase
-	patchCaseErr        error
-	run                 domain.Run
-	runErr              error
-	failureItems        []failurereview.Item
-	failureItemsErr     error
-	executionContext    repository.RunAgentExecutionContext
-	executionContextErr error
-	scorecard           repository.RunAgentScorecard
-	scorecardErr        error
-	evaluationSpec      repository.EvaluationSpecRecord
-	evaluationSpecErr   error
-	promoteResult       repository.PromoteFailureResult
-	promoteErr          error
-	promoteInput        *repository.PromoteFailureParams
+	challengePacks          []repository.ChallengePackSummary
+	challengePacksErr       error
+	suite                   repository.RegressionSuite
+	suiteErr                error
+	regressionCase          repository.RegressionCase
+	regressionCaseErr       error
+	listSuites              []repository.RegressionSuite
+	listSuitesErr           error
+	listCases               []repository.RegressionCase
+	listCasesErr            error
+	countSuites             int64
+	countSuitesErr          error
+	patchSuiteResult        repository.RegressionSuite
+	patchSuiteErr           error
+	createCaseResult        repository.RegressionCase
+	createCaseErr           error
+	createCaseInput         *repository.CreateRegressionCaseParams
+	patchCaseResult         repository.RegressionCase
+	patchCaseErr            error
+	challengePackVersion    repository.RunnableChallengePackVersion
+	challengePackVersionErr error
+	challengeInputSet       repository.ChallengeInputSet
+	challengeInputSetErr    error
+	challengeIdentityIDs    []uuid.UUID
+	challengeIdentityIDsErr error
+	run                     domain.Run
+	runErr                  error
+	failureItems            []failurereview.Item
+	failureItemsErr         error
+	executionContext        repository.RunAgentExecutionContext
+	executionContextErr     error
+	scorecard               repository.RunAgentScorecard
+	scorecardErr            error
+	evaluationSpec          repository.EvaluationSpecRecord
+	evaluationSpecErr       error
+	promoteResult           repository.PromoteFailureResult
+	promoteErr              error
+	promoteInput            *repository.PromoteFailureParams
 }
 
 func (f *fakeRegressionRepository) ListVisibleChallengePacks(_ context.Context, _ uuid.UUID) ([]repository.ChallengePackSummary, error) {
@@ -1065,6 +1331,35 @@ func (f *fakeRegressionRepository) PatchRegressionSuite(_ context.Context, _ rep
 	return f.patchSuiteResult, f.patchSuiteErr
 }
 
+func (f *fakeRegressionRepository) CreateRegressionCase(_ context.Context, params repository.CreateRegressionCaseParams) (repository.RegressionCase, error) {
+	if f.createCaseErr != nil {
+		return repository.RegressionCase{}, f.createCaseErr
+	}
+	f.createCaseInput = &params
+	result := f.createCaseResult
+	if result.ID == uuid.Nil {
+		result.ID = uuid.New()
+	}
+	result.SuiteID = params.SuiteID
+	result.Title = params.Title
+	result.Status = params.Status
+	result.Severity = params.Severity
+	result.PromotionMode = params.PromotionMode
+	result.SourceChallengePackVersionID = params.SourceChallengePackVersionID
+	result.SourceChallengeInputSetID = cloneUUIDPtr(params.SourceChallengeInputSetID)
+	result.SourceChallengeIdentityID = params.SourceChallengeIdentityID
+	result.SourceCaseKey = params.SourceCaseKey
+	result.SourceItemKey = cloneStringPtr(params.SourceItemKey)
+	result.EvidenceTier = params.EvidenceTier
+	result.FailureClass = params.FailureClass
+	result.FailureSummary = params.FailureSummary
+	result.PayloadSnapshot = params.PayloadSnapshot
+	result.ExpectedContract = params.ExpectedContract
+	result.ValidatorOverrides = params.ValidatorOverrides
+	result.Metadata = params.Metadata
+	return result, nil
+}
+
 func (f *fakeRegressionRepository) GetRegressionCaseByID(_ context.Context, _ uuid.UUID) (repository.RegressionCase, error) {
 	if f.regressionCaseErr != nil {
 		return repository.RegressionCase{}, f.regressionCaseErr
@@ -1078,6 +1373,24 @@ func (f *fakeRegressionRepository) ListRegressionCasesBySuiteID(_ context.Contex
 
 func (f *fakeRegressionRepository) PatchRegressionCase(_ context.Context, _ repository.PatchRegressionCaseParams) (repository.RegressionCase, error) {
 	return f.patchCaseResult, f.patchCaseErr
+}
+
+func (f *fakeRegressionRepository) GetRunnableChallengePackVersionByID(_ context.Context, _ uuid.UUID) (repository.RunnableChallengePackVersion, error) {
+	if f.challengePackVersionErr != nil {
+		return repository.RunnableChallengePackVersion{}, f.challengePackVersionErr
+	}
+	return f.challengePackVersion, nil
+}
+
+func (f *fakeRegressionRepository) GetChallengeInputSetByID(_ context.Context, _ uuid.UUID) (repository.ChallengeInputSet, error) {
+	if f.challengeInputSetErr != nil {
+		return repository.ChallengeInputSet{}, f.challengeInputSetErr
+	}
+	return f.challengeInputSet, nil
+}
+
+func (f *fakeRegressionRepository) ListChallengeIdentityIDsByPackVersionID(_ context.Context, _ uuid.UUID) ([]uuid.UUID, error) {
+	return f.challengeIdentityIDs, f.challengeIdentityIDsErr
 }
 
 func (f *fakeRegressionRepository) GetRunByID(_ context.Context, _ uuid.UUID) (domain.Run, error) {
@@ -1131,9 +1444,11 @@ type fakeRegressionService struct {
 	listCasesErr    error
 	patchCaseErr    error
 	promoteErr      error
+	captureErr      error
 	patchSuiteInput *PatchRegressionSuiteInput
 	patchCaseInput  *PatchRegressionCaseInput
 	promoteInput    *PromoteFailureInput
+	captureInput    *CaptureProductionFailureInput
 }
 
 func (f *fakeRegressionService) CreateRegressionSuite(_ context.Context, _ Caller, input CreateRegressionSuiteInput) (repository.RegressionSuite, error) {
@@ -1217,4 +1532,36 @@ func (f *fakeRegressionService) PromoteFailure(_ context.Context, _ Caller, inpu
 		f.promoteResult.Case = f.regressionCase
 	}
 	return f.promoteResult, nil
+}
+
+func (f *fakeRegressionService) CaptureProductionFailure(_ context.Context, _ Caller, input CaptureProductionFailureInput) (repository.RegressionCase, error) {
+	if f.captureErr != nil {
+		return repository.RegressionCase{}, f.captureErr
+	}
+	f.captureInput = &input
+	if f.regressionCase.ID == uuid.Nil {
+		f.regressionCase.ID = uuid.New()
+	}
+	f.regressionCase.WorkspaceID = input.WorkspaceID
+	f.regressionCase.SuiteID = input.SuiteID
+	f.regressionCase.Title = input.Title
+	f.regressionCase.Status = domain.RegressionCaseStatusProposed
+	if input.Severity != nil {
+		f.regressionCase.Severity = *input.Severity
+	}
+	if input.PromotionMode != nil {
+		f.regressionCase.PromotionMode = *input.PromotionMode
+	}
+	f.regressionCase.SourceChallengePackVersionID = input.SourceChallengePackVersionID
+	f.regressionCase.SourceChallengeInputSetID = cloneUUIDPtr(input.SourceChallengeInputSetID)
+	f.regressionCase.SourceChallengeIdentityID = input.SourceChallengeIdentityID
+	f.regressionCase.SourceCaseKey = input.SourceCaseKey
+	f.regressionCase.SourceItemKey = cloneStringPtr(input.SourceItemKey)
+	f.regressionCase.EvidenceTier = input.EvidenceTier
+	f.regressionCase.FailureClass = input.FailureClass
+	f.regressionCase.FailureSummary = input.FailureSummary
+	f.regressionCase.PayloadSnapshot = input.PayloadSnapshot
+	f.regressionCase.ExpectedContract = input.ExpectedContract
+	f.regressionCase.Metadata = input.Metadata
+	return f.regressionCase, nil
 }

--- a/backend/internal/api/regression_suites_test.go
+++ b/backend/internal/api/regression_suites_test.go
@@ -637,6 +637,41 @@ func TestRegressionManagerCaptureProductionFailureCreatesProposedCase(t *testing
 	}
 }
 
+func TestProductionFailureMetadataDefaultsSourceBeforeFingerprint(t *testing.T) {
+	versionID := uuid.New()
+	challengeIdentityID := uuid.New()
+	baseInput := CaptureProductionFailureInput{
+		SourceChallengePackVersionID: versionID,
+		SourceChallengeIdentityID:    challengeIdentityID,
+		SourceCaseKey:                "prod-incident-123",
+		FailureSummary:               "Agent emitted an invalid tool argument in production.",
+	}
+	defaultMetadata, err := productionFailureMetadata(baseInput, string(failurereview.FailureClassToolArgumentError))
+	if err != nil {
+		t.Fatalf("productionFailureMetadata default source: %v", err)
+	}
+	baseInput.Source = "production"
+	explicitMetadata, err := productionFailureMetadata(baseInput, string(failurereview.FailureClassToolArgumentError))
+	if err != nil {
+		t.Fatalf("productionFailureMetadata explicit source: %v", err)
+	}
+
+	var defaultValues map[string]any
+	if err := json.Unmarshal(defaultMetadata, &defaultValues); err != nil {
+		t.Fatalf("default metadata unmarshal: %v", err)
+	}
+	var explicitValues map[string]any
+	if err := json.Unmarshal(explicitMetadata, &explicitValues); err != nil {
+		t.Fatalf("explicit metadata unmarshal: %v", err)
+	}
+	if defaultValues["source"] != "production" {
+		t.Fatalf("default source = %#v, want production", defaultValues["source"])
+	}
+	if defaultValues["source_failure_fingerprint"] != explicitValues["source_failure_fingerprint"] {
+		t.Fatalf("fingerprint default source = %#v, explicit production = %#v", defaultValues["source_failure_fingerprint"], explicitValues["source_failure_fingerprint"])
+	}
+}
+
 func TestRegressionManagerCaptureProductionFailureRejectsInvalidSources(t *testing.T) {
 	workspaceID := uuid.New()
 	suiteID := uuid.New()
@@ -802,6 +837,78 @@ func TestCaptureProductionFailureEndpointCreatesProposedCase(t *testing.T) {
 	}
 	if service.captureInput.PromotionMode == nil || *service.captureInput.PromotionMode != domain.RegressionPromotionModeManual {
 		t.Fatalf("promotion mode = %v, want manual", service.captureInput.PromotionMode)
+	}
+}
+
+func TestCaptureProductionFailureEndpointRejectsInvalidClassAndEvidenceTier(t *testing.T) {
+	workspaceID := uuid.New()
+	userID := uuid.New()
+	suiteID := uuid.New()
+	versionID := uuid.New()
+	challengeIdentityID := uuid.New()
+	service := &fakeRegressionService{}
+	router := buildRouter(routerOptions{
+		authMode:                   "dev",
+		logger:                     testLogger(t),
+		authenticator:              NewDevelopmentAuthenticator(),
+		authorizer:                 NewCallerWorkspaceAuthorizer(),
+		runCreationService:         stubRunCreationService{},
+		runReadService:             stubRunReadService{},
+		replayReadService:          stubReplayReadService{},
+		hostedRunIngestionService:  stubHostedRunIngestionService{},
+		compareReadService:         stubCompareReadService{},
+		agentDeploymentReadService: stubAgentDeploymentReadService{},
+		challengePackReadService:   stubChallengePackReadService{},
+		agentBuildService:          stubAgentBuildService{},
+		releaseGateService:         noopReleaseGateService{},
+		regressionService:          service,
+	})
+
+	testCases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "invalid failure class",
+			body: fmt.Sprintf(`{
+				"source_challenge_pack_version_id":"%s",
+				"source_challenge_identity_id":"%s",
+				"source_case_key":"prod-incident-123",
+				"title":"Production tool schema incident",
+				"failure_summary":"Agent emitted an invalid tool argument in production.",
+				"failure_class":"custom_agent_breakage",
+				"payload_snapshot":{"ticket":"example"}
+			}`, versionID, challengeIdentityID),
+		},
+		{
+			name: "invalid evidence tier",
+			body: fmt.Sprintf(`{
+				"source_challenge_pack_version_id":"%s",
+				"source_challenge_identity_id":"%s",
+				"source_case_key":"prod-incident-123",
+				"title":"Production tool schema incident",
+				"failure_summary":"Agent emitted an invalid tool argument in production.",
+				"evidence_tier":"custom_replay",
+				"payload_snapshot":{"ticket":"example"}
+			}`, versionID, challengeIdentityID),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/v1/workspaces/"+workspaceID.String()+"/regression-suites/"+suiteID.String()+"/production-failures", bytes.NewBufferString(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set(headerUserID, userID.String())
+			req.Header.Set(headerWorkspaceMemberships, workspaceID.String()+":workspace_member")
+			rec := httptest.NewRecorder()
+
+			router.ServeHTTP(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400, body=%s", rec.Code, rec.Body.String())
+			}
+			if service.captureInput != nil {
+				t.Fatal("service should not be called for invalid enum input")
+			}
+		})
 	}
 }
 

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -94,6 +94,7 @@ func registerProtectedRoutes(
 	router.Get("/workspaces/{workspaceID}/regression-suites/{suiteID}", getRegressionSuiteHandler(logger, regressionService))
 	router.Patch("/workspaces/{workspaceID}/regression-suites/{suiteID}", patchRegressionSuiteHandler(logger, regressionService))
 	router.Get("/workspaces/{workspaceID}/regression-suites/{suiteID}/cases", listRegressionCasesHandler(logger, regressionService))
+	router.Post("/workspaces/{workspaceID}/regression-suites/{suiteID}/production-failures", captureProductionFailureHandler(logger, regressionService))
 	router.Patch("/workspaces/{workspaceID}/regression-cases/{caseID}", patchRegressionCaseHandler(logger, regressionService))
 	router.Get("/replays/{runAgentID}/viewer", getRunAgentReplayViewerHandler(logger))
 	router.Get("/replays/{runAgentID}", getRunAgentReplayHandler(logger, replayReadService))

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -478,6 +478,10 @@ func (noopRegressionService) PromoteFailure(_ context.Context, _ Caller, _ Promo
 	return PromoteFailureResult{}, errors.New("regression service is not configured")
 }
 
+func (noopRegressionService) CaptureProductionFailure(_ context.Context, _ Caller, _ CaptureProductionFailureInput) (repository.RegressionCase, error) {
+	return repository.RegressionCase{}, errors.New("regression service is not configured")
+}
+
 type noopArtifactService struct{}
 
 func (noopArtifactService) UploadArtifact(_ context.Context, _ Caller, _ UploadArtifactInput) (UploadArtifactResult, error) {

--- a/cli/cmd/cli_surface_gaps_test.go
+++ b/cli/cmd/cli_surface_gaps_test.go
@@ -187,10 +187,11 @@ func TestRegressionCaseCaptureProductionPayload(t *testing.T) {
 		"--failure-summary", "Agent emitted an invalid tool argument.",
 		"--failure-class", "tool_argument_error",
 		"--incident-id", "INC-123",
+		"--observed-at", "2026-05-05T00:00:00Z",
 	}, srv.URL); err != nil {
 		t.Fatalf("capture production error: %v", err)
 	}
-	if gotBody["source_challenge_pack_version_id"] != "version-1" || gotBody["incident_id"] != "INC-123" {
+	if gotBody["source_challenge_pack_version_id"] != "version-1" || gotBody["incident_id"] != "INC-123" || gotBody["observed_at"] != "2026-05-05T00:00:00Z" {
 		t.Fatalf("unexpected body: %#v", gotBody)
 	}
 	if _, ok := gotBody["payload_snapshot"].(map[string]any); !ok {

--- a/cli/cmd/cli_surface_gaps_test.go
+++ b/cli/cmd/cli_surface_gaps_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"net/http"
+	"os"
 	"testing"
 )
 
@@ -155,6 +156,45 @@ func TestRegressionCaseUpdatePayload(t *testing.T) {
 	}
 	if gotBody["title"] != "Policy regression" || gotBody["severity"] != "warning" {
 		t.Fatalf("unexpected body: %#v", gotBody)
+	}
+}
+
+func TestRegressionCaseCaptureProductionPayload(t *testing.T) {
+	var gotBody map[string]any
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/workspaces/ws-123/regression-suites/suite-1/production-failures": func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			jsonHandler(201, map[string]any{"id": "case-1", "title": "Production incident"})(w, r)
+		},
+	})
+	defer srv.Close()
+
+	payloadPath := t.TempDir() + "/capture.json"
+	if err := os.WriteFile(payloadPath, []byte(`{"payload_snapshot":{"ticket":"example"},"expected_contract":{"validators":[]}}`), 0o600); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"regression-suite", "case", "capture-production", "suite-1", "-w", "ws-123",
+		"--from-file", payloadPath,
+		"--source-challenge-pack-version-id", "version-1",
+		"--source-challenge-identity-id", "identity-1",
+		"--source-case-key", "prod-incident-123",
+		"--title", "Production incident",
+		"--failure-summary", "Agent emitted an invalid tool argument.",
+		"--failure-class", "tool_argument_error",
+		"--incident-id", "INC-123",
+	}, srv.URL); err != nil {
+		t.Fatalf("capture production error: %v", err)
+	}
+	if gotBody["source_challenge_pack_version_id"] != "version-1" || gotBody["incident_id"] != "INC-123" {
+		t.Fatalf("unexpected body: %#v", gotBody)
+	}
+	if _, ok := gotBody["payload_snapshot"].(map[string]any); !ok {
+		t.Fatalf("payload_snapshot = %#v, want object from file", gotBody["payload_snapshot"])
 	}
 }
 

--- a/cli/cmd/regression_suite.go
+++ b/cli/cmd/regression_suite.go
@@ -51,6 +51,7 @@ func init() {
 	regressionCaseCaptureProductionCmd.Flags().String("incident-id", "", "Production incident ID")
 	regressionCaseCaptureProductionCmd.Flags().String("external-url", "", "Production incident URL")
 	regressionCaseCaptureProductionCmd.Flags().String("source", "", "Production source label")
+	regressionCaseCaptureProductionCmd.Flags().String("observed-at", "", "Production observation timestamp (RFC3339)")
 }
 
 var regressionSuiteCmd = &cobra.Command{
@@ -283,6 +284,7 @@ var regressionCaseCaptureProductionCmd = &cobra.Command{
 		setFlagIfChanged(cmd, body, "incident-id", "incident_id")
 		setFlagIfChanged(cmd, body, "external-url", "external_url")
 		setFlagIfChanged(cmd, body, "source", "source")
+		setFlagIfChanged(cmd, body, "observed-at", "observed_at")
 
 		resp, err := rc.Client.Post(cmd.Context(), "/v1/workspaces/"+wsID+"/regression-suites/"+args[0]+"/production-failures", body)
 		if err != nil {

--- a/cli/cmd/regression_suite.go
+++ b/cli/cmd/regression_suite.go
@@ -16,6 +16,7 @@ func init() {
 	regressionSuiteCmd.AddCommand(regressionSuiteCasesCmd)
 	regressionSuiteCmd.AddCommand(regressionCaseCmd)
 	regressionCaseCmd.AddCommand(regressionCaseUpdateCmd)
+	regressionCaseCmd.AddCommand(regressionCaseCaptureProductionCmd)
 
 	regressionSuiteCreateCmd.Flags().String("from-file", "", "JSON file with regression suite create payload")
 	regressionSuiteCreateCmd.Flags().String("source-challenge-pack-id", "", "Source challenge pack ID")
@@ -34,6 +35,22 @@ func init() {
 	regressionCaseUpdateCmd.Flags().String("description", "", "Case description")
 	regressionCaseUpdateCmd.Flags().String("status", "", "Case status: proposed, active, muted, archived, or rejected")
 	regressionCaseUpdateCmd.Flags().String("severity", "", "Case severity: info, warning, or blocking")
+
+	regressionCaseCaptureProductionCmd.Flags().String("from-file", "", "JSON file with production failure capture payload")
+	regressionCaseCaptureProductionCmd.Flags().String("source-challenge-pack-version-id", "", "Source challenge pack version ID")
+	regressionCaseCaptureProductionCmd.Flags().String("source-challenge-input-set-id", "", "Source challenge input set ID")
+	regressionCaseCaptureProductionCmd.Flags().String("source-challenge-identity-id", "", "Source challenge identity ID")
+	regressionCaseCaptureProductionCmd.Flags().String("source-case-key", "", "Source production case or incident key")
+	regressionCaseCaptureProductionCmd.Flags().String("source-item-key", "", "Source item key")
+	regressionCaseCaptureProductionCmd.Flags().String("title", "", "Regression case title")
+	regressionCaseCaptureProductionCmd.Flags().String("failure-summary", "", "Failure summary")
+	regressionCaseCaptureProductionCmd.Flags().String("failure-class", "", "Failure class")
+	regressionCaseCaptureProductionCmd.Flags().String("evidence-tier", "", "Evidence tier")
+	regressionCaseCaptureProductionCmd.Flags().String("severity", "", "Case severity: info, warning, or blocking")
+	regressionCaseCaptureProductionCmd.Flags().String("promotion-mode", "", "Promotion mode: full_executable, output_only, or manual")
+	regressionCaseCaptureProductionCmd.Flags().String("incident-id", "", "Production incident ID")
+	regressionCaseCaptureProductionCmd.Flags().String("external-url", "", "Production incident URL")
+	regressionCaseCaptureProductionCmd.Flags().String("source", "", "Production source label")
 }
 
 var regressionSuiteCmd = &cobra.Command{
@@ -237,6 +254,52 @@ var regressionCaseUpdateCmd = &cobra.Command{
 			return rc.Output.PrintRaw(regressionCase)
 		}
 		rc.Output.PrintSuccess(fmt.Sprintf("Updated regression case %s", args[0]))
+		return nil
+	},
+}
+
+var regressionCaseCaptureProductionCmd = &cobra.Command{
+	Use:   "capture-production <suiteId>",
+	Short: "Capture a production failure as a proposed regression case",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		wsID := RequireWorkspace(cmd)
+		body, err := loadBodyFromFileOrFlags(cmd)
+		if err != nil {
+			return err
+		}
+		setFlagIfChanged(cmd, body, "source-challenge-pack-version-id", "source_challenge_pack_version_id")
+		setFlagIfChanged(cmd, body, "source-challenge-input-set-id", "source_challenge_input_set_id")
+		setFlagIfChanged(cmd, body, "source-challenge-identity-id", "source_challenge_identity_id")
+		setFlagIfChanged(cmd, body, "source-case-key", "source_case_key")
+		setFlagIfChanged(cmd, body, "source-item-key", "source_item_key")
+		setFlagIfChanged(cmd, body, "title", "title")
+		setFlagIfChanged(cmd, body, "failure-summary", "failure_summary")
+		setFlagIfChanged(cmd, body, "failure-class", "failure_class")
+		setFlagIfChanged(cmd, body, "evidence-tier", "evidence_tier")
+		setFlagIfChanged(cmd, body, "severity", "severity")
+		setFlagIfChanged(cmd, body, "promotion-mode", "promotion_mode")
+		setFlagIfChanged(cmd, body, "incident-id", "incident_id")
+		setFlagIfChanged(cmd, body, "external-url", "external_url")
+		setFlagIfChanged(cmd, body, "source", "source")
+
+		resp, err := rc.Client.Post(cmd.Context(), "/v1/workspaces/"+wsID+"/regression-suites/"+args[0]+"/production-failures", body)
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+
+		var regressionCase map[string]any
+		if err := resp.DecodeJSON(&regressionCase); err != nil {
+			return err
+		}
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(regressionCase)
+		}
+		rc.Output.PrintSuccess(fmt.Sprintf("Captured production failure as regression case %s", str(regressionCase["id"])))
 		return nil
 	},
 }

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -2706,6 +2706,45 @@ paths:
         "404":
           $ref: "#/components/responses/NotFoundError"
 
+  /v1/workspaces/{workspaceID}/regression-suites/{suiteID}/production-failures:
+    post:
+      operationId: captureProductionFailure
+      tags: [Regressions]
+      summary: Capture a production failure as a proposed regression case
+      description: >
+        Creates a proposed regression case from an external or production
+        incident without requiring a run-agent failure review item.
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+        - $ref: "#/components/parameters/RegressionSuiteID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CaptureProductionFailureInput"
+      responses:
+        "201":
+          description: Production failure captured as a proposed regression case
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RegressionCase"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "409":
+          $ref: "#/components/responses/ConflictError"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
+
   /v1/workspaces/{workspaceID}/regression-cases/{caseID}:
     patch:
       operationId: patchRegressionCase
@@ -7071,6 +7110,67 @@ components:
           $ref: "#/components/schemas/RegressionCaseStatus"
         severity:
           $ref: "#/components/schemas/RegressionSeverity"
+
+    CaptureProductionFailureInput:
+      type: object
+      required:
+        - source_challenge_pack_version_id
+        - source_challenge_identity_id
+        - source_case_key
+        - title
+        - failure_summary
+        - payload_snapshot
+      properties:
+        source_challenge_pack_version_id:
+          type: string
+          format: uuid
+        source_challenge_input_set_id:
+          type: string
+          format: uuid
+        source_challenge_identity_id:
+          type: string
+          format: uuid
+        source_case_key:
+          type: string
+          description: Stable external case, session, or incident key.
+        source_item_key:
+          type: string
+        title:
+          type: string
+        failure_summary:
+          type: string
+        failure_class:
+          $ref: "#/components/schemas/FailureReviewFailureClass"
+        evidence_tier:
+          $ref: "#/components/schemas/FailureReviewEvidenceTier"
+        severity:
+          $ref: "#/components/schemas/RegressionSeverity"
+        promotion_mode:
+          $ref: "#/components/schemas/RegressionPromotionMode"
+        payload_snapshot:
+          type: object
+          additionalProperties: true
+        expected_contract:
+          type: object
+          additionalProperties: true
+        validator_overrides:
+          anyOf:
+            - type: object
+              additionalProperties: true
+            - type: "null"
+        metadata:
+          type: object
+          additionalProperties: true
+        incident_id:
+          type: string
+        external_url:
+          type: string
+        source:
+          type: string
+          description: External production system label; defaults to production.
+        observed_at:
+          type: string
+          format: date-time
 
     PromoteFailureInput:
       type: object

--- a/web/src/lib/api/__tests__/regression.test.ts
+++ b/web/src/lib/api/__tests__/regression.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createApiClient } from "../client";
 import {
   buildPromotionOverrides,
+  captureProductionFailure,
   defaultPromotionSeverityForFailure,
   listRegressionSuites,
   promoteFailure,
@@ -104,6 +105,61 @@ describe("Regression API helpers", () => {
           title: "Filesystem regression",
           failure_summary: "Attempted forbidden write",
           severity: "blocking",
+        }),
+      }),
+    );
+  });
+
+  it("posts production failures to a regression suite", async () => {
+    const capturedCase = {
+      id: "case-1",
+      suite_id: "suite-1",
+      workspace_id: "ws-1",
+      title: "Production incident",
+      description: "",
+      status: "proposed",
+      severity: "warning",
+      promotion_mode: "output_only",
+      source_challenge_pack_version_id: "cpv-1",
+      source_challenge_identity_id: "challenge-1",
+      source_case_key: "prod-incident-123",
+      evidence_tier: "hosted_black_box",
+      failure_class: "tool_argument_error",
+      failure_summary: "Agent emitted an invalid tool argument.",
+      payload_snapshot: {},
+      expected_contract: {},
+      metadata: { origin: "production_failure" },
+      created_at: "2026-05-05T00:00:00Z",
+      updated_at: "2026-05-05T00:00:00Z",
+    };
+    mockFetch.mockResolvedValueOnce(jsonResponse(capturedCase, 201));
+
+    const api = createApiClient("token");
+    const result = await captureProductionFailure(api, "ws-1", "suite-1", {
+      source_challenge_pack_version_id: "cpv-1",
+      source_challenge_identity_id: "challenge-1",
+      source_case_key: "prod-incident-123",
+      title: "Production incident",
+      failure_summary: "Agent emitted an invalid tool argument.",
+      failure_class: "tool_argument_error",
+      payload_snapshot: { ticket: "example" },
+      metadata: { incident_id: "INC-123" },
+    });
+
+    expect(result).toEqual(capturedCase);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/v1/workspaces/ws-1/regression-suites/suite-1/production-failures",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          source_challenge_pack_version_id: "cpv-1",
+          source_challenge_identity_id: "challenge-1",
+          source_case_key: "prod-incident-123",
+          title: "Production incident",
+          failure_summary: "Agent emitted an invalid tool argument.",
+          failure_class: "tool_argument_error",
+          payload_snapshot: { ticket: "example" },
+          metadata: { incident_id: "INC-123" },
         }),
       }),
     );

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -86,9 +86,11 @@ export { AGENT_KINDS } from "./types";
 export { listRunFailures, type ListRunFailuresParams } from "./failure-reviews";
 export {
   buildPromotionOverrides,
+  captureProductionFailure,
   defaultPromotionSeverityForFailure,
   listRegressionSuites,
   promoteFailure,
+  type CaptureProductionFailureInput,
   type ListRegressionSuitesParams,
   type PromoteFailureInput,
   type PromoteFailureResult,

--- a/web/src/lib/api/regression.ts
+++ b/web/src/lib/api/regression.ts
@@ -3,6 +3,7 @@ import type {
   FailureReviewFailureClass,
   FailureReviewPromotionMode,
   RegressionCase,
+  RegressionPromotionMode,
   RegressionSeverity,
   RegressionSuite,
 } from "./types";
@@ -30,6 +31,28 @@ export interface PromoteFailureInput {
 export interface PromoteFailureResult {
   case: RegressionCase;
   created: boolean;
+}
+
+export interface CaptureProductionFailureInput {
+  source_challenge_pack_version_id: string;
+  source_challenge_input_set_id?: string;
+  source_challenge_identity_id: string;
+  source_case_key: string;
+  source_item_key?: string;
+  title: string;
+  failure_summary: string;
+  failure_class?: FailureReviewFailureClass | string;
+  evidence_tier?: string;
+  severity?: RegressionSeverity;
+  promotion_mode?: RegressionPromotionMode;
+  payload_snapshot: Record<string, unknown>;
+  expected_contract?: Record<string, unknown>;
+  validator_overrides?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown>;
+  incident_id?: string;
+  external_url?: string;
+  source?: string;
+  observed_at?: string;
 }
 
 export function listRegressionSuites(
@@ -60,6 +83,18 @@ export async function promoteFailure(
     case: response.data,
     created: response.status === 201,
   };
+}
+
+export function captureProductionFailure(
+  api: ApiClient,
+  workspaceId: string,
+  suiteId: string,
+  input: CaptureProductionFailureInput,
+): Promise<RegressionCase> {
+  return api.post<RegressionCase>(
+    `/v1/workspaces/${workspaceId}/regression-suites/${suiteId}/production-failures`,
+    input,
+  );
 }
 
 export function defaultPromotionSeverityForFailure(

--- a/web/src/lib/api/regression.ts
+++ b/web/src/lib/api/regression.ts
@@ -1,5 +1,6 @@
 import type { ApiClient, PaginatedResponse } from "./client";
 import type {
+  FailureReviewEvidenceTier,
   FailureReviewFailureClass,
   FailureReviewPromotionMode,
   RegressionCase,
@@ -41,8 +42,8 @@ export interface CaptureProductionFailureInput {
   source_item_key?: string;
   title: string;
   failure_summary: string;
-  failure_class?: FailureReviewFailureClass | string;
-  evidence_tier?: string;
+  failure_class?: FailureReviewFailureClass;
+  evidence_tier?: FailureReviewEvidenceTier;
   severity?: RegressionSeverity;
   promotion_mode?: RegressionPromotionMode;
   payload_snapshot: Record<string, unknown>;


### PR DESCRIPTION
## Summary
- add a workspace-scoped production/external failure capture endpoint for regression suites
- create proposed regression cases without requiring run/run-agent records while validating suite/source pack/version/identity/input-set ownership
- add CLI capture command, OpenAPI schema, and web API helper/types

## Review checkpoint
- Contract: /tmp/reviewcheckpoint-issue-82-production-capture-contract.md
- Checkpoint: /tmp/reviewcheckpoint-issue-82-production-capture.json
- Verdict: ready

## Tests
- git diff --check origin/main...HEAD
- backend: go vet ./...
- backend: go test ./...
- cli: go test ./...
- web: npm run lint
- web: npx tsc --noEmit
- web: npm test
- web: npm run build

Refs #82