### PR TITLE
feat: add race series creation

### DIFF
--- a/backend/internal/api/eval_session_reads.go
+++ b/backend/internal/api/eval_session_reads.go
@@ -62,6 +62,8 @@ type evalSessionChildRunResponse struct {
 	Status                 domain.RunStatus `json:"status"`
 	ExecutionMode          string           `json:"execution_mode"`
 	Seed                   *int64           `json:"seed,omitempty"`
+	MatrixKey              string           `json:"matrix_key,omitempty"`
+	DeploymentLineup       string           `json:"deployment_lineup,omitempty"`
 	QueuedAt               *time.Time       `json:"queued_at,omitempty"`
 	StartedAt              *time.Time       `json:"started_at,omitempty"`
 	FinishedAt             *time.Time       `json:"finished_at,omitempty"`
@@ -402,6 +404,7 @@ func buildEvalSessionListItemResponse(result GetEvalSessionResult) evalSessionLi
 }
 
 func buildEvalSessionChildRunResponse(run domain.Run) evalSessionChildRunResponse {
+	series := evalSessionChildRunSeries(run.ExecutionPlan)
 	return evalSessionChildRunResponse{
 		ID:                     run.ID,
 		WorkspaceID:            run.WorkspaceID,
@@ -413,6 +416,8 @@ func buildEvalSessionChildRunResponse(run domain.Run) evalSessionChildRunRespons
 		Status:                 run.Status,
 		ExecutionMode:          run.ExecutionMode,
 		Seed:                   evalSessionChildRunSeed(run.ExecutionPlan),
+		MatrixKey:              series.MatrixKey,
+		DeploymentLineup:       series.DeploymentLineup,
 		QueuedAt:               run.QueuedAt,
 		StartedAt:              run.StartedAt,
 		FinishedAt:             run.FinishedAt,
@@ -421,6 +426,30 @@ func buildEvalSessionChildRunResponse(run domain.Run) evalSessionChildRunRespons
 		CreatedAt:              run.CreatedAt,
 		UpdatedAt:              run.UpdatedAt,
 		Links:                  buildRunLinks(run.ID),
+	}
+}
+
+type evalSessionChildRunSeriesMetadata struct {
+	MatrixKey        string
+	DeploymentLineup string
+}
+
+func evalSessionChildRunSeries(executionPlan json.RawMessage) evalSessionChildRunSeriesMetadata {
+	if len(executionPlan) == 0 {
+		return evalSessionChildRunSeriesMetadata{}
+	}
+	var plan struct {
+		Series struct {
+			MatrixKey        string `json:"matrix_key"`
+			DeploymentLineup string `json:"deployment_lineup"`
+		} `json:"series"`
+	}
+	if err := json.Unmarshal(executionPlan, &plan); err != nil {
+		return evalSessionChildRunSeriesMetadata{}
+	}
+	return evalSessionChildRunSeriesMetadata{
+		MatrixKey:        plan.Series.MatrixKey,
+		DeploymentLineup: plan.Series.DeploymentLineup,
 	}
 }
 

--- a/backend/internal/api/eval_session_reads_test.go
+++ b/backend/internal/api/eval_session_reads_test.go
@@ -308,7 +308,7 @@ func TestGetEvalSessionEndpointReturnsDetail(t *testing.T) {
 						Name:             "Repeated Eval [1/2]",
 						Status:           domain.RunStatusQueued,
 						ExecutionMode:    "single_agent",
-						ExecutionPlan:    json.RawMessage(`{"seed":42}`),
+						ExecutionPlan:    json.RawMessage(`{"seed":42,"series":{"matrix_key":"default:seed-42","deployment_lineup":"default"}}`),
 						CreatedAt:        time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
 						UpdatedAt:        time.Date(2026, 4, 20, 12, 1, 0, 0, time.UTC),
 					},
