### PR TITLE
feat(cli): compile and launch prompt-eval runs

### DIFF
--- a/cli/cmd/prompt_eval.go
+++ b/cli/cmd/prompt_eval.go
@@ -27,6 +27,7 @@ func init() {
 	rootCmd.AddCommand(promptEvalCmd)
 	promptEvalCmd.AddCommand(promptEvalInitCmd)
 	promptEvalCmd.AddCommand(promptEvalValidateCmd)
+	promptEvalCmd.AddCommand(promptEvalRunCmd)
 
 	promptEvalInitCmd.Flags().Bool("force", false, "Overwrite an existing file")
 	promptEvalInitCmd.Flags().String("name", "", "Prompt eval name (defaults from the file name)")
@@ -34,6 +35,9 @@ func init() {
 	promptEvalValidateCmd.Flags().Int("max-cases", 100, "Maximum model x test cases allowed before launch")
 	promptEvalValidateCmd.Flags().Bool("remote", false, "Validate referenced AgentClash workspace resources without creating them")
 	promptEvalValidateCmd.Flags().Bool("ci", false, "Apply CI-safe validation rules")
+
+	promptEvalRunCmd.Flags().Int("max-cases", 100, "Maximum model x test cases allowed before launch")
+	promptEvalRunCmd.Flags().Bool("ci", false, "Apply CI-safe validation rules")
 }
 
 var promptEvalCmd = &cobra.Command{
@@ -118,6 +122,35 @@ var promptEvalValidateCmd = &cobra.Command{
 		}
 		if !result.Valid {
 			return &ExitCodeError{Code: promptEvalExitInvalid}
+		}
+		return nil
+	},
+}
+
+var promptEvalRunCmd = &cobra.Command{
+	Use:   "run [file]",
+	Short: "Compile a prompt eval config and launch playground experiments",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		path := ".agentclash/prompt-eval.yaml"
+		if len(args) > 0 {
+			path = args[0]
+		}
+		maxCases, _ := cmd.Flags().GetInt("max-cases")
+		ciMode, _ := cmd.Flags().GetBool("ci")
+		result, err := executePromptEvalRun(cmd, rc, path, maxCases, ciMode)
+		if rc.Output.IsStructured() {
+			if result != nil {
+				if printErr := rc.Output.PrintRaw(result); printErr != nil {
+					return printErr
+				}
+			}
+		} else if result != nil {
+			renderPromptEvalRun(rc, *result)
+		}
+		if err != nil {
+			return err
 		}
 		return nil
 	},
