### PR TITLE
feat: add race series aggregate reports

### DIFF
--- a/backend/db/queries/replay_reads.sql
+++ b/backend/db/queries/replay_reads.sql
@@ -52,3 +52,23 @@ SELECT
 FROM run_agent_scorecards
 WHERE run_agent_id = @run_agent_id
 LIMIT 1;
+
+-- name: ListRunAgentScorecardsByRunID :many
+SELECT
+    sc.id,
+    sc.run_agent_id,
+    sc.evaluation_spec_id,
+    sc.overall_score,
+    sc.correctness_score,
+    sc.reliability_score,
+    sc.latency_score,
+    sc.cost_score,
+    sc.behavioral_score,
+    sc.scorecard_passed,
+    sc.scorecard,
+    sc.created_at,
+    sc.updated_at
+FROM run_agent_scorecards sc
+JOIN run_agents ra ON ra.id = sc.run_agent_id
+WHERE ra.run_id = @run_id
+ORDER BY ra.lane_index, ra.label, sc.run_agent_id;

--- a/backend/db/queries/replay_reads.sql
+++ b/backend/db/queries/replay_reads.sql
@@ -51,10 +51,11 @@ SELECT
     updated_at
 FROM run_agent_scorecards
 WHERE run_agent_id = @run_agent_id
+ORDER BY updated_at DESC, id DESC
 LIMIT 1;
 
 -- name: ListRunAgentScorecardsByRunID :many
-SELECT
+SELECT DISTINCT ON (sc.run_agent_id)
     sc.id,
     sc.run_agent_id,
     sc.evaluation_spec_id,
@@ -71,4 +72,4 @@ SELECT
 FROM run_agent_scorecards sc
 JOIN run_agents ra ON ra.id = sc.run_agent_id
 WHERE ra.run_id = @run_id
-ORDER BY ra.lane_index, ra.label, sc.run_agent_id;
+ORDER BY sc.run_agent_id, sc.updated_at DESC, sc.id DESC;

