### PR TITLE
Add docs structured data

### DIFF
--- a/testing/codex-seo-docs-structured-data.md
+++ b/testing/codex-seo-docs-structured-data.md
@@ -1,0 +1,34 @@
+# codex/seo-docs-structured-data - Test Contract
+
+## Functional Behavior
+
+- Add invisible JSON-LD structured data to public docs pages.
+- Structured data includes BreadcrumbList and TechArticle nodes with absolute URLs.
+- The change must not alter visible homepage/landing UI, shared marketing footer, authenticated/internal UI, DB code, or destructive behavior.
+
+## Unit Tests
+
+- `pnpm -C web test -- json-ld.test.ts docs-page-schema.test.tsx`
+
+## Integration / Functional Tests
+
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+
+- Rendered docs output includes BreadcrumbList and TechArticle JSON-LD.
+
+## E2E Tests
+
+- N/A - public metadata-only SEO change.
+
+## Manual / cURL Tests
+
+After deploy:
+
+```bash
+curl -s https://www.agentclash.dev/docs/getting-started/quickstart | rg 'BreadcrumbList|TechArticle'
+```
+
+Expected: docs HTML includes breadcrumb and TechArticle structured data.

--- a/web/src/app/docs/[[...slug]]/page.tsx
+++ b/web/src/app/docs/[[...slug]]/page.tsx
@@ -11,24 +11,11 @@ import {
   getDocBySlug,
   getDocNeighbors,
 } from "@/lib/docs";
+import { docsSchemaId } from "../docs-schema-id";
 
 type Props = {
   params: Promise<{ slug?: string[] }>;
 };
