### PR TITLE
Cover sitemap discovery routes

### DIFF
--- a/testing/codex-seo-sitemap-test-coverage.md
+++ b/testing/codex-seo-sitemap-test-coverage.md
@@ -1,0 +1,27 @@
+# codex/seo-sitemap-test-coverage - Test Contract
+
+## Functional Behavior
+- The public sitemap continues to include the homepage, blog index, platform pages, docs pages, blog posts, and machine-readable `llms` files.
+- Sitemap entries preserve expected priorities for the highest-value SEO surfaces.
+- The change must be test-only: no homepage UI changes, no shared footer changes, no authenticated/internal UI changes, no database changes, and no destructive behavior.
+
+## Unit Tests
+- `web/src/app/sitemap.test.ts` verifies representative sitemap entries for homepage, blog, platform pages, docs, blog posts, and `llms` files.
+- The test mocks blog posts and docs paths to keep assertions deterministic.
+
+## Integration / Functional Tests
+- `pnpm -C web test -- sitemap.test.ts`
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+- N/A - test-only guardrail change.
+
+## E2E Tests
+- N/A - test-only guardrail change.
+
+## Manual / cURL Tests
+```bash
+curl -s https://www.agentclash.dev/sitemap.xml | rg 'platform/agent-evaluation|docs|get-started|llms.txt|blog/'
+# Expected: representative public discovery URLs remain present.
+```

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import sitemap from "./sitemap";
+
+vi.mock("@/lib/blog", () => ({
+  getAllPosts: vi.fn(() => [
+    {
+      slug: "ai-agent-evaluation-regression-testing",
+      date: "2026-05-07",
+    },
+  ]),
+}));
+
+vi.mock("@/lib/docs", () => ({
+  DOCS_ORIGIN: "https://www.agentclash.dev",
+  getAllDocPaths: vi.fn(() => [
+    "/docs",
+    "/docs/getting-started/quickstart",
+  ]),
+}));
+
+describe("sitemap", () => {
+  it("keeps core public discovery surfaces indexed", () => {
+    const entries = sitemap();
+    const byUrl = new Map(entries.map((entry) => [entry.url, entry]));
+
+    expect(byUrl.get("https://www.agentclash.dev")).toMatchObject({
+      changeFrequency: "weekly",
+      priority: 1,
+    });
+    expect(byUrl.get("https://www.agentclash.dev/blog")).toMatchObject({
+      changeFrequency: "weekly",
+      priority: 0.8,
+    });
+    expect(byUrl.get("https://www.agentclash.dev/why")).toMatchObject({
+      changeFrequency: "monthly",
+      priority: 0.7,
+    });
+    expect(byUrl.get("https://www.agentclash.dev/team")).toMatchObject({
+      changeFrequency: "monthly",
+      priority: 0.5,
+    });
+    expect(
+      byUrl.get("https://www.agentclash.dev/platform/agent-evaluation"),
+    ).toMatchObject({
+      changeFrequency: "monthly",
+      priority: 0.85,
+    });
+    expect(
+      byUrl.get(
+        "https://www.agentclash.dev/platform/agent-regression-testing",
+      ),
+    ).toMatchObject({
+      changeFrequency: "monthly",
+      priority: 0.82,
+    });
+    expect(byUrl.get("https://www.agentclash.dev/llms.txt")).toMatchObject({
+      changeFrequency: "weekly",
+      priority: 0.6,
+    });
+    expect(
+      byUrl.get("https://www.agentclash.dev/llms-full.txt"),
+    ).toMatchObject({
+      changeFrequency: "weekly",
+      priority: 0.55,
+    });
+  });
+
+  it("includes docs pages and blog posts from source readers", () => {
+    const entries = sitemap();
+    const byUrl = new Map(entries.map((entry) => [entry.url, entry]));
+
+    expect(byUrl.get("https://www.agentclash.dev/docs")).toMatchObject({
+      changeFrequency: "weekly",
+      priority: 0.85,
+    });
+    expect(
+      byUrl.get("https://www.agentclash.dev/docs/getting-started/quickstart"),
+    ).toMatchObject({
+      changeFrequency: "weekly",
+      priority: 0.75,
+    });
+    expect(
+      byUrl.get(
+        "https://www.agentclash.dev/blog/ai-agent-evaluation-regression-testing",
+      ),
+    ).toMatchObject({
+      lastModified: new Date("2026-05-07"),
+      changeFrequency: "monthly",
+      priority: 0.7,
+    });
+  });
+});

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import sitemap from "./sitemap";
 
 vi.mock("@/lib/blog", () => ({
@@ -19,6 +19,10 @@ vi.mock("@/lib/docs", () => ({
 }));
 
 describe("sitemap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("keeps core public discovery surfaces indexed", () => {
     const entries = sitemap();
     const byUrl = new Map(entries.map((entry) => [entry.url, entry]));


### PR DESCRIPTION
## Summary
- add a deterministic sitemap unit test for public discovery routes
- cover homepage, blog, why/team, platform pages, docs, blog posts, and llms discovery files
- add the review-checkpoint test contract for this SEO guardrail

## Validation
- pnpm -C web test -- sitemap.test.ts
- pnpm -C web lint
- pnpm -C web build
- git diff --check
- Cursor/gstack review: clean for merge readiness; adopted low-severity /why and /team coverage suggestion

## Guardrails
- No visible homepage UI changes
- No shared footer changes
- No authenticated/internal UI changes
- No DB or destructive changes