### PR TITLE
fix: reap orphaned queued runs

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -82,7 +82,7 @@ func main() {
 	runCreationManager := api.NewRunCreationManager(
 		authorizer,
 		repo,
-		api.NewTemporalRunWorkflowStarter(temporalClient),
+		api.NewTemporalRunWorkflowStarter(temporalClient, repo),
 		budgetChecker,
 	).WithEvalSessionWorkflowStarter(api.NewTemporalEvalSessionWorkflowStarter(temporalClient))
 	providerRouter := provider.NewDefaultRouter(nil, provider.EnvCredentialResolver{})

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -127,11 +127,12 @@ func main() {
 		NativeModelInvoker: nativeModelInvoker,
 		PromptEvalInvoker:  promptEvalInvoker,
 	})
+	orphanRunReaper := workerapp.NewRepositoryOrphanRunReaper(repo, cfg.OrphanRunReaperInterval, cfg.OrphanRunReaperThreshold, logger)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	if err := workerapp.Run(ctx, cfg, temporalWorker, logger); err != nil {
+	if err := workerapp.RunWithReaper(ctx, cfg, temporalWorker, orphanRunReaper, logger); err != nil {
 		logger.Error("worker stopped with error", "error", err)
 		os.Exit(1)
 	}

--- a/backend/db/queries/runs.sql
+++ b/backend/db/queries/runs.sql
@@ -130,6 +130,7 @@ SET temporal_workflow_id = @temporal_workflow_id,
 WHERE id = @id
   AND temporal_workflow_id IS NULL
   AND temporal_run_id IS NULL
+  AND status NOT IN ('completed', 'failed', 'cancelled')
 RETURNING *;
 
 -- name: UpdateRunStatus :one

--- a/backend/internal/api/temporal.go
+++ b/backend/internal/api/temporal.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/agentclash/agentclash/backend/internal/domain"
 	"github.com/agentclash/agentclash/backend/internal/hostedruns"
+	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/agentclash/agentclash/backend/internal/workflow"
 	"github.com/google/uuid"
 	temporalsdk "go.temporal.io/sdk/client"
@@ -18,19 +20,35 @@ type TemporalClient interface {
 
 type TemporalRunWorkflowStarter struct {
 	client TemporalClient
+	repo   RunTemporalIDRepository
 }
 
-func NewTemporalRunWorkflowStarter(client TemporalClient) TemporalRunWorkflowStarter {
-	return TemporalRunWorkflowStarter{client: client}
+type RunTemporalIDRepository interface {
+	SetRunTemporalIDs(ctx context.Context, params repository.SetRunTemporalIDsParams) (domain.Run, error)
+}
+
+func NewTemporalRunWorkflowStarter(client TemporalClient, repo RunTemporalIDRepository) TemporalRunWorkflowStarter {
+	return TemporalRunWorkflowStarter{client: client, repo: repo}
 }
 
 func (s TemporalRunWorkflowStarter) StartRunWorkflow(ctx context.Context, runID uuid.UUID) error {
 	workflowID := fmt.Sprintf("%s/%s", workflow.RunWorkflowName, runID)
-	_, err := s.client.ExecuteWorkflow(ctx, temporalsdk.StartWorkflowOptions{
+	run, err := s.client.ExecuteWorkflow(ctx, temporalsdk.StartWorkflowOptions{
 		ID:        workflowID,
 		TaskQueue: workflow.WorkflowTaskQueue,
 	}, workflow.RunWorkflowName, workflow.RunWorkflowInput{
 		RunID: runID,
+	})
+	if err != nil {
+		return err
+	}
+	if s.repo == nil {
+		return nil
+	}
+	_, err = s.repo.SetRunTemporalIDs(ctx, repository.SetRunTemporalIDsParams{
+		RunID:              runID,
+		TemporalWorkflowID: run.GetID(),
+		TemporalRunID:      run.GetRunID(),
 	})
 	return err
 }

--- a/backend/internal/api/temporal_test.go
+++ b/backend/internal/api/temporal_test.go
@@ -2,12 +2,61 @@ package api
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/agentclash/agentclash/backend/internal/domain"
+	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/agentclash/agentclash/backend/internal/workflow"
 	"github.com/google/uuid"
 	temporalsdk "go.temporal.io/sdk/client"
 )
+
+func TestTemporalRunWorkflowStarterStartRunWorkflowPersistsTemporalIDs(t *testing.T) {
+	runID := uuid.New()
+	client := &fakeTemporalClient{}
+	repo := &fakeRunTemporalIDRepository{}
+
+	err := NewTemporalRunWorkflowStarter(client, repo).StartRunWorkflow(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("StartRunWorkflow returned error: %v", err)
+	}
+
+	if client.workflowName != workflow.RunWorkflowName {
+		t.Fatalf("workflow name = %q, want %q", client.workflowName, workflow.RunWorkflowName)
+	}
+	if client.options.ID != workflow.RunWorkflowName+"/"+runID.String() {
+		t.Fatalf("workflow id = %q, want %q", client.options.ID, workflow.RunWorkflowName+"/"+runID.String())
+	}
+	if client.options.TaskQueue != workflow.WorkflowTaskQueue {
+		t.Fatalf("task queue = %q, want %q", client.options.TaskQueue, workflow.WorkflowTaskQueue)
+	}
+
+	input, ok := client.args[0].(workflow.RunWorkflowInput)
+	if !ok {
+		t.Fatalf("workflow input type = %T, want workflow.RunWorkflowInput", client.args[0])
+	}
+	if input.RunID != runID {
+		t.Fatalf("run id = %s, want %s", input.RunID, runID)
+	}
+	if repo.params.RunID != runID {
+		t.Fatalf("persisted run id = %s, want %s", repo.params.RunID, runID)
+	}
+	if repo.params.TemporalWorkflowID != client.options.ID || repo.params.TemporalRunID != "run-id" {
+		t.Fatalf("persisted temporal ids = %#v", repo.params)
+	}
+}
+
+func TestTemporalRunWorkflowStarterReturnsTemporalIDPersistenceError(t *testing.T) {
+	runID := uuid.New()
+	persistErr := errors.New("db down")
+
+	err := NewTemporalRunWorkflowStarter(&fakeTemporalClient{}, &fakeRunTemporalIDRepository{err: persistErr}).
+		StartRunWorkflow(context.Background(), runID)
+	if !errors.Is(err, persistErr) {
+		t.Fatalf("StartRunWorkflow error = %v, want %v", err, persistErr)
+	}
+}
 
 func TestTemporalEvalSessionWorkflowStarterStartEvalSessionWorkflow(t *testing.T) {
 	sessionID := uuid.New()
@@ -108,4 +157,14 @@ func (f fakeWorkflowRun) Get(context.Context, interface{}) error {
 
 func (f fakeWorkflowRun) GetWithOptions(context.Context, interface{}, temporalsdk.WorkflowRunGetOptions) error {
 	return nil
+}
+
+type fakeRunTemporalIDRepository struct {
+	params repository.SetRunTemporalIDsParams
+	err    error
+}
+
+func (f *fakeRunTemporalIDRepository) SetRunTemporalIDs(_ context.Context, params repository.SetRunTemporalIDsParams) (domain.Run, error) {
+	f.params = params
+	return domain.Run{ID: params.RunID}, f.err
 }

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -51,6 +51,12 @@ type TransitionRunAgentStatusParams struct {
 	FailureReason *string
 }
 
+type ReapOrphanedRunsParams struct {
+	Cutoff time.Time
+	Reason string
+	Limit  int
+}
+
 type InsertRunStatusHistoryParams struct {
 	RunID           uuid.UUID
 	FromStatus      *domain.RunStatus
@@ -1775,6 +1781,87 @@ func (r *Repository) TransitionRunStatus(ctx context.Context, params TransitionR
 	}
 
 	return run, nil
+}
+
+func (r *Repository) ReapOrphanedRuns(ctx context.Context, params ReapOrphanedRunsParams) ([]domain.Run, error) {
+	if params.Cutoff.IsZero() {
+		return nil, fmt.Errorf("orphaned run cleanup cutoff is required")
+	}
+	reason := strings.TrimSpace(params.Reason)
+	if reason == "" {
+		reason = "orphaned run reaper: no temporal workflow id after threshold"
+	}
+	limit := params.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin orphaned run cleanup transaction: %w", err)
+	}
+	defer rollback(ctx, tx)
+
+	rows, err := tx.Query(ctx, `
+		SELECT *
+		FROM runs
+		WHERE status IN ('queued', 'provisioning')
+		  AND temporal_workflow_id IS NULL
+		  AND temporal_run_id IS NULL
+		  AND created_at < $1
+		ORDER BY created_at ASC, id ASC
+		LIMIT $2
+		FOR UPDATE SKIP LOCKED
+	`, params.Cutoff.UTC(), limit)
+	if err != nil {
+		return nil, fmt.Errorf("select orphaned runs for cleanup: %w", err)
+	}
+	selectedRows, err := pgx.CollectRows(rows, pgx.RowToStructByName[repositorysqlc.Run])
+	if err != nil {
+		return nil, fmt.Errorf("collect orphaned runs for cleanup: %w", err)
+	}
+	if len(selectedRows) == 0 {
+		if err := tx.Commit(ctx); err != nil {
+			return nil, fmt.Errorf("commit empty orphaned run cleanup: %w", err)
+		}
+		return nil, nil
+	}
+
+	queries := r.queries.WithTx(tx)
+	cleaned := make([]domain.Run, 0, len(selectedRows))
+	for _, row := range selectedRows {
+		currentStatus, err := domain.ParseRunStatus(row.Status)
+		if err != nil {
+			return nil, fmt.Errorf("parse orphaned run %s status: %w", row.ID, err)
+		}
+		updatedRow, err := queries.UpdateRunStatus(ctx, repositorysqlc.UpdateRunStatusParams{
+			ID:         row.ID,
+			FromStatus: string(currentStatus),
+			ToStatus:   string(domain.RunStatusFailed),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("mark orphaned run %s failed: %w", row.ID, err)
+		}
+		_, err = queries.InsertRunStatusHistory(ctx, repositorysqlc.InsertRunStatusHistoryParams{
+			RunID:      row.ID,
+			FromStatus: stringPtr(string(currentStatus)),
+			ToStatus:   string(domain.RunStatusFailed),
+			Reason:     stringPtr(reason),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("insert orphaned run %s status history: %w", row.ID, err)
+		}
+		run, err := mapRun(updatedRow)
+		if err != nil {
+			return nil, fmt.Errorf("map orphaned run %s: %w", row.ID, err)
+		}
+		cleaned = append(cleaned, run)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit orphaned run cleanup: %w", err)
+	}
+	return cleaned, nil
 }
 
 func (r *Repository) TransitionRunAgentStatus(ctx context.Context, params TransitionRunAgentStatusParams) (domain.RunAgent, error) {

--- a/backend/internal/repository/repository_integration_test.go
+++ b/backend/internal/repository/repository_integration_test.go
@@ -1379,6 +1379,43 @@ func TestRepositorySetRunTemporalIDsRejectsReassignment(t *testing.T) {
 	}
 }
 
+func TestRepositorySetRunTemporalIDsRejectsTerminalRun(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	if _, err := db.Exec(ctx, `
+		UPDATE runs
+		SET status = 'failed',
+		    failed_at = now(),
+		    finished_at = now()
+		WHERE id = $1
+	`, fixture.runID); err != nil {
+		t.Fatalf("mark run failed returned error: %v", err)
+	}
+
+	_, err := repo.SetRunTemporalIDs(ctx, repository.SetRunTemporalIDsParams{
+		RunID:              fixture.runID,
+		TemporalWorkflowID: "run-workflow-123",
+		TemporalRunID:      "temporal-run-456",
+	})
+	if err == nil {
+		t.Fatalf("SetRunTemporalIDs returned nil error for terminal run")
+	}
+	if !errors.Is(err, repository.ErrTemporalIDConflict) {
+		t.Fatalf("SetRunTemporalIDs error = %v, want ErrTemporalIDConflict", err)
+	}
+
+	persisted, err := repo.GetRunByID(ctx, fixture.runID)
+	if err != nil {
+		t.Fatalf("GetRunByID after terminal temporal id rejection returned error: %v", err)
+	}
+	if persisted.TemporalWorkflowID != nil || persisted.TemporalRunID != nil {
+		t.Fatalf("persisted temporal ids = (%v, %v), want nil", persisted.TemporalWorkflowID, persisted.TemporalRunID)
+	}
+}
+
 func TestRepositoryTransitionRunStatusWritesCurrentStateAndHistory(t *testing.T) {
 	ctx := context.Background()
 	db := openTestDB(t)

--- a/backend/internal/repository/repository_integration_test.go
+++ b/backend/internal/repository/repository_integration_test.go
@@ -1538,6 +1538,77 @@ func TestRepositoryCreateQueuedRunWritesRunRunAgentsAndInitialHistory(t *testing
 	}
 }
 
+func TestRepositoryReapOrphanedRunsMarksOnlyOldQueuedAndProvisioningNullTemporalRunsFailed(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+	queries := repositorysqlc.New(db)
+
+	now := time.Date(2026, 5, 9, 20, 0, 0, 0, time.UTC)
+	oldAt := now.Add(-2 * time.Hour)
+	freshAt := now.Add(-5 * time.Minute)
+	cutoff := now.Add(-15 * time.Minute)
+
+	oldQueued, _ := createTestRun(t, ctx, repo, fixture, 1, "old-queued-orphan")
+	oldProvisioning, _ := createTestRun(t, ctx, repo, fixture, 1, "old-provisioning-orphan")
+	freshQueued, _ := createTestRun(t, ctx, repo, fixture, 1, "fresh-queued-orphan")
+	withWorkflowID, _ := createTestRun(t, ctx, repo, fixture, 1, "old-queued-workflow-id")
+	withRunID, _ := createTestRun(t, ctx, repo, fixture, 1, "old-queued-run-id")
+	oldRunning, _ := createTestRun(t, ctx, repo, fixture, 1, "old-running-null-temporal")
+	oldScoring, _ := createTestRun(t, ctx, repo, fixture, 1, "old-scoring-null-temporal")
+
+	setRunForOrphanReaperTest(t, ctx, db, oldQueued.ID, domain.RunStatusQueued, oldAt, nil, nil)
+	setRunForOrphanReaperTest(t, ctx, db, oldProvisioning.ID, domain.RunStatusProvisioning, oldAt, nil, nil)
+	setRunForOrphanReaperTest(t, ctx, db, freshQueued.ID, domain.RunStatusQueued, freshAt, nil, nil)
+	workflowID := "RunWorkflow/" + withWorkflowID.ID.String()
+	setRunForOrphanReaperTest(t, ctx, db, withWorkflowID.ID, domain.RunStatusQueued, oldAt, &workflowID, nil)
+	temporalRunID := "temporal-run-id"
+	setRunForOrphanReaperTest(t, ctx, db, withRunID.ID, domain.RunStatusQueued, oldAt, nil, &temporalRunID)
+	setRunForOrphanReaperTest(t, ctx, db, oldRunning.ID, domain.RunStatusRunning, oldAt, nil, nil)
+	setRunForOrphanReaperTest(t, ctx, db, oldScoring.ID, domain.RunStatusScoring, oldAt, nil, nil)
+
+	cleaned, err := repo.ReapOrphanedRuns(ctx, repository.ReapOrphanedRunsParams{
+		Cutoff: cutoff,
+		Reason: "test orphan cleanup",
+	})
+	if err != nil {
+		t.Fatalf("ReapOrphanedRuns returned error: %v", err)
+	}
+	if len(cleaned) != 2 {
+		t.Fatalf("cleaned count = %d, want 2: %+v", len(cleaned), cleaned)
+	}
+	cleanedIDs := map[uuid.UUID]bool{}
+	for _, run := range cleaned {
+		cleanedIDs[run.ID] = true
+		if run.Status != domain.RunStatusFailed {
+			t.Fatalf("cleaned run %s status = %s, want failed", run.ID, run.Status)
+		}
+		if run.FinishedAt == nil || run.FailedAt == nil {
+			t.Fatalf("cleaned run %s terminal timestamps missing: finished=%v failed=%v", run.ID, run.FinishedAt, run.FailedAt)
+		}
+	}
+	for _, runID := range []uuid.UUID{oldQueued.ID, oldProvisioning.ID} {
+		if !cleanedIDs[runID] {
+			t.Fatalf("run %s was not cleaned", runID)
+		}
+		historyRows, err := queries.ListRunStatusHistoryByRunID(ctx, repositorysqlc.ListRunStatusHistoryByRunIDParams{RunID: runID})
+		if err != nil {
+			t.Fatalf("ListRunStatusHistoryByRunID(%s) returned error: %v", runID, err)
+		}
+		last := historyRows[len(historyRows)-1]
+		if last.ToStatus != string(domain.RunStatusFailed) || last.Reason == nil || *last.Reason != "test orphan cleanup" {
+			t.Fatalf("last history for %s = %+v, want failed with cleanup reason", runID, last)
+		}
+	}
+
+	assertRunStatus(t, ctx, repo, freshQueued.ID, domain.RunStatusQueued)
+	assertRunStatus(t, ctx, repo, withWorkflowID.ID, domain.RunStatusQueued)
+	assertRunStatus(t, ctx, repo, withRunID.ID, domain.RunStatusQueued)
+	assertRunStatus(t, ctx, repo, oldRunning.ID, domain.RunStatusRunning)
+	assertRunStatus(t, ctx, repo, oldScoring.ID, domain.RunStatusScoring)
+}
+
 func TestRepositoryGetRunAgentReplayByRunAgentID(t *testing.T) {
 	ctx := context.Background()
 	db := openTestDB(t)
@@ -4008,6 +4079,51 @@ func setRunForClusterTrendTest(t *testing.T, ctx context.Context, db *pgxpool.Po
 		WHERE id = $1
 	`, runID, string(status), observedAt, finishedAt); err != nil {
 		t.Fatalf("set run %s for cluster trend test returned error: %v", runID, err)
+	}
+}
+
+func setRunForOrphanReaperTest(
+	t *testing.T,
+	ctx context.Context,
+	db *pgxpool.Pool,
+	runID uuid.UUID,
+	status domain.RunStatus,
+	createdAt time.Time,
+	temporalWorkflowID *string,
+	temporalRunID *string,
+) {
+	t.Helper()
+
+	var startedAt *time.Time
+	if status == domain.RunStatusProvisioning || status == domain.RunStatusRunning || status == domain.RunStatusScoring {
+		startedAt = &createdAt
+	}
+	if _, err := db.Exec(ctx, `
+		UPDATE runs
+		SET status = $2,
+		    temporal_workflow_id = $3,
+		    temporal_run_id = $4,
+		    created_at = $5,
+		    queued_at = $5,
+		    started_at = $6,
+		    finished_at = NULL,
+		    failed_at = NULL,
+		    cancelled_at = NULL
+		WHERE id = $1
+	`, runID, string(status), temporalWorkflowID, temporalRunID, createdAt, startedAt); err != nil {
+		t.Fatalf("set run %s for orphan reaper test returned error: %v", runID, err)
+	}
+}
+
+func assertRunStatus(t *testing.T, ctx context.Context, repo *repository.Repository, runID uuid.UUID, want domain.RunStatus) {
+	t.Helper()
+
+	run, err := repo.GetRunByID(ctx, runID)
+	if err != nil {
+		t.Fatalf("GetRunByID(%s) returned error: %v", runID, err)
+	}
+	if run.Status != want {
+		t.Fatalf("run %s status = %s, want %s", runID, run.Status, want)
 	}
 }
 

--- a/backend/internal/repository/sqlc/runs.sql.go
+++ b/backend/internal/repository/sqlc/runs.sql.go
@@ -604,6 +604,7 @@ SET temporal_workflow_id = $1,
 WHERE id = $3
   AND temporal_workflow_id IS NULL
   AND temporal_run_id IS NULL
+  AND status NOT IN ('completed', 'failed', 'cancelled')
 RETURNING id, organization_id, workspace_id, challenge_pack_version_id, challenge_input_set_id, created_by_user_id, name, status, execution_mode, temporal_workflow_id, temporal_run_id, execution_plan, queued_at, started_at, finished_at, cancelled_at, failed_at, created_at, updated_at, official_pack_mode, eval_session_id, race_context, race_context_min_step_gap, ci_metadata, source_type
 `
 

--- a/backend/internal/worker/config.go
+++ b/backend/internal/worker/config.go
@@ -16,35 +16,39 @@ import (
 )
 
 const (
-	defaultDatabaseURL            = "postgres://agentclash:agentclash@localhost:5432/agentclash?sslmode=disable"
-	defaultTemporalTarget         = "localhost:7233"
-	defaultNamespace              = "default"
-	defaultAppEnvironment         = "development"
-	defaultShutdownTime           = 10 * time.Second
-	defaultHostedCallbackBaseURL  = "http://localhost:8080"
-	defaultHostedCallbackSecret   = "agentclash-dev-hosted-callback-secret"
-	defaultArtifactStorageBackend = "filesystem"
-	defaultArtifactStorageBucket  = "agentclash-dev-artifacts"
-	defaultArtifactMaxAssetBytes  = 100 << 20
+	defaultDatabaseURL              = "postgres://agentclash:agentclash@localhost:5432/agentclash?sslmode=disable"
+	defaultTemporalTarget           = "localhost:7233"
+	defaultNamespace                = "default"
+	defaultAppEnvironment           = "development"
+	defaultShutdownTime             = 10 * time.Second
+	defaultHostedCallbackBaseURL    = "http://localhost:8080"
+	defaultHostedCallbackSecret     = "agentclash-dev-hosted-callback-secret"
+	defaultArtifactStorageBackend   = "filesystem"
+	defaultArtifactStorageBucket    = "agentclash-dev-artifacts"
+	defaultArtifactMaxAssetBytes    = 100 << 20
+	defaultOrphanRunReaperInterval  = 5 * time.Minute
+	defaultOrphanRunReaperThreshold = 15 * time.Minute
 )
 
 var ErrInvalidConfig = errors.New("invalid worker config")
 
 type Config struct {
-	AppEnvironment        string
-	DatabaseURL           string
-	TemporalAddress       string
-	TemporalNamespace     string
-	Identity              string
-	TaskQueue             string
-	HostedCallbackBaseURL string
-	HostedCallbackSecret  string
-	GitHubAppID           int64
-	GitHubAppPrivateKey   string
-	ShutdownTimeout       time.Duration
-	ArtifactStorage       ArtifactStorageConfig
-	Sandbox               SandboxConfig
-	SecretsCipher         *secrets.AESGCMCipher
+	AppEnvironment           string
+	DatabaseURL              string
+	TemporalAddress          string
+	TemporalNamespace        string
+	Identity                 string
+	TaskQueue                string
+	HostedCallbackBaseURL    string
+	HostedCallbackSecret     string
+	GitHubAppID              int64
+	GitHubAppPrivateKey      string
+	ShutdownTimeout          time.Duration
+	OrphanRunReaperInterval  time.Duration
+	OrphanRunReaperThreshold time.Duration
+	ArtifactStorage          ArtifactStorageConfig
+	Sandbox                  SandboxConfig
+	SecretsCipher            *secrets.AESGCMCipher
 }
 
 type ArtifactStorageConfig struct {
@@ -108,6 +112,14 @@ func LoadConfigFromEnv() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	orphanRunReaperInterval, err := durationEnvOrDefaultAllowZero("WORKER_ORPHAN_RUN_REAPER_INTERVAL", defaultOrphanRunReaperInterval)
+	if err != nil {
+		return Config{}, err
+	}
+	orphanRunReaperThreshold, err := durationEnvOrDefault("WORKER_ORPHAN_RUN_REAPER_THRESHOLD", defaultOrphanRunReaperThreshold)
+	if err != nil {
+		return Config{}, err
+	}
 	sandboxProvider, err := envOrDefault("SANDBOX_PROVIDER", "unconfigured")
 	if err != nil {
 		return Config{}, err
@@ -163,17 +175,19 @@ func LoadConfigFromEnv() (Config, error) {
 	}
 
 	return Config{
-		AppEnvironment:        appEnvironment,
-		DatabaseURL:           databaseURL,
-		TemporalAddress:       temporalAddress,
-		TemporalNamespace:     temporalNamespace,
-		Identity:              identity,
-		TaskQueue:             workflow.WorkflowTaskQueue,
-		HostedCallbackBaseURL: hostedCallbackBaseURL,
-		HostedCallbackSecret:  hostedCallbackSecret,
-		GitHubAppID:           githubAppID,
-		GitHubAppPrivateKey:   normalizePEMEnv(os.Getenv("GITHUB_APP_PRIVATE_KEY")),
-		ShutdownTimeout:       shutdownTimeout,
+		AppEnvironment:           appEnvironment,
+		DatabaseURL:              databaseURL,
+		TemporalAddress:          temporalAddress,
+		TemporalNamespace:        temporalNamespace,
+		Identity:                 identity,
+		TaskQueue:                workflow.WorkflowTaskQueue,
+		HostedCallbackBaseURL:    hostedCallbackBaseURL,
+		HostedCallbackSecret:     hostedCallbackSecret,
+		GitHubAppID:              githubAppID,
+		GitHubAppPrivateKey:      normalizePEMEnv(os.Getenv("GITHUB_APP_PRIVATE_KEY")),
+		ShutdownTimeout:          shutdownTimeout,
+		OrphanRunReaperInterval:  orphanRunReaperInterval,
+		OrphanRunReaperThreshold: orphanRunReaperThreshold,
 		ArtifactStorage: ArtifactStorageConfig{
 			Backend:          artifactStorageBackend,
 			Bucket:           artifactStorageBucket,
@@ -320,6 +334,26 @@ func durationEnvOrDefault(key string, fallback time.Duration) (time.Duration, er
 	}
 	if duration <= 0 {
 		return 0, fmt.Errorf("%w: %s must be greater than zero", ErrInvalidConfig, key)
+	}
+
+	return duration, nil
+}
+
+func durationEnvOrDefaultAllowZero(key string, fallback time.Duration) (time.Duration, error) {
+	value, ok := os.LookupEnv(key)
+	if !ok {
+		return fallback, nil
+	}
+	if value == "" {
+		return 0, fmt.Errorf("%w: %s cannot be empty", ErrInvalidConfig, key)
+	}
+
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %s must be a valid duration: %v", ErrInvalidConfig, key, err)
+	}
+	if duration < 0 {
+		return 0, fmt.Errorf("%w: %s must be zero or greater", ErrInvalidConfig, key)
 	}
 
 	return duration, nil

--- a/backend/internal/worker/config_test.go
+++ b/backend/internal/worker/config_test.go
@@ -16,6 +16,8 @@ func TestLoadConfigFromEnvUsesDefaultsWhenUnset(t *testing.T) {
 	unsetEnv(t, "TEMPORAL_NAMESPACE")
 	unsetEnv(t, "WORKER_IDENTITY")
 	unsetEnv(t, "WORKER_SHUTDOWN_TIMEOUT")
+	unsetEnv(t, "WORKER_ORPHAN_RUN_REAPER_INTERVAL")
+	unsetEnv(t, "WORKER_ORPHAN_RUN_REAPER_THRESHOLD")
 	unsetEnv(t, "SANDBOX_PROVIDER")
 	unsetEnv(t, "E2B_API_KEY")
 	unsetEnv(t, "E2B_TEMPLATE_ID")
@@ -56,6 +58,12 @@ func TestLoadConfigFromEnvUsesDefaultsWhenUnset(t *testing.T) {
 	}
 	if cfg.ShutdownTimeout != defaultShutdownTime {
 		t.Fatalf("ShutdownTimeout = %s, want %s", cfg.ShutdownTimeout, defaultShutdownTime)
+	}
+	if cfg.OrphanRunReaperInterval != defaultOrphanRunReaperInterval {
+		t.Fatalf("OrphanRunReaperInterval = %s, want %s", cfg.OrphanRunReaperInterval, defaultOrphanRunReaperInterval)
+	}
+	if cfg.OrphanRunReaperThreshold != defaultOrphanRunReaperThreshold {
+		t.Fatalf("OrphanRunReaperThreshold = %s, want %s", cfg.OrphanRunReaperThreshold, defaultOrphanRunReaperThreshold)
 	}
 	if cfg.Sandbox.Provider != "unconfigured" {
 		t.Fatalf("Sandbox.Provider = %q, want unconfigured", cfg.Sandbox.Provider)
@@ -115,6 +123,8 @@ func TestLoadConfigFromEnvOverrides(t *testing.T) {
 	t.Setenv("TEMPORAL_NAMESPACE", "agentclash-dev")
 	t.Setenv("WORKER_IDENTITY", "worker-dev-1")
 	t.Setenv("WORKER_SHUTDOWN_TIMEOUT", "30s")
+	t.Setenv("WORKER_ORPHAN_RUN_REAPER_INTERVAL", "0s")
+	t.Setenv("WORKER_ORPHAN_RUN_REAPER_THRESHOLD", "1h")
 	t.Setenv("SANDBOX_PROVIDER", "e2b")
 	t.Setenv("E2B_API_KEY", "key")
 	t.Setenv("E2B_TEMPLATE_ID", "tmpl")
@@ -151,6 +161,12 @@ func TestLoadConfigFromEnvOverrides(t *testing.T) {
 	}
 	if cfg.ShutdownTimeout != 30*time.Second {
 		t.Fatalf("ShutdownTimeout = %s, want %s", cfg.ShutdownTimeout, 30*time.Second)
+	}
+	if cfg.OrphanRunReaperInterval != 0 {
+		t.Fatalf("OrphanRunReaperInterval = %s, want disabled interval 0", cfg.OrphanRunReaperInterval)
+	}
+	if cfg.OrphanRunReaperThreshold != time.Hour {
+		t.Fatalf("OrphanRunReaperThreshold = %s, want 1h", cfg.OrphanRunReaperThreshold)
 	}
 	if cfg.Sandbox.Provider != "e2b" {
 		t.Fatalf("Sandbox.Provider = %q, want e2b", cfg.Sandbox.Provider)

--- a/backend/internal/worker/orphan_run_reaper.go
+++ b/backend/internal/worker/orphan_run_reaper.go
@@ -13,6 +13,11 @@ type OrphanRunReaperRepository interface {
 	ReapOrphanedRuns(ctx context.Context, params repository.ReapOrphanedRunsParams) ([]domain.Run, error)
 }
 
+const (
+	orphanRunReaperBatchLimit = 500
+	orphanRunReaperMaxBatches = 20
+)
+
 type RepositoryOrphanRunReaper struct {
 	repo      OrphanRunReaperRepository
 	interval  time.Duration
@@ -57,15 +62,23 @@ func (r *RepositoryOrphanRunReaper) Start(ctx context.Context) {
 
 func (r *RepositoryOrphanRunReaper) reapOnce(ctx context.Context) {
 	cutoff := r.now().UTC().Add(-r.threshold)
-	cleaned, err := r.repo.ReapOrphanedRuns(ctx, repository.ReapOrphanedRunsParams{
-		Cutoff: cutoff,
-		Reason: "orphaned run reaper: no temporal workflow id after threshold",
-	})
-	if err != nil {
-		r.logger.Error("orphaned run reaper failed", "error", err)
-		return
+	totalCleaned := 0
+	for batch := 0; batch < orphanRunReaperMaxBatches; batch++ {
+		cleaned, err := r.repo.ReapOrphanedRuns(ctx, repository.ReapOrphanedRunsParams{
+			Cutoff: cutoff,
+			Limit:  orphanRunReaperBatchLimit,
+			Reason: "orphaned run reaper: no temporal workflow id after threshold",
+		})
+		if err != nil {
+			r.logger.Error("orphaned run reaper failed", "error", err)
+			return
+		}
+		totalCleaned += len(cleaned)
+		if len(cleaned) < orphanRunReaperBatchLimit {
+			break
+		}
 	}
-	if len(cleaned) > 0 {
-		r.logger.Warn("orphaned run reaper marked runs failed", "count", len(cleaned), "cutoff", cutoff)
+	if totalCleaned > 0 {
+		r.logger.Warn("orphaned run reaper marked runs failed", "count", totalCleaned, "cutoff", cutoff)
 	}
 }

--- a/backend/internal/worker/orphan_run_reaper.go
+++ b/backend/internal/worker/orphan_run_reaper.go
@@ -1,0 +1,71 @@
+package worker
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/domain"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+)
+
+type OrphanRunReaperRepository interface {
+	ReapOrphanedRuns(ctx context.Context, params repository.ReapOrphanedRunsParams) ([]domain.Run, error)
+}
+
+type RepositoryOrphanRunReaper struct {
+	repo      OrphanRunReaperRepository
+	interval  time.Duration
+	threshold time.Duration
+	logger    *slog.Logger
+	now       func() time.Time
+}
+
+func NewRepositoryOrphanRunReaper(
+	repo OrphanRunReaperRepository,
+	interval time.Duration,
+	threshold time.Duration,
+	logger *slog.Logger,
+) *RepositoryOrphanRunReaper {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &RepositoryOrphanRunReaper{
+		repo:      repo,
+		interval:  interval,
+		threshold: threshold,
+		logger:    logger,
+		now:       time.Now,
+	}
+}
+
+func (r *RepositoryOrphanRunReaper) Start(ctx context.Context) {
+	if r == nil || r.repo == nil || r.interval <= 0 || r.threshold <= 0 {
+		return
+	}
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.reapOnce(ctx)
+		}
+	}
+}
+
+func (r *RepositoryOrphanRunReaper) reapOnce(ctx context.Context) {
+	cutoff := r.now().UTC().Add(-r.threshold)
+	cleaned, err := r.repo.ReapOrphanedRuns(ctx, repository.ReapOrphanedRunsParams{
+		Cutoff: cutoff,
+		Reason: "orphaned run reaper: no temporal workflow id after threshold",
+	})
+	if err != nil {
+		r.logger.Error("orphaned run reaper failed", "error", err)
+		return
+	}
+	if len(cleaned) > 0 {
+		r.logger.Warn("orphaned run reaper marked runs failed", "count", len(cleaned), "cutoff", cutoff)
+	}
+}

--- a/backend/internal/worker/orphan_run_reaper_test.go
+++ b/backend/internal/worker/orphan_run_reaper_test.go
@@ -73,17 +73,47 @@ func TestRepositoryOrphanRunReaperSwallowsRepositoryError(t *testing.T) {
 	<-done
 }
 
+func TestRepositoryOrphanRunReaperDrainsBoundedBatches(t *testing.T) {
+	repo := &fakeOrphanRunReaperRepo{batchSizes: []int{
+		orphanRunReaperBatchLimit,
+		orphanRunReaperBatchLimit,
+		5,
+	}}
+	reaper := NewRepositoryOrphanRunReaper(repo, time.Minute, 15*time.Minute, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	reaper.now = func() time.Time { return time.Date(2026, 5, 9, 20, 0, 0, 0, time.UTC) }
+
+	reaper.reapOnce(context.Background())
+
+	if got := int(repo.calls.Load()); got != 3 {
+		t.Fatalf("calls = %d, want 3", got)
+	}
+	if repo.lastLimit != orphanRunReaperBatchLimit {
+		t.Fatalf("limit = %d, want %d", repo.lastLimit, orphanRunReaperBatchLimit)
+	}
+}
+
 type fakeOrphanRunReaperRepo struct {
 	calls      atomic.Int32
 	lastCutoff time.Time
+	lastLimit  int
+	batchSizes []int
 	err        error
 }
 
 func (f *fakeOrphanRunReaperRepo) ReapOrphanedRuns(_ context.Context, params repository.ReapOrphanedRunsParams) ([]domain.Run, error) {
-	f.calls.Add(1)
+	call := int(f.calls.Add(1))
 	f.lastCutoff = params.Cutoff
+	f.lastLimit = params.Limit
 	if f.err != nil {
 		return nil, f.err
 	}
-	return []domain.Run{{Status: domain.RunStatusFailed}}, nil
+	size := 1
+	if call <= len(f.batchSizes) {
+		size = f.batchSizes[call-1]
+	}
+	runs := make([]domain.Run, size)
+	for i := range runs {
+		runs[i] = domain.Run{Status: domain.RunStatusFailed}
+	}
+	return runs, nil
 }

--- a/backend/internal/worker/orphan_run_reaper_test.go
+++ b/backend/internal/worker/orphan_run_reaper_test.go
@@ -1,0 +1,89 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/domain"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+)
+
+func TestRepositoryOrphanRunReaperRunsOnTickAndStops(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	repo := &fakeOrphanRunReaperRepo{}
+	reaper := NewRepositoryOrphanRunReaper(repo, time.Millisecond, 15*time.Minute, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	reaper.now = func() time.Time { return time.Date(2026, 5, 9, 20, 0, 0, 0, time.UTC) }
+
+	done := make(chan struct{})
+	go func() {
+		reaper.Start(ctx)
+		close(done)
+	}()
+
+	waitForCondition(t, time.Second, func() bool {
+		return repo.calls.Load() > 0
+	})
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("reaper did not stop after context cancellation")
+	}
+	if !repo.lastCutoff.Equal(time.Date(2026, 5, 9, 19, 45, 0, 0, time.UTC)) {
+		t.Fatalf("cutoff = %s, want 2026-05-09T19:45:00Z", repo.lastCutoff)
+	}
+}
+
+func TestRepositoryOrphanRunReaperDisabledIntervalDoesNothing(t *testing.T) {
+	repo := &fakeOrphanRunReaperRepo{}
+	reaper := NewRepositoryOrphanRunReaper(repo, 0, 15*time.Minute, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	reaper.Start(context.Background())
+
+	if repo.calls.Load() != 0 {
+		t.Fatalf("calls = %d, want 0", repo.calls.Load())
+	}
+}
+
+func TestRepositoryOrphanRunReaperSwallowsRepositoryError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	repo := &fakeOrphanRunReaperRepo{err: errors.New("db down")}
+	reaper := NewRepositoryOrphanRunReaper(repo, time.Millisecond, 15*time.Minute, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	done := make(chan struct{})
+	go func() {
+		reaper.Start(ctx)
+		close(done)
+	}()
+
+	waitForCondition(t, time.Second, func() bool {
+		return repo.calls.Load() > 0
+	})
+	cancel()
+	<-done
+}
+
+type fakeOrphanRunReaperRepo struct {
+	calls      atomic.Int32
+	lastCutoff time.Time
+	err        error
+}
+
+func (f *fakeOrphanRunReaperRepo) ReapOrphanedRuns(_ context.Context, params repository.ReapOrphanedRunsParams) ([]domain.Run, error) {
+	f.calls.Add(1)
+	f.lastCutoff = params.Cutoff
+	if f.err != nil {
+		return nil, f.err
+	}
+	return []domain.Run{{Status: domain.RunStatusFailed}}, nil
+}

--- a/backend/internal/worker/service.go
+++ b/backend/internal/worker/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/provider"
@@ -17,6 +18,10 @@ import (
 type TemporalWorker interface {
 	Start() error
 	Stop()
+}
+
+type OrphanRunReaper interface {
+	Start(ctx context.Context)
 }
 
 // executionHooks is the temporary extension seam for later hosted and native
@@ -44,6 +49,10 @@ func NewTemporalWorker(
 }
 
 func Run(ctx context.Context, cfg Config, temporalWorker TemporalWorker, logger *slog.Logger) error {
+	return RunWithReaper(ctx, cfg, temporalWorker, nil, logger)
+}
+
+func RunWithReaper(ctx context.Context, cfg Config, temporalWorker TemporalWorker, reaper OrphanRunReaper, logger *slog.Logger) error {
 	logger.Info("starting worker",
 		"task_queue", cfg.TaskQueue,
 		"identity", cfg.Identity,
@@ -53,6 +62,15 @@ func Run(ctx context.Context, cfg Config, temporalWorker TemporalWorker, logger 
 
 	if err := temporalWorker.Start(); err != nil {
 		return fmt.Errorf("start temporal worker: %w", err)
+	}
+
+	var wg sync.WaitGroup
+	if reaper != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			reaper.Start(ctx)
+		}()
 	}
 
 	<-ctx.Done()
@@ -70,6 +88,7 @@ func Run(ctx context.Context, cfg Config, temporalWorker TemporalWorker, logger 
 
 	select {
 	case <-stoppedCh:
+		wg.Wait()
 		return nil
 	case <-timer.C:
 		return fmt.Errorf("worker shutdown timed out after %s", cfg.ShutdownTimeout)

--- a/backend/internal/worker/service.go
+++ b/backend/internal/worker/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"sync"
 	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/provider"
@@ -64,13 +63,14 @@ func RunWithReaper(ctx context.Context, cfg Config, temporalWorker TemporalWorke
 		return fmt.Errorf("start temporal worker: %w", err)
 	}
 
-	var wg sync.WaitGroup
+	reaperDoneCh := make(chan struct{})
 	if reaper != nil {
-		wg.Add(1)
 		go func() {
-			defer wg.Done()
+			defer close(reaperDoneCh)
 			reaper.Start(ctx)
 		}()
+	} else {
+		close(reaperDoneCh)
 	}
 
 	<-ctx.Done()
@@ -86,11 +86,19 @@ func RunWithReaper(ctx context.Context, cfg Config, temporalWorker TemporalWorke
 	timer := time.NewTimer(cfg.ShutdownTimeout)
 	defer timer.Stop()
 
-	select {
-	case <-stoppedCh:
-		wg.Wait()
-		return nil
-	case <-timer.C:
-		return fmt.Errorf("worker shutdown timed out after %s", cfg.ShutdownTimeout)
+	workerStopped := false
+	reaperStopped := false
+	for !workerStopped || !reaperStopped {
+		select {
+		case <-stoppedCh:
+			workerStopped = true
+			stoppedCh = nil
+		case <-reaperDoneCh:
+			reaperStopped = true
+			reaperDoneCh = nil
+		case <-timer.C:
+			return fmt.Errorf("worker shutdown timed out after %s", cfg.ShutdownTimeout)
+		}
 	}
+	return nil
 }

--- a/backend/internal/worker/service_test.go
+++ b/backend/internal/worker/service_test.go
@@ -44,6 +44,43 @@ func TestRunStartsAndStopsWorker(t *testing.T) {
 	}
 }
 
+func TestRunWithReaperStartsAndStopsReaper(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fakeWorker := &fakeTemporalWorker{
+		stopCh: make(chan struct{}),
+	}
+	reaper := &fakeWorkerReaper{
+		doneCh: make(chan struct{}),
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	resultCh := make(chan error, 1)
+	go func() {
+		resultCh <- RunWithReaper(ctx, Config{
+			TaskQueue:       "RunWorkflow",
+			Identity:        "worker-test",
+			TemporalAddress: "localhost:7233",
+			ShutdownTimeout: time.Second,
+		}, fakeWorker, reaper, logger)
+	}()
+
+	waitForCondition(t, time.Second, func() bool {
+		return fakeWorker.startCalls.Load() == 1 && reaper.startCalls.Load() == 1
+	})
+
+	cancel()
+
+	err := <-resultCh
+	if err != nil {
+		t.Fatalf("RunWithReaper returned error: %v", err)
+	}
+	if fakeWorker.stopCalls.Load() != 1 {
+		t.Fatalf("stop calls = %d, want 1", fakeWorker.stopCalls.Load())
+	}
+}
+
 func TestRunReturnsStartError(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	startErr := errors.New("temporal unavailable")
@@ -107,6 +144,17 @@ type fakeTemporalWorker struct {
 	blockStop  bool
 	startCalls atomic.Int32
 	stopCalls  atomic.Int32
+}
+
+type fakeWorkerReaper struct {
+	startCalls atomic.Int32
+	doneCh     chan struct{}
+}
+
+func (f *fakeWorkerReaper) Start(ctx context.Context) {
+	f.startCalls.Add(1)
+	<-ctx.Done()
+	close(f.doneCh)
 }
 
 func (f *fakeTemporalWorker) Start() error {

--- a/backend/internal/worker/service_test.go
+++ b/backend/internal/worker/service_test.go
@@ -138,6 +138,45 @@ func TestRunReturnsShutdownTimeout(t *testing.T) {
 	}
 }
 
+func TestRunWithReaperReturnsShutdownTimeoutWhenReaperBlocks(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	fakeWorker := &fakeTemporalWorker{
+		stopCh: make(chan struct{}),
+	}
+	reaper := &fakeWorkerReaper{
+		doneCh:    make(chan struct{}),
+		blockDone: true,
+	}
+
+	resultCh := make(chan error, 1)
+	go func() {
+		resultCh <- RunWithReaper(ctx, Config{
+			TaskQueue:       "RunWorkflow",
+			Identity:        "worker-test",
+			TemporalAddress: "localhost:7233",
+			ShutdownTimeout: 10 * time.Millisecond,
+		}, fakeWorker, reaper, logger)
+	}()
+
+	waitForCondition(t, time.Second, func() bool {
+		return fakeWorker.startCalls.Load() == 1 && reaper.startCalls.Load() == 1
+	})
+
+	cancel()
+
+	err := <-resultCh
+	if err == nil {
+		t.Fatalf("RunWithReaper returned nil error")
+	}
+	close(reaper.doneCh)
+	if got := err.Error(); got != "worker shutdown timed out after 10ms" {
+		t.Fatalf("error = %q, want shutdown timeout", got)
+	}
+}
+
 type fakeTemporalWorker struct {
 	startErr   error
 	stopCh     chan struct{}
@@ -149,11 +188,16 @@ type fakeTemporalWorker struct {
 type fakeWorkerReaper struct {
 	startCalls atomic.Int32
 	doneCh     chan struct{}
+	blockDone  bool
 }
 
 func (f *fakeWorkerReaper) Start(ctx context.Context) {
 	f.startCalls.Add(1)
 	<-ctx.Done()
+	if f.blockDone {
+		<-f.doneCh
+		return
+	}
 	close(f.doneCh)
 }
 

--- a/testing/codex-roadmap-693-orphan-run-reaper-grill.md
+++ b/testing/codex-roadmap-693-orphan-run-reaper-grill.md
@@ -1,0 +1,28 @@
+# Grill Review: codex/roadmap-693-orphan-run-reaper
+
+## Decisions tested
+
+- Predicate scope — recommendation: clean only `queued`/`provisioning` rows with both Temporal IDs NULL and older than cutoff — trade-off accepted: some bad `running`/`scoring` rows remain for future/manual remediation, but this PR avoids killing real workflows.
+- Status target — recommendation: transition to `failed`, not `cancelled` — trade-off accepted: these are infrastructure failures, not user-requested cancellations.
+- Quota behavior — recommendation: release active concurrency by changing terminal status, but do not touch monthly race counters — trade-off accepted: billing/accounting semantics stay unchanged.
+- Worker wiring — recommendation: periodic worker loop with interval-disable guard and conservative threshold — trade-off accepted: cleanup is eventually consistent, not immediate.
+
+## Evidence checked
+
+- Local `RunCreationManager.CreateRun` persists queued runs before calling `StartRunWorkflow`, so workflow-start failures can strand active rows.
+- Local `CountActiveWorkspaceRuns` counts `queued`, `provisioning`, `running`, and `scoring`, so stranded rows consume concurrency.
+- Local run status transitions allow `queued` and `provisioning` to transition to `failed`.
+- Local `runs.sql` status update already sets `finished_at`/`failed_at` for failed terminal transitions.
+
+## Blockers
+
+- None.
+
+## Major concerns
+
+- **Severity: major** — If cleanup is implemented as a broad SQL update without checking both Temporal IDs and cutoff, it could fail legitimate work. Recommended fix: keep predicate exact and test skip cases.
+- **Severity: major** — If cleanup updates status without history, operators cannot audit why runs failed. Recommended fix: write status history for every cleaned run.
+
+## Questions for autonomous resolution
+
+- None.

--- a/testing/codex-roadmap-693-orphan-run-reaper.md
+++ b/testing/codex-roadmap-693-orphan-run-reaper.md
@@ -1,0 +1,71 @@
+# codex/roadmap-693-orphan-run-reaper — Test Contract
+
+## Files touched
+
+- `backend/db/queries/runs.sql` — add an atomic query for stale orphan run cleanup.
+- `backend/internal/repository/repository.go` — expose a cleanup method that maps cleaned run rows and writes status history.
+- `backend/internal/repository/repository_integration_test.go` or focused repository tests — cover cleanup predicates.
+- `backend/internal/worker/config.go` — add conservative reaper interval/threshold configuration.
+- `backend/internal/worker/orphan_run_reaper.go` — periodic worker loop.
+- `backend/internal/worker/orphan_run_reaper_test.go` — unit-test loop behavior without sleeping.
+- `backend/cmd/worker/main.go` — wire the reaper into worker startup.
+
+## External APIs used
+
+- Go `time.Ticker` and context cancellation for the periodic worker loop — verified-as-of: 2026-05-09 — source URL: https://pkg.go.dev/time#Ticker
+- No Temporal API calls are used in this PR. Runs are selected only when `temporal_workflow_id IS NULL`.
+
+## Rollback strategy
+
+Revert this PR. The change is additive and does not introduce a schema migration. If the worker loop causes unexpected cleanup, set the interval to zero or revert worker wiring; already-marked rows remain failed as an auditable terminal state.
+
+## Functional Behavior
+
+- The cleanup predicate is exactly:
+  - `status IN ('queued', 'provisioning')`
+  - `temporal_workflow_id IS NULL`
+  - `temporal_run_id IS NULL`
+  - `created_at < cutoff`
+- Matching runs transition to `failed`.
+- `finished_at` and `failed_at` are set if they were unset.
+- A `run_status_history` row is written with a clear reaper reason.
+- Runs in `running` or `scoring` are not reaped in this first PR.
+- Runs with any Temporal workflow/run ID are not reaped.
+- Fresh rows newer than the cutoff are not reaped.
+- Monthly quota counters are not changed.
+- The worker loop is conservative and configurable:
+  - default threshold is at least 15 minutes.
+  - default interval is nonzero in worker runtime.
+  - interval <= 0 disables the loop.
+
+## Unit Tests
+
+- Repository cleanup test marks only old queued/provisioning NULL-Temporal rows failed.
+- Repository cleanup test skips fresh NULL-Temporal rows.
+- Repository cleanup test skips rows with Temporal workflow or run IDs.
+- Repository cleanup test skips running/scoring rows even if old and NULL-Temporal.
+- Repository cleanup test writes one status-history row per cleaned run.
+- Worker reaper test invokes cleanup once per tick and stops cleanly on context cancellation.
+- Worker reaper test does nothing when interval is disabled.
+
+## Integration / Functional Tests
+
+```bash
+cd backend
+go test ./internal/repository ./internal/worker
+```
+
+## Smoke Tests
+
+```bash
+cd backend
+go test ./...
+```
+
+## E2E Tests
+
+No hosted mutation smoke for this PR. The reaper is a backend worker safety mechanism and should be verified through repository/worker tests before deployment. After deploy, operators can observe logs for cleaned run counts.
+
+## Manual / cURL Tests
+
+N/A — this PR intentionally adds no public API or CLI command.


### PR DESCRIPTION
Implements #694.

Parent roadmap: #693

Test contract: `testing/codex-roadmap-693-orphan-run-reaper.md`

## Summary

Adds a conservative worker-side orphan-run reaper for runs stranded before Temporal workflow publication. The cleanup only marks stale `queued`/`provisioning` runs failed when both `temporal_workflow_id` and `temporal_run_id` are NULL and the run is older than the configured threshold.

This intentionally does not add manual cancellation, quota visibility, or quota refunds. Those are tracked separately in #695 and #696.

## Verification

- `cd backend && go test ./internal/repository ./internal/worker`
- `cd backend && go test ./...`

## Notes

- `WORKER_ORPHAN_RUN_REAPER_INTERVAL=0s` disables the loop.
- Default interval is 5m; default threshold is 15m.
- Each cleaned run gets a `run_status_history` row with the reaper reason.