--- a/backend/internal/repository/eval_session_aggregation.go
+++ b/backend/internal/repository/eval_session_aggregation.go
@@ -60,6 +60,7 @@ type evalSessionAggregateDocument struct {
 	MetricRouting    *evalSessionMetricRouting             `json:"metric_routing,omitempty"`
 	Participants     []evalSessionParticipantAggregate     `json:"participants,omitempty"`
 	Comparison       *evalSessionRepeatedComparison        `json:"comparison,omitempty"`
+	SeriesReport     *evalSessionSeriesReport              `json:"series_report,omitempty"`
 }
 
 type evalSessionParticipantAggregate struct {
@@ -71,7 +72,36 @@ type evalSessionParticipantAggregate struct {
 	PassAtK       *evalSessionPassMetricSeries          `json:"pass_at_k,omitempty"`
 	PassPowK      *evalSessionPassMetricSeries          `json:"pass_pow_k,omitempty"`
 	MetricRouting *evalSessionMetricRouting             `json:"metric_routing,omitempty"`
+	CostUSD       *evalSessionCostAggregate             `json:"cost_usd,omitempty"`
 	ObservedRuns  int                                   `json:"-"`
+}
+
+type evalSessionSeriesReport struct {
+	RankMetric string                       `json:"rank_metric"`
+	Rows       []evalSessionSeriesReportRow `json:"rows"`
+}
+
+type evalSessionSeriesReportRow struct {
+	Rank                int      `json:"rank"`
+	LaneIndex           int32    `json:"lane_index"`
+	Label               string   `json:"label"`
+	DeploymentLineup    string   `json:"deployment_lineup,omitempty"`
+	ParticipantLabel    string   `json:"participant_label,omitempty"`
+	ObservedRuns        int      `json:"observed_runs"`
+	OverallScore        *float64 `json:"overall_score,omitempty"`
+	CorrectnessScore    *float64 `json:"correctness_score,omitempty"`
+	SuccessRate         *float64 `json:"success_rate,omitempty"`
+	CompositeAgentScore *float64 `json:"composite_agent_score,omitempty"`
+	MeanCostUSD         *float64 `json:"mean_cost_usd,omitempty"`
+	TotalCostUSD        *float64 `json:"total_cost_usd,omitempty"`
+}
+
+type evalSessionCostAggregate struct {
+	N     int     `json:"n"`
+	Total float64 `json:"total"`
+	Mean  float64 `json:"mean"`
+	Min   float64 `json:"min"`
+	Max   float64 `json:"max"`
 }
 
 type evalSessionTaskSuccess struct {
@@ -173,6 +203,7 @@ type evalSessionParticipantAccumulator struct {
 	Key          evalSessionParticipantKey
 	Overall      []float64
 	Dimensions   map[string][]float64
+	TotalCostUSD []float64
 	TaskOutcomes map[string]*evalSessionTaskOutcomeAccumulator
 }
 
@@ -494,6 +525,18 @@ func (r *Repository) buildEvalSessionAggregateParticipantSources(
 	warnings := make([]string, 0)
 
 	for _, agent := range document.Agents {
+		if agent.HasScorecard && agent.TotalCostUSD == nil {
+			scorecard, err := r.GetRunAgentScorecardByRunAgentID(ctx, agent.RunAgentID)
+			switch {
+			case err == nil:
+				agent = evalSessionAgentWithScorecardCost(agent, scorecard.Scorecard)
+			case errors.Is(err, ErrRunAgentScorecardNotFound):
+				warnings = append(warnings, fmt.Sprintf("run %s participant %q (lane %d): run-agent scorecard unavailable; cost will be omitted", runID, agent.Label, agent.LaneIndex))
+			default:
+				return nil, nil, fmt.Errorf("load run-agent scorecard %s for cost aggregation: %w", agent.RunAgentID, err)
+			}
+		}
+
 		participantSource := evalSessionAggregateParticipantSource{
 			Key: evalSessionParticipantKey{
 				LaneIndex: agent.LaneIndex,
@@ -517,6 +560,14 @@ func (r *Repository) buildEvalSessionAggregateParticipantSources(
 	}
 
 	return participantSources, warnings, nil
+}
+
+func evalSessionAgentWithScorecardCost(agent runScorecardAgentSummary, scorecard json.RawMessage) runScorecardAgentSummary {
+	if agent.TotalCostUSD != nil {
+		return agent
+	}
+	agent.TotalCostUSD = totalCostUSDFromRunAgentScorecardDocument(scorecard)
+	return agent
 }
 
 func (r *Repository) loadEvalSessionParticipantTaskOutcomes(
@@ -727,6 +778,9 @@ func buildEvalSessionAggregatePayload(
 			if agent.OverallScore != nil {
 				accumulator.Overall = append(accumulator.Overall, *agent.OverallScore)
 			}
+			if agent.TotalCostUSD != nil {
+				accumulator.TotalCostUSD = append(accumulator.TotalCostUSD, *agent.TotalCostUSD)
+			}
 			for dimKey, value := range evalSessionAggregateDimensions(agent) {
 				accumulator.Dimensions[dimKey] = append(accumulator.Dimensions[dimKey], value)
 			}
@@ -828,6 +882,13 @@ func buildEvalSessionAggregatePayload(
 				}
 			}
 		}
+		if len(accumulator.TotalCostUSD) > 0 {
+			costUSD := buildEvalSessionCostAggregate(accumulator.TotalCostUSD)
+			participant.CostUSD = &costUSD
+			if len(accumulator.TotalCostUSD) < expectedParticipantRuns {
+				warnings = append(warnings, fmt.Sprintf("participant %q (lane %d) cost aggregate uses %d of %d expected scored child runs", key.Label, key.LaneIndex, len(accumulator.TotalCostUSD), expectedParticipantRuns))
+			}
+		}
 		if len(accumulator.TaskOutcomes) > 0 {
 			participant.TaskSuccess = buildEvalSessionTaskSuccess(accumulator.TaskOutcomes, aggregateBehavior.KValues)
 			participant.PassAtK = buildEvalSessionPassMetricSeries(participant.TaskSuccess, aggregateBehavior.KValues, aggregateBehavior.EffectiveK, "pass_at_k")
@@ -841,6 +902,7 @@ func buildEvalSessionAggregatePayload(
 		}
 		document.Participants = append(document.Participants, participant)
 	}
+	document.SeriesReport = buildEvalSessionSeriesReport(document.Participants)
 
 	if len(document.Participants) == 1 {
 		participant := document.Participants[0]
@@ -928,6 +990,9 @@ func evalSessionParticipantObservedRuns(accumulator *evalSessionParticipantAccum
 		if len(values) > observedRuns {
 			observedRuns = len(values)
 		}
+	}
+	if len(accumulator.TotalCostUSD) > observedRuns {
+		observedRuns = len(accumulator.TotalCostUSD)
 	}
 	for _, taskOutcome := range accumulator.TaskOutcomes {
 		if taskOutcome != nil && len(taskOutcome.Outcomes) > observedRuns {
@@ -1317,6 +1382,129 @@ func appendBuiltInEvalSessionDimension(target map[string]float64, key string, va
 	target[key] = *value
 }
 
+func buildEvalSessionSeriesReport(participants []evalSessionParticipantAggregate) *evalSessionSeriesReport {
+	if len(participants) == 0 {
+		return nil
+	}
+
+	rows := make([]evalSessionSeriesReportRow, 0, len(participants))
+	rankMetric := "overall_score"
+	for _, participant := range participants {
+		row := buildEvalSessionSeriesReportRow(participant)
+		if row.CompositeAgentScore != nil {
+			rankMetric = "composite_agent_score"
+		}
+		rows = append(rows, row)
+	}
+
+	sort.SliceStable(rows, func(i, j int) bool {
+		left, leftOK := evalSessionSeriesReportRankValue(rows[i], rankMetric)
+		right, rightOK := evalSessionSeriesReportRankValue(rows[j], rankMetric)
+		if leftOK != rightOK {
+			return leftOK
+		}
+		if leftOK && math.Abs(left-right) > 1e-12 {
+			return left > right
+		}
+		if rows[i].MeanCostUSD != nil && rows[j].MeanCostUSD != nil && math.Abs(*rows[i].MeanCostUSD-*rows[j].MeanCostUSD) > 1e-12 {
+			return *rows[i].MeanCostUSD < *rows[j].MeanCostUSD
+		}
+		if rows[i].LaneIndex != rows[j].LaneIndex {
+			return rows[i].LaneIndex < rows[j].LaneIndex
+		}
+		return rows[i].Label < rows[j].Label
+	})
+
+	for i := range rows {
+		rows[i].Rank = i + 1
+	}
+	return &evalSessionSeriesReport{
+		RankMetric: rankMetric,
+		Rows:       rows,
+	}
+}
+
+func buildEvalSessionSeriesReportRow(participant evalSessionParticipantAggregate) evalSessionSeriesReportRow {
+	deploymentLineup, participantLabel := evalSessionSeriesReportLabelParts(participant.Label)
+	row := evalSessionSeriesReportRow{
+		LaneIndex:        participant.LaneIndex,
+		Label:            participant.Label,
+		DeploymentLineup: deploymentLineup,
+		ParticipantLabel: participantLabel,
+		ObservedRuns:     participant.ObservedRuns,
+	}
+	if participant.Overall != nil {
+		value := participant.Overall.Mean
+		row.OverallScore = &value
+	}
+	if correctness, ok := participant.Dimensions["correctness"]; ok {
+		value := correctness.Mean
+		row.CorrectnessScore = &value
+	}
+	if successRate, ok := evalSessionParticipantSuccessRate(participant); ok {
+		row.SuccessRate = &successRate
+	}
+	if participant.MetricRouting != nil {
+		value := participant.MetricRouting.CompositeAgentScore
+		row.CompositeAgentScore = &value
+	}
+	if participant.CostUSD != nil {
+		mean := participant.CostUSD.Mean
+		total := participant.CostUSD.Total
+		row.MeanCostUSD = &mean
+		row.TotalCostUSD = &total
+	}
+	return row
+}
+
+func evalSessionSeriesReportRankValue(row evalSessionSeriesReportRow, rankMetric string) (float64, bool) {
+	if rankMetric == "composite_agent_score" && row.CompositeAgentScore != nil {
+		return *row.CompositeAgentScore, true
+	}
+	if row.OverallScore != nil {
+		return *row.OverallScore, true
+	}
+	return 0, false
+}
+
+func evalSessionSeriesReportLabelParts(label string) (string, string) {
+	trimmed := strings.TrimSpace(label)
+	if trimmed == "" {
+		return "", ""
+	}
+	if lineup, participant, ok := strings.Cut(trimmed, " / "); ok {
+		return strings.TrimSpace(lineup), strings.TrimSpace(participant)
+	}
+	return trimmed, ""
+}
+
+func evalSessionParticipantSuccessRate(participant evalSessionParticipantAggregate) (float64, bool) {
+	if len(participant.TaskSuccess) == 0 {
+		return 0, false
+	}
+	values := make([]float64, 0, len(participant.TaskSuccess))
+	for _, task := range participant.TaskSuccess {
+		values = append(values, task.SuccessRate)
+	}
+	return kahanMean(values), true
+}
+
+func buildEvalSessionCostAggregate(values []float64) evalSessionCostAggregate {
+	if len(values) == 0 {
+		return evalSessionCostAggregate{}
+	}
+	sortedValues := append([]float64(nil), values...)
+	sort.Float64s(sortedValues)
+	total := kahanSum(sortedValues)
+	return evalSessionCostAggregate{
+		N:     len(sortedValues),
+		Total: total,
+		Mean:  total / float64(len(sortedValues)),
+		Min:   sortedValues[0],
+		Max:   sortedValues[len(sortedValues)-1],
+	}
+}
+
 func buildEvalSessionMetricAggregate(values []float64) evalSessionMetricAggregate {
 	if len(values) == 0 {
 		return evalSessionMetricAggregate{}
@@ -1377,6 +1565,10 @@ func kahanMean(values []float64) float64 {
 	if len(values) == 0 {
 		return 0
 	}
+	return kahanSum(values) / float64(len(values))
+}
+
+func kahanSum(values []float64) float64 {
 	sum := 0.0
 	compensation := 0.0
 	for _, value := range values {
@@ -1385,7 +1577,7 @@ func kahanMean(values []float64) float64 {
 		compensation = (t - sum) - y
 		sum = t
 	}
-	return sum / float64(len(values))
+	return sum
 }
 
 func median(values []float64) float64 {

--- a/backend/internal/repository/eval_session_aggregation.go
+++ b/backend/internal/repository/eval_session_aggregation.go
@@ -1511,11 +1511,16 @@ func evalSessionParticipantSuccessRate(participant evalSessionParticipantAggrega
 	if len(participant.TaskSuccess) == 0 {
 		return 0, false
 	}
-	values := make([]float64, 0, len(participant.TaskSuccess))
+	successfulTrials := 0
+	observedTrials := 0
 	for _, task := range participant.TaskSuccess {
-		values = append(values, task.SuccessRate)
+		successfulTrials += task.SuccessfulTrials
+		observedTrials += task.ObservedTrials
 	}
-	return kahanMean(values), true
+	if observedTrials == 0 {
+		return 0, false
+	}
+	return float64(successfulTrials) / float64(observedTrials), true
 }
 
 func buildEvalSessionCostAggregate(values []float64) evalSessionCostAggregate {

--- a/backend/internal/repository/eval_session_aggregation.go
+++ b/backend/internal/repository/eval_session_aggregation.go
@@ -322,7 +322,11 @@ func (r *Repository) AggregateEvalSession(ctx context.Context, evalSessionID uui
 				return EvalSessionAggregateRecord{}, fmt.Errorf("decode run scorecard %s: %w", run.ID, err)
 			}
 			deploymentLineup := evalSessionRunSeriesDeploymentLineup(run.ExecutionPlan)
-			participantSources, participantWarnings, err := r.buildEvalSessionAggregateParticipantSources(ctx, run.ID, document, behavior, deploymentLineup)
+			scorecardsByRunAgentID, err := r.evalSessionCostBackfillScorecards(ctx, run.ID, document)
+			if err != nil {
+				return EvalSessionAggregateRecord{}, err
+			}
+			participantSources, participantWarnings, err := r.buildEvalSessionAggregateParticipantSources(ctx, run.ID, document, behavior, deploymentLineup, scorecardsByRunAgentID)
 			if err != nil {
 				return EvalSessionAggregateRecord{}, fmt.Errorf("build eval session participant sources for run %s: %w", run.ID, err)
 			}
@@ -520,20 +524,17 @@ func (r *Repository) buildEvalSessionAggregateParticipantSources(
 	document runScorecardDocument,
 	behavior evalSessionAggregateBehavior,
 	deploymentLineup string,
+	scorecardsByRunAgentID map[uuid.UUID]RunAgentScorecard,
 ) ([]evalSessionAggregateParticipantSource, []string, error) {
 	participantSources := make([]evalSessionAggregateParticipantSource, 0, len(document.Agents))
 	warnings := make([]string, 0)
 
 	for _, agent := range document.Agents {
 		if agent.HasScorecard && agent.TotalCostUSD == nil {
-			scorecard, err := r.GetRunAgentScorecardByRunAgentID(ctx, agent.RunAgentID)
-			switch {
-			case err == nil:
+			if scorecard, ok := scorecardsByRunAgentID[agent.RunAgentID]; ok {
 				agent = evalSessionAgentWithScorecardCost(agent, scorecard.Scorecard)
-			case errors.Is(err, ErrRunAgentScorecardNotFound):
+			} else {
 				warnings = append(warnings, fmt.Sprintf("run %s participant %q (lane %d): run-agent scorecard unavailable; cost will be omitted", runID, agent.Label, agent.LaneIndex))
-			default:
-				return nil, nil, fmt.Errorf("load run-agent scorecard %s for cost aggregation: %w", agent.RunAgentID, err)
 			}
 		}
 
@@ -560,6 +561,29 @@ func (r *Repository) buildEvalSessionAggregateParticipantSources(
 	}
 
 	return participantSources, warnings, nil
+}
+
+func (r *Repository) evalSessionCostBackfillScorecards(ctx context.Context, runID uuid.UUID, document runScorecardDocument) (map[uuid.UUID]RunAgentScorecard, error) {
+	needsBackfill := false
+	for _, agent := range document.Agents {
+		if agent.HasScorecard && agent.TotalCostUSD == nil {
+			needsBackfill = true
+			break
+		}
+	}
+	if !needsBackfill {
+		return nil, nil
+	}
+
+	scorecards, err := r.ListRunAgentScorecardsByRunID(ctx, runID)
+	if err != nil {
+		return nil, fmt.Errorf("list run-agent scorecards for cost aggregation on run %s: %w", runID, err)
+	}
+	byRunAgentID := make(map[uuid.UUID]RunAgentScorecard, len(scorecards))
+	for _, scorecard := range scorecards {
+		byRunAgentID[scorecard.RunAgentID] = scorecard
+	}
+	return byRunAgentID, nil
 }
 
 func evalSessionAgentWithScorecardCost(agent runScorecardAgentSummary, scorecard json.RawMessage) runScorecardAgentSummary {
@@ -902,7 +926,9 @@ func buildEvalSessionAggregatePayload(
 		}
 		document.Participants = append(document.Participants, participant)
 	}
-	document.SeriesReport = buildEvalSessionSeriesReport(document.Participants)
+	if len(document.Participants) > 1 {
+		document.SeriesReport = buildEvalSessionSeriesReport(document.Participants)
+	}
 
 	if len(document.Participants) == 1 {
 		participant := document.Participants[0]
@@ -1458,7 +1484,10 @@ func buildEvalSessionSeriesReportRow(participant evalSessionParticipantAggregate
 }
 
 func evalSessionSeriesReportRankValue(row evalSessionSeriesReportRow, rankMetric string) (float64, bool) {
-	if rankMetric == "composite_agent_score" && row.CompositeAgentScore != nil {
+	if rankMetric == "composite_agent_score" {
+		if row.CompositeAgentScore == nil {
+			return 0, false
+		}
 		return *row.CompositeAgentScore, true
 	}
 	if row.OverallScore != nil {

--- a/backend/internal/repository/eval_session_aggregation_test.go
+++ b/backend/internal/repository/eval_session_aggregation_test.go
@@ -665,6 +665,31 @@ func TestBuildEvalSessionSeriesReportKeepsMixedMetricsBelowCompositeRows(t *test
 	}
 }
 
+func TestEvalSessionParticipantSuccessRateWeightsObservedTrials(t *testing.T) {
+	successRate, ok := evalSessionParticipantSuccessRate(evalSessionParticipantAggregate{
+		TaskSuccess: []evalSessionTaskSuccess{
+			{
+				TaskKey:          "sparse-pass",
+				ObservedTrials:   1,
+				SuccessfulTrials: 1,
+				SuccessRate:      1,
+			},
+			{
+				TaskKey:          "dense-failures",
+				ObservedTrials:   9,
+				SuccessfulTrials: 0,
+				SuccessRate:      0,
+			},
+		},
+	})
+	if !ok {
+		t.Fatal("success rate unresolved, want weighted rate")
+	}
+	if math.Abs(successRate-0.1) > 1e-9 {
+		t.Fatalf("success rate = %f, want 0.1", successRate)
+	}
+}
+
 func TestEvalSessionAgentWithScorecardCostBackfillsOldRunScorecardSummary(t *testing.T) {
 	agent := evalSessionAgentWithScorecardCost(runScorecardAgentSummary{
 		RunAgentID:   uuid.New(),

--- a/backend/internal/repository/eval_session_aggregation_test.go
+++ b/backend/internal/repository/eval_session_aggregation_test.go
@@ -117,6 +117,39 @@ func TestBuildEvalSessionAggregatePayloadCapturesMissingScorecardsAndPartialCove
 	}
 }
 
+func TestBuildEvalSessionAggregatePayloadOmitsSeriesReportForSingleParticipant(t *testing.T) {
+	aggregateJSON, _, _, err := buildEvalSessionAggregatePayload(
+		1,
+		[]evalSessionAggregateSource{
+			evalSessionTestSource(
+				"45454545-4545-4545-4545-454545454545",
+				evalSessionTestParticipant(
+					"dddddddd-dddd-dddd-dddd-dddddddddddd",
+					0,
+					"Primary",
+					0.88,
+					map[string]float64{"correctness": 0.88},
+					evalSessionTestTask("task-a", true),
+				),
+			),
+		},
+		nil,
+		evalSessionTestBehavior(),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("buildEvalSessionAggregatePayload returned error: %v", err)
+	}
+
+	var aggregate evalSessionAggregateDocument
+	if err := json.Unmarshal(aggregateJSON, &aggregate); err != nil {
+		t.Fatalf("unmarshal aggregate: %v", err)
+	}
+	if aggregate.SeriesReport != nil {
+		t.Fatalf("series_report = %#v, want nil for a single participant session", aggregate.SeriesReport)
+	}
+}
+
 func TestBuildEvalSessionAggregatePayloadRejectsMissingScoredChildren(t *testing.T) {
 	_, _, _, err := buildEvalSessionAggregatePayload(2, nil, nil, evalSessionTestBehavior(), nil)
 	if !errors.Is(err, ErrEvalSessionAggregateUnavailable) {
@@ -594,6 +627,42 @@ func TestBuildEvalSessionAggregatePayloadSeriesReportIncludesScoreCostCorrectnes
 		}
 	}
 	t.Fatalf("participants = %#v, want smoke / Primary", aggregate.Participants)
+}
+
+func TestBuildEvalSessionSeriesReportKeepsMixedMetricsBelowCompositeRows(t *testing.T) {
+	report := buildEvalSessionSeriesReport([]evalSessionParticipantAggregate{
+		{
+			LaneIndex: 0,
+			Label:     "composite / Primary",
+			Overall:   &evalSessionMetricAggregate{Mean: 0.60},
+			MetricRouting: &evalSessionMetricRouting{
+				CompositeAgentScore: 0.55,
+			},
+			ObservedRuns: 2,
+		},
+		{
+			LaneIndex:    0,
+			Label:        "overall-only / Primary",
+			Overall:      &evalSessionMetricAggregate{Mean: 0.99},
+			ObservedRuns: 2,
+		},
+	})
+
+	if report == nil {
+		t.Fatal("series report = nil, want rows")
+	}
+	if report.RankMetric != "composite_agent_score" {
+		t.Fatalf("rank metric = %q, want composite_agent_score", report.RankMetric)
+	}
+	if len(report.Rows) != 2 {
+		t.Fatalf("rows = %#v, want two rows", report.Rows)
+	}
+	if report.Rows[0].Label != "composite / Primary" || report.Rows[0].Rank != 1 {
+		t.Fatalf("top row = %#v, want composite-scored row above overall-only row", report.Rows[0])
+	}
+	if report.Rows[1].Label != "overall-only / Primary" || report.Rows[1].Rank != 2 {
+		t.Fatalf("second row = %#v, want overall-only row below composite-scored row", report.Rows[1])
+	}
 }
 
 func TestEvalSessionAgentWithScorecardCostBackfillsOldRunScorecardSummary(t *testing.T) {

--- a/backend/internal/repository/eval_session_aggregation_test.go
+++ b/backend/internal/repository/eval_session_aggregation_test.go
@@ -489,6 +489,148 @@ func TestBuildEvalSessionAggregatePayloadSeriesLabelsDisambiguateLineups(t *test
 	}
 }
 
+func TestBuildEvalSessionAggregatePayloadSeriesReportIncludesScoreCostCorrectness(t *testing.T) {
+	aggregateJSON, _, _, err := buildEvalSessionAggregatePayload(
+		4,
+		[]evalSessionAggregateSource{
+			evalSessionTestSource(
+				"70707070-7070-7070-7070-707070707071",
+				evalSessionTestParticipantWithCost(
+					"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa71",
+					0,
+					"default / Primary",
+					0.60,
+					map[string]float64{"correctness": 0.50},
+					[]evalSessionAggregateTaskOutcome{evalSessionTestTask("task-a", true), evalSessionTestTask("task-b", false)},
+					0.01,
+				),
+			),
+			evalSessionTestSource(
+				"70707070-7070-7070-7070-707070707072",
+				evalSessionTestParticipantWithCost(
+					"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa72",
+					0,
+					"default / Primary",
+					0.70,
+					map[string]float64{"correctness": 0.70},
+					[]evalSessionAggregateTaskOutcome{evalSessionTestTask("task-a", false), evalSessionTestTask("task-b", false)},
+					0.03,
+				),
+			),
+			evalSessionTestSource(
+				"70707070-7070-7070-7070-707070707073",
+				evalSessionTestParticipantWithCost(
+					"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa73",
+					0,
+					"smoke / Primary",
+					0.90,
+					map[string]float64{"correctness": 0.90},
+					[]evalSessionAggregateTaskOutcome{evalSessionTestTask("task-a", true), evalSessionTestTask("task-b", true)},
+					0.02,
+				),
+			),
+			evalSessionTestSource(
+				"70707070-7070-7070-7070-707070707074",
+				evalSessionTestParticipantWithCost(
+					"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa74",
+					0,
+					"smoke / Primary",
+					0.80,
+					map[string]float64{"correctness": 0.80},
+					[]evalSessionAggregateTaskOutcome{evalSessionTestTask("task-a", true), evalSessionTestTask("task-b", false)},
+					0.04,
+				),
+			),
+		},
+		nil,
+		evalSessionAggregateBehavior{KValues: []int{1, 2, 3, 5, 10}, EffectiveK: 2, SuccessThreshold: 0.8},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("buildEvalSessionAggregatePayload returned error: %v", err)
+	}
+
+	var aggregate evalSessionAggregateDocument
+	if err := json.Unmarshal(aggregateJSON, &aggregate); err != nil {
+		t.Fatalf("unmarshal aggregate: %v", err)
+	}
+	if aggregate.SeriesReport == nil {
+		t.Fatal("series_report = nil, want aggregate report")
+	}
+	if aggregate.SeriesReport.RankMetric != "composite_agent_score" {
+		t.Fatalf("rank_metric = %q, want composite_agent_score", aggregate.SeriesReport.RankMetric)
+	}
+	if len(aggregate.SeriesReport.Rows) != 2 {
+		t.Fatalf("report rows = %#v, want two lineups", aggregate.SeriesReport.Rows)
+	}
+	top := aggregate.SeriesReport.Rows[0]
+	if top.Label != "smoke / Primary" || top.DeploymentLineup != "smoke" || top.ParticipantLabel != "Primary" {
+		t.Fatalf("top row labels = %#v, want smoke / Primary split into lineup/participant", top)
+	}
+	if top.ObservedRuns != 2 {
+		t.Fatalf("top observed runs = %d, want 2", top.ObservedRuns)
+	}
+	if top.OverallScore == nil || math.Abs(*top.OverallScore-0.85) > 1e-9 {
+		t.Fatalf("top overall = %v, want 0.85", top.OverallScore)
+	}
+	if top.CorrectnessScore == nil || math.Abs(*top.CorrectnessScore-0.85) > 1e-9 {
+		t.Fatalf("top correctness = %v, want 0.85", top.CorrectnessScore)
+	}
+	if top.SuccessRate == nil || math.Abs(*top.SuccessRate-0.75) > 1e-9 {
+		t.Fatalf("top success rate = %v, want 0.75", top.SuccessRate)
+	}
+	if top.MeanCostUSD == nil || math.Abs(*top.MeanCostUSD-0.03) > 1e-9 {
+		t.Fatalf("top mean cost = %v, want 0.03", top.MeanCostUSD)
+	}
+	if top.TotalCostUSD == nil || math.Abs(*top.TotalCostUSD-0.06) > 1e-9 {
+		t.Fatalf("top total cost = %v, want 0.06", top.TotalCostUSD)
+	}
+	for _, participant := range aggregate.Participants {
+		if participant.Label == "smoke / Primary" {
+			if participant.CostUSD == nil || math.Abs(participant.CostUSD.Total-0.06) > 1e-9 {
+				t.Fatalf("smoke participant cost = %#v, want total 0.06", participant.CostUSD)
+			}
+			return
+		}
+	}
+	t.Fatalf("participants = %#v, want smoke / Primary", aggregate.Participants)
+}
+
+func TestEvalSessionAgentWithScorecardCostBackfillsOldRunScorecardSummary(t *testing.T) {
+	agent := evalSessionAgentWithScorecardCost(runScorecardAgentSummary{
+		RunAgentID:   uuid.New(),
+		LaneIndex:    0,
+		Label:        "Primary",
+		HasScorecard: true,
+	}, json.RawMessage(`{
+		"metric_details": [
+			{"collector": "run_model_cost_usd", "numeric_value": 0.044}
+		]
+	}`))
+	if agent.TotalCostUSD == nil || *agent.TotalCostUSD != 0.044 {
+		t.Fatalf("total cost = %v, want 0.044", agent.TotalCostUSD)
+	}
+
+	existing := 0.12
+	agent = evalSessionAgentWithScorecardCost(runScorecardAgentSummary{
+		RunAgentID:       uuid.New(),
+		LaneIndex:        0,
+		Label:            "Primary",
+		HasScorecard:     true,
+		TotalCostUSD:     &existing,
+		OverallScore:     float64Ptr(0.9),
+		CostScore:        float64Ptr(0.8),
+		CorrectnessScore: float64Ptr(0.7),
+	}, json.RawMessage(`{
+		"metric_details": [
+			{"collector": "run_model_cost_usd", "numeric_value": 0.01}
+		]
+	}`))
+	if agent.TotalCostUSD == nil || *agent.TotalCostUSD != existing {
+		t.Fatalf("total cost = %v, want existing value %f", agent.TotalCostUSD, existing)
+	}
+}
+
 func TestEvalSessionSeriesParticipantLabelAvoidsDuplicateLineup(t *testing.T) {
 	if got := evalSessionSeriesParticipantLabel("smoke", "smoke"); got != "smoke" {
 		t.Fatalf("label = %q, want smoke", got)
@@ -709,6 +851,20 @@ func evalSessionTestParticipant(
 		Agent:        agent,
 		TaskOutcomes: tasks,
 	}
+}
+
+func evalSessionTestParticipantWithCost(
+	runAgentID string,
+	laneIndex int32,
+	label string,
+	overall float64,
+	dimensions map[string]float64,
+	tasks []evalSessionAggregateTaskOutcome,
+	costUSD float64,
+) evalSessionAggregateParticipantSource {
+	participant := evalSessionTestParticipant(runAgentID, laneIndex, label, overall, dimensions, tasks...)
+	participant.Agent.TotalCostUSD = float64Ptr(costUSD)
+	return participant
 }
 
 func evalSessionTestTask(taskKey string, success bool) evalSessionAggregateTaskOutcome {

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -926,6 +926,37 @@ func (r *Repository) GetRunAgentScorecardByRunAgentID(ctx context.Context, runAg
 	return scorecard, nil
 }
 
+func (r *Repository) ListRunAgentScorecardsByRunID(ctx context.Context, runID uuid.UUID) ([]RunAgentScorecard, error) {
+	rows, err := r.queries.ListRunAgentScorecardsByRunID(ctx, repositorysqlc.ListRunAgentScorecardsByRunIDParams{RunID: runID})
+	if err != nil {
+		return nil, fmt.Errorf("list run-agent scorecards by run id: %w", err)
+	}
+
+	scorecards := make([]RunAgentScorecard, 0, len(rows))
+	for _, row := range rows {
+		scorecard, err := mapRunAgentScorecardFromFields(
+			row.ID,
+			row.RunAgentID,
+			row.EvaluationSpecID,
+			row.OverallScore,
+			row.CorrectnessScore,
+			row.ReliabilityScore,
+			row.LatencyScore,
+			row.CostScore,
+			row.BehavioralScore,
+			row.ScorecardPassed,
+			row.Scorecard,
+			row.CreatedAt,
+			row.UpdatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("map run-agent scorecard %s: %w", row.RunAgentID, err)
+		}
+		scorecards = append(scorecards, scorecard)
+	}
+	return scorecards, nil
+}
+
 func (r *Repository) StoreRunAgentEvaluationResults(ctx context.Context, evaluation scoring.RunAgentEvaluation) error {
 	tx, err := r.db.Begin(ctx)
 	if err != nil {
@@ -2218,27 +2249,59 @@ func mapRunEvent(row repositorysqlc.RunEvent) (RunEvent, error) {
 }
 
 func mapRunAgentScorecard(row repositorysqlc.GetRunAgentScorecardByRunAgentIDRow) (RunAgentScorecard, error) {
-	createdAt, err := requiredTime("run_agent_scorecards.created_at", row.CreatedAt)
+	return mapRunAgentScorecardFromFields(
+		row.ID,
+		row.RunAgentID,
+		row.EvaluationSpecID,
+		row.OverallScore,
+		row.CorrectnessScore,
+		row.ReliabilityScore,
+		row.LatencyScore,
+		row.CostScore,
+		row.BehavioralScore,
+		row.ScorecardPassed,
+		row.Scorecard,
+		row.CreatedAt,
+		row.UpdatedAt,
+	)
+}
+
+func mapRunAgentScorecardFromFields(
+	id uuid.UUID,
+	runAgentID uuid.UUID,
+	evaluationSpecID uuid.UUID,
+	overallScore pgtype.Numeric,
+	correctnessScore pgtype.Numeric,
+	reliabilityScore pgtype.Numeric,
+	latencyScore pgtype.Numeric,
+	costScore pgtype.Numeric,
+	behavioralScore pgtype.Numeric,
+	scorecardPassed *bool,
+	scorecard json.RawMessage,
+	createdAtValue pgtype.Timestamptz,
+	updatedAtValue pgtype.Timestamptz,
+) (RunAgentScorecard, error) {
+	createdAt, err := requiredTime("run_agent_scorecards.created_at", createdAtValue)
 	if err != nil {
 		return RunAgentScorecard{}, err
 	}
-	updatedAt, err := requiredTime("run_agent_scorecards.updated_at", row.UpdatedAt)
+	updatedAt, err := requiredTime("run_agent_scorecards.updated_at", updatedAtValue)
 	if err != nil {
 		return RunAgentScorecard{}, err
 	}
 
 	return RunAgentScorecard{
-		ID:               row.ID,
-		RunAgentID:       row.RunAgentID,
-		EvaluationSpecID: row.EvaluationSpecID,
-		OverallScore:     numericPtr(row.OverallScore),
-		CorrectnessScore: numericPtr(row.CorrectnessScore),
-		ReliabilityScore: numericPtr(row.ReliabilityScore),
-		LatencyScore:     numericPtr(row.LatencyScore),
-		CostScore:        numericPtr(row.CostScore),
-		BehavioralScore:  numericPtr(row.BehavioralScore),
-		Passed:           cloneBoolPtr(row.ScorecardPassed),
-		Scorecard:        cloneJSON(row.Scorecard),
+		ID:               id,
+		RunAgentID:       runAgentID,
+		EvaluationSpecID: evaluationSpecID,
+		OverallScore:     numericPtr(overallScore),
+		CorrectnessScore: numericPtr(correctnessScore),
+		ReliabilityScore: numericPtr(reliabilityScore),
+		LatencyScore:     numericPtr(latencyScore),
+		CostScore:        numericPtr(costScore),
+		BehavioralScore:  numericPtr(behavioralScore),
+		Passed:           cloneBoolPtr(scorecardPassed),
+		Scorecard:        cloneJSON(scorecard),
 		CreatedAt:        createdAt,
 		UpdatedAt:        updatedAt,
 	}, nil

--- a/backend/internal/repository/run_scorecard.go
+++ b/backend/internal/repository/run_scorecard.go
@@ -64,6 +64,7 @@ type runScorecardAgentSummary struct {
 	ReliabilityScore *float64                                    `json:"reliability_score,omitempty"`
 	LatencyScore     *float64                                    `json:"latency_score,omitempty"`
 	CostScore        *float64                                    `json:"cost_score,omitempty"`
+	TotalCostUSD     *float64                                    `json:"total_cost_usd,omitempty"`
 	BehavioralScore  *float64                                    `json:"behavioral_score,omitempty"`
 	Dimensions       map[string]comparisonScorecardDimensionInfo `json:"dimensions,omitempty"`
 }
@@ -209,6 +210,7 @@ func buildRunScorecardDocument(
 			summary.ReliabilityScore = cloneFloat64Ptr(participant.scorecard.ReliabilityScore)
 			summary.LatencyScore = cloneFloat64Ptr(participant.scorecard.LatencyScore)
 			summary.CostScore = cloneFloat64Ptr(participant.scorecard.CostScore)
+			summary.TotalCostUSD = totalCostUSDFromRunAgentScorecardDocument(participant.scorecard.Scorecard)
 			summary.BehavioralScore = cloneFloat64Ptr(participant.scorecard.BehavioralScore)
 			summary.Dimensions = cloneRunScorecardDimensions(participant.document.Dimensions)
 			scoredAgents = append(scoredAgents, scoredRunAgent{
@@ -250,6 +252,25 @@ func buildRunScorecardDocument(
 		return nil, nil, fmt.Errorf("marshal run scorecard: %w", err)
 	}
 	return encoded, winningRunAgentID, nil
+}
+
+func totalCostUSDFromRunAgentScorecardDocument(payload json.RawMessage) *float64 {
+	var document struct {
+		MetricDetails []struct {
+			Collector    string   `json:"collector"`
+			NumericValue *float64 `json:"numeric_value"`
+		} `json:"metric_details"`
+	}
+	if err := json.Unmarshal(payload, &document); err != nil {
+		return nil
+	}
+	for _, metric := range document.MetricDetails {
+		if metric.Collector == "run_model_cost_usd" && metric.NumericValue != nil {
+			cost := *metric.NumericValue
+			return &cost
+		}
+	}
+	return nil
 }
 
 func determineRunWinner(participants []runScorecardParticipant, scoredAgents []scoredRunAgent) (*uuid.UUID, runScorecardWinnerSummary) {

--- a/backend/internal/repository/run_scorecard_test.go
+++ b/backend/internal/repository/run_scorecard_test.go
@@ -107,6 +107,22 @@ func TestBuildRunAgentScorecardDocumentIncludesRegressionCaseIDs(t *testing.T) {
 	}
 }
 
+func TestTotalCostUSDFromRunAgentScorecardDocument(t *testing.T) {
+	cost := totalCostUSDFromRunAgentScorecardDocument(json.RawMessage(`{
+		"metric_details": [
+			{"collector": "tool_call_count", "numeric_value": 7},
+			{"collector": "run_model_cost_usd", "numeric_value": 0.0125}
+		]
+	}`))
+	if cost == nil || *cost != 0.0125 {
+		t.Fatalf("cost = %v, want 0.0125", cost)
+	}
+
+	if got := totalCostUSDFromRunAgentScorecardDocument(json.RawMessage(`{"metric_details":[]}`)); got != nil {
+		t.Fatalf("cost = %v, want nil without run_model_cost_usd metric", got)
+	}
+}
+
 func TestBuildRunAgentScorecardDocumentIncludesValidityAndValidatorOutcomeClass(t *testing.T) {
 	document, err := buildRunAgentScorecardDocument(scoring.RunAgentEvaluation{
 		RunAgentID:       uuid.New(),

--- a/backend/internal/repository/sqlc/querier.go
+++ b/backend/internal/repository/sqlc/querier.go
@@ -99,6 +99,7 @@ type Querier interface {
 	ListRegressionCasesBySuiteID(ctx context.Context, arg ListRegressionCasesBySuiteIDParams) ([]ListRegressionCasesBySuiteIDRow, error)
 	ListRegressionCasesByWorkspaceID(ctx context.Context, arg ListRegressionCasesByWorkspaceIDParams) ([]ListRegressionCasesByWorkspaceIDRow, error)
 	ListRegressionSuitesByWorkspaceID(ctx context.Context, arg ListRegressionSuitesByWorkspaceIDParams) ([]WorkspaceRegressionSuite, error)
+	ListRunAgentScorecardsByRunID(ctx context.Context, arg ListRunAgentScorecardsByRunIDParams) ([]ListRunAgentScorecardsByRunIDRow, error)
 	ListRunAgentStatusHistoryByRunAgentID(ctx context.Context, arg ListRunAgentStatusHistoryByRunAgentIDParams) ([]RunAgentStatusHistory, error)
 	ListRunAgentsByRunID(ctx context.Context, arg ListRunAgentsByRunIDParams) ([]RunAgent, error)
 	ListRunCaseSelectionsByRunID(ctx context.Context, arg ListRunCaseSelectionsByRunIDParams) ([]RunCaseSelection, error)

--- a/backend/internal/repository/sqlc/replay_reads.sql.go
+++ b/backend/internal/repository/sqlc/replay_reads.sql.go
@@ -64,6 +64,7 @@ SELECT
     updated_at
 FROM run_agent_scorecards
 WHERE run_agent_id = $1
+ORDER BY updated_at DESC, id DESC
 LIMIT 1
 `
 
@@ -109,7 +110,7 @@ func (q *Queries) GetRunAgentScorecardByRunAgentID(ctx context.Context, arg GetR
 }
 
 const listRunAgentScorecardsByRunID = `-- name: ListRunAgentScorecardsByRunID :many
-SELECT
+SELECT DISTINCT ON (sc.run_agent_id)
     sc.id,
     sc.run_agent_id,
     sc.evaluation_spec_id,
@@ -126,7 +127,7 @@ SELECT
 FROM run_agent_scorecards sc
 JOIN run_agents ra ON ra.id = sc.run_agent_id
 WHERE ra.run_id = $1
-ORDER BY ra.lane_index, ra.label, sc.run_agent_id
+ORDER BY sc.run_agent_id, sc.updated_at DESC, sc.id DESC
 `
 
 type ListRunAgentScorecardsByRunIDParams struct {

--- a/backend/internal/repository/sqlc/replay_reads.sql.go
+++ b/backend/internal/repository/sqlc/replay_reads.sql.go
@@ -108,6 +108,81 @@ func (q *Queries) GetRunAgentScorecardByRunAgentID(ctx context.Context, arg GetR
 	return i, err
 }
 
+const listRunAgentScorecardsByRunID = `-- name: ListRunAgentScorecardsByRunID :many
+SELECT
+    sc.id,
+    sc.run_agent_id,
+    sc.evaluation_spec_id,
+    sc.overall_score,
+    sc.correctness_score,
+    sc.reliability_score,
+    sc.latency_score,
+    sc.cost_score,
+    sc.behavioral_score,
+    sc.scorecard_passed,
+    sc.scorecard,
+    sc.created_at,
+    sc.updated_at
+FROM run_agent_scorecards sc
+JOIN run_agents ra ON ra.id = sc.run_agent_id
+WHERE ra.run_id = $1
+ORDER BY ra.lane_index, ra.label, sc.run_agent_id
+`
+
+type ListRunAgentScorecardsByRunIDParams struct {
+	RunID uuid.UUID
+}
+
+type ListRunAgentScorecardsByRunIDRow struct {
+	ID               uuid.UUID
+	RunAgentID       uuid.UUID
+	EvaluationSpecID uuid.UUID
+	OverallScore     pgtype.Numeric
+	CorrectnessScore pgtype.Numeric
+	ReliabilityScore pgtype.Numeric
+	LatencyScore     pgtype.Numeric
+	CostScore        pgtype.Numeric
+	BehavioralScore  pgtype.Numeric
+	ScorecardPassed  *bool
+	Scorecard        []byte
+	CreatedAt        pgtype.Timestamptz
+	UpdatedAt        pgtype.Timestamptz
+}
+
+func (q *Queries) ListRunAgentScorecardsByRunID(ctx context.Context, arg ListRunAgentScorecardsByRunIDParams) ([]ListRunAgentScorecardsByRunIDRow, error) {
+	rows, err := q.db.Query(ctx, listRunAgentScorecardsByRunID, arg.RunID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListRunAgentScorecardsByRunIDRow
+	for rows.Next() {
+		var i ListRunAgentScorecardsByRunIDRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.RunAgentID,
+			&i.EvaluationSpecID,
+			&i.OverallScore,
+			&i.CorrectnessScore,
+			&i.ReliabilityScore,
+			&i.LatencyScore,
+			&i.CostScore,
+			&i.BehavioralScore,
+			&i.ScorecardPassed,
+			&i.Scorecard,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const upsertRunAgentReplayIndex = `-- name: UpsertRunAgentReplayIndex :one
 INSERT INTO run_agent_replays (
     run_agent_id,

--- a/cli/cmd/eval_session_test.go
+++ b/cli/cmd/eval_session_test.go
@@ -462,6 +462,95 @@ func TestRunSeriesCreateRoutesToEvalSessions(t *testing.T) {
 	}
 }
 
+func TestRunSeriesReportRendersAggregateScoreCostCorrectness(t *testing.T) {
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/eval-sessions/es-1": jsonHandler(200, map[string]any{
+			"eval_session": map[string]any{
+				"id":          "es-1",
+				"status":      "completed",
+				"repetitions": 4,
+			},
+			"runs": []map[string]any{},
+			"summary": map[string]any{
+				"run_counts": map[string]any{"total": 4, "completed": 4},
+			},
+			"aggregate_result": map[string]any{
+				"schema_version":     1,
+				"child_run_count":    4,
+				"scored_child_count": 4,
+				"series_report": map[string]any{
+					"rank_metric": "composite_agent_score",
+					"rows": []map[string]any{
+						{
+							"rank":                  1,
+							"lane_index":            0,
+							"label":                 "smoke / Primary",
+							"deployment_lineup":     "smoke",
+							"participant_label":     "Primary",
+							"observed_runs":         2,
+							"overall_score":         0.85,
+							"correctness_score":     0.9,
+							"success_rate":          0.75,
+							"mean_cost_usd":         0.03,
+							"total_cost_usd":        0.06,
+							"composite_agent_score": 0.91,
+						},
+						{
+							"rank":                  2,
+							"lane_index":            0,
+							"label":                 "default / Primary",
+							"deployment_lineup":     "default",
+							"participant_label":     "Primary",
+							"observed_runs":         2,
+							"overall_score":         0.95,
+							"correctness_score":     0.95,
+							"success_rate":          0.5,
+							"mean_cost_usd":         0.01,
+							"total_cost_usd":        0.02,
+							"composite_agent_score": 0.40,
+						},
+					},
+				},
+			},
+			"evidence_warnings": []string{"partial cost evidence"},
+		}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{"run", "series", "report", "es-1"}, srv.URL)
+	out := stdout.finish()
+	if err != nil {
+		t.Fatalf("run series report error: %v", err)
+	}
+	for _, snippet := range []string{
+		"Eval Session ID",
+		"Race Series Report",
+		"COMPOSITE",
+		"smoke",
+		"default",
+		"Primary",
+		"0.91",
+		"0.85",
+		"0.95",
+		"0.90",
+		"75.0%",
+		"$0.0300",
+		"$0.0600",
+		"partial cost evidence",
+	} {
+		if !strings.Contains(out, snippet) {
+			t.Fatalf("run series report output missing %q\n---\n%s", snippet, out)
+		}
+	}
+	smokeIndex := strings.Index(out, "smoke")
+	defaultIndex := strings.Index(out, "default")
+	if smokeIndex < 0 || defaultIndex < 0 || smokeIndex > defaultIndex {
+		t.Fatalf("report rows should preserve backend rank order by composite score\n---\n%s", out)
+	}
+}
+
 func TestRunSeriesCreateValidatesSeedsBeforeResolvingLineups(t *testing.T) {
 	requests := 0
 	routes := evalStartFakeRoutes(t, nil)

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -220,14 +220,7 @@ func renderRunSeriesReport(rc *RunContext, result map[string]any) {
 	}
 
 	fmt.Fprintf(rc.Output.Writer(), "\n%s\n", output.Bold("Race Series Report"))
-	reportUsesComposite := false
-	for _, raw := range rowsRaw {
-		row, ok := raw.(map[string]any)
-		if ok && mapValue(row, "composite_agent_score") != nil {
-			reportUsesComposite = true
-			break
-		}
-	}
+	reportUsesComposite := mapString(report, "rank_metric") == "composite_agent_score"
 	cols := []output.Column{
 		{Header: "Rank"},
 		{Header: "Lineup"},

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -28,6 +28,7 @@ func init() {
 	runCmd.AddCommand(runPromoteFailureCmd)
 	runCmd.AddCommand(runSeriesCmd)
 	runSeriesCmd.AddCommand(runSeriesCreateCmd)
+	runSeriesCmd.AddCommand(runSeriesReportCmd)
 
 	runCreateCmd.Flags().String("challenge-pack-version", "", "Challenge pack version ID (optional in a TTY; prompted when omitted)")
 	runCreateCmd.Flags().StringSlice("deployments", nil, "Agent deployment IDs (optional in a TTY; prompted when omitted)")
@@ -111,6 +112,35 @@ var runSeriesCreateCmd = &cobra.Command{
 	},
 }
 
+var runSeriesReportCmd = &cobra.Command{
+	Use:   "report <eval-session-id>",
+	Short: "Show aggregate score, correctness, and cost for a race series",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+
+		resp, err := rc.Client.Get(cmd.Context(), "/v1/eval-sessions/"+args[0], nil)
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+
+		var result map[string]any
+		if err := resp.DecodeJSON(&result); err != nil {
+			return err
+		}
+
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(result)
+		}
+
+		renderRunSeriesReport(rc, result)
+		return nil
+	},
+}
+
 var runListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List runs in the workspace",
@@ -155,6 +185,101 @@ var runListCmd = &cobra.Command{
 		rc.Output.PrintTable(cols, rows)
 		return nil
 	},
+}
+
+func renderRunSeriesReport(rc *RunContext, result map[string]any) {
+	session := mapObject(result, "eval_session")
+	if id := mapString(session, "id"); id != "" {
+		rc.Output.PrintDetail("Eval Session ID", id)
+	}
+	if status := mapString(session, "status"); status != "" {
+		rc.Output.PrintDetail("Status", output.StatusColor(status))
+	}
+	if repetitions := mapValue(session, "repetitions"); repetitions != nil {
+		rc.Output.PrintDetail("Repetitions", str(repetitions))
+	}
+
+	summary := mapObject(result, "summary")
+	if runCounts := mapObject(summary, "run_counts"); runCounts != nil {
+		rc.Output.PrintDetail("Runs", fmt.Sprintf("%s total, %s completed", str(runCounts["total"]), str(runCounts["completed"])))
+	}
+
+	aggregate := mapObject(result, "aggregate_result")
+	if aggregate == nil {
+		rc.Output.PrintWarning("Aggregate result is not available yet.")
+		renderEvalSessionEvidenceWarnings(rc, result)
+		return
+	}
+
+	report := mapObject(aggregate, "series_report")
+	rowsRaw := mapSlice(report, "rows")
+	if len(rowsRaw) == 0 {
+		rc.Output.PrintWarning("Aggregate result does not include a race series report.")
+		renderEvalSessionEvidenceWarnings(rc, result)
+		return
+	}
+
+	fmt.Fprintf(rc.Output.Writer(), "\n%s\n", output.Bold("Race Series Report"))
+	reportUsesComposite := false
+	for _, raw := range rowsRaw {
+		row, ok := raw.(map[string]any)
+		if ok && mapValue(row, "composite_agent_score") != nil {
+			reportUsesComposite = true
+			break
+		}
+	}
+	cols := []output.Column{
+		{Header: "Rank"},
+		{Header: "Lineup"},
+		{Header: "Participant"},
+		{Header: "Runs"},
+	}
+	if reportUsesComposite {
+		cols = append(cols, output.Column{Header: "Composite"})
+	}
+	cols = append(cols,
+		output.Column{Header: "Score"},
+		output.Column{Header: "Correctness"},
+		output.Column{Header: "Success"},
+		output.Column{Header: "Mean Cost"},
+		output.Column{Header: "Total Cost"},
+	)
+	rows := make([][]string, 0, len(rowsRaw))
+	for _, raw := range rowsRaw {
+		row, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		rows = append(rows, []string{
+			str(row["rank"]),
+			mapString(row, "deployment_lineup"),
+			mapString(row, "participant_label", "label"),
+			str(row["observed_runs"]),
+		})
+		if reportUsesComposite {
+			rows[len(rows)-1] = append(rows[len(rows)-1], fmtScore(mapValue(row, "composite_agent_score")))
+		}
+		rows[len(rows)-1] = append(rows[len(rows)-1],
+			fmtScore(mapValue(row, "overall_score")),
+			fmtScore(mapValue(row, "correctness_score")),
+			fmtPercent(mapValue(row, "success_rate")),
+			fmtUSD(mapValue(row, "mean_cost_usd")),
+			fmtUSD(mapValue(row, "total_cost_usd")),
+		)
+	}
+	rc.Output.PrintTable(cols, rows)
+	renderEvalSessionEvidenceWarnings(rc, result)
+}
+
+func renderEvalSessionEvidenceWarnings(rc *RunContext, result map[string]any) {
+	warnings := mapStringSlice(result, "evidence_warnings")
+	if len(warnings) == 0 {
+		return
+	}
+	fmt.Fprintf(rc.Output.Writer(), "\n%s\n", output.Bold("Evidence Warnings"))
+	for _, warning := range warnings {
+		fmt.Fprintf(rc.Output.Writer(), "  - %s\n", output.SanitizeLine(warning))
+	}
 }
 
 var runGetCmd = &cobra.Command{
@@ -693,6 +818,16 @@ func fmtScore(v any) string {
 	}
 	if f, ok := v.(float64); ok {
 		return fmt.Sprintf("%.2f", f)
+	}
+	return fmt.Sprint(v)
+}
+
+func fmtPercent(v any) string {
+	if v == nil {
+		return "-"
+	}
+	if f, ok := v.(float64); ok {
+		return fmt.Sprintf("%.1f%%", f*100)
 	}
 	return fmt.Sprint(v)
 }

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -7320,6 +7320,8 @@ components:
             $ref: "#/components/schemas/EvalSessionParticipantAggregate"
         comparison:
           $ref: "#/components/schemas/EvalSessionRepeatedComparison"
+        series_report:
+          $ref: "#/components/schemas/EvalSessionSeriesReport"
 
     EvalSessionParticipantAggregate:
       type: object
@@ -7345,6 +7347,64 @@ components:
           $ref: "#/components/schemas/EvalSessionPassMetricSeries"
         metric_routing:
           $ref: "#/components/schemas/EvalSessionMetricRouting"
+        cost_usd:
+          $ref: "#/components/schemas/EvalSessionCostAggregate"
+
+    EvalSessionSeriesReport:
+      type: object
+      required: [rank_metric, rows]
+      properties:
+        rank_metric:
+          type: string
+          enum: [overall_score, composite_agent_score]
+        rows:
+          type: array
+          items:
+            $ref: "#/components/schemas/EvalSessionSeriesReportRow"
+
+    EvalSessionSeriesReportRow:
+      type: object
+      required: [rank, lane_index, label, observed_runs]
+      properties:
+        rank:
+          type: integer
+        lane_index:
+          type: integer
+        label:
+          type: string
+        deployment_lineup:
+          type: string
+        participant_label:
+          type: string
+        observed_runs:
+          type: integer
+        overall_score:
+          type: number
+        correctness_score:
+          type: number
+        success_rate:
+          type: number
+        composite_agent_score:
+          type: number
+        mean_cost_usd:
+          type: number
+        total_cost_usd:
+          type: number
+
+    EvalSessionCostAggregate:
+      type: object
+      required: [n, total, mean, min, max]
+      properties:
+        n:
+          type: integer
+        total:
+          type: number
+        mean:
+          type: number
+        min:
+          type: number
+        max:
+          type: number
 
     EvalSessionTaskSuccess:
       type: object


### PR DESCRIPTION
## Summary
- Add cost-aware race series aggregation with per-participant `cost_usd` and top-level `series_report` rows for score, correctness, success, composite rank, and cost.
- Backfill report costs from persisted run-agent scorecard metric details when older run scorecard summaries do not yet include `total_cost_usd`.
- Add `agentclash run series report <eval-session-id>` for human and structured report output, plus OpenAPI schema coverage.

## Validation
- `cd backend && go test ./...`
- `cd backend && go vet ./...`
- `cd cli && go build ./... && go vet ./... && go test -short -race -count=1 ./...`
- `cd cli && go run github.com/goreleaser/goreleaser/v2@latest check`

Fixes #712
Refs #693, #732
