### PR TITLE
Add AI agent evaluation blog post

### DIFF
--- a/testing/codex-seo-agent-evaluation-blog.md
+++ b/testing/codex-seo-agent-evaluation-blog.md
@@ -1,0 +1,36 @@
+# codex/seo-agent-evaluation-blog - Test Contract
+
+## Functional Behavior
+
+- Add a public blog post targeting AI agent evaluation and AI agent regression testing search intent.
+- Post should explain why real-task agent evals need replay evidence, scorecards, challenge packs, and CI gates.
+- Post should include internal links to the platform pages and relevant docs.
+- No homepage, main landing page UI, shared marketing footer, authenticated/internal UI, DB, or destructive changes.
+
+## Unit Tests
+
+- `pnpm -C web test -- blog.test.ts`
+
+## Integration / Functional Tests
+
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+
+- Built blog route includes `/blog/ai-agent-evaluation-regression-testing`.
+- Built blog page includes the post title and internal links to both platform pages.
+
+## E2E Tests
+
+- N/A - static blog content.
+
+## Manual / cURL Tests
+
+After deploy:
+
+```bash
+curl -s https://www.agentclash.dev/blog/ai-agent-evaluation-regression-testing | rg "AI Agent Evaluation Needs Regression Testing|/platform/agent-evaluation|/platform/agent-regression-testing"
+```
+
+Expected: the new blog post is published and internally links to both platform pages.

--- a/web/content/blog/ai-agent-evaluation-regression-testing.mdx
+++ b/web/content/blog/ai-agent-evaluation-regression-testing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "AI Agent Evaluation Needs Regression Testing, Not Just Benchmarks"
-date: "2026-05-08"
+date: "2026-05-07"
 description: "A practical guide to AI agent evaluation with real-task workloads, replay evidence, scorecards, challenge packs, and CI regression gates."
 author: "Atharva"
 ---

--- a/web/content/blog/ai-agent-evaluation-regression-testing.mdx
+++ b/web/content/blog/ai-agent-evaluation-regression-testing.mdx
@@ -1,0 +1,102 @@
+---
+title: "AI Agent Evaluation Needs Regression Testing, Not Just Benchmarks"
+date: "2026-05-08"
+description: "A practical guide to AI agent evaluation with real-task workloads, replay evidence, scorecards, challenge packs, and CI regression gates."
+author: "Atharva"
+---
+
+Most AI agent evaluation starts in the wrong place.
+
+A team tries a few prompts, compares a model leaderboard, watches one impressive demo, and ships the agent that looked best in a narrow test. Then the agent reaches a real workflow: messy tools, missing context, timeouts, partial files, stale APIs, and users who expect the whole task to finish.
+
+That is where benchmark-only evaluation breaks down. Agents are not just text generators. They plan, call tools, modify state, inspect results, recover from mistakes, and decide when to stop. If the eval only checks the final answer, it misses the behavior that makes an agent safe or expensive to run in production.
+
+Real AI agent evaluation needs regression testing.
+
+## What an agent eval should prove
+
+An agent eval should answer a practical release question: is this agent ready to do this job again, under the same constraints, without getting worse?
+
+That means the eval needs more than a score. It needs a repeatable workload, a fair comparison, and enough evidence for a reviewer to understand the result. A useful AI agent evaluation platform should capture:
+
+- the task definition and inputs
+- the tool and network policy
+- the agent's actions and observations
+- produced files, logs, and artifacts
+- correctness, cost, latency, and evidence quality
+- the comparison between a candidate and a baseline
+
+That is the difference between "the model looked good" and "this agent passed the release gate."
+
+AgentClash is built around that second workflow. The [AI agent evaluation platform](/platform/agent-evaluation) page explains the product surface, but the core idea is simple: run agents on the same real task with the same tools, then preserve replay evidence and scorecards so the result is reviewable.
+
+## Why static benchmarks are not enough
+
+Static benchmarks are useful for a first filter. They are not enough for shipping agents.
+
+They usually measure isolated answers, not trajectories. They rarely include your private tools, your repository shape, your data contracts, your latency budget, or your failure modes. They can also hide the most important production question: did the agent solve the task in a way your team can trust and repeat?
+
+For agents, the path matters.
+
+Two agents can produce the same final answer while behaving very differently. One might use the right tool, verify its work, attach the required artifact, and stay inside budget. Another might hallucinate a file, skip the failing test, and still land near the correct prose answer. A final-answer-only benchmark treats those runs as similar. A real agent eval should not.
+
+## Turn failures into challenge packs
+
+The repeatable unit in AgentClash is a challenge pack: a workload definition with cases, inputs, tools, scoring rules, and artifacts. Challenge packs make agent evaluation operational because they turn a vague question into something runnable:
+
+- What task should the agent perform?
+- What inputs and fixtures should it see?
+- Which tools are allowed?
+- What evidence should be captured?
+- Which validators or judges decide success?
+
+When an agent fails in production or in a release test, the failure should become a reusable case. That is how the eval suite compounds. Instead of debugging the same mistake every few weeks, you promote it into coverage and make the next candidate prove it did not regress.
+
+The docs for [writing a challenge pack](/docs/guides/write-a-challenge-pack) are the right starting point if you want to turn a real workflow into a durable eval.
+
+## Add regression gates to CI
+
+The strongest agent eval is not a dashboard someone remembers to check. It is a gate in the release loop.
+
+AI agent regression testing compares a candidate run against a known baseline. If the candidate gets worse on correctness, cost, latency, artifacts, or another scorecard dimension, the gate can block the pull request before the change reaches users.
+
+That matters because agent quality can regress in subtle ways:
+
+- a prompt edit improves one demo but breaks another workflow
+- a model switch changes tool strategy or latency
+- a sandbox image update changes installed dependencies
+- a retrieval change gives the agent stale or incomplete context
+- a tool permission change makes a previously solved task impossible
+
+The [AI agent regression testing](/platform/agent-regression-testing) page covers the product angle. The [CI/CD agent gates](/docs/guides/ci-cd-agent-gates) guide covers the implementation path.
+
+## What to look for in an agent evaluation tool
+
+If you are comparing agent evaluation tools, look past the leaderboard. The tool should help your team make a release decision, debug failures, and improve the next test suite.
+
+Useful capabilities include:
+
+- real-task execution instead of prompt-only grading
+- sandboxed runs with explicit tool and network policy
+- replay timelines for tool calls and observations
+- scorecards that separate correctness, cost, latency, and evidence
+- artifact capture for files, logs, and outputs
+- baseline versus candidate comparison
+- CI gates for regressions
+- a workflow for promoting failures into reusable tests
+
+The goal is not to collect more numbers. The goal is to shorten the path from "this agent failed" to "we understand why, we fixed it, and the failure is now covered."
+
+## The release loop
+
+The loop should look like this:
+
+1. Capture a real task as a challenge pack.
+2. Run candidate and baseline agents under the same constraints.
+3. Inspect replay evidence and scorecards.
+4. Promote important failures into regression cases.
+5. Gate future changes in CI.
+
+That is how AI agent evaluation becomes engineering infrastructure instead of a one-off experiment.
+
+Benchmarks can tell you where to look. Regression testing tells you whether the agent is safe to ship again.

