### PR TITLE
feat: add agent harness bootstrap setup stage

### DIFF
--- a/backend/internal/api/agent_harnesses.go
+++ b/backend/internal/api/agent_harnesses.go
@@ -400,6 +400,7 @@ type agentHarnessExecutionResponse struct {
 	ExecutionConfigSnapshot  json.RawMessage                      `json:"execution_config_snapshot"`
 	EvaluationConfigSnapshot json.RawMessage                      `json:"evaluation_config_snapshot"`
 	ErrorMessage             *string                              `json:"error_message,omitempty"`
+	FailureStage             *string                              `json:"failure_stage,omitempty"`
 	StartedAt                *time.Time                           `json:"started_at,omitempty"`
 	CompletedAt              *time.Time                           `json:"completed_at,omitempty"`
 	CancelledAt              *time.Time                           `json:"cancelled_at,omitempty"`
@@ -568,6 +569,7 @@ func listAgentHarnessExecutionsHandler(logger *slog.Logger, service AgentHarness
 				return
 			}
 			response.Events = mapAgentHarnessExecutionEventResponses(events)
+			response.FailureStage = agentHarnessExecutionFailureStage(response.Status, events)
 			items = append(items, response)
 		}
 		writeJSON(w, http.StatusOK, listAgentHarnessExecutionsResponse{Items: items})
@@ -603,6 +605,7 @@ func getAgentHarnessExecutionHandler(logger *slog.Logger, service AgentHarnessSe
 			return
 		}
 		response.Events = mapAgentHarnessExecutionEventResponses(events)
+		response.FailureStage = agentHarnessExecutionFailureStage(response.Status, events)
 		writeJSON(w, http.StatusOK, response)
 	}
 }
@@ -678,6 +681,36 @@ func mapAgentHarnessExecutionEventResponses(events []repository.AgentHarnessExec
 		})
 	}
 	return items
+}
+
+func agentHarnessExecutionFailureStage(status string, events []repository.AgentHarnessExecutionEvent) *string {
+	if status != string(repository.AgentHarnessExecutionStatusFailed) {
+		return nil
+	}
+	for index := len(events) - 1; index >= 0; index-- {
+		eventType := events[index].EventType
+		if eventType == "github.repository_access_revoked" {
+			stage := "repository"
+			return &stage
+		}
+		if !strings.HasSuffix(eventType, ".failed") {
+			continue
+		}
+		stage := "infrastructure"
+		switch {
+		case strings.HasPrefix(eventType, "setup."):
+			stage = "setup"
+		case strings.HasPrefix(eventType, "codex.") || strings.HasPrefix(eventType, "claude."):
+			stage = "agent"
+		case strings.HasPrefix(eventType, "validator.") || strings.HasPrefix(eventType, "scoring.") || strings.HasPrefix(eventType, "llm_judges."):
+			stage = "validator"
+		case strings.HasPrefix(eventType, "repository.") || strings.HasPrefix(eventType, "github.git_auth"):
+			stage = "repository"
+		}
+		return &stage
+	}
+	stage := "infrastructure"
+	return &stage
 }
 
 func marshalAgentHarnessSnapshot(h repository.AgentHarness, input StartAgentHarnessExecutionInput) (json.RawMessage, error) {

--- a/backend/internal/api/agent_harnesses_test.go
+++ b/backend/internal/api/agent_harnesses_test.go
@@ -575,6 +575,134 @@ func TestAgentHarnessExecutionRoutes(t *testing.T) {
 	}
 }
 
+func TestAgentHarnessExecutionRoutesSerializeFailureStage(t *testing.T) {
+	workspaceID := uuid.New()
+	harness := testAgentHarnessRecord(workspaceID, "Existing harness")
+	execution := testAgentHarnessExecutionRecord(workspaceID, harness.ID)
+	execution.Status = string(repository.AgentHarnessExecutionStatusFailed)
+	event := repository.AgentHarnessExecutionEvent{
+		ID:                      1,
+		AgentHarnessExecutionID: execution.ID,
+		SequenceNumber:          1,
+		EventType:               "setup.command.failed",
+		ActorType:               "worker",
+		OccurredAt:              time.Now().UTC(),
+		Payload:                 json.RawMessage(`{"error":"setup failed"}`),
+	}
+	service := &fakeAgentHarnessService{
+		executions: []repository.AgentHarnessExecution{execution},
+		events:     []repository.AgentHarnessExecutionEvent{event},
+	}
+	router := chi.NewRouter()
+	router.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := context.WithValue(r.Context(), callerContextKey{}, testAgentHarnessCaller(workspaceID))
+			ctx = context.WithValue(ctx, workspaceIDContextKey{}, workspaceID)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	})
+	router.Get("/v1/workspaces/{workspaceID}/agent-harness-executions", listAgentHarnessExecutionsHandler(slog.Default(), service))
+	router.Get("/v1/workspaces/{workspaceID}/agent-harness-executions/{executionID}", getAgentHarnessExecutionHandler(slog.Default(), service))
+
+	listReq := httptest.NewRequest(http.MethodGet, "/v1/workspaces/"+workspaceID.String()+"/agent-harness-executions", nil)
+	listRec := httptest.NewRecorder()
+	router.ServeHTTP(listRec, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("list status = %d, body %s", listRec.Code, listRec.Body.String())
+	}
+	var listed listAgentHarnessExecutionsResponse
+	if err := json.Unmarshal(listRec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode listed executions: %v", err)
+	}
+	if len(listed.Items) != 1 || listed.Items[0].FailureStage == nil || *listed.Items[0].FailureStage != "setup" {
+		t.Fatalf("listed failure_stage = %#v, want setup", listed.Items)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/v1/workspaces/"+workspaceID.String()+"/agent-harness-executions/"+execution.ID.String(), nil)
+	getRec := httptest.NewRecorder()
+	router.ServeHTTP(getRec, getReq)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("get status = %d, body %s", getRec.Code, getRec.Body.String())
+	}
+	var gotExecution agentHarnessExecutionResponse
+	if err := json.Unmarshal(getRec.Body.Bytes(), &gotExecution); err != nil {
+		t.Fatalf("decode execution: %v", err)
+	}
+	if gotExecution.FailureStage == nil || *gotExecution.FailureStage != "setup" {
+		t.Fatalf("failure_stage = %#v, want setup", gotExecution.FailureStage)
+	}
+}
+
+func TestAgentHarnessExecutionFailureStage(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+		events []repository.AgentHarnessExecutionEvent
+		want   *string
+	}{
+		{
+			name:   "setup",
+			status: string(repository.AgentHarnessExecutionStatusFailed),
+			events: []repository.AgentHarnessExecutionEvent{{
+				EventType: "setup.command.failed",
+			}},
+			want: stringPtr("setup"),
+		},
+		{
+			name:   "agent",
+			status: string(repository.AgentHarnessExecutionStatusFailed),
+			events: []repository.AgentHarnessExecutionEvent{{
+				EventType: "codex.exec.failed",
+			}},
+			want: stringPtr("agent"),
+		},
+		{
+			name:   "validator",
+			status: string(repository.AgentHarnessExecutionStatusFailed),
+			events: []repository.AgentHarnessExecutionEvent{{
+				EventType: "validator.command.failed",
+			}},
+			want: stringPtr("validator"),
+		},
+		{
+			name:   "non failed execution",
+			status: string(repository.AgentHarnessExecutionStatusRunning),
+			events: []repository.AgentHarnessExecutionEvent{{
+				EventType: "setup.command.failed",
+			}},
+			want: nil,
+		},
+		{
+			name:   "repository access revoked",
+			status: string(repository.AgentHarnessExecutionStatusFailed),
+			events: []repository.AgentHarnessExecutionEvent{{
+				EventType: "github.repository_access_revoked",
+			}},
+			want: stringPtr("repository"),
+		},
+		{
+			name:   "infrastructure fallback",
+			status: string(repository.AgentHarnessExecutionStatusFailed),
+			events: nil,
+			want:   stringPtr("infrastructure"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := agentHarnessExecutionFailureStage(tt.status, tt.events)
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("failure stage = %q, want nil", *got)
+				}
+				return
+			}
+			if got == nil || *got != *tt.want {
+				t.Fatalf("failure stage = %#v, want %q", got, *tt.want)
+			}
+		})
+	}
+}
+
 func testAgentHarnessCaller(workspaceID uuid.UUID) Caller {
 	return testAgentHarnessCallerWithRole(workspaceID, RoleWorkspaceAdmin)
 }

