### PR TITLE
feat(cli): add prompt-eval follow and results

### DIFF
--- a/cli/cmd/prompt_eval.go
+++ b/cli/cmd/prompt_eval.go
@@ -782,7 +782,7 @@ func followPromptEvalRun(cmd *cobra.Command, rc *RunContext, run *promptEvalRunR
 					allTerminal = false
 					continue
 				}
-				envelope, err := fetchPromptEvalResultsEnvelope(cmd, rc, exp.ExperimentID, options.ThresholdOverride)
+				envelope, err := fetchStablePromptEvalResultsEnvelope(cmd, rc, exp.ExperimentID, options.ThresholdOverride)
 				if err != nil {
 					run.ExitCode = promptEvalExitExecution
 					run.Errors = append(run.Errors, err.Error())
@@ -802,12 +802,63 @@ func followPromptEvalRun(cmd *cobra.Command, rc *RunContext, run *promptEvalRunR
 			return nil
 		}
 		if options.Timeout > 0 && time.Since(started) >= options.Timeout {
+			run.Results = fetchPromptEvalPartialResults(cmd, rc, run, options.ThresholdOverride)
+			run.Summary = combinePromptEvalSummaries(run.Results)
+			run.GateVerdict = promptEvalCombinedGateVerdict(run.Results)
 			run.ExitCode = promptEvalExitExecution
 			run.Errors = append(run.Errors, "timed out waiting for prompt eval experiments")
 			return &ExitCodeError{Code: promptEvalExitExecution}
 		}
 		time.Sleep(options.PollInterval)
 	}
