### PR TITLE
Add blog index structured data

### DIFF
--- a/testing/codex-seo-blog-index-structured-data.md
+++ b/testing/codex-seo-blog-index-structured-data.md
@@ -1,0 +1,34 @@
+# codex/seo-blog-index-structured-data - Test Contract
+
+## Functional Behavior
+
+- Add invisible JSON-LD structured data to the public `/blog` index.
+- Structured data describes the AgentClash blog and lists current blog posts with absolute URLs, names, descriptions, and positions.
+- The change must not alter visible homepage/landing UI, shared marketing footer, authenticated/internal UI, DB code, or destructive behavior.
+
+## Unit Tests
+
+- `pnpm -C web test -- json-ld.test.ts blog-index-schema.test.tsx`
+
+## Integration / Functional Tests
+
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+
+- Rendered `/blog` output includes an `application/ld+json` script for the blog index schema.
+
+## E2E Tests
+
+- N/A - public metadata-only SEO change.
+
+## Manual / cURL Tests
+
+After deploy:
+
+```bash
+curl -s https://www.agentclash.dev/blog | rg 'agentclash-blog-index-schema|ItemList|Blog'
+```
+
+Expected: blog HTML includes JSON-LD for the blog index and post list.

--- a/web/src/app/blog/blog-index-schema.test.tsx
+++ b/web/src/app/blog/blog-index-schema.test.tsx
@@ -1,0 +1,76 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SITE_URL } from "@/components/marketing/json-ld";
+import BlogPage from "./page";
+
+vi.mock("@/lib/blog", () => ({
+  getAllPosts: vi.fn(() => [
+    {
+      slug: "agent-evaluation",
+      title: "Agent Evaluation",
+      date: "2026-05-08",
+      description: "Evaluate agents on real tasks.",
+      author: "AgentClash",
+    },
+  ]),
+}));
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function render(element: React.ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(element);
+  });
+}
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe("blog index structured data", () => {
+  it("renders Blog and ItemList JSON-LD for the post index", () => {
+    render(<BlogPage />);
+
+    const script = container?.querySelector<HTMLScriptElement>(
+      "#agentclash-blog-index-schema",
+    );
+    expect(script?.type).toBe("application/ld+json");
+
+    const jsonLd = JSON.parse(script?.textContent ?? "[]") as Array<
+      Record<string, unknown>
+    >;
+
+    expect(jsonLd.map((item) => item["@type"])).toEqual(["Blog", "ItemList"]);
+    expect(jsonLd[0]).toMatchObject({
+      "@type": "Blog",
+      name: "AgentClash Blog",
+      url: `${SITE_URL}/blog`,
+    });
+    expect(jsonLd[1]).toMatchObject({
+      "@type": "ItemList",
+      numberOfItems: 1,
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          position: 1,
+          name: "Agent Evaluation",
+          description: "Evaluate agents on real tasks.",
+          url: `${SITE_URL}/blog/agent-evaluation`,
+          item: {
+            "@id": `${SITE_URL}/blog/agent-evaluation`,
+          },
+        },
+      ],
+    });
+  });
+});

--- a/web/src/app/blog/page.tsx
+++ b/web/src/app/blog/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { JsonLd, blogIndexSchema } from "@/components/marketing/json-ld";
 import { getAllPosts } from "@/lib/blog";
 import { blogRssAlternate } from "@/lib/seo";
 
