### PR TITLE
fix(cli): render json errors

### DIFF
--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -41,6 +41,7 @@ func executeCommandWithQuiet(t *testing.T, args []string, apiURL string, quiet b
 	flagYes = false
 	flagDevice = false
 	flagForceLogin = false
+	runtimeOutputJSON = false
 
 	rootCmd.SetArgs(args)
 	return rootCmd.Execute()

--- a/cli/cmd/error_renderer.go
+++ b/cli/cmd/error_renderer.go
@@ -1,0 +1,136 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"io/fs"
+	"net"
+	"net/url"
+	"strings"
+
+	cliapi "github.com/agentclash/agentclash/cli/internal/api"
+)
+
+type cliError struct {
+	Code    string
+	Message string
+	Err     error
+}
+
+func (e *cliError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return e.Code
+}
+
+func (e *cliError) Unwrap() error {
+	return e.Err
+}
+
+type structuredErrorEnvelope struct {
+	Error structuredError `json:"error"`
+}
+
+type structuredError struct {
+	Code    string         `json:"code"`
+	Message string         `json:"message"`
+	Status  int            `json:"status,omitempty"`
+	Details map[string]any `json:"details"`
+}
+
+// RenderError writes a machine-readable error envelope when JSON output was
+// explicitly requested. It returns the process exit code and whether it
+// rendered or intentionally suppressed output for a silent ExitCodeError.
+func RenderError(err error, w io.Writer) (int, bool) {
+	code := exitCodeForError(err)
+	if err == nil || !structuredErrorOutputRequested() {
+		return code, false
+	}
+
+	var exitErr *ExitCodeError
+	if errors.As(err, &exitErr) && exitErr.Silent() {
+		return code, true
+	}
+
+	_ = json.NewEncoder(w).Encode(structuredErrorEnvelope{
+		Error: classifyStructuredError(err),
+	})
+	return code, true
+}
+
+func structuredErrorOutputRequested() bool {
+	return flagJSON || flagOutput == "json"
+}
+
+func exitCodeForError(err error) int {
+	var exitErr *ExitCodeError
+	if errors.As(err, &exitErr) {
+		return exitErr.Code
+	}
+	return 1
+}
+
+func classifyStructuredError(err error) structuredError {
+	details := map[string]any{}
+
+	var apiErr *cliapi.APIError
+	if errors.As(err, &apiErr) {
+		code := apiErr.Code
+		if code == "" {
+			code = "api_error"
+		}
+		message := apiErr.Message
+		if message == "" {
+			message = apiErr.Error()
+		}
+		return structuredError{Code: code, Message: message, Status: apiErr.StatusCode, Details: details}
+	}
+
+	var localErr *cliError
+	if errors.As(err, &localErr) {
+		return structuredError{Code: nonEmpty(localErr.Code, "invalid_argument"), Message: localErr.Error(), Details: details}
+	}
+
+	var exitErr *ExitCodeError
+	if errors.As(err, &exitErr) {
+		return structuredError{Code: "command_failed", Message: exitErr.Error(), Details: details}
+	}
+
+	if errors.Is(err, fs.ErrNotExist) {
+		return structuredError{Code: "file_not_found", Message: err.Error(), Details: details}
+	}
+	if errors.Is(err, fs.ErrPermission) {
+		return structuredError{Code: "permission_denied", Message: err.Error(), Details: details}
+	}
+
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return structuredError{Code: "request_failed", Message: err.Error(), Details: details}
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return structuredError{Code: "request_failed", Message: err.Error(), Details: details}
+	}
+
+	message := err.Error()
+	if strings.Contains(message, "request failed:") {
+		return structuredError{Code: "request_failed", Message: message, Details: details}
+	}
+	if strings.HasPrefix(message, "loading config:") {
+		return structuredError{Code: "invalid_config", Message: message, Details: details}
+	}
+
+	return structuredError{Code: "invalid_argument", Message: message, Details: details}
+}
+
+func nonEmpty(value, fallback string) string {
+	if value != "" {
+		return value
+	}
+	return fallback
+}

--- a/cli/cmd/error_renderer.go
+++ b/cli/cmd/error_renderer.go
@@ -12,6 +12,8 @@ import (
 	cliapi "github.com/agentclash/agentclash/cli/internal/api"
 )
 
