### PR TITLE
feat: add seeded run creation

### DIFF
--- a/backend/internal/api/eval_session_reads.go
+++ b/backend/internal/api/eval_session_reads.go
@@ -61,6 +61,7 @@ type evalSessionChildRunResponse struct {
 	Name                   string           `json:"name"`
 	Status                 domain.RunStatus `json:"status"`
 	ExecutionMode          string           `json:"execution_mode"`
+	Seed                   *int64           `json:"seed,omitempty"`
 	QueuedAt               *time.Time       `json:"queued_at,omitempty"`
 	StartedAt              *time.Time       `json:"started_at,omitempty"`
 	FinishedAt             *time.Time       `json:"finished_at,omitempty"`
@@ -411,6 +412,7 @@ func buildEvalSessionChildRunResponse(run domain.Run) evalSessionChildRunRespons
 		Name:                   run.Name,
 		Status:                 run.Status,
 		ExecutionMode:          run.ExecutionMode,
+		Seed:                   evalSessionChildRunSeed(run.ExecutionPlan),
 		QueuedAt:               run.QueuedAt,
 		StartedAt:              run.StartedAt,
 		FinishedAt:             run.FinishedAt,
@@ -420,4 +422,18 @@ func buildEvalSessionChildRunResponse(run domain.Run) evalSessionChildRunRespons
 		UpdatedAt:              run.UpdatedAt,
 		Links:                  buildRunLinks(run.ID),
 	}
+}
+
+func evalSessionChildRunSeed(executionPlan json.RawMessage) *int64 {
+	if len(executionPlan) == 0 {
+		return nil
+	}
+	var plan struct {
+		Seed *int64 `json:"seed"`
+	}
+	if err := json.Unmarshal(executionPlan, &plan); err != nil || plan.Seed == nil || *plan.Seed < 1 {
+		return nil
+	}
+	seed := *plan.Seed
+	return &seed
 }

--- a/backend/internal/api/eval_session_reads_test.go
+++ b/backend/internal/api/eval_session_reads_test.go
@@ -308,6 +308,7 @@ func TestGetEvalSessionEndpointReturnsDetail(t *testing.T) {
 						Name:             "Repeated Eval [1/2]",
 						Status:           domain.RunStatusQueued,
 						ExecutionMode:    "single_agent",
+						ExecutionPlan:    json.RawMessage(`{"seed":42}`),
 						CreatedAt:        time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
 						UpdatedAt:        time.Date(2026, 4, 20, 12, 1, 0, 0, time.UTC),
 					},
@@ -351,6 +352,9 @@ func TestGetEvalSessionEndpointReturnsDetail(t *testing.T) {
 	}
 	if len(response.Runs) != 1 || response.Runs[0].ID != runID {
 		t.Fatalf("runs = %#v, want one run %s", response.Runs, runID)
+	}
+	if response.Runs[0].Seed == nil || *response.Runs[0].Seed != 42 {
+		t.Fatalf("run seed = %v, want 42", response.Runs[0].Seed)
 	}
 	if response.Summary.RunCounts.Queued != 1 {
 		t.Fatalf("queued run count = %d, want 1", response.Summary.RunCounts.Queued)

--- a/backend/internal/api/eval_session_service.go
+++ b/backend/internal/api/eval_session_service.go
@@ -388,12 +388,12 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 
 	runIDs := make([]uuid.UUID, 0, len(createResult.Runs))
 	seededRuns := make([]EvalSessionSeededRun, 0, len(input.EvalSession.SeedFanout))
-	for index, run := range createResult.Runs {
+	for _, run := range createResult.Runs {
 		runIDs = append(runIDs, run.ID)
-		if index < len(input.EvalSession.SeedFanout) {
+		if seed := evalSessionChildRunSeed(run.ExecutionPlan); seed != nil {
 			seededRuns = append(seededRuns, EvalSessionSeededRun{
 				RunID: run.ID,
-				Seed:  input.EvalSession.SeedFanout[index],
+				Seed:  *seed,
 			})
 		}
 	}

--- a/backend/internal/api/eval_session_service.go
+++ b/backend/internal/api/eval_session_service.go
@@ -53,6 +53,7 @@ type CreateEvalSessionConfigInput struct {
 	SuccessThreshold    *EvalSessionSuccessThresholdInput
 	RoutingTaskSnapshot EvalSessionRoutingTaskSnapshotInput
 	ReliabilityWeights  *EvalSessionReliabilityWeightsInput
+	SeedFanout          []int64
 	SchemaVersion       int32
 }
 
@@ -63,12 +64,19 @@ type CreateEvalSessionInput struct {
 	Participants           []EvalSessionParticipantInput
 	ExecutionMode          string
 	Name                   string
+	MaxIterations          *int32
 	EvalSession            CreateEvalSessionConfigInput
 }
 
+type EvalSessionSeededRun struct {
+	RunID uuid.UUID `json:"run_id"`
+	Seed  int64     `json:"seed"`
+}
+
 type CreateEvalSessionResult struct {
-	Session domain.EvalSession
-	RunIDs  []uuid.UUID
+	Session    domain.EvalSession
+	RunIDs     []uuid.UUID
+	SeededRuns []EvalSessionSeededRun
 }
 
 func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Caller, input CreateEvalSessionInput) (CreateEvalSessionResult, error) {
@@ -125,6 +133,9 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 			Code:    "invalid_challenge_pack_version_id",
 			Message: "challenge_pack_version_id must be visible to the selected workspace",
 		}
+	}
+	if input.MaxIterations == nil {
+		input.MaxIterations = challengePackDefaultMaxIterations(challengePackVersion.Manifest)
 	}
 
 	if input.ChallengeInputSetID != nil {
@@ -299,16 +310,6 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 		})
 	}
 
