### PR TITLE
feat: surface scorecard total cost

### DIFF
--- a/backend/internal/api/replay_reads.go
+++ b/backend/internal/api/replay_reads.go
@@ -70,6 +70,7 @@ type GetRunAgentScorecardResult struct {
 	State           ReplayState
 	Message         string
 	Scorecard       *repository.RunAgentScorecard
+	TotalCostUSD    *float64
 	LLMJudgeResults []repository.LLMJudgeResultRecord
 }
 
@@ -169,6 +170,7 @@ func (m *ReplayReadManager) GetRunAgentScorecard(ctx context.Context, caller Cal
 		RunAgent:        runAgent,
 		State:           ReplayStateReady,
 		Scorecard:       &scorecard,
+		TotalCostUSD:    totalCostUSDFromScorecardDocument(scorecard.Scorecard),
 		LLMJudgeResults: judgeResults,
 	}, nil
 }
@@ -214,6 +216,7 @@ type getRunAgentScorecardResponse struct {
 	ReliabilityScore *float64                  `json:"reliability_score,omitempty"`
 	LatencyScore     *float64                  `json:"latency_score,omitempty"`
 	CostScore        *float64                  `json:"cost_score,omitempty"`
+	TotalCostUSD     *float64                  `json:"total_cost_usd,omitempty"`
 	BehavioralScore  *float64                  `json:"behavioral_score,omitempty"`
 	LLMJudgeResults  []runAgentLLMJudgePayload `json:"llm_judge_results"`
 	Scorecard        json.RawMessage           `json:"scorecard"`
@@ -374,12 +377,32 @@ func buildRunAgentScorecardResponse(result GetRunAgentScorecardResult) getRunAge
 		response.ReliabilityScore = result.Scorecard.ReliabilityScore
 		response.LatencyScore = result.Scorecard.LatencyScore
 		response.CostScore = result.Scorecard.CostScore
+		response.TotalCostUSD = result.TotalCostUSD
 		response.BehavioralScore = result.Scorecard.BehavioralScore
 		response.Scorecard = result.Scorecard.Scorecard
 		response.CreatedAt = result.Scorecard.CreatedAt
 		response.UpdatedAt = result.Scorecard.UpdatedAt
 	}
 	return response
