### PR TITLE
Add AI agent regression testing page

### DIFF
--- a/testing/codex-agent-regression-testing-page.md
+++ b/testing/codex-agent-regression-testing-page.md
@@ -6,7 +6,7 @@
 - Page has one visible H1, route-scoped metadata, canonical URL, OpenGraph URL, BreadcrumbList JSON-LD, and FAQ JSON-LD for visible FAQ content.
 - Page explains the AgentClash wedge for regression testing: baseline versus candidate runs, replay evidence, scorecards, promoted failures, challenge packs, and pull request gates.
 - Page links to relevant docs and trial paths without changing authenticated product behavior.
-- Sitemap and public marketing navigation expose the new page.
+- Sitemap exposes the new page without changing the homepage or shared marketing footer.
 
 ## Unit Tests
 

--- a/testing/codex-agent-regression-testing-page.md
+++ b/testing/codex-agent-regression-testing-page.md
@@ -1,0 +1,39 @@
+# codex/agent-regression-testing-page - Test Contract
+
+## Functional Behavior
+
+- Add an indexable `/platform/agent-regression-testing` page targeting `AI agent regression testing` and `AI agent CI gates`.
+- Page has one visible H1, route-scoped metadata, canonical URL, OpenGraph URL, BreadcrumbList JSON-LD, and FAQ JSON-LD for visible FAQ content.
+- Page explains the AgentClash wedge for regression testing: baseline versus candidate runs, replay evidence, scorecards, promoted failures, challenge packs, and pull request gates.
+- Page links to relevant docs and trial paths without changing authenticated product behavior.
+- Sitemap and public marketing navigation expose the new page.
+
+## Unit Tests
+
+- N/A - static marketing page and metadata.
+
+## Integration / Functional Tests
+
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+
+- Built output includes `/platform/agent-regression-testing`.
+- Built page output includes the H1 text, canonical metadata, BreadcrumbList JSON-LD, and FAQPage JSON-LD.
+- Sitemap output includes `https://www.agentclash.dev/platform/agent-regression-testing`.
+
+## E2E Tests
+
+- N/A - no authenticated workflow changes.
+
+## Manual / cURL Tests
+
+After deploy:
+
+```bash
+curl -s https://www.agentclash.dev/platform/agent-regression-testing | rg "AI agent regression testing|BreadcrumbList|FAQPage|canonical"
+curl -s https://www.agentclash.dev/sitemap.xml | rg "platform/agent-regression-testing"
+```
+
+Expected: page HTML exposes the target phrase, structured data, canonical tag, and sitemap URL.

