### PR TITLE
fix(cli): stream json follow run creation

### DIFF
--- a/cli/cmd/run_create_helpers.go
+++ b/cli/cmd/run_create_helpers.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -127,7 +128,13 @@ func createRun(cmd *cobra.Command, rc *RunContext, body map[string]any) (map[str
 
 func presentCreatedRun(cmd *cobra.Command, rc *RunContext, run map[string]any, follow bool, afterFollow func(string) error) error {
 	if rc.Output.IsStructured() {
-		return rc.Output.PrintRaw(run)
+		if !follow {
+			return rc.Output.PrintRaw(run)
+		}
+		if err := printStructuredRunCreated(rc, run); err != nil {
+			return err
+		}
+		return streamRunEvents(cmd, rc, str(run["id"]))
 	}
 
 	runID := str(run["id"])
@@ -145,6 +152,17 @@ func presentCreatedRun(cmd *cobra.Command, rc *RunContext, run map[string]any, f
 	}
 
 	return nil
+}
+
+func printStructuredRunCreated(rc *RunContext, run map[string]any) error {
+	envelope := map[string]any{
+		"type": "run.created",
+		"run":  run,
+	}
+	if rc.Output.IsYAML() {
+		return rc.Output.PrintRaw(envelope)
+	}
+	return json.NewEncoder(rc.Output.Writer()).Encode(envelope)
 }
 
 func compactNonEmptyStrings(values []string) []string {

--- a/cli/cmd/run_events_test.go
+++ b/cli/cmd/run_events_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -111,5 +112,219 @@ func TestRunEventsEmitsNDJSONForJSON(t *testing.T) {
 		if !strings.HasPrefix(line, "{") {
 			t.Fatalf("line %d is not JSON: %q", i, line)
 		}
+	}
+}
+
+func TestRunCreateFollowJSONStreamsCreatedRunAndEvents(t *testing.T) {
+	sseBody := "event: step\n" +
+		"data: {\"EventType\":\"run.started\"}\n" +
+		"\n" +
+		"event: step\n" +
+		"data: {\"EventType\":\"run.completed\"}\n" +
+		"\n"
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/runs": jsonHandler(201, map[string]any{
+			"id":     "run-json-follow",
+			"status": "queued",
+		}),
+		"GET /v1/runs/run-json-follow/events/stream": sseHandler([]string{sseBody}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"run", "create",
+		"-w", "ws-1",
+		"--challenge-pack-version", "cpv-1",
+		"--deployments", "dep-1",
+		"--follow",
+		"--json",
+	}, srv.URL); err != nil {
+		t.Fatalf("run create --follow --json: %v", err)
+	}
+	out := stdout.finish()
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected created run + 2 event lines, got %d\n---\n%s", len(lines), out)
+	}
+
+	var created map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &created); err != nil {
+		t.Fatalf("created line is not JSON: %v\n%s", err, lines[0])
+	}
+	if created["type"] != "run.created" {
+		t.Fatalf("created.type = %v, want run.created", created["type"])
+	}
+	run, ok := created["run"].(map[string]any)
+	if !ok || run["id"] != "run-json-follow" {
+		t.Fatalf("created.run = %#v, want run-json-follow", created["run"])
+	}
+
+	for i, want := range []string{"run.started", "run.completed"} {
+		var event map[string]any
+		if err := json.Unmarshal([]byte(lines[i+1]), &event); err != nil {
+			t.Fatalf("event line %d is not JSON: %v\n%s", i+1, err, lines[i+1])
+		}
+		if event["EventType"] != want {
+			t.Fatalf("event line %d EventType = %v, want %s", i+1, event["EventType"], want)
+		}
+	}
+}
+
+func TestRunCreateJSONWithoutFollowStillPrintsSingleRunObject(t *testing.T) {
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/runs": jsonHandler(201, map[string]any{
+			"id":     "run-json",
+			"status": "queued",
+		}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"run", "create",
+		"-w", "ws-1",
+		"--challenge-pack-version", "cpv-1",
+		"--deployments", "dep-1",
+		"--json",
+	}, srv.URL); err != nil {
+		t.Fatalf("run create --json: %v", err)
+	}
+	out := stdout.finish()
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("output is not a single JSON object: %v\n%s", err, out)
+	}
+	if payload["id"] != "run-json" {
+		t.Fatalf("payload.id = %v, want run-json", payload["id"])
+	}
+	if _, ok := payload["type"]; ok {
+		t.Fatalf("non-follow JSON must not use streaming envelope: %#v", payload)
+	}
+}
+
+func TestRunCreateFollowYAMLStreamsCreatedRunAndEvents(t *testing.T) {
+	sseBody := "event: step\n" +
+		"id: 1\n" +
+		"data: {\"EventType\":\"run.started\"}\n" +
+		"\n"
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/runs": jsonHandler(201, map[string]any{
+			"id":     "run-yaml-follow",
+			"status": "queued",
+		}),
+		"GET /v1/runs/run-yaml-follow/events/stream": sseHandler([]string{sseBody}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"run", "create",
+		"-w", "ws-1",
+		"--challenge-pack-version", "cpv-1",
+		"--deployments", "dep-1",
+		"--follow",
+		"--output", "yaml",
+	}, srv.URL); err != nil {
+		t.Fatalf("run create --follow --output yaml: %v", err)
+	}
+	out := stdout.finish()
+
+	dec := yaml.NewDecoder(strings.NewReader(out))
+	var docs []map[string]any
+	for {
+		var doc map[string]any
+		err := dec.Decode(&doc)
+		if err != nil {
+			break
+		}
+		docs = append(docs, doc)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("expected created run + 1 event YAML docs, got %d\n---\n%s", len(docs), out)
+	}
+	if docs[0]["type"] != "run.created" {
+		t.Fatalf("first doc type = %v, want run.created", docs[0]["type"])
+	}
+	if docs[1]["event"] != "step" {
+		t.Fatalf("second doc event = %v, want step", docs[1]["event"])
+	}
+}
+
+func TestEvalStartFollowJSONStreamsCreatedRunAndEvents(t *testing.T) {
+	sseBody := "event: step\n" +
+		"data: {\"EventType\":\"eval.completed\"}\n" +
+		"\n"
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/challenge-packs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{
+					"id":   "pack-1",
+					"name": "Support Eval",
+					"slug": "support-eval",
+					"versions": []map[string]any{
+						{"id": "ver-1", "version_number": 1, "lifecycle_status": "active"},
+					},
+				},
+			},
+		}),
+		"GET /v1/workspaces/ws-1/challenge-pack-versions/ver-1/input-sets": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "input-1", "input_key": "default", "name": "Default Inputs"},
+			},
+		}),
+		"GET /v1/workspaces/ws-1/agent-deployments": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "dep-1", "name": "prod", "status": "ready"},
+			},
+		}),
+		"POST /v1/runs": jsonHandler(201, map[string]any{
+			"id":     "run-eval-follow",
+			"status": "queued",
+		}),
+		"GET /v1/runs/run-eval-follow/events/stream": sseHandler([]string{sseBody}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"eval", "start",
+		"-w", "ws-1",
+		"--pack", "support-eval",
+		"--deployment", "prod",
+		"--follow",
+		"--json",
+	}, srv.URL); err != nil {
+		t.Fatalf("eval start --follow --json: %v", err)
+	}
+	out := stdout.finish()
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected created run + event lines, got %d\n---\n%s", len(lines), out)
+	}
+	var created map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &created); err != nil {
+		t.Fatalf("created line is not JSON: %v\n%s", err, lines[0])
+	}
+	if created["type"] != "run.created" {
+		t.Fatalf("created.type = %v, want run.created", created["type"])
+	}
+	var event map[string]any
+	if err := json.Unmarshal([]byte(lines[1]), &event); err != nil {
+		t.Fatalf("event line is not JSON: %v\n%s", err, lines[1])
+	}
+	if event["EventType"] != "eval.completed" {
+		t.Fatalf("event.EventType = %v, want eval.completed", event["EventType"])
 	}
 }


### PR DESCRIPTION
## Summary
- Fix `agentclash run create --follow --json` to emit a `run.created` envelope and then continue through the existing structured event stream
- Keep non-follow structured output as the original single run payload
- Cover `run create` JSON/YAML follow streams and `eval start --follow --json` with fake API/SSE tests

## Review checkpoint
- Contract: `/tmp/reviewcheckpoint-issue-426-json-follow-contract.md`
- Checkpoint: `/tmp/reviewcheckpoint-issue-426-json-follow.json`
- Final verdict: ready

## Tests
- `cd cli && go test ./cmd -run 'TestRunCreateFollowJSONStreamsCreatedRunAndEvents|TestRunCreateJSONWithoutFollowStillPrintsSingleRunObject|TestRunCreateFollowYAMLStreamsCreatedRunAndEvents|TestEvalStartFollowJSONStreamsCreatedRunAndEvents' -count=1`\n- `cd cli && go test ./cmd -count=1`\n- `cd cli && go test ./internal/... -count=1`\n- `cd cli && go test ./...`\n- `cd cli && go build ./...`\n- `cd cli && go vet ./...`\n- `cd cli && go test -short -race -count=1 ./...`\n- `git diff --check`\n\nCloses #426