### PR TITLE
Add docs social metadata

### DIFF
--- a/testing/codex-seo-docs-open-graph.md
+++ b/testing/codex-seo-docs-open-graph.md
@@ -1,0 +1,29 @@
+# codex/seo-docs-open-graph - Test Contract
+
+## Functional Behavior
+- Public docs pages keep their existing title, description, and canonical metadata.
+- Public docs pages add page-specific Open Graph metadata using the doc title, doc description, doc href, `website` type, and the existing default social image.
+- Public docs pages add page-specific Twitter metadata using the doc title, doc description, `summary_large_image`, and the existing default Twitter image.
+- The change must be metadata-only: no homepage UI changes, no shared footer changes, no authenticated/internal UI changes, no database changes, and no destructive behavior.
+
+## Unit Tests
+- `web/src/app/docs/docs-metadata.test.ts` verifies `generateMetadata` returns canonical, Open Graph, and Twitter metadata for a fixture docs page.
+- The test verifies missing docs still return an empty metadata object.
+
+## Integration / Functional Tests
+- `pnpm -C web test -- docs-metadata.test.ts`
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+- Build the web app and confirm docs route generation still succeeds.
+- Optionally inspect a built docs HTML page for page-specific OG title/description.
+
+## E2E Tests
+- N/A - metadata-only SEO change with unit and build coverage.
+
+## Manual / cURL Tests
+```bash
+curl -s https://www.agentclash.dev/docs/getting-started/quickstart | rg 'og:title|twitter:title|Quickstart'
+# Expected after deploy: metadata reflects the docs page title/description.
+```

--- a/web/src/app/docs/[[...slug]]/page.tsx
+++ b/web/src/app/docs/[[...slug]]/page.tsx
@@ -26,11 +26,34 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const doc = getDocBySlug(slug);
   if (!doc) return {};
 
+  const title = `${doc.title} — AgentClash Docs`;
+
   return {
-    title: `${doc.title} — AgentClash Docs`,
+    title,
     description: doc.description,
     alternates: {
       canonical: doc.href,
+    },
+    openGraph: {
+      title,
+      description: doc.description,
+      url: doc.href,
+      type: "website",
+      siteName: "AgentClash",
+      images: [
+        {
+          url: "/og-image.png",
+          width: 1200,
+          height: 630,
+          alt: "AgentClash docs for AI agent evaluation workflows.",
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description: doc.description,
+      images: ["/twitter-image.png"],
     },
   };
 }

--- a/web/src/app/docs/docs-metadata.test.ts
+++ b/web/src/app/docs/docs-metadata.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { generateMetadata } from "./[[...slug]]/page";
+
+const getDocBySlugMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/docs", () => ({
+  DOCS_NAV: [],
+  getAllDocSlugs: vi.fn(() => []),
+  getDocBySlug: getDocBySlugMock,
+  getDocNeighbors: vi.fn(() => ({})),
+}));
+
+describe("docs metadata", () => {
+  it("adds page-specific Open Graph and Twitter metadata", async () => {
+    getDocBySlugMock.mockReturnValue({
+      href: "/docs/getting-started/quickstart",
+      title: "Quickstart",
+      description: "Run your first AgentClash eval.",
+    });
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({
+        slug: ["getting-started", "quickstart"],
+      }),
+    });
+
+    expect(metadata).toMatchObject({
+      title: "Quickstart — AgentClash Docs",
+      description: "Run your first AgentClash eval.",
+      alternates: {
+        canonical: "/docs/getting-started/quickstart",
+      },
+      openGraph: {
+        title: "Quickstart — AgentClash Docs",
+        description: "Run your first AgentClash eval.",
+        url: "/docs/getting-started/quickstart",
+        type: "website",
+        siteName: "AgentClash",
+        images: [
+          {
+            url: "/og-image.png",
+            width: 1200,
+            height: 630,
+            alt: "AgentClash docs for AI agent evaluation workflows.",
+          },
+        ],
+      },
+      twitter: {
+        card: "summary_large_image",
+        title: "Quickstart — AgentClash Docs",
+        description: "Run your first AgentClash eval.",
+        images: ["/twitter-image.png"],
+      },
+    });
+  });
+
+  it("returns empty metadata when the doc is missing", async () => {
+    getDocBySlugMock.mockReturnValue(null);
+
+    await expect(
+      generateMetadata({
+        params: Promise.resolve({
+          slug: ["missing"],
+        }),
+      }),
+    ).resolves.toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- add page-specific Open Graph metadata for public docs pages
- add page-specific Twitter metadata for public docs pages
- cover docs metadata generation with fixture tests

## Validation
- `pnpm -C web test -- docs-metadata.test.ts`
- `pnpm -C web lint`
- `pnpm -C web build`
- `git diff --check`
- built docs quickstart HTML smoke check for page-specific OG/Twitter tags
- Cursor/gstack review: no blockers

## Scope guardrails
- no visible homepage/main landing page UI changes
- no shared marketing footer changes
- no authenticated/internal UI changes
- no DB changes
- no destructive actions