### PR TITLE
feat: add workspace quota visibility

### DIFF
--- a/backend/internal/api/billing.go
+++ b/backend/internal/api/billing.go
@@ -30,6 +30,7 @@ type BillingService interface {
 	CreateCheckout(ctx context.Context, caller Caller, orgID uuid.UUID, input CreateBillingCheckoutInput) (CreateBillingCheckoutResult, error)
 	CreatePortal(ctx context.Context, caller Caller, orgID uuid.UUID) (CreateBillingPortalResult, error)
 	GetWorkspaceEntitlements(ctx context.Context, caller Caller, workspaceID uuid.UUID) (WorkspaceEntitlementsResult, error)
+	GetWorkspaceQuota(ctx context.Context, caller Caller, workspaceID uuid.UUID) (WorkspaceQuotaResult, error)
 	ProcessDodoWebhook(ctx context.Context, headers DodoWebhookHeaders, rawBody []byte) (ProcessDodoWebhookResult, error)
 }
 
@@ -139,6 +140,26 @@ type WorkspaceEntitlementsResult struct {
 
 type WorkspaceGateSummary struct {
 	Run billingpkg.GateDecision `json:"run"`
+}
+
+type WorkspaceQuotaResult struct {
+	OrganizationID  uuid.UUID    `json:"organization_id"`
+	WorkspaceID     uuid.UUID    `json:"workspace_id"`
+	PlanKey         string       `json:"plan_key"`
+	BillingPeriod   string       `json:"billing_period"`
+	Status          string       `json:"status"`
+	MonthlyRaces    QuotaCounter `json:"monthly_races"`
+	ConcurrentRaces QuotaCounter `json:"concurrent_races"`
+	Seats           QuotaCounter `json:"seats"`
+	WindowStart     time.Time    `json:"window_start"`
+	WindowEnd       time.Time    `json:"window_end"`
+}
+
+type QuotaCounter struct {
+	Used      int        `json:"used"`
+	Limit     *int       `json:"limit,omitempty"`
+	Remaining *int       `json:"remaining,omitempty"`
+	ResetAt   *time.Time `json:"reset_at,omitempty"`
 }
 
 type DodoWebhookHeaders struct {
@@ -332,6 +353,37 @@ func (m *BillingManager) GetWorkspaceEntitlements(ctx context.Context, caller Ca
 		Gates: WorkspaceGateSummary{
 			Run: runDecision,
 		},
+	}, nil
+}
+
+func (m *BillingManager) GetWorkspaceQuota(ctx context.Context, caller Caller, workspaceID uuid.UUID) (WorkspaceQuotaResult, error) {
+	result, err := m.GetWorkspaceEntitlements(ctx, caller, workspaceID)
+	if err != nil {
+		return WorkspaceQuotaResult{}, err
+	}
+	activeSeats, err := m.repo.CountActiveOrgMembers(ctx, result.OrganizationID)
+	if err != nil {
+		return WorkspaceQuotaResult{}, err
+	}
+	return WorkspaceQuotaResult{
+		OrganizationID: result.OrganizationID,
+		WorkspaceID:    result.WorkspaceID,
+		PlanKey:        result.Entitlements.PlanKey,
+		BillingPeriod:  result.Entitlements.BillingPeriod,
+		Status:         result.Entitlements.Status,
+		MonthlyRaces: quotaCounter(
+			result.Usage.RaceCount,
+			result.Entitlements.RacesPerWorkspaceMonth,
+			&result.Usage.WindowEnd,
+		),
+		ConcurrentRaces: quotaCounter(
+			result.Usage.ActiveRuns,
+			result.Entitlements.ConcurrentRaces,
+			nil,
+		),
+		Seats:       quotaCounter(activeSeats, result.Entitlements.SeatsLimit, nil),
+		WindowStart: result.Usage.WindowStart,
+		WindowEnd:   result.Usage.WindowEnd,
 	}, nil
 }
 
@@ -1088,6 +1140,7 @@ func registerBillingRoutes(router chi.Router, logger *slog.Logger, service Billi
 	router.Post("/organizations/{organizationID}/billing/checkout", createBillingCheckoutHandler(logger, service))
 	router.Post("/organizations/{organizationID}/billing/portal", createBillingPortalHandler(logger, service))
 	router.Get("/workspaces/{workspaceID}/entitlements", getWorkspaceEntitlementsHandler(logger, service))
+	router.Get("/workspaces/{workspaceID}/quota", getWorkspaceQuotaHandler(logger, service))
 }
 
 func listBillingPlansHandler(logger *slog.Logger, service BillingService) http.HandlerFunc {
@@ -1226,6 +1279,27 @@ func getWorkspaceEntitlementsHandler(logger *slog.Logger, service BillingService
 	}
 }
 
+func getWorkspaceQuotaHandler(logger *slog.Logger, service BillingService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		workspaceID, err := uuid.Parse(chi.URLParam(r, "workspaceID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_workspace_id", "workspace ID is malformed")
+			return
+		}
+		result, err := service.GetWorkspaceQuota(r.Context(), caller, workspaceID)
+		if err != nil {
+			writeBillingServiceError(w, logger, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
 func writeBillingServiceError(w http.ResponseWriter, logger *slog.Logger, err error) {
 	var validationErr validationErrorEnvelope
 	var gateErr billingpkg.GateError
@@ -1262,6 +1336,29 @@ func (noopBillingService) CreatePortal(context.Context, Caller, uuid.UUID) (Crea
 func (noopBillingService) GetWorkspaceEntitlements(context.Context, Caller, uuid.UUID) (WorkspaceEntitlementsResult, error) {
 	return WorkspaceEntitlementsResult{}, errors.New("billing service is not configured")
 }
+func (noopBillingService) GetWorkspaceQuota(context.Context, Caller, uuid.UUID) (WorkspaceQuotaResult, error) {
+	return WorkspaceQuotaResult{}, errors.New("billing service is not configured")
+}
 func (noopBillingService) ProcessDodoWebhook(context.Context, DodoWebhookHeaders, []byte) (ProcessDodoWebhookResult, error) {
 	return ProcessDodoWebhookResult{}, errors.New("billing service is not configured")
+}
+
+func quotaCounter(used int, limit *int, resetAt *time.Time) QuotaCounter {
+	counter := QuotaCounter{
+		Used: used,
+	}
+	if limit != nil {
+		copiedLimit := *limit
+		counter.Limit = &copiedLimit
+		remaining := *limit - used
+		if remaining < 0 {
+			remaining = 0
+		}
+		counter.Remaining = &remaining
+	}
+	if resetAt != nil {
+		reset := resetAt.UTC()
+		counter.ResetAt = &reset
+	}
+	return counter
 }

--- a/backend/internal/api/billing_test.go
+++ b/backend/internal/api/billing_test.go
@@ -99,6 +99,49 @@ func TestBillingManagerBuildRunGateRejectsExpiredTrial(t *testing.T) {
 	}
 }
 
+func TestBillingManagerGetWorkspaceQuotaSeparatesRaceAndConcurrencyUsage(t *testing.T) {
+	workspaceID := uuid.New()
+	repo := newFakeBillingRepository(workspaceID)
+	repo.entitlements = billingpkg.MaterializeEntitlements(
+		billingpkg.MustPlan(billingpkg.PlanPro),
+		billingpkg.PeriodMonthly,
+		5,
+		billingpkg.EntitlementStatusActive,
+	)
+	repo.usage.RaceCount = 47
+	repo.usage.ActiveRuns = 2
+	repo.activeMembers = 3
+	now := time.Date(2026, 5, 10, 9, 0, 0, 0, time.UTC)
+	manager := NewBillingManager(NewCallerOrganizationAuthorizer(), NewCallerWorkspaceAuthorizer(), repo, BillingManagerConfig{
+		WebhookSecret: "secret",
+	})
+	manager.now = func() time.Time { return now }
+	caller := Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: RoleWorkspaceViewer},
+		},
+	}
+
+	result, err := manager.GetWorkspaceQuota(context.Background(), caller, workspaceID)
+	if err != nil {
+		t.Fatalf("GetWorkspaceQuota returned error: %v", err)
+	}
+	if result.PlanKey != billingpkg.PlanPro {
+		t.Fatalf("plan key = %q, want pro", result.PlanKey)
+	}
+	assertQuotaCounter(t, "monthly races", result.MonthlyRaces, 47, 2500, 2453)
+	assertQuotaCounter(t, "concurrent races", result.ConcurrentRaces, 2, 3, 1)
+	assertQuotaCounter(t, "seats", result.Seats, 3, 25, 22)
+	assertTimePtr(t, "monthly races reset_at", result.MonthlyRaces.ResetAt, time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	if !result.WindowStart.Equal(time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("window start = %s, want 2026-05-01", result.WindowStart)
+	}
+	if !result.WindowEnd.Equal(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("window end = %s, want 2026-06-01", result.WindowEnd)
+	}
+}
+
 func TestBillingGateHTTPStatus(t *testing.T) {
 	entitlements := billingpkg.DefaultEntitlements()
 	featureDecision := billingpkg.CheckFeature(entitlements, billingpkg.FeaturePrivateChallengePacks)
@@ -813,6 +856,7 @@ type fakeBillingRepository struct {
 	workspaceID   uuid.UUID
 	entitlements  billingpkg.EffectiveEntitlements
 	usage         repository.WorkspaceUsageSnapshot
+	activeMembers int
 	webhookIDs    map[string]bool
 	subscription  repository.BillingSubscription
 	account       repository.BillingAccount
@@ -823,9 +867,10 @@ type fakeBillingRepository struct {
 func newFakeBillingRepository(workspaceID uuid.UUID) *fakeBillingRepository {
 	windowStart, windowEnd := usageWindow(time.Date(2026, 4, 29, 0, 0, 0, 0, time.UTC))
 	return &fakeBillingRepository{
-		orgID:        uuid.New(),
-		workspaceID:  workspaceID,
-		entitlements: billingpkg.DefaultEntitlements(),
+		orgID:         uuid.New(),
+		workspaceID:   workspaceID,
+		entitlements:  billingpkg.DefaultEntitlements(),
+		activeMembers: 1,
 		usage: repository.WorkspaceUsageSnapshot{
 			WorkspaceID: workspaceID,
 			WindowStart: windowStart,
@@ -861,7 +906,7 @@ func (f *fakeBillingRepository) UpsertOrganizationEntitlements(_ context.Context
 }
 
 func (f *fakeBillingRepository) CountActiveOrgMembers(context.Context, uuid.UUID) (int, error) {
-	return 1, nil
+	return f.activeMembers, nil
 }
 
 func (f *fakeBillingRepository) CountActiveWorkspaces(context.Context, uuid.UUID) (int, error) {
@@ -1021,5 +1066,24 @@ func assertIntPtr(t *testing.T, label string, got *int, want int) {
 	}
 	if *got != want {
 		t.Fatalf("%s = %d, want %d", label, *got, want)
+	}
+}
+
+func assertQuotaCounter(t *testing.T, label string, got QuotaCounter, wantUsed int, wantLimit int, wantRemaining int) {
+	t.Helper()
+	if got.Used != wantUsed {
+		t.Fatalf("%s used = %d, want %d", label, got.Used, wantUsed)
+	}
+	assertIntPtr(t, label+" limit", got.Limit, wantLimit)
+	assertIntPtr(t, label+" remaining", got.Remaining, wantRemaining)
+}
+
+func assertTimePtr(t *testing.T, label string, got *time.Time, want time.Time) {
+	t.Helper()
+	if got == nil {
+		t.Fatalf("%s = nil, want %s", label, want)
+	}
+	if !got.Equal(want) {
+		t.Fatalf("%s = %s, want %s", label, got, want)
 	}
 }

--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -284,6 +284,72 @@ func TestRunCancelSuccessMessageDistinguishesNoop(t *testing.T) {
 	}
 }
 
+func TestQuotaCallsWorkspaceQuotaEndpoint(t *testing.T) {
+	var called bool
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-123/quota": captureHandler(t, &called, http.StatusOK, map[string]any{
+			"workspace_id": "ws-123",
+			"plan_key":     "pro",
+			"status":       "active",
+			"monthly_races": map[string]any{
+				"used":      47,
+				"limit":     2500,
+				"remaining": 2453,
+			},
+			"concurrent_races": map[string]any{
+				"used":      2,
+				"limit":     3,
+				"remaining": 1,
+			},
+		}),
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	stdout := captureStdout(t)
+	err := executeCommand(t, []string{"--workspace", "ws-123", "--json", "quota"}, srv.URL)
+	out := stdout.finish()
+	if err != nil {
+		t.Fatalf("quota error: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("quota json output was not valid JSON: %v", err)
+	}
+	if !called {
+		t.Fatal("GET /v1/workspaces/ws-123/quota was not called")
+	}
+	if payload["plan_key"] != "pro" {
+		t.Fatalf("plan_key = %v, want pro", payload["plan_key"])
+	}
+	if got := quotaCounterLine(mapObject(payload, "monthly_races")); got != "47 / 2500 used (2453 remaining)" {
+		t.Fatalf("monthly_races = %q", got)
+	}
+	if got := quotaCounterLine(mapObject(payload, "concurrent_races")); got != "2 / 3 used (1 remaining)" {
+		t.Fatalf("concurrent_races = %q", got)
+	}
+}
+
+func TestQuotaCounterLineSeparatesMonthlyAndConcurrencyUsage(t *testing.T) {
+	monthly := quotaCounterLine(map[string]any{
+		"used":      47,
+		"limit":     2500,
+		"remaining": 2453,
+	})
+	if monthly != "47 / 2500 used (2453 remaining)" {
+		t.Fatalf("monthly quota line = %q", monthly)
+	}
+
+	concurrent := quotaCounterLine(map[string]any{
+		"used":      2,
+		"limit":     3,
+		"remaining": 1,
+	})
+	if concurrent != "2 / 3 used (1 remaining)" {
+		t.Fatalf("concurrency quota line = %q", concurrent)
+	}
+}
+
 func TestRunEventsUsesAuthorizationHeaderWithoutQueryToken(t *testing.T) {
 	var called bool
 	var gotAuth string

--- a/cli/cmd/quota.go
+++ b/cli/cmd/quota.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/agentclash/agentclash/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(quotaCmd)
+}
+
+var quotaCmd = &cobra.Command{
+	Use:   "quota",
+	Short: "Show workspace quota usage",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		workspaceID := RequireWorkspace(cmd)
+
+		resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+workspaceID+"/quota", nil)
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+
+		var quota map[string]any
+		if err := resp.DecodeJSON(&quota); err != nil {
+			return err
+		}
+
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(quota)
+		}
+
+		rc.Output.PrintDetail("Plan", mapString(quota, "plan_key"))
+		if status := mapString(quota, "status"); status != "" {
+			rc.Output.PrintDetail("Status", output.StatusColor(status))
+		}
+		rc.Output.PrintDetail("Monthly races", quotaCounterLine(mapObject(quota, "monthly_races")))
+		rc.Output.PrintDetail("Concurrent races", quotaCounterLine(mapObject(quota, "concurrent_races")))
+		rc.Output.PrintDetail("Seats", quotaCounterLine(mapObject(quota, "seats")))
+		if resetAt := mapString(mapObject(quota, "monthly_races"), "reset_at"); resetAt != "" {
+			rc.Output.PrintDetail("Quota resets", resetAt)
+		}
+		return nil
+	},
+}
+
+func quotaCounterLine(counter map[string]any) string {
+	used := mapInt(counter, "used")
+	limit, hasLimit := mapOptionalInt(counter, "limit")
+	remaining, hasRemaining := mapOptionalInt(counter, "remaining")
+	if !hasLimit {
+		return fmt.Sprintf("%d used / unlimited", used)
+	}
+	if hasRemaining {
+		return fmt.Sprintf("%d / %d used (%d remaining)", used, limit, remaining)
+	}
+	return fmt.Sprintf("%d / %d used", used, limit)
+}
+
+func mapInt(m map[string]any, key string) int {
+	value, ok := mapOptionalInt(m, key)
+	if !ok {
+		return 0
+	}
+	return value
+}
+
+func mapOptionalInt(m map[string]any, key string) (int, bool) {
+	if m == nil {
+		return 0, false
+	}
+	switch value := m[key].(type) {
+	case int:
+		return value, true
+	case int64:
+		return int(value), true
+	case float64:
+		return int(value), true
+	case json.Number:
+		i, err := value.Int64()
+		return int(i), err == nil
+	default:
+		return 0, false
+	}
+}

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -917,6 +917,34 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /v1/workspaces/{workspaceID}/quota:
+    get:
+      operationId: getWorkspaceQuota
+      tags: [Billing]
+      summary: Get workspace quota usage
+      description: >
+        Returns the workspace plan and quota counters for monthly race usage,
+        active concurrent race usage, and organization seats.
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+      responses:
+        "200":
+          description: Workspace quota snapshot
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkspaceQuotaResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
   # ---------------------------------------------------------------------------
   # User Profile
   # ---------------------------------------------------------------------------
@@ -6011,6 +6039,61 @@ components:
           $ref: "#/components/schemas/WorkspaceUsageSnapshot"
         gates:
           $ref: "#/components/schemas/WorkspaceGateSummary"
+
+    QuotaCounter:
+      type: object
+      required: [used]
+      properties:
+        used:
+          type: integer
+        limit:
+          type: integer
+        remaining:
+          type: integer
+        reset_at:
+          type: string
+          format: date-time
+
+    WorkspaceQuotaResponse:
+      type: object
+      required:
+        [
+          organization_id,
+          workspace_id,
+          plan_key,
+          billing_period,
+          status,
+          monthly_races,
+          concurrent_races,
+          seats,
+          window_start,
+          window_end,
+        ]
+      properties:
+        organization_id:
+          type: string
+          format: uuid
+        workspace_id:
+          type: string
+          format: uuid
+        plan_key:
+          $ref: "#/components/schemas/BillingPlanKey"
+        billing_period:
+          type: string
+        status:
+          type: string
+        monthly_races:
+          $ref: "#/components/schemas/QuotaCounter"
+        concurrent_races:
+          $ref: "#/components/schemas/QuotaCounter"
+        seats:
+          $ref: "#/components/schemas/QuotaCounter"
+        window_start:
+          type: string
+          format: date-time
+        window_end:
+          type: string
+          format: date-time
 
     ProcessDodoWebhookResponse:
       type: object


### PR DESCRIPTION
Implements #696.

## Summary
- Add `GET /v1/workspaces/{workspaceID}/quota` with plan, monthly race quota, active concurrency, seat usage, limits, remaining values, and reset window metadata.
- Add `agentclash quota` / `agentclash quota --json` to surface the new snapshot from the CLI.
- Document the endpoint in OpenAPI and cover API/CLI distinction between monthly usage and concurrency usage.

## Verification
- `cd backend && go test ./internal/api`
- `cd cli && go test ./cmd`
- `cd backend && go test ./...`
- `cd cli && go build ./...`
- `cd cli && go vet ./...`
- `cd cli && go test -short -race -count=1 ./...`
- `cd cli && go run github.com/goreleaser/goreleaser/v2@latest check`
- `cd cli && go run github.com/goreleaser/goreleaser/v2@latest release --snapshot --clean`