### PR TITLE
fix(ci): harden action CLI resolution

### DIFF
--- a/.github/actions/agentclash-ci/README.md
+++ b/.github/actions/agentclash-ci/README.md
@@ -2,14 +2,16 @@
 
 Run a manifest-based AgentClash CI gate from GitHub Actions.
 
-This action is a thin wrapper around the published `agentclash` CLI:
+This action is a thin wrapper around the `agentclash` CLI:
 
 1. optionally install `agentclash` from npm
-2. validate the repo-tracked CI manifest
-3. run `agentclash ci should-run`
-4. run `agentclash ci run` when the manifest trigger matches
-5. post or update a sticky structured PR comment when pull request context and permissions are available
-6. expose result paths and gate outputs for artifact upload or downstream steps
+2. verify the installed CLI exposes the required CI commands
+3. fall back to the action checkout's Go source when npm has not caught up yet
+4. validate the repo-tracked CI manifest
+5. run `agentclash ci should-run`
+6. run `agentclash ci run` when the manifest trigger matches
+7. post or update a sticky structured PR comment when pull request context and permissions are available
+8. expose result paths and gate outputs for artifact upload or downstream steps
 
 ## Example
 
@@ -67,6 +69,8 @@ jobs:
 | `app-url` | `https://agentclash.dev` | AgentClash app base URL used for PR comment links. |
 | `install-cli` | `true` | Install `agentclash` from npm before running. |
 | `cli-version` | `latest` | npm version or tag for the `agentclash` package. |
+| `source-fallback` | `true` | Use the action checkout's Go source when the installed CLI does not expose `ci should-run` and `ci run`. When enabled, the action sets up Go with `go-version` before resolving the CLI. |
+| `go-version` | `1.25.x` | Go version used by the source fallback. |
 | `remote-validate` | `true` | Validate manifest resource IDs against the API. |
 | `skip-if-unmatched` | `true` | Skip `ci run` when manifest paths and labels do not match. |
 | `base` | pull request base branch | Base ref for `ci should-run`. |

--- a/.github/actions/agentclash-ci/action.yml
+++ b/.github/actions/agentclash-ci/action.yml
@@ -32,6 +32,14 @@ inputs:
     description: npm version or tag for the agentclash package.
     required: false
     default: latest
+  source-fallback:
+    description: Run the CLI from this action checkout when the installed npm CLI does not expose the required CI commands.
+    required: false
+    default: "true"
+  go-version:
+    description: Go version used by the source fallback.
+    required: false
+    default: "1.25.x"
   remote-validate:
     description: Validate manifest resource IDs against the AgentClash API.
     required: false
@@ -107,6 +115,13 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Set up Go for source CLI fallback
+      if: ${{ inputs.source-fallback == 'true' }}
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ inputs.go-version }}
+        cache: false
+
     - id: agentclash
       name: Run AgentClash CI gate
       shell: bash
@@ -119,6 +134,7 @@ runs:
         INPUT_APP_URL: ${{ inputs.app-url }}
         INPUT_INSTALL_CLI: ${{ inputs.install-cli }}
         INPUT_CLI_VERSION: ${{ inputs.cli-version }}
+        INPUT_SOURCE_FALLBACK: ${{ inputs.source-fallback }}
         INPUT_REMOTE_VALIDATE: ${{ inputs.remote-validate }}
         INPUT_SKIP_IF_UNMATCHED: ${{ inputs.skip-if-unmatched }}
         INPUT_BASE: ${{ inputs.base }}

--- a/.github/actions/agentclash-ci/run.sh
+++ b/.github/actions/agentclash-ci/run.sh
@@ -53,6 +53,49 @@ else:
 PY
 }
 
