### PR TITLE
feat(voice-evals): add multimodal trace contract

### DIFF
--- a/backend/internal/multimodaltrace/trace.go
+++ b/backend/internal/multimodaltrace/trace.go
@@ -1,0 +1,358 @@
+package multimodaltrace
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const SchemaVersionV1 = "2026-05-13"
+
+type SegmentKind string
+
+const (
+	SegmentKindAudioInput        SegmentKind = "audio_input"
+	SegmentKindAudioOutput       SegmentKind = "audio_output"
+	SegmentKindTextInput         SegmentKind = "text_input"
+	SegmentKindTextOutput        SegmentKind = "text_output"
+	SegmentKindTranscriptPartial SegmentKind = "transcript_partial"
+	SegmentKindTranscriptFinal   SegmentKind = "transcript_final"
+	SegmentKindToolCall          SegmentKind = "tool_call"
+	SegmentKindToolResult        SegmentKind = "tool_result"
+	SegmentKindStructuredOutput  SegmentKind = "structured_output"
+	SegmentKindTimingMarker      SegmentKind = "timing_marker"
+	SegmentKindMediaControl      SegmentKind = "media_control"
+)
+
+type Actor string
+
+const (
+	ActorUser      Actor = "user"
+	ActorAgent     Actor = "agent"
+	ActorSystem    Actor = "system"
+	ActorTool      Actor = "tool"
+	ActorEvaluator Actor = "evaluator"
+)
+
+var (
+	ErrInvalidSchemaVersion = errors.New("invalid multimodal trace schema version")
+	ErrInvalidSegmentKind   = errors.New("invalid multimodal trace segment kind")
+	ErrInvalidActor         = errors.New("invalid multimodal trace actor")
+)
+
+type Trace struct {
+	TraceID       string    `json:"trace_id"`
+	SchemaVersion string    `json:"schema_version"`
+	RunID         uuid.UUID `json:"run_id"`
+	RunAgentID    uuid.UUID `json:"run_agent_id"`
+	Segments      []Segment `json:"segments"`
+}
+
+type Segment struct {
+	SegmentID        string                   `json:"segment_id"`
+	SequenceNumber   int64                    `json:"sequence_number"`
+	Kind             SegmentKind              `json:"kind"`
+	Actor            Actor                    `json:"actor"`
+	OccurredAt       time.Time                `json:"occurred_at"`
+	Text             *TextPayload             `json:"text,omitempty"`
+	Audio            *AudioPayload            `json:"audio,omitempty"`
+	Transcript       *TranscriptPayload       `json:"transcript,omitempty"`
+	ToolCall         *ToolCallPayload         `json:"tool_call,omitempty"`
+	ToolResult       *ToolResultPayload       `json:"tool_result,omitempty"`
+	StructuredOutput *StructuredOutputPayload `json:"structured_output,omitempty"`
+	TimingMarker     *TimingMarkerPayload     `json:"timing_marker,omitempty"`
+	MediaControl     *MediaControlPayload     `json:"media_control,omitempty"`
+}
+
+type TextPayload struct {
+	Text     string `json:"text"`
+	Language string `json:"language,omitempty"`
+}
+
+type AudioPayload struct {
+	ArtifactRef string `json:"artifact_ref"`
+	Format      string `json:"format"`
+	Channel     string `json:"channel,omitempty"`
+	DurationMS  int64  `json:"duration_ms,omitempty"`
+}
+
+type TranscriptPayload struct {
+	Text            string   `json:"text"`
+	Language        string   `json:"language,omitempty"`
+	Confidence      *float64 `json:"confidence,omitempty"`
+	SourceSegmentID string   `json:"source_segment_id,omitempty"`
+}
+
+type ToolCallPayload struct {
+	CallID    string          `json:"call_id"`
+	ToolName  string          `json:"tool_name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+type ToolResultPayload struct {
+	CallID   string          `json:"call_id"`
+	ToolName string          `json:"tool_name"`
+	Result   json.RawMessage `json:"result,omitempty"`
+	Error    string          `json:"error,omitempty"`
+}
+
+type StructuredOutputPayload struct {
+	SchemaRef string          `json:"schema_ref,omitempty"`
+	Output    json.RawMessage `json:"output"`
+}
+
+type TimingMarkerPayload struct {
+	Key     string `json:"key"`
+	ValueMS int64  `json:"value_ms"`
+}
+
+type MediaControlPayload struct {
+	Action          string `json:"action"`
+	TargetSegmentID string `json:"target_segment_id,omitempty"`
+}
+
+func (t Trace) Validate() error {
+	if t.TraceID == "" {
+		return errors.New("trace_id is required")
+	}
+	if t.SchemaVersion != SchemaVersionV1 {
+		return fmt.Errorf("%w: %q", ErrInvalidSchemaVersion, t.SchemaVersion)
+	}
+	if t.RunID == uuid.Nil {
+		return errors.New("run_id is required")
+	}
+	if t.RunAgentID == uuid.Nil {
+		return errors.New("run_agent_id is required")
+	}
+	seenSequences := make(map[int64]struct{}, len(t.Segments))
+	var previousSequence int64
+	for i, segment := range t.Segments {
+		if err := segment.Validate(); err != nil {
+			return fmt.Errorf("segments[%d]: %w", i, err)
+		}
+		if _, ok := seenSequences[segment.SequenceNumber]; ok {
+			return fmt.Errorf("segments[%d]: duplicate sequence_number %d", i, segment.SequenceNumber)
+		}
+		if previousSequence > 0 && segment.SequenceNumber <= previousSequence {
+			return fmt.Errorf("segments[%d]: sequence_number must increase monotonically", i)
+		}
+		seenSequences[segment.SequenceNumber] = struct{}{}
+		previousSequence = segment.SequenceNumber
+	}
+	return nil
+}
+
+func (s Segment) Validate() error {
+	if s.SegmentID == "" {
+		return errors.New("segment_id is required")
+	}
+	if s.SequenceNumber <= 0 {
+		return errors.New("sequence_number must be greater than zero")
+	}
+	if !s.Kind.IsValid() {
+		return fmt.Errorf("%w: %q", ErrInvalidSegmentKind, s.Kind)
+	}
+	if !s.Actor.IsValid() {
+		return fmt.Errorf("%w: %q", ErrInvalidActor, s.Actor)
+	}
+	if s.OccurredAt.IsZero() {
+		return errors.New("occurred_at is required")
+	}
+	if s.payloadCount() > 1 {
+		return errors.New("segment must contain exactly one payload")
+	}
+	return s.validatePayloadForKind()
+}
+
+func (k SegmentKind) IsValid() bool {
+	switch k {
+	case SegmentKindAudioInput,
+		SegmentKindAudioOutput,
+		SegmentKindTextInput,
+		SegmentKindTextOutput,
+		SegmentKindTranscriptPartial,
+		SegmentKindTranscriptFinal,
+		SegmentKindToolCall,
+		SegmentKindToolResult,
+		SegmentKindStructuredOutput,
+		SegmentKindTimingMarker,
+		SegmentKindMediaControl:
+		return true
+	default:
+		return false
+	}
+}
+
+func (a Actor) IsValid() bool {
+	switch a {
+	case ActorUser, ActorAgent, ActorSystem, ActorTool, ActorEvaluator:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s Segment) payloadCount() int {
+	count := 0
+	if s.Text != nil {
+		count++
+	}
+	if s.Audio != nil {
+		count++
+	}
+	if s.Transcript != nil {
+		count++
+	}
+	if s.ToolCall != nil {
+		count++
+	}
+	if s.ToolResult != nil {
+		count++
+	}
+	if s.StructuredOutput != nil {
+		count++
+	}
+	if s.TimingMarker != nil {
+		count++
+	}
+	if s.MediaControl != nil {
+		count++
+	}
+	return count
+}
+
+func (s Segment) validatePayloadForKind() error {
+	switch s.Kind {
+	case SegmentKindAudioInput, SegmentKindAudioOutput:
+		if s.Audio == nil {
+			return errors.New("audio payload is required")
+		}
+		return s.Audio.Validate()
+	case SegmentKindTextInput, SegmentKindTextOutput:
+		if s.Text == nil {
+			return errors.New("text payload is required")
+		}
+		return s.Text.Validate()
+	case SegmentKindTranscriptPartial, SegmentKindTranscriptFinal:
+		if s.Transcript == nil {
+			return errors.New("transcript payload is required")
+		}
+		return s.Transcript.Validate()
+	case SegmentKindToolCall:
+		if s.ToolCall == nil {
+			return errors.New("tool_call payload is required")
+		}
+		return s.ToolCall.Validate()
+	case SegmentKindToolResult:
+		if s.ToolResult == nil {
+			return errors.New("tool_result payload is required")
+		}
+		return s.ToolResult.Validate()
+	case SegmentKindStructuredOutput:
+		if s.StructuredOutput == nil {
+			return errors.New("structured_output payload is required")
+		}
+		return s.StructuredOutput.Validate()
+	case SegmentKindTimingMarker:
+		if s.TimingMarker == nil {
+			return errors.New("timing_marker payload is required")
+		}
+		return s.TimingMarker.Validate()
+	case SegmentKindMediaControl:
+		if s.MediaControl == nil {
+			return errors.New("media_control payload is required")
+		}
+		return s.MediaControl.Validate()
+	default:
+		return fmt.Errorf("%w: %q", ErrInvalidSegmentKind, s.Kind)
+	}
+}
+
+func (p TextPayload) Validate() error {
+	if p.Text == "" {
+		return errors.New("text.text is required")
+	}
+	return nil
+}
+
+func (p AudioPayload) Validate() error {
+	if p.ArtifactRef == "" {
+		return errors.New("audio.artifact_ref is required")
+	}
+	if p.Format == "" {
+		return errors.New("audio.format is required")
+	}
+	if p.DurationMS < 0 {
+		return errors.New("audio.duration_ms must be non-negative")
+	}
+	return nil
+}
+
+func (p TranscriptPayload) Validate() error {
+	if p.Text == "" {
+		return errors.New("transcript.text is required")
+	}
+	if p.Confidence != nil && (*p.Confidence < 0 || *p.Confidence > 1) {
+		return errors.New("transcript.confidence must be between 0 and 1")
+	}
+	return nil
+}
+
+func (p ToolCallPayload) Validate() error {
+	if p.CallID == "" {
+		return errors.New("tool_call.call_id is required")
+	}
+	if p.ToolName == "" {
+		return errors.New("tool_call.tool_name is required")
+	}
+	if len(p.Arguments) == 0 {
+		return errors.New("tool_call.arguments is required")
+	}
+	if !json.Valid(p.Arguments) {
+		return errors.New("tool_call.arguments must be valid JSON")
+	}
+	return nil
+}
+
+func (p ToolResultPayload) Validate() error {
+	if p.CallID == "" {
+		return errors.New("tool_result.call_id is required")
+	}
+	if p.ToolName == "" {
+		return errors.New("tool_result.tool_name is required")
+	}
+	if len(p.Result) > 0 && !json.Valid(p.Result) {
+		return errors.New("tool_result.result must be valid JSON")
+	}
+	return nil
+}
+
+func (p StructuredOutputPayload) Validate() error {
+	if len(p.Output) == 0 {
+		return errors.New("structured_output.output is required")
+	}
+	if !json.Valid(p.Output) {
+		return errors.New("structured_output.output must be valid JSON")
+	}
+	return nil
+}
+
+func (p TimingMarkerPayload) Validate() error {
+	if p.Key == "" {
+		return errors.New("timing_marker.key is required")
+	}
+	if p.ValueMS < 0 {
+		return errors.New("timing_marker.value_ms must be non-negative")
+	}
+	return nil
+}
+
+func (p MediaControlPayload) Validate() error {
+	if p.Action == "" {
+		return errors.New("media_control.action is required")
+	}
+	return nil
+}

--- a/backend/internal/multimodaltrace/trace.go
+++ b/backend/internal/multimodaltrace/trace.go
@@ -128,10 +128,15 @@ func (t Trace) Validate() error {
 		return errors.New("run_agent_id is required")
 	}
 	seenSequences := make(map[int64]struct{}, len(t.Segments))
+	seenSegmentIDs := make(map[string]Segment, len(t.Segments))
+	seenToolCalls := make(map[string]ToolCallPayload)
 	var previousSequence int64
 	for i, segment := range t.Segments {
 		if err := segment.Validate(); err != nil {
 			return fmt.Errorf("segments[%d]: %w", i, err)
+		}
+		if _, ok := seenSegmentIDs[segment.SegmentID]; ok {
+			return fmt.Errorf("segments[%d]: duplicate segment_id %q", i, segment.SegmentID)
 		}
 		if _, ok := seenSequences[segment.SequenceNumber]; ok {
 			return fmt.Errorf("segments[%d]: duplicate sequence_number %d", i, segment.SequenceNumber)
@@ -139,7 +144,17 @@ func (t Trace) Validate() error {
 		if previousSequence > 0 && segment.SequenceNumber <= previousSequence {
 			return fmt.Errorf("segments[%d]: sequence_number must increase monotonically", i)
 		}
+		if err := validateSegmentReferences(i, segment, seenSegmentIDs, seenToolCalls); err != nil {
+			return err
+		}
 		seenSequences[segment.SequenceNumber] = struct{}{}
+		seenSegmentIDs[segment.SegmentID] = segment
+		if segment.ToolCall != nil {
+			if _, ok := seenToolCalls[segment.ToolCall.CallID]; ok {
+				return fmt.Errorf("segments[%d]: duplicate tool_call.call_id %q", i, segment.ToolCall.CallID)
+			}
+			seenToolCalls[segment.ToolCall.CallID] = *segment.ToolCall
+		}
 		previousSequence = segment.SequenceNumber
 	}
 	return nil
@@ -193,6 +208,33 @@ func (a Actor) IsValid() bool {
 	default:
 		return false
 	}
+}
+
+func validateSegmentReferences(index int, segment Segment, priorSegments map[string]Segment, priorToolCalls map[string]ToolCallPayload) error {
+	if segment.Transcript != nil && segment.Transcript.SourceSegmentID != "" {
+		source, ok := priorSegments[segment.Transcript.SourceSegmentID]
+		if !ok {
+			return fmt.Errorf("segments[%d]: transcript.source_segment_id %q does not reference a prior segment", index, segment.Transcript.SourceSegmentID)
+		}
+		if source.Kind != SegmentKindAudioInput && source.Kind != SegmentKindAudioOutput {
+			return fmt.Errorf("segments[%d]: transcript.source_segment_id %q must reference an audio segment", index, segment.Transcript.SourceSegmentID)
+		}
+	}
+	if segment.MediaControl != nil && segment.MediaControl.TargetSegmentID != "" {
+		if _, ok := priorSegments[segment.MediaControl.TargetSegmentID]; !ok {
+			return fmt.Errorf("segments[%d]: media_control.target_segment_id %q does not reference a prior segment", index, segment.MediaControl.TargetSegmentID)
+		}
+	}
+	if segment.ToolResult != nil {
+		call, ok := priorToolCalls[segment.ToolResult.CallID]
+		if !ok {
+			return fmt.Errorf("segments[%d]: tool_result.call_id %q does not reference a prior tool_call", index, segment.ToolResult.CallID)
+		}
+		if call.ToolName != segment.ToolResult.ToolName {
+			return fmt.Errorf("segments[%d]: tool_result.tool_name %q does not match prior tool_call.tool_name %q", index, segment.ToolResult.ToolName, call.ToolName)
+		}
+	}
+	return nil
 }
 
 func (s Segment) payloadCount() int {

--- a/backend/internal/multimodaltrace/trace.go
+++ b/backend/internal/multimodaltrace/trace.go
@@ -127,6 +127,9 @@ func (t Trace) Validate() error {
 	if t.RunAgentID == uuid.Nil {
 		return errors.New("run_agent_id is required")
 	}
+	if len(t.Segments) == 0 {
+		return errors.New("segments must contain at least one segment")
+	}
 	seenSequences := make(map[int64]struct{}, len(t.Segments))
 	seenSegmentIDs := make(map[string]Segment, len(t.Segments))
 	seenToolCalls := make(map[string]ToolCallPayload)
@@ -183,22 +186,8 @@ func (s Segment) Validate() error {
 }
 
 func (k SegmentKind) IsValid() bool {
-	switch k {
-	case SegmentKindAudioInput,
-		SegmentKindAudioOutput,
-		SegmentKindTextInput,
-		SegmentKindTextOutput,
-		SegmentKindTranscriptPartial,
-		SegmentKindTranscriptFinal,
-		SegmentKindToolCall,
-		SegmentKindToolResult,
-		SegmentKindStructuredOutput,
-		SegmentKindTimingMarker,
-		SegmentKindMediaControl:
-		return true
-	default:
-		return false
-	}
+	_, ok := segmentPayloadValidators[k]
+	return ok
 }
 
 func (a Actor) IsValid() bool {
@@ -267,50 +256,81 @@ func (s Segment) payloadCount() int {
 }
 
 func (s Segment) validatePayloadForKind() error {
-	switch s.Kind {
-	case SegmentKindAudioInput, SegmentKindAudioOutput:
-		if s.Audio == nil {
-			return errors.New("audio payload is required")
-		}
-		return s.Audio.Validate()
-	case SegmentKindTextInput, SegmentKindTextOutput:
-		if s.Text == nil {
-			return errors.New("text payload is required")
-		}
-		return s.Text.Validate()
-	case SegmentKindTranscriptPartial, SegmentKindTranscriptFinal:
-		if s.Transcript == nil {
-			return errors.New("transcript payload is required")
-		}
-		return s.Transcript.Validate()
-	case SegmentKindToolCall:
-		if s.ToolCall == nil {
-			return errors.New("tool_call payload is required")
-		}
-		return s.ToolCall.Validate()
-	case SegmentKindToolResult:
-		if s.ToolResult == nil {
-			return errors.New("tool_result payload is required")
-		}
-		return s.ToolResult.Validate()
-	case SegmentKindStructuredOutput:
-		if s.StructuredOutput == nil {
-			return errors.New("structured_output payload is required")
-		}
-		return s.StructuredOutput.Validate()
-	case SegmentKindTimingMarker:
-		if s.TimingMarker == nil {
-			return errors.New("timing_marker payload is required")
-		}
-		return s.TimingMarker.Validate()
-	case SegmentKindMediaControl:
-		if s.MediaControl == nil {
-			return errors.New("media_control payload is required")
-		}
-		return s.MediaControl.Validate()
-	default:
+	validator, ok := segmentPayloadValidators[s.Kind]
+	if !ok {
 		return fmt.Errorf("%w: %q", ErrInvalidSegmentKind, s.Kind)
 	}
+	return validator(s)
+}
+
+var segmentPayloadValidators = map[SegmentKind]func(Segment) error{
+	SegmentKindAudioInput:        validateAudioSegment,
+	SegmentKindAudioOutput:       validateAudioSegment,
+	SegmentKindTextInput:         validateTextSegment,
+	SegmentKindTextOutput:        validateTextSegment,
+	SegmentKindTranscriptPartial: validateTranscriptSegment,
+	SegmentKindTranscriptFinal:   validateTranscriptSegment,
+	SegmentKindToolCall:          validateToolCallSegment,
+	SegmentKindToolResult:        validateToolResultSegment,
+	SegmentKindStructuredOutput:  validateStructuredOutputSegment,
+	SegmentKindTimingMarker:      validateTimingMarkerSegment,
+	SegmentKindMediaControl:      validateMediaControlSegment,
+}
+
+func validateAudioSegment(s Segment) error {
+	if s.Audio == nil {
+		return errors.New("audio payload is required")
+	}
+	return s.Audio.Validate()
+}
+
+func validateTextSegment(s Segment) error {
+	if s.Text == nil {
+		return errors.New("text payload is required")
+	}
+	return s.Text.Validate()
+}
+
+func validateTranscriptSegment(s Segment) error {
+	if s.Transcript == nil {
+		return errors.New("transcript payload is required")
+	}
+	return s.Transcript.Validate()
+}
+
+func validateToolCallSegment(s Segment) error {
+	if s.ToolCall == nil {
+		return errors.New("tool_call payload is required")
+	}
+	return s.ToolCall.Validate()
+}
+
+func validateToolResultSegment(s Segment) error {
+	if s.ToolResult == nil {
+		return errors.New("tool_result payload is required")
+	}
+	return s.ToolResult.Validate()
+}
+
+func validateStructuredOutputSegment(s Segment) error {
+	if s.StructuredOutput == nil {
+		return errors.New("structured_output payload is required")
+	}
+	return s.StructuredOutput.Validate()
+}
+
+func validateTimingMarkerSegment(s Segment) error {
+	if s.TimingMarker == nil {
+		return errors.New("timing_marker payload is required")
+	}
+	return s.TimingMarker.Validate()
+}
+
+func validateMediaControlSegment(s Segment) error {
+	if s.MediaControl == nil {
+		return errors.New("media_control payload is required")
+	}
+	return s.MediaControl.Validate()
 }
 
 func (p TextPayload) Validate() error {
@@ -365,6 +385,9 @@ func (p ToolResultPayload) Validate() error {
 	}
 	if p.ToolName == "" {
 		return errors.New("tool_result.tool_name is required")
+	}
+	if len(p.Result) == 0 && p.Error == "" {
+		return errors.New("tool_result must contain at least one of result or error")
 	}
 	if len(p.Result) > 0 && !json.Valid(p.Result) {
 		return errors.New("tool_result.result must be valid JSON")

--- a/backend/internal/multimodaltrace/trace_test.go
+++ b/backend/internal/multimodaltrace/trace_test.go
@@ -1,0 +1,302 @@
+package multimodaltrace
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	testRunID      = "11111111-1111-1111-1111-111111111111"
+	testRunAgentID = "22222222-2222-2222-2222-222222222222"
+)
+
+func TestTraceRoundTripGoldenFixtures(t *testing.T) {
+	fixtures := map[string]string{
+		"text_only":  `{"trace_id":"trace-text-only","schema_version":"2026-05-13","run_id":"11111111-1111-1111-1111-111111111111","run_agent_id":"22222222-2222-2222-2222-222222222222","segments":[{"segment_id":"seg-001","sequence_number":1,"kind":"text_input","actor":"user","occurred_at":"2026-05-13T09:00:00Z","text":{"text":"I was charged twice.","language":"en-US"}},{"segment_id":"seg-002","sequence_number":2,"kind":"text_output","actor":"agent","occurred_at":"2026-05-13T09:00:02Z","text":{"text":"I can help check the duplicate charge.","language":"en-US"}}]}`,
+		"audio_only": `{"trace_id":"trace-audio-only","schema_version":"2026-05-13","run_id":"11111111-1111-1111-1111-111111111111","run_agent_id":"22222222-2222-2222-2222-222222222222","segments":[{"segment_id":"seg-001","sequence_number":1,"kind":"audio_input","actor":"user","occurred_at":"2026-05-13T09:01:00Z","audio":{"artifact_ref":"artifacts/caller.wav","format":"wav","channel":"caller","duration_ms":1400}},{"segment_id":"seg-002","sequence_number":2,"kind":"audio_output","actor":"agent","occurred_at":"2026-05-13T09:01:02Z","audio":{"artifact_ref":"artifacts/agent.wav","format":"wav","channel":"agent","duration_ms":2100}}]}`,
+		"mixed":      `{"trace_id":"trace-mixed-support","schema_version":"2026-05-13","run_id":"11111111-1111-1111-1111-111111111111","run_agent_id":"22222222-2222-2222-2222-222222222222","segments":[{"segment_id":"seg-001","sequence_number":1,"kind":"audio_input","actor":"user","occurred_at":"2026-05-13T09:02:00Z","audio":{"artifact_ref":"artifacts/caller-001.wav","format":"wav","channel":"caller","duration_ms":1200}},{"segment_id":"seg-002","sequence_number":2,"kind":"transcript_final","actor":"system","occurred_at":"2026-05-13T09:02:01Z","transcript":{"text":"Please refund the duplicate charge.","language":"en-US","source_segment_id":"seg-001"}},{"segment_id":"seg-003","sequence_number":3,"kind":"tool_call","actor":"agent","occurred_at":"2026-05-13T09:02:02Z","tool_call":{"call_id":"call-refund-1","tool_name":"refund_api","arguments":{"amount_cents":4200,"reason":"duplicate_charge"}}},{"segment_id":"seg-004","sequence_number":4,"kind":"tool_result","actor":"tool","occurred_at":"2026-05-13T09:02:03Z","tool_result":{"call_id":"call-refund-1","tool_name":"refund_api","result":{"status":"created","refund_id":"rf_123"}}},{"segment_id":"seg-005","sequence_number":5,"kind":"structured_output","actor":"agent","occurred_at":"2026-05-13T09:02:04Z","structured_output":{"schema_ref":"voice.support.resolution.v1","output":{"resolution":"refund_created","refund_id":"rf_123"}}},{"segment_id":"seg-006","sequence_number":6,"kind":"timing_marker","actor":"evaluator","occurred_at":"2026-05-13T09:02:04Z","timing_marker":{"key":"end_of_speech_to_first_agent_output","value_ms":800}},{"segment_id":"seg-007","sequence_number":7,"kind":"media_control","actor":"system","occurred_at":"2026-05-13T09:02:05Z","media_control":{"action":"audio_buffer_cleared","target_segment_id":"seg-001"}}]}`,
+	}
+
+	for name, golden := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			var trace Trace
+			if err := json.Unmarshal([]byte(golden), &trace); err != nil {
+				t.Fatalf("unmarshal golden trace: %v", err)
+			}
+			if err := trace.Validate(); err != nil {
+				t.Fatalf("validate golden trace: %v", err)
+			}
+			roundTripped, err := json.Marshal(trace)
+			if err != nil {
+				t.Fatalf("marshal golden trace: %v", err)
+			}
+			if string(roundTripped) != golden {
+				t.Fatalf("round-trip JSON mismatch\nwant: %s\n got: %s", golden, string(roundTripped))
+			}
+		})
+	}
+}
+
+func TestTraceValidateRequiresCoreFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*Trace)
+		wantErr string
+	}{
+		{
+			name: "trace_id",
+			mutate: func(trace *Trace) {
+				trace.TraceID = ""
+			},
+			wantErr: "trace_id is required",
+		},
+		{
+			name: "schema_version",
+			mutate: func(trace *Trace) {
+				trace.SchemaVersion = "bad-version"
+			},
+			wantErr: "invalid multimodal trace schema version",
+		},
+		{
+			name: "run_id",
+			mutate: func(trace *Trace) {
+				trace.RunID = uuid.Nil
+			},
+			wantErr: "run_id is required",
+		},
+		{
+			name: "run_agent_id",
+			mutate: func(trace *Trace) {
+				trace.RunAgentID = uuid.Nil
+			},
+			wantErr: "run_agent_id is required",
+		},
+		{
+			name: "segment_id",
+			mutate: func(trace *Trace) {
+				trace.Segments[0].SegmentID = ""
+			},
+			wantErr: "segment_id is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trace := validTrace()
+			tt.mutate(&trace)
+			err := trace.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Validate() error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestTraceValidateSegmentKinds(t *testing.T) {
+	tests := []struct {
+		name    string
+		segment Segment
+	}{
+		{name: "audio_input", segment: validSegment(SegmentKindAudioInput)},
+		{name: "audio_output", segment: validSegment(SegmentKindAudioOutput)},
+		{name: "text_input", segment: validSegment(SegmentKindTextInput)},
+		{name: "text_output", segment: validSegment(SegmentKindTextOutput)},
+		{name: "transcript_partial", segment: validSegment(SegmentKindTranscriptPartial)},
+		{name: "transcript_final", segment: validSegment(SegmentKindTranscriptFinal)},
+		{name: "tool_call", segment: validSegment(SegmentKindToolCall)},
+		{name: "tool_result", segment: validSegment(SegmentKindToolResult)},
+		{name: "structured_output", segment: validSegment(SegmentKindStructuredOutput)},
+		{name: "timing_marker", segment: validSegment(SegmentKindTimingMarker)},
+		{name: "media_control", segment: validSegment(SegmentKindMediaControl)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.segment.Validate(); err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+		})
+	}
+
+	segment := validSegment(SegmentKindTextInput)
+	segment.Kind = SegmentKind("unknown_kind")
+	err := segment.Validate()
+	if !errors.Is(err, ErrInvalidSegmentKind) {
+		t.Fatalf("Validate() error = %v, want ErrInvalidSegmentKind", err)
+	}
+}
+
+func TestTraceValidateSegmentOrdering(t *testing.T) {
+	t.Run("non_positive_sequence_number", func(t *testing.T) {
+		trace := validTrace()
+		trace.Segments[0].SequenceNumber = 0
+		err := trace.Validate()
+		if err == nil || !strings.Contains(err.Error(), "sequence_number must be greater than zero") {
+			t.Fatalf("Validate() error = %v, want non-positive sequence error", err)
+		}
+	})
+
+	t.Run("duplicate_sequence_number", func(t *testing.T) {
+		trace := validTrace()
+		trace.Segments = append(trace.Segments, validSegment(SegmentKindTextOutput))
+		trace.Segments[1].SegmentID = "seg-002"
+		trace.Segments[1].SequenceNumber = trace.Segments[0].SequenceNumber
+		err := trace.Validate()
+		if err == nil || !strings.Contains(err.Error(), "duplicate sequence_number") {
+			t.Fatalf("Validate() error = %v, want duplicate sequence error", err)
+		}
+	})
+
+	t.Run("sequence_numbers_must_increase", func(t *testing.T) {
+		trace := validTrace()
+		trace.Segments = append(trace.Segments, validSegment(SegmentKindTextOutput))
+		trace.Segments[1].SegmentID = "seg-002"
+		trace.Segments[0].SequenceNumber = 2
+		trace.Segments[1].SequenceNumber = 1
+		err := trace.Validate()
+		if err == nil || !strings.Contains(err.Error(), "sequence_number must increase monotonically") {
+			t.Fatalf("Validate() error = %v, want monotonic sequence error", err)
+		}
+	})
+}
+
+func TestTraceValidateReferences(t *testing.T) {
+	tests := []struct {
+		name    string
+		segment Segment
+		wantErr string
+	}{
+		{
+			name: "audio_artifact_ref_required",
+			segment: segmentWith(func(segment *Segment) {
+				segment.Kind = SegmentKindAudioInput
+				segment.Audio = &AudioPayload{Format: "wav"}
+			}),
+			wantErr: "audio.artifact_ref is required",
+		},
+		{
+			name: "tool_call_arguments_must_be_json",
+			segment: segmentWith(func(segment *Segment) {
+				segment.Kind = SegmentKindToolCall
+				segment.ToolCall = &ToolCallPayload{CallID: "call-1", ToolName: "refund_api", Arguments: json.RawMessage(`{bad`)}
+			}),
+			wantErr: "tool_call.arguments must be valid JSON",
+		},
+		{
+			name: "structured_output_must_be_json",
+			segment: segmentWith(func(segment *Segment) {
+				segment.Kind = SegmentKindStructuredOutput
+				segment.StructuredOutput = &StructuredOutputPayload{Output: json.RawMessage(`{bad`)}
+			}),
+			wantErr: "structured_output.output must be valid JSON",
+		},
+		{
+			name: "media_control_action_required",
+			segment: segmentWith(func(segment *Segment) {
+				segment.Kind = SegmentKindMediaControl
+				segment.MediaControl = &MediaControlPayload{TargetSegmentID: "seg-001"}
+			}),
+			wantErr: "media_control.action is required",
+		},
+		{
+			name: "transcript_confidence_range",
+			segment: segmentWith(func(segment *Segment) {
+				confidence := 1.2
+				segment.Kind = SegmentKindTranscriptFinal
+				segment.Transcript = &TranscriptPayload{Text: "hello", Confidence: &confidence}
+			}),
+			wantErr: "transcript.confidence must be between 0 and 1",
+		},
+		{
+			name: "exactly_one_payload",
+			segment: segmentWith(func(segment *Segment) {
+				segment.Kind = SegmentKindTextInput
+				segment.Text = &TextPayload{Text: "hello"}
+				segment.Audio = &AudioPayload{ArtifactRef: "artifacts/audio.wav", Format: "wav"}
+			}),
+			wantErr: "segment must contain exactly one payload",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.segment.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Validate() error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func validTrace() Trace {
+	return Trace{
+		TraceID:       "trace-test",
+		SchemaVersion: SchemaVersionV1,
+		RunID:         uuid.MustParse(testRunID),
+		RunAgentID:    uuid.MustParse(testRunAgentID),
+		Segments: []Segment{
+			validSegment(SegmentKindTextInput),
+		},
+	}
+}
+
+func validSegment(kind SegmentKind) Segment {
+	segment := Segment{
+		SegmentID:      "seg-001",
+		SequenceNumber: 1,
+		Kind:           kind,
+		Actor:          ActorUser,
+		OccurredAt:     mustParseTime("2026-05-13T09:00:00Z"),
+	}
+	switch kind {
+	case SegmentKindAudioInput, SegmentKindAudioOutput:
+		segment.Audio = &AudioPayload{ArtifactRef: "artifacts/audio.wav", Format: "wav", DurationMS: 1000}
+	case SegmentKindTextInput, SegmentKindTextOutput:
+		segment.Text = &TextPayload{Text: "hello", Language: "en-US"}
+	case SegmentKindTranscriptPartial, SegmentKindTranscriptFinal:
+		segment.Transcript = &TranscriptPayload{Text: "hello", Language: "en-US", SourceSegmentID: "seg-audio"}
+	case SegmentKindToolCall:
+		segment.Actor = ActorAgent
+		segment.ToolCall = &ToolCallPayload{CallID: "call-1", ToolName: "refund_api", Arguments: json.RawMessage(`{"amount_cents":4200}`)}
+	case SegmentKindToolResult:
+		segment.Actor = ActorTool
+		segment.ToolResult = &ToolResultPayload{CallID: "call-1", ToolName: "refund_api", Result: json.RawMessage(`{"status":"created"}`)}
+	case SegmentKindStructuredOutput:
+		segment.Actor = ActorAgent
+		segment.StructuredOutput = &StructuredOutputPayload{SchemaRef: "support.resolution.v1", Output: json.RawMessage(`{"resolution":"refund_created"}`)}
+	case SegmentKindTimingMarker:
+		segment.Actor = ActorEvaluator
+		segment.TimingMarker = &TimingMarkerPayload{Key: "end_of_speech_to_first_agent_output", ValueMS: 800}
+	case SegmentKindMediaControl:
+		segment.Actor = ActorSystem
+		segment.MediaControl = &MediaControlPayload{Action: "audio_buffer_cleared", TargetSegmentID: "seg-001"}
+	}
+	return segment
+}
+
+func segmentWith(mutator func(*Segment)) Segment {
+	segment := validSegment(SegmentKindTextInput)
+	segment.Text = nil
+	segment.Audio = nil
+	segment.Transcript = nil
+	segment.ToolCall = nil
+	segment.ToolResult = nil
+	segment.StructuredOutput = nil
+	segment.TimingMarker = nil
+	segment.MediaControl = nil
+	mutator(&segment)
+	return segment
+}
+
+func mustParseTime(value string) time.Time {
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		panic(err)
+	}
+	return parsed
+}

--- a/backend/internal/multimodaltrace/trace_test.go
+++ b/backend/internal/multimodaltrace/trace_test.go
@@ -3,6 +3,7 @@ package multimodaltrace
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -166,6 +167,87 @@ func TestTraceValidateSegmentOrdering(t *testing.T) {
 }
 
 func TestTraceValidateReferences(t *testing.T) {
+	traceTests := []struct {
+		name    string
+		mutate  func(*Trace)
+		wantErr string
+	}{
+		{
+			name: "transcript_source_segment_missing",
+			mutate: func(trace *Trace) {
+				trace.Segments[1].Transcript.SourceSegmentID = "missing-segment"
+			},
+			wantErr: `transcript.source_segment_id "missing-segment" does not reference a prior segment`,
+		},
+		{
+			name: "transcript_source_segment_must_be_audio",
+			mutate: func(trace *Trace) {
+				textSegment := validSegment(SegmentKindTextInput)
+				textSegment.SegmentID = trace.Segments[0].SegmentID
+				textSegment.SequenceNumber = trace.Segments[0].SequenceNumber
+				textSegment.OccurredAt = trace.Segments[0].OccurredAt
+				trace.Segments[0] = textSegment
+			},
+			wantErr: `transcript.source_segment_id "seg-001" must reference an audio segment`,
+		},
+		{
+			name: "media_control_target_missing",
+			mutate: func(trace *Trace) {
+				trace.Segments[5].MediaControl.TargetSegmentID = "missing-segment"
+			},
+			wantErr: `media_control.target_segment_id "missing-segment" does not reference a prior segment`,
+		},
+		{
+			name: "tool_result_call_missing",
+			mutate: func(trace *Trace) {
+				trace.Segments[3].ToolResult.CallID = "missing-call"
+			},
+			wantErr: `tool_result.call_id "missing-call" does not reference a prior tool_call`,
+		},
+		{
+			name: "tool_result_tool_name_mismatch",
+			mutate: func(trace *Trace) {
+				trace.Segments[3].ToolResult.ToolName = "different_tool"
+			},
+			wantErr: `tool_result.tool_name "different_tool" does not match prior tool_call.tool_name "refund_api"`,
+		},
+		{
+			name: "duplicate_segment_id",
+			mutate: func(trace *Trace) {
+				trace.Segments[1].SegmentID = trace.Segments[0].SegmentID
+			},
+			wantErr: `duplicate segment_id "seg-001"`,
+		},
+		{
+			name: "duplicate_tool_call_id",
+			mutate: func(trace *Trace) {
+				duplicateCall := validSegment(SegmentKindToolCall)
+				duplicateCall.SegmentID = "seg-007"
+				duplicateCall.SequenceNumber = 7
+				duplicateCall.ToolCall.CallID = trace.Segments[2].ToolCall.CallID
+				trace.Segments = append(trace.Segments, duplicateCall)
+			},
+			wantErr: `duplicate tool_call.call_id "call-refund-1"`,
+		},
+	}
+
+	for _, tt := range traceTests {
+		t.Run(tt.name, func(t *testing.T) {
+			trace := validReferenceTrace()
+			tt.mutate(&trace)
+			err := trace.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Validate() error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+
+	t.Run("valid_cross_references", func(t *testing.T) {
+		if err := validReferenceTrace().Validate(); err != nil {
+			t.Fatalf("Validate() error = %v", err)
+		}
+	})
+
 	tests := []struct {
 		name    string
 		segment Segment
@@ -243,6 +325,31 @@ func validTrace() Trace {
 			validSegment(SegmentKindTextInput),
 		},
 	}
+}
+
+func validReferenceTrace() Trace {
+	trace := validTrace()
+	trace.TraceID = "trace-reference-test"
+	trace.Segments = []Segment{
+		validSegment(SegmentKindAudioInput),
+		validSegment(SegmentKindTranscriptFinal),
+		validSegment(SegmentKindToolCall),
+		validSegment(SegmentKindToolResult),
+		validSegment(SegmentKindTextOutput),
+		validSegment(SegmentKindMediaControl),
+	}
+	for i := range trace.Segments {
+		trace.Segments[i].SegmentID = fmt.Sprintf("seg-%03d", i+1)
+		trace.Segments[i].SequenceNumber = int64(i + 1)
+		trace.Segments[i].OccurredAt = mustParseTime(fmt.Sprintf("2026-05-13T09:00:0%dZ", i))
+	}
+	trace.Segments[1].Transcript.SourceSegmentID = trace.Segments[0].SegmentID
+	trace.Segments[2].ToolCall.CallID = "call-refund-1"
+	trace.Segments[2].ToolCall.ToolName = "refund_api"
+	trace.Segments[3].ToolResult.CallID = "call-refund-1"
+	trace.Segments[3].ToolResult.ToolName = "refund_api"
+	trace.Segments[5].MediaControl.TargetSegmentID = trace.Segments[0].SegmentID
+	return trace
 }
 
 func validSegment(kind SegmentKind) Segment {

--- a/backend/internal/multimodaltrace/trace_test.go
+++ b/backend/internal/multimodaltrace/trace_test.go
@@ -84,6 +84,13 @@ func TestTraceValidateRequiresCoreFields(t *testing.T) {
 			},
 			wantErr: "segment_id is required",
 		},
+		{
+			name: "segments",
+			mutate: func(trace *Trace) {
+				trace.Segments = nil
+			},
+			wantErr: "segments must contain at least one segment",
+		},
 	}
 
 	for _, tt := range tests {
@@ -129,6 +136,34 @@ func TestTraceValidateSegmentKinds(t *testing.T) {
 	err := segment.Validate()
 	if !errors.Is(err, ErrInvalidSegmentKind) {
 		t.Fatalf("Validate() error = %v, want ErrInvalidSegmentKind", err)
+	}
+}
+
+func TestSegmentKindPayloadValidatorsStayInSync(t *testing.T) {
+	kinds := []SegmentKind{
+		SegmentKindAudioInput,
+		SegmentKindAudioOutput,
+		SegmentKindTextInput,
+		SegmentKindTextOutput,
+		SegmentKindTranscriptPartial,
+		SegmentKindTranscriptFinal,
+		SegmentKindToolCall,
+		SegmentKindToolResult,
+		SegmentKindStructuredOutput,
+		SegmentKindTimingMarker,
+		SegmentKindMediaControl,
+	}
+
+	if len(segmentPayloadValidators) != len(kinds) {
+		t.Fatalf("segmentPayloadValidators has %d entries, want %d", len(segmentPayloadValidators), len(kinds))
+	}
+	for _, kind := range kinds {
+		if !kind.IsValid() {
+			t.Fatalf("%q IsValid() = false, want true", kind)
+		}
+		if _, ok := segmentPayloadValidators[kind]; !ok {
+			t.Fatalf("%q missing payload validator", kind)
+		}
 	}
 }
 
@@ -268,6 +303,14 @@ func TestTraceValidateReferences(t *testing.T) {
 				segment.ToolCall = &ToolCallPayload{CallID: "call-1", ToolName: "refund_api", Arguments: json.RawMessage(`{bad`)}
 			}),
 			wantErr: "tool_call.arguments must be valid JSON",
+		},
+		{
+			name: "tool_result_requires_result_or_error",
+			segment: segmentWith(func(segment *Segment) {
+				segment.Kind = SegmentKindToolResult
+				segment.ToolResult = &ToolResultPayload{CallID: "call-1", ToolName: "refund_api"}
+			}),
+			wantErr: "tool_result must contain at least one of result or error",
 		},
 		{
 			name: "structured_output_must_be_json",


### PR DESCRIPTION
## Summary

Closes #755.

Adds the first deterministic voice-evals foundation: a provider-neutral multimodal trace contract for representing text-only, audio-only, and mixed voice-agent interactions.

The new `backend/internal/multimodaltrace` package supports typed segments for:

- audio input/output
- text input/output
- partial/final transcripts
- tool calls/results
- structured outputs
- timing markers
- media controls

The contract is intentionally independent of any LLM, STT/TTS, telephony, or realtime provider. Later issues can plug OpenAI, LiveKit, Twilio, Vapi, Retell, or custom stacks behind this contract without changing deterministic tests.

## Review feedback addressed

Resolved the blocking review issue around trace-level references:

- `transcript.source_segment_id` must reference a prior audio segment.
- `media_control.target_segment_id` must reference a prior segment.
- `tool_result.call_id` must reference a prior `tool_call` and match its tool name.
- duplicate `segment_id` values fail validation.
- duplicate `tool_call.call_id` values fail validation.

Resolved Greptile's P2 comments:

- empty traces now fail validation.
- `SegmentKind.IsValid()` and payload validation now share one `segmentPayloadValidators` map to reduce drift risk.
- `ToolResultPayload` now requires at least one of `result` or `error`.

## Review-checkpoint test contract

```markdown
# codex/voice-multimodal-trace — Test Contract

## Functional Behavior

Implement issue #755: a provider-neutral multimodal trace contract for voice evals.

The implementation must:

- Represent text-only traces.
- Represent audio-only traces.
- Represent mixed audio, transcripts, tool calls/results, structured outputs, timing markers, and media controls.
- Use explicit segment ordering.
- Use explicit timestamps supplied by callers or fixtures, never wall-clock time in tests.
- Round-trip JSON deterministically enough for golden fixture comparisons.
- Avoid dependencies on OpenAI, Anthropic, Vapi, Retell, Twilio, LiveKit, STT, TTS, telephony, or any network service.

## Unit Tests

- `TestTraceRoundTripGoldenFixtures` — text-only, audio-only, and mixed traces unmarshal and marshal back to exact golden JSON.
- `TestTraceValidateRequiresCoreFields` — missing trace id, run id, run agent id, schema version, or segment id fails with a field-specific validation error.
- `TestTraceValidateSegmentKinds` — all declared segment kinds validate and unknown kinds fail.
- `TestTraceValidateSegmentOrdering` — duplicate or non-positive sequence numbers fail.
- `TestTraceValidateReferences` — transcript/audio/tool/structured/timing/media payload references are validated without provider dependencies.

## Integration / Functional Tests

N/A — this first slice only defines the local contract and golden fixtures. Later issues wire it into challenge packs, run execution, replay, and scoring.

## Smoke Tests

Run from `backend/`:

```bash
go test ./internal/multimodaltrace
```

Expected: pass without API keys, network, or external services.

## E2E Tests

N/A — this issue deliberately stops before execution mode integration.

## Manual / cURL Tests

N/A — no API endpoint is added in this issue.
```

## Review-checkpoint record

```json
{
  "branch": "codex/voice-multimodal-trace",
  "test_contract": "/tmp/codex-voice-multimodal-trace-test-contract.md",
  "created_at": "2026-05-13T09:15:34Z",
  "steps": [
    {
      "step_number": 1,
      "title": "Add deterministic multimodal trace contract",
      "review_result": {
        "status": "partial",
        "issues_found": [
          "Initial review found trace-level references were not validated."
        ]
      }
    },
    {
      "step_number": 2,
      "title": "Validate trace-level cross references",
      "review_result": {
        "status": "pass",
        "issues_found": []
      }
    },
    {
      "step_number": 3,
      "title": "Address Greptile contract-tightening comments",
      "what_changed": "Rejected empty traces, consolidated segment-kind validation through one segmentPayloadValidators map so IsValid and payload validation cannot drift independently, and required tool results to contain at least one of result or error. Added deterministic tests for empty segments, validator-map sync, and empty tool results.",
      "review_result": {
        "status": "pass",
        "issues_found": []
      }
    },
    {
      "step_number": "final",
      "title": "Final review after requested changes",
      "overall_verdict": "ready",
      "blocking_issues": []
    }
  ]
}
```

## Testing

```bash
cd backend
go test ./internal/multimodaltrace
go test ./...
```

Both passed locally after the requested changes and after the Greptile fixes.

## Notes for reviewer

No review-checkpoint markdown or JSON files are committed. Golden JSON fixtures live as Go string constants in tests, not as standalone JSON files.
