### PR TITLE
Add platform pages to docs search index

### DIFF
--- a/testing/codex-seo-search-platform-pages.md
+++ b/testing/codex-seo-search-platform-pages.md
@@ -1,0 +1,34 @@
+# codex/seo-search-platform-pages - Test Contract
+
+## Functional Behavior
+
+- Add public platform page entries to `/docs/search.json` data only.
+- Search index includes `/platform/agent-evaluation` and `/platform/agent-regression-testing` with search text for AI agent evaluation, regression testing, CI gates, replay evidence, scorecards, and challenge packs.
+- No homepage, main landing page UI, shared marketing footer, authenticated/internal UI, DB, or destructive changes.
+
+## Unit Tests
+
+- `pnpm -C web test -- docs.test.ts`
+
+## Integration / Functional Tests
+
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+
+- Built `/docs/search.json` output includes both platform page URLs and target phrases.
+
+## E2E Tests
+
+- N/A - search JSON data only.
+
+## Manual / cURL Tests
+
+After deploy:
+
+```bash
+curl -s https://www.agentclash.dev/docs/search.json | rg "platform/agent-evaluation|platform/agent-regression-testing"
+```
+
+Expected: public search JSON includes both platform URLs.

--- a/web/src/lib/docs.test.ts
+++ b/web/src/lib/docs.test.ts
@@ -6,6 +6,7 @@ import {
   DOCS_NAV,
   getAllDocMarkdownPaths,
   getDocBySlug,
+  getDocsSearchIndex,
 } from "./docs";
 
 const skillSlugs = [
@@ -497,6 +498,31 @@ describe("agent skill docs", () => {
     expect(index).toContain(
       "https://example.test/docs-md/agent-skills/challenge-pack-skills/agentclash-challenge-pack-yaml-author",
     );
+  });
+
+  it("includes platform pages in docs search data", () => {
+    const index = getDocsSearchIndex();
+    const evaluation = index.find(
+      (item) => item.href === "/platform/agent-evaluation",
+    );
+    const regression = index.find(
+      (item) => item.href === "/platform/agent-regression-testing",
+    );
+
+    expect(index.slice(0, 2).map((item) => item.href)).toEqual([
+      "/platform/agent-evaluation",
+      "/platform/agent-regression-testing",
+    ]);
+    expect(evaluation?.title).toBe("AI Agent Evaluation Platform");
+    expect(evaluation?.searchText).toContain("platform/agent-evaluation");
+    expect(evaluation?.searchText).toContain("ai agent evaluation");
+    expect(evaluation?.searchText).toContain("challenge packs");
+    expect(evaluation?.searchText).toContain("ci regression gates");
+    expect(regression?.title).toBe("AI Agent Regression Testing");
+    expect(regression?.searchText).toContain("platform/agent-regression-testing");
+    expect(regression?.searchText).toContain("ai agent regression testing");
+    expect(regression?.searchText).toContain("pull request gates");
+    expect(regression?.searchText).toContain("scorecards");
   });
 
   it("includes platform pages, skill catalog, and skill bodies in llms-full.txt", () => {

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -31,18 +31,29 @@ const BACKEND_ENV_FILE = path.join(REPO_ROOT, "backend", ".env.example");
 
 export const DOCS_ORIGIN = "https://www.agentclash.dev";
 
-const PUBLIC_PRODUCT_PAGES = [
+type PublicProductPage = {
+  title: string;
+  href: string;
+  description: string;
+  searchKeywords: string;
+};
+
+const PUBLIC_PRODUCT_PAGES: PublicProductPage[] = [
   {
     title: "AI Agent Evaluation Platform",
     href: "/platform/agent-evaluation",
     description:
       "Public page for real-task AI agent evaluation, replay evidence, scorecards, challenge packs, and CI regression gates.",
+    searchKeywords:
+      "AI agent evaluation agent evals real task agent benchmark coding agent evaluation LLM agent evaluation sandboxed agent workloads replay evidence scorecards challenge packs CI regression gates",
   },
   {
     title: "AI Agent Regression Testing",
     href: "/platform/agent-regression-testing",
     description:
       "Public page for baseline-versus-candidate agent regression testing, pull request gates, and release evidence.",
+    searchKeywords:
+      "AI agent regression testing agent evaluation CI gates pull request gates release gates baseline candidate comparisons replay evidence scorecards challenge packs agent eval regression suite",
   },
 ];
 
@@ -1494,7 +1505,7 @@ export function getAllDocMarkdownPaths() {
 }
 
 export function getDocsSearchIndex(): DocSearchItem[] {
-  return getAllDocSlugs()
+  const docsSearchItems = getAllDocSlugs()
     .map((slug) => getDocBySlug(slug))
     .filter((doc): doc is DocPage => Boolean(doc))
     .map((doc) => ({
@@ -1505,6 +1516,16 @@ export function getDocsSearchIndex(): DocSearchItem[] {
         .map((heading) => heading.text)
         .join(" ")} ${stripInlineMarkdown(doc.content).slice(0, 900)}`.toLowerCase(),
     }));
+
+  const productPageSearchItems = PUBLIC_PRODUCT_PAGES.map((page) => ({
+    title: page.title,
+    description: page.description,
+    href: page.href,
+    searchText:
+      `${page.title} ${page.description} ${page.href} ${page.searchKeywords}`.toLowerCase(),
+  }));
+
+  return [...productPageSearchItems, ...docsSearchItems];
 }
 
 export function renderDocMarkdown(doc: DocPage, origin = DOCS_ORIGIN) {


### PR DESCRIPTION
## Summary
- add the public AI agent evaluation and regression testing pages to `/docs/search.json`
- put those platform results first so the docs search result cap does not bury them
- cover titles, href fragments, ordering, and SEO phrases in docs tests

## Review
- Cursor Agent ran a gstack `/review` style pass twice; no blocking issues remained.

## Tests
- `pnpm -C web test -- docs.test.ts`
- `pnpm -C web lint`
- `pnpm -C web build`
- built search JSON smoke check for both platform URLs and path fragments

## Scope Guardrails
- no homepage/main landing UI changes
- no shared marketing footer changes
- no authenticated/internal UI changes
- no DB or destructive changes