### PR TITLE
fix: address doctor pack review feedback

### DIFF
--- a/cli/cmd/doctor.go
+++ b/cli/cmd/doctor.go
@@ -102,6 +102,8 @@ be set after the first eval run completes.`,
 		packPath, _ := cmd.Flags().GetString("pack")
 
 		checks := make([]doctorCheck, 0, 10)
+		var cachedDeployments []deploymentWorkflowSummary
+		cachedDeploymentsOK := false
 		appendCheck := func(check doctorCheck) {
 			checks = append(checks, check)
 		}
@@ -146,7 +148,7 @@ be set after the first eval run completes.`,
 				Detail:   "Workspace check skipped until authentication succeeds.",
 				NextStep: "Run `agentclash auth login`, then `agentclash link`.",
 			})
-			appendDoctorPackChecks(cmd, rc, packPath, "", false, appendCheck)
+			appendDoctorPackChecks(cmd, rc, packPath, "", false, nil, false, appendCheck)
 			return printDoctorResult(rc, checks)
 		}
 
@@ -179,7 +181,7 @@ be set after the first eval run completes.`,
 				Detail:   "Baseline check skipped until a workspace is linked.",
 				NextStep: "Run `agentclash link`.",
 			})
-			appendDoctorPackChecks(cmd, rc, packPath, "", false, appendCheck)
+			appendDoctorPackChecks(cmd, rc, packPath, "", false, nil, false, appendCheck)
 			return printDoctorResult(rc, checks)
 		}
 
@@ -208,7 +210,7 @@ be set after the first eval run completes.`,
 				Status: "warn",
 				Detail: "Baseline check skipped until workspace is relinked.",
 			})
-			appendDoctorPackChecks(cmd, rc, packPath, workspaceID, false, appendCheck)
+			appendDoctorPackChecks(cmd, rc, packPath, workspaceID, false, nil, false, appendCheck)
 			return printDoctorResult(rc, checks)
 		}
 		if apiErr := resp.ParseError(); apiErr != nil {
@@ -235,7 +237,7 @@ be set after the first eval run completes.`,
 				Status: "warn",
 				Detail: "Baseline check skipped until workspace is relinked.",
 			})
-			appendDoctorPackChecks(cmd, rc, packPath, workspaceID, false, appendCheck)
+			appendDoctorPackChecks(cmd, rc, packPath, workspaceID, false, nil, false, appendCheck)
 			return printDoctorResult(rc, checks)
 		}
 
@@ -288,14 +290,18 @@ be set after the first eval run completes.`,
 				Detail:   fmt.Sprintf("Could not list deployments: %v", deploymentErr),
 				NextStep: "Check workspace access or API connectivity.",
 			})
