### PR TITLE
feat: add workspace public pack opt-in

### DIFF
--- a/backend/db/migrations/00046_workspace_public_packs.sql
+++ b/backend/db/migrations/00046_workspace_public_packs.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE workspaces
+ADD COLUMN public_packs boolean NOT NULL DEFAULT false;
+
+-- +goose Down
+ALTER TABLE workspaces
+DROP COLUMN IF EXISTS public_packs;

--- a/backend/internal/api/challenge_packs.go
+++ b/backend/internal/api/challenge_packs.go
@@ -22,6 +22,7 @@ import (
 
 type ChallengePackReadRepository interface {
 	ListVisibleChallengePacks(ctx context.Context, workspaceID uuid.UUID) ([]repository.ChallengePackSummary, error)
+	WorkspacePublicPacksEnabled(ctx context.Context, workspaceID uuid.UUID) (bool, error)
 	ListRunnableChallengePVersionsByPackID(ctx context.Context, challengePackID uuid.UUID) ([]repository.ChallengePackVersionSummary, error)
 	GetRunnableChallengePackVersionByID(ctx context.Context, id uuid.UUID) (repository.RunnableChallengePackVersion, error)
 	ListChallengeInputSetsByVersionID(ctx context.Context, challengePackVersionID uuid.UUID) ([]repository.ChallengeInputSetSummary, error)
@@ -96,6 +97,15 @@ func (m *ChallengePackReadManager) ListChallengeInputSets(ctx context.Context, c
 	}
 	if version.WorkspaceID != nil && *version.WorkspaceID != workspaceID {
 		return ListChallengeInputSetsResult{}, repository.ErrChallengePackVersionNotFound
+	}
+	if version.WorkspaceID == nil {
+		enabled, accessErr := m.repo.WorkspacePublicPacksEnabled(ctx, workspaceID)
+		if accessErr != nil {
+			return ListChallengeInputSetsResult{}, accessErr
+		}
+		if !enabled {
+			return ListChallengeInputSetsResult{}, repository.ErrChallengePackVersionNotFound
+		}
 	}
 
 	inputSets, err := m.repo.ListChallengeInputSetsByVersionID(ctx, challengePackVersionID)

--- a/backend/internal/api/challenge_packs_test.go
+++ b/backend/internal/api/challenge_packs_test.go
@@ -23,6 +23,7 @@ type fakeChallengePackReadRepository struct {
 	runnableVersion repository.RunnableChallengePackVersion
 	inputSets       []repository.ChallengeInputSetSummary
 	versionDefaults json.RawMessage
+	publicPacks     bool
 }
 
 func (f *fakeChallengePackReadRepository) ListVisibleChallengePacks(_ context.Context, workspaceID uuid.UUID) ([]repository.ChallengePackSummary, error) {
@@ -36,6 +37,11 @@ func (f *fakeChallengePackReadRepository) ListVisibleChallengePacks(_ context.Co
 			UpdatedAt: time.Now().UTC(),
 		},
 	}, nil
+}
+
+func (f *fakeChallengePackReadRepository) WorkspacePublicPacksEnabled(_ context.Context, workspaceID uuid.UUID) (bool, error) {
+	f.lastWorkspaceID = workspaceID
+	return f.publicPacks, nil
 }
 
 func (f *fakeChallengePackReadRepository) ListRunnableChallengePVersionsByPackID(_ context.Context, challengePackID uuid.UUID) ([]repository.ChallengePackVersionSummary, error) {
@@ -285,6 +291,55 @@ func TestChallengePackReadManagerHidesInputSetsForOtherWorkspace(t *testing.T) {
 	_, err := manager.ListChallengeInputSets(ctx, versionID)
 	if !errors.Is(err, repository.ErrChallengePackVersionNotFound) {
 		t.Fatalf("error = %v, want challenge pack version not found", err)
+	}
+}
+
+func TestChallengePackReadManagerHidesGlobalInputSetsWhenPublicPacksDisabled(t *testing.T) {
+	workspaceID := uuid.New()
+	versionID := uuid.New()
+	repo := &fakeChallengePackReadRepository{
+		runnableVersion: repository.RunnableChallengePackVersion{
+			ID:          versionID,
+			WorkspaceID: nil,
+		},
+		publicPacks: false,
+	}
+	manager := NewChallengePackReadManager(repo)
+
+	ctx := context.WithValue(context.Background(), workspaceIDContextKey{}, workspaceID)
+	_, err := manager.ListChallengeInputSets(ctx, versionID)
+	if !errors.Is(err, repository.ErrChallengePackVersionNotFound) {
+		t.Fatalf("error = %v, want challenge pack version not found", err)
+	}
+}
+
+func TestChallengePackReadManagerListsGlobalInputSetsWhenPublicPacksEnabled(t *testing.T) {
+	workspaceID := uuid.New()
+	versionID := uuid.New()
+	repo := &fakeChallengePackReadRepository{
+		runnableVersion: repository.RunnableChallengePackVersion{
+			ID:          versionID,
+			WorkspaceID: nil,
+		},
+		inputSets: []repository.ChallengeInputSetSummary{
+			{
+				ID:                     uuid.New(),
+				ChallengePackVersionID: versionID,
+				InputKey:               "public-default",
+				Name:                   "Public Default",
+			},
+		},
+		publicPacks: true,
+	}
+	manager := NewChallengePackReadManager(repo)
+
+	ctx := context.WithValue(context.Background(), workspaceIDContextKey{}, workspaceID)
+	result, err := manager.ListChallengeInputSets(ctx, versionID)
+	if err != nil {
+		t.Fatalf("ListChallengeInputSets returned error: %v", err)
+	}
+	if len(result.InputSets) != 1 || result.InputSets[0].InputKey != "public-default" {
+		t.Fatalf("input sets = %#v, want public-default", result.InputSets)
 	}
 }
 

--- a/backend/internal/api/eval_session_service.go
+++ b/backend/internal/api/eval_session_service.go
@@ -144,6 +144,18 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 			Message: "challenge_pack_version_id must be visible to the selected workspace",
 		}
 	}
