### PR TITLE
[codex] add RAG retrieval validators

### DIFF
--- a/backend/internal/challengepack/bundle_test.go
+++ b/backend/internal/challengepack/bundle_test.go
@@ -97,6 +97,64 @@ tools:
 	}
 }
 
+func TestParseYAMLValidRAGRetrievalValidators(t *testing.T) {
+	bundle, err := ParseYAML([]byte(`
+pack:
+  slug: rag-support
+  name: RAG Support
+  family: support
+version:
+  number: 1
+  evaluation_spec:
+    name: rag-support-v1
+    version_number: 1
+    judge_mode: deterministic
+    validators:
+      - key: retrieval_hit
+        type: retrieval_hit
+        target: final_output
+        expected_from: case.expectations.relevant_docs
+        config:
+          k: 3
+          id_fields: [document_id]
+      - key: retrieval_precision
+        type: retrieval_precision
+        target: final_output
+        expected_from: case.expectations.relevant_docs
+        config:
+          k: 3
+          pass_at: 0.5
+    scorecard:
+      dimensions:
+        - key: retrieval
+          source: validators
+          validators: [retrieval_hit, retrieval_precision]
+challenges:
+  - key: travel-policy
+    title: Travel Policy
+    category: support
+    difficulty: medium
+input_sets:
+  - key: default
+    name: Default
+    cases:
+      - challenge_key: travel-policy
+        case_key: after-hours-rideshare
+        payload:
+          question: Can employees expense Uber after 10pm?
+        expectations:
+          - key: relevant_docs
+            kind: json
+            value: ["travel-policy"]
+`))
+	if err != nil {
+		t.Fatalf("ParseYAML returned error: %v", err)
+	}
+	if got := bundle.Version.EvaluationSpec.Validators[0].Type; got != "retrieval_hit" {
+		t.Fatalf("validator type = %q, want retrieval_hit", got)
+	}
+}
+
 func TestManifestJSONPreservesGeneralizedContract(t *testing.T) {
 	bundle := Bundle{
 		Pack: PackMetadata{

--- a/backend/internal/scoring/engine_validators.go
+++ b/backend/internal/scoring/engine_validators.go
@@ -117,7 +117,9 @@ func evaluateValidators(validators []ValidatorDeclaration, evidence extractedEvi
 		result.Verdict = outcome.verdict
 		result.NormalizedScore = outcome.normalizedScore
 		result.Reason = outcome.reason
-		if outcome.verdict == "error" {
+		if outcome.state != "" {
+			result.State = outcome.state
+		} else if outcome.verdict == "error" {
 			result.State = OutputStateError
 		} else {
 			result.State = OutputStateAvailable
@@ -376,6 +378,10 @@ func applyValidator(validator ValidatorDeclaration, actual string, expected stri
 		return validateROUGEScore(actual, expected, validator.Config)
 	case ValidatorTypeChrFScore:
 		return validateChrFScore(actual, expected, validator.Config)
+	case ValidatorTypeRetrievalHit:
+		return validateRetrievalHit(actual, expected, validator.Config)
+	case ValidatorTypeRetrievalPrecision:
+		return validateRetrievalPrecision(actual, expected, validator.Config)
 	case ValidatorTypeFileExists:
 		return validateFileExists(actual, validator.Config)
 	case ValidatorTypeFileContentMatch:

--- a/backend/internal/scoring/json_validators.go
+++ b/backend/internal/scoring/json_validators.go
@@ -22,6 +22,7 @@ const (
 )
 
 type validatorOutcome struct {
+	state           OutputState
 	verdict         string
 	normalizedScore *float64
 	reason          string

--- a/backend/internal/scoring/retrieval_validators.go
+++ b/backend/internal/scoring/retrieval_validators.go
@@ -1,0 +1,404 @@
+package scoring
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const (
+	defaultRetrievedChunksPath = "$.retrieved_chunks"
+	defaultRetrievalPassAt     = 1.0
+)
+
+type retrievalValidatorConfig struct {
+	RetrievedChunksPath string    `json:"retrieved_chunks_path"`
+	ExpectedIDsPath     string    `json:"expected_ids_path"`
+	IDFields            *[]string `json:"id_fields"`
+	K                   *int      `json:"k"`
+	PassAt              *float64  `json:"pass_at"`
+}
+
+type retrievalChunkEvidence struct {
+	Index int
+	IDs   []string
+}
+
+func validateRetrievalHit(actual string, expected string, rawConfig json.RawMessage) validatorOutcome {
+	cfg, err := parseRetrievalValidatorConfig(rawConfig)
+	if err != nil {
+		return validatorError("parse retrieval_hit config", err, nil)
+	}
+	actualDoc, err := parseJSONValue(actual)
+	if err != nil {
+		return validatorError("parse actual retrieval JSON", err, nil)
+	}
+	expectedDoc, err := parseExpectedRetrievalEvidence(expected, cfg.ExpectedIDsPath)
+	if err != nil {
+		return validatorError("parse expected retrieval ids", err, nil)
+	}
+
+	chunks, outcome := retrievalChunksFromDocument(actualDoc, cfg)
+	if outcome != nil {
+		return *outcome
+	}
+	expectedIDs := retrievalIDsFromValue(expectedDoc)
+	if len(expectedIDs) == 0 {
+		return unavailableRetrievalOutcome("expected retrieval ids are unavailable", map[string]any{
+			"expected_ids_path": cfg.ExpectedIDsPath,
+		})
+	}
+
+	considered := clipRetrievalChunks(chunks, cfg.K)
+	matched, missing := matchExpectedRetrievalIDs(considered, expectedIDs)
+	evidence := retrievalEvidence(cfg, considered, expectedIDs, matched)
+	evidence["missing_ids"] = missing
+
+	if len(matched) > 0 {
+		return validatorOutcome{verdict: "pass", normalizedScore: floatPtr(1), evidence: evidence}
+	}
+	return validatorOutcome{
+		verdict:         "fail",
+		normalizedScore: floatPtr(0),
+		reason:          "none of the expected retrieval ids appeared in retrieved chunks",
+		evidence:        evidence,
+	}
+}
+
+func validateRetrievalPrecision(actual string, expected string, rawConfig json.RawMessage) validatorOutcome {
+	cfg, err := parseRetrievalValidatorConfig(rawConfig)
+	if err != nil {
+		return validatorError("parse retrieval_precision config", err, nil)
+	}
+	actualDoc, err := parseJSONValue(actual)
+	if err != nil {
+		return validatorError("parse actual retrieval JSON", err, nil)
+	}
+	expectedDoc, err := parseExpectedRetrievalEvidence(expected, cfg.ExpectedIDsPath)
+	if err != nil {
+		return validatorError("parse expected retrieval ids", err, nil)
+	}
+
+	chunks, outcome := retrievalChunksFromDocument(actualDoc, cfg)
+	if outcome != nil {
+		return *outcome
+	}
+	expectedIDs := retrievalIDsFromValue(expectedDoc)
+	if len(expectedIDs) == 0 {
+		return unavailableRetrievalOutcome("expected retrieval ids are unavailable", map[string]any{
+			"expected_ids_path": cfg.ExpectedIDsPath,
+		})
+	}
+
+	considered := clipRetrievalChunks(chunks, cfg.K)
+	if len(considered) == 0 {
+		return unavailableRetrievalOutcome("retrieved chunks are unavailable", map[string]any{
+			"retrieved_chunks_path": cfg.RetrievedChunksPath,
+		})
+	}
+
+	expectedSet := stringSet(expectedIDs)
+	matchedChunks := 0
+	matchedIDs := make([]string, 0)
+	for _, chunk := range considered {
+		if chunkMatchesAnyExpectedID(chunk, expectedSet) {
+			matchedChunks++
+			matchedIDs = append(matchedIDs, matchingChunkIDs(chunk, expectedSet)...)
+		}
+	}
+	precision := float64(matchedChunks) / float64(len(considered))
+	passAt := cfg.effectivePassAt()
+	evidence := retrievalEvidence(cfg, considered, expectedIDs, uniqueStrings(matchedIDs))
+	evidence["matched_chunks"] = matchedChunks
+	evidence["considered_chunks"] = len(considered)
+	evidence["precision"] = precision
+	evidence["pass_at"] = passAt
+
+	if precision >= passAt {
+		return validatorOutcome{verdict: "pass", normalizedScore: floatPtr(precision), evidence: evidence}
+	}
+	return validatorOutcome{
+		verdict:         "fail",
+		normalizedScore: floatPtr(precision),
+		reason:          fmt.Sprintf("retrieval precision %.4f is below pass_at %.4f", precision, passAt),
+		evidence:        evidence,
+	}
+}
+
+func parseRetrievalValidatorConfig(raw json.RawMessage) (retrievalValidatorConfig, error) {
+	cfg := retrievalValidatorConfig{RetrievedChunksPath: defaultRetrievedChunksPath}
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return cfg, nil
+	}
+	if err := strictUnmarshal(raw, &cfg); err != nil {
+		return retrievalValidatorConfig{}, err
+	}
+	if strings.TrimSpace(cfg.RetrievedChunksPath) == "" {
+		cfg.RetrievedChunksPath = defaultRetrievedChunksPath
+	} else {
+		cfg.RetrievedChunksPath = strings.TrimSpace(cfg.RetrievedChunksPath)
+	}
+	cfg.ExpectedIDsPath = strings.TrimSpace(cfg.ExpectedIDsPath)
+	if cfg.IDFields != nil {
+		for i := range *cfg.IDFields {
+			(*cfg.IDFields)[i] = strings.TrimSpace((*cfg.IDFields)[i])
+		}
+	}
+	return cfg, nil
+}
+
+func (c retrievalValidatorConfig) idFields() []string {
+	if c.IDFields == nil {
+		return []string{"chunk_id", "document_id"}
+	}
+	fields := make([]string, 0, len(*c.IDFields))
+	for _, field := range *c.IDFields {
+		if trimmed := strings.TrimSpace(field); trimmed != "" {
+			fields = append(fields, trimmed)
+		}
+	}
+	return fields
+}
+
+func (c retrievalValidatorConfig) effectivePassAt() float64 {
+	if c.PassAt == nil {
+		return defaultRetrievalPassAt
+	}
+	return *c.PassAt
+}
+
+func parseExpectedRetrievalEvidence(expected string, path string) (any, error) {
+	if strings.TrimSpace(path) == "" {
+		parsed, err := parseJSONValue(expected)
+		if err == nil {
+			return parsed, nil
+		}
+		return strings.TrimSpace(expected), nil
+	}
+	document, err := parseJSONValue(expected)
+	if err != nil {
+		return nil, err
+	}
+	value, exists, err := extractJSONPathValue(document, path)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, nil
+	}
+	return value, nil
+}
+
+func retrievalChunksFromDocument(document any, cfg retrievalValidatorConfig) ([]retrievalChunkEvidence, *validatorOutcome) {
+	value, exists, err := extractJSONPathValue(document, cfg.RetrievedChunksPath)
+	if err != nil {
+		outcome := validatorError("evaluate retrieved_chunks_path", err, map[string]any{
+			"retrieved_chunks_path": cfg.RetrievedChunksPath,
+		})
+		return nil, &outcome
+	}
+	if !exists {
+		outcome := unavailableRetrievalOutcome("retrieved chunks are unavailable", map[string]any{
+			"retrieved_chunks_path": cfg.RetrievedChunksPath,
+		})
+		return nil, &outcome
+	}
+	rawChunks, ok := value.([]any)
+	if !ok {
+		outcome := validatorError("parse retrieved chunks", fmt.Errorf("retrieved_chunks_path must resolve to an array"), map[string]any{
+			"retrieved_chunks_path": cfg.RetrievedChunksPath,
+		})
+		return nil, &outcome
+	}
+	if len(rawChunks) == 0 {
+		outcome := unavailableRetrievalOutcome("retrieved chunks are unavailable", map[string]any{
+			"retrieved_chunks_path": cfg.RetrievedChunksPath,
+		})
+		return nil, &outcome
+	}
+
+	fields := cfg.idFields()
+	chunks := make([]retrievalChunkEvidence, 0, len(rawChunks))
+	for i, raw := range rawChunks {
+		object, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		ids := make([]string, 0, len(fields))
+		for _, field := range fields {
+			if id, ok := retrievalIDString(object[field]); ok {
+				ids = append(ids, id)
+			}
+		}
+		chunks = append(chunks, retrievalChunkEvidence{Index: i, IDs: uniqueStrings(ids)})
+	}
+	if len(chunks) == 0 {
+		outcome := unavailableRetrievalOutcome("retrieved chunk ids are unavailable", map[string]any{
+			"retrieved_chunks_path": cfg.RetrievedChunksPath,
+			"id_fields":             fields,
+		})
+		return nil, &outcome
+	}
+	return chunks, nil
+}
+
+func retrievalIDsFromValue(value any) []string {
+	switch typed := value.(type) {
+	case nil:
+		return nil
+	case string:
+		if trimmed := strings.TrimSpace(typed); trimmed != "" {
+			return []string{trimmed}
+		}
+	case []any:
+		ids := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if id, ok := retrievalIDString(item); ok {
+				ids = append(ids, id)
+			}
+		}
+		return uniqueStrings(ids)
+	case map[string]any:
+		for _, key := range []string{"chunk_id", "document_id", "id"} {
+			if id, ok := retrievalIDString(typed[key]); ok {
+				return []string{id}
+			}
+		}
+	}
+	if id, ok := retrievalIDString(value); ok {
+		return []string{id}
+	}
+	return nil
+}
+
+func retrievalIDString(value any) (string, bool) {
+	switch typed := value.(type) {
+	case string:
+		trimmed := strings.TrimSpace(typed)
+		return trimmed, trimmed != ""
+	case json.Number:
+		return typed.String(), typed.String() != ""
+	default:
+		return "", false
+	}
+}
+
+func clipRetrievalChunks(chunks []retrievalChunkEvidence, k *int) []retrievalChunkEvidence {
+	limit := len(chunks)
+	if k != nil && *k < limit {
+		limit = *k
+	}
+	return append([]retrievalChunkEvidence(nil), chunks[:limit]...)
+}
+
+func matchExpectedRetrievalIDs(chunks []retrievalChunkEvidence, expectedIDs []string) ([]string, []string) {
+	retrieved := map[string]struct{}{}
+	for _, chunk := range chunks {
+		for _, id := range chunk.IDs {
+			retrieved[id] = struct{}{}
+		}
+	}
+	matched := make([]string, 0)
+	missing := make([]string, 0)
+	for _, id := range uniqueStrings(expectedIDs) {
+		if _, ok := retrieved[id]; ok {
+			matched = append(matched, id)
+		} else {
+			missing = append(missing, id)
+		}
+	}
+	return matched, missing
+}
+
+func retrievalEvidence(cfg retrievalValidatorConfig, chunks []retrievalChunkEvidence, expectedIDs []string, matchedIDs []string) map[string]any {
+	return map[string]any{
+		"retrieved_chunks_path": cfg.RetrievedChunksPath,
+		"expected_ids_path":     cfg.ExpectedIDsPath,
+		"id_fields":             cfg.idFields(),
+		"k":                     cfg.K,
+		"expected_ids":          uniqueStrings(expectedIDs),
+		"considered_ids":        consideredRetrievalIDs(chunks),
+		"matched_ids":           uniqueStrings(matchedIDs),
+	}
+}
+
+func consideredRetrievalIDs(chunks []retrievalChunkEvidence) []string {
+	ids := make([]string, 0, len(chunks))
+	for _, chunk := range chunks {
+		ids = append(ids, chunk.IDs...)
+	}
+	return uniqueStrings(ids)
+}
+
+func chunkMatchesAnyExpectedID(chunk retrievalChunkEvidence, expected map[string]struct{}) bool {
+	for _, id := range chunk.IDs {
+		if _, ok := expected[id]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func matchingChunkIDs(chunk retrievalChunkEvidence, expected map[string]struct{}) []string {
+	matched := make([]string, 0)
+	for _, id := range chunk.IDs {
+		if _, ok := expected[id]; ok {
+			matched = append(matched, id)
+		}
+	}
+	return matched
+}
+
+func stringSet(values []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			out[trimmed] = struct{}{}
+		}
+	}
+	return out
+}
+
+func unavailableRetrievalOutcome(reason string, evidence map[string]any) validatorOutcome {
+	if evidence == nil {
+		evidence = map[string]any{}
+	}
+	return validatorOutcome{
+		state:    OutputStateUnavailable,
+		reason:   reason,
+		evidence: evidence,
+	}
+}
+
+func validateJSONPathSyntax(path string) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return fmt.Errorf("path is required")
+	}
+	if path[0] != '$' {
+		return fmt.Errorf("path must start with '$'")
+	}
+	index := 1
+	for index < len(path) {
+		switch path[index] {
+		case '.':
+			index++
+			start := index
+			for index < len(path) && isJSONPathIdentifierChar(path[index]) {
+				index++
+			}
+			if start == index {
+				return fmt.Errorf("missing property name at position %d", start)
+			}
+		case '[':
+			closeIndex, _, err := parseJSONPathBracket(path, index)
+			if err != nil {
+				return err
+			}
+			index = closeIndex + 1
+		default:
+			return fmt.Errorf("unexpected token %q at position %d", path[index], index)
+		}
+	}
+	return nil
+}

--- a/backend/internal/scoring/retrieval_validators_test.go
+++ b/backend/internal/scoring/retrieval_validators_test.go
@@ -1,0 +1,243 @@
+package scoring
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestRetrievalHitValidator_PassesWhenExpectedDocumentAppearsInTopK(t *testing.T) {
+	outcome := validateRetrievalHit(ragFinalOutput(), `["policy-travel"]`, json.RawMessage(`{"k":2}`))
+	if outcome.verdict != "pass" {
+		t.Fatalf("verdict = %q, want pass; reason=%s", outcome.verdict, outcome.reason)
+	}
+	if outcome.normalizedScore == nil || *outcome.normalizedScore != 1 {
+		t.Fatalf("score = %v, want 1", outcome.normalizedScore)
+	}
+	if got := outcome.evidence["matched_ids"]; !containsStringValue(got, "policy-travel") {
+		t.Fatalf("matched_ids = %#v, want policy-travel", got)
+	}
+}
+
+func TestRetrievalHitValidator_FailsWhenExpectedDocumentOutsideTopK(t *testing.T) {
+	outcome := validateRetrievalHit(ragFinalOutput(), `["policy-security"]`, json.RawMessage(`{"k":2}`))
+	if outcome.verdict != "fail" {
+		t.Fatalf("verdict = %q, want fail", outcome.verdict)
+	}
+	if outcome.normalizedScore == nil || *outcome.normalizedScore != 0 {
+		t.Fatalf("score = %v, want 0", outcome.normalizedScore)
+	}
+}
+
+func TestRetrievalPrecisionValidator_ComputesPartialCredit(t *testing.T) {
+	outcome := validateRetrievalPrecision(ragFinalOutput(), `["policy-travel"]`, json.RawMessage(`{"k":2,"pass_at":0.5}`))
+	if outcome.verdict != "pass" {
+		t.Fatalf("verdict = %q, want pass; reason=%s", outcome.verdict, outcome.reason)
+	}
+	if outcome.normalizedScore == nil || *outcome.normalizedScore != 0.5 {
+		t.Fatalf("score = %v, want 0.5", outcome.normalizedScore)
+	}
+	if got := outcome.evidence["considered_chunks"]; got != 2 {
+		t.Fatalf("considered_chunks = %#v, want 2", got)
+	}
+}
+
+func TestRetrievalPrecisionValidator_PassFailFromThreshold(t *testing.T) {
+	outcome := validateRetrievalPrecision(ragFinalOutput(), `["policy-travel"]`, json.RawMessage(`{"k":2,"pass_at":0.75}`))
+	if outcome.verdict != "fail" {
+		t.Fatalf("verdict = %q, want fail", outcome.verdict)
+	}
+	if !strings.Contains(outcome.reason, "below pass_at") {
+		t.Fatalf("reason = %q, want threshold failure", outcome.reason)
+	}
+}
+
+func TestRetrievalHitValidator_UsesExpectedIdsPathForCitationStyleChecks(t *testing.T) {
+	outcome := validateRetrievalHit(ragFinalOutput(), ragFinalOutput(), json.RawMessage(`{"expected_ids_path":"$.citations","k":2}`))
+	if outcome.verdict != "pass" {
+		t.Fatalf("verdict = %q, want pass; reason=%s", outcome.verdict, outcome.reason)
+	}
+}
+
+func TestRetrievalHitValidator_IgnoresRankFieldAndUsesArrayOrder(t *testing.T) {
+	actual := `{
+		"retrieved_chunks": [
+			{"chunk_id":"wrong-top","document_id":"wrong","rank":99,"score":0.1},
+			{"chunk_id":"right-second","document_id":"right","rank":1,"score":0.99}
+		]
+	}`
+	outcome := validateRetrievalHit(actual, `["right"]`, json.RawMessage(`{"k":1}`))
+	if outcome.verdict != "fail" {
+		t.Fatalf("verdict = %q, want fail because array order, not rank field, controls top-k", outcome.verdict)
+	}
+}
+
+func TestRetrievalHitValidator_MatchesConfiguredIDFields(t *testing.T) {
+	actual := `{"retrieved_chunks":[{"source_id":"source-7","chunk_id":"ignored"}]}`
+	outcome := validateRetrievalHit(actual, `["source-7"]`, json.RawMessage(`{"id_fields":["source_id"]}`))
+	if outcome.verdict != "pass" {
+		t.Fatalf("verdict = %q, want pass; reason=%s", outcome.verdict, outcome.reason)
+	}
+}
+
+func TestRetrievalHitValidator_FailsWhenExpectedIDsAreAbsent(t *testing.T) {
+	outcome := validateRetrievalHit(ragFinalOutput(), `["policy-missing"]`, nil)
+	if outcome.verdict != "fail" {
+		t.Fatalf("verdict = %q, want fail", outcome.verdict)
+	}
+	if got := outcome.evidence["missing_ids"]; !containsStringValue(got, "policy-missing") {
+		t.Fatalf("missing_ids = %#v, want policy-missing", got)
+	}
+}
+
+func TestRetrievalValidators_ReturnErrorForMalformedJSON(t *testing.T) {
+	outcome := validateRetrievalHit(`{"retrieved_chunks":`, `["policy-travel"]`, nil)
+	if outcome.verdict != "error" {
+		t.Fatalf("verdict = %q, want error", outcome.verdict)
+	}
+	if !strings.Contains(outcome.reason, "parse actual retrieval JSON") {
+		t.Fatalf("reason = %q, want parse error", outcome.reason)
+	}
+}
+
+func TestRetrievalValidators_ReturnUnavailableForEmptyRetrievedChunks(t *testing.T) {
+	outcome := validateRetrievalHit(`{"retrieved_chunks":[]}`, `["policy-travel"]`, nil)
+	if outcome.state != OutputStateUnavailable {
+		t.Fatalf("state = %s, want unavailable", outcome.state)
+	}
+	if !strings.Contains(outcome.reason, "retrieved chunks are unavailable") {
+		t.Fatalf("reason = %q, want unavailable reason", outcome.reason)
+	}
+}
+
+func TestValidateEvaluationSpec_RAGValidatorConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		vtype   ValidatorType
+		config  json.RawMessage
+		wantSub string
+	}{
+		{name: "negative k", vtype: ValidatorTypeRetrievalHit, config: json.RawMessage(`{"k":-1}`), wantSub: ".k"},
+		{name: "zero pass_at", vtype: ValidatorTypeRetrievalPrecision, config: json.RawMessage(`{"pass_at":0}`), wantSub: ".pass_at"},
+		{name: "invalid pass_at", vtype: ValidatorTypeRetrievalPrecision, config: json.RawMessage(`{"pass_at":1.1}`), wantSub: ".pass_at"},
+		{name: "empty id fields", vtype: ValidatorTypeRetrievalHit, config: json.RawMessage(`{"id_fields":[]}`), wantSub: ".id_fields"},
+		{name: "invalid path", vtype: ValidatorTypeRetrievalHit, config: json.RawMessage(`{"retrieved_chunks_path":"retrieved_chunks"}`), wantSub: ".retrieved_chunks_path"},
+		{name: "unknown field", vtype: ValidatorTypeRetrievalHit, config: json.RawMessage(`{"unknown":true}`), wantSub: "unknown field"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := retrievalSpec(tt.vtype, tt.config)
+			err := ValidateEvaluationSpec(spec)
+			if err == nil {
+				t.Fatalf("ValidateEvaluationSpec returned nil, want error")
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tt.wantSub)
+			}
+		})
+	}
+}
+
+func TestEvaluateRunAgent_RAGRetrievalValidatorsScoreFinalOutputEnvelope(t *testing.T) {
+	spec := EvaluationSpec{
+		Name:          "rag-retrieval",
+		VersionNumber: 1,
+		JudgeMode:     JudgeModeDeterministic,
+		Validators: []ValidatorDeclaration{
+			{
+				Key:          "hit",
+				Type:         ValidatorTypeRetrievalHit,
+				Target:       "final_output",
+				ExpectedFrom: "literal:[\"policy-travel\"]",
+				Config:       json.RawMessage(`{"k":2}`),
+			},
+			{
+				Key:          "precision",
+				Type:         ValidatorTypeRetrievalPrecision,
+				Target:       "final_output",
+				ExpectedFrom: "literal:[\"policy-travel\"]",
+				Config:       json.RawMessage(`{"k":2,"pass_at":0.5}`),
+			},
+		},
+		Scorecard: ScorecardDeclaration{
+			Dimensions: []DimensionDeclaration{
+				{Key: "retrieval", Source: DimensionSourceValidators, Validators: []string{"hit", "precision"}},
+			},
+		},
+	}
+
+	evaluation, err := EvaluateRunAgent(EvaluationInput{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		Events: []Event{
+			{Type: "system.output.finalized", SequenceNumber: 9, OccurredAt: time.Date(2026, 5, 6, 1, 0, 0, 0, time.UTC), Payload: []byte(`{"final_output":` + quoteJSON(ragFinalOutput()) + `}`)},
+		},
+	}, spec)
+	if err != nil {
+		t.Fatalf("EvaluateRunAgent returned error: %v", err)
+	}
+	if evaluation.ValidatorResults[0].State != OutputStateAvailable || evaluation.ValidatorResults[0].Verdict != "pass" {
+		t.Fatalf("hit result = state %s verdict %q, want available/pass", evaluation.ValidatorResults[0].State, evaluation.ValidatorResults[0].Verdict)
+	}
+	if evaluation.ValidatorResults[0].Source == nil || evaluation.ValidatorResults[0].Source.EventType != "system.output.finalized" {
+		t.Fatalf("source = %#v, want finalized event source", evaluation.ValidatorResults[0].Source)
+	}
+	if evaluation.DimensionScores["retrieval"] == nil || *evaluation.DimensionScores["retrieval"] != 0.75 {
+		t.Fatalf("retrieval dimension score = %v, want 0.75", evaluation.DimensionScores["retrieval"])
+	}
+}
+
+func retrievalSpec(vtype ValidatorType, config json.RawMessage) EvaluationSpec {
+	return EvaluationSpec{
+		Name:          "rag-config",
+		VersionNumber: 1,
+		JudgeMode:     JudgeModeDeterministic,
+		Validators: []ValidatorDeclaration{
+			{Key: "rag", Type: vtype, Target: "final_output", ExpectedFrom: "literal:[\"policy-travel\"]", Config: config},
+		},
+		Scorecard: ScorecardDeclaration{Dimensions: []DimensionDeclaration{{Key: "correctness"}}},
+	}
+}
+
+func ragFinalOutput() string {
+	return `{
+		"answer": "Employees may expense Uber after 10pm if policy conditions are met.",
+		"retrieved_chunks": [
+			{"chunk_id":"travel-policy#chunk-03","document_id":"policy-travel","rank":3,"score":0.91},
+			{"chunk_id":"benefits-policy#chunk-01","document_id":"policy-benefits","rank":1,"score":0.99},
+			{"chunk_id":"security-policy#chunk-09","document_id":"policy-security","rank":2,"score":0.95}
+		],
+		"citations": ["travel-policy#chunk-03"]
+	}`
+}
+
+func quoteJSON(value string) string {
+	encoded, _ := json.Marshal(value)
+	return string(encoded)
+}
+
+func containsStringValue(value any, want string) bool {
+	items, ok := value.([]string)
+	if ok {
+		for _, item := range items {
+			if item == want {
+				return true
+			}
+		}
+		return false
+	}
+	anyItems, ok := value.([]any)
+	if !ok {
+		return false
+	}
+	for _, item := range anyItems {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/scoring/spec.go
+++ b/backend/internal/scoring/spec.go
@@ -37,6 +37,9 @@ const (
 	ValidatorTypeFileJSONSchema     ValidatorType = "file_json_schema"
 	ValidatorTypeDirectoryStructure ValidatorType = "directory_structure"
 	ValidatorTypeCodeExecution      ValidatorType = "code_execution"
+
+	ValidatorTypeRetrievalHit       ValidatorType = "retrieval_hit"
+	ValidatorTypeRetrievalPrecision ValidatorType = "retrieval_precision"
 )
 
 type MetricType string
@@ -336,7 +339,7 @@ func (t ValidatorType) IsValid() bool {
 		ValidatorTypeMathEquivalence, ValidatorTypeBLEUScore, ValidatorTypeROUGEScore, ValidatorTypeChrFScore,
 		ValidatorTypeFileContentMatch, ValidatorTypeFileExists,
 		ValidatorTypeFileJSONSchema, ValidatorTypeDirectoryStructure,
-		ValidatorTypeCodeExecution:
+		ValidatorTypeCodeExecution, ValidatorTypeRetrievalHit, ValidatorTypeRetrievalPrecision:
 		return true
 	default:
 		return false

--- a/backend/internal/scoring/validation.go
+++ b/backend/internal/scoring/validation.go
@@ -770,6 +770,33 @@ func validateValidatorConfig(validator ValidatorDeclaration, path string) Valida
 		if cfg.PassThreshold != nil && (*cfg.PassThreshold < 0 || *cfg.PassThreshold > 1) {
 			errs = append(errs, ValidationError{Field: configPath + ".pass_threshold", Message: "must be between 0 and 1"})
 		}
+
+	case ValidatorTypeRetrievalHit, ValidatorTypeRetrievalPrecision:
+		cfg, err := parseRetrievalValidatorConfig(validator.Config)
+		if err != nil {
+			errs = append(errs, ValidationError{Field: configPath, Message: configParseErrorMessage(err)})
+			return errs
+		}
+		if err := validateJSONPathSyntax(cfg.RetrievedChunksPath); err != nil {
+			errs = append(errs, ValidationError{Field: configPath + ".retrieved_chunks_path", Message: err.Error()})
+		}
+		if cfg.ExpectedIDsPath != "" {
+			if err := validateJSONPathSyntax(cfg.ExpectedIDsPath); err != nil {
+				errs = append(errs, ValidationError{Field: configPath + ".expected_ids_path", Message: err.Error()})
+			}
+		}
+		if cfg.K != nil && *cfg.K <= 0 {
+			errs = append(errs, ValidationError{Field: configPath + ".k", Message: "must be greater than 0"})
+		}
+		if len(cfg.idFields()) == 0 {
+			errs = append(errs, ValidationError{Field: configPath + ".id_fields", Message: "must contain at least one field"})
+		}
+		if validator.Type == ValidatorTypeRetrievalPrecision {
+			passAt := cfg.effectivePassAt()
+			if passAt <= 0 || passAt > 1 {
+				errs = append(errs, ValidationError{Field: configPath + ".pass_at", Message: "must be greater than 0 and less than or equal to 1"})
+			}
+		}
 	}
 
 	return errs

--- a/docs/evaluation/challenge-pack-v0.md
+++ b/docs/evaluation/challenge-pack-v0.md
@@ -91,6 +91,65 @@ The manifest may contain a top-level `evaluation_spec` block like this:
 - `scorecard.dimensions`: score groups later surfaced to users
 - `scorecard.normalization`: dimension-specific thresholds for turning raw latency/cost into scores
 
+## RAG retrieval evaluation
+
+AgentClash evaluates customer-owned RAG pipelines; it does not ingest documents,
+chunk text, call embedding models, host vector databases, or run rerankers. A RAG
+agent can expose retrieval evidence by submitting a JSON object as `final_output`:
+
+```json
+{
+  "answer": "Employees may expense Uber after 10pm when policy conditions are met.",
+  "retrieved_chunks": [
+    {
+      "chunk_id": "travel-policy#chunk-03",
+      "document_id": "travel-policy",
+      "rank": 1,
+      "score": 0.91,
+      "text": "Rideshare after 10pm is reimbursable...",
+      "metadata": { "title": "Travel Policy" }
+    }
+  ],
+  "citations": ["travel-policy#chunk-03"]
+}
+```
+
+Array order in `retrieved_chunks` is the canonical rank. `rank` and `score` are
+descriptive metadata only.
+
+Two deterministic validators consume this envelope:
+
+```yaml
+validators:
+  - key: travel_policy_hit
+    type: retrieval_hit
+    target: final_output
+    expected_from: literal:["travel-policy"]
+    config:
+      k: 3
+      id_fields: [document_id]
+
+  - key: retrieval_precision
+    type: retrieval_precision
+    target: final_output
+    expected_from: literal:["travel-policy"]
+    config:
+      k: 3
+      pass_at: 0.5
+
+  - key: cited_chunks_were_retrieved
+    type: retrieval_hit
+    target: final_output
+    expected_from: final_output
+    config:
+      expected_ids_path: $.citations
+```
+
+`retrieval_hit` passes when any expected id appears in the considered chunks.
+`retrieval_precision` scores matched considered chunks divided by considered chunks
+after the optional top-k cutoff. Malformed JSON is an error; missing or empty
+retrieval evidence is unavailable evidence.
+
 ## Loader behavior
 
 The loader:
@@ -118,3 +177,5 @@ This preserves comparability while still allowing the benchmark to evolve throug
 - `#47`: scorecard generation
 - `#48`-`#50`: comparison and release gates
 - `#82`: failure-to-eval flywheel
+- First-class retrieval trace events, recall/MRR validators, and RAG ingestion/indexing
+  infrastructure remain out of scope for this contract.

--- a/scripts/internal-agent-skills/prepare-skill-harnesses.mjs
+++ b/scripts/internal-agent-skills/prepare-skill-harnesses.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
@@ -88,6 +89,10 @@ function validatorCommand(skillPath) {
   return `node scripts/internal-agent-skills/validate-skill-harness-output.mjs ${JSON.stringify(skillPath)} .agentclash/skill-eval-result.json`;
 }
 
+function shortSkillKey(skillPath, skillName) {
+  return createHash("sha256").update(`${skillPath}\0${skillName}`).digest("hex").slice(0, 8);
+}
+
 const skills = JSON.parse(skillsArg);
 if (!Array.isArray(skills)) {
   throw new Error("changed skills input must be a JSON array");
@@ -104,9 +109,10 @@ for (const skillPath of skills) {
   }
   const title = titleFromSkill(content);
   const slug = meta.name.replace(/[^a-z0-9-]+/gi, "-").toLowerCase();
+  const skillKey = shortSkillKey(skillPath, meta.name);
   const specPath = path.join(outDir, `${slug}.harness.json`);
   const spec = {
-    name: `skill-self-test-${safeRunLabel}-${slug}`.slice(0, 120),
+    name: `skill-self-test-${skillKey}-${safeRunLabel}-${slug}`.slice(0, 120),
     description: `Internal blind self-containment test for ${skillPath}`,
     task_prompt: taskPrompt(skillPath, meta, title),
     codex_template: "codex",

--- a/scripts/internal-agent-skills/skill-harness-scripts.test.mjs
+++ b/scripts/internal-agent-skills/skill-harness-scripts.test.mjs
@@ -7,6 +7,19 @@ import path from "node:path";
 
 const repo = process.cwd();
 const tmp = mkdtempSync(path.join(tmpdir(), "agentclash-skill-harness-"));
+
+function backendSlug(name) {
+  let slug = name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (slug.length > 60) {
+    slug = slug.slice(0, 60).replace(/-+$/g, "");
+  }
+  return slug;
+}
+
 const detectRepo = path.join(tmp, "detect-repo");
 mkdirSync(path.join(detectRepo, "web/content/agent-skills/detect-skill"), { recursive: true });
 execFileSync("git", ["init"], { cwd: detectRepo, stdio: "ignore" });
@@ -82,7 +95,7 @@ const manifestPath = execFileSync(
 const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
 assert.equal(manifest.harnesses.length, 1);
 const spec = JSON.parse(readFileSync(manifest.harnesses[0].spec, "utf8"));
-assert.match(spec.name, /^skill-self-test-unit-agentclash-example-skill$/);
+assert.match(spec.name, /^skill-self-test-[a-f0-9]{8}-unit-agentclash-example-skill$/);
 assert.equal(spec.auth_mode, "api_key_secret");
 assert.equal(spec.openai_api_key_secret_name, "OPENAI_API_KEY");
 assert.equal(spec.repository_url, "https://github.com/agentclash/agentclash.git");
@@ -125,7 +138,46 @@ const longManifestPath = execFileSync(
 ).trim();
 const longManifest = JSON.parse(readFileSync(longManifestPath, "utf8"));
 const longSpec = JSON.parse(readFileSync(longManifest.harnesses[0].spec, "utf8"));
-assert.match(longSpec.name.slice(0, 60), /^skill-self-test-run-123456789-1-/);
+assert.match(longSpec.name.slice(0, 60), /^skill-self-test-[a-f0-9]{8}-run-123456789-1-/);
+
+const collidingNames = ["agentclash-challenge-pack-scoring-validators", "agentclash-challenge-pack-yaml-author"];
+const collidingPaths = collidingNames.map((name) => {
+  const dir = path.join(tmp, "web/content/agent-skills", name);
+  mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, "SKILL.md");
+  writeFileSync(
+    file,
+    `---
+name: ${name}
+description: Use when testing harness slug collisions.
+metadata:
+  agentclash.role: testing
+  agentclash.version: "1"
+  agentclash.requires_cli: "false"
+---
+
+# ${name}
+`,
+  );
+  return file;
+});
+const collisionOutDir = path.join(tmp, "collision-out");
+const collisionManifestPath = execFileSync(
+  "node",
+  ["scripts/internal-agent-skills/prepare-skill-harnesses.mjs", JSON.stringify(collidingPaths), collisionOutDir],
+  {
+    cwd: repo,
+    env: {
+      ...process.env,
+      RUN_LABEL: "run-25422143294-1",
+    },
+    encoding: "utf8",
+  },
+).trim();
+const collisionManifest = JSON.parse(readFileSync(collisionManifestPath, "utf8"));
+const collisionSpecs = collisionManifest.harnesses.map((entry) => JSON.parse(readFileSync(entry.spec, "utf8")));
+const collisionSlugs = collisionSpecs.map((entry) => backendSlug(entry.name));
+assert.equal(new Set(collisionSlugs).size, collisionSlugs.length);
 
 const resultPath = path.join(tmp, "result.json");
 writeFileSync(

--- a/web/content/agent-skills/challenge-pack-skills/agentclash-challenge-pack-scoring-validators/SKILL.md
+++ b/web/content/agent-skills/challenge-pack-skills/agentclash-challenge-pack-scoring-validators/SKILL.md
@@ -133,9 +133,13 @@ file_exists
 file_json_schema
 directory_structure
 code_execution
+retrieval_hit
+retrieval_precision
 ```
 
 Do not use `has_json`, `json_equals`, `semantic_match`, `unit_test`, `shell`, or provider-specific names; the validator rejects unknown `type` values.
+
+`retrieval_hit` and `retrieval_precision` expect the agent's `final_output` to be a JSON object containing `retrieved_chunks`. They evaluate customer-owned RAG pipelines only; they do not ingest, chunk, embed, or query knowledge sources.
 
 ## Evidence References
 Validator `target` and required `expected_from` values must use supported evidence references:

--- a/web/content/agent-skills/challenge-pack-skills/agentclash-challenge-pack-yaml-author/SKILL.md
+++ b/web/content/agent-skills/challenge-pack-skills/agentclash-challenge-pack-yaml-author/SKILL.md
@@ -250,7 +250,7 @@ evaluation_spec:
 
 Supported `judge_mode` values are `deterministic`, `llm_judge`, and `hybrid`.
 
-Supported validator types include `exact_match`, `contains`, `regex_match`, `json_schema`, `json_path_match`, `boolean_assert`, `fuzzy_match`, `numeric_match`, `normalized_match`, `token_f1`, `math_equivalence`, `bleu_score`, `rouge_score`, `chrf_score`, `file_content_match`, `file_exists`, `file_json_schema`, `directory_structure`, and `code_execution`.
+Supported validator types include `exact_match`, `contains`, `regex_match`, `json_schema`, `json_path_match`, `boolean_assert`, `fuzzy_match`, `numeric_match`, `normalized_match`, `token_f1`, `math_equivalence`, `bleu_score`, `rouge_score`, `chrf_score`, `file_content_match`, `file_exists`, `file_json_schema`, `directory_structure`, `code_execution`, `retrieval_hit`, and `retrieval_precision`.
 
 Evidence references accepted by validators and judges include `final_output`, `run.final_output`, `challenge_input`, `case.payload`, `case.payload.<path>`, `case.inputs.<path>`, `case.expectations.<path>`, `artifact.<path>`, `file:<post_execution_check_key>`, and `literal:<value>`.
 

--- a/web/content/docs/challenge-packs/evaluation-spec-reference.mdx
+++ b/web/content/docs/challenge-packs/evaluation-spec-reference.mdx
@@ -33,11 +33,51 @@ Each entry is a `ValidatorDeclaration`:
 
 From `ValidatorType*` constants:
 
-`exact_match`, `contains`, `regex_match`, `json_schema`, `json_path_match`, `boolean_assert`, `fuzzy_match`, `numeric_match`, `normalized_match`, `token_f1`, `math_equivalence`, `bleu_score`, `rouge_score`, `chrf_score`, `file_content_match`, `file_exists`, `file_json_schema`, `directory_structure`, `code_execution`
+`exact_match`, `contains`, `regex_match`, `json_schema`, `json_path_match`, `boolean_assert`, `fuzzy_match`, `numeric_match`, `normalized_match`, `token_f1`, `math_equivalence`, `bleu_score`, `rouge_score`, `chrf_score`, `file_content_match`, `file_exists`, `file_json_schema`, `directory_structure`, `code_execution`, `retrieval_hit`, `retrieval_precision`
 
 File-ish validators gate on sandbox artifacts (see **File validators**: `IsFileValidator()` distinguishes these).
 
 Always check `requires_expected_from`: e.g., `file_exists`, `directory_structure`, and `code_execution` can rely on config/paths without `expected_from`.
+
+### RAG retrieval validators
+
+`retrieval_hit` and `retrieval_precision` evaluate retrieval evidence that the agent writes into `final_output` as JSON. AgentClash does **not** ingest documents, chunk text, compute embeddings, host vector indexes, or wire workspace `knowledge_sources` into this path.
+
+The canonical envelope is:
+
+```json
+{
+  "answer": "Employees may expense Uber after 10pm when policy conditions are met.",
+  "retrieved_chunks": [
+    {
+      "chunk_id": "travel-policy#chunk-03",
+      "document_id": "travel-policy",
+      "rank": 1,
+      "score": 0.91,
+      "text": "Rideshare after 10pm is reimbursable...",
+      "metadata": { "title": "Travel Policy" }
+    }
+  ],
+  "citations": ["travel-policy#chunk-03"]
+}
+```
+
+Array order in `retrieved_chunks` is the canonical rank; `rank` and `score` are descriptive metadata only. Malformed JSON is a validator error. Missing or empty retrieval evidence is unavailable evidence.
+
+Common config:
+
+```yaml
+config:
+  retrieved_chunks_path: $.retrieved_chunks # default
+  expected_ids_path: $.citations            # optional; reads ids from expected_from JSON
+  id_fields: [chunk_id, document_id]        # default
+  k: 3                                      # optional top-k cutoff
+  pass_at: 0.5                              # retrieval_precision only; default 1.0
+```
+
+Use `retrieval_hit` for hit@k style checks: it passes when any expected id appears in the considered chunks. Use `retrieval_precision` when you want partial credit: it scores matched considered chunks divided by considered chunks after the top-k cutoff.
+
+Citation support does not need a separate validator type. Set both `target` and `expected_from` to `final_output`, then use `expected_ids_path: $.citations` so the cited ids must appear in `retrieved_chunks`.
 
 ## Metrics (`metrics[]`)
 
@@ -137,6 +177,8 @@ Validated by `isSupportedEvidenceReference`:
 - Literals: `literal:…`
 
 Prefer explicit paths whenever you refactor input schema—ambiguous references fail validate instead of drifting silently.
+
+RAG retrieval validators usually keep `target: final_output`; their inner JSON paths live in `config.retrieved_chunks_path` and `config.expected_ids_path`.
 
 ## See also
 


### PR DESCRIPTION
## Summary

- Add deterministic `retrieval_hit` and `retrieval_precision` validators for customer-provided RAG retrieval evidence in `final_output` JSON.
- Keep the implementation scoring-only: no ingestion, chunking, embedding, vector DB, reranker, `knowledge_sources`, API, CLI, migration, or run-event changes.
- Document the RAG output envelope, top-k array-order semantics, citation-style checks, and validator config in evaluation docs and challenge-pack authoring skills.

## Validation

- `cd backend && go test ./internal/scoring`
- `cd backend && go test ./internal/challengepack`
- `cd backend && go test ./...`
- `git diff --check`

## Notes

The branch was rebased onto current `origin/main` before push. Local scratch `plans/` files were intentionally left uncommitted and are not part of this PR.
