### PR TITLE
feat(agent-harnesses): chat-first harness workbench

### DIFF
--- a/testing/codex-issue-610-harness-chat-ui-local-test-log.md
+++ b/testing/codex-issue-610-harness-chat-ui-local-test-log.md
@@ -1,0 +1,43 @@
+# Local Test Log: codex/issue-610-harness-chat-ui
+
+Timestamp: 2026-05-06T15:28:09+0530
+
+## Dependency Setup
+
+Command:
+
+```bash
+cd web
+npm install
+```
+
+Result: passed. npm reported existing dependency advisories; no dependency files were intentionally changed for this PR.
+
+## Focused Component Tests
+
+Command:
+
+```bash
+cd web
+npm test -- --run 'src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx'
+```
+
+Result: passed.
+
+Summary:
+
+```text
+Test Files  1 passed (1)
+Tests       17 passed (17)
+```
+
+## Focused Lint
+
+Command:
+
+```bash
+cd web
+npm run lint -- 'src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.tsx' 'src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx'
+```
+
+Result: passed.

--- a/testing/codex-issue-610-harness-chat-ui-local-test-log.md
+++ b/testing/codex-issue-610-harness-chat-ui-local-test-log.md
@@ -24,12 +24,18 @@ npm test -- --run 'src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/
 
 Result: passed.
 
-Summary:
+Latest summary:
 
 ```text
 Test Files  1 passed (1)
-Tests       17 passed (17)
+Tests       19 passed (19)
 ```
+
+Reviewer follow-up coverage added:
+
+- runner output events do not render raw `message` or `raw` payloads
+- failed POST preserves the user's prompt for retry
+- setup sidebar includes repository and base branch context
 
 ## Focused Lint
 

