### PR TITLE
feat: export run events as JSONL

### DIFF
--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -81,6 +81,7 @@ func registerProtectedRoutes(
 	router.Get("/runs/{runID}/ranking", getRunRankingHandler(logger, runReadService))
 	router.Post("/runs/{runID}/ranking-insights", createRunRankingInsightsHandler(logger, runReadService))
 	router.Get("/runs/{runID}/agents", listRunAgentsHandler(logger, runReadService))
+	router.Get("/runs/{runID}/events/export", exportRunEventsJSONLHandler(logger, runReadService))
 	// This workspace-scoped URL also resolves authz in the manager after loading the run
 	// so cross-workspace requests return 404 instead of leaking run existence via middleware.
 	router.Get("/workspaces/{workspaceID}/runs/{runID}/failures", listRunFailuresHandler(logger, runReadService))

--- a/backend/internal/api/run_events_sse.go
+++ b/backend/internal/api/run_events_sse.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -179,6 +181,67 @@ func streamRunEventsHandler(
 	}
 }
 
+func exportRunEventsJSONLHandler(logger *slog.Logger, runReadService RunReadService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		streamService, ok := runReadService.(RunEventStreamService)
+		if !ok {
+			logger.Error("run read service does not implement run event export")
+			writeError(w, http.StatusInternalServerError, "internal_error", "run event export is unavailable")
+			return
+		}
+
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		runID, err := runIDFromURLParam("runID")(r)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_run_id", err.Error())
+			return
+		}
+
+		snapshot, err := streamService.ListRunEventStream(r.Context(), caller, runID)
+		if err != nil {
+			switch {
+			case errors.Is(err, repository.ErrRunNotFound):
+				writeError(w, http.StatusNotFound, "run_not_found", "run not found")
+			case errors.Is(err, ErrForbidden):
+				writeAuthzError(w, err)
+			default:
+				logger.Error("failed to export run events",
+					"run_id", runID,
+					"error", err,
+				)
+				writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+			}
+			return
+		}
+
+		var body bytes.Buffer
+		if err := writeRunEventsJSONL(&body, snapshot.Events); err != nil {
+			logger.Error("failed to write run events export",
+				"run_id", runID,
+				"error", err,
+			)
+			writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="agentclash-run-%s-events.jsonl"`, runID.String()))
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", body.Len()))
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write(body.Bytes()); err != nil {
+			logger.Error("failed to send run events export",
+				"run_id", runID,
+				"error", err,
+			)
+		}
+	}
+}
+
 func emitPersistedRunEvents(
 	w http.ResponseWriter,
 	flusher http.Flusher,
@@ -195,6 +258,22 @@ func emitPersistedRunEvents(
 		}
 		delivered[streamEventID] = struct{}{}
 		writeSSEFrame(w, flusher, streamEventID, data)
+	}
+	return nil
+}
+
+func writeRunEventsJSONL(w io.Writer, events []repository.RunEvent) error {
+	for _, event := range events {
+		data, _, err := marshalPersistedRunEvent(event)
+		if err != nil {
+			return err
+		}
+		if _, err := w.Write(data); err != nil {
+			return err
+		}
+		if _, err := w.Write([]byte("\n")); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/backend/internal/api/run_events_sse_test.go
+++ b/backend/internal/api/run_events_sse_test.go
@@ -249,6 +249,96 @@ func TestRunEventsStreamPollsPersistedEventsWhenNoLiveMessagesArrive(t *testing.
 	}
 }
 
+func TestExportRunEventsJSONLEmitsPersistedEnvelopes(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	service := &fakeSSERunReadService{
+		streamResults: []ListRunEventStreamResult{
+			{
+				Run: persistedStreamRun(runID, domain.RunStatusCompleted),
+				Events: []repository.RunEvent{
+					persistedTestRunEvent(runID, runAgentID, 1, time.Date(2026, 4, 22, 10, 0, 0, 0, time.UTC)),
+					persistedTestRunEvent(runID, runAgentID, 2, time.Date(2026, 4, 22, 10, 0, 1, 0, time.UTC)),
+				},
+			},
+		},
+	}
+
+	router := chi.NewRouter()
+	router.Get("/v1/runs/{runID}/events/export", exportRunEventsJSONLHandler(slog.New(slog.NewTextHandler(io.Discard, nil)), service))
+	req := httptest.NewRequest(http.MethodGet, "/v1/runs/"+runID.String()+"/events/export", nil)
+	req = req.WithContext(context.WithValue(req.Context(), callerContextKey{}, Caller{UserID: uuid.New()}))
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if got := recorder.Header().Get("Content-Type"); got != "application/x-ndjson" {
+		t.Fatalf("content-type = %q, want application/x-ndjson", got)
+	}
+	if got := recorder.Header().Get("Content-Length"); got == "" {
+		t.Fatal("Content-Length header is empty")
+	}
+
+	lines := strings.Split(strings.TrimRight(recorder.Body.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("line count = %d, want 2; body=%s", len(lines), recorder.Body.String())
+	}
+	var first map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &first); err != nil {
+		t.Fatalf("decode first JSONL line: %v", err)
+	}
+	if first["event_id"] != persistedStreamEventID(runAgentID, 1) {
+		t.Fatalf("first event_id = %v, want %s", first["event_id"], persistedStreamEventID(runAgentID, 1))
+	}
+	if first["schema_version"] != runevents.SchemaVersionV1 {
+		t.Fatalf("schema_version = %v, want %s", first["schema_version"], runevents.SchemaVersionV1)
+	}
+	if first["run_id"] != runID.String() || first["run_agent_id"] != runAgentID.String() {
+		t.Fatalf("run identifiers = %#v", first)
+	}
+}
+
+func TestExportRunEventsJSONLReturnsErrorBeforeCommittingInvalidPayload(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	service := &fakeSSERunReadService{
+		streamResults: []ListRunEventStreamResult{
+			{
+				Run: persistedStreamRun(runID, domain.RunStatusCompleted),
+				Events: []repository.RunEvent{
+					{
+						RunID:          runID,
+						RunAgentID:     runAgentID,
+						SequenceNumber: 1,
+						EventType:      runevents.EventTypeSystemRunStarted,
+						Source:         runevents.SourceNativeEngine,
+						OccurredAt:     time.Date(2026, 4, 22, 10, 0, 0, 0, time.UTC),
+						Payload:        []byte(`{"unterminated"`),
+					},
+				},
+			},
+		},
+	}
+
+	router := chi.NewRouter()
+	router.Get("/v1/runs/{runID}/events/export", exportRunEventsJSONLHandler(slog.New(slog.NewTextHandler(io.Discard, nil)), service))
+	req := httptest.NewRequest(http.MethodGet, "/v1/runs/"+runID.String()+"/events/export", nil)
+	req = req.WithContext(context.WithValue(req.Context(), callerContextKey{}, Caller{UserID: uuid.New()}))
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusInternalServerError, recorder.Body.String())
+	}
+	if strings.Contains(recorder.Body.String(), "unterminated") {
+		t.Fatalf("error response leaked partial JSONL body: %s", recorder.Body.String())
+	}
+}
+
 func serveRunEventsSSE(
 	t *testing.T,
 	auth Authenticator,

--- a/backend/internal/api/run_reads_test.go
+++ b/backend/internal/api/run_reads_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/agentclash/agentclash/backend/internal/domain"
 	"github.com/agentclash/agentclash/backend/internal/failurereview"
 	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/runevents"
 	"github.com/agentclash/agentclash/backend/internal/workflow"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -708,6 +709,53 @@ func TestListRunAgentsEndpointReturnsForbidden(t *testing.T) {
 	}
 }
 
+func TestRunReadManagerListsRunEventStreamInTracePackOrder(t *testing.T) {
+	workspaceID := uuid.New()
+	runID := uuid.New()
+	agentLaneOne := uuid.New()
+	agentLaneZero := uuid.New()
+	occurredAt := time.Date(2026, 4, 22, 10, 0, 0, 0, time.UTC)
+	caller := Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: RoleWorkspaceMember},
+		},
+	}
+	manager := NewRunReadManager(NewCallerWorkspaceAuthorizer(), &fakeRunReadRepository{
+		run: domain.Run{ID: runID, WorkspaceID: workspaceID},
+		runAgents: []domain.RunAgent{
+			{ID: agentLaneOne, RunID: runID, LaneIndex: 1},
+			{ID: agentLaneZero, RunID: runID, LaneIndex: 0},
+		},
+		runEvents: map[uuid.UUID][]repository.RunEvent{
+			agentLaneOne: {
+				{ID: 30, RunID: runID, RunAgentID: agentLaneOne, SequenceNumber: 2, EventType: runevents.EventTypeSystemStepCompleted, Source: runevents.SourceNativeEngine, OccurredAt: occurredAt, Payload: []byte(`{"label":"lane-one-seq-two"}`)},
+				{ID: 20, RunID: runID, RunAgentID: agentLaneOne, SequenceNumber: 1, EventType: runevents.EventTypeSystemStepStarted, Source: runevents.SourceNativeEngine, OccurredAt: occurredAt, Payload: []byte(`{"label":"lane-one-seq-one"}`)},
+			},
+			agentLaneZero: {
+				{ID: 10, RunID: runID, RunAgentID: agentLaneZero, SequenceNumber: 1, EventType: runevents.EventTypeSystemRunStarted, Source: runevents.SourceNativeEngine, OccurredAt: occurredAt.Add(time.Second), Payload: []byte(`{"label":"later"}`)},
+				{ID: 40, RunID: runID, RunAgentID: agentLaneZero, SequenceNumber: 2, EventType: runevents.EventTypeSystemStepStarted, Source: runevents.SourceNativeEngine, OccurredAt: occurredAt, Payload: []byte(`{"label":"lane-zero"}`)},
+			},
+		},
+	})
+
+	result, err := manager.ListRunEventStream(context.Background(), caller, runID)
+	if err != nil {
+		t.Fatalf("ListRunEventStream returned error: %v", err)
+	}
+
+	if len(result.Events) != 4 {
+		t.Fatalf("event count = %d, want 4", len(result.Events))
+	}
+	got := []int64{result.Events[0].ID, result.Events[1].ID, result.Events[2].ID, result.Events[3].ID}
+	want := []int64{40, 20, 30, 10}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("event order = %v, want %v", got, want)
+		}
+	}
+}
+
 type fakeRunReadRepository struct {
 	run                      domain.Run
 	latestRun                domain.Run
@@ -719,6 +767,7 @@ type fakeRunReadRepository struct {
 	runScorecard             repository.RunScorecard
 	regressionCoverageCases  []repository.RunRegressionCoverageCase
 	runAgents                []domain.RunAgent
+	runEvents                map[uuid.UUID][]repository.RunEvent
 	failureItems             []failurereview.Item
 	failureItemsByRunID      map[uuid.UUID][]failurereview.Item
 	recentComparableRuns     []domain.Run
@@ -809,6 +858,10 @@ func (f *fakeRunReadRepository) ListRunRegressionCoverageCasesByRunID(_ context.
 
 func (f *fakeRunReadRepository) ListRunAgentsByRunID(_ context.Context, _ uuid.UUID) ([]domain.RunAgent, error) {
 	return f.runAgents, f.listRunAgentsErr
+}
+
+func (f *fakeRunReadRepository) ListRunEventsByRunAgentID(_ context.Context, runAgentID uuid.UUID) ([]repository.RunEvent, error) {
+	return append([]repository.RunEvent(nil), f.runEvents[runAgentID]...), nil
 }
 
 func (f *fakeRunReadRepository) ListRunFailureReviewItems(_ context.Context, runID uuid.UUID, _ *uuid.UUID) ([]failurereview.Item, error) {

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -22,6 +22,7 @@ func init() {
 	runCmd.AddCommand(runRankingCmd)
 	runCmd.AddCommand(runAgentsCmd)
 	runCmd.AddCommand(runEventsCmd)
+	runEventsCmd.AddCommand(runEventsExportCmd)
 	runCmd.AddCommand(runScorecardCmd)
 	runCmd.AddCommand(runFailuresCmd)
 	runCmd.AddCommand(runPromoteFailureCmd)
@@ -361,6 +362,25 @@ var runEventsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		rc := GetRunContext(cmd)
 		return streamRunEvents(cmd, rc, args[0])
+	},
+}
+
+var runEventsExportCmd = &cobra.Command{
+	Use:   "export <runId>",
+	Short: "Export persisted run events as JSONL",
+	Long:  "Export the full ordered persisted run-agent event stream for a run as JSONL.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		resp, err := rc.Client.Get(cmd.Context(), "/v1/runs/"+args[0]+"/events/export", nil)
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+		_, err = rc.Output.Writer().Write(resp.Body)
+		return err
 	},
 }
 

--- a/cli/cmd/run_events_test.go
+++ b/cli/cmd/run_events_test.go
@@ -115,6 +115,37 @@ func TestRunEventsEmitsNDJSONForJSON(t *testing.T) {
 	}
 }
 
+func TestRunEventsExportPrintsJSONL(t *testing.T) {
+	jsonl := strings.Join([]string{
+		`{"event_id":"persisted:agent-1:1","sequence_number":1}`,
+		`{"event_id":"persisted:agent-1:2","sequence_number":2}`,
+		"",
+	}, "\n")
+	called := false
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/runs/run-x/events/export": func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, jsonl)
+		},
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{"run", "events", "export", "run-x"}, srv.URL); err != nil {
+		t.Fatalf("run events export: %v", err)
+	}
+
+	if !called {
+		t.Fatal("export endpoint was not called")
+	}
+	if out := stdout.finish(); out != jsonl {
+		t.Fatalf("export output mismatch\nwant:\n%s\ngot:\n%s", jsonl, out)
+	}
+}
+
 func TestRunCreateFollowJSONStreamsCreatedRunAndEvents(t *testing.T) {
 	sseBody := "event: step\n" +
 		"data: {\"EventType\":\"run.started\"}\n" +

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -2941,6 +2941,42 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
 
+  /v1/runs/{runID}/events/export:
+    get:
+      operationId: exportRunEventsJSONL
+      tags: [Runs]
+      summary: Export run events as JSONL
+      description: >
+        Exports the full persisted run-agent event stream for a run as JSONL.
+        Events are ordered by occurrence time, run-agent lane, per-agent
+        sequence number, and stable database id so trace packs are deterministic.
+      parameters:
+        - $ref: "#/components/parameters/RunID"
+      responses:
+        "200":
+          description: Ordered run-event JSONL export
+          headers:
+            Content-Disposition:
+              description: Suggested trace-pack filename.
+              schema:
+                type: string
+          content:
+            application/x-ndjson:
+              schema:
+                type: string
+                description: >
+                  One JSON run-event envelope per line. Each envelope includes
+                  event_id, schema_version, run_id, run_agent_id,
+                  sequence_number, event_type, source, occurred_at, and payload.
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
   /v1/workspaces/{workspaceID}/runs:
     get:
       operationId: listRuns


### PR DESCRIPTION
## Summary
- add `GET /v1/runs/{runID}/events/export` to emit the full persisted run-agent event stream as JSONL
- add `agentclash run events export <runId>` to print the JSONL trace pack
- document the endpoint and cover deterministic ordering/output shape in backend and CLI tests

Closes #702.

## Validation
- `cd backend && go test ./internal/api -run 'TestExportRunEventsJSONLEmitsPersistedEnvelopes|TestRunReadManagerListsRunEventStreamInTracePackOrder' -count=1`\n- `cd backend && go test ./internal/api`\n- `cd backend && go test ./...`\n- `cd cli && go test ./cmd -run 'TestRunEventsExportPrintsJSONL|TestRunEventsEmitsNDJSONForJSON' -count=1`\n- `cd cli && go test ./cmd`\n- `cd cli && go build ./...`\n- `cd cli && go vet ./...`\n- `cd cli && go test -short -race -count=1 ./...`\n- `cd cli && go run github.com/goreleaser/goreleaser/v2@latest check`\n\n## Reviews\n- Cursor Agent / Claude low was invoked but stalled without output.\n- Independent GPT-5.5 xhigh fallback review: No blockers or majors.\n- Waiting for Greptile before merge.\n