@@ -355,6 +355,9 @@ func TestGetEvalSessionEndpointReturnsDetail(t *testing.T) {
 	}
 	if response.Runs[0].Seed == nil || *response.Runs[0].Seed != 42 {
 		t.Fatalf("run seed = %v, want 42", response.Runs[0].Seed)
+	}
+	if response.Runs[0].MatrixKey != "default:seed-42" || response.Runs[0].DeploymentLineup != "default" {
+		t.Fatalf("run series metadata = %q/%q, want persisted matrix metadata", response.Runs[0].MatrixKey, response.Runs[0].DeploymentLineup)
 	}
 	if response.Summary.RunCounts.Queued != 1 {
 		t.Fatalf("queued run count = %d, want 1", response.Summary.RunCounts.Queued)

--- a/backend/internal/api/eval_session_service.go
+++ b/backend/internal/api/eval_session_service.go
@@ -14,9 +14,9 @@ import (
 )
 
 type EvalSessionParticipantInput struct {
-	AgentDeploymentID   *uuid.UUID
-	AgentBuildVersionID *uuid.UUID
-	Label               string
+	AgentDeploymentID   *uuid.UUID `json:"agent_deployment_id,omitempty"`
+	AgentBuildVersionID *uuid.UUID `json:"agent_build_version_id,omitempty"`
+	Label               string     `json:"label"`
 }
 
 type EvalSessionAggregationInput struct {
@@ -54,6 +54,7 @@ type CreateEvalSessionConfigInput struct {
 	RoutingTaskSnapshot EvalSessionRoutingTaskSnapshotInput
 	ReliabilityWeights  *EvalSessionReliabilityWeightsInput
 	SeedFanout          []int64
+	RunMatrix           []EvalSessionRunMatrixEntryInput
 	SchemaVersion       int32
 }
 
@@ -68,15 +69,30 @@ type CreateEvalSessionInput struct {
 	EvalSession            CreateEvalSessionConfigInput
 }
 
+type EvalSessionRunMatrixEntryInput struct {
+	Key              string                        `json:"key"`
+	DeploymentLineup string                        `json:"deployment_lineup,omitempty"`
+	Seed             *int64                        `json:"seed,omitempty"`
+	Participants     []EvalSessionParticipantInput `json:"participants"`
+}
+
 type EvalSessionSeededRun struct {
 	RunID uuid.UUID `json:"run_id"`
 	Seed  int64     `json:"seed"`
+}
+
+type EvalSessionSeriesRun struct {
+	RunID            uuid.UUID `json:"run_id"`
+	MatrixKey        string    `json:"matrix_key,omitempty"`
+	DeploymentLineup string    `json:"deployment_lineup,omitempty"`
+	Seed             *int64    `json:"seed,omitempty"`
 }
 
 type CreateEvalSessionResult struct {
 	Session    domain.EvalSession
 	RunIDs     []uuid.UUID
 	SeededRuns []EvalSessionSeededRun
+	SeriesRuns []EvalSessionSeriesRun
 }
 
 func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Caller, input CreateEvalSessionInput) (CreateEvalSessionResult, error) {
@@ -84,7 +100,20 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 		return CreateEvalSessionResult{}, err
 	}
 
-	if len(input.Participants) == 0 {
+	hasRunMatrix := len(input.EvalSession.RunMatrix) > 0
+	if input.EvalSession.Repetitions < 1 {
+		return CreateEvalSessionResult{}, RunCreationValidationError{
+			Code:    "invalid_eval_session",
+			Message: "eval_session.repetitions must be at least 1",
+		}
+	}
+	if hasRunMatrix && int32(len(input.EvalSession.RunMatrix)) != input.EvalSession.Repetitions {
+		return CreateEvalSessionResult{}, RunCreationValidationError{
+			Code:    "invalid_eval_session",
+			Message: "eval_session.run_matrix length must match repetitions",
+		}
+	}
+	if len(input.Participants) == 0 && !hasRunMatrix {
 		return CreateEvalSessionResult{}, RunCreationValidationError{
 			Code:    "invalid_participants",
 			Message: "at least one participant is required",
@@ -93,7 +122,11 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 
 	executionMode := strings.TrimSpace(input.ExecutionMode)
 	if executionMode == "" {
-		if len(input.Participants) == 1 {
+		participantCount := len(input.Participants)
+		if hasRunMatrix {
+			participantCount = len(input.EvalSession.RunMatrix[0].Participants)
+		}
+		if participantCount == 1 {
 			executionMode = "single_agent"
 		} else {
 			executionMode = "comparison"
@@ -105,16 +138,18 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 			Message: "execution_mode must be either single_agent or comparison",
 		}
 	}
-	if len(input.Participants) == 1 && executionMode != "single_agent" {
-		return CreateEvalSessionResult{}, RunCreationValidationError{
-			Code:    "invalid_execution_mode",
-			Message: "single-participant eval sessions must use execution_mode single_agent",
+	if !hasRunMatrix {
+		if len(input.Participants) == 1 && executionMode != "single_agent" {
+			return CreateEvalSessionResult{}, RunCreationValidationError{
+				Code:    "invalid_execution_mode",
+				Message: "single-participant eval sessions must use execution_mode single_agent",
+			}
 		}
-	}
-	if len(input.Participants) > 1 && executionMode != "comparison" {
-		return CreateEvalSessionResult{}, RunCreationValidationError{
-			Code:    "invalid_execution_mode",
-			Message: "multi-participant eval sessions must use execution_mode comparison",
+		if len(input.Participants) > 1 && executionMode != "comparison" {
+			return CreateEvalSessionResult{}, RunCreationValidationError{
+				Code:    "invalid_execution_mode",
+				Message: "multi-participant eval sessions must use execution_mode comparison",
+			}
 		}
 	}
 
@@ -172,11 +207,15 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 		}
 	}
 
-	uniqueDeploymentIDs := make([]uuid.UUID, 0, len(input.Participants))
-	seenDeploymentIDs := make(map[uuid.UUID]struct{}, len(input.Participants))
-	uniqueBuildVersionIDs := make([]uuid.UUID, 0, len(input.Participants))
-	seenBuildVersionIDs := make(map[uuid.UUID]struct{}, len(input.Participants))
-	for _, participant := range input.Participants {
+	allParticipants := append([]EvalSessionParticipantInput(nil), input.Participants...)
+	for _, entry := range input.EvalSession.RunMatrix {
+		allParticipants = append(allParticipants, entry.Participants...)
+	}
+	uniqueDeploymentIDs := make([]uuid.UUID, 0, len(allParticipants))
+	seenDeploymentIDs := make(map[uuid.UUID]struct{}, len(allParticipants))
+	uniqueBuildVersionIDs := make([]uuid.UUID, 0, len(allParticipants))
+	seenBuildVersionIDs := make(map[uuid.UUID]struct{}, len(allParticipants))
+	for _, participant := range allParticipants {
 		if participant.AgentDeploymentID != nil {
 			if _, ok := seenDeploymentIDs[*participant.AgentDeploymentID]; ok {
 				continue
@@ -216,47 +255,89 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 		}
 	}
 
-	participantDetails := make([]evalSessionValidationDetail, 0)
-	participantDeployments := make([]repository.RunnableDeployment, 0, len(input.Participants))
-	for idx, participant := range input.Participants {
-		if participant.AgentDeploymentID != nil {
-			deployment, ok := deploymentsByID[*participant.AgentDeploymentID]
-			if !ok {
-				participantDetails = append(participantDetails, evalSessionValidationDetail{
-					Field:   fmt.Sprintf("participants[%d].agent_deployment_id", idx),
-					Code:    "participants.agent_deployment_id.unresolved",
-					Message: "agent_deployment_id must reference an active deployment with a snapshot in the selected workspace",
+	resolveParticipants := func(participants []EvalSessionParticipantInput, fieldPrefix string) ([]repository.RunnableDeployment, []evalSessionValidationDetail) {
+		details := make([]evalSessionValidationDetail, 0)
+		resolved := make([]repository.RunnableDeployment, 0, len(participants))
+		for idx, participant := range participants {
+			field := fmt.Sprintf("%s[%d]", fieldPrefix, idx)
+			if participant.AgentDeploymentID != nil {
+				deployment, ok := deploymentsByID[*participant.AgentDeploymentID]
+				if !ok {
+					details = append(details, evalSessionValidationDetail{
+						Field:   field + ".agent_deployment_id",
+						Code:    "participants.agent_deployment_id.unresolved",
+						Message: "agent_deployment_id must reference an active deployment with a snapshot in the selected workspace",
+					})
+					continue
+				}
+				resolved = append(resolved, deployment)
+				continue
+			}
+
+			if participant.AgentBuildVersionID == nil {
+				details = append(details, evalSessionValidationDetail{
+					Field:   field,
+					Code:    "invalid_participants",
+					Message: "participants must include agent_deployment_id",
 				})
 				continue
 			}
-			participantDeployments = append(participantDeployments, deployment)
-			continue
-		}
 
-		if participant.AgentBuildVersionID == nil {
-			participantDetails = append(participantDetails, evalSessionValidationDetail{
-				Field:   fmt.Sprintf("participants[%d]", idx),
-				Code:    "invalid_participants",
-				Message: "participants must include agent_deployment_id",
-			})
-			continue
+			candidates := groupedDeployments[*participant.AgentBuildVersionID]
+			switch len(candidates) {
+			case 0:
+				details = append(details, evalSessionValidationDetail{
+					Field:   field + ".agent_build_version_id",
+					Code:    "participants.agent_build_version_id.unresolved",
+					Message: "agent_build_version_id must resolve to exactly one active deployment in the selected workspace",
+				})
+			case 1:
+				resolved = append(resolved, candidates[0])
+			default:
+				details = append(details, evalSessionValidationDetail{
+					Field:   field + ".agent_build_version_id",
+					Code:    "participants.agent_build_version_id.ambiguous",
+					Message: "agent_build_version_id resolved to multiple active deployments in the selected workspace",
+				})
+			}
 		}
+		return resolved, details
+	}
 
-		candidates := groupedDeployments[*participant.AgentBuildVersionID]
-		switch len(candidates) {
-		case 0:
-			participantDetails = append(participantDetails, evalSessionValidationDetail{
-				Field:   fmt.Sprintf("participants[%d].agent_build_version_id", idx),
-				Code:    "participants.agent_build_version_id.unresolved",
-				Message: "agent_build_version_id must resolve to exactly one active deployment in the selected workspace",
+	type childRunSpec struct {
+		MatrixKey        string
+		DeploymentLineup string
+		Seed             *int64
+		Participants     []EvalSessionParticipantInput
+		Deployments      []repository.RunnableDeployment
+	}
+
+	childSpecs := make([]childRunSpec, 0, input.EvalSession.Repetitions)
+	participantDetails := make([]evalSessionValidationDetail, 0)
+	if hasRunMatrix {
+		for idx, entry := range input.EvalSession.RunMatrix {
+			deployments, details := resolveParticipants(entry.Participants, fmt.Sprintf("eval_session.run_matrix[%d].participants", idx))
+			participantDetails = append(participantDetails, details...)
+			childSpecs = append(childSpecs, childRunSpec{
+				MatrixKey:        entry.Key,
+				DeploymentLineup: entry.DeploymentLineup,
+				Seed:             cloneInt64Ptr(entry.Seed),
+				Participants:     entry.Participants,
+				Deployments:      deployments,
 			})
-		case 1:
-			participantDeployments = append(participantDeployments, candidates[0])
-		default:
-			participantDetails = append(participantDetails, evalSessionValidationDetail{
-				Field:   fmt.Sprintf("participants[%d].agent_build_version_id", idx),
-				Code:    "participants.agent_build_version_id.ambiguous",
-				Message: "agent_build_version_id resolved to multiple active deployments in the selected workspace",
+		}
+	} else {
+		deployments, details := resolveParticipants(input.Participants, "participants")
+		participantDetails = append(participantDetails, details...)
+		for repetition := int32(0); repetition < input.EvalSession.Repetitions; repetition++ {
+			var seed *int64
+			if int(repetition) < len(input.EvalSession.SeedFanout) {
+				seed = &input.EvalSession.SeedFanout[repetition]
+			}
+			childSpecs = append(childSpecs, childRunSpec{
+				Seed:         cloneInt64Ptr(seed),
+				Participants: input.Participants,
+				Deployments:  deployments,
 			})
 		}
 	}
@@ -264,15 +345,41 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 		return CreateEvalSessionResult{}, evalSessionValidationError{Errors: participantDetails}
 	}
 
-	organizationID := participantDeployments[0].OrganizationID
-	for _, deployment := range participantDeployments[1:] {
+	for _, spec := range childSpecs {
+		if len(spec.Deployments) == 0 {
+			return CreateEvalSessionResult{}, RunCreationValidationError{
+				Code:    "invalid_participants",
+				Message: "each eval session child run requires at least one participant",
+			}
+		}
+		if len(spec.Participants) == 1 && executionMode != "single_agent" {
+			return CreateEvalSessionResult{}, RunCreationValidationError{
+				Code:    "invalid_execution_mode",
+				Message: "single-participant eval sessions must use execution_mode single_agent",
+			}
+		}
+		if len(spec.Participants) > 1 && executionMode != "comparison" {
+			return CreateEvalSessionResult{}, RunCreationValidationError{
+				Code:    "invalid_execution_mode",
+				Message: "multi-participant eval sessions must use execution_mode comparison",
+			}
+		}
+	}
+
+	firstDeployment := childSpecs[0].Deployments[0]
+	organizationID := firstDeployment.OrganizationID
+	allResolvedDeployments := make([]repository.RunnableDeployment, 0, len(allParticipants))
+	for _, spec := range childSpecs {
+		allResolvedDeployments = append(allResolvedDeployments, spec.Deployments...)
+	}
+	for _, deployment := range allResolvedDeployments {
 		if deployment.OrganizationID != organizationID {
 			return CreateEvalSessionResult{}, fmt.Errorf("participant deployments in workspace %s resolved to multiple organizations", input.WorkspaceID)
 		}
 	}
 
 	checkedPolicies := make(map[uuid.UUID]struct{})
-	for _, deployment := range participantDeployments {
+	for _, deployment := range allResolvedDeployments {
 		if deployment.SpendPolicyID == nil {
 			continue
 		}
@@ -300,14 +407,32 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 		}
 	}
 
-	runAgents := make([]repository.CreateQueuedRunAgentParams, 0, len(participantDeployments))
-	for laneIndex, deployment := range participantDeployments {
-		runAgents = append(runAgents, repository.CreateQueuedRunAgentParams{
-			AgentDeploymentID:         deployment.ID,
-			AgentDeploymentSnapshotID: deployment.AgentDeploymentSnapshotID,
-			LaneIndex:                 int32(laneIndex),
-			Label:                     input.Participants[laneIndex].Label,
-		})
+	buildRunAgents := func(spec childRunSpec) []repository.CreateQueuedRunAgentParams {
+		runAgents := make([]repository.CreateQueuedRunAgentParams, 0, len(spec.Deployments))
+		for laneIndex, deployment := range spec.Deployments {
+			label := spec.Participants[laneIndex].Label
+			if strings.TrimSpace(label) == "" {
+				label = deployment.Name
+			}
+			runAgents = append(runAgents, repository.CreateQueuedRunAgentParams{
+				AgentDeploymentID:         deployment.ID,
+				AgentDeploymentSnapshotID: deployment.AgentDeploymentSnapshotID,
+				LaneIndex:                 int32(laneIndex),
+				Label:                     label,
+			})
+		}
+		return runAgents
+	}
+
+	maxParticipantCount := 0
+	for _, spec := range childSpecs {
+		if len(spec.Participants) > maxParticipantCount {
+			maxParticipantCount = len(spec.Participants)
+		}
+	}
+	baseRunAgents := buildRunAgents(childSpecs[0])
+	if !hasRunMatrix {
+		maxParticipantCount = len(baseRunAgents)
 	}
 
 	challengeIdentityIDs, err := m.repo.ListChallengeIdentityIDsByPackVersionID(ctx, input.ChallengePackVersionID)
@@ -329,8 +454,12 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 		baseName = defaultEvalSessionRunName(m.now().UTC())
 	}
 
-	childRuns := make([]repository.CreateQueuedRunParams, 0, input.EvalSession.Repetitions)
-	for repetition := int32(0); repetition < input.EvalSession.Repetitions; repetition++ {
+	childRuns := make([]repository.CreateQueuedRunParams, 0, len(childSpecs))
+	for repetition, spec := range childSpecs {
+		specRunAgents := baseRunAgents
+		if hasRunMatrix {
+			specRunAgents = buildRunAgents(spec)
+		}
 		runInput := CreateRunInput{
 			WorkspaceID:            input.WorkspaceID,
 			ChallengePackVersionID: input.ChallengePackVersionID,
@@ -338,10 +467,8 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 			OfficialPackMode:       domain.OfficialPackModeFull,
 			MaxIterations:          input.MaxIterations,
 		}
-		if int(repetition) < len(input.EvalSession.SeedFanout) {
-			runInput.Seed = &input.EvalSession.SeedFanout[repetition]
-		}
-		executionPlan, err := buildExecutionPlan(runInput, runAgents)
+		runInput.Seed = cloneInt64Ptr(spec.Seed)
+		executionPlan, err := buildExecutionPlan(runInput, specRunAgents)
 		if err != nil {
 			return CreateEvalSessionResult{}, fmt.Errorf("build execution plan: %w", err)
 		}
@@ -352,17 +479,17 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 			ChallengeInputSetID:    input.ChallengeInputSetID,
 			OfficialPackMode:       domain.OfficialPackModeFull,
 			CreatedByUserID:        &caller.UserID,
-			Name:                   evalSessionRunName(baseName, repetition, input.EvalSession.Repetitions),
+			Name:                   evalSessionRunName(baseName, int32(repetition), input.EvalSession.Repetitions),
 			ExecutionMode:          executionMode,
 			ExecutionPlan:          executionPlan,
-			RunAgents:              runAgents,
+			RunAgents:              specRunAgents,
 			CaseSelections:         caseSelections,
 		})
 	}
 
 	var entitlementGate *repository.RunEntitlementGate
 	if m.entitlementGate != nil {
-		entitlementGate, err = m.entitlementGate.BuildRunGate(ctx, input.WorkspaceID, len(runAgents), len(childRuns))
+		entitlementGate, err = m.entitlementGate.BuildRunGate(ctx, input.WorkspaceID, maxParticipantCount, len(childRuns))
 		if err != nil {
 			return CreateEvalSessionResult{}, err
 		}
@@ -388,6 +515,7 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 
 	runIDs := make([]uuid.UUID, 0, len(createResult.Runs))
 	seededRuns := make([]EvalSessionSeededRun, 0, len(input.EvalSession.SeedFanout))
+	seriesRuns := make([]EvalSessionSeriesRun, 0, len(input.EvalSession.RunMatrix))
 	for _, run := range createResult.Runs {
 		runIDs = append(runIDs, run.ID)
 		if seed := evalSessionChildRunSeed(run.ExecutionPlan); seed != nil {
@@ -397,11 +525,26 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 			})
 		}
 	}
+	if hasRunMatrix {
+		for idx, run := range createResult.Runs {
+			if idx >= len(input.EvalSession.RunMatrix) {
+				break
+			}
+			entry := input.EvalSession.RunMatrix[idx]
+			seriesRuns = append(seriesRuns, EvalSessionSeriesRun{
+				RunID:            run.ID,
+				MatrixKey:        entry.Key,
+				DeploymentLineup: entry.DeploymentLineup,
+				Seed:             cloneInt64Ptr(entry.Seed),
+			})
+		}
+	}
 
 	return CreateEvalSessionResult{
 		Session:    createResult.Session,
 		RunIDs:     runIDs,
 		SeededRuns: seededRuns,
+		SeriesRuns: seriesRuns,
 	}, nil
 }
 
@@ -463,6 +606,23 @@ func buildRoutingTaskSnapshot(input CreateEvalSessionConfigInput) json.RawMessag
 			"strategy": "explicit",
 			"seeds":    input.SeedFanout,
 		}
+	}
+	if len(input.RunMatrix) > 0 {
+		matrix := make([]map[string]any, 0, len(input.RunMatrix))
+		for _, entry := range input.RunMatrix {
+			item := map[string]any{
+				"key":          entry.Key,
+				"participants": entry.Participants,
+			}
+			if entry.DeploymentLineup != "" {
+				item["deployment_lineup"] = entry.DeploymentLineup
+			}
+			if entry.Seed != nil {
+				item["seed"] = *entry.Seed
+			}
+			matrix = append(matrix, item)
+		}
+		payload["run_matrix"] = matrix
 	}
 	return mustMarshalEvalSessionJSON(payload)
 }

--- a/backend/internal/api/eval_session_service.go
+++ b/backend/internal/api/eval_session_service.go
@@ -121,35 +121,10 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 	}
 
 	executionMode := strings.TrimSpace(input.ExecutionMode)
-	if executionMode == "" {
-		participantCount := len(input.Participants)
-		if hasRunMatrix {
-			participantCount = len(input.EvalSession.RunMatrix[0].Participants)
-		}
-		if participantCount == 1 {
-			executionMode = "single_agent"
-		} else {
-			executionMode = "comparison"
-		}
-	}
-	if executionMode != "single_agent" && executionMode != "comparison" {
+	if executionMode != "" && executionMode != "single_agent" && executionMode != "comparison" {
 		return CreateEvalSessionResult{}, RunCreationValidationError{
 			Code:    "invalid_execution_mode",
 			Message: "execution_mode must be either single_agent or comparison",
-		}
-	}
-	if !hasRunMatrix {
-		if len(input.Participants) == 1 && executionMode != "single_agent" {
-			return CreateEvalSessionResult{}, RunCreationValidationError{
-				Code:    "invalid_execution_mode",
-				Message: "single-participant eval sessions must use execution_mode single_agent",
-			}
-		}
-		if len(input.Participants) > 1 && executionMode != "comparison" {
-			return CreateEvalSessionResult{}, RunCreationValidationError{
-				Code:    "invalid_execution_mode",
-				Message: "multi-participant eval sessions must use execution_mode comparison",
-			}
 		}
 	}
 
@@ -345,6 +320,14 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 		return CreateEvalSessionResult{}, evalSessionValidationError{Errors: participantDetails}
 	}
 
+	if executionMode == "" {
+		participantCount := len(childSpecs[0].Participants)
+		if participantCount == 1 {
+			executionMode = "single_agent"
+		} else {
+			executionMode = "comparison"
+		}
+	}
 	for _, spec := range childSpecs {
 		if len(spec.Deployments) == 0 {
 			return CreateEvalSessionResult{}, RunCreationValidationError{
@@ -466,6 +449,8 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 			ChallengeInputSetID:    input.ChallengeInputSetID,
 			OfficialPackMode:       domain.OfficialPackModeFull,
 			MaxIterations:          input.MaxIterations,
+			SeriesMatrixKey:        spec.MatrixKey,
+			SeriesDeploymentLineup: spec.DeploymentLineup,
 		}
 		runInput.Seed = cloneInt64Ptr(spec.Seed)
 		executionPlan, err := buildExecutionPlan(runInput, specRunAgents)
@@ -526,16 +511,13 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 		}
 	}
 	if hasRunMatrix {
-		for idx, run := range createResult.Runs {
-			if idx >= len(input.EvalSession.RunMatrix) {
-				break
-			}
-			entry := input.EvalSession.RunMatrix[idx]
+		for _, run := range createResult.Runs {
+			series := evalSessionChildRunSeries(run.ExecutionPlan)
 			seriesRuns = append(seriesRuns, EvalSessionSeriesRun{
 				RunID:            run.ID,
-				MatrixKey:        entry.Key,
-				DeploymentLineup: entry.DeploymentLineup,
-				Seed:             cloneInt64Ptr(entry.Seed),
+				MatrixKey:        series.MatrixKey,
+				DeploymentLineup: series.DeploymentLineup,
+				Seed:             evalSessionChildRunSeed(run.ExecutionPlan),
 			})
 		}
 	}

--- a/backend/internal/api/eval_sessions.go
+++ b/backend/internal/api/eval_sessions.go
@@ -38,11 +38,19 @@ type createEvalSessionResponse struct {
 	EvalSession evalSessionResponse            `json:"eval_session"`
 	RunIDs      []uuid.UUID                    `json:"run_ids"`
 	SeededRuns  []evalSessionSeededRunResponse `json:"seeded_runs,omitempty"`
+	SeriesRuns  []evalSessionSeriesRunResponse `json:"series_runs,omitempty"`
 }
 
 type evalSessionSeededRunResponse struct {
 	RunID uuid.UUID `json:"run_id"`
 	Seed  int64     `json:"seed"`
+}
+
+type evalSessionSeriesRunResponse struct {
+	RunID            uuid.UUID `json:"run_id"`
+	MatrixKey        string    `json:"matrix_key,omitempty"`
+	DeploymentLineup string    `json:"deployment_lineup,omitempty"`
+	Seed             *int64    `json:"seed,omitempty"`
 }
 
 type evalSessionResponse struct {
@@ -111,6 +119,7 @@ func createEvalSessionHandler(logger *slog.Logger, service RunCreationService) h
 			EvalSession: buildEvalSessionResponse(result.Session),
 			RunIDs:      append([]uuid.UUID(nil), result.RunIDs...),
 			SeededRuns:  buildEvalSessionSeededRunResponse(result.SeededRuns),
+			SeriesRuns:  buildEvalSessionSeriesRunResponse(result.SeriesRuns),
 		})
 	}
 }
@@ -175,6 +184,22 @@ func buildEvalSessionSeededRunResponse(items []EvalSessionSeededRun) []evalSessi
 		out = append(out, evalSessionSeededRunResponse{
 			RunID: item.RunID,
 			Seed:  item.Seed,
+		})
+	}
+	return out
+}
+
+func buildEvalSessionSeriesRunResponse(items []EvalSessionSeriesRun) []evalSessionSeriesRunResponse {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]evalSessionSeriesRunResponse, 0, len(items))
+	for _, item := range items {
+		out = append(out, evalSessionSeriesRunResponse{
+			RunID:            item.RunID,
+			MatrixKey:        item.MatrixKey,
+			DeploymentLineup: item.DeploymentLineup,
+			Seed:             cloneInt64Ptr(item.Seed),
 		})
 	}
 	return out
@@ -255,48 +280,11 @@ func decodeCreateEvalSessionRequest(_ context.Context, r *http.Request) (CreateE
 
 	participants := make([]EvalSessionParticipantInput, 0, len(body.Participants))
 	for _, participant := range body.Participants {
-		var deploymentID *uuid.UUID
-		if strings.TrimSpace(participant.AgentDeploymentID) != "" {
-			parsedDeploymentID, parseErr := parseRequiredUUID(participant.AgentDeploymentID, "participants.agent_deployment_id", "invalid_participants")
-			if parseErr != nil {
-				return CreateEvalSessionInput{}, RunCreationValidationError{
-					Code:    "invalid_participants",
-					Message: "participants must contain valid agent_deployment_id values",
-				}
-			}
-			deploymentID = &parsedDeploymentID
+		parsed, parseErr := decodeEvalSessionParticipant(participant, "participants")
+		if parseErr != nil {
+			return CreateEvalSessionInput{}, parseErr
 		}
-
-		var buildVersionID *uuid.UUID
-		if deploymentID == nil && strings.TrimSpace(participant.AgentBuildVersionID) != "" {
-			parsedBuildVersionID, parseErr := parseRequiredUUID(participant.AgentBuildVersionID, "participants.agent_build_version_id", "invalid_participants")
-			if parseErr != nil {
-				return CreateEvalSessionInput{}, RunCreationValidationError{
-					Code:    "invalid_participants",
-					Message: "participants must contain valid agent_deployment_id values",
-				}
-			}
-			buildVersionID = &parsedBuildVersionID
-		}
-		if deploymentID == nil && buildVersionID == nil {
-			return CreateEvalSessionInput{}, RunCreationValidationError{
-				Code:    "invalid_participants",
-				Message: "participants must contain valid agent_deployment_id values",
-			}
-		}
-
-		label := strings.TrimSpace(participant.Label)
-		if label == "" {
-			return CreateEvalSessionInput{}, RunCreationValidationError{
-				Code:    "invalid_participants",
-				Message: "participants must contain non-empty labels",
-			}
-		}
-		participants = append(participants, EvalSessionParticipantInput{
-			AgentDeploymentID:   deploymentID,
-			AgentBuildVersionID: buildVersionID,
-			Label:               label,
-		})
+		participants = append(participants, parsed)
 	}
 
 	config, err := decodeEvalSessionConfig(body.EvalSession)
@@ -325,6 +313,7 @@ func decodeEvalSessionConfig(raw json.RawMessage) (CreateEvalSessionConfigInput,
 		ReliabilityWeights  json.RawMessage `json:"reliability_weights"`
 		SeedFanout          json.RawMessage `json:"seed_fanout"`
 		SchemaVersion       json.RawMessage `json:"schema_version"`
+		RunMatrix           json.RawMessage `json:"run_matrix"`
 	}
 
 	var body evalSessionConfigRequest
@@ -376,6 +365,15 @@ func decodeEvalSessionConfig(raw json.RawMessage) (CreateEvalSessionConfigInput,
 	details = append(details, reliabilityDetails...)
 	seedFanout, seedFanoutDetails := decodeEvalSessionSeedFanout(body.SeedFanout, repetitions)
 	details = append(details, seedFanoutDetails...)
+	runMatrix, runMatrixDetails := decodeEvalSessionRunMatrix(body.RunMatrix, repetitions)
+	details = append(details, runMatrixDetails...)
+	if len(seedFanout) > 0 && len(runMatrix) > 0 {
+		details = append(details, evalSessionValidationDetail{
+			Field:   "eval_session.run_matrix",
+			Code:    "eval_session.run_matrix.seed_fanout_conflict",
+			Message: "run_matrix cannot be combined with seed_fanout",
+		})
+	}
 
 	if aggregation.Method == "weighted_mean" && reliabilityWeights == nil {
 		details = append(details, evalSessionValidationDetail{
@@ -396,8 +394,162 @@ func decodeEvalSessionConfig(raw json.RawMessage) (CreateEvalSessionConfigInput,
 		RoutingTaskSnapshot: routingTaskSnapshot,
 		ReliabilityWeights:  reliabilityWeights,
 		SeedFanout:          seedFanout,
+		RunMatrix:           runMatrix,
 		SchemaVersion:       schemaVersion,
 	}, nil
+}
+
+func decodeEvalSessionParticipant(participant createEvalSessionParticipant, fieldPrefix string) (EvalSessionParticipantInput, error) {
+	var deploymentID *uuid.UUID
+	if strings.TrimSpace(participant.AgentDeploymentID) != "" {
+		parsedDeploymentID, parseErr := parseRequiredUUID(participant.AgentDeploymentID, fieldPrefix+".agent_deployment_id", "invalid_participants")
+		if parseErr != nil {
+			return EvalSessionParticipantInput{}, RunCreationValidationError{
+				Code:    "invalid_participants",
+				Message: "participants must contain valid agent_deployment_id values",
+			}
+		}
+		deploymentID = &parsedDeploymentID
+	}
+
+	var buildVersionID *uuid.UUID
+	if deploymentID == nil && strings.TrimSpace(participant.AgentBuildVersionID) != "" {
+		parsedBuildVersionID, parseErr := parseRequiredUUID(participant.AgentBuildVersionID, fieldPrefix+".agent_build_version_id", "invalid_participants")
+		if parseErr != nil {
+			return EvalSessionParticipantInput{}, RunCreationValidationError{
+				Code:    "invalid_participants",
+				Message: "participants must contain valid agent_deployment_id values",
+			}
+		}
+		buildVersionID = &parsedBuildVersionID
+	}
+	if deploymentID == nil && buildVersionID == nil {
+		return EvalSessionParticipantInput{}, RunCreationValidationError{
+			Code:    "invalid_participants",
+			Message: "participants must contain valid agent_deployment_id values",
+		}
+	}
+
+	label := strings.TrimSpace(participant.Label)
+	if label == "" {
+		return EvalSessionParticipantInput{}, RunCreationValidationError{
+			Code:    "invalid_participants",
+			Message: "participants must contain non-empty labels",
+		}
+	}
+	return EvalSessionParticipantInput{
+		AgentDeploymentID:   deploymentID,
+		AgentBuildVersionID: buildVersionID,
+		Label:               label,
+	}, nil
+}
+
+func decodeEvalSessionRunMatrix(raw json.RawMessage, repetitions int32) ([]EvalSessionRunMatrixEntryInput, []evalSessionValidationDetail) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil, nil
+	}
+	type runMatrixEntryRequest struct {
+		Key              json.RawMessage                `json:"key"`
+		DeploymentLineup json.RawMessage                `json:"deployment_lineup"`
+		Seed             json.RawMessage                `json:"seed"`
+		Participants     []createEvalSessionParticipant `json:"participants"`
+	}
+	var rawEntries []runMatrixEntryRequest
+	if err := json.Unmarshal(raw, &rawEntries); err != nil {
+		return nil, []evalSessionValidationDetail{{
+			Field:   "eval_session.run_matrix",
+			Code:    "eval_session.run_matrix.invalid",
+			Message: "run_matrix must be an array of child run entries",
+		}}
+	}
+	details := make([]evalSessionValidationDetail, 0)
+	if int32(len(rawEntries)) != repetitions {
+		details = append(details, evalSessionValidationDetail{
+			Field:   "eval_session.run_matrix",
+			Code:    "eval_session.run_matrix.length_mismatch",
+			Message: "run_matrix length must match repetitions",
+		})
+	}
+	entries := make([]EvalSessionRunMatrixEntryInput, 0, len(rawEntries))
+	seenKeys := make(map[string]struct{}, len(rawEntries))
+	for idx, rawEntry := range rawEntries {
+		field := fmt.Sprintf("eval_session.run_matrix[%d]", idx)
+		key, ok := decodeRequiredString(rawEntry.Key)
+		if !ok {
+			details = append(details, evalSessionValidationDetail{
+				Field:   field + ".key",
+				Code:    "eval_session.run_matrix.key.invalid",
+				Message: "run_matrix entries must include a non-empty key",
+			})
+		}
+		if _, exists := seenKeys[key]; key != "" && exists {
+			details = append(details, evalSessionValidationDetail{
+				Field:   field + ".key",
+				Code:    "eval_session.run_matrix.key.duplicate",
+				Message: "run_matrix entry keys must be unique",
+			})
+		}
+		seenKeys[key] = struct{}{}
+
+		deploymentLineup := ""
+		if len(bytes.TrimSpace(rawEntry.DeploymentLineup)) > 0 {
+			lineup, lineupOK := decodeRequiredString(rawEntry.DeploymentLineup)
+			if !lineupOK {
+				details = append(details, evalSessionValidationDetail{
+					Field:   field + ".deployment_lineup",
+					Code:    "eval_session.run_matrix.deployment_lineup.invalid",
+					Message: "deployment_lineup must be a non-empty string when provided",
+				})
+			}
+			deploymentLineup = lineup
+		}
+
+		var seed *int64
+		if len(bytes.TrimSpace(rawEntry.Seed)) > 0 {
+			var parsedSeed int64
+			if err := json.Unmarshal(rawEntry.Seed, &parsedSeed); err != nil || parsedSeed < 1 {
+				details = append(details, evalSessionValidationDetail{
+					Field:   field + ".seed",
+					Code:    "eval_session.run_matrix.seed.invalid",
+					Message: "run_matrix seed must be a positive integer when provided",
+				})
+			} else {
+				seed = &parsedSeed
+			}
+		}
+
+		if len(rawEntry.Participants) == 0 {
+			details = append(details, evalSessionValidationDetail{
+				Field:   field + ".participants",
+				Code:    "eval_session.run_matrix.participants.required",
+				Message: "run_matrix entries must include at least one participant",
+			})
+		}
+		participants := make([]EvalSessionParticipantInput, 0, len(rawEntry.Participants))
+		for participantIdx, participant := range rawEntry.Participants {
+			parsed, parseErr := decodeEvalSessionParticipant(participant, fmt.Sprintf("%s.participants[%d]", field, participantIdx))
+			if parseErr != nil {
+				details = append(details, evalSessionValidationDetail{
+					Field:   fmt.Sprintf("%s.participants[%d]", field, participantIdx),
+					Code:    "eval_session.run_matrix.participants.invalid",
+					Message: "run_matrix participants must contain valid deployment or build version IDs and labels",
+				})
+				continue
+			}
+			participants = append(participants, parsed)
+		}
+		entries = append(entries, EvalSessionRunMatrixEntryInput{
+			Key:              key,
+			DeploymentLineup: deploymentLineup,
+			Seed:             seed,
+			Participants:     participants,
+		})
+	}
+	if len(details) > 0 {
+		return nil, details
+	}
+	return entries, nil
 }
 
 func decodeEvalSessionSeedFanout(raw json.RawMessage, repetitions int32) ([]int64, []evalSessionValidationDetail) {

--- a/backend/internal/api/eval_sessions.go
+++ b/backend/internal/api/eval_sessions.go
@@ -291,6 +291,13 @@ func decodeCreateEvalSessionRequest(_ context.Context, r *http.Request) (CreateE
 	if err != nil {
 		return CreateEvalSessionInput{}, err
 	}
+	if len(participants) > 0 && len(config.RunMatrix) > 0 {
+		return CreateEvalSessionInput{}, evalSessionValidationError{Errors: []evalSessionValidationDetail{{
+			Field:   "participants",
+			Code:    "participants.run_matrix_conflict",
+			Message: "participants cannot be combined with eval_session.run_matrix; put participants on each matrix entry",
+		}}}
+	}
 
 	return CreateEvalSessionInput{
 		WorkspaceID:            workspaceID,
@@ -528,10 +535,20 @@ func decodeEvalSessionRunMatrix(raw json.RawMessage, repetitions int32) ([]EvalS
 		}
 		participants := make([]EvalSessionParticipantInput, 0, len(rawEntry.Participants))
 		for participantIdx, participant := range rawEntry.Participants {
-			parsed, parseErr := decodeEvalSessionParticipant(participant, fmt.Sprintf("%s.participants[%d]", field, participantIdx))
+			participantField := fmt.Sprintf("%s.participants[%d]", field, participantIdx)
+			parsed, parseErr := decodeEvalSessionParticipant(participant, participantField)
 			if parseErr != nil {
+				var validationErr RunCreationValidationError
+				if errors.As(parseErr, &validationErr) {
+					details = append(details, evalSessionValidationDetail{
+						Field:   participantField,
+						Code:    validationErr.Code,
+						Message: validationErr.Message,
+					})
+					continue
+				}
 				details = append(details, evalSessionValidationDetail{
-					Field:   fmt.Sprintf("%s.participants[%d]", field, participantIdx),
+					Field:   participantField,
 					Code:    "eval_session.run_matrix.participants.invalid",
 					Message: "run_matrix participants must contain valid deployment or build version IDs and labels",
 				})

--- a/backend/internal/api/run_service.go
+++ b/backend/internal/api/run_service.go
@@ -472,6 +472,11 @@ func buildExecutionPlan(input CreateRunInput, runAgents []repository.CreateQueue
 		MaxIterations *int32 `json:"max_iterations,omitempty"`
 	}
 
+	type executionPlanSeries struct {
+		MatrixKey        string `json:"matrix_key,omitempty"`
+		DeploymentLineup string `json:"deployment_lineup,omitempty"`
+	}
+
 	type executionPlan struct {
 		WorkspaceID            uuid.UUID                   `json:"workspace_id"`
 		ChallengePackVersionID uuid.UUID                   `json:"challenge_pack_version_id"`
@@ -480,6 +485,7 @@ func buildExecutionPlan(input CreateRunInput, runAgents []repository.CreateQueue
 		Participants           []executionPlanRunAgent     `json:"participants"`
 		RuntimeLimits          *executionPlanRuntimeLimits `json:"runtime_limits,omitempty"`
 		Seed                   *int64                      `json:"seed,omitempty"`
+		Series                 *executionPlanSeries        `json:"series,omitempty"`
 	}
 
 	participants := make([]executionPlanRunAgent, 0, len(runAgents))
@@ -502,6 +508,12 @@ func buildExecutionPlan(input CreateRunInput, runAgents []repository.CreateQueue
 	}
 	if input.MaxIterations != nil {
 		plan.RuntimeLimits = &executionPlanRuntimeLimits{MaxIterations: cloneInt32Ptr(input.MaxIterations)}
+	}
+	if input.SeriesMatrixKey != "" || input.SeriesDeploymentLineup != "" {
+		plan.Series = &executionPlanSeries{
+			MatrixKey:        input.SeriesMatrixKey,
+			DeploymentLineup: input.SeriesDeploymentLineup,
+		}
 	}
 
 	payload, err := json.Marshal(plan)

--- a/backend/internal/api/run_service_test.go
+++ b/backend/internal/api/run_service_test.go
@@ -746,6 +746,132 @@ func TestRunCreationManagerCreateEvalSessionPersistsSeedFanout(t *testing.T) {
 	}
 }
 
+func TestRunCreationManagerCreateEvalSessionExpandsRunMatrix(t *testing.T) {
+	workspaceID := uuid.New()
+	challengePackVersionID := uuid.New()
+	challengeInputSetID := uuid.New()
+	defaultDeploymentID := uuid.New()
+	smokeDeploymentID := uuid.New()
+	sessionID := uuid.New()
+	defaultRunID := uuid.New()
+	smokeRunID := uuid.New()
+	maxIterations := int32(5)
+	caller := Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}
+
+	repo := &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{ID: challengePackVersionID},
+		challengeInputSets: []repository.ChallengeInputSetSummary{
+			{ID: challengeInputSetID, ChallengePackVersionID: challengePackVersionID},
+		},
+		challengeIdentityIDs: []uuid.UUID{uuid.New()},
+		deployments: []repository.RunnableDeployment{
+			{
+				ID:                        defaultDeploymentID,
+				OrganizationID:            uuid.MustParse("00000000-0000-0000-0000-000000000111"),
+				WorkspaceID:               workspaceID,
+				Name:                      "Default Agent",
+				AgentDeploymentSnapshotID: uuid.New(),
+			},
+			{
+				ID:                        smokeDeploymentID,
+				OrganizationID:            uuid.MustParse("00000000-0000-0000-0000-000000000111"),
+				WorkspaceID:               workspaceID,
+				Name:                      "Smoke Agent",
+				AgentDeploymentSnapshotID: uuid.New(),
+			},
+		},
+		createEvalSessionWithRunsResult: repository.CreateEvalSessionWithQueuedRunsResult{
+			Session: domain.EvalSession{ID: sessionID, Status: domain.EvalSessionStatusQueued, Repetitions: 2, SchemaVersion: 1},
+			Runs: []domain.Run{
+				{ID: defaultRunID, EvalSessionID: &sessionID, ExecutionPlan: json.RawMessage(`{"seed":1}`)},
+				{ID: smokeRunID, EvalSessionID: &sessionID, ExecutionPlan: json.RawMessage(`{"seed":1}`)},
+			},
+		},
+	}
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, &fakeRunWorkflowStarter{}, nil)
+
+	result, err := manager.CreateEvalSession(context.Background(), caller, CreateEvalSessionInput{
+		WorkspaceID:            workspaceID,
+		ChallengePackVersionID: challengePackVersionID,
+		ExecutionMode:          "single_agent",
+		Name:                   "Lineup race",
+		MaxIterations:          &maxIterations,
+		EvalSession: CreateEvalSessionConfigInput{
+			Repetitions: 2,
+			Aggregation: EvalSessionAggregationInput{
+				Method:             "mean",
+				ReportVariance:     true,
+				ConfidenceInterval: 0.95,
+			},
+			RoutingTaskSnapshot: EvalSessionRoutingTaskSnapshotInput{
+				Routing: json.RawMessage(`{"mode":"series"}`),
+				Task:    json.RawMessage(`{"pack_version":"v1"}`),
+			},
+			RunMatrix: []EvalSessionRunMatrixEntryInput{
+				{
+					Key:              "default:seed-1",
+					DeploymentLineup: "default",
+					Seed:             int64Ptr(1),
+					Participants: []EvalSessionParticipantInput{
+						{AgentDeploymentID: &defaultDeploymentID, Label: "Primary"},
+					},
+				},
+				{
+					Key:              "smoke:seed-1",
+					DeploymentLineup: "smoke",
+					Seed:             int64Ptr(1),
+					Participants: []EvalSessionParticipantInput{
+						{AgentDeploymentID: &smokeDeploymentID, Label: "Primary"},
+					},
+				},
+			},
+			SchemaVersion: 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateEvalSession returned error: %v", err)
+	}
+
+	if len(repo.createEvalSessionWithRunsParams.Runs) != 2 {
+		t.Fatalf("queued run count = %d, want 2", len(repo.createEvalSessionWithRunsParams.Runs))
+	}
+	firstRun := repo.createEvalSessionWithRunsParams.Runs[0]
+	secondRun := repo.createEvalSessionWithRunsParams.Runs[1]
+	if firstRun.RunAgents[0].AgentDeploymentID != defaultDeploymentID || secondRun.RunAgents[0].AgentDeploymentID != smokeDeploymentID {
+		t.Fatalf("run matrix deployments = %s/%s, want %s/%s", firstRun.RunAgents[0].AgentDeploymentID, secondRun.RunAgents[0].AgentDeploymentID, defaultDeploymentID, smokeDeploymentID)
+	}
+	if firstRun.Name != "Lineup race [1/2]" || secondRun.Name != "Lineup race [2/2]" {
+		t.Fatalf("child names = %q/%q, want suffixed names", firstRun.Name, secondRun.Name)
+	}
+	if got := executionPlanTestSeed(t, firstRun.ExecutionPlan); got != 1 {
+		t.Fatalf("first execution plan seed = %d, want 1", got)
+	}
+	if got := executionPlanTestMaxIterations(t, secondRun.ExecutionPlan); got != 5 {
+		t.Fatalf("second execution plan max_iterations = %d, want 5", got)
+	}
+	if len(result.SeriesRuns) != 2 || result.SeriesRuns[0].RunID != defaultRunID || result.SeriesRuns[0].DeploymentLineup != "default" || result.SeriesRuns[1].MatrixKey != "smoke:seed-1" {
+		t.Fatalf("series runs = %+v, want child metadata in order", result.SeriesRuns)
+	}
+	var routingSnapshot struct {
+		RunMatrix []struct {
+			Key              string `json:"key"`
+			DeploymentLineup string `json:"deployment_lineup"`
+			Seed             int64  `json:"seed"`
+		} `json:"run_matrix"`
+	}
+	if err := json.Unmarshal(repo.createEvalSessionWithRunsParams.Session.RoutingTaskSnapshot, &routingSnapshot); err != nil {
+		t.Fatalf("decode routing task snapshot: %v", err)
+	}
+	if len(routingSnapshot.RunMatrix) != 2 || routingSnapshot.RunMatrix[1].DeploymentLineup != "smoke" {
+		t.Fatalf("routing run_matrix = %+v, want matrix metadata persisted", routingSnapshot.RunMatrix)
+	}
+}
+
 func TestRunCreationManagerCreateEvalSessionStartsEvalSessionWorkflow(t *testing.T) {
 	workspaceID := uuid.New()
 	challengePackVersionID := uuid.New()

--- a/backend/internal/api/run_service_test.go
+++ b/backend/internal/api/run_service_test.go
@@ -788,8 +788,8 @@ func TestRunCreationManagerCreateEvalSessionExpandsRunMatrix(t *testing.T) {
 		createEvalSessionWithRunsResult: repository.CreateEvalSessionWithQueuedRunsResult{
 			Session: domain.EvalSession{ID: sessionID, Status: domain.EvalSessionStatusQueued, Repetitions: 2, SchemaVersion: 1},
 			Runs: []domain.Run{
-				{ID: defaultRunID, EvalSessionID: &sessionID, ExecutionPlan: json.RawMessage(`{"seed":1}`)},
-				{ID: smokeRunID, EvalSessionID: &sessionID, ExecutionPlan: json.RawMessage(`{"seed":1}`)},
+				{ID: smokeRunID, EvalSessionID: &sessionID, ExecutionPlan: json.RawMessage(`{"seed":1,"series":{"matrix_key":"smoke:seed-1","deployment_lineup":"smoke"}}`)},
+				{ID: defaultRunID, EvalSessionID: &sessionID, ExecutionPlan: json.RawMessage(`{"seed":1,"series":{"matrix_key":"default:seed-1","deployment_lineup":"default"}}`)},
 			},
 		},
 	}
@@ -854,8 +854,22 @@ func TestRunCreationManagerCreateEvalSessionExpandsRunMatrix(t *testing.T) {
 	if got := executionPlanTestMaxIterations(t, secondRun.ExecutionPlan); got != 5 {
 		t.Fatalf("second execution plan max_iterations = %d, want 5", got)
 	}
-	if len(result.SeriesRuns) != 2 || result.SeriesRuns[0].RunID != defaultRunID || result.SeriesRuns[0].DeploymentLineup != "default" || result.SeriesRuns[1].MatrixKey != "smoke:seed-1" {
-		t.Fatalf("series runs = %+v, want child metadata in order", result.SeriesRuns)
+	matrixKey, lineup := executionPlanTestSeries(t, firstRun.ExecutionPlan)
+	if matrixKey != "default:seed-1" || lineup != "default" {
+		t.Fatalf("first execution plan series = %q/%q, want default metadata", matrixKey, lineup)
+	}
+	matrixKey, lineup = executionPlanTestSeries(t, secondRun.ExecutionPlan)
+	if matrixKey != "smoke:seed-1" || lineup != "smoke" {
+		t.Fatalf("second execution plan series = %q/%q, want smoke metadata", matrixKey, lineup)
+	}
+	if len(result.SeriesRuns) != 2 ||
+		result.SeriesRuns[0].RunID != smokeRunID ||
+		result.SeriesRuns[0].DeploymentLineup != "smoke" ||
+		result.SeriesRuns[0].MatrixKey != "smoke:seed-1" ||
+		result.SeriesRuns[1].RunID != defaultRunID ||
+		result.SeriesRuns[1].DeploymentLineup != "default" ||
+		result.SeriesRuns[1].MatrixKey != "default:seed-1" {
+		t.Fatalf("series runs = %+v, want metadata from each run execution plan", result.SeriesRuns)
 	}
 	var routingSnapshot struct {
 		RunMatrix []struct {
@@ -2074,6 +2088,20 @@ func executionPlanTestSeed(t *testing.T, payload json.RawMessage) int64 {
 		t.Fatalf("decode execution plan: %v", err)
 	}
 	return plan.Seed
+}
+
+func executionPlanTestSeries(t *testing.T, payload json.RawMessage) (string, string) {
+	t.Helper()
+	var plan struct {
+		Series struct {
+			MatrixKey        string `json:"matrix_key"`
+			DeploymentLineup string `json:"deployment_lineup"`
+		} `json:"series"`
+	}
+	if err := json.Unmarshal(payload, &plan); err != nil {
+		t.Fatalf("decode execution plan: %v", err)
+	}
+	return plan.Series.MatrixKey, plan.Series.DeploymentLineup
 }
 
 func (f *fakeRunCreationRepository) GetRunnableChallengePackVersionByID(_ context.Context, _ uuid.UUID) (repository.RunnableChallengePackVersion, error) {

--- a/backend/internal/api/runs.go
+++ b/backend/internal/api/runs.go
@@ -65,6 +65,8 @@ type CreateRunInput struct {
 	RaceContextMinStepGap      *int32
 	MaxIterations              *int32
 	Seed                       *int64
+	SeriesMatrixKey            string
+	SeriesDeploymentLineup     string
 	CIMetadata                 *domain.RunCIMetadata
 }
 

--- a/backend/internal/api/runs_test.go
+++ b/backend/internal/api/runs_test.go
@@ -730,6 +730,9 @@ func TestCreateEvalSessionEndpointReturnsCreated(t *testing.T) {
 			SeededRuns: []EvalSessionSeededRun{
 				{RunID: runID, Seed: 1},
 			},
+			SeriesRuns: []EvalSessionSeriesRun{
+				{RunID: runID, MatrixKey: "default:seed-1", DeploymentLineup: "default", Seed: int64Ptr(1)},
+			},
 		},
 	}
 
@@ -797,6 +800,9 @@ func TestCreateEvalSessionEndpointReturnsCreated(t *testing.T) {
 	if len(response.SeededRuns) != 1 || response.SeededRuns[0].RunID != runID || response.SeededRuns[0].Seed != 1 {
 		t.Fatalf("seeded runs = %+v, want first run seed", response.SeededRuns)
 	}
+	if len(response.SeriesRuns) != 1 || response.SeriesRuns[0].RunID != runID || response.SeriesRuns[0].DeploymentLineup != "default" || response.SeriesRuns[0].Seed == nil || *response.SeriesRuns[0].Seed != 1 {
+		t.Fatalf("series runs = %+v, want first run metadata", response.SeriesRuns)
+	}
 	if service.evalSessionInput.WorkspaceID != workspaceID {
 		t.Fatalf("workspace id = %s, want %s", service.evalSessionInput.WorkspaceID, workspaceID)
 	}
@@ -808,6 +814,91 @@ func TestCreateEvalSessionEndpointReturnsCreated(t *testing.T) {
 	}
 	if got := service.evalSessionInput.EvalSession.SeedFanout; len(got) != 2 || got[0] != 1 || got[1] != 2 {
 		t.Fatalf("seed fanout = %v, want [1 2]", got)
+	}
+}
+
+func TestCreateEvalSessionEndpointAcceptsRunMatrix(t *testing.T) {
+	userID := uuid.New()
+	workspaceID := uuid.New()
+	firstDeploymentID := uuid.New()
+	secondDeploymentID := uuid.New()
+	service := &fakeRunCreationService{
+		evalSessionResult: CreateEvalSessionResult{
+			Session: domain.EvalSession{
+				ID:                     uuid.New(),
+				Status:                 domain.EvalSessionStatusQueued,
+				Repetitions:            2,
+				AggregationConfig:      domain.EvalSessionSnapshot{Document: []byte(`{"schema_version":1,"method":"mean","report_variance":true,"confidence_interval":0.95}`)},
+				SuccessThresholdConfig: domain.EvalSessionSnapshot{Document: []byte(`{"schema_version":1}`)},
+				RoutingTaskSnapshot:    domain.EvalSessionSnapshot{Document: []byte(`{"schema_version":1,"routing":{"mode":"series"},"task":{"pack_version":"v1"}}`)},
+				SchemaVersion:          1,
+				CreatedAt:              time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
+				UpdatedAt:              time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
+			},
+			RunIDs: []uuid.UUID{uuid.New(), uuid.New()},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/eval-sessions", bytes.NewBufferString(`{
+		"workspace_id":"`+workspaceID.String()+`",
+		"challenge_pack_version_id":"`+uuid.New().String()+`",
+		"execution_mode":"single_agent",
+		"eval_session":{
+			"repetitions":2,
+			"aggregation":{"method":"mean","report_variance":true,"confidence_interval":0.95},
+			"routing_task_snapshot":{"routing":{"mode":"series"},"task":{"pack_version":"v1"}},
+			"run_matrix":[
+				{"key":"default:seed-1","deployment_lineup":"default","seed":1,"participants":[{"agent_deployment_id":"`+firstDeploymentID.String()+`","label":"Primary"}]},
+				{"key":"smoke:seed-1","deployment_lineup":"smoke","seed":1,"participants":[{"agent_deployment_id":"`+secondDeploymentID.String()+`","label":"Primary"}]}
+			],
+			"schema_version":1
+		}
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(headerUserID, userID.String())
+	req.Header.Set(headerWorkspaceMemberships, workspaceID.String()+":workspace_member")
+	recorder := httptest.NewRecorder()
+
+	newRouter("dev", nil,
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		nil,
+		0,
+		service,
+		&fakeRunReadService{},
+		&fakeReplayReadService{},
+		stubHostedRunIngestionService{},
+		nil,
+		stubAgentDeploymentReadService{},
+		stubChallengePackReadService{},
+		stubAgentBuildService{},
+		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d (body: %s)", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+	matrix := service.evalSessionInput.EvalSession.RunMatrix
+	if len(matrix) != 2 || matrix[0].Key != "default:seed-1" || matrix[1].DeploymentLineup != "smoke" {
+		t.Fatalf("run matrix = %+v, want two entries", matrix)
+	}
+	if matrix[0].Seed == nil || *matrix[0].Seed != 1 {
+		t.Fatalf("run matrix seed = %v, want 1", matrix[0].Seed)
+	}
+	if len(matrix[1].Participants) != 1 || matrix[1].Participants[0].AgentDeploymentID == nil || *matrix[1].Participants[0].AgentDeploymentID != secondDeploymentID {
+		t.Fatalf("second matrix participants = %+v, want second deployment", matrix[1].Participants)
 	}
 }
 
@@ -849,6 +940,58 @@ func TestDecodeEvalSessionConfigRejectsInvalidSeedFanout(t *testing.T) {
 			if len(validationErr.Errors) == 0 || validationErr.Errors[0].Code != tc.code {
 				t.Fatalf("validation errors = %+v, want first code %s", validationErr.Errors, tc.code)
 			}
+		})
+	}
+}
+
+func TestDecodeEvalSessionConfigRejectsInvalidRunMatrix(t *testing.T) {
+	cases := []struct {
+		name     string
+		matrix   string
+		extra    string
+		wantCode string
+	}{
+		{
+			name:     "length_mismatch",
+			matrix:   `[{"key":"default:seed-1","seed":1,"participants":[{"agent_deployment_id":"` + uuid.New().String() + `","label":"Primary"}]}]`,
+			wantCode: "eval_session.run_matrix.length_mismatch",
+		},
+		{
+			name:     "duplicate_key",
+			matrix:   `[{"key":"dup","seed":1,"participants":[{"agent_deployment_id":"` + uuid.New().String() + `","label":"Primary"}]},{"key":"dup","seed":2,"participants":[{"agent_deployment_id":"` + uuid.New().String() + `","label":"Primary"}]}]`,
+			wantCode: "eval_session.run_matrix.key.duplicate",
+		},
+		{
+			name:     "non_positive_seed",
+			matrix:   `[{"key":"default:seed-1","seed":0,"participants":[{"agent_deployment_id":"` + uuid.New().String() + `","label":"Primary"}]},{"key":"default:seed-2","seed":2,"participants":[{"agent_deployment_id":"` + uuid.New().String() + `","label":"Primary"}]}]`,
+			wantCode: "eval_session.run_matrix.seed.invalid",
+		},
+		{
+			name:     "seed_fanout_conflict",
+			matrix:   `[{"key":"default:seed-1","seed":1,"participants":[{"agent_deployment_id":"` + uuid.New().String() + `","label":"Primary"}]},{"key":"default:seed-2","seed":2,"participants":[{"agent_deployment_id":"` + uuid.New().String() + `","label":"Primary"}]}]`,
+			extra:    `,"seed_fanout":{"strategy":"explicit","seeds":[1,2]}`,
+			wantCode: "eval_session.run_matrix.seed_fanout_conflict",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := decodeEvalSessionConfig(json.RawMessage(`{
+				"repetitions":2,
+				"aggregation":{"method":"mean","report_variance":true,"confidence_interval":0.95},
+				"routing_task_snapshot":{"routing":{"mode":"single_agent"},"task":{"pack_version":"v1"}},
+				"run_matrix":` + tc.matrix + tc.extra + `,
+				"schema_version":1
+			}`))
+			var validationErr evalSessionValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("error = %v, want evalSessionValidationError", err)
+			}
+			for _, detail := range validationErr.Errors {
+				if detail.Code == tc.wantCode {
+					return
+				}
+			}
+			t.Fatalf("validation errors = %+v, want code %s", validationErr.Errors, tc.wantCode)
 		})
 	}
 }

--- a/backend/internal/api/runs_test.go
+++ b/backend/internal/api/runs_test.go
@@ -902,6 +902,34 @@ func TestCreateEvalSessionEndpointAcceptsRunMatrix(t *testing.T) {
 	}
 }
 
+func TestCreateEvalSessionEndpointRejectsParticipantsWithRunMatrix(t *testing.T) {
+	workspaceID := uuid.New()
+	deploymentID := uuid.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/eval-sessions", bytes.NewBufferString(`{
+		"workspace_id":"`+workspaceID.String()+`",
+		"challenge_pack_version_id":"`+uuid.New().String()+`",
+		"participants":[{"agent_deployment_id":"`+deploymentID.String()+`","label":"Primary"}],
+		"execution_mode":"single_agent",
+		"eval_session":{
+			"repetitions":1,
+			"aggregation":{"method":"mean","report_variance":true,"confidence_interval":0.95},
+			"routing_task_snapshot":{"routing":{"mode":"series"},"task":{"pack_version":"v1"}},
+			"run_matrix":[
+				{"key":"default:seed-1","deployment_lineup":"default","seed":1,"participants":[{"agent_deployment_id":"`+deploymentID.String()+`","label":"default"}]}
+			],
+			"schema_version":1
+		}
+	}`))
+	_, err := decodeCreateEvalSessionRequest(req.Context(), req)
+	var validationErr evalSessionValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error = %v, want evalSessionValidationError", err)
+	}
+	if len(validationErr.Errors) != 1 || validationErr.Errors[0].Code != "participants.run_matrix_conflict" {
+		t.Fatalf("validation errors = %+v, want participants/run_matrix conflict", validationErr.Errors)
+	}
+}
+
 func TestDecodeEvalSessionConfigRejectsInvalidSeedFanout(t *testing.T) {
 	cases := []struct {
 		name string
@@ -941,6 +969,28 @@ func TestDecodeEvalSessionConfigRejectsInvalidSeedFanout(t *testing.T) {
 				t.Fatalf("validation errors = %+v, want first code %s", validationErr.Errors, tc.code)
 			}
 		})
+	}
+}
+
+func TestDecodeEvalSessionConfigPreservesMatrixParticipantErrorCode(t *testing.T) {
+	_, err := decodeEvalSessionConfig(json.RawMessage(`{
+		"repetitions":1,
+		"aggregation":{"method":"mean","report_variance":true,"confidence_interval":0.95},
+		"routing_task_snapshot":{"routing":{"mode":"single_agent"},"task":{"pack_version":"v1"}},
+		"run_matrix":[
+			{"key":"default:seed-1","seed":1,"participants":[{"agent_deployment_id":"not-a-uuid","label":"Primary"}]}
+		],
+		"schema_version":1
+	}`))
+	var validationErr evalSessionValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error = %v, want evalSessionValidationError", err)
+	}
+	if len(validationErr.Errors) != 1 {
+		t.Fatalf("validation errors = %+v, want one participant error", validationErr.Errors)
+	}
+	if validationErr.Errors[0].Field != "eval_session.run_matrix[0].participants[0]" || validationErr.Errors[0].Code != "invalid_participants" {
+		t.Fatalf("validation error = %+v, want field path and invalid_participants code", validationErr.Errors[0])
 	}
 }
 

--- a/backend/internal/repository/eval_session_aggregation.go
+++ b/backend/internal/repository/eval_session_aggregation.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -70,6 +71,7 @@ type evalSessionParticipantAggregate struct {
 	PassAtK       *evalSessionPassMetricSeries          `json:"pass_at_k,omitempty"`
 	PassPowK      *evalSessionPassMetricSeries          `json:"pass_pow_k,omitempty"`
 	MetricRouting *evalSessionMetricRouting             `json:"metric_routing,omitempty"`
+	ObservedRuns  int                                   `json:"-"`
 }
 
 type evalSessionTaskSuccess struct {
@@ -143,6 +145,7 @@ type evalSessionAggregateEvidence struct {
 type evalSessionAggregateSource struct {
 	RunID              uuid.UUID
 	Document           runScorecardDocument
+	DeploymentLineup   string
 	ParticipantSources []evalSessionAggregateParticipantSource
 }
 
@@ -287,7 +290,8 @@ func (r *Repository) AggregateEvalSession(ctx context.Context, evalSessionID uui
 			if err := json.Unmarshal(scorecard.Scorecard, &document); err != nil {
 				return EvalSessionAggregateRecord{}, fmt.Errorf("decode run scorecard %s: %w", run.ID, err)
 			}
-			participantSources, participantWarnings, err := r.buildEvalSessionAggregateParticipantSources(ctx, run.ID, document, behavior)
+			deploymentLineup := evalSessionRunSeriesDeploymentLineup(run.ExecutionPlan)
+			participantSources, participantWarnings, err := r.buildEvalSessionAggregateParticipantSources(ctx, run.ID, document, behavior, deploymentLineup)
 			if err != nil {
 				return EvalSessionAggregateRecord{}, fmt.Errorf("build eval session participant sources for run %s: %w", run.ID, err)
 			}
@@ -295,6 +299,7 @@ func (r *Repository) AggregateEvalSession(ctx context.Context, evalSessionID uui
 			sources = append(sources, evalSessionAggregateSource{
 				RunID:              run.ID,
 				Document:           document,
+				DeploymentLineup:   deploymentLineup,
 				ParticipantSources: participantSources,
 			})
 		case errors.Is(scorecardErr, ErrRunScorecardNotFound):
@@ -398,6 +403,51 @@ func evalSessionKValues(repetitions int) []int {
 	return values
 }
 
+func evalSessionKValuesWithEffectiveK(values []int, effectiveK int) []int {
+	set := map[int]struct{}{}
+	for _, value := range values {
+		if value > 0 {
+			set[value] = struct{}{}
+		}
+	}
+	if effectiveK > 0 {
+		set[effectiveK] = struct{}{}
+	}
+	result := make([]int, 0, len(set))
+	for value := range set {
+		result = append(result, value)
+	}
+	sort.Ints(result)
+	return result
+}
+
+func evalSessionRunSeriesDeploymentLineup(executionPlan json.RawMessage) string {
+	if len(bytes.TrimSpace(executionPlan)) == 0 {
+		return ""
+	}
+	var document struct {
+		Series struct {
+			DeploymentLineup string `json:"deployment_lineup"`
+		} `json:"series"`
+	}
+	if err := json.Unmarshal(executionPlan, &document); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(document.Series.DeploymentLineup)
+}
+
+func evalSessionSeriesParticipantLabel(deploymentLineup string, label string) string {
+	trimmedLabel := strings.TrimSpace(label)
+	trimmedLineup := strings.TrimSpace(deploymentLineup)
+	if trimmedLineup == "" || trimmedLabel == "" || strings.HasPrefix(trimmedLabel, trimmedLineup+" / ") {
+		return trimmedLabel
+	}
+	if trimmedLabel == trimmedLineup {
+		return trimmedLineup
+	}
+	return trimmedLineup + " / " + trimmedLabel
+}
+
 func mapValue(value any) (map[string]any, bool) {
 	result, ok := value.(map[string]any)
 	return result, ok
@@ -438,6 +488,7 @@ func (r *Repository) buildEvalSessionAggregateParticipantSources(
 	runID uuid.UUID,
 	document runScorecardDocument,
 	behavior evalSessionAggregateBehavior,
+	deploymentLineup string,
 ) ([]evalSessionAggregateParticipantSource, []string, error) {
 	participantSources := make([]evalSessionAggregateParticipantSource, 0, len(document.Agents))
 	warnings := make([]string, 0)
@@ -446,7 +497,7 @@ func (r *Repository) buildEvalSessionAggregateParticipantSources(
 		participantSource := evalSessionAggregateParticipantSource{
 			Key: evalSessionParticipantKey{
 				LaneIndex: agent.LaneIndex,
-				Label:     agent.Label,
+				Label:     evalSessionSeriesParticipantLabel(deploymentLineup, agent.Label),
 			},
 			Agent: agent,
 		}
@@ -718,6 +769,11 @@ func buildEvalSessionAggregatePayload(
 		}
 	}
 
+	aggregateBehavior := behavior
+	aggregateBehavior.EffectiveK = evalSessionAggregateEffectiveK(participantAccumulators, behavior.EffectiveK)
+	aggregateBehavior.KValues = evalSessionKValuesWithEffectiveK(behavior.KValues, aggregateBehavior.EffectiveK)
+	expectedParticipantRuns := aggregateBehavior.EffectiveK
+
 	evidence := evalSessionAggregateEvidence{
 		MissingScorecardRunIDs: append([]uuid.UUID(nil), missingScorecardRunIDs...),
 	}
@@ -745,14 +801,15 @@ func buildEvalSessionAggregatePayload(
 	for _, key := range participantKeys {
 		accumulator := participantAccumulators[key]
 		participant := evalSessionParticipantAggregate{
-			LaneIndex: key.LaneIndex,
-			Label:     key.Label,
+			LaneIndex:    key.LaneIndex,
+			Label:        key.Label,
+			ObservedRuns: evalSessionParticipantObservedRuns(accumulator),
 		}
 		if len(accumulator.Overall) > 0 {
 			overall := buildEvalSessionMetricAggregate(accumulator.Overall)
 			participant.Overall = &overall
-			if len(accumulator.Overall) < len(sources) {
-				warnings = append(warnings, fmt.Sprintf("participant %q (lane %d) overall aggregate uses %d of %d scored child runs", key.Label, key.LaneIndex, len(accumulator.Overall), len(sources)))
+			if len(accumulator.Overall) < expectedParticipantRuns {
+				warnings = append(warnings, fmt.Sprintf("participant %q (lane %d) overall aggregate uses %d of %d expected scored child runs", key.Label, key.LaneIndex, len(accumulator.Overall), expectedParticipantRuns))
 			}
 			if len(accumulator.Overall) < 2 {
 				insufficientEvidence = true
@@ -763,8 +820,8 @@ func buildEvalSessionAggregatePayload(
 			for _, dimKey := range sortedMetricKeys(accumulator.Dimensions) {
 				values := accumulator.Dimensions[dimKey]
 				participant.Dimensions[dimKey] = buildEvalSessionMetricAggregate(values)
-				if len(values) < len(sources) {
-					warnings = append(warnings, fmt.Sprintf("participant %q (lane %d) dimension %q aggregate uses %d of %d scored child runs", key.Label, key.LaneIndex, dimKey, len(values), len(sources)))
+				if len(values) < expectedParticipantRuns {
+					warnings = append(warnings, fmt.Sprintf("participant %q (lane %d) dimension %q aggregate uses %d of %d expected scored child runs", key.Label, key.LaneIndex, dimKey, len(values), expectedParticipantRuns))
 				}
 				if len(values) < 2 {
 					insufficientEvidence = true
@@ -772,13 +829,13 @@ func buildEvalSessionAggregatePayload(
 			}
 		}
 		if len(accumulator.TaskOutcomes) > 0 {
-			participant.TaskSuccess = buildEvalSessionTaskSuccess(accumulator.TaskOutcomes, behavior.KValues)
-			participant.PassAtK = buildEvalSessionPassMetricSeries(participant.TaskSuccess, behavior.KValues, behavior.EffectiveK, "pass_at_k")
-			participant.PassPowK = buildEvalSessionPassMetricSeries(participant.TaskSuccess, behavior.KValues, behavior.EffectiveK, "pass_pow_k")
-			participant.MetricRouting = buildEvalSessionMetricRouting(behavior, participant.PassAtK, participant.PassPowK)
+			participant.TaskSuccess = buildEvalSessionTaskSuccess(accumulator.TaskOutcomes, aggregateBehavior.KValues)
+			participant.PassAtK = buildEvalSessionPassMetricSeries(participant.TaskSuccess, aggregateBehavior.KValues, aggregateBehavior.EffectiveK, "pass_at_k")
+			participant.PassPowK = buildEvalSessionPassMetricSeries(participant.TaskSuccess, aggregateBehavior.KValues, aggregateBehavior.EffectiveK, "pass_pow_k")
+			participant.MetricRouting = buildEvalSessionMetricRouting(aggregateBehavior, participant.PassAtK, participant.PassPowK)
 			for _, task := range participant.TaskSuccess {
-				if task.ObservedTrials < len(sources) {
-					warnings = append(warnings, fmt.Sprintf("participant %q (lane %d) task %q uses %d of %d scored child runs", key.Label, key.LaneIndex, task.TaskKey, task.ObservedTrials, len(sources)))
+				if task.ObservedTrials < expectedParticipantRuns {
+					warnings = append(warnings, fmt.Sprintf("participant %q (lane %d) task %q uses %d of %d expected scored child runs", key.Label, key.LaneIndex, task.TaskKey, task.ObservedTrials, expectedParticipantRuns))
 				}
 			}
 		}
@@ -795,9 +852,9 @@ func buildEvalSessionAggregatePayload(
 		document.PassPowK = participant.PassPowK
 		document.MetricRouting = participant.MetricRouting
 	} else if len(document.Participants) > 1 {
-		document.Comparison = buildEvalSessionRepeatedComparison(document.Participants, behavior.EffectiveK, len(sources))
+		document.Comparison = buildEvalSessionRepeatedComparison(document.Participants, aggregateBehavior.EffectiveK, evalSessionComparisonEvidenceCount(document.Participants, len(sources)))
 		if document.Comparison != nil && document.Comparison.Status == "clear_winner" && document.Comparison.WinnerLaneIndex != nil {
-			if winner, ok := evalSessionParticipantByLane(document.Participants, *document.Comparison.WinnerLaneIndex); ok {
+			if winner, ok := evalSessionParticipantByComparisonWinner(document.Participants, document.Comparison); ok {
 				document.TopLevelSource = "repeated_clear_winner"
 				document.Overall = winner.Overall
 				document.Dimensions = winner.Dimensions
@@ -834,12 +891,63 @@ func defaultEvalSessionParticipantSources(source evalSessionAggregateSource) []e
 		participants = append(participants, evalSessionAggregateParticipantSource{
 			Key: evalSessionParticipantKey{
 				LaneIndex: agent.LaneIndex,
-				Label:     agent.Label,
+				Label:     evalSessionSeriesParticipantLabel(source.DeploymentLineup, agent.Label),
 			},
 			Agent: agent,
 		})
 	}
 	return participants
+}
+
+func evalSessionAggregateEffectiveK(
+	participantAccumulators map[evalSessionParticipantKey]*evalSessionParticipantAccumulator,
+	defaultEffectiveK int,
+) int {
+	effectiveK := defaultEffectiveK
+	if effectiveK < 1 {
+		effectiveK = 1
+	}
+	for _, accumulator := range participantAccumulators {
+		observedRuns := evalSessionParticipantObservedRuns(accumulator)
+		if observedRuns == 0 {
+			continue
+		}
+		if observedRuns < effectiveK {
+			effectiveK = observedRuns
+		}
+	}
+	return effectiveK
+}
+
+func evalSessionParticipantObservedRuns(accumulator *evalSessionParticipantAccumulator) int {
+	if accumulator == nil {
+		return 0
+	}
+	observedRuns := len(accumulator.Overall)
+	for _, values := range accumulator.Dimensions {
+		if len(values) > observedRuns {
+			observedRuns = len(values)
+		}
+	}
+	for _, taskOutcome := range accumulator.TaskOutcomes {
+		if taskOutcome != nil && len(taskOutcome.Outcomes) > observedRuns {
+			observedRuns = len(taskOutcome.Outcomes)
+		}
+	}
+	return observedRuns
+}
+
+func evalSessionComparisonEvidenceCount(participants []evalSessionParticipantAggregate, fallback int) int {
+	evidenceCount := fallback
+	for _, participant := range participants {
+		if participant.ObservedRuns == 0 {
+			continue
+		}
+		if evidenceCount == 0 || participant.ObservedRuns < evidenceCount {
+			evidenceCount = participant.ObservedRuns
+		}
+	}
+	return evidenceCount
 }
 
 func buildEvalSessionTaskSuccess(
@@ -1119,10 +1227,22 @@ func evalSessionComparisonMetric(
 	return participant.PassAtK, participant.PassAtK.Mean
 }
 
-func evalSessionParticipantByLane(
+func evalSessionParticipantByComparisonWinner(
 	participants []evalSessionParticipantAggregate,
-	laneIndex int32,
+	comparison *evalSessionRepeatedComparison,
 ) (evalSessionParticipantAggregate, bool) {
+	if comparison == nil || comparison.WinnerLaneIndex == nil {
+		return evalSessionParticipantAggregate{}, false
+	}
+	laneIndex := *comparison.WinnerLaneIndex
+	if comparison.WinnerLabel != "" {
+		for _, participant := range participants {
+			if participant.LaneIndex == laneIndex && participant.Label == comparison.WinnerLabel {
+				return participant, true
+			}
+		}
+		return evalSessionParticipantAggregate{}, false
+	}
 	for _, participant := range participants {
 		if participant.LaneIndex == laneIndex {
 			return participant, true

--- a/backend/internal/repository/eval_session_aggregation_test.go
+++ b/backend/internal/repository/eval_session_aggregation_test.go
@@ -391,6 +391,130 @@ func TestBuildEvalSessionAggregatePayloadComparisonClearWinner(t *testing.T) {
 	}
 }
 
+func TestBuildEvalSessionAggregatePayloadComparisonUsesWinnerLabel(t *testing.T) {
+	aggregateJSON, _, _, err := buildEvalSessionAggregatePayload(
+		3,
+		[]evalSessionAggregateSource{
+			evalSessionTestSameLaneComparisonSource("67676767-6767-6767-6767-676767676761"),
+			evalSessionTestSameLaneComparisonSource("67676767-6767-6767-6767-676767676762"),
+			evalSessionTestSameLaneComparisonSource("67676767-6767-6767-6767-676767676763"),
+		},
+		nil,
+		evalSessionAggregateBehavior{KValues: []int{1, 3, 5, 10}, EffectiveK: 3, SuccessThreshold: 0.8},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("buildEvalSessionAggregatePayload returned error: %v", err)
+	}
+
+	var aggregate evalSessionAggregateDocument
+	if err := json.Unmarshal(aggregateJSON, &aggregate); err != nil {
+		t.Fatalf("unmarshal aggregate: %v", err)
+	}
+	if aggregate.Comparison == nil || aggregate.Comparison.Status != "clear_winner" {
+		t.Fatalf("comparison = %#v, want clear_winner", aggregate.Comparison)
+	}
+	if aggregate.Comparison.WinnerLaneIndex == nil || *aggregate.Comparison.WinnerLaneIndex != 0 {
+		t.Fatalf("winner lane index = %v, want 0", aggregate.Comparison.WinnerLaneIndex)
+	}
+	if aggregate.Comparison.WinnerLabel != "smoke / Primary" {
+		t.Fatalf("winner label = %q, want smoke / Primary", aggregate.Comparison.WinnerLabel)
+	}
+	if aggregate.Overall == nil || math.Abs(aggregate.Overall.Mean-0.95) > 1e-9 {
+		t.Fatalf("top-level overall = %#v, want smoke winner aggregate", aggregate.Overall)
+	}
+}
+
+func TestBuildEvalSessionAggregatePayloadSeriesEffectiveKUsesRunsPerLineup(t *testing.T) {
+	aggregateJSON, _, _, err := buildEvalSessionAggregatePayload(
+		6,
+		[]evalSessionAggregateSource{
+			evalSessionTestSeriesSource("68686868-6868-6868-6868-686868686861", "default", false, 0.30),
+			evalSessionTestSeriesSource("68686868-6868-6868-6868-686868686862", "default", false, 0.30),
+			evalSessionTestSeriesSource("68686868-6868-6868-6868-686868686863", "default", false, 0.30),
+			evalSessionTestSeriesSource("68686868-6868-6868-6868-686868686864", "smoke", true, 0.95),
+			evalSessionTestSeriesSource("68686868-6868-6868-6868-686868686865", "smoke", true, 0.95),
+			evalSessionTestSeriesSource("68686868-6868-6868-6868-686868686866", "smoke", true, 0.95),
+		},
+		nil,
+		evalSessionAggregateBehavior{KValues: []int{1, 3, 5, 6, 10}, EffectiveK: 6, SuccessThreshold: 0.8},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("buildEvalSessionAggregatePayload returned error: %v", err)
+	}
+
+	var aggregate evalSessionAggregateDocument
+	if err := json.Unmarshal(aggregateJSON, &aggregate); err != nil {
+		t.Fatalf("unmarshal aggregate: %v", err)
+	}
+	if aggregate.Comparison == nil || aggregate.Comparison.EffectiveK != 3 {
+		t.Fatalf("comparison = %#v, want effective_k 3 from per-lineup repetitions", aggregate.Comparison)
+	}
+	if aggregate.Comparison.WinnerLabel != "smoke / Primary" {
+		t.Fatalf("winner label = %q, want smoke / Primary", aggregate.Comparison.WinnerLabel)
+	}
+	for _, participant := range aggregate.Participants {
+		if participant.MetricRouting == nil || participant.MetricRouting.EffectiveK != 3 {
+			t.Fatalf("participant = %#v, want metric routing effective_k 3", participant)
+		}
+	}
+}
+
+func TestBuildEvalSessionAggregatePayloadSeriesLabelsDisambiguateLineups(t *testing.T) {
+	aggregateJSON, _, _, err := buildEvalSessionAggregatePayload(
+		2,
+		[]evalSessionAggregateSource{
+			evalSessionTestSeriesDocumentSource("69696969-6969-6969-6969-696969696961", "default", 0.30),
+			evalSessionTestSeriesDocumentSource("69696969-6969-6969-6969-696969696962", "smoke", 0.95),
+		},
+		nil,
+		evalSessionAggregateBehavior{KValues: []int{1, 2, 3, 5, 10}, EffectiveK: 2, SuccessThreshold: 0.8},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("buildEvalSessionAggregatePayload returned error: %v", err)
+	}
+
+	var aggregate evalSessionAggregateDocument
+	if err := json.Unmarshal(aggregateJSON, &aggregate); err != nil {
+		t.Fatalf("unmarshal aggregate: %v", err)
+	}
+	if len(aggregate.Participants) != 2 {
+		t.Fatalf("participants = %#v, want separate lineup participants", aggregate.Participants)
+	}
+	labels := []string{aggregate.Participants[0].Label, aggregate.Participants[1].Label}
+	if !slices.Contains(labels, "default / Primary") || !slices.Contains(labels, "smoke / Primary") {
+		t.Fatalf("participant labels = %v, want lineup-qualified labels", labels)
+	}
+}
+
+func TestEvalSessionSeriesParticipantLabelAvoidsDuplicateLineup(t *testing.T) {
+	if got := evalSessionSeriesParticipantLabel("smoke", "smoke"); got != "smoke" {
+		t.Fatalf("label = %q, want smoke", got)
+	}
+	if got := evalSessionSeriesParticipantLabel("premium", "Primary"); got != "premium / Primary" {
+		t.Fatalf("label = %q, want premium / Primary", got)
+	}
+}
+
+func TestEvalSessionParticipantByComparisonWinnerRejectsMissingLabel(t *testing.T) {
+	laneIndex := int32(0)
+	_, ok := evalSessionParticipantByComparisonWinner(
+		[]evalSessionParticipantAggregate{
+			{LaneIndex: 0, Label: "default / Primary"},
+			{LaneIndex: 0, Label: "smoke / Primary"},
+		},
+		&evalSessionRepeatedComparison{
+			WinnerLaneIndex: &laneIndex,
+			WinnerLabel:     "premium / Primary",
+		},
+	)
+	if ok {
+		t.Fatal("winner lookup succeeded with mismatched non-empty label; want fail closed")
+	}
+}
+
 func TestBuildEvalSessionAggregatePayloadComparisonNoClearWinner(t *testing.T) {
 	aggregateJSON, evidenceJSON, _, err := buildEvalSessionAggregatePayload(
 		3,
@@ -619,6 +743,71 @@ func evalSessionTestComparisonSource(runID string, alphaSuccess bool, betaSucces
 			evalSessionTestTask("task-c", betaSuccess),
 		),
 	)
+}
+
+func evalSessionTestSameLaneComparisonSource(runID string) evalSessionAggregateSource {
+	return evalSessionTestSource(
+		runID,
+		evalSessionTestParticipant(
+			runIDToRunAgentID(runID, "00000000-0000-0000-0000-000000000001"),
+			0,
+			"default / Primary",
+			0.30,
+			map[string]float64{"correctness": 0.30},
+			evalSessionTestTask("task-a", false),
+			evalSessionTestTask("task-b", false),
+			evalSessionTestTask("task-c", false),
+		),
+		evalSessionTestParticipant(
+			runIDToRunAgentID(runID, "00000000-0000-0000-0000-000000000002"),
+			0,
+			"smoke / Primary",
+			0.95,
+			map[string]float64{"correctness": 0.95},
+			evalSessionTestTask("task-a", true),
+			evalSessionTestTask("task-b", true),
+			evalSessionTestTask("task-c", true),
+		),
+	)
+}
+
+func evalSessionTestSeriesSource(runID string, lineup string, success bool, overall float64) evalSessionAggregateSource {
+	label := evalSessionSeriesParticipantLabel(lineup, "Primary")
+	return evalSessionTestSource(
+		runID,
+		evalSessionTestParticipant(
+			runIDToRunAgentID(runID, "00000000-0000-0000-0000-000000000001"),
+			0,
+			label,
+			overall,
+			map[string]float64{"correctness": overall},
+			evalSessionTestTask("task-a", success),
+			evalSessionTestTask("task-b", success),
+			evalSessionTestTask("task-c", success),
+		),
+	)
+}
+
+func evalSessionTestSeriesDocumentSource(runID string, lineup string, overall float64) evalSessionAggregateSource {
+	agentID := uuid.MustParse(runIDToRunAgentID(runID, "00000000-0000-0000-0000-000000000001"))
+	return evalSessionAggregateSource{
+		RunID:            uuid.MustParse(runID),
+		DeploymentLineup: lineup,
+		Document: runScorecardDocument{
+			Agents: []runScorecardAgentSummary{
+				{
+					RunAgentID:   agentID,
+					LaneIndex:    0,
+					Label:        "Primary",
+					HasScorecard: true,
+					OverallScore: float64Ptr(overall),
+					Dimensions: map[string]comparisonScorecardDimensionInfo{
+						"correctness": {Score: float64Ptr(overall)},
+					},
+				},
+			},
+		},
+	}
 }
 
 func evalSessionTestOverlapSource(runID string, alpha map[string]bool, beta map[string]bool) evalSessionAggregateSource {

--- a/cli/cmd/eval_session_helpers.go
+++ b/cli/cmd/eval_session_helpers.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/agentclash/agentclash/cli/internal/output"
 	"github.com/spf13/cobra"
@@ -142,8 +143,35 @@ func presentCreatedEvalSession(rc *RunContext, result map[string]any) error {
 			seedByRunID[str(item["run_id"])] = str(item["seed"])
 		}
 	}
+	seriesByRunID := map[string]string{}
+	if seriesRuns, ok := result["series_runs"].([]any); ok {
+		for _, raw := range seriesRuns {
+			item, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			runID := str(item["run_id"])
+			parts := make([]string, 0, 3)
+			if lineup := str(item["deployment_lineup"]); lineup != "" {
+				parts = append(parts, "lineup "+lineup)
+			}
+			if seed := str(item["seed"]); seed != "" {
+				parts = append(parts, "seed "+seed)
+			}
+			if key := str(item["matrix_key"]); key != "" {
+				parts = append(parts, key)
+			}
+			if len(parts) > 0 {
+				seriesByRunID[runID] = strings.Join(parts, ", ")
+			}
+		}
+	}
 	for _, id := range runIDs {
 		runID := str(id)
+		if metadata := seriesByRunID[runID]; metadata != "" {
+			fmt.Fprintf(rc.Output.Writer(), "  - %s (%s)\n", runID, metadata)
+			continue
+		}
 		if seed := seedByRunID[runID]; seed != "" {
 			fmt.Fprintf(rc.Output.Writer(), "  - %s (seed %s)\n", runID, seed)
 			continue

--- a/cli/cmd/eval_session_test.go
+++ b/cli/cmd/eval_session_test.go
@@ -99,6 +99,48 @@ func TestBuildSeededEvalSessionBody(t *testing.T) {
 	}
 }
 
+func TestBuildSeriesEvalSessionBodyCrossesLineupsAndSeeds(t *testing.T) {
+	body, err := buildSeriesEvalSessionBody("ws-1", runCreateRequest{
+		ChallengePackVersionID: "pv-1",
+		ChallengeInputSetID:    "is-1",
+		Name:                   "lineup-series",
+		OfficialPackMode:       "full",
+		MaxIterations:          4,
+		Seeds:                  2,
+		ResolvedDeploymentLineups: []runCreateDeploymentLineup{
+			{Name: "default", DeploymentIDs: []string{"dep-default"}},
+			{Name: "smoke", DeploymentIDs: []string{"dep-smoke"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := body["execution_mode"]; got != "single_agent" {
+		t.Fatalf("execution_mode = %v, want single_agent", got)
+	}
+	if got := body["max_iterations"]; got != 4 {
+		t.Fatalf("max_iterations = %v, want 4", got)
+	}
+	session := body["eval_session"].(map[string]any)
+	if got := session["repetitions"]; got != 4 {
+		t.Fatalf("repetitions = %v, want 4", got)
+	}
+	matrix := session["run_matrix"].([]map[string]any)
+	if len(matrix) != 4 {
+		t.Fatalf("run_matrix length = %d, want 4", len(matrix))
+	}
+	if matrix[0]["key"] != "default:seed-1" || matrix[0]["deployment_lineup"] != "default" || matrix[0]["seed"] != 1 {
+		t.Fatalf("first matrix entry = %#v, want default seed 1", matrix[0])
+	}
+	if matrix[3]["key"] != "smoke:seed-2" {
+		t.Fatalf("last matrix key = %v, want smoke:seed-2", matrix[3]["key"])
+	}
+	participants := matrix[2]["participants"].([]map[string]any)
+	if len(participants) != 1 || participants[0]["agent_deployment_id"] != "dep-smoke" {
+		t.Fatalf("third matrix participants = %#v, want dep-smoke", participants)
+	}
+}
+
 func TestBuildEvalSessionBody_MultiDeployment_LabelsAndMode(t *testing.T) {
 	body, err := buildEvalSessionBody("ws-1", runCreateRequest{
 		ChallengePackVersionID: "pv-1",
@@ -323,6 +365,76 @@ func TestRunCreateSeedsRoutesToEvalSessions(t *testing.T) {
 	seeds, ok := seedFanout["seeds"].([]any)
 	if !ok || len(seeds) != 3 || seeds[0] != float64(1) || seeds[2] != float64(3) {
 		t.Fatalf("seeds = %#v, want [1 2 3]", seedFanout["seeds"])
+	}
+}
+
+func TestRunSeriesCreateRoutesToEvalSessions(t *testing.T) {
+	captured := map[string]any{}
+	routes := evalStartFakeRoutes(t, &captured)
+	routes["GET /v1/workspaces/ws-1/challenge-packs"] = jsonHandler(200, map[string]any{
+		"items": []map[string]any{
+			{
+				"id":   "pack-1",
+				"name": "Test Pack",
+				"slug": "test-pack",
+				"versions": []map[string]any{
+					{
+						"id":               "pv-1",
+						"version_number":   1,
+						"lifecycle_status": "ready",
+						"deployment_defaults": map[string]any{
+							"lineups": map[string]any{
+								"default": []string{"claude-sonnet"},
+								"smoke":   []string{"smoke-agent"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	routes["GET /v1/workspaces/ws-1/agent-deployments"] = jsonHandler(200, map[string]any{
+		"items": []map[string]any{
+			{"id": "dep-1", "name": "claude-sonnet", "status": "ready", "created_at": "now"},
+			{"id": "dep-2", "name": "smoke-agent", "status": "ready", "created_at": "now"},
+		},
+	})
+	srv := fakeAPI(t, routes)
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"run", "series", "create", "-w", "ws-1",
+		"--challenge-pack-version", "pv-1",
+		"--deployment-lineups", "default,smoke",
+		"--seeds", "2",
+	}, srv.URL); err != nil {
+		t.Fatalf("run series create error: %v", err)
+	}
+
+	if _, hit := captured["__hit_runs"]; hit {
+		t.Fatal("POST /v1/runs was called; expected POST /v1/eval-sessions")
+	}
+	session, ok := captured["eval_session"].(map[string]any)
+	if !ok {
+		t.Fatalf("eval_session missing in body: %#v", captured["eval_session"])
+	}
+	if r, ok := session["repetitions"].(float64); !ok || int(r) != 4 {
+		t.Fatalf("repetitions = %v, want 4", session["repetitions"])
+	}
+	matrix, ok := session["run_matrix"].([]any)
+	if !ok || len(matrix) != 4 {
+		t.Fatalf("run_matrix = %#v, want four entries", session["run_matrix"])
+	}
+	first := matrix[0].(map[string]any)
+	if first["key"] != "default:seed-1" || first["deployment_lineup"] != "default" || first["seed"] != float64(1) {
+		t.Fatalf("first matrix entry = %#v, want default seed 1", first)
+	}
+	third := matrix[2].(map[string]any)
+	participants := third["participants"].([]any)
+	participant := participants[0].(map[string]any)
+	if third["deployment_lineup"] != "smoke" || participant["agent_deployment_id"] != "dep-2" {
+		t.Fatalf("third matrix entry = %#v, want smoke dep-2", third)
 	}
 }
 

--- a/cli/cmd/eval_session_test.go
+++ b/cli/cmd/eval_session_test.go
@@ -139,6 +139,27 @@ func TestBuildSeriesEvalSessionBodyCrossesLineupsAndSeeds(t *testing.T) {
 	if len(participants) != 1 || participants[0]["agent_deployment_id"] != "dep-smoke" {
 		t.Fatalf("third matrix participants = %#v, want dep-smoke", participants)
 	}
+	if participants[0]["label"] != "smoke" {
+		t.Fatalf("third matrix participant label = %v, want smoke", participants[0]["label"])
+	}
+}
+
+func TestBuildSeriesEvalSessionBodyRejectsMatrixOverflow(t *testing.T) {
+	_, err := buildSeriesEvalSessionBody("ws-1", runCreateRequest{
+		ChallengePackVersionID: "pv-1",
+		OfficialPackMode:       "full",
+		Seeds:                  51,
+		ResolvedDeploymentLineups: []runCreateDeploymentLineup{
+			{Name: "default", DeploymentIDs: []string{"dep-default"}},
+			{Name: "smoke", DeploymentIDs: []string{"dep-smoke"}},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected matrix overflow error")
+	}
+	if !strings.Contains(err.Error(), "at most 100 child runs") {
+		t.Fatalf("err = %v, want total child-run limit guidance", err)
+	}
 }
 
 func TestBuildEvalSessionBody_MultiDeployment_LabelsAndMode(t *testing.T) {
@@ -435,6 +456,56 @@ func TestRunSeriesCreateRoutesToEvalSessions(t *testing.T) {
 	participant := participants[0].(map[string]any)
 	if third["deployment_lineup"] != "smoke" || participant["agent_deployment_id"] != "dep-2" {
 		t.Fatalf("third matrix entry = %#v, want smoke dep-2", third)
+	}
+	if participant["label"] != "smoke" {
+		t.Fatalf("third matrix participant label = %v, want smoke", participant["label"])
+	}
+}
+
+func TestRunSeriesCreateValidatesSeedsBeforeResolvingLineups(t *testing.T) {
+	requests := 0
+	routes := evalStartFakeRoutes(t, nil)
+	routes["GET /v1/workspaces/ws-1/challenge-packs"] = func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		jsonHandler(200, map[string]any{"items": []map[string]any{}})(w, r)
+	}
+	srv := fakeAPI(t, routes)
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{
+		"run", "series", "create", "-w", "ws-1",
+		"--challenge-pack-version", "pv-1",
+		"--deployment-lineups", "default,smoke",
+	}, srv.URL)
+	if err == nil {
+		t.Fatal("expected missing seeds error")
+	}
+	if !strings.Contains(err.Error(), "--seeds must be between 1 and 100") {
+		t.Fatalf("err = %v, want local seeds validation", err)
+	}
+	if requests != 0 {
+		t.Fatalf("challenge pack resolver was called %d times, want local validation first", requests)
+	}
+}
+
+func TestBuildSeriesEvalSessionBodyQualifiesMultiParticipantLabelsByLineup(t *testing.T) {
+	body, err := buildSeriesEvalSessionBody("ws-1", runCreateRequest{
+		ChallengePackVersionID: "pv-1",
+		OfficialPackMode:       "full",
+		Seeds:                  1,
+		ResolvedDeploymentLineups: []runCreateDeploymentLineup{
+			{Name: "premium", DeploymentIDs: []string{"dep-a", "dep-b"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	session := body["eval_session"].(map[string]any)
+	matrix := session["run_matrix"].([]map[string]any)
+	participants := matrix[0]["participants"].([]map[string]any)
+	if participants[0]["label"] != "premium / Primary" || participants[1]["label"] != "premium / Participant 2" {
+		t.Fatalf("participants = %#v, want lineup-qualified labels", participants)
 	}
 }
 

--- a/cli/cmd/eval_test.go
+++ b/cli/cmd/eval_test.go
@@ -77,6 +77,57 @@ func TestEvalStartResolvesSelectorsAndCreatesRun(t *testing.T) {
 	}
 }
 
+func TestEvalStartKeepsResolvedInputSetSelector(t *testing.T) {
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+
+	var gotBody map[string]any
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/challenge-packs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{
+					"id":   "pack-1",
+					"name": "Support Eval",
+					"slug": "support-eval",
+					"versions": []map[string]any{
+						{"id": "ver-1", "version_number": 1, "lifecycle_status": "active"},
+					},
+				},
+			},
+		}),
+		"GET /v1/workspaces/ws-1/challenge-pack-versions/ver-1/input-sets": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "input-1", "input_key": "default", "name": "Default Inputs"},
+			},
+		}),
+		"GET /v1/workspaces/ws-1/agent-deployments": jsonHandler(200, map[string]any{
+			"items": []map[string]any{
+				{"id": "dep-1", "name": "prod", "status": "ready"},
+			},
+		}),
+		"POST /v1/runs": func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("Decode() error: %v", err)
+			}
+			jsonHandler(201, map[string]any{"id": "run-1", "status": "queued"})(w, r)
+		},
+	})
+	defer srv.Close()
+
+	if err := executeCommand(t, []string{
+		"eval", "start",
+		"-w", "ws-1",
+		"--pack", "support-eval",
+		"--input-set", "default",
+		"--deployment", "prod",
+	}, srv.URL); err != nil {
+		t.Fatalf("eval start error: %v", err)
+	}
+
+	if gotBody["challenge_input_set_id"] != "input-1" {
+		t.Fatalf("challenge_input_set_id = %v, want resolved id input-1", gotBody["challenge_input_set_id"])
+	}
+}
+
 func TestEvalScorecardJSONEnvelopeIncludesBaselineComparisonAndGate(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -26,10 +26,13 @@ func init() {
 	runCmd.AddCommand(runScorecardCmd)
 	runCmd.AddCommand(runFailuresCmd)
 	runCmd.AddCommand(runPromoteFailureCmd)
+	runCmd.AddCommand(runSeriesCmd)
+	runSeriesCmd.AddCommand(runSeriesCreateCmd)
 
 	runCreateCmd.Flags().String("challenge-pack-version", "", "Challenge pack version ID (optional in a TTY; prompted when omitted)")
 	runCreateCmd.Flags().StringSlice("deployments", nil, "Agent deployment IDs (optional in a TTY; prompted when omitted)")
 	runCreateCmd.Flags().String("deployment-lineup", "", "Challenge pack deployment lineup to use when --deployments is omitted (default: default)")
+	runCreateCmd.Flags().StringSlice("deployment-lineups", nil, "Challenge pack deployment lineups to cross with --seeds for a race series")
 	runCreateCmd.Flags().String("name", "", "Run name (optional)")
 	runCreateCmd.Flags().String("input-set", "", "Challenge input set ID (optional)")
 	runCreateCmd.Flags().Bool("follow", false, "Follow run events after creation")
@@ -58,11 +61,51 @@ func init() {
 	runPromoteFailureCmd.Flags().String("title", "", "Regression case title")
 	runPromoteFailureCmd.Flags().String("failure-summary", "", "Failure summary")
 	runPromoteFailureCmd.Flags().String("severity", "", "Case severity: info, warning, or blocking")
+
+	runSeriesCreateCmd.Flags().String("challenge-pack-version", "", "Challenge pack version ID")
+	runSeriesCreateCmd.Flags().String("input-set", "", "Challenge input set ID (optional)")
+	runSeriesCreateCmd.Flags().StringSlice("deployment-lineups", nil, "Challenge pack deployment lineups to cross with --seeds")
+	runSeriesCreateCmd.Flags().Int("seeds", 0, "Number of seeds to cross with each deployment lineup (1-100)")
+	runSeriesCreateCmd.Flags().String("name", "", "Series name (optional)")
+	runSeriesCreateCmd.Flags().Int("max-iter", 0, "Override max iterations for each child run (1-1000). 0 uses the pack/runtime default.")
 }
 
 var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Manage evaluation runs",
+}
+
+var runSeriesCmd = &cobra.Command{
+	Use:   "series",
+	Short: "Manage durable race series",
+}
+
+var runSeriesCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a race series from deployment lineups and seeds",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		wsID := RequireWorkspace(cmd)
+
+		request, err := runCreateRequestFromFlags(cmd, runCreateRequest{})
+		if err != nil {
+			return err
+		}
+		lineups, err := resolveRunCreateDeploymentLineups(cmd, rc, wsID, request.ChallengePackVersionID, request.DeploymentLineups)
+		if err != nil {
+			return err
+		}
+		request.ResolvedDeploymentLineups = lineups
+		body, err := buildSeriesEvalSessionBody(wsID, request)
+		if err != nil {
+			return err
+		}
+		result, err := createEvalSession(cmd, rc, body)
+		if err != nil {
+			return err
+		}
+		return presentCreatedEvalSession(rc, result)
+	},
 }
 
 var runListCmd = &cobra.Command{
@@ -214,6 +257,27 @@ For CI and other non-interactive use, keep passing explicit IDs via flags.`,
 			return err
 		}
 
+		follow, _ := cmd.Flags().GetBool("follow")
+		if len(request.DeploymentLineups) > 0 {
+			if follow {
+				return fmt.Errorf("--follow is not supported with --deployment-lineups; tail individual runs with 'agentclash run events <run-id> --follow' instead")
+			}
+			lineups, err := resolveRunCreateDeploymentLineups(cmd, rc, wsID, request.ChallengePackVersionID, request.DeploymentLineups)
+			if err != nil {
+				return err
+			}
+			request.ResolvedDeploymentLineups = lineups
+			body, err := buildSeriesEvalSessionBody(wsID, request)
+			if err != nil {
+				return err
+			}
+			result, err := createEvalSession(cmd, rc, body)
+			if err != nil {
+				return err
+			}
+			return presentCreatedEvalSession(rc, result)
+		}
+
 		selections, err := resolveRunCreateSelections(cmd, rc, wsID)
 		if err != nil {
 			return err
@@ -222,7 +286,6 @@ For CI and other non-interactive use, keep passing explicit IDs via flags.`,
 		request.ChallengeInputSetID = selections.challengeInputSetID
 		request.DeploymentIDs = selections.deploymentIDs
 
-		follow, _ := cmd.Flags().GetBool("follow")
 		if request.Seeds > 0 {
 			if follow {
 				return fmt.Errorf("--follow is not supported with --seeds; tail individual runs with 'agentclash run events <run-id> --follow' instead")

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -91,6 +91,9 @@ var runSeriesCreateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if err := validateSeriesSeedCount(request.Seeds); err != nil {
+			return err
+		}
 		lineups, err := resolveRunCreateDeploymentLineups(cmd, rc, wsID, request.ChallengePackVersionID, request.DeploymentLineups)
 		if err != nil {
 			return err
@@ -261,6 +264,9 @@ For CI and other non-interactive use, keep passing explicit IDs via flags.`,
 		if len(request.DeploymentLineups) > 0 {
 			if follow {
 				return fmt.Errorf("--follow is not supported with --deployment-lineups; tail individual runs with 'agentclash run events <run-id> --follow' instead")
+			}
+			if err := validateSeriesSeedCount(request.Seeds); err != nil {
+				return err
 			}
 			lineups, err := resolveRunCreateDeploymentLineups(cmd, rc, wsID, request.ChallengePackVersionID, request.DeploymentLineups)
 			if err != nil {

--- a/cli/cmd/run_create_helpers.go
+++ b/cli/cmd/run_create_helpers.go
@@ -17,6 +17,8 @@ type runCreateRequest struct {
 	ChallengePackVersionID     string
 	ChallengeInputSetID        string
 	DeploymentIDs              []string
+	DeploymentLineups          []string
+	ResolvedDeploymentLineups  []runCreateDeploymentLineup
 	Name                       string
 	OfficialPackMode           string
 	RegressionSuiteIDs         []string
@@ -29,8 +31,41 @@ type runCreateRequest struct {
 	CIMetadata                 map[string]any
 }
 
+type runCreateDeploymentLineup struct {
+	Name          string
+	DeploymentIDs []string
+}
+
 func runCreateRequestFromFlags(cmd *cobra.Command, base runCreateRequest) (runCreateRequest, error) {
 	request := base
+
+	if cmd.Flags().Lookup("challenge-pack-version") != nil {
+		challengePackVersionID, _ := cmd.Flags().GetString("challenge-pack-version")
+		if trimmed := strings.TrimSpace(challengePackVersionID); trimmed != "" {
+			request.ChallengePackVersionID = trimmed
+		}
+	}
+
+	if cmd.Flags().Lookup("input-set") != nil {
+		inputSetID, _ := cmd.Flags().GetString("input-set")
+		if trimmed := strings.TrimSpace(inputSetID); trimmed != "" {
+			request.ChallengeInputSetID = trimmed
+		}
+	}
+
+	if cmd.Flags().Lookup("deployments") != nil {
+		deploymentIDs, _ := cmd.Flags().GetStringSlice("deployments")
+		if compacted := compactNonEmptyStrings(deploymentIDs); len(compacted) > 0 {
+			request.DeploymentIDs = compacted
+		}
+	}
+
+	if cmd.Flags().Lookup("deployment-lineups") != nil {
+		deploymentLineups, _ := cmd.Flags().GetStringSlice("deployment-lineups")
+		if compacted := compactNonEmptyStrings(deploymentLineups); len(compacted) > 0 {
+			request.DeploymentLineups = compacted
+		}
+	}
 
 	name, _ := cmd.Flags().GetString("name")
 	request.Name = name
@@ -160,6 +195,107 @@ func buildSeededEvalSessionBody(workspaceID string, request runCreateRequest) (m
 		"seeds":    seeds,
 	}
 	return body, nil
+}
+
+func buildSeriesEvalSessionBody(workspaceID string, request runCreateRequest) (map[string]any, error) {
+	if request.ChallengePackVersionID == "" {
+		return nil, fmt.Errorf("challenge pack version is required")
+	}
+	if request.Seeds < 1 || request.Seeds > maxRunCreateSeeds {
+		return nil, fmt.Errorf("--seeds must be between 1 and %d when using --deployment-lineups, got %d", maxRunCreateSeeds, request.Seeds)
+	}
+	if len(request.DeploymentIDs) > 0 {
+		return nil, fmt.Errorf("--deployment-lineups cannot be combined with --deployments")
+	}
+	if len(request.ResolvedDeploymentLineups) == 0 {
+		return nil, fmt.Errorf("at least one deployment lineup is required")
+	}
+	if request.RaceContextCadence < 0 || request.RaceContextCadence > 10 {
+		return nil, fmt.Errorf("--race-context-cadence must be 0 (backend default) or between 1 and 10, got %d", request.RaceContextCadence)
+	}
+	if request.MaxIterations < 0 || request.MaxIterations > maxRunCreateMaxIter {
+		return nil, fmt.Errorf("--max-iter must be 0 (pack/runtime default) or between 1 and %d, got %d", maxRunCreateMaxIter, request.MaxIterations)
+	}
+	if len(request.RegressionSuiteIDs) > 0 || len(request.RegressionCaseIDs) > 0 || request.OfficialPackMode == "suite_only" {
+		return nil, fmt.Errorf("--scope suite_only / --suite / --case are not supported with --deployment-lineups")
+	}
+	if request.RaceContext || request.RaceContextCadence > 0 {
+		return nil, fmt.Errorf("--race-context flags are not supported with --deployment-lineups")
+	}
+
+	executionMode := "single_agent"
+	if len(request.ResolvedDeploymentLineups[0].DeploymentIDs) > 1 {
+		executionMode = "comparison"
+	}
+
+	repetitions := len(request.ResolvedDeploymentLineups) * request.Seeds
+	body := map[string]any{
+		"workspace_id":              workspaceID,
+		"challenge_pack_version_id": request.ChallengePackVersionID,
+		"execution_mode":            executionMode,
+		"eval_session": map[string]any{
+			"repetitions": repetitions,
+			"aggregation": map[string]any{
+				"method":              "mean",
+				"report_variance":     true,
+				"confidence_interval": 0.95,
+			},
+			"routing_task_snapshot": map[string]any{
+				"routing": map[string]any{"mode": "series", "child_execution_mode": executionMode},
+				"task":    map[string]any{"pack_version": "v1"},
+			},
+			"schema_version": 1,
+		},
+	}
+	if request.Name != "" {
+		body["name"] = request.Name
+	}
+	if request.ChallengeInputSetID != "" {
+		body["challenge_input_set_id"] = request.ChallengeInputSetID
+	}
+	if request.MaxIterations > 0 {
+		body["max_iterations"] = request.MaxIterations
+	}
+
+	matrix := make([]map[string]any, 0, repetitions)
+	for _, lineup := range request.ResolvedDeploymentLineups {
+		if len(lineup.DeploymentIDs) == 0 {
+			return nil, fmt.Errorf("deployment lineup %q resolved to no deployments", lineup.Name)
+		}
+		lineupMode := "single_agent"
+		if len(lineup.DeploymentIDs) > 1 {
+			lineupMode = "comparison"
+		}
+		if lineupMode != executionMode {
+			return nil, fmt.Errorf("deployment lineup %q has %d deployment(s), but all lineups in a series must use the same execution mode", lineup.Name, len(lineup.DeploymentIDs))
+		}
+		for seed := 1; seed <= request.Seeds; seed++ {
+			matrix = append(matrix, map[string]any{
+				"key":               fmt.Sprintf("%s:seed-%d", lineup.Name, seed),
+				"deployment_lineup": lineup.Name,
+				"seed":              seed,
+				"participants":      deploymentIDsToEvalSessionParticipants(lineup.DeploymentIDs),
+			})
+		}
+	}
+	session := body["eval_session"].(map[string]any)
+	session["run_matrix"] = matrix
+	return body, nil
+}
+
+func deploymentIDsToEvalSessionParticipants(deploymentIDs []string) []map[string]any {
+	participants := make([]map[string]any, 0, len(deploymentIDs))
+	for i, deploymentID := range deploymentIDs {
+		label := "Primary"
+		if i > 0 {
+			label = fmt.Sprintf("Participant %d", i+1)
+		}
+		participants = append(participants, map[string]any{
+			"agent_deployment_id": deploymentID,
+			"label":               label,
+		})
+	}
+	return participants
 }
 
 func createRun(cmd *cobra.Command, rc *RunContext, body map[string]any) (map[string]any, error) {

--- a/cli/cmd/run_create_helpers.go
+++ b/cli/cmd/run_create_helpers.go
@@ -48,7 +48,7 @@ func runCreateRequestFromFlags(cmd *cobra.Command, base runCreateRequest) (runCr
 
 	if cmd.Flags().Lookup("input-set") != nil {
 		inputSetID, _ := cmd.Flags().GetString("input-set")
-		if trimmed := strings.TrimSpace(inputSetID); trimmed != "" {
+		if trimmed := strings.TrimSpace(inputSetID); trimmed != "" && strings.TrimSpace(request.ChallengeInputSetID) == "" {
 			request.ChallengeInputSetID = trimmed
 		}
 	}
@@ -201,14 +201,18 @@ func buildSeriesEvalSessionBody(workspaceID string, request runCreateRequest) (m
 	if request.ChallengePackVersionID == "" {
 		return nil, fmt.Errorf("challenge pack version is required")
 	}
-	if request.Seeds < 1 || request.Seeds > maxRunCreateSeeds {
-		return nil, fmt.Errorf("--seeds must be between 1 and %d when using --deployment-lineups, got %d", maxRunCreateSeeds, request.Seeds)
+	if err := validateSeriesSeedCount(request.Seeds); err != nil {
+		return nil, err
 	}
 	if len(request.DeploymentIDs) > 0 {
 		return nil, fmt.Errorf("--deployment-lineups cannot be combined with --deployments")
 	}
 	if len(request.ResolvedDeploymentLineups) == 0 {
 		return nil, fmt.Errorf("at least one deployment lineup is required")
+	}
+	repetitions := len(request.ResolvedDeploymentLineups) * request.Seeds
+	if repetitions > evalSessionMaxRepetitions {
+		return nil, fmt.Errorf("--deployment-lineups × --seeds must create at most %d child runs, got %d", evalSessionMaxRepetitions, repetitions)
 	}
 	if request.RaceContextCadence < 0 || request.RaceContextCadence > 10 {
 		return nil, fmt.Errorf("--race-context-cadence must be 0 (backend default) or between 1 and 10, got %d", request.RaceContextCadence)
@@ -228,7 +232,6 @@ func buildSeriesEvalSessionBody(workspaceID string, request runCreateRequest) (m
 		executionMode = "comparison"
 	}
 
-	repetitions := len(request.ResolvedDeploymentLineups) * request.Seeds
 	body := map[string]any{
 		"workspace_id":              workspaceID,
 		"challenge_pack_version_id": request.ChallengePackVersionID,
@@ -274,7 +277,7 @@ func buildSeriesEvalSessionBody(workspaceID string, request runCreateRequest) (m
 				"key":               fmt.Sprintf("%s:seed-%d", lineup.Name, seed),
 				"deployment_lineup": lineup.Name,
 				"seed":              seed,
-				"participants":      deploymentIDsToEvalSessionParticipants(lineup.DeploymentIDs),
+				"participants":      deploymentIDsToEvalSessionParticipants(lineup.Name, lineup.DeploymentIDs),
 			})
 		}
 	}
@@ -283,19 +286,37 @@ func buildSeriesEvalSessionBody(workspaceID string, request runCreateRequest) (m
 	return body, nil
 }
 
-func deploymentIDsToEvalSessionParticipants(deploymentIDs []string) []map[string]any {
+func validateSeriesSeedCount(seeds int) error {
+	if seeds < 1 || seeds > maxRunCreateSeeds {
+		return fmt.Errorf("--seeds must be between 1 and %d when using --deployment-lineups, got %d", maxRunCreateSeeds, seeds)
+	}
+	return nil
+}
+
+func deploymentIDsToEvalSessionParticipants(lineupName string, deploymentIDs []string) []map[string]any {
 	participants := make([]map[string]any, 0, len(deploymentIDs))
 	for i, deploymentID := range deploymentIDs {
-		label := "Primary"
-		if i > 0 {
-			label = fmt.Sprintf("Participant %d", i+1)
-		}
+		label := seriesParticipantLabel(lineupName, i, len(deploymentIDs))
 		participants = append(participants, map[string]any{
 			"agent_deployment_id": deploymentID,
 			"label":               label,
 		})
 	}
 	return participants
+}
+
+func seriesParticipantLabel(lineupName string, index int, total int) string {
+	lineupName = strings.TrimSpace(lineupName)
+	if lineupName == "" {
+		lineupName = "lineup"
+	}
+	if total <= 1 {
+		return lineupName
+	}
+	if index == 0 {
+		return lineupName + " / Primary"
+	}
+	return fmt.Sprintf("%s / Participant %d", lineupName, index+1)
 }
 
 func createRun(cmd *cobra.Command, rc *RunContext, body map[string]any) (map[string]any, error) {

--- a/cli/cmd/run_create_interactive.go
+++ b/cli/cmd/run_create_interactive.go
@@ -308,12 +308,9 @@ func resolveRunCreateDeploymentLineups(cmd *cobra.Command, rc *RunContext, works
 
 	resolved := make([]runCreateDeploymentLineup, 0, len(names))
 	for _, name := range names {
-		ids, ok, err := resolveDefaultDeploymentLineup(cmd, rc, workspaceID, challengePackVersionID, name)
+		ids, _, err := resolveDefaultDeploymentLineup(cmd, rc, workspaceID, challengePackVersionID, name)
 		if err != nil {
 			return nil, err
-		}
-		if !ok {
-			return nil, fmt.Errorf("challenge pack version %s was not found while resolving deployment lineups", challengePackVersionID)
 		}
 		resolved = append(resolved, runCreateDeploymentLineup{
 			Name:          name,

--- a/cli/cmd/run_create_interactive.go
+++ b/cli/cmd/run_create_interactive.go
@@ -49,9 +49,13 @@ func resolveRunCreateSelections(cmd *cobra.Command, rc *RunContext, workspaceID 
 	cpvID, _ := cmd.Flags().GetString("challenge-pack-version")
 	deployments, _ := cmd.Flags().GetStringSlice("deployments")
 	lineup, _ := cmd.Flags().GetString("deployment-lineup")
+	lineups, _ := cmd.Flags().GetStringSlice("deployment-lineups")
 	inputSetID, _ := cmd.Flags().GetString("input-set")
 	if len(deployments) > 0 && strings.TrimSpace(lineup) != "" {
 		return runCreateSelections{}, fmt.Errorf("--deployment-lineup cannot be combined with --deployments")
+	}
+	if len(compactNonEmptyStrings(lineups)) > 0 {
+		return runCreateSelections{}, fmt.Errorf("--deployment-lineups must be used with --seeds and cannot use guided deployment selection")
 	}
 
 	selections := runCreateSelections{
@@ -283,6 +287,40 @@ func resolveDefaultDeploymentLineup(cmd *cobra.Command, rc *RunContext, workspac
 		return nil, false, err
 	}
 	return ids, true, nil
+}
+
+func resolveRunCreateDeploymentLineups(cmd *cobra.Command, rc *RunContext, workspaceID, challengePackVersionID string, lineups []string) ([]runCreateDeploymentLineup, error) {
+	if strings.TrimSpace(challengePackVersionID) == "" {
+		return nil, fmt.Errorf("--challenge-pack-version is required with --deployment-lineups")
+	}
+	names := compactNonEmptyStrings(lineups)
+	if len(names) == 0 {
+		return nil, fmt.Errorf("at least one deployment lineup is required")
+	}
+	singleLineup, _ := cmd.Flags().GetString("deployment-lineup")
+	deployments, _ := cmd.Flags().GetStringSlice("deployments")
+	if strings.TrimSpace(singleLineup) != "" {
+		return nil, fmt.Errorf("--deployment-lineups cannot be combined with --deployment-lineup")
+	}
+	if len(compactNonEmptyStrings(deployments)) > 0 {
+		return nil, fmt.Errorf("--deployment-lineups cannot be combined with --deployments")
+	}
+
+	resolved := make([]runCreateDeploymentLineup, 0, len(names))
+	for _, name := range names {
+		ids, ok, err := resolveDefaultDeploymentLineup(cmd, rc, workspaceID, challengePackVersionID, name)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, fmt.Errorf("challenge pack version %s was not found while resolving deployment lineups", challengePackVersionID)
+		}
+		resolved = append(resolved, runCreateDeploymentLineup{
+			Name:          name,
+			DeploymentIDs: ids,
+		})
+	}
+	return resolved, nil
 }
 
 func findChallengePackVersion(cmd *cobra.Command, rc *RunContext, workspaceID, challengePackVersionID string) (challengePackVersionBrief, bool, error) {

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -7507,6 +7507,12 @@ components:
           type: integer
           minimum: 1
           description: Seed assigned to this child run when the eval session was created via seeded fanout.
+        matrix_key:
+          type: string
+          description: Stable series matrix key persisted on this child run, when created from `run_matrix`.
+        deployment_lineup:
+          type: string
+          description: Deployment lineup name persisted on this child run, when created from `run_matrix`.
         queued_at:
           type: string
           format: date-time

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -6867,7 +6867,7 @@ components:
 
     CreateEvalSessionRequest:
       type: object
-      required: [workspace_id, challenge_pack_version_id, participants, eval_session]
+      required: [workspace_id, challenge_pack_version_id, eval_session]
       properties:
         workspace_id:
           type: string
@@ -6886,6 +6886,9 @@ components:
         participants:
           type: array
           minItems: 1
+          description: >
+            Uniform participants used for every child run. May be omitted when
+            `eval_session.run_matrix` supplies participants per child run.
           items:
             $ref: "#/components/schemas/CreateEvalSessionParticipant"
         execution_mode:
@@ -6947,9 +6950,40 @@ components:
           description: Optional. Explicit `null` is treated the same as omission.
         seed_fanout:
           $ref: "#/components/schemas/EvalSessionSeedFanoutConfig"
+        run_matrix:
+          type: array
+          minItems: 1
+          maxItems: 100
+          description: >
+            Explicit child-run matrix for race series. Length must equal
+            `repetitions`. Cannot be combined with `seed_fanout`.
+          items:
+            $ref: "#/components/schemas/EvalSessionRunMatrixEntry"
         schema_version:
           type: integer
           minimum: 1
+
+    EvalSessionRunMatrixEntry:
+      type: object
+      required: [key, participants]
+      properties:
+        key:
+          type: string
+          minLength: 1
+          description: Stable client-generated key for this matrix cell.
+        deployment_lineup:
+          type: string
+          minLength: 1
+          description: Optional challenge-pack lineup name used for this child run.
+        seed:
+          type: integer
+          minimum: 1
+          description: Optional deterministic seed assigned to this child run.
+        participants:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/CreateEvalSessionParticipant"
 
     EvalSessionAggregationConfig:
       type: object
@@ -7057,6 +7091,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/EvalSessionSeededRun"
+        series_runs:
+          type: array
+          items:
+            $ref: "#/components/schemas/EvalSessionSeriesRun"
 
     EvalSessionSeededRun:
       type: object
@@ -7065,6 +7103,21 @@ components:
         run_id:
           type: string
           format: uuid
+        seed:
+          type: integer
+          minimum: 1
+
+    EvalSessionSeriesRun:
+      type: object
+      required: [run_id]
+      properties:
+        run_id:
+          type: string
+          format: uuid
+        matrix_key:
+          type: string
+        deployment_lineup:
+          type: string
         seed:
           type: integer
           minimum: 1

--- a/testing/codex-roadmap-693-race-series-create.md
+++ b/testing/codex-roadmap-693-race-series-create.md
@@ -1,0 +1,68 @@
+# codex/roadmap-693-race-series-create - Test Contract
+
+## Files touched
+- `backend/internal/api/eval_sessions.go` - decode and return per-child run matrix metadata.
+- `backend/internal/api/eval_session_service.go` - expand matrix entries into queued child runs.
+- `backend/internal/api/run_service_test.go` - service tests for matrix expansion and metadata.
+- `backend/internal/api/runs_test.go` - handler/decode tests for the API contract.
+- `cli/cmd/run.go` - CLI flag for multi-lineup series creation.
+- `cli/cmd/run_create_helpers.go` - build matrix eval-session request bodies.
+- `cli/cmd/eval_session_helpers.go` - render series child metadata.
+- `cli/cmd/eval_session_test.go` and `cli/cmd/run_create_interactive_test.go` - CLI request/response tests.
+- `docs/api-server/openapi.yaml` - document the additive request/response fields.
+
+## External APIs used
+- Cobra flag parsing - `StringSlice` flags and `GetStringSlice`, verified-as-of: 2026-05-10, source URL: https://pkg.go.dev/github.com/spf13/pflag#FlagSet.StringSlice
+- Go `encoding/json` - `Decoder.DisallowUnknownFields` and `RawMessage`, verified-as-of: 2026-05-10, source URL: https://pkg.go.dev/encoding/json
+
+## Rollback strategy
+Revert this PR. It is additive to the eval-session request/response schema and CLI flags, with no migration. Existing single-run and single-lineup seeded run creation paths remain intact.
+
+## Functional Behavior
+- API accepts optional `eval_session.run_matrix` entries; each entry supplies a key, optional seed, optional deployment lineup name, and participants for that child run.
+- When `run_matrix` is present, `eval_session.repetitions` must equal the matrix length.
+- Service creates one queued child run per matrix entry, preserving child order and setting each child execution plan seed and participant list from the entry.
+- Existing uniform `participants` plus `seed_fanout` behavior remains unchanged.
+- Response continues to include `run_ids` and additionally surfaces series child metadata with every child `run_id`, `matrix_key`, `deployment_lineup`, and `seed` when available.
+- CLI supports multiple pack-declared lineups crossed with `--seeds N`, resolving each lineup to deployment IDs and posting a matrix eval-session request.
+- CLI rejects multi-lineup series without `--seeds`, with `--deployments`, or with `--follow`.
+
+## Unit Tests
+- `TestDecodeEvalSessionConfigAcceptsRunMatrix` - accepts valid matrix entries and rejects length mismatches/invalid participants.
+- `TestRunCreationManagerCreateEvalSessionExpandsRunMatrix` - verifies generated child run count, per-child participants, names, execution plans, and returned metadata.
+- `TestBuildSeriesEvalSessionBodyCrossesLineupsAndSeeds` - verifies CLI request body matrix shape.
+- `TestRunCreateDeploymentLineupsRoutesToEvalSession` - verifies CLI posts to `/v1/eval-sessions` and surfaces response metadata.
+
+## Integration / Functional Tests
+- `go test ./internal/api -run 'TestCreateEvalSession|TestRunCreationManagerCreateEvalSession'`
+- `go test ./cmd -run 'TestRunCreate|TestEvalSession'`
+
+## Smoke Tests
+- `cd backend && go test ./internal/api`
+- `cd cli && go test ./cmd`
+- `cd cli && go build ./...`
+
+## E2E Tests
+- After merge and deploy, run hosted CLI smoke against `https://api.agentclash.dev` with a request path that exercises the new multi-lineup flag. If the hosted pack does not declare enough lineups, verify the deployed CLI/API returns the expected validation error without regressing existing seeded creation.
+
+## Manual / cURL Tests
+```bash
+curl -sS -X POST "$AGENTCLASH_API_URL/v1/eval-sessions" \
+  -H "Authorization: Bearer $AGENTCLASH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "workspace_id":"<workspace-id>",
+    "challenge_pack_version_id":"<pack-version-id>",
+    "eval_session":{
+      "repetitions":2,
+      "aggregation":{"method":"mean","report_variance":true,"confidence_interval":0.95},
+      "routing_task_snapshot":{"routing":{"mode":"series"},"task":{"pack_version":"v1"}},
+      "schema_version":1,
+      "run_matrix":[
+        {"key":"default:seed-1","deployment_lineup":"default","seed":1,"participants":[{"agent_deployment_id":"<deployment-id>","label":"Primary"}]},
+        {"key":"default:seed-2","deployment_lineup":"default","seed":2,"participants":[{"agent_deployment_id":"<deployment-id>","label":"Primary"}]}
+      ]
+    }
+  }'
+# Expected: 201, body includes eval_session, run_ids length 2, and series_runs with matching run IDs.
+```


### PR DESCRIPTION
Closes #711.

## Summary
- add eval-session `run_matrix` support so a durable parent can queue explicit child-run matrices
- add `series_runs` response metadata with run ID, matrix key, deployment lineup, and seed
- add `agentclash run series create` plus `run create --deployment-lineups` to cross pack-declared lineups with seeds
- document the additive OpenAPI request/response fields

## Validation
- backend: `go test ./internal/api`
- backend: `go test ./...`
- backend: `go vet ./...`
- cli: `go test ./cmd`
- cli: `go test ./...`
- cli: `go build ./...`
- cli: `go vet ./...`
- `git diff --check`
- `npx @redocly/cli lint docs/api-server/openapi.yaml` parses, but fails on pre-existing unrelated repo lint issues: unresolved `InternalServerError`, missing security declarations, localhost server warning.

Test contract: `testing/codex-roadmap-693-race-series-create.md`.
