### PR TITLE
fix: repair invite acceptance flow

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -149,7 +149,7 @@ func main() {
 		logger.Info("email sender: noop (RESEND_API_KEY not set)")
 	}
 	orgMembershipManager := api.NewOrgMembershipManager(orgAuthz, repo, emailSender, cfg.FrontendURL, billingManager)
-	wsMembershipManager := api.NewWorkspaceMembershipManager(repo, emailSender, cfg.FrontendURL)
+	wsMembershipManager := api.NewWorkspaceMembershipManager(repo, emailSender, cfg.FrontendURL, billingManager)
 	onboardingManager := api.NewOnboardingManager(repo)
 	infraManager := api.NewInfrastructureManager(repo)
 	workspaceSecretsManager := api.NewWorkspaceSecretsManager(repo)

--- a/backend/db/migrations/00041_membership_invite_tokens.sql
+++ b/backend/db/migrations/00041_membership_invite_tokens.sql
@@ -1,0 +1,29 @@
+-- +goose Up
+
+ALTER TABLE organization_memberships
+    ADD COLUMN invite_token text,
+    ADD COLUMN invite_token_expires_at timestamptz;
+
+CREATE UNIQUE INDEX organization_memberships_invite_token_uq
+    ON organization_memberships (invite_token)
+    WHERE invite_token IS NOT NULL;
+
+ALTER TABLE workspace_memberships
+    ADD COLUMN invite_token text,
+    ADD COLUMN invite_token_expires_at timestamptz;
+
+CREATE UNIQUE INDEX workspace_memberships_invite_token_uq
+    ON workspace_memberships (invite_token)
+    WHERE invite_token IS NOT NULL;
+
+-- +goose Down
+
+DROP INDEX IF EXISTS workspace_memberships_invite_token_uq;
+ALTER TABLE workspace_memberships
+    DROP COLUMN IF EXISTS invite_token_expires_at,
+    DROP COLUMN IF EXISTS invite_token;
+
+DROP INDEX IF EXISTS organization_memberships_invite_token_uq;
+ALTER TABLE organization_memberships
+    DROP COLUMN IF EXISTS invite_token_expires_at,
+    DROP COLUMN IF EXISTS invite_token;

--- a/backend/internal/api/invite_urls.go
+++ b/backend/internal/api/invite_urls.go
@@ -3,16 +3,46 @@ package api
 import (
 	"fmt"
 	"strings"
-
-	"github.com/google/uuid"
+	"time"
 )
 
