### PR TITLE
feat(scoring): surface evaluator validity

### DIFF
--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -1017,6 +1017,7 @@ func buildRunAgentScorecardDocument(evaluation scoring.RunAgentEvaluation) (json
 		Type             string          `json:"type"`
 		Verdict          string          `json:"verdict"`
 		State            string          `json:"state"`
+		OutcomeClass     string          `json:"outcome_class,omitempty"`
 		Reason           string          `json:"reason,omitempty"`
 		NormalizedScore  *float64        `json:"normalized_score,omitempty"`
 		RegressionCaseID *uuid.UUID      `json:"regression_case_id,omitempty"`
@@ -1055,6 +1056,8 @@ func buildRunAgentScorecardDocument(evaluation scoring.RunAgentEvaluation) (json
 		OverallScore     *float64                    `json:"overall_score,omitempty"`
 		Passed           *bool                       `json:"passed,omitempty"`
 		OverallReason    string                      `json:"overall_reason,omitempty"`
+		Validity         scoring.EvaluationValidity  `json:"validity,omitempty"`
+		ValidityReason   string                      `json:"validity_reason,omitempty"`
 		Warnings         []string                    `json:"warnings,omitempty"`
 		Dimensions       map[string]dimensionSummary `json:"dimensions"`
 		ValidatorSummary map[string]int              `json:"validator_summary"`
@@ -1123,6 +1126,7 @@ func buildRunAgentScorecardDocument(evaluation scoring.RunAgentEvaluation) (json
 			Type:             string(vr.Type),
 			Verdict:          vr.Verdict,
 			State:            string(vr.State),
+			OutcomeClass:     string(vr.OutcomeClass),
 			Reason:           vr.Reason,
 			NormalizedScore:  cloneFloat64Ptr(vr.NormalizedScore),
 			RegressionCaseID: cloneUUIDPtr(vr.RegressionCaseID),
@@ -1173,6 +1177,8 @@ func buildRunAgentScorecardDocument(evaluation scoring.RunAgentEvaluation) (json
 		OverallScore:     cloneFloat64Ptr(evaluation.OverallScore),
 		Passed:           passedCopy,
 		OverallReason:    evaluation.OverallReason,
+		Validity:         evaluation.Validity,
+		ValidityReason:   evaluation.ValidityReason,
 		Warnings:         append([]string(nil), evaluation.Warnings...),
 		Dimensions:       dimensions,
 		ValidatorSummary: validatorSummary,

--- a/backend/internal/repository/run_scorecard_test.go
+++ b/backend/internal/repository/run_scorecard_test.go
@@ -107,6 +107,52 @@ func TestBuildRunAgentScorecardDocumentIncludesRegressionCaseIDs(t *testing.T) {
 	}
 }
 
+func TestBuildRunAgentScorecardDocumentIncludesValidityAndValidatorOutcomeClass(t *testing.T) {
+	document, err := buildRunAgentScorecardDocument(scoring.RunAgentEvaluation{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		Status:           scoring.EvaluationStatusPartial,
+		Validity:         scoring.EvaluationValidityInvalid,
+		ValidityReason:   `validator "unit_tests" errored: sandbox lease expired`,
+		ValidatorResults: []scoring.ValidatorResult{
+			{
+				Key:          "unit_tests",
+				Type:         scoring.ValidatorTypeCodeExecution,
+				State:        scoring.OutputStateError,
+				OutcomeClass: scoring.ValidatorOutcomeInfraError,
+				Verdict:      "error",
+				Reason:       "sandbox lease expired",
+			},
+		},
+		DimensionResults: []scoring.DimensionResult{
+			{
+				Dimension: "correctness",
+				State:     scoring.OutputStateError,
+				Reason:    `validator "unit_tests" errored: sandbox lease expired`,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildRunAgentScorecardDocument returned error: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(document, &decoded); err != nil {
+		t.Fatalf("unmarshal scorecard document: %v", err)
+	}
+	if decoded["validity"] != string(scoring.EvaluationValidityInvalid) {
+		t.Fatalf("validity = %v, want invalid", decoded["validity"])
+	}
+	if decoded["validity_reason"] != `validator "unit_tests" errored: sandbox lease expired` {
+		t.Fatalf("validity_reason = %v", decoded["validity_reason"])
+	}
+	validatorDetails := decoded["validator_details"].([]any)
+	got := validatorDetails[0].(map[string]any)["outcome_class"]
+	if got != string(scoring.ValidatorOutcomeInfraError) {
+		t.Fatalf("validator outcome_class = %v, want infra_error", got)
+	}
+}
+
 func TestBuildRunScorecardDocumentMarksSingleAgentAsTrivialWinner(t *testing.T) {
 	runID := uuid.New()
 	evaluationSpecID := uuid.New()

--- a/backend/internal/scoring/engine.go
+++ b/backend/internal/scoring/engine.go
@@ -27,6 +27,25 @@ const (
 	EvaluationStatusFailed   EvaluationStatus = "failed"
 )
 
+type EvaluationValidity string
+
+const (
+	EvaluationValidityValid    EvaluationValidity = "valid"
+	EvaluationValidityDegraded EvaluationValidity = "degraded"
+	EvaluationValidityInvalid  EvaluationValidity = "invalid"
+)
+
+type ValidatorOutcomeClass string
+
+const (
+	ValidatorOutcomePass           ValidatorOutcomeClass = "pass"
+	ValidatorOutcomeFail           ValidatorOutcomeClass = "fail"
+	ValidatorOutcomeUnavailable    ValidatorOutcomeClass = "unavailable"
+	ValidatorOutcomeInfraError     ValidatorOutcomeClass = "infra_error"
+	ValidatorOutcomePackError      ValidatorOutcomeClass = "pack_error"
+	ValidatorOutcomeEvaluatorError ValidatorOutcomeClass = "evaluator_error"
+)
+
 type EvidenceInput struct {
 	ChallengeIdentityID uuid.UUID                   `json:"challenge_identity_id"`
 	RegressionCaseID    *uuid.UUID                  `json:"regression_case_id,omitempty"`
@@ -81,25 +100,28 @@ type RunAgentEvaluation struct {
 	OverallScore     *float64            `json:"overall_score,omitempty"`
 	Passed           *bool               `json:"passed,omitempty"`
 	OverallReason    string              `json:"overall_reason,omitempty"`
+	Validity         EvaluationValidity  `json:"validity,omitempty"`
+	ValidityReason   string              `json:"validity_reason,omitempty"`
 	Strategy         ScoringStrategy     `json:"strategy,omitempty"`
 	Warnings         []string            `json:"warnings,omitempty"`
 }
 
 type ValidatorResult struct {
-	Key                 string          `json:"key"`
-	Type                ValidatorType   `json:"type"`
-	State               OutputState     `json:"state"`
-	Verdict             string          `json:"verdict,omitempty"`
-	NormalizedScore     *float64        `json:"normalized_score,omitempty"`
-	Target              string          `json:"target"`
-	ExpectedFrom        string          `json:"expected_from"`
-	ActualValue         *string         `json:"actual_value,omitempty"`
-	ExpectedValue       *string         `json:"expected_value,omitempty"`
-	ChallengeIdentityID *uuid.UUID      `json:"challenge_identity_id,omitempty"`
-	RegressionCaseID    *uuid.UUID      `json:"regression_case_id,omitempty"`
-	Reason              string          `json:"reason,omitempty"`
-	Source              *Source         `json:"source,omitempty"`
-	RawOutput           json.RawMessage `json:"raw_output"`
+	Key                 string                `json:"key"`
+	Type                ValidatorType         `json:"type"`
+	State               OutputState           `json:"state"`
+	OutcomeClass        ValidatorOutcomeClass `json:"outcome_class,omitempty"`
+	Verdict             string                `json:"verdict,omitempty"`
+	NormalizedScore     *float64              `json:"normalized_score,omitempty"`
+	Target              string                `json:"target"`
+	ExpectedFrom        string                `json:"expected_from"`
+	ActualValue         *string               `json:"actual_value,omitempty"`
+	ExpectedValue       *string               `json:"expected_value,omitempty"`
+	ChallengeIdentityID *uuid.UUID            `json:"challenge_identity_id,omitempty"`
+	RegressionCaseID    *uuid.UUID            `json:"regression_case_id,omitempty"`
+	Reason              string                `json:"reason,omitempty"`
+	Source              *Source               `json:"source,omitempty"`
+	RawOutput           json.RawMessage       `json:"raw_output"`
 }
 
 type MetricResult struct {
@@ -219,6 +241,7 @@ func evaluateRunAgentWithResolvedJudges(
 	}
 
 	overallScore, passed, overallReason := computeOverallScore(spec, dimensionResults)
+	validity, validityReason := computeEvaluationValidity(validatorResults, metricResults, dimensionResults)
 
 	return RunAgentEvaluation{
 		RunAgentID:       input.RunAgentID,
@@ -232,6 +255,8 @@ func evaluateRunAgentWithResolvedJudges(
 		OverallScore:     overallScore,
 		Passed:           passed,
 		OverallReason:    overallReason,
+		Validity:         validity,
+		ValidityReason:   validityReason,
 		Strategy:         spec.Scorecard.Strategy,
 		Warnings:         uniqueStrings(warnings),
 	}, nil
@@ -292,18 +317,18 @@ func computeOverallScore(spec EvaluationSpec, results []DimensionResult) (*float
 		case ScoringStrategyBinary:
 			score := 0.0
 			passedVal := false
-			key, found := firstUnavailableRequiredDimension(spec.Scorecard.Dimensions, resultByKey, strategy)
-			return &score, &passedVal, unavailableGateReason(strategy, key, found)
+			key, state, found := firstUnavailableRequiredDimension(spec.Scorecard.Dimensions, resultByKey, strategy)
+			return &score, &passedVal, unavailableGateReason(strategy, key, state, found)
 		case ScoringStrategyHybrid:
-			if key, ok := firstUnavailableRequiredDimension(spec.Scorecard.Dimensions, resultByKey, strategy); ok {
+			if key, state, ok := firstUnavailableRequiredDimension(spec.Scorecard.Dimensions, resultByKey, strategy); ok {
 				score := 0.0
 				passedVal := false
-				return &score, &passedVal, unavailableGateReason(strategy, key, true)
+				return &score, &passedVal, unavailableGateReason(strategy, key, state, true)
 			}
 		case ScoringStrategyWeighted:
-			if key, ok := firstUnavailableRequiredDimension(spec.Scorecard.Dimensions, resultByKey, strategy); ok {
+			if key, state, ok := firstUnavailableRequiredDimension(spec.Scorecard.Dimensions, resultByKey, strategy); ok {
 				passedVal := false
-				return nil, &passedVal, unavailableGateReason(strategy, key, true)
+				return nil, &passedVal, unavailableGateReason(strategy, key, state, true)
 			}
 		}
 		return nil, nil, "no dimensions produced an available score"
@@ -324,7 +349,7 @@ func computeOverallScore(spec EvaluationSpec, results []DimensionResult) (*float
 		}
 	}
 
-	firstUnavailableGate, hasUnavailableGate := firstUnavailableRequiredDimension(spec.Scorecard.Dimensions, resultByKey, strategy)
+	firstUnavailableGate, unavailableGateState, hasUnavailableGate := firstUnavailableRequiredDimension(spec.Scorecard.Dimensions, resultByKey, strategy)
 	overallThreshold := spec.Scorecard.PassThreshold
 
 	switch strategy {
@@ -336,7 +361,7 @@ func computeOverallScore(spec EvaluationSpec, results []DimensionResult) (*float
 		}
 		reason := ""
 		if hasUnavailableGate {
-			reason = unavailableGateReason(strategy, firstUnavailableGate, true)
+			reason = unavailableGateReason(strategy, firstUnavailableGate, unavailableGateState, true)
 		} else if !passedVal {
 			reason = fmt.Sprintf("binary: dimension %q below pass_threshold", firstFailedGate)
 		}
@@ -346,7 +371,7 @@ func computeOverallScore(spec EvaluationSpec, results []DimensionResult) (*float
 		if hasUnavailableGate {
 			score := 0.0
 			passedVal := false
-			return &score, &passedVal, unavailableGateReason(strategy, firstUnavailableGate, true)
+			return &score, &passedVal, unavailableGateReason(strategy, firstUnavailableGate, unavailableGateState, true)
 		}
 		if anyGateFailed {
 			score := 0.0
@@ -388,7 +413,7 @@ func computeOverallScore(spec EvaluationSpec, results []DimensionResult) (*float
 		passedVal := !anyGateFailed && !hasUnavailableGate
 		reason := ""
 		if hasUnavailableGate {
-			reason = unavailableGateReason(strategy, firstUnavailableGate, true)
+			reason = unavailableGateReason(strategy, firstUnavailableGate, unavailableGateState, true)
 		} else if !passedVal {
 			reason = fmt.Sprintf("weighted: gated dimension %q below pass_threshold", firstFailedGate)
 		} else if overallThreshold != nil && score < *overallThreshold {
@@ -403,7 +428,7 @@ func firstUnavailableRequiredDimension(
 	decls []DimensionDeclaration,
 	results map[string]DimensionResult,
 	strategy ScoringStrategy,
-) (string, bool) {
+) (string, OutputState, bool) {
 	for _, decl := range decls {
 		required := decl.Gate || strategy == ScoringStrategyBinary
 		if !required {
@@ -411,15 +436,25 @@ func firstUnavailableRequiredDimension(
 		}
 		result, ok := results[decl.Key]
 		if !ok || result.State != OutputStateAvailable || result.Score == nil {
-			return decl.Key, true
+			return decl.Key, result.State, true
 		}
 	}
-	return "", false
+	return "", "", false
 }
 
-func unavailableGateReason(strategy ScoringStrategy, dimension string, found bool) string {
+func unavailableGateReason(strategy ScoringStrategy, dimension string, state OutputState, found bool) string {
 	if !found {
 		return "required dimension is unavailable"
+	}
+	if state == OutputStateError {
+		switch strategy {
+		case ScoringStrategyBinary:
+			return fmt.Sprintf("binary: dimension %q has evaluator error", dimension)
+		case ScoringStrategyHybrid:
+			return fmt.Sprintf("hybrid: gated dimension %q has evaluator error", dimension)
+		default:
+			return fmt.Sprintf("weighted: gated dimension %q has evaluator error", dimension)
+		}
 	}
 	switch strategy {
 	case ScoringStrategyBinary:

--- a/backend/internal/scoring/engine_dimensions.go
+++ b/backend/internal/scoring/engine_dimensions.go
@@ -75,8 +75,11 @@ func averageScopedValidators(scope []string, validators []ValidatorResult) (*flo
 	}
 	var total float64
 	for _, v := range selected {
+		if v.State == OutputStateError {
+			return nil, fmt.Sprintf("validator %q errored: %s", v.Key, firstNonEmpty(v.Reason, "validator error")), OutputStateError
+		}
 		if v.State != OutputStateAvailable || v.NormalizedScore == nil {
-			return nil, "all scoped validators must be available", OutputStateUnavailable
+			return nil, fmt.Sprintf("validator %q is unavailable: %s", v.Key, firstNonEmpty(v.Reason, "missing validator evidence")), OutputStateUnavailable
 		}
 		total += *v.NormalizedScore
 	}

--- a/backend/internal/scoring/engine_validators.go
+++ b/backend/internal/scoring/engine_validators.go
@@ -134,6 +134,10 @@ func evaluateValidators(validators []ValidatorDeclaration, evidence extractedEvi
 		}, outcome.evidence))
 		results = append(results, result)
 	}
+	for i := range results {
+		results[i].OutcomeClass = classifyValidatorOutcome(results[i])
+		results[i].RawOutput = withValidatorOutcomeClass(results[i].RawOutput, results[i].OutcomeClass)
+	}
 	return results, warnings
 }
 
@@ -226,6 +230,68 @@ func validateFileExistsUnavailable(config json.RawMessage) validatorOutcome {
 		return validatorOutcome{verdict: "fail", normalizedScore: floatPtr(0), reason: "file does not exist"}
 	}
 	return validatorOutcome{verdict: "pass", normalizedScore: floatPtr(1), reason: "file correctly does not exist"}
+}
+
+func classifyValidatorOutcome(result ValidatorResult) ValidatorOutcomeClass {
+	switch result.State {
+	case OutputStateAvailable:
+		switch result.Verdict {
+		case "pass":
+			return ValidatorOutcomePass
+		case "fail":
+			return ValidatorOutcomeFail
+		case "error":
+			return ValidatorOutcomeEvaluatorError
+		default:
+			if result.NormalizedScore != nil {
+				return ValidatorOutcomeFail
+			}
+			return ValidatorOutcomeUnavailable
+		}
+	case OutputStateUnavailable:
+		return ValidatorOutcomeUnavailable
+	case OutputStateError:
+		return classifyValidatorErrorOutcome(result)
+	default:
+		return ValidatorOutcomeEvaluatorError
+	}
+}
+
+func classifyValidatorErrorOutcome(result ValidatorResult) ValidatorOutcomeClass {
+	reason := strings.ToLower(result.Reason)
+	if result.Type == ValidatorTypeCodeExecution {
+		switch {
+		case strings.HasPrefix(reason, "parse code_execution config"),
+			strings.Contains(reason, "pass_at_k requires"):
+			return ValidatorOutcomePackError
+		default:
+			return ValidatorOutcomeInfraError
+		}
+	}
+	switch {
+	case strings.HasPrefix(reason, "parse "),
+		strings.Contains(reason, "invalid regex pattern"),
+		strings.Contains(reason, "unsupported comparator"):
+		return ValidatorOutcomePackError
+	default:
+		return ValidatorOutcomeEvaluatorError
+	}
+}
+
+func withValidatorOutcomeClass(raw json.RawMessage, class ValidatorOutcomeClass) json.RawMessage {
+	if class == "" {
+		return raw
+	}
+	decoded := map[string]any{}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &decoded); err != nil || decoded == nil {
+			decoded = map[string]any{
+				"raw_output": string(raw),
+			}
+		}
+	}
+	decoded["outcome_class"] = class
+	return mustMarshalJSON(decoded)
 }
 
 func applyValidator(validator ValidatorDeclaration, actual string, expected string) validatorOutcome {

--- a/backend/internal/scoring/engine_validators.go
+++ b/backend/internal/scoring/engine_validators.go
@@ -268,14 +268,51 @@ func classifyValidatorErrorOutcome(result ValidatorResult) ValidatorOutcomeClass
 			return ValidatorOutcomeInfraError
 		}
 	}
-	switch {
-	case strings.HasPrefix(reason, "parse "),
-		strings.Contains(reason, "invalid regex pattern"),
-		strings.Contains(reason, "unsupported comparator"):
+	if isPackAuthorValidatorError(reason) {
 		return ValidatorOutcomePackError
-	default:
-		return ValidatorOutcomeEvaluatorError
 	}
+	return ValidatorOutcomeEvaluatorError
+}
+
+func isPackAuthorValidatorError(reason string) bool {
+	switch {
+	case strings.Contains(reason, "invalid regex pattern"),
+		strings.Contains(reason, "unsupported comparator"),
+		strings.Contains(reason, "invalid ") && strings.Contains(reason, " config"),
+		strings.Contains(reason, " config is required"),
+		strings.Contains(reason, " config.") && strings.Contains(reason, " is required"),
+		strings.Contains(reason, "unsupported match_mode"),
+		strings.Contains(reason, "unsupported validator type"):
+		return true
+	}
+
+	packPrefixes := []string{
+		"parse expected boolean assertion value",
+		"parse expected numeric value",
+		"parse expected as json",
+		"parse fuzzy_match config",
+		"parse numeric_match config",
+		"parse normalized_match config",
+		"parse token_f1 config",
+		"parse math_equivalence config",
+		"parse bleu_score config",
+		"parse bleu_score references",
+		"parse rouge_score config",
+		"parse rouge_score references",
+		"parse chrf_score config",
+		"parse chrf_score references",
+		"parse json schema",
+		"resolve json schema",
+		"parse json_path_match expectation",
+		"evaluate jsonpath expression",
+		"compare jsonpath value",
+	}
+	for _, prefix := range packPrefixes {
+		if strings.HasPrefix(reason, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func withValidatorOutcomeClass(raw json.RawMessage, class ValidatorOutcomeClass) json.RawMessage {

--- a/backend/internal/scoring/evaluation_validity.go
+++ b/backend/internal/scoring/evaluation_validity.go
@@ -1,0 +1,39 @@
+package scoring
+
+import "fmt"
+
+func computeEvaluationValidity(validators []ValidatorResult, metrics []MetricResult, dimensions []DimensionResult) (EvaluationValidity, string) {
+	for _, validator := range validators {
+		if validator.State == OutputStateError {
+			return EvaluationValidityInvalid, fmt.Sprintf("validator %q errored: %s", validator.Key, firstNonEmpty(validator.Reason, "validator error"))
+		}
+	}
+	for _, metric := range metrics {
+		if metric.State == OutputStateError {
+			return EvaluationValidityInvalid, fmt.Sprintf("metric %q errored: %s", metric.Key, firstNonEmpty(metric.Reason, "metric error"))
+		}
+	}
+	for _, dimension := range dimensions {
+		if dimension.State == OutputStateError {
+			return EvaluationValidityInvalid, fmt.Sprintf("dimension %q errored: %s", dimension.Dimension, firstNonEmpty(dimension.Reason, "dimension error"))
+		}
+	}
+
+	for _, dimension := range dimensions {
+		if dimension.State == OutputStateUnavailable {
+			return EvaluationValidityDegraded, fmt.Sprintf("dimension %q unavailable: %s", dimension.Dimension, firstNonEmpty(dimension.Reason, "missing scoring evidence"))
+		}
+	}
+	for _, validator := range validators {
+		if validator.State == OutputStateUnavailable {
+			return EvaluationValidityDegraded, fmt.Sprintf("validator %q unavailable: %s", validator.Key, firstNonEmpty(validator.Reason, "missing validator evidence"))
+		}
+	}
+	for _, metric := range metrics {
+		if metric.State == OutputStateUnavailable {
+			return EvaluationValidityDegraded, fmt.Sprintf("metric %q unavailable: %s", metric.Key, firstNonEmpty(metric.Reason, "missing metric evidence"))
+		}
+	}
+
+	return EvaluationValidityValid, ""
+}

--- a/backend/internal/scoring/evaluation_validity_test.go
+++ b/backend/internal/scoring/evaluation_validity_test.go
@@ -155,6 +155,96 @@ func TestEvaluateRunAgent_CodeExecutionErrorClassifiedAsInfraError(t *testing.T)
 	}
 }
 
+func TestClassifyValidatorErrorOutcome_PackAuthorErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		result ValidatorResult
+	}{
+		{
+			name: "invalid file_exists config",
+			result: ValidatorResult{
+				Type:   ValidatorTypeFileExists,
+				State:  OutputStateError,
+				Reason: "invalid file_exists config: json: cannot unmarshal string into Go struct field fileExistsConfig.must_exist of type bool",
+			},
+		},
+		{
+			name: "file_json_schema config required",
+			result: ValidatorResult{
+				Type:   ValidatorTypeFileJSONSchema,
+				State:  OutputStateError,
+				Reason: "file_json_schema config is required",
+			},
+		},
+		{
+			name: "nested config field required",
+			result: ValidatorResult{
+				Type:   ValidatorTypeFileJSONSchema,
+				State:  OutputStateError,
+				Reason: "file_json_schema config.schema is required",
+			},
+		},
+		{
+			name: "directory_structure config required",
+			result: ValidatorResult{
+				Type:   ValidatorTypeDirectoryStructure,
+				State:  OutputStateError,
+				Reason: "directory_structure config is required",
+			},
+		},
+		{
+			name: "unsupported match mode",
+			result: ValidatorResult{
+				Type:   ValidatorTypeFileContentMatch,
+				State:  OutputStateError,
+				Reason: `unsupported match_mode "weird"`,
+			},
+		},
+		{
+			name: "unsupported validator type",
+			result: ValidatorResult{
+				Type:   ValidatorType("made_up"),
+				State:  OutputStateError,
+				Reason: `unsupported validator type "made_up"`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyValidatorErrorOutcome(tt.result); got != ValidatorOutcomePackError {
+				t.Fatalf("classifyValidatorErrorOutcome() = %s, want %s", got, ValidatorOutcomePackError)
+			}
+		})
+	}
+}
+
+func TestClassifyValidatorErrorOutcome_ActualParseErrorsRemainEvaluatorErrors(t *testing.T) {
+	tests := []ValidatorResult{
+		{
+			Type:   ValidatorTypeJSONSchema,
+			State:  OutputStateError,
+			Reason: "parse actual JSON document: invalid character '}' looking for beginning of object key string",
+		},
+		{
+			Type:   ValidatorTypeNumericMatch,
+			State:  OutputStateError,
+			Reason: `parse actual numeric value: no numeric value found in "not a number"`,
+		},
+		{
+			Type:   ValidatorTypeFileContentMatch,
+			State:  OutputStateError,
+			Reason: "parse actual as JSON: invalid character 'x' looking for beginning of value",
+		},
+	}
+
+	for _, result := range tests {
+		if got := classifyValidatorErrorOutcome(result); got != ValidatorOutcomeEvaluatorError {
+			t.Fatalf("classifyValidatorErrorOutcome(%q) = %s, want %s", result.Reason, got, ValidatorOutcomeEvaluatorError)
+		}
+	}
+}
+
 func mustUnmarshalValidityObject(t *testing.T, raw json.RawMessage) map[string]any {
 	t.Helper()
 	var decoded map[string]any

--- a/backend/internal/scoring/evaluation_validity_test.go
+++ b/backend/internal/scoring/evaluation_validity_test.go
@@ -1,0 +1,165 @@
+package scoring
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestEvaluateRunAgent_ValidatorErrorMarksEvaluationInvalid(t *testing.T) {
+	spec := EvaluationSpec{
+		Name:          "validator-error-validity",
+		VersionNumber: 1,
+		JudgeMode:     JudgeModeDeterministic,
+		Validators: []ValidatorDeclaration{
+			{
+				Key:          "regex_contract",
+				Type:         ValidatorTypeRegexMatch,
+				Target:       "final_output",
+				ExpectedFrom: "literal:[",
+			},
+		},
+		Scorecard: ScorecardDeclaration{
+			Strategy: ScoringStrategyHybrid,
+			Dimensions: []DimensionDeclaration{
+				{Key: "correctness", Source: DimensionSourceValidators, Gate: true, PassThreshold: floatPtr(0.9)},
+			},
+		},
+	}
+
+	evaluation, err := EvaluateRunAgent(EvaluationInput{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		Events: []Event{
+			{Type: "system.run.completed", OccurredAt: time.Date(2026, 5, 5, 10, 0, 0, 0, time.UTC), Payload: []byte(`{"final_output":"done"}`)},
+		},
+	}, spec)
+	if err != nil {
+		t.Fatalf("EvaluateRunAgent returned error: %v", err)
+	}
+
+	validator := evaluation.ValidatorResults[0]
+	if validator.State != OutputStateError {
+		t.Fatalf("validator state = %s, want error", validator.State)
+	}
+	if validator.OutcomeClass != ValidatorOutcomePackError {
+		t.Fatalf("validator outcome_class = %s, want pack_error", validator.OutcomeClass)
+	}
+	raw := mustUnmarshalValidityObject(t, validator.RawOutput)
+	if raw["outcome_class"] != string(ValidatorOutcomePackError) {
+		t.Fatalf("raw outcome_class = %v, want pack_error", raw["outcome_class"])
+	}
+	dimension := evaluation.DimensionResults[0]
+	if dimension.State != OutputStateError {
+		t.Fatalf("dimension state = %s, want error", dimension.State)
+	}
+	if !strings.Contains(dimension.Reason, `validator "regex_contract" errored`) {
+		t.Fatalf("dimension reason = %q, want validator error", dimension.Reason)
+	}
+	if evaluation.Validity != EvaluationValidityInvalid {
+		t.Fatalf("validity = %s, want invalid", evaluation.Validity)
+	}
+	if !strings.Contains(evaluation.ValidityReason, `validator "regex_contract"`) {
+		t.Fatalf("validity_reason = %q, want validator name", evaluation.ValidityReason)
+	}
+	if !strings.Contains(evaluation.OverallReason, "evaluator error") {
+		t.Fatalf("overall_reason = %q, want evaluator error", evaluation.OverallReason)
+	}
+}
+
+func TestEvaluateRunAgent_UnavailableValidatorMarksEvaluationDegraded(t *testing.T) {
+	spec := EvaluationSpec{
+		Name:          "validator-unavailable-validity",
+		VersionNumber: 1,
+		JudgeMode:     JudgeModeDeterministic,
+		Validators: []ValidatorDeclaration{
+			{
+				Key:          "exact",
+				Type:         ValidatorTypeExactMatch,
+				Target:       "final_output",
+				ExpectedFrom: "challenge_input",
+			},
+		},
+		Scorecard: ScorecardDeclaration{
+			Dimensions: []DimensionDeclaration{{Key: "correctness", Source: DimensionSourceValidators}},
+		},
+	}
+
+	evaluation, err := EvaluateRunAgent(EvaluationInput{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		Events: []Event{
+			{Type: "system.run.completed", OccurredAt: time.Date(2026, 5, 5, 10, 0, 0, 0, time.UTC), Payload: []byte(`{"final_output":"done"}`)},
+		},
+	}, spec)
+	if err != nil {
+		t.Fatalf("EvaluateRunAgent returned error: %v", err)
+	}
+
+	if evaluation.ValidatorResults[0].OutcomeClass != ValidatorOutcomeUnavailable {
+		t.Fatalf("validator outcome_class = %s, want unavailable", evaluation.ValidatorResults[0].OutcomeClass)
+	}
+	if evaluation.Validity != EvaluationValidityDegraded {
+		t.Fatalf("validity = %s, want degraded", evaluation.Validity)
+	}
+	if !strings.Contains(evaluation.ValidityReason, `dimension "correctness" unavailable`) {
+		t.Fatalf("validity_reason = %q, want degraded dimension reason", evaluation.ValidityReason)
+	}
+}
+
+func TestEvaluateRunAgent_CodeExecutionErrorClassifiedAsInfraError(t *testing.T) {
+	execPayload, err := json.Marshal(CodeExecutionResult{
+		ValidatorKey:   "unit_tests",
+		Target:         "file:generated_code",
+		TestCommand:    "pytest",
+		ExecutionError: "sandbox lease expired",
+	})
+	if err != nil {
+		t.Fatalf("marshal code execution result: %v", err)
+	}
+	spec := EvaluationSpec{
+		Name:          "code-exec-infra-validity",
+		VersionNumber: 1,
+		JudgeMode:     JudgeModeDeterministic,
+		Validators: []ValidatorDeclaration{
+			{Key: "unit_tests", Type: ValidatorTypeCodeExecution, Target: "file:generated_code", Config: json.RawMessage(`{"test_command":"pytest"}`)},
+		},
+		PostExecutionChecks: []PostExecutionCheck{
+			{Key: "generated_code", Type: PostExecutionCheckTypeFileCapture, Path: "/workspace/app.py"},
+		},
+		Scorecard: ScorecardDeclaration{
+			Dimensions: []DimensionDeclaration{{Key: "correctness", Source: DimensionSourceValidators}},
+		},
+	}
+
+	evaluation, err := EvaluateRunAgent(EvaluationInput{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		Events: []Event{
+			{Type: "grader.verification.code_executed", OccurredAt: time.Date(2026, 5, 5, 10, 0, 0, 0, time.UTC), Payload: execPayload},
+		},
+	}, spec)
+	if err != nil {
+		t.Fatalf("EvaluateRunAgent returned error: %v", err)
+	}
+
+	validator := evaluation.ValidatorResults[0]
+	if validator.OutcomeClass != ValidatorOutcomeInfraError {
+		t.Fatalf("validator outcome_class = %s, want infra_error", validator.OutcomeClass)
+	}
+	if evaluation.Validity != EvaluationValidityInvalid {
+		t.Fatalf("validity = %s, want invalid", evaluation.Validity)
+	}
+}
+
+func mustUnmarshalValidityObject(t *testing.T, raw json.RawMessage) map[string]any {
+	t.Helper()
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal raw output: %v", err)
+	}
+	return decoded
+}

--- a/backend/internal/workflow/scoring.go
+++ b/backend/internal/workflow/scoring.go
@@ -315,11 +315,11 @@ func scoringCompletedPayload(evaluation scoring.RunAgentEvaluation) map[string]a
 	llmJudgeResults := make([]map[string]any, 0, len(evaluation.LLMJudgeResults))
 	for _, result := range evaluation.LLMJudgeResults {
 		payload := map[string]any{
-			"judge_key":     result.JudgeKey,
-			"mode":          result.Mode,
-			"sample_count":  result.SampleCount,
-			"model_count":   result.ModelCount,
-			"reason":        result.Reason,
+			"judge_key":    result.JudgeKey,
+			"mode":         result.Mode,
+			"sample_count": result.SampleCount,
+			"model_count":  result.ModelCount,
+			"reason":       result.Reason,
 		}
 		if result.NormalizedScore != nil {
 			payload["normalized_score"] = *result.NormalizedScore
@@ -336,6 +336,8 @@ func scoringCompletedPayload(evaluation scoring.RunAgentEvaluation) map[string]a
 	return map[string]any{
 		"evaluation_spec_id": evaluation.EvaluationSpecID,
 		"status":             evaluation.Status,
+		"validity":           evaluation.Validity,
+		"validity_reason":    evaluation.ValidityReason,
 		"dimension_scores":   dimensionScores,
 		"llm_judge_results":  llmJudgeResults,
 		"warnings":           append([]string(nil), evaluation.Warnings...),

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -7747,6 +7747,11 @@ components:
           type: boolean
         overall_reason:
           type: string
+        validity:
+          type: string
+          enum: [valid, degraded, invalid]
+        validity_reason:
+          type: string
         warnings:
           type: array
           items:
@@ -7785,6 +7790,9 @@ components:
           type: string
         state:
           type: string
+        outcome_class:
+          type: string
+          enum: [pass, fail, unavailable, infra_error, pack_error, evaluator_error]
         reason:
           type: string
         normalized_score:


### PR DESCRIPTION
## Summary
- Add evaluator validity states (`valid`, `degraded`, `invalid`) to run-agent scorecard/scoring event payloads
- Classify validator outcomes as `pass`, `fail`, `unavailable`, `infra_error`, `pack_error`, or `evaluator_error`
- Propagate errored validators into dimension `state: error` with validator-specific reasons instead of collapsing them into generic unavailable evidence
- Keep ordinary available pass/fail scoring unchanged and avoid DB schema changes

## Review checkpoint
- Contract: `/tmp/reviewcheckpoint-issue-367-validator-outcomes-contract.md`
- Checkpoint: `/tmp/reviewcheckpoint-issue-367-validator-outcomes.json`
- Final verdict: ready

## Tests
- `cd backend && go test ./internal/scoring -run 'TestEvaluateRunAgent_.*Validity|TestEvaluateRunAgent_CodeExecutionErrorClassifiedAsInfraError' -count=1`\n- `cd backend && go test ./internal/repository -run 'TestBuildRunAgentScorecardDocumentIncludesValidityAndValidatorOutcomeClass' -count=1`\n- `cd backend && go test ./internal/scoring -count=1`\n- `cd backend && go test ./internal/repository -run 'TestBuildRunAgentScorecardDocument|TestBuildRunScorecardDocument' -count=1`\n- `cd backend && go test ./internal/scoring ./internal/repository ./internal/workflow ./internal/api -count=1`\n- `cd backend && go test ./...`\n- `cd backend && go build ./...`\n- `cd backend && go vet ./...`\n- `cd backend && go test -short -race -count=1 ./internal/scoring ./internal/repository ./internal/workflow`\n- `git diff --check`\n\nRefs #367