-	executionPlan, err := buildExecutionPlan(CreateRunInput{
-		WorkspaceID:            input.WorkspaceID,
-		ChallengePackVersionID: input.ChallengePackVersionID,
-		ChallengeInputSetID:    input.ChallengeInputSetID,
-		OfficialPackMode:       domain.OfficialPackModeFull,
-	}, runAgents)
-	if err != nil {
-		return CreateEvalSessionResult{}, fmt.Errorf("build execution plan: %w", err)
-	}
-
 	challengeIdentityIDs, err := m.repo.ListChallengeIdentityIDsByPackVersionID(ctx, input.ChallengePackVersionID)
 	if err != nil {
 		return CreateEvalSessionResult{}, fmt.Errorf("list official challenge identities: %w", err)
@@ -330,6 +331,20 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 
 	childRuns := make([]repository.CreateQueuedRunParams, 0, input.EvalSession.Repetitions)
 	for repetition := int32(0); repetition < input.EvalSession.Repetitions; repetition++ {
+		runInput := CreateRunInput{
+			WorkspaceID:            input.WorkspaceID,
+			ChallengePackVersionID: input.ChallengePackVersionID,
+			ChallengeInputSetID:    input.ChallengeInputSetID,
+			OfficialPackMode:       domain.OfficialPackModeFull,
+			MaxIterations:          input.MaxIterations,
+		}
+		if int(repetition) < len(input.EvalSession.SeedFanout) {
+			runInput.Seed = &input.EvalSession.SeedFanout[repetition]
+		}
+		executionPlan, err := buildExecutionPlan(runInput, runAgents)
+		if err != nil {
+			return CreateEvalSessionResult{}, fmt.Errorf("build execution plan: %w", err)
+		}
 		childRuns = append(childRuns, repository.CreateQueuedRunParams{
 			OrganizationID:         organizationID,
 			WorkspaceID:            input.WorkspaceID,
@@ -372,13 +387,21 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 	}
 
 	runIDs := make([]uuid.UUID, 0, len(createResult.Runs))
-	for _, run := range createResult.Runs {
+	seededRuns := make([]EvalSessionSeededRun, 0, len(input.EvalSession.SeedFanout))
+	for index, run := range createResult.Runs {
 		runIDs = append(runIDs, run.ID)
+		if index < len(input.EvalSession.SeedFanout) {
+			seededRuns = append(seededRuns, EvalSessionSeededRun{
+				RunID: run.ID,
+				Seed:  input.EvalSession.SeedFanout[index],
+			})
+		}
 	}
 
 	return CreateEvalSessionResult{
-		Session: createResult.Session,
-		RunIDs:  runIDs,
+		Session:    createResult.Session,
+		RunIDs:     runIDs,
+		SeededRuns: seededRuns,
 	}, nil
 }
 
@@ -434,6 +457,12 @@ func buildRoutingTaskSnapshot(input CreateEvalSessionConfigInput) json.RawMessag
 		"schema_version": input.SchemaVersion,
 		"routing":        json.RawMessage(input.RoutingTaskSnapshot.Routing),
 		"task":           json.RawMessage(input.RoutingTaskSnapshot.Task),
+	}
+	if len(input.SeedFanout) > 0 {
+		payload["seed_fanout"] = map[string]any{
+			"strategy": "explicit",
+			"seeds":    input.SeedFanout,
+		}
 	}
 	return mustMarshalEvalSessionJSON(payload)
 }

--- a/backend/internal/api/eval_sessions.go
+++ b/backend/internal/api/eval_sessions.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -23,6 +24,7 @@ type createEvalSessionRequest struct {
 	Participants           []createEvalSessionParticipant `json:"participants"`
 	ExecutionMode          string                         `json:"execution_mode"`
 	Name                   string                         `json:"name,omitempty"`
+	MaxIterations          *int                           `json:"max_iterations,omitempty"`
 	EvalSession            json.RawMessage                `json:"eval_session"`
 }
 
@@ -33,8 +35,14 @@ type createEvalSessionParticipant struct {
 }
 
 type createEvalSessionResponse struct {
-	EvalSession evalSessionResponse `json:"eval_session"`
-	RunIDs      []uuid.UUID         `json:"run_ids"`
+	EvalSession evalSessionResponse            `json:"eval_session"`
+	RunIDs      []uuid.UUID                    `json:"run_ids"`
+	SeededRuns  []evalSessionSeededRunResponse `json:"seeded_runs,omitempty"`
+}
+
+type evalSessionSeededRunResponse struct {
+	RunID uuid.UUID `json:"run_id"`
+	Seed  int64     `json:"seed"`
 }
 
 type evalSessionResponse struct {
@@ -102,6 +110,7 @@ func createEvalSessionHandler(logger *slog.Logger, service RunCreationService) h
 		writeJSON(w, http.StatusCreated, createEvalSessionResponse{
 			EvalSession: buildEvalSessionResponse(result.Session),
 			RunIDs:      append([]uuid.UUID(nil), result.RunIDs...),
+			SeededRuns:  buildEvalSessionSeededRunResponse(result.SeededRuns),
 		})
 	}
 }
@@ -155,6 +164,20 @@ func buildEvalSessionResponse(session domain.EvalSession) evalSessionResponse {
 		FinishedAt:             cloneTimePtr(session.FinishedAt),
 		UpdatedAt:              session.UpdatedAt,
 	}
+}
+
+func buildEvalSessionSeededRunResponse(items []EvalSessionSeededRun) []evalSessionSeededRunResponse {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]evalSessionSeededRunResponse, 0, len(items))
+	for _, item := range items {
+		out = append(out, evalSessionSeededRunResponse{
+			RunID: item.RunID,
+			Seed:  item.Seed,
+		})
+	}
+	return out
 }
 
 func cloneTimePtr(value *time.Time) *time.Time {
@@ -217,6 +240,19 @@ func decodeCreateEvalSessionRequest(_ context.Context, r *http.Request) (CreateE
 		}
 	}
 
