### PR TITLE
Finish AgentClash CI setup profiles and conflict handling

### DIFF
--- a/backend/db/migrations/00040_workspace_ci_profiles.sql
+++ b/backend/db/migrations/00040_workspace_ci_profiles.sql
@@ -1,0 +1,30 @@
+-- +goose Up
+CREATE TABLE workspace_ci_profiles (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace_id uuid NOT NULL REFERENCES workspaces (id) ON DELETE CASCADE,
+    name text NOT NULL,
+    repository_full_name text NOT NULL DEFAULT '',
+    github_repository_id bigint,
+    github_installation_id bigint,
+    default_branch text NOT NULL DEFAULT 'main',
+    manifest_path text NOT NULL DEFAULT '.agentclash/ci.yaml',
+    workflow_path text NOT NULL DEFAULT '.github/workflows/agentclash.yml',
+    config jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_by_user_id uuid REFERENCES users (id) ON DELETE SET NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (workspace_id, name)
+);
+
+CREATE INDEX workspace_ci_profiles_workspace_updated_idx
+ON workspace_ci_profiles (workspace_id, updated_at DESC);
+
+CREATE TRIGGER workspace_ci_profiles_set_updated_at
+BEFORE UPDATE ON workspace_ci_profiles
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+-- +goose Down
+DROP TRIGGER IF EXISTS workspace_ci_profiles_set_updated_at ON workspace_ci_profiles;
+DROP INDEX IF EXISTS workspace_ci_profiles_workspace_updated_idx;
+DROP TABLE IF EXISTS workspace_ci_profiles;

