### PR TITLE
feat: add provider account smoke test

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -152,7 +152,7 @@ func main() {
 	orgMembershipManager := api.NewOrgMembershipManager(orgAuthz, repo, emailSender, cfg.FrontendURL, billingManager)
 	wsMembershipManager := api.NewWorkspaceMembershipManager(repo, emailSender, cfg.FrontendURL, billingManager)
 	onboardingManager := api.NewOnboardingManager(repo)
-	infraManager := api.NewInfrastructureManager(repo)
+	infraManager := api.NewInfrastructureManager(repo).WithProviderClient(providerRouter)
 	workspaceSecretsManager := api.NewWorkspaceSecretsManager(repo)
 	cliAuthManager := api.NewCLIAuthManager(repo, logger, cfg.FrontendURL)
 	cliTokenAuth := api.NewCLITokenAuthenticator(repo, logger)

--- a/backend/internal/api/infrastructure.go
+++ b/backend/internal/api/infrastructure.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -31,6 +32,7 @@ type InfrastructureService interface {
 	ListProviderAccounts(ctx context.Context, workspaceID uuid.UUID) ([]repository.ProviderAccountRow, error)
 	GetProviderAccount(ctx context.Context, id uuid.UUID) (repository.ProviderAccountRow, error)
 	DeleteProviderAccount(ctx context.Context, id uuid.UUID) error
+	TestProviderAccount(ctx context.Context, account repository.ProviderAccountRow, input ProviderAccountTestInput) (ProviderAccountTestResult, error)
 
 	// Model Catalog (global, read-only)
 	ListModelCatalog(ctx context.Context) ([]repository.ModelCatalogEntryRow, error)
@@ -86,6 +88,11 @@ type CreateProviderAccountInput struct {
 	CredentialReference string          `json:"credential_reference"`
 	APIKey              string          `json:"api_key"`
 	LimitsConfig        json.RawMessage `json:"limits_config,omitempty"`
+}
+
+type ProviderAccountTestInput struct {
+	Model              string `json:"model,omitempty"`
+	StepTimeoutSeconds int32  `json:"step_timeout_seconds,omitempty"`
 }
 
 func (i *CreateProviderAccountInput) Validate() error {
@@ -193,6 +200,21 @@ type providerAccountResponse struct {
 	CreatedAt           time.Time       `json:"created_at"`
 	UpdatedAt           time.Time       `json:"updated_at"`
 }
+
+type providerAccountTestResponse struct {
+	AccountID       uuid.UUID `json:"account_id"`
+	ProviderKey     string    `json:"provider_key"`
+	Model           string    `json:"model"`
+	ProviderModelID string    `json:"provider_model_id,omitempty"`
+	Passed          bool      `json:"passed"`
+	Status          string    `json:"status"`
+	Code            string    `json:"code,omitempty"`
+	Message         string    `json:"message,omitempty"`
+	Retryable       bool      `json:"retryable,omitempty"`
+	DurationMS      int64     `json:"duration_ms"`
+}
+
+type ProviderAccountTestResult = providerAccountTestResponse
 
 type modelCatalogResponse struct {
 	ID              uuid.UUID       `json:"id"`
@@ -451,6 +473,61 @@ func infraDeleteHandler[Row WorkspaceOwned](
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func testProviderAccountHandler(logger *slog.Logger, authorizer WorkspaceAuthorizer, svc InfrastructureService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "authentication required")
+			return
+		}
+
+		accountID, err := uuid.Parse(chi.URLParam(r, "accountID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "invalid ID")
+			return
+		}
+		account, err := svc.GetProviderAccount(r.Context(), accountID)
+		if err != nil {
+			if isInfraNotFoundErr(err) {
+				writeError(w, http.StatusNotFound, "not_found", "provider account not found")
+				return
+			}
+			logger.Error("get provider account for smoke test failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "failed to get provider account")
+			return
+		}
+		if account.WorkspaceID != nil {
+			if err := AuthorizeWorkspaceAction(r.Context(), authorizer, caller, *account.WorkspaceID, ActionManageInfrastructure); err != nil {
+				writeAuthzError(w, err)
+				return
+			}
+		} else {
+			writeError(w, http.StatusNotFound, "not_found", "provider account not found")
+			return
+		}
+
+		var input ProviderAccountTestInput
+		if r.Body != nil && r.ContentLength != 0 {
+			if err := requireJSONContentType(r); err != nil {
+				writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+				return
+			}
+			if err := json.NewDecoder(r.Body).Decode(&input); err != nil && !errors.Is(err, io.EOF) {
+				writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body")
+				return
+			}
+		}
+
+		result, err := svc.TestProviderAccount(r.Context(), account, input)
+		if err != nil {
+			logger.Error("provider account smoke test failed internally", "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "failed to test provider account")
+			return
+		}
+		writeJSON(w, http.StatusOK, result)
 	}
 }
 

--- a/backend/internal/api/infrastructure_manager.go
+++ b/backend/internal/api/infrastructure_manager.go
@@ -2,9 +2,12 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/agentclash/agentclash/backend/internal/provider"
 	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/google/uuid"
 )
@@ -24,6 +27,7 @@ type InfrastructureRepository interface {
 
 	// Workspace Secrets
 	UpsertWorkspaceSecret(ctx context.Context, params repository.UpsertWorkspaceSecretParams) error
+	LoadWorkspaceSecrets(ctx context.Context, workspaceID uuid.UUID) (map[string]string, error)
 
 	// Model Catalog
 	ListModelCatalogEntries(ctx context.Context) ([]repository.ModelCatalogEntryRow, error)
@@ -58,11 +62,17 @@ type InfrastructureRepository interface {
 }
 
 type InfrastructureManager struct {
-	repo InfrastructureRepository
+	repo           InfrastructureRepository
+	providerClient provider.Client
 }
 
 func NewInfrastructureManager(repo InfrastructureRepository) *InfrastructureManager {
 	return &InfrastructureManager{repo: repo}
+}
+
+func (m *InfrastructureManager) WithProviderClient(client provider.Client) *InfrastructureManager {
+	m.providerClient = client
+	return m
 }
 
 func (m *InfrastructureManager) resolveOrgID(ctx context.Context, workspaceID uuid.UUID) (uuid.UUID, error) {
@@ -153,6 +163,151 @@ func (m *InfrastructureManager) GetProviderAccount(ctx context.Context, id uuid.
 
 func (m *InfrastructureManager) DeleteProviderAccount(ctx context.Context, id uuid.UUID) error {
 	return m.repo.ArchiveProviderAccount(ctx, id)
+}
+
+func (m *InfrastructureManager) TestProviderAccount(ctx context.Context, account repository.ProviderAccountRow, input ProviderAccountTestInput) (ProviderAccountTestResult, error) {
+	model := strings.TrimSpace(input.Model)
+	if model == "" {
+		model = defaultProviderAccountSmokeModel(account.ProviderKey)
+	}
+	result := ProviderAccountTestResult{
+		AccountID:   account.ID,
+		ProviderKey: account.ProviderKey,
+		Model:       model,
+		Passed:      false,
+		Status:      "failed",
+	}
+	startedAt := time.Now()
+
+	if m.providerClient == nil {
+		result.Code = string(provider.FailureCodeUnsupportedProvider)
+		result.Message = "provider smoke test client is not configured"
+		return result, nil
+	}
+	if model == "" {
+		result.Code = string(provider.FailureCodeUnsupportedProvider)
+		result.Message = fmt.Sprintf("no default smoke-test model is configured for provider %q; pass --model", account.ProviderKey)
+		return result, nil
+	}
+	if account.WorkspaceID == nil {
+		result.Code = "invalid_provider_account"
+		result.Message = "provider account is not attached to a workspace"
+		return result, nil
+	}
+	if account.Status != "" && account.Status != "active" {
+		result.Code = "inactive_provider_account"
+		result.Message = fmt.Sprintf("provider account status is %q", account.Status)
+		return result, nil
+	}
+
+	timeout := providerAccountTestTimeout(input.StepTimeoutSeconds)
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	secrets := map[string]string{}
+	if strings.HasPrefix(account.CredentialReference, "workspace-secret://") {
+		loaded, err := m.repo.LoadWorkspaceSecrets(ctx, *account.WorkspaceID)
+		if err != nil {
+			return ProviderAccountTestResult{}, fmt.Errorf("load workspace secrets: %w", err)
+		}
+		secrets = loaded
+	}
+	runCtx = provider.WithWorkspaceSecrets(runCtx, secrets)
+	redactionValues := providerAccountRedactionValues(runCtx, secrets, account.CredentialReference)
+
+	response, err := m.providerClient.InvokeModel(runCtx, provider.Request{
+		ProviderKey:         account.ProviderKey,
+		ProviderAccountID:   account.ID.String(),
+		CredentialReference: account.CredentialReference,
+		Model:               model,
+		TraceMode:           "optional",
+		StepTimeout:         timeout,
+		Messages: []provider.Message{
+			{Role: "user", Content: "Reply with exactly: agentclash-smoke-ok"},
+		},
+	})
+	result.DurationMS = time.Since(startedAt).Milliseconds()
+	if err != nil {
+		return providerAccountFailureResult(result, err, redactionValues, account.CredentialReference), nil
+	}
+
+	result.Passed = true
+	result.Status = "passed"
+	result.ProviderModelID = response.ProviderModelID
+	result.Message = "provider account smoke test passed"
+	return result, nil
+}
+
+func providerAccountTestTimeout(seconds int32) time.Duration {
+	if seconds <= 0 {
+		return 20 * time.Second
+	}
+	if seconds > 30 {
+		return 30 * time.Second
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func defaultProviderAccountSmokeModel(providerKey string) string {
+	switch strings.TrimSpace(providerKey) {
+	case "openai":
+		return "gpt-4.1-mini"
+	case "anthropic":
+		return "claude-haiku-4-5-20251001"
+	case "gemini":
+		return "gemini-2.0-flash"
+	case "xai":
+		return "grok-4-1-fast-reasoning"
+	case "openrouter":
+		return "openai/gpt-4.1-mini"
+	case "mistral":
+		return "mistral-small-latest"
+	default:
+		return ""
+	}
+}
+
+func providerAccountFailureResult(result ProviderAccountTestResult, err error, redactionValues []string, credentialReference string) ProviderAccountTestResult {
+	result.Passed = false
+	result.Status = "failed"
+	if errors.Is(err, context.DeadlineExceeded) {
+		result.Code = string(provider.FailureCodeTimeout)
+		result.Message = "provider account smoke test timed out"
+		return result
+	}
+	if failure, ok := provider.AsFailure(err); ok {
+		result.Code = string(failure.Code)
+		result.Message = sanitizeProviderAccountTestMessage(failure.Message, redactionValues, credentialReference)
+		result.Retryable = failure.Retryable
+		return result
+	}
+	result.Code = string(provider.FailureCodeUnknown)
+	result.Message = sanitizeProviderAccountTestMessage(err.Error(), redactionValues, credentialReference)
+	return result
+}
+
+func providerAccountRedactionValues(ctx context.Context, secrets map[string]string, credentialReference string) []string {
+	values := make([]string, 0, len(secrets)+1)
+	for _, value := range secrets {
+		if value != "" {
+			values = append(values, value)
+		}
+	}
+	if resolved, err := (provider.EnvCredentialResolver{}).Resolve(ctx, credentialReference); err == nil && resolved != "" {
+		values = append(values, resolved)
+	}
+	return values
+}
+
+func sanitizeProviderAccountTestMessage(message string, redactionValues []string, credentialReference string) string {
+	sanitized := message
+	for _, value := range redactionValues {
+		sanitized = strings.ReplaceAll(sanitized, value, "[redacted]")
+	}
+	if credentialReference != "" {
+		sanitized = strings.ReplaceAll(sanitized, credentialReference, "[credential-reference]")
+	}
+	return sanitized
 }
 
 // --------------------------------------------------------------------------

--- a/backend/internal/api/infrastructure_manager_test.go
+++ b/backend/internal/api/infrastructure_manager_test.go
@@ -1,0 +1,216 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+func TestInfrastructureManagerTestProviderAccountSuccess(t *testing.T) {
+	workspaceID := uuid.New()
+	accountID := uuid.New()
+	client := &provider.FakeClient{Response: provider.Response{ProviderModelID: "gpt-4.1-mini"}}
+	repo := &providerAccountTestRepo{
+		secrets: map[string]string{"PROVIDER_OPENAI_API_KEY": "sk-test-secret"},
+	}
+	manager := NewInfrastructureManager(repo).WithProviderClient(client)
+
+	result, err := manager.TestProviderAccount(context.Background(), repository.ProviderAccountRow{
+		ID:                  accountID,
+		WorkspaceID:         &workspaceID,
+		ProviderKey:         "openai",
+		CredentialReference: "workspace-secret://PROVIDER_OPENAI_API_KEY",
+		Status:              "active",
+	}, ProviderAccountTestInput{})
+	if err != nil {
+		t.Fatalf("TestProviderAccount returned error: %v", err)
+	}
+	if !result.Passed || result.Status != "passed" {
+		t.Fatalf("result = %#v, want passed", result)
+	}
+	if len(client.Requests) != 1 {
+		t.Fatalf("provider calls = %d, want 1", len(client.Requests))
+	}
+	request := client.Requests[0]
+	if request.ProviderKey != "openai" || request.ProviderAccountID != accountID.String() {
+		t.Fatalf("request account/provider = %#v", request)
+	}
+	if request.CredentialReference != "workspace-secret://PROVIDER_OPENAI_API_KEY" {
+		t.Fatalf("credential reference = %q", request.CredentialReference)
+	}
+	if request.Model != "gpt-4.1-mini" {
+		t.Fatalf("model = %q, want default openai model", request.Model)
+	}
+}
+
+func TestInfrastructureManagerTestProviderAccountFailureIsSanitized(t *testing.T) {
+	workspaceID := uuid.New()
+	secret := "sk-live-leaky-value"
+	client := &provider.FakeClient{
+		Err: provider.NewFailure("openai", provider.FailureCodeAuth, "bad key "+secret+" from workspace-secret://PROVIDER_OPENAI_API_KEY", false, errors.New("auth")),
+	}
+	repo := &providerAccountTestRepo{
+		secrets: map[string]string{"PROVIDER_OPENAI_API_KEY": secret},
+	}
+	manager := NewInfrastructureManager(repo).WithProviderClient(client)
+
+	result, err := manager.TestProviderAccount(context.Background(), repository.ProviderAccountRow{
+		ID:                  uuid.New(),
+		WorkspaceID:         &workspaceID,
+		ProviderKey:         "openai",
+		CredentialReference: "workspace-secret://PROVIDER_OPENAI_API_KEY",
+		Status:              "active",
+	}, ProviderAccountTestInput{Model: "custom-model"})
+	if err != nil {
+		t.Fatalf("TestProviderAccount returned error: %v", err)
+	}
+	if result.Passed {
+		t.Fatalf("result = %#v, want failed", result)
+	}
+	if result.Code != string(provider.FailureCodeAuth) {
+		t.Fatalf("code = %q, want auth", result.Code)
+	}
+	if strings.Contains(result.Message, secret) || strings.Contains(result.Message, "workspace-secret://") {
+		t.Fatalf("message was not sanitized: %q", result.Message)
+	}
+	if !strings.Contains(result.Message, "[redacted]") || !strings.Contains(result.Message, "[credential-reference]") {
+		t.Fatalf("message missing redaction markers: %q", result.Message)
+	}
+}
+
+func TestInfrastructureManagerTestProviderAccountSanitizesShortWorkspaceSecret(t *testing.T) {
+	workspaceID := uuid.New()
+	secret := "abc"
+	client := &provider.FakeClient{
+		Err: provider.NewFailure("openai", provider.FailureCodeAuth, "bad key "+secret, false, errors.New("auth")),
+	}
+	repo := &providerAccountTestRepo{
+		secrets: map[string]string{"PROVIDER_OPENAI_API_KEY": secret},
+	}
+	manager := NewInfrastructureManager(repo).WithProviderClient(client)
+
+	result, err := manager.TestProviderAccount(context.Background(), repository.ProviderAccountRow{
+		ID:                  uuid.New(),
+		WorkspaceID:         &workspaceID,
+		ProviderKey:         "openai",
+		CredentialReference: "workspace-secret://PROVIDER_OPENAI_API_KEY",
+		Status:              "active",
+	}, ProviderAccountTestInput{})
+	if err != nil {
+		t.Fatalf("TestProviderAccount returned error: %v", err)
+	}
+	if strings.Contains(result.Message, secret) || !strings.Contains(result.Message, "[redacted]") {
+		t.Fatalf("message was not sanitized: %q", result.Message)
+	}
+}
+
+func TestInfrastructureManagerTestProviderAccountSanitizesEnvCredential(t *testing.T) {
+	workspaceID := uuid.New()
+	secret := "env-secret-value"
+	t.Setenv("OPENAI_API_KEY", secret)
+	client := &provider.FakeClient{
+		Err: provider.NewFailure("openai", provider.FailureCodeAuth, "bad key "+secret, false, errors.New("auth")),
+	}
+	manager := NewInfrastructureManager(&providerAccountTestRepo{}).WithProviderClient(client)
+
+	result, err := manager.TestProviderAccount(context.Background(), repository.ProviderAccountRow{
+		ID:                  uuid.New(),
+		WorkspaceID:         &workspaceID,
+		ProviderKey:         "openai",
+		CredentialReference: "env://OPENAI_API_KEY",
+		Status:              "active",
+	}, ProviderAccountTestInput{})
+	if err != nil {
+		t.Fatalf("TestProviderAccount returned error: %v", err)
+	}
+	if strings.Contains(result.Message, secret) || !strings.Contains(result.Message, "[redacted]") {
+		t.Fatalf("message was not sanitized: %q", result.Message)
+	}
+}
+
+type providerAccountTestRepo struct {
+	secrets map[string]string
+}
+
+func (r *providerAccountTestRepo) CreateRuntimeProfile(context.Context, repository.CreateRuntimeProfileParams) (repository.RuntimeProfileRow, error) {
+	return repository.RuntimeProfileRow{}, nil
+}
+func (r *providerAccountTestRepo) GetRuntimeProfileByID(context.Context, uuid.UUID) (repository.RuntimeProfileRow, error) {
+	return repository.RuntimeProfileRow{}, repository.ErrRuntimeProfileNotFound
+}
+func (r *providerAccountTestRepo) ListRuntimeProfilesByWorkspaceID(context.Context, uuid.UUID) ([]repository.RuntimeProfileRow, error) {
+	return nil, nil
+}
+func (r *providerAccountTestRepo) ArchiveRuntimeProfile(context.Context, uuid.UUID) error { return nil }
+func (r *providerAccountTestRepo) CreateProviderAccount(context.Context, repository.CreateProviderAccountParams) (repository.ProviderAccountRow, error) {
+	return repository.ProviderAccountRow{}, nil
+}
+func (r *providerAccountTestRepo) GetProviderAccountByID(context.Context, uuid.UUID) (repository.ProviderAccountRow, error) {
+	return repository.ProviderAccountRow{}, repository.ErrProviderAccountNotFound
+}
+func (r *providerAccountTestRepo) ListProviderAccountsByWorkspaceID(context.Context, uuid.UUID) ([]repository.ProviderAccountRow, error) {
+	return nil, nil
+}
+func (r *providerAccountTestRepo) ArchiveProviderAccount(context.Context, uuid.UUID) error {
+	return nil
+}
+func (r *providerAccountTestRepo) UpsertWorkspaceSecret(context.Context, repository.UpsertWorkspaceSecretParams) error {
+	return nil
+}
+func (r *providerAccountTestRepo) LoadWorkspaceSecrets(context.Context, uuid.UUID) (map[string]string, error) {
+	return r.secrets, nil
+}
+func (r *providerAccountTestRepo) ListModelCatalogEntries(context.Context) ([]repository.ModelCatalogEntryRow, error) {
+	return nil, nil
+}
+func (r *providerAccountTestRepo) GetModelCatalogEntryByID(context.Context, uuid.UUID) (repository.ModelCatalogEntryRow, error) {
+	return repository.ModelCatalogEntryRow{}, repository.ErrModelCatalogNotFound
+}
+func (r *providerAccountTestRepo) CreateModelAlias(context.Context, repository.CreateModelAliasParams) (repository.ModelAliasRow, error) {
+	return repository.ModelAliasRow{}, nil
+}
+func (r *providerAccountTestRepo) GetModelAliasByID(context.Context, uuid.UUID) (repository.ModelAliasRow, error) {
+	return repository.ModelAliasRow{}, repository.ErrModelAliasNotFound
+}
+func (r *providerAccountTestRepo) ListModelAliasesByWorkspaceID(context.Context, uuid.UUID) ([]repository.ModelAliasRow, error) {
+	return nil, nil
+}
+func (r *providerAccountTestRepo) ArchiveModelAlias(context.Context, uuid.UUID) error { return nil }
+func (r *providerAccountTestRepo) CreateTool(context.Context, repository.CreateToolParams) (repository.ToolRow, error) {
+	return repository.ToolRow{}, nil
+}
+func (r *providerAccountTestRepo) GetToolByID(context.Context, uuid.UUID) (repository.ToolRow, error) {
+	return repository.ToolRow{}, repository.ErrToolNotFound
+}
+func (r *providerAccountTestRepo) ListToolsByWorkspaceID(context.Context, uuid.UUID) ([]repository.ToolRow, error) {
+	return nil, nil
+}
+func (r *providerAccountTestRepo) CreateKnowledgeSource(context.Context, repository.CreateKnowledgeSourceParams) (repository.KnowledgeSourceRow, error) {
+	return repository.KnowledgeSourceRow{}, nil
+}
+func (r *providerAccountTestRepo) GetKnowledgeSourceByID(context.Context, uuid.UUID) (repository.KnowledgeSourceRow, error) {
+	return repository.KnowledgeSourceRow{}, repository.ErrKnowledgeSourceNotFound
+}
+func (r *providerAccountTestRepo) ListKnowledgeSourcesByWorkspaceID(context.Context, uuid.UUID) ([]repository.KnowledgeSourceRow, error) {
+	return nil, nil
+}
+func (r *providerAccountTestRepo) CreateRoutingPolicy(context.Context, repository.CreateRoutingPolicyParams) (repository.RoutingPolicyRow, error) {
+	return repository.RoutingPolicyRow{}, nil
+}
+func (r *providerAccountTestRepo) ListRoutingPoliciesByWorkspaceID(context.Context, uuid.UUID) ([]repository.RoutingPolicyRow, error) {
+	return nil, nil
+}
+func (r *providerAccountTestRepo) CreateSpendPolicy(context.Context, repository.CreateSpendPolicyParams) (repository.SpendPolicyRow, error) {
+	return repository.SpendPolicyRow{}, nil
+}
+func (r *providerAccountTestRepo) ListSpendPoliciesByWorkspaceID(context.Context, uuid.UUID) ([]repository.SpendPolicyRow, error) {
+	return nil, nil
+}
+func (r *providerAccountTestRepo) GetOrganizationIDByWorkspaceID(context.Context, uuid.UUID) (uuid.UUID, error) {
+	return uuid.New(), nil
+}

--- a/backend/internal/api/infrastructure_test.go
+++ b/backend/internal/api/infrastructure_test.go
@@ -16,7 +16,9 @@ import (
 
 // stubInfraService implements InfrastructureService for testing.
 type stubInfraService struct {
-	profiles []repository.RuntimeProfileRow
+	profiles           []repository.RuntimeProfileRow
+	providerAccount    repository.ProviderAccountRow
+	providerTestResult ProviderAccountTestResult
 }
 
 func (s stubInfraService) CreateRuntimeProfile(_ context.Context, _ Caller, _ uuid.UUID, _ CreateRuntimeProfileInput) (repository.RuntimeProfileRow, error) {
@@ -41,9 +43,15 @@ func (s stubInfraService) ListProviderAccounts(_ context.Context, _ uuid.UUID) (
 	return nil, nil
 }
 func (s stubInfraService) GetProviderAccount(_ context.Context, _ uuid.UUID) (repository.ProviderAccountRow, error) {
+	if s.providerAccount.ID != uuid.Nil {
+		return s.providerAccount, nil
+	}
 	return repository.ProviderAccountRow{}, repository.ErrProviderAccountNotFound
 }
 func (s stubInfraService) DeleteProviderAccount(_ context.Context, _ uuid.UUID) error { return nil }
+func (s stubInfraService) TestProviderAccount(_ context.Context, _ repository.ProviderAccountRow, _ ProviderAccountTestInput) (ProviderAccountTestResult, error) {
+	return s.providerTestResult, nil
+}
 func (s stubInfraService) ListModelCatalog(_ context.Context) ([]repository.ModelCatalogEntryRow, error) {
 	return nil, nil
 }
@@ -203,6 +211,151 @@ func TestCreateRuntimeProfileRequiresAdminRole(t *testing.T) {
 
 	if recorder.Code != http.StatusForbidden {
 		t.Errorf("expected 403 Forbidden for viewer creating resource, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestProviderAccountTestRequiresAdminRole(t *testing.T) {
+	workspaceID := uuid.New()
+	accountID := uuid.New()
+
+	svc := stubInfraService{
+		providerAccount: repository.ProviderAccountRow{
+			ID:          accountID,
+			WorkspaceID: &workspaceID,
+			ProviderKey: "openai",
+			Status:      "active",
+		},
+		providerTestResult: ProviderAccountTestResult{
+			AccountID:   accountID,
+			ProviderKey: "openai",
+			Model:       "gpt-4.1-mini",
+			Passed:      true,
+			Status:      "passed",
+		},
+	}
+
+	router := newRouter("dev", nil,
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		nil, 0,
+		stubRunCreationService{}, stubRunReadService{}, stubReplayReadService{},
+		stubHostedRunIngestionService{}, nil,
+		stubAgentDeploymentReadService{}, stubChallengePackReadService{},
+		stubAgentBuildService{}, noopReleaseGateService{},
+		nil, nil, nil, nil, nil, nil, nil,
+		svc,
+		nil,
+		nil,
+		nil,
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/provider-accounts/"+accountID.String()+"/test", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(headerUserID, uuid.New().String())
+	req.Header.Set(headerWorkspaceMemberships, workspaceID.String()+":workspace_viewer")
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Errorf("expected 403 Forbidden for viewer testing provider account, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestProviderAccountTestReturnsResult(t *testing.T) {
+	workspaceID := uuid.New()
+	accountID := uuid.New()
+
+	svc := stubInfraService{
+		providerAccount: repository.ProviderAccountRow{
+			ID:          accountID,
+			WorkspaceID: &workspaceID,
+			ProviderKey: "openai",
+			Status:      "active",
+		},
+		providerTestResult: ProviderAccountTestResult{
+			AccountID:   accountID,
+			ProviderKey: "openai",
+			Model:       "gpt-4.1-mini",
+			Passed:      true,
+			Status:      "passed",
+		},
+	}
+
+	router := newRouter("dev", nil,
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		nil, 0,
+		stubRunCreationService{}, stubRunReadService{}, stubReplayReadService{},
+		stubHostedRunIngestionService{}, nil,
+		stubAgentDeploymentReadService{}, stubChallengePackReadService{},
+		stubAgentBuildService{}, noopReleaseGateService{},
+		nil, nil, nil, nil, nil, nil, nil,
+		svc,
+		nil,
+		nil,
+		nil,
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/provider-accounts/"+accountID.String()+"/test", strings.NewReader(`{"model":"gpt-4.1-mini"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(headerUserID, uuid.New().String())
+	req.Header.Set(headerWorkspaceMemberships, workspaceID.String()+":workspace_admin")
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	var result ProviderAccountTestResult
+	if err := json.NewDecoder(recorder.Body).Decode(&result); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if !result.Passed || result.Status != "passed" {
+		t.Fatalf("result = %#v, want passed", result)
+	}
+}
+
+func TestProviderAccountTestHidesGlobalAccounts(t *testing.T) {
+	accountID := uuid.New()
+
+	svc := stubInfraService{
+		providerAccount: repository.ProviderAccountRow{
+			ID:          accountID,
+			ProviderKey: "openai",
+			Status:      "active",
+		},
+	}
+
+	router := newRouter("dev", nil,
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		nil, 0,
+		stubRunCreationService{}, stubRunReadService{}, stubReplayReadService{},
+		stubHostedRunIngestionService{}, nil,
+		stubAgentDeploymentReadService{}, stubChallengePackReadService{},
+		stubAgentBuildService{}, noopReleaseGateService{},
+		nil, nil, nil, nil, nil, nil, nil,
+		svc,
+		nil,
+		nil,
+		nil,
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/provider-accounts/"+accountID.String()+"/test", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(headerUserID, uuid.New().String())
+	req.Header.Set(headerWorkspaceMemberships, uuid.New().String()+":workspace_admin")
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for nil-workspace provider account, got %d: %s", recorder.Code, recorder.Body.String())
 	}
 }
 

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -243,6 +243,7 @@ func registerProtectedRoutes(
 	router.Method("GET", "/workspaces/{workspaceID}/provider-accounts", wsMiddleware(infraListHandler(logger, infraService.ListProviderAccounts, mapProviderAccount)))
 	router.Get("/provider-accounts/{accountID}", infraGetHandler(logger, authorizer, "accountID", infraService.GetProviderAccount, mapProviderAccount, "provider account"))
 	router.Delete("/provider-accounts/{accountID}", infraDeleteHandler(logger, authorizer, "accountID", infraService.GetProviderAccount, infraService.DeleteProviderAccount, "provider account"))
+	router.Post("/provider-accounts/{accountID}/test", testProviderAccountHandler(logger, authorizer, infraService))
 
 	// Model Catalog (global, no workspace scope)
 	router.Get("/model-catalog", listModelCatalogHandler(logger, infraService))

--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -496,6 +496,72 @@ func TestInfraProviderAccountListCallsCorrectEndpoint(t *testing.T) {
 	}
 }
 
+func TestInfraProviderAccountTestCallsSmokeEndpoint(t *testing.T) {
+	var called bool
+	var gotBody map[string]any
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/provider-accounts/pa-1/test": func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"account_id":        "pa-1",
+				"provider_key":      "openai",
+				"model":             "gpt-4.1-mini",
+				"provider_model_id": "gpt-4.1-mini",
+				"passed":            true,
+				"status":            "passed",
+				"message":           "provider account smoke test passed",
+				"duration_ms":       12,
+			})
+		},
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{
+		"infra", "provider-account", "test", "pa-1",
+		"--model", "gpt-4.1-mini",
+		"--timeout-seconds", "7",
+	}, srv.URL)
+	if err != nil {
+		t.Fatalf("infra provider-account test error: %v", err)
+	}
+	if !called {
+		t.Fatal("POST /v1/provider-accounts/pa-1/test was not called")
+	}
+	if gotBody["model"] != "gpt-4.1-mini" || gotBody["step_timeout_seconds"] != float64(7) {
+		t.Fatalf("request body = %#v", gotBody)
+	}
+}
+
+func TestInfraProviderAccountTestReturnsErrorOnFailedSmoke(t *testing.T) {
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/provider-accounts/pa-1/test": jsonHandler(200, map[string]any{
+			"account_id":   "pa-1",
+			"provider_key": "openai",
+			"model":        "gpt-4.1-mini",
+			"passed":       false,
+			"status":       "failed",
+			"code":         "auth",
+			"message":      "bad key [redacted]",
+			"duration_ms":  12,
+		}),
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{"infra", "provider-account", "test", "pa-1"}, srv.URL)
+	if err == nil {
+		t.Fatal("expected error for failed provider account test")
+	}
+	if !strings.Contains(err.Error(), "bad key [redacted]") {
+		t.Fatalf("error = %q, want sanitized failure message", err.Error())
+	}
+}
+
 func TestInfraModelAliasCreateBuildsRequestBodyFromFlags(t *testing.T) {
 	var called bool
 	var gotBody map[string]any

--- a/cli/cmd/infra.go
+++ b/cli/cmd/infra.go
@@ -246,6 +246,7 @@ func newInfraResourceCmd(res infraResource) *cobra.Command {
 		}
 		parent.AddCommand(deleteCmd)
 	}
+	addInfraResourceExtraCommands(parent, res.Name)
 
 	// archive (if path provided)
 	if res.ArchivePath != "" {
@@ -273,6 +274,78 @@ func newInfraResourceCmd(res infraResource) *cobra.Command {
 	}
 
 	return parent
+}
+
+func addInfraResourceExtraCommands(parent *cobra.Command, resourceName string) {
+	switch resourceName {
+	case "provider-account":
+		parent.AddCommand(providerAccountTestCmd())
+	}
+}
+
+func providerAccountTestCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "test <id>",
+		Short: "Smoke test provider account credentials",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rc := GetRunContext(cmd)
+			body := map[string]any{}
+			if cmd.Flags().Changed("model") {
+				model, _ := cmd.Flags().GetString("model")
+				body["model"] = model
+			}
+			if cmd.Flags().Changed("timeout-seconds") {
+				timeoutSeconds, _ := cmd.Flags().GetInt32("timeout-seconds")
+				body["step_timeout_seconds"] = timeoutSeconds
+			}
+
+			resp, err := rc.Client.Post(cmd.Context(), "/v1/provider-accounts/"+args[0]+"/test", body)
+			if err != nil {
+				return err
+			}
+			if apiErr := resp.ParseError(); apiErr != nil {
+				return apiErr
+			}
+
+			var result map[string]any
+			if err := resp.DecodeJSON(&result); err != nil {
+				return err
+			}
+			if rc.Output.IsStructured() {
+				if err := rc.Output.PrintRaw(result); err != nil {
+					return err
+				}
+			} else {
+				printProviderAccountTestResult(rc.Output, result)
+			}
+			if passed, _ := result["passed"].(bool); !passed {
+				return fmt.Errorf("provider account test failed: %s", str(result["message"]))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().String("model", "", "Provider model ID to use for the smoke test")
+	cmd.Flags().Int32("timeout-seconds", 20, "Provider call timeout in seconds, capped by the API")
+	return cmd
+}
+
+func printProviderAccountTestResult(formatter *output.Formatter, result map[string]any) {
+	formatter.PrintDetail("Status", output.StatusColor(str(result["status"])))
+	formatter.PrintDetail("Provider", str(result["provider_key"]))
+	formatter.PrintDetail("Model", str(result["model"]))
+	if providerModel := str(result["provider_model_id"]); providerModel != "" {
+		formatter.PrintDetail("Provider Model", providerModel)
+	}
+	if code := str(result["code"]); code != "" {
+		formatter.PrintDetail("Code", code)
+	}
+	if message := str(result["message"]); message != "" {
+		formatter.PrintDetail("Message", message)
+	}
+	if duration := fmtScore(result["duration_ms"]); duration != "" {
+		formatter.PrintDetail("Duration MS", duration)
+	}
 }
 
 func addInfraCreateFlags(cmd *cobra.Command, resourceName string) {

--- a/testing/codex-roadmap-693-provider-account-test.md
+++ b/testing/codex-roadmap-693-provider-account-test.md
@@ -1,0 +1,19 @@
+# Roadmap #693: provider account smoke test
+
+Issue: #718
+Branch: codex/roadmap-693-provider-account-test
+
+## Change
+
+- Added `POST /v1/provider-accounts/{accountID}/test`.
+- Added `agentclash infra provider-account test <id>`.
+- The smoke test performs one bounded provider invocation with a small prompt.
+- The response omits credential references and raw provider payloads; failure messages are redacted against loaded workspace secret values.
+
+## Verification
+
+- `cd backend && go test ./internal/api -run 'TestInfrastructureManagerTestProviderAccount|TestGetRuntimeProfile' -count=1`
+- `cd cli && go test ./cmd -run 'TestInfraProviderAccountTest|TestInfraProviderAccountListCallsCorrectEndpoint' -count=1`
+- `cd backend && go test ./internal/api ./internal/provider -count=1`
+- `cd cli && go test ./...`
+- `git diff --check`


### PR DESCRIPTION
Closes #718.

## Summary
- add a bounded provider account smoke-test endpoint: `POST /v1/provider-accounts/{accountID}/test`
- wire the API manager to the existing provider router and workspace-secret resolver
- add `agentclash infra provider-account test <id>` with optional `--model` and `--timeout-seconds` flags
- sanitize provider failure messages against loaded workspace secret values and avoid returning credential references/raw provider payloads

## Verification
- `cd backend && go test ./internal/api -run 'TestInfrastructureManagerTestProviderAccount|TestProviderAccountTest' -count=1`\n- `cd cli && go test ./cmd -run 'TestInfraProviderAccountTest|TestInfraProviderAccountListCallsCorrectEndpoint' -count=1`\n- `cd backend && go test ./internal/api ./internal/provider -count=1`\n- `cd backend && go test ./cmd/api-server ./internal/api ./internal/provider -count=1`\n- `cd cli && go test ./...`\n- `cd cli && go run . infra provider-account test --help`\n- `git diff --check`