+var runtimeOutputJSON bool
+
 type cliError struct {
 	Code    string
 	Message string
@@ -64,7 +66,11 @@ func RenderError(err error, w io.Writer) (int, bool) {
 }
 
 func structuredErrorOutputRequested() bool {
-	return flagJSON || flagOutput == "json"
+	return flagJSON || flagOutput == "json" || runtimeOutputJSON
+}
+
+func setRuntimeOutputFormat(format string) {
+	runtimeOutputJSON = format == "json"
 }
 
 func exitCodeForError(err error) int {

--- a/cli/cmd/error_renderer_test.go
+++ b/cli/cmd/error_renderer_test.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/agentclash/agentclash/cli/internal/config"
 )
 
 func TestRenderErrorJSONPreservesAPIError(t *testing.T) {
@@ -72,6 +74,63 @@ func TestRenderErrorOutputJSONPreservesAPIError(t *testing.T) {
 	envelope := decodeStructuredError(t, stderr.String())
 	if envelope.Error.Code != "forbidden" || envelope.Error.Status != 403 {
 		t.Fatalf("error = %#v, want forbidden 403", envelope.Error)
+	}
+}
+
+func TestRenderErrorUserConfigJSONPreservesAPIError(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if err := config.Save(config.UserConfig{Output: "json"}); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-denied/runs": jsonHandler(403, map[string]any{
+			"error": map[string]any{"code": "forbidden", "message": "workspace access denied"},
+		}),
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{"run", "list", "-w", "ws-denied"}, srv.URL)
+	if err == nil {
+		t.Fatal("expected API error")
+	}
+
+	var stderr bytes.Buffer
+	_, rendered := RenderError(err, &stderr)
+	if !rendered {
+		t.Fatal("expected structured error to render for config output json")
+	}
+
+	envelope := decodeStructuredError(t, stderr.String())
+	if envelope.Error.Code != "forbidden" || envelope.Error.Status != 403 {
+		t.Fatalf("error = %#v, want forbidden 403", envelope.Error)
+	}
+}
+
+func TestRenderErrorUserConfigTableDoesNotRender(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if err := config.Save(config.UserConfig{Output: "table"}); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-denied/runs": jsonHandler(403, map[string]any{
+			"error": map[string]any{"code": "forbidden", "message": "workspace access denied"},
+		}),
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{"run", "list", "-w", "ws-denied"}, srv.URL)
+	if err == nil {
+		t.Fatal("expected API error")
+	}
+
+	var stderr bytes.Buffer
+	_, rendered := RenderError(err, &stderr)
+	if rendered {
+		t.Fatalf("expected table config to skip structured renderer, got %q", stderr.String())
 	}
 }
 