-
-export function docsSchemaId(href: string) {
-  const pathname = href
-    .replace(/^https?:\/\/[^/]+/, "")
-    .replace(/\/+$/, "");
-  const slug = pathname
-    .replace(/^\/docs(?:\/|$)/, "")
-    .replace(/^\/+|\/+$/g, "")
-    .replace(/\//g, "-");
-
-  return `agentclash-docs-${
-    slug || "home"
-  }-schema`;
-}
 
 export function generateStaticParams() {
   return getAllDocSlugs().map((slug) => ({ slug }));

--- a/web/src/app/docs/[[...slug]]/page.tsx
+++ b/web/src/app/docs/[[...slug]]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import { DocsShell } from "@/components/docs/docs-shell";
 import { docsMDXComponents } from "@/components/docs/mdx-components";
+import { JsonLd, docsPageSchema } from "@/components/marketing/json-ld";
 import {
   DOCS_NAV,
   getAllDocSlugs,
@@ -14,6 +15,12 @@ import {
 type Props = {
   params: Promise<{ slug?: string[] }>;
 };
+
+function docsSchemaId(href: string) {
+  return `agentclash-docs-${
+    href.replace(/^\/docs\/?/, "").replace(/\//g, "-") || "home"
+  }-schema`;
+}
 
 export function generateStaticParams() {
   return getAllDocSlugs().map((slug) => ({ slug }));
@@ -50,6 +57,15 @@ export default async function DocsPage({ params }: Props) {
       sections={DOCS_NAV}
       headings={doc.headings}
     >
+      <JsonLd
+        id={docsSchemaId(doc.href)}
+        data={docsPageSchema({
+          title: doc.title,
+          description: doc.description,
+          href: doc.href,
+        })}
+      />
+
       <div className="prose-agentclash-docs">
         <MDXRemote source={doc.content} components={docsMDXComponents} />
       </div>

--- a/web/src/app/docs/[[...slug]]/page.tsx
+++ b/web/src/app/docs/[[...slug]]/page.tsx
@@ -16,9 +16,17 @@ type Props = {
   params: Promise<{ slug?: string[] }>;
 };
 
-function docsSchemaId(href: string) {
+export function docsSchemaId(href: string) {
+  const pathname = href
+    .replace(/^https?:\/\/[^/]+/, "")
+    .replace(/\/+$/, "");
+  const slug = pathname
+    .replace(/^\/docs(?:\/|$)/, "")
+    .replace(/^\/+|\/+$/g, "")
+    .replace(/\//g, "-");
+
   return `agentclash-docs-${
-    href.replace(/^\/docs\/?/, "").replace(/\//g, "-") || "home"
+    slug || "home"
   }-schema`;
 }
 

--- a/web/src/app/docs/docs-page-schema.test.tsx
+++ b/web/src/app/docs/docs-page-schema.test.tsx
@@ -1,0 +1,106 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SITE_URL } from "@/components/marketing/json-ld";
+import DocsPage from "./[[...slug]]/page";
+
+vi.mock("next-mdx-remote/rsc", () => ({
+  MDXRemote: ({ source }: { source: string }) => <div>{source}</div>,
+}));
+
+vi.mock("@/components/docs/docs-shell", () => ({
+  DocsShell: ({ children }: { children: React.ReactNode }) => (
+    <section>{children}</section>
+  ),
+}));
+
+vi.mock("@/components/docs/mdx-components", () => ({
+  docsMDXComponents: {},
+}));
+
+vi.mock("@/lib/docs", () => ({
+  DOCS_NAV: [],
+  getAllDocSlugs: vi.fn(() => [["getting-started", "quickstart"]]),
+  getDocBySlug: vi.fn(() => ({
+    href: "/docs/getting-started/quickstart",
+    title: "Quickstart",
+    description: "Run your first AgentClash eval.",
+    sectionTitle: "Getting Started",
+    headings: [],
+    content: "Fixture docs content.",
+  })),
+  getDocNeighbors: vi.fn(() => ({})),
+}));
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function render(element: React.ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(element);
+  });
+}
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe("docs page structured data", () => {
+  it("renders breadcrumb and TechArticle JSON-LD", async () => {
+    const page = await DocsPage({
+      params: Promise.resolve({ slug: ["getting-started", "quickstart"] }),
+    });
+
+    render(page);
+
+    const script = container?.querySelector<HTMLScriptElement>(
+      "#agentclash-docs-getting-started-quickstart-schema",
+    );
+    expect(script?.type).toBe("application/ld+json");
+
+    const jsonLd = JSON.parse(script?.textContent ?? "[]") as Array<
+      Record<string, unknown>
+    >;
+
+    expect(jsonLd.map((item) => item["@type"])).toEqual([
+      "BreadcrumbList",
+      "TechArticle",
+    ]);
+    expect(jsonLd[0]).toMatchObject({
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          position: 1,
+          name: "Home",
+          item: `${SITE_URL}/`,
+        },
+        {
+          "@type": "ListItem",
+          position: 2,
+          name: "Docs",
+          item: `${SITE_URL}/docs`,
+        },
+        {
+          "@type": "ListItem",
+          position: 3,
+          name: "Quickstart",
+          item: `${SITE_URL}/docs/getting-started/quickstart`,
+        },
+      ],
+    });
+    expect(jsonLd[1]).toMatchObject({
+      "@type": "TechArticle",
+      headline: "Quickstart",
+      url: `${SITE_URL}/docs/getting-started/quickstart`,
+    });
+  });
+});

--- a/web/src/app/docs/docs-page-schema.test.tsx
+++ b/web/src/app/docs/docs-page-schema.test.tsx
@@ -2,7 +2,7 @@ import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SITE_URL } from "@/components/marketing/json-ld";
-import DocsPage from "./[[...slug]]/page";
+import DocsPage, { docsSchemaId } from "./[[...slug]]/page";
 
 vi.mock("next-mdx-remote/rsc", () => ({
   MDXRemote: ({ source }: { source: string }) => <div>{source}</div>,
@@ -54,6 +54,13 @@ afterEach(() => {
 });
 
 describe("docs page structured data", () => {
+  it("normalizes trailing slashes in JSON-LD script ids", () => {
+    expect(docsSchemaId("/docs/api/reference/")).toBe(
+      "agentclash-docs-api-reference-schema",
+    );
+    expect(docsSchemaId("/docs/")).toBe("agentclash-docs-home-schema");
+  });
+
   it("renders breadcrumb and TechArticle JSON-LD", async () => {
     const page = await DocsPage({
       params: Promise.resolve({ slug: ["getting-started", "quickstart"] }),

--- a/web/src/app/docs/docs-page-schema.test.tsx
+++ b/web/src/app/docs/docs-page-schema.test.tsx
@@ -2,7 +2,8 @@ import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SITE_URL } from "@/components/marketing/json-ld";
-import DocsPage, { docsSchemaId } from "./[[...slug]]/page";
+import DocsPage from "./[[...slug]]/page";
+import { docsSchemaId } from "./docs-schema-id";
 
 vi.mock("next-mdx-remote/rsc", () => ({
   MDXRemote: ({ source }: { source: string }) => <div>{source}</div>,

--- a/web/src/app/docs/docs-schema-id.ts
+++ b/web/src/app/docs/docs-schema-id.ts
@@ -1,0 +1,11 @@
+export function docsSchemaId(href: string) {
+  const pathname = href
+    .replace(/^https?:\/\/[^/]+/, "")
+    .replace(/\/+$/, "");
+  const slug = pathname
+    .replace(/^\/docs(?:\/|$)/, "")
+    .replace(/^\/+|\/+$/g, "")
+    .replace(/\//g, "-");
+
+  return `agentclash-docs-${slug || "home"}-schema`;
+}

--- a/web/src/components/marketing/json-ld.test.ts
+++ b/web/src/components/marketing/json-ld.test.ts
@@ -132,13 +132,14 @@ describe("docsPageSchema", () => {
   });
 
   it("uses a two-item breadcrumb for the docs home page", () => {
-    const [breadcrumb] = docsPageSchema({
+    const schema = docsPageSchema({
       title: "AgentClash Docs",
       description: "Documentation for AgentClash.",
-      href: "/docs",
+      href: "/docs/",
     });
 
-    expect(breadcrumb).toMatchObject({
+    expect(schema).toHaveLength(1);
+    expect(schema[0]).toMatchObject({
       "@type": "BreadcrumbList",
       itemListElement: [
         {
@@ -155,5 +156,6 @@ describe("docsPageSchema", () => {
         },
       ],
     });
+    expect(schema.map((item) => item["@type"])).not.toContain("TechArticle");
   });
 });

--- a/web/src/components/marketing/json-ld.test.ts
+++ b/web/src/components/marketing/json-ld.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { blogIndexSchema, productSchema, SITE_URL } from "./json-ld";
+import {
+  blogIndexSchema,
+  docsPageSchema,
+  productSchema,
+  SITE_URL,
+} from "./json-ld";
 
 describe("productSchema", () => {
   it("builds SoftwareApplication structured data with absolute URLs", () => {
@@ -68,6 +73,85 @@ describe("blogIndexSchema", () => {
           item: {
             "@id": `${SITE_URL}/blog/agent-evaluation`,
           },
+        },
+      ],
+    });
+  });
+});
+
+describe("docsPageSchema", () => {
+  it("builds BreadcrumbList and TechArticle structured data for docs pages", () => {
+    const schema = docsPageSchema({
+      title: "Quickstart",
+      description: "Run your first AgentClash eval.",
+      href: "/docs/getting-started/quickstart",
+    });
+
+    expect(schema).toHaveLength(2);
+    expect(schema[0]).toMatchObject({
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          position: 1,
+          name: "Home",
+          item: `${SITE_URL}/`,
+        },
+        {
+          "@type": "ListItem",
+          position: 2,
+          name: "Docs",
+          item: `${SITE_URL}/docs`,
+        },
+        {
+          "@type": "ListItem",
+          position: 3,
+          name: "Quickstart",
+          item: `${SITE_URL}/docs/getting-started/quickstart`,
+        },
+      ],
+    });
+    expect(schema[1]).toMatchObject({
+      "@context": "https://schema.org",
+      "@type": "TechArticle",
+      headline: "Quickstart",
+      description: "Run your first AgentClash eval.",
+      url: `${SITE_URL}/docs/getting-started/quickstart`,
+      mainEntityOfPage: `${SITE_URL}/docs/getting-started/quickstart`,
+      author: {
+        "@type": "Organization",
+        name: "AgentClash",
+      },
+      isPartOf: {
+        "@type": "WebSite",
+        name: "AgentClash Docs",
+        url: `${SITE_URL}/docs`,
+      },
+    });
+  });
+
+  it("uses a two-item breadcrumb for the docs home page", () => {
+    const [breadcrumb] = docsPageSchema({
+      title: "AgentClash Docs",
+      description: "Documentation for AgentClash.",
+      href: "/docs",
+    });
+
+    expect(breadcrumb).toMatchObject({
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          position: 1,
+          name: "Home",
+          item: `${SITE_URL}/`,
+        },
+        {
+          "@type": "ListItem",
+          position: 2,
+          name: "Docs",
+          item: `${SITE_URL}/docs`,
         },
       ],
     });

--- a/web/src/components/marketing/json-ld.tsx
+++ b/web/src/components/marketing/json-ld.tsx
@@ -172,3 +172,45 @@ export function blogIndexSchema(
     },
   ];
 }
+
+export function docsPageSchema({
+  title,
+  description,
+  href,
+}: {
+  title: string;
+  description: string;
+  href: string;
+}): Record<string, unknown>[] {
+  const absoluteUrl = href.startsWith("http") ? href : `${SITE_URL}${href}`;
+  const breadcrumbs =
+    href === "/docs"
+      ? [
+          { name: "Home", url: "/" },
+          { name: "Docs", url: "/docs" },
+        ]
+      : [
+          { name: "Home", url: "/" },
+          { name: "Docs", url: "/docs" },
+          { name: title, url: href },
+        ];
+
+  return [
+    breadcrumbSchema(breadcrumbs),
+    {
+      "@context": "https://schema.org",
+      "@type": "TechArticle",
+      headline: title,
+      description,
+      url: absoluteUrl,
+      mainEntityOfPage: absoluteUrl,
+      author: publisherSchema(),
+      publisher: publisherSchema(),
+      isPartOf: {
+        "@type": "WebSite",
+        name: "AgentClash Docs",
+        url: `${SITE_URL}/docs`,
+      },
+    },
+  ];
+}

--- a/web/src/components/marketing/json-ld.tsx
+++ b/web/src/components/marketing/json-ld.tsx
@@ -183,8 +183,10 @@ export function docsPageSchema({
   href: string;
 }): Record<string, unknown>[] {
   const absoluteUrl = href.startsWith("http") ? href : `${SITE_URL}${href}`;
+  const pathname = href.replace(/^https?:\/\/[^/]+/, "").replace(/\/+$/, "");
+  const isDocsHome = pathname === "/docs";
   const breadcrumbs =
-    href === "/docs"
+    isDocsHome
       ? [
           { name: "Home", url: "/" },
           { name: "Docs", url: "/docs" },
@@ -195,8 +197,11 @@ export function docsPageSchema({
           { name: title, url: href },
         ];
 
+  const schema = [breadcrumbSchema(breadcrumbs)];
+  if (isDocsHome) return schema;
+
   return [
-    breadcrumbSchema(breadcrumbs),
+    ...schema,
     {
       "@context": "https://schema.org",
       "@type": "TechArticle",


### PR DESCRIPTION
## Summary
- add invisible BreadcrumbList + TechArticle JSON-LD for public docs pages
- render docs structured data through the existing JsonLd component
- add helper and rendered-page tests with fixture docs data

## Validation
- `pnpm -C web test -- json-ld.test.ts docs-page-schema.test.tsx`
- `pnpm -C web lint`
- `pnpm -C web build`
- `git diff --check`
- built docs quickstart HTML smoke check for `agentclash-docs-getting-started-quickstart-schema`, `BreadcrumbList`, and `TechArticle`
- Cursor/gstack review: no blockers or majors

## Scope guardrails
- no visible homepage/main landing page UI changes
- no shared marketing footer changes
- no authenticated/internal UI changes
- no DB changes
- no destructive actions