### PR TITLE
Enrich docs main entity schema

### DIFF
--- a/testing/codex-seo-docs-main-entity-schema.md
+++ b/testing/codex-seo-docs-main-entity-schema.md
@@ -1,0 +1,27 @@
+# codex/seo-docs-main-entity-schema - Test Contract
+
+## Functional Behavior
+- Docs page `TechArticle` JSON-LD describes `mainEntityOfPage` as a `WebPage` node with the canonical docs URL.
+- Existing docs structured data remains intact, including breadcrumbs, headline, description, author, publisher, and docs website relationship.
+- The change must be crawler-only: no homepage UI changes, no shared footer changes, no authenticated/internal UI changes, no database changes, and no destructive behavior.
+
+## Unit Tests
+- `web/src/components/marketing/json-ld.test.ts` verifies `docsPageSchema` emits the richer `mainEntityOfPage` object.
+- `web/src/app/docs/docs-page-schema.test.tsx` verifies rendered docs page JSON-LD uses the same shape.
+
+## Integration / Functional Tests
+- `pnpm -C web test -- docs-page-schema.test.tsx json-ld.test.ts`
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+- N/A - structured data only.
+
+## E2E Tests
+- N/A - structured data only.
+
+## Manual / cURL Tests
+```bash
+curl -s https://www.agentclash.dev/docs/getting-started/quickstart | rg 'mainEntityOfPage|WebPage'
+# Expected: docs article structured data includes a WebPage mainEntityOfPage node.
+```

--- a/web/src/app/docs/docs-page-schema.test.tsx
+++ b/web/src/app/docs/docs-page-schema.test.tsx
@@ -109,6 +109,11 @@ describe("docs page structured data", () => {
       "@type": "TechArticle",
       headline: "Quickstart",
       url: `${SITE_URL}/docs/getting-started/quickstart`,
+      mainEntityOfPage: {
+        "@type": "WebPage",
+        "@id": `${SITE_URL}/docs/getting-started/quickstart`,
+        url: `${SITE_URL}/docs/getting-started/quickstart`,
+      },
     });
   });
 });

--- a/web/src/components/marketing/json-ld.test.ts
+++ b/web/src/components/marketing/json-ld.test.ts
@@ -160,7 +160,11 @@ describe("docsPageSchema", () => {
       headline: "Quickstart",
       description: "Run your first AgentClash eval.",
       url: `${SITE_URL}/docs/getting-started/quickstart`,
-      mainEntityOfPage: `${SITE_URL}/docs/getting-started/quickstart`,
+      mainEntityOfPage: {
+        "@type": "WebPage",
+        "@id": `${SITE_URL}/docs/getting-started/quickstart`,
+        url: `${SITE_URL}/docs/getting-started/quickstart`,
+      },
       author: {
         "@type": "Organization",
         name: "AgentClash",

--- a/web/src/components/marketing/json-ld.tsx
+++ b/web/src/components/marketing/json-ld.tsx
@@ -218,7 +218,11 @@ export function docsPageSchema({
       headline: title,
       description,
       url: absoluteUrl,
-      mainEntityOfPage: absoluteUrl,
+      mainEntityOfPage: {
+        "@type": "WebPage",
+        "@id": absoluteUrl,
+        url: absoluteUrl,
+      },
       author: publisherSchema(),
       publisher: publisherSchema(),
       isPartOf: {


### PR DESCRIPTION
## Summary
- change docs TechArticle `mainEntityOfPage` to a WebPage node with `@id` and `url`
- cover the richer shape in both the JSON-LD helper test and rendered docs page schema test
- add the review-checkpoint test contract for this crawler-only SEO refinement

## Validation
- pnpm -C web test -- docs-page-schema.test.tsx json-ld.test.ts
- pnpm -C web lint
- pnpm -C web build
- git diff --check
- Cursor/gstack review: no blockers; only low/info notes

## Guardrails
- No visible homepage UI changes
- No shared footer changes
- No authenticated/internal UI changes
- No DB or destructive changes