### PR TITLE
Add secondary page social metadata

### DIFF
--- a/testing/codex-seo-secondary-page-social-metadata.md
+++ b/testing/codex-seo-secondary-page-social-metadata.md
@@ -1,0 +1,29 @@
+# codex/seo-secondary-page-social-metadata - Test Contract
+
+## Functional Behavior
+- Public `/why` and `/team` pages keep their existing title, description, and canonical metadata.
+- Both pages add explicit Open Graph metadata using page-specific title, description, URL, `website` type, site name, and default OG image with page-specific alt text.
+- Both pages add explicit Twitter card metadata using page-specific title, description, and default Twitter image with page-specific alt text.
+- The change must be metadata-only: no homepage UI changes, no shared footer changes, no authenticated/internal UI changes, no database changes, and no destructive behavior.
+
+## Unit Tests
+- `web/src/app/secondary-pages-metadata.test.ts` verifies `/why` and `/team` metadata exports include explicit Open Graph image and Twitter image metadata.
+
+## Integration / Functional Tests
+- `pnpm -C web test -- secondary-pages-metadata.test.ts`
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+- Build the web app and confirm `/why` and `/team` still prerender.
+- Optionally inspect built HTML for `og:image`, `twitter:image`, and `summary_large_image`.
+
+## E2E Tests
+- N/A - metadata-only SEO change with unit and build coverage.
+
+## Manual / cURL Tests
+```bash
+curl -s https://www.agentclash.dev/why | rg 'og:image|twitter:image|summary_large_image'
+curl -s https://www.agentclash.dev/team | rg 'og:image|twitter:image|summary_large_image'
+# Expected after deploy: both pages emit explicit OG and Twitter image metadata.
+```

--- a/web/src/app/secondary-pages-metadata.test.ts
+++ b/web/src/app/secondary-pages-metadata.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { teamMetadata } from "./team/metadata";
+import { whyMetadata } from "./why/metadata";
+
+describe("secondary public page social metadata", () => {
+  it("adds explicit social metadata for the why page", () => {
+    expect(whyMetadata).toMatchObject({
+      title: "Why AgentClash Exists - AI Agent Evaluation for Real Tasks",
+      description:
+        "Why AgentClash exists: evaluate AI agents on your real tasks with the same tools, same constraints, replayable failures, and regression gates.",
+      alternates: {
+        canonical: "/why",
+      },
+      openGraph: {
+        title: "Why AgentClash Exists - AI Agent Evaluation for Real Tasks",
+        description:
+          "Why AgentClash exists: evaluate AI agents on your real tasks with the same tools, same constraints, replayable failures, and regression gates.",
+        url: "/why",
+        type: "website",
+        siteName: "AgentClash",
+        images: [
+          {
+            url: "/og-image.png",
+            width: 1200,
+            height: 630,
+          },
+        ],
+      },
+      twitter: {
+        card: "summary_large_image",
+        title: "Why AgentClash Exists - AI Agent Evaluation for Real Tasks",
+        description:
+          "Why AgentClash exists: evaluate AI agents on your real tasks with the same tools, same constraints, replayable failures, and regression gates.",
+        images: [
+          {
+            url: "/twitter-image.png",
+          },
+        ],
+      },
+    });
+
+    const openGraph = whyMetadata.openGraph as {
+      images?: Array<{ alt?: string }>;
+    };
+    const twitter = whyMetadata.twitter as {
+      images?: Array<{ alt?: string }>;
+    };
+    expect(openGraph.images?.[0]?.alt).toContain("Why AgentClash");
+    expect(twitter.images?.[0]?.alt).toBe(openGraph.images?.[0]?.alt);
+  });
+
+  it("adds explicit social metadata for the team page", () => {
+    expect(teamMetadata).toMatchObject({
+      title: "Team - AgentClash",
+      description:
+        "Meet the engineers building AgentClash, an open-source AI agent evaluation platform for real-task races, replay, scorecards, and CI gates.",
+      alternates: {
+        canonical: "/team",
+      },
+      openGraph: {
+        title: "Team - AgentClash",
+        description:
+          "Meet the engineers building AgentClash, an open-source AI agent evaluation platform for real-task races, replay, scorecards, and CI gates.",
+        url: "/team",
+        type: "website",
+        siteName: "AgentClash",
+        images: [
+          {
+            url: "/og-image.png",
+            width: 1200,
+            height: 630,
+          },
+        ],
+      },
+      twitter: {
+        card: "summary_large_image",
+        title: "Team - AgentClash",
+        description:
+          "Meet the engineers building AgentClash, an open-source AI agent evaluation platform for real-task races, replay, scorecards, and CI gates.",
+        images: [
+          {
+            url: "/twitter-image.png",
+          },
+        ],
+      },
+    });
+
+    const openGraph = teamMetadata.openGraph as {
+      images?: Array<{ alt?: string }>;
+    };
+    const twitter = teamMetadata.twitter as {
+      images?: Array<{ alt?: string }>;
+    };
+    expect(openGraph.images?.[0]?.alt).toContain("AgentClash team");
+    expect(twitter.images?.[0]?.alt).toBe(openGraph.images?.[0]?.alt);
+  });
+});

