### PR TITLE
feat: add agent harness task suites

### DIFF
--- a/backend/db/migrations/00042_agent_harness_suites.sql
+++ b/backend/db/migrations/00042_agent_harness_suites.sql
@@ -1,0 +1,78 @@
+-- +goose Up
+CREATE TABLE agent_harness_suites (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id uuid NOT NULL REFERENCES organizations (id) ON DELETE CASCADE,
+    workspace_id uuid NOT NULL,
+    created_by_user_id uuid REFERENCES users (id) ON DELETE SET NULL,
+    name text NOT NULL,
+    slug text NOT NULL,
+    description text NOT NULL DEFAULT '',
+    status text NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'archived')),
+    current_version_number integer NOT NULL DEFAULT 1,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (workspace_id, slug),
+    UNIQUE (id, organization_id, workspace_id),
+    FOREIGN KEY (workspace_id, organization_id) REFERENCES workspaces (id, organization_id) ON DELETE CASCADE
+);
+
+CREATE TABLE agent_harness_suite_versions (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id uuid NOT NULL,
+    workspace_id uuid NOT NULL,
+    agent_harness_suite_id uuid NOT NULL,
+    version_number integer NOT NULL,
+    status text NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'archived')),
+    metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_by_user_id uuid REFERENCES users (id) ON DELETE SET NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (agent_harness_suite_id, version_number),
+    UNIQUE (id, organization_id, workspace_id),
+    FOREIGN KEY (agent_harness_suite_id, organization_id, workspace_id) REFERENCES agent_harness_suites (id, organization_id, workspace_id) ON DELETE CASCADE
+);
+
+CREATE TABLE agent_harness_suite_tasks (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id uuid NOT NULL,
+    workspace_id uuid NOT NULL,
+    agent_harness_suite_version_id uuid NOT NULL,
+    task_order integer NOT NULL DEFAULT 0,
+    title text NOT NULL,
+    public_prompt text NOT NULL DEFAULT '',
+    task_prompt text NOT NULL,
+    source_type text NOT NULL CHECK (source_type IN ('manual', 'github_issue', 'upload', 'prior_harness_run')),
+    source_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+    repository_url text,
+    base_branch text,
+    execution_config jsonb NOT NULL DEFAULT '{}'::jsonb,
+    evaluation_config jsonb NOT NULL DEFAULT '{}'::jsonb,
+    metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    FOREIGN KEY (agent_harness_suite_version_id, organization_id, workspace_id) REFERENCES agent_harness_suite_versions (id, organization_id, workspace_id) ON DELETE CASCADE
+);
+
+CREATE INDEX agent_harness_suites_workspace_status_idx
+ON agent_harness_suites (workspace_id, status, updated_at DESC);
+
+CREATE INDEX agent_harness_suite_tasks_version_order_idx
+ON agent_harness_suite_tasks (agent_harness_suite_version_id, task_order, id);
+
+CREATE TRIGGER agent_harness_suites_set_updated_at
+BEFORE UPDATE ON agent_harness_suites
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER agent_harness_suite_tasks_set_updated_at
+BEFORE UPDATE ON agent_harness_suite_tasks
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+-- +goose Down
+DROP TRIGGER IF EXISTS agent_harness_suite_tasks_set_updated_at ON agent_harness_suite_tasks;
+DROP TRIGGER IF EXISTS agent_harness_suites_set_updated_at ON agent_harness_suites;
+DROP INDEX IF EXISTS agent_harness_suite_tasks_version_order_idx;
+DROP INDEX IF EXISTS agent_harness_suites_workspace_status_idx;
+DROP TABLE IF EXISTS agent_harness_suite_tasks;
+DROP TABLE IF EXISTS agent_harness_suite_versions;
+DROP TABLE IF EXISTS agent_harness_suites;

--- a/backend/internal/api/agent_harnesses.go
+++ b/backend/internal/api/agent_harnesses.go
@@ -29,6 +29,10 @@ type AgentHarnessRepository interface {
 	CreateAgentHarness(ctx context.Context, p repository.CreateAgentHarnessParams) (repository.AgentHarness, error)
 	GetAgentHarnessByID(ctx context.Context, id uuid.UUID) (repository.AgentHarness, error)
 	ListAgentHarnessesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]repository.AgentHarness, error)
+	CreateAgentHarnessSuite(ctx context.Context, p repository.CreateAgentHarnessSuiteParams) (repository.AgentHarnessSuite, error)
+	GetAgentHarnessSuiteByID(ctx context.Context, id uuid.UUID) (repository.AgentHarnessSuite, error)
+	ListAgentHarnessSuitesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]repository.AgentHarnessSuite, error)
+	ListAgentHarnessSuiteTasksByVersionID(ctx context.Context, versionID uuid.UUID) ([]repository.AgentHarnessSuiteTask, error)
 	CreateAgentHarnessExecution(ctx context.Context, p repository.CreateAgentHarnessExecutionParams) (repository.AgentHarnessExecution, error)
 	TransitionAgentHarnessExecutionStatus(ctx context.Context, p repository.TransitionAgentHarnessExecutionStatusParams) (repository.AgentHarnessExecution, error)
 	GetAgentHarnessExecutionByID(ctx context.Context, id uuid.UUID) (repository.AgentHarnessExecution, error)
