### PR TITLE
feat: add harness execution controls

### DIFF
--- a/backend/db/migrations/00043_agent_harness_execution_controls.sql
+++ b/backend/db/migrations/00043_agent_harness_execution_controls.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+ALTER TABLE agent_harness_executions
+ADD COLUMN temporal_workflow_id text,
+ADD COLUMN temporal_run_id text,
+ADD COLUMN retry_of_execution_id uuid REFERENCES agent_harness_executions (id) ON DELETE SET NULL,
+ADD COLUMN retry_idempotency_key text;
+
+CREATE UNIQUE INDEX agent_harness_executions_retry_idempotency_idx
+ON agent_harness_executions (workspace_id, retry_of_execution_id, retry_idempotency_key)
+WHERE retry_of_execution_id IS NOT NULL AND retry_idempotency_key IS NOT NULL;
+
+CREATE INDEX agent_harness_executions_workspace_active_idx
+ON agent_harness_executions (workspace_id, status)
+WHERE status IN ('queued', 'provisioning', 'running', 'scoring');
+
+-- +goose Down
+DROP INDEX IF EXISTS agent_harness_executions_workspace_active_idx;
+DROP INDEX IF EXISTS agent_harness_executions_retry_idempotency_idx;
+ALTER TABLE agent_harness_executions
+DROP COLUMN IF EXISTS retry_idempotency_key,
+DROP COLUMN IF EXISTS retry_of_execution_id,
+DROP COLUMN IF EXISTS temporal_run_id,
+DROP COLUMN IF EXISTS temporal_workflow_id;

--- a/backend/internal/api/agent_harnesses.go
+++ b/backend/internal/api/agent_harnesses.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/workflow"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 )
@@ -34,8 +35,11 @@ type AgentHarnessRepository interface {
 	ListAgentHarnessSuitesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]repository.AgentHarnessSuite, error)
 	ListAgentHarnessSuiteTasksByVersionID(ctx context.Context, versionID uuid.UUID) ([]repository.AgentHarnessSuiteTask, error)
 	CreateAgentHarnessExecution(ctx context.Context, p repository.CreateAgentHarnessExecutionParams) (repository.AgentHarnessExecution, error)
+	SetAgentHarnessExecutionTemporalIDs(ctx context.Context, p repository.SetAgentHarnessExecutionTemporalIDsParams) (repository.AgentHarnessExecution, error)
 	TransitionAgentHarnessExecutionStatus(ctx context.Context, p repository.TransitionAgentHarnessExecutionStatusParams) (repository.AgentHarnessExecution, error)
 	GetAgentHarnessExecutionByID(ctx context.Context, id uuid.UUID) (repository.AgentHarnessExecution, error)
+	GetAgentHarnessRetryByIdempotencyKey(ctx context.Context, workspaceID uuid.UUID, retryOfExecutionID uuid.UUID, idempotencyKey string) (repository.AgentHarnessExecution, error)
+	CountActiveAgentHarnessExecutionsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (int, error)
 	ListAgentHarnessExecutions(ctx context.Context, p repository.ListAgentHarnessExecutionsParams) ([]repository.AgentHarnessExecution, error)
 	ListAgentHarnessExecutionEvents(ctx context.Context, executionID uuid.UUID) ([]repository.AgentHarnessExecutionEvent, error)
 }
@@ -49,25 +53,38 @@ type AgentHarnessService interface {
 	ListAgentHarnessSuiteTasks(ctx context.Context, caller Caller, workspaceID uuid.UUID, suiteID uuid.UUID) ([]repository.AgentHarnessSuiteTask, error)
 	StartAgentHarnessSuiteRun(ctx context.Context, caller Caller, workspaceID uuid.UUID, suiteID uuid.UUID, input StartAgentHarnessSuiteRunInput) ([]repository.AgentHarnessExecution, error)
 	StartAgentHarnessExecution(ctx context.Context, caller Caller, workspaceID uuid.UUID, harnessID uuid.UUID, input StartAgentHarnessExecutionInput) (repository.AgentHarnessExecution, error)
+	CancelAgentHarnessExecution(ctx context.Context, caller Caller, workspaceID uuid.UUID, executionID uuid.UUID) (repository.AgentHarnessExecution, error)
+	RetryAgentHarnessExecution(ctx context.Context, caller Caller, workspaceID uuid.UUID, executionID uuid.UUID, input RetryAgentHarnessExecutionInput) (repository.AgentHarnessExecution, error)
 	GetAgentHarnessExecution(ctx context.Context, caller Caller, workspaceID uuid.UUID, executionID uuid.UUID) (repository.AgentHarnessExecution, error)
 	ListAgentHarnessExecutions(ctx context.Context, caller Caller, workspaceID uuid.UUID, harnessID *uuid.UUID) ([]repository.AgentHarnessExecution, error)
 	ListAgentHarnessExecutionEvents(ctx context.Context, caller Caller, workspaceID uuid.UUID, executionID uuid.UUID) ([]repository.AgentHarnessExecutionEvent, error)
 }
 
 type AgentHarnessExecutionWorkflowStarter interface {
-	StartAgentHarnessExecutionWorkflow(ctx context.Context, executionID uuid.UUID, timeoutSeconds int) error
+	StartAgentHarnessExecutionWorkflow(ctx context.Context, executionID uuid.UUID, timeoutSeconds int) (AgentHarnessExecutionWorkflowRef, error)
+}
+
+type AgentHarnessExecutionWorkflowController interface {
+	CancelAgentHarnessExecutionWorkflow(ctx context.Context, workflowID string, runID string) error
+}
+
+type AgentHarnessExecutionWorkflowRef struct {
+	WorkflowID string
+	RunID      string
 }
 
 type noopAgentHarnessExecutionWorkflowStarter struct{}
 
