### PR TITLE
Add rich SEO schema and discovery guardrails

### DIFF
--- a/testing/codex-seo-rich-schema-canonical-discovery.md
+++ b/testing/codex-seo-rich-schema-canonical-discovery.md
@@ -1,0 +1,35 @@
+# codex/seo-rich-schema-canonical-discovery - Test Contract
+
+## Functional Behavior
+- Platform and homepage `SoftwareApplication` JSON-LD include richer feature/pricing fields without changing the landing page UI.
+- Docs home emits FAQ structured data only for FAQ content that is visible on the docs home page.
+- Public canonical metadata is guarded for homepage, blog, blog posts, docs, platform pages, why, team, and the new HTML sitemap page.
+- A public HTML sitemap page improves crawler and human discovery for marketing pages, platform pages, docs, and blog posts.
+- The XML sitemap includes the HTML sitemap route.
+- The change must not modify the homepage/landing UI, shared marketing footer, authenticated/internal UI, database behavior, or destructive behavior.
+
+## Unit Tests
+- `web/src/components/marketing/json-ld.test.ts` covers richer `SoftwareApplication` fields and docs home FAQ schema.
+- `web/src/app/platform/platform-pages.test.tsx` covers platform page `SoftwareApplication` feature lists.
+- `web/src/app/docs/docs-page-schema.test.tsx` covers rendered docs home FAQ JSON-LD.
+- `web/src/app/public-canonical-metadata.test.ts` covers canonical metadata across public pages.
+- `web/src/app/sitemap-page.test.tsx` covers the HTML sitemap page route and links.
+- `web/src/app/sitemap.test.ts` covers the XML sitemap entry for `/sitemap`.
+
+## Integration / Functional Tests
+- `pnpm -C web test -- json-ld.test.ts platform-pages.test.tsx docs-page-schema.test.tsx public-canonical-metadata.test.ts sitemap-page.test.tsx sitemap.test.ts`
+- `pnpm -C web lint`
+- `pnpm -C web build`
+
+## Smoke Tests
+- N/A - public metadata, structured data, and static discovery page only.
+
+## E2E Tests
+- N/A - no authenticated user journey changes.
+
+## Manual / cURL Tests
+```bash
+curl -s https://www.agentclash.dev/sitemap | rg 'Agent evaluation|Docs|Blog'
+curl -s https://www.agentclash.dev/sitemap.xml | rg 'https://www.agentclash.dev/sitemap'
+# Expected: HTML sitemap exposes public discovery links, and XML sitemap advertises the HTML sitemap route.
+```

--- a/web/src/app/docs/[[...slug]]/page.tsx
+++ b/web/src/app/docs/[[...slug]]/page.tsx
@@ -17,6 +17,24 @@ type Props = {
   params: Promise<{ slug?: string[] }>;
 };
 
+const DOCS_HOME_FAQ = [
+  {
+    question: "Where should I start with AgentClash?",
+    answer:
+      "Start with the quickstart, then write a challenge pack for one real agent workload and run it locally or against a hosted workspace.",
+  },
+  {
+    question: "Can AgentClash docs help with CI agent gates?",
+    answer:
+      "Yes. The docs cover challenge packs, scorecards, baseline comparisons, and CI/CD gates for catching AI agent regressions before release.",
+  },
+  {
+    question: "Are the docs available for coding agents?",
+    answer:
+      "Yes. AgentClash publishes llms.txt, llms-full.txt, and per-page markdown exports so coding agents can read the docs directly.",
+  },
+];
+
 export function generateStaticParams() {
   return getAllDocSlugs().map((slug) => ({ slug }));
 }
@@ -90,6 +108,7 @@ export default async function DocsPage({ params }: Props) {
           title: doc.title,
           description: doc.description,
           href: doc.href,
+          faqItems: isHome ? DOCS_HOME_FAQ : undefined,
         })}
       />
 
@@ -127,6 +146,29 @@ export default async function DocsPage({ params }: Props) {
                     </Link>
                   ))}
                 </div>
