### PR TITLE
fix(releasegate): distinguish invalid scorecards

### DIFF
--- a/backend/internal/releasegate/releasegate.go
+++ b/backend/internal/releasegate/releasegate.go
@@ -336,17 +336,6 @@ func Evaluate(summary ComparisonSummary, policy Policy) (Evaluation, error) {
 		}, nil
 	}
 
-	if normalized.RequireEvidenceQuality && len(details.MissingFields) > 0 {
-		details.TriggeredConditions = []string{"comparison_evidence_missing"}
-		return Evaluation{
-			Verdict:        VerdictInsufficientEvidence,
-			ReasonCode:     "comparison_evidence_missing",
-			Summary:        buildInsufficientSummary("comparison evidence is incomplete", "", details.MissingFields),
-			EvidenceStatus: EvidenceStatusInsufficient,
-			Details:        details,
-		}, nil
-	}
-
 	if side, validity := blockingScorecardValidity(summary.ScorecardValidity); validity != nil {
 		reasonCode := scorecardValidityReasonCode(side, validity.Validity)
 		details.TriggeredConditions = append(details.TriggeredConditions, reasonCode)
@@ -354,6 +343,17 @@ func Evaluate(summary ComparisonSummary, policy Policy) (Evaluation, error) {
 			Verdict:        VerdictInsufficientEvidence,
 			ReasonCode:     reasonCode,
 			Summary:        scorecardValiditySummary(side, *validity),
+			EvidenceStatus: EvidenceStatusInsufficient,
+			Details:        details,
+		}, nil
+	}
+
+	if normalized.RequireEvidenceQuality && len(details.MissingFields) > 0 {
+		details.TriggeredConditions = []string{"comparison_evidence_missing"}
+		return Evaluation{
+			Verdict:        VerdictInsufficientEvidence,
+			ReasonCode:     "comparison_evidence_missing",
+			Summary:        buildInsufficientSummary("comparison evidence is incomplete", "", details.MissingFields),
 			EvidenceStatus: EvidenceStatusInsufficient,
 			Details:        details,
 		}, nil

--- a/backend/internal/releasegate/releasegate.go
+++ b/backend/internal/releasegate/releasegate.go
@@ -74,6 +74,7 @@ type ComparisonSummary struct {
 	CandidateRefs           ComparisonRunRefs         `json:"candidate_refs"`
 	DimensionDeltas         map[string]DimensionDelta `json:"dimension_deltas,omitempty"`
 	ScorecardPass           *ScorecardPassSummary     `json:"scorecard_pass,omitempty"`
+	ScorecardValidity       *ScorecardValiditySummary `json:"scorecard_validity,omitempty"`
 	FailureDivergence       FailureDivergence         `json:"failure_divergence"`
 	ReplaySummaryDivergence ReplayDivergence          `json:"replay_summary_divergence"`
 	EvidenceQuality         compareEvidenceQuality    `json:"evidence_quality"`
@@ -92,6 +93,16 @@ type ComparisonRunRefs struct {
 type ScorecardPassSummary struct {
 	Baseline  *bool `json:"baseline,omitempty"`
 	Candidate *bool `json:"candidate,omitempty"`
+}
+
+type ScorecardValiditySummary struct {
+	Baseline  *ScorecardValiditySide `json:"baseline,omitempty"`
+	Candidate *ScorecardValiditySide `json:"candidate,omitempty"`
+}
+
+type ScorecardValiditySide struct {
+	Validity       string `json:"validity"`
+	ValidityReason string `json:"validity_reason,omitempty"`
 }
 
 type DimensionDelta struct {
@@ -133,6 +144,7 @@ type EvaluationDetails struct {
 	TriggeredConditions  []string                       `json:"triggered_conditions,omitempty"`
 	RequiredDimensions   []string                       `json:"required_dimensions,omitempty"`
 	DimensionResults     map[string]DimensionEvaluation `json:"dimension_results,omitempty"`
+	ScorecardValidity    *ScorecardValiditySummary      `json:"scorecard_validity,omitempty"`
 	RegressionViolations []RegressionGateViolation      `json:"regression_violations,omitempty"`
 }
 
@@ -310,6 +322,7 @@ func Evaluate(summary ComparisonSummary, policy Policy) (Evaluation, error) {
 		Warnings:           append([]string(nil), summary.EvidenceQuality.Warnings...),
 		RequiredDimensions: append([]string(nil), normalized.RequiredDimensions...),
 		DimensionResults:   make(map[string]DimensionEvaluation, len(normalized.Dimensions)),
+		ScorecardValidity:  cloneScorecardValiditySummary(summary.ScorecardValidity),
 	}
 
 	if normalized.RequireComparable && summary.Status != "comparable" {
@@ -329,6 +342,18 @@ func Evaluate(summary ComparisonSummary, policy Policy) (Evaluation, error) {
 			Verdict:        VerdictInsufficientEvidence,
 			ReasonCode:     "comparison_evidence_missing",
 			Summary:        buildInsufficientSummary("comparison evidence is incomplete", "", details.MissingFields),
+			EvidenceStatus: EvidenceStatusInsufficient,
+			Details:        details,
+		}, nil
+	}
+
+	if side, validity := blockingScorecardValidity(summary.ScorecardValidity); validity != nil {
+		reasonCode := scorecardValidityReasonCode(side, validity.Validity)
+		details.TriggeredConditions = append(details.TriggeredConditions, reasonCode)
+		return Evaluation{
+			Verdict:        VerdictInsufficientEvidence,
+			ReasonCode:     reasonCode,
+			Summary:        scorecardValiditySummary(side, *validity),
 			EvidenceStatus: EvidenceStatusInsufficient,
 			Details:        details,
 		}, nil
@@ -470,6 +495,82 @@ func scorecardPassValue(summary *ScorecardPassSummary, candidate bool) *bool {
 	}
 	value := *source
 	return &value
+}
+
+func cloneScorecardValiditySummary(summary *ScorecardValiditySummary) *ScorecardValiditySummary {
+	if summary == nil {
+		return nil
+	}
+	return &ScorecardValiditySummary{
+		Baseline:  cloneScorecardValiditySide(summary.Baseline),
+		Candidate: cloneScorecardValiditySide(summary.Candidate),
+	}
+}
+
+func cloneScorecardValiditySide(side *ScorecardValiditySide) *ScorecardValiditySide {
+	if side == nil {
+		return nil
+	}
+	return &ScorecardValiditySide{
+		Validity:       side.Validity,
+		ValidityReason: side.ValidityReason,
+	}
+}
+
+func blockingScorecardValidity(summary *ScorecardValiditySummary) (string, *ScorecardValiditySide) {
+	if summary == nil {
+		return "", nil
+	}
+	if isBlockingScorecardValidity(summary.Candidate) {
+		return "candidate", summary.Candidate
+	}
+	if isBlockingScorecardValidity(summary.Baseline) {
+		return "baseline", summary.Baseline
+	}
+	return "", nil
+}
+
+func isBlockingScorecardValidity(side *ScorecardValiditySide) bool {
+	if side == nil {
+		return false
+	}
+	switch strings.TrimSpace(strings.ToLower(side.Validity)) {
+	case "invalid", "degraded":
+		return true
+	default:
+		return false
+	}
+}
+
+func scorecardValidityReasonCode(side string, validity string) string {
+	normalized := strings.TrimSpace(strings.ToLower(validity))
+	if normalized == "" {
+		normalized = "unknown"
+	}
+	return side + "_scorecard_" + normalized
+}
+
+func scorecardValiditySummary(side string, validity ScorecardValiditySide) string {
+	normalized := strings.TrimSpace(strings.ToLower(validity.Validity))
+	if normalized == "" {
+		normalized = "unknown"
+	}
+	switch normalized {
+	case "invalid":
+		return appendScorecardValidityReason(fmt.Sprintf("%s scorecard is invalid; fix evaluator, pack, or platform errors before evaluating agent changes", side), validity.ValidityReason)
+	case "degraded":
+		return appendScorecardValidityReason(fmt.Sprintf("%s scorecard is degraded; rerun or fix missing evidence before evaluating agent changes", side), validity.ValidityReason)
+	default:
+		return appendScorecardValidityReason(fmt.Sprintf("%s scorecard validity is %s", side, normalized), validity.ValidityReason)
+	}
+}
+
+func appendScorecardValidityReason(summary string, reason string) string {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return summary
+	}
+	return summary + ": " + reason
 }
 
 func worseningDelta(delta DimensionDelta) *float64 {

--- a/backend/internal/releasegate/releasegate_test.go
+++ b/backend/internal/releasegate/releasegate_test.go
@@ -283,10 +283,10 @@ func TestEvaluateRequiresScorecardPass(t *testing.T) {
 	}`
 
 	tests := []struct {
-		name       string
-		payload    string
+		name        string
+		payload     string
 		wantVerdict Verdict
-		wantReason string
+		wantReason  string
 	}{
 		{"candidate_passed", passPayload, VerdictPass, "within_thresholds"},
 		{"candidate_failed", failPayload, VerdictFail, "scorecard_not_passed"},
@@ -305,6 +305,112 @@ func TestEvaluateRequiresScorecardPass(t *testing.T) {
 				t.Fatalf("reason code = %q, want %q", evaluation.ReasonCode, tt.wantReason)
 			}
 		})
+	}
+}
+
+func TestEvaluateBlocksInvalidScorecardBeforeScorecardPassFailure(t *testing.T) {
+	policy := scorecardValidityTestPolicy()
+	evaluation, err := Evaluate(testSummary(t, `{
+		"status":"comparable",
+		"dimension_deltas":{
+			"correctness":{"delta":0,"better_direction":"higher","state":"available"}
+		},
+		"scorecard_pass":{"baseline":true,"candidate":false},
+		"scorecard_validity":{
+			"baseline":{"validity":"valid"},
+			"candidate":{"validity":"invalid","validity_reason":"validator \"regex_contract\" errored: invalid regex pattern"}
+		},
+		"failure_divergence":{"candidate_failed_baseline_succeeded":false,"both_failed_differently":false},
+		"replay_summary_divergence":{"state":"available"},
+		"evidence_quality":{}
+	}`), policy)
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if evaluation.Verdict != VerdictInsufficientEvidence {
+		t.Fatalf("verdict = %q, want %q", evaluation.Verdict, VerdictInsufficientEvidence)
+	}
+	if evaluation.ReasonCode != "candidate_scorecard_invalid" {
+		t.Fatalf("reason code = %q, want candidate_scorecard_invalid", evaluation.ReasonCode)
+	}
+	if evaluation.EvidenceStatus != EvidenceStatusInsufficient {
+		t.Fatalf("evidence status = %q, want %q", evaluation.EvidenceStatus, EvidenceStatusInsufficient)
+	}
+	if evaluation.Details.ScorecardValidity == nil || evaluation.Details.ScorecardValidity.Candidate == nil ||
+		evaluation.Details.ScorecardValidity.Candidate.ValidityReason == "" {
+		t.Fatalf("scorecard validity details missing candidate reason: %#v", evaluation.Details.ScorecardValidity)
+	}
+}
+
+func TestEvaluateBlocksDegradedScorecardWithDistinctReason(t *testing.T) {
+	policy := scorecardValidityTestPolicy()
+	evaluation, err := Evaluate(testSummary(t, `{
+		"status":"comparable",
+		"dimension_deltas":{
+			"correctness":{"delta":0,"better_direction":"higher","state":"available"}
+		},
+		"scorecard_pass":{"baseline":true,"candidate":true},
+		"scorecard_validity":{
+			"baseline":{"validity":"valid"},
+			"candidate":{"validity":"degraded","validity_reason":"dimension \"correctness\" unavailable: challenge input is unavailable"}
+		},
+		"failure_divergence":{"candidate_failed_baseline_succeeded":false,"both_failed_differently":false},
+		"replay_summary_divergence":{"state":"available"},
+		"evidence_quality":{}
+	}`), policy)
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if evaluation.Verdict != VerdictInsufficientEvidence {
+		t.Fatalf("verdict = %q, want %q", evaluation.Verdict, VerdictInsufficientEvidence)
+	}
+	if evaluation.ReasonCode != "candidate_scorecard_degraded" {
+		t.Fatalf("reason code = %q, want candidate_scorecard_degraded", evaluation.ReasonCode)
+	}
+	if evaluation.Summary == "release gate failed because candidate scorecard did not pass" {
+		t.Fatal("degraded scorecard reused ordinary scorecard_not_passed summary")
+	}
+}
+
+func TestEvaluateValidScorecardPassFailureStillUsesScorecardNotPassed(t *testing.T) {
+	policy := scorecardValidityTestPolicy()
+	evaluation, err := Evaluate(testSummary(t, `{
+		"status":"comparable",
+		"dimension_deltas":{
+			"correctness":{"delta":0,"better_direction":"higher","state":"available"}
+		},
+		"scorecard_pass":{"baseline":true,"candidate":false},
+		"scorecard_validity":{
+			"baseline":{"validity":"valid"},
+			"candidate":{"validity":"valid"}
+		},
+		"failure_divergence":{"candidate_failed_baseline_succeeded":false,"both_failed_differently":false},
+		"replay_summary_divergence":{"state":"available"},
+		"evidence_quality":{}
+	}`), policy)
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if evaluation.Verdict != VerdictFail {
+		t.Fatalf("verdict = %q, want %q", evaluation.Verdict, VerdictFail)
+	}
+	if evaluation.ReasonCode != "scorecard_not_passed" {
+		t.Fatalf("reason code = %q, want scorecard_not_passed", evaluation.ReasonCode)
+	}
+}
+
+func scorecardValidityTestPolicy() Policy {
+	warn := 0.05
+	fail := 0.10
+	return Policy{
+		PolicyKey:            "scorecard-validity-gate",
+		PolicyVersion:        1,
+		RequireComparable:    true,
+		RequireScorecardPass: true,
+		RequiredDimensions:   []string{"correctness"},
+		Dimensions: map[string]DimensionThreshold{
+			"correctness": {WarnDelta: &warn, FailDelta: &fail},
+		},
 	}
 }
 

--- a/backend/internal/releasegate/releasegate_test.go
+++ b/backend/internal/releasegate/releasegate_test.go
@@ -342,6 +342,31 @@ func TestEvaluateBlocksInvalidScorecardBeforeScorecardPassFailure(t *testing.T) 
 	}
 }
 
+func TestEvaluateScorecardValidityWinsOverGenericEvidenceMissing(t *testing.T) {
+	policy := scorecardValidityTestPolicy()
+	policy.RequireEvidenceQuality = true
+	evaluation, err := Evaluate(testSummary(t, `{
+		"status":"comparable",
+		"dimension_deltas":{
+			"correctness":{"delta":0,"better_direction":"higher","state":"available"}
+		},
+		"scorecard_pass":{"baseline":true},
+		"scorecard_validity":{
+			"baseline":{"validity":"valid"},
+			"candidate":{"validity":"invalid","validity_reason":"pack authoring error"}
+		},
+		"failure_divergence":{"candidate_failed_baseline_succeeded":false,"both_failed_differently":false},
+		"replay_summary_divergence":{"state":"available"},
+		"evidence_quality":{"missing_fields":["scorecard_pass.candidate"]}
+	}`), policy)
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if evaluation.ReasonCode != "candidate_scorecard_invalid" {
+		t.Fatalf("reason code = %q, want candidate_scorecard_invalid", evaluation.ReasonCode)
+	}
+}
+
 func TestEvaluateBlocksDegradedScorecardWithDistinctReason(t *testing.T) {
 	policy := scorecardValidityTestPolicy()
 	evaluation, err := Evaluate(testSummary(t, `{

--- a/backend/internal/repository/run_comparison.go
+++ b/backend/internal/repository/run_comparison.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/domain"
@@ -20,8 +21,9 @@ import (
 // runComparisonSummaryDocument changes in a way that schema-aware
 // consumers can observe. Phase 5 (2026-04-14) added the scorecard_pass
 // object so release-gate consumers can branch on whether the verdict is
-// known.
-const runComparisonSummarySchemaVersion = "2026-04-14"
+// known. The 2026-05-05 version added scorecard_validity so release gates
+// can separate evaluator/pack/platform failures from ordinary agent failures.
+const runComparisonSummarySchemaVersion = "2026-05-05"
 
 type RunComparisonStatus string
 
@@ -52,17 +54,18 @@ type RunComparison struct {
 }
 
 type runComparisonSummaryDocument struct {
-	SchemaVersion           string                         `json:"schema_version"`
-	Status                  RunComparisonStatus            `json:"status"`
-	ReasonCode              string                         `json:"reason_code,omitempty"`
-	BaselineRefs            runComparisonRefs              `json:"baseline_refs"`
-	CandidateRefs           runComparisonRefs              `json:"candidate_refs"`
-	MatchedParticipants     *runComparisonMatchedPair      `json:"matched_participants,omitempty"`
-	DimensionDeltas         map[string]runComparisonDelta  `json:"dimension_deltas,omitempty"`
-	ScorecardPass           *runComparisonScorecardPass    `json:"scorecard_pass,omitempty"`
-	FailureDivergence       runComparisonFailureDivergence `json:"failure_divergence"`
-	ReplaySummaryDivergence runComparisonReplayDivergence  `json:"replay_summary_divergence"`
-	EvidenceQuality         runComparisonEvidenceQuality   `json:"evidence_quality"`
+	SchemaVersion           string                          `json:"schema_version"`
+	Status                  RunComparisonStatus             `json:"status"`
+	ReasonCode              string                          `json:"reason_code,omitempty"`
+	BaselineRefs            runComparisonRefs               `json:"baseline_refs"`
+	CandidateRefs           runComparisonRefs               `json:"candidate_refs"`
+	MatchedParticipants     *runComparisonMatchedPair       `json:"matched_participants,omitempty"`
+	DimensionDeltas         map[string]runComparisonDelta   `json:"dimension_deltas,omitempty"`
+	ScorecardPass           *runComparisonScorecardPass     `json:"scorecard_pass,omitempty"`
+	ScorecardValidity       *runComparisonScorecardValidity `json:"scorecard_validity,omitempty"`
+	FailureDivergence       runComparisonFailureDivergence  `json:"failure_divergence"`
+	ReplaySummaryDivergence runComparisonReplayDivergence   `json:"replay_summary_divergence"`
+	EvidenceQuality         runComparisonEvidenceQuality    `json:"evidence_quality"`
 }
 
 // runComparisonScorecardPass carries the per-agent scorecard pass verdict
@@ -73,6 +76,16 @@ type runComparisonSummaryDocument struct {
 type runComparisonScorecardPass struct {
 	Baseline  *bool `json:"baseline,omitempty"`
 	Candidate *bool `json:"candidate,omitempty"`
+}
+
+type runComparisonScorecardValidity struct {
+	Baseline  *runComparisonScorecardValiditySide `json:"baseline,omitempty"`
+	Candidate *runComparisonScorecardValiditySide `json:"candidate,omitempty"`
+}
+
+type runComparisonScorecardValiditySide struct {
+	Validity       string `json:"validity"`
+	ValidityReason string `json:"validity_reason,omitempty"`
 }
 
 type runComparisonRefs struct {
@@ -132,12 +145,14 @@ type runComparisonEvidenceQuality struct {
 }
 
 type comparisonScorecardDocument struct {
-	Status        string                                      `json:"status"`
-	Strategy      string                                      `json:"strategy,omitempty"`
-	OverallScore  *float64                                    `json:"overall_score,omitempty"`
-	Passed        *bool                                       `json:"passed,omitempty"`
-	OverallReason string                                      `json:"overall_reason,omitempty"`
-	Dimensions    map[string]comparisonScorecardDimensionInfo `json:"dimensions"`
+	Status         string                                      `json:"status"`
+	Strategy       string                                      `json:"strategy,omitempty"`
+	OverallScore   *float64                                    `json:"overall_score,omitempty"`
+	Passed         *bool                                       `json:"passed,omitempty"`
+	OverallReason  string                                      `json:"overall_reason,omitempty"`
+	Validity       string                                      `json:"validity,omitempty"`
+	ValidityReason string                                      `json:"validity_reason,omitempty"`
+	Dimensions     map[string]comparisonScorecardDimensionInfo `json:"dimensions"`
 }
 
 type comparisonScorecardDimensionInfo struct {
@@ -506,6 +521,14 @@ func buildComparableRunComparisonSummary(
 	}
 	if candidatePassed == nil {
 		missingFields = append(missingFields, "scorecard_pass.candidate")
+	}
+	baselineValidity := runComparisonScorecardValidityFromDocument(baselineScorecardDoc)
+	candidateValidity := runComparisonScorecardValidityFromDocument(candidateScorecardDoc)
+	if baselineValidity != nil || candidateValidity != nil {
+		summary.ScorecardValidity = &runComparisonScorecardValidity{
+			Baseline:  baselineValidity,
+			Candidate: candidateValidity,
+		}
 	}
 	failureDivergence, failureWarnings := buildFailureDivergence(baseline.runAgent, candidate.runAgent, baseline.replay, candidate.replay)
 	warnings = append(warnings, failureWarnings...)
@@ -959,6 +982,17 @@ func resolveScorecardPass(scorecard *RunAgentScorecard, jsonbPassed *bool) *bool
 		return &value
 	}
 	return nil
+}
+
+func runComparisonScorecardValidityFromDocument(document comparisonScorecardDocument) *runComparisonScorecardValiditySide {
+	validity := strings.TrimSpace(document.Validity)
+	if validity == "" {
+		return nil
+	}
+	return &runComparisonScorecardValiditySide{
+		Validity:       validity,
+		ValidityReason: strings.TrimSpace(document.ValidityReason),
+	}
 }
 
 func decodeComparisonScorecard(payload json.RawMessage) (comparisonScorecardDocument, error) {

--- a/backend/internal/repository/run_comparison_test.go
+++ b/backend/internal/repository/run_comparison_test.go
@@ -247,3 +247,58 @@ func TestRunComparisonSummaryEmitsPartialScorecardPass(t *testing.T) {
 		t.Fatalf("expected baseline-only scorecard_pass, got: %s", string(encoded))
 	}
 }
+
+func TestDecodeComparisonScorecardReadsValidity(t *testing.T) {
+	document, err := decodeComparisonScorecard(json.RawMessage(`{
+		"status":"completed",
+		"validity":"invalid",
+		"validity_reason":"validator \"regex_contract\" errored",
+		"dimensions":{}
+	}`))
+	if err != nil {
+		t.Fatalf("decodeComparisonScorecard returned error: %v", err)
+	}
+	if document.Validity != "invalid" {
+		t.Fatalf("validity = %q, want invalid", document.Validity)
+	}
+	if document.ValidityReason != `validator "regex_contract" errored` {
+		t.Fatalf("validity_reason = %q", document.ValidityReason)
+	}
+}
+
+func TestRunComparisonSummaryOmitsScorecardValidityWhenBothNil(t *testing.T) {
+	summary := runComparisonSummaryDocument{
+		SchemaVersion: runComparisonSummarySchemaVersion,
+		Status:        RunComparisonStatusComparable,
+	}
+	encoded, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(encoded), "scorecard_validity") {
+		t.Fatalf("expected scorecard_validity to be omitted, got: %s", string(encoded))
+	}
+}
+
+func TestRunComparisonSummaryEmitsPartialScorecardValidity(t *testing.T) {
+	summary := runComparisonSummaryDocument{
+		SchemaVersion: runComparisonSummarySchemaVersion,
+		Status:        RunComparisonStatusComparable,
+		ScorecardValidity: &runComparisonScorecardValidity{
+			Candidate: &runComparisonScorecardValiditySide{
+				Validity:       "invalid",
+				ValidityReason: "pack error",
+			},
+		},
+	}
+	encoded, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(encoded), `"baseline"`) {
+		t.Fatalf("expected baseline scorecard_validity to be omitted, got: %s", string(encoded))
+	}
+	if !strings.Contains(string(encoded), `"scorecard_validity":{"candidate":{"validity":"invalid","validity_reason":"pack error"}}`) {
+		t.Fatalf("expected candidate scorecard_validity, got: %s", string(encoded))
+	}
+}

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -8227,10 +8227,30 @@ components:
           type: object
           additionalProperties:
             $ref: "#/components/schemas/ReleaseGateDimensionEvaluation"
+        scorecard_validity:
+          $ref: "#/components/schemas/ReleaseGateScorecardValidity"
         regression_violations:
           type: array
           items:
             $ref: "#/components/schemas/ReleaseGateRegressionViolation"
+
+    ReleaseGateScorecardValidity:
+      type: object
+      properties:
+        baseline:
+          $ref: "#/components/schemas/ReleaseGateScorecardValiditySide"
+        candidate:
+          $ref: "#/components/schemas/ReleaseGateScorecardValiditySide"
+
+    ReleaseGateScorecardValiditySide:
+      type: object
+      required: [validity]
+      properties:
+        validity:
+          type: string
+          enum: [valid, degraded, invalid]
+        validity_reason:
+          type: string
 
     ReleaseGateDimensionEvaluation:
       type: object


### PR DESCRIPTION
## Summary

Closes #554.

This PR makes CI/release gates consume the scorecard validity signal added in #553 so evaluator/pack/platform failures do not look like ordinary agent regressions.

- Adds `scorecard_validity` to run-comparison summaries from persisted run-agent scorecard JSON.
- Adds release-gate handling for `invalid` and `degraded` scorecards as distinct `insufficient_evidence` outcomes.
- Preserves baseline/candidate `validity` and `validity_reason` in release-gate `evaluation_details`.
- Keeps ordinary valid-but-failing scorecards on the existing `scorecard_not_passed` path.
- Documents the new release-gate details shape in OpenAPI.

## Review Checkpoint

Contract: `/tmp/reviewcheckpoint-issue-554-gate-validity-contract.md`
Checkpoint: `/tmp/reviewcheckpoint-issue-554-gate-validity.json`

Final verdict: ready.

## Tests

- `go test ./internal/releasegate -run 'TestEvaluate.*Scorecard|TestDefaultPolicy|TestEvaluateRequiresScorecardPass' -count=1`
- `go test ./internal/repository -run 'TestDecodeComparisonScorecardReadsValidity|TestRunComparisonSummary.*Scorecard' -count=1`
- `go test ./internal/releasegate ./internal/repository ./internal/api -count=1`
- `go test ./...`
- `go build ./...`
- `go vet ./...`
- `go test -short -race -count=1 ./internal/releasegate ./internal/repository ./internal/api`
- `git diff --check`
- `npx --yes @redocly/cli lint docs/api-server/openapi.yaml`

Redocly lint passes with only the pre-existing localhost server and `/healthz` 4XX warnings.
