### PR TITLE
feat: link AgentClash PR comments to app views

### DIFF
--- a/.github/actions/agentclash-ci/README.md
+++ b/.github/actions/agentclash-ci/README.md
@@ -28,8 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -65,6 +64,7 @@ jobs:
 | `token` | `AGENTCLASH_TOKEN` | AgentClash API token. |
 | `workspace` | `AGENTCLASH_WORKSPACE` | AgentClash workspace ID. |
 | `api-url` | `https://api.agentclash.dev` | AgentClash API base URL. |
+| `app-url` | `https://app.agentclash.dev` | AgentClash app base URL used for PR comment links. |
 | `install-cli` | `true` | Install `agentclash` from npm before running. |
 | `cli-version` | `latest` | npm version or tag for the `agentclash` package. |
 | `remote-validate` | `true` | Validate manifest resource IDs against the API. |
@@ -98,6 +98,6 @@ The action preserves the CLI exit code. A blocking AgentClash gate fails the job
 
 ## Pull Request Comments
 
-When `pr-comment` is enabled, the action posts a single sticky comment on pull requests. The comment summarizes the gate verdict, failure reason, candidate and baseline runs, score deltas, regression tracking outcome, and next actions. If the action fails before a candidate run is created, the comment reports an errored setup state and points reviewers at the GitHub Actions log. Later pushes update the existing AgentClash comment instead of creating a new one.
+When `pr-comment` is enabled, the action posts a single sticky comment on pull requests. The comment summarizes the gate verdict, failure reason, candidate and baseline runs, score deltas, regression tracking outcome, and next actions. When run metadata is available, it also links directly to the AgentClash candidate run, baseline run, comparison, failures, scorecard, replay, and regression cases. If the action fails before a candidate run is created, the comment reports an errored setup state and points reviewers at the GitHub Actions log. Later pushes update the existing AgentClash comment instead of creating a new one.
 
-Commenting is best-effort. If the workflow is not running on a pull request, the token is missing, or the token lacks comment permissions, the action logs a notice and preserves the original AgentClash exit code. For GitHub-hosted PR comments, grant `issues: write` in the job permissions.
+Commenting is best-effort. If the workflow is not running on a pull request, the token is missing, or the token lacks comment permissions, the action logs a notice and preserves the original AgentClash exit code. For GitHub-hosted PR comments, grant `pull-requests: write` in the job permissions.

--- a/.github/actions/agentclash-ci/action.yml
+++ b/.github/actions/agentclash-ci/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: AgentClash API base URL.
     required: false
     default: https://api.agentclash.dev
+  app-url:
+    description: AgentClash app base URL used for links in PR comments.
+    required: false
+    default: https://app.agentclash.dev
   install-cli:
     description: Install the published agentclash npm package before running.
     required: false
@@ -112,6 +116,7 @@ runs:
         INPUT_TOKEN: ${{ inputs.token }}
         INPUT_WORKSPACE: ${{ inputs.workspace }}
         INPUT_API_URL: ${{ inputs.api-url }}
+        INPUT_APP_URL: ${{ inputs.app-url }}
         INPUT_INSTALL_CLI: ${{ inputs.install-cli }}
         INPUT_CLI_VERSION: ${{ inputs.cli-version }}
         INPUT_REMOTE_VALIDATE: ${{ inputs.remote-validate }}

--- a/.github/actions/agentclash-ci/comment.py
+++ b/.github/actions/agentclash-ci/comment.py
@@ -23,6 +23,7 @@ from typing import Any
 
 MARKER_PREFIX = "agentclash-ci-comment:v1"
 DIMENSION_ORDER = ("correctness", "reliability", "latency", "cost")
+DEFAULT_APP_URL = "https://app.agentclash.dev"
 
 
 @dataclass
@@ -94,6 +95,7 @@ def build_comment(
     result: dict[str, Any],
     should_run: dict[str, Any],
     exit_code: int,
+    app_url: str = DEFAULT_APP_URL,
 ) -> str:
     marker = marker_for_manifest(manifest)
     if should_run and should_run.get("should_run") is False:
@@ -112,6 +114,9 @@ def build_comment(
         )
 
     status = status_label(result, exit_code)