+              </section>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {isHome && (
+        <div className="mt-12 border-t border-white/[0.08] pt-8">
+          <p className="text-[11px] font-semibold uppercase tracking-wider text-zinc-400">
+            Docs FAQ
+          </p>
+          <div className="mt-5 grid gap-4 xl:grid-cols-3">
+            {DOCS_HOME_FAQ.map((item) => (
+              <section
+                key={item.question}
+                className="rounded-[24px] border border-white/[0.08] bg-black/20 p-5"
+              >
+                <h2 className="text-sm font-semibold text-white/90">
+                  {item.question}
+                </h2>
+                <p className="mt-3 text-sm leading-6 text-white/45">
+                  {item.answer}
+                </p>
               </section>
             ))}
           </div>

--- a/web/src/app/docs/docs-page-schema.test.tsx
+++ b/web/src/app/docs/docs-page-schema.test.tsx
@@ -5,6 +5,8 @@ import { SITE_URL } from "@/components/marketing/json-ld";
 import DocsPage from "./[[...slug]]/page";
 import { docsSchemaId } from "./docs-schema-id";
 
+const getDocBySlugMock = vi.hoisted(() => vi.fn());
+
 vi.mock("next-mdx-remote/rsc", () => ({
   MDXRemote: ({ source }: { source: string }) => <div>{source}</div>,
 }));
@@ -20,18 +22,35 @@ vi.mock("@/components/docs/mdx-components", () => ({
 }));
 
 vi.mock("@/lib/docs", () => ({
-  DOCS_NAV: [],
+  DOCS_NAV: [
+    {
+      title: "Getting started",
+      description: "Start running AgentClash.",
+      items: [
+        {
+          title: "Quickstart",
+          description: "Run your first AgentClash eval.",
+          href: "/docs/getting-started/quickstart",
+        },
+      ],
+    },
+  ],
   getAllDocSlugs: vi.fn(() => [["getting-started", "quickstart"]]),
-  getDocBySlug: vi.fn(() => ({
+  getDocBySlug: getDocBySlugMock,
+  getDocNeighbors: vi.fn(() => ({})),
+}));
+
+function mockDoc(overrides: Record<string, unknown> = {}) {
+  getDocBySlugMock.mockReturnValue({
     href: "/docs/getting-started/quickstart",
     title: "Quickstart",
     description: "Run your first AgentClash eval.",
     sectionTitle: "Getting Started",
     headings: [],
     content: "Fixture docs content.",
-  })),
-  getDocNeighbors: vi.fn(() => ({})),
-}));
+    ...overrides,
+  });
+}
 
 let root: Root | null = null;
 let container: HTMLDivElement | null = null;