--- a/backend/internal/api/github_integrations.go
+++ b/backend/internal/api/github_integrations.go
@@ -460,20 +460,22 @@ func (m *GitHubIntegrationManager) CreateCISetupPullRequest(ctx context.Context,
 	for _, file := range files {
 		summaries = append(summaries, CISetupPullRequestFileSummary{Path: file.Path})
 	}
-	conflicts, err := m.client.CheckRepositoryFiles(ctx, githubCheckRepositoryFilesInput{
-		InstallationID: selected.GitHubInstallationID,
-		Owner:          owner,
-		Repo:           repoName,
-		BaseBranch:     baseBranch,
-		Files:          files,
-	})
-	if err != nil {
-		return CreateCISetupPullRequestResult{}, err
-	}
 	existingConflicts := make([]CISetupFileConflict, 0)
-	for _, conflict := range conflicts {
-		if conflict.Exists {
-			existingConflicts = append(existingConflicts, conflict)
+	if input.CheckOnly || !input.OverwriteExisting {
+		conflicts, err := m.client.CheckRepositoryFiles(ctx, githubCheckRepositoryFilesInput{
+			InstallationID: selected.GitHubInstallationID,
+			Owner:          owner,
+			Repo:           repoName,
+			BaseBranch:     baseBranch,
+			Files:          files,
+		})
+		if err != nil {
+			return CreateCISetupPullRequestResult{}, err
+		}
+		for _, conflict := range conflicts {
+			if conflict.Exists {
+				existingConflicts = append(existingConflicts, conflict)
+			}
 		}
 	}
 	if input.CheckOnly || (len(existingConflicts) > 0 && !input.OverwriteExisting) {

--- a/backend/internal/api/github_integrations.go
+++ b/backend/internal/api/github_integrations.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 )
 
@@ -36,6 +37,10 @@ type GitHubIntegrationRepository interface {
 	ListWorkspaceGitHubInstallations(ctx context.Context, workspaceID uuid.UUID) ([]repository.GitHubInstallation, error)
 	ListWorkspaceGitHubRepositories(ctx context.Context, p repository.ListWorkspaceGitHubRepositoriesParams) ([]repository.GitHubInstallationRepository, error)
 	GetWorkspaceGitHubRepository(ctx context.Context, workspaceID uuid.UUID, githubRepositoryID int64, githubInstallationID *int64) (repository.GitHubInstallationRepository, error)
+	ListWorkspaceCIProfiles(ctx context.Context, workspaceID uuid.UUID) ([]repository.WorkspaceCIProfile, error)
+	GetWorkspaceCIProfile(ctx context.Context, workspaceID uuid.UUID, profileID uuid.UUID) (repository.WorkspaceCIProfile, error)
+	CreateWorkspaceCIProfile(ctx context.Context, p repository.CreateWorkspaceCIProfileParams) (repository.WorkspaceCIProfile, error)
+	UpdateWorkspaceCIProfile(ctx context.Context, p repository.UpdateWorkspaceCIProfileParams) (repository.WorkspaceCIProfile, error)
 }
 
 type GitHubIntegrationService interface {
@@ -43,6 +48,9 @@ type GitHubIntegrationService interface {
 	CompleteGitHubInstallation(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CompleteGitHubInstallationInput) (CompleteGitHubInstallationResult, error)
 	ListGitHubInstallations(ctx context.Context, caller Caller, workspaceID uuid.UUID) ([]repository.GitHubInstallation, error)
 	ListGitHubRepositories(ctx context.Context, caller Caller, workspaceID uuid.UUID, query string) ([]repository.GitHubInstallationRepository, error)
+	ListCIProfiles(ctx context.Context, caller Caller, workspaceID uuid.UUID) ([]repository.WorkspaceCIProfile, error)
+	CreateCIProfile(ctx context.Context, caller Caller, workspaceID uuid.UUID, input SaveCIProfileInput) (repository.WorkspaceCIProfile, error)
+	UpdateCIProfile(ctx context.Context, caller Caller, workspaceID uuid.UUID, profileID uuid.UUID, input SaveCIProfileInput) (repository.WorkspaceCIProfile, error)
 	CreateCISetupPullRequest(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateCISetupPullRequestInput) (CreateCISetupPullRequestResult, error)
 	HandleGitHubWebhook(ctx context.Context, headers http.Header, body []byte) error
 }
@@ -90,6 +98,7 @@ type CompleteGitHubInstallationResult struct {
 type GitHubAppClient interface {
 	GetInstallation(ctx context.Context, installationID int64) (githubAPIInstallation, error)
 	ListInstallationRepositories(ctx context.Context, installationID int64) ([]githubAPIRepository, error)
+	CheckRepositoryFiles(ctx context.Context, input githubCheckRepositoryFilesInput) ([]CISetupFileConflict, error)
 	CreateRepositoryFilesPullRequest(ctx context.Context, input githubCreateFilesPullRequestInput) (githubPullRequest, error)
 }
 
@@ -100,6 +109,8 @@ type CreateCISetupPullRequestInput struct {
 	Title                string                   `json:"title,omitempty"`
 	Body                 string                   `json:"body,omitempty"`
 	Draft                *bool                    `json:"draft,omitempty"`
+	CheckOnly            bool                     `json:"check_only,omitempty"`
+	OverwriteExisting    bool                     `json:"overwrite_existing,omitempty"`
 	Files                []CISetupPullRequestFile `json:"files"`
 }
 
@@ -109,14 +120,60 @@ type CISetupPullRequestFile struct {
 }
 
 type CreateCISetupPullRequestResult struct {
-	PullRequest githubPullRequestResponse       `json:"pull_request"`
+	PullRequest *githubPullRequestResponse      `json:"pull_request,omitempty"`
 	Branch      string                          `json:"branch"`
 	BaseBranch  string                          `json:"base_branch"`
 	Files       []CISetupPullRequestFileSummary `json:"files"`
+	Conflicts   []CISetupFileConflict           `json:"conflicts,omitempty"`
 }
 
 type CISetupPullRequestFileSummary struct {
 	Path string `json:"path"`
+}
+
+type CISetupFileConflict struct {
+	Path   string `json:"path"`
+	Exists bool   `json:"exists"`
+	SHA    string `json:"sha,omitempty"`
+}
+
+type SaveCIProfileInput struct {
+	Name                 string          `json:"name"`
+	RepositoryFullName   string          `json:"repository_full_name"`
+	GitHubRepositoryID   *int64          `json:"github_repository_id,omitempty"`
+	GitHubInstallationID *int64          `json:"github_installation_id,omitempty"`
+	DefaultBranch        string          `json:"default_branch"`
+	ManifestPath         string          `json:"manifest_path"`
+	WorkflowPath         string          `json:"workflow_path"`
+	Config               json.RawMessage `json:"config"`
+}
+
+type ciProfilesResponse struct {
+	Items []ciProfileResponse `json:"items"`
+}
+
+type ciProfileResponse struct {
+	ID                   uuid.UUID       `json:"id"`
+	WorkspaceID          uuid.UUID       `json:"workspace_id"`
+	Name                 string          `json:"name"`
+	RepositoryFullName   string          `json:"repository_full_name"`
+	GitHubRepositoryID   *int64          `json:"github_repository_id,omitempty"`
+	GitHubInstallationID *int64          `json:"github_installation_id,omitempty"`
+	DefaultBranch        string          `json:"default_branch"`
+	ManifestPath         string          `json:"manifest_path"`
+	WorkflowPath         string          `json:"workflow_path"`
+	Config               json.RawMessage `json:"config"`
+	CreatedByUserID      *uuid.UUID      `json:"created_by_user_id,omitempty"`
+	CreatedAt            time.Time       `json:"created_at"`
+	UpdatedAt            time.Time       `json:"updated_at"`
+}
+
+type githubCheckRepositoryFilesInput struct {
+	InstallationID int64
+	Owner          string
+	Repo           string
+	BaseBranch     string
+	Files          []CISetupPullRequestFile
 }
 
 type githubCreateFilesPullRequestInput struct {
@@ -299,6 +356,58 @@ func (m *GitHubIntegrationManager) ListGitHubRepositories(ctx context.Context, c
 	})
 }
 
+func (m *GitHubIntegrationManager) ListCIProfiles(ctx context.Context, caller Caller, workspaceID uuid.UUID) ([]repository.WorkspaceCIProfile, error) {
+	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, workspaceID, ActionReadWorkspace); err != nil {
+		return nil, err
+	}
+	return m.repo.ListWorkspaceCIProfiles(ctx, workspaceID)
+}
+
+func (m *GitHubIntegrationManager) CreateCIProfile(ctx context.Context, caller Caller, workspaceID uuid.UUID, input SaveCIProfileInput) (repository.WorkspaceCIProfile, error) {
+	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, workspaceID, ActionManageIntegrations); err != nil {
+		return repository.WorkspaceCIProfile{}, err
+	}
+	params, err := validateSaveCIProfileInput(input)
+	if err != nil {
+		return repository.WorkspaceCIProfile{}, err
+	}
+	createdBy := caller.UserID
+	return m.repo.CreateWorkspaceCIProfile(ctx, repository.CreateWorkspaceCIProfileParams{
+		WorkspaceID:          workspaceID,
+		Name:                 params.Name,
+		RepositoryFullName:   params.RepositoryFullName,
+		GitHubRepositoryID:   params.GitHubRepositoryID,
+		GitHubInstallationID: params.GitHubInstallationID,
+		DefaultBranch:        params.DefaultBranch,
+		ManifestPath:         params.ManifestPath,
+		WorkflowPath:         params.WorkflowPath,
+		Config:               params.Config,
+		CreatedByUserID:      &createdBy,
+	})
+}
+
+func (m *GitHubIntegrationManager) UpdateCIProfile(ctx context.Context, caller Caller, workspaceID uuid.UUID, profileID uuid.UUID, input SaveCIProfileInput) (repository.WorkspaceCIProfile, error) {
+	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, workspaceID, ActionManageIntegrations); err != nil {
+		return repository.WorkspaceCIProfile{}, err
+	}
+	params, err := validateSaveCIProfileInput(input)
+	if err != nil {
+		return repository.WorkspaceCIProfile{}, err
+	}
+	return m.repo.UpdateWorkspaceCIProfile(ctx, repository.UpdateWorkspaceCIProfileParams{
+		ID:                   profileID,
+		WorkspaceID:          workspaceID,
+		Name:                 params.Name,
+		RepositoryFullName:   params.RepositoryFullName,
+		GitHubRepositoryID:   params.GitHubRepositoryID,
+		GitHubInstallationID: params.GitHubInstallationID,
+		DefaultBranch:        params.DefaultBranch,
+		ManifestPath:         params.ManifestPath,
+		WorkflowPath:         params.WorkflowPath,
+		Config:               params.Config,
+	})
+}
+
 func (m *GitHubIntegrationManager) CreateCISetupPullRequest(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateCISetupPullRequestInput) (CreateCISetupPullRequestResult, error) {
 	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, workspaceID, ActionManageIntegrations); err != nil {
 		return CreateCISetupPullRequestResult{}, err
@@ -347,6 +456,33 @@ func (m *GitHubIntegrationManager) CreateCISetupPullRequest(ctx context.Context,
 	if input.Draft != nil {
 		draft = *input.Draft
 	}
+	summaries := make([]CISetupPullRequestFileSummary, 0, len(files))
+	for _, file := range files {
+		summaries = append(summaries, CISetupPullRequestFileSummary{Path: file.Path})
+	}
+	conflicts, err := m.client.CheckRepositoryFiles(ctx, githubCheckRepositoryFilesInput{
+		InstallationID: selected.GitHubInstallationID,
+		Owner:          owner,
+		Repo:           repoName,
+		BaseBranch:     baseBranch,
+		Files:          files,
+	})
+	if err != nil {
+		return CreateCISetupPullRequestResult{}, err
+	}
+	existingConflicts := make([]CISetupFileConflict, 0)
+	for _, conflict := range conflicts {
+		if conflict.Exists {
+			existingConflicts = append(existingConflicts, conflict)
+		}
+	}
+	if input.CheckOnly || (len(existingConflicts) > 0 && !input.OverwriteExisting) {
+		return CreateCISetupPullRequestResult{
+			BaseBranch: baseBranch,
+			Files:      summaries,
+			Conflicts:  existingConflicts,
+		}, nil
+	}
 	branch := "agentclash/ci-setup/" + uuid.NewString()[:8]
 	pr, err := m.client.CreateRepositoryFilesPullRequest(ctx, githubCreateFilesPullRequestInput{
 		InstallationID: selected.GitHubInstallationID,
@@ -362,20 +498,67 @@ func (m *GitHubIntegrationManager) CreateCISetupPullRequest(ctx context.Context,
 	if err != nil {
 		return CreateCISetupPullRequestResult{}, err
 	}
-	summaries := make([]CISetupPullRequestFileSummary, 0, len(files))
-	for _, file := range files {
-		summaries = append(summaries, CISetupPullRequestFileSummary{Path: file.Path})
+	prResponse := githubPullRequestResponse{
+		Number:  pr.Number,
+		HTMLURL: pr.HTMLURL,
+		State:   pr.State,
+		Draft:   pr.Draft,
 	}
 	return CreateCISetupPullRequestResult{
-		PullRequest: githubPullRequestResponse{
-			Number:  pr.Number,
-			HTMLURL: pr.HTMLURL,
-			State:   pr.State,
-			Draft:   pr.Draft,
-		},
-		Branch:     branch,
-		BaseBranch: baseBranch,
-		Files:      summaries,
+		PullRequest: &prResponse,
+		Branch:      branch,
+		BaseBranch:  baseBranch,
+		Files:       summaries,
+		Conflicts:   existingConflicts,
+	}, nil
+}
+
+func validateSaveCIProfileInput(input SaveCIProfileInput) (SaveCIProfileInput, error) {
+	name := strings.TrimSpace(input.Name)
+	if name == "" {
+		return SaveCIProfileInput{}, GitHubIntegrationValidationError{Code: "invalid_profile_name", Message: "profile name is required"}
+	}
+	if len(name) > 120 {
+		return SaveCIProfileInput{}, GitHubIntegrationValidationError{Code: "invalid_profile_name", Message: "profile name must be 120 characters or fewer"}
+	}
+	repositoryFullName := strings.TrimSpace(input.RepositoryFullName)
+	if repositoryFullName != "" {
+		if _, _, ok := parseGitHubFullName(repositoryFullName); !ok {
+			return SaveCIProfileInput{}, GitHubIntegrationValidationError{Code: "invalid_github_repository", Message: "repository_full_name must be owner/repo"}
+		}
+	}
+	defaultBranch := strings.TrimSpace(input.DefaultBranch)
+	if defaultBranch == "" {
+		defaultBranch = "main"
+	}
+	manifestPath := strings.TrimSpace(input.ManifestPath)
+	if !isSafeRepositoryFilePath(manifestPath) {
+		return SaveCIProfileInput{}, GitHubIntegrationValidationError{Code: "invalid_manifest_path", Message: "manifest_path must be a relative repository path without traversal"}
+	}
+	workflowPath := strings.TrimSpace(input.WorkflowPath)
+	if !isSafeRepositoryFilePath(workflowPath) {
+		return SaveCIProfileInput{}, GitHubIntegrationValidationError{Code: "invalid_workflow_path", Message: "workflow_path must be a relative repository path without traversal"}
+	}
+	config := input.Config
+	if len(config) == 0 {
+		config = json.RawMessage(`{}`)
+	}
+	if len(config) > 1<<20 {
+		return SaveCIProfileInput{}, GitHubIntegrationValidationError{Code: "profile_config_too_large", Message: "profile config must be 1 MiB or smaller"}
+	}
+	var decoded any
+	if err := json.Unmarshal(config, &decoded); err != nil {
+		return SaveCIProfileInput{}, GitHubIntegrationValidationError{Code: "invalid_profile_config", Message: "profile config must be valid JSON"}
+	}
+	return SaveCIProfileInput{
+		Name:                 name,
+		RepositoryFullName:   repositoryFullName,
+		GitHubRepositoryID:   input.GitHubRepositoryID,
+		GitHubInstallationID: input.GitHubInstallationID,
+		DefaultBranch:        defaultBranch,
+		ManifestPath:         manifestPath,
+		WorkflowPath:         workflowPath,
+		Config:               config,
 	}, nil
 }
 
@@ -757,6 +940,26 @@ func (c *githubAppHTTPClient) ListInstallationRepositories(ctx context.Context, 
 	}
 }
 
+func (c *githubAppHTTPClient) CheckRepositoryFiles(ctx context.Context, input githubCheckRepositoryFilesInput) ([]CISetupFileConflict, error) {
+	token, err := c.createInstallationToken(ctx, input.InstallationID)
+	if err != nil {
+		return nil, err
+	}
+	conflicts := make([]CISetupFileConflict, 0, len(input.Files))
+	for _, file := range input.Files {
+		sha, err := c.getRepositoryContentSHA(ctx, token, input.Owner, input.Repo, file.Path, input.BaseBranch)
+		if err != nil {
+			return nil, err
+		}
+		conflicts = append(conflicts, CISetupFileConflict{
+			Path:   file.Path,
+			Exists: sha != "",
+			SHA:    sha,
+		})
+	}
+	return conflicts, nil
+}
+
 func (c *githubAppHTTPClient) CreateRepositoryFilesPullRequest(ctx context.Context, input githubCreateFilesPullRequestInput) (githubPullRequest, error) {
 	token, err := c.createInstallationToken(ctx, input.InstallationID)
 	if err != nil {
@@ -1064,6 +1267,88 @@ func listGitHubRepositoriesHandler(logger *slog.Logger, service GitHubIntegratio
 	}
 }
 
+func listCIProfilesHandler(logger *slog.Logger, service GitHubIntegrationService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		workspaceID, err := WorkspaceIDFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		profiles, err := service.ListCIProfiles(r.Context(), caller, workspaceID)
+		if err != nil {
+			writeGitHubIntegrationError(w, logger, r, err)
+			return
+		}
+		items := make([]ciProfileResponse, 0, len(profiles))
+		for _, profile := range profiles {
+			items = append(items, mapCIProfileResponse(profile))
+		}
+		writeJSON(w, http.StatusOK, ciProfilesResponse{Items: items})
+	}
+}
+
+func createCIProfileHandler(logger *slog.Logger, service GitHubIntegrationService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		workspaceID, err := WorkspaceIDFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		var input SaveCIProfileInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_json", "request body must be JSON")
+			return
+		}
+		profile, err := service.CreateCIProfile(r.Context(), caller, workspaceID, input)
+		if err != nil {
+			writeGitHubIntegrationError(w, logger, r, err)
+			return
+		}
+		writeJSON(w, http.StatusCreated, mapCIProfileResponse(profile))
+	}
+}
+
+func updateCIProfileHandler(logger *slog.Logger, service GitHubIntegrationService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		workspaceID, err := WorkspaceIDFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		profileID, err := uuid.Parse(chi.URLParam(r, "profileID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_profile_id", "profile_id must be a valid UUID")
+			return
+		}
+		var input SaveCIProfileInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_json", "request body must be JSON")
+			return
+		}
+		profile, err := service.UpdateCIProfile(r.Context(), caller, workspaceID, profileID, input)
+		if err != nil {
+			writeGitHubIntegrationError(w, logger, r, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, mapCIProfileResponse(profile))
+	}
+}
+
 func createCISetupPullRequestHandler(logger *slog.Logger, service GitHubIntegrationService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		caller, err := CallerFromContext(r.Context())
@@ -1086,7 +1371,11 @@ func createCISetupPullRequestHandler(logger *slog.Logger, service GitHubIntegrat
 			writeGitHubIntegrationError(w, logger, r, err)
 			return
 		}
-		writeJSON(w, http.StatusCreated, result)
+		status := http.StatusCreated
+		if result.PullRequest == nil {
+			status = http.StatusOK
+		}
+		writeJSON(w, status, result)
 	}
 }
 
@@ -1121,6 +1410,28 @@ func mapGitHubRepositoryResponse(r repository.GitHubInstallationRepository) gith
 	}
 }
 
