### PR TITLE
fix(billing): hardcode Dodo checkout quantity to 1

### DIFF
--- a/backend/internal/api/billing.go
+++ b/backend/internal/api/billing.go
@@ -589,11 +589,14 @@ func (m *BillingManager) createDodoCheckoutSession(ctx context.Context, caller C
 	if productID == "" {
 		return "", "", validationError("invalid_billing_period", "selected plan does not have a Dodo product for this billing period")
 	}
+	// Dodo subscription line items must have quantity=1; per-seat billing is
+	// expressed via add-ons, not by multiplying the subscription quantity.
+	// See https://docs.dodopayments.com/developer-resources/seat-based-pricing.
 	requestPayload := map[string]any{
 		"product_cart": []map[string]any{
 			{
 				"product_id": productID,
-				"quantity":   input.SeatQuantity,
+				"quantity":   1,
 			},
 		},
 		"return_url": input.ReturnURL,

--- a/backend/internal/api/billing_test.go
+++ b/backend/internal/api/billing_test.go
@@ -553,8 +553,8 @@ func TestBillingManagerCreateCheckoutUsesDodoAPIWhenConfigured(t *testing.T) {
 	if !ok {
 		t.Fatalf("product cart item = %#v, want object", productCart[0])
 	}
-	if item["product_id"] != "agentclash_pro_monthly" || item["quantity"] != float64(5) {
-		t.Fatalf("product cart item = %#v, want pro monthly quantity 5", item)
+	if item["product_id"] != "agentclash_pro_monthly" || item["quantity"] != float64(1) {
+		t.Fatalf("product cart item = %#v, want pro monthly quantity 1", item)
 	}
 	metadata, ok := capturedPayload["metadata"].(map[string]any)
 	if !ok {


### PR DESCRIPTION
## Summary

- Dodo's subscription products reject `product_cart` entries with `quantity > 1` and return HTTP 422 — per-seat pricing must be expressed via **add-ons**, not by multiplying the subscription quantity ([Dodo seat-based pricing docs](https://docs.dodopayments.com/developer-resources/seat-based-pricing)).
- Backend was sending `quantity: input.SeatQuantity` (5 for Pro, matching `MinimumSeats`), so every paid checkout failed live with a 422.
- Hardcodes `quantity: 1` on the subscription line item; updates the matching test in `billing_test.go`.

## Tradeoff (intentional, per offline discussion)

With this change, Dodo charges the subscription's flat price regardless of seat count. Internal entitlements still enforce the per-plan seat minimum, but Dodo billing is no longer per-seat. Wiring add-ons (one add-on ID per plan-period combination, plumbed through env vars + plan config) is a larger change tracked as a follow-up — this PR is the minimum to get checkout working end-to-end.

## Test plan

- [x] `go vet ./...`
- [x] `go test -short -race -count=1 ./internal/api/... ./internal/billing/...`
- [ ] After Railway redeploy: click "Switch to Pro Monthly" in the web UI → expect Dodo-hosted checkout page (not HTTP 422 from `billing service error` log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)