### PR TITLE
Add blog RSS feed

### DIFF
--- a/testing/codex-seo-blog-rss-feed.md
+++ b/testing/codex-seo-blog-rss-feed.md
@@ -1,0 +1,35 @@
+# codex/seo-blog-rss-feed - Test Contract
+
+## Functional Behavior
+
+- Add a public `/feed.xml` RSS feed for blog posts.
+- Feed includes site title, description, canonical blog URL, and each blog post with title, link, guid, publication date, author, and description.
+- Feed XML escapes text safely for titles/descriptions.
+- No homepage, main landing page UI, shared marketing footer, authenticated/internal UI, DB, or destructive changes.
+
+## Unit Tests
+
+- `pnpm -C web test -- rss.test.ts`
+
+## Integration / Functional Tests
+
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+
+- Built `/feed.xml` route returns RSS XML with the new blog post URL.
+
+## E2E Tests
+
+- N/A - static XML route only.
+
+## Manual / cURL Tests
+
+After deploy:
+
+```bash
+curl -s https://www.agentclash.dev/feed.xml | rg "<rss|/blog/ai-agent-evaluation-regression-testing"
+```
+
+Expected: RSS XML includes the blog feed channel and the new post URL.

--- a/web/src/app/feed.xml/route.ts
+++ b/web/src/app/feed.xml/route.ts
@@ -1,0 +1,12 @@
+import { buildBlogRssFeed } from "@/lib/rss";
+
+export const revalidate = 3600;
+
+export function GET() {
+  return new Response(buildBlogRssFeed(), {
+    headers: {
+      "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+      "Content-Type": "application/rss+xml; charset=utf-8",
+    },
+  });
+}

--- a/web/src/lib/blog.test.ts
+++ b/web/src/lib/blog.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getAllPosts, getPostBySlug } from "./blog";
+import { getAllPosts, getPostBySlug, parseBlogPost } from "./blog";
 
 const SLUG = "ai-agent-evaluation-regression-testing";
 
@@ -41,5 +41,25 @@ describe("blog content", () => {
       date: "2026-05-07",
       author: "Atharva",
     });
+  });
+
+  it("ignores malformed frontmatter when parsing a post", () => {
+    expect(parseBlogPost("broken", "---\ntitle: [\n---\ncontent")).toBeNull();
+  });
+
+  it("ignores posts missing required metadata", () => {
+    expect(
+      parseBlogPost(
+        "missing-author",
+        [
+          "---",
+          "title: Missing Author",
+          "date: 2026-05-07",
+          "description: Missing required author field.",
+          "---",
+          "content",
+        ].join("\n"),
+      ),
+    ).toBeNull();
   });
 });

--- a/web/src/lib/blog.ts
+++ b/web/src/lib/blog.ts
@@ -16,43 +16,73 @@ export type BlogPostWithContent = BlogPost & {
   content: string;
 };
 
