### PR TITLE
feat(cli): add run replay and compare commands

### DIFF
--- a/cli/cmd/compare.go
+++ b/cli/cmd/compare.go
@@ -13,13 +13,10 @@ func init() {
 	rootCmd.AddCommand(compareCmd)
 	compareCmd.AddCommand(compareRunsCmd)
 	compareCmd.AddCommand(compareGateCmd)
+	runCmd.AddCommand(runCompareCmd)
 
-	compareRunsCmd.Flags().String("baseline", "", "Baseline run ID (required)")
-	compareRunsCmd.Flags().String("candidate", "", "Candidate run ID (required)")
-	compareRunsCmd.Flags().String("baseline-agent", "", "Baseline run agent ID (optional)")
-	compareRunsCmd.Flags().String("candidate-agent", "", "Candidate run agent ID (optional)")
-	compareRunsCmd.MarkFlagRequired("baseline")
-	compareRunsCmd.MarkFlagRequired("candidate")
+	addRunComparisonFlags(compareRunsCmd)
+	addRunComparisonFlags(runCompareCmd)
 
 	compareGateCmd.Flags().String("baseline", "", "Baseline run ID (required)")
 	compareGateCmd.Flags().String("candidate", "", "Candidate run ID (required)")
@@ -38,104 +35,131 @@ var compareRunsCmd = &cobra.Command{
 	Use:   "runs",
 	Short: "Compare baseline vs candidate runs",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		rc := GetRunContext(cmd)
-		baseline, _ := cmd.Flags().GetString("baseline")
-		candidate, _ := cmd.Flags().GetString("candidate")
-
-		q := url.Values{}
-		q.Set("baseline_run_id", baseline)
-		q.Set("candidate_run_id", candidate)
-		if v, _ := cmd.Flags().GetString("baseline-agent"); v != "" {
-			q.Set("baseline_run_agent_id", v)
-		}
-		if v, _ := cmd.Flags().GetString("candidate-agent"); v != "" {
-			q.Set("candidate_run_agent_id", v)
-		}
-
-		resp, err := rc.Client.Get(cmd.Context(), "/v1/compare", q)
-		if err != nil {
-			return err
-		}
-		if apiErr := resp.ParseError(); apiErr != nil {
-			return apiErr
-		}
-
-		var result map[string]any
-		if err := resp.DecodeJSON(&result); err != nil {
-			return err
-		}
-
-		if rc.Output.IsStructured() {
-			return rc.Output.PrintRaw(result)
-		}
-
-		fmt.Fprintln(rc.Output.Writer(), output.Bold("Run Comparison"))
-		fmt.Fprintf(rc.Output.Writer(), "  Baseline:  %s\n", baseline)
-		fmt.Fprintf(rc.Output.Writer(), "  Candidate: %s\n\n", candidate)
-		rc.Output.PrintDetail("State", mapString(result, "state"))
-		rc.Output.PrintDetail("Status", output.StatusColor(mapString(result, "status")))
-		if reason := mapString(result, "reason_code"); reason != "" {
-			rc.Output.PrintDetail("Reason", reason)
-		}
-		if generated := mapString(result, "generated_at"); generated != "" {
-			rc.Output.PrintDetail("Generated", generated)
-		}
-		fmt.Fprintln(rc.Output.Writer())
-
-		if deltas := mapSlice(result, "key_deltas"); len(deltas) > 0 {
-			cols := []output.Column{{Header: "Metric"}, {Header: "Baseline"}, {Header: "Candidate"}, {Header: "Delta"}, {Header: "Outcome"}}
-			rows := make([][]string, len(deltas))
-			for i, d := range deltas {
-				delta := d.(map[string]any)
-				rows[i] = []string{
-					mapString(delta, "metric"),
-					fmtScore(mapValue(delta, "baseline_value")),
-					fmtScore(mapValue(delta, "candidate_value")),
-					fmtDelta(mapValue(delta, "delta")),
-					mapString(delta, "outcome", "state"),
-				}
-			}
-			rc.Output.PrintTable(cols, rows)
-		} else if dimensions := mapSlice(result, "dimensions"); len(dimensions) > 0 {
-			cols := []output.Column{{Header: "Dimension"}, {Header: "Baseline"}, {Header: "Candidate"}, {Header: "Delta"}}
-			rows := make([][]string, len(dimensions))
-			for i, d := range dimensions {
-				dim := d.(map[string]any)
-				delta := fmtDelta(dim["delta"])
-				rows[i] = []string{
-					str(dim["name"]),
-					fmtScore(dim["baseline_score"]),
-					fmtScore(dim["candidate_score"]),
-					delta,
-				}
-			}
-			rc.Output.PrintTable(cols, rows)
-		}
-		if reasons := mapSlice(result, "regression_reasons"); len(reasons) > 0 {
-			fmt.Fprintln(rc.Output.Writer())
-			fmt.Fprintln(rc.Output.Writer(), output.Bold("Regression Reasons"))
-			for _, reason := range reasons {
-				fmt.Fprintf(rc.Output.Writer(), "  - %s\n", str(reason))
-			}
-		}
-		if evidence := mapObject(result, "evidence_quality"); evidence != nil {
-			if warnings := mapSlice(evidence, "warnings"); len(warnings) > 0 {
-				fmt.Fprintln(rc.Output.Writer())
-				fmt.Fprintln(rc.Output.Writer(), output.Bold("Evidence Warnings"))
-				for _, warning := range warnings {
-					fmt.Fprintf(rc.Output.Writer(), "  - %s\n", str(warning))
-				}
-			}
-			if missing := mapSlice(evidence, "missing_fields"); len(missing) > 0 {
-				fmt.Fprintln(rc.Output.Writer())
-				fmt.Fprintln(rc.Output.Writer(), output.Bold("Missing Evidence"))
-				for _, field := range missing {
-					fmt.Fprintf(rc.Output.Writer(), "  - %s\n", str(field))
-				}
-			}
-		}
-		return nil
+		return executeCompareRuns(cmd)
 	},
+}
+
+var runCompareCmd = &cobra.Command{
+	Use:   "compare",
+	Short: "Compare a baseline run against a candidate run",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return executeCompareRuns(cmd)
+	},
+}
+
+func addRunComparisonFlags(cmd *cobra.Command) {
+	cmd.Flags().String("baseline", "", "Baseline run ID (required)")
+	cmd.Flags().String("candidate", "", "Candidate run ID (required)")
+	cmd.Flags().String("baseline-agent", "", "Baseline run agent ID (optional)")
+	cmd.Flags().String("candidate-agent", "", "Candidate run agent ID (optional)")
+	_ = cmd.MarkFlagRequired("baseline")
+	_ = cmd.MarkFlagRequired("candidate")
+}
+
+func executeCompareRuns(cmd *cobra.Command) error {
+	rc := GetRunContext(cmd)
+	baseline, _ := cmd.Flags().GetString("baseline")
+	candidate, _ := cmd.Flags().GetString("candidate")
+
+	q := url.Values{}
+	q.Set("baseline_run_id", baseline)
+	q.Set("candidate_run_id", candidate)
+	if v, _ := cmd.Flags().GetString("baseline-agent"); v != "" {
+		q.Set("baseline_run_agent_id", v)
+	}
+	if v, _ := cmd.Flags().GetString("candidate-agent"); v != "" {
+		q.Set("candidate_run_agent_id", v)
+	}
+
+	resp, err := rc.Client.Get(cmd.Context(), "/v1/compare", q)
+	if err != nil {
+		return err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return apiErr
+	}
+
+	var result map[string]any
+	if err := resp.DecodeJSON(&result); err != nil {
+		return err
+	}
+
+	if rc.Output.IsStructured() {
+		return rc.Output.PrintRaw(result)
+	}
+
+	fmt.Fprintln(rc.Output.Writer(), output.Bold("Run Comparison"))
+	fmt.Fprintf(rc.Output.Writer(), "  Baseline:  %s\n", baseline)
+	fmt.Fprintf(rc.Output.Writer(), "  Candidate: %s\n\n", candidate)
+	rc.Output.PrintDetail("State", output.SanitizeLine(mapString(result, "state")))
+	rc.Output.PrintDetail("Status", output.StatusColor(output.SanitizeLine(mapString(result, "status"))))
+	if reason := mapString(result, "reason_code"); reason != "" {
+		rc.Output.PrintDetail("Reason", output.SanitizeLine(reason))
+	}
+	if generated := mapString(result, "generated_at"); generated != "" {
+		rc.Output.PrintDetail("Generated", output.SanitizeLine(generated))
+	}
+	fmt.Fprintln(rc.Output.Writer())
+
+	if deltas := mapSlice(result, "key_deltas"); len(deltas) > 0 {
+		cols := []output.Column{{Header: "Metric"}, {Header: "Baseline"}, {Header: "Candidate"}, {Header: "Delta"}, {Header: "Outcome"}}
+		rows := make([][]string, 0, len(deltas))
+		for _, d := range deltas {
+			delta, ok := d.(map[string]any)
+			if !ok {
+				continue
+			}
+			rows = append(rows, []string{
+				output.SanitizeLine(mapString(delta, "metric")),
+				fmtScore(mapValue(delta, "baseline_value")),
+				fmtScore(mapValue(delta, "candidate_value")),
+				fmtDelta(mapValue(delta, "delta")),
+				output.SanitizeLine(mapString(delta, "outcome", "state")),
+			})
+		}
+		rc.Output.PrintTable(cols, rows)
+	} else if dimensions := mapSlice(result, "dimensions"); len(dimensions) > 0 {
+		cols := []output.Column{{Header: "Dimension"}, {Header: "Baseline"}, {Header: "Candidate"}, {Header: "Delta"}}
+		rows := make([][]string, 0, len(dimensions))
+		for _, d := range dimensions {
+			dim, ok := d.(map[string]any)
+			if !ok {
+				continue
+			}
+			delta := fmtDelta(dim["delta"])
+			rows = append(rows, []string{
+				output.SanitizeLine(str(dim["name"])),
+				fmtScore(dim["baseline_score"]),
+				fmtScore(dim["candidate_score"]),
+				delta,
+			})
+		}
+		rc.Output.PrintTable(cols, rows)
+	}
+	if reasons := mapSlice(result, "regression_reasons"); len(reasons) > 0 {
+		fmt.Fprintln(rc.Output.Writer())
+		fmt.Fprintln(rc.Output.Writer(), output.Bold("Regression Reasons"))
+		for _, reason := range reasons {
+			fmt.Fprintf(rc.Output.Writer(), "  - %s\n", output.SanitizeLine(str(reason)))
+		}
+	}
+	if evidence := mapObject(result, "evidence_quality"); evidence != nil {
+		if warnings := mapSlice(evidence, "warnings"); len(warnings) > 0 {
+			fmt.Fprintln(rc.Output.Writer())
+			fmt.Fprintln(rc.Output.Writer(), output.Bold("Evidence Warnings"))
+			for _, warning := range warnings {
+				fmt.Fprintf(rc.Output.Writer(), "  - %s\n", output.SanitizeLine(str(warning)))
+			}
+		}
+		if missing := mapSlice(evidence, "missing_fields"); len(missing) > 0 {
+			fmt.Fprintln(rc.Output.Writer())
+			fmt.Fprintln(rc.Output.Writer(), output.Bold("Missing Evidence"))
+			for _, field := range missing {
+				fmt.Fprintf(rc.Output.Writer(), "  - %s\n", output.SanitizeLine(str(field)))
+			}
+		}
+	}
+	return nil
 }
 
 // Exit codes for `agentclash compare gate`. Documented in the command's Long

