### PR TITLE
feat(action): add prompt-eval CI mode

### DIFF
--- a/.github/actions/agentclash-ci/README.md
+++ b/.github/actions/agentclash-ci/README.md
@@ -1,6 +1,6 @@
 # AgentClash CI Gate Action
 
-Run a manifest-based AgentClash CI gate from GitHub Actions.
+Run a manifest-based AgentClash CI gate or prompt-eval gate from GitHub Actions.
 
 This action is a thin wrapper around the `agentclash` CLI:
 
@@ -62,7 +62,11 @@ jobs:
 
 | Input | Default | Description |
 | --- | --- | --- |
+| `mode` | `ci` | Gate mode: `ci` for manifest-based agent CI, or `prompt-eval` for prompt eval configs. |
 | `manifest` | `.agentclash/ci.yaml` | Path to the AgentClash CI manifest. |
+| `prompt-eval-config` | `.agentclash/prompt-eval.yaml` | Path to the prompt eval config when `mode: prompt-eval`. |
+| `prompt-eval-watch-paths` | `prompts/**`, `agents/**`, `tools/**`, `.agentclash/**` | Newline-separated globs that trigger prompt-eval mode in addition to the config path. |
+| `prompt-eval-threshold` | config default | Optional assertion pass-rate threshold override passed to `prompt-eval run`. |
 | `token` | `AGENTCLASH_TOKEN` | AgentClash API token. |
 | `workspace` | `AGENTCLASH_WORKSPACE` | AgentClash workspace ID. |
 | `api-url` | `https://api.agentclash.dev` | AgentClash API base URL. |
@@ -105,3 +109,47 @@ The action preserves the CLI exit code. A blocking AgentClash gate fails the job
 When `pr-comment` is enabled, the action posts a single sticky comment on pull requests. The comment summarizes the gate verdict, failure reason, candidate and baseline runs, score deltas, regression tracking outcome, and next actions. When run metadata is available, it also links directly to the AgentClash candidate run, baseline run, comparison, failures, scorecard, replay, and regression cases. If the action fails before a candidate run is created, the comment reports an errored setup state and points reviewers at the GitHub Actions log. Later pushes update the existing AgentClash comment instead of creating a new one.
 
 Commenting is best-effort. If the workflow is not running on a pull request, the token is missing, or the token lacks comment permissions, the action logs a notice and preserves the original AgentClash exit code. For GitHub-hosted PR comments, grant `pull-requests: write` in the job permissions.
+
+## Prompt Eval Mode
+
+Prompt eval mode runs `agentclash prompt-eval validate <config> --remote --ci`, checks whether the prompt eval config or watch paths changed, then runs `agentclash prompt-eval run <config> --json --follow --ci`. Gate failures exit `3`, keep the JSON result parseable, and post a sticky prompt-eval PR comment with failed assertions and AgentClash playground/experiment links.
+
+```yaml
+name: AgentClash prompt eval
+
+on:
+  pull_request:
+    paths:
+      - ".agentclash/prompt-eval.yaml"
+      - "prompts/**"
+      - "tools/**"
+
+concurrency:
+  group: agentclash-prompt-eval-${{ github.repository }}-${{ github.workflow }}-${{ vars.AGENTCLASH_WORKSPACE }}-.agentclash-prompt-eval-yaml
+  cancel-in-progress: false
+
+jobs:
+  prompt-eval:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - uses: agentclash/agentclash/.github/actions/agentclash-ci@main
+        with:
+          mode: prompt-eval
+          token: ${{ secrets.AGENTCLASH_TOKEN }}
+          workspace: ${{ vars.AGENTCLASH_WORKSPACE }}
+          prompt-eval-config: .agentclash/prompt-eval.yaml
+```
+
+The concurrency group intentionally excludes `github.ref`. Prompt eval V1 updates shared AgentClash playground resources by workspace and config path, so every PR targeting the same workspace/config should serialize instead of racing.

--- a/.github/actions/agentclash-ci/action.yml
+++ b/.github/actions/agentclash-ci/action.yml
@@ -6,10 +6,29 @@ branding:
   color: green
 
 inputs:
+  mode:
+    description: Gate mode to run. Use "ci" for manifest-based agent CI or "prompt-eval" for prompt eval configs.
+    required: false
+    default: ci
   manifest:
     description: Path to the AgentClash CI manifest.
     required: false
     default: .agentclash/ci.yaml
