### PR TITLE
Add platform social metadata

### DIFF
--- a/testing/codex-seo-platform-social-metadata.md
+++ b/testing/codex-seo-platform-social-metadata.md
@@ -1,0 +1,29 @@
+# codex/seo-platform-social-metadata - Test Contract
+
+## Functional Behavior
+- Public platform pages keep their existing title, description, canonical, and Open Graph title/description/url/type metadata.
+- Public platform pages add explicit Open Graph site name and default image data with page-specific alt text.
+- Public platform pages add explicit Twitter card metadata using the page title, page description, and default Twitter image with page-specific alt text.
+- The change must be metadata-only: no homepage UI changes, no shared footer changes, no authenticated/internal UI changes, no database changes, and no destructive behavior.
+
+## Unit Tests
+- `web/src/app/platform/platform-pages.test.tsx` verifies both platform page metadata exports include explicit Open Graph image and Twitter image metadata.
+- Existing platform structured-data tests continue to pass.
+
+## Integration / Functional Tests
+- `pnpm -C web test -- platform-pages.test.tsx`
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+- Build the web app and confirm platform routes still prerender.
+- Optionally inspect built platform HTML for `og:image`, `twitter:image`, and `summary_large_image`.
+
+## E2E Tests
+- N/A - metadata-only SEO change with unit and build coverage.
+
+## Manual / cURL Tests
+```bash
+curl -s https://www.agentclash.dev/platform/agent-evaluation | rg 'og:image|twitter:image|summary_large_image'
+# Expected after deploy: platform page emits explicit OG and Twitter image metadata.
+```

--- a/web/src/app/platform/agent-evaluation/page.tsx
+++ b/web/src/app/platform/agent-evaluation/page.tsx
@@ -22,6 +22,8 @@ const PAGE_PATH = "/platform/agent-evaluation";
 const PAGE_TITLE = "AI Agent Evaluation Platform for Real Tasks - AgentClash";
 const PAGE_DESCRIPTION =
   "Evaluate AI agents on real tasks with same-tools races, sandboxed execution, replay, scorecards, challenge packs, and CI regression gates.";
+const SOCIAL_IMAGE_ALT =
+  "AgentClash AI agent evaluation platform social preview.";
 
 const faqItems = [
   {
@@ -84,6 +86,26 @@ export const metadata: Metadata = {
     description: PAGE_DESCRIPTION,
     url: PAGE_PATH,
     type: "website",
+    siteName: "AgentClash",
+    images: [
+      {
+        url: "/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: SOCIAL_IMAGE_ALT,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    images: [
+      {
+        url: "/twitter-image.png",
+        alt: SOCIAL_IMAGE_ALT,
+      },
+    ],
   },
 };
 

--- a/web/src/app/platform/agent-regression-testing/page.tsx
+++ b/web/src/app/platform/agent-regression-testing/page.tsx
@@ -22,6 +22,8 @@ const PAGE_PATH = "/platform/agent-regression-testing";
 const PAGE_TITLE = "AI Agent Regression Testing and CI Gates - AgentClash";
 const PAGE_DESCRIPTION =
   "Catch AI agent regressions before release with baseline comparisons, repeatable challenge packs, replay evidence, scorecards, and pull request gates.";
+const SOCIAL_IMAGE_ALT =
+  "AgentClash AI agent regression testing social preview.";
 
 const faqItems = [
   {
@@ -84,6 +86,26 @@ export const metadata: Metadata = {
     description: PAGE_DESCRIPTION,
     url: PAGE_PATH,
     type: "website",
+    siteName: "AgentClash",
+    images: [
+      {
+        url: "/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: SOCIAL_IMAGE_ALT,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    images: [
+      {
+        url: "/twitter-image.png",
+        alt: SOCIAL_IMAGE_ALT,
+      },
+    ],
   },
 };
 

--- a/web/src/app/platform/platform-pages.test.tsx
+++ b/web/src/app/platform/platform-pages.test.tsx
@@ -1,8 +1,12 @@
 import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it } from "vitest";
-import AgentEvaluationPage from "./agent-evaluation/page";
-import AgentRegressionTestingPage from "./agent-regression-testing/page";
+import AgentEvaluationPage, {
+  metadata as agentEvaluationMetadata,
+} from "./agent-evaluation/page";
+import AgentRegressionTestingPage, {
+  metadata as agentRegressionTestingMetadata,
+} from "./agent-regression-testing/page";
 
 let root: Root | null = null;
 let container: HTMLDivElement | null = null;
@@ -77,6 +81,88 @@ describe("platform pages structured data", () => {
       url: "https://www.agentclash.dev/platform/agent-regression-testing",
       applicationCategory: "DeveloperApplication",
       applicationSubCategory: "AI agent regression testing software",
+    });
+  });
+});
+
+describe("platform page social metadata", () => {
+  it("adds explicit social image metadata for agent evaluation", () => {
+    const title = "AI Agent Evaluation Platform for Real Tasks - AgentClash";
+    const description =
+      "Evaluate AI agents on real tasks with same-tools races, sandboxed execution, replay, scorecards, challenge packs, and CI regression gates.";
+
+    expect(agentEvaluationMetadata).toMatchObject({
+      title,
+      description,
+      alternates: {
+        canonical: "/platform/agent-evaluation",
+      },
+      openGraph: {
+        title,
+        description,
+        url: "/platform/agent-evaluation",
+        type: "website",
+        siteName: "AgentClash",
+        images: [
+          {
+            url: "/og-image.png",
+            width: 1200,
+            height: 630,
+            alt: "AgentClash AI agent evaluation platform social preview.",
+          },
+        ],
+      },
+      twitter: {
+        card: "summary_large_image",
+        title,
+        description,
+        images: [
+          {
+            url: "/twitter-image.png",
+            alt: "AgentClash AI agent evaluation platform social preview.",
+          },
+        ],
+      },
+    });
+  });
+
+  it("adds explicit social image metadata for regression testing", () => {
+    const title = "AI Agent Regression Testing and CI Gates - AgentClash";
+    const description =
+      "Catch AI agent regressions before release with baseline comparisons, repeatable challenge packs, replay evidence, scorecards, and pull request gates.";
+
+    expect(agentRegressionTestingMetadata).toMatchObject({
+      title,
+      description,
+      alternates: {
+        canonical: "/platform/agent-regression-testing",
+      },
+      openGraph: {
+        title,
+        description,
+        url: "/platform/agent-regression-testing",
+        type: "website",
+        siteName: "AgentClash",
+        images: [
+          {
+            url: "/og-image.png",
+            width: 1200,
+            height: 630,
+            alt: "AgentClash AI agent regression testing social preview.",
+          },
+        ],
+      },
+      twitter: {
+        card: "summary_large_image",
+        title,
+        description,
+        images: [
+          {
+            url: "/twitter-image.png",
+            alt: "AgentClash AI agent regression testing social preview.",
+          },
+        ],
+      },
     });
   });
 });

