### PR TITLE
feat(regression): validate proposed cases explicitly

### DIFF
--- a/backend/internal/api/release_gates_regression.go
+++ b/backend/internal/api/release_gates_regression.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/agentclash/agentclash/backend/internal/domain"
 	"github.com/agentclash/agentclash/backend/internal/releasegate"
 	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/google/uuid"
@@ -158,22 +159,25 @@ func (m *ReleaseGateManager) loadRegressionCaseEvaluations(
 	evaluations := make(map[uuid.UUID]*releasegate.RegressionCaseEvaluation)
 	fallbackRefs := make(map[uuid.UUID][]releasegate.RegressionReplayStepRef)
 
-	ensureCase := func(caseID uuid.UUID) (*releasegate.RegressionCaseEvaluation, error) {
+	ensureCase := func(caseID uuid.UUID) (*releasegate.RegressionCaseEvaluation, bool, error) {
 		if existing, ok := evaluations[caseID]; ok {
-			return existing, nil
+			return existing, true, nil
 		}
 		regressionCase, ok := caseCache[caseID]
 		if !ok {
 			var loadErr error
 			regressionCase, loadErr = m.repo.GetRegressionCaseByID(ctx, caseID)
 			if loadErr != nil {
-				return nil, fmt.Errorf("load regression case %s: %w", caseID, loadErr)
+				return nil, false, fmt.Errorf("load regression case %s: %w", caseID, loadErr)
 			}
 			if regressionCase.WorkspaceID != workspaceID {
-				return nil, fmt.Errorf("%w: regression case %s belongs to workspace %s, want %s", errRegressionCaseWorkspaceMismatch, caseID, regressionCase.WorkspaceID, workspaceID)
+				return nil, false, fmt.Errorf("%w: regression case %s belongs to workspace %s, want %s", errRegressionCaseWorkspaceMismatch, caseID, regressionCase.WorkspaceID, workspaceID)
 			}
 			caseCache[caseID] = regressionCase
 			fallbackRefs[caseID] = promotionReplayRefs(regressionCase)
+		}
+		if regressionCase.Status != domain.RegressionCaseStatusActive {
+			return nil, false, nil
 		}
 		evaluation := &releasegate.RegressionCaseEvaluation{
 			RegressionCaseID: caseID,
@@ -181,19 +185,22 @@ func (m *ReleaseGateManager) loadRegressionCaseEvaluations(
 			Severity:         string(regressionCase.Severity),
 		}
 		evaluations[caseID] = evaluation
-		return evaluation, nil
+		return evaluation, true, nil
 	}
 
 	for _, result := range judgeResults {
 		if result.RegressionCaseID == nil {
 			continue
 		}
-		evaluation, err := ensureCase(*result.RegressionCaseID)
+		evaluation, ok, err := ensureCase(*result.RegressionCaseID)
 		if err != nil {
 			if errors.Is(err, errRegressionCaseWorkspaceMismatch) {
 				return nil, true, "regression scoring evidence referenced a regression case outside the authorized workspace; skipped regression gate rules", nil
 			}
 			return nil, false, "", err
+		}
+		if !ok {
+			continue
 		}
 		detail := validatorDetails[regressionDetailKey{CaseID: *result.RegressionCaseID, Key: result.JudgeKey}]
 		if !judgeResultFailed(result, detail) {
@@ -214,12 +221,15 @@ func (m *ReleaseGateManager) loadRegressionCaseEvaluations(
 		if result.RegressionCaseID == nil {
 			continue
 		}
-		evaluation, err := ensureCase(*result.RegressionCaseID)
+		evaluation, ok, err := ensureCase(*result.RegressionCaseID)
 		if err != nil {
 			if errors.Is(err, errRegressionCaseWorkspaceMismatch) {
 				return nil, true, "regression scoring evidence referenced a regression case outside the authorized workspace; skipped regression gate rules", nil
 			}
 			return nil, false, "", err
+		}
+		if !ok {
+			continue
 		}
 		detail := metricDetails[regressionDetailKey{CaseID: *result.RegressionCaseID, Key: result.MetricKey}]
 		if !metricResultFailed(result, detail) {

--- a/backend/internal/api/release_gates_test.go
+++ b/backend/internal/api/release_gates_test.go
@@ -83,6 +83,7 @@ func TestReleaseGateManagerEvaluatePersistsRegressionViolations(t *testing.T) {
 	evaluationSpecID := uuid.New()
 	comparisonID := uuid.New()
 	regressionCaseID := uuid.New()
+	proposedRegressionCaseID := uuid.New()
 	suiteID := uuid.New()
 	candidateJudgeResultID := uuid.New()
 
@@ -132,6 +133,11 @@ func TestReleaseGateManagerEvaluatePersistsRegressionViolations(t *testing.T) {
 							"event_type": "validator.completed",
 						},
 					},
+					map[string]any{
+						"key":                "proposed_check",
+						"state":              "available",
+						"regression_case_id": proposedRegressionCaseID.String(),
+					},
 				},
 				"metric_details": []any{},
 			})},
@@ -156,6 +162,14 @@ func TestReleaseGateManagerEvaluatePersistsRegressionViolations(t *testing.T) {
 					JudgeKey:         "correctness_check",
 					Verdict:          rgStringPtr("fail"),
 				},
+				{
+					ID:               uuid.New(),
+					RunAgentID:       candidateRunAgentID,
+					EvaluationSpecID: evaluationSpecID,
+					RegressionCaseID: &proposedRegressionCaseID,
+					JudgeKey:         "proposed_check",
+					Verdict:          rgStringPtr("fail"),
+				},
 			},
 			fakeReleaseGateResultsKey(baselineRunAgentID, evaluationSpecID): {
 				{
@@ -173,6 +187,7 @@ func TestReleaseGateManagerEvaluatePersistsRegressionViolations(t *testing.T) {
 				ID:          regressionCaseID,
 				WorkspaceID: workspaceID,
 				SuiteID:     suiteID,
+				Status:      domain.RegressionCaseStatusActive,
 				Severity:    domain.RegressionSeverityBlocking,
 				LatestPromotion: &repository.RegressionPromotion{
 					SourceEventRefs: mustJSON(t, []map[string]any{{
@@ -181,6 +196,13 @@ func TestReleaseGateManagerEvaluatePersistsRegressionViolations(t *testing.T) {
 						"kind":            "run_event",
 					}}),
 				},
+			},
+			proposedRegressionCaseID: {
+				ID:          proposedRegressionCaseID,
+				WorkspaceID: workspaceID,
+				SuiteID:     suiteID,
+				Status:      domain.RegressionCaseStatusProposed,
+				Severity:    domain.RegressionSeverityBlocking,
 			},
 		},
 		upsertedRecord: repository.RunComparisonReleaseGate{
@@ -337,6 +359,7 @@ func TestReleaseGateManagerEvaluateWarnsWhenBaselineRegressionEvidenceMissing(t 
 				ID:          regressionCaseID,
 				WorkspaceID: workspaceID,
 				SuiteID:     suiteID,
+				Status:      domain.RegressionCaseStatusActive,
 				Severity:    domain.RegressionSeverityBlocking,
 			},
 		},
@@ -545,6 +568,7 @@ func TestReleaseGateManagerEvaluateRejectsCrossWorkspaceRegressionCaseEvidence(t
 				ID:          regressionCaseID,
 				WorkspaceID: foreignWorkspaceID,
 				SuiteID:     uuid.New(),
+				Status:      domain.RegressionCaseStatusActive,
 				Severity:    domain.RegressionSeverityBlocking,
 			},
 		},
@@ -663,8 +687,8 @@ func TestReleaseGateManagerEvaluateScopesRegressionRulesToSelectedSuites(t *test
 			},
 		},
 		regressionCases: map[uuid.UUID]repository.RegressionCase{
-			allowedCaseID: {ID: allowedCaseID, WorkspaceID: workspaceID, SuiteID: allowedSuiteID, Severity: domain.RegressionSeverityBlocking},
-			blockedCaseID: {ID: blockedCaseID, WorkspaceID: workspaceID, SuiteID: blockedSuiteID, Severity: domain.RegressionSeverityBlocking},
+			allowedCaseID: {ID: allowedCaseID, WorkspaceID: workspaceID, SuiteID: allowedSuiteID, Status: domain.RegressionCaseStatusActive, Severity: domain.RegressionSeverityBlocking},
+			blockedCaseID: {ID: blockedCaseID, WorkspaceID: workspaceID, SuiteID: blockedSuiteID, Status: domain.RegressionCaseStatusActive, Severity: domain.RegressionSeverityBlocking},
 		},
 		upsertedRecord: repository.RunComparisonReleaseGate{
 			ID:        uuid.New(),

--- a/backend/internal/api/run_service.go
+++ b/backend/internal/api/run_service.go
@@ -399,10 +399,16 @@ func (m *RunCreationManager) resolveRunCaseSelections(
 				Message: "regression_case_ids must reference cases in the selected workspace",
 			}
 		}
-		if regressionCase.Status != domain.RegressionCaseStatusActive {
+		if !regressionCaseSelectableForRun(regressionCase.Status, input.IncludeProposedRegressions) {
+			if regressionCase.Status == domain.RegressionCaseStatusProposed && !input.IncludeProposedRegressions {
+				return nil, RunCreationValidationError{
+					Code:    "proposed_regression_case_ids",
+					Message: "regression_case_ids can include proposed cases only when include_proposed_regressions is true",
+				}
+			}
 			return nil, RunCreationValidationError{
 				Code:    "inactive_regression_case_ids",
-				Message: "regression_case_ids must reference active cases",
+				Message: "regression_case_ids must reference active cases or proposed cases explicitly included for validation",
 			}
 		}
 		if _, err := loadSuite(regressionCase.SuiteID); err != nil {
@@ -426,7 +432,7 @@ func (m *RunCreationManager) resolveRunCaseSelections(
 			return nil, fmt.Errorf("list regression cases by suite: %w", err)
 		}
 		for _, regressionCase := range regressionCases {
-			if regressionCase.Status != domain.RegressionCaseStatusActive {
+			if !regressionCaseSelectableForRun(regressionCase.Status, input.IncludeProposedRegressions) {
 				continue
 			}
 			appendSelection(repository.RunCaseSelectionOriginRegressionSuite, regressionCase.SourceChallengeIdentityID, &regressionCase.ID)
@@ -444,6 +450,11 @@ func (m *RunCreationManager) resolveRunCaseSelections(
 	}
 
 	return selections, nil
+}
+
+func regressionCaseSelectableForRun(status domain.RegressionCaseStatus, includeProposed bool) bool {
+	return status == domain.RegressionCaseStatusActive ||
+		(includeProposed && status == domain.RegressionCaseStatusProposed)
 }
 
 func buildExecutionPlan(input CreateRunInput, runAgents []repository.CreateQueuedRunAgentParams) (json.RawMessage, error) {

--- a/backend/internal/api/run_service_test.go
+++ b/backend/internal/api/run_service_test.go
@@ -1324,6 +1324,7 @@ func TestRunCreationManagerSkipsInactiveSuiteCasesWhenExpandingSelections(t *tes
 	runID := uuid.New()
 	suiteID := uuid.New()
 	activeCaseID := uuid.New()
+	proposedCaseID := uuid.New()
 	archivedCaseID := uuid.New()
 	activeChallengeID := uuid.New()
 
@@ -1365,6 +1366,13 @@ func TestRunCreationManagerSkipsInactiveSuiteCasesWhenExpandingSelections(t *tes
 					Status:                    domain.RegressionCaseStatusArchived,
 					SourceChallengeIdentityID: uuid.New(),
 				},
+				{
+					ID:                        proposedCaseID,
+					SuiteID:                   suiteID,
+					WorkspaceID:               workspaceID,
+					Status:                    domain.RegressionCaseStatusProposed,
+					SourceChallengeIdentityID: uuid.New(),
+				},
 			},
 		},
 		createResult: repository.CreateQueuedRunResult{
@@ -1403,6 +1411,175 @@ func TestRunCreationManagerSkipsInactiveSuiteCasesWhenExpandingSelections(t *tes
 	}
 	if repo.createParams.CaseSelections[0].RegressionCaseID == nil || *repo.createParams.CaseSelections[0].RegressionCaseID != activeCaseID {
 		t.Fatalf("selected regression case = %v, want %s", repo.createParams.CaseSelections[0].RegressionCaseID, activeCaseID)
+	}
+}
+
+func TestRunCreationManagerRejectsProposedRegressionCaseUnlessValidationEnabled(t *testing.T) {
+	workspaceID := uuid.New()
+	challengePackVersionID := uuid.New()
+	challengePackID := uuid.New()
+	deploymentID := uuid.New()
+	regressionCaseID := uuid.New()
+	suiteID := uuid.New()
+
+	repo := &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{
+			ID:              challengePackVersionID,
+			ChallengePackID: challengePackID,
+		},
+		deployments: []repository.RunnableDeployment{
+			{
+				ID:                        deploymentID,
+				OrganizationID:            uuid.New(),
+				WorkspaceID:               workspaceID,
+				Name:                      "Agent",
+				AgentDeploymentSnapshotID: uuid.New(),
+			},
+		},
+		regressionSuites: map[uuid.UUID]repository.RegressionSuite{
+			suiteID: {
+				ID:                    suiteID,
+				WorkspaceID:           workspaceID,
+				SourceChallengePackID: challengePackID,
+				Status:                domain.RegressionSuiteStatusActive,
+			},
+		},
+		regressionCases: map[uuid.UUID]repository.RegressionCase{
+			regressionCaseID: {
+				ID:                        regressionCaseID,
+				SuiteID:                   suiteID,
+				WorkspaceID:               workspaceID,
+				Status:                    domain.RegressionCaseStatusProposed,
+				SourceChallengeIdentityID: uuid.New(),
+			},
+		},
+	}
+
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, &fakeRunWorkflowStarter{}, nil)
+	_, err := manager.CreateRun(context.Background(), Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}, CreateRunInput{
+		WorkspaceID:            workspaceID,
+		ChallengePackVersionID: challengePackVersionID,
+		AgentDeploymentIDs:     []uuid.UUID{deploymentID},
+		RegressionCaseIDs:      []uuid.UUID{regressionCaseID},
+	})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	var validationErr RunCreationValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error = %v, want RunCreationValidationError", err)
+	}
+	if validationErr.Code != "proposed_regression_case_ids" {
+		t.Fatalf("validation code = %q, want proposed_regression_case_ids", validationErr.Code)
+	}
+}
+
+func TestRunCreationManagerIncludesProposedRegressionCasesForValidationRuns(t *testing.T) {
+	workspaceID := uuid.New()
+	challengePackVersionID := uuid.New()
+	challengePackID := uuid.New()
+	deploymentID := uuid.New()
+	runID := uuid.New()
+	suiteID := uuid.New()
+	directProposedCaseID := uuid.New()
+	suiteProposedCaseID := uuid.New()
+	mutedCaseID := uuid.New()
+
+	repo := &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{
+			ID:              challengePackVersionID,
+			ChallengePackID: challengePackID,
+		},
+		deployments: []repository.RunnableDeployment{
+			{
+				ID:                        deploymentID,
+				OrganizationID:            uuid.New(),
+				WorkspaceID:               workspaceID,
+				Name:                      "Agent",
+				AgentDeploymentSnapshotID: uuid.New(),
+			},
+		},
+		regressionSuites: map[uuid.UUID]repository.RegressionSuite{
+			suiteID: {
+				ID:                    suiteID,
+				WorkspaceID:           workspaceID,
+				SourceChallengePackID: challengePackID,
+				Status:                domain.RegressionSuiteStatusActive,
+			},
+		},
+		regressionCases: map[uuid.UUID]repository.RegressionCase{
+			directProposedCaseID: {
+				ID:                        directProposedCaseID,
+				SuiteID:                   suiteID,
+				WorkspaceID:               workspaceID,
+				Status:                    domain.RegressionCaseStatusProposed,
+				SourceChallengeIdentityID: uuid.New(),
+			},
+		},
+		regressionCasesBySuite: map[uuid.UUID][]repository.RegressionCase{
+			suiteID: {
+				{
+					ID:                        suiteProposedCaseID,
+					SuiteID:                   suiteID,
+					WorkspaceID:               workspaceID,
+					Status:                    domain.RegressionCaseStatusProposed,
+					SourceChallengeIdentityID: uuid.New(),
+				},
+				{
+					ID:                        mutedCaseID,
+					SuiteID:                   suiteID,
+					WorkspaceID:               workspaceID,
+					Status:                    domain.RegressionCaseStatusMuted,
+					SourceChallengeIdentityID: uuid.New(),
+				},
+			},
+		},
+		createResult: repository.CreateQueuedRunResult{
+			Run: domain.Run{
+				ID:               runID,
+				WorkspaceID:      workspaceID,
+				OfficialPackMode: domain.OfficialPackModeSuiteOnly,
+				Status:           domain.RunStatusQueued,
+				ExecutionMode:    "single_agent",
+			},
+		},
+	}
+
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, &fakeRunWorkflowStarter{}, nil)
+	_, err := manager.CreateRun(context.Background(), Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}, CreateRunInput{
+		WorkspaceID:                workspaceID,
+		ChallengePackVersionID:     challengePackVersionID,
+		OfficialPackMode:           domain.OfficialPackModeSuiteOnly,
+		AgentDeploymentIDs:         []uuid.UUID{deploymentID},
+		RegressionSuiteIDs:         []uuid.UUID{suiteID},
+		RegressionCaseIDs:          []uuid.UUID{directProposedCaseID},
+		IncludeProposedRegressions: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateRun returned error: %v", err)
+	}
+
+	selected := map[uuid.UUID]bool{}
+	for _, selection := range repo.createParams.CaseSelections {
+		if selection.RegressionCaseID != nil {
+			selected[*selection.RegressionCaseID] = true
+		}
+	}
+	if !selected[directProposedCaseID] || !selected[suiteProposedCaseID] {
+		t.Fatalf("selected regression cases = %#v, want direct and suite proposed cases", selected)
+	}
+	if selected[mutedCaseID] {
+		t.Fatalf("selected muted case %s", mutedCaseID)
 	}
 }
 

