### PR TITLE
feat(web): surface CI curation metadata

### DIFF
--- a/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/cases/[caseId]/case-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/cases/[caseId]/case-detail-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { PlayCircle } from "lucide-react";
+import { ArrowUpRight, PlayCircle } from "lucide-react";
 
 import type { RegressionCase, RegressionSuite } from "@/lib/api/types";
 import { Badge } from "@/components/ui/badge";
@@ -23,6 +23,33 @@ interface CaseDetailClientProps {
   regressionCase: RegressionCase;
 }
 
+const curationLinkLabels = [
+  ["candidate_run", "Candidate Run"],
+  ["scorecard", "Scorecard"],
+  ["replay", "Replay"],
+  ["comparison", "Comparison"],
+  ["release_gate", "Release Gate"],
+] as const;
+
+type CurationLink = {
+  key: (typeof curationLinkLabels)[number][0];
+  label: (typeof curationLinkLabels)[number][1];
+  href: string;
+};
+
+const taxonomyRowLabels = [
+  ["source", "Source"],
+  ["failure_mode", "Failure Mode"],
+  ["severity_hint", "Severity Hint"],
+  ["gate_verdict", "Gate Verdict"],
+  ["gate_reason_code", "Reason Code"],
+  ["reason_code", "Reason Code"],
+  ["triggered_condition", "Triggered Condition"],
+  ["scorecard_dimension", "Scorecard Dimension"],
+  ["review_failure_class", "Review Class"],
+  ["review_failure_state", "Review State"],
+] as const;
+
 export function CaseDetailClient({
   workspaceId,
   suite,
@@ -32,6 +59,10 @@ export function CaseDetailClient({
     c.source_run_id && c.source_run_agent_id
       ? `/workspaces/${workspaceId}/runs/${c.source_run_id}/agents/${c.source_run_agent_id}/replay`
       : null;
+  const curationLinks = getCurationLinks(c.metadata);
+  const taxonomyRows = getTaxonomyRows(c.metadata);
+  const hasCurationMetadata =
+    curationLinks.length > 0 || taxonomyRows.length > 0;
 
   return (
     <div className="space-y-6">
@@ -244,6 +275,41 @@ export function CaseDetailClient({
         )}
       </Section>
 
+      {hasCurationMetadata && (
+        <Section title="CI Curation">
+          {taxonomyRows.length > 0 && (
+            <dl className="grid gap-x-6 gap-y-3 text-sm sm:grid-cols-2">
+              {taxonomyRows.map((row) => (
+                <MetaRow key={`${row.label}-${row.value}`} label={row.label}>
+                  <span className="font-[family-name:var(--font-mono)] text-xs text-muted-foreground">
+                    {row.value}
+                  </span>
+                </MetaRow>
+              ))}
+            </dl>
+          )}
+          {curationLinks.length > 0 && (
+            <div className="mt-4 flex flex-wrap gap-2">
+              {curationLinks.map((link) => (
+                <Link
+                  key={link.key}
+                  href={link.href}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={buttonVariants({
+                    variant: "outline",
+                    size: "sm",
+                  })}
+                >
+                  {link.label}
+                  <ArrowUpRight data-icon="inline-end" className="size-3.5" />
+                </Link>
+              ))}
+            </div>
+          )}
+        </Section>
+      )}
+
       <Section title="Payload Snapshot">
         <JsonViewer value={c.payload_snapshot} />
       </Section>
@@ -324,6 +390,49 @@ function MetaRow({
 
 function formatPercent(value: number): string {
   return `${Math.round(value * 100)}%`;
+}
+
+function getCurationLinks(metadata: Record<string, unknown>) {
+  const links = readRecord(metadata.curation_links);
+  if (!links) return [];
+
+  const result: CurationLink[] = [];
+  for (const [key, label] of curationLinkLabels) {
+    const href = readString(links[key]);
+    if (href) {
+      result.push({ key, label, href });
+    }
+  }
+  return result;
+}
+
+function getTaxonomyRows(metadata: Record<string, unknown>) {
+  const taxonomy = readRecord(metadata.failure_taxonomy);
+  if (!taxonomy) return [];
+
+  const seenLabels = new Set<string>();
+  const rows: Array<{ label: string; value: string }> = [];
+  for (const [key, label] of taxonomyRowLabels) {
+    if (seenLabels.has(label)) continue;
+    const value = readString(taxonomy[key]);
+    if (!value) continue;
+    seenLabels.add(label);
+    rows.push({ label, value });
+  }
+  return rows;
+}
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function readString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
 }
 
 function ProvenanceRow({

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/cases/[caseId]/case-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/cases/[caseId]/case-detail-client.tsx
@@ -398,7 +398,7 @@ function getCurationLinks(metadata: Record<string, unknown>) {
 
   const result: CurationLink[] = [];
   for (const [key, label] of curationLinkLabels) {
-    const href = readString(links[key]);
+    const href = readExternalURL(links[key]);
     if (href) {
       result.push({ key, label, href });
     }
@@ -433,6 +433,20 @@ function readString(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
   return trimmed === "" ? null : trimmed;
+}
+
+function readExternalURL(value: unknown): string | null {
+  const href = readString(value);
+  if (!href) return null;
+
+  try {
+    const parsed = new URL(href);
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+      ? href
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 function ProvenanceRow({

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/cases/[caseId]/case-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/cases/[caseId]/case-detail-client.tsx
@@ -280,7 +280,7 @@ export function CaseDetailClient({
           {taxonomyRows.length > 0 && (
             <dl className="grid gap-x-6 gap-y-3 text-sm sm:grid-cols-2">
               {taxonomyRows.map((row) => (
-                <MetaRow key={`${row.label}-${row.value}`} label={row.label}>
+                <MetaRow key={row.label} label={row.label}>
                   <span className="font-[family-name:var(--font-mono)] text-xs text-muted-foreground">
                     {row.value}
                   </span>
@@ -295,7 +295,7 @@ export function CaseDetailClient({
                   key={link.key}
                   href={link.href}
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                   className={buttonVariants({
                     variant: "outline",
                     size: "sm",

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/suite-detail-client.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/suite-detail-client.test.tsx
@@ -274,6 +274,35 @@ describe("regression provenance UI", () => {
     }
   });
 
+  it("omits unsafe CI curation links", () => {
+    const view = render(
+      <CaseDetailClient
+        workspaceId="ws-1"
+        suite={suite}
+        regressionCase={makeCase({
+          metadata: {
+            curation_links: {
+              candidate_run: "javascript:alert(1)",
+              replay: " https://app.agentclash.dev/replays/agent-candidate ",
+            },
+          },
+        })}
+      />,
+    );
+    try {
+      expect(
+        view.container.querySelector('a[href="javascript:alert(1)"]'),
+      ).toBeNull();
+      expect(view.container.textContent).not.toContain("Candidate Run");
+      const replayLink = view.container.querySelector<HTMLAnchorElement>(
+        'a[href="https://app.agentclash.dev/replays/agent-candidate"]',
+      );
+      expect(replayLink?.textContent).toContain("Replay");
+    } finally {
+      view.cleanup();
+    }
+  });
+
   it("renders maintenance variants in the suite case list", () => {
     const view = render(
       <SuiteDetailClient

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/suite-detail-client.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/regression-suites/[suiteId]/suite-detail-client.test.tsx
@@ -190,6 +190,90 @@ describe("regression provenance UI", () => {
     }
   });
 
+  it("shows CI curation metadata in the case detail view", () => {
+    const view = render(
+      <CaseDetailClient
+        workspaceId="ws-1"
+        suite={suite}
+        regressionCase={makeCase({
+          metadata: {
+            source: "agentclash_ci",
+            failure_taxonomy: {
+              source: "release_gate",
+              failure_mode: "scorecard_dimension_regression",
+              severity_hint: "blocking",
+              gate_verdict: "fail",
+              gate_reason_code: "threshold_fail_correctness",
+              triggered_condition: "threshold_fail_correctness",
+            },
+            curation_links: {
+              candidate_run: "https://app.agentclash.dev/runs/run-candidate",
+              scorecard:
+                "https://app.agentclash.dev/scorecards/agent-candidate",
+              replay: "https://app.agentclash.dev/replays/agent-candidate",
+              comparison:
+                "https://app.agentclash.dev/compare/run-baseline/run-candidate",
+              release_gate:
+                "https://app.agentclash.dev/release-gates/gate-1",
+            },
+          },
+        })}
+      />,
+    );
+    try {
+      expect(view.container.textContent).toContain("CI Curation");
+      expect(view.container.textContent).toContain("Failure Mode");
+      expect(view.container.textContent).toContain(
+        "scorecard_dimension_regression",
+      );
+      expect(view.container.textContent).toContain("Reason Code");
+      expect(view.container.textContent).toContain("threshold_fail_correctness");
+      expect(view.container.textContent).toContain("Metadata");
+      expect(view.container.textContent).toContain("agentclash_ci");
+
+      for (const [label, href] of [
+        ["Candidate Run", "https://app.agentclash.dev/runs/run-candidate"],
+        [
+          "Scorecard",
+          "https://app.agentclash.dev/scorecards/agent-candidate",
+        ],
+        ["Replay", "https://app.agentclash.dev/replays/agent-candidate"],
+        [
+          "Comparison",
+          "https://app.agentclash.dev/compare/run-baseline/run-candidate",
+        ],
+        [
+          "Release Gate",
+          "https://app.agentclash.dev/release-gates/gate-1",
+        ],
+      ]) {
+        const link = view.container.querySelector<HTMLAnchorElement>(
+          `a[href="${href}"]`,
+        );
+        expect(link?.textContent).toContain(label);
+        expect(link?.getAttribute("target")).toBe("_blank");
+      }
+    } finally {
+      view.cleanup();
+    }
+  });
+
+  it("omits the CI curation section without CI metadata", () => {
+    const view = render(
+      <CaseDetailClient
+        workspaceId="ws-1"
+        suite={suite}
+        regressionCase={makeCase()}
+      />,
+    );
+    try {
+      expect(view.container.textContent).not.toContain("CI Curation");
+      expect(view.container.textContent).toContain("Metadata");
+    } finally {
+      view.cleanup();
+    }
+  });
+
   it("renders maintenance variants in the suite case list", () => {
     const view = render(
       <SuiteDetailClient


### PR DESCRIPTION
## Summary

- Adds a structured **CI Curation** section to regression case detail when case metadata includes `failure_taxonomy` and/or `curation_links`.
- Renders stable evidence links for candidate run, scorecard, replay, comparison, and release gate, omitting missing links.
- Keeps the raw Metadata JSON section available for debugging.

Closes #560.

## Review Checkpoint

- Contract: `/tmp/reviewcheckpoint-issue-560-regression-curation-metadata-contract.md`
- Checkpoint log: `/tmp/reviewcheckpoint-issue-560-regression-curation-metadata.json`
- Step 1 verdict: pass
- Final verdict: ready

## Tests

- `cd web && npm ci`
- `cd web && npm test -- --run src/app/'(workspace)'/workspaces/'[workspaceId]'/regression-suites/'[suiteId]'/suite-detail-client.test.tsx`
- `cd web && npx tsc --noEmit`
- `cd web && npm run lint`
- `cd web && npm test`
- `cd web && npm run build`
- `git diff --check`
