### PR TITLE
Include blog posts in llms discovery files

### DIFF
--- a/testing/codex-seo-llms-blog-posts.md
+++ b/testing/codex-seo-llms-blog-posts.md
@@ -1,0 +1,37 @@
+# codex/seo-llms-blog-posts - Test Contract
+
+## Functional Behavior
+
+- Add public blog posts to `/llms.txt` so AI tools can discover the blog corpus.
+- Add public blog post content to `/llms-full.txt` with source URLs and normalized internal links.
+- Preserve existing docs, agent skills, and platform page coverage.
+- No homepage, main landing page UI, shared marketing footer, authenticated/internal UI, DB, or destructive changes.
+
+## Unit Tests
+
+- `pnpm -C web test -- docs.test.ts`
+
+## Integration / Functional Tests
+
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+
+- Built `/llms.txt` includes `/blog/ai-agent-evaluation-regression-testing`.
+- Built `/llms-full.txt` includes the blog title and links to both platform pages.
+
+## E2E Tests
+
+- N/A - machine-readable text routes only.
+
+## Manual / cURL Tests
+
+After deploy:
+
+```bash
+curl -s https://www.agentclash.dev/llms.txt | rg "/blog/ai-agent-evaluation-regression-testing"
+curl -s https://www.agentclash.dev/llms-full.txt | rg "AI Agent Evaluation Needs Regression Testing|/platform/agent-evaluation|/platform/agent-regression-testing"
+```
+
+Expected: blog posts are discoverable in both machine-readable files.

--- a/web/src/lib/docs.test.ts
+++ b/web/src/lib/docs.test.ts
@@ -484,12 +484,18 @@ describe("agent skill docs", () => {
     }
   });
 