--- a/backend/internal/api/runs.go
+++ b/backend/internal/api/runs.go
@@ -34,6 +34,9 @@ type createRunRequest struct {
 	RegressionSuiteIDs     []string `json:"regression_suite_ids,omitempty"`
 	RegressionCaseIDs      []string `json:"regression_case_ids,omitempty"`
 	OfficialPackMode       string   `json:"official_pack_mode,omitempty"`
+	// IncludeProposedRegressions lets explicit validation runs execute proposed
+	// cases before they are activated into CI gate scope.
+	IncludeProposedRegressions bool `json:"include_proposed_regressions,omitempty"`
 	// RaceContext opts the run into live peer-standings injection. See #400.
 	// Requires at least two agents; a request with true + one agent is 400.
 	RaceContext bool `json:"race_context,omitempty"`
@@ -44,17 +47,18 @@ type createRunRequest struct {
 }
 
 type CreateRunInput struct {
-	WorkspaceID            uuid.UUID
-	ChallengePackVersionID uuid.UUID
-	ChallengeInputSetID    *uuid.UUID
-	OfficialPackMode       domain.OfficialPackMode
-	Name                   string
-	AgentDeploymentIDs     []uuid.UUID
-	RegressionSuiteIDs     []uuid.UUID
-	RegressionCaseIDs      []uuid.UUID
-	RaceContext            bool
-	RaceContextMinStepGap  *int32
-	CIMetadata             *domain.RunCIMetadata
+	WorkspaceID                uuid.UUID
+	ChallengePackVersionID     uuid.UUID
+	ChallengeInputSetID        *uuid.UUID
+	OfficialPackMode           domain.OfficialPackMode
+	Name                       string
+	AgentDeploymentIDs         []uuid.UUID
+	RegressionSuiteIDs         []uuid.UUID
+	RegressionCaseIDs          []uuid.UUID
+	IncludeProposedRegressions bool
+	RaceContext                bool
+	RaceContextMinStepGap      *int32
+	CIMetadata                 *domain.RunCIMetadata
 }
 
 type CreateRunResult struct {
@@ -315,17 +319,18 @@ func decodeCreateRunRequest(r *http.Request) (CreateRunInput, error) {
 	}
 
 	return CreateRunInput{
-		WorkspaceID:            workspaceID,
-		ChallengePackVersionID: challengePackVersionID,
-		ChallengeInputSetID:    challengeInputSetID,
-		OfficialPackMode:       officialPackMode,
-		Name:                   strings.TrimSpace(body.Name),
-		AgentDeploymentIDs:     deploymentIDs,
-		RegressionSuiteIDs:     regressionSuiteIDs,
-		RegressionCaseIDs:      regressionCaseIDs,
-		RaceContext:            body.RaceContext,
-		RaceContextMinStepGap:  raceContextMinStepGap,
-		CIMetadata:             ciMetadata,
+		WorkspaceID:                workspaceID,
+		ChallengePackVersionID:     challengePackVersionID,
+		ChallengeInputSetID:        challengeInputSetID,
+		OfficialPackMode:           officialPackMode,
+		Name:                       strings.TrimSpace(body.Name),
+		AgentDeploymentIDs:         deploymentIDs,
+		RegressionSuiteIDs:         regressionSuiteIDs,
+		RegressionCaseIDs:          regressionCaseIDs,
+		IncludeProposedRegressions: body.IncludeProposedRegressions,
+		RaceContext:                body.RaceContext,
+		RaceContextMinStepGap:      raceContextMinStepGap,
+		CIMetadata:                 ciMetadata,
 	}, nil
 }
 

--- a/cli/cmd/contract_alignment_test.go
+++ b/cli/cmd/contract_alignment_test.go
@@ -71,6 +71,7 @@ func TestRunCreateUsesRegressionSelectorsAndOfficialPackMode(t *testing.T) {
 		"--scope", "suite_only",
 		"--suite", "suite-1",
 		"--case", "case-1",
+		"--include-proposed-regressions",
 	}, srv.URL)
 	if err != nil {
 		t.Fatalf("run create error: %v", err)
@@ -84,6 +85,9 @@ func TestRunCreateUsesRegressionSelectorsAndOfficialPackMode(t *testing.T) {
 	}
 	if caseIDs, ok := gotBody["regression_case_ids"].([]any); !ok || len(caseIDs) != 1 || caseIDs[0] != "case-1" {
 		t.Fatalf("regression_case_ids = %#v, want [case-1]", gotBody["regression_case_ids"])
+	}
+	if gotBody["include_proposed_regressions"] != true {
+		t.Fatalf("include_proposed_regressions = %v, want true", gotBody["include_proposed_regressions"])
 	}
 }
 

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -33,6 +33,7 @@ func init() {
 	runCreateCmd.Flags().String("scope", "full", "Run scope: full or suite_only")
 	runCreateCmd.Flags().StringSlice("suite", nil, "Regression suite IDs (repeatable; required with --scope suite_only unless --case is used)")
 	runCreateCmd.Flags().StringSlice("case", nil, "Regression case IDs (repeatable)")
+	runCreateCmd.Flags().Bool("include-proposed-regressions", false, "Include proposed regression cases for validation runs")
 	runCreateCmd.Flags().Bool("race-context", false, "Enable live peer-standings injection during the run (requires 2+ agents)")
 	runCreateCmd.Flags().Int("race-context-cadence", 0, "Override race-context cadence; minimum steps between standings injections, [1, 10]. 0 uses the backend default.")
 

--- a/cli/cmd/run_create_helpers.go
+++ b/cli/cmd/run_create_helpers.go
@@ -10,16 +10,17 @@ import (
 )
 
 type runCreateRequest struct {
-	ChallengePackVersionID string
-	ChallengeInputSetID    string
-	DeploymentIDs          []string
-	Name                   string
-	OfficialPackMode       string
-	RegressionSuiteIDs     []string
-	RegressionCaseIDs      []string
-	RaceContext            bool
-	RaceContextCadence     int
-	CIMetadata             map[string]any
+	ChallengePackVersionID     string
+	ChallengeInputSetID        string
+	DeploymentIDs              []string
+	Name                       string
+	OfficialPackMode           string
+	RegressionSuiteIDs         []string
+	RegressionCaseIDs          []string
+	IncludeProposedRegressions bool
+	RaceContext                bool
+	RaceContextCadence         int
+	CIMetadata                 map[string]any
 }
 
 func runCreateRequestFromFlags(cmd *cobra.Command, base runCreateRequest) (runCreateRequest, error) {
@@ -44,6 +45,8 @@ func runCreateRequestFromFlags(cmd *cobra.Command, base runCreateRequest) (runCr
 	caseIDs, _ := cmd.Flags().GetStringSlice("case")
 	request.RegressionSuiteIDs = compactNonEmptyStrings(suiteIDs)
 	request.RegressionCaseIDs = compactNonEmptyStrings(caseIDs)
+	includeProposed, _ := cmd.Flags().GetBool("include-proposed-regressions")
+	request.IncludeProposedRegressions = includeProposed
 
 	raceContext, _ := cmd.Flags().GetBool("race-context")
 	request.RaceContext = raceContext
@@ -85,6 +88,9 @@ func buildRunCreateBody(workspaceID string, request runCreateRequest) (map[strin
 	}
 	if len(request.RegressionCaseIDs) > 0 {
 		body["regression_case_ids"] = request.RegressionCaseIDs
+	}
+	if request.IncludeProposedRegressions {
+		body["include_proposed_regressions"] = true
 	}
 	if request.RaceContext {
 		body["race_context"] = true

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -5626,6 +5626,13 @@ components:
             Optional. Defaults to `full`. Use `suite_only` to execute only the
             resolved regression selection instead of unioning it with the full
             official pack case set.
+        include_proposed_regressions:
+          type: boolean
+          default: false
+          description: >
+            Optional. When true, explicitly selected regression suites and cases
+            may include proposed regression cases for validation runs. Release
+            gates still enforce only active regression cases.
         race_context:
           type: boolean
           default: false

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -661,6 +661,7 @@ export interface CreateRunRequest {
   regression_suite_ids?: string[];
   regression_case_ids?: string[];
   official_pack_mode?: OfficialPackMode;
+  include_proposed_regressions?: boolean;
   race_context?: boolean;
   race_context_min_step_gap?: number;
   ci_metadata?: RunCIMetadata;


### PR DESCRIPTION
## Summary
- add `include_proposed_regressions` to run creation for explicit validation runs
- keep default regression selection active-only while allowing proposed direct/suite cases only when requested
- ensure release gates enforce only active regression cases, so proposed validation evidence cannot block CI
- expose the switch in CLI, OpenAPI, and web API types

## Review checkpoint
- Contract: /tmp/reviewcheckpoint-issue-82-validation-confidence-contract.md
- Checkpoint: /tmp/reviewcheckpoint-issue-82-validation-confidence.json
- Verdict: ready

## Tests
- git diff --check origin/main...HEAD
- backend: go vet ./...
- backend: go test ./...
- cli: go test ./...
- web: npm run lint
- web: npx tsc --noEmit
- web: npm test
- web: npm run build

Refs #82