--- a/cli/cmd/replay.go
+++ b/cli/cmd/replay.go
@@ -11,9 +11,12 @@ import (
 func init() {
 	rootCmd.AddCommand(replayCmd)
 	replayCmd.AddCommand(replayGetCmd)
+	runCmd.AddCommand(runReplayCmd)
 
 	replayGetCmd.Flags().Int("cursor", 0, "Step offset to start from")
 	replayGetCmd.Flags().Int("limit", 50, "Steps per page (1-200)")
+	runReplayCmd.Flags().Int("cursor", 0, "Step offset to start from")
+	runReplayCmd.Flags().Int("limit", 50, "Steps per page (1-200)")
 }
 
 var replayCmd = &cobra.Command{
@@ -26,61 +29,77 @@ var replayGetCmd = &cobra.Command{
 	Short: "Get execution replay steps",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		rc := GetRunContext(cmd)
-
-		q := url.Values{}
-		if cursor, _ := cmd.Flags().GetInt("cursor"); cursor > 0 {
-			q.Set("cursor", fmt.Sprintf("%d", cursor))
-		}
-		if limit, _ := cmd.Flags().GetInt("limit"); limit > 0 {
-			q.Set("limit", fmt.Sprintf("%d", limit))
-		}
-
-		resp, err := rc.Client.Get(cmd.Context(), "/v1/replays/"+args[0], q)
-		if err != nil {
-			return err
-		}
-		if handled, err := handleStatefulReadResponse(rc, resp, "Replay"); handled {
-			return err
-		}
-		if apiErr := resp.ParseError(); apiErr != nil {
-			return apiErr
-		}
-
-		var replay map[string]any
-		if err := resp.DecodeJSON(&replay); err != nil {
-			return err
-		}
-
-		if rc.Output.IsStructured() {
-			return rc.Output.PrintRaw(replay)
-		}
-
-		rc.Output.PrintDetail("Run Agent ID", args[0])
-		rc.Output.PrintDetail("State", output.StatusColor(mapString(replay, "state", "status")))
-		if message := mapString(replay, "message"); message != "" {
-			rc.Output.PrintDetail("Message", message)
-		}
-		if runAgentStatus := mapString(replay, "run_agent_status"); runAgentStatus != "" {
-			rc.Output.PrintDetail("Run Agent Status", output.StatusColor(runAgentStatus))
-		}
-
-		if steps, ok := replay["steps"].([]any); ok {
-			fmt.Fprintf(rc.Output.Writer(), "\n%s (%d steps)\n\n", output.Bold("Replay Steps"), len(steps))
-			cols := []output.Column{{Header: "#"}, {Header: "Type"}, {Header: "Summary"}}
-			rows := make([][]string, len(steps))
-			for i, s := range steps {
-				step := s.(map[string]any)
-				rows[i] = []string{
-					fmt.Sprintf("%d", i+1),
-					output.SanitizeControl(str(step["step_type"])),
-					truncateRunes(output.SanitizeControl(str(step["summary"])), 80),
-				}
-			}
-			rc.Output.PrintTable(cols, rows)
-		}
-		return nil
+		return executeReplayGet(cmd, args[0])
 	},
+}
+
+var runReplayCmd = &cobra.Command{
+	Use:   "replay <run-agent-id>",
+	Short: "Inspect replay steps for a run agent",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return executeReplayGet(cmd, args[0])
+	},
+}
+
+func executeReplayGet(cmd *cobra.Command, runAgentID string) error {
+	rc := GetRunContext(cmd)
+
+	q := url.Values{}
+	if cursor, _ := cmd.Flags().GetInt("cursor"); cursor > 0 {
+		q.Set("cursor", fmt.Sprintf("%d", cursor))
+	}
+	if limit, _ := cmd.Flags().GetInt("limit"); limit > 0 {
+		q.Set("limit", fmt.Sprintf("%d", limit))
+	}
+
+	resp, err := rc.Client.Get(cmd.Context(), "/v1/replays/"+runAgentID, q)
+	if err != nil {
+		return err
+	}
+	if handled, err := handleStatefulReadResponse(rc, resp, "Replay"); handled {
+		return err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return apiErr
+	}
+
+	var replay map[string]any
+	if err := resp.DecodeJSON(&replay); err != nil {
+		return err
+	}
+
+	if rc.Output.IsStructured() {
+		return rc.Output.PrintRaw(replay)
+	}
+
+	rc.Output.PrintDetail("Run Agent ID", runAgentID)
+	rc.Output.PrintDetail("State", output.StatusColor(output.SanitizeLine(mapString(replay, "state", "status"))))
+	if message := mapString(replay, "message"); message != "" {
+		rc.Output.PrintDetail("Message", output.SanitizeLine(message))
+	}
+	if runAgentStatus := mapString(replay, "run_agent_status"); runAgentStatus != "" {
+		rc.Output.PrintDetail("Run Agent Status", output.StatusColor(output.SanitizeLine(runAgentStatus)))
+	}
+
+	if steps, ok := replay["steps"].([]any); ok {
+		cols := []output.Column{{Header: "#"}, {Header: "Type"}, {Header: "Summary"}}
+		rows := make([][]string, 0, len(steps))
+		for _, s := range steps {
+			step, ok := s.(map[string]any)
+			if !ok {
+				continue
+			}
+			rows = append(rows, []string{
+				fmt.Sprintf("%d", len(rows)+1),
+				output.SanitizeControl(str(step["step_type"])),
+				truncateRunes(output.SanitizeControl(str(step["summary"])), 80),
+			})
+		}
+		fmt.Fprintf(rc.Output.Writer(), "\n%s (%d steps)\n\n", output.Bold("Replay Steps"), len(rows))
+		rc.Output.PrintTable(cols, rows)
+	}
+	return nil
 }
 
 // truncateRunes returns s trimmed to at most max runes, appending "…" when