+}
+
+func totalCostUSDFromScorecardDocument(payload json.RawMessage) *float64 {
+	var document struct {
+		MetricDetails []struct {
+			Collector    string   `json:"collector"`
+			NumericValue *float64 `json:"numeric_value"`
+		} `json:"metric_details"`
+	}
+	if err := json.Unmarshal(payload, &document); err != nil {
+		return nil
+	}
+	for _, metric := range document.MetricDetails {
+		if metric.Collector == "run_model_cost_usd" && metric.NumericValue != nil {
+			cost := *metric.NumericValue
+			return &cost
+		}
+	}
+	return nil
 }
 
 func buildRunAgentLLMJudgePayloads(records []repository.LLMJudgeResultRecord) []runAgentLLMJudgePayload {

--- a/backend/internal/api/replay_reads_test.go
+++ b/backend/internal/api/replay_reads_test.go
@@ -163,11 +163,12 @@ func TestReplayReadManagerRejectsNegativeCursorOutsideHTTPHandler(t *testing.T) 
 func TestReplayReadManagerReturnsLLMJudgeResultsWithScorecard(t *testing.T) {
 	workspaceID := uuid.New()
 	runAgentID := uuid.New()
+	runID := uuid.New()
 	evaluationSpecID := uuid.New()
 	manager := NewReplayReadManager(NewCallerWorkspaceAuthorizer(), &fakeReplayReadRepository{
 		runAgent: domain.RunAgent{
 			ID:          runAgentID,
-			RunID:       uuid.New(),
+			RunID:       runID,
 			WorkspaceID: workspaceID,
 			Status:      domain.RunAgentStatusCompleted,
 		},
@@ -175,7 +176,7 @@ func TestReplayReadManagerReturnsLLMJudgeResultsWithScorecard(t *testing.T) {
 			ID:               uuid.New(),
 			RunAgentID:       runAgentID,
 			EvaluationSpecID: evaluationSpecID,
-			Scorecard:        []byte(`{"passed":true,"dimensions":{"correctness":{"state":"available","score":0.84}}}`),
+			Scorecard:        []byte(`{"passed":true,"dimensions":{"correctness":{"state":"available","score":0.84}},"metric_details":[{"key":"model_cost","collector":"run_model_cost_usd","state":"available","numeric_value":0.0123}]}`),
 		},
 		evaluationSpec: repository.EvaluationSpecRecord{
 			ID:         evaluationSpecID,
@@ -215,6 +216,9 @@ func TestReplayReadManagerReturnsLLMJudgeResultsWithScorecard(t *testing.T) {
 	}
 	if result.LLMJudgeResults[0].JudgeKey != "handoff_quality" {
 		t.Fatalf("judge_key = %q, want handoff_quality", result.LLMJudgeResults[0].JudgeKey)
+	}
+	if result.TotalCostUSD == nil || *result.TotalCostUSD != 0.0123 {
+		t.Fatalf("total_cost_usd = %v, want 0.0123", result.TotalCostUSD)
 	}
 
 	document := decodeReplayPayload(t, result.Scorecard.Scorecard)
@@ -273,6 +277,48 @@ func TestReplayReadManagerFallsBackToStoredScorecardWhenEvaluationSpecMissing(t 
 	}
 	if string(result.Scorecard.Scorecard) != string(originalScorecard) {
 		t.Fatalf("scorecard = %s, want original payload %s", result.Scorecard.Scorecard, originalScorecard)
+	}
+}
+
+func TestTotalCostUSDFromScorecardDocument(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload []byte
+		want    *float64
+	}{
+		{
+			name:    "absent metric",
+			payload: []byte(`{"metric_details":[{"collector":"run_total_tokens","numeric_value":123}]}`),
+		},
+		{
+			name:    "nil numeric value",
+			payload: []byte(`{"metric_details":[{"collector":"run_model_cost_usd"}]}`),
+		},
+		{
+			name:    "zero cost is present",
+			payload: []byte(`{"metric_details":[{"collector":"run_model_cost_usd","numeric_value":0}]}`),
+			want:    float64Ptr(0),
+		},
+		{
+			name:    "positive cost",
+			payload: []byte(`{"metric_details":[{"collector":"run_model_cost_usd","numeric_value":0.0123}]}`),
+			want:    float64Ptr(0.0123),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := totalCostUSDFromScorecardDocument(tt.payload)
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("totalCostUSDFromScorecardDocument() = %v, want nil", *got)
+				}
+				return
+			}
+			if got == nil || *got != *tt.want {
+				t.Fatalf("totalCostUSDFromScorecardDocument() = %v, want %v", got, *tt.want)
+			}
+		})
 	}
 }
 
@@ -779,6 +825,7 @@ func TestGetRunAgentScorecardEndpointReturnsScorecard(t *testing.T) {
 					CreatedAt:        time.Date(2026, 3, 13, 12, 0, 0, 0, time.UTC),
 					UpdatedAt:        time.Date(2026, 3, 13, 12, 1, 0, 0, time.UTC),
 				},