--- a/backend/internal/workflow/agent_harness_execution_workflow.go
+++ b/backend/internal/workflow/agent_harness_execution_workflow.go
@@ -40,7 +40,15 @@ type ExecuteAgentHarnessExecutionInput struct {
 }
 
 type agentHarnessExecutionConfig struct {
-	TimeoutSeconds int `json:"timeout_seconds,omitempty"`
+	TimeoutSeconds int                        `json:"timeout_seconds,omitempty"`
+	SetupCommands  []agentHarnessSetupCommand `json:"setup_commands,omitempty"`
+}
+
+type agentHarnessSetupCommand struct {
+	Name             string `json:"name,omitempty"`
+	Command          string `json:"command"`
+	WorkingDirectory string `json:"working_directory,omitempty"`
+	TimeoutSeconds   int    `json:"timeout_seconds,omitempty"`
 }
 
 type agentHarnessEvaluationConfig struct {
@@ -198,6 +206,14 @@ func (a *Activities) ExecuteAgentHarnessExecution(ctx context.Context, input Exe
 	if err := a.recordAgentHarnessEvent(ctx, execution.ID, "sandbox.created", "worker", map[string]any{"sandbox_id": session.ID(), "template": harness.CodexTemplate}); err != nil {
 		return err
 	}
+	if err := a.recordAgentHarnessEvent(ctx, execution.ID, "setup.runtime.detected", "worker", map[string]any{
+		"template":         harness.CodexTemplate,
+		"harness_kind":     harness.HarnessKind,
+		"agent_tool":       agentHarnessToolName(harness),
+		"metadata_version": 1,
+	}); err != nil {
+		return err
+	}
 
 	workdir := agentHarnessWorkspaceDir
 	hasRepository := harness.RepositoryURL != nil && strings.TrimSpace(*harness.RepositoryURL) != ""
@@ -224,8 +240,13 @@ func (a *Activities) ExecuteAgentHarnessExecution(ctx context.Context, input Exe
 				return fmt.Errorf("repository checkout failed with exit code %d", result.ExitCode)
 			}
 		}
+		_ = a.detectAgentHarnessSetupHints(ctx, execution.ID, session, workdir, gitEnv)
 	} else {
 		workdir = "/"
+	}
+
+	if err := a.runAgentHarnessSetupCommands(ctx, execution.ID, session, execution.ExecutionConfigSnapshot, workdir, timeout, env); err != nil {
+		return err
 	}
 
 	runner, err := agentHarnessRunnerFor(harness, workdir)
@@ -428,6 +449,15 @@ func normalizeAgentHarnessKind(kind string) string {
 	return trimmed
 }
 
+func agentHarnessToolName(h agentHarnessSnapshot) string {
+	switch normalizeAgentHarnessKind(h.HarnessKind) {
+	case "claude_e2b":
+		return "claude"
+	default:
+		return "codex"
+	}
+}
+
 type agentHarnessGitChanges struct {
 	ChangedFiles       string
 	WorkingTreeChanges string
@@ -462,6 +492,42 @@ func combineGitChangeLists(lists ...string) string {
 		}
 	}
 	return strings.Join(parts, "\n")
