### PR TITLE
Improve homepage SEO metadata signals

### DIFF
--- a/testing/codex-homepage-seo-foundation.md
+++ b/testing/codex-homepage-seo-foundation.md
@@ -1,0 +1,42 @@
+# codex/homepage-seo-foundation - Test Contract
+
+## Functional Behavior
+
+- Update the homepage/root metadata so search engines see AgentClash as an AI agent evaluation platform, not only a brand name.
+- Use `https://www.agentclash.dev` consistently for canonical public web signals touched in this PR.
+- Add an explicit canonical URL for `/`.
+- Add homepage `SoftwareApplication` and `Organization` JSON-LD so crawlers can identify the product and official profiles.
+- Keep this PR narrow: no new landing pages, no blog posts, no docs-md duplicate-content changes.
+
+## Unit Tests
+
+- N/A - metadata/structured-data changes do not have isolated unit coverage.
+
+## Integration / Functional Tests
+
+- `pnpm -C web lint` should pass.
+- `pnpm -C web build` should pass if the local environment has all required production build variables.
+- `rg "https://agentclash.dev" web/src/app web/src/lib/docs.ts web/src/components/marketing/json-ld.tsx` should only report intentional documentation/examples, not canonical metadata constants.
+
+## Smoke Tests
+
+- `/` should still render the existing homepage for anonymous users.
+- `/robots.txt` should point at the chosen canonical sitemap host after deploy.
+- `/sitemap.xml` should emit URLs using the chosen canonical host after deploy.
+
+## E2E Tests
+
+- N/A - no authenticated product behavior changes are intended.
+
+## Manual / cURL Tests
+
+```bash
+curl -s https://www.agentclash.dev | grep -E "AI agent evaluation|SoftwareApplication|canonical"
+# Expected after deploy: category metadata, structured data, and canonical signal appear.
+```
+
+## Follow-Up Outside Code
+
+- Submit the canonical sitemap in Google Search Console.
+- Use URL Inspection for `/` after deploy.
+- Monitor impressions for `AI agent evaluation platform`, `agent evaluation platform`, and `open source agent evals`.

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -48,33 +48,38 @@ const geistMono = Geist_Mono({
   variable: "--font-race-mono",
 });
 
-const siteUrl = "https://agentclash.dev";
+const siteUrl = "https://www.agentclash.dev";
+const siteDescription =
+  "AgentClash is an open-source AI agent evaluation platform. Race coding, research, support, and ops agents head-to-head on real tasks with sandboxed tools, live replay, scorecards, and CI regression gates.";
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
-  title: "AgentClash",
-  description:
-    "Opensource head-to-head agent evals. Pit your models against each other on real tasks. Same tools, same constraints, scored live — not benchmarks, not vibes.",
+  title: "AgentClash - Open-source AI Agent Evaluation Platform",
+  description: siteDescription,
   keywords: [
-    "AI agents",
-    "LLM benchmarks",
-    "AI race",
-    "model comparison",
+    "AI agent evaluation",
+    "agent evaluation platform",
+    "open-source agent evals",
+    "AI agent regression testing",
+    "coding agent benchmark",
+    "LLM agent evaluation",
+    "agent eval CI",
+    "head-to-head AI benchmarks",
     "agent evaluation",
-    "AI competition",
-    "head-to-head AI",
     "LLM testing",
   ],
   authors: [{ name: "AgentClash" }],
   creator: "AgentClash",
