### PR TITLE
Keep page Open Graph locale explicit

### DIFF
--- a/testing/codex-seo-og-locale-consistency.md
+++ b/testing/codex-seo-og-locale-consistency.md
@@ -1,0 +1,31 @@
+# codex/seo-og-locale-consistency - Test Contract
+
+## Functional Behavior
+- Public page-level Open Graph metadata should preserve `locale: "en_US"` when it overrides root Open Graph metadata.
+- Blog index, blog post, docs pages, and platform pages add explicit `openGraph.locale`.
+- Existing title, description, canonical, RSS, social-image, and structured-data behavior must remain unchanged.
+- The change must be metadata-only: no homepage UI changes, no shared footer changes, no authenticated/internal UI changes, no database changes, and no destructive behavior.
+
+## Unit Tests
+- `web/src/app/blog/blog-metadata.test.ts` verifies blog index and blog post Open Graph metadata include `locale: "en_US"`.
+- `web/src/app/docs/docs-metadata.test.ts` verifies docs Open Graph metadata includes `locale: "en_US"`.
+- `web/src/app/platform/platform-pages.test.tsx` verifies both platform page metadata exports include `locale: "en_US"`.
+
+## Integration / Functional Tests
+- `pnpm -C web test -- blog-metadata.test.ts docs-metadata.test.ts platform-pages.test.tsx`
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+- Build the web app and confirm representative blog/docs/platform pages still prerender.
+
+## E2E Tests
+- N/A - metadata-only SEO change with unit and build coverage.
+
+## Manual / cURL Tests
+```bash
+curl -s https://www.agentclash.dev/blog | rg 'og:locale'
+curl -s https://www.agentclash.dev/docs/getting-started/quickstart | rg 'og:locale'
+curl -s https://www.agentclash.dev/platform/agent-evaluation | rg 'og:locale'
+# Expected after deploy: all pages emit og:locale en_US.
+```

--- a/web/src/app/blog/[slug]/page.tsx
+++ b/web/src/app/blog/[slug]/page.tsx
@@ -37,6 +37,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title,
       description: post.description,
       url: `/blog/${post.slug}`,
+      locale: "en_US",
       siteName: "AgentClash",
       publishedTime: post.date,
       authors: [post.author],

--- a/web/src/app/blog/blog-metadata.test.ts
+++ b/web/src/app/blog/blog-metadata.test.ts
@@ -54,6 +54,7 @@ describe("blog index social metadata", () => {
           "Engineering notes on AI agent evaluation, head-to-head agent evals, replayable failures, scorecards, and CI regression gates.",
         url: "/blog",
         type: "website",
+        locale: "en_US",
         siteName: "AgentClash",
         images: [
           {
@@ -115,6 +116,7 @@ describe("blog post social metadata", () => {
         title: "Fixture Post — AgentClash",
         description: "Fixture description.",
         url: "/blog/fixture-post",
+        locale: "en_US",
         siteName: "AgentClash",
         publishedTime: "2026-05-08",
         authors: ["AgentClash"],

--- a/web/src/app/blog/page.tsx
+++ b/web/src/app/blog/page.tsx
@@ -22,6 +22,7 @@ export const metadata: Metadata = {
     description: PAGE_DESCRIPTION,
     url: "/blog",
     type: "website",
+    locale: "en_US",
     siteName: "AgentClash",
     images: [
       {

--- a/web/src/app/docs/[[...slug]]/page.tsx
+++ b/web/src/app/docs/[[...slug]]/page.tsx
@@ -39,6 +39,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       description: doc.description,
       url: doc.href,
       type: "website",
+      locale: "en_US",
       siteName: "AgentClash",
       images: [
         {

--- a/web/src/app/docs/docs-metadata.test.ts
+++ b/web/src/app/docs/docs-metadata.test.ts
@@ -35,6 +35,7 @@ describe("docs metadata", () => {
         description: "Run your first AgentClash eval.",
         url: "/docs/getting-started/quickstart",
         type: "website",
+        locale: "en_US",
         siteName: "AgentClash",
         images: [
           {

--- a/web/src/app/platform/agent-evaluation/page.tsx
+++ b/web/src/app/platform/agent-evaluation/page.tsx
@@ -86,6 +86,7 @@ export const metadata: Metadata = {
     description: PAGE_DESCRIPTION,
     url: PAGE_PATH,
     type: "website",
+    locale: "en_US",
     siteName: "AgentClash",
     images: [
       {

--- a/web/src/app/platform/agent-regression-testing/page.tsx
+++ b/web/src/app/platform/agent-regression-testing/page.tsx
@@ -86,6 +86,7 @@ export const metadata: Metadata = {
     description: PAGE_DESCRIPTION,
     url: PAGE_PATH,
     type: "website",
+    locale: "en_US",
     siteName: "AgentClash",
     images: [
       {

--- a/web/src/app/platform/platform-pages.test.tsx
+++ b/web/src/app/platform/platform-pages.test.tsx
@@ -119,6 +119,7 @@ describe("platform page social metadata", () => {
         description,
         url: "/platform/agent-evaluation",
         type: "website",
+        locale: "en_US",
         siteName: "AgentClash",
         images: [
           {
@@ -162,6 +163,7 @@ describe("platform page social metadata", () => {
         description,
         url: "/platform/agent-regression-testing",
         type: "website",
+        locale: "en_US",
         siteName: "AgentClash",
         images: [
           {


### PR DESCRIPTION
## Summary
- add explicit `openGraph.locale: en_US` to blog index and blog post metadata
- add explicit `openGraph.locale: en_US` to docs page metadata
- add explicit `openGraph.locale: en_US` to platform page metadata

## Validation
- `pnpm -C web test -- blog-metadata.test.ts docs-metadata.test.ts platform-pages.test.tsx`
- `pnpm -C web lint`
- `pnpm -C web build`
- `git diff --check`
- built blog/docs/platform HTML smoke check for `og:locale` and `en_US`
- Cursor/gstack review: no blockers

## Scope guardrails
- no visible homepage/main landing page UI changes
- no shared marketing footer changes
- no authenticated/internal UI changes
- no DB changes
- no destructive actions