### PR TITLE
Cover robots crawler policy

### DIFF
--- a/testing/codex-seo-robots-ai-crawler-policy.md
+++ b/testing/codex-seo-robots-ai-crawler-policy.md
@@ -1,0 +1,26 @@
+# codex/seo-robots-ai-crawler-policy - Test Contract
+
+## Functional Behavior
+- `robots.txt` continues to allow public crawlers to access the site.
+- `robots.txt` continues to advertise the canonical production sitemap URL.
+- The change must be test-only: no homepage UI changes, no shared footer changes, no authenticated/internal UI changes, no database changes, and no destructive behavior.
+
+## Unit Tests
+- `web/src/app/robots.test.ts` verifies the exported robots metadata allows `*` and points at `https://www.agentclash.dev/sitemap.xml`.
+
+## Integration / Functional Tests
+- `pnpm -C web test -- robots.test.ts`
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+- N/A - test-only guardrail change.
+
+## E2E Tests
+- N/A - test-only guardrail change.
+
+## Manual / cURL Tests
+```bash
+curl -s https://www.agentclash.dev/robots.txt | rg 'Allow: /|Sitemap: https://www.agentclash.dev/sitemap.xml'
+# Expected: public crawling remains allowed and the sitemap URL is present.
+```

--- a/web/src/app/robots.test.ts
+++ b/web/src/app/robots.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import robots from "./robots";
+
+describe("robots", () => {
+  it("keeps public crawling open and advertises the canonical sitemap", () => {
+    expect(robots()).toEqual({
+      rules: [{ userAgent: "*", allow: "/" }],
+      sitemap: "https://www.agentclash.dev/sitemap.xml",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a deterministic unit test for the public robots metadata
- lock the wildcard allow rule and canonical sitemap URL
- add the review-checkpoint test contract for this SEO guardrail

## Validation
- pnpm -C web test -- robots.test.ts
- pnpm -C web lint
- pnpm -C web build
- git diff --check
- Cursor/gstack review: no blockers; strict object assertion kept intentionally as crawler-policy guardrail

## Guardrails
- No visible homepage UI changes
- No shared footer changes
- No authenticated/internal UI changes
- No DB or destructive changes