@@ -63,6 +82,8 @@ describe("docs page structured data", () => {
   });
 
   it("renders breadcrumb and TechArticle JSON-LD", async () => {
+    mockDoc();
+
     const page = await DocsPage({
       params: Promise.resolve({ slug: ["getting-started", "quickstart"] }),
     });
@@ -114,6 +135,61 @@ describe("docs page structured data", () => {
         "@id": `${SITE_URL}/docs/getting-started/quickstart`,
         url: `${SITE_URL}/docs/getting-started/quickstart`,
       },
+    });
+  });
+
+  it("renders visible docs home FAQ with matching FAQPage JSON-LD", async () => {
+    mockDoc({
+      href: "/docs",
+      title: "AgentClash Docs",
+      description: "Documentation for AgentClash.",
+      content: "Docs home content.",
+    });
+
+    const page = await DocsPage({
+      params: Promise.resolve({ slug: [] }),
+    });
+
+    render(page);
+
+    expect(container?.textContent).toContain("Docs FAQ");
+    expect(container?.textContent).toContain(
+      "Where should I start with AgentClash?",
+    );
+    expect(container?.textContent).toContain(
+      "Can AgentClash docs help with CI agent gates?",
+    );
+    expect(container?.textContent).toContain(
+      "Are the docs available for coding agents?",
+    );
+
+    const script = container?.querySelector<HTMLScriptElement>(
+      "#agentclash-docs-home-schema",
+    );
+    const jsonLd = JSON.parse(script?.textContent ?? "[]") as Array<
+      Record<string, unknown>
+    >;
+
+    expect(jsonLd.map((item) => item["@type"])).toEqual([
+      "BreadcrumbList",
+      "FAQPage",
+    ]);
+    expect(jsonLd[1]).toMatchObject({
+      "@type": "FAQPage",
+      mainEntity: [
+        {
+          "@type": "Question",
+          name: "Where should I start with AgentClash?",
+        },
+        {
+          "@type": "Question",
+          name: "Can AgentClash docs help with CI agent gates?",
+        },
+        {
+          "@type": "Question",
+          name: "Are the docs available for coding agents?",
+        },
+      ],
     });
   });
 });

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -2,6 +2,7 @@ import { withAuth } from "@workos-inc/authkit-nextjs";
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { JsonLd, SITE_URL, productSchema } from "@/components/marketing/json-ld";
+import { AGENT_EVALUATION_FEATURES } from "@/lib/seo-features";
 import HomePage from "./landing";
 
 export const metadata: Metadata = {
@@ -17,13 +18,7 @@ const softwareApplicationSchema = productSchema({
   url: SITE_URL,
   applicationSubCategory: "AI agent evaluation platform",
   softwareVersion: "beta",
-  featureList: [
-    "Head-to-head AI agent evaluation",
-    "Sandboxed real-tool execution",
-    "Replay evidence and artifacts",
-    "Scorecards for correctness, latency, and cost",
-    "CI regression gates for agent releases",
-  ],
+  featureList: AGENT_EVALUATION_FEATURES,
 });
 
 const organizationSchema = {

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -17,6 +17,13 @@ const softwareApplicationSchema = productSchema({
   url: SITE_URL,
   applicationSubCategory: "AI agent evaluation platform",
   softwareVersion: "beta",
+  featureList: [
+    "Head-to-head AI agent evaluation",
+    "Sandboxed real-tool execution",
+    "Replay evidence and artifacts",
+    "Scorecards for correctness, latency, and cost",
+    "CI regression gates for agent releases",
+  ],
 });
 
 const organizationSchema = {

--- a/web/src/app/platform/agent-evaluation/page.tsx
+++ b/web/src/app/platform/agent-evaluation/page.tsx
@@ -17,6 +17,7 @@ import {
   faqSchema,
   productSchema,
 } from "@/components/marketing/json-ld";
+import { AGENT_EVALUATION_FEATURES } from "@/lib/seo-features";
 
 const PAGE_PATH = "/platform/agent-evaluation";
 const PAGE_TITLE = "AI Agent Evaluation Platform for Real Tasks - AgentClash";
@@ -66,14 +67,7 @@ const workflow = [
   },
 ];
 
-const proofPoints = [
-  "Sandboxed real-tool execution",
-  "Head-to-head runs with fair constraints",
-  "Scorecards for correctness, cost, latency, and tool strategy",
-  "Replay trails for every important action",
-  "Challenge packs that turn failures into reusable tests",
-  "CI gates for baseline versus candidate decisions",
-];
+const proofPoints = AGENT_EVALUATION_FEATURES;
 
 export const metadata: Metadata = {
   title: PAGE_TITLE,

--- a/web/src/app/platform/agent-evaluation/page.tsx
+++ b/web/src/app/platform/agent-evaluation/page.tsx
@@ -277,6 +277,7 @@ export default function AgentEvaluationPage() {
             description: PAGE_DESCRIPTION,
             url: PAGE_PATH,
             applicationSubCategory: "AI agent evaluation platform",
+            featureList: proofPoints,
           }),
         ]}
       />