@@ -209,6 +242,38 @@ type promptEvalRemoteDryRun struct {
 	TestsUpdate       int `json:"tests_update" yaml:"tests_update"`
 	TestsNoop         int `json:"tests_noop" yaml:"tests_noop"`
 	TestsOrphan       int `json:"tests_orphan" yaml:"tests_orphan"`
+}
+
+type promptEvalRunResult struct {
+	SchemaVersion int                       `json:"schemaVersion" yaml:"schemaVersion"`
+	Path          string                    `json:"path" yaml:"path"`
+	ConfigHash    string                    `json:"config_hash" yaml:"config_hash"`
+	WorkspaceID   string                    `json:"workspace_id" yaml:"workspace_id"`
+	ModelCount    int                       `json:"model_count" yaml:"model_count"`
+	TestCount     int                       `json:"test_count" yaml:"test_count"`
+	CaseCount     int                       `json:"case_count" yaml:"case_count"`
+	Playgrounds   []promptEvalRunPlayground `json:"playgrounds" yaml:"playgrounds"`
+	Errors        []string                  `json:"errors,omitempty" yaml:"errors,omitempty"`
+	ExitCode      int                       `json:"exit_code" yaml:"exit_code"`
+}
+
+type promptEvalRunPlayground struct {
+	Name          string                    `json:"name" yaml:"name"`
+	Signature     string                    `json:"signature" yaml:"signature"`
+	PlaygroundID  string                    `json:"playground_id" yaml:"playground_id"`
+	PlaygroundURL string                    `json:"playground_url,omitempty" yaml:"playground_url,omitempty"`
+	TestsCreated  int                       `json:"tests_created" yaml:"tests_created"`
+	TestsUpdated  int                       `json:"tests_updated" yaml:"tests_updated"`
+	TestsNoop     int                       `json:"tests_noop" yaml:"tests_noop"`
+	Experiments   []promptEvalRunExperiment `json:"experiments" yaml:"experiments"`
+}
+
+type promptEvalRunExperiment struct {
+	ExperimentID      string `json:"experiment_id" yaml:"experiment_id"`
+	ExperimentURL     string `json:"experiment_url,omitempty" yaml:"experiment_url,omitempty"`
+	ModelAliasID      string `json:"model_alias_id" yaml:"model_alias_id"`
+	ProviderAccountID string `json:"provider_account_id" yaml:"provider_account_id"`
+	Status            string `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 func buildPromptEvalScaffold(name string) ([]byte, error) {
@@ -416,6 +481,260 @@ func validatePromptEvalRemote(cmd *cobra.Command, rc *RunContext, cfg promptEval
 		remote.DryRun.TestsNoop += pg.TestsNoop
 		remote.DryRun.TestsOrphan += pg.TestsOrphan
 	}
+}
+
+func executePromptEvalRun(cmd *cobra.Command, rc *RunContext, path string, maxCases int, ciMode bool) (*promptEvalRunResult, error) {
+	cfg, validation := validatePromptEvalFileWithConfig(path, maxCases)
+	if validation.Valid {
+		validatePromptEvalRemote(cmd, rc, cfg, ciMode, &validation)
+		validation.Valid = len(validation.Errors) == 0
+		if !validation.Valid {
+			validation.ExitCode = promptEvalExitInvalid
+		}
+	}
+	if !validation.Valid {
+		if rc.Output.IsStructured() {
+			_ = rc.Output.PrintRaw(validation)
+		} else {
+			renderPromptEvalValidation(rc, validation)
+		}
+		return nil, &ExitCodeError{Code: promptEvalExitInvalid}
+	}
+	data, _ := os.ReadFile(path)
+	run := &promptEvalRunResult{
+		SchemaVersion: promptEvalSchemaVersion,
+		Path:          path,
+		ConfigHash:    promptEvalConfigHash(data),
+		WorkspaceID:   validation.Remote.WorkspaceID,
+		ModelCount:    validation.ModelCount,
+		TestCount:     validation.TestCount,
+		CaseCount:     validation.CaseCount,
+		Playgrounds:   []promptEvalRunPlayground{},
+	}
+	groups := promptEvalTestGroups(cfg)
+	for _, group := range groups {
+		compiled, err := compilePromptEvalGroup(cmd, rc, cfg, validation, group, len(groups))
+		if err != nil {
+			run.Errors = append(run.Errors, err.Error())
+			run.ExitCode = promptEvalExitInvalid
+			return run, &ExitCodeError{Code: promptEvalExitInvalid}
+		}
+		run.Playgrounds = append(run.Playgrounds, compiled)
+	}
+	return run, nil
+}
+
+func compilePromptEvalGroup(cmd *cobra.Command, rc *RunContext, cfg promptEvalConfig, validation promptEvalValidationResult, group promptEvalTestGroup, groupCount int) (promptEvalRunPlayground, error) {
+	name := promptEvalPlaygroundName(cfg.Name, group.Signature, groupCount)
+	playgroundID, playgroundURL, err := upsertPromptEvalPlayground(cmd, rc, validation.Remote.WorkspaceID, name, cfg.Prompt.Template, promptEvalEvaluationSpec(cfg.Name, group))
+	if err != nil {
+		return promptEvalRunPlayground{}, err
+	}
+	result := promptEvalRunPlayground{
+		Name:          name,
+		Signature:     group.Signature,
+		PlaygroundID:  playgroundID,
+		PlaygroundURL: playgroundURL,
+		Experiments:   []promptEvalRunExperiment{},
+	}
+	created, updated, noop, err := upsertPromptEvalTestCases(cmd, rc, playgroundID, group)
+	if err != nil {
+		return promptEvalRunPlayground{}, err
+	}
+	result.TestsCreated = created
+	result.TestsUpdated = updated
+	result.TestsNoop = noop
+	for _, model := range validation.Remote.Models {
+		experiment, err := createPromptEvalExperiment(cmd, rc, playgroundID, name, model)
+		if err != nil {
+			return promptEvalRunPlayground{}, err
+		}
+		result.Experiments = append(result.Experiments, experiment)
+	}
+	return result, nil
+}
+
+func upsertPromptEvalPlayground(cmd *cobra.Command, rc *RunContext, workspaceID, name, promptTemplate string, evaluationSpec map[string]any) (string, string, error) {
+	playgrounds, err := promptEvalListRemoteItems(cmd, rc, fmt.Sprintf("/v1/workspaces/%s/playgrounds", workspaceID))
+	if err != nil {
+		return "", "", err
+	}
+	matches := promptEvalItemsByName(playgrounds, name)
+	body := map[string]any{"name": name, "prompt_template": promptTemplate, "evaluation_spec": evaluationSpec}
+	switch len(matches) {
+	case 0:
+		resp, err := rc.Client.Post(cmd.Context(), fmt.Sprintf("/v1/workspaces/%s/playgrounds", workspaceID), body)
+		if err != nil {
+			return "", "", err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return "", "", apiErr
+		}
+		var created map[string]any
+		if err := resp.DecodeJSON(&created); err != nil {
+			return "", "", err
+		}
+		return mapString(created, "id"), promptEvalUIURL(created, "playground", mapString(created, "id")), nil
+	case 1:
+		id := mapString(matches[0], "id")
+		resp, err := rc.Client.Patch(cmd.Context(), "/v1/playgrounds/"+id, body)
+		if err != nil {
+			return "", "", err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return "", "", apiErr
+		}
+		var updated map[string]any
+		if err := resp.DecodeJSON(&updated); err != nil {
+			return "", "", err
+		}
+		if got := mapString(updated, "id"); got != "" {
+			id = got
+		}
+		return id, promptEvalUIURL(updated, "playground", id), nil
+	default:
+		return "", "", fmt.Errorf("multiple playgrounds named %q; clean up duplicates before running prompt-eval", name)
+	}
+}
+
+func upsertPromptEvalTestCases(cmd *cobra.Command, rc *RunContext, playgroundID string, group promptEvalTestGroup) (int, int, int, error) {
+	items, err := promptEvalListRemoteItems(cmd, rc, fmt.Sprintf("/v1/playgrounds/%s/test-cases", playgroundID))
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	remoteByKey := map[string]map[string]any{}
+	for _, item := range items {
+		remoteByKey[mapString(item, "case_key")] = item
+	}
+	var created, updated, noop int
+	for _, test := range group.Tests {
+		body := promptEvalTestCaseBody(test)
+		remote, exists := remoteByKey[test.Key]
+		if !exists {
+			resp, err := rc.Client.Post(cmd.Context(), fmt.Sprintf("/v1/playgrounds/%s/test-cases", playgroundID), body)
+			if err != nil {
+				return 0, 0, 0, err
+			}
+			if apiErr := resp.ParseError(); apiErr != nil {
+				return 0, 0, 0, apiErr
+			}
+			created++
+			continue
+		}
+		if promptEvalCanonical(remote["variables"]) == promptEvalCanonical(test.Vars) &&
+			promptEvalCanonical(remote["expectations"]) == promptEvalCanonical(promptEvalExpectationsForTest(test)) {
+			noop++
+			continue
+		}
+		resp, err := rc.Client.Patch(cmd.Context(), "/v1/playground-test-cases/"+mapString(remote, "id"), body)
+		if err != nil {
+			return 0, 0, 0, err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return 0, 0, 0, apiErr
+		}
+		updated++
+	}
+	return created, updated, noop, nil
+}
+
+func createPromptEvalExperiment(cmd *cobra.Command, rc *RunContext, playgroundID, playgroundName string, model promptEvalRemoteModel) (promptEvalRunExperiment, error) {
+	body := map[string]any{
+		"name":                playgroundName,
+		"provider_account_id": model.ProviderAccountID,
+		"model_alias_id":      model.ModelAliasID,
+	}
+	resp, err := rc.Client.Post(cmd.Context(), fmt.Sprintf("/v1/playgrounds/%s/experiments", playgroundID), body)
+	if err != nil {
+		return promptEvalRunExperiment{}, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return promptEvalRunExperiment{}, apiErr
+	}
+	var created map[string]any
+	if err := resp.DecodeJSON(&created); err != nil {
+		return promptEvalRunExperiment{}, err
+	}
+	id := mapString(created, "id")
+	return promptEvalRunExperiment{
+		ExperimentID:      id,
+		ExperimentURL:     promptEvalUIURL(created, "experiment", id),
+		ModelAliasID:      model.ModelAliasID,
+		ProviderAccountID: model.ProviderAccountID,
+		Status:            mapString(created, "status"),
+	}, nil
+}
+
+func promptEvalTestCaseBody(test promptEvalTest) map[string]any {
+	return map[string]any{
+		"case_key":     test.Key,
+		"variables":    test.Vars,
+		"expectations": promptEvalExpectationsForTest(test),
+	}
+}
+
+func promptEvalEvaluationSpec(configName string, group promptEvalTestGroup) map[string]any {
+	assertions := promptEvalAssertionsForTest(group.Tests[0])
+	validators := make([]map[string]any, 0, len(assertions))
+	metricValidators := map[string][]string{}
+	for i, assertion := range assertions {
+		kind := normalizePromptEvalAssertionType(assertion.Type)
+		key := fmt.Sprintf("%s_%s_%d", group.Signature, kind, i+1)
+		metric := strings.TrimSpace(assertion.Metric)
+		if metric == "" {
+			metric = "correctness"
+		}
+		validators = append(validators, map[string]any{
+			"key":           key,
+			"type":          kind,
+			"target":        "final_output",
+			"expected_from": fmt.Sprintf("case.expectations.prompt_eval_assertions.%d.expected", i),
+		})
+		metricValidators[metric] = append(metricValidators[metric], key)
+	}
+	dimensions := make([]map[string]any, 0, len(metricValidators))
+	metrics := sortedPromptEvalStringSliceKeys(metricValidators)
+	for _, metric := range metrics {
+		dimensions = append(dimensions, map[string]any{
+			"key":              metric,
+			"source":           "validators",
+			"validators":       metricValidators[metric],
+			"better_direction": "higher",
+		})
+	}
+	return map[string]any{
+		"name":           slugifyChallengePackName(configName) + "-" + group.Signature,
+		"version_number": 1,
+		"judge_mode":     "deterministic",
+		"validators":     validators,
+		"scorecard": map[string]any{
+			"dimensions": dimensions,
+		},
+	}
+}
+
+func sortedPromptEvalStringSliceKeys(values map[string][]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func promptEvalConfigHash(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func promptEvalUIURL(item map[string]any, fallbackKind, id string) string {
+	if link := mapString(item, "url", "web_url", "html_url"); link != "" {
+		return link
+	}
+	if id == "" {
+		return ""
+	}
+	return "https://agentclash.dev/" + fallbackKind + "s/" + id
 }
 
 func promptEvalListRemoteItems(cmd *cobra.Command, rc *RunContext, path string) ([]map[string]any, error) {
@@ -749,6 +1068,24 @@ func renderPromptEvalValidation(rc *RunContext, result promptEvalValidationResul
 		}
 		rc.Output.PrintTable(cols, rows)
 	}
+}
+
+func renderPromptEvalRun(rc *RunContext, result promptEvalRunResult) {
+	if result.ExitCode != 0 {
+		rc.Output.PrintError("Prompt eval run failed")
+		for _, msg := range result.Errors {
+			fmt.Fprintf(os.Stderr, "  - %s\n", msg)
+		}
+		return
+	}
+	rc.Output.PrintSuccess(fmt.Sprintf("Launched prompt eval (%d models x %d tests = %d cases)", result.ModelCount, result.TestCount, result.CaseCount))
+	rows := [][]string{}
+	for _, playground := range result.Playgrounds {
+		for _, experiment := range playground.Experiments {
+			rows = append(rows, []string{playground.PlaygroundID, experiment.ExperimentID, experiment.ModelAliasID, output.StatusColor(experiment.Status)})
+		}
+	}
+	rc.Output.PrintTable([]output.Column{{Header: "Playground"}, {Header: "Experiment"}, {Header: "Model Alias"}, {Header: "Status"}}, rows)
 }
 
 func sortedPromptEvalKeys(values map[string]bool) []string {

--- a/cli/cmd/prompt_eval.go
+++ b/cli/cmd/prompt_eval.go
@@ -500,7 +500,16 @@ func executePromptEvalRun(cmd *cobra.Command, rc *RunContext, path string, maxCa
 		}
 		return nil, &ExitCodeError{Code: promptEvalExitInvalid}
 	}
-	data, _ := os.ReadFile(path)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return &promptEvalRunResult{
+			SchemaVersion: promptEvalSchemaVersion,
+			Path:          path,
+			WorkspaceID:   validation.Remote.WorkspaceID,
+			Errors:        []string{fmt.Sprintf("reading file: %v", err)},
+			ExitCode:      promptEvalExitInvalid,
+		}, &ExitCodeError{Code: promptEvalExitInvalid}
+	}
 	run := &promptEvalRunResult{
 		SchemaVersion: promptEvalSchemaVersion,
 		Path:          path,

--- a/cli/cmd/prompt_eval_test.go
+++ b/cli/cmd/prompt_eval_test.go
@@ -3,11 +3,13 @@ package cmd
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -379,6 +381,83 @@ func TestPromptEvalValidateRemoteIsReadOnly(t *testing.T) {
 	}
 }
 
+func TestPromptEvalRunCreatesPlaygroundTestCasesAndExperiments(t *testing.T) {
+	path := writePromptEvalFixture(t, allAssertionsPromptEvalYAML())
+	fake := newPromptEvalRunFake(t, nil)
+	defer fake.server.Close()
+
+	result := runPromptEvalRunJSON(t, path, fake.server.URL)
+	if result.ExitCode != 0 || len(result.Playgrounds) != 1 || len(result.Playgrounds[0].Experiments) != 1 {
+		t.Fatalf("unexpected run result: %+v", result)
+	}
+	if len(fake.playgroundCreates) != 1 {
+		t.Fatalf("playground creates = %d, want 1", len(fake.playgroundCreates))
+	}
+	spec := mapObject(fake.playgroundCreates[0], "evaluation_spec")
+	validators := mapSlice(spec, "validators")
+	if len(validators) != 7 {
+		t.Fatalf("validators = %d, want 7: %#v", len(validators), validators)
+	}
+	for _, want := range []string{"exact_match", "contains", "regex_match", "json_schema", "json_path_match", "boolean_assert"} {
+		if !promptEvalValidatorTypesContain(validators, want) {
+			t.Fatalf("validators missing %s: %#v", want, validators)
+		}
+	}
+	if len(fake.testCaseCreates) != 1 {
+		t.Fatalf("test case creates = %d, want 1", len(fake.testCaseCreates))
+	}
+	expectations := mapObject(fake.testCaseCreates[0], "expectations")
+	if got := len(mapSlice(expectations, "prompt_eval_assertions")); got != 7 {
+		t.Fatalf("prompt_eval_assertions = %d, want 7", got)
+	}
+	if len(fake.experimentCreates) != 1 || fake.experimentCreates[0]["model_alias_id"] != "alias-1" || fake.experimentCreates[0]["provider_account_id"] != "pa-1" {
+		t.Fatalf("experiment create payloads = %#v", fake.experimentCreates)
+	}
+}
+
+func TestPromptEvalRunUpdatesExistingResourcesWithoutDeletingOrphans(t *testing.T) {
+	path := writePromptEvalFixture(t, validPromptEvalYAML())
+	fake := newPromptEvalRunFake(t, &promptEvalRunFakeState{
+		playgrounds: []map[string]any{{"id": "pg-1", "name": "Prompt Eval: refund-bot-v1"}},
+		testCases: []map[string]any{
+			{"id": "tc-1", "case_key": "greeting", "variables": map[string]any{"input": "old"}, "expectations": map[string]any{}},
+			{"id": "tc-orphan", "case_key": "orphan", "variables": map[string]any{}, "expectations": map[string]any{}},
+		},
+	})
+	defer fake.server.Close()
+
+	result := runPromptEvalRunJSON(t, path, fake.server.URL)
+	if result.ExitCode != 0 || result.Playgrounds[0].TestsUpdated != 1 {
+		t.Fatalf("unexpected run result: %+v", result)
+	}
+	if len(fake.playgroundUpdates) != 1 {
+		t.Fatalf("playground updates = %d, want 1", len(fake.playgroundUpdates))
+	}
+	if len(fake.testCaseUpdates) != 1 {
+		t.Fatalf("test case updates = %d, want 1", len(fake.testCaseUpdates))
+	}
+	if fake.deleteCalled {
+		t.Fatal("run deleted an orphan test case")
+	}
+}
+
+func TestPromptEvalRunGroupsByAssertionSignature(t *testing.T) {
+	body := strings.Replace(validPromptEvalYAML(), "thresholds:", "  - key: regex-case\n    vars:\n      input: Say hello in French\n    assert:\n      - type: regex\n        value: \"Bonjour|Salut\"\n        metric: correctness\nthresholds:", 1)
+	path := writePromptEvalFixture(t, body)
+	fake := newPromptEvalRunFake(t, nil)
+	defer fake.server.Close()
+
+	result := runPromptEvalRunJSON(t, path, fake.server.URL)
+	if len(result.Playgrounds) != 2 {
+		t.Fatalf("playgrounds = %d, want 2: %+v", len(result.Playgrounds), result.Playgrounds)
+	}
+	for _, create := range fake.playgroundCreates {
+		if !strings.Contains(str(create["name"]), "Prompt Eval: refund-bot-v1 [") {
+			t.Fatalf("grouped playground name missing signature suffix: %#v", create["name"])
+		}
+	}
+}
+
 func TestChallengePackPromptEvalTemplateMentionsPromptEvalInit(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "pack.yaml")
@@ -435,6 +514,44 @@ thresholds:
   assertion_pass_rate: 0.9
   dimensions:
     correctness: 0.9
+`
+}
+
+func allAssertionsPromptEvalYAML() string {
+	return `schemaVersion: 1
+name: all-assertions
+prompt:
+  template: |
+    Reply to: {{input}}
+models:
+  - alias: gpt-5.5
+    provider_account: default
+tests:
+  - key: all
+    vars:
+      input: test
+    assert:
+      - type: exact_match
+        value: done
+        metric: correctness
+      - type: equals
+        value: done
+        metric: correctness
+      - type: contains
+        value: done
+        metric: correctness
+      - type: regex
+        value: "done|ok"
+        metric: correctness
+      - type: json_schema
+        value: '{"type":"object"}'
+        metric: correctness
+      - type: json_path_match
+        value: '{"path":"$.ok","value":true}'
+        metric: correctness
+      - type: boolean_assert
+        value: true
+        metric: correctness
 `
 }
 