+    links = agentclash_links(result, app_url)
+    candidate_run_url = first_safe_url(nested(result, "candidate.run_url"), links.get("candidate_run"))
+    baseline_run_url = first_safe_url(nested(result, "baseline.run_url"), links.get("baseline_run"))
     lines = [
         marker,
         f"## AgentClash CI: {status}",
@@ -122,20 +127,25 @@ def build_comment(
         f"| Verdict | `{escape_cell(str(result.get('gate_verdict') or 'n/a'))}` |",
         f"| Failure reason | `{escape_cell(str(result.get('failure_reason') or 'n/a'))}` |",
         f"| Exit code | `{exit_code}` |",
-        f"| Candidate run | {format_link_or_code(nested(result, 'candidate.run_id'), nested(result, 'candidate.run_url'))} |",
-        f"| Baseline run | {format_link_or_code(nested(result, 'baseline.run_id'), nested(result, 'baseline.run_url'))} |",
+        f"| Candidate run | {format_link_or_code(nested(result, 'candidate.run_id'), candidate_run_url)} |",
+        f"| Baseline run | {format_link_or_code(nested(result, 'baseline.run_id'), baseline_run_url)} |",
     ]
 
     workflow_url = nested(result, "candidate.ci_metadata.workflow_run_url")
-    if workflow_url:
+    if is_safe_http_url(workflow_url):
         lines.append(f"| Workflow run | [open]({workflow_url}) |")
+
+    inspect_lines = inspect_link_lines(links)
+    if inspect_lines:
+        lines.extend(["", "### Inspect in AgentClash", ""])
+        lines.extend(inspect_lines)
 
     dimensions = dimension_rows(result)
     if dimensions:
         lines.extend(["", "### Score Deltas", "", "| Dimension | Outcome | Observed delta | Fail threshold |", "| --- | --- | ---: | ---: |"])
         lines.extend(dimensions)
 
-    regression_summary = regression_lines(result)
+    regression_summary = regression_lines(result, links)
     if regression_summary:
         lines.extend(["", "### Regression Tracking", ""])
         lines.extend(regression_summary)
@@ -180,10 +190,11 @@ def dimension_rows(result: dict[str, Any]) -> list[str]:
     return rows
 
 
-def regression_lines(result: dict[str, Any]) -> list[str]:
+def regression_lines(result: dict[str, Any], links: dict[str, str] | None = None) -> list[str]:
     promotions = result.get("regression_promotions")
     if not isinstance(promotions, dict):
         return []
+    links = links or {}
     lines = []
     policy = promotions.get("policy")
     case_status = promotions.get("case_status")
@@ -197,18 +208,24 @@ def regression_lines(result: dict[str, Any]) -> list[str]:
     ):
         items = promotions.get(key)
         if isinstance(items, list) and items:
-            lines.append(f"- {label}: {summarize_regression_items(items)}")
+            lines.append(f"- {label}: {summarize_regression_items(items, links)}")
     errors = promotions.get("errors")
     if isinstance(errors, list) and errors:
         lines.append(f"- Promotion errors: {', '.join(f'`{escape_cell(str(error))}`' for error in errors[:3])}")
     return lines
 
 
-def summarize_regression_items(items: list[Any]) -> str:
+def summarize_regression_items(items: list[Any], links: dict[str, str] | None = None) -> str:
+    links = links or {}
     labels = []
     for item in items[:5]:
         if isinstance(item, dict):
-            labels.append(f"`{escape_cell(str(item.get('challenge_key') or item.get('case_id') or item.get('reason') or 'unknown'))}`")
+            label = escape_cell(str(item.get("challenge_key") or item.get("case_id") or item.get("reason") or "unknown"))
+            case_url = regression_case_url(item, links)
+            if case_url:
+                labels.append(f"[`{label}`]({case_url})")
+            else:
+                labels.append(f"`{label}`")
         else:
             labels.append(f"`{escape_cell(str(item))}`")
     if len(items) > 5:
@@ -236,9 +253,133 @@ def format_link_or_code(value: Any, url: Any = None) -> str:
     if not value:
         return "`n/a`"
     label = escape_cell(str(value))
-    if url:
+    if is_safe_http_url(url):
         return f"[`{label}`]({url})"
     return f"`{label}`"