-		} else if len(deployments) == 0 {
+		} else {
+			cachedDeployments = deployments
+			cachedDeploymentsOK = true
+		}
+		if deploymentErr == nil && len(deployments) == 0 {
 			appendCheck(doctorCheck{
 				Name:     "deployments",
 				Status:   "warn",
 				Detail:   "No deployments are available in this workspace.",
 				NextStep: "Create or deploy an agent before starting an eval.",
 			})
-		} else {
+		} else if deploymentErr == nil {
 			appendCheck(doctorCheck{
 				Name:   "deployments",
 				Status: "ok",
@@ -325,12 +331,12 @@ be set after the first eval run completes.`,
 			})
 		}
 
-		appendDoctorPackChecks(cmd, rc, packPath, workspaceID, true, appendCheck)
+		appendDoctorPackChecks(cmd, rc, packPath, workspaceID, true, cachedDeployments, cachedDeploymentsOK, appendCheck)
 		return printDoctorResult(rc, checks)
 	},
 }
 
-func appendDoctorPackChecks(cmd *cobra.Command, rc *RunContext, packPath, workspaceID string, remoteReady bool, appendCheck func(doctorCheck)) {
+func appendDoctorPackChecks(cmd *cobra.Command, rc *RunContext, packPath, workspaceID string, remoteReady bool, cachedDeployments []deploymentWorkflowSummary, cachedDeploymentsOK bool, appendCheck func(doctorCheck)) {
 	packPath = strings.TrimSpace(packPath)
 	if packPath == "" {
 		return
@@ -385,8 +391,8 @@ func appendDoctorPackChecks(cmd *cobra.Command, rc *RunContext, packPath, worksp
 	})
 
 	appendDoctorPackInputSetCheck(bundle, appendCheck)
-	appendDoctorPackSecretCheck(cmd, rc, bundle, data, workspaceID, remoteReady, appendCheck)
-	appendDoctorPackDeploymentCheck(cmd, rc, bundle, workspaceID, remoteReady, appendCheck)
+	appendDoctorPackSecretCheck(cmd, rc, data, workspaceID, remoteReady, appendCheck)
+	appendDoctorPackDeploymentCheck(cmd, rc, bundle, workspaceID, remoteReady, cachedDeployments, cachedDeploymentsOK, appendCheck)
 }
 
 func doctorPackManifestIssues(bundle doctorPackBundle) []string {
@@ -453,8 +459,8 @@ func appendDoctorPackInputSetCheck(bundle doctorPackBundle, appendCheck func(doc
 	})
 }
 
-func appendDoctorPackSecretCheck(cmd *cobra.Command, rc *RunContext, bundle doctorPackBundle, data []byte, workspaceID string, remoteReady bool, appendCheck func(doctorCheck)) {
-	refs := collectDoctorPackSecretRefs(bundle, data)
+func appendDoctorPackSecretCheck(cmd *cobra.Command, rc *RunContext, data []byte, workspaceID string, remoteReady bool, appendCheck func(doctorCheck)) {
+	refs := collectDoctorPackSecretRefs(data)
 	if len(refs) == 0 {
 		appendCheck(doctorCheck{
 			Name:   "pack_secrets",
@@ -512,7 +518,7 @@ func appendDoctorPackSecretCheck(cmd *cobra.Command, rc *RunContext, bundle doct
 	})
 }
 
-func collectDoctorPackSecretRefs(bundle doctorPackBundle, data []byte) []string {
+func collectDoctorPackSecretRefs(data []byte) []string {
 	seen := map[string]struct{}{}
 	for _, matches := range doctorTemplateSecretPattern.FindAllSubmatch(data, -1) {
 		if len(matches) == 2 {
@@ -522,15 +528,6 @@ func collectDoctorPackSecretRefs(bundle doctorPackBundle, data []byte) []string 
 	for _, matches := range doctorWorkspaceSecretRefPattern.FindAllSubmatch(data, -1) {
 		if len(matches) == 2 {
 			seen[string(matches[1])] = struct{}{}
-		}
-	}
-	if bundle.Version.Sandbox != nil {
-		for _, value := range bundle.Version.Sandbox.EnvVars {
-			for _, matches := range doctorTemplateSecretPattern.FindAllStringSubmatch(value, -1) {
-				if len(matches) == 2 {
-					seen[matches[1]] = struct{}{}
-				}
-			}
 		}
 	}
 	return sortedKeys(seen)
@@ -562,7 +559,7 @@ func listDoctorWorkspaceSecretKeys(cmd *cobra.Command, rc *RunContext, workspace
 	return keys, nil
 }
 
-func appendDoctorPackDeploymentCheck(cmd *cobra.Command, rc *RunContext, bundle doctorPackBundle, workspaceID string, remoteReady bool, appendCheck func(doctorCheck)) {
+func appendDoctorPackDeploymentCheck(cmd *cobra.Command, rc *RunContext, bundle doctorPackBundle, workspaceID string, remoteReady bool, cachedDeployments []deploymentWorkflowSummary, cachedDeploymentsOK bool, appendCheck func(doctorCheck)) {
 	defaults := bundle.Version.DeploymentDefaults
 	if defaults == nil || len(defaults.Lineups) == 0 {
 		appendCheck(doctorCheck{
@@ -591,7 +588,7 @@ func appendDoctorPackDeploymentCheck(cmd *cobra.Command, rc *RunContext, bundle 
 			Status:   "warn",
 			Detail:   "Deployment defaults do not define a `default` lineup.",
 			NextStep: "Add `version.deployment_defaults.lineups.default` for guided run creation.",
-			Metadata: map[string]any{"lineups": sortedKeysFromSlices(lineupSelectors)},
+			Metadata: map[string]any{"lineups": lineupSelectors},
 		})
 		return
 	}
@@ -608,16 +605,20 @@ func appendDoctorPackDeploymentCheck(cmd *cobra.Command, rc *RunContext, bundle 
 		return
 	}
 
-	deployments, err := listDeploymentsForWorkflow(cmd, rc, workspaceID)
-	if err != nil {
-		appendCheck(doctorCheck{
-			Name:     "pack_deployments",
-			Status:   "warn",
-			Detail:   fmt.Sprintf("Could not list deployments for pack readiness: %v", err),
-			NextStep: "Check workspace access or API connectivity.",
-			Metadata: map[string]any{"lineups": lineupSelectors},
-		})
-		return
+	deployments := cachedDeployments
+	if !cachedDeploymentsOK {
+		var err error
+		deployments, err = listDeploymentsForWorkflow(cmd, rc, workspaceID)
+		if err != nil {
+			appendCheck(doctorCheck{
+				Name:     "pack_deployments",
+				Status:   "warn",
+				Detail:   fmt.Sprintf("Could not list deployments for pack readiness: %v", err),
+				NextStep: "Check workspace access or API connectivity.",
+				Metadata: map[string]any{"lineups": lineupSelectors},
+			})
+			return
+		}
 	}
 
 	missing, unhealthy := doctorPackDeploymentGaps(lineupSelectors, deployments)
@@ -723,15 +724,6 @@ func countLineupSelectors(lineups map[string][]string) int {
 }
 
 func sortedKeys(values map[string]struct{}) []string {
-	keys := make([]string, 0, len(values))
-	for key := range values {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	return keys
-}
-
-func sortedKeysFromSlices(values map[string][]string) []string {
 	keys := make([]string, 0, len(values))
 	for key := range values {
 		keys = append(keys, key)

--- a/cli/cmd/doctor_test.go
+++ b/cli/cmd/doctor_test.go
@@ -206,6 +206,7 @@ func TestDoctorPackReportsMissingDeploymentDefaults(t *testing.T) {
 	if err := config.Save(config.UserConfig{DefaultWorkspace: "ws-1"}); err != nil {
 		t.Fatalf("Save() error: %v", err)
 	}
+	deploymentCalls := 0
 	packPath := writeDoctorPack(t, `
 pack:
   slug: support-eval
@@ -230,9 +231,12 @@ input_sets:
 `)
 
 	srv := healthyDoctorWorkspaceAPI(t, map[string]http.HandlerFunc{
-		"GET /v1/workspaces/ws-1/agent-deployments": jsonHandler(200, map[string]any{
-			"items": []map[string]any{{"id": "dep-1", "name": "prod", "status": "ready"}},
-		}),
+		"GET /v1/workspaces/ws-1/agent-deployments": func(w http.ResponseWriter, r *http.Request) {
+			deploymentCalls++
+			jsonHandler(200, map[string]any{
+				"items": []map[string]any{{"id": "dep-1", "name": "prod", "status": "ready"}},
+			})(w, r)
+		},
 	})
 	defer srv.Close()
 
@@ -250,6 +254,9 @@ input_sets:
 	}
 	if missing, ok := check.Metadata["missing"].([]any); check.Metadata == nil || !ok || len(missing) == 0 {
 		t.Fatalf("pack_deployments missing metadata not populated: %#v", check.Metadata)
+	}
+	if deploymentCalls != 1 {
+		t.Fatalf("deployment endpoint called %d times, want 1", deploymentCalls)
 	}
 }
 
@@ -352,6 +359,58 @@ input_sets:
 	check := findDoctorCheck(t, payload.Checks, "pack_input_sets")
 	if check.Status != "warn" {
 		t.Fatalf("pack_input_sets status = %q, want warn; check=%#v", check.Status, check)
+	}
+}
+
+func TestDoctorPackNoDefaultLineupUsesLineupsMapMetadata(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+
+	if err := config.Save(config.UserConfig{DefaultWorkspace: "ws-1"}); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+	packPath := writeDoctorPack(t, `
+pack:
+  slug: support-eval
+  name: Support Eval
+  family: support
+version:
+  number: 1
+  deployment_defaults:
+    lineups:
+      smoke: [prod]
+challenges:
+  - key: ticket-1
+    title: Ticket One
+    category: support
+    difficulty: medium
+input_sets:
+  - key: default
+    name: Default
+    cases:
+      - challenge_key: ticket-1
+        case_key: case-1
+`)
+
+	srv := healthyDoctorWorkspaceAPI(t, nil)
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	err := executeCommand(t, []string{"doctor", "--json", "--pack", packPath}, srv.URL)
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("doctor error = %T (%v), want exit code 1", err, err)
+	}
+
+	payload := decodeDoctorPayload(t, stdout.finish())
+	check := findDoctorCheck(t, payload.Checks, "pack_deployments")
+	if check.Status != "warn" {
+		t.Fatalf("pack_deployments status = %q, want warn; check=%#v", check.Status, check)
+	}
+	lineups, ok := check.Metadata["lineups"].(map[string]any)
+	if check.Metadata == nil || !ok || len(lineups) != 1 {
+		t.Fatalf("lineups metadata = %#v, want object map", check.Metadata["lineups"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep `pack_deployments.metadata.lineups` consistently shaped as a lineup map
- reuse the deployment list already loaded by `doctor` so `doctor --pack` does not duplicate the deployments request
- remove the redundant sandbox env-var secret scan now that raw YAML scanning covers it

Follow-up to Greptile review on #742.

## Tests
- `cd cli && go test ./cmd -run TestDoctorPack -count=1`
- `cd cli && go test ./cmd -count=1`
- `cd cli && go vet ./...`
- `cd cli && go test -short -race -count=1 ./...`
- `git diff --check`