### PR TITLE
fix: accept CI default branch metadata

### DIFF
--- a/backend/internal/api/run_reads_test.go
+++ b/backend/internal/api/run_reads_test.go
@@ -161,6 +161,7 @@ func TestGetRunEndpointReturnsRun(t *testing.T) {
 						Repository:        "acme/agent",
 						PullRequestNumber: &prNumber,
 						WorkflowRunURL:    "https://github.com/acme/agent/actions/runs/123",
+						DefaultBranch:     "main",
 					},
 					CreatedAt: time.Date(2026, 3, 13, 12, 0, 0, 0, time.UTC),
 					UpdatedAt: time.Date(2026, 3, 13, 12, 1, 0, 0, time.UTC),
@@ -215,7 +216,7 @@ func TestGetRunEndpointReturnsRun(t *testing.T) {
 	if response.TemporalWorkflowID == nil || *response.TemporalWorkflowID != workflowID {
 		t.Fatalf("temporal workflow id = %v, want %q", response.TemporalWorkflowID, workflowID)
 	}
-	if response.CIMetadata == nil || response.CIMetadata.Repository != "acme/agent" || response.CIMetadata.PullRequestNumber == nil || *response.CIMetadata.PullRequestNumber != prNumber {
+	if response.CIMetadata == nil || response.CIMetadata.Repository != "acme/agent" || response.CIMetadata.PullRequestNumber == nil || *response.CIMetadata.PullRequestNumber != prNumber || response.CIMetadata.DefaultBranch != "main" {
 		t.Fatalf("ci metadata = %+v, want GitHub metadata", response.CIMetadata)
 	}
 	if response.RegressionCoverage == nil || len(response.RegressionCoverage.Suites) != 1 {

--- a/backend/internal/api/run_service_test.go
+++ b/backend/internal/api/run_service_test.go
@@ -32,6 +32,7 @@ func TestRunCreationManagerCreatesQueuedRunAndStartsWorkflow(t *testing.T) {
 		PullRequestNumber: &prNumber,
 		Branch:            "feature/gate",
 		CommitSHA:         "abc123",
+		DefaultBranch:     "main",
 	}
 
 	repo := &fakeRunCreationRepository{
@@ -90,7 +91,7 @@ func TestRunCreationManagerCreatesQueuedRunAndStartsWorkflow(t *testing.T) {
 	if repo.createParams.RunAgents[0].AgentDeploymentSnapshotID != snapshotID {
 		t.Fatalf("snapshot id = %s, want %s", repo.createParams.RunAgents[0].AgentDeploymentSnapshotID, snapshotID)
 	}
-	if repo.createParams.CIMetadata == nil || repo.createParams.CIMetadata.Repository != "acme/agent" || repo.createParams.CIMetadata.PullRequestNumber == nil || *repo.createParams.CIMetadata.PullRequestNumber != prNumber {
+	if repo.createParams.CIMetadata == nil || repo.createParams.CIMetadata.Repository != "acme/agent" || repo.createParams.CIMetadata.PullRequestNumber == nil || *repo.createParams.CIMetadata.PullRequestNumber != prNumber || repo.createParams.CIMetadata.DefaultBranch != "main" {
 		t.Fatalf("ci metadata = %+v, want copied GitHub metadata", repo.createParams.CIMetadata)
 	}
 	if repo.createParams.CIMetadata == ciMetadata {

--- a/backend/internal/api/runs.go
+++ b/backend/internal/api/runs.go
@@ -356,6 +356,7 @@ func normalizeCreateRunCIMetadata(metadata *domain.RunCIMetadata) (*domain.RunCI
 		WorkflowRunAttempt: strings.TrimSpace(metadata.WorkflowRunAttempt),
 		WorkflowRunURL:     strings.TrimSpace(metadata.WorkflowRunURL),
 		EventName:          strings.TrimSpace(metadata.EventName),
+		DefaultBranch:      strings.TrimSpace(metadata.DefaultBranch),
 	}
 	if normalized.Empty() {
 		return nil, nil
@@ -370,6 +371,7 @@ func normalizeCreateRunCIMetadata(metadata *domain.RunCIMetadata) (*domain.RunCI
 		"ci_metadata.workflow_run_id":      normalized.WorkflowRunID,
 		"ci_metadata.workflow_run_attempt": normalized.WorkflowRunAttempt,
 		"ci_metadata.event_name":           normalized.EventName,
+		"ci_metadata.default_branch":       normalized.DefaultBranch,
 	} {
 		if len(value) > 512 {
 			return nil, RunCreationValidationError{Code: "invalid_ci_metadata", Message: field + " must be 512 characters or fewer"}
@@ -416,6 +418,7 @@ func cloneRunCIMetadata(metadata *domain.RunCIMetadata) *domain.RunCIMetadata {
 		WorkflowRunAttempt: metadata.WorkflowRunAttempt,
 		WorkflowRunURL:     metadata.WorkflowRunURL,
 		EventName:          metadata.EventName,
+		DefaultBranch:      metadata.DefaultBranch,
 	}
 }
 

--- a/backend/internal/api/runs_test.go
+++ b/backend/internal/api/runs_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -112,6 +113,7 @@ func TestCreateRunEndpointPropagatesCIMetadata(t *testing.T) {
 					Workflow:          "AgentClash gate",
 					WorkflowRunURL:    "https://github.com/acme/agent/actions/runs/99",
 					EventName:         "pull_request",
+					DefaultBranch:     "main",
 				},
 				CreatedAt: time.Date(2026, 3, 13, 12, 0, 0, 0, time.UTC),
 			},
@@ -131,7 +133,8 @@ func TestCreateRunEndpointPropagatesCIMetadata(t *testing.T) {
 			"commit_sha":"abc123",
 			"workflow":"AgentClash gate",
 			"workflow_run_url":"https://github.com/acme/agent/actions/runs/99",
-			"event_name":"pull_request"
+			"event_name":"pull_request",
+			"default_branch":" main "
 		}
 	}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -170,7 +173,7 @@ func TestCreateRunEndpointPropagatesCIMetadata(t *testing.T) {
 	if recorder.Code != http.StatusCreated {
 		t.Fatalf("status = %d, want %d\n%s", recorder.Code, http.StatusCreated, recorder.Body.String())
 	}
-	if service.input.CIMetadata == nil || service.input.CIMetadata.Repository != "acme/agent" || service.input.CIMetadata.Branch != "feature/gate" {
+	if service.input.CIMetadata == nil || service.input.CIMetadata.Repository != "acme/agent" || service.input.CIMetadata.Branch != "feature/gate" || service.input.CIMetadata.DefaultBranch != "main" {
 		t.Fatalf("input ci metadata = %+v, want trimmed request metadata", service.input.CIMetadata)
 	}
 	if service.input.CIMetadata.PullRequestNumber == nil || *service.input.CIMetadata.PullRequestNumber != prNumber {
@@ -181,8 +184,8 @@ func TestCreateRunEndpointPropagatesCIMetadata(t *testing.T) {
 	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
-	if response.CIMetadata == nil || response.CIMetadata.WorkflowRunURL != "https://github.com/acme/agent/actions/runs/99" {
-		t.Fatalf("response ci metadata = %+v, want workflow link", response.CIMetadata)
+	if response.CIMetadata == nil || response.CIMetadata.WorkflowRunURL != "https://github.com/acme/agent/actions/runs/99" || response.CIMetadata.DefaultBranch != "main" {
+		t.Fatalf("response ci metadata = %+v, want workflow link and default branch", response.CIMetadata)
 	}
 }
 
@@ -281,6 +284,55 @@ func TestCreateRunEndpointRejectsUnsafeCIMetadataURL(t *testing.T) {
 	}
 	if !bytes.Contains(recorder.Body.Bytes(), []byte("ci_metadata.workflow_run_url must be an http or https URL")) {
 		t.Fatalf("body = %s, want workflow_run_url validation error", recorder.Body.String())
+	}
+}
+
+func TestCreateRunEndpointRejectsOverlongDefaultBranchCIMetadata(t *testing.T) {
+	workspaceID := uuid.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/runs", bytes.NewBufferString(`{
+		"workspace_id":"`+workspaceID.String()+`",
+		"challenge_pack_version_id":"`+uuid.New().String()+`",
+		"agent_deployment_ids":["`+uuid.New().String()+`"],
+		"ci_metadata":{"default_branch":"`+strings.Repeat("a", 513)+`"}
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(headerUserID, uuid.New().String())
+	req.Header.Set(headerWorkspaceMemberships, workspaceID.String()+":workspace_member")
+	recorder := httptest.NewRecorder()
+
+	newRouter("dev", nil,
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		nil,
+		0,
+		&fakeRunCreationService{},
+		&fakeRunReadService{},
+		&fakeReplayReadService{},
+		stubHostedRunIngestionService{},
+		nil,
+		stubAgentDeploymentReadService{},
+		stubChallengePackReadService{},
+		stubAgentBuildService{},
+		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+	}
+	if !bytes.Contains(recorder.Body.Bytes(), []byte("ci_metadata.default_branch must be 512 characters or fewer")) {
+		t.Fatalf("body = %s, want default_branch validation error", recorder.Body.String())
 	}
 }
 

--- a/backend/internal/domain/run.go
+++ b/backend/internal/domain/run.go
@@ -202,6 +202,7 @@ type RunCIMetadata struct {
 	WorkflowRunAttempt string `json:"workflow_run_attempt,omitempty"`
 	WorkflowRunURL     string `json:"workflow_run_url,omitempty"`
 	EventName          string `json:"event_name,omitempty"`
+	DefaultBranch      string `json:"default_branch,omitempty"`
 }
 
 func (m RunCIMetadata) Empty() bool {
@@ -215,7 +216,8 @@ func (m RunCIMetadata) Empty() bool {
 		m.WorkflowRunID == "" &&
 		m.WorkflowRunAttempt == "" &&
 		m.WorkflowRunURL == "" &&
-		m.EventName == ""
+		m.EventName == "" &&
+		m.DefaultBranch == ""
 }
 
 type RunAgent struct {

--- a/backend/internal/repository/repository_integration_test.go
+++ b/backend/internal/repository/repository_integration_test.go
@@ -1467,6 +1467,7 @@ func TestRepositoryCreateQueuedRunWritesRunRunAgentsAndInitialHistory(t *testing
 			Repository:        "acme/agent",
 			PullRequestNumber: &prNumber,
 			WorkflowRunURL:    "https://github.com/acme/agent/actions/runs/108",
+			DefaultBranch:     "main",
 		},
 		RunAgents: []repository.CreateQueuedRunAgentParams{
 			{
@@ -1487,14 +1488,14 @@ func TestRepositoryCreateQueuedRunWritesRunRunAgentsAndInitialHistory(t *testing
 	if result.Run.QueuedAt == nil {
 		t.Fatalf("queued_at was not set")
 	}
-	if result.Run.CIMetadata == nil || result.Run.CIMetadata.Repository != "acme/agent" || result.Run.CIMetadata.PullRequestNumber == nil || *result.Run.CIMetadata.PullRequestNumber != prNumber {
+	if result.Run.CIMetadata == nil || result.Run.CIMetadata.Repository != "acme/agent" || result.Run.CIMetadata.PullRequestNumber == nil || *result.Run.CIMetadata.PullRequestNumber != prNumber || result.Run.CIMetadata.DefaultBranch != "main" {
 		t.Fatalf("ci metadata = %+v, want persisted GitHub metadata", result.Run.CIMetadata)
 	}
 	persistedRun, err := repo.GetRunByID(ctx, result.Run.ID)
 	if err != nil {
 		t.Fatalf("GetRunByID returned error: %v", err)
 	}
-	if persistedRun.CIMetadata == nil || persistedRun.CIMetadata.Repository != "acme/agent" || persistedRun.CIMetadata.PullRequestNumber == nil || *persistedRun.CIMetadata.PullRequestNumber != prNumber {
+	if persistedRun.CIMetadata == nil || persistedRun.CIMetadata.Repository != "acme/agent" || persistedRun.CIMetadata.PullRequestNumber == nil || *persistedRun.CIMetadata.PullRequestNumber != prNumber || persistedRun.CIMetadata.DefaultBranch != "main" {
 		t.Fatalf("persisted ci metadata = %+v, want GitHub metadata after read", persistedRun.CIMetadata)
 	}
 	if len(result.RunAgents) != 1 {

--- a/cli/cmd/ci_run_test.go
+++ b/cli/cmd/ci_run_test.go
@@ -775,7 +775,7 @@ func TestCIRunAttachesGitHubActionsMetadata(t *testing.T) {
 	srv := fakeAPI(t, ciRunRoutes(t, captures, nil))
 	defer srv.Close()
 	eventPath := filepath.Join(t.TempDir(), "event.json")
-	if err := os.WriteFile(eventPath, []byte(`{"pull_request":{"number":42}}`), 0o644); err != nil {
+	if err := os.WriteFile(eventPath, []byte(`{"pull_request":{"number":42},"repository":{"default_branch":"main"}}`), 0o644); err != nil {
 		t.Fatalf("WriteFile(event) error: %v", err)
 	}
 	t.Setenv("AGENTCLASH_TOKEN", "test-token")
@@ -799,10 +799,10 @@ func TestCIRunAttachesGitHubActionsMetadata(t *testing.T) {
 	if !ok {
 		t.Fatalf("run body = %+v, want ci_metadata", captures.RunBody)
 	}
-	if metadata["repository"] != "acme/agent" || metadata["pull_request_number"] != float64(42) || metadata["workflow_run_url"] != "https://github.com/acme/agent/actions/runs/99" {
+	if metadata["repository"] != "acme/agent" || metadata["pull_request_number"] != float64(42) || metadata["workflow_run_url"] != "https://github.com/acme/agent/actions/runs/99" || metadata["default_branch"] != "main" {
 		t.Fatalf("ci metadata = %+v, want GitHub Actions metadata", metadata)
 	}
-	if result.Candidate.CIMetadata["repository"] != "acme/agent" || result.Candidate.CIMetadata["pull_request_number"] != float64(42) {
+	if result.Candidate.CIMetadata["repository"] != "acme/agent" || result.Candidate.CIMetadata["pull_request_number"] != float64(42) || result.Candidate.CIMetadata["default_branch"] != "main" {
 		t.Fatalf("result metadata = %+v, want persisted metadata", result.Candidate.CIMetadata)
 	}
 }

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -5627,6 +5627,8 @@ components:
           format: uri
         event_name:
           type: string
+        default_branch:
+          type: string
 
     CreateRunRequest:
       type: object

--- a/testing/codex-ci-metadata-default-branch.md
+++ b/testing/codex-ci-metadata-default-branch.md
@@ -1,0 +1,43 @@
+# codex/ci-metadata-default-branch — Test Contract
+
+## Functional Behavior
+- `POST /v1/runs` accepts `ci_metadata.default_branch` when the CLI detects it from GitHub Actions or receives `--ci-default-branch`.
+- Accepted CI metadata is normalized consistently: surrounding whitespace is trimmed, empty metadata is omitted, and `default_branch` follows the same max length guard as other short CI metadata strings.
+- Created runs persist `default_branch` inside `runs.ci_metadata`, and run creation/read responses include it when present.
+- Existing clients that omit `default_branch` continue to create runs successfully.
+- The CLI regression-promotion logic can rely on `candidate.ci_metadata.default_branch` echoed from the backend for `auto_on_main` decisions.
+
+## Unit Tests
+- `backend/internal/api` run creation tests cover decoding and echoing `ci_metadata.default_branch`.
+- `backend/internal/api` validation tests cover the 512-character limit for `ci_metadata.default_branch`.
+- `backend/internal/api` run read tests cover serialized metadata including `default_branch`.
+- `cli/cmd` CI tests continue to prove GitHub Actions metadata includes `default_branch` and is passed in the run-create body.
+
+## Integration / Functional Tests
+- Repository CI metadata round-trip tests cover `default_branch` persistence through `runs.ci_metadata`.
+
+## Smoke Tests
+- `go test ./backend/internal/domain ./backend/internal/api ./cli/cmd` passes from the repository root.
+- `go test ./backend/internal/repository` may require local database services; if unavailable, record the blocker and rely on the repository test source review.
+
+## E2E Tests
+- N/A — this schema-alignment fix is covered at API/CLI contract level. Full hosted GitHub rerun is optional after merge/deploy because the production API needs this backend change deployed.
+
+## Manual / cURL Tests
+```bash
+curl -X POST "$AGENTCLASH_API_URL/v1/runs" \
+  -H "Authorization: Bearer $AGENTCLASH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "workspace_id": "workspace-id",
+    "challenge_pack_version_id": "challenge-pack-version-id",
+    "agent_deployment_ids": ["deployment-id"],
+    "ci_metadata": {
+      "provider": "github_actions",
+      "repository": "owner/repo",
+      "branch": "main",
+      "default_branch": "main"
+    }
+  }'
+# Expected: 200/201-style run response, no "unknown field default_branch" JSON decode failure.
+```

--- a/testing/codex-ci-metadata-default-branch.md
+++ b/testing/codex-ci-metadata-default-branch.md
@@ -17,8 +17,9 @@
 - Repository CI metadata round-trip tests cover `default_branch` persistence through `runs.ci_metadata`.
 
 ## Smoke Tests
-- `go test ./backend/internal/domain ./backend/internal/api ./cli/cmd` passes from the repository root.
-- `go test ./backend/internal/repository` may require local database services; if unavailable, record the blocker and rely on the repository test source review.
+- From `backend/`, `go test ./internal/domain ./internal/api` passes.
+- From `cli/`, `go test ./cmd` passes.
+- From `backend/`, `go test ./internal/repository -run TestRepositoryCreateQueuedRunWritesRunRunAgentsAndInitialHistory -count=1` passes.
 
 ## E2E Tests
 - N/A — this schema-alignment fix is covered at API/CLI contract level. Full hosted GitHub rerun is optional after merge/deploy because the production API needs this backend change deployed.

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -618,6 +618,7 @@ export interface RunCIMetadata {
   workflow_run_attempt?: string;
   workflow_run_url?: string;
   event_name?: string;
+  default_branch?: string;
 }
 
 export interface RunRegressionCoverage {


### PR DESCRIPTION
## Summary
- add default_branch to backend RunCIMetadata so GitHub Actions ci_metadata.default_branch no longer fails JSON decoding
- trim, validate, clone, persist, and expose the field through API responses/docs/types
- update CLI/API/repository tests and the review-checkpoint contract

## Review checkpoint
- Contract: testing/codex-ci-metadata-default-branch.md
- Checkpoint: /tmp/reviewcheckpoint-ci-metadata-default-branch.json

## Tests
- (backend) go test ./internal/domain ./internal/api
- (cli) go test ./cmd
- (backend) go test ./internal/repository -run TestRepositoryCreateQueuedRunWritesRunRunAgentsAndInitialHistory -count=1