--- a/cli/cmd/error_renderer_test.go
+++ b/cli/cmd/error_renderer_test.go
@@ -1,0 +1,204 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestRenderErrorJSONPreservesAPIError(t *testing.T) {
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/runs/not-a-uuid": jsonHandler(400, map[string]any{
+			"error": map[string]any{"code": "invalid_run_id", "message": "run id must be a valid UUID"},
+		}),
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{"run", "get", "not-a-uuid", "--json"}, srv.URL)
+	if err == nil {
+		t.Fatal("expected API error")
+	}
+
+	var stderr bytes.Buffer
+	exitCode, rendered := RenderError(err, &stderr)
+	if !rendered {
+		t.Fatal("expected structured error to render")
+	}
+	if exitCode == 0 {
+		t.Fatal("expected non-zero exit code")
+	}
+
+	envelope := decodeStructuredError(t, stderr.String())
+	if envelope.Error.Code != "invalid_run_id" {
+		t.Fatalf("code = %q, want invalid_run_id", envelope.Error.Code)
+	}
+	if envelope.Error.Message != "run id must be a valid UUID" {
+		t.Fatalf("message = %q", envelope.Error.Message)
+	}
+	if envelope.Error.Status != 400 {
+		t.Fatalf("status = %d, want 400", envelope.Error.Status)
+	}
+	if envelope.Error.Details == nil {
+		t.Fatal("details must be present")
+	}
+}
+
+func TestRenderErrorOutputJSONPreservesAPIError(t *testing.T) {
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-denied/runs": jsonHandler(403, map[string]any{
+			"error": map[string]any{"code": "forbidden", "message": "workspace access denied"},
+		}),
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{"run", "list", "-w", "ws-denied", "--output", "json"}, srv.URL)
+	if err == nil {
+		t.Fatal("expected API error")
+	}
+
+	var stderr bytes.Buffer
+	_, rendered := RenderError(err, &stderr)
+	if !rendered {
+		t.Fatal("expected structured error to render for --output json")
+	}
+
+	envelope := decodeStructuredError(t, stderr.String())
+	if envelope.Error.Code != "forbidden" || envelope.Error.Status != 403 {
+		t.Fatalf("error = %#v, want forbidden 403", envelope.Error)
+	}
+}
+
+func TestRenderErrorJSONClassifiesMissingFile(t *testing.T) {
+	err := executeCommand(t, []string{"challenge-pack", "validate", "missing.yaml", "-w", "ws-1", "--json"}, "http://unused")
+	if err == nil {
+		t.Fatal("expected missing file error")
+	}
+
+	var stderr bytes.Buffer
+	_, rendered := RenderError(err, &stderr)
+	if !rendered {
+		t.Fatal("expected structured error to render")
+	}
+
+	envelope := decodeStructuredError(t, stderr.String())
+	if envelope.Error.Code != "file_not_found" {
+		t.Fatalf("code = %q, want file_not_found", envelope.Error.Code)
+	}
+	if !strings.Contains(envelope.Error.Message, "missing.yaml") {
+		t.Fatalf("message = %q, want missing filename", envelope.Error.Message)
+	}
+}
+
+func TestRenderErrorJSONClassifiesLocalValidation(t *testing.T) {
+	err := executeCommand(t, []string{
+		"run", "create",
+		"-w", "ws-1",
+		"--challenge-pack-version", "cpv-1",
+		"--deployments", "dep-1",
+		"--scope", "bogus",
+		"--json",
+	}, "http://unused")
+	if err == nil {
+		t.Fatal("expected local validation error")
+	}
+
+	var stderr bytes.Buffer
+	_, rendered := RenderError(err, &stderr)
+	if !rendered {
+		t.Fatal("expected structured error to render")
+	}
+
+	envelope := decodeStructuredError(t, stderr.String())
+	if envelope.Error.Code != "invalid_argument" {
+		t.Fatalf("code = %q, want invalid_argument", envelope.Error.Code)
+	}
+	if !strings.Contains(envelope.Error.Message, "invalid --scope") {
+		t.Fatalf("message = %q, want invalid scope", envelope.Error.Message)
+	}
+}
+
+func TestRenderErrorJSONClassifiesRequestFailure(t *testing.T) {
+	err := fmt.Errorf("request failed: %w", &url.Error{Op: "Get", URL: "http://127.0.0.1:1", Err: errors.New("connection refused")})
+	withJSONFlag(t, func() {
+		var stderr bytes.Buffer
+		_, rendered := RenderError(err, &stderr)
+		if !rendered {
+			t.Fatal("expected structured error to render")
+		}
+
+		envelope := decodeStructuredError(t, stderr.String())
+		if envelope.Error.Code != "request_failed" {
+			t.Fatalf("code = %q, want request_failed", envelope.Error.Code)
+		}
+	})
+}
+
+func TestRenderErrorJSONClassifiesInvalidConfig(t *testing.T) {
+	err := fmt.Errorf("loading config: %w", errors.New("invalid yaml"))
+	withJSONFlag(t, func() {
+		var stderr bytes.Buffer
+		_, rendered := RenderError(err, &stderr)
+		if !rendered {
+			t.Fatal("expected structured error to render")
+		}
+
+		envelope := decodeStructuredError(t, stderr.String())
+		if envelope.Error.Code != "invalid_config" {
+			t.Fatalf("code = %q, want invalid_config", envelope.Error.Code)
+		}
+	})
+}
+
+func withJSONFlag(t *testing.T, fn func()) {
+	t.Helper()
+	oldJSON := flagJSON
+	oldOutput := flagOutput
+	flagJSON = true
+	flagOutput = ""
+	t.Cleanup(func() {
+		flagJSON = oldJSON
+		flagOutput = oldOutput
+	})
+	fn()
+}
+
+func TestRenderErrorDefaultOutputDoesNotRender(t *testing.T) {
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/organizations": jsonHandler(401, map[string]any{
+			"error": map[string]any{"code": "unauthorized", "message": "invalid token"},
+		}),
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "bad-token")
+	err := executeCommand(t, []string{"org", "list"}, srv.URL)
+	if err == nil {
+		t.Fatal("expected API error")
+	}
+
+	var stderr bytes.Buffer
+	_, rendered := RenderError(err, &stderr)
+	if rendered {
+		t.Fatalf("expected default output to skip structured renderer, got %q", stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func decodeStructuredError(t *testing.T, raw string) structuredErrorEnvelope {
+	t.Helper()
+
+	var envelope structuredErrorEnvelope
+	if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
+		t.Fatalf("structured error is not valid JSON: %v\n%s", err, raw)
+	}
+	return envelope
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -46,7 +46,13 @@ func GetRunContext(cmd *cobra.Command) *RunContext {
 func RequireWorkspace(cmd *cobra.Command) string {
 	rc := GetRunContext(cmd)
 	if rc.Workspace == "" {
-		fmt.Fprintln(os.Stderr, "Error: no workspace specified. Run 'agentclash link' to choose a default workspace, or pass --workspace, set AGENTCLASH_WORKSPACE, or create .agentclash.yaml with 'agentclash init'.")
+		err := &cliError{
+			Code:    "missing_workspace",
+			Message: "no workspace specified. Run 'agentclash link' to choose a default workspace, or pass --workspace, set AGENTCLASH_WORKSPACE, or create .agentclash.yaml with 'agentclash init'.",
+		}
+		if _, rendered := RenderError(err, os.Stderr); !rendered {
+			fmt.Fprintln(os.Stderr, "Error: "+err.Error())
+		}
 		os.Exit(2)
 	}
 	return rc.Workspace

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -116,6 +116,7 @@ Get started:
 
 		client := api.NewClient(mgr.APIURL(), token, opts...)
 		formatter := output.NewFormatter(mgr.OutputFormat(), flagJSON, flagQuiet)
+		setRuntimeOutputFormat(formatter.Format())
 
 		rc := &RunContext{
 			Client:    client,

--- a/cli/main.go
+++ b/cli/main.go
@@ -22,6 +22,10 @@ func main() {
 		return
 	}
 
+	if code, rendered := cmd.RenderError(err, os.Stderr); rendered {
+		os.Exit(code)
+	}
+
 	var exitErr *cmd.ExitCodeError
 	if errors.As(err, &exitErr) {
 		if !exitErr.Silent() {


### PR DESCRIPTION
## Summary
- Add a root-level JSON error renderer for `--json` / `--output json` failures
- Preserve API error `code`, `message`, and HTTP `status` in machine-readable envelopes
- Classify local failures with stable CLI codes including `file_not_found`, `invalid_argument`, `invalid_config`, `request_failed`, and `missing_workspace`
- Keep default human-readable error output unchanged

## Review checkpoint
- Contract: `/tmp/reviewcheckpoint-issue-425-json-errors-contract.md`
- Checkpoint: `/tmp/reviewcheckpoint-issue-425-json-errors.json`
- Final verdict: ready

## Tests
- `cd cli && go test ./cmd -run 'TestRenderError' -count=1`\n- `cd cli && go test ./cmd -count=1`\n- `cd cli && go test ./internal/... -count=1`\n- `cd cli && go test ./...`\n- `cd cli && go build ./...`\n- `cd cli && go vet ./...`\n- `cd cli && go test -short -race -count=1 ./...`\n- `git diff --check`\n\n## Local binary dry runs\n- Built `/tmp/agentclash-json-errors` and verified JSON + non-zero exit for missing workspace\n- Verified JSON + non-zero exit for `challenge-pack validate missing.yaml -w ws-1 --json`\n- Verified JSON + non-zero exit for `org list --api-url http://127.0.0.1:1 --json` request failure\n- Removed the temporary binary/config scratch after testing\n\nCloses #425