--- a/web/src/app/platform/agent-regression-testing/page.tsx
+++ b/web/src/app/platform/agent-regression-testing/page.tsx
@@ -258,7 +258,7 @@ export default function AgentRegressionTestingPage() {
                   Home
                 </Link>
                 <span>/</span>
-                <span>Platform</span>
+                <span>AI Agent Regression Testing</span>
               </nav>
               <p className="mt-10 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-emerald-200/70">
                 Release gates for agents

--- a/web/src/app/platform/agent-regression-testing/page.tsx
+++ b/web/src/app/platform/agent-regression-testing/page.tsx
@@ -1,0 +1,455 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowRight,
+  CheckCircle2,
+  GitCompare,
+  GitPullRequest,
+  ListChecks,
+  ShieldCheck,
+  Terminal,
+  TimerReset,
+} from "lucide-react";
+import { ClashMark } from "@/components/marketing/clash-mark";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  faqSchema,
+} from "@/components/marketing/json-ld";
+
+const PAGE_PATH = "/platform/agent-regression-testing";
+const PAGE_TITLE = "AI Agent Regression Testing and CI Gates - AgentClash";
+const PAGE_DESCRIPTION =
+  "Catch AI agent regressions before release with baseline comparisons, repeatable challenge packs, replay evidence, scorecards, and pull request gates.";
+
+const faqItems = [
+  {
+    question: "What is AI agent regression testing?",
+    answer:
+      "AI agent regression testing reruns repeatable agent tasks against a candidate agent or model, compares the result to a baseline, and flags behavior that got worse before it ships.",
+  },
+  {
+    question: "How do AgentClash CI gates work?",
+    answer:
+      "AgentClash can run a challenge pack in CI, compare candidate and baseline scorecards, then fail a pull request when correctness, cost, latency, or required artifacts cross the threshold you set.",
+  },
+  {
+    question: "Can teams debug a failed agent gate?",
+    answer:
+      "Yes. Each run keeps replay evidence, tool calls, logs, artifacts, and scorecards so reviewers can see why the candidate failed instead of guessing from a final answer alone.",
+  },
+];
+
+const workflow = [
+  {
+    icon: ListChecks,
+    title: "Freeze the workload",
+    text: "Turn a real failure or release risk into a challenge pack with inputs, tools, artifacts, and scoring rules.",
+  },
+  {
+    icon: GitCompare,
+    title: "Compare candidate to baseline",
+    text: "Run both agents under the same constraints and compare correctness, latency, cost, and evidence.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Block risky changes",
+    text: "Fail the pull request when the scorecard regresses past the release gate threshold.",
+  },
+  {
+    icon: TimerReset,
+    title: "Promote failures",
+    text: "Convert escaped failures into reusable regression cases so the same mistake stays covered.",
+  },
+];
+
+const gateSignals = [
+  "Baseline versus candidate scorecards",
+  "Replay timelines for every failed gate",
+  "Artifact checks for files, logs, and evidence",
+  "Cost and latency thresholds for production budgets",
+  "Challenge packs that make failures repeatable",
+  "Pull request gates for model, prompt, and tool changes",
+];
+
+export const metadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  alternates: {
+    canonical: PAGE_PATH,
+  },
+  openGraph: {
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: PAGE_PATH,
+    type: "website",
+  },
+};
+
+function StaticHeader() {
+  return (
+    <header className="border-b border-white/[0.06] px-5 py-5 sm:px-12 sm:py-6">
+      <div className="mx-auto flex max-w-[1440px] items-center justify-between gap-4">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2.5 text-white/90"
+        >
+          <ClashMark className="size-6" />
+          <span className="font-[family-name:var(--font-display)] text-xl tracking-normal">
+            AgentClash
+          </span>
+        </Link>
+        <nav className="flex items-center gap-2 text-xs">
+          <Link
+            href="/docs"
+            className="hidden px-3 py-1.5 text-white/55 transition-colors hover:text-white/85 sm:inline-flex"
+          >
+            Docs
+          </Link>
+          <a
+            href="https://github.com/agentclash/agentclash"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hidden px-3 py-1.5 text-white/55 transition-colors hover:text-white/85 sm:inline-flex"
+          >
+            GitHub
+          </a>
+          <Link
+            href="/auth/login"
+            className="inline-flex items-center gap-1.5 rounded-md bg-white px-3 py-1.5 font-medium text-[#060606] transition-colors hover:bg-white/90"
+          >
+            Start
+            <ArrowRight className="size-3.5" />
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}
+
+function StaticFooter() {
+  return (
+    <footer className="border-t border-white/[0.06] bg-[#060606] px-6 py-10 sm:px-12">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-5 text-sm text-white/45 sm:flex-row sm:items-center sm:justify-between">
+        <Link href="/" className="font-medium text-white/65">
+          AgentClash
+        </Link>
+        <nav className="flex flex-wrap gap-5">
+          <Link
+            href="/platform/agent-evaluation"
+            className="transition-colors hover:text-white/75"
+          >
+            Agent evaluation
+          </Link>
+          <Link href="/docs" className="transition-colors hover:text-white/75">
+            Docs
+          </Link>
+          <Link href="/blog" className="transition-colors hover:text-white/75">
+            Blog
+          </Link>
+          <a
+            href="https://github.com/agentclash/agentclash"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="transition-colors hover:text-white/75"
+          >
+            GitHub
+          </a>
+        </nav>
+      </div>
+    </footer>
+  );
+}
+
+function GateVisual() {
+  return (
+    <div className="overflow-hidden rounded-md border border-white/[0.08] bg-[#090909] shadow-2xl shadow-emerald-950/20">
+      <div className="border-b border-white/[0.08] px-4 py-3">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-2">
+            <span className="size-2 rounded-full bg-emerald-300" />
+            <span className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/45">
+              pull request gate
+            </span>
+          </div>
+          <span className="rounded-md border border-rose-300/20 bg-rose-300/[0.06] px-2 py-1 font-[family-name:var(--font-mono)] text-[11px] text-rose-100/75">
+            blocked
+          </span>
+        </div>
+      </div>
+      <div className="grid gap-px bg-white/[0.06] md:grid-cols-[0.92fr_1.08fr]">
+        <div className="bg-[#090909] p-5">
+          <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+            regression scorecard
+          </p>
+          <div className="mt-5 space-y-3">
+            {[
+              ["Correctness", "-9", "threshold -3"],
+              ["Latency", "+18%", "threshold +15%"],
+              ["Cost", "+2%", "threshold +10%"],
+              ["Artifacts", "missing", "required"],
+            ].map(([label, value, threshold]) => (
+              <div
+                key={label}
+                className="rounded-md border border-white/[0.08] bg-white/[0.025] p-4"
+              >
+                <div className="flex items-center justify-between gap-4">
+                  <span className="text-sm font-medium text-white/78">
+                    {label}
+                  </span>
+                  <span className="font-[family-name:var(--font-mono)] text-sm text-white">
+                    {value}
+                  </span>
+                </div>
+                <p className="mt-2 font-[family-name:var(--font-mono)] text-[11px] text-white/35">
+                  {threshold}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="bg-[#090909] p-5">
+          <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+            replay evidence
+          </p>
+          <div className="mt-5 space-y-4">
+            {[
+              "candidate skipped validator retry after tool timeout",
+              "baseline produced required patch and attached artifact",
+              "candidate final answer passed prose check but failed file check",
+            ].map((item, index) => (
+              <div key={item} className="flex items-start gap-3">
+                <span className="mt-1 flex size-5 items-center justify-center rounded-md border border-emerald-300/25 bg-emerald-300/10 font-[family-name:var(--font-mono)] text-[10px] text-emerald-100">
+                  {index + 1}
+                </span>
+                <span className="text-sm leading-6 text-white/62">{item}</span>
+              </div>
+            ))}
+          </div>
+          <pre className="mt-6 overflow-hidden rounded-md border border-white/[0.08] bg-black px-4 py-3 font-[family-name:var(--font-mono)] text-[11px] leading-5 text-white/55">
+            agentclash compare gate --baseline run-stable --candidate run-pr-184
+          </pre>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function AgentRegressionTestingPage() {
+  return (
+    <>
+      <JsonLd
+        id="agentclash-platform-agent-regression-testing-schema"
+        data={[
+          breadcrumbSchema([
+            { name: "Home", url: "/" },
+            { name: "AI Agent Regression Testing", url: PAGE_PATH },
+          ]),
+          faqSchema(faqItems),
+        ]}
+      />
+      <StaticHeader />
+      <main className="min-h-screen bg-[#060606] text-white">
+        <section className="px-6 py-20 sm:px-12 sm:py-28">
+          <div className="mx-auto grid max-w-[1440px] gap-14 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
+            <div>
+              <nav className="flex items-center gap-2 text-xs text-white/35">
+                <Link href="/" className="transition-colors hover:text-white/70">
+                  Home
+                </Link>
+                <span>/</span>
+                <span>Platform</span>
+              </nav>
+              <p className="mt-10 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-emerald-200/70">
+                Release gates for agents
+              </p>
+              <h1 className="mt-5 max-w-[11ch] font-[family-name:var(--font-display)] text-5xl font-normal leading-none tracking-normal text-white sm:text-7xl">
+                AI agent regression testing for CI
+              </h1>
+              <p className="mt-8 max-w-[58ch] text-base leading-8 text-white/62 sm:text-lg">
+                Agent changes can pass a demo and still get worse in
+                production. AgentClash reruns real tasks, compares candidates
+                against a baseline, and blocks pull requests when scorecards or
+                evidence regress.
+              </p>
+              <div className="mt-9 flex flex-col gap-3 sm:flex-row">
+                <Link
+                  href="/auth/login"
+                  className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-medium text-[#060606] transition-colors hover:bg-white/90"
+                >
+                  Start first gate
+                  <ArrowRight className="size-4" />
+                </Link>
+                <Link
+                  href="/docs/guides/ci-cd-agent-gates"
+                  className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 transition-colors hover:border-white/30 hover:text-white"
+                >
+                  Read CI guide
+                  <Terminal className="size-4" />
+                </Link>
+              </div>
+            </div>
+            <GateVisual />
+          </div>
+        </section>
+
+        <section className="border-y border-white/[0.06] px-6 py-20 sm:px-12">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-3xl">
+              <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+                What a gate checks
+              </p>
+              <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">
+                Regression signals that survive model churn
+              </h2>
+              <p className="mt-5 text-sm leading-7 text-white/55 sm:text-base">
+                Prompts, models, tools, and sandbox images all move. AgentClash
+                makes the workload repeatable so the release decision is based
+                on behavior, not a one-off transcript.
+              </p>
+            </div>
+            <div className="mt-12 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              {gateSignals.map((signal) => (
+                <div
+                  key={signal}
+                  className="rounded-md border border-white/[0.08] bg-white/[0.03] p-5"
+                >
+                  <CheckCircle2 className="size-5 text-emerald-200" />
+                  <p className="mt-4 text-sm leading-6 text-white/78">
+                    {signal}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="px-6 py-20 sm:px-12 sm:py-28">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="grid gap-12 lg:grid-cols-[0.7fr_1fr]">
+              <div>
+                <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+                  Workflow
+                </p>
+                <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">
+                  From escaped failure to pull request gate
+                </h2>
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {workflow.map((item) => (
+                  <div
+                    key={item.title}
+                    className="rounded-md border border-white/[0.08] bg-white/[0.03] p-5"
+                  >
+                    <item.icon className="size-5 text-emerald-200" />
+                    <h3 className="mt-5 text-lg font-semibold tracking-normal text-white">
+                      {item.title}
+                    </h3>
+                    <p className="mt-3 text-sm leading-6 text-white/55">
+                      {item.text}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="border-y border-white/[0.06] px-6 py-20 sm:px-12">
+          <div className="mx-auto grid max-w-[1440px] gap-10 lg:grid-cols-[0.8fr_1fr] lg:items-start">
+            <div>
+              <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+                Start with docs
+              </p>
+              <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">
+                Wire regression gates into the release loop
+              </h2>
+              <p className="mt-5 text-sm leading-7 text-white/55 sm:text-base">
+                Start with one challenge pack and one release gate. Then add
+                escaped failures as reusable cases instead of rebuilding the
+                entire eval stack every time an agent changes.
+              </p>
+            </div>
+            <div className="grid gap-3">
+              {[
+                [
+                  "CI/CD agent gates",
+                  "Fail a pull request when an agent regresses.",
+                  "/docs/guides/ci-cd-agent-gates",
+                ],
+                [
+                  "CI/CD workload recipes",
+                  "Choose practical workloads for agent release checks.",
+                  "/docs/guides/ci-cd-workload-recipes",
+                ],
+                [
+                  "Interpret results",
+                  "Read scorecards, replay evidence, and regression signals.",
+                  "/docs/guides/interpret-results",
+                ],
+              ].map(([title, text, href]) => (
+                <Link
+                  key={href}
+                  href={href}
+                  className="group rounded-md border border-white/[0.08] bg-white/[0.03] p-5 transition-colors hover:border-white/20 hover:bg-white/[0.05]"
+                >
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <h3 className="text-base font-semibold tracking-normal text-white">
+                        {title}
+                      </h3>
+                      <p className="mt-2 text-sm leading-6 text-white/50">
+                        {text}
+                      </p>
+                    </div>
+                    <ArrowRight className="size-4 shrink-0 text-white/35 transition-colors group-hover:text-white/75" />
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="px-6 py-20 sm:px-12 sm:py-28">
+          <div className="mx-auto max-w-[960px]">
+            <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+              FAQ
+            </p>
+            <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">
+              Questions teams ask before gating agent releases
+            </h2>
+            <div className="mt-10 divide-y divide-white/[0.08] border-y border-white/[0.08]">
+              {faqItems.map((item) => (
+                <section key={item.question} className="py-6">
+                  <h3 className="text-lg font-semibold tracking-normal text-white">
+                    {item.question}
+                  </h3>
+                  <p className="mt-3 text-sm leading-7 text-white/55">
+                    {item.answer}
+                  </p>
+                </section>
+              ))}
+            </div>
+            <div className="mt-10 flex flex-col gap-3 sm:flex-row">
+              <Link
+                href="/auth/login"
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-medium text-[#060606] transition-colors hover:bg-white/90"
+              >
+                Start first gate
+                <ArrowRight className="size-4" />
+              </Link>
+              <Link
+                href="/platform/agent-evaluation"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 transition-colors hover:border-white/30 hover:text-white"
+              >
+                Compare eval platform
+                <GitPullRequest className="size-4" />
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
+      <StaticFooter />
+    </>
+  );
+}

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -47,6 +47,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.85,
     },
     {
+      url: `${DOCS_ORIGIN}/platform/agent-regression-testing`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.82,
+    },
+    {
       url: `${DOCS_ORIGIN}/llms.txt`,
       lastModified: new Date(),
       changeFrequency: "weekly",


### PR DESCRIPTION
## Summary
- add an indexable `/platform/agent-regression-testing` SEO page for AI agent regression testing and CI gate searches
- include route metadata, canonical/OpenGraph URL, BreadcrumbList JSON-LD, and FAQ JSON-LD tied to visible FAQ content
- expose the page through sitemap only, avoiding homepage/shared footer/internal UI changes

Part of #633.

## Safety constraints
- no homepage or main landing page UI changes
- no shared marketing footer changes
- no authenticated/internal app UI changes
- no DB/destructive changes

## Review checkpoint
- Contract: `testing/codex-agent-regression-testing-page.md`
- Cursor Agent + gstack-style review: ship as-is
- Final checkpoint verdict: ready

## Verification
- `pnpm -C web lint`
- `pnpm -C web build`
- `rg -n "AI agent regression testing for CI|BreadcrumbList|FAQPage|canonical|agentclash compare gate" web/.next/server/app/platform/agent-regression-testing.html web/.next/server/app/platform/agent-regression-testing.rsc`
- `rg -n "https://www.agentclash.dev/platform/agent-regression-testing" web/.next/server/app/sitemap.xml.body`
- `git diff --check`