+}
+
+func fetchStablePromptEvalResultsEnvelope(cmd *cobra.Command, rc *RunContext, experimentID string, thresholdOverride float64) (promptEvalResultsEnvelope, error) {
+	first, err := fetchPromptEvalResultsEnvelope(cmd, rc, experimentID, thresholdOverride)
+	if err != nil {
+		return first, err
+	}
+	second, err := fetchPromptEvalResultsEnvelope(cmd, rc, experimentID, thresholdOverride)
+	if err != nil {
+		return second, err
+	}
+	if promptEvalResultsStable(first, second) {
+		second.Telemetry["stability_checks"] = 2
+		return second, nil
+	}
+	third, err := fetchPromptEvalResultsEnvelope(cmd, rc, experimentID, thresholdOverride)
+	if err != nil {
+		return third, err
+	}
+	third.Telemetry["stability_checks"] = 3
+	return third, nil
+}
+
+func fetchPromptEvalPartialResults(cmd *cobra.Command, rc *RunContext, run *promptEvalRunResult, thresholdOverride float64) []promptEvalResultsEnvelope {
+	envelopes := []promptEvalResultsEnvelope{}
+	for _, playground := range run.Playgrounds {
+		for _, exp := range playground.Experiments {
+			envelope, err := fetchPromptEvalResultsEnvelope(cmd, rc, exp.ExperimentID, thresholdOverride)
+			if err != nil && envelope.ExperimentID == "" {
+				continue
+			}
+			envelopes = append(envelopes, envelope)
+		}
+	}
+	return envelopes
+}
+
+func promptEvalResultsStable(a, b promptEvalResultsEnvelope) bool {
+	return a.GateVerdict == b.GateVerdict &&
+		a.ExitCode == b.ExitCode &&
+		a.Summary.TotalCases == b.Summary.TotalCases &&
+		a.Summary.CompletedCases == b.Summary.CompletedCases &&
+		a.Summary.ExecutionErrors == b.Summary.ExecutionErrors &&
+		a.Summary.AssertionsPassed == b.Summary.AssertionsPassed &&
+		a.Summary.AssertionsFailed == b.Summary.AssertionsFailed &&
+		a.Summary.AssertionPassRate == b.Summary.AssertionPassRate &&
+		promptEvalRowsStable(a.Rows, b.Rows) &&
+		promptEvalFloatMapsStable(a.Summary.DimensionScores, b.Summary.DimensionScores)
 }
 
 func fetchPromptEvalExperimentStatus(cmd *cobra.Command, rc *RunContext, experimentID string) (string, bool, error) {
@@ -1428,6 +1479,44 @@ func promptEvalExitCodeForSummary(summary promptEvalResultsSummary, verdict stri
 		return promptEvalExitGate
 	}
 	return 0
+}
+
+func promptEvalRowsStable(a, b []promptEvalResultRow) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].CaseKey != b[i].CaseKey ||
+			a[i].AssertionKey != b[i].AssertionKey ||
+			a[i].Assertion != b[i].Assertion ||
+			a[i].Result != b[i].Result ||
+			a[i].Actual != b[i].Actual ||
+			a[i].Expected != b[i].Expected ||
+			a[i].Error != b[i].Error ||
+			a[i].LatencyMS != b[i].LatencyMS ||
+			a[i].Tokens != b[i].Tokens {
+			return false
+		}
+		if (a[i].Score == nil) != (b[i].Score == nil) {
+			return false
+		}
+		if a[i].Score != nil && b[i].Score != nil && *a[i].Score != *b[i].Score {
+			return false
+		}
+	}
+	return true
+}
+
+func promptEvalFloatMapsStable(a, b map[string]float64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key, value := range a {
+		if b[key] != value {
+			return false
+		}
+	}
+	return true
 }
 
 func promptEvalFloat(value any) (float64, bool) {

--- a/cli/cmd/prompt_eval.go
+++ b/cli/cmd/prompt_eval.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/agentclash/agentclash/cli/internal/output"
 	"github.com/spf13/cobra"
@@ -21,6 +22,8 @@ import (
 const (
 	promptEvalSchemaVersion = 1
 	promptEvalExitInvalid   = 5
+	promptEvalExitGate      = 3
+	promptEvalExitExecution = 4
 )
 
 func init() {
@@ -28,6 +31,7 @@ func init() {
 	promptEvalCmd.AddCommand(promptEvalInitCmd)
 	promptEvalCmd.AddCommand(promptEvalValidateCmd)
 	promptEvalCmd.AddCommand(promptEvalRunCmd)
+	promptEvalCmd.AddCommand(promptEvalResultsCmd)
 
 	promptEvalInitCmd.Flags().Bool("force", false, "Overwrite an existing file")
 	promptEvalInitCmd.Flags().String("name", "", "Prompt eval name (defaults from the file name)")
@@ -38,6 +42,10 @@ func init() {
 
 	promptEvalRunCmd.Flags().Int("max-cases", 100, "Maximum model x test cases allowed before launch")
 	promptEvalRunCmd.Flags().Bool("ci", false, "Apply CI-safe validation rules")
+	promptEvalRunCmd.Flags().Bool("follow", false, "Wait for launched experiments and print results")
+	promptEvalRunCmd.Flags().Duration("poll-interval", 3*time.Second, "Polling interval while following experiments")
+	promptEvalRunCmd.Flags().Duration("timeout", 20*time.Minute, "Maximum time to wait while following experiments; 0 disables the timeout")
+	promptEvalRunCmd.Flags().Float64("threshold", -1, "Override thresholds.assertion_pass_rate for this run")
 }
 
 var promptEvalCmd = &cobra.Command{
@@ -139,7 +147,14 @@ var promptEvalRunCmd = &cobra.Command{
 		}
 		maxCases, _ := cmd.Flags().GetInt("max-cases")
 		ciMode, _ := cmd.Flags().GetBool("ci")
+		follow, _ := cmd.Flags().GetBool("follow")
+		pollInterval, _ := cmd.Flags().GetDuration("poll-interval")
+		timeout, _ := cmd.Flags().GetDuration("timeout")
+		threshold, _ := cmd.Flags().GetFloat64("threshold")
 		result, err := executePromptEvalRun(cmd, rc, path, maxCases, ciMode)
+		if err == nil && follow && result != nil {
+			err = followPromptEvalRun(cmd, rc, result, promptEvalFollowOptions{PollInterval: pollInterval, Timeout: timeout, ThresholdOverride: threshold})
+		}
 		if rc.Output.IsStructured() {
 			if result != nil {
 				if printErr := rc.Output.PrintRaw(result); printErr != nil {
@@ -153,6 +168,27 @@ var promptEvalRunCmd = &cobra.Command{
 			return err
 		}
 		return nil
+	},
+}
+
+var promptEvalResultsCmd = &cobra.Command{
+	Use:   "results <experiment-id>",
+	Short: "Fetch prompt eval experiment results",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		envelope, err := fetchPromptEvalResultsEnvelope(cmd, rc, args[0], -1)
+		if rc.Output.IsStructured() {
+			if printErr := rc.Output.PrintRaw(envelope); printErr != nil {
+				return printErr
+			}
+		} else {
+			renderPromptEvalResults(rc, envelope)
+		}
+		if err != nil {
+			return err
+		}
+		return promptEvalExitForResults(envelope)
 	},
 }
 
@@ -245,16 +281,19 @@ type promptEvalRemoteDryRun struct {
 }
 
 type promptEvalRunResult struct {
-	SchemaVersion int                       `json:"schemaVersion" yaml:"schemaVersion"`
-	Path          string                    `json:"path" yaml:"path"`
-	ConfigHash    string                    `json:"config_hash" yaml:"config_hash"`
-	WorkspaceID   string                    `json:"workspace_id" yaml:"workspace_id"`
-	ModelCount    int                       `json:"model_count" yaml:"model_count"`
-	TestCount     int                       `json:"test_count" yaml:"test_count"`
-	CaseCount     int                       `json:"case_count" yaml:"case_count"`
-	Playgrounds   []promptEvalRunPlayground `json:"playgrounds" yaml:"playgrounds"`
-	Errors        []string                  `json:"errors,omitempty" yaml:"errors,omitempty"`
-	ExitCode      int                       `json:"exit_code" yaml:"exit_code"`
+	SchemaVersion int                         `json:"schemaVersion" yaml:"schemaVersion"`
+	Path          string                      `json:"path" yaml:"path"`
+	ConfigHash    string                      `json:"config_hash" yaml:"config_hash"`
+	WorkspaceID   string                      `json:"workspace_id" yaml:"workspace_id"`
+	ModelCount    int                         `json:"model_count" yaml:"model_count"`
+	TestCount     int                         `json:"test_count" yaml:"test_count"`
+	CaseCount     int                         `json:"case_count" yaml:"case_count"`
+	Playgrounds   []promptEvalRunPlayground   `json:"playgrounds" yaml:"playgrounds"`
+	Results       []promptEvalResultsEnvelope `json:"results,omitempty" yaml:"results,omitempty"`
+	Summary       promptEvalResultsSummary    `json:"summary,omitempty" yaml:"summary,omitempty"`
+	GateVerdict   string                      `json:"gate_verdict,omitempty" yaml:"gate_verdict,omitempty"`
+	Errors        []string                    `json:"errors,omitempty" yaml:"errors,omitempty"`
+	ExitCode      int                         `json:"exit_code" yaml:"exit_code"`
 }
 
 type promptEvalRunPlayground struct {
@@ -274,6 +313,48 @@ type promptEvalRunExperiment struct {
 	ModelAliasID      string `json:"model_alias_id" yaml:"model_alias_id"`
 	ProviderAccountID string `json:"provider_account_id" yaml:"provider_account_id"`
 	Status            string `json:"status,omitempty" yaml:"status,omitempty"`
+}
+
+type promptEvalFollowOptions struct {
+	PollInterval      time.Duration
+	Timeout           time.Duration
+	ThresholdOverride float64
+}
+
+type promptEvalResultsEnvelope struct {
+	SchemaVersion int                      `json:"schemaVersion" yaml:"schemaVersion"`
+	ExperimentID  string                   `json:"experiment_id" yaml:"experiment_id"`
+	Status        string                   `json:"status,omitempty" yaml:"status,omitempty"`
+	Rows          []promptEvalResultRow    `json:"rows" yaml:"rows"`
+	Summary       promptEvalResultsSummary `json:"summary" yaml:"summary"`
+	Thresholds    map[string]float64       `json:"thresholds,omitempty" yaml:"thresholds,omitempty"`
+	GateVerdict   string                   `json:"gate_verdict" yaml:"gate_verdict"`
+	Telemetry     map[string]any           `json:"telemetry,omitempty" yaml:"telemetry,omitempty"`
+	Errors        []string                 `json:"errors,omitempty" yaml:"errors,omitempty"`
+	ExitCode      int                      `json:"exit_code" yaml:"exit_code"`
+}
+
+type promptEvalResultRow struct {
+	CaseKey      string   `json:"case_key" yaml:"case_key"`
+	AssertionKey string   `json:"assertion_key,omitempty" yaml:"assertion_key,omitempty"`
+	Assertion    string   `json:"assertion,omitempty" yaml:"assertion,omitempty"`
+	Result       string   `json:"result" yaml:"result"`
+	Score        *float64 `json:"score,omitempty" yaml:"score,omitempty"`
+	Actual       string   `json:"actual,omitempty" yaml:"actual,omitempty"`
+	Expected     string   `json:"expected,omitempty" yaml:"expected,omitempty"`
+	LatencyMS    int64    `json:"latency_ms,omitempty" yaml:"latency_ms,omitempty"`
+	Tokens       int64    `json:"tokens,omitempty" yaml:"tokens,omitempty"`
+	Error        string   `json:"error,omitempty" yaml:"error,omitempty"`
+}
+
+type promptEvalResultsSummary struct {
+	TotalCases        int                `json:"total_cases" yaml:"total_cases"`
+	CompletedCases    int                `json:"completed_cases" yaml:"completed_cases"`
+	ExecutionErrors   int                `json:"execution_errors" yaml:"execution_errors"`
+	AssertionsPassed  int                `json:"assertions_passed" yaml:"assertions_passed"`
+	AssertionsFailed  int                `json:"assertions_failed" yaml:"assertions_failed"`
+	AssertionPassRate float64            `json:"assertion_pass_rate" yaml:"assertion_pass_rate"`
+	DimensionScores   map[string]float64 `json:"dimension_scores,omitempty" yaml:"dimension_scores,omitempty"`
 }
 
 func buildPromptEvalScaffold(name string) ([]byte, error) {
@@ -672,6 +753,188 @@ func createPromptEvalExperiment(cmd *cobra.Command, rc *RunContext, playgroundID
 		ProviderAccountID: model.ProviderAccountID,
 		Status:            mapString(created, "status"),
 	}, nil
+}
+
+func followPromptEvalRun(cmd *cobra.Command, rc *RunContext, run *promptEvalRunResult, options promptEvalFollowOptions) error {
+	if options.PollInterval <= 0 {
+		options.PollInterval = 3 * time.Second
+	}
+	started := time.Now()
+	for {
+		allTerminal := true
+		var envelopes []promptEvalResultsEnvelope
+		for pIndex := range run.Playgrounds {
+			for eIndex := range run.Playgrounds[pIndex].Experiments {
+				exp := &run.Playgrounds[pIndex].Experiments[eIndex]
+				status, authErr, err := fetchPromptEvalExperimentStatus(cmd, rc, exp.ExperimentID)
+				if authErr {
+					run.ExitCode = promptEvalExitInvalid
+					run.Errors = append(run.Errors, "auth failed while polling experiment "+exp.ExperimentID)
+					return &ExitCodeError{Code: promptEvalExitInvalid}
+				}
+				if err != nil {
+					run.ExitCode = promptEvalExitExecution
+					run.Errors = append(run.Errors, err.Error())
+					return &ExitCodeError{Code: promptEvalExitExecution}
+				}
+				exp.Status = status
+				if status != "completed" && status != "failed" {
+					allTerminal = false
+					continue
+				}
+				envelope, err := fetchPromptEvalResultsEnvelope(cmd, rc, exp.ExperimentID, options.ThresholdOverride)
+				if err != nil {
+					run.ExitCode = promptEvalExitExecution
+					run.Errors = append(run.Errors, err.Error())
+					return &ExitCodeError{Code: promptEvalExitExecution}
+				}
+				envelopes = append(envelopes, envelope)
+			}
+		}
+		if allTerminal {
+			run.Results = envelopes
+			run.Summary = combinePromptEvalSummaries(envelopes)
+			run.GateVerdict = promptEvalCombinedGateVerdict(envelopes)
+			run.ExitCode = promptEvalExitCodeForSummary(run.Summary, run.GateVerdict)
+			if run.ExitCode != 0 {
+				return &ExitCodeError{Code: run.ExitCode}
+			}
+			return nil
+		}
+		if options.Timeout > 0 && time.Since(started) >= options.Timeout {
+			run.ExitCode = promptEvalExitExecution
+			run.Errors = append(run.Errors, "timed out waiting for prompt eval experiments")
+			return &ExitCodeError{Code: promptEvalExitExecution}
+		}
+		time.Sleep(options.PollInterval)
+	}
+}
+
+func fetchPromptEvalExperimentStatus(cmd *cobra.Command, rc *RunContext, experimentID string) (string, bool, error) {
+	resp, err := rc.Client.Get(cmd.Context(), "/v1/playground-experiments/"+experimentID, nil)
+	if err != nil {
+		return "", false, err
+	}
+	if resp.StatusCode == 401 {
+		return "", true, nil
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return "", false, apiErr
+	}
+	var payload map[string]any
+	if err := resp.DecodeJSON(&payload); err != nil {
+		return "", false, err
+	}
+	return mapString(payload, "status"), false, nil
+}
+
+func fetchPromptEvalResultsEnvelope(cmd *cobra.Command, rc *RunContext, experimentID string, thresholdOverride float64) (promptEvalResultsEnvelope, error) {
+	resp, err := rc.Client.Get(cmd.Context(), "/v1/playground-experiments/"+experimentID+"/results", nil)
+	envelope := promptEvalResultsEnvelope{
+		SchemaVersion: promptEvalSchemaVersion,
+		ExperimentID:  experimentID,
+		Rows:          []promptEvalResultRow{},
+		Thresholds:    map[string]float64{},
+		Telemetry:     map[string]any{"fetched_at": time.Now().UTC().Format(time.RFC3339)},
+	}
+	if err != nil {
+		envelope.Errors = append(envelope.Errors, err.Error())
+		envelope.ExitCode = promptEvalExitExecution
+		return envelope, err
+	}
+	if resp.StatusCode == 401 {
+		err := fmt.Errorf("auth failed while fetching experiment results")
+		envelope.Errors = append(envelope.Errors, err.Error())
+		envelope.ExitCode = promptEvalExitInvalid
+		return envelope, &ExitCodeError{Code: promptEvalExitInvalid}
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		envelope.Errors = append(envelope.Errors, apiErr.Error())
+		envelope.ExitCode = promptEvalExitExecution
+		return envelope, apiErr
+	}
+	var payload struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := resp.DecodeJSON(&payload); err != nil {
+		envelope.Errors = append(envelope.Errors, err.Error())
+		envelope.ExitCode = promptEvalExitExecution
+		return envelope, err
+	}
+	envelope.Rows, envelope.Summary = aggregatePromptEvalRows(payload.Items)
+	threshold := thresholdOverride
+	if threshold < 0 {
+		threshold = 1
+	}
+	envelope.Thresholds["assertion_pass_rate"] = threshold
+	envelope.GateVerdict = "pass"
+	if envelope.Summary.ExecutionErrors > 0 {
+		envelope.GateVerdict = "error"
+		envelope.ExitCode = promptEvalExitExecution
+	} else if envelope.Summary.AssertionPassRate < threshold {
+		envelope.GateVerdict = "fail"
+		envelope.ExitCode = promptEvalExitGate
+	}
+	envelope.Telemetry["row_count"] = len(envelope.Rows)
+	return envelope, nil
+}
+
+func aggregatePromptEvalRows(items []map[string]any) ([]promptEvalResultRow, promptEvalResultsSummary) {
+	rows := []promptEvalResultRow{}
+	summary := promptEvalResultsSummary{TotalCases: len(items), DimensionScores: map[string]float64{}}
+	dimensionTotals := map[string]float64{}
+	dimensionCounts := map[string]int{}
+	for _, item := range items {
+		caseKey := mapString(item, "case_key")
+		status := mapString(item, "status")
+		if status == "completed" {
+			summary.CompletedCases++
+		}
+		if status == "failed" || mapString(item, "error_message") != "" {
+			summary.ExecutionErrors++
+			rows = append(rows, promptEvalResultRow{CaseKey: caseKey, Result: "ERROR", Error: mapString(item, "error_message"), Actual: truncateRunes(mapString(item, "actual_output"), 160), LatencyMS: promptEvalInt64(item["latency_ms"]), Tokens: promptEvalInt64(item["total_tokens"])})
+			continue
+		}
+		for _, raw := range mapSlice(item, "validator_results") {
+			validator, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			verdict := mapString(validator, "verdict")
+			if verdict == "pass" {
+				summary.AssertionsPassed++
+			} else {
+				summary.AssertionsFailed++
+			}
+			score := promptEvalFloatPtr(mapValue(validator, "normalized_score", "score"))
+			rows = append(rows, promptEvalResultRow{
+				CaseKey:      caseKey,
+				AssertionKey: mapString(validator, "key"),
+				Assertion:    mapString(validator, "type"),
+				Result:       strings.ToUpper(verdict),
+				Score:        score,
+				Actual:       truncateRunes(mapString(item, "actual_output"), 160),
+				Expected:     mapString(validator, "expected", "expected_value"),
+				LatencyMS:    promptEvalInt64(item["latency_ms"]),
+				Tokens:       promptEvalInt64(item["total_tokens"]),
+				Error:        mapString(validator, "reason"),
+			})
+		}
+		for key, value := range mapObject(item, "dimension_scores") {
+			if f, ok := promptEvalFloat(value); ok {
+				dimensionTotals[key] += f
+				dimensionCounts[key]++
+			}
+		}
+	}
+	totalAssertions := summary.AssertionsPassed + summary.AssertionsFailed
+	if totalAssertions > 0 {
+		summary.AssertionPassRate = float64(summary.AssertionsPassed) / float64(totalAssertions)
+	}
+	for key, total := range dimensionTotals {
+		summary.DimensionScores[key] = total / float64(dimensionCounts[key])
+	}
+	return rows, summary
 }
 
 func promptEvalTestCaseBody(test promptEvalTest) map[string]any {
@@ -1095,6 +1358,114 @@ func renderPromptEvalRun(rc *RunContext, result promptEvalRunResult) {
 		}
 	}
 	rc.Output.PrintTable([]output.Column{{Header: "Playground"}, {Header: "Experiment"}, {Header: "Model Alias"}, {Header: "Status"}}, rows)
+}
+
+func renderPromptEvalResults(rc *RunContext, result promptEvalResultsEnvelope) {
+	if result.ExitCode != 0 {
+		rc.Output.PrintError("Prompt eval results failed")
+	}
+	rows := make([][]string, 0, len(result.Rows))
+	for _, row := range result.Rows {
+		score := "-"
+		if row.Score != nil {
+			score = fmt.Sprintf("%.2f", *row.Score)
+		}
+		rows = append(rows, []string{row.CaseKey, row.AssertionKey, row.Result, score, row.Error})
+	}
+	rc.Output.PrintTable([]output.Column{{Header: "Case"}, {Header: "Assertion"}, {Header: "Result"}, {Header: "Score"}, {Header: "Error"}}, rows)
+}
+
+func combinePromptEvalSummaries(envelopes []promptEvalResultsEnvelope) promptEvalResultsSummary {
+	out := promptEvalResultsSummary{DimensionScores: map[string]float64{}}
+	dimTotals := map[string]float64{}
+	dimCounts := map[string]int{}
+	for _, envelope := range envelopes {
+		out.TotalCases += envelope.Summary.TotalCases
+		out.CompletedCases += envelope.Summary.CompletedCases
+		out.ExecutionErrors += envelope.Summary.ExecutionErrors
+		out.AssertionsPassed += envelope.Summary.AssertionsPassed
+		out.AssertionsFailed += envelope.Summary.AssertionsFailed
+		for key, value := range envelope.Summary.DimensionScores {
+			dimTotals[key] += value
+			dimCounts[key]++
+		}
+	}
+	totalAssertions := out.AssertionsPassed + out.AssertionsFailed
+	if totalAssertions > 0 {
+		out.AssertionPassRate = float64(out.AssertionsPassed) / float64(totalAssertions)
+	}
+	for key, total := range dimTotals {
+		out.DimensionScores[key] = total / float64(dimCounts[key])
+	}
+	return out
+}
+
+func promptEvalCombinedGateVerdict(envelopes []promptEvalResultsEnvelope) string {
+	verdict := "pass"
+	for _, envelope := range envelopes {
+		if envelope.GateVerdict == "error" {
+			return "error"
+		}
+		if envelope.GateVerdict == "fail" {
+			verdict = "fail"
+		}
+	}
+	return verdict
+}
+
+func promptEvalExitForResults(envelope promptEvalResultsEnvelope) error {
+	if envelope.ExitCode == 0 {
+		return nil
+	}
+	return &ExitCodeError{Code: envelope.ExitCode}
+}
+
+func promptEvalExitCodeForSummary(summary promptEvalResultsSummary, verdict string) int {
+	if summary.ExecutionErrors > 0 || verdict == "error" {
+		return promptEvalExitExecution
+	}
+	if verdict == "fail" {
+		return promptEvalExitGate
+	}
+	return 0
+}
+
+func promptEvalFloat(value any) (float64, bool) {
+	switch typed := value.(type) {
+	case float64:
+		return typed, true
+	case float32:
+		return float64(typed), true
+	case int:
+		return float64(typed), true
+	case int64:
+		return float64(typed), true
+	case json.Number:
+		f, err := typed.Float64()
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func promptEvalFloatPtr(value any) *float64 {
+	if f, ok := promptEvalFloat(value); ok {
+		return &f
+	}
+	return nil
+}
+
+func promptEvalInt64(value any) int64 {
+	switch typed := value.(type) {
+	case float64:
+		return int64(typed)
+	case int64:
+		return typed
+	case int:
+		return int64(typed)
+	default:
+		return 0
+	}
 }
 
 func sortedPromptEvalKeys(values map[string]bool) []string {

--- a/cli/cmd/prompt_eval.go
+++ b/cli/cmd/prompt_eval.go
@@ -46,6 +46,7 @@ func init() {
 	promptEvalRunCmd.Flags().Duration("poll-interval", 3*time.Second, "Polling interval while following experiments")
 	promptEvalRunCmd.Flags().Duration("timeout", 20*time.Minute, "Maximum time to wait while following experiments; 0 disables the timeout")
 	promptEvalRunCmd.Flags().Float64("threshold", -1, "Override thresholds.assertion_pass_rate for this run")
+	promptEvalResultsCmd.Flags().Float64("threshold", -1, "Override the assertion pass-rate gate for fetched results")
 }
 
 var promptEvalCmd = &cobra.Command{
@@ -153,6 +154,9 @@ var promptEvalRunCmd = &cobra.Command{
 		threshold, _ := cmd.Flags().GetFloat64("threshold")
 		result, err := executePromptEvalRun(cmd, rc, path, maxCases, ciMode)
 		if err == nil && follow && result != nil {
+			if threshold < 0 {
+				threshold = result.AssertionPassThreshold
+			}
 			err = followPromptEvalRun(cmd, rc, result, promptEvalFollowOptions{PollInterval: pollInterval, Timeout: timeout, ThresholdOverride: threshold})
 		}
 		if rc.Output.IsStructured() {
@@ -177,7 +181,8 @@ var promptEvalResultsCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		rc := GetRunContext(cmd)
-		envelope, err := fetchPromptEvalResultsEnvelope(cmd, rc, args[0], -1)
+		threshold, _ := cmd.Flags().GetFloat64("threshold")
+		envelope, err := fetchPromptEvalResultsEnvelope(cmd, rc, args[0], threshold)
 		if rc.Output.IsStructured() {
 			if printErr := rc.Output.PrintRaw(envelope); printErr != nil {
 				return printErr
@@ -186,6 +191,9 @@ var promptEvalResultsCmd = &cobra.Command{
 			renderPromptEvalResults(rc, envelope)
 		}
 		if err != nil {
+			if exitErr := promptEvalExitForResults(envelope); exitErr != nil {
+				return exitErr
+			}
 			return err
 		}
 		return promptEvalExitForResults(envelope)
@@ -294,6 +302,8 @@ type promptEvalRunResult struct {
 	GateVerdict   string                      `json:"gate_verdict,omitempty" yaml:"gate_verdict,omitempty"`
 	Errors        []string                    `json:"errors,omitempty" yaml:"errors,omitempty"`
 	ExitCode      int                         `json:"exit_code" yaml:"exit_code"`
+
+	AssertionPassThreshold float64 `json:"-" yaml:"-"`
 }
 
 type promptEvalRunPlayground struct {
@@ -592,14 +602,15 @@ func executePromptEvalRun(cmd *cobra.Command, rc *RunContext, path string, maxCa
 		}, &ExitCodeError{Code: promptEvalExitInvalid}
 	}
 	run := &promptEvalRunResult{
-		SchemaVersion: promptEvalSchemaVersion,
-		Path:          path,
-		ConfigHash:    promptEvalConfigHash(data),
-		WorkspaceID:   validation.Remote.WorkspaceID,
-		ModelCount:    validation.ModelCount,
-		TestCount:     validation.TestCount,
-		CaseCount:     validation.CaseCount,
-		Playgrounds:   []promptEvalRunPlayground{},
+		SchemaVersion:          promptEvalSchemaVersion,
+		Path:                   path,
+		ConfigHash:             promptEvalConfigHash(data),
+		WorkspaceID:            validation.Remote.WorkspaceID,
+		ModelCount:             validation.ModelCount,
+		TestCount:              validation.TestCount,
+		CaseCount:              validation.CaseCount,
+		Playgrounds:            []promptEvalRunPlayground{},
+		AssertionPassThreshold: promptEvalAssertionPassThreshold(cfg),
 	}
 	groups := promptEvalTestGroups(cfg)
 	for _, group := range groups {
@@ -809,7 +820,13 @@ func followPromptEvalRun(cmd *cobra.Command, rc *RunContext, run *promptEvalRunR
 			run.Errors = append(run.Errors, "timed out waiting for prompt eval experiments")
 			return &ExitCodeError{Code: promptEvalExitExecution}
 		}
-		time.Sleep(options.PollInterval)
+		select {
+		case <-cmd.Context().Done():
+			run.ExitCode = promptEvalExitExecution
+			run.Errors = append(run.Errors, cmd.Context().Err().Error())
+			return &ExitCodeError{Code: promptEvalExitExecution}
+		case <-time.After(options.PollInterval):
+		}
 	}
 }
 
@@ -839,13 +856,20 @@ func fetchPromptEvalPartialResults(cmd *cobra.Command, rc *RunContext, run *prom
 	for _, playground := range run.Playgrounds {
 		for _, exp := range playground.Experiments {
 			envelope, err := fetchPromptEvalResultsEnvelope(cmd, rc, exp.ExperimentID, thresholdOverride)
-			if err != nil && envelope.ExperimentID == "" {
+			if err != nil {
 				continue
 			}
 			envelopes = append(envelopes, envelope)
 		}
 	}
 	return envelopes
+}
+
+func promptEvalAssertionPassThreshold(cfg promptEvalConfig) float64 {
+	if cfg.Thresholds.AssertionPassRate == nil {
+		return 1
+	}
+	return *cfg.Thresholds.AssertionPassRate
 }
 
 func promptEvalResultsStable(a, b promptEvalResultsEnvelope) bool {

--- a/cli/cmd/prompt_eval_test.go
+++ b/cli/cmd/prompt_eval_test.go
@@ -523,6 +523,9 @@ func TestPromptEvalRunFollowPassesGate(t *testing.T) {
 	if result.GateVerdict != "pass" || result.Summary.AssertionsPassed != 1 || result.ExitCode != 0 {
 		t.Fatalf("unexpected follow result: %+v", result)
 	}
+	if got := result.Results[0].Telemetry["stability_checks"]; got == nil {
+		t.Fatalf("missing stability telemetry: %+v", result.Results[0].Telemetry)
+	}
 }
 
 func TestPromptEvalRunFollowFailsAssertionGate(t *testing.T) {
@@ -567,6 +570,9 @@ func TestPromptEvalRunFollowTimesOutWithPartialResults(t *testing.T) {
 	}
 	if !containsPromptEvalMessage(result.Errors, "timed out") {
 		t.Fatalf("errors = %v", result.Errors)
+	}
+	if len(result.Results) != 1 || result.Results[0].Summary.TotalCases != 1 {
+		t.Fatalf("timeout did not include partial results: %+v", result)
 	}
 }
 

--- a/cli/cmd/prompt_eval_test.go
+++ b/cli/cmd/prompt_eval_test.go
@@ -511,6 +511,96 @@ func TestPromptEvalRunRerunNoopsExistingTestCases(t *testing.T) {
 	}
 }
 
+func TestPromptEvalRunFollowPassesGate(t *testing.T) {
+	path := writePromptEvalFixture(t, validPromptEvalYAML())
+	fake := newPromptEvalRunFake(t, nil)
+	defer fake.server.Close()
+
+	result, err := runPromptEvalRunJSONWithArgs(t, []string{"prompt-eval", "run", path, "-w", "ws-1", "--json", "--follow", "--poll-interval", "1ms"}, fake.server.URL)
+	if err != nil {
+		t.Fatalf("follow pass error: %v", err)
+	}
+	if result.GateVerdict != "pass" || result.Summary.AssertionsPassed != 1 || result.ExitCode != 0 {
+		t.Fatalf("unexpected follow result: %+v", result)
+	}
+}
+
+func TestPromptEvalRunFollowFailsAssertionGate(t *testing.T) {
+	path := writePromptEvalFixture(t, validPromptEvalYAML())
+	fake := newPromptEvalRunFake(t, &promptEvalRunFakeState{resultVerdict: "fail"})
+	defer fake.server.Close()
+
+	result, err := runPromptEvalRunJSONWithArgs(t, []string{"prompt-eval", "run", path, "-w", "ws-1", "--json", "--follow", "--poll-interval", "1ms"}, fake.server.URL)
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) || exitErr.Code != promptEvalExitGate {
+		t.Fatalf("expected gate exit, got %T %v with result %+v", err, err, result)
+	}
+	if result.GateVerdict != "fail" || result.ExitCode != promptEvalExitGate {
+		t.Fatalf("unexpected gate result: %+v", result)
+	}
+}
+
+func TestPromptEvalRunFollowReportsExecutionError(t *testing.T) {
+	path := writePromptEvalFixture(t, validPromptEvalYAML())
+	fake := newPromptEvalRunFake(t, &promptEvalRunFakeState{caseStatus: "failed"})
+	defer fake.server.Close()
+
+	result, err := runPromptEvalRunJSONWithArgs(t, []string{"prompt-eval", "run", path, "-w", "ws-1", "--json", "--follow", "--poll-interval", "1ms"}, fake.server.URL)
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) || exitErr.Code != promptEvalExitExecution {
+		t.Fatalf("expected execution exit, got %T %v with result %+v", err, err, result)
+	}
+	if result.Summary.ExecutionErrors != 1 {
+		t.Fatalf("execution errors = %d, want 1", result.Summary.ExecutionErrors)
+	}
+}
+
+func TestPromptEvalRunFollowTimesOutWithPartialResults(t *testing.T) {
+	path := writePromptEvalFixture(t, validPromptEvalYAML())
+	fake := newPromptEvalRunFake(t, &promptEvalRunFakeState{experimentStatus: "running"})
+	defer fake.server.Close()
+
+	result, err := runPromptEvalRunJSONWithArgs(t, []string{"prompt-eval", "run", path, "-w", "ws-1", "--json", "--follow", "--poll-interval", "1ms", "--timeout", "1ms"}, fake.server.URL)
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) || exitErr.Code != promptEvalExitExecution {
+		t.Fatalf("expected timeout execution exit, got %T %v with result %+v", err, err, result)
+	}
+	if !containsPromptEvalMessage(result.Errors, "timed out") {
+		t.Fatalf("errors = %v", result.Errors)
+	}
+}
+
+func TestPromptEvalRunFollowAuthFailureDuringPoll(t *testing.T) {
+	path := writePromptEvalFixture(t, validPromptEvalYAML())
+	fake := newPromptEvalRunFake(t, &promptEvalRunFakeState{authOnExperimentGet: true})
+	defer fake.server.Close()
+
+	result, err := runPromptEvalRunJSONWithArgs(t, []string{"prompt-eval", "run", path, "-w", "ws-1", "--json", "--follow", "--poll-interval", "1ms"}, fake.server.URL)
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) || exitErr.Code != promptEvalExitInvalid {
+		t.Fatalf("expected auth invalid exit, got %T %v with result %+v", err, err, result)
+	}
+}
+
+func TestPromptEvalResultsCommandPrintsStableEnvelope(t *testing.T) {
+	fake := newPromptEvalRunFake(t, nil)
+	defer fake.server.Close()
+
+	stdout := captureStdout(t)
+	err := executeCommand(t, []string{"prompt-eval", "results", "exp-1", "--json"}, fake.server.URL)
+	out := stdout.finish()
+	if err != nil {
+		t.Fatalf("results command error: %v\n%s", err, out)
+	}
+	var result promptEvalResultsEnvelope
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode results json: %v\n%s", err, out)
+	}
+	if result.SchemaVersion != 1 || result.Summary.AssertionsPassed != 1 || result.GateVerdict != "pass" || result.Telemetry["row_count"] == nil {
+		t.Fatalf("unexpected results envelope: %+v", result)
+	}
+}
+
 func TestChallengePackPromptEvalTemplateMentionsPromptEvalInit(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "pack.yaml")
@@ -690,23 +780,31 @@ func runPromptEvalValidateJSON(t *testing.T, args []string, apiURL string) promp
 }
 
 type promptEvalRunFakeState struct {
-	playgrounds []map[string]any
-	testCases   []map[string]any
+	playgrounds         []map[string]any
+	testCases           []map[string]any
+	experimentStatus    string
+	caseStatus          string
+	resultVerdict       string
+	authOnExperimentGet bool
 }
 
 type promptEvalRunFake struct {
-	server            *httptest.Server
-	mu                sync.Mutex
-	playgrounds       []map[string]any
-	testCases         []map[string]any
-	playgroundCreates []map[string]any
-	playgroundUpdates []map[string]any
-	testCaseCreates   []map[string]any
-	testCaseUpdates   []map[string]any
-	experimentCreates []map[string]any
-	deleteCalled      bool
-	nextPlaygroundID  int
-	nextExperimentID  int
+	server              *httptest.Server
+	mu                  sync.Mutex
+	playgrounds         []map[string]any
+	testCases           []map[string]any
+	playgroundCreates   []map[string]any
+	playgroundUpdates   []map[string]any
+	testCaseCreates     []map[string]any
+	testCaseUpdates     []map[string]any
+	experimentCreates   []map[string]any
+	deleteCalled        bool
+	nextPlaygroundID    int
+	nextExperimentID    int
+	experimentStatus    string
+	caseStatus          string
+	resultVerdict       string
+	authOnExperimentGet bool
 }
 
 func newPromptEvalRunFake(t *testing.T, state *promptEvalRunFakeState) *promptEvalRunFake {
@@ -715,6 +813,19 @@ func newPromptEvalRunFake(t *testing.T, state *promptEvalRunFakeState) *promptEv
 	if state != nil {
 		f.playgrounds = append(f.playgrounds, state.playgrounds...)
 		f.testCases = append(f.testCases, state.testCases...)
+		f.experimentStatus = state.experimentStatus
+		f.caseStatus = state.caseStatus
+		f.resultVerdict = state.resultVerdict
+		f.authOnExperimentGet = state.authOnExperimentGet
+	}
+	if f.experimentStatus == "" {
+		f.experimentStatus = "completed"
+	}
+	if f.caseStatus == "" {
+		f.caseStatus = "completed"
+	}
+	if f.resultVerdict == "" {
+		f.resultVerdict = "pass"
 	}
 	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		f.mu.Lock()
@@ -763,6 +874,16 @@ func newPromptEvalRunFake(t *testing.T, state *promptEvalRunFakeState) *promptEv
 			id := fmt.Sprintf("exp-%d", f.nextExperimentID)
 			f.nextExperimentID++
 			json.NewEncoder(w).Encode(map[string]any{"id": id, "status": "queued", "url": "https://agentclash.dev/playground-experiments/" + id})
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/playground-experiments/") && strings.HasSuffix(r.URL.Path, "/results"):
+			json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{f.resultItem()}})
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/playground-experiments/"):
+			if f.authOnExperimentGet {
+				w.WriteHeader(http.StatusUnauthorized)
+				json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"code": "unauthorized", "message": "unauthorized"}})
+				return
+			}
+			id := strings.TrimPrefix(r.URL.Path, "/v1/playground-experiments/")
+			json.NewEncoder(w).Encode(map[string]any{"id": id, "status": f.experimentStatus})
 		case r.Method == http.MethodDelete:
 			f.deleteCalled = true
 			w.WriteHeader(http.StatusInternalServerError)
@@ -773,6 +894,30 @@ func newPromptEvalRunFake(t *testing.T, state *promptEvalRunFakeState) *promptEv
 		}
 	}))
 	return f