@@ -517,4 +634,116 @@ func runPromptEvalValidateJSON(t *testing.T, args []string, apiURL string) promp
 		t.Fatalf("remote validate returned error for valid result: %v\n%s", err, out)
 	}
 	return result
+}
+
+type promptEvalRunFakeState struct {
+	playgrounds []map[string]any
+	testCases   []map[string]any
+}
+
+type promptEvalRunFake struct {
+	server            *httptest.Server
+	mu                sync.Mutex
+	playgrounds       []map[string]any
+	testCases         []map[string]any
+	playgroundCreates []map[string]any
+	playgroundUpdates []map[string]any
+	testCaseCreates   []map[string]any
+	testCaseUpdates   []map[string]any
+	experimentCreates []map[string]any
+	deleteCalled      bool
+	nextPlaygroundID  int
+	nextExperimentID  int
+}
+
+func newPromptEvalRunFake(t *testing.T, state *promptEvalRunFakeState) *promptEvalRunFake {
+	t.Helper()
+	f := &promptEvalRunFake{nextPlaygroundID: 1, nextExperimentID: 1}
+	if state != nil {
+		f.playgrounds = append(f.playgrounds, state.playgrounds...)
+		f.testCases = append(f.testCases, state.testCases...)
+	}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/workspaces/ws-1/model-aliases":
+			json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{{"id": "alias-1", "alias_key": "gpt-5.5", "provider_account_id": "pa-1"}}})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/workspaces/ws-1/provider-accounts":
+			json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{{"id": "pa-1", "provider_key": "openai", "status": "active"}}})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/workspaces/ws-1/playgrounds":
+			json.NewEncoder(w).Encode(map[string]any{"items": f.playgrounds})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/workspaces/ws-1/playgrounds":
+			body := decodePromptEvalRequestBody(t, r)
+			f.playgroundCreates = append(f.playgroundCreates, body)
+			id := fmt.Sprintf("pg-%d", f.nextPlaygroundID)
+			f.nextPlaygroundID++
+			item := map[string]any{"id": id, "name": body["name"], "url": "https://agentclash.dev/playgrounds/" + id}
+			f.playgrounds = append(f.playgrounds, item)
+			json.NewEncoder(w).Encode(item)
+		case r.Method == http.MethodPatch && strings.HasPrefix(r.URL.Path, "/v1/playgrounds/"):
+			body := decodePromptEvalRequestBody(t, r)
+			f.playgroundUpdates = append(f.playgroundUpdates, body)
+			id := strings.TrimPrefix(r.URL.Path, "/v1/playgrounds/")
+			json.NewEncoder(w).Encode(map[string]any{"id": id, "name": body["name"], "url": "https://agentclash.dev/playgrounds/" + id})
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/playgrounds/") && strings.HasSuffix(r.URL.Path, "/test-cases"):
+			json.NewEncoder(w).Encode(map[string]any{"items": f.testCases})
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/playgrounds/") && strings.HasSuffix(r.URL.Path, "/test-cases"):
+			body := decodePromptEvalRequestBody(t, r)
+			f.testCaseCreates = append(f.testCaseCreates, body)
+			json.NewEncoder(w).Encode(map[string]any{"id": fmt.Sprintf("tc-created-%d", len(f.testCaseCreates)), "case_key": body["case_key"]})
+		case r.Method == http.MethodPatch && strings.HasPrefix(r.URL.Path, "/v1/playground-test-cases/"):
+			body := decodePromptEvalRequestBody(t, r)
+			f.testCaseUpdates = append(f.testCaseUpdates, body)
+			json.NewEncoder(w).Encode(map[string]any{"id": strings.TrimPrefix(r.URL.Path, "/v1/playground-test-cases/"), "case_key": body["case_key"]})
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/playgrounds/") && strings.HasSuffix(r.URL.Path, "/experiments"):
+			body := decodePromptEvalRequestBody(t, r)
+			f.experimentCreates = append(f.experimentCreates, body)
+			id := fmt.Sprintf("exp-%d", f.nextExperimentID)
+			f.nextExperimentID++
+			json.NewEncoder(w).Encode(map[string]any{"id": id, "status": "queued", "url": "https://agentclash.dev/playground-experiments/" + id})
+		case r.Method == http.MethodDelete:
+			f.deleteCalled = true
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"message": "delete not allowed"}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"message": "not found"}})
+		}
+	}))
+	return f
+}
+
+func decodePromptEvalRequestBody(t *testing.T, r *http.Request) map[string]any {
+	t.Helper()
+	var body map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+	return body
+}
+
+func runPromptEvalRunJSON(t *testing.T, path, apiURL string) promptEvalRunResult {
+	t.Helper()
+	stdout := captureStdout(t)
+	err := executeCommand(t, []string{"prompt-eval", "run", path, "-w", "ws-1", "--json"}, apiURL)
+	out := stdout.finish()
+	if err != nil {
+		t.Fatalf("prompt-eval run error: %v\n%s", err, out)
+	}
+	var result promptEvalRunResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode run json: %v\n%s", err, out)
+	}
+	return result
+}
+
+func promptEvalValidatorTypesContain(validators []any, want string) bool {
+	for _, item := range validators {
+		if asMap, ok := item.(map[string]any); ok && asMap["type"] == want {
+			return true
+		}
+	}
+	return false
 }