+agentclash_supports_ci_commands() {
+  local should_run_help
+  local run_help
+  should_run_help="$("$@" ci should-run --help 2>&1)" &&
+    run_help="$("$@" ci run --help 2>&1)" &&
+    [[ "$should_run_help" == *"agentclash ci should-run"* ]] &&
+    [[ "$should_run_help" == *"Flags:"* ]] &&
+    [[ "$run_help" == *"agentclash ci run"* ]] &&
+    [[ "$run_help" == *"Flags:"* ]]
+}
+
+resolve_agentclash_cli() {
+  agentclash_cmd=(agentclash)
+
+  if command -v agentclash >/dev/null 2>&1; then
+    if agentclash_supports_ci_commands agentclash; then
+      echo "Using installed agentclash CLI"
+      return 0
+    fi
+    echo "::notice::Installed agentclash CLI does not expose ci should-run/run; checking source fallback"
+  fi
+
+  if bool_true "${INPUT_SOURCE_FALLBACK:-true}"; then
+    local source_dir
+    source_dir="$(cd "${ACTION_PATH}/../../.." && pwd)/cli"
+    if [[ -d "$source_dir" ]] && command -v go >/dev/null 2>&1; then
+      if agentclash_supports_ci_commands go -C "$source_dir" run .; then
+        agentclash_cmd=(go -C "$source_dir" run .)
+        echo "Using AgentClash CLI source fallback from ${source_dir}"
+        return 0
+      fi
+      echo "::notice::AgentClash CLI source fallback exists but does not expose ci should-run/run"
+    elif [[ ! -d "$source_dir" ]]; then
+      echo "::notice::AgentClash CLI source fallback is unavailable at ${source_dir}"
+    else
+      echo "::notice::Go is unavailable, so AgentClash CLI source fallback cannot run"
+    fi
+  fi
+
+  echo "::error::AgentClash CI requires an agentclash CLI with 'ci should-run' and 'ci run'. Publish a newer npm CLI, set cli-version to a compatible version, or keep source-fallback enabled with Go available."
+  return 1
+}
+
 post_pr_comment() {
   local status="$1"
   if ! bool_true "${INPUT_PR_COMMENT:-true}"; then
@@ -120,10 +163,12 @@ if bool_true "${INPUT_INSTALL_CLI:-true}"; then
   npm install --global "agentclash@${INPUT_CLI_VERSION:-latest}"
 fi
 
+resolve_agentclash_cli
+
 if bool_true "${INPUT_REMOTE_VALIDATE:-true}"; then
-  agentclash ci validate "$manifest" --remote
+  "${agentclash_cmd[@]}" ci validate "$manifest" --remote
 else
-  agentclash ci validate "$manifest"
+  "${agentclash_cmd[@]}" ci validate "$manifest"
 fi
 
 should_args=(ci should-run --manifest "$manifest" --json)
@@ -149,7 +194,7 @@ if [[ -n "${INPUT_LABELS:-}" ]]; then
   should_args+=(--labels "${INPUT_LABELS}")
 fi
 
-agentclash "${should_args[@]}" >"$should_run_file"
+"${agentclash_cmd[@]}" "${should_args[@]}" >"$should_run_file"
 should_run="$(json_get "$should_run_file" should_run)"
 skip_reason="$(json_get "$should_run_file" reason)"
 write_output "should-run" "$should_run"
@@ -184,7 +229,7 @@ if [[ -n "${INPUT_DEFAULT_BRANCH:-}" ]]; then
 fi
 
 set +e
-agentclash "${run_args[@]}" >"$result_file"
+"${agentclash_cmd[@]}" "${run_args[@]}" >"$result_file"
 status=$?
 set -e
 

--- a/.github/actions/agentclash-ci/run_test.py
+++ b/.github/actions/agentclash-ci/run_test.py
@@ -1,0 +1,213 @@
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ACTION_DIR = Path(__file__).resolve().parent
+
+
+class RunScriptCLIResolutionTests(unittest.TestCase):
+    def test_uses_installed_cli_when_ci_commands_exist(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            calls = root / "calls.log"
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            self.write_executable(
+                bin_dir / "agentclash",
+                f"""#!/usr/bin/env bash
+printf 'agentclash %s\\n' "$*" >>"{calls}"
+if [[ "$*" == "ci should-run --help" || "$*" == "ci run --help" ]]; then
+  printf 'Usage:\\n  agentclash %s [flags]\\n\\nFlags:\\n  --help\\n' "${{*:1:2}}"
+  exit 0
+fi
+if [[ "$1 $2" == "ci validate" ]]; then
+  exit 0
+fi
+if [[ "$1 $2" == "ci should-run" ]]; then
+  printf '%s\\n' '{{"should_run":false,"reason":"no matched files"}}'
+  exit 0
+fi
+exit 9
+""",
+            )
+
+            result = self.run_action(root, bin_dir)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("Using installed agentclash CLI", result.stdout)
+            call_log = calls.read_text()
+            self.assertIn("agentclash ci validate", call_log)
+            self.assertIn("agentclash ci should-run", call_log)
+
+    def test_falls_back_to_source_cli_when_installed_cli_is_stale(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            calls = root / "calls.log"
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            self.write_executable(
+                bin_dir / "agentclash",
+                f"""#!/usr/bin/env bash
+printf 'agentclash %s\\n' "$*" >>"{calls}"
+exit 1
+""",
+            )
+            self.write_executable(
+                bin_dir / "go",
+                f"""#!/usr/bin/env bash
+printf 'go %s\\n' "$*" >>"{calls}"
+if [[ "$1" == "-C" && "$3 $4" == "run ." && "$5 $6" == "ci should-run" && "$7" == "--help" ]]; then
+  printf 'Usage:\\n  agentclash ci should-run [flags]\\n\\nFlags:\\n  --help\\n'
+  exit 0
+fi
+if [[ "$1" == "-C" && "$3 $4" == "run ." && "$5 $6" == "ci run" && "$7" == "--help" ]]; then
+  printf 'Usage:\\n  agentclash ci run [flags]\\n\\nFlags:\\n  --help\\n'
+  exit 0
+fi
+if [[ "$1" == "-C" && "$3 $4" == "run ." && "$5 $6" == "ci validate" ]]; then
+  exit 0
+fi
+if [[ "$1" == "-C" && "$3 $4" == "run ." && "$5 $6" == "ci should-run" ]]; then
+  printf '%s\\n' '{{"should_run":false,"reason":"no matched files"}}'
+  exit 0
+fi
+exit 9
+""",
+            )
+
+            result = self.run_action(root, bin_dir)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("Using AgentClash CLI source fallback", result.stdout)
+            call_log = calls.read_text()
+            self.assertIn("agentclash ci should-run --help", call_log)
+            self.assertIn("go -C", call_log)
+            self.assertIn("ci validate", call_log)
+            self.assertIn("ci should-run", call_log)
+
+    def test_falls_back_when_installed_cli_is_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            calls = root / "calls.log"
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            self.write_fake_go(bin_dir / "go", calls)
+
+            result = self.run_action(root, bin_dir)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("Using AgentClash CLI source fallback", result.stdout)
+            self.assertIn("go -C", calls.read_text())
+
+    def test_fails_when_fallback_is_disabled_and_installed_cli_is_stale(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            calls = root / "calls.log"
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            self.write_executable(
+                bin_dir / "agentclash",
+                f"""#!/usr/bin/env bash
+printf 'agentclash %s\\n' "$*" >>"{calls}"
+exit 1
+""",
+            )
+            self.write_fake_go(bin_dir / "go", calls)
+
+            result = self.run_action(root, bin_dir, source_fallback="false")
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("AgentClash CI requires an agentclash CLI", result.stdout)
+            self.assertNotIn("go -C", calls.read_text())
+
+    def run_action(
+        self,
+        root: Path,
+        bin_dir: Path,
+        *,
+        source_fallback: str = "true",
+    ) -> subprocess.CompletedProcess[str]:
+        manifest = root / "ci.yaml"
+        manifest.write_text(
+            textwrap.dedent(
+                """
+                version: 1
+                trigger:
+                  paths:
+                    - "agents/**"
+                candidate:
+                  build:
+                    agent_build_id: build-1
+                    spec_file: agents/agent.json
+                  deployment:
+                    runtime_profile_id: runtime-1
+                evaluation:
+                  challenge_pack_version_id: pack-1
+                baseline:
+                  run_id: run-1
+                gate:
+                  fail_on: regression
+                regressions:
+                  promote_failures: proposed
+                """
+            ).strip()
+            + "\n",
+        )
+        env = {
+            **os.environ,
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "ACTION_PATH": str(ACTION_DIR),
+            "INPUT_INSTALL_CLI": "false",
+            "INPUT_REMOTE_VALIDATE": "false",
+            "INPUT_SOURCE_FALLBACK": source_fallback,
+            "INPUT_SKIP_IF_UNMATCHED": "true",
+            "INPUT_PR_COMMENT": "false",
+            "INPUT_MANIFEST": str(manifest),
+            "INPUT_CHANGED_FILES": "docs/readme.md",
+            "RUNNER_TEMP": str(root),
+        }
+        return subprocess.run(
+            ["bash", str(ACTION_DIR / "run.sh")],
+            cwd=root,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    @staticmethod
+    def write_executable(path: Path, content: str):
+        path.write_text(textwrap.dedent(content))
+        path.chmod(0o755)
+
+    def write_fake_go(self, path: Path, calls: Path):
+        self.write_executable(
+            path,
+            f"""#!/usr/bin/env bash
+printf 'go %s\\n' "$*" >>"{calls}"
+if [[ "$1" == "-C" && "$3 $4" == "run ." && "$5 $6" == "ci should-run" && "$7" == "--help" ]]; then
+  printf 'Usage:\\n  agentclash ci should-run [flags]\\n\\nFlags:\\n  --help\\n'
+  exit 0
+fi
+if [[ "$1" == "-C" && "$3 $4" == "run ." && "$5 $6" == "ci run" && "$7" == "--help" ]]; then
+  printf 'Usage:\\n  agentclash ci run [flags]\\n\\nFlags:\\n  --help\\n'
+  exit 0
+fi
+if [[ "$1" == "-C" && "$3 $4" == "run ." && "$5 $6" == "ci validate" ]]; then
+  exit 0
+fi
+if [[ "$1" == "-C" && "$3 $4" == "run ." && "$5 $6" == "ci should-run" ]]; then
+  printf '%s\\n' '{{"should_run":false,"reason":"no matched files"}}'
+  exit 0
+fi
+exit 9
+""",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - "cli/**"
+      - ".github/actions/agentclash-ci/**"
       - ".github/workflows/cli.yml"
   pull_request:
     branches: [main]
     paths:
       - "cli/**"
+      - ".github/actions/agentclash-ci/**"
       - ".github/workflows/cli.yml"
 
 defaults:
@@ -47,3 +49,17 @@ jobs:
 
       - name: Run tests (short mode)
         run: go test -short -race -count=1 ./...
+
+  action-tests:
+    name: AgentClash CI Action Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run action tests
+        run: |
+          python3 .github/actions/agentclash-ci/run_test.py
+          python3 .github/actions/agentclash-ci/comment_test.py


### PR DESCRIPTION
## Summary
- verify the installed npm CLI exposes `ci should-run` and `ci run` before using it
- fall back to the action checkout source via `go -C <repo>/cli run .` when npm latest is stale
- run AgentClash CI action tests from CLI CI whenever action files change

## Why
`agentclash@latest` is currently 0.12.0 and does not expose the CI run commands needed by the generated workflow. Without this fallback, a live customer setup PR can look correct but fail at runtime before AgentClash evaluates anything.

## Tests
- `python3 .github/actions/agentclash-ci/run_test.py`
- `python3 .github/actions/agentclash-ci/comment_test.py`
- `go test ./cmd -run 'TestCIShouldRun|TestCIRun' -count=1`\n- `git diff --check`\n- smoke: action script with `agentclash@latest`, `remote-validate=false`, non-matching changed file, and source fallback enabled