### PR TITLE
feat: add model alias create flags

### DIFF
--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -496,6 +496,173 @@ func TestInfraProviderAccountListCallsCorrectEndpoint(t *testing.T) {
 	}
 }
 
+func TestInfraModelAliasCreateBuildsRequestBodyFromFlags(t *testing.T) {
+	var called bool
+	var gotBody map[string]any
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/workspaces/ws-1/model-aliases": func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":           "alias-1",
+				"alias_key":    "gpt-5.5",
+				"display_name": "GPT 5.5",
+				"status":       "active",
+			})
+		},
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{
+		"infra", "model-alias", "create",
+		"-w", "ws-1",
+		"--alias-key", "gpt-5.5",
+		"--display-name", "GPT 5.5",
+		"--model-catalog-entry-id", "model-1",
+		"--provider-account-id", "provider-1",
+	}, srv.URL)
+	if err != nil {
+		t.Fatalf("infra model-alias create error: %v", err)
+	}
+	if !called {
+		t.Fatal("POST /v1/workspaces/ws-1/model-aliases was not called")
+	}
+	want := map[string]string{
+		"alias_key":              "gpt-5.5",
+		"display_name":           "GPT 5.5",
+		"model_catalog_entry_id": "model-1",
+		"provider_account_id":    "provider-1",
+	}
+	for key, value := range want {
+		if gotBody[key] != value {
+			t.Fatalf("request body %s = %#v, want %q; body=%#v", key, gotBody[key], value, gotBody)
+		}
+	}
+}
+
+func TestInfraModelAliasCreateMergesFromFileAndFlagOverrides(t *testing.T) {
+	specPath := t.TempDir() + "/model-alias.json"
+	if err := os.WriteFile(specPath, []byte(`{
+		"alias_key": "from-file",
+		"display_name": "From File",
+		"model_catalog_entry_id": "model-file",
+		"provider_account_id": "provider-file"
+	}`), 0o600); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+
+	var gotBody map[string]any
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/workspaces/ws-1/model-aliases": func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":           "alias-1",
+				"alias_key":    "from-flag",
+				"display_name": "From File",
+				"status":       "active",
+			})
+		},
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{
+		"infra", "model-alias", "create",
+		"-w", "ws-1",
+		"--from-file", specPath,
+		"--alias-key", "from-flag",
+		"--provider-account-id", "provider-flag",
+	}, srv.URL)
+	if err != nil {
+		t.Fatalf("infra model-alias create error: %v", err)
+	}
+
+	want := map[string]string{
+		"alias_key":              "from-flag",
+		"display_name":           "From File",
+		"model_catalog_entry_id": "model-file",
+		"provider_account_id":    "provider-flag",
+	}
+	for key, value := range want {
+		if gotBody[key] != value {
+			t.Fatalf("request body %s = %#v, want %q; body=%#v", key, gotBody[key], value, gotBody)
+		}
+	}
+}
+
+func TestInfraModelAliasCreateAllowsOmittingProviderAccount(t *testing.T) {
+	var gotBody map[string]any
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/workspaces/ws-1/model-aliases": func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":           "alias-1",
+				"alias_key":    "gpt-5.5",
+				"display_name": "GPT 5.5",
+				"status":       "active",
+			})
+		},
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{
+		"infra", "model-alias", "create",
+		"-w", "ws-1",
+		"--alias-key", "gpt-5.5",
+		"--display-name", "GPT 5.5",
+		"--model-catalog-entry-id", "model-1",
+	}, srv.URL)
+	if err != nil {
+		t.Fatalf("infra model-alias create error: %v", err)
+	}
+	if _, ok := gotBody["provider_account_id"]; ok {
+		t.Fatalf("provider_account_id should be omitted when not supplied; body=%#v", gotBody)
+	}
+}
+
+func TestInfraModelAliasCreateValidatesRequiredFields(t *testing.T) {
+	var called bool
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/workspaces/ws-1/model-aliases": func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			t.Fatal("request should not be sent when required fields are missing")
+		},
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{
+		"infra", "model-alias", "create",
+		"-w", "ws-1",
+		"--alias-key", "gpt-5.5",
+	}, srv.URL)
+	if err == nil {
+		t.Fatal("expected required field validation error")
+	}
+	for _, want := range []string{"--display-name", "--model-catalog-entry-id"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q should mention %s", err.Error(), want)
+		}
+	}
+	if called {
+		t.Fatal("request was sent despite validation error")
+	}
+}
+
 func TestAPIErrorPropagates(t *testing.T) {
 	srv := fakeAPI(t, map[string]http.HandlerFunc{
 		"GET /v1/organizations": jsonHandler(401, map[string]any{

--- a/cli/cmd/infra.go
+++ b/cli/cmd/infra.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/agentclash/agentclash/cli/internal/output"
 	"github.com/spf13/cobra"
@@ -10,15 +12,15 @@ import (
 
 // infraResource describes a workspace-scoped infrastructure resource for the command factory.
 type infraResource struct {
-	Name       string // e.g. "runtime-profile"
-	Plural     string // e.g. "runtime-profiles"
-	ListPath   string // e.g. "/v1/workspaces/%s/runtime-profiles"
-	CreatePath string // same as ListPath for POST
-	GetPath    string // e.g. "/v1/runtime-profiles/%s" (empty = no get command)
-	DeletePath string // e.g. "/v1/runtime-profiles/%s" (empty = no delete command)
+	Name        string // e.g. "runtime-profile"
+	Plural      string // e.g. "runtime-profiles"
+	ListPath    string // e.g. "/v1/workspaces/%s/runtime-profiles"
+	CreatePath  string // same as ListPath for POST
+	GetPath     string // e.g. "/v1/runtime-profiles/%s" (empty = no get command)
+	DeletePath  string // e.g. "/v1/runtime-profiles/%s" (empty = no delete command)
 	ArchivePath string // e.g. "/v1/runtime-profiles/%s/archive" (empty = no archive command)
-	Columns    []output.Column
-	RowMapper  func(map[string]any) []string
+	Columns     []output.Column
+	RowMapper   func(map[string]any) []string
 }
 
 var infraResources = []infraResource{
@@ -162,6 +164,10 @@ func newInfraResourceCmd(res infraResource) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			applyInfraCreateFlags(cmd, res.Name, body)
+			if err := validateInfraCreateBody(res.Name, body); err != nil {
+				return err
+			}
 
 			resp, err := rc.Client.Post(cmd.Context(), path, body)
 			if err != nil {
@@ -184,6 +190,7 @@ func newInfraResourceCmd(res infraResource) *cobra.Command {
 		},
 	}
 	createCmd.Flags().String("from-file", "", "JSON file with resource spec")
+	addInfraCreateFlags(createCmd, res.Name)
 	parent.AddCommand(createCmd)
 
 	// get (if path provided)
@@ -266,6 +273,53 @@ func newInfraResourceCmd(res infraResource) *cobra.Command {
 	}
 
 	return parent
+}
+
+func addInfraCreateFlags(cmd *cobra.Command, resourceName string) {
+	switch resourceName {
+	case "model-alias":
+		cmd.Flags().String("alias-key", "", "Alias key")
+		cmd.Flags().String("display-name", "", "Display name")
+		cmd.Flags().String("model-catalog-entry-id", "", "Model catalog entry ID")
+		cmd.Flags().String("provider-account-id", "", "Optional provider account ID")
+	}
+}
+
+func applyInfraCreateFlags(cmd *cobra.Command, resourceName string, body map[string]any) {
+	switch resourceName {
+	case "model-alias":
+		setFlagIfChanged(cmd, body, "alias-key", "alias_key")
+		setFlagIfChanged(cmd, body, "display-name", "display_name")
+		setFlagIfChanged(cmd, body, "model-catalog-entry-id", "model_catalog_entry_id")
+		setFlagIfChanged(cmd, body, "provider-account-id", "provider_account_id")
+	}
+}
+
+func validateInfraCreateBody(resourceName string, body map[string]any) error {
+	switch resourceName {
+	case "model-alias":
+		missing := missingStringFields(body, map[string]string{
+			"alias_key":              "--alias-key",
+			"display_name":           "--display-name",
+			"model_catalog_entry_id": "--model-catalog-entry-id",
+		})
+		if len(missing) > 0 {
+			return fmt.Errorf("missing required model-alias fields: %s (set flags or provide them in --from-file)", strings.Join(missing, ", "))
+		}
+	}
+	return nil
+}
+
+func missingStringFields(body map[string]any, fieldFlags map[string]string) []string {
+	missing := make([]string, 0, len(fieldFlags))
+	for field, flagName := range fieldFlags {
+		value, ok := body[field].(string)
+		if !ok || strings.TrimSpace(value) == "" {
+			missing = append(missing, flagName)
+		}
+	}
+	sort.Strings(missing)
+	return missing
 }
 
 // --- Model Catalog (global, not workspace-scoped) ---

--- a/testing/codex-roadmap-693-model-alias-create-flags.md
+++ b/testing/codex-roadmap-693-model-alias-create-flags.md
@@ -1,0 +1,20 @@
+# Roadmap #693: model alias create flags
+
+Issue: #717
+Branch: codex/roadmap-693-model-alias-create-flags
+
+## Change
+
+- Added non-interactive flags to `agentclash infra model-alias create`:
+  - `--alias-key`
+  - `--display-name`
+  - `--model-catalog-entry-id`
+  - `--provider-account-id` (optional, matching the backend create contract)
+- Flags populate the JSON request body sent to `/v1/workspaces/{workspace}/model-aliases`.
+- Existing `--from-file` support is preserved; explicitly supplied flags override matching file fields.
+
+## Verification
+
+- `cd cli && go test ./cmd -run 'TestInfraModelAliasCreateBuildsRequestBodyFromFlags|TestInfraModelAliasCreateMergesFromFileAndFlagOverrides|TestInfraModelAliasCreateAllowsOmittingProviderAccount|TestInfraModelAliasCreateValidatesRequiredFields|TestInfraProviderAccountListCallsCorrectEndpoint|TestInfraModelCatalogListCallsCorrectEndpoint' -count=1`
+- `cd cli && go test ./...`
+- `git diff --check`


### PR DESCRIPTION
Closes #717.

## Summary
- add non-interactive flags to `agentclash infra model-alias create`
- map flags into the model alias create request body while preserving `--from-file` support
- cover request body generation with a CLI fake-server test

## Verification
- `cd cli && go test ./cmd -run 'TestInfraModelAliasCreateBuildsRequestBodyFromFlags|TestInfraProviderAccountListCallsCorrectEndpoint|TestInfraModelCatalogListCallsCorrectEndpoint' -count=1`\n- `cd cli && go test ./...`\n- `git diff --check`