### PR TITLE
List platform pages in llms discovery files

### DIFF
--- a/testing/codex-seo-llms-platform-pages.md
+++ b/testing/codex-seo-llms-platform-pages.md
@@ -1,0 +1,37 @@
+# codex/seo-llms-platform-pages - Test Contract
+
+## Functional Behavior
+
+- Add public platform page entries to machine-readable discovery surfaces only.
+- `/llms.txt` includes `/platform/agent-evaluation` and `/platform/agent-regression-testing` with concise descriptions for AI agent evaluation discovery.
+- `/llms-full.txt` includes the same public product page links in its introductory bundle metadata.
+- No homepage, main landing page UI, shared marketing footer, authenticated/internal UI, DB, or destructive changes.
+
+## Unit Tests
+
+- `pnpm -C web test -- docs.test.ts`
+
+## Integration / Functional Tests
+
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+
+- Built `/llms.txt` output includes both platform page URLs.
+- Built `/llms-full.txt` output includes both platform page URLs.
+
+## E2E Tests
+
+- N/A - machine-readable text routes only.
+
+## Manual / cURL Tests
+
+After deploy:
+
+```bash
+curl -s https://www.agentclash.dev/llms.txt | rg "platform/agent-evaluation|platform/agent-regression-testing"
+curl -s https://www.agentclash.dev/llms-full.txt | rg "platform/agent-evaluation|platform/agent-regression-testing"
+```
+
+Expected: both machine-readable files expose the public platform URLs.

--- a/web/src/lib/docs.test.ts
+++ b/web/src/lib/docs.test.ts
@@ -486,6 +486,10 @@ describe("agent skill docs", () => {
   it("includes agent skills in llms.txt", () => {
     const index = buildLlmsIndex("https://example.test");
 
+    expect(index).toContain("https://example.test/platform/agent-evaluation");
+    expect(index).toContain(
+      "https://example.test/platform/agent-regression-testing",
+    );
     expect(index).toContain("https://example.test/docs-md/agent-skills");
     expect(index).toContain(
       "https://example.test/docs-md/agent-skills/agentclash-cli-setup",
@@ -498,6 +502,10 @@ describe("agent skill docs", () => {
   it("includes the skill catalog and skill bodies in llms-full.txt", () => {
     const bundle = buildLlmsFull("https://example.test");
 
+    expect(bundle).toContain("https://example.test/platform/agent-evaluation");
+    expect(bundle).toContain(
+      "https://example.test/platform/agent-regression-testing",
+    );
     expect(bundle).toContain("# Agent Skills");
     expect(bundle).toContain("name: agentclash-skill-catalog");
     expect(bundle).toContain("## Generated Docs Contract");

--- a/web/src/lib/docs.test.ts
+++ b/web/src/lib/docs.test.ts
@@ -483,7 +483,7 @@ describe("agent skill docs", () => {
     }
   });
 
-  it("includes agent skills in llms.txt", () => {
+  it("includes platform pages and agent skills in llms.txt", () => {
     const index = buildLlmsIndex("https://example.test");
 
     expect(index).toContain("https://example.test/platform/agent-evaluation");
@@ -499,7 +499,7 @@ describe("agent skill docs", () => {
     );
   });
 
-  it("includes the skill catalog and skill bodies in llms-full.txt", () => {
+  it("includes platform pages, skill catalog, and skill bodies in llms-full.txt", () => {
     const bundle = buildLlmsFull("https://example.test");
 
     expect(bundle).toContain("https://example.test/platform/agent-evaluation");

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -31,6 +31,21 @@ const BACKEND_ENV_FILE = path.join(REPO_ROOT, "backend", ".env.example");
 
 export const DOCS_ORIGIN = "https://www.agentclash.dev";
 
+const PUBLIC_PRODUCT_PAGES = [
+  {
+    title: "AI Agent Evaluation Platform",
+    href: "/platform/agent-evaluation",
+    description:
+      "Public page for real-task AI agent evaluation, replay evidence, scorecards, challenge packs, and CI regression gates.",
+  },
+  {
+    title: "AI Agent Regression Testing",
+    href: "/platform/agent-regression-testing",
+    description:
+      "Public page for baseline-versus-candidate agent regression testing, pull request gates, and release evidence.",
+  },
+];
+
 export type DocNavItem = {
   title: string;
   description: string;
@@ -1513,7 +1528,7 @@ export function buildLlmsIndex(origin = DOCS_ORIGIN) {
     "",
     "> AgentClash runs agents against repeatable challenge packs, captures replay evidence, and shows where a run won, failed, or drifted.",
     "",
-    "Use this index when you want the shortest machine-readable map of the public docs. Fetch `/llms-full.txt` for the bundled corpus, or use the `/docs-md/...` links below for page-level markdown exports.",
+    "Use this index when you want the shortest machine-readable map of the public docs and selected product pages. Fetch `/llms-full.txt` for the bundled corpus, or use the `/docs-md/...` links below for page-level markdown exports.",
     "",
     "## Core entrypoints",
     "",
@@ -1525,6 +1540,12 @@ export function buildLlmsIndex(origin = DOCS_ORIGIN) {
     `- [Config Reference](${origin}/docs-md/reference/config) - generated environment and precedence reference.`,
     `- [Agent Skills](${origin}/docs-md/agent-skills) - copyable AgentClash skills for coding agents.`,
     `- [Full bundle](${origin}/llms-full.txt) - all shipped docs in one file.`,
+    "",
+    "## Public product pages",
+    "",
+    ...PUBLIC_PRODUCT_PAGES.map(
+      (page) => `- [${page.title}](${origin}${page.href}) - ${page.description}`,
+    ),
     "",
   ];
 
@@ -1564,7 +1585,13 @@ export function buildLlmsFull(origin = DOCS_ORIGIN) {
     `Canonical docs home: ${origin}/docs`,
     `Machine-readable index: ${origin}/llms.txt`,
     "",
-    "This file concatenates the currently shipped AgentClash docs pages into one markdown-oriented bundle for assistants, coding agents, and local retrieval pipelines.",
+    "This file concatenates the currently shipped AgentClash docs pages and selected product page links into one markdown-oriented bundle for assistants, coding agents, and local retrieval pipelines.",
+    "",
+    "## Public product pages",
+    "",
+    ...PUBLIC_PRODUCT_PAGES.map(
+      (page) => `- [${page.title}](${origin}${page.href}) - ${page.description}`,
+    ),
   ];
 
   for (const doc of docs) {


### PR DESCRIPTION
## Summary
- add the public platform pages to `/llms.txt` and `/llms-full.txt` machine-readable discovery output
- update the corpus wording so assistants see docs plus selected product pages, not docs-only
- cover both platform URLs in docs tests

Part of #633.

## Safety constraints
- no homepage or main landing page UI changes
- no shared marketing footer changes
- no authenticated/internal app UI changes
- no DB/destructive changes

## Review checkpoint
- Contract: `testing/codex-seo-llms-platform-pages.md`
- Cursor Agent + gstack-style review: wording polish fixed, ready
- Final checkpoint verdict: ready

## Verification
- `pnpm -C web test -- docs.test.ts`
- `pnpm -C web lint`
- `pnpm -C web build`
- `rg -n "public docs and selected product pages|docs pages and selected product page links|platform/agent-evaluation|platform/agent-regression-testing" web/.next/server/app/llms.txt.body web/.next/server/app/llms-full.txt.body`
- `git diff --check`