### PR TITLE
feat: add tool-call assertion validator

### DIFF
--- a/backend/internal/challengepack/bundle_test.go
+++ b/backend/internal/challengepack/bundle_test.go
@@ -290,6 +290,52 @@ func TestManifestJSONPreservesGeneralizedContract(t *testing.T) {
 	}
 }
 
+func TestParseYAMLAcceptsToolCallAssertionValidator(t *testing.T) {
+	bundle, err := ParseYAML([]byte(`
+pack:
+  slug: tool-eval
+  name: Tool Eval
+  family: support
+version:
+  number: 1
+  evaluation_spec:
+    name: tool-v1
+    version_number: 1
+    judge_mode: deterministic
+    validators:
+      - key: submitted
+        type: tool_call_assertion
+        target: tool_calls
+        config:
+          tool_name: submit
+          arguments_contain:
+            answer: "42"
+    scorecard:
+      dimensions: [correctness]
+challenges:
+  - key: ticket-1
+    title: Ticket One
+    category: support
+    difficulty: easy
+input_sets:
+  - key: default
+    name: Default
+    cases:
+      - challenge_key: ticket-1
+        case_key: sample-1
+`))
+	if err != nil {
+		t.Fatalf("ParseYAML returned error: %v", err)
+	}
+	validator := bundle.Version.EvaluationSpec.Validators[0]
+	if validator.Type != scoring.ValidatorTypeToolCallAssertion {
+		t.Fatalf("validator type = %q, want %q", validator.Type, scoring.ValidatorTypeToolCallAssertion)
+	}
+	if validator.ExpectedFrom != "" {
+		t.Fatalf("expected_from = %q, want empty", validator.ExpectedFrom)
+	}
+}
+
 func TestParseYAMLRejectsInvalidBundle(t *testing.T) {
 	_, err := ParseYAML([]byte(`
 pack:

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -1392,6 +1392,8 @@ func buildValidatorDetailEvidence(result scoring.ValidatorResult) any {
 		return buildValidatorJSONSchemaEvidence(result, raw)
 	case scoring.ValidatorTypeJSONPathMatch:
 		return buildValidatorJSONPathEvidence(result, raw)
+	case scoring.ValidatorTypeToolCallAssertion:
+		return buildValidatorToolCallAssertionEvidence(result, raw)
 	default:
 		return buildValidatorCustomEvidence(raw)
 	}
@@ -1478,6 +1480,37 @@ func buildValidatorJSONPathEvidence(result scoring.ValidatorResult, raw map[stri
 	}
 	if len(evidence) == 1 {
 		return buildValidatorCustomEvidence(raw)
+	}
+	return evidence
+}
+
+func buildValidatorToolCallAssertionEvidence(result scoring.ValidatorResult, raw map[string]any) any {
+	evidence := map[string]any{
+		"kind": "tool_call_assertion",
+	}
+	if sourceField := strings.TrimSpace(result.Target); sourceField != "" {
+		evidence["source_field"] = sourceField
+	}
+	for _, key := range []string{
+		"tool_name",
+		"observed_count",
+		"failed_count",
+		"matched_count",
+		"matched_indices",
+		"observed_tool_names",
+		"expected_count",
+		"expected_min_count",
+		"expected_max_count",
+		"expected_order",
+		"expected_order_mode",
+		"arguments_contain_set",
+	} {
+		if value, ok := raw[key]; ok {
+			evidence[key] = value
+		}
+	}
+	if result.Verdict == "pass" || result.Verdict == "fail" {
+		evidence["matched"] = result.Verdict == "pass"
 	}
 	return evidence
 }

--- a/backend/internal/repository/run_scorecard_test.go
+++ b/backend/internal/repository/run_scorecard_test.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"encoding/json"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -616,6 +617,63 @@ func TestBuildRunAgentScorecardDocumentFallsBackToCustomEvidence(t *testing.T) {
 	raw := evidence["raw"].(map[string]any)
 	if raw["stdout"] != "ok" {
 		t.Fatalf("raw evidence = %#v, want stdout", raw)
+	}
+}
+
+func TestBuildRunAgentScorecardDocumentIncludesToolCallAssertionEvidence(t *testing.T) {
+	evaluation := scoring.RunAgentEvaluation{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		Status:           scoring.EvaluationStatusComplete,
+		DimensionResults: []scoring.DimensionResult{
+			{Dimension: "correctness", State: scoring.OutputStateAvailable, Score: float64Ptr(1)},
+		},
+		ValidatorResults: []scoring.ValidatorResult{
+			{
+				Key:             "submitted",
+				Type:            scoring.ValidatorTypeToolCallAssertion,
+				State:           scoring.OutputStateAvailable,
+				Verdict:         "pass",
+				NormalizedScore: float64Ptr(1),
+				Target:          "tool_calls",
+				RawOutput: []byte(`{
+					"state":"available",
+					"verdict":"pass",
+						"tool_name":"submit",
+						"observed_count":2,
+						"failed_count":1,
+						"matched_count":1,
+						"matched_indices":[1],
+						"observed_tool_names":["search","submit"],
+					"arguments_contain_set":true,
+					"tool_arguments":{"secret":"SHOULD_NOT_LEAK"}
+				}`),
+			},
+		},
+	}
+
+	document, err := buildRunAgentScorecardDocument(evaluation)
+	if err != nil {
+		t.Fatalf("buildRunAgentScorecardDocument returned error: %v", err)
+	}
+	if strings.Contains(string(document), "SHOULD_NOT_LEAK") {
+		t.Fatalf("scorecard document leaked tool arguments: %s", document)
+	}
+
+	decoded := decodeRunScorecardJSON(t, document)
+	validators := decoded["validator_details"].([]any)
+	evidence := validators[0].(map[string]any)["evidence"].(map[string]any)
+	if evidence["kind"] != "tool_call_assertion" {
+		t.Fatalf("evidence kind = %#v, want %q", evidence["kind"], "tool_call_assertion")
+	}
+	if evidence["source_field"] != "tool_calls" || evidence["matched"] != true {
+		t.Fatalf("evidence = %#v, want tool_calls source and matched=true", evidence)
+	}
+	if evidence["observed_count"] != float64(2) || evidence["failed_count"] != float64(1) || evidence["matched_count"] != float64(1) {
+		t.Fatalf("evidence counts = %#v, want observed=2 failed=1 matched=1", evidence)
+	}
+	if _, ok := evidence["tool_arguments"]; ok {
+		t.Fatalf("evidence included raw tool arguments: %#v", evidence)
 	}
 }
 

--- a/backend/internal/scoring/engine.go
+++ b/backend/internal/scoring/engine.go
@@ -209,10 +209,7 @@ func evaluateRunAgentWithResolvedJudges(
 		return RunAgentEvaluation{}, errJudgeModeUnsupported
 	}
 
-	events := append([]Event(nil), input.Events...)
-	sort.SliceStable(events, func(i, j int) bool {
-		return events[i].OccurredAt.Before(events[j].OccurredAt)
-	})
+	events := orderedEvaluationEvents(input.Events)
 
 	evidence := buildEvidence(input.ChallengeInputs, events)
 	validatorResults, warnings := evaluateValidators(spec.Validators, evidence)
@@ -223,12 +220,30 @@ func evaluateRunAgentWithResolvedJudges(
 }
 
 func finalizeRunAgentEvaluation(input EvaluationInput, spec EvaluationSpec, validatorResults []ValidatorResult, metricResults []MetricResult, llmJudgeResults []LLMJudgeResult, warnings []string) RunAgentEvaluation {
-	events := append([]Event(nil), input.Events...)
-	sort.SliceStable(events, func(i, j int) bool {
-		return events[i].OccurredAt.Before(events[j].OccurredAt)
-	})
+	events := orderedEvaluationEvents(input.Events)
 	evidence := buildEvidence(input.ChallengeInputs, events)
 	return finalizeRunAgentEvaluationWithEvidence(input, spec, evidence, validatorResults, metricResults, llmJudgeResults, warnings)
+}
+
+func orderedEvaluationEvents(events []Event) []Event {
+	ordered := append([]Event(nil), events...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		left := ordered[i]
+		right := ordered[j]
+		leftHasSequence := left.SequenceNumber > 0
+		rightHasSequence := right.SequenceNumber > 0
+		if leftHasSequence != rightHasSequence {
+			return leftHasSequence
+		}
+		if leftHasSequence && left.SequenceNumber != right.SequenceNumber {
+			return left.SequenceNumber < right.SequenceNumber
+		}
+		if !left.OccurredAt.Equal(right.OccurredAt) {
+			return left.OccurredAt.Before(right.OccurredAt)
+		}
+		return left.Type < right.Type
+	})
+	return ordered
 }
 
 func finalizeRunAgentEvaluationWithEvidence(input EvaluationInput, spec EvaluationSpec, evidence extractedEvidence, validatorResults []ValidatorResult, metricResults []MetricResult, llmJudgeResults []LLMJudgeResult, warnings []string) RunAgentEvaluation {

--- a/backend/internal/scoring/engine_behavioral.go
+++ b/backend/internal/scoring/engine_behavioral.go
@@ -14,6 +14,8 @@ type toolCallTraceEntry struct {
 	Failed        bool            `json:"failed"`
 	FailureOrigin string          `json:"failure_origin,omitempty"`
 	ErrorMessage  string          `json:"error_message,omitempty"`
+	Sequence      int64           `json:"sequence,omitempty"`
+	EventType     string          `json:"event_type,omitempty"`
 }
 
 func behavioralDimensionScore(spec EvaluationSpec, evidence extractedEvidence, validators []ValidatorResult) (*float64, string, OutputState) {
@@ -230,7 +232,7 @@ func normalizeToolCallArguments(raw json.RawMessage) json.RawMessage {
 	return normalized
 }
 
-func buildToolCallTraceEntry(payload map[string]any, eventType string) (toolCallTraceEntry, bool) {
+func buildToolCallTraceEntry(event Event, payload map[string]any) (toolCallTraceEntry, bool) {
 	toolName, ok := stringValue(payload, "tool_name")
 	if !ok || strings.TrimSpace(toolName) == "" {
 		return toolCallTraceEntry{}, false
@@ -245,7 +247,9 @@ func buildToolCallTraceEntry(payload map[string]any, eventType string) (toolCall
 	entry := toolCallTraceEntry{
 		ToolName:  strings.TrimSpace(toolName),
 		Arguments: args,
-		Failed:    eventType == "tool.call.failed",
+		Failed:    event.Type == "tool.call.failed",
+		Sequence:  event.SequenceNumber,
+		EventType: event.Type,
 	}
 	if failureOrigin, ok := stringValue(payload, "failure_origin"); ok {
 		entry.FailureOrigin = strings.TrimSpace(failureOrigin)

--- a/backend/internal/scoring/engine_evidence.go
+++ b/backend/internal/scoring/engine_evidence.go
@@ -179,7 +179,7 @@ func buildEvidence(challengeInputs []EvidenceInput, events []Event) extractedEvi
 			evidence.completedSuccessfully = &completed
 			evidence.failureCount++
 		case "tool.call.completed", "tool.call.failed":
-			if entry, ok := buildToolCallTraceEntry(payload, event.Type); ok {
+			if entry, ok := buildToolCallTraceEntry(event, payload); ok {
 				evidence.toolCallTrace = append(evidence.toolCallTrace, entry)
 				if entry.Failed {
 					evidence.failureCount++

--- a/backend/internal/scoring/engine_validators.go
+++ b/backend/internal/scoring/engine_validators.go
@@ -23,6 +23,10 @@ func evaluateValidators(validators []ValidatorDeclaration, evidence extractedEvi
 			results = append(results, evaluateCodeExecutionValidator(result, validator, evidence))
 			continue
 		}
+		if validator.Type == ValidatorTypeToolCallAssertion {
+			results = append(results, evaluateToolCallAssertionValidator(result, validator, evidence))
+			continue
+		}
 
 		// Resolve the target (actual) evidence.
 		actualValue, actualChallengeID, actualReason, actualErr := resolveEvidenceValue(validator.Target, evidence)
@@ -301,6 +305,7 @@ func isPackAuthorValidatorError(reason string) bool {
 		"parse rouge_score references",
 		"parse chrf_score config",
 		"parse chrf_score references",
+		"parse tool_call_assertion config",
 		"parse json schema",
 		"resolve json schema",
 		"parse json_path_match expectation",

--- a/backend/internal/scoring/spec.go
+++ b/backend/internal/scoring/spec.go
@@ -37,6 +37,7 @@ const (
 	ValidatorTypeFileJSONSchema     ValidatorType = "file_json_schema"
 	ValidatorTypeDirectoryStructure ValidatorType = "directory_structure"
 	ValidatorTypeCodeExecution      ValidatorType = "code_execution"
+	ValidatorTypeToolCallAssertion  ValidatorType = "tool_call_assertion"
 )
 
 type MetricType string
@@ -337,7 +338,7 @@ func (t ValidatorType) IsValid() bool {
 		ValidatorTypeMathEquivalence, ValidatorTypeBLEUScore, ValidatorTypeROUGEScore, ValidatorTypeChrFScore,
 		ValidatorTypeFileContentMatch, ValidatorTypeFileExists,
 		ValidatorTypeFileJSONSchema, ValidatorTypeDirectoryStructure,
-		ValidatorTypeCodeExecution:
+		ValidatorTypeCodeExecution, ValidatorTypeToolCallAssertion:
 		return true
 	default:
 		return false
@@ -362,7 +363,7 @@ func (t ValidatorType) IsFileValidator() bool {
 // (file_exists, file_json_schema, directory_structure) return false.
 func (t ValidatorType) RequiresExpectedFrom() bool {
 	switch t {
-	case ValidatorTypeFileExists, ValidatorTypeFileJSONSchema, ValidatorTypeDirectoryStructure, ValidatorTypeCodeExecution:
+	case ValidatorTypeFileExists, ValidatorTypeFileJSONSchema, ValidatorTypeDirectoryStructure, ValidatorTypeCodeExecution, ValidatorTypeToolCallAssertion:
 		return false
 	default:
 		return true

--- a/backend/internal/scoring/tool_call_assertion.go
+++ b/backend/internal/scoring/tool_call_assertion.go
@@ -1,0 +1,407 @@
+package scoring
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type toolCallAssertionConfig struct {
+	ToolName         string          `json:"tool_name,omitempty"`
+	MustCall         *bool           `json:"must_call,omitempty"`
+	Count            *int            `json:"count,omitempty"`
+	MinCount         *int            `json:"min_count,omitempty"`
+	MaxCount         *int            `json:"max_count,omitempty"`
+	ArgumentsContain json.RawMessage `json:"arguments_contain,omitempty"`
+	OrderedTools     []string        `json:"ordered_tools,omitempty"`
+	OrderMode        string          `json:"order_mode,omitempty"`
+}
+
+const (
+	toolCallOrderModeSubsequence = "subsequence"
+	toolCallOrderModeExact       = "exact"
+)
+
+func ParseToolCallAssertionConfig(rawConfig json.RawMessage) (toolCallAssertionConfig, error) {
+	var cfg toolCallAssertionConfig
+	if len(strings.TrimSpace(string(rawConfig))) == 0 {
+		return cfg, fmt.Errorf("tool_call_assertion config is required")
+	}
+	if err := decodeStrictJSON(rawConfig, &cfg); err != nil {
+		return toolCallAssertionConfig{}, err
+	}
+	cfg.ToolName = strings.TrimSpace(cfg.ToolName)
+	cfg.OrderMode = strings.TrimSpace(cfg.OrderMode)
+	for i := range cfg.OrderedTools {
+		cfg.OrderedTools[i] = strings.TrimSpace(cfg.OrderedTools[i])
+	}
+	if cfg.OrderMode == "" && len(cfg.OrderedTools) > 0 {
+		cfg.OrderMode = toolCallOrderModeSubsequence
+	}
+	return cfg, nil
+}
+
+func validateToolCallAssertionConfig(cfg toolCallAssertionConfig, configPath string) ValidationErrors {
+	var errs ValidationErrors
+
+	if cfg.Count != nil && *cfg.Count < 0 {
+		errs = append(errs, ValidationError{Field: configPath + ".count", Message: "must be greater than or equal to 0"})
+	}
+	if cfg.MinCount != nil && *cfg.MinCount < 0 {
+		errs = append(errs, ValidationError{Field: configPath + ".min_count", Message: "must be greater than or equal to 0"})
+	}
+	if cfg.MaxCount != nil && *cfg.MaxCount < 0 {
+		errs = append(errs, ValidationError{Field: configPath + ".max_count", Message: "must be greater than or equal to 0"})
+	}
+	if cfg.Count != nil && (cfg.MinCount != nil || cfg.MaxCount != nil) {
+		errs = append(errs, ValidationError{Field: configPath + ".count", Message: "cannot be combined with min_count or max_count"})
+	}
+	if cfg.MinCount != nil && cfg.MaxCount != nil && *cfg.MinCount > *cfg.MaxCount {
+		errs = append(errs, ValidationError{Field: configPath + ".min_count", Message: "must be less than or equal to max_count"})
+	}
+	if cfg.MustCall != nil && cfg.hasCountAssertion() {
+		if *cfg.MustCall && cfg.Count != nil && *cfg.Count == 0 {
+			errs = append(errs, ValidationError{Field: configPath + ".must_call", Message: "cannot be true when count is 0"})
+		}
+		if *cfg.MustCall && cfg.MaxCount != nil && *cfg.MaxCount == 0 {
+			errs = append(errs, ValidationError{Field: configPath + ".must_call", Message: "cannot be true when max_count is 0"})
+		}
+		if !*cfg.MustCall && cfg.Count != nil && *cfg.Count > 0 {
+			errs = append(errs, ValidationError{Field: configPath + ".must_call", Message: "cannot be false when count is greater than 0"})
+		}
+		if !*cfg.MustCall && cfg.MinCount != nil && *cfg.MinCount > 0 {
+			errs = append(errs, ValidationError{Field: configPath + ".must_call", Message: "cannot be false when min_count is greater than 0"})
+		}
+	}
+	if len(cfg.ArgumentsContain) > 0 {
+		var fragment any
+		if err := json.Unmarshal(cfg.ArgumentsContain, &fragment); err != nil {
+			errs = append(errs, ValidationError{Field: configPath + ".arguments_contain", Message: fmt.Sprintf("must be valid JSON: %v", err)})
+		} else if _, ok := fragment.(map[string]any); !ok {
+			errs = append(errs, ValidationError{Field: configPath + ".arguments_contain", Message: "must be a JSON object"})
+		}
+	}
+	if len(cfg.OrderedTools) > 0 {
+		for i, tool := range cfg.OrderedTools {
+			if tool == "" {
+				errs = append(errs, ValidationError{Field: fmt.Sprintf("%s.ordered_tools[%d]", configPath, i), Message: "must not be empty"})
+			}
+		}
+	}
+	if cfg.OrderMode != "" {
+		switch cfg.OrderMode {
+		case toolCallOrderModeSubsequence, toolCallOrderModeExact:
+		default:
+			errs = append(errs, ValidationError{Field: configPath + ".order_mode", Message: `must be "subsequence" or "exact"`})
+		}
+		if len(cfg.OrderedTools) == 0 {
+			errs = append(errs, ValidationError{Field: configPath + ".ordered_tools", Message: "is required when order_mode is set"})
+		}
+	}
+	if !cfg.hasAnyAssertion() {
+		errs = append(errs, ValidationError{Field: configPath, Message: "must declare at least one tool call assertion"})
+	}
+	return errs
+}
+
+func (cfg toolCallAssertionConfig) hasAnyAssertion() bool {
+	return cfg.ToolName != "" ||
+		cfg.MustCall != nil ||
+		cfg.Count != nil ||
+		cfg.MinCount != nil ||
+		cfg.MaxCount != nil ||
+		len(cfg.ArgumentsContain) > 0 ||
+		len(cfg.OrderedTools) > 0
+}
+
+func evaluateToolCallAssertionValidator(result ValidatorResult, validator ValidatorDeclaration, evidence extractedEvidence) ValidatorResult {
+	cfg, err := ParseToolCallAssertionConfig(validator.Config)
+	if err != nil {
+		result.State = OutputStateError
+		result.Reason = fmt.Sprintf("parse tool_call_assertion config: %v", err)
+		result.RawOutput = mustMarshalJSON(map[string]any{
+			"state":  result.State,
+			"reason": result.Reason,
+		})
+		return result
+	}
+
+	if errs := validateToolCallAssertionConfig(cfg, "config"); len(errs) > 0 {
+		result.State = OutputStateError
+		result.Reason = fmt.Sprintf("invalid tool_call_assertion config: %v", errs)
+		result.RawOutput = mustMarshalJSON(map[string]any{
+			"state":  result.State,
+			"reason": result.Reason,
+		})
+		return result
+	}
+
+	outcome := applyToolCallAssertion(cfg, evidence.toolCallTrace)
+	result.State = OutputStateAvailable
+	result.Verdict = outcome.verdict
+	result.NormalizedScore = outcome.normalizedScore
+	result.Reason = outcome.reason
+	if outcome.source != nil {
+		result.Source = outcome.source
+	}
+	result.RawOutput = mustMarshalJSON(mergeEvidence(map[string]any{
+		"state":            result.State,
+		"verdict":          result.Verdict,
+		"normalized_score": result.NormalizedScore,
+		"reason":           result.Reason,
+		"target":           validator.Target,
+		"tool_name":        emptyNil(cfg.ToolName),
+	}, outcome.evidence))
+	return result
+}
+
+type toolCallAssertionOutcome struct {
+	verdict         string
+	normalizedScore *float64
+	reason          string
+	source          *Source
+	evidence        map[string]any
+}
+
+func applyToolCallAssertion(cfg toolCallAssertionConfig, trace []toolCallTraceEntry) toolCallAssertionOutcome {
+	matches := matchingToolCalls(cfg, trace)
+	reasons := make([]string, 0)
+	pass := true
+
+	if cfg.hasPresenceAssertion() {
+		mustCall := true
+		if cfg.MustCall != nil {
+			mustCall = *cfg.MustCall
+		}
+		if mustCall && len(matches) == 0 {
+			pass = false
+			reasons = append(reasons, "expected matching tool call was not observed")
+		}
+		if !mustCall && len(matches) > 0 {
+			pass = false
+			reasons = append(reasons, "forbidden matching tool call was observed")
+		}
+	}
+	if cfg.Count != nil && len(matches) != *cfg.Count {
+		pass = false
+		reasons = append(reasons, fmt.Sprintf("matched tool call count %d != expected %d", len(matches), *cfg.Count))
+	}
+	if cfg.MinCount != nil && len(matches) < *cfg.MinCount {
+		pass = false
+		reasons = append(reasons, fmt.Sprintf("matched tool call count %d < min_count %d", len(matches), *cfg.MinCount))
+	}
+	if cfg.MaxCount != nil && len(matches) > *cfg.MaxCount {
+		pass = false
+		reasons = append(reasons, fmt.Sprintf("matched tool call count %d > max_count %d", len(matches), *cfg.MaxCount))
+	}
+	orderPass, orderReason := evaluateToolOrder(cfg, trace)
+	if !orderPass {
+		pass = false
+		reasons = append(reasons, orderReason)
+	}
+
+	verdict := "pass"
+	score := 1.0
+	if !pass {
+		verdict = "fail"
+		score = 0
+	}
+
+	successfulToolNames := successfulObservedToolNames(trace)
+	return toolCallAssertionOutcome{
+		verdict:         verdict,
+		normalizedScore: &score,
+		reason:          strings.Join(reasons, "; "),
+		source:          sourceForFirstMatchedToolCall(matches),
+		evidence: map[string]any{
+			"observed_count":        len(successfulToolNames),
+			"failed_count":          len(trace) - len(successfulToolNames),
+			"matched_count":         len(matches),
+			"matched_indices":       matchedIndices(matches),
+			"observed_tool_names":   successfulToolNames,
+			"expected_count":        cfg.Count,
+			"expected_min_count":    cfg.MinCount,
+			"expected_max_count":    cfg.MaxCount,
+			"expected_order":        nonEmptyStringsOrNil(cfg.OrderedTools),
+			"expected_order_mode":   emptyNil(cfg.OrderMode),
+			"arguments_contain_set": len(cfg.ArgumentsContain) > 0,
+		},
+	}
+}
+
+func (cfg toolCallAssertionConfig) hasPresenceAssertion() bool {
+	if cfg.MustCall != nil {
+		return true
+	}
+	if cfg.hasCountAssertion() {
+		return false
+	}
+	return cfg.ToolName != "" || len(cfg.ArgumentsContain) > 0
+}
+
+func (cfg toolCallAssertionConfig) hasCountAssertion() bool {
+	return cfg.Count != nil || cfg.MinCount != nil || cfg.MaxCount != nil
+}
+
+func matchingToolCalls(cfg toolCallAssertionConfig, trace []toolCallTraceEntry) []toolCallMatch {
+	matches := make([]toolCallMatch, 0, len(trace))
+	for i, entry := range trace {
+		if entry.Failed {
+			continue
+		}
+		if cfg.ToolName != "" && entry.ToolName != cfg.ToolName {
+			continue
+		}
+		if len(cfg.ArgumentsContain) > 0 && !toolCallArgumentsContain(entry.Arguments, cfg.ArgumentsContain) {
+			continue
+		}
+		matches = append(matches, toolCallMatch{Index: i, Entry: entry})
+	}
+	return matches
+}
+
+type toolCallMatch struct {
+	Index int
+	Entry toolCallTraceEntry
+}
+
+func toolCallArgumentsContain(arguments json.RawMessage, fragment json.RawMessage) bool {
+	var actual any
+	if err := json.Unmarshal(arguments, &actual); err != nil {
+		return false
+	}
+	var expected any
+	if err := json.Unmarshal(fragment, &expected); err != nil {
+		return false
+	}
+	return jsonContains(actual, expected)
+}
+
+func jsonContains(actual any, expected any) bool {
+	switch expectedTyped := expected.(type) {
+	case map[string]any:
+		actualTyped, ok := actual.(map[string]any)
+		if !ok {
+			return false
+		}
+		for key, expectedValue := range expectedTyped {
+			actualValue, ok := actualTyped[key]
+			if !ok || !jsonContains(actualValue, expectedValue) {
+				return false
+			}
+		}
+		return true
+	case []any:
+		actualTyped, ok := actual.([]any)
+		if !ok || len(expectedTyped) > len(actualTyped) {
+			return false
+		}
+		used := make([]bool, len(actualTyped))
+		for _, expectedValue := range expectedTyped {
+			found := false
+			for i, actualValue := range actualTyped {
+				if used[i] {
+					continue
+				}
+				if jsonContains(actualValue, expectedValue) {
+					used[i] = true
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		}
+		return true
+	default:
+		return reflect.DeepEqual(actual, expected)
+	}
+}
+
+func evaluateToolOrder(cfg toolCallAssertionConfig, trace []toolCallTraceEntry) (bool, string) {
+	if len(cfg.OrderedTools) == 0 {
+		return true, ""
+	}
+	observed := successfulObservedToolNames(trace)
+	switch cfg.OrderMode {
+	case "", toolCallOrderModeSubsequence:
+		if containsToolSubsequence(observed, cfg.OrderedTools) {
+			return true, ""
+		}
+		return false, fmt.Sprintf("observed tool order %v does not contain expected subsequence %v", observed, cfg.OrderedTools)
+	case toolCallOrderModeExact:
+		if reflect.DeepEqual(observed, cfg.OrderedTools) {
+			return true, ""
+		}
+		return false, fmt.Sprintf("observed tool order %v does not exactly match expected order %v", observed, cfg.OrderedTools)
+	default:
+		return false, fmt.Sprintf("unsupported order_mode %q", cfg.OrderMode)
+	}
+}
+
+func containsToolSubsequence(observed []string, expected []string) bool {
+	if len(expected) == 0 {
+		return true
+	}
+	next := 0
+	for _, tool := range observed {
+		if tool == expected[next] {
+			next++
+			if next == len(expected) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func sourceForFirstMatchedToolCall(matches []toolCallMatch) *Source {
+	if len(matches) == 0 {
+		return nil
+	}
+	entry := matches[0].Entry
+	if entry.Sequence <= 0 {
+		return nil
+	}
+	return &Source{
+		Kind:      SourceKindToolCall,
+		Sequence:  int64Ptr(entry.Sequence),
+		EventType: entry.EventType,
+		FieldPath: "tool_calls",
+	}
+}
+
+func matchedIndices(matches []toolCallMatch) []int {
+	indices := make([]int, 0, len(matches))
+	for _, match := range matches {
+		indices = append(indices, match.Index)
+	}
+	return indices
+}
+
+func successfulObservedToolNames(trace []toolCallTraceEntry) []string {
+	names := make([]string, 0, len(trace))
+	for _, entry := range trace {
+		if entry.Failed {
+			continue
+		}
+		names = append(names, entry.ToolName)
+	}
+	return names
+}
+
+func emptyNil(value string) any {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return value
+}
+
+func nonEmptyStringsOrNil(values []string) any {
+	if len(values) == 0 {
+		return nil
+	}
+	return values
+}

--- a/backend/internal/scoring/tool_call_assertion_test.go
+++ b/backend/internal/scoring/tool_call_assertion_test.go
@@ -1,0 +1,482 @@
+package scoring
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestToolCallAssertionPresenceAndArgumentFragment(t *testing.T) {
+	evaluation := evaluateToolCallAssertionSpec(t,
+		[]ValidatorDeclaration{{
+			Key:    "submitted_answer",
+			Type:   ValidatorTypeToolCallAssertion,
+			Target: "tool_calls",
+			Config: json.RawMessage(`{
+				"tool_name": "submit",
+				"arguments_contain": {"answer": {"value": "42"}}
+			}`),
+		}},
+		[]Event{
+			toolCallEvent(1, "tool.call.completed", "search", `{"query":"life"}`),
+			toolCallEvent(2, "tool.call.completed", "submit", `{"answer":{"value":"42","secret":"SHOULD_NOT_LEAK"}}`),
+		},
+	)
+
+	result := evaluation.ValidatorResults[0]
+	if result.State != OutputStateAvailable || result.Verdict != "pass" {
+		t.Fatalf("validator = state %s verdict %q reason %q", result.State, result.Verdict, result.Reason)
+	}
+	if result.Source == nil || result.Source.Kind != SourceKindToolCall || result.Source.Sequence == nil || *result.Source.Sequence != 2 {
+		t.Fatalf("source = %+v, want tool-call source at sequence 2", result.Source)
+	}
+	if strings.Contains(string(result.RawOutput), "SHOULD_NOT_LEAK") {
+		t.Fatalf("raw output leaked tool arguments: %s", result.RawOutput)
+	}
+	assertRawOutputField(t, result.RawOutput, "matched_count", float64(1))
+}
+
+func TestToolCallAssertionArgumentFragmentArraySubset(t *testing.T) {
+	evaluation := evaluateToolCallAssertionSpec(t,
+		[]ValidatorDeclaration{{
+			Key:    "tagged_submit",
+			Type:   ValidatorTypeToolCallAssertion,
+			Target: "tool_calls",
+			Config: json.RawMessage(`{
+				"tool_name": "submit",
+				"arguments_contain": {"tags": ["urgent"], "steps": [{"status": "done"}]}
+			}`),
+		}},
+		[]Event{
+			toolCallEvent(1, "tool.call.completed", "submit", `{
+				"tags":["info","urgent"],
+				"steps":[{"status":"queued"},{"status":"done","id":"final"}]
+			}`),
+		},
+	)
+
+	if got := evaluation.ValidatorResults[0].Verdict; got != "pass" {
+		t.Fatalf("array subset fragment verdict = %q, want pass; reason=%q", got, evaluation.ValidatorResults[0].Reason)
+	}
+}
+
+func TestToolCallAssertionArgumentFragmentArraySubsetConsumesMatches(t *testing.T) {
+	evaluation := evaluateToolCallAssertionSpec(t,
+		[]ValidatorDeclaration{{
+			Key:    "duplicate_steps",
+			Type:   ValidatorTypeToolCallAssertion,
+			Target: "tool_calls",
+			Config: json.RawMessage(`{
+				"tool_name": "submit",
+				"arguments_contain": {"steps": ["approve", "approve"]}
+			}`),
+		}},
+		[]Event{
+			toolCallEvent(1, "tool.call.completed", "submit", `{"steps":["approve"]}`),
+		},
+	)
+
+	if got := evaluation.ValidatorResults[0].Verdict; got != "fail" {
+		t.Fatalf("duplicate array subset verdict = %q, want fail; reason=%q", got, evaluation.ValidatorResults[0].Reason)
+	}
+}
+
+func TestToolCallAssertionAbsence(t *testing.T) {
+	evaluation := evaluateToolCallAssertionSpec(t,
+		[]ValidatorDeclaration{
+			{
+				Key:    "no_exec",
+				Type:   ValidatorTypeToolCallAssertion,
+				Target: "tool_calls",
+				Config: json.RawMessage(`{"tool_name":"exec","must_call":false}`),
+			},
+			{
+				Key:    "no_search",
+				Type:   ValidatorTypeToolCallAssertion,
+				Target: "tool_calls",
+				Config: json.RawMessage(`{"tool_name":"search","must_call":false}`),
+			},
+		},
+		[]Event{
+			toolCallEvent(1, "tool.call.completed", "search", `{"query":"x"}`),
+		},
+	)
+
+	if got := evaluation.ValidatorResults[0].Verdict; got != "pass" {
+		t.Fatalf("absence pass verdict = %q, want pass", got)
+	}
+	if got := evaluation.ValidatorResults[1].Verdict; got != "fail" {
+		t.Fatalf("absence fail verdict = %q, want fail", got)
+	}
+	if !strings.Contains(evaluation.ValidatorResults[1].Reason, "forbidden matching tool call") {
+		t.Fatalf("absence failure reason = %q", evaluation.ValidatorResults[1].Reason)
+	}
+}
+
+func TestToolCallAssertionCountsAndOrder(t *testing.T) {
+	evaluation := evaluateToolCallAssertionSpec(t,
+		[]ValidatorDeclaration{
+			{
+				Key:    "read_count",
+				Type:   ValidatorTypeToolCallAssertion,
+				Target: "tool_calls",
+				Config: json.RawMessage(`{"tool_name":"read_file","min_count":2,"max_count":2}`),
+			},
+			{
+				Key:    "expected_order",
+				Type:   ValidatorTypeToolCallAssertion,
+				Target: "tool_calls",
+				Config: json.RawMessage(`{"ordered_tools":["search","read_file","submit"],"order_mode":"subsequence"}`),
+			},
+			{
+				Key:    "exact_order_fails",
+				Type:   ValidatorTypeToolCallAssertion,
+				Target: "tool_calls",
+				Config: json.RawMessage(`{"ordered_tools":["search","read_file","submit"],"order_mode":"exact"}`),
+			},
+			{
+				Key:    "exact_submit_count_fails",
+				Type:   ValidatorTypeToolCallAssertion,
+				Target: "tool_calls",
+				Config: json.RawMessage(`{"tool_name":"submit","count":2}`),
+			},
+			{
+				Key:    "zero_exec_count",
+				Type:   ValidatorTypeToolCallAssertion,
+				Target: "tool_calls",
+				Config: json.RawMessage(`{"tool_name":"exec","count":0}`),
+			},
+			{
+				Key:    "zero_exec_min",
+				Type:   ValidatorTypeToolCallAssertion,
+				Target: "tool_calls",
+				Config: json.RawMessage(`{"tool_name":"exec","min_count":0}`),
+			},
+		},
+		[]Event{
+			toolCallEvent(1, "tool.call.completed", "search", `{"query":"x"}`),
+			toolCallEvent(2, "tool.call.completed", "read_file", `{"path":"a.txt"}`),
+			toolCallEvent(3, "tool.call.completed", "read_file", `{"path":"b.txt"}`),
+			toolCallEvent(4, "tool.call.completed", "submit", `{"answer":"done"}`),
+		},
+	)
+
+	wantVerdicts := map[string]string{
+		"read_count":               "pass",
+		"expected_order":           "pass",
+		"exact_order_fails":        "fail",
+		"exact_submit_count_fails": "fail",
+		"zero_exec_count":          "pass",
+		"zero_exec_min":            "pass",
+	}
+	for _, result := range evaluation.ValidatorResults {
+		if result.Verdict != wantVerdicts[result.Key] {
+			t.Fatalf("%s verdict = %q, want %q; reason=%q", result.Key, result.Verdict, wantVerdicts[result.Key], result.Reason)
+		}
+	}
+}
+
+func TestToolCallAssertionZeroCountFailsWhenToolObserved(t *testing.T) {
+	evaluation := evaluateToolCallAssertionSpec(t,
+		[]ValidatorDeclaration{{
+			Key:    "zero_search_count",
+			Type:   ValidatorTypeToolCallAssertion,
+			Target: "tool_calls",
+			Config: json.RawMessage(`{"tool_name":"search","count":0}`),
+		}},
+		[]Event{
+			toolCallEvent(1, "tool.call.completed", "search", `{"query":"x"}`),
+		},
+	)
+
+	result := evaluation.ValidatorResults[0]
+	if result.Verdict != "fail" {
+		t.Fatalf("zero count observed verdict = %q, want fail", result.Verdict)
+	}
+	if strings.Contains(result.Reason, "expected matching tool call was not observed") {
+		t.Fatalf("zero count failure used implicit presence reason: %q", result.Reason)
+	}
+}
+
+func TestToolCallAssertionPresenceAndCountsIgnoreFailedCalls(t *testing.T) {
+	evaluation := evaluateToolCallAssertionSpec(t,
+		[]ValidatorDeclaration{
+			{
+				Key:    "failed_submit_presence",
+				Type:   ValidatorTypeToolCallAssertion,
+				Target: "tool_calls",
+				Config: json.RawMessage(`{"tool_name":"submit","must_call":true}`),
+			},
+			{
+				Key:    "failed_submit_count",
+				Type:   ValidatorTypeToolCallAssertion,
+				Target: "tool_calls",
+				Config: json.RawMessage(`{"tool_name":"submit","count":1}`),
+			},
+			{
+				Key:    "failed_submit_zero_count",
+				Type:   ValidatorTypeToolCallAssertion,
+				Target: "tool_calls",
+				Config: json.RawMessage(`{"tool_name":"submit","count":0}`),
+			},
+		},
+		[]Event{
+			toolCallEvent(1, "tool.call.failed", "submit", `{"answer":"done"}`),
+		},
+	)
+
+	wantVerdicts := map[string]string{
+		"failed_submit_presence":   "fail",
+		"failed_submit_count":      "fail",
+		"failed_submit_zero_count": "pass",
+	}
+	for _, result := range evaluation.ValidatorResults {
+		if result.Verdict != wantVerdicts[result.Key] {
+			t.Fatalf("%s verdict = %q, want %q; reason=%q", result.Key, result.Verdict, wantVerdicts[result.Key], result.Reason)
+		}
+	}
+	assertRawOutputField(t, evaluation.ValidatorResults[0].RawOutput, "observed_count", float64(0))
+	assertRawOutputField(t, evaluation.ValidatorResults[0].RawOutput, "failed_count", float64(1))
+}
+
+func TestToolCallAssertionExactOrderIgnoresFailedRetries(t *testing.T) {
+	evaluation := evaluateToolCallAssertionSpec(t,
+		[]ValidatorDeclaration{{
+			Key:    "retry_order",
+			Type:   ValidatorTypeToolCallAssertion,
+			Target: "tool_calls",
+			Config: json.RawMessage(`{"ordered_tools":["search","submit"],"order_mode":"exact"}`),
+		}},
+		[]Event{
+			toolCallEvent(1, "tool.call.failed", "search", `{"query":"x"}`),
+			toolCallEvent(2, "tool.call.completed", "search", `{"query":"x"}`),
+			toolCallEvent(3, "tool.call.completed", "submit", `{"answer":"done"}`),
+		},
+	)
+
+	if got := evaluation.ValidatorResults[0].Verdict; got != "pass" {
+		t.Fatalf("retry exact order verdict = %q, want pass; reason=%q", got, evaluation.ValidatorResults[0].Reason)
+	}
+}
+
+func TestToolCallAssertionOrdersBySequenceNumber(t *testing.T) {
+	search := toolCallEvent(1, "tool.call.completed", "search", `{"query":"x"}`)
+	submit := toolCallEvent(2, "tool.call.completed", "submit", `{"answer":"done"}`)
+	search.OccurredAt = time.Date(2026, 5, 10, 12, 0, 2, 0, time.UTC)
+	submit.OccurredAt = time.Date(2026, 5, 10, 12, 0, 1, 0, time.UTC)
+
+	evaluation := evaluateToolCallAssertionSpec(t,
+		[]ValidatorDeclaration{{
+			Key:    "sequence_order",
+			Type:   ValidatorTypeToolCallAssertion,
+			Target: "tool_calls",
+			Config: json.RawMessage(`{"ordered_tools":["search","submit"],"order_mode":"exact"}`),
+		}},
+		[]Event{submit, search},
+	)
+
+	if got := evaluation.ValidatorResults[0].Verdict; got != "pass" {
+		t.Fatalf("sequence order verdict = %q, want pass; reason=%q", got, evaluation.ValidatorResults[0].Reason)
+	}
+}
+
+func TestOrderedEvaluationEventsHandlesMixedSequences(t *testing.T) {
+	unsequenced := Event{Type: "unsequenced", OccurredAt: time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)}
+	seqTwo := Event{Type: "seq-two", SequenceNumber: 2, OccurredAt: time.Date(2026, 5, 10, 12, 0, 1, 0, time.UTC)}
+	seqOne := Event{Type: "seq-one", SequenceNumber: 1, OccurredAt: time.Date(2026, 5, 10, 12, 0, 2, 0, time.UTC)}
+
+	ordered := orderedEvaluationEvents([]Event{unsequenced, seqTwo, seqOne})
+
+	got := []string{ordered[0].Type, ordered[1].Type, ordered[2].Type}
+	want := []string{"seq-one", "seq-two", "unsequenced"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("ordered event types = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestToolCallAssertionValidation(t *testing.T) {
+	cases := []struct {
+		name   string
+		config string
+		target string
+		needle string
+	}{
+		{
+			name:   "missing config",
+			config: "",
+			target: "tool_calls",
+			needle: "tool_call_assertion config is required",
+		},
+		{
+			name:   "wrong target",
+			config: `{"tool_name":"submit"}`,
+			target: "final_output",
+			needle: `target must be "tool_calls"`,
+		},
+		{
+			name:   "unknown field",
+			config: `{"tool_name":"submit","typo":true}`,
+			target: "tool_calls",
+			needle: "unknown field",
+		},
+		{
+			name:   "invalid count range",
+			config: `{"tool_name":"submit","min_count":2,"max_count":1}`,
+			target: "tool_calls",
+			needle: "min_count must be less than or equal to max_count",
+		},
+		{
+			name:   "invalid arguments fragment",
+			config: `{"tool_name":"submit","arguments_contain":["answer"]}`,
+			target: "tool_calls",
+			needle: "arguments_contain must be a JSON object",
+		},
+		{
+			name:   "invalid order mode",
+			config: `{"ordered_tools":["search"],"order_mode":"before"}`,
+			target: "tool_calls",
+			needle: `order_mode must be "subsequence" or "exact"`,
+		},
+		{
+			name:   "must call true with zero count",
+			config: `{"tool_name":"submit","must_call":true,"count":0}`,
+			target: "tool_calls",
+			needle: "must_call cannot be true when count is 0",
+		},
+		{
+			name:   "must call false with positive count",
+			config: `{"tool_name":"submit","must_call":false,"count":1}`,
+			target: "tool_calls",
+			needle: "must_call cannot be false when count is greater than 0",
+		},
+		{
+			name:   "must call true with zero max count",
+			config: `{"tool_name":"submit","must_call":true,"max_count":0}`,
+			target: "tool_calls",
+			needle: "must_call cannot be true when max_count is 0",
+		},
+		{
+			name:   "must call false with positive min count",
+			config: `{"tool_name":"submit","must_call":false,"min_count":1}`,
+			target: "tool_calls",
+			needle: "must_call cannot be false when min_count is greater than 0",
+		},
+		{
+			name:   "expected_from rejected",
+			config: `{"tool_name":"submit"}`,
+			target: "tool_calls",
+			needle: "expected_from must be omitted for tool_call_assertion validators",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := json.RawMessage(tc.config)
+			if tc.config == "" {
+				config = nil
+			}
+			spec := toolCallAssertionSpec([]ValidatorDeclaration{{
+				Key:    "tool_assert",
+				Type:   ValidatorTypeToolCallAssertion,
+				Target: tc.target,
+				Config: config,
+			}})
+			if tc.name == "expected_from rejected" {
+				spec.Validators[0].ExpectedFrom = "case.expectations.expected_output"
+			}
+			err := ValidateEvaluationSpec(spec)
+			if err == nil {
+				t.Fatal("ValidateEvaluationSpec error = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tc.needle) {
+				t.Fatalf("error = %q, want containing %q", err.Error(), tc.needle)
+			}
+		})
+	}
+}
+
+func TestLoadEvaluationSpecToolCallAssertion(t *testing.T) {
+	spec, err := DecodeDefinition(json.RawMessage(`{
+		"name": "tool-assertions",
+		"version_number": 1,
+		"judge_mode": "deterministic",
+		"validators": [{
+			"key": "submitted",
+			"type": "tool_call_assertion",
+			"target": "tool_calls",
+			"config": {
+				"tool_name": "submit",
+				"must_call": true,
+				"arguments_contain": {"answer": "42"}
+			}
+		}],
+		"scorecard": {"dimensions": ["correctness"]}
+	}`))
+	if err != nil {
+		t.Fatalf("DecodeDefinition returned error: %v", err)
+	}
+	if spec.Validators[0].Type != ValidatorTypeToolCallAssertion {
+		t.Fatalf("validator type = %q, want %q", spec.Validators[0].Type, ValidatorTypeToolCallAssertion)
+	}
+	if spec.Validators[0].ExpectedFrom != "" {
+		t.Fatalf("expected_from = %q, want empty", spec.Validators[0].ExpectedFrom)
+	}
+}
+
+func evaluateToolCallAssertionSpec(t *testing.T, validators []ValidatorDeclaration, events []Event) RunAgentEvaluation {
+	t.Helper()
+	evaluation, err := EvaluateRunAgent(EvaluationInput{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		Events:           events,
+	}, toolCallAssertionSpec(validators))
+	if err != nil {
+		t.Fatalf("EvaluateRunAgent returned error: %v", err)
+	}
+	return evaluation
+}
+
+func toolCallAssertionSpec(validators []ValidatorDeclaration) EvaluationSpec {
+	return EvaluationSpec{
+		Name:          "tool-call-assertions",
+		VersionNumber: 1,
+		JudgeMode:     JudgeModeDeterministic,
+		Validators:    validators,
+		Scorecard: ScorecardDeclaration{
+			Dimensions: []DimensionDeclaration{{Key: ScorecardDimensionCorrectness}},
+		},
+	}
+}
+
+func toolCallEvent(sequence int64, eventType, toolName, arguments string) Event {
+	return Event{
+		Type:           eventType,
+		SequenceNumber: sequence,
+		OccurredAt:     time.Date(2026, 5, 10, 12, 0, int(sequence), 0, time.UTC),
+		Payload:        json.RawMessage(`{"tool_name":` + quoteJSON(toolName) + `,"arguments":` + arguments + `,"result":{"is_error":false,"content":"ok"}}`),
+	}
+}
+
+func quoteJSON(value string) string {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return string(encoded)
+}
+
+func assertRawOutputField(t *testing.T, raw json.RawMessage, key string, want any) {
+	t.Helper()
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("decode raw output: %v", err)
+	}
+	if got := decoded[key]; got != want {
+		t.Fatalf("raw_output[%q] = %#v, want %#v; raw=%s", key, got, want, raw)
+	}
+}

--- a/backend/internal/scoring/validation.go
+++ b/backend/internal/scoring/validation.go
@@ -96,6 +96,10 @@ func ValidateEvaluationSpec(spec EvaluationSpec) error {
 		}
 		if strings.TrimSpace(validator.Target) == "" {
 			errs = append(errs, ValidationError{Field: path + ".target", Message: "is required"})
+		} else if validator.Type == ValidatorTypeToolCallAssertion {
+			if strings.TrimSpace(validator.Target) != "tool_calls" {
+				errs = append(errs, ValidationError{Field: path + ".target", Message: `must be "tool_calls" for tool_call_assertion validators`})
+			}
 		} else if !isSupportedEvidenceReference(validator.Target) {
 			errs = append(errs, ValidationError{Field: path + ".target", Message: "must be a supported evidence reference"})
 		}
@@ -105,6 +109,8 @@ func ValidateEvaluationSpec(spec EvaluationSpec) error {
 			} else if !isSupportedEvidenceReference(validator.ExpectedFrom) {
 				errs = append(errs, ValidationError{Field: path + ".expected_from", Message: "must be a supported evidence reference"})
 			}
+		} else if validator.Type == ValidatorTypeToolCallAssertion && strings.TrimSpace(validator.ExpectedFrom) != "" {
+			errs = append(errs, ValidationError{Field: path + ".expected_from", Message: "must be omitted for tool_call_assertion validators"})
 		}
 		if validator.Type.IsFileValidator() {
 			if strings.TrimSpace(validator.Target) != "" && !strings.HasPrefix(validator.Target, "file:") {
@@ -629,7 +635,7 @@ func isSupportedEvidenceReference(value string) bool {
 }
 
 func validateValidatorConfig(validator ValidatorDeclaration, path string) ValidationErrors {
-	if len(validator.Config) == 0 {
+	if len(validator.Config) == 0 && validator.Type != ValidatorTypeToolCallAssertion {
 		return nil
 	}
 
@@ -775,6 +781,13 @@ func validateValidatorConfig(validator ValidatorDeclaration, path string) Valida
 		if cfg.PassThreshold != nil && (*cfg.PassThreshold < 0 || *cfg.PassThreshold > 1) {
 			errs = append(errs, ValidationError{Field: configPath + ".pass_threshold", Message: "must be between 0 and 1"})
 		}
+	case ValidatorTypeToolCallAssertion:
+		cfg, err := ParseToolCallAssertionConfig(validator.Config)
+		if err != nil {
+			errs = append(errs, ValidationError{Field: configPath, Message: configParseErrorMessage(err)})
+			return errs
+		}
+		errs = append(errs, validateToolCallAssertionConfig(cfg, configPath)...)
 	}
 
 	return errs

--- a/scripts/internal-agent-skills/prepare-skill-harnesses.mjs
+++ b/scripts/internal-agent-skills/prepare-skill-harnesses.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { createHash } from "node:crypto";
 
 const skillsArg = process.env.CHANGED_SKILLS_JSON || process.argv[2] || "[]";
 const outDir = process.env.OUT_DIR || process.argv[3] || ".agentclash/skill-harnesses";
@@ -104,9 +105,10 @@ for (const skillPath of skills) {
   }
   const title = titleFromSkill(content);
   const slug = meta.name.replace(/[^a-z0-9-]+/gi, "-").toLowerCase();
+  const slugHash = createHash("sha256").update(slug).digest("hex").slice(0, 8);
   const specPath = path.join(outDir, `${slug}.harness.json`);
   const spec = {
-    name: `skill-self-test-${safeRunLabel}-${slug}`.slice(0, 120),
+    name: `skill-self-test-${safeRunLabel}-${slugHash}-${slug}`.slice(0, 120),
     description: `Internal blind self-containment test for ${skillPath}`,
     task_prompt: taskPrompt(skillPath, meta, title),
     codex_template: "codex",

--- a/scripts/internal-agent-skills/skill-harness-scripts.test.mjs
+++ b/scripts/internal-agent-skills/skill-harness-scripts.test.mjs
@@ -82,7 +82,7 @@ const manifestPath = execFileSync(
 const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
 assert.equal(manifest.harnesses.length, 1);
 const spec = JSON.parse(readFileSync(manifest.harnesses[0].spec, "utf8"));
-assert.match(spec.name, /^skill-self-test-unit-agentclash-example-skill$/);
+assert.match(spec.name, /^skill-self-test-unit-e3a05841-agentclash-example-skill$/);
 assert.equal(spec.auth_mode, "api_key_secret");
 assert.equal(spec.openai_api_key_secret_name, "OPENAI_API_KEY");
 assert.equal(spec.repository_url, "https://github.com/agentclash/agentclash.git");
@@ -125,7 +125,7 @@ const longManifestPath = execFileSync(
 ).trim();
 const longManifest = JSON.parse(readFileSync(longManifestPath, "utf8"));
 const longSpec = JSON.parse(readFileSync(longManifest.harnesses[0].spec, "utf8"));
-assert.match(longSpec.name.slice(0, 60), /^skill-self-test-run-123456789-1-/);
+assert.match(longSpec.name.slice(0, 60), /^skill-self-test-run-123456789-1-34cd64be-/);
 
 const resultPath = path.join(tmp, "result.json");
 writeFileSync(

--- a/testing/codex-roadmap-693-tool-call-assertion.md
+++ b/testing/codex-roadmap-693-tool-call-assertion.md
@@ -1,0 +1,51 @@
+# Roadmap #693 / Issue #706 Test Contract
+
+## Feature
+
+Challenge packs can declare a deterministic `tool_call_assertion` validator that scores recorded tool-call evidence.
+
+## Manifest Contract
+
+The validator is config-only:
+
+```yaml
+validators:
+  - key: used_submit
+    type: tool_call_assertion
+    target: tool_calls
+    config:
+      tool_name: submit
+      must_call: true
+      arguments_contain:
+        answer: "42"
+```
+
+Supported config fields:
+
+- `tool_name`: optional tool-name filter for presence, absence, count, and argument-fragment checks.
+- `must_call`: optional boolean; defaults to `true` when `tool_name` is set. `false` asserts absence.
+- `count`: optional exact count for calls matching `tool_name` and `arguments_contain`.
+- `min_count` / `max_count`: optional count bounds for matching calls.
+- `arguments_contain`: optional JSON object fragment that must be contained in at least one matching tool call's arguments.
+- `ordered_tools`: optional ordered list of tool names.
+- `order_mode`: optional `subsequence` (default) or `exact`.
+
+`expected_from` is not required. `target` must be `tool_calls`.
+
+## Required Test Cases
+
+1. Presence passes when a matching tool call is recorded.
+2. Absence passes when the forbidden tool is not recorded and fails when it is.
+3. Exact/min/max count checks pass and fail against synthetic tool-call events.
+4. Ordered tool checks support subsequence order and exact full order.
+5. Argument fragments match nested JSON objects without requiring exact argument equality.
+6. Missing required config or invalid config values fail spec validation.
+7. Validator output includes safe summary evidence (counts, tool names, matched indices) and does not echo raw tool arguments.
+
+## Validation Commands
+
+```bash
+cd backend
+go test ./internal/scoring ./internal/challengepack ./internal/repository -run 'TestToolCallAssertion|TestOrderedEvaluationEventsHandlesMixedSequences|TestLoadEvaluationSpecToolCallAssertion|TestParseYAMLAcceptsToolCallAssertionValidator|TestBuildRunAgentScorecardDocumentIncludesToolCallAssertionEvidence' -count=1
+go test ./...
+```

--- a/web/content/agent-skills/challenge-pack-skills/agentclash-challenge-pack-scoring-validators/SKILL.md
+++ b/web/content/agent-skills/challenge-pack-skills/agentclash-challenge-pack-scoring-validators/SKILL.md
@@ -105,7 +105,7 @@ Fields:
 - `key`: required, trimmed, and unique.
 - `type`: required and must be one of the supported validator types below.
 - `target`: required supported evidence reference.
-- `expected_from`: required for most validators; omitted for `file_exists`, `file_json_schema`, `directory_structure`, and `code_execution`.
+- `expected_from`: required for most validators; omitted for `file_exists`, `file_json_schema`, `directory_structure`, `code_execution`, and `tool_call_assertion`.
 - `config`: optional JSON/YAML object interpreted by the validator type.
 
 There is no validator-level `failure_message`, `pass_message`, or custom result text field. Results emit `state`, `verdict`, `normalized_score`, `reason`, `raw_output`, `target`, `expected_from`, `actual_value`, and `expected_value`; the reason text is produced by the scorer.
@@ -133,6 +133,7 @@ file_exists
 file_json_schema
 directory_structure
 code_execution
+tool_call_assertion
 ```
 
 Do not use `has_json`, `json_equals`, `semantic_match`, `unit_test`, `shell`, or provider-specific names; the validator rejects unknown `type` values.
@@ -150,6 +151,24 @@ Validator `target` and required `expected_from` values must use supported eviden
 - `artifact.<artifact_key>[.<field>]`
 - `file:<post_execution_check_key>`
 - `literal:<value>`
+- `tool_calls` (only for `tool_call_assertion`)
+
+## Tool Call Assertions
+Use `tool_call_assertion` to score executed tool-call traces without asking the final answer to self-report behavior. It must use `target: tool_calls` and does not use `expected_from`.
+
+```yaml
+validators:
+  - key: submitted_answer
+    type: tool_call_assertion
+    target: tool_calls
+    config:
+      tool_name: submit
+      must_call: true
+      arguments_contain:
+        answer: "42"
+```
+
+Config supports `tool_name`, `must_call`, `count`, `min_count`, `max_count`, `arguments_contain`, `ordered_tools`, and `order_mode`. `order_mode` is `subsequence` by default and can be `exact`. Scorecard evidence includes counts, matched indices, and tool names, but not raw tool arguments.
 
 Use `literal:` for inline expected values. Use `case.expectations.<key>` or `artifact.<artifact_key>.path` when the expected value should come from case evidence rather than the skill text.
 

--- a/web/content/agent-skills/challenge-pack-skills/agentclash-challenge-pack-yaml-author/SKILL.md
+++ b/web/content/agent-skills/challenge-pack-skills/agentclash-challenge-pack-yaml-author/SKILL.md
@@ -250,11 +250,11 @@ evaluation_spec:
 
 Supported `judge_mode` values are `deterministic`, `llm_judge`, and `hybrid`.
 
-Supported validator types include `exact_match`, `contains`, `regex_match`, `json_schema`, `json_path_match`, `boolean_assert`, `fuzzy_match`, `numeric_match`, `normalized_match`, `token_f1`, `math_equivalence`, `bleu_score`, `rouge_score`, `chrf_score`, `file_content_match`, `file_exists`, `file_json_schema`, `directory_structure`, and `code_execution`.
+Supported validator types include `exact_match`, `contains`, `regex_match`, `json_schema`, `json_path_match`, `boolean_assert`, `fuzzy_match`, `numeric_match`, `normalized_match`, `token_f1`, `math_equivalence`, `bleu_score`, `rouge_score`, `chrf_score`, `file_content_match`, `file_exists`, `file_json_schema`, `directory_structure`, `code_execution`, and `tool_call_assertion`.
 
 Evidence references accepted by validators and judges include `final_output`, `run.final_output`, `challenge_input`, `case.payload`, `case.payload.<path>`, `case.inputs.<path>`, `case.expectations.<path>`, `artifact.<path>`, `file:<post_execution_check_key>`, and `literal:<value>`.
 
-File validators require a `file:` target. `code_execution` validators must target a `post_execution_checks` entry of type `file_capture`.
+File validators require a `file:` target. `code_execution` validators must target a `post_execution_checks` entry of type `file_capture`. `tool_call_assertion` validators must target `tool_calls` and omit `expected_from`.
 
 For `judge_mode: deterministic`, omit `llm_judges`. For `judge_mode: llm_judge`, include at least one judge. For `judge_mode: hybrid`, include validators and at least one judge; hybrid scorecards need a gated dimension.
 

--- a/web/content/docs/challenge-packs/evaluation-spec-reference.mdx
+++ b/web/content/docs/challenge-packs/evaluation-spec-reference.mdx
@@ -33,11 +33,13 @@ Each entry is a `ValidatorDeclaration`:
 
 From `ValidatorType*` constants:
 
-`exact_match`, `contains`, `regex_match`, `json_schema`, `json_path_match`, `boolean_assert`, `fuzzy_match`, `numeric_match`, `normalized_match`, `token_f1`, `math_equivalence`, `bleu_score`, `rouge_score`, `chrf_score`, `file_content_match`, `file_exists`, `file_json_schema`, `directory_structure`, `code_execution`
+`exact_match`, `contains`, `regex_match`, `json_schema`, `json_path_match`, `boolean_assert`, `fuzzy_match`, `numeric_match`, `normalized_match`, `token_f1`, `math_equivalence`, `bleu_score`, `rouge_score`, `chrf_score`, `file_content_match`, `file_exists`, `file_json_schema`, `directory_structure`, `code_execution`, `tool_call_assertion`
 
 File-ish validators gate on sandbox artifacts (see **File validators**: `IsFileValidator()` distinguishes these).
 
-Always check `requires_expected_from`: e.g., `file_exists`, `directory_structure`, and `code_execution` can rely on config/paths without `expected_from`.
+Always check `requires_expected_from`: e.g., `file_exists`, `directory_structure`, `code_execution`, and `tool_call_assertion` can rely on config/paths without `expected_from`.
+
+`tool_call_assertion` uses `target: tool_calls` and strict config to assert executed tool-call evidence. It supports `tool_name`, `must_call`, `count`, `min_count`, `max_count`, `arguments_contain` JSON fragments, `ordered_tools`, and `order_mode` (`subsequence` or `exact`). Raw tool arguments are not copied into scorecard evidence.
 
 ## Metrics (`metrics[]`)
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/eval-spec-builder.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/eval-spec-builder.tsx
@@ -31,7 +31,8 @@ type ValidatorType =
   | "regex_match"
   | "json_schema"
   | "json_path_match"
-  | "boolean_assert";
+  | "boolean_assert"
+  | "tool_call_assertion";
 
 type MetricType = "numeric" | "text" | "boolean";
 
@@ -45,7 +46,8 @@ interface ValidatorDeclaration {
   key: string;
   type: ValidatorType;
   target: string;
-  expected_from: string;
+  expected_from?: string;
+  config?: Record<string, unknown>;
 }
 
 interface MetricDeclaration {
@@ -95,11 +97,20 @@ const VALIDATOR_TYPES: { value: ValidatorType; label: string }[] = [
   { value: "json_schema", label: "JSON Schema" },
   { value: "json_path_match", label: "JSON Path Match" },
   { value: "boolean_assert", label: "Boolean Assert" },
+  { value: "tool_call_assertion", label: "Tool Call Assertion" },
 ];
+
+const DEFAULT_TOOL_CALL_ASSERTION_CONFIG = {
+  tool_name: "submit",
+  must_call: true,
+};
+
+function defaultToolCallAssertionConfig(): Record<string, unknown> {
+  return { ...DEFAULT_TOOL_CALL_ASSERTION_CONFIG };
+}
 
 const TARGET_OPTIONS = [
   { value: "final_output", label: "final_output" },
-  { value: "tool_calls", label: "tool_calls" },
   { value: "intermediate_steps", label: "intermediate_steps" },
 ];
 
@@ -298,10 +309,24 @@ function formToSpec(state: FormState): EvaluationSpec {
     name: state.specName,
     version_number: 1,
     judge_mode: "deterministic",
-    validators: state.validators,
+    validators: state.validators.map(normalizeValidatorForSpec),
     metrics: state.metrics,
     scorecard,
   };
+}
+
+function normalizeValidatorForSpec(validator: ValidatorDeclaration): ValidatorDeclaration {
+  const normalized = { ...validator };
+  if (normalized.type === "tool_call_assertion") {
+    normalized.target = "tool_calls";
+    normalized.config = normalized.config ?? defaultToolCallAssertionConfig();
+    delete normalized.expected_from;
+  }
+  return normalized;
+}
+
+function validatorConfigText(validator: ValidatorDeclaration): string {
+  return JSON.stringify(validator.config ?? defaultToolCallAssertionConfig(), null, 2);
 }
 
 // ---------------------------------------------------------------------------
@@ -317,10 +342,14 @@ export function EvalSpecBuilder({ value, onChange }: EvalSpecBuilderProps) {
   const [form, setForm] = useState<FormState>(() => parseIncoming(value));
   const [preset, setPreset] = useState<PresetKey>("custom");
   const [showJson, setShowJson] = useState(false);
+  const [validatorConfigDrafts, setValidatorConfigDrafts] = useState<Record<string, string>>({});
+  const [validatorConfigErrors, setValidatorConfigErrors] = useState<Record<string, string>>({});
 
   // Reparse if the external value changes identity (e.g. server refresh)
   useEffect(() => {
     setForm(parseIncoming(value));
+    setValidatorConfigDrafts({});
+    setValidatorConfigErrors({});
   }, [value]);
 
   // Propagate changes upstream
@@ -371,23 +400,96 @@ export function EvalSpecBuilder({ value, onChange }: EvalSpecBuilderProps) {
   }
 
   function updateValidator(index: number, patch: Partial<ValidatorDeclaration>) {
+    const previousKey = form.validators[index]?.key;
     const validators = form.validators.map((v, i) => {
       if (i !== index) return v;
       const updated = { ...v, ...patch };
       // Auto-generate key from type + (index+1)
       if (patch.type) {
         updated.key = `${patch.type}-${i + 1}`;
+        if (patch.type === "tool_call_assertion") {
+          updated.target = "tool_calls";
+          updated.config = v.type === "tool_call_assertion" && v.config
+            ? v.config
+            : defaultToolCallAssertionConfig();
+          delete updated.expected_from;
+        } else if (v.type === "tool_call_assertion") {
+          updated.target = "final_output";
+          updated.expected_from = "case.expectations.expected_output";
+          delete updated.config;
+        }
       }
       return updated;
     });
+    if (patch.type && previousKey) {
+      clearValidatorConfigState(previousKey);
+    }
     setPreset("custom");
     emit({ ...form, validators });
   }
 
   function removeValidator(index: number) {
+    const removedKey = form.validators[index]?.key;
     const validators = form.validators.filter((_, i) => i !== index);
+    if (removedKey) {
+      clearValidatorConfigState(removedKey);
+    }
     setPreset("custom");
     emit({ ...form, validators });
+  }
+
+  function commitValidatorConfigText(index: number, key: string, text: string) {
+    try {
+      const parsed = JSON.parse(text);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        setValidatorConfigErrors((errors) => ({
+          ...errors,
+          [key]: "Config must be a JSON object.",
+        }));
+        return;
+      }
+      updateValidator(index, { config: parsed as Record<string, unknown> });
+      setValidatorConfigDrafts((drafts) => {
+        const next = { ...drafts };
+        delete next[key];
+        return next;
+      });
+      setValidatorConfigErrors((errors) => {
+        const next = { ...errors };
+        delete next[key];
+        return next;
+      });
+    } catch (err) {
+      setValidatorConfigErrors((errors) => ({
+        ...errors,
+        [key]: err instanceof Error ? err.message : "Config must be valid JSON.",
+      }));
+      return;
+    }
+  }
+
+  function updateValidatorConfigDraft(key: string, text: string) {
+    setValidatorConfigDrafts((drafts) => ({ ...drafts, [key]: text }));
+    setValidatorConfigErrors((errors) => {
+      const next = { ...errors };
+      delete next[key];
+      return next;
+    });
+  }
+
+  function clearValidatorConfigState(key: string) {
+    setValidatorConfigDrafts((drafts) => {
+      if (!(key in drafts)) return drafts;
+      const next = { ...drafts };
+      delete next[key];
+      return next;
+    });
+    setValidatorConfigErrors((errors) => {
+      if (!(key in errors)) return errors;
+      const next = { ...errors };
+      delete next[key];
+      return next;
+    });
   }
 
   // ---- Metric helpers ----
@@ -467,7 +569,9 @@ export function EvalSpecBuilder({ value, onChange }: EvalSpecBuilderProps) {
         </div>
         <div className="space-y-2">
           <label className="text-sm font-medium">Preset Template</label>
-          <Select value={preset} onValueChange={(v) => v && applyPreset(v as PresetKey)}>
+          <Select value={preset} onValueChange={(v: string | null) => {
+            if (v) applyPreset(v as PresetKey);
+          }}>
             <SelectTrigger className="w-full sm:w-44">
               <SelectValue />
             </SelectTrigger>
@@ -547,7 +651,9 @@ export function EvalSpecBuilder({ value, onChange }: EvalSpecBuilderProps) {
 
                 <Select
                   value={v.type}
-                  onValueChange={(val) => val && updateValidator(i, { type: val as ValidatorType })}
+                  onValueChange={(val: string | null) => {
+                    if (val) updateValidator(i, { type: val as ValidatorType });
+                  }}
                 >
                   <SelectTrigger className="w-full sm:w-40">
                     <SelectValue />
@@ -561,33 +667,61 @@ export function EvalSpecBuilder({ value, onChange }: EvalSpecBuilderProps) {
                   </SelectContent>
                 </Select>
 
-                <Select
-                  value={v.target}
-                  onValueChange={(val) => val && updateValidator(i, { target: val })}
-                >
-                  <SelectTrigger className="w-full sm:w-40">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {TARGET_OPTIONS.map((t) => (
-                      <SelectItem key={t.value} value={t.value}>
-                        {t.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                {v.type === "tool_call_assertion" ? (
+                  <Badge variant="secondary" className="shrink-0">
+                    tool_calls
+                  </Badge>
+                ) : (
+                  <Select
+                    value={v.target}
+                    onValueChange={(val: string | null) => {
+                      if (val) updateValidator(i, { target: val });
+                    }}
+                  >
+                    <SelectTrigger className="w-full sm:w-40">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {TARGET_OPTIONS.map((t) => (
+                        <SelectItem key={t.value} value={t.value}>
+                          {t.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
 
-                <div className="flex-1">
-                  <Input
-                    value={v.expected_from}
-                    onChange={(e) => updateValidator(i, { expected_from: e.target.value })}
-                    placeholder="case.expectations.expected_output"
-                    className="text-xs"
-                  />
-                  <p className="mt-1 text-[10px] text-muted-foreground">
-                    Path to expected value in your test case, e.g. <code className="font-mono">case.expectations.your_field</code>
-                  </p>
-                </div>
+                {v.type === "tool_call_assertion" ? (
+                  <div className="flex-1">
+                    <textarea
+                      value={validatorConfigDrafts[v.key] ?? validatorConfigText(v)}
+                      onChange={(e) => updateValidatorConfigDraft(v.key, e.target.value)}
+                      onBlur={(e) => commitValidatorConfigText(i, v.key, e.target.value)}
+                      aria-invalid={Boolean(validatorConfigErrors[v.key])}
+                      className="min-h-24 w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-xs shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring aria-invalid:border-destructive aria-invalid:ring-destructive/30"
+                    />
+                    {validatorConfigErrors[v.key] && (
+                      <p className="mt-1 text-[10px] text-destructive">
+                        {validatorConfigErrors[v.key]}
+                      </p>
+                    )}
+                    <p className="mt-1 text-[10px] text-muted-foreground">
+                      JSON config for tool_name, must_call, count, min_count, max_count, arguments_contain, ordered_tools, and order_mode.
+                    </p>
+                  </div>
+                ) : (
+                  <div className="flex-1">
+                    <Input
+                      value={v.expected_from ?? ""}
+                      onChange={(e) => updateValidator(i, { expected_from: e.target.value })}
+                      placeholder="case.expectations.expected_output"
+                      className="text-xs"
+                    />
+                    <p className="mt-1 text-[10px] text-muted-foreground">
+                      Path to expected value in your test case, e.g. <code className="font-mono">case.expectations.your_field</code>
+                    </p>
+                  </div>
+                )}
               </div>
 
               <Button
@@ -637,7 +771,9 @@ export function EvalSpecBuilder({ value, onChange }: EvalSpecBuilderProps) {
 
                 <Select
                   value={m.collector}
-                  onValueChange={(val) => val && updateMetricCollector(i, val)}
+                  onValueChange={(val: string | null) => {
+                    if (val) updateMetricCollector(i, val);
+                  }}
                 >
                   <SelectTrigger className="w-full sm:w-48">
                     <SelectValue />

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/validator-evidence.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/validator-evidence.tsx
@@ -8,6 +8,7 @@ import type {
   ValidatorJSONSchemaEvidence,
   ValidatorRegexEvidence,
   ValidatorTextCompareEvidence,
+  ValidatorToolCallAssertionEvidence,
 } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
 import {
@@ -29,6 +30,8 @@ export function ValidatorEvidenceView({
       return <JSONSchemaEvidence evidence={evidence} />;
     case "json_path_match":
       return <JSONPathEvidence evidence={evidence} />;
+    case "tool_call_assertion":
+      return <ToolCallAssertionEvidence evidence={evidence} />;
     case "custom":
       return <CustomEvidence evidence={evidence} />;
     default:
@@ -156,6 +159,63 @@ function CustomEvidence({ evidence }: { evidence: ValidatorCustomEvidence }) {
       <EvidenceBlock label="Payload">
         {prettyEvidenceValue(evidence.raw)}
       </EvidenceBlock>
+    </EvidenceSection>
+  );
+}
+
+function ToolCallAssertionEvidence({
+  evidence,
+}: {
+  evidence: ValidatorToolCallAssertionEvidence;
+}) {
+  return (
+    <EvidenceSection title="Tool Call Evidence" sourceField={evidence.source_field}>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {evidence.tool_name && (
+          <EvidenceMeta label="Tool" value={evidence.tool_name} mono />
+        )}
+        {evidence.matched != null && (
+          <EvidenceMeta label="Passed" value={evidence.matched ? "yes" : "no"} />
+        )}
+        {evidence.observed_count != null && (
+          <EvidenceMeta label="Observed" value={String(evidence.observed_count)} mono />
+        )}
+        {evidence.failed_count != null && evidence.failed_count > 0 && (
+          <EvidenceMeta label="Failed" value={String(evidence.failed_count)} mono />
+        )}
+        {evidence.matched_count != null && (
+          <EvidenceMeta label="Matches" value={String(evidence.matched_count)} mono />
+        )}
+        {evidence.expected_count != null && (
+          <EvidenceMeta label="Expected" value={String(evidence.expected_count)} mono />
+        )}
+        {evidence.expected_min_count != null && (
+          <EvidenceMeta label="Min" value={String(evidence.expected_min_count)} mono />
+        )}
+        {evidence.expected_max_count != null && (
+          <EvidenceMeta label="Max" value={String(evidence.expected_max_count)} mono />
+        )}
+        {evidence.expected_order_mode && (
+          <EvidenceMeta label="Order" value={evidence.expected_order_mode} mono />
+        )}
+        {evidence.arguments_contain_set != null && (
+          <EvidenceMeta
+            label="Args"
+            value={evidence.arguments_contain_set ? "fragment" : "not checked"}
+          />
+        )}
+      </div>
+      <EvidenceGrid
+        leftLabel="Observed Tools"
+        leftValue={prettyEvidenceValue(evidence.observed_tool_names)}
+        rightLabel="Expected Order"
+        rightValue={prettyEvidenceValue(evidence.expected_order)}
+      />
+      {evidence.matched_indices && evidence.matched_indices.length > 0 && (
+        <EvidenceBlock label="Matched Indices">
+          {prettyEvidenceValue(evidence.matched_indices)}
+        </EvidenceBlock>
+      )}
     </EvidenceSection>
   );
 }

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -1302,6 +1302,7 @@ export type ValidatorEvidence =
   | ValidatorRegexEvidence
   | ValidatorJSONSchemaEvidence
   | ValidatorJSONPathEvidence
+  | ValidatorToolCallAssertionEvidence
   | ValidatorCustomEvidence;
 
 export interface ValidatorTextCompareEvidence {
@@ -1335,6 +1336,24 @@ export interface ValidatorJSONPathEvidence {
   expected?: unknown;
   exists?: boolean;
   source_field?: string;
+}
+
+export interface ValidatorToolCallAssertionEvidence {
+  kind: "tool_call_assertion";
+  source_field?: string;
+  tool_name?: string;
+  observed_count?: number;
+  failed_count?: number;
+  matched_count?: number;
+  matched_indices?: number[];
+  observed_tool_names?: string[];
+  expected_count?: number;
+  expected_min_count?: number;
+  expected_max_count?: number;
+  expected_order?: string[];
+  expected_order_mode?: string;
+  arguments_contain_set?: boolean;
+  matched?: boolean;
 }
 
 export interface ValidatorCustomEvidence {


### PR DESCRIPTION
## Summary
- Adds deterministic `tool_call_assertion` scoring for recorded tool-call events, including presence/absence, exact/min/max counts, argument JSON fragments, and ordered tool checks.
- Locks the challenge-pack contract with scoring/challengepack/repository tests and safe scorecard evidence that avoids raw tool argument leakage.
- Updates challenge-pack docs/skills plus the playground eval-spec builder so authors can create `tool_call_assertion` validators without `expected_from`.

Closes #706.

## Validation
- `cd backend && go test ./internal/scoring ./internal/challengepack ./internal/repository -run 'TestToolCallAssertion|TestOrderedEvaluationEventsHandlesMixedSequences|TestLoadEvaluationSpecToolCallAssertion|TestParseYAMLAcceptsToolCallAssertionValidator|TestBuildRunAgentScorecardDocumentIncludesToolCallAssertionEvidence' -count=1`
- `cd backend && go test ./...`
- `git diff --check`
- `cd web && /Users/atharva/agentclash/web/node_modules/.bin/eslint 'src/app/(workspace)/workspaces/[workspaceId]/playgrounds/[playgroundId]/components/eval-spec-builder.tsx'` (with existing main-checkout `node_modules` temporarily symlinked into the worktree)
