### PR TITLE
feat: persist harness scorecards

### DIFF
--- a/backend/internal/repository/agent_harness_executions.go
+++ b/backend/internal/repository/agent_harness_executions.go
@@ -149,6 +149,11 @@ type RecordAgentHarnessExecutionEventParams struct {
 	Payload     json.RawMessage
 }
 
+type SetAgentHarnessExecutionEvaluationSpecParams struct {
+	ExecutionID      uuid.UUID
+	EvaluationSpecID uuid.UUID
+}
+
 func (r *Repository) CreateAgentHarnessExecution(ctx context.Context, p CreateAgentHarnessExecutionParams) (AgentHarnessExecution, error) {
 	tx, err := r.db.Begin(ctx)
 	if err != nil {
@@ -312,6 +317,21 @@ SELECT id, organization_id, workspace_id, agent_harness_id, created_by_user_id,
     error_message, started_at, completed_at, cancelled_at, created_at, updated_at
 FROM agent_harness_executions
 WHERE id = $1`, id)
+	return scanAgentHarnessExecution(row)
+}
+
+func (r *Repository) SetAgentHarnessExecutionEvaluationSpec(ctx context.Context, p SetAgentHarnessExecutionEvaluationSpecParams) (AgentHarnessExecution, error) {
+	row := r.db.QueryRow(ctx, `
+UPDATE agent_harness_executions
+SET evaluation_spec_id = $2,
+    updated_at = now()
+WHERE id = $1
+RETURNING id, organization_id, workspace_id, agent_harness_id, created_by_user_id,
+    run_id, run_agent_id, evaluation_spec_id,
+    status, harness_snapshot, execution_config_snapshot, evaluation_config_snapshot,
+    error_message, started_at, completed_at, cancelled_at, created_at, updated_at`,
+		p.ExecutionID, p.EvaluationSpecID,
+	)
 	return scanAgentHarnessExecution(row)
 }
 

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -296,6 +296,13 @@ type CreateEvaluationSpecParams struct {
 	Definition             json.RawMessage
 }
 
+type CreateStandaloneEvaluationSpecParams struct {
+	Name          string
+	VersionNumber int32
+	JudgeMode     string
+	Definition    json.RawMessage
+}
+
 type RunEvent struct {
 	ID             int64
 	RunID          uuid.UUID
@@ -799,6 +806,57 @@ func (r *Repository) CreateEvaluationSpec(ctx context.Context, params CreateEval
 	}
 
 	return record, nil
+}
+
+func (r *Repository) CreateStandaloneEvaluationSpec(ctx context.Context, params CreateStandaloneEvaluationSpecParams) (EvaluationSpecRecord, error) {
+	normalizedDefinition, err := normalizeEvaluationSpecDefinition(params.Definition)
+	if err != nil {
+		return EvaluationSpecRecord{}, fmt.Errorf("create standalone evaluation spec: %w", err)
+	}
+	existing, getErr := r.getStandaloneEvaluationSpecByNameAndVersion(ctx, params.Name, params.VersionNumber)
+	if getErr == nil {
+		return existing, nil
+	}
+	if !errors.Is(getErr, ErrEvaluationSpecNotFound) {
+		return EvaluationSpecRecord{}, getErr
+	}
+	row, err := r.queries.CreateEvaluationSpec(ctx, repositorysqlc.CreateEvaluationSpecParams{
+		ChallengePackVersionID: nil,
+		Name:                   params.Name,
+		VersionNumber:          params.VersionNumber,
+		JudgeMode:              params.JudgeMode,
+		Definition:             normalizedDefinition,
+	})
+	if err != nil {
+		if existing, getErr := r.getStandaloneEvaluationSpecByNameAndVersion(ctx, params.Name, params.VersionNumber); getErr == nil {
+			return existing, nil
+		}
+		return EvaluationSpecRecord{}, fmt.Errorf("create standalone evaluation spec: %w", err)
+	}
+	record, err := mapEvaluationSpecRecord(row)
+	if err != nil {
+		return EvaluationSpecRecord{}, fmt.Errorf("map standalone evaluation spec: %w", err)
+	}
+	return record, nil
+}
+
+func (r *Repository) getStandaloneEvaluationSpecByNameAndVersion(ctx context.Context, name string, versionNumber int32) (EvaluationSpecRecord, error) {
+	var row repositorysqlc.EvaluationSpec
+	err := r.db.QueryRow(ctx, `
+SELECT id, challenge_pack_version_id, name, version_number, judge_mode, definition, created_at, updated_at
+FROM evaluation_specs
+WHERE challenge_pack_version_id IS NULL
+  AND name = $1
+  AND version_number = $2
+LIMIT 1
+`, name, versionNumber).Scan(&row.ID, &row.ChallengePackVersionID, &row.Name, &row.VersionNumber, &row.JudgeMode, &row.Definition, &row.CreatedAt, &row.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return EvaluationSpecRecord{}, ErrEvaluationSpecNotFound
+		}
+		return EvaluationSpecRecord{}, fmt.Errorf("get standalone evaluation spec by name and version: %w", err)
+	}
+	return mapEvaluationSpecRecord(row)
 }
 
 func (r *Repository) GetEvaluationSpecByID(ctx context.Context, id uuid.UUID) (EvaluationSpecRecord, error) {
@@ -2105,13 +2163,13 @@ func mapEvaluationSpecRecord(row repositorysqlc.EvaluationSpec) (EvaluationSpecR
 	if err != nil {
 		return EvaluationSpecRecord{}, err
 	}
-	if row.ChallengePackVersionID == nil {
-		return EvaluationSpecRecord{}, fmt.Errorf("evaluation_specs.challenge_pack_version_id is required")
+	challengePackVersionID := uuid.Nil
+	if row.ChallengePackVersionID != nil {
+		challengePackVersionID = *row.ChallengePackVersionID
 	}
-
 	return EvaluationSpecRecord{
 		ID:                     row.ID,
-		ChallengePackVersionID: *row.ChallengePackVersionID,
+		ChallengePackVersionID: challengePackVersionID,
 		Name:                   row.Name,
 		VersionNumber:          row.VersionNumber,
 		JudgeMode:              row.JudgeMode,

--- a/backend/internal/scoring/engine.go
+++ b/backend/internal/scoring/engine.go
@@ -186,6 +186,14 @@ func EvaluateRunAgentWithLLMJudgeResults(input EvaluationInput, spec EvaluationS
 	return evaluateRunAgentWithResolvedJudges(input, spec, llmJudgeResults, true)
 }
 
+func EvaluateRunAgentWithPrecomputedResults(input EvaluationInput, spec EvaluationSpec, validatorResults []ValidatorResult, metricResults []MetricResult, llmJudgeResults []LLMJudgeResult) (RunAgentEvaluation, error) {
+	normalizeEvaluationSpec(&spec)
+	if err := ValidateEvaluationSpec(spec); err != nil {
+		return RunAgentEvaluation{}, err
+	}
+	return finalizeRunAgentEvaluation(input, spec, validatorResults, metricResults, llmJudgeResults, nil), nil
+}
+
 func evaluateRunAgentWithResolvedJudges(
 	input EvaluationInput,
 	spec EvaluationSpec,
@@ -210,6 +218,19 @@ func evaluateRunAgentWithResolvedJudges(
 	metricResults, metricWarnings := evaluateMetrics(spec.Metrics, evidence, validatorResults, spec)
 	warnings = append(warnings, metricWarnings...)
 
+	return finalizeRunAgentEvaluationWithEvidence(input, spec, evidence, validatorResults, metricResults, llmJudgeResults, warnings), nil
+}
+
+func finalizeRunAgentEvaluation(input EvaluationInput, spec EvaluationSpec, validatorResults []ValidatorResult, metricResults []MetricResult, llmJudgeResults []LLMJudgeResult, warnings []string) RunAgentEvaluation {
+	events := append([]Event(nil), input.Events...)
+	sort.SliceStable(events, func(i, j int) bool {
+		return events[i].OccurredAt.Before(events[j].OccurredAt)
+	})
+	evidence := buildEvidence(input.ChallengeInputs, events)
+	return finalizeRunAgentEvaluationWithEvidence(input, spec, evidence, validatorResults, metricResults, llmJudgeResults, warnings)
+}
+
+func finalizeRunAgentEvaluationWithEvidence(input EvaluationInput, spec EvaluationSpec, evidence extractedEvidence, validatorResults []ValidatorResult, metricResults []MetricResult, llmJudgeResults []LLMJudgeResult, warnings []string) RunAgentEvaluation {
 	dimensionResults := evaluateDimensions(spec, evidence, validatorResults, metricResults, llmJudgeResults)
 	warnings = append(warnings, dimensionWarnings(dimensionResults, spec.Scorecard.Dimensions)...)
 	dimensionScores := make(map[string]*float64, len(dimensionResults))
@@ -259,7 +280,7 @@ func evaluateRunAgentWithResolvedJudges(
 		ValidityReason:   validityReason,
 		Strategy:         spec.Scorecard.Strategy,
 		Warnings:         uniqueStrings(warnings),
-	}, nil
+	}
 }
 
 func cloneLLMJudgeResults(results []LLMJudgeResult) []LLMJudgeResult {

--- a/backend/internal/workflow/agent_harness_execution_workflow.go
+++ b/backend/internal/workflow/agent_harness_execution_workflow.go
@@ -9,10 +9,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/agentclash/agentclash/backend/internal/domain"
 	"github.com/agentclash/agentclash/backend/internal/maputil"
 	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/agentclash/agentclash/backend/internal/runevents"
 	"github.com/agentclash/agentclash/backend/internal/sandbox"
+	"github.com/agentclash/agentclash/backend/internal/scoring"
 	"github.com/google/uuid"
 	sdkworkflow "go.temporal.io/sdk/workflow"
 )
@@ -54,9 +56,11 @@ type agentHarnessSetupCommand struct {
 type agentHarnessEvaluationConfig struct {
 	Validators []agentHarnessValidatorConfig `json:"validators,omitempty"`
 	LLMJudges  []json.RawMessage             `json:"llm_judges,omitempty"`
+	Scorecard  json.RawMessage               `json:"scorecard,omitempty"`
 }
 
 type agentHarnessValidatorConfig struct {
+	Key              string `json:"key,omitempty"`
 	Type             string `json:"type"`
 	Command          string `json:"command,omitempty"`
 	WorkingDirectory string `json:"working_directory,omitempty"`
@@ -315,7 +319,7 @@ func (a *Activities) ExecuteAgentHarnessExecution(ctx context.Context, input Exe
 	}); err != nil {
 		return err
 	}
-	if err := a.evaluateAgentHarnessExecution(ctx, execution.ID, session, harness.EvaluationConfig, workdir, timeout, env); err != nil {
+	if err := a.evaluateAgentHarnessExecution(ctx, execution.ID, session, harness, harness.EvaluationConfig, workdir, timeout, env); err != nil {
 		return err
 	}
 
@@ -656,7 +660,7 @@ func (a *Activities) execAgentHarnessShellCommand(ctx context.Context, execution
 	return result, workdir, err
 }
 
-func (a *Activities) evaluateAgentHarnessExecution(ctx context.Context, executionID uuid.UUID, session sandbox.Session, rawConfig json.RawMessage, workdir string, defaultTimeout time.Duration, env map[string]string) error {
+func (a *Activities) evaluateAgentHarnessExecution(ctx context.Context, executionID uuid.UUID, session sandbox.Session, harness agentHarnessSnapshot, rawConfig json.RawMessage, workdir string, defaultTimeout time.Duration, env map[string]string) error {
 	config, err := decodeAgentHarnessEvaluationConfig(rawConfig)
 	if err != nil {
 		_ = a.recordAgentHarnessEvent(ctx, executionID, "scoring.failed", "worker", map[string]any{"error": err.Error()})
@@ -669,15 +673,17 @@ func (a *Activities) evaluateAgentHarnessExecution(ctx context.Context, executio
 	passed := 0
 	failed := 0
 	skipped := 0
+	var requiredValidatorErr error
+	validatorResults := make([]scoring.ValidatorResult, 0, len(config.Validators))
 	for index, validator := range config.Validators {
 		switch strings.TrimSpace(validator.Type) {
 		case "command":
-			ok, err := a.evaluateCommandValidator(ctx, executionID, session, validator, index, workdir, defaultTimeout, env)
+			result, ok, err := a.evaluateCommandValidator(ctx, executionID, session, validator, index, workdir, defaultTimeout, env)
+			validatorResults = append(validatorResults, result)
 			if err != nil {
 				failed++
 				if validatorRequired(validator) {
-					_ = a.recordAgentHarnessEvent(ctx, executionID, "scoring.completed", "worker", map[string]any{"passed": passed, "failed": failed, "skipped": skipped, "score": agentHarnessScore(passed, failed)})
-					return err
+					requiredValidatorErr = err
 				}
 			}
 			if ok {
@@ -690,14 +696,31 @@ func (a *Activities) evaluateAgentHarnessExecution(ctx context.Context, executio
 			}
 		}
 	}
-	if len(config.LLMJudges) > 0 {
-		skipped += len(config.LLMJudges)
-		if err := a.recordAgentHarnessEvent(ctx, executionID, "llm_judges.skipped", "worker", map[string]any{"count": len(config.LLMJudges), "reason": "agent harness LLM judge scoring is not wired yet"}); err != nil {
+
+	if a.repo != nil {
+		evaluation, err := a.buildAndStoreAgentHarnessScorecard(ctx, executionID, harness, config, validatorResults, passed, failed, skipped)
+		if err != nil {
+			_ = a.recordAgentHarnessEvent(ctx, executionID, "scoring.failed", "worker", map[string]any{"error": err.Error()})
 			return err
+		}
+		if evaluation.RunAgentID != uuid.Nil {
+			if err := a.recordAgentHarnessEvent(ctx, executionID, "scorecard.persisted", "worker", map[string]any{
+				"evaluation_spec_id": evaluation.EvaluationSpecID,
+				"status":             evaluation.Status,
+				"passed":             evaluation.Passed,
+				"overall_score":      evaluation.OverallScore,
+				"llm_judges":         len(evaluation.LLMJudgeResults),
+				"dimensions":         evaluation.DimensionScores,
+			}); err != nil {
+				return err
+			}
 		}
 	}
 
-	return a.recordAgentHarnessEvent(ctx, executionID, "scoring.completed", "worker", map[string]any{"passed": passed, "failed": failed, "skipped": skipped, "score": agentHarnessScore(passed, failed)})
+	if err := a.recordAgentHarnessEvent(ctx, executionID, "scoring.completed", "worker", map[string]any{"passed": passed, "failed": failed, "skipped": skipped, "score": agentHarnessScore(passed, failed)}); err != nil {
+		return err
+	}
+	return requiredValidatorErr
 }
 
 func (a *Activities) detectAgentHarnessSetupHints(ctx context.Context, executionID uuid.UUID, session sandbox.Session, workdir string, env map[string]string) error {
@@ -755,12 +778,23 @@ func (a *Activities) runAgentHarnessSetupCommands(ctx context.Context, execution
 	return a.recordAgentHarnessEvent(ctx, executionID, "setup.completed", "worker", map[string]any{"commands": len(cfg.SetupCommands)})
 }
 
-func (a *Activities) evaluateCommandValidator(ctx context.Context, executionID uuid.UUID, session sandbox.Session, validator agentHarnessValidatorConfig, index int, defaultWorkdir string, defaultTimeout time.Duration, env map[string]string) (bool, error) {
+func (a *Activities) evaluateCommandValidator(ctx context.Context, executionID uuid.UUID, session sandbox.Session, validator agentHarnessValidatorConfig, index int, defaultWorkdir string, defaultTimeout time.Duration, env map[string]string) (scoring.ValidatorResult, bool, error) {
 	command := strings.TrimSpace(validator.Command)
+	validatorResult := scoring.ValidatorResult{
+		Key:          agentHarnessValidatorKey(validator, index),
+		Type:         scoring.ValidatorTypeBooleanAssert,
+		Target:       "agent_harness.command_validator",
+		ExpectedFrom: "exit_code_zero",
+	}
 	if command == "" {
 		err := fmt.Errorf("command validator %d is missing command", index)
 		_ = a.recordAgentHarnessEvent(ctx, executionID, "validator.command.failed", "worker", map[string]any{"index": index, "error": err.Error()})
-		return false, err
+		validatorResult.State = scoring.OutputStateError
+		validatorResult.Verdict = "error"
+		validatorResult.OutcomeClass = scoring.ValidatorOutcomePackError
+		validatorResult.Reason = err.Error()
+		validatorResult.RawOutput = mustMarshalJSON(map[string]any{"error": err.Error()})
+		return validatorResult, false, err
 	}
 	result, workdir, err := a.execAgentHarnessShellCommand(ctx, executionID, session, "validator.command.exec", command, validator.WorkingDirectory, validator.TimeoutSeconds, defaultWorkdir, defaultTimeout, env)
 	payload := map[string]any{
@@ -771,18 +805,312 @@ func (a *Activities) evaluateCommandValidator(ctx context.Context, executionID u
 	if err != nil {
 		payload["error"] = err.Error()
 		_ = a.recordAgentHarnessEvent(ctx, executionID, "validator.command.failed", "worker", payload)
-		return false, err
+		validatorResult.State = scoring.OutputStateError
+		validatorResult.Verdict = "error"
+		validatorResult.OutcomeClass = scoring.ValidatorOutcomeInfraError
+		validatorResult.Reason = err.Error()
+		validatorResult.RawOutput = mustMarshalJSON(payload)
+		return validatorResult, false, err
 	}
 	payload["exit_code"] = result.ExitCode
 	payload["stdout"] = result.Stdout
 	payload["stderr"] = result.Stderr
+	score := 0.0
+	validatorResult.State = scoring.OutputStateAvailable
+	validatorResult.RawOutput = mustMarshalJSON(payload)
 	if result.ExitCode == 0 {
-		return true, a.recordAgentHarnessEvent(ctx, executionID, "validator.command.passed", "worker", payload)
+		score = 1
+		validatorResult.Verdict = "pass"
+		validatorResult.OutcomeClass = scoring.ValidatorOutcomePass
+		validatorResult.NormalizedScore = &score
+		return validatorResult, true, a.recordAgentHarnessEvent(ctx, executionID, "validator.command.passed", "worker", payload)
 	}
 	err = fmt.Errorf("command validator %d failed with exit code %d", index, result.ExitCode)
 	payload["error"] = err.Error()
 	_ = a.recordAgentHarnessEvent(ctx, executionID, "validator.command.failed", "worker", payload)
-	return false, err
+	validatorResult.Verdict = "fail"
+	validatorResult.OutcomeClass = scoring.ValidatorOutcomeFail
+	validatorResult.NormalizedScore = &score
+	validatorResult.Reason = err.Error()
+	validatorResult.RawOutput = mustMarshalJSON(payload)
+	return validatorResult, false, err
+}
+
+func agentHarnessValidatorKey(validator agentHarnessValidatorConfig, index int) string {
+	if key := strings.TrimSpace(validator.Key); key != "" {
+		return key
+	}
+	return fmt.Sprintf("command_%d", index+1)
+}
+
+func (a *Activities) buildAndStoreAgentHarnessScorecard(ctx context.Context, executionID uuid.UUID, harness agentHarnessSnapshot, config agentHarnessEvaluationConfig, validatorResults []scoring.ValidatorResult, passed int, failed int, skipped int) (scoring.RunAgentEvaluation, error) {
+	execution, err := a.agentHarnessRepo.GetAgentHarnessExecutionByID(ctx, executionID)
+	if err != nil {
+		return scoring.RunAgentEvaluation{}, wrapActivityError(err)
+	}
+	if execution.RunID == nil || execution.RunAgentID == nil {
+		return scoring.RunAgentEvaluation{}, nil
+	}
+	spec, err := agentHarnessEvaluationSpec(executionID, config, validatorResults)
+	if err != nil {
+		return scoring.RunAgentEvaluation{}, err
+	}
+	definition, err := scoring.MarshalDefinition(spec)
+	if err != nil {
+		return scoring.RunAgentEvaluation{}, err
+	}
+	normalizedSpec, err := scoring.DecodeDefinition(definition)
+	if err != nil {
+		return scoring.RunAgentEvaluation{}, err
+	}
+	specRecord, err := a.repo.CreateStandaloneEvaluationSpec(ctx, repository.CreateStandaloneEvaluationSpecParams{
+		Name:          normalizedSpec.Name,
+		VersionNumber: normalizedSpec.VersionNumber,
+		JudgeMode:     string(normalizedSpec.JudgeMode),
+		Definition:    definition,
+	})
+	if err != nil {
+		return scoring.RunAgentEvaluation{}, err
+	}
+	if _, err := a.agentHarnessRepo.SetAgentHarnessExecutionEvaluationSpec(ctx, repository.SetAgentHarnessExecutionEvaluationSpecParams{
+		ExecutionID:      executionID,
+		EvaluationSpecID: specRecord.ID,
+	}); err != nil {
+		return scoring.RunAgentEvaluation{}, err
+	}
+	runEvents, err := a.repo.ListRunEventsByRunAgentID(ctx, *execution.RunAgentID)
+	if err != nil {
+		return scoring.RunAgentEvaluation{}, err
+	}
+	evaluationEvents := agentHarnessEvaluationEvents(runEvents)
+	input := scoring.EvaluationInput{
+		RunAgentID:       *execution.RunAgentID,
+		EvaluationSpecID: specRecord.ID,
+		Events:           evaluationEvents,
+	}
+	executionContext := repository.RunAgentExecutionContext{
+		Run: domain.Run{
+			ID:          *execution.RunID,
+			WorkspaceID: execution.WorkspaceID,
+		},
+		RunAgent: domain.RunAgent{
+			ID: *execution.RunAgentID,
+		},
+		Deployment: agentHarnessJudgeDeploymentContext(harness),
+	}
+	llmJudgeResults, judgeWarnings := evaluateLLMJudges(ctx, a.judgeClient, a.repo, executionContext, input, normalizedSpec)
+	evaluation, err := scoring.EvaluateRunAgentWithPrecomputedResults(input, normalizedSpec, validatorResults, nil, llmJudgeResults)
+	if err != nil {
+		return scoring.RunAgentEvaluation{}, err
+	}
+	evaluation.Warnings = append(evaluation.Warnings, judgeWarnings...)
+	if err := a.repo.StoreRunAgentEvaluationResults(ctx, evaluation); err != nil {
+		return scoring.RunAgentEvaluation{}, err
+	}
+	if err := recordScoringEvents(ctx, a.repo, *execution.RunID, evaluation); err != nil {
+		evaluation.Warnings = append(evaluation.Warnings, fmt.Sprintf("record scoring events: %v", err))
+	}
+	return evaluation, nil
+}
+
+func agentHarnessEvaluationSpec(executionID uuid.UUID, config agentHarnessEvaluationConfig, validatorResults []scoring.ValidatorResult) (scoring.EvaluationSpec, error) {
+	judges, err := agentHarnessLLMJudges(config.LLMJudges)
+	if err != nil {
+		return scoring.EvaluationSpec{}, err
+	}
+	spec := scoring.EvaluationSpec{
+		Name:          "agent-harness-" + executionID.String(),
+		VersionNumber: 1,
+		JudgeMode:     scoring.JudgeModeDeterministic,
+		Validators:    make([]scoring.ValidatorDeclaration, 0, len(validatorResults)),
+		LLMJudges:     judges,
+		Scorecard: scoring.ScorecardDeclaration{
+			Strategy: scoring.ScoringStrategyWeighted,
+		},
+	}
+	passThreshold := 1.0
+	spec.Scorecard.PassThreshold = &passThreshold
+	if len(judges) > 0 {
+		spec.JudgeMode = scoring.JudgeModeHybrid
+	}
+	validatorKeys := make([]string, 0, len(validatorResults))
+	for index, result := range validatorResults {
+		key := strings.TrimSpace(result.Key)
+		if key == "" {
+			key = fmt.Sprintf("command_%d", index+1)
+		}
+		validatorKeys = append(validatorKeys, key)
+		spec.Validators = append(spec.Validators, scoring.ValidatorDeclaration{
+			Key:          key,
+			Type:         scoring.ValidatorTypeBooleanAssert,
+			Target:       "literal:true",
+			ExpectedFrom: "literal:true",
+		})
+	}
+	if len(spec.Validators) == 0 {
+		spec.Validators = append(spec.Validators, scoring.ValidatorDeclaration{
+			Key:          "harness_execution",
+			Type:         scoring.ValidatorTypeBooleanAssert,
+			Target:       "literal:true",
+			ExpectedFrom: "literal:true",
+		})
+	}
+	if len(config.Scorecard) > 0 && string(config.Scorecard) != "null" {
+		if err := json.Unmarshal(config.Scorecard, &spec.Scorecard); err != nil {
+			return scoring.EvaluationSpec{}, fmt.Errorf("decode harness scorecard: %w", err)
+		}
+	} else {
+		targetLatency := 60_000.0
+		maxLatency := 30 * 60_000.0
+		targetCost := 0.0
+		maxCost := 1.0
+		spec.Scorecard.Dimensions = append(spec.Scorecard.Dimensions, scoring.DimensionDeclaration{
+			Key:             "correctness",
+			Source:          scoring.DimensionSourceValidators,
+			Validators:      validatorKeys,
+			BetterDirection: "higher",
+		})
+		spec.Scorecard.Dimensions = append(spec.Scorecard.Dimensions, scoring.DimensionDeclaration{
+			Key:             "latency",
+			Source:          scoring.DimensionSourceLatency,
+			BetterDirection: "lower",
+			Normalization:   &scoring.DimensionNormalization{Target: &targetLatency, Max: &maxLatency},
+		})
+		spec.Scorecard.Dimensions = append(spec.Scorecard.Dimensions, scoring.DimensionDeclaration{
+			Key:             "cost",
+			Source:          scoring.DimensionSourceCost,
+			BetterDirection: "lower",
+			Normalization:   &scoring.DimensionNormalization{Target: &targetCost, Max: &maxCost},
+		})
+		for _, judge := range judges {
+			spec.Scorecard.Dimensions = append(spec.Scorecard.Dimensions, scoring.DimensionDeclaration{
+				Key:             judge.Key,
+				Source:          scoring.DimensionSourceLLMJudge,
+				JudgeKey:        judge.Key,
+				BetterDirection: "higher",
+			})
+		}
+	}
+	return spec, nil
+}
+
+func agentHarnessJudgeDeploymentContext(harness agentHarnessSnapshot) repository.AgentDeploymentExecutionContext {
+	providerKey := ""
+	switch normalizeAgentHarnessKind(harness.HarnessKind) {
+	case "claude_e2b":
+		providerKey = "anthropic"
+	default:
+		providerKey = "openai"
+	}
+	secretName := strings.TrimSpace(derefString(harness.OpenAIAPIKeySecretName))
+	if secretName == "" || providerKey == "" {
+		return repository.AgentDeploymentExecutionContext{}
+	}
+	return repository.AgentDeploymentExecutionContext{
+		ProviderAccount: &repository.ProviderAccountExecutionContext{
+			ProviderKey:         providerKey,
+			CredentialReference: "workspace-secret://" + secretName,
+		},
+	}
+}
+
+func agentHarnessEvaluationEvents(runEvents []repository.RunEvent) []scoring.Event {
+	events := mapRunEvents(runEvents)
+	if len(runEvents) == 0 {
+		now := time.Now().UTC()
+		return append(events, scoring.Event{
+			Type:       "system.run.completed",
+			Source:     string(runevents.SourceAgentHarnessWorker),
+			OccurredAt: now,
+			Payload:    mustMarshalJSON(map[string]any{"final_output": "Agent Harness execution produced no canonical events."}),
+		})
+	}
+	startedAt := runEvents[0].OccurredAt
+	completedAt := runEvents[len(runEvents)-1].OccurredAt
+	finalOutput := agentHarnessJudgeTranscript(runEvents)
+	return append(events,
+		scoring.Event{
+			Type:       "system.run.started",
+			Source:     string(runevents.SourceAgentHarnessWorker),
+			OccurredAt: startedAt,
+			Payload:    mustMarshalJSON(map[string]any{}),
+		},
+		scoring.Event{
+			Type:       "system.run.completed",
+			Source:     string(runevents.SourceAgentHarnessWorker),
+			OccurredAt: completedAt,
+			Payload:    mustMarshalJSON(map[string]any{"final_output": finalOutput}),
+		},
+	)
+}
+
+func agentHarnessJudgeTranscript(runEvents []repository.RunEvent) string {
+	lines := []string{"Agent Harness execution evidence:"}
+	for _, event := range runEvents {
+		var payload map[string]any
+		if err := json.Unmarshal(event.Payload, &payload); err != nil {
+			continue
+		}
+		eventType, _ := payload["agent_harness_event_type"].(string)
+		if eventType == "" {
+			eventType = string(event.EventType)
+		}
+		switch {
+		case eventType == "codex.exec.output" || eventType == "claude.exec.output":
+			if preview := summaryPreview(payload, "message_summary"); preview != "" {
+				lines = append(lines, fmt.Sprintf("- %s: %s", eventType, preview))
+			}
+		case eventType == "artifact.git_diff":
+			if preview := summaryPreview(payload, "diff_summary"); preview != "" {
+				lines = append(lines, fmt.Sprintf("- git diff summary: %s", preview))
+			}
+		case eventType == "artifact.changed_files":
+			if changed, ok := payload["changed_files"].(string); ok && strings.TrimSpace(changed) != "" {
+				lines = append(lines, fmt.Sprintf("- changed files: %s", strings.TrimSpace(changed)))
+			}
+		case strings.HasPrefix(eventType, "validator."):
+			if exitCode, ok := payload["exit_code"]; ok {
+				lines = append(lines, fmt.Sprintf("- %s exit_code=%v", eventType, exitCode))
+			}
+		}
+	}
+	if len(lines) == 1 {
+		lines = append(lines, "No agent output, diff, or validator evidence was available.")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func summaryPreview(payload map[string]any, key string) string {
+	summary, ok := payload[key].(map[string]any)
+	if !ok {
+		return ""
+	}
+	preview, _ := summary["preview"].(string)
+	return strings.TrimSpace(preview)
+}
+
+func agentHarnessLLMJudges(rawJudges []json.RawMessage) ([]scoring.LLMJudgeDeclaration, error) {
+	judges := make([]scoring.LLMJudgeDeclaration, 0, len(rawJudges))
+	for index, raw := range rawJudges {
+		var judge scoring.LLMJudgeDeclaration
+		if err := json.Unmarshal(raw, &judge); err != nil {
+			return nil, fmt.Errorf("decode llm_judges[%d]: %w", index, err)
+		}
+		if judge.Mode == "" {
+			judge.Mode = scoring.JudgeMethodRubric
+		}
+		if strings.TrimSpace(judge.Key) == "" {
+			judge.Key = fmt.Sprintf("llm_judge_%d", index+1)
+		}
+		if strings.TrimSpace(judge.Model) == "" && len(judge.Models) == 0 {
+			judge.Model = "gpt-4.1-mini"
+		}
+		if len(judge.ContextFrom) == 0 {
+			judge.ContextFrom = []string{"final_output"}
+		}
+		judges = append(judges, judge)
+	}
+	return judges, nil
 }
 
 func agentHarnessValidatorWorkdir(defaultWorkdir string, configured string) string {

--- a/backend/internal/workflow/agent_harness_execution_workflow_test.go
+++ b/backend/internal/workflow/agent_harness_execution_workflow_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/domain"
+	"github.com/agentclash/agentclash/backend/internal/provider"
 	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/agentclash/agentclash/backend/internal/sandbox"
 	"github.com/google/uuid"
@@ -33,7 +34,7 @@ func TestExecuteAgentHarnessExecutionRunsCodexAndRecordsTrace(t *testing.T) {
 		RepositoryURL:          stringPtr("https://github.com/acme/repo"),
 		BaseBranch:             stringPtr("main"),
 		ExecutionConfig:        json.RawMessage(`{"timeout_seconds":120,"setup_commands":[{"name":"deps","command":"go mod download","working_directory":"backend","timeout_seconds":30}]}`),
-		EvaluationConfig:       json.RawMessage(`{"validators":[{"type":"command","command":"go test ./...","working_directory":"backend","timeout_seconds":60}]}`),
+		EvaluationConfig:       json.RawMessage(`{"validators":[{"key":"tests","type":"command","command":"go test ./...","working_directory":"backend","timeout_seconds":60}],"llm_judges":[{"key":"autonomy","rubric":"Score whether the coding agent completed the requested task coherently."}]}`),
 	})
 	repo.setAgentHarnessExecution(repository.AgentHarnessExecution{
 		ID:                      executionID,
@@ -86,18 +87,21 @@ func TestExecuteAgentHarnessExecutionRunsCodexAndRecordsTrace(t *testing.T) {
 			return sandbox.ExecResult{}, nil
 		}
 	})
-	provider := &sandbox.FakeProvider{NextSession: session}
-	activities := NewActivities(repo, FakeWorkHooks{}).WithSandboxProvider(provider)
+	sandboxProvider := &sandbox.FakeProvider{NextSession: session}
+	judgeClient := &provider.FakeClient{
+		Response: provider.Response{OutputText: `{"score":5,"confidence":"high","reasoning":"complete"}`},
+	}
+	activities := NewActivities(repo, FakeWorkHooks{}, judgeClient).WithSandboxProvider(sandboxProvider)
 
 	err := activities.ExecuteAgentHarnessExecution(context.Background(), ExecuteAgentHarnessExecutionInput{ExecutionID: executionID})
 	if err != nil {
 		t.Fatalf("ExecuteAgentHarnessExecution error: %v", err)
 	}
 
-	if len(provider.CreateRequests) != 1 {
-		t.Fatalf("sandbox create calls = %d, want 1", len(provider.CreateRequests))
+	if len(sandboxProvider.CreateRequests) != 1 {
+		t.Fatalf("sandbox create calls = %d, want 1", len(sandboxProvider.CreateRequests))
 	}
-	createRequest := provider.CreateRequests[0]
+	createRequest := sandboxProvider.CreateRequests[0]
 	if createRequest.EnvVars["OPENAI_API_KEY"] != "sk-test" || createRequest.EnvVars["CODEX_API_KEY"] != "sk-test" {
 		t.Fatalf("env vars = %#v, want OpenAI and Codex keys", createRequest.EnvVars)
 	}
@@ -132,6 +136,8 @@ func TestExecuteAgentHarnessExecutionRunsCodexAndRecordsTrace(t *testing.T) {
 	var sawScoringCompleted bool
 	var sawSetupCompleted bool
 	var sawHints bool
+	var sawScorecardPersisted bool
+	var sawLLMJudgesSkipped bool
 	for _, event := range repo.agentHarnessEvents[executionID] {
 		switch event.EventType {
 		case "codex.exec.output":
@@ -171,6 +177,10 @@ func TestExecuteAgentHarnessExecutionRunsCodexAndRecordsTrace(t *testing.T) {
 			if payload["template"] != "codex" || payload["agent_tool"] != "codex" || payload["metadata_version"] != float64(1) {
 				t.Fatalf("runtime payload = %#v, want template/tool metadata", payload)
 			}
+		case "scorecard.persisted":
+			sawScorecardPersisted = true
+		case "llm_judges.skipped":
+			sawLLMJudgesSkipped = true
 		}
 	}
 	if !sawCodexOutput {
@@ -187,6 +197,50 @@ func TestExecuteAgentHarnessExecutionRunsCodexAndRecordsTrace(t *testing.T) {
 	}
 	if !sawHints {
 		t.Fatal("expected setup hints detected event")
+	}
+	if !sawScorecardPersisted {
+		t.Fatal("expected persisted scorecard event")
+	}
+	if sawLLMJudgesSkipped {
+		t.Fatal("did not expect llm_judges.skipped after judge wiring")
+	}
+	evaluation, ok := repo.evaluations[runAgentID]
+	if !ok {
+		t.Fatal("expected stored run-agent evaluation")
+	}
+	if len(evaluation.ValidatorResults) != 1 || evaluation.ValidatorResults[0].Key != "tests" || evaluation.ValidatorResults[0].Verdict != "pass" {
+		t.Fatalf("validator results = %#v, want passing tests validator", evaluation.ValidatorResults)
+	}
+	if len(evaluation.LLMJudgeResults) != 1 || evaluation.LLMJudgeResults[0].JudgeKey != "autonomy" {
+		t.Fatalf("llm judge results = %#v, want autonomy judge result", evaluation.LLMJudgeResults)
+	}
+	if evaluation.LLMJudgeResults[0].NormalizedScore == nil || *evaluation.LLMJudgeResults[0].NormalizedScore != 1 {
+		t.Fatalf("llm judge score = %#v, want normalized 1", evaluation.LLMJudgeResults[0].NormalizedScore)
+	}
+	if len(judgeClient.Requests) != 3 {
+		t.Fatalf("judge requests = %d, want default 3 samples", len(judgeClient.Requests))
+	}
+	if !strings.Contains(judgeClient.Requests[0].Messages[0].Content, "done") {
+		t.Fatalf("judge prompt = %q, want agent output evidence", judgeClient.Requests[0].Messages[0].Content)
+	}
+	if judgeClient.Requests[0].CredentialReference != "workspace-secret://OPENAI_API_KEY" {
+		t.Fatalf("judge credential reference = %q, want harness workspace secret", judgeClient.Requests[0].CredentialReference)
+	}
+	if evaluation.OverallScore == nil || *evaluation.OverallScore != 1 {
+		t.Fatalf("overall score = %#v, want 1 from command validator", evaluation.OverallScore)
+	}
+	if _, ok := evaluation.DimensionScores["latency"]; !ok {
+		t.Fatalf("dimension scores = %#v, want latency dimension exposed", evaluation.DimensionScores)
+	}
+	if _, ok := evaluation.DimensionScores["cost"]; !ok {
+		t.Fatalf("dimension scores = %#v, want cost dimension exposed", evaluation.DimensionScores)
+	}
+	if repo.callCountWithPrefix("CreateStandaloneEvaluationSpec:") != 1 {
+		t.Fatalf("CreateStandaloneEvaluationSpec call count = %d, want 1", repo.callCountWithPrefix("CreateStandaloneEvaluationSpec:"))
+	}
+	updatedExecution, ok := repo.agentHarnessExecutions[executionID]
+	if !ok || updatedExecution.EvaluationSpecID == nil || *updatedExecution.EvaluationSpecID != evaluation.EvaluationSpecID {
+		t.Fatalf("execution evaluation_spec_id = %#v, want %s", updatedExecution.EvaluationSpecID, evaluation.EvaluationSpecID)
 	}
 	runEvents := repo.runEvents[runAgentID]
 	if len(runEvents) == 0 {
@@ -301,6 +355,16 @@ func TestExecuteAgentHarnessExecutionFailsRequiredValidator(t *testing.T) {
 	}
 	if !sawPartialScore {
 		t.Fatal("expected partial score event")
+	}
+	evaluation, ok := repo.evaluations[runAgentID]
+	if !ok {
+		t.Fatal("expected stored scorecard evaluation for failed required validator")
+	}
+	if len(evaluation.ValidatorResults) != 2 || evaluation.ValidatorResults[1].Verdict != "fail" {
+		t.Fatalf("validator results = %#v, want failed npm validator persisted", evaluation.ValidatorResults)
+	}
+	if evaluation.Passed == nil || *evaluation.Passed {
+		t.Fatalf("scorecard passed = %#v, want false", evaluation.Passed)
 	}
 	if repo.callCountWithPrefix("BuildRunAgentReplay:"+runAgentID.String()) != 1 {
 		t.Fatalf("BuildRunAgentReplay call count = %d, want 1", repo.callCountWithPrefix("BuildRunAgentReplay:"+runAgentID.String()))

--- a/backend/internal/workflow/repository.go
+++ b/backend/internal/workflow/repository.go
@@ -29,6 +29,7 @@ type RunRepository interface {
 	GetRunAgentExecutionContextByID(ctx context.Context, runAgentID uuid.UUID) (repository.RunAgentExecutionContext, error)
 	LoadWorkspaceSecrets(ctx context.Context, workspaceID uuid.UUID) (map[string]string, error)
 	CreateEvaluationSpec(ctx context.Context, params repository.CreateEvaluationSpecParams) (repository.EvaluationSpecRecord, error)
+	CreateStandaloneEvaluationSpec(ctx context.Context, params repository.CreateStandaloneEvaluationSpecParams) (repository.EvaluationSpecRecord, error)
 	GetEvaluationSpecByChallengePackVersionAndVersion(ctx context.Context, challengePackVersionID uuid.UUID, name string, versionNumber int32) (repository.EvaluationSpecRecord, error)
 	ListRunEventsByRunAgentID(ctx context.Context, runAgentID uuid.UUID) ([]repository.RunEvent, error)
 	RecordRunEvent(ctx context.Context, params repository.RecordRunEventParams) (repository.RunEvent, error)
@@ -54,6 +55,7 @@ type EvalSessionRepository interface {
 type AgentHarnessExecutionRepository interface {
 	GetAgentHarnessByID(ctx context.Context, id uuid.UUID) (repository.AgentHarness, error)
 	GetAgentHarnessExecutionByID(ctx context.Context, id uuid.UUID) (repository.AgentHarnessExecution, error)
+	SetAgentHarnessExecutionEvaluationSpec(ctx context.Context, params repository.SetAgentHarnessExecutionEvaluationSpecParams) (repository.AgentHarnessExecution, error)
 	GetWorkspaceGitHubRepository(ctx context.Context, workspaceID uuid.UUID, githubRepositoryID int64, githubInstallationID *int64) (repository.GitHubInstallationRepository, error)
 	LoadWorkspaceSecrets(ctx context.Context, workspaceID uuid.UUID) (map[string]string, error)
 	TransitionAgentHarnessExecutionStatus(ctx context.Context, params repository.TransitionAgentHarnessExecutionStatusParams) (repository.AgentHarnessExecution, error)

--- a/backend/internal/workflow/workflow_test.go
+++ b/backend/internal/workflow/workflow_test.go
@@ -1398,6 +1398,29 @@ func (r *fakeRunRepository) CreateEvaluationSpec(_ context.Context, params repos
 	return record, nil
 }
 
+func (r *fakeRunRepository) CreateStandaloneEvaluationSpec(_ context.Context, params repository.CreateStandaloneEvaluationSpecParams) (repository.EvaluationSpecRecord, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	key := evaluationSpecKey(uuid.Nil, params.Name, params.VersionNumber)
+	if existing, ok := r.evaluationSpecs[key]; ok {
+		return existing, nil
+	}
+
+	record := repository.EvaluationSpecRecord{
+		ID:            uuid.New(),
+		Name:          params.Name,
+		VersionNumber: params.VersionNumber,
+		JudgeMode:     params.JudgeMode,
+		Definition:    append([]byte(nil), params.Definition...),
+		CreatedAt:     time.Now().UTC(),
+		UpdatedAt:     time.Now().UTC(),
+	}
+	r.evaluationSpecs[key] = record
+	r.callLog = append(r.callLog, fmt.Sprintf("CreateStandaloneEvaluationSpec:%s:%d", params.Name, params.VersionNumber))
+	return record, nil
+}
+
 func (r *fakeRunRepository) GetEvaluationSpecByChallengePackVersionAndVersion(_ context.Context, challengePackVersionID uuid.UUID, name string, versionNumber int32) (repository.EvaluationSpecRecord, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -1512,6 +1535,20 @@ func (r *fakeRunRepository) GetAgentHarnessExecutionByID(_ context.Context, id u
 	if !ok {
 		return repository.AgentHarnessExecution{}, repository.ErrAgentHarnessExecutionNotFound
 	}
+	return execution, nil
+}
+
+func (r *fakeRunRepository) SetAgentHarnessExecutionEvaluationSpec(_ context.Context, params repository.SetAgentHarnessExecutionEvaluationSpecParams) (repository.AgentHarnessExecution, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.callLog = append(r.callLog, fmt.Sprintf("SetAgentHarnessExecutionEvaluationSpec:%s", params.ExecutionID))
+	execution, ok := r.agentHarnessExecutions[params.ExecutionID]
+	if !ok {
+		return repository.AgentHarnessExecution{}, repository.ErrAgentHarnessExecutionNotFound
+	}
+	evaluationSpecID := params.EvaluationSpecID
+	execution.EvaluationSpecID = &evaluationSpecID
+	r.agentHarnessExecutions[params.ExecutionID] = execution
 	return execution, nil
 }
 

--- a/testing/codex-issue-583-harness-scorecards-local-test-log.md
+++ b/testing/codex-issue-583-harness-scorecards-local-test-log.md
@@ -1,0 +1,26 @@
+# Issue #583 Local Test Log
+
+## Commands
+
+- `cd backend && go test ./internal/scoring ./internal/workflow ./internal/repository ./internal/api`
+- `cd backend && go test ./internal/workflow -run TestExecuteAgentHarnessExecutionRunsCodexAndRecordsTrace -count=1`
+- `cd backend && go test ./...`
+- `cd web && npm test -- --run 'src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx'`
+- `cd web && npm run lint -- 'src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.tsx' 'src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx'`
+- `git diff --check`
+
+## Result
+
+- Focused backend packages passed.
+- Full backend suite passed.
+- Focused Agent Harness UI tests passed.
+- Focused Agent Harness UI lint passed.
+- Whitespace check passed.
+
+## Notes
+
+- Harness command validators are converted into standard scoring validator results.
+- Harness LLM judges flow through the existing workflow judge evaluator after normal scoring-spec normalization.
+- Harness LLM judge credentials resolve through the harness workspace secret, not only process env vars.
+- Persistence uses the existing `StoreRunAgentEvaluationResults` scorecard path.
+- The created standalone evaluation spec is linked back onto the harness execution.

--- a/testing/codex-issue-583-harness-scorecards.md
+++ b/testing/codex-issue-583-harness-scorecards.md
@@ -1,0 +1,19 @@
+# Test Contract: Issue #583 Harness Scorecards
+
+## Intent
+
+Agent Harness scoring must use the existing AgentClash scorecard and LLM judge pipeline instead of a separate harness-only scorer.
+
+## Expectations
+
+- Command validators continue to execute in the harness sandbox.
+- Harness command validator results are converted into standard scoring validator results.
+- Harness `llm_judges` execute through the existing workflow judge evaluator instead of `llm_judges.skipped`.
+- Harness executions persist run-agent scorecards through `StoreRunAgentEvaluationResults`.
+- Scorecards include dimensions, pass/fail verdict, reasons, validator results, and LLM judge results.
+- Agent Harness API/UI can surface scorecard status using the canonical run-agent scorecard endpoint via `run_agent_id`.
+
+## Verification
+
+- `cd backend && go test ./internal/scoring ./internal/workflow ./internal/repository ./internal/api`
+- Focused Agent Harness UI tests if UI rendering changes.

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx
@@ -221,14 +221,14 @@ function baseExecution(overrides: Record<string, unknown> = {}) {
         id: "event-3",
         agent_harness_execution_id: "execution-1",
         sequence_number: 3,
-        event_type: "scoring.completed",
+        event_type: "scorecard.persisted",
         actor_type: "worker",
         occurred_at: "2026-05-01T00:01:40Z",
         payload: {
-          score: 1,
-          passed: 1,
-          failed: 0,
-          skipped: 1,
+          status: "complete",
+          overall_score: 1,
+          passed: true,
+          llm_judges: 1,
         },
       },
     ],
@@ -348,9 +348,9 @@ describe("AgentHarnessesClient", () => {
     expect(document.body.textContent).toContain("Repository");
     expect(document.body.textContent).toContain("Agent work");
     expect(document.body.textContent).toContain("Validation");
-    expect(document.body.textContent).toContain("Scoring · Completed");
-    expect(document.body.textContent).toContain("Score: 1");
-    expect(document.body.textContent).toContain("Passed: 1");
+    expect(document.body.textContent).toContain("Scorecard · Persisted");
+    expect(document.body.textContent).toContain("Overall Score: 1");
+    expect(document.body.textContent).toContain("Passed: true");
 
     rendered.cleanup();
   });

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.tsx
@@ -654,6 +654,7 @@ function eventSummaryKeys(eventType: string) {
     "command",
     "tool",
     "exit_code",
+    "overall_score",
     "score",
     "passed",
     "failed",
@@ -731,6 +732,7 @@ function eventPhase(eventType: string): HarnessPhase | null {
   if (
     eventType.startsWith("validator.") ||
     eventType.startsWith("scoring.") ||
+    eventType.startsWith("scorecard.") ||
     eventType.startsWith("llm_judges.")
   ) {
     return "validation";


### PR DESCRIPTION
## Summary
- Persist Agent Harness executions through the existing run-agent scorecard storage path
- Convert command validators into standard scoring validator results and wire harness LLM judges through the existing workflow judge evaluator
- Expose scorecard persistence in harness live activity, link the generated standalone evaluation spec back to the execution, and resolve judge credentials from the harness workspace secret

## Tests
- cd backend && go test ./internal/workflow -run TestExecuteAgentHarnessExecutionRunsCodexAndRecordsTrace -count=1
- cd backend && go test ./internal/scoring ./internal/workflow ./internal/repository ./internal/api
- cd backend && go test ./...
- cd web && npm test -- --run 'src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx'\n- cd web && npm run lint -- 'src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.tsx' 'src/app/(workspace)/workspaces/[workspaceId]/agent-harnesses/agent-harnesses-client.test.tsx'\n- git diff --check\n\nCloses #583