+	if challengePackVersion.WorkspaceID == nil {
+		publicPacks, accessErr := m.repo.WorkspacePublicPacksEnabled(ctx, input.WorkspaceID)
+		if accessErr != nil {
+			return CreateEvalSessionResult{}, fmt.Errorf("load workspace public pack access: %w", accessErr)
+		}
+		if !publicPacks {
+			return CreateEvalSessionResult{}, RunCreationValidationError{
+				Code:    "invalid_challenge_pack_version_id",
+				Message: "challenge_pack_version_id must be visible to the selected workspace",
+			}
+		}
+	}
 	if input.MaxIterations == nil {
 		input.MaxIterations = challengePackDefaultMaxIterations(challengePackVersion.Manifest)
 	}

--- a/backend/internal/api/regression_suites.go
+++ b/backend/internal/api/regression_suites.go
@@ -24,6 +24,7 @@ type RegressionRepository interface {
 	CreateRegressionSuite(ctx context.Context, params repository.CreateRegressionSuiteParams) (repository.RegressionSuite, error)
 	GetRegressionSuiteByID(ctx context.Context, id uuid.UUID) (repository.RegressionSuite, error)
 	ListVisibleChallengePacks(ctx context.Context, workspaceID uuid.UUID) ([]repository.ChallengePackSummary, error)
+	WorkspacePublicPacksEnabled(ctx context.Context, workspaceID uuid.UUID) (bool, error)
 	ListRegressionSuitesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID, limit, offset int32) ([]repository.RegressionSuite, error)
 	CountRegressionSuitesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (int64, error)
 	PatchRegressionSuite(ctx context.Context, params repository.PatchRegressionSuiteParams) (repository.RegressionSuite, error)