--- a/web/src/app/platform/agent-regression-testing/page.tsx
+++ b/web/src/app/platform/agent-regression-testing/page.tsx
@@ -275,6 +275,7 @@ export default function AgentRegressionTestingPage() {
             description: PAGE_DESCRIPTION,
             url: PAGE_PATH,
             applicationSubCategory: "AI agent regression testing software",
+            featureList: gateSignals,
           }),
         ]}
       />

--- a/web/src/app/platform/platform-pages.test.tsx
+++ b/web/src/app/platform/platform-pages.test.tsx
@@ -73,6 +73,19 @@ describe("platform pages structured data", () => {
       url: "https://www.agentclash.dev/platform/agent-evaluation",
       applicationCategory: "DeveloperApplication",
       applicationSubCategory: "AI agent evaluation platform",
+      featureList: [
+        "Sandboxed real-tool execution",
+        "Head-to-head runs with fair constraints",
+        "Scorecards for correctness, cost, latency, and tool strategy",
+        "Replay trails for every important action",
+        "Challenge packs that turn failures into reusable tests",
+        "CI gates for baseline versus candidate decisions",
+      ],
+      offers: {
+        name: "Open-source self-hosted edition",
+        price: "0",
+        priceCurrency: "USD",
+      },
     });
   });
 
@@ -98,6 +111,19 @@ describe("platform pages structured data", () => {
       url: "https://www.agentclash.dev/platform/agent-regression-testing",
       applicationCategory: "DeveloperApplication",
       applicationSubCategory: "AI agent regression testing software",
+      featureList: [
+        "Baseline versus candidate scorecards",
+        "Replay timelines for every failed gate",
+        "Artifact checks for files, logs, and evidence",
+        "Cost and latency thresholds for production budgets",
+        "Challenge packs that make failures repeatable",
+        "Pull request gates for model, prompt, and tool changes",
+      ],
+      offers: {
+        name: "Open-source self-hosted edition",
+        price: "0",
+        priceCurrency: "USD",
+      },
     });
   });
 });

--- a/web/src/app/public-canonical-metadata.test.ts
+++ b/web/src/app/public-canonical-metadata.test.ts
@@ -1,0 +1,103 @@
+import type { Metadata } from "next";
+import { describe, expect, it, vi } from "vitest";
+import { metadata as homeMetadata } from "./page";
+import { metadata as blogMetadata } from "./blog/page";
+import { generateMetadata as generateBlogPostMetadata } from "./blog/[slug]/page";
+import { generateMetadata as generateDocsMetadata } from "./docs/[[...slug]]/page";
+import { metadata as agentEvaluationMetadata } from "./platform/agent-evaluation/page";
+import { metadata as agentRegressionTestingMetadata } from "./platform/agent-regression-testing/page";
+import { metadata as sitemapMetadata } from "./sitemap/page";
+import { teamMetadata } from "./team/metadata";
+import { whyMetadata } from "./why/metadata";
+
+const getPostBySlugMock = vi.hoisted(() => vi.fn());
+const getDocBySlugMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  withAuth: vi.fn(),
+}));
+
+vi.mock("./landing", () => ({
+  default: () => null,
+}));
+
+vi.mock("next-mdx-remote/rsc", () => ({
+  MDXRemote: () => null,
+}));
+
+vi.mock("@/lib/blog", () => ({
+  getAllPosts: vi.fn(() => []),
+  getAllSlugs: vi.fn(() => []),
+  getPostBySlug: getPostBySlugMock,
+}));
+
+vi.mock("@/lib/docs", () => ({
+  DOCS_NAV: [],
+  getAllDocSlugs: vi.fn(() => []),
+  getDocBySlug: getDocBySlugMock,
+  getDocNeighbors: vi.fn(() => ({})),
+}));
+
+function expectCanonical(metadata: Metadata, canonical: string) {
+  expect(metadata.alternates).toMatchObject({ canonical });
+}
+
+describe("public canonical metadata", () => {
+  it("locks static public page canonicals", () => {
+    expectCanonical(homeMetadata, "/");
+    expectCanonical(blogMetadata, "/blog");
+    expectCanonical(agentEvaluationMetadata, "/platform/agent-evaluation");
+    expectCanonical(
+      agentRegressionTestingMetadata,
+      "/platform/agent-regression-testing",
+    );
+    expectCanonical(whyMetadata, "/why");
+    expectCanonical(teamMetadata, "/team");
+    expectCanonical(sitemapMetadata, "/sitemap");
+  });
+
+  it("locks blog post canonical metadata", async () => {
+    getPostBySlugMock.mockReturnValue({
+      slug: "fixture-post",
+      title: "Fixture Post",
+      date: "2026-05-08",
+      description: "Fixture description.",
+      author: "AgentClash",
+      content: "",
+    });
+
+    const metadata = await generateBlogPostMetadata({
+      params: Promise.resolve({ slug: "fixture-post" }),
+    });
+
+    expectCanonical(metadata, "/blog/fixture-post");
+  });
+
+  it("locks docs canonical metadata", async () => {
+    getDocBySlugMock.mockReturnValue({
+      href: "/docs/getting-started/quickstart",
+      title: "Quickstart",
+      description: "Run your first AgentClash eval.",
+    });
+
+    const metadata = await generateDocsMetadata({
+      params: Promise.resolve({ slug: ["getting-started", "quickstart"] }),
+    });
+
+    expectCanonical(metadata, "/docs/getting-started/quickstart");
+  });
+
+  it("locks docs home canonical metadata", async () => {
+    getDocBySlugMock.mockReturnValue({
+      href: "/docs",
+      title: "AgentClash Docs",
+      description: "Documentation for AgentClash.",
+    });
+
+    const metadata = await generateDocsMetadata({
+      params: Promise.resolve({ slug: [] }),
+    });
+
+    expectCanonical(metadata, "/docs");
+  });
+});

