### PR TITLE
Add platform page structured data

### DIFF
--- a/testing/codex-seo-platform-structured-data.md
+++ b/testing/codex-seo-platform-structured-data.md
@@ -1,0 +1,37 @@
+# codex/seo-platform-structured-data - Test Contract
+
+## Functional Behavior
+
+- Add SoftwareApplication JSON-LD to the two public platform pages only.
+- Structured data uses the existing marketing JSON-LD helper and matches each page's title, description, canonical path, and product category.
+- Preserve existing breadcrumb and FAQ JSON-LD.
+- No homepage, main landing page UI, shared marketing footer, authenticated/internal UI, DB, or destructive changes.
+
+## Unit Tests
+
+- `pnpm -C web test -- json-ld.test.ts platform-pages.test.ts`
+
+## Integration / Functional Tests
+
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+
+- Built platform page HTML includes one SoftwareApplication JSON-LD object for each platform page.
+- Built platform page HTML preserves FAQPage and BreadcrumbList JSON-LD.
+
+## E2E Tests
+
+- N/A - structured metadata only.
+
+## Manual / cURL Tests
+
+After deploy:
+
+```bash
+curl -s https://www.agentclash.dev/platform/agent-evaluation | rg "SoftwareApplication|AI Agent Evaluation Platform"
+curl -s https://www.agentclash.dev/platform/agent-regression-testing | rg "SoftwareApplication|AI Agent Regression Testing"
+```
+
+Expected: both public pages expose SoftwareApplication structured data without visible UI changes.

--- a/web/src/app/platform/agent-evaluation/page.tsx
+++ b/web/src/app/platform/agent-evaluation/page.tsx
@@ -15,6 +15,7 @@ import {
   JsonLd,
   breadcrumbSchema,
   faqSchema,
+  productSchema,
 } from "@/components/marketing/json-ld";
 
 const PAGE_PATH = "/platform/agent-evaluation";
@@ -248,6 +249,12 @@ export default function AgentEvaluationPage() {
             { name: "AI Agent Evaluation Platform", url: PAGE_PATH },
           ]),
           faqSchema(faqItems),
+          productSchema({
+            name: PAGE_TITLE,
+            description: PAGE_DESCRIPTION,
+            url: PAGE_PATH,
+            applicationSubCategory: "AI agent evaluation platform",
+          }),
         ]}
       />
       <StaticHeader />

--- a/web/src/app/platform/agent-regression-testing/page.tsx
+++ b/web/src/app/platform/agent-regression-testing/page.tsx
@@ -15,6 +15,7 @@ import {
   JsonLd,
   breadcrumbSchema,
   faqSchema,
+  productSchema,
 } from "@/components/marketing/json-ld";
 
 const PAGE_PATH = "/platform/agent-regression-testing";
@@ -246,6 +247,12 @@ export default function AgentRegressionTestingPage() {
             { name: "AI Agent Regression Testing", url: PAGE_PATH },
           ]),
           faqSchema(faqItems),
+          productSchema({
+            name: PAGE_TITLE,
+            description: PAGE_DESCRIPTION,
+            url: PAGE_PATH,
+            applicationSubCategory: "AI agent regression testing software",
+          }),
         ]}
       />
       <StaticHeader />