+func mapCIProfileResponse(profile repository.WorkspaceCIProfile) ciProfileResponse {
+	config := profile.Config
+	if len(config) == 0 {
+		config = json.RawMessage(`{}`)
+	}
+	return ciProfileResponse{
+		ID:                   profile.ID,
+		WorkspaceID:          profile.WorkspaceID,
+		Name:                 profile.Name,
+		RepositoryFullName:   profile.RepositoryFullName,
+		GitHubRepositoryID:   profile.GitHubRepositoryID,
+		GitHubInstallationID: profile.GitHubInstallationID,
+		DefaultBranch:        profile.DefaultBranch,
+		ManifestPath:         profile.ManifestPath,
+		WorkflowPath:         profile.WorkflowPath,
+		Config:               config,
+		CreatedByUserID:      profile.CreatedByUserID,
+		CreatedAt:            profile.CreatedAt,
+		UpdatedAt:            profile.UpdatedAt,
+	}
+}
+
 func writeGitHubIntegrationError(w http.ResponseWriter, logger *slog.Logger, r *http.Request, err error) {
 	var configErr GitHubIntegrationConfigError
 	var validationErr GitHubIntegrationValidationError
@@ -1129,6 +1440,10 @@ func writeGitHubIntegrationError(w http.ResponseWriter, logger *slog.Logger, r *
 		writeError(w, http.StatusServiceUnavailable, "github_app_not_configured", configErr.Error())
 	case errors.As(err, &validationErr):
 		writeError(w, http.StatusBadRequest, validationErr.Code, validationErr.Message)
+	case errors.Is(err, repository.ErrWorkspaceCIProfileNotFound):
+		writeError(w, http.StatusNotFound, "ci_profile_not_found", "ci profile not found")
+	case errors.Is(err, repository.ErrWorkspaceCIProfileNameConflict):
+		writeError(w, http.StatusConflict, "ci_profile_name_conflict", "a ci profile with that name already exists")
 	case errors.Is(err, ErrUnauthenticated) || errors.Is(err, ErrCallerMissing) || errors.Is(err, ErrForbidden):
 		writeAuthzError(w, err)
 	default:
@@ -1157,6 +1472,18 @@ func (noopGitHubIntegrationService) ListGitHubInstallations(context.Context, Cal
 
 func (noopGitHubIntegrationService) ListGitHubRepositories(context.Context, Caller, uuid.UUID, string) ([]repository.GitHubInstallationRepository, error) {
 	return nil, errors.New("github integration service is not configured")
+}
+
+func (noopGitHubIntegrationService) ListCIProfiles(context.Context, Caller, uuid.UUID) ([]repository.WorkspaceCIProfile, error) {
+	return nil, errors.New("github integration service is not configured")
+}
+
+func (noopGitHubIntegrationService) CreateCIProfile(context.Context, Caller, uuid.UUID, SaveCIProfileInput) (repository.WorkspaceCIProfile, error) {
+	return repository.WorkspaceCIProfile{}, errors.New("github integration service is not configured")
+}
+
+func (noopGitHubIntegrationService) UpdateCIProfile(context.Context, Caller, uuid.UUID, uuid.UUID, SaveCIProfileInput) (repository.WorkspaceCIProfile, error) {
+	return repository.WorkspaceCIProfile{}, errors.New("github integration service is not configured")
 }
 
 func (noopGitHubIntegrationService) CreateCISetupPullRequest(context.Context, Caller, uuid.UUID, CreateCISetupPullRequestInput) (CreateCISetupPullRequestResult, error) {

--- a/backend/internal/api/github_integrations_test.go
+++ b/backend/internal/api/github_integrations_test.go
@@ -427,6 +427,69 @@ func TestGitHubIntegrationManagerCreatesAndListsCIProfiles(t *testing.T) {
 	}
 }
 
+func TestGitHubIntegrationManagerUpdatesCIProfile(t *testing.T) {
+	workspaceID := uuid.New()
+	profileID := uuid.New()
+	repo := &fakeGitHubIntegrationRepo{
+		organizationID: uuid.New(),
+		ciProfiles: []repository.WorkspaceCIProfile{
+			{
+				ID:                 profileID,
+				WorkspaceID:        workspaceID,
+				Name:               "Default",
+				RepositoryFullName: "acme/support-agent",
+				DefaultBranch:      "main",
+				ManifestPath:       ".agentclash/ci.yaml",
+				WorkflowPath:       ".github/workflows/agentclash.yml",
+				Config:             []byte(`{"schemaVersion":1}`),
+			},
+		},
+	}
+	manager := NewGitHubIntegrationManager(NewCallerWorkspaceAuthorizer(), repo, GitHubIntegrationConfig{
+		AppSlug:     "agentclash-dev",
+		StateSecret: "state-secret",
+	})
+
+	updated, err := manager.UpdateCIProfile(context.Background(), testAgentHarnessCaller(workspaceID), workspaceID, profileID, SaveCIProfileInput{
+		Name:               "Release gate",
+		RepositoryFullName: "acme/support-agent",
+		DefaultBranch:      "trunk",
+		ManifestPath:       ".agentclash/release.yaml",
+		WorkflowPath:       ".github/workflows/release-agentclash.yml",
+		Config:             []byte(`{"schemaVersion":1,"agentBuildId":"build-2"}`),
+	})
+	if err != nil {
+		t.Fatalf("UpdateCIProfile error: %v", err)
+	}
+	if updated.Name != "Release gate" || updated.DefaultBranch != "trunk" || updated.ManifestPath != ".agentclash/release.yaml" {
+		t.Fatalf("updated = %#v", updated)
+	}
+}
+
+func TestGitHubIntegrationManagerUpdateCIProfileReportsNameConflict(t *testing.T) {
+	workspaceID := uuid.New()
+	repo := &fakeGitHubIntegrationRepo{
+		organizationID:     uuid.New(),
+		updateCIProfileErr: repository.ErrWorkspaceCIProfileNameConflict,
+	}
+	manager := NewGitHubIntegrationManager(NewCallerWorkspaceAuthorizer(), repo, GitHubIntegrationConfig{
+		AppSlug:     "agentclash-dev",
+		StateSecret: "state-secret",
+	})
+
+	_, err := manager.UpdateCIProfile(context.Background(), testAgentHarnessCaller(workspaceID), workspaceID, uuid.New(), SaveCIProfileInput{
+		Name:               "Default",
+		RepositoryFullName: "acme/support-agent",
+		DefaultBranch:      "main",
+		ManifestPath:       ".agentclash/ci.yaml",
+		WorkflowPath:       ".github/workflows/agentclash.yml",
+		Config:             []byte(`{"schemaVersion":1}`),
+	})
+	if !errors.Is(err, repository.ErrWorkspaceCIProfileNameConflict) {
+		t.Fatalf("error = %v, want name conflict", err)
+	}
+}
+
 type fakeGitHubIntegrationRepo struct {
 	organizationID         uuid.UUID
 	installations          []repository.GitHubInstallation
@@ -441,6 +504,7 @@ type fakeGitHubIntegrationRepo struct {
 	upsertRepositories     []repository.UpsertGitHubInstallationRepositoryParams
 	upsertErr              error
 	ciProfiles             []repository.WorkspaceCIProfile
+	updateCIProfileErr     error
 }
 
 func (f *fakeGitHubIntegrationRepo) GetOrganizationIDByWorkspaceID(context.Context, uuid.UUID) (uuid.UUID, error) {
@@ -544,6 +608,9 @@ func (f *fakeGitHubIntegrationRepo) CreateWorkspaceCIProfile(_ context.Context, 
 }
 
 func (f *fakeGitHubIntegrationRepo) UpdateWorkspaceCIProfile(_ context.Context, p repository.UpdateWorkspaceCIProfileParams) (repository.WorkspaceCIProfile, error) {
+	if f.updateCIProfileErr != nil {
+		return repository.WorkspaceCIProfile{}, f.updateCIProfileErr
+	}
 	for index, profile := range f.ciProfiles {
 		if profile.WorkspaceID == p.WorkspaceID && profile.ID == p.ID {
 			profile.Name = p.Name

--- a/backend/internal/api/github_integrations_test.go
+++ b/backend/internal/api/github_integrations_test.go
@@ -259,8 +259,91 @@ func TestGitHubIntegrationManagerCreateCISetupPullRequest(t *testing.T) {
 	if len(client.createFilesInput.Files) != 2 || client.createFilesInput.Files[0].Path != ".agentclash/ci.yaml" {
 		t.Fatalf("files = %#v", client.createFilesInput.Files)
 	}
-	if result.PullRequest.Number != 42 || result.Branch != client.createFilesInput.Branch || len(result.Files) != 2 {
+	if result.PullRequest == nil || result.PullRequest.Number != 42 || result.Branch != client.createFilesInput.Branch || len(result.Files) != 2 {
 		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestGitHubIntegrationManagerCreateCISetupPullRequestReturnsConflictsBeforeCreate(t *testing.T) {
+	workspaceID := uuid.New()
+	repo := &fakeGitHubIntegrationRepo{
+		organizationID: uuid.New(),
+		githubRepo: repository.GitHubInstallationRepository{
+			GitHubInstallationID: 123,
+			GitHubRepositoryID:   456,
+			FullName:             "acme/support-agent",
+			DefaultBranch:        "main",
+		},
+	}
+	client := &fakeGitHubAppClient{
+		checkConflicts: []CISetupFileConflict{
+			{Path: ".agentclash/ci.yaml", Exists: true, SHA: "abc123"},
+		},
+	}
+	manager := NewGitHubIntegrationManager(NewCallerWorkspaceAuthorizer(), repo, GitHubIntegrationConfig{
+		AppSlug:     "agentclash-dev",
+		StateSecret: "state-secret",
+	})
+	manager.client = client
+
+	result, err := manager.CreateCISetupPullRequest(context.Background(), testAgentHarnessCaller(workspaceID), workspaceID, CreateCISetupPullRequestInput{
+		GitHubRepositoryID: 456,
+		Files: []CISetupPullRequestFile{
+			{Path: ".agentclash/ci.yaml", Content: "version: 1\n"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateCISetupPullRequest error: %v", err)
+	}
+	if result.PullRequest != nil {
+		t.Fatalf("pull request = %#v, want nil on conflict", result.PullRequest)
+	}
+	if len(result.Conflicts) != 1 || result.Conflicts[0].Path != ".agentclash/ci.yaml" {
+		t.Fatalf("conflicts = %#v", result.Conflicts)
+	}
+	if client.createFilesInput.Branch != "" {
+		t.Fatalf("create should not run when conflicts are unconfirmed: %#v", client.createFilesInput)
+	}
+}
+
+func TestGitHubIntegrationManagerCreateCISetupPullRequestOverwriteAllowsConflicts(t *testing.T) {
+	workspaceID := uuid.New()
+	repo := &fakeGitHubIntegrationRepo{
+		organizationID: uuid.New(),
+		githubRepo: repository.GitHubInstallationRepository{
+			GitHubInstallationID: 123,
+			GitHubRepositoryID:   456,
+			FullName:             "acme/support-agent",
+			DefaultBranch:        "main",
+		},
+	}
+	client := &fakeGitHubAppClient{
+		checkConflicts: []CISetupFileConflict{
+			{Path: ".agentclash/ci.yaml", Exists: true, SHA: "abc123"},
+		},
+		pullRequest: githubPullRequest{Number: 43, HTMLURL: "https://github.com/acme/support-agent/pull/43", State: "open", Draft: true},
+	}
+	manager := NewGitHubIntegrationManager(NewCallerWorkspaceAuthorizer(), repo, GitHubIntegrationConfig{
+		AppSlug:     "agentclash-dev",
+		StateSecret: "state-secret",
+	})
+	manager.client = client
+
+	result, err := manager.CreateCISetupPullRequest(context.Background(), testAgentHarnessCaller(workspaceID), workspaceID, CreateCISetupPullRequestInput{
+		GitHubRepositoryID: 456,
+		OverwriteExisting:  true,
+		Files: []CISetupPullRequestFile{
+			{Path: ".agentclash/ci.yaml", Content: "version: 1\n"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateCISetupPullRequest error: %v", err)
+	}
+	if result.PullRequest == nil || result.PullRequest.Number != 43 {
+		t.Fatalf("result = %#v", result)
+	}
+	if client.createFilesInput.Branch == "" {
+		t.Fatalf("expected create input to be populated")
 	}
 }
 
@@ -310,6 +393,40 @@ func TestGitHubIntegrationManagerCreateCISetupPullRequestRequiresAdminAction(t *
 	}
 }
 
+func TestGitHubIntegrationManagerCreatesAndListsCIProfiles(t *testing.T) {
+	workspaceID := uuid.New()
+	repo := &fakeGitHubIntegrationRepo{organizationID: uuid.New()}
+	manager := NewGitHubIntegrationManager(NewCallerWorkspaceAuthorizer(), repo, GitHubIntegrationConfig{
+		AppSlug:     "agentclash-dev",
+		StateSecret: "state-secret",
+	})
+	caller := testAgentHarnessCaller(workspaceID)
+
+	created, err := manager.CreateCIProfile(context.Background(), caller, workspaceID, SaveCIProfileInput{
+		Name:                 "Default",
+		RepositoryFullName:   "acme/support-agent",
+		GitHubRepositoryID:   ptrInt64(456),
+		GitHubInstallationID: ptrInt64(123),
+		DefaultBranch:        "main",
+		ManifestPath:         ".agentclash/ci.yaml",
+		WorkflowPath:         ".github/workflows/agentclash.yml",
+		Config:               []byte(`{"agentBuildId":"build-1"}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateCIProfile error: %v", err)
+	}
+	if created.Name != "Default" || created.WorkspaceID != workspaceID {
+		t.Fatalf("created = %#v", created)
+	}
+	profiles, err := manager.ListCIProfiles(context.Background(), caller, workspaceID)
+	if err != nil {
+		t.Fatalf("ListCIProfiles error: %v", err)
+	}
+	if len(profiles) != 1 || profiles[0].Name != "Default" {
+		t.Fatalf("profiles = %#v", profiles)
+	}
+}
+
 type fakeGitHubIntegrationRepo struct {
 	organizationID         uuid.UUID
 	installations          []repository.GitHubInstallation
@@ -323,6 +440,7 @@ type fakeGitHubIntegrationRepo struct {
 	binding                repository.BindGitHubInstallationToWorkspaceParams
 	upsertRepositories     []repository.UpsertGitHubInstallationRepositoryParams
 	upsertErr              error
+	ciProfiles             []repository.WorkspaceCIProfile
 }
 
 func (f *fakeGitHubIntegrationRepo) GetOrganizationIDByWorkspaceID(context.Context, uuid.UUID) (uuid.UUID, error) {
@@ -392,9 +510,63 @@ func (f *fakeGitHubIntegrationRepo) GetWorkspaceGitHubRepository(_ context.Conte
 	return f.githubRepo, nil
 }
 
+func (f *fakeGitHubIntegrationRepo) ListWorkspaceCIProfiles(context.Context, uuid.UUID) ([]repository.WorkspaceCIProfile, error) {
+	return f.ciProfiles, nil
+}
+
+func (f *fakeGitHubIntegrationRepo) GetWorkspaceCIProfile(_ context.Context, workspaceID uuid.UUID, profileID uuid.UUID) (repository.WorkspaceCIProfile, error) {
+	for _, profile := range f.ciProfiles {
+		if profile.WorkspaceID == workspaceID && profile.ID == profileID {
+			return profile, nil
+		}
+	}
+	return repository.WorkspaceCIProfile{}, repository.ErrWorkspaceCIProfileNotFound
+}
+
+func (f *fakeGitHubIntegrationRepo) CreateWorkspaceCIProfile(_ context.Context, p repository.CreateWorkspaceCIProfileParams) (repository.WorkspaceCIProfile, error) {
+	profile := repository.WorkspaceCIProfile{
+		ID:                   uuid.New(),
+		WorkspaceID:          p.WorkspaceID,
+		Name:                 p.Name,
+		RepositoryFullName:   p.RepositoryFullName,
+		GitHubRepositoryID:   p.GitHubRepositoryID,
+		GitHubInstallationID: p.GitHubInstallationID,
+		DefaultBranch:        p.DefaultBranch,
+		ManifestPath:         p.ManifestPath,
+		WorkflowPath:         p.WorkflowPath,
+		Config:               p.Config,
+		CreatedByUserID:      p.CreatedByUserID,
+		CreatedAt:            time.Now().UTC(),
+		UpdatedAt:            time.Now().UTC(),
+	}
+	f.ciProfiles = append(f.ciProfiles, profile)
+	return profile, nil
+}
+
+func (f *fakeGitHubIntegrationRepo) UpdateWorkspaceCIProfile(_ context.Context, p repository.UpdateWorkspaceCIProfileParams) (repository.WorkspaceCIProfile, error) {
+	for index, profile := range f.ciProfiles {
+		if profile.WorkspaceID == p.WorkspaceID && profile.ID == p.ID {
+			profile.Name = p.Name
+			profile.RepositoryFullName = p.RepositoryFullName
+			profile.GitHubRepositoryID = p.GitHubRepositoryID
+			profile.GitHubInstallationID = p.GitHubInstallationID
+			profile.DefaultBranch = p.DefaultBranch
+			profile.ManifestPath = p.ManifestPath
+			profile.WorkflowPath = p.WorkflowPath
+			profile.Config = p.Config
+			profile.UpdatedAt = time.Now().UTC()
+			f.ciProfiles[index] = profile
+			return profile, nil
+		}
+	}
+	return repository.WorkspaceCIProfile{}, repository.ErrWorkspaceCIProfileNotFound
+}
+
 type fakeGitHubAppClient struct {
 	installation     githubAPIInstallation
 	repositories     []githubAPIRepository
+	checkInput       githubCheckRepositoryFilesInput
+	checkConflicts   []CISetupFileConflict
 	createFilesInput githubCreateFilesPullRequestInput
 	pullRequest      githubPullRequest
 }
@@ -407,7 +579,16 @@ func (f fakeGitHubAppClient) ListInstallationRepositories(context.Context, int64
 	return f.repositories, nil
 }
 
+func (f *fakeGitHubAppClient) CheckRepositoryFiles(_ context.Context, input githubCheckRepositoryFilesInput) ([]CISetupFileConflict, error) {
+	f.checkInput = input
+	return f.checkConflicts, nil
+}
+
 func (f *fakeGitHubAppClient) CreateRepositoryFilesPullRequest(_ context.Context, input githubCreateFilesPullRequestInput) (githubPullRequest, error) {
 	f.createFilesInput = input
 	return f.pullRequest, nil
+}
+
+func ptrInt64(value int64) *int64 {
+	return &value
 }

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -146,6 +146,12 @@ func registerProtectedRoutes(
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Get("/workspaces/{workspaceID}/github/repositories", listGitHubRepositoriesHandler(logger, githubIntegrationService))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Get("/workspaces/{workspaceID}/ci-profiles", listCIProfilesHandler(logger, githubIntegrationService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Post("/workspaces/{workspaceID}/ci-profiles", createCIProfileHandler(logger, githubIntegrationService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Patch("/workspaces/{workspaceID}/ci-profiles/{profileID}", updateCIProfileHandler(logger, githubIntegrationService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Post("/workspaces/{workspaceID}/github/ci-setup-pull-request", createCISetupPullRequestHandler(logger, githubIntegrationService))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Get("/workspaces/{workspaceID}/challenge-packs", listChallengePacksHandler(logger, challengePackReadService))

--- a/backend/internal/repository/ci_profiles.go
+++ b/backend/internal/repository/ci_profiles.go
@@ -88,9 +88,6 @@ WHERE workspace_id = $1 AND id = $2`, workspaceID, profileID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return WorkspaceCIProfile{}, ErrWorkspaceCIProfileNotFound
 	}
-	if isWorkspaceCIProfileNameConflict(err) {
-		return WorkspaceCIProfile{}, ErrWorkspaceCIProfileNameConflict
-	}
 	return profile, err
 }
 
@@ -138,6 +135,9 @@ RETURNING id, workspace_id, name, repository_full_name, github_repository_id,
 	profile, err := scanWorkspaceCIProfile(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return WorkspaceCIProfile{}, ErrWorkspaceCIProfileNotFound
+	}
+	if isWorkspaceCIProfileNameConflict(err) {
+		return WorkspaceCIProfile{}, ErrWorkspaceCIProfileNameConflict
 	}
 	return profile, err
 }

--- a/backend/internal/repository/ci_profiles.go
+++ b/backend/internal/repository/ci_profiles.go
@@ -1,0 +1,181 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+type WorkspaceCIProfile struct {
+	ID                   uuid.UUID
+	WorkspaceID          uuid.UUID
+	Name                 string
+	RepositoryFullName   string
+	GitHubRepositoryID   *int64
+	GitHubInstallationID *int64
+	DefaultBranch        string
+	ManifestPath         string
+	WorkflowPath         string
+	Config               json.RawMessage
+	CreatedByUserID      *uuid.UUID
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+}
+
+type CreateWorkspaceCIProfileParams struct {
+	WorkspaceID          uuid.UUID
+	Name                 string
+	RepositoryFullName   string
+	GitHubRepositoryID   *int64
+	GitHubInstallationID *int64
+	DefaultBranch        string
+	ManifestPath         string
+	WorkflowPath         string
+	Config               json.RawMessage
+	CreatedByUserID      *uuid.UUID
+}
+
+type UpdateWorkspaceCIProfileParams struct {
+	ID                   uuid.UUID
+	WorkspaceID          uuid.UUID
+	Name                 string
+	RepositoryFullName   string
+	GitHubRepositoryID   *int64
+	GitHubInstallationID *int64
+	DefaultBranch        string
+	ManifestPath         string
+	WorkflowPath         string
+	Config               json.RawMessage
+}
+
+func (r *Repository) ListWorkspaceCIProfiles(ctx context.Context, workspaceID uuid.UUID) ([]WorkspaceCIProfile, error) {
+	rows, err := r.db.Query(ctx, `
+SELECT id, workspace_id, name, repository_full_name, github_repository_id,
+    github_installation_id, default_branch, manifest_path, workflow_path, config,
+    created_by_user_id, created_at, updated_at
+FROM workspace_ci_profiles
+WHERE workspace_id = $1
+ORDER BY updated_at DESC, name ASC`, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	profiles := make([]WorkspaceCIProfile, 0)
+	for rows.Next() {
+		profile, scanErr := scanWorkspaceCIProfile(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		profiles = append(profiles, profile)
+	}
+	return profiles, rows.Err()
+}
+
+func (r *Repository) GetWorkspaceCIProfile(ctx context.Context, workspaceID uuid.UUID, profileID uuid.UUID) (WorkspaceCIProfile, error) {
+	row := r.db.QueryRow(ctx, `
+SELECT id, workspace_id, name, repository_full_name, github_repository_id,
+    github_installation_id, default_branch, manifest_path, workflow_path, config,
+    created_by_user_id, created_at, updated_at
+FROM workspace_ci_profiles
+WHERE workspace_id = $1 AND id = $2`, workspaceID, profileID)
+	profile, err := scanWorkspaceCIProfile(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return WorkspaceCIProfile{}, ErrWorkspaceCIProfileNotFound
+	}
+	if isWorkspaceCIProfileNameConflict(err) {
+		return WorkspaceCIProfile{}, ErrWorkspaceCIProfileNameConflict
+	}
+	return profile, err
+}
+
+func (r *Repository) CreateWorkspaceCIProfile(ctx context.Context, p CreateWorkspaceCIProfileParams) (WorkspaceCIProfile, error) {
+	config := normalizeCIProfileConfig(p.Config)
+	row := r.db.QueryRow(ctx, `
+INSERT INTO workspace_ci_profiles (
+    workspace_id, name, repository_full_name, github_repository_id,
+    github_installation_id, default_branch, manifest_path, workflow_path,
+    config, created_by_user_id
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+RETURNING id, workspace_id, name, repository_full_name, github_repository_id,
+    github_installation_id, default_branch, manifest_path, workflow_path, config,
+    created_by_user_id, created_at, updated_at`,
+		p.WorkspaceID, p.Name, p.RepositoryFullName, p.GitHubRepositoryID,
+		p.GitHubInstallationID, p.DefaultBranch, p.ManifestPath, p.WorkflowPath,
+		config, p.CreatedByUserID,
+	)
+	profile, err := scanWorkspaceCIProfile(row)
+	if isWorkspaceCIProfileNameConflict(err) {
+		return WorkspaceCIProfile{}, ErrWorkspaceCIProfileNameConflict
+	}
+	return profile, err
+}
+
+func (r *Repository) UpdateWorkspaceCIProfile(ctx context.Context, p UpdateWorkspaceCIProfileParams) (WorkspaceCIProfile, error) {
+	config := normalizeCIProfileConfig(p.Config)
+	row := r.db.QueryRow(ctx, `
+UPDATE workspace_ci_profiles
+SET name = $3,
+    repository_full_name = $4,
+    github_repository_id = $5,
+    github_installation_id = $6,
+    default_branch = $7,
+    manifest_path = $8,
+    workflow_path = $9,
+    config = $10
+WHERE workspace_id = $1 AND id = $2
+RETURNING id, workspace_id, name, repository_full_name, github_repository_id,
+    github_installation_id, default_branch, manifest_path, workflow_path, config,
+    created_by_user_id, created_at, updated_at`,
+		p.WorkspaceID, p.ID, p.Name, p.RepositoryFullName, p.GitHubRepositoryID,
+		p.GitHubInstallationID, p.DefaultBranch, p.ManifestPath, p.WorkflowPath, config,
+	)
+	profile, err := scanWorkspaceCIProfile(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return WorkspaceCIProfile{}, ErrWorkspaceCIProfileNotFound
+	}
+	return profile, err
+}
+
+func normalizeCIProfileConfig(config json.RawMessage) json.RawMessage {
+	if len(config) == 0 {
+		return json.RawMessage(`{}`)
+	}
+	return config
+}
+
+type workspaceCIProfileScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanWorkspaceCIProfile(scanner workspaceCIProfileScanner) (WorkspaceCIProfile, error) {
+	var profile WorkspaceCIProfile
+	err := scanner.Scan(
+		&profile.ID,
+		&profile.WorkspaceID,
+		&profile.Name,
+		&profile.RepositoryFullName,
+		&profile.GitHubRepositoryID,
+		&profile.GitHubInstallationID,
+		&profile.DefaultBranch,
+		&profile.ManifestPath,
+		&profile.WorkflowPath,
+		&profile.Config,
+		&profile.CreatedByUserID,
+		&profile.CreatedAt,
+		&profile.UpdatedAt,
+	)
+	return profile, err
+}
+
+func isWorkspaceCIProfileNameConflict(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) &&
+		pgErr.Code == "23505" &&
+		pgErr.ConstraintName == "workspace_ci_profiles_workspace_id_name_key"
+}

--- a/backend/internal/repository/errors.go
+++ b/backend/internal/repository/errors.go
@@ -49,6 +49,8 @@ var (
 	ErrDeviceCodeNotFound              = errors.New("device code not found")
 	ErrDeviceCodeExpired               = errors.New("device code expired")
 	ErrWorkspaceSecretNotFound         = errors.New("workspace secret not found")
+	ErrWorkspaceCIProfileNotFound      = errors.New("workspace ci profile not found")
+	ErrWorkspaceCIProfileNameConflict  = errors.New("workspace ci profile name already exists")
 	ErrSecretsCipherUnset              = errors.New("secrets cipher is not configured")
 	ErrInvalidSecretKey                = errors.New("secret key must match [A-Za-z_][A-Za-z0-9_]* and be 1..128 characters")
 )

--- a/docs/agentclash-ci-github.md
+++ b/docs/agentclash-ci-github.md
@@ -1,0 +1,102 @@
+# AgentClash GitHub CI
+
+AgentClash CI turns a pull request into an agent regression gate. The product UI
+generates a repository manifest at `.agentclash/ci.yaml` and a GitHub Actions
+workflow at `.github/workflows/agentclash.yml`; the CLI then runs the configured
+workspace resources from the PR.
+
+## What Runs
+
+AgentClash CI runs when the workflow receives a pull request event and either:
+
+- a changed file matches the manifest `triggers.paths` entries, such as
+  `agents/**`, `prompts/**`, `.agentclash/**`, or `.github/workflows/agentclash.yml`
+- the PR has one of the force-run labels in `triggers.labels`, such as
+  `agentclash/eval`
+
+The manifest points at workspace resources that define the gate:
+
+- candidate agent build and runtime profile
+- optional provider account or model alias override
+- challenge pack version and optional input set
+- regression suites
+- locked baseline run or deployment-derived baseline
+- release gate policy and regression-promotion behavior
+
+## Setup From The UI
+
+1. Open `https://agentclash.dev`.
+2. Choose a workspace, then open **CI setup**.
+3. Connect or select an installed GitHub repository.
+4. Choose the agent build, runtime profile, challenge pack, baseline, and gate
+   policy.
+5. Save the setup as a CI profile when the configuration should be reused later.
+6. Click **Open setup PR** to create a draft PR with the generated manifest and
+   workflow.
+7. If target files already exist, review the conflict list, then confirm
+   overwrite to open a setup PR that replaces those files on a branch.
+
+The repository also needs GitHub Actions secrets:
+
+```text
+AGENTCLASH_TOKEN
+AGENTCLASH_WORKSPACE
+```
+
+Use the hosted backend unless you are intentionally testing a local stack:
+
+```text
+AGENTCLASH_API_URL=https://api.agentclash.dev
+```
+
+## PR Feedback
+
+The workflow posts one sticky PR comment. It should include the verdict, score
+deltas, run links, comparison links, replay links, artifact pointers, and
+regression-tracking status so the PR author can inspect failures without guessing
+which AgentClash page to open.
+
+The GitHub check fails only when `agentclash ci run` returns a blocking gate
+verdict. Non-blocking warnings still appear in the comment and uploaded artifacts.
+
+## Regression Promotion
+
+Use `regression_promotion: proposed` when CI should convert failed cases into
+reviewable regression work. Use `auto_on_main` only when your default branch run
+is trusted enough to promote failures automatically after merge. Use `disabled`
+when CI should only report the gate result.
+
+## Live E2E Runbook
+
+1. In production, create or select a workspace with a runnable challenge pack,
+   runtime profile, agent build, baseline run, and GitHub App installation.
+2. Save a CI profile from the CI setup page.
+3. Open a setup PR into a CI test repository.
+4. Verify the generated PR contains `.agentclash/ci.yaml` and
+   `.github/workflows/agentclash.yml`.
+5. Re-run setup against the same repo and confirm the UI reports file conflicts
+   before creating a replacement PR.
+6. Merge the setup PR.
+7. Open a deliberate regression PR that changes a watched agent, prompt, model,
+   or runtime file.
+8. Confirm GitHub Actions runs AgentClash only for matched paths or labels.
+9. Confirm the sticky PR comment links to the AgentClash run, comparison, and
+   replay pages.
+10. Confirm the GitHub check blocks the PR on a regression verdict and uploads
+    result artifacts.
+11. Confirm failed cases show up as proposed regression work, or auto-promote on
+    the default branch when that profile option is selected.
+
+## Local Dry Run
+
+From a repository with a generated manifest:
+
+```bash
+export AGENTCLASH_API_URL="https://api.agentclash.dev"
+export AGENTCLASH_TOKEN="..."
+export AGENTCLASH_WORKSPACE="workspace-id"
+npx agentclash ci run --config .agentclash/ci.yaml --dry-run
+```
+
+Then run without `--dry-run` on a CI branch after confirming the selected
+workspace resources are correct.

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -64,6 +64,8 @@ tags:
     description: Workspace membership invitations and updates
   - name: WorkspaceSecrets
     description: Encrypted workspace secret management
+  - name: GitHubIntegrations
+    description: GitHub App installation, repository selection, and CI setup
   - name: RuntimeProfiles
     description: Execution runtime profile configuration
   - name: ProviderAccounts
@@ -501,6 +503,134 @@ paths:
           $ref: "#/components/responses/UnauthorizedError"
         "403":
           $ref: "#/components/responses/ForbiddenError"
+
+  /v1/workspaces/{workspaceID}/ci-profiles:
+    get:
+      operationId: listCIProfiles
+      tags: [GitHubIntegrations]
+      summary: List saved CI profiles
+      description: Lists reusable AgentClash CI setup profiles for a workspace.
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+      responses:
+        "200":
+          description: Saved CI profiles
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CIProfilesResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+    post:
+      operationId: createCIProfile
+      tags: [GitHubIntegrations]
+      summary: Create a saved CI profile
+      description: Saves a complete CI setup profile for later reuse in the workspace UI.
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SaveCIProfileRequest"
+      responses:
+        "201":
+          description: CI profile created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CIProfile"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "409":
+          $ref: "#/components/responses/ConflictError"
+
+  /v1/workspaces/{workspaceID}/ci-profiles/{profileID}:
+    patch:
+      operationId: updateCIProfile
+      tags: [GitHubIntegrations]
+      summary: Update a saved CI profile
+      description: Replaces the saved CI setup profile snapshot with the supplied values.
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+        - $ref: "#/components/parameters/ProfileID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SaveCIProfileRequest"
+      responses:
+        "200":
+          description: CI profile updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CIProfile"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "409":
+          $ref: "#/components/responses/ConflictError"
+
+  /v1/workspaces/{workspaceID}/github/ci-setup-pull-request:
+    post:
+      operationId: createCISetupPullRequest
+      tags: [GitHubIntegrations]
+      summary: Open a GitHub setup PR for AgentClash CI
+      description: >
+        Creates a draft pull request containing generated AgentClash CI files.
+        If target files already exist and overwrite_existing is false, returns a
+        conflict preflight response without creating a pull request.
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateCISetupPullRequestRequest"
+      responses:
+        "201":
+          description: Setup pull request created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateCISetupPullRequestResponse"
+        "200":
+          description: Conflict preflight completed without creating a pull request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateCISetupPullRequestResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "503":
+          $ref: "#/components/responses/InternalError"
 
   # ---------------------------------------------------------------------------
   # Billing
@@ -4142,6 +4272,191 @@ components:
     EmptyObject:
       type: object
       additionalProperties: false
+
+    CIProfilesResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/CIProfile"
+
+    CIProfile:
+      type: object
+      required:
+        - id
+        - workspace_id
+        - name
+        - repository_full_name
+        - default_branch
+        - manifest_path
+        - workflow_path
+        - config
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        workspace_id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        repository_full_name:
+          type: string
+          example: acme/support-agent
+        github_repository_id:
+          type: integer
+          format: int64
+        github_installation_id:
+          type: integer
+          format: int64
+        default_branch:
+          type: string
+          example: main
+        manifest_path:
+          type: string
+          example: .agentclash/ci.yaml
+        workflow_path:
+          type: string
+          example: .github/workflows/agentclash.yml
+        config:
+          type: object
+          additionalProperties: true
+          description: UI profile snapshot. Includes schemaVersion for forward-compatible migrations.
+        created_by_user_id:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    SaveCIProfileRequest:
+      type: object
+      required: [name, repository_full_name, default_branch, manifest_path, workflow_path, config]
+      properties:
+        name:
+          type: string
+          maxLength: 120
+        repository_full_name:
+          type: string
+          example: acme/support-agent
+        github_repository_id:
+          type: integer
+          format: int64
+        github_installation_id:
+          type: integer
+          format: int64
+        default_branch:
+          type: string
+          example: main
+        manifest_path:
+          type: string
+          example: .agentclash/ci.yaml
+        workflow_path:
+          type: string
+          example: .github/workflows/agentclash.yml
+        config:
+          type: object
+          additionalProperties: true
+
+    CreateCISetupPullRequestRequest:
+      type: object
+      required: [github_repository_id, base_branch, files]
+      properties:
+        github_repository_id:
+          type: integer
+          format: int64
+        github_installation_id:
+          type: integer
+          format: int64
+        base_branch:
+          type: string
+          example: main
+        title:
+          type: string
+        body:
+          type: string
+        draft:
+          type: boolean
+        check_only:
+          type: boolean
+          description: Return target-file conflicts without creating a PR.
+        overwrite_existing:
+          type: boolean
+          description: Allow generated files to replace existing target paths in the setup PR branch.
+        files:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/CISetupPullRequestFile"
+
+    CreateCISetupPullRequestResponse:
+      type: object
+      required: [base_branch, files]
+      properties:
+        pull_request:
+          $ref: "#/components/schemas/GitHubPullRequest"
+        branch:
+          type: string
+          description: Created branch name. Empty when no pull request was created.
+        base_branch:
+          type: string
+        files:
+          type: array
+          items:
+            $ref: "#/components/schemas/CISetupPullRequestFileSummary"
+        conflicts:
+          type: array
+          items:
+            $ref: "#/components/schemas/CISetupFileConflict"
+
+    CISetupPullRequestFile:
+      type: object
+      required: [path, content]
+      properties:
+        path:
+          type: string
+          example: .agentclash/ci.yaml
+        content:
+          type: string
+
+    CISetupPullRequestFileSummary:
+      type: object
+      required: [path]
+      properties:
+        path:
+          type: string
+
+    CISetupFileConflict:
+      type: object
+      required: [path, exists]
+      properties:
+        path:
+          type: string
+        exists:
+          type: boolean
+        sha:
+          type: string
+
+    GitHubPullRequest:
+      type: object
+      required: [number, html_url, state, draft]
+      properties:
+        number:
+          type: integer
+        html_url:
+          type: string
+          format: uri
+        state:
+          type: string
+        draft:
+          type: boolean
 
     ValidationResult:
       type: object

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/ci-setup/ci-setup-client.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/ci-setup/ci-setup-client.test.tsx
@@ -367,6 +367,7 @@ describe("CISetupClient", () => {
         github_repository_id: 456,
         github_installation_id: 123,
         config: expect.objectContaining({
+          schemaVersion: 1,
           agentBuildId: "build-1",
           selectedPackId: "pack-1",
         }),

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/ci-setup/ci-setup-client.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/ci-setup/ci-setup-client.test.tsx
@@ -7,6 +7,7 @@ const {
   mockGetAccessToken,
   mockCreateApiClient,
   mockListResponse,
+  mockPatch,
   mockPost,
   mockRunsResponse,
   toast,
@@ -14,11 +15,13 @@ const {
   mockGetAccessToken: vi.fn(),
   mockCreateApiClient: vi.fn(),
   mockListResponse: vi.fn(),
+  mockPatch: vi.fn(),
   mockPost: vi.fn(),
   mockRunsResponse: vi.fn(),
   toast: Object.assign(vi.fn(), {
     success: vi.fn(),
     error: vi.fn(),
+    warning: vi.fn(),
   }),
 }));
 
@@ -38,6 +41,7 @@ vi.mock("@/lib/api/swr", async (importOriginal) => {
       data: { items: mockListResponse(path) },
       isLoading: false,
       error: null,
+      mutate: vi.fn(),
     }),
     usePaginatedApiQuery: () => ({
       data: mockRunsResponse(),
@@ -111,6 +115,7 @@ const cleanups: Array<() => void> = [];
 beforeEach(() => {
   document.body.innerHTML = "";
   mockPost.mockReset();
+  mockPatch.mockReset();
   mockGetAccessToken.mockResolvedValue("token");
   mockCreateApiClient.mockReturnValue({
     get: vi.fn(async (path: string) => {
@@ -145,6 +150,7 @@ beforeEach(() => {
       }
       return { items: [] };
     }),
+    patch: mockPatch,
     post: mockPost,
   });
   mockPost.mockResolvedValue({
@@ -160,6 +166,20 @@ beforeEach(() => {
       { path: ".agentclash/ci.yaml" },
       { path: ".github/workflows/agentclash.yml" },
     ],
+  });
+  mockPatch.mockResolvedValue({
+    id: "profile-1",
+    workspace_id: "ws-1",
+    name: "Default CI profile",
+    repository_full_name: "acme/support-agent",
+    github_repository_id: 456,
+    github_installation_id: 123,
+    default_branch: "main",
+    manifest_path: ".agentclash/ci.yaml",
+    workflow_path: ".github/workflows/agentclash.yml",
+    config: {},
+    created_at: "2026-05-05T00:00:00Z",
+    updated_at: "2026-05-05T00:00:00Z",
   });
   mockListResponse.mockImplementation(listResponse);
   mockRunsResponse.mockReturnValue({
@@ -278,6 +298,81 @@ describe("CISetupClient", () => {
     );
     expect(document.body.textContent).toContain("Setup PR #7 created");
     expect(toast.success).toHaveBeenCalledWith("Created setup PR #7");
+  });
+
+  it("shows setup PR conflicts before overwriting generated files", async () => {
+    mockPost.mockResolvedValueOnce({
+      branch: "",
+      base_branch: "main",
+      files: [{ path: ".agentclash/ci.yaml" }],
+      conflicts: [{ path: ".agentclash/ci.yaml", exists: true, sha: "abc123" }],
+    });
+
+    renderClient();
+    await flushEffects();
+
+    const button = Array.from(document.querySelectorAll("button")).find(
+      (item) => item.textContent?.includes("Open setup PR"),
+    );
+    if (!button) throw new Error("Open setup PR button not found");
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(document.body.textContent).toContain("Generated files already exist");
+    expect(document.body.textContent).toContain(".agentclash/ci.yaml");
+    expect(toast.warning).toHaveBeenCalledWith(
+      "Generated files already exist. Confirm overwrite to open a setup PR.",
+    );
+  });
+
+  it("saves the current setup as a reusable CI profile", async () => {
+    mockPost.mockResolvedValueOnce({
+      id: "profile-2",
+      workspace_id: "ws-1",
+      name: "Default CI profile",
+      repository_full_name: "acme/support-agent",
+      github_repository_id: 456,
+      github_installation_id: 123,
+      default_branch: "main",
+      manifest_path: ".agentclash/ci.yaml",
+      workflow_path: ".github/workflows/agentclash.yml",
+      config: {},
+      created_at: "2026-05-05T00:00:00Z",
+      updated_at: "2026-05-05T00:00:00Z",
+    });
+
+    renderClient();
+    await flushEffects();
+
+    const button = Array.from(document.querySelectorAll("button")).find(
+      (item) => item.textContent?.includes("Save profile"),
+    );
+    if (!button) throw new Error("Save profile button not found");
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/v1/workspaces/ws-1/ci-profiles",
+      expect.objectContaining({
+        name: "Default CI profile",
+        repository_full_name: "acme/support-agent",
+        github_repository_id: 456,
+        github_installation_id: 123,
+        config: expect.objectContaining({
+          agentBuildId: "build-1",
+          selectedPackId: "pack-1",
+        }),
+      }),
+    );
+    expect(toast.success).toHaveBeenCalledWith("CI profile saved");
   });
 
   it("disables setup PR creation for manual repositories", async () => {
@@ -420,6 +515,9 @@ function listResponse(path: string) {
         last_synced_at: "2026-05-05T00:00:00Z",
       },
     ];
+  }
+  if (path.includes("/ci-profiles")) {
+    return [];
   }
   return [];
 }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/ci-setup/ci-setup-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/ci-setup/ci-setup-client.tsx
@@ -425,8 +425,6 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
   const readiness = ciSetupReadiness(config);
   const manifest = generateAgentClashCIManifest(config);
   const workflow = generateAgentClashGitHubWorkflow(config);
-  const canCreateSetupPR =
-    readiness.ready && selectedGitHubRepository !== null && !creatingSetupPR;
   const loadingAny =
     builds.isLoading ||
     deployments.isLoading ||
@@ -438,6 +436,11 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
     repositories.isLoading ||
     ciProfiles.isLoading ||
     runs.isLoading;
+  const canCreateSetupPR =
+    readiness.ready &&
+    selectedGitHubRepository !== null &&
+    !loadingAny &&
+    !creatingSetupPR;
   const loadError =
     builds.error ||
     deployments.error ||
@@ -704,7 +707,11 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
                     const value = event.target.value;
                     setSelectedProfileId(value);
                     const profile = savedProfiles.find((item) => item.id === value);
-                    if (profile) setProfileName(profile.name);
+                    if (profile) {
+                      applyProfile(profile);
+                    } else {
+                      setProfileName("Default CI profile");
+                    }
                   }}
                   className={selectClass}
                 >
@@ -1521,6 +1528,7 @@ function ResourceLinks({ workspaceId }: { workspaceId: string }) {
 }
 
 type StoredCIProfileConfig = {
+  schemaVersion?: unknown;
   selectedRepositoryKey?: unknown;
   selectedPackId?: unknown;
   selectedRegressionSuiteIds?: unknown;
@@ -1578,6 +1586,7 @@ function buildProfileConfig(config: {
   regressionPromotion: CIRegressionPromotion;
 }): StoredCIProfileConfig {
   return {
+    schemaVersion: 1,
     selectedRepositoryKey: config.selectedRepositoryKey,
     selectedPackId: config.selectedPackId,
     selectedRegressionSuiteIds: config.selectedRegressionSuiteIds,

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/ci-setup/ci-setup-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/ci-setup/ci-setup-client.tsx
@@ -36,8 +36,10 @@ import {
 import type {
   AgentBuild,
   AgentDeployment,
+  CIProfile,
   ChallengeInputSetSummary,
   ChallengePack,
+  CISetupFileConflict,
   CreateCISetupPullRequestRequest,
   CreateCISetupPullRequestResponse,
   GitHubRepository,
@@ -47,6 +49,7 @@ import type {
   Run,
   RunAgent,
   RuntimeProfile,
+  SaveCIProfileRequest,
 } from "@/lib/api/types";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -117,9 +120,16 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
   const [loadingInputSets, setLoadingInputSets] = useState(false);
   const [loadingRunAgents, setLoadingRunAgents] = useState(false);
   const [selectedRepositoryKey, setSelectedRepositoryKey] = useState("");
+  const [selectedProfileId, setSelectedProfileId] = useState("");
+  const [profileName, setProfileName] = useState("Default CI profile");
+  const [savingProfile, setSavingProfile] = useState(false);
   const [creatingSetupPR, setCreatingSetupPR] = useState(false);
   const [setupPRResult, setSetupPRResult] =
     useState<CreateCISetupPullRequestResponse | null>(null);
+  const [setupPRConflicts, setSetupPRConflicts] = useState<CISetupFileConflict[]>(
+    [],
+  );
+  const [overwriteExisting, setOverwriteExisting] = useState(false);
 
   const builds = useApiListQuery<AgentBuild>(
     `/v1/workspaces/${workspaceId}/agent-builds`,
@@ -145,6 +155,9 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
   );
   const repositories = useApiListQuery<GitHubRepository>(
     `/v1/workspaces/${workspaceId}/github/repositories`,
+  );
+  const ciProfiles = useApiListQuery<CIProfile>(
+    `/v1/workspaces/${workspaceId}/ci-profiles`,
   );
   const runs = usePaginatedApiQuery<Run>(`/v1/workspaces/${workspaceId}/runs`, {
     limit: 100,
@@ -423,6 +436,7 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
     modelAliases.isLoading ||
     regressionSuites.isLoading ||
     repositories.isLoading ||
+    ciProfiles.isLoading ||
     runs.isLoading;
   const loadError =
     builds.error ||
@@ -432,7 +446,13 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
     providerAccounts.error ||
     modelAliases.error ||
     regressionSuites.error ||
+    repositories.error ||
+    ciProfiles.error ||
     runs.error;
+
+  const savedProfiles = ciProfiles.data?.items ?? [];
+  const selectedProfile =
+    savedProfiles.find((profile) => profile.id === selectedProfileId) ?? null;
 
   async function createSetupPullRequest() {
     if (!selectedGitHubRepository) {
@@ -441,6 +461,7 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
     }
     setCreatingSetupPR(true);
     setSetupPRResult(null);
+    setSetupPRConflicts([]);
     try {
       const token = await getAccessToken();
       const api = createApiClient(token ?? undefined);
@@ -456,6 +477,7 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
           `Workflow: \`${config.workflowPath}\``,
         ].join("\n"),
         draft: true,
+        overwrite_existing: overwriteExisting,
         files: [
           { path: config.manifestPath, content: manifest },
           { path: config.workflowPath, content: workflow },
@@ -465,7 +487,15 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
         `/v1/workspaces/${workspaceId}/github/ci-setup-pull-request`,
         payload,
       );
+      if (!result.pull_request) {
+        setSetupPRConflicts(result.conflicts ?? []);
+        if ((result.conflicts ?? []).length > 0) {
+          toast.warning("Generated files already exist. Confirm overwrite to open a setup PR.");
+        }
+        return;
+      }
       setSetupPRResult(result);
+      setOverwriteExisting(false);
       toast.success(`Created setup PR #${result.pull_request.number}`);
     } catch (err) {
       toast.error(
@@ -474,6 +504,132 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
     } finally {
       setCreatingSetupPR(false);
     }
+  }
+
+  async function saveCIProfile() {
+    const name = profileName.trim();
+    if (!name) {
+      toast.error("Name the CI profile before saving");
+      return;
+    }
+    setSavingProfile(true);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token ?? undefined);
+      const payload: SaveCIProfileRequest = {
+        name,
+        repository_full_name: config.repositoryFullName,
+        github_repository_id: selectedGitHubRepository?.github_repository_id,
+        github_installation_id: selectedGitHubRepository?.github_installation_id,
+        default_branch: config.defaultBranch,
+        manifest_path: config.manifestPath,
+        workflow_path: config.workflowPath,
+        config: buildProfileConfig({
+          selectedRepositoryKey,
+          selectedPackId,
+          selectedRegressionSuiteIds,
+          triggerPathsText,
+          triggerLabelsText,
+          workflowPath,
+          manifestPath,
+          agentSpecPath,
+          repositoryFullName,
+          defaultBranch,
+          agentBuildId,
+          runtimeProfileId,
+          providerAccountId,
+          modelAliasId,
+          deploymentName,
+          selectedVersionId,
+          inputSetId,
+          baselineStrategy,
+          baselineRunId,
+          baselineRunAgentId,
+          baselineDeploymentId,
+          baselineRefresh,
+          baselineMaxAgeDays,
+          gateFailOn,
+          gatePolicyFile,
+          regressionPromotion,
+        }),
+      };
+      let saved: CIProfile;
+      if (selectedProfileId) {
+        saved = await api.patch<CIProfile>(
+          `/v1/workspaces/${workspaceId}/ci-profiles/${selectedProfileId}`,
+          payload,
+        );
+      } else {
+        saved = await api.post<CIProfile>(
+          `/v1/workspaces/${workspaceId}/ci-profiles`,
+          payload,
+        );
+      }
+      setSelectedProfileId(saved.id);
+      setProfileName(saved.name);
+      await ciProfiles.mutate?.();
+      toast.success("CI profile saved");
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Failed to save CI profile");
+    } finally {
+      setSavingProfile(false);
+    }
+  }
+
+  function applyProfile(profile: CIProfile | null) {
+    if (!profile) return;
+    const stored = normalizeProfileConfig(profile.config);
+    setSelectedProfileId(profile.id);
+    setProfileName(profile.name);
+    setSelectedRepositoryKey(stringValue(stored.selectedRepositoryKey, ""));
+    setWorkflowPath(stringValue(stored.workflowPath, profile.workflow_path));
+    setManifestPath(stringValue(stored.manifestPath, profile.manifest_path));
+    setAgentSpecPath(
+      stringValue(stored.agentSpecPath, defaultCISetupConfig.agentSpecPath),
+    );
+    setTriggerPathsText(
+      stringArrayValue(stored.triggerPaths, defaultCISetupConfig.triggerPaths).join(
+        "\n",
+      ),
+    );
+    setTriggerLabelsText(
+      stringArrayValue(
+        stored.triggerLabels,
+        defaultCISetupConfig.triggerLabels,
+      ).join("\n"),
+    );
+    setRepositoryFullName(
+      stringValue(stored.repositoryFullName, profile.repository_full_name),
+    );
+    setDefaultBranch(stringValue(stored.defaultBranch, profile.default_branch));
+    setAgentBuildId(stringValue(stored.agentBuildId, ""));
+    setRuntimeProfileId(stringValue(stored.runtimeProfileId, ""));
+    setProviderAccountId(stringValue(stored.providerAccountId, ""));
+    setModelAliasId(stringValue(stored.modelAliasId, ""));
+    setDeploymentName(stringValue(stored.deploymentName, "pr-candidate"));
+    setSelectedPackId(stringValue(stored.selectedPackId, ""));
+    setSelectedVersionId(stringValue(stored.selectedVersionId, ""));
+    setInputSetId(stringValue(stored.inputSetId, ""));
+    setSelectedRegressionSuiteIds(
+      stringArrayValue(stored.selectedRegressionSuiteIds, []),
+    );
+    setBaselineStrategy(
+      stringValue(stored.baselineStrategy, "locked_run") as CIBaselineStrategy,
+    );
+    setBaselineRunId(stringValue(stored.baselineRunId, ""));
+    setBaselineRunIdManualOverride(Boolean(stored.baselineRunId));
+    setBaselineRunAgentId(stringValue(stored.baselineRunAgentId, ""));
+    setBaselineDeploymentId(stringValue(stored.baselineDeploymentId, ""));
+    setBaselineRefresh(
+      stringValue(stored.baselineRefresh, "manual") as CIBaselineRefresh,
+    );
+    setBaselineMaxAgeDays(numberValue(stored.baselineMaxAgeDays, 30));
+    setGateFailOn(stringValue(stored.gateFailOn, "regression") as CIGateFailOn);
+    setGatePolicyFile(stringValue(stored.gatePolicyFile, ""));
+    setRegressionPromotion(
+      stringValue(stored.regressionPromotion, "proposed") as CIRegressionPromotion,
+    );
+    toast.success(`Loaded ${profile.name}`);
   }
 
   return (
@@ -535,6 +691,61 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.02fr)_minmax(420px,0.98fr)]">
         <div className="space-y-6">
+          <Section
+            icon={<ShieldCheck className="size-4" />}
+            title="Saved Profile"
+            meta={savedProfiles.length ? `${savedProfiles.length} saved` : "New"}
+          >
+            <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto]">
+              <Field label="Profile">
+                <select
+                  value={selectedProfileId}
+                  onChange={(event) => {
+                    const value = event.target.value;
+                    setSelectedProfileId(value);
+                    const profile = savedProfiles.find((item) => item.id === value);
+                    if (profile) setProfileName(profile.name);
+                  }}
+                  className={selectClass}
+                >
+                  <option value="">Create a new profile</option>
+                  {savedProfiles.map((profile) => (
+                    <option key={profile.id} value={profile.id}>
+                      {profile.name}
+                    </option>
+                  ))}
+                </select>
+              </Field>
+              <div className="flex items-end">
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={!selectedProfile}
+                  onClick={() => applyProfile(selectedProfile)}
+                >
+                  <Download data-icon="inline-start" className="size-4" />
+                  Load profile
+                </Button>
+              </div>
+              <Field label="Profile name">
+                <Input
+                  value={profileName}
+                  onChange={(event) => setProfileName(event.target.value)}
+                />
+              </Field>
+              <div className="flex items-end">
+                <Button type="button" disabled={savingProfile} onClick={saveCIProfile}>
+                  {savingProfile ? (
+                    <Loader2 data-icon="inline-start" className="size-4 animate-spin" />
+                  ) : (
+                    <CheckCircle2 data-icon="inline-start" className="size-4" />
+                  )}
+                  Save profile
+                </Button>
+              </div>
+            </div>
+          </Section>
+
           <Section
             icon={<Github className="size-4" />}
             title="Repository"
@@ -964,7 +1175,7 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
             }
           />
 
-          {setupPRResult ? (
+          {setupPRResult?.pull_request ? (
             <StatusPanel
               tone="success"
               title={`Setup PR #${setupPRResult.pull_request.number} created`}
@@ -978,6 +1189,33 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
                 >
                   View pull request
                 </a>
+              }
+            />
+          ) : null}
+
+          {setupPRConflicts.length > 0 ? (
+            <StatusPanel
+              tone="warn"
+              title="Generated files already exist"
+              body={`AgentClash found ${setupPRConflicts.length} target file(s) on ${config.defaultBranch}. Review them before replacing repo CI configuration.`}
+              action={
+                <div className="space-y-3">
+                  <ul className="space-y-1 text-xs text-muted-foreground">
+                    {setupPRConflicts.map((conflict) => (
+                      <li key={conflict.path}>
+                        <code>{conflict.path}</code>
+                      </li>
+                    ))}
+                  </ul>
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={overwriteExisting}
+                      onChange={(event) => setOverwriteExisting(event.target.checked)}
+                    />
+                    Overwrite these files in a setup PR
+                  </label>
+                </div>
               }
             />
           ) : null}
@@ -1037,6 +1275,18 @@ export function CISetupClient({ workspaceId }: CISetupClientProps) {
                 Result JSON and AgentClash artifact JSON files are uploaded on
                 every matched run.
               </BehaviorItem>
+              <BehaviorItem title="Regression tracking">
+                Failed CI cases are recorded as proposed regression work unless
+                auto_on_main promotion is selected for default-branch runs.
+              </BehaviorItem>
+            </div>
+            <div className="mt-4">
+              <Link
+                href={`/workspaces/${workspaceId}/regression-suites`}
+                className="text-sm font-medium underline underline-offset-4"
+              >
+                Review regression suites
+              </Link>
             </div>
           </div>
 
@@ -1268,6 +1518,113 @@ function ResourceLinks({ workspaceId }: { workspaceId: string }) {
       ))}
     </div>
   );
+}
+
+type StoredCIProfileConfig = {
+  selectedRepositoryKey?: unknown;
+  selectedPackId?: unknown;
+  selectedRegressionSuiteIds?: unknown;
+  triggerPaths?: unknown;
+  triggerLabels?: unknown;
+  workflowPath?: unknown;
+  manifestPath?: unknown;
+  agentSpecPath?: unknown;
+  repositoryFullName?: unknown;
+  defaultBranch?: unknown;
+  agentBuildId?: unknown;
+  runtimeProfileId?: unknown;
+  providerAccountId?: unknown;
+  modelAliasId?: unknown;
+  deploymentName?: unknown;
+  selectedVersionId?: unknown;
+  inputSetId?: unknown;
+  baselineStrategy?: unknown;
+  baselineRunId?: unknown;
+  baselineRunAgentId?: unknown;
+  baselineDeploymentId?: unknown;
+  baselineRefresh?: unknown;
+  baselineMaxAgeDays?: unknown;
+  gateFailOn?: unknown;
+  gatePolicyFile?: unknown;
+  regressionPromotion?: unknown;
+};
+
+function buildProfileConfig(config: {
+  selectedRepositoryKey: string;
+  selectedPackId: string;
+  selectedRegressionSuiteIds: string[];
+  triggerPathsText: string;
+  triggerLabelsText: string;
+  workflowPath: string;
+  manifestPath: string;
+  agentSpecPath: string;
+  repositoryFullName: string;
+  defaultBranch: string;
+  agentBuildId: string;
+  runtimeProfileId: string;
+  providerAccountId: string;
+  modelAliasId: string;
+  deploymentName: string;
+  selectedVersionId: string;
+  inputSetId: string;
+  baselineStrategy: CIBaselineStrategy;
+  baselineRunId: string;
+  baselineRunAgentId: string;
+  baselineDeploymentId: string;
+  baselineRefresh: CIBaselineRefresh;
+  baselineMaxAgeDays: number;
+  gateFailOn: CIGateFailOn;
+  gatePolicyFile: string;
+  regressionPromotion: CIRegressionPromotion;
+}): StoredCIProfileConfig {
+  return {
+    selectedRepositoryKey: config.selectedRepositoryKey,
+    selectedPackId: config.selectedPackId,
+    selectedRegressionSuiteIds: config.selectedRegressionSuiteIds,
+    triggerPaths: splitLines(config.triggerPathsText),
+    triggerLabels: splitLines(config.triggerLabelsText),
+    workflowPath: config.workflowPath,
+    manifestPath: config.manifestPath,
+    agentSpecPath: config.agentSpecPath,
+    repositoryFullName: config.repositoryFullName,
+    defaultBranch: config.defaultBranch,
+    agentBuildId: config.agentBuildId,
+    runtimeProfileId: config.runtimeProfileId,
+    providerAccountId: config.providerAccountId,
+    modelAliasId: config.modelAliasId,
+    deploymentName: config.deploymentName,
+    selectedVersionId: config.selectedVersionId,
+    inputSetId: config.inputSetId,
+    baselineStrategy: config.baselineStrategy,
+    baselineRunId: config.baselineRunId,
+    baselineRunAgentId: config.baselineRunAgentId,
+    baselineDeploymentId: config.baselineDeploymentId,
+    baselineRefresh: config.baselineRefresh,
+    baselineMaxAgeDays: config.baselineMaxAgeDays,
+    gateFailOn: config.gateFailOn,
+    gatePolicyFile: config.gatePolicyFile,
+    regressionPromotion: config.regressionPromotion,
+  };
+}
+
+function normalizeProfileConfig(config: unknown): StoredCIProfileConfig {
+  return config && typeof config === "object" && !Array.isArray(config)
+    ? (config as StoredCIProfileConfig)
+    : {};
+}
+
+function stringValue(value: unknown, fallback: string): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function numberValue(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function stringArrayValue(value: unknown, fallback: string[]): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : fallback;
 }
 
 function splitLines(value: string): string[] {

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -408,14 +408,22 @@ export interface CreateCISetupPullRequestRequest {
   title?: string;
   body?: string;
   draft?: boolean;
+  check_only?: boolean;
+  overwrite_existing?: boolean;
   files: Array<{
     path: string;
     content: string;
   }>;
 }
 
+export interface CISetupFileConflict {
+  path: string;
+  exists: boolean;
+  sha?: string;
+}
+
 export interface CreateCISetupPullRequestResponse {
-  pull_request: {
+  pull_request?: {
     number: number;
     html_url: string;
     state: string;
@@ -426,6 +434,34 @@ export interface CreateCISetupPullRequestResponse {
   files: Array<{
     path: string;
   }>;
+  conflicts?: CISetupFileConflict[];
+}
+
+export interface CIProfile {
+  id: string;
+  workspace_id: string;
+  name: string;
+  repository_full_name: string;
+  github_repository_id?: number;
+  github_installation_id?: number;
+  default_branch: string;
+  manifest_path: string;
+  workflow_path: string;
+  config: unknown;
+  created_by_user_id?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SaveCIProfileRequest {
+  name: string;
+  repository_full_name: string;
+  github_repository_id?: number;
+  github_installation_id?: number;
+  default_branch: string;
+  manifest_path: string;
+  workflow_path: string;
+  config: unknown;
 }
 
 export type AgentHarnessExecutionStatus =


### PR DESCRIPTION
## Summary
- add persisted workspace CI profiles with create/list/update APIs
- make setup PR creation conflict-aware before overwriting generated files
- add CI setup UI save/load profile controls, overwrite confirmation, and regression promotion guidance
- document GitHub CI setup, PR feedback, regression promotion, and live E2E runbook

## Verification
- go test ./... (backend)
- npm test -- --run 'src/app/(workspace)/workspaces/[workspaceId]/ci-setup/ci-setup-client.test.tsx'
- npx eslint 'src/app/(workspace)/workspaces/[workspaceId]/ci-setup/ci-setup-client.tsx' 'src/app/(workspace)/workspaces/[workspaceId]/ci-setup/ci-setup-client.test.tsx' src/lib/api/types.ts
- npx tsc --noEmit
- NEXT_PUBLIC_API_URL=http://localhost:8080 npm run build
