### PR TITLE
feat: export markdown run transcripts

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -23,6 +23,7 @@ func init() {
 	runCmd.AddCommand(runRankingCmd)
 	runCmd.AddCommand(runAgentsCmd)
 	runCmd.AddCommand(runEventsCmd)
+	runCmd.AddCommand(runTranscriptCmd)
 	runEventsCmd.AddCommand(runEventsExportCmd)
 	runCmd.AddCommand(runScorecardCmd)
 	runCmd.AddCommand(runFailuresCmd)

--- a/cli/cmd/run_transcript.go
+++ b/cli/cmd/run_transcript.go
@@ -63,6 +63,7 @@ func buildRunMarkdownTranscript(cmd *cobra.Command, rc *RunContext, runID string
 	if err != nil {
 		return "", err
 	}
+	sortTranscriptEvents(events)
 	return renderRunMarkdownTranscript(runID, agents, events), nil
 }
 
@@ -119,6 +120,23 @@ func fetchTranscriptEvents(cmd *cobra.Command, rc *RunContext, runID string) ([]
 		events = append(events, event)
 	}
 	return events, nil
+}
+
+func sortTranscriptEvents(events []transcriptEvent) {
+	sort.SliceStable(events, func(i, j int) bool {
+		left := events[i]
+		right := events[j]
+		if left.SequenceNumber != right.SequenceNumber {
+			return left.SequenceNumber < right.SequenceNumber
+		}
+		if left.OccurredAt != right.OccurredAt {
+			return left.OccurredAt < right.OccurredAt
+		}
+		if left.RunAgentID != right.RunAgentID {
+			return left.RunAgentID < right.RunAgentID
+		}
+		return left.EventID < right.EventID
+	})
 }
 
 func renderRunMarkdownTranscript(runID string, agents map[string]transcriptAgent, events []transcriptEvent) string {
@@ -387,6 +405,8 @@ func markdownInline(value string) string {
 		")", "\\)",
 		"|", "\\|",
 		"#", "\\#",
+		"<", "&lt;",
+		">", "&gt;",
 	)
 	return replacer.Replace(value)
 }

