### PR TITLE
feat: surface model alias pricing drift

### DIFF
--- a/backend/db/migrations/00045_model_alias_pricing_snapshot.sql
+++ b/backend/db/migrations/00045_model_alias_pricing_snapshot.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+
+ALTER TABLE model_aliases
+ADD COLUMN input_cost_per_million_tokens numeric(18,6),
+ADD COLUMN output_cost_per_million_tokens numeric(18,6);
+
+UPDATE model_aliases ma
+SET input_cost_per_million_tokens = mce.input_cost_per_million_tokens,
+    output_cost_per_million_tokens = mce.output_cost_per_million_tokens
+FROM model_catalog_entries mce
+WHERE ma.model_catalog_entry_id = mce.id;
+
+ALTER TABLE model_aliases
+ALTER COLUMN input_cost_per_million_tokens SET DEFAULT 0,
+ALTER COLUMN input_cost_per_million_tokens SET NOT NULL,
+ALTER COLUMN output_cost_per_million_tokens SET DEFAULT 0,
+ALTER COLUMN output_cost_per_million_tokens SET NOT NULL;
+
+-- +goose Down
+
+ALTER TABLE model_aliases
+DROP COLUMN IF EXISTS output_cost_per_million_tokens,
+DROP COLUMN IF EXISTS input_cost_per_million_tokens;

--- a/backend/db/migrations/00045_model_alias_pricing_snapshot.sql
+++ b/backend/db/migrations/00045_model_alias_pricing_snapshot.sql
@@ -10,6 +10,12 @@ SET input_cost_per_million_tokens = mce.input_cost_per_million_tokens,
 FROM model_catalog_entries mce
 WHERE ma.model_catalog_entry_id = mce.id;
 
+UPDATE model_aliases
+SET input_cost_per_million_tokens = 0,
+    output_cost_per_million_tokens = 0
+WHERE input_cost_per_million_tokens IS NULL
+   OR output_cost_per_million_tokens IS NULL;
+
 ALTER TABLE model_aliases
 ALTER COLUMN input_cost_per_million_tokens SET DEFAULT 0,
 ALTER COLUMN input_cost_per_million_tokens SET NOT NULL,

--- a/backend/internal/api/infrastructure.go
+++ b/backend/internal/api/infrastructure.go
@@ -351,6 +351,10 @@ func infraCreateHandler[Input any, Row any, Resp any](
 				writeError(w, http.StatusConflict, "slug_taken", "a resource with that name already exists")
 				return
 			}
+			if errors.Is(err, repository.ErrModelCatalogNotFound) {
+				writeError(w, http.StatusBadRequest, "validation_error", "model_catalog_entry_id must reference an existing model catalog entry")
+				return
+			}
 			logger.Error("create failed", "error", err)
 			writeError(w, http.StatusInternalServerError, "internal_error", "failed to create resource")
 			return

--- a/backend/internal/api/infrastructure.go
+++ b/backend/internal/api/infrastructure.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
 	"strings"
 	"time"
