### PR TITLE
Enrich blog main entity schema

### DIFF
--- a/testing/codex-seo-blog-main-entity-schema.md
+++ b/testing/codex-seo-blog-main-entity-schema.md
@@ -1,0 +1,26 @@
+# codex/seo-blog-main-entity-schema - Test Contract
+
+## Functional Behavior
+- Blog post `BlogPosting` JSON-LD describes `mainEntityOfPage` as a `WebPage` node with the canonical article URL.
+- Existing blog post structured data remains intact, including breadcrumb, image, dates, author, and publisher.
+- The change must be crawler-only: no homepage UI changes, no shared footer changes, no authenticated/internal UI changes, no database changes, and no destructive behavior.
+
+## Unit Tests
+- `web/src/app/blog/blog-post-schema.test.tsx` verifies the rendered blog post JSON-LD includes a `WebPage` `mainEntityOfPage` object.
+
+## Integration / Functional Tests
+- `pnpm -C web test -- blog-post-schema.test.tsx`
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+- N/A - structured data only.
+
+## E2E Tests
+- N/A - structured data only.
+
+## Manual / cURL Tests
+```bash
+curl -s https://www.agentclash.dev/blog/ai-agent-evaluation-regression-testing | rg 'mainEntityOfPage|WebPage'
+# Expected: blog article structured data includes a WebPage mainEntityOfPage node.
+```

--- a/web/src/app/blog/blog-post-schema.test.tsx
+++ b/web/src/app/blog/blog-post-schema.test.tsx
@@ -90,7 +90,11 @@ describe("blog post structured data", () => {
       headline: "Fixture Post",
       description: "Fixture description.",
       url: `${SITE_URL}/blog/fixture-post`,
-      mainEntityOfPage: `${SITE_URL}/blog/fixture-post`,
+      mainEntityOfPage: {
+        "@type": "WebPage",
+        "@id": `${SITE_URL}/blog/fixture-post`,
+        url: `${SITE_URL}/blog/fixture-post`,
+      },
       image: {
         "@type": "ImageObject",
         url: `${SITE_URL}/og-image.png`,

--- a/web/src/components/marketing/json-ld.test.ts
+++ b/web/src/components/marketing/json-ld.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  articleSchema,
   blogIndexSchema,
   docsPageSchema,
   productSchema,
@@ -75,6 +76,47 @@ describe("blogIndexSchema", () => {
           },
         },
       ],
+    });
+  });
+});
+
+describe("articleSchema", () => {
+  it("builds BlogPosting structured data with a WebPage main entity", () => {
+    expect(
+      articleSchema({
+        headline: "Agent Evaluation",
+        description: "Evaluate agents on real tasks.",
+        url: "/blog/agent-evaluation",
+        datePublished: "2026-05-08",
+        authorName: "AgentClash",
+      }),
+    ).toMatchObject({
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      headline: "Agent Evaluation",
+      description: "Evaluate agents on real tasks.",
+      url: `${SITE_URL}/blog/agent-evaluation`,
+      mainEntityOfPage: {
+        "@type": "WebPage",
+        "@id": `${SITE_URL}/blog/agent-evaluation`,
+        url: `${SITE_URL}/blog/agent-evaluation`,
+      },
+      image: {
+        "@type": "ImageObject",
+        url: `${SITE_URL}/og-image.png`,
+        width: 1200,
+        height: 630,
+      },
+      datePublished: "2026-05-08",
+      dateModified: "2026-05-08",
+      author: {
+        "@type": "Person",
+        name: "AgentClash",
+      },
+      publisher: {
+        "@type": "Organization",
+        name: "AgentClash",
+      },
     });
   });
 });

--- a/web/src/components/marketing/json-ld.tsx
+++ b/web/src/components/marketing/json-ld.tsx
@@ -107,7 +107,11 @@ export function articleSchema({
     headline,
     description,
     url: absoluteUrl,
-    mainEntityOfPage: absoluteUrl,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": absoluteUrl,
+      url: absoluteUrl,
+    },
     image: {
       "@type": "ImageObject",
       url: `${SITE_URL}/og-image.png`,


### PR DESCRIPTION
## Summary
- change blog post BlogPosting `mainEntityOfPage` to a WebPage node with `@id` and `url`
- add direct `articleSchema` unit coverage plus rendered blog post schema coverage
- add the review-checkpoint test contract for this crawler-only SEO refinement

## Validation
- pnpm -C web test -- blog-post-schema.test.tsx json-ld.test.ts
- pnpm -C web lint
- pnpm -C web build
- git diff --check
- Cursor/gstack review: no blockers; adopted optional WebPage.url and direct helper-test suggestions

## Guardrails
- No visible homepage UI changes
- No shared footer changes
- No authenticated/internal UI changes
- No DB or destructive changes