### PR TITLE
feat: add run max-iteration overrides

### DIFF
--- a/backend/internal/api/run_service.go
+++ b/backend/internal/api/run_service.go
@@ -148,6 +148,9 @@ func (m *RunCreationManager) CreateRun(ctx context.Context, caller Caller, input
 			Message: "challenge_pack_version_id must be visible to the selected workspace",
 		}
 	}
+	if input.MaxIterations == nil {
+		input.MaxIterations = challengePackDefaultMaxIterations(challengePackVersion.Manifest)
+	}
 
 	if input.ChallengeInputSetID != nil {
 		challengeInputSet, err := m.repo.GetChallengeInputSetByID(ctx, *input.ChallengeInputSetID)
@@ -465,12 +468,17 @@ func buildExecutionPlan(input CreateRunInput, runAgents []repository.CreateQueue
 		Label                     string    `json:"label"`
 	}
 
+	type executionPlanRuntimeLimits struct {
+		MaxIterations *int32 `json:"max_iterations,omitempty"`
+	}
+
 	type executionPlan struct {
-		WorkspaceID            uuid.UUID               `json:"workspace_id"`
-		ChallengePackVersionID uuid.UUID               `json:"challenge_pack_version_id"`
-		ChallengeInputSetID    *uuid.UUID              `json:"challenge_input_set_id,omitempty"`
-		OfficialPackMode       domain.OfficialPackMode `json:"official_pack_mode"`
-		Participants           []executionPlanRunAgent `json:"participants"`
+		WorkspaceID            uuid.UUID                   `json:"workspace_id"`
+		ChallengePackVersionID uuid.UUID                   `json:"challenge_pack_version_id"`
+		ChallengeInputSetID    *uuid.UUID                  `json:"challenge_input_set_id,omitempty"`
+		OfficialPackMode       domain.OfficialPackMode     `json:"official_pack_mode"`
+		Participants           []executionPlanRunAgent     `json:"participants"`
+		RuntimeLimits          *executionPlanRuntimeLimits `json:"runtime_limits,omitempty"`
 	}
 
 	participants := make([]executionPlanRunAgent, 0, len(runAgents))
@@ -483,18 +491,57 @@ func buildExecutionPlan(input CreateRunInput, runAgents []repository.CreateQueue
 		})
 	}
 
-	payload, err := json.Marshal(executionPlan{
+	plan := executionPlan{
 		WorkspaceID:            input.WorkspaceID,
 		ChallengePackVersionID: input.ChallengePackVersionID,
 		ChallengeInputSetID:    input.ChallengeInputSetID,
 		OfficialPackMode:       input.OfficialPackMode,
 		Participants:           participants,
-	})
+	}
+	if input.MaxIterations != nil {
+		plan.RuntimeLimits = &executionPlanRuntimeLimits{MaxIterations: cloneInt32Ptr(input.MaxIterations)}
+	}
+
+	payload, err := json.Marshal(plan)
 	if err != nil {
 		return nil, err
 	}
 
 	return payload, nil