@@ -217,28 +218,38 @@ type providerAccountTestResponse struct {
 type ProviderAccountTestResult = providerAccountTestResponse
 
 type modelCatalogResponse struct {
-	ID              uuid.UUID       `json:"id"`
-	ProviderKey     string          `json:"provider_key"`
-	ProviderModelID string          `json:"provider_model_id"`
-	DisplayName     string          `json:"display_name"`
-	ModelFamily     string          `json:"model_family"`
-	Modality        string          `json:"modality"`
-	LifecycleStatus string          `json:"lifecycle_status"`
-	Metadata        json.RawMessage `json:"metadata"`
-	CreatedAt       time.Time       `json:"created_at"`
-	UpdatedAt       time.Time       `json:"updated_at"`
+	ID                         uuid.UUID       `json:"id"`
+	ProviderKey                string          `json:"provider_key"`
+	ProviderModelID            string          `json:"provider_model_id"`
+	DisplayName                string          `json:"display_name"`
+	ModelFamily                string          `json:"model_family"`
+	Modality                   string          `json:"modality"`
+	LifecycleStatus            string          `json:"lifecycle_status"`
+	Metadata                   json.RawMessage `json:"metadata"`
+	InputCostPerMillionTokens  float64         `json:"input_cost_per_million_tokens"`
+	OutputCostPerMillionTokens float64         `json:"output_cost_per_million_tokens"`
+	CreatedAt                  time.Time       `json:"created_at"`
+	UpdatedAt                  time.Time       `json:"updated_at"`
 }
 
 type modelAliasResponse struct {
-	ID                  uuid.UUID  `json:"id"`
-	WorkspaceID         *uuid.UUID `json:"workspace_id,omitempty"`
-	ProviderAccountID   *uuid.UUID `json:"provider_account_id,omitempty"`
-	ModelCatalogEntryID uuid.UUID  `json:"model_catalog_entry_id"`
-	AliasKey            string     `json:"alias_key"`
-	DisplayName         string     `json:"display_name"`
-	Status              string     `json:"status"`
-	CreatedAt           time.Time  `json:"created_at"`
-	UpdatedAt           time.Time  `json:"updated_at"`
+	ID                                uuid.UUID  `json:"id"`
+	WorkspaceID                       *uuid.UUID `json:"workspace_id,omitempty"`
+	ProviderAccountID                 *uuid.UUID `json:"provider_account_id,omitempty"`
+	ModelCatalogEntryID               uuid.UUID  `json:"model_catalog_entry_id"`
+	ProviderKey                       string     `json:"provider_key"`
+	ProviderModelID                   string     `json:"provider_model_id"`
+	ModelDisplayName                  string     `json:"model_display_name"`
+	AliasKey                          string     `json:"alias_key"`
+	DisplayName                       string     `json:"display_name"`
+	Status                            string     `json:"status"`
+	InputCostPerMillionTokens         float64    `json:"input_cost_per_million_tokens"`
+	OutputCostPerMillionTokens        float64    `json:"output_cost_per_million_tokens"`
+	CatalogInputCostPerMillionTokens  float64    `json:"catalog_input_cost_per_million_tokens"`
+	CatalogOutputCostPerMillionTokens float64    `json:"catalog_output_cost_per_million_tokens"`
+	PricingDriftWarning               string     `json:"pricing_drift_warning,omitempty"`
+	CreatedAt                         time.Time  `json:"created_at"`
+	UpdatedAt                         time.Time  `json:"updated_at"`
 }
 
 type toolResponse struct {
@@ -569,16 +580,43 @@ func mapModelCatalog(r repository.ModelCatalogEntryRow) modelCatalogResponse {
 		ID: r.ID, ProviderKey: r.ProviderKey, ProviderModelID: r.ProviderModelID,
 		DisplayName: r.DisplayName, ModelFamily: r.ModelFamily, Modality: r.Modality,
 		LifecycleStatus: r.LifecycleStatus, Metadata: r.Metadata,
-		CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+		InputCostPerMillionTokens:  r.InputCostPerMillionTokens,
+		OutputCostPerMillionTokens: r.OutputCostPerMillionTokens,
+		CreatedAt:                  r.CreatedAt, UpdatedAt: r.UpdatedAt,
 	}
 }
 
 func mapModelAlias(r repository.ModelAliasRow) modelAliasResponse {
 	return modelAliasResponse{
 		ID: r.ID, WorkspaceID: r.WorkspaceID, ProviderAccountID: r.ProviderAccountID,
-		ModelCatalogEntryID: r.ModelCatalogEntryID, AliasKey: r.AliasKey, DisplayName: r.DisplayName,
+		ModelCatalogEntryID: r.ModelCatalogEntryID,
+		ProviderKey:         r.CatalogProviderKey, ProviderModelID: r.CatalogProviderModelID, ModelDisplayName: r.CatalogDisplayName,
+		AliasKey: r.AliasKey, DisplayName: r.DisplayName,
 		Status: r.Status, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+		InputCostPerMillionTokens:         r.InputCostPerMillionTokens,
+		OutputCostPerMillionTokens:        r.OutputCostPerMillionTokens,
+		CatalogInputCostPerMillionTokens:  r.CatalogInputCostPerMillionTokens,
+		CatalogOutputCostPerMillionTokens: r.CatalogOutputCostPerMillionTokens,
+		PricingDriftWarning:               modelAliasPricingDriftWarning(r),
 	}
+}
+
+func modelAliasPricingDriftWarning(r repository.ModelAliasRow) string {
+	const epsilon = 1e-9
+	inputDrift := math.Abs(r.InputCostPerMillionTokens-r.CatalogInputCostPerMillionTokens) > epsilon
+	outputDrift := math.Abs(r.OutputCostPerMillionTokens-r.CatalogOutputCostPerMillionTokens) > epsilon
+	if !inputDrift && !outputDrift {
+		return ""
+	}
+	return fmt.Sprintf(
+		"alias pricing differs from current catalog pricing for %s/%s: alias input/output %.6f/%.6f, catalog input/output %.6f/%.6f per 1M tokens",
+		r.CatalogProviderKey,
+		r.CatalogProviderModelID,
+		r.InputCostPerMillionTokens,
+		r.OutputCostPerMillionTokens,
+		r.CatalogInputCostPerMillionTokens,
+		r.CatalogOutputCostPerMillionTokens,
+	)
 }
 
 func mapTool(r repository.ToolRow) toolResponse {

--- a/backend/internal/api/infrastructure_test.go
+++ b/backend/internal/api/infrastructure_test.go
@@ -19,6 +19,7 @@ type stubInfraService struct {
 	profiles           []repository.RuntimeProfileRow
 	providerAccount    repository.ProviderAccountRow
 	providerTestResult ProviderAccountTestResult
+	modelAlias         repository.ModelAliasRow
 }
 
 func (s stubInfraService) CreateRuntimeProfile(_ context.Context, _ Caller, _ uuid.UUID, _ CreateRuntimeProfileInput) (repository.RuntimeProfileRow, error) {
@@ -65,6 +66,9 @@ func (s stubInfraService) ListModelAliases(_ context.Context, _ uuid.UUID) ([]re
 	return nil, nil
 }
 func (s stubInfraService) GetModelAlias(_ context.Context, _ uuid.UUID) (repository.ModelAliasRow, error) {
+	if s.modelAlias.ID != uuid.Nil {
+		return s.modelAlias, nil
+	}
 	return repository.ModelAliasRow{}, repository.ErrModelAliasNotFound
 }
 func (s stubInfraService) DeleteModelAlias(_ context.Context, _ uuid.UUID) error { return nil }
@@ -260,6 +264,72 @@ func TestProviderAccountTestRequiresAdminRole(t *testing.T) {
 
 	if recorder.Code != http.StatusForbidden {
 		t.Errorf("expected 403 Forbidden for viewer testing provider account, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestGetModelAliasIncludesPricingAndDriftWarning(t *testing.T) {
+	workspaceID := uuid.New()
+	aliasID := uuid.New()
+	catalogID := uuid.New()
+
+	svc := stubInfraService{
+		modelAlias: repository.ModelAliasRow{
+			ID:                                aliasID,
+			WorkspaceID:                       &workspaceID,
+			ModelCatalogEntryID:               catalogID,
+			AliasKey:                          "fast-model",
+			DisplayName:                       "Fast Model",
+			Status:                            "active",
+			InputCostPerMillionTokens:         0.4,
+			OutputCostPerMillionTokens:        1.6,
+			CatalogProviderKey:                "openai",
+			CatalogProviderModelID:            "gpt-4.1-mini",
+			CatalogDisplayName:                "GPT 4.1 Mini",
+			CatalogInputCostPerMillionTokens:  0.5,
+			CatalogOutputCostPerMillionTokens: 2.0,
+			CreatedAt:                         time.Now(),
+			UpdatedAt:                         time.Now(),
+		},
+	}
+
+	router := newRouter("dev", nil,
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		nil, 0,
+		stubRunCreationService{}, stubRunReadService{}, stubReplayReadService{},
+		stubHostedRunIngestionService{}, nil,
+		stubAgentDeploymentReadService{}, stubChallengePackReadService{},
+		stubAgentBuildService{}, noopReleaseGateService{},
+		nil, nil, nil, nil, nil, nil, nil,
+		svc,
+		nil,
+		nil,
+		nil,
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/model-aliases/"+aliasID.String(), nil)
+	req.Header.Set(headerUserID, uuid.New().String())
+	req.Header.Set(headerWorkspaceMemberships, workspaceID.String()+":workspace_member")
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	var response modelAliasResponse
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.InputCostPerMillionTokens != 0.4 || response.OutputCostPerMillionTokens != 1.6 {
+		t.Fatalf("alias pricing = %.2f/%.2f, want 0.4/1.6", response.InputCostPerMillionTokens, response.OutputCostPerMillionTokens)
+	}
+	if response.CatalogInputCostPerMillionTokens != 0.5 || response.CatalogOutputCostPerMillionTokens != 2.0 {
+		t.Fatalf("catalog pricing = %.2f/%.2f, want 0.5/2.0", response.CatalogInputCostPerMillionTokens, response.CatalogOutputCostPerMillionTokens)
+	}
+	if !strings.Contains(response.PricingDriftWarning, "alias pricing differs from current catalog pricing") {
+		t.Fatalf("pricing_drift_warning = %q", response.PricingDriftWarning)
 	}
 }
 

--- a/backend/internal/api/infrastructure_test.go
+++ b/backend/internal/api/infrastructure_test.go
@@ -16,10 +16,11 @@ import (
 
 // stubInfraService implements InfrastructureService for testing.
 type stubInfraService struct {
-	profiles           []repository.RuntimeProfileRow
-	providerAccount    repository.ProviderAccountRow
-	providerTestResult ProviderAccountTestResult
-	modelAlias         repository.ModelAliasRow
+	profiles            []repository.RuntimeProfileRow
+	providerAccount     repository.ProviderAccountRow
+	providerTestResult  ProviderAccountTestResult
+	modelAlias          repository.ModelAliasRow
+	createModelAliasErr error
 }
 
 func (s stubInfraService) CreateRuntimeProfile(_ context.Context, _ Caller, _ uuid.UUID, _ CreateRuntimeProfileInput) (repository.RuntimeProfileRow, error) {
@@ -60,6 +61,9 @@ func (s stubInfraService) GetModelCatalogEntry(_ context.Context, _ uuid.UUID) (
 	return repository.ModelCatalogEntryRow{}, nil
 }
 func (s stubInfraService) CreateModelAlias(_ context.Context, _ Caller, _ uuid.UUID, _ CreateModelAliasInput) (repository.ModelAliasRow, error) {
+	if s.createModelAliasErr != nil {
+		return repository.ModelAliasRow{}, s.createModelAliasErr
+	}
 	return repository.ModelAliasRow{}, nil
 }
 func (s stubInfraService) ListModelAliases(_ context.Context, _ uuid.UUID) ([]repository.ModelAliasRow, error) {
@@ -330,6 +334,46 @@ func TestGetModelAliasIncludesPricingAndDriftWarning(t *testing.T) {
 	}
 	if !strings.Contains(response.PricingDriftWarning, "alias pricing differs from current catalog pricing") {
 		t.Fatalf("pricing_drift_warning = %q", response.PricingDriftWarning)
+	}
+}
+
+func TestCreateModelAliasMissingCatalogEntryReturnsValidationError(t *testing.T) {
+	workspaceID := uuid.New()
+	svc := stubInfraService{createModelAliasErr: repository.ErrModelCatalogNotFound}
+
+	router := newRouter("dev", nil,
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		nil, 0,
+		stubRunCreationService{}, stubRunReadService{}, stubReplayReadService{},
+		stubHostedRunIngestionService{}, nil,
+		stubAgentDeploymentReadService{}, stubChallengePackReadService{},
+		stubAgentBuildService{}, noopReleaseGateService{},
+		nil, nil, nil, nil, nil, nil, nil,
+		svc,
+		nil,
+		nil,
+		nil,
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/workspaces/"+workspaceID.String()+"/model-aliases", strings.NewReader(`{
+		"alias_key": "missing",
+		"display_name": "Missing",
+		"model_catalog_entry_id": "`+uuid.NewString()+`"
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(headerUserID, uuid.New().String())
+	req.Header.Set(headerWorkspaceMemberships, workspaceID.String()+":workspace_admin")
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 Bad Request, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "model_catalog_entry_id must reference an existing model catalog entry") {
+		t.Fatalf("response body missing validation message: %s", recorder.Body.String())
 	}
 }
 

--- a/backend/internal/repository/infrastructure.go
+++ b/backend/internal/repository/infrastructure.go
@@ -566,6 +566,13 @@ func (r *Repository) UnarchiveModelAliasByKey(ctx context.Context, workspaceID u
 		&createdAt, &updatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
+			catalogExists, existsErr := r.modelCatalogEntryExists(ctx, catalogEntryID)
+			if existsErr != nil {
+				return ModelAliasRow{}, fmt.Errorf("check model catalog entry: %w", existsErr)
+			}
+			if !catalogExists {
+				return ModelAliasRow{}, ErrModelCatalogNotFound
+			}
 			return ModelAliasRow{}, ErrModelAliasNotFound
 		}
 		return ModelAliasRow{}, fmt.Errorf("unarchive model alias: %w", err)
@@ -573,6 +580,14 @@ func (r *Repository) UnarchiveModelAliasByKey(ctx context.Context, workspaceID u
 	row.CreatedAt = createdAt.Time
 	row.UpdatedAt = updatedAt.Time
 	return row, nil
+}
+
+func (r *Repository) modelCatalogEntryExists(ctx context.Context, id uuid.UUID) (bool, error) {
+	var exists bool
+	if err := r.db.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM model_catalog_entries WHERE id = $1)`, id).Scan(&exists); err != nil {
+		return false, err
+	}
+	return exists, nil
 }
 
 func (r *Repository) ArchiveModelAlias(ctx context.Context, id uuid.UUID) error {

--- a/backend/internal/repository/infrastructure.go
+++ b/backend/internal/repository/infrastructure.go
@@ -421,20 +421,33 @@ func (r *Repository) CreateModelAlias(ctx context.Context, p CreateModelAliasPar
 	var row ModelAliasRow
 	var createdAt, updatedAt pgtype.Timestamptz
 	err := r.db.QueryRow(ctx, `
-		INSERT INTO model_aliases (
-			organization_id, workspace_id, provider_account_id, model_catalog_entry_id, alias_key, display_name,
-			input_cost_per_million_tokens, output_cost_per_million_tokens
+		WITH inserted AS (
+			INSERT INTO model_aliases (
+				organization_id, workspace_id, provider_account_id, model_catalog_entry_id, alias_key, display_name,
+				input_cost_per_million_tokens, output_cost_per_million_tokens
+			)
+			SELECT $1, $2, $3, mce.id, $5, $6,
+				mce.input_cost_per_million_tokens, mce.output_cost_per_million_tokens
+			FROM model_catalog_entries mce
+			WHERE mce.id = $4
+			RETURNING id, organization_id, workspace_id, provider_account_id, model_catalog_entry_id, alias_key, display_name,
+				status, input_cost_per_million_tokens, output_cost_per_million_tokens, created_at, updated_at
 		)
-		SELECT $1, $2, $3, mce.id, $5, $6,
-			mce.input_cost_per_million_tokens, mce.output_cost_per_million_tokens
-		FROM model_catalog_entries mce
-		WHERE mce.id = $4
-		RETURNING id, organization_id, workspace_id, provider_account_id, model_catalog_entry_id, alias_key, display_name,
-			status, input_cost_per_million_tokens, output_cost_per_million_tokens, created_at, updated_at
+		SELECT inserted.id, inserted.organization_id, inserted.workspace_id, inserted.provider_account_id, inserted.model_catalog_entry_id,
+			inserted.alias_key, inserted.display_name, inserted.status,
+			inserted.input_cost_per_million_tokens, inserted.output_cost_per_million_tokens,
+			mce.provider_key, mce.provider_model_id, mce.display_name,
+			mce.input_cost_per_million_tokens, mce.output_cost_per_million_tokens,
+			inserted.created_at, inserted.updated_at
+		FROM inserted
+		JOIN model_catalog_entries mce ON mce.id = inserted.model_catalog_entry_id
 	`, p.OrganizationID, p.WorkspaceID, p.ProviderAccountID, p.ModelCatalogEntryID, p.AliasKey, p.DisplayName,
 	).Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.ProviderAccountID, &row.ModelCatalogEntryID,
 		&row.AliasKey, &row.DisplayName, &row.Status,
-		&row.InputCostPerMillionTokens, &row.OutputCostPerMillionTokens, &createdAt, &updatedAt)
+		&row.InputCostPerMillionTokens, &row.OutputCostPerMillionTokens,
+		&row.CatalogProviderKey, &row.CatalogProviderModelID, &row.CatalogDisplayName,
+		&row.CatalogInputCostPerMillionTokens, &row.CatalogOutputCostPerMillionTokens,
+		&createdAt, &updatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return ModelAliasRow{}, ErrModelCatalogNotFound
@@ -443,7 +456,7 @@ func (r *Repository) CreateModelAlias(ctx context.Context, p CreateModelAliasPar
 	}
 	row.CreatedAt = createdAt.Time
 	row.UpdatedAt = updatedAt.Time
-	return r.GetModelAliasByID(ctx, row.ID)
+	return row, nil
 }
 
 func (r *Repository) GetModelAliasByID(ctx context.Context, id uuid.UUID) (ModelAliasRow, error) {
@@ -523,19 +536,34 @@ func (r *Repository) UnarchiveModelAliasByKey(ctx context.Context, workspaceID u
 	var row ModelAliasRow
 	var createdAt, updatedAt pgtype.Timestamptz
 	err := r.db.QueryRow(ctx, `
-		UPDATE model_aliases
-		SET status = 'active', archived_at = NULL, updated_at = now(),
-			provider_account_id = $3, model_catalog_entry_id = mce.id,
-			input_cost_per_million_tokens = mce.input_cost_per_million_tokens,
-			output_cost_per_million_tokens = mce.output_cost_per_million_tokens
-		FROM model_catalog_entries mce
-		WHERE workspace_id = $1 AND alias_key = $2 AND archived_at IS NOT NULL AND mce.id = $4
-		RETURNING model_aliases.id, organization_id, workspace_id, provider_account_id, model_catalog_entry_id, alias_key, display_name,
-			status, input_cost_per_million_tokens, output_cost_per_million_tokens, created_at, updated_at
+		WITH updated AS (
+			UPDATE model_aliases ma
+			SET status = 'active', archived_at = NULL, updated_at = now(),
+				provider_account_id = $3, model_catalog_entry_id = mce.id,
+				input_cost_per_million_tokens = mce.input_cost_per_million_tokens,
+				output_cost_per_million_tokens = mce.output_cost_per_million_tokens
+			FROM model_catalog_entries mce
+			WHERE ma.workspace_id = $1 AND ma.alias_key = $2 AND ma.archived_at IS NOT NULL AND mce.id = $4
+			RETURNING ma.id, ma.organization_id, ma.workspace_id, ma.provider_account_id, ma.model_catalog_entry_id,
+				ma.alias_key, ma.display_name, ma.status,
+				ma.input_cost_per_million_tokens, ma.output_cost_per_million_tokens,
+				ma.created_at, ma.updated_at
+		)
+		SELECT updated.id, updated.organization_id, updated.workspace_id, updated.provider_account_id, updated.model_catalog_entry_id,
+			updated.alias_key, updated.display_name, updated.status,
+			updated.input_cost_per_million_tokens, updated.output_cost_per_million_tokens,
+			mce.provider_key, mce.provider_model_id, mce.display_name,
+			mce.input_cost_per_million_tokens, mce.output_cost_per_million_tokens,
+			updated.created_at, updated.updated_at
+		FROM updated
+		JOIN model_catalog_entries mce ON mce.id = updated.model_catalog_entry_id
 	`, workspaceID, aliasKey, providerAccountID, catalogEntryID,
 	).Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.ProviderAccountID, &row.ModelCatalogEntryID,
 		&row.AliasKey, &row.DisplayName, &row.Status,
-		&row.InputCostPerMillionTokens, &row.OutputCostPerMillionTokens, &createdAt, &updatedAt)
+		&row.InputCostPerMillionTokens, &row.OutputCostPerMillionTokens,
+		&row.CatalogProviderKey, &row.CatalogProviderModelID, &row.CatalogDisplayName,
+		&row.CatalogInputCostPerMillionTokens, &row.CatalogOutputCostPerMillionTokens,
+		&createdAt, &updatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return ModelAliasRow{}, ErrModelAliasNotFound
@@ -544,7 +572,7 @@ func (r *Repository) UnarchiveModelAliasByKey(ctx context.Context, workspaceID u
 	}
 	row.CreatedAt = createdAt.Time
 	row.UpdatedAt = updatedAt.Time
-	return r.GetModelAliasByID(ctx, row.ID)
+	return row, nil
 }
 
 func (r *Repository) ArchiveModelAlias(ctx context.Context, id uuid.UUID) error {

--- a/backend/internal/repository/infrastructure.go
+++ b/backend/internal/repository/infrastructure.go
@@ -273,18 +273,18 @@ func (r *Repository) ArchiveProviderAccount(ctx context.Context, id uuid.UUID) e
 // --------------------------------------------------------------------------
 
 type ModelCatalogEntryRow struct {
-	ID                          uuid.UUID
-	ProviderKey                 string
-	ProviderModelID             string
-	DisplayName                 string
-	ModelFamily                 string
-	Modality                    string
-	LifecycleStatus             string
-	Metadata                    json.RawMessage
-	InputCostPerMillionTokens   float64
-	OutputCostPerMillionTokens  float64
-	CreatedAt                   time.Time
-	UpdatedAt                   time.Time
+	ID                         uuid.UUID
+	ProviderKey                string
+	ProviderModelID            string
+	DisplayName                string
+	ModelFamily                string
+	Modality                   string
+	LifecycleStatus            string
+	Metadata                   json.RawMessage
+	InputCostPerMillionTokens  float64
+	OutputCostPerMillionTokens float64
+	CreatedAt                  time.Time
+	UpdatedAt                  time.Time
 }
 
 func (r *Repository) GetModelCatalogEntryByID(ctx context.Context, id uuid.UUID) (ModelCatalogEntryRow, error) {
@@ -315,9 +315,11 @@ func (r *Repository) UpsertModelCatalogEntry(ctx context.Context, providerKey, p
 		INSERT INTO model_catalog_entries (provider_key, provider_model_id, display_name, model_family, modality)
 		VALUES ($1, $2, $2, $2, 'text')
 		ON CONFLICT (provider_key, provider_model_id) DO UPDATE SET updated_at = now()
-		RETURNING id, provider_key, provider_model_id, display_name, model_family, modality, lifecycle_status, metadata, created_at, updated_at
+		RETURNING id, provider_key, provider_model_id, display_name, model_family, modality, lifecycle_status, metadata,
+			input_cost_per_million_tokens, output_cost_per_million_tokens, created_at, updated_at
 	`, providerKey, providerModelID).Scan(&row.ID, &row.ProviderKey, &row.ProviderModelID, &row.DisplayName, &row.ModelFamily,
-		&row.Modality, &row.LifecycleStatus, &row.Metadata, &createdAt, &updatedAt)
+		&row.Modality, &row.LifecycleStatus, &row.Metadata,
+		&row.InputCostPerMillionTokens, &row.OutputCostPerMillionTokens, &createdAt, &updatedAt)
 	if err != nil {
 		return ModelCatalogEntryRow{}, fmt.Errorf("upsert model catalog entry: %w", err)
 	}
@@ -330,10 +332,12 @@ func (r *Repository) GetModelCatalogEntryByProviderModel(ctx context.Context, pr
 	var row ModelCatalogEntryRow
 	var createdAt, updatedAt pgtype.Timestamptz
 	err := r.db.QueryRow(ctx, `
-		SELECT id, provider_key, provider_model_id, display_name, model_family, modality, lifecycle_status, metadata, created_at, updated_at
+		SELECT id, provider_key, provider_model_id, display_name, model_family, modality, lifecycle_status, metadata,
+			input_cost_per_million_tokens, output_cost_per_million_tokens, created_at, updated_at
 		FROM model_catalog_entries WHERE provider_key = $1 AND provider_model_id = $2
 	`, providerKey, providerModelID).Scan(&row.ID, &row.ProviderKey, &row.ProviderModelID, &row.DisplayName, &row.ModelFamily,
-		&row.Modality, &row.LifecycleStatus, &row.Metadata, &createdAt, &updatedAt)
+		&row.Modality, &row.LifecycleStatus, &row.Metadata,
+		&row.InputCostPerMillionTokens, &row.OutputCostPerMillionTokens, &createdAt, &updatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return ModelCatalogEntryRow{}, ErrModelCatalogNotFound
@@ -385,16 +389,23 @@ func (r *Repository) ListModelCatalogEntries(ctx context.Context) ([]ModelCatalo
 // --------------------------------------------------------------------------
 
 type ModelAliasRow struct {
-	ID                  uuid.UUID
-	OrganizationID      uuid.UUID
-	WorkspaceID         *uuid.UUID
-	ProviderAccountID   *uuid.UUID
-	ModelCatalogEntryID uuid.UUID
-	AliasKey            string
-	DisplayName         string
-	Status              string
-	CreatedAt           time.Time
-	UpdatedAt           time.Time
+	ID                                uuid.UUID
+	OrganizationID                    uuid.UUID
+	WorkspaceID                       *uuid.UUID
+	ProviderAccountID                 *uuid.UUID
+	ModelCatalogEntryID               uuid.UUID
+	AliasKey                          string
+	DisplayName                       string
+	Status                            string
+	InputCostPerMillionTokens         float64
+	OutputCostPerMillionTokens        float64
+	CatalogProviderKey                string
+	CatalogProviderModelID            string
+	CatalogDisplayName                string
+	CatalogInputCostPerMillionTokens  float64
+	CatalogOutputCostPerMillionTokens float64
+	CreatedAt                         time.Time
+	UpdatedAt                         time.Time
 }
 
 type CreateModelAliasParams struct {
@@ -410,28 +421,50 @@ func (r *Repository) CreateModelAlias(ctx context.Context, p CreateModelAliasPar
 	var row ModelAliasRow
 	var createdAt, updatedAt pgtype.Timestamptz
 	err := r.db.QueryRow(ctx, `
-		INSERT INTO model_aliases (organization_id, workspace_id, provider_account_id, model_catalog_entry_id, alias_key, display_name)
-		VALUES ($1, $2, $3, $4, $5, $6)
-		RETURNING id, organization_id, workspace_id, provider_account_id, model_catalog_entry_id, alias_key, display_name, status, created_at, updated_at
+		INSERT INTO model_aliases (
+			organization_id, workspace_id, provider_account_id, model_catalog_entry_id, alias_key, display_name,
+			input_cost_per_million_tokens, output_cost_per_million_tokens
+		)
+		SELECT $1, $2, $3, mce.id, $5, $6,
+			mce.input_cost_per_million_tokens, mce.output_cost_per_million_tokens
+		FROM model_catalog_entries mce
+		WHERE mce.id = $4
+		RETURNING id, organization_id, workspace_id, provider_account_id, model_catalog_entry_id, alias_key, display_name,
+			status, input_cost_per_million_tokens, output_cost_per_million_tokens, created_at, updated_at
 	`, p.OrganizationID, p.WorkspaceID, p.ProviderAccountID, p.ModelCatalogEntryID, p.AliasKey, p.DisplayName,
 	).Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.ProviderAccountID, &row.ModelCatalogEntryID,
-		&row.AliasKey, &row.DisplayName, &row.Status, &createdAt, &updatedAt)
+		&row.AliasKey, &row.DisplayName, &row.Status,
+		&row.InputCostPerMillionTokens, &row.OutputCostPerMillionTokens, &createdAt, &updatedAt)
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ModelAliasRow{}, ErrModelCatalogNotFound
+		}
 		return ModelAliasRow{}, fmt.Errorf("create model alias: %w", err)
 	}
 	row.CreatedAt = createdAt.Time
 	row.UpdatedAt = updatedAt.Time
-	return row, nil
+	return r.GetModelAliasByID(ctx, row.ID)
 }
 
 func (r *Repository) GetModelAliasByID(ctx context.Context, id uuid.UUID) (ModelAliasRow, error) {
 	var row ModelAliasRow
 	var createdAt, updatedAt pgtype.Timestamptz
 	err := r.db.QueryRow(ctx, `
-		SELECT id, organization_id, workspace_id, provider_account_id, model_catalog_entry_id, alias_key, display_name, status, created_at, updated_at
-		FROM model_aliases WHERE id = $1 AND archived_at IS NULL
+		SELECT ma.id, ma.organization_id, ma.workspace_id, ma.provider_account_id, ma.model_catalog_entry_id,
+			ma.alias_key, ma.display_name, ma.status,
+			ma.input_cost_per_million_tokens, ma.output_cost_per_million_tokens,
+			mce.provider_key, mce.provider_model_id, mce.display_name,
+			mce.input_cost_per_million_tokens, mce.output_cost_per_million_tokens,
+			ma.created_at, ma.updated_at
+		FROM model_aliases ma
+		JOIN model_catalog_entries mce ON mce.id = ma.model_catalog_entry_id
+		WHERE ma.id = $1 AND ma.archived_at IS NULL
 	`, id).Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.ProviderAccountID, &row.ModelCatalogEntryID,
-		&row.AliasKey, &row.DisplayName, &row.Status, &createdAt, &updatedAt)
+		&row.AliasKey, &row.DisplayName, &row.Status,
+		&row.InputCostPerMillionTokens, &row.OutputCostPerMillionTokens,
+		&row.CatalogProviderKey, &row.CatalogProviderModelID, &row.CatalogDisplayName,
+		&row.CatalogInputCostPerMillionTokens, &row.CatalogOutputCostPerMillionTokens,
+		&createdAt, &updatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return ModelAliasRow{}, ErrModelAliasNotFound
@@ -445,10 +478,16 @@ func (r *Repository) GetModelAliasByID(ctx context.Context, id uuid.UUID) (Model
 
 func (r *Repository) ListModelAliasesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]ModelAliasRow, error) {
 	rows, err := r.db.Query(ctx, `
-		SELECT id, organization_id, workspace_id, provider_account_id, model_catalog_entry_id, alias_key, display_name, status, created_at, updated_at
-		FROM model_aliases
-		WHERE workspace_id = $1 AND archived_at IS NULL
-		ORDER BY display_name
+		SELECT ma.id, ma.organization_id, ma.workspace_id, ma.provider_account_id, ma.model_catalog_entry_id,
+			ma.alias_key, ma.display_name, ma.status,
+			ma.input_cost_per_million_tokens, ma.output_cost_per_million_tokens,
+			mce.provider_key, mce.provider_model_id, mce.display_name,
+			mce.input_cost_per_million_tokens, mce.output_cost_per_million_tokens,
+			ma.created_at, ma.updated_at
+		FROM model_aliases ma
+		JOIN model_catalog_entries mce ON mce.id = ma.model_catalog_entry_id
+		WHERE ma.workspace_id = $1 AND ma.archived_at IS NULL
+		ORDER BY ma.display_name
 	`, workspaceID)
 	if err != nil {
 		return nil, fmt.Errorf("list model aliases: %w", err)
@@ -460,7 +499,11 @@ func (r *Repository) ListModelAliasesByWorkspaceID(ctx context.Context, workspac
 		var row ModelAliasRow
 		var createdAt, updatedAt pgtype.Timestamptz
 		if err := rows.Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.ProviderAccountID, &row.ModelCatalogEntryID,
-			&row.AliasKey, &row.DisplayName, &row.Status, &createdAt, &updatedAt); err != nil {
+			&row.AliasKey, &row.DisplayName, &row.Status,
+			&row.InputCostPerMillionTokens, &row.OutputCostPerMillionTokens,
+			&row.CatalogProviderKey, &row.CatalogProviderModelID, &row.CatalogDisplayName,
+			&row.CatalogInputCostPerMillionTokens, &row.CatalogOutputCostPerMillionTokens,
+			&createdAt, &updatedAt); err != nil {
 			return nil, fmt.Errorf("scan model alias: %w", err)
 		}
 		row.CreatedAt = createdAt.Time
@@ -482,12 +525,17 @@ func (r *Repository) UnarchiveModelAliasByKey(ctx context.Context, workspaceID u
 	err := r.db.QueryRow(ctx, `
 		UPDATE model_aliases
 		SET status = 'active', archived_at = NULL, updated_at = now(),
-			provider_account_id = $3, model_catalog_entry_id = $4
-		WHERE workspace_id = $1 AND alias_key = $2 AND archived_at IS NOT NULL
-		RETURNING id, organization_id, workspace_id, provider_account_id, model_catalog_entry_id, alias_key, display_name, status, created_at, updated_at
+			provider_account_id = $3, model_catalog_entry_id = mce.id,
+			input_cost_per_million_tokens = mce.input_cost_per_million_tokens,
+			output_cost_per_million_tokens = mce.output_cost_per_million_tokens
+		FROM model_catalog_entries mce
+		WHERE workspace_id = $1 AND alias_key = $2 AND archived_at IS NOT NULL AND mce.id = $4
+		RETURNING model_aliases.id, organization_id, workspace_id, provider_account_id, model_catalog_entry_id, alias_key, display_name,
+			status, input_cost_per_million_tokens, output_cost_per_million_tokens, created_at, updated_at
 	`, workspaceID, aliasKey, providerAccountID, catalogEntryID,
 	).Scan(&row.ID, &row.OrganizationID, &row.WorkspaceID, &row.ProviderAccountID, &row.ModelCatalogEntryID,
-		&row.AliasKey, &row.DisplayName, &row.Status, &createdAt, &updatedAt)
+		&row.AliasKey, &row.DisplayName, &row.Status,
+		&row.InputCostPerMillionTokens, &row.OutputCostPerMillionTokens, &createdAt, &updatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return ModelAliasRow{}, ErrModelAliasNotFound
@@ -496,7 +544,7 @@ func (r *Repository) UnarchiveModelAliasByKey(ctx context.Context, workspaceID u
 	}
 	row.CreatedAt = createdAt.Time
 	row.UpdatedAt = updatedAt.Time
-	return row, nil
+	return r.GetModelAliasByID(ctx, row.ID)
 }
 
 func (r *Repository) ArchiveModelAlias(ctx context.Context, id uuid.UUID) error {
@@ -914,10 +962,10 @@ func isDuplicateSlug(err error) bool {
 
 // GetWorkspaceID methods implement WorkspaceOwned for authorization checks.
 func (r RuntimeProfileRow) GetWorkspaceID() *uuid.UUID  { return r.WorkspaceID }
-func (r ProviderAccountRow) GetWorkspaceID() *uuid.UUID  { return r.WorkspaceID }
-func (r ModelAliasRow) GetWorkspaceID() *uuid.UUID       { return r.WorkspaceID }
-func (r ToolRow) GetWorkspaceID() *uuid.UUID             { return r.WorkspaceID }
-func (r KnowledgeSourceRow) GetWorkspaceID() *uuid.UUID  { return r.WorkspaceID }
+func (r ProviderAccountRow) GetWorkspaceID() *uuid.UUID { return r.WorkspaceID }
+func (r ModelAliasRow) GetWorkspaceID() *uuid.UUID      { return r.WorkspaceID }
+func (r ToolRow) GetWorkspaceID() *uuid.UUID            { return r.WorkspaceID }
+func (r KnowledgeSourceRow) GetWorkspaceID() *uuid.UUID { return r.WorkspaceID }
 
 func defaultStr(v, fallback string) string {
 	if v == "" {

--- a/backend/internal/repository/repository_integration_test.go
+++ b/backend/internal/repository/repository_integration_test.go
@@ -49,6 +49,22 @@ func TestRepositoryGetRunByID(t *testing.T) {
 	}
 }
 
+func TestRepositoryUnarchiveModelAliasByKeyInvalidCatalogEntry(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	if err := repo.ArchiveModelAlias(ctx, fixture.modelAliasID); err != nil {
+		t.Fatalf("ArchiveModelAlias returned error: %v", err)
+	}
+
+	_, err := repo.UnarchiveModelAliasByKey(ctx, fixture.workspaceID, "primary-model", &fixture.providerAccountID, uuid.New())
+	if !errors.Is(err, repository.ErrModelCatalogNotFound) {
+		t.Fatalf("UnarchiveModelAliasByKey error = %v, want ErrModelCatalogNotFound", err)
+	}
+}
+
 func TestRepositoryListRecentComparableScoredRunsBeforeRunID(t *testing.T) {
 	ctx := context.Background()
 	db := openTestDB(t)

--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/agentclash/agentclash/cli/internal/auth"
+	"github.com/agentclash/agentclash/cli/internal/output"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -730,39 +731,36 @@ func TestInfraModelAliasCreateValidatesRequiredFields(t *testing.T) {
 	}
 }
 
-func TestInfraModelAliasGetPrintsPricingAndDriftWarning(t *testing.T) {
-	srv := fakeAPI(t, map[string]http.HandlerFunc{
-		"GET /v1/model-aliases/alias-1": jsonHandler(200, map[string]any{
-			"id":                                     "alias-1",
-			"alias_key":                              "fast-model",
-			"display_name":                           "Fast Model",
-			"status":                                 "active",
-			"provider_key":                           "openai",
-			"provider_model_id":                      "gpt-4.1-mini",
-			"model_display_name":                     "GPT 4.1 Mini",
-			"model_catalog_entry_id":                 "model-1",
-			"provider_account_id":                    "provider-1",
-			"input_cost_per_million_tokens":          0.4,
-			"output_cost_per_million_tokens":         1.6,
-			"catalog_input_cost_per_million_tokens":  0.5,
-			"catalog_output_cost_per_million_tokens": 2.0,
-			"pricing_drift_warning":                  "alias pricing differs from current catalog pricing",
-		}),
-	})
-	defer srv.Close()
+func TestPrintModelAliasDetailsPrintsPricingAndDriftWarning(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	formatter := output.NewFormatter(output.FormatTable, false, false)
+	formatter.SetWriters(&stdout, &stderr)
 
-	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
-	stdout, stderr, err := captureCommandOutput(t, []string{"infra", "model-alias", "get", "alias-1"}, srv.URL)
-	if err != nil {
-		t.Fatalf("infra model-alias get error: %v", err)
-	}
+	printModelAliasDetails(formatter, map[string]any{
+		"id":                                     "alias-1",
+		"alias_key":                              "fast-model",
+		"display_name":                           "Fast Model",
+		"status":                                 "active",
+		"provider_key":                           "openai",
+		"provider_model_id":                      "gpt-4.1-mini",
+		"model_display_name":                     "GPT 4.1 Mini",
+		"model_catalog_entry_id":                 "model-1",
+		"provider_account_id":                    "provider-1",
+		"input_cost_per_million_tokens":          0.4,
+		"output_cost_per_million_tokens":         1.6,
+		"catalog_input_cost_per_million_tokens":  0.5,
+		"catalog_output_cost_per_million_tokens": 2.0,
+		"pricing_drift_warning":                  "alias pricing differs from current catalog pricing",
+	})
+
 	for _, want := range []string{"Input / 1M", "0.4", "Catalog Output / 1M", "2"} {
-		if !strings.Contains(stdout, want) {
-			t.Fatalf("stdout missing %q:\n%s", want, stdout)
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
 		}
 	}
-	if !strings.Contains(stderr, "alias pricing differs from current catalog pricing") {
-		t.Fatalf("stderr missing drift warning:\n%s", stderr)
+	if !strings.Contains(stderr.String(), "alias pricing differs from current catalog pricing") {
+		t.Fatalf("stderr missing drift warning:\n%s", stderr.String())
 	}
 }
 
@@ -782,40 +780,6 @@ func TestAPIErrorPropagates(t *testing.T) {
 	if !strings.Contains(err.Error(), "unauthorized") {
 		t.Fatalf("error should contain 'unauthorized', got: %v", err)
 	}
-}
-
-func captureCommandOutput(t *testing.T, args []string, apiURL string) (string, string, error) {
-	t.Helper()
-
-	oldStdout := os.Stdout
-	oldStderr := os.Stderr
-	stdoutReader, stdoutWriter, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("stdout pipe: %v", err)
-	}
-	stderrReader, stderrWriter, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("stderr pipe: %v", err)
-	}
-	os.Stdout = stdoutWriter
-	os.Stderr = stderrWriter
-	defer func() {
-		os.Stdout = oldStdout
-		os.Stderr = oldStderr
-	}()
-
-	cmdErr := executeCommandWithQuiet(t, args, apiURL, false)
-	_ = stdoutWriter.Close()
-	_ = stderrWriter.Close()
-	stdoutBytes, readStdoutErr := io.ReadAll(stdoutReader)
-	stderrBytes, readStderrErr := io.ReadAll(stderrReader)
-	if readStdoutErr != nil {
-		t.Fatalf("read stdout: %v", readStdoutErr)
-	}
-	if readStderrErr != nil {
-		t.Fatalf("read stderr: %v", readStderrErr)
-	}
-	return string(stdoutBytes), string(stderrBytes), cmdErr
 }
 
 func TestAuthHeaderSentToAPI(t *testing.T) {

--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -729,6 +730,42 @@ func TestInfraModelAliasCreateValidatesRequiredFields(t *testing.T) {
 	}
 }
 
+func TestInfraModelAliasGetPrintsPricingAndDriftWarning(t *testing.T) {
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/model-aliases/alias-1": jsonHandler(200, map[string]any{
+			"id":                                     "alias-1",
+			"alias_key":                              "fast-model",
+			"display_name":                           "Fast Model",
+			"status":                                 "active",
+			"provider_key":                           "openai",
+			"provider_model_id":                      "gpt-4.1-mini",
+			"model_display_name":                     "GPT 4.1 Mini",
+			"model_catalog_entry_id":                 "model-1",
+			"provider_account_id":                    "provider-1",
+			"input_cost_per_million_tokens":          0.4,
+			"output_cost_per_million_tokens":         1.6,
+			"catalog_input_cost_per_million_tokens":  0.5,
+			"catalog_output_cost_per_million_tokens": 2.0,
+			"pricing_drift_warning":                  "alias pricing differs from current catalog pricing",
+		}),
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	stdout, stderr, err := captureCommandOutput(t, []string{"infra", "model-alias", "get", "alias-1"}, srv.URL)
+	if err != nil {
+		t.Fatalf("infra model-alias get error: %v", err)
+	}
+	for _, want := range []string{"Input / 1M", "0.4", "Catalog Output / 1M", "2"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout)
+		}
+	}
+	if !strings.Contains(stderr, "alias pricing differs from current catalog pricing") {
+		t.Fatalf("stderr missing drift warning:\n%s", stderr)
+	}
+}
+
 func TestAPIErrorPropagates(t *testing.T) {
 	srv := fakeAPI(t, map[string]http.HandlerFunc{
 		"GET /v1/organizations": jsonHandler(401, map[string]any{
@@ -745,6 +782,40 @@ func TestAPIErrorPropagates(t *testing.T) {
 	if !strings.Contains(err.Error(), "unauthorized") {
 		t.Fatalf("error should contain 'unauthorized', got: %v", err)
 	}
+}
+
+func captureCommandOutput(t *testing.T, args []string, apiURL string) (string, string, error) {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	stderrReader, stderrWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stderr pipe: %v", err)
+	}
+	os.Stdout = stdoutWriter
+	os.Stderr = stderrWriter
+	defer func() {
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+	}()
+
+	cmdErr := executeCommandWithQuiet(t, args, apiURL, false)
+	_ = stdoutWriter.Close()
+	_ = stderrWriter.Close()
+	stdoutBytes, readStdoutErr := io.ReadAll(stdoutReader)
+	stderrBytes, readStderrErr := io.ReadAll(stderrReader)
+	if readStdoutErr != nil {
+		t.Fatalf("read stdout: %v", readStdoutErr)
+	}
+	if readStderrErr != nil {
+		t.Fatalf("read stderr: %v", readStderrErr)
+	}
+	return string(stdoutBytes), string(stderrBytes), cmdErr
 }
 
 func TestAuthHeaderSentToAPI(t *testing.T) {

--- a/cli/cmd/infra.go
+++ b/cli/cmd/infra.go
@@ -46,9 +46,17 @@ var infraResources = []infraResource{
 		Name: "model-alias", Plural: "model-aliases",
 		ListPath: "/v1/workspaces/%s/model-aliases", CreatePath: "/v1/workspaces/%s/model-aliases",
 		GetPath: "/v1/model-aliases/%s", DeletePath: "/v1/model-aliases/%s",
-		Columns: []output.Column{{Header: "ID"}, {Header: "Alias Key"}, {Header: "Display Name"}, {Header: "Status"}, {Header: "Created"}},
+		Columns: []output.Column{{Header: "ID"}, {Header: "Alias Key"}, {Header: "Model"}, {Header: "Input/M"}, {Header: "Output/M"}, {Header: "Status"}, {Header: "Created"}},
 		RowMapper: func(item map[string]any) []string {
-			return []string{str(item["id"]), str(item["alias_key"]), str(item["display_name"]), output.StatusColor(str(item["status"])), str(item["created_at"])}
+			return []string{
+				str(item["id"]),
+				str(item["alias_key"]),
+				modelAliasModelLabel(item),
+				fmtPricingRate(item["input_cost_per_million_tokens"]),
+				fmtPricingRate(item["output_cost_per_million_tokens"]),
+				output.StatusColor(str(item["status"])),
+				str(item["created_at"]),
+			}
 		},
 	},
 	{
@@ -216,6 +224,10 @@ func newInfraResourceCmd(res infraResource) *cobra.Command {
 					return err
 				}
 
+				if !rc.Output.IsStructured() && res.Name == "model-alias" {
+					printModelAliasDetails(rc.Output, item)
+					return nil
+				}
 				return rc.Output.PrintRaw(item)
 			},
 		}
@@ -348,6 +360,49 @@ func printProviderAccountTestResult(formatter *output.Formatter, result map[stri
 	}
 }
 
+func printModelAliasDetails(formatter *output.Formatter, alias map[string]any) {
+	formatter.PrintDetail("ID", str(alias["id"]))
+	formatter.PrintDetail("Alias Key", str(alias["alias_key"]))
+	formatter.PrintDetail("Display Name", str(alias["display_name"]))
+	formatter.PrintDetail("Status", output.StatusColor(str(alias["status"])))
+	formatter.PrintDetail("Provider", str(alias["provider_key"]))
+	formatter.PrintDetail("Model", str(alias["provider_model_id"]))
+	formatter.PrintDetail("Model Name", str(alias["model_display_name"]))
+	formatter.PrintDetail("Model Catalog", str(alias["model_catalog_entry_id"]))
+	if providerAccountID := str(alias["provider_account_id"]); providerAccountID != "" {
+		formatter.PrintDetail("Provider Account", providerAccountID)
+	}
+	formatter.PrintDetail("Input / 1M", fmtPricingRate(alias["input_cost_per_million_tokens"]))
+	formatter.PrintDetail("Output / 1M", fmtPricingRate(alias["output_cost_per_million_tokens"]))
+	formatter.PrintDetail("Catalog Input / 1M", fmtPricingRate(alias["catalog_input_cost_per_million_tokens"]))
+	formatter.PrintDetail("Catalog Output / 1M", fmtPricingRate(alias["catalog_output_cost_per_million_tokens"]))
+	if warning := str(alias["pricing_drift_warning"]); warning != "" {
+		formatter.PrintWarning(warning)
+	}
+}
+
+func modelAliasModelLabel(item map[string]any) string {
+	provider := str(item["provider_key"])
+	model := str(item["provider_model_id"])
+	if provider == "" {
+		return model
+	}
+	if model == "" {
+		return provider
+	}
+	return provider + "/" + model
+}
+
+func fmtPricingRate(v any) string {
+	if v == nil {
+		return "-"
+	}
+	if f, ok := v.(float64); ok {
+		return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.6f", f), "0"), ".")
+	}
+	return str(v)
+}
+
 func addInfraCreateFlags(cmd *cobra.Command, resourceName string) {
 	switch resourceName {
 	case "model-alias":
@@ -475,6 +530,8 @@ var modelCatalogGetCmd = &cobra.Command{
 		rc.Output.PrintDetail("Family", str(entry["model_family"]))
 		rc.Output.PrintDetail("Modality", str(entry["modality"]))
 		rc.Output.PrintDetail("Status", output.StatusColor(str(entry["lifecycle_status"])))
+		rc.Output.PrintDetail("Input / 1M", fmtPricingRate(entry["input_cost_per_million_tokens"]))
+		rc.Output.PrintDetail("Output / 1M", fmtPricingRate(entry["output_cost_per_million_tokens"]))
 
 		if md, ok := entry["metadata"]; ok && md != nil {
 			mdJSON, _ := json.MarshalIndent(md, "", "  ")

--- a/cli/internal/output/formatter.go
+++ b/cli/internal/output/formatter.go
@@ -67,6 +67,17 @@ func (f *Formatter) Writer() io.Writer {
 	return f.writer
 }
 
+// SetWriters overrides output streams. It is primarily useful for focused
+// command rendering tests that should not mutate process-wide stdout/stderr.
+func (f *Formatter) SetWriters(writer, errw io.Writer) {
+	if writer != nil {
+		f.writer = writer
+	}
+	if errw != nil {
+		f.errw = errw
+	}
+}
+
 // PrintTable renders a table to stdout.
 func (f *Formatter) PrintTable(columns []Column, rows [][]string) {
 	if len(rows) == 0 {

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -6436,7 +6436,7 @@ components:
 
     ModelCatalogEntryResponse:
       type: object
-      required: [id, provider_key, provider_model_id, display_name, model_family, modality, lifecycle_status, metadata, created_at, updated_at]
+      required: [id, provider_key, provider_model_id, display_name, model_family, modality, lifecycle_status, metadata, input_cost_per_million_tokens, output_cost_per_million_tokens, created_at, updated_at]
       properties:
         id:
           type: string
@@ -6456,6 +6456,12 @@ components:
         metadata:
           type: object
           additionalProperties: true
+        input_cost_per_million_tokens:
+          type: number
+          format: double
+        output_cost_per_million_tokens:
+          type: number
+          format: double
         created_at:
           type: string
           format: date-time
@@ -6489,7 +6495,7 @@ components:
 
     ModelAliasResponse:
       type: object
-      required: [id, model_catalog_entry_id, alias_key, display_name, status, created_at, updated_at]
+      required: [id, model_catalog_entry_id, provider_key, provider_model_id, model_display_name, alias_key, display_name, status, input_cost_per_million_tokens, output_cost_per_million_tokens, catalog_input_cost_per_million_tokens, catalog_output_cost_per_million_tokens, created_at, updated_at]
       properties:
         id:
           type: string
@@ -6503,11 +6509,31 @@ components:
         model_catalog_entry_id:
           type: string
           format: uuid
+        provider_key:
+          type: string
+        provider_model_id:
+          type: string
+        model_display_name:
+          type: string
         alias_key:
           type: string
         display_name:
           type: string
         status:
+          type: string
+        input_cost_per_million_tokens:
+          type: number
+          format: double
+        output_cost_per_million_tokens:
+          type: number
+          format: double
+        catalog_input_cost_per_million_tokens:
+          type: number
+          format: double
+        catalog_output_cost_per_million_tokens:
+          type: number
+          format: double
+        pricing_drift_warning:
           type: string
         created_at:
           type: string

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -561,9 +561,17 @@ export interface ModelAlias {
   workspace_id?: string;
   provider_account_id?: string;
   model_catalog_entry_id: string;
+  provider_key: string;
+  provider_model_id: string;
+  model_display_name: string;
   alias_key: string;
   display_name: string;
   status: string;
+  input_cost_per_million_tokens: number;
+  output_cost_per_million_tokens: number;
+  catalog_input_cost_per_million_tokens: number;
+  catalog_output_cost_per_million_tokens: number;
+  pricing_drift_warning?: string;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
Closes #720.

## Summary
- snapshot model catalog pricing onto model aliases and expose alias/catalog pricing in model-alias API reads
- add pricing drift warnings when an alias snapshot differs from current catalog values
- render model-alias pricing and drift warnings in the CLI

## Tests
- cd backend && go test ./internal/api ./internal/repository -count=1
- cd backend && go test ./...
- cd backend && go vet ./...
- cd cli && go test ./...
- cd web && pnpm lint (fails locally: node_modules missing / eslint not found)
