### PR TITLE
feat(failures): classify dependency resolution regressions

### DIFF
--- a/backend/internal/api/failure_reviews.go
+++ b/backend/internal/api/failure_reviews.go
@@ -267,6 +267,7 @@ func parseFailureClass(raw string) (failurereview.FailureClass, error) {
 		failurereview.FailureClassPolicyViolation,
 		failurereview.FailureClassTimeoutOrBudget,
 		failurereview.FailureClassSandboxFailure,
+		failurereview.FailureClassDependencyResolution,
 		failurereview.FailureClassMalformedOutput,
 		failurereview.FailureClassFlakyNonDeterministic,
 		failurereview.FailureClassInsufficientEvidence,

--- a/backend/internal/api/failure_reviews_test.go
+++ b/backend/internal/api/failure_reviews_test.go
@@ -116,6 +116,7 @@ func TestListRunFailuresEndpointFiltersByClassChallengeAndEvidenceTier(t *testin
 	items := []failurereview.Item{
 		mustBuildFailureItem(t, runID, uuid.New(), "ticket-a", "case-a", "policy.filesystem"),
 		mustBuildFailureItem(t, runID, uuid.New(), "ticket-b", "case-b", "tool_argument.schema"),
+		mustBuildFailureItem(t, runID, uuid.New(), "ticket-c", "case-c", "dependency.registry"),
 	}
 
 	service := NewRunReadManager(NewCallerWorkspaceAuthorizer(), &fakeRunReadRepository{
@@ -140,6 +141,17 @@ func TestListRunFailuresEndpointFiltersByClassChallengeAndEvidenceTier(t *testin
 	}
 	if response.Items[0].Severity == "" {
 		t.Fatalf("filtered item severity = %q, want non-empty severity on the wire", response.Items[0].Severity)
+	}
+
+	dependencyResponse := performListRunFailuresRequest(t, service, workspaceID, runID, url.Values{
+		"failure_class": []string{"dependency_resolution_failure"},
+		"challenge_key": []string{"ticket-c"},
+	})
+	if len(dependencyResponse.Items) != 1 {
+		t.Fatalf("dependency filtered items = %d, want 1", len(dependencyResponse.Items))
+	}
+	if dependencyResponse.Items[0].FailureClass != "dependency_resolution_failure" {
+		t.Fatalf("dependency filtered item = %#v, want dependency_resolution_failure", dependencyResponse.Items[0])
 	}
 }
 

--- a/backend/internal/domain/regression_test.go
+++ b/backend/internal/domain/regression_test.go
@@ -91,6 +91,7 @@ func TestDefaultPromotionSeverityForFailureClass(t *testing.T) {
 	}{
 		{failureClass: "policy_violation", want: RegressionSeverityBlocking},
 		{failureClass: "sandbox_failure", want: RegressionSeverityBlocking},
+		{failureClass: "dependency_resolution_failure", want: RegressionSeverityWarning},
 		{failureClass: "incorrect_final_output", want: RegressionSeverityWarning},
 	}
 

--- a/backend/internal/failurereview/classify.go
+++ b/backend/internal/failurereview/classify.go
@@ -112,17 +112,14 @@ func containsAny(value string, needles ...string) bool {
 func isDependencyResolutionCheck(normalized string) bool {
 	return strings.HasPrefix(normalized, "dependency.") ||
 		strings.HasPrefix(normalized, "dependencies.") ||
-		strings.HasPrefix(normalized, "import.") ||
+		strings.HasPrefix(normalized, "import.resolution.") ||
+		strings.HasPrefix(normalized, "import.dependency.") ||
 		containsAny(
 			normalized,
-			"unresolved import",
-			"missing import",
-			"missing module",
-			"module_not_found",
-			"module not found",
-			"cannot find module",
-			"no module named",
-			"package not found",
+			"unresolved dependency",
+			"missing dependency",
+			"dependency not found",
+			"package not found in registry",
 			"no matching distribution",
 			"not found in registry",
 			"hallucinated dependency",

--- a/backend/internal/failurereview/classify.go
+++ b/backend/internal/failurereview/classify.go
@@ -12,6 +12,7 @@ const (
 	FailureClassPolicyViolation       FailureClass = "policy_violation"
 	FailureClassTimeoutOrBudget       FailureClass = "timeout_or_budget_exhaustion"
 	FailureClassSandboxFailure        FailureClass = "sandbox_failure"
+	FailureClassDependencyResolution  FailureClass = "dependency_resolution_failure"
 	FailureClassMalformedOutput       FailureClass = "malformed_output"
 	FailureClassFlakyNonDeterministic FailureClass = "flaky_non_deterministic"
 	FailureClassInsufficientEvidence  FailureClass = "insufficient_evidence"
@@ -46,6 +47,8 @@ func Classify(input ClassificationInput) FailureClass {
 			return FailureClassToolArgumentError
 		case containsAny(normalized, "tool_selection", "tool-selection", "wrong tool", "tool choice", "tool selection"):
 			return FailureClassToolSelectionError
+		case isDependencyResolutionCheck(normalized):
+			return FailureClassDependencyResolution
 		case containsAny(normalized, "retrieval", "grounding"):
 			return FailureClassRetrievalGrounding
 		case containsAny(normalized, "flaky", "non-deterministic", "nondeterministic"):
@@ -74,6 +77,8 @@ func TaxonomyForFailureClass(class FailureClass) FailureTaxonomy {
 		return FailureTaxonomy{Family: "workflow", Code: "workflow.timeout_budget", Label: "Timeout or budget exhaustion", AgentFault: true}
 	case FailureClassSandboxFailure:
 		return FailureTaxonomy{Family: "platform", Code: "platform.sandbox_failure", Label: "Sandbox failure", AgentFault: false}
+	case FailureClassDependencyResolution:
+		return FailureTaxonomy{Family: "workflow", Code: "workflow.dependency_resolution", Label: "Dependency resolution failure", AgentFault: true}
 	case FailureClassMalformedOutput:
 		return FailureTaxonomy{Family: "agent", Code: "agent.malformed_output", Label: "Malformed output", AgentFault: true}
 	case FailureClassFlakyNonDeterministic:
@@ -102,4 +107,25 @@ func containsAny(value string, needles ...string) bool {
 		}
 	}
 	return false
+}
+
+func isDependencyResolutionCheck(normalized string) bool {
+	return strings.HasPrefix(normalized, "dependency.") ||
+		strings.HasPrefix(normalized, "dependencies.") ||
+		strings.HasPrefix(normalized, "import.") ||
+		containsAny(
+			normalized,
+			"unresolved import",
+			"missing import",
+			"missing module",
+			"module_not_found",
+			"module not found",
+			"cannot find module",
+			"no module named",
+			"package not found",
+			"no matching distribution",
+			"not found in registry",
+			"hallucinated dependency",
+			"hallucinated package",
+		)
 }

--- a/backend/internal/failurereview/classify_test.go
+++ b/backend/internal/failurereview/classify_test.go
@@ -32,6 +32,27 @@ func TestClassifyFailureClassMappings(t *testing.T) {
 			want: FailureClassToolSelectionError,
 		},
 		{
+			name: "dependency resolution validator key",
+			input: ClassificationInput{
+				FailedChecks: []string{"dependency.registry"},
+			},
+			want: FailureClassDependencyResolution,
+		},
+		{
+			name: "unresolved import runtime message",
+			input: ClassificationInput{
+				FailedChecks: []string{"Cannot find module '@fake/hallucinated-sdk'"},
+			},
+			want: FailureClassDependencyResolution,
+		},
+		{
+			name: "python missing package message",
+			input: ClassificationInput{
+				FailedChecks: []string{"No module named hallucinated_client"},
+			},
+			want: FailureClassDependencyResolution,
+		},
+		{
 			name: "timeout and budget",
 			input: ClassificationInput{
 				HasTimeoutOrBudgetSignal: true,
@@ -104,6 +125,7 @@ func TestTaxonomyForFailureClass(t *testing.T) {
 		agentFault bool
 	}{
 		{class: FailureClassToolArgumentError, family: "agent", code: "agent.tool_arguments", agentFault: true},
+		{class: FailureClassDependencyResolution, family: "workflow", code: "workflow.dependency_resolution", agentFault: true},
 		{class: FailureClassTimeoutOrBudget, family: "workflow", code: "workflow.timeout_budget", agentFault: true},
 		{class: FailureClassSandboxFailure, family: "platform", code: "platform.sandbox_failure", agentFault: false},
 		{class: FailureClassInsufficientEvidence, family: "evidence", code: "evidence.insufficient", agentFault: false},

--- a/backend/internal/failurereview/classify_test.go
+++ b/backend/internal/failurereview/classify_test.go
@@ -39,18 +39,40 @@ func TestClassifyFailureClassMappings(t *testing.T) {
 			want: FailureClassDependencyResolution,
 		},
 		{
-			name: "unresolved import runtime message",
+			name: "dependency resolution import key",
 			input: ClassificationInput{
-				FailedChecks: []string{"Cannot find module '@fake/hallucinated-sdk'"},
+				FailedChecks: []string{"import.resolution.npm"},
 			},
 			want: FailureClassDependencyResolution,
 		},
 		{
-			name: "python missing package message",
+			name: "dependency resolution dependencies key",
 			input: ClassificationInput{
-				FailedChecks: []string{"No module named hallucinated_client"},
+				FailedChecks: []string{"dependencies.pypi"},
 			},
 			want: FailureClassDependencyResolution,
+		},
+		{
+			name: "registry package not found message",
+			input: ClassificationInput{
+				FailedChecks: []string{"Package hallucinated-client was not found in registry"},
+			},
+			want: FailureClassDependencyResolution,
+		},
+		{
+			name: "generic module not found stays other",
+			input: ClassificationInput{
+				FailedChecks: []string{"Cannot find module '@fake/hallucinated-sdk'"},
+			},
+			want: FailureClassOther,
+		},
+		{
+			name: "sandbox failure takes precedence over dependency key",
+			input: ClassificationInput{
+				FailedChecks:      []string{"dependency.registry"},
+				HasSandboxFailure: true,
+			},
+			want: FailureClassSandboxFailure,
 		},
 		{
 			name: "timeout and budget",
@@ -140,5 +162,16 @@ func TestTaxonomyForFailureClass(t *testing.T) {
 				t.Fatalf("taxonomy = %+v, want family=%s code=%s agent_fault=%t with label", got, tt.family, tt.code, tt.agentFault)
 			}
 		})
+	}
+}
+
+func TestDependencyResolutionPresentationDefaults(t *testing.T) {
+	t.Parallel()
+
+	if got := severityFor(FailureClassDependencyResolution, FailureStateFailed, EvidenceTierNativeStructured); got != SeverityWarning {
+		t.Fatalf("severityFor(dependency_resolution_failure) = %s, want %s", got, SeverityWarning)
+	}
+	if got := recommendedActionForClass(FailureClassDependencyResolution); got != "Verify dependency declarations, import paths, and registry availability." {
+		t.Fatalf("recommendedActionForClass(dependency_resolution_failure) = %q", got)
 	}
 }

--- a/backend/internal/failurereview/read_model.go
+++ b/backend/internal/failurereview/read_model.go
@@ -949,7 +949,7 @@ func severityFor(class FailureClass, state FailureState, evidenceTier EvidenceTi
 	switch class {
 	case FailureClassPolicyViolation, FailureClassTimeoutOrBudget, FailureClassSandboxFailure, FailureClassMalformedOutput:
 		return SeverityBlocking
-	case FailureClassIncorrectFinalOutput, FailureClassToolArgumentError, FailureClassToolSelectionError, FailureClassRetrievalGrounding, FailureClassOther:
+	case FailureClassIncorrectFinalOutput, FailureClassToolArgumentError, FailureClassToolSelectionError, FailureClassRetrievalGrounding, FailureClassDependencyResolution, FailureClassOther:
 		return SeverityWarning
 	case FailureClassInsufficientEvidence:
 		return SeverityInfo
@@ -983,6 +983,8 @@ func recommendedActionForClass(class FailureClass) string {
 		return "Review runtime limits, tool-call counts, and long-running steps."
 	case FailureClassSandboxFailure:
 		return "Inspect sandbox command events and environment assumptions before retrying."
+	case FailureClassDependencyResolution:
+		return "Verify dependency declarations, import paths, and registry availability before promoting this failure."
 	case FailureClassMalformedOutput:
 		return "Validate the final-output contract and any JSON/schema formatting logic."
 	case FailureClassIncorrectFinalOutput:

--- a/backend/internal/failurereview/read_model.go
+++ b/backend/internal/failurereview/read_model.go
@@ -984,7 +984,7 @@ func recommendedActionForClass(class FailureClass) string {
 	case FailureClassSandboxFailure:
 		return "Inspect sandbox command events and environment assumptions before retrying."
 	case FailureClassDependencyResolution:
-		return "Verify dependency declarations, import paths, and registry availability before promoting this failure."
+		return "Verify dependency declarations, import paths, and registry availability."
 	case FailureClassMalformedOutput:
 		return "Validate the final-output contract and any JSON/schema formatting logic."
 	case FailureClassIncorrectFinalOutput:

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -6457,6 +6457,7 @@ components:
         - policy_violation
         - timeout_or_budget_exhaustion
         - sandbox_failure
+        - dependency_resolution_failure
         - malformed_output
         - flaky_non_deterministic
         - insufficient_evidence

--- a/web/content/agent-skills/agentclash-regression-flywheel/SKILL.md
+++ b/web/content/agent-skills/agentclash-regression-flywheel/SKILL.md
@@ -76,7 +76,7 @@ Supported filters are:
 - `--cursor <NEXT_CURSOR>`
 - `--limit <COUNT>`
 
-Failure classes currently accepted by the API are `incorrect_final_output`, `tool_selection_error`, `tool_argument_error`, `retrieval_grounding_failure`, `policy_violation`, `timeout_or_budget_exhaustion`, `sandbox_failure`, `malformed_output`, `flaky_non_deterministic`, `insufficient_evidence`, and `other`.
+Failure classes currently accepted by the API are `incorrect_final_output`, `tool_selection_error`, `tool_argument_error`, `retrieval_grounding_failure`, `policy_violation`, `timeout_or_budget_exhaustion`, `sandbox_failure`, `dependency_resolution_failure`, `malformed_output`, `flaky_non_deterministic`, `insufficient_evidence`, and `other`.
 
 The fields that matter for promotion are:
 

--- a/web/content/agent-skills/agentclash-scorecard-reader/SKILL.md
+++ b/web/content/agent-skills/agentclash-scorecard-reader/SKILL.md
@@ -396,7 +396,7 @@ Filters supported by the CLI:
 - `--cursor <NEXT_CURSOR>`
 - `--limit <COUNT>`
 
-Failure classes currently accepted by the API are `incorrect_final_output`, `tool_selection_error`, `tool_argument_error`, `retrieval_grounding_failure`, `policy_violation`, `timeout_or_budget_exhaustion`, `sandbox_failure`, `malformed_output`, `flaky_non_deterministic`, `insufficient_evidence`, and `other`.
+Failure classes currently accepted by the API are `incorrect_final_output`, `tool_selection_error`, `tool_argument_error`, `retrieval_grounding_failure`, `policy_violation`, `timeout_or_budget_exhaustion`, `sandbox_failure`, `dependency_resolution_failure`, `malformed_output`, `flaky_non_deterministic`, `insufficient_evidence`, and `other`.
 
 ## Stateful Reads and Exit Codes
 Ranking, scorecard, and replay reads can be ready, pending, or errored.

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/failures/failures-client.tsx
@@ -56,6 +56,7 @@ const FAILURE_CLASS_OPTIONS: FailureReviewFailureClass[] = [
   "policy_violation",
   "timeout_or_budget_exhaustion",
   "sandbox_failure",
+  "dependency_resolution_failure",
   "malformed_output",
   "flaky_non_deterministic",
   "insufficient_evidence",

--- a/web/src/lib/api/__tests__/regression.test.ts
+++ b/web/src/lib/api/__tests__/regression.test.ts
@@ -199,6 +199,9 @@ describe("Regression API helpers", () => {
     expect(defaultPromotionSeverityForFailure("sandbox_failure")).toBe(
       "blocking",
     );
+    expect(
+      defaultPromotionSeverityForFailure("dependency_resolution_failure"),
+    ).toBe("warning");
     expect(defaultPromotionSeverityForFailure("incorrect_final_output")).toBe(
       "warning",
     );

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -1622,6 +1622,7 @@ export type FailureReviewFailureClass =
   | "policy_violation"
   | "timeout_or_budget_exhaustion"
   | "sandbox_failure"
+  | "dependency_resolution_failure"
   | "malformed_output"
   | "flaky_non_deterministic"
   | "insufficient_evidence"

--- a/web/src/lib/docs.test.ts
+++ b/web/src/lib/docs.test.ts
@@ -110,6 +110,7 @@ describe("agent skill docs", () => {
     expect(doc?.content).toContain("incorrect_final_output");
     expect(doc?.content).toContain("retrieval_grounding_failure");
     expect(doc?.content).toContain("timeout_or_budget_exhaustion");
+    expect(doc?.content).toContain("dependency_resolution_failure");
     expect(doc?.content).toContain("flaky_non_deterministic");
     expect(doc?.content).toContain("agentclash-regression-flywheel");
   });


### PR DESCRIPTION
## Summary
- add `dependency_resolution_failure` as a first-class failure review class for scoped dependency/import-resolution validator keys and registry/package-not-found signals
- avoid retroactive broad runtime reclassification: generic module-not-found text remains `other`, and sandbox/platform signals keep precedence
- wire the class through backend taxonomy, API filter parsing, OpenAPI, web TS types, and the run-failures class filter
- keep promotion severity at warning by default and refresh generated skill docs

## Review checkpoint
- Contract: `/tmp/reviewcheckpoint-issue-82-dependency-failure-class-contract.md`
- Checkpoint: `/tmp/reviewcheckpoint-issue-82-dependency-failure-class.json`

## Tests
- `go test ./internal/failurereview ./internal/api ./internal/domain`
- `go test ./...` (backend)
- `npm test -- src/lib/api/__tests__/regression.test.ts src/lib/docs.test.ts`
- `npx tsc --noEmit`
- `npm run lint`
- `npm test`
- `npm run build`
- `npm exec --yes @redocly/cli@latest -- lint docs/api-server/openapi.yaml`

Notes: Redocly reports the existing localhost server / healthz 4XX warnings; Next build reports the existing WorkOS Edge Runtime warnings.