+  prompt-eval-config:
+    description: Path to the AgentClash prompt eval config used when mode is prompt-eval.
+    required: false
+    default: .agentclash/prompt-eval.yaml
+  prompt-eval-watch-paths:
+    description: Newline-separated shell globs that should trigger prompt-eval mode in addition to the config path.
+    required: false
+    default: |
+      prompts/**
+      agents/**
+      tools/**
+      .agentclash/**
+  prompt-eval-threshold:
+    description: Optional assertion pass-rate threshold override for prompt-eval mode.
+    required: false
   token:
     description: AgentClash API token. Defaults to AGENTCLASH_TOKEN when omitted.
     required: false
@@ -127,7 +146,11 @@ runs:
       shell: bash
       env:
         ACTION_PATH: ${{ github.action_path }}
+        INPUT_MODE: ${{ inputs.mode }}
         INPUT_MANIFEST: ${{ inputs.manifest }}
+        INPUT_PROMPT_EVAL_CONFIG: ${{ inputs.prompt-eval-config }}
+        INPUT_PROMPT_EVAL_WATCH_PATHS: ${{ inputs.prompt-eval-watch-paths }}
+        INPUT_PROMPT_EVAL_THRESHOLD: ${{ inputs.prompt-eval-threshold }}
         INPUT_TOKEN: ${{ inputs.token }}
         INPUT_WORKSPACE: ${{ inputs.workspace }}
         INPUT_API_URL: ${{ inputs.api-url }}

--- a/.github/actions/agentclash-ci/comment.py
+++ b/.github/actions/agentclash-ci/comment.py
@@ -326,6 +326,7 @@ def redact_snippet(value: Any, limit: int = 160) -> str:
     text = escape_cell(str(value or ""))
     text = re.sub(r"(?i)(api[_-]?key|token|secret|password)\s*[:=]\s*['\"]?[^\s,'\"]+", r"\1=[redacted]", text)
     text = re.sub(r"sk-[A-Za-z0-9_-]{12,}", "sk-[redacted]", text)
+    text = re.sub(r"github_pat_[A-Za-z0-9_]{12,}", "github_pat_[redacted]", text)
     text = re.sub(r"gh[pousr]_[A-Za-z0-9_]{12,}", "gh[redacted]", text)
     text = re.sub(r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", "[private-key-redacted]", text)
     text = re.sub(r"(?i)bearer\s+[A-Za-z0-9._-]{12,}", "Bearer [redacted]", text)

--- a/.github/actions/agentclash-ci/comment.py
+++ b/.github/actions/agentclash-ci/comment.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any
 
 MARKER_PREFIX = "agentclash-ci-comment:v1"
+PROMPT_EVAL_MARKER = "<!-- agentclash:prompt-eval -->"
 DIMENSION_ORDER = ("correctness", "reliability", "latency", "cost")
 DEFAULT_APP_URL = "https://agentclash.dev"
 
@@ -89,6 +90,10 @@ def marker_for_manifest(manifest: str) -> str:
     return f"<!-- {MARKER_PREFIX}:{digest} -->"
 
 
+def marker_for_mode(mode: str, manifest: str) -> str:
+    return PROMPT_EVAL_MARKER if mode == "prompt-eval" else marker_for_manifest(manifest)
+
+
 def build_comment(
     *,
     manifest: str,
@@ -96,7 +101,10 @@ def build_comment(
     should_run: dict[str, Any],
     exit_code: int,
     app_url: str = DEFAULT_APP_URL,
+    mode: str = "ci",
 ) -> str:
+    if mode == "prompt-eval":
+        return build_prompt_eval_comment(config=manifest, result=result, should_run=should_run, exit_code=exit_code, app_url=app_url)
     marker = marker_for_manifest(manifest)
     if should_run and should_run.get("should_run") is False:
         reason = str(should_run.get("reason") or "manifest trigger did not match this change set")
@@ -161,6 +169,78 @@ def build_comment(
     return "\n".join(lines)
 
 
+def build_prompt_eval_comment(
+    *,
+    config: str,
+    result: dict[str, Any],
+    should_run: dict[str, Any],
+    exit_code: int,
+    app_url: str = DEFAULT_APP_URL,
+) -> str:
+    marker = PROMPT_EVAL_MARKER
+    if should_run and should_run.get("should_run") is False:
+        reason = str(should_run.get("reason") or "prompt eval paths did not match this change set")
+        return "\n".join(
+            [
+                marker,
+                "## AgentClash Prompt Eval: Skipped",
+                "",
+                f"AgentClash did not run for `{config}`.",
+                "",
+                f"**Reason:** {escape_cell(reason)}",
+                "",
+                "_Updated automatically by AgentClash CI._",
+            ],
+        )
+
+    status = prompt_eval_status_label(result, exit_code)
+    summary = result.get("summary") if isinstance(result.get("summary"), dict) else {}
+    lines = [
+        marker,
+        f"## AgentClash Prompt Eval: {status}",
+        "",
+        "| Field | Value |",
+        "| --- | --- |",
+        f"| Config | `{escape_cell(config)}` |",
+        f"| Verdict | `{escape_cell(str(result.get('gate_verdict') or 'n/a'))}` |",
+        f"| Exit code | `{exit_code}` |",
+        f"| Cases | `{format_number(summary.get('completed_cases'))}/{format_number(summary.get('total_cases'))}` |",
+        f"| Assertions | `{format_number(summary.get('assertions_passed'))} passed / {format_number(summary.get('assertions_failed'))} failed` |",
+        f"| Assertion pass rate | `{format_number(summary.get('assertion_pass_rate'))}` |",
+        f"| Execution errors | `{format_number(summary.get('execution_errors'))}` |",
+    ]
+
+    links = prompt_eval_links(result, app_url)
+    if links:
+        lines.extend(["", "### Inspect in AgentClash", ""])
+        lines.extend(f"- [{label}]({url})" for label, url in links)
+
+    failed_rows = prompt_eval_failed_rows(result)
+    if failed_rows:
+        lines.extend(["", "### Failed Assertions", "", "| Case | Assertion | Expected | Actual / Error |", "| --- | --- | --- | --- |"])
+        for row in failed_rows[:5]:
+            lines.append(
+                f"| `{escape_cell(str(row.get('case_key') or 'n/a'))}` | "
+                f"`{escape_cell(str(row.get('assertion') or row.get('assertion_key') or 'n/a'))}` | "
+                f"`{redact_snippet(row.get('expected'))}` | "
+                f"`{redact_snippet(row.get('error') or row.get('actual'))}` |",
+            )
+        if len(failed_rows) > 5:
+            lines.append(f"| ... | ... | ... | `{len(failed_rows) - 5} more failed assertion(s)` |")
+
+    errors = result.get("errors")
+    if isinstance(errors, list) and errors:
+        lines.extend(["", "### Errors", ""])
+        lines.extend(f"- `{redact_snippet(error)}`" for error in errors[:5])
+
+    lines.extend(["", "### Reproduce Locally", ""])
+    lines.append(f"`agentclash prompt-eval run {escape_cell(config)} --ci --follow --json`")
+    lines.extend(["", "### Next Actions", ""])
+    lines.extend(prompt_eval_next_actions(result, exit_code))
+    lines.extend(["", "_Updated automatically by AgentClash CI._"])
+    return "\n".join(lines)
+
+
 def status_label(result: dict[str, Any], exit_code: int) -> str:
     if exit_code == 0:
         return "Passed"
@@ -170,6 +250,86 @@ def status_label(result: dict[str, Any], exit_code: int) -> str:
     if verdict in {"warn", "warning"}:
         return "Warning"
     return "Errored"
+
+
+def prompt_eval_status_label(result: dict[str, Any], exit_code: int) -> str:
+    if exit_code == 0:
+        return "Passed"
+    if exit_code == 3 or str(result.get("gate_verdict") or "").lower() == "fail":
+        return "Failed"
+    return "Errored"
+
+
+def prompt_eval_failed_rows(result: dict[str, Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for envelope in result.get("results") or []:
+        if not isinstance(envelope, dict):
+            continue
+        for row in envelope.get("rows") or []:
+            if isinstance(row, dict) and str(row.get("result") or "").upper() in {"FAIL", "ERROR"}:
+                rows.append(row)
+    return rows
+
+
+def prompt_eval_links(result: dict[str, Any], app_url: str) -> list[tuple[str, str]]:
+    links: list[tuple[str, str]] = []
+    seen: set[str] = set()
+
+    def add(label: str, url: Any) -> None:
+        safe = normalize_safe_url(url)
+        if safe and safe not in seen:
+            links.append((label, safe))
+            seen.add(safe)
+
+    for playground in result.get("playgrounds") or []:
+        if not isinstance(playground, dict):
+            continue
+        add(f"Playground {playground.get('name') or playground.get('playground_id') or ''}".strip(), playground.get("playground_url"))
+        for experiment in playground.get("experiments") or []:
+            if isinstance(experiment, dict):
+                add(f"Experiment {experiment.get('experiment_id') or ''}".strip(), experiment.get("experiment_url"))
+
+    workspace_id = clean_id(result.get("workspace_id"))
+    if workspace_id:
+        base = normalize_safe_url(app_url)
+        for playground in result.get("playgrounds") or []:
+            if not isinstance(playground, dict):
+                continue
+            playground_id = clean_id(playground.get("playground_id"))
+            if playground_id:
+                add("Playground", app_link(base, "workspaces", workspace_id, "playgrounds", playground_id))
+            for experiment in playground.get("experiments") or []:
+                if isinstance(experiment, dict):
+                    experiment_id = clean_id(experiment.get("experiment_id"))
+                    if experiment_id:
+                        add("Experiment", app_link(base, "workspaces", workspace_id, "playground-experiments", experiment_id))
+    return links[:8]
+
+
+def prompt_eval_next_actions(result: dict[str, Any], exit_code: int) -> list[str]:
+    verdict = str(result.get("gate_verdict") or "").lower()
+    if exit_code == 3 or verdict == "fail":
+        return [
+            "- Inspect the failed assertions and AgentClash experiment links above.",
+            "- Fix the prompt, model, provider account, or test expectation and push again.",
+            "- If the behavior change is intentional, update the prompt eval config deliberately in a separate review.",
+        ]
+    if exit_code == 0:
+        return ["- No action needed. The prompt eval gate passed."]
+    return [
+        "- Open the GitHub Actions log and AgentClash JSON output.",
+        "- Fix config, auth, provider, or runtime errors before trusting the gate result.",
+    ]
+
+
+def redact_snippet(value: Any, limit: int = 160) -> str:
+    text = escape_cell(str(value or ""))
+    text = re.sub(r"(?i)(api[_-]?key|token|secret|password)\s*[:=]\s*['\"]?[^\s,'\"]+", r"\1=[redacted]", text)
+    text = re.sub(r"sk-[A-Za-z0-9_-]{12,}", "sk-[redacted]", text)
+    text = re.sub(r"(?i)bearer\s+[A-Za-z0-9._-]{12,}", "Bearer [redacted]", text)
+    if len(text) > limit:
+        return text[: limit - 1] + "..."
+    return text
 
 
 def dimension_rows(result: dict[str, Any]) -> list[str]:
@@ -447,6 +607,7 @@ def upsert_comment(client: Any, pr_number: int, marker: str, body: str) -> Comme
 def post_comment(
     *,
     manifest: str,
+    mode: str = "ci",
     result: dict[str, Any],
     should_run: dict[str, Any],
     exit_code: int,
@@ -466,8 +627,8 @@ def post_comment(
     if pr_number is None:
         return CommentOutcome("skipped", "missing pull request context")
 
-    body = build_comment(manifest=manifest, result=result, should_run=should_run, exit_code=exit_code, app_url=app_url)
-    marker = marker_for_manifest(manifest)
+    body = build_comment(manifest=manifest, result=result, should_run=should_run, exit_code=exit_code, app_url=app_url, mode=mode)
+    marker = marker_for_mode(mode, manifest)
     github = client or GitHubClient(api_url, repo, token)
     try:
         return upsert_comment(github, pr_number, marker, body)
@@ -480,6 +641,7 @@ def post_comment(
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Post a sticky AgentClash CI pull request comment.")
     parser.add_argument("--manifest", required=True)
+    parser.add_argument("--mode", default="ci", choices=["ci", "prompt-eval"])
     parser.add_argument("--result-file", default="")
     parser.add_argument("--should-run-file", default="")
     parser.add_argument("--exit-code", type=int, default=0)
@@ -508,6 +670,7 @@ def main(argv: list[str]) -> int:
 
     outcome = post_comment(
         manifest=args.manifest,
+        mode=args.mode,
         result=result,
         should_run=should_run,
         exit_code=args.exit_code,

--- a/.github/actions/agentclash-ci/comment.py
+++ b/.github/actions/agentclash-ci/comment.py
@@ -326,6 +326,8 @@ def redact_snippet(value: Any, limit: int = 160) -> str:
     text = escape_cell(str(value or ""))
     text = re.sub(r"(?i)(api[_-]?key|token|secret|password)\s*[:=]\s*['\"]?[^\s,'\"]+", r"\1=[redacted]", text)
     text = re.sub(r"sk-[A-Za-z0-9_-]{12,}", "sk-[redacted]", text)
+    text = re.sub(r"gh[pousr]_[A-Za-z0-9_]{12,}", "gh[redacted]", text)
+    text = re.sub(r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", "[private-key-redacted]", text)
     text = re.sub(r"(?i)bearer\s+[A-Za-z0-9._-]{12,}", "Bearer [redacted]", text)
     if len(text) > limit:
         return text[: limit - 1] + "..."

--- a/.github/actions/agentclash-ci/comment_test.py
+++ b/.github/actions/agentclash-ci/comment_test.py
@@ -239,6 +239,14 @@ class CommentFormattingTests(unittest.TestCase):
         self.assertIn("https://agentclash.dev/workspaces/workspace-1/playground-experiments/exp-1", body)
         self.assertIn("agentclash prompt-eval run .agentclash/prompt-eval.yaml --ci --follow --json", body)
 
+    def test_prompt_eval_redacts_common_token_shapes(self):
+        redacted = comment.redact_snippet("sk-abcdef1234567890 ghp_abcdefghijklmnopqrstuvwxyz Bearer abcdefghijklmnop")
+
+        self.assertIn("sk-[redacted]", redacted)
+        self.assertIn("gh[redacted]", redacted)
+        self.assertIn("Bearer [redacted]", redacted)
+        self.assertNotIn("abcdefghijklmnop", redacted)
+
     def test_build_prompt_eval_skipped_comment_uses_prompt_eval_marker(self):
         body = comment.build_comment(
             manifest=".agentclash/prompt-eval.yaml",

--- a/.github/actions/agentclash-ci/comment_test.py
+++ b/.github/actions/agentclash-ci/comment_test.py
@@ -69,6 +69,48 @@ def failing_result():
     }
 
 
+def prompt_eval_result():
+    return {
+        "workspace_id": "workspace-1",
+        "gate_verdict": "fail",
+        "summary": {
+            "total_cases": 2,
+            "completed_cases": 2,
+            "assertions_passed": 1,
+            "assertions_failed": 1,
+            "assertion_pass_rate": 0.5,
+            "execution_errors": 0,
+        },
+        "playgrounds": [
+            {
+                "name": "refund-bot",
+                "playground_id": "pg-1",
+                "playground_url": "https://agentclash.dev/workspaces/workspace-1/playgrounds/pg-1",
+                "experiments": [
+                    {
+                        "experiment_id": "exp-1",
+                        "experiment_url": "https://agentclash.dev/workspaces/workspace-1/playground-experiments/exp-1",
+                    },
+                ],
+            },
+        ],
+        "results": [
+            {
+                "experiment_id": "exp-1",
+                "rows": [
+                    {
+                        "case_key": "refund",
+                        "assertion": "contains",
+                        "result": "FAIL",
+                        "expected": "refund denied",
+                        "actual": "token=super-secret-value refund accepted",
+                    },
+                ],
+            },
+        ],
+    }
+
+
 class CommentFormattingTests(unittest.TestCase):
     def test_build_failed_comment_contains_reviewer_triage(self):
         body = comment.build_comment(
@@ -176,6 +218,40 @@ class CommentFormattingTests(unittest.TestCase):
         self.assertIn("changed files did not match trigger.paths", body)
         self.assertNotIn("Score Deltas", body)
 
+    def test_build_prompt_eval_failed_comment_contains_actionable_triage(self):
+        body = comment.build_comment(
+            manifest=".agentclash/prompt-eval.yaml",
+            mode="prompt-eval",
+            result=prompt_eval_result(),
+            should_run={"should_run": True},
+            exit_code=3,
+        )
+
+        self.assertIn("<!-- agentclash:prompt-eval -->", body)
+        self.assertIn("## AgentClash Prompt Eval: Failed", body)
+        self.assertIn("0.5", body)
+        self.assertIn("Failed Assertions", body)
+        self.assertIn("refund", body)
+        self.assertIn("refund denied", body)
+        self.assertIn("token=[redacted]", body)
+        self.assertNotIn("super-secret-value", body)
+        self.assertIn("https://agentclash.dev/workspaces/workspace-1/playgrounds/pg-1", body)
+        self.assertIn("https://agentclash.dev/workspaces/workspace-1/playground-experiments/exp-1", body)
+        self.assertIn("agentclash prompt-eval run .agentclash/prompt-eval.yaml --ci --follow --json", body)
+
+    def test_build_prompt_eval_skipped_comment_uses_prompt_eval_marker(self):
+        body = comment.build_comment(
+            manifest=".agentclash/prompt-eval.yaml",
+            mode="prompt-eval",
+            result={},
+            should_run={"should_run": False, "reason": "changed files did not match prompt eval paths"},
+            exit_code=0,
+        )
+
+        self.assertIn("<!-- agentclash:prompt-eval -->", body)
+        self.assertIn("AgentClash Prompt Eval: Skipped", body)
+        self.assertIn("changed files did not match prompt eval paths", body)
+
 
 class CommentContextTests(unittest.TestCase):
     def test_find_pr_number_prefers_result_metadata(self):
@@ -213,6 +289,23 @@ class CommentUpsertTests(unittest.TestCase):
         self.assertEqual(outcome.action, "created")
         self.assertEqual(fake.created, [(42, f"{marker}\nnew body")])
         self.assertEqual(fake.updated, [])
+
+    def test_upsert_updates_existing_prompt_eval_comment(self):
+        marker = comment.PROMPT_EVAL_MARKER
+        fake = FakeGitHubClient(comments=[{"id": 12, "body": f"{marker}\nold body"}])
+
+        body = comment.build_comment(
+            manifest=".agentclash/prompt-eval.yaml",
+            mode="prompt-eval",
+            result=prompt_eval_result(),
+            should_run={"should_run": True},
+            exit_code=3,
+        )
+        outcome = comment.upsert_comment(fake, 42, marker, body)
+
+        self.assertEqual(outcome.action, "updated")
+        self.assertEqual(fake.updated, [(12, body)])
+        self.assertEqual(fake.created, [])
 
     def test_post_comment_gracefully_skips_missing_token_or_context(self):
         base = {

--- a/.github/actions/agentclash-ci/comment_test.py
+++ b/.github/actions/agentclash-ci/comment_test.py
@@ -240,10 +240,11 @@ class CommentFormattingTests(unittest.TestCase):
         self.assertIn("agentclash prompt-eval run .agentclash/prompt-eval.yaml --ci --follow --json", body)
 
     def test_prompt_eval_redacts_common_token_shapes(self):
-        redacted = comment.redact_snippet("sk-abcdef1234567890 ghp_abcdefghijklmnopqrstuvwxyz Bearer abcdefghijklmnop")
+        redacted = comment.redact_snippet("sk-abcdef1234567890 ghp_abcdefghijklmnopqrstuvwxyz github_pat_abcdefghijklmnopqrstuvwxyz Bearer abcdefghijklmnop")
 
         self.assertIn("sk-[redacted]", redacted)
         self.assertIn("gh[redacted]", redacted)
+        self.assertIn("github_pat_[redacted]", redacted)
         self.assertIn("Bearer [redacted]", redacted)
         self.assertNotIn("abcdefghijklmnop", redacted)
 

--- a/.github/actions/agentclash-ci/run.sh
+++ b/.github/actions/agentclash-ci/run.sh
@@ -237,6 +237,7 @@ PY
 on_error() {
   local status="$?"
   trap - ERR
+  write_output "exit-code" "$status"
   if [[ "${comment_posted:-false}" != "true" ]]; then
     write_early_error_result
     post_pr_comment "$status" || true

--- a/.github/actions/agentclash-ci/run.sh
+++ b/.github/actions/agentclash-ci/run.sh
@@ -39,6 +39,11 @@ for part in sys.argv[2].split("."):
         continue
     if isinstance(value, dict):
         value = value.get(part)
+    elif isinstance(value, list):
+        try:
+            value = value[int(part)]
+        except (ValueError, IndexError):
+            value = None
     else:
         value = None
     if value is None:
@@ -64,15 +69,37 @@ agentclash_supports_ci_commands() {
     [[ "$run_help" == *"Flags:"* ]]
 }
 
+agentclash_supports_prompt_eval_commands() {
+  local validate_help
+  local run_help
+  validate_help="$("$@" prompt-eval validate --help 2>&1)" &&
+    run_help="$("$@" prompt-eval run --help 2>&1)" &&
+    [[ "$validate_help" == *"agentclash prompt-eval validate"* ]] &&
+    [[ "$validate_help" == *"Flags:"* ]] &&
+    [[ "$run_help" == *"agentclash prompt-eval run"* ]] &&
+    [[ "$run_help" == *"Flags:"* ]]
+}
+
+agentclash_supports_required_commands() {
+  case "$mode" in
+    ci) agentclash_supports_ci_commands "$@" ;;
+    prompt-eval) agentclash_supports_prompt_eval_commands "$@" ;;
+    *)
+      echo "::error::Unsupported AgentClash CI action mode '${mode}'. Use 'ci' or 'prompt-eval'."
+      return 1
+      ;;
+  esac
+}
+
 resolve_agentclash_cli() {
   agentclash_cmd=(agentclash)
 
   if command -v agentclash >/dev/null 2>&1; then
-    if agentclash_supports_ci_commands agentclash; then
+    if agentclash_supports_required_commands agentclash; then
       echo "Using installed agentclash CLI"
       return 0
     fi
-    echo "::notice::Installed agentclash CLI does not expose ci should-run/run; checking source fallback"
+    echo "::notice::Installed agentclash CLI does not expose required ${mode} commands; checking source fallback"
   fi
 
   if bool_true "${INPUT_SOURCE_FALLBACK:-true}"; then
@@ -82,12 +109,12 @@ resolve_agentclash_cli() {
     if [[ -d "$source_dir" ]] && command -v go >/dev/null 2>&1; then
       fallback_bin="${RUNNER_TEMP:-/tmp}/agentclash-source-cli"
       if go -C "$source_dir" build -o "$fallback_bin" .; then
-        if agentclash_supports_ci_commands "$fallback_bin"; then
+        if agentclash_supports_required_commands "$fallback_bin"; then
           agentclash_cmd=("$fallback_bin")
           echo "Using AgentClash CLI source fallback from ${source_dir}"
           return 0
         fi
-        echo "::notice::AgentClash CLI source fallback exists but does not expose ci should-run/run"
+        echo "::notice::AgentClash CLI source fallback exists but does not expose required ${mode} commands"
       else
         echo "::notice::AgentClash CLI source fallback failed to build"
       fi
@@ -98,12 +125,16 @@ resolve_agentclash_cli() {
     fi
   fi
 
-  echo "::error::AgentClash CI requires an agentclash CLI with 'ci should-run' and 'ci run'. Publish a newer npm CLI, set cli-version to a compatible version, or keep source-fallback enabled with Go available."
+  echo "::error::AgentClash CI requires an agentclash CLI with the required ${mode} commands. Publish a newer npm CLI, set cli-version to a compatible version, or keep source-fallback enabled with Go available."
   return 1
 }
 
 post_pr_comment() {
   local status="$1"
+  local comment_manifest="$manifest"
+  if [[ "$mode" == "prompt-eval" ]]; then
+    comment_manifest="$prompt_eval_config"
+  fi
   if ! bool_true "${INPUT_PR_COMMENT:-true}"; then
     comment_posted=true
     return 0
@@ -111,7 +142,8 @@ post_pr_comment() {
 
   set +e
   python3 "${ACTION_PATH}/comment.py" \
-    --manifest "$manifest" \
+    --manifest "$comment_manifest" \
+    --mode "$mode" \
     --result-file "$result_file" \
     --should-run-file "$should_run_file" \
     --exit-code "$status" \
@@ -134,7 +166,72 @@ write_early_error_result() {
     return 0
   fi
   mkdir -p "$(dirname "$result_file")"
-  printf '%s\n' '{"gate_verdict":"error","failure_reason":"action_failed_before_ci_run","errors":["AgentClash action failed before ci run completed. Inspect the GitHub Actions log for the failing command."]}' >"$result_file"
+  printf '{"gate_verdict":"error","failure_reason":"action_failed_before_%s_run","errors":["AgentClash action failed before %s run completed. Inspect the GitHub Actions log for the failing command."]}\n' "$mode" "$mode" >"$result_file"
+}
+
+write_should_run_json() {
+  local should_run="$1"
+  local reason="$2"
+  mkdir -p "$(dirname "$should_run_file")"
+  SHOULD_RUN="$should_run" REASON="$reason" python3 - "$should_run_file" <<'PY'
+import json
+import os
+import sys
+
+with open(sys.argv[1], "w", encoding="utf-8") as handle:
+    json.dump({"should_run": os.environ["SHOULD_RUN"] == "true", "reason": os.environ["REASON"]}, handle)
+    handle.write("\n")
+PY
+}
+
+collect_changed_files() {
+  if [[ -n "${INPUT_CHANGED_FILES:-}" ]]; then
+    printf '%s\n' "${INPUT_CHANGED_FILES}"
+    return 0
+  fi
+  local base="${INPUT_BASE:-}"
+  local head="${INPUT_HEAD:-}"
+  if [[ -z "$base" && -n "${GITHUB_BASE_REF:-}" ]]; then
+    base="origin/${GITHUB_BASE_REF}"
+  fi
+  if [[ -z "$head" ]]; then
+    head="HEAD"
+  fi
+  if [[ -n "$base" ]]; then
+    git diff --name-only "$base" "$head"
+  fi
+}
+
+prompt_eval_should_run() {
+  local changed
+  changed="$(collect_changed_files || true)"
+  if [[ -z "$changed" ]]; then
+    write_should_run_json "true" "no change set was available; running prompt eval conservatively"
+    return 0
+  fi
+  CHANGED_FILES="$changed" PROMPT_EVAL_CONFIG="$prompt_eval_config" PROMPT_EVAL_WATCH_PATHS="${INPUT_PROMPT_EVAL_WATCH_PATHS:-}" python3 - "$should_run_file" <<'PY'
+import fnmatch
+import json
+import os
+import sys
+
+changed = [line.strip() for line in os.environ.get("CHANGED_FILES", "").splitlines() if line.strip()]
+config = os.environ.get("PROMPT_EVAL_CONFIG", ".agentclash/prompt-eval.yaml").strip()
+patterns = [config]
+patterns.extend(line.strip() for line in os.environ.get("PROMPT_EVAL_WATCH_PATHS", "").splitlines() if line.strip())
+matched = []
+for path in changed:
+    if any(path == pattern or fnmatch.fnmatch(path, pattern) for pattern in patterns):
+        matched.append(path)
+result = {
+    "should_run": bool(matched),
+    "reason": "matched prompt eval paths" if matched else "changed files did not match prompt eval paths",
+    "matched_paths": matched,
+}
+with open(sys.argv[1], "w", encoding="utf-8") as handle:
+    json.dump(result, handle)
+    handle.write("\n")
+PY
 }
 
 on_error() {
@@ -147,7 +244,9 @@ on_error() {
   exit "$status"
 }
 
+mode="${INPUT_MODE:-ci}"
 manifest="${INPUT_MANIFEST:-.agentclash/ci.yaml}"
+prompt_eval_config="${INPUT_PROMPT_EVAL_CONFIG:-.agentclash/prompt-eval.yaml}"
 artifact_dir="${INPUT_ARTIFACT_DIR:-agentclash-artifacts}"
 result_file="${INPUT_RESULT_FILE:-agentclash-ci-result.json}"
 should_run_file="${RUNNER_TEMP:-/tmp}/agentclash-should-run.json"
@@ -171,36 +270,45 @@ fi
 
 resolve_agentclash_cli
 
-if bool_true "${INPUT_REMOTE_VALIDATE:-true}"; then
-  "${agentclash_cmd[@]}" ci validate "$manifest" --remote
+if [[ "$mode" == "prompt-eval" ]]; then
+  if bool_true "${INPUT_REMOTE_VALIDATE:-true}"; then
+    "${agentclash_cmd[@]}" prompt-eval validate "$prompt_eval_config" --remote --ci
+  else
+    "${agentclash_cmd[@]}" prompt-eval validate "$prompt_eval_config" --ci
+  fi
+  prompt_eval_should_run
 else
-  "${agentclash_cmd[@]}" ci validate "$manifest"
-fi
+  if bool_true "${INPUT_REMOTE_VALIDATE:-true}"; then
+    "${agentclash_cmd[@]}" ci validate "$manifest" --remote
+  else
+    "${agentclash_cmd[@]}" ci validate "$manifest"
+  fi
 
-should_args=(ci should-run --manifest "$manifest" --json)
-if [[ -n "${INPUT_CHANGED_FILES:-}" ]]; then
-  while IFS= read -r changed_file; do
-    [[ -z "$changed_file" ]] && continue
-    should_args+=(--changed-file "$changed_file")
-  done <<<"${INPUT_CHANGED_FILES}"
-else
-  base="${INPUT_BASE:-}"
-  head="${INPUT_HEAD:-}"
-  if [[ -z "$base" && -n "${GITHUB_BASE_REF:-}" ]]; then
-    base="origin/${GITHUB_BASE_REF}"
+  should_args=(ci should-run --manifest "$manifest" --json)
+  if [[ -n "${INPUT_CHANGED_FILES:-}" ]]; then
+    while IFS= read -r changed_file; do
+      [[ -z "$changed_file" ]] && continue
+      should_args+=(--changed-file "$changed_file")
+    done <<<"${INPUT_CHANGED_FILES}"
+  else
+    base="${INPUT_BASE:-}"
+    head="${INPUT_HEAD:-}"
+    if [[ -z "$base" && -n "${GITHUB_BASE_REF:-}" ]]; then
+      base="origin/${GITHUB_BASE_REF}"
+    fi
+    if [[ -z "$head" ]]; then
+      head="HEAD"
+    fi
+    if [[ -n "$base" ]]; then
+      should_args+=(--base "$base" --head "$head")
+    fi
   fi
-  if [[ -z "$head" ]]; then
-    head="HEAD"
+  if [[ -n "${INPUT_LABELS:-}" ]]; then
+    should_args+=(--labels "${INPUT_LABELS}")
   fi
-  if [[ -n "$base" ]]; then
-    should_args+=(--base "$base" --head "$head")
-  fi
-fi
-if [[ -n "${INPUT_LABELS:-}" ]]; then
-  should_args+=(--labels "${INPUT_LABELS}")
-fi
 
-"${agentclash_cmd[@]}" "${should_args[@]}" >"$should_run_file"
+  "${agentclash_cmd[@]}" "${should_args[@]}" >"$should_run_file"
+fi
 should_run="$(json_get "$should_run_file" should_run)"
 skip_reason="$(json_get "$should_run_file" reason)"
 write_output "should-run" "$should_run"
@@ -213,25 +321,32 @@ fi
 
 if [[ "$should_run" != "true" && "$skip_if_unmatched" == "true" ]]; then
   write_output "exit-code" "0"
-  append_summary "## AgentClash CI"
+  append_summary "## AgentClash ${mode}"
   append_summary ""
-  append_summary "Skipped: ${skip_reason:-manifest trigger did not match this change set}"
+  append_summary "Skipped: ${skip_reason:-trigger did not match this change set}"
   post_pr_comment "0"
   exit 0
 fi
 
-run_args=(ci run --manifest "$manifest" --json --artifact-dir "$artifact_dir")
+if [[ "$mode" == "prompt-eval" ]]; then
+  run_args=(prompt-eval run "$prompt_eval_config" --json --follow --ci)
+else
+  run_args=(ci run --manifest "$manifest" --json --artifact-dir "$artifact_dir")
+fi
 if [[ -n "${INPUT_TIMEOUT:-}" ]]; then
   run_args+=(--timeout "${INPUT_TIMEOUT}")
 fi
 if [[ -n "${INPUT_POLL_INTERVAL:-}" ]]; then
   run_args+=(--poll-interval "${INPUT_POLL_INTERVAL}")
 fi
-if bool_true "${INPUT_FOLLOW:-false}"; then
+if [[ "$mode" == "ci" ]] && bool_true "${INPUT_FOLLOW:-false}"; then
   run_args+=(--follow)
 fi
-if [[ -n "${INPUT_DEFAULT_BRANCH:-}" ]]; then
+if [[ "$mode" == "ci" && -n "${INPUT_DEFAULT_BRANCH:-}" ]]; then
   run_args+=(--ci-default-branch "${INPUT_DEFAULT_BRANCH}")
+fi
+if [[ "$mode" == "prompt-eval" && -n "${INPUT_PROMPT_EVAL_THRESHOLD:-}" ]]; then
+  run_args+=(--threshold "${INPUT_PROMPT_EVAL_THRESHOLD}")
 fi
 
 set +e
@@ -242,7 +357,11 @@ set -e
 write_output "exit-code" "$status"
 if [[ -s "$result_file" ]]; then
   cat "$result_file"
-  write_output "run-id" "$(json_get "$result_file" candidate.run_id)"
+  if [[ "$mode" == "prompt-eval" ]]; then
+    write_output "run-id" "$(json_get "$result_file" playgrounds.0.experiments.0.experiment_id)"
+  else
+    write_output "run-id" "$(json_get "$result_file" candidate.run_id)"
+  fi
   write_output "gate-verdict" "$(json_get "$result_file" gate_verdict)"
 else
   write_output "run-id" ""

--- a/.github/actions/agentclash-ci/run_test.py
+++ b/.github/actions/agentclash-ci/run_test.py
@@ -199,5 +199,139 @@ exit 9
         )
 
 
+class RunScriptPromptEvalModeTests(unittest.TestCase):
+    def test_prompt_eval_runs_when_config_changed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            calls = root / "calls.log"
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            self.write_prompt_eval_cli(bin_dir / "agentclash", calls, exit_code=0, verdict="pass")
+
+            result = self.run_prompt_eval_action(root, bin_dir, changed_files=".agentclash/prompt-eval.yaml\n")
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            call_log = calls.read_text()
+            self.assertIn("prompt-eval validate .agentclash/prompt-eval.yaml --remote --ci", call_log)
+            self.assertIn("prompt-eval run .agentclash/prompt-eval.yaml --json --follow --ci", call_log)
+            self.assertIn('"gate_verdict":"pass"', (root / "agentclash-ci-result.json").read_text())
+
+    def test_prompt_eval_skips_when_paths_do_not_match(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            calls = root / "calls.log"
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            self.write_prompt_eval_cli(bin_dir / "agentclash", calls, exit_code=0, verdict="pass")
+
+            result = self.run_prompt_eval_action(root, bin_dir, changed_files="docs/readme.md\n")
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            call_log = calls.read_text()
+            self.assertIn("prompt-eval validate", call_log)
+            self.assertNotIn("prompt-eval run .agentclash/prompt-eval.yaml", call_log)
+            self.assertFalse((root / "agentclash-ci-result.json").exists())
+
+    def test_prompt_eval_gate_failure_preserves_exit_three_and_comments(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            calls = root / "calls.log"
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            self.write_prompt_eval_cli(bin_dir / "agentclash", calls, exit_code=3, verdict="fail")
+
+            result = self.run_prompt_eval_action(root, bin_dir, changed_files=".agentclash/prompt-eval.yaml\n", pr_comment="true")
+
+            self.assertEqual(result.returncode, 3)
+            self.assertIn("AgentClash CI PR comment skipped", result.stdout)
+            self.assertIn('"gate_verdict":"fail"', (root / "agentclash-ci-result.json").read_text())
+
+    def test_prompt_eval_infrastructure_failure_preserves_exit_four(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            calls = root / "calls.log"
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            self.write_prompt_eval_cli(bin_dir / "agentclash", calls, exit_code=4, verdict="error")
+
+            result = self.run_prompt_eval_action(root, bin_dir, changed_files=".agentclash/prompt-eval.yaml\n")
+
+            self.assertEqual(result.returncode, 4)
+            self.assertIn('"gate_verdict":"error"', (root / "agentclash-ci-result.json").read_text())
+
+    def run_prompt_eval_action(self, root: Path, bin_dir: Path, *, changed_files: str, pr_comment: str = "false"):
+        config = root / ".agentclash" / "prompt-eval.yaml"
+        config.parent.mkdir(parents=True)
+        config.write_text(
+            textwrap.dedent(
+                """
+                schemaVersion: 1
+                name: smoke
+                prompt:
+                  template: "Reply to {{input}}"
+                models:
+                  - alias: gpt-5.5
+                    provider_account: ci-openai
+                tests:
+                  - key: hello
+                    vars:
+                      input: hello
+                    assert:
+                      - type: contains
+                        value: hello
+                """
+            ).strip()
+            + "\n",
+        )
+        env = {
+            **os.environ,
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "ACTION_PATH": str(ACTION_DIR),
+            "INPUT_MODE": "prompt-eval",
+            "INPUT_INSTALL_CLI": "false",
+            "INPUT_REMOTE_VALIDATE": "true",
+            "INPUT_SOURCE_FALLBACK": "false",
+            "INPUT_SKIP_IF_UNMATCHED": "true",
+            "INPUT_PR_COMMENT": pr_comment,
+            "INPUT_PROMPT_EVAL_CONFIG": ".agentclash/prompt-eval.yaml",
+            "INPUT_CHANGED_FILES": changed_files,
+            "RUNNER_TEMP": str(root),
+        }
+        return subprocess.run(
+            ["bash", str(ACTION_DIR / "run.sh")],
+            cwd=root,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    @staticmethod
+    def write_prompt_eval_cli(path: Path, calls: Path, *, exit_code: int, verdict: str):
+        path.write_text(
+            textwrap.dedent(
+                f"""#!/usr/bin/env bash
+                printf 'agentclash %s\\n' "$*" >>"{calls}"
+                if [[ "$*" == "prompt-eval validate --help" || "$*" == "prompt-eval run --help" ]]; then
+                  printf 'Usage:\\n  agentclash %s [flags]\\n\\nFlags:\\n  --help\\n' "${{*:1:2}}"
+                  exit 0
+                fi
+                if [[ "$1 $2" == "prompt-eval validate" ]]; then
+                  [[ -f "$3" ]] || exit 12
+                  exit 0
+                fi
+                if [[ "$1 $2" == "prompt-eval run" ]]; then
+                  cat <<'JSON'
+{{"schemaVersion":1,"workspace_id":"ws-1","gate_verdict":"{verdict}","summary":{{"total_cases":1,"completed_cases":1,"assertions_passed":0,"assertions_failed":1,"assertion_pass_rate":0,"execution_errors":0}},"playgrounds":[{{"name":"smoke","playground_id":"pg-1","playground_url":"https://agentclash.dev/workspaces/ws-1/playgrounds/pg-1","experiments":[{{"experiment_id":"exp-1","experiment_url":"https://agentclash.dev/workspaces/ws-1/playground-experiments/exp-1"}}]}}],"results":[{{"experiment_id":"exp-1","rows":[{{"case_key":"hello","assertion":"contains","result":"FAIL","expected":"hello","actual":"api_key=super-secret-value should be redacted"}}]}}],"exit_code":{exit_code}}}
+JSON
+                  exit {exit_code}
+                fi
+                exit 9
+                """,
+            ),
+        )
+        path.chmod(0o755)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.github/actions/agentclash-ci/run_test.py
+++ b/.github/actions/agentclash-ci/run_test.py
@@ -259,6 +259,19 @@ class RunScriptPromptEvalModeTests(unittest.TestCase):
             self.assertEqual(result.returncode, 4)
             self.assertIn('"gate_verdict":"error"', (root / "agentclash-ci-result.json").read_text())
 
+    def test_prompt_eval_validation_failure_preserves_exit_five(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            calls = root / "calls.log"
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            self.write_prompt_eval_cli(bin_dir / "agentclash", calls, exit_code=0, verdict="pass", validate_exit=5)
+
+            result = self.run_prompt_eval_action(root, bin_dir, changed_files=".agentclash/prompt-eval.yaml\n")
+
+            self.assertEqual(result.returncode, 5)
+            self.assertIn("action_failed_before_prompt-eval_run", (root / "agentclash-ci-result.json").read_text())
+
     def run_prompt_eval_action(self, root: Path, bin_dir: Path, *, changed_files: str, pr_comment: str = "false"):
         config = root / ".agentclash" / "prompt-eval.yaml"
         config.parent.mkdir(parents=True)
@@ -307,7 +320,7 @@ class RunScriptPromptEvalModeTests(unittest.TestCase):
         )
 
     @staticmethod
-    def write_prompt_eval_cli(path: Path, calls: Path, *, exit_code: int, verdict: str):
+    def write_prompt_eval_cli(path: Path, calls: Path, *, exit_code: int, verdict: str, validate_exit: int = 0):
         path.write_text(
             textwrap.dedent(
                 f"""#!/usr/bin/env bash
@@ -318,7 +331,7 @@ class RunScriptPromptEvalModeTests(unittest.TestCase):
                 fi
                 if [[ "$1 $2" == "prompt-eval validate" ]]; then
                   [[ -f "$3" ]] || exit 12
-                  exit 0
+                  exit {validate_exit}
                 fi
                 if [[ "$1 $2" == "prompt-eval run" ]]; then
                   cat <<'JSON'

--- a/testing/codex-prompt-eval-ci-action.md
+++ b/testing/codex-prompt-eval-ci-action.md
@@ -1,0 +1,49 @@
+# Codex Prompt Eval CI Action - Test Contract
+
+Issue: #592
+Branch: `codex/prompt-eval-ci-action`
+
+## Functional Behavior
+
+- The composite action accepts `mode: ci` (default) and `mode: prompt-eval`.
+- Existing manifest-based CI behavior remains unchanged for default mode.
+- In prompt-eval mode, the action resolves a CLI that supports `prompt-eval validate` and `prompt-eval run`.
+- In prompt-eval mode, the action validates `.agentclash/prompt-eval.yaml` by default, or `prompt-eval-config` when provided.
+- Prompt-eval remote validation uses `agentclash prompt-eval validate <config> --remote --ci` when `remote-validate` is true, otherwise local `--ci` validation.
+- Prompt-eval change detection runs from provided `changed-files` or git base/head. It should run when the prompt-eval config or configured prompt-eval watch paths changed, and skip when unmatched if `skip-if-unmatched` is true.
+- Prompt-eval execution invokes `agentclash prompt-eval run <config> --json --follow --ci`, plus optional timeout, poll interval, and threshold inputs.
+- The action parses and preserves structured output when the CLI exits `3` for a gate failure, posts a PR comment, writes outputs, and exits `3`.
+- Prompt-eval infrastructure/runtime failures preserve their CLI exit codes and still post a structured comment when JSON exists or an early error result can be synthesized.
+- The prompt-eval PR comment is sticky and uses `<!-- agentclash:prompt-eval -->`. Re-runs update the existing comment rather than creating duplicates.
+- The prompt-eval comment includes pass/fail summary, execution errors, top failed assertions, AgentClash UI links, a local reproduction command, and redacted/truncated snippets.
+
+## Unit Tests
+
+- `run_test.py` covers prompt-eval mode should-run from config path changes.
+- `run_test.py` covers prompt-eval skip when changed files do not match.
+- `run_test.py` covers prompt-eval CLI pass and captures result outputs.
+- `run_test.py` covers prompt-eval gate failure exit `3` with a result file and comment helper invocation.
+- `run_test.py` covers prompt-eval infrastructure failure exit `4`.
+- `comment_test.py` covers prompt-eval comment formatting, links, failed assertions, redaction, reproduction command, and idempotent update marker.
+
+## Integration / Functional Tests
+
+- Run `.github/actions/agentclash-ci/run_test.py`.
+- Run `.github/actions/agentclash-ci/comment_test.py`.
+
+## Smoke Tests
+
+- Run the action shell tests with fake CLIs; no hosted AgentClash call is required.
+- Run shell syntax checks for `.github/actions/agentclash-ci/run.sh`.
+
+## E2E Tests
+
+N/A - live GitHub PR E2E is deferred until a stable hosted prompt-eval fixture workspace exists.
+
+## Manual / cURL Tests
+
+```bash
+cd .github/actions/agentclash-ci
+python3 -m unittest run_test.py comment_test.py
+bash -n run.sh
+```


### PR DESCRIPTION
## Summary
- add `mode: prompt-eval` to the AgentClash CI composite action
- run prompt-eval validate/change-detection/run --follow --json with exit-code preservation
- add sticky prompt-eval PR comments with failed assertions, redacted snippets, reproduction command, and AgentClash links
- document prompt-eval workflow setup and concurrency guidance

Closes #592

## Review checkpoint
- Contract: `testing/codex-prompt-eval-ci-action.md`
- Checkpoint: implementation reviewed against the contract in `/tmp/reviewcheckpoint.json`

## Tests
- `python3 -m unittest run_test.py comment_test.py` from `.github/actions/agentclash-ci`
- `bash -n .github/actions/agentclash-ci/run.sh`