### PR TITLE
feat: add postcondition validator

### DIFF
--- a/backend/internal/scoring/engine_validators.go
+++ b/backend/internal/scoring/engine_validators.go
@@ -27,6 +27,10 @@ func evaluateValidators(validators []ValidatorDeclaration, evidence extractedEvi
 			results = append(results, evaluateToolCallAssertionValidator(result, validator, evidence))
 			continue
 		}
+		if validator.Type == ValidatorTypePostcondition {
+			results = append(results, evaluatePostconditionValidator(result, validator, evidence))
+			continue
+		}
 
 		// Resolve the target (actual) evidence.
 		actualValue, actualChallengeID, actualReason, actualErr := resolveEvidenceValue(validator.Target, evidence)

--- a/backend/internal/scoring/loader_test.go
+++ b/backend/internal/scoring/loader_test.go
@@ -724,6 +724,41 @@ func TestLoadEvaluationSpecAcceptsCodeExecutionValidator(t *testing.T) {
 	}
 }
 
+func TestLoadEvaluationSpecAcceptsPostconditionValidator(t *testing.T) {
+	spec, err := LoadEvaluationSpec(json.RawMessage(`{
+		"evaluation_spec": {
+			"name": "postcondition",
+			"version_number": 1,
+			"judge_mode": "deterministic",
+			"validators": [
+				{
+					"key": "output_ok",
+					"type": "postcondition",
+					"target": "file:output_file",
+					"config": {
+						"condition": "json_path_match",
+						"json_path": "$.status",
+						"value": "ok"
+					}
+				}
+			],
+			"post_execution_checks": [
+				{"key": "output_file", "type": "file_capture", "path": "/workspace/output.json"}
+			],
+			"scorecard": {
+				"dimensions": ["correctness"]
+			}
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("LoadEvaluationSpec returned error: %v", err)
+	}
+
+	if spec.Validators[0].Type != ValidatorTypePostcondition {
+		t.Fatalf("validator type = %s, want %s", spec.Validators[0].Type, ValidatorTypePostcondition)
+	}
+}
+
 func TestLoadEvaluationSpecRejectsPassAtKCodeExecution(t *testing.T) {
 	_, err := LoadEvaluationSpec(json.RawMessage(`{
 		"evaluation_spec": {

--- a/backend/internal/scoring/postcondition.go
+++ b/backend/internal/scoring/postcondition.go
@@ -120,6 +120,17 @@ func evaluatePostconditionValidator(result ValidatorResult, validator ValidatorD
 		result.ActualValue = stringPtr(*actualValue)
 	}
 
+	if actualValue == nil && postconditionMissingEvidenceUnavailable(actualReason) {
+		result.State = OutputStateUnavailable
+		result.Reason = firstNonEmpty(actualReason, "postcondition target evidence is unavailable")
+		result.RawOutput = mustMarshalJSON(map[string]any{
+			"state":     result.State,
+			"reason":    result.Reason,
+			"target":    validator.Target,
+			"condition": cfg.Condition,
+		})
+		return result
+	}
 	if actualValue == nil && !postconditionCanEvaluateMissing(cfg.Condition) {
 		result.State = OutputStateUnavailable
 		result.Reason = firstNonEmpty(actualReason, "postcondition target evidence is unavailable")
@@ -263,4 +274,8 @@ func decodePostconditionValue(value json.RawMessage) (any, error) {
 
 func postconditionCanEvaluateMissing(condition PostconditionCondition) bool {
 	return condition == PostconditionConditionExists || condition == PostconditionConditionNotExists
+}
+
+func postconditionMissingEvidenceUnavailable(reason string) bool {
+	return strings.Contains(reason, "unavailable")
 }

--- a/backend/internal/scoring/postcondition.go
+++ b/backend/internal/scoring/postcondition.go
@@ -1,0 +1,266 @@
+package scoring
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type PostconditionCondition string
+
+const (
+	PostconditionConditionExists        PostconditionCondition = "exists"
+	PostconditionConditionNotExists     PostconditionCondition = "not_exists"
+	PostconditionConditionContains      PostconditionCondition = "contains"
+	PostconditionConditionNotContains   PostconditionCondition = "not_contains"
+	PostconditionConditionRegexMatch    PostconditionCondition = "regex_match"
+	PostconditionConditionJSONPathMatch PostconditionCondition = "json_path_match"
+	PostconditionConditionEquals        PostconditionCondition = "equals"
+)
+
+type PostconditionConfig struct {
+	Condition PostconditionCondition `json:"condition"`
+	Value     json.RawMessage        `json:"value,omitempty"`
+	JSONPath  string                 `json:"json_path,omitempty"`
+}
+
+func ParsePostconditionConfig(raw json.RawMessage) (PostconditionConfig, error) {
+	var cfg PostconditionConfig
+	if err := strictUnmarshal(raw, &cfg); err != nil {
+		return PostconditionConfig{}, err
+	}
+	cfg.Condition = PostconditionCondition(strings.TrimSpace(string(cfg.Condition)))
+	cfg.JSONPath = strings.TrimSpace(cfg.JSONPath)
+	return cfg, nil
+}
+
+func validatePostconditionConfig(cfg PostconditionConfig, configPath string) ValidationErrors {
+	var errs ValidationErrors
+	switch cfg.Condition {
+	case PostconditionConditionExists, PostconditionConditionNotExists:
+		if postconditionValueConfigured(cfg.Value) {
+			errs = append(errs, ValidationError{Field: configPath + ".value", Message: fmt.Sprintf("must be omitted for %s", cfg.Condition)})
+		}
+		if cfg.JSONPath != "" {
+			errs = append(errs, ValidationError{Field: configPath + ".json_path", Message: fmt.Sprintf("must be omitted for %s", cfg.Condition)})
+		}
+	case PostconditionConditionContains, PostconditionConditionNotContains:
+		if _, err := postconditionStringValue(cfg.Value); err != nil {
+			errs = append(errs, ValidationError{Field: configPath + ".value", Message: "must be a string"})
+		}
+		if cfg.JSONPath != "" {
+			errs = append(errs, ValidationError{Field: configPath + ".json_path", Message: fmt.Sprintf("must be omitted for %s", cfg.Condition)})
+		}
+	case PostconditionConditionRegexMatch:
+		pattern, err := postconditionStringValue(cfg.Value)
+		if err != nil {
+			errs = append(errs, ValidationError{Field: configPath + ".value", Message: "must be a string regex pattern"})
+			break
+		}
+		if _, err := regexp.Compile(pattern); err != nil {
+			errs = append(errs, ValidationError{Field: configPath + ".value", Message: fmt.Sprintf("must be a valid regex: %v", err)})
+		}
+		if cfg.JSONPath != "" {
+			errs = append(errs, ValidationError{Field: configPath + ".json_path", Message: fmt.Sprintf("must be omitted for %s", cfg.Condition)})
+		}
+	case PostconditionConditionJSONPathMatch:
+		if strings.TrimSpace(cfg.JSONPath) == "" {
+			errs = append(errs, ValidationError{Field: configPath + ".json_path", Message: "is required"})
+		}
+		if !postconditionValueConfigured(cfg.Value) {
+			errs = append(errs, ValidationError{Field: configPath + ".value", Message: "is required"})
+		} else if _, err := decodePostconditionValue(cfg.Value); err != nil {
+			errs = append(errs, ValidationError{Field: configPath + ".value", Message: fmt.Sprintf("must be valid JSON: %v", err)})
+		}
+	case PostconditionConditionEquals:
+		if !postconditionValueConfigured(cfg.Value) {
+			errs = append(errs, ValidationError{Field: configPath + ".value", Message: "is required"})
+		} else if _, err := decodePostconditionValue(cfg.Value); err != nil {
+			errs = append(errs, ValidationError{Field: configPath + ".value", Message: fmt.Sprintf("must be valid JSON: %v", err)})
+		}
+		if cfg.JSONPath != "" {
+			errs = append(errs, ValidationError{Field: configPath + ".json_path", Message: fmt.Sprintf("must be omitted for %s", cfg.Condition)})
+		}
+	case "":
+		errs = append(errs, ValidationError{Field: configPath + ".condition", Message: "is required"})
+	default:
+		errs = append(errs, ValidationError{Field: configPath + ".condition", Message: "must be one of exists, not_exists, contains, not_contains, regex_match, json_path_match, equals"})
+	}
+	return errs
+}
+
+func evaluatePostconditionValidator(result ValidatorResult, validator ValidatorDeclaration, evidence extractedEvidence) ValidatorResult {
+	cfg, err := ParsePostconditionConfig(validator.Config)
+	if err != nil {
+		result.State = OutputStateError
+		result.Reason = fmt.Sprintf("parse postcondition config: %v", err)
+		result.RawOutput = mustMarshalJSON(map[string]any{"state": result.State, "reason": result.Reason})
+		return result
+	}
+	if errs := validatePostconditionConfig(cfg, "config"); len(errs) > 0 {
+		result.State = OutputStateError
+		result.Reason = "invalid postcondition config: " + errs.Error()
+		result.RawOutput = mustMarshalJSON(map[string]any{"state": result.State, "reason": result.Reason})
+		return result
+	}
+
+	actualValue, actualChallengeID, actualReason, actualErr := resolveEvidenceValue(validator.Target, evidence)
+	if actualErr != nil {
+		result.State = OutputStateError
+		result.Reason = actualErr.Error()
+		result.RawOutput = mustMarshalJSON(map[string]any{"state": result.State, "reason": result.Reason})
+		return result
+	}
+	result.ChallengeIdentityID = actualChallengeID
+	result.RegressionCaseID = regressionCaseIDForChallenge(evidence, actualChallengeID)
+	result.Source = resolveEvidenceSource(validator.Target, evidence)
+	if actualValue != nil {
+		result.ActualValue = stringPtr(*actualValue)
+	}
+
+	if actualValue == nil && !postconditionCanEvaluateMissing(cfg.Condition) {
+		result.State = OutputStateUnavailable
+		result.Reason = firstNonEmpty(actualReason, "postcondition target evidence is unavailable")
+		result.RawOutput = mustMarshalJSON(map[string]any{
+			"state":     result.State,
+			"reason":    result.Reason,
+			"target":    validator.Target,
+			"condition": cfg.Condition,
+		})
+		return result
+	}
+
+	outcome := applyPostcondition(cfg, actualValue)
+	result.Verdict = outcome.verdict
+	result.NormalizedScore = outcome.normalizedScore
+	result.Reason = outcome.reason
+	if outcome.verdict == "error" {
+		result.State = OutputStateError
+	} else {
+		result.State = OutputStateAvailable
+	}
+	result.RawOutput = mustMarshalJSON(mergeEvidence(map[string]any{
+		"state":            result.State,
+		"verdict":          result.Verdict,
+		"normalized_score": result.NormalizedScore,
+		"reason":           result.Reason,
+		"target":           validator.Target,
+		"condition":        cfg.Condition,
+		"actual_value":     result.ActualValue,
+	}, outcome.evidence))
+	return result
+}
+
+func applyPostcondition(cfg PostconditionConfig, actualValue *string) validatorOutcome {
+	actual := ""
+	if actualValue != nil {
+		actual = *actualValue
+	}
+	switch cfg.Condition {
+	case PostconditionConditionExists:
+		return postconditionBoolOutcome(actualValue != nil, "postcondition target exists", "postcondition target does not exist", nil)
+	case PostconditionConditionNotExists:
+		return postconditionBoolOutcome(actualValue == nil, "postcondition target does not exist", "postcondition target exists", nil)
+	case PostconditionConditionContains:
+		expected, err := postconditionStringValue(cfg.Value)
+		if err != nil {
+			return validatorError("parse postcondition value", err, nil)
+		}
+		return postconditionBoolOutcome(strings.Contains(actual, expected), "target contains expected text", "target does not contain expected text", map[string]any{"expected": expected})
+	case PostconditionConditionNotContains:
+		expected, err := postconditionStringValue(cfg.Value)
+		if err != nil {
+			return validatorError("parse postcondition value", err, nil)
+		}
+		return postconditionBoolOutcome(!strings.Contains(actual, expected), "target does not contain forbidden text", "target contains forbidden text", map[string]any{"forbidden": expected})
+	case PostconditionConditionRegexMatch:
+		pattern, err := postconditionStringValue(cfg.Value)
+		if err != nil {
+			return validatorError("parse postcondition regex", err, nil)
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return validatorError("compile postcondition regex", err, map[string]any{"pattern": pattern})
+		}
+		return postconditionBoolOutcome(re.MatchString(actual), "target matches regex", "target does not match regex", map[string]any{"pattern": pattern})
+	case PostconditionConditionEquals:
+		return applyPostconditionEquals(actual, cfg.Value)
+	case PostconditionConditionJSONPathMatch:
+		return applyPostconditionJSONPath(actual, cfg)
+	default:
+		return validatorOutcome{verdict: "error", reason: fmt.Sprintf("unsupported postcondition condition %q", cfg.Condition)}
+	}
+}
+
+func applyPostconditionEquals(actual string, expectedRaw json.RawMessage) validatorOutcome {
+	expected, err := decodePostconditionValue(expectedRaw)
+	if err != nil {
+		return validatorError("parse postcondition expected value", err, nil)
+	}
+	if expectedString, ok := expected.(string); ok {
+		return postconditionBoolOutcome(actual == expectedString, "target equals expected string", "target does not equal expected string", map[string]any{"expected": expectedString})
+	}
+	actualJSON, err := parseJSONValue(actual)
+	if err != nil {
+		return validatorError("parse postcondition target as JSON", err, nil)
+	}
+	return postconditionBoolOutcome(jsonValuesEqual(actualJSON, expected), "target JSON equals expected value", "target JSON does not equal expected value", map[string]any{"expected": expected})
+}
+
+func applyPostconditionJSONPath(actual string, cfg PostconditionConfig) validatorOutcome {
+	expected, err := decodePostconditionValue(cfg.Value)
+	if err != nil {
+		return validatorError("parse postcondition expected value", err, nil)
+	}
+	expectation := jsonPathExpectation{
+		Path:       cfg.JSONPath,
+		Comparator: jsonPathComparatorEquals,
+		Value:      expected,
+	}
+	rawExpectation, err := json.Marshal(expectation)
+	if err != nil {
+		return validatorError("encode postcondition json_path expectation", err, nil)
+	}
+	return validateJSONPathMatch(actual, string(rawExpectation))
+}
+
+func postconditionBoolOutcome(pass bool, passReason, failReason string, evidence map[string]any) validatorOutcome {
+	if pass {
+		return validatorOutcome{verdict: "pass", normalizedScore: floatPtr(1), reason: passReason, evidence: evidence}
+	}
+	return validatorOutcome{verdict: "fail", normalizedScore: floatPtr(0), reason: failReason, evidence: evidence}
+}
+
+func postconditionValueConfigured(value json.RawMessage) bool {
+	return len(bytes.TrimSpace(value)) > 0
+}
+
+func postconditionStringValue(value json.RawMessage) (string, error) {
+	if !postconditionValueConfigured(value) {
+		return "", fmt.Errorf("value is required")
+	}
+	var out string
+	if err := json.Unmarshal(value, &out); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func decodePostconditionValue(value json.RawMessage) (any, error) {
+	decoder := json.NewDecoder(bytes.NewReader(value))
+	decoder.UseNumber()
+	var out any
+	if err := decoder.Decode(&out); err != nil {
+		return nil, err
+	}
+	if decoder.More() {
+		return nil, fmt.Errorf("multiple JSON values are not allowed")
+	}
+	return out, nil
+}
+
+func postconditionCanEvaluateMissing(condition PostconditionCondition) bool {
+	return condition == PostconditionConditionExists || condition == PostconditionConditionNotExists
+}

--- a/backend/internal/scoring/postcondition_validator_test.go
+++ b/backend/internal/scoring/postcondition_validator_test.go
@@ -1,0 +1,144 @@
+package scoring
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestEvaluateRunAgent_PostconditionPassFailAndError(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		config      json.RawMessage
+		wantState   OutputState
+		wantVerdict string
+	}{
+		{
+			name:        "contains passes",
+			content:     "workflow completed: ok",
+			config:      json.RawMessage(`{"condition":"contains","value":"ok"}`),
+			wantState:   OutputStateAvailable,
+			wantVerdict: "pass",
+		},
+		{
+			name:        "json path mismatch fails",
+			content:     `{"status":"failed"}`,
+			config:      json.RawMessage(`{"condition":"json_path_match","json_path":"$.status","value":"ok"}`),
+			wantState:   OutputStateAvailable,
+			wantVerdict: "fail",
+		},
+		{
+			name:        "malformed json target errors",
+			content:     `{"status":`,
+			config:      json.RawMessage(`{"condition":"json_path_match","json_path":"$.status","value":"ok"}`),
+			wantState:   OutputStateError,
+			wantVerdict: "error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evaluation := evaluatePostconditionFixture(t, tt.content, tt.config)
+			result := evaluation.ValidatorResults[0]
+			if result.State != tt.wantState {
+				t.Fatalf("state = %q, want %q; result=%#v", result.State, tt.wantState, result)
+			}
+			if result.Verdict != tt.wantVerdict {
+				t.Fatalf("verdict = %q, want %q; result=%#v", result.Verdict, tt.wantVerdict, result)
+			}
+		})
+	}
+}
+
+func TestEvaluateRunAgent_PostconditionNotExistsCanPassOnMissingCapture(t *testing.T) {
+	capturePayload, _ := json.Marshal(FileCaptureResult{
+		Key:    "forbidden_file",
+		Path:   "/workspace/forbidden.txt",
+		Exists: false,
+	})
+
+	evaluation := evaluatePostconditionEvents(t, json.RawMessage(`{"condition":"not_exists"}`), []Event{
+		{Type: "grader.verification.file_captured", OccurredAt: time.Date(2026, 5, 11, 0, 0, 1, 0, time.UTC), Payload: capturePayload},
+		{Type: "system.run.completed", OccurredAt: time.Date(2026, 5, 11, 0, 0, 2, 0, time.UTC), Payload: []byte(`{"final_output":"done"}`)},
+	})
+
+	result := evaluation.ValidatorResults[0]
+	if result.State != OutputStateAvailable || result.Verdict != "pass" {
+		t.Fatalf("result = %#v, want available pass", result)
+	}
+}
+
+func TestValidateEvaluationSpec_PostconditionRejectsExpectedFrom(t *testing.T) {
+	spec := postconditionSpec(json.RawMessage(`{"condition":"exists"}`))
+	spec.Validators[0].ExpectedFrom = "literal:anything"
+	if err := ValidateEvaluationSpec(spec); err == nil {
+		t.Fatal("ValidateEvaluationSpec() error = nil, want expected_from rejection")
+	}
+}
+
+func TestValidateEvaluationSpec_PostconditionRequiresPostExecutionCheck(t *testing.T) {
+	spec := postconditionSpec(json.RawMessage(`{"condition":"exists"}`))
+	spec.PostExecutionChecks = nil
+	if err := ValidateEvaluationSpec(spec); err == nil {
+		t.Fatal("ValidateEvaluationSpec() error = nil, want post_execution_check reference rejection")
+	}
+}
+
+func evaluatePostconditionFixture(t *testing.T, content string, config json.RawMessage) RunAgentEvaluation {
+	t.Helper()
+	capturePayload, err := json.Marshal(FileCaptureResult{
+		Key:     "output_file",
+		Path:    "/workspace/output.json",
+		Exists:  true,
+		Content: content,
+		Size:    int64(len(content)),
+	})
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+	return evaluatePostconditionEvents(t, config, []Event{
+		{Type: "grader.verification.file_captured", OccurredAt: time.Date(2026, 5, 11, 0, 0, 1, 0, time.UTC), Payload: capturePayload},
+		{Type: "system.run.completed", OccurredAt: time.Date(2026, 5, 11, 0, 0, 2, 0, time.UTC), Payload: []byte(`{"final_output":"done"}`)},
+	})
+}
+
+func evaluatePostconditionEvents(t *testing.T, config json.RawMessage, events []Event) RunAgentEvaluation {
+	t.Helper()
+	evaluation, err := EvaluateRunAgent(EvaluationInput{
+		RunAgentID:       uuid.New(),
+		EvaluationSpecID: uuid.New(),
+		Events:           events,
+	}, postconditionSpec(config))
+	if err != nil {
+		t.Fatalf("EvaluateRunAgent() error: %v", err)
+	}
+	if len(evaluation.ValidatorResults) != 1 {
+		t.Fatalf("validator results = %d, want 1", len(evaluation.ValidatorResults))
+	}
+	return evaluation
+}
+
+func postconditionSpec(config json.RawMessage) EvaluationSpec {
+	return EvaluationSpec{
+		Name:          "postcondition-fixture",
+		VersionNumber: 1,
+		JudgeMode:     JudgeModeDeterministic,
+		Validators: []ValidatorDeclaration{
+			{
+				Key:    "output_ok",
+				Type:   ValidatorTypePostcondition,
+				Target: "file:output_file",
+				Config: config,
+			},
+		},
+		PostExecutionChecks: []PostExecutionCheck{
+			{Key: "output_file", Type: PostExecutionCheckTypeFileCapture, Path: "/workspace/output.json"},
+		},
+		Scorecard: ScorecardDeclaration{
+			Dimensions: []DimensionDeclaration{{Key: ScorecardDimensionCorrectness}},
+		},
+	}
+}

--- a/backend/internal/scoring/postcondition_validator_test.go
+++ b/backend/internal/scoring/postcondition_validator_test.go
@@ -2,6 +2,7 @@ package scoring
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -55,8 +56,8 @@ func TestEvaluateRunAgent_PostconditionPassFailAndError(t *testing.T) {
 
 func TestEvaluateRunAgent_PostconditionNotExistsCanPassOnMissingCapture(t *testing.T) {
 	capturePayload, _ := json.Marshal(FileCaptureResult{
-		Key:    "forbidden_file",
-		Path:   "/workspace/forbidden.txt",
+		Key:    "output_file",
+		Path:   "/workspace/output.json",
 		Exists: false,
 	})
 
@@ -68,6 +69,20 @@ func TestEvaluateRunAgent_PostconditionNotExistsCanPassOnMissingCapture(t *testi
 	result := evaluation.ValidatorResults[0]
 	if result.State != OutputStateAvailable || result.Verdict != "pass" {
 		t.Fatalf("result = %#v, want available pass", result)
+	}
+}
+
+func TestEvaluateRunAgent_PostconditionNotExistsUnavailableWhenCaptureMissing(t *testing.T) {
+	evaluation := evaluatePostconditionEvents(t, json.RawMessage(`{"condition":"not_exists"}`), []Event{
+		{Type: "system.run.completed", OccurredAt: time.Date(2026, 5, 11, 0, 0, 2, 0, time.UTC), Payload: []byte(`{"final_output":"done"}`)},
+	})
+
+	result := evaluation.ValidatorResults[0]
+	if result.State != OutputStateUnavailable {
+		t.Fatalf("state = %q, want %q; result=%#v", result.State, OutputStateUnavailable, result)
+	}
+	if result.Verdict != "" {
+		t.Fatalf("verdict = %q, want empty verdict for unavailable evidence", result.Verdict)
 	}
 }
 
@@ -84,6 +99,21 @@ func TestValidateEvaluationSpec_PostconditionRequiresPostExecutionCheck(t *testi
 	spec.PostExecutionChecks = nil
 	if err := ValidateEvaluationSpec(spec); err == nil {
 		t.Fatal("ValidateEvaluationSpec() error = nil, want post_execution_check reference rejection")
+	}
+}
+
+func TestValidateEvaluationSpec_PostconditionUnknownTargetReportedOnce(t *testing.T) {
+	spec := postconditionSpec(json.RawMessage(`{"condition":"exists"}`))
+	spec.Validators[0].Target = "file:missing_key"
+
+	err := ValidateEvaluationSpec(spec)
+	if err == nil {
+		t.Fatal("ValidateEvaluationSpec() error = nil, want post_execution_check reference rejection")
+	}
+	got := err.Error()
+	want := `references unknown post_execution_check key "missing_key"`
+	if count := strings.Count(got, want); count != 1 {
+		t.Fatalf("reference error count = %d, want 1; error=%q", count, got)
 	}
 }
 

--- a/backend/internal/scoring/spec.go
+++ b/backend/internal/scoring/spec.go
@@ -38,6 +38,7 @@ const (
 	ValidatorTypeDirectoryStructure ValidatorType = "directory_structure"
 	ValidatorTypeCodeExecution      ValidatorType = "code_execution"
 	ValidatorTypeToolCallAssertion  ValidatorType = "tool_call_assertion"
+	ValidatorTypePostcondition      ValidatorType = "postcondition"
 )
 
 type MetricType string
@@ -338,7 +339,7 @@ func (t ValidatorType) IsValid() bool {
 		ValidatorTypeMathEquivalence, ValidatorTypeBLEUScore, ValidatorTypeROUGEScore, ValidatorTypeChrFScore,
 		ValidatorTypeFileContentMatch, ValidatorTypeFileExists,
 		ValidatorTypeFileJSONSchema, ValidatorTypeDirectoryStructure,
-		ValidatorTypeCodeExecution, ValidatorTypeToolCallAssertion:
+		ValidatorTypeCodeExecution, ValidatorTypeToolCallAssertion, ValidatorTypePostcondition:
 		return true
 	default:
 		return false
@@ -351,7 +352,7 @@ func (t ValidatorType) IsFileValidator() bool {
 	switch t {
 	case ValidatorTypeFileContentMatch, ValidatorTypeFileExists,
 		ValidatorTypeFileJSONSchema, ValidatorTypeDirectoryStructure,
-		ValidatorTypeCodeExecution:
+		ValidatorTypeCodeExecution, ValidatorTypePostcondition:
 		return true
 	default:
 		return false
@@ -363,7 +364,7 @@ func (t ValidatorType) IsFileValidator() bool {
 // (file_exists, file_json_schema, directory_structure) return false.
 func (t ValidatorType) RequiresExpectedFrom() bool {
 	switch t {
-	case ValidatorTypeFileExists, ValidatorTypeFileJSONSchema, ValidatorTypeDirectoryStructure, ValidatorTypeCodeExecution, ValidatorTypeToolCallAssertion:
+	case ValidatorTypeFileExists, ValidatorTypeFileJSONSchema, ValidatorTypeDirectoryStructure, ValidatorTypeCodeExecution, ValidatorTypeToolCallAssertion, ValidatorTypePostcondition:
 		return false
 	default:
 		return true

--- a/backend/internal/scoring/validation.go
+++ b/backend/internal/scoring/validation.go
@@ -109,8 +109,8 @@ func ValidateEvaluationSpec(spec EvaluationSpec) error {
 			} else if !isSupportedEvidenceReference(validator.ExpectedFrom) {
 				errs = append(errs, ValidationError{Field: path + ".expected_from", Message: "must be a supported evidence reference"})
 			}
-		} else if validator.Type == ValidatorTypeToolCallAssertion && strings.TrimSpace(validator.ExpectedFrom) != "" {
-			errs = append(errs, ValidationError{Field: path + ".expected_from", Message: "must be omitted for tool_call_assertion validators"})
+		} else if (validator.Type == ValidatorTypeToolCallAssertion || validator.Type == ValidatorTypePostcondition) && strings.TrimSpace(validator.ExpectedFrom) != "" {
+			errs = append(errs, ValidationError{Field: path + ".expected_from", Message: fmt.Sprintf("must be omitted for %s validators", validator.Type)})
 		}
 		if validator.Type.IsFileValidator() {
 			if strings.TrimSpace(validator.Target) != "" && !strings.HasPrefix(validator.Target, "file:") {
@@ -125,6 +125,12 @@ func ValidateEvaluationSpec(spec EvaluationSpec) error {
 				errs = append(errs, ValidationError{Field: path + ".target", Message: fmt.Sprintf("references unknown post_execution_check key %q", refKey)})
 			case check.Type != PostExecutionCheckTypeFileCapture:
 				errs = append(errs, ValidationError{Field: path + ".target", Message: fmt.Sprintf("must reference a %s post_execution_check", PostExecutionCheckTypeFileCapture)})
+			}
+		}
+		if validator.Type == ValidatorTypePostcondition {
+			refKey := strings.TrimPrefix(validator.Target, "file:")
+			if _, exists := findPostExecutionCheck(spec.PostExecutionChecks, refKey); !exists {
+				errs = append(errs, ValidationError{Field: path + ".target", Message: fmt.Sprintf("references unknown post_execution_check key %q", refKey)})
 			}
 		}
 	}
@@ -635,12 +641,14 @@ func isSupportedEvidenceReference(value string) bool {
 }
 
 func validateValidatorConfig(validator ValidatorDeclaration, path string) ValidationErrors {
-	if len(validator.Config) == 0 && validator.Type != ValidatorTypeToolCallAssertion {
-		return nil
-	}
-
 	var errs ValidationErrors
 	configPath := path + ".config"
+	if len(validator.Config) == 0 && validator.Type != ValidatorTypeToolCallAssertion {
+		if validator.Type == ValidatorTypePostcondition {
+			return append(errs, ValidationError{Field: configPath, Message: "is required"})
+		}
+		return nil
+	}
 
 	switch validator.Type {
 	case ValidatorTypeFuzzyMatch:
@@ -788,6 +796,13 @@ func validateValidatorConfig(validator ValidatorDeclaration, path string) Valida
 			return errs
 		}
 		errs = append(errs, validateToolCallAssertionConfig(cfg, configPath)...)
+	case ValidatorTypePostcondition:
+		cfg, err := ParsePostconditionConfig(validator.Config)
+		if err != nil {
+			errs = append(errs, ValidationError{Field: configPath, Message: configParseErrorMessage(err)})
+			return errs
+		}
+		errs = append(errs, validatePostconditionConfig(cfg, configPath)...)
 	}
 
 	return errs

--- a/backend/internal/scoring/validation.go
+++ b/backend/internal/scoring/validation.go
@@ -129,7 +129,7 @@ func ValidateEvaluationSpec(spec EvaluationSpec) error {
 		}
 		if validator.Type == ValidatorTypePostcondition {
 			refKey := strings.TrimPrefix(validator.Target, "file:")
-			if _, exists := findPostExecutionCheck(spec.PostExecutionChecks, refKey); !exists {
+			if strings.HasPrefix(validator.Target, "file:") && len(spec.PostExecutionChecks) == 0 {
 				errs = append(errs, ValidationError{Field: path + ".target", Message: fmt.Sprintf("references unknown post_execution_check key %q", refKey)})
 			}
 		}

--- a/web/content/agent-skills/challenge-pack-skills/agentclash-challenge-pack-scoring-validators/SKILL.md
+++ b/web/content/agent-skills/challenge-pack-skills/agentclash-challenge-pack-scoring-validators/SKILL.md
@@ -105,7 +105,7 @@ Fields:
 - `key`: required, trimmed, and unique.
 - `type`: required and must be one of the supported validator types below.
 - `target`: required supported evidence reference.
-- `expected_from`: required for most validators; omitted for `file_exists`, `file_json_schema`, `directory_structure`, `code_execution`, and `tool_call_assertion`.
+- `expected_from`: required for most validators; omitted for `file_exists`, `file_json_schema`, `directory_structure`, `code_execution`, `tool_call_assertion`, and `postcondition`.
 - `config`: optional JSON/YAML object interpreted by the validator type.
 
 There is no validator-level `failure_message`, `pass_message`, or custom result text field. Results emit `state`, `verdict`, `normalized_score`, `reason`, `raw_output`, `target`, `expected_from`, `actual_value`, and `expected_value`; the reason text is produced by the scorer.
@@ -134,6 +134,7 @@ file_json_schema
 directory_structure
 code_execution
 tool_call_assertion
+postcondition
 ```
 
 Do not use `has_json`, `json_equals`, `semantic_match`, `unit_test`, `shell`, or provider-specific names; the validator rejects unknown `type` values.
@@ -152,6 +153,9 @@ Validator `target` and required `expected_from` values must use supported eviden
 - `file:<post_execution_check_key>`
 - `literal:<value>`
 - `tool_calls` (only for `tool_call_assertion`)
+
+## Postconditions
+Use `postcondition` to score post-run captured files or directory listings without shelling out through `code_execution`. It must use `target: file:<post_execution_check_key>` and omit `expected_from`. Its strict `config.condition` supports `exists`, `not_exists`, `contains`, `not_contains`, `regex_match`, `json_path_match`, and `equals`.
 
 ## Tool Call Assertions
 Use `tool_call_assertion` to score executed tool-call traces without asking the final answer to self-report behavior. It must use `target: tool_calls` and does not use `expected_from`.

--- a/web/content/agent-skills/challenge-pack-skills/agentclash-challenge-pack-yaml-author/SKILL.md
+++ b/web/content/agent-skills/challenge-pack-skills/agentclash-challenge-pack-yaml-author/SKILL.md
@@ -250,11 +250,11 @@ evaluation_spec:
 
 Supported `judge_mode` values are `deterministic`, `llm_judge`, and `hybrid`.
 
-Supported validator types include `exact_match`, `contains`, `regex_match`, `json_schema`, `json_path_match`, `boolean_assert`, `fuzzy_match`, `numeric_match`, `normalized_match`, `token_f1`, `math_equivalence`, `bleu_score`, `rouge_score`, `chrf_score`, `file_content_match`, `file_exists`, `file_json_schema`, `directory_structure`, `code_execution`, and `tool_call_assertion`.
+Supported validator types include `exact_match`, `contains`, `regex_match`, `json_schema`, `json_path_match`, `boolean_assert`, `fuzzy_match`, `numeric_match`, `normalized_match`, `token_f1`, `math_equivalence`, `bleu_score`, `rouge_score`, `chrf_score`, `file_content_match`, `file_exists`, `file_json_schema`, `directory_structure`, `code_execution`, `tool_call_assertion`, and `postcondition`.
 
 Evidence references accepted by validators and judges include `final_output`, `run.final_output`, `challenge_input`, `case.payload`, `case.payload.<path>`, `case.inputs.<path>`, `case.expectations.<path>`, `artifact.<path>`, `file:<post_execution_check_key>`, and `literal:<value>`.
 
-File validators require a `file:` target. `code_execution` validators must target a `post_execution_checks` entry of type `file_capture`. `tool_call_assertion` validators must target `tool_calls` and omit `expected_from`.
+File validators require a `file:` target. `code_execution` validators must target a `post_execution_checks` entry of type `file_capture`. `tool_call_assertion` validators must target `tool_calls` and omit `expected_from`. `postcondition` validators target `file:<post_execution_check_key>`, omit `expected_from`, and use `config.condition` for declarative post-run checks.
 
 For `judge_mode: deterministic`, omit `llm_judges`. For `judge_mode: llm_judge`, include at least one judge. For `judge_mode: hybrid`, include validators and at least one judge; hybrid scorecards need a gated dimension.
 

--- a/web/content/docs/challenge-packs/evaluation-spec-reference.mdx
+++ b/web/content/docs/challenge-packs/evaluation-spec-reference.mdx
@@ -33,13 +33,15 @@ Each entry is a `ValidatorDeclaration`:
 
 From `ValidatorType*` constants:
 
-`exact_match`, `contains`, `regex_match`, `json_schema`, `json_path_match`, `boolean_assert`, `fuzzy_match`, `numeric_match`, `normalized_match`, `token_f1`, `math_equivalence`, `bleu_score`, `rouge_score`, `chrf_score`, `file_content_match`, `file_exists`, `file_json_schema`, `directory_structure`, `code_execution`, `tool_call_assertion`
+`exact_match`, `contains`, `regex_match`, `json_schema`, `json_path_match`, `boolean_assert`, `fuzzy_match`, `numeric_match`, `normalized_match`, `token_f1`, `math_equivalence`, `bleu_score`, `rouge_score`, `chrf_score`, `file_content_match`, `file_exists`, `file_json_schema`, `directory_structure`, `code_execution`, `tool_call_assertion`, `postcondition`
 
 File-ish validators gate on sandbox artifacts (see **File validators**: `IsFileValidator()` distinguishes these).
 
-Always check `requires_expected_from`: e.g., `file_exists`, `directory_structure`, `code_execution`, and `tool_call_assertion` can rely on config/paths without `expected_from`.
+Always check `requires_expected_from`: e.g., `file_exists`, `directory_structure`, `code_execution`, `tool_call_assertion`, and `postcondition` can rely on config/paths without `expected_from`.
 
 `tool_call_assertion` uses `target: tool_calls` and strict config to assert executed tool-call evidence. It supports `tool_name`, `must_call`, `count`, `min_count`, `max_count`, `arguments_contain` JSON fragments, `ordered_tools`, and `order_mode` (`subsequence` or `exact`). Raw tool arguments are not copied into scorecard evidence.
+
+`postcondition` uses `target: file:<post_execution_check_key>` and strict config to assert post-run captured evidence without shelling out through `code_execution`. Supported `condition` values are `exists`, `not_exists`, `contains`, `not_contains`, `regex_match`, `json_path_match`, and `equals`.
 
 ## Metrics (`metrics[]`)
 


### PR DESCRIPTION
## Summary
- add a `postcondition` validator type for declarative post-run checks over `file:<post_execution_check_key>` evidence
- support exists/not_exists, contains/not_contains, regex_match, json_path_match, and equals conditions
- validate postcondition config and post_execution_check references in manifest loading
- document the new validator in challenge-pack docs and authoring skills

Closes #707.

## Tests
- `cd backend && go test ./internal/scoring -count=1`
- `cd backend && go test ./internal/scoring ./internal/challengepack -count=1`
- `cd backend && go test ./...`
- `cd backend && go vet ./...`
- `cd backend && go build ./cmd/api-server ./cmd/worker`
- `git diff --check`

## Notes
- Tried `cd web && pnpm test -- docs.test.ts`, but this worktree has no `web/node_modules` (`vitest: command not found`).