+}
+
+func splitNonEmptyLines(raw string) []string {
+	lines := strings.Split(raw, "\n")
+	items := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			items = append(items, trimmed)
+		}
+	}
+	return items
+}
+
+func agentHarnessSetupHints(paths []string) []map[string]string {
+	hints := make([]map[string]string, 0, len(paths))
+	for _, path := range paths {
+		kind := "unknown"
+		switch {
+		case path == ".devcontainer/devcontainer.json" || path == "devcontainer.json":
+			kind = "devcontainer"
+		case strings.HasPrefix(path, ".github/workflows/"):
+			kind = "github_workflow"
+		case path == "go.mod":
+			kind = "go"
+		case path == "Cargo.toml":
+			kind = "rust"
+		case path == "package.json":
+			kind = "node"
+		case path == "pyproject.toml":
+			kind = "python"
+		case path == "flake.nix":
+			kind = "nix"
+		}
+		hints = append(hints, map[string]string{"path": path, "kind": kind})
+	}
+	return hints
 }
 
 func (a *Activities) createGitHubPullRequest(ctx context.Context, executionID uuid.UUID, session sandbox.Session, harness agentHarnessSnapshot, workdir string, timeout time.Duration, gitEnv map[string]string, token string, changes agentHarnessGitChanges) error {
@@ -580,6 +646,16 @@ func (a *Activities) execHarnessCommand(ctx context.Context, executionID uuid.UU
 	return result, a.recordAgentHarnessEvent(ctx, executionID, eventType+".failed", "worker", payload)
 }
 
+func (a *Activities) execAgentHarnessShellCommand(ctx context.Context, executionID uuid.UUID, session sandbox.Session, eventType string, command string, configuredWorkdir string, timeoutSeconds int, defaultWorkdir string, defaultTimeout time.Duration, env map[string]string) (sandbox.ExecResult, string, error) {
+	workdir := agentHarnessValidatorWorkdir(defaultWorkdir, configuredWorkdir)
+	timeout := defaultTimeout
+	if timeoutSeconds > 0 {
+		timeout = time.Duration(timeoutSeconds) * time.Second
+	}
+	result, err := a.execHarnessCommand(ctx, executionID, session, eventType, []string{"bash", "-lc", command}, workdir, timeout, env)
+	return result, workdir, err
+}
+
 func (a *Activities) evaluateAgentHarnessExecution(ctx context.Context, executionID uuid.UUID, session sandbox.Session, rawConfig json.RawMessage, workdir string, defaultTimeout time.Duration, env map[string]string) error {
 	config, err := decodeAgentHarnessEvaluationConfig(rawConfig)
 	if err != nil {
@@ -624,6 +700,61 @@ func (a *Activities) evaluateAgentHarnessExecution(ctx context.Context, executio
 	return a.recordAgentHarnessEvent(ctx, executionID, "scoring.completed", "worker", map[string]any{"passed": passed, "failed": failed, "skipped": skipped, "score": agentHarnessScore(passed, failed)})
 }
 
+func (a *Activities) detectAgentHarnessSetupHints(ctx context.Context, executionID uuid.UUID, session sandbox.Session, workdir string, env map[string]string) error {
+	result, err := a.execHarnessCommand(ctx, executionID, session, "setup.hints.detect", []string{"bash", "-lc", "for f in .devcontainer/devcontainer.json devcontainer.json .github/workflows/*.yml .github/workflows/*.yaml go.mod Cargo.toml package.json pyproject.toml flake.nix; do [ -e \"$f\" ] && echo \"$f\"; done"}, workdir, 30*time.Second, env)
+	if err != nil {
+		return a.recordAgentHarnessEvent(ctx, executionID, "setup.hints.detected", "worker", map[string]any{"hints": []map[string]string{}, "error": err.Error()})
+	}
+	if result.ExitCode != 0 {
+		return a.recordAgentHarnessEvent(ctx, executionID, "setup.hints.detected", "worker", map[string]any{"hints": []map[string]string{}, "error": fmt.Sprintf("setup hint detection failed with exit code %d", result.ExitCode)})
+	}
+	hints := agentHarnessSetupHints(splitNonEmptyLines(result.Stdout))
+	return a.recordAgentHarnessEvent(ctx, executionID, "setup.hints.detected", "worker", map[string]any{"hints": hints})
+}
+
+func (a *Activities) runAgentHarnessSetupCommands(ctx context.Context, executionID uuid.UUID, session sandbox.Session, rawConfig json.RawMessage, defaultWorkdir string, defaultTimeout time.Duration, env map[string]string) error {
+	cfg := agentHarnessExecutionConfig{}
+	if len(rawConfig) > 0 && string(rawConfig) != "null" {
+		if err := json.Unmarshal(rawConfig, &cfg); err != nil {
+			_ = a.recordAgentHarnessEvent(ctx, executionID, "setup.config.failed", "worker", map[string]any{"error": err.Error()})
+			return fmt.Errorf("decode execution_config setup commands: %w", err)
+		}
+	}
+	if len(cfg.SetupCommands) == 0 {
+		return a.recordAgentHarnessEvent(ctx, executionID, "setup.skipped", "worker", map[string]any{"reason": "execution_config has no setup_commands"})
+	}
+	for index, setup := range cfg.SetupCommands {
+		command := strings.TrimSpace(setup.Command)
+		if command == "" {
+			err := fmt.Errorf("setup command %d is missing command", index)
+			_ = a.recordAgentHarnessEvent(ctx, executionID, "setup.command.failed", "worker", map[string]any{"index": index, "error": err.Error()})
+			return err
+		}
+		name := strings.TrimSpace(setup.Name)
+		if name == "" {
+			name = fmt.Sprintf("setup-%d", index+1)
+		}
+		result, workdir, err := a.execAgentHarnessShellCommand(ctx, executionID, session, "setup.command.exec", command, setup.WorkingDirectory, setup.TimeoutSeconds, defaultWorkdir, defaultTimeout, env)
+		if err != nil {
+			_ = a.recordAgentHarnessEvent(ctx, executionID, "setup.command.failed", "worker", map[string]any{"index": index, "name": name, "command": command, "error": err.Error()})
+			return err
+		}
+		payload := map[string]any{"index": index, "name": name, "command": command, "working_directory": workdir, "exit_code": result.ExitCode}
+		if result.ExitCode != 0 {
+			payload["stdout"] = result.Stdout
+			payload["stderr"] = result.Stderr
+			err := fmt.Errorf("setup command %q failed with exit code %d", name, result.ExitCode)
+			payload["error"] = err.Error()
+			_ = a.recordAgentHarnessEvent(ctx, executionID, "setup.command.failed", "worker", payload)
+			return err
+		}
+		if err := a.recordAgentHarnessEvent(ctx, executionID, "setup.command.completed", "worker", payload); err != nil {
+			return err
+		}
+	}
+	return a.recordAgentHarnessEvent(ctx, executionID, "setup.completed", "worker", map[string]any{"commands": len(cfg.SetupCommands)})
+}
+
 func (a *Activities) evaluateCommandValidator(ctx context.Context, executionID uuid.UUID, session sandbox.Session, validator agentHarnessValidatorConfig, index int, defaultWorkdir string, defaultTimeout time.Duration, env map[string]string) (bool, error) {
 	command := strings.TrimSpace(validator.Command)
 	if command == "" {
@@ -631,13 +762,7 @@ func (a *Activities) evaluateCommandValidator(ctx context.Context, executionID u
 		_ = a.recordAgentHarnessEvent(ctx, executionID, "validator.command.failed", "worker", map[string]any{"index": index, "error": err.Error()})
 		return false, err
 	}
-	workdir := agentHarnessValidatorWorkdir(defaultWorkdir, validator.WorkingDirectory)
-	timeout := defaultTimeout
-	if validator.TimeoutSeconds > 0 {
-		timeout = time.Duration(validator.TimeoutSeconds) * time.Second
-	}
-
-	result, err := a.execHarnessCommand(ctx, executionID, session, "validator.command.exec", []string{"bash", "-lc", command}, workdir, timeout, env)
+	result, workdir, err := a.execAgentHarnessShellCommand(ctx, executionID, session, "validator.command.exec", command, validator.WorkingDirectory, validator.TimeoutSeconds, defaultWorkdir, defaultTimeout, env)
 	payload := map[string]any{
 		"index":             index,
 		"command":           command,

--- a/backend/internal/workflow/agent_harness_execution_workflow_test.go
+++ b/backend/internal/workflow/agent_harness_execution_workflow_test.go
@@ -32,7 +32,7 @@ func TestExecuteAgentHarnessExecutionRunsCodexAndRecordsTrace(t *testing.T) {
 		OpenAIAPIKeySecretName: &openAISecret,
 		RepositoryURL:          stringPtr("https://github.com/acme/repo"),
 		BaseBranch:             stringPtr("main"),
-		ExecutionConfig:        json.RawMessage(`{"timeout_seconds":120}`),
+		ExecutionConfig:        json.RawMessage(`{"timeout_seconds":120,"setup_commands":[{"name":"deps","command":"go mod download","working_directory":"backend","timeout_seconds":30}]}`),
 		EvaluationConfig:       json.RawMessage(`{"validators":[{"type":"command","command":"go test ./...","working_directory":"backend","timeout_seconds":60}]}`),
 	})
 	repo.setAgentHarnessExecution(repository.AgentHarnessExecution{
@@ -42,7 +42,7 @@ func TestExecuteAgentHarnessExecutionRunsCodexAndRecordsTrace(t *testing.T) {
 		RunID:                   &runID,
 		RunAgentID:              &runAgentID,
 		Status:                  string(repository.AgentHarnessExecutionStatusRunning),
-		ExecutionConfigSnapshot: json.RawMessage(`{"timeout_seconds":120}`),
+		ExecutionConfigSnapshot: json.RawMessage(`{"timeout_seconds":120,"setup_commands":[{"name":"deps","command":"go mod download","working_directory":"backend","timeout_seconds":30}]}`),
 	})
 	repo.setWorkspaceSecrets(workspaceID, map[string]string{
 		openAISecret: "sk-test",
@@ -55,6 +55,13 @@ func TestExecuteAgentHarnessExecutionRunsCodexAndRecordsTrace(t *testing.T) {
 			return sandbox.ExecResult{ExitCode: 0, Stdout: "cloned"}, nil
 		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "checkout":
 			return sandbox.ExecResult{ExitCode: 0, Stdout: "checked out"}, nil
+		case len(request.Command) >= 3 && request.Command[0] == "bash" && request.Command[1] == "-lc" && strings.Contains(request.Command[2], ".devcontainer/devcontainer.json"):
+			return sandbox.ExecResult{ExitCode: 0, Stdout: "go.mod\npackage.json\n"}, nil
+		case len(request.Command) >= 3 && request.Command[0] == "bash" && request.Command[1] == "-lc" && request.Command[2] == "go mod download":
+			if request.WorkingDirectory != agentHarnessWorkspaceDir+"/backend" {
+				t.Fatalf("setup workdir = %q, want backend under workspace", request.WorkingDirectory)
+			}
+			return sandbox.ExecResult{ExitCode: 0, Stdout: "downloaded"}, nil
 		case len(request.Command) >= 2 && request.Command[0] == "codex" && request.Command[1] == "exec":
 			if request.Environment["CODEX_API_KEY"] != "sk-test" || request.Environment["OPENAI_API_KEY"] != "sk-test" {
 				t.Fatalf("codex env = %#v, want OpenAI and Codex keys", request.Environment)
@@ -103,6 +110,8 @@ func TestExecuteAgentHarnessExecutionRunsCodexAndRecordsTrace(t *testing.T) {
 	calls := session.ExecCalls()
 	addIntentIndex := commandIndex(calls, "git", "add", "--intent-to-add")
 	diffIndex := commandIndex(calls, "git", "diff", "--binary")
+	setupIndex := commandIndex(calls, "bash", "-lc", "go mod download")
+	codexIndex := commandIndex(calls, "codex", "exec")
 	if addIntentIndex == -1 {
 		t.Fatal("expected git add --intent-to-add before diff capture")
 	}
@@ -112,12 +121,17 @@ func TestExecuteAgentHarnessExecutionRunsCodexAndRecordsTrace(t *testing.T) {
 	if addIntentIndex > diffIndex {
 		t.Fatalf("git add --intent-to-add call index = %d, diff index = %d; want add before diff", addIntentIndex, diffIndex)
 	}
+	if setupIndex == -1 || codexIndex == -1 || setupIndex > codexIndex {
+		t.Fatalf("setup command index = %d, codex index = %d; want setup before codex", setupIndex, codexIndex)
+	}
 	if got := len(repo.agentHarnessEvents[executionID]); got < 8 {
 		t.Fatalf("recorded events = %d, want at least 8", got)
 	}
 	var sawCodexOutput bool
 	var sawValidatorPassed bool
 	var sawScoringCompleted bool
+	var sawSetupCompleted bool
+	var sawHints bool
 	for _, event := range repo.agentHarnessEvents[executionID] {
 		switch event.EventType {
 		case "codex.exec.output":
@@ -133,6 +147,30 @@ func TestExecuteAgentHarnessExecutionRunsCodexAndRecordsTrace(t *testing.T) {
 			sawValidatorPassed = true
 		case "scoring.completed":
 			sawScoringCompleted = true
+		case "setup.command.completed":
+			sawSetupCompleted = true
+		case "setup.hints.detected":
+			sawHints = true
+			var payload map[string]any
+			if err := json.Unmarshal(event.Payload, &payload); err != nil {
+				t.Fatalf("decode setup hints payload: %v", err)
+			}
+			hints, ok := payload["hints"].([]any)
+			if !ok || len(hints) != 2 {
+				t.Fatalf("setup hints = %#v, want two structured hints", payload["hints"])
+			}
+			first, ok := hints[0].(map[string]any)
+			if !ok || first["kind"] != "go" || first["path"] != "go.mod" {
+				t.Fatalf("first setup hint = %#v, want go.mod kind go", hints[0])
+			}
+		case "setup.runtime.detected":
+			var payload map[string]any
+			if err := json.Unmarshal(event.Payload, &payload); err != nil {
+				t.Fatalf("decode setup runtime payload: %v", err)
+			}
+			if payload["template"] != "codex" || payload["agent_tool"] != "codex" || payload["metadata_version"] != float64(1) {
+				t.Fatalf("runtime payload = %#v, want template/tool metadata", payload)
+			}
 		}
 	}
 	if !sawCodexOutput {
@@ -143,6 +181,12 @@ func TestExecuteAgentHarnessExecutionRunsCodexAndRecordsTrace(t *testing.T) {
 	}
 	if !sawScoringCompleted {
 		t.Fatal("expected scoring completed event")
+	}
+	if !sawSetupCompleted {
+		t.Fatal("expected setup command completed event")
+	}
+	if !sawHints {
+		t.Fatal("expected setup hints detected event")
 	}
 	runEvents := repo.runEvents[runAgentID]
 	if len(runEvents) == 0 {
@@ -210,6 +254,8 @@ func TestExecuteAgentHarnessExecutionFailsRequiredValidator(t *testing.T) {
 		switch {
 		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "clone":
 			return sandbox.ExecResult{ExitCode: 0}, nil
+		case isSetupHintsCommand(request.Command):
+			return sandbox.ExecResult{ExitCode: 0}, nil
 		case len(request.Command) >= 2 && request.Command[0] == "codex" && request.Command[1] == "exec":
 			return sandbox.ExecResult{ExitCode: 0, Stdout: `{"type":"final","message":"done"}`}, nil
 		case len(request.Command) >= 3 && request.Command[0] == "git" && request.Command[1] == "add" && request.Command[2] == "--intent-to-add":
@@ -258,6 +304,196 @@ func TestExecuteAgentHarnessExecutionFailsRequiredValidator(t *testing.T) {
 	}
 	if repo.callCountWithPrefix("BuildRunAgentReplay:"+runAgentID.String()) != 1 {
 		t.Fatalf("BuildRunAgentReplay call count = %d, want 1", repo.callCountWithPrefix("BuildRunAgentReplay:"+runAgentID.String()))
+	}
+}
+
+func TestExecuteAgentHarnessExecutionFailsSetupBeforeAgent(t *testing.T) {
+	workspaceID := uuid.New()
+	harnessID := uuid.New()
+	executionID := uuid.New()
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	openAISecret := "OPENAI_API_KEY"
+	repo := newFakeRunRepository(fixtureRun(runID, domain.RunStatusQueued), fixtureRunAgent(runID, runAgentID, 0))
+	repo.setAgentHarness(repository.AgentHarness{
+		ID:                     harnessID,
+		OrganizationID:         uuid.New(),
+		WorkspaceID:            workspaceID,
+		TaskPrompt:             "implement issue 462",
+		CodexTemplate:          "codex",
+		AuthMode:               "api_key_secret",
+		OpenAIAPIKeySecretName: &openAISecret,
+		RepositoryURL:          stringPtr("https://github.com/acme/repo"),
+		ExecutionConfig:        json.RawMessage(`{"timeout_seconds":120,"setup_commands":[{"name":"deps","command":"go mod download"}]}`),
+	})
+	repo.setAgentHarnessExecution(repository.AgentHarnessExecution{
+		ID:                      executionID,
+		WorkspaceID:             workspaceID,
+		AgentHarnessID:          harnessID,
+		RunID:                   &runID,
+		RunAgentID:              &runAgentID,
+		Status:                  string(repository.AgentHarnessExecutionStatusRunning),
+		ExecutionConfigSnapshot: json.RawMessage(`{"timeout_seconds":120,"setup_commands":[{"name":"deps","command":"go mod download"}]}`),
+	})
+	repo.setWorkspaceSecrets(workspaceID, map[string]string{openAISecret: "sk-test"})
+
+	session := sandbox.NewFakeSession("sandbox-1")
+	session.SetExecFunc(func(request sandbox.ExecRequest, _ map[string][]byte) (sandbox.ExecResult, error) {
+		switch {
+		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "clone":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case isSetupHintsCommand(request.Command):
+			return sandbox.ExecResult{ExitCode: 0, Stdout: "go.mod\n"}, nil
+		case len(request.Command) >= 3 && request.Command[0] == "bash" && request.Command[1] == "-lc" && request.Command[2] == "go mod download":
+			return sandbox.ExecResult{ExitCode: 1, Stderr: "module download failed"}, nil
+		case len(request.Command) >= 2 && request.Command[0] == "codex" && request.Command[1] == "exec":
+			t.Fatalf("codex should not run after setup failure")
+			return sandbox.ExecResult{}, nil
+		default:
+			t.Fatalf("unexpected command: %#v", request.Command)
+			return sandbox.ExecResult{}, nil
+		}
+	})
+	provider := &sandbox.FakeProvider{NextSession: session}
+	activities := NewActivities(repo, FakeWorkHooks{}).WithSandboxProvider(provider)
+
+	err := activities.ExecuteAgentHarnessExecution(context.Background(), ExecuteAgentHarnessExecutionInput{ExecutionID: executionID})
+	if err == nil || !strings.Contains(err.Error(), `setup command "deps" failed`) {
+		t.Fatalf("ExecuteAgentHarnessExecution error = %v, want setup command failure", err)
+	}
+	if !agentHarnessEventRecorded(repo.agentHarnessEvents[executionID], "setup.command.failed") {
+		t.Fatal("expected setup.command.failed event")
+	}
+	if agentHarnessEventRecorded(repo.agentHarnessEvents[executionID], "codex.exec.started") {
+		t.Fatal("did not expect codex.exec.started after setup failure")
+	}
+	if repo.callCountWithPrefix("BuildRunAgentReplay:"+runAgentID.String()) != 1 {
+		t.Fatalf("BuildRunAgentReplay call count = %d, want 1", repo.callCountWithPrefix("BuildRunAgentReplay:"+runAgentID.String()))
+	}
+}
+
+func TestExecuteAgentHarnessExecutionReportsAgentFailureSeparately(t *testing.T) {
+	workspaceID := uuid.New()
+	harnessID := uuid.New()
+	executionID := uuid.New()
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	openAISecret := "OPENAI_API_KEY"
+	repo := newFakeRunRepository(fixtureRun(runID, domain.RunStatusQueued), fixtureRunAgent(runID, runAgentID, 0))
+	repo.setAgentHarness(repository.AgentHarness{
+		ID:                     harnessID,
+		OrganizationID:         uuid.New(),
+		WorkspaceID:            workspaceID,
+		TaskPrompt:             "implement issue 462",
+		CodexTemplate:          "codex",
+		AuthMode:               "api_key_secret",
+		OpenAIAPIKeySecretName: &openAISecret,
+		ExecutionConfig:        json.RawMessage(`{"timeout_seconds":120}`),
+	})
+	repo.setAgentHarnessExecution(repository.AgentHarnessExecution{
+		ID:                      executionID,
+		WorkspaceID:             workspaceID,
+		AgentHarnessID:          harnessID,
+		RunID:                   &runID,
+		RunAgentID:              &runAgentID,
+		Status:                  string(repository.AgentHarnessExecutionStatusRunning),
+		ExecutionConfigSnapshot: json.RawMessage(`{"timeout_seconds":120}`),
+	})
+	repo.setWorkspaceSecrets(workspaceID, map[string]string{openAISecret: "sk-test"})
+
+	session := sandbox.NewFakeSession("sandbox-1")
+	session.SetExecFunc(func(request sandbox.ExecRequest, _ map[string][]byte) (sandbox.ExecResult, error) {
+		switch {
+		case len(request.Command) >= 2 && request.Command[0] == "codex" && request.Command[1] == "exec":
+			return sandbox.ExecResult{ExitCode: 1, Stderr: "agent failed"}, nil
+		default:
+			t.Fatalf("unexpected command: %#v", request.Command)
+			return sandbox.ExecResult{}, nil
+		}
+	})
+	provider := &sandbox.FakeProvider{NextSession: session}
+	activities := NewActivities(repo, FakeWorkHooks{}).WithSandboxProvider(provider)
+
+	err := activities.ExecuteAgentHarnessExecution(context.Background(), ExecuteAgentHarnessExecutionInput{ExecutionID: executionID})
+	if err == nil || !strings.Contains(err.Error(), "codex exec failed with exit code 1") {
+		t.Fatalf("ExecuteAgentHarnessExecution error = %v, want agent command failure", err)
+	}
+	if !agentHarnessEventRecorded(repo.agentHarnessEvents[executionID], "setup.skipped") {
+		t.Fatal("expected setup.skipped event before agent failure")
+	}
+	if !agentHarnessEventRecorded(repo.agentHarnessEvents[executionID], "codex.exec.failed") {
+		t.Fatal("expected codex.exec.failed event")
+	}
+	if agentHarnessEventRecorded(repo.agentHarnessEvents[executionID], "validator.command.failed") {
+		t.Fatal("did not expect validator failure event for agent failure")
+	}
+	if repo.callCountWithPrefix("BuildRunAgentReplay:"+runAgentID.String()) != 1 {
+		t.Fatalf("BuildRunAgentReplay call count = %d, want 1", repo.callCountWithPrefix("BuildRunAgentReplay:"+runAgentID.String()))
+	}
+}
+
+func TestExecuteAgentHarnessExecutionContinuesWhenSetupHintDetectionFails(t *testing.T) {
+	workspaceID := uuid.New()
+	harnessID := uuid.New()
+	executionID := uuid.New()
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	openAISecret := "OPENAI_API_KEY"
+	repo := newFakeRunRepository(fixtureRun(runID, domain.RunStatusQueued), fixtureRunAgent(runID, runAgentID, 0))
+	repo.setAgentHarness(repository.AgentHarness{
+		ID:                     harnessID,
+		OrganizationID:         uuid.New(),
+		WorkspaceID:            workspaceID,
+		TaskPrompt:             "implement issue 462",
+		CodexTemplate:          "codex",
+		AuthMode:               "api_key_secret",
+		OpenAIAPIKeySecretName: &openAISecret,
+		RepositoryURL:          stringPtr("https://github.com/acme/repo"),
+		ExecutionConfig:        json.RawMessage(`{"timeout_seconds":120}`),
+	})
+	repo.setAgentHarnessExecution(repository.AgentHarnessExecution{
+		ID:                      executionID,
+		WorkspaceID:             workspaceID,
+		AgentHarnessID:          harnessID,
+		RunID:                   &runID,
+		RunAgentID:              &runAgentID,
+		Status:                  string(repository.AgentHarnessExecutionStatusRunning),
+		ExecutionConfigSnapshot: json.RawMessage(`{"timeout_seconds":120}`),
+	})
+	repo.setWorkspaceSecrets(workspaceID, map[string]string{openAISecret: "sk-test"})
+
+	session := sandbox.NewFakeSession("sandbox-1")
+	session.SetExecFunc(func(request sandbox.ExecRequest, _ map[string][]byte) (sandbox.ExecResult, error) {
+		switch {
+		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "clone":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case isSetupHintsCommand(request.Command):
+			return sandbox.ExecResult{ExitCode: 127, Stderr: "bash unavailable"}, nil
+		case len(request.Command) >= 2 && request.Command[0] == "codex" && request.Command[1] == "exec":
+			return sandbox.ExecResult{ExitCode: 0, Stdout: `{"type":"final","message":"done"}`}, nil
+		case len(request.Command) >= 3 && request.Command[0] == "git" && request.Command[1] == "add" && request.Command[2] == "--intent-to-add":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "diff":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "status":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		default:
+			t.Fatalf("unexpected command: %#v", request.Command)
+			return sandbox.ExecResult{}, nil
+		}
+	})
+	provider := &sandbox.FakeProvider{NextSession: session}
+	activities := NewActivities(repo, FakeWorkHooks{}).WithSandboxProvider(provider)
+
+	err := activities.ExecuteAgentHarnessExecution(context.Background(), ExecuteAgentHarnessExecutionInput{ExecutionID: executionID})
+	if err != nil {
+		t.Fatalf("ExecuteAgentHarnessExecution error = %v, want setup hint failure to be non-fatal", err)
+	}
+	if !agentHarnessEventRecorded(repo.agentHarnessEvents[executionID], "setup.hints.detect.failed") {
+		t.Fatal("expected setup.hints.detect.failed event")
+	}
+	if !agentHarnessEventRecorded(repo.agentHarnessEvents[executionID], "codex.exec.started") {
+		t.Fatal("expected codex to run after setup hint failure")
 	}
 }
 
@@ -558,6 +794,8 @@ func TestExecuteAgentHarnessExecutionCreatesDraftPullRequestForGitHubHarness(t *
 			return sandbox.ExecResult{ExitCode: 0}, nil
 		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "checkout" && request.Command[2] == "main":
 			return sandbox.ExecResult{ExitCode: 0}, nil
+		case isSetupHintsCommand(request.Command):
+			return sandbox.ExecResult{ExitCode: 0}, nil
 		case len(request.Command) >= 2 && request.Command[0] == "codex" && request.Command[1] == "exec":
 			if _, ok := request.Environment["GITHUB_TOKEN"]; ok {
 				t.Fatal("codex env must not include github token")
@@ -678,6 +916,8 @@ func TestExecuteAgentHarnessExecutionCreatesPullRequestForAgentCommittedChanges(
 		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "clone":
 			return sandbox.ExecResult{ExitCode: 0}, nil
 		case len(request.Command) >= 3 && request.Command[0] == "git" && request.Command[1] == "checkout" && request.Command[2] == "main":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case isSetupHintsCommand(request.Command):
 			return sandbox.ExecResult{ExitCode: 0}, nil
 		case len(request.Command) >= 2 && request.Command[0] == "codex" && request.Command[1] == "exec":
 			return sandbox.ExecResult{ExitCode: 0, Stdout: `{"type":"final","message":"committed"}`}, nil
@@ -800,6 +1040,8 @@ func TestExecuteAgentHarnessExecutionSkipsPullRequestWhenNoChanges(t *testing.T)
 		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "clone":
 			return sandbox.ExecResult{ExitCode: 0}, nil
 		case len(request.Command) >= 2 && request.Command[0] == "git" && request.Command[1] == "checkout" && request.Command[2] == "main":
+			return sandbox.ExecResult{ExitCode: 0}, nil
+		case isSetupHintsCommand(request.Command):
 			return sandbox.ExecResult{ExitCode: 0}, nil
 		case len(request.Command) >= 2 && request.Command[0] == "codex" && request.Command[1] == "exec":
 			return sandbox.ExecResult{ExitCode: 0, Stdout: `{"type":"final","message":"done"}`}, nil
@@ -934,6 +1176,14 @@ func isGitSubcommand(command []string, subcommand string) bool {
 		}
 	}
 	return false
+}
+
+func isSetupHintsCommand(command []string) bool {
+	return len(command) >= 3 &&
+		command[0] == "bash" &&
+		command[1] == "-lc" &&
+		strings.Contains(command[2], ".devcontainer/devcontainer.json") &&
+		strings.Contains(command[2], "Cargo.toml")
 }
 
 func commandIndex(calls []sandbox.ExecRequest, parts ...string) int {

--- a/testing/codex-issue-585-harness-bootstrap-local-test-log.md
+++ b/testing/codex-issue-585-harness-bootstrap-local-test-log.md
@@ -1,0 +1,22 @@
+# Issue #585 Local Test Log
+
+## Commands
+
+- `cd backend && go test ./internal/workflow`
+- `cd backend && go test ./internal/repository ./internal/api`
+- `cd backend && go test ./...`
+- `cd web && npm test -- --run 'src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx'`
+- `cd web && npm run lint -- 'src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.tsx' 'src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx'`
+
+## Result
+
+- `go test ./internal/workflow` passed.
+- `go test ./internal/repository ./internal/api` passed.
+- `go test ./...` passed.
+- Focused Agent Harness UI tests passed.
+- Focused Agent Harness UI lint passed.
+
+## Notes
+
+- The bootstrap stage reuses the existing sandbox command executor and harness event recording path.
+- Setup events are regular harness events, so the canonical run event/replay bridge from issue #582 can mirror them without a separate replay implementation.

--- a/testing/codex-issue-585-harness-bootstrap.md
+++ b/testing/codex-issue-585-harness-bootstrap.md
@@ -1,0 +1,17 @@
+# Test Contract: Issue #585 Harness Bootstrap
+
+## Intent
+
+Make repository setup a first-class Agent Harness stage so arbitrary repo stacks can prepare dependencies before the coding agent runs.
+
+## Expectations
+
+- `execution_config.setup_commands` runs after repository checkout and before the agent command.
+- Setup command events are distinct from agent, validator, and infrastructure events.
+- Setup command failures stop the harness with a setup-specific failure reason.
+- Harness executions record runtime/template metadata and repository setup hints.
+- Agent failures remain distinct from setup failures.
+
+## Verification
+
+- `go test ./internal/workflow`

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx
@@ -495,6 +495,39 @@ describe("AgentHarnessesClient", () => {
     rendered.cleanup();
   });
 
+  it("classifies setup failures separately from agent failures", () => {
+    mockExecutions.mockReturnValue([
+      baseExecution({
+        status: "failed",
+        failure_stage: "setup",
+        error_message: "Setup command failed",
+        events: [
+          {
+            id: "event-setup-failed",
+            agent_harness_execution_id: "execution-1",
+            sequence_number: 1,
+            event_type: "setup.command.exec.failed",
+            actor_type: "worker",
+            occurred_at: "2026-05-01T00:01:05Z",
+            payload: {
+              command: ["bash", "-lc", "go mod download"],
+              working_directory: "/workspace",
+              exit_code: 1,
+            },
+          },
+        ],
+      }),
+    ]);
+    const rendered = renderClient();
+
+    expect(document.body.textContent).toContain("Setup failed");
+    expect(document.body.textContent).toContain("Setup command failed");
+    expect(document.body.textContent).toContain("Setupfailed");
+    expect(document.body.textContent).toContain("Agent workwaiting");
+
+    rendered.cleanup();
+  });
+
   it("keeps loading, error, and empty states readable", () => {
     mockHarnessQuery.mockReturnValueOnce({ isLoading: true });
     let rendered = renderClient();

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.tsx
@@ -51,6 +51,7 @@ const statusVariant: Record<string, "default" | "secondary" | "outline"> = {
 const phaseOrder = [
   "sandbox",
   "repository",
+  "setup",
   "agent",
   "diff",
   "validation",
@@ -62,8 +63,9 @@ type HarnessPhase = (typeof phaseOrder)[number];
 type HarnessPhaseState = "waiting" | "running" | "done" | "failed";
 
 const phaseLabels: Record<HarnessPhase, string> = {
-  sandbox: "Setup",
+  sandbox: "Sandbox",
   repository: "Repository",
+  setup: "Setup",
   agent: "Agent work",
   diff: "Diff",
   validation: "Validation",
@@ -412,7 +414,10 @@ function LatestRunPanel({
 
       <div className="space-y-4 p-4">
         {execution.status === "failed" ? (
-          <FailureNotice message={failureMessage} />
+          <FailureNotice
+            message={failureMessage}
+            stage={execution.failure_stage}
+          />
         ) : null}
 
         <PhaseProgress execution={execution} />
@@ -457,14 +462,21 @@ function LatestRunPanel({
   );
 }
 
-function FailureNotice({ message }: { message: string }) {
+function FailureNotice({
+  message,
+  stage,
+}: {
+  message: string;
+  stage?: AgentHarnessExecution["failure_stage"];
+}) {
+  const title = stage ? `${failureStageLabel(stage)} failed` : "This run needs attention";
   return (
     <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-3">
       <div className="flex items-start gap-2">
         <AlertCircle className="mt-0.5 size-4 shrink-0 text-destructive" />
         <div className="min-w-0">
           <div className="text-sm font-medium text-destructive">
-            This run needs attention
+            {title}
           </div>
           <p className="mt-1 whitespace-pre-wrap break-words text-sm text-destructive/90">
             {message || "Open the summarized activity details and check the latest failed step."}
@@ -473,6 +485,21 @@ function FailureNotice({ message }: { message: string }) {
       </div>
     </div>
   );
+}
+
+function failureStageLabel(stage: NonNullable<AgentHarnessExecution["failure_stage"]>) {
+  switch (stage) {
+    case "setup":
+      return "Setup";
+    case "agent":
+      return "Agent";
+    case "validator":
+      return "Validation";
+    case "repository":
+      return "Repository";
+    case "infrastructure":
+      return "Infrastructure";
+  }
 }
 
 function PhaseProgress({ execution }: { execution: AgentHarnessExecution }) {
@@ -654,6 +681,7 @@ function phaseStates(execution: AgentHarnessExecution) {
   const states: Record<HarnessPhase, HarnessPhaseState> = {
     sandbox: "waiting",
     repository: "waiting",
+    setup: "waiting",
     agent: "waiting",
     diff: "waiting",
     validation: "waiting",
@@ -689,6 +717,7 @@ function eventPhase(eventType: string): HarnessPhase | null {
   if (eventType.startsWith("repository.") || eventType.startsWith("github.git_auth")) {
     return "repository";
   }
+  if (eventType.startsWith("setup.")) return "setup";
   if (
     eventType.startsWith("codex.") ||
     eventType.startsWith("claude.") ||

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -497,6 +497,7 @@ export interface AgentHarnessExecution {
   status: AgentHarnessExecutionStatus;
   status_reason?: string;
   error_message?: string;
+  failure_stage?: "setup" | "agent" | "validator" | "repository" | "infrastructure";
   harness_snapshot: unknown;
   execution_config_snapshot: unknown;
   evaluation_config_snapshot: unknown;


### PR DESCRIPTION
## Summary

- adds explicit `execution_config.setup_commands` support before Agent Harness runners execute
- records setup runtime metadata, structured repo setup hints, and setup command events through the existing harness event/replay path
- exposes a derived `failure_stage` so setup, agent, validator, repository, and infrastructure failures are distinguishable in API/UI
- keeps setup hint detection best-effort so custom templates do not fail only because the hint probe is unavailable

Closes #585

## DRY / reuse notes

- setup commands reuse the existing sandbox command executor and shared shell command helper used by command validators
- setup events go through `recordAgentHarnessEvent`, so canonical run events and replay reuse the bridge from #582
- no new validator, judge, scoring, replay, or artifact system is introduced

## Tests

- `cd backend && go test ./internal/workflow`
- `cd backend && go test ./internal/repository ./internal/api`
- `cd backend && go test ./...`
- `cd web && npm test -- --run 'src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx'`
- `cd web && npm run lint -- 'src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.tsx' 'src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx'`