+	var maxIterations *int32
+	if body.MaxIterations != nil {
+		value := *body.MaxIterations
+		if value < 1 || value > maxRunMaxIterations {
+			return CreateEvalSessionInput{}, RunCreationValidationError{
+				Code:    "invalid_max_iterations",
+				Message: fmt.Sprintf("max_iterations must be between 1 and %d", maxRunMaxIterations),
+			}
+		}
+		value32 := int32(value)
+		maxIterations = &value32
+	}
+
 	participants := make([]EvalSessionParticipantInput, 0, len(body.Participants))
 	for _, participant := range body.Participants {
 		var deploymentID *uuid.UUID
@@ -275,6 +311,7 @@ func decodeCreateEvalSessionRequest(_ context.Context, r *http.Request) (CreateE
 		Participants:           participants,
 		ExecutionMode:          strings.TrimSpace(body.ExecutionMode),
 		Name:                   strings.TrimSpace(body.Name),
+		MaxIterations:          maxIterations,
 		EvalSession:            config,
 	}, nil
 }
@@ -286,6 +323,7 @@ func decodeEvalSessionConfig(raw json.RawMessage) (CreateEvalSessionConfigInput,
 		SuccessThreshold    json.RawMessage `json:"success_threshold"`
 		RoutingTaskSnapshot json.RawMessage `json:"routing_task_snapshot"`
 		ReliabilityWeights  json.RawMessage `json:"reliability_weights"`
+		SeedFanout          json.RawMessage `json:"seed_fanout"`
 		SchemaVersion       json.RawMessage `json:"schema_version"`
 	}
 
