### PR TITLE
Add RSS autodiscovery metadata

### DIFF
--- a/testing/codex-seo-rss-autodiscovery.md
+++ b/testing/codex-seo-rss-autodiscovery.md
@@ -1,0 +1,34 @@
+# codex/seo-rss-autodiscovery - Test Contract
+
+## Functional Behavior
+
+- Add RSS autodiscovery metadata for the public blog index and blog post pages.
+- The alternate feed URL points to `/feed.xml` with `application/rss+xml`.
+- The change must not alter visible homepage/landing UI, shared marketing footer, authenticated/internal UI, DB code, or destructive behavior.
+
+## Unit Tests
+
+- `pnpm -C web test -- blog-metadata.test.ts`
+
+## Integration / Functional Tests
+
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+
+- Built blog pages include the RSS autodiscovery link in generated metadata/head output.
+
+## E2E Tests
+
+- N/A - metadata-only SEO discovery change.
+
+## Manual / cURL Tests
+
+After deploy:
+
+```bash
+curl -s https://www.agentclash.dev/blog | rg 'application/rss\\+xml|/feed.xml'
+```
+
+Expected: blog HTML includes an RSS alternate link for `/feed.xml`.

--- a/web/src/app/blog/[slug]/page.tsx
+++ b/web/src/app/blog/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import { JsonLd, articleSchema } from "@/components/marketing/json-ld";
 import { getAllSlugs, getPostBySlug } from "@/lib/blog";
+import { blogRssAlternate } from "@/lib/seo";
 
 type Props = {
   params: Promise<{ slug: string }>;
@@ -22,6 +23,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     description: post.description,
     alternates: {
       canonical: `/blog/${post.slug}`,
+      types: blogRssAlternate,
     },
     openGraph: {
       type: "article",

--- a/web/src/app/blog/blog-metadata.test.ts
+++ b/web/src/app/blog/blog-metadata.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { blogRssAlternate } from "@/lib/seo";
+import { metadata as blogMetadata } from "./page";
+import { generateMetadata } from "./[slug]/page";
+
+describe("blog RSS autodiscovery metadata", () => {
+  it("links the RSS feed from the blog index metadata", () => {
+    expect(blogMetadata.alternates).toMatchObject({
+      canonical: "/blog",
+      types: blogRssAlternate,
+    });
+  });
+
+  it("links the RSS feed from blog post metadata", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({
+        slug: "ai-agent-evaluation-regression-testing",
+      }),
+    });
+
+    expect(metadata.alternates).toMatchObject({
+      canonical: "/blog/ai-agent-evaluation-regression-testing",
+      types: blogRssAlternate,
+    });
+  });
+});

--- a/web/src/app/blog/blog-metadata.test.ts
+++ b/web/src/app/blog/blog-metadata.test.ts
@@ -1,7 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { blogRssAlternate } from "@/lib/seo";
 import { metadata as blogMetadata } from "./page";
 import { generateMetadata } from "./[slug]/page";
+
+const getPostBySlugMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/blog", () => ({
+  getAllPosts: vi.fn(() => []),
+  getAllSlugs: vi.fn(() => []),
+  getPostBySlug: getPostBySlugMock,
+}));
 
 describe("blog RSS autodiscovery metadata", () => {
   it("links the RSS feed from the blog index metadata", () => {
@@ -12,14 +20,23 @@ describe("blog RSS autodiscovery metadata", () => {
   });
 
   it("links the RSS feed from blog post metadata", async () => {
+    getPostBySlugMock.mockReturnValue({
+      slug: "fixture-post",
+      title: "Fixture Post",
+      date: "2026-05-08",
+      description: "Fixture description.",
+      author: "AgentClash",
+      content: "",
+    });
+
     const metadata = await generateMetadata({
       params: Promise.resolve({
-        slug: "ai-agent-evaluation-regression-testing",
+        slug: "fixture-post",
       }),
     });
 
     expect(metadata.alternates).toMatchObject({
-      canonical: "/blog/ai-agent-evaluation-regression-testing",
+      canonical: "/blog/fixture-post",
       types: blogRssAlternate,
     });
   });

--- a/web/src/app/blog/page.tsx
+++ b/web/src/app/blog/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { getAllPosts } from "@/lib/blog";
+import { blogRssAlternate } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "AI Agent Evaluation Blog - AgentClash",
@@ -8,6 +9,7 @@ export const metadata: Metadata = {
     "Engineering notes on AI agent evaluation, head-to-head agent evals, replayable failures, scorecards, and CI regression gates.",
   alternates: {
     canonical: "/blog",
+    types: blogRssAlternate,
   },
 };
 

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+type AlternateTypes = NonNullable<NonNullable<Metadata["alternates"]>["types"]>;
+
+export const blogRssAlternate = {
+  "application/rss+xml": [
+    {
+      title: "AgentClash Blog",
+      url: "/feed.xml",
+    },
+  ],
+} satisfies AlternateTypes;


### PR DESCRIPTION
## Summary
- add a shared RSS alternate metadata descriptor for the blog feed
- attach RSS autodiscovery to the public blog index and individual blog post metadata
- add a focused metadata test for both public blog paths

## Validation
- `pnpm -C web test -- blog-metadata.test.ts`
- `pnpm -C web lint`
- `pnpm -C web build`
- `git diff --check`
- built HTML smoke check for `rel="alternate" type="application/rss+xml"` on `/blog` and a blog post
- Cursor/gstack review: no blockers or majors

## Scope guardrails
- no visible homepage/main landing page UI changes
- no shared marketing footer changes
- no authenticated/internal UI changes
- no DB changes
- no destructive actions