+function requiredText(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function parseBlogPost(slug: string, raw: string): BlogPostWithContent | null {
+  try {
+    const { data, content } = matter(raw);
+    const title = requiredText(data.title);
+    const date = requiredText(data.date);
+    const description = requiredText(data.description);
+    const author = requiredText(data.author);
+
+    if (!title || !date || !description || !author) {
+      return null;
+    }
+
+    return {
+      slug,
+      title,
+      date,
+      description,
+      author,
+      content,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function readPostBySlug(slug: string): BlogPostWithContent | null {
+  const filePath = path.join(CONTENT_DIR, `${slug}.mdx`);
+
+  if (!fs.existsSync(filePath)) return null;
+
+  try {
+    return parseBlogPost(slug, fs.readFileSync(filePath, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
 export function getAllPosts(): BlogPost[] {
   if (!fs.existsSync(CONTENT_DIR)) return [];
   const files = fs.readdirSync(CONTENT_DIR).filter((f) => f.endsWith(".mdx"));
-  const posts = files.map((filename) => {
-    const slug = filename.replace(/\.mdx$/, "");
-    const raw = fs.readFileSync(path.join(CONTENT_DIR, filename), "utf-8");
-    const { data } = matter(raw);
-    return {
-      slug,
-      title: data.title as string,
-      date: data.date as string,
-      description: data.description as string,
-      author: data.author as string,
-    };
-  });
+  const posts: BlogPost[] = [];
+
+  for (const filename of files) {
+    const post = readPostBySlug(filename.replace(/\.mdx$/, ""));
+
+    if (!post) continue;
+
+    posts.push({
+      slug: post.slug,
+      title: post.title,
+      date: post.date,
+      description: post.description,
+      author: post.author,
+    });
+  }
+
   return posts.sort((a, b) => (a.date > b.date ? -1 : 1));
 }
 
 export function getPostBySlug(slug: string): BlogPostWithContent | null {
-  const filePath = path.join(CONTENT_DIR, `${slug}.mdx`);
-  if (!fs.existsSync(filePath)) return null;
-  const raw = fs.readFileSync(filePath, "utf-8");
-  const { data, content } = matter(raw);
-  return {
-    slug,
-    title: data.title as string,
-    date: data.date as string,
-    description: data.description as string,
-    author: data.author as string,
-    content,
-  };
+  return readPostBySlug(slug);
 }
 
 export function getAllSlugs(): string[] {
-  if (!fs.existsSync(CONTENT_DIR)) return [];
-  return fs
-    .readdirSync(CONTENT_DIR)
-    .filter((f) => f.endsWith(".mdx"))
-    .map((f) => f.replace(/\.mdx$/, ""));
+  return getAllPosts().map((post) => post.slug);
 }

--- a/web/src/lib/rss.test.ts
+++ b/web/src/lib/rss.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import type { BlogPost } from "./blog";
+import { buildBlogRssFeed, escapeXml, formatRssDate } from "./rss";
+
+const posts = [
+  {
+    slug: "older-post",
+    title: "Older Post",
+    date: "2026-04-01",
+    description: "Earlier release note.",
+    author: "Team",
+  },
+  {
+    slug: "agent-evaluation",
+    title: `Agent Eval & "Replay"`,
+    date: "2026-05-07",
+    description: "Compare <agents> & ship the reliable one.",
+    author: "Atharva",
+  },
+] satisfies BlogPost[];
+
+describe("rss feed", () => {
+  it("escapes XML entities", () => {
+    expect(escapeXml(`A & B <C> "D" 'E'`)).toBe(
+      "A &amp; B &lt;C&gt; &quot;D&quot; &apos;E&apos;",
+    );
+  });
+
+  it("formats calendar dates and ISO timestamps as RSS dates", () => {
+    expect(formatRssDate("2026-05-07")).toBe(
+      "Thu, 07 May 2026 00:00:00 GMT",
+    );
+    expect(formatRssDate("2026-05-07T18:30:00.000Z")).toBe(
+      "Thu, 07 May 2026 18:30:00 GMT",
+    );
+  });
+
+  it("builds a blog RSS feed with provided posts", () => {
+    const feed = buildBlogRssFeed("https://example.test", posts);
+
+    expect(feed).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(feed).toContain('<rss version="2.0"');
+    expect(feed).toContain("<title>AgentClash Blog</title>");
+    expect(feed).toContain("<link>https://example.test/blog</link>");
+    expect(feed).toContain(
+      '<atom:link href="https://example.test/feed.xml" rel="self" type="application/rss+xml" />',
+    );
+    expect(feed).toContain(
+      "<title>Agent Eval &amp; &quot;Replay&quot;</title>",
+    );
+    expect(feed).toContain(
+      "<link>https://example.test/blog/agent-evaluation</link>",
+    );
+    expect(feed).toContain(
+      '<guid isPermaLink="true">https://example.test/blog/agent-evaluation</guid>',
+    );
+    expect(feed).toContain("<pubDate>Thu, 07 May 2026 00:00:00 GMT</pubDate>");
+    expect(feed).toContain("<dc:creator>Atharva</dc:creator>");
+    expect(feed).toContain(
+      "<description>Compare &lt;agents&gt; &amp; ship the reliable one.</description>",
+    );
+  });
+
+  it("omits posts with invalid or incomplete metadata", () => {
+    const feed = buildBlogRssFeed("https://example.test", [
+      posts[0],
+      { ...posts[0], slug: "invalid-date", date: "not-a-date" },
+      {
+        ...posts[0],
+        slug: "missing-title",
+        title: undefined as unknown as string,
+      },
+    ]);
+
+    expect(feed).toContain("<title>Older Post</title>");
+    expect(feed).not.toContain("invalid-date");
+    expect(feed).not.toContain("missing-title");
+  });
+});

--- a/web/src/lib/rss.ts
+++ b/web/src/lib/rss.ts
@@ -1,0 +1,102 @@
+import { getAllPosts, type BlogPost } from "./blog";
+
+const SITE_URL = "https://www.agentclash.dev";
+
+const XML_ENTITIES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&apos;",
+};
+
+export function escapeXml(value: string) {
+  return value.replace(/[&<>"']/g, (char) => XML_ENTITIES[char] ?? char);
+}
+
+function parseRssDate(date: string) {
+  const rssDate = /^\d{4}-\d{2}-\d{2}$/.test(date)
+    ? new Date(`${date}T00:00:00.000Z`)
+    : new Date(date);
+
+  return Number.isNaN(rssDate.getTime()) ? null : rssDate;
+}
+
+export function formatRssDate(date: string) {
+  const rssDate = parseRssDate(date);
+
+  if (!rssDate) {
+    throw new Error(`Invalid blog post date: ${date}`);
+  }
+
+  return rssDate.toUTCString();
+}
+
+function requiredText(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function toRssPost(post: BlogPost) {
+  const slug = requiredText(post.slug);
+  const title = requiredText(post.title);
+  const date = requiredText(post.date);
+  const description = requiredText(post.description);
+  const author = requiredText(post.author);
+  const rssDate = parseRssDate(date);
+
+  if (!slug || !title || !date || !description || !author || !rssDate) {
+    return null;
+  }
+
+  return {
+    slug,
+    title,
+    description,
+    author,
+    pubDate: rssDate.toUTCString(),
+    publishedAtMs: rssDate.getTime(),
+  };
+}
+
+export function buildBlogRssFeed(
+  origin = SITE_URL,
+  posts: BlogPost[] = getAllPosts(),
+) {
+  const rssPosts = posts
+    .map(toRssPost)
+    .filter((post) => post !== null)
+    .sort((a, b) => b.publishedAtMs - a.publishedAtMs);
+  const blogUrl = `${origin}/blog`;
+  const feedUrl = `${origin}/feed.xml`;
+  const lastBuildDate = rssPosts[0]?.pubDate ?? new Date().toUTCString();
+
+  const items = rssPosts.map((post) => {
+    const url = `${origin}/blog/${post.slug}`;
+
+    return [
+      "    <item>",
+      `      <title>${escapeXml(post.title)}</title>`,
+      `      <link>${escapeXml(url)}</link>`,
+      `      <guid isPermaLink="true">${escapeXml(url)}</guid>`,
+      `      <pubDate>${post.pubDate}</pubDate>`,
+      `      <dc:creator>${escapeXml(post.author)}</dc:creator>`,
+      `      <description>${escapeXml(post.description)}</description>`,
+      "    </item>",
+    ].join("\n");
+  });
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">',
+    "  <channel>",
+    "    <title>AgentClash Blog</title>",
+    `    <link>${escapeXml(blogUrl)}</link>`,
+    `    <atom:link href="${escapeXml(feedUrl)}" rel="self" type="application/rss+xml" />`,
+    "    <description>Engineering notes on AI agent evaluation, replayable failures, scorecards, and CI regression gates.</description>",
+    "    <language>en</language>",
+    `    <lastBuildDate>${lastBuildDate}</lastBuildDate>`,
+    ...items,
+    "  </channel>",
+    "</rss>",
+  ].join("\n");
+}


### PR DESCRIPTION
## Summary
- add a public `/feed.xml` RSS feed for blog posts with canonical AgentClash URLs and RSS headers
- harden blog metadata parsing so malformed or incomplete posts are skipped instead of breaking feed generation
- add focused tests for RSS escaping/date handling, fixture-based feed generation, invalid metadata, and malformed frontmatter

## Validation
- `pnpm -C web test -- blog.test.ts rss.test.ts docs.test.ts`
- `pnpm -C web lint`
- `pnpm -C web build`
- `git diff --check`
- built `.next` feed smoke check for `<rss>`, `/blog/ai-agent-evaluation-regression-testing`, and `application/rss+xml`
- Cursor/gstack review: no blockers or majors after fixes

## Scope guardrails
- no homepage/main landing page UI changes
- no shared marketing footer changes
- no authenticated/internal UI changes
- no DB changes
- no destructive actions