+				TotalCostUSD: float64Ptr(0.0123),
 				LLMJudgeResults: []repository.LLMJudgeResultRecord{
 					{
 						ID:               uuid.New(),
@@ -831,6 +878,9 @@ func TestGetRunAgentScorecardEndpointReturnsScorecard(t *testing.T) {
 	}
 	if response.BehavioralScore == nil || *response.BehavioralScore != 0.73 {
 		t.Fatalf("behavioral_score = %v, want 0.73", response.BehavioralScore)
+	}
+	if response.TotalCostUSD == nil || *response.TotalCostUSD != 0.0123 {
+		t.Fatalf("total_cost_usd = %v, want 0.0123", response.TotalCostUSD)
 	}
 	if len(response.LLMJudgeResults) != 1 {
 		t.Fatalf("llm_judge_results length = %d, want 1", len(response.LLMJudgeResults))

--- a/cli/cmd/contract_alignment_test.go
+++ b/cli/cmd/contract_alignment_test.go
@@ -229,6 +229,7 @@ func TestRunScorecardHandlesCurrentAPIShape(t *testing.T) {
 			"reliability_score": 0.90,
 			"latency_score":     0.88,
 			"cost_score":        0.85,
+			"total_cost_usd":    0.0123,
 			"scorecard": map[string]any{
 				"passed":   true,
 				"strategy": "weighted",
@@ -253,6 +254,8 @@ func TestRunScorecardHandlesCurrentAPIShape(t *testing.T) {
 		"State:",
 		"ready",
 		"Run Agent Status:",
+		"Total Cost",
+		"$0.0123",
 		"Overall Score",
 		"0.91",
 		"Correctness",

--- a/cli/cmd/eval_test.go
+++ b/cli/cmd/eval_test.go
@@ -111,6 +111,7 @@ func TestEvalScorecardJSONEnvelopeIncludesBaselineComparisonAndGate(t *testing.T
 			"run_agent_id":     "agent-candidate",
 			"run_agent_status": "completed",
 			"overall_score":    0.91,
+			"total_cost_usd":   0.0123,
 		}),
 		"GET /v1/compare": jsonHandler(200, map[string]any{
 			"state":      "comparable",
@@ -142,6 +143,10 @@ func TestEvalScorecardJSONEnvelopeIncludesBaselineComparisonAndGate(t *testing.T
 
 	if payload["candidate"] == nil || payload["baseline"] == nil || payload["comparison"] == nil || payload["release_gate"] == nil {
 		t.Fatalf("eval scorecard payload missing workflow envelope fields: %#v", payload)
+	}
+	scorecard := mapObject(payload, "scorecard")
+	if got := scorecard["total_cost_usd"]; got != 0.0123 {
+		t.Fatalf("total_cost_usd = %v, want 0.0123", got)
 	}
 }
 

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -590,6 +590,16 @@ func fmtScore(v any) string {
 	return fmt.Sprint(v)
 }
 
+func fmtUSD(v any) string {
+	if v == nil {
+		return "-"
+	}
+	if f, ok := v.(float64); ok {
+		return fmt.Sprintf("$%.4f", f)
+	}
+	return fmt.Sprint(v)
+}
+
 func formatDimensionSummary(v any) string {
 	dimension, ok := v.(map[string]any)
 	if !ok {

--- a/cli/cmd/scorecard_helpers.go
+++ b/cli/cmd/scorecard_helpers.go
@@ -40,6 +40,9 @@ func renderRunAgentScorecard(rc *RunContext, scorecard map[string]any) {
 	if runAgentStatus := mapString(scorecard, "run_agent_status"); runAgentStatus != "" {
 		rc.Output.PrintDetail("Run Agent Status", output.StatusColor(runAgentStatus))
 	}
+	if totalCost := mapValue(scorecard, "total_cost_usd"); totalCost != nil {
+		rc.Output.PrintDetail("Total Cost", fmtUSD(totalCost))
+	}
 
 	scoreLabels := []struct {
 		Key   string

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -8834,6 +8834,10 @@ components:
         cost_score:
           type: number
           format: double
+        total_cost_usd:
+          type: number
+          format: double
+          description: Total model cost in USD for this run agent, derived from stored scorecard cost metrics.
         behavioral_score:
           type: number
           format: double


### PR DESCRIPTION
Implements #700.

## Summary
- Adds optional `total_cost_usd` to the run-agent scorecard API response when a run cost summary exists.
- Renders total cost in `agentclash run scorecard` human output and preserves it in `run/eval scorecard --json`.
- Documents `total_cost_usd` in OpenAPI and adds API/CLI tests for JSON and human output.

## Verification
- `cd backend && go test ./internal/api -run 'TestReplayReadManagerReturnsLLMJudgeResultsWithScorecard|TestGetRunAgentScorecardEndpointReturnsScorecard' -count=1`\n- `cd cli && go test ./cmd -run 'TestRunScorecardHandlesCurrentAPIShape|TestEvalScorecardJSONEnvelopeIncludesBaselineComparisonAndGate' -count=1`\n- `cd backend && go test ./internal/api`\n- `cd cli && go test ./cmd`\n- `cd backend && go test ./...`\n- `cd cli && go build ./...`\n- `cd cli && go vet ./...`\n- `cd cli && go test -short -race -count=1 ./...`\n- `cd cli && go run github.com/goreleaser/goreleaser/v2@latest check`\n- `cd cli && go run github.com/goreleaser/goreleaser/v2@latest release --snapshot --clean`