### PR TITLE
fix(challenge-packs): allow reused evaluation spec names

### DIFF
--- a/backend/db/migrations/00038_scope_evaluation_spec_uniqueness.sql
+++ b/backend/db/migrations/00038_scope_evaluation_spec_uniqueness.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+ALTER TABLE evaluation_specs
+DROP CONSTRAINT IF EXISTS evaluation_specs_name_version_number_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS evaluation_specs_challenge_pack_version_name_version_uq
+ON evaluation_specs (challenge_pack_version_id, name, version_number)
+WHERE challenge_pack_version_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS evaluation_specs_global_name_version_uq
+ON evaluation_specs (name, version_number)
+WHERE challenge_pack_version_id IS NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS evaluation_specs_global_name_version_uq;
+DROP INDEX IF EXISTS evaluation_specs_challenge_pack_version_name_version_uq;
+
+ALTER TABLE evaluation_specs
+ADD CONSTRAINT evaluation_specs_name_version_number_key UNIQUE (name, version_number);

--- a/backend/db/migrations/00038_scope_evaluation_spec_uniqueness.sql
+++ b/backend/db/migrations/00038_scope_evaluation_spec_uniqueness.sql
@@ -14,5 +14,7 @@ WHERE challenge_pack_version_id IS NULL;
 DROP INDEX IF EXISTS evaluation_specs_global_name_version_uq;
 DROP INDEX IF EXISTS evaluation_specs_challenge_pack_version_name_version_uq;
 
+-- This down migration can fail if duplicate name/version pairs were written
+-- for different challenge pack versions after the Up migration ran.
 ALTER TABLE evaluation_specs
 ADD CONSTRAINT evaluation_specs_name_version_number_key UNIQUE (name, version_number);

--- a/backend/internal/repository/repository_integration_test.go
+++ b/backend/internal/repository/repository_integration_test.go
@@ -799,6 +799,43 @@ func TestRepositoryPublishChallengePackBundle(t *testing.T) {
 	}
 }
 
+func TestRepositoryPublishChallengePackBundleAllowsSharedEvaluationSpecNamesAcrossPacks(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	first, err := repo.PublishChallengePackBundle(ctx, repository.PublishChallengePackBundleParams{
+		OrganizationID: fixture.organizationID,
+		WorkspaceID:    fixture.workspaceID,
+		Bundle:         publishableChallengePackBundle("shared-spec-pack-a", "Shared Spec Pack A", "shared-eval-spec"),
+	})
+	if err != nil {
+		t.Fatalf("first PublishChallengePackBundle returned error: %v", err)
+	}
+
+	second, err := repo.PublishChallengePackBundle(ctx, repository.PublishChallengePackBundleParams{
+		OrganizationID: fixture.organizationID,
+		WorkspaceID:    fixture.workspaceID,
+		Bundle:         publishableChallengePackBundle("shared-spec-pack-b", "Shared Spec Pack B", "shared-eval-spec"),
+	})
+	if err != nil {
+		t.Fatalf("second PublishChallengePackBundle returned error: %v", err)
+	}
+
+	if first.EvaluationSpecID == second.EvaluationSpecID {
+		t.Fatal("evaluation spec ids matched across distinct challenge pack versions")
+	}
+
+	secondSpec, err := repo.GetEvaluationSpecByChallengePackVersionAndVersion(ctx, second.ChallengePackVersionID, "shared-eval-spec", 1)
+	if err != nil {
+		t.Fatalf("GetEvaluationSpecByChallengePackVersionAndVersion returned error: %v", err)
+	}
+	if secondSpec.ID != second.EvaluationSpecID {
+		t.Fatalf("second spec id = %s, want %s", secondSpec.ID, second.EvaluationSpecID)
+	}
+}
+
 func TestRepositoryPublishChallengePackBundleRejectsDuplicateVersion(t *testing.T) {
 	ctx := context.Background()
 	db := openTestDB(t)
@@ -839,6 +876,46 @@ func TestRepositoryPublishChallengePackBundleRejectsDuplicateVersion(t *testing.
 	}
 	if _, err := repo.PublishChallengePackBundle(ctx, params); !errors.Is(err, repository.ErrChallengePackVersionExists) {
 		t.Fatalf("second PublishChallengePackBundle error = %v, want ErrChallengePackVersionExists", err)
+	}
+}
+
+func publishableChallengePackBundle(slug string, name string, evaluationSpecName string) challengepack.Bundle {
+	return challengepack.Bundle{
+		Pack: challengepack.PackMetadata{
+			Slug:   slug,
+			Name:   name,
+			Family: "support",
+		},
+		Version: challengepack.VersionMetadata{
+			Number: 1,
+			EvaluationSpec: scoring.EvaluationSpec{
+				Name:          evaluationSpecName,
+				VersionNumber: 1,
+				JudgeMode:     scoring.JudgeModeDeterministic,
+				Validators: []scoring.ValidatorDeclaration{
+					{Key: "exact", Type: scoring.ValidatorTypeExactMatch, Target: "final_output", ExpectedFrom: "challenge_input"},
+				},
+				Scorecard: scoring.ScorecardDeclaration{
+					Dimensions: []scoring.DimensionDeclaration{{Key: "correctness"}},
+				},
+			},
+		},
+		Challenges: []challengepack.ChallengeDefinition{
+			{Key: "ticket-1", Title: "Ticket One", Category: "support", Difficulty: "easy"},
+		},
+		InputSets: []challengepack.InputSetDefinition{
+			{
+				Key:  "default",
+				Name: "Default",
+				Cases: []challengepack.CaseDefinition{
+					{
+						ChallengeKey: "ticket-1",
+						CaseKey:      "case-1",
+						Payload:      map[string]any{"prompt": "Customer needs help"},
+					},
+				},
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary
- scope evaluation spec name/version uniqueness to each challenge pack version
- preserve uniqueness for unattached/global specs
- add a regression integration test that publishes two distinct packs with the same evaluation spec name/version

Closes #496

## Review checkpoint
- Contract: /tmp/reviewcheckpoint-issue-496-challenge-pack-publish-500-contract.md
- Checkpoint: /tmp/reviewcheckpoint-issue-496-challenge-pack-publish-500.json

## Tests
- `cd backend && go test ./internal/api ./internal/challengepack ./internal/repository`
- `cd backend && go test ./...`
- `git diff --check`

## Notes
- Local `DATABASE_URL` is unset and Docker is unavailable, so DB-backed repository tests skip locally. The new integration test is intended to run in CI with migrated Postgres.