### PR TITLE
fix(cli): compact prompt eval results tables

### DIFF
--- a/cli/cmd/prompt_eval.go
+++ b/cli/cmd/prompt_eval.go
@@ -1867,37 +1867,35 @@ func renderPromptEvalResults(rc *RunContext, result promptEvalResultsEnvelope) {
 		}
 	}
 	threshold := result.Thresholds["assertion_pass_rate"]
-	rc.Output.PrintDetail("Experiment", result.ExperimentID)
-	rc.Output.PrintDetail("Status", promptEvalStatusText(result.Status))
-	rc.Output.PrintDetail("Gate", promptEvalColoredVerdict(result.GateVerdict))
-	rc.Output.PrintDetail("Pass Rate", fmt.Sprintf("%s (%d passed, %d failed, %d errors, threshold %s)",
+	summaryRows := [][]string{{
+		result.ExperimentID,
+		promptEvalStatusText(result.Status),
+		promptEvalColoredVerdict(result.GateVerdict),
 		promptEvalPercent(result.Summary.AssertionPassRate),
-		result.Summary.AssertionsPassed,
-		result.Summary.AssertionsFailed,
-		result.Summary.ExecutionErrors,
+		fmt.Sprintf("%d/%d", result.Summary.CompletedCases, result.Summary.TotalCases),
+		fmt.Sprintf("%d/%d/%d", result.Summary.AssertionsPassed, result.Summary.AssertionsFailed, result.Summary.ExecutionErrors),
 		promptEvalPercent(threshold),
-	))
-	rc.Output.PrintDetail("Cases", fmt.Sprintf("%d/%d completed", result.Summary.CompletedCases, result.Summary.TotalCases))
+	}}
+	output.RenderBorderedTable(rc.Output.Writer(), []output.Column{{Header: "Experiment"}, {Header: "Status"}, {Header: "Gate"}, {Header: "Pass Rate"}, {Header: "Cases"}, {Header: "Pass/Fail/Err"}, {Header: "Threshold"}}, summaryRows)
 	if len(result.Summary.DimensionScores) > 0 {
 		dimensionRows := make([][]string, 0, len(result.Summary.DimensionScores))
 		for _, key := range sortedPromptEvalFloatKeys(result.Summary.DimensionScores) {
 			dimensionRows = append(dimensionRows, []string{key, promptEvalPercent(result.Summary.DimensionScores[key])})
 		}
-		rc.Output.PrintTable([]output.Column{{Header: "Dimension"}, {Header: "Score"}}, dimensionRows)
+		output.RenderBorderedTable(rc.Output.Writer(), []output.Column{{Header: "Dimension"}, {Header: "Score"}}, dimensionRows)
 	}
 	rows := make([][]string, 0, len(result.Rows))
 	for _, row := range result.Rows {
 		rows = append(rows, []string{
 			promptEvalColoredResult(row.Result),
 			row.CaseKey,
-			promptEvalAssertionLabel(row),
+			promptEvalAssertionKind(row),
 			promptEvalScoreText(row.Score),
-			truncateRunes(row.Expected, 80),
-			truncateRunes(row.Actual, 80),
-			truncateRunes(row.Error, 80),
+			promptEvalShortAssertionKey(row.AssertionKey),
 		})
 	}