@@ -336,6 +374,8 @@ func decodeEvalSessionConfig(raw json.RawMessage) (CreateEvalSessionConfigInput,
 
 	reliabilityWeights, reliabilityDetails := decodeEvalSessionReliabilityWeights(body.ReliabilityWeights)
 	details = append(details, reliabilityDetails...)
+	seedFanout, seedFanoutDetails := decodeEvalSessionSeedFanout(body.SeedFanout, repetitions)
+	details = append(details, seedFanoutDetails...)
 
 	if aggregation.Method == "weighted_mean" && reliabilityWeights == nil {
 		details = append(details, evalSessionValidationDetail{
@@ -355,8 +395,76 @@ func decodeEvalSessionConfig(raw json.RawMessage) (CreateEvalSessionConfigInput,
 		SuccessThreshold:    successThreshold,
 		RoutingTaskSnapshot: routingTaskSnapshot,
 		ReliabilityWeights:  reliabilityWeights,
+		SeedFanout:          seedFanout,
 		SchemaVersion:       schemaVersion,
 	}, nil
+}
+
+func decodeEvalSessionSeedFanout(raw json.RawMessage, repetitions int32) ([]int64, []evalSessionValidationDetail) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil, nil
+	}
+	type seedFanoutRequest struct {
+		Strategy json.RawMessage `json:"strategy"`
+		Seeds    json.RawMessage `json:"seeds"`
+	}
+	var body seedFanoutRequest
+	if !decodeJSONObject(raw, &body) {
+		return nil, []evalSessionValidationDetail{{
+			Field:   "eval_session.seed_fanout",
+			Code:    "eval_session.seed_fanout.invalid",
+			Message: "seed_fanout must be an object with strategy and seeds",
+		}}
+	}
+	strategy, ok := decodeRequiredString(body.Strategy)
+	if !ok || strategy != "explicit" {
+		return nil, []evalSessionValidationDetail{{
+			Field:   "eval_session.seed_fanout.strategy",
+			Code:    "eval_session.seed_fanout.strategy.unsupported",
+			Message: "seed_fanout.strategy must be explicit",
+		}}
+	}
+	var seeds []int64
+	if err := json.Unmarshal(body.Seeds, &seeds); err != nil {
+		return nil, []evalSessionValidationDetail{{
+			Field:   "eval_session.seed_fanout.seeds",
+			Code:    "eval_session.seed_fanout.seeds.invalid",
+			Message: "seed_fanout.seeds must be an array of positive integers",
+		}}
+	}
+	details := make([]evalSessionValidationDetail, 0)
+	if int32(len(seeds)) != repetitions {
+		details = append(details, evalSessionValidationDetail{
+			Field:   "eval_session.seed_fanout.seeds",
+			Code:    "eval_session.seed_fanout.seeds.length_mismatch",
+			Message: "seed_fanout.seeds length must match repetitions",
+		})
+	}
+	seen := make(map[int64]struct{}, len(seeds))
+	for _, seed := range seeds {
+		if seed < 1 {
+			details = append(details, evalSessionValidationDetail{
+				Field:   "eval_session.seed_fanout.seeds",
+				Code:    "eval_session.seed_fanout.seeds.invalid",
+				Message: "seed_fanout.seeds must be an array of positive integers",
+			})
+			break
+		}
+		if _, exists := seen[seed]; exists {
+			details = append(details, evalSessionValidationDetail{
+				Field:   "eval_session.seed_fanout.seeds",
+				Code:    "eval_session.seed_fanout.seeds.duplicate",
+				Message: "seed_fanout.seeds must not contain duplicates",
+			})
+			break
+		}
+		seen[seed] = struct{}{}
+	}
+	if len(details) > 0 {
+		return nil, details
+	}
+	return seeds, nil
 }
 
 func decodeEvalSessionAggregation(raw json.RawMessage) (EvalSessionAggregationInput, []evalSessionValidationDetail) {

--- a/backend/internal/api/run_service.go
+++ b/backend/internal/api/run_service.go
@@ -479,6 +479,7 @@ func buildExecutionPlan(input CreateRunInput, runAgents []repository.CreateQueue
 		OfficialPackMode       domain.OfficialPackMode     `json:"official_pack_mode"`
 		Participants           []executionPlanRunAgent     `json:"participants"`
 		RuntimeLimits          *executionPlanRuntimeLimits `json:"runtime_limits,omitempty"`
+		Seed                   *int64                      `json:"seed,omitempty"`
 	}
 
 	participants := make([]executionPlanRunAgent, 0, len(runAgents))
@@ -497,6 +498,7 @@ func buildExecutionPlan(input CreateRunInput, runAgents []repository.CreateQueue
 		ChallengeInputSetID:    input.ChallengeInputSetID,
 		OfficialPackMode:       input.OfficialPackMode,
 		Participants:           participants,
+		Seed:                   cloneInt64Ptr(input.Seed),
 	}
 	if input.MaxIterations != nil {
 		plan.RuntimeLimits = &executionPlanRuntimeLimits{MaxIterations: cloneInt32Ptr(input.MaxIterations)}

--- a/backend/internal/api/run_service_test.go
+++ b/backend/internal/api/run_service_test.go
@@ -685,8 +685,8 @@ func TestRunCreationManagerCreateEvalSessionPersistsSeedFanout(t *testing.T) {
 		createEvalSessionWithRunsResult: repository.CreateEvalSessionWithQueuedRunsResult{
 			Session: domain.EvalSession{ID: sessionID, Status: domain.EvalSessionStatusQueued, Repetitions: 2, SchemaVersion: 1},
 			Runs: []domain.Run{
-				{ID: firstRunID, EvalSessionID: &sessionID},
-				{ID: secondRunID, EvalSessionID: &sessionID},
+				{ID: secondRunID, EvalSessionID: &sessionID, ExecutionPlan: json.RawMessage(`{"seed":2}`)},
+				{ID: firstRunID, EvalSessionID: &sessionID, ExecutionPlan: json.RawMessage(`{"seed":1}`)},
 			},
 		},
 	}
@@ -720,8 +720,8 @@ func TestRunCreationManagerCreateEvalSessionPersistsSeedFanout(t *testing.T) {
 		t.Fatalf("CreateEvalSession returned error: %v", err)
 	}
 
-	if len(result.SeededRuns) != 2 || result.SeededRuns[0].RunID != firstRunID || result.SeededRuns[0].Seed != 1 || result.SeededRuns[1].RunID != secondRunID || result.SeededRuns[1].Seed != 2 {
-		t.Fatalf("seeded runs = %+v, want run/seed pairs", result.SeededRuns)
+	if len(result.SeededRuns) != 2 || result.SeededRuns[0].RunID != secondRunID || result.SeededRuns[0].Seed != 2 || result.SeededRuns[1].RunID != firstRunID || result.SeededRuns[1].Seed != 1 {
+		t.Fatalf("seeded runs = %+v, want run/seed pairs extracted from execution plans", result.SeededRuns)
 	}
 	if got := executionPlanTestSeed(t, repo.createEvalSessionWithRunsParams.Runs[0].ExecutionPlan); got != 1 {
 		t.Fatalf("first execution plan seed = %d, want 1", got)

--- a/backend/internal/api/run_service_test.go
+++ b/backend/internal/api/run_service_test.go
@@ -651,6 +651,101 @@ func TestRunCreationManagerCreateEvalSessionCreatesQueuedRuns(t *testing.T) {
 	}
 }
 
+func TestRunCreationManagerCreateEvalSessionPersistsSeedFanout(t *testing.T) {
+	workspaceID := uuid.New()
+	challengePackVersionID := uuid.New()
+	challengeInputSetID := uuid.New()
+	deploymentID := uuid.New()
+	sessionID := uuid.New()
+	firstRunID := uuid.New()
+	secondRunID := uuid.New()
+	maxIterations := int32(3)
+	caller := Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}
+
+	repo := &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{ID: challengePackVersionID},
+		challengeInputSets: []repository.ChallengeInputSetSummary{
+			{ID: challengeInputSetID, ChallengePackVersionID: challengePackVersionID},
+		},
+		challengeIdentityIDs: []uuid.UUID{uuid.New()},
+		deployments: []repository.RunnableDeployment{
+			{
+				ID:                        deploymentID,
+				OrganizationID:            uuid.New(),
+				WorkspaceID:               workspaceID,
+				Name:                      "Support Agent Deployment",
+				AgentDeploymentSnapshotID: uuid.New(),
+			},
+		},
+		createEvalSessionWithRunsResult: repository.CreateEvalSessionWithQueuedRunsResult{
+			Session: domain.EvalSession{ID: sessionID, Status: domain.EvalSessionStatusQueued, Repetitions: 2, SchemaVersion: 1},
+			Runs: []domain.Run{
+				{ID: firstRunID, EvalSessionID: &sessionID},
+				{ID: secondRunID, EvalSessionID: &sessionID},
+			},
+		},
+	}
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, &fakeRunWorkflowStarter{}, nil)
+
+	result, err := manager.CreateEvalSession(context.Background(), caller, CreateEvalSessionInput{
+		WorkspaceID:            workspaceID,
+		ChallengePackVersionID: challengePackVersionID,
+		Participants: []EvalSessionParticipantInput{
+			{AgentDeploymentID: &deploymentID, Label: "Primary"},
+		},
+		ExecutionMode: "single_agent",
+		Name:          "Seeded eval",
+		MaxIterations: &maxIterations,
+		EvalSession: CreateEvalSessionConfigInput{
+			Repetitions: 2,
+			Aggregation: EvalSessionAggregationInput{
+				Method:             "mean",
+				ReportVariance:     true,
+				ConfidenceInterval: 0.95,
+			},
+			RoutingTaskSnapshot: EvalSessionRoutingTaskSnapshotInput{
+				Routing: json.RawMessage(`{"mode":"single_agent"}`),
+				Task:    json.RawMessage(`{"pack_version":"v1"}`),
+			},
+			SeedFanout:    []int64{1, 2},
+			SchemaVersion: 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateEvalSession returned error: %v", err)
+	}
+
+	if len(result.SeededRuns) != 2 || result.SeededRuns[0].RunID != firstRunID || result.SeededRuns[0].Seed != 1 || result.SeededRuns[1].RunID != secondRunID || result.SeededRuns[1].Seed != 2 {
+		t.Fatalf("seeded runs = %+v, want run/seed pairs", result.SeededRuns)
+	}
+	if got := executionPlanTestSeed(t, repo.createEvalSessionWithRunsParams.Runs[0].ExecutionPlan); got != 1 {
+		t.Fatalf("first execution plan seed = %d, want 1", got)
+	}
+	if got := executionPlanTestSeed(t, repo.createEvalSessionWithRunsParams.Runs[1].ExecutionPlan); got != 2 {
+		t.Fatalf("second execution plan seed = %d, want 2", got)
+	}
+	if got := executionPlanTestMaxIterations(t, repo.createEvalSessionWithRunsParams.Runs[0].ExecutionPlan); got != 3 {
+		t.Fatalf("execution plan max_iterations = %d, want 3", got)
+	}
+	var routingSnapshot struct {
+		SeedFanout struct {
+			Strategy string  `json:"strategy"`
+			Seeds    []int64 `json:"seeds"`
+		} `json:"seed_fanout"`
+	}
+	if err := json.Unmarshal(repo.createEvalSessionWithRunsParams.Session.RoutingTaskSnapshot, &routingSnapshot); err != nil {
+		t.Fatalf("decode routing task snapshot: %v", err)
+	}
+	if routingSnapshot.SeedFanout.Strategy != "explicit" || len(routingSnapshot.SeedFanout.Seeds) != 2 || routingSnapshot.SeedFanout.Seeds[1] != 2 {
+		t.Fatalf("seed fanout snapshot = %+v, want explicit [1 2]", routingSnapshot.SeedFanout)
+	}
+}
+
 func TestRunCreationManagerCreateEvalSessionStartsEvalSessionWorkflow(t *testing.T) {
 	workspaceID := uuid.New()
 	challengePackVersionID := uuid.New()
@@ -1842,6 +1937,17 @@ func executionPlanTestMaxIterations(t *testing.T, payload json.RawMessage) int32
 		t.Fatalf("decode execution plan: %v", err)
 	}
 	return plan.RuntimeLimits.MaxIterations
+}
+
+func executionPlanTestSeed(t *testing.T, payload json.RawMessage) int64 {
+	t.Helper()
+	var plan struct {
+		Seed int64 `json:"seed"`
+	}
+	if err := json.Unmarshal(payload, &plan); err != nil {
+		t.Fatalf("decode execution plan: %v", err)
+	}
+	return plan.Seed
 }
 
 func (f *fakeRunCreationRepository) GetRunnableChallengePackVersionByID(_ context.Context, _ uuid.UUID) (repository.RunnableChallengePackVersion, error) {

--- a/backend/internal/api/runs.go
+++ b/backend/internal/api/runs.go
@@ -64,6 +64,7 @@ type CreateRunInput struct {
 	RaceContext                bool
 	RaceContextMinStepGap      *int32
 	MaxIterations              *int32
+	Seed                       *int64
 	CIMetadata                 *domain.RunCIMetadata
 }
 

--- a/backend/internal/api/runs_test.go
+++ b/backend/internal/api/runs_test.go
@@ -727,6 +727,9 @@ func TestCreateEvalSessionEndpointReturnsCreated(t *testing.T) {
 				UpdatedAt:              time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
 			},
 			RunIDs: []uuid.UUID{runID, uuid.New()},
+			SeededRuns: []EvalSessionSeededRun{
+				{RunID: runID, Seed: 1},
+			},
 		},
 	}
 
@@ -735,10 +738,12 @@ func TestCreateEvalSessionEndpointReturnsCreated(t *testing.T) {
 		"challenge_pack_version_id":"`+uuid.New().String()+`",
 		"participants":[{"agent_deployment_id":"`+uuid.New().String()+`","label":"Primary"}],
 		"execution_mode":"single_agent",
+		"max_iterations":7,
 		"eval_session":{
 			"repetitions":2,
 			"aggregation":{"method":"mean","report_variance":true,"confidence_interval":0.95},
 			"routing_task_snapshot":{"routing":{"mode":"single_agent"},"task":{"pack_version":"v1"}},
+			"seed_fanout":{"strategy":"explicit","seeds":[1,2]},
 			"schema_version":1
 		}
 	}`))
@@ -789,11 +794,62 @@ func TestCreateEvalSessionEndpointReturnsCreated(t *testing.T) {
 	if len(response.RunIDs) != 2 || response.RunIDs[0] != runID {
 		t.Fatalf("run ids = %v, want first id %s", response.RunIDs, runID)
 	}
+	if len(response.SeededRuns) != 1 || response.SeededRuns[0].RunID != runID || response.SeededRuns[0].Seed != 1 {
+		t.Fatalf("seeded runs = %+v, want first run seed", response.SeededRuns)
+	}
 	if service.evalSessionInput.WorkspaceID != workspaceID {
 		t.Fatalf("workspace id = %s, want %s", service.evalSessionInput.WorkspaceID, workspaceID)
 	}
+	if service.evalSessionInput.MaxIterations == nil || *service.evalSessionInput.MaxIterations != 7 {
+		t.Fatalf("max iterations = %v, want 7", service.evalSessionInput.MaxIterations)
+	}
 	if len(service.evalSessionInput.Participants) != 1 || service.evalSessionInput.Participants[0].AgentDeploymentID == nil {
 		t.Fatalf("participants = %+v, want one participant deployment id", service.evalSessionInput.Participants)
+	}
+	if got := service.evalSessionInput.EvalSession.SeedFanout; len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Fatalf("seed fanout = %v, want [1 2]", got)
+	}
+}
+
+func TestDecodeEvalSessionConfigRejectsInvalidSeedFanout(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		code string
+	}{
+		{
+			name: "length_mismatch",
+			body: `{"strategy":"explicit","seeds":[1]}`,
+			code: "eval_session.seed_fanout.seeds.length_mismatch",
+		},
+		{
+			name: "duplicate",
+			body: `{"strategy":"explicit","seeds":[1,1]}`,
+			code: "eval_session.seed_fanout.seeds.duplicate",
+		},
+		{
+			name: "non_positive",
+			body: `{"strategy":"explicit","seeds":[1,0]}`,
+			code: "eval_session.seed_fanout.seeds.invalid",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := decodeEvalSessionConfig(json.RawMessage(`{
+				"repetitions":2,
+				"aggregation":{"method":"mean","report_variance":true,"confidence_interval":0.95},
+				"routing_task_snapshot":{"routing":{"mode":"single_agent"},"task":{"pack_version":"v1"}},
+				"seed_fanout":` + tc.body + `,
+				"schema_version":1
+			}`))
+			var validationErr evalSessionValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("error = %v, want evalSessionValidationError", err)
+			}
+			if len(validationErr.Errors) == 0 || validationErr.Errors[0].Code != tc.code {
+				t.Fatalf("validation errors = %+v, want first code %s", validationErr.Errors, tc.code)
+			}
+		})
 	}
 }
 

--- a/cli/cmd/eval_session_helpers.go
+++ b/cli/cmd/eval_session_helpers.go
@@ -48,7 +48,7 @@ func buildEvalSessionBody(workspaceID string, request runCreateRequest, repetiti
 
 	executionMode := "single_agent"
 	if len(request.DeploymentIDs) > 1 {
-		executionMode = "multi_agent"
+		executionMode = "comparison"
 	}
 
 	participants := make([]map[string]any, 0, len(request.DeploymentIDs))
@@ -132,7 +132,22 @@ func presentCreatedEvalSession(rc *RunContext, result map[string]any) error {
 
 	runIDs, _ := result["run_ids"].([]any)
 	rc.Output.PrintDetail("Run IDs", fmt.Sprintf("%d", len(runIDs)))
+	seedByRunID := map[string]string{}
+	if seededRuns, ok := result["seeded_runs"].([]any); ok {
+		for _, raw := range seededRuns {
+			item, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			seedByRunID[str(item["run_id"])] = str(item["seed"])
+		}
+	}
 	for _, id := range runIDs {
+		runID := str(id)
+		if seed := seedByRunID[runID]; seed != "" {
+			fmt.Fprintf(rc.Output.Writer(), "  - %s (seed %s)\n", runID, seed)
+			continue
+		}
 		fmt.Fprintf(rc.Output.Writer(), "  - %s\n", str(id))
 	}
 	return nil

--- a/cli/cmd/eval_session_test.go
+++ b/cli/cmd/eval_session_test.go
@@ -69,6 +69,36 @@ func TestBuildEvalSessionBody_HappyPath_SingleDeployment(t *testing.T) {
 	}
 }
 
+func TestBuildSeededEvalSessionBody(t *testing.T) {
+	body, err := buildSeededEvalSessionBody("ws-1", runCreateRequest{
+		ChallengePackVersionID: "pv-1",
+		ChallengeInputSetID:    "is-1",
+		DeploymentIDs:          []string{"dep-1"},
+		Name:                   "seeded-boardroom",
+		OfficialPackMode:       "full",
+		MaxIterations:          7,
+		Seeds:                  3,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := body["max_iterations"]; got != 7 {
+		t.Fatalf("max_iterations = %v, want 7", got)
+	}
+	session := body["eval_session"].(map[string]any)
+	if got := session["repetitions"]; got != 3 {
+		t.Fatalf("repetitions = %v, want 3", got)
+	}
+	seedFanout := session["seed_fanout"].(map[string]any)
+	if seedFanout["strategy"] != "explicit" {
+		t.Fatalf("seed_fanout.strategy = %v, want explicit", seedFanout["strategy"])
+	}
+	seeds := seedFanout["seeds"].([]int64)
+	if len(seeds) != 3 || seeds[0] != 1 || seeds[2] != 3 {
+		t.Fatalf("seeds = %v, want [1 2 3]", seeds)
+	}
+}
+
 func TestBuildEvalSessionBody_MultiDeployment_LabelsAndMode(t *testing.T) {
 	body, err := buildEvalSessionBody("ws-1", runCreateRequest{
 		ChallengePackVersionID: "pv-1",
@@ -77,8 +107,8 @@ func TestBuildEvalSessionBody_MultiDeployment_LabelsAndMode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := body["execution_mode"]; got != "multi_agent" {
-		t.Errorf("execution_mode = %v, want multi_agent", got)
+	if got := body["execution_mode"]; got != "comparison" {
+		t.Errorf("execution_mode = %v, want comparison", got)
 	}
 	participants := body["participants"].([]map[string]any)
 	if len(participants) != 3 {
@@ -254,6 +284,120 @@ func TestEvalStart_Repetitions_RoutesToEvalSessions(t *testing.T) {
 	aggregation, _ := session["aggregation"].(map[string]any)
 	if aggregation["method"] != "mean" {
 		t.Errorf("aggregation.method = %v, want mean", aggregation["method"])
+	}
+}
+
+func TestRunCreateSeedsRoutesToEvalSessions(t *testing.T) {
+	captured := map[string]any{}
+	srv := fakeAPI(t, evalStartFakeRoutes(t, &captured))
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"run", "create", "-w", "ws-1",
+		"--challenge-pack-version", "pv-1",
+		"--deployments", "dep-1",
+		"--seeds", "3",
+		"--max-iter", "7",
+	}, srv.URL); err != nil {
+		t.Fatalf("run create --seeds error: %v", err)
+	}
+
+	if _, hit := captured["__hit_runs"]; hit {
+		t.Fatal("POST /v1/runs was called; expected POST /v1/eval-sessions")
+	}
+	if captured["max_iterations"] != float64(7) {
+		t.Fatalf("max_iterations = %v, want 7", captured["max_iterations"])
+	}
+	session, ok := captured["eval_session"].(map[string]any)
+	if !ok {
+		t.Fatalf("eval_session missing in body: %#v", captured["eval_session"])
+	}
+	if r, ok := session["repetitions"].(float64); !ok || int(r) != 3 {
+		t.Fatalf("repetitions = %v, want 3", session["repetitions"])
+	}
+	seedFanout, ok := session["seed_fanout"].(map[string]any)
+	if !ok {
+		t.Fatalf("seed_fanout missing in body: %#v", session)
+	}
+	seeds, ok := seedFanout["seeds"].([]any)
+	if !ok || len(seeds) != 3 || seeds[0] != float64(1) || seeds[2] != float64(3) {
+		t.Fatalf("seeds = %#v, want [1 2 3]", seedFanout["seeds"])
+	}
+}
+
+func TestRunCreateSeedsRejectsFollow(t *testing.T) {
+	srv := fakeAPI(t, evalStartFakeRoutes(t, nil))
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{
+		"run", "create", "-w", "ws-1",
+		"--challenge-pack-version", "pv-1",
+		"--deployments", "dep-1",
+		"--seeds", "3",
+		"--follow",
+	}, srv.URL)
+	if err == nil {
+		t.Fatal("expected error when combining --seeds and --follow")
+	}
+	if !strings.Contains(err.Error(), "--follow is not supported with --seeds") {
+		t.Errorf("err = %v, want --follow/--seeds guidance", err)
+	}
+}
+
+func TestBuildSeededEvalSessionBodyRejectsUnsupportedScope(t *testing.T) {
+	_, err := buildSeededEvalSessionBody("ws-1", runCreateRequest{
+		ChallengePackVersionID: "pv-1",
+		DeploymentIDs:          []string{"dep-1"},
+		OfficialPackMode:       "suite_only",
+		Seeds:                  2,
+	})
+	if err == nil {
+		t.Fatal("expected error for suite_only with --seeds")
+	}
+	if !strings.Contains(err.Error(), "not supported with --seeds") {
+		t.Errorf("err = %v, want --seeds unsupported scope guidance", err)
+	}
+}
+
+func TestBuildSeededEvalSessionBodyRejectsInvalidFlagRanges(t *testing.T) {
+	cases := []struct {
+		name    string
+		request runCreateRequest
+		want    string
+	}{
+		{
+			name: "negative_max_iter",
+			request: runCreateRequest{
+				ChallengePackVersionID: "pv-1",
+				DeploymentIDs:          []string{"dep-1"},
+				MaxIterations:          -1,
+				Seeds:                  2,
+			},
+			want: "--max-iter",
+		},
+		{
+			name: "negative_race_context_cadence",
+			request: runCreateRequest{
+				ChallengePackVersionID: "pv-1",
+				DeploymentIDs:          []string{"dep-1"},
+				RaceContextCadence:     -1,
+				Seeds:                  2,
+			},
+			want: "--race-context-cadence",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildSeededEvalSessionBody("ws-1", tc.request)
+			if err == nil {
+				t.Fatal("expected range validation error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want %s guidance", err, tc.want)
+			}
+		})
 	}
 }
 

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -39,6 +39,7 @@ func init() {
 	runCreateCmd.Flags().Bool("race-context", false, "Enable live peer-standings injection during the run (requires 2+ agents)")
 	runCreateCmd.Flags().Int("race-context-cadence", 0, "Override race-context cadence; minimum steps between standings injections, [1, 10]. 0 uses the backend default.")
 	runCreateCmd.Flags().Int("max-iter", 0, "Override max iterations for this run (1-1000). 0 uses the pack/runtime default.")
+	runCreateCmd.Flags().Int("seeds", 0, "Create a seeded eval session with N child runs, one per seed (1-100). 0 creates a single run.")
 
 	runRankingCmd.Flags().String("sort-by", "", "Sort by: composite, correctness, reliability, latency, cost")
 	runFailuresCmd.Flags().String("agent", "", "Filter by run agent ID")
@@ -220,6 +221,22 @@ For CI and other non-interactive use, keep passing explicit IDs via flags.`,
 		request.ChallengeInputSetID = selections.challengeInputSetID
 		request.DeploymentIDs = selections.deploymentIDs
 
+		follow, _ := cmd.Flags().GetBool("follow")
+		if request.Seeds > 0 {
+			if follow {
+				return fmt.Errorf("--follow is not supported with --seeds; tail individual runs with 'agentclash run events <run-id> --follow' instead")
+			}
+			body, err := buildSeededEvalSessionBody(wsID, request)
+			if err != nil {
+				return err
+			}
+			result, err := createEvalSession(cmd, rc, body)
+			if err != nil {
+				return err
+			}
+			return presentCreatedEvalSession(rc, result)
+		}
+
 		body, err := buildRunCreateBody(wsID, request)
 		if err != nil {
 			return err
@@ -230,7 +247,6 @@ For CI and other non-interactive use, keep passing explicit IDs via flags.`,
 			return err
 		}
 
-		follow, _ := cmd.Flags().GetBool("follow")
 		return presentCreatedRun(cmd, rc, run, follow, nil)
 	},
 }

--- a/cli/cmd/run_create_helpers.go
+++ b/cli/cmd/run_create_helpers.go
@@ -11,6 +11,7 @@ import (
 )
 
 const maxRunCreateMaxIter = 1000
+const maxRunCreateSeeds = 100
 
 type runCreateRequest struct {
 	ChallengePackVersionID     string
@@ -24,6 +25,7 @@ type runCreateRequest struct {
 	RaceContext                bool
 	RaceContextCadence         int
 	MaxIterations              int
+	Seeds                      int
 	CIMetadata                 map[string]any
 }
 
@@ -61,6 +63,9 @@ func runCreateRequestFromFlags(cmd *cobra.Command, base runCreateRequest) (runCr
 	maxIterations, _ := cmd.Flags().GetInt("max-iter")
 	request.MaxIterations = maxIterations
 
+	seeds, _ := cmd.Flags().GetInt("seeds")
+	request.Seeds = seeds
+
 	return request, nil
 }
 
@@ -79,6 +84,9 @@ func buildRunCreateBody(workspaceID string, request runCreateRequest) (map[strin
 	}
 	if request.MaxIterations < 0 || request.MaxIterations > maxRunCreateMaxIter {
 		return nil, fmt.Errorf("--max-iter must be 0 (pack/runtime default) or between 1 and %d, got %d", maxRunCreateMaxIter, request.MaxIterations)
+	}
+	if request.Seeds < 0 || request.Seeds > maxRunCreateSeeds {
+		return nil, fmt.Errorf("--seeds must be 0 (single run) or between 1 and %d, got %d", maxRunCreateSeeds, request.Seeds)
 	}
 
 	body := map[string]any{
@@ -113,6 +121,43 @@ func buildRunCreateBody(workspaceID string, request runCreateRequest) (map[strin
 	}
 	if len(request.CIMetadata) > 0 {
 		body["ci_metadata"] = request.CIMetadata
+	}
+	return body, nil
+}
+
+func buildSeededEvalSessionBody(workspaceID string, request runCreateRequest) (map[string]any, error) {
+	if request.Seeds < 1 || request.Seeds > maxRunCreateSeeds {
+		return nil, fmt.Errorf("--seeds must be between 1 and %d, got %d", maxRunCreateSeeds, request.Seeds)
+	}
+	if request.RaceContextCadence < 0 || request.RaceContextCadence > 10 {
+		return nil, fmt.Errorf("--race-context-cadence must be 0 (backend default) or between 1 and 10, got %d", request.RaceContextCadence)
+	}
+	if request.MaxIterations < 0 || request.MaxIterations > maxRunCreateMaxIter {
+		return nil, fmt.Errorf("--max-iter must be 0 (pack/runtime default) or between 1 and %d, got %d", maxRunCreateMaxIter, request.MaxIterations)
+	}
+	if len(request.RegressionSuiteIDs) > 0 || len(request.RegressionCaseIDs) > 0 || request.OfficialPackMode == "suite_only" {
+		return nil, fmt.Errorf("--scope suite_only / --suite / --case are not supported with --seeds")
+	}
+	if request.RaceContext || request.RaceContextCadence > 0 {
+		return nil, fmt.Errorf("--race-context flags are not supported with --seeds")
+	}
+	sessionRequest := request
+	sessionRequest.MaxIterations = 0
+	body, err := buildEvalSessionBody(workspaceID, sessionRequest, request.Seeds)
+	if err != nil {
+		return nil, err
+	}
+	if request.MaxIterations > 0 {
+		body["max_iterations"] = request.MaxIterations
+	}
+	session := body["eval_session"].(map[string]any)
+	seeds := make([]int64, 0, request.Seeds)
+	for seed := 1; seed <= request.Seeds; seed++ {
+		seeds = append(seeds, int64(seed))
+	}
+	session["seed_fanout"] = map[string]any{
+		"strategy": "explicit",
+		"seeds":    seeds,
 	}
 	return body, nil
 }

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -6912,6 +6912,13 @@ components:
             `comparison` for multiple participants.
         name:
           type: string
+        max_iterations:
+          type: integer
+          minimum: 1
+          maximum: 1000
+          description: >
+            Optional. Applies the same native-agent iteration budget override
+            to every child run in the eval session.
         eval_session:
           $ref: "#/components/schemas/CreateEvalSessionConfig"
 
@@ -6954,6 +6961,8 @@ components:
             - $ref: "#/components/schemas/EvalSessionReliabilityWeightsConfig"
             - type: "null"
           description: Optional. Explicit `null` is treated the same as omission.
+        seed_fanout:
+          $ref: "#/components/schemas/EvalSessionSeedFanoutConfig"
         schema_version:
           type: integer
           minimum: 1
@@ -7032,6 +7041,23 @@ components:
           type: object
           additionalProperties: true
 
+    EvalSessionSeedFanoutConfig:
+      type: object
+      required: [strategy, seeds]
+      properties:
+        strategy:
+          type: string
+          enum: [explicit]
+        seeds:
+          type: array
+          minItems: 1
+          maxItems: 100
+          uniqueItems: true
+          items:
+            type: integer
+            minimum: 1
+          description: Must contain exactly one seed per requested repetition.
+
     CreateEvalSessionResponse:
       type: object
       required: [eval_session, run_ids]
@@ -7043,6 +7069,21 @@ components:
           items:
             type: string
             format: uuid
+        seeded_runs:
+          type: array
+          items:
+            $ref: "#/components/schemas/EvalSessionSeededRun"
+
+    EvalSessionSeededRun:
+      type: object
+      required: [run_id, seed]
+      properties:
+        run_id:
+          type: string
+          format: uuid
+        seed:
+          type: integer
+          minimum: 1
 
     EvalSessionResponse:
       type: object
@@ -7425,6 +7466,10 @@ components:
           $ref: "#/components/schemas/RunStatus"
         execution_mode:
           type: string
+        seed:
+          type: integer
+          minimum: 1
+          description: Seed assigned to this child run when the eval session was created via seeded fanout.
         queued_at:
           type: string
           format: date-time


### PR DESCRIPTION
## Summary
- add `agentclash run create --seeds N` to create a seeded eval session with one child run per seed
- persist explicit seed fanout metadata on the eval-session routing snapshot and child run execution plans
- surface `seeded_runs` from eval-session creation and `seed` on eval-session child-run reads
- support `--max-iter` for seeded eval sessions and document the new API shape

## Compatibility note
- `buildEvalSessionBody` now sends `execution_mode: "comparison"` for multi-deployment eval sessions. This is the backend-supported value; the previous CLI value, `"multi_agent"`, was rejected by the eval-session API, so this fixes the existing `--repetitions` multi-deployment path rather than changing stored backend semantics.

## Tests
- `cd backend && go test ./internal/api -run 'TestGetEvalSessionEndpointReturnsDetail|TestCreateEvalSessionEndpointReturnsCreated|TestDecodeEvalSessionConfigRejectsInvalidSeedFanout|TestRunCreationManagerCreateEvalSessionPersistsSeedFanout' -count=1`
- `cd cli && go test ./cmd -run 'TestBuildSeededEvalSessionBody|TestRunCreateSeedsRoutesToEvalSessions|TestRunCreateSeedsRejectsFollow|TestBuildSeededEvalSessionBodyRejectsUnsupportedScope|TestBuildSeededEvalSessionBodyRejectsInvalidFlagRanges|TestBuildEvalSessionBody_MultiDeployment_LabelsAndMode' -count=1`
- `git diff --check`
- `cd backend && go test ./...`
- `cd backend && go vet ./...`
- `cd cli && go build ./...`
- `cd cli && go vet ./...`
- `cd cli && go test -short -race -count=1 ./...`
- `cd cli && go run github.com/goreleaser/goreleaser/v2@latest check`

Fixes #699