+  alternates: {
+    canonical: "/",
+  },
   openGraph: {
     type: "website",
     locale: "en_US",
     url: siteUrl,
     siteName: "AgentClash",
-    title: "AgentClash",
-    description:
-      "Opensource head-to-head agent evals. Pit your models against each other on real tasks. Same tools, same constraints, scored live — not benchmarks, not vibes.",
+    title: "AgentClash - Open-source AI agent evaluation platform",
+    description: siteDescription,
     images: [
       {
         url: "/og-image.png",
@@ -86,9 +91,8 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "AgentClash",
-    description:
-      "Opensource head-to-head agent evals. Pit your models against each other on real tasks. Same tools, same constraints, scored live — not benchmarks, not vibes.",
+    title: "AgentClash - AI agent evaluation platform",
+    description: siteDescription,
     images: ["/twitter-image.png"],
   },
   robots: {

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -70,9 +70,6 @@ export const metadata: Metadata = {
   ],
   authors: [{ name: "AgentClash" }],
   creator: "AgentClash",
-  alternates: {
-    canonical: "/",
-  },
   openGraph: {
     type: "website",
     locale: "en_US",

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,9 +1,52 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { redirect } from "next/navigation";
+import { JsonLd } from "@/components/marketing/json-ld";
 import HomePage from "./landing";
+
+const SITE_URL = "https://www.agentclash.dev";
+
+const softwareApplicationSchema = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: "AgentClash",
+  alternateName: "Agent Clash",
+  applicationCategory: "DeveloperApplication",
+  applicationSubCategory: "AI agent evaluation platform",
+  operatingSystem: "Web, macOS, Linux, Windows",
+  description:
+    "Open-source AI agent evaluation platform for racing agents head-to-head on real tasks with sandboxed tools, replay, scorecards, and CI regression gates.",
+  url: SITE_URL,
+  softwareVersion: "beta",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+  },
+};
+
+const organizationSchema = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "AgentClash",
+  alternateName: "Agent Clash",
+  url: SITE_URL,
+  logo: `${SITE_URL}/icon.svg`,
+  sameAs: [
+    "https://github.com/agentclash/agentclash",
+    "https://www.npmjs.com/package/agentclash",
+  ],
+};
 
 export default async function RootPage() {
   const { user } = await withAuth();
   if (user) redirect("/dashboard");
-  return <HomePage />;
+  return (
+    <>
+      <JsonLd
+        id="agentclash-homepage-schema"
+        data={[softwareApplicationSchema, organizationSchema]}
+      />
+      <HomePage />
+    </>
+  );
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -10,16 +10,14 @@ export const metadata: Metadata = {
   },
 };
 
-const softwareApplicationSchema = {
-  ...productSchema({
-    name: "AgentClash",
-    description:
-      "Open-source AI agent evaluation platform for racing agents head-to-head on real tasks with sandboxed tools, replay, scorecards, and CI regression gates.",
-    url: SITE_URL,
-  }),
+const softwareApplicationSchema = productSchema({
+  name: "AgentClash",
+  description:
+    "Open-source AI agent evaluation platform for racing agents head-to-head on real tasks with sandboxed tools, replay, scorecards, and CI regression gates.",
+  url: SITE_URL,
   applicationSubCategory: "AI agent evaluation platform",
   softwareVersion: "beta",
-};
+});
 
 const organizationSchema = {
   "@context": "https://schema.org",

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,27 +1,24 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
-import { JsonLd } from "@/components/marketing/json-ld";
+import { JsonLd, SITE_URL, productSchema } from "@/components/marketing/json-ld";
 import HomePage from "./landing";
 
-const SITE_URL = "https://www.agentclash.dev";
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "/",
+  },
+};
 
 const softwareApplicationSchema = {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  name: "AgentClash",
-  alternateName: "Agent Clash",
-  applicationCategory: "DeveloperApplication",
+  ...productSchema({
+    name: "AgentClash",
+    description:
+      "Open-source AI agent evaluation platform for racing agents head-to-head on real tasks with sandboxed tools, replay, scorecards, and CI regression gates.",
+    url: SITE_URL,
+  }),
   applicationSubCategory: "AI agent evaluation platform",
-  operatingSystem: "Web, macOS, Linux, Windows",
-  description:
-    "Open-source AI agent evaluation platform for racing agents head-to-head on real tasks with sandboxed tools, replay, scorecards, and CI regression gates.",
-  url: SITE_URL,
   softwareVersion: "beta",
-  offers: {
-    "@type": "Offer",
-    price: "0",
-    priceCurrency: "USD",
-  },
 };
 
 const organizationSchema = {

--- a/web/src/app/robots.ts
+++ b/web/src/app/robots.ts
@@ -3,6 +3,6 @@ import type { MetadataRoute } from "next";
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [{ userAgent: "*", allow: "/" }],
-    sitemap: "https://agentclash.dev/sitemap.xml",
+    sitemap: "https://www.agentclash.dev/sitemap.xml",
   };
 }

--- a/web/src/components/marketing/json-ld.tsx
+++ b/web/src/components/marketing/json-ld.tsx
@@ -13,7 +13,7 @@ export function JsonLd({ id, data }: Props) {
   );
 }
 
-export const SITE_URL = "https://agentclash.dev";
+export const SITE_URL = "https://www.agentclash.dev";
 
 export function breadcrumbSchema(
   items: Array<{ name: string; url: string }>,

--- a/web/src/components/marketing/json-ld.tsx
+++ b/web/src/components/marketing/json-ld.tsx
@@ -51,10 +51,14 @@ export function productSchema({
   name,
   description,
   url,
+  applicationSubCategory,
+  softwareVersion,
 }: {
   name: string;
   description: string;
   url: string;
+  applicationSubCategory?: string;
+  softwareVersion?: string;
 }): Record<string, unknown> {
   return {
     "@context": "https://schema.org",
@@ -62,9 +66,11 @@ export function productSchema({
     name,
     alternateName: "Agent Clash",
     applicationCategory: "DeveloperApplication",
+    ...(applicationSubCategory ? { applicationSubCategory } : {}),
     operatingSystem: "Web, macOS, Linux, Windows",
     description,
     url: url.startsWith("http") ? url : `${SITE_URL}${url}`,
+    ...(softwareVersion ? { softwareVersion } : {}),
     offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
   };
 }

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -29,7 +29,7 @@ const CLI_CONFIG_FILE = path.join(
 );
 const BACKEND_ENV_FILE = path.join(REPO_ROOT, "backend", ".env.example");
 
-export const DOCS_ORIGIN = "https://agentclash.dev";
+export const DOCS_ORIGIN = "https://www.agentclash.dev";
 
 export type DocNavItem = {
   title: string;


### PR DESCRIPTION
## Summary
- Reposition root metadata around the category term: open-source AI agent evaluation platform
- Align touched canonical/public URL constants to https://www.agentclash.dev
- Add explicit root canonical metadata and homepage SoftwareApplication/Organization JSON-LD

## Testing
- pnpm -C web lint
- pnpm -C web build
- rg 'https://agentclash.dev' web/src/app web/src/lib/docs.ts web/src/components/marketing/json-ld.tsx

Part of #633.