+}
+
+func (f *promptEvalRunFake) resultItem() map[string]any {
+	validatorVerdict := f.resultVerdict
+	score := 1.0
+	if validatorVerdict == "fail" {
+		score = 0
+	}
+	item := map[string]any{
+		"id":               "res-1",
+		"case_key":         "greeting",
+		"status":           f.caseStatus,
+		"actual_output":    "Bonjour",
+		"latency_ms":       12,
+		"total_tokens":     7,
+		"dimension_scores": map[string]any{"correctness": score},
+		"validator_results": []any{
+			map[string]any{"key": "v1", "type": "contains", "verdict": validatorVerdict, "normalized_score": score, "reason": ""},
+		},
+	}
+	if f.caseStatus == "failed" {
+		item["error_message"] = "provider failed"
+	}
+	return item
 }
 
 func decodePromptEvalRequestBody(t *testing.T, r *http.Request) map[string]any {
@@ -786,17 +931,23 @@ func decodePromptEvalRequestBody(t *testing.T, r *http.Request) map[string]any {
 
 func runPromptEvalRunJSON(t *testing.T, path, apiURL string) promptEvalRunResult {
 	t.Helper()
-	stdout := captureStdout(t)
-	err := executeCommand(t, []string{"prompt-eval", "run", path, "-w", "ws-1", "--json"}, apiURL)
-	out := stdout.finish()
+	result, err := runPromptEvalRunJSONWithArgs(t, []string{"prompt-eval", "run", path, "-w", "ws-1", "--json"}, apiURL)
 	if err != nil {
-		t.Fatalf("prompt-eval run error: %v\n%s", err, out)
+		t.Fatalf("prompt-eval run error: %v", err)
 	}
+	return result
+}
+
+func runPromptEvalRunJSONWithArgs(t *testing.T, args []string, apiURL string) (promptEvalRunResult, error) {
+	t.Helper()
+	stdout := captureStdout(t)
+	err := executeCommand(t, args, apiURL)
+	out := stdout.finish()
 	var result promptEvalRunResult
 	if err := json.Unmarshal([]byte(out), &result); err != nil {
 		t.Fatalf("decode run json: %v\n%s", err, out)
 	}
-	return result
+	return result, err
 }
 
 func promptEvalValidatorTypesContain(validators []any, want string) bool {

--- a/cli/cmd/prompt_eval_test.go
+++ b/cli/cmd/prompt_eval_test.go
@@ -543,6 +543,21 @@ func TestPromptEvalRunFollowFailsAssertionGate(t *testing.T) {
 	}
 }
 
+func TestPromptEvalRunFollowUsesConfigThreshold(t *testing.T) {
+	body := strings.Replace(validPromptEvalYAML(), "assertion_pass_rate: 0.9", "assertion_pass_rate: 0.0", 1)
+	path := writePromptEvalFixture(t, body)
+	fake := newPromptEvalRunFake(t, &promptEvalRunFakeState{resultVerdict: "fail"})
+	defer fake.server.Close()
+
+	result, err := runPromptEvalRunJSONWithArgs(t, []string{"prompt-eval", "run", path, "-w", "ws-1", "--json", "--follow", "--poll-interval", "1ms"}, fake.server.URL)
+	if err != nil {
+		t.Fatalf("config threshold should allow zero pass rate: %v with result %+v", err, result)
+	}
+	if result.Results[0].Thresholds["assertion_pass_rate"] != 0 || result.GateVerdict != "pass" {
+		t.Fatalf("config threshold was not applied: %+v", result)
+	}
+}
+
 func TestPromptEvalRunFollowReportsExecutionError(t *testing.T) {
 	path := writePromptEvalFixture(t, validPromptEvalYAML())
 	fake := newPromptEvalRunFake(t, &promptEvalRunFakeState{caseStatus: "failed"})
@@ -604,6 +619,26 @@ func TestPromptEvalResultsCommandPrintsStableEnvelope(t *testing.T) {
 	}
 	if result.SchemaVersion != 1 || result.Summary.AssertionsPassed != 1 || result.GateVerdict != "pass" || result.Telemetry["row_count"] == nil {
 		t.Fatalf("unexpected results envelope: %+v", result)
+	}
+}
+
+func TestPromptEvalResultsCommandWrapsBackendErrorExit(t *testing.T) {
+	fake := newPromptEvalRunFake(t, &promptEvalRunFakeState{resultStatusCode: http.StatusBadGateway})
+	defer fake.server.Close()
+
+	stdout := captureStdout(t)
+	err := executeCommand(t, []string{"prompt-eval", "results", "exp-1", "--json"}, fake.server.URL)
+	out := stdout.finish()
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) || exitErr.Code != promptEvalExitExecution {
+		t.Fatalf("expected execution exit, got %T %v\n%s", err, err, out)
+	}
+	var result promptEvalResultsEnvelope
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode results json: %v\n%s", err, out)
+	}
+	if result.ExitCode != promptEvalExitExecution {
+		t.Fatalf("json exit_code = %d, want %d", result.ExitCode, promptEvalExitExecution)
 	}
 }
 