+}
+
+func challengePackDefaultMaxIterations(manifest json.RawMessage) *int32 {
+	var document struct {
+		RuntimeLimits struct {
+			MaxIterations *int32 `json:"max_iterations"`
+		} `json:"runtime_limits"`
+		EvaluationSpec struct {
+			RuntimeLimits struct {
+				MaxIterations *int32 `json:"max_iterations"`
+			} `json:"runtime_limits"`
+		} `json:"evaluation_spec"`
+	}
+	if len(manifest) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(manifest, &document); err != nil {
+		return nil
+	}
+	if value := validMaxIterationsDefault(document.RuntimeLimits.MaxIterations); value != nil {
+		return value
+	}
+	return validMaxIterationsDefault(document.EvaluationSpec.RuntimeLimits.MaxIterations)
+}
+
+func validMaxIterationsDefault(candidate *int32) *int32 {
+	if candidate == nil {
+		return nil
+	}
+	value := *candidate
+	if value < 1 || value > maxRunMaxIterations {
+		return nil
+	}
+	return &value
 }
 
 func defaultRunName(now time.Time) string {

--- a/backend/internal/api/run_service.go
+++ b/backend/internal/api/run_service.go
@@ -527,10 +527,10 @@ func challengePackDefaultMaxIterations(manifest json.RawMessage) *int32 {
 	if err := json.Unmarshal(manifest, &document); err != nil {
 		return nil
 	}
-	if value := validMaxIterationsDefault(document.RuntimeLimits.MaxIterations); value != nil {
+	if value := validMaxIterationsDefault(document.EvaluationSpec.RuntimeLimits.MaxIterations); value != nil {
 		return value
 	}
-	return validMaxIterationsDefault(document.EvaluationSpec.RuntimeLimits.MaxIterations)
+	return validMaxIterationsDefault(document.RuntimeLimits.MaxIterations)
 }
 
 func validMaxIterationsDefault(candidate *int32) *int32 {

--- a/backend/internal/api/run_service_test.go
+++ b/backend/internal/api/run_service_test.go
@@ -102,6 +102,189 @@ func TestRunCreationManagerCreatesQueuedRunAndStartsWorkflow(t *testing.T) {
 	}
 }
 
+func TestRunCreationManagerAddsMaxIterationsToExecutionPlan(t *testing.T) {
+	workspaceID := uuid.New()
+	challengePackVersionID := uuid.New()
+	deploymentID := uuid.New()
+	snapshotID := uuid.New()
+	runID := uuid.New()
+	maxIterations := int32(7)
+	caller := Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}
+
+	repo := &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{ID: challengePackVersionID},
+		deployments: []repository.RunnableDeployment{
+			{
+				ID:                        deploymentID,
+				OrganizationID:            uuid.New(),
+				WorkspaceID:               workspaceID,
+				Name:                      "Support Agent Deployment",
+				AgentDeploymentSnapshotID: snapshotID,
+			},
+		},
+		createResult: repository.CreateQueuedRunResult{
+			Run: domain.Run{
+				ID:                     runID,
+				WorkspaceID:            workspaceID,
+				ChallengePackVersionID: challengePackVersionID,
+				Status:                 domain.RunStatusQueued,
+				ExecutionMode:          "single_agent",
+			},
+		},
+	}
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, &fakeRunWorkflowStarter{}, nil)
+
+	_, err := manager.CreateRun(context.Background(), caller, CreateRunInput{
+		WorkspaceID:            workspaceID,
+		ChallengePackVersionID: challengePackVersionID,
+		AgentDeploymentIDs:     []uuid.UUID{deploymentID},
+		MaxIterations:          &maxIterations,
+	})
+	if err != nil {
+		t.Fatalf("CreateRun returned error: %v", err)
+	}
+
+	if got := executionPlanTestMaxIterations(t, repo.createParams.ExecutionPlan); got != 7 {
+		t.Fatalf("execution plan max_iterations = %d, want 7", got)
+	}
+}
+
+func TestRunCreationManagerUsesChallengePackMaxIterationsDefault(t *testing.T) {
+	workspaceID := uuid.New()
+	challengePackVersionID := uuid.New()
+	deploymentID := uuid.New()
+	caller := Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}
+
+	repo := &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{
+			ID:       challengePackVersionID,
+			Manifest: json.RawMessage(`{"runtime_limits":{"max_iterations":4}}`),
+		},
+		deployments: []repository.RunnableDeployment{
+			{
+				ID:                        deploymentID,
+				OrganizationID:            uuid.New(),
+				WorkspaceID:               workspaceID,
+				Name:                      "Support Agent Deployment",
+				AgentDeploymentSnapshotID: uuid.New(),
+			},
+		},
+		createResult: repository.CreateQueuedRunResult{Run: domain.Run{ID: uuid.New(), WorkspaceID: workspaceID}},
+	}
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, &fakeRunWorkflowStarter{}, nil)
+
+	_, err := manager.CreateRun(context.Background(), caller, CreateRunInput{
+		WorkspaceID:            workspaceID,
+		ChallengePackVersionID: challengePackVersionID,
+		AgentDeploymentIDs:     []uuid.UUID{deploymentID},
+	})
+	if err != nil {
+		t.Fatalf("CreateRun returned error: %v", err)
+	}
+
+	if got := executionPlanTestMaxIterations(t, repo.createParams.ExecutionPlan); got != 4 {
+		t.Fatalf("execution plan max_iterations = %d, want 4", got)
+	}
+}
+
+func TestRunCreationManagerExplicitMaxIterationsWinsOverChallengePackDefault(t *testing.T) {
+	workspaceID := uuid.New()
+	challengePackVersionID := uuid.New()
+	deploymentID := uuid.New()
+	explicitMaxIterations := int32(7)
+	caller := Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}
+
+	repo := &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{
+			ID:       challengePackVersionID,
+			Manifest: json.RawMessage(`{"evaluation_spec":{"runtime_limits":{"max_iterations":4}}}`),
+		},
+		deployments: []repository.RunnableDeployment{
+			{
+				ID:                        deploymentID,
+				OrganizationID:            uuid.New(),
+				WorkspaceID:               workspaceID,
+				Name:                      "Support Agent Deployment",
+				AgentDeploymentSnapshotID: uuid.New(),
+			},
+		},
+		createResult: repository.CreateQueuedRunResult{Run: domain.Run{ID: uuid.New(), WorkspaceID: workspaceID}},
+	}
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, &fakeRunWorkflowStarter{}, nil)
+
+	_, err := manager.CreateRun(context.Background(), caller, CreateRunInput{
+		WorkspaceID:            workspaceID,
+		ChallengePackVersionID: challengePackVersionID,
+		AgentDeploymentIDs:     []uuid.UUID{deploymentID},
+		MaxIterations:          &explicitMaxIterations,
+	})
+	if err != nil {
+		t.Fatalf("CreateRun returned error: %v", err)
+	}
+
+	if got := executionPlanTestMaxIterations(t, repo.createParams.ExecutionPlan); got != 7 {
+		t.Fatalf("execution plan max_iterations = %d, want 7", got)
+	}
+}
+
+func TestRunCreationManagerUsesEvaluationSpecMaxIterationsDefault(t *testing.T) {
+	workspaceID := uuid.New()
+	challengePackVersionID := uuid.New()
+	deploymentID := uuid.New()
+	caller := Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}
+
+	repo := &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{
+			ID:       challengePackVersionID,
+			Manifest: json.RawMessage(`{"evaluation_spec":{"runtime_limits":{"max_iterations":5}}}`),
+		},
+		deployments: []repository.RunnableDeployment{
+			{
+				ID:                        deploymentID,
+				OrganizationID:            uuid.New(),
+				WorkspaceID:               workspaceID,
+				Name:                      "Support Agent Deployment",
+				AgentDeploymentSnapshotID: uuid.New(),
+			},
+		},
+		createResult: repository.CreateQueuedRunResult{Run: domain.Run{ID: uuid.New(), WorkspaceID: workspaceID}},
+	}
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, &fakeRunWorkflowStarter{}, nil)
+
+	_, err := manager.CreateRun(context.Background(), caller, CreateRunInput{
+		WorkspaceID:            workspaceID,
+		ChallengePackVersionID: challengePackVersionID,
+		AgentDeploymentIDs:     []uuid.UUID{deploymentID},
+	})
+	if err != nil {
+		t.Fatalf("CreateRun returned error: %v", err)
+	}
+
+	if got := executionPlanTestMaxIterations(t, repo.createParams.ExecutionPlan); got != 5 {
+		t.Fatalf("execution plan max_iterations = %d, want 5", got)
+	}
+}
+
 func TestRunCreationManagerRejectsEntitlementGateBeforeQueue(t *testing.T) {
 	workspaceID := uuid.New()
 	challengePackVersionID := uuid.New()
@@ -1600,6 +1783,19 @@ type fakeRunCreationRepository struct {
 	createParams                    *repository.CreateQueuedRunParams
 	createEvalSessionWithRunsResult repository.CreateEvalSessionWithQueuedRunsResult
 	createEvalSessionWithRunsParams *repository.CreateEvalSessionWithQueuedRunsParams
+}
+
+func executionPlanTestMaxIterations(t *testing.T, payload json.RawMessage) int32 {
+	t.Helper()
+	var plan struct {
+		RuntimeLimits struct {
+			MaxIterations int32 `json:"max_iterations"`
+		} `json:"runtime_limits"`
+	}
+	if err := json.Unmarshal(payload, &plan); err != nil {
+		t.Fatalf("decode execution plan: %v", err)
+	}
+	return plan.RuntimeLimits.MaxIterations
 }
 
 func (f *fakeRunCreationRepository) GetRunnableChallengePackVersionByID(_ context.Context, _ uuid.UUID) (repository.RunnableChallengePackVersion, error) {

--- a/backend/internal/api/run_service_test.go
+++ b/backend/internal/api/run_service_test.go
@@ -197,6 +197,52 @@ func TestRunCreationManagerUsesChallengePackMaxIterationsDefault(t *testing.T) {
 	}
 }
 
+func TestRunCreationManagerPrefersEvaluationSpecMaxIterationsDefault(t *testing.T) {
+	workspaceID := uuid.New()
+	challengePackVersionID := uuid.New()
+	deploymentID := uuid.New()
+	caller := Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}
+
+	repo := &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{
+			ID: challengePackVersionID,
+			Manifest: json.RawMessage(`{
+				"runtime_limits":{"max_iterations":4},
+				"evaluation_spec":{"runtime_limits":{"max_iterations":6}}
+			}`),
+		},
+		deployments: []repository.RunnableDeployment{
+			{
+				ID:                        deploymentID,
+				OrganizationID:            uuid.New(),
+				WorkspaceID:               workspaceID,
+				Name:                      "Support Agent Deployment",
+				AgentDeploymentSnapshotID: uuid.New(),
+			},
+		},
+		createResult: repository.CreateQueuedRunResult{Run: domain.Run{ID: uuid.New(), WorkspaceID: workspaceID}},
+	}
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, &fakeRunWorkflowStarter{}, nil)
+
+	_, err := manager.CreateRun(context.Background(), caller, CreateRunInput{
+		WorkspaceID:            workspaceID,
+		ChallengePackVersionID: challengePackVersionID,
+		AgentDeploymentIDs:     []uuid.UUID{deploymentID},
+	})
+	if err != nil {
+		t.Fatalf("CreateRun returned error: %v", err)
+	}
+
+	if got := executionPlanTestMaxIterations(t, repo.createParams.ExecutionPlan); got != 6 {
+		t.Fatalf("execution plan max_iterations = %d, want 6", got)
+	}
+}
+
 func TestRunCreationManagerExplicitMaxIterationsWinsOverChallengePackDefault(t *testing.T) {
 	workspaceID := uuid.New()
 	challengePackVersionID := uuid.New()

--- a/backend/internal/api/runs.go
+++ b/backend/internal/api/runs.go
@@ -19,7 +19,10 @@ import (
 	"github.com/google/uuid"
 )
 
-const maxCreateRunRequestBytes = 1 << 20
+const (
+	maxCreateRunRequestBytes = 1 << 20
+	maxRunMaxIterations      = 1000
+)
 
 type RunCreationService interface {
 	CreateRun(ctx context.Context, caller Caller, input CreateRunInput) (CreateRunResult, error)
@@ -44,6 +47,7 @@ type createRunRequest struct {
 	// RaceContextMinStepGap overrides the default cadence threshold. When
 	// omitted, the executor uses the backend default. Valid range [1, 10].
 	RaceContextMinStepGap *int                  `json:"race_context_min_step_gap,omitempty"`
+	MaxIterations         *int                  `json:"max_iterations,omitempty"`
 	CIMetadata            *domain.RunCIMetadata `json:"ci_metadata,omitempty"`
 }
 
@@ -59,6 +63,7 @@ type CreateRunInput struct {
 	IncludeProposedRegressions bool
 	RaceContext                bool
 	RaceContextMinStepGap      *int32
+	MaxIterations              *int32
 	CIMetadata                 *domain.RunCIMetadata
 }
 
@@ -368,6 +373,19 @@ func decodeCreateRunRequest(r *http.Request) (CreateRunInput, error) {
 		gap32 := int32(gap)
 		raceContextMinStepGap = &gap32
 	}
+
+	var maxIterations *int32
+	if body.MaxIterations != nil {
+		value := *body.MaxIterations
+		if value < 1 || value > maxRunMaxIterations {
+			return CreateRunInput{}, RunCreationValidationError{
+				Code:    "invalid_max_iterations",
+				Message: fmt.Sprintf("max_iterations must be between 1 and %d", maxRunMaxIterations),
+			}
+		}
+		value32 := int32(value)
+		maxIterations = &value32
+	}
 	ciMetadata, err := normalizeCreateRunCIMetadata(body.CIMetadata)
 	if err != nil {
 		return CreateRunInput{}, err
@@ -385,6 +403,7 @@ func decodeCreateRunRequest(r *http.Request) (CreateRunInput, error) {
 		IncludeProposedRegressions: body.IncludeProposedRegressions,
 		RaceContext:                body.RaceContext,
 		RaceContextMinStepGap:      raceContextMinStepGap,
+		MaxIterations:              maxIterations,
 		CIMetadata:                 ciMetadata,
 	}, nil
 }

--- a/backend/internal/api/runs_test.go
+++ b/backend/internal/api/runs_test.go
@@ -620,6 +620,43 @@ func TestCreateRunEndpointPropagatesRaceContext(t *testing.T) {
 	}
 }
 
+func TestDecodeCreateRunRequestAcceptsMaxIterations(t *testing.T) {
+	workspaceID := uuid.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/runs", bytes.NewBufferString(`{
+		"workspace_id":"`+workspaceID.String()+`",
+		"challenge_pack_version_id":"`+uuid.New().String()+`",
+		"agent_deployment_ids":["`+uuid.New().String()+`"],
+		"max_iterations":7
+	}`))
+
+	input, err := decodeCreateRunRequest(req)
+	if err != nil {
+		t.Fatalf("decodeCreateRunRequest returned error: %v", err)
+	}
+	if input.MaxIterations == nil || *input.MaxIterations != 7 {
+		t.Fatalf("MaxIterations = %v, want 7", input.MaxIterations)
+	}
+}
+
+func TestDecodeCreateRunRequestRejectsInvalidMaxIterations(t *testing.T) {
+	workspaceID := uuid.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/runs", bytes.NewBufferString(`{
+		"workspace_id":"`+workspaceID.String()+`",
+		"challenge_pack_version_id":"`+uuid.New().String()+`",
+		"agent_deployment_ids":["`+uuid.New().String()+`"],
+		"max_iterations":0
+	}`))
+
+	_, err := decodeCreateRunRequest(req)
+	var validationErr RunCreationValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error = %v, want RunCreationValidationError", err)
+	}
+	if validationErr.Code != "invalid_max_iterations" {
+		t.Fatalf("code = %q, want invalid_max_iterations", validationErr.Code)
+	}
+}
+
 func TestCreateRunEndpointRejectsRaceContextCadenceOutOfRange(t *testing.T) {
 	workspaceID := uuid.New()
 	// 11 is out of range (valid is [1, 10]).

--- a/backend/internal/engine/executor_builders.go
+++ b/backend/internal/engine/executor_builders.go
@@ -25,6 +25,8 @@ const (
 	runTestsToolName    = "run_tests"
 	buildToolName       = "build"
 	execToolName        = "exec"
+
+	maxExecutionPlanMaxIterations = 1000
 )
 
 func toolMessage(result provider.ToolResult) provider.Message {
@@ -164,6 +166,35 @@ func runTimeout(executionContext repository.RunAgentExecutionContext) time.Durat
 		return 0
 	}
 	return time.Duration(executionContext.Deployment.RuntimeProfile.RunTimeoutSeconds) * time.Second
+}
+
+func maxIterationsLimit(executionContext repository.RunAgentExecutionContext) int {
+	if override := executionPlanMaxIterations(executionContext.Run.ExecutionPlan); override != nil {
+		return int(*override)
+	}
+	return int(executionContext.Deployment.RuntimeProfile.MaxIterations)
+}
+
+func executionPlanMaxIterations(executionPlan json.RawMessage) *int32 {
+	var document struct {
+		RuntimeLimits struct {
+			MaxIterations *int32 `json:"max_iterations"`
+		} `json:"runtime_limits"`
+	}
+	if len(executionPlan) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(executionPlan, &document); err != nil {
+		return nil
+	}
+	if document.RuntimeLimits.MaxIterations == nil {
+		return nil
+	}
+	value := *document.RuntimeLimits.MaxIterations
+	if value <= 0 || value > maxExecutionPlanMaxIterations {
+		return nil
+	}
+	return &value
 }
 
 func extractPolicyInstructions(policySpec json.RawMessage) string {

--- a/backend/internal/engine/native_executor.go
+++ b/backend/internal/engine/native_executor.go
@@ -331,7 +331,7 @@ func (e NativeExecutor) Execute(ctx context.Context, executionContext repository
 			}
 			return Result{}, NewFailure(StopReasonTimeout, fmt.Sprintf("native execution exceeded runtime budget after %s", time.Since(state.startedAt).Round(time.Millisecond)), loopErr)
 		}
-		if limit := int(executionContext.Deployment.RuntimeProfile.MaxIterations); limit > 0 && state.stepCount >= limit {
+		if limit := maxIterationsLimit(executionContext); limit > 0 && state.stepCount >= limit {
 			return Result{}, NewFailure(StopReasonStepLimit, fmt.Sprintf("native execution exhausted step budget after %d steps", state.stepCount), nil)
 		}
 

--- a/backend/internal/engine/native_executor_test.go
+++ b/backend/internal/engine/native_executor_test.go
@@ -572,6 +572,36 @@ func TestNativeExecutorFailsOnStepLimit(t *testing.T) {
 	}
 }
 
+func TestMaxIterationsLimitPrefersRunExecutionPlanOverride(t *testing.T) {
+	executionContext := nativeExecutionContext()
+	executionContext.Deployment.RuntimeProfile.MaxIterations = 9
+	executionContext.Run.ExecutionPlan = []byte(`{"runtime_limits":{"max_iterations":2}}`)
+
+	if got := maxIterationsLimit(executionContext); got != 2 {
+		t.Fatalf("maxIterationsLimit = %d, want 2", got)
+	}
+}
+
+func TestMaxIterationsLimitFallsBackToRuntimeProfile(t *testing.T) {
+	executionContext := nativeExecutionContext()
+	executionContext.Deployment.RuntimeProfile.MaxIterations = 9
+	executionContext.Run.ExecutionPlan = []byte(`{"runtime_limits":{"max_iterations":0}}`)
+
+	if got := maxIterationsLimit(executionContext); got != 9 {
+		t.Fatalf("maxIterationsLimit = %d, want 9", got)
+	}
+}
+
+func TestMaxIterationsLimitFallsBackWhenExecutionPlanOverrideIsTooLarge(t *testing.T) {
+	executionContext := nativeExecutionContext()
+	executionContext.Deployment.RuntimeProfile.MaxIterations = 9
+	executionContext.Run.ExecutionPlan = []byte(`{"runtime_limits":{"max_iterations":1001}}`)
+
+	if got := maxIterationsLimit(executionContext); got != 9 {
+		t.Fatalf("maxIterationsLimit = %d, want 9", got)
+	}
+}
+
 func TestNativeExecutorFailsWhenSandboxSetupFails(t *testing.T) {
 	executor := NewNativeExecutor(&scriptedProviderClient{t: t}, &sandbox.FakeProvider{
 		CreateErr: errors.New("sandbox unavailable"),

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -86,6 +86,7 @@ type RunnableChallengePackVersion struct {
 	ID              uuid.UUID
 	ChallengePackID uuid.UUID
 	WorkspaceID     *uuid.UUID
+	Manifest        json.RawMessage
 }
 
 type ChallengeInputSet struct {
@@ -355,7 +356,7 @@ func (r *Repository) GetRunByID(ctx context.Context, id uuid.UUID) (domain.Run, 
 
 func (r *Repository) GetRunnableChallengePackVersionByID(ctx context.Context, id uuid.UUID) (RunnableChallengePackVersion, error) {
 	row := r.db.QueryRow(ctx, `
-		SELECT cpv.id, cpv.challenge_pack_id, cp.workspace_id
+		SELECT cpv.id, cpv.challenge_pack_id, cp.workspace_id, cpv.manifest
 		FROM challenge_pack_versions cpv
 		JOIN challenge_packs cp ON cp.id = cpv.challenge_pack_id
 		WHERE cpv.id = $1
@@ -366,7 +367,7 @@ func (r *Repository) GetRunnableChallengePackVersionByID(ctx context.Context, id
 	`, id)
 
 	var version RunnableChallengePackVersion
-	if err := row.Scan(&version.ID, &version.ChallengePackID, &version.WorkspaceID); err != nil {
+	if err := row.Scan(&version.ID, &version.ChallengePackID, &version.WorkspaceID, &version.Manifest); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return RunnableChallengePackVersion{}, ErrChallengePackVersionNotFound
 		}

--- a/backend/internal/scoring/loader_test.go
+++ b/backend/internal/scoring/loader_test.go
@@ -31,7 +31,8 @@ func TestLoadEvaluationSpec(t *testing.T) {
 				],
 				"runtime_limits": {
 					"max_duration_ms": 60000,
-					"max_cost_usd": 20
+					"max_cost_usd": 20,
+					"max_iterations": 6
 				},
 				"pricing": {
 					"models": [
@@ -68,6 +69,9 @@ func TestLoadEvaluationSpec(t *testing.T) {
 		if spec.RuntimeLimits.MaxDurationMS == nil || *spec.RuntimeLimits.MaxDurationMS != 60000 {
 			t.Fatalf("max duration = %v, want 60000", spec.RuntimeLimits.MaxDurationMS)
 		}
+		if spec.RuntimeLimits.MaxIterations == nil || *spec.RuntimeLimits.MaxIterations != 6 {
+			t.Fatalf("max iterations = %v, want 6", spec.RuntimeLimits.MaxIterations)
+		}
 		if len(spec.Pricing.Models) != 1 || spec.Pricing.Models[0].ProviderKey != "openai" {
 			t.Fatalf("pricing models = %#v, want openai pricing", spec.Pricing.Models)
 		}
@@ -92,6 +96,11 @@ func TestLoadEvaluationSpec(t *testing.T) {
 			name:     "non-positive version",
 			manifest: `{"evaluation_spec":{"name":"spec","version_number":0,"judge_mode":"deterministic","validators":[{"key":"v1","type":"exact_match","target":"final_output","expected_from":"challenge_input"}],"scorecard":{"dimensions":["correctness"]}}}`,
 			needle:   "evaluation_spec.version_number must be greater than 0",
+		},
+		{
+			name:     "non-positive max iterations",
+			manifest: `{"evaluation_spec":{"name":"spec","version_number":1,"judge_mode":"deterministic","validators":[{"key":"v1","type":"exact_match","target":"final_output","expected_from":"challenge_input"}],"runtime_limits":{"max_iterations":0},"scorecard":{"dimensions":["correctness"]}}}`,
+			needle:   "evaluation_spec.runtime_limits.max_iterations must be greater than 0",
 		},
 		{
 			name:     "invalid judge mode",

--- a/backend/internal/scoring/loader_test.go
+++ b/backend/internal/scoring/loader_test.go
@@ -100,7 +100,12 @@ func TestLoadEvaluationSpec(t *testing.T) {
 		{
 			name:     "non-positive max iterations",
 			manifest: `{"evaluation_spec":{"name":"spec","version_number":1,"judge_mode":"deterministic","validators":[{"key":"v1","type":"exact_match","target":"final_output","expected_from":"challenge_input"}],"runtime_limits":{"max_iterations":0},"scorecard":{"dimensions":["correctness"]}}}`,
-			needle:   "evaluation_spec.runtime_limits.max_iterations must be greater than 0",
+			needle:   "evaluation_spec.runtime_limits.max_iterations must be between 1 and 1000",
+		},
+		{
+			name:     "too-large max iterations",
+			manifest: `{"evaluation_spec":{"name":"spec","version_number":1,"judge_mode":"deterministic","validators":[{"key":"v1","type":"exact_match","target":"final_output","expected_from":"challenge_input"}],"runtime_limits":{"max_iterations":1001},"scorecard":{"dimensions":["correctness"]}}}`,
+			needle:   "evaluation_spec.runtime_limits.max_iterations must be between 1 and 1000",
 		},
 		{
 			name:     "invalid judge mode",

--- a/backend/internal/scoring/spec.go
+++ b/backend/internal/scoring/spec.go
@@ -288,6 +288,7 @@ type RuntimeLimits struct {
 	MaxTotalTokens *int64   `json:"max_total_tokens,omitempty"`
 	MaxCostUSD     *float64 `json:"max_cost_usd,omitempty"`
 	MaxDurationMS  *int64   `json:"max_duration_ms,omitempty"`
+	MaxIterations  *int32   `json:"max_iterations,omitempty"`
 }
 
 type PricingConfig struct {

--- a/backend/internal/scoring/validation.go
+++ b/backend/internal/scoring/validation.go
@@ -68,6 +68,9 @@ func ValidateEvaluationSpec(spec EvaluationSpec) error {
 	if spec.RuntimeLimits.MaxDurationMS != nil && *spec.RuntimeLimits.MaxDurationMS <= 0 {
 		errs = append(errs, ValidationError{Field: "evaluation_spec.runtime_limits.max_duration_ms", Message: "must be greater than 0"})
 	}
+	if spec.RuntimeLimits.MaxIterations != nil && *spec.RuntimeLimits.MaxIterations <= 0 {
+		errs = append(errs, ValidationError{Field: "evaluation_spec.runtime_limits.max_iterations", Message: "must be greater than 0"})
+	}
 
 	validatorKeys := map[string]struct{}{}
 	for i, validator := range spec.Validators {

--- a/backend/internal/scoring/validation.go
+++ b/backend/internal/scoring/validation.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 )
 
+const maxEvaluationSpecMaxIterations = 1000
+
 type ValidationError struct {
 	Field   string
 	Message string
@@ -68,8 +70,8 @@ func ValidateEvaluationSpec(spec EvaluationSpec) error {
 	if spec.RuntimeLimits.MaxDurationMS != nil && *spec.RuntimeLimits.MaxDurationMS <= 0 {
 		errs = append(errs, ValidationError{Field: "evaluation_spec.runtime_limits.max_duration_ms", Message: "must be greater than 0"})
 	}
-	if spec.RuntimeLimits.MaxIterations != nil && *spec.RuntimeLimits.MaxIterations <= 0 {
-		errs = append(errs, ValidationError{Field: "evaluation_spec.runtime_limits.max_iterations", Message: "must be greater than 0"})
+	if spec.RuntimeLimits.MaxIterations != nil && (*spec.RuntimeLimits.MaxIterations <= 0 || *spec.RuntimeLimits.MaxIterations > maxEvaluationSpecMaxIterations) {
+		errs = append(errs, ValidationError{Field: "evaluation_spec.runtime_limits.max_iterations", Message: fmt.Sprintf("must be between 1 and %d", maxEvaluationSpecMaxIterations)})
 	}
 
 	validatorKeys := map[string]struct{}{}

--- a/cli/cmd/contract_alignment_test.go
+++ b/cli/cmd/contract_alignment_test.go
@@ -72,6 +72,7 @@ func TestRunCreateUsesRegressionSelectorsAndOfficialPackMode(t *testing.T) {
 		"--suite", "suite-1",
 		"--case", "case-1",
 		"--include-proposed-regressions",
+		"--max-iter", "7",
 	}, srv.URL)
 	if err != nil {
 		t.Fatalf("run create error: %v", err)
@@ -88,6 +89,9 @@ func TestRunCreateUsesRegressionSelectorsAndOfficialPackMode(t *testing.T) {
 	}
 	if gotBody["include_proposed_regressions"] != true {
 		t.Fatalf("include_proposed_regressions = %v, want true", gotBody["include_proposed_regressions"])
+	}
+	if gotBody["max_iterations"] != float64(7) {
+		t.Fatalf("max_iterations = %v, want 7", gotBody["max_iterations"])
 	}
 }
 

--- a/cli/cmd/eval_session_helpers.go
+++ b/cli/cmd/eval_session_helpers.go
@@ -42,6 +42,9 @@ func buildEvalSessionBody(workspaceID string, request runCreateRequest, repetiti
 	if request.RaceContext || request.RaceContextCadence > 0 {
 		return nil, fmt.Errorf("--race-context flags are not supported with --repetitions >= 2")
 	}
+	if request.MaxIterations > 0 {
+		return nil, fmt.Errorf("--max-iter is not supported with --repetitions >= 2")
+	}
 
 	executionMode := "single_agent"
 	if len(request.DeploymentIDs) > 1 {

--- a/cli/cmd/eval_session_test.go
+++ b/cli/cmd/eval_session_test.go
@@ -146,6 +146,11 @@ func TestBuildEvalSessionBody_RejectsUnsupportedFlags(t *testing.T) {
 			mutate:  func(r *runCreateRequest) { r.RaceContextCadence = 5 },
 			wantErr: "race-context",
 		},
+		{
+			name:    "max_iterations",
+			mutate:  func(r *runCreateRequest) { r.MaxIterations = 7 },
+			wantErr: "max-iter",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -38,6 +38,7 @@ func init() {
 	runCreateCmd.Flags().Bool("include-proposed-regressions", false, "Include proposed regression cases for validation runs")
 	runCreateCmd.Flags().Bool("race-context", false, "Enable live peer-standings injection during the run (requires 2+ agents)")
 	runCreateCmd.Flags().Int("race-context-cadence", 0, "Override race-context cadence; minimum steps between standings injections, [1, 10]. 0 uses the backend default.")
+	runCreateCmd.Flags().Int("max-iter", 0, "Override max iterations for this run (1-1000). 0 uses the pack/runtime default.")
 
 	runRankingCmd.Flags().String("sort-by", "", "Sort by: composite, correctness, reliability, latency, cost")
 	runFailuresCmd.Flags().String("agent", "", "Filter by run agent ID")

--- a/cli/cmd/run_create_helpers.go
+++ b/cli/cmd/run_create_helpers.go
@@ -10,6 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const maxRunCreateMaxIter = 1000
+
 type runCreateRequest struct {
 	ChallengePackVersionID     string
 	ChallengeInputSetID        string
@@ -21,6 +23,7 @@ type runCreateRequest struct {
 	IncludeProposedRegressions bool
 	RaceContext                bool
 	RaceContextCadence         int
+	MaxIterations              int
 	CIMetadata                 map[string]any
 }
 
@@ -55,6 +58,9 @@ func runCreateRequestFromFlags(cmd *cobra.Command, base runCreateRequest) (runCr
 	cadence, _ := cmd.Flags().GetInt("race-context-cadence")
 	request.RaceContextCadence = cadence
 
+	maxIterations, _ := cmd.Flags().GetInt("max-iter")
+	request.MaxIterations = maxIterations
+
 	return request, nil
 }
 
@@ -70,6 +76,9 @@ func buildRunCreateBody(workspaceID string, request runCreateRequest) (map[strin
 	}
 	if request.RaceContextCadence < 0 || request.RaceContextCadence > 10 {
 		return nil, fmt.Errorf("--race-context-cadence must be 0 (backend default) or between 1 and 10, got %d", request.RaceContextCadence)
+	}
+	if request.MaxIterations < 0 || request.MaxIterations > maxRunCreateMaxIter {
+		return nil, fmt.Errorf("--max-iter must be 0 (pack/runtime default) or between 1 and %d, got %d", maxRunCreateMaxIter, request.MaxIterations)
 	}
 
 	body := map[string]any{
@@ -98,6 +107,9 @@ func buildRunCreateBody(workspaceID string, request runCreateRequest) (map[strin
 	}
 	if request.RaceContextCadence > 0 {
 		body["race_context_min_step_gap"] = request.RaceContextCadence
+	}
+	if request.MaxIterations > 0 {
+		body["max_iterations"] = request.MaxIterations
 	}
 	if len(request.CIMetadata) > 0 {
 		body["ci_metadata"] = request.CIMetadata

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -6867,6 +6867,15 @@ components:
             Optional. Overrides the default cadence (minimum steps between
             standings injections). Null / omitted uses the backend default.
             Only meaningful when `race_context` is true.
+        max_iterations:
+          type: integer
+          minimum: 1
+          maximum: 1000
+          description: >
+            Optional. Overrides the max native-agent iteration budget for this
+            run. If omitted, AgentClash uses the challenge pack
+            `evaluation_spec.runtime_limits.max_iterations` default when
+            present, otherwise the selected runtime profile default.
         ci_metadata:
           $ref: "#/components/schemas/RunCIMetadata"
           description: >

--- a/docs/evaluation/challenge-pack-v0.md
+++ b/docs/evaluation/challenge-pack-v0.md
@@ -52,7 +52,8 @@ The manifest may contain a top-level `evaluation_spec` block like this:
     "runtime_limits": {
       "max_total_tokens": 50000,
       "max_cost_usd": 20,
-      "max_duration_ms": 1800000
+      "max_duration_ms": 1800000,
+      "max_iterations": 12
     },
     "pricing": {
       "models": [
@@ -86,7 +87,7 @@ The manifest may contain a top-level `evaluation_spec` block like this:
 - `evaluation_spec.judge_mode`: one of `deterministic`, `llm_judge`, `hybrid`
 - `validators`: declared checks that later validator execution can implement
 - `metrics`: declared collectors that later metric execution can implement
-- `runtime_limits`: pack-level hard ceilings and normalization fallbacks
+- `runtime_limits`: pack-level hard ceilings and normalization fallbacks, including the optional default native-agent `max_iterations` budget for runs created from the pack
 - `pricing.models`: configurable provider/model pricing rows used for cost scoring
 - `scorecard.dimensions`: score groups later surfaced to users
 - `scorecard.normalization`: dimension-specific thresholds for turning raw latency/cost into scores


### PR DESCRIPTION
Closes #698.

## Summary
- add `max_iterations` to run creation and persist the effective limit into `execution_plan.runtime_limits.max_iterations`
- default from challenge pack `evaluation_spec.runtime_limits.max_iterations` (with legacy top-level manifest fallback) when no explicit override is provided
- add CLI `agentclash run create --max-iter` and reject it for repetitions until fanout support lands
- teach the native executor to honor execution-plan max-iteration overrides before runtime profile defaults
- document the API and challenge pack runtime limit shape

## Validation
- `cd backend && go test ./...`
- `cd backend && go vet ./...`
- `cd cli && go build ./...`
- `cd cli && go vet ./...`
- `cd cli && go test -short -race -count=1 ./...`
- `cd cli && go run github.com/goreleaser/goreleaser/v2@latest check`

## Review
- Cursor Agent (`claude-opus-4-7-low`, `--mode ask`) completed pre-landing review: no blocking findings.
- Applied the cheap hardening suggestions from that review: bounded executor-side plan parsing and explicit override-wins-over-pack-default test.