--- a/web/src/app/secondary-pages-metadata.test.ts
+++ b/web/src/app/secondary-pages-metadata.test.ts
@@ -17,6 +17,7 @@ describe("secondary public page social metadata", () => {
           "Why AgentClash exists: evaluate AI agents on your real tasks with the same tools, same constraints, replayable failures, and regression gates.",
         url: "/why",
         type: "website",
+        locale: "en_US",
         siteName: "AgentClash",
         images: [
           {
@@ -63,6 +64,7 @@ describe("secondary public page social metadata", () => {
           "Meet the engineers building AgentClash, an open-source AI agent evaluation platform for real-task races, replay, scorecards, and CI gates.",
         url: "/team",
         type: "website",
+        locale: "en_US",
         siteName: "AgentClash",
         images: [
           {

--- a/web/src/app/team/metadata.ts
+++ b/web/src/app/team/metadata.ts
@@ -1,0 +1,40 @@
+import type { Metadata } from "next";
+
+const PAGE_TITLE = "Team - AgentClash";
+const PAGE_DESCRIPTION =
+  "Meet the engineers building AgentClash, an open-source AI agent evaluation platform for real-task races, replay, scorecards, and CI gates.";
+const SOCIAL_IMAGE_ALT = "AgentClash team social preview.";
+
+export const teamMetadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  alternates: {
+    canonical: "/team",
+  },
+  openGraph: {
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: "/team",
+    type: "website",
+    siteName: "AgentClash",
+    images: [
+      {
+        url: "/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: SOCIAL_IMAGE_ALT,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    images: [
+      {
+        url: "/twitter-image.png",
+        alt: SOCIAL_IMAGE_ALT,
+      },
+    ],
+  },
+};

--- a/web/src/app/team/metadata.ts
+++ b/web/src/app/team/metadata.ts
@@ -16,6 +16,7 @@ export const teamMetadata: Metadata = {
     description: PAGE_DESCRIPTION,
     url: "/team",
     type: "website",
+    locale: "en_US",
     siteName: "AgentClash",
     images: [
       {

--- a/web/src/app/team/page.tsx
+++ b/web/src/app/team/page.tsx
@@ -1,15 +1,8 @@
-import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
+import { teamMetadata } from "./metadata";
 
-export const metadata: Metadata = {
-  title: "Team - AgentClash",
-  description:
-    "Meet the engineers building AgentClash, an open-source AI agent evaluation platform for real-task races, replay, scorecards, and CI gates.",
-  alternates: {
-    canonical: "/team",
-  },
-};
+export const metadata = teamMetadata;
 
 const TEAM = [
   { handle: "attharrva15", name: "Atharva", avatar: "https://unavatar.io/x/attharrva15", tagline: "The guy who runs on caffeine and PRs" },

--- a/web/src/app/why/metadata.ts
+++ b/web/src/app/why/metadata.ts
@@ -1,0 +1,40 @@
+import type { Metadata } from "next";
+
+const PAGE_TITLE = "Why AgentClash Exists - AI Agent Evaluation for Real Tasks";
+const PAGE_DESCRIPTION =
+  "Why AgentClash exists: evaluate AI agents on your real tasks with the same tools, same constraints, replayable failures, and regression gates.";
+const SOCIAL_IMAGE_ALT = "Why AgentClash exists social preview.";
+
+export const whyMetadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  alternates: {
+    canonical: "/why",
+  },
+  openGraph: {
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: "/why",
+    type: "website",
+    siteName: "AgentClash",
+    images: [
+      {
+        url: "/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: SOCIAL_IMAGE_ALT,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    images: [
+      {
+        url: "/twitter-image.png",
+        alt: SOCIAL_IMAGE_ALT,
+      },
+    ],
+  },
+};

--- a/web/src/app/why/metadata.ts
+++ b/web/src/app/why/metadata.ts
@@ -16,6 +16,7 @@ export const whyMetadata: Metadata = {
     description: PAGE_DESCRIPTION,
     url: "/why",
     type: "website",
+    locale: "en_US",
     siteName: "AgentClash",
     images: [
       {

--- a/web/src/app/why/page.tsx
+++ b/web/src/app/why/page.tsx
@@ -1,16 +1,9 @@
-import type { Metadata } from "next";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { ClashMark } from "@/components/marketing/clash-mark";
+import { whyMetadata } from "./metadata";
 
-export const metadata: Metadata = {
-  title: "Why AgentClash Exists - AI Agent Evaluation for Real Tasks",
-  description:
-    "Why AgentClash exists: evaluate AI agents on your real tasks with the same tools, same constraints, replayable failures, and regression gates.",
-  alternates: {
-    canonical: "/why",
-  },
-};
+export const metadata = whyMetadata;
 
 export default function WhyWeBuiltThisPage() {
   return (


### PR DESCRIPTION
## Summary
- add explicit Open Graph site/image metadata for /why and /team
- add explicit Twitter card metadata for /why and /team
- keep metadata in small sidecar modules and cover it with focused tests

## Validation
- `pnpm -C web test -- secondary-pages-metadata.test.ts`
- `pnpm -C web lint`
- `pnpm -C web build`
- `git diff --check`
- built /why and /team HTML smoke check for `og:image`, `twitter:image`, and `summary_large_image`
- Cursor/gstack review: no blockers; medium test-import concern resolved by sidecar metadata modules

## Scope guardrails
- no visible homepage/main landing page UI changes
- no shared marketing footer changes
- no authenticated/internal UI changes
- no DB changes
- no destructive actions