@@ -17,44 +18,47 @@ export default function BlogPage() {
   const posts = getAllPosts();
 
   return (
-    <main className="min-h-screen flex flex-col items-center px-6 py-16">
-      <h1 className="font-[family-name:var(--font-display)] text-3xl sm:text-4xl text-center tracking-[-0.02em] leading-[1.15]">
-        Blog
-      </h1>
-      <p className="mt-3 text-sm text-white/25">
-        Engineering notes from the team.
-      </p>
+    <>
+      <JsonLd id="agentclash-blog-index-schema" data={blogIndexSchema(posts)} />
+      <main className="min-h-screen flex flex-col items-center px-6 py-16">
+        <h1 className="font-[family-name:var(--font-display)] text-3xl sm:text-4xl text-center tracking-[-0.02em] leading-[1.15]">
+          Blog
+        </h1>
+        <p className="mt-3 text-sm text-white/25">
+          Engineering notes from the team.
+        </p>
 
-      <div className="mt-10 w-full max-w-lg flex flex-col gap-3">
-        {posts.map((post) => (
-          <Link
-            key={post.slug}
-            href={`/blog/${post.slug}`}
-            className="group flex flex-col gap-1 rounded-lg border border-white/[0.08] bg-white/[0.03] px-5 py-4 hover:border-white/15 transition-colors"
-          >
-            <span className="font-[family-name:var(--font-mono)] text-[11px] text-white/40">
-              {post.date} &middot; {post.author}
-            </span>
-            <span className="text-sm font-medium text-white group-hover:text-white/90">
-              {post.title}
-            </span>
-            <span className="text-xs text-white/35 leading-relaxed">
-              {post.description}
-            </span>
-          </Link>
-        ))}
-      </div>
+        <div className="mt-10 w-full max-w-lg flex flex-col gap-3">
+          {posts.map((post) => (
+            <Link
+              key={post.slug}
+              href={`/blog/${post.slug}`}
+              className="group flex flex-col gap-1 rounded-lg border border-white/[0.08] bg-white/[0.03] px-5 py-4 hover:border-white/15 transition-colors"
+            >
+              <span className="font-[family-name:var(--font-mono)] text-[11px] text-white/40">
+                {post.date} &middot; {post.author}
+              </span>
+              <span className="text-sm font-medium text-white group-hover:text-white/90">
+                {post.title}
+              </span>
+              <span className="text-xs text-white/35 leading-relaxed">
+                {post.description}
+              </span>
+            </Link>
+          ))}
+        </div>
 
-      {posts.length === 0 && (
-        <p className="mt-10 text-xs text-white/20">No posts yet.</p>
-      )}
+        {posts.length === 0 && (
+          <p className="mt-10 text-xs text-white/20">No posts yet.</p>
+        )}
 
-      <Link
-        href="/"
-        className="mt-10 text-xs text-white/30 hover:text-white/50 transition-colors"
-      >
-        &larr; Back to AgentClash
-      </Link>
-    </main>
+        <Link
+          href="/"
+          className="mt-10 text-xs text-white/30 hover:text-white/50 transition-colors"
+        >
+          &larr; Back to AgentClash
+        </Link>
+      </main>
+    </>
   );
 }

--- a/web/src/components/marketing/json-ld.test.ts
+++ b/web/src/components/marketing/json-ld.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { productSchema, SITE_URL } from "./json-ld";
+import { blogIndexSchema, productSchema, SITE_URL } from "./json-ld";
 
 describe("productSchema", () => {
   it("builds SoftwareApplication structured data with absolute URLs", () => {
@@ -25,6 +25,51 @@ describe("productSchema", () => {
         price: "0",
         priceCurrency: "USD",
       },
+    });
+  });
+});
+
+describe("blogIndexSchema", () => {
+  it("builds Blog and ItemList structured data with absolute post URLs", () => {
+    const schema = blogIndexSchema([
+      {
+        slug: "agent-evaluation",
+        title: "Agent Evaluation",
+        description: "Evaluate agents on real tasks.",
+        date: "2026-05-08",
+        author: "AgentClash",
+      },
+    ]);
+
+    expect(schema).toHaveLength(2);
+    expect(schema[0]).toMatchObject({
+      "@context": "https://schema.org",
+      "@type": "Blog",
+      name: "AgentClash Blog",
+      url: `${SITE_URL}/blog`,
+      blogPost: [
+        {
+          "@id": `${SITE_URL}/blog/agent-evaluation`,
+        },
+      ],
+    });
+    expect(schema[1]).toMatchObject({
+      "@context": "https://schema.org",
+      "@type": "ItemList",
+      name: "AgentClash Blog Posts",
+      numberOfItems: 1,
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          position: 1,
+          name: "Agent Evaluation",
+          description: "Evaluate agents on real tasks.",
+          url: `${SITE_URL}/blog/agent-evaluation`,
+          item: {
+            "@id": `${SITE_URL}/blog/agent-evaluation`,
+          },
+        },
+      ],
     });
   });
 });

--- a/web/src/components/marketing/json-ld.tsx
+++ b/web/src/components/marketing/json-ld.tsx
@@ -113,3 +113,69 @@ export function articleSchema({
     },
   };
 }
