### PR TITLE
feat: add run cancellation

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -97,7 +97,8 @@ func main() {
 	runReadManager := api.NewRunReadManager(authorizer, repo).
 		WithInsightsClient(providerRouter).
 		WithBudgetChecker(budgetChecker).
-		WithInsightsRateLimiter(insightsLimiter)
+		WithInsightsRateLimiter(insightsLimiter).
+		WithRunWorkflowControl(api.NewTemporalRunWorkflowCanceller(temporalClient))
 	if !runReadManager.InsightsConfigured() {
 		logger.Error("run ranking insights client is not configured")
 		os.Exit(1)

--- a/backend/internal/api/permissions.go
+++ b/backend/internal/api/permissions.go
@@ -21,6 +21,7 @@ const (
 	ActionMarkAgentBuildReady         Action = "mark_agent_build_ready"
 	ActionCreateAgentDeployment       Action = "create_agent_deployment"
 	ActionCreateRun                   Action = "create_run"
+	ActionCancelRun                   Action = "cancel_run"
 	ActionManagePlaygrounds           Action = "manage_playgrounds"
 	ActionManageRegressions           Action = "manage_regressions"
 	ActionSelectIntegrationRepository Action = "select_integration_repository"
@@ -55,6 +56,7 @@ var permissionMatrix = map[string]map[Action]bool{
 		ActionMarkAgentBuildReady:         true,
 		ActionCreateAgentDeployment:       true,
 		ActionCreateRun:                   true,
+		ActionCancelRun:                   true,
 		ActionManagePlaygrounds:           true,
 		ActionManageRegressions:           true,
 		ActionSelectIntegrationRepository: true,
@@ -72,6 +74,7 @@ var permissionMatrix = map[string]map[Action]bool{
 		ActionMarkAgentBuildReady:         true,
 		ActionCreateAgentDeployment:       true,
 		ActionCreateRun:                   true,
+		ActionCancelRun:                   true,
 		ActionManagePlaygrounds:           true,
 		ActionManageRegressions:           true,
 		ActionSelectIntegrationRepository: true,

--- a/backend/internal/api/permissions_test.go
+++ b/backend/internal/api/permissions_test.go
@@ -35,6 +35,7 @@ func TestRequireWorkspaceRole_AdminAllowedForAllActions(t *testing.T) {
 		ActionMarkAgentBuildReady,
 		ActionCreateAgentDeployment,
 		ActionCreateRun,
+		ActionCancelRun,
 		ActionManageRegressions,
 		ActionPublishChallengePack,
 		ActionUploadArtifact,
@@ -66,6 +67,7 @@ func TestRequireWorkspaceRole_MemberAllowedForBusinessActions(t *testing.T) {
 		ActionMarkAgentBuildReady,
 		ActionCreateAgentDeployment,
 		ActionCreateRun,
+		ActionCancelRun,
 		ActionManageRegressions,
 		ActionPublishChallengePack,
 		ActionUploadArtifact,
@@ -133,6 +135,7 @@ func TestRequireWorkspaceRole_ViewerDeniedWrites(t *testing.T) {
 		ActionMarkAgentBuildReady,
 		ActionCreateAgentDeployment,
 		ActionCreateRun,
+		ActionCancelRun,
 		ActionManageRegressions,
 		ActionPublishChallengePack,
 		ActionUploadArtifact,
@@ -169,6 +172,7 @@ func TestRequireWorkspaceRole_OrgAdminImplicitAccess(t *testing.T) {
 		ActionReadWorkspace,
 		ActionCreateAgentBuild,
 		ActionCreateRun,
+		ActionCancelRun,
 		ActionManageRegressions,
 		ActionManageInfrastructure,
 	}
@@ -307,6 +311,7 @@ func TestRequireWorkspaceRole_OrgAdminOverridesExplicitViewerRole(t *testing.T) 
 	// org_admin with explicit workspace_viewer should still be allowed to write.
 	writeActions := []Action{
 		ActionCreateRun,
+		ActionCancelRun,
 		ActionCreateAgentBuild,
 		ActionManageRegressions,
 		ActionUploadArtifact,
@@ -338,6 +343,7 @@ func TestAuthorizeWorkspaceAction_OrgAdminOverridesExplicitViewerRole(t *testing
 	// org_admin with explicit workspace_viewer should still be allowed to write.
 	writeActions := []Action{
 		ActionCreateRun,
+		ActionCancelRun,
 		ActionCreateAgentBuild,
 		ActionManageRegressions,
 		ActionUploadArtifact,

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -77,6 +77,7 @@ func registerProtectedRoutes(
 	router.Get("/eval-sessions/{evalSessionID}", getEvalSessionHandler(logger, runReadService))
 	router.Post("/runs", createRunHandler(logger, runCreationService))
 	router.Get("/runs/{runID}", getRunHandler(logger, runReadService))
+	router.Post("/runs/{runID}/cancel", cancelRunHandler(logger, runReadService))
 	router.Get("/runs/{runID}/ranking", getRunRankingHandler(logger, runReadService))
 	router.Post("/runs/{runID}/ranking-insights", createRunRankingInsightsHandler(logger, runReadService))
 	router.Get("/runs/{runID}/agents", listRunAgentsHandler(logger, runReadService))

--- a/backend/internal/api/run_events_sse_test.go
+++ b/backend/internal/api/run_events_sse_test.go
@@ -304,6 +304,10 @@ func (f *fakeSSERunReadService) GetRun(context.Context, Caller, uuid.UUID) (GetR
 	return GetRunResult{}, nil
 }
 
+func (f *fakeSSERunReadService) CancelRun(context.Context, Caller, uuid.UUID) (CancelRunResult, error) {
+	return CancelRunResult{}, nil
+}
+
 func (f *fakeSSERunReadService) GetEvalSession(context.Context, Caller, uuid.UUID) (GetEvalSessionResult, error) {
 	return GetEvalSessionResult{}, nil
 }

--- a/backend/internal/api/run_reads.go
+++ b/backend/internal/api/run_reads.go
@@ -16,8 +16,10 @@ import (
 	"github.com/agentclash/agentclash/backend/internal/failurereview"
 	"github.com/agentclash/agentclash/backend/internal/provider"
 	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/workflow"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"go.temporal.io/api/serviceerror"
 )
 
 type RunReadRepository interface {
@@ -218,19 +220,27 @@ func (m *RunReadManager) CancelRun(ctx context.Context, caller Caller, runID uui
 		return CancelRunResult{Run: run}, nil
 	}
 
-	workflowID := strings.TrimSpace(derefString(run.TemporalWorkflowID))
-	if workflowID != "" {
-		if m.workflowControl == nil {
-			return CancelRunResult{}, RunCancellationWorkflowError{
-				Run:   run,
-				Cause: errors.New("run workflow control is not configured"),
-			}
+	persistedWorkflowID := strings.TrimSpace(derefString(run.TemporalWorkflowID))
+	workflowID := persistedWorkflowID
+	if workflowID == "" {
+		workflowID = fmt.Sprintf("%s/%s", workflow.RunWorkflowName, run.ID)
+	}
+	if m.workflowControl == nil {
+		return CancelRunResult{}, RunCancellationWorkflowError{
+			Run:   run,
+			Cause: errors.New("run workflow control is not configured"),
 		}
-		if err := m.workflowControl.CancelRunWorkflow(ctx, workflowID, strings.TrimSpace(derefString(run.TemporalRunID))); err != nil {
-			latest, latestErr := m.repo.GetRunByID(ctx, run.ID)
-			if latestErr == nil && !latest.Status.CanTransitionTo(domain.RunStatusCancelled) {
-				return CancelRunResult{Run: latest}, nil
-			}
+	}
+	if err := m.workflowControl.CancelRunWorkflow(ctx, workflowID, strings.TrimSpace(derefString(run.TemporalRunID))); err != nil {
+		latest, latestErr := m.repo.GetRunByID(ctx, run.ID)
+		if latestErr == nil && !latest.Status.CanTransitionTo(domain.RunStatusCancelled) {
+			return CancelRunResult{Run: latest}, nil
+		}
+		if persistedWorkflowID == "" && isTemporalNotFound(err) {
+			// The workflow ID is deterministic, but there is a startup window before
+			// it is persisted. NotFound in that window means the workflow never
+			// started or already disappeared, so the DB transition remains safe.
+		} else {
 			return CancelRunResult{}, RunCancellationWorkflowError{Run: run, Cause: err}
 		}
 	}
@@ -252,6 +262,11 @@ func (m *RunReadManager) CancelRun(ctx context.Context, caller Caller, runID uui
 		}
 	}
 	return CancelRunResult{}, err
+}
+
+func isTemporalNotFound(err error) bool {
+	var notFound *serviceerror.NotFound
+	return errors.As(err, &notFound)
 }
 
 func (m *RunReadManager) ListRuns(ctx context.Context, caller Caller, input ListRunsInput) (ListRunsResult, error) {

--- a/backend/internal/api/run_reads.go
+++ b/backend/internal/api/run_reads.go
@@ -33,6 +33,7 @@ type RunReadRepository interface {
 	ListEvalSessionsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID, limit int32, offset int32) ([]domain.EvalSession, error)
 	ListRunsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID, limit int32, offset int32) ([]domain.Run, error)
 	CountRunsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (int64, error)
+	TransitionRunStatus(ctx context.Context, params repository.TransitionRunStatusParams) (domain.Run, error)
 	GetProviderAccountByID(ctx context.Context, id uuid.UUID) (repository.ProviderAccountRow, error)
 	GetModelAliasByID(ctx context.Context, id uuid.UUID) (repository.ModelAliasRow, error)
 	GetModelCatalogEntryByID(ctx context.Context, id uuid.UUID) (repository.ModelCatalogEntryRow, error)
@@ -78,10 +79,6 @@ type CancelRunResult struct {
 
 type RunWorkflowControl interface {
 	CancelRunWorkflow(ctx context.Context, workflowID string, runID string) error
-}
-
-type runCancellationRepository interface {
-	TransitionRunStatus(ctx context.Context, params repository.TransitionRunStatusParams) (domain.Run, error)
 }
 
 type RunCancellationWorkflowError struct {
@@ -222,19 +219,20 @@ func (m *RunReadManager) CancelRun(ctx context.Context, caller Caller, runID uui
 	}
 
 	workflowID := strings.TrimSpace(derefString(run.TemporalWorkflowID))
-	if workflowID != "" && m.workflowControl != nil {
+	if workflowID != "" {
+		if m.workflowControl == nil {
+			return CancelRunResult{}, RunCancellationWorkflowError{
+				Run:   run,
+				Cause: errors.New("run workflow control is not configured"),
+			}
+		}
 		if err := m.workflowControl.CancelRunWorkflow(ctx, workflowID, strings.TrimSpace(derefString(run.TemporalRunID))); err != nil {
 			return CancelRunResult{}, RunCancellationWorkflowError{Run: run, Cause: err}
 		}
 	}
 
-	transitionRepo, ok := m.repo.(runCancellationRepository)
-	if !ok {
-		return CancelRunResult{}, errors.New("run cancellation repository is not configured")
-	}
-
 	reason := "cancelled by user"
-	cancelled, err := transitionRepo.TransitionRunStatus(ctx, repository.TransitionRunStatusParams{
+	cancelled, err := m.repo.TransitionRunStatus(ctx, repository.TransitionRunStatusParams{
 		RunID:           run.ID,
 		ToStatus:        domain.RunStatusCancelled,
 		Reason:          &reason,

--- a/backend/internal/api/run_reads.go
+++ b/backend/internal/api/run_reads.go
@@ -212,7 +212,7 @@ func (m *RunReadManager) CancelRun(ctx context.Context, caller Caller, runID uui
 	if err != nil {
 		return CancelRunResult{}, err
 	}
-	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, run.WorkspaceID, ActionCreateRun); err != nil {
+	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, run.WorkspaceID, ActionCancelRun); err != nil {
 		return CancelRunResult{}, err
 	}
 

--- a/backend/internal/api/run_reads.go
+++ b/backend/internal/api/run_reads.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/budget"
@@ -41,6 +42,7 @@ type RunReadRepository interface {
 
 type RunReadService interface {
 	GetRun(ctx context.Context, caller Caller, runID uuid.UUID) (GetRunResult, error)
+	CancelRun(ctx context.Context, caller Caller, runID uuid.UUID) (CancelRunResult, error)
 	GetEvalSession(ctx context.Context, caller Caller, evalSessionID uuid.UUID) (GetEvalSessionResult, error)
 	GetRunRanking(ctx context.Context, caller Caller, runID uuid.UUID, input GetRunRankingInput) (GetRunRankingResult, error)
 	GenerateRunRankingInsights(ctx context.Context, caller Caller, runID uuid.UUID, input GenerateRunRankingInsightsInput) (GenerateRunRankingInsightsResult, error)
@@ -68,6 +70,31 @@ type ListRunsResult struct {
 type GetRunResult struct {
 	Run                domain.Run
 	RegressionCoverage *RunRegressionCoverage
+}
+
+type CancelRunResult struct {
+	Run domain.Run
+}
+
+type RunWorkflowControl interface {
+	CancelRunWorkflow(ctx context.Context, workflowID string, runID string) error
+}
+
+type runCancellationRepository interface {
+	TransitionRunStatus(ctx context.Context, params repository.TransitionRunStatusParams) (domain.Run, error)
+}
+
+type RunCancellationWorkflowError struct {
+	Run   domain.Run
+	Cause error
+}
+
+func (e RunCancellationWorkflowError) Error() string {
+	return fmt.Sprintf("cancel run workflow for run %s: %v", e.Run.ID, e.Cause)
+}
+
+func (e RunCancellationWorkflowError) Unwrap() error {
+	return e.Cause
 }
 
 type RunRegressionCoverage struct {
@@ -110,6 +137,7 @@ type RunReadManager struct {
 	budgetChecker   budget.BudgetChecker
 	insightsLimiter WorkspaceRateLimiter
 	insightsTimeout time.Duration
+	workflowControl RunWorkflowControl
 	now             func() time.Time
 }
 
@@ -150,6 +178,11 @@ func (m *RunReadManager) WithInsightsTimeout(timeout time.Duration) *RunReadMana
 	return m
 }
 
+func (m *RunReadManager) WithRunWorkflowControl(control RunWorkflowControl) *RunReadManager {
+	m.workflowControl = control
+	return m
+}
+
 func (m *RunReadManager) InsightsConfigured() bool {
 	return m.insightsClient != nil
 }
@@ -173,6 +206,50 @@ func (m *RunReadManager) GetRun(ctx context.Context, caller Caller, runID uuid.U
 		Run:                run,
 		RegressionCoverage: &coverage,
 	}, nil
+}
+
+func (m *RunReadManager) CancelRun(ctx context.Context, caller Caller, runID uuid.UUID) (CancelRunResult, error) {
+	run, err := m.repo.GetRunByID(ctx, runID)
+	if err != nil {
+		return CancelRunResult{}, err
+	}
+	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, run.WorkspaceID, ActionCreateRun); err != nil {
+		return CancelRunResult{}, err
+	}
+
+	if !run.Status.CanTransitionTo(domain.RunStatusCancelled) {
+		return CancelRunResult{Run: run}, nil
+	}
+
+	workflowID := strings.TrimSpace(derefString(run.TemporalWorkflowID))
+	if workflowID != "" && m.workflowControl != nil {
+		if err := m.workflowControl.CancelRunWorkflow(ctx, workflowID, strings.TrimSpace(derefString(run.TemporalRunID))); err != nil {
+			return CancelRunResult{}, RunCancellationWorkflowError{Run: run, Cause: err}
+		}
+	}
+
+	transitionRepo, ok := m.repo.(runCancellationRepository)
+	if !ok {
+		return CancelRunResult{}, errors.New("run cancellation repository is not configured")
+	}
+
+	reason := "cancelled by user"
+	cancelled, err := transitionRepo.TransitionRunStatus(ctx, repository.TransitionRunStatusParams{
+		RunID:           run.ID,
+		ToStatus:        domain.RunStatusCancelled,
+		Reason:          &reason,
+		ChangedByUserID: &caller.UserID,
+	})
+	if err == nil {
+		return CancelRunResult{Run: cancelled}, nil
+	}
+	if errors.Is(err, repository.ErrInvalidTransition) || errors.Is(err, repository.ErrTransitionConflict) {
+		latest, latestErr := m.repo.GetRunByID(ctx, run.ID)
+		if latestErr == nil && !latest.Status.CanTransitionTo(domain.RunStatusCancelled) {
+			return CancelRunResult{Run: latest}, nil
+		}
+	}
+	return CancelRunResult{}, err
 }
 
 func (m *RunReadManager) ListRuns(ctx context.Context, caller Caller, input ListRunsInput) (ListRunsResult, error) {

--- a/backend/internal/api/run_reads.go
+++ b/backend/internal/api/run_reads.go
@@ -227,6 +227,10 @@ func (m *RunReadManager) CancelRun(ctx context.Context, caller Caller, runID uui
 			}
 		}
 		if err := m.workflowControl.CancelRunWorkflow(ctx, workflowID, strings.TrimSpace(derefString(run.TemporalRunID))); err != nil {
+			latest, latestErr := m.repo.GetRunByID(ctx, run.ID)
+			if latestErr == nil && !latest.Status.CanTransitionTo(domain.RunStatusCancelled) {
+				return CancelRunResult{Run: latest}, nil
+			}
 			return CancelRunResult{}, RunCancellationWorkflowError{Run: run, Cause: err}
 		}
 	}

--- a/backend/internal/api/run_reads_test.go
+++ b/backend/internal/api/run_reads_test.go
@@ -176,6 +176,42 @@ func TestRunReadManagerCancelRunReturnsTemporalFailure(t *testing.T) {
 	}
 }
 
+func TestRunReadManagerCancelRunReturnsLatestTerminalRunAfterTemporalFailure(t *testing.T) {
+	workspaceID := uuid.New()
+	runID := uuid.New()
+	workflowID := "RunWorkflow/" + runID.String()
+	repo := &fakeRunReadRepository{
+		run: domain.Run{
+			ID:                 runID,
+			WorkspaceID:        workspaceID,
+			Status:             domain.RunStatusRunning,
+			TemporalWorkflowID: &workflowID,
+		},
+		latestRun: domain.Run{
+			ID:          runID,
+			WorkspaceID: workspaceID,
+			Status:      domain.RunStatusCompleted,
+		},
+	}
+	manager := NewRunReadManager(NewCallerWorkspaceAuthorizer(), repo).WithRunWorkflowControl(&fakeRunWorkflowControl{err: errors.New("workflow not found")})
+
+	result, err := manager.CancelRun(context.Background(), Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: RoleWorkspaceMember},
+		},
+	}, runID)
+	if err != nil {
+		t.Fatalf("CancelRun returned error: %v", err)
+	}
+	if result.Run.Status != domain.RunStatusCompleted {
+		t.Fatalf("status = %s, want completed", result.Run.Status)
+	}
+	if repo.transitionRunStatusCalls != 0 {
+		t.Fatalf("transition calls = %d, want 0", repo.transitionRunStatusCalls)
+	}
+}
+
 func TestRunReadManagerCancelRunRequiresWorkflowControlForTemporalRun(t *testing.T) {
 	workspaceID := uuid.New()
 	runID := uuid.New()
@@ -254,7 +290,7 @@ func TestCancelRunHandlerReturnsTemporalFailure(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
 	}
-	var response createRunErrorResponse
+	var response runWorkflowErrorResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -610,6 +646,7 @@ func TestListRunAgentsEndpointReturnsForbidden(t *testing.T) {
 
 type fakeRunReadRepository struct {
 	run                      domain.Run
+	latestRun                domain.Run
 	transitionedRun          domain.Run
 	evalSession              repository.EvalSessionWithRuns
 	evalSessions             []domain.EvalSession
@@ -646,9 +683,14 @@ type fakeRunReadRepository struct {
 	transitionRunStatus      domain.RunStatus
 	transitionReason         *string
 	transitionChangedBy      *uuid.UUID
+	getRunByIDCalls          int
 }
 
 func (f *fakeRunReadRepository) GetRunByID(_ context.Context, _ uuid.UUID) (domain.Run, error) {
+	f.getRunByIDCalls++
+	if f.getRunByIDCalls > 1 && f.latestRun.ID != uuid.Nil {
+		return f.latestRun, f.getRunErr
+	}
 	return f.run, f.getRunErr
 }
 

--- a/backend/internal/api/run_reads_test.go
+++ b/backend/internal/api/run_reads_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/agentclash/agentclash/backend/internal/domain"
 	"github.com/agentclash/agentclash/backend/internal/failurereview"
 	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 )
 
@@ -69,6 +70,167 @@ func TestRunReadManagerReturnsRunForAuthorizedCaller(t *testing.T) {
 	}
 	if result.RegressionCoverage.Suites[1].FailCount != 1 {
 		t.Fatalf("second suite fail_count = %d, want 1", result.RegressionCoverage.Suites[1].FailCount)
+	}
+}
+
+func TestRunReadManagerCancelRunTransitionsActiveRunAndCancelsTemporal(t *testing.T) {
+	workspaceID := uuid.New()
+	userID := uuid.New()
+	runID := uuid.New()
+	workflowID := "RunWorkflow/" + runID.String()
+	temporalRunID := "temporal-run-1"
+	cancelled := domain.Run{ID: runID, WorkspaceID: workspaceID, Status: domain.RunStatusCancelled}
+	repo := &fakeRunReadRepository{
+		run: domain.Run{
+			ID:                 runID,
+			WorkspaceID:        workspaceID,
+			Status:             domain.RunStatusRunning,
+			TemporalWorkflowID: &workflowID,
+			TemporalRunID:      &temporalRunID,
+		},
+		transitionedRun: cancelled,
+	}
+	control := &fakeRunWorkflowControl{}
+	manager := NewRunReadManager(NewCallerWorkspaceAuthorizer(), repo).WithRunWorkflowControl(control)
+
+	result, err := manager.CancelRun(context.Background(), Caller{
+		UserID: userID,
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: RoleWorkspaceMember},
+		},
+	}, runID)
+	if err != nil {
+		t.Fatalf("CancelRun returned error: %v", err)
+	}
+
+	if result.Run.Status != domain.RunStatusCancelled {
+		t.Fatalf("status = %s, want cancelled", result.Run.Status)
+	}
+	if control.workflowID != workflowID || control.runID != temporalRunID {
+		t.Fatalf("temporal cancel = (%q, %q), want (%q, %q)", control.workflowID, control.runID, workflowID, temporalRunID)
+	}
+	if repo.transitionRunStatusCalls != 1 || repo.transitionRunStatus != domain.RunStatusCancelled {
+		t.Fatalf("transition calls/status = %d/%s, want 1/cancelled", repo.transitionRunStatusCalls, repo.transitionRunStatus)
+	}
+	if repo.transitionChangedBy == nil || *repo.transitionChangedBy != userID {
+		t.Fatalf("changed by = %v, want %s", repo.transitionChangedBy, userID)
+	}
+	if repo.transitionReason == nil || *repo.transitionReason != "cancelled by user" {
+		t.Fatalf("reason = %v, want cancelled by user", repo.transitionReason)
+	}
+}
+
+func TestRunReadManagerCancelRunIsIdempotentForTerminalRun(t *testing.T) {
+	workspaceID := uuid.New()
+	runID := uuid.New()
+	repo := &fakeRunReadRepository{
+		run: domain.Run{ID: runID, WorkspaceID: workspaceID, Status: domain.RunStatusCompleted},
+	}
+	control := &fakeRunWorkflowControl{}
+	manager := NewRunReadManager(NewCallerWorkspaceAuthorizer(), repo).WithRunWorkflowControl(control)
+
+	result, err := manager.CancelRun(context.Background(), Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: RoleWorkspaceMember},
+		},
+	}, runID)
+	if err != nil {
+		t.Fatalf("CancelRun returned error: %v", err)
+	}
+
+	if result.Run.Status != domain.RunStatusCompleted {
+		t.Fatalf("status = %s, want completed", result.Run.Status)
+	}
+	if control.cancelCalls != 0 || repo.transitionRunStatusCalls != 0 {
+		t.Fatalf("cancel/transition calls = %d/%d, want 0/0", control.cancelCalls, repo.transitionRunStatusCalls)
+	}
+}
+
+func TestRunReadManagerCancelRunReturnsTemporalFailure(t *testing.T) {
+	workspaceID := uuid.New()
+	runID := uuid.New()
+	workflowID := "RunWorkflow/" + runID.String()
+	temporalErr := errors.New("temporal unavailable")
+	repo := &fakeRunReadRepository{
+		run: domain.Run{
+			ID:                 runID,
+			WorkspaceID:        workspaceID,
+			Status:             domain.RunStatusRunning,
+			TemporalWorkflowID: &workflowID,
+		},
+	}
+	manager := NewRunReadManager(NewCallerWorkspaceAuthorizer(), repo).WithRunWorkflowControl(&fakeRunWorkflowControl{err: temporalErr})
+
+	_, err := manager.CancelRun(context.Background(), Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: RoleWorkspaceMember},
+		},
+	}, runID)
+	if !errors.Is(err, temporalErr) {
+		t.Fatalf("CancelRun error = %v, want temporal error", err)
+	}
+	if repo.transitionRunStatusCalls != 0 {
+		t.Fatalf("transition calls = %d, want 0", repo.transitionRunStatusCalls)
+	}
+}
+
+func TestCancelRunHandlerReturnsCancelledRun(t *testing.T) {
+	runID := uuid.New()
+	workspaceID := uuid.New()
+	service := &fakeRunReadService{
+		cancelRunResult: CancelRunResult{
+			Run: domain.Run{ID: runID, WorkspaceID: workspaceID, Status: domain.RunStatusCancelled},
+		},
+	}
+	router := chi.NewRouter()
+	router.Post("/v1/runs/{runID}/cancel", cancelRunHandler(slog.Default(), service))
+	req := httptest.NewRequest(http.MethodPost, "/v1/runs/"+runID.String()+"/cancel", nil)
+	req = req.WithContext(context.WithValue(req.Context(), callerContextKey{}, Caller{UserID: uuid.New()}))
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	var response getRunResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.ID != runID || response.Status != domain.RunStatusCancelled {
+		t.Fatalf("response = %+v, want cancelled run %s", response, runID)
+	}
+}
+
+func TestCancelRunHandlerReturnsTemporalFailure(t *testing.T) {
+	runID := uuid.New()
+	workspaceID := uuid.New()
+	workflowErr := errors.New("temporal unavailable")
+	service := &fakeRunReadService{
+		cancelRunErr: RunCancellationWorkflowError{
+			Run:   domain.Run{ID: runID, WorkspaceID: workspaceID, Status: domain.RunStatusRunning},
+			Cause: workflowErr,
+		},
+	}
+	router := chi.NewRouter()
+	router.Post("/v1/runs/{runID}/cancel", cancelRunHandler(slog.Default(), service))
+	req := httptest.NewRequest(http.MethodPost, "/v1/runs/"+runID.String()+"/cancel", nil)
+	req = req.WithContext(context.WithValue(req.Context(), callerContextKey{}, Caller{UserID: uuid.New()}))
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	var response createRunErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Error.Code != "workflow_cancel_failed" || response.Run.ID != runID {
+		t.Fatalf("response = %+v, want workflow_cancel_failed for %s", response, runID)
 	}
 }
 
@@ -419,6 +581,7 @@ func TestListRunAgentsEndpointReturnsForbidden(t *testing.T) {
 
 type fakeRunReadRepository struct {
 	run                      domain.Run
+	transitionedRun          domain.Run
 	evalSession              repository.EvalSessionWithRuns
 	evalSessions             []domain.EvalSession
 	evalSessionRuns          map[uuid.UUID][]domain.Run
@@ -449,10 +612,31 @@ type fakeRunReadRepository struct {
 	getModelCatalogErr       error
 	listSpendPoliciesErr     error
 	loadWorkspaceSecretsErr  error
+	transitionRunStatusErr   error
+	transitionRunStatusCalls int
+	transitionRunStatus      domain.RunStatus
+	transitionReason         *string
+	transitionChangedBy      *uuid.UUID
 }
 
 func (f *fakeRunReadRepository) GetRunByID(_ context.Context, _ uuid.UUID) (domain.Run, error) {
 	return f.run, f.getRunErr
+}
+
+func (f *fakeRunReadRepository) TransitionRunStatus(_ context.Context, params repository.TransitionRunStatusParams) (domain.Run, error) {
+	f.transitionRunStatusCalls++
+	f.transitionRunStatus = params.ToStatus
+	f.transitionReason = params.Reason
+	f.transitionChangedBy = params.ChangedByUserID
+	if f.transitionRunStatusErr != nil {
+		return domain.Run{}, f.transitionRunStatusErr
+	}
+	if f.transitionedRun.ID != uuid.Nil {
+		return f.transitionedRun, nil
+	}
+	run := f.run
+	run.Status = params.ToStatus
+	return run, nil
 }
 
 func (f *fakeRunReadRepository) GetEvalSessionWithRuns(_ context.Context, _ uuid.UUID) (repository.EvalSessionWithRuns, error) {
@@ -541,6 +725,8 @@ func (f *fakeRunReadRepository) LoadWorkspaceSecrets(_ context.Context, _ uuid.U
 type fakeRunReadService struct {
 	getRunResult           GetRunResult
 	getRunErr              error
+	cancelRunResult        CancelRunResult
+	cancelRunErr           error
 	getEvalSessionResult   GetEvalSessionResult
 	getEvalSessionErr      error
 	getRunRankingResult    GetRunRankingResult
@@ -557,6 +743,10 @@ type fakeRunReadService struct {
 
 func (f *fakeRunReadService) GetRun(_ context.Context, _ Caller, _ uuid.UUID) (GetRunResult, error) {
 	return f.getRunResult, f.getRunErr
+}
+
+func (f *fakeRunReadService) CancelRun(_ context.Context, _ Caller, _ uuid.UUID) (CancelRunResult, error) {
+	return f.cancelRunResult, f.cancelRunErr
 }
 
 func (f *fakeRunReadService) GetEvalSession(_ context.Context, _ Caller, _ uuid.UUID) (GetEvalSessionResult, error) {
@@ -585,6 +775,20 @@ func (f *fakeRunReadService) ListRunFailures(_ context.Context, _ Caller, _ List
 
 func (f *fakeRunReadService) ListRuns(_ context.Context, _ Caller, _ ListRunsInput) (ListRunsResult, error) {
 	return ListRunsResult{}, nil
+}
+
+type fakeRunWorkflowControl struct {
+	workflowID  string
+	runID       string
+	cancelCalls int
+	err         error
+}
+
+func (f *fakeRunWorkflowControl) CancelRunWorkflow(_ context.Context, workflowID string, runID string) error {
+	f.cancelCalls++
+	f.workflowID = workflowID
+	f.runID = runID
+	return f.err
 }
 
 func uuidPtr(value uuid.UUID) *uuid.UUID {

--- a/backend/internal/api/run_reads_test.go
+++ b/backend/internal/api/run_reads_test.go
@@ -14,8 +14,10 @@ import (
 	"github.com/agentclash/agentclash/backend/internal/domain"
 	"github.com/agentclash/agentclash/backend/internal/failurereview"
 	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/workflow"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"go.temporal.io/api/serviceerror"
 )
 
 func TestRunReadManagerReturnsRunForAuthorizedCaller(t *testing.T) {
@@ -173,6 +175,68 @@ func TestRunReadManagerCancelRunReturnsTemporalFailure(t *testing.T) {
 	}
 	if repo.transitionRunStatusCalls != 0 {
 		t.Fatalf("transition calls = %d, want 0", repo.transitionRunStatusCalls)
+	}
+}
+
+func TestRunReadManagerCancelRunUsesDeterministicWorkflowIDWhenNotPersisted(t *testing.T) {
+	workspaceID := uuid.New()
+	userID := uuid.New()
+	runID := uuid.New()
+	repo := &fakeRunReadRepository{
+		run: domain.Run{
+			ID:          runID,
+			WorkspaceID: workspaceID,
+			Status:      domain.RunStatusQueued,
+		},
+	}
+	control := &fakeRunWorkflowControl{}
+	manager := NewRunReadManager(NewCallerWorkspaceAuthorizer(), repo).WithRunWorkflowControl(control)
+
+	_, err := manager.CancelRun(context.Background(), Caller{
+		UserID: userID,
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: RoleWorkspaceMember},
+		},
+	}, runID)
+	if err != nil {
+		t.Fatalf("CancelRun returned error: %v", err)
+	}
+
+	wantWorkflowID := workflow.RunWorkflowName + "/" + runID.String()
+	if control.workflowID != wantWorkflowID || control.runID != "" {
+		t.Fatalf("temporal cancel = (%q, %q), want (%q, \"\")", control.workflowID, control.runID, wantWorkflowID)
+	}
+	if repo.transitionRunStatusCalls != 1 {
+		t.Fatalf("transition calls = %d, want 1", repo.transitionRunStatusCalls)
+	}
+}
+
+func TestRunReadManagerCancelRunTransitionsWhenUnpersistedWorkflowIsNotFound(t *testing.T) {
+	workspaceID := uuid.New()
+	runID := uuid.New()
+	repo := &fakeRunReadRepository{
+		run: domain.Run{
+			ID:          runID,
+			WorkspaceID: workspaceID,
+			Status:      domain.RunStatusQueued,
+		},
+	}
+	manager := NewRunReadManager(NewCallerWorkspaceAuthorizer(), repo).WithRunWorkflowControl(&fakeRunWorkflowControl{err: serviceerror.NewNotFound("workflow not found")})
+
+	result, err := manager.CancelRun(context.Background(), Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: RoleWorkspaceMember},
+		},
+	}, runID)
+	if err != nil {
+		t.Fatalf("CancelRun returned error: %v", err)
+	}
+	if result.Run.Status != domain.RunStatusCancelled {
+		t.Fatalf("status = %s, want cancelled", result.Run.Status)
+	}
+	if repo.transitionRunStatusCalls != 1 {
+		t.Fatalf("transition calls = %d, want 1", repo.transitionRunStatusCalls)
 	}
 }
 

--- a/backend/internal/api/run_reads_test.go
+++ b/backend/internal/api/run_reads_test.go
@@ -176,6 +176,35 @@ func TestRunReadManagerCancelRunReturnsTemporalFailure(t *testing.T) {
 	}
 }
 
+func TestRunReadManagerCancelRunRequiresWorkflowControlForTemporalRun(t *testing.T) {
+	workspaceID := uuid.New()
+	runID := uuid.New()
+	workflowID := "RunWorkflow/" + runID.String()
+	repo := &fakeRunReadRepository{
+		run: domain.Run{
+			ID:                 runID,
+			WorkspaceID:        workspaceID,
+			Status:             domain.RunStatusRunning,
+			TemporalWorkflowID: &workflowID,
+		},
+	}
+	manager := NewRunReadManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	_, err := manager.CancelRun(context.Background(), Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: RoleWorkspaceMember},
+		},
+	}, runID)
+	var workflowErr RunCancellationWorkflowError
+	if !errors.As(err, &workflowErr) {
+		t.Fatalf("CancelRun error = %v, want RunCancellationWorkflowError", err)
+	}
+	if repo.transitionRunStatusCalls != 0 {
+		t.Fatalf("transition calls = %d, want 0", repo.transitionRunStatusCalls)
+	}
+}
+
 func TestCancelRunHandlerReturnsCancelledRun(t *testing.T) {
 	runID := uuid.New()
 	workspaceID := uuid.New()

--- a/backend/internal/api/runs.go
+++ b/backend/internal/api/runs.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/agentclash/agentclash/backend/internal/billing"
 	"github.com/agentclash/agentclash/backend/internal/domain"
+	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/google/uuid"
 )
 
@@ -214,6 +215,55 @@ func buildRunLinks(runID uuid.UUID) runLinksResponse {
 	return runLinksResponse{
 		Self:   fmt.Sprintf("/v1/runs/%s", runID),
 		Agents: fmt.Sprintf("/v1/runs/%s/agents", runID),
+	}
+}
+
+func cancelRunHandler(logger *slog.Logger, service RunReadService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		runID, err := runIDFromURLParam("runID")(r)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_run_id", err.Error())
+			return
+		}
+
+		result, err := service.CancelRun(r.Context(), caller, runID)
+		if err != nil {
+			switch {
+			case errors.Is(err, repository.ErrRunNotFound):
+				writeError(w, http.StatusNotFound, "run_not_found", "run not found")
+			case errors.Is(err, ErrForbidden):
+				writeAuthzError(w, err)
+			default:
+				var workflowErr RunCancellationWorkflowError
+				if errors.As(err, &workflowErr) {
+					writeJSON(w, http.StatusBadGateway, createRunErrorResponse{
+						Error: apiError{
+							Code:    "workflow_cancel_failed",
+							Message: "run could not be cancelled in Temporal",
+						},
+						Run: buildCreateRunResponse(workflowErr.Run),
+					})
+					return
+				}
+
+				logger.Error("cancel run request failed",
+					"method", r.Method,
+					"path", r.URL.Path,
+					"run_id", runID,
+					"error", err,
+				)
+				writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+			}
+			return
+		}
+
+		writeJSON(w, http.StatusOK, buildGetRunResponse(result.Run, nil))
 	}
 }
 

--- a/backend/internal/api/runs.go
+++ b/backend/internal/api/runs.go
@@ -193,6 +193,11 @@ type createRunErrorResponse struct {
 	Run   createRunResponse `json:"run"`
 }
 
+type runWorkflowErrorResponse struct {
+	Error apiError       `json:"error"`
+	Run   getRunResponse `json:"run"`
+}
+
 func buildCreateRunResponse(run domain.Run) createRunResponse {
 	return createRunResponse{
 		ID:                     run.ID,
@@ -242,12 +247,12 @@ func cancelRunHandler(logger *slog.Logger, service RunReadService) http.HandlerF
 			default:
 				var workflowErr RunCancellationWorkflowError
 				if errors.As(err, &workflowErr) {
-					writeJSON(w, http.StatusBadGateway, createRunErrorResponse{
+					writeJSON(w, http.StatusBadGateway, runWorkflowErrorResponse{
 						Error: apiError{
 							Code:    "workflow_cancel_failed",
 							Message: "run could not be cancelled in Temporal",
 						},
-						Run: buildCreateRunResponse(workflowErr.Run),
+						Run: buildGetRunResponse(workflowErr.Run, nil),
 					})
 					return
 				}

--- a/backend/internal/api/server_test.go
+++ b/backend/internal/api/server_test.go
@@ -30,6 +30,10 @@ func (stubRunReadService) GetRun(_ context.Context, _ Caller, _ uuid.UUID) (GetR
 	return GetRunResult{}, errors.New("not implemented")
 }
 
+func (stubRunReadService) CancelRun(_ context.Context, _ Caller, _ uuid.UUID) (CancelRunResult, error) {
+	return CancelRunResult{}, errors.New("not implemented")
+}
+
 func (stubRunReadService) GetEvalSession(_ context.Context, _ Caller, _ uuid.UUID) (GetEvalSessionResult, error) {
 	return GetEvalSessionResult{}, errors.New("not implemented")
 }

--- a/backend/internal/api/temporal.go
+++ b/backend/internal/api/temporal.go
@@ -53,6 +53,18 @@ func (s TemporalRunWorkflowStarter) StartRunWorkflow(ctx context.Context, runID 
 	return err
 }
 
+type TemporalRunWorkflowCanceller struct {
+	client TemporalClient
+}
+
+func NewTemporalRunWorkflowCanceller(client TemporalClient) TemporalRunWorkflowCanceller {
+	return TemporalRunWorkflowCanceller{client: client}
+}
+
+func (c TemporalRunWorkflowCanceller) CancelRunWorkflow(ctx context.Context, workflowID string, runID string) error {
+	return c.client.CancelWorkflow(ctx, workflowID, runID)
+}
+
 type TemporalEvalSessionWorkflowStarter struct {
 	client TemporalClient
 }

--- a/backend/internal/workflow/activities.go
+++ b/backend/internal/workflow/activities.go
@@ -53,6 +53,7 @@ const (
 	repositoryIllegalSessionTransitionType        = "repository.ErrIllegalSessionTransition"
 	repositoryInvalidTransitionType               = "repository.ErrInvalidTransition"
 	repositoryTransitionConflictType              = "repository.ErrTransitionConflict"
+	runMustBeQueuedErrorType                      = "workflow.ErrRunMustBeQueued"
 	engineFailureErrorTypePrefix                  = "engine."
 	providerFailureErrorTypePrefix                = "provider."
 )

--- a/backend/internal/workflow/eval_session_workflow.go
+++ b/backend/internal/workflow/eval_session_workflow.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/agentclash/agentclash/backend/internal/domain"
@@ -160,18 +161,18 @@ func executeEvalSessionRuns(ctx sdkworkflow.Context, runs []domain.Run) error {
 		return errEvalSessionChildrenCancelled
 	}
 	if startedChildren > 0 && len(actionableErrors) == startedChildren {
-		for _, err := range actionableErrors {
-			return err
-		}
+		return actionableErrors[0]
 	}
 
 	return nil
 }
 
-func classifyEvalSessionChildErrors(ctx sdkworkflow.Context, childErrors map[uuid.UUID]error) (map[uuid.UUID]error, int, error) {
-	actionableErrors := make(map[uuid.UUID]error, len(childErrors))
+func classifyEvalSessionChildErrors(ctx sdkworkflow.Context, childErrors map[uuid.UUID]error) ([]error, int, error) {
+	runIDs := sortedUUIDKeys(childErrors)
+	actionableErrors := make([]error, 0, len(childErrors))
 	cancelledChildren := 0
-	for runID, childErr := range childErrors {
+	for _, runID := range runIDs {
+		childErr := childErrors[runID]
 		if childRunMayAlreadyBeTerminal(childErr) {
 			latest, loadErr := loadRun(ctx, runID)
 			if loadErr != nil {
@@ -184,9 +185,20 @@ func classifyEvalSessionChildErrors(ctx sdkworkflow.Context, childErrors map[uui
 				continue
 			}
 		}
-		actionableErrors[runID] = childErr
+		actionableErrors = append(actionableErrors, childErr)
 	}
 	return actionableErrors, cancelledChildren, nil
+}
+
+func sortedUUIDKeys(values map[uuid.UUID]error) []uuid.UUID {
+	keys := make([]uuid.UUID, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i].String() < keys[j].String()
+	})
+	return keys
 }
 
 func childRunMayAlreadyBeTerminal(err error) bool {

--- a/backend/internal/workflow/eval_session_workflow.go
+++ b/backend/internal/workflow/eval_session_workflow.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/agentclash/agentclash/backend/internal/domain"
 	"github.com/agentclash/agentclash/backend/internal/repository"
@@ -160,7 +159,8 @@ func executeEvalSessionRuns(ctx sdkworkflow.Context, runs []domain.Run) error {
 	if startedChildren > 0 && cancelledChildren == startedChildren {
 		return errEvalSessionChildrenCancelled
 	}
-	if startedChildren > 0 && len(actionableErrors) == startedChildren {
+	successfulChildren := startedChildren - len(childErrors)
+	if startedChildren > 0 && successfulChildren == 0 && len(actionableErrors) > 0 {
 		return actionableErrors[0]
 	}
 
@@ -203,7 +203,7 @@ func sortedUUIDKeys(values map[uuid.UUID]error) []uuid.UUID {
 
 func childRunMayAlreadyBeTerminal(err error) bool {
 	return errors.Is(err, ErrRunMustBeQueued) ||
-		strings.Contains(err.Error(), ErrRunMustBeQueued.Error()) ||
+		hasApplicationErrorType(err, runMustBeQueuedErrorType) ||
 		hasApplicationErrorType(err, repositoryInvalidTransitionType) ||
 		hasApplicationErrorType(err, repositoryTransitionConflictType)
 }

--- a/backend/internal/workflow/eval_session_workflow.go
+++ b/backend/internal/workflow/eval_session_workflow.go
@@ -156,14 +156,14 @@ func executeEvalSessionRuns(ctx sdkworkflow.Context, runs []domain.Run) error {
 		selector.Select(ctx)
 	}
 
-	actionableErrors, cancelledChildren, err := classifyEvalSessionChildErrors(ctx, childErrors)
+	actionableErrors, cancelledChildren, terminalChildren, err := classifyEvalSessionChildErrors(ctx, childErrors)
 	if err != nil {
 		return err
 	}
 	if startedChildren > 0 && cancelledChildren == startedChildren {
 		return errEvalSessionChildrenCancelled
 	}
-	successfulChildren := startedChildren - len(childErrors)
+	successfulChildren := startedChildren - len(childErrors) + terminalChildren
 	if startedChildren > 0 && successfulChildren == 0 && len(actionableErrors) > 0 {
 		return actionableErrors[0]
 	}
@@ -171,28 +171,32 @@ func executeEvalSessionRuns(ctx sdkworkflow.Context, runs []domain.Run) error {
 	return nil
 }
 
-func classifyEvalSessionChildErrors(ctx sdkworkflow.Context, childErrors map[uuid.UUID]error) ([]error, int, error) {
+func classifyEvalSessionChildErrors(ctx sdkworkflow.Context, childErrors map[uuid.UUID]error) ([]error, int, int, error) {
 	runIDs := sortedUUIDKeys(childErrors)
 	actionableErrors := make([]error, 0, len(childErrors))
 	cancelledChildren := 0
+	terminalChildren := 0
 	for _, runID := range runIDs {
 		childErr := childErrors[runID]
-		if childRunMayAlreadyBeTerminal(childErr) || isWorkflowCanceled(childErr) {
+		mayAlreadyBeTerminal := childRunMayAlreadyBeTerminal(childErr)
+		workflowCanceled := isWorkflowCanceled(childErr)
+		if mayAlreadyBeTerminal || workflowCanceled {
 			latest, loadErr := loadRun(ctx, runID)
 			if loadErr != nil {
-				return nil, 0, loadErr
+				return nil, 0, 0, loadErr
 			}
 			if latest.Status == domain.RunStatusCancelled {
 				cancelledChildren++
 				continue
 			}
-			if childRunMayAlreadyBeTerminal(childErr) && !latest.Status.CanTransitionTo(domain.RunStatusCancelled) {
+			if !latest.Status.CanTransitionTo(domain.RunStatusCancelled) {
+				terminalChildren++
 				continue
 			}
 		}
 		actionableErrors = append(actionableErrors, childErr)
 	}
-	return actionableErrors, cancelledChildren, nil
+	return actionableErrors, cancelledChildren, terminalChildren, nil
 }
 
 func sortedUUIDKeys(values map[uuid.UUID]error) []uuid.UUID {

--- a/backend/internal/workflow/eval_session_workflow.go
+++ b/backend/internal/workflow/eval_session_workflow.go
@@ -15,6 +15,8 @@ import (
 var ErrEvalSessionHasNoRuns = errors.New("eval session must have at least one run")
 var errEvalSessionChildrenCancelled = errors.New("eval session child runs cancelled")
 
+const evalSessionRefreshChildRunsVersionChangeID = "eval-session-refresh-child-runs"
+
 func EvalSessionWorkflow(ctx sdkworkflow.Context, input EvalSessionWorkflowInput) error {
 	ctx = sdkworkflow.WithActivityOptions(ctx, defaultActivityOptions)
 
@@ -53,12 +55,14 @@ func runEvalSessionWorkflow(ctx sdkworkflow.Context, input EvalSessionWorkflowIn
 	if len(runs) == 0 {
 		return fmt.Errorf("%w: eval session %s", ErrEvalSessionHasNoRuns, input.EvalSessionID)
 	}
-	runs, err = loadLatestEvalSessionRuns(ctx, runs)
-	if err != nil {
-		return err
-	}
-	if allRunsCancelled(runs) {
-		return transitionEvalSessionStatus(ctx, input.EvalSessionID, domain.EvalSessionStatusCancelled)
+	if sdkworkflow.GetVersion(ctx, evalSessionRefreshChildRunsVersionChangeID, sdkworkflow.DefaultVersion, 1) != sdkworkflow.DefaultVersion {
+		runs, err = loadLatestEvalSessionRuns(ctx, runs)
+		if err != nil {
+			return err
+		}
+		if allRunsCancelled(runs) {
+			return transitionEvalSessionStatus(ctx, input.EvalSessionID, domain.EvalSessionStatusCancelled)
+		}
 	}
 
 	if err := executeEvalSessionRuns(ctx, runs); err != nil {
@@ -173,15 +177,16 @@ func classifyEvalSessionChildErrors(ctx sdkworkflow.Context, childErrors map[uui
 	cancelledChildren := 0
 	for _, runID := range runIDs {
 		childErr := childErrors[runID]
-		if childRunMayAlreadyBeTerminal(childErr) {
+		if childRunMayAlreadyBeTerminal(childErr) || isWorkflowCanceled(childErr) {
 			latest, loadErr := loadRun(ctx, runID)
 			if loadErr != nil {
 				return nil, 0, loadErr
 			}
-			if !latest.Status.CanTransitionTo(domain.RunStatusCancelled) {
-				if latest.Status == domain.RunStatusCancelled {
-					cancelledChildren++
-				}
+			if latest.Status == domain.RunStatusCancelled {
+				cancelledChildren++
+				continue
+			}
+			if childRunMayAlreadyBeTerminal(childErr) && !latest.Status.CanTransitionTo(domain.RunStatusCancelled) {
 				continue
 			}
 		}

--- a/backend/internal/workflow/eval_session_workflow.go
+++ b/backend/internal/workflow/eval_session_workflow.go
@@ -51,6 +51,13 @@ func runEvalSessionWorkflow(ctx sdkworkflow.Context, input EvalSessionWorkflowIn
 	if len(runs) == 0 {
 		return fmt.Errorf("%w: eval session %s", ErrEvalSessionHasNoRuns, input.EvalSessionID)
 	}
+	runs, err = loadLatestEvalSessionRuns(ctx, runs)
+	if err != nil {
+		return err
+	}
+	if allRunsCancelled(runs) {
+		return transitionEvalSessionStatus(ctx, input.EvalSessionID, domain.EvalSessionStatusCancelled)
+	}
 
 	if err := executeEvalSessionRuns(ctx, runs); err != nil {
 		return err
@@ -82,6 +89,18 @@ func listEvalSessionRuns(ctx sdkworkflow.Context, evalSessionID uuid.UUID) ([]do
 	return runs, err
 }
 
+func loadLatestEvalSessionRuns(ctx sdkworkflow.Context, runs []domain.Run) ([]domain.Run, error) {
+	latestRuns := make([]domain.Run, 0, len(runs))
+	for _, run := range runs {
+		latest, err := loadRun(ctx, run.ID)
+		if err != nil {
+			return nil, err
+		}
+		latestRuns = append(latestRuns, latest)
+	}
+	return latestRuns, nil
+}
+
 func transitionEvalSessionStatus(ctx sdkworkflow.Context, evalSessionID uuid.UUID, toStatus domain.EvalSessionStatus) error {
 	var session domain.EvalSession
 	return sdkworkflow.ExecuteActivity(ctx, transitionEvalSessionStatusActivityName, TransitionEvalSessionStatusInput{
@@ -100,10 +119,14 @@ func aggregateEvalSession(ctx sdkworkflow.Context, evalSessionID uuid.UUID) erro
 func executeEvalSessionRuns(ctx sdkworkflow.Context, runs []domain.Run) error {
 	selector := sdkworkflow.NewSelector(ctx)
 	completedChildren := 0
+	startedChildren := 0
 	childErrors := make(map[uuid.UUID]error, len(runs))
 
 	for _, run := range runs {
 		run := run
+		if run.Status != domain.RunStatusQueued {
+			continue
+		}
 		childCtx := sdkworkflow.WithChildOptions(ctx, sdkworkflow.ChildWorkflowOptions{
 			WorkflowID:        fmt.Sprintf("%s/%s", RunWorkflowName, run.ID),
 			ParentClosePolicy: enumspb.PARENT_CLOSE_POLICY_REQUEST_CANCEL,
@@ -111,6 +134,7 @@ func executeEvalSessionRuns(ctx sdkworkflow.Context, runs []domain.Run) error {
 		future := sdkworkflow.ExecuteChildWorkflow(childCtx, RunWorkflowName, RunWorkflowInput{
 			RunID: run.ID,
 		})
+		startedChildren++
 		selector.AddFuture(future, func(f sdkworkflow.Future) {
 			completedChildren++
 			if err := f.Get(ctx, nil); err != nil {
@@ -119,17 +143,29 @@ func executeEvalSessionRuns(ctx sdkworkflow.Context, runs []domain.Run) error {
 		})
 	}
 
-	for completedChildren < len(runs) {
+	for completedChildren < startedChildren {
 		selector.Select(ctx)
 	}
 
-	if len(childErrors) == len(runs) {
+	if startedChildren > 0 && len(childErrors) == startedChildren {
 		for _, err := range childErrors {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func allRunsCancelled(runs []domain.Run) bool {
+	if len(runs) == 0 {
+		return false
+	}
+	for _, run := range runs {
+		if run.Status != domain.RunStatusCancelled {
+			return false
+		}
+	}
+	return true
 }
 
 func markEvalSessionFailed(ctx sdkworkflow.Context, evalSessionID uuid.UUID, workflowErr error) error {

--- a/backend/internal/workflow/eval_session_workflow.go
+++ b/backend/internal/workflow/eval_session_workflow.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/agentclash/agentclash/backend/internal/domain"
 	"github.com/agentclash/agentclash/backend/internal/repository"
@@ -12,6 +13,7 @@ import (
 )
 
 var ErrEvalSessionHasNoRuns = errors.New("eval session must have at least one run")
+var errEvalSessionChildrenCancelled = errors.New("eval session child runs cancelled")
 
 func EvalSessionWorkflow(ctx sdkworkflow.Context, input EvalSessionWorkflowInput) error {
 	ctx = sdkworkflow.WithActivityOptions(ctx, defaultActivityOptions)
@@ -60,6 +62,9 @@ func runEvalSessionWorkflow(ctx sdkworkflow.Context, input EvalSessionWorkflowIn
 	}
 
 	if err := executeEvalSessionRuns(ctx, runs); err != nil {
+		if errors.Is(err, errEvalSessionChildrenCancelled) {
+			return transitionEvalSessionStatus(ctx, input.EvalSessionID, domain.EvalSessionStatusCancelled)
+		}
 		return err
 	}
 
@@ -147,13 +152,48 @@ func executeEvalSessionRuns(ctx sdkworkflow.Context, runs []domain.Run) error {
 		selector.Select(ctx)
 	}
 
-	if startedChildren > 0 && len(childErrors) == startedChildren {
-		for _, err := range childErrors {
+	actionableErrors, cancelledChildren, err := classifyEvalSessionChildErrors(ctx, childErrors)
+	if err != nil {
+		return err
+	}
+	if startedChildren > 0 && cancelledChildren == startedChildren {
+		return errEvalSessionChildrenCancelled
+	}
+	if startedChildren > 0 && len(actionableErrors) == startedChildren {
+		for _, err := range actionableErrors {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func classifyEvalSessionChildErrors(ctx sdkworkflow.Context, childErrors map[uuid.UUID]error) (map[uuid.UUID]error, int, error) {
+	actionableErrors := make(map[uuid.UUID]error, len(childErrors))
+	cancelledChildren := 0
+	for runID, childErr := range childErrors {
+		if childRunMayAlreadyBeTerminal(childErr) {
+			latest, loadErr := loadRun(ctx, runID)
+			if loadErr != nil {
+				return nil, 0, loadErr
+			}
+			if !latest.Status.CanTransitionTo(domain.RunStatusCancelled) {
+				if latest.Status == domain.RunStatusCancelled {
+					cancelledChildren++
+				}
+				continue
+			}
+		}
+		actionableErrors[runID] = childErr
+	}
+	return actionableErrors, cancelledChildren, nil
+}
+
+func childRunMayAlreadyBeTerminal(err error) bool {
+	return errors.Is(err, ErrRunMustBeQueued) ||
+		strings.Contains(err.Error(), ErrRunMustBeQueued.Error()) ||
+		hasApplicationErrorType(err, repositoryInvalidTransitionType) ||
+		hasApplicationErrorType(err, repositoryTransitionConflictType)
 }
 
 func allRunsCancelled(runs []domain.Run) bool {

--- a/backend/internal/workflow/run_workflow.go
+++ b/backend/internal/workflow/run_workflow.go
@@ -37,6 +37,9 @@ func RunWorkflow(ctx sdkworkflow.Context, input RunWorkflowInput) error {
 	if isWorkflowCanceled(err) {
 		return markRunCancelled(ctx, input.RunID, err)
 	}
+	if errors.Is(err, ErrRunMustBeQueued) {
+		return temporal.NewNonRetryableApplicationError(err.Error(), runMustBeQueuedErrorType, err)
+	}
 	if shouldSkipRunFailureTransition(err) {
 		return err
 	}
@@ -123,12 +126,25 @@ func executeRunAgents(ctx sdkworkflow.Context, runAgents []domain.RunAgent) erro
 	}
 
 	if len(childErrors) == len(runAgents) {
-		for _, err := range childErrors {
-			return err
-		}
+		return selectRunAgentChildError(childErrors)
 	}
 
 	return nil
+}
+
+func selectRunAgentChildError(childErrors map[uuid.UUID]error) error {
+	runAgentIDs := sortedUUIDKeys(childErrors)
+	var firstActionable error
+	for _, runAgentID := range runAgentIDs {
+		err := childErrors[runAgentID]
+		if isWorkflowCanceled(err) {
+			return err
+		}
+		if firstActionable == nil {
+			firstActionable = err
+		}
+	}
+	return firstActionable
 }
 
 func scoreEvaluatingRunAgents(ctx sdkworkflow.Context, runAgents []domain.RunAgent) (string, error) {

--- a/backend/internal/workflow/run_workflow.go
+++ b/backend/internal/workflow/run_workflow.go
@@ -295,6 +295,16 @@ func markRunCancelled(ctx sdkworkflow.Context, runID uuid.UUID, workflowErr erro
 		Reason:   &reason,
 	}).Get(disconnectedCtx, &run)
 	if activityErr != nil {
+		if hasApplicationErrorType(activityErr, repositoryInvalidTransitionType) ||
+			hasApplicationErrorType(activityErr, repositoryTransitionConflictType) {
+			latest, loadErr := loadRun(disconnectedCtx, runID)
+			if loadErr == nil && latest.Status == domain.RunStatusCancelled {
+				return workflowErr
+			}
+			if loadErr != nil {
+				return fmt.Errorf("run workflow cancelled: %v; additionally failed to mark run cancelled: %w; additionally failed to load latest run: %v", workflowErr, activityErr, loadErr)
+			}
+		}
 		return fmt.Errorf("run workflow cancelled: %v; additionally failed to mark run cancelled: %w", workflowErr, activityErr)
 	}
 

--- a/backend/internal/workflow/run_workflow.go
+++ b/backend/internal/workflow/run_workflow.go
@@ -298,7 +298,7 @@ func markRunCancelled(ctx sdkworkflow.Context, runID uuid.UUID, workflowErr erro
 		if hasApplicationErrorType(activityErr, repositoryInvalidTransitionType) ||
 			hasApplicationErrorType(activityErr, repositoryTransitionConflictType) {
 			latest, loadErr := loadRun(disconnectedCtx, runID)
-			if loadErr == nil && latest.Status == domain.RunStatusCancelled {
+			if loadErr == nil && !latest.Status.CanTransitionTo(domain.RunStatusCancelled) {
 				return workflowErr
 			}
 			if loadErr != nil {

--- a/backend/internal/workflow/workflow_test.go
+++ b/backend/internal/workflow/workflow_test.go
@@ -173,7 +173,11 @@ func TestEvalSessionWorkflowMarksSessionCancelledWhenStartedChildWasCancelled(t 
 
 	env := newEvalSessionWorkflowTestEnvironment(repo, nil, func(ctx sdkworkflow.Context, input RunWorkflowInput) error {
 		repo.forceEvalSessionRunStatus(sessionID, input.RunID, domain.RunStatusCancelled)
-		return ErrRunMustBeQueued
+		return temporal.NewNonRetryableApplicationError(
+			ErrRunMustBeQueued.Error(),
+			runMustBeQueuedErrorType,
+			ErrRunMustBeQueued,
+		)
 	})
 	env.ExecuteWorkflow(EvalSessionWorkflow, EvalSessionWorkflowInput{EvalSessionID: sessionID})
 
@@ -182,6 +186,41 @@ func TestEvalSessionWorkflowMarksSessionCancelledWhenStartedChildWasCancelled(t 
 	}
 	if got := repo.currentEvalSession(sessionID).Status; got != domain.EvalSessionStatusCancelled {
 		t.Fatalf("eval session status = %s, want %s", got, domain.EvalSessionStatusCancelled)
+	}
+	if repo.callCountWithPrefix("AggregateEvalSession:") != 0 {
+		t.Fatalf("AggregateEvalSession call count = %d, want 0", repo.callCountWithPrefix("AggregateEvalSession:"))
+	}
+}
+
+func TestEvalSessionWorkflowMixedCancelledAndFailedChildrenMarksSessionFailed(t *testing.T) {
+	sessionID := uuid.New()
+	cancelledRunID := uuid.New()
+	failedRunID := uuid.New()
+	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
+	repo.setEvalSession(
+		fixtureEvalSession(sessionID, domain.EvalSessionStatusQueued),
+		fixtureChildRun(cancelledRunID, sessionID),
+		fixtureChildRun(failedRunID, sessionID),
+	)
+
+	env := newEvalSessionWorkflowTestEnvironment(repo, nil, func(ctx sdkworkflow.Context, input RunWorkflowInput) error {
+		if input.RunID == cancelledRunID {
+			repo.forceEvalSessionRunStatus(sessionID, input.RunID, domain.RunStatusCancelled)
+			return temporal.NewNonRetryableApplicationError(
+				ErrRunMustBeQueued.Error(),
+				runMustBeQueuedErrorType,
+				ErrRunMustBeQueued,
+			)
+		}
+		return errors.New("real child failure")
+	})
+	env.ExecuteWorkflow(EvalSessionWorkflow, EvalSessionWorkflowInput{EvalSessionID: sessionID})
+
+	if err := env.GetWorkflowError(); err == nil {
+		t.Fatalf("expected workflow failure")
+	}
+	if got := repo.currentEvalSession(sessionID).Status; got != domain.EvalSessionStatusFailed {
+		t.Fatalf("eval session status = %s, want %s", got, domain.EvalSessionStatusFailed)
 	}
 	if repo.callCountWithPrefix("AggregateEvalSession:") != 0 {
 		t.Fatalf("AggregateEvalSession call count = %d, want 0", repo.callCountWithPrefix("AggregateEvalSession:"))
@@ -1162,6 +1201,19 @@ func TestRunWorkflowChildFailureReturnsOriginalErrorWhenReplayBuildFails(t *test
 	}
 	if got := repo.currentRunAgent(runAgentID).Status; got != domain.RunAgentStatusFailed {
 		t.Fatalf("run agent status = %s, want %s", got, domain.RunAgentStatusFailed)
+	}
+}
+
+func TestSelectRunAgentChildErrorPrefersCancellationDeterministically(t *testing.T) {
+	cancelledRunAgentID := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	failedRunAgentID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	selected := selectRunAgentChildError(map[uuid.UUID]error{
+		failedRunAgentID:    errors.New("child failed"),
+		cancelledRunAgentID: temporal.NewCanceledError("child cancelled"),
+	})
+
+	if !isWorkflowCanceled(selected) {
+		t.Fatalf("selected error = %v, want cancellation to win over child failure", selected)
 	}
 }
 

--- a/backend/internal/workflow/workflow_test.go
+++ b/backend/internal/workflow/workflow_test.go
@@ -248,6 +248,37 @@ func TestEvalSessionWorkflowMixedCancelledAndFailedChildrenMarksSessionFailed(t 
 	}
 }
 
+func TestEvalSessionWorkflowLateCancelAfterCompletedChildStillAggregates(t *testing.T) {
+	sessionID := uuid.New()
+	completedRunID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	failedRunID := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
+	repo.setEvalSession(
+		fixtureEvalSession(sessionID, domain.EvalSessionStatusQueued),
+		fixtureChildRun(completedRunID, sessionID),
+		fixtureChildRun(failedRunID, sessionID),
+	)
+
+	env := newEvalSessionWorkflowTestEnvironment(repo, nil, func(ctx sdkworkflow.Context, input RunWorkflowInput) error {
+		if input.RunID == completedRunID {
+			repo.forceEvalSessionRunStatus(sessionID, input.RunID, domain.RunStatusCompleted)
+			return temporal.NewCanceledError("late cancel after completion")
+		}
+		return errors.New("real child failure")
+	})
+	env.ExecuteWorkflow(EvalSessionWorkflow, EvalSessionWorkflowInput{EvalSessionID: sessionID})
+
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("EvalSessionWorkflow returned error: %v", err)
+	}
+	if got := repo.currentEvalSession(sessionID).Status; got != domain.EvalSessionStatusCompleted {
+		t.Fatalf("eval session status = %s, want %s", got, domain.EvalSessionStatusCompleted)
+	}
+	if repo.callCountWithPrefix("AggregateEvalSession:") != 1 {
+		t.Fatalf("AggregateEvalSession call count = %d, want 1", repo.callCountWithPrefix("AggregateEvalSession:"))
+	}
+}
+
 func TestEvalSessionWorkflowAggregationFailureMarksSessionFailed(t *testing.T) {
 	sessionID := uuid.New()
 	runID := uuid.New()

--- a/backend/internal/workflow/workflow_test.go
+++ b/backend/internal/workflow/workflow_test.go
@@ -931,6 +931,38 @@ func TestRunWorkflowCancellationIsIdempotentWhenRunAlreadyCancelled(t *testing.T
 	}
 }
 
+func TestRunWorkflowCancellationIsIdempotentWhenRunAlreadyTerminal(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	repo := newFakeRunRepository(
+		fixtureRun(runID, domain.RunStatusQueued),
+		fixtureRunAgent(runID, runAgentID, 0),
+	)
+
+	env := newTestWorkflowEnvironment(repo, FakeWorkHooks{
+		PrepareExecutionLane: func(ctx context.Context, input RunAgentWorkflowInput) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	})
+	env.RegisterDelayedCallback(func() {
+		repo.forceRunStatus(domain.RunStatusCompleted)
+		env.CancelWorkflow()
+	}, fakeStageDelay/2)
+	env.ExecuteWorkflow(RunWorkflow, RunWorkflowInput{RunID: runID})
+
+	err := env.GetWorkflowError()
+	if err == nil {
+		t.Fatalf("expected cancellation error")
+	}
+	if !temporal.IsCanceledError(err) {
+		t.Fatalf("workflow error = %v, want canceled error", err)
+	}
+	if run := repo.currentRun(); run.Status != domain.RunStatusCompleted {
+		t.Fatalf("run status = %s, want %s", run.Status, domain.RunStatusCompleted)
+	}
+}
+
 func TestRunWorkflowPartialChildFailureDoesNotCancelOtherAgents(t *testing.T) {
 	runID := uuid.New()
 	successAgentID := uuid.New()

--- a/backend/internal/workflow/workflow_test.go
+++ b/backend/internal/workflow/workflow_test.go
@@ -100,6 +100,68 @@ func TestEvalSessionWorkflowPartialChildFailureStillAggregates(t *testing.T) {
 	}
 }
 
+func TestEvalSessionWorkflowSkipsAlreadyCancelledChildRuns(t *testing.T) {
+	sessionID := uuid.New()
+	cancelledRunID := uuid.New()
+	queuedRunID := uuid.New()
+	cancelledRun := fixtureChildRun(cancelledRunID, sessionID)
+	cancelledRun.Status = domain.RunStatusCancelled
+	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
+	repo.setEvalSession(
+		fixtureEvalSession(sessionID, domain.EvalSessionStatusQueued),
+		cancelledRun,
+		fixtureChildRun(queuedRunID, sessionID),
+	)
+
+	var started []uuid.UUID
+	var startedMu sync.Mutex
+	env := newEvalSessionWorkflowTestEnvironment(repo, nil, func(ctx sdkworkflow.Context, input RunWorkflowInput) error {
+		startedMu.Lock()
+		started = append(started, input.RunID)
+		startedMu.Unlock()
+		return nil
+	})
+	env.ExecuteWorkflow(EvalSessionWorkflow, EvalSessionWorkflowInput{EvalSessionID: sessionID})
+
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("EvalSessionWorkflow returned error: %v", err)
+	}
+	if got := repo.currentEvalSession(sessionID).Status; got != domain.EvalSessionStatusCompleted {
+		t.Fatalf("eval session status = %s, want %s", got, domain.EvalSessionStatusCompleted)
+	}
+	if fmt.Sprint(started) != fmt.Sprint([]uuid.UUID{queuedRunID}) {
+		t.Fatalf("started child runs = %v, want [%s]", started, queuedRunID)
+	}
+}
+
+func TestEvalSessionWorkflowAllCancelledChildRunsMarksSessionCancelled(t *testing.T) {
+	sessionID := uuid.New()
+	runID := uuid.New()
+	cancelledRun := fixtureChildRun(runID, sessionID)
+	cancelledRun.Status = domain.RunStatusCancelled
+	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
+	repo.setEvalSession(
+		fixtureEvalSession(sessionID, domain.EvalSessionStatusQueued),
+		cancelledRun,
+	)
+
+	env := newEvalSessionWorkflowTestEnvironment(repo, nil, func(ctx sdkworkflow.Context, input RunWorkflowInput) error {
+		t.Fatalf("cancelled run %s should not be started", input.RunID)
+		return nil
+	})
+	env.ExecuteWorkflow(EvalSessionWorkflow, EvalSessionWorkflowInput{EvalSessionID: sessionID})
+
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("EvalSessionWorkflow returned error: %v", err)
+	}
+	if got := repo.currentEvalSession(sessionID).Status; got != domain.EvalSessionStatusCancelled {
+		t.Fatalf("eval session status = %s, want %s", got, domain.EvalSessionStatusCancelled)
+	}
+	if repo.callCountWithPrefix("AggregateEvalSession:") != 0 {
+		t.Fatalf("AggregateEvalSession call count = %d, want 0", repo.callCountWithPrefix("AggregateEvalSession:"))
+	}
+}
+
 func TestEvalSessionWorkflowAggregationFailureMarksSessionFailed(t *testing.T) {
 	sessionID := uuid.New()
 	runID := uuid.New()
@@ -1145,6 +1207,7 @@ func newEvalSessionWorkflowTestEnvironment(
 	env.RegisterWorkflowWithOptions(EvalSessionWorkflow, sdkworkflow.RegisterOptions{Name: EvalSessionWorkflowName})
 	env.RegisterActivityWithOptions(activities.LoadEvalSession, sdkactivity.RegisterOptions{Name: loadEvalSessionActivityName})
 	env.RegisterActivityWithOptions(activities.ListEvalSessionRuns, sdkactivity.RegisterOptions{Name: listEvalSessionRunsActivityName})
+	env.RegisterActivityWithOptions(activities.LoadRun, sdkactivity.RegisterOptions{Name: loadRunActivityName})
 	env.RegisterActivityWithOptions(activities.TransitionEvalSessionStatus, sdkactivity.RegisterOptions{Name: transitionEvalSessionStatusActivityName})
 	env.RegisterActivityWithOptions(activities.AggregateEvalSession, sdkactivity.RegisterOptions{Name: aggregateEvalSessionActivityName})
 	if childWorkflow == nil {
@@ -1321,6 +1384,14 @@ func (r *fakeRunRepository) GetRunByID(_ context.Context, id uuid.UUID) (domain.
 	defer r.mu.Unlock()
 
 	if r.run.ID != id {
+		for _, runs := range r.evalSessionRuns {
+			for _, run := range runs {
+				if run.ID == id {
+					r.callLog = append(r.callLog, "GetRunByID")
+					return cloneRun(run), nil
+				}
+			}
+		}
 		return domain.Run{}, repository.ErrRunNotFound
 	}
 	r.callLog = append(r.callLog, "GetRunByID")

--- a/backend/internal/workflow/workflow_test.go
+++ b/backend/internal/workflow/workflow_test.go
@@ -162,6 +162,31 @@ func TestEvalSessionWorkflowAllCancelledChildRunsMarksSessionCancelled(t *testin
 	}
 }
 
+func TestEvalSessionWorkflowDefaultVersionSkipsChildRefresh(t *testing.T) {
+	sessionID := uuid.New()
+	runID := uuid.New()
+	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
+	repo.setEvalSession(
+		fixtureEvalSession(sessionID, domain.EvalSessionStatusQueued),
+		fixtureChildRun(runID, sessionID),
+	)
+
+	env := newEvalSessionWorkflowTestEnvironment(repo, nil, nil)
+	env.OnGetVersion(
+		evalSessionRefreshChildRunsVersionChangeID,
+		sdkworkflow.DefaultVersion,
+		sdkworkflow.Version(1),
+	).Return(sdkworkflow.DefaultVersion)
+	env.ExecuteWorkflow(EvalSessionWorkflow, EvalSessionWorkflowInput{EvalSessionID: sessionID})
+
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("EvalSessionWorkflow returned error: %v", err)
+	}
+	if repo.callCountWithPrefix("GetRunByID") != 0 {
+		t.Fatalf("GetRunByID call count = %d, want 0 for default version replay path", repo.callCountWithPrefix("GetRunByID"))
+	}
+}
+
 func TestEvalSessionWorkflowMarksSessionCancelledWhenStartedChildWasCancelled(t *testing.T) {
 	sessionID := uuid.New()
 	runID := uuid.New()
@@ -194,8 +219,8 @@ func TestEvalSessionWorkflowMarksSessionCancelledWhenStartedChildWasCancelled(t 
 
 func TestEvalSessionWorkflowMixedCancelledAndFailedChildrenMarksSessionFailed(t *testing.T) {
 	sessionID := uuid.New()
-	cancelledRunID := uuid.New()
-	failedRunID := uuid.New()
+	cancelledRunID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	failedRunID := uuid.MustParse("00000000-0000-0000-0000-000000000002")
 	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
 	repo.setEvalSession(
 		fixtureEvalSession(sessionID, domain.EvalSessionStatusQueued),
@@ -206,11 +231,7 @@ func TestEvalSessionWorkflowMixedCancelledAndFailedChildrenMarksSessionFailed(t 
 	env := newEvalSessionWorkflowTestEnvironment(repo, nil, func(ctx sdkworkflow.Context, input RunWorkflowInput) error {
 		if input.RunID == cancelledRunID {
 			repo.forceEvalSessionRunStatus(sessionID, input.RunID, domain.RunStatusCancelled)
-			return temporal.NewNonRetryableApplicationError(
-				ErrRunMustBeQueued.Error(),
-				runMustBeQueuedErrorType,
-				ErrRunMustBeQueued,
-			)
+			return temporal.NewCanceledError("child cancelled")
 		}
 		return errors.New("real child failure")
 	})

--- a/backend/internal/workflow/workflow_test.go
+++ b/backend/internal/workflow/workflow_test.go
@@ -162,6 +162,32 @@ func TestEvalSessionWorkflowAllCancelledChildRunsMarksSessionCancelled(t *testin
 	}
 }
 
+func TestEvalSessionWorkflowMarksSessionCancelledWhenStartedChildWasCancelled(t *testing.T) {
+	sessionID := uuid.New()
+	runID := uuid.New()
+	repo := newFakeRunRepository(fixtureRun(uuid.New(), domain.RunStatusQueued))
+	repo.setEvalSession(
+		fixtureEvalSession(sessionID, domain.EvalSessionStatusQueued),
+		fixtureChildRun(runID, sessionID),
+	)
+
+	env := newEvalSessionWorkflowTestEnvironment(repo, nil, func(ctx sdkworkflow.Context, input RunWorkflowInput) error {
+		repo.forceEvalSessionRunStatus(sessionID, input.RunID, domain.RunStatusCancelled)
+		return ErrRunMustBeQueued
+	})
+	env.ExecuteWorkflow(EvalSessionWorkflow, EvalSessionWorkflowInput{EvalSessionID: sessionID})
+
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatalf("EvalSessionWorkflow returned error: %v", err)
+	}
+	if got := repo.currentEvalSession(sessionID).Status; got != domain.EvalSessionStatusCancelled {
+		t.Fatalf("eval session status = %s, want %s", got, domain.EvalSessionStatusCancelled)
+	}
+	if repo.callCountWithPrefix("AggregateEvalSession:") != 0 {
+		t.Fatalf("AggregateEvalSession call count = %d, want 0", repo.callCountWithPrefix("AggregateEvalSession:"))
+	}
+}
+
 func TestEvalSessionWorkflowAggregationFailureMarksSessionFailed(t *testing.T) {
 	sessionID := uuid.New()
 	runID := uuid.New()
@@ -1930,6 +1956,21 @@ func (r *fakeRunRepository) forceRunStatus(status domain.RunStatus) {
 	defer r.mu.Unlock()
 
 	r.run.Status = status
+}
+
+func (r *fakeRunRepository) forceEvalSessionRunStatus(evalSessionID uuid.UUID, runID uuid.UUID, status domain.RunStatus) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	runs := r.evalSessionRuns[evalSessionID]
+	for index, run := range runs {
+		if run.ID == runID {
+			run.Status = status
+			runs[index] = run
+			r.evalSessionRuns[evalSessionID] = runs
+			return
+		}
+	}
 }
 
 func (r *fakeRunRepository) currentEvalSession(id uuid.UUID) domain.EvalSession {

--- a/backend/internal/workflow/workflow_test.go
+++ b/backend/internal/workflow/workflow_test.go
@@ -899,6 +899,38 @@ func TestRunWorkflowCancellationMarksRunCancelled(t *testing.T) {
 	}
 }
 
+func TestRunWorkflowCancellationIsIdempotentWhenRunAlreadyCancelled(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	repo := newFakeRunRepository(
+		fixtureRun(runID, domain.RunStatusQueued),
+		fixtureRunAgent(runID, runAgentID, 0),
+	)
+
+	env := newTestWorkflowEnvironment(repo, FakeWorkHooks{
+		PrepareExecutionLane: func(ctx context.Context, input RunAgentWorkflowInput) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	})
+	env.RegisterDelayedCallback(func() {
+		repo.forceRunStatus(domain.RunStatusCancelled)
+		env.CancelWorkflow()
+	}, fakeStageDelay/2)
+	env.ExecuteWorkflow(RunWorkflow, RunWorkflowInput{RunID: runID})
+
+	err := env.GetWorkflowError()
+	if err == nil {
+		t.Fatalf("expected cancellation error")
+	}
+	if !temporal.IsCanceledError(err) {
+		t.Fatalf("workflow error = %v, want canceled error", err)
+	}
+	if run := repo.currentRun(); run.Status != domain.RunStatusCancelled {
+		t.Fatalf("run status = %s, want %s", run.Status, domain.RunStatusCancelled)
+	}
+}
+
 func TestRunWorkflowPartialChildFailureDoesNotCancelOtherAgents(t *testing.T) {
 	runID := uuid.New()
 	successAgentID := uuid.New()
@@ -1788,6 +1820,13 @@ func (r *fakeRunRepository) currentRun() domain.Run {
 	defer r.mu.Unlock()
 
 	return cloneRun(r.run)
+}
+
+func (r *fakeRunRepository) forceRunStatus(status domain.RunStatus) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.run.Status = status
 }
 
 func (r *fakeRunRepository) currentEvalSession(id uuid.UUID) domain.EvalSession {

--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -247,6 +247,25 @@ func TestRunGetCallsCorrectEndpoint(t *testing.T) {
 	}
 }
 
+func TestRunCancelCallsCorrectEndpoint(t *testing.T) {
+	var called bool
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/runs/run-456/cancel": captureHandler(t, &called, 200, map[string]any{
+			"id": "run-456", "name": "Test", "status": "cancelled",
+		}),
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{"run", "cancel", "run-456"}, srv.URL)
+	if err != nil {
+		t.Fatalf("run cancel error: %v", err)
+	}
+	if !called {
+		t.Fatal("POST /v1/runs/run-456/cancel was not called")
+	}
+}
+
 func TestRunEventsUsesAuthorizationHeaderWithoutQueryToken(t *testing.T) {
 	var called bool
 	var gotAuth string

--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -266,6 +266,24 @@ func TestRunCancelCallsCorrectEndpoint(t *testing.T) {
 	}
 }
 
+func TestRunCancelSuccessMessageDistinguishesNoop(t *testing.T) {
+	tests := []struct {
+		status string
+		want   string
+	}{
+		{status: "cancelled", want: "Run run-456 cancelled"},
+		{status: "completed", want: "Run run-456 is already completed; no cancellation performed"},
+		{status: "failed", want: "Run run-456 is already failed; no cancellation performed"},
+		{status: "running", want: "Run run-456 status is running"},
+	}
+
+	for _, tc := range tests {
+		if got := runCancelSuccessMessage("run-456", tc.status); got != tc.want {
+			t.Fatalf("runCancelSuccessMessage(%q) = %q, want %q", tc.status, got, tc.want)
+		}
+	}
+}
+
 func TestRunEventsUsesAuthorizationHeaderWithoutQueryToken(t *testing.T) {
 	var called bool
 	var gotAuth string

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -170,10 +170,22 @@ var runCancelCmd = &cobra.Command{
 			return rc.Output.PrintRaw(run)
 		}
 
-		rc.Output.PrintSuccess(fmt.Sprintf("Run %s status updated", args[0]))
-		rc.Output.PrintDetail("Status", output.StatusColor(str(run["status"])))
+		status := str(run["status"])
+		rc.Output.PrintSuccess(runCancelSuccessMessage(args[0], status))
+		rc.Output.PrintDetail("Status", output.StatusColor(status))
 		return nil
 	},
+}
+
+func runCancelSuccessMessage(runID, status string) string {
+	switch status {
+	case "cancelled":
+		return fmt.Sprintf("Run %s cancelled", runID)
+	case "completed", "failed":
+		return fmt.Sprintf("Run %s is already %s; no cancellation performed", runID, status)
+	default:
+		return fmt.Sprintf("Run %s status is %s", runID, status)
+	}
 }
 
 var runCreateCmd = &cobra.Command{

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -17,6 +17,7 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 	runCmd.AddCommand(runListCmd)
 	runCmd.AddCommand(runGetCmd)
+	runCmd.AddCommand(runCancelCmd)
 	runCmd.AddCommand(runCreateCmd)
 	runCmd.AddCommand(runRankingCmd)
 	runCmd.AddCommand(runAgentsCmd)
@@ -141,6 +142,36 @@ var runGetCmd = &cobra.Command{
 		if finished := mapString(run, "finished_at", "completed_at"); finished != "" {
 			rc.Output.PrintDetail("Completed", finished)
 		}
+		return nil
+	},
+}
+
+var runCancelCmd = &cobra.Command{
+	Use:   "cancel <id>",
+	Short: "Cancel an active run",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+
+		resp, err := rc.Client.Post(cmd.Context(), "/v1/runs/"+args[0]+"/cancel", map[string]any{})
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+
+		var run map[string]any
+		if err := resp.DecodeJSON(&run); err != nil {
+			return err
+		}
+
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(run)
+		}
+
+		rc.Output.PrintSuccess(fmt.Sprintf("Cancelled run %s", args[0]))
+		rc.Output.PrintDetail("Status", output.StatusColor(str(run["status"])))
 		return nil
 	},
 }

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -170,7 +170,7 @@ var runCancelCmd = &cobra.Command{
 			return rc.Output.PrintRaw(run)
 		}
 
-		rc.Output.PrintSuccess(fmt.Sprintf("Cancelled run %s", args[0]))
+		rc.Output.PrintSuccess(fmt.Sprintf("Run %s status updated", args[0]))
 		rc.Output.PrintDetail("Status", output.StatusColor(str(run["status"])))
 		return nil
 	},

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -2587,6 +2587,42 @@ paths:
         "404":
           $ref: "#/components/responses/NotFoundError"
 
+  /v1/runs/{runID}/cancel:
+    post:
+      operationId: cancelRun
+      tags: [Runs]
+      summary: Cancel a run
+      description: >
+        Cancels an active run. If the run has already reached a terminal status,
+        the endpoint returns the current run details without changing it.
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/RunID"
+      responses:
+        "200":
+          description: Run cancelled or already terminal
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RunDetail"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "502":
+          description: Run workflow could not be cancelled
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateRunErrorResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /v1/runs/{runID}/ranking:
     get:
       operationId: getRunRanking

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -2619,7 +2619,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CreateRunErrorResponse"
+                $ref: "#/components/schemas/RunWorkflowErrorResponse"
         "500":
           $ref: "#/components/responses/InternalServerError"
 
@@ -7382,6 +7382,24 @@ components:
               type: string
         run:
           $ref: "#/components/schemas/CreateRunResponse"
+
+    RunWorkflowErrorResponse:
+      type: object
+      required: [error, run]
+      description: >
+        Returned when a run workflow operation could not be completed in
+        Temporal (HTTP 502).
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+        run:
+          $ref: "#/components/schemas/RunDetail"
 
     RunDetail:
       type: object


### PR DESCRIPTION
## Summary
- add POST /v1/runs/{runID}/cancel for authorized run cancellation
- cancel the Temporal run workflow when Temporal IDs are present, then mark the run cancelled with audit history
- make terminal run cancellation idempotent
- add agentclash run cancel <id>

Closes #695.

## Tests
- cd backend && go test ./...
- cd backend && go build ./... && go vet ./...
- cd cli && go test ./...
- cd cli && go build ./... && go vet ./...