### PR TITLE
test: tighten doctor pack lineup assertion

### DIFF
--- a/cli/cmd/doctor_test.go
+++ b/cli/cmd/doctor_test.go
@@ -412,6 +412,10 @@ input_sets:
 	if check.Metadata == nil || !ok || len(lineups) != 1 {
 		t.Fatalf("lineups metadata = %#v, want object map", check.Metadata["lineups"])
 	}
+	smoke, ok := lineups["smoke"].([]any)
+	if !ok || len(smoke) != 1 || smoke[0] != "prod" {
+		t.Fatalf("lineups[smoke] = %#v, want [prod]", lineups["smoke"])
+	}
 }
 
 type doctorPayload struct {


### PR DESCRIPTION
## Summary
- tighten the no-default-lineup doctor test to assert the `smoke` lineup key and `[prod]` selector contents

Follow-up to Greptile review on #743.

## Tests
- `cd cli && go test ./cmd -run TestDoctorPackNoDefaultLineupUsesLineupsMapMetadata -count=1`
- `cd cli && go test ./cmd -count=1`
- `cd cli && go vet ./...`
- `git diff --check`