### PR TITLE
fix: accept invite tokens when auth email is unavailable

### DIFF
--- a/backend/internal/api/auth_workos.go
+++ b/backend/internal/api/auth_workos.go
@@ -28,6 +28,8 @@ const (
 	defaultWorkOSIssuer = "https://api.workos.com"
 )
 
+var errWorkOSUserInfoUnavailable = errors.New("workos userinfo unavailable for user-management issuer")
+
 // UserRepository is the subset of repository.Repository needed for auth.
 type UserRepository interface {
 	GetUserByWorkOSID(ctx context.Context, workosUserID string) (repository.User, error)
@@ -408,6 +410,9 @@ func needsIdentityForUser(user repository.User, identity workOSIdentity) bool {
 
 func (a *WorkOSAuthenticator) lookupIdentityFromUserInfo(ctx context.Context, issuer, token string) (workOSIdentity, error) {
 	userInfoURL, err := workOSUserInfoURL(issuer)
+	if errors.Is(err, errWorkOSUserInfoUnavailable) {
+		return workOSIdentity{}, nil
+	}
 	if err != nil {
 		return workOSIdentity{}, err
 	}
@@ -503,6 +508,9 @@ func workOSUserInfoURL(issuer string) (string, error) {
 	}
 	if parsed.Scheme == "" || parsed.Host == "" {
 		return "", fmt.Errorf("issuer %q must include scheme and host", issuer)
+	}
+	if strings.EqualFold(parsed.Host, "api.workos.com") {
+		return "", errWorkOSUserInfoUnavailable
 	}
 
 	return (&url.URL{

--- a/backend/internal/api/auth_workos_test.go
+++ b/backend/internal/api/auth_workos_test.go
@@ -849,23 +849,65 @@ func TestWorkOSAuthenticator_UserInfoFailureDoesNotBlockExistingUserAuth(t *test
 	}
 }
 
+func TestWorkOSAuthenticator_UserManagementIssuerSkipsUserInfoFallback(t *testing.T) {
+	privKey, jwksServer := testJWKS(t)
+
+	var backfillCalls int
+	repo := stubUserRepo{
+		user: repository.User{
+			ID:           uuid.New(),
+			WorkOSUserID: "user_01ABC",
+			Email:        "",
+			DisplayName:  "Test User",
+		},
+		backfillCallCount: &backfillCalls,
+	}
+
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, "test-client", "https://api.workos.com", repo, authTestLogger)
+	if err != nil {
+		t.Fatalf("create authenticator: %v", err)
+	}
+
+	token := signTestJWT(t, privKey, map[string]interface{}{
+		"sub": "user_01ABC",
+		"iss": "https://api.workos.com",
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(5 * time.Minute).Unix(),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/session", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	caller, err := auth.Authenticate(req)
+	if err != nil {
+		t.Fatalf("authenticate: %v", err)
+	}
+	if caller.Email != "" {
+		t.Fatalf("Email = %q, want empty string", caller.Email)
+	}
+	if backfillCalls != 0 {
+		t.Fatalf("backfill calls = %d, want 0", backfillCalls)
+	}
+}
+
 func TestWorkOSUserInfoURL(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name   string
-		issuer string
-		want   string
+		name    string
+		issuer  string
+		want    string
+		wantErr error
 	}{
 		{
-			name:   "root issuer",
-			issuer: "https://api.workos.com",
-			want:   "https://api.workos.com/oauth2/userinfo",
+			name:    "root issuer",
+			issuer:  "https://api.workos.com",
+			wantErr: errWorkOSUserInfoUnavailable,
 		},
 		{
-			name:   "issuer with user management path",
-			issuer: "https://api.workos.com/user_management/client_123",
-			want:   "https://api.workos.com/oauth2/userinfo",
+			name:    "issuer with user management path",
+			issuer:  "https://api.workos.com/user_management/client_123",
+			wantErr: errWorkOSUserInfoUnavailable,
 		},
 		{
 			name:   "custom auth domain",
@@ -877,6 +919,12 @@ func TestWorkOSUserInfoURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := workOSUserInfoURL(tt.issuer)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("workOSUserInfoURL() error = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("workOSUserInfoURL() error = %v", err)
 			}

--- a/backend/internal/api/org_memberships.go
+++ b/backend/internal/api/org_memberships.go
@@ -308,7 +308,7 @@ func (m *OrgMembershipManager) AcceptOrgInvite(ctx context.Context, caller Calle
 	if err != nil {
 		return OrgMembershipResult{}, err
 	}
-	if !inviteEmailMatchesCaller(caller, membership.Email) {
+	if !inviteTokenCanBeAcceptedByCaller(caller, membership.Email) {
 		return OrgMembershipResult{}, ErrForbidden
 	}
 	if orgInviteExpired(membership) {
@@ -342,6 +342,20 @@ func (m *OrgMembershipManager) AcceptOrgInvite(ctx context.Context, caller Calle
 
 func inviteEmailMatchesCaller(caller Caller, inviteEmail string) bool {
 	return strings.EqualFold(strings.TrimSpace(caller.Email), strings.TrimSpace(inviteEmail)) && strings.TrimSpace(caller.Email) != ""
+}
+
+func inviteTokenCanBeAcceptedByCaller(caller Caller, inviteEmail string) bool {
+	inviteEmail = strings.TrimSpace(inviteEmail)
+	callerEmail := strings.TrimSpace(caller.Email)
+	if inviteEmail == "" {
+		return false
+	}
+	if callerEmail == "" {
+		// The invite token is a high-entropy bearer secret. Some WorkOS session
+		// tokens do not expose email claims, so token possession is the fallback.
+		return true
+	}
+	return strings.EqualFold(callerEmail, inviteEmail)
 }
 
 func orgInviteExpired(membership repository.OrgMembershipFullRow) bool {

--- a/backend/internal/api/org_memberships_test.go
+++ b/backend/internal/api/org_memberships_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -255,6 +256,79 @@ func TestAcceptOrgInviteToken_ReassignsPendingInviteToCaller(t *testing.T) {
 	}
 	if result.MembershipStatus != "active" {
 		t.Fatalf("result status = %q, want active", result.MembershipStatus)
+	}
+}
+
+func TestAcceptOrgInviteToken_AllowsEmptyCallerEmail(t *testing.T) {
+	orgID := uuid.New()
+	invitedUserID := uuid.New()
+	callerUserID := uuid.New()
+	membershipID := uuid.New()
+	expiresAt := time.Now().Add(time.Hour)
+
+	repo := &fakeOrgMembershipRepo{
+		orgMembership: repository.OrgMembershipFullRow{
+			ID:                   membershipID,
+			OrganizationID:       orgID,
+			UserID:               invitedUserID,
+			Email:                "friend@example.com",
+			Role:                 "org_member",
+			MembershipStatus:     "invited",
+			InviteToken:          "invite_testtoken",
+			InviteTokenExpiresAt: &expiresAt,
+		},
+		updated: repository.OrgMembershipFullRow{
+			ID:               membershipID,
+			OrganizationID:   orgID,
+			UserID:           callerUserID,
+			Email:            "friend@example.com",
+			Role:             "org_member",
+			MembershipStatus: "active",
+		},
+	}
+	manager := NewOrgMembershipManager(NewCallerOrganizationAuthorizer(), repo, &fakeEmailSender{}, "https://app.agentclash.dev")
+
+	result, err := manager.AcceptOrgInvite(context.Background(), Caller{UserID: callerUserID}, "invite_testtoken")
+	if err != nil {
+		t.Fatalf("AcceptOrgInvite returned error: %v", err)
+	}
+
+	if repo.lastUpdate.UserID == nil || *repo.lastUpdate.UserID != callerUserID {
+		t.Fatalf("AcceptOrgInvite UserID = %v, want %s", repo.lastUpdate.UserID, callerUserID)
+	}
+	if !repo.lastUpdate.ClearInviteToken {
+		t.Fatalf("ClearInviteToken = false, want true")
+	}
+	if result.MembershipStatus != "active" {
+		t.Fatalf("result status = %q, want active", result.MembershipStatus)
+	}
+}
+
+func TestAcceptOrgInviteToken_RejectsMismatchedCallerEmail(t *testing.T) {
+	orgID := uuid.New()
+	membershipID := uuid.New()
+	expiresAt := time.Now().Add(time.Hour)
+
+	repo := &fakeOrgMembershipRepo{
+		orgMembership: repository.OrgMembershipFullRow{
+			ID:                   membershipID,
+			OrganizationID:       orgID,
+			UserID:               uuid.New(),
+			Email:                "friend@example.com",
+			Role:                 "org_member",
+			MembershipStatus:     "invited",
+			InviteToken:          "invite_testtoken",
+			InviteTokenExpiresAt: &expiresAt,
+		},
+	}
+	manager := NewOrgMembershipManager(NewCallerOrganizationAuthorizer(), repo, &fakeEmailSender{}, "https://app.agentclash.dev")
+
+	_, err := manager.AcceptOrgInvite(context.Background(), Caller{UserID: uuid.New(), Email: "other@example.com"}, "invite_testtoken")
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("AcceptOrgInvite error = %v, want ErrForbidden", err)
+	}
+	if repo.lastUpdate.Status != nil || repo.lastUpdate.UserID != nil || repo.lastUpdate.ClearInviteToken {
+		t.Fatalf("membership was updated despite forbidden caller: %+v", repo.lastUpdate)
 	}
 }
 

--- a/backend/internal/api/workspace_memberships.go
+++ b/backend/internal/api/workspace_memberships.go
@@ -292,7 +292,7 @@ func (m *WorkspaceMembershipManager) AcceptWorkspaceInvite(ctx context.Context, 
 	if err != nil {
 		return WorkspaceMembershipResult{}, err
 	}
-	if !inviteEmailMatchesCaller(caller, membership.Email) {
+	if !inviteTokenCanBeAcceptedByCaller(caller, membership.Email) {
 		return WorkspaceMembershipResult{}, ErrForbidden
 	}
 	if wsInviteExpired(membership) {

--- a/backend/internal/api/workspace_memberships_test.go
+++ b/backend/internal/api/workspace_memberships_test.go
@@ -343,6 +343,94 @@ func TestAcceptWorkspaceInviteToken_ActivatesOrgAndWorkspaceMemberships(t *testi
 	}
 }
 
+func TestAcceptWorkspaceInviteToken_AllowsEmptyCallerEmail(t *testing.T) {
+	workspaceID := uuid.New()
+	orgID := uuid.New()
+	invitedUserID := uuid.New()
+	callerUserID := uuid.New()
+	membershipID := uuid.New()
+	expiresAt := time.Now().Add(time.Hour)
+
+	repo := &fakeWsMembershipRepo{
+		orgID:        orgID,
+		user:         repository.User{ID: callerUserID, Email: ""},
+		orgMemberErr: repository.ErrMembershipNotFound,
+		wsMembership: repository.WorkspaceMembershipFullRow{
+			ID:                   membershipID,
+			WorkspaceID:          workspaceID,
+			OrganizationID:       orgID,
+			UserID:               invitedUserID,
+			Email:                "friend@example.com",
+			Role:                 "workspace_member",
+			MembershipStatus:     "invited",
+			InviteToken:          "invite_testtoken",
+			InviteTokenExpiresAt: &expiresAt,
+		},
+		updated: repository.WorkspaceMembershipFullRow{
+			ID:               membershipID,
+			WorkspaceID:      workspaceID,
+			OrganizationID:   orgID,
+			UserID:           callerUserID,
+			Email:            "friend@example.com",
+			Role:             "workspace_member",
+			MembershipStatus: "active",
+		},
+	}
+	manager := NewWorkspaceMembershipManager(repo, &fakeEmailSender{}, "https://app.agentclash.dev")
+
+	result, err := manager.AcceptWorkspaceInvite(context.Background(), Caller{UserID: callerUserID}, "invite_testtoken")
+	if err != nil {
+		t.Fatalf("AcceptWorkspaceInvite returned error: %v", err)
+	}
+
+	if repo.lastOrgCreate.UserID != callerUserID {
+		t.Fatalf("org membership created for %s, want %s", repo.lastOrgCreate.UserID, callerUserID)
+	}
+	if repo.lastOrgUpdate.Status == nil || *repo.lastOrgUpdate.Status != "active" {
+		t.Fatalf("org update status = %v, want active", repo.lastOrgUpdate.Status)
+	}
+	if repo.lastUpdate.UserID == nil || *repo.lastUpdate.UserID != callerUserID {
+		t.Fatalf("workspace update user = %v, want %s", repo.lastUpdate.UserID, callerUserID)
+	}
+	if !repo.lastUpdate.ClearInviteToken {
+		t.Fatalf("workspace ClearInviteToken = false, want true")
+	}
+	if result.MembershipStatus != "active" {
+		t.Fatalf("result status = %q, want active", result.MembershipStatus)
+	}
+}
+
+func TestAcceptWorkspaceInviteToken_RejectsMismatchedCallerEmail(t *testing.T) {
+	workspaceID := uuid.New()
+	orgID := uuid.New()
+	membershipID := uuid.New()
+	expiresAt := time.Now().Add(time.Hour)
+
+	repo := &fakeWsMembershipRepo{
+		orgID: orgID,
+		wsMembership: repository.WorkspaceMembershipFullRow{
+			ID:                   membershipID,
+			WorkspaceID:          workspaceID,
+			OrganizationID:       orgID,
+			UserID:               uuid.New(),
+			Email:                "friend@example.com",
+			Role:                 "workspace_member",
+			MembershipStatus:     "invited",
+			InviteToken:          "invite_testtoken",
+			InviteTokenExpiresAt: &expiresAt,
+		},
+	}
+	manager := NewWorkspaceMembershipManager(repo, &fakeEmailSender{}, "https://app.agentclash.dev")
+
+	_, err := manager.AcceptWorkspaceInvite(context.Background(), Caller{UserID: uuid.New(), Email: "other@example.com"}, "invite_testtoken")
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("AcceptWorkspaceInvite error = %v, want ErrForbidden", err)
+	}
+	if repo.lastOrgCreate.UserID != uuid.Nil || repo.lastOrgUpdate.Status != nil || repo.lastUpdate.Status != nil {
+		t.Fatalf("membership was updated despite forbidden caller: orgCreate=%+v orgUpdate=%+v wsUpdate=%+v", repo.lastOrgCreate, repo.lastOrgUpdate, repo.lastUpdate)
+	}
+}
+
 func TestInviteWorkspaceMember_CreatesMissingOrgInvite(t *testing.T) {
 	workspaceID := uuid.New()
 	userID := uuid.New()

--- a/testing/codex-fix-invite-accept-email-identity.md
+++ b/testing/codex-fix-invite-accept-email-identity.md
@@ -1,0 +1,30 @@
+# codex/fix-invite-accept-email-identity - Test Contract
+
+## Functional Behavior
+- WorkOS userinfo fallback uses an HTTP method accepted by production AuthKit userinfo.
+- Token invite acceptance succeeds when the caller has the invite token and WorkOS returns an empty caller email.
+- Token invite acceptance stays forbidden when WorkOS returns a non-empty caller email that differs from the invited email.
+- Legacy membership-id invite acceptance still requires the caller email to match the invited email.
+- Organization and workspace invite tokens are cleared after successful acceptance.
+
+## Unit Tests
+- `TestWorkOSAuthenticator_FallsBackToUserInfoEmailWhenClaimMissing` verifies the fallback userinfo request method and profile backfill.
+- `TestWorkOSAuthenticator_BackfillsMissingIdentityFromUserInfo` verifies missing profile backfill via userinfo.
+- Organization invite manager tests cover empty-email token acceptance and mismatched non-empty email rejection.
+- Workspace invite manager tests cover empty-email token acceptance and mismatched non-empty email rejection.
+
+## Integration / Functional Tests
+- `go test ./internal/api` validates auth and invite manager behavior together at the API package level.
+
+## Smoke Tests
+- N/A - production smoke should be creating an invite, opening the emailed `/invites/.../invite_...` URL while logged in, and seeing the accept request return `200` instead of `403`.
+
+## E2E Tests
+- N/A - no browser E2E harness is part of this narrowly scoped backend fix.
+
+## Manual / cURL Tests
+```bash
+curl -X PATCH "$AGENTCLASH_API_URL/v1/invites/organization/invite_<token>" \
+  -H "Authorization: Bearer <authkit-session-token>"
+# Expected: 200 when token is valid and the caller email is either empty or matches the invite email.
+```


### PR DESCRIPTION
## Summary
- allow token-based org/workspace invite acceptance when WorkOS authenticates the user but provides an empty email
- keep non-empty mismatched emails forbidden, and leave legacy membership-id invite acceptance on strict email matching
- skip WorkOS userinfo fallback for the api.workos.com user-management issuer so production stops calling an unavailable /oauth2/userinfo endpoint

## Root Cause
Production logs show the accept endpoints returning 403 while resolve_user has email="". The WorkOS session token is authenticating, but the backend cannot hydrate an email: it derives /oauth2/userinfo from the api.workos.com user-management issuer, and production returns Cannot POST /oauth2/userinfo. The email-match guard then rejects the token invite.

## Tests
- cd backend && go test ./internal/api
- cd backend && go test ./...