+
+type BlogIndexPost = {
+  slug: string;
+  title: string;
+  description: string;
+  date: string;
+  author: string;
+};
+
+function publisherSchema() {
+  return {
+    "@type": "Organization",
+    name: "AgentClash",
+    logo: {
+      "@type": "ImageObject",
+      url: `${SITE_URL}/icon.svg`,
+    },
+  };
+}
+
+export function blogIndexSchema(
+  posts: BlogIndexPost[],
+): Record<string, unknown>[] {
+  const blogPosts = posts.map((post) => {
+    const url = `${SITE_URL}/blog/${post.slug}`;
+
+    return {
+      id: url,
+      title: post.title,
+      description: post.description,
+      url,
+    };
+  });
+
+  return [
+    {
+      "@context": "https://schema.org",
+      "@type": "Blog",
+      name: "AgentClash Blog",
+      description:
+        "Engineering notes on AI agent evaluation, replayable failures, scorecards, and CI regression gates.",
+      url: `${SITE_URL}/blog`,
+      publisher: publisherSchema(),
+      blogPost: blogPosts.map((post) => ({
+        "@id": post.id,
+      })),
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "ItemList",
+      name: "AgentClash Blog Posts",
+      url: `${SITE_URL}/blog`,
+      numberOfItems: blogPosts.length,
+      itemListElement: blogPosts.map((post, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        name: post.title,
+        description: post.description,
+        url: post.url,
+        item: {
+          "@id": post.id,
+        },
+      })),
+    },
+  ];
+}

--- a/web/src/components/marketing/json-ld.tsx
+++ b/web/src/components/marketing/json-ld.tsx
@@ -75,6 +75,17 @@ export function productSchema({
   };
 }
 
+export function publisherSchema(): Record<string, unknown> {
+  return {
+    "@type": "Organization",
+    name: "AgentClash",
+    logo: {
+      "@type": "ImageObject",
+      url: `${SITE_URL}/icon.svg`,
+    },
+  };
+}
+
 export function articleSchema({
   headline,
   description,
@@ -103,14 +114,7 @@ export function articleSchema({
       "@type": "Person",
       name: authorName,
     },
-    publisher: {
-      "@type": "Organization",
-      name: "AgentClash",
-      logo: {
-        "@type": "ImageObject",
-        url: `${SITE_URL}/icon.svg`,
-      },
-    },
+    publisher: publisherSchema(),
   };
 }
 
@@ -122,17 +126,6 @@ type BlogIndexPost = {
   author: string;
 };
 
-function publisherSchema() {
-  return {
-    "@type": "Organization",
-    name: "AgentClash",
-    logo: {
-      "@type": "ImageObject",
-      url: `${SITE_URL}/icon.svg`,
-    },
-  };
-}
-
 export function blogIndexSchema(
   posts: BlogIndexPost[],
 ): Record<string, unknown>[] {
@@ -140,7 +133,7 @@ export function blogIndexSchema(
     const url = `${SITE_URL}/blog/${post.slug}`;
 
     return {
-      id: url,
+      atId: url,
       title: post.title,
       description: post.description,
       url,
@@ -157,7 +150,7 @@ export function blogIndexSchema(
       url: `${SITE_URL}/blog`,
       publisher: publisherSchema(),
       blogPost: blogPosts.map((post) => ({
-        "@id": post.id,
+        "@id": post.atId,
       })),
     },
     {
@@ -173,7 +166,7 @@ export function blogIndexSchema(
         description: post.description,
         url: post.url,
         item: {
-          "@id": post.id,
+          "@id": post.atId,
         },
       })),
     },


### PR DESCRIPTION
## Summary
- add invisible Blog + ItemList JSON-LD for the public `/blog` index
- use stable `@id` references for post items and list-level name/description/url metadata
- add helper and rendered-page tests with fixture posts

## Validation
- `pnpm -C web test -- json-ld.test.ts blog-index-schema.test.tsx`
- `pnpm -C web lint`
- `pnpm -C web build`
- `git diff --check`
- built `/blog` HTML smoke check for `agentclash-blog-index-schema`, `Blog`, `ItemList`, and the AI agent evaluation post URL
- Cursor/gstack review: no blockers or majors

## Scope guardrails
- no visible homepage/main landing page UI changes
- no shared marketing footer changes
- no authenticated/internal UI changes
- no DB changes
- no destructive actions