### PR TITLE
test(voice-evals): add golden fixture adapters

### DIFF
--- a/backend/internal/voicefixtures/fixtures.go
+++ b/backend/internal/voicefixtures/fixtures.go
@@ -1,0 +1,513 @@
+package voicefixtures
+
+import (
+	"bytes"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/multimodaltrace"
+	"github.com/google/uuid"
+)
+
+const (
+	SupportBillingScenarioKey = "support_billing_duplicate_charge"
+	SupportBillingSeed        = int64(42)
+
+	supportBillingBaseTime = "2026-05-13T10:00:00Z"
+	supportBillingRunID    = "33333333-3333-3333-3333-333333333333"
+	supportBillingAgentID  = "44444444-4444-4444-4444-444444444444"
+)
+
+//go:embed testdata/support_billing/*
+var supportBillingFS embed.FS
+
+type SupportBillingFixture struct {
+	ChallengePackYAML       []byte
+	ScriptedUserTurnsJSON   []byte
+	ExpectedToolCallJSON    []byte
+	ExpectedToolResultJSON  []byte
+	ExpectedAgentTextOutput []byte
+	ExpectedStructuredJSON  []byte
+	ExpectedTraceJSON       []byte
+	ExpectedScorecardJSON   []byte
+}
+
+type ScriptedUserTurn struct {
+	TurnID             string `json:"turn_id"`
+	Speaker            string `json:"speaker"`
+	Text               string `json:"text"`
+	Language           string `json:"language"`
+	AudioArtifactRef   string `json:"audio_artifact_ref"`
+	AudioFormat        string `json:"audio_format"`
+	AudioChannel       string `json:"audio_channel"`
+	DurationMS         int64  `json:"duration_ms"`
+	OccurredAtOffsetMS int64  `json:"occurred_at_offset_ms"`
+}
+
+type ToolCallFixture struct {
+	CallID    string          `json:"call_id"`
+	ToolName  string          `json:"tool_name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+type ToolResultFixture struct {
+	CallID   string          `json:"call_id"`
+	ToolName string          `json:"tool_name"`
+	Result   json.RawMessage `json:"result"`
+}
+
+type StructuredOutputFixture struct {
+	SchemaRef string          `json:"schema_ref"`
+	Output    json.RawMessage `json:"output"`
+}
+
+type AgentResponse struct {
+	TextOutput       string
+	Language         string
+	AudioArtifactRef string
+	AudioFormat      string
+	AudioChannel     string
+	AudioDurationMS  int64
+	StructuredOutput StructuredOutputFixture
+	ToolCall         ToolCallFixture
+	ToolResult       ToolResultFixture
+}
+
+type ScenarioRun struct {
+	Trace                 multimodaltrace.Trace
+	TraceJSON             []byte
+	ScorecardJSON         []byte
+	ToolCallJSON          []byte
+	ToolCallArgumentsJSON []byte
+	ToolResultJSON        []byte
+	AgentTextOutput       []byte
+	StructuredOutputJSON  []byte
+	EventTimestamps       []time.Time
+}
+
+type FakeClock struct {
+	base time.Time
+}
+
+func NewFakeClock(base time.Time) *FakeClock {
+	return &FakeClock{base: base}
+}
+
+func (c *FakeClock) AtOffset(offset time.Duration) time.Time {
+	return c.base.Add(offset).UTC()
+}
+
+type FakeUserSimulator struct {
+	turns []ScriptedUserTurn
+}
+
+func NewFakeUserSimulator(turns []ScriptedUserTurn) *FakeUserSimulator {
+	return &FakeUserSimulator{turns: append([]ScriptedUserTurn(nil), turns...)}
+}
+
+func (s *FakeUserSimulator) Turns() []ScriptedUserTurn {
+	return append([]ScriptedUserTurn(nil), s.turns...)
+}
+
+type FakeToolEndpoint struct {
+	expectedCall ToolCallFixture
+	result       ToolResultFixture
+	calls        []ToolCallFixture
+}
+
+func NewFakeToolEndpoint(expectedCall ToolCallFixture, result ToolResultFixture) *FakeToolEndpoint {
+	return &FakeToolEndpoint{expectedCall: expectedCall, result: result}
+}
+
+func (e *FakeToolEndpoint) Call(call ToolCallFixture) (ToolResultFixture, error) {
+	if call.CallID != e.expectedCall.CallID || call.ToolName != e.expectedCall.ToolName || !bytes.Equal(call.Arguments, e.expectedCall.Arguments) {
+		return ToolResultFixture{}, fmt.Errorf("unexpected tool call: got %s/%s %s", call.CallID, call.ToolName, string(call.Arguments))
+	}
+	e.calls = append(e.calls, call)
+	return e.result, nil
+}
+
+func (e *FakeToolEndpoint) Calls() []ToolCallFixture {
+	return append([]ToolCallFixture(nil), e.calls...)
+}
+
+type FakeVoiceAgentDeployment struct {
+	tool             *FakeToolEndpoint
+	expectedCall     ToolCallFixture
+	structuredOutput StructuredOutputFixture
+	textOutput       string
+}
+
+func NewFakeVoiceAgentDeployment(tool *FakeToolEndpoint, expectedCall ToolCallFixture, structuredOutput StructuredOutputFixture, textOutput string) *FakeVoiceAgentDeployment {
+	return &FakeVoiceAgentDeployment{
+		tool:             tool,
+		expectedCall:     expectedCall,
+		structuredOutput: structuredOutput,
+		textOutput:       textOutput,
+	}
+}
+
+func (d *FakeVoiceAgentDeployment) Respond(turn ScriptedUserTurn) (AgentResponse, error) {
+	if strings.TrimSpace(turn.Text) == "" {
+		return AgentResponse{}, fmt.Errorf("scripted user turn %q has empty text", turn.TurnID)
+	}
+	result, err := d.tool.Call(d.expectedCall)
+	if err != nil {
+		return AgentResponse{}, err
+	}
+	return AgentResponse{
+		TextOutput:       d.textOutput,
+		Language:         turn.Language,
+		AudioArtifactRef: "fixtures/support_billing/audio/agent-turn-001.wav",
+		AudioFormat:      "wav",
+		AudioChannel:     "agent",
+		AudioDurationMS:  2400,
+		StructuredOutput: d.structuredOutput,
+		ToolCall:         d.expectedCall,
+		ToolResult:       result,
+	}, nil
+}
+
+type FakeMediaTransport struct {
+	frames []MediaFrame
+}
+
+type MediaFrame struct {
+	Actor       multimodaltrace.Actor
+	ArtifactRef string
+	Format      string
+	Channel     string
+	DurationMS  int64
+	OccurredAt  time.Time
+}
+
+func (t *FakeMediaTransport) ReceiveUserAudio(turn ScriptedUserTurn, occurredAt time.Time) MediaFrame {
+	frame := MediaFrame{
+		Actor:       multimodaltrace.ActorUser,
+		ArtifactRef: turn.AudioArtifactRef,
+		Format:      turn.AudioFormat,
+		Channel:     turn.AudioChannel,
+		DurationMS:  turn.DurationMS,
+		OccurredAt:  occurredAt,
+	}
+	t.frames = append(t.frames, frame)
+	return frame
+}
+
+func (t *FakeMediaTransport) SendAgentAudio(response AgentResponse, occurredAt time.Time) MediaFrame {
+	frame := MediaFrame{
+		Actor:       multimodaltrace.ActorAgent,
+		ArtifactRef: response.AudioArtifactRef,
+		Format:      response.AudioFormat,
+		Channel:     response.AudioChannel,
+		DurationMS:  response.AudioDurationMS,
+		OccurredAt:  occurredAt,
+	}
+	t.frames = append(t.frames, frame)
+	return frame
+}
+
+func (t *FakeMediaTransport) Frames() []MediaFrame {
+	return append([]MediaFrame(nil), t.frames...)
+}
+
+func LoadSupportBillingFixture() (SupportBillingFixture, error) {
+	read := func(name string) ([]byte, error) {
+		data, err := supportBillingFS.ReadFile("testdata/support_billing/" + name)
+		if err != nil {
+			return nil, err
+		}
+		return data, nil
+	}
+
+	var fixture SupportBillingFixture
+	var err error
+	if fixture.ChallengePackYAML, err = read("challenge_pack.yaml"); err != nil {
+		return SupportBillingFixture{}, err
+	}
+	if fixture.ScriptedUserTurnsJSON, err = read("scripted_user_turns.json"); err != nil {
+		return SupportBillingFixture{}, err
+	}
+	if fixture.ExpectedToolCallJSON, err = read("expected_tool_call.json"); err != nil {
+		return SupportBillingFixture{}, err
+	}
+	if fixture.ExpectedToolResultJSON, err = read("expected_tool_result.json"); err != nil {
+		return SupportBillingFixture{}, err
+	}
+	if fixture.ExpectedAgentTextOutput, err = read("expected_agent_text_output.txt"); err != nil {
+		return SupportBillingFixture{}, err
+	}
+	if fixture.ExpectedStructuredJSON, err = read("expected_structured_output.json"); err != nil {
+		return SupportBillingFixture{}, err
+	}
+	if fixture.ExpectedTraceJSON, err = read("expected_trace.json"); err != nil {
+		return SupportBillingFixture{}, err
+	}
+	if fixture.ExpectedScorecardJSON, err = read("expected_scorecard.json"); err != nil {
+		return SupportBillingFixture{}, err
+	}
+	return fixture, nil
+}
+
+func RunSupportBillingScenario(seed int64) (ScenarioRun, error) {
+	fixture, err := LoadSupportBillingFixture()
+	if err != nil {
+		return ScenarioRun{}, err
+	}
+	if seed != SupportBillingSeed {
+		return ScenarioRun{}, fmt.Errorf("unsupported support billing fixture seed %d", seed)
+	}
+
+	var turns []ScriptedUserTurn
+	if err := json.Unmarshal(fixture.ScriptedUserTurnsJSON, &turns); err != nil {
+		return ScenarioRun{}, fmt.Errorf("decode scripted user turns: %w", err)
+	}
+	if len(turns) != 1 {
+		return ScenarioRun{}, fmt.Errorf("support billing fixture expects one scripted turn, got %d", len(turns))
+	}
+
+	var expectedCall ToolCallFixture
+	if err := decodeCanonical(fixture.ExpectedToolCallJSON, &expectedCall); err != nil {
+		return ScenarioRun{}, fmt.Errorf("decode expected tool call: %w", err)
+	}
+	var expectedResult ToolResultFixture
+	if err := decodeCanonical(fixture.ExpectedToolResultJSON, &expectedResult); err != nil {
+		return ScenarioRun{}, fmt.Errorf("decode expected tool result: %w", err)
+	}
+	var structured StructuredOutputFixture
+	if err := decodeCanonical(fixture.ExpectedStructuredJSON, &structured); err != nil {
+		return ScenarioRun{}, fmt.Errorf("decode expected structured output: %w", err)
+	}
+
+	baseTime, err := time.Parse(time.RFC3339, supportBillingBaseTime)
+	if err != nil {
+		return ScenarioRun{}, err
+	}
+	runID := uuid.MustParse(supportBillingRunID)
+	runAgentID := uuid.MustParse(supportBillingAgentID)
+	clock := NewFakeClock(baseTime)
+	simulator := NewFakeUserSimulator(turns)
+	tool := NewFakeToolEndpoint(expectedCall, expectedResult)
+	agent := NewFakeVoiceAgentDeployment(tool, expectedCall, structured, strings.TrimSpace(string(fixture.ExpectedAgentTextOutput)))
+	media := &FakeMediaTransport{}
+
+	turn := simulator.Turns()[0]
+	response, err := agent.Respond(turn)
+	if err != nil {
+		return ScenarioRun{}, err
+	}
+
+	userFrame := media.ReceiveUserAudio(turn, clock.AtOffset(time.Duration(turn.OccurredAtOffsetMS)*time.Millisecond))
+	agentFrame := media.SendAgentAudio(response, clock.AtOffset(6*time.Second))
+	confidence := 1.0
+	trace := multimodaltrace.Trace{
+		TraceID:       "trace-support-billing-seed-42",
+		SchemaVersion: multimodaltrace.SchemaVersionV1,
+		RunID:         runID,
+		RunAgentID:    runAgentID,
+		Segments: []multimodaltrace.Segment{
+			{
+				SegmentID:      "seg-001",
+				SequenceNumber: 1,
+				Kind:           multimodaltrace.SegmentKindAudioInput,
+				Actor:          userFrame.Actor,
+				OccurredAt:     userFrame.OccurredAt,
+				Audio: &multimodaltrace.AudioPayload{
+					ArtifactRef: userFrame.ArtifactRef,
+					Format:      userFrame.Format,
+					Channel:     userFrame.Channel,
+					DurationMS:  userFrame.DurationMS,
+				},
+			},
+			{
+				SegmentID:      "seg-002",
+				SequenceNumber: 2,
+				Kind:           multimodaltrace.SegmentKindTranscriptFinal,
+				Actor:          multimodaltrace.ActorSystem,
+				OccurredAt:     clock.AtOffset(2 * time.Second),
+				Transcript: &multimodaltrace.TranscriptPayload{
+					Text:            turn.Text,
+					Language:        turn.Language,
+					Confidence:      &confidence,
+					SourceSegmentID: "seg-001",
+				},
+			},
+			{
+				SegmentID:      "seg-003",
+				SequenceNumber: 3,
+				Kind:           multimodaltrace.SegmentKindToolCall,
+				Actor:          multimodaltrace.ActorAgent,
+				OccurredAt:     clock.AtOffset(3 * time.Second),
+				ToolCall: &multimodaltrace.ToolCallPayload{
+					CallID:    response.ToolCall.CallID,
+					ToolName:  response.ToolCall.ToolName,
+					Arguments: response.ToolCall.Arguments,
+				},
+			},
+			{
+				SegmentID:      "seg-004",
+				SequenceNumber: 4,
+				Kind:           multimodaltrace.SegmentKindToolResult,
+				Actor:          multimodaltrace.ActorTool,
+				OccurredAt:     clock.AtOffset(4 * time.Second),
+				ToolResult: &multimodaltrace.ToolResultPayload{
+					CallID:   response.ToolResult.CallID,
+					ToolName: response.ToolResult.ToolName,
+					Result:   response.ToolResult.Result,
+				},
+			},
+			{
+				SegmentID:      "seg-005",
+				SequenceNumber: 5,
+				Kind:           multimodaltrace.SegmentKindTextOutput,
+				Actor:          multimodaltrace.ActorAgent,
+				OccurredAt:     clock.AtOffset(5 * time.Second),
+				Text: &multimodaltrace.TextPayload{
+					Text:     response.TextOutput,
+					Language: response.Language,
+				},
+			},
+			{
+				SegmentID:      "seg-006",
+				SequenceNumber: 6,
+				Kind:           multimodaltrace.SegmentKindAudioOutput,
+				Actor:          agentFrame.Actor,
+				OccurredAt:     agentFrame.OccurredAt,
+				Audio: &multimodaltrace.AudioPayload{
+					ArtifactRef: agentFrame.ArtifactRef,
+					Format:      agentFrame.Format,
+					Channel:     agentFrame.Channel,
+					DurationMS:  agentFrame.DurationMS,
+				},
+			},
+			{
+				SegmentID:      "seg-007",
+				SequenceNumber: 7,
+				Kind:           multimodaltrace.SegmentKindStructuredOutput,
+				Actor:          multimodaltrace.ActorAgent,
+				OccurredAt:     clock.AtOffset(7 * time.Second),
+				StructuredOutput: &multimodaltrace.StructuredOutputPayload{
+					SchemaRef: response.StructuredOutput.SchemaRef,
+					Output:    response.StructuredOutput.Output,
+				},
+			},
+			{
+				SegmentID:      "seg-008",
+				SequenceNumber: 8,
+				Kind:           multimodaltrace.SegmentKindTimingMarker,
+				Actor:          multimodaltrace.ActorEvaluator,
+				OccurredAt:     clock.AtOffset(7 * time.Second),
+				TimingMarker: &multimodaltrace.TimingMarkerPayload{
+					Key:     "end_of_speech_to_first_agent_text",
+					ValueMS: 3200,
+				},
+			},
+		},
+	}
+	if err := trace.Validate(); err != nil {
+		return ScenarioRun{}, fmt.Errorf("validate support billing trace: %w", err)
+	}
+
+	traceJSON, err := marshalGolden(trace)
+	if err != nil {
+		return ScenarioRun{}, err
+	}
+	scorecardJSON, err := marshalGolden(supportBillingScorecard(seed))
+	if err != nil {
+		return ScenarioRun{}, err
+	}
+	toolCallJSON, err := marshalGolden(response.ToolCall)
+	if err != nil {
+		return ScenarioRun{}, err
+	}
+	toolResultJSON, err := marshalGolden(response.ToolResult)
+	if err != nil {
+		return ScenarioRun{}, err
+	}
+	structuredJSON, err := marshalGolden(response.StructuredOutput)
+	if err != nil {
+		return ScenarioRun{}, err
+	}
+
+	timestamps := make([]time.Time, 0, len(trace.Segments))
+	for _, segment := range trace.Segments {
+		timestamps = append(timestamps, segment.OccurredAt)
+	}
+
+	return ScenarioRun{
+		Trace:                 trace,
+		TraceJSON:             traceJSON,
+		ScorecardJSON:         scorecardJSON,
+		ToolCallJSON:          toolCallJSON,
+		ToolCallArgumentsJSON: append([]byte(nil), response.ToolCall.Arguments...),
+		ToolResultJSON:        toolResultJSON,
+		AgentTextOutput:       append([]byte(response.TextOutput), '\n'),
+		StructuredOutputJSON:  structuredJSON,
+		EventTimestamps:       timestamps,
+	}, nil
+}
+
+type supportBillingScorecardFixture struct {
+	SchemaVersion int                         `json:"schema_version"`
+	ScenarioKey   string                      `json:"scenario_key"`
+	Seed          int64                       `json:"seed"`
+	Passed        bool                        `json:"passed"`
+	OverallScore  float64                     `json:"overall_score"`
+	Checks        []supportBillingScoreCheck  `json:"checks"`
+	Metrics       []supportBillingScoreMetric `json:"metrics"`
+}
+
+type supportBillingScoreCheck struct {
+	Key      string `json:"key"`
+	Passed   bool   `json:"passed"`
+	Expected string `json:"expected"`
+	Actual   string `json:"actual"`
+}
+
+type supportBillingScoreMetric struct {
+	Key   string `json:"key"`
+	Value int64  `json:"value"`
+	Unit  string `json:"unit"`
+}
+
+func supportBillingScorecard(seed int64) supportBillingScorecardFixture {
+	return supportBillingScorecardFixture{
+		SchemaVersion: 1,
+		ScenarioKey:   SupportBillingScenarioKey,
+		Seed:          seed,
+		Passed:        true,
+		OverallScore:  1,
+		Checks: []supportBillingScoreCheck{
+			{Key: "refund_created", Passed: true, Expected: "created", Actual: "created"},
+			{Key: "tool_name", Passed: true, Expected: "refund_api", Actual: "refund_api"},
+			{Key: "structured_resolution", Passed: true, Expected: "refund_created", Actual: "refund_created"},
+		},
+		Metrics: []supportBillingScoreMetric{
+			{Key: "turn_count", Value: 1, Unit: "turn"},
+			{Key: "end_of_speech_to_first_agent_text_ms", Value: 3200, Unit: "ms"},
+		},
+	}
+}
+
+func decodeCanonical(data []byte, out any) error {
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	canonical, err := json.Marshal(raw)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(canonical, out)
+}
+
+func marshalGolden(value any) ([]byte, error) {
+	encoded, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(encoded, '\n'), nil
+}

--- a/backend/internal/voicefixtures/fixtures.go
+++ b/backend/internal/voicefixtures/fixtures.go
@@ -252,13 +252,10 @@ func LoadSupportBillingFixture() (SupportBillingFixture, error) {
 	return fixture, nil
 }
 
-func RunSupportBillingScenario(seed int64) (ScenarioRun, error) {
+func RunSupportBillingScenario() (ScenarioRun, error) {
 	fixture, err := LoadSupportBillingFixture()
 	if err != nil {
 		return ScenarioRun{}, err
-	}
-	if seed != SupportBillingSeed {
-		return ScenarioRun{}, fmt.Errorf("unsupported support billing fixture seed %d", seed)
 	}
 
 	var turns []ScriptedUserTurn
@@ -301,7 +298,9 @@ func RunSupportBillingScenario(seed int64) (ScenarioRun, error) {
 	}
 
 	userFrame := media.ReceiveUserAudio(turn, clock.AtOffset(time.Duration(turn.OccurredAtOffsetMS)*time.Millisecond))
+	agentTextOccurredAt := clock.AtOffset(5 * time.Second)
 	agentFrame := media.SendAgentAudio(response, clock.AtOffset(6*time.Second))
+	endOfSpeechToAgentTextMS := durationMillis(agentTextOccurredAt.Sub(userFrame.OccurredAt.Add(time.Duration(userFrame.DurationMS) * time.Millisecond)))
 	confidence := 1.0
 	trace := multimodaltrace.Trace{
 		TraceID:       "trace-support-billing-seed-42",
@@ -364,7 +363,7 @@ func RunSupportBillingScenario(seed int64) (ScenarioRun, error) {
 				SequenceNumber: 5,
 				Kind:           multimodaltrace.SegmentKindTextOutput,
 				Actor:          multimodaltrace.ActorAgent,
-				OccurredAt:     clock.AtOffset(5 * time.Second),
+				OccurredAt:     agentTextOccurredAt,
 				Text: &multimodaltrace.TextPayload{
 					Text:     response.TextOutput,
 					Language: response.Language,
@@ -402,7 +401,7 @@ func RunSupportBillingScenario(seed int64) (ScenarioRun, error) {
 				OccurredAt:     clock.AtOffset(7 * time.Second),
 				TimingMarker: &multimodaltrace.TimingMarkerPayload{
 					Key:     "end_of_speech_to_first_agent_text",
-					ValueMS: 3200,
+					ValueMS: endOfSpeechToAgentTextMS,
 				},
 			},
 		},
@@ -415,7 +414,7 @@ func RunSupportBillingScenario(seed int64) (ScenarioRun, error) {
 	if err != nil {
 		return ScenarioRun{}, err
 	}
-	scorecardJSON, err := marshalGolden(supportBillingScorecard(seed))
+	scorecardJSON, err := marshalGolden(supportBillingScorecard(endOfSpeechToAgentTextMS))
 	if err != nil {
 		return ScenarioRun{}, err
 	}
@@ -473,11 +472,11 @@ type supportBillingScoreMetric struct {
 	Unit  string `json:"unit"`
 }
 
-func supportBillingScorecard(seed int64) supportBillingScorecardFixture {
+func supportBillingScorecard(endOfSpeechToAgentTextMS int64) supportBillingScorecardFixture {
 	return supportBillingScorecardFixture{
 		SchemaVersion: 1,
 		ScenarioKey:   SupportBillingScenarioKey,
-		Seed:          seed,
+		Seed:          SupportBillingSeed,
 		Passed:        true,
 		OverallScore:  1,
 		Checks: []supportBillingScoreCheck{
@@ -487,9 +486,13 @@ func supportBillingScorecard(seed int64) supportBillingScorecardFixture {
 		},
 		Metrics: []supportBillingScoreMetric{
 			{Key: "turn_count", Value: 1, Unit: "turn"},
-			{Key: "end_of_speech_to_first_agent_text_ms", Value: 3200, Unit: "ms"},
+			{Key: "end_of_speech_to_first_agent_text_ms", Value: endOfSpeechToAgentTextMS, Unit: "ms"},
 		},
 	}
+}
+
+func durationMillis(duration time.Duration) int64 {
+	return int64(duration / time.Millisecond)
 }
 
 func decodeCanonical(data []byte, out any) error {

--- a/backend/internal/voicefixtures/fixtures_test.go
+++ b/backend/internal/voicefixtures/fixtures_test.go
@@ -1,0 +1,48 @@
+package voicefixtures
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/challengepack"
+)
+
+func TestSupportBillingScenarioGoldensAreDeterministic(t *testing.T) {
+	fixture, err := LoadSupportBillingFixture()
+	if err != nil {
+		t.Fatalf("LoadSupportBillingFixture returned error: %v", err)
+	}
+	if _, err := challengepack.ParseYAML(fixture.ChallengePackYAML); err != nil {
+		t.Fatalf("challenge pack fixture failed validation: %v", err)
+	}
+
+	first, err := RunSupportBillingScenario(SupportBillingSeed)
+	if err != nil {
+		t.Fatalf("first RunSupportBillingScenario returned error: %v", err)
+	}
+	second, err := RunSupportBillingScenario(SupportBillingSeed)
+	if err != nil {
+		t.Fatalf("second RunSupportBillingScenario returned error: %v", err)
+	}
+
+	assertBytesEqual(t, "trace output repeated run", first.TraceJSON, second.TraceJSON)
+	assertBytesEqual(t, "scorecard output repeated run", first.ScorecardJSON, second.ScorecardJSON)
+	if !reflect.DeepEqual(first.EventTimestamps, second.EventTimestamps) {
+		t.Fatalf("event timestamps mismatch\nwant: %#v\n got: %#v", first.EventTimestamps, second.EventTimestamps)
+	}
+	assertBytesEqual(t, "tool-call arguments repeated run", first.ToolCallArgumentsJSON, second.ToolCallArgumentsJSON)
+	assertBytesEqual(t, "tool call golden", fixture.ExpectedToolCallJSON, first.ToolCallJSON)
+	assertBytesEqual(t, "tool result golden", fixture.ExpectedToolResultJSON, first.ToolResultJSON)
+	assertBytesEqual(t, "agent text output golden", fixture.ExpectedAgentTextOutput, first.AgentTextOutput)
+	assertBytesEqual(t, "structured output golden", fixture.ExpectedStructuredJSON, first.StructuredOutputJSON)
+	assertBytesEqual(t, "trace golden", fixture.ExpectedTraceJSON, first.TraceJSON)
+	assertBytesEqual(t, "scorecard golden", fixture.ExpectedScorecardJSON, first.ScorecardJSON)
+}
+
+func assertBytesEqual(t *testing.T, label string, want []byte, got []byte) {
+	t.Helper()
+	if !bytes.Equal(want, got) {
+		t.Fatalf("%s mismatch\nwant:\n%s\n got:\n%s", label, string(want), string(got))
+	}
+}

--- a/backend/internal/voicefixtures/fixtures_test.go
+++ b/backend/internal/voicefixtures/fixtures_test.go
@@ -2,11 +2,15 @@ package voicefixtures
 
 import (
 	"bytes"
+	"flag"
+	"os"
 	"reflect"
 	"testing"
 
 	"github.com/agentclash/agentclash/backend/internal/challengepack"
 )
+
+var updateGoldens = flag.Bool("update", false, "update generated golden fixture files")
 
 func TestSupportBillingScenarioGoldensAreDeterministic(t *testing.T) {
 	fixture, err := LoadSupportBillingFixture()
@@ -17,11 +21,11 @@ func TestSupportBillingScenarioGoldensAreDeterministic(t *testing.T) {
 		t.Fatalf("challenge pack fixture failed validation: %v", err)
 	}
 
-	first, err := RunSupportBillingScenario(SupportBillingSeed)
+	first, err := RunSupportBillingScenario()
 	if err != nil {
 		t.Fatalf("first RunSupportBillingScenario returned error: %v", err)
 	}
-	second, err := RunSupportBillingScenario(SupportBillingSeed)
+	second, err := RunSupportBillingScenario()
 	if err != nil {
 		t.Fatalf("second RunSupportBillingScenario returned error: %v", err)
 	}
@@ -32,6 +36,13 @@ func TestSupportBillingScenarioGoldensAreDeterministic(t *testing.T) {
 		t.Fatalf("event timestamps mismatch\nwant: %#v\n got: %#v", first.EventTimestamps, second.EventTimestamps)
 	}
 	assertBytesEqual(t, "tool-call arguments repeated run", first.ToolCallArgumentsJSON, second.ToolCallArgumentsJSON)
+	if *updateGoldens {
+		updateGeneratedGoldens(t, first)
+		fixture, err = LoadSupportBillingFixture()
+		if err != nil {
+			t.Fatalf("reload updated fixture: %v", err)
+		}
+	}
 	assertBytesEqual(t, "tool call golden", fixture.ExpectedToolCallJSON, first.ToolCallJSON)
 	assertBytesEqual(t, "tool result golden", fixture.ExpectedToolResultJSON, first.ToolResultJSON)
 	assertBytesEqual(t, "agent text output golden", fixture.ExpectedAgentTextOutput, first.AgentTextOutput)
@@ -44,5 +55,22 @@ func assertBytesEqual(t *testing.T, label string, want []byte, got []byte) {
 	t.Helper()
 	if !bytes.Equal(want, got) {
 		t.Fatalf("%s mismatch\nwant:\n%s\n got:\n%s", label, string(want), string(got))
+	}
+}
+
+func updateGeneratedGoldens(t *testing.T, run ScenarioRun) {
+	t.Helper()
+	writeGolden(t, "testdata/support_billing/expected_tool_call.json", run.ToolCallJSON)
+	writeGolden(t, "testdata/support_billing/expected_tool_result.json", run.ToolResultJSON)
+	writeGolden(t, "testdata/support_billing/expected_agent_text_output.txt", run.AgentTextOutput)
+	writeGolden(t, "testdata/support_billing/expected_structured_output.json", run.StructuredOutputJSON)
+	writeGolden(t, "testdata/support_billing/expected_trace.json", run.TraceJSON)
+	writeGolden(t, "testdata/support_billing/expected_scorecard.json", run.ScorecardJSON)
+}
+
+func writeGolden(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("update golden %s: %v", path, err)
 	}
 }

--- a/backend/internal/voicefixtures/testdata/support_billing/challenge_pack.yaml
+++ b/backend/internal/voicefixtures/testdata/support_billing/challenge_pack.yaml
@@ -1,0 +1,51 @@
+modality: voice
+interface_spec:
+  transports: [text_sim]
+  channel_profile: deterministic_text
+  supports_barge_in: false
+scenario:
+  persona: billing_customer
+  language: en-US
+  max_turns: 6
+  max_duration_ms: 120000
+pack:
+  slug: voice-support-billing-fixture
+  name: Voice Support Billing Fixture
+  family: support
+version:
+  number: 1
+  evaluation_spec:
+    name: voice-support-billing-fixture-v1
+    version_number: 1
+    judge_mode: deterministic
+    validators:
+      - key: refund_created
+        type: exact_match
+        target: final_output
+        expected_from: challenge_input
+    metrics:
+      - key: total_latency_ms
+        type: numeric
+        collector: run_total_latency_ms
+        unit: ms
+    scorecard:
+      dimensions: [correctness]
+challenges:
+  - key: duplicate-charge-refund
+    title: Refund a duplicate card charge
+    category: billing
+    difficulty: easy
+input_sets:
+  - key: default
+    name: Default Billing Voice Cases
+    cases:
+      - challenge_key: duplicate-charge-refund
+        case_key: duplicate-charge
+        inputs:
+          - key: prompt
+            kind: text
+            value: Please refund the duplicate charge on my card.
+        expectations:
+          - key: answer
+            kind: text
+            value: refund_created

--- a/backend/internal/voicefixtures/testdata/support_billing/expected_agent_text_output.txt
+++ b/backend/internal/voicefixtures/testdata/support_billing/expected_agent_text_output.txt
@@ -1,0 +1,1 @@
+I found the duplicate charge and created refund rf_123 for $42.00.

--- a/backend/internal/voicefixtures/testdata/support_billing/expected_scorecard.json
+++ b/backend/internal/voicefixtures/testdata/support_billing/expected_scorecard.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": 1,
+  "scenario_key": "support_billing_duplicate_charge",
+  "seed": 42,
+  "passed": true,
+  "overall_score": 1,
+  "checks": [
+    {
+      "key": "refund_created",
+      "passed": true,
+      "expected": "created",
+      "actual": "created"
+    },
+    {
+      "key": "tool_name",
+      "passed": true,
+      "expected": "refund_api",
+      "actual": "refund_api"
+    },
+    {
+      "key": "structured_resolution",
+      "passed": true,
+      "expected": "refund_created",
+      "actual": "refund_created"
+    }
+  ],
+  "metrics": [
+    {
+      "key": "turn_count",
+      "value": 1,
+      "unit": "turn"
+    },
+    {
+      "key": "end_of_speech_to_first_agent_text_ms",
+      "value": 3200,
+      "unit": "ms"
+    }
+  ]
+}

--- a/backend/internal/voicefixtures/testdata/support_billing/expected_structured_output.json
+++ b/backend/internal/voicefixtures/testdata/support_billing/expected_structured_output.json
@@ -1,0 +1,9 @@
+{
+  "schema_ref": "voice.support.resolution.v1",
+  "output": {
+    "final_message": "I found the duplicate charge and created refund rf_123 for $42.00.",
+    "refund_id": "rf_123",
+    "requires_human_transfer": false,
+    "resolution": "refund_created"
+  }
+}

--- a/backend/internal/voicefixtures/testdata/support_billing/expected_tool_call.json
+++ b/backend/internal/voicefixtures/testdata/support_billing/expected_tool_call.json
@@ -1,0 +1,11 @@
+{
+  "call_id": "call-refund-001",
+  "tool_name": "refund_api",
+  "arguments": {
+    "account_id": "acct_123",
+    "amount_cents": 4200,
+    "currency": "USD",
+    "idempotency_key": "voice-fixture-42-refund",
+    "reason": "duplicate_charge"
+  }
+}

--- a/backend/internal/voicefixtures/testdata/support_billing/expected_tool_result.json
+++ b/backend/internal/voicefixtures/testdata/support_billing/expected_tool_result.json
@@ -1,0 +1,10 @@
+{
+  "call_id": "call-refund-001",
+  "tool_name": "refund_api",
+  "result": {
+    "amount_cents": 4200,
+    "currency": "USD",
+    "refund_id": "rf_123",
+    "status": "created"
+  }
+}

--- a/backend/internal/voicefixtures/testdata/support_billing/expected_trace.json
+++ b/backend/internal/voicefixtures/testdata/support_billing/expected_trace.json
@@ -1,0 +1,120 @@
+{
+  "trace_id": "trace-support-billing-seed-42",
+  "schema_version": "2026-05-13",
+  "run_id": "33333333-3333-3333-3333-333333333333",
+  "run_agent_id": "44444444-4444-4444-4444-444444444444",
+  "segments": [
+    {
+      "segment_id": "seg-001",
+      "sequence_number": 1,
+      "kind": "audio_input",
+      "actor": "user",
+      "occurred_at": "2026-05-13T10:00:00Z",
+      "audio": {
+        "artifact_ref": "fixtures/support_billing/audio/caller-turn-001.wav",
+        "format": "wav",
+        "channel": "caller",
+        "duration_ms": 1800
+      }
+    },
+    {
+      "segment_id": "seg-002",
+      "sequence_number": 2,
+      "kind": "transcript_final",
+      "actor": "system",
+      "occurred_at": "2026-05-13T10:00:02Z",
+      "transcript": {
+        "text": "Please refund the duplicate charge on my card.",
+        "language": "en-US",
+        "confidence": 1,
+        "source_segment_id": "seg-001"
+      }
+    },
+    {
+      "segment_id": "seg-003",
+      "sequence_number": 3,
+      "kind": "tool_call",
+      "actor": "agent",
+      "occurred_at": "2026-05-13T10:00:03Z",
+      "tool_call": {
+        "call_id": "call-refund-001",
+        "tool_name": "refund_api",
+        "arguments": {
+          "account_id": "acct_123",
+          "amount_cents": 4200,
+          "currency": "USD",
+          "idempotency_key": "voice-fixture-42-refund",
+          "reason": "duplicate_charge"
+        }
+      }
+    },
+    {
+      "segment_id": "seg-004",
+      "sequence_number": 4,
+      "kind": "tool_result",
+      "actor": "tool",
+      "occurred_at": "2026-05-13T10:00:04Z",
+      "tool_result": {
+        "call_id": "call-refund-001",
+        "tool_name": "refund_api",
+        "result": {
+          "amount_cents": 4200,
+          "currency": "USD",
+          "refund_id": "rf_123",
+          "status": "created"
+        }
+      }
+    },
+    {
+      "segment_id": "seg-005",
+      "sequence_number": 5,
+      "kind": "text_output",
+      "actor": "agent",
+      "occurred_at": "2026-05-13T10:00:05Z",
+      "text": {
+        "text": "I found the duplicate charge and created refund rf_123 for $42.00.",
+        "language": "en-US"
+      }
+    },
+    {
+      "segment_id": "seg-006",
+      "sequence_number": 6,
+      "kind": "audio_output",
+      "actor": "agent",
+      "occurred_at": "2026-05-13T10:00:06Z",
+      "audio": {
+        "artifact_ref": "fixtures/support_billing/audio/agent-turn-001.wav",
+        "format": "wav",
+        "channel": "agent",
+        "duration_ms": 2400
+      }
+    },
+    {
+      "segment_id": "seg-007",
+      "sequence_number": 7,
+      "kind": "structured_output",
+      "actor": "agent",
+      "occurred_at": "2026-05-13T10:00:07Z",
+      "structured_output": {
+        "schema_ref": "voice.support.resolution.v1",
+        "output": {
+          "final_message": "I found the duplicate charge and created refund rf_123 for $42.00.",
+          "refund_id": "rf_123",
+          "requires_human_transfer": false,
+          "resolution": "refund_created"
+        }
+      }
+    },
+    {
+      "segment_id": "seg-008",
+      "sequence_number": 8,
+      "kind": "timing_marker",
+      "actor": "evaluator",
+      "occurred_at": "2026-05-13T10:00:07Z",
+      "timing_marker": {
+        "key": "end_of_speech_to_first_agent_text",
+        "value_ms": 3200
+      }
+    }
+  ]
+}

--- a/backend/internal/voicefixtures/testdata/support_billing/scripted_user_turns.json
+++ b/backend/internal/voicefixtures/testdata/support_billing/scripted_user_turns.json
@@ -1,0 +1,13 @@
+[
+  {
+    "turn_id": "turn-001",
+    "speaker": "user",
+    "text": "Please refund the duplicate charge on my card.",
+    "language": "en-US",
+    "audio_artifact_ref": "fixtures/support_billing/audio/caller-turn-001.wav",
+    "audio_format": "wav",
+    "audio_channel": "caller",
+    "duration_ms": 1800,
+    "occurred_at_offset_ms": 0
+  }
+]


### PR DESCRIPTION
Closes #757
Parent: #754
Depends on: #755, #756

## Summary

- Adds `backend/internal/voicefixtures`, a reusable deterministic support-billing voice fixture package for later voice-evals PRs.
- Commits the issue-required product fixtures: challenge-pack YAML, scripted user turns, expected tool call/result, expected agent text output, expected structured output, expected trace JSON, and expected scorecard JSON.
- Adds fake adapters for user simulation, voice-agent deployment, tool endpoint, fake clock, and fake media transport.
- Pins deterministic behavior with a test that runs the fake scenario twice and byte-compares generated outputs against committed goldens.

## Testing

- `cd backend && go test ./internal/voicefixtures`
- `cd backend && go test ./internal/voicefixtures ./internal/challengepack ./internal/multimodaltrace`
- `cd backend && go test ./...`

## Review Checkpoint

The review-checkpoint contract and JSON were intentionally kept in `/tmp` and not committed. The JSON/YAML files committed in this PR are product fixtures required by #757, not checkpoint scratch files.

### Test Contract

```markdown
# codex/voice-golden-fixtures - Test Contract

## Functional Behavior

Implement issue #757: add deterministic golden fixtures and fake adapters for a voice support-agent billing scenario.

The implementation must:

- Commit small, readable fixtures for a billing refund voice scenario.
- Include a voice challenge-pack YAML fixture that parses with current challenge-pack validation.
- Include scripted user turns, expected tool call, expected tool result, expected agent text output, expected structured output, expected trace JSON, and expected scorecard JSON fixtures.
- Provide reusable fake adapters for a user simulator, voice-agent deployment, tool endpoint, clock, and media transport.
- Ensure all fake adapters are deterministic for a fixed seed and use the fake clock for timestamps.
- Avoid real LLM, STT, TTS, telephony, media provider, API key, network, or environment-variable dependencies.

## Unit Tests

- `TestSupportBillingScenarioGoldensAreDeterministic` - runs the fake scenario twice and proves identical trace JSON, scorecard JSON, event timestamps, tool-call arguments, tool result, agent text output, and structured output.
- The same test compares generated trace and scorecard bytes against committed golden fixtures.
- The voice challenge-pack YAML fixture must parse through `challengepack.ParseYAML`.

## Integration / Functional Tests

N/A - this slice only adds local fixtures and fake adapters for later voice-evals PRs.

## Smoke Tests

Run from `backend/`:

`go test ./internal/voicefixtures ./internal/challengepack ./internal/multimodaltrace`

Expected: pass with no network, API keys, live LLMs, STT/TTS providers, or telephony providers.

## E2E Tests

N/A - execution-mode integration is deferred to later issues.

## Manual / cURL Tests

N/A - no API endpoint behavior changes.
```

### Review Update: Greptile Comments

Addressed Greptile review feedback in commit `5597c9a2`:

- Removed the misleading `seed` parameter from `RunSupportBillingScenario`; the fixture seed remains explicit in the generated scorecard via `SupportBillingSeed`.
- Derived `end_of_speech_to_first_agent_text_ms` from fake-clock timestamps and scripted user audio duration instead of hardcoding `3200`.
- Added `go test ./internal/voicefixtures -update` support for generated golden outputs.

Checkpoint status: pass. Focused fixture tests, the review-contract smoke set, full backend tests, and the new `-update` path all passed.

### Checkpoint JSON

```json
{
  "branch": "codex/voice-golden-fixtures",
  "test_contract": "/tmp/codex-voice-golden-fixtures-test-contract.md",
  "created_at": "2026-05-13T10:44:55Z",
  "steps": [
    {
      "step_number": 1,
      "title": "Add deterministic voice fixtures and fake adapters",
      "timestamp": "2026-05-13T10:48:08Z",
      "files_changed": [
        "backend/internal/voicefixtures/fixtures.go",
        "backend/internal/voicefixtures/fixtures_test.go",
        "backend/internal/voicefixtures/testdata/support_billing/challenge_pack.yaml",
        "backend/internal/voicefixtures/testdata/support_billing/scripted_user_turns.json",
        "backend/internal/voicefixtures/testdata/support_billing/expected_tool_call.json",
        "backend/internal/voicefixtures/testdata/support_billing/expected_tool_result.json",
        "backend/internal/voicefixtures/testdata/support_billing/expected_agent_text_output.txt",
        "backend/internal/voicefixtures/testdata/support_billing/expected_structured_output.json",
        "backend/internal/voicefixtures/testdata/support_billing/expected_trace.json",
        "backend/internal/voicefixtures/testdata/support_billing/expected_scorecard.json"
      ],
      "what_changed": "Added a reusable voicefixtures package with embedded support-billing goldens, fake user simulator, fake voice-agent deployment, fake tool endpoint, fake clock, and fake media transport. The deterministic runner emits trace, scorecard, tool, structured-output, text-output, and timestamp results from a fixed seed.",
      "review_instructions": "Verify fixtures are committed because #757 explicitly requires product JSON/YAML goldens, while review-checkpoint scratch files stay in /tmp. Check that no fake uses network, API keys, LLMs, STT/TTS, telephony, or environment variables. Confirm repeated runs are byte-stable and the challenge pack parses.",
      "review_result": {
        "status": "pass",
        "issues_found": [],
        "notes": "The package is self-contained under backend/internal/voicefixtures. The test compares repeated generated bytes and generated bytes against committed goldens."
      },
      "cumulative_review": {
        "previous_steps_still_valid": true,
        "integration_issues": [],
        "notes": "Single-step implementation; it depends on the merged multimodal trace and voice pack validation contracts from #755 and #756."
      }
    },
    {
      "step_number": "final",
      "title": "Final review against test contract",
      "timestamp": "2026-05-13T10:48:08Z",
      "test_contract_review": {
        "functional_behavior": "pass - committed readable support-billing fixtures and reusable deterministic fake adapters for simulator, deployment, tool endpoint, clock, and media transport.",
        "unit_tests": "pass - TestSupportBillingScenarioGoldensAreDeterministic runs the fake scenario twice and verifies trace, scorecard, timestamps, tool-call arguments, tool result, agent text output, structured output, and challenge-pack parsing.",
        "integration_tests": "N/A - local fixtures/adapters only.",
        "smoke_tests": "pass - go test ./internal/voicefixtures ./internal/challengepack ./internal/multimodaltrace and go test ./... passed from backend/.",
        "e2e_tests": "N/A - execution mode is deferred.",
        "manual_tests": "N/A - no API endpoint behavior changed."
      },
      "overall_verdict": "ready",
      "blocking_issues": []
    }
  ]
}
```
