### PR TITLE
Add blog social image metadata

### DIFF
--- a/testing/codex-seo-blog-social-images.md
+++ b/testing/codex-seo-blog-social-images.md
@@ -1,0 +1,29 @@
+# codex/seo-blog-social-images - Test Contract
+
+## Functional Behavior
+- Blog post metadata keeps existing title, description, canonical, RSS alternate, article type, published time, and author fields.
+- Blog post metadata adds explicit `siteName` and default Open Graph image data so shared blog links have stable preview images.
+- Blog post metadata adds explicit Twitter card metadata using the post title, post description, and default Twitter image.
+- The change must be metadata-only: no homepage UI changes, no shared footer changes, no authenticated/internal UI changes, no database changes, and no destructive behavior.
+
+## Unit Tests
+- `web/src/app/blog/blog-metadata.test.ts` verifies blog post metadata includes the explicit Open Graph image and Twitter card fields.
+- Existing RSS autodiscovery assertions continue to pass.
+
+## Integration / Functional Tests
+- `pnpm -C web test -- blog-metadata.test.ts`
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+- Build the web app and confirm blog routes still prerender.
+- Optionally inspect a built blog HTML page for page-specific `og:image` and `twitter:image` tags.
+
+## E2E Tests
+- N/A - metadata-only SEO change with unit and build coverage.
+
+## Manual / cURL Tests
+```bash
+curl -s https://www.agentclash.dev/blog/ai-agent-evaluation-regression-testing | rg 'og:image|twitter:image|summary_large_image'
+# Expected after deploy: the blog post emits explicit OG and Twitter image metadata.
+```

--- a/web/src/app/blog/[slug]/page.tsx
+++ b/web/src/app/blog/[slug]/page.tsx
@@ -23,6 +23,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const post = getPostBySlug(slug);
   if (!post) return {};
   const title = `${post.title} — AgentClash`;
+  const imageAlt = `${post.title} — ${post.description}`;
 
   return {
     title,
@@ -44,7 +45,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
           url: "/og-image.png",
           width: 1200,
           height: 630,
-          alt: "AgentClash blog for AI agent evaluation and regression testing.",
+          alt: imageAlt,
         },
       ],
     },
@@ -52,7 +53,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       card: "summary_large_image",
       title,
       description: post.description,
-      images: ["/twitter-image.png"],
+      images: [
+        {
+          url: "/twitter-image.png",
+          alt: imageAlt,
+        },
+      ],
     },
   };
 }

--- a/web/src/app/blog/[slug]/page.tsx
+++ b/web/src/app/blog/[slug]/page.tsx
@@ -22,8 +22,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
   const post = getPostBySlug(slug);
   if (!post) return {};
+  const title = `${post.title} — AgentClash`;
+
   return {
-    title: `${post.title} — AgentClash`,
+    title,
     description: post.description,
     alternates: {
       canonical: `/blog/${post.slug}`,
@@ -31,11 +33,26 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     openGraph: {
       type: "article",
-      title: `${post.title} — AgentClash`,
+      title,
       description: post.description,
       url: `/blog/${post.slug}`,
+      siteName: "AgentClash",
       publishedTime: post.date,
       authors: [post.author],
+      images: [
+        {
+          url: "/og-image.png",
+          width: 1200,
+          height: 630,
+          alt: "AgentClash blog for AI agent evaluation and regression testing.",
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description: post.description,
+      images: ["/twitter-image.png"],
     },
   };
 }

--- a/web/src/app/blog/blog-metadata.test.ts
+++ b/web/src/app/blog/blog-metadata.test.ts
@@ -41,3 +41,50 @@ describe("blog RSS autodiscovery metadata", () => {
     });
   });
 });
+
+describe("blog post social metadata", () => {
+  it("adds explicit Open Graph image and Twitter card metadata", async () => {
+    getPostBySlugMock.mockReturnValue({
+      slug: "fixture-post",
+      title: "Fixture Post",
+      date: "2026-05-08",
+      description: "Fixture description.",
+      author: "AgentClash",
+      content: "",
+    });
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({
+        slug: "fixture-post",
+      }),
+    });
+
+    expect(metadata).toMatchObject({
+      title: "Fixture Post — AgentClash",
+      description: "Fixture description.",
+      openGraph: {
+        type: "article",
+        title: "Fixture Post — AgentClash",
+        description: "Fixture description.",
+        url: "/blog/fixture-post",
+        siteName: "AgentClash",
+        publishedTime: "2026-05-08",
+        authors: ["AgentClash"],
+        images: [
+          {
+            url: "/og-image.png",
+            width: 1200,
+            height: 630,
+            alt: "AgentClash blog for AI agent evaluation and regression testing.",
+          },
+        ],
+      },
+      twitter: {
+        card: "summary_large_image",
+        title: "Fixture Post — AgentClash",
+        description: "Fixture description.",
+        images: ["/twitter-image.png"],
+      },
+    });
+  });
+});

--- a/web/src/app/blog/blog-metadata.test.ts
+++ b/web/src/app/blog/blog-metadata.test.ts
@@ -75,7 +75,7 @@ describe("blog post social metadata", () => {
             url: "/og-image.png",
             width: 1200,
             height: 630,
-            alt: "AgentClash blog for AI agent evaluation and regression testing.",
+            alt: "Fixture Post — Fixture description.",
           },
         ],
       },
@@ -83,7 +83,12 @@ describe("blog post social metadata", () => {
         card: "summary_large_image",
         title: "Fixture Post — AgentClash",
         description: "Fixture description.",
-        images: ["/twitter-image.png"],
+        images: [
+          {
+            url: "/twitter-image.png",
+            alt: "Fixture Post — Fixture description.",
+          },
+        ],
       },
     });
   });


### PR DESCRIPTION
## Summary
- add explicit Open Graph site/image metadata for public blog posts
- add explicit Twitter card metadata for public blog posts
- cover blog post social metadata with fixture tests

## Validation
- `pnpm -C web test -- blog-metadata.test.ts`
- `pnpm -C web lint`
- `pnpm -C web build`
- `git diff --check`
- built blog HTML smoke check for `og:image`, `twitter:image`, and `summary_large_image`
- Cursor/gstack review: no blockers

## Scope guardrails
- no visible homepage/main landing page UI changes
- no shared marketing footer changes
- no authenticated/internal UI changes
- no DB changes
- no destructive actions