### PR TITLE
Add public page SEO metadata

### DIFF
--- a/testing/codex-public-page-seo-metadata.md
+++ b/testing/codex-public-page-seo-metadata.md
@@ -1,0 +1,36 @@
+# codex/public-page-seo-metadata - Test Contract
+
+## Functional Behavior
+
+- Public indexable pages (`/why`, `/blog`, `/blog/[slug]`, `/team`, and `/docs/...`) expose route-scoped canonical metadata.
+- Blog post pages include Article JSON-LD based on existing frontmatter.
+- Existing routes, sitemap generation, and authenticated product pages remain unchanged.
+
+## Unit Tests
+
+- N/A - this is a metadata-only App Router change with no isolated unit-test surface.
+
+## Integration / Functional Tests
+
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+
+- Next.js should prerender the existing blog post and docs pages without metadata errors.
+- Generated blog post structured data should use the shared canonical host.
+
+## E2E Tests
+
+- N/A - no user workflow, auth state, or browser interaction changes.
+
+## Manual / cURL Tests
+
+After deploy, inspect:
+
+```bash
+curl -s https://www.agentclash.dev/blog/why-we-built-agentclash | rg 'application/ld\\+json|canonical'
+curl -s https://www.agentclash.dev/docs/getting-started/quickstart | rg 'canonical'
+```
+
+Expected: blog post HTML includes Article JSON-LD and canonical tags point at `https://www.agentclash.dev/...`.

--- a/web/src/app/blog/[slug]/page.tsx
+++ b/web/src/app/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
+import { JsonLd, articleSchema } from "@/components/marketing/json-ld";
 import { getAllSlugs, getPostBySlug } from "@/lib/blog";
 
 type Props = {
@@ -19,6 +20,17 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title: `${post.title} — AgentClash`,
     description: post.description,
+    alternates: {
+      canonical: `/blog/${post.slug}`,
+    },
+    openGraph: {
+      type: "article",
+      title: `${post.title} — AgentClash`,
+      description: post.description,
+      url: `/blog/${post.slug}`,
+      publishedTime: post.date,
+      authors: [post.author],
+    },
   };
 }
 
@@ -29,6 +41,16 @@ export default async function BlogPostPage({ params }: Props) {
 
   return (
     <main className="min-h-screen flex flex-col items-center px-6 py-16">
+      <JsonLd
+        id={`agentclash-blog-${post.slug}-schema`}
+        data={articleSchema({
+          headline: post.title,
+          description: post.description,
+          url: `/blog/${post.slug}`,
+          datePublished: post.date,
+          authorName: post.author,
+        })}
+      />
       <article className="w-full max-w-lg">
         <header className="mb-8">
           <p className="font-[family-name:var(--font-mono)] text-[11px] text-white/20">

--- a/web/src/app/blog/page.tsx
+++ b/web/src/app/blog/page.tsx
@@ -3,8 +3,12 @@ import Link from "next/link";
 import { getAllPosts } from "@/lib/blog";
 
 export const metadata: Metadata = {
-  title: "Blog — AgentClash",
-  description: "Engineering notes from the AgentClash team.",
+  title: "AI Agent Evaluation Blog - AgentClash",
+  description:
+    "Engineering notes on AI agent evaluation, head-to-head agent evals, replayable failures, scorecards, and CI regression gates.",
+  alternates: {
+    canonical: "/blog",
+  },
 };
 
 export default function BlogPage() {

--- a/web/src/app/docs/[[...slug]]/page.tsx
+++ b/web/src/app/docs/[[...slug]]/page.tsx
@@ -27,6 +27,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title: `${doc.title} — AgentClash Docs`,
     description: doc.description,
+    alternates: {
+      canonical: doc.href,
+    },
   };
 }
 

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -36,6 +36,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.8,
     },
     {
+      url: `${DOCS_ORIGIN}/why`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+    {
+      url: `${DOCS_ORIGIN}/team`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
       url: `${DOCS_ORIGIN}/llms.txt`,
       lastModified: new Date(),
       changeFrequency: "weekly",

--- a/web/src/app/team/page.tsx
+++ b/web/src/app/team/page.tsx
@@ -3,7 +3,12 @@ import Image from "next/image";
 import Link from "next/link";
 
 export const metadata: Metadata = {
-  title: "Team",
+  title: "Team - AgentClash",
+  description:
+    "Meet the engineers building AgentClash, an open-source AI agent evaluation platform for real-task races, replay, scorecards, and CI gates.",
+  alternates: {
+    canonical: "/team",
+  },
 };
 
 const TEAM = [

--- a/web/src/app/why/page.tsx
+++ b/web/src/app/why/page.tsx
@@ -4,9 +4,12 @@ import { ArrowLeft } from "lucide-react";
 import { ClashMark } from "@/components/marketing/clash-mark";
 
 export const metadata: Metadata = {
-  title: "Why we built this",
+  title: "Why AgentClash Exists - AI Agent Evaluation for Real Tasks",
   description:
-    "Every benchmark passed. Then it failed in week one. Why AgentClash exists.",
+    "Why AgentClash exists: evaluate AI agents on your real tasks with the same tools, same constraints, replayable failures, and regression gates.",
+  alternates: {
+    canonical: "/why",
+  },
 };
 
 export default function WhyWeBuiltThisPage() {

--- a/web/src/components/marketing/json-ld.tsx
+++ b/web/src/components/marketing/json-ld.tsx
@@ -74,3 +74,42 @@ export function productSchema({
     offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
   };
 }
+
+export function articleSchema({
+  headline,
+  description,
+  url,
+  datePublished,
+  authorName,
+}: {
+  headline: string;
+  description: string;
+  url: string;
+  datePublished: string;
+  authorName: string;
+}): Record<string, unknown> {
+  const absoluteUrl = url.startsWith("http") ? url : `${SITE_URL}${url}`;
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline,
+    description,
+    url: absoluteUrl,
+    mainEntityOfPage: absoluteUrl,
+    datePublished,
+    dateModified: datePublished,
+    author: {
+      "@type": "Person",
+      name: authorName,
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "AgentClash",
+      logo: {
+        "@type": "ImageObject",
+        url: `${SITE_URL}/icon.svg`,
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- add page-scoped canonical metadata for `/why`, `/blog`, `/blog/[slug]`, `/team`, and docs pages
- add shared BlogPosting JSON-LD for blog posts using existing frontmatter
- include `/why` and `/team` in the XML sitemap

Closes part of #633.

## Test contract

- `testing/codex-public-page-seo-metadata.md`

## Verification

- `pnpm -C web lint`
- `pnpm -C web build`
- `git diff --check`
- rendered-output smoke: built blog post contains `BlogPosting` JSON-LD and canonical; built docs quickstart contains canonical; built sitemap contains `/why` and `/team`
