### PR TITLE
Improve npm discovery metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # AgentClash
 
-Opensource race engine. Pit your models against each other on real tasks. Same tools, same constraints, scored live — not benchmarks, not vibes.
+AI agent evaluation platform for real-task races. Compare agents with the same tools, same constraints, live scorecards, replay, and CI regression gates.
 
 **[agentclash.dev](https://www.agentclash.dev)**
 
 ## What is this?
 
-AgentClash puts AI models on the same real task, at the same time. Scored live on completion, speed, token efficiency, and tool strategy. Step-by-step replays show exactly why one agent won and another didn't.
+AgentClash puts AI agents on the same real task, at the same time. Scored live on completion, speed, token efficiency, and tool strategy. Step-by-step replays show exactly why one agent won and another didn't.
 
 - Head-to-head races
 - Composite scoring

--- a/npm/cli/README.md
+++ b/npm/cli/README.md
@@ -1,7 +1,8 @@
 # agentclash
 
-Command-line interface for the [AgentClash](https://www.agentclash.dev) race
-engine — evaluate, compare, and deploy AI agents.
+Command-line interface for [AgentClash](https://www.agentclash.dev), an AI
+agent evaluation platform for real-task races, replay, scorecards, and CI
+regression gates.
 
 ## Install
 

--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentclash",
   "version": "0.0.0",
-  "description": "AgentClash CLI — evaluate, compare, and deploy AI agents",
+  "description": "AI agent evaluation CLI for races, replay, scorecards, and CI regression gates",
   "bin": {
     "agentclash": "bin/agentclash.js"
   },
@@ -19,9 +19,23 @@
   },
   "keywords": [
     "agentclash",
-    "ai",
+    "ai-agent-evaluation",
+    "agent-evaluation",
+    "llm-evaluation",
+    "llm-eval",
+    "agent-testing",
+    "ai-testing",
+    "coding-agent",
+    "coding-agents",
+    "agent-regression-testing",
+    "benchmark",
+    "scorecard",
+    "replay",
+    "ci",
+    "ci-cd",
+    "llmops",
     "cli",
-    "evaluation",
+    "ai",
     "llm",
     "agent"
   ],

--- a/testing/codex-npm-discovery-keywords.md
+++ b/testing/codex-npm-discovery-keywords.md
@@ -1,0 +1,35 @@
+# codex/npm-discovery-keywords - Test Contract
+
+## Functional Behavior
+
+- Published `agentclash` npm metadata describes the CLI as an AI agent evaluation tool.
+- npm keywords include high-intent discovery terms from issue #633.
+- npm README opener matches the updated positioning.
+- Package contents and binary wiring remain unchanged.
+
+## Unit Tests
+
+- N/A - package metadata and README copy only.
+
+## Integration / Functional Tests
+
+- Parse `npm/cli/package.json` as JSON.
+- `npm pack --dry-run --json` from `npm/cli`.
+
+## Smoke Tests
+
+- Dry-run package output should still include `bin/agentclash.js`, `README.md`, and `LICENSE`.
+
+## E2E Tests
+
+- N/A - no CLI runtime behavior changes.
+
+## Manual / cURL Tests
+
+After the next npm release, inspect:
+
+```bash
+npm view agentclash description keywords
+```
+
+Expected: description and keywords include AI agent evaluation / agent eval discovery terms.

--- a/testing/codex-npm-discovery-keywords.md
+++ b/testing/codex-npm-discovery-keywords.md
@@ -18,7 +18,7 @@
 
 ## Smoke Tests
 
-- Dry-run package output should still include `bin/agentclash.js`, `README.md`, and `LICENSE`.
+- Dry-run package output should still include `bin/agentclash.js`, `README.md`, and `package.json`.
 
 ## E2E Tests
 


### PR DESCRIPTION
## Summary

- update the published `agentclash` npm description with AI agent evaluation positioning
- expand npm keywords with high-intent discovery terms from #633
- align root and npm README openers around real-task races, replay, scorecards, and CI regression gates

Closes part of #633.

## Test contract

- `testing/codex-npm-discovery-keywords.md`

## Verification

- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('npm/cli/package.json','utf8'))"`
- `npm pack --dry-run --json` from `npm/cli`
- `git diff --check`
