### PR TITLE
[codex] fix member invite links

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -139,7 +139,6 @@ func main() {
 	runCreationManager.WithEntitlementGateService(billingManager)
 	orgManager := api.NewOrganizationManager(orgAuthz, repo)
 	wsManager := api.NewWorkspaceManager(orgAuthz, repo, billingManager)
-	orgMembershipManager := api.NewOrgMembershipManager(orgAuthz, repo, billingManager)
 
 	var emailSender email.Sender
 	if cfg.ResendAPIKey != "" {
@@ -149,6 +148,7 @@ func main() {
 		emailSender = email.NoopSender{}
 		logger.Info("email sender: noop (RESEND_API_KEY not set)")
 	}
+	orgMembershipManager := api.NewOrgMembershipManager(orgAuthz, repo, emailSender, cfg.FrontendURL, billingManager)
 	wsMembershipManager := api.NewWorkspaceMembershipManager(repo, emailSender, cfg.FrontendURL)
 	onboardingManager := api.NewOnboardingManager(repo)
 	infraManager := api.NewInfrastructureManager(repo)

--- a/backend/internal/api/invite_urls.go
+++ b/backend/internal/api/invite_urls.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+func organizationInviteAcceptURL(frontendURL string, membershipID uuid.UUID) string {
+	return frontendURLForPath(frontendURL, fmt.Sprintf("/invites/organization/%s", membershipID))
+}
+
+func workspaceInviteAcceptURL(frontendURL string, membershipID uuid.UUID) string {
+	return frontendURLForPath(frontendURL, fmt.Sprintf("/invites/workspace/%s", membershipID))
+}
+
+func frontendURLForPath(frontendURL, path string) string {
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	base := strings.TrimRight(strings.TrimSpace(frontendURL), "/")
+	if base == "" {
+		return path
+	}
+	return base + path
+}

--- a/backend/internal/api/org_memberships.go
+++ b/backend/internal/api/org_memberships.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	billingpkg "github.com/agentclash/agentclash/backend/internal/billing"
+	"github.com/agentclash/agentclash/backend/internal/email"
 	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -40,6 +41,7 @@ type OrgMembershipResult struct {
 	Role             string    `json:"role"`
 	MembershipStatus string    `json:"membership_status"`
 	CreatedAt        time.Time `json:"created_at"`
+	AcceptURL        string    `json:"accept_url,omitempty"`
 }
 
 type ListOrgMembershipsResult struct {
@@ -54,6 +56,7 @@ type OrgMembershipRepository interface {
 	CountOrgMemberships(ctx context.Context, orgID uuid.UUID) (int64, error)
 	GetUserByEmail(ctx context.Context, email string) (repository.User, error)
 	CreateUser(ctx context.Context, input repository.CreateUserInput) (repository.User, error)
+	GetOrganizationByID(ctx context.Context, orgID uuid.UUID) (repository.OrganizationRow, error)
 	GetOrgMembershipByOrgAndUser(ctx context.Context, orgID, userID uuid.UUID) (repository.OrgMembershipFullRow, error)
 	CreateOrgMembership(ctx context.Context, input repository.CreateOrgMembershipInput) (repository.OrgMembershipFullRow, error)
 	GetOrgMembershipByID(ctx context.Context, membershipID uuid.UUID) (repository.OrgMembershipFullRow, error)
@@ -67,15 +70,20 @@ const inviteExpiryDays = 7
 type OrgMembershipManager struct {
 	orgAuthz        OrganizationAuthorizer
 	repo            OrgMembershipRepository
+	emailSender     email.Sender
+	frontendURL     string
 	entitlementGate EntitlementGateService
 }
 
-func NewOrgMembershipManager(orgAuthz OrganizationAuthorizer, repo OrgMembershipRepository, entitlementGate ...EntitlementGateService) *OrgMembershipManager {
+func NewOrgMembershipManager(orgAuthz OrganizationAuthorizer, repo OrgMembershipRepository, emailSender email.Sender, frontendURL string, entitlementGate ...EntitlementGateService) *OrgMembershipManager {
 	var gate EntitlementGateService
 	if len(entitlementGate) > 0 {
 		gate = entitlementGate[0]
 	}
-	return &OrgMembershipManager{orgAuthz: orgAuthz, repo: repo, entitlementGate: gate}
+	if emailSender == nil {
+		emailSender = email.NoopSender{}
+	}
+	return &OrgMembershipManager{orgAuthz: orgAuthz, repo: repo, emailSender: emailSender, frontendURL: frontendURL, entitlementGate: gate}
 }
 
 func (m *OrgMembershipManager) ListOrgMemberships(ctx context.Context, caller Caller, orgID uuid.UUID, limit, offset int32) (ListOrgMembershipsResult, error) {
@@ -94,8 +102,12 @@ func (m *OrgMembershipManager) ListOrgMemberships(ctx context.Context, caller Ca
 	}
 
 	items := make([]OrgMembershipResult, 0, len(memberships))
+	includeInviteLinks := false
+	if membership, ok := caller.OrganizationMemberships[orgID]; ok && membership.Role == "org_admin" {
+		includeInviteLinks = true
+	}
 	for _, row := range memberships {
-		items = append(items, orgMembershipRowToResult(row))
+		items = append(items, m.orgMembershipRowToResult(row, includeInviteLinks))
 	}
 
 	return ListOrgMembershipsResult{
@@ -154,7 +166,9 @@ func (m *OrgMembershipManager) InviteOrgMember(ctx context.Context, caller Calle
 		if err != nil {
 			return OrgMembershipResult{}, err
 		}
-		return orgMembershipRowToResult(result), nil
+		acceptURL := organizationInviteAcceptURL(m.frontendURL, result.ID)
+		m.sendInviteEmail(ctx, caller, orgID, input.Email, input.Role, acceptURL)
+		return m.orgMembershipRowToResult(result, true), nil
 	}
 	if !errors.Is(err, repository.ErrMembershipNotFound) {
 		return OrgMembershipResult{}, err
@@ -177,9 +191,9 @@ func (m *OrgMembershipManager) InviteOrgMember(ctx context.Context, caller Calle
 		return OrgMembershipResult{}, err
 	}
 
-	// TODO: Send invitation email notification (stubbed for now).
-
-	return orgMembershipRowToResult(result), nil
+	acceptURL := organizationInviteAcceptURL(m.frontendURL, result.ID)
+	m.sendInviteEmail(ctx, caller, orgID, input.Email, input.Role, acceptURL)
+	return m.orgMembershipRowToResult(result, true), nil
 }
 
 func (m *OrgMembershipManager) UpdateOrgMembership(ctx context.Context, caller Caller, membershipID uuid.UUID, input UpdateOrgMembershipInput) (OrgMembershipResult, error) {
@@ -262,7 +276,31 @@ func (m *OrgMembershipManager) UpdateOrgMembership(ctx context.Context, caller C
 		}
 	}
 
-	return orgMembershipRowToResult(result), nil
+	return m.orgMembershipRowToResult(result, isAdmin), nil
+}
+
+func (m *OrgMembershipManager) sendInviteEmail(ctx context.Context, caller Caller, orgID uuid.UUID, inviteeEmail, role, acceptURL string) {
+	org, err := m.repo.GetOrganizationByID(ctx, orgID)
+	if err != nil {
+		slog.Default().Warn("failed to load organization for invite email", "organization_id", orgID, "error", err)
+		return
+	}
+
+	inviterEmail := caller.Email
+	if inviterEmail == "" {
+		inviterEmail = "a team member"
+	}
+
+	if err := m.emailSender.SendInvite(ctx, email.InviteEmail{
+		To:           inviteeEmail,
+		ResourceName: org.Name,
+		ResourceKind: "organization",
+		InviterEmail: inviterEmail,
+		Role:         role,
+		AcceptURL:    acceptURL,
+	}); err != nil {
+		slog.Default().Warn("failed to send invite email", "to", inviteeEmail, "organization_id", orgID, "error", err)
+	}
 }
 
 func isRemovingAdmin(membership repository.OrgMembershipFullRow, input UpdateOrgMembershipInput) bool {
@@ -296,8 +334,8 @@ func validateOrgMembershipTransition(from, to string) error {
 
 var ErrInvalidTransition = errors.New("invalid status transition")
 
-func orgMembershipRowToResult(row repository.OrgMembershipFullRow) OrgMembershipResult {
-	return OrgMembershipResult{
+func (m *OrgMembershipManager) orgMembershipRowToResult(row repository.OrgMembershipFullRow, includeInviteLink bool) OrgMembershipResult {
+	result := OrgMembershipResult{
 		ID:               row.ID,
 		OrganizationID:   row.OrganizationID,
 		UserID:           row.UserID,
@@ -307,6 +345,10 @@ func orgMembershipRowToResult(row repository.OrgMembershipFullRow) OrgMembership
 		MembershipStatus: row.MembershipStatus,
 		CreatedAt:        row.CreatedAt,
 	}
+	if includeInviteLink && row.MembershipStatus == "invited" {
+		result.AcceptURL = organizationInviteAcceptURL(m.frontendURL, row.ID)
+	}
+	return result
 }
 
 func strPtr(s string) *string { return &s }

--- a/backend/internal/api/org_memberships_test.go
+++ b/backend/internal/api/org_memberships_test.go
@@ -1,0 +1,185 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+type fakeOrgMembershipRepo struct {
+	organization    repository.OrganizationRow
+	user            repository.User
+	userErr         error
+	orgMembership   repository.OrgMembershipFullRow
+	orgMemberErr    error
+	created         repository.OrgMembershipFullRow
+	createErr       error
+	updated         repository.OrgMembershipFullRow
+	updateErr       error
+	adminCount      int64
+	memberships     []repository.OrgMembershipFullRow
+	membershipCount int64
+}
+
+func (r *fakeOrgMembershipRepo) ListOrgMemberships(_ context.Context, _ uuid.UUID, _, _ int32) ([]repository.OrgMembershipFullRow, error) {
+	return r.memberships, nil
+}
+
+func (r *fakeOrgMembershipRepo) CountOrgMemberships(_ context.Context, _ uuid.UUID) (int64, error) {
+	return r.membershipCount, nil
+}
+
+func (r *fakeOrgMembershipRepo) GetUserByEmail(_ context.Context, _ string) (repository.User, error) {
+	return r.user, r.userErr
+}
+
+func (r *fakeOrgMembershipRepo) CreateUser(_ context.Context, input repository.CreateUserInput) (repository.User, error) {
+	return repository.User{ID: uuid.New(), Email: input.Email}, nil
+}
+
+func (r *fakeOrgMembershipRepo) GetOrganizationByID(_ context.Context, _ uuid.UUID) (repository.OrganizationRow, error) {
+	return r.organization, nil
+}
+
+func (r *fakeOrgMembershipRepo) GetOrgMembershipByOrgAndUser(_ context.Context, _, _ uuid.UUID) (repository.OrgMembershipFullRow, error) {
+	return r.orgMembership, r.orgMemberErr
+}
+
+func (r *fakeOrgMembershipRepo) CreateOrgMembership(_ context.Context, _ repository.CreateOrgMembershipInput) (repository.OrgMembershipFullRow, error) {
+	return r.created, r.createErr
+}
+
+func (r *fakeOrgMembershipRepo) GetOrgMembershipByID(_ context.Context, _ uuid.UUID) (repository.OrgMembershipFullRow, error) {
+	return r.orgMembership, r.orgMemberErr
+}
+
+func (r *fakeOrgMembershipRepo) UpdateOrgMembership(_ context.Context, _ uuid.UUID, _ repository.UpdateOrgMembershipInput) (repository.OrgMembershipFullRow, error) {
+	return r.updated, r.updateErr
+}
+
+func (r *fakeOrgMembershipRepo) CountActiveOrgAdmins(_ context.Context, _ uuid.UUID) (int64, error) {
+	return r.adminCount, nil
+}
+
+func (r *fakeOrgMembershipRepo) CascadeOrgMembershipStatusToWorkspaces(_ context.Context, _, _ uuid.UUID, _ string) error {
+	return nil
+}
+
+func TestInviteOrgMember_SendsEmail(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	membershipID := uuid.New()
+
+	repo := &fakeOrgMembershipRepo{
+		organization: repository.OrganizationRow{
+			ID:   orgID,
+			Name: "Test Org",
+		},
+		user:         repository.User{ID: userID, Email: "invitee@example.com"},
+		orgMemberErr: repository.ErrMembershipNotFound,
+		created: repository.OrgMembershipFullRow{
+			ID:               membershipID,
+			OrganizationID:   orgID,
+			UserID:           userID,
+			Email:            "invitee@example.com",
+			Role:             "org_member",
+			MembershipStatus: "invited",
+		},
+	}
+
+	sender := &fakeEmailSender{}
+	manager := NewOrgMembershipManager(NewCallerOrganizationAuthorizer(), repo, sender, "https://app.agentclash.dev")
+
+	caller := Caller{
+		UserID: uuid.New(),
+		Email:  "admin@example.com",
+		OrganizationMemberships: map[uuid.UUID]OrganizationMembership{
+			orgID: {OrganizationID: orgID, Role: "org_admin"},
+		},
+	}
+
+	result, err := manager.InviteOrgMember(context.Background(), caller, orgID, InviteOrgMemberInput{
+		Email: "invitee@example.com",
+		Role:  "org_member",
+	})
+	if err != nil {
+		t.Fatalf("InviteOrgMember returned error: %v", err)
+	}
+
+	wantAcceptURL := "https://app.agentclash.dev/invites/organization/" + membershipID.String()
+	if result.AcceptURL != wantAcceptURL {
+		t.Errorf("result AcceptURL = %q, want %q", result.AcceptURL, wantAcceptURL)
+	}
+	if len(sender.calls) != 1 {
+		t.Fatalf("expected 1 email sent, got %d", len(sender.calls))
+	}
+	sent := sender.calls[0]
+	if sent.To != "invitee@example.com" {
+		t.Errorf("email To = %q, want invitee@example.com", sent.To)
+	}
+	if sent.ResourceName != "Test Org" {
+		t.Errorf("email ResourceName = %q, want Test Org", sent.ResourceName)
+	}
+	if sent.ResourceKind != "organization" {
+		t.Errorf("email ResourceKind = %q, want organization", sent.ResourceKind)
+	}
+	if sent.InviterEmail != "admin@example.com" {
+		t.Errorf("email InviterEmail = %q, want admin@example.com", sent.InviterEmail)
+	}
+	if sent.Role != "org_member" {
+		t.Errorf("email Role = %q, want org_member", sent.Role)
+	}
+	if sent.AcceptURL != wantAcceptURL {
+		t.Errorf("email AcceptURL = %q, want %q", sent.AcceptURL, wantAcceptURL)
+	}
+}
+
+func TestListOrgMemberships_InviteLinksOnlyForAdmins(t *testing.T) {
+	orgID := uuid.New()
+	membershipID := uuid.New()
+	repo := &fakeOrgMembershipRepo{
+		memberships: []repository.OrgMembershipFullRow{
+			{
+				ID:               membershipID,
+				OrganizationID:   orgID,
+				UserID:           uuid.New(),
+				Email:            "invitee@example.com",
+				Role:             "org_member",
+				MembershipStatus: "invited",
+			},
+		},
+		membershipCount: 1,
+	}
+	manager := NewOrgMembershipManager(NewCallerOrganizationAuthorizer(), repo, &fakeEmailSender{}, "https://app.agentclash.dev")
+
+	memberCaller := Caller{
+		UserID: uuid.New(),
+		OrganizationMemberships: map[uuid.UUID]OrganizationMembership{
+			orgID: {OrganizationID: orgID, Role: "org_member"},
+		},
+	}
+	memberResult, err := manager.ListOrgMemberships(context.Background(), memberCaller, orgID, 50, 0)
+	if err != nil {
+		t.Fatalf("ListOrgMemberships returned error for member: %v", err)
+	}
+	if got := memberResult.Items[0].AcceptURL; got != "" {
+		t.Fatalf("member caller AcceptURL = %q, want empty", got)
+	}
+
+	adminCaller := Caller{
+		UserID: uuid.New(),
+		OrganizationMemberships: map[uuid.UUID]OrganizationMembership{
+			orgID: {OrganizationID: orgID, Role: "org_admin"},
+		},
+	}
+	adminResult, err := manager.ListOrgMemberships(context.Background(), adminCaller, orgID, 50, 0)
+	if err != nil {
+		t.Fatalf("ListOrgMemberships returned error for admin: %v", err)
+	}
+	wantAcceptURL := "https://app.agentclash.dev/invites/organization/" + membershipID.String()
+	if got := adminResult.Items[0].AcceptURL; got != wantAcceptURL {
+		t.Fatalf("admin caller AcceptURL = %q, want %q", got, wantAcceptURL)
+	}
+}

--- a/backend/internal/api/workspace_memberships.go
+++ b/backend/internal/api/workspace_memberships.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -42,6 +41,7 @@ type WorkspaceMembershipResult struct {
 	Role             string    `json:"role"`
 	MembershipStatus string    `json:"membership_status"`
 	CreatedAt        time.Time `json:"created_at"`
+	AcceptURL        string    `json:"accept_url,omitempty"`
 }
 
 type ListWorkspaceMembershipsResult struct {
@@ -92,8 +92,9 @@ func (m *WorkspaceMembershipManager) ListWorkspaceMemberships(ctx context.Contex
 	}
 
 	items := make([]WorkspaceMembershipResult, 0, len(memberships))
+	includeInviteLinks := m.callerCanCopyWorkspaceInviteLinks(ctx, caller, workspaceID)
 	for _, row := range memberships {
-		items = append(items, wsMembershipRowToResult(row))
+		items = append(items, m.wsMembershipRowToResult(row, includeInviteLinks))
 	}
 
 	return ListWorkspaceMembershipsResult{
@@ -157,8 +158,9 @@ func (m *WorkspaceMembershipManager) InviteWorkspaceMember(ctx context.Context, 
 		if err != nil {
 			return WorkspaceMembershipResult{}, err
 		}
-		m.sendInviteEmail(ctx, caller, workspaceID, input.Email, input.Role)
-		return wsMembershipRowToResult(result), nil
+		acceptURL := workspaceInviteAcceptURL(m.frontendURL, result.ID)
+		m.sendInviteEmail(ctx, caller, workspaceID, input.Email, input.Role, acceptURL)
+		return m.wsMembershipRowToResult(result, true), nil
 	}
 	if !errors.Is(err, repository.ErrMembershipNotFound) {
 		return WorkspaceMembershipResult{}, err
@@ -174,8 +176,9 @@ func (m *WorkspaceMembershipManager) InviteWorkspaceMember(ctx context.Context, 
 		return WorkspaceMembershipResult{}, err
 	}
 
-	m.sendInviteEmail(ctx, caller, workspaceID, input.Email, input.Role)
-	return wsMembershipRowToResult(result), nil
+	acceptURL := workspaceInviteAcceptURL(m.frontendURL, result.ID)
+	m.sendInviteEmail(ctx, caller, workspaceID, input.Email, input.Role, acceptURL)
+	return m.wsMembershipRowToResult(result, true), nil
 }
 
 func (m *WorkspaceMembershipManager) UpdateWorkspaceMembership(ctx context.Context, caller Caller, membershipID uuid.UUID, input UpdateWorkspaceMembershipInput) (WorkspaceMembershipResult, error) {
@@ -245,10 +248,10 @@ func (m *WorkspaceMembershipManager) UpdateWorkspaceMembership(ctx context.Conte
 		return WorkspaceMembershipResult{}, err
 	}
 
-	return wsMembershipRowToResult(result), nil
+	return m.wsMembershipRowToResult(result, isAdmin), nil
 }
 
-func (m *WorkspaceMembershipManager) sendInviteEmail(ctx context.Context, caller Caller, workspaceID uuid.UUID, inviteeEmail, role string) {
+func (m *WorkspaceMembershipManager) sendInviteEmail(ctx context.Context, caller Caller, workspaceID uuid.UUID, inviteeEmail, role, acceptURL string) {
 	workspace, err := m.repo.GetWorkspaceByID(ctx, workspaceID)
 	if err != nil {
 		slog.Default().Warn("failed to load workspace for invite email", "workspace_id", workspaceID, "error", err)
@@ -260,14 +263,13 @@ func (m *WorkspaceMembershipManager) sendInviteEmail(ctx context.Context, caller
 		inviterEmail = "a team member"
 	}
 
-	acceptURL := fmt.Sprintf("%s/dashboard", m.frontendURL)
-
 	if err := m.emailSender.SendInvite(ctx, email.InviteEmail{
-		To:            inviteeEmail,
-		WorkspaceName: workspace.Name,
-		InviterEmail:  inviterEmail,
-		Role:          role,
-		AcceptURL:     acceptURL,
+		To:           inviteeEmail,
+		ResourceName: workspace.Name,
+		ResourceKind: "workspace",
+		InviterEmail: inviterEmail,
+		Role:         role,
+		AcceptURL:    acceptURL,
 	}); err != nil {
 		slog.Default().Warn("failed to send invite email", "to", inviteeEmail, "workspace_id", workspaceID, "error", err)
 	}
@@ -301,6 +303,21 @@ func (m *WorkspaceMembershipManager) authorizeAdmin(ctx context.Context, caller 
 	return ErrForbidden
 }
 
+func (m *WorkspaceMembershipManager) callerCanCopyWorkspaceInviteLinks(ctx context.Context, caller Caller, workspaceID uuid.UUID) bool {
+	if wm, ok := caller.WorkspaceMemberships[workspaceID]; ok && wm.Role == "workspace_admin" {
+		return true
+	}
+	orgID, err := m.repo.GetOrganizationIDByWorkspaceID(ctx, workspaceID)
+	if err != nil {
+		slog.Default().Warn("failed to load organization for invite link visibility", "workspace_id", workspaceID, "error", err)
+		return false
+	}
+	if om, ok := caller.OrganizationMemberships[orgID]; ok && om.Role == "org_admin" {
+		return true
+	}
+	return false
+}
+
 func isRemovingWsAdmin(membership repository.WorkspaceMembershipFullRow, input UpdateWorkspaceMembershipInput) bool {
 	if membership.Role != "workspace_admin" || membership.MembershipStatus != "active" {
 		return false
@@ -328,8 +345,8 @@ func validateWsMembershipTransition(from, to string) error {
 	return ErrInvalidTransition
 }
 
-func wsMembershipRowToResult(row repository.WorkspaceMembershipFullRow) WorkspaceMembershipResult {
-	return WorkspaceMembershipResult{
+func (m *WorkspaceMembershipManager) wsMembershipRowToResult(row repository.WorkspaceMembershipFullRow, includeInviteLink bool) WorkspaceMembershipResult {
+	result := WorkspaceMembershipResult{
 		ID:               row.ID,
 		WorkspaceID:      row.WorkspaceID,
 		OrganizationID:   row.OrganizationID,
@@ -340,6 +357,10 @@ func wsMembershipRowToResult(row repository.WorkspaceMembershipFullRow) Workspac
 		MembershipStatus: row.MembershipStatus,
 		CreatedAt:        row.CreatedAt,
 	}
+	if includeInviteLink && row.MembershipStatus == "invited" {
+		result.AcceptURL = workspaceInviteAcceptURL(m.frontendURL, row.ID)
+	}
+	return result
 }
 
 // --- Handlers ---

--- a/backend/internal/api/workspace_memberships_test.go
+++ b/backend/internal/api/workspace_memberships_test.go
@@ -129,7 +129,7 @@ func TestInviteWorkspaceMember_SendsEmail(t *testing.T) {
 		},
 	}
 
-	_, err := manager.InviteWorkspaceMember(context.Background(), caller, workspaceID, InviteWorkspaceMemberInput{
+	result, err := manager.InviteWorkspaceMember(context.Background(), caller, workspaceID, InviteWorkspaceMemberInput{
 		Email: "invitee@example.com",
 		Role:  "workspace_member",
 	})
@@ -144,14 +144,24 @@ func TestInviteWorkspaceMember_SendsEmail(t *testing.T) {
 	if sent.To != "invitee@example.com" {
 		t.Errorf("email To = %q, want invitee@example.com", sent.To)
 	}
-	if sent.WorkspaceName != "Test Workspace" {
-		t.Errorf("email WorkspaceName = %q, want Test Workspace", sent.WorkspaceName)
+	wantAcceptURL := "https://app.agentclash.dev/invites/workspace/" + result.ID.String()
+	if result.AcceptURL != wantAcceptURL {
+		t.Errorf("result AcceptURL = %q, want %q", result.AcceptURL, wantAcceptURL)
+	}
+	if sent.ResourceName != "Test Workspace" {
+		t.Errorf("email ResourceName = %q, want Test Workspace", sent.ResourceName)
+	}
+	if sent.ResourceKind != "workspace" {
+		t.Errorf("email ResourceKind = %q, want workspace", sent.ResourceKind)
 	}
 	if sent.InviterEmail != "admin@example.com" {
 		t.Errorf("email InviterEmail = %q, want admin@example.com", sent.InviterEmail)
 	}
 	if sent.Role != "workspace_member" {
 		t.Errorf("email Role = %q, want workspace_member", sent.Role)
+	}
+	if sent.AcceptURL != wantAcceptURL {
+		t.Errorf("email AcceptURL = %q, want %q", sent.AcceptURL, wantAcceptURL)
 	}
 }
 
@@ -208,5 +218,56 @@ func TestInviteWorkspaceMember_EmailFailureDoesNotBlockInvite(t *testing.T) {
 	}
 	if len(sender.calls) != 1 {
 		t.Errorf("email should have been attempted, got %d calls", len(sender.calls))
+	}
+}
+
+func TestListWorkspaceMemberships_InviteLinksOnlyForAdmins(t *testing.T) {
+	workspaceID := uuid.New()
+	orgID := uuid.New()
+	membershipID := uuid.New()
+	repo := &fakeWsMembershipRepo{
+		orgID: orgID,
+		memberships: []repository.WorkspaceMembershipFullRow{
+			{
+				ID:               membershipID,
+				WorkspaceID:      workspaceID,
+				OrganizationID:   orgID,
+				UserID:           uuid.New(),
+				Email:            "invitee@example.com",
+				Role:             "workspace_member",
+				MembershipStatus: "invited",
+			},
+		},
+		membershipCount: 1,
+	}
+	manager := NewWorkspaceMembershipManager(repo, &fakeEmailSender{}, "https://app.agentclash.dev")
+
+	memberCaller := Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}
+	memberResult, err := manager.ListWorkspaceMemberships(context.Background(), memberCaller, workspaceID, 50, 0)
+	if err != nil {
+		t.Fatalf("ListWorkspaceMemberships returned error for member: %v", err)
+	}
+	if got := memberResult.Items[0].AcceptURL; got != "" {
+		t.Fatalf("member caller AcceptURL = %q, want empty", got)
+	}
+
+	adminCaller := Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_admin"},
+		},
+	}
+	adminResult, err := manager.ListWorkspaceMemberships(context.Background(), adminCaller, workspaceID, 50, 0)
+	if err != nil {
+		t.Fatalf("ListWorkspaceMemberships returned error for admin: %v", err)
+	}
+	wantAcceptURL := "https://app.agentclash.dev/invites/workspace/" + membershipID.String()
+	if got := adminResult.Items[0].AcceptURL; got != wantAcceptURL {
+		t.Fatalf("admin caller AcceptURL = %q, want %q", got, wantAcceptURL)
 	}
 }

--- a/backend/internal/email/email.go
+++ b/backend/internal/email/email.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"html"
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -16,13 +18,14 @@ type Sender interface {
 	SendInvite(ctx context.Context, input InviteEmail) error
 }
 
-// InviteEmail contains everything needed to send a workspace invitation.
+// InviteEmail contains everything needed to send a membership invitation.
 type InviteEmail struct {
-	To            string
-	WorkspaceName string
-	InviterEmail  string
-	Role          string
-	AcceptURL     string
+	To           string
+	ResourceName string
+	ResourceKind string
+	InviterEmail string
+	Role         string
+	AcceptURL    string
 }
 
 // ResendSender sends emails via the Resend API.
@@ -41,7 +44,7 @@ func NewResendSender(apiKey, fromEmail string) *ResendSender {
 }
 
 func (s *ResendSender) SendInvite(ctx context.Context, input InviteEmail) error {
-	subject := fmt.Sprintf("You've been invited to %s on AgentClash", input.WorkspaceName)
+	subject := fmt.Sprintf("You've been invited to %s on AgentClash", input.ResourceName)
 	html := buildInviteHTML(input)
 
 	body, err := json.Marshal(map[string]any{
@@ -76,10 +79,20 @@ func (s *ResendSender) SendInvite(ctx context.Context, input InviteEmail) error 
 }
 
 func buildInviteHTML(input InviteEmail) string {
+	resourceKind := strings.TrimSpace(input.ResourceKind)
+	if resourceKind == "" {
+		resourceKind = "workspace"
+	}
+	resourceKind = html.EscapeString(resourceKind)
+	resourceName := html.EscapeString(input.ResourceName)
+	inviterEmail := html.EscapeString(input.InviterEmail)
+	role := html.EscapeString(input.Role)
+	acceptURL := html.EscapeString(input.AcceptURL)
+
 	return fmt.Sprintf(`<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:480px;margin:0 auto;padding:32px 0">
   <h2 style="font-size:20px;font-weight:600;margin:0 0 16px">You've been invited to %s</h2>
   <p style="color:#555;font-size:14px;line-height:1.6;margin:0 0 8px">
-    <strong>%s</strong> invited you as <strong>%s</strong> on AgentClash.
+    <strong>%s</strong> invited you to this %s as <strong>%s</strong> on AgentClash.
   </p>
   <p style="color:#555;font-size:14px;line-height:1.6;margin:0 0 24px">
     Click the button below to accept the invitation. This invite expires in 7 days.
@@ -87,16 +100,22 @@ func buildInviteHTML(input InviteEmail) string {
   <a href="%s" style="display:inline-block;background:#000;color:#fff;font-size:14px;font-weight:500;padding:10px 24px;border-radius:6px;text-decoration:none">
     Accept Invitation
   </a>
+  <p style="color:#777;font-size:12px;line-height:1.6;margin:24px 0 0">
+    If the button does not work, copy and paste this link into your browser:
+  </p>
+  <p style="font-size:12px;line-height:1.6;margin:6px 0 0;word-break:break-all">
+    <a href="%s" style="color:#000">%s</a>
+  </p>
   <p style="color:#999;font-size:12px;margin:24px 0 0">
     If you didn't expect this invitation, you can ignore this email.
   </p>
-</div>`, input.WorkspaceName, input.InviterEmail, input.Role, input.AcceptURL)
+</div>`, resourceName, inviterEmail, resourceKind, role, acceptURL, acceptURL, acceptURL)
 }
 
 // NoopSender logs invite emails without sending them.
 type NoopSender struct{}
 
 func (NoopSender) SendInvite(_ context.Context, input InviteEmail) error {
-	slog.Default().Info("invite email (noop)", "to", input.To, "workspace", input.WorkspaceName, "role", input.Role, "accept_url", input.AcceptURL)
+	slog.Default().Info("invite email (noop)", "to", input.To, "resource_kind", input.ResourceKind, "resource", input.ResourceName, "role", input.Role, "accept_url", input.AcceptURL)
 	return nil
 }

--- a/backend/internal/email/email_test.go
+++ b/backend/internal/email/email_test.go
@@ -8,11 +8,12 @@ import (
 func TestNoopSenderDoesNotError(t *testing.T) {
 	sender := NoopSender{}
 	err := sender.SendInvite(context.Background(), InviteEmail{
-		To:            "test@example.com",
-		WorkspaceName: "My Workspace",
-		InviterEmail:  "admin@example.com",
-		Role:          "workspace_member",
-		AcceptURL:     "https://app.agentclash.dev/dashboard",
+		To:           "test@example.com",
+		ResourceName: "My Workspace",
+		ResourceKind: "workspace",
+		InviterEmail: "admin@example.com",
+		Role:         "workspace_member",
+		AcceptURL:    "https://app.agentclash.dev/invites/workspace/membership-id",
 	})
 	if err != nil {
 		t.Fatalf("NoopSender.SendInvite returned error: %v", err)
@@ -21,14 +22,15 @@ func TestNoopSenderDoesNotError(t *testing.T) {
 
 func TestBuildInviteHTML_ContainsKeyFields(t *testing.T) {
 	html := buildInviteHTML(InviteEmail{
-		To:            "test@example.com",
-		WorkspaceName: "Eval Team",
-		InviterEmail:  "alice@example.com",
-		Role:          "workspace_admin",
-		AcceptURL:     "https://app.agentclash.dev/dashboard",
+		To:           "test@example.com",
+		ResourceName: "Eval Team",
+		ResourceKind: "workspace",
+		InviterEmail: "alice@example.com",
+		Role:         "workspace_admin",
+		AcceptURL:    "https://app.agentclash.dev/invites/workspace/membership-id",
 	})
 
-	for _, want := range []string{"Eval Team", "alice@example.com", "workspace_admin", "https://app.agentclash.dev/dashboard", "7 days"} {
+	for _, want := range []string{"Eval Team", "alice@example.com", "workspace_admin", "https://app.agentclash.dev/invites/workspace/membership-id", "copy and paste", "7 days"} {
 		if !contains(html, want) {
 			t.Errorf("invite HTML missing %q", want)
 		}

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -3502,7 +3502,7 @@ func (r *Repository) GetOrgMembershipByID(ctx context.Context, membershipID uuid
 		JOIN users u ON u.id = om.user_id
 		WHERE om.id = $1
 	`, membershipID).Scan(&m.ID, &m.OrganizationID, &m.UserID, &m.Email, &m.DisplayName,
-		&m.Role, &m.MembershipStatus, &m.CreatedAt)
+		&m.Role, &m.MembershipStatus, &m.CreatedAt, &m.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return OrgMembershipFullRow{}, ErrMembershipNotFound

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -1120,7 +1120,7 @@ paths:
               $ref: "#/components/schemas/InviteOrgMemberRequest"
       responses:
         "201":
-          description: Member invited
+          description: Member invited. Pending invitations include accept_url for copy-link fallback.
           content:
             application/json:
               schema:
@@ -1295,7 +1295,7 @@ paths:
               $ref: "#/components/schemas/InviteWorkspaceMemberRequest"
       responses:
         "201":
-          description: Member invited
+          description: Member invited. Pending invitations include accept_url for copy-link fallback.
           content:
             application/json:
               schema:
@@ -5419,6 +5419,10 @@ components:
         created_at:
           type: string
           format: date-time
+        accept_url:
+          type: string
+          format: uri
+          description: Present while the membership is invited.
 
     ListOrgMembershipsResponse:
       type: object
@@ -5486,6 +5490,10 @@ components:
         created_at:
           type: string
           format: date-time
+        accept_url:
+          type: string
+          format: uri
+          description: Present while the membership is invited.
 
     ListWorkspaceMembershipsResponse:
       type: object

--- a/web/src/app/(org)/orgs/[orgSlug]/members/invite-member-dialog.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/members/invite-member-dialog.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";
-import type { OrgRole } from "@/lib/api/types";
+import type { OrgMember, OrgRole } from "@/lib/api/types";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ToggleGroup } from "@/components/ui/toggle-group";
@@ -17,7 +17,7 @@ import {
   DialogFooter,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { UserPlus, Loader2 } from "lucide-react";
+import { Copy, UserPlus, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 
 interface InviteMemberDialogProps {
@@ -35,6 +35,8 @@ export function InviteMemberDialog({
   const [role, setRole] = useState<OrgRole>("org_member");
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string>();
+  const [inviteLink, setInviteLink] = useState("");
+  const [invitedEmail, setInvitedEmail] = useState("");
 
   function handleOpenChange(next: boolean) {
     setOpen(next);
@@ -42,24 +44,34 @@ export function InviteMemberDialog({
       setEmail("");
       setRole("org_member");
       setError(undefined);
+      setInviteLink("");
+      setInvitedEmail("");
     }
   }
 
   async function handleInvite() {
-    if (!email.trim()) return;
+    const trimmedEmail = email.trim();
+    if (!trimmedEmail) return;
     setError(undefined);
     setSending(true);
     try {
       const token = await getAccessToken();
       if (!token) return;
       const api = createApiClient(token);
-      await api.post(`/v1/organizations/${orgId}/memberships`, {
-        email: email.trim(),
-        role,
-      });
-      toast.success(`Invited ${email.trim()}`);
-      setOpen(false);
+      const invited = await api.post<OrgMember>(
+        `/v1/organizations/${orgId}/memberships`,
+        {
+          email: trimmedEmail,
+          role,
+        },
+      );
+      toast.success(`Invited ${trimmedEmail}`);
+      setInvitedEmail(trimmedEmail);
+      setInviteLink(invited.accept_url ?? "");
       onInvited();
+      if (!invited.accept_url) {
+        setOpen(false);
+      }
     } catch (err) {
       setError(
         err instanceof ApiError ? err.message : "Failed to send invite",
@@ -69,13 +81,33 @@ export function InviteMemberDialog({
     }
   }
 
+  async function handleCopyInviteLink() {
+    if (!inviteLink) return;
+    try {
+      await navigator.clipboard.writeText(inviteLink);
+      toast.success("Copied invite link");
+    } catch {
+      setError(
+        "Could not copy the invite link. Select the link and copy it manually.",
+      );
+    }
+  }
+
+  function handleInviteAnother() {
+    setEmail("");
+    setRole("org_member");
+    setInviteLink("");
+    setInvitedEmail("");
+    setError(undefined);
+  }
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger render={<Button size="sm" />}>
         <UserPlus className="size-4 mr-1.5" />
         Invite Member
       </DialogTrigger>
-      <DialogContent className="sm:max-w-sm">
+      <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Invite Member</DialogTitle>
           <DialogDescription>
@@ -85,34 +117,77 @@ export function InviteMemberDialog({
         </DialogHeader>
 
         <div className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium mb-1.5">Email</label>
-            <Input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              disabled={sending}
-              placeholder="colleague@company.com"
-            />
-          </div>
+          {inviteLink ? (
+            <div className="space-y-3">
+              <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-sm">
+                Invite sent to{" "}
+                <span className="font-medium text-foreground">
+                  {invitedEmail}
+                </span>
+                .
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1.5">
+                  Invite link
+                </label>
+                <div className="flex gap-2">
+                  <Input
+                    readOnly
+                    value={inviteLink}
+                    className="font-mono text-xs"
+                    onFocus={(event) => event.currentTarget.select()}
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    onClick={handleCopyInviteLink}
+                    aria-label="Copy invite link"
+                  >
+                    <Copy className="size-4" />
+                  </Button>
+                </div>
+                <p className="mt-1.5 text-xs text-muted-foreground">
+                  Share this if the email does not arrive.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <>
+              <div>
+                <label className="block text-sm font-medium mb-1.5">
+                  Email
+                </label>
+                <Input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  disabled={sending}
+                  placeholder="colleague@company.com"
+                />
+              </div>
 
-          <div>
-            <label className="block text-sm font-medium mb-1.5">Role</label>
-            <ToggleGroup
-              options={[
-                { value: "org_member" as const, label: "Member" },
-                { value: "org_admin" as const, label: "Admin" },
-              ]}
-              value={role}
-              onChange={setRole}
-              disabled={sending}
-            />
-            <p className="mt-1 text-xs text-muted-foreground">
-              {role === "org_admin"
-                ? "Admins can manage members, workspaces, and settings."
-                : "Members can access assigned workspaces."}
-            </p>
-          </div>
+              <div>
+                <label className="block text-sm font-medium mb-1.5">
+                  Role
+                </label>
+                <ToggleGroup
+                  options={[
+                    { value: "org_member" as const, label: "Member" },
+                    { value: "org_admin" as const, label: "Admin" },
+                  ]}
+                  value={role}
+                  onChange={setRole}
+                  disabled={sending}
+                />
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {role === "org_admin"
+                    ? "Admins can manage members, workspaces, and settings."
+                    : "Members can access assigned workspaces."}
+                </p>
+              </div>
+            </>
+          )}
 
           {error && (
             <div className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2 text-xs text-destructive">
@@ -122,15 +197,24 @@ export function InviteMemberDialog({
         </div>
 
         <DialogFooter>
-          <Button onClick={handleInvite} disabled={!email.trim() || sending}>
-            {sending && (
-              <Loader2
-                data-icon="inline-start"
-                className="size-4 animate-spin"
-              />
-            )}
-            {sending ? "Inviting..." : "Send Invite"}
-          </Button>
+          {inviteLink ? (
+            <>
+              <Button variant="outline" onClick={handleInviteAnother}>
+                Invite another
+              </Button>
+              <Button onClick={() => setOpen(false)}>Done</Button>
+            </>
+          ) : (
+            <Button onClick={handleInvite} disabled={!email.trim() || sending}>
+              {sending && (
+                <Loader2
+                  data-icon="inline-start"
+                  className="size-4 animate-spin"
+                />
+              )}
+              {sending ? "Inviting..." : "Send Invite"}
+            </Button>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/web/src/app/(org)/orgs/[orgSlug]/members/org-members-client.tsx
+++ b/web/src/app/(org)/orgs/[orgSlug]/members/org-members-client.tsx
@@ -74,9 +74,14 @@ function getMemberActions(
   isLastAdmin: boolean,
   onChangeRole: (role: OrgRole) => void,
   onChangeStatus: (status: OrgMembershipStatus) => void,
+  onCopyInviteLink: () => void,
 ): MemberAction[] {
   const actions: MemberAction[] = [];
   const isArchived = member.membership_status === "archived";
+
+  if (member.membership_status === "invited" && member.accept_url) {
+    actions.push({ label: "Copy Invite Link", onClick: onCopyInviteLink });
+  }
 
   // Role changes
   if (!isArchived) {
@@ -208,6 +213,16 @@ export function OrgMembersClient({
     }
   }
 
+  async function handleCopyInviteLink(member: OrgMember) {
+    if (!member.accept_url) return;
+    try {
+      await navigator.clipboard.writeText(member.accept_url);
+      toast.success(`Copied invite link for ${member.email}`);
+    } catch {
+      toast.error("Failed to copy invite link");
+    }
+  }
+
   function canManageMember(member: OrgMember): boolean {
     if (!isAdmin) return false;
     if (member.user_id === currentUserId) return false;
@@ -268,6 +283,7 @@ export function OrgMembersClient({
                       isLastAdmin,
                       (role) => handleChangeRole(member, role),
                       (status) => handleChangeStatus(member, status),
+                      () => handleCopyInviteLink(member),
                     )
                   : [];
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/settings/members/ws-invite-member-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/settings/members/ws-invite-member-dialog.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";
-import type { WorkspaceRole } from "@/lib/api/types";
+import type { WorkspaceMember, WorkspaceRole } from "@/lib/api/types";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ToggleGroup } from "@/components/ui/toggle-group";
@@ -17,7 +17,7 @@ import {
   DialogFooter,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { UserPlus, Loader2 } from "lucide-react";
+import { Copy, UserPlus, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 
 const ROLE_OPTIONS: { value: WorkspaceRole; label: string }[] = [
@@ -47,6 +47,8 @@ export function WsInviteMemberDialog({
   const [role, setRole] = useState<WorkspaceRole>("workspace_member");
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string>();
+  const [inviteLink, setInviteLink] = useState("");
+  const [invitedEmail, setInvitedEmail] = useState("");
 
   function handleOpenChange(next: boolean) {
     setOpen(next);
@@ -54,24 +56,34 @@ export function WsInviteMemberDialog({
       setEmail("");
       setRole("workspace_member");
       setError(undefined);
+      setInviteLink("");
+      setInvitedEmail("");
     }
   }
 
   async function handleInvite() {
-    if (!email.trim()) return;
+    const trimmedEmail = email.trim();
+    if (!trimmedEmail) return;
     setError(undefined);
     setSending(true);
     try {
       const token = await getAccessToken();
       if (!token) return;
       const api = createApiClient(token);
-      await api.post(`/v1/workspaces/${workspaceId}/memberships`, {
-        email: email.trim(),
-        role,
-      });
-      toast.success(`Invited ${email.trim()}`);
-      setOpen(false);
+      const invited = await api.post<WorkspaceMember>(
+        `/v1/workspaces/${workspaceId}/memberships`,
+        {
+          email: trimmedEmail,
+          role,
+        },
+      );
+      toast.success(`Invited ${trimmedEmail}`);
+      setInvitedEmail(trimmedEmail);
+      setInviteLink(invited.accept_url ?? "");
       onInvited();
+      if (!invited.accept_url) {
+        setOpen(false);
+      }
     } catch (err) {
       setError(
         err instanceof ApiError ? err.message : "Failed to send invite",
@@ -81,13 +93,33 @@ export function WsInviteMemberDialog({
     }
   }
 
+  async function handleCopyInviteLink() {
+    if (!inviteLink) return;
+    try {
+      await navigator.clipboard.writeText(inviteLink);
+      toast.success("Copied invite link");
+    } catch {
+      setError(
+        "Could not copy the invite link. Select the link and copy it manually.",
+      );
+    }
+  }
+
+  function handleInviteAnother() {
+    setEmail("");
+    setRole("workspace_member");
+    setInviteLink("");
+    setInvitedEmail("");
+    setError(undefined);
+  }
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger render={<Button size="sm" />}>
         <UserPlus className="size-4 mr-1.5" />
         Invite Member
       </DialogTrigger>
-      <DialogContent className="sm:max-w-sm">
+      <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Invite Workspace Member</DialogTitle>
           <DialogDescription>
@@ -97,29 +129,72 @@ export function WsInviteMemberDialog({
         </DialogHeader>
 
         <div className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium mb-1.5">Email</label>
-            <Input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              disabled={sending}
-              placeholder="colleague@company.com"
-            />
-          </div>
+          {inviteLink ? (
+            <div className="space-y-3">
+              <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-sm">
+                Invite sent to{" "}
+                <span className="font-medium text-foreground">
+                  {invitedEmail}
+                </span>
+                .
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1.5">
+                  Invite link
+                </label>
+                <div className="flex gap-2">
+                  <Input
+                    readOnly
+                    value={inviteLink}
+                    className="font-mono text-xs"
+                    onFocus={(event) => event.currentTarget.select()}
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    onClick={handleCopyInviteLink}
+                    aria-label="Copy invite link"
+                  >
+                    <Copy className="size-4" />
+                  </Button>
+                </div>
+                <p className="mt-1.5 text-xs text-muted-foreground">
+                  Share this if the email does not arrive.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <>
+              <div>
+                <label className="block text-sm font-medium mb-1.5">
+                  Email
+                </label>
+                <Input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  disabled={sending}
+                  placeholder="colleague@company.com"
+                />
+              </div>
 
-          <div>
-            <label className="block text-sm font-medium mb-1.5">Role</label>
-            <ToggleGroup
-              options={ROLE_OPTIONS}
-              value={role}
-              onChange={setRole}
-              disabled={sending}
-            />
-            <p className="mt-1 text-xs text-muted-foreground">
-              {ROLE_DESCRIPTIONS[role]}
-            </p>
-          </div>
+              <div>
+                <label className="block text-sm font-medium mb-1.5">
+                  Role
+                </label>
+                <ToggleGroup
+                  options={ROLE_OPTIONS}
+                  value={role}
+                  onChange={setRole}
+                  disabled={sending}
+                />
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {ROLE_DESCRIPTIONS[role]}
+                </p>
+              </div>
+            </>
+          )}
 
           {error && (
             <div className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2 text-xs text-destructive">
@@ -129,15 +204,24 @@ export function WsInviteMemberDialog({
         </div>
 
         <DialogFooter>
-          <Button onClick={handleInvite} disabled={!email.trim() || sending}>
-            {sending && (
-              <Loader2
-                data-icon="inline-start"
-                className="size-4 animate-spin"
-              />
-            )}
-            {sending ? "Inviting..." : "Send Invite"}
-          </Button>
+          {inviteLink ? (
+            <>
+              <Button variant="outline" onClick={handleInviteAnother}>
+                Invite another
+              </Button>
+              <Button onClick={() => setOpen(false)}>Done</Button>
+            </>
+          ) : (
+            <Button onClick={handleInvite} disabled={!email.trim() || sending}>
+              {sending && (
+                <Loader2
+                  data-icon="inline-start"
+                  className="size-4 animate-spin"
+                />
+              )}
+              {sending ? "Inviting..." : "Send Invite"}
+            </Button>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/settings/members/ws-members-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/settings/members/ws-members-client.tsx
@@ -86,9 +86,14 @@ function getMemberActions(
   isLastAdmin: boolean,
   onChangeRole: (role: WorkspaceRole) => void,
   onChangeStatus: (status: OrgMembershipStatus) => void,
+  onCopyInviteLink: () => void,
 ): MemberAction[] {
   const actions: MemberAction[] = [];
   const isArchived = member.membership_status === "archived";
+
+  if (member.membership_status === "invited" && member.accept_url) {
+    actions.push({ label: "Copy Invite Link", onClick: onCopyInviteLink });
+  }
 
   if (!isArchived) {
     if (member.role !== "workspace_admin") {
@@ -247,6 +252,16 @@ export function WsMembersClient({
     }
   }
 
+  async function handleCopyInviteLink(member: WorkspaceMember) {
+    if (!member.accept_url) return;
+    try {
+      await navigator.clipboard.writeText(member.accept_url);
+      toast.success(`Copied invite link for ${member.email}`);
+    } catch {
+      toast.error("Failed to copy invite link");
+    }
+  }
+
   function canManageMember(member: WorkspaceMember): boolean {
     if (!isAdmin) return false;
     if (member.user_id === currentUserId) return false;
@@ -310,6 +325,7 @@ export function WsMembersClient({
                       isLastAdmin,
                       (role) => handleChangeRole(member, role),
                       (status) => handleChangeStatus(member, status),
+                      () => handleCopyInviteLink(member),
                     )
                   : [];
 

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -1,14 +1,14 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { redirect } from "next/navigation";
 import { createApiClient } from "@/lib/api/client";
-import type { SessionResponse } from "@/lib/api/types";
+import type { SessionResponse, UserMeResponse } from "@/lib/api/types";
 
 /**
  * Route guard: after login the callback sends users here.
  * We check their session and redirect:
  *   - No org memberships → /onboard (first-time user)
  *   - Has workspace memberships → /workspaces/{first workspace id}
- *   - Has org but no workspace → /onboard (shouldn't happen, but safe fallback)
+ *   - Has org but no workspace → /orgs/{first org slug}/workspaces
  */
 export default async function DashboardPage() {
   const { user, accessToken } = await withAuth();
@@ -40,7 +40,9 @@ export default async function DashboardPage() {
             </pre>
           )}
           <p className="text-xs text-muted-foreground mb-4">
-            token: {accessToken ? `yes (${accessToken.length} chars)` : "no"} | api: {process.env.API_URL || process.env.NEXT_PUBLIC_API_URL || "unset"}
+            token: {accessToken ? `yes (${accessToken.length} chars)` : "no"}{" "}
+            | api:{" "}
+            {process.env.API_URL || process.env.NEXT_PUBLIC_API_URL || "unset"}
           </p>
           <a
             href="/dashboard"
@@ -54,17 +56,28 @@ export default async function DashboardPage() {
   }
 
   // Redirects must be outside try/catch — Next.js redirect() throws internally.
-  const isOnboarded = session.organization_memberships.some(
-    (m) => m.role === "org_admin",
-  );
-
-  if (!isOnboarded) {
+  if (session.organization_memberships.length === 0) {
     redirect("/onboard");
   }
 
   const firstWorkspace = session.workspace_memberships[0];
   if (firstWorkspace) {
     redirect(`/workspaces/${firstWorkspace.workspace_id}`);
+  }
+
+  let orgRedirectTarget: string | null = null;
+  try {
+    const api = createApiClient(accessToken);
+    const userMe = await api.get<UserMeResponse>("/v1/users/me");
+    const firstOrg = userMe.organizations[0];
+    if (firstOrg) {
+      orgRedirectTarget = `/orgs/${firstOrg.slug}/workspaces`;
+    }
+  } catch {
+    // Fall through to onboarding if the richer profile cannot be loaded.
+  }
+  if (orgRedirectTarget) {
+    redirect(orgRedirectTarget);
   }
 
   redirect("/onboard");

--- a/web/src/app/invites/invite-error.tsx
+++ b/web/src/app/invites/invite-error.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+
+interface InviteErrorProps {
+  title: string;
+  message: string;
+}
+
+export function InviteError({ title, message }: InviteErrorProps) {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background px-6 text-foreground">
+      <div className="w-full max-w-sm rounded-lg border border-border bg-card p-6 text-center">
+        <h1 className="text-base font-semibold">{title}</h1>
+        <p className="mt-2 text-sm text-muted-foreground">{message}</p>
+        <Link
+          href="/dashboard"
+          className="mt-5 inline-flex h-8 items-center justify-center rounded-lg bg-primary px-3 text-sm font-medium text-primary-foreground"
+        >
+          Go to dashboard
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/web/src/app/invites/organization/[membershipId]/page.tsx
+++ b/web/src/app/invites/organization/[membershipId]/page.tsx
@@ -1,0 +1,54 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { redirect } from "next/navigation";
+import { createApiClient } from "@/lib/api/client";
+import type { OrgMember, UserMeResponse } from "@/lib/api/types";
+import { InviteError } from "../../invite-error";
+
+export default async function OrganizationInvitePage({
+  params,
+}: {
+  params: Promise<{ membershipId: string }>;
+}) {
+  const { membershipId } = await params;
+  const returnTo = `/invites/organization/${membershipId}`;
+  const { user, accessToken } = await withAuth();
+
+  if (!user) {
+    redirect(`/auth/login?returnTo=${encodeURIComponent(returnTo)}`);
+  }
+
+  const api = createApiClient(accessToken);
+  let accepted: OrgMember;
+  try {
+    accepted = await api.patch<OrgMember>(
+      `/v1/organization-memberships/${membershipId}`,
+      { status: "active" },
+    );
+  } catch (err) {
+    return (
+      <InviteError
+        title="Unable to accept invite"
+        message={
+          err instanceof Error
+            ? err.message
+            : "The invite may have expired or belongs to another account."
+        }
+      />
+    );
+  }
+
+  let redirectTarget = "/dashboard";
+  try {
+    const userMe = await api.get<UserMeResponse>("/v1/users/me");
+    const org = userMe.organizations.find(
+      (item) => item.id === accepted.organization_id,
+    );
+    if (org) {
+      redirectTarget = `/orgs/${org.slug}/workspaces`;
+    }
+  } catch {
+    // The invite is already accepted; fall back to dashboard if lookup fails.
+  }
+
+  redirect(redirectTarget);
+}

--- a/web/src/app/invites/workspace/[membershipId]/page.tsx
+++ b/web/src/app/invites/workspace/[membershipId]/page.tsx
@@ -1,0 +1,42 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { redirect } from "next/navigation";
+import { createApiClient } from "@/lib/api/client";
+import type { WorkspaceMember } from "@/lib/api/types";
+import { InviteError } from "../../invite-error";
+
+export default async function WorkspaceInvitePage({
+  params,
+}: {
+  params: Promise<{ membershipId: string }>;
+}) {
+  const { membershipId } = await params;
+  const returnTo = `/invites/workspace/${membershipId}`;
+  const { user, accessToken } = await withAuth();
+
+  if (!user) {
+    redirect(`/auth/login?returnTo=${encodeURIComponent(returnTo)}`);
+  }
+
+  let redirectTarget = "/dashboard";
+  try {
+    const api = createApiClient(accessToken);
+    const accepted = await api.patch<WorkspaceMember>(
+      `/v1/workspace-memberships/${membershipId}`,
+      { status: "active" },
+    );
+    redirectTarget = `/workspaces/${accepted.workspace_id}`;
+  } catch (err) {
+    return (
+      <InviteError
+        title="Unable to accept invite"
+        message={
+          err instanceof Error
+            ? err.message
+            : "The invite may have expired or belongs to another account."
+        }
+      />
+    );
+  }
+
+  redirect(redirectTarget);
+}

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -109,6 +109,7 @@ export interface OrgMember {
   membership_status: OrgMembershipStatus;
   created_at: string;
   updated_at?: string;
+  accept_url?: string;
 }
 
 /** POST /v1/organizations/{id}/memberships request */
@@ -164,6 +165,7 @@ export interface WorkspaceMember {
   membership_status: OrgMembershipStatus; // same enum: invited/active/suspended/archived
   created_at: string;
   updated_at?: string;
+  accept_url?: string;
 }
 
 // --- Agent Builds ---

--- a/web/src/lib/auth/__tests__/return-to.test.ts
+++ b/web/src/lib/auth/__tests__/return-to.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildInviteReturnTo,
   buildGitHubSetupReturnTo,
   buildDeviceReturnTo,
   normalizeDeviceUserCode,
@@ -29,6 +30,28 @@ describe("sanitizeReturnTo", () => {
       "/github/setup?installation_id=42&state=abc_DEF-123.sig_456&setup_action=install",
     );
   });
+
+  it("preserves invite accept routes", () => {
+    const membershipId = "018f9f2e-65cb-7d0b-9c98-0df2ce4076d8";
+
+    expect(sanitizeReturnTo(`/invites/organization/${membershipId}`)).toBe(
+      `/invites/organization/${membershipId}`,
+    );
+    expect(sanitizeReturnTo(`/invites/workspace/${membershipId}`)).toBe(
+      `/invites/workspace/${membershipId}`,
+    );
+  });
+
+  it("rejects malformed invite accept routes", () => {
+    expect(sanitizeReturnTo("/invites/organization/not-a-uuid")).toBe(
+      "/dashboard",
+    );
+    expect(
+      sanitizeReturnTo(
+        "/invites/workspace/018f9f2e-65cb-7d0b-9c98-0df2ce4076d8/extra",
+      ),
+    ).toBe("/dashboard");
+  });
 });
 
 describe("github setup return-to helpers", () => {
@@ -51,5 +74,18 @@ describe("device return-to helpers", () => {
       "/auth/device?user_code=ABCD-1234",
     );
     expect(buildDeviceReturnTo("")).toBe("/auth/device");
+  });
+});
+
+describe("invite return-to helpers", () => {
+  it("builds safe invite return paths", () => {
+    const membershipId = "018f9f2e-65cb-7d0b-9c98-0df2ce4076d8";
+
+    expect(
+      buildInviteReturnTo("organization", `/invites/organization/${membershipId}`),
+    ).toBe(`/invites/organization/${membershipId}`);
+    expect(buildInviteReturnTo("workspace", "/invites/workspace/nope")).toBe(
+      "/dashboard",
+    );
   });
 });

--- a/web/src/lib/auth/return-to.ts
+++ b/web/src/lib/auth/return-to.ts
@@ -1,6 +1,10 @@
 const DEFAULT_RETURN_TO = "/dashboard";
 const DEVICE_PATH = "/auth/device";
 const GITHUB_SETUP_PATH = "/github/setup";
+const INVITE_ORG_PATH_PREFIX = "/invites/organization/";
+const INVITE_WORKSPACE_PATH_PREFIX = "/invites/workspace/";
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const ALLOWED_RETURN_PATHS = new Set([
   DEFAULT_RETURN_TO,
   DEVICE_PATH,
@@ -24,6 +28,14 @@ export function sanitizeReturnTo(raw: string | null | undefined): string {
     return DEFAULT_RETURN_TO;
   }
 
+  if (parsed.pathname.startsWith(INVITE_ORG_PATH_PREFIX)) {
+    return buildInviteReturnTo("organization", parsed.pathname);
+  }
+
+  if (parsed.pathname.startsWith(INVITE_WORKSPACE_PATH_PREFIX)) {
+    return buildInviteReturnTo("workspace", parsed.pathname);
+  }
+
   if (!ALLOWED_RETURN_PATHS.has(parsed.pathname)) {
     return DEFAULT_RETURN_TO;
   }
@@ -37,6 +49,24 @@ export function sanitizeReturnTo(raw: string | null | undefined): string {
   }
 
   return DEFAULT_RETURN_TO;
+}
+
+export function buildInviteReturnTo(
+  inviteType: "organization" | "workspace",
+  pathname: string,
+): string {
+  const prefix =
+    inviteType === "organization"
+      ? INVITE_ORG_PATH_PREFIX
+      : INVITE_WORKSPACE_PATH_PREFIX;
+  if (!pathname.startsWith(prefix)) {
+    return DEFAULT_RETURN_TO;
+  }
+  const membershipId = pathname.slice(prefix.length);
+  if (!UUID_PATTERN.test(membershipId)) {
+    return DEFAULT_RETURN_TO;
+  }
+  return `${prefix}${membershipId}`;
 }
 
 export function buildGitHubSetupReturnTo(searchParams: URLSearchParams): string {


### PR DESCRIPTION
## Summary
- Add real organization and workspace invite accept links, including copyable fallback links in invite dialogs and member lists for admins.
- Send organization invite emails and update workspace invite emails to point at invite acceptance routes instead of `/dashboard`.
- Add authenticated invite acceptance pages that preserve `returnTo` through login and redirect accepted users to the right workspace or organization area.
- Fix org membership acceptance by scanning `updated_at` from `GetOrgMembershipByID`, and avoid returning invite links to non-admin list callers.

## Root Cause
- Organization invites had no email send path.
- Workspace invite emails pointed at the dashboard, so there was no direct accept action.
- The org membership lookup selected `updated_at` but did not scan it, which could break invite acceptance.
- The UI offered no copy-link fallback when delivery failed or email was missed.

## Validation
- `cd backend && go test ./internal/api ./internal/email`
- `cd web && npm test -- --run src/lib/auth/__tests__/return-to.test.ts`
- `cd web && npm run lint`
- `cd web && npx tsc --noEmit`
- `git diff --check`
