### PR TITLE
feat: filter streamed run events

### DIFF
--- a/cli/cmd/ci_run.go
+++ b/cli/cmd/ci_run.go
@@ -241,7 +241,7 @@ func executeCIRun(cmd *cobra.Command, rc *RunContext) (ciRunResult, error) {
 
 	if follow && !rc.Output.IsStructured() {
 		fmt.Fprintln(os.Stderr)
-		if err := streamRunEvents(cmd, rc, result.Candidate.RunID); err != nil {
+		if err := streamRunEvents(cmd, rc, result.Candidate.RunID, nil); err != nil {
 			result.ExitCode = ciRunExitAPI
 			result.Errors = append(result.Errors, err.Error())
 			return finishWithReports(err, run, nil, nil, nil, nil)

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -46,7 +46,7 @@ func init() {
 	runCreateCmd.Flags().Int("race-context-cadence", 0, "Override race-context cadence; minimum steps between standings injections, [1, 10]. 0 uses the backend default.")
 	runCreateCmd.Flags().Int("max-iter", 0, "Override max iterations for this run (1-1000). 0 uses the pack/runtime default.")
 	runCreateCmd.Flags().Int("seeds", 0, "Create a seeded eval session with N child runs, one per seed (1-100). 0 creates a single run.")
-	runEventsCmd.Flags().StringSlice("filter", nil, "Filter streamed events by event type pattern (exact or glob, e.g. 'model.*'; repeatable)")
+	runEventsCmd.Flags().StringSlice("filter", nil, "Filter streamed events by event type pattern (exact, comma-separated, or glob, e.g. 'model.*'; repeatable)")
 
 	runRankingCmd.Flags().String("sort-by", "", "Sort by: composite, correctness, reliability, latency, cost")
 	runFailuresCmd.Flags().String("agent", "", "Filter by run agent ID")
@@ -827,9 +827,6 @@ func runEventMatchesFilters(sseEvent string, data []byte, patterns []string) boo
 		}
 	}
 	for _, pattern := range patterns {
-		if pattern == eventType {
-			return true
-		}
 		if matched, err := path.Match(pattern, eventType); err == nil && matched {
 			return true
 		}

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -569,7 +569,11 @@ var runEventsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		rc := GetRunContext(cmd)
 		filters, _ := cmd.Flags().GetStringSlice("filter")
-		return streamRunEvents(cmd, rc, args[0], filters)
+		patterns, err := normalizeRunEventFilters(filters)
+		if err != nil {
+			return err
+		}
+		return streamRunEvents(cmd, rc, args[0], patterns)
 	},
 }
 
@@ -750,7 +754,7 @@ var runPromoteFailureCmd = &cobra.Command{
 	},
 }
 
-func streamRunEvents(cmd *cobra.Command, rc *RunContext, runID string, filters []string) error {
+func streamRunEvents(cmd *cobra.Command, rc *RunContext, runID string, patterns []string) error {
 	ch, err := rc.Client.StreamSSE(cmd.Context(), "/v1/runs/"+runID+"/events/stream", nil)
 	if err != nil {
 		return fmt.Errorf("connecting to event stream: %w", err)
@@ -761,7 +765,7 @@ func streamRunEvents(cmd *cobra.Command, rc *RunContext, runID string, filters [
 	}
 
 	for event := range ch {
-		if !runEventMatchesFilters(event.Event, event.Data, filters) {
+		if !runEventMatchesFilters(event.Event, event.Data, patterns) {
 			continue
 		}
 		switch {
@@ -811,8 +815,7 @@ func streamRunEvents(cmd *cobra.Command, rc *RunContext, runID string, filters [
 	return nil
 }
 
-func runEventMatchesFilters(sseEvent string, data []byte, filters []string) bool {
-	patterns := normalizeRunEventFilters(filters)
+func runEventMatchesFilters(sseEvent string, data []byte, patterns []string) bool {
 	if len(patterns) == 0 {
 		return true
 	}
@@ -834,17 +837,21 @@ func runEventMatchesFilters(sseEvent string, data []byte, filters []string) bool
 	return false
 }
 
-func normalizeRunEventFilters(filters []string) []string {
+func normalizeRunEventFilters(filters []string) ([]string, error) {
 	var patterns []string
 	for _, filter := range filters {
 		for _, part := range strings.Split(filter, ",") {
 			part = strings.TrimSpace(part)
-			if part != "" {
-				patterns = append(patterns, part)
+			if part == "" {
+				continue
 			}
+			if _, err := path.Match(part, ""); err != nil {
+				return nil, fmt.Errorf("invalid event filter pattern %q: %w", part, err)
+			}
+			patterns = append(patterns, part)
 		}
 	}
-	return patterns
+	return patterns, nil
 }
 
 func eventTypeFromPayload(payload map[string]any) string {

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -46,7 +46,7 @@ func init() {
 	runCreateCmd.Flags().Int("race-context-cadence", 0, "Override race-context cadence; minimum steps between standings injections, [1, 10]. 0 uses the backend default.")
 	runCreateCmd.Flags().Int("max-iter", 0, "Override max iterations for this run (1-1000). 0 uses the pack/runtime default.")
 	runCreateCmd.Flags().Int("seeds", 0, "Create a seeded eval session with N child runs, one per seed (1-100). 0 creates a single run.")
-	runEventsCmd.Flags().StringSlice("filter", nil, "Filter streamed events by event type pattern (exact, comma-separated, or glob, e.g. 'model.*'; repeatable)")
+	runEventsCmd.Flags().StringSlice("filter", nil, "Filter streamed events by event type pattern (exact, comma-separated, or glob; '*' matches any non-slash chars, so 'model.*' matches 'model.call.started'; repeatable)")
 
 	runRankingCmd.Flags().String("sort-by", "", "Sort by: composite, correctness, reliability, latency, cost")
 	runFailuresCmd.Flags().String("agent", "", "Filter by run agent ID")

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/yaml.v3"
 	"net/url"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -45,6 +46,7 @@ func init() {
 	runCreateCmd.Flags().Int("race-context-cadence", 0, "Override race-context cadence; minimum steps between standings injections, [1, 10]. 0 uses the backend default.")
 	runCreateCmd.Flags().Int("max-iter", 0, "Override max iterations for this run (1-1000). 0 uses the pack/runtime default.")
 	runCreateCmd.Flags().Int("seeds", 0, "Create a seeded eval session with N child runs, one per seed (1-100). 0 creates a single run.")
+	runEventsCmd.Flags().StringSlice("filter", nil, "Filter streamed events by event type pattern (exact or glob, e.g. 'model.*'; repeatable)")
 
 	runRankingCmd.Flags().String("sort-by", "", "Sort by: composite, correctness, reliability, latency, cost")
 	runFailuresCmd.Flags().String("agent", "", "Filter by run agent ID")
@@ -566,7 +568,8 @@ var runEventsCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		rc := GetRunContext(cmd)
-		return streamRunEvents(cmd, rc, args[0])
+		filters, _ := cmd.Flags().GetStringSlice("filter")
+		return streamRunEvents(cmd, rc, args[0], filters)
 	},
 }
 
@@ -747,7 +750,7 @@ var runPromoteFailureCmd = &cobra.Command{
 	},
 }
 
-func streamRunEvents(cmd *cobra.Command, rc *RunContext, runID string) error {
+func streamRunEvents(cmd *cobra.Command, rc *RunContext, runID string, filters []string) error {
 	ch, err := rc.Client.StreamSSE(cmd.Context(), "/v1/runs/"+runID+"/events/stream", nil)
 	if err != nil {
 		return fmt.Errorf("connecting to event stream: %w", err)
@@ -758,6 +761,9 @@ func streamRunEvents(cmd *cobra.Command, rc *RunContext, runID string) error {
 	}
 
 	for event := range ch {
+		if !runEventMatchesFilters(event.Event, event.Data, filters) {
+			continue
+		}
 		switch {
 		case rc.Output.IsYAML():
 			// Emit a YAML document per event, separated by `---`, which is a
@@ -787,7 +793,7 @@ func streamRunEvents(cmd *cobra.Command, rc *RunContext, runID string) error {
 			var parsed map[string]any
 			summary := string(event.Data)
 			if json.Unmarshal(event.Data, &parsed) == nil {
-				if et, ok := parsed["EventType"].(string); ok {
+				if et := eventTypeFromPayload(parsed); et != "" {
 					summary = et
 				}
 			}
@@ -803,6 +809,51 @@ func streamRunEvents(cmd *cobra.Command, rc *RunContext, runID string) error {
 		fmt.Fprintf(os.Stderr, "%s Stream ended\n", output.Faint("▸"))
 	}
 	return nil
+}
+
+func runEventMatchesFilters(sseEvent string, data []byte, filters []string) bool {
+	patterns := normalizeRunEventFilters(filters)
+	if len(patterns) == 0 {
+		return true
+	}
+	eventType := sseEvent
+	var parsed map[string]any
+	if json.Unmarshal(data, &parsed) == nil {
+		if extracted := eventTypeFromPayload(parsed); extracted != "" {
+			eventType = extracted
+		}
+	}
+	for _, pattern := range patterns {
+		if pattern == eventType {
+			return true
+		}
+		if matched, err := path.Match(pattern, eventType); err == nil && matched {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeRunEventFilters(filters []string) []string {
+	var patterns []string
+	for _, filter := range filters {
+		for _, part := range strings.Split(filter, ",") {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				patterns = append(patterns, part)
+			}
+		}
+	}
+	return patterns
+}
+
+func eventTypeFromPayload(payload map[string]any) string {
+	for _, key := range []string{"event_type", "EventType"} {
+		if eventType, ok := payload[key].(string); ok && eventType != "" {
+			return eventType
+		}
+	}
+	return ""
 }
 
 func fmtScore(v any) string {

--- a/cli/cmd/run_create_helpers.go
+++ b/cli/cmd/run_create_helpers.go
@@ -348,7 +348,7 @@ func presentCreatedRun(cmd *cobra.Command, rc *RunContext, run map[string]any, f
 		if err := printStructuredRunCreated(rc, run); err != nil {
 			return err
 		}
-		return streamRunEvents(cmd, rc, str(run["id"]))
+		return streamRunEvents(cmd, rc, str(run["id"]), nil)
 	}
 
 	runID := str(run["id"])
@@ -357,7 +357,7 @@ func presentCreatedRun(cmd *cobra.Command, rc *RunContext, run map[string]any, f
 
 	if follow {
 		fmt.Fprintln(os.Stderr)
-		if err := streamRunEvents(cmd, rc, runID); err != nil {
+		if err := streamRunEvents(cmd, rc, runID, nil); err != nil {
 			return err
 		}
 		if afterFollow != nil {

--- a/cli/cmd/run_events_test.go
+++ b/cli/cmd/run_events_test.go
@@ -193,6 +193,37 @@ func TestRunEventsFilterGlobPattern(t *testing.T) {
 	}
 }
 
+func TestRunEventsFilterFallsBackToSSEEventName(t *testing.T) {
+	sseBody := "event: model.delta\n" +
+		"data: {\"delta\":\"hello\"}\n" +
+		"\n" +
+		"event: tool.result\n" +
+		"data: {\"result\":\"ok\"}\n" +
+		"\n"
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/runs/run-x/events/stream": sseHandler([]string{sseBody}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"run", "events", "run-x", "--json", "--filter", "model.*",
+	}, srv.URL); err != nil {
+		t.Fatalf("run events --filter SSE event name: %v", err)
+	}
+	out := stdout.finish()
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 filtered event, got %d\n---\n%s", len(lines), out)
+	}
+	if !strings.Contains(lines[0], `"delta":"hello"`) {
+		t.Fatalf("filtered output = %q, want model.delta payload", lines[0])
+	}
+}
+
 func TestRunEventsFilterRejectsInvalidGlobPattern(t *testing.T) {
 	called := false
 	srv := fakeAPI(t, map[string]http.HandlerFunc{

--- a/cli/cmd/run_events_test.go
+++ b/cli/cmd/run_events_test.go
@@ -115,6 +115,84 @@ func TestRunEventsEmitsNDJSONForJSON(t *testing.T) {
 	}
 }
 
+func TestRunEventsFilterExactEventType(t *testing.T) {
+	sseBody := "event: step\n" +
+		"data: {\"event_type\":\"model.call.started\"}\n" +
+		"\n" +
+		"event: step\n" +
+		"data: {\"event_type\":\"model.call.completed\"}\n" +
+		"\n" +
+		"event: step\n" +
+		"data: {\"event_type\":\"tool.call.completed\"}\n" +
+		"\n"
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/runs/run-x/events/stream": sseHandler([]string{sseBody}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"run", "events", "run-x", "--json", "--filter", "model.call.completed",
+	}, srv.URL); err != nil {
+		t.Fatalf("run events --filter exact: %v", err)
+	}
+	out := stdout.finish()
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 filtered event, got %d\n---\n%s", len(lines), out)
+	}
+	var event map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &event); err != nil {
+		t.Fatalf("filtered line is not JSON: %v\n%s", err, lines[0])
+	}
+	if event["event_type"] != "model.call.completed" {
+		t.Fatalf("event_type = %v, want model.call.completed", event["event_type"])
+	}
+}
+
+func TestRunEventsFilterGlobPattern(t *testing.T) {
+	sseBody := "event: step\n" +
+		"data: {\"EventType\":\"model.call.started\"}\n" +
+		"\n" +
+		"event: step\n" +
+		"data: {\"EventType\":\"model.output.delta\"}\n" +
+		"\n" +
+		"event: step\n" +
+		"data: {\"EventType\":\"tool.call.completed\"}\n" +
+		"\n"
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/runs/run-x/events/stream": sseHandler([]string{sseBody}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"run", "events", "run-x", "--json", "--filter", "model.*",
+	}, srv.URL); err != nil {
+		t.Fatalf("run events --filter glob: %v", err)
+	}
+	out := stdout.finish()
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 filtered events, got %d\n---\n%s", len(lines), out)
+	}
+	for i, line := range lines {
+		var event map[string]any
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("filtered line %d is not JSON: %v\n%s", i, err, line)
+		}
+		if !strings.HasPrefix(event["EventType"].(string), "model.") {
+			t.Fatalf("line %d EventType = %v, want model.*", i, event["EventType"])
+		}
+	}
+}
+
 func TestRunEventsExportPrintsJSONL(t *testing.T) {
 	jsonl := strings.Join([]string{
 		`{"event_id":"persisted:agent-1:1","sequence_number":1}`,

--- a/cli/cmd/run_events_test.go
+++ b/cli/cmd/run_events_test.go
@@ -193,6 +193,31 @@ func TestRunEventsFilterGlobPattern(t *testing.T) {
 	}
 }
 
+func TestRunEventsFilterRejectsInvalidGlobPattern(t *testing.T) {
+	called := false
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/runs/run-x/events/stream": func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusOK)
+		},
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{
+		"run", "events", "run-x", "--filter", "model.[",
+	}, srv.URL)
+	if err == nil {
+		t.Fatal("run events --filter invalid glob error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "invalid event filter pattern") {
+		t.Fatalf("error = %v, want invalid event filter pattern", err)
+	}
+	if called {
+		t.Fatal("stream endpoint should not be called when filter pattern is invalid")
+	}
+}
+
 func TestRunEventsExportPrintsJSONL(t *testing.T) {
 	jsonl := strings.Join([]string{
 		`{"event_id":"persisted:agent-1:1","sequence_number":1}`,


### PR DESCRIPTION
## Summary
- Adds `agentclash run events --filter` for local event-type filtering on the live SSE stream.
- Supports exact event type matches and simple glob patterns such as `'model.*'`, including comma-separated or repeated filters.
- Preserves existing JSON NDJSON, YAML document-stream, and human output shapes; follow callers remain unfiltered.

Closes #703
Part of #693

## Validation
- `cd cli && go test ./cmd -run 'TestRunEvents(EmitsNDJSONForJSON|FilterExactEventType|FilterGlobPattern|FilterRejectsInvalidGlobPattern|EmitsYAMLDocumentStream)' -count=1`
- `cd cli && go build ./... && go vet ./... && go test -short -race -count=1 ./...`
- `cd cli && AGENTCLASH_API_URL=https://api.agentclash.dev go run . run events --help`

## Review
- Subagent review 1: no blockers/majors; P3 quoted-glob help text fixed.
- Subagent review 2: no blockers/majors; P3 invalid glob validation fixed.
