### PR TITLE
Add docs social image alt metadata

### DIFF
--- a/testing/codex-seo-docs-social-image-alt.md
+++ b/testing/codex-seo-docs-social-image-alt.md
@@ -1,0 +1,28 @@
+# codex/seo-docs-social-image-alt - Test Contract
+
+## Functional Behavior
+- Public docs pages keep existing title, description, canonical, Open Graph, Twitter, and structured-data behavior.
+- Docs page social image alt text becomes page-specific from the doc title and description.
+- Twitter image metadata uses an object with `url` and `alt`, matching the blog and platform metadata shape.
+- The change must be metadata-only: no homepage UI changes, no shared footer changes, no authenticated/internal UI changes, no database changes, and no destructive behavior.
+
+## Unit Tests
+- `web/src/app/docs/docs-metadata.test.ts` verifies docs Open Graph image alt and Twitter image alt match the docs page title/description.
+
+## Integration / Functional Tests
+- `pnpm -C web test -- docs-metadata.test.ts`
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+- Build the web app and confirm a docs page still prerenders.
+- Optionally inspect built docs HTML for Twitter image metadata.
+
+## E2E Tests
+- N/A - metadata-only SEO change with unit and build coverage.
+
+## Manual / cURL Tests
+```bash
+curl -s https://www.agentclash.dev/docs/getting-started/quickstart | rg 'twitter:image|twitter:image:alt|og:image:alt'
+# Expected after deploy: docs social images include page-specific alt metadata.
+```

--- a/web/src/app/docs/[[...slug]]/page.tsx
+++ b/web/src/app/docs/[[...slug]]/page.tsx
@@ -27,7 +27,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!doc) return {};
 
   const title = `${doc.title} — AgentClash Docs`;
-  const description = doc.description.trim();
+  const description =
+    typeof doc.description === "string" ? doc.description.trim() : "";
   const imageAlt = description ? `${doc.title} — ${description}` : doc.title;
 
   return {

--- a/web/src/app/docs/[[...slug]]/page.tsx
+++ b/web/src/app/docs/[[...slug]]/page.tsx
@@ -27,6 +27,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!doc) return {};
 
   const title = `${doc.title} — AgentClash Docs`;
+  const description = doc.description.trim();
+  const imageAlt = description ? `${doc.title} — ${description}` : doc.title;
 
   return {
     title,
@@ -46,7 +48,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
           url: "/og-image.png",
           width: 1200,
           height: 630,
-          alt: "AgentClash docs for AI agent evaluation workflows.",
+          alt: imageAlt,
         },
       ],
     },
@@ -54,7 +56,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       card: "summary_large_image",
       title,
       description: doc.description,
-      images: ["/twitter-image.png"],
+      images: [
+        {
+          url: "/twitter-image.png",
+          alt: imageAlt,
+        },
+      ],
     },
   };
 }

--- a/web/src/app/docs/docs-metadata.test.ts
+++ b/web/src/app/docs/docs-metadata.test.ts
@@ -42,7 +42,7 @@ describe("docs metadata", () => {
             url: "/og-image.png",
             width: 1200,
             height: 630,
-            alt: "AgentClash docs for AI agent evaluation workflows.",
+            alt: "Quickstart — Run your first AgentClash eval.",
           },
         ],
       },
@@ -50,7 +50,12 @@ describe("docs metadata", () => {
         card: "summary_large_image",
         title: "Quickstart — AgentClash Docs",
         description: "Run your first AgentClash eval.",
-        images: ["/twitter-image.png"],
+        images: [
+          {
+            url: "/twitter-image.png",
+            alt: "Quickstart — Run your first AgentClash eval.",
+          },
+        ],
       },
     });
   });
@@ -65,5 +70,28 @@ describe("docs metadata", () => {
         }),
       }),
     ).resolves.toEqual({});
+  });
+
+  it("falls back to title-only social image alt when description is empty", async () => {
+    getDocBySlugMock.mockReturnValue({
+      href: "/docs/reference/cli",
+      title: "CLI",
+      description: "",
+    });
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({
+        slug: ["reference", "cli"],
+      }),
+    });
+    const openGraph = metadata.openGraph as {
+      images?: Array<{ alt?: string }>;
+    };
+    const twitter = metadata.twitter as {
+      images?: Array<{ alt?: string }>;
+    };
+
+    expect(openGraph.images?.[0]?.alt).toBe("CLI");
+    expect(twitter.images?.[0]?.alt).toBe("CLI");
   });
 });

--- a/web/src/app/docs/docs-metadata.test.ts
+++ b/web/src/app/docs/docs-metadata.test.ts
@@ -94,4 +94,26 @@ describe("docs metadata", () => {
     expect(openGraph.images?.[0]?.alt).toBe("CLI");
     expect(twitter.images?.[0]?.alt).toBe("CLI");
   });
+
+  it("falls back to title-only social image alt when description is missing", async () => {
+    getDocBySlugMock.mockReturnValue({
+      href: "/docs/reference/config",
+      title: "Config",
+    });
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({
+        slug: ["reference", "config"],
+      }),
+    });
+    const openGraph = metadata.openGraph as {
+      images?: Array<{ alt?: string }>;
+    };
+    const twitter = metadata.twitter as {
+      images?: Array<{ alt?: string }>;
+    };
+
+    expect(openGraph.images?.[0]?.alt).toBe("Config");
+    expect(twitter.images?.[0]?.alt).toBe("Config");
+  });
 });


### PR DESCRIPTION
## Summary
- make docs Open Graph image alt text page-specific
- switch docs Twitter image metadata to include alt text
- add fallback coverage for empty docs descriptions

## Validation
- `pnpm -C web test -- docs-metadata.test.ts`
- `pnpm -C web lint`
- `pnpm -C web build`
- `git diff --check`
- built docs HTML smoke check for `og:image:alt`, `twitter:image`, and `twitter:image:alt`
- Cursor/gstack review: no blockers

## Scope guardrails
- no visible homepage/main landing page UI changes
- no shared marketing footer changes
- no authenticated/internal UI changes
- no DB changes
- no destructive actions