### PR TITLE
feat(regression): expose proposed validation runs in web

### DIFF
--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.test.tsx
@@ -318,6 +318,27 @@ function buildApiMock(options: BuildApiMockOptions = {}) {
             created_at: "2026-04-19T00:00:00Z",
             updated_at: "2026-04-19T00:00:00Z",
           },
+          {
+            id: "case-2",
+            suite_id: "suite-1",
+            workspace_id: "ws-1",
+            title: "Unvalidated Regression",
+            description: "",
+            status: "proposed",
+            severity: "warning",
+            promotion_mode: "full_executable",
+            source_challenge_pack_version_id: "version-1",
+            source_challenge_identity_id: "challenge-2",
+            source_case_key: "case-b",
+            evidence_tier: "native_structured",
+            failure_class: "tool_argument_error",
+            failure_summary: "Mismatched tool arguments",
+            payload_snapshot: {},
+            expected_contract: {},
+            metadata: {},
+            created_at: "2026-04-19T00:00:00Z",
+            updated_at: "2026-04-19T00:00:00Z",
+          },
         ],
       };
     }
@@ -336,7 +357,7 @@ function buildApiMock(options: BuildApiMockOptions = {}) {
             status: "active",
             source_mode: "derived_only",
             default_gate_severity: "warning",
-            case_count: 1,
+            case_count: 2,
             created_by_user_id: "user-1",
             created_at: "2026-04-19T00:00:00Z",
             updated_at: "2026-04-19T00:00:00Z",
@@ -411,6 +432,7 @@ describe("CreateRunDialog", () => {
       clickElement(findCheckboxByLabel("Primary Agent"));
       clickElement(findCheckboxByLabel("Regression Suite"));
       clickElement(findCheckboxByLabel("Filesystem Regression"));
+      expect(() => findCheckboxByLabel("Unvalidated Regression")).toThrow();
 
       const officialPackModeSelect = document.querySelector(
         'select[aria-label="Official Pack Mode"]',
@@ -432,6 +454,134 @@ describe("CreateRunDialog", () => {
           regression_suite_ids: ["suite-1"],
           regression_case_ids: ["case-1"],
           official_pack_mode: "suite_only",
+          race_context: false,
+        });
+      });
+    } finally {
+      view.cleanup();
+    }
+  });
+
+  it("submits proposed regression cases only when validation runs are enabled", async () => {
+    const api = buildApiMock();
+    mockCreateApiClient.mockReturnValue(api);
+
+    const view = renderDialog();
+    try {
+      clickElement(findButton("New Run"));
+
+      await waitFor(() => {
+        expect(api.get).toHaveBeenCalledWith(
+          "/v1/workspaces/ws-1/challenge-packs",
+        );
+      });
+
+      const packSelect = document.querySelector(
+        'select[aria-label="Challenge Pack"]',
+      );
+      if (!(packSelect instanceof HTMLSelectElement)) {
+        throw new Error("Challenge Pack select not found");
+      }
+      changeSelect(packSelect, "pack-1");
+
+      await waitFor(() => {
+        expect(api.get).toHaveBeenCalledWith(
+          "/v1/workspaces/ws-1/regression-suites/suite-1/cases",
+        );
+      });
+      await waitFor(() => {
+        expect(api.get).toHaveBeenCalledWith(
+          "/v1/workspaces/ws-1/challenge-pack-versions/version-1/input-sets",
+        );
+      });
+
+      expect(() => findCheckboxByLabel("Unvalidated Regression")).toThrow();
+
+      clickElement(findCheckboxByLabel("Include proposed cases for validation"));
+      await waitFor(() => {
+        expect(findCheckboxByLabel("Unvalidated Regression")).toBeTruthy();
+      });
+
+      clickElement(findCheckboxByLabel("Primary Agent"));
+      clickElement(findCheckboxByLabel("Unvalidated Regression"));
+      clickElement(findButton("Create Run"));
+
+      await waitFor(() => {
+        expect(api.post).toHaveBeenCalledWith("/v1/runs", {
+          workspace_id: "ws-1",
+          challenge_pack_version_id: "version-1",
+          challenge_input_set_id: undefined,
+          name: undefined,
+          agent_deployment_ids: ["deploy-1"],
+          regression_suite_ids: undefined,
+          regression_case_ids: ["case-2"],
+          official_pack_mode: "full",
+          include_proposed_regressions: true,
+          race_context: false,
+        });
+      });
+    } finally {
+      view.cleanup();
+    }
+  });
+
+  it("clears proposed regression selections when validation runs are disabled", async () => {
+    const api = buildApiMock();
+    mockCreateApiClient.mockReturnValue(api);
+
+    const view = renderDialog();
+    try {
+      clickElement(findButton("New Run"));
+
+      await waitFor(() => {
+        expect(api.get).toHaveBeenCalledWith(
+          "/v1/workspaces/ws-1/challenge-packs",
+        );
+      });
+
+      const packSelect = document.querySelector(
+        'select[aria-label="Challenge Pack"]',
+      );
+      if (!(packSelect instanceof HTMLSelectElement)) {
+        throw new Error("Challenge Pack select not found");
+      }
+      changeSelect(packSelect, "pack-1");
+
+      await waitFor(() => {
+        expect(api.get).toHaveBeenCalledWith(
+          "/v1/workspaces/ws-1/regression-suites/suite-1/cases",
+        );
+      });
+      await waitFor(() => {
+        expect(api.get).toHaveBeenCalledWith(
+          "/v1/workspaces/ws-1/challenge-pack-versions/version-1/input-sets",
+        );
+      });
+
+      clickElement(findCheckboxByLabel("Include proposed cases for validation"));
+      await waitFor(() => {
+        expect(findCheckboxByLabel("Unvalidated Regression")).toBeTruthy();
+      });
+      clickElement(findCheckboxByLabel("Unvalidated Regression"));
+
+      clickElement(findCheckboxByLabel("Include proposed cases for validation"));
+      await waitFor(() => {
+        expect(() => findCheckboxByLabel("Unvalidated Regression")).toThrow();
+      });
+
+      clickElement(findCheckboxByLabel("Primary Agent"));
+      clickElement(findButton("Create Run"));
+
+      await waitFor(() => {
+        expect(api.post).toHaveBeenCalledWith("/v1/runs", {
+          workspace_id: "ws-1",
+          challenge_pack_version_id: "version-1",
+          challenge_input_set_id: undefined,
+          name: undefined,
+          agent_deployment_ids: ["deploy-1"],
+          regression_suite_ids: undefined,
+          regression_case_ids: undefined,
+          official_pack_mode: undefined,
           race_context: false,
         });
       });

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.test.tsx
@@ -454,6 +454,7 @@ describe("CreateRunDialog", () => {
           regression_suite_ids: ["suite-1"],
           regression_case_ids: ["case-1"],
           official_pack_mode: "suite_only",
+          include_proposed_regressions: false,
           race_context: false,
         });
       });
@@ -582,6 +583,72 @@ describe("CreateRunDialog", () => {
           regression_suite_ids: undefined,
           regression_case_ids: undefined,
           official_pack_mode: undefined,
+          race_context: false,
+        });
+      });
+    } finally {
+      view.cleanup();
+    }
+  });
+
+  it("submits an explicit proposed-regression false flag for suite selections after opt-out", async () => {
+    const api = buildApiMock();
+    mockCreateApiClient.mockReturnValue(api);
+
+    const view = renderDialog();
+    try {
+      clickElement(findButton("New Run"));
+
+      await waitFor(() => {
+        expect(api.get).toHaveBeenCalledWith(
+          "/v1/workspaces/ws-1/challenge-packs",
+        );
+      });
+
+      const packSelect = document.querySelector(
+        'select[aria-label="Challenge Pack"]',
+      );
+      if (!(packSelect instanceof HTMLSelectElement)) {
+        throw new Error("Challenge Pack select not found");
+      }
+      changeSelect(packSelect, "pack-1");
+
+      await waitFor(() => {
+        expect(api.get).toHaveBeenCalledWith(
+          "/v1/workspaces/ws-1/regression-suites/suite-1/cases",
+        );
+      });
+      await waitFor(() => {
+        expect(api.get).toHaveBeenCalledWith(
+          "/v1/workspaces/ws-1/challenge-pack-versions/version-1/input-sets",
+        );
+      });
+
+      clickElement(findCheckboxByLabel("Include proposed cases for validation"));
+      await waitFor(() => {
+        expect(findCheckboxByLabel("Unvalidated Regression")).toBeTruthy();
+      });
+      clickElement(findCheckboxByLabel("Regression Suite"));
+
+      clickElement(findCheckboxByLabel("Include proposed cases for validation"));
+      await waitFor(() => {
+        expect(() => findCheckboxByLabel("Unvalidated Regression")).toThrow();
+      });
+
+      clickElement(findCheckboxByLabel("Primary Agent"));
+      clickElement(findButton("Create Run"));
+
+      await waitFor(() => {
+        expect(api.post).toHaveBeenCalledWith("/v1/runs", {
+          workspace_id: "ws-1",
+          challenge_pack_version_id: "version-1",
+          challenge_input_set_id: undefined,
+          name: undefined,
+          agent_deployment_ids: ["deploy-1"],
+          regression_suite_ids: ["suite-1"],
+          regression_case_ids: undefined,
+          official_pack_mode: "full",
+          include_proposed_regressions: false,
           race_context: false,
         });
       });

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
@@ -335,9 +335,9 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
             ? selectedRegressionCaseIds
             : undefined,
         official_pack_mode: hasRegressionSelection ? officialPackMode : undefined,
-        ...(hasRegressionSelection && includeProposedRegressions
-          ? { include_proposed_regressions: true }
-          : {}),
+        include_proposed_regressions: hasRegressionSelection
+          ? includeProposedRegressions
+          : undefined,
         race_context: raceContext,
       };
       const result = await api.post<CreateRunResponse>("/v1/runs", request);

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
@@ -56,6 +56,8 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
   const [selectedRegressionCaseIds, setSelectedRegressionCaseIds] = useState<
     string[]
   >([]);
+  const [includeProposedRegressions, setIncludeProposedRegressions] =
+    useState(false);
   const [officialPackMode, setOfficialPackMode] =
     useState<OfficialPackMode>("full");
   const [raceContext, setRaceContext] = useState(false);
@@ -131,6 +133,7 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
     setInputSets([]);
     setSelectedRegressionSuiteIds([]);
     setSelectedRegressionCaseIds([]);
+    setIncludeProposedRegressions(false);
     setOfficialPackMode("full");
     setRegressionLoadError(null);
     if (packId) {
@@ -246,7 +249,11 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
             );
             return [
               suiteId,
-              response.items.filter((regressionCase) => regressionCase.status === "active"),
+              response.items.filter(
+                (regressionCase) =>
+                  regressionCase.status === "active" ||
+                  regressionCase.status === "proposed",
+              ),
             ] as const;
           }),
         );
