### PR TITLE
fix: log invite accept denial reasons

### DIFF
--- a/backend/internal/api/org_memberships.go
+++ b/backend/internal/api/org_memberships.go
@@ -308,8 +308,8 @@ func (m *OrgMembershipManager) AcceptOrgInvite(ctx context.Context, caller Calle
 	if err != nil {
 		return OrgMembershipResult{}, err
 	}
-	if !inviteTokenCanBeAcceptedByCaller(caller, membership.Email) {
-		return OrgMembershipResult{}, ErrForbidden
+	if err := inviteTokenAcceptError(caller, membership.Email); err != nil {
+		return OrgMembershipResult{}, withInviteAcceptDenialContext(err, "organization", caller.UserID, membership.ID, membership.OrganizationID, uuid.Nil)
 	}
 	if orgInviteExpired(membership) {
 		return OrgMembershipResult{}, repository.ErrInviteExpired
@@ -344,18 +344,65 @@ func inviteEmailMatchesCaller(caller Caller, inviteEmail string) bool {
 	return strings.EqualFold(strings.TrimSpace(caller.Email), strings.TrimSpace(inviteEmail)) && strings.TrimSpace(caller.Email) != ""
 }
 
-func inviteTokenCanBeAcceptedByCaller(caller Caller, inviteEmail string) bool {
+type inviteTokenAcceptDeniedError struct {
+	Kind               string
+	Reason             string
+	CallerUserID       uuid.UUID
+	MembershipID       uuid.UUID
+	OrganizationID     uuid.UUID
+	WorkspaceID        uuid.UUID
+	CallerEmailPresent bool
+	InviteEmailPresent bool
+	EmailMatch         bool
+}
+
+func (e *inviteTokenAcceptDeniedError) Error() string {
+	return ErrForbidden.Error() + ": invite token accept denied: " + e.Reason
+}
+
+func (e *inviteTokenAcceptDeniedError) Unwrap() error {
+	return ErrForbidden
+}
+
+func inviteTokenAcceptError(caller Caller, inviteEmail string) error {
 	inviteEmail = strings.TrimSpace(inviteEmail)
 	callerEmail := strings.TrimSpace(caller.Email)
 	if inviteEmail == "" {
-		return false
+		return &inviteTokenAcceptDeniedError{
+			Reason:             "invite_email_empty",
+			CallerEmailPresent: callerEmail != "",
+			InviteEmailPresent: false,
+			EmailMatch:         false,
+		}
 	}
 	if callerEmail == "" {
 		// The invite token is a high-entropy bearer secret. Some WorkOS session
 		// tokens do not expose email claims, so token possession is the fallback.
-		return true
+		return nil
 	}
-	return strings.EqualFold(callerEmail, inviteEmail)
+	if !strings.EqualFold(callerEmail, inviteEmail) {
+		return &inviteTokenAcceptDeniedError{
+			Reason:             "caller_email_mismatch",
+			CallerEmailPresent: true,
+			InviteEmailPresent: true,
+			EmailMatch:         false,
+		}
+	}
+	return nil
+}
+
+func withInviteAcceptDenialContext(err error, kind string, callerUserID, membershipID, organizationID, workspaceID uuid.UUID) error {
+	var denial *inviteTokenAcceptDeniedError
+	if !errors.As(err, &denial) {
+		return err
+	}
+	withContext := *denial
+	withContext.Kind = kind
+	withContext.CallerUserID = callerUserID
+	withContext.MembershipID = membershipID
+	withContext.OrganizationID = organizationID
+	withContext.WorkspaceID = workspaceID
+	return &withContext
 }
 
 func orgInviteExpired(membership repository.OrgMembershipFullRow) bool {
@@ -633,6 +680,23 @@ func handleMembershipError(w http.ResponseWriter, logger *slog.Logger, err error
 	var gateErr billingpkg.GateError
 	switch {
 	case errors.Is(err, ErrForbidden):
+		var inviteDenial *inviteTokenAcceptDeniedError
+		if errors.As(err, &inviteDenial) {
+			attrs := []any{
+				"kind", inviteDenial.Kind,
+				"reason", inviteDenial.Reason,
+				"caller_user_id", inviteDenial.CallerUserID,
+				"membership_id", inviteDenial.MembershipID,
+				"organization_id", inviteDenial.OrganizationID,
+				"caller_email_present", inviteDenial.CallerEmailPresent,
+				"invite_email_present", inviteDenial.InviteEmailPresent,
+				"email_match", inviteDenial.EmailMatch,
+			}
+			if inviteDenial.WorkspaceID != uuid.Nil {
+				attrs = append(attrs, "workspace_id", inviteDenial.WorkspaceID)
+			}
+			logger.Warn("invite accept forbidden", attrs...)
+		}
 		writeError(w, http.StatusForbidden, "forbidden", "access denied")
 	case errors.As(err, &gateErr):
 		writeBillingGateError(w, gateErr.Decision)

--- a/backend/internal/api/org_memberships_test.go
+++ b/backend/internal/api/org_memberships_test.go
@@ -327,8 +327,50 @@ func TestAcceptOrgInviteToken_RejectsMismatchedCallerEmail(t *testing.T) {
 	if !errors.Is(err, ErrForbidden) {
 		t.Fatalf("AcceptOrgInvite error = %v, want ErrForbidden", err)
 	}
+	var denial *inviteTokenAcceptDeniedError
+	if !errors.As(err, &denial) {
+		t.Fatalf("AcceptOrgInvite error = %T, want inviteTokenAcceptDeniedError", err)
+	}
+	if denial.Kind != "organization" || denial.Reason != "caller_email_mismatch" || denial.MembershipID != membershipID || denial.OrganizationID != orgID {
+		t.Fatalf("denial metadata = %+v", denial)
+	}
 	if repo.lastUpdate.Status != nil || repo.lastUpdate.UserID != nil || repo.lastUpdate.ClearInviteToken {
 		t.Fatalf("membership was updated despite forbidden caller: %+v", repo.lastUpdate)
+	}
+}
+
+func TestInviteTokenAcceptError_AllowsEmptyCallerEmail(t *testing.T) {
+	err := inviteTokenAcceptError(Caller{}, "friend@example.com")
+	if err != nil {
+		t.Fatalf("inviteTokenAcceptError returned error: %v", err)
+	}
+}
+
+func TestInviteTokenAcceptError_RejectsEmptyInviteEmail(t *testing.T) {
+	err := inviteTokenAcceptError(Caller{Email: "friend@example.com"}, " ")
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("inviteTokenAcceptError error = %v, want ErrForbidden", err)
+	}
+	var denial *inviteTokenAcceptDeniedError
+	if !errors.As(err, &denial) {
+		t.Fatalf("inviteTokenAcceptError error = %T, want inviteTokenAcceptDeniedError", err)
+	}
+	if denial.Reason != "invite_email_empty" || !denial.CallerEmailPresent || denial.InviteEmailPresent || denial.EmailMatch {
+		t.Fatalf("denial metadata = %+v", denial)
+	}
+}
+
+func TestInviteTokenAcceptError_RejectsMismatchedCallerEmail(t *testing.T) {
+	err := inviteTokenAcceptError(Caller{Email: "other@example.com"}, "friend@example.com")
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("inviteTokenAcceptError error = %v, want ErrForbidden", err)
+	}
+	var denial *inviteTokenAcceptDeniedError
+	if !errors.As(err, &denial) {
+		t.Fatalf("inviteTokenAcceptError error = %T, want inviteTokenAcceptDeniedError", err)
+	}
+	if denial.Reason != "caller_email_mismatch" || !denial.CallerEmailPresent || !denial.InviteEmailPresent || denial.EmailMatch {
+		t.Fatalf("denial metadata = %+v", denial)
 	}
 }
 

--- a/backend/internal/api/workspace_memberships.go
+++ b/backend/internal/api/workspace_memberships.go
@@ -292,8 +292,8 @@ func (m *WorkspaceMembershipManager) AcceptWorkspaceInvite(ctx context.Context, 
 	if err != nil {
 		return WorkspaceMembershipResult{}, err
 	}
-	if !inviteTokenCanBeAcceptedByCaller(caller, membership.Email) {
-		return WorkspaceMembershipResult{}, ErrForbidden
+	if err := inviteTokenAcceptError(caller, membership.Email); err != nil {
+		return WorkspaceMembershipResult{}, withInviteAcceptDenialContext(err, "workspace", caller.UserID, membership.ID, membership.OrganizationID, membership.WorkspaceID)
 	}
 	if wsInviteExpired(membership) {
 		return WorkspaceMembershipResult{}, repository.ErrInviteExpired

--- a/backend/internal/api/workspace_memberships_test.go
+++ b/backend/internal/api/workspace_memberships_test.go
@@ -426,6 +426,13 @@ func TestAcceptWorkspaceInviteToken_RejectsMismatchedCallerEmail(t *testing.T) {
 	if !errors.Is(err, ErrForbidden) {
 		t.Fatalf("AcceptWorkspaceInvite error = %v, want ErrForbidden", err)
 	}
+	var denial *inviteTokenAcceptDeniedError
+	if !errors.As(err, &denial) {
+		t.Fatalf("AcceptWorkspaceInvite error = %T, want inviteTokenAcceptDeniedError", err)
+	}
+	if denial.Kind != "workspace" || denial.Reason != "caller_email_mismatch" || denial.MembershipID != membershipID || denial.OrganizationID != orgID || denial.WorkspaceID != workspaceID {
+		t.Fatalf("denial metadata = %+v", denial)
+	}
 	if repo.lastOrgCreate.UserID != uuid.Nil || repo.lastOrgUpdate.Status != nil || repo.lastUpdate.Status != nil {
 		t.Fatalf("membership was updated despite forbidden caller: orgCreate=%+v orgUpdate=%+v wsUpdate=%+v", repo.lastOrgCreate, repo.lastOrgUpdate, repo.lastUpdate)
 	}

--- a/testing/codex-log-invite-accept-denials.md
+++ b/testing/codex-log-invite-accept-denials.md
@@ -1,0 +1,26 @@
+# codex/log-invite-accept-denials - Test Contract
+
+## Functional Behavior
+- Token invite accept should keep the #620 security behavior: a caller with an empty email may accept a valid invite token when the invite row has an email.
+- A caller with a non-empty email that differs from the invite row email should still be rejected.
+- A malformed invite row with no invite email should still be rejected.
+- Rejections from token invite acceptance should carry a private, structured reason that server logs can report without logging the token or raw email addresses.
+- HTTP responses should remain unchanged: forbidden invite acceptance still returns `403` with `access denied`.
+
+## Unit Tests
+- `TestInviteTokenAcceptError_AllowsEmptyCallerEmail` - empty caller email and non-empty invite email returns no error.
+- `TestInviteTokenAcceptError_RejectsEmptyInviteEmail` - empty invite email returns `ErrForbidden` and reason metadata.
+- `TestInviteTokenAcceptError_RejectsMismatchedCallerEmail` - mismatched non-empty caller email returns `ErrForbidden` and reason metadata.
+- Existing org and workspace token accept tests continue to pass.
+
+## Integration / Functional Tests
+- `go test ./internal/api` from `backend/` should pass.
+
+## Smoke Tests
+- N/A - this change is backend-only diagnostic behavior and does not start services.
+
+## E2E Tests
+- N/A - production verification requires a fresh failed invite click after deployment and checking backend logs for the structured denial reason.
+
+## Manual / cURL Tests
+- N/A locally - invite acceptance needs seeded membership data and authenticated WorkOS sessions.


### PR DESCRIPTION
## Summary
- add typed, non-sensitive denial reasons for token invite accept failures
- log invite accept denials with reason, membership/org/workspace IDs, and email-present booleans only
- keep invite acceptance security behavior and public 403 response unchanged

## Tests
- cd backend && go test ./internal/api
- cd backend && go test ./...

## Notes
This should tell us whether the current production 403 is from a stale deployment, a non-empty caller email mismatch, or an invite row missing email data.