@@ -791,6 +826,7 @@ type promptEvalRunFakeState struct {
 	experimentStatus    string
 	caseStatus          string
 	resultVerdict       string
+	resultStatusCode    int
 	authOnExperimentGet bool
 }
 
@@ -810,6 +846,7 @@ type promptEvalRunFake struct {
 	experimentStatus    string
 	caseStatus          string
 	resultVerdict       string
+	resultStatusCode    int
 	authOnExperimentGet bool
 }
 
@@ -822,6 +859,7 @@ func newPromptEvalRunFake(t *testing.T, state *promptEvalRunFakeState) *promptEv
 		f.experimentStatus = state.experimentStatus
 		f.caseStatus = state.caseStatus
 		f.resultVerdict = state.resultVerdict
+		f.resultStatusCode = state.resultStatusCode
 		f.authOnExperimentGet = state.authOnExperimentGet
 	}
 	if f.experimentStatus == "" {
@@ -881,6 +919,11 @@ func newPromptEvalRunFake(t *testing.T, state *promptEvalRunFakeState) *promptEv
 			f.nextExperimentID++
 			json.NewEncoder(w).Encode(map[string]any{"id": id, "status": "queued", "url": "https://agentclash.dev/playground-experiments/" + id})
 		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/playground-experiments/") && strings.HasSuffix(r.URL.Path, "/results"):
+			if f.resultStatusCode != 0 {
+				w.WriteHeader(f.resultStatusCode)
+				json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"code": "bad_gateway", "message": "bad gateway"}})
+				return
+			}
 			json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{f.resultItem()}})
 		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/playground-experiments/"):
 			if f.authOnExperimentGet {

--- a/testing/codex-prompt-eval-follow-results.md
+++ b/testing/codex-prompt-eval-follow-results.md
@@ -10,7 +10,7 @@ Branch: `codex/prompt-eval-follow-results`
 - `--poll-interval` and `--timeout` control follow polling.
 - Follow treats terminal experiment status plus stable results as complete.
 - Aggregation reports completed cases, execution errors, assertion passes/fails, assertion pass rate, dimension scores, threshold verdict, and telemetry fields.
-- Exit codes are `0` for pass, `3` for threshold/assertion gate failure, `4` for post-launch provider/execution/timeout/auth failures, `5` for config/auth/workspace/validation errors before launch, and `1` for unexpected internal errors.
+- Exit codes are `0` for pass, `3` for threshold/assertion gate failure, `4` for post-launch provider/execution/timeout/non-auth failures, `5` for config/auth/workspace/validation errors including auth failures discovered while polling, and `1` for unexpected internal errors.
 - Structured output remains parseable for non-zero exits.
 
 ## Unit Tests

--- a/testing/codex-prompt-eval-follow-results.md
+++ b/testing/codex-prompt-eval-follow-results.md
@@ -1,0 +1,40 @@
+# Codex Prompt Eval Follow Results - Test Contract
+
+Issue: #591
+Branch: `codex/prompt-eval-follow-results`
+
+## Functional Behavior
+
+- `agentclash prompt-eval run [path] --follow` launches experiments and waits for them to finish.
+- `agentclash prompt-eval results <experiment-id>` fetches persisted playground experiment results and prints the same result envelope/table shape used by `run --follow`.
+- `--poll-interval` and `--timeout` control follow polling.
+- Follow treats terminal experiment status plus stable results as complete.
+- Aggregation reports completed cases, execution errors, assertion passes/fails, assertion pass rate, dimension scores, threshold verdict, and telemetry fields.
+- Exit codes are `0` for pass, `3` for threshold/assertion gate failure, `4` for post-launch provider/execution/timeout/auth failures, `5` for config/auth/workspace/validation errors before launch, and `1` for unexpected internal errors.
+- Structured output remains parseable for non-zero exits.
+
+## Unit Tests
+
+- `TestPromptEvalRunFollowPassesGate` - completed experiment with passing validator exits 0 and prints result rows.
+- `TestPromptEvalRunFollowFailsAssertionGate` - failed assertion exits 3 with parseable JSON.
+- `TestPromptEvalRunFollowReportsExecutionError` - failed provider/test case after launch exits 4.
+- `TestPromptEvalRunFollowTimesOutWithPartialResults` - timeout exits 4 and includes partial results.
+- `TestPromptEvalRunFollowAuthFailureDuringPoll` - 401 during poll exits 5 before silently continuing.
+- `TestPromptEvalResultsCommandPrintsStableEnvelope` - direct results command prints schemaVersion, summary, rows, thresholds, and telemetry fields.
+
+## Integration / Functional Tests
+
+- Run focused Go tests in `cli/cmd`.
+- Run `go test -short -race -count=1 ./...` from `cli/`.
+
+## Smoke Tests
+
+- Fake API tests cover follow/result behavior. Hosted smoke is deferred until a stable workspace fixture exists.
+
+## E2E Tests
+
+N/A - GitHub Action integration follows in #592.
+
+## Manual / cURL Tests
+
+N/A - fake API tests pin the polling and result API contract.


### PR DESCRIPTION
Closes #591.\n\n## Summary\n- add `prompt-eval run --follow` polling and gate exits\n- add `prompt-eval results <experiment-id>`\n- aggregate case rows, assertion counts, execution errors, dimension scores, thresholds, and telemetry\n- keep JSON parseable on non-zero exits\n\n## Review checkpoint\n- Contract: `testing/codex-prompt-eval-follow-results.md`\n- Checkpoint status: ready\n\n## Tests\n- `cd cli && go build ./...`\n- `cd cli && go vet ./...`\n- `cd cli && go test -short -race -count=1 ./...`