### PR TITLE
feat: add agent build version templates

### DIFF
--- a/backend/internal/api/agent_build_templates.go
+++ b/backend/internal/api/agent_build_templates.go
@@ -1,0 +1,196 @@
+package api
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+)
+
+type agentBuildVersionTemplate struct {
+	Key             string
+	Name            string
+	Description     string
+	AgentKind       string
+	InterfaceSpec   json.RawMessage
+	PolicySpec      json.RawMessage
+	ReasoningSpec   json.RawMessage
+	MemorySpec      json.RawMessage
+	WorkflowSpec    json.RawMessage
+	GuardrailSpec   json.RawMessage
+	ModelSpec       json.RawMessage
+	OutputSchema    json.RawMessage
+	TraceContract   json.RawMessage
+	PublicationSpec json.RawMessage
+}
+
+type agentBuildVersionTemplateResponse struct {
+	Key             string          `json:"key"`
+	Name            string          `json:"name"`
+	Description     string          `json:"description"`
+	AgentKind       string          `json:"agent_kind"`
+	InterfaceSpec   json.RawMessage `json:"interface_spec"`
+	PolicySpec      json.RawMessage `json:"policy_spec"`
+	ReasoningSpec   json.RawMessage `json:"reasoning_spec"`
+	MemorySpec      json.RawMessage `json:"memory_spec"`
+	WorkflowSpec    json.RawMessage `json:"workflow_spec"`
+	GuardrailSpec   json.RawMessage `json:"guardrail_spec"`
+	ModelSpec       json.RawMessage `json:"model_spec"`
+	OutputSchema    json.RawMessage `json:"output_schema"`
+	TraceContract   json.RawMessage `json:"trace_contract"`
+	PublicationSpec json.RawMessage `json:"publication_spec"`
+}
+
+var agentBuildVersionTemplates = map[string]agentBuildVersionTemplate{
+	"code-reviewer": {
+		Key:         "code-reviewer",
+		Name:        "Code Reviewer",
+		Description: "Reviews source changes for correctness, regressions, security risks, and missing tests.",
+		AgentKind:   "llm_agent",
+		PolicySpec: json.RawMessage(`{
+			"instructions": "You are a senior code reviewer. Prioritize correctness bugs, security and privacy risks, behavioral regressions, and missing tests. Lead with actionable findings and cite concrete files or evidence when possible."
+		}`),
+		ReasoningSpec: json.RawMessage(`{
+			"mode": "deliberate",
+			"review_focus": ["correctness", "security", "regressions", "tests"]
+		}`),
+		ModelSpec: json.RawMessage(`{
+			"temperature": 0.1
+		}`),
+		OutputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"findings": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"severity": {"type": "string"},
+							"title": {"type": "string"},
+							"location": {"type": "string"},
+							"recommendation": {"type": "string"}
+						}
+					}
+				},
+				"summary": {"type": "string"}
+			}
+		}`),
+		TraceContract: json.RawMessage(`{
+			"required_events": ["analysis", "finding_summary"]
+		}`),
+		PublicationSpec: json.RawMessage(`{
+			"display": "review_findings"
+		}`),
+	},
+	"honest-agent": {
+		Key:         "honest-agent",
+		Name:        "Honest Agent",
+		Description: "Answers directly, states uncertainty, and refuses to invent facts when evidence is missing.",
+		AgentKind:   "llm_agent",
+		PolicySpec: json.RawMessage(`{
+			"instructions": "Answer honestly and directly. State uncertainty, ask for missing context when it matters, and never invent facts, tool results, citations, or successful actions."
+		}`),
+		ReasoningSpec: json.RawMessage(`{
+			"mode": "careful",
+			"uncertainty_policy": "state_limits"
+		}`),
+		ModelSpec: json.RawMessage(`{
+			"temperature": 0.2
+		}`),
+		OutputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"answer": {"type": "string"},
+				"confidence": {"type": "string"},
+				"open_questions": {
+					"type": "array",
+					"items": {"type": "string"}
+				}
+			}
+		}`),
+		TraceContract: json.RawMessage(`{
+			"required_events": ["answer"]
+		}`),
+		PublicationSpec: json.RawMessage(`{
+			"display": "answer"
+		}`),
+	},
+}
+
+func listAgentBuildVersionTemplateResponses() []agentBuildVersionTemplateResponse {
+	keys := make([]string, 0, len(agentBuildVersionTemplates))
+	for key := range agentBuildVersionTemplates {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	items := make([]agentBuildVersionTemplateResponse, 0, len(keys))
+	for _, key := range keys {
+		items = append(items, buildAgentBuildVersionTemplateResponse(agentBuildVersionTemplates[key]))
+	}
+	return items
+}
+
+func buildAgentBuildVersionTemplateResponse(template agentBuildVersionTemplate) agentBuildVersionTemplateResponse {
+	return agentBuildVersionTemplateResponse{
+		Key:             template.Key,
+		Name:            template.Name,
+		Description:     template.Description,
+		AgentKind:       template.AgentKind,
+		InterfaceSpec:   defaultJSON(template.InterfaceSpec),
+		PolicySpec:      defaultJSON(template.PolicySpec),
+		ReasoningSpec:   defaultJSON(template.ReasoningSpec),
+		MemorySpec:      defaultJSON(template.MemorySpec),
+		WorkflowSpec:    defaultJSON(template.WorkflowSpec),
+		GuardrailSpec:   defaultJSON(template.GuardrailSpec),
+		ModelSpec:       defaultJSON(template.ModelSpec),
+		OutputSchema:    defaultJSON(template.OutputSchema),
+		TraceContract:   defaultJSON(template.TraceContract),
+		PublicationSpec: defaultJSON(template.PublicationSpec),
+	}
+}
+
+func applyAgentBuildVersionTemplate(input CreateAgentBuildVersionInput) (CreateAgentBuildVersionInput, error) {
+	key := strings.TrimSpace(input.Template)
+	if key == "" {
+		return input, nil
+	}
+
+	template, ok := agentBuildVersionTemplates[key]
+	if !ok {
+		return CreateAgentBuildVersionInput{}, AgentBuildValidationError{
+			Code:    "invalid_template",
+			Message: "template must be one of: " + strings.Join(agentBuildVersionTemplateKeys(), ", "),
+		}
+	}
+
+	if strings.TrimSpace(input.AgentKind) == "" {
+		input.AgentKind = template.AgentKind
+	}
+	input.InterfaceSpec = defaultRawMessage(input.InterfaceSpec, template.InterfaceSpec)
+	input.PolicySpec = defaultRawMessage(input.PolicySpec, template.PolicySpec)
+	input.ReasoningSpec = defaultRawMessage(input.ReasoningSpec, template.ReasoningSpec)
+	input.MemorySpec = defaultRawMessage(input.MemorySpec, template.MemorySpec)
+	input.WorkflowSpec = defaultRawMessage(input.WorkflowSpec, template.WorkflowSpec)
+	input.GuardrailSpec = defaultRawMessage(input.GuardrailSpec, template.GuardrailSpec)
+	input.ModelSpec = defaultRawMessage(input.ModelSpec, template.ModelSpec)
+	input.OutputSchema = defaultRawMessage(input.OutputSchema, template.OutputSchema)
+	input.TraceContract = defaultRawMessage(input.TraceContract, template.TraceContract)
+	input.PublicationSpec = defaultRawMessage(input.PublicationSpec, template.PublicationSpec)
+	return input, nil
+}
+
+func agentBuildVersionTemplateKeys() []string {
+	keys := make([]string, 0, len(agentBuildVersionTemplates))
+	for key := range agentBuildVersionTemplates {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func defaultRawMessage(value, fallback json.RawMessage) json.RawMessage {
+	if len(value) == 0 || strings.EqualFold(strings.TrimSpace(string(value)), "null") {
+		return fallback
+	}
+	return value
+}

--- a/backend/internal/api/agent_build_templates_test.go
+++ b/backend/internal/api/agent_build_templates_test.go
@@ -1,0 +1,195 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+type templateAgentBuildRepository struct {
+	build        repository.AgentBuild
+	latest       int32
+	created      repository.CreateAgentBuildVersionParams
+	createdValid bool
+}
+
+func (r *templateAgentBuildRepository) GetOrganizationIDByWorkspaceID(context.Context, uuid.UUID) (uuid.UUID, error) {
+	return r.build.OrganizationID, nil
+}
+
+func (r *templateAgentBuildRepository) CreateAgentBuild(context.Context, repository.CreateAgentBuildParams) (repository.AgentBuild, error) {
+	return repository.AgentBuild{}, nil
+}
+
+func (r *templateAgentBuildRepository) GetAgentBuildByID(_ context.Context, id uuid.UUID) (repository.AgentBuild, error) {
+	if id != r.build.ID {
+		return repository.AgentBuild{}, repository.ErrAgentBuildNotFound
+	}
+	return r.build, nil
+}
+
+func (r *templateAgentBuildRepository) ListAgentBuildsByWorkspaceID(context.Context, uuid.UUID) ([]repository.AgentBuild, error) {
+	return nil, nil
+}
+
+func (r *templateAgentBuildRepository) CreateAgentBuildVersion(_ context.Context, params repository.CreateAgentBuildVersionParams) (repository.AgentBuildVersion, error) {
+	r.created = params
+	r.createdValid = true
+	return repository.AgentBuildVersion{
+		ID:               uuid.New(),
+		AgentBuildID:     params.AgentBuildID,
+		VersionNumber:    params.VersionNumber,
+		VersionStatus:    "draft",
+		AgentKind:        params.AgentKind,
+		InterfaceSpec:    params.InterfaceSpec,
+		PolicySpec:       params.PolicySpec,
+		ReasoningSpec:    params.ReasoningSpec,
+		MemorySpec:       params.MemorySpec,
+		WorkflowSpec:     params.WorkflowSpec,
+		GuardrailSpec:    params.GuardrailSpec,
+		ModelSpec:        params.ModelSpec,
+		OutputSchema:     params.OutputSchema,
+		TraceContract:    params.TraceContract,
+		PublicationSpec:  params.PublicationSpec,
+		CreatedByUserID:  params.CreatedByUserID,
+		CreatedAt:        time.Now().UTC(),
+		Tools:            params.Tools,
+		KnowledgeSources: params.KnowledgeSources,
+	}, nil
+}
+
+func (r *templateAgentBuildRepository) GetAgentBuildVersionByID(context.Context, uuid.UUID) (repository.AgentBuildVersion, error) {
+	return repository.AgentBuildVersion{}, repository.ErrAgentBuildVersionNotFound
+}
+
+func (r *templateAgentBuildRepository) GetLatestVersionNumberForBuild(context.Context, uuid.UUID) (int32, error) {
+	return r.latest, nil
+}
+
+func (r *templateAgentBuildRepository) ListAgentBuildVersionsByBuildID(context.Context, uuid.UUID) ([]repository.AgentBuildVersion, error) {
+	return nil, nil
+}
+
+func (r *templateAgentBuildRepository) UpdateAgentBuildVersionDraft(context.Context, repository.UpdateAgentBuildVersionDraftParams) error {
+	return nil
+}
+
+func (r *templateAgentBuildRepository) MarkAgentBuildVersionReady(context.Context, uuid.UUID) error {
+	return nil
+}
+
+func (r *templateAgentBuildRepository) CreateAgentDeployment(context.Context, repository.CreateAgentDeploymentParams) (repository.AgentDeploymentRow, error) {
+	return repository.AgentDeploymentRow{}, nil
+}
+
+func (r *templateAgentBuildRepository) GetProviderAccountByID(context.Context, uuid.UUID) (repository.ProviderAccountRow, error) {
+	return repository.ProviderAccountRow{}, nil
+}
+
+func (r *templateAgentBuildRepository) UpsertModelCatalogEntry(context.Context, string, string) (repository.ModelCatalogEntryRow, error) {
+	return repository.ModelCatalogEntryRow{}, nil
+}
+
+func (r *templateAgentBuildRepository) CreateModelAlias(context.Context, repository.CreateModelAliasParams) (repository.ModelAliasRow, error) {
+	return repository.ModelAliasRow{}, nil
+}
+
+func (r *templateAgentBuildRepository) ListModelAliasesByWorkspaceID(context.Context, uuid.UUID) ([]repository.ModelAliasRow, error) {
+	return nil, nil
+}
+
+func (r *templateAgentBuildRepository) UnarchiveModelAliasByKey(context.Context, uuid.UUID, string, *uuid.UUID, uuid.UUID) (repository.ModelAliasRow, error) {
+	return repository.ModelAliasRow{}, repository.ErrModelAliasNotFound
+}
+
+func TestCreateVersionAppliesTemplateDefaultsAndExplicitOverrides(t *testing.T) {
+	buildID := uuid.New()
+	userID := uuid.New()
+	repo := &templateAgentBuildRepository{
+		build: repository.AgentBuild{
+			ID:             buildID,
+			OrganizationID: uuid.New(),
+			WorkspaceID:    uuid.New(),
+		},
+		latest: 3,
+	}
+	manager := NewAgentBuildManager(repo)
+
+	version, err := manager.CreateVersion(context.Background(), Caller{UserID: userID}, buildID, CreateAgentBuildVersionInput{
+		Template:     "honest-agent",
+		PolicySpec:   json.RawMessage(`null`),
+		ModelSpec:    json.RawMessage(`{"temperature":0}`),
+		OutputSchema: json.RawMessage(`{"type":"object","properties":{"custom":{"type":"string"}}}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateVersion returned error: %v", err)
+	}
+	if !repo.createdValid {
+		t.Fatal("CreateAgentBuildVersion was not called")
+	}
+	if version.VersionNumber != 4 || repo.created.VersionNumber != 4 {
+		t.Fatalf("version number = %d/%d, want 4", version.VersionNumber, repo.created.VersionNumber)
+	}
+	if repo.created.AgentKind != "llm_agent" {
+		t.Fatalf("agent kind = %q, want llm_agent", repo.created.AgentKind)
+	}
+	if !strings.Contains(string(repo.created.PolicySpec), "Answer honestly and directly") {
+		t.Fatalf("policy spec did not come from honest-agent template: %s", repo.created.PolicySpec)
+	}
+	if string(repo.created.ModelSpec) != `{"temperature":0}` {
+		t.Fatalf("model spec = %s, want explicit override", repo.created.ModelSpec)
+	}
+	if !strings.Contains(string(repo.created.OutputSchema), `"custom"`) {
+		t.Fatalf("output schema = %s, want explicit override", repo.created.OutputSchema)
+	}
+}
+
+func TestCreateVersionRejectsUnknownTemplate(t *testing.T) {
+	buildID := uuid.New()
+	repo := &templateAgentBuildRepository{
+		build: repository.AgentBuild{
+			ID:             buildID,
+			OrganizationID: uuid.New(),
+			WorkspaceID:    uuid.New(),
+		},
+	}
+	manager := NewAgentBuildManager(repo)
+
+	_, err := manager.CreateVersion(context.Background(), Caller{UserID: uuid.New()}, buildID, CreateAgentBuildVersionInput{
+		Template: "missing-template",
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown template")
+	}
+	var validationErr AgentBuildValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error type = %T, want AgentBuildValidationError", err)
+	}
+	if validationErr.Code != "invalid_template" || !strings.Contains(validationErr.Message, "code-reviewer") || !strings.Contains(validationErr.Message, "honest-agent") {
+		t.Fatalf("validation error = %#v", validationErr)
+	}
+}
+
+func TestListAgentBuildVersionTemplateResponsesIncludesBuiltIns(t *testing.T) {
+	items := listAgentBuildVersionTemplateResponses()
+	got := make(map[string]agentBuildVersionTemplateResponse, len(items))
+	for _, item := range items {
+		got[item.Key] = item
+	}
+
+	for _, key := range []string{"code-reviewer", "honest-agent"} {
+		item, ok := got[key]
+		if !ok {
+			t.Fatalf("template %q missing from catalog: %+v", key, got)
+		}
+		if item.AgentKind != "llm_agent" || len(item.PolicySpec) == 0 {
+			t.Fatalf("template %q response incomplete: %+v", key, item)
+		}
+	}
+}

--- a/backend/internal/api/agent_builds.go
+++ b/backend/internal/api/agent_builds.go
@@ -59,6 +59,7 @@ type CreateAgentBuildInput struct {
 }
 
 type CreateAgentBuildVersionInput struct {
+	Template         string
 	AgentKind        string
 	InterfaceSpec    json.RawMessage
 	PolicySpec       json.RawMessage
@@ -136,6 +137,10 @@ func (m *AgentBuildManager) ListVersions(ctx context.Context, agentBuildID uuid.
 
 func (m *AgentBuildManager) CreateVersion(ctx context.Context, caller Caller, agentBuildID uuid.UUID, input CreateAgentBuildVersionInput) (repository.AgentBuildVersion, error) {
 	_, err := m.repo.GetAgentBuildByID(ctx, agentBuildID)
+	if err != nil {
+		return repository.AgentBuildVersion{}, err
+	}
+	input, err = applyAgentBuildVersionTemplate(input)
 	if err != nil {
 		return repository.AgentBuildVersion{}, err
 	}
@@ -362,6 +367,7 @@ type createAgentBuildRequest struct {
 }
 
 type createAgentBuildVersionRequest struct {
+	Template         string                          `json:"template,omitempty"`
 	AgentKind        string                          `json:"agent_kind"`
 	InterfaceSpec    json.RawMessage                 `json:"interface_spec"`
 	PolicySpec       json.RawMessage                 `json:"policy_spec"`
@@ -453,6 +459,10 @@ type knowledgeSourceBindingResponse struct {
 
 type listAgentBuildsResponse struct {
 	Items []agentBuildResponse `json:"items"`
+}
+
+type listAgentBuildVersionTemplatesResponse struct {
+	Items []agentBuildVersionTemplateResponse `json:"items"`
 }
 
 type validationErrorDetail struct {
@@ -562,6 +572,14 @@ func listAgentBuildsHandler(logger *slog.Logger, service AgentBuildService) http
 		}
 
 		writeJSON(w, http.StatusOK, listAgentBuildsResponse{Items: items})
+	}
+}
+
+func listAgentBuildVersionTemplatesHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, listAgentBuildVersionTemplatesResponse{
+			Items: listAgentBuildVersionTemplateResponses(),
+		})
 	}
 }
 
@@ -1084,6 +1102,7 @@ func decodeCreateAgentBuildVersionInput(body createAgentBuildVersionRequest) (Cr
 	}
 
 	return CreateAgentBuildVersionInput{
+		Template:         body.Template,
 		AgentKind:        body.AgentKind,
 		InterfaceSpec:    body.InterfaceSpec,
 		PolicySpec:       body.PolicySpec,

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -196,6 +196,7 @@ func registerProtectedRoutes(
 		Post("/workspaces/{workspaceID}/agent-builds", createAgentBuildHandler(logger, agentBuildService, authorizer))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Get("/workspaces/{workspaceID}/agent-builds", listAgentBuildsHandler(logger, agentBuildService))
+	router.Get("/agent-build-version-templates", listAgentBuildVersionTemplatesHandler())
 
 	router.Get("/agent-builds/{agentBuildID}", getAgentBuildHandler(logger, agentBuildService, authorizer))
 	router.Post("/agent-builds/{agentBuildID}/versions", createAgentBuildVersionHandler(logger, agentBuildService, authorizer))

--- a/cli/cmd/build.go
+++ b/cli/cmd/build.go
@@ -20,6 +20,7 @@ func init() {
 	buildVersionCmd.AddCommand(buildVersionUpdateCmd)
 	buildVersionCmd.AddCommand(buildVersionValidateCmd)
 	buildVersionCmd.AddCommand(buildVersionReadyCmd)
+	buildVersionCmd.AddCommand(buildVersionTemplatesCmd)
 
 	buildCreateCmd.Flags().String("name", "", "Build name (required)")
 	buildCreateCmd.Flags().String("description", "", "Build description")
@@ -27,6 +28,7 @@ func init() {
 
 	buildVersionCreateCmd.Flags().String("agent-kind", "", "Agent kind: llm_agent, workflow_agent, programmatic_agent, multi_agent_system, hosted_external")
 	buildVersionCreateCmd.Flags().String("spec-file", "", "JSON file with version spec fields")
+	buildVersionCreateCmd.Flags().String("template", "", "Template key to scaffold this version (for example: honest-agent, code-reviewer)")
 
 	buildVersionUpdateCmd.Flags().String("spec-file", "", "JSON file with updated version spec fields")
 }
@@ -339,6 +341,46 @@ var buildVersionReadyCmd = &cobra.Command{
 	},
 }
 
+var buildVersionTemplatesCmd = &cobra.Command{
+	Use:   "templates",
+	Short: "List built-in build version templates",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+
+		resp, err := rc.Client.Get(cmd.Context(), "/v1/agent-build-version-templates", nil)
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+
+		var result struct {
+			Items []map[string]any `json:"items"`
+		}
+		if err := resp.DecodeJSON(&result); err != nil {
+			return err
+		}
+
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(result)
+		}
+
+		cols := []output.Column{{Header: "Key"}, {Header: "Name"}, {Header: "Kind"}, {Header: "Description"}}
+		rows := make([][]string, len(result.Items))
+		for i, item := range result.Items {
+			rows[i] = []string{
+				str(item["key"]),
+				str(item["name"]),
+				str(item["agent_kind"]),
+				str(item["description"]),
+			}
+		}
+		rc.Output.PrintTable(cols, rows)
+		return nil
+	},
+}
+
 func loadSpecBody(cmd *cobra.Command) (map[string]any, error) {
 	body := make(map[string]any)
 
@@ -355,6 +397,10 @@ func loadSpecBody(cmd *cobra.Command) (map[string]any, error) {
 	if cmd.Flags().Changed("agent-kind") {
 		v, _ := cmd.Flags().GetString("agent-kind")
 		body["agent_kind"] = v
+	}
+	if flag := cmd.Flags().Lookup("template"); flag != nil && cmd.Flags().Changed("template") {
+		v, _ := cmd.Flags().GetString("template")
+		body["template"] = v
 	}
 
 	return body, nil

--- a/cli/cmd/build_templates_test.go
+++ b/cli/cmd/build_templates_test.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildVersionCreateSendsTemplateWithSpecOverrides(t *testing.T) {
+	var gotBody map[string]any
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/agent-builds/build-1/versions": func(w http.ResponseWriter, r *http.Request) {
+			decodeJSONBody(t, r, &gotBody)
+			jsonHandler(http.StatusCreated, map[string]any{
+				"id":             "version-1",
+				"version_number": 1,
+			})(w, r)
+		},
+	})
+	defer srv.Close()
+
+	specFile := filepath.Join(t.TempDir(), "build-version.json")
+	if err := os.WriteFile(specFile, []byte(`{"policy_spec":{"instructions":"Use the local rubric."}}`), 0o600); err != nil {
+		t.Fatalf("write spec file: %v", err)
+	}
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{
+		"build", "version", "create", "build-1",
+		"--template", "code-reviewer",
+		"--agent-kind", "llm_agent",
+		"--spec-file", specFile,
+	}, srv.URL); err != nil {
+		t.Fatalf("build version create error: %v", err)
+	}
+
+	if gotBody["template"] != "code-reviewer" {
+		t.Fatalf("template = %v, want code-reviewer; body=%v", gotBody["template"], gotBody)
+	}
+	if gotBody["agent_kind"] != "llm_agent" {
+		t.Fatalf("agent_kind = %v, want llm_agent; body=%v", gotBody["agent_kind"], gotBody)
+	}
+	policy, ok := gotBody["policy_spec"].(map[string]any)
+	if !ok || policy["instructions"] != "Use the local rubric." {
+		t.Fatalf("policy_spec = %#v, want spec-file override", gotBody["policy_spec"])
+	}
+}
+
+func TestBuildVersionTemplatesListsCatalog(t *testing.T) {
+	var called bool
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/agent-build-version-templates": func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			jsonHandler(http.StatusOK, map[string]any{
+				"items": []map[string]any{
+					{
+						"key":         "honest-agent",
+						"name":        "Honest Agent",
+						"agent_kind":  "llm_agent",
+						"description": "Answers directly.",
+					},
+					{
+						"key":         "code-reviewer",
+						"name":        "Code Reviewer",
+						"agent_kind":  "llm_agent",
+						"description": "Reviews code.",
+					},
+				},
+			})(w, r)
+		},
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	if err := executeCommand(t, []string{"build", "version", "templates"}, srv.URL); err != nil {
+		t.Fatalf("build version templates error: %v", err)
+	}
+	if !called {
+		t.Fatal("template catalog endpoint was not called")
+	}
+
+	out := stdout.finish()
+	for _, snippet := range []string{"honest-agent", "code-reviewer", "llm_agent"} {
+		if !strings.Contains(out, snippet) {
+			t.Fatalf("template list output missing %q\n---\n%s", snippet, out)
+		}
+	}
+}


### PR DESCRIPTION
Closes #721.

## Summary
- add a built-in agent build version template catalog with honest-agent and code-reviewer templates
- allow POST /v1/agent-builds/{id}/versions to opt into a template while preserving explicit spec-field overrides
- add CLI discovery via `agentclash build version templates` and creation via `agentclash build version create --template`

## Tests
- `cd backend && go test ./internal/api -run 'TestCreateVersion.*Template|TestListAgentBuildVersionTemplate' -count=1`\n- `cd cli && go test ./cmd -run 'TestBuildVersion.*Template' -count=1`\n- `cd backend && go test -short -count=1 ./...`\n- `cd cli && go test -short -count=1 ./...`\n- `cd backend && go build ./... && go vet ./...`\n- `cd cli && go build ./... && go vet ./...`\n- `cd cli && go run . build version templates --help`\n- `cd cli && go run . build version create --help`