--- a/cli/cmd/run_replay_compare_test.go
+++ b/cli/cmd/run_replay_compare_test.go
@@ -1,0 +1,317 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestRunReplayCallsReplayEndpointAndRendersSteps(t *testing.T) {
+	var gotCursor string
+	var gotLimit string
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/replays/agent-1": func(w http.ResponseWriter, r *http.Request) {
+			gotCursor = r.URL.Query().Get("cursor")
+			gotLimit = r.URL.Query().Get("limit")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]any{
+				"state":            "ready",
+				"run_agent_status": "completed",
+				"steps": []map[string]any{
+					{"step_type": "model_call", "summary": "Explained the fix"},
+					{"step_type": "tool_call", "summary": "Ran regression tests"},
+				},
+			})
+		},
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"run", "replay", "agent-1", "--cursor", "3", "--limit", "2",
+	}, srv.URL); err != nil {
+		t.Fatalf("run replay error: %v", err)
+	}
+
+	if gotCursor != "3" || gotLimit != "2" {
+		t.Fatalf("query cursor/limit = %q/%q, want 3/2", gotCursor, gotLimit)
+	}
+	out := stdout.finish()
+	for _, snippet := range []string{
+		"Run Agent ID:",
+		"agent-1",
+		"Replay Steps",
+		"model_call",
+		"Ran regression tests",
+	} {
+		if !strings.Contains(out, snippet) {
+			t.Fatalf("run replay output missing %q\n---\n%s", snippet, out)
+		}
+	}
+}
+
+func TestReplayGetLegacySurfaceUsesSharedReplayPath(t *testing.T) {
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/replays/agent-1": jsonHandler(http.StatusOK, map[string]any{
+			"state":            "ready",
+			"run_agent_status": "completed",
+			"steps": []map[string]any{
+				{"step_type": "model_call", "summary": "Legacy replay still works"},
+			},
+		}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{"replay", "get", "agent-1", "--limit", "1"}, srv.URL); err != nil {
+		t.Fatalf("replay get error: %v", err)
+	}
+
+	out := stdout.finish()
+	if !strings.Contains(out, "Legacy replay still works") {
+		t.Fatalf("legacy replay output missing shared renderer content\n---\n%s", out)
+	}
+}
+
+func TestRunCompareCallsCompareEndpointAndRendersRegressionSummary(t *testing.T) {
+	var gotBaseline string
+	var gotCandidate string
+	var gotBaselineAgent string
+	var gotCandidateAgent string
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/compare": func(w http.ResponseWriter, r *http.Request) {
+			gotBaseline = r.URL.Query().Get("baseline_run_id")
+			gotCandidate = r.URL.Query().Get("candidate_run_id")
+			gotBaselineAgent = r.URL.Query().Get("baseline_run_agent_id")
+			gotCandidateAgent = r.URL.Query().Get("candidate_run_agent_id")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]any{
+				"state":       "comparable",
+				"status":      "regression",
+				"reason_code": "correctness_regressed",
+				"key_deltas": []map[string]any{
+					{
+						"metric":          "correctness",
+						"baseline_value":  0.96,
+						"candidate_value": 0.81,
+						"delta":           -0.15,
+						"outcome":         "regressed",
+					},
+				},
+				"regression_reasons": []string{
+					"candidate failed a regression case that baseline passed",
+				},
+				"evidence_quality": map[string]any{
+					"warnings": []string{"candidate replay omitted one terminal event"},
+				},
+			})
+		},
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"run", "compare",
+		"--baseline", "run-b",
+		"--candidate", "run-c",
+		"--baseline-agent", "agent-b",
+		"--candidate-agent", "agent-c",
+	}, srv.URL); err != nil {
+		t.Fatalf("run compare error: %v", err)
+	}
+
+	if gotBaseline != "run-b" || gotCandidate != "run-c" || gotBaselineAgent != "agent-b" || gotCandidateAgent != "agent-c" {
+		t.Fatalf("compare query = baseline %q candidate %q baseline-agent %q candidate-agent %q", gotBaseline, gotCandidate, gotBaselineAgent, gotCandidateAgent)
+	}
+	out := stdout.finish()
+	for _, snippet := range []string{
+		"Run Comparison",
+		"correctness_regressed",
+		"correctness",
+		"regressed",
+		"candidate failed a regression case",
+		"candidate replay omitted one terminal event",
+	} {
+		if !strings.Contains(out, snippet) {
+			t.Fatalf("run compare output missing %q\n---\n%s", snippet, out)
+		}
+	}
+}
+
+func TestCompareRunsLegacySurfaceUsesSharedComparePath(t *testing.T) {
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/compare": jsonHandler(http.StatusOK, map[string]any{
+			"state":       "comparable",
+			"status":      "improved",
+			"reason_code": "candidate_improved",
+			"key_deltas": []map[string]any{
+				{
+					"metric":          "correctness",
+					"baseline_value":  0.81,
+					"candidate_value": 0.96,
+					"delta":           0.15,
+					"outcome":         "improved",
+				},
+			},
+		}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"compare", "runs", "--baseline", "run-b", "--candidate", "run-c",
+	}, srv.URL); err != nil {
+		t.Fatalf("compare runs error: %v", err)
+	}
+
+	out := stdout.finish()
+	for _, snippet := range []string{"Run Comparison", "candidate_improved", "improved"} {
+		if !strings.Contains(out, snippet) {
+			t.Fatalf("legacy compare output missing %q\n---\n%s", snippet, out)
+		}
+	}
+}
+
+func TestRunCompareSanitizesRegressionReasonLines(t *testing.T) {
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/compare": jsonHandler(http.StatusOK, map[string]any{
+			"state":        "comparable\nstate",
+			"status":       "regression\x1b[2J",
+			"reason_code":  "correctness_regressed\nreason",
+			"generated_at": "2026-05-11T10:00:00Z\ngenerated",
+			"key_deltas": []any{
+				nil,
+				"not an object",
+				map[string]any{
+					"metric":          "correctness\nmetric",
+					"baseline_value":  0.96,
+					"candidate_value": 0.81,
+					"delta":           -0.15,
+					"outcome":         "regressed\noutcome",
+				},
+			},
+			"regression_reasons": []string{
+				"candidate regressed\x1b[2J\nerror: forged reason",
+			},
+			"evidence_quality": map[string]any{
+				"warnings":       []string{"missing replay\x07\nwarning: forged warning"},
+				"missing_fields": []string{"summary\nfield"},
+			},
+		}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"run", "compare", "--baseline", "run-b", "--candidate", "run-c",
+	}, srv.URL); err != nil {
+		t.Fatalf("run compare error: %v", err)
+	}
+
+	out := stdout.finish()
+	for _, forbidden := range []string{"\x1b", "\x07"} {
+		if strings.Contains(out, forbidden) {
+			t.Fatalf("compare output leaked control byte %q: %q", forbidden, out)
+		}
+	}
+	for _, line := range strings.Split(out, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "error: forged") || strings.HasPrefix(trimmed, "warning: forged") || trimmed == "field" {
+			t.Fatalf("compare output allowed forged newline line: %q", out)
+		}
+	}
+	for _, snippet := range []string{
+		"comparable state",
+		"correctness_regressed reason",
+		"2026-05-11T10:00:00Z generated",
+		"correctness metric",
+		"regressed outcome",
+		"candidate regressed",
+		"error: forged reason",
+	} {
+		if !strings.Contains(out, snippet) {
+			t.Fatalf("sanitized compare output missing %q\n---\n%s", snippet, out)
+		}
+	}
+}
+
+func TestRunCompareSanitizesDimensionTableCells(t *testing.T) {
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/compare": jsonHandler(http.StatusOK, map[string]any{
+			"state":  "comparable",
+			"status": "stable",
+			"dimensions": []any{
+				nil,
+				map[string]any{
+					"name":            "instruction following\nDimension",
+					"baseline_score":  0.9,
+					"candidate_score": 0.8,
+					"delta":           -0.1,
+				},
+			},
+		}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"run", "compare", "--baseline", "run-b", "--candidate", "run-c",
+	}, srv.URL); err != nil {
+		t.Fatalf("run compare error: %v", err)
+	}
+
+	out := stdout.finish()
+	if !strings.Contains(out, "instruction following Dimension") {
+		t.Fatalf("sanitized dimension name missing\n---\n%s", out)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.TrimSpace(line) == "Dimension" {
+			t.Fatalf("dimension table allowed forged newline line: %q", out)
+		}
+	}
+}
+
+func TestRunReplaySanitizesDetailLines(t *testing.T) {
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/replays/agent-1": jsonHandler(http.StatusOK, map[string]any{
+			"state":            "ready\nstate",
+			"message":          "finished\x1b[2J\nerror: forged message",
+			"run_agent_status": "completed\nstatus",
+			"steps": []any{
+				nil,
+				map[string]any{"step_type": "model_call", "summary": "ok"},
+			},
+		}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{"run", "replay", "agent-1"}, srv.URL); err != nil {
+		t.Fatalf("run replay error: %v", err)
+	}
+
+	out := stdout.finish()
+	if strings.Contains(out, "\x1b") {
+		t.Fatalf("replay output leaked control byte: %q", out)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "error: forged") {
+			t.Fatalf("replay output allowed forged newline line: %q", out)
+		}
+	}
+	for _, snippet := range []string{"ready state", "finished", "error: forged message", "completed status"} {
+		if !strings.Contains(out, snippet) {
+			t.Fatalf("sanitized replay output missing %q\n---\n%s", snippet, out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- adds first-class `agentclash run replay <run-agent-id>` over the replay read API
- adds first-class `agentclash run compare --baseline --candidate` over the run comparison API
- keeps the existing top-level `replay get` and `compare runs` surfaces by sharing the same execution/rendering helpers
- adds CLI tests for route calls, pagination/agent query forwarding, rendered replay steps, regression deltas, regression reasons, and evidence warnings

Closes #713

## Tests
- go test ./cmd -run 'TestRunReplay|TestRunCompare|TestCompareRuns|TestReplayGet' -count=1\n- go test -short -count=1 ./...\n- go build ./...\n- go vet ./...