--- a/web/src/app/sitemap-page.test.tsx
+++ b/web/src/app/sitemap-page.test.tsx
@@ -1,0 +1,91 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import HtmlSitemapPage, { metadata } from "./sitemap/page";
+
+vi.mock("@/lib/blog", () => ({
+  getAllPosts: vi.fn(() => [
+    {
+      slug: "ai-agent-evaluation-regression-testing",
+      title: "AI Agent Evaluation and Regression Testing",
+      description: "Evaluate AI agents on real tasks.",
+      date: "2026-05-07",
+      author: "AgentClash",
+    },
+  ]),
+}));
+
+vi.mock("@/lib/docs", () => ({
+  DOCS_NAV: [
+    {
+      title: "Getting started",
+      description: "Start running AgentClash.",
+      items: [
+        {
+          title: "Quickstart",
+          description: "Run your first AgentClash eval.",
+          href: "/docs/getting-started/quickstart",
+        },
+      ],
+    },
+  ],
+}));
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function render(element: React.ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(element);
+  });
+}
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe("HTML sitemap page", () => {
+  it("has canonical metadata", () => {
+    expect(metadata).toMatchObject({
+      title: "Sitemap - AgentClash",
+      alternates: {
+        canonical: "/sitemap",
+      },
+      openGraph: {
+        url: "/sitemap",
+      },
+    });
+  });
+
+  it("links core pages, docs, and blog posts for crawler discovery", () => {
+    render(<HtmlSitemapPage />);
+
+    const links = Array.from(container?.querySelectorAll("a") ?? []).map(
+      (link) => link.getAttribute("href"),
+    );
+
+    expect(links).toEqual(
+      expect.arrayContaining([
+        "/",
+        "/platform/agent-evaluation",
+        "/platform/agent-regression-testing",
+        "/docs",
+        "/blog",
+        "/why",
+        "/team",
+        "/llms.txt",
+        "/llms-full.txt",
+        "/docs/getting-started/quickstart",
+        "/blog/ai-agent-evaluation-regression-testing",
+      ]),
+    );
+  });
+});

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -43,6 +43,10 @@ describe("sitemap", () => {
       changeFrequency: "monthly",
       priority: 0.5,
     });
