### PR TITLE
Noindex markdown docs exports

### DIFF
--- a/testing/codex-docs-md-noindex.md
+++ b/testing/codex-docs-md-noindex.md
@@ -1,0 +1,37 @@
+# codex/docs-md-noindex - Test Contract
+
+## Functional Behavior
+
+- `/docs-md/...` Markdown exports continue to serve existing rendered Markdown content.
+- Successful `/docs-md/...` responses include `X-Robots-Tag: noindex, follow`.
+- XML sitemap excludes `/docs-md/...` URLs so canonical `/docs/...` pages remain the indexed docs surface.
+- `/docs/...`, `/llms.txt`, and `/llms-full.txt` behavior remains unchanged.
+
+## Unit Tests
+
+- N/A - this change is route header and sitemap behavior.
+
+## Integration / Functional Tests
+
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+
+- Built sitemap output should not include `/docs-md`.
+- `/docs-md` route source should set `X-Robots-Tag: noindex, follow` on successful Markdown responses.
+
+## E2E Tests
+
+- N/A - no browser workflow changes.
+
+## Manual / cURL Tests
+
+After deploy:
+
+```bash
+curl -I https://www.agentclash.dev/docs-md/getting-started/quickstart
+curl -s https://www.agentclash.dev/sitemap.xml | rg docs-md
+```
+
+Expected: `X-Robots-Tag: noindex, follow` is present and the sitemap command returns no matches.

--- a/web/src/app/docs-md/[[...slug]]/route.ts
+++ b/web/src/app/docs-md/[[...slug]]/route.ts
@@ -23,6 +23,7 @@ export async function GET(_request: Request, context: Context) {
   return new Response(renderDocMarkdown(doc), {
     headers: {
       "Content-Type": "text/markdown; charset=utf-8",
+      "X-Robots-Tag": "noindex, follow",
     },
   });
 }

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from "next";
 import { getAllPosts } from "@/lib/blog";
-import { DOCS_ORIGIN, getAllDocMarkdownPaths, getAllDocPaths } from "@/lib/docs";
+import { DOCS_ORIGIN, getAllDocPaths } from "@/lib/docs";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const posts = getAllPosts().map((post) => ({
@@ -15,13 +15,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
     changeFrequency: "weekly" as const,
     priority: docPath === "/docs" ? 0.85 : 0.75,
   }));
-  const markdownDocs = getAllDocMarkdownPaths().map((docPath) => ({
-    url: `${DOCS_ORIGIN}${docPath}`,
-    lastModified: new Date(),
-    changeFrequency: "weekly" as const,
-    priority: docPath === "/docs-md" ? 0.5 : 0.4,
-  }));
-
   return [
     {
       url: DOCS_ORIGIN,
@@ -60,7 +53,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.55,
     },
     ...docs,
-    ...markdownDocs,
     ...posts,
   ];
 }


### PR DESCRIPTION
## Summary

- keep `/docs-md/...` Markdown exports available, but send `X-Robots-Tag: noindex, follow`
- remove `/docs-md/...` URLs from the XML sitemap so canonical `/docs/...` pages are the indexed docs surface

Closes part of #633.

## Test contract

- `testing/codex-docs-md-noindex.md`

## Verification

- `pnpm -C web lint`
- `pnpm -C web build`
- `git diff --check`
- rendered-output smoke: built sitemap has no `/docs-md` matches
- compiled-route smoke: docs-md route contains `X-Robots-Tag: noindex, follow`
