### PR TITLE
feat: add pack readiness doctor checks

### DIFF
--- a/cli/cmd/doctor.go
+++ b/cli/cmd/doctor.go
@@ -3,13 +3,19 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
 
 	"github.com/agentclash/agentclash/cli/internal/auth"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func init() {
 	rootCmd.AddCommand(doctorCmd)
+	doctorCmd.Flags().String("pack", "", "Challenge pack YAML file to check for run readiness")
 }
 
 type doctorCheck struct {
@@ -19,6 +25,64 @@ type doctorCheck struct {
 	NextStep string         `json:"next_step,omitempty"`
 	Metadata map[string]any `json:"metadata,omitempty"`
 }
+
+type doctorPackBundle struct {
+	Pack struct {
+		Slug   string `yaml:"slug"`
+		Name   string `yaml:"name"`
+		Family string `yaml:"family"`
+	} `yaml:"pack"`
+	Version struct {
+		Number             int                           `yaml:"number"`
+		DeploymentDefaults *doctorPackDeploymentDefaults `yaml:"deployment_defaults"`
+		Sandbox            *doctorPackSandbox            `yaml:"sandbox"`
+		EvaluationSpec     map[string]any                `yaml:"evaluation_spec"`
+	} `yaml:"version"`
+	Tools      map[string]any        `yaml:"tools"`
+	Challenges []doctorPackChallenge `yaml:"challenges"`
+	InputSets  []doctorPackInputSet  `yaml:"input_sets"`
+}
+
+type doctorPackDeploymentDefaults struct {
+	Aliases map[string]string   `yaml:"aliases"`
+	Lineups map[string][]string `yaml:"lineups"`
+}
+
+type doctorPackSandbox struct {
+	EnvVars map[string]string `yaml:"env_vars"`
+}
+
+type doctorPackChallenge struct {
+	Key        string `yaml:"key"`
+	Title      string `yaml:"title"`
+	Category   string `yaml:"category"`
+	Difficulty string `yaml:"difficulty"`
+}
+
+type doctorPackInputSet struct {
+	Key   string                `yaml:"key"`
+	Name  string                `yaml:"name"`
+	Cases []doctorPackInputCase `yaml:"cases"`
+}
+
+type doctorPackInputCase struct {
+	ChallengeKey string `yaml:"challenge_key"`
+	CaseKey      string `yaml:"case_key"`
+	ItemKey      string `yaml:"item_key"`
+}
+
+type doctorWorkspaceSecretSummary struct {
+	Key string `json:"key"`
+}
+
+var (
+	doctorTemplateSecretPattern       = regexp.MustCompile(`\$\{secrets\.([A-Za-z_][A-Za-z0-9_]*)\}`)
+	doctorWorkspaceSecretRefPattern   = regexp.MustCompile(`workspace-secret://([A-Za-z_][A-Za-z0-9_]*)`)
+	doctorDeploymentReadyStatusValues = map[string]struct{}{
+		"active": {},
+		"ready":  {},
+	}
+)
 
 var doctorCmd = &cobra.Command{
 	Use:   "doctor",
@@ -35,8 +99,9 @@ The 'baseline' check is 'info' on a fresh workspace because a baseline can only
 be set after the first eval run completes.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		rc := GetRunContext(cmd)
+		packPath, _ := cmd.Flags().GetString("pack")
 
-		checks := make([]doctorCheck, 0, 6)
+		checks := make([]doctorCheck, 0, 10)
 		appendCheck := func(check doctorCheck) {
 			checks = append(checks, check)
 		}
@@ -81,6 +146,7 @@ be set after the first eval run completes.`,
 				Detail:   "Workspace check skipped until authentication succeeds.",
 				NextStep: "Run `agentclash auth login`, then `agentclash link`.",
 			})
+			appendDoctorPackChecks(cmd, rc, packPath, "", false, appendCheck)
 			return printDoctorResult(rc, checks)
 		}
 
@@ -113,6 +179,7 @@ be set after the first eval run completes.`,
 				Detail:   "Baseline check skipped until a workspace is linked.",
 				NextStep: "Run `agentclash link`.",
 			})
