### PR TITLE
Create CI setup pull requests from the workspace UI

### DIFF
--- a/backend/internal/api/github_integrations.go
+++ b/backend/internal/api/github_integrations.go
@@ -35,6 +35,7 @@ type GitHubIntegrationRepository interface {
 	MarkGitHubInstallationRepositoriesRemoved(ctx context.Context, organizationGitHubInstallationID uuid.UUID, repositoryIDs []int64) error
 	ListWorkspaceGitHubInstallations(ctx context.Context, workspaceID uuid.UUID) ([]repository.GitHubInstallation, error)
 	ListWorkspaceGitHubRepositories(ctx context.Context, p repository.ListWorkspaceGitHubRepositoriesParams) ([]repository.GitHubInstallationRepository, error)
+	GetWorkspaceGitHubRepository(ctx context.Context, workspaceID uuid.UUID, githubRepositoryID int64, githubInstallationID *int64) (repository.GitHubInstallationRepository, error)
 }
 
 type GitHubIntegrationService interface {
@@ -42,6 +43,7 @@ type GitHubIntegrationService interface {
 	CompleteGitHubInstallation(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CompleteGitHubInstallationInput) (CompleteGitHubInstallationResult, error)
 	ListGitHubInstallations(ctx context.Context, caller Caller, workspaceID uuid.UUID) ([]repository.GitHubInstallation, error)
 	ListGitHubRepositories(ctx context.Context, caller Caller, workspaceID uuid.UUID, query string) ([]repository.GitHubInstallationRepository, error)
+	CreateCISetupPullRequest(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateCISetupPullRequestInput) (CreateCISetupPullRequestResult, error)
 	HandleGitHubWebhook(ctx context.Context, headers http.Header, body []byte) error
 }
 
@@ -88,6 +90,59 @@ type CompleteGitHubInstallationResult struct {
 type GitHubAppClient interface {
 	GetInstallation(ctx context.Context, installationID int64) (githubAPIInstallation, error)
 	ListInstallationRepositories(ctx context.Context, installationID int64) ([]githubAPIRepository, error)
+	CreateRepositoryFilesPullRequest(ctx context.Context, input githubCreateFilesPullRequestInput) (githubPullRequest, error)
+}
+
+type CreateCISetupPullRequestInput struct {
+	GitHubRepositoryID   int64                    `json:"github_repository_id"`
+	GitHubInstallationID int64                    `json:"github_installation_id,omitempty"`
+	BaseBranch           string                   `json:"base_branch"`
+	Title                string                   `json:"title,omitempty"`
+	Body                 string                   `json:"body,omitempty"`
+	Draft                *bool                    `json:"draft,omitempty"`
+	Files                []CISetupPullRequestFile `json:"files"`
+}
+
+type CISetupPullRequestFile struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+type CreateCISetupPullRequestResult struct {
+	PullRequest githubPullRequestResponse       `json:"pull_request"`
+	Branch      string                          `json:"branch"`
+	BaseBranch  string                          `json:"base_branch"`
+	Files       []CISetupPullRequestFileSummary `json:"files"`
+}
+
+type CISetupPullRequestFileSummary struct {
+	Path string `json:"path"`
+}
+
+type githubCreateFilesPullRequestInput struct {
+	InstallationID int64
+	Owner          string
+	Repo           string
+	BaseBranch     string
+	Branch         string
+	Title          string
+	Body           string
+	Draft          bool
+	Files          []CISetupPullRequestFile
+}
+
+type githubPullRequest struct {
+	Number  int    `json:"number"`
+	HTMLURL string `json:"html_url"`
+	State   string `json:"state"`
+	Draft   bool   `json:"draft"`
+}
+
+type githubPullRequestResponse struct {
+	Number  int    `json:"number"`
+	HTMLURL string `json:"html_url"`
+	State   string `json:"state"`
+	Draft   bool   `json:"draft"`
 }
 
 type githubInstallState struct {
@@ -242,6 +297,125 @@ func (m *GitHubIntegrationManager) ListGitHubRepositories(ctx context.Context, c
 		WorkspaceID: workspaceID,
 		Query:       strings.TrimSpace(query),
 	})
+}
+
+func (m *GitHubIntegrationManager) CreateCISetupPullRequest(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateCISetupPullRequestInput) (CreateCISetupPullRequestResult, error) {
+	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, workspaceID, ActionManageIntegrations); err != nil {
+		return CreateCISetupPullRequestResult{}, err
+	}
+	if m.client == nil {
+		return CreateCISetupPullRequestResult{}, GitHubIntegrationConfigError("github app credentials are not configured")
+	}
+	if input.GitHubRepositoryID <= 0 {
+		return CreateCISetupPullRequestResult{}, GitHubIntegrationValidationError{Code: "missing_github_repository", Message: "github_repository_id is required"}
+	}
+	var installationID *int64
+	if input.GitHubInstallationID > 0 {
+		installationID = &input.GitHubInstallationID
+	}
+	selected, err := m.repo.GetWorkspaceGitHubRepository(ctx, workspaceID, input.GitHubRepositoryID, installationID)
+	if err != nil {
+		if errors.Is(err, repository.ErrGitHubRepositoryNotInstalled) {
+			return CreateCISetupPullRequestResult{}, GitHubIntegrationValidationError{Code: "github_repo_not_installed", Message: "github repository is not installed for this workspace"}
+		}
+		return CreateCISetupPullRequestResult{}, err
+	}
+	owner, repoName, ok := parseGitHubFullName(selected.FullName)
+	if !ok {
+		return CreateCISetupPullRequestResult{}, GitHubIntegrationValidationError{Code: "invalid_github_repository", Message: "github repository full name is invalid"}
+	}
+	baseBranch := strings.TrimSpace(input.BaseBranch)
+	if baseBranch == "" {
+		baseBranch = strings.TrimSpace(selected.DefaultBranch)
+	}
+	if baseBranch == "" {
+		return CreateCISetupPullRequestResult{}, GitHubIntegrationValidationError{Code: "missing_base_branch", Message: "base_branch is required"}
+	}
+	files, err := validateCISetupPullRequestFiles(input.Files)
+	if err != nil {
+		return CreateCISetupPullRequestResult{}, err
+	}
+	title := strings.TrimSpace(input.Title)
+	if title == "" {
+		title = "Set up AgentClash CI"
+	}
+	body := strings.TrimSpace(input.Body)
+	if body == "" {
+		body = "Adds AgentClash CI configuration generated from the workspace setup UI."
+	}
+	draft := true
+	if input.Draft != nil {
+		draft = *input.Draft
+	}
+	branch := "agentclash/ci-setup/" + uuid.NewString()[:8]
+	pr, err := m.client.CreateRepositoryFilesPullRequest(ctx, githubCreateFilesPullRequestInput{
+		InstallationID: selected.GitHubInstallationID,
+		Owner:          owner,
+		Repo:           repoName,
+		BaseBranch:     baseBranch,
+		Branch:         branch,
+		Title:          title,
+		Body:           body,
+		Draft:          draft,
+		Files:          files,
+	})
+	if err != nil {
+		return CreateCISetupPullRequestResult{}, err
+	}
+	summaries := make([]CISetupPullRequestFileSummary, 0, len(files))
+	for _, file := range files {
+		summaries = append(summaries, CISetupPullRequestFileSummary{Path: file.Path})
+	}
+	return CreateCISetupPullRequestResult{
+		PullRequest: githubPullRequestResponse{
+			Number:  pr.Number,
+			HTMLURL: pr.HTMLURL,
+			State:   pr.State,
+			Draft:   pr.Draft,
+		},
+		Branch:     branch,
+		BaseBranch: baseBranch,
+		Files:      summaries,
+	}, nil
+}
+
+func validateCISetupPullRequestFiles(files []CISetupPullRequestFile) ([]CISetupPullRequestFile, error) {
+	if len(files) == 0 {
+		return nil, GitHubIntegrationValidationError{Code: "missing_files", Message: "at least one file is required"}
+	}
+	seen := make(map[string]struct{}, len(files))
+	validated := make([]CISetupPullRequestFile, 0, len(files))
+	for _, file := range files {
+		path := strings.TrimSpace(file.Path)
+		if !isSafeRepositoryFilePath(path) {
+			return nil, GitHubIntegrationValidationError{Code: "invalid_file_path", Message: "file paths must be relative repository paths without traversal"}
+		}
+		if _, ok := seen[path]; ok {
+			return nil, GitHubIntegrationValidationError{Code: "duplicate_file_path", Message: "file paths must be unique"}
+		}
+		content := file.Content
+		if strings.TrimSpace(content) == "" {
+			return nil, GitHubIntegrationValidationError{Code: "empty_file_content", Message: "file content cannot be empty"}
+		}
+		if len(content) > 1<<20 {
+			return nil, GitHubIntegrationValidationError{Code: "file_too_large", Message: "file content must be 1 MiB or smaller"}
+		}
+		seen[path] = struct{}{}
+		validated = append(validated, CISetupPullRequestFile{Path: path, Content: content})
+	}
+	return validated, nil
+}
+
+func isSafeRepositoryFilePath(path string) bool {
+	if path == "" || strings.HasPrefix(path, "/") || strings.Contains(path, `\`) {
+		return false
+	}
+	for _, part := range strings.Split(path, "/") {
+		if part == "" || part == "." || part == ".." {
+			return false
+		}
+	}
+	return true
 }
 
 func (m *GitHubIntegrationManager) signState(state githubInstallState) (string, error) {
@@ -501,6 +675,16 @@ type githubAPIAccessTokenResponse struct {
 	Token string `json:"token"`
 }
 
+type githubReferenceResponse struct {
+	Object struct {
+		SHA string `json:"sha"`
+	} `json:"object"`
+}
+
+type githubContentResponse struct {
+	SHA string `json:"sha"`
+}
+
 type githubWebhookInstallationPayload struct {
 	Action       string                `json:"action"`
 	Installation githubAPIInstallation `json:"installation"`
@@ -573,6 +757,100 @@ func (c *githubAppHTTPClient) ListInstallationRepositories(ctx context.Context, 
 	}
 }
 
+func (c *githubAppHTTPClient) CreateRepositoryFilesPullRequest(ctx context.Context, input githubCreateFilesPullRequestInput) (githubPullRequest, error) {
+	token, err := c.createInstallationToken(ctx, input.InstallationID)
+	if err != nil {
+		return githubPullRequest{}, err
+	}
+	base, err := c.getRepositoryRef(ctx, token, input.Owner, input.Repo, input.BaseBranch)
+	if err != nil {
+		return githubPullRequest{}, err
+	}
+	if err := c.createRepositoryRef(ctx, token, input.Owner, input.Repo, input.Branch, base.Object.SHA); err != nil {
+		return githubPullRequest{}, err
+	}
+	for _, file := range input.Files {
+		sha, err := c.getRepositoryContentSHA(ctx, token, input.Owner, input.Repo, file.Path, input.Branch)
+		if err != nil {
+			return githubPullRequest{}, err
+		}
+		if err := c.putRepositoryContent(ctx, token, input.Owner, input.Repo, input.Branch, file, sha); err != nil {
+			return githubPullRequest{}, err
+		}
+	}
+	return c.createRepositoryPullRequest(ctx, token, input)
+}
+
+func (c *githubAppHTTPClient) getRepositoryRef(ctx context.Context, token string, owner string, repo string, branch string) (githubReferenceResponse, error) {
+	var response githubReferenceResponse
+	path := fmt.Sprintf("/repos/%s/%s/git/ref/heads/%s", urlPathEscape(owner), urlPathEscape(repo), urlPathEscape(branch))
+	if err := c.doJSON(ctx, http.MethodGet, path, token, nil, &response); err != nil {
+		return githubReferenceResponse{}, err
+	}
+	return response, nil
+}
+
+func (c *githubAppHTTPClient) createRepositoryRef(ctx context.Context, token string, owner string, repo string, branch string, sha string) error {
+	body, err := json.Marshal(map[string]string{
+		"ref": "refs/heads/" + branch,
+		"sha": sha,
+	})
+	if err != nil {
+		return err
+	}
+	path := fmt.Sprintf("/repos/%s/%s/git/refs", urlPathEscape(owner), urlPathEscape(repo))
+	return c.doJSON(ctx, http.MethodPost, path, token, bytes.NewReader(body), nil)
+}
+
+func (c *githubAppHTTPClient) getRepositoryContentSHA(ctx context.Context, token string, owner string, repo string, path string, branch string) (string, error) {
+	var response githubContentResponse
+	apiPath := fmt.Sprintf("/repos/%s/%s/contents/%s?ref=%s", urlPathEscape(owner), urlPathEscape(repo), urlPathEscape(path), url.QueryEscape(branch))
+	err := c.doJSON(ctx, http.MethodGet, apiPath, token, nil, &response)
+	if err == nil {
+		return response.SHA, nil
+	}
+	if isGitHubNotFoundError(err) {
+		return "", nil
+	}
+	return "", err
+}
+
+func (c *githubAppHTTPClient) putRepositoryContent(ctx context.Context, token string, owner string, repo string, branch string, file CISetupPullRequestFile, sha string) error {
+	payload := map[string]any{
+		"message": "Set up AgentClash CI",
+		"content": base64.StdEncoding.EncodeToString([]byte(file.Content)),
+		"branch":  branch,
+	}
+	if sha != "" {
+		payload["sha"] = sha
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	path := fmt.Sprintf("/repos/%s/%s/contents/%s", urlPathEscape(owner), urlPathEscape(repo), urlPathEscape(file.Path))
+	return c.doJSON(ctx, http.MethodPut, path, token, bytes.NewReader(body), nil)
+}
+
+func (c *githubAppHTTPClient) createRepositoryPullRequest(ctx context.Context, token string, input githubCreateFilesPullRequestInput) (githubPullRequest, error) {
+	var response githubPullRequest
+	body, err := json.Marshal(map[string]any{
+		"title": input.Title,
+		"head":  input.Owner + ":" + input.Branch,
+		"base":  input.BaseBranch,
+		"body":  input.Body,
+		"draft": input.Draft,
+	})
+	if err != nil {
+		return githubPullRequest{}, err
+	}
+	path := fmt.Sprintf("/repos/%s/%s/pulls", urlPathEscape(input.Owner), urlPathEscape(input.Repo))
+	if err := c.doJSON(ctx, http.MethodPost, path, token, bytes.NewReader(body), &response); err != nil {
+		return githubPullRequest{}, err
+	}
+	return response, nil
+}
+
 func (c *githubAppHTTPClient) createInstallationToken(ctx context.Context, installationID int64) (string, error) {
 	var response githubAPIAccessTokenResponse
 	if err := c.doJSON(ctx, http.MethodPost, fmt.Sprintf("/app/installations/%d/access_tokens", installationID), "", bytes.NewReader([]byte(`{}`)), &response); err != nil {
@@ -610,12 +888,40 @@ func (c *githubAppHTTPClient) doJSON(ctx context.Context, method string, path st
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		payload, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return fmt.Errorf("github api %s %s returned %d: %s", method, path, resp.StatusCode, strings.TrimSpace(string(payload)))
+		return githubAPIError{Method: method, Path: path, StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(payload))}
 	}
 	if out == nil {
 		return nil
 	}
 	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+type githubAPIError struct {
+	Method     string
+	Path       string
+	StatusCode int
+	Body       string
+}
+
+func (e githubAPIError) Error() string {
+	return fmt.Sprintf("github api %s %s returned %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
+}
+
+func isGitHubNotFoundError(err error) bool {
+	var apiErr githubAPIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound
+}
+
+func parseGitHubFullName(fullName string) (string, string, bool) {
+	parts := strings.Split(strings.TrimSpace(fullName), "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+func urlPathEscape(value string) string {
+	return strings.ReplaceAll(url.PathEscape(value), "%2F", "/")
 }
 
 func (c *githubAppHTTPClient) appJWT() (string, error) {
@@ -758,6 +1064,32 @@ func listGitHubRepositoriesHandler(logger *slog.Logger, service GitHubIntegratio
 	}
 }
 
+func createCISetupPullRequestHandler(logger *slog.Logger, service GitHubIntegrationService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		workspaceID, err := WorkspaceIDFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		var input CreateCISetupPullRequestInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_json", "request body must be JSON")
+			return
+		}
+		result, err := service.CreateCISetupPullRequest(r.Context(), caller, workspaceID, input)
+		if err != nil {
+			writeGitHubIntegrationError(w, logger, r, err)
+			return
+		}
+		writeJSON(w, http.StatusCreated, result)
+	}
+}
+
 func mapGitHubInstallationResponse(i repository.GitHubInstallation) githubInstallationResponse {
 	return githubInstallationResponse{
 		ID:                   i.ID,
@@ -825,6 +1157,10 @@ func (noopGitHubIntegrationService) ListGitHubInstallations(context.Context, Cal
 
 func (noopGitHubIntegrationService) ListGitHubRepositories(context.Context, Caller, uuid.UUID, string) ([]repository.GitHubInstallationRepository, error) {
 	return nil, errors.New("github integration service is not configured")
+}
+
+func (noopGitHubIntegrationService) CreateCISetupPullRequest(context.Context, Caller, uuid.UUID, CreateCISetupPullRequestInput) (CreateCISetupPullRequestResult, error) {
+	return CreateCISetupPullRequestResult{}, errors.New("github integration service is not configured")
 }
 
 func (noopGitHubIntegrationService) HandleGitHubWebhook(context.Context, http.Header, []byte) error {

--- a/backend/internal/api/github_integrations_test.go
+++ b/backend/internal/api/github_integrations_test.go
@@ -88,7 +88,7 @@ func TestGitHubIntegrationManagerCompleteInstallationVerifiesStateAndSyncsReposi
 		StateSecret: "state-secret",
 		StateTTL:    time.Minute,
 	})
-	manager.client = fakeGitHubAppClient{
+	manager.client = &fakeGitHubAppClient{
 		installation: githubAPIInstallation{
 			ID: 42,
 			Account: githubAPIAccount{
@@ -150,7 +150,7 @@ func TestGitHubIntegrationManagerCompleteInstallationReportsCrossOrgConflict(t *
 		StateSecret: "state-secret",
 		StateTTL:    time.Minute,
 	})
-	manager.client = fakeGitHubAppClient{
+	manager.client = &fakeGitHubAppClient{
 		installation: githubAPIInstallation{
 			ID:                  42,
 			Account:             githubAPIAccount{ID: 99, Login: "acme", Type: "Organization"},
@@ -207,10 +207,117 @@ func TestGitHubIntegrationManagerListRepositoriesRequiresRunPermission(t *testin
 	}
 }
 
+func TestGitHubIntegrationManagerCreateCISetupPullRequest(t *testing.T) {
+	workspaceID := uuid.New()
+	repo := &fakeGitHubIntegrationRepo{
+		organizationID: uuid.New(),
+		githubRepo: repository.GitHubInstallationRepository{
+			GitHubInstallationID: 123,
+			GitHubRepositoryID:   456,
+			FullName:             "acme/support-agent",
+			DefaultBranch:        "main",
+		},
+	}
+	client := &fakeGitHubAppClient{
+		pullRequest: githubPullRequest{
+			Number:  42,
+			HTMLURL: "https://github.com/acme/support-agent/pull/42",
+			State:   "open",
+			Draft:   true,
+		},
+	}
+	manager := NewGitHubIntegrationManager(NewCallerWorkspaceAuthorizer(), repo, GitHubIntegrationConfig{
+		AppSlug:     "agentclash-dev",
+		StateSecret: "state-secret",
+	})
+	manager.client = client
+
+	result, err := manager.CreateCISetupPullRequest(context.Background(), testAgentHarnessCaller(workspaceID), workspaceID, CreateCISetupPullRequestInput{
+		GitHubRepositoryID:   456,
+		GitHubInstallationID: 123,
+		BaseBranch:           "main",
+		Files: []CISetupPullRequestFile{
+			{Path: ".agentclash/ci.yaml", Content: "version: 1\n"},
+			{Path: ".github/workflows/agentclash.yml", Content: "name: AgentClash CI\n"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateCISetupPullRequest error: %v", err)
+	}
+	if repo.getRepositoryID != 456 || repo.getInstallationID == nil || *repo.getInstallationID != 123 {
+		t.Fatalf("repo lookup = %d/%v", repo.getRepositoryID, repo.getInstallationID)
+	}
+	if client.createFilesInput.Owner != "acme" || client.createFilesInput.Repo != "support-agent" {
+		t.Fatalf("github repo = %s/%s", client.createFilesInput.Owner, client.createFilesInput.Repo)
+	}
+	if client.createFilesInput.InstallationID != 123 || client.createFilesInput.BaseBranch != "main" {
+		t.Fatalf("github input = %#v", client.createFilesInput)
+	}
+	if client.createFilesInput.Branch == "" || !strings.HasPrefix(client.createFilesInput.Branch, "agentclash/ci-setup/") {
+		t.Fatalf("branch = %q", client.createFilesInput.Branch)
+	}
+	if len(client.createFilesInput.Files) != 2 || client.createFilesInput.Files[0].Path != ".agentclash/ci.yaml" {
+		t.Fatalf("files = %#v", client.createFilesInput.Files)
+	}
+	if result.PullRequest.Number != 42 || result.Branch != client.createFilesInput.Branch || len(result.Files) != 2 {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestGitHubIntegrationManagerCreateCISetupPullRequestValidatesFiles(t *testing.T) {
+	workspaceID := uuid.New()
+	repo := &fakeGitHubIntegrationRepo{
+		organizationID: uuid.New(),
+		githubRepo: repository.GitHubInstallationRepository{
+			GitHubInstallationID: 123,
+			GitHubRepositoryID:   456,
+			FullName:             "acme/support-agent",
+			DefaultBranch:        "main",
+		},
+	}
+	manager := NewGitHubIntegrationManager(NewCallerWorkspaceAuthorizer(), repo, GitHubIntegrationConfig{
+		AppSlug:     "agentclash-dev",
+		StateSecret: "state-secret",
+	})
+	manager.client = &fakeGitHubAppClient{}
+
+	_, err := manager.CreateCISetupPullRequest(context.Background(), testAgentHarnessCaller(workspaceID), workspaceID, CreateCISetupPullRequestInput{
+		GitHubRepositoryID: 456,
+		Files: []CISetupPullRequestFile{
+			{Path: "../ci.yaml", Content: "version: 1\n"},
+		},
+	})
+	var validationErr GitHubIntegrationValidationError
+	if !errors.As(err, &validationErr) || validationErr.Code != "invalid_file_path" {
+		t.Fatalf("error = %#v, want invalid_file_path", err)
+	}
+}
+
+func TestGitHubIntegrationManagerCreateCISetupPullRequestRequiresAdminAction(t *testing.T) {
+	workspaceID := uuid.New()
+	manager := NewGitHubIntegrationManager(NewCallerWorkspaceAuthorizer(), &fakeGitHubIntegrationRepo{organizationID: uuid.New()}, GitHubIntegrationConfig{
+		AppSlug:     "agentclash-dev",
+		StateSecret: "state-secret",
+	})
+	manager.client = &fakeGitHubAppClient{}
+
+	_, err := manager.CreateCISetupPullRequest(context.Background(), testAgentHarnessCallerWithRole(workspaceID, RoleWorkspaceMember), workspaceID, CreateCISetupPullRequestInput{
+		GitHubRepositoryID: 456,
+		Files:              []CISetupPullRequestFile{{Path: ".agentclash/ci.yaml", Content: "version: 1\n"}},
+	})
+	if err == nil {
+		t.Fatal("expected member to be forbidden from creating CI setup pull request")
+	}
+}
+
 type fakeGitHubIntegrationRepo struct {
 	organizationID         uuid.UUID
 	installations          []repository.GitHubInstallation
 	repositories           []repository.GitHubInstallationRepository
+	githubRepo             repository.GitHubInstallationRepository
+	githubRepoErr          error
+	getRepositoryID        int64
+	getInstallationID      *int64
 	listRepositoriesParams repository.ListWorkspaceGitHubRepositoriesParams
 	upsertInstallation     repository.UpsertGitHubInstallationParams
 	binding                repository.BindGitHubInstallationToWorkspaceParams
@@ -276,9 +383,20 @@ func (f *fakeGitHubIntegrationRepo) ListWorkspaceGitHubRepositories(_ context.Co
 	return f.repositories, nil
 }
 
+func (f *fakeGitHubIntegrationRepo) GetWorkspaceGitHubRepository(_ context.Context, _ uuid.UUID, githubRepositoryID int64, githubInstallationID *int64) (repository.GitHubInstallationRepository, error) {
+	f.getRepositoryID = githubRepositoryID
+	f.getInstallationID = githubInstallationID
+	if f.githubRepoErr != nil {
+		return repository.GitHubInstallationRepository{}, f.githubRepoErr
+	}
+	return f.githubRepo, nil
+}
+
 type fakeGitHubAppClient struct {
-	installation githubAPIInstallation
-	repositories []githubAPIRepository
+	installation     githubAPIInstallation
+	repositories     []githubAPIRepository
+	createFilesInput githubCreateFilesPullRequestInput
+	pullRequest      githubPullRequest
 }
 
 func (f fakeGitHubAppClient) GetInstallation(context.Context, int64) (githubAPIInstallation, error) {
@@ -287,4 +405,9 @@ func (f fakeGitHubAppClient) GetInstallation(context.Context, int64) (githubAPII
 
 func (f fakeGitHubAppClient) ListInstallationRepositories(context.Context, int64) ([]githubAPIRepository, error) {
 	return f.repositories, nil
+}
+
+func (f *fakeGitHubAppClient) CreateRepositoryFilesPullRequest(_ context.Context, input githubCreateFilesPullRequestInput) (githubPullRequest, error) {
+	f.createFilesInput = input
+	return f.pullRequest, nil
 }

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -146,6 +146,8 @@ func registerProtectedRoutes(
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Get("/workspaces/{workspaceID}/github/repositories", listGitHubRepositoriesHandler(logger, githubIntegrationService))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Post("/workspaces/{workspaceID}/github/ci-setup-pull-request", createCISetupPullRequestHandler(logger, githubIntegrationService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Get("/workspaces/{workspaceID}/challenge-packs", listChallengePacksHandler(logger, challengePackReadService))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Get("/workspaces/{workspaceID}/challenge-pack-versions/{versionID}/input-sets", listChallengeInputSetsHandler(logger, challengePackReadService))

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/ci-setup/ci-setup-client.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/ci-setup/ci-setup-client.test.tsx
@@ -7,12 +7,14 @@ const {
   mockGetAccessToken,
   mockCreateApiClient,
   mockListResponse,
+  mockPost,
   mockRunsResponse,
   toast,
 } = vi.hoisted(() => ({
   mockGetAccessToken: vi.fn(),
   mockCreateApiClient: vi.fn(),
   mockListResponse: vi.fn(),
+  mockPost: vi.fn(),
   mockRunsResponse: vi.fn(),
   toast: Object.assign(vi.fn(), {
     success: vi.fn(),
@@ -108,6 +110,7 @@ const cleanups: Array<() => void> = [];
 
 beforeEach(() => {
   document.body.innerHTML = "";
+  mockPost.mockReset();
   mockGetAccessToken.mockResolvedValue("token");
   mockCreateApiClient.mockReturnValue({
     get: vi.fn(async (path: string) => {
@@ -142,6 +145,21 @@ beforeEach(() => {
       }
       return { items: [] };
     }),
+    post: mockPost,
+  });
+  mockPost.mockResolvedValue({
+    pull_request: {
+      number: 7,
+      html_url: "https://github.com/acme/support-agent/pull/7",
+      state: "open",
+      draft: true,
+    },
+    branch: "agentclash/ci-setup/abc12345",
+    base_branch: "main",
+    files: [
+      { path: ".agentclash/ci.yaml" },
+      { path: ".github/workflows/agentclash.yml" },
+    ],
   });
   mockListResponse.mockImplementation(listResponse);
   mockRunsResponse.mockReturnValue({
@@ -222,6 +240,59 @@ describe("CISetupClient", () => {
       expect.stringContaining('agent_build_id: "build-1"'),
     );
     expect(toast.success).toHaveBeenCalledWith("Manifest copied");
+  });
+
+  it("creates a GitHub setup pull request from the generated files", async () => {
+    renderClient();
+    await flushEffects();
+
+    const button = Array.from(document.querySelectorAll("button")).find(
+      (item) => item.textContent?.includes("Open setup PR"),
+    );
+    if (!button) throw new Error("Open setup PR button not found");
+    expect(button).not.toHaveProperty("disabled", true);
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/v1/workspaces/ws-1/github/ci-setup-pull-request",
+      expect.objectContaining({
+        github_repository_id: 456,
+        github_installation_id: 123,
+        base_branch: "main",
+        files: [
+          expect.objectContaining({
+            path: ".agentclash/ci.yaml",
+            content: expect.stringContaining('agent_build_id: "build-1"'),
+          }),
+          expect.objectContaining({
+            path: ".github/workflows/agentclash.yml",
+            content: expect.stringContaining("name: AgentClash CI"),
+          }),
+        ],
+      }),
+    );
+    expect(document.body.textContent).toContain("Setup PR #7 created");
+    expect(toast.success).toHaveBeenCalledWith("Created setup PR #7");
+  });
+
+  it("disables setup PR creation for manual repositories", async () => {
+    mockListResponse.mockImplementation((path: string) =>
+      path.includes("/github/repositories") ? [] : listResponse(path),
+    );
+
+    renderClient();
+    await flushEffects();
+
+    const button = Array.from(document.querySelectorAll("button")).find(
+      (item) => item.textContent?.includes("Open setup PR"),
+    );
+    if (!button) throw new Error("Open setup PR button not found");
+    expect(button).toHaveProperty("disabled", true);
   });
 });
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/ci-setup/ci-setup-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/ci-setup/ci-setup-client.tsx
@@ -38,6 +38,8 @@ import type {
   AgentDeployment,
   ChallengeInputSetSummary,
   ChallengePack,
+  CreateCISetupPullRequestRequest,
+  CreateCISetupPullRequestResponse,
   GitHubRepository,
   ModelAlias,
   ProviderAccount,
@@ -114,6 +116,10 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
   const [runAgents, setRunAgents] = useState<RunAgent[]>([]);
   const [loadingInputSets, setLoadingInputSets] = useState(false);
   const [loadingRunAgents, setLoadingRunAgents] = useState(false);
+  const [selectedRepositoryKey, setSelectedRepositoryKey] = useState("");
+  const [creatingSetupPR, setCreatingSetupPR] = useState(false);
+  const [setupPRResult, setSetupPRResult] =
+    useState<CreateCISetupPullRequestResponse | null>(null);
 
   const builds = useApiListQuery<AgentBuild>(
     `/v1/workspaces/${workspaceId}/agent-builds`,
@@ -194,14 +200,35 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
     () => (runs.data?.items ?? []).filter((run) => run.status === "completed"),
     [runs.data?.items],
   );
+  const githubRepositories = useMemo(
+    () => repositories.data?.items ?? [],
+    [repositories.data?.items],
+  );
+  const selectedGitHubRepository = useMemo(
+    () =>
+      githubRepositories.find((repo) => gitHubRepositoryKey(repo) === selectedRepositoryKey) ??
+      null,
+    [githubRepositories, selectedRepositoryKey],
+  );
 
   useEffect(() => {
-    const repository = repositories.data?.items?.[0];
+    const repository = githubRepositories[0];
     if (repository && !repositoryFullName) {
+      setSelectedRepositoryKey(gitHubRepositoryKey(repository));
       setRepositoryFullName(repository.full_name);
       setDefaultBranch(repository.default_branch || "main");
     }
-  }, [repositories.data?.items, repositoryFullName]);
+  }, [githubRepositories, repositoryFullName]);
+
+  useEffect(() => {
+    if (!selectedRepositoryKey || !repositories.data) return;
+    const repository = githubRepositories.find(
+      (repo) => gitHubRepositoryKey(repo) === selectedRepositoryKey,
+    );
+    if (!repository) {
+      setSelectedRepositoryKey("");
+    }
+  }, [githubRepositories, repositories.data, selectedRepositoryKey]);
 
   useEffect(() => {
     if (!builds.data) return;
@@ -385,6 +412,8 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
   const readiness = ciSetupReadiness(config);
   const manifest = generateAgentClashCIManifest(config);
   const workflow = generateAgentClashGitHubWorkflow(config);
+  const canCreateSetupPR =
+    readiness.ready && selectedGitHubRepository !== null && !creatingSetupPR;
   const loadingAny =
     builds.isLoading ||
     deployments.isLoading ||
@@ -404,6 +433,48 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
     modelAliases.error ||
     regressionSuites.error ||
     runs.error;
+
+  async function createSetupPullRequest() {
+    if (!selectedGitHubRepository) {
+      toast.error("Select an installed GitHub repository first");
+      return;
+    }
+    setCreatingSetupPR(true);
+    setSetupPRResult(null);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token ?? undefined);
+      const payload: CreateCISetupPullRequestRequest = {
+        github_repository_id: selectedGitHubRepository.github_repository_id,
+        github_installation_id: selectedGitHubRepository.github_installation_id,
+        base_branch: config.defaultBranch,
+        title: "Set up AgentClash CI",
+        body: [
+          "Adds AgentClash CI configuration generated from the workspace setup UI.",
+          "",
+          `Manifest: \`${config.manifestPath}\``,
+          `Workflow: \`${config.workflowPath}\``,
+        ].join("\n"),
+        draft: true,
+        files: [
+          { path: config.manifestPath, content: manifest },
+          { path: config.workflowPath, content: workflow },
+        ],
+      };
+      const result = await api.post<CreateCISetupPullRequestResponse>(
+        `/v1/workspaces/${workspaceId}/github/ci-setup-pull-request`,
+        payload,
+      );
+      setSetupPRResult(result);
+      toast.success(`Created setup PR #${result.pull_request.number}`);
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError ? err.message : "Failed to create setup PR",
+      );
+    } finally {
+      setCreatingSetupPR(false);
+    }
+  }
 
   return (
     <div className="mx-auto flex max-w-7xl flex-col gap-6">
@@ -439,6 +510,18 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
             <Download data-icon="inline-start" className="size-4" />
             Workflow
           </Button>
+          <Button
+            size="sm"
+            disabled={!canCreateSetupPR}
+            onClick={createSetupPullRequest}
+          >
+            {creatingSetupPR ? (
+              <Loader2 data-icon="inline-start" className="size-4 animate-spin" />
+            ) : (
+              <Github data-icon="inline-start" className="size-4" />
+            )}
+            Open setup PR
+          </Button>
         </div>
       </header>
 
@@ -460,20 +543,25 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
             <div className="grid gap-4 md:grid-cols-2">
               <Field label="Repository">
                 <select
-                  value={repositoryFullName}
+                  value={selectedRepositoryKey}
                   onChange={(event) => {
                     const value = event.target.value;
-                    setRepositoryFullName(value);
-                    const repo = repositories.data?.items?.find(
-                      (item) => item.full_name === value,
+                    setSelectedRepositoryKey(value);
+                    const repo = githubRepositories.find(
+                      (item) => gitHubRepositoryKey(item) === value,
                     );
-                    if (repo) setDefaultBranch(repo.default_branch || "main");
+                    if (repo) {
+                      setRepositoryFullName(repo.full_name);
+                      setDefaultBranch(repo.default_branch || "main");
+                    } else {
+                      setRepositoryFullName("");
+                    }
                   }}
                   className={selectClass}
                 >
                   <option value="">Enter manually below</option>
-                  {(repositories.data?.items ?? []).map((repo) => (
-                    <option key={repo.id} value={repo.full_name}>
+                  {githubRepositories.map((repo) => (
+                    <option key={repo.id} value={gitHubRepositoryKey(repo)}>
                       {repo.full_name}
                     </option>
                   ))}
@@ -489,7 +577,10 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
               <Field label="Repository full name">
                 <Input
                   value={repositoryFullName}
-                  onChange={(event) => setRepositoryFullName(event.target.value)}
+                  onChange={(event) => {
+                    setSelectedRepositoryKey("");
+                    setRepositoryFullName(event.target.value);
+                  }}
                   placeholder="owner/repo"
                 />
               </Field>
@@ -873,6 +964,24 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
             }
           />
 
+          {setupPRResult ? (
+            <StatusPanel
+              tone="success"
+              title={`Setup PR #${setupPRResult.pull_request.number} created`}
+              body={`Opened ${setupPRResult.branch} against ${setupPRResult.base_branch}.`}
+              action={
+                <a
+                  href={setupPRResult.pull_request.html_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-sm font-medium underline underline-offset-4"
+                >
+                  View pull request
+                </a>
+              }
+            />
+          ) : null}
+
           <div className="rounded-lg border border-border">
             <div className="flex items-center justify-between border-b border-border px-4 py-3">
               <div>
@@ -1010,10 +1119,12 @@ function StatusPanel({
   tone,
   title,
   body,
+  action,
 }: {
   tone: "success" | "warn" | "danger";
   title: string;
   body: string;
+  action?: React.ReactNode;
 }) {
   return (
     <div
@@ -1038,6 +1149,7 @@ function StatusPanel({
         <div>
           <h2 className="text-sm font-semibold">{title}</h2>
           <p className="mt-1 text-sm leading-6 text-muted-foreground">{body}</p>
+          {action ? <div className="mt-3">{action}</div> : null}
         </div>
       </div>
     </div>
@@ -1163,6 +1275,10 @@ function splitLines(value: string): string[] {
     .split(/\r?\n|,/)
     .map((item) => item.trim())
     .filter(Boolean);
+}
+
+function gitHubRepositoryKey(repo: GitHubRepository): string {
+  return `${repo.github_installation_id}:${repo.github_repository_id}`;
 }
 
 async function copyText(value: string, message: string) {

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -401,6 +401,33 @@ export interface GitHubRepository {
   last_synced_at: string;
 }
 
+export interface CreateCISetupPullRequestRequest {
+  github_repository_id: number;
+  github_installation_id?: number;
+  base_branch: string;
+  title?: string;
+  body?: string;
+  draft?: boolean;
+  files: Array<{
+    path: string;
+    content: string;
+  }>;
+}
+
+export interface CreateCISetupPullRequestResponse {
+  pull_request: {
+    number: number;
+    html_url: string;
+    state: string;
+    draft: boolean;
+  };
+  branch: string;
+  base_branch: string;
+  files: Array<{
+    path: string;
+  }>;
+}
+
 export type AgentHarnessExecutionStatus =
   | "queued"
   | "provisioning"


### PR DESCRIPTION
## Summary

- Adds a backend GitHub App endpoint that validates an installed workspace repository, writes generated CI setup files to a new branch, and opens a draft setup PR.
- Wires the CI Setup page to create that PR directly when an installed GitHub repository is selected, while keeping manual copy/download flows intact.
- Adds typed request/response contracts and tests for backend validation plus frontend success/disabled states.

## Review checkpoint

- Contract kept local at `/tmp/codex-ci-setup-install-pr.md` per repo policy against committed `testing/*.md` files.
- Refs #568

## Tests

- `cd backend && go test ./internal/api`
- `cd web && npm test -- ci-setup`
- `cd web && npm run lint -- 'src/app/(workspace)/workspaces/[workspaceId]/ci-setup/ci-setup-client.tsx' 'src/app/(workspace)/workspaces/[workspaceId]/ci-setup/ci-setup-client.test.tsx' src/lib/api/types.ts`\n- `cd web && npx tsc --noEmit`\n- `cd web && npm run build` (passes with existing WorkOS edge-runtime and webpack cache warnings)\n