### PR TITLE
Add blog post breadcrumb structured data

### DIFF
--- a/testing/codex-seo-blog-post-breadcrumbs.md
+++ b/testing/codex-seo-blog-post-breadcrumbs.md
@@ -1,0 +1,34 @@
+# codex/seo-blog-post-breadcrumbs - Test Contract
+
+## Functional Behavior
+
+- Add invisible breadcrumb JSON-LD to public blog post pages.
+- Breadcrumbs include Home, Blog, and the current post with absolute URLs.
+- The change must not alter visible homepage/landing UI, shared marketing footer, authenticated/internal UI, DB code, or destructive behavior.
+
+## Unit Tests
+
+- `pnpm -C web test -- blog-post-schema.test.tsx`
+
+## Integration / Functional Tests
+
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+
+- Rendered blog post output includes breadcrumb JSON-LD alongside the existing BlogPosting schema.
+
+## E2E Tests
+
+- N/A - public metadata-only SEO change.
+
+## Manual / cURL Tests
+
+After deploy:
+
+```bash
+curl -s https://www.agentclash.dev/blog/ai-agent-evaluation-regression-testing | rg 'BreadcrumbList|BlogPosting'
+```
+
+Expected: blog post HTML includes both article and breadcrumb structured data.

--- a/web/src/app/blog/[slug]/page.tsx
+++ b/web/src/app/blog/[slug]/page.tsx
@@ -2,7 +2,11 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
-import { JsonLd, articleSchema } from "@/components/marketing/json-ld";
+import {
+  JsonLd,
+  articleSchema,
+  breadcrumbSchema,
+} from "@/components/marketing/json-ld";
 import { getAllSlugs, getPostBySlug } from "@/lib/blog";
 import { blogRssAlternate } from "@/lib/seo";
 
@@ -45,13 +49,20 @@ export default async function BlogPostPage({ params }: Props) {
     <main className="min-h-screen flex flex-col items-center px-6 py-16">
       <JsonLd
         id={`agentclash-blog-${post.slug}-schema`}
-        data={articleSchema({
-          headline: post.title,
-          description: post.description,
-          url: `/blog/${post.slug}`,
-          datePublished: post.date,
-          authorName: post.author,
-        })}
+        data={[
+          breadcrumbSchema([
+            { name: "Home", url: "/" },
+            { name: "Blog", url: "/blog" },
+            { name: post.title, url: `/blog/${post.slug}` },
+          ]),
+          articleSchema({
+            headline: post.title,
+            description: post.description,
+            url: `/blog/${post.slug}`,
+            datePublished: post.date,
+            authorName: post.author,
+          }),
+        ]}
       />
       <article className="w-full max-w-lg">
         <header className="mb-8">

--- a/web/src/app/blog/blog-post-schema.test.tsx
+++ b/web/src/app/blog/blog-post-schema.test.tsx
@@ -1,0 +1,91 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SITE_URL } from "@/components/marketing/json-ld";
+import BlogPostPage from "./[slug]/page";
+
+vi.mock("next-mdx-remote/rsc", () => ({
+  MDXRemote: ({ source }: { source: string }) => <div>{source}</div>,
+}));
+
+vi.mock("@/lib/blog", () => ({
+  getAllSlugs: vi.fn(() => ["fixture-post"]),
+  getPostBySlug: vi.fn(() => ({
+    slug: "fixture-post",
+    title: "Fixture Post",
+    date: "2026-05-08",
+    description: "Fixture description.",
+    author: "AgentClash",
+    content: "Fixture content.",
+  })),
+}));
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function render(element: React.ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(element);
+  });
+}
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe("blog post structured data", () => {
+  it("renders breadcrumb and BlogPosting JSON-LD", async () => {
+    const page = await BlogPostPage({
+      params: Promise.resolve({ slug: "fixture-post" }),
+    });
+
+    render(page);
+
+    const script = container?.querySelector<HTMLScriptElement>(
+      "#agentclash-blog-fixture-post-schema",
+    );
+    expect(script?.type).toBe("application/ld+json");
+
+    const jsonLd = JSON.parse(script?.textContent ?? "[]") as Array<
+      Record<string, unknown>
+    >;
+
+    expect(jsonLd.map((item) => item["@type"])).toEqual([
+      "BreadcrumbList",
+      "BlogPosting",
+    ]);
+    expect(jsonLd[0]).toMatchObject({
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        {
+          position: 1,
+          name: "Home",
+          item: `${SITE_URL}/`,
+        },
+        {
+          position: 2,
+          name: "Blog",
+          item: `${SITE_URL}/blog`,
+        },
+        {
+          position: 3,
+          name: "Fixture Post",
+          item: `${SITE_URL}/blog/fixture-post`,
+        },
+      ],
+    });
+    expect(jsonLd[1]).toMatchObject({
+      "@type": "BlogPosting",
+      headline: "Fixture Post",
+      url: `${SITE_URL}/blog/fixture-post`,
+    });
+  });
+});

--- a/web/src/app/blog/blog-post-schema.test.tsx
+++ b/web/src/app/blog/blog-post-schema.test.tsx
@@ -66,16 +66,19 @@ describe("blog post structured data", () => {
       "@type": "BreadcrumbList",
       itemListElement: [
         {
+          "@type": "ListItem",
           position: 1,
           name: "Home",
           item: `${SITE_URL}/`,
         },
         {
+          "@type": "ListItem",
           position: 2,
           name: "Blog",
           item: `${SITE_URL}/blog`,
         },
         {
+          "@type": "ListItem",
           position: 3,
           name: "Fixture Post",
           item: `${SITE_URL}/blog/fixture-post`,


### PR DESCRIPTION
## Summary
- add invisible BreadcrumbList JSON-LD to public blog post pages
- keep existing BlogPosting schema in the same structured-data script
- add a fixture-based render test for breadcrumb + article schema output

## Validation
- `pnpm -C web test -- blog-post-schema.test.tsx`
- `pnpm -C web lint`
- `pnpm -C web build`
- `git diff --check`
- built blog post HTML smoke check for `BreadcrumbList`, `BlogPosting`, and the canonical post URL
- Cursor/gstack review: no blockers or majors

## Scope guardrails
- no visible homepage/main landing page UI changes
- no shared marketing footer changes
- no authenticated/internal UI changes
- no DB changes
- no destructive actions