### PR TITLE
Add blog index social metadata

### DIFF
--- a/testing/codex-seo-blog-index-social-metadata.md
+++ b/testing/codex-seo-blog-index-social-metadata.md
@@ -1,0 +1,29 @@
+# codex/seo-blog-index-social-metadata - Test Contract
+
+## Functional Behavior
+- The public blog index keeps its existing title, description, canonical URL, and RSS autodiscovery metadata.
+- The blog index adds explicit Open Graph metadata using the page title, page description, `/blog` URL, `website` type, site name, and default OG image with blog-specific alt text.
+- The blog index adds explicit Twitter card metadata using the page title, page description, and default Twitter image with blog-specific alt text.
+- The change must be metadata-only: no homepage UI changes, no shared footer changes, no authenticated/internal UI changes, no database changes, and no destructive behavior.
+
+## Unit Tests
+- `web/src/app/blog/blog-metadata.test.ts` verifies the blog index metadata includes explicit Open Graph image and Twitter image metadata.
+- Existing RSS autodiscovery assertions continue to pass.
+
+## Integration / Functional Tests
+- `pnpm -C web test -- blog-metadata.test.ts`
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+- Build the web app and confirm the blog index still prerenders.
+- Optionally inspect built blog HTML for `og:image`, `twitter:image`, and `summary_large_image`.
+
+## E2E Tests
+- N/A - metadata-only SEO change with unit and build coverage.
+
+## Manual / cURL Tests
+```bash
+curl -s https://www.agentclash.dev/blog | rg 'og:image|twitter:image|summary_large_image'
+# Expected after deploy: the blog index emits explicit OG and Twitter image metadata.
+```

--- a/web/src/app/blog/blog-metadata.test.ts
+++ b/web/src/app/blog/blog-metadata.test.ts
@@ -42,6 +42,54 @@ describe("blog RSS autodiscovery metadata", () => {
   });
 });
 
+describe("blog index social metadata", () => {
+  it("adds explicit Open Graph image and Twitter card metadata", () => {
+    expect(blogMetadata).toMatchObject({
+      title: "AI Agent Evaluation Blog - AgentClash",
+      description:
+        "Engineering notes on AI agent evaluation, head-to-head agent evals, replayable failures, scorecards, and CI regression gates.",
+      openGraph: {
+        title: "AI Agent Evaluation Blog - AgentClash",
+        description:
+          "Engineering notes on AI agent evaluation, head-to-head agent evals, replayable failures, scorecards, and CI regression gates.",
+        url: "/blog",
+        type: "website",
+        siteName: "AgentClash",
+        images: [
+          {
+            url: "/og-image.png",
+            width: 1200,
+            height: 630,
+          },
+        ],
+      },
+      twitter: {
+        card: "summary_large_image",
+        title: "AI Agent Evaluation Blog - AgentClash",
+        description:
+          "Engineering notes on AI agent evaluation, head-to-head agent evals, replayable failures, scorecards, and CI regression gates.",
+        images: [
+          {
+            url: "/twitter-image.png",
+          },
+        ],
+      },
+    });
+
+    const openGraph = blogMetadata.openGraph as {
+      images?: Array<{ alt?: string }>;
+    };
+    const twitter = blogMetadata.twitter as {
+      images?: Array<{ alt?: string }>;
+    };
+    const ogAlt = openGraph.images?.[0]?.alt;
+
+    expect(ogAlt).toContain("AgentClash");
+    expect(ogAlt).toContain("evaluation blog");
+    expect(twitter.images?.[0]?.alt).toBe(ogAlt);
+  });
+});
+
 describe("blog post social metadata", () => {
   it("adds explicit Open Graph image and Twitter card metadata", async () => {
     getPostBySlugMock.mockReturnValue({

--- a/web/src/app/blog/page.tsx
+++ b/web/src/app/blog/page.tsx
@@ -4,13 +4,44 @@ import { JsonLd, blogIndexSchema } from "@/components/marketing/json-ld";
 import { getAllPosts } from "@/lib/blog";
 import { blogRssAlternate } from "@/lib/seo";
 
+const PAGE_TITLE = "AI Agent Evaluation Blog - AgentClash";
+const PAGE_DESCRIPTION =
+  "Engineering notes on AI agent evaluation, head-to-head agent evals, replayable failures, scorecards, and CI regression gates.";
+const SOCIAL_IMAGE_ALT =
+  "AgentClash AI agent evaluation blog social preview.";
+
 export const metadata: Metadata = {
-  title: "AI Agent Evaluation Blog - AgentClash",
-  description:
-    "Engineering notes on AI agent evaluation, head-to-head agent evals, replayable failures, scorecards, and CI regression gates.",
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
   alternates: {
     canonical: "/blog",
     types: blogRssAlternate,
+  },
+  openGraph: {
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: "/blog",
+    type: "website",
+    siteName: "AgentClash",
+    images: [
+      {
+        url: "/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: SOCIAL_IMAGE_ALT,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    images: [
+      {
+        url: "/twitter-image.png",
+        alt: SOCIAL_IMAGE_ALT,
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
## Summary
- add explicit Open Graph site/image metadata for the public blog index
- add explicit Twitter card metadata for the public blog index
- preserve RSS autodiscovery and cover the metadata in existing blog tests

## Validation
- `pnpm -C web test -- blog-metadata.test.ts`
- `pnpm -C web lint`
- `pnpm -C web build`
- `git diff --check`
- built blog HTML smoke check for `og:image`, `twitter:image`, and `summary_large_image`
- Cursor/gstack review: no blockers

## Scope guardrails
- no visible homepage/main landing page UI changes
- no shared marketing footer changes
- no authenticated/internal UI changes
- no DB changes
- no destructive actions