### PR TITLE
feat: add challenge pack deployment lineups

### DIFF
--- a/backend/db/queries/challenge_packs.sql
+++ b/backend/db/queries/challenge_packs.sql
@@ -5,7 +5,7 @@ WHERE cp.archived_at IS NULL
 ORDER BY cp.name ASC;
 
 -- name: ListRunnableChallengePVersionsByPackID :many
-SELECT id, challenge_pack_id, version_number, lifecycle_status, created_at, updated_at
+SELECT id, challenge_pack_id, version_number, lifecycle_status, manifest, created_at, updated_at
 FROM challenge_pack_versions
 WHERE challenge_pack_id = @challenge_pack_id
   AND lifecycle_status = 'runnable'

--- a/backend/internal/api/challenge_packs.go
+++ b/backend/internal/api/challenge_packs.go
@@ -255,12 +255,13 @@ type challengePackResponse struct {
 }
 
 type challengePackVersionResponse struct {
-	ID              uuid.UUID `json:"id"`
-	ChallengePackID uuid.UUID `json:"challenge_pack_id"`
-	VersionNumber   int32     `json:"version_number"`
-	LifecycleStatus string    `json:"lifecycle_status"`
-	CreatedAt       time.Time `json:"created_at"`
-	UpdatedAt       time.Time `json:"updated_at"`
+	ID                 uuid.UUID       `json:"id"`
+	ChallengePackID    uuid.UUID       `json:"challenge_pack_id"`
+	VersionNumber      int32           `json:"version_number"`
+	LifecycleStatus    string          `json:"lifecycle_status"`
+	DeploymentDefaults json.RawMessage `json:"deployment_defaults,omitempty"`
+	CreatedAt          time.Time       `json:"created_at"`
+	UpdatedAt          time.Time       `json:"updated_at"`
 }
 
 type listChallengePacksResponse struct {
@@ -296,12 +297,13 @@ func listChallengePacksHandler(logger *slog.Logger, service ChallengePackReadSer
 			versions := make([]challengePackVersionResponse, 0, len(packWithVersions.Versions))
 			for _, v := range packWithVersions.Versions {
 				versions = append(versions, challengePackVersionResponse{
-					ID:              v.ID,
-					ChallengePackID: v.ChallengePackID,
-					VersionNumber:   v.VersionNumber,
-					LifecycleStatus: v.LifecycleStatus,
-					CreatedAt:       v.CreatedAt,
-					UpdatedAt:       v.UpdatedAt,
+					ID:                 v.ID,
+					ChallengePackID:    v.ChallengePackID,
+					VersionNumber:      v.VersionNumber,
+					LifecycleStatus:    v.LifecycleStatus,
+					DeploymentDefaults: v.DeploymentDefaults,
+					CreatedAt:          v.CreatedAt,
+					UpdatedAt:          v.UpdatedAt,
 				})
 			}
 

--- a/backend/internal/api/challenge_packs_test.go
+++ b/backend/internal/api/challenge_packs_test.go
@@ -22,6 +22,7 @@ type fakeChallengePackReadRepository struct {
 	lastWorkspaceID uuid.UUID
 	runnableVersion repository.RunnableChallengePackVersion
 	inputSets       []repository.ChallengeInputSetSummary
+	versionDefaults json.RawMessage
 }
 
 func (f *fakeChallengePackReadRepository) ListVisibleChallengePacks(_ context.Context, workspaceID uuid.UUID) ([]repository.ChallengePackSummary, error) {
@@ -40,12 +41,13 @@ func (f *fakeChallengePackReadRepository) ListVisibleChallengePacks(_ context.Co
 func (f *fakeChallengePackReadRepository) ListRunnableChallengePVersionsByPackID(_ context.Context, challengePackID uuid.UUID) ([]repository.ChallengePackVersionSummary, error) {
 	return []repository.ChallengePackVersionSummary{
 		{
-			ID:              uuid.New(),
-			ChallengePackID: challengePackID,
-			VersionNumber:   1,
-			LifecycleStatus: "runnable",
-			CreatedAt:       time.Now().UTC(),
-			UpdatedAt:       time.Now().UTC(),
+			ID:                 uuid.New(),
+			ChallengePackID:    challengePackID,
+			VersionNumber:      1,
+			LifecycleStatus:    "runnable",
+			DeploymentDefaults: f.versionDefaults,
+			CreatedAt:          time.Now().UTC(),
+			UpdatedAt:          time.Now().UTC(),
 		},
 	}, nil
 }
@@ -177,6 +179,45 @@ func TestListChallengePacksHandlerIncludesSlug(t *testing.T) {
 	}
 	if response.Items[0].Slug != "workspace-pack" {
 		t.Fatalf("slug = %q, want workspace-pack", response.Items[0].Slug)
+	}
+}
+
+func TestListChallengePacksHandlerIncludesDeploymentDefaults(t *testing.T) {
+	workspaceID := uuid.New()
+	manager := NewChallengePackReadManager(&fakeChallengePackReadRepository{
+		versionDefaults: json.RawMessage(`{"aliases":{"candidate":"Candidate Agent"},"lineups":{"default":["candidate"]}}`),
+	})
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	handler := listChallengePacksHandler(logger, manager)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/workspaces/"+workspaceID.String()+"/challenge-packs", nil)
+	req = req.WithContext(context.WithValue(req.Context(), workspaceIDContextKey{}, workspaceID))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var response listChallengePacksResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Items) != 1 || len(response.Items[0].Versions) != 1 {
+		t.Fatalf("versions = %+v, want one version", response.Items)
+	}
+	var defaults struct {
+		Aliases map[string]string   `json:"aliases"`
+		Lineups map[string][]string `json:"lineups"`
+	}
+	if err := json.Unmarshal(response.Items[0].Versions[0].DeploymentDefaults, &defaults); err != nil {
+		t.Fatalf("decode deployment defaults: %v", err)
+	}
+	if defaults.Aliases["candidate"] != "Candidate Agent" {
+		t.Fatalf("candidate alias = %q, want Candidate Agent", defaults.Aliases["candidate"])
+	}
+	if got := defaults.Lineups["default"]; len(got) != 1 || got[0] != "candidate" {
+		t.Fatalf("default lineup = %#v, want [candidate]", got)
 	}
 }
 

--- a/backend/internal/challengepack/bundle.go
+++ b/backend/internal/challengepack/bundle.go
@@ -27,13 +27,14 @@ type PackMetadata struct {
 }
 
 type VersionMetadata struct {
-	Number         int32                  `yaml:"number" json:"number"`
-	ExecutionMode  string                 `yaml:"execution_mode,omitempty" json:"execution_mode,omitempty"`
-	ToolPolicy     map[string]any         `yaml:"tool_policy,omitempty" json:"tool_policy,omitempty"`
-	Filesystem     map[string]any         `yaml:"filesystem,omitempty" json:"filesystem,omitempty"`
-	Sandbox        *SandboxConfig         `yaml:"sandbox,omitempty" json:"sandbox,omitempty"`
-	EvaluationSpec scoring.EvaluationSpec `yaml:"evaluation_spec" json:"evaluation_spec"`
-	Assets         []AssetReference       `yaml:"assets,omitempty" json:"assets,omitempty"`
+	Number             int32                  `yaml:"number" json:"number"`
+	ExecutionMode      string                 `yaml:"execution_mode,omitempty" json:"execution_mode,omitempty"`
+	ToolPolicy         map[string]any         `yaml:"tool_policy,omitempty" json:"tool_policy,omitempty"`
+	Filesystem         map[string]any         `yaml:"filesystem,omitempty" json:"filesystem,omitempty"`
+	Sandbox            *SandboxConfig         `yaml:"sandbox,omitempty" json:"sandbox,omitempty"`
+	DeploymentDefaults *DeploymentDefaults    `yaml:"deployment_defaults,omitempty" json:"deployment_defaults,omitempty"`
+	EvaluationSpec     scoring.EvaluationSpec `yaml:"evaluation_spec" json:"evaluation_spec"`
+	Assets             []AssetReference       `yaml:"assets,omitempty" json:"assets,omitempty"`
 }
 
 const (
@@ -47,6 +48,11 @@ type SandboxConfig struct {
 	EnvVars            map[string]string `yaml:"env_vars,omitempty" json:"env_vars,omitempty"`
 	AdditionalPackages []string          `yaml:"additional_packages,omitempty" json:"additional_packages,omitempty"`
 	SandboxTemplateID  string            `yaml:"sandbox_template_id,omitempty" json:"sandbox_template_id,omitempty"`
+}
+
+type DeploymentDefaults struct {
+	Aliases map[string]string   `yaml:"aliases,omitempty" json:"aliases,omitempty"`
+	Lineups map[string][]string `yaml:"lineups,omitempty" json:"lineups,omitempty"`
 }
 
 type ChallengeDefinition struct {
@@ -132,13 +138,14 @@ func ParseYAML(data []byte) (Bundle, error) {
 	}
 
 	type rawVersionMetadata struct {
-		Number         int32            `yaml:"number"`
-		ExecutionMode  string           `yaml:"execution_mode,omitempty"`
-		ToolPolicy     map[string]any   `yaml:"tool_policy,omitempty"`
-		Filesystem     map[string]any   `yaml:"filesystem,omitempty"`
-		Sandbox        *SandboxConfig   `yaml:"sandbox,omitempty"`
-		EvaluationSpec map[string]any   `yaml:"evaluation_spec"`
-		Assets         []AssetReference `yaml:"assets,omitempty"`
+		Number             int32               `yaml:"number"`
+		ExecutionMode      string              `yaml:"execution_mode,omitempty"`
+		ToolPolicy         map[string]any      `yaml:"tool_policy,omitempty"`
+		Filesystem         map[string]any      `yaml:"filesystem,omitempty"`
+		Sandbox            *SandboxConfig      `yaml:"sandbox,omitempty"`
+		DeploymentDefaults *DeploymentDefaults `yaml:"deployment_defaults,omitempty"`
+		EvaluationSpec     map[string]any      `yaml:"evaluation_spec"`
+		Assets             []AssetReference    `yaml:"assets,omitempty"`
 	}
 	type rawBundle struct {
 		Pack       PackMetadata          `yaml:"pack"`
@@ -171,13 +178,14 @@ func ParseYAML(data []byte) (Bundle, error) {
 	bundle := Bundle{
 		Pack: raw.Pack,
 		Version: VersionMetadata{
-			Number:         raw.Version.Number,
-			ExecutionMode:  raw.Version.ExecutionMode,
-			ToolPolicy:     raw.Version.ToolPolicy,
-			Filesystem:     raw.Version.Filesystem,
-			Sandbox:        raw.Version.Sandbox,
-			EvaluationSpec: evaluationSpec,
-			Assets:         raw.Version.Assets,
+			Number:             raw.Version.Number,
+			ExecutionMode:      raw.Version.ExecutionMode,
+			ToolPolicy:         raw.Version.ToolPolicy,
+			Filesystem:         raw.Version.Filesystem,
+			Sandbox:            raw.Version.Sandbox,
+			DeploymentDefaults: raw.Version.DeploymentDefaults,
+			EvaluationSpec:     evaluationSpec,
+			Assets:             raw.Version.Assets,
 		},
 		Tools:      raw.Tools,
 		Challenges: raw.Challenges,
@@ -205,6 +213,9 @@ func ManifestJSON(bundle Bundle) (json.RawMessage, error) {
 	}
 	if normalized.Version.Sandbox != nil {
 		versionMap["sandbox_template_id"] = normalized.Version.Sandbox.SandboxTemplateID
+	}
+	if normalized.Version.DeploymentDefaults != nil {
+		versionMap["deployment_defaults"] = normalized.Version.DeploymentDefaults
 	}
 
 	manifest := map[string]any{
@@ -237,6 +248,7 @@ func normalizeBundle(bundle *Bundle) {
 	bundle.Pack.Name = strings.TrimSpace(bundle.Pack.Name)
 	bundle.Pack.Family = strings.TrimSpace(bundle.Pack.Family)
 	bundle.Version.ExecutionMode = strings.TrimSpace(bundle.Version.ExecutionMode)
+	bundle.Version.DeploymentDefaults = normalizeDeploymentDefaults(bundle.Version.DeploymentDefaults)
 	bundle.Challenges = append([]ChallengeDefinition(nil), bundle.Challenges...)
 	bundle.InputSets = append([]InputSetDefinition(nil), bundle.InputSets...)
 	bundle.Version.Assets = append([]AssetReference(nil), bundle.Version.Assets...)
@@ -297,6 +309,34 @@ func normalizeBundle(bundle *Bundle) {
 	}
 
 	bundle.Version.Assets = normalizeAssets(bundle.Version.Assets)
+}
+
+func normalizeDeploymentDefaults(defaults *DeploymentDefaults) *DeploymentDefaults {
+	if defaults == nil {
+		return nil
+	}
+
+	normalized := &DeploymentDefaults{}
+	if len(defaults.Aliases) > 0 {
+		normalized.Aliases = make(map[string]string, len(defaults.Aliases))
+		for key, value := range defaults.Aliases {
+			normalized.Aliases[strings.TrimSpace(key)] = strings.TrimSpace(value)
+		}
+	}
+	if len(defaults.Lineups) > 0 {
+		normalized.Lineups = make(map[string][]string, len(defaults.Lineups))
+		for key, values := range defaults.Lineups {
+			lineup := make([]string, 0, len(values))
+			for _, value := range values {
+				lineup = append(lineup, strings.TrimSpace(value))
+			}
+			normalized.Lineups[strings.TrimSpace(key)] = lineup
+		}
+	}
+	if len(normalized.Aliases) == 0 && len(normalized.Lineups) == 0 {
+		return nil
+	}
+	return normalized
 }
 
 func normalizeAssets(assets []AssetReference) []AssetReference {

--- a/backend/internal/challengepack/bundle_test.go
+++ b/backend/internal/challengepack/bundle_test.go
@@ -97,6 +97,122 @@ tools:
 	}
 }
 
+func TestParseYAMLDeploymentDefaultsRoundTrip(t *testing.T) {
+	bundle, err := ParseYAML([]byte(`
+pack:
+  slug: support-eval
+  name: Support Eval
+  family: support
+version:
+  number: 1
+  deployment_defaults:
+    aliases:
+      candidate: " Candidate Agent "
+      baseline: Baseline Agent
+    lineups:
+      default: ["candidate", "baseline"]
+      smoke: ["candidate"]
+  evaluation_spec:
+    name: support-v1
+    version_number: 1
+    judge_mode: deterministic
+    validators:
+      - key: exact
+        type: exact_match
+        target: final_output
+        expected_from: challenge_input
+    scorecard:
+      dimensions: [correctness]
+challenges:
+  - key: ticket-1
+    title: Ticket One
+    category: support
+    difficulty: medium
+input_sets:
+  - key: default
+    name: Default Inputs
+    cases:
+      - challenge_key: ticket-1
+        case_key: sample-1
+        inputs:
+          - key: prompt
+            kind: text
+            value: hello
+        expectations:
+          - key: answer
+            kind: text
+            source: input:prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseYAML returned error: %v", err)
+	}
+	if bundle.Version.DeploymentDefaults == nil {
+		t.Fatal("deployment defaults missing")
+	}
+	if got := bundle.Version.DeploymentDefaults.Aliases["candidate"]; got != "Candidate Agent" {
+		t.Fatalf("candidate alias = %q, want Candidate Agent", got)
+	}
+
+	manifest, err := ManifestJSON(bundle)
+	if err != nil {
+		t.Fatalf("ManifestJSON returned error: %v", err)
+	}
+	var decoded struct {
+		Version struct {
+			DeploymentDefaults DeploymentDefaults `json:"deployment_defaults"`
+		} `json:"version"`
+	}
+	if err := json.Unmarshal(manifest, &decoded); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	if got := decoded.Version.DeploymentDefaults.Lineups["default"]; len(got) != 2 || got[0] != "candidate" || got[1] != "baseline" {
+		t.Fatalf("default lineup = %#v, want [candidate baseline]", got)
+	}
+}
+
+func TestValidateBundleRejectsDeploymentDefaultsWithoutDefaultLineup(t *testing.T) {
+	bundle := minimalBundle()
+	bundle.Version.DeploymentDefaults = &DeploymentDefaults{
+		Aliases: map[string]string{"candidate": "Candidate Agent"},
+		Lineups: map[string][]string{"smoke": []string{"candidate"}},
+	}
+
+	err := ValidateBundle(bundle)
+	if err == nil {
+		t.Fatal("ValidateBundle returned nil error")
+	}
+	errs, ok := err.(ValidationErrors)
+	if !ok {
+		t.Fatalf("error type = %T, want ValidationErrors", err)
+	}
+	if !containsField(errs, "version.deployment_defaults.lineups.default") {
+		t.Fatalf("validation errors = %+v, want default lineup error", errs)
+	}
+}
+
+func TestValidateBundleRejectsEmptyDeploymentDefaultSelectors(t *testing.T) {
+	bundle := minimalBundle()
+	bundle.Version.DeploymentDefaults = &DeploymentDefaults{
+		Aliases: map[string]string{"candidate": ""},
+		Lineups: map[string][]string{"default": []string{""}},
+	}
+
+	err := ValidateBundle(bundle)
+	if err == nil {
+		t.Fatal("ValidateBundle returned nil error")
+	}
+	errs, ok := err.(ValidationErrors)
+	if !ok {
+		t.Fatalf("error type = %T, want ValidationErrors", err)
+	}
+	if !containsField(errs, "version.deployment_defaults.aliases[\"candidate\"]") {
+		t.Fatalf("validation errors = %+v, want empty alias error", errs)
+	}
+	if !containsField(errs, "version.deployment_defaults.lineups[\"default\"][0]") {
+		t.Fatalf("validation errors = %+v, want empty lineup selector error", errs)
+	}
+}
+
 func TestManifestJSONPreservesGeneralizedContract(t *testing.T) {
 	bundle := Bundle{
 		Pack: PackMetadata{
@@ -773,6 +889,46 @@ func minimalSpec() scoring.EvaluationSpec {
 		},
 		Scorecard: scoring.ScorecardDeclaration{
 			Dimensions: []scoring.DimensionDeclaration{{Key: "correctness"}},
+		},
+	}
+}
+
+func minimalBundle() Bundle {
+	return Bundle{
+		Pack: PackMetadata{
+			Slug:   "support-eval",
+			Name:   "Support Eval",
+			Family: "support",
+		},
+		Version: VersionMetadata{
+			Number:         1,
+			EvaluationSpec: minimalSpec(),
+		},
+		Challenges: []ChallengeDefinition{
+			{
+				Key:        "ticket-1",
+				Title:      "Ticket One",
+				Category:   "support",
+				Difficulty: "easy",
+			},
+		},
+		InputSets: []InputSetDefinition{
+			{
+				Key:  "default",
+				Name: "Default",
+				Cases: []CaseDefinition{
+					{
+						ChallengeKey: "ticket-1",
+						CaseKey:      "case-1",
+						Inputs: []CaseInput{
+							{Key: "prompt", Kind: "text", Value: "hello"},
+						},
+						Expectations: []CaseExpectation{
+							{Key: "answer", Kind: "text", Source: "input:prompt"},
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/backend/internal/challengepack/validation.go
+++ b/backend/internal/challengepack/validation.go
@@ -174,6 +174,7 @@ func ValidateBundle(bundle Bundle) error {
 	if bundle.Version.Sandbox != nil {
 		errs = append(errs, validateSandboxConfig("version.sandbox", bundle.Version.Sandbox)...)
 	}
+	errs = append(errs, validateDeploymentDefaults("version.deployment_defaults", bundle.Version.DeploymentDefaults)...)
 
 	if err := scoring.ValidateEvaluationSpec(bundle.Version.EvaluationSpec); err != nil {
 		if scoringErrs, ok := err.(scoring.ValidationErrors); ok {
@@ -190,6 +191,66 @@ func ValidateBundle(bundle Bundle) error {
 		return errs
 	}
 	return nil
+}
+
+func validateDeploymentDefaults(path string, defaults *DeploymentDefaults) ValidationErrors {
+	if defaults == nil {
+		return nil
+	}
+
+	var errs ValidationErrors
+	seenAliasKeys := map[string]struct{}{}
+	for key, value := range defaults.Aliases {
+		field := fmt.Sprintf("%s.aliases[%q]", path, key)
+		if strings.TrimSpace(key) == "" {
+			errs = append(errs, ValidationError{Field: field, Message: "key is required"})
+			continue
+		}
+		normalizedKey := strings.TrimSpace(key)
+		if _, exists := seenAliasKeys[normalizedKey]; exists {
+			errs = append(errs, ValidationError{Field: field, Message: "key must be unique after trimming whitespace"})
+		}
+		seenAliasKeys[normalizedKey] = struct{}{}
+		if strings.TrimSpace(value) == "" {
+			errs = append(errs, ValidationError{Field: field, Message: "selector is required"})
+		}
+	}
+
+	if len(defaults.Lineups) == 0 {
+		errs = append(errs, ValidationError{Field: path + ".lineups", Message: "must include at least a default lineup"})
+		return errs
+	}
+	if _, ok := defaults.Lineups["default"]; !ok {
+		errs = append(errs, ValidationError{Field: path + ".lineups.default", Message: "is required"})
+	}
+
+	seenLineupKeys := map[string]struct{}{}
+	for key, values := range defaults.Lineups {
+		field := fmt.Sprintf("%s.lineups[%q]", path, key)
+		if strings.TrimSpace(key) == "" {
+			errs = append(errs, ValidationError{Field: field, Message: "key is required"})
+			continue
+		}
+		normalizedKey := strings.TrimSpace(key)
+		if _, exists := seenLineupKeys[normalizedKey]; exists {
+			errs = append(errs, ValidationError{Field: field, Message: "key must be unique after trimming whitespace"})
+		}
+		seenLineupKeys[normalizedKey] = struct{}{}
+		if len(values) == 0 {
+			errs = append(errs, ValidationError{Field: field, Message: "must include at least one deployment selector"})
+			continue
+		}
+		for i, value := range values {
+			if strings.TrimSpace(value) == "" {
+				errs = append(errs, ValidationError{
+					Field:   fmt.Sprintf("%s[%d]", field, i),
+					Message: "selector is required",
+				})
+			}
+		}
+	}
+
+	return errs
 }
 
 func validateToolPolicyConfig(path string, policy map[string]any) ValidationErrors {

--- a/backend/internal/repository/challenge_pack_defaults_test.go
+++ b/backend/internal/repository/challenge_pack_defaults_test.go
@@ -1,0 +1,34 @@
+package repository
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestChallengePackDeploymentDefaultsExtractsVersionDefaults(t *testing.T) {
+	defaults, err := challengePackDeploymentDefaults([]byte(`{
+		"schema_version": 1,
+		"version": {
+			"deployment_defaults": {
+				"aliases": {"candidate": "Candidate Agent"},
+				"lineups": {"default": ["candidate"]}
+			}
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("challengePackDeploymentDefaults returned error: %v", err)
+	}
+	if !strings.Contains(string(defaults), `"candidate"`) {
+		t.Fatalf("defaults = %s, want candidate alias", defaults)
+	}
+}
+
+func TestChallengePackDeploymentDefaultsRejectsMalformedManifest(t *testing.T) {
+	_, err := challengePackDeploymentDefaults([]byte(`{"version":`))
+	if err == nil {
+		t.Fatal("challengePackDeploymentDefaults returned nil error")
+	}
+	if !strings.Contains(err.Error(), "decode challenge pack manifest") {
+		t.Fatalf("error = %q, want decode context", err.Error())
+	}
+}

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -2718,12 +2718,13 @@ type ChallengePackSummary struct {
 }
 
 type ChallengePackVersionSummary struct {
-	ID              uuid.UUID
-	ChallengePackID uuid.UUID
-	VersionNumber   int32
-	LifecycleStatus string
-	CreatedAt       time.Time
-	UpdatedAt       time.Time
+	ID                 uuid.UUID
+	ChallengePackID    uuid.UUID
+	VersionNumber      int32
+	LifecycleStatus    string
+	DeploymentDefaults json.RawMessage
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
 }
 
 func (r *Repository) ListChallengePacks(ctx context.Context) ([]ChallengePackSummary, error) {
@@ -2774,17 +2775,42 @@ func (r *Repository) ListRunnableChallengePVersionsByPackID(ctx context.Context,
 			return nil, err
 		}
 
+		deploymentDefaults, err := challengePackDeploymentDefaults(row.Manifest)
+		if err != nil {
+			return nil, fmt.Errorf("extract deployment defaults for challenge pack version %s: %w", row.ID, err)
+		}
+
 		versions = append(versions, ChallengePackVersionSummary{
-			ID:              row.ID,
-			ChallengePackID: row.ChallengePackID,
-			VersionNumber:   row.VersionNumber,
-			LifecycleStatus: row.LifecycleStatus,
-			CreatedAt:       createdAt,
-			UpdatedAt:       updatedAt,
+			ID:                 row.ID,
+			ChallengePackID:    row.ChallengePackID,
+			VersionNumber:      row.VersionNumber,
+			LifecycleStatus:    row.LifecycleStatus,
+			DeploymentDefaults: deploymentDefaults,
+			CreatedAt:          createdAt,
+			UpdatedAt:          updatedAt,
 		})
 	}
 
 	return versions, nil
+}
+
+func challengePackDeploymentDefaults(manifest json.RawMessage) (json.RawMessage, error) {
+	if len(manifest) == 0 {
+		return nil, nil
+	}
+
+	var decoded struct {
+		Version struct {
+			DeploymentDefaults json.RawMessage `json:"deployment_defaults"`
+		} `json:"version"`
+	}
+	if err := json.Unmarshal(manifest, &decoded); err != nil {
+		return nil, fmt.Errorf("decode challenge pack manifest: %w", err)
+	}
+	if len(decoded.Version.DeploymentDefaults) == 0 || string(decoded.Version.DeploymentDefaults) == "null" {
+		return nil, nil
+	}
+	return cloneJSON(decoded.Version.DeploymentDefaults), nil
 }
 
 var (

--- a/backend/internal/repository/sqlc/challenge_packs.sql.go
+++ b/backend/internal/repository/sqlc/challenge_packs.sql.go
@@ -54,7 +54,7 @@ func (q *Queries) ListChallengePacks(ctx context.Context) ([]ListChallengePacksR
 }
 
 const listRunnableChallengePVersionsByPackID = `-- name: ListRunnableChallengePVersionsByPackID :many
-SELECT id, challenge_pack_id, version_number, lifecycle_status, created_at, updated_at
+SELECT id, challenge_pack_id, version_number, lifecycle_status, manifest, created_at, updated_at
 FROM challenge_pack_versions
 WHERE challenge_pack_id = $1
   AND lifecycle_status = 'runnable'
@@ -71,6 +71,7 @@ type ListRunnableChallengePVersionsByPackIDRow struct {
 	ChallengePackID uuid.UUID
 	VersionNumber   int32
 	LifecycleStatus string
+	Manifest        []byte
 	CreatedAt       pgtype.Timestamptz
 	UpdatedAt       pgtype.Timestamptz
 }
@@ -89,6 +90,7 @@ func (q *Queries) ListRunnableChallengePVersionsByPackID(ctx context.Context, ar
 			&i.ChallengePackID,
 			&i.VersionNumber,
 			&i.LifecycleStatus,
+			&i.Manifest,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -29,6 +29,7 @@ func init() {
 
 	runCreateCmd.Flags().String("challenge-pack-version", "", "Challenge pack version ID (optional in a TTY; prompted when omitted)")
 	runCreateCmd.Flags().StringSlice("deployments", nil, "Agent deployment IDs (optional in a TTY; prompted when omitted)")
+	runCreateCmd.Flags().String("deployment-lineup", "", "Challenge pack deployment lineup to use when --deployments is omitted (default: default)")
 	runCreateCmd.Flags().String("name", "", "Run name (optional)")
 	runCreateCmd.Flags().String("input-set", "", "Challenge input set ID (optional)")
 	runCreateCmd.Flags().Bool("follow", false, "Follow run events after creation")

--- a/cli/cmd/run_create_interactive.go
+++ b/cli/cmd/run_create_interactive.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -14,9 +15,15 @@ type challengePackSummary struct {
 }
 
 type challengePackVersionBrief struct {
-	ID              string `json:"id"`
-	VersionNumber   int    `json:"version_number"`
-	LifecycleStatus string `json:"lifecycle_status"`
+	ID                 string              `json:"id"`
+	VersionNumber      int                 `json:"version_number"`
+	LifecycleStatus    string              `json:"lifecycle_status"`
+	DeploymentDefaults *deploymentDefaults `json:"deployment_defaults,omitempty"`
+}
+
+type deploymentDefaults struct {
+	Aliases map[string]string   `json:"aliases,omitempty"`
+	Lineups map[string][]string `json:"lineups,omitempty"`
 }
 
 type challengeInputSetSummary struct {
@@ -41,7 +48,11 @@ type runCreateSelections struct {
 func resolveRunCreateSelections(cmd *cobra.Command, rc *RunContext, workspaceID string) (runCreateSelections, error) {
 	cpvID, _ := cmd.Flags().GetString("challenge-pack-version")
 	deployments, _ := cmd.Flags().GetStringSlice("deployments")
+	lineup, _ := cmd.Flags().GetString("deployment-lineup")
 	inputSetID, _ := cmd.Flags().GetString("input-set")
+	if len(deployments) > 0 && strings.TrimSpace(lineup) != "" {
+		return runCreateSelections{}, fmt.Errorf("--deployment-lineup cannot be combined with --deployments")
+	}
 
 	selections := runCreateSelections{
 		challengePackVersionID: cpvID,
@@ -49,7 +60,18 @@ func resolveRunCreateSelections(cmd *cobra.Command, rc *RunContext, workspaceID 
 		deploymentIDs:          deployments,
 	}
 
-	if !isInteractiveTerminal(rc) {
+	interactive := isInteractiveTerminal(rc)
+	if selections.challengePackVersionID != "" && len(selections.deploymentIDs) == 0 && !interactive {
+		resolved, ok, err := resolveDefaultDeploymentLineup(cmd, rc, workspaceID, selections.challengePackVersionID, lineup)
+		if err != nil {
+			return runCreateSelections{}, err
+		}
+		if ok {
+			selections.deploymentIDs = resolved
+		}
+	}
+
+	if !interactive {
 		missing := missingRunCreateInputs(selections)
 		if len(missing) > 0 {
 			return runCreateSelections{}, fmt.Errorf(
@@ -84,6 +106,14 @@ func resolveRunCreateSelections(cmd *cobra.Command, rc *RunContext, workspaceID 
 	}
 
 	if len(selections.deploymentIDs) == 0 {
+		resolved, ok, err := resolveDefaultDeploymentLineup(cmd, rc, workspaceID, selections.challengePackVersionID, lineup)
+		if err != nil {
+			return runCreateSelections{}, err
+		}
+		if ok {
+			selections.deploymentIDs = resolved
+			return selections, nil
+		}
 		selectedDeployments, err := promptForDeployments(cmd, rc, workspaceID, picker)
 		if err != nil {
 			return runCreateSelections{}, err
@@ -111,7 +141,7 @@ func missingRunCreateFlags(selections runCreateSelections) []string {
 		missing = append(missing, "--challenge-pack-version")
 	}
 	if len(selections.deploymentIDs) == 0 {
-		missing = append(missing, "--deployments")
+		missing = append(missing, "--deployments or --deployment-lineup")
 	}
 	return missing
 }
@@ -224,6 +254,119 @@ func promptForDeployments(cmd *cobra.Command, rc *RunContext, workspaceID string
 		ids = append(ids, deployment.Value)
 	}
 	return ids, nil
+}
+
+func resolveDefaultDeploymentLineup(cmd *cobra.Command, rc *RunContext, workspaceID, challengePackVersionID, lineup string) ([]string, bool, error) {
+	version, ok, err := findChallengePackVersion(cmd, rc, workspaceID, challengePackVersionID)
+	if err != nil {
+		return nil, false, err
+	}
+	if !ok {
+		if strings.TrimSpace(lineup) != "" {
+			return nil, false, fmt.Errorf("challenge pack version %s was not found while resolving deployment lineup", challengePackVersionID)
+		}
+		return nil, false, nil
+	}
+	if version.DeploymentDefaults == nil {
+		if strings.TrimSpace(lineup) != "" {
+			return nil, false, fmt.Errorf("challenge pack version %s does not declare deployment defaults", challengePackVersionID)
+		}
+		return nil, false, nil
+	}
+
+	selectors, err := deploymentSelectorsForLineup(version.DeploymentDefaults, lineup)
+	if err != nil {
+		return nil, false, err
+	}
+	ids, err := resolveRunCreateDeploymentSelectors(cmd, rc, workspaceID, selectors)
+	if err != nil {
+		return nil, false, err
+	}
+	return ids, true, nil
+}
+
+func findChallengePackVersion(cmd *cobra.Command, rc *RunContext, workspaceID, challengePackVersionID string) (challengePackVersionBrief, bool, error) {
+	packs, err := listChallengePacks(cmd, rc, workspaceID)
+	if err != nil {
+		return challengePackVersionBrief{}, false, err
+	}
+	for _, pack := range packs {
+		for _, version := range pack.Versions {
+			if version.ID == challengePackVersionID {
+				return version, true, nil
+			}
+		}
+	}
+	return challengePackVersionBrief{}, false, nil
+}
+
+func deploymentSelectorsForLineup(defaults *deploymentDefaults, lineup string) ([]string, error) {
+	lineupName := strings.TrimSpace(lineup)
+	if lineupName == "" {
+		lineupName = "default"
+	}
+	selectors, ok := defaults.Lineups[lineupName]
+	if !ok {
+		return nil, fmt.Errorf("deployment lineup %q is not declared by the challenge pack version", lineupName)
+	}
+	if len(selectors) == 0 {
+		return nil, fmt.Errorf("deployment lineup %q does not include any deployment selectors", lineupName)
+	}
+
+	resolved := make([]string, 0, len(selectors))
+	for i, selector := range selectors {
+		trimmed := strings.TrimSpace(selector)
+		if trimmed == "" {
+			return nil, fmt.Errorf("deployment lineup %q entry %d is empty", lineupName, i)
+		}
+		if alias, ok := defaults.Aliases[trimmed]; ok {
+			trimmed = strings.TrimSpace(alias)
+		}
+		if trimmed == "" {
+			return nil, fmt.Errorf("deployment lineup %q entry %d resolves to an empty selector", lineupName, i)
+		}
+		resolved = append(resolved, trimmed)
+	}
+	return resolved, nil
+}
+
+func resolveRunCreateDeploymentSelectors(cmd *cobra.Command, rc *RunContext, workspaceID string, selectors []string) ([]string, error) {
+	deployments, err := listDeployments(cmd, rc, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]string, 0, len(selectors))
+	seen := map[string]struct{}{}
+	for _, selector := range selectors {
+		matched, err := matchRunCreateDeployment(selector, deployments)
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := seen[matched.ID]; exists {
+			continue
+		}
+		seen[matched.ID] = struct{}{}
+		ids = append(ids, matched.ID)
+	}
+	return ids, nil
+}
+
+func matchRunCreateDeployment(selector string, deployments []deploymentSummary) (deploymentSummary, error) {
+	var matches []deploymentSummary
+	for _, deployment := range deployments {
+		if selectorMatches(selector, deployment.ID, deployment.Name) {
+			matches = append(matches, deployment)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return deploymentSummary{}, fmt.Errorf("no deployment matched %q", selector)
+	case 1:
+		return matches[0], nil
+	default:
+		return deploymentSummary{}, fmt.Errorf("deployment selector %q matched multiple deployments; use the deployment id", selector)
+	}
 }
 
 func selectOneOrAuto(picker interactivePicker, prompt string, options []pickerOption) (pickerOption, error) {

--- a/cli/cmd/run_create_interactive_test.go
+++ b/cli/cmd/run_create_interactive_test.go
@@ -272,7 +272,220 @@ func TestRunCreateNonInteractiveRequiresExplicitFlags(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected non-interactive validation error")
 	}
-	if got := err.Error(); got != "challenge pack version and deployment selection required in non-interactive mode; pass --challenge-pack-version and --deployments or rerun `agentclash run create` in a TTY for guided selection" {
+	if got := err.Error(); got != "challenge pack version and deployment selection required in non-interactive mode; pass --challenge-pack-version and --deployments or --deployment-lineup or rerun `agentclash run create` in a TTY for guided selection" {
+		t.Fatalf("error = %q", got)
+	}
+}
+
+func TestRunCreateNonInteractiveUsesChallengePackDefaultDeploymentLineup(t *testing.T) {
+	oldInteractive := isInteractiveTerminal
+	isInteractiveTerminal = func(*RunContext) bool { return false }
+	t.Cleanup(func() { isInteractiveTerminal = oldInteractive })
+
+	var gotBody map[string]any
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/challenge-packs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{
+					"id":   "pack-1",
+					"name": "Support Eval",
+					"versions": []map[string]any{
+						{
+							"id":               "cpv-defaults",
+							"version_number":   1,
+							"lifecycle_status": "runnable",
+							"deployment_defaults": map[string]any{
+								"aliases": map[string]any{
+									"candidate": "Candidate Agent",
+								},
+								"lineups": map[string]any{
+									"default": []any{"candidate", "dep-baseline"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}),
+		"GET /v1/workspaces/ws-1/agent-deployments": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "dep-candidate", "name": "Candidate Agent", "status": "active"},
+				{"id": "dep-baseline", "name": "Baseline Agent", "status": "active"},
+			},
+		}),
+		"POST /v1/runs": func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "run-1", "status": "queued"})
+		},
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"run", "create",
+		"-w", "ws-1",
+		"--challenge-pack-version", "cpv-defaults",
+		"--input-set", "input-default",
+	}, srv.URL); err != nil {
+		t.Fatalf("run create error: %v", err)
+	}
+
+	deploymentIDs, ok := gotBody["agent_deployment_ids"].([]any)
+	if !ok {
+		t.Fatalf("agent_deployment_ids type = %T, want []any", gotBody["agent_deployment_ids"])
+	}
+	if len(deploymentIDs) != 2 || deploymentIDs[0] != "dep-candidate" || deploymentIDs[1] != "dep-baseline" {
+		t.Fatalf("agent_deployment_ids = %#v, want [dep-candidate dep-baseline]", deploymentIDs)
+	}
+}
+
+func TestRunCreateUsesNamedDeploymentLineup(t *testing.T) {
+	oldInteractive := isInteractiveTerminal
+	isInteractiveTerminal = func(*RunContext) bool { return false }
+	t.Cleanup(func() { isInteractiveTerminal = oldInteractive })
+
+	var gotBody map[string]any
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/challenge-packs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{
+					"id":   "pack-1",
+					"name": "Support Eval",
+					"versions": []map[string]any{
+						{
+							"id":               "cpv-defaults",
+							"version_number":   1,
+							"lifecycle_status": "runnable",
+							"deployment_defaults": map[string]any{
+								"lineups": map[string]any{
+									"default": []any{"dep-baseline"},
+									"smoke":   []any{"Candidate Agent"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}),
+		"GET /v1/workspaces/ws-1/agent-deployments": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "dep-candidate", "name": "Candidate Agent", "status": "active"},
+				{"id": "dep-baseline", "name": "Baseline Agent", "status": "active"},
+			},
+		}),
+		"POST /v1/runs": func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "run-1", "status": "queued"})
+		},
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"run", "create",
+		"-w", "ws-1",
+		"--challenge-pack-version", "cpv-defaults",
+		"--input-set", "input-default",
+		"--deployment-lineup", "smoke",
+	}, srv.URL); err != nil {
+		t.Fatalf("run create error: %v", err)
+	}
+
+	deploymentIDs := gotBody["agent_deployment_ids"].([]any)
+	if len(deploymentIDs) != 1 || deploymentIDs[0] != "dep-candidate" {
+		t.Fatalf("agent_deployment_ids = %#v, want [dep-candidate]", deploymentIDs)
+	}
+}
+
+func TestRunCreateInteractiveExplicitVersionLooksUpDefaultsOnce(t *testing.T) {
+	picker := &fakePicker{selectIndices: []int{0}}
+	oldInteractive := isInteractiveTerminal
+	oldPickerFactory := newInteractivePicker
+	isInteractiveTerminal = func(*RunContext) bool { return true }
+	newInteractivePicker = func() interactivePicker { return picker }
+	t.Cleanup(func() {
+		isInteractiveTerminal = oldInteractive
+		newInteractivePicker = oldPickerFactory
+	})
+
+	challengePacksCalls := 0
+	var gotBody map[string]any
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/challenge-pack-versions/cpv-explicit/input-sets": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "input-1", "name": "Small", "input_key": "small"},
+			},
+		}),
+		"GET /v1/workspaces/ws-1/challenge-packs": func(w http.ResponseWriter, r *http.Request) {
+			challengePacksCalls++
+			jsonHandler(200, map[string]any{
+				"items": []map[string]any{
+					{
+						"id":   "pack-1",
+						"name": "Support Eval",
+						"versions": []map[string]any{
+							{"id": "cpv-explicit", "version_number": 1, "lifecycle_status": "runnable"},
+						},
+					},
+				},
+			})(w, r)
+		},
+		"GET /v1/workspaces/ws-1/agent-deployments": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "dep-only", "name": "Only Agent", "status": "active"},
+			},
+		}),
+		"POST /v1/runs": func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "run-1", "status": "queued"})
+		},
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"run", "create",
+		"-w", "ws-1",
+		"--challenge-pack-version", "cpv-explicit",
+	}, srv.URL); err != nil {
+		t.Fatalf("run create error: %v", err)
+	}
+
+	if challengePacksCalls != 1 {
+		t.Fatalf("challenge-packs calls = %d, want 1", challengePacksCalls)
+	}
+	deploymentIDs := gotBody["agent_deployment_ids"].([]any)
+	if len(deploymentIDs) != 1 || deploymentIDs[0] != "dep-only" {
+		t.Fatalf("agent_deployment_ids = %#v, want [dep-only]", deploymentIDs)
+	}
+}
+
+func TestRunCreateRejectsDeploymentLineupWithExplicitDeployments(t *testing.T) {
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{
+		"run", "create",
+		"-w", "ws-1",
+		"--challenge-pack-version", "cpv-explicit",
+		"--input-set", "input-explicit",
+		"--deployments", "dep-a",
+		"--deployment-lineup", "smoke",
+	}, "http://unused")
+	if err == nil {
+		t.Fatal("expected --deployment-lineup/--deployments conflict")
+	}
+	if got := err.Error(); got != "--deployment-lineup cannot be combined with --deployments" {
 		t.Fatalf("error = %q", got)
 	}
 }

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -4963,22 +4963,6 @@ components:
         updated_at:
           type: string
           format: date-time
-            limit:
-              anyOf:
-                - type: integer
-                - type: "null"
-            used:
-              type: integer
-            remaining:
-              anyOf:
-                - type: integer
-                - type: "null"
-            reset_at:
-              type: string
-              format: date-time
-            expires_at:
-              type: string
-              format: date-time
 
     EmptyObject:
       type: object
@@ -9691,6 +9675,20 @@ components:
           format: int32
         lifecycle_status:
           type: string
+        deployment_defaults:
+          type: object
+          description: Default deployment aliases and lineups declared by the challenge pack version.
+          properties:
+            aliases:
+              type: object
+              additionalProperties:
+                type: string
+            lineups:
+              type: object
+              additionalProperties:
+                type: array
+                items:
+                  type: string
         created_at:
           type: string
           format: date-time


### PR DESCRIPTION
## Summary
- Add `version.deployment_defaults` to challenge-pack manifests with aliases and named lineups.
- Surface deployment defaults on the challenge-pack list API from stored version manifests.
- Let `agentclash run create` resolve the manifest default lineup when `--deployments` is omitted, plus `--deployment-lineup` for named lineups.

Fixes #710.

## Validation
- `go test ./internal/challengepack ./internal/api` (backend)
- `go test ./cmd -run 'TestRunCreate|TestListChallenge|TestValidateBundle|TestParseYAML'` (cli)\n- `go test ./...` (backend)\n- `go test ./...` (cli)\n- `go vet ./...` (backend)\n- `go build ./...` (cli)\n- `go vet ./...` (cli)\n- `go test -short -race -count=1 ./...` (cli)\n- `go test -short -race -count=1 ./...` (backend)\n- `go run github.com/goreleaser/goreleaser/v2@latest check`\n- `go run github.com/goreleaser/goreleaser/v2@latest release --snapshot --clean`\n