### PR TITLE
feat(ci): auto-detect GitHub labels

### DIFF
--- a/.github/actions/agentclash-ci/README.md
+++ b/.github/actions/agentclash-ci/README.md
@@ -67,7 +67,7 @@ jobs:
 | `base` | pull request base branch | Base ref for `ci should-run`. |
 | `head` | `HEAD` | Head ref for `ci should-run`. |
 | `changed-files` | empty | Newline-separated files to pass directly to `ci should-run`. |
-| `labels` | empty | Comma-separated pull request labels. |
+| `labels` | GitHub event labels | Comma-separated pull request labels. Override only when the workflow cannot rely on the event payload. |
 | `artifact-dir` | `agentclash-artifacts` | Directory for `ci run` JSON artifacts. |
 | `result-file` | `agentclash-ci-result.json` | Top-level `ci run` JSON result path. |
 | `timeout` | CLI default | Optional `ci run` timeout, for example `30m` or `0`. |

--- a/.github/actions/agentclash-ci/action.yml
+++ b/.github/actions/agentclash-ci/action.yml
@@ -46,7 +46,7 @@ inputs:
     description: Newline-separated changed files. When set, these are passed directly to ci should-run.
     required: false
   labels:
-    description: Comma-separated pull request labels that may force the gate.
+    description: Comma-separated pull request labels that may force the gate. Defaults to labels from the GitHub event payload when omitted.
     required: false
   artifact-dir:
     description: Directory for AgentClash CI JSON artifacts.

--- a/cli/cmd/ci.go
+++ b/cli/cmd/ci.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -36,6 +37,7 @@ func init() {
 	ciShouldRunCmd.Flags().String("base", "", "Base git ref for deriving changed files")
 	ciShouldRunCmd.Flags().String("head", "", "Head git ref for deriving changed files")
 	ciShouldRunCmd.Flags().String("repo", ".", "Git repository path for --base/--head diff")
+	ciShouldRunCmd.Flags().String("github-event", "", "GitHub event JSON file for deriving pull request labels")
 }
 
 var ciCmd = &cobra.Command{
@@ -154,6 +156,7 @@ changed files from git diff.`,
 		base, _ := cmd.Flags().GetString("base")
 		head, _ := cmd.Flags().GetString("head")
 		repo, _ := cmd.Flags().GetString("repo")
+		githubEventPath, _ := cmd.Flags().GetString("github-event")
 
 		validation, err := validateCIManifestFile(manifestPath)
 		if err != nil {
@@ -172,6 +175,18 @@ changed files from git diff.`,
 				return err
 			}
 			changedFiles = derived
+		}
+		if len(labels) == 0 {
+			if strings.TrimSpace(githubEventPath) == "" {
+				githubEventPath = os.Getenv("GITHUB_EVENT_PATH")
+			}
+			if strings.TrimSpace(githubEventPath) != "" {
+				derivedLabels, err := githubEventLabels(githubEventPath)
+				if err != nil {
+					return err
+				}
+				labels = derivedLabels
+			}
 		}
 
 		result, err := evaluateCIShouldRun(manifestPath, *validation.Manifest, changedFiles, labels)
@@ -351,6 +366,10 @@ type ciShouldRunResult struct {
 	CheckedLabels    []string               `json:"checked_labels" yaml:"checked_labels"`
 	MatchedPaths     []ciShouldRunPathMatch `json:"matched_paths,omitempty" yaml:"matched_paths,omitempty"`
 	MatchedLabels    []string               `json:"matched_labels,omitempty" yaml:"matched_labels,omitempty"`
+}
+
+type githubEventLabel struct {
+	Name string `json:"name"`
 }
 
 type ciBaselineResolution struct {
@@ -1290,6 +1309,69 @@ func normalizeCIValues(values []string) []string {
 		if trimmed != "" {
 			out = append(out, trimmed)
 		}
+	}
+	return out
+}
+
+func githubEventLabels(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read GitHub event labels from %s: %w", path, err)
+	}
+
+	type githubPullRequest struct {
+		Labels []githubEventLabel `json:"labels"`
+	}
+	type githubIssue struct {
+		PullRequest json.RawMessage    `json:"pull_request"`
+		Labels      []githubEventLabel `json:"labels"`
+	}
+	var event struct {
+		PullRequest *githubPullRequest `json:"pull_request"`
+		Issue       *githubIssue       `json:"issue"`
+		Label       *githubEventLabel  `json:"label"`
+	}
+	if err := json.Unmarshal(data, &event); err != nil {
+		return nil, fmt.Errorf("parse GitHub event labels from %s: %w", path, err)
+	}
+
+	var labels []string
+	isPullRequestEvent := event.PullRequest != nil
+	switch {
+	case event.PullRequest != nil:
+		labels = labelNames(event.PullRequest.Labels)
+	case event.Issue != nil && githubIssueEventIsPullRequest(event.Issue.PullRequest):
+		isPullRequestEvent = true
+		labels = labelNames(event.Issue.Labels)
+	}
+	if isPullRequestEvent && event.Label != nil {
+		labels = append(labels, event.Label.Name)
+	}
+	return dedupeCIValues(normalizeCIValues(labels)), nil
+}
+
+func githubIssueEventIsPullRequest(raw json.RawMessage) bool {
+	text := strings.TrimSpace(string(raw))
+	return text != "" && text != "null"
+}
+
+func labelNames(labels []githubEventLabel) []string {
+	names := make([]string, 0, len(labels))
+	for _, label := range labels {
+		names = append(names, label.Name)
+	}
+	return names
+}
+
+func dedupeCIValues(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
 	}
 	return out
 }