@@ -40,6 +44,10 @@ type AgentHarnessService interface {
 	CreateAgentHarness(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateAgentHarnessInput) (repository.AgentHarness, error)
 	GetAgentHarness(ctx context.Context, caller Caller, workspaceID uuid.UUID, id uuid.UUID) (repository.AgentHarness, error)
 	ListAgentHarnesses(ctx context.Context, caller Caller, workspaceID uuid.UUID) ([]repository.AgentHarness, error)
+	CreateAgentHarnessSuite(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateAgentHarnessSuiteInput) (repository.AgentHarnessSuite, error)
+	ListAgentHarnessSuites(ctx context.Context, caller Caller, workspaceID uuid.UUID) ([]repository.AgentHarnessSuite, error)
+	ListAgentHarnessSuiteTasks(ctx context.Context, caller Caller, workspaceID uuid.UUID, suiteID uuid.UUID) ([]repository.AgentHarnessSuiteTask, error)
+	StartAgentHarnessSuiteRun(ctx context.Context, caller Caller, workspaceID uuid.UUID, suiteID uuid.UUID, input StartAgentHarnessSuiteRunInput) ([]repository.AgentHarnessExecution, error)
 	StartAgentHarnessExecution(ctx context.Context, caller Caller, workspaceID uuid.UUID, harnessID uuid.UUID, input StartAgentHarnessExecutionInput) (repository.AgentHarnessExecution, error)
 	GetAgentHarnessExecution(ctx context.Context, caller Caller, workspaceID uuid.UUID, executionID uuid.UUID) (repository.AgentHarnessExecution, error)
 	ListAgentHarnessExecutions(ctx context.Context, caller Caller, workspaceID uuid.UUID, harnessID *uuid.UUID) ([]repository.AgentHarnessExecution, error)
@@ -90,6 +98,31 @@ type CreateAgentHarnessInput struct {
 
 type StartAgentHarnessExecutionInput struct {
 	Message string `json:"message"`
+}
+
+type CreateAgentHarnessSuiteInput struct {
+	Name        string                             `json:"name"`
+	Description string                             `json:"description"`
+	Metadata    json.RawMessage                    `json:"metadata"`
+	Tasks       []CreateAgentHarnessSuiteTaskInput `json:"tasks"`
+}
+
+type CreateAgentHarnessSuiteTaskInput struct {
+	Title            string          `json:"title"`
+	PublicPrompt     string          `json:"public_prompt"`
+	TaskPrompt       string          `json:"task_prompt"`
+	SourceType       string          `json:"source_type"`
+	SourceSnapshot   json.RawMessage `json:"source_snapshot"`
+	RepositoryURL    string          `json:"repository_url"`
+	BaseBranch       string          `json:"base_branch"`
+	ExecutionConfig  json.RawMessage `json:"execution_config"`
+	EvaluationConfig json.RawMessage `json:"evaluation_config"`
+	Metadata         json.RawMessage `json:"metadata"`
+}
+
+type StartAgentHarnessSuiteRunInput struct {
+	HarnessIDs []uuid.UUID `json:"harness_ids"`
+	TaskIDs    []uuid.UUID `json:"task_ids"`
 }
 
 type AgentHarnessValidationError struct {
@@ -191,6 +224,190 @@ func (m *AgentHarnessManager) ListAgentHarnesses(ctx context.Context, caller Cal
 		return nil, err
 	}
 	return m.repo.ListAgentHarnessesByWorkspaceID(ctx, workspaceID)
+}
+
+func (m *AgentHarnessManager) CreateAgentHarnessSuite(ctx context.Context, caller Caller, workspaceID uuid.UUID, input CreateAgentHarnessSuiteInput) (repository.AgentHarnessSuite, error) {
+	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, workspaceID, ActionCreateRun); err != nil {
+		return repository.AgentHarnessSuite{}, err
+	}
+	if strings.TrimSpace(input.Name) == "" {
+		return repository.AgentHarnessSuite{}, AgentHarnessValidationError{Code: "name_required", Message: "name is required"}
+	}
+	if len(input.Tasks) == 0 {
+		return repository.AgentHarnessSuite{}, AgentHarnessValidationError{Code: "tasks_required", Message: "at least one task is required"}
+	}
+	if err := validateRawJSONFields(map[string]json.RawMessage{"metadata": input.Metadata}); err != nil {
+		return repository.AgentHarnessSuite{}, err
+	}
+	orgID, err := m.repo.GetOrganizationIDByWorkspaceID(ctx, workspaceID)
+	if err != nil {
+		return repository.AgentHarnessSuite{}, err
+	}
+	tasks := make([]repository.CreateAgentHarnessSuiteTaskParams, 0, len(input.Tasks))
+	for index, task := range input.Tasks {
+		if strings.TrimSpace(task.Title) == "" || strings.TrimSpace(task.TaskPrompt) == "" {
+			return repository.AgentHarnessSuite{}, AgentHarnessValidationError{Code: "task_invalid", Message: fmt.Sprintf("task %d requires title and task_prompt", index)}
+		}
+		sourceType := strings.TrimSpace(task.SourceType)
+		if sourceType == "" {
+			sourceType = "manual"
+		}
+		if !validAgentHarnessSuiteTaskSource(sourceType) {
+			return repository.AgentHarnessSuite{}, AgentHarnessValidationError{Code: "task_source_invalid", Message: fmt.Sprintf("task %d has unsupported source_type", index)}
+		}
+		if err := validateRawJSONFields(map[string]json.RawMessage{
+			"source_snapshot":   task.SourceSnapshot,
+			"execution_config":  task.ExecutionConfig,
+			"evaluation_config": task.EvaluationConfig,
+			"metadata":          task.Metadata,
+		}); err != nil {
+			var validationErr AgentHarnessValidationError
+			if errors.As(err, &validationErr) {
+				validationErr.Message = fmt.Sprintf("task %d %s", index, validationErr.Message)
+				return repository.AgentHarnessSuite{}, validationErr
+			}
+			return repository.AgentHarnessSuite{}, err
+		}
+		tasks = append(tasks, repository.CreateAgentHarnessSuiteTaskParams{
+			Title:            strings.TrimSpace(task.Title),
+			PublicPrompt:     strings.TrimSpace(task.PublicPrompt),
+			TaskPrompt:       strings.TrimSpace(task.TaskPrompt),
+			SourceType:       sourceType,
+			SourceSnapshot:   defaultJSON(task.SourceSnapshot),
+			RepositoryURL:    optionalHarnessString(task.RepositoryURL),
+			BaseBranch:       optionalHarnessString(task.BaseBranch),
+			ExecutionConfig:  defaultJSON(task.ExecutionConfig),
+			EvaluationConfig: defaultJSON(task.EvaluationConfig),
+			Metadata:         defaultJSON(task.Metadata),
+		})
+	}
+	return m.repo.CreateAgentHarnessSuite(ctx, repository.CreateAgentHarnessSuiteParams{
+		OrganizationID:  orgID,
+		WorkspaceID:     workspaceID,
+		CreatedByUserID: &caller.UserID,
+		Name:            strings.TrimSpace(input.Name),
+		Slug:            generateSlug(input.Name),
+		Description:     strings.TrimSpace(input.Description),
+		Metadata:        defaultJSON(input.Metadata),
+		Tasks:           tasks,
+	})
+}
+
+func (m *AgentHarnessManager) ListAgentHarnessSuites(ctx context.Context, caller Caller, workspaceID uuid.UUID) ([]repository.AgentHarnessSuite, error) {
+	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, workspaceID); err != nil {
+		return nil, err
+	}
+	return m.repo.ListAgentHarnessSuitesByWorkspaceID(ctx, workspaceID)
+}
+
+func (m *AgentHarnessManager) ListAgentHarnessSuiteTasks(ctx context.Context, caller Caller, workspaceID uuid.UUID, suiteID uuid.UUID) ([]repository.AgentHarnessSuiteTask, error) {
+	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, workspaceID); err != nil {
+		return nil, err
+	}
+	suite, err := m.repo.GetAgentHarnessSuiteByID(ctx, suiteID)
+	if err != nil {
+		return nil, err
+	}
+	if suite.WorkspaceID != workspaceID || suite.Status != "active" {
+		return nil, repository.ErrAgentHarnessSuiteNotFound
+	}
+	return m.repo.ListAgentHarnessSuiteTasksByVersionID(ctx, suite.CurrentVersionID)
+}
+
+func (m *AgentHarnessManager) StartAgentHarnessSuiteRun(ctx context.Context, caller Caller, workspaceID uuid.UUID, suiteID uuid.UUID, input StartAgentHarnessSuiteRunInput) ([]repository.AgentHarnessExecution, error) {
+	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, workspaceID, ActionCreateRun); err != nil {
+		return nil, err
+	}
+	suite, err := m.repo.GetAgentHarnessSuiteByID(ctx, suiteID)
+	if err != nil {
+		return nil, err
+	}
+	if suite.WorkspaceID != workspaceID {
+		return nil, repository.ErrAgentHarnessSuiteNotFound
+	}
+	if suite.Status != "active" {
+		return nil, repository.ErrAgentHarnessSuiteNotFound
+	}
+	if len(input.HarnessIDs) == 0 {
+		return nil, AgentHarnessValidationError{Code: "harnesses_required", Message: "at least one harness_id is required"}
+	}
+	tasks, err := m.repo.ListAgentHarnessSuiteTasksByVersionID(ctx, suite.CurrentVersionID)
+	if err != nil {
+		return nil, err
+	}
+	tasks = filterAgentHarnessSuiteTasks(tasks, input.TaskIDs)
+	if len(tasks) == 0 {
+		return nil, AgentHarnessValidationError{Code: "tasks_required", Message: "no suite tasks matched the request"}
+	}
+	harnesses := make([]repository.AgentHarness, 0, len(input.HarnessIDs))
+	for _, harnessID := range input.HarnessIDs {
+		harness, err := m.repo.GetAgentHarnessByID(ctx, harnessID)
+		if err != nil {
+			return nil, err
+		}
+		if harness.WorkspaceID != workspaceID {
+			return nil, repository.ErrAgentHarnessNotFound
+		}
+		for _, task := range tasks {
+			if err := validateAgentHarnessSuiteTaskHarnessBinding(harness, task); err != nil {
+				return nil, err
+			}
+		}
+		harnesses = append(harnesses, harness)
+	}
+	executions := make([]repository.AgentHarnessExecution, 0, len(tasks)*len(input.HarnessIDs))
+	for _, harness := range harnesses {
+		for _, task := range tasks {
+			taskHarness := harness
+			taskHarness.TaskPrompt = task.TaskPrompt
+			if task.RepositoryURL != nil {
+				taskHarness.RepositoryURL = task.RepositoryURL
+			}
+			if task.BaseBranch != nil {
+				taskHarness.BaseBranch = task.BaseBranch
+			}
+			if !isEmptyJSONObject(task.ExecutionConfig) {
+				taskHarness.ExecutionConfig = task.ExecutionConfig
+			}
+			if !isEmptyJSONObject(task.EvaluationConfig) {
+				taskHarness.EvaluationConfig = task.EvaluationConfig
+			}
+			snapshot, err := marshalAgentHarnessSnapshot(taskHarness, StartAgentHarnessExecutionInput{})
+			if err != nil {
+				return nil, err
+			}
+			executionConfig := taskHarness.ExecutionConfig
+			evaluationConfig := agentHarnessSuiteEvaluationConfig(taskHarness.EvaluationConfig, suite, task)
+			execution, err := m.repo.CreateAgentHarnessExecution(ctx, repository.CreateAgentHarnessExecutionParams{
+				OrganizationID:           harness.OrganizationID,
+				WorkspaceID:              workspaceID,
+				AgentHarnessID:           harness.ID,
+				CreatedByUserID:          &caller.UserID,
+				HarnessSnapshot:          snapshot,
+				ExecutionConfigSnapshot:  defaultJSON(executionConfig),
+				EvaluationConfigSnapshot: evaluationConfig,
+			})
+			if err != nil {
+				return nil, err
+			}
+			if err := m.workflowStarter.StartAgentHarnessExecutionWorkflow(ctx, execution.ID, agentHarnessExecutionTimeoutSeconds(execution.ExecutionConfigSnapshot)); err != nil {
+				reason := err.Error()
+				failedExecution, transitionErr := m.repo.TransitionAgentHarnessExecutionStatus(ctx, repository.TransitionAgentHarnessExecutionStatusParams{
+					ExecutionID: execution.ID,
+					ToStatus:    repository.AgentHarnessExecutionStatusFailed,
+					Reason:      &reason,
+				})
+				if transitionErr == nil {
+					execution = failedExecution
+				} else {
+					execution.Status = string(repository.AgentHarnessExecutionStatusFailed)
+					execution.ErrorMessage = &reason
+				}
+			}
+			executions = append(executions, execution)
+		}
+	}
+	return executions, nil
 }
 
 func (m *AgentHarnessManager) StartAgentHarnessExecution(ctx context.Context, caller Caller, workspaceID uuid.UUID, harnessID uuid.UUID, input StartAgentHarnessExecutionInput) (repository.AgentHarnessExecution, error) {
@@ -303,10 +520,17 @@ func validateAgentHarnessInput(input CreateAgentHarnessInput) error {
 	default:
 		return AgentHarnessValidationError{Code: "invalid_repository_provider", Message: "repository_provider must be github when provided"}
 	}
-	for field, raw := range map[string]json.RawMessage{
+	if err := validateRawJSONFields(map[string]json.RawMessage{
 		"execution_config":  input.ExecutionConfig,
 		"evaluation_config": input.EvaluationConfig,
-	} {
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateRawJSONFields(fields map[string]json.RawMessage) error {
+	for field, raw := range fields {
 		if len(raw) > 0 && !json.Valid(raw) {
 			return AgentHarnessValidationError{Code: "invalid_json", Message: fmt.Sprintf("%s must be valid JSON", field)}
 		}
@@ -384,6 +608,31 @@ type agentHarnessResponse struct {
 
 type listAgentHarnessesResponse struct {
 	Items []agentHarnessResponse `json:"items"`
+}
+
+type listAgentHarnessSuitesResponse struct {
+	Items []repository.AgentHarnessSuite `json:"items"`
+}
+
+type agentHarnessSuiteTaskResponse struct {
+	ID             uuid.UUID `json:"id"`
+	SuiteVersionID uuid.UUID `json:"suite_version_id"`
+	TaskOrder      int32     `json:"task_order"`
+	Title          string    `json:"title"`
+	PublicPrompt   string    `json:"public_prompt"`
+	SourceType     string    `json:"source_type"`
+	RepositoryURL  *string   `json:"repository_url,omitempty"`
+	BaseBranch     *string   `json:"base_branch,omitempty"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+type listAgentHarnessSuiteTasksResponse struct {
+	Items []agentHarnessSuiteTaskResponse `json:"items"`
+}
+
+type startAgentHarnessSuiteRunResponse struct {
+	Executions []agentHarnessExecutionResponse `json:"executions"`
 }
 
 type agentHarnessExecutionResponse struct {
@@ -472,6 +721,114 @@ func listAgentHarnessesHandler(logger *slog.Logger, service AgentHarnessService)
 			items = append(items, mapAgentHarnessResponse(harness))
 		}
 		writeJSON(w, http.StatusOK, listAgentHarnessesResponse{Items: items})
+	}
+}
+
+func createAgentHarnessSuiteHandler(logger *slog.Logger, service AgentHarnessService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		workspaceID, err := WorkspaceIDFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		var input CreateAgentHarnessSuiteInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_json", "request body must be JSON")
+			return
+		}
+		suite, err := service.CreateAgentHarnessSuite(r.Context(), caller, workspaceID, input)
+		if err != nil {
+			writeAgentHarnessError(w, logger, r, err)
+			return
+		}
+		writeJSON(w, http.StatusCreated, suite)
+	}
+}
+
+func listAgentHarnessSuitesHandler(logger *slog.Logger, service AgentHarnessService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		workspaceID, err := WorkspaceIDFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		suites, err := service.ListAgentHarnessSuites(r.Context(), caller, workspaceID)
+		if err != nil {
+			writeAgentHarnessError(w, logger, r, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, listAgentHarnessSuitesResponse{Items: suites})
+	}
+}
+
+func listAgentHarnessSuiteTasksHandler(logger *slog.Logger, service AgentHarnessService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		workspaceID, err := WorkspaceIDFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		suiteID, err := uuid.Parse(chi.URLParam(r, "suiteID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_suite_id", "suiteID must be a UUID")
+			return
+		}
+		tasks, err := service.ListAgentHarnessSuiteTasks(r.Context(), caller, workspaceID, suiteID)
+		if err != nil {
+			writeAgentHarnessError(w, logger, r, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, listAgentHarnessSuiteTasksResponse{Items: mapAgentHarnessSuiteTaskResponses(tasks)})
+	}
+}
+
+func startAgentHarnessSuiteRunHandler(logger *slog.Logger, service AgentHarnessService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		workspaceID, err := WorkspaceIDFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		suiteID, err := uuid.Parse(chi.URLParam(r, "suiteID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_suite_id", "suiteID must be a UUID")
+			return
+		}
+		var input StartAgentHarnessSuiteRunInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_json", "request body must be JSON")
+			return
+		}
+		executions, err := service.StartAgentHarnessSuiteRun(r.Context(), caller, workspaceID, suiteID, input)
+		if err != nil {
+			writeAgentHarnessError(w, logger, r, err)
+			return
+		}
+		response := startAgentHarnessSuiteRunResponse{Executions: make([]agentHarnessExecutionResponse, 0, len(executions))}
+		for _, execution := range executions {
+			response.Executions = append(response.Executions, mapAgentHarnessExecutionResponse(execution))
+		}
+		writeJSON(w, http.StatusCreated, response)
 	}
 }
 
@@ -641,6 +998,12 @@ func mapAgentHarnessResponse(h repository.AgentHarness) agentHarnessResponse {
 }
 
 func mapAgentHarnessExecutionResponse(e repository.AgentHarnessExecution) agentHarnessExecutionResponse {
+	harnessSnapshot := e.HarnessSnapshot
+	evaluationConfigSnapshot := e.EvaluationConfigSnapshot
+	if agentHarnessEvaluationConfigIsPrivate(e.EvaluationConfigSnapshot) {
+		harnessSnapshot = sanitizeAgentHarnessSnapshot(e.HarnessSnapshot, e.EvaluationConfigSnapshot)
+		evaluationConfigSnapshot = sanitizeAgentHarnessEvaluationConfigSnapshot(e.EvaluationConfigSnapshot)
+	}
 	return agentHarnessExecutionResponse{
 		ID:                       e.ID,
 		OrganizationID:           e.OrganizationID,
@@ -651,9 +1014,9 @@ func mapAgentHarnessExecutionResponse(e repository.AgentHarnessExecution) agentH
 		EvaluationSpecID:         e.EvaluationSpecID,
 		CreatedByUserID:          e.CreatedByUserID,
 		Status:                   e.Status,
-		HarnessSnapshot:          e.HarnessSnapshot,
+		HarnessSnapshot:          harnessSnapshot,
 		ExecutionConfigSnapshot:  e.ExecutionConfigSnapshot,
-		EvaluationConfigSnapshot: e.EvaluationConfigSnapshot,
+		EvaluationConfigSnapshot: evaluationConfigSnapshot,
 		ErrorMessage:             e.ErrorMessage,
 		StartedAt:                e.StartedAt,
 		CompletedAt:              e.CompletedAt,
@@ -661,6 +1024,25 @@ func mapAgentHarnessExecutionResponse(e repository.AgentHarnessExecution) agentH
 		CreatedAt:                e.CreatedAt,
 		UpdatedAt:                e.UpdatedAt,
 	}
+}
+
+func mapAgentHarnessSuiteTaskResponses(tasks []repository.AgentHarnessSuiteTask) []agentHarnessSuiteTaskResponse {
+	items := make([]agentHarnessSuiteTaskResponse, 0, len(tasks))
+	for _, task := range tasks {
+		items = append(items, agentHarnessSuiteTaskResponse{
+			ID:             task.ID,
+			SuiteVersionID: task.SuiteVersionID,
+			TaskOrder:      task.TaskOrder,
+			Title:          task.Title,
+			PublicPrompt:   task.PublicPrompt,
+			SourceType:     task.SourceType,
+			RepositoryURL:  task.RepositoryURL,
+			BaseBranch:     task.BaseBranch,
+			CreatedAt:      task.CreatedAt,
+			UpdatedAt:      task.UpdatedAt,
+		})
+	}
+	return items
 }
 
 func mapAgentHarnessExecutionEventResponses(events []repository.AgentHarnessExecutionEvent) []agentHarnessExecutionEventResponse {
@@ -725,6 +1107,151 @@ func marshalAgentHarnessSnapshot(h repository.AgentHarness, input StartAgentHarn
 	return snapshot, nil
 }
 
+func validAgentHarnessSuiteTaskSource(source string) bool {
+	switch source {
+	case "manual", "github_issue", "upload", "prior_harness_run":
+		return true
+	default:
+		return false
+	}
+}
+
+func filterAgentHarnessSuiteTasks(tasks []repository.AgentHarnessSuiteTask, requested []uuid.UUID) []repository.AgentHarnessSuiteTask {
+	if len(requested) == 0 {
+		return tasks
+	}
+	allowed := make(map[uuid.UUID]struct{}, len(requested))
+	for _, id := range requested {
+		allowed[id] = struct{}{}
+	}
+	filtered := make([]repository.AgentHarnessSuiteTask, 0, len(tasks))
+	for _, task := range tasks {
+		if _, ok := allowed[task.ID]; ok {
+			filtered = append(filtered, task)
+		}
+	}
+	return filtered
+}
+
+func validateAgentHarnessSuiteTaskHarnessBinding(harness repository.AgentHarness, task repository.AgentHarnessSuiteTask) error {
+	if task.RepositoryURL == nil || strings.TrimSpace(*task.RepositoryURL) == "" {
+		return nil
+	}
+	if harness.RepositoryURL == nil || strings.TrimSpace(*harness.RepositoryURL) == "" {
+		return AgentHarnessValidationError{Code: "task_repository_mismatch", Message: "suite task repository_url requires a harness repository_url"}
+	}
+	if strings.TrimSpace(*task.RepositoryURL) != strings.TrimSpace(*harness.RepositoryURL) {
+		return AgentHarnessValidationError{Code: "task_repository_mismatch", Message: "suite task repository_url must match the harness repository_url"}
+	}
+	return nil
+}
+
+func agentHarnessSuiteEvaluationConfig(base json.RawMessage, suite repository.AgentHarnessSuite, task repository.AgentHarnessSuiteTask) json.RawMessage {
+	var config map[string]any
+	if len(base) > 0 && string(base) != "null" {
+		_ = json.Unmarshal(base, &config)
+	}
+	if config == nil {
+		config = map[string]any{}
+	}
+	config["suite"] = map[string]any{
+		"suite_id":         suite.ID,
+		"suite_version":    suite.CurrentVersionNumber,
+		"suite_version_id": suite.CurrentVersionID,
+		"task_id":          task.ID,
+		"task_source":      task.SourceType,
+		"task_metadata":    task.Metadata,
+		"public_prompt":    task.PublicPrompt,
+	}
+	if _, ok := config["result"]; !ok {
+		config["result"] = map[string]any{
+			"kind":             "private_task_bank",
+			"benchmark_source": suite.Name,
+			"publicity":        "private",
+		}
+	}
+	privacy, _ := config["privacy"].(map[string]any)
+	if privacy == nil {
+		privacy = map[string]any{}
+		config["privacy"] = privacy
+	}
+	if _, ok := privacy["redact_replay"]; !ok {
+		privacy["redact_replay"] = true
+	}
+	return defaultJSON(mustMarshalJSON(config))
+}
+
+func isEmptyJSONObject(raw json.RawMessage) bool {
+	if len(raw) == 0 || string(raw) == "null" {
+		return true
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return false
+	}
+	return len(decoded) == 0
+}
+
+func agentHarnessEvaluationConfigIsPrivate(raw json.RawMessage) bool {
+	var config map[string]any
+	if len(raw) == 0 || json.Unmarshal(raw, &config) != nil {
+		return false
+	}
+	if _, ok := config["suite"]; ok {
+		return true
+	}
+	if result, _ := config["result"].(map[string]any); result != nil {
+		if publicity, _ := result["publicity"].(string); strings.EqualFold(strings.TrimSpace(publicity), "private") {
+			return true
+		}
+	}
+	if privacy, _ := config["privacy"].(map[string]any); privacy != nil {
+		if redact, ok := privacy["redact_replay"].(bool); ok && redact {
+			return true
+		}
+	}
+	return false
+}
+
+func sanitizeAgentHarnessSnapshot(raw json.RawMessage, evaluationConfig json.RawMessage) json.RawMessage {
+	var snapshot map[string]any
+	if len(raw) == 0 || json.Unmarshal(raw, &snapshot) != nil {
+		return raw
+	}
+	snapshot["task_prompt"] = agentHarnessSuitePublicPrompt(evaluationConfig)
+	return mustMarshalJSON(snapshot)
+}
+
+func sanitizeAgentHarnessEvaluationConfigSnapshot(raw json.RawMessage) json.RawMessage {
+	var config map[string]any
+	if len(raw) == 0 || json.Unmarshal(raw, &config) != nil {
+		return raw
+	}
+	if validators, ok := config["validators"].([]any); ok {
+		config["validator_count"] = len(validators)
+	}
+	if judges, ok := config["llm_judges"].([]any); ok {
+		config["llm_judge_count"] = len(judges)
+	}
+	delete(config, "validators")
+	delete(config, "llm_judges")
+	delete(config, "scorecard")
+	return mustMarshalJSON(config)
+}
+
+func agentHarnessSuitePublicPrompt(raw json.RawMessage) string {
+	var config struct {
+		Suite struct {
+			PublicPrompt string `json:"public_prompt"`
+		} `json:"suite"`
+	}
+	_ = json.Unmarshal(raw, &config)
+	if prompt := strings.TrimSpace(config.Suite.PublicPrompt); prompt != "" {
+		return prompt
+	}
+	return "[redacted private suite task]"
+}
+
 func writeAgentHarnessError(w http.ResponseWriter, logger *slog.Logger, r *http.Request, err error) {
 	var validationErr AgentHarnessValidationError
 	switch {
@@ -734,6 +1261,8 @@ func writeAgentHarnessError(w http.ResponseWriter, logger *slog.Logger, r *http.
 		writeError(w, http.StatusConflict, "agent_harness_slug_conflict", "an agent harness with this name already exists in the workspace")
 	case errors.Is(err, repository.ErrAgentHarnessNotFound):
 		writeError(w, http.StatusNotFound, "not_found", "agent harness not found")
+	case errors.Is(err, repository.ErrAgentHarnessSuiteNotFound):
+		writeError(w, http.StatusNotFound, "not_found", "agent harness suite not found")
 	case errors.Is(err, repository.ErrAgentHarnessExecutionNotFound):
 		writeError(w, http.StatusNotFound, "not_found", "agent harness execution not found")
 	default:
@@ -761,6 +1290,22 @@ func (noopAgentHarnessService) GetAgentHarness(context.Context, Caller, uuid.UUI
 }
 
 func (noopAgentHarnessService) ListAgentHarnesses(context.Context, Caller, uuid.UUID) ([]repository.AgentHarness, error) {
+	return nil, errors.New("agent harness service is not configured")
+}
+
+func (noopAgentHarnessService) CreateAgentHarnessSuite(context.Context, Caller, uuid.UUID, CreateAgentHarnessSuiteInput) (repository.AgentHarnessSuite, error) {
+	return repository.AgentHarnessSuite{}, errors.New("agent harness service is not configured")
+}
+
+func (noopAgentHarnessService) ListAgentHarnessSuites(context.Context, Caller, uuid.UUID) ([]repository.AgentHarnessSuite, error) {
+	return nil, errors.New("agent harness service is not configured")
+}
+
+func (noopAgentHarnessService) ListAgentHarnessSuiteTasks(context.Context, Caller, uuid.UUID, uuid.UUID) ([]repository.AgentHarnessSuiteTask, error) {
+	return nil, errors.New("agent harness service is not configured")
+}
+
+func (noopAgentHarnessService) StartAgentHarnessSuiteRun(context.Context, Caller, uuid.UUID, uuid.UUID, StartAgentHarnessSuiteRunInput) ([]repository.AgentHarnessExecution, error) {
 	return nil, errors.New("agent harness service is not configured")
 }
 

--- a/backend/internal/api/agent_harnesses_test.go
+++ b/backend/internal/api/agent_harnesses_test.go
@@ -256,6 +256,228 @@ func TestAgentHarnessManagerCreatePersistsGitHubRepositoryMetadata(t *testing.T)
 	}
 }
 
+func TestAgentHarnessManagerCreateSuitePersistsVersionedTasks(t *testing.T) {
+	workspaceID := uuid.New()
+	orgID := uuid.New()
+	repo := &fakeAgentHarnessRepo{organizationID: orgID}
+	manager := NewAgentHarnessManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	suite, err := manager.CreateAgentHarnessSuite(context.Background(), testAgentHarnessCaller(workspaceID), workspaceID, CreateAgentHarnessSuiteInput{
+		Name:        "Rust repo private tasks",
+		Description: "Autonomy checks for private Rust work",
+		Metadata:    json.RawMessage(`{"suite_kind":"private_task_bank"}`),
+		Tasks: []CreateAgentHarnessSuiteTaskInput{{
+			Title:          "Fix ownership bug",
+			PublicPrompt:   "Fix a Rust compile failure.",
+			TaskPrompt:     "Fix the hidden borrow-checker failure and open a PR.",
+			SourceType:     "github_issue",
+			SourceSnapshot: json.RawMessage(`{"repository":"acme/rusty","number":17,"title":"Borrow checker failure","labels":["rust"]}`),
+			RepositoryURL:  "https://github.com/acme/rusty",
+			BaseBranch:     "main",
+			ExecutionConfig: json.RawMessage(`{
+				"setup_commands": ["cargo fetch"],
+				"timeout_seconds": 900
+			}`),
+			EvaluationConfig: json.RawMessage(`{
+				"validators": [{"type":"command","command":"cargo test --all"}],
+				"llm_judges": [{"key":"pr_quality"}],
+				"private": true
+			}`),
+			Metadata: json.RawMessage(`{"difficulty":"medium"}`),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentHarnessSuite error: %v", err)
+	}
+
+	if suite.OrganizationID != orgID {
+		t.Fatalf("organization_id = %s, want %s", suite.OrganizationID, orgID)
+	}
+	if suite.Slug != "rust-repo-private-tasks" {
+		t.Fatalf("slug = %q", suite.Slug)
+	}
+	if suite.CurrentVersionNumber != 1 || suite.TaskCount != 1 {
+		t.Fatalf("version/task count = %d/%d, want 1/1", suite.CurrentVersionNumber, suite.TaskCount)
+	}
+	if got := repo.createdSuite.Tasks[0]; got.SourceType != "github_issue" || string(got.EvaluationConfig) == "{}" {
+		t.Fatalf("task source/eval = %q/%s, want github_issue with hidden eval config", got.SourceType, got.EvaluationConfig)
+	}
+	if string(repo.createdSuite.Tasks[0].SourceSnapshot) == "{}" {
+		t.Fatal("github issue source snapshot was not preserved")
+	}
+}
+
+func TestAgentHarnessManagerStartSuiteRunCreatesExecutionsFromTasks(t *testing.T) {
+	workspaceID := uuid.New()
+	suite := testAgentHarnessSuiteRecord(workspaceID, "Private Rust Tasks")
+	harnessA := testAgentHarnessRecord(workspaceID, "Codex Rust")
+	harnessB := testAgentHarnessRecord(workspaceID, "Claude Rust")
+	harnessB.HarnessKind = AgentHarnessKindClaudeE2B
+	harnessA.RepositoryURL = stringPtr("https://github.com/acme/rusty")
+	harnessB.RepositoryURL = stringPtr("https://github.com/acme/rusty")
+	taskA := testAgentHarnessSuiteTaskRecord(workspaceID, suite.CurrentVersionID, "Hidden borrow checker")
+	taskA.ID = uuid.New()
+	taskA.TaskPrompt = "Fix the hidden borrow checker bug and open a PR."
+	taskA.RepositoryURL = stringPtr("https://github.com/acme/rusty")
+	taskA.BaseBranch = stringPtr("trunk")
+	taskA.ExecutionConfig = json.RawMessage(`{"timeout_seconds":1200}`)
+	taskA.EvaluationConfig = json.RawMessage(`{
+		"validators": [{"type":"command","command":"cargo test --all"}],
+		"llm_judges": [{"key":"pr_quality"}],
+		"privacy": {"redact_replay": true}
+	}`)
+	taskB := testAgentHarnessSuiteTaskRecord(workspaceID, suite.CurrentVersionID, "Unselected")
+	repo := &fakeAgentHarnessRepo{
+		organizationID: harnessA.OrganizationID,
+		harnessesByID: map[uuid.UUID]repository.AgentHarness{
+			harnessA.ID: harnessA,
+			harnessB.ID: harnessB,
+		},
+		suite:      suite,
+		suiteTasks: []repository.AgentHarnessSuiteTask{taskA, taskB},
+	}
+	starter := &fakeAgentHarnessWorkflowStarter{}
+	manager := NewAgentHarnessManager(NewCallerWorkspaceAuthorizer(), repo, starter)
+
+	executions, err := manager.StartAgentHarnessSuiteRun(context.Background(), testAgentHarnessCaller(workspaceID), workspaceID, suite.ID, StartAgentHarnessSuiteRunInput{
+		HarnessIDs: []uuid.UUID{harnessA.ID, harnessB.ID},
+		TaskIDs:    []uuid.UUID{taskA.ID},
+	})
+	if err != nil {
+		t.Fatalf("StartAgentHarnessSuiteRun error: %v", err)
+	}
+
+	if len(executions) != 2 || len(repo.createdExecutions) != 2 {
+		t.Fatalf("executions = %d created = %d, want 2", len(executions), len(repo.createdExecutions))
+	}
+	for index, created := range repo.createdExecutions {
+		var snapshot agentHarnessResponse
+		if err := json.Unmarshal(created.HarnessSnapshot, &snapshot); err != nil {
+			t.Fatalf("decode harness snapshot %d: %v", index, err)
+		}
+		if snapshot.TaskPrompt != taskA.TaskPrompt {
+			t.Fatalf("snapshot task prompt = %q, want task prompt", snapshot.TaskPrompt)
+		}
+		if snapshot.RepositoryURL == nil || *snapshot.RepositoryURL != "https://github.com/acme/rusty" {
+			t.Fatalf("snapshot repository = %#v, want task repository", snapshot.RepositoryURL)
+		}
+		if snapshot.BaseBranch == nil || *snapshot.BaseBranch != "trunk" {
+			t.Fatalf("snapshot base branch = %#v, want task base branch", snapshot.BaseBranch)
+		}
+		if string(created.ExecutionConfigSnapshot) != string(taskA.ExecutionConfig) {
+			t.Fatalf("execution config = %s, want task config", created.ExecutionConfigSnapshot)
+		}
+		var eval struct {
+			Validators []map[string]any `json:"validators"`
+			LLMJudges  []map[string]any `json:"llm_judges"`
+			Privacy    struct {
+				Redact bool `json:"redact_replay"`
+			} `json:"privacy"`
+			Suite struct {
+				SuiteID        uuid.UUID       `json:"suite_id"`
+				SuiteVersionID uuid.UUID       `json:"suite_version_id"`
+				TaskID         uuid.UUID       `json:"task_id"`
+				TaskSource     string          `json:"task_source"`
+				TaskMetadata   json.RawMessage `json:"task_metadata"`
+			} `json:"suite"`
+			Result map[string]any `json:"result"`
+		}
+		if err := json.Unmarshal(created.EvaluationConfigSnapshot, &eval); err != nil {
+			t.Fatalf("decode evaluation config %d: %v", index, err)
+		}
+		if len(eval.Validators) != 1 || len(eval.LLMJudges) != 1 || !eval.Privacy.Redact {
+			t.Fatalf("eval config did not preserve validators/judges/privacy: %#v", eval)
+		}
+		if eval.Suite.SuiteID != suite.ID || eval.Suite.SuiteVersionID != suite.CurrentVersionID || eval.Suite.TaskID != taskA.ID {
+			t.Fatalf("suite metadata = %#v, want suite/task ids", eval.Suite)
+		}
+		if eval.Result["kind"] != "private_task_bank" {
+			t.Fatalf("result metadata = %#v, want private_task_bank", eval.Result)
+		}
+	}
+	if starter.startedCount != 2 || starter.timeoutSeconds != 1200 {
+		t.Fatalf("starter count/timeout = %d/%d, want 2/1200", starter.startedCount, starter.timeoutSeconds)
+	}
+}
+
+func TestAgentHarnessManagerStartSuiteRunInheritsHarnessConfigWhenTaskConfigOmitted(t *testing.T) {
+	workspaceID := uuid.New()
+	suite := testAgentHarnessSuiteRecord(workspaceID, "Private Tasks")
+	harness := testAgentHarnessRecord(workspaceID, "Codex Rust")
+	harness.ExecutionConfig = json.RawMessage(`{"timeout_seconds":600}`)
+	harness.EvaluationConfig = json.RawMessage(`{"validators":[{"type":"command","command":"go test ./..."}]}`)
+	task := testAgentHarnessSuiteTaskRecord(workspaceID, suite.CurrentVersionID, "No overrides")
+	task.ExecutionConfig = json.RawMessage(`{}`)
+	task.EvaluationConfig = json.RawMessage(`{}`)
+	repo := &fakeAgentHarnessRepo{
+		organizationID: harness.OrganizationID,
+		harness:        harness,
+		suite:          suite,
+		suiteTasks:     []repository.AgentHarnessSuiteTask{task},
+	}
+	manager := NewAgentHarnessManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	_, err := manager.StartAgentHarnessSuiteRun(context.Background(), testAgentHarnessCaller(workspaceID), workspaceID, suite.ID, StartAgentHarnessSuiteRunInput{
+		HarnessIDs: []uuid.UUID{harness.ID},
+	})
+	if err != nil {
+		t.Fatalf("StartAgentHarnessSuiteRun error: %v", err)
+	}
+	if string(repo.createdExecution.ExecutionConfigSnapshot) != string(harness.ExecutionConfig) {
+		t.Fatalf("execution config = %s, want inherited harness config", repo.createdExecution.ExecutionConfigSnapshot)
+	}
+	var eval struct {
+		Validators []map[string]any `json:"validators"`
+		Suite      map[string]any   `json:"suite"`
+	}
+	if err := json.Unmarshal(repo.createdExecution.EvaluationConfigSnapshot, &eval); err != nil {
+		t.Fatalf("decode evaluation config: %v", err)
+	}
+	if len(eval.Validators) != 1 || eval.Suite == nil {
+		t.Fatalf("evaluation config = %#v, want inherited validators plus suite metadata", eval)
+	}
+}
+
+func TestMapAgentHarnessExecutionResponseRedactsPrivateSuiteSnapshots(t *testing.T) {
+	workspaceID := uuid.New()
+	harnessID := uuid.New()
+	execution := testAgentHarnessExecutionRecord(workspaceID, harnessID)
+	execution.HarnessSnapshot = json.RawMessage(`{"id":"` + harnessID.String() + `","task_prompt":"hidden private task","name":"Harness"}`)
+	execution.EvaluationConfigSnapshot = json.RawMessage(`{
+		"validators": [{"type":"command","command":"cargo test --hidden"}],
+		"llm_judges": [{"key":"secret"}],
+		"suite": {"suite_id":"` + uuid.NewString() + `","public_prompt":"Fix a Rust test."},
+		"result": {"publicity":"private"},
+		"privacy": {"redact_replay": true}
+	}`)
+
+	response := mapAgentHarnessExecutionResponse(execution)
+
+	if string(response.HarnessSnapshot) == string(execution.HarnessSnapshot) {
+		t.Fatal("harness snapshot was not redacted")
+	}
+	var snapshot map[string]any
+	if err := json.Unmarshal(response.HarnessSnapshot, &snapshot); err != nil {
+		t.Fatalf("decode redacted snapshot: %v", err)
+	}
+	if snapshot["task_prompt"] != "Fix a Rust test." {
+		t.Fatalf("task_prompt = %#v, want public prompt", snapshot["task_prompt"])
+	}
+	var evaluation map[string]any
+	if err := json.Unmarshal(response.EvaluationConfigSnapshot, &evaluation); err != nil {
+		t.Fatalf("decode redacted eval config: %v", err)
+	}
+	if _, ok := evaluation["validators"]; ok {
+		t.Fatalf("redacted evaluation leaked validators: %#v", evaluation)
+	}
+	if _, ok := evaluation["llm_judges"]; ok {
+		t.Fatalf("redacted evaluation leaked llm_judges: %#v", evaluation)
+	}
+	if evaluation["validator_count"].(float64) != 1 || evaluation["llm_judge_count"].(float64) != 1 {
+		t.Fatalf("redacted counts = %#v, want validator/judge counts", evaluation)
+	}
+}
+
 func TestAgentHarnessRoutesCreateAndList(t *testing.T) {
 	workspaceID := uuid.New()
 	service := &fakeAgentHarnessService{
@@ -336,6 +558,98 @@ func TestAgentHarnessRouteReturnsConflictOnDuplicateSlug(t *testing.T) {
 	router.ServeHTTP(rec, req)
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("status = %d, want %d; body %s", rec.Code, http.StatusConflict, rec.Body.String())
+	}
+}
+
+func TestAgentHarnessSuiteRoutesCreateListAndRun(t *testing.T) {
+	workspaceID := uuid.New()
+	harnessID := uuid.New()
+	taskID := uuid.New()
+	suite := testAgentHarnessSuiteRecord(workspaceID, "Nightly private tasks")
+	service := &fakeAgentHarnessService{
+		suites:     []repository.AgentHarnessSuite{suite},
+		suiteTasks: []repository.AgentHarnessSuiteTask{testAgentHarnessSuiteTaskRecord(workspaceID, suite.CurrentVersionID, "Fix flaky Rust test")},
+	}
+	router := chi.NewRouter()
+	router.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := context.WithValue(r.Context(), callerContextKey{}, testAgentHarnessCaller(workspaceID))
+			ctx = context.WithValue(ctx, workspaceIDContextKey{}, workspaceID)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	})
+	router.Post("/v1/workspaces/{workspaceID}/agent-harness-suites", createAgentHarnessSuiteHandler(slog.Default(), service))
+	router.Get("/v1/workspaces/{workspaceID}/agent-harness-suites", listAgentHarnessSuitesHandler(slog.Default(), service))
+	router.Get("/v1/workspaces/{workspaceID}/agent-harness-suites/{suiteID}/tasks", listAgentHarnessSuiteTasksHandler(slog.Default(), service))
+	router.Post("/v1/workspaces/{workspaceID}/agent-harness-suites/{suiteID}/runs", startAgentHarnessSuiteRunHandler(slog.Default(), service))
+
+	createReq := httptest.NewRequest(http.MethodPost, "/v1/workspaces/"+workspaceID.String()+"/agent-harness-suites", bytes.NewBufferString(`{
+		"name": "Nightly private tasks",
+		"description": "Private benchmark bank",
+		"metadata": {"owner": "platform"},
+		"tasks": [{
+			"title": "Fix flaky Rust test",
+			"public_prompt": "Fix a flaky Rust test.",
+			"task_prompt": "Fix the hidden flaky Rust test and make a PR.",
+			"source_type": "github_issue",
+			"source_snapshot": {"repository": "acme/rusty", "number": 44},
+			"evaluation_config": {"validators": [{"type": "command", "command": "cargo test --all"}]}
+		}]
+	}`))
+	createRec := httptest.NewRecorder()
+	router.ServeHTTP(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, body %s", createRec.Code, createRec.Body.String())
+	}
+	if service.createdSuiteInput.Tasks[0].SourceType != "github_issue" {
+		t.Fatalf("source type = %q, want github_issue", service.createdSuiteInput.Tasks[0].SourceType)
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/v1/workspaces/"+workspaceID.String()+"/agent-harness-suites", nil)
+	listRec := httptest.NewRecorder()
+	router.ServeHTTP(listRec, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("list status = %d, body %s", listRec.Code, listRec.Body.String())
+	}
+	var listed listAgentHarnessSuitesResponse
+	if err := json.Unmarshal(listRec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode suites: %v", err)
+	}
+	if len(listed.Items) != 1 || listed.Items[0].ID != suite.ID {
+		t.Fatalf("listed suites = %#v, want suite", listed.Items)
+	}
+
+	tasksReq := httptest.NewRequest(http.MethodGet, "/v1/workspaces/"+workspaceID.String()+"/agent-harness-suites/"+suite.ID.String()+"/tasks", nil)
+	tasksRec := httptest.NewRecorder()
+	router.ServeHTTP(tasksRec, tasksReq)
+	if tasksRec.Code != http.StatusOK {
+		t.Fatalf("tasks status = %d, body %s", tasksRec.Code, tasksRec.Body.String())
+	}
+	var listedTasks listAgentHarnessSuiteTasksResponse
+	if err := json.Unmarshal(tasksRec.Body.Bytes(), &listedTasks); err != nil {
+		t.Fatalf("decode suite tasks: %v", err)
+	}
+	if len(listedTasks.Items) != 1 || listedTasks.Items[0].ID == uuid.Nil || listedTasks.Items[0].PublicPrompt == "" {
+		t.Fatalf("listed tasks = %#v, want public task with id", listedTasks.Items)
+	}
+
+	runReq := httptest.NewRequest(http.MethodPost, "/v1/workspaces/"+workspaceID.String()+"/agent-harness-suites/"+suite.ID.String()+"/runs", bytes.NewBufferString(`{
+		"harness_ids": ["`+harnessID.String()+`"],
+		"task_ids": ["`+taskID.String()+`"]
+	}`))
+	runRec := httptest.NewRecorder()
+	router.ServeHTTP(runRec, runReq)
+	if runRec.Code != http.StatusCreated {
+		t.Fatalf("run status = %d, body %s", runRec.Code, runRec.Body.String())
+	}
+	if service.startedSuiteID != suite.ID {
+		t.Fatalf("started suite = %s, want %s", service.startedSuiteID, suite.ID)
+	}
+	if len(service.startedSuiteInput.HarnessIDs) != 1 || service.startedSuiteInput.HarnessIDs[0] != harnessID {
+		t.Fatalf("started harnesses = %#v, want harness id", service.startedSuiteInput.HarnessIDs)
+	}
+	if len(service.startedSuiteInput.TaskIDs) != 1 || service.startedSuiteInput.TaskIDs[0] != taskID {
+		t.Fatalf("started tasks = %#v, want task id", service.startedSuiteInput.TaskIDs)
 	}
 }
 
@@ -754,13 +1068,58 @@ func testAgentHarnessExecutionRecord(workspaceID uuid.UUID, harnessID uuid.UUID)
 	}
 }
 
+func testAgentHarnessSuiteRecord(workspaceID uuid.UUID, name string) repository.AgentHarnessSuite {
+	now := time.Now().UTC()
+	return repository.AgentHarnessSuite{
+		ID:                   uuid.New(),
+		OrganizationID:       uuid.New(),
+		WorkspaceID:          workspaceID,
+		Name:                 name,
+		Slug:                 generateSlug(name),
+		Description:          "description",
+		Status:               "active",
+		CurrentVersionNumber: 1,
+		CurrentVersionID:     uuid.New(),
+		TaskCount:            1,
+		Metadata:             json.RawMessage(`{}`),
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}
+}
+
+func testAgentHarnessSuiteTaskRecord(workspaceID uuid.UUID, versionID uuid.UUID, title string) repository.AgentHarnessSuiteTask {
+	now := time.Now().UTC()
+	return repository.AgentHarnessSuiteTask{
+		ID:               uuid.New(),
+		OrganizationID:   uuid.New(),
+		WorkspaceID:      workspaceID,
+		SuiteVersionID:   versionID,
+		Title:            title,
+		PublicPrompt:     "Fix a public task.",
+		TaskPrompt:       "Fix the hidden task.",
+		SourceType:       "manual",
+		SourceSnapshot:   json.RawMessage(`{}`),
+		ExecutionConfig:  json.RawMessage(`{}`),
+		EvaluationConfig: json.RawMessage(`{}`),
+		Metadata:         json.RawMessage(`{}`),
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+}
+
 type fakeAgentHarnessRepo struct {
 	organizationID          uuid.UUID
 	created                 repository.CreateAgentHarnessParams
+	createdSuite            repository.CreateAgentHarnessSuiteParams
 	createdExecution        repository.CreateAgentHarnessExecutionParams
+	createdExecutions       []repository.CreateAgentHarnessExecutionParams
 	transitionedStatus      repository.AgentHarnessExecutionStatus
 	transitionedReason      *string
 	harness                 repository.AgentHarness
+	harnessesByID           map[uuid.UUID]repository.AgentHarness
+	suite                   repository.AgentHarnessSuite
+	suites                  []repository.AgentHarnessSuite
+	suiteTasks              []repository.AgentHarnessSuiteTask
 	execution               repository.AgentHarnessExecution
 	executions              []repository.AgentHarnessExecution
 	getByIDCalls            int
@@ -805,6 +1164,27 @@ func (f *fakeAgentHarnessRepo) CreateAgentHarness(_ context.Context, p repositor
 	}, nil
 }
 
+func (f *fakeAgentHarnessRepo) CreateAgentHarnessSuite(_ context.Context, p repository.CreateAgentHarnessSuiteParams) (repository.AgentHarnessSuite, error) {
+	f.createdSuite = p
+	now := time.Now().UTC()
+	return repository.AgentHarnessSuite{
+		ID:                   uuid.New(),
+		OrganizationID:       p.OrganizationID,
+		WorkspaceID:          p.WorkspaceID,
+		CreatedByUserID:      p.CreatedByUserID,
+		Name:                 p.Name,
+		Slug:                 p.Slug,
+		Description:          p.Description,
+		Status:               "active",
+		CurrentVersionNumber: 1,
+		CurrentVersionID:     uuid.New(),
+		TaskCount:            len(p.Tasks),
+		Metadata:             p.Metadata,
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}, nil
+}
+
 func (f *fakeAgentHarnessRepo) GetWorkspaceGitHubRepository(_ context.Context, workspaceID uuid.UUID, _ int64, _ *int64) (repository.GitHubInstallationRepository, error) {
 	f.githubLookupWorkspaceID = workspaceID
 	if f.githubRepoErr != nil {
@@ -815,6 +1195,11 @@ func (f *fakeAgentHarnessRepo) GetWorkspaceGitHubRepository(_ context.Context, w
 
 func (f *fakeAgentHarnessRepo) GetAgentHarnessByID(_ context.Context, id uuid.UUID) (repository.AgentHarness, error) {
 	f.getByIDCalls++
+	if f.harnessesByID != nil {
+		if harness, ok := f.harnessesByID[id]; ok {
+			return harness, nil
+		}
+	}
 	if f.harness.ID == id {
 		return f.harness, nil
 	}
@@ -825,8 +1210,24 @@ func (f *fakeAgentHarnessRepo) ListAgentHarnessesByWorkspaceID(context.Context, 
 	return nil, nil
 }
 
+func (f *fakeAgentHarnessRepo) GetAgentHarnessSuiteByID(_ context.Context, id uuid.UUID) (repository.AgentHarnessSuite, error) {
+	if f.suite.ID == id {
+		return f.suite, nil
+	}
+	return repository.AgentHarnessSuite{}, repository.ErrAgentHarnessSuiteNotFound
+}
+
+func (f *fakeAgentHarnessRepo) ListAgentHarnessSuitesByWorkspaceID(context.Context, uuid.UUID) ([]repository.AgentHarnessSuite, error) {
+	return f.suites, nil
+}
+
+func (f *fakeAgentHarnessRepo) ListAgentHarnessSuiteTasksByVersionID(context.Context, uuid.UUID) ([]repository.AgentHarnessSuiteTask, error) {
+	return f.suiteTasks, nil
+}
+
 func (f *fakeAgentHarnessRepo) CreateAgentHarnessExecution(_ context.Context, p repository.CreateAgentHarnessExecutionParams) (repository.AgentHarnessExecution, error) {
 	f.createdExecution = p
+	f.createdExecutions = append(f.createdExecutions, p)
 	now := time.Now().UTC()
 	return repository.AgentHarnessExecution{
 		ID:                       uuid.New(),
@@ -871,9 +1272,14 @@ func (f *fakeAgentHarnessRepo) ListAgentHarnessExecutionEvents(context.Context, 
 
 type fakeAgentHarnessService struct {
 	harnesses               []repository.AgentHarness
+	suites                  []repository.AgentHarnessSuite
+	suiteTasks              []repository.AgentHarnessSuiteTask
 	executions              []repository.AgentHarnessExecution
 	events                  []repository.AgentHarnessExecutionEvent
 	createdInput            CreateAgentHarnessInput
+	createdSuiteInput       CreateAgentHarnessSuiteInput
+	startedSuiteID          uuid.UUID
+	startedSuiteInput       StartAgentHarnessSuiteRunInput
 	startedHarnessID        uuid.UUID
 	startedInput            StartAgentHarnessExecutionInput
 	listExecutionsHarnessID *uuid.UUID
@@ -899,6 +1305,44 @@ func (f *fakeAgentHarnessService) GetAgentHarness(_ context.Context, _ Caller, _
 
 func (f *fakeAgentHarnessService) ListAgentHarnesses(context.Context, Caller, uuid.UUID) ([]repository.AgentHarness, error) {
 	return f.harnesses, nil
+}
+
+func (f *fakeAgentHarnessService) CreateAgentHarnessSuite(_ context.Context, _ Caller, workspaceID uuid.UUID, input CreateAgentHarnessSuiteInput) (repository.AgentHarnessSuite, error) {
+	f.createdSuiteInput = input
+	now := time.Now().UTC()
+	return repository.AgentHarnessSuite{
+		ID:                   uuid.New(),
+		OrganizationID:       uuid.New(),
+		WorkspaceID:          workspaceID,
+		Name:                 input.Name,
+		Slug:                 generateSlug(input.Name),
+		Description:          input.Description,
+		Status:               "active",
+		CurrentVersionNumber: 1,
+		CurrentVersionID:     uuid.New(),
+		TaskCount:            len(input.Tasks),
+		Metadata:             input.Metadata,
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}, nil
+}
+
+func (f *fakeAgentHarnessService) ListAgentHarnessSuites(context.Context, Caller, uuid.UUID) ([]repository.AgentHarnessSuite, error) {
+	return f.suites, nil
+}
+
+func (f *fakeAgentHarnessService) ListAgentHarnessSuiteTasks(context.Context, Caller, uuid.UUID, uuid.UUID) ([]repository.AgentHarnessSuiteTask, error) {
+	return f.suiteTasks, nil
+}
+
+func (f *fakeAgentHarnessService) StartAgentHarnessSuiteRun(_ context.Context, _ Caller, workspaceID uuid.UUID, suiteID uuid.UUID, input StartAgentHarnessSuiteRunInput) ([]repository.AgentHarnessExecution, error) {
+	f.startedSuiteID = suiteID
+	f.startedSuiteInput = input
+	executions := make([]repository.AgentHarnessExecution, 0, len(input.HarnessIDs))
+	for _, harnessID := range input.HarnessIDs {
+		executions = append(executions, testAgentHarnessExecutionRecord(workspaceID, harnessID))
+	}
+	return executions, nil
 }
 
 func (f *fakeAgentHarnessService) StartAgentHarnessExecution(_ context.Context, _ Caller, workspaceID uuid.UUID, harnessID uuid.UUID, input StartAgentHarnessExecutionInput) (repository.AgentHarnessExecution, error) {
@@ -927,10 +1371,12 @@ func (f *fakeAgentHarnessService) ListAgentHarnessExecutions(_ context.Context, 
 
 type fakeAgentHarnessWorkflowStarter struct {
 	err            error
+	startedCount   int
 	timeoutSeconds int
 }
 
 func (f *fakeAgentHarnessWorkflowStarter) StartAgentHarnessExecutionWorkflow(_ context.Context, _ uuid.UUID, timeoutSeconds int) error {
+	f.startedCount++
 	f.timeoutSeconds = timeoutSeconds
 	return f.err
 }

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -134,6 +134,14 @@ func registerProtectedRoutes(
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Get("/workspaces/{workspaceID}/agent-harnesses/{harnessID}", getAgentHarnessHandler(logger, agentHarnessService))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Post("/workspaces/{workspaceID}/agent-harness-suites", createAgentHarnessSuiteHandler(logger, agentHarnessService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Get("/workspaces/{workspaceID}/agent-harness-suites", listAgentHarnessSuitesHandler(logger, agentHarnessService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Get("/workspaces/{workspaceID}/agent-harness-suites/{suiteID}/tasks", listAgentHarnessSuiteTasksHandler(logger, agentHarnessService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Post("/workspaces/{workspaceID}/agent-harness-suites/{suiteID}/runs", startAgentHarnessSuiteRunHandler(logger, agentHarnessService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Post("/workspaces/{workspaceID}/agent-harnesses/{harnessID}/executions", startAgentHarnessExecutionHandler(logger, agentHarnessService))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Get("/workspaces/{workspaceID}/agent-harness-executions", listAgentHarnessExecutionsHandler(logger, agentHarnessService))

--- a/backend/internal/repository/agent_harness_suites.go
+++ b/backend/internal/repository/agent_harness_suites.go
@@ -1,0 +1,306 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+var (
+	ErrAgentHarnessSuiteNotFound     = errors.New("agent harness suite not found")
+	ErrAgentHarnessSuiteSlugConflict = errors.New("agent harness suite slug already exists in workspace")
+)
+
+type AgentHarnessSuite struct {
+	ID                   uuid.UUID       `json:"id"`
+	OrganizationID       uuid.UUID       `json:"organization_id"`
+	WorkspaceID          uuid.UUID       `json:"workspace_id"`
+	CreatedByUserID      *uuid.UUID      `json:"created_by_user_id,omitempty"`
+	Name                 string          `json:"name"`
+	Slug                 string          `json:"slug"`
+	Description          string          `json:"description"`
+	Status               string          `json:"status"`
+	CurrentVersionNumber int32           `json:"current_version_number"`
+	CurrentVersionID     uuid.UUID       `json:"current_version_id"`
+	TaskCount            int             `json:"task_count"`
+	Metadata             json.RawMessage `json:"metadata,omitempty"`
+	CreatedAt            time.Time       `json:"created_at"`
+	UpdatedAt            time.Time       `json:"updated_at"`
+}
+
+type AgentHarnessSuiteTask struct {
+	ID               uuid.UUID       `json:"id"`
+	OrganizationID   uuid.UUID       `json:"organization_id"`
+	WorkspaceID      uuid.UUID       `json:"workspace_id"`
+	SuiteVersionID   uuid.UUID       `json:"suite_version_id"`
+	TaskOrder        int32           `json:"task_order"`
+	Title            string          `json:"title"`
+	PublicPrompt     string          `json:"public_prompt"`
+	TaskPrompt       string          `json:"-"`
+	SourceType       string          `json:"source_type"`
+	SourceSnapshot   json.RawMessage `json:"-"`
+	RepositoryURL    *string         `json:"repository_url,omitempty"`
+	BaseBranch       *string         `json:"base_branch,omitempty"`
+	ExecutionConfig  json.RawMessage `json:"execution_config"`
+	EvaluationConfig json.RawMessage `json:"-"`
+	Metadata         json.RawMessage `json:"metadata"`
+	CreatedAt        time.Time       `json:"created_at"`
+	UpdatedAt        time.Time       `json:"updated_at"`
+}
+
+type CreateAgentHarnessSuiteParams struct {
+	OrganizationID  uuid.UUID
+	WorkspaceID     uuid.UUID
+	CreatedByUserID *uuid.UUID
+	Name            string
+	Slug            string
+	Description     string
+	Metadata        json.RawMessage
+	Tasks           []CreateAgentHarnessSuiteTaskParams
+}
+
+type CreateAgentHarnessSuiteTaskParams struct {
+	Title            string
+	PublicPrompt     string
+	TaskPrompt       string
+	SourceType       string
+	SourceSnapshot   json.RawMessage
+	RepositoryURL    *string
+	BaseBranch       *string
+	ExecutionConfig  json.RawMessage
+	EvaluationConfig json.RawMessage
+	Metadata         json.RawMessage
+}
+
+func (r *Repository) CreateAgentHarnessSuite(ctx context.Context, params CreateAgentHarnessSuiteParams) (AgentHarnessSuite, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return AgentHarnessSuite{}, fmt.Errorf("begin agent harness suite create transaction: %w", err)
+	}
+	defer rollback(ctx, tx)
+
+	suiteRow := tx.QueryRow(ctx, `
+INSERT INTO agent_harness_suites (
+    organization_id, workspace_id, created_by_user_id, name, slug, description
+) VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING id, organization_id, workspace_id, created_by_user_id, name, slug, description,
+    status, current_version_number, created_at, updated_at`,
+		params.OrganizationID,
+		params.WorkspaceID,
+		params.CreatedByUserID,
+		strings.TrimSpace(params.Name),
+		strings.TrimSpace(params.Slug),
+		params.Description,
+	)
+	suite, err := scanAgentHarnessSuite(suiteRow)
+	if err != nil {
+		if isAgentHarnessSuiteSlugConflict(err) {
+			return AgentHarnessSuite{}, ErrAgentHarnessSuiteSlugConflict
+		}
+		return AgentHarnessSuite{}, err
+	}
+
+	versionRow := tx.QueryRow(ctx, `
+INSERT INTO agent_harness_suite_versions (
+    organization_id, workspace_id, agent_harness_suite_id, version_number, metadata, created_by_user_id
+) VALUES ($1, $2, $3, 1, $4, $5)
+RETURNING id`,
+		params.OrganizationID,
+		params.WorkspaceID,
+		suite.ID,
+		defaultRepositoryJSON(params.Metadata),
+		params.CreatedByUserID,
+	)
+	if err := versionRow.Scan(&suite.CurrentVersionID); err != nil {
+		return AgentHarnessSuite{}, fmt.Errorf("create agent harness suite version: %w", err)
+	}
+	suite.Metadata = defaultRepositoryJSON(params.Metadata)
+
+	for index, task := range params.Tasks {
+		if _, err := tx.Exec(ctx, `
+INSERT INTO agent_harness_suite_tasks (
+    organization_id, workspace_id, agent_harness_suite_version_id, task_order,
+    title, public_prompt, task_prompt, source_type, source_snapshot,
+    repository_url, base_branch, execution_config, evaluation_config, metadata
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
+			params.OrganizationID,
+			params.WorkspaceID,
+			suite.CurrentVersionID,
+			int32(index),
+			strings.TrimSpace(task.Title),
+			task.PublicPrompt,
+			task.TaskPrompt,
+			task.SourceType,
+			defaultRepositoryJSON(task.SourceSnapshot),
+			task.RepositoryURL,
+			task.BaseBranch,
+			defaultRepositoryJSON(task.ExecutionConfig),
+			defaultRepositoryJSON(task.EvaluationConfig),
+			defaultRepositoryJSON(task.Metadata),
+		); err != nil {
+			return AgentHarnessSuite{}, fmt.Errorf("create agent harness suite task %d: %w", index, err)
+		}
+	}
+	suite.TaskCount = len(params.Tasks)
+
+	if err := tx.Commit(ctx); err != nil {
+		return AgentHarnessSuite{}, fmt.Errorf("commit agent harness suite create transaction: %w", err)
+	}
+	return suite, nil
+}
+
+func (r *Repository) ListAgentHarnessSuitesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]AgentHarnessSuite, error) {
+	rows, err := r.db.Query(ctx, `
+SELECT
+    s.id, s.organization_id, s.workspace_id, s.created_by_user_id, s.name, s.slug, s.description,
+    s.status, s.current_version_number, s.created_at, s.updated_at,
+    v.id, v.metadata, count(t.id)::bigint
+FROM agent_harness_suites s
+JOIN agent_harness_suite_versions v
+  ON v.agent_harness_suite_id = s.id AND v.version_number = s.current_version_number
+LEFT JOIN agent_harness_suite_tasks t ON t.agent_harness_suite_version_id = v.id
+WHERE s.workspace_id = $1 AND s.status = 'active'
+GROUP BY s.id, v.id, v.metadata
+ORDER BY s.updated_at DESC, s.id DESC`, workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("list agent harness suites by workspace id: %w", err)
+	}
+	defer rows.Close()
+
+	suites := make([]AgentHarnessSuite, 0)
+	for rows.Next() {
+		suite, scanErr := scanAgentHarnessSuiteWithVersion(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		suites = append(suites, suite)
+	}
+	return suites, rows.Err()
+}
+
+func (r *Repository) GetAgentHarnessSuiteByID(ctx context.Context, id uuid.UUID) (AgentHarnessSuite, error) {
+	row := r.db.QueryRow(ctx, `
+SELECT
+    s.id, s.organization_id, s.workspace_id, s.created_by_user_id, s.name, s.slug, s.description,
+    s.status, s.current_version_number, s.created_at, s.updated_at,
+    v.id, v.metadata, count(t.id)::bigint
+FROM agent_harness_suites s
+JOIN agent_harness_suite_versions v
+  ON v.agent_harness_suite_id = s.id AND v.version_number = s.current_version_number
+LEFT JOIN agent_harness_suite_tasks t ON t.agent_harness_suite_version_id = v.id
+WHERE s.id = $1
+GROUP BY s.id, v.id, v.metadata
+LIMIT 1`, id)
+	return scanAgentHarnessSuiteWithVersion(row)
+}
+
+func (r *Repository) ListAgentHarnessSuiteTasksByVersionID(ctx context.Context, versionID uuid.UUID) ([]AgentHarnessSuiteTask, error) {
+	rows, err := r.db.Query(ctx, `
+SELECT id, organization_id, workspace_id, agent_harness_suite_version_id, task_order,
+    title, public_prompt, task_prompt, source_type, source_snapshot,
+    repository_url, base_branch, execution_config, evaluation_config, metadata, created_at, updated_at
+FROM agent_harness_suite_tasks
+WHERE agent_harness_suite_version_id = $1
+ORDER BY task_order ASC, id ASC`, versionID)
+	if err != nil {
+		return nil, fmt.Errorf("list agent harness suite tasks by version id: %w", err)
+	}
+	defer rows.Close()
+
+	tasks := make([]AgentHarnessSuiteTask, 0)
+	for rows.Next() {
+		task, scanErr := scanAgentHarnessSuiteTask(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		tasks = append(tasks, task)
+	}
+	return tasks, rows.Err()
+}
+
+type agentHarnessSuiteScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanAgentHarnessSuite(scanner agentHarnessSuiteScanner) (AgentHarnessSuite, error) {
+	var suite AgentHarnessSuite
+	err := scanner.Scan(
+		&suite.ID,
+		&suite.OrganizationID,
+		&suite.WorkspaceID,
+		&suite.CreatedByUserID,
+		&suite.Name,
+		&suite.Slug,
+		&suite.Description,
+		&suite.Status,
+		&suite.CurrentVersionNumber,
+		&suite.CreatedAt,
+		&suite.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return AgentHarnessSuite{}, ErrAgentHarnessSuiteNotFound
+	}
+	return suite, err
+}
+
+func scanAgentHarnessSuiteWithVersion(scanner agentHarnessSuiteScanner) (AgentHarnessSuite, error) {
+	var suite AgentHarnessSuite
+	var count int64
+	err := scanner.Scan(
+		&suite.ID,
+		&suite.OrganizationID,
+		&suite.WorkspaceID,
+		&suite.CreatedByUserID,
+		&suite.Name,
+		&suite.Slug,
+		&suite.Description,
+		&suite.Status,
+		&suite.CurrentVersionNumber,
+		&suite.CreatedAt,
+		&suite.UpdatedAt,
+		&suite.CurrentVersionID,
+		&suite.Metadata,
+		&count,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return AgentHarnessSuite{}, ErrAgentHarnessSuiteNotFound
+	}
+	suite.TaskCount = int(count)
+	return suite, err
+}
+
+func scanAgentHarnessSuiteTask(scanner agentHarnessSuiteScanner) (AgentHarnessSuiteTask, error) {
+	var task AgentHarnessSuiteTask
+	err := scanner.Scan(
+		&task.ID,
+		&task.OrganizationID,
+		&task.WorkspaceID,
+		&task.SuiteVersionID,
+		&task.TaskOrder,
+		&task.Title,
+		&task.PublicPrompt,
+		&task.TaskPrompt,
+		&task.SourceType,
+		&task.SourceSnapshot,
+		&task.RepositoryURL,
+		&task.BaseBranch,
+		&task.ExecutionConfig,
+		&task.EvaluationConfig,
+		&task.Metadata,
+		&task.CreatedAt,
+		&task.UpdatedAt,
+	)
+	return task, err
+}
+
+func isAgentHarnessSuiteSlugConflict(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505" && strings.Contains(pgErr.ConstraintName, "slug")
+}

--- a/backend/internal/repository/agent_harness_suites_integration_test.go
+++ b/backend/internal/repository/agent_harness_suites_integration_test.go
@@ -1,0 +1,91 @@
+package repository_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+func TestRepositoryAgentHarnessSuitePersistsVersionedTaskBank(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	suite, err := repo.CreateAgentHarnessSuite(ctx, repository.CreateAgentHarnessSuiteParams{
+		OrganizationID:  fixture.organizationID,
+		WorkspaceID:     fixture.workspaceID,
+		CreatedByUserID: &fixture.userID,
+		Name:            "Rust Private Bank",
+		Slug:            "rust-private-bank",
+		Description:     "Private Rust coding tasks",
+		Metadata:        json.RawMessage(`{"suite_kind":"private_task_bank"}`),
+		Tasks: []repository.CreateAgentHarnessSuiteTaskParams{{
+			Title:          "Fix ownership bug",
+			PublicPrompt:   "Fix a Rust compile failure.",
+			TaskPrompt:     "Fix the hidden borrow-checker failure and open a PR.",
+			SourceType:     "github_issue",
+			SourceSnapshot: json.RawMessage(`{"repository":"acme/rusty","number":17,"labels":["rust"]}`),
+			RepositoryURL:  stringPtr("https://github.com/acme/rusty"),
+			BaseBranch:     stringPtr("main"),
+			ExecutionConfig: json.RawMessage(`{
+				"setup_commands": ["cargo fetch"],
+				"timeout_seconds": 900
+			}`),
+			EvaluationConfig: json.RawMessage(`{
+				"validators": [{"type":"command","command":"cargo test --all"}],
+				"llm_judges": [{"key":"pr_quality"}],
+				"redact_replay": true
+			}`),
+			Metadata: json.RawMessage(`{"difficulty":"medium"}`),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentHarnessSuite returned error: %v", err)
+	}
+
+	if suite.CurrentVersionNumber != 1 || suite.CurrentVersionID == uuid.Nil || suite.TaskCount != 1 {
+		t.Fatalf("suite version/task count = %d/%s/%d, want v1 with one task", suite.CurrentVersionNumber, suite.CurrentVersionID, suite.TaskCount)
+	}
+	listed, err := repo.ListAgentHarnessSuitesByWorkspaceID(ctx, fixture.workspaceID)
+	if err != nil {
+		t.Fatalf("ListAgentHarnessSuitesByWorkspaceID returned error: %v", err)
+	}
+	if len(listed) != 1 || listed[0].ID != suite.ID || listed[0].TaskCount != 1 {
+		t.Fatalf("listed suites = %#v, want persisted suite", listed)
+	}
+	tasks, err := repo.ListAgentHarnessSuiteTasksByVersionID(ctx, suite.CurrentVersionID)
+	if err != nil {
+		t.Fatalf("ListAgentHarnessSuiteTasksByVersionID returned error: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("tasks = %d, want 1", len(tasks))
+	}
+	task := tasks[0]
+	if task.SourceType != "github_issue" || task.RepositoryURL == nil || *task.RepositoryURL != "https://github.com/acme/rusty" {
+		t.Fatalf("task source/repo = %q/%#v, want github issue repo snapshot", task.SourceType, task.RepositoryURL)
+	}
+	if string(task.EvaluationConfig) == "{}" || string(task.SourceSnapshot) == "{}" {
+		t.Fatalf("task hidden evaluation/source snapshot not preserved: eval=%s source=%s", task.EvaluationConfig, task.SourceSnapshot)
+	}
+
+	_, err = repo.CreateAgentHarnessSuite(ctx, repository.CreateAgentHarnessSuiteParams{
+		OrganizationID:  fixture.organizationID,
+		WorkspaceID:     fixture.workspaceID,
+		CreatedByUserID: &fixture.userID,
+		Name:            "Rust Private Bank Again",
+		Slug:            "rust-private-bank",
+		Tasks: []repository.CreateAgentHarnessSuiteTaskParams{{
+			Title:      "Duplicate slug task",
+			TaskPrompt: "Do the hidden task.",
+			SourceType: "manual",
+		}},
+	})
+	if !errors.Is(err, repository.ErrAgentHarnessSuiteSlugConflict) {
+		t.Fatalf("duplicate slug error = %v, want ErrAgentHarnessSuiteSlugConflict", err)
+	}
+}

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -1123,6 +1123,7 @@ func buildRunAgentScorecardDocument(evaluation scoring.RunAgentEvaluation) (json
 		MetricSummary    map[string]int              `json:"metric_summary"`
 		MetricDetails    []metricDetail              `json:"metric_details,omitempty"`
 		LLMJudgeDetails  []llmJudgeDetail            `json:"llm_judge_details,omitempty"`
+		Metadata         json.RawMessage             `json:"metadata,omitempty"`
 	}
 
 	dimensions := make(map[string]dimensionSummary, len(evaluation.DimensionResults))
@@ -1244,6 +1245,7 @@ func buildRunAgentScorecardDocument(evaluation scoring.RunAgentEvaluation) (json
 		MetricSummary:    metricSummary,
 		MetricDetails:    metricDetails,
 		LLMJudgeDetails:  llmJudgeDetails,
+		Metadata:         cloneJSON(evaluation.Metadata),
 	}
 
 	encoded, err := json.Marshal(document)

--- a/backend/internal/scoring/engine.go
+++ b/backend/internal/scoring/engine.go
@@ -103,6 +103,7 @@ type RunAgentEvaluation struct {
 	Validity         EvaluationValidity  `json:"validity,omitempty"`
 	ValidityReason   string              `json:"validity_reason,omitempty"`
 	Strategy         ScoringStrategy     `json:"strategy,omitempty"`
+	Metadata         json.RawMessage     `json:"metadata,omitempty"`
 	Warnings         []string            `json:"warnings,omitempty"`
 }
 

--- a/backend/internal/workflow/agent_harness_execution_workflow.go
+++ b/backend/internal/workflow/agent_harness_execution_workflow.go
@@ -58,6 +58,7 @@ type agentHarnessEvaluationConfig struct {
 	LLMJudges  []json.RawMessage             `json:"llm_judges,omitempty"`
 	Scorecard  json.RawMessage               `json:"scorecard,omitempty"`
 	Result     agentHarnessResultMetadata    `json:"result,omitempty"`
+	Suite      agentHarnessSuiteMetadata     `json:"suite,omitempty"`
 	Privacy    agentHarnessPrivacyConfig     `json:"privacy,omitempty"`
 }
 
@@ -80,6 +81,16 @@ type agentHarnessResultMetadata struct {
 	AllowedPublicContext []string `json:"allowed_public_context,omitempty"`
 	Contamination        string   `json:"contamination,omitempty"`
 	Publicity            string   `json:"publicity,omitempty"`
+}
+
+type agentHarnessSuiteMetadata struct {
+	SuiteID        uuid.UUID       `json:"suite_id,omitempty"`
+	SuiteVersion   int32           `json:"suite_version,omitempty"`
+	SuiteVersionID uuid.UUID       `json:"suite_version_id,omitempty"`
+	TaskID         uuid.UUID       `json:"task_id,omitempty"`
+	TaskSource     string          `json:"task_source,omitempty"`
+	TaskMetadata   json.RawMessage `json:"task_metadata,omitempty"`
+	PublicPrompt   string          `json:"public_prompt,omitempty"`
 }
 
 type agentHarnessPrivacyConfig struct {
@@ -821,6 +832,7 @@ func (a *Activities) evaluateAgentHarnessExecution(ctx context.Context, executio
 				"llm_judges":         len(evaluation.LLMJudgeResults),
 				"dimensions":         evaluation.DimensionScores,
 				"result":             config.Result,
+				"suite":              config.Suite,
 				"privacy":            config.Privacy,
 			}); err != nil {
 				return err
@@ -854,7 +866,7 @@ func (a *Activities) recordAgentHarnessEvaluationControls(ctx context.Context, e
 			}
 		}
 	}
-	if !agentHarnessResultMetadataEmpty(config.Result) {
+	if !agentHarnessResultMetadataEmpty(config.Result) || !agentHarnessSuiteMetadataEmpty(config.Suite) {
 		return a.recordAgentHarnessEvent(ctx, executionID, "benchmark.metadata.recorded", "worker", map[string]any{
 			"kind":                   strings.TrimSpace(config.Result.Kind),
 			"benchmark_source":       strings.TrimSpace(config.Result.BenchmarkSource),
@@ -862,6 +874,7 @@ func (a *Activities) recordAgentHarnessEvaluationControls(ctx context.Context, e
 			"allowed_public_context": config.Result.AllowedPublicContext,
 			"contamination":          strings.TrimSpace(config.Result.Contamination),
 			"publicity":              strings.TrimSpace(config.Result.Publicity),
+			"suite":                  config.Suite,
 		})
 	}
 	return nil
@@ -883,6 +896,16 @@ func agentHarnessResultMetadataEmpty(metadata agentHarnessResultMetadata) bool {
 		len(metadata.AllowedPublicContext) == 0 &&
 		strings.TrimSpace(metadata.Contamination) == "" &&
 		strings.TrimSpace(metadata.Publicity) == ""
+}
+
+func agentHarnessSuiteMetadataEmpty(metadata agentHarnessSuiteMetadata) bool {
+	return metadata.SuiteID == uuid.Nil &&
+		metadata.SuiteVersion == 0 &&
+		metadata.SuiteVersionID == uuid.Nil &&
+		metadata.TaskID == uuid.Nil &&
+		strings.TrimSpace(metadata.TaskSource) == "" &&
+		len(metadata.TaskMetadata) == 0 &&
+		strings.TrimSpace(metadata.PublicPrompt) == ""
 }
 
 func (a *Activities) detectAgentHarnessSetupHints(ctx context.Context, executionID uuid.UUID, session sandbox.Session, workdir string, env map[string]string) error {
@@ -1061,6 +1084,12 @@ func (a *Activities) buildAndStoreAgentHarnessScorecard(ctx context.Context, exe
 	evaluation, err := scoring.EvaluateRunAgentWithPrecomputedResults(input, normalizedSpec, validatorResults, nil, llmJudgeResults)
 	if err != nil {
 		return scoring.RunAgentEvaluation{}, err
+	}
+	if !agentHarnessSuiteMetadataEmpty(config.Suite) || !agentHarnessResultMetadataEmpty(config.Result) {
+		evaluation.Metadata = mustMarshalJSON(map[string]any{
+			"agent_harness_suite": config.Suite,
+			"result":              config.Result,
+		})
 	}
 	evaluation.Warnings = append(evaluation.Warnings, judgeWarnings...)
 	if err := a.repo.StoreRunAgentEvaluationResults(ctx, evaluation); err != nil {

--- a/testing/codex-issue-581-harness-suites-local-test-log.md
+++ b/testing/codex-issue-581-harness-suites-local-test-log.md
@@ -1,0 +1,13 @@
+# Local Test Log - Issue 581 Harness Suites
+
+## 2026-05-06
+
+- `cd backend && go test ./internal/api ./internal/repository ./internal/workflow`
+  - Result: passed.
+  - Notes: repository integration tests that require `DATABASE_URL` skip when no local database is configured.
+- `cd backend && go test ./internal/api ./internal/repository ./internal/workflow ./internal/scoring`
+  - Result: passed after reviewer fixes for task discovery, privacy redaction, config inheritance, suite metadata, and repository binding validation.
+- `cd backend && go test ./...`
+  - Result: passed.
+- `git diff --check`
+  - Result: passed.

--- a/testing/codex-issue-581-harness-suites.md
+++ b/testing/codex-issue-581-harness-suites.md
@@ -1,0 +1,19 @@
+# Issue #581 Expectations
+
+## Scope
+
+Add a backend foundation for Agent Harness suites and private task banks without requiring challenge packs and without duplicating scoring, validator, replay, or judge systems.
+
+## Expected behavior
+
+- Workspaces can create and list versioned Agent Harness suites.
+- Suites contain versioned tasks with public task prompts plus private evaluation config, execution config, repository/base ref, and source snapshots.
+- Task sources support manual, GitHub issue, uploaded file, and prior harness run metadata. GitHub issue tasks persist title/body/comments/labels/repository/base ref in the source snapshot.
+- Starting a suite creates normal Agent Harness executions for a single task, a subset, or the full suite against one or more harnesses. Each execution snapshots the task prompt/configs and records suite/task/version metadata.
+- Results remain comparable through existing harness execution/run-agent scorecards by suite version, harness, model/template/repo, and budget metadata.
+
+## Validation
+
+- Repository tests cover suite/task creation and listing.
+- API tests cover creating/listing suites and starting suite runs.
+- Existing harness execution tests remain green.


### PR DESCRIPTION
## Summary
- add versioned Agent Harness suites and private task-bank storage
- add public suite task discovery plus suite run fan-out across harnesses/tasks
- reuse normal agent harness execution, replay, validators, LLM judges, and scorecard persistence paths
- redact private suite prompts/evaluator config from execution API responses while keeping worker snapshots intact

## Review notes
- Fixes #581
- DRY note: suite runs create ordinary `agent_harness_executions`; they do not introduce a separate evaluator or scoring path.
- Reviewer checkpoint found privacy/discovery/repo-binding issues; this PR includes fixes for those before opening.

## Tests
- `cd backend && go test ./internal/api ./internal/repository ./internal/workflow`
- `cd backend && go test ./internal/api ./internal/repository ./internal/workflow ./internal/scoring`
- `cd backend && go test ./...`
- `git diff --check`
