### PR TITLE
feat(cli): preserve ci curation links

### DIFF
--- a/cli/cmd/ci_regressions.go
+++ b/cli/cmd/ci_regressions.go
@@ -61,7 +61,7 @@ type ciRunRegressionCaseSummary struct {
 	Metadata            map[string]any `json:"metadata"`
 }
 
-func promoteCIRunRegressionFailures(cmd *cobra.Command, rc *RunContext, workspaceID string, manifest ciManifest, result ciRunResult, releaseGate map[string]any) *ciRunRegressionPromotionResult {
+func promoteCIRunRegressionFailures(cmd *cobra.Command, rc *RunContext, workspaceID string, manifest ciManifest, result ciRunResult, releaseGate map[string]any, scorecard map[string]any, comparison map[string]any) *ciRunRegressionPromotionResult {
 	policy := strings.TrimSpace(manifest.Regressions.PromoteFailures)
 	if policy == "" || result.GateVerdict != "fail" {
 		return nil
@@ -151,7 +151,7 @@ func promoteCIRunRegressionFailures(cmd *cobra.Command, rc *RunContext, workspac
 				continue
 			}
 
-			created, err := promoteCIRunFailure(cmd, rc, workspaceID, suiteID, caseStatus, promotionMode, failure, result, releaseGate, manifest)
+			created, err := promoteCIRunFailure(cmd, rc, workspaceID, suiteID, caseStatus, promotionMode, failure, result, releaseGate, scorecard, comparison, manifest)
 			if err != nil {
 				summary.Errors = append(summary.Errors, fmt.Sprintf("promote challenge %s in suite %s: %v", failure.ChallengeIdentityID, suiteID, err))
 				continue
@@ -288,7 +288,7 @@ func ciRunPreferredPromotionMode(modes []string) string {
 	return ""
 }
 
-func promoteCIRunFailure(cmd *cobra.Command, rc *RunContext, workspaceID, suiteID, caseStatus, promotionMode string, failure ciRunFailureReviewItem, result ciRunResult, releaseGate map[string]any, manifest ciManifest) (ciRunRegressionPromotionCase, error) {
+func promoteCIRunFailure(cmd *cobra.Command, rc *RunContext, workspaceID, suiteID, caseStatus, promotionMode string, failure ciRunFailureReviewItem, result ciRunResult, releaseGate map[string]any, scorecard map[string]any, comparison map[string]any, manifest ciManifest) (ciRunRegressionPromotionCase, error) {
 	body := map[string]any{
 		"run_agent_id":        failure.RunAgentID,
 		"suite_id":            suiteID,
@@ -297,7 +297,7 @@ func promoteCIRunFailure(cmd *cobra.Command, rc *RunContext, workspaceID, suiteI
 		"failure_summary":     ciRunPromotionFailureSummary(failure, result),
 		"status":              caseStatus,
 		"validator_overrides": nil,
-		"metadata":            ciRunPromotionMetadata(failure, result, releaseGate, manifest),
+		"metadata":            ciRunPromotionMetadata(failure, result, releaseGate, scorecard, comparison, manifest),
 	}
 	if severity := strings.TrimSpace(failure.Severity); severity != "" {
 		body["severity"] = severity
@@ -349,7 +349,7 @@ func ciRunPromotionFailureSummary(failure ciRunFailureReviewItem, result ciRunRe
 	return "Candidate failed the AgentClash CI release gate."
 }
 
-func ciRunPromotionMetadata(failure ciRunFailureReviewItem, result ciRunResult, releaseGate map[string]any, manifest ciManifest) map[string]any {
+func ciRunPromotionMetadata(failure ciRunFailureReviewItem, result ciRunResult, releaseGate map[string]any, scorecard map[string]any, comparison map[string]any, manifest ciManifest) map[string]any {
 	metadata := map[string]any{
 		"source":                       "agentclash_ci",
 		"manifest_path":                result.ManifestPath,
@@ -378,7 +378,26 @@ func ciRunPromotionMetadata(failure ciRunFailureReviewItem, result ciRunResult, 
 	if fingerprint := mapString(releaseGate, "policy_fingerprint"); fingerprint != "" {
 		metadata["gate_policy_fingerprint"] = fingerprint
 	}
+	if links := ciRunPromotionCurationLinks(result, releaseGate, scorecard, comparison); len(links) > 0 {
+		metadata["curation_links"] = links
+	}
 	return metadata
+}
+
+func ciRunPromotionCurationLinks(result ciRunResult, releaseGate map[string]any, scorecard map[string]any, comparison map[string]any) map[string]string {
+	links := map[string]string{}
+	add := func(key string, value string) {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			links[key] = value
+		}
+	}
+	add("candidate_run", result.Candidate.RunURL)
+	add("scorecard", mapString(scorecard, "url", "web_url", "scorecard_url"))
+	add("replay", mapString(scorecard, "replay_url"))
+	add("comparison", mapString(comparison, "url", "web_url", "comparison_url"))
+	add("release_gate", mapString(releaseGate, "url", "web_url", "release_gate_url"))
+	return links
 }
 
 func ciRunPromotionFailureTaxonomy(failure ciRunFailureReviewItem, result ciRunResult, releaseGate map[string]any) map[string]any {

--- a/cli/cmd/ci_regressions.go
+++ b/cli/cmd/ci_regressions.go
@@ -393,11 +393,20 @@ func ciRunPromotionCurationLinks(result ciRunResult, releaseGate map[string]any,
 		}
 	}
 	add("candidate_run", result.Candidate.RunURL)
-	add("scorecard", mapString(scorecard, "url", "web_url", "scorecard_url"))
-	add("replay", mapString(scorecard, "replay_url"))
-	add("comparison", mapString(comparison, "url", "web_url", "comparison_url"))
-	add("release_gate", mapString(releaseGate, "url", "web_url", "release_gate_url"))
+	add("scorecard", ciRunFirstNonEmptyMapString(scorecard, "url", "web_url", "scorecard_url"))
+	add("replay", ciRunFirstNonEmptyMapString(scorecard, "replay_url"))
+	add("comparison", ciRunFirstNonEmptyMapString(comparison, "url", "web_url", "comparison_url"))
+	add("release_gate", ciRunFirstNonEmptyMapString(releaseGate, "url", "web_url", "release_gate_url"))
 	return links
+}
+
+func ciRunFirstNonEmptyMapString(m map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value := strings.TrimSpace(mapString(m, key)); value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func ciRunPromotionFailureTaxonomy(failure ciRunFailureReviewItem, result ciRunResult, releaseGate map[string]any) map[string]any {

--- a/cli/cmd/ci_run.go
+++ b/cli/cmd/ci_run.go
@@ -299,7 +299,7 @@ func executeCIRun(cmd *cobra.Command, rc *RunContext) (ciRunResult, error) {
 	result.GateVerdict = gateVerdict.ReleaseGate.Verdict
 	result.FailureReason = ciRunGateFailureReason(result.ReleaseGate)
 	result.ExitCode = ciRunExitCodeForGate(result.GateVerdict)
-	result.RegressionPromotions = promoteCIRunRegressionFailures(cmd, rc, workspaceID, manifest, result, result.ReleaseGate)
+	result.RegressionPromotions = promoteCIRunRegressionFailures(cmd, rc, workspaceID, manifest, result, result.ReleaseGate, scorecard, comparison)
 	if result.RegressionPromotions != nil && len(result.RegressionPromotions.Errors) > 0 {
 		for _, msg := range result.RegressionPromotions.Errors {
 			result.Errors = append(result.Errors, "regression promotion: "+msg)

--- a/cli/cmd/ci_run_test.go
+++ b/cli/cmd/ci_run_test.go
@@ -354,6 +354,7 @@ func TestCIRunWritesSummaryAndArtifactsForNonPassingVerdicts(t *testing.T) {
 
 func TestCIRunProposesRegressionCandidatesOnFailingGate(t *testing.T) {
 	target := writeCIRunManifest(t)
+	summaryPath := filepath.Join(t.TempDir(), "summary.md")
 	captures := &ciRunRouteCaptures{}
 	srv := fakeAPI(t, ciRunRoutes(t, captures, ciRunRegressionPromotionRoutes(t, captures, "fail", nil)))
 	defer srv.Close()
@@ -371,6 +372,7 @@ func TestCIRunProposesRegressionCandidatesOnFailingGate(t *testing.T) {
 		"--ci-pull-request", "42",
 		"--ci-branch", "feature/gate",
 		"--ci-default-branch", "main",
+		"--summary-file", summaryPath,
 	}, srv.URL)
 	if got := exitCodeOf(t, err); got != gateExitFail {
 		t.Fatalf("exit code = %d, want gate fail %d", got, gateExitFail)
@@ -399,6 +401,35 @@ func TestCIRunProposesRegressionCandidatesOnFailingGate(t *testing.T) {
 		taxonomy["failure_mode"] != "policy_violation" ||
 		taxonomy["gate_verdict"] != "fail" {
 		t.Fatalf("failure_taxonomy = %+v, want deterministic failure-review taxonomy", taxonomy)
+	}
+	links := mapObject(metadata, "curation_links")
+	if links["candidate_run"] != "https://app.agentclash.dev/runs/run-candidate" ||
+		links["scorecard"] != "https://app.agentclash.dev/scorecards/agent-candidate" ||
+		links["replay"] != "https://app.agentclash.dev/replays/agent-candidate" ||
+		links["comparison"] != "https://app.agentclash.dev/compare/run-baseline/run-candidate" ||
+		links["release_gate"] != "https://app.agentclash.dev/release-gates/gate-1" {
+		t.Fatalf("curation_links = %+v, want run/scorecard/replay/comparison/gate links", links)
+	}
+}
+
+func TestCIRunPromotionCurationLinksOmitMissingValues(t *testing.T) {
+	links := ciRunPromotionCurationLinks(ciRunResult{}, nil, nil, nil)
+	if len(links) != 0 {
+		t.Fatalf("links = %+v, want empty when inputs have no URLs", links)
+	}
+
+	links = ciRunPromotionCurationLinks(ciRunResult{
+		Candidate: ciRunCandidateResult{RunURL: " https://app.agentclash.dev/runs/run-candidate "},
+	}, map[string]any{
+		"web_url": "",
+	}, map[string]any{
+		"replay_url": "https://app.agentclash.dev/replays/agent-candidate",
+	}, map[string]any{})
+	if len(links) != 2 || links["candidate_run"] != "https://app.agentclash.dev/runs/run-candidate" || links["replay"] == "" {
+		t.Fatalf("links = %+v, want only non-empty candidate run and replay links", links)
+	}
+	if _, ok := links["release_gate"]; ok {
+		t.Fatalf("links = %+v, release_gate should be omitted when empty", links)
 	}
 }
 
@@ -1179,6 +1210,7 @@ func ciRunGateHandler(t *testing.T, captures *ciRunRouteCaptures, verdict string
 				"policy_key":         "default",
 				"policy_version":     1,
 				"policy_fingerprint": "fp-123",
+				"web_url":            "https://app.agentclash.dev/release-gates/gate-1",
 				"evaluation_details": map[string]any{
 					"triggered_conditions": []string{"latency_delta"},
 				},

--- a/cli/cmd/ci_run_test.go
+++ b/cli/cmd/ci_run_test.go
@@ -433,6 +433,26 @@ func TestCIRunPromotionCurationLinksOmitMissingValues(t *testing.T) {
 	}
 }
 
+func TestCIRunPromotionCurationLinksUseFirstNonEmptyURL(t *testing.T) {
+	links := ciRunPromotionCurationLinks(ciRunResult{}, map[string]any{
+		"url":              "",
+		"release_gate_url": "https://app.agentclash.dev/release-gates/gate-1",
+	}, map[string]any{
+		"url":           "",
+		"web_url":       "https://app.agentclash.dev/scorecards/agent-candidate",
+		"scorecard_url": "https://app.agentclash.dev/scorecards/fallback",
+	}, map[string]any{
+		"url":            "",
+		"comparison_url": "https://app.agentclash.dev/compare/run-baseline/run-candidate",
+	})
+
+	if links["scorecard"] != "https://app.agentclash.dev/scorecards/agent-candidate" ||
+		links["comparison"] != "https://app.agentclash.dev/compare/run-baseline/run-candidate" ||
+		links["release_gate"] != "https://app.agentclash.dev/release-gates/gate-1" {
+		t.Fatalf("links = %+v, want first non-empty fallback URLs", links)
+	}
+}
+
 func TestCIRunPromotionFailureTaxonomyRegressionGateFailure(t *testing.T) {
 	taxonomy := ciRunPromotionFailureTaxonomy(ciRunFailureReviewItem{
 		FailureClass: "policy_violation",


### PR DESCRIPTION
## Summary

Closes #558.

This PR adds curation links to CI-proposed regression metadata so reviewers can jump directly to the relevant run, scorecard, replay, comparison, and release gate when those URLs are already available to the CLI.

- Adds `metadata.curation_links` to promotion requests.
- Preserves candidate run, scorecard, replay, comparison, and release-gate URLs when present.
- Omits missing links instead of emitting empty strings.
- Leaves existing flat metadata and `failure_taxonomy` intact.

## Review Checkpoint

Contract: `/tmp/reviewcheckpoint-issue-558-ci-curation-links-contract.md`
Checkpoint: `/tmp/reviewcheckpoint-issue-558-ci-curation-links.json`

Final verdict: ready.

## Tests

- `go test ./cmd -run 'TestCIRunProposesRegressionCandidatesOnFailingGate|TestCIRunPromotionCurationLinks' -count=1`
- `go test ./...`
- `go build ./...`
- `go vet ./...`
- `go test -short -race -count=1 ./cmd`
- `git diff --check`
