### PR TITLE
feat(voice-evals): add canonical voice events

### DIFF
--- a/backend/internal/runevents/envelope.go
+++ b/backend/internal/runevents/envelope.go
@@ -57,6 +57,7 @@ const (
 	EventTypeTurnCompleted       Type = "turn.completed"
 	EventTypeAgentAudioStarted   Type = "agent.audio.started"
 	EventTypeAgentAudioCompleted Type = "agent.audio.completed"
+	// Barge-in is specified as one domain term in #758, so the canonical value intentionally keeps the underscore.
 	EventTypeBargeInDetected     Type = "barge_in.detected"
 	EventTypeAudioBufferCleared  Type = "audio.buffer.cleared"
 	EventTypeDTMFReceived        Type = "dtmf.received"
@@ -106,7 +107,7 @@ type SummaryMetadata struct {
 	ToolCategory    string        `json:"tool_category,omitempty"`
 	SandboxAction   string        `json:"sandbox_action,omitempty"`
 	MetricKey       string        `json:"metric_key,omitempty"`
-	TurnIndex       int           `json:"turn_index,omitempty"`
+	TurnIndex       *int          `json:"turn_index,omitempty"`
 	Speaker         string        `json:"speaker,omitempty"`
 	Channel         string        `json:"channel,omitempty"`
 	ExternalRunID   string        `json:"external_run_id,omitempty"`

--- a/backend/internal/runevents/envelope.go
+++ b/backend/internal/runevents/envelope.go
@@ -47,6 +47,24 @@ const (
 	EventTypeScoringFailed         Type = "scoring.failed"
 
 	EventTypeRaceStandingsInjected Type = "race.standings.injected"
+
+	EventTypeMediaSessionStarted Type = "media.session.started"
+	EventTypeMediaFrameReceived  Type = "media.frame.received"
+	EventTypeSpeechStarted       Type = "speech.started"
+	EventTypeSpeechStopped       Type = "speech.stopped"
+	EventTypeTranscriptPartial   Type = "transcript.partial"
+	EventTypeTranscriptFinal     Type = "transcript.final"
+	EventTypeTurnCompleted       Type = "turn.completed"
+	EventTypeAgentAudioStarted   Type = "agent.audio.started"
+	EventTypeAgentAudioCompleted Type = "agent.audio.completed"
+	EventTypeBargeInDetected     Type = "barge_in.detected"
+	EventTypeAudioBufferCleared  Type = "audio.buffer.cleared"
+	EventTypeDTMFReceived        Type = "dtmf.received"
+	EventTypeTelephonyAnswered   Type = "telephony.answered"
+	EventTypeTelephonyVoicemail  Type = "telephony.voicemail"
+	EventTypeTransferStarted     Type = "transfer.started"
+	EventTypeTransferBridged     Type = "transfer.bridged"
+	EventTypeVoiceMetricRecorded Type = "voice.metric.recorded"
 )
 
 type Source string
@@ -59,6 +77,8 @@ const (
 	SourceAgentHarnessWorker Source = "agent_harness_worker"
 	SourceWorkerScoring      Source = "worker_scoring"
 	SourceGraderVerification Source = "grader_verification"
+	SourceVoiceAdapter       Source = "voice_adapter"
+	SourceMediaGateway       Source = "media_gateway"
 )
 
 type EvidenceLevel string
@@ -68,6 +88,7 @@ const (
 	EvidenceLevelHostedStructured EvidenceLevel = "hosted_structured"
 	EvidenceLevelHostedBlackBox   EvidenceLevel = "hosted_black_box"
 	EvidenceLevelDerivedSummary   EvidenceLevel = "derived_summary"
+	EvidenceLevelVoiceStructured  EvidenceLevel = "voice_structured"
 )
 
 var (
@@ -85,6 +106,9 @@ type SummaryMetadata struct {
 	ToolCategory    string        `json:"tool_category,omitempty"`
 	SandboxAction   string        `json:"sandbox_action,omitempty"`
 	MetricKey       string        `json:"metric_key,omitempty"`
+	TurnIndex       int           `json:"turn_index,omitempty"`
+	Speaker         string        `json:"speaker,omitempty"`
+	Channel         string        `json:"channel,omitempty"`
 	ExternalRunID   string        `json:"external_run_id,omitempty"`
 	EvidenceLevel   EvidenceLevel `json:"evidence_level,omitempty"`
 	IdempotencyKey  string        `json:"idempotency_key,omitempty"`
@@ -174,7 +198,24 @@ func isValidType(eventType Type) bool {
 		EventTypeScoringMetricRecorded,
 		EventTypeScoringCompleted,
 		EventTypeScoringFailed,
-		EventTypeRaceStandingsInjected:
+		EventTypeRaceStandingsInjected,
+		EventTypeMediaSessionStarted,
+		EventTypeMediaFrameReceived,
+		EventTypeSpeechStarted,
+		EventTypeSpeechStopped,
+		EventTypeTranscriptPartial,
+		EventTypeTranscriptFinal,
+		EventTypeTurnCompleted,
+		EventTypeAgentAudioStarted,
+		EventTypeAgentAudioCompleted,
+		EventTypeBargeInDetected,
+		EventTypeAudioBufferCleared,
+		EventTypeDTMFReceived,
+		EventTypeTelephonyAnswered,
+		EventTypeTelephonyVoicemail,
+		EventTypeTransferStarted,
+		EventTypeTransferBridged,
+		EventTypeVoiceMetricRecorded:
 		return true
 	default:
 		return false
@@ -183,7 +224,15 @@ func isValidType(eventType Type) bool {
 
 func isValidSource(source Source) bool {
 	switch source {
-	case SourceNativeEngine, SourcePromptEvalEngine, SourceHostedExternal, SourceHostedCallback, SourceAgentHarnessWorker, SourceWorkerScoring, SourceGraderVerification:
+	case SourceNativeEngine,
+		SourcePromptEvalEngine,
+		SourceHostedExternal,
+		SourceHostedCallback,
+		SourceAgentHarnessWorker,
+		SourceWorkerScoring,
+		SourceGraderVerification,
+		SourceVoiceAdapter,
+		SourceMediaGateway:
 		return true
 	default:
 		return false

--- a/backend/internal/runevents/hosted.go
+++ b/backend/internal/runevents/hosted.go
@@ -34,6 +34,9 @@ type hostedTraceSummaryDocument struct {
 	ToolCategory    string `json:"tool_category,omitempty"`
 	SandboxAction   string `json:"sandbox_action,omitempty"`
 	MetricKey       string `json:"metric_key,omitempty"`
+	TurnIndex       int    `json:"turn_index,omitempty"`
+	Speaker         string `json:"speaker,omitempty"`
+	Channel         string `json:"channel,omitempty"`
 	ExternalRunID   string `json:"external_run_id,omitempty"`
 	EvidenceLevel   string `json:"evidence_level,omitempty"`
 	IdempotencyKey  string `json:"idempotency_key,omitempty"`
@@ -239,6 +242,9 @@ func normalizeHostedTraceSummary(raw json.RawMessage, event hostedruns.Event) (S
 	summary.ToolCategory = decoded.ToolCategory
 	summary.SandboxAction = decoded.SandboxAction
 	summary.MetricKey = decoded.MetricKey
+	summary.TurnIndex = decoded.TurnIndex
+	summary.Speaker = decoded.Speaker
+	summary.Channel = decoded.Channel
 	if decoded.ExternalRunID != "" {
 		summary.ExternalRunID = decoded.ExternalRunID
 	}

--- a/backend/internal/runevents/hosted.go
+++ b/backend/internal/runevents/hosted.go
@@ -34,7 +34,7 @@ type hostedTraceSummaryDocument struct {
 	ToolCategory    string `json:"tool_category,omitempty"`
 	SandboxAction   string `json:"sandbox_action,omitempty"`
 	MetricKey       string `json:"metric_key,omitempty"`
-	TurnIndex       int    `json:"turn_index,omitempty"`
+	TurnIndex       *int   `json:"turn_index,omitempty"`
 	Speaker         string `json:"speaker,omitempty"`
 	Channel         string `json:"channel,omitempty"`
 	ExternalRunID   string `json:"external_run_id,omitempty"`

--- a/backend/internal/runevents/hosted_test.go
+++ b/backend/internal/runevents/hosted_test.go
@@ -189,6 +189,66 @@ func TestNormalizeHostedTraceEventsExtractsStructuredTraceFragments(t *testing.T
 	}
 }
 
+func TestNormalizeHostedTraceEventsPreservesVoiceSummaryFields(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	occurredAt := time.Date(2026, 5, 13, 11, 33, 0, 0, time.UTC)
+	event := hostedruns.Event{
+		RunAgentID:    runAgentID,
+		ExternalRunID: "ext-voice-trace",
+		EventType:     hostedruns.EventTypeFinalAnswer,
+		OccurredAt:    occurredAt,
+		Metadata: json.RawMessage(`{
+			"trace_events": [
+				{
+					"event_id": "voice-trace-1",
+					"event_type": "transcript.final",
+					"source": "voice_adapter",
+					"occurred_at": "2026-05-13T11:32:59Z",
+					"payload": {"text": "I can help with that."},
+					"summary": {
+						"turn_index": 4,
+						"speaker": "assistant",
+						"channel": "outbound",
+						"metric_key": "final_transcript_chars",
+						"evidence_level": "voice_structured"
+					}
+				}
+			]
+		}`),
+	}
+
+	envelopes, err := NormalizeHostedTraceEvents(runID, event)
+	if err != nil {
+		t.Fatalf("NormalizeHostedTraceEvents returned error: %v", err)
+	}
+	if len(envelopes) != 1 {
+		t.Fatalf("trace envelope count = %d, want 1", len(envelopes))
+	}
+	envelope := envelopes[0]
+	if envelope.EventType != EventTypeTranscriptFinal {
+		t.Fatalf("event type = %q, want %q", envelope.EventType, EventTypeTranscriptFinal)
+	}
+	if envelope.Source != SourceVoiceAdapter {
+		t.Fatalf("source = %q, want %q", envelope.Source, SourceVoiceAdapter)
+	}
+	if envelope.Summary.TurnIndex != 4 {
+		t.Fatalf("turn index = %d, want 4", envelope.Summary.TurnIndex)
+	}
+	if envelope.Summary.Speaker != "assistant" {
+		t.Fatalf("speaker = %q, want assistant", envelope.Summary.Speaker)
+	}
+	if envelope.Summary.Channel != "outbound" {
+		t.Fatalf("channel = %q, want outbound", envelope.Summary.Channel)
+	}
+	if envelope.Summary.MetricKey != "final_transcript_chars" {
+		t.Fatalf("metric key = %q, want final_transcript_chars", envelope.Summary.MetricKey)
+	}
+	if envelope.Summary.EvidenceLevel != EvidenceLevelVoiceStructured {
+		t.Fatalf("evidence level = %q, want %q", envelope.Summary.EvidenceLevel, EvidenceLevelVoiceStructured)
+	}
+}
+
 func TestEnvelopeValidatePersistedRequiresPositiveSequenceNumber(t *testing.T) {
 	envelope := Envelope{
 		EventID:       "evt-1",

--- a/backend/internal/runevents/hosted_test.go
+++ b/backend/internal/runevents/hosted_test.go
@@ -232,8 +232,8 @@ func TestNormalizeHostedTraceEventsPreservesVoiceSummaryFields(t *testing.T) {
 	if envelope.Source != SourceVoiceAdapter {
 		t.Fatalf("source = %q, want %q", envelope.Source, SourceVoiceAdapter)
 	}
-	if envelope.Summary.TurnIndex != 4 {
-		t.Fatalf("turn index = %d, want 4", envelope.Summary.TurnIndex)
+	if envelope.Summary.TurnIndex == nil || *envelope.Summary.TurnIndex != 4 {
+		t.Fatalf("turn index = %v, want 4", envelope.Summary.TurnIndex)
 	}
 	if envelope.Summary.Speaker != "assistant" {
 		t.Fatalf("speaker = %q, want assistant", envelope.Summary.Speaker)

--- a/backend/internal/runevents/voice.go
+++ b/backend/internal/runevents/voice.go
@@ -1,0 +1,161 @@
+package runevents
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type VoiceAdapterEvent struct {
+	EventID      string
+	RunID        uuid.UUID
+	RunAgentID   uuid.UUID
+	RawEventType string
+	Source       Source
+	OccurredAt   time.Time
+	Payload      json.RawMessage
+	Summary      SummaryMetadata
+}
+
+var canonicalVoiceEventTypes = map[Type]struct{}{
+	EventTypeMediaSessionStarted: {},
+	EventTypeMediaFrameReceived:  {},
+	EventTypeSpeechStarted:       {},
+	EventTypeSpeechStopped:       {},
+	EventTypeTranscriptPartial:   {},
+	EventTypeTranscriptFinal:     {},
+	EventTypeTurnCompleted:       {},
+	EventTypeAgentAudioStarted:   {},
+	EventTypeAgentAudioCompleted: {},
+	EventTypeBargeInDetected:     {},
+	EventTypeAudioBufferCleared:  {},
+	EventTypeDTMFReceived:        {},
+	EventTypeTelephonyAnswered:   {},
+	EventTypeTelephonyVoicemail:  {},
+	EventTypeTransferStarted:     {},
+	EventTypeTransferBridged:     {},
+	EventTypeVoiceMetricRecorded: {},
+}
+
+var voiceAdapterRawEventTypes = map[string]Type{
+	"fake.media_session_started": EventTypeMediaSessionStarted,
+	"fake.media_frame":           EventTypeMediaFrameReceived,
+	"fake.speech_started":        EventTypeSpeechStarted,
+	"fake.speech_stopped":        EventTypeSpeechStopped,
+	"fake.transcript_partial":    EventTypeTranscriptPartial,
+	"fake.transcript_final":      EventTypeTranscriptFinal,
+	"fake.turn_completed":        EventTypeTurnCompleted,
+	"fake.agent_audio_started":   EventTypeAgentAudioStarted,
+	"fake.agent_audio_completed": EventTypeAgentAudioCompleted,
+	"fake.barge_in":              EventTypeBargeInDetected,
+	"fake.audio_buffer_cleared":  EventTypeAudioBufferCleared,
+	"fake.dtmf":                  EventTypeDTMFReceived,
+	"fake.telephony_answered":    EventTypeTelephonyAnswered,
+	"fake.telephony_voicemail":   EventTypeTelephonyVoicemail,
+	"fake.transfer_started":      EventTypeTransferStarted,
+	"fake.transfer_bridged":      EventTypeTransferBridged,
+	"fake.voice_metric_recorded": EventTypeVoiceMetricRecorded,
+}
+
+func NormalizeVoiceAdapterEvent(event VoiceAdapterEvent) (Envelope, error) {
+	eventType, err := normalizeVoiceAdapterEventType(event.RawEventType)
+	if err != nil {
+		return Envelope{}, err
+	}
+
+	source := event.Source
+	if source == "" {
+		source = SourceVoiceAdapter
+	}
+
+	payload := normalizeJSON(event.Payload)
+	summary := event.Summary
+	if summary.EvidenceLevel == "" {
+		summary.EvidenceLevel = EvidenceLevelVoiceStructured
+	}
+
+	eventID := strings.TrimSpace(event.EventID)
+	if eventID == "" {
+		eventID = deterministicVoiceEventID(event, eventType, payload)
+	}
+	if summary.IdempotencyKey == "" {
+		summary.IdempotencyKey = eventID
+	}
+
+	envelope := Envelope{
+		EventID:        eventID,
+		SchemaVersion:  SchemaVersionV1,
+		RunID:          event.RunID,
+		RunAgentID:     event.RunAgentID,
+		SequenceNumber: 0,
+		EventType:      eventType,
+		Source:         source,
+		OccurredAt:     event.OccurredAt.UTC(),
+		Payload:        payload,
+		Summary:        summary,
+	}
+	return envelope, envelope.ValidatePending()
+}
+
+func NormalizeVoiceAdapterEvents(events []VoiceAdapterEvent) ([]Envelope, error) {
+	envelopes := make([]Envelope, 0, len(events))
+	for idx, event := range events {
+		envelope, err := NormalizeVoiceAdapterEvent(event)
+		if err != nil {
+			return nil, fmt.Errorf("normalize voice adapter event[%d]: %w", idx, err)
+		}
+		envelopes = append(envelopes, envelope)
+	}
+
+	sort.SliceStable(envelopes, func(i, j int) bool {
+		if !envelopes[i].OccurredAt.Equal(envelopes[j].OccurredAt) {
+			return envelopes[i].OccurredAt.Before(envelopes[j].OccurredAt)
+		}
+		if envelopes[i].EventID != envelopes[j].EventID {
+			return envelopes[i].EventID < envelopes[j].EventID
+		}
+		if envelopes[i].EventType != envelopes[j].EventType {
+			return envelopes[i].EventType < envelopes[j].EventType
+		}
+		return string(envelopes[i].Payload) < string(envelopes[j].Payload)
+	})
+
+	for idx := range envelopes {
+		envelopes[idx] = envelopes[idx].WithSequenceNumber(int64(idx + 1))
+		if err := envelopes[idx].ValidatePersisted(); err != nil {
+			return nil, fmt.Errorf("validate sequenced voice adapter event[%d]: %w", idx, err)
+		}
+	}
+	return envelopes, nil
+}
+
+func normalizeVoiceAdapterEventType(rawEventType string) (Type, error) {
+	trimmed := strings.TrimSpace(rawEventType)
+	if eventType, ok := voiceAdapterRawEventTypes[trimmed]; ok {
+		return eventType, nil
+	}
+
+	eventType := Type(trimmed)
+	if _, ok := canonicalVoiceEventTypes[eventType]; ok {
+		return eventType, nil
+	}
+	return "", fmt.Errorf("%w: %q", ErrInvalidEventType, rawEventType)
+}
+
+func deterministicVoiceEventID(event VoiceAdapterEvent, eventType Type, payload json.RawMessage) string {
+	hash := sha256.Sum256([]byte(fmt.Sprintf(
+		"%s\n%s\n%s\n%s\n%s",
+		event.RunAgentID.String(),
+		strings.TrimSpace(event.RawEventType),
+		eventType,
+		event.OccurredAt.UTC().Format(time.RFC3339Nano),
+		string(payload),
+	)))
+	return fmt.Sprintf("voice:%s:%s", event.RunAgentID.String(), hex.EncodeToString(hash[:8]))
+}

--- a/backend/internal/runevents/voice_test.go
+++ b/backend/internal/runevents/voice_test.go
@@ -43,7 +43,7 @@ func TestVoiceMediaEventTypesAreValid(t *testing.T) {
 				OccurredAt:    time.Date(2026, 5, 13, 11, 30, 0, 0, time.UTC),
 				Payload:       json.RawMessage(`{"fixture":true}`),
 				Summary: SummaryMetadata{
-					TurnIndex:     2,
+					TurnIndex:     intPtr(2),
 					Speaker:       "caller",
 					Channel:       "input",
 					MetricKey:     "latency_ms",
@@ -90,7 +90,7 @@ func TestNormalizeVoiceAdapterEventMapsRawEventToCanonicalEnvelope(t *testing.T)
 		OccurredAt:   occurredAt,
 		Payload:      payload,
 		Summary: SummaryMetadata{
-			TurnIndex:     3,
+			TurnIndex:     intPtr(3),
 			Speaker:       "caller",
 			Channel:       "inbound",
 			MetricKey:     "input_audio_ms",
@@ -122,7 +122,7 @@ func TestNormalizeVoiceAdapterEventMapsRawEventToCanonicalEnvelope(t *testing.T)
 	if string(envelope.Payload) != string(payload) {
 		t.Fatalf("payload = %s, want %s", envelope.Payload, payload)
 	}
-	if envelope.Summary.TurnIndex != 3 || envelope.Summary.Speaker != "caller" || envelope.Summary.Channel != "inbound" {
+	if envelope.Summary.TurnIndex == nil || *envelope.Summary.TurnIndex != 3 || envelope.Summary.Speaker != "caller" || envelope.Summary.Channel != "inbound" {
 		t.Fatalf("summary voice fields not preserved: %+v", envelope.Summary)
 	}
 	if envelope.Summary.MetricKey != "input_audio_ms" {
@@ -184,9 +184,34 @@ func voiceAdapterEventForSequence(runID uuid.UUID, runAgentID uuid.UUID, eventID
 		OccurredAt:   occurredAt,
 		Payload:      json.RawMessage(`{"fixture":true}`),
 		Summary: SummaryMetadata{
-			TurnIndex: 1,
+			TurnIndex: intPtr(1),
 			Speaker:   "assistant",
 			Channel:   "outbound",
 		},
 	}
+}
+
+func TestSummaryMetadataPreservesExplicitZeroTurnIndex(t *testing.T) {
+	encoded, err := json.Marshal(SummaryMetadata{
+		TurnIndex: intPtr(0),
+		Speaker:   "caller",
+	})
+	if err != nil {
+		t.Fatalf("marshal summary: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"turn_index":0`) {
+		t.Fatalf("encoded summary = %s, want explicit zero turn_index", encoded)
+	}
+
+	encoded, err = json.Marshal(SummaryMetadata{Speaker: "caller"})
+	if err != nil {
+		t.Fatalf("marshal summary without turn index: %v", err)
+	}
+	if strings.Contains(string(encoded), "turn_index") {
+		t.Fatalf("encoded summary = %s, want omitted turn_index when nil", encoded)
+	}
+}
+
+func intPtr(value int) *int {
+	return &value
 }

--- a/backend/internal/runevents/voice_test.go
+++ b/backend/internal/runevents/voice_test.go
@@ -1,0 +1,192 @@
+package runevents
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestVoiceMediaEventTypesAreValid(t *testing.T) {
+	eventTypes := []Type{
+		EventTypeMediaSessionStarted,
+		EventTypeMediaFrameReceived,
+		EventTypeSpeechStarted,
+		EventTypeSpeechStopped,
+		EventTypeTranscriptPartial,
+		EventTypeTranscriptFinal,
+		EventTypeTurnCompleted,
+		EventTypeAgentAudioStarted,
+		EventTypeAgentAudioCompleted,
+		EventTypeBargeInDetected,
+		EventTypeAudioBufferCleared,
+		EventTypeDTMFReceived,
+		EventTypeTelephonyAnswered,
+		EventTypeTelephonyVoicemail,
+		EventTypeTransferStarted,
+		EventTypeTransferBridged,
+		EventTypeVoiceMetricRecorded,
+	}
+
+	for _, eventType := range eventTypes {
+		t.Run(string(eventType), func(t *testing.T) {
+			envelope := Envelope{
+				EventID:       "evt-" + strings.ReplaceAll(string(eventType), ".", "-"),
+				SchemaVersion: SchemaVersionV1,
+				RunID:         uuid.New(),
+				RunAgentID:    uuid.New(),
+				EventType:     eventType,
+				Source:        SourceVoiceAdapter,
+				OccurredAt:    time.Date(2026, 5, 13, 11, 30, 0, 0, time.UTC),
+				Payload:       json.RawMessage(`{"fixture":true}`),
+				Summary: SummaryMetadata{
+					TurnIndex:     2,
+					Speaker:       "caller",
+					Channel:       "input",
+					MetricKey:     "latency_ms",
+					EvidenceLevel: EvidenceLevelVoiceStructured,
+				},
+			}
+
+			if err := envelope.ValidatePending(); err != nil {
+				t.Fatalf("ValidatePending returned error: %v", err)
+			}
+		})
+	}
+}
+
+func TestVoiceMediaEventRejectsUnknownType(t *testing.T) {
+	envelope := Envelope{
+		EventID:       "evt-unknown",
+		SchemaVersion: SchemaVersionV1,
+		RunID:         uuid.New(),
+		RunAgentID:    uuid.New(),
+		EventType:     Type("media.session.strated"),
+		Source:        SourceVoiceAdapter,
+		OccurredAt:    time.Date(2026, 5, 13, 11, 30, 0, 0, time.UTC),
+		Payload:       json.RawMessage(`{}`),
+	}
+
+	if err := envelope.ValidatePending(); !errors.Is(err, ErrInvalidEventType) {
+		t.Fatalf("ValidatePending error = %v, want ErrInvalidEventType", err)
+	}
+}
+
+func TestNormalizeVoiceAdapterEventMapsRawEventToCanonicalEnvelope(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	occurredAt := time.Date(2026, 5, 13, 11, 31, 0, 0, time.UTC)
+	payload := json.RawMessage(`{"frame_index":7,"sample_rate_hz":16000}`)
+
+	envelope, err := NormalizeVoiceAdapterEvent(VoiceAdapterEvent{
+		EventID:      "fake-evt-7",
+		RunID:        runID,
+		RunAgentID:   runAgentID,
+		RawEventType: "fake.media_frame",
+		Source:       SourceVoiceAdapter,
+		OccurredAt:   occurredAt,
+		Payload:      payload,
+		Summary: SummaryMetadata{
+			TurnIndex:     3,
+			Speaker:       "caller",
+			Channel:       "inbound",
+			MetricKey:     "input_audio_ms",
+			EvidenceLevel: EvidenceLevelVoiceStructured,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeVoiceAdapterEvent returned error: %v", err)
+	}
+
+	if strings.Contains(string(envelope.EventType), "fake") {
+		t.Fatalf("canonical event type leaked raw adapter name: %q", envelope.EventType)
+	}
+	if envelope.EventType != EventTypeMediaFrameReceived {
+		t.Fatalf("event type = %q, want %q", envelope.EventType, EventTypeMediaFrameReceived)
+	}
+	if envelope.RunID != runID {
+		t.Fatalf("run id = %s, want %s", envelope.RunID, runID)
+	}
+	if envelope.RunAgentID != runAgentID {
+		t.Fatalf("run agent id = %s, want %s", envelope.RunAgentID, runAgentID)
+	}
+	if envelope.Source != SourceVoiceAdapter {
+		t.Fatalf("source = %q, want %q", envelope.Source, SourceVoiceAdapter)
+	}
+	if !envelope.OccurredAt.Equal(occurredAt) {
+		t.Fatalf("occurred_at = %s, want %s", envelope.OccurredAt, occurredAt)
+	}
+	if string(envelope.Payload) != string(payload) {
+		t.Fatalf("payload = %s, want %s", envelope.Payload, payload)
+	}
+	if envelope.Summary.TurnIndex != 3 || envelope.Summary.Speaker != "caller" || envelope.Summary.Channel != "inbound" {
+		t.Fatalf("summary voice fields not preserved: %+v", envelope.Summary)
+	}
+	if envelope.Summary.MetricKey != "input_audio_ms" {
+		t.Fatalf("metric key = %q, want input_audio_ms", envelope.Summary.MetricKey)
+	}
+	if envelope.Summary.EvidenceLevel != EvidenceLevelVoiceStructured {
+		t.Fatalf("evidence level = %q, want %q", envelope.Summary.EvidenceLevel, EvidenceLevelVoiceStructured)
+	}
+	if envelope.Summary.IdempotencyKey != "fake-evt-7" {
+		t.Fatalf("idempotency key = %q, want fake-evt-7", envelope.Summary.IdempotencyKey)
+	}
+}
+
+func TestNormalizeVoiceAdapterEventsAssignsDeterministicSequences(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	baseTime := time.Date(2026, 5, 13, 11, 32, 0, 0, time.UTC)
+	events := []VoiceAdapterEvent{
+		voiceAdapterEventForSequence(runID, runAgentID, "evt-c", "fake.turn_completed", baseTime.Add(2*time.Second)),
+		voiceAdapterEventForSequence(runID, runAgentID, "evt-b", "fake.transcript_final", baseTime),
+		voiceAdapterEventForSequence(runID, runAgentID, "evt-a", "fake.speech_started", baseTime),
+	}
+
+	first, err := NormalizeVoiceAdapterEvents(events)
+	if err != nil {
+		t.Fatalf("NormalizeVoiceAdapterEvents returned error: %v", err)
+	}
+	second, err := NormalizeVoiceAdapterEvents([]VoiceAdapterEvent{events[2], events[0], events[1]})
+	if err != nil {
+		t.Fatalf("NormalizeVoiceAdapterEvents second run returned error: %v", err)
+	}
+
+	wantOrder := []string{"evt-a", "evt-b", "evt-c"}
+	for idx, wantEventID := range wantOrder {
+		if first[idx].EventID != wantEventID {
+			t.Fatalf("first[%d].EventID = %q, want %q", idx, first[idx].EventID, wantEventID)
+		}
+		if first[idx].SequenceNumber != int64(idx+1) {
+			t.Fatalf("first[%d].SequenceNumber = %d, want %d", idx, first[idx].SequenceNumber, idx+1)
+		}
+		if second[idx].EventID != wantEventID {
+			t.Fatalf("second[%d].EventID = %q, want %q", idx, second[idx].EventID, wantEventID)
+		}
+		if second[idx].SequenceNumber != first[idx].SequenceNumber {
+			t.Fatalf("second[%d].SequenceNumber = %d, want %d", idx, second[idx].SequenceNumber, first[idx].SequenceNumber)
+		}
+		if err := first[idx].ValidatePersisted(); err != nil {
+			t.Fatalf("first[%d] persisted validation failed: %v", idx, err)
+		}
+	}
+}
+
+func voiceAdapterEventForSequence(runID uuid.UUID, runAgentID uuid.UUID, eventID string, rawEventType string, occurredAt time.Time) VoiceAdapterEvent {
+	return VoiceAdapterEvent{
+		EventID:      eventID,
+		RunID:        runID,
+		RunAgentID:   runAgentID,
+		RawEventType: rawEventType,
+		OccurredAt:   occurredAt,
+		Payload:      json.RawMessage(`{"fixture":true}`),
+		Summary: SummaryMetadata{
+			TurnIndex: 1,
+			Speaker:   "assistant",
+			Channel:   "outbound",
+		},
+	}
+}


### PR DESCRIPTION
## Summary

Closes #758. Parent: #754.

- Add provider-neutral canonical event constants for the 17 voice/media event types in #758.
- Add voice/media event sources, `voice_structured` evidence, and stable voice summary fields (`turn_index`, `speaker`, `channel`).
- Add deterministic `VoiceAdapterEvent` normalization from fake raw adapter event names into canonical envelopes with stable sequence assignment.
- Preserve voice summary fields when hosted trace fragments carry voice/media evidence.
- Address Greptile follow-up by preserving explicit `turn_index: 0` and documenting why `barge_in.detected` keeps the issue-specified underscore.

## Test Contract

```markdown
# codex/voice-canonical-events - Test Contract

## Functional Behavior
- Canonical run events accept the 17 voice/media event types from issue #758.
- Unknown or typo voice/media event types are rejected by canonical envelope validation.
- Voice adapter normalization maps raw adapter event names to canonical event types only.
- Voice/media envelopes preserve `run_id`, `run_agent_id`, source, occurrence time, payload, and summary metadata.
- Voice/media summary metadata preserves stable fields: `turn_index`, `speaker`, `channel`, `metric_key`, `evidence_level`, and `idempotency_key`.
- Normalized fixture events receive deterministic sequence numbers after sorting by occurrence time and stable tie-breakers.

## Unit Tests
- `TestVoiceMediaEventTypesAreValid` - validates every new canonical event type.
- `TestVoiceMediaEventRejectsUnknownType` - rejects unknown voice/media event strings.
- `TestNormalizeVoiceAdapterEventMapsRawEventToCanonicalEnvelope` - maps a fake raw adapter event into canonical form and preserves envelope fields.
- `TestNormalizeVoiceAdapterEventsAssignsDeterministicSequences` - proves fixture sequence ordering is deterministic regardless of input order.
- `TestNormalizeHostedTraceEventsPreservesVoiceSummaryFields` - hosted trace fragments preserve voice summary fields.
- `TestSummaryMetadataPreservesExplicitZeroTurnIndex` - proves `turn_index: 0` survives JSON serialization while nil turn indexes are omitted.

## Integration / Functional Tests
- `go test ./internal/runevents ./internal/voicefixtures ./internal/multimodaltrace`

## Smoke Tests
- `go test ./internal/runevents`
- `go test ./...`

## E2E Tests
N/A - this slice adds provider-neutral canonical vocabulary and deterministic normalization helpers only.

## Manual / cURL Tests
N/A - no HTTP surface is added in this slice.
```

## Review Checkpoint

```json
{
  "branch": "codex/voice-canonical-events",
  "test_contract": "/tmp/codex-voice-canonical-events-test-contract.md",
  "created_at": "2026-05-13T11:25:00Z",
  "steps": [
    {
      "step_number": 1,
      "title": "Add canonical voice event vocabulary and deterministic normalization",
      "timestamp": "2026-05-13T11:27:56Z",
      "files_changed": [
        "backend/internal/runevents/envelope.go",
        "backend/internal/runevents/hosted.go",
        "backend/internal/runevents/hosted_test.go",
        "backend/internal/runevents/voice.go",
        "backend/internal/runevents/voice_test.go"
      ],
      "what_changed": "Added the issue #758 voice/media event constants, voice-oriented sources and evidence metadata, hosted trace summary preservation for voice fields, and a VoiceAdapterEvent normalizer that maps fake raw event names into provider-neutral canonical envelopes with deterministic sequence assignment.",
      "review_instructions": "Verify every #758 event type is accepted, typo voice/media event strings are rejected, raw fake adapter names do not become canonical event types, summary fields are preserved, and normalized fixture ordering is stable by occurred_at then event_id.",
      "review_result": {
        "status": "pass",
        "issues_found": [],
        "notes": "Self-review found the implementation matches the contract. go test ./internal/runevents and the deterministic package set passed."
      },
      "cumulative_review": {
        "previous_steps_still_valid": true,
        "integration_issues": [],
        "notes": "This is the first implementation step and it builds on the already-merged trace and fixture foundation from #755 and #757."
      }
    },
    {
      "step_number": "final",
      "title": "Final review against test contract",
      "timestamp": "2026-05-13T11:28:45Z",
      "test_contract_review": {
        "functional_behavior": "pass - all requested voice/media event constants validate; unknown event strings fail; fake raw adapter events normalize to canonical event types while preserving envelope fields and voice summary metadata.",
        "unit_tests": "pass - added and ran runevents tests covering canonical event validation, unknown type rejection, fake adapter normalization, deterministic sequencing, and hosted voice summary preservation.",
        "integration_tests": "pass - go test ./internal/runevents ./internal/voicefixtures ./internal/multimodaltrace passed.",
        "smoke_tests": "pass - go test ./internal/runevents and go test ./... passed.",
        "e2e_tests": "N/A - no user-facing or HTTP surface is added.",
        "manual_tests": "N/A - no manual API surface is added."
      },
      "overall_verdict": "ready",
      "blocking_issues": []
    }
  ]
}
```

## Verification

- `go test ./internal/runevents`
- `go test ./internal/runevents ./internal/voicefixtures ./internal/multimodaltrace`
- `go test ./...`

## Greptile Follow-Up

- `TurnIndex` is now `*int`, so `turn_index: 0` remains distinguishable from an absent field.
- `barge_in.detected` remains unchanged because issue #758 explicitly names that canonical value; a code comment documents the intentional underscore.