+    expect(byUrl.get("https://www.agentclash.dev/sitemap")).toMatchObject({
+      changeFrequency: "weekly",
+      priority: 0.5,
+    });
     expect(
       byUrl.get("https://www.agentclash.dev/platform/agent-evaluation"),
     ).toMatchObject({

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -41,6 +41,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.5,
     },
     {
+      url: `${DOCS_ORIGIN}/sitemap`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.5,
+    },
+    {
       url: `${DOCS_ORIGIN}/platform/agent-evaluation`,
       lastModified: new Date(),
       changeFrequency: "monthly",

--- a/web/src/app/sitemap/page.tsx
+++ b/web/src/app/sitemap/page.tsx
@@ -1,0 +1,164 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { DOCS_NAV } from "@/lib/docs";
+import { getAllPosts } from "@/lib/blog";
+
+export const metadata: Metadata = {
+  title: "Sitemap - AgentClash",
+  description:
+    "Browse AgentClash public pages, AI agent evaluation resources, docs, and blog posts.",
+  alternates: {
+    canonical: "/sitemap",
+  },
+  openGraph: {
+    title: "Sitemap - AgentClash",
+    description:
+      "Browse AgentClash public pages, AI agent evaluation resources, docs, and blog posts.",
+    url: "/sitemap",
+    type: "website",
+    locale: "en_US",
+    siteName: "AgentClash",
+    images: [
+      {
+        url: "/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "AgentClash sitemap social preview.",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Sitemap - AgentClash",
+    description:
+      "Browse AgentClash public pages, AI agent evaluation resources, docs, and blog posts.",
+    images: [
+      {
+        url: "/twitter-image.png",
+        alt: "AgentClash sitemap social preview.",
+      },
+    ],
+  },
+};
+
+const primaryPages = [
+  {
+    title: "Home",
+    href: "/",
+    description: "AgentClash overview and product entry point.",
+  },
+  {
+    title: "Agent evaluation",
+    href: "/platform/agent-evaluation",
+    description: "Evaluate AI agents on real tasks with replay and scorecards.",
+  },
+  {
+    title: "Agent regression testing",
+    href: "/platform/agent-regression-testing",
+    description: "Catch AI agent regressions with baseline comparisons and CI gates.",
+  },
+  {
+    title: "Docs",
+    href: "/docs",
+    description: "Guides and references for running AgentClash.",
+  },
+  {
+    title: "Blog",
+    href: "/blog",
+    description: "Engineering notes on AI agent evaluation and release gates.",
+  },
+  {
+    title: "Why AgentClash",
+    href: "/why",
+    description: "Why real-task AI agent evaluation matters.",
+  },
+  {
+    title: "Team",
+    href: "/team",
+    description: "The engineers building AgentClash.",
+  },
+  {
+    title: "LLMs index",
+    href: "/llms.txt",
+    description: "Machine-readable index for AI assistants and coding agents.",
+  },
+  {
+    title: "Full LLMs bundle",
+    href: "/llms-full.txt",
+    description: "Complete machine-readable AgentClash docs bundle.",
+  },
+];
+
+function LinkList({
+  title,
+  items,
+}: {
+  title: string;
+  items: Array<{ title: string; href: string; description?: string }>;
+}) {
+  return (
+    <section>
+      <h2 className="text-sm font-semibold uppercase tracking-wider text-white/45">
+        {title}
+      </h2>
+      <div className="mt-4 grid gap-3">
+        {items.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className="rounded-lg border border-white/[0.08] bg-white/[0.03] px-5 py-4 transition-colors hover:border-white/15"
+          >
+            <span className="block text-sm font-medium text-white/90">
+              {item.title}
+            </span>
+            {item.description && (
+              <span className="mt-1 block text-xs leading-5 text-white/40">
+                {item.description}
+              </span>
+            )}
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default function HtmlSitemapPage() {
+  const posts = getAllPosts().map((post) => ({
+    title: post.title,
+    href: `/blog/${post.slug}`,
+    description: post.description,
+  }));
+
+  return (
+    <main className="min-h-screen px-6 py-16 text-white">
+      <div className="mx-auto max-w-5xl">
+        <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-wider text-white/35">
+          Public sitemap
+        </p>
+        <h1 className="mt-4 font-[family-name:var(--font-display)] text-3xl leading-tight tracking-normal sm:text-5xl">
+          AgentClash sitemap
+        </h1>
+        <p className="mt-4 max-w-2xl text-sm leading-7 text-white/50">
+          Browse public AgentClash pages, AI agent evaluation resources, docs,
+          and engineering posts.
+        </p>
+
+        <div className="mt-12 grid gap-10 lg:grid-cols-2">
+          <LinkList title="Core pages" items={primaryPages} />
+          <LinkList title="Blog posts" items={posts} />
+        </div>
+
+        <div className="mt-12 grid gap-10 lg:grid-cols-2">
+          {DOCS_NAV.map((section) => (
+            <LinkList
+              key={section.title}
+              title={section.title}
+              items={section.items}
+            />
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/web/src/components/marketing/json-ld.test.ts
+++ b/web/src/components/marketing/json-ld.test.ts
@@ -15,6 +15,7 @@ describe("productSchema", () => {
         description: "Evaluate AI agents on real tasks.",
         url: "/platform/agent-evaluation",
         applicationSubCategory: "AI agent evaluation platform",
+        featureList: ["Replay evidence", "CI regression gates"],
       }),
     ).toMatchObject({
       "@context": "https://schema.org",
@@ -26,10 +27,18 @@ describe("productSchema", () => {
       operatingSystem: "Web, macOS, Linux, Windows",
       description: "Evaluate AI agents on real tasks.",
       url: `${SITE_URL}/platform/agent-evaluation`,
+      featureList: ["Replay evidence", "CI regression gates"],
+      sameAs: [
+        "https://github.com/agentclash/agentclash",
+        "https://www.npmjs.com/package/agentclash",
+      ],
       offers: {
         "@type": "Offer",
+        name: "Open-source self-hosted edition",
         price: "0",
         priceCurrency: "USD",
+        availability: "https://schema.org/InStock",
+        category: "Open-source software",
       },
     });
   });
@@ -182,9 +191,15 @@ describe("docsPageSchema", () => {
       title: "AgentClash Docs",
       description: "Documentation for AgentClash.",
       href: "/docs/",
+      faqItems: [
+        {
+          question: "Where should I start?",
+          answer: "Start with the quickstart.",
+        },
+      ],
     });
 
-    expect(schema).toHaveLength(1);
+    expect(schema).toHaveLength(2);
     expect(schema[0]).toMatchObject({
       "@type": "BreadcrumbList",
       itemListElement: [
@@ -199,6 +214,19 @@ describe("docsPageSchema", () => {
           position: 2,
           name: "Docs",
           item: `${SITE_URL}/docs`,
+        },
+      ],
+    });
+    expect(schema[1]).toMatchObject({
+      "@type": "FAQPage",
+      mainEntity: [
+        {
+          "@type": "Question",
+          name: "Where should I start?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "Start with the quickstart.",
+          },
         },
       ],
     });

--- a/web/src/components/marketing/json-ld.test.ts
+++ b/web/src/components/marketing/json-ld.test.ts
@@ -232,4 +232,20 @@ describe("docsPageSchema", () => {
     });
     expect(schema.map((item) => item["@type"])).not.toContain("TechArticle");
   });
+
+  it("rejects FAQ items for non-home docs pages", () => {
+    expect(() =>
+      docsPageSchema({
+        title: "Quickstart",
+        description: "Run your first AgentClash eval.",
+        href: "/docs/getting-started/quickstart",
+        faqItems: [
+          {
+            question: "Where should I start?",
+            answer: "Start with the quickstart.",
+          },
+        ],
+      }),
+    ).toThrow("docsPageSchema faqItems are only supported for /docs");
+  });
 });

--- a/web/src/components/marketing/json-ld.tsx
+++ b/web/src/components/marketing/json-ld.tsx
@@ -227,6 +227,9 @@ export function docsPageSchema({
     breadcrumbSchema(breadcrumbs),
     ...(isDocsHome && faqItems.length ? [faqSchema(faqItems)] : []),
   ];
+  if (!isDocsHome && faqItems.length) {
+    throw new Error("docsPageSchema faqItems are only supported for /docs");
+  }
   if (isDocsHome) return schema;
 
   return [

--- a/web/src/components/marketing/json-ld.tsx
+++ b/web/src/components/marketing/json-ld.tsx
@@ -53,12 +53,14 @@ export function productSchema({
   url,
   applicationSubCategory,
   softwareVersion,
+  featureList,
 }: {
   name: string;
   description: string;
   url: string;
   applicationSubCategory?: string;
   softwareVersion?: string;
+  featureList?: string[];
 }): Record<string, unknown> {
   return {
     "@context": "https://schema.org",
@@ -71,7 +73,19 @@ export function productSchema({
     description,
     url: url.startsWith("http") ? url : `${SITE_URL}${url}`,
     ...(softwareVersion ? { softwareVersion } : {}),
-    offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+    ...(featureList?.length ? { featureList } : {}),
+    sameAs: [
+      "https://github.com/agentclash/agentclash",
+      "https://www.npmjs.com/package/agentclash",
+    ],
+    offers: {
+      "@type": "Offer",
+      name: "Open-source self-hosted edition",
+      price: "0",
+      priceCurrency: "USD",
+      availability: "https://schema.org/InStock",
+      category: "Open-source software",
+    },
   };
 }
 
@@ -187,10 +201,12 @@ export function docsPageSchema({
   title,
   description,
   href,
+  faqItems = [],
 }: {
   title: string;
   description: string;
   href: string;
+  faqItems?: Array<{ question: string; answer: string }>;
 }): Record<string, unknown>[] {
   const absoluteUrl = href.startsWith("http") ? href : `${SITE_URL}${href}`;
   const pathname = href.replace(/^https?:\/\/[^/]+/, "").replace(/\/+$/, "");
@@ -207,7 +223,10 @@ export function docsPageSchema({
           { name: title, url: href },
         ];
 
-  const schema = [breadcrumbSchema(breadcrumbs)];
+  const schema = [
+    breadcrumbSchema(breadcrumbs),
+    ...(isDocsHome && faqItems.length ? [faqSchema(faqItems)] : []),
+  ];
   if (isDocsHome) return schema;
 
   return [

--- a/web/src/lib/seo-features.ts
+++ b/web/src/lib/seo-features.ts
@@ -1,0 +1,8 @@
+export const AGENT_EVALUATION_FEATURES = [
+  "Sandboxed real-tool execution",
+  "Head-to-head runs with fair constraints",
+  "Scorecards for correctness, cost, latency, and tool strategy",
+  "Replay trails for every important action",
+  "Challenge packs that turn failures into reusable tests",
+  "CI gates for baseline versus candidate decisions",
+];


### PR DESCRIPTION
## Summary
- enrich SoftwareApplication JSON-LD with feature lists, sameAs links, and an explicit open-source self-hosted offer
- add docs-home FAQ content with matching FAQPage JSON-LD
- add public canonical metadata guardrails across homepage, blog, docs, platform, why, team, and sitemap pages
- add a public HTML sitemap and include it in the XML sitemap

## Validation
- pnpm -C web test -- json-ld.test.ts platform-pages.test.tsx docs-page-schema.test.tsx public-canonical-metadata.test.ts sitemap-page.test.tsx sitemap.test.ts
- pnpm -C web lint
- pnpm -C web build
- git diff --check
- Cursor/gstack review: no blockers after fixes; medium pricing/schema note addressed

## Guardrails
- No homepage landing UI changes
- No shared marketing footer changes
- No authenticated/internal UI changes
- No DB or destructive changes