--- a/testing/codex-issue-610-harness-chat-ui.md
+++ b/testing/codex-issue-610-harness-chat-ui.md
@@ -1,0 +1,77 @@
+# codex/issue-610-harness-chat-ui — Test Contract
+
+Implements GitHub issue #610.
+
+## Files Touched
+
+- `web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.tsx` — redesign the default Agent Harness page into a chat-first workbench, using existing harness and execution APIs.
+- `web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx` — update coverage for chat-first layout, live progress, follow-up composer, and actionable failure states.
+
+## External APIs Used
+
+- N/A — this PR uses existing React/Next/Vitest code and existing AgentClash API client hooks already present in the repo. No new third-party API or package is introduced.
+
+## Rollback Strategy
+
+Revert this PR to restore the current table/form-centered Agent Harness page. No database, API, or worker changes are introduced.
+
+## Functional Behavior
+
+- The Agent Harness page should present a chat-first workbench as the primary experience.
+- Users should see a prominent natural-language task composer for the selected harness.
+- Repository, runner, auth, and advanced setup details should remain visible but visually secondary.
+- Existing harnesses should still be selectable.
+- Sending a message should keep using `POST /v1/workspaces/{workspaceId}/agent-harnesses/{harnessId}/executions` with `{message}` when the prompt is non-empty.
+- The latest execution should be summarized as a live progress surface with approachable phase names.
+- The page should still support expanding the latest execution into safe summarized timeline details: event type, actor, timestamp, phase/status, and allowlisted short payload fields only.
+- The page must not render raw JSON, full diffs, long logs, artifact links/downloads, replay routes, or new artifact storage behavior. Those belong to #582.
+- GitHub issue URLs/text should be accepted as normal task composer text and posted exactly as `{message}`. This PR must not fetch GitHub issues, snapshot issue metadata, write task-bank data, or implement suite ingestion.
+- Failed executions should surface an actionable failure panel instead of only showing a `failed` badge.
+- Failed execution copy should prefer `execution.error_message`, then fall back to the latest failed event payload's `error` or `message`.
+- Empty, loading, and error states should remain understandable.
+- The UI should be responsive and should not depend on new backend fields.
+
+## Unit Tests
+
+- `AgentHarnessesClient` renders a chat-first composer when harnesses exist.
+- `AgentHarnessesClient` posts follow-up prompts to the existing execution endpoint.
+- `AgentHarnessesClient` renders live execution phase/progress from existing events.
+- `AgentHarnessesClient` expands safe summarized timeline details.
+- `AgentHarnessesClient` does not render full diff/log payloads from `artifact.git_diff` or other large event payloads.
+- `AgentHarnessesClient` accepts a GitHub issue URL as plain composer text and posts it exactly as a run message.
+- `AgentHarnessesClient` renders actionable failure copy when latest execution failed.
+- `AgentHarnessesClient` uses `error_message` when present and falls back to failed event payloads.
+- `AgentHarnessesClient` covers loading, error, empty, queued/provisioning/running/scoring/completed/failed, no-events waiting state, harness selection, empty prompt disabled, successful post, mutation, and prompt clearing.
+- `web/src/lib/api/types.ts` exposes `error_message?: string` for `AgentHarnessExecution`.
+- Existing empty/loading/error state coverage remains valid or is updated.
+
+## Integration / Functional Tests
+
+- Frontend component tests mock the existing API hooks and verify the user workflow:
+  - Select harness.
+  - Type a prompt.
+  - Send.
+  - Observe mutation calls and cleared prompt.
+  - Inspect latest execution activity.
+
+## Smoke Tests
+
+- `npm test -- --run 'src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx'` from `web/`.
+- `npm run lint -- 'src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.tsx' 'src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx'` from `web/` if lint supports path arguments.
+
+## E2E Tests
+
+- N/A for this PR. A browser smoke is enough because no backend behavior changes. Later #582 will introduce deeper execution replay navigation.
+
+## Manual / cURL Tests
+
+Manual browser smoke after starting the web app:
+
+1. Open `/workspaces/{workspaceId}/agent-harnesses`.
+2. Confirm the first viewport is a chat/workbench experience, not a table-first admin form.
+3. Confirm the selected harness details are visible but secondary.
+4. Type a task prompt and send it.
+5. Confirm live activity and expandable timeline remain available.
+6. Confirm failed latest execution shows next-step copy.
+
+No cURL tests are needed because this PR does not change API behavior.

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx
@@ -6,14 +6,16 @@ import { AgentHarnessesClient } from "./agent-harnesses-client";
 
 const {
   mockGetAccessToken,
-  mockHarnesses,
+  mockHarnessQuery,
   mockExecutions,
   mockMutate,
+  mockPost,
 } = vi.hoisted(() => ({
   mockGetAccessToken: vi.fn(),
-  mockHarnesses: vi.fn(),
+  mockHarnessQuery: vi.fn(),
   mockExecutions: vi.fn(),
   mockMutate: vi.fn(),
+  mockPost: vi.fn(),
 }));
 
 vi.mock("@workos-inc/authkit-nextjs/components", () => ({
@@ -21,15 +23,16 @@ vi.mock("@workos-inc/authkit-nextjs/components", () => ({
 }));
 
 vi.mock("@/lib/api/client", () => ({
-  createApiClient: () => ({ post: vi.fn() }),
+  createApiClient: () => ({ post: mockPost }),
 }));
 
 vi.mock("@/lib/api/swr", () => ({
+  apiQueryKey: (path: string) => [path],
   useApiListQuery: (path: string) => {
     if (path.includes("agent-harness-executions")) {
       return { data: { items: mockExecutions() }, isLoading: false };
     }
-    return { data: { items: mockHarnesses() }, isLoading: false };
+    return mockHarnessQuery();
   },
   useApiMutator: () => ({ mutate: mockMutate }),
 }));
@@ -52,13 +55,13 @@ vi.mock("@/components/ui/button", () => ({
 }));
 
 vi.mock("@/components/ui/empty-state", () => ({
-  EmptyState: ({ title }: { title: string }) =>
-    React.createElement("div", null, title),
-}));
-
-vi.mock("@/components/ui/input", () => ({
-  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) =>
-    React.createElement("input", props),
+  EmptyState: ({
+    title,
+    description,
+  }: {
+    title: string;
+    description?: string;
+  }) => React.createElement("div", null, title, description),
 }));
 
 vi.mock("@/components/ui/page-header", () => ({
@@ -71,30 +74,6 @@ vi.mock("@/components/ui/page-header", () => ({
   }) => React.createElement("header", null, title, actions),
 }));
 
-vi.mock("@/components/ui/table", () => ({
-  Table: ({ children }: { children: React.ReactNode }) =>
-    React.createElement("table", null, children),
-  TableBody: ({ children }: { children: React.ReactNode }) =>
-    React.createElement("tbody", null, children),
-  TableCell: ({
-    children,
-    ...props
-  }: React.TdHTMLAttributes<HTMLTableCellElement>) =>
-    React.createElement("td", props, children),
-  TableHead: ({
-    children,
-    ...props
-  }: React.ThHTMLAttributes<HTMLTableCellElement>) =>
-    React.createElement("th", props, children),
-  TableHeader: ({ children }: { children: React.ReactNode }) =>
-    React.createElement("thead", null, children),
-  TableRow: ({
-    children,
-    ...props
-  }: React.HTMLAttributes<HTMLTableRowElement>) =>
-    React.createElement("tr", props, children),
-}));
-
 vi.mock("./create-agent-harness-dialog", () => ({
   CreateAgentHarnessDialog: () =>
     React.createElement("button", null, "New Harness"),
@@ -102,12 +81,17 @@ vi.mock("./create-agent-harness-dialog", () => ({
 
 vi.mock("lucide-react", () => ({
   Activity: () => React.createElement("span", null, "activity"),
+  AlertCircle: () => React.createElement("span", null, "alert"),
+  Bot: () => React.createElement("span", null, "bot"),
+  CheckCircle2: () => React.createElement("span", null, "done"),
   ChevronDown: () => React.createElement("span", null, "expand"),
+  Clock3: () => React.createElement("span", null, "clock"),
   Loader2: () => React.createElement("span", null, "loader"),
   MessageSquare: () => React.createElement("span", null, "message"),
   PackageCheck: () => React.createElement("span", null, "package"),
-  Play: () => React.createElement("span", null, "play"),
   Send: () => React.createElement("span", null, "send"),
+  Settings2: () => React.createElement("span", null, "settings"),
+  TerminalSquare: () => React.createElement("span", null, "terminal"),
 }));
 
 function renderClient() {
@@ -125,12 +109,128 @@ function renderClient() {
   };
 }
 
-function clickButtonByLabel(label: string) {
-  const button = document.querySelector(`button[aria-label="${label}"]`);
-  if (!button) throw new Error(`button ${label} not found`);
+function changeTextarea(value: string) {
+  const textarea = document.querySelector("textarea");
+  if (!textarea) throw new Error("textarea not found");
+  act(() => {
+    setNativeValue(textarea, value);
+    textarea.dispatchEvent(new InputEvent("input", { bubbles: true, data: value }));
+  });
+}
+
+function setNativeValue(
+  element: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement,
+  value: string,
+) {
+  const valueSetter = Object.getOwnPropertyDescriptor(element, "value")?.set;
+  const prototype = Object.getPrototypeOf(element);
+  const prototypeValueSetter = Object.getOwnPropertyDescriptor(
+    prototype,
+    "value",
+  )?.set;
+  if (prototypeValueSetter && valueSetter !== prototypeValueSetter) {
+    prototypeValueSetter.call(element, value);
+  } else if (valueSetter) {
+    valueSetter.call(element, value);
+  } else {
+    element.value = value;
+  }
+}
+
+function changeSelect(value: string) {
+  const select = document.querySelector("select");
+  if (!select) throw new Error("select not found");
+  act(() => {
+    select.value = value;
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+}
+
+function clickButtonByText(text: string) {
+  const button = Array.from(document.querySelectorAll("button")).find((item) =>
+    item.textContent?.includes(text),
+  );
+  if (!button) throw new Error(`button ${text} not found`);
   act(() => {
     button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
   });
+}
+
+function baseHarness(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "harness-1",
+    workspace_id: "ws-1",
+    organization_id: "org-1",
+    name: "agentclash Codex",
+    slug: "agentclash-codex",
+    description: "",
+    status: "draft",
+    harness_kind: "codex_e2b",
+    task_prompt: "Patch the failing test.",
+    codex_template: "codex",
+    auth_mode: "api_key_secret",
+    execution_config: {},
+    evaluation_config: {},
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function baseExecution(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "execution-1",
+    workspace_id: "ws-1",
+    organization_id: "org-1",
+    agent_harness_id: "harness-1",
+    status: "running",
+    harness_snapshot: {},
+    execution_config_snapshot: {},
+    evaluation_config_snapshot: {},
+    created_at: "2026-05-01T00:01:00Z",
+    updated_at: "2026-05-01T00:02:00Z",
+    events: [
+      {
+        id: "event-1",
+        agent_harness_execution_id: "execution-1",
+        sequence_number: 1,
+        event_type: "repository.clone.started",
+        actor_type: "worker",
+        occurred_at: "2026-05-01T00:01:05Z",
+        payload: {
+          command: ["git", "clone", "https://github.com/acme/repo"],
+          working_directory: "",
+        },
+      },
+      {
+        id: "event-2",
+        agent_harness_execution_id: "execution-1",
+        sequence_number: 2,
+        event_type: "codex.exec.started",
+        actor_type: "worker",
+        occurred_at: "2026-05-01T00:01:30Z",
+        payload: {
+          command: ["codex", "exec", "--full-auto"],
+          working_directory: "/workspace",
+        },
+      },
+      {
+        id: "event-3",
+        agent_harness_execution_id: "execution-1",
+        sequence_number: 3,
+        event_type: "scoring.completed",
+        actor_type: "worker",
+        occurred_at: "2026-05-01T00:01:40Z",
+        payload: {
+          score: 1,
+          passed: 1,
+          failed: 0,
+          skipped: 1,
+        },
+      },
+    ],
+    ...overrides,
+  };
 }
 
 describe("AgentHarnessesClient", () => {
@@ -140,86 +240,92 @@ describe("AgentHarnessesClient", () => {
     document.body.innerHTML = "";
     vi.clearAllMocks();
     mockGetAccessToken.mockResolvedValue("token");
-    mockHarnesses.mockReturnValue([
-      {
-        id: "harness-1",
-        workspace_id: "ws-1",
-        organization_id: "org-1",
-        name: "agentclash Codex",
-        slug: "agentclash-codex",
-        description: "",
-        status: "draft",
-        harness_kind: "codex_e2b",
-        task_prompt: "Patch the failing test.",
-        codex_template: "codex",
-        auth_mode: "api_key_secret",
-        execution_config: {},
-        evaluation_config: {},
-        created_at: "2026-05-01T00:00:00Z",
-        updated_at: "2026-05-01T00:00:00Z",
-      },
-    ]);
-    mockExecutions.mockReturnValue([
-      {
-        id: "execution-1",
-        workspace_id: "ws-1",
-        organization_id: "org-1",
-        agent_harness_id: "harness-1",
-        status: "running",
-        harness_snapshot: {},
-        execution_config_snapshot: {},
-        evaluation_config_snapshot: {},
-        created_at: "2026-05-01T00:01:00Z",
-        updated_at: "2026-05-01T00:02:00Z",
-        events: [
-          {
-            id: "event-1",
-            agent_harness_execution_id: "execution-1",
-            sequence_number: 1,
-            event_type: "repository.clone.started",
-            actor_type: "worker",
-            occurred_at: "2026-05-01T00:01:05Z",
-            payload: {
-              command: ["git", "clone", "https://github.com/acme/repo"],
-              working_directory: "",
-            },
-          },
-          {
-            id: "event-2",
-            agent_harness_execution_id: "execution-1",
-            sequence_number: 2,
-            event_type: "codex.exec.started",
-            actor_type: "worker",
-            occurred_at: "2026-05-01T00:01:30Z",
-            payload: {
-              command: ["codex", "exec", "--full-auto"],
-              working_directory: "/workspace",
-            },
-          },
-          {
-            id: "event-3",
-            agent_harness_execution_id: "execution-1",
-            sequence_number: 3,
-            event_type: "scoring.completed",
-            actor_type: "worker",
-            occurred_at: "2026-05-01T00:01:40Z",
-            payload: {
-              score: 1,
-              passed: 1,
-              failed: 0,
-              skipped: 1,
-            },
-          },
-        ],
-      },
-    ]);
+    mockPost.mockResolvedValue({});
+    mockMutate.mockResolvedValue(undefined);
+    mockHarnessQuery.mockReturnValue({
+      data: { items: [baseHarness()] },
+      isLoading: false,
+    });
+    mockExecutions.mockReturnValue([baseExecution()]);
   });
 
-  it("shows live activity from the latest execution event", () => {
+  it("renders a chat-first workbench around the selected harness", () => {
     const rendered = renderClient();
 
-    expect(document.body.textContent).toContain("Live Activity");
+    expect(document.body.textContent).toContain("Chat with a coding harness");
+    expect(document.body.textContent).toContain("Active harness");
+    expect(document.body.textContent).toContain("Setup context");
+    expect(document.body.textContent).toContain("agentclash Codex");
+    expect(document.body.textContent).not.toContain("Live Activity");
+
+    rendered.cleanup();
+  });
+
+  it("posts a GitHub issue URL as plain follow-up text and clears the prompt", async () => {
+    const rendered = renderClient();
+    const message = "https://github.com/agentclash/agentclash/issues/610";
+
+    changeTextarea(message);
+    await act(async () => {
+      clickButtonByText("Send");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/v1/workspaces/ws-1/agent-harnesses/harness-1/executions",
+      { message },
+    );
+    expect(mockMutate).toHaveBeenCalledTimes(2);
+    expect(document.querySelector("textarea")?.value).toBe("");
+
+    rendered.cleanup();
+  });
+
+  it("keeps empty prompts disabled", () => {
+    const rendered = renderClient();
+
+    const sendButton = Array.from(document.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Send"),
+    );
+    expect(sendButton).toHaveProperty("disabled", true);
+
+    rendered.cleanup();
+  });
+
+  it("switches harnesses without leaving the chat workbench", () => {
+    mockHarnessQuery.mockReturnValue({
+      data: {
+        items: [
+          baseHarness(),
+          baseHarness({
+            id: "harness-2",
+            name: "repo Claude",
+            task_prompt: "Review the migration.",
+            codex_template: "agentclash-claude-fullstack",
+          }),
+        ],
+      },
+      isLoading: false,
+    });
+    const rendered = renderClient();
+
+    changeSelect("harness-2");
+
+    expect(document.body.textContent).toContain("repo Claude");
+    expect(document.body.textContent).toContain("Review the migration.");
+
+    rendered.cleanup();
+  });
+
+  it("shows approachable live progress and summarized latest activity", () => {
+    const rendered = renderClient();
+
+    expect(document.body.textContent).toContain("Live activity");
     expect(document.body.textContent).toContain("running");
+    expect(document.body.textContent).toContain("Setup");
+    expect(document.body.textContent).toContain("Repository");
+    expect(document.body.textContent).toContain("Agent work");
+    expect(document.body.textContent).toContain("Validation");
     expect(document.body.textContent).toContain("Scoring · Completed");
     expect(document.body.textContent).toContain("Score: 1");
     expect(document.body.textContent).toContain("Passed: 1");
@@ -227,12 +333,12 @@ describe("AgentHarnessesClient", () => {
     rendered.cleanup();
   });
 
-  it("expands the latest execution into a readable event timeline", () => {
+  it("expands the latest execution into safe summarized details", () => {
     const rendered = renderClient();
 
-    clickButtonByLabel("Show activity for agentclash Codex");
+    clickButtonByText("Show summarized details");
 
-    expect(document.body.textContent).toContain("Execution timeline");
+    expect(document.body.textContent).toContain("Summarized activity details");
     expect(document.body.textContent).toContain("3 events");
     expect(document.body.textContent).toContain("#1 · worker");
     expect(document.body.textContent).toContain("Repository · Clone · Started");
@@ -240,6 +346,119 @@ describe("AgentHarnessesClient", () => {
       "Command: git clone https://github.com/acme/repo",
     );
 
+    rendered.cleanup();
+  });
+
+  it("does not render full diff payloads in the summarized timeline", () => {
+    mockExecutions.mockReturnValue([
+      baseExecution({
+        events: [
+          {
+            id: "event-diff",
+            agent_harness_execution_id: "execution-1",
+            sequence_number: 1,
+            event_type: "artifact.git_diff",
+            actor_type: "worker",
+            occurred_at: "2026-05-01T00:01:05Z",
+            payload: {
+              diff: "SECRET DIFF BODY",
+              changed_files: "M web/app.tsx",
+            },
+          },
+        ],
+      }),
+    ]);
+    const rendered = renderClient();
+
+    clickButtonByText("Show summarized details");
+
+    expect(document.body.textContent).toContain("Changed Files: M web/app.tsx");
+    expect(document.body.textContent).not.toContain("SECRET DIFF BODY");
+
+    rendered.cleanup();
+  });
+
+  it.each(["queued", "provisioning", "running", "scoring", "completed", "failed"])(
+    "renders %s execution status",
+    (status) => {
+      mockExecutions.mockReturnValue([baseExecution({ status })]);
+      const rendered = renderClient();
+
+      expect(document.body.textContent).toContain(status);
+
+      rendered.cleanup();
+    },
+  );
+
+  it("shows a waiting state when an execution has no events", () => {
+    mockExecutions.mockReturnValue([baseExecution({ events: [] })]);
+    const rendered = renderClient();
+
+    expect(document.body.textContent).toContain(
+      "Waiting for the first execution event...",
+    );
+
+    rendered.cleanup();
+  });
+
+  it("renders actionable failure copy from error_message", () => {
+    mockExecutions.mockReturnValue([
+      baseExecution({
+        status: "failed",
+        error_message: "Codex exited with status 1",
+      }),
+    ]);
+    const rendered = renderClient();
+
+    expect(document.body.textContent).toContain("This run needs attention");
+    expect(document.body.textContent).toContain("Codex exited with status 1");
+
+    rendered.cleanup();
+  });
+
+  it("falls back to failed event payloads for actionable failure copy", () => {
+    mockExecutions.mockReturnValue([
+      baseExecution({
+        status: "failed",
+        events: [
+          {
+            id: "event-failed",
+            agent_harness_execution_id: "execution-1",
+            sequence_number: 1,
+            event_type: "codex.exec.failed",
+            actor_type: "worker",
+            occurred_at: "2026-05-01T00:01:05Z",
+            payload: {
+              error: "command timed out",
+            },
+          },
+        ],
+      }),
+    ]);
+    const rendered = renderClient();
+
+    expect(document.body.textContent).toContain("command timed out");
+
+    rendered.cleanup();
+  });
+
+  it("keeps loading, error, and empty states readable", () => {
+    mockHarnessQuery.mockReturnValueOnce({ isLoading: true });
+    let rendered = renderClient();
+    expect(document.body.textContent).toContain("loading");
+    rendered.cleanup();
+
+    mockHarnessQuery.mockReturnValueOnce({ error: new Error("boom") });
+    rendered = renderClient();
+    expect(document.body.textContent).toContain("Failed to load agent harnesses.");
+    rendered.cleanup();
+
+    mockHarnessQuery.mockReturnValueOnce({
+      data: { items: [] },
+      isLoading: false,
+    });
+    rendered = renderClient();
+    expect(document.body.textContent).toContain("No agent harnesses yet");
     rendered.cleanup();
   });
 });

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx
@@ -169,6 +169,9 @@ function baseHarness(overrides: Record<string, unknown> = {}) {
     task_prompt: "Patch the failing test.",
     codex_template: "codex",
     auth_mode: "api_key_secret",
+    repository_full_name: "acme/repo",
+    repository_url: "https://github.com/acme/repo",
+    base_branch: "main",
     execution_config: {},
     evaluation_config: {},
     created_at: "2026-05-01T00:00:00Z",
@@ -255,8 +258,27 @@ describe("AgentHarnessesClient", () => {
     expect(document.body.textContent).toContain("Chat with a coding harness");
     expect(document.body.textContent).toContain("Active harness");
     expect(document.body.textContent).toContain("Setup context");
+    expect(document.body.textContent).toContain("acme/repo");
+    expect(document.body.textContent).toContain("Base branch");
     expect(document.body.textContent).toContain("agentclash Codex");
     expect(document.body.textContent).not.toContain("Live Activity");
+
+    rendered.cleanup();
+  });
+
+  it("preserves prompt text when starting a run fails", async () => {
+    mockPost.mockRejectedValueOnce(new Error("network failed"));
+    const rendered = renderClient();
+    const message = "retry this task";
+
+    changeTextarea(message);
+    await act(async () => {
+      clickButtonByText("Send");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(document.body.textContent).toContain("network failed");
+    expect(document.querySelector("textarea")?.value).toBe(message);
 
     rendered.cleanup();
   });
@@ -374,6 +396,37 @@ describe("AgentHarnessesClient", () => {
 
     expect(document.body.textContent).toContain("Changed Files: M web/app.tsx");
     expect(document.body.textContent).not.toContain("SECRET DIFF BODY");
+
+    rendered.cleanup();
+  });
+
+  it("does not render raw runner output messages in the summarized timeline", () => {
+    mockExecutions.mockReturnValue([
+      baseExecution({
+        events: [
+          {
+            id: "event-output",
+            agent_harness_execution_id: "execution-1",
+            sequence_number: 1,
+            event_type: "codex.exec.output",
+            actor_type: "codex",
+            occurred_at: "2026-05-01T00:01:05Z",
+            payload: {
+              message: "RAW RUNNER STDOUT",
+              raw: "RAW JSON LINE",
+              type: "agent_message",
+            },
+          },
+        ],
+      }),
+    ]);
+    const rendered = renderClient();
+
+    clickButtonByText("Show summarized details");
+
+    expect(document.body.textContent).toContain("Type: agent_message");
+    expect(document.body.textContent).not.toContain("RAW RUNNER STDOUT");
+    expect(document.body.textContent).not.toContain("RAW JSON LINE");
 
     rendered.cleanup();
   });

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment, type FormEvent, useMemo, useState } from "react";
+import { type FormEvent, useMemo, useState } from "react";
 import { useAccessToken } from "@workos-inc/authkit-nextjs/components";
 import { createApiClient } from "@/lib/api/client";
 import type {
@@ -14,24 +14,20 @@ import { WorkspaceListLoading } from "@/components/app-shell/workspace-loading";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
-import { Input } from "@/components/ui/input";
 import { PageHeader } from "@/components/ui/page-header";
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import {
   Activity,
+  AlertCircle,
+  Bot,
+  CheckCircle2,
   ChevronDown,
+  Clock3,
   Loader2,
   MessageSquare,
   PackageCheck,
-  Play,
   Send,
+  Settings2,
+  TerminalSquare,
 } from "lucide-react";
 import { CreateAgentHarnessDialog } from "./create-agent-harness-dialog";
 
@@ -52,6 +48,28 @@ const statusVariant: Record<string, "default" | "secondary" | "outline"> = {
   scoring: "default",
 };
 
+const phaseOrder = [
+  "sandbox",
+  "repository",
+  "agent",
+  "diff",
+  "validation",
+  "pull-request",
+] as const;
+
+type HarnessPhase = (typeof phaseOrder)[number];
+
+type HarnessPhaseState = "waiting" | "running" | "done" | "failed";
+
+const phaseLabels: Record<HarnessPhase, string> = {
+  sandbox: "Setup",
+  repository: "Repository",
+  agent: "Agent work",
+  diff: "Diff",
+  validation: "Validation",
+  "pull-request": "Pull request",
+};
+
 export function AgentHarnessesClient({
   workspaceId,
 }: {
@@ -60,7 +78,7 @@ export function AgentHarnessesClient({
   const { getAccessToken } = useAccessToken();
   const { mutate } = useApiMutator();
   const [runningHarnessId, setRunningHarnessId] = useState<string | null>(null);
-  const [chatHarnessId, setChatHarnessId] = useState<string>("");
+  const [selectedHarnessId, setSelectedHarnessId] = useState<string>("");
   const [chatMessage, setChatMessage] = useState("");
   const [expandedExecutionId, setExpandedExecutionId] = useState<string | null>(
     null,
@@ -75,8 +93,9 @@ export function AgentHarnessesClient({
     { refreshInterval: 2500 },
   );
   const harnesses = data?.items ?? [];
-  const selectedChatHarness =
-    harnesses.find((harness) => harness.id === chatHarnessId) ?? harnesses[0];
+  const selectedHarness =
+    harnesses.find((harness) => harness.id === selectedHarnessId) ??
+    harnesses[0];
   const latestExecutionByHarness = useMemo(() => {
     const latest = new Map<string, AgentHarnessExecution>();
     for (const execution of executionsData?.items ?? []) {
@@ -87,6 +106,18 @@ export function AgentHarnessesClient({
     }
     return latest;
   }, [executionsData?.items]);
+  const latestExecution = selectedHarness
+    ? latestExecutionByHarness.get(selectedHarness.id)
+    : undefined;
+  const latestEvent = latestExecution
+    ? latestAgentHarnessEvent(latestExecution)
+    : undefined;
+  const failureMessage = latestExecution
+    ? executionFailureMessage(latestExecution)
+    : "";
+  const isRunning = selectedHarness
+    ? runningHarnessId === selectedHarness.id
+    : false;
 
   async function startHarnessExecution(harnessId: string, message?: string) {
     setRunError(null);
@@ -113,8 +144,8 @@ export function AgentHarnessesClient({
 
   async function handleChatSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (!selectedChatHarness || !chatMessage.trim()) return;
-    await startHarnessExecution(selectedChatHarness.id, chatMessage);
+    if (!selectedHarness || !chatMessage.trim()) return;
+    await startHarnessExecution(selectedHarness.id, chatMessage);
     setChatMessage("");
   }
 
@@ -127,7 +158,7 @@ export function AgentHarnessesClient({
       />
 
       {runError ? (
-        <div className="mb-4 rounded-lg border border-destructive/20 bg-destructive/5 p-4 text-sm text-destructive">
+        <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-4 text-sm text-destructive">
           {runError}
         </div>
       ) : null}
@@ -142,221 +173,313 @@ export function AgentHarnessesClient({
         <EmptyState
           icon={<PackageCheck className="size-10" />}
           title="No agent harnesses yet"
-          description="Create a Codex harness to evaluate long-running autonomous coding tasks without writing a challenge pack."
+          description="Create a coding harness to evaluate long-running autonomous work without writing a challenge pack."
         />
       ) : (
-        <>
-          <form
-            onSubmit={handleChatSubmit}
-            className="space-y-3 rounded-lg border border-border bg-card p-4"
-          >
-            <div className="flex flex-col gap-3 md:flex-row md:items-center">
-              <div className="flex min-w-0 flex-1 items-center gap-2">
-                <MessageSquare className="size-4 text-muted-foreground" />
-                <select
-                  value={selectedChatHarness?.id ?? ""}
-                  onChange={(event) => setChatHarnessId(event.target.value)}
-                  className="h-8 min-w-0 rounded-lg border border-input bg-transparent px-2 text-sm focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/50"
-                >
-                  {harnesses.map((harness) => (
-                    <option key={harness.id} value={harness.id}>
-                      {harness.name}
-                    </option>
-                  ))}
-                </select>
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_22rem]">
+          <section className="min-w-0 rounded-lg border border-border bg-card">
+            <div className="border-b border-border px-4 py-3">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2 text-sm font-medium">
+                    <MessageSquare className="size-4 text-muted-foreground" />
+                    Chat with a coding harness
+                  </div>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    Describe a task, paste a GitHub issue URL, or ask for a
+                    follow-up on the latest run.
+                  </p>
+                </div>
+                {selectedHarness ? (
+                  <Badge variant={statusVariant[selectedHarness.status] ?? "outline"}>
+                    {selectedHarness.status}
+                  </Badge>
+                ) : null}
               </div>
-              {selectedChatHarness ? (
-                <Badge
-                  variant={
-                    statusVariant[selectedChatHarness.auth_mode] ?? "outline"
+            </div>
+
+            <div className="space-y-4 p-4">
+              <HarnessSelector
+                harnesses={harnesses}
+                selectedHarness={selectedHarness}
+                onSelect={setSelectedHarnessId}
+              />
+
+              <div className="rounded-lg border border-border bg-background p-4">
+                <div className="flex items-start gap-3">
+                  <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+                    <Bot className="size-4" />
+                  </div>
+                  <div className="min-w-0 flex-1 space-y-3">
+                    <div>
+                      <div className="text-sm font-medium">
+                        {selectedHarness?.name ?? "Select a harness"}
+                      </div>
+                      <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+                        {selectedHarness?.task_prompt ??
+                          "Pick a harness, then describe the work you want it to attempt."}
+                      </p>
+                    </div>
+                    <form onSubmit={handleChatSubmit} className="space-y-2">
+                      <textarea
+                        value={chatMessage}
+                        onChange={(event) => setChatMessage(event.target.value)}
+                        spellCheck={false}
+                        className="min-h-28 w-full resize-y rounded-lg border border-input bg-transparent px-3 py-2 text-sm leading-relaxed focus:outline-none focus:ring-2 focus:ring-ring/50"
+                        placeholder="Ask this harness to inspect, patch, test, or paste a GitHub issue URL..."
+                      />
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <div className="text-xs text-muted-foreground">
+                          Sends as a normal harness run message. Advanced setup stays in New Harness.
+                        </div>
+                        <Button
+                          type="submit"
+                          disabled={
+                            !selectedHarness ||
+                            !chatMessage.trim() ||
+                            runningHarnessId === selectedHarness.id
+                          }
+                        >
+                          {isRunning ? (
+                            <Loader2
+                              data-icon="inline-start"
+                              className="size-4 animate-spin"
+                            />
+                          ) : (
+                            <Send data-icon="inline-start" className="size-4" />
+                          )}
+                          {isRunning ? "Sending..." : "Send"}
+                        </Button>
+                      </div>
+                    </form>
+                  </div>
+                </div>
+              </div>
+
+              {latestExecution ? (
+                <LatestRunPanel
+                  execution={latestExecution}
+                  latestEvent={latestEvent}
+                  failureMessage={failureMessage}
+                  isExpanded={expandedExecutionId === latestExecution.id}
+                  onToggleExpanded={() =>
+                    setExpandedExecutionId((current) =>
+                      current === latestExecution.id ? null : latestExecution.id,
+                    )
                   }
-                >
-                  {authLabel[selectedChatHarness.auth_mode] ??
-                    selectedChatHarness.auth_mode}
-                </Badge>
+                />
+              ) : (
+                <div className="rounded-lg border border-dashed border-border p-4 text-sm text-muted-foreground">
+                  No runs yet for this harness. Send a task to start watching live activity here.
+                </div>
+              )}
+            </div>
+          </section>
+
+          <aside className="space-y-4">
+            <div className="rounded-lg border border-border bg-card p-4">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                <Settings2 className="size-4 text-muted-foreground" />
+                Setup context
+              </div>
+              {selectedHarness ? (
+                <dl className="mt-3 space-y-3 text-sm">
+                  <ContextRow
+                    label="Auth"
+                    value={authLabel[selectedHarness.auth_mode] ?? selectedHarness.auth_mode}
+                  />
+                  <ContextRow
+                    label="Runner"
+                    value={formatHarnessRunner(selectedHarness)}
+                  />
+                  <ContextRow
+                    label="Updated"
+                    value={formatDateTime(selectedHarness.updated_at)}
+                  />
+                </dl>
               ) : null}
             </div>
-            <div className="flex flex-col gap-2 md:flex-row">
-              <Input
-                value={chatMessage}
-                onChange={(event) => setChatMessage(event.target.value)}
-                placeholder="Ask this harness to inspect, patch, or test something..."
-                className="min-h-9 flex-1"
-              />
-              <Button
-                type="submit"
-                disabled={
-                  !selectedChatHarness ||
-                  !chatMessage.trim() ||
-                  runningHarnessId === selectedChatHarness.id
-                }
-              >
-                {runningHarnessId === selectedChatHarness?.id ? (
-                  <Loader2 data-icon="inline-start" className="size-4 animate-spin" />
-                ) : (
-                  <Send data-icon="inline-start" className="size-4" />
-                )}
-                Send
-              </Button>
-            </div>
-          </form>
 
-          <div className="rounded-lg border border-border">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Name</TableHead>
-                  <TableHead>Auth</TableHead>
-                  <TableHead>Codex</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead>Live Activity</TableHead>
-                  <TableHead>Updated</TableHead>
-                  <TableHead className="w-28 text-right">Run</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {harnesses.map((harness) => {
-                  const latestExecution = latestExecutionByHarness.get(
-                    harness.id,
-                  );
-                  const latestEvent = latestExecution
-                    ? latestAgentHarnessEvent(latestExecution)
-                    : undefined;
-                  const isRunning = runningHarnessId === harness.id;
-                  const isExpanded =
-                    !!latestExecution &&
-                    expandedExecutionId === latestExecution.id;
-                  return (
-                    <Fragment key={harness.id}>
-                      <TableRow>
-                        <TableCell>
-                          <div className="font-medium">{harness.name}</div>
-                          <div className="max-w-xl truncate text-xs text-muted-foreground">
-                            {harness.task_prompt}
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          {authLabel[harness.auth_mode] ?? harness.auth_mode}
-                        </TableCell>
-                        <TableCell className="text-muted-foreground">
-                          {harness.codex_model
-                            ? `${harness.codex_template} / ${harness.codex_model}`
-                            : harness.codex_template}
-                        </TableCell>
-                        <TableCell>
-                          <Badge
-                            variant={statusVariant[harness.status] ?? "outline"}
-                          >
-                            {harness.status}
-                          </Badge>
-                        </TableCell>
-                        <TableCell>
-                          {latestExecution ? (
-                            <div className="min-w-64 space-y-2">
-                              <div className="flex flex-wrap items-center gap-2">
-                                <Badge
-                                  variant={
-                                    statusVariant[latestExecution.status] ??
-                                    "outline"
-                                  }
-                                >
-                                  {latestExecution.status}
-                                </Badge>
-                                <span className="text-xs text-muted-foreground">
-                                  started{" "}
-                                  {formatDateTime(latestExecution.created_at)}
-                                </span>
-                              </div>
-                              {latestEvent ? (
-                                <div className="space-y-1">
-                                  <div className="flex items-center gap-2 text-sm">
-                                    <Activity className="size-4 text-muted-foreground" />
-                                    <span className="font-medium">
-                                      {formatEventType(latestEvent.event_type)}
-                                    </span>
-                                  </div>
-                                  <p className="line-clamp-2 max-w-lg text-xs text-muted-foreground">
-                                    {eventSummary(latestEvent)}
-                                  </p>
-                                  <div className="text-xs text-muted-foreground">
-                                    {formatDateTime(latestEvent.occurred_at)}
-                                  </div>
-                                </div>
-                              ) : (
-                                <div className="text-xs text-muted-foreground">
-                                  Waiting for the first execution event...
-                                </div>
-                              )}
-                            </div>
-                          ) : (
-                            <span className="text-sm text-muted-foreground">
-                              Never run
-                            </span>
-                          )}
-                        </TableCell>
-                        <TableCell className="text-muted-foreground">
-                          {new Date(harness.updated_at).toLocaleString()}
-                        </TableCell>
-                        <TableCell className="text-right">
-                          <div className="flex justify-end gap-2">
-                            <Button
-                              type="button"
-                              size="icon-sm"
-                              variant="ghost"
-                              aria-label={`Show activity for ${harness.name}`}
-                              disabled={!latestExecution}
-                              onClick={() =>
-                                setExpandedExecutionId(
-                                  isExpanded || !latestExecution
-                                    ? null
-                                    : latestExecution.id,
-                                )
-                              }
-                            >
-                              <ChevronDown
-                                className={`size-4 transition-transform ${
-                                  isExpanded ? "rotate-180" : ""
-                                }`}
-                              />
-                            </Button>
-                            <Button
-                              type="button"
-                              size="icon-sm"
-                              variant="outline"
-                              aria-label={`Run ${harness.name}`}
-                              disabled={
-                                isRunning || harness.status === "archived"
-                              }
-                              onClick={() =>
-                                void startHarnessExecution(harness.id)
-                              }
-                            >
-                              {isRunning ? (
-                                <Loader2 className="size-4 animate-spin" />
-                              ) : (
-                                <Play className="size-4" />
-                              )}
-                            </Button>
-                          </div>
-                        </TableCell>
-                      </TableRow>
-                      {isExpanded && latestExecution ? (
-                        <TableRow>
-                          <TableCell colSpan={7} className="bg-muted/30 p-0">
-                            <AgentHarnessExecutionTimeline
-                              execution={latestExecution}
-                            />
-                          </TableCell>
-                        </TableRow>
-                      ) : null}
-                    </Fragment>
-                  );
-                })}
-              </TableBody>
-            </Table>
-          </div>
-        </>
+            <div className="rounded-lg border border-border bg-card p-4">
+              <div className="mb-3 flex items-center justify-between gap-2">
+                <div className="text-sm font-medium">Harnesses</div>
+                <Badge variant="outline">{harnesses.length}</Badge>
+              </div>
+              <div className="space-y-2">
+                {harnesses.map((harness) => (
+                  <button
+                    key={harness.id}
+                    type="button"
+                    onClick={() => setSelectedHarnessId(harness.id)}
+                    className={`w-full rounded-lg border p-3 text-left text-sm transition-colors ${
+                      selectedHarness?.id === harness.id
+                        ? "border-primary bg-primary/5"
+                        : "border-border hover:bg-muted/50"
+                    }`}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="truncate font-medium">{harness.name}</span>
+                      <Badge variant={statusVariant[harness.status] ?? "outline"}>
+                        {harness.status}
+                      </Badge>
+                    </div>
+                    <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+                      {harness.task_prompt}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </div>
+          </aside>
+        </div>
       )}
+    </div>
+  );
+}
+
+function HarnessSelector({
+  harnesses,
+  selectedHarness,
+  onSelect,
+}: {
+  harnesses: AgentHarness[];
+  selectedHarness?: AgentHarness;
+  onSelect: (harnessId: string) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+      <label className="text-sm font-medium" htmlFor="agent-harness-select">
+        Active harness
+      </label>
+      <select
+        id="agent-harness-select"
+        value={selectedHarness?.id ?? ""}
+        onChange={(event) => onSelect(event.target.value)}
+        className="h-10 min-w-0 rounded-lg border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring/50 md:w-80"
+      >
+        {harnesses.map((harness) => (
+          <option key={harness.id} value={harness.id}>
+            {harness.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function LatestRunPanel({
+  execution,
+  latestEvent,
+  failureMessage,
+  isExpanded,
+  onToggleExpanded,
+}: {
+  execution: AgentHarnessExecution;
+  latestEvent?: AgentHarnessExecutionEvent;
+  failureMessage: string;
+  isExpanded: boolean;
+  onToggleExpanded: () => void;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-background">
+      <div className="border-b border-border p-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <div className="flex items-center gap-2 text-sm font-medium">
+              <Activity className="size-4 text-muted-foreground" />
+              Live activity
+            </div>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Started {formatDateTime(execution.created_at)}
+            </p>
+          </div>
+          <Badge variant={statusVariant[execution.status] ?? "outline"}>
+            {execution.status}
+          </Badge>
+        </div>
+      </div>
+
+      <div className="space-y-4 p-4">
+        {execution.status === "failed" ? (
+          <FailureNotice message={failureMessage} />
+        ) : null}
+
+        <PhaseProgress execution={execution} />
+
+        {latestEvent ? (
+          <div className="rounded-lg border border-border p-3">
+            <div className="flex flex-wrap items-center gap-2 text-sm">
+              <TerminalSquare className="size-4 text-muted-foreground" />
+              <span className="font-medium">
+                {formatEventType(latestEvent.event_type)}
+              </span>
+            </div>
+            <p className="mt-2 whitespace-pre-wrap break-words text-sm text-muted-foreground">
+              {eventSummary(latestEvent)}
+            </p>
+            <div className="mt-2 text-xs text-muted-foreground">
+              {formatDateTime(latestEvent.occurred_at)}
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-lg border border-dashed border-border p-3 text-sm text-muted-foreground">
+            Waiting for the first execution event...
+          </div>
+        )}
+
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onToggleExpanded}
+          aria-label="Show summarized activity details"
+        >
+          <ChevronDown
+            data-icon="inline-start"
+            className={`size-4 transition-transform ${isExpanded ? "rotate-180" : ""}`}
+          />
+          {isExpanded ? "Hide summarized details" : "Show summarized details"}
+        </Button>
+
+        {isExpanded ? <AgentHarnessExecutionTimeline execution={execution} /> : null}
+      </div>
+    </div>
+  );
+}
+
+function FailureNotice({ message }: { message: string }) {
+  return (
+    <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-3">
+      <div className="flex items-start gap-2">
+        <AlertCircle className="mt-0.5 size-4 shrink-0 text-destructive" />
+        <div className="min-w-0">
+          <div className="text-sm font-medium text-destructive">
+            This run needs attention
+          </div>
+          <p className="mt-1 whitespace-pre-wrap break-words text-sm text-destructive/90">
+            {message || "Open the summarized activity details and check the latest failed step."}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PhaseProgress({ execution }: { execution: AgentHarnessExecution }) {
+  const phases = phaseStates(execution);
+  return (
+    <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+      {phaseOrder.map((phase) => (
+        <div
+          key={phase}
+          className="flex items-center gap-2 rounded-lg border border-border p-2 text-sm"
+        >
+          {phaseIcon(phases[phase])}
+          <span className="min-w-0 flex-1 truncate">{phaseLabels[phase]}</span>
+          <span className="text-xs capitalize text-muted-foreground">
+            {phases[phase]}
+          </span>
+        </div>
+      ))}
     </div>
   );
 }
@@ -366,16 +489,11 @@ function AgentHarnessExecutionTimeline({
 }: {
   execution: AgentHarnessExecution;
 }) {
-  const events = [...(execution.events ?? [])].sort(
-    (a, b) => a.sequence_number - b.sequence_number,
-  );
+  const events = executionEvents(execution);
   return (
-    <div className="space-y-3 px-4 py-3">
+    <div className="space-y-3">
       <div className="flex flex-wrap items-center gap-2 text-sm">
-        <span className="font-medium">Execution timeline</span>
-        <Badge variant={statusVariant[execution.status] ?? "outline"}>
-          {execution.status}
-        </Badge>
+        <span className="font-medium">Summarized activity details</span>
         <span className="text-xs text-muted-foreground">
           {events.length} {events.length === 1 ? "event" : "events"}
         </span>
@@ -389,7 +507,7 @@ function AgentHarnessExecutionTimeline({
           {events.map((event) => (
             <li
               key={event.id}
-              className="grid gap-3 rounded-md border border-border bg-background p-3 md:grid-cols-[11rem_1fr]"
+              className="grid gap-3 rounded-md border border-border p-3 md:grid-cols-[10rem_1fr]"
             >
               <div className="space-y-1">
                 <div className="text-xs font-medium text-muted-foreground">
@@ -415,10 +533,29 @@ function AgentHarnessExecutionTimeline({
   );
 }
 
+function ContextRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="max-w-48 truncate text-right font-medium">{value}</dd>
+    </div>
+  );
+}
+
 function latestAgentHarnessEvent(execution: AgentHarnessExecution) {
+  return executionEvents(execution).at(-1);
+}
+
+function executionEvents(execution: AgentHarnessExecution) {
   return [...(execution.events ?? [])].sort(
-    (a, b) => b.sequence_number - a.sequence_number,
-  )[0];
+    (a, b) => a.sequence_number - b.sequence_number,
+  );
+}
+
+function formatHarnessRunner(harness: AgentHarness) {
+  return harness.codex_model
+    ? `${harness.codex_template} / ${harness.codex_model}`
+    : harness.codex_template;
 }
 
 function formatEventType(eventType: string) {
@@ -447,7 +584,6 @@ function eventSummary(event: AgentHarnessExecutionEvent) {
     "skipped",
     "changed_files",
     "working_directory",
-    "raw",
   ];
   const lines = preferredKeys
     .flatMap((key) => {
@@ -457,6 +593,93 @@ function eventSummary(event: AgentHarnessExecutionEvent) {
     .filter(Boolean);
   if (lines.length > 0) return lines.join("\n");
   return `${event.actor_type} emitted ${event.event_type}`;
+}
+
+function executionFailureMessage(execution: AgentHarnessExecution) {
+  if (execution.error_message?.trim()) return execution.error_message.trim();
+  const failedEvent = [...executionEvents(execution)]
+    .reverse()
+    .find((event) => event.event_type.endsWith(".failed"));
+  if (!failedEvent) return "";
+  const payload = payloadObject(failedEvent.payload);
+  for (const key of ["error", "message"] as const) {
+    const value = payload[key];
+    if (typeof value === "string" && value.trim()) return truncateText(value, 220);
+  }
+  return "";
+}
+
+function phaseStates(execution: AgentHarnessExecution) {
+  const states: Record<HarnessPhase, HarnessPhaseState> = {
+    sandbox: "waiting",
+    repository: "waiting",
+    agent: "waiting",
+    diff: "waiting",
+    validation: "waiting",
+    "pull-request": "waiting",
+  };
+  for (const event of executionEvents(execution)) {
+    const phase = eventPhase(event.event_type);
+    if (!phase) continue;
+    if (event.event_type.endsWith(".failed")) {
+      states[phase] = "failed";
+    } else if (event.event_type.endsWith(".started")) {
+      states[phase] = states[phase] === "done" ? "done" : "running";
+    } else if (
+      event.event_type.endsWith(".completed") ||
+      event.event_type.endsWith(".passed") ||
+      event.event_type.endsWith(".created")
+    ) {
+      states[phase] = "done";
+    } else if (states[phase] === "waiting") {
+      states[phase] = "running";
+    }
+  }
+  if (execution.status === "completed") {
+    for (const phase of phaseOrder) {
+      if (states[phase] === "running") states[phase] = "done";
+    }
+  }
+  return states;
+}
+
+function eventPhase(eventType: string): HarnessPhase | null {
+  if (eventType.startsWith("sandbox.")) return "sandbox";
+  if (eventType.startsWith("repository.") || eventType.startsWith("github.git_auth")) {
+    return "repository";
+  }
+  if (
+    eventType.startsWith("codex.") ||
+    eventType.startsWith("claude.") ||
+    eventType.includes(".exec")
+  ) {
+    return "agent";
+  }
+  if (eventType.startsWith("git.") || eventType.startsWith("artifact.")) {
+    return "diff";
+  }
+  if (
+    eventType.startsWith("validator.") ||
+    eventType.startsWith("scoring.") ||
+    eventType.startsWith("llm_judges.")
+  ) {
+    return "validation";
+  }
+  if (eventType.startsWith("github.pull_request.")) return "pull-request";
+  return null;
+}
+
+function phaseIcon(state: HarnessPhaseState) {
+  switch (state) {
+    case "done":
+      return <CheckCircle2 className="size-4 text-emerald-500" />;
+    case "failed":
+      return <AlertCircle className="size-4 text-destructive" />;
+    case "running":
+      return <Loader2 className="size-4 animate-spin text-primary" />;
+    case "waiting":
+      return <Clock3 className="size-4 text-muted-foreground" />;
+  }
 }
 
 function payloadObject(payload: unknown): Record<string, unknown> {
@@ -475,18 +698,23 @@ function formatPayloadKey(key: string) {
 
 function formatPayloadValue(value: unknown) {
   if (Array.isArray(value)) {
-    return value.map((item) => String(item)).join(" ");
+    return truncateText(value.map((item) => String(item)).join(" "), 180);
   }
   if (typeof value === "string") {
-    return value.trim() || "(empty)";
+    return truncateText(value.trim() || "(empty)", 180);
   }
   if (value === null || value === undefined) {
     return "(empty)";
   }
   if (typeof value === "object") {
-    return JSON.stringify(value);
+    return "(summary unavailable)";
   }
   return String(value);
+}
+
+function truncateText(value: string, maxLength: number) {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength - 1)}...`;
 }
 
 function formatDateTime(value: string) {

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.tsx
@@ -127,16 +127,18 @@ export function AgentHarnessesClient({
       const api = createApiClient(token);
       await api.post(
         `/v1/workspaces/${workspaceId}/agent-harnesses/${harnessId}/executions`,
-        message?.trim() ? { message: message.trim() } : {},
+        message && message.trim() ? { message } : {},
       );
       await Promise.all([
         mutate(workspaceResourceKeys.agentHarnesses(workspaceId)),
         mutate(workspaceResourceKeys.agentHarnessExecutions(workspaceId)),
       ]);
+      return true;
     } catch (err) {
       setRunError(
         err instanceof Error ? err.message : "Failed to start agent harness",
       );
+      return false;
     } finally {
       setRunningHarnessId(null);
     }
@@ -145,8 +147,8 @@ export function AgentHarnessesClient({
   async function handleChatSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (!selectedHarness || !chatMessage.trim()) return;
-    await startHarnessExecution(selectedHarness.id, chatMessage);
-    setChatMessage("");
+    const started = await startHarnessExecution(selectedHarness.id, chatMessage);
+    if (started) setChatMessage("");
   }
 
   return (
@@ -222,6 +224,7 @@ export function AgentHarnessesClient({
                     </div>
                     <form onSubmit={handleChatSubmit} className="space-y-2">
                       <textarea
+                        aria-label="Agent harness task message"
                         value={chatMessage}
                         onChange={(event) => setChatMessage(event.target.value)}
                         spellCheck={false}
@@ -291,6 +294,14 @@ export function AgentHarnessesClient({
                   <ContextRow
                     label="Runner"
                     value={formatHarnessRunner(selectedHarness)}
+                  />
+                  <ContextRow
+                    label="Repository"
+                    value={formatHarnessRepository(selectedHarness)}
+                  />
+                  <ContextRow
+                    label="Base branch"
+                    value={selectedHarness.base_branch ?? "main"}
                   />
                   <ContextRow
                     label="Updated"
@@ -558,6 +569,14 @@ function formatHarnessRunner(harness: AgentHarness) {
     : harness.codex_template;
 }
 
+function formatHarnessRepository(harness: AgentHarness) {
+  return (
+    harness.repository_full_name ??
+    parseRepositoryName(harness.repository_url ?? "") ??
+    "Not configured"
+  );
+}
+
 function formatEventType(eventType: string) {
   return eventType
     .split(".")
@@ -568,7 +587,37 @@ function formatEventType(eventType: string) {
 
 function eventSummary(event: AgentHarnessExecutionEvent) {
   const payload = payloadObject(event.payload);
-  const preferredKeys = [
+  const preferredKeys = eventSummaryKeys(event.event_type);
+  const lines = preferredKeys
+    .flatMap((key) => {
+      if (!(key in payload)) return [];
+      return [`${formatPayloadKey(key)}: ${formatPayloadValue(payload[key])}`];
+    })
+    .filter(Boolean);
+  if (lines.length > 0) return lines.join("\n");
+  return `${event.actor_type} emitted ${event.event_type}`;
+}
+
+function eventSummaryKeys(eventType: string) {
+  if (eventType === "codex.exec.output" || eventType === "claude.exec.output") {
+    return ["type", "decision", "summary", "tool", "exit_code"];
+  }
+  if (
+    eventType.startsWith("artifact.") ||
+    eventType.startsWith("git.diff") ||
+    eventType.startsWith("validator.command.exec")
+  ) {
+    return [
+      "changed_files",
+      "working_directory",
+      "exit_code",
+      "score",
+      "passed",
+      "failed",
+      "skipped",
+    ];
+  }
+  return [
     "type",
     "message",
     "decision",
@@ -585,14 +634,6 @@ function eventSummary(event: AgentHarnessExecutionEvent) {
     "changed_files",
     "working_directory",
   ];
-  const lines = preferredKeys
-    .flatMap((key) => {
-      if (!(key in payload)) return [];
-      return [`${formatPayloadKey(key)}: ${formatPayloadValue(payload[key])}`];
-    })
-    .filter(Boolean);
-  if (lines.length > 0) return lines.join("\n");
-  return `${event.actor_type} emitted ${event.event_type}`;
 }
 
 function executionFailureMessage(execution: AgentHarnessExecution) {
@@ -719,4 +760,22 @@ function truncateText(value: string, maxLength: number) {
 
 function formatDateTime(value: string) {
   return new Date(value).toLocaleString();
+}
+
+function parseRepositoryName(repositoryURL: string) {
+  const trimmed = repositoryURL.trim().replace(/\.git$/i, "");
+  if (!trimmed) return undefined;
+  const scpPath = trimmed.match(/^[^@]+@[^:]+:(.+)$/)?.[1];
+  if (scpPath) {
+    const segments = scpPath.split("/").filter(Boolean);
+    return segments.length >= 2 ? segments.slice(-2).join("/") : undefined;
+  }
+  try {
+    const url = new URL(trimmed);
+    const segments = url.pathname.split("/").filter(Boolean);
+    return segments.length >= 2 ? segments.slice(-2).join("/") : undefined;
+  } catch {
+    const segments = trimmed.split("/").filter(Boolean);
+    return segments.length >= 2 ? segments.slice(-2).join("/") : undefined;
+  }
 }

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -493,6 +493,7 @@ export interface AgentHarnessExecution {
   agent_harness_id: string;
   status: AgentHarnessExecutionStatus;
   status_reason?: string;
+  error_message?: string;
   harness_snapshot: unknown;
   execution_config_snapshot: unknown;
   evaluation_config_snapshot: unknown;


### PR DESCRIPTION
Implements #610.

Test contract: `testing/codex-issue-610-harness-chat-ui.md`
Parent plan: #609

## Summary
- Reworks Agent Harnesses into a chat-first workbench using the existing harness/execution APIs.
- Keeps advanced setup context secondary while preserving harness selection and follow-up run creation.
- Shows safe summarized live activity, status phases, actionable failure copy, and guarded event summaries that avoid raw diff/log payloads.
- Adds `error_message` to the local web execution type to match the backend response.

## Verification
- `cd web && npm test -- --run 'src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx'`\n- `cd web && npm run lint -- 'src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.tsx' 'src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx'`\n