### PR TITLE
fix: log orphan reaper run ids

### DIFF
--- a/backend/internal/worker/orphan_run_reaper.go
+++ b/backend/internal/worker/orphan_run_reaper.go
@@ -16,6 +16,7 @@ type OrphanRunReaperRepository interface {
 const (
 	orphanRunReaperBatchLimit = 500
 	orphanRunReaperMaxBatches = 20
+	orphanRunReaperLogIDLimit = 25
 )
 
 type RepositoryOrphanRunReaper struct {
@@ -63,6 +64,7 @@ func (r *RepositoryOrphanRunReaper) Start(ctx context.Context) {
 func (r *RepositoryOrphanRunReaper) reapOnce(ctx context.Context) {
 	cutoff := r.now().UTC().Add(-r.threshold)
 	totalCleaned := 0
+	runIDSample := make([]string, 0, orphanRunReaperLogIDLimit)
 	for batch := 0; batch < orphanRunReaperMaxBatches; batch++ {
 		cleaned, err := r.repo.ReapOrphanedRuns(ctx, repository.ReapOrphanedRunsParams{
 			Cutoff: cutoff,
@@ -74,11 +76,23 @@ func (r *RepositoryOrphanRunReaper) reapOnce(ctx context.Context) {
 			return
 		}
 		totalCleaned += len(cleaned)
+		for _, run := range cleaned {
+			if len(runIDSample) >= orphanRunReaperLogIDLimit {
+				break
+			}
+			runIDSample = append(runIDSample, run.ID.String())
+		}
 		if len(cleaned) < orphanRunReaperBatchLimit {
 			break
 		}
 	}
 	if totalCleaned > 0 {
-		r.logger.Warn("orphaned run reaper marked runs failed", "count", totalCleaned, "cutoff", cutoff)
+		r.logger.Warn(
+			"orphaned run reaper marked runs failed",
+			"count", totalCleaned,
+			"cutoff", cutoff,
+			"run_ids", runIDSample,
+			"run_ids_truncated", totalCleaned > len(runIDSample),
+		)
 	}
 }

--- a/backend/internal/worker/orphan_run_reaper_test.go
+++ b/backend/internal/worker/orphan_run_reaper_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"strings"
@@ -96,9 +97,8 @@ func TestRepositoryOrphanRunReaperDrainsBoundedBatches(t *testing.T) {
 }
 
 func TestRepositoryOrphanRunReaperLogsRunIDSample(t *testing.T) {
-	runIDOne := uuid.MustParse("00000000-0000-0000-0000-000000000001")
-	runIDTwo := uuid.MustParse("00000000-0000-0000-0000-000000000002")
-	repo := &fakeOrphanRunReaperRepo{runIDs: []uuid.UUID{runIDOne, runIDTwo}}
+	runIDs := sequentialRunIDs(2)
+	repo := &fakeOrphanRunReaperRepo{runIDs: runIDs}
 	var logBuffer bytes.Buffer
 	reaper := NewRepositoryOrphanRunReaper(repo, time.Minute, 15*time.Minute, slog.New(slog.NewTextHandler(&logBuffer, nil)))
 	reaper.now = func() time.Time { return time.Date(2026, 5, 9, 20, 0, 0, 0, time.UTC) }
@@ -106,12 +106,41 @@ func TestRepositoryOrphanRunReaperLogsRunIDSample(t *testing.T) {
 	reaper.reapOnce(context.Background())
 
 	logLine := logBuffer.String()
-	if !strings.Contains(logLine, runIDOne.String()) || !strings.Contains(logLine, runIDTwo.String()) {
+	if !strings.Contains(logLine, runIDs[0].String()) || !strings.Contains(logLine, runIDs[1].String()) {
 		t.Fatalf("log line = %q, want sampled run ids", logLine)
 	}
 	if !strings.Contains(logLine, "run_ids_truncated=false") {
 		t.Fatalf("log line = %q, want run_ids_truncated=false", logLine)
 	}
+}
+
+func TestRepositoryOrphanRunReaperLogsTruncatedRunIDSample(t *testing.T) {
+	runIDs := sequentialRunIDs(orphanRunReaperLogIDLimit + 1)
+	repo := &fakeOrphanRunReaperRepo{runIDs: runIDs}
+	var logBuffer bytes.Buffer
+	reaper := NewRepositoryOrphanRunReaper(repo, time.Minute, 15*time.Minute, slog.New(slog.NewTextHandler(&logBuffer, nil)))
+	reaper.now = func() time.Time { return time.Date(2026, 5, 9, 20, 0, 0, 0, time.UTC) }
+
+	reaper.reapOnce(context.Background())
+
+	logLine := logBuffer.String()
+	if !strings.Contains(logLine, "run_ids_truncated=true") {
+		t.Fatalf("log line = %q, want run_ids_truncated=true", logLine)
+	}
+	if got := strings.Count(logLine, "00000000-0000-0000-0000-"); got != orphanRunReaperLogIDLimit {
+		t.Fatalf("logged run id count = %d, want %d in %q", got, orphanRunReaperLogIDLimit, logLine)
+	}
+	if strings.Contains(logLine, runIDs[orphanRunReaperLogIDLimit].String()) {
+		t.Fatalf("log line = %q, did not want run ID beyond sample limit", logLine)
+	}
+}
+
+func sequentialRunIDs(count int) []uuid.UUID {
+	ids := make([]uuid.UUID, count)
+	for i := range ids {
+		ids[i] = uuid.MustParse(fmt.Sprintf("00000000-0000-0000-0000-%012d", i+1))
+	}
+	return ids
 }
 
 type fakeOrphanRunReaperRepo struct {
@@ -131,6 +160,9 @@ func (f *fakeOrphanRunReaperRepo) ReapOrphanedRuns(_ context.Context, params rep
 		return nil, f.err
 	}
 	if len(f.runIDs) > 0 {
+		if call > 1 {
+			return nil, nil
+		}
 		runs := make([]domain.Run, len(f.runIDs))
 		for i, runID := range f.runIDs {
 			runs[i] = domain.Run{ID: runID, Status: domain.RunStatusFailed}

--- a/backend/internal/worker/orphan_run_reaper_test.go
+++ b/backend/internal/worker/orphan_run_reaper_test.go
@@ -1,16 +1,19 @@
 package worker
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
 	"log/slog"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/domain"
 	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
 )
 
 func TestRepositoryOrphanRunReaperRunsOnTickAndStops(t *testing.T) {
@@ -92,11 +95,31 @@ func TestRepositoryOrphanRunReaperDrainsBoundedBatches(t *testing.T) {
 	}
 }
 
+func TestRepositoryOrphanRunReaperLogsRunIDSample(t *testing.T) {
+	runIDOne := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	runIDTwo := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	repo := &fakeOrphanRunReaperRepo{runIDs: []uuid.UUID{runIDOne, runIDTwo}}
+	var logBuffer bytes.Buffer
+	reaper := NewRepositoryOrphanRunReaper(repo, time.Minute, 15*time.Minute, slog.New(slog.NewTextHandler(&logBuffer, nil)))
+	reaper.now = func() time.Time { return time.Date(2026, 5, 9, 20, 0, 0, 0, time.UTC) }
+
+	reaper.reapOnce(context.Background())
+
+	logLine := logBuffer.String()
+	if !strings.Contains(logLine, runIDOne.String()) || !strings.Contains(logLine, runIDTwo.String()) {
+		t.Fatalf("log line = %q, want sampled run ids", logLine)
+	}
+	if !strings.Contains(logLine, "run_ids_truncated=false") {
+		t.Fatalf("log line = %q, want run_ids_truncated=false", logLine)
+	}
+}
+
 type fakeOrphanRunReaperRepo struct {
 	calls      atomic.Int32
 	lastCutoff time.Time
 	lastLimit  int
 	batchSizes []int
+	runIDs     []uuid.UUID
 	err        error
 }
 
@@ -106,6 +129,13 @@ func (f *fakeOrphanRunReaperRepo) ReapOrphanedRuns(_ context.Context, params rep
 	f.lastLimit = params.Limit
 	if f.err != nil {
 		return nil, f.err
+	}
+	if len(f.runIDs) > 0 {
+		runs := make([]domain.Run, len(f.runIDs))
+		for i, runID := range f.runIDs {
+			runs[i] = domain.Run{ID: runID, Status: domain.RunStatusFailed}
+		}
+		return runs, nil
 	}
 	size := 1
 	if call <= len(f.batchSizes) {


### PR DESCRIPTION
## Summary
- log a capped sample of run IDs when the orphan-run reaper marks runs failed
- include a truncation flag so operators know when more runs were reaped than logged
- add a worker unit test covering the log fields

Addresses Greptile feedback from #722.

## Tests
- cd backend && go test ./internal/worker