--- a/cli/cmd/run_transcript.go
+++ b/cli/cmd/run_transcript.go
@@ -1,0 +1,420 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/agentclash/agentclash/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var runTranscriptCmd = &cobra.Command{
+	Use:   "transcript <runId>",
+	Short: "Export a Markdown run transcript",
+	Long:  "Export a readable, secret-safe Markdown transcript from persisted run events.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		transcript, err := buildRunMarkdownTranscript(cmd, rc, args[0])
+		if err != nil {
+			return err
+		}
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(map[string]any{
+				"run_id":     args[0],
+				"format":     "markdown",
+				"transcript": transcript,
+			})
+		}
+		_, err = fmt.Fprint(rc.Output.Writer(), transcript)
+		return err
+	},
+}
+
+type transcriptAgent struct {
+	ID     string
+	Label  string
+	Status string
+}
+
+type transcriptEvent struct {
+	EventID        string         `json:"event_id"`
+	RunID          string         `json:"run_id"`
+	RunAgentID     string         `json:"run_agent_id"`
+	SequenceNumber int64          `json:"sequence_number"`
+	EventType      string         `json:"event_type"`
+	Source         string         `json:"source"`
+	OccurredAt     string         `json:"occurred_at"`
+	Payload        map[string]any `json:"payload"`
+	Summary        map[string]any `json:"summary"`
+}
+
+func buildRunMarkdownTranscript(cmd *cobra.Command, rc *RunContext, runID string) (string, error) {
+	agents, err := fetchTranscriptAgents(cmd, rc, runID)
+	if err != nil {
+		return "", err
+	}
+	events, err := fetchTranscriptEvents(cmd, rc, runID)
+	if err != nil {
+		return "", err
+	}
+	return renderRunMarkdownTranscript(runID, agents, events), nil
+}
+
+func fetchTranscriptAgents(cmd *cobra.Command, rc *RunContext, runID string) (map[string]transcriptAgent, error) {
+	resp, err := rc.Client.Get(cmd.Context(), "/v1/runs/"+runID+"/agents", nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return nil, apiErr
+	}
+
+	var result struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := resp.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+
+	agents := make(map[string]transcriptAgent, len(result.Items))
+	for _, item := range result.Items {
+		id := str(item["id"])
+		if id == "" {
+			continue
+		}
+		agents[id] = transcriptAgent{
+			ID:     id,
+			Label:  firstNonEmpty(mapString(item, "label"), mapString(item, "agent_deployment_name"), id),
+			Status: str(item["status"]),
+		}
+	}
+	return agents, nil
+}
+
+func fetchTranscriptEvents(cmd *cobra.Command, rc *RunContext, runID string) ([]transcriptEvent, error) {
+	resp, err := rc.Client.Get(cmd.Context(), "/v1/runs/"+runID+"/events/export", nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return nil, apiErr
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(resp.Body))
+	var events []transcriptEvent
+	for {
+		var event transcriptEvent
+		if err := decoder.Decode(&event); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("decode run event JSONL: %w", err)
+		}
+		events = append(events, event)
+	}
+	return events, nil
+}
+
+func renderRunMarkdownTranscript(runID string, agents map[string]transcriptAgent, events []transcriptEvent) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Run Transcript\n\n")
+	fmt.Fprintf(&b, "- Run ID: `%s`\n", markdownInline(runID))
+	fmt.Fprintf(&b, "- Events considered: %d\n", len(events))
+	fmt.Fprintf(&b, "- Raw payloads and tool arguments are intentionally omitted.\n\n")
+
+	writeTranscriptAgents(&b, agents)
+
+	b.WriteString("## Transcript\n\n")
+	wrote := false
+	for _, event := range events {
+		if writeTranscriptEvent(&b, event, agents) {
+			wrote = true
+		}
+	}
+	if !wrote {
+		b.WriteString("_No transcript-safe events found._\n")
+	}
+	return b.String()
+}
+
+func writeTranscriptAgents(b *strings.Builder, agents map[string]transcriptAgent) {
+	if len(agents) == 0 {
+		return
+	}
+	b.WriteString("## Agents\n\n")
+	ids := make([]string, 0, len(agents))
+	for id := range agents {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		agent := agents[id]
+		fmt.Fprintf(b, "- `%s`", markdownInline(id))
+		if agent.Label != "" && agent.Label != id {
+			fmt.Fprintf(b, " - %s", markdownInline(agent.Label))
+		}
+		if agent.Status != "" {
+			fmt.Fprintf(b, " (%s)", markdownInline(agent.Status))
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+}
+
+func writeTranscriptEvent(b *strings.Builder, event transcriptEvent, agents map[string]transcriptAgent) bool {
+	title, details, block := transcriptEventSummary(event)
+	if title == "" {
+		return false
+	}
+
+	agent := transcriptAgentLabel(event.RunAgentID, agents)
+	fmt.Fprintf(b, "### %s", markdownInline(title))
+	if event.OccurredAt != "" {
+		fmt.Fprintf(b, " - %s", markdownInline(event.OccurredAt))
+	}
+	b.WriteString("\n\n")
+	if agent != "" {
+		fmt.Fprintf(b, "- Agent: %s\n", markdownInline(agent))
+	}
+	if event.SequenceNumber > 0 {
+		fmt.Fprintf(b, "- Sequence: %d\n", event.SequenceNumber)
+	}
+	if len(details) > 0 {
+		for _, detail := range details {
+			fmt.Fprintf(b, "- %s\n", markdownInline(detail))
+		}
+	}
+	if block != "" {
+		b.WriteString("\n")
+		b.WriteString(markdownFence(block))
+	}
+	b.WriteString("\n")
+	return true
+}
+
+func transcriptEventSummary(event transcriptEvent) (string, []string, string) {
+	payload := event.Payload
+	switch event.EventType {
+	case "system.run.started":
+		return "Run started", nil, ""
+	case "system.run.completed":
+		return "Run completed", nil, ""
+	case "system.run.failed":
+		return "Run failed", transcriptFailureDetails(payload), ""
+	case "system.output.finalized":
+		return "Final output", nil, safePayloadString(payload, "final_output", "output_text", "output", "message")
+	case "model.call.started":
+		return "Model call started", compactDetails(
+			labelValue("Provider", safePayloadString(payload, "provider_key")),
+			labelValue("Model", firstNonEmpty(safePayloadString(payload, "provider_model_id"), safePayloadString(payload, "model"))),
+			labelValue("Messages", safePayloadString(payload, "message_count")),
+		), ""
+	case "model.call.completed":
+		return "Model call completed", compactDetails(
+			labelValue("Finish", safePayloadString(payload, "finish_reason")),
+			labelValue("Usage", transcriptUsage(payload)),
+			labelValue("Tool calls", transcriptToolCallNames(payload)),
+		), safePayloadString(payload, "output_text")
+	case "model.tool_calls.proposed":
+		return "Tool calls proposed", compactDetails(labelValue("Tool calls", transcriptToolCallNames(payload))), ""
+	case "tool.call.started":
+		return "Tool call started", compactDetails(labelValue("Tool", transcriptToolName(payload))), ""
+	case "tool.call.completed":
+		return "Tool call completed", compactDetails(labelValue("Tool", transcriptToolName(payload))), ""
+	case "tool.call.failed":
+		return "Tool call failed", compactDetails(
+			labelValue("Tool", transcriptToolName(payload)),
+			labelValue("Code", safePayloadString(payload, "error_code", "code", "failure_code")),
+		), ""
+	case "sandbox.command.started":
+		return "Sandbox command started", compactDetails(labelValue("Action", safePayloadString(payload, "sandbox_action", "action"))), ""
+	case "sandbox.command.completed":
+		return "Sandbox command completed", compactDetails(
+			labelValue("Action", safePayloadString(payload, "sandbox_action", "action")),
+			labelValue("Exit code", safePayloadString(payload, "exit_code")),
+		), ""
+	case "sandbox.command.failed":
+		return "Sandbox command failed", compactDetails(
+			labelValue("Action", safePayloadString(payload, "sandbox_action", "action")),
+			labelValue("Exit code", safePayloadString(payload, "exit_code")),
+			labelValue("Code", safePayloadString(payload, "error_code", "code", "failure_code")),
+		), ""
+	case "scoring.started":
+		return "Scoring started", nil, ""
+	case "scoring.completed":
+		return "Scoring completed", transcriptStatusDetails(payload), ""
+	case "scoring.failed":
+		return "Scoring failed", transcriptFailureDetails(payload), ""
+	default:
+		return "", nil, ""
+	}
+}
+
+func transcriptStatusDetails(payload map[string]any) []string {
+	return compactDetails(
+		labelValue("Status", safePayloadString(payload, "status")),
+	)
+}
+
+func transcriptFailureDetails(payload map[string]any) []string {
+	return compactDetails(
+		labelValue("Status", safePayloadString(payload, "status")),
+		labelValue("Class", safePayloadString(payload, "failure_class", "error_class")),
+		labelValue("Code", safePayloadString(payload, "failure_code", "error_code", "code")),
+	)
+}
+
+func transcriptUsage(payload map[string]any) string {
+	usage := mapObject(payload, "usage")
+	if usage == nil {
+		return ""
+	}
+	parts := compactDetails(
+		labelValue("input", safePayloadString(usage, "input_tokens", "prompt_tokens")),
+		labelValue("output", safePayloadString(usage, "output_tokens", "completion_tokens")),
+		labelValue("total", safePayloadString(usage, "total_tokens")),
+	)
+	return strings.Join(parts, ", ")
+}
+
+func transcriptToolCallNames(payload map[string]any) string {
+	calls := mapSlice(payload, "tool_calls")
+	names := make([]string, 0, len(calls))
+	for _, raw := range calls {
+		call, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		name := safePayloadString(call, "name", "tool_name")
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return strings.Join(names, ", ")
+}
+
+func transcriptToolName(payload map[string]any) string {
+	return firstNonEmpty(
+		safePayloadString(payload, "tool_name"),
+		safePayloadString(payload, "name"),
+		safePayloadString(mapObject(payload, "tool_call"), "name", "tool_name"),
+	)
+}
+
+func safePayloadString(payload map[string]any, keys ...string) string {
+	if payload == nil {
+		return ""
+	}
+	for _, key := range keys {
+		value, ok := payload[key]
+		if !ok || value == nil {
+			continue
+		}
+		switch typed := value.(type) {
+		case string:
+			return strings.TrimSpace(output.SanitizeControl(typed))
+		case float64:
+			if typed == float64(int64(typed)) {
+				return fmt.Sprintf("%d", int64(typed))
+			}
+			return fmt.Sprint(typed)
+		case bool:
+			return fmt.Sprint(typed)
+		default:
+			return ""
+		}
+	}
+	return ""
+}
+
+func transcriptAgentLabel(runAgentID string, agents map[string]transcriptAgent) string {
+	if runAgentID == "" {
+		return ""
+	}
+	agent, ok := agents[runAgentID]
+	if !ok {
+		return runAgentID
+	}
+	if agent.Label == "" || agent.Label == agent.ID {
+		return agent.ID
+	}
+	return fmt.Sprintf("%s (%s)", agent.Label, agent.ID)
+}
+
+func compactDetails(values ...string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func labelValue(label, value string) string {
+	if strings.TrimSpace(value) == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s: %s", label, value)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func markdownInline(value string) string {
+	value = output.SanitizeLine(value)
+	replacer := strings.NewReplacer(
+		"\\", "\\\\",
+		"`", "\\`",
+		"*", "\\*",
+		"_", "\\_",
+		"[", "\\[",
+		"]", "\\]",
+		"(", "\\(",
+		")", "\\)",
+		"|", "\\|",
+		"#", "\\#",
+	)
+	return replacer.Replace(value)
+}
+
+func markdownFence(value string) string {
+	value = strings.TrimRight(output.SanitizeControl(value), "\n")
+	if value == "" {
+		return ""
+	}
+	fence := strings.Repeat("`", maxBacktickRun(value)+1)
+	if len(fence) < 3 {
+		fence = "```"
+	}
+	return fmt.Sprintf("%s\n%s\n%s\n", fence, value, fence)
+}
+
+func maxBacktickRun(value string) int {
+	maxRun := 0
+	current := 0
+	for _, r := range value {
+		if r == '`' {
+			current++
+			if current > maxRun {
+				maxRun = current
+			}
+			continue
+		}
+		current = 0
+	}
+	return maxRun
+}

--- a/cli/cmd/run_transcript_test.go
+++ b/cli/cmd/run_transcript_test.go
@@ -1,0 +1,296 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestRunTranscriptExportsReadableMarkdown(t *testing.T) {
+	jsonl := transcriptJSONL(t,
+		map[string]any{
+			"event_id":        "event-1",
+			"run_id":          "run-1",
+			"run_agent_id":    "agent-1",
+			"sequence_number": 1,
+			"event_type":      "system.run.started",
+			"source":          "native_engine",
+			"occurred_at":     "2026-05-10T10:00:00Z",
+			"payload":         map[string]any{},
+		},
+		map[string]any{
+			"event_id":        "event-2",
+			"run_id":          "run-1",
+			"run_agent_id":    "agent-1",
+			"sequence_number": 2,
+			"event_type":      "model.call.started",
+			"source":          "native_engine",
+			"occurred_at":     "2026-05-10T10:00:01Z",
+			"payload": map[string]any{
+				"provider_key":  "openai",
+				"model":         "gpt-test",
+				"message_count": 2,
+			},
+		},
+		map[string]any{
+			"event_id":        "event-3",
+			"run_id":          "run-1",
+			"run_agent_id":    "agent-1",
+			"sequence_number": 3,
+			"event_type":      "model.call.completed",
+			"source":          "native_engine",
+			"occurred_at":     "2026-05-10T10:00:02Z",
+			"payload": map[string]any{
+				"finish_reason": "tool_calls",
+				"output_text":   "I will submit the answer.",
+				"usage": map[string]any{
+					"input_tokens":  100,
+					"output_tokens": 12,
+					"total_tokens":  112,
+				},
+				"tool_calls": []map[string]any{
+					{
+						"name":      "submit",
+						"arguments": map[string]any{"secret": "SHOULD_NOT_LEAK"},
+					},
+				},
+			},
+		},
+		map[string]any{
+			"event_id":        "event-4",
+			"run_id":          "run-1",
+			"run_agent_id":    "agent-1",
+			"sequence_number": 4,
+			"event_type":      "system.output.finalized",
+			"source":          "native_engine",
+			"occurred_at":     "2026-05-10T10:00:03Z",
+			"payload": map[string]any{
+				"final_output": "Hello, World!",
+			},
+		},
+	)
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/runs/run-1/agents": jsonHandler(http.StatusOK, map[string]any{
+			"items": []map[string]any{
+				{"id": "agent-1", "label": "candidate", "status": "completed"},
+			},
+		}),
+		"GET /v1/runs/run-1/events/export": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, jsonl)
+		},
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{"run", "transcript", "run-1"}, srv.URL); err != nil {
+		t.Fatalf("run transcript error: %v", err)
+	}
+	out := stdout.finish()
+
+	want := `# Run Transcript
+
+- Run ID: ` + "`run-1`" + `
+- Events considered: 4
+- Raw payloads and tool arguments are intentionally omitted.
+
+## Agents
+
+- ` + "`agent-1`" + ` - candidate (completed)
+
+## Transcript
+
+### Run started - 2026-05-10T10:00:00Z
+
+- Agent: candidate \(agent-1\)
+- Sequence: 1
+
+### Model call started - 2026-05-10T10:00:01Z
+
+- Agent: candidate \(agent-1\)
+- Sequence: 2
+- Provider: openai
+- Model: gpt-test
+- Messages: 2
+
+### Model call completed - 2026-05-10T10:00:02Z
+
+- Agent: candidate \(agent-1\)
+- Sequence: 3
+- Finish: tool\_calls
+- Usage: input: 100, output: 12, total: 112
+- Tool calls: submit
+
+` + "```" + `
+I will submit the answer.
+` + "```" + `
+
+### Final output - 2026-05-10T10:00:03Z
+
+- Agent: candidate \(agent-1\)
+- Sequence: 4
+
+` + "```" + `
+Hello, World!
+` + "```" + `
+
+`
+	if out != want {
+		t.Fatalf("transcript output mismatch\nwant:\n%s\n--- got:\n%s", want, out)
+	}
+	if strings.Contains(out, "SHOULD_NOT_LEAK") || strings.Contains(out, `"secret"`) {
+		t.Fatalf("transcript leaked raw tool arguments\n---\n%s", out)
+	}
+}
+
+func TestRunTranscriptOmitsUnsafeRawEvents(t *testing.T) {
+	jsonl := transcriptJSONL(t,
+		map[string]any{
+			"event_id":        "event-1",
+			"run_id":          "run-1",
+			"run_agent_id":    "agent-1",
+			"sequence_number": 1,
+			"event_type":      "model.output.delta",
+			"source":          "native_engine",
+			"occurred_at":     "2026-05-10T10:00:00Z",
+			"payload": map[string]any{
+				"provider_raw": "SHOULD_NOT_LEAK",
+			},
+		},
+	)
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/runs/run-1/agents": jsonHandler(http.StatusOK, map[string]any{
+			"items": []map[string]any{{"id": "agent-1", "label": "candidate"}},
+		}),
+		"GET /v1/runs/run-1/events/export": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, jsonl)
+		},
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{"run", "transcript", "run-1"}, srv.URL); err != nil {
+		t.Fatalf("run transcript error: %v", err)
+	}
+	out := stdout.finish()
+
+	if !strings.Contains(out, "_No transcript-safe events found._") {
+		t.Fatalf("transcript should report no safe events\n---\n%s", out)
+	}
+	if strings.Contains(out, "SHOULD_NOT_LEAK") {
+		t.Fatalf("transcript leaked raw payload\n---\n%s", out)
+	}
+}
+
+func TestRunTranscriptOmitsFreeFormFailurePayloads(t *testing.T) {
+	jsonl := transcriptJSONL(t,
+		map[string]any{
+			"event_id":        "event-1",
+			"run_id":          "run-1",
+			"run_agent_id":    "agent-1",
+			"sequence_number": 1,
+			"event_type":      "tool.call.failed",
+			"occurred_at":     "2026-05-10T10:00:00Z",
+			"payload": map[string]any{
+				"tool_name":  "submit",
+				"error_code": "tool_timeout",
+				"error":      "SHOULD_NOT_LEAK command text",
+				"message":    "SHOULD_NOT_LEAK stderr",
+				"reason":     "SHOULD_NOT_LEAK provider detail",
+			},
+		},
+	)
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/runs/run-1/agents": jsonHandler(http.StatusOK, map[string]any{
+			"items": []map[string]any{{"id": "agent-1", "label": "candidate"}},
+		}),
+		"GET /v1/runs/run-1/events/export": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, jsonl)
+		},
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{"run", "transcript", "run-1"}, srv.URL); err != nil {
+		t.Fatalf("run transcript error: %v", err)
+	}
+	out := stdout.finish()
+
+	if !strings.Contains(out, "- Tool: submit") || !strings.Contains(out, "- Code: tool\\_timeout") {
+		t.Fatalf("transcript should include curated failure fields\n---\n%s", out)
+	}
+	if strings.Contains(out, "SHOULD_NOT_LEAK") {
+		t.Fatalf("transcript leaked free-form failure payload\n---\n%s", out)
+	}
+}
+
+func TestRunTranscriptStructuredOutputWrapsMarkdown(t *testing.T) {
+	jsonl := transcriptJSONL(t,
+		map[string]any{
+			"event_id":        "event-1",
+			"run_id":          "run-1",
+			"run_agent_id":    "agent-1",
+			"sequence_number": 1,
+			"event_type":      "system.run.completed",
+			"occurred_at":     "2026-05-10T10:00:00Z",
+			"payload":         map[string]any{},
+		},
+	)
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/runs/run-1/agents": jsonHandler(http.StatusOK, map[string]any{
+			"items": []map[string]any{{"id": "agent-1", "label": "candidate"}},
+		}),
+		"GET /v1/runs/run-1/events/export": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, jsonl)
+		},
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{"--json", "run", "transcript", "run-1"}, srv.URL); err != nil {
+		t.Fatalf("run transcript error: %v", err)
+	}
+
+	var payload struct {
+		RunID      string `json:"run_id"`
+		Format     string `json:"format"`
+		Transcript string `json:"transcript"`
+	}
+	if err := json.Unmarshal([]byte(stdout.finish()), &payload); err != nil {
+		t.Fatalf("decode structured transcript output: %v", err)
+	}
+	if payload.RunID != "run-1" || payload.Format != "markdown" {
+		t.Fatalf("unexpected structured envelope: %+v", payload)
+	}
+	if !strings.Contains(payload.Transcript, "# Run Transcript") || !strings.Contains(payload.Transcript, "### Run completed") {
+		t.Fatalf("structured envelope should include markdown transcript: %+v", payload)
+	}
+}
+
+func transcriptJSONL(t *testing.T, events ...map[string]any) string {
+	t.Helper()
+	var b strings.Builder
+	for _, event := range events {
+		encoded, err := json.Marshal(event)
+		if err != nil {
+			t.Fatalf("marshal transcript event: %v", err)
+		}
+		b.Write(encoded)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}

--- a/cli/cmd/run_transcript_test.go
+++ b/cli/cmd/run_transcript_test.go
@@ -281,6 +281,99 @@ func TestRunTranscriptStructuredOutputWrapsMarkdown(t *testing.T) {
 	}
 }
 