+
+
+def inspect_link_lines(links: dict[str, str]) -> list[str]:
+    ordered = (
+        ("candidate_run", "Candidate run"),
+        ("baseline_run", "Baseline run"),
+        ("comparison", "Compare baseline vs candidate"),
+        ("candidate_failures", "Candidate failures"),
+        ("candidate_scorecard", "Candidate scorecard"),
+        ("candidate_replay", "Candidate replay"),
+    )
+    lines = []
+    for key, label in ordered:
+        url = links.get(key)
+        if url:
+            lines.append(f"- [{label}]({url})")
+    return lines
+
+
+def agentclash_links(result: dict[str, Any], app_url: str) -> dict[str, str]:
+    links: dict[str, str] = {}
+    workspace_id = clean_id(result.get("workspace_id"))
+    candidate_run_id = clean_id(nested(result, "candidate.run_id"))
+    candidate_run_agent_id = clean_id(nested(result, "candidate.run_agent_id"))
+    baseline_run_id = clean_id(nested(result, "baseline.run_id"))
+    baseline_run_agent_id = clean_id(nested(result, "baseline.run_agent_id"))
+
+    def add(key: str, url: Any) -> None:
+        safe = normalize_safe_url(url)
+        if safe:
+            links[key] = safe
+
+    if workspace_id:
+        links["_workspace_id"] = workspace_id
+    if normalize_safe_url(app_url):
+        links["_app_url"] = normalize_safe_url(app_url)
+
+    if workspace_id:
+        if candidate_run_id:
+            add("candidate_run", app_link(app_url, "workspaces", workspace_id, "runs", candidate_run_id))
+            add("candidate_failures", app_link(app_url, "workspaces", workspace_id, "runs", candidate_run_id, "failures"))
+            if candidate_run_agent_id:
+                add(
+                    "candidate_scorecard",
+                    app_link(app_url, "workspaces", workspace_id, "runs", candidate_run_id, "agents", candidate_run_agent_id, "scorecard"),
+                )
+                add(
+                    "candidate_replay",
+                    app_link(app_url, "workspaces", workspace_id, "runs", candidate_run_id, "agents", candidate_run_agent_id, "replay"),
+                )
+        if baseline_run_id:
+            add("baseline_run", app_link(app_url, "workspaces", workspace_id, "runs", baseline_run_id))
+            if baseline_run_agent_id:
+                add(
+                    "baseline_scorecard",
+                    app_link(app_url, "workspaces", workspace_id, "runs", baseline_run_id, "agents", baseline_run_agent_id, "scorecard"),
+                )
+                add(
+                    "baseline_replay",
+                    app_link(app_url, "workspaces", workspace_id, "runs", baseline_run_id, "agents", baseline_run_agent_id, "replay"),
+                )
+        if baseline_run_id and candidate_run_id:
+            query = urllib.parse.urlencode({"baseline": baseline_run_id, "candidate": candidate_run_id})
+            add("comparison", app_link(app_url, "workspaces", workspace_id, "compare", query=query))
+
+    add("candidate_run", links.get("candidate_run") or nested(result, "candidate.run_url"))
+    add("baseline_run", links.get("baseline_run") or nested(result, "baseline.run_url"))
+    add("workflow_run", nested(result, "candidate.ci_metadata.workflow_run_url"))
+    return links
+
+
+def regression_case_url(item: dict[str, Any], links: dict[str, str]) -> str:
+    workspace_id = clean_id(links.get("_workspace_id"))
+    if not workspace_id:
+        return ""
+    suite_id = clean_id(item.get("suite_id"))
+    case_id = clean_id(item.get("case_id"))
+    app_url = links.get("_app_url", "")
+    if not suite_id or not case_id:
+        return ""
+    return app_link(app_url, "workspaces", workspace_id, "regression-suites", suite_id, "cases", case_id)
+
+
+def app_link(app_url: str, *parts: str, query: str = "") -> str:
+    base = normalize_safe_url(app_url)
+    if not base:
+        return ""
+    path = "/".join(urllib.parse.quote(str(part).strip(), safe="") for part in parts if str(part).strip())
+    if not path:
+        return base.rstrip("/")
+    url = f"{base.rstrip('/')}/{path}"
+    if query:
+        url = f"{url}?{query}"
+    return url
+
+
+def clean_id(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def first_safe_url(*values: Any) -> str:
+    for value in values:
+        safe = normalize_safe_url(value)
+        if safe:
+            return safe
+    return ""
+
+
+def normalize_safe_url(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    url = value.strip()
+    if not url:
+        return ""
+    parsed = urllib.parse.urlsplit(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return ""
+    return url
+
+
+def is_safe_http_url(value: Any) -> bool:
+    return normalize_safe_url(value) != ""
 
 
 def nested(value: Any, path: str) -> Any:
@@ -314,6 +455,7 @@ def post_comment(
     api_url: str,
     env: dict[str, str],
     event_payload: dict[str, Any],
+    app_url: str = DEFAULT_APP_URL,
     client: Any | None = None,
 ) -> CommentOutcome:
     if not token:
@@ -324,7 +466,7 @@ def post_comment(
     if pr_number is None:
         return CommentOutcome("skipped", "missing pull request context")
 
-    body = build_comment(manifest=manifest, result=result, should_run=should_run, exit_code=exit_code)
+    body = build_comment(manifest=manifest, result=result, should_run=should_run, exit_code=exit_code, app_url=app_url)
     marker = marker_for_manifest(manifest)
     github = client or GitHubClient(api_url, repo, token)
     try:
@@ -345,6 +487,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
     parser.add_argument("--event-path", default=os.environ.get("GITHUB_EVENT_PATH", ""))
     parser.add_argument("--api-url", default=os.environ.get("GITHUB_API_URL", "https://api.github.com"))
+    parser.add_argument("--app-url", default=os.environ.get("AGENTCLASH_APP_URL", DEFAULT_APP_URL))
     return parser.parse_args(argv)
 
 
@@ -371,6 +514,7 @@ def main(argv: list[str]) -> int:
         repo=args.repo,
         token=os.environ.get("INPUT_GITHUB_TOKEN") or os.environ.get("GITHUB_TOKEN") or "",
         api_url=args.api_url,
+        app_url=args.app_url,
         env=dict(os.environ),
         event_payload=load_event_payload(args.event_path),
     )

--- a/.github/actions/agentclash-ci/comment.py
+++ b/.github/actions/agentclash-ci/comment.py
@@ -115,8 +115,8 @@ def build_comment(
 
     status = status_label(result, exit_code)
     links = agentclash_links(result, app_url)
-    candidate_run_url = first_safe_url(nested(result, "candidate.run_url"), links.get("candidate_run"))
-    baseline_run_url = first_safe_url(nested(result, "baseline.run_url"), links.get("baseline_run"))
+    candidate_run_url = first_safe_url(links.get("candidate_run"), nested(result, "candidate.run_url"))
+    baseline_run_url = first_safe_url(links.get("baseline_run"), nested(result, "baseline.run_url"))
     lines = [
         marker,
         f"## AgentClash CI: {status}",

--- a/.github/actions/agentclash-ci/comment_test.py
+++ b/.github/actions/agentclash-ci/comment_test.py
@@ -24,11 +24,12 @@ class FakeGitHubClient:
 
 def failing_result():
     return {
+        "workspace_id": "workspace-1",
         "gate_verdict": "fail",
         "failure_reason": "threshold_fail_correctness",
         "candidate": {
             "run_id": "run-candidate",
-            "run_url": "https://app.agentclash.dev/runs/run-candidate",
+            "run_agent_id": "agent-candidate",
             "ci_metadata": {
                 "pull_request_number": 42,
                 "workflow_run_url": "https://github.com/acme/agent/actions/runs/123",
@@ -36,6 +37,7 @@ def failing_result():
         },
         "baseline": {
             "run_id": "run-baseline",
+            "run_agent_id": "agent-baseline",
         },
         "release_gate": {
             "evaluation_details": {
@@ -58,6 +60,7 @@ def failing_result():
             "case_status": "proposed",
             "created": [
                 {
+                    "suite_id": "suite-1",
                     "challenge_key": "refund-abuse-triage",
                     "case_id": "case-1",
                 },
@@ -80,11 +83,62 @@ class CommentFormattingTests(unittest.TestCase):
         self.assertIn("threshold_fail_correctness", body)
         self.assertIn("run-candidate", body)
         self.assertIn("run-baseline", body)
+        self.assertIn("Inspect in AgentClash", body)
+        self.assertIn("https://app.agentclash.dev/workspaces/workspace-1/runs/run-candidate", body)
+        self.assertIn("https://app.agentclash.dev/workspaces/workspace-1/runs/run-baseline", body)
+        self.assertIn("https://app.agentclash.dev/workspaces/workspace-1/compare?baseline=run-baseline&candidate=run-candidate", body)
+        self.assertIn("https://app.agentclash.dev/workspaces/workspace-1/runs/run-candidate/failures", body)
+        self.assertIn("https://app.agentclash.dev/workspaces/workspace-1/runs/run-candidate/agents/agent-candidate/scorecard", body)
+        self.assertIn("https://app.agentclash.dev/workspaces/workspace-1/runs/run-candidate/agents/agent-candidate/replay", body)
         self.assertIn("Score Deltas", body)
         self.assertIn("`correctness` | `fail` | `-1` | `0.05`", body)
         self.assertIn("Regression Tracking", body)
         self.assertIn("refund-abuse-triage", body)
+        self.assertIn("https://app.agentclash.dev/workspaces/workspace-1/regression-suites/suite-1/cases/case-1", body)
         self.assertIn("Next Actions", body)
+
+    def test_build_failed_comment_uses_custom_app_url(self):
+        body = comment.build_comment(
+            manifest=".agentclash/ci.yaml",
+            result=failing_result(),
+            should_run={"should_run": True},
+            exit_code=1,
+            app_url="https://agentclash.example.com/app/",
+        )
+
+        self.assertIn("https://agentclash.example.com/app/workspaces/workspace-1/runs/run-candidate", body)
+
+    def test_build_failed_comment_respects_safe_api_run_urls(self):
+        result = failing_result()
+        result["candidate"]["run_url"] = "https://api.example.com/runs/candidate"
+        result["baseline"]["run_url"] = "https://api.example.com/runs/baseline"
+
+        body = comment.build_comment(
+            manifest=".agentclash/ci.yaml",
+            result=result,
+            should_run={"should_run": True},
+            exit_code=1,
+        )
+
+        self.assertIn("| Candidate run | [`run-candidate`](https://api.example.com/runs/candidate) |", body)
+        self.assertIn("| Baseline run | [`run-baseline`](https://api.example.com/runs/baseline) |", body)
+
+    def test_build_failed_comment_rejects_unsafe_urls(self):
+        result = failing_result()
+        result["workspace_id"] = ""
+        result["candidate"]["run_url"] = "javascript:alert(1)"
+        result["candidate"]["ci_metadata"]["workflow_run_url"] = "javascript:alert(2)"
+
+        body = comment.build_comment(
+            manifest=".agentclash/ci.yaml",
+            result=result,
+            should_run={"should_run": True},
+            exit_code=1,
+        )
+
+        self.assertIn("| Candidate run | `run-candidate` |", body)
+        self.assertNotIn("javascript:", body)
+        self.assertNotIn("Workflow run", body)
 
     def test_build_skipped_comment_explains_skip_reason(self):
         body = comment.build_comment(

--- a/.github/actions/agentclash-ci/comment_test.py
+++ b/.github/actions/agentclash-ci/comment_test.py
@@ -108,8 +108,32 @@ class CommentFormattingTests(unittest.TestCase):
 
         self.assertIn("https://agentclash.example.com/app/workspaces/workspace-1/runs/run-candidate", body)
 
-    def test_build_failed_comment_respects_safe_api_run_urls(self):
+    def test_build_failed_comment_prefers_app_links_over_safe_api_run_urls(self):
         result = failing_result()
+        result["candidate"]["run_url"] = "https://api.example.com/runs/candidate"
+        result["baseline"]["run_url"] = "https://api.example.com/runs/baseline"
+
+        body = comment.build_comment(
+            manifest=".agentclash/ci.yaml",
+            result=result,
+            should_run={"should_run": True},
+            exit_code=1,
+        )
+
+        self.assertIn(
+            "| Candidate run | [`run-candidate`](https://app.agentclash.dev/workspaces/workspace-1/runs/run-candidate) |",
+            body,
+        )
+        self.assertIn(
+            "| Baseline run | [`run-baseline`](https://app.agentclash.dev/workspaces/workspace-1/runs/run-baseline) |",
+            body,
+        )
+        self.assertNotIn("https://api.example.com/runs/candidate", body)
+        self.assertNotIn("https://api.example.com/runs/baseline", body)
+
+    def test_build_failed_comment_falls_back_to_safe_api_run_urls(self):
+        result = failing_result()
+        result["workspace_id"] = ""
         result["candidate"]["run_url"] = "https://api.example.com/runs/candidate"
         result["baseline"]["run_url"] = "https://api.example.com/runs/baseline"
 

--- a/.github/actions/agentclash-ci/run.sh
+++ b/.github/actions/agentclash-ci/run.sh
@@ -69,7 +69,8 @@ post_pr_comment() {
     --enabled "${INPUT_PR_COMMENT:-true}" \
     --repo "${GITHUB_REPOSITORY:-}" \
     --event-path "${GITHUB_EVENT_PATH:-}" \
-    --api-url "${GITHUB_API_URL:-https://api.github.com}"
+    --api-url "${GITHUB_API_URL:-https://api.github.com}" \
+    --app-url "${INPUT_APP_URL:-https://app.agentclash.dev}"
   local comment_status=$?
   set -e
 

--- a/testing/codex-pr-comment-links.md
+++ b/testing/codex-pr-comment-links.md
@@ -17,7 +17,8 @@
 
 ## Unit Tests
 - Formatter test for a failing result without API-provided `run_url` asserts the comment includes workspace-scoped candidate, baseline, comparison, failures, scorecard, replay, and regression-case links.
-- Formatter test for explicit safe API URLs asserts they are respected where appropriate.
+- Formatter test asserts workspace-scoped app links are preferred over explicit API run URLs when app metadata is present.
+- Formatter test for explicit safe API URLs asserts they are respected as fallbacks when app link metadata is unavailable.
 - Formatter test for unsafe URLs asserts `javascript:` or similar values are not rendered as links.
 - Existing formatting, skipped, context, create, update, and graceful-skip tests continue to pass.
 

--- a/testing/codex-pr-comment-links.md
+++ b/testing/codex-pr-comment-links.md
@@ -1,0 +1,47 @@
+# codex/pr-comment-links — Test Contract
+
+## Functional Behavior
+- AgentClash PR comments must turn run evidence into direct AgentClash UI links instead of leaving reviewers with raw IDs only.
+- When `workspace_id`, candidate run ID, baseline run ID, and candidate run-agent ID are present, the comment includes links for:
+  - candidate run
+  - baseline run
+  - baseline-vs-candidate comparison
+  - candidate failures
+  - candidate scorecard
+  - candidate replay
+- When regression promotions include created or existing cases with suite and case IDs, the comment links to those regression cases.
+- Links are generated against a configurable AgentClash app base URL and default to `https://app.agentclash.dev`.
+- Unsafe/non-HTTP URLs must not be rendered as Markdown links.
+- Comment posting remains best-effort and must not alter the original AgentClash CI exit code.
+- GitHub workflow examples use the permission that live testing proved works for PR comments: `pull-requests: write`.
+
+## Unit Tests
+- Formatter test for a failing result without API-provided `run_url` asserts the comment includes workspace-scoped candidate, baseline, comparison, failures, scorecard, replay, and regression-case links.
+- Formatter test for explicit safe API URLs asserts they are respected where appropriate.
+- Formatter test for unsafe URLs asserts `javascript:` or similar values are not rendered as links.
+- Existing formatting, skipped, context, create, update, and graceful-skip tests continue to pass.
+
+## Integration / Functional Tests
+- `action.yml` exposes an optional app URL input and passes it into `comment.py`.
+- `run.sh` passes the app URL to the helper in normal, skipped, and early-error paths.
+- Action README and CI/CD guide document the linked PR comment behavior and correct `pull-requests: write` permission.
+
+## Smoke Tests
+- `python3 -m unittest discover -s .github/actions/agentclash-ci -p comment_test.py` passes.
+- `python3 -m py_compile .github/actions/agentclash-ci/comment.py .github/actions/agentclash-ci/comment_test.py` passes.
+- `bash -n .github/actions/agentclash-ci/run.sh` passes.
+- Action metadata parses as YAML.
+- `git diff --check` passes.
+
+## E2E Tests
+- After this PR merges, a follow-up demo repo PR must trigger AgentClash CI and the PR comment links must open in the AgentClash app to the expected run, comparison, failures, scorecard, replay, and regression-case views.
+
+## Manual / cURL Tests
+```bash
+python3 -m unittest discover -s .github/actions/agentclash-ci -p comment_test.py
+python3 -m py_compile .github/actions/agentclash-ci/comment.py .github/actions/agentclash-ci/comment_test.py
+bash -n .github/actions/agentclash-ci/run.sh
+ruby -e 'require "yaml"; YAML.load_file(".github/actions/agentclash-ci/action.yml"); puts "action yaml ok"'
+git diff --check
+# Expected: all commands succeed.
+```

--- a/web/content/docs/guides/ci-cd-agent-gates.mdx
+++ b/web/content/docs/guides/ci-cd-agent-gates.mdx
@@ -162,8 +162,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -192,7 +191,7 @@ jobs:
             ${{ steps.agentclash.outputs.artifact-dir }}/*.json
 ```
 
-The action installs the published `agentclash` npm package by default, runs `ci validate --remote`, runs `ci should-run`, auto-detects pull request labels from the GitHub event payload, skips unrelated changes, runs `ci run` when matched, posts or updates a sticky structured PR comment when pull request context is available, and exposes `should-run`, `skip-reason`, `run-id`, `gate-verdict`, `exit-code`, `result-file`, and `artifact-dir` outputs. It preserves the CLI exit code, so a blocking gate fails the workflow normally. Grant `issues: write` when you want GitHub-hosted PR comments; commenting is best-effort and permission failures do not override the AgentClash result. If setup fails before a candidate run is created, the sticky comment reports the errored setup state and points reviewers at the GitHub Actions log.
+The action installs the published `agentclash` npm package by default, runs `ci validate --remote`, runs `ci should-run`, auto-detects pull request labels from the GitHub event payload, skips unrelated changes, runs `ci run` when matched, posts or updates a sticky structured PR comment when pull request context is available, and exposes `should-run`, `skip-reason`, `run-id`, `gate-verdict`, `exit-code`, `result-file`, and `artifact-dir` outputs. It preserves the CLI exit code, so a blocking gate fails the workflow normally. Grant `pull-requests: write` when you want GitHub-hosted PR comments; commenting is best-effort and permission failures do not override the AgentClash result. When run metadata is available, the comment links reviewers directly to the AgentClash candidate run, baseline run, comparison, failures, scorecard, replay, and regression cases. If setup fails before a candidate run is created, the sticky comment reports the errored setup state and points reviewers at the GitHub Actions log.
 
 `agentclash ci run` exits nonzero when the gate verdict should block CI, when the candidate run times out, or when the manifest/API setup is invalid. In GitHub Actions, it automatically attaches repository, pull request, branch, default branch, commit, workflow, event, and workflow-run URL metadata to the AgentClash run. It also appends a reviewer-friendly Markdown section when the `$GITHUB_STEP_SUMMARY` environment variable is set, while the bundled action turns the same run evidence into the PR comment. Pass `--summary-file <path>` for another Markdown destination, or `--github-step-summary=false` to disable the automatic GitHub summary.
 


### PR DESCRIPTION
## Summary
- add workspace-scoped AgentClash app links to CI PR comments for candidate run, baseline run, comparison, failures, scorecard, replay, and regression cases
- add configurable `app-url` input and wire it through the composite action
- document linked comments and the `pull-requests: write` permission that live testing proved works

## Review Checkpoint
- Contract: `testing/codex-pr-comment-links.md`
- Step 0 committed before implementation: lock expectations
- Step 1: implement safe links, action wiring, tests, and docs
- Final checkpoint verdict: ready, with post-merge demo repo E2E link validation still pending by design

## Tests
- `python3 -m unittest discover -s .github/actions/agentclash-ci -p comment_test.py`
- `python3 -m py_compile .github/actions/agentclash-ci/comment.py .github/actions/agentclash-ci/comment_test.py`
- `bash -n .github/actions/agentclash-ci/run.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/actions/agentclash-ci/action.yml"); puts "action yaml ok"'`
- `git diff --check`