--- a/cli/cmd/prompt_eval_test.go
+++ b/cli/cmd/prompt_eval_test.go
@@ -415,6 +415,44 @@ func TestPromptEvalRunCreatesPlaygroundTestCasesAndExperiments(t *testing.T) {
 	}
 }
 
+func TestPromptEvalRunValidatorMappingCoversSupportedAssertions(t *testing.T) {
+	path := writePromptEvalFixture(t, allAssertionsPromptEvalYAML())
+	fake := newPromptEvalRunFake(t, nil)
+	defer fake.server.Close()
+
+	_ = runPromptEvalRunJSON(t, path, fake.server.URL)
+	spec := mapObject(fake.playgroundCreates[0], "evaluation_spec")
+	validators := mapSlice(spec, "validators")
+	for _, want := range []string{"exact_match", "contains", "regex_match", "json_schema", "json_path_match", "boolean_assert"} {
+		if !promptEvalValidatorTypesContain(validators, want) {
+			t.Fatalf("validators missing %s: %#v", want, validators)
+		}
+	}
+	for _, validator := range validators {
+		asMap := validator.(map[string]any)
+		if !strings.HasPrefix(str(asMap["expected_from"]), "case.expectations.prompt_eval_assertions.") {
+			t.Fatalf("validator expected_from should read prompt_eval_assertions: %#v", asMap)
+		}
+	}
+}
+
+func TestPromptEvalRunJSONEnvelope(t *testing.T) {
+	path := writePromptEvalFixture(t, validPromptEvalYAML())
+	fake := newPromptEvalRunFake(t, nil)
+	defer fake.server.Close()
+
+	result := runPromptEvalRunJSON(t, path, fake.server.URL)
+	if result.SchemaVersion != 1 || result.WorkspaceID != "ws-1" || result.ConfigHash == "" || result.ModelCount != 1 || result.TestCount != 1 || result.CaseCount != 1 {
+		t.Fatalf("unexpected envelope: %+v", result)
+	}
+	if len(result.Playgrounds) != 1 || result.Playgrounds[0].PlaygroundID == "" || result.Playgrounds[0].PlaygroundURL == "" {
+		t.Fatalf("missing playground envelope: %+v", result.Playgrounds)
+	}
+	if len(result.Playgrounds[0].Experiments) != 1 || result.Playgrounds[0].Experiments[0].ExperimentID == "" || result.Playgrounds[0].Experiments[0].ExperimentURL == "" {
+		t.Fatalf("missing experiment envelope: %+v", result.Playgrounds[0].Experiments)
+	}
+}
+
 func TestPromptEvalRunUpdatesExistingResourcesWithoutDeletingOrphans(t *testing.T) {
 	path := writePromptEvalFixture(t, validPromptEvalYAML())
 	fake := newPromptEvalRunFake(t, &promptEvalRunFakeState{
@@ -455,6 +493,21 @@ func TestPromptEvalRunGroupsByAssertionSignature(t *testing.T) {
 		if !strings.Contains(str(create["name"]), "Prompt Eval: refund-bot-v1 [") {
 			t.Fatalf("grouped playground name missing signature suffix: %#v", create["name"])
 		}
+	}
+}
+
+func TestPromptEvalRunRerunNoopsExistingTestCases(t *testing.T) {
+	path := writePromptEvalFixture(t, validPromptEvalYAML())
+	fake := newPromptEvalRunFake(t, nil)
+	defer fake.server.Close()
+
+	first := runPromptEvalRunJSON(t, path, fake.server.URL)
+	second := runPromptEvalRunJSON(t, path, fake.server.URL)
+	if first.Playgrounds[0].TestsCreated != 1 {
+		t.Fatalf("first tests_created = %d, want 1", first.Playgrounds[0].TestsCreated)
+	}
+	if second.Playgrounds[0].TestsNoop != 1 || second.Playgrounds[0].TestsCreated != 0 || second.Playgrounds[0].TestsUpdated != 0 {
+		t.Fatalf("second run should no-op existing test case: %+v", second.Playgrounds[0])
 	}
 }
 
@@ -692,7 +745,14 @@ func newPromptEvalRunFake(t *testing.T, state *promptEvalRunFakeState) *promptEv
 		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/playgrounds/") && strings.HasSuffix(r.URL.Path, "/test-cases"):
 			body := decodePromptEvalRequestBody(t, r)
 			f.testCaseCreates = append(f.testCaseCreates, body)
-			json.NewEncoder(w).Encode(map[string]any{"id": fmt.Sprintf("tc-created-%d", len(f.testCaseCreates)), "case_key": body["case_key"]})
+			id := fmt.Sprintf("tc-created-%d", len(f.testCaseCreates))
+			f.testCases = append(f.testCases, map[string]any{
+				"id":           id,
+				"case_key":     body["case_key"],
+				"variables":    body["variables"],
+				"expectations": body["expectations"],
+			})
+			json.NewEncoder(w).Encode(map[string]any{"id": id, "case_key": body["case_key"]})
 		case r.Method == http.MethodPatch && strings.HasPrefix(r.URL.Path, "/v1/playground-test-cases/"):
 			body := decodePromptEvalRequestBody(t, r)
 			f.testCaseUpdates = append(f.testCaseUpdates, body)

--- a/testing/codex-prompt-eval-compile-run.md
+++ b/testing/codex-prompt-eval-compile-run.md
@@ -1,0 +1,41 @@
+# Codex Prompt Eval Compile Run - Test Contract
+
+Issue: #590
+Branch: `codex/prompt-eval-compile-run`
+
+## Functional Behavior
+
+- `agentclash prompt-eval run [path]` validates local config and remote resources before writing anything.
+- Run requires a workspace and uses the same model/provider resolution as `validate --remote`.
+- Test cases are grouped by assertion signature; heterogeneous assertion signatures compile into separate playgrounds.
+- Missing playgrounds are created with `name`, `prompt_template`, and an `evaluation_spec`.
+- Existing matching playgrounds are updated with the current prompt template and evaluation spec.
+- Missing test cases are created; changed test cases are updated; orphaned test cases are left untouched.
+- `tests[].assert[]` compiles into `expectations.prompt_eval_assertions` and playground-level validators using signature-level validator keys.
+- One fresh experiment is created for each resolved model in each compiled playground.
+- Structured output returns schemaVersion, workspace ID, config hash, model/test/case counts, playground IDs, experiment IDs, and UI links.
+
+## Unit Tests
+
+- `TestPromptEvalRunCreatesPlaygroundTestCasesAndExperiments` - fake API captures exact create payloads and experiment payloads.
+- `TestPromptEvalRunUpdatesExistingResourcesWithoutDeletingOrphans` - fake API captures playground/test-case update payloads and proves no DELETE is called.
+- `TestPromptEvalRunGroupsByAssertionSignature` - heterogeneous assertions create separate playgrounds with signature suffixes.
+- `TestPromptEvalRunValidatorMappingCoversSupportedAssertions` - exact/equals/contains/regex/json_schema/json_path_match/boolean_assert map to expected validator declarations.
+- `TestPromptEvalRunJSONEnvelope` - run output includes config hash, workspace, playgrounds, experiments, UI links, and counts.
+
+## Integration / Functional Tests
+
+- Run focused Go tests in `cli/cmd`.
+- Run `go test -short -race -count=1 ./...` from `cli/`.
+
+## Smoke Tests
+
+- `go run . prompt-eval run /tmp/agentclash-prompt-eval.yaml --workspace ws-1 --api-url <fake-or-local-api>` is covered by fake API tests. Hosted smoke is deferred until a workspace fixture exists.
+
+## E2E Tests
+
+N/A - this PR launches experiments but does not follow or aggregate results; E2E follows in #591.
+
+## Manual / cURL Tests
+
+N/A - fake API tests pin the request payloads for this write slice.


### PR DESCRIPTION
Closes #590.\n\n## Summary\n- add `prompt-eval run` launch mode\n- compile prompt-eval configs into grouped playgrounds and test cases\n- emit playground evaluation specs with validators and validator-backed dimensions\n- create one fresh experiment per resolved model/playground\n- return structured run output with config hash, playgrounds, experiments, links, and counts\n\n## Review checkpoint\n- Contract: `testing/codex-prompt-eval-compile-run.md`\n- Checkpoint status: ready\n\n## Tests\n- `cd cli && go build ./...`\n- `cd cli && go vet ./...`\n- `cd cli && go test -short -race -count=1 ./...`