@@ -279,6 +286,25 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
   }, [getAccessToken, open, regressionSuites, selectedPackId, workspaceId]);
 
   useEffect(() => {
+    if (includeProposedRegressions) return;
+
+    const proposedCaseIds = new Set<string>();
+    for (const cases of Object.values(suiteCases)) {
+      for (const regressionCase of cases) {
+        if (regressionCase.status === "proposed") {
+          proposedCaseIds.add(regressionCase.id);
+        }
+      }
+    }
+
+    if (proposedCaseIds.size === 0) return;
+
+    setSelectedRegressionCaseIds((prev) =>
+      prev.filter((caseId) => !proposedCaseIds.has(caseId)),
+    );
+  }, [includeProposedRegressions, suiteCases]);
+
+  useEffect(() => {
     if (selectedRegressionSuiteIds.length === 0 && selectedRegressionCaseIds.length === 0) {
       setOfficialPackMode("full");
     }
@@ -289,6 +315,9 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
 
     setSubmitting(true);
     try {
+      const hasRegressionSelection =
+        selectedRegressionSuiteIds.length > 0 ||
+        selectedRegressionCaseIds.length > 0;
       const token = await getAccessToken();
       const api = createApiClient(token);
       const request: CreateRunRequest = {
@@ -305,11 +334,10 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
           selectedRegressionCaseIds.length > 0
             ? selectedRegressionCaseIds
             : undefined,
-        official_pack_mode:
-          selectedRegressionSuiteIds.length > 0 ||
-          selectedRegressionCaseIds.length > 0
-            ? officialPackMode
-            : undefined,
+        official_pack_mode: hasRegressionSelection ? officialPackMode : undefined,
+        ...(hasRegressionSelection && includeProposedRegressions
+          ? { include_proposed_regressions: true }
+          : {}),
         race_context: raceContext,
       };
       const result = await api.post<CreateRunResponse>("/v1/runs", request);
@@ -341,6 +369,7 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
     setSelectedDeploymentIds([]);
     setSelectedRegressionSuiteIds([]);
     setSelectedRegressionCaseIds([]);
+    setIncludeProposedRegressions(false);
     setOfficialPackMode("full");
     setRaceContext(false);
     setRegressionLoadError(null);
@@ -524,9 +553,31 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
               </p>
             ) : (
               <div className="space-y-3">
+                <label className="flex items-start gap-2 rounded-lg border border-input p-2 text-sm cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={includeProposedRegressions}
+                    onChange={(e) =>
+                      setIncludeProposedRegressions(e.target.checked)
+                    }
+                    className="mt-0.5 rounded border-input"
+                  />
+                  <span className="space-y-0.5">
+                    <span className="block font-medium text-foreground">
+                      Include proposed cases for validation
+                    </span>
+                    <span className="block text-xs text-muted-foreground">
+                      Proposed cases collect signal but do not block release gates.
+                    </span>
+                  </span>
+                </label>
                 <div className="space-y-2 rounded-lg border border-input p-2">
                   {eligibleRegressionSuites.map((suite) => {
-                    const cases = suiteCases[suite.id] ?? [];
+                    const cases = (suiteCases[suite.id] ?? []).filter(
+                      (regressionCase) =>
+                        regressionCase.status === "active" ||
+                        includeProposedRegressions,
+                    );
                     return (
                       <div key={suite.id} className="space-y-2 rounded-md border border-border/60 p-2">
                         <label className="flex items-start gap-2 text-sm cursor-pointer">
@@ -571,6 +622,11 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
                                   <span className="ml-2 text-xs text-muted-foreground">
                                     {regressionCase.severity}
                                   </span>
+                                  {regressionCase.status === "proposed" && (
+                                    <span className="ml-2 text-xs text-muted-foreground">
+                                      proposed
+                                    </span>
+                                  )}
                                   {regressionCase.failure_summary && (
                                     <span className="mt-0.5 block text-xs text-muted-foreground">
                                       {regressionCase.failure_summary}


### PR DESCRIPTION
## Summary
- add an explicit create-run dialog toggle for proposed regression validation runs
- hide proposed regression cases by default while preserving active-only submissions
- send `include_proposed_regressions: true` for opted-in regression selections and `false` for opted-out regression selections
- cover default, opt-in, opt-out clearing, and suite-level opt-out behavior in dialog tests

## Review checkpoint
- Contract: `/tmp/reviewcheckpoint-issue-82-web-validation-runs-contract.md`
- Checkpoint: `/tmp/reviewcheckpoint-issue-82-web-validation-runs.json`

## Tests
- `npm test -- 'src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.test.tsx'`\n- `npx tsc --noEmit`\n- `npm run lint`\n- `npm test`\n- `npm run build`\n\nBuild note: Next build still emits the existing WorkOS Edge Runtime warnings.