+func TestRunTranscriptSortsEventsBySequence(t *testing.T) {
+	jsonl := transcriptJSONL(t,
+		map[string]any{
+			"event_id":        "event-2",
+			"run_id":          "run-1",
+			"run_agent_id":    "agent-1",
+			"sequence_number": 2,
+			"event_type":      "system.run.completed",
+			"occurred_at":     "2026-05-10T10:00:02Z",
+			"payload":         map[string]any{},
+		},
+		map[string]any{
+			"event_id":        "event-1",
+			"run_id":          "run-1",
+			"run_agent_id":    "agent-1",
+			"sequence_number": 1,
+			"event_type":      "system.run.started",
+			"occurred_at":     "2026-05-10T10:00:01Z",
+			"payload":         map[string]any{},
+		},
+	)
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/runs/run-1/agents": jsonHandler(http.StatusOK, map[string]any{
+			"items": []map[string]any{{"id": "agent-1", "label": "candidate"}},
+		}),
+		"GET /v1/runs/run-1/events/export": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, jsonl)
+		},
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{"run", "transcript", "run-1"}, srv.URL); err != nil {
+		t.Fatalf("run transcript error: %v", err)
+	}
+	out := stdout.finish()
+
+	started := strings.Index(out, "### Run started")
+	completed := strings.Index(out, "### Run completed")
+	if started == -1 || completed == -1 || started > completed {
+		t.Fatalf("transcript should sort events by sequence\n---\n%s", out)
+	}
+}
+
+func TestRunTranscriptEscapesInlineHTML(t *testing.T) {
+	jsonl := transcriptJSONL(t,
+		map[string]any{
+			"event_id":        "event-1",
+			"run_id":          "run-1",
+			"run_agent_id":    "agent-1",
+			"sequence_number": 1,
+			"event_type":      "tool.call.failed",
+			"occurred_at":     "2026-05-10T10:00:00Z",
+			"payload": map[string]any{
+				"tool_name":  "<script>",
+				"error_code": "<timeout>",
+			},
+		},
+	)
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/runs/run-1/agents": jsonHandler(http.StatusOK, map[string]any{
+			"items": []map[string]any{{"id": "agent-1", "label": "<b>winner</b>"}},
+		}),
+		"GET /v1/runs/run-1/events/export": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, jsonl)
+		},
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{"run", "transcript", "run-1"}, srv.URL); err != nil {
+		t.Fatalf("run transcript error: %v", err)
+	}
+	out := stdout.finish()
+
+	for _, raw := range []string{"<b>winner</b>", "<script>", "<timeout>"} {
+		if strings.Contains(out, raw) {
+			t.Fatalf("transcript should escape raw inline HTML %q\n---\n%s", raw, out)
+		}
+	}
+	for _, escaped := range []string{"&lt;b&gt;winner&lt;/b&gt;", "&lt;script&gt;", "&lt;timeout&gt;"} {
+		if !strings.Contains(out, escaped) {
+			t.Fatalf("transcript missing escaped inline HTML %q\n---\n%s", escaped, out)
+		}
+	}
+}
+
 func transcriptJSONL(t *testing.T, events ...map[string]any) string {
 	t.Helper()
 	var b strings.Builder


### PR DESCRIPTION
## Summary
- add `agentclash run transcript <runId>` to render a readable Markdown transcript from persisted run events
- fetch run-agent labels for context and whitelist transcript-safe event summaries only
- support structured output by wrapping the Markdown transcript for `--json`/`--output yaml`
- cover golden Markdown output plus raw payload/free-form failure leak prevention

Closes #704

## Validation
- `go test ./cmd -run 'TestRunTranscript' -count=1`
- `go build ./...`
- `go vet ./...`
- `go test -short -race -count=1 ./...`
- `git diff --check`
- `AGENTCLASH_API_URL=https://api.agentclash.dev go run . run transcript --help`
- `AGENTCLASH_API_URL=https://api.agentclash.dev go run . run transcript a23bda99-8396-4cd9-9768-2c60c6108998`
- `AGENTCLASH_API_URL=https://api.agentclash.dev go run . --json run transcript a23bda99-8396-4cd9-9768-2c60c6108998`