--- a/web/src/app/platform/platform-pages.test.tsx
+++ b/web/src/app/platform/platform-pages.test.tsx
@@ -1,0 +1,82 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import AgentEvaluationPage from "./agent-evaluation/page";
+import AgentRegressionTestingPage from "./agent-regression-testing/page";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function render(element: React.ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(element);
+  });
+}
+
+function getJsonLd(id: string) {
+  const script = container?.querySelector<HTMLScriptElement>(`#${id}`);
+  expect(script?.type).toBe("application/ld+json");
+  return JSON.parse(script?.textContent ?? "[]") as Array<Record<string, unknown>>;
+}
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe("platform pages structured data", () => {
+  it("emits breadcrumb, FAQ, and SoftwareApplication data for agent evaluation", () => {
+    render(<AgentEvaluationPage />);
+
+    const jsonLd = getJsonLd("agentclash-platform-agent-evaluation-schema");
+    const software = jsonLd.find(
+      (item) => item["@type"] === "SoftwareApplication",
+    );
+
+    expect(jsonLd.map((item) => item["@type"])).toEqual([
+      "BreadcrumbList",
+      "FAQPage",
+      "SoftwareApplication",
+    ]);
+    expect(software).toMatchObject({
+      name: "AI Agent Evaluation Platform for Real Tasks - AgentClash",
+      description:
+        "Evaluate AI agents on real tasks with same-tools races, sandboxed execution, replay, scorecards, challenge packs, and CI regression gates.",
+      url: "https://www.agentclash.dev/platform/agent-evaluation",
+      applicationCategory: "DeveloperApplication",
+      applicationSubCategory: "AI agent evaluation platform",
+    });
+  });
+
+  it("emits breadcrumb, FAQ, and SoftwareApplication data for regression testing", () => {
+    render(<AgentRegressionTestingPage />);
+
+    const jsonLd = getJsonLd(
+      "agentclash-platform-agent-regression-testing-schema",
+    );
+    const software = jsonLd.find(
+      (item) => item["@type"] === "SoftwareApplication",
+    );
+
+    expect(jsonLd.map((item) => item["@type"])).toEqual([
+      "BreadcrumbList",
+      "FAQPage",
+      "SoftwareApplication",
+    ]);
+    expect(software).toMatchObject({
+      name: "AI Agent Regression Testing and CI Gates - AgentClash",
+      description:
+        "Catch AI agent regressions before release with baseline comparisons, repeatable challenge packs, replay evidence, scorecards, and pull request gates.",
+      url: "https://www.agentclash.dev/platform/agent-regression-testing",
+      applicationCategory: "DeveloperApplication",
+      applicationSubCategory: "AI agent regression testing software",
+    });
+  });
+});

--- a/web/src/components/marketing/json-ld.test.ts
+++ b/web/src/components/marketing/json-ld.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { productSchema, SITE_URL } from "./json-ld";
+
+describe("productSchema", () => {
+  it("builds SoftwareApplication structured data with absolute URLs", () => {
+    expect(
+      productSchema({
+        name: "AI Agent Evaluation Platform for Real Tasks - AgentClash",
+        description: "Evaluate AI agents on real tasks.",
+        url: "/platform/agent-evaluation",
+        applicationSubCategory: "AI agent evaluation platform",
+      }),
+    ).toMatchObject({
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      name: "AI Agent Evaluation Platform for Real Tasks - AgentClash",
+      alternateName: "Agent Clash",
+      applicationCategory: "DeveloperApplication",
+      applicationSubCategory: "AI agent evaluation platform",
+      operatingSystem: "Web, macOS, Linux, Windows",
+      description: "Evaluate AI agents on real tasks.",
+      url: `${SITE_URL}/platform/agent-evaluation`,
+      offers: {
+        "@type": "Offer",
+        price: "0",
+        priceCurrency: "USD",
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add SoftwareApplication JSON-LD to the AI agent evaluation and regression testing platform pages
- keep existing BreadcrumbList and FAQPage structured data intact
- add tests for the JSON-LD helper and rendered platform page schema scripts

## Review
- Cursor Agent ran a gstack `/review` style pass twice; the complete-diff pass recommended shipping as-is.

## Tests
- `pnpm -C web test -- json-ld.test.ts platform-pages.test.ts`
- `pnpm -C web lint`
- `pnpm -C web build`
- built platform HTML smoke check for SoftwareApplication, FAQPage, and BreadcrumbList

## Scope Guardrails
- no homepage/main landing UI changes
- no shared marketing footer changes
- no authenticated/internal UI changes
- no DB or destructive changes