### PR TITLE
feat(voice-evals): add voice pack validation

### DIFF
--- a/backend/internal/challengepack/bundle.go
+++ b/backend/internal/challengepack/bundle.go
@@ -351,13 +351,14 @@ func normalizeInterfaceSpec(spec *InterfaceSpec) *InterfaceSpec {
 	if spec == nil {
 		return nil
 	}
+	var transports []string
+	for _, transport := range spec.Transports {
+		transports = append(transports, strings.TrimSpace(transport))
+	}
 	normalized := &InterfaceSpec{
-		Transports:      make([]string, 0, len(spec.Transports)),
+		Transports:      transports,
 		ChannelProfile:  strings.TrimSpace(spec.ChannelProfile),
 		SupportsBargeIn: spec.SupportsBargeIn,
-	}
-	for _, transport := range spec.Transports {
-		normalized.Transports = append(normalized.Transports, strings.TrimSpace(transport))
 	}
 	return normalized
 }

--- a/backend/internal/challengepack/bundle.go
+++ b/backend/internal/challengepack/bundle.go
@@ -12,11 +12,29 @@ import (
 )
 
 type Bundle struct {
-	Pack       PackMetadata          `yaml:"pack" json:"pack"`
-	Version    VersionMetadata       `yaml:"version" json:"version"`
-	Tools      map[string]any        `yaml:"tools,omitempty" json:"tools,omitempty"`
-	Challenges []ChallengeDefinition `yaml:"challenges" json:"challenges"`
-	InputSets  []InputSetDefinition  `yaml:"input_sets" json:"input_sets"`
+	Modality      string                `yaml:"modality,omitempty" json:"modality,omitempty"`
+	InterfaceSpec *InterfaceSpec        `yaml:"interface_spec,omitempty" json:"interface_spec,omitempty"`
+	Scenario      *ScenarioSpec         `yaml:"scenario,omitempty" json:"scenario,omitempty"`
+	Pack          PackMetadata          `yaml:"pack" json:"pack"`
+	Version       VersionMetadata       `yaml:"version" json:"version"`
+	Tools         map[string]any        `yaml:"tools,omitempty" json:"tools,omitempty"`
+	Challenges    []ChallengeDefinition `yaml:"challenges" json:"challenges"`
+	InputSets     []InputSetDefinition  `yaml:"input_sets" json:"input_sets"`
+}
+
+const ModalityVoice = "voice"
+
+type InterfaceSpec struct {
+	Transports      []string `yaml:"transports,omitempty" json:"transports,omitempty"`
+	ChannelProfile  string   `yaml:"channel_profile,omitempty" json:"channel_profile,omitempty"`
+	SupportsBargeIn bool     `yaml:"supports_barge_in,omitempty" json:"supports_barge_in,omitempty"`
+}
+
+type ScenarioSpec struct {
+	Persona       string `yaml:"persona,omitempty" json:"persona,omitempty"`
+	Language      string `yaml:"language,omitempty" json:"language,omitempty"`
+	MaxTurns      int32  `yaml:"max_turns,omitempty" json:"max_turns,omitempty"`
+	MaxDurationMS int64  `yaml:"max_duration_ms,omitempty" json:"max_duration_ms,omitempty"`
 }
 
 type PackMetadata struct {
@@ -148,11 +166,14 @@ func ParseYAML(data []byte) (Bundle, error) {
 		Assets             []AssetReference    `yaml:"assets,omitempty"`
 	}
 	type rawBundle struct {
-		Pack       PackMetadata          `yaml:"pack"`
-		Version    rawVersionMetadata    `yaml:"version"`
-		Tools      map[string]any        `yaml:"tools,omitempty"`
-		Challenges []ChallengeDefinition `yaml:"challenges"`
-		InputSets  []InputSetDefinition  `yaml:"input_sets"`
+		Modality      string                `yaml:"modality,omitempty"`
+		InterfaceSpec *InterfaceSpec        `yaml:"interface_spec,omitempty"`
+		Scenario      *ScenarioSpec         `yaml:"scenario,omitempty"`
+		Pack          PackMetadata          `yaml:"pack"`
+		Version       rawVersionMetadata    `yaml:"version"`
+		Tools         map[string]any        `yaml:"tools,omitempty"`
+		Challenges    []ChallengeDefinition `yaml:"challenges"`
+		InputSets     []InputSetDefinition  `yaml:"input_sets"`
 	}
 
 	var raw rawBundle
@@ -176,7 +197,10 @@ func ParseYAML(data []byte) (Bundle, error) {
 	}
 
 	bundle := Bundle{
-		Pack: raw.Pack,
+		Modality:      raw.Modality,
+		InterfaceSpec: raw.InterfaceSpec,
+		Scenario:      raw.Scenario,
+		Pack:          raw.Pack,
 		Version: VersionMetadata{
 			Number:             raw.Version.Number,
 			ExecutionMode:      raw.Version.ExecutionMode,
@@ -228,6 +252,15 @@ func ManifestJSON(bundle Bundle) (json.RawMessage, error) {
 		"challenges":      normalized.Challenges,
 		"input_sets":      normalized.InputSets,
 	}
+	if normalized.Modality != "" {
+		manifest["modality"] = normalized.Modality
+	}
+	if normalized.InterfaceSpec != nil {
+		manifest["interface_spec"] = normalized.InterfaceSpec
+	}
+	if normalized.Scenario != nil {
+		manifest["scenario"] = normalized.Scenario
+	}
 	if normalized.Tools != nil {
 		manifest["tools"] = normalized.Tools
 	}
@@ -244,6 +277,9 @@ func ManifestJSON(bundle Bundle) (json.RawMessage, error) {
 }
 
 func normalizeBundle(bundle *Bundle) {
+	bundle.Modality = strings.TrimSpace(bundle.Modality)
+	bundle.InterfaceSpec = normalizeInterfaceSpec(bundle.InterfaceSpec)
+	bundle.Scenario = normalizeScenarioSpec(bundle.Scenario)
 	bundle.Pack.Slug = strings.TrimSpace(bundle.Pack.Slug)
 	bundle.Pack.Name = strings.TrimSpace(bundle.Pack.Name)
 	bundle.Pack.Family = strings.TrimSpace(bundle.Pack.Family)
@@ -309,6 +345,33 @@ func normalizeBundle(bundle *Bundle) {
 	}
 
 	bundle.Version.Assets = normalizeAssets(bundle.Version.Assets)
+}
+
+func normalizeInterfaceSpec(spec *InterfaceSpec) *InterfaceSpec {
+	if spec == nil {
+		return nil
+	}
+	normalized := &InterfaceSpec{
+		Transports:      make([]string, 0, len(spec.Transports)),
+		ChannelProfile:  strings.TrimSpace(spec.ChannelProfile),
+		SupportsBargeIn: spec.SupportsBargeIn,
+	}
+	for _, transport := range spec.Transports {
+		normalized.Transports = append(normalized.Transports, strings.TrimSpace(transport))
+	}
+	return normalized
+}
+
+func normalizeScenarioSpec(spec *ScenarioSpec) *ScenarioSpec {
+	if spec == nil {
+		return nil
+	}
+	return &ScenarioSpec{
+		Persona:       strings.TrimSpace(spec.Persona),
+		Language:      strings.TrimSpace(spec.Language),
+		MaxTurns:      spec.MaxTurns,
+		MaxDurationMS: spec.MaxDurationMS,
+	}
 }
 
 func normalizeDeploymentDefaults(defaults *DeploymentDefaults) *DeploymentDefaults {

--- a/backend/internal/challengepack/bundle_test.go
+++ b/backend/internal/challengepack/bundle_test.go
@@ -190,6 +190,204 @@ func TestValidateBundleRejectsDeploymentDefaultsWithoutDefaultLineup(t *testing.
 	}
 }
 
+func TestParseYAMLAcceptsVoiceModalityBundle(t *testing.T) {
+	bundle, err := ParseYAML([]byte(`
+modality: voice
+interface_spec:
+  transports: [text_sim, webrtc]
+  channel_profile: deterministic_text
+  supports_barge_in: true
+scenario:
+  persona: billing_customer
+  language: en-US
+  max_turns: 6
+  max_duration_ms: 120000
+pack:
+  slug: voice-support-eval
+  name: Voice Support Eval
+  family: support
+version:
+  number: 1
+  evaluation_spec:
+    name: voice-support-v1
+    version_number: 1
+    judge_mode: deterministic
+    validators:
+      - key: exact
+        type: exact_match
+        target: final_output
+        expected_from: challenge_input
+    metrics:
+      - key: voice_latency_ms
+        type: numeric
+        collector: run_total_latency_ms
+        unit: ms
+    scorecard:
+      dimensions: [correctness]
+challenges:
+  - key: billing-refund
+    title: Billing Refund
+    category: support
+    difficulty: easy
+input_sets:
+  - key: default
+    name: Default Voice Inputs
+    cases:
+      - challenge_key: billing-refund
+        case_key: duplicate-charge
+        inputs:
+          - key: prompt
+            kind: text
+            value: Please refund the duplicate charge.
+        expectations:
+          - key: answer
+            kind: text
+            source: input:prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseYAML returned error: %v", err)
+	}
+	if bundle.Modality != ModalityVoice {
+		t.Fatalf("modality = %q, want voice", bundle.Modality)
+	}
+	if bundle.InterfaceSpec == nil || len(bundle.InterfaceSpec.Transports) != 2 || bundle.InterfaceSpec.Transports[0] != "text_sim" {
+		t.Fatalf("interface spec = %#v, want normalized voice transports", bundle.InterfaceSpec)
+	}
+	if bundle.Scenario == nil || bundle.Scenario.Language != "en-US" || bundle.Scenario.MaxTurns != 6 {
+		t.Fatalf("scenario = %#v, want normalized voice scenario", bundle.Scenario)
+	}
+
+	manifest, err := ManifestJSON(bundle)
+	if err != nil {
+		t.Fatalf("ManifestJSON returned error: %v", err)
+	}
+	var decoded struct {
+		Modality      string        `json:"modality"`
+		InterfaceSpec InterfaceSpec `json:"interface_spec"`
+		Scenario      ScenarioSpec  `json:"scenario"`
+	}
+	if err := json.Unmarshal(manifest, &decoded); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	if decoded.Modality != ModalityVoice {
+		t.Fatalf("manifest modality = %q, want voice", decoded.Modality)
+	}
+	if decoded.InterfaceSpec.ChannelProfile != "deterministic_text" {
+		t.Fatalf("manifest channel profile = %q, want deterministic_text", decoded.InterfaceSpec.ChannelProfile)
+	}
+	if decoded.Scenario.MaxDurationMS != 120000 {
+		t.Fatalf("manifest max_duration_ms = %d, want 120000", decoded.Scenario.MaxDurationMS)
+	}
+}
+
+func TestValidateBundleVoiceModalityCases(t *testing.T) {
+	cases := []struct {
+		name       string
+		mutate     func(*Bundle)
+		wantFields []string
+	}{
+		{
+			name: "valid existing pack",
+		},
+		{
+			name: "valid minimal voice pack",
+			mutate: func(bundle *Bundle) {
+				*bundle = minimalVoiceBundle()
+			},
+		},
+		{
+			name: "invalid modality",
+			mutate: func(bundle *Bundle) {
+				bundle.Modality = "video"
+			},
+			wantFields: []string{"modality"},
+		},
+		{
+			name: "invalid interface_spec transports",
+			mutate: func(bundle *Bundle) {
+				*bundle = minimalVoiceBundle()
+				bundle.InterfaceSpec.Transports = []string{"text_sim", "satellite"}
+			},
+			wantFields: []string{"interface_spec.transports[1]"},
+		},
+		{
+			name: "missing scenario max_turns",
+			mutate: func(bundle *Bundle) {
+				*bundle = minimalVoiceBundle()
+				bundle.Scenario.MaxTurns = 0
+			},
+			wantFields: []string{"scenario.max_turns"},
+		},
+		{
+			name: "missing scenario language",
+			mutate: func(bundle *Bundle) {
+				*bundle = minimalVoiceBundle()
+				bundle.Scenario.Language = ""
+			},
+			wantFields: []string{"scenario.language"},
+		},
+		{
+			name: "duplicate metric keys",
+			mutate: func(bundle *Bundle) {
+				bundle.Version.EvaluationSpec.Metrics = []scoring.MetricDeclaration{
+					{Key: "latency", Type: scoring.MetricTypeNumeric, Collector: "run_total_latency_ms"},
+					{Key: "latency", Type: scoring.MetricTypeNumeric, Collector: "run_ttft_ms"},
+				}
+			},
+			wantFields: []string{"version.evaluation_spec.metrics[1].key"},
+		},
+		{
+			name: "duplicate validator keys",
+			mutate: func(bundle *Bundle) {
+				bundle.Version.EvaluationSpec.Validators = append(bundle.Version.EvaluationSpec.Validators, scoring.ValidatorDeclaration{
+					Key:          "exact",
+					Type:         scoring.ValidatorTypeContains,
+					Target:       "final_output",
+					ExpectedFrom: "challenge_input",
+				})
+			},
+			wantFields: []string{"version.evaluation_spec.validators[1].key"},
+		},
+		{
+			name: "voice blocks without modality",
+			mutate: func(bundle *Bundle) {
+				bundle.InterfaceSpec = &InterfaceSpec{Transports: []string{"text_sim"}, ChannelProfile: "deterministic_text"}
+				bundle.Scenario = &ScenarioSpec{Persona: "billing_customer", Language: "en-US", MaxTurns: 6, MaxDurationMS: 120000}
+			},
+			wantFields: []string{"modality"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := minimalBundle()
+			if tc.mutate != nil {
+				tc.mutate(&bundle)
+			}
+
+			err := ValidateBundle(bundle)
+			if len(tc.wantFields) == 0 {
+				if err != nil {
+					t.Fatalf("ValidateBundle returned error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("ValidateBundle returned nil error")
+			}
+			errs, ok := err.(ValidationErrors)
+			if !ok {
+				t.Fatalf("error type = %T, want ValidationErrors", err)
+			}
+			for _, field := range tc.wantFields {
+				if !containsField(errs, field) {
+					t.Fatalf("validation errors = %+v, want field %q", errs, field)
+				}
+			}
+		})
+	}
+}
+
 func TestValidateBundleRejectsEmptyDeploymentDefaultSelectors(t *testing.T) {
 	bundle := minimalBundle()
 	bundle.Version.DeploymentDefaults = &DeploymentDefaults{
@@ -977,6 +1175,23 @@ func minimalBundle() Bundle {
 			},
 		},
 	}
+}
+
+func minimalVoiceBundle() Bundle {
+	bundle := minimalBundle()
+	bundle.Modality = ModalityVoice
+	bundle.InterfaceSpec = &InterfaceSpec{
+		Transports:      []string{"text_sim"},
+		ChannelProfile:  "deterministic_text",
+		SupportsBargeIn: false,
+	}
+	bundle.Scenario = &ScenarioSpec{
+		Persona:       "billing_customer",
+		Language:      "en-US",
+		MaxTurns:      6,
+		MaxDurationMS: 120000,
+	}
+	return bundle
 }
 
 func containsField(errs ValidationErrors, field string) bool {

--- a/backend/internal/challengepack/bundle_test.go
+++ b/backend/internal/challengepack/bundle_test.go
@@ -327,6 +327,22 @@ func TestValidateBundleVoiceModalityCases(t *testing.T) {
 			wantFields: []string{"scenario.language"},
 		},
 		{
+			name: "missing scenario persona",
+			mutate: func(bundle *Bundle) {
+				*bundle = minimalVoiceBundle()
+				bundle.Scenario.Persona = ""
+			},
+			wantFields: []string{"scenario.persona"},
+		},
+		{
+			name: "missing scenario max_duration_ms",
+			mutate: func(bundle *Bundle) {
+				*bundle = minimalVoiceBundle()
+				bundle.Scenario.MaxDurationMS = 0
+			},
+			wantFields: []string{"scenario.max_duration_ms"},
+		},
+		{
 			name: "duplicate metric keys",
 			mutate: func(bundle *Bundle) {
 				bundle.Version.EvaluationSpec.Metrics = []scoring.MetricDeclaration{
@@ -385,6 +401,21 @@ func TestValidateBundleVoiceModalityCases(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestNormalizeInterfaceSpecOmitsEmptyVoiceTransports(t *testing.T) {
+	normalized := normalizeInterfaceSpec(&InterfaceSpec{ChannelProfile: "deterministic_text"})
+	encoded, err := json.Marshal(normalized)
+	if err != nil {
+		t.Fatalf("marshal normalized interface spec: %v", err)
+	}
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal normalized interface spec: %v", err)
+	}
+	if _, ok := decoded["transports"]; ok {
+		t.Fatalf("normalized transports present, want omitted")
 	}
 }
 

--- a/backend/internal/challengepack/validation.go
+++ b/backend/internal/challengepack/validation.go
@@ -25,6 +25,14 @@ var supportedToolKinds = map[string]struct{}{
 	"network": {},
 }
 
+var supportedVoiceTransports = map[string]struct{}{
+	"text_sim":  {},
+	"webrtc":    {},
+	"sip":       {},
+	"pstn":      {},
+	"websocket": {},
+}
+
 type ValidationError struct {
 	Field   string
 	Message string
@@ -59,6 +67,7 @@ func ValidateBundle(bundle Bundle) error {
 	if bundle.Version.Number <= 0 {
 		errs = append(errs, ValidationError{Field: "version.number", Message: "must be greater than 0"})
 	}
+	errs = append(errs, validateModalityConfig(bundle)...)
 	switch bundle.Version.ExecutionMode {
 	case "", ExecutionModeNative, ExecutionModePromptEval:
 	default:
@@ -191,6 +200,79 @@ func ValidateBundle(bundle Bundle) error {
 		return errs
 	}
 	return nil
+}
+
+func validateModalityConfig(bundle Bundle) ValidationErrors {
+	var errs ValidationErrors
+	switch strings.TrimSpace(bundle.Modality) {
+	case "":
+		if bundle.InterfaceSpec != nil {
+			errs = append(errs, ValidationError{Field: "modality", Message: "is required when interface_spec is set"})
+		}
+		if bundle.Scenario != nil {
+			errs = append(errs, ValidationError{Field: "modality", Message: "is required when scenario is set"})
+		}
+		return errs
+	case ModalityVoice:
+		errs = append(errs, validateVoiceInterfaceSpec("interface_spec", bundle.InterfaceSpec)...)
+		errs = append(errs, validateVoiceScenarioSpec("scenario", bundle.Scenario)...)
+	default:
+		errs = append(errs, ValidationError{Field: "modality", Message: `must be "voice" when specified`})
+	}
+	return errs
+}
+
+func validateVoiceInterfaceSpec(path string, spec *InterfaceSpec) ValidationErrors {
+	if spec == nil {
+		return ValidationErrors{{Field: path, Message: "is required when modality is voice"}}
+	}
+
+	var errs ValidationErrors
+	if len(spec.Transports) == 0 {
+		errs = append(errs, ValidationError{Field: path + ".transports", Message: "must contain at least one transport"})
+	}
+	seen := map[string]struct{}{}
+	for i, transport := range spec.Transports {
+		field := fmt.Sprintf("%s.transports[%d]", path, i)
+		normalized := strings.TrimSpace(transport)
+		if normalized == "" {
+			errs = append(errs, ValidationError{Field: field, Message: "must be one of text_sim, webrtc, sip, pstn, websocket"})
+			continue
+		}
+		if _, exists := seen[normalized]; exists {
+			errs = append(errs, ValidationError{Field: field, Message: "must be unique"})
+			continue
+		}
+		seen[normalized] = struct{}{}
+		if _, ok := supportedVoiceTransports[normalized]; !ok {
+			errs = append(errs, ValidationError{Field: field, Message: "must be one of text_sim, webrtc, sip, pstn, websocket"})
+		}
+	}
+	if strings.TrimSpace(spec.ChannelProfile) == "" {
+		errs = append(errs, ValidationError{Field: path + ".channel_profile", Message: "is required when modality is voice"})
+	}
+	return errs
+}
+
+func validateVoiceScenarioSpec(path string, spec *ScenarioSpec) ValidationErrors {
+	if spec == nil {
+		return ValidationErrors{{Field: path, Message: "is required when modality is voice"}}
+	}
+
+	var errs ValidationErrors
+	if strings.TrimSpace(spec.Persona) == "" {
+		errs = append(errs, ValidationError{Field: path + ".persona", Message: "is required when modality is voice"})
+	}
+	if strings.TrimSpace(spec.Language) == "" {
+		errs = append(errs, ValidationError{Field: path + ".language", Message: "is required when modality is voice"})
+	}
+	if spec.MaxTurns <= 0 {
+		errs = append(errs, ValidationError{Field: path + ".max_turns", Message: "must be greater than 0 when modality is voice"})
+	}
+	if spec.MaxDurationMS <= 0 {
+		errs = append(errs, ValidationError{Field: path + ".max_duration_ms", Message: "must be greater than 0 when modality is voice"})
+	}
+	return errs
 }
 
 func validateDeploymentDefaults(path string, defaults *DeploymentDefaults) ValidationErrors {


### PR DESCRIPTION
Closes #756
Parent: #754
Depends on: #755, merged in #771

## Summary

- Adds optional top-level `modality`, `interface_spec`, and `scenario` fields to challenge-pack bundles.
- Supports `modality: voice` validation for deterministic voice-pack contracts without adding live voice, telephony, STT/TTS, network, provider, or LLM dependencies.
- Preserves normalized voice metadata in `ManifestJSON` so challenge-pack versions can freeze the validated structure.
- Adds deterministic parser/manifest coverage plus table-driven `ValidateBundle` cases for existing packs, voice packs, invalid fields, and duplicate scoring keys.

## Testing

- `cd backend && go test ./internal/challengepack ./internal/scoring`
- `cd backend && go test ./...`

## Review Checkpoint

The test contract and checkpoint JSON were intentionally kept in `/tmp` and not committed.

### Test Contract

```markdown
# codex/voice-pack-validation — Test Contract

## Functional Behavior

Implement issue #756: extend challenge-pack validation for `modality: voice` without changing existing non-voice challenge-pack behavior.

The implementation must:

- Preserve existing challenge-pack parsing, validation, and manifest output for packs without a modality.
- Accept a minimal voice challenge pack with top-level `modality: voice`, `interface_spec`, and `scenario` blocks.
- Validate voice interface transports against the initial deterministic set: `text_sim`, `webrtc`, `sip`, `pstn`, `websocket`.
- Reject unknown modality values.
- Reject `modality: voice` when required voice blocks/fields are missing.
- Preserve the normalized voice modality/interface/scenario fields in `ManifestJSON` so the runnable challenge-pack version can freeze them.
- Avoid adding any LLM, telephony, STT, TTS, media, or network dependency.

## Unit Tests

- `TestParseYAMLAcceptsVoiceModalityBundle` — valid minimal voice pack parses and manifest JSON includes `modality`, `interface_spec`, and `scenario`.
- `TestValidateBundleVoiceModalityCases` — table-driven validation for valid existing pack, valid minimal voice pack, invalid top-level modality, invalid `interface_spec.transports`, missing `scenario.language`, missing `scenario.max_turns`, duplicate metric keys, duplicate validator keys, and voice blocks without `modality: voice`.

## Integration / Functional Tests

N/A — this slice only extends the challenge-pack bundle contract. It does not create voice execution, scoring, replay, or artifact behavior.

## Smoke Tests

Run from `backend/`:

`go test ./internal/challengepack ./internal/scoring`

Expected: pass without API keys, network, voice providers, or live LLMs.

## E2E Tests

N/A — execution-mode integration is intentionally deferred to later issues.

## Manual / cURL Tests

N/A — no API endpoint behavior changes in this issue.
```

### Review Update: Greptile Comments

Addressed both Greptile review comments in commit `e87beb12`:

- Added table-driven coverage for `scenario.persona` and `scenario.max_duration_ms`.
- Changed `normalizeInterfaceSpec` so absent transports remain nil and `json:",omitempty"` can omit the field.
- Added `TestNormalizeInterfaceSpecOmitsEmptyVoiceTransports` to pin the normalization behavior directly.

Checkpoint status: pass. Focused and full backend tests passed after the review fix.

### Checkpoint JSON

```json
{
  "branch": "codex/voice-pack-validation",
  "test_contract": "/tmp/codex-voice-pack-validation-test-contract.md",
  "created_at": "2026-05-13T10:09:35Z",
  "steps": [
    {
      "step_number": 1,
      "title": "Add voice modality challenge-pack validation",
      "timestamp": "2026-05-13T10:13:45Z",
      "files_changed": [
        "backend/internal/challengepack/bundle.go",
        "backend/internal/challengepack/validation.go",
        "backend/internal/challengepack/bundle_test.go"
      ],
      "what_changed": "Added top-level modality, interface_spec, and scenario fields to challenge-pack bundles; preserved them in manifest JSON; validated voice interface/scenario requirements and supported transports; added deterministic parser and table-driven validation tests.",
      "review_instructions": "Verify that non-voice packs still validate, modality: voice requires interface_spec and scenario, unknown modalities and transports fail with field-specific errors, required scenario fields are enforced, duplicate validator/metric key coverage still flows through ValidateBundle, and no provider/network/LLM dependency was introduced.",
      "review_result": {
        "status": "pass",
        "issues_found": [],
        "notes": "Diff is limited to challenge-pack bundle parsing, manifest normalization, validation, and tests. Focused and full backend tests pass."
      },
      "cumulative_review": {
        "previous_steps_still_valid": true,
        "integration_issues": [],
        "notes": "Single-step implementation; no earlier step to invalidate."
      }
    },
    {
      "step_number": "final",
      "title": "Final review against test contract",
      "timestamp": "2026-05-13T10:13:45Z",
      "test_contract_review": {
        "functional_behavior": "pass - existing non-voice packs remain valid; minimal voice packs parse and validate; unsupported modality/transport and missing required scenario fields are rejected field-specifically; normalized voice metadata is emitted by ManifestJSON; no live voice/LLM/provider dependency was added.",
        "unit_tests": "pass - TestParseYAMLAcceptsVoiceModalityBundle and TestValidateBundleVoiceModalityCases cover the requested deterministic parser/validation cases, including duplicate metric and validator keys through ValidateBundle.",
        "integration_tests": "N/A - this change is limited to challenge-pack bundle contract validation.",
        "smoke_tests": "pass - go test ./internal/challengepack ./internal/scoring and go test ./... passed from backend/.",
        "e2e_tests": "N/A - voice execution/replay is deferred to later issues.",
        "manual_tests": "N/A - no API endpoint behavior changed."
      },
      "overall_verdict": "ready",
      "blocking_issues": []
    }
  ]
}
```
