### PR TITLE
fix(cli): polish prompt eval results table

### DIFF
--- a/cli/cmd/prompt_eval.go
+++ b/cli/cmd/prompt_eval.go
@@ -1854,18 +1854,113 @@ func renderPromptEvalRun(rc *RunContext, result promptEvalRunResult) {
 }
 
 func renderPromptEvalResults(rc *RunContext, result promptEvalResultsEnvelope) {
-	if result.ExitCode != 0 {
-		rc.Output.PrintError("Prompt eval results failed")
+	switch result.GateVerdict {
+	case "pass":
+		rc.Output.PrintSuccess("Prompt eval gate passed")
+	case "fail":
+		rc.Output.PrintError("Prompt eval gate failed")
+	case "error":
+		rc.Output.PrintError("Prompt eval results errored")
+	default:
+		if result.ExitCode != 0 {
+			rc.Output.PrintError("Prompt eval results failed")
+		}
+	}
+	threshold := result.Thresholds["assertion_pass_rate"]
+	rc.Output.PrintDetail("Experiment", result.ExperimentID)
+	rc.Output.PrintDetail("Status", promptEvalStatusText(result.Status))
+	rc.Output.PrintDetail("Gate", promptEvalColoredVerdict(result.GateVerdict))
+	rc.Output.PrintDetail("Pass Rate", fmt.Sprintf("%s (%d passed, %d failed, %d errors, threshold %s)",
+		promptEvalPercent(result.Summary.AssertionPassRate),
+		result.Summary.AssertionsPassed,
+		result.Summary.AssertionsFailed,
+		result.Summary.ExecutionErrors,
+		promptEvalPercent(threshold),
+	))
+	rc.Output.PrintDetail("Cases", fmt.Sprintf("%d/%d completed", result.Summary.CompletedCases, result.Summary.TotalCases))
+	if len(result.Summary.DimensionScores) > 0 {
+		dimensionRows := make([][]string, 0, len(result.Summary.DimensionScores))
+		for _, key := range sortedPromptEvalFloatKeys(result.Summary.DimensionScores) {
+			dimensionRows = append(dimensionRows, []string{key, promptEvalPercent(result.Summary.DimensionScores[key])})
+		}
+		rc.Output.PrintTable([]output.Column{{Header: "Dimension"}, {Header: "Score"}}, dimensionRows)
 	}
 	rows := make([][]string, 0, len(result.Rows))
 	for _, row := range result.Rows {
-		score := "-"
-		if row.Score != nil {
-			score = fmt.Sprintf("%.2f", *row.Score)
-		}
-		rows = append(rows, []string{row.CaseKey, row.AssertionKey, row.Result, score, row.Error})
+		rows = append(rows, []string{
+			promptEvalColoredResult(row.Result),
+			row.CaseKey,
+			promptEvalAssertionLabel(row),
+			promptEvalScoreText(row.Score),
+			truncateRunes(row.Expected, 80),
+			truncateRunes(row.Actual, 80),
+			truncateRunes(row.Error, 80),
+		})
 	}
-	rc.Output.PrintTable([]output.Column{{Header: "Case"}, {Header: "Assertion"}, {Header: "Result"}, {Header: "Score"}, {Header: "Error"}}, rows)
+	rc.Output.PrintTable([]output.Column{{Header: "Result"}, {Header: "Case"}, {Header: "Assertion"}, {Header: "Score"}, {Header: "Expected"}, {Header: "Actual"}, {Header: "Error"}}, rows)
+}
+
+func promptEvalColoredVerdict(verdict string) string {
+	normalized := strings.ToLower(strings.TrimSpace(verdict))
+	if normalized == "" {
+		return "-"
+	}
+	return output.StatusColor(normalized)
+}
+
+func promptEvalStatusText(status string) string {
+	normalized := strings.ToLower(strings.TrimSpace(status))
+	if normalized == "" {
+		return "-"
+	}
+	return output.StatusColor(normalized)
+}
+
+func promptEvalColoredResult(result string) string {
+	normalized := strings.ToLower(strings.TrimSpace(result))
+	if normalized == "" {
+		return "-"
+	}
+	switch normalized {
+	case "pass":
+		return output.Green("PASS")
+	case "fail":
+		return output.Red("FAIL")
+	case "error":
+		return output.Red("ERROR")
+	default:
+		return output.StatusColor(strings.ToUpper(result))
+	}
+}
+
+func promptEvalAssertionLabel(row promptEvalResultRow) string {
+	if strings.TrimSpace(row.AssertionKey) == "" {
+		return strings.TrimSpace(row.Assertion)
+	}
+	if strings.TrimSpace(row.Assertion) == "" {
+		return strings.TrimSpace(row.AssertionKey)
+	}
+	return fmt.Sprintf("%s (%s)", row.Assertion, row.AssertionKey)
+}
+
+func promptEvalScoreText(score *float64) string {
+	if score == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%.2f", *score)
+}
+
+func promptEvalPercent(value float64) string {
+	return fmt.Sprintf("%.0f%%", value*100)
+}
+
+func sortedPromptEvalFloatKeys(values map[string]float64) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func renderPromptfooImportResult(rc *RunContext, result promptfooImportResult, outPath string) {

--- a/cli/cmd/prompt_eval_test.go
+++ b/cli/cmd/prompt_eval_test.go
@@ -752,6 +752,38 @@ func TestPromptEvalResultsCommandPrintsStableEnvelope(t *testing.T) {
 	}
 }
 
+func TestPromptEvalResultsCommandPrintsReadableTable(t *testing.T) {
+	fake := newPromptEvalRunFake(t, &promptEvalRunFakeState{resultVerdict: "fail"})
+	defer fake.server.Close()
+
+	stdout := captureStdout(t)
+	err := executeCommand(t, []string{"prompt-eval", "results", "exp-1"}, fake.server.URL)
+	out := stdout.finish()
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) || exitErr.Code != promptEvalExitGate {
+		t.Fatalf("expected gate exit, got %T %v\n%s", err, err, out)
+	}
+	for _, want := range []string{
+		"Experiment:",
+		"Gate:",
+		"fail",
+		"Status:",
+		"Pass Rate:",
+		"0% (0 passed, 1 failed, 0 errors, threshold 100%)",
+		"DIMENSION",
+		"correctness",
+		"RESULT",
+		"FAIL",
+		"contains (v1)",
+		"done",
+		"Bonjour",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("table output missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestPromptEvalResultsCommandWrapsBackendErrorExit(t *testing.T) {
 	fake := newPromptEvalRunFake(t, &promptEvalRunFakeState{resultStatusCode: http.StatusBadGateway})
 	defer fake.server.Close()
@@ -1136,7 +1168,7 @@ func (f *promptEvalRunFake) resultItem() map[string]any {
 		"total_tokens":     7,
 		"dimension_scores": map[string]any{"correctness": score},
 		"validator_results": []any{
-			map[string]any{"key": "v1", "type": "contains", "verdict": validatorVerdict, "normalized_score": score, "reason": ""},
+			map[string]any{"key": "v1", "type": "contains", "verdict": validatorVerdict, "normalized_score": score, "expected_value": "done", "reason": ""},
 		},
 	}
 	if f.caseStatus == "failed" {

--- a/cli/internal/output/color.go
+++ b/cli/internal/output/color.go
@@ -34,7 +34,7 @@ func StatusColor(status string) string {
 	switch status {
 	case "completed", "active", "ready", "passed", "pass":
 		return Green(status)
-	case "failed", "error", "archived":
+	case "failed", "fail", "error", "archived":
 		return Red(status)
 	case "running", "executing", "evaluating", "provisioning", "building":
 		return Cyan(status)

--- a/testing/codex-prompt-eval-results-polish.md
+++ b/testing/codex-prompt-eval-results-polish.md
@@ -1,0 +1,31 @@
+# codex/prompt-eval-results-polish — Test Contract
+
+## Functional Behavior
+- `agentclash prompt-eval results <experiment-id>` in table mode prints a readable verdict summary before assertion rows.
+- Passing assertions render green, failing assertions render red, evaluator/runtime errors render red or yellow as appropriate through the existing output color system.
+- Results output includes gate verdict, pass rate, assertion pass/fail counts, execution errors, threshold, and dimension scores when present.
+- Assertion rows include result, case key, assertion type/key, score, expected value, actual value, and error/reason.
+- `--json` and `--output yaml` remain unchanged structured envelopes.
+- `--no-color` / test color disabling still removes ANSI colors through the existing output package.
+
+## Unit Tests
+- `TestPromptEvalResultsCommandPrintsReadableTable` verifies table output includes verdict summary, pass/fail labels, expected/actual context, and dimension rows.
+- Existing prompt-eval JSON tests continue to pass unchanged.
+- Existing output color tests continue to pass.
+
+## Integration / Functional Tests
+- Run `go test ./cmd -run 'TestPromptEvalResultsCommand|TestPromptEvalRunFollow'`.
+
+## Smoke Tests
+- Run `go test ./cmd ./internal/output`.
+- Run `go build ./...`.
+
+## E2E Tests
+N/A — this is CLI rendering only; live backend behavior is unchanged.
+
+## Manual / cURL Tests
+```bash
+agentclash prompt-eval results 2e5de156-21de-4aba-aef3-4bc7491f3bac --threshold 1
+```
+
+Expected: human table output shows a failing gate, green PASS rows, a red FAIL row, and summary/dimension context.


### PR DESCRIPTION
## Summary
- Add a readable prompt-eval results summary in table mode
- Color PASS/FAIL/gate labels through the existing output color system
- Show dimension scores plus expected/actual/error context for assertion rows

## Tests
- go test ./cmd -run 'TestPromptEvalResultsCommand|TestPromptEvalRunFollow'
- go test ./cmd ./internal/output
- go build ./...
- go run . prompt-eval results 2e5de156-21de-4aba-aef3-4bc7491f3bac --threshold 1