--- a/web/src/lib/blog.test.ts
+++ b/web/src/lib/blog.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { getAllPosts, getPostBySlug } from "./blog";
+
+describe("blog content", () => {
+  it("indexes the AI agent evaluation regression testing post", () => {
+    const post = getPostBySlug("ai-agent-evaluation-regression-testing");
+    const indexedPost = getAllPosts().find(
+      (candidate) => candidate.slug === "ai-agent-evaluation-regression-testing",
+    );
+
+    expect(post?.title).toBe(
+      "AI Agent Evaluation Needs Regression Testing, Not Just Benchmarks",
+    );
+    expect(post?.description).toContain("AI agent evaluation");
+    expect(post?.description).toContain("CI regression gates");
+    expect(post?.content).toContain(
+      "[AI agent evaluation platform](/platform/agent-evaluation)",
+    );
+    expect(post?.content).toContain(
+      "[AI agent regression testing](/platform/agent-regression-testing)",
+    );
+    expect(post?.content).toContain(
+      "[writing a challenge pack](/docs/guides/write-a-challenge-pack)",
+    );
+    expect(post?.content).toContain(
+      "[CI/CD agent gates](/docs/guides/ci-cd-agent-gates)",
+    );
+    expect(indexedPost).toMatchObject({
+      slug: "ai-agent-evaluation-regression-testing",
+      date: "2026-05-08",
+      author: "Atharva",
+    });
+  });
+});

--- a/web/src/lib/blog.test.ts
+++ b/web/src/lib/blog.test.ts
@@ -1,18 +1,24 @@
 import { describe, expect, it } from "vitest";
 import { getAllPosts, getPostBySlug } from "./blog";
 
-describe("blog content", () => {
-  it("indexes the AI agent evaluation regression testing post", () => {
-    const post = getPostBySlug("ai-agent-evaluation-regression-testing");
-    const indexedPost = getAllPosts().find(
-      (candidate) => candidate.slug === "ai-agent-evaluation-regression-testing",
-    );
+const SLUG = "ai-agent-evaluation-regression-testing";
 
+describe("blog content", () => {
+  it("loads the AI agent evaluation regression testing metadata", () => {
+    const post = getPostBySlug(SLUG);
+
+    expect(post).not.toBeNull();
     expect(post?.title).toBe(
       "AI Agent Evaluation Needs Regression Testing, Not Just Benchmarks",
     );
     expect(post?.description).toContain("AI agent evaluation");
     expect(post?.description).toContain("CI regression gates");
+  });
+
+  it("loads internal links from the AI agent evaluation post", () => {
+    const post = getPostBySlug(SLUG);
+
+    expect(post).not.toBeNull();
     expect(post?.content).toContain(
       "[AI agent evaluation platform](/platform/agent-evaluation)",
     );
@@ -25,9 +31,14 @@ describe("blog content", () => {
     expect(post?.content).toContain(
       "[CI/CD agent gates](/docs/guides/ci-cd-agent-gates)",
     );
+  });
+
+  it("indexes the AI agent evaluation post with publish metadata", () => {
+    const indexedPost = getAllPosts().find((candidate) => candidate.slug === SLUG);
+
     expect(indexedPost).toMatchObject({
-      slug: "ai-agent-evaluation-regression-testing",
-      date: "2026-05-08",
+      slug: SLUG,
+      date: "2026-05-07",
       author: "Atharva",
     });
   });


### PR DESCRIPTION
## Summary
- add a new blog post targeting AI agent evaluation and AI agent regression testing search intent
- explain real-task evals, replay evidence, scorecards, challenge packs, and CI gates
- include internal links to both platform pages and relevant docs
- add a blog library test for the slug, metadata, and internal links

## Review
- Cursor Agent ran a gstack `/review` style pass and recommended shipping as-is after the test-ordering hardening fix.

## Tests
- `pnpm -C web test -- blog.test.ts`
- `pnpm -C web lint`
- `pnpm -C web build`
- built blog HTML smoke check for title and platform links

## Scope Guardrails
- no homepage/main landing UI changes
- no shared marketing footer changes
- no authenticated/internal UI changes
- no DB or destructive changes