-func organizationInviteAcceptURL(frontendURL string, membershipID uuid.UUID) string {
-	return frontendURLForPath(frontendURL, fmt.Sprintf("/invites/organization/%s", membershipID))
+const inviteTokenPrefix = "invite_"
+
+func newInviteToken() (string, error) {
+	token, err := generateSecureToken(32)
+	if err != nil {
+		return "", err
+	}
+	return inviteTokenPrefix + token, nil
 }
 
-func workspaceInviteAcceptURL(frontendURL string, membershipID uuid.UUID) string {
-	return frontendURLForPath(frontendURL, fmt.Sprintf("/invites/workspace/%s", membershipID))
+func newMembershipInviteToken() (string, time.Time, error) {
+	token, err := newInviteToken()
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	return token, time.Now().Add(inviteExpiryDays * 24 * time.Hour), nil
+}
+
+func validInviteToken(token string) bool {
+	if !strings.HasPrefix(token, inviteTokenPrefix) || len(token) > 256 {
+		return false
+	}
+	for _, r := range token {
+		if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func organizationInviteAcceptURL(frontendURL, inviteToken string) string {
+	return frontendURLForPath(frontendURL, fmt.Sprintf("/invites/organization/%s", inviteToken))
+}
+
+func workspaceInviteAcceptURL(frontendURL, inviteToken string) string {
+	return frontendURLForPath(frontendURL, fmt.Sprintf("/invites/workspace/%s", inviteToken))
 }
 
 func frontendURLForPath(frontendURL, path string) string {

--- a/backend/internal/api/org_memberships.go
+++ b/backend/internal/api/org_memberships.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	billingpkg "github.com/agentclash/agentclash/backend/internal/billing"
@@ -20,6 +21,7 @@ type OrgMembershipService interface {
 	ListOrgMemberships(ctx context.Context, caller Caller, orgID uuid.UUID, limit, offset int32) (ListOrgMembershipsResult, error)
 	InviteOrgMember(ctx context.Context, caller Caller, orgID uuid.UUID, input InviteOrgMemberInput) (OrgMembershipResult, error)
 	UpdateOrgMembership(ctx context.Context, caller Caller, membershipID uuid.UUID, input UpdateOrgMembershipInput) (OrgMembershipResult, error)
+	AcceptOrgInvite(ctx context.Context, caller Caller, inviteToken string) (OrgMembershipResult, error)
 }
 
 type InviteOrgMemberInput struct {
@@ -60,6 +62,7 @@ type OrgMembershipRepository interface {
 	GetOrgMembershipByOrgAndUser(ctx context.Context, orgID, userID uuid.UUID) (repository.OrgMembershipFullRow, error)
 	CreateOrgMembership(ctx context.Context, input repository.CreateOrgMembershipInput) (repository.OrgMembershipFullRow, error)
 	GetOrgMembershipByID(ctx context.Context, membershipID uuid.UUID) (repository.OrgMembershipFullRow, error)
+	GetOrgMembershipByInviteToken(ctx context.Context, inviteToken string) (repository.OrgMembershipFullRow, error)
 	UpdateOrgMembership(ctx context.Context, membershipID uuid.UUID, input repository.UpdateOrgMembershipInput) (repository.OrgMembershipFullRow, error)
 	CountActiveOrgAdmins(ctx context.Context, orgID uuid.UUID) (int64, error)
 	CascadeOrgMembershipStatusToWorkspaces(ctx context.Context, orgID, userID uuid.UUID, status string) error
@@ -150,6 +153,10 @@ func (m *OrgMembershipManager) InviteOrgMember(ctx context.Context, caller Calle
 		if existing.MembershipStatus == "active" || existing.MembershipStatus == "invited" {
 			return OrgMembershipResult{}, repository.ErrAlreadyMember
 		}
+		inviteToken, inviteTokenExpiresAt, err := newMembershipInviteToken()
+		if err != nil {
+			return OrgMembershipResult{}, err
+		}
 		var entitlementGate *repository.OrganizationEntitlementGate
 		if m.entitlementGate != nil {
 			entitlementGate, err = m.entitlementGate.BuildSeatGate(ctx, orgID, false)
@@ -159,14 +166,16 @@ func (m *OrgMembershipManager) InviteOrgMember(ctx context.Context, caller Calle
 		}
 		// Previously archived — allow re-invite by updating status.
 		result, err := m.repo.UpdateOrgMembership(ctx, existing.ID, repository.UpdateOrgMembershipInput{
-			Role:            &input.Role,
-			Status:          strPtr("invited"),
-			EntitlementGate: entitlementGate,
+			Role:                 &input.Role,
+			Status:               strPtr("invited"),
+			InviteToken:          &inviteToken,
+			InviteTokenExpiresAt: &inviteTokenExpiresAt,
+			EntitlementGate:      entitlementGate,
 		})
 		if err != nil {
 			return OrgMembershipResult{}, err
 		}
-		acceptURL := organizationInviteAcceptURL(m.frontendURL, result.ID)
+		acceptURL := organizationInviteAcceptURL(m.frontendURL, result.InviteToken)
 		m.sendInviteEmail(ctx, caller, orgID, input.Email, input.Role, acceptURL)
 		return m.orgMembershipRowToResult(result, true), nil
 	}
@@ -181,17 +190,23 @@ func (m *OrgMembershipManager) InviteOrgMember(ctx context.Context, caller Calle
 		}
 	}
 
+	inviteToken, inviteTokenExpiresAt, err := newMembershipInviteToken()
+	if err != nil {
+		return OrgMembershipResult{}, err
+	}
 	result, err := m.repo.CreateOrgMembership(ctx, repository.CreateOrgMembershipInput{
-		OrganizationID:  orgID,
-		UserID:          user.ID,
-		Role:            input.Role,
-		EntitlementGate: entitlementGate,
+		OrganizationID:       orgID,
+		UserID:               user.ID,
+		Role:                 input.Role,
+		InviteToken:          inviteToken,
+		InviteTokenExpiresAt: inviteTokenExpiresAt,
+		EntitlementGate:      entitlementGate,
 	})
 	if err != nil {
 		return OrgMembershipResult{}, err
 	}
 
-	acceptURL := organizationInviteAcceptURL(m.frontendURL, result.ID)
+	acceptURL := organizationInviteAcceptURL(m.frontendURL, result.InviteToken)
 	m.sendInviteEmail(ctx, caller, orgID, input.Email, input.Role, acceptURL)
 	return m.orgMembershipRowToResult(result, true), nil
 }
@@ -207,24 +222,21 @@ func (m *OrgMembershipManager) UpdateOrgMembership(ctx context.Context, caller C
 	if m, ok := caller.OrganizationMemberships[membership.OrganizationID]; ok && m.Role == "org_admin" {
 		isAdmin = true
 	}
-	isInvitedUser := membership.UserID == caller.UserID && membership.MembershipStatus == "invited"
+	isLegacyInviteLink := membership.InviteToken == ""
+	isInvitedUser := isLegacyInviteLink && membership.UserID == caller.UserID && membership.MembershipStatus == "invited"
+	isInviteAcceptance := input.Role == nil && input.Status != nil && *input.Status == "active" && membership.MembershipStatus == "invited"
+	isInviteLinkHolder := isLegacyInviteLink && !isAdmin && !isInvitedUser && isInviteAcceptance && inviteEmailMatchesCaller(caller, membership.Email)
 
-	if !isAdmin && !isInvitedUser {
+	if !isAdmin && !isInvitedUser && !isInviteLinkHolder {
 		return OrgMembershipResult{}, ErrForbidden
 	}
 
-	// Invited user can only accept (invited -> active).
-	if isInvitedUser && !isAdmin {
-		if input.Status == nil || *input.Status != "active" {
+	// Non-admins can only accept a pending invite link.
+	if (isInvitedUser || isInviteLinkHolder) && !isAdmin {
+		if !isInviteAcceptance {
 			return OrgMembershipResult{}, ErrForbidden
 		}
-		// Check invite expiry. Use UpdatedAt because re-invites refresh it
-		// via the DB trigger, while CreatedAt is the original row creation.
-		invitedAt := membership.UpdatedAt
-		if invitedAt.IsZero() {
-			invitedAt = membership.CreatedAt
-		}
-		if time.Since(invitedAt) > inviteExpiryDays*24*time.Hour {
+		if orgInviteExpired(membership) {
 			return OrgMembershipResult{}, repository.ErrInviteExpired
 		}
 	}
@@ -259,11 +271,19 @@ func (m *OrgMembershipManager) UpdateOrgMembership(ctx context.Context, caller C
 		}
 	}
 
-	result, err := m.repo.UpdateOrgMembership(ctx, membershipID, repository.UpdateOrgMembershipInput{
+	updateInput := repository.UpdateOrgMembershipInput{
 		Role:            input.Role,
 		Status:          input.Status,
 		EntitlementGate: entitlementGate,
-	})
+	}
+	if isInviteLinkHolder {
+		updateInput.UserID = &caller.UserID
+	}
+	if input.Status != nil && (*input.Status == "active" || *input.Status == "archived") && membership.MembershipStatus == "invited" {
+		updateInput.ClearInviteToken = true
+	}
+
+	result, err := m.repo.UpdateOrgMembership(ctx, membershipID, updateInput)
 	if err != nil {
 		return OrgMembershipResult{}, err
 	}
@@ -279,6 +299,65 @@ func (m *OrgMembershipManager) UpdateOrgMembership(ctx context.Context, caller C
 	return m.orgMembershipRowToResult(result, isAdmin), nil
 }
 
+func (m *OrgMembershipManager) AcceptOrgInvite(ctx context.Context, caller Caller, inviteToken string) (OrgMembershipResult, error) {
+	if !validInviteToken(inviteToken) {
+		return OrgMembershipResult{}, repository.ErrMembershipNotFound
+	}
+
+	membership, err := m.repo.GetOrgMembershipByInviteToken(ctx, inviteToken)
+	if err != nil {
+		return OrgMembershipResult{}, err
+	}
+	if !inviteEmailMatchesCaller(caller, membership.Email) {
+		return OrgMembershipResult{}, ErrForbidden
+	}
+	if orgInviteExpired(membership) {
+		return OrgMembershipResult{}, repository.ErrInviteExpired
+	}
+
+	var entitlementGate *repository.OrganizationEntitlementGate
+	if m.entitlementGate != nil {
+		entitlementGate, err = m.entitlementGate.BuildSeatGate(ctx, membership.OrganizationID, false)
+		if err != nil {
+			return OrgMembershipResult{}, err
+		}
+	}
+
+	status := "active"
+	updateInput := repository.UpdateOrgMembershipInput{
+		Status:           &status,
+		ClearInviteToken: true,
+		EntitlementGate:  entitlementGate,
+	}
+	if membership.UserID != caller.UserID {
+		updateInput.UserID = &caller.UserID
+	}
+
+	result, err := m.repo.UpdateOrgMembership(ctx, membership.ID, updateInput)
+	if err != nil {
+		return OrgMembershipResult{}, err
+	}
+	return m.orgMembershipRowToResult(result, false), nil
+}
+
+func inviteEmailMatchesCaller(caller Caller, inviteEmail string) bool {
+	return strings.EqualFold(strings.TrimSpace(caller.Email), strings.TrimSpace(inviteEmail)) && strings.TrimSpace(caller.Email) != ""
+}
+
+func orgInviteExpired(membership repository.OrgMembershipFullRow) bool {
+	if membership.InviteTokenExpiresAt != nil {
+		return time.Now().After(*membership.InviteTokenExpiresAt)
+	}
+	invitedAt := membership.UpdatedAt
+	if invitedAt.IsZero() {
+		invitedAt = membership.CreatedAt
+	}
+	if invitedAt.IsZero() {
+		return false
+	}
+	return time.Since(invitedAt) > inviteExpiryDays*24*time.Hour
+}
+
 func (m *OrgMembershipManager) sendInviteEmail(ctx context.Context, caller Caller, orgID uuid.UUID, inviteeEmail, role, acceptURL string) {
 	org, err := m.repo.GetOrganizationByID(ctx, orgID)
 	if err != nil {
@@ -287,14 +366,12 @@ func (m *OrgMembershipManager) sendInviteEmail(ctx context.Context, caller Calle
 	}
 
 	inviterEmail := caller.Email
-	if inviterEmail == "" {
-		inviterEmail = "a team member"
-	}
 
 	if err := m.emailSender.SendInvite(ctx, email.InviteEmail{
 		To:           inviteeEmail,
 		ResourceName: org.Name,
 		ResourceKind: "organization",
+		InviterName:  caller.DisplayName,
 		InviterEmail: inviterEmail,
 		Role:         role,
 		AcceptURL:    acceptURL,
@@ -345,8 +422,12 @@ func (m *OrgMembershipManager) orgMembershipRowToResult(row repository.OrgMember
 		MembershipStatus: row.MembershipStatus,
 		CreatedAt:        row.CreatedAt,
 	}
-	if includeInviteLink && row.MembershipStatus == "invited" {
-		result.AcceptURL = organizationInviteAcceptURL(m.frontendURL, row.ID)
+	if includeInviteLink && row.MembershipStatus == "invited" && !orgInviteExpired(row) {
+		inviteToken := row.InviteToken
+		if inviteToken == "" {
+			inviteToken = row.ID.String()
+		}
+		result.AcceptURL = organizationInviteAcceptURL(m.frontendURL, inviteToken)
 	}
 	return result
 }
@@ -484,6 +565,47 @@ func updateOrgMembershipHandler(logger *slog.Logger, service OrgMembershipServic
 			Role:   req.Role,
 			Status: req.Status,
 		})
+		if err != nil {
+			handleMembershipError(w, logger, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func acceptOrgInviteHandler(logger *slog.Logger, service OrgMembershipService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		inviteToken := chi.URLParam(r, "inviteToken")
+		if !validInviteToken(inviteToken) {
+			writeError(w, http.StatusBadRequest, "invalid_invite_token", "invite token is malformed")
+			return
+		}
+
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+
+		var req struct {
+			Status *string `json:"status,omitempty"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body")
+			return
+		}
+		if req.Status == nil || *req.Status != "active" {
+			writeError(w, http.StatusBadRequest, "validation_error", "status must be active")
+			return
+		}
+
+		result, err := service.AcceptOrgInvite(r.Context(), caller, inviteToken)
 		if err != nil {
 			handleMembershipError(w, logger, err)
 			return

--- a/backend/internal/api/org_memberships_test.go
+++ b/backend/internal/api/org_memberships_test.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/google/uuid"
@@ -17,6 +19,7 @@ type fakeOrgMembershipRepo struct {
 	created         repository.OrgMembershipFullRow
 	createErr       error
 	updated         repository.OrgMembershipFullRow
+	lastUpdate      repository.UpdateOrgMembershipInput
 	updateErr       error
 	adminCount      int64
 	memberships     []repository.OrgMembershipFullRow
@@ -47,7 +50,11 @@ func (r *fakeOrgMembershipRepo) GetOrgMembershipByOrgAndUser(_ context.Context, 
 	return r.orgMembership, r.orgMemberErr
 }
 
-func (r *fakeOrgMembershipRepo) CreateOrgMembership(_ context.Context, _ repository.CreateOrgMembershipInput) (repository.OrgMembershipFullRow, error) {
+func (r *fakeOrgMembershipRepo) CreateOrgMembership(_ context.Context, input repository.CreateOrgMembershipInput) (repository.OrgMembershipFullRow, error) {
+	if r.created.InviteToken == "" {
+		r.created.InviteToken = input.InviteToken
+		r.created.InviteTokenExpiresAt = &input.InviteTokenExpiresAt
+	}
 	return r.created, r.createErr
 }
 
@@ -55,7 +62,20 @@ func (r *fakeOrgMembershipRepo) GetOrgMembershipByID(_ context.Context, _ uuid.U
 	return r.orgMembership, r.orgMemberErr
 }
 
-func (r *fakeOrgMembershipRepo) UpdateOrgMembership(_ context.Context, _ uuid.UUID, _ repository.UpdateOrgMembershipInput) (repository.OrgMembershipFullRow, error) {
+func (r *fakeOrgMembershipRepo) GetOrgMembershipByInviteToken(_ context.Context, _ string) (repository.OrgMembershipFullRow, error) {
+	return r.orgMembership, r.orgMemberErr
+}
+
+func (r *fakeOrgMembershipRepo) UpdateOrgMembership(_ context.Context, _ uuid.UUID, input repository.UpdateOrgMembershipInput) (repository.OrgMembershipFullRow, error) {
+	r.lastUpdate = input
+	if input.InviteToken != nil && r.updated.InviteToken == "" {
+		r.updated.InviteToken = *input.InviteToken
+		r.updated.InviteTokenExpiresAt = input.InviteTokenExpiresAt
+	}
+	if input.ClearInviteToken {
+		r.updated.InviteToken = ""
+		r.updated.InviteTokenExpiresAt = nil
+	}
 	return r.updated, r.updateErr
 }
 
@@ -93,8 +113,9 @@ func TestInviteOrgMember_SendsEmail(t *testing.T) {
 	manager := NewOrgMembershipManager(NewCallerOrganizationAuthorizer(), repo, sender, "https://app.agentclash.dev")
 
 	caller := Caller{
-		UserID: uuid.New(),
-		Email:  "admin@example.com",
+		UserID:      uuid.New(),
+		Email:       "admin@example.com",
+		DisplayName: "Atharva",
 		OrganizationMemberships: map[uuid.UUID]OrganizationMembership{
 			orgID: {OrganizationID: orgID, Role: "org_admin"},
 		},
@@ -108,9 +129,9 @@ func TestInviteOrgMember_SendsEmail(t *testing.T) {
 		t.Fatalf("InviteOrgMember returned error: %v", err)
 	}
 
-	wantAcceptURL := "https://app.agentclash.dev/invites/organization/" + membershipID.String()
-	if result.AcceptURL != wantAcceptURL {
-		t.Errorf("result AcceptURL = %q, want %q", result.AcceptURL, wantAcceptURL)
+	wantAcceptURLPrefix := "https://app.agentclash.dev/invites/organization/invite_"
+	if !strings.HasPrefix(result.AcceptURL, wantAcceptURLPrefix) {
+		t.Errorf("result AcceptURL = %q, want prefix %q", result.AcceptURL, wantAcceptURLPrefix)
 	}
 	if len(sender.calls) != 1 {
 		t.Fatalf("expected 1 email sent, got %d", len(sender.calls))
@@ -125,14 +146,115 @@ func TestInviteOrgMember_SendsEmail(t *testing.T) {
 	if sent.ResourceKind != "organization" {
 		t.Errorf("email ResourceKind = %q, want organization", sent.ResourceKind)
 	}
+	if sent.InviterName != "Atharva" {
+		t.Errorf("email InviterName = %q, want Atharva", sent.InviterName)
+	}
 	if sent.InviterEmail != "admin@example.com" {
 		t.Errorf("email InviterEmail = %q, want admin@example.com", sent.InviterEmail)
 	}
 	if sent.Role != "org_member" {
 		t.Errorf("email Role = %q, want org_member", sent.Role)
 	}
-	if sent.AcceptURL != wantAcceptURL {
-		t.Errorf("email AcceptURL = %q, want %q", sent.AcceptURL, wantAcceptURL)
+	if sent.AcceptURL != result.AcceptURL {
+		t.Errorf("email AcceptURL = %q, want %q", sent.AcceptURL, result.AcceptURL)
+	}
+}
+
+func TestAcceptOrgInviteLink_ReassignsPendingInviteToCaller(t *testing.T) {
+	orgID := uuid.New()
+	invitedUserID := uuid.New()
+	callerUserID := uuid.New()
+	membershipID := uuid.New()
+	now := time.Now()
+
+	repo := &fakeOrgMembershipRepo{
+		orgMembership: repository.OrgMembershipFullRow{
+			ID:               membershipID,
+			OrganizationID:   orgID,
+			UserID:           invitedUserID,
+			Email:            "friend@example.com",
+			Role:             "org_admin",
+			MembershipStatus: "invited",
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		},
+		updated: repository.OrgMembershipFullRow{
+			ID:               membershipID,
+			OrganizationID:   orgID,
+			UserID:           callerUserID,
+			Email:            "friend@example.com",
+			Role:             "org_admin",
+			MembershipStatus: "active",
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		},
+	}
+	manager := NewOrgMembershipManager(NewCallerOrganizationAuthorizer(), repo, &fakeEmailSender{}, "https://app.agentclash.dev")
+	status := "active"
+
+	result, err := manager.UpdateOrgMembership(context.Background(), Caller{UserID: callerUserID, Email: "friend@example.com"}, membershipID, UpdateOrgMembershipInput{
+		Status: &status,
+	})
+	if err != nil {
+		t.Fatalf("UpdateOrgMembership returned error: %v", err)
+	}
+
+	if repo.lastUpdate.UserID == nil || *repo.lastUpdate.UserID != callerUserID {
+		t.Fatalf("UpdateOrgMembership UserID = %v, want %s", repo.lastUpdate.UserID, callerUserID)
+	}
+	if result.UserID != callerUserID {
+		t.Fatalf("result UserID = %s, want %s", result.UserID, callerUserID)
+	}
+	if result.MembershipStatus != "active" {
+		t.Fatalf("result status = %q, want active", result.MembershipStatus)
+	}
+	if !repo.lastUpdate.ClearInviteToken {
+		t.Fatalf("ClearInviteToken = false, want true")
+	}
+}
+
+func TestAcceptOrgInviteToken_ReassignsPendingInviteToCaller(t *testing.T) {
+	orgID := uuid.New()
+	invitedUserID := uuid.New()
+	callerUserID := uuid.New()
+	membershipID := uuid.New()
+	expiresAt := time.Now().Add(time.Hour)
+
+	repo := &fakeOrgMembershipRepo{
+		orgMembership: repository.OrgMembershipFullRow{
+			ID:                   membershipID,
+			OrganizationID:       orgID,
+			UserID:               invitedUserID,
+			Email:                "friend@example.com",
+			Role:                 "org_member",
+			MembershipStatus:     "invited",
+			InviteToken:          "invite_testtoken",
+			InviteTokenExpiresAt: &expiresAt,
+		},
+		updated: repository.OrgMembershipFullRow{
+			ID:               membershipID,
+			OrganizationID:   orgID,
+			UserID:           callerUserID,
+			Email:            "friend@example.com",
+			Role:             "org_member",
+			MembershipStatus: "active",
+		},
+	}
+	manager := NewOrgMembershipManager(NewCallerOrganizationAuthorizer(), repo, &fakeEmailSender{}, "https://app.agentclash.dev")
+
+	result, err := manager.AcceptOrgInvite(context.Background(), Caller{UserID: callerUserID, Email: "friend@example.com"}, "invite_testtoken")
+	if err != nil {
+		t.Fatalf("AcceptOrgInvite returned error: %v", err)
+	}
+
+	if repo.lastUpdate.UserID == nil || *repo.lastUpdate.UserID != callerUserID {
+		t.Fatalf("AcceptOrgInvite UserID = %v, want %s", repo.lastUpdate.UserID, callerUserID)
+	}
+	if !repo.lastUpdate.ClearInviteToken {
+		t.Fatalf("ClearInviteToken = false, want true")
+	}
+	if result.MembershipStatus != "active" {
+		t.Fatalf("result status = %q, want active", result.MembershipStatus)
 	}
 }
 
@@ -148,6 +270,7 @@ func TestListOrgMemberships_InviteLinksOnlyForAdmins(t *testing.T) {
 				Email:            "invitee@example.com",
 				Role:             "org_member",
 				MembershipStatus: "invited",
+				InviteToken:      "invite_testtoken",
 			},
 		},
 		membershipCount: 1,
@@ -178,7 +301,7 @@ func TestListOrgMemberships_InviteLinksOnlyForAdmins(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListOrgMemberships returned error for admin: %v", err)
 	}
-	wantAcceptURL := "https://app.agentclash.dev/invites/organization/" + membershipID.String()
+	wantAcceptURL := "https://app.agentclash.dev/invites/organization/invite_testtoken"
 	if got := adminResult.Items[0].AcceptURL; got != wantAcceptURL {
 		t.Fatalf("admin caller AcceptURL = %q, want %q", got, wantAcceptURL)
 	}

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -59,6 +59,7 @@ func registerProtectedRoutes(
 		})
 	})
 	router.Patch("/organization-memberships/{membershipID}", updateOrgMembershipHandler(logger, orgMembershipService))
+	router.Patch("/invites/organization/{inviteToken}", acceptOrgInviteHandler(logger, orgMembershipService))
 
 	// Standalone workspace endpoints (by workspace ID).
 	router.Get("/workspaces/{workspaceID}/details", getWorkspaceHandler(logger, wsService))
@@ -66,6 +67,7 @@ func registerProtectedRoutes(
 	router.Get("/workspaces/{workspaceID}/memberships", listWorkspaceMembershipsHandler(logger, wsMembershipService))
 	router.Post("/workspaces/{workspaceID}/memberships", inviteWorkspaceMemberHandler(logger, wsMembershipService))
 	router.Patch("/workspace-memberships/{membershipID}", updateWorkspaceMembershipHandler(logger, wsMembershipService))
+	router.Patch("/invites/workspace/{inviteToken}", acceptWorkspaceInviteHandler(logger, wsMembershipService))
 	router.Get("/artifacts/{artifactID}/download", getArtifactDownloadHandler(logger, artifactService))
 	// POST /v1/runs resolves workspace access from the JSON body, so authz stays in the run-creation service
 	// instead of URL-param middleware. The run read endpoints below also resolve authz in the service layer

--- a/backend/internal/api/workspace_memberships.go
+++ b/backend/internal/api/workspace_memberships.go
@@ -19,6 +19,7 @@ type WorkspaceMembershipService interface {
 	ListWorkspaceMemberships(ctx context.Context, caller Caller, workspaceID uuid.UUID, limit, offset int32) (ListWorkspaceMembershipsResult, error)
 	InviteWorkspaceMember(ctx context.Context, caller Caller, workspaceID uuid.UUID, input InviteWorkspaceMemberInput) (WorkspaceMembershipResult, error)
 	UpdateWorkspaceMembership(ctx context.Context, caller Caller, membershipID uuid.UUID, input UpdateWorkspaceMembershipInput) (WorkspaceMembershipResult, error)
+	AcceptWorkspaceInvite(ctx context.Context, caller Caller, inviteToken string) (WorkspaceMembershipResult, error)
 }
 
 type InviteWorkspaceMemberInput struct {
@@ -59,21 +60,32 @@ type WorkspaceMembershipRepository interface {
 	GetUserByEmail(ctx context.Context, email string) (repository.User, error)
 	CreateUser(ctx context.Context, input repository.CreateUserInput) (repository.User, error)
 	GetOrgMembershipByOrgAndUser(ctx context.Context, orgID, userID uuid.UUID) (repository.OrgMembershipFullRow, error)
+	CreateOrgMembership(ctx context.Context, input repository.CreateOrgMembershipInput) (repository.OrgMembershipFullRow, error)
+	UpdateOrgMembership(ctx context.Context, membershipID uuid.UUID, input repository.UpdateOrgMembershipInput) (repository.OrgMembershipFullRow, error)
 	GetWorkspaceMembershipByWorkspaceAndUser(ctx context.Context, workspaceID, userID uuid.UUID) (repository.WorkspaceMembershipFullRow, error)
 	CreateWorkspaceMembership(ctx context.Context, input repository.CreateWorkspaceMembershipInput) (repository.WorkspaceMembershipFullRow, error)
 	GetWorkspaceMembershipByID(ctx context.Context, membershipID uuid.UUID) (repository.WorkspaceMembershipFullRow, error)
+	GetWorkspaceMembershipByInviteToken(ctx context.Context, inviteToken string) (repository.WorkspaceMembershipFullRow, error)
 	UpdateWorkspaceMembership(ctx context.Context, membershipID uuid.UUID, input repository.UpdateWorkspaceMembershipInput) (repository.WorkspaceMembershipFullRow, error)
 	CountActiveWorkspaceAdmins(ctx context.Context, workspaceID uuid.UUID) (int64, error)
 }
 
 type WorkspaceMembershipManager struct {
-	repo        WorkspaceMembershipRepository
-	emailSender email.Sender
-	frontendURL string
+	repo            WorkspaceMembershipRepository
+	emailSender     email.Sender
+	frontendURL     string
+	entitlementGate EntitlementGateService
 }
 
-func NewWorkspaceMembershipManager(repo WorkspaceMembershipRepository, emailSender email.Sender, frontendURL string) *WorkspaceMembershipManager {
-	return &WorkspaceMembershipManager{repo: repo, emailSender: emailSender, frontendURL: frontendURL}
+func NewWorkspaceMembershipManager(repo WorkspaceMembershipRepository, emailSender email.Sender, frontendURL string, entitlementGate ...EntitlementGateService) *WorkspaceMembershipManager {
+	var gate EntitlementGateService
+	if len(entitlementGate) > 0 {
+		gate = entitlementGate[0]
+	}
+	if emailSender == nil {
+		emailSender = email.NoopSender{}
+	}
+	return &WorkspaceMembershipManager{repo: repo, emailSender: emailSender, frontendURL: frontendURL, entitlementGate: gate}
 }
 
 func (m *WorkspaceMembershipManager) ListWorkspaceMemberships(ctx context.Context, caller Caller, workspaceID uuid.UUID, limit, offset int32) (ListWorkspaceMembershipsResult, error) {
@@ -135,12 +147,7 @@ func (m *WorkspaceMembershipManager) InviteWorkspaceMember(ctx context.Context, 
 		return WorkspaceMembershipResult{}, err
 	}
 
-	// Pre-check: user must have active org membership.
-	orgMembership, err := m.repo.GetOrgMembershipByOrgAndUser(ctx, orgID, user.ID)
-	if errors.Is(err, repository.ErrMembershipNotFound) || (err == nil && orgMembership.MembershipStatus != "active") {
-		return WorkspaceMembershipResult{}, repository.ErrOrgMembershipRequired
-	}
-	if err != nil {
+	if _, err := m.ensureWorkspaceInviteOrgMembership(ctx, orgID, user.ID); err != nil {
 		return WorkspaceMembershipResult{}, err
 	}
 
@@ -150,15 +157,21 @@ func (m *WorkspaceMembershipManager) InviteWorkspaceMember(ctx context.Context, 
 		if existing.MembershipStatus == "active" || existing.MembershipStatus == "invited" {
 			return WorkspaceMembershipResult{}, repository.ErrAlreadyMember
 		}
+		inviteToken, inviteTokenExpiresAt, err := newMembershipInviteToken()
+		if err != nil {
+			return WorkspaceMembershipResult{}, err
+		}
 		// Previously archived — re-invite.
 		result, err := m.repo.UpdateWorkspaceMembership(ctx, existing.ID, repository.UpdateWorkspaceMembershipInput{
-			Role:   &input.Role,
-			Status: strPtr("invited"),
+			Role:                 &input.Role,
+			Status:               strPtr("invited"),
+			InviteToken:          &inviteToken,
+			InviteTokenExpiresAt: &inviteTokenExpiresAt,
 		})
 		if err != nil {
 			return WorkspaceMembershipResult{}, err
 		}
-		acceptURL := workspaceInviteAcceptURL(m.frontendURL, result.ID)
+		acceptURL := workspaceInviteAcceptURL(m.frontendURL, result.InviteToken)
 		m.sendInviteEmail(ctx, caller, workspaceID, input.Email, input.Role, acceptURL)
 		return m.wsMembershipRowToResult(result, true), nil
 	}
@@ -166,17 +179,23 @@ func (m *WorkspaceMembershipManager) InviteWorkspaceMember(ctx context.Context, 
 		return WorkspaceMembershipResult{}, err
 	}
 
+	inviteToken, inviteTokenExpiresAt, err := newMembershipInviteToken()
+	if err != nil {
+		return WorkspaceMembershipResult{}, err
+	}
 	result, err := m.repo.CreateWorkspaceMembership(ctx, repository.CreateWorkspaceMembershipInput{
-		OrganizationID: orgID,
-		WorkspaceID:    workspaceID,
-		UserID:         user.ID,
-		Role:           input.Role,
+		OrganizationID:       orgID,
+		WorkspaceID:          workspaceID,
+		UserID:               user.ID,
+		Role:                 input.Role,
+		InviteToken:          inviteToken,
+		InviteTokenExpiresAt: inviteTokenExpiresAt,
 	})
 	if err != nil {
 		return WorkspaceMembershipResult{}, err
 	}
 
-	acceptURL := workspaceInviteAcceptURL(m.frontendURL, result.ID)
+	acceptURL := workspaceInviteAcceptURL(m.frontendURL, result.InviteToken)
 	m.sendInviteEmail(ctx, caller, workspaceID, input.Email, input.Role, acceptURL)
 	return m.wsMembershipRowToResult(result, true), nil
 }
@@ -200,21 +219,20 @@ func (m *WorkspaceMembershipManager) UpdateWorkspaceMembership(ctx context.Conte
 			}
 		}
 	}
-	isInvitedUser := membership.UserID == caller.UserID && membership.MembershipStatus == "invited"
+	isLegacyInviteLink := membership.InviteToken == ""
+	isInvitedUser := isLegacyInviteLink && membership.UserID == caller.UserID && membership.MembershipStatus == "invited"
+	isInviteAcceptance := input.Role == nil && input.Status != nil && *input.Status == "active" && membership.MembershipStatus == "invited"
+	isInviteLinkHolder := isLegacyInviteLink && !isAdmin && !isInvitedUser && isInviteAcceptance && inviteEmailMatchesCaller(caller, membership.Email)
 
-	if !isAdmin && !isInvitedUser {
+	if !isAdmin && !isInvitedUser && !isInviteLinkHolder {
 		return WorkspaceMembershipResult{}, ErrForbidden
 	}
 
-	if isInvitedUser && !isAdmin {
-		if input.Status == nil || *input.Status != "active" {
+	if (isInvitedUser || isInviteLinkHolder) && !isAdmin {
+		if !isInviteAcceptance {
 			return WorkspaceMembershipResult{}, ErrForbidden
 		}
-		invitedAt := membership.UpdatedAt
-		if invitedAt.IsZero() {
-			invitedAt = membership.CreatedAt
-		}
-		if time.Since(invitedAt) > inviteExpiryDays*24*time.Hour {
+		if wsInviteExpired(membership) {
 			return WorkspaceMembershipResult{}, repository.ErrInviteExpired
 		}
 	}
@@ -240,15 +258,187 @@ func (m *WorkspaceMembershipManager) UpdateWorkspaceMembership(ctx context.Conte
 		}
 	}
 
-	result, err := m.repo.UpdateWorkspaceMembership(ctx, membershipID, repository.UpdateWorkspaceMembershipInput{
+	updateInput := repository.UpdateWorkspaceMembershipInput{
 		Role:   input.Role,
 		Status: input.Status,
-	})
+	}
+	if isInviteLinkHolder {
+		updateInput.UserID = &caller.UserID
+	}
+	if input.Status != nil && (*input.Status == "active" || *input.Status == "archived") && membership.MembershipStatus == "invited" {
+		updateInput.ClearInviteToken = true
+	}
+
+	result, err := m.repo.UpdateWorkspaceMembership(ctx, membershipID, updateInput)
+	if errors.Is(err, repository.ErrOrgMembershipRequired) && updateInput.UserID != nil && input.Status != nil && *input.Status == "active" {
+		if _, ensureErr := m.ensureActiveOrgMembership(ctx, membership.OrganizationID, caller.UserID); ensureErr != nil {
+			return WorkspaceMembershipResult{}, ensureErr
+		}
+		result, err = m.repo.UpdateWorkspaceMembership(ctx, membershipID, updateInput)
+	}
 	if err != nil {
 		return WorkspaceMembershipResult{}, err
 	}
 
 	return m.wsMembershipRowToResult(result, isAdmin), nil
+}
+
+func (m *WorkspaceMembershipManager) AcceptWorkspaceInvite(ctx context.Context, caller Caller, inviteToken string) (WorkspaceMembershipResult, error) {
+	if !validInviteToken(inviteToken) {
+		return WorkspaceMembershipResult{}, repository.ErrMembershipNotFound
+	}
+
+	membership, err := m.repo.GetWorkspaceMembershipByInviteToken(ctx, inviteToken)
+	if err != nil {
+		return WorkspaceMembershipResult{}, err
+	}
+	if !inviteEmailMatchesCaller(caller, membership.Email) {
+		return WorkspaceMembershipResult{}, ErrForbidden
+	}
+	if wsInviteExpired(membership) {
+		return WorkspaceMembershipResult{}, repository.ErrInviteExpired
+	}
+
+	if _, err := m.ensureActiveOrgMembership(ctx, membership.OrganizationID, caller.UserID); err != nil {
+		return WorkspaceMembershipResult{}, err
+	}
+
+	status := "active"
+	updateInput := repository.UpdateWorkspaceMembershipInput{
+		Status:           &status,
+		ClearInviteToken: true,
+	}
+	if membership.UserID != caller.UserID {
+		updateInput.UserID = &caller.UserID
+	}
+
+	result, err := m.repo.UpdateWorkspaceMembership(ctx, membership.ID, updateInput)
+	if err != nil {
+		return WorkspaceMembershipResult{}, err
+	}
+	return m.wsMembershipRowToResult(result, false), nil
+}
+
+func (m *WorkspaceMembershipManager) ensureWorkspaceInviteOrgMembership(ctx context.Context, orgID, userID uuid.UUID) (repository.OrgMembershipFullRow, error) {
+	orgMembership, err := m.repo.GetOrgMembershipByOrgAndUser(ctx, orgID, userID)
+	if err == nil {
+		switch orgMembership.MembershipStatus {
+		case "active", "invited":
+			return orgMembership, nil
+		case "archived":
+			return m.reinviteOrgMembershipForWorkspace(ctx, orgMembership)
+		default:
+			return repository.OrgMembershipFullRow{}, repository.ErrOrgMembershipRequired
+		}
+	}
+	if !errors.Is(err, repository.ErrMembershipNotFound) {
+		return repository.OrgMembershipFullRow{}, err
+	}
+
+	inviteToken, inviteTokenExpiresAt, err := newMembershipInviteToken()
+	if err != nil {
+		return repository.OrgMembershipFullRow{}, err
+	}
+	var entitlementGate *repository.OrganizationEntitlementGate
+	if m.entitlementGate != nil {
+		entitlementGate, err = m.entitlementGate.BuildSeatGate(ctx, orgID, false)
+		if err != nil {
+			return repository.OrgMembershipFullRow{}, err
+		}
+	}
+	return m.repo.CreateOrgMembership(ctx, repository.CreateOrgMembershipInput{
+		OrganizationID:       orgID,
+		UserID:               userID,
+		Role:                 "org_member",
+		InviteToken:          inviteToken,
+		InviteTokenExpiresAt: inviteTokenExpiresAt,
+		EntitlementGate:      entitlementGate,
+	})
+}
+
+func (m *WorkspaceMembershipManager) reinviteOrgMembershipForWorkspace(ctx context.Context, orgMembership repository.OrgMembershipFullRow) (repository.OrgMembershipFullRow, error) {
+	inviteToken, inviteTokenExpiresAt, err := newMembershipInviteToken()
+	if err != nil {
+		return repository.OrgMembershipFullRow{}, err
+	}
+	var entitlementGate *repository.OrganizationEntitlementGate
+	if m.entitlementGate != nil {
+		entitlementGate, err = m.entitlementGate.BuildSeatGate(ctx, orgMembership.OrganizationID, false)
+		if err != nil {
+			return repository.OrgMembershipFullRow{}, err
+		}
+	}
+	role := "org_member"
+	status := "invited"
+	return m.repo.UpdateOrgMembership(ctx, orgMembership.ID, repository.UpdateOrgMembershipInput{
+		Role:                 &role,
+		Status:               &status,
+		InviteToken:          &inviteToken,
+		InviteTokenExpiresAt: &inviteTokenExpiresAt,
+		EntitlementGate:      entitlementGate,
+	})
+}
+
+func (m *WorkspaceMembershipManager) ensureActiveOrgMembership(ctx context.Context, orgID, userID uuid.UUID) (repository.OrgMembershipFullRow, error) {
+	orgMembership, err := m.repo.GetOrgMembershipByOrgAndUser(ctx, orgID, userID)
+	if errors.Is(err, repository.ErrMembershipNotFound) {
+		inviteToken, inviteTokenExpiresAt, tokenErr := newMembershipInviteToken()
+		if tokenErr != nil {
+			return repository.OrgMembershipFullRow{}, tokenErr
+		}
+		var entitlementGate *repository.OrganizationEntitlementGate
+		if m.entitlementGate != nil {
+			entitlementGate, err = m.entitlementGate.BuildSeatGate(ctx, orgID, false)
+			if err != nil {
+				return repository.OrgMembershipFullRow{}, err
+			}
+		}
+		orgMembership, err = m.repo.CreateOrgMembership(ctx, repository.CreateOrgMembershipInput{
+			OrganizationID:       orgID,
+			UserID:               userID,
+			Role:                 "org_member",
+			InviteToken:          inviteToken,
+			InviteTokenExpiresAt: inviteTokenExpiresAt,
+			EntitlementGate:      entitlementGate,
+		})
+	}
+	if err != nil {
+		return repository.OrgMembershipFullRow{}, err
+	}
+	if orgMembership.MembershipStatus == "active" {
+		return orgMembership, nil
+	}
+	if orgMembership.MembershipStatus != "invited" {
+		return repository.OrgMembershipFullRow{}, repository.ErrOrgMembershipRequired
+	}
+
+	var entitlementGate *repository.OrganizationEntitlementGate
+	if m.entitlementGate != nil {
+		entitlementGate, err = m.entitlementGate.BuildSeatGate(ctx, orgID, false)
+		if err != nil {
+			return repository.OrgMembershipFullRow{}, err
+		}
+	}
+	status := "active"
+	return m.repo.UpdateOrgMembership(ctx, orgMembership.ID, repository.UpdateOrgMembershipInput{
+		Status:           &status,
+		ClearInviteToken: true,
+		EntitlementGate:  entitlementGate,
+	})
+}
+
+func wsInviteExpired(membership repository.WorkspaceMembershipFullRow) bool {
+	if membership.InviteTokenExpiresAt != nil {
+		return time.Now().After(*membership.InviteTokenExpiresAt)
+	}
+	invitedAt := membership.UpdatedAt
+	if invitedAt.IsZero() {
+		invitedAt = membership.CreatedAt
+	}
+	if invitedAt.IsZero() {
+		return false
+	}
+	return time.Since(invitedAt) > inviteExpiryDays*24*time.Hour
 }
 
 func (m *WorkspaceMembershipManager) sendInviteEmail(ctx context.Context, caller Caller, workspaceID uuid.UUID, inviteeEmail, role, acceptURL string) {
@@ -259,14 +449,12 @@ func (m *WorkspaceMembershipManager) sendInviteEmail(ctx context.Context, caller
 	}
 
 	inviterEmail := caller.Email
-	if inviterEmail == "" {
-		inviterEmail = "a team member"
-	}
 
 	if err := m.emailSender.SendInvite(ctx, email.InviteEmail{
 		To:           inviteeEmail,
 		ResourceName: workspace.Name,
 		ResourceKind: "workspace",
+		InviterName:  caller.DisplayName,
 		InviterEmail: inviterEmail,
 		Role:         role,
 		AcceptURL:    acceptURL,
@@ -357,8 +545,12 @@ func (m *WorkspaceMembershipManager) wsMembershipRowToResult(row repository.Work
 		MembershipStatus: row.MembershipStatus,
 		CreatedAt:        row.CreatedAt,
 	}
-	if includeInviteLink && row.MembershipStatus == "invited" {
-		result.AcceptURL = workspaceInviteAcceptURL(m.frontendURL, row.ID)
+	if includeInviteLink && row.MembershipStatus == "invited" && !wsInviteExpired(row) {
+		inviteToken := row.InviteToken
+		if inviteToken == "" {
+			inviteToken = row.ID.String()
+		}
+		result.AcceptURL = workspaceInviteAcceptURL(m.frontendURL, inviteToken)
 	}
 	return result
 }
@@ -494,6 +686,47 @@ func updateWorkspaceMembershipHandler(logger *slog.Logger, service WorkspaceMemb
 			Role:   req.Role,
 			Status: req.Status,
 		})
+		if err != nil {
+			handleMembershipError(w, logger, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func acceptWorkspaceInviteHandler(logger *slog.Logger, service WorkspaceMembershipService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		inviteToken := chi.URLParam(r, "inviteToken")
+		if !validInviteToken(inviteToken) {
+			writeError(w, http.StatusBadRequest, "invalid_invite_token", "invite token is malformed")
+			return
+		}
+
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+
+		var req struct {
+			Status *string `json:"status,omitempty"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body")
+			return
+		}
+		if req.Status == nil || *req.Status != "active" {
+			writeError(w, http.StatusBadRequest, "validation_error", "status must be active")
+			return
+		}
+
+		result, err := service.AcceptWorkspaceInvite(r.Context(), caller, inviteToken)
 		if err != nil {
 			handleMembershipError(w, logger, err)
 			return

--- a/backend/internal/api/workspace_memberships_test.go
+++ b/backend/internal/api/workspace_memberships_test.go
@@ -3,7 +3,9 @@ package api
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/email"
 	"github.com/agentclash/agentclash/backend/internal/repository"
@@ -17,11 +19,16 @@ type fakeWsMembershipRepo struct {
 	userErr         error
 	orgMembership   repository.OrgMembershipFullRow
 	orgMemberErr    error
+	orgCreated      repository.OrgMembershipFullRow
+	orgUpdated      repository.OrgMembershipFullRow
+	lastOrgCreate   repository.CreateOrgMembershipInput
+	lastOrgUpdate   repository.UpdateOrgMembershipInput
 	wsMembership    repository.WorkspaceMembershipFullRow
 	wsMemberErr     error
 	created         repository.WorkspaceMembershipFullRow
 	createErr       error
 	updated         repository.WorkspaceMembershipFullRow
+	lastUpdate      repository.UpdateWorkspaceMembershipInput
 	updateErr       error
 	adminCount      int64
 	memberships     []repository.WorkspaceMembershipFullRow
@@ -56,11 +63,48 @@ func (r *fakeWsMembershipRepo) GetOrgMembershipByOrgAndUser(_ context.Context, _
 	return r.orgMembership, r.orgMemberErr
 }
 
+func (r *fakeWsMembershipRepo) CreateOrgMembership(_ context.Context, input repository.CreateOrgMembershipInput) (repository.OrgMembershipFullRow, error) {
+	r.lastOrgCreate = input
+	if r.orgCreated.ID == uuid.Nil {
+		r.orgCreated = repository.OrgMembershipFullRow{
+			ID:                   uuid.New(),
+			OrganizationID:       input.OrganizationID,
+			UserID:               input.UserID,
+			Email:                r.user.Email,
+			Role:                 input.Role,
+			MembershipStatus:     "invited",
+			InviteToken:          input.InviteToken,
+			InviteTokenExpiresAt: &input.InviteTokenExpiresAt,
+		}
+	}
+	return r.orgCreated, nil
+}
+
+func (r *fakeWsMembershipRepo) UpdateOrgMembership(_ context.Context, _ uuid.UUID, input repository.UpdateOrgMembershipInput) (repository.OrgMembershipFullRow, error) {
+	r.lastOrgUpdate = input
+	if r.orgUpdated.ID != uuid.Nil {
+		return r.orgUpdated, nil
+	}
+	result := r.orgMembership
+	if input.Status != nil {
+		result.MembershipStatus = *input.Status
+	}
+	if input.ClearInviteToken {
+		result.InviteToken = ""
+		result.InviteTokenExpiresAt = nil
+	}
+	return result, nil
+}
+
 func (r *fakeWsMembershipRepo) GetWorkspaceMembershipByWorkspaceAndUser(_ context.Context, _, _ uuid.UUID) (repository.WorkspaceMembershipFullRow, error) {
 	return r.wsMembership, r.wsMemberErr
 }
 
-func (r *fakeWsMembershipRepo) CreateWorkspaceMembership(_ context.Context, _ repository.CreateWorkspaceMembershipInput) (repository.WorkspaceMembershipFullRow, error) {
+func (r *fakeWsMembershipRepo) CreateWorkspaceMembership(_ context.Context, input repository.CreateWorkspaceMembershipInput) (repository.WorkspaceMembershipFullRow, error) {
+	if r.created.InviteToken == "" {
+		r.created.InviteToken = input.InviteToken
+		r.created.InviteTokenExpiresAt = &input.InviteTokenExpiresAt
+	}
 	return r.created, r.createErr
 }
 
@@ -68,7 +112,20 @@ func (r *fakeWsMembershipRepo) GetWorkspaceMembershipByID(_ context.Context, _ u
 	return r.wsMembership, r.wsMemberErr
 }
 
-func (r *fakeWsMembershipRepo) UpdateWorkspaceMembership(_ context.Context, _ uuid.UUID, _ repository.UpdateWorkspaceMembershipInput) (repository.WorkspaceMembershipFullRow, error) {
+func (r *fakeWsMembershipRepo) GetWorkspaceMembershipByInviteToken(_ context.Context, _ string) (repository.WorkspaceMembershipFullRow, error) {
+	return r.wsMembership, r.wsMemberErr
+}
+
+func (r *fakeWsMembershipRepo) UpdateWorkspaceMembership(_ context.Context, _ uuid.UUID, input repository.UpdateWorkspaceMembershipInput) (repository.WorkspaceMembershipFullRow, error) {
+	r.lastUpdate = input
+	if input.InviteToken != nil && r.updated.InviteToken == "" {
+		r.updated.InviteToken = *input.InviteToken
+		r.updated.InviteTokenExpiresAt = input.InviteTokenExpiresAt
+	}
+	if input.ClearInviteToken {
+		r.updated.InviteToken = ""
+		r.updated.InviteTokenExpiresAt = nil
+	}
 	return r.updated, r.updateErr
 }
 
@@ -122,8 +179,9 @@ func TestInviteWorkspaceMember_SendsEmail(t *testing.T) {
 	manager := NewWorkspaceMembershipManager(repo, sender, "https://app.agentclash.dev")
 
 	caller := Caller{
-		UserID: uuid.New(),
-		Email:  "admin@example.com",
+		UserID:      uuid.New(),
+		Email:       "admin@example.com",
+		DisplayName: "Atharva",
 		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
 			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_admin"},
 		},
@@ -144,9 +202,9 @@ func TestInviteWorkspaceMember_SendsEmail(t *testing.T) {
 	if sent.To != "invitee@example.com" {
 		t.Errorf("email To = %q, want invitee@example.com", sent.To)
 	}
-	wantAcceptURL := "https://app.agentclash.dev/invites/workspace/" + result.ID.String()
-	if result.AcceptURL != wantAcceptURL {
-		t.Errorf("result AcceptURL = %q, want %q", result.AcceptURL, wantAcceptURL)
+	wantAcceptURLPrefix := "https://app.agentclash.dev/invites/workspace/invite_"
+	if !strings.HasPrefix(result.AcceptURL, wantAcceptURLPrefix) {
+		t.Errorf("result AcceptURL = %q, want prefix %q", result.AcceptURL, wantAcceptURLPrefix)
 	}
 	if sent.ResourceName != "Test Workspace" {
 		t.Errorf("email ResourceName = %q, want Test Workspace", sent.ResourceName)
@@ -154,14 +212,182 @@ func TestInviteWorkspaceMember_SendsEmail(t *testing.T) {
 	if sent.ResourceKind != "workspace" {
 		t.Errorf("email ResourceKind = %q, want workspace", sent.ResourceKind)
 	}
+	if sent.InviterName != "Atharva" {
+		t.Errorf("email InviterName = %q, want Atharva", sent.InviterName)
+	}
 	if sent.InviterEmail != "admin@example.com" {
 		t.Errorf("email InviterEmail = %q, want admin@example.com", sent.InviterEmail)
 	}
 	if sent.Role != "workspace_member" {
 		t.Errorf("email Role = %q, want workspace_member", sent.Role)
 	}
-	if sent.AcceptURL != wantAcceptURL {
-		t.Errorf("email AcceptURL = %q, want %q", sent.AcceptURL, wantAcceptURL)
+	if sent.AcceptURL != result.AcceptURL {
+		t.Errorf("email AcceptURL = %q, want %q", sent.AcceptURL, result.AcceptURL)
+	}
+}
+
+func TestAcceptWorkspaceInviteLink_ReassignsPendingInviteToCaller(t *testing.T) {
+	workspaceID := uuid.New()
+	orgID := uuid.New()
+	invitedUserID := uuid.New()
+	callerUserID := uuid.New()
+	membershipID := uuid.New()
+	now := time.Now()
+
+	repo := &fakeWsMembershipRepo{
+		orgID: orgID,
+		wsMembership: repository.WorkspaceMembershipFullRow{
+			ID:               membershipID,
+			WorkspaceID:      workspaceID,
+			OrganizationID:   orgID,
+			UserID:           invitedUserID,
+			Email:            "friend@example.com",
+			Role:             "workspace_member",
+			MembershipStatus: "invited",
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		},
+		updated: repository.WorkspaceMembershipFullRow{
+			ID:               membershipID,
+			WorkspaceID:      workspaceID,
+			OrganizationID:   orgID,
+			UserID:           callerUserID,
+			Email:            "friend@example.com",
+			Role:             "workspace_member",
+			MembershipStatus: "active",
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		},
+	}
+	manager := NewWorkspaceMembershipManager(repo, &fakeEmailSender{}, "https://app.agentclash.dev")
+	status := "active"
+
+	result, err := manager.UpdateWorkspaceMembership(context.Background(), Caller{UserID: callerUserID, Email: "friend@example.com"}, membershipID, UpdateWorkspaceMembershipInput{
+		Status: &status,
+	})
+	if err != nil {
+		t.Fatalf("UpdateWorkspaceMembership returned error: %v", err)
+	}
+
+	if repo.lastUpdate.UserID == nil || *repo.lastUpdate.UserID != callerUserID {
+		t.Fatalf("UpdateWorkspaceMembership UserID = %v, want %s", repo.lastUpdate.UserID, callerUserID)
+	}
+	if result.UserID != callerUserID {
+		t.Fatalf("result UserID = %s, want %s", result.UserID, callerUserID)
+	}
+	if result.MembershipStatus != "active" {
+		t.Fatalf("result status = %q, want active", result.MembershipStatus)
+	}
+	if !repo.lastUpdate.ClearInviteToken {
+		t.Fatalf("ClearInviteToken = false, want true")
+	}
+}
+
+func TestAcceptWorkspaceInviteToken_ActivatesOrgAndWorkspaceMemberships(t *testing.T) {
+	workspaceID := uuid.New()
+	orgID := uuid.New()
+	userID := uuid.New()
+	membershipID := uuid.New()
+	orgMembershipID := uuid.New()
+	expiresAt := time.Now().Add(time.Hour)
+
+	repo := &fakeWsMembershipRepo{
+		orgID: orgID,
+		orgMembership: repository.OrgMembershipFullRow{
+			ID:               orgMembershipID,
+			OrganizationID:   orgID,
+			UserID:           userID,
+			Email:            "friend@example.com",
+			Role:             "org_member",
+			MembershipStatus: "invited",
+		},
+		wsMembership: repository.WorkspaceMembershipFullRow{
+			ID:                   membershipID,
+			WorkspaceID:          workspaceID,
+			OrganizationID:       orgID,
+			UserID:               userID,
+			Email:                "friend@example.com",
+			Role:                 "workspace_member",
+			MembershipStatus:     "invited",
+			InviteToken:          "invite_testtoken",
+			InviteTokenExpiresAt: &expiresAt,
+		},
+		updated: repository.WorkspaceMembershipFullRow{
+			ID:               membershipID,
+			WorkspaceID:      workspaceID,
+			OrganizationID:   orgID,
+			UserID:           userID,
+			Email:            "friend@example.com",
+			Role:             "workspace_member",
+			MembershipStatus: "active",
+		},
+	}
+	manager := NewWorkspaceMembershipManager(repo, &fakeEmailSender{}, "https://app.agentclash.dev")
+
+	result, err := manager.AcceptWorkspaceInvite(context.Background(), Caller{UserID: userID, Email: "friend@example.com"}, "invite_testtoken")
+	if err != nil {
+		t.Fatalf("AcceptWorkspaceInvite returned error: %v", err)
+	}
+
+	if repo.lastOrgUpdate.Status == nil || *repo.lastOrgUpdate.Status != "active" {
+		t.Fatalf("org update status = %v, want active", repo.lastOrgUpdate.Status)
+	}
+	if !repo.lastOrgUpdate.ClearInviteToken {
+		t.Fatalf("org ClearInviteToken = false, want true")
+	}
+	if !repo.lastUpdate.ClearInviteToken {
+		t.Fatalf("workspace ClearInviteToken = false, want true")
+	}
+	if result.MembershipStatus != "active" {
+		t.Fatalf("result status = %q, want active", result.MembershipStatus)
+	}
+}
+
+func TestInviteWorkspaceMember_CreatesMissingOrgInvite(t *testing.T) {
+	workspaceID := uuid.New()
+	userID := uuid.New()
+	orgID := uuid.New()
+
+	repo := &fakeWsMembershipRepo{
+		orgID:        orgID,
+		workspace:    repository.WorkspaceRow{ID: workspaceID, Name: "Test Workspace"},
+		user:         repository.User{ID: userID, Email: "invitee@example.com"},
+		orgMemberErr: repository.ErrMembershipNotFound,
+		wsMemberErr:  repository.ErrMembershipNotFound,
+		created: repository.WorkspaceMembershipFullRow{
+			ID:               uuid.New(),
+			WorkspaceID:      workspaceID,
+			OrganizationID:   orgID,
+			UserID:           userID,
+			Email:            "invitee@example.com",
+			Role:             "workspace_member",
+			MembershipStatus: "invited",
+		},
+	}
+	manager := NewWorkspaceMembershipManager(repo, &fakeEmailSender{}, "https://app.agentclash.dev")
+	caller := Caller{
+		UserID: uuid.New(),
+		Email:  "admin@example.com",
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_admin"},
+		},
+	}
+
+	_, err := manager.InviteWorkspaceMember(context.Background(), caller, workspaceID, InviteWorkspaceMemberInput{
+		Email: "invitee@example.com",
+		Role:  "workspace_member",
+	})
+	if err != nil {
+		t.Fatalf("InviteWorkspaceMember returned error: %v", err)
+	}
+	if repo.lastOrgCreate.UserID != userID {
+		t.Fatalf("org invite user = %s, want %s", repo.lastOrgCreate.UserID, userID)
+	}
+	if repo.lastOrgCreate.Role != "org_member" {
+		t.Fatalf("org invite role = %q, want org_member", repo.lastOrgCreate.Role)
+	}
+	if !strings.HasPrefix(repo.lastOrgCreate.InviteToken, "invite_") {
+		t.Fatalf("org invite token = %q, want invite_ prefix", repo.lastOrgCreate.InviteToken)
 	}
 }
 
@@ -236,6 +462,7 @@ func TestListWorkspaceMemberships_InviteLinksOnlyForAdmins(t *testing.T) {
 				Email:            "invitee@example.com",
 				Role:             "workspace_member",
 				MembershipStatus: "invited",
+				InviteToken:      "invite_testtoken",
 			},
 		},
 		membershipCount: 1,
@@ -266,7 +493,7 @@ func TestListWorkspaceMemberships_InviteLinksOnlyForAdmins(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListWorkspaceMemberships returned error for admin: %v", err)
 	}
-	wantAcceptURL := "https://app.agentclash.dev/invites/workspace/" + membershipID.String()
+	wantAcceptURL := "https://app.agentclash.dev/invites/workspace/invite_testtoken"
 	if got := adminResult.Items[0].AcceptURL; got != wantAcceptURL {
 		t.Fatalf("admin caller AcceptURL = %q, want %q", got, wantAcceptURL)
 	}

--- a/backend/internal/email/email.go
+++ b/backend/internal/email/email.go
@@ -23,6 +23,7 @@ type InviteEmail struct {
 	To           string
 	ResourceName string
 	ResourceKind string
+	InviterName  string
 	InviterEmail string
 	Role         string
 	AcceptURL    string
@@ -85,8 +86,8 @@ func buildInviteHTML(input InviteEmail) string {
 	}
 	resourceKind = html.EscapeString(resourceKind)
 	resourceName := html.EscapeString(input.ResourceName)
-	inviterEmail := html.EscapeString(input.InviterEmail)
-	role := html.EscapeString(input.Role)
+	inviterLabel := html.EscapeString(inviteInviterLabel(input))
+	role := html.EscapeString(inviteRoleLabel(input.Role))
 	acceptURL := html.EscapeString(input.AcceptURL)
 
 	return fmt.Sprintf(`<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:480px;margin:0 auto;padding:32px 0">
@@ -109,7 +110,30 @@ func buildInviteHTML(input InviteEmail) string {
   <p style="color:#999;font-size:12px;margin:24px 0 0">
     If you didn't expect this invitation, you can ignore this email.
   </p>
-</div>`, resourceName, inviterEmail, resourceKind, role, acceptURL, acceptURL, acceptURL)
+</div>`, resourceName, inviterLabel, resourceKind, role, acceptURL, acceptURL, acceptURL)
+}
+
+func inviteInviterLabel(input InviteEmail) string {
+	if name := strings.TrimSpace(input.InviterName); name != "" {
+		return name
+	}
+	if email := strings.TrimSpace(input.InviterEmail); email != "" {
+		return email
+	}
+	return "An AgentClash admin"
+}
+
+func inviteRoleLabel(role string) string {
+	switch strings.TrimSpace(role) {
+	case "org_admin", "workspace_admin":
+		return "Admin"
+	case "org_member", "workspace_member":
+		return "Member"
+	case "workspace_viewer":
+		return "Viewer"
+	default:
+		return strings.TrimSpace(role)
+	}
 }
 
 // NoopSender logs invite emails without sending them.

--- a/backend/internal/email/email_test.go
+++ b/backend/internal/email/email_test.go
@@ -25,15 +25,38 @@ func TestBuildInviteHTML_ContainsKeyFields(t *testing.T) {
 		To:           "test@example.com",
 		ResourceName: "Eval Team",
 		ResourceKind: "workspace",
+		InviterName:  "Alice",
 		InviterEmail: "alice@example.com",
 		Role:         "workspace_admin",
 		AcceptURL:    "https://app.agentclash.dev/invites/workspace/membership-id",
 	})
 
-	for _, want := range []string{"Eval Team", "alice@example.com", "workspace_admin", "https://app.agentclash.dev/invites/workspace/membership-id", "copy and paste", "7 days"} {
+	for _, want := range []string{"Eval Team", "Alice", "Admin", "https://app.agentclash.dev/invites/workspace/membership-id", "copy and paste", "7 days"} {
 		if !contains(html, want) {
 			t.Errorf("invite HTML missing %q", want)
 		}
+	}
+	if contains(html, "workspace_admin") {
+		t.Errorf("invite HTML should not expose raw role")
+	}
+}
+
+func TestBuildInviteHTML_UsesFriendlyFallbackInviter(t *testing.T) {
+	html := buildInviteHTML(InviteEmail{
+		To:           "test@example.com",
+		ResourceName: "Eval Team",
+		ResourceKind: "organization",
+		Role:         "org_member",
+		AcceptURL:    "https://app.agentclash.dev/invites/organization/membership-id",
+	})
+
+	for _, want := range []string{"An AgentClash admin", "Member"} {
+		if !contains(html, want) {
+			t.Errorf("invite HTML missing %q", want)
+		}
+	}
+	if contains(html, "org_member") {
+		t.Errorf("invite HTML should not expose raw role")
 	}
 }
 

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -2743,53 +2743,69 @@ type UpdateWorkspaceInput struct {
 }
 
 type OrgMembershipFullRow struct {
-	ID               uuid.UUID
-	OrganizationID   uuid.UUID
-	UserID           uuid.UUID
-	Email            string
-	DisplayName      string
-	Role             string
-	MembershipStatus string
-	CreatedAt        time.Time
-	UpdatedAt        time.Time // set by DB trigger on every UPDATE
+	ID                   uuid.UUID
+	OrganizationID       uuid.UUID
+	UserID               uuid.UUID
+	Email                string
+	DisplayName          string
+	Role                 string
+	MembershipStatus     string
+	InviteToken          string
+	InviteTokenExpiresAt *time.Time
+	CreatedAt            time.Time
+	UpdatedAt            time.Time // set by DB trigger on every UPDATE
 }
 
 type CreateOrgMembershipInput struct {
-	OrganizationID  uuid.UUID
-	UserID          uuid.UUID
-	Role            string
-	EntitlementGate *OrganizationEntitlementGate
+	OrganizationID       uuid.UUID
+	UserID               uuid.UUID
+	Role                 string
+	InviteToken          string
+	InviteTokenExpiresAt time.Time
+	EntitlementGate      *OrganizationEntitlementGate
 }
 
 type UpdateOrgMembershipInput struct {
-	Role            *string
-	Status          *string
-	EntitlementGate *OrganizationEntitlementGate
+	Role                 *string
+	Status               *string
+	UserID               *uuid.UUID
+	InviteToken          *string
+	InviteTokenExpiresAt *time.Time
+	ClearInviteToken     bool
+	EntitlementGate      *OrganizationEntitlementGate
 }
 
 type WorkspaceMembershipFullRow struct {
-	ID               uuid.UUID
-	WorkspaceID      uuid.UUID
-	OrganizationID   uuid.UUID
-	UserID           uuid.UUID
-	Email            string
-	DisplayName      string
-	Role             string
-	MembershipStatus string
-	CreatedAt        time.Time
-	UpdatedAt        time.Time
+	ID                   uuid.UUID
+	WorkspaceID          uuid.UUID
+	OrganizationID       uuid.UUID
+	UserID               uuid.UUID
+	Email                string
+	DisplayName          string
+	Role                 string
+	MembershipStatus     string
+	InviteToken          string
+	InviteTokenExpiresAt *time.Time
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
 }
 
 type CreateWorkspaceMembershipInput struct {
-	OrganizationID uuid.UUID
-	WorkspaceID    uuid.UUID
-	UserID         uuid.UUID
-	Role           string
+	OrganizationID       uuid.UUID
+	WorkspaceID          uuid.UUID
+	UserID               uuid.UUID
+	Role                 string
+	InviteToken          string
+	InviteTokenExpiresAt time.Time
 }
 
 type UpdateWorkspaceMembershipInput struct {
-	Role   *string
-	Status *string
+	Role                 *string
+	Status               *string
+	UserID               *uuid.UUID
+	InviteToken          *string
+	InviteTokenExpiresAt *time.Time
+	ClearInviteToken     bool
 }
 
 type OnboardInput struct {
@@ -3196,7 +3212,8 @@ func (r *Repository) ListWorkspaceMemberships(ctx context.Context, workspaceID u
 	rows, err := r.db.Query(ctx, `
 		SELECT wm.id, wm.workspace_id, wm.organization_id, wm.user_id,
 		       u.email, COALESCE(u.display_name, ''),
-		       wm.role, wm.membership_status, wm.created_at, wm.updated_at
+		       wm.role, wm.membership_status, COALESCE(wm.invite_token, ''),
+		       wm.invite_token_expires_at, wm.created_at, wm.updated_at
 		FROM workspace_memberships wm
 		JOIN users u ON u.id = wm.user_id
 		WHERE wm.workspace_id = $1 AND wm.membership_status IN ('active', 'invited')
@@ -3211,10 +3228,13 @@ func (r *Repository) ListWorkspaceMemberships(ctx context.Context, workspaceID u
 	var memberships []WorkspaceMembershipFullRow
 	for rows.Next() {
 		var m WorkspaceMembershipFullRow
+		var inviteTokenExpiresAt pgtype.Timestamptz
 		if err := rows.Scan(&m.ID, &m.WorkspaceID, &m.OrganizationID, &m.UserID,
-			&m.Email, &m.DisplayName, &m.Role, &m.MembershipStatus, &m.CreatedAt, &m.UpdatedAt); err != nil {
+			&m.Email, &m.DisplayName, &m.Role, &m.MembershipStatus, &m.InviteToken,
+			&inviteTokenExpiresAt, &m.CreatedAt, &m.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan workspace membership: %w", err)
 		}
+		m.InviteTokenExpiresAt = optionalTime(inviteTokenExpiresAt)
 		memberships = append(memberships, m)
 	}
 	if err := rows.Err(); err != nil {
@@ -3240,32 +3260,42 @@ func (r *Repository) CountWorkspaceMemberships(ctx context.Context, workspaceID 
 
 func (r *Repository) GetWorkspaceMembershipByWorkspaceAndUser(ctx context.Context, workspaceID, userID uuid.UUID) (WorkspaceMembershipFullRow, error) {
 	var m WorkspaceMembershipFullRow
+	var inviteTokenExpiresAt pgtype.Timestamptz
 	err := r.db.QueryRow(ctx, `
 		SELECT wm.id, wm.workspace_id, wm.organization_id, wm.user_id,
 		       u.email, COALESCE(u.display_name, ''),
-		       wm.role, wm.membership_status, wm.created_at, wm.updated_at
+		       wm.role, wm.membership_status, COALESCE(wm.invite_token, ''),
+		       wm.invite_token_expires_at, wm.created_at, wm.updated_at
 		FROM workspace_memberships wm
 		JOIN users u ON u.id = wm.user_id
 		WHERE wm.workspace_id = $1 AND wm.user_id = $2
 	`, workspaceID, userID).Scan(&m.ID, &m.WorkspaceID, &m.OrganizationID, &m.UserID,
-		&m.Email, &m.DisplayName, &m.Role, &m.MembershipStatus, &m.CreatedAt, &m.UpdatedAt)
+		&m.Email, &m.DisplayName, &m.Role, &m.MembershipStatus, &m.InviteToken,
+		&inviteTokenExpiresAt, &m.CreatedAt, &m.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return WorkspaceMembershipFullRow{}, ErrMembershipNotFound
 		}
 		return WorkspaceMembershipFullRow{}, fmt.Errorf("get workspace membership by workspace and user: %w", err)
 	}
+	m.InviteTokenExpiresAt = optionalTime(inviteTokenExpiresAt)
 	return m, nil
 }
 
 func (r *Repository) CreateWorkspaceMembership(ctx context.Context, input CreateWorkspaceMembershipInput) (WorkspaceMembershipFullRow, error) {
 	var m WorkspaceMembershipFullRow
+	var inviteTokenExpiresAt pgtype.Timestamptz
 	err := r.db.QueryRow(ctx, `
-		INSERT INTO workspace_memberships (id, organization_id, workspace_id, user_id, role, membership_status)
-		VALUES (gen_random_uuid(), $1, $2, $3, $4, 'invited')
-		RETURNING id, organization_id, workspace_id, user_id, role, membership_status, created_at, updated_at
-	`, input.OrganizationID, input.WorkspaceID, input.UserID, input.Role).Scan(
-		&m.ID, &m.OrganizationID, &m.WorkspaceID, &m.UserID, &m.Role, &m.MembershipStatus, &m.CreatedAt, &m.UpdatedAt,
+		INSERT INTO workspace_memberships (
+			id, organization_id, workspace_id, user_id, role, membership_status,
+			invite_token, invite_token_expires_at
+		)
+		VALUES (gen_random_uuid(), $1, $2, $3, $4, 'invited', $5, $6)
+		RETURNING id, organization_id, workspace_id, user_id, role, membership_status,
+		          COALESCE(invite_token, ''), invite_token_expires_at, created_at, updated_at
+	`, input.OrganizationID, input.WorkspaceID, input.UserID, input.Role, input.InviteToken, input.InviteTokenExpiresAt).Scan(
+		&m.ID, &m.OrganizationID, &m.WorkspaceID, &m.UserID, &m.Role, &m.MembershipStatus,
+		&m.InviteToken, &inviteTokenExpiresAt, &m.CreatedAt, &m.UpdatedAt,
 	)
 	if err != nil {
 		var pgErr *pgconn.PgError
@@ -3274,6 +3304,7 @@ func (r *Repository) CreateWorkspaceMembership(ctx context.Context, input Create
 		}
 		return WorkspaceMembershipFullRow{}, fmt.Errorf("create workspace membership: %w", err)
 	}
+	m.InviteTokenExpiresAt = optionalTime(inviteTokenExpiresAt)
 
 	var user User
 	if err = r.db.QueryRow(ctx, `SELECT email, COALESCE(display_name, '') FROM users WHERE id = $1`, input.UserID).Scan(&user.Email, &user.DisplayName); err != nil {
@@ -3287,21 +3318,49 @@ func (r *Repository) CreateWorkspaceMembership(ctx context.Context, input Create
 
 func (r *Repository) GetWorkspaceMembershipByID(ctx context.Context, membershipID uuid.UUID) (WorkspaceMembershipFullRow, error) {
 	var m WorkspaceMembershipFullRow
+	var inviteTokenExpiresAt pgtype.Timestamptz
 	err := r.db.QueryRow(ctx, `
 		SELECT wm.id, wm.workspace_id, wm.organization_id, wm.user_id,
 		       u.email, COALESCE(u.display_name, ''),
-		       wm.role, wm.membership_status, wm.created_at, wm.updated_at
+		       wm.role, wm.membership_status, COALESCE(wm.invite_token, ''),
+		       wm.invite_token_expires_at, wm.created_at, wm.updated_at
 		FROM workspace_memberships wm
 		JOIN users u ON u.id = wm.user_id
 		WHERE wm.id = $1
 	`, membershipID).Scan(&m.ID, &m.WorkspaceID, &m.OrganizationID, &m.UserID,
-		&m.Email, &m.DisplayName, &m.Role, &m.MembershipStatus, &m.CreatedAt, &m.UpdatedAt)
+		&m.Email, &m.DisplayName, &m.Role, &m.MembershipStatus, &m.InviteToken,
+		&inviteTokenExpiresAt, &m.CreatedAt, &m.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return WorkspaceMembershipFullRow{}, ErrMembershipNotFound
 		}
 		return WorkspaceMembershipFullRow{}, fmt.Errorf("get workspace membership by id: %w", err)
 	}
+	m.InviteTokenExpiresAt = optionalTime(inviteTokenExpiresAt)
+	return m, nil
+}
+
+func (r *Repository) GetWorkspaceMembershipByInviteToken(ctx context.Context, inviteToken string) (WorkspaceMembershipFullRow, error) {
+	var m WorkspaceMembershipFullRow
+	var inviteTokenExpiresAt pgtype.Timestamptz
+	err := r.db.QueryRow(ctx, `
+		SELECT wm.id, wm.workspace_id, wm.organization_id, wm.user_id,
+		       u.email, COALESCE(u.display_name, ''),
+		       wm.role, wm.membership_status, COALESCE(wm.invite_token, ''),
+		       wm.invite_token_expires_at, wm.created_at, wm.updated_at
+		FROM workspace_memberships wm
+		JOIN users u ON u.id = wm.user_id
+		WHERE wm.invite_token = $1 AND wm.membership_status = 'invited'
+	`, inviteToken).Scan(&m.ID, &m.WorkspaceID, &m.OrganizationID, &m.UserID,
+		&m.Email, &m.DisplayName, &m.Role, &m.MembershipStatus, &m.InviteToken,
+		&inviteTokenExpiresAt, &m.CreatedAt, &m.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return WorkspaceMembershipFullRow{}, ErrMembershipNotFound
+		}
+		return WorkspaceMembershipFullRow{}, fmt.Errorf("get workspace membership by invite token: %w", err)
+	}
+	m.InviteTokenExpiresAt = optionalTime(inviteTokenExpiresAt)
 	return m, nil
 }
 
@@ -3327,6 +3386,21 @@ func (r *Repository) UpdateWorkspaceMembership(ctx context.Context, membershipID
 			setClauses = append(setClauses, "archived_at = NULL")
 		}
 	}
+	if input.UserID != nil {
+		setClauses = append(setClauses, fmt.Sprintf("user_id = $%d", argIdx))
+		args = append(args, *input.UserID)
+		argIdx++
+	}
+	if input.ClearInviteToken {
+		setClauses = append(setClauses, "invite_token = NULL", "invite_token_expires_at = NULL")
+	} else if input.InviteToken != nil {
+		setClauses = append(setClauses, fmt.Sprintf("invite_token = $%d", argIdx))
+		args = append(args, *input.InviteToken)
+		argIdx++
+		setClauses = append(setClauses, fmt.Sprintf("invite_token_expires_at = $%d", argIdx))
+		args = append(args, input.InviteTokenExpiresAt)
+		argIdx++
+	}
 
 	if len(setClauses) == 0 {
 		return r.GetWorkspaceMembershipByID(ctx, membershipID)
@@ -3335,20 +3409,33 @@ func (r *Repository) UpdateWorkspaceMembership(ctx context.Context, membershipID
 	query := fmt.Sprintf(`
 		UPDATE workspace_memberships SET %s
 		WHERE id = $%d
-		RETURNING id, organization_id, workspace_id, user_id, role, membership_status, created_at, updated_at
+		RETURNING id, organization_id, workspace_id, user_id, role, membership_status,
+		          COALESCE(invite_token, ''), invite_token_expires_at, created_at, updated_at
 	`, strings.Join(setClauses, ", "), argIdx)
 	args = append(args, membershipID)
 
 	var m WorkspaceMembershipFullRow
+	var inviteTokenExpiresAt pgtype.Timestamptz
 	err := r.db.QueryRow(ctx, query, args...).Scan(
-		&m.ID, &m.OrganizationID, &m.WorkspaceID, &m.UserID, &m.Role, &m.MembershipStatus, &m.CreatedAt, &m.UpdatedAt,
+		&m.ID, &m.OrganizationID, &m.WorkspaceID, &m.UserID, &m.Role, &m.MembershipStatus,
+		&m.InviteToken, &inviteTokenExpiresAt, &m.CreatedAt, &m.UpdatedAt,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return WorkspaceMembershipFullRow{}, ErrMembershipNotFound
 		}
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) {
+			switch pgErr.Code {
+			case "23505":
+				return WorkspaceMembershipFullRow{}, ErrAlreadyMember
+			case "23503":
+				return WorkspaceMembershipFullRow{}, ErrOrgMembershipRequired
+			}
+		}
 		return WorkspaceMembershipFullRow{}, fmt.Errorf("update workspace membership: %w", err)
 	}
+	m.InviteTokenExpiresAt = optionalTime(inviteTokenExpiresAt)
 
 	var user User
 	if err = r.db.QueryRow(ctx, `SELECT email, COALESCE(display_name, '') FROM users WHERE id = $1`, m.UserID).Scan(&user.Email, &user.DisplayName); err != nil {
@@ -3392,7 +3479,8 @@ func (r *Repository) GetUserByEmail(ctx context.Context, email string) (User, er
 func (r *Repository) ListOrgMemberships(ctx context.Context, orgID uuid.UUID, limit, offset int32) ([]OrgMembershipFullRow, error) {
 	rows, err := r.db.Query(ctx, `
 		SELECT om.id, om.organization_id, om.user_id, u.email, COALESCE(u.display_name, ''),
-		       om.role, om.membership_status, om.created_at, om.updated_at
+		       om.role, om.membership_status, COALESCE(om.invite_token, ''),
+		       om.invite_token_expires_at, om.created_at, om.updated_at
 		FROM organization_memberships om
 		JOIN users u ON u.id = om.user_id
 		WHERE om.organization_id = $1 AND om.membership_status IN ('active', 'invited')
@@ -3407,10 +3495,13 @@ func (r *Repository) ListOrgMemberships(ctx context.Context, orgID uuid.UUID, li
 	var memberships []OrgMembershipFullRow
 	for rows.Next() {
 		var m OrgMembershipFullRow
+		var inviteTokenExpiresAt pgtype.Timestamptz
 		if err := rows.Scan(&m.ID, &m.OrganizationID, &m.UserID, &m.Email, &m.DisplayName,
-			&m.Role, &m.MembershipStatus, &m.CreatedAt, &m.UpdatedAt); err != nil {
+			&m.Role, &m.MembershipStatus, &m.InviteToken, &inviteTokenExpiresAt,
+			&m.CreatedAt, &m.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan org membership: %w", err)
 		}
+		m.InviteTokenExpiresAt = optionalTime(inviteTokenExpiresAt)
 		memberships = append(memberships, m)
 	}
 	if err := rows.Err(); err != nil {
@@ -3436,20 +3527,23 @@ func (r *Repository) CountOrgMemberships(ctx context.Context, orgID uuid.UUID) (
 
 func (r *Repository) GetOrgMembershipByOrgAndUser(ctx context.Context, orgID, userID uuid.UUID) (OrgMembershipFullRow, error) {
 	var m OrgMembershipFullRow
+	var inviteTokenExpiresAt pgtype.Timestamptz
 	err := r.db.QueryRow(ctx, `
 		SELECT om.id, om.organization_id, om.user_id, u.email, COALESCE(u.display_name, ''),
-		       om.role, om.membership_status, om.created_at, om.updated_at
+		       om.role, om.membership_status, COALESCE(om.invite_token, ''),
+		       om.invite_token_expires_at, om.created_at, om.updated_at
 		FROM organization_memberships om
 		JOIN users u ON u.id = om.user_id
 		WHERE om.organization_id = $1 AND om.user_id = $2
 	`, orgID, userID).Scan(&m.ID, &m.OrganizationID, &m.UserID, &m.Email, &m.DisplayName,
-		&m.Role, &m.MembershipStatus, &m.CreatedAt, &m.UpdatedAt)
+		&m.Role, &m.MembershipStatus, &m.InviteToken, &inviteTokenExpiresAt, &m.CreatedAt, &m.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return OrgMembershipFullRow{}, ErrMembershipNotFound
 		}
 		return OrgMembershipFullRow{}, fmt.Errorf("get org membership by org and user: %w", err)
 	}
+	m.InviteTokenExpiresAt = optionalTime(inviteTokenExpiresAt)
 	return m, nil
 }
 
@@ -3465,12 +3559,18 @@ func (r *Repository) CreateOrgMembership(ctx context.Context, input CreateOrgMem
 	}
 
 	var m OrgMembershipFullRow
+	var inviteTokenExpiresAt pgtype.Timestamptz
 	err = tx.QueryRow(ctx, `
-		INSERT INTO organization_memberships (id, organization_id, user_id, role, membership_status)
-		VALUES (gen_random_uuid(), $1, $2, $3, 'invited')
-		RETURNING id, organization_id, user_id, role, membership_status, created_at, updated_at
-	`, input.OrganizationID, input.UserID, input.Role).Scan(
-		&m.ID, &m.OrganizationID, &m.UserID, &m.Role, &m.MembershipStatus, &m.CreatedAt, &m.UpdatedAt,
+		INSERT INTO organization_memberships (
+			id, organization_id, user_id, role, membership_status,
+			invite_token, invite_token_expires_at
+		)
+		VALUES (gen_random_uuid(), $1, $2, $3, 'invited', $4, $5)
+		RETURNING id, organization_id, user_id, role, membership_status,
+		          COALESCE(invite_token, ''), invite_token_expires_at, created_at, updated_at
+	`, input.OrganizationID, input.UserID, input.Role, input.InviteToken, input.InviteTokenExpiresAt).Scan(
+		&m.ID, &m.OrganizationID, &m.UserID, &m.Role, &m.MembershipStatus,
+		&m.InviteToken, &inviteTokenExpiresAt, &m.CreatedAt, &m.UpdatedAt,
 	)
 	if err != nil {
 		var pgErr *pgconn.PgError
@@ -3479,6 +3579,7 @@ func (r *Repository) CreateOrgMembership(ctx context.Context, input CreateOrgMem
 		}
 		return OrgMembershipFullRow{}, fmt.Errorf("create org membership: %w", err)
 	}
+	m.InviteTokenExpiresAt = optionalTime(inviteTokenExpiresAt)
 
 	// Fetch user details to fill the response.
 	var user User
@@ -3495,20 +3596,45 @@ func (r *Repository) CreateOrgMembership(ctx context.Context, input CreateOrgMem
 
 func (r *Repository) GetOrgMembershipByID(ctx context.Context, membershipID uuid.UUID) (OrgMembershipFullRow, error) {
 	var m OrgMembershipFullRow
+	var inviteTokenExpiresAt pgtype.Timestamptz
 	err := r.db.QueryRow(ctx, `
 		SELECT om.id, om.organization_id, om.user_id, u.email, COALESCE(u.display_name, ''),
-		       om.role, om.membership_status, om.created_at, om.updated_at
+		       om.role, om.membership_status, COALESCE(om.invite_token, ''),
+		       om.invite_token_expires_at, om.created_at, om.updated_at
 		FROM organization_memberships om
 		JOIN users u ON u.id = om.user_id
 		WHERE om.id = $1
 	`, membershipID).Scan(&m.ID, &m.OrganizationID, &m.UserID, &m.Email, &m.DisplayName,
-		&m.Role, &m.MembershipStatus, &m.CreatedAt, &m.UpdatedAt)
+		&m.Role, &m.MembershipStatus, &m.InviteToken, &inviteTokenExpiresAt, &m.CreatedAt, &m.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return OrgMembershipFullRow{}, ErrMembershipNotFound
 		}
 		return OrgMembershipFullRow{}, fmt.Errorf("get org membership by id: %w", err)
 	}
+	m.InviteTokenExpiresAt = optionalTime(inviteTokenExpiresAt)
+	return m, nil
+}
+
+func (r *Repository) GetOrgMembershipByInviteToken(ctx context.Context, inviteToken string) (OrgMembershipFullRow, error) {
+	var m OrgMembershipFullRow
+	var inviteTokenExpiresAt pgtype.Timestamptz
+	err := r.db.QueryRow(ctx, `
+		SELECT om.id, om.organization_id, om.user_id, u.email, COALESCE(u.display_name, ''),
+		       om.role, om.membership_status, COALESCE(om.invite_token, ''),
+		       om.invite_token_expires_at, om.created_at, om.updated_at
+		FROM organization_memberships om
+		JOIN users u ON u.id = om.user_id
+		WHERE om.invite_token = $1 AND om.membership_status = 'invited'
+	`, inviteToken).Scan(&m.ID, &m.OrganizationID, &m.UserID, &m.Email, &m.DisplayName,
+		&m.Role, &m.MembershipStatus, &m.InviteToken, &inviteTokenExpiresAt, &m.CreatedAt, &m.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return OrgMembershipFullRow{}, ErrMembershipNotFound
+		}
+		return OrgMembershipFullRow{}, fmt.Errorf("get org membership by invite token: %w", err)
+	}
+	m.InviteTokenExpiresAt = optionalTime(inviteTokenExpiresAt)
 	return m, nil
 }
 
@@ -3534,6 +3660,21 @@ func (r *Repository) UpdateOrgMembership(ctx context.Context, membershipID uuid.
 			setClauses = append(setClauses, "archived_at = NULL")
 		}
 	}
+	if input.UserID != nil {
+		setClauses = append(setClauses, fmt.Sprintf("user_id = $%d", argIdx))
+		args = append(args, *input.UserID)
+		argIdx++
+	}
+	if input.ClearInviteToken {
+		setClauses = append(setClauses, "invite_token = NULL", "invite_token_expires_at = NULL")
+	} else if input.InviteToken != nil {
+		setClauses = append(setClauses, fmt.Sprintf("invite_token = $%d", argIdx))
+		args = append(args, *input.InviteToken)
+		argIdx++
+		setClauses = append(setClauses, fmt.Sprintf("invite_token_expires_at = $%d", argIdx))
+		args = append(args, input.InviteTokenExpiresAt)
+		argIdx++
+	}
 
 	if len(setClauses) == 0 {
 		return r.GetOrgMembershipByID(ctx, membershipID)
@@ -3542,7 +3683,8 @@ func (r *Repository) UpdateOrgMembership(ctx context.Context, membershipID uuid.
 	query := fmt.Sprintf(`
 		UPDATE organization_memberships SET %s
 		WHERE id = $%d
-		RETURNING id, organization_id, user_id, role, membership_status, created_at, updated_at
+		RETURNING id, organization_id, user_id, role, membership_status,
+		          COALESCE(invite_token, ''), invite_token_expires_at, created_at, updated_at
 	`, strings.Join(setClauses, ", "), argIdx)
 	args = append(args, membershipID)
 
@@ -3566,15 +3708,22 @@ func (r *Repository) UpdateOrgMembership(ctx context.Context, membershipID uuid.
 	}
 
 	var m OrgMembershipFullRow
+	var inviteTokenExpiresAt pgtype.Timestamptz
 	err = tx.QueryRow(ctx, query, args...).Scan(
-		&m.ID, &m.OrganizationID, &m.UserID, &m.Role, &m.MembershipStatus, &m.CreatedAt, &m.UpdatedAt,
+		&m.ID, &m.OrganizationID, &m.UserID, &m.Role, &m.MembershipStatus,
+		&m.InviteToken, &inviteTokenExpiresAt, &m.CreatedAt, &m.UpdatedAt,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return OrgMembershipFullRow{}, ErrMembershipNotFound
 		}
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return OrgMembershipFullRow{}, ErrAlreadyMember
+		}
 		return OrgMembershipFullRow{}, fmt.Errorf("update org membership: %w", err)
 	}
+	m.InviteTokenExpiresAt = optionalTime(inviteTokenExpiresAt)
 
 	// Fetch user details.
 	var user User

--- a/web/src/app/invites/organization/[membershipId]/page.tsx
+++ b/web/src/app/invites/organization/[membershipId]/page.tsx
@@ -4,6 +4,9 @@ import { createApiClient } from "@/lib/api/client";
 import type { OrgMember, UserMeResponse } from "@/lib/api/types";
 import { InviteError } from "../../invite-error";
 
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export default async function OrganizationInvitePage({
   params,
 }: {
@@ -20,8 +23,11 @@ export default async function OrganizationInvitePage({
   const api = createApiClient(accessToken);
   let accepted: OrgMember;
   try {
+    const acceptPath = UUID_PATTERN.test(membershipId)
+      ? `/v1/organization-memberships/${membershipId}`
+      : `/v1/invites/organization/${membershipId}`;
     accepted = await api.patch<OrgMember>(
-      `/v1/organization-memberships/${membershipId}`,
+      acceptPath,
       { status: "active" },
     );
   } catch (err) {

--- a/web/src/app/invites/workspace/[membershipId]/page.tsx
+++ b/web/src/app/invites/workspace/[membershipId]/page.tsx
@@ -4,6 +4,9 @@ import { createApiClient } from "@/lib/api/client";
 import type { WorkspaceMember } from "@/lib/api/types";
 import { InviteError } from "../../invite-error";
 
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export default async function WorkspaceInvitePage({
   params,
 }: {
@@ -20,8 +23,11 @@ export default async function WorkspaceInvitePage({
   let redirectTarget = "/dashboard";
   try {
     const api = createApiClient(accessToken);
+    const acceptPath = UUID_PATTERN.test(membershipId)
+      ? `/v1/workspace-memberships/${membershipId}`
+      : `/v1/invites/workspace/${membershipId}`;
     const accepted = await api.patch<WorkspaceMember>(
-      `/v1/workspace-memberships/${membershipId}`,
+      acceptPath,
       { status: "active" },
     );
     redirectTarget = `/workspaces/${accepted.workspace_id}`;

--- a/web/src/lib/auth/__tests__/return-to.test.ts
+++ b/web/src/lib/auth/__tests__/return-to.test.ts
@@ -33,12 +33,13 @@ describe("sanitizeReturnTo", () => {
 
   it("preserves invite accept routes", () => {
     const membershipId = "018f9f2e-65cb-7d0b-9c98-0df2ce4076d8";
+    const inviteToken = "invite_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi0123456789";
 
     expect(sanitizeReturnTo(`/invites/organization/${membershipId}`)).toBe(
       `/invites/organization/${membershipId}`,
     );
-    expect(sanitizeReturnTo(`/invites/workspace/${membershipId}`)).toBe(
-      `/invites/workspace/${membershipId}`,
+    expect(sanitizeReturnTo(`/invites/workspace/${inviteToken}`)).toBe(
+      `/invites/workspace/${inviteToken}`,
     );
   });
 
@@ -84,8 +85,13 @@ describe("invite return-to helpers", () => {
     expect(
       buildInviteReturnTo("organization", `/invites/organization/${membershipId}`),
     ).toBe(`/invites/organization/${membershipId}`);
-    expect(buildInviteReturnTo("workspace", "/invites/workspace/nope")).toBe(
-      "/dashboard",
+    expect(
+      buildInviteReturnTo(
+        "workspace",
+        "/invites/workspace/invite_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi0123456789",
+      ),
+    ).toBe(
+      "/invites/workspace/invite_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi0123456789",
     );
   });
 });

--- a/web/src/lib/auth/return-to.ts
+++ b/web/src/lib/auth/return-to.ts
@@ -3,6 +3,7 @@ const DEVICE_PATH = "/auth/device";
 const GITHUB_SETUP_PATH = "/github/setup";
 const INVITE_ORG_PATH_PREFIX = "/invites/organization/";
 const INVITE_WORKSPACE_PATH_PREFIX = "/invites/workspace/";
+const INVITE_TOKEN_PATTERN = /^invite_[A-Za-z0-9_-]{32,256}$/;
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const ALLOWED_RETURN_PATHS = new Set([
@@ -62,11 +63,11 @@ export function buildInviteReturnTo(
   if (!pathname.startsWith(prefix)) {
     return DEFAULT_RETURN_TO;
   }
-  const membershipId = pathname.slice(prefix.length);
-  if (!UUID_PATTERN.test(membershipId)) {
+  const inviteToken = pathname.slice(prefix.length);
+  if (!INVITE_TOKEN_PATTERN.test(inviteToken) && !UUID_PATTERN.test(inviteToken)) {
     return DEFAULT_RETURN_TO;
   }
-  return `${prefix}${membershipId}`;
+  return `${prefix}${inviteToken}`;
 }
 
 export function buildGitHubSetupReturnTo(searchParams: URLSearchParams): string {


### PR DESCRIPTION
## Summary
- add high-entropy invite tokens and token accept endpoints while keeping legacy UUID invite links compatible
- include inviter display names and human-readable roles in invite emails
- allow workspace invites to create/re-invite the required org membership and activate org membership before workspace membership on accept
- keep admin copy-link behavior for invited org/workspace members

## Validation
- go test ./internal/api ./internal/email
- go test ./cmd/api-server
- npm test -- --run src/lib/auth/__tests__/return-to.test.ts
- npx tsc --noEmit
- git diff --check

## Notes
- Attempted Claude CLI review, but the process hung without producing output and was stopped; no Claude findings were available to apply.