--- a/web/src/app/platform/platform-pages.test.tsx
+++ b/web/src/app/platform/platform-pages.test.tsx
@@ -26,6 +26,23 @@ function getJsonLd(id: string) {
   return JSON.parse(script?.textContent ?? "[]") as Array<Record<string, unknown>>;
 }
 
+function getSocialImageAlt(metadata: {
+  openGraph?: unknown;
+  twitter?: unknown;
+}) {
+  const openGraph = metadata.openGraph as {
+    images?: Array<{ alt?: string }>;
+  };
+  const twitter = metadata.twitter as {
+    images?: Array<{ alt?: string }>;
+  };
+
+  return {
+    ogAlt: openGraph.images?.[0]?.alt,
+    twitterAlt: twitter.images?.[0]?.alt,
+  };
+}
+
 afterEach(() => {
   act(() => {
     root?.unmount();
@@ -108,7 +125,6 @@ describe("platform page social metadata", () => {
             url: "/og-image.png",
             width: 1200,
             height: 630,
-            alt: "AgentClash AI agent evaluation platform social preview.",
           },
         ],
       },
@@ -119,11 +135,15 @@ describe("platform page social metadata", () => {
         images: [
           {
             url: "/twitter-image.png",
-            alt: "AgentClash AI agent evaluation platform social preview.",
           },
         ],
       },
     });
+
+    const { ogAlt, twitterAlt } = getSocialImageAlt(agentEvaluationMetadata);
+    expect(ogAlt).toContain("AgentClash");
+    expect(ogAlt).toContain("evaluation platform");
+    expect(twitterAlt).toBe(ogAlt);
   });
 
   it("adds explicit social image metadata for regression testing", () => {
@@ -148,7 +168,6 @@ describe("platform page social metadata", () => {
             url: "/og-image.png",
             width: 1200,
             height: 630,
-            alt: "AgentClash AI agent regression testing social preview.",
           },
         ],
       },
@@ -159,10 +178,17 @@ describe("platform page social metadata", () => {
         images: [
           {
             url: "/twitter-image.png",
-            alt: "AgentClash AI agent regression testing social preview.",
           },
         ],
       },
     });
+
+    const { ogAlt, twitterAlt } = getSocialImageAlt(
+      agentRegressionTestingMetadata,
+    );
+    expect(ogAlt).toContain("AgentClash");
+    expect(ogAlt).toContain("regression testing");
+    expect(twitterAlt).toBe(ogAlt);
+    expect(ogAlt).not.toBe(getSocialImageAlt(agentEvaluationMetadata).ogAlt);
   });
 });


### PR DESCRIPTION
## Summary
- add explicit Open Graph site/image metadata for public platform pages
- add explicit Twitter card metadata for public platform pages
- cover both platform metadata exports in existing platform tests

## Validation
- `pnpm -C web test -- platform-pages.test.tsx`
- `pnpm -C web lint`
- `pnpm -C web build`
- `git diff --check`
- built platform HTML smoke check for `og:image`, `twitter:image`, and `summary_large_image`
- Cursor/gstack review: no blockers

## Scope guardrails
- no visible homepage/main landing page UI changes
- no shared marketing footer changes
- no authenticated/internal UI changes
- no DB changes
- no destructive actions