+			appendDoctorPackChecks(cmd, rc, packPath, "", false, appendCheck)
 			return printDoctorResult(rc, checks)
 		}
 
@@ -141,6 +208,7 @@ be set after the first eval run completes.`,
 				Status: "warn",
 				Detail: "Baseline check skipped until workspace is relinked.",
 			})
+			appendDoctorPackChecks(cmd, rc, packPath, workspaceID, false, appendCheck)
 			return printDoctorResult(rc, checks)
 		}
 		if apiErr := resp.ParseError(); apiErr != nil {
@@ -167,6 +235,7 @@ be set after the first eval run completes.`,
 				Status: "warn",
 				Detail: "Baseline check skipped until workspace is relinked.",
 			})
+			appendDoctorPackChecks(cmd, rc, packPath, workspaceID, false, appendCheck)
 			return printDoctorResult(rc, checks)
 		}
 
@@ -256,8 +325,419 @@ be set after the first eval run completes.`,
 			})
 		}
 
+		appendDoctorPackChecks(cmd, rc, packPath, workspaceID, true, appendCheck)
 		return printDoctorResult(rc, checks)
 	},
+}
+
+func appendDoctorPackChecks(cmd *cobra.Command, rc *RunContext, packPath, workspaceID string, remoteReady bool, appendCheck func(doctorCheck)) {
+	packPath = strings.TrimSpace(packPath)
+	if packPath == "" {
+		return
+	}
+
+	data, err := os.ReadFile(packPath)
+	if err != nil {
+		appendCheck(doctorCheck{
+			Name:     "pack_manifest",
+			Status:   "fail",
+			Detail:   fmt.Sprintf("Could not read %s: %v", packPath, err),
+			NextStep: "Pass a readable challenge-pack YAML file to `agentclash doctor --pack`.",
+			Metadata: map[string]any{"path": packPath},
+		})
+		return
+	}
+
+	var bundle doctorPackBundle
+	if err := yaml.Unmarshal(data, &bundle); err != nil {
+		appendCheck(doctorCheck{
+			Name:     "pack_manifest",
+			Status:   "fail",
+			Detail:   fmt.Sprintf("Challenge-pack YAML is invalid: %v", err),
+			NextStep: "Fix the challenge-pack YAML, then rerun `agentclash doctor --pack`.",
+			Metadata: map[string]any{"path": packPath},
+		})
+		return
+	}
+
+	if issues := doctorPackManifestIssues(bundle); len(issues) > 0 {
+		appendCheck(doctorCheck{
+			Name:     "pack_manifest",
+			Status:   "fail",
+			Detail:   "Challenge-pack manifest is missing required fields: " + strings.Join(issues, ", ") + ".",
+			NextStep: "Run `agentclash challenge-pack validate " + packPath + "` for full schema validation.",
+			Metadata: map[string]any{"path": packPath, "missing": issues},
+		})
+		return
+	}
+
+	appendCheck(doctorCheck{
+		Name:   "pack_manifest",
+		Status: "ok",
+		Detail: fmt.Sprintf("%s v%d parsed from %s.", fallbackDisplay(bundle.Pack.Name, bundle.Pack.Slug), bundle.Version.Number, packPath),
+		Metadata: map[string]any{
+			"path":       packPath,
+			"pack_slug":  bundle.Pack.Slug,
+			"pack_name":  bundle.Pack.Name,
+			"version":    bundle.Version.Number,
+			"challenges": len(bundle.Challenges),
+		},
+	})
+
+	appendDoctorPackInputSetCheck(bundle, appendCheck)
+	appendDoctorPackSecretCheck(cmd, rc, bundle, data, workspaceID, remoteReady, appendCheck)
+	appendDoctorPackDeploymentCheck(cmd, rc, bundle, workspaceID, remoteReady, appendCheck)
+}
+
+func doctorPackManifestIssues(bundle doctorPackBundle) []string {
+	var issues []string
+	if strings.TrimSpace(bundle.Pack.Slug) == "" {
+		issues = append(issues, "pack.slug")
+	}
+	if strings.TrimSpace(bundle.Pack.Name) == "" {
+		issues = append(issues, "pack.name")
+	}
+	if strings.TrimSpace(bundle.Pack.Family) == "" {
+		issues = append(issues, "pack.family")
+	}
+	if bundle.Version.Number <= 0 {
+		issues = append(issues, "version.number")
+	}
+	if len(bundle.Challenges) == 0 {
+		issues = append(issues, "challenges")
+	}
+	return issues
+}
+
+func appendDoctorPackInputSetCheck(bundle doctorPackBundle, appendCheck func(doctorCheck)) {
+	if len(bundle.InputSets) == 0 {
+		appendCheck(doctorCheck{
+			Name:     "pack_input_sets",
+			Status:   "warn",
+			Detail:   "Pack declares no input sets; run creation will not have cases to execute.",
+			NextStep: "Add at least one `input_sets` entry with cases.",
+		})
+		return
+	}
+
+	totalCases := 0
+	emptySets := make([]string, 0)
+	for _, inputSet := range bundle.InputSets {
+		totalCases += len(inputSet.Cases)
+		if len(inputSet.Cases) == 0 {
+			emptySets = append(emptySets, fallbackDisplay(inputSet.Key, inputSet.Name))
+		}
+	}
+	if len(emptySets) > 0 {
+		appendCheck(doctorCheck{
+			Name:     "pack_input_sets",
+			Status:   "warn",
+			Detail:   fmt.Sprintf("%d input set(s) have no cases: %s.", len(emptySets), strings.Join(emptySets, ", ")),
+			NextStep: "Add at least one case to every input set before publishing.",
+			Metadata: map[string]any{
+				"empty_input_sets": emptySets,
+				"input_set_count":  len(bundle.InputSets),
+			},
+		})
+		return
+	}
+
+	appendCheck(doctorCheck{
+		Name:   "pack_input_sets",
+		Status: "ok",
+		Detail: fmt.Sprintf("%d input set(s), %d case(s).", len(bundle.InputSets), totalCases),
+		Metadata: map[string]any{
+			"input_set_count": len(bundle.InputSets),
+			"case_count":      totalCases,
+		},
+	})
+}
+
+func appendDoctorPackSecretCheck(cmd *cobra.Command, rc *RunContext, bundle doctorPackBundle, data []byte, workspaceID string, remoteReady bool, appendCheck func(doctorCheck)) {
+	refs := collectDoctorPackSecretRefs(bundle, data)
+	if len(refs) == 0 {
+		appendCheck(doctorCheck{
+			Name:   "pack_secrets",
+			Status: "ok",
+			Detail: "No workspace secret references found.",
+		})
+		return
+	}
+
+	if !remoteReady || strings.TrimSpace(workspaceID) == "" {
+		appendCheck(doctorCheck{
+			Name:     "pack_secrets",
+			Status:   "warn",
+			Detail:   fmt.Sprintf("%d workspace secret reference(s) found; remote secret check skipped until a workspace is linked.", len(refs)),
+			NextStep: "Run `agentclash auth login` and `agentclash link`, then rerun `agentclash doctor --pack`.",
+			Metadata: map[string]any{"referenced": refs},
+		})
+		return
+	}
+
+	available, err := listDoctorWorkspaceSecretKeys(cmd, rc, workspaceID)
+	if err != nil {
+		appendCheck(doctorCheck{
+			Name:     "pack_secrets",
+			Status:   "warn",
+			Detail:   fmt.Sprintf("Could not list workspace secrets: %v", err),
+			NextStep: "Check workspace permissions or run `agentclash secret list`.",
+			Metadata: map[string]any{"referenced": refs},
+		})
+		return
+	}
+
+	missing := missingStrings(refs, available)
+	if len(missing) > 0 {
+		appendCheck(doctorCheck{
+			Name:     "pack_secrets",
+			Status:   "warn",
+			Detail:   fmt.Sprintf("%d referenced workspace secret(s) are missing: %s.", len(missing), strings.Join(missing, ", ")),
+			NextStep: "Create the missing secret(s) with `agentclash secret set <KEY>`.",
+			Metadata: map[string]any{
+				"referenced": refs,
+				"missing":    missing,
+			},
+		})
+		return
+	}
+
+	appendCheck(doctorCheck{
+		Name:   "pack_secrets",
+		Status: "ok",
+		Detail: fmt.Sprintf("%d workspace secret reference(s) exist in the linked workspace.", len(refs)),
+		Metadata: map[string]any{
+			"referenced": refs,
+		},
+	})
+}
+
+func collectDoctorPackSecretRefs(bundle doctorPackBundle, data []byte) []string {
+	seen := map[string]struct{}{}
+	for _, matches := range doctorTemplateSecretPattern.FindAllSubmatch(data, -1) {
+		if len(matches) == 2 {
+			seen[string(matches[1])] = struct{}{}
+		}
+	}
+	for _, matches := range doctorWorkspaceSecretRefPattern.FindAllSubmatch(data, -1) {
+		if len(matches) == 2 {
+			seen[string(matches[1])] = struct{}{}
+		}
+	}
+	if bundle.Version.Sandbox != nil {
+		for _, value := range bundle.Version.Sandbox.EnvVars {
+			for _, matches := range doctorTemplateSecretPattern.FindAllStringSubmatch(value, -1) {
+				if len(matches) == 2 {
+					seen[matches[1]] = struct{}{}
+				}
+			}
+		}
+	}
+	return sortedKeys(seen)
+}
+
+func listDoctorWorkspaceSecretKeys(cmd *cobra.Command, rc *RunContext, workspaceID string) ([]string, error) {
+	resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+workspaceID+"/secrets", nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return nil, apiErr
+	}
+
+	var result struct {
+		Items []doctorWorkspaceSecretSummary `json:"items"`
+	}
+	if err := resp.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+
+	keys := make([]string, 0, len(result.Items))
+	for _, item := range result.Items {
+		if strings.TrimSpace(item.Key) != "" {
+			keys = append(keys, item.Key)
+		}
+	}
+	sort.Strings(keys)
+	return keys, nil
+}
+
+func appendDoctorPackDeploymentCheck(cmd *cobra.Command, rc *RunContext, bundle doctorPackBundle, workspaceID string, remoteReady bool, appendCheck func(doctorCheck)) {
+	defaults := bundle.Version.DeploymentDefaults
+	if defaults == nil || len(defaults.Lineups) == 0 {
+		appendCheck(doctorCheck{
+			Name:     "pack_deployments",
+			Status:   "warn",
+			Detail:   "Pack has no deployment defaults; non-interactive run creation needs deployment flags.",
+			NextStep: "Add `version.deployment_defaults.lineups.default` or pass `--deployments` when creating runs.",
+		})
+		return
+	}
+
+	lineupSelectors := doctorPackResolvedLineups(defaults)
+	if len(lineupSelectors) == 0 {
+		appendCheck(doctorCheck{
+			Name:     "pack_deployments",
+			Status:   "warn",
+			Detail:   "Deployment defaults do not resolve to any selectors.",
+			NextStep: "Add at least one selector under `version.deployment_defaults.lineups.default`.",
+		})
+		return
+	}
+
+	if _, ok := lineupSelectors["default"]; !ok {
+		appendCheck(doctorCheck{
+			Name:     "pack_deployments",
+			Status:   "warn",
+			Detail:   "Deployment defaults do not define a `default` lineup.",
+			NextStep: "Add `version.deployment_defaults.lineups.default` for guided run creation.",
+			Metadata: map[string]any{"lineups": sortedKeysFromSlices(lineupSelectors)},
+		})
+		return
+	}
+
+	totalSelectors := countLineupSelectors(lineupSelectors)
+	if !remoteReady || strings.TrimSpace(workspaceID) == "" {
+		appendCheck(doctorCheck{
+			Name:     "pack_deployments",
+			Status:   "warn",
+			Detail:   fmt.Sprintf("%d deployment selector(s) found; remote deployment check skipped until a workspace is linked.", totalSelectors),
+			NextStep: "Run `agentclash auth login` and `agentclash link`, then rerun `agentclash doctor --pack`.",
+			Metadata: map[string]any{"lineups": lineupSelectors},
+		})
+		return
+	}
+
+	deployments, err := listDeploymentsForWorkflow(cmd, rc, workspaceID)
+	if err != nil {
+		appendCheck(doctorCheck{
+			Name:     "pack_deployments",
+			Status:   "warn",
+			Detail:   fmt.Sprintf("Could not list deployments for pack readiness: %v", err),
+			NextStep: "Check workspace access or API connectivity.",
+			Metadata: map[string]any{"lineups": lineupSelectors},
+		})
+		return
+	}
+
+	missing, unhealthy := doctorPackDeploymentGaps(lineupSelectors, deployments)
+	if len(missing) > 0 || len(unhealthy) > 0 {
+		details := make([]string, 0, 2)
+		if len(missing) > 0 {
+			details = append(details, fmt.Sprintf("missing selectors: %s", strings.Join(missing, ", ")))
+		}
+		if len(unhealthy) > 0 {
+			details = append(details, fmt.Sprintf("not ready: %s", strings.Join(unhealthy, ", ")))
+		}
+		appendCheck(doctorCheck{
+			Name:     "pack_deployments",
+			Status:   "warn",
+			Detail:   "Deployment defaults have readiness gaps (" + strings.Join(details, "; ") + ").",
+			NextStep: "Create or fix the referenced deployment(s), or update `version.deployment_defaults`.",
+			Metadata: map[string]any{
+				"lineups":   lineupSelectors,
+				"missing":   missing,
+				"unhealthy": unhealthy,
+			},
+		})
+		return
+	}
+
+	appendCheck(doctorCheck{
+		Name:     "pack_deployments",
+		Status:   "ok",
+		Detail:   fmt.Sprintf("%d deployment selector(s) across %d lineup(s) resolve in the linked workspace.", totalSelectors, len(lineupSelectors)),
+		Metadata: map[string]any{"lineups": lineupSelectors},
+	})
+}
+
+func doctorPackResolvedLineups(defaults *doctorPackDeploymentDefaults) map[string][]string {
+	lineups := make(map[string][]string, len(defaults.Lineups))
+	for name, selectors := range defaults.Lineups {
+		lineupName := strings.TrimSpace(name)
+		if lineupName == "" {
+			continue
+		}
+		resolved := make([]string, 0, len(selectors))
+		for _, selector := range selectors {
+			selector = strings.TrimSpace(selector)
+			if selector == "" {
+				continue
+			}
+			if replacement := strings.TrimSpace(defaults.Aliases[selector]); replacement != "" {
+				selector = replacement
+			}
+			resolved = append(resolved, selector)
+		}
+		if len(resolved) > 0 {
+			lineups[lineupName] = resolved
+		}
+	}
+	return lineups
+}
+
+func doctorPackDeploymentGaps(lineups map[string][]string, deployments []deploymentWorkflowSummary) ([]string, []string) {
+	missingSet := map[string]struct{}{}
+	unhealthySet := map[string]struct{}{}
+	for _, selectors := range lineups {
+		for _, selector := range selectors {
+			matched, err := matchDeployment(selector, deployments)
+			if err != nil {
+				missingSet[selector] = struct{}{}
+				continue
+			}
+			if !doctorDeploymentIsReady(matched.Status) {
+				unhealthySet[fallbackDisplay(matched.Name, matched.ID)+" ("+matched.Status+")"] = struct{}{}
+			}
+		}
+	}
+	return sortedKeys(missingSet), sortedKeys(unhealthySet)
+}
+
+func doctorDeploymentIsReady(status string) bool {
+	_, ok := doctorDeploymentReadyStatusValues[strings.ToLower(strings.TrimSpace(status))]
+	return ok
+}
+
+func missingStrings(needles, haystack []string) []string {
+	available := make(map[string]struct{}, len(haystack))
+	for _, item := range haystack {
+		available[item] = struct{}{}
+	}
+	var missing []string
+	for _, item := range needles {
+		if _, ok := available[item]; !ok {
+			missing = append(missing, item)
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}
+
+func countLineupSelectors(lineups map[string][]string) int {
+	count := 0
+	for _, selectors := range lineups {
+		count += len(selectors)
+	}
+	return count
+}
+
+func sortedKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedKeysFromSlices(values map[string][]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func validateDoctorAuth(ctx context.Context, rc *RunContext) (*auth.LoginResult, error) {

--- a/cli/cmd/doctor_test.go
+++ b/cli/cmd/doctor_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/agentclash/agentclash/cli/internal/config"
@@ -193,4 +196,218 @@ func TestDoctorReadyWithoutBaselineBookmark(t *testing.T) {
 	if !foundBaselineInfo {
 		t.Fatalf("baseline check missing from doctor output: %#v", payload.Checks)
 	}
+}
+
+func TestDoctorPackReportsMissingDeploymentDefaults(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+
+	if err := config.Save(config.UserConfig{DefaultWorkspace: "ws-1"}); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+	packPath := writeDoctorPack(t, `
+pack:
+  slug: support-eval
+  name: Support Eval
+  family: support
+version:
+  number: 1
+  deployment_defaults:
+    lineups:
+      default: [missing-agent]
+challenges:
+  - key: ticket-1
+    title: Ticket One
+    category: support
+    difficulty: medium
+input_sets:
+  - key: default
+    name: Default
+    cases:
+      - challenge_key: ticket-1
+        case_key: case-1
+`)
+
+	srv := healthyDoctorWorkspaceAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/agent-deployments": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{"id": "dep-1", "name": "prod", "status": "ready"}},
+		}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	err := executeCommand(t, []string{"doctor", "--json", "--pack", packPath}, srv.URL)
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("doctor error = %T (%v), want exit code 1", err, err)
+	}
+
+	payload := decodeDoctorPayload(t, stdout.finish())
+	check := findDoctorCheck(t, payload.Checks, "pack_deployments")
+	if check.Status != "warn" {
+		t.Fatalf("pack_deployments status = %q, want warn; check=%#v", check.Status, check)
+	}
+	if missing, ok := check.Metadata["missing"].([]any); check.Metadata == nil || !ok || len(missing) == 0 {
+		t.Fatalf("pack_deployments missing metadata not populated: %#v", check.Metadata)
+	}
+}
+
+func TestDoctorPackReportsMissingSecrets(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+
+	if err := config.Save(config.UserConfig{DefaultWorkspace: "ws-1"}); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+	packPath := writeDoctorPack(t, `
+pack:
+  slug: support-eval
+  name: Support Eval
+  family: support
+version:
+  number: 1
+  sandbox:
+    env_vars:
+      INVENTORY_TOKEN: "${secrets.INVENTORY_API_KEY}"
+  deployment_defaults:
+    lineups:
+      default: [prod]
+challenges:
+  - key: ticket-1
+    title: Ticket One
+    category: support
+    difficulty: medium
+input_sets:
+  - key: default
+    name: Default
+    cases:
+      - challenge_key: ticket-1
+        case_key: case-1
+`)
+
+	srv := healthyDoctorWorkspaceAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/secrets": jsonHandler(200, map[string]any{"items": []map[string]any{}}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	err := executeCommand(t, []string{"doctor", "--json", "--pack", packPath}, srv.URL)
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("doctor error = %T (%v), want exit code 1", err, err)
+	}
+
+	payload := decodeDoctorPayload(t, stdout.finish())
+	check := findDoctorCheck(t, payload.Checks, "pack_secrets")
+	if check.Status != "warn" {
+		t.Fatalf("pack_secrets status = %q, want warn; check=%#v", check.Status, check)
+	}
+	if missing, ok := check.Metadata["missing"].([]any); check.Metadata == nil || !ok || len(missing) != 1 {
+		t.Fatalf("pack_secrets missing metadata not populated: %#v", check.Metadata)
+	}
+}
+
+func TestDoctorPackReportsInputSetIssues(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+
+	if err := config.Save(config.UserConfig{DefaultWorkspace: "ws-1"}); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+	packPath := writeDoctorPack(t, `
+pack:
+  slug: support-eval
+  name: Support Eval
+  family: support
+version:
+  number: 1
+  deployment_defaults:
+    lineups:
+      default: [prod]
+challenges:
+  - key: ticket-1
+    title: Ticket One
+    category: support
+    difficulty: medium
+input_sets:
+  - key: default
+    name: Default
+    cases: []
+`)
+
+	srv := healthyDoctorWorkspaceAPI(t, nil)
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	err := executeCommand(t, []string{"doctor", "--json", "--pack", packPath}, srv.URL)
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("doctor error = %T (%v), want exit code 1", err, err)
+	}
+
+	payload := decodeDoctorPayload(t, stdout.finish())
+	check := findDoctorCheck(t, payload.Checks, "pack_input_sets")
+	if check.Status != "warn" {
+		t.Fatalf("pack_input_sets status = %q, want warn; check=%#v", check.Status, check)
+	}
+}
+
+type doctorPayload struct {
+	Ready  bool          `json:"ready"`
+	Checks []doctorCheck `json:"checks"`
+}
+
+func healthyDoctorWorkspaceAPI(t *testing.T, overrides map[string]http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	routes := map[string]http.HandlerFunc{
+		"GET /v1/auth/session": jsonHandler(200, map[string]any{
+			"user_id": "user-1",
+			"email":   "dev@example.com",
+		}),
+		"GET /v1/workspaces/ws-1/details": jsonHandler(200, map[string]any{
+			"id": "ws-1", "name": "Alpha", "slug": "alpha",
+		}),
+		"GET /v1/workspaces/ws-1/challenge-packs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{"id": "pack-1", "name": "Support Eval", "slug": "support-eval"}},
+		}),
+		"GET /v1/workspaces/ws-1/agent-deployments": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{"id": "dep-1", "name": "prod", "status": "ready"}},
+		}),
+	}
+	for route, handler := range overrides {
+		routes[route] = handler
+	}
+	return fakeAPI(t, routes)
+}
+
+func writeDoctorPack(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "pack.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+	return path
+}
+
+func decodeDoctorPayload(t *testing.T, body string) doctorPayload {
+	t.Helper()
+	var payload doctorPayload
+	if err := json.Unmarshal([]byte(body), &payload); err != nil {
+		t.Fatalf("Unmarshal() error: %v", err)
+	}
+	return payload
+}
+
+func findDoctorCheck(t *testing.T, checks []doctorCheck, name string) doctorCheck {
+	t.Helper()
+	for _, check := range checks {
+		if check.Name == name {
+			return check
+		}
+	}
+	t.Fatalf("doctor check %q missing from %#v", name, checks)
+	return doctorCheck{}
 }


### PR DESCRIPTION
## Summary
- add `agentclash doctor --pack <yaml>` to parse local challenge-pack manifests
- report pack readiness gaps for input sets, workspace secrets, and deployment defaults
- keep remote checks optional, using the linked workspace when auth/workspace are available

Closes #719.

## Tests
- `cd cli && go test ./cmd -run TestDoctor -count=1`
- `cd cli && go test ./cmd -count=1`
- `cd cli && go build ./...`
- `cd cli && go vet ./...`
- `cd cli && go test -short -race -count=1 ./...`
- `cd cli && go run . doctor --help`
- `git diff --check`