-  it("includes platform pages and agent skills in llms.txt", () => {
+  it("includes platform pages, blog posts, and agent skills in llms.txt", () => {
     const index = buildLlmsIndex("https://example.test");
 
     expect(index).toContain("https://example.test/platform/agent-evaluation");
     expect(index).toContain(
       "https://example.test/platform/agent-regression-testing",
+    );
+    expect(index).toContain(
+      "https://example.test/blog/ai-agent-evaluation-regression-testing",
+    );
+    expect(index).toContain(
+      "AI Agent Evaluation Needs Regression Testing, Not Just Benchmarks",
     );
     expect(index).toContain("https://example.test/docs-md/agent-skills");
     expect(index).toContain(
@@ -525,12 +531,27 @@ describe("agent skill docs", () => {
     expect(regression?.searchText).toContain("scorecards");
   });
 
-  it("includes platform pages, skill catalog, and skill bodies in llms-full.txt", () => {
+  it("includes platform pages, blog posts, skill catalog, and skill bodies in llms-full.txt", () => {
     const bundle = buildLlmsFull("https://example.test");
 
     expect(bundle).toContain("https://example.test/platform/agent-evaluation");
     expect(bundle).toContain(
       "https://example.test/platform/agent-regression-testing",
+    );
+    expect(bundle).toContain(
+      "# AI Agent Evaluation Needs Regression Testing, Not Just Benchmarks",
+    );
+    expect(bundle).toContain(
+      "Source: https://example.test/blog/ai-agent-evaluation-regression-testing",
+    );
+    expect(bundle).toContain(
+      "[AI agent evaluation platform](https://example.test/platform/agent-evaluation)",
+    );
+    expect(bundle).toContain(
+      "[AI agent regression testing](https://example.test/platform/agent-regression-testing)",
+    );
+    expect(bundle).toContain(
+      "[CI/CD agent gates](https://example.test/docs-md/guides/ci-cd-agent-gates)",
     );
     expect(bundle).toContain("# Agent Skills");
     expect(bundle).toContain("name: agentclash-skill-catalog");

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -1,6 +1,11 @@
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
+import {
+  getAllPosts,
+  getPostBySlug,
+  type BlogPostWithContent,
+} from "./blog";
 
 const CONTENT_DIR = path.join(process.cwd(), "content", "docs");
 const AGENT_SKILLS_DIR = path.join(process.cwd(), "content", "agent-skills");
@@ -1427,6 +1432,13 @@ function normalizeMarkdownForExport(content: string, origin: string) {
     .trim();
 }
 
+function normalizeBlogMarkdownForExport(content: string, origin: string) {
+  return normalizeMarkdownForExport(content, origin).replace(
+    /\]\((\/[^)\s]*)\)/g,
+    (_, href) => `](${origin}${href})`,
+  );
+}
+
 export function getDocMarkdownPath(slug: string[] = []) {
   return slug.length === 0 ? "/docs-md" : `/docs-md/${slug.join("/")}`;
 }
@@ -1543,7 +1555,27 @@ export function renderDocMarkdown(doc: DocPage, origin = DOCS_ORIGIN) {
   return lines.join("\n").trim();
 }
 
+export function renderBlogMarkdown(
+  post: BlogPostWithContent,
+  origin = DOCS_ORIGIN,
+) {
+  const lines = [
+    `# ${post.title}`,
+    "",
+    post.description,
+    "",
+    `Source: ${origin}/blog/${post.slug}`,
+    `Published: ${post.date}`,
+    `Author: ${post.author}`,
+    "",
+    normalizeBlogMarkdownForExport(post.content, origin),
+  ];
+
+  return lines.join("\n").trim();
+}
+
 export function buildLlmsIndex(origin = DOCS_ORIGIN) {
+  const blogPosts = getAllPosts();
   const lines = [
     "# AgentClash",
     "",
@@ -1566,6 +1598,12 @@ export function buildLlmsIndex(origin = DOCS_ORIGIN) {
     "",
     ...PUBLIC_PRODUCT_PAGES.map(
       (page) => `- [${page.title}](${origin}${page.href}) - ${page.description}`,
+    ),
+    "",
+    "## Blog posts",
+    "",
+    ...blogPosts.map(
+      (post) => `- [${post.title}](${origin}/blog/${post.slug}) - ${post.description}`,
     ),
     "",
   ];
@@ -1599,6 +1637,9 @@ export function buildLlmsFull(origin = DOCS_ORIGIN) {
   const docs = orderedSlugs
     .map((slug) => getDocBySlug(slug))
     .filter((doc): doc is DocPage => Boolean(doc));
+  const blogPosts = getAllPosts()
+    .map((post) => getPostBySlug(post.slug))
+    .filter((post): post is BlogPostWithContent => Boolean(post));
 
   const lines = [
     "# AgentClash Docs Bundle",
@@ -1613,7 +1654,17 @@ export function buildLlmsFull(origin = DOCS_ORIGIN) {
     ...PUBLIC_PRODUCT_PAGES.map(
       (page) => `- [${page.title}](${origin}${page.href}) - ${page.description}`,
     ),
+    "",
+    "## Blog posts",
+    "",
+    ...blogPosts.map(
+      (post) => `- [${post.title}](${origin}/blog/${post.slug}) - ${post.description}`,
+    ),
   ];
+
+  for (const post of blogPosts) {
+    lines.push("", "---", "", renderBlogMarkdown(post, origin));
+  }
 
   for (const doc of docs) {
     lines.push("", "---", "", renderDocMarkdown(doc, origin));


### PR DESCRIPTION
## Summary
- add public blog post links to `/llms.txt`
- add blog markdown bodies to `/llms-full.txt` with source, publish metadata, and normalized links
- preserve existing docs, agent skills, and platform page coverage

## Review
- Cursor Agent ran a gstack `/review` style pass and recommended shipping as-is.

## Tests
- `pnpm -C web test -- docs.test.ts`
- `pnpm -C web lint`
- `pnpm -C web build`
- built `llms.txt` and `llms-full.txt` smoke checks for the blog URL/title and normalized links

## Scope Guardrails
- no homepage/main landing UI changes
- no shared marketing footer changes
- no authenticated/internal UI changes
- no DB or destructive changes