### PR TITLE
fix: unblock Claude harness pull requests

### DIFF
--- a/backend/e2b-template/template.ts
+++ b/backend/e2b-template/template.ts
@@ -28,6 +28,27 @@ export const template = Template()
 
   // Coding-agent CLIs for Agent Harness tasks
   .runCmd('npm install -g @openai/codex @anthropic-ai/claude-code')
+  // Claude Code refuses bypass-permissions mode as root. Keep the sandbox root
+  // user for git/auth setup, but make the claude entrypoint drop to E2B's
+  // unprivileged user and make the cloned repo writable before Claude edits it.
+  .runCmd(
+    "set -e\n" +
+      'id user >/dev/null\n' +
+      'claude_bin="$(command -v claude)"\n' +
+      'mv "$claude_bin" "${claude_bin}.real"\n' +
+      'cat > "$claude_bin" <<\'EOF\'\n' +
+      '#!/bin/sh\n' +
+      'set -eu\n' +
+      'if [ "$(id -u)" = "0" ]; then\n' +
+      '  mkdir -p /home/user/.claude\n' +
+      '  chown -R user:user /home/user/.claude 2>/dev/null || true\n' +
+      '  if [ -d "${PWD:-/workspace}" ]; then chown -R user:user "${PWD:-/workspace}" 2>/dev/null || true; fi\n' +
+      '  exec runuser -u user --preserve-environment -- env HOME=/home/user USER=user LOGNAME=user "$0.real" "$@"\n' +
+      'fi\n' +
+      'exec "$0.real" "$@"\n' +
+      'EOF\n' +
+      'chmod 755 "$claude_bin"',
+  )
 
   // Python 3, Go, C/C++ toolchain
   .runCmd(
@@ -74,6 +95,8 @@ export const template = Template()
   .copy('tools/', '/tools/', { user: 'root', mode: 0o755 })
 
   // Workspace setup
-  .runCmd('mkdir -p /workspace')
+  // Claude's root-dropping wrapper makes the cloned repo user-owned, while
+  // AgentClash post-run git artifact/PR collection still runs as root.
+  .runCmd('mkdir -p /workspace && git config --global --add safe.directory /workspace')
   .setWorkdir('/workspace')
   .setStartCmd('sleep infinity', 'sleep 20')

--- a/backend/internal/workflow/agent_harness_execution_workflow.go
+++ b/backend/internal/workflow/agent_harness_execution_workflow.go
@@ -243,20 +243,43 @@ func (a *Activities) ExecuteAgentHarnessExecution(ctx context.Context, input Exe
 		} else if result.ExitCode != 0 {
 			return fmt.Errorf("git add intent failed with exit code %d", result.ExitCode)
 		}
-		if result, err := a.execHarnessCommand(ctx, execution.ID, session, "git.diff", []string{"git", "diff", "--binary"}, workdir, 60*time.Second, env); err != nil {
+		baseRef := agentHarnessGitBaseRef(harness)
+		diffCommand := []string{"git", "diff", "--binary"}
+		if baseRef != "" {
+			diffCommand = append(diffCommand, baseRef)
+		}
+		if result, err := a.execHarnessCommand(ctx, execution.ID, session, "git.diff", diffCommand, workdir, 60*time.Second, env); err != nil {
 			return err
 		} else {
 			_ = a.recordAgentHarnessEvent(ctx, execution.ID, "artifact.git_diff", "worker", map[string]any{"diff": result.Stdout})
 		}
-		changedFiles := ""
+		baseChangedFiles := ""
+		changedFilesCommand := []string{"git", "diff", "--name-status"}
+		if baseRef != "" {
+			changedFilesCommand = append(changedFilesCommand, baseRef)
+		}
+		if result, err := a.execHarnessCommand(ctx, execution.ID, session, "git.base_changed_files", changedFilesCommand, workdir, 60*time.Second, env); err != nil {
+			return err
+		} else {
+			baseChangedFiles = result.Stdout
+		}
+		workingTreeFiles := ""
 		if result, err := a.execHarnessCommand(ctx, execution.ID, session, "git.changed_files", []string{"git", "status", "--short"}, workdir, 60*time.Second, env); err != nil {
 			return err
 		} else {
-			changedFiles = result.Stdout
-			_ = a.recordAgentHarnessEvent(ctx, execution.ID, "artifact.changed_files", "worker", map[string]any{"changed_files": result.Stdout})
+			workingTreeFiles = result.Stdout
+			_ = a.recordAgentHarnessEvent(ctx, execution.ID, "artifact.changed_files", "worker", map[string]any{
+				"changed_files":        combineGitChangeLists(baseChangedFiles, workingTreeFiles),
+				"base_changed_files":   baseChangedFiles,
+				"working_tree_changes": workingTreeFiles,
+			})
 		}
 		if isStructuredGitHubHarness(harness) {
-			if err := a.createGitHubPullRequest(ctx, execution.ID, session, harness, workdir, timeout, gitEnv, gitHubToken, changedFiles); err != nil {
+			changes := agentHarnessGitChanges{
+				ChangedFiles:       combineGitChangeLists(baseChangedFiles, workingTreeFiles),
+				WorkingTreeChanges: workingTreeFiles,
+			}
+			if err := a.createGitHubPullRequest(ctx, execution.ID, session, harness, workdir, timeout, gitEnv, gitHubToken, changes); err != nil {
 				return err
 			}
 		}
@@ -393,8 +416,44 @@ func normalizeAgentHarnessKind(kind string) string {
 	return trimmed
 }
 
-func (a *Activities) createGitHubPullRequest(ctx context.Context, executionID uuid.UUID, session sandbox.Session, harness agentHarnessSnapshot, workdir string, timeout time.Duration, gitEnv map[string]string, token string, changedFiles string) error {
-	if strings.TrimSpace(changedFiles) == "" {
+type agentHarnessGitChanges struct {
+	ChangedFiles       string
+	WorkingTreeChanges string
+}
+
+type agentHarnessGitCommand struct {
+	event   string
+	command []string
+}
+
+func (c agentHarnessGitChanges) hasChanges() bool {
+	return strings.TrimSpace(c.ChangedFiles) != ""
+}
+
+func (c agentHarnessGitChanges) hasWorkingTreeChanges() bool {
+	return strings.TrimSpace(c.WorkingTreeChanges) != ""
+}
+
+func agentHarnessGitBaseRef(harness agentHarnessSnapshot) string {
+	baseBranch := strings.TrimSpace(derefString(harness.BaseBranch))
+	if baseBranch == "" {
+		baseBranch = "main"
+	}
+	return "origin/" + baseBranch
+}
+
+func combineGitChangeLists(lists ...string) string {
+	parts := make([]string, 0, len(lists))
+	for _, list := range lists {
+		if trimmed := strings.TrimSpace(list); trimmed != "" {
+			parts = append(parts, trimmed)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func (a *Activities) createGitHubPullRequest(ctx context.Context, executionID uuid.UUID, session sandbox.Session, harness agentHarnessSnapshot, workdir string, timeout time.Duration, gitEnv map[string]string, token string, changes agentHarnessGitChanges) error {
+	if !changes.hasChanges() {
 		return a.recordAgentHarnessEvent(ctx, executionID, "github.pull_request.skipped", "worker", map[string]any{"reason": "no_changes"})
 	}
 	if a.githubClient == nil || token == "" {
@@ -410,17 +469,18 @@ func (a *Activities) createGitHubPullRequest(ctx context.Context, executionID uu
 	}
 	branch := "agentclash/harness/" + strings.ReplaceAll(executionID.String()[:8], "-", "")
 	pushURL := "https://github.com/" + owner + "/" + repo + ".git"
-	commands := []struct {
-		event   string
-		command []string
-	}{
+	commands := []agentHarnessGitCommand{
 		{"git.config_user_email", []string{"git", "config", "user.email", "agentclash[bot]@users.noreply.github.com"}},
 		{"git.config_user_name", []string{"git", "config", "user.name", "agentclash[bot]"}},
 		{"git.create_branch", []string{"git", "checkout", "-B", branch}},
-		{"git.add_all", []string{"git", "add", "--all"}},
-		{"git.commit", []string{"git", "-c", "core.hooksPath=/dev/null", "commit", "-m", "AgentClash harness changes"}},
-		{"git.push_branch", []string{"git", "-c", "core.hooksPath=/dev/null", "-c", "credential.helper=", "push", pushURL, "HEAD:refs/heads/" + branch}},
 	}
+	if changes.hasWorkingTreeChanges() {
+		commands = append(commands,
+			agentHarnessGitCommand{"git.add_all", []string{"git", "add", "--all"}},
+			agentHarnessGitCommand{"git.commit", []string{"git", "-c", "core.hooksPath=/dev/null", "commit", "-m", "AgentClash harness changes"}},
+		)
+	}
+	commands = append(commands, agentHarnessGitCommand{"git.push_branch", []string{"git", "-c", "core.hooksPath=/dev/null", "-c", "credential.helper=", "push", pushURL, "HEAD:refs/heads/" + branch}})
 	for _, step := range commands {
 		stepEnv := map[string]string(nil)
 		if step.event == "git.push_branch" {

--- a/backend/internal/workflow/agent_harness_execution_workflow_test.go
+++ b/backend/internal/workflow/agent_harness_execution_workflow_test.go
@@ -538,6 +538,128 @@ func TestExecuteAgentHarnessExecutionCreatesDraftPullRequestForGitHubHarness(t *
 	}
 }
 
+func TestExecuteAgentHarnessExecutionCreatesPullRequestForAgentCommittedChanges(t *testing.T) {
+	workspaceID := uuid.New()
+	harnessID := uuid.New()
+	executionID := uuid.New()
+	openAISecret := "OPENAI_API_KEY"
+	repositoryID := int64(100)
+	installationID := int64(42)
+	provider := "github"
+	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
+	repo.githubRepo = repository.GitHubInstallationRepository{
+		GitHubInstallationID: installationID,
+		GitHubRepositoryID:   repositoryID,
+		FullName:             "acme/repo",
+		DefaultBranch:        "main",
+		Status:               "active",
+	}
+	repo.setAgentHarness(repository.AgentHarness{
+		ID:                     harnessID,
+		OrganizationID:         uuid.New(),
+		WorkspaceID:            workspaceID,
+		TaskPrompt:             "make and commit a sample change",
+		CodexTemplate:          "codex",
+		AuthMode:               "api_key_secret",
+		OpenAIAPIKeySecretName: &openAISecret,
+		RepositoryURL:          stringPtr("https://github.com/acme/repo"),
+		RepositoryProvider:     &provider,
+		GitHubRepositoryID:     &repositoryID,
+		GitHubInstallationID:   &installationID,
+		RepositoryFullName:     stringPtr("acme/repo"),
+		BaseBranch:             stringPtr("main"),
+	})
+	repo.setAgentHarnessExecution(repository.AgentHarnessExecution{
+		ID:                      executionID,
+		WorkspaceID:             workspaceID,
+		AgentHarnessID:          harnessID,
+		Status:                  string(repository.AgentHarnessExecutionStatusRunning),
+		ExecutionConfigSnapshot: json.RawMessage(`{"timeout_seconds":120}`),
+	})
+	repo.setWorkspaceSecrets(workspaceID, map[string]string{openAISecret: "sk-test"})
+
+	session := sandbox.NewFakeSession("sandbox-1")
+	session.SetExecFunc(func(request sandbox.ExecRequest, _ map[string][]byte) (sandbox.ExecResult, error) {
+		switch {
+		case len(request.Command) >= 2 && request.Command[0] == "chmod":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "clone":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case len(request.Command) >= 3 && request.Command[0] == "git" && request.Command[1] == "checkout" && request.Command[2] == "main":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case len(request.Command) >= 2 && request.Command[0] == "codex" && request.Command[1] == "exec":
+			return sandbox.ExecResult{ExitCode: 0, Stdout: `{"type":"final","message":"committed"}`}, nil
+		case len(request.Command) >= 3 && request.Command[0] == "git" && request.Command[1] == "add" && request.Command[2] == "--intent-to-add":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case len(request.Command) >= 3 && request.Command[0] == "git" && request.Command[1] == "diff" && request.Command[2] == "--binary":
+			if !containsString(request.Command, "origin/main") {
+				t.Fatalf("binary diff command = %#v, want origin/main", request.Command)
+			}
+			return sandbox.ExecResult{ExitCode: 0, Stdout: "diff --git a/README.md b/README.md"}, nil
+		case len(request.Command) >= 3 && request.Command[0] == "git" && request.Command[1] == "diff" && request.Command[2] == "--name-status":
+			if !containsString(request.Command, "origin/main") {
+				t.Fatalf("name-status diff command = %#v, want origin/main", request.Command)
+			}
+			return sandbox.ExecResult{ExitCode: 0, Stdout: "M\tREADME.md\n"}, nil
+		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "status":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "config":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case len(request.Command) >= 3 && request.Command[0] == "git" && request.Command[1] == "checkout" && request.Command[2] == "-B":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "add":
+			t.Fatalf("unexpected git add for already-committed agent changes: %#v", request.Command)
+			return sandbox.ExecResult{}, nil
+		case isGitSubcommand(request.Command, "commit"):
+			t.Fatalf("unexpected git commit for already-committed agent changes: %#v", request.Command)
+			return sandbox.ExecResult{}, nil
+		case isGitSubcommand(request.Command, "push"):
+			if request.Environment["GITHUB_TOKEN"] != "ghs_test_token" {
+				t.Fatalf("push env missing github token")
+			}
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		default:
+			t.Fatalf("unexpected command: %#v", request.Command)
+			return sandbox.ExecResult{}, nil
+		}
+	})
+	providerStub := &sandbox.FakeProvider{NextSession: session}
+	githubClient := &fakeGitHubPullRequestClient{token: "ghs_test_token"}
+	activities := NewActivities(repo, FakeWorkHooks{}).
+		WithSandboxProvider(providerStub).
+		WithGitHubPullRequestClient(githubClient)
+
+	err := activities.ExecuteAgentHarnessExecution(context.Background(), ExecuteAgentHarnessExecutionInput{ExecutionID: executionID})
+	if err != nil {
+		t.Fatalf("ExecuteAgentHarnessExecution error: %v", err)
+	}
+	if githubClient.pullRequestInput.Head != "acme:agentclash/harness/"+strings.ReplaceAll(executionID.String()[:8], "-", "") {
+		t.Fatalf("pull request head = %q", githubClient.pullRequestInput.Head)
+	}
+	var sawPREvent bool
+	var sawBaseChanges bool
+	for _, event := range repo.agentHarnessEvents[executionID] {
+		switch event.EventType {
+		case "github.pull_request.created":
+			sawPREvent = true
+		case "artifact.changed_files":
+			var payload map[string]any
+			if err := json.Unmarshal(event.Payload, &payload); err != nil {
+				t.Fatalf("decode changed files payload: %v", err)
+			}
+			if payload["changed_files"] == "M\tREADME.md" {
+				sawBaseChanges = true
+			}
+		}
+	}
+	if !sawPREvent {
+		t.Fatal("expected github.pull_request.created event")
+	}
+	if !sawBaseChanges {
+		t.Fatal("expected artifact.changed_files to include base diff files")
+	}
+}
+
 func TestExecuteAgentHarnessExecutionSkipsPullRequestWhenNoChanges(t *testing.T) {
 	workspaceID := uuid.New()
 	harnessID := uuid.New()

--- a/testing/codex-debug-claude-harness-pr.md
+++ b/testing/codex-debug-claude-harness-pr.md
@@ -1,0 +1,30 @@
+# codex/debug-claude-harness-pr - Test Contract
+
+## Functional Behavior
+- Claude Agent Harness executions must run Claude Code in a non-root sandbox context so `--permission-mode bypassPermissions` does not fail with Claude's root/sudo guard.
+- AgentClash post-agent git collection must still work after Claude's repo ownership changes; root-side git commands must not fail with Git's dubious ownership guard for `/workspace`.
+- GitHub PR creation must detect both dirty working-tree changes and agent-created commits ahead of the configured base branch.
+- Structured GitHub harnesses must still prepare git authentication, clone private GitHub repos, push an execution branch, and create a draft PR.
+- The shared Codex fullstack template must remain unchanged unless explicitly needed for the Claude fix.
+
+## Unit Tests
+- Workflow tests cover GitHub askpass preparation without depending on `session.WriteFile` ownership.
+- Workflow tests cover agents that commit their own changes before returning; AgentClash must push those commits instead of skipping the PR as `no_changes`.
+- Existing Claude runner tests continue to assert `--output-format stream-json`, `--verbose`, `--permission-mode bypassPermissions`, model override, and Anthropic secret mapping.
+
+## Integration / Functional Tests
+- `go test -short -race -count=1 ./internal/workflow` from `backend/`.
+- `go test -short -race -count=1 ./internal/api ./internal/repository ./internal/workflow` from `backend/` if workflow changes are broader than the askpass preparation.
+
+## Smoke Tests
+- Rebuild hosted E2B template `agentclash-claude-fullstack`.
+- Start the existing `Atharva-Kanherkar/e2b-go Claude` harness and verify the execution no longer fails with Claude's root/sudo error or root-side `/workspace` safe-directory error.
+- After deploying the backend workflow change, rerun the same harness and verify a Claude-created local commit is pushed to an AgentClash branch and opened as a draft PR.
+
+## E2E Tests
+- Verify the rerun creates a draft PR when Claude commits locally; only truly empty base diffs should skip PR creation as `no_changes`.
+
+## Manual / cURL Tests
+```bash
+AGENTCLASH_API_URL=https://api.agentclash.dev go run ./cli agent-harness run 616d9b02-e680-42dd-b947-fdbe73bb5a3e --follow
+```


### PR DESCRIPTION
## Summary
- wraps the Claude Code CLI in the E2B template so root-launched harness commands drop to E2B's unprivileged `user`, avoiding Claude's `--permission-mode bypassPermissions` root guard
- marks `/workspace` as a safe git directory for root-side AgentClash artifact/PR collection after Claude changes repo ownership
- teaches Agent Harness PR creation to detect agent-created local commits ahead of `origin/<base>`, not just dirty working-tree changes, and to push those commits without creating a redundant AgentClash commit

## Diagnosis
I reproduced the hosted Claude harness against `Atharva-Kanherkar/e2b-go`.

1. Failed execution `d8993c39-d159-499f-aa1c-1794df8c3016`: Claude never reached GitHub. It exited with:
   `--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons`.
2. After E2B template build `c9a6f9b9-ffdb-4e57-8394-4c883044bec8`, execution `edb3fc96-94d5-4251-8b3d-93f996b67788` reached Claude but root-side git collection failed with Git dubious ownership for `/workspace`.
3. After E2B template build `b9d4c4b1-d324-431b-8ba3-7fb3e282a92c`, execution `2b6380d7-aaea-4292-a668-c885b02a58d4` completed and passed `go test ./...`, but skipped PR creation as `no_changes` because Claude had committed locally and the workflow only looked at uncommitted `git status` / `git diff`.

## Review Checkpoint
- Test contract: `testing/codex-debug-claude-harness-pr.md`
- Checkpoint scratchpad: `/tmp/reviewcheckpoint-codex-debug-claude-harness-pr.json`

## Tests
- `cd backend && go test -short -race -count=1 ./internal/workflow`
- `cd backend && go test -short -race -count=1 ./internal/api ./internal/repository ./internal/workflow`

## Notes
- The hosted E2B template `agentclash-claude-fullstack` has already been rebuilt with the template-side fixes.
- The final PR-creation fix requires this backend workflow change to be merged and deployed before the hosted harness can turn Claude's local commit into a draft PR.
