### PR TITLE
feat(cli): add prompt-eval remote preflight

### DIFF
--- a/cli/cmd/prompt_eval.go
+++ b/cli/cmd/prompt_eval.go
@@ -31,6 +31,8 @@ func init() {
 	promptEvalInitCmd.Flags().String("name", "", "Prompt eval name (defaults from the file name)")
 
 	promptEvalValidateCmd.Flags().Int("max-cases", 100, "Maximum model x test cases allowed before launch")
+	promptEvalValidateCmd.Flags().Bool("remote", false, "Validate referenced AgentClash workspace resources without creating them")
+	promptEvalValidateCmd.Flags().Bool("ci", false, "Apply CI-safe validation rules")
 }
 
 var promptEvalCmd = &cobra.Command{
@@ -91,7 +93,16 @@ var promptEvalValidateCmd = &cobra.Command{
 			path = args[0]
 		}
 		maxCases, _ := cmd.Flags().GetInt("max-cases")
-		result := validatePromptEvalFile(path, maxCases)
+		remote, _ := cmd.Flags().GetBool("remote")
+		ciMode, _ := cmd.Flags().GetBool("ci")
+		cfg, result := validatePromptEvalFileWithConfig(path, maxCases)
+		if result.Valid && remote {
+			validatePromptEvalRemote(cmd, rc, cfg, ciMode, &result)
+			result.Valid = len(result.Errors) == 0
+			if !result.Valid {
+				result.ExitCode = promptEvalExitInvalid
+			}
+		}
 		if rc.Output.IsStructured() {
 			if err := rc.Output.PrintRaw(result); err != nil {
 				return err
@@ -148,17 +159,50 @@ type promptEvalThresholds struct {
 }
 
 type promptEvalValidationResult struct {
-	SchemaVersion       int      `json:"schemaVersion" yaml:"schemaVersion"`
-	Path                string   `json:"path" yaml:"path"`
-	Valid               bool     `json:"valid" yaml:"valid"`
-	Errors              []string `json:"errors,omitempty" yaml:"errors,omitempty"`
-	Warnings            []string `json:"warnings,omitempty" yaml:"warnings,omitempty"`
-	ModelCount          int      `json:"model_count" yaml:"model_count"`
-	TestCount           int      `json:"test_count" yaml:"test_count"`
-	CaseCount           int      `json:"case_count" yaml:"case_count"`
-	MaxCases            int      `json:"max_cases" yaml:"max_cases"`
-	AssertionSignatures []string `json:"assertion_signatures" yaml:"assertion_signatures"`
-	ExitCode            int      `json:"exit_code" yaml:"exit_code"`
+	SchemaVersion       int                         `json:"schemaVersion" yaml:"schemaVersion"`
+	Path                string                      `json:"path" yaml:"path"`
+	Valid               bool                        `json:"valid" yaml:"valid"`
+	Errors              []string                    `json:"errors,omitempty" yaml:"errors,omitempty"`
+	Warnings            []string                    `json:"warnings,omitempty" yaml:"warnings,omitempty"`
+	ModelCount          int                         `json:"model_count" yaml:"model_count"`
+	TestCount           int                         `json:"test_count" yaml:"test_count"`
+	CaseCount           int                         `json:"case_count" yaml:"case_count"`
+	MaxCases            int                         `json:"max_cases" yaml:"max_cases"`
+	AssertionSignatures []string                    `json:"assertion_signatures" yaml:"assertion_signatures"`
+	Remote              *promptEvalRemoteValidation `json:"remote,omitempty" yaml:"remote,omitempty"`
+	ExitCode            int                         `json:"exit_code" yaml:"exit_code"`
+}
+
+type promptEvalRemoteValidation struct {
+	WorkspaceID string                       `json:"workspace_id" yaml:"workspace_id"`
+	Models      []promptEvalRemoteModel      `json:"models,omitempty" yaml:"models,omitempty"`
+	Playgrounds []promptEvalRemotePlayground `json:"playgrounds,omitempty" yaml:"playgrounds,omitempty"`
+	DryRun      promptEvalRemoteDryRun       `json:"dry_run" yaml:"dry_run"`
+}
+
+type promptEvalRemoteModel struct {
+	Alias             string `json:"alias,omitempty" yaml:"alias,omitempty"`
+	ModelAliasID      string `json:"model_alias_id" yaml:"model_alias_id"`
+	ProviderAccountID string `json:"provider_account_id" yaml:"provider_account_id"`
+}
+
+type promptEvalRemotePlayground struct {
+	Name         string `json:"name" yaml:"name"`
+	Signature    string `json:"signature" yaml:"signature"`
+	PlaygroundID string `json:"playground_id,omitempty" yaml:"playground_id,omitempty"`
+	TestsCreate  int    `json:"tests_create" yaml:"tests_create"`
+	TestsUpdate  int    `json:"tests_update" yaml:"tests_update"`
+	TestsNoop    int    `json:"tests_noop" yaml:"tests_noop"`
+	TestsOrphan  int    `json:"tests_orphan" yaml:"tests_orphan"`
+}
+
+type promptEvalRemoteDryRun struct {
+	PlaygroundsCreate int `json:"playgrounds_create" yaml:"playgrounds_create"`
+	PlaygroundsReuse  int `json:"playgrounds_reuse" yaml:"playgrounds_reuse"`
+	TestsCreate       int `json:"tests_create" yaml:"tests_create"`
+	TestsUpdate       int `json:"tests_update" yaml:"tests_update"`
+	TestsNoop         int `json:"tests_noop" yaml:"tests_noop"`
+	TestsOrphan       int `json:"tests_orphan" yaml:"tests_orphan"`
 }
 
 func buildPromptEvalScaffold(name string) ([]byte, error) {
@@ -186,6 +230,11 @@ Reply to: {{input}}
 }
 
 func validatePromptEvalFile(path string, maxCases int) promptEvalValidationResult {
+	_, result := validatePromptEvalFileWithConfig(path, maxCases)
+	return result
+}
+
+func validatePromptEvalFileWithConfig(path string, maxCases int) (promptEvalConfig, promptEvalValidationResult) {
 	result := promptEvalValidationResult{
 		SchemaVersion:       promptEvalSchemaVersion,
 		Path:                path,
@@ -198,7 +247,7 @@ func validatePromptEvalFile(path string, maxCases int) promptEvalValidationResul
 		result.Valid = false
 		result.Errors = append(result.Errors, fmt.Sprintf("reading file: %v", err))
 		result.ExitCode = promptEvalExitInvalid
-		return result
+		return promptEvalConfig{}, result
 	}
 	var cfg promptEvalConfig
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
@@ -207,7 +256,7 @@ func validatePromptEvalFile(path string, maxCases int) promptEvalValidationResul
 		result.Valid = false
 		result.Errors = append(result.Errors, fmt.Sprintf("parsing yaml: %v", err))
 		result.ExitCode = promptEvalExitInvalid
-		return result
+		return promptEvalConfig{}, result
 	}
 	result.ModelCount = len(cfg.Models)
 	result.TestCount = len(cfg.Tests)
@@ -218,7 +267,7 @@ func validatePromptEvalFile(path string, maxCases int) promptEvalValidationResul
 	if !result.Valid {
 		result.ExitCode = promptEvalExitInvalid
 	}
-	return result
+	return cfg, result
 }
 
 func validatePromptEvalConfig(cfg promptEvalConfig, maxCases int, result *promptEvalValidationResult) {
@@ -292,6 +341,274 @@ func validatePromptEvalConfig(cfg promptEvalConfig, maxCases int, result *prompt
 		}
 	}
 	result.AssertionSignatures = sortedPromptEvalKeys(signatures)
+}
+
+func validatePromptEvalRemote(cmd *cobra.Command, rc *RunContext, cfg promptEvalConfig, ciMode bool, result *promptEvalValidationResult) {
+	workspaceID := strings.TrimSpace(rc.Workspace)
+	remote := &promptEvalRemoteValidation{WorkspaceID: workspaceID}
+	result.Remote = remote
+	if workspaceID == "" {
+		result.Errors = append(result.Errors, "no workspace specified for --remote. Pass --workspace, set AGENTCLASH_WORKSPACE, or run agentclash link.")
+		return
+	}
+
+	modelAliases, err := promptEvalListRemoteItems(cmd, rc, fmt.Sprintf("/v1/workspaces/%s/model-aliases", workspaceID))
+	if err != nil {
+		result.Errors = append(result.Errors, err.Error())
+		return
+	}
+	providerAccounts, err := promptEvalListRemoteItems(cmd, rc, fmt.Sprintf("/v1/workspaces/%s/provider-accounts", workspaceID))
+	if err != nil {
+		result.Errors = append(result.Errors, err.Error())
+		return
+	}
+	for i, model := range cfg.Models {
+		resolvedAlias, err := promptEvalResolveModelAlias(model, modelAliases)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("models[%d]: %v", i, err))
+			continue
+		}
+		resolvedProvider, err := promptEvalResolveProviderAccount(model, resolvedAlias, providerAccounts, ciMode)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("models[%d]: %v", i, err))
+			continue
+		}
+		remote.Models = append(remote.Models, promptEvalRemoteModel{
+			Alias:             strings.TrimSpace(model.Alias),
+			ModelAliasID:      mapString(resolvedAlias, "id"),
+			ProviderAccountID: mapString(resolvedProvider, "id"),
+		})
+	}
+	if len(result.Errors) > 0 {
+		return
+	}
+
+	playgrounds, err := promptEvalListRemoteItems(cmd, rc, fmt.Sprintf("/v1/workspaces/%s/playgrounds", workspaceID))
+	if err != nil {
+		result.Errors = append(result.Errors, err.Error())
+		return
+	}
+	groups := promptEvalTestGroups(cfg)
+	for _, group := range groups {
+		name := promptEvalPlaygroundName(cfg.Name, group.Signature, len(groups))
+		matches := promptEvalItemsByName(playgrounds, name)
+		pg := promptEvalRemotePlayground{Name: name, Signature: group.Signature}
+		switch len(matches) {
+		case 0:
+			pg.TestsCreate = len(group.Tests)
+			remote.DryRun.PlaygroundsCreate++
+		case 1:
+			pg.PlaygroundID = mapString(matches[0], "id")
+			remote.DryRun.PlaygroundsReuse++
+			promptEvalCompareRemoteTestCases(cmd, rc, pg.PlaygroundID, group, &pg, result)
+		default:
+			result.Errors = append(result.Errors, fmt.Sprintf("multiple playgrounds named %q; clean up duplicates before running prompt-eval", name))
+		}
+		remote.Playgrounds = append(remote.Playgrounds, pg)
+		remote.DryRun.TestsCreate += pg.TestsCreate
+		remote.DryRun.TestsUpdate += pg.TestsUpdate
+		remote.DryRun.TestsNoop += pg.TestsNoop
+		remote.DryRun.TestsOrphan += pg.TestsOrphan
+	}
+}
+
+func promptEvalListRemoteItems(cmd *cobra.Command, rc *RunContext, path string) ([]map[string]any, error) {
+	resp, err := rc.Client.Get(cmd.Context(), path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return nil, apiErr
+	}
+	var payload struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := resp.DecodeJSON(&payload); err != nil {
+		return nil, err
+	}
+	return payload.Items, nil
+}
+
+func promptEvalResolveModelAlias(model promptEvalModel, aliases []map[string]any) (map[string]any, error) {
+	if id := strings.TrimSpace(model.ModelAliasID); id != "" {
+		for _, item := range aliases {
+			if mapString(item, "id") == id {
+				return item, nil
+			}
+		}
+		return nil, fmt.Errorf("model_alias_id %q was not found in the workspace", id)
+	}
+	alias := strings.TrimSpace(model.Alias)
+	matches := []map[string]any{}
+	for _, item := range aliases {
+		for _, key := range []string{"alias", "alias_key", "key", "name", "display_name"} {
+			if mapString(item, key) == alias {
+				matches = append(matches, item)
+				break
+			}
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("model alias %q was not found", alias)
+	case 1:
+		return matches[0], nil
+	default:
+		return nil, fmt.Errorf("model alias %q matched %d workspace aliases; use model_alias_id", alias, len(matches))
+	}
+}
+
+func promptEvalResolveProviderAccount(model promptEvalModel, alias map[string]any, providers []map[string]any, ciMode bool) (map[string]any, error) {
+	selector := strings.TrimSpace(model.ProviderAccount)
+	if selector == "" {
+		return nil, fmt.Errorf("provider_account is required for --remote")
+	}
+	if selector == "default" {
+		if ciMode {
+			return nil, fmt.Errorf("provider_account: default is not allowed with --ci; pin a provider account")
+		}
+		aliasProviderID := mapString(alias, "provider_account_id")
+		if aliasProviderID != "" {
+			for _, item := range providers {
+				if promptEvalProviderActive(item) && mapString(item, "id") == aliasProviderID {
+					return item, nil
+				}
+			}
+		}
+		providerKey := mapString(alias, "provider_key", "provider")
+		return promptEvalSingleProviderMatch(providers, func(item map[string]any) bool {
+			return providerKey != "" && mapString(item, "provider_key", "provider") == providerKey
+		}, "default provider account")
+	}
+	return promptEvalSingleProviderMatch(providers, func(item map[string]any) bool {
+		return mapString(item, "id") == selector ||
+			mapString(item, "provider_key", "provider") == selector ||
+			mapString(item, "name", "display_name") == selector
+	}, fmt.Sprintf("provider_account %q", selector))
+}
+
+func promptEvalSingleProviderMatch(providers []map[string]any, match func(map[string]any) bool, label string) (map[string]any, error) {
+	matches := []map[string]any{}
+	for _, item := range providers {
+		if promptEvalProviderActive(item) && match(item) {
+			matches = append(matches, item)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("%s was not found", label)
+	case 1:
+		return matches[0], nil
+	default:
+		return nil, fmt.Errorf("%s matched %d provider accounts; use a provider account id", label, len(matches))
+	}
+}
+
+func promptEvalProviderActive(item map[string]any) bool {
+	status := strings.TrimSpace(mapString(item, "status", "lifecycle_status"))
+	return status == "" || status == "active"
+}
+
+type promptEvalTestGroup struct {
+	Signature string
+	Tests     []promptEvalTest
+}
+
+func promptEvalTestGroups(cfg promptEvalConfig) []promptEvalTestGroup {
+	bySignature := map[string][]promptEvalTest{}
+	for _, test := range cfg.Tests {
+		signature := promptEvalAssertionSignature(promptEvalAssertionsForTest(test))
+		bySignature[signature] = append(bySignature[signature], test)
+	}
+	signatures := sortedPromptEvalKeys(promptEvalBoolMapKeys(bySignature))
+	groups := make([]promptEvalTestGroup, 0, len(signatures))
+	for _, signature := range signatures {
+		groups = append(groups, promptEvalTestGroup{Signature: signature, Tests: bySignature[signature]})
+	}
+	return groups
+}
+
+func promptEvalBoolMapKeys(values map[string][]promptEvalTest) map[string]bool {
+	keys := map[string]bool{}
+	for key := range values {
+		keys[key] = true
+	}
+	return keys
+}
+
+func promptEvalPlaygroundName(configName, signature string, groupCount int) string {
+	name := "Prompt Eval: " + strings.TrimSpace(configName)
+	if groupCount > 1 {
+		name += " [" + signature + "]"
+	}
+	return name
+}
+
+func promptEvalItemsByName(items []map[string]any, name string) []map[string]any {
+	var matches []map[string]any
+	for _, item := range items {
+		if mapString(item, "name") == name {
+			matches = append(matches, item)
+		}
+	}
+	return matches
+}
+
+func promptEvalCompareRemoteTestCases(cmd *cobra.Command, rc *RunContext, playgroundID string, group promptEvalTestGroup, pg *promptEvalRemotePlayground, result *promptEvalValidationResult) {
+	items, err := promptEvalListRemoteItems(cmd, rc, fmt.Sprintf("/v1/playgrounds/%s/test-cases", playgroundID))
+	if err != nil {
+		result.Errors = append(result.Errors, err.Error())
+		return
+	}
+	remoteByKey := map[string]map[string]any{}
+	for _, item := range items {
+		remoteByKey[mapString(item, "case_key")] = item
+	}
+	expectedKeys := map[string]bool{}
+	for _, test := range group.Tests {
+		expectedKeys[test.Key] = true
+		remote, exists := remoteByKey[test.Key]
+		if !exists {
+			pg.TestsCreate++
+			continue
+		}
+		if promptEvalCanonical(remote["variables"]) == promptEvalCanonical(test.Vars) &&
+			promptEvalCanonical(remote["expectations"]) == promptEvalCanonical(promptEvalExpectationsForTest(test)) {
+			pg.TestsNoop++
+			continue
+		}
+		pg.TestsUpdate++
+	}
+	for _, item := range items {
+		key := mapString(item, "case_key")
+		if key != "" && !expectedKeys[key] {
+			pg.TestsOrphan++
+		}
+	}
+}
+
+func promptEvalExpectationsForTest(test promptEvalTest) map[string]any {
+	assertions := make([]map[string]any, 0, len(promptEvalAssertionsForTest(test)))
+	for _, assertion := range promptEvalAssertionsForTest(test) {
+		assertions = append(assertions, map[string]any{
+			"type":     normalizePromptEvalAssertionType(assertion.Type),
+			"expected": promptEvalAssertionValueString(assertion.Value),
+			"metric":   strings.TrimSpace(assertion.Metric),
+		})
+	}
+	out := map[string]any{"prompt_eval_assertions": assertions}
+	if test.Expect.Output != nil {
+		out["output"] = test.Expect.Output
+	}
+	return out
+}
+
+func promptEvalCanonical(value any) string {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Sprint(value)
+	}
+	return string(data)
 }
 
 func validatePromptEvalAssertion(testIndex, assertionIndex int, assertion promptEvalAssertion, result *promptEvalValidationResult) {

--- a/cli/cmd/prompt_eval.go
+++ b/cli/cmd/prompt_eval.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -96,6 +97,11 @@ var promptEvalValidateCmd = &cobra.Command{
 		remote, _ := cmd.Flags().GetBool("remote")
 		ciMode, _ := cmd.Flags().GetBool("ci")
 		cfg, result := validatePromptEvalFileWithConfig(path, maxCases)
+		if result.Valid && ciMode && !remote {
+			result.Valid = false
+			result.Errors = append(result.Errors, "--ci requires --remote so CI-safe provider and workspace checks run")
+			result.ExitCode = promptEvalExitInvalid
+		}
 		if result.Valid && remote {
 			validatePromptEvalRemote(cmd, rc, cfg, ciMode, &result)
 			result.Valid = len(result.Errors) == 0
@@ -345,12 +351,12 @@ func validatePromptEvalConfig(cfg promptEvalConfig, maxCases int, result *prompt
 
 func validatePromptEvalRemote(cmd *cobra.Command, rc *RunContext, cfg promptEvalConfig, ciMode bool, result *promptEvalValidationResult) {
 	workspaceID := strings.TrimSpace(rc.Workspace)
-	remote := &promptEvalRemoteValidation{WorkspaceID: workspaceID}
-	result.Remote = remote
 	if workspaceID == "" {
 		result.Errors = append(result.Errors, "no workspace specified for --remote. Pass --workspace, set AGENTCLASH_WORKSPACE, or run agentclash link.")
 		return
 	}
+	remote := &promptEvalRemoteValidation{WorkspaceID: workspaceID}
+	result.Remote = remote
 
 	modelAliases, err := promptEvalListRemoteItems(cmd, rc, fmt.Sprintf("/v1/workspaces/%s/model-aliases", workspaceID))
 	if err != nil {
@@ -413,20 +419,34 @@ func validatePromptEvalRemote(cmd *cobra.Command, rc *RunContext, cfg promptEval
 }
 
 func promptEvalListRemoteItems(cmd *cobra.Command, rc *RunContext, path string) ([]map[string]any, error) {
-	resp, err := rc.Client.Get(cmd.Context(), path, nil)
-	if err != nil {
-		return nil, err
+	var out []map[string]any
+	var cursor string
+	for {
+		query := url.Values{}
+		if cursor != "" {
+			query.Set("cursor", cursor)
+		}
+		resp, err := rc.Client.Get(cmd.Context(), path, query)
+		if err != nil {
+			return nil, err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return nil, apiErr
+		}
+		var payload struct {
+			Items      []map[string]any `json:"items"`
+			NextCursor string           `json:"next_cursor"`
+		}
+		if err := resp.DecodeJSON(&payload); err != nil {
+			return nil, err
+		}
+		out = append(out, payload.Items...)
+		cursor = strings.TrimSpace(payload.NextCursor)
+		if cursor == "" {
+			break
+		}
 	}
-	if apiErr := resp.ParseError(); apiErr != nil {
-		return nil, apiErr
-	}
-	var payload struct {
-		Items []map[string]any `json:"items"`
-	}
-	if err := resp.DecodeJSON(&payload); err != nil {
-		return nil, err
-	}
-	return payload.Items, nil
+	return out, nil
 }
 
 func promptEvalResolveModelAlias(model promptEvalModel, aliases []map[string]any) (map[string]any, error) {
@@ -474,11 +494,9 @@ func promptEvalResolveProviderAccount(model promptEvalModel, alias map[string]an
 					return item, nil
 				}
 			}
+			return nil, fmt.Errorf("default provider account %q from model alias was not found", aliasProviderID)
 		}
-		providerKey := mapString(alias, "provider_key", "provider")
-		return promptEvalSingleProviderMatch(providers, func(item map[string]any) bool {
-			return providerKey != "" && mapString(item, "provider_key", "provider") == providerKey
-		}, "default provider account")
+		return nil, fmt.Errorf("model alias does not expose provider_account_id; set provider_account explicitly")
 	}
 	return promptEvalSingleProviderMatch(providers, func(item map[string]any) bool {
 		return mapString(item, "id") == selector ||

--- a/cli/cmd/prompt_eval_test.go
+++ b/cli/cmd/prompt_eval_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -173,6 +175,174 @@ func TestPromptEvalValidateJSONEnvelopeForMissingFile(t *testing.T) {
 	}
 }
 
+func TestPromptEvalValidateRemoteRequiresWorkspace(t *testing.T) {
+	path := writePromptEvalFixture(t, validPromptEvalYAML())
+	err := executeCommand(t, []string{"prompt-eval", "validate", path, "--remote"}, "http://unused")
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) || exitErr.Code != promptEvalExitInvalid {
+		t.Fatalf("expected ExitCodeError{%d}, got %T %v", promptEvalExitInvalid, err, err)
+	}
+}
+
+func TestPromptEvalValidateRemoteResolvesAliasesAndProviderAccounts(t *testing.T) {
+	path := writePromptEvalFixture(t, validPromptEvalYAML())
+	srv := promptEvalRemoteFakeAPI(t, promptEvalRemoteFakeOptions{})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	err := executeCommand(t, []string{"prompt-eval", "validate", path, "--remote", "-w", "ws-1", "--json"}, srv.URL)
+	out := stdout.finish()
+	if err != nil {
+		t.Fatalf("remote validate error: %v\n%s", err, out)
+	}
+	var result promptEvalValidationResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode remote json: %v\n%s", err, out)
+	}
+	if result.Remote == nil || len(result.Remote.Models) != 1 {
+		t.Fatalf("remote models missing: %+v", result.Remote)
+	}
+	if got := result.Remote.Models[0].ProviderAccountID; got != "pa-1" {
+		t.Fatalf("provider_account_id = %q, want pa-1", got)
+	}
+}
+
+func TestPromptEvalValidateRemoteRejectsUnknownOrAmbiguousModelAlias(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		options promptEvalRemoteFakeOptions
+		want    string
+	}{
+		{name: "unknown", options: promptEvalRemoteFakeOptions{ModelAliases: []map[string]any{}}, want: "model alias \"gpt-5.5\" was not found"},
+		{name: "ambiguous", options: promptEvalRemoteFakeOptions{ModelAliases: []map[string]any{
+			{"id": "alias-1", "alias_key": "gpt-5.5", "provider_key": "openai", "provider_account_id": "pa-1"},
+			{"id": "alias-2", "alias_key": "gpt-5.5", "provider_key": "openai", "provider_account_id": "pa-1"},
+		}}, want: "matched 2 workspace aliases"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writePromptEvalFixture(t, validPromptEvalYAML())
+			srv := promptEvalRemoteFakeAPI(t, tc.options)
+			defer srv.Close()
+			result := runPromptEvalRemoteValidateJSON(t, path, srv.URL, false)
+			if result.Valid || !containsPromptEvalMessage(result.Errors, tc.want) {
+				t.Fatalf("errors = %v, want %q", result.Errors, tc.want)
+			}
+		})
+	}
+}
+
+func TestPromptEvalValidateRemoteRejectsProviderAmbiguity(t *testing.T) {
+	body := strings.Replace(validPromptEvalYAML(), "provider_account: default", "provider_account: openai", 1)
+	path := writePromptEvalFixture(t, body)
+	srv := promptEvalRemoteFakeAPI(t, promptEvalRemoteFakeOptions{ProviderAccounts: []map[string]any{
+		{"id": "pa-1", "provider_key": "openai", "status": "active"},
+		{"id": "pa-2", "provider_key": "openai", "status": "active"},
+	}})
+	defer srv.Close()
+
+	result := runPromptEvalRemoteValidateJSON(t, path, srv.URL, false)
+	if result.Valid || !containsPromptEvalMessage(result.Errors, "matched 2 provider accounts") {
+		t.Fatalf("errors = %v", result.Errors)
+	}
+}
+
+func TestPromptEvalValidateRemoteRejectsDefaultProviderInCI(t *testing.T) {
+	path := writePromptEvalFixture(t, validPromptEvalYAML())
+	srv := promptEvalRemoteFakeAPI(t, promptEvalRemoteFakeOptions{})
+	defer srv.Close()
+
+	result := runPromptEvalRemoteValidateJSON(t, path, srv.URL, true)
+	if result.Valid || !containsPromptEvalMessage(result.Errors, "provider_account: default is not allowed with --ci") {
+		t.Fatalf("errors = %v", result.Errors)
+	}
+}
+
+func TestPromptEvalValidateRemoteDetectsDuplicatePlaygrounds(t *testing.T) {
+	path := writePromptEvalFixture(t, validPromptEvalYAML())
+	srv := promptEvalRemoteFakeAPI(t, promptEvalRemoteFakeOptions{Playgrounds: []map[string]any{
+		{"id": "pg-1", "name": "Prompt Eval: refund-bot-v1"},
+		{"id": "pg-2", "name": "Prompt Eval: refund-bot-v1"},
+	}})
+	defer srv.Close()
+
+	result := runPromptEvalRemoteValidateJSON(t, path, srv.URL, false)
+	if result.Valid || !containsPromptEvalMessage(result.Errors, "multiple playgrounds named") {
+		t.Fatalf("errors = %v", result.Errors)
+	}
+}
+
+func TestPromptEvalValidateRemoteReportsDryRunCounts(t *testing.T) {
+	body := strings.Replace(validPromptEvalYAML(), "tests:\n  - key: greeting", "tests:\n  - key: salutation\n    vars:\n      input: Say hello in French\n    expect:\n      output: Bonjour\n    assert:\n      - type: contains\n        value: Salut\n        metric: correctness\n  - key: greeting", 1)
+	body = strings.Replace(body, "thresholds:", "  - key: farewell\n    vars:\n      input: Say goodbye in French\n    expect:\n      output: Au revoir\n    assert:\n      - type: contains\n        value: Au revoir\n        metric: correctness\nthresholds:", 1)
+	path := writePromptEvalFixture(t, body)
+	srv := promptEvalRemoteFakeAPI(t, promptEvalRemoteFakeOptions{
+		Playgrounds: []map[string]any{{"id": "pg-1", "name": "Prompt Eval: refund-bot-v1"}},
+		TestCases: []map[string]any{
+			{
+				"id":        "tc-1",
+				"case_key":  "greeting",
+				"variables": map[string]any{"input": "Say hello in French"},
+				"expectations": map[string]any{
+					"output": "Bonjour",
+					"prompt_eval_assertions": []any{
+						map[string]any{"type": "contains", "expected": "Bonjour", "metric": "correctness"},
+					},
+				},
+			},
+			{
+				"id":        "tc-3",
+				"case_key":  "farewell",
+				"variables": map[string]any{"input": "Say goodbye in French"},
+				"expectations": map[string]any{
+					"output": "Au revoir",
+					"prompt_eval_assertions": []any{
+						map[string]any{"type": "contains", "expected": "Bonjour", "metric": "correctness"},
+					},
+				},
+			},
+			{
+				"id":           "tc-2",
+				"case_key":     "orphan",
+				"variables":    map[string]any{"input": "old"},
+				"expectations": map[string]any{},
+			},
+		},
+	})
+	defer srv.Close()
+
+	result := runPromptEvalRemoteValidateJSON(t, path, srv.URL, false)
+	if !result.Valid {
+		t.Fatalf("remote validate errors = %v", result.Errors)
+	}
+	if got := result.Remote.DryRun.TestsCreate; got != 1 {
+		t.Fatalf("tests_create = %d, want 1", got)
+	}
+	if got := result.Remote.DryRun.TestsNoop; got != 1 {
+		t.Fatalf("tests_noop = %d, want 1", got)
+	}
+	if got := result.Remote.DryRun.TestsUpdate; got != 1 {
+		t.Fatalf("tests_update = %d, want 1", got)
+	}
+	if got := result.Remote.DryRun.TestsOrphan; got != 1 {
+		t.Fatalf("tests_orphan = %d, want 1", got)
+	}
+}
+
+func TestPromptEvalValidateRemoteIsReadOnly(t *testing.T) {
+	var writeCalled bool
+	path := writePromptEvalFixture(t, validPromptEvalYAML())
+	srv := promptEvalRemoteFakeAPI(t, promptEvalRemoteFakeOptions{OnWrite: func() { writeCalled = true }})
+	defer srv.Close()
+
+	result := runPromptEvalRemoteValidateJSON(t, path, srv.URL, false)
+	if !result.Valid {
+		t.Fatalf("remote validate errors = %v", result.Errors)
+	}
+	if writeCalled {
+		t.Fatal("remote validate performed a write request")
+	}
+}
+
 func TestChallengePackPromptEvalTemplateMentionsPromptEvalInit(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "pack.yaml")
@@ -230,4 +400,75 @@ thresholds:
   dimensions:
     correctness: 0.9
 `
+}
+
+type promptEvalRemoteFakeOptions struct {
+	ModelAliases     []map[string]any
+	ProviderAccounts []map[string]any
+	Playgrounds      []map[string]any
+	TestCases        []map[string]any
+	OnWrite          func()
+}
+
+func promptEvalRemoteFakeAPI(t *testing.T, options promptEvalRemoteFakeOptions) *httptest.Server {
+	t.Helper()
+	modelAliases := options.ModelAliases
+	if modelAliases == nil {
+		modelAliases = []map[string]any{{"id": "alias-1", "alias_key": "gpt-5.5", "provider_key": "openai", "provider_account_id": "pa-1"}}
+	}
+	providerAccounts := options.ProviderAccounts
+	if providerAccounts == nil {
+		providerAccounts = []map[string]any{{"id": "pa-1", "provider_key": "openai", "name": "OpenAI", "status": "active"}}
+	}
+	playgrounds := options.Playgrounds
+	if playgrounds == nil {
+		playgrounds = []map[string]any{}
+	}
+	testCases := options.TestCases
+	if testCases == nil {
+		testCases = []map[string]any{}
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost || r.Method == http.MethodPatch || r.Method == http.MethodDelete {
+			if options.OnWrite != nil {
+				options.OnWrite()
+			}
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"message": "unexpected write request"}})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/workspaces/ws-1/model-aliases":
+			json.NewEncoder(w).Encode(map[string]any{"items": modelAliases})
+		case "/v1/workspaces/ws-1/provider-accounts":
+			json.NewEncoder(w).Encode(map[string]any{"items": providerAccounts})
+		case "/v1/workspaces/ws-1/playgrounds":
+			json.NewEncoder(w).Encode(map[string]any{"items": playgrounds})
+		case "/v1/playgrounds/pg-1/test-cases":
+			json.NewEncoder(w).Encode(map[string]any{"items": testCases})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"message": "not found"}})
+		}
+	}))
+}
+
+func runPromptEvalRemoteValidateJSON(t *testing.T, path, apiURL string, ciMode bool) promptEvalValidationResult {
+	t.Helper()
+	args := []string{"prompt-eval", "validate", path, "--remote", "-w", "ws-1", "--json"}
+	if ciMode {
+		args = append(args, "--ci")
+	}
+	stdout := captureStdout(t)
+	err := executeCommand(t, args, apiURL)
+	out := stdout.finish()
+	var result promptEvalValidationResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode remote json: %v\n%s", err, out)
+	}
+	if result.Valid && err != nil {
+		t.Fatalf("remote validate returned error for valid result: %v\n%s", err, out)
+	}
+	return result
 }

--- a/cli/cmd/prompt_eval_test.go
+++ b/cli/cmd/prompt_eval_test.go
@@ -176,11 +176,33 @@ func TestPromptEvalValidateJSONEnvelopeForMissingFile(t *testing.T) {
 }
 
 func TestPromptEvalValidateRemoteRequiresWorkspace(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("AGENTCLASH_WORKSPACE", "")
 	path := writePromptEvalFixture(t, validPromptEvalYAML())
-	err := executeCommand(t, []string{"prompt-eval", "validate", path, "--remote"}, "http://unused")
+	stdout := captureStdout(t)
+	err := executeCommand(t, []string{"prompt-eval", "validate", path, "--remote", "--json"}, "http://unused")
+	out := stdout.finish()
 	var exitErr *ExitCodeError
 	if !errors.As(err, &exitErr) || exitErr.Code != promptEvalExitInvalid {
 		t.Fatalf("expected ExitCodeError{%d}, got %T %v", promptEvalExitInvalid, err, err)
+	}
+	var result promptEvalValidationResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode json output: %v\n%s", err, out)
+	}
+	if result.Remote != nil {
+		t.Fatalf("remote payload should be absent when workspace is missing: %+v", result.Remote)
+	}
+	if !containsPromptEvalMessage(result.Errors, "no workspace specified for --remote") {
+		t.Fatalf("errors = %v", result.Errors)
+	}
+}
+
+func TestPromptEvalValidateCIRequiresRemote(t *testing.T) {
+	path := writePromptEvalFixture(t, validPromptEvalYAML())
+	result := runPromptEvalValidateJSON(t, []string{"prompt-eval", "validate", path, "--ci", "--json"}, "http://unused")
+	if result.Valid || !containsPromptEvalMessage(result.Errors, "--ci requires --remote") {
+		t.Fatalf("errors = %v", result.Errors)
 	}
 }
 
@@ -204,6 +226,20 @@ func TestPromptEvalValidateRemoteResolvesAliasesAndProviderAccounts(t *testing.T
 	}
 	if got := result.Remote.Models[0].ProviderAccountID; got != "pa-1" {
 		t.Fatalf("provider_account_id = %q, want pa-1", got)
+	}
+}
+
+func TestPromptEvalValidateRemoteFollowsPagination(t *testing.T) {
+	path := writePromptEvalFixture(t, validPromptEvalYAML())
+	srv := promptEvalRemoteFakeAPI(t, promptEvalRemoteFakeOptions{PaginateAliases: true})
+	defer srv.Close()
+
+	result := runPromptEvalRemoteValidateJSON(t, path, srv.URL, false)
+	if !result.Valid {
+		t.Fatalf("remote validate errors = %v", result.Errors)
+	}
+	if got := result.Remote.Models[0].ModelAliasID; got != "alias-1" {
+		t.Fatalf("model_alias_id = %q, want alias-1", got)
 	}
 }
 
@@ -408,6 +444,7 @@ type promptEvalRemoteFakeOptions struct {
 	Playgrounds      []map[string]any
 	TestCases        []map[string]any
 	OnWrite          func()
+	PaginateAliases  bool
 }
 
 func promptEvalRemoteFakeAPI(t *testing.T, options promptEvalRemoteFakeOptions) *httptest.Server {
@@ -429,7 +466,7 @@ func promptEvalRemoteFakeAPI(t *testing.T, options promptEvalRemoteFakeOptions) 
 		testCases = []map[string]any{}
 	}
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost || r.Method == http.MethodPatch || r.Method == http.MethodDelete {
+		if r.Method == http.MethodPost || r.Method == http.MethodPatch || r.Method == http.MethodPut || r.Method == http.MethodDelete {
 			if options.OnWrite != nil {
 				options.OnWrite()
 			}
@@ -440,6 +477,10 @@ func promptEvalRemoteFakeAPI(t *testing.T, options promptEvalRemoteFakeOptions) 
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/v1/workspaces/ws-1/model-aliases":
+			if options.PaginateAliases && r.URL.Query().Get("cursor") == "" {
+				json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{}, "next_cursor": "page-2"})
+				return
+			}
 			json.NewEncoder(w).Encode(map[string]any{"items": modelAliases})
 		case "/v1/workspaces/ws-1/provider-accounts":
 			json.NewEncoder(w).Encode(map[string]any{"items": providerAccounts})
@@ -460,6 +501,11 @@ func runPromptEvalRemoteValidateJSON(t *testing.T, path, apiURL string, ciMode b
 	if ciMode {
 		args = append(args, "--ci")
 	}
+	return runPromptEvalValidateJSON(t, args, apiURL)
+}
+
+func runPromptEvalValidateJSON(t *testing.T, args []string, apiURL string) promptEvalValidationResult {
+	t.Helper()
 	stdout := captureStdout(t)
 	err := executeCommand(t, args, apiURL)
 	out := stdout.finish()

--- a/docs/ci-prompt-eval.md
+++ b/docs/ci-prompt-eval.md
@@ -1,0 +1,11 @@
+# AgentClash Prompt Eval CI
+
+Prompt eval CI uses shared workspace playground resources during V1. Until the backend exposes an idempotent playground upsert API, serialize jobs that target the same workspace and config.
+
+```yaml
+concurrency:
+  group: agentclash-prompt-eval-${{ github.repository }}-${{ github.workflow }}-${{ vars.AGENTCLASH_WORKSPACE }}-.agentclash-prompt-eval-yaml
+  cancel-in-progress: false
+```
+
+Do not include `github.ref` in the group. Two pull requests can target the same AgentClash workspace and prompt-eval config, so including the ref would allow both jobs to race the same playground.

--- a/docs/ci-prompt-eval.md
+++ b/docs/ci-prompt-eval.md
@@ -9,3 +9,5 @@ concurrency:
 ```
 
 Do not include `github.ref` in the group. Two pull requests can target the same AgentClash workspace and prompt-eval config, so including the ref would allow both jobs to race the same playground.
+
+If you use a config path other than `.agentclash/prompt-eval.yaml`, replace the final suffix with a stable slug for that path. Multiple prompt-eval configs can use separate concurrency groups, but every PR targeting the same workspace and config should share one group.

--- a/testing/codex-prompt-eval-remote-preflight.md
+++ b/testing/codex-prompt-eval-remote-preflight.md
@@ -1,0 +1,45 @@
+# Codex Prompt Eval Remote Preflight - Test Contract
+
+Issue: #589
+Branch: `codex/prompt-eval-remote-preflight`
+
+## Functional Behavior
+
+- `agentclash prompt-eval validate [path] --remote` runs local validation first, then performs read-only API checks.
+- Remote validation requires a workspace from normal CLI precedence and exits with the prompt-eval validation code when missing.
+- Remote validation resolves each model by `model_alias_id` or by unique `alias` from `/v1/workspaces/{workspaceID}/model-aliases`.
+- Remote validation resolves provider accounts from `/v1/workspaces/{workspaceID}/provider-accounts`.
+- `provider_account: default` remains a local warning, but `--ci` rejects it because CI configs must be pinned.
+- Remote validation name-matches playgrounds as `Prompt Eval: {name}` or `Prompt Eval: {name} [{signatureHash}]`.
+- Duplicate matching playground names are errors; zero matches are reported as dry-run creates.
+- Existing playground test cases are compared by `case_key` to report dry-run create/update/no-op/orphan counts without creating or updating anything.
+- `validate --remote --json` includes remote validation details in the existing validation envelope.
+- The PR adds a copy-paste GitHub Actions concurrency snippet for prompt-eval CI docs.
+
+## Unit Tests
+
+- `TestPromptEvalValidateRemoteRequiresWorkspace` - `--remote` without workspace returns a structured validation error.
+- `TestPromptEvalValidateRemoteResolvesAliasesAndProviderAccounts` - fake API returns one model alias/provider account and validation succeeds.
+- `TestPromptEvalValidateRemoteRejectsUnknownOrAmbiguousModelAlias` - zero and multiple alias matches fail.
+- `TestPromptEvalValidateRemoteRejectsProviderAmbiguity` - zero or multiple provider account matches fail.
+- `TestPromptEvalValidateRemoteRejectsDefaultProviderInCI` - `--remote --ci` rejects `provider_account: default`.
+- `TestPromptEvalValidateRemoteDetectsDuplicatePlaygrounds` - multiple matching playgrounds fail.
+- `TestPromptEvalValidateRemoteReportsDryRunCounts` - create/update/no-op/orphan counts are computed from fake test cases.
+- `TestPromptEvalValidateRemoteIsReadOnly` - fake API fails the test if POST/PATCH/DELETE is called.
+
+## Integration / Functional Tests
+
+- Run focused Go tests in `cli/cmd`.
+- Run `go test -short -race -count=1 ./...` from `cli/`.
+
+## Smoke Tests
+
+- `go run . prompt-eval validate /tmp/agentclash-prompt-eval.yaml --remote --workspace ws-1 --api-url <fake-or-local-api>` is covered by fake API tests; no hosted smoke is required for this PR because it is read-only and depends on workspace-specific fixtures.
+
+## E2E Tests
+
+N/A - this PR does not create playgrounds, test cases, or experiments.
+
+## Manual / cURL Tests
+
+N/A - fake API tests pin the API contract for this read-only preflight slice.


### PR DESCRIPTION
Closes #589.\n\n## Summary\n- add `prompt-eval validate --remote` and `--ci`\n- resolve model aliases and provider accounts read-only\n- name-match prompt-eval playgrounds and compute dry-run test-case counts\n- document the CI concurrency workaround for shared playground resources\n\n## Review checkpoint\n- Contract: `testing/codex-prompt-eval-remote-preflight.md`\n- Checkpoint status: ready\n\n## Tests\n- `cd cli && go build ./...`\n- `cd cli && go vet ./...`\n- `cd cli && go test -short -race -count=1 ./...`