@@ -458,6 +459,15 @@ func (m *RegressionManager) CaptureProductionFailure(ctx context.Context, caller
 	}
 	if version.WorkspaceID != nil && *version.WorkspaceID != input.WorkspaceID {
 		return repository.RegressionCase{}, repository.ErrChallengePackVersionNotFound
+	}
+	if version.WorkspaceID == nil {
+		publicPacks, accessErr := m.repo.WorkspacePublicPacksEnabled(ctx, input.WorkspaceID)
+		if accessErr != nil {
+			return repository.RegressionCase{}, accessErr
+		}
+		if !publicPacks {
+			return repository.RegressionCase{}, repository.ErrChallengePackVersionNotFound
+		}
 	}
 	if version.ChallengePackID != suite.SourceChallengePackID {
 		return repository.RegressionCase{}, ErrRegressionSuitePackMismatch

--- a/backend/internal/api/regression_suites_test.go
+++ b/backend/internal/api/regression_suites_test.go
@@ -1390,6 +1390,7 @@ func TestRegressionSuitePatchReturnsConflictOnTransitionConflict(t *testing.T) {
 type fakeRegressionRepository struct {
 	challengePacks          []repository.ChallengePackSummary
 	challengePacksErr       error
+	publicPacksDisabled     bool
 	suite                   repository.RegressionSuite
 	suiteErr                error
 	regressionCase          repository.RegressionCase
@@ -1430,6 +1431,10 @@ type fakeRegressionRepository struct {
 
 func (f *fakeRegressionRepository) ListVisibleChallengePacks(_ context.Context, _ uuid.UUID) ([]repository.ChallengePackSummary, error) {
 	return f.challengePacks, f.challengePacksErr
+}
+
+func (f *fakeRegressionRepository) WorkspacePublicPacksEnabled(context.Context, uuid.UUID) (bool, error) {
+	return !f.publicPacksDisabled, nil
 }
 
 func (f *fakeRegressionRepository) CreateRegressionSuite(_ context.Context, params repository.CreateRegressionSuiteParams) (repository.RegressionSuite, error) {

--- a/backend/internal/api/run_service.go
+++ b/backend/internal/api/run_service.go
@@ -16,6 +16,7 @@ import (
 
 type RunCreationRepository interface {
 	GetRunnableChallengePackVersionByID(ctx context.Context, id uuid.UUID) (repository.RunnableChallengePackVersion, error)
+	WorkspacePublicPacksEnabled(ctx context.Context, workspaceID uuid.UUID) (bool, error)
 	GetChallengeInputSetByID(ctx context.Context, id uuid.UUID) (repository.ChallengeInputSet, error)
 	ListChallengeInputSetsByVersionID(ctx context.Context, challengePackVersionID uuid.UUID) ([]repository.ChallengeInputSetSummary, error)
 	ListChallengeIdentityIDsByPackVersionID(ctx context.Context, challengePackVersionID uuid.UUID) ([]uuid.UUID, error)
@@ -146,6 +147,18 @@ func (m *RunCreationManager) CreateRun(ctx context.Context, caller Caller, input
 		return CreateRunResult{}, RunCreationValidationError{
 			Code:    "invalid_challenge_pack_version_id",
 			Message: "challenge_pack_version_id must be visible to the selected workspace",
+		}
+	}
+	if challengePackVersion.WorkspaceID == nil {
+		publicPacks, accessErr := m.repo.WorkspacePublicPacksEnabled(ctx, input.WorkspaceID)
+		if accessErr != nil {
+			return CreateRunResult{}, fmt.Errorf("load workspace public pack access: %w", accessErr)
+		}
+		if !publicPacks {
+			return CreateRunResult{}, RunCreationValidationError{
+				Code:    "invalid_challenge_pack_version_id",
+				Message: "challenge_pack_version_id must be visible to the selected workspace",
+			}
 		}
 	}
 	if input.MaxIterations == nil {

--- a/backend/internal/api/run_service_test.go
+++ b/backend/internal/api/run_service_test.go
@@ -554,6 +554,40 @@ func TestRunCreationManagerRejectsChallengePackVersionNotFound(t *testing.T) {
 	}
 }
 
+func TestRunCreationManagerRejectsGlobalChallengePackWhenPublicPacksDisabled(t *testing.T) {
+	workspaceID := uuid.New()
+	deploymentID := uuid.New()
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{
+			ID:          uuid.New(),
+			WorkspaceID: nil,
+		},
+		publicPacksDisabled: true,
+	}, &fakeRunWorkflowStarter{}, nil)
+
+	_, err := manager.CreateRun(context.Background(), Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}, CreateRunInput{
+		WorkspaceID:            workspaceID,
+		ChallengePackVersionID: uuid.New(),
+		AgentDeploymentIDs:     []uuid.UUID{deploymentID},
+	})
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+
+	var validationErr RunCreationValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error = %v, want RunCreationValidationError", err)
+	}
+	if validationErr.Code != "invalid_challenge_pack_version_id" {
+		t.Fatalf("validation code = %q, want invalid_challenge_pack_version_id", validationErr.Code)
+	}
+}
+
 func TestRunCreationManagerCreateEvalSessionCreatesQueuedRuns(t *testing.T) {
 	workspaceID := uuid.New()
 	challengePackVersionID := uuid.New()
@@ -2051,6 +2085,7 @@ func TestRunCreationManagerIncludesProposedRegressionCasesForValidationRuns(t *t
 type fakeRunCreationRepository struct {
 	challengePackVersion            repository.RunnableChallengePackVersion
 	challengePackVersionErr         error
+	publicPacksDisabled             bool
 	challengeInputSet               repository.ChallengeInputSet
 	challengeInputSetErr            error
 	challengeInputSets              []repository.ChallengeInputSetSummary
@@ -2106,6 +2141,10 @@ func executionPlanTestSeries(t *testing.T, payload json.RawMessage) (string, str
 
 func (f *fakeRunCreationRepository) GetRunnableChallengePackVersionByID(_ context.Context, _ uuid.UUID) (repository.RunnableChallengePackVersion, error) {
 	return f.challengePackVersion, f.challengePackVersionErr
+}
+
+func (f *fakeRunCreationRepository) WorkspacePublicPacksEnabled(context.Context, uuid.UUID) (bool, error) {
+	return !f.publicPacksDisabled, nil
 }
 
 func (f *fakeRunCreationRepository) GetChallengeInputSetByID(_ context.Context, _ uuid.UUID) (repository.ChallengeInputSet, error) {

--- a/backend/internal/api/workspaces.go
+++ b/backend/internal/api/workspaces.go
@@ -28,8 +28,9 @@ type CreateWorkspaceInput struct {
 }
 
 type UpdateWorkspaceInput struct {
-	Name   *string
-	Status *string
+	Name        *string
+	Status      *string
+	PublicPacks *bool
 }
 
 type WorkspaceResult struct {
@@ -38,6 +39,7 @@ type WorkspaceResult struct {
 	Name           string    `json:"name"`
 	Slug           string    `json:"slug"`
 	Status         string    `json:"status"`
+	PublicPacks    bool      `json:"public_packs"`
 	CreatedAt      time.Time `json:"created_at"`
 	UpdatedAt      time.Time `json:"updated_at"`
 }
@@ -183,8 +185,9 @@ func (m *WorkspaceManager) UpdateWorkspace(ctx context.Context, caller Caller, w
 	}
 
 	ws, err := m.repo.UpdateWorkspace(ctx, workspaceID, repository.UpdateWorkspaceInput{
-		Name:   input.Name,
-		Status: input.Status,
+		Name:        input.Name,
+		Status:      input.Status,
+		PublicPacks: input.PublicPacks,
 	})
 	if err != nil {
 		return WorkspaceResult{}, err
@@ -231,6 +234,7 @@ func wsRowToResult(ws repository.WorkspaceRow) WorkspaceResult {
 		Name:           ws.Name,
 		Slug:           ws.Slug,
 		Status:         ws.Status,
+		PublicPacks:    ws.PublicPacks,
 		CreatedAt:      ws.CreatedAt,
 		UpdatedAt:      ws.UpdatedAt,
 	}
@@ -367,15 +371,16 @@ func updateWorkspaceHandler(logger *slog.Logger, service WorkspaceService) http.
 		}
 
 		var req struct {
-			Name   *string `json:"name,omitempty"`
-			Status *string `json:"status,omitempty"`
+			Name        *string `json:"name,omitempty"`
+			Status      *string `json:"status,omitempty"`
+			PublicPacks *bool   `json:"public_packs,omitempty"`
 		}
 		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&req); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body")
 			return
 		}
-		if req.Name == nil && req.Status == nil {
-			writeError(w, http.StatusBadRequest, "validation_error", "at least one of name or status is required")
+		if req.Name == nil && req.Status == nil && req.PublicPacks == nil {
+			writeError(w, http.StatusBadRequest, "validation_error", "at least one of name, status, or public_packs is required")
 			return
 		}
 		if req.Status != nil && *req.Status != "active" && *req.Status != "archived" {
@@ -384,8 +389,9 @@ func updateWorkspaceHandler(logger *slog.Logger, service WorkspaceService) http.
 		}
 
 		result, err := service.UpdateWorkspace(r.Context(), caller, workspaceID, UpdateWorkspaceInput{
-			Name:   req.Name,
-			Status: req.Status,
+			Name:        req.Name,
+			Status:      req.Status,
+			PublicPacks: req.PublicPacks,
 		})
 		if err != nil {
 			handleWorkspaceError(w, logger, err)

--- a/backend/internal/repository/challenge_pack_authoring.go
+++ b/backend/internal/repository/challenge_pack_authoring.go
@@ -76,7 +76,7 @@ func (r *Repository) WorkspacePublicPacksEnabled(ctx context.Context, workspaceI
 	err := r.db.QueryRow(ctx, `
 		SELECT public_packs
 		FROM workspaces
-		WHERE id = $1 AND status = 'active'
+		WHERE id = $1
 	`, workspaceID).Scan(&enabled)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/backend/internal/repository/challenge_pack_authoring.go
+++ b/backend/internal/repository/challenge_pack_authoring.go
@@ -35,7 +35,17 @@ func (r *Repository) ListVisibleChallengePacks(ctx context.Context, workspaceID 
 		SELECT id, name, slug, description, created_at, updated_at
 		FROM challenge_packs
 		WHERE archived_at IS NULL
-		  AND (workspace_id IS NULL OR workspace_id = $1)
+		  AND (
+			workspace_id = $1
+			OR (
+				workspace_id IS NULL
+				AND EXISTS (
+					SELECT 1
+					FROM workspaces
+					WHERE id = $1 AND public_packs
+				)
+			)
+		  )
 		ORDER BY name ASC
 	`, workspaceID)
 	if err != nil {
@@ -59,6 +69,22 @@ func (r *Repository) ListVisibleChallengePacks(ctx context.Context, workspaceID 
 	}
 
 	return packs, nil
+}
+
+func (r *Repository) WorkspacePublicPacksEnabled(ctx context.Context, workspaceID uuid.UUID) (bool, error) {
+	var enabled bool
+	err := r.db.QueryRow(ctx, `
+		SELECT public_packs
+		FROM workspaces
+		WHERE id = $1 AND status = 'active'
+	`, workspaceID).Scan(&enabled)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, ErrWorkspaceNotFound
+		}
+		return false, fmt.Errorf("get workspace public pack access: %w", err)
+	}
+	return enabled, nil
 }
 
 func (r *Repository) PublishChallengePackBundle(ctx context.Context, params PublishChallengePackBundleParams) (PublishedChallengePack, error) {

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -3079,6 +3079,7 @@ type WorkspaceRow struct {
 	Name           string
 	Slug           string
 	Status         string
+	PublicPacks    bool
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 }
@@ -3092,8 +3093,9 @@ type CreateWorkspaceWithAdminInput struct {
 }
 
 type UpdateWorkspaceInput struct {
-	Name   *string
-	Status *string
+	Name        *string
+	Status      *string
+	PublicPacks *bool
 }
 
 type OrgMembershipFullRow struct {
@@ -3520,9 +3522,9 @@ func (r *Repository) Onboard(ctx context.Context, input OnboardInput) (OnboardRe
 	err = tx.QueryRow(ctx, `
 		INSERT INTO workspaces (id, organization_id, name, slug, status)
 		VALUES (gen_random_uuid(), $1, $2, $3, 'active')
-		RETURNING id, organization_id, name, slug, status, created_at, updated_at
+		RETURNING id, organization_id, name, slug, status, public_packs, created_at, updated_at
 	`, org.ID, input.WorkspaceName, input.WorkspaceSlug).Scan(
-		&ws.ID, &ws.OrganizationID, &ws.Name, &ws.Slug, &ws.Status, &ws.CreatedAt, &ws.UpdatedAt,
+		&ws.ID, &ws.OrganizationID, &ws.Name, &ws.Slug, &ws.Status, &ws.PublicPacks, &ws.CreatedAt, &ws.UpdatedAt,
 	)
 	if err != nil {
 		var pgErr *pgconn.PgError
@@ -4134,9 +4136,9 @@ func (r *Repository) CreateWorkspaceWithAdmin(ctx context.Context, input CreateW
 	err = tx.QueryRow(ctx, `
 		INSERT INTO workspaces (id, organization_id, name, slug, status)
 		VALUES (gen_random_uuid(), $1, $2, $3, 'active')
-		RETURNING id, organization_id, name, slug, status, created_at, updated_at
+		RETURNING id, organization_id, name, slug, status, public_packs, created_at, updated_at
 	`, input.OrganizationID, input.Name, input.Slug).Scan(
-		&ws.ID, &ws.OrganizationID, &ws.Name, &ws.Slug, &ws.Status, &ws.CreatedAt, &ws.UpdatedAt,
+		&ws.ID, &ws.OrganizationID, &ws.Name, &ws.Slug, &ws.Status, &ws.PublicPacks, &ws.CreatedAt, &ws.UpdatedAt,
 	)
 	if err != nil {
 		var pgErr *pgconn.PgError
@@ -4163,9 +4165,9 @@ func (r *Repository) CreateWorkspaceWithAdmin(ctx context.Context, input CreateW
 func (r *Repository) GetWorkspaceByID(ctx context.Context, workspaceID uuid.UUID) (WorkspaceRow, error) {
 	var ws WorkspaceRow
 	err := r.db.QueryRow(ctx, `
-		SELECT id, organization_id, name, slug, status, created_at, updated_at
+		SELECT id, organization_id, name, slug, status, public_packs, created_at, updated_at
 		FROM workspaces WHERE id = $1
-	`, workspaceID).Scan(&ws.ID, &ws.OrganizationID, &ws.Name, &ws.Slug, &ws.Status, &ws.CreatedAt, &ws.UpdatedAt)
+	`, workspaceID).Scan(&ws.ID, &ws.OrganizationID, &ws.Name, &ws.Slug, &ws.Status, &ws.PublicPacks, &ws.CreatedAt, &ws.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return WorkspaceRow{}, ErrWorkspaceNotFound
@@ -4177,7 +4179,7 @@ func (r *Repository) GetWorkspaceByID(ctx context.Context, workspaceID uuid.UUID
 
 func (r *Repository) ListWorkspacesByOrgID(ctx context.Context, orgID uuid.UUID, limit, offset int32) ([]WorkspaceRow, error) {
 	rows, err := r.db.Query(ctx, `
-		SELECT id, organization_id, name, slug, status, created_at, updated_at
+		SELECT id, organization_id, name, slug, status, public_packs, created_at, updated_at
 		FROM workspaces
 		WHERE organization_id = $1 AND status = 'active'
 		ORDER BY name
@@ -4204,7 +4206,7 @@ func (r *Repository) CountWorkspacesByOrgID(ctx context.Context, orgID uuid.UUID
 
 func (r *Repository) ListWorkspacesByOrgIDForMember(ctx context.Context, orgID, userID uuid.UUID, limit, offset int32) ([]WorkspaceRow, error) {
 	rows, err := r.db.Query(ctx, `
-		SELECT w.id, w.organization_id, w.name, w.slug, w.status, w.created_at, w.updated_at
+		SELECT w.id, w.organization_id, w.name, w.slug, w.status, w.public_packs, w.created_at, w.updated_at
 		FROM workspaces w
 		JOIN workspace_memberships wm ON wm.workspace_id = w.id
 		WHERE w.organization_id = $1 AND wm.user_id = $2 AND wm.membership_status = 'active'
@@ -4257,6 +4259,11 @@ func (r *Repository) UpdateWorkspace(ctx context.Context, workspaceID uuid.UUID,
 			setClauses = append(setClauses, "archived_at = NULL")
 		}
 	}
+	if input.PublicPacks != nil {
+		setClauses = append(setClauses, fmt.Sprintf("public_packs = $%d", argIdx))
+		args = append(args, *input.PublicPacks)
+		argIdx++
+	}
 
 	if len(setClauses) == 0 {
 		return r.GetWorkspaceByID(ctx, workspaceID)
@@ -4265,13 +4272,13 @@ func (r *Repository) UpdateWorkspace(ctx context.Context, workspaceID uuid.UUID,
 	query := fmt.Sprintf(`
 		UPDATE workspaces SET %s
 		WHERE id = $%d
-		RETURNING id, organization_id, name, slug, status, created_at, updated_at
+		RETURNING id, organization_id, name, slug, status, public_packs, created_at, updated_at
 	`, strings.Join(setClauses, ", "), argIdx)
 	args = append(args, workspaceID)
 
 	var ws WorkspaceRow
 	err := r.db.QueryRow(ctx, query, args...).Scan(
-		&ws.ID, &ws.OrganizationID, &ws.Name, &ws.Slug, &ws.Status, &ws.CreatedAt, &ws.UpdatedAt,
+		&ws.ID, &ws.OrganizationID, &ws.Name, &ws.Slug, &ws.Status, &ws.PublicPacks, &ws.CreatedAt, &ws.UpdatedAt,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -4305,9 +4312,9 @@ func (r *Repository) ArchiveWorkspaceCascade(ctx context.Context, workspaceID uu
 		UPDATE workspaces
 		SET status = 'archived', archived_at = $2
 		WHERE id = $1
-		RETURNING id, organization_id, name, slug, status, created_at, updated_at
+		RETURNING id, organization_id, name, slug, status, public_packs, created_at, updated_at
 	`, workspaceID, now).Scan(
-		&ws.ID, &ws.OrganizationID, &ws.Name, &ws.Slug, &ws.Status, &ws.CreatedAt, &ws.UpdatedAt,
+		&ws.ID, &ws.OrganizationID, &ws.Name, &ws.Slug, &ws.Status, &ws.PublicPacks, &ws.CreatedAt, &ws.UpdatedAt,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -4326,7 +4333,7 @@ func scanWorkspaceRows(rows pgx.Rows) ([]WorkspaceRow, error) {
 	var workspaces []WorkspaceRow
 	for rows.Next() {
 		var ws WorkspaceRow
-		if err := rows.Scan(&ws.ID, &ws.OrganizationID, &ws.Name, &ws.Slug, &ws.Status, &ws.CreatedAt, &ws.UpdatedAt); err != nil {
+		if err := rows.Scan(&ws.ID, &ws.OrganizationID, &ws.Name, &ws.Slug, &ws.Status, &ws.PublicPacks, &ws.CreatedAt, &ws.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan workspace: %w", err)
 		}
 		workspaces = append(workspaces, ws)

--- a/backend/internal/repository/repository_integration_test.go
+++ b/backend/internal/repository/repository_integration_test.go
@@ -65,6 +65,50 @@ func TestRepositoryUnarchiveModelAliasByKeyInvalidCatalogEntry(t *testing.T) {
 	}
 }
 
+func TestRepositoryListVisibleChallengePacksRespectsPublicPacksOptIn(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	if _, err := db.Exec(ctx, `
+		INSERT INTO challenge_packs (id, workspace_id, slug, name, family)
+		VALUES ($1, $2, $3, $4, $5)
+	`, uuid.New(), fixture.workspaceID, "workspace-only", "Workspace Only", "support"); err != nil {
+		t.Fatalf("insert workspace challenge pack returned error: %v", err)
+	}
+
+	packs, err := repo.ListVisibleChallengePacks(ctx, fixture.workspaceID)
+	if err != nil {
+		t.Fatalf("ListVisibleChallengePacks returned error: %v", err)
+	}
+	if challengePackSlugs(packs)["benchmark-pack"] {
+		t.Fatalf("global pack was visible before public_packs opt-in: %#v", challengePackSlugs(packs))
+	}
+	if !challengePackSlugs(packs)["workspace-only"] {
+		t.Fatalf("workspace pack was not visible: %#v", challengePackSlugs(packs))
+	}
+
+	if _, err := db.Exec(ctx, `UPDATE workspaces SET public_packs = true WHERE id = $1`, fixture.workspaceID); err != nil {
+		t.Fatalf("enable public packs returned error: %v", err)
+	}
+	packs, err = repo.ListVisibleChallengePacks(ctx, fixture.workspaceID)
+	if err != nil {
+		t.Fatalf("ListVisibleChallengePacks after opt-in returned error: %v", err)
+	}
+	if !challengePackSlugs(packs)["benchmark-pack"] {
+		t.Fatalf("global pack was not visible after public_packs opt-in: %#v", challengePackSlugs(packs))
+	}
+}
+
+func challengePackSlugs(packs []repository.ChallengePackSummary) map[string]bool {
+	slugs := make(map[string]bool, len(packs))
+	for _, pack := range packs {
+		slugs[pack.Slug] = true
+	}
+	return slugs
+}
+
 func TestRepositoryListRecentComparableScoredRunsBeforeRunID(t *testing.T) {
 	ctx := context.Background()
 	db := openTestDB(t)

--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -460,6 +460,41 @@ func TestChallengePackListCallsCorrectEndpoint(t *testing.T) {
 	}
 }
 
+func TestWorkspaceUpdateSendsPublicPacks(t *testing.T) {
+	var called bool
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"PATCH /v1/workspaces/ws-1/details": func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body["public_packs"] != true {
+				t.Fatalf("public_packs = %#v, want true", body["public_packs"])
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":              "ws-1",
+				"name":            "Workspace",
+				"slug":            "workspace",
+				"organization_id": "org-1",
+				"status":          "active",
+				"public_packs":    true,
+			})
+		},
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{"workspace", "update", "ws-1", "--public-packs"}, srv.URL)
+	if err != nil {
+		t.Fatalf("workspace update error: %v", err)
+	}
+	if !called {
+		t.Fatal("PATCH /v1/workspaces/ws-1/details was not called")
+	}
+}
+
 func TestInfraModelCatalogListCallsCorrectEndpoint(t *testing.T) {
 	var called bool
 	srv := fakeAPI(t, map[string]http.HandlerFunc{

--- a/cli/cmd/workspace.go
+++ b/cli/cmd/workspace.go
@@ -28,6 +28,7 @@ func init() {
 
 	wsUpdateCmd.Flags().String("name", "", "New workspace name")
 	wsUpdateCmd.Flags().String("status", "", "New status (active, archived)")
+	wsUpdateCmd.Flags().Bool("public-packs", false, "Allow this workspace to use public challenge packs")
 
 	wsMembersInviteCmd.Flags().String("email", "", "Email address to invite (required)")
 	wsMembersInviteCmd.Flags().String("role", "workspace_member", "Role: workspace_admin, workspace_member, workspace_viewer")
@@ -118,6 +119,7 @@ var wsGetCmd = &cobra.Command{
 		rc.Output.PrintDetail("Slug", str(ws["slug"]))
 		rc.Output.PrintDetail("Org ID", str(ws["organization_id"]))
 		rc.Output.PrintDetail("Status", output.StatusColor(str(ws["status"])))
+		rc.Output.PrintDetail("Public Packs", boolLabel(ws["public_packs"]))
 		rc.Output.PrintDetail("Created", str(ws["created_at"]))
 		return nil
 	},
@@ -182,8 +184,12 @@ var wsUpdateCmd = &cobra.Command{
 			v, _ := cmd.Flags().GetString("status")
 			body["status"] = v
 		}
+		if cmd.Flags().Changed("public-packs") {
+			v, _ := cmd.Flags().GetBool("public-packs")
+			body["public_packs"] = v
+		}
 		if len(body) == 0 {
-			return fmt.Errorf("no fields to update; use --name or --status")
+			return fmt.Errorf("no fields to update; use --name, --status, or --public-packs")
 		}
 
 		resp, err := rc.Client.Patch(cmd.Context(), "/v1/workspaces/"+args[0]+"/details", body)
@@ -206,6 +212,13 @@ var wsUpdateCmd = &cobra.Command{
 		rc.Output.PrintSuccess(fmt.Sprintf("Updated workspace %s", args[0]))
 		return nil
 	},
+}
+
+func boolLabel(value any) string {
+	if b, ok := value.(bool); ok && b {
+		return "enabled"
+	}
+	return "disabled"
 }
 
 var wsUseCmd = &cobra.Command{

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -5556,10 +5556,12 @@ components:
         status:
           type: string
           enum: [active, archived]
+        public_packs:
+          type: boolean
 
     WorkspaceDetailResponse:
       type: object
-      required: [id, organization_id, name, slug, status, created_at, updated_at]
+      required: [id, organization_id, name, slug, status, public_packs, created_at, updated_at]
       properties:
         id:
           type: string
@@ -5573,6 +5575,8 @@ components:
           type: string
         status:
           type: string
+        public_packs:
+          type: boolean
         created_at:
           type: string
           format: date-time

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/settings/ws-general-settings.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/settings/ws-general-settings.tsx
@@ -41,7 +41,10 @@ export function WsGeneralSettings({ workspace: initialWs }: WsGeneralSettingsPro
     setSaving(true);
     try {
       const token = await getAccessToken();
-      if (!token) return;
+      if (!token) {
+        toast.error("Sign in again to update the workspace name");
+        return;
+      }
       const api = createApiClient(token);
       const updated = await api.patch<WorkspaceDetail>(
         `/v1/workspaces/${ws.id}/details`,
@@ -62,7 +65,10 @@ export function WsGeneralSettings({ workspace: initialWs }: WsGeneralSettingsPro
     setSavingPublicPacks(true);
     try {
       const token = await getAccessToken();
-      if (!token) return;
+      if (!token) {
+        toast.error("Sign in again to update challenge pack access");
+        return;
+      }
       const api = createApiClient(token);
       const updated = await api.patch<WorkspaceDetail>(
         `/v1/workspaces/${ws.id}/details`,

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/settings/ws-general-settings.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/settings/ws-general-settings.tsx
@@ -31,6 +31,7 @@ export function WsGeneralSettings({ workspace: initialWs }: WsGeneralSettingsPro
   const [ws, setWs] = useState(initialWs);
   const [name, setName] = useState(ws.name);
   const [saving, setSaving] = useState(false);
+  const [savingPublicPacks, setSavingPublicPacks] = useState(false);
   const [archiveOpen, setArchiveOpen] = useState(false);
   const [archiveConfirm, setArchiveConfirm] = useState("");
   const [archiving, setArchiving] = useState(false);
@@ -57,6 +58,29 @@ export function WsGeneralSettings({ workspace: initialWs }: WsGeneralSettingsPro
     }
   }
 
+  async function handlePublicPacksChange(publicPacks: boolean) {
+    setSavingPublicPacks(true);
+    try {
+      const token = await getAccessToken();
+      if (!token) return;
+      const api = createApiClient(token);
+      const updated = await api.patch<WorkspaceDetail>(
+        `/v1/workspaces/${ws.id}/details`,
+        { public_packs: publicPacks },
+      );
+      toast.success("Challenge pack access updated");
+      setWs(updated);
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError
+          ? err.message
+          : "Failed to update challenge pack access",
+      );
+    } finally {
+      setSavingPublicPacks(false);
+    }
+  }
+
   async function handleArchive() {
     setArchiving(true);
     try {
@@ -75,6 +99,11 @@ export function WsGeneralSettings({ workspace: initialWs }: WsGeneralSettingsPro
     } finally {
       setArchiving(false);
     }
+  }
+
+  function publicPacksStateLabel() {
+    if (savingPublicPacks) return "Saving";
+    return ws.public_packs ? "Enabled" : "Disabled";
   }
 
   return (
@@ -112,6 +141,29 @@ export function WsGeneralSettings({ workspace: initialWs }: WsGeneralSettingsPro
             {ws.slug}
           </code>
         </p>
+      </div>
+
+      <div className="rounded-lg border border-border p-4">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h3 className="text-sm font-medium">Public Challenge Packs</h3>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Allow this workspace to use the shared challenge pack catalog.
+            </p>
+          </div>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={ws.public_packs}
+              disabled={savingPublicPacks}
+              onChange={(event) =>
+                handlePublicPacksChange(event.currentTarget.checked)
+              }
+              className="size-4 accent-primary"
+            />
+            {publicPacksStateLabel()}
+          </label>
+        </div>
       </div>
 
       {/* Workspace ID (for API/CLI) */}

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -131,6 +131,7 @@ export interface OrgWorkspace {
   name: string;
   slug: string;
   status: string; // "active" | "archived"
+  public_packs: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -149,6 +150,7 @@ export interface WorkspaceDetail {
   name: string;
   slug: string;
   status: string; // "active" | "archived"
+  public_packs: boolean;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
Closes #716.

## Summary
- add `workspaces.public_packs` and expose it through workspace details/update APIs
- gate global challenge pack catalog visibility, input-set reads, run/eval-session creation, and regression capture unless the workspace opts in
- add CLI and workspace settings controls for toggling public challenge pack access

## Tests
- `cd backend && go test ./internal/api -run 'ChallengePack|RunCreationManagerRejectsGlobalChallengePack|Workspace' -count=1`\n- `cd backend && go test ./internal/api ./internal/repository -count=1`\n- `cd backend && go test ./...`\n- `cd backend && go vet ./...`\n- `cd cli && go test ./cmd -run 'TestWorkspaceUpdateSendsPublicPacks|TestChallengePackListCallsCorrectEndpoint' -count=1`\n- `cd cli && go test ./...`\n- `cd cli && go vet ./...`\n\n## Not run\n- `cd web && pnpm lint` (local `node_modules` missing; `eslint: command not found`)\n