-func (noopAgentHarnessExecutionWorkflowStarter) StartAgentHarnessExecutionWorkflow(context.Context, uuid.UUID, int) error {
-	return nil
+func (noopAgentHarnessExecutionWorkflowStarter) StartAgentHarnessExecutionWorkflow(_ context.Context, executionID uuid.UUID, _ int) (AgentHarnessExecutionWorkflowRef, error) {
+	return AgentHarnessExecutionWorkflowRef{WorkflowID: defaultAgentHarnessExecutionWorkflowID(executionID), RunID: "noop"}, nil
 }
 
 type AgentHarnessManager struct {
-	authorizer      WorkspaceAuthorizer
-	repo            AgentHarnessRepository
-	workflowStarter AgentHarnessExecutionWorkflowStarter
+	authorizer       WorkspaceAuthorizer
+	repo             AgentHarnessRepository
+	workflowStarter  AgentHarnessExecutionWorkflowStarter
+	workflowControl  AgentHarnessExecutionWorkflowController
+	concurrencyLimit int
 }
 
 func NewAgentHarnessManager(authorizer WorkspaceAuthorizer, repo AgentHarnessRepository, starters ...AgentHarnessExecutionWorkflowStarter) *AgentHarnessManager {
@@ -75,7 +92,11 @@ func NewAgentHarnessManager(authorizer WorkspaceAuthorizer, repo AgentHarnessRep
 	if len(starters) > 0 && starters[0] != nil {
 		starter = starters[0]
 	}
-	return &AgentHarnessManager{authorizer: authorizer, repo: repo, workflowStarter: starter}
+	var controller AgentHarnessExecutionWorkflowController
+	if candidate, ok := starter.(AgentHarnessExecutionWorkflowController); ok {
+		controller = candidate
+	}
+	return &AgentHarnessManager{authorizer: authorizer, repo: repo, workflowStarter: starter, workflowControl: controller, concurrencyLimit: 3}
 }
 
 type CreateAgentHarnessInput struct {
@@ -98,6 +119,10 @@ type CreateAgentHarnessInput struct {
 
 type StartAgentHarnessExecutionInput struct {
 	Message string `json:"message"`
+}
+
+type RetryAgentHarnessExecutionInput struct {
+	IdempotencyKey string `json:"idempotency_key"`
 }
 
 type CreateAgentHarnessSuiteInput struct {
@@ -339,6 +364,9 @@ func (m *AgentHarnessManager) StartAgentHarnessSuiteRun(ctx context.Context, cal
 	if len(tasks) == 0 {
 		return nil, AgentHarnessValidationError{Code: "tasks_required", Message: "no suite tasks matched the request"}
 	}
+	if err := m.ensureAgentHarnessExecutionCapacity(ctx, workspaceID, len(input.HarnessIDs)*len(tasks)); err != nil {
+		return nil, err
+	}
 	harnesses := make([]repository.AgentHarness, 0, len(input.HarnessIDs))
 	for _, harnessID := range input.HarnessIDs {
 		harness, err := m.repo.GetAgentHarnessByID(ctx, harnessID)
@@ -386,11 +414,12 @@ func (m *AgentHarnessManager) StartAgentHarnessSuiteRun(ctx context.Context, cal
 				HarnessSnapshot:          snapshot,
 				ExecutionConfigSnapshot:  defaultJSON(executionConfig),
 				EvaluationConfigSnapshot: evaluationConfig,
+				ConcurrencyLimit:         m.concurrencyLimit,
 			})
 			if err != nil {
 				return nil, err
 			}
-			if err := m.workflowStarter.StartAgentHarnessExecutionWorkflow(ctx, execution.ID, agentHarnessExecutionTimeoutSeconds(execution.ExecutionConfigSnapshot)); err != nil {
+			if err := m.startAgentHarnessExecutionWorkflow(ctx, execution); err != nil {
 				reason := err.Error()
 				failedExecution, transitionErr := m.repo.TransitionAgentHarnessExecutionStatus(ctx, repository.TransitionAgentHarnessExecutionStatusParams{
 					ExecutionID: execution.ID,
@@ -421,6 +450,9 @@ func (m *AgentHarnessManager) StartAgentHarnessExecution(ctx context.Context, ca
 	if harness.WorkspaceID != workspaceID {
 		return repository.AgentHarnessExecution{}, repository.ErrAgentHarnessNotFound
 	}
+	if err := m.ensureAgentHarnessExecutionCapacity(ctx, workspaceID, 1); err != nil {
+		return repository.AgentHarnessExecution{}, err
+	}
 	snapshot, err := marshalAgentHarnessSnapshot(harness, input)
 	if err != nil {
 		return repository.AgentHarnessExecution{}, err
@@ -433,11 +465,12 @@ func (m *AgentHarnessManager) StartAgentHarnessExecution(ctx context.Context, ca
 		HarnessSnapshot:          snapshot,
 		ExecutionConfigSnapshot:  defaultJSON(harness.ExecutionConfig),
 		EvaluationConfigSnapshot: defaultJSON(harness.EvaluationConfig),
+		ConcurrencyLimit:         m.concurrencyLimit,
 	})
 	if err != nil {
 		return repository.AgentHarnessExecution{}, err
 	}
-	if err := m.workflowStarter.StartAgentHarnessExecutionWorkflow(ctx, execution.ID, agentHarnessExecutionTimeoutSeconds(execution.ExecutionConfigSnapshot)); err != nil {
+	if err := m.startAgentHarnessExecutionWorkflow(ctx, execution); err != nil {
 		reason := err.Error()
 		_, _ = m.repo.TransitionAgentHarnessExecutionStatus(ctx, repository.TransitionAgentHarnessExecutionStatusParams{
 			ExecutionID: execution.ID,
@@ -447,6 +480,108 @@ func (m *AgentHarnessManager) StartAgentHarnessExecution(ctx context.Context, ca
 		return repository.AgentHarnessExecution{}, err
 	}
 	return execution, nil
+}
+
+func (m *AgentHarnessManager) CancelAgentHarnessExecution(ctx context.Context, caller Caller, workspaceID uuid.UUID, executionID uuid.UUID) (repository.AgentHarnessExecution, error) {
+	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, workspaceID, ActionCreateRun); err != nil {
+		return repository.AgentHarnessExecution{}, err
+	}
+	execution, err := m.repo.GetAgentHarnessExecutionByID(ctx, executionID)
+	if err != nil {
+		return repository.AgentHarnessExecution{}, err
+	}
+	if execution.WorkspaceID != workspaceID {
+		return repository.AgentHarnessExecution{}, repository.ErrAgentHarnessExecutionNotFound
+	}
+	status, err := repository.ParseAgentHarnessExecutionStatus(execution.Status)
+	if err != nil {
+		return repository.AgentHarnessExecution{}, err
+	}
+	if !status.CanTransitionTo(repository.AgentHarnessExecutionStatusCancelled) {
+		return execution, nil
+	}
+	workflowID := strings.TrimSpace(derefString(execution.TemporalWorkflowID))
+	if workflowID == "" {
+		workflowID = defaultAgentHarnessExecutionWorkflowID(execution.ID)
+	}
+	if m.workflowControl != nil {
+		if err := m.workflowControl.CancelAgentHarnessExecutionWorkflow(ctx, workflowID, strings.TrimSpace(derefString(execution.TemporalRunID))); err != nil {
+			return repository.AgentHarnessExecution{}, err
+		}
+	}
+	reason := "cancelled by user"
+	cancelled, err := m.repo.TransitionAgentHarnessExecutionStatus(ctx, repository.TransitionAgentHarnessExecutionStatusParams{
+		ExecutionID:     execution.ID,
+		ToStatus:        repository.AgentHarnessExecutionStatusCancelled,
+		Reason:          &reason,
+		ChangedByUserID: &caller.UserID,
+	})
+	if err == nil {
+		return cancelled, nil
+	}
+	var invalidTransition repository.InvalidTransitionError
+	if errors.As(err, &invalidTransition) {
+		latest, latestErr := m.repo.GetAgentHarnessExecutionByID(ctx, execution.ID)
+		if latestErr == nil && latest.Status == string(repository.AgentHarnessExecutionStatusCancelled) {
+			return latest, nil
+		}
+	}
+	return repository.AgentHarnessExecution{}, err
+}
+
+func (m *AgentHarnessManager) RetryAgentHarnessExecution(ctx context.Context, caller Caller, workspaceID uuid.UUID, executionID uuid.UUID, input RetryAgentHarnessExecutionInput) (repository.AgentHarnessExecution, error) {
+	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, workspaceID, ActionCreateRun); err != nil {
+		return repository.AgentHarnessExecution{}, err
+	}
+	idempotencyKey := strings.TrimSpace(input.IdempotencyKey)
+	if idempotencyKey == "" {
+		return repository.AgentHarnessExecution{}, AgentHarnessValidationError{Code: "idempotency_key_required", Message: "idempotency_key is required for retry"}
+	}
+	previous, err := m.repo.GetAgentHarnessExecutionByID(ctx, executionID)
+	if err != nil {
+		return repository.AgentHarnessExecution{}, err
+	}
+	if previous.WorkspaceID != workspaceID {
+		return repository.AgentHarnessExecution{}, repository.ErrAgentHarnessExecutionNotFound
+	}
+	if agentHarnessExecutionActive(previous.Status) {
+		return repository.AgentHarnessExecution{}, AgentHarnessValidationError{Code: "execution_not_retryable", Message: "only completed, failed, or cancelled executions can be retried"}
+	}
+	existing, err := m.repo.GetAgentHarnessRetryByIdempotencyKey(ctx, workspaceID, executionID, idempotencyKey)
+	if err == nil {
+		return existing, nil
+	}
+	if !errors.Is(err, repository.ErrAgentHarnessExecutionNotFound) {
+		return repository.AgentHarnessExecution{}, err
+	}
+	if err := m.ensureAgentHarnessExecutionCapacity(ctx, workspaceID, 1); err != nil {
+		return repository.AgentHarnessExecution{}, err
+	}
+	retryExecution, err := m.repo.CreateAgentHarnessExecution(ctx, repository.CreateAgentHarnessExecutionParams{
+		OrganizationID:           previous.OrganizationID,
+		WorkspaceID:              previous.WorkspaceID,
+		AgentHarnessID:           previous.AgentHarnessID,
+		CreatedByUserID:          &caller.UserID,
+		HarnessSnapshot:          previous.HarnessSnapshot,
+		ExecutionConfigSnapshot:  previous.ExecutionConfigSnapshot,
+		EvaluationConfigSnapshot: previous.EvaluationConfigSnapshot,
+		RetryOfExecutionID:       &previous.ID,
+		RetryIdempotencyKey:      &idempotencyKey,
+		ConcurrencyLimit:         m.concurrencyLimit,
+	})
+	if err != nil {
+		return repository.AgentHarnessExecution{}, err
+	}
+	if err := m.startAgentHarnessExecutionWorkflow(ctx, retryExecution); err != nil {
+		reason := err.Error()
+		_, _ = m.repo.TransitionAgentHarnessExecutionStatus(ctx, repository.TransitionAgentHarnessExecutionStatusParams{
+			ExecutionID: retryExecution.ID,
+			ToStatus:    repository.AgentHarnessExecutionStatusFailed,
+			Reason:      &reason,
+		})
+		return repository.AgentHarnessExecution{}, err
+	}
+	return retryExecution, nil
 }
 
 func (m *AgentHarnessManager) GetAgentHarnessExecution(ctx context.Context, caller Caller, workspaceID uuid.UUID, executionID uuid.UUID) (repository.AgentHarnessExecution, error) {
@@ -487,6 +622,51 @@ func (m *AgentHarnessManager) ListAgentHarnessExecutions(ctx context.Context, ca
 		WorkspaceID:    workspaceID,
 		AgentHarnessID: harnessID,
 	})
+}
+
+func (m *AgentHarnessManager) ensureAgentHarnessExecutionCapacity(ctx context.Context, workspaceID uuid.UUID, requested int) error {
+	if requested <= 0 || m.concurrencyLimit <= 0 {
+		return nil
+	}
+	active, err := m.repo.CountActiveAgentHarnessExecutionsByWorkspaceID(ctx, workspaceID)
+	if err != nil {
+		return err
+	}
+	if active+requested > m.concurrencyLimit {
+		return AgentHarnessValidationError{Code: "concurrency_limit_exceeded", Message: "workspace agent harness execution concurrency limit exceeded"}
+	}
+	return nil
+}
+
+func agentHarnessExecutionActive(status string) bool {
+	switch repository.AgentHarnessExecutionStatus(status) {
+	case repository.AgentHarnessExecutionStatusQueued,
+		repository.AgentHarnessExecutionStatusProvisioning,
+		repository.AgentHarnessExecutionStatusRunning,
+		repository.AgentHarnessExecutionStatusScoring:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *AgentHarnessManager) startAgentHarnessExecutionWorkflow(ctx context.Context, execution repository.AgentHarnessExecution) error {
+	ref, err := m.workflowStarter.StartAgentHarnessExecutionWorkflow(ctx, execution.ID, agentHarnessExecutionTimeoutSeconds(execution.ExecutionConfigSnapshot))
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(ref.WorkflowID) == "" {
+		ref.WorkflowID = defaultAgentHarnessExecutionWorkflowID(execution.ID)
+	}
+	_, err = m.repo.SetAgentHarnessExecutionTemporalIDs(ctx, repository.SetAgentHarnessExecutionTemporalIDsParams{
+		ExecutionID:        execution.ID,
+		TemporalWorkflowID: ref.WorkflowID,
+		TemporalRunID:      ref.RunID,
+	})
+	if err != nil && m.workflowControl != nil {
+		_ = m.workflowControl.CancelAgentHarnessExecutionWorkflow(ctx, ref.WorkflowID, ref.RunID)
+	}
+	return err
 }
 
 func validateAgentHarnessInput(input CreateAgentHarnessInput) error {
@@ -578,6 +758,10 @@ func agentHarnessExecutionTimeoutSeconds(raw json.RawMessage) int {
 	return config.TimeoutSeconds
 }
 
+func defaultAgentHarnessExecutionWorkflowID(executionID uuid.UUID) string {
+	return fmt.Sprintf("%s/%s", workflow.AgentHarnessExecutionWorkflowName, executionID)
+}
+
 type agentHarnessResponse struct {
 	ID                     uuid.UUID       `json:"id"`
 	OrganizationID         uuid.UUID       `json:"organization_id"`
@@ -643,6 +827,9 @@ type agentHarnessExecutionResponse struct {
 	RunID                    *uuid.UUID                           `json:"run_id,omitempty"`
 	RunAgentID               *uuid.UUID                           `json:"run_agent_id,omitempty"`
 	EvaluationSpecID         *uuid.UUID                           `json:"evaluation_spec_id,omitempty"`
+	TemporalWorkflowID       *string                              `json:"temporal_workflow_id,omitempty"`
+	TemporalRunID            *string                              `json:"temporal_run_id,omitempty"`
+	RetryOfExecutionID       *uuid.UUID                           `json:"retry_of_execution_id,omitempty"`
 	CreatedByUserID          *uuid.UUID                           `json:"created_by_user_id,omitempty"`
 	Status                   string                               `json:"status"`
 	HarnessSnapshot          json.RawMessage                      `json:"harness_snapshot"`
@@ -891,6 +1078,63 @@ func startAgentHarnessExecutionHandler(logger *slog.Logger, service AgentHarness
 	}
 }
 
+func cancelAgentHarnessExecutionHandler(logger *slog.Logger, service AgentHarnessService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		workspaceID, err := WorkspaceIDFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		executionID, err := uuid.Parse(chi.URLParam(r, "executionID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_execution_id", "executionID must be a UUID")
+			return
+		}
+		execution, err := service.CancelAgentHarnessExecution(r.Context(), caller, workspaceID, executionID)
+		if err != nil {
+			writeAgentHarnessError(w, logger, r, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, mapAgentHarnessExecutionResponse(execution))
+	}
+}
+
+func retryAgentHarnessExecutionHandler(logger *slog.Logger, service AgentHarnessService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		workspaceID, err := WorkspaceIDFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		executionID, err := uuid.Parse(chi.URLParam(r, "executionID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_execution_id", "executionID must be a UUID")
+			return
+		}
+		var input RetryAgentHarnessExecutionInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_json", "request body must be JSON")
+			return
+		}
+		execution, err := service.RetryAgentHarnessExecution(r.Context(), caller, workspaceID, executionID, input)
+		if err != nil {
+			writeAgentHarnessError(w, logger, r, err)
+			return
+		}
+		writeJSON(w, http.StatusCreated, mapAgentHarnessExecutionResponse(execution))
+	}
+}
+
 func listAgentHarnessExecutionsHandler(logger *slog.Logger, service AgentHarnessService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		caller, err := CallerFromContext(r.Context())
@@ -1012,6 +1256,9 @@ func mapAgentHarnessExecutionResponse(e repository.AgentHarnessExecution) agentH
 		RunID:                    e.RunID,
 		RunAgentID:               e.RunAgentID,
 		EvaluationSpecID:         e.EvaluationSpecID,
+		TemporalWorkflowID:       e.TemporalWorkflowID,
+		TemporalRunID:            e.TemporalRunID,
+		RetryOfExecutionID:       e.RetryOfExecutionID,
 		CreatedByUserID:          e.CreatedByUserID,
 		Status:                   e.Status,
 		HarnessSnapshot:          harnessSnapshot,
@@ -1265,6 +1512,8 @@ func writeAgentHarnessError(w http.ResponseWriter, logger *slog.Logger, r *http.
 		writeError(w, http.StatusNotFound, "not_found", "agent harness suite not found")
 	case errors.Is(err, repository.ErrAgentHarnessExecutionNotFound):
 		writeError(w, http.StatusNotFound, "not_found", "agent harness execution not found")
+	case errors.Is(err, repository.ErrAgentHarnessConcurrencyLimitExceeded):
+		writeError(w, http.StatusTooManyRequests, "concurrency_limit_exceeded", "workspace agent harness execution concurrency limit exceeded")
 	default:
 		if errors.Is(err, ErrUnauthenticated) || errors.Is(err, ErrCallerMissing) || errors.Is(err, ErrForbidden) {
 			writeAuthzError(w, err)
@@ -1310,6 +1559,14 @@ func (noopAgentHarnessService) StartAgentHarnessSuiteRun(context.Context, Caller
 }
 
 func (noopAgentHarnessService) StartAgentHarnessExecution(context.Context, Caller, uuid.UUID, uuid.UUID, StartAgentHarnessExecutionInput) (repository.AgentHarnessExecution, error) {
+	return repository.AgentHarnessExecution{}, errors.New("agent harness service is not configured")
+}
+
+func (noopAgentHarnessService) CancelAgentHarnessExecution(context.Context, Caller, uuid.UUID, uuid.UUID) (repository.AgentHarnessExecution, error) {
+	return repository.AgentHarnessExecution{}, errors.New("agent harness service is not configured")
+}
+
+func (noopAgentHarnessService) RetryAgentHarnessExecution(context.Context, Caller, uuid.UUID, uuid.UUID, RetryAgentHarnessExecutionInput) (repository.AgentHarnessExecution, error) {
 	return repository.AgentHarnessExecution{}, errors.New("agent harness service is not configured")
 }
 

--- a/backend/internal/api/agent_harnesses_test.go
+++ b/backend/internal/api/agent_harnesses_test.go
@@ -787,6 +787,87 @@ func TestAgentHarnessExecutionManagerStartRequiresRunPermission(t *testing.T) {
 	}
 }
 
+func TestAgentHarnessExecutionManagerStartEnforcesConcurrencyLimit(t *testing.T) {
+	workspaceID := uuid.New()
+	harness := testAgentHarnessRecord(workspaceID, "Codex execution harness")
+	repo := &fakeAgentHarnessRepo{organizationID: harness.OrganizationID, harness: harness, activeCount: 3}
+	manager := NewAgentHarnessManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	_, err := manager.StartAgentHarnessExecution(context.Background(), testAgentHarnessCaller(workspaceID), workspaceID, harness.ID, StartAgentHarnessExecutionInput{})
+	var validationErr AgentHarnessValidationError
+	if !errors.As(err, &validationErr) || validationErr.Code != "concurrency_limit_exceeded" {
+		t.Fatalf("error = %T %v, want concurrency validation", err, err)
+	}
+}
+
+func TestAgentHarnessExecutionManagerCancelIsIdempotentAndAuthorized(t *testing.T) {
+	workspaceID := uuid.New()
+	execution := testAgentHarnessExecutionRecord(workspaceID, uuid.New())
+	execution.Status = string(repository.AgentHarnessExecutionStatusRunning)
+	repo := &fakeAgentHarnessRepo{organizationID: execution.OrganizationID, execution: execution}
+	manager := NewAgentHarnessManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	cancelled, err := manager.CancelAgentHarnessExecution(context.Background(), testAgentHarnessCaller(workspaceID), workspaceID, execution.ID)
+	if err != nil {
+		t.Fatalf("CancelAgentHarnessExecution error: %v", err)
+	}
+	if cancelled.Status != string(repository.AgentHarnessExecutionStatusCancelled) {
+		t.Fatalf("status = %q, want cancelled", cancelled.Status)
+	}
+	if repo.transitionedStatus != repository.AgentHarnessExecutionStatusCancelled {
+		t.Fatalf("transitioned status = %q, want cancelled", repo.transitionedStatus)
+	}
+
+	execution.Status = string(repository.AgentHarnessExecutionStatusCompleted)
+	repo.transitionedStatus = ""
+	completedRepo := &fakeAgentHarnessRepo{organizationID: execution.OrganizationID, execution: execution}
+	manager = NewAgentHarnessManager(NewCallerWorkspaceAuthorizer(), completedRepo)
+	got, err := manager.CancelAgentHarnessExecution(context.Background(), testAgentHarnessCaller(workspaceID), workspaceID, execution.ID)
+	if err != nil {
+		t.Fatalf("CancelAgentHarnessExecution terminal error: %v", err)
+	}
+	if got.Status != string(repository.AgentHarnessExecutionStatusCompleted) || completedRepo.transitionedStatus != "" {
+		t.Fatalf("terminal cancel mutated execution: status=%q transition=%q", got.Status, completedRepo.transitionedStatus)
+	}
+}
+
+func TestAgentHarnessExecutionManagerRetryIsIdempotent(t *testing.T) {
+	workspaceID := uuid.New()
+	previous := testAgentHarnessExecutionRecord(workspaceID, uuid.New())
+	previous.Status = string(repository.AgentHarnessExecutionStatusFailed)
+	retry := testAgentHarnessExecutionRecord(workspaceID, previous.AgentHarnessID)
+	retry.RetryOfExecutionID = &previous.ID
+	retryKey := "retry-1"
+	retry.RetryIdempotencyKey = &retryKey
+	repo := &fakeAgentHarnessRepo{organizationID: previous.OrganizationID, execution: previous, retryExecution: retry}
+	manager := NewAgentHarnessManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	got, err := manager.RetryAgentHarnessExecution(context.Background(), testAgentHarnessCaller(workspaceID), workspaceID, previous.ID, RetryAgentHarnessExecutionInput{IdempotencyKey: retryKey})
+	if err != nil {
+		t.Fatalf("RetryAgentHarnessExecution error: %v", err)
+	}
+	if got.ID != retry.ID {
+		t.Fatalf("retry id = %s, want existing retry %s", got.ID, retry.ID)
+	}
+	if len(repo.createdExecutions) != 0 {
+		t.Fatalf("created executions = %d, want idempotent existing retry", len(repo.createdExecutions))
+	}
+}
+
+func TestAgentHarnessExecutionManagerRetryRejectsActiveExecution(t *testing.T) {
+	workspaceID := uuid.New()
+	previous := testAgentHarnessExecutionRecord(workspaceID, uuid.New())
+	previous.Status = string(repository.AgentHarnessExecutionStatusRunning)
+	repo := &fakeAgentHarnessRepo{organizationID: previous.OrganizationID, execution: previous}
+	manager := NewAgentHarnessManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	_, err := manager.RetryAgentHarnessExecution(context.Background(), testAgentHarnessCaller(workspaceID), workspaceID, previous.ID, RetryAgentHarnessExecutionInput{IdempotencyKey: "retry-1"})
+	var validationErr AgentHarnessValidationError
+	if !errors.As(err, &validationErr) || validationErr.Code != "execution_not_retryable" {
+		t.Fatalf("error = %T %v, want execution_not_retryable", err, err)
+	}
+}
+
 func TestAgentHarnessExecutionManagerGetReturnsNotFoundForWorkspaceMismatch(t *testing.T) {
 	workspaceID := uuid.New()
 	execution := testAgentHarnessExecutionRecord(uuid.New(), uuid.New())
@@ -834,6 +915,8 @@ func TestAgentHarnessExecutionRoutes(t *testing.T) {
 	router.Post("/v1/workspaces/{workspaceID}/agent-harnesses/{harnessID}/executions", startAgentHarnessExecutionHandler(slog.Default(), service))
 	router.Get("/v1/workspaces/{workspaceID}/agent-harness-executions", listAgentHarnessExecutionsHandler(slog.Default(), service))
 	router.Get("/v1/workspaces/{workspaceID}/agent-harness-executions/{executionID}", getAgentHarnessExecutionHandler(slog.Default(), service))
+	router.Post("/v1/workspaces/{workspaceID}/agent-harness-executions/{executionID}/cancel", cancelAgentHarnessExecutionHandler(slog.Default(), service))
+	router.Post("/v1/workspaces/{workspaceID}/agent-harness-executions/{executionID}/retry", retryAgentHarnessExecutionHandler(slog.Default(), service))
 
 	startReq := httptest.NewRequest(http.MethodPost, "/v1/workspaces/"+workspaceID.String()+"/agent-harnesses/"+harness.ID.String()+"/executions", bytes.NewBufferString(`{"message":"Patch the failing test."}`))
 	startRec := httptest.NewRecorder()
@@ -886,6 +969,34 @@ func TestAgentHarnessExecutionRoutes(t *testing.T) {
 	}
 	if gotExecution.EvaluationSpecID == nil || *gotExecution.EvaluationSpecID != evaluationSpecID {
 		t.Fatalf("evaluation_spec_id = %#v, want %s", gotExecution.EvaluationSpecID, evaluationSpecID)
+	}
+
+	cancelReq := httptest.NewRequest(http.MethodPost, "/v1/workspaces/"+workspaceID.String()+"/agent-harness-executions/"+execution.ID.String()+"/cancel", nil)
+	cancelRec := httptest.NewRecorder()
+	router.ServeHTTP(cancelRec, cancelReq)
+	if cancelRec.Code != http.StatusOK {
+		t.Fatalf("cancel status = %d, body %s", cancelRec.Code, cancelRec.Body.String())
+	}
+	var cancelled agentHarnessExecutionResponse
+	if err := json.Unmarshal(cancelRec.Body.Bytes(), &cancelled); err != nil {
+		t.Fatalf("decode cancelled: %v", err)
+	}
+	if cancelled.Status != string(repository.AgentHarnessExecutionStatusCancelled) {
+		t.Fatalf("cancelled status = %q, want cancelled", cancelled.Status)
+	}
+
+	retryReq := httptest.NewRequest(http.MethodPost, "/v1/workspaces/"+workspaceID.String()+"/agent-harness-executions/"+execution.ID.String()+"/retry", bytes.NewBufferString(`{"idempotency_key":"retry-1"}`))
+	retryRec := httptest.NewRecorder()
+	router.ServeHTTP(retryRec, retryReq)
+	if retryRec.Code != http.StatusCreated {
+		t.Fatalf("retry status = %d, body %s", retryRec.Code, retryRec.Body.String())
+	}
+	var retried agentHarnessExecutionResponse
+	if err := json.Unmarshal(retryRec.Body.Bytes(), &retried); err != nil {
+		t.Fatalf("decode retried: %v", err)
+	}
+	if retried.RetryOfExecutionID == nil || *retried.RetryOfExecutionID != execution.ID {
+		t.Fatalf("retry_of_execution_id = %#v, want %s", retried.RetryOfExecutionID, execution.ID)
 	}
 }
 
@@ -1121,7 +1232,9 @@ type fakeAgentHarnessRepo struct {
 	suites                  []repository.AgentHarnessSuite
 	suiteTasks              []repository.AgentHarnessSuiteTask
 	execution               repository.AgentHarnessExecution
+	retryExecution          repository.AgentHarnessExecution
 	executions              []repository.AgentHarnessExecution
+	activeCount             int
 	getByIDCalls            int
 	githubRepo              repository.GitHubInstallationRepository
 	githubRepoErr           error
@@ -1237,6 +1350,8 @@ func (f *fakeAgentHarnessRepo) CreateAgentHarnessExecution(_ context.Context, p 
 		RunID:                    p.RunID,
 		RunAgentID:               p.RunAgentID,
 		EvaluationSpecID:         p.EvaluationSpecID,
+		RetryOfExecutionID:       p.RetryOfExecutionID,
+		RetryIdempotencyKey:      p.RetryIdempotencyKey,
 		CreatedByUserID:          p.CreatedByUserID,
 		Status:                   "queued",
 		HarnessSnapshot:          p.HarnessSnapshot,
@@ -1245,6 +1360,12 @@ func (f *fakeAgentHarnessRepo) CreateAgentHarnessExecution(_ context.Context, p 
 		CreatedAt:                now,
 		UpdatedAt:                now,
 	}, nil
+}
+
+func (f *fakeAgentHarnessRepo) SetAgentHarnessExecutionTemporalIDs(_ context.Context, p repository.SetAgentHarnessExecutionTemporalIDsParams) (repository.AgentHarnessExecution, error) {
+	f.execution.TemporalWorkflowID = &p.TemporalWorkflowID
+	f.execution.TemporalRunID = &p.TemporalRunID
+	return f.execution, nil
 }
 
 func (f *fakeAgentHarnessRepo) TransitionAgentHarnessExecutionStatus(_ context.Context, p repository.TransitionAgentHarnessExecutionStatusParams) (repository.AgentHarnessExecution, error) {
@@ -1260,6 +1381,17 @@ func (f *fakeAgentHarnessRepo) GetAgentHarnessExecutionByID(_ context.Context, i
 		return f.execution, nil
 	}
 	return repository.AgentHarnessExecution{}, repository.ErrAgentHarnessExecutionNotFound
+}
+
+func (f *fakeAgentHarnessRepo) GetAgentHarnessRetryByIdempotencyKey(context.Context, uuid.UUID, uuid.UUID, string) (repository.AgentHarnessExecution, error) {
+	if f.retryExecution.ID != uuid.Nil {
+		return f.retryExecution, nil
+	}
+	return repository.AgentHarnessExecution{}, repository.ErrAgentHarnessExecutionNotFound
+}
+
+func (f *fakeAgentHarnessRepo) CountActiveAgentHarnessExecutionsByWorkspaceID(context.Context, uuid.UUID) (int, error) {
+	return f.activeCount, nil
 }
 
 func (f *fakeAgentHarnessRepo) ListAgentHarnessExecutions(context.Context, repository.ListAgentHarnessExecutionsParams) ([]repository.AgentHarnessExecution, error) {
@@ -1351,6 +1483,27 @@ func (f *fakeAgentHarnessService) StartAgentHarnessExecution(_ context.Context, 
 	return testAgentHarnessExecutionRecord(workspaceID, harnessID), nil
 }
 
+func (f *fakeAgentHarnessService) CancelAgentHarnessExecution(_ context.Context, _ Caller, _ uuid.UUID, executionID uuid.UUID) (repository.AgentHarnessExecution, error) {
+	for _, execution := range f.executions {
+		if execution.ID == executionID {
+			execution.Status = string(repository.AgentHarnessExecutionStatusCancelled)
+			return execution, nil
+		}
+	}
+	return repository.AgentHarnessExecution{}, repository.ErrAgentHarnessExecutionNotFound
+}
+
+func (f *fakeAgentHarnessService) RetryAgentHarnessExecution(_ context.Context, _ Caller, workspaceID uuid.UUID, executionID uuid.UUID, _ RetryAgentHarnessExecutionInput) (repository.AgentHarnessExecution, error) {
+	for _, execution := range f.executions {
+		if execution.ID == executionID {
+			retry := testAgentHarnessExecutionRecord(workspaceID, execution.AgentHarnessID)
+			retry.RetryOfExecutionID = &executionID
+			return retry, nil
+		}
+	}
+	return repository.AgentHarnessExecution{}, repository.ErrAgentHarnessExecutionNotFound
+}
+
 func (f *fakeAgentHarnessService) GetAgentHarnessExecution(_ context.Context, _ Caller, _ uuid.UUID, id uuid.UUID) (repository.AgentHarnessExecution, error) {
 	for _, execution := range f.executions {
 		if execution.ID == id {
@@ -1375,8 +1528,11 @@ type fakeAgentHarnessWorkflowStarter struct {
 	timeoutSeconds int
 }
 
-func (f *fakeAgentHarnessWorkflowStarter) StartAgentHarnessExecutionWorkflow(_ context.Context, _ uuid.UUID, timeoutSeconds int) error {
+func (f *fakeAgentHarnessWorkflowStarter) StartAgentHarnessExecutionWorkflow(_ context.Context, executionID uuid.UUID, timeoutSeconds int) (AgentHarnessExecutionWorkflowRef, error) {
 	f.startedCount++
 	f.timeoutSeconds = timeoutSeconds
-	return f.err
+	if f.err != nil {
+		return AgentHarnessExecutionWorkflowRef{}, f.err
+	}
+	return AgentHarnessExecutionWorkflowRef{WorkflowID: defaultAgentHarnessExecutionWorkflowID(executionID), RunID: "run-id"}, nil
 }

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -148,6 +148,10 @@ func registerProtectedRoutes(
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Get("/workspaces/{workspaceID}/agent-harness-executions/{executionID}", getAgentHarnessExecutionHandler(logger, agentHarnessService))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Post("/workspaces/{workspaceID}/agent-harness-executions/{executionID}/cancel", cancelAgentHarnessExecutionHandler(logger, agentHarnessService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Post("/workspaces/{workspaceID}/agent-harness-executions/{executionID}/retry", retryAgentHarnessExecutionHandler(logger, agentHarnessService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Post("/workspaces/{workspaceID}/github/installations/start", startGitHubInstallationHandler(logger, githubIntegrationService))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Post("/workspaces/{workspaceID}/github/installations/complete", completeGitHubInstallationHandler(logger, githubIntegrationService))

--- a/backend/internal/api/temporal.go
+++ b/backend/internal/api/temporal.go
@@ -13,6 +13,7 @@ import (
 type TemporalClient interface {
 	ExecuteWorkflow(ctx context.Context, options temporalsdk.StartWorkflowOptions, workflow interface{}, args ...interface{}) (temporalsdk.WorkflowRun, error)
 	SignalWorkflow(ctx context.Context, workflowID string, runID string, signalName string, arg interface{}) error
+	CancelWorkflow(ctx context.Context, workflowID string, runID string) error
 }
 
 type TemporalRunWorkflowStarter struct {
@@ -61,16 +62,23 @@ func NewTemporalAgentHarnessExecutionWorkflowStarter(client TemporalClient) Temp
 	return TemporalAgentHarnessExecutionWorkflowStarter{client: client}
 }
 
-func (s TemporalAgentHarnessExecutionWorkflowStarter) StartAgentHarnessExecutionWorkflow(ctx context.Context, executionID uuid.UUID, timeoutSeconds int) error {
+func (s TemporalAgentHarnessExecutionWorkflowStarter) StartAgentHarnessExecutionWorkflow(ctx context.Context, executionID uuid.UUID, timeoutSeconds int) (AgentHarnessExecutionWorkflowRef, error) {
 	workflowID := fmt.Sprintf("%s/%s", workflow.AgentHarnessExecutionWorkflowName, executionID)
-	_, err := s.client.ExecuteWorkflow(ctx, temporalsdk.StartWorkflowOptions{
+	run, err := s.client.ExecuteWorkflow(ctx, temporalsdk.StartWorkflowOptions{
 		ID:        workflowID,
 		TaskQueue: workflow.WorkflowTaskQueue,
 	}, workflow.AgentHarnessExecutionWorkflowName, workflow.AgentHarnessExecutionWorkflowInput{
 		ExecutionID:    executionID,
 		TimeoutSeconds: timeoutSeconds,
 	})
-	return err
+	if err != nil {
+		return AgentHarnessExecutionWorkflowRef{}, err
+	}
+	return AgentHarnessExecutionWorkflowRef{WorkflowID: run.GetID(), RunID: run.GetRunID()}, nil
+}
+
+func (s TemporalAgentHarnessExecutionWorkflowStarter) CancelAgentHarnessExecutionWorkflow(ctx context.Context, workflowID string, runID string) error {
+	return s.client.CancelWorkflow(ctx, workflowID, runID)
 }
 
 type TemporalPlaygroundWorkflowStarter struct {

--- a/backend/internal/api/temporal_test.go
+++ b/backend/internal/api/temporal_test.go
@@ -41,7 +41,7 @@ func TestTemporalAgentHarnessExecutionWorkflowStarter(t *testing.T) {
 	executionID := uuid.New()
 	client := &fakeTemporalClient{}
 
-	err := NewTemporalAgentHarnessExecutionWorkflowStarter(client).StartAgentHarnessExecutionWorkflow(context.Background(), executionID, 600)
+	ref, err := NewTemporalAgentHarnessExecutionWorkflowStarter(client).StartAgentHarnessExecutionWorkflow(context.Background(), executionID, 600)
 	if err != nil {
 		t.Fatalf("StartAgentHarnessExecutionWorkflow returned error: %v", err)
 	}
@@ -51,6 +51,9 @@ func TestTemporalAgentHarnessExecutionWorkflowStarter(t *testing.T) {
 	}
 	if client.options.ID != workflow.AgentHarnessExecutionWorkflowName+"/"+executionID.String() {
 		t.Fatalf("workflow id = %q, want %q", client.options.ID, workflow.AgentHarnessExecutionWorkflowName+"/"+executionID.String())
+	}
+	if ref.WorkflowID != client.options.ID || ref.RunID != "run-id" {
+		t.Fatalf("workflow ref = %#v", ref)
 	}
 	input, ok := client.args[0].(workflow.AgentHarnessExecutionWorkflowInput)
 	if !ok {
@@ -75,9 +78,34 @@ func (f *fakeTemporalClient) ExecuteWorkflow(_ context.Context, options temporal
 	name, _ := workflowFn.(string)
 	f.workflowName = name
 	f.args = append([]interface{}(nil), args...)
-	return nil, nil
+	return fakeWorkflowRun{id: options.ID, runID: "run-id"}, nil
 }
 
 func (f *fakeTemporalClient) SignalWorkflow(context.Context, string, string, string, interface{}) error {
+	return nil
+}
+
+func (f *fakeTemporalClient) CancelWorkflow(context.Context, string, string) error {
+	return nil
+}
+
+type fakeWorkflowRun struct {
+	id    string
+	runID string
+}
+
+func (f fakeWorkflowRun) GetID() string {
+	return f.id
+}
+
+func (f fakeWorkflowRun) GetRunID() string {
+	return f.runID
+}
+
+func (f fakeWorkflowRun) Get(context.Context, interface{}) error {
+	return nil
+}
+
+func (f fakeWorkflowRun) GetWithOptions(context.Context, interface{}, temporalsdk.WorkflowRunGetOptions) error {
 	return nil
 }

--- a/backend/internal/repository/agent_harness_executions.go
+++ b/backend/internal/repository/agent_harness_executions.go
@@ -5,13 +5,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 )
 
-var ErrAgentHarnessExecutionNotFound = errors.New("agent harness execution not found")
+var (
+	ErrAgentHarnessExecutionNotFound        = errors.New("agent harness execution not found")
+	ErrAgentHarnessConcurrencyLimitExceeded = errors.New("agent harness concurrency limit exceeded")
+)
 
 type AgentHarnessExecution struct {
 	ID                       uuid.UUID
@@ -21,6 +25,11 @@ type AgentHarnessExecution struct {
 	RunID                    *uuid.UUID
 	RunAgentID               *uuid.UUID
 	EvaluationSpecID         *uuid.UUID
+	TemporalWorkflowID       *string
+	TemporalRunID            *string
+	RetryOfExecutionID       *uuid.UUID
+	RetryIdempotencyKey      *string
+	ConcurrencyLimit         int
 	CreatedByUserID          *uuid.UUID
 	Status                   string
 	HarnessSnapshot          json.RawMessage
@@ -122,10 +131,13 @@ type CreateAgentHarnessExecutionParams struct {
 	RunID                    *uuid.UUID
 	RunAgentID               *uuid.UUID
 	EvaluationSpecID         *uuid.UUID
+	RetryOfExecutionID       *uuid.UUID
+	RetryIdempotencyKey      *string
 	CreatedByUserID          *uuid.UUID
 	HarnessSnapshot          json.RawMessage
 	ExecutionConfigSnapshot  json.RawMessage
 	EvaluationConfigSnapshot json.RawMessage
+	ConcurrencyLimit         int
 }
 
 type TransitionAgentHarnessExecutionStatusParams struct {
@@ -154,12 +166,35 @@ type SetAgentHarnessExecutionEvaluationSpecParams struct {
 	EvaluationSpecID uuid.UUID
 }
 
+type SetAgentHarnessExecutionTemporalIDsParams struct {
+	ExecutionID        uuid.UUID
+	TemporalWorkflowID string
+	TemporalRunID      string
+}
+
 func (r *Repository) CreateAgentHarnessExecution(ctx context.Context, p CreateAgentHarnessExecutionParams) (AgentHarnessExecution, error) {
 	tx, err := r.db.Begin(ctx)
 	if err != nil {
 		return AgentHarnessExecution{}, fmt.Errorf("begin agent harness execution create transaction: %w", err)
 	}
 	defer rollback(ctx, tx)
+
+	if p.ConcurrencyLimit > 0 {
+		if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1::text, 611))`, p.WorkspaceID.String()); err != nil {
+			return AgentHarnessExecution{}, fmt.Errorf("lock agent harness workspace capacity: %w", err)
+		}
+		var active int
+		if err := tx.QueryRow(ctx, `
+SELECT count(*)::integer
+FROM agent_harness_executions
+WHERE workspace_id = $1
+  AND status IN ('queued', 'provisioning', 'running', 'scoring')`, p.WorkspaceID).Scan(&active); err != nil {
+			return AgentHarnessExecution{}, fmt.Errorf("count active agent harness executions: %w", err)
+		}
+		if active >= p.ConcurrencyLimit {
+			return AgentHarnessExecution{}, ErrAgentHarnessConcurrencyLimitExceeded
+		}
+	}
 
 	runID := p.RunID
 	runAgentID := p.RunAgentID
@@ -201,18 +236,21 @@ FROM canonical_run_agent`, p.OrganizationID, p.WorkspaceID, p.CreatedByUserID)
 INSERT INTO agent_harness_executions (
     organization_id, workspace_id, agent_harness_id, created_by_user_id,
     run_id, run_agent_id, evaluation_spec_id,
+    temporal_workflow_id, temporal_run_id, retry_of_execution_id, retry_idempotency_key,
     harness_snapshot, execution_config_snapshot, evaluation_config_snapshot
 ) VALUES (
     $1, $2, $3, $4,
     $5, $6, $7,
-    $8, $9, $10
+    NULL, NULL, $8, $9,
+    $10, $11, $12
 )
 RETURNING id, organization_id, workspace_id, agent_harness_id, created_by_user_id,
-    run_id, run_agent_id, evaluation_spec_id,
+    run_id, run_agent_id, evaluation_spec_id, temporal_workflow_id, temporal_run_id, retry_of_execution_id, retry_idempotency_key,
     status, harness_snapshot, execution_config_snapshot, evaluation_config_snapshot,
     error_message, started_at, completed_at, cancelled_at, created_at, updated_at`,
 		p.OrganizationID, p.WorkspaceID, p.AgentHarnessID, p.CreatedByUserID,
 		runID, runAgentID, p.EvaluationSpecID,
+		p.RetryOfExecutionID, p.RetryIdempotencyKey,
 		defaultRepositoryJSON(p.HarnessSnapshot), defaultRepositoryJSON(p.ExecutionConfigSnapshot), defaultRepositoryJSON(p.EvaluationConfigSnapshot),
 	)
 	execution, err := scanAgentHarnessExecution(row)
@@ -238,7 +276,7 @@ func (r *Repository) TransitionAgentHarnessExecutionStatus(ctx context.Context, 
 
 	current, err := scanAgentHarnessExecution(tx.QueryRow(ctx, `
 SELECT id, organization_id, workspace_id, agent_harness_id, created_by_user_id,
-    run_id, run_agent_id, evaluation_spec_id,
+    run_id, run_agent_id, evaluation_spec_id, temporal_workflow_id, temporal_run_id, retry_of_execution_id, retry_idempotency_key,
     status, harness_snapshot, execution_config_snapshot, evaluation_config_snapshot,
     error_message, started_at, completed_at, cancelled_at, created_at, updated_at
 FROM agent_harness_executions
@@ -279,7 +317,7 @@ SET status = $2,
     END
 WHERE id = $1 AND status = $4
 RETURNING id, organization_id, workspace_id, agent_harness_id, created_by_user_id,
-    run_id, run_agent_id, evaluation_spec_id,
+    run_id, run_agent_id, evaluation_spec_id, temporal_workflow_id, temporal_run_id, retry_of_execution_id, retry_idempotency_key,
     status, harness_snapshot, execution_config_snapshot, evaluation_config_snapshot,
     error_message, started_at, completed_at, cancelled_at, created_at, updated_at`,
 		p.ExecutionID, string(p.ToStatus), p.Reason, string(currentStatus)))
@@ -312,7 +350,7 @@ INSERT INTO agent_harness_execution_status_history (
 func (r *Repository) GetAgentHarnessExecutionByID(ctx context.Context, id uuid.UUID) (AgentHarnessExecution, error) {
 	row := r.db.QueryRow(ctx, `
 SELECT id, organization_id, workspace_id, agent_harness_id, created_by_user_id,
-    run_id, run_agent_id, evaluation_spec_id,
+    run_id, run_agent_id, evaluation_spec_id, temporal_workflow_id, temporal_run_id, retry_of_execution_id, retry_idempotency_key,
     status, harness_snapshot, execution_config_snapshot, evaluation_config_snapshot,
     error_message, started_at, completed_at, cancelled_at, created_at, updated_at
 FROM agent_harness_executions
@@ -327,7 +365,7 @@ SET evaluation_spec_id = $2,
     updated_at = now()
 WHERE id = $1
 RETURNING id, organization_id, workspace_id, agent_harness_id, created_by_user_id,
-    run_id, run_agent_id, evaluation_spec_id,
+    run_id, run_agent_id, evaluation_spec_id, temporal_workflow_id, temporal_run_id, retry_of_execution_id, retry_idempotency_key,
     status, harness_snapshot, execution_config_snapshot, evaluation_config_snapshot,
     error_message, started_at, completed_at, cancelled_at, created_at, updated_at`,
 		p.ExecutionID, p.EvaluationSpecID,
@@ -335,10 +373,56 @@ RETURNING id, organization_id, workspace_id, agent_harness_id, created_by_user_i
 	return scanAgentHarnessExecution(row)
 }
 
+func (r *Repository) SetAgentHarnessExecutionTemporalIDs(ctx context.Context, p SetAgentHarnessExecutionTemporalIDsParams) (AgentHarnessExecution, error) {
+	if strings.TrimSpace(p.TemporalWorkflowID) == "" {
+		return AgentHarnessExecution{}, fmt.Errorf("temporal workflow id is required")
+	}
+	temporalRunID := optionalString(strings.TrimSpace(p.TemporalRunID))
+	row := r.db.QueryRow(ctx, `
+UPDATE agent_harness_executions
+SET temporal_workflow_id = $2,
+    temporal_run_id = $3,
+    updated_at = now()
+WHERE id = $1
+RETURNING id, organization_id, workspace_id, agent_harness_id, created_by_user_id,
+    run_id, run_agent_id, evaluation_spec_id, temporal_workflow_id, temporal_run_id, retry_of_execution_id, retry_idempotency_key,
+    status, harness_snapshot, execution_config_snapshot, evaluation_config_snapshot,
+    error_message, started_at, completed_at, cancelled_at, created_at, updated_at`,
+		p.ExecutionID, strings.TrimSpace(p.TemporalWorkflowID), temporalRunID,
+	)
+	return scanAgentHarnessExecution(row)
+}
+
+func (r *Repository) GetAgentHarnessRetryByIdempotencyKey(ctx context.Context, workspaceID uuid.UUID, retryOfExecutionID uuid.UUID, idempotencyKey string) (AgentHarnessExecution, error) {
+	row := r.db.QueryRow(ctx, `
+SELECT id, organization_id, workspace_id, agent_harness_id, created_by_user_id,
+    run_id, run_agent_id, evaluation_spec_id, temporal_workflow_id, temporal_run_id, retry_of_execution_id, retry_idempotency_key,
+    status, harness_snapshot, execution_config_snapshot, evaluation_config_snapshot,
+    error_message, started_at, completed_at, cancelled_at, created_at, updated_at
+FROM agent_harness_executions
+WHERE workspace_id = $1
+  AND retry_of_execution_id = $2
+  AND retry_idempotency_key = $3
+LIMIT 1`, workspaceID, retryOfExecutionID, strings.TrimSpace(idempotencyKey))
+	return scanAgentHarnessExecution(row)
+}
+
+func (r *Repository) CountActiveAgentHarnessExecutionsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (int, error) {
+	var count int
+	if err := r.db.QueryRow(ctx, `
+SELECT count(*)::integer
+FROM agent_harness_executions
+WHERE workspace_id = $1
+  AND status IN ('queued', 'provisioning', 'running', 'scoring')`, workspaceID).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
 func (r *Repository) ListAgentHarnessExecutions(ctx context.Context, p ListAgentHarnessExecutionsParams) ([]AgentHarnessExecution, error) {
 	rows, err := r.db.Query(ctx, `
 SELECT id, organization_id, workspace_id, agent_harness_id, created_by_user_id,
-    run_id, run_agent_id, evaluation_spec_id,
+    run_id, run_agent_id, evaluation_spec_id, temporal_workflow_id, temporal_run_id, retry_of_execution_id, retry_idempotency_key,
     status, harness_snapshot, execution_config_snapshot, evaluation_config_snapshot,
     error_message, started_at, completed_at, cancelled_at, created_at, updated_at
 FROM agent_harness_executions
@@ -450,6 +534,10 @@ func scanAgentHarnessExecution(scanner agentHarnessExecutionScanner) (AgentHarne
 		&e.RunID,
 		&e.RunAgentID,
 		&e.EvaluationSpecID,
+		&e.TemporalWorkflowID,
+		&e.TemporalRunID,
+		&e.RetryOfExecutionID,
+		&e.RetryIdempotencyKey,
 		&e.Status,
 		&e.HarnessSnapshot,
 		&e.ExecutionConfigSnapshot,

--- a/backend/internal/workflow/agent_harness_execution_workflow.go
+++ b/backend/internal/workflow/agent_harness_execution_workflow.go
@@ -125,6 +125,7 @@ type agentHarnessSnapshot struct {
 
 func AgentHarnessExecutionWorkflow(ctx sdkworkflow.Context, input AgentHarnessExecutionWorkflowInput) error {
 	ctx = sdkworkflow.WithActivityOptions(ctx, defaultActivityOptions)
+	defer markAgentHarnessExecutionCancelledOnWorkflowCancel(ctx, input.ExecutionID)
 
 	if err := transitionAgentHarnessExecutionStatus(ctx, input.ExecutionID, repository.AgentHarnessExecutionStatusProvisioning, nil); err != nil {
 		return err
@@ -139,6 +140,16 @@ func AgentHarnessExecutionWorkflow(ctx sdkworkflow.Context, input AgentHarnessEx
 		return markAgentHarnessExecutionFailed(ctx, input.ExecutionID, err)
 	}
 	return nil
+}
+
+func markAgentHarnessExecutionCancelledOnWorkflowCancel(ctx sdkworkflow.Context, executionID uuid.UUID) {
+	if ctx.Err() == nil {
+		return
+	}
+	disconnectedCtx, _ := sdkworkflow.NewDisconnectedContext(ctx)
+	disconnectedCtx = sdkworkflow.WithActivityOptions(disconnectedCtx, defaultActivityOptions)
+	reason := "workflow cancelled"
+	_ = transitionAgentHarnessExecutionStatus(disconnectedCtx, executionID, repository.AgentHarnessExecutionStatusCancelled, &reason)
 }
 
 func transitionAgentHarnessExecutionStatus(ctx sdkworkflow.Context, executionID uuid.UUID, status repository.AgentHarnessExecutionStatus, reason *string) error {

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -46,6 +46,8 @@ tags:
     description: Agent build and version lifecycle
   - name: AgentDeployments
     description: Agent deployment management
+  - name: AgentHarnesses
+    description: Long-running coding harness configuration and execution controls
   - name: HostedRuns
     description: External hosted agent event ingestion
   - name: Playgrounds
@@ -82,6 +84,70 @@ tags:
     description: Routing and spend policy configuration
 
 paths:
+  /v1/workspaces/{workspaceID}/agent-harness-executions/{executionID}/cancel:
+    post:
+      operationId: cancelAgentHarnessExecution
+      tags: [AgentHarnesses]
+      summary: Cancel an Agent Harness execution
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+        - $ref: "#/components/parameters/ExecutionID"
+      responses:
+        "200":
+          description: Execution cancelled, or already terminal.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentHarnessExecution"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /v1/workspaces/{workspaceID}/agent-harness-executions/{executionID}/retry:
+    post:
+      operationId: retryAgentHarnessExecution
+      tags: [AgentHarnesses]
+      summary: Retry an Agent Harness execution
+      description: >
+        Retries a terminal harness execution using frozen snapshots from the
+        original execution. The idempotency key scopes duplicate retry requests
+        for the same source execution.
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+        - $ref: "#/components/parameters/ExecutionID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RetryAgentHarnessExecutionRequest"
+      responses:
+        "201":
+          description: Retry execution queued or existing retry returned.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentHarnessExecution"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
   # ---------------------------------------------------------------------------
   # Health
   # ---------------------------------------------------------------------------
@@ -4067,6 +4133,13 @@ components:
       schema:
         type: string
         format: uuid
+    ExecutionID:
+      name: executionID
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
     ArtifactID:
       name: artifactID
       in: path
@@ -4215,6 +4288,12 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorEnvelope"
+    TooManyRequests:
+      description: Rate or concurrency limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorEnvelope"
     GoneError:
       description: Resource expired or removed
       content:
@@ -4252,6 +4331,82 @@ components:
             upgrade_target:
               type: string
               description: Suggested plan key for resolving a billing gate failure.
+
+    RetryAgentHarnessExecutionRequest:
+      type: object
+      required: [idempotency_key]
+      properties:
+        idempotency_key:
+          type: string
+          minLength: 1
+          description: Idempotency key scoped to the source execution retry.
+
+    AgentHarnessExecution:
+      type: object
+      required: [id, organization_id, workspace_id, agent_harness_id, status, harness_snapshot, execution_config_snapshot, evaluation_config_snapshot, created_at, updated_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+        organization_id:
+          type: string
+          format: uuid
+        workspace_id:
+          type: string
+          format: uuid
+        agent_harness_id:
+          type: string
+          format: uuid
+        run_id:
+          type: string
+          format: uuid
+        run_agent_id:
+          type: string
+          format: uuid
+        evaluation_spec_id:
+          type: string
+          format: uuid
+        temporal_workflow_id:
+          type: string
+        temporal_run_id:
+          type: string
+        retry_of_execution_id:
+          type: string
+          format: uuid
+        created_by_user_id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [queued, provisioning, running, scoring, completed, failed, cancelled]
+        harness_snapshot:
+          type: object
+          additionalProperties: true
+        execution_config_snapshot:
+          type: object
+          additionalProperties: true
+        evaluation_config_snapshot:
+          type: object
+          additionalProperties: true
+        error_message:
+          type: string
+        failure_stage:
+          type: string
+        started_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+        cancelled_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
             limit:
               anyOf:
                 - type: integer

--- a/testing/codex-issue-611-harness-execution-controls-local-test-log.md
+++ b/testing/codex-issue-611-harness-execution-controls-local-test-log.md
@@ -1,0 +1,10 @@
+# Local Test Log - Issue 611 Harness Execution Controls
+
+## 2026-05-06
+
+- `cd backend && go test ./internal/api ./internal/repository ./internal/workflow`
+  - Result: passed.
+- `cd backend && go test ./...`
+  - Result: passed.
+- `git diff --check`
+  - Result: passed.

--- a/testing/codex-issue-611-harness-execution-controls.md
+++ b/testing/codex-issue-611-harness-execution-controls.md
@@ -1,0 +1,16 @@
+# Review Checkpoint - Issue 611 Harness Execution Controls
+
+## Expectations
+
+- Add cancel and retry controls to the existing Agent Harness execution API; do not introduce a parallel runner.
+- Persist recoverable Temporal workflow identifiers for harness executions so operations can target the right workflow.
+- Make cancellation safe and idempotent for terminal executions, with workspace authorization enforced before side effects.
+- Make retry explicit and idempotent via a caller-provided idempotency key, creating a normal `agent_harness_executions` row that reuses the original snapshots.
+- Enforce a workspace-level active harness execution cap before starting single, suite, or retry executions.
+- Preserve existing timeout cleanup behavior and make cancellation/timeout states clear in execution status and events.
+- Cover repository transitions, API authorization/routes, Temporal start/cancel wiring, retry idempotency, and concurrency-limit behavior.
+
+## DRY Constraints
+
+- Reuse existing `agent_harness_executions`, status transitions, canonical run bridge, replay/events, validators, LLM judges, and scorecards.
+- Reuse Temporal workflow operations for control; no new sandbox scheduler or evaluator path.


### PR DESCRIPTION
## Summary
- add cancel and retry APIs for Agent Harness executions
- persist Temporal workflow/run IDs for harness executions and expose them in responses
- add retry idempotency keys and retry parent linkage
- enforce workspace harness execution concurrency with a transactional advisory lock guard
- mark workflow cancellation as cancelled and compensate if Temporal starts but ID persistence fails
- document new controls in OpenAPI

## Review notes
- Fixes #611
- DRY note: controls operate on the existing `agent_harness_executions` workflow/status path. No separate runner, evaluator, validator, replay, or scorecard path is introduced.
- Claude reviewed the first implementation and found blockers; this PR includes the terminal-only retry, idempotent cancel, transactional cap, OpenAPI, and start-compensation fixes.

## Tests
- `cd backend && go test ./internal/api ./internal/repository ./internal/workflow`
- `cd backend && go test ./...`
- `git diff --check`
