### PR TITLE
fix: preserve Gemini thought signatures

### DIFF
--- a/backend/internal/engine/executor_util.go
+++ b/backend/internal/engine/executor_util.go
@@ -39,9 +39,10 @@ func cloneToolCalls(toolCalls []provider.ToolCall) []provider.ToolCall {
 	cloned := make([]provider.ToolCall, 0, len(toolCalls))
 	for _, toolCall := range toolCalls {
 		cloned = append(cloned, provider.ToolCall{
-			ID:        toolCall.ID,
-			Name:      toolCall.Name,
-			Arguments: cloneJSON(toolCall.Arguments),
+			ID:               toolCall.ID,
+			Name:             toolCall.Name,
+			Arguments:        cloneJSON(toolCall.Arguments),
+			ThoughtSignature: toolCall.ThoughtSignature,
 		})
 	}
 	return cloned

--- a/backend/internal/engine/native_executor_test.go
+++ b/backend/internal/engine/native_executor_test.go
@@ -36,9 +36,10 @@ func TestNativeExecutorHappyPathWritesFileThenSubmits(t *testing.T) {
 					FinishReason:    "tool_calls",
 					ToolCalls: []provider.ToolCall{
 						{
-							ID:        "call-write",
-							Name:      writeFileToolName,
-							Arguments: []byte(`{"path":"/workspace/result.txt","content":"done"}`),
+							ID:               "call-write",
+							Name:             writeFileToolName,
+							Arguments:        []byte(`{"path":"/workspace/result.txt","content":"done"}`),
+							ThoughtSignature: "sig-write",
 						},
 					},
 				},
@@ -54,6 +55,10 @@ func TestNativeExecutorHappyPathWritesFileThenSubmits(t *testing.T) {
 					}
 					if last.IsError {
 						t.Fatalf("tool result unexpectedly marked as error")
+					}
+					assistant := request.Messages[len(request.Messages)-2]
+					if len(assistant.ToolCalls) != 1 || assistant.ToolCalls[0].ThoughtSignature != "sig-write" {
+						t.Fatalf("assistant tool calls = %#v, want preserved thought signature", assistant.ToolCalls)
 					}
 				},
 				response: provider.Response{

--- a/backend/internal/provider/fake.go
+++ b/backend/internal/provider/fake.go
@@ -42,9 +42,10 @@ func cloneResponse(response Response) Response {
 	cloned.ToolCalls = make([]ToolCall, 0, len(response.ToolCalls))
 	for _, toolCall := range response.ToolCalls {
 		cloned.ToolCalls = append(cloned.ToolCalls, ToolCall{
-			ID:        toolCall.ID,
-			Name:      toolCall.Name,
-			Arguments: cloneJSON(toolCall.Arguments),
+			ID:               toolCall.ID,
+			Name:             toolCall.Name,
+			Arguments:        cloneJSON(toolCall.Arguments),
+			ThoughtSignature: toolCall.ThoughtSignature,
 		})
 	}
 	cloned.RawResponse = cloneJSON(response.RawResponse)
@@ -86,9 +87,10 @@ func cloneMessage(message Message) Message {
 	cloned.ToolCalls = make([]ToolCall, 0, len(message.ToolCalls))
 	for _, toolCall := range message.ToolCalls {
 		cloned.ToolCalls = append(cloned.ToolCalls, ToolCall{
-			ID:        toolCall.ID,
-			Name:      toolCall.Name,
-			Arguments: cloneJSON(toolCall.Arguments),
+			ID:               toolCall.ID,
+			Name:             toolCall.Name,
+			Arguments:        cloneJSON(toolCall.Arguments),
+			ThoughtSignature: toolCall.ThoughtSignature,
 		})
 	}
 	return cloned

--- a/backend/internal/provider/gemini.go
+++ b/backend/internal/provider/gemini.go
@@ -154,6 +154,7 @@ func normalizeGeminiRequestMessage(providerKey string, msg Message) (geminiConte
 					return geminiContent{}, NewFailure(providerKey, FailureCodeInvalidRequest, fmt.Sprintf("tool call %q arguments must be valid JSON", tc.Name), false, nil)
 				}
 				parts = append(parts, geminiPart{
+					ThoughtSignature: tc.ThoughtSignature,
 					FunctionCall: &geminiFunctionCall{
 						Name: tc.Name,
 						Args: append(json.RawMessage(nil), args...),
@@ -309,9 +310,11 @@ type geminiContent struct {
 }
 
 type geminiPart struct {
-	Text             string                  `json:"text,omitempty"`
-	FunctionCall     *geminiFunctionCall     `json:"functionCall,omitempty"`
-	FunctionResponse *geminiFunctionResponse `json:"functionResponse,omitempty"`
+	Text                  string                  `json:"text,omitempty"`
+	ThoughtSignature      string                  `json:"thoughtSignature,omitempty"`
+	SnakeThoughtSignature string                  `json:"thought_signature,omitempty"`
+	FunctionCall          *geminiFunctionCall     `json:"functionCall,omitempty"`
+	FunctionResponse      *geminiFunctionResponse `json:"functionResponse,omitempty"`
 }
 
 type geminiFunctionCall struct {
@@ -320,7 +323,7 @@ type geminiFunctionCall struct {
 }
 
 type geminiFunctionResponse struct {
-	Name     string               `json:"name"`
+	Name     string                `json:"name"`
 	Response geminiResponsePayload `json:"response"`
 }
 
@@ -343,10 +346,7 @@ type geminiFunctionDeclaration struct {
 type geminiStreamChunk struct {
 	Candidates []struct {
 		Content struct {
-			Parts []struct {
-				Text         string              `json:"text,omitempty"`
-				FunctionCall *geminiFunctionCall `json:"functionCall,omitempty"`
-			} `json:"parts"`
+			Parts []geminiPart `json:"parts"`
 		} `json:"content"`
 		FinishReason string `json:"finishReason,omitempty"`
 	} `json:"candidates"`
@@ -462,6 +462,7 @@ func processGeminiStreamEvent(providerKey string, model string, raw []byte, accu
 						IDFragment:        fmt.Sprintf("gemini-call-%d", *toolCallIndex),
 						NameFragment:      part.FunctionCall.Name,
 						ArgumentsFragment: string(args),
+						ThoughtSignature:  part.geminiThoughtSignature(),
 					},
 				}); err != nil {
 					return err
@@ -508,6 +509,13 @@ func processGeminiStreamEvent(providerKey string, model string, raw []byte, accu
 	}
 
 	return nil
+}
+
+func (p geminiPart) geminiThoughtSignature() string {
+	if p.ThoughtSignature != "" {
+		return p.ThoughtSignature
+	}
+	return p.SnakeThoughtSignature
 }
 
 func emitGeminiDelta(accumulator *StreamAccumulator, onDelta func(StreamDelta) error, delta StreamDelta) error {

--- a/backend/internal/provider/gemini_test.go
+++ b/backend/internal/provider/gemini_test.go
@@ -118,6 +118,78 @@ func TestGeminiClientStreamModelEmitsToolCallDeltas(t *testing.T) {
 	}
 }
 
+func TestGeminiClientPreservesThoughtSignatureOnFunctionCallParts(t *testing.T) {
+	const thoughtSignature = "sig-gemini-step-1"
+	requestCount := 0
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			requestCount++
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
+			if requestCount == 2 {
+				var payload geminiRequest
+				if err := json.Unmarshal(body, &payload); err != nil {
+					t.Fatalf("unmarshal second request body: %v", err)
+				}
+				if len(payload.Contents) < 2 {
+					t.Fatalf("contents = %d, want assistant function call history", len(payload.Contents))
+				}
+				parts := payload.Contents[1].Parts
+				if len(parts) != 1 || parts[0].FunctionCall == nil {
+					t.Fatalf("assistant history parts = %#v, want one function call", parts)
+				}
+				if parts[0].ThoughtSignature != thoughtSignature {
+					t.Fatalf("thoughtSignature = %q, want %q", parts[0].ThoughtSignature, thoughtSignature)
+				}
+			}
+			return sseResponse(http.StatusOK, strings.Join([]string{
+				`data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"read_file","args":{"path":"/workspace/app.go"}},"thoughtSignature":"` + thoughtSignature + `"}]},"finishReason":"STOP"}],"modelVersion":"gemini-3-pro-preview","usageMetadata":{"promptTokenCount":21,"candidatesTokenCount":9,"totalTokenCount":30}}`,
+				``,
+			}, "\n")), nil
+		}),
+	}
+
+	client := NewGeminiClient(httpClient, "https://example.com", staticCredentialResolver{value: "test-key"})
+
+	firstResponse, err := client.InvokeModel(context.Background(), Request{
+		ProviderKey:         "gemini",
+		CredentialReference: "env://GEMINI_API_KEY",
+		Model:               "gemini-3-pro-preview",
+		Messages:            []Message{{Role: "user", Content: "inspect workspace"}},
+		Tools: []ToolDefinition{
+			{Name: "read_file", Parameters: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("first InvokeModel returned error: %v", err)
+	}
+	if len(firstResponse.ToolCalls) != 1 {
+		t.Fatalf("tool calls = %d, want 1", len(firstResponse.ToolCalls))
+	}
+	if firstResponse.ToolCalls[0].ThoughtSignature != thoughtSignature {
+		t.Fatalf("captured thought signature = %q, want %q", firstResponse.ToolCalls[0].ThoughtSignature, thoughtSignature)
+	}
+
+	_, err = client.InvokeModel(context.Background(), Request{
+		ProviderKey:         "gemini",
+		CredentialReference: "env://GEMINI_API_KEY",
+		Model:               "gemini-3-pro-preview",
+		Messages: []Message{
+			{Role: "user", Content: "inspect workspace"},
+			{Role: "assistant", ToolCalls: firstResponse.ToolCalls},
+			{Role: "tool", ToolCallID: "read_file", Content: "package main"},
+		},
+		Tools: []ToolDefinition{
+			{Name: "read_file", Parameters: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("second InvokeModel returned error: %v", err)
+	}
+}
+
 func TestGeminiClientNormalizesRateLimitFailure(t *testing.T) {
 	httpClient := &http.Client{
 		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {

--- a/backend/internal/provider/gemini_test.go
+++ b/backend/internal/provider/gemini_test.go
@@ -119,74 +119,84 @@ func TestGeminiClientStreamModelEmitsToolCallDeltas(t *testing.T) {
 }
 
 func TestGeminiClientPreservesThoughtSignatureOnFunctionCallParts(t *testing.T) {
-	const thoughtSignature = "sig-gemini-step-1"
-	requestCount := 0
-	httpClient := &http.Client{
-		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
-			requestCount++
-			body, err := io.ReadAll(r.Body)
+	for _, tc := range []struct {
+		name      string
+		fieldName string
+	}{
+		{name: "camelCase", fieldName: "thoughtSignature"},
+		{name: "snake_case", fieldName: "thought_signature"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const thoughtSignature = "sig-gemini-step-1"
+			requestCount := 0
+			httpClient := &http.Client{
+				Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+					requestCount++
+					body, err := io.ReadAll(r.Body)
+					if err != nil {
+						t.Fatalf("read request body: %v", err)
+					}
+					if requestCount == 2 {
+						var payload geminiRequest
+						if err := json.Unmarshal(body, &payload); err != nil {
+							t.Fatalf("unmarshal second request body: %v", err)
+						}
+						if len(payload.Contents) < 2 {
+							t.Fatalf("contents = %d, want assistant function call history", len(payload.Contents))
+						}
+						parts := payload.Contents[1].Parts
+						if len(parts) != 1 || parts[0].FunctionCall == nil {
+							t.Fatalf("assistant history parts = %#v, want one function call", parts)
+						}
+						if parts[0].ThoughtSignature != thoughtSignature {
+							t.Fatalf("thoughtSignature = %q, want %q", parts[0].ThoughtSignature, thoughtSignature)
+						}
+					}
+					return sseResponse(http.StatusOK, strings.Join([]string{
+						`data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"read_file","args":{"path":"/workspace/app.go"}},"` + tc.fieldName + `":"` + thoughtSignature + `"}]},"finishReason":"STOP"}],"modelVersion":"gemini-3-pro-preview","usageMetadata":{"promptTokenCount":21,"candidatesTokenCount":9,"totalTokenCount":30}}`,
+						``,
+					}, "\n")), nil
+				}),
+			}
+
+			client := NewGeminiClient(httpClient, "https://example.com", staticCredentialResolver{value: "test-key"})
+
+			firstResponse, err := client.InvokeModel(context.Background(), Request{
+				ProviderKey:         "gemini",
+				CredentialReference: "env://GEMINI_API_KEY",
+				Model:               "gemini-3-pro-preview",
+				Messages:            []Message{{Role: "user", Content: "inspect workspace"}},
+				Tools: []ToolDefinition{
+					{Name: "read_file", Parameters: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`)},
+				},
+			})
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Fatalf("first InvokeModel returned error: %v", err)
 			}
-			if requestCount == 2 {
-				var payload geminiRequest
-				if err := json.Unmarshal(body, &payload); err != nil {
-					t.Fatalf("unmarshal second request body: %v", err)
-				}
-				if len(payload.Contents) < 2 {
-					t.Fatalf("contents = %d, want assistant function call history", len(payload.Contents))
-				}
-				parts := payload.Contents[1].Parts
-				if len(parts) != 1 || parts[0].FunctionCall == nil {
-					t.Fatalf("assistant history parts = %#v, want one function call", parts)
-				}
-				if parts[0].ThoughtSignature != thoughtSignature {
-					t.Fatalf("thoughtSignature = %q, want %q", parts[0].ThoughtSignature, thoughtSignature)
-				}
+			if len(firstResponse.ToolCalls) != 1 {
+				t.Fatalf("tool calls = %d, want 1", len(firstResponse.ToolCalls))
 			}
-			return sseResponse(http.StatusOK, strings.Join([]string{
-				`data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"read_file","args":{"path":"/workspace/app.go"}},"thoughtSignature":"` + thoughtSignature + `"}]},"finishReason":"STOP"}],"modelVersion":"gemini-3-pro-preview","usageMetadata":{"promptTokenCount":21,"candidatesTokenCount":9,"totalTokenCount":30}}`,
-				``,
-			}, "\n")), nil
-		}),
-	}
+			if firstResponse.ToolCalls[0].ThoughtSignature != thoughtSignature {
+				t.Fatalf("captured thought signature = %q, want %q", firstResponse.ToolCalls[0].ThoughtSignature, thoughtSignature)
+			}
 
-	client := NewGeminiClient(httpClient, "https://example.com", staticCredentialResolver{value: "test-key"})
-
-	firstResponse, err := client.InvokeModel(context.Background(), Request{
-		ProviderKey:         "gemini",
-		CredentialReference: "env://GEMINI_API_KEY",
-		Model:               "gemini-3-pro-preview",
-		Messages:            []Message{{Role: "user", Content: "inspect workspace"}},
-		Tools: []ToolDefinition{
-			{Name: "read_file", Parameters: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`)},
-		},
-	})
-	if err != nil {
-		t.Fatalf("first InvokeModel returned error: %v", err)
-	}
-	if len(firstResponse.ToolCalls) != 1 {
-		t.Fatalf("tool calls = %d, want 1", len(firstResponse.ToolCalls))
-	}
-	if firstResponse.ToolCalls[0].ThoughtSignature != thoughtSignature {
-		t.Fatalf("captured thought signature = %q, want %q", firstResponse.ToolCalls[0].ThoughtSignature, thoughtSignature)
-	}
-
-	_, err = client.InvokeModel(context.Background(), Request{
-		ProviderKey:         "gemini",
-		CredentialReference: "env://GEMINI_API_KEY",
-		Model:               "gemini-3-pro-preview",
-		Messages: []Message{
-			{Role: "user", Content: "inspect workspace"},
-			{Role: "assistant", ToolCalls: firstResponse.ToolCalls},
-			{Role: "tool", ToolCallID: "read_file", Content: "package main"},
-		},
-		Tools: []ToolDefinition{
-			{Name: "read_file", Parameters: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`)},
-		},
-	})
-	if err != nil {
-		t.Fatalf("second InvokeModel returned error: %v", err)
+			_, err = client.InvokeModel(context.Background(), Request{
+				ProviderKey:         "gemini",
+				CredentialReference: "env://GEMINI_API_KEY",
+				Model:               "gemini-3-pro-preview",
+				Messages: []Message{
+					{Role: "user", Content: "inspect workspace"},
+					{Role: "assistant", ToolCalls: firstResponse.ToolCalls},
+					{Role: "tool", ToolCallID: "read_file", Content: "package main"},
+				},
+				Tools: []ToolDefinition{
+					{Name: "read_file", Parameters: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`)},
+				},
+			})
+			if err != nil {
+				t.Fatalf("second InvokeModel returned error: %v", err)
+			}
+		})
 	}
 }
 

--- a/backend/internal/provider/provider.go
+++ b/backend/internal/provider/provider.go
@@ -45,9 +45,10 @@ type ToolDefinition struct {
 }
 
 type ToolCall struct {
-	ID        string          `json:"id"`
-	Name      string          `json:"name"`
-	Arguments json.RawMessage `json:"arguments,omitempty"`
+	ID               string          `json:"id"`
+	Name             string          `json:"name"`
+	Arguments        json.RawMessage `json:"arguments,omitempty"`
+	ThoughtSignature string          `json:"thought_signature,omitempty"`
 }
 
 type ToolResult struct {

--- a/backend/internal/provider/streaming.go
+++ b/backend/internal/provider/streaming.go
@@ -43,6 +43,7 @@ type ToolCallFragment struct {
 	IDFragment        string
 	NameFragment      string
 	ArgumentsFragment string
+	ThoughtSignature  string
 }
 
 type StreamTerminal struct {
@@ -68,9 +69,10 @@ type StreamAccumulator struct {
 }
 
 type toolCallAccumulator struct {
-	id        string
-	name      string
-	arguments string
+	id               string
+	name             string
+	arguments        string
+	thoughtSignature string
 }
 
 func NewStreamAccumulator(providerKey string, startedAt time.Time) *StreamAccumulator {
@@ -107,6 +109,9 @@ func (a *StreamAccumulator) Consume(delta StreamDelta) error {
 		target.id += fragment.IDFragment
 		target.name += fragment.NameFragment
 		target.arguments += fragment.ArgumentsFragment
+		if fragment.ThoughtSignature != "" {
+			target.thoughtSignature = fragment.ThoughtSignature
+		}
 	case StreamDeltaKindTerminal:
 		a.streamed = true
 		if delta.Terminal.ProviderModelID != "" {
@@ -165,9 +170,10 @@ func (a *StreamAccumulator) Finalize(completedAt time.Time) (Response, error) {
 		}
 
 		toolCalls = append(toolCalls, ToolCall{
-			ID:        accumulated.id,
-			Name:      accumulated.name,
-			Arguments: cloneJSON(rawArguments),
+			ID:               accumulated.id,
+			Name:             accumulated.name,
+			Arguments:        cloneJSON(rawArguments),
+			ThoughtSignature: accumulated.thoughtSignature,
 		})
 	}
 


### PR DESCRIPTION
## Summary
- capture Gemini `thoughtSignature` from streamed function-call parts
- preserve the signature through provider/tool-call clone paths and native executor assistant history
- re-emit the signature on Gemini assistant `functionCall` parts in follow-up requests

## Validation
- `cd backend && go test ./internal/provider ./internal/engine`
- `cd backend && go test ./...`
- `cd backend && go vet ./...`
- subagent PR-blocking review: no findings

Fixes #697
Fixes #666