-	rc.Output.PrintTable([]output.Column{{Header: "Result"}, {Header: "Case"}, {Header: "Assertion"}, {Header: "Score"}, {Header: "Expected"}, {Header: "Actual"}, {Header: "Error"}}, rows)
+	output.RenderBorderedTable(rc.Output.Writer(), []output.Column{{Header: "Result"}, {Header: "Case"}, {Header: "Assertion"}, {Header: "Score"}, {Header: "Key"}}, rows)
+	renderPromptEvalFailureDetails(rc, result.Rows)
 }
 
 func promptEvalColoredVerdict(verdict string) string {
@@ -1943,6 +1941,13 @@ func promptEvalAssertionLabel(row promptEvalResultRow) string {
 	return fmt.Sprintf("%s (%s)", row.Assertion, row.AssertionKey)
 }
 
+func promptEvalAssertionKind(row promptEvalResultRow) string {
+	if strings.TrimSpace(row.Assertion) != "" {
+		return strings.TrimSpace(row.Assertion)
+	}
+	return "-"
+}
+
 func promptEvalScoreText(score *float64) string {
 	if score == nil {
 		return "-"
@@ -1961,6 +1966,52 @@ func sortedPromptEvalFloatKeys(values map[string]float64) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+func renderPromptEvalFailureDetails(rc *RunContext, rows []promptEvalResultRow) {
+	detailRows := [][]string{}
+	for _, row := range rows {
+		result := strings.ToLower(strings.TrimSpace(row.Result))
+		if result == "pass" {
+			continue
+		}
+		expected := promptEvalDetailText(row.Expected)
+		actual := promptEvalDetailText(row.Actual)
+		errText := promptEvalDetailText(row.Error)
+		if expected == "-" && actual == "-" && errText == "-" {
+			continue
+		}
+		detailRows = append(detailRows, []string{
+			row.CaseKey,
+			fmt.Sprintf("%s (%s)", promptEvalAssertionKind(row), promptEvalShortAssertionKey(row.AssertionKey)),
+			expected,
+			actual,
+			errText,
+		})
+	}
+	if len(detailRows) == 0 {
+		return
+	}
+	output.RenderBorderedTable(rc.Output.Writer(), []output.Column{{Header: "Failure Case"}, {Header: "Assertion"}, {Header: "Expected"}, {Header: "Actual"}, {Header: "Reason"}}, detailRows)
+}
+
+func promptEvalDetailText(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	return truncateRunes(value, 56)
+}
+
+func promptEvalShortAssertionKey(key string) string {
+	key = strings.TrimSpace(key)
+	if len(key) > 13 && key[12] == '_' {
+		return key[13:]
+	}
+	if key == "" {
+		return "-"
+	}
+	return key
 }
 
 func renderPromptfooImportResult(rc *RunContext, result promptfooImportResult, outPath string) {

--- a/cli/cmd/prompt_eval_test.go
+++ b/cli/cmd/prompt_eval_test.go
@@ -764,17 +764,21 @@ func TestPromptEvalResultsCommandPrintsReadableTable(t *testing.T) {
 		t.Fatalf("expected gate exit, got %T %v\n%s", err, err, out)
 	}
 	for _, want := range []string{
-		"Experiment:",
-		"Gate:",
+		"EXPERIMENT",
+		"+",
+		"|",
+		"PASS RATE",
+		"PASS/FAIL/ERR",
 		"fail",
-		"Status:",
-		"Pass Rate:",
-		"0% (0 passed, 1 failed, 0 errors, threshold 100%)",
+		"0%",
+		"0/1/0",
 		"DIMENSION",
 		"correctness",
 		"RESULT",
 		"FAIL",
-		"contains (v1)",
+		"contains",
+		"v1",
+		"FAILURE CASE",
 		"done",
 		"Bonjour",
 	} {

--- a/cli/internal/output/table.go
+++ b/cli/internal/output/table.go
@@ -3,6 +3,7 @@ package output
 import (
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 )
 
@@ -56,9 +57,77 @@ func RenderTable(w io.Writer, columns []Column, rows [][]string) {
 	}
 }
 
+// RenderBorderedTable writes a table with ASCII borders for dense result views
+// where column boundaries matter more than the default compact gh-style table.
+func RenderBorderedTable(w io.Writer, columns []Column, rows [][]string) {
+	if len(columns) == 0 {
+		return
+	}
+	widths := tableWidths(columns, rows)
+	printBorder := func() {
+		fmt.Fprint(w, "+")
+		for _, width := range widths {
+			fmt.Fprint(w, strings.Repeat("-", width+2))
+			fmt.Fprint(w, "+")
+		}
+		fmt.Fprintln(w)
+	}
+	printRow := func(cells []string) {
+		fmt.Fprint(w, "|")
+		for i := range columns {
+			cell := ""
+			if i < len(cells) {
+				cell = cells[i]
+			}
+			fmt.Fprintf(w, " %s |", padRightVisible(cell, widths[i]))
+		}
+		fmt.Fprintln(w)
+	}
+
+	headers := make([]string, len(columns))
+	for i, column := range columns {
+		headers[i] = strings.ToUpper(column.Header)
+	}
+	printBorder()
+	printRow(headers)
+	printBorder()
+	for _, row := range rows {
+		printRow(row)
+	}
+	printBorder()
+}
+
+func tableWidths(columns []Column, rows [][]string) []int {
+	widths := make([]int, len(columns))
+	for i, c := range columns {
+		widths[i] = visibleLen(c.Header)
+	}
+	for _, row := range rows {
+		for i, cell := range row {
+			if i < len(widths) && visibleLen(cell) > widths[i] {
+				widths[i] = visibleLen(cell)
+			}
+		}
+	}
+	return widths
+}
+
 func padRight(s string, width int) string {
 	if len(s) >= width {
 		return s
 	}
 	return s + strings.Repeat(" ", width-len(s))
+}
+
+func padRightVisible(s string, width int) string {
+	if visibleLen(s) >= width {
+		return s
+	}
+	return s + strings.Repeat(" ", width-visibleLen(s))
+}
+
+var ansiEscapePattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func visibleLen(s string) int {
+	return len(ansiEscapePattern.ReplaceAllString(s, ""))
 }

--- a/testing/codex-prompt-eval-results-readable.md
+++ b/testing/codex-prompt-eval-results-readable.md
@@ -1,0 +1,30 @@
+# codex/prompt-eval-results-readable — Test Contract
+
+## Functional Behavior
+- `agentclash prompt-eval results <experiment-id>` table mode renders a compact summary table instead of loose key/value lines.
+- Dimension scores render as a compact table.
+- Main assertion rows remain narrow and readable: result, case, assertion type, score, and assertion key.
+- Expected/actual/error details do not stretch the main table; they render below only for failed/error rows.
+- `--json` and `--output yaml` remain unchanged.
+- Color behavior continues through the existing output package and respects `--no-color`.
+
+## Unit Tests
+- Update `TestPromptEvalResultsCommandPrintsReadableTable` to assert compact summary/assertion tables and failure details.
+- Existing JSON results tests continue to pass.
+
+## Integration / Functional Tests
+- Run `go test ./cmd -run 'TestPromptEvalResultsCommand|TestPromptEvalRunFollow'`.
+
+## Smoke Tests
+- Run `go test ./cmd ./internal/output`.
+- Run `go build ./...`.
+
+## E2E Tests
+N/A — CLI rendering only.
+
+## Manual / cURL Tests
+```bash
+agentclash prompt-eval results 2e5de156-21de-4aba-aef3-4bc7491f3bac --threshold 1
+```
+
+Expected: output is readable in a normal terminal-width window, with a compact assertion table and a separate failure detail block.


### PR DESCRIPTION
## Summary
- Replace loose prompt-eval result details with a compact summary table
- Keep assertion rows narrow by moving expected/actual/error into failure-only details
- Shorten displayed assertion keys while preserving structured JSON/YAML output

## Tests
- go test ./cmd -run 'TestPromptEvalResultsCommand|TestPromptEvalRunFollow'
- go test ./cmd ./internal/output
- go build ./...
- go run . prompt-eval results 2e5de156-21de-4aba-aef3-4bc7491f3bac --threshold 1