### PR TITLE
feat(agent-harnesses): mirror executions into run replay

### DIFF
--- a/backend/internal/runevents/envelope.go
+++ b/backend/internal/runevents/envelope.go
@@ -56,6 +56,7 @@ const (
 	SourcePromptEvalEngine   Source = "prompt_eval_engine"
 	SourceHostedExternal     Source = "hosted_external"
 	SourceHostedCallback     Source = "hosted_callback"
+	SourceAgentHarnessWorker Source = "agent_harness_worker"
 	SourceWorkerScoring      Source = "worker_scoring"
 	SourceGraderVerification Source = "grader_verification"
 )
@@ -182,7 +183,7 @@ func isValidType(eventType Type) bool {
 
 func isValidSource(source Source) bool {
 	switch source {
-	case SourceNativeEngine, SourcePromptEvalEngine, SourceHostedExternal, SourceHostedCallback, SourceWorkerScoring, SourceGraderVerification:
+	case SourceNativeEngine, SourcePromptEvalEngine, SourceHostedExternal, SourceHostedCallback, SourceAgentHarnessWorker, SourceWorkerScoring, SourceGraderVerification:
 		return true
 	default:
 		return false

--- a/backend/internal/workflow/agent_harness_execution_workflow.go
+++ b/backend/internal/workflow/agent_harness_execution_workflow.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/agentclash/agentclash/backend/internal/maputil"
 	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/runevents"
 	"github.com/agentclash/agentclash/backend/internal/sandbox"
 	"github.com/google/uuid"
 	sdkworkflow "go.temporal.io/sdk/workflow"
@@ -20,6 +21,7 @@ const (
 	agentHarnessWorkspaceDir          = "/workspace"
 	agentHarnessActivityTimeoutBuffer = 2 * time.Minute
 	defaultAgentHarnessTimeoutSeconds = 1800
+	agentHarnessReplayTextPreviewMax  = 2048
 )
 
 var (
@@ -145,6 +147,7 @@ func (a *Activities) ExecuteAgentHarnessExecution(ctx context.Context, input Exe
 	if err != nil {
 		return wrapActivityError(err)
 	}
+	defer a.buildAgentHarnessReplayBestEffort(ctx, execution)
 	harness, err := a.agentHarnessSnapshot(ctx, execution)
 	if err != nil {
 		return wrapActivityError(err)
@@ -296,6 +299,15 @@ func (a *Activities) ExecuteAgentHarnessExecution(ctx context.Context, input Exe
 	}
 
 	return nil
+}
+
+func (a *Activities) buildAgentHarnessReplayBestEffort(ctx context.Context, execution repository.AgentHarnessExecution) {
+	if a.repo == nil || execution.RunAgentID == nil {
+		return
+	}
+	if _, err := a.repo.BuildRunAgentReplay(ctx, *execution.RunAgentID); err != nil {
+		_ = a.recordAgentHarnessEvent(context.Background(), execution.ID, "replay.build.failed", "worker", map[string]any{"error": err.Error()})
+	}
 }
 
 func (a *Activities) agentHarnessSnapshot(ctx context.Context, execution repository.AgentHarnessExecution) (agentHarnessSnapshot, error) {
@@ -733,7 +745,165 @@ func (a *Activities) recordAgentHarnessEvent(ctx context.Context, executionID uu
 		OccurredAt:  time.Now().UTC(),
 		Payload:     raw,
 	})
+	if err != nil {
+		return wrapActivityError(err)
+	}
+	return a.recordAgentHarnessRunEvent(ctx, executionID, eventType, actorType, raw)
+}
+
+func (a *Activities) recordAgentHarnessRunEvent(ctx context.Context, executionID uuid.UUID, eventType string, actorType string, raw json.RawMessage) error {
+	if a.repo == nil {
+		return nil
+	}
+	execution, err := a.agentHarnessRepo.GetAgentHarnessExecutionByID(ctx, executionID)
+	if err != nil {
+		return wrapActivityError(err)
+	}
+	if execution.RunID == nil || execution.RunAgentID == nil {
+		return nil
+	}
+	payload, err := agentHarnessRunEventPayload(eventType, actorType, raw)
+	if err != nil {
+		return err
+	}
+	_, err = a.repo.RecordRunEvent(ctx, repository.RecordRunEventParams{Event: runevents.Envelope{
+		EventID:       fmt.Sprintf("agent-harness:%s:%s", executionID, eventType),
+		SchemaVersion: runevents.SchemaVersionV1,
+		RunID:         *execution.RunID,
+		RunAgentID:    *execution.RunAgentID,
+		EventType:     agentHarnessRunEventType(eventType),
+		Source:        runevents.SourceAgentHarnessWorker,
+		OccurredAt:    time.Now().UTC(),
+		Payload:       payload,
+		Summary: runevents.SummaryMetadata{
+			SandboxAction: eventType,
+			EvidenceLevel: runevents.EvidenceLevelHostedStructured,
+		},
+	}})
 	return wrapActivityError(err)
+}
+
+func agentHarnessRunEventPayload(eventType string, actorType string, raw json.RawMessage) (json.RawMessage, error) {
+	var rawPayload map[string]any
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &rawPayload); err != nil {
+			return nil, fmt.Errorf("decode agent harness event payload for replay: %w", err)
+		}
+	}
+	payload := summarizeAgentHarnessRunEventPayload(rawPayload)
+	payload["agent_harness_event_type"] = eventType
+	payload["agent_harness_actor_type"] = actorType
+	return json.Marshal(payload)
+}
+
+func summarizeAgentHarnessRunEventPayload(raw map[string]any) map[string]any {
+	payload := map[string]any{}
+	for key, value := range raw {
+		switch key {
+		case "stdout", "stderr", "diff", "raw", "message":
+			if text, ok := value.(string); ok {
+				payload[key+"_summary"] = summarizeAgentHarnessText(text)
+			}
+		case "command":
+			payload[key] = summarizeAgentHarnessCommand(value)
+		default:
+			payload[key] = summarizeAgentHarnessValue(value)
+		}
+	}
+	return payload
+}
+
+func summarizeAgentHarnessValue(value any) any {
+	switch typed := value.(type) {
+	case string:
+		return truncateAgentHarnessText(redactAgentHarnessText(typed))
+	case []any:
+		items := make([]any, 0, len(typed))
+		for _, item := range typed {
+			items = append(items, summarizeAgentHarnessValue(item))
+		}
+		return items
+	case map[string]any:
+		return summarizeAgentHarnessRunEventPayload(typed)
+	default:
+		return value
+	}
+}
+
+func summarizeAgentHarnessCommand(value any) any {
+	items, ok := value.([]any)
+	if !ok {
+		return summarizeAgentHarnessValue(value)
+	}
+	command := make([]any, 0, len(items))
+	for _, item := range items {
+		command = append(command, summarizeAgentHarnessValue(item))
+	}
+	return command
+}
+
+func summarizeAgentHarnessText(text string) map[string]any {
+	redacted := redactAgentHarnessText(text)
+	return map[string]any{
+		"size_bytes": len(text),
+		"truncated":  len(redacted) > agentHarnessReplayTextPreviewMax,
+		"preview":    truncateAgentHarnessText(redacted),
+	}
+}
+
+func truncateAgentHarnessText(text string) string {
+	if len(text) <= agentHarnessReplayTextPreviewMax {
+		return text
+	}
+	return text[:agentHarnessReplayTextPreviewMax]
+}
+
+func redactAgentHarnessText(text string) string {
+	parts := strings.Fields(text)
+	for _, part := range parts {
+		if looksLikeSecret(part) {
+			text = strings.ReplaceAll(text, part, "[redacted]")
+		}
+	}
+	return text
+}
+
+func looksLikeSecret(value string) bool {
+	trimmed := strings.Trim(value, `"'.,;:()[]{}<>`)
+	if len(trimmed) < 16 {
+		return false
+	}
+	secretPrefixes := []string{"sk-", "ghp_", "github_pat_", "ghs_", "glpat-", "xoxb-", "xoxp-", "AKIA"}
+	for _, prefix := range secretPrefixes {
+		if strings.HasPrefix(trimmed, prefix) {
+			return true
+		}
+	}
+	return strings.Contains(strings.ToLower(trimmed), "api_key=") || strings.Contains(strings.ToLower(trimmed), "token=")
+}
+
+func agentHarnessRunEventType(eventType string) runevents.Type {
+	switch {
+	case strings.HasPrefix(eventType, "scoring."):
+		switch eventType {
+		case "scoring.started":
+			return runevents.EventTypeScoringStarted
+		case "scoring.failed":
+			return runevents.EventTypeScoringFailed
+		default:
+			return runevents.EventTypeScoringCompleted
+		}
+	case strings.HasSuffix(eventType, ".started"):
+		return runevents.EventTypeSandboxCommandStarted
+	case strings.HasSuffix(eventType, ".failed"):
+		return runevents.EventTypeSandboxCommandFailed
+	case eventType == "codex.exec.output" || eventType == "claude.exec.output":
+		return runevents.EventTypeModelOutputDelta
+	case strings.HasPrefix(eventType, "artifact."):
+		return runevents.EventTypeSandboxFileWritten
+	default:
+		return runevents.EventTypeSandboxCommandCompleted
+	}
 }
 
 func agentHarnessEnv(h agentHarnessSnapshot, secrets map[string]string) (map[string]string, error) {

--- a/backend/internal/workflow/agent_harness_execution_workflow_test.go
+++ b/backend/internal/workflow/agent_harness_execution_workflow_test.go
@@ -18,8 +18,10 @@ func TestExecuteAgentHarnessExecutionRunsCodexAndRecordsTrace(t *testing.T) {
 	workspaceID := uuid.New()
 	harnessID := uuid.New()
 	executionID := uuid.New()
+	runID := uuid.New()
+	runAgentID := uuid.New()
 	openAISecret := "OPENAI_API_KEY"
-	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
+	repo := newFakeRunRepository(fixtureRun(runID, domain.RunStatusQueued), fixtureRunAgent(runID, runAgentID, 0))
 	repo.setAgentHarness(repository.AgentHarness{
 		ID:                     harnessID,
 		OrganizationID:         uuid.New(),
@@ -37,6 +39,8 @@ func TestExecuteAgentHarnessExecutionRunsCodexAndRecordsTrace(t *testing.T) {
 		ID:                      executionID,
 		WorkspaceID:             workspaceID,
 		AgentHarnessID:          harnessID,
+		RunID:                   &runID,
+		RunAgentID:              &runAgentID,
 		Status:                  string(repository.AgentHarnessExecutionStatusRunning),
 		ExecutionConfigSnapshot: json.RawMessage(`{"timeout_seconds":120}`),
 	})
@@ -140,14 +144,44 @@ func TestExecuteAgentHarnessExecutionRunsCodexAndRecordsTrace(t *testing.T) {
 	if !sawScoringCompleted {
 		t.Fatal("expected scoring completed event")
 	}
+	runEvents := repo.runEvents[runAgentID]
+	if len(runEvents) == 0 {
+		t.Fatal("expected agent harness events mirrored to canonical run_events")
+	}
+	if runEvents[0].RunID != runID {
+		t.Fatalf("mirrored run_id = %s, want %s", runEvents[0].RunID, runID)
+	}
+	var mirroredPayload map[string]any
+	if err := json.Unmarshal(runEvents[0].Payload, &mirroredPayload); err != nil {
+		t.Fatalf("decode mirrored payload: %v", err)
+	}
+	if mirroredPayload["agent_harness_event_type"] == "" {
+		t.Fatalf("mirrored payload missing harness event type: %#v", mirroredPayload)
+	}
+	for _, event := range runEvents {
+		var payload map[string]any
+		if err := json.Unmarshal(event.Payload, &payload); err != nil {
+			t.Fatalf("decode mirrored run event payload: %v", err)
+		}
+		for _, rawKey := range []string{"stdout", "stderr", "diff", "raw"} {
+			if _, ok := payload[rawKey]; ok {
+				t.Fatalf("mirrored run event payload leaked raw %s: %#v", rawKey, payload)
+			}
+		}
+	}
+	if repo.callCountWithPrefix("BuildRunAgentReplay:"+runAgentID.String()) != 1 {
+		t.Fatalf("BuildRunAgentReplay call count = %d, want 1", repo.callCountWithPrefix("BuildRunAgentReplay:"+runAgentID.String()))
+	}
 }
 
 func TestExecuteAgentHarnessExecutionFailsRequiredValidator(t *testing.T) {
 	workspaceID := uuid.New()
 	harnessID := uuid.New()
 	executionID := uuid.New()
+	runID := uuid.New()
+	runAgentID := uuid.New()
 	openAISecret := "OPENAI_API_KEY"
-	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
+	repo := newFakeRunRepository(fixtureRun(runID, domain.RunStatusQueued), fixtureRunAgent(runID, runAgentID, 0))
 	repo.setAgentHarness(repository.AgentHarness{
 		ID:                     harnessID,
 		OrganizationID:         uuid.New(),
@@ -164,6 +198,8 @@ func TestExecuteAgentHarnessExecutionFailsRequiredValidator(t *testing.T) {
 		ID:                      executionID,
 		WorkspaceID:             workspaceID,
 		AgentHarnessID:          harnessID,
+		RunID:                   &runID,
+		RunAgentID:              &runAgentID,
 		Status:                  string(repository.AgentHarnessExecutionStatusRunning),
 		ExecutionConfigSnapshot: json.RawMessage(`{"timeout_seconds":120}`),
 	})
@@ -219,6 +255,62 @@ func TestExecuteAgentHarnessExecutionFailsRequiredValidator(t *testing.T) {
 	}
 	if !sawPartialScore {
 		t.Fatal("expected partial score event")
+	}
+	if repo.callCountWithPrefix("BuildRunAgentReplay:"+runAgentID.String()) != 1 {
+		t.Fatalf("BuildRunAgentReplay call count = %d, want 1", repo.callCountWithPrefix("BuildRunAgentReplay:"+runAgentID.String()))
+	}
+}
+
+func TestExecuteAgentHarnessExecutionTreatsReplayBuildFailureAsNonFatal(t *testing.T) {
+	workspaceID := uuid.New()
+	harnessID := uuid.New()
+	executionID := uuid.New()
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	openAISecret := "OPENAI_API_KEY"
+	repo := newFakeRunRepository(fixtureRun(runID, domain.RunStatusQueued), fixtureRunAgent(runID, runAgentID, 0))
+	repo.buildReplayErr = errors.New("replay index unavailable")
+	repo.setAgentHarness(repository.AgentHarness{
+		ID:                     harnessID,
+		OrganizationID:         uuid.New(),
+		WorkspaceID:            workspaceID,
+		TaskPrompt:             "write a file without a repository",
+		CodexTemplate:          "codex",
+		AuthMode:               "api_key_secret",
+		OpenAIAPIKeySecretName: &openAISecret,
+		ExecutionConfig:        json.RawMessage(`{"timeout_seconds":120}`),
+	})
+	repo.setAgentHarnessExecution(repository.AgentHarnessExecution{
+		ID:                      executionID,
+		WorkspaceID:             workspaceID,
+		AgentHarnessID:          harnessID,
+		RunID:                   &runID,
+		RunAgentID:              &runAgentID,
+		Status:                  string(repository.AgentHarnessExecutionStatusRunning),
+		ExecutionConfigSnapshot: json.RawMessage(`{"timeout_seconds":120}`),
+	})
+	repo.setWorkspaceSecrets(workspaceID, map[string]string{openAISecret: "sk-test"})
+
+	session := sandbox.NewFakeSession("sandbox-1")
+	session.SetExecFunc(func(request sandbox.ExecRequest, _ map[string][]byte) (sandbox.ExecResult, error) {
+		if len(request.Command) >= 2 && request.Command[0] == "codex" && request.Command[1] == "exec" {
+			return sandbox.ExecResult{ExitCode: 0, Stdout: `{"type":"final","message":"done"}`}, nil
+		}
+		t.Fatalf("unexpected command: %#v", request.Command)
+		return sandbox.ExecResult{}, nil
+	})
+	provider := &sandbox.FakeProvider{NextSession: session}
+	activities := NewActivities(repo, FakeWorkHooks{}).WithSandboxProvider(provider)
+
+	err := activities.ExecuteAgentHarnessExecution(context.Background(), ExecuteAgentHarnessExecutionInput{ExecutionID: executionID})
+	if err != nil {
+		t.Fatalf("ExecuteAgentHarnessExecution error = %v, want replay build failure to be non-fatal", err)
+	}
+	if repo.callCountWithPrefix("BuildRunAgentReplay:"+runAgentID.String()) != 1 {
+		t.Fatalf("BuildRunAgentReplay call count = %d, want 1", repo.callCountWithPrefix("BuildRunAgentReplay:"+runAgentID.String()))
+	}
+	if !agentHarnessEventRecorded(repo.agentHarnessEvents[executionID], "replay.build.failed") {
+		t.Fatal("expected replay.build.failed harness event")
 	}
 }
 
@@ -817,6 +909,15 @@ func TestAgentHarnessValidatorWorkdir(t *testing.T) {
 func containsString(values []string, target string) bool {
 	for _, value := range values {
 		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func agentHarnessEventRecorded(events []repository.AgentHarnessExecutionEvent, eventType string) bool {
+	for _, event := range events {
+		if event.EventType == eventType {
 			return true
 		}
 	}

--- a/testing/codex-issue-582-harness-replay-artifacts-local-test-log.md
+++ b/testing/codex-issue-582-harness-replay-artifacts-local-test-log.md
@@ -1,0 +1,11 @@
+# Local Test Log: Issue #582 Harness Replay And Artifacts
+
+## Commands
+
+- `go test ./internal/workflow`
+- `go test ./internal/repository ./internal/api`
+
+## Result
+
+- Workflow tests passed.
+- Repository/API tests passed.

--- a/testing/codex-issue-582-harness-replay-artifacts.md
+++ b/testing/codex-issue-582-harness-replay-artifacts.md
@@ -1,0 +1,18 @@
+# Test Contract: Issue #582 Harness Replay And Artifacts
+
+## Intent
+
+Make Agent Harness executions observable through the existing canonical run replay path instead of duplicating replay/scoring storage.
+
+## Expectations
+
+- Harness workflow events are mirrored to linked `run_events` when `agent_harness_executions.run_id` and `run_agent_id` are present.
+- Mirrored events use existing `runevents` types and preserve the original harness event type in payload metadata.
+- Harness completion rebuilds the linked `run_agent_replays` summary through the existing replay builder.
+- API responses expose bridge IDs so the UI can link to canonical replay/scorecard endpoints.
+- Large/raw payload handling should avoid adding new harness-only replay tables.
+
+## Verification
+
+- `go test ./internal/workflow`
+- `go test ./internal/repository ./internal/api`


### PR DESCRIPTION
## Summary
- mirrors Agent Harness workflow events into canonical run_events using the linked run_id/run_agent_id bridge
- rebuilds the linked run_agent_replay after successful harness execution so existing replay APIs/viewer can inspect harness runs
- preserves original harness event type/actor metadata in mirrored payloads and adds focused workflow coverage

## Tests
- go test ./internal/workflow
- go test ./internal/repository ./internal/api

Implements #582.