--- a/cli/cmd/ci.go
+++ b/cli/cmd/ci.go
@@ -1329,23 +1329,17 @@ func githubEventLabels(path string) ([]string, error) {
 	var event struct {
 		PullRequest *githubPullRequest `json:"pull_request"`
 		Issue       *githubIssue       `json:"issue"`
-		Label       *githubEventLabel  `json:"label"`
 	}
 	if err := json.Unmarshal(data, &event); err != nil {
 		return nil, fmt.Errorf("parse GitHub event labels from %s: %w", path, err)
 	}
 
 	var labels []string
-	isPullRequestEvent := event.PullRequest != nil
 	switch {
 	case event.PullRequest != nil:
 		labels = labelNames(event.PullRequest.Labels)
 	case event.Issue != nil && githubIssueEventIsPullRequest(event.Issue.PullRequest):
-		isPullRequestEvent = true
 		labels = labelNames(event.Issue.Labels)
-	}
-	if isPullRequestEvent && event.Label != nil {
-		labels = append(labels, event.Label.Name)
 	}
 	return dedupeCIValues(normalizeCIValues(labels)), nil
 }

--- a/cli/cmd/ci_test.go
+++ b/cli/cmd/ci_test.go
@@ -819,6 +819,33 @@ func TestCIShouldRunMatchesGitHubPullRequestEventLabels(t *testing.T) {
 	}
 }
 
+func TestCIShouldRunIgnoresRemovedGitHubPullRequestLabel(t *testing.T) {
+	target := writeCIManifest(t, sampleCIManifestYAML)
+	eventPath := writeGitHubEvent(t, `{
+		"action": "unlabeled",
+		"pull_request": {
+			"labels": [
+				{"name": "docs-only"}
+			]
+		},
+		"label": {"name": "agentclash/eval"}
+	}`)
+	result := runCIShouldRunJSON(t, []string{
+		"ci", "should-run",
+		"--manifest", target,
+		"--changed-file", "docs/readme.md",
+		"--github-event", eventPath,
+		"--json",
+	})
+
+	if result.ShouldRun {
+		t.Fatalf("should_run = true, want false after label removal: %+v", result)
+	}
+	if len(result.Labels) != 1 || result.Labels[0] != "docs-only" {
+		t.Fatalf("labels = %+v, want current pull_request labels only", result.Labels)
+	}
+}
+
 func TestCIShouldRunFallsBackToGitHubEventPath(t *testing.T) {
 	target := writeCIManifest(t, sampleCIManifestYAML)
 	eventPath := writeGitHubEvent(t, `{
@@ -894,8 +921,7 @@ func TestGitHubEventLabelsReadsIssuePullRequestLabels(t *testing.T) {
 				{"name": "agentclash/eval"},
 				{"name": "agentclash/eval"}
 			]
-		},
-		"label": {"name": "agentclash/eval"}
+		}
 	}`)
 
 	labels, err := githubEventLabels(eventPath)

--- a/cli/cmd/ci_test.go
+++ b/cli/cmd/ci_test.go
@@ -790,6 +790,143 @@ func TestCIShouldRunMatchesLabel(t *testing.T) {
 	}
 }
 
+func TestCIShouldRunMatchesGitHubPullRequestEventLabels(t *testing.T) {
+	target := writeCIManifest(t, sampleCIManifestYAML)
+	eventPath := writeGitHubEvent(t, `{
+		"pull_request": {
+			"labels": [
+				{"name": "docs-only"},
+				{"name": "agentclash/eval"}
+			]
+		}
+	}`)
+	result := runCIShouldRunJSON(t, []string{
+		"ci", "should-run",
+		"--manifest", target,
+		"--changed-file", "docs/readme.md",
+		"--github-event", eventPath,
+		"--json",
+	})
+
+	if !result.ShouldRun {
+		t.Fatalf("should_run = false, want true: %+v", result)
+	}
+	if len(result.MatchedLabels) != 1 || result.MatchedLabels[0] != "agentclash/eval" {
+		t.Fatalf("matched_labels = %+v, want agentclash/eval", result.MatchedLabels)
+	}
+	if len(result.Labels) != 2 || result.Labels[0] != "docs-only" || result.Labels[1] != "agentclash/eval" {
+		t.Fatalf("labels = %+v, want GitHub event labels", result.Labels)
+	}
+}
+
+func TestCIShouldRunFallsBackToGitHubEventPath(t *testing.T) {
+	target := writeCIManifest(t, sampleCIManifestYAML)
+	eventPath := writeGitHubEvent(t, `{
+		"pull_request": {
+			"labels": [
+				{"name": "agentclash/eval"}
+			]
+		}
+	}`)
+	t.Setenv("GITHUB_EVENT_PATH", eventPath)
+
+	result := runCIShouldRunJSON(t, []string{
+		"ci", "should-run",
+		"--manifest", target,
+		"--changed-file", "docs/readme.md",
+		"--json",
+	})
+
+	if !result.ShouldRun {
+		t.Fatalf("should_run = false, want true: %+v", result)
+	}
+	if len(result.MatchedLabels) != 1 || result.MatchedLabels[0] != "agentclash/eval" {
+		t.Fatalf("matched_labels = %+v, want agentclash/eval", result.MatchedLabels)
+	}
+}
+
+func TestCIShouldRunExplicitLabelsOverrideGitHubEventLabels(t *testing.T) {
+	target := writeCIManifest(t, sampleCIManifestYAML)
+	eventPath := writeGitHubEvent(t, `{
+		"pull_request": {
+			"labels": [
+				{"name": "agentclash/eval"}
+			]
+		}
+	}`)
+	result := runCIShouldRunJSON(t, []string{
+		"ci", "should-run",
+		"--manifest", target,
+		"--changed-file", "docs/readme.md",
+		"--labels", "docs-only",
+		"--github-event", eventPath,
+		"--json",
+	})
+
+	if result.ShouldRun {
+		t.Fatalf("should_run = true, want false: %+v", result)
+	}
+	if len(result.Labels) != 1 || result.Labels[0] != "docs-only" {
+		t.Fatalf("labels = %+v, want explicit labels only", result.Labels)
+	}
+}
+
+func TestCIShouldRunRejectsMalformedGitHubEvent(t *testing.T) {
+	target := writeCIManifest(t, sampleCIManifestYAML)
+	eventPath := writeGitHubEvent(t, `{`)
+
+	err := executeCommand(t, []string{
+		"ci", "should-run",
+		"--manifest", target,
+		"--changed-file", "docs/readme.md",
+		"--github-event", eventPath,
+	}, "http://unused")
+	if err == nil || !strings.Contains(err.Error(), "parse GitHub event labels") {
+		t.Fatalf("error = %v, want parse GitHub event labels", err)
+	}
+}
+
+func TestGitHubEventLabelsReadsIssuePullRequestLabels(t *testing.T) {
+	eventPath := writeGitHubEvent(t, `{
+		"issue": {
+			"pull_request": {"url": "https://api.github.com/repos/acme/repo/pulls/1"},
+			"labels": [
+				{"name": "agentclash/eval"},
+				{"name": "agentclash/eval"}
+			]
+		},
+		"label": {"name": "agentclash/eval"}
+	}`)
+
+	labels, err := githubEventLabels(eventPath)
+	if err != nil {
+		t.Fatalf("githubEventLabels() error: %v", err)
+	}
+	if len(labels) != 1 || labels[0] != "agentclash/eval" {
+		t.Fatalf("labels = %+v, want deduped pull request issue labels", labels)
+	}
+}
+
+func TestGitHubEventLabelsIgnoresNonPullRequestIssues(t *testing.T) {
+	eventPath := writeGitHubEvent(t, `{
+		"issue": {
+			"pull_request": null,
+			"labels": [
+				{"name": "agentclash/eval"}
+			]
+		},
+		"label": {"name": "agentclash/eval"}
+	}`)
+
+	labels, err := githubEventLabels(eventPath)
+	if err != nil {
+		t.Fatalf("githubEventLabels() error: %v", err)
+	}
+	if len(labels) != 0 {
+		t.Fatalf("labels = %+v, want no labels for non-PR issue event", labels)
+	}
+}
+
 func TestCIShouldRunMatchesChangedPathAndLabel(t *testing.T) {
 	target := writeCIManifest(t, sampleCIManifestYAML)
 	result := runCIShouldRunJSON(t, []string{
@@ -1445,10 +1582,20 @@ func writeCIManifest(t *testing.T, text string) string {
 	return target
 }
 
+func writeGitHubEvent(t *testing.T, text string) string {
+	t.Helper()
+	target := filepath.Join(t.TempDir(), "event.json")
+	if err := os.WriteFile(target, []byte(text), 0o644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+	return target
+}
+
 type ciShouldRunJSONResult struct {
 	ShouldRun     bool                   `json:"should_run"`
 	Reason        string                 `json:"reason"`
 	ChangedFiles  []string               `json:"changed_files"`
+	Labels        []string               `json:"labels"`
 	MatchedPaths  []ciShouldRunPathMatch `json:"matched_paths"`
 	MatchedLabels []string               `json:"matched_labels"`
 }

--- a/web/content/docs/guides/ci-cd-agent-gates.mdx
+++ b/web/content/docs/guides/ci-cd-agent-gates.mdx
@@ -129,6 +129,8 @@ agentclash ci should-run \
   --json
 ```
 
+In GitHub Actions, `ci should-run` reads pull request labels from `GITHUB_EVENT_PATH` automatically when `--labels` is omitted, and the bundled action passes that behavior through. Use `--github-event <path>` only when testing a saved event payload locally.
+
 For local or GitHub Actions diffing, pass refs explicitly:
 
 ```bash
@@ -186,7 +188,7 @@ jobs:
             ${{ steps.agentclash.outputs.artifact-dir }}/*.json
 ```
 
-The action installs the published `agentclash` npm package by default, runs `ci validate --remote`, runs `ci should-run`, skips unrelated changes, runs `ci run` when matched, and exposes `should-run`, `skip-reason`, `run-id`, `gate-verdict`, `exit-code`, `result-file`, and `artifact-dir` outputs. It preserves the CLI exit code, so a blocking gate fails the workflow normally.
+The action installs the published `agentclash` npm package by default, runs `ci validate --remote`, runs `ci should-run`, auto-detects pull request labels from the GitHub event payload, skips unrelated changes, runs `ci run` when matched, and exposes `should-run`, `skip-reason`, `run-id`, `gate-verdict`, `exit-code`, `result-file`, and `artifact-dir` outputs. It preserves the CLI exit code, so a blocking gate fails the workflow normally.
 
 `agentclash ci run` exits nonzero when the gate verdict should block CI, when the candidate run times out, or when the manifest/API setup is invalid. In GitHub Actions, it automatically attaches repository, pull request, branch, default branch, commit, workflow, event, and workflow-run URL metadata to the AgentClash run. It also appends a reviewer-friendly Markdown section when the `$GITHUB_STEP_SUMMARY` environment variable is set. Pass `--summary-file <path>` for another Markdown destination, or `--github-step-summary=false` to disable the automatic GitHub summary.
 


### PR DESCRIPTION
## Summary
- add `agentclash ci should-run --github-event` for deriving pull request labels from GitHub event JSON
- fall back to `GITHUB_EVENT_PATH` when explicit `--labels` are omitted, so the bundled GitHub Action gets label autodetection by default
- document the action behavior and cover PR, issue-as-PR, malformed event, env fallback, and explicit-label override cases

## Review Checkpoint
Contract: `/tmp/reviewcheckpoint-issue-82-github-label-autodetect-contract.md`
Checkpoint: `/tmp/reviewcheckpoint-issue-82-github-label-autodetect.json`

Locked expectations:
- explicit `--labels` remains authoritative and does not merge event labels
- `pull_request.labels` drives label matching for PR events
- `issue.labels` is used only when `issue.pull_request` marks the issue as a PR
- invalid event JSON fails clearly
- composite GitHub Action inherits autodetection without additional workflow config

## Tests
- `go test ./cmd -run 'TestCIShouldRun.*GitHub|TestGitHubEventLabels'`
- `go test ./...`
- `git diff --check`
