### PR TITLE
Add blog article schema image

### DIFF
--- a/testing/codex-seo-blog-article-schema-refinement.md
+++ b/testing/codex-seo-blog-article-schema-refinement.md
@@ -1,0 +1,26 @@
+# codex/seo-blog-article-schema-refinement - Test Contract
+
+## Functional Behavior
+- Blog post `BlogPosting` JSON-LD includes an article image using the existing AgentClash Open Graph image asset.
+- Existing blog post structured data remains intact: breadcrumb, headline, URL, publication date, author, and publisher.
+- The change must be crawler-only: no homepage UI changes, no shared footer changes, no authenticated/internal UI changes, no database changes, and no destructive behavior.
+
+## Unit Tests
+- `web/src/app/blog/blog-post-schema.test.tsx` verifies the rendered blog post JSON-LD includes the image object.
+
+## Integration / Functional Tests
+- `pnpm -C web test -- blog-post-schema.test.tsx`
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+- N/A - structured data only.
+
+## E2E Tests
+- N/A - structured data only.
+
+## Manual / cURL Tests
+```bash
+curl -s https://www.agentclash.dev/blog/ai-agent-evaluation-regression-testing | rg 'BlogPosting|og-image.png'
+# Expected: blog article structured data includes the existing AgentClash article image.
+```

--- a/web/src/app/blog/blog-post-schema.test.tsx
+++ b/web/src/app/blog/blog-post-schema.test.tsx
@@ -88,7 +88,25 @@ describe("blog post structured data", () => {
     expect(jsonLd[1]).toMatchObject({
       "@type": "BlogPosting",
       headline: "Fixture Post",
+      description: "Fixture description.",
       url: `${SITE_URL}/blog/fixture-post`,
+      mainEntityOfPage: `${SITE_URL}/blog/fixture-post`,
+      image: {
+        "@type": "ImageObject",
+        url: `${SITE_URL}/og-image.png`,
+        width: 1200,
+        height: 630,
+      },
+      datePublished: "2026-05-08",
+      dateModified: "2026-05-08",
+      author: {
+        "@type": "Person",
+        name: "AgentClash",
+      },
+      publisher: {
+        "@type": "Organization",
+        name: "AgentClash",
+      },
     });
   });
 });

--- a/web/src/components/marketing/json-ld.tsx
+++ b/web/src/components/marketing/json-ld.tsx
@@ -108,6 +108,12 @@ export function articleSchema({
     description,
     url: absoluteUrl,
     mainEntityOfPage: absoluteUrl,
+    image: {
+      "@type": "ImageObject",
+      url: `${SITE_URL}/og-image.png`,
+      width: 1200,
+      height: 630,
+    },
     datePublished,
     dateModified: datePublished,
     author: {


### PR DESCRIPTION
## Summary
- add the existing AgentClash OG image to blog post BlogPosting JSON-LD
- tighten the blog post structured-data test around existing article fields
- add the review-checkpoint test contract for this crawler-only SEO refinement

## Validation
- pnpm -C web test -- blog-post-schema.test.tsx
- pnpm -C web lint
- pnpm -C web build
- git diff --check
- Cursor/gstack review: no blockers; adopted the low-severity suggestion to assert the rest of the BlogPosting contract

## Guardrails
- No visible homepage UI changes
- No shared footer changes
- No authenticated/internal UI changes
- No DB or destructive changes