### PR TITLE
feat(voice-evals): define artifact manifest

### DIFF
--- a/backend/internal/voiceartifacts/manifest.go
+++ b/backend/internal/voiceartifacts/manifest.go
@@ -1,0 +1,254 @@
+package voiceartifacts
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const SchemaVersionV1 = "2026-05-13"
+
+type ArtifactKind string
+
+const (
+	ArtifactKindCallerAudio       ArtifactKind = "caller_audio"
+	ArtifactKindAgentAudio        ArtifactKind = "agent_audio"
+	ArtifactKindMixedAudio        ArtifactKind = "mixed_audio"
+	ArtifactKindTranscriptJSON    ArtifactKind = "transcript_json"
+	ArtifactKindWaveformTimeline  ArtifactKind = "waveform_timeline_json"
+	ArtifactKindRawProviderTrace  ArtifactKind = "raw_provider_trace_json"
+	ArtifactKindStructuredOutput  ArtifactKind = "structured_output_json"
+	ArtifactKindRedactionMetadata ArtifactKind = "redaction_metadata_json"
+)
+
+type ArtifactLocationType string
+
+const (
+	ArtifactLocationLocalPath     ArtifactLocationType = "local_path"
+	ArtifactLocationObjectStorage ArtifactLocationType = "object_storage"
+)
+
+var (
+	ErrInvalidSchemaVersion      = errors.New("invalid voice artifact manifest schema version")
+	ErrInvalidArtifactKind       = errors.New("invalid voice artifact kind")
+	ErrInvalidArtifactLocation   = errors.New("invalid voice artifact location")
+	ErrMissingRequiredArtifact   = errors.New("missing required voice artifact")
+	ErrArtifactChecksumMismatch  = errors.New("voice artifact checksum mismatch")
+	errArtifactChecksumRequired  = errors.New("voice artifact checksum_sha256 is required")
+	errArtifactReferenceRequired = errors.New("voice artifact reference is required")
+)
+
+type Manifest struct {
+	SchemaVersion  string        `json:"schema_version"`
+	RunID          uuid.UUID     `json:"run_id"`
+	RunAgentID     uuid.UUID     `json:"run_agent_id"`
+	VoiceSessionID string        `json:"voice_session_id"`
+	Artifacts      []ArtifactRef `json:"artifacts"`
+}
+
+type ArtifactRef struct {
+	Key            string               `json:"key"`
+	Kind           ArtifactKind         `json:"kind"`
+	Location       ArtifactLocationType `json:"location"`
+	Path           string               `json:"path,omitempty"`
+	Bucket         string               `json:"bucket,omitempty"`
+	ObjectKey      string               `json:"object_key,omitempty"`
+	ContentType    string               `json:"content_type,omitempty"`
+	SizeBytes      int64                `json:"size_bytes,omitempty"`
+	ChecksumSHA256 string               `json:"checksum_sha256"`
+}
+
+func Load(path string) (Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Manifest{}, err
+	}
+	var manifest Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return Manifest{}, fmt.Errorf("decode voice artifact manifest: %w", err)
+	}
+	if err := manifest.Validate(); err != nil {
+		return Manifest{}, err
+	}
+	return manifest, nil
+}
+
+func (m Manifest) Validate() error {
+	if m.SchemaVersion != SchemaVersionV1 {
+		return fmt.Errorf("%w: %q", ErrInvalidSchemaVersion, m.SchemaVersion)
+	}
+	if m.RunID == uuid.Nil {
+		return errors.New("run_id is required")
+	}
+	if m.RunAgentID == uuid.Nil {
+		return errors.New("run_agent_id is required")
+	}
+	if strings.TrimSpace(m.VoiceSessionID) == "" {
+		return errors.New("voice_session_id is required")
+	}
+	if len(m.Artifacts) == 0 {
+		return errors.New("artifacts must contain at least one artifact")
+	}
+
+	seenKeys := make(map[string]struct{}, len(m.Artifacts))
+	seenKinds := make(map[ArtifactKind]struct{}, len(m.Artifacts))
+	for idx, artifact := range m.Artifacts {
+		if err := artifact.Validate(); err != nil {
+			return fmt.Errorf("artifacts[%d]: %w", idx, err)
+		}
+		if _, ok := seenKeys[artifact.Key]; ok {
+			return fmt.Errorf("artifacts[%d]: duplicate key %q", idx, artifact.Key)
+		}
+		seenKeys[artifact.Key] = struct{}{}
+		seenKinds[artifact.Kind] = struct{}{}
+	}
+
+	for _, kind := range requiredArtifactKinds() {
+		if _, ok := seenKinds[kind]; !ok {
+			return fmt.Errorf("%w: %s", ErrMissingRequiredArtifact, kind)
+		}
+	}
+	return nil
+}
+
+func (a ArtifactRef) Validate() error {
+	if strings.TrimSpace(a.Key) == "" {
+		return errors.New("key is required")
+	}
+	if !a.Kind.IsValid() {
+		return fmt.Errorf("%w: %q", ErrInvalidArtifactKind, a.Kind)
+	}
+	if strings.TrimSpace(a.ChecksumSHA256) == "" {
+		return errArtifactChecksumRequired
+	}
+	if !isLowerHexSHA256(a.ChecksumSHA256) {
+		return errors.New("checksum_sha256 must be 64 lowercase hex characters")
+	}
+	switch a.Location {
+	case ArtifactLocationLocalPath:
+		if strings.TrimSpace(a.Path) == "" {
+			return errArtifactReferenceRequired
+		}
+		cleanPath := filepath.Clean(filepath.FromSlash(a.Path))
+		if filepath.IsAbs(cleanPath) || cleanPath == ".." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) {
+			return errors.New("local_path path must be relative and must not traverse directories")
+		}
+		if a.Bucket != "" || a.ObjectKey != "" {
+			return errors.New("local_path artifacts must not set bucket or object_key")
+		}
+	case ArtifactLocationObjectStorage:
+		if strings.TrimSpace(a.ObjectKey) == "" {
+			return errArtifactReferenceRequired
+		}
+		if a.Path != "" {
+			return errors.New("object_storage artifacts must not set path")
+		}
+	default:
+		return fmt.Errorf("%w: %q", ErrInvalidArtifactLocation, a.Location)
+	}
+	if a.SizeBytes < 0 {
+		return errors.New("size_bytes must be non-negative")
+	}
+	return nil
+}
+
+func (k ArtifactKind) IsValid() bool {
+	switch k {
+	case ArtifactKindCallerAudio,
+		ArtifactKindAgentAudio,
+		ArtifactKindMixedAudio,
+		ArtifactKindTranscriptJSON,
+		ArtifactKindWaveformTimeline,
+		ArtifactKindRawProviderTrace,
+		ArtifactKindStructuredOutput,
+		ArtifactKindRedactionMetadata:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m Manifest) VerifyLocalChecksums(root string) error {
+	if err := m.Validate(); err != nil {
+		return err
+	}
+	for idx, artifact := range m.Artifacts {
+		if artifact.Location != ArtifactLocationLocalPath {
+			continue
+		}
+		path := filepath.Join(root, filepath.FromSlash(artifact.Path))
+		checksum, size, err := FileSHA256(path)
+		if err != nil {
+			return fmt.Errorf("artifacts[%d]: verify %s: %w", idx, artifact.Key, err)
+		}
+		if checksum != artifact.ChecksumSHA256 {
+			return fmt.Errorf("%w: artifacts[%d] %s got %s want %s", ErrArtifactChecksumMismatch, idx, artifact.Key, checksum, artifact.ChecksumSHA256)
+		}
+		if artifact.SizeBytes > 0 && artifact.SizeBytes != size {
+			return fmt.Errorf("artifacts[%d]: size_bytes = %d, want %d", idx, size, artifact.SizeBytes)
+		}
+	}
+	return nil
+}
+
+func (m Manifest) StableJSON() ([]byte, error) {
+	if err := m.Validate(); err != nil {
+		return nil, err
+	}
+	normalized := m
+	normalized.Artifacts = append([]ArtifactRef(nil), m.Artifacts...)
+	sort.SliceStable(normalized.Artifacts, func(i, j int) bool {
+		return normalized.Artifacts[i].Key < normalized.Artifacts[j].Key
+	})
+	encoded, err := json.MarshalIndent(normalized, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(encoded, '\n'), nil
+}
+
+func FileSHA256(path string) (string, int64, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", 0, err
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	size, err := io.Copy(hash, file)
+	if err != nil {
+		return "", 0, err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), size, nil
+}
+
+func requiredArtifactKinds() []ArtifactKind {
+	return []ArtifactKind{
+		ArtifactKindCallerAudio,
+		ArtifactKindAgentAudio,
+		ArtifactKindTranscriptJSON,
+		ArtifactKindWaveformTimeline,
+		ArtifactKindStructuredOutput,
+	}
+}
+
+func isLowerHexSHA256(value string) bool {
+	if len(value) != 64 {
+		return false
+	}
+	for _, ch := range value {
+		if (ch < '0' || ch > '9') && (ch < 'a' || ch > 'f') {
+			return false
+		}
+	}
+	return true
+}

--- a/backend/internal/voiceartifacts/manifest.go
+++ b/backend/internal/voiceartifacts/manifest.go
@@ -149,6 +149,9 @@ func (a ArtifactRef) Validate() error {
 		if strings.TrimSpace(a.ObjectKey) == "" {
 			return errArtifactReferenceRequired
 		}
+		if strings.TrimSpace(a.Bucket) == "" {
+			return errors.New("object_storage artifacts must set bucket")
+		}
 		if a.Path != "" {
 			return errors.New("object_storage artifacts must not set path")
 		}
@@ -194,7 +197,7 @@ func (m Manifest) VerifyLocalChecksums(root string) error {
 			return fmt.Errorf("%w: artifacts[%d] %s got %s want %s", ErrArtifactChecksumMismatch, idx, artifact.Key, checksum, artifact.ChecksumSHA256)
 		}
 		if artifact.SizeBytes > 0 && artifact.SizeBytes != size {
-			return fmt.Errorf("artifacts[%d]: size_bytes = %d, want %d", idx, size, artifact.SizeBytes)
+			return fmt.Errorf("artifacts[%d]: %s size mismatch: got %d bytes, manifest declares %d", idx, artifact.Key, size, artifact.SizeBytes)
 		}
 	}
 	return nil

--- a/backend/internal/voiceartifacts/manifest_test.go
+++ b/backend/internal/voiceartifacts/manifest_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -78,6 +79,8 @@ func TestVoiceArtifactManifestRoundTripsStably(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load returned error: %v", err)
 	}
+	assertArtifactsSortedByKey(t, manifest.Artifacts)
+
 	stable, err := manifest.StableJSON()
 	if err != nil {
 		t.Fatalf("StableJSON returned error: %v", err)
@@ -113,6 +116,15 @@ func TestVoiceArtifactManifestAcceptsObjectStorageReference(t *testing.T) {
 	}
 }
 
+func TestVoiceArtifactManifestRejectsObjectStorageReferenceWithoutBucket(t *testing.T) {
+	manifest := validObjectStorageManifest()
+	manifest.Artifacts[0].Bucket = ""
+
+	if err := manifest.Validate(); err == nil || !strings.Contains(err.Error(), "object_storage artifacts must set bucket") {
+		t.Fatalf("Validate error = %v, want missing object storage bucket", err)
+	}
+}
+
 func validObjectStorageManifest() Manifest {
 	return Manifest{
 		SchemaVersion:  SchemaVersionV1,
@@ -140,6 +152,15 @@ func objectArtifact(key string, kind ArtifactKind) ArtifactRef {
 		ContentType:    "application/octet-stream",
 		SizeBytes:      1,
 		ChecksumSHA256: "1111111111111111111111111111111111111111111111111111111111111111",
+	}
+}
+
+func assertArtifactsSortedByKey(t *testing.T, artifacts []ArtifactRef) {
+	t.Helper()
+	for idx := 1; idx < len(artifacts); idx++ {
+		if artifacts[idx-1].Key > artifacts[idx].Key {
+			t.Fatalf("fixture artifacts must be sorted by key for StableJSON golden comparison: %q before %q", artifacts[idx-1].Key, artifacts[idx].Key)
+		}
 	}
 }
 

--- a/backend/internal/voiceartifacts/manifest_test.go
+++ b/backend/internal/voiceartifacts/manifest_test.go
@@ -1,0 +1,155 @@
+package voiceartifacts
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+const supportBillingRoot = "testdata/support_billing"
+
+func TestLoadAndVerifyVoiceArtifactManifest(t *testing.T) {
+	manifest, err := Load(filepath.Join(supportBillingRoot, "voice_artifact_manifest.json"))
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	if manifest.RunID != uuid.MustParse("33333333-3333-3333-3333-333333333333") {
+		t.Fatalf("run_id = %s, want support billing run id", manifest.RunID)
+	}
+	if manifest.RunAgentID != uuid.MustParse("44444444-4444-4444-4444-444444444444") {
+		t.Fatalf("run_agent_id = %s, want support billing run agent id", manifest.RunAgentID)
+	}
+	if manifest.VoiceSessionID != "voice-session-support-billing-seed-42" {
+		t.Fatalf("voice_session_id = %q, want support billing session", manifest.VoiceSessionID)
+	}
+	if err := manifest.VerifyLocalChecksums(supportBillingRoot); err != nil {
+		t.Fatalf("VerifyLocalChecksums returned error: %v", err)
+	}
+
+	kinds := map[ArtifactKind]bool{}
+	for _, artifact := range manifest.Artifacts {
+		kinds[artifact.Kind] = true
+	}
+	for _, kind := range []ArtifactKind{
+		ArtifactKindCallerAudio,
+		ArtifactKindAgentAudio,
+		ArtifactKindMixedAudio,
+		ArtifactKindTranscriptJSON,
+		ArtifactKindWaveformTimeline,
+		ArtifactKindRawProviderTrace,
+		ArtifactKindStructuredOutput,
+		ArtifactKindRedactionMetadata,
+	} {
+		if !kinds[kind] {
+			t.Fatalf("manifest missing supported artifact kind %q", kind)
+		}
+	}
+}
+
+func TestVoiceArtifactManifestRejectsMissingRequiredReference(t *testing.T) {
+	manifest := validObjectStorageManifest()
+	manifest.Artifacts = filterArtifacts(manifest.Artifacts, ArtifactKindCallerAudio)
+
+	if err := manifest.Validate(); !errors.Is(err, ErrMissingRequiredArtifact) {
+		t.Fatalf("Validate error = %v, want ErrMissingRequiredArtifact", err)
+	}
+}
+
+func TestVoiceArtifactManifestRejectsChecksumMismatch(t *testing.T) {
+	manifest, err := Load(filepath.Join(supportBillingRoot, "voice_artifact_manifest.json"))
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	manifest.Artifacts[0].ChecksumSHA256 = "0000000000000000000000000000000000000000000000000000000000000000"
+
+	if err := manifest.VerifyLocalChecksums(supportBillingRoot); !errors.Is(err, ErrArtifactChecksumMismatch) {
+		t.Fatalf("VerifyLocalChecksums error = %v, want ErrArtifactChecksumMismatch", err)
+	}
+}
+
+func TestVoiceArtifactManifestRoundTripsStably(t *testing.T) {
+	manifest, err := Load(filepath.Join(supportBillingRoot, "voice_artifact_manifest.json"))
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	stable, err := manifest.StableJSON()
+	if err != nil {
+		t.Fatalf("StableJSON returned error: %v", err)
+	}
+	golden, err := os.ReadFile(filepath.Join(supportBillingRoot, "voice_artifact_manifest.json"))
+	if err != nil {
+		t.Fatalf("read golden manifest: %v", err)
+	}
+	if !bytes.Equal(golden, stable) {
+		t.Fatalf("stable manifest mismatch\nwant:\n%s\n got:\n%s", golden, stable)
+	}
+
+	var decoded Manifest
+	if err := json.Unmarshal(stable, &decoded); err != nil {
+		t.Fatalf("unmarshal stable manifest: %v", err)
+	}
+	second, err := decoded.StableJSON()
+	if err != nil {
+		t.Fatalf("StableJSON second pass returned error: %v", err)
+	}
+	if !bytes.Equal(stable, second) {
+		t.Fatalf("stable round-trip mismatch\nfirst:\n%s\nsecond:\n%s", stable, second)
+	}
+}
+
+func TestVoiceArtifactManifestAcceptsObjectStorageReference(t *testing.T) {
+	manifest := validObjectStorageManifest()
+	if err := manifest.Validate(); err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+	if err := manifest.VerifyLocalChecksums(supportBillingRoot); err != nil {
+		t.Fatalf("VerifyLocalChecksums should skip object storage refs, got error: %v", err)
+	}
+}
+
+func validObjectStorageManifest() Manifest {
+	return Manifest{
+		SchemaVersion:  SchemaVersionV1,
+		RunID:          uuid.MustParse("33333333-3333-3333-3333-333333333333"),
+		RunAgentID:     uuid.MustParse("44444444-4444-4444-4444-444444444444"),
+		VoiceSessionID: "voice-session-support-billing-seed-42",
+		Artifacts: []ArtifactRef{
+			objectArtifact("caller_audio", ArtifactKindCallerAudio),
+			objectArtifact("agent_audio", ArtifactKindAgentAudio),
+			objectArtifact("transcript", ArtifactKindTranscriptJSON),
+			objectArtifact("waveform_timeline", ArtifactKindWaveformTimeline),
+			objectArtifact("structured_output", ArtifactKindStructuredOutput),
+			objectArtifact("raw_provider_trace", ArtifactKindRawProviderTrace),
+		},
+	}
+}
+
+func objectArtifact(key string, kind ArtifactKind) ArtifactRef {
+	return ArtifactRef{
+		Key:            key,
+		Kind:           kind,
+		Location:       ArtifactLocationObjectStorage,
+		Bucket:         "agentclash-dev-artifacts",
+		ObjectKey:      "voice/sessions/voice-session-support-billing-seed-42/" + key,
+		ContentType:    "application/octet-stream",
+		SizeBytes:      1,
+		ChecksumSHA256: "1111111111111111111111111111111111111111111111111111111111111111",
+	}
+}
+
+func filterArtifacts(artifacts []ArtifactRef, without ArtifactKind) []ArtifactRef {
+	filtered := make([]ArtifactRef, 0, len(artifacts))
+	for _, artifact := range artifacts {
+		if artifact.Kind == without {
+			continue
+		}
+		filtered = append(filtered, artifact)
+	}
+	return filtered
+}

--- a/backend/internal/voiceartifacts/testdata/support_billing/artifacts/agent-turn-001.wav
+++ b/backend/internal/voiceartifacts/testdata/support_billing/artifacts/agent-turn-001.wav
@@ -1,0 +1,1 @@
+placeholder agent audio bytes

--- a/backend/internal/voiceartifacts/testdata/support_billing/artifacts/caller-turn-001.wav
+++ b/backend/internal/voiceartifacts/testdata/support_billing/artifacts/caller-turn-001.wav
@@ -1,0 +1,1 @@
+placeholder caller audio bytes

--- a/backend/internal/voiceartifacts/testdata/support_billing/artifacts/mixed-session.wav
+++ b/backend/internal/voiceartifacts/testdata/support_billing/artifacts/mixed-session.wav
@@ -1,0 +1,1 @@
+placeholder mixed audio bytes

--- a/backend/internal/voiceartifacts/testdata/support_billing/artifacts/raw_provider_trace.json
+++ b/backend/internal/voiceartifacts/testdata/support_billing/artifacts/raw_provider_trace.json
@@ -1,0 +1,9 @@
+{
+  "provider": "fake",
+  "events": [
+    {
+      "event_type": "fake.media_frame",
+      "sequence": 1
+    }
+  ]
+}

--- a/backend/internal/voiceartifacts/testdata/support_billing/artifacts/redaction_metadata.json
+++ b/backend/internal/voiceartifacts/testdata/support_billing/artifacts/redaction_metadata.json
@@ -1,0 +1,7 @@
+{
+  "status": "redacted",
+  "rules": [
+    "card_number",
+    "email"
+  ]
+}

--- a/backend/internal/voiceartifacts/testdata/support_billing/artifacts/structured_output.json
+++ b/backend/internal/voiceartifacts/testdata/support_billing/artifacts/structured_output.json
@@ -1,0 +1,7 @@
+{
+  "schema_ref": "voice.support.resolution.v1",
+  "output": {
+    "resolution": "refund_created",
+    "refund_id": "rf_123"
+  }
+}

--- a/backend/internal/voiceartifacts/testdata/support_billing/artifacts/transcript.json
+++ b/backend/internal/voiceartifacts/testdata/support_billing/artifacts/transcript.json
@@ -7,7 +7,7 @@
       "language": "en-US"
     },
     {
-      "turn_index": 1,
+      "turn_index": 2,
       "speaker": "agent",
       "text": "I found the duplicate charge and created refund rf_123.",
       "language": "en-US"

--- a/backend/internal/voiceartifacts/testdata/support_billing/artifacts/transcript.json
+++ b/backend/internal/voiceartifacts/testdata/support_billing/artifacts/transcript.json
@@ -1,0 +1,16 @@
+{
+  "turns": [
+    {
+      "turn_index": 1,
+      "speaker": "caller",
+      "text": "I was charged twice for my last invoice.",
+      "language": "en-US"
+    },
+    {
+      "turn_index": 1,
+      "speaker": "agent",
+      "text": "I found the duplicate charge and created refund rf_123.",
+      "language": "en-US"
+    }
+  ]
+}

--- a/backend/internal/voiceartifacts/testdata/support_billing/artifacts/waveform_timeline.json
+++ b/backend/internal/voiceartifacts/testdata/support_billing/artifacts/waveform_timeline.json
@@ -1,0 +1,20 @@
+{
+  "channels": [
+    {
+      "channel": "caller",
+      "artifact_key": "caller_audio",
+      "duration_ms": 1800
+    },
+    {
+      "channel": "agent",
+      "artifact_key": "agent_audio",
+      "duration_ms": 2400
+    }
+  ],
+  "markers": [
+    {
+      "key": "end_of_speech_to_first_agent_text",
+      "offset_ms": 3200
+    }
+  ]
+}

--- a/backend/internal/voiceartifacts/testdata/support_billing/voice_artifact_manifest.json
+++ b/backend/internal/voiceartifacts/testdata/support_billing/voice_artifact_manifest.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": "2026-05-13",
+  "run_id": "33333333-3333-3333-3333-333333333333",
+  "run_agent_id": "44444444-4444-4444-4444-444444444444",
+  "voice_session_id": "voice-session-support-billing-seed-42",
+  "artifacts": [
+    {
+      "key": "agent_audio",
+      "kind": "agent_audio",
+      "location": "local_path",
+      "path": "artifacts/agent-turn-001.wav",
+      "content_type": "audio/wav",
+      "size_bytes": 30,
+      "checksum_sha256": "d95869356aa66d7543cc9e21a4d68534034d2e91a33039b43bbac661d753fb49"
+    },
+    {
+      "key": "caller_audio",
+      "kind": "caller_audio",
+      "location": "local_path",
+      "path": "artifacts/caller-turn-001.wav",
+      "content_type": "audio/wav",
+      "size_bytes": 31,
+      "checksum_sha256": "8f1415ad8c350a9547df1f13cd0836d7ffb8b459f587ad5d423f471fada0197e"
+    },
+    {
+      "key": "mixed_audio",
+      "kind": "mixed_audio",
+      "location": "local_path",
+      "path": "artifacts/mixed-session.wav",
+      "content_type": "audio/wav",
+      "size_bytes": 30,
+      "checksum_sha256": "bcf377986e5fc44d7699278e4607bfbb6602d844cf512a678267d732dac3f2fc"
+    },
+    {
+      "key": "raw_provider_trace",
+      "kind": "raw_provider_trace_json",
+      "location": "local_path",
+      "path": "artifacts/raw_provider_trace.json",
+      "content_type": "application/json",
+      "size_bytes": 116,
+      "checksum_sha256": "2b0de1dfc776dbe85ba4813758eeace9b99c310b0448ceb67659ef9e37be4031"
+    },
+    {
+      "key": "redaction_metadata",
+      "kind": "redaction_metadata_json",
+      "location": "local_path",
+      "path": "artifacts/redaction_metadata.json",
+      "content_type": "application/json",
+      "size_bytes": 76,
+      "checksum_sha256": "0ea5f85848b67f3852ddf7292dd7d76a5d90e249f8aceac1699a301990d4eb1b"
+    },
+    {
+      "key": "structured_output",
+      "kind": "structured_output_json",
+      "location": "local_path",
+      "path": "artifacts/structured_output.json",
+      "content_type": "application/json",
+      "size_bytes": 131,
+      "checksum_sha256": "f2475c7d3db11f1ff5aa8109cf9d3a8cbf75cc36eeadacc6f0e8f9083fbca989"
+    },
+    {
+      "key": "transcript",
+      "kind": "transcript_json",
+      "location": "local_path",
+      "path": "artifacts/transcript.json",
+      "content_type": "application/json",
+      "size_bytes": 328,
+      "checksum_sha256": "c551fe1daf1c3f2efa2b94ca39d66b43e82cbdb220edbf84243766a6772b63f9"
+    },
+    {
+      "key": "waveform_timeline",
+      "kind": "waveform_timeline_json",
+      "location": "local_path",
+      "path": "artifacts/waveform_timeline.json",
+      "content_type": "application/json",
+      "size_bytes": 335,
+      "checksum_sha256": "f33379b417f077ba9a8ab8427dbec74d3732ded995c4bb9563d119b251d52a0d"
+    }
+  ]
+}

--- a/backend/internal/voiceartifacts/testdata/support_billing/voice_artifact_manifest.json
+++ b/backend/internal/voiceartifacts/testdata/support_billing/voice_artifact_manifest.json
@@ -65,7 +65,7 @@
       "path": "artifacts/transcript.json",
       "content_type": "application/json",
       "size_bytes": 328,
-      "checksum_sha256": "c551fe1daf1c3f2efa2b94ca39d66b43e82cbdb220edbf84243766a6772b63f9"
+      "checksum_sha256": "6f380a999d74c02d7dd29d1c85eb0c697762abddff18215f6c424cdf167aee73"
     },
     {
       "key": "waveform_timeline",


### PR DESCRIPTION
## Summary

Closes #759. Parent: #754.

- Add a versioned `voiceartifacts` manifest model linked to `run_id`, `run_agent_id`, and `voice_session_id`.
- Define artifact references for caller/agent/mixed audio, transcript JSON, waveform/timeline JSON, raw provider trace JSON, structured output JSON, and redaction metadata JSON.
- Support deterministic local fixture refs plus future object-storage refs, both with required SHA-256 checksums.
- Add checksum verification and stable JSON round-trip tests using tiny local placeholder fixtures.
- Address Greptile follow-up by requiring object-storage buckets, clarifying size mismatch errors, fixing transcript turn indexes, and documenting/enforcing sorted fixture artifacts for stable JSON goldens.

## Test Contract

```markdown
# codex/voice-artifact-manifest - Test Contract

## Functional Behavior
- Define a versioned voice artifact manifest for a single voice session.
- Manifest links to `run_id`, `run_agent_id`, and `voice_session_id`.
- Manifest references large artifacts instead of embedding audio/blob data.
- Manifest supports caller audio, agent audio, mixed audio, transcript JSON, waveform/timeline JSON, raw provider trace JSON, structured output JSON, and redaction metadata JSON.
- Local fixture references include SHA-256 checksums and can be verified deterministically.
- Future object-storage references can be represented without network access and still require checksums.
- Manifest JSON round-trips stably.

## Unit Tests
- `TestLoadAndVerifyVoiceArtifactManifest` - loads a complete fixture manifest and verifies local checksums.
- `TestVoiceArtifactManifestRejectsMissingRequiredReference` - rejects a manifest missing a required core artifact kind.
- `TestVoiceArtifactManifestRejectsChecksumMismatch` - detects local checksum mismatches.
- `TestVoiceArtifactManifestRoundTripsStably` - proves stable JSON output after parse/validate/marshal.
- `TestVoiceArtifactManifestAcceptsObjectStorageReference` - validates future object-storage references without network access.
- `TestVoiceArtifactManifestRejectsObjectStorageReferenceWithoutBucket` - rejects incomplete object-storage references at manifest validation time.

## Integration / Functional Tests
- `go test ./internal/voiceartifacts ./internal/voicefixtures ./internal/multimodaltrace ./internal/runevents`

## Smoke Tests
- `go test ./internal/voiceartifacts`
- `go test ./...`

## E2E Tests
N/A - this slice defines local manifest conventions only.

## Manual / cURL Tests
N/A - no HTTP surface is added in this slice.
```

## Review Checkpoint

```json
{
  "branch": "codex/voice-artifact-manifest",
  "test_contract": "/tmp/codex-voice-artifact-manifest-test-contract.md",
  "created_at": "2026-05-13T12:05:00Z",
  "steps": [
    {
      "step_number": 1,
      "title": "Define voice artifact manifest conventions",
      "timestamp": "2026-05-13T12:07:07Z",
      "files_changed": [
        "backend/internal/voiceartifacts/manifest.go",
        "backend/internal/voiceartifacts/manifest_test.go",
        "backend/internal/voiceartifacts/testdata/support_billing/voice_artifact_manifest.json",
        "backend/internal/voiceartifacts/testdata/support_billing/artifacts/*"
      ],
      "what_changed": "Added a versioned voice artifact manifest model with local and future object-storage references, required core artifact validation, local SHA-256 verification, stable JSON serialization, and deterministic support-billing fixture artifacts covering all #759 artifact kinds.",
      "review_instructions": "Verify the manifest links run_id/run_agent_id/voice_session_id, references artifacts rather than embedding large blobs, requires checksums, validates required core artifact kinds, supports object_storage refs without network access, and detects local checksum mismatches.",
      "review_result": {
        "status": "pass",
        "issues_found": [],
        "notes": "Self-review found the implementation matches #759. go test ./internal/voiceartifacts and the neighboring voice package set passed."
      },
      "cumulative_review": {
        "previous_steps_still_valid": true,
        "integration_issues": [],
        "notes": "This builds on the merged multimodal trace, voice fixture, and canonical event contracts without changing their behavior."
      }
    },
    {
      "step_number": "final",
      "title": "Final review against test contract",
      "timestamp": "2026-05-13T12:07:56Z",
      "test_contract_review": {
        "functional_behavior": "pass - manifest is versioned, links run_id/run_agent_id/voice_session_id, references all requested artifact kinds, requires checksums, supports local_path and object_storage references, and verifies local fixture checksums.",
        "unit_tests": "pass - added tests for loading/verifying, missing required refs, checksum mismatch, stable round-trip JSON, and object-storage refs.",
        "integration_tests": "pass - go test ./internal/voiceartifacts ./internal/voicefixtures ./internal/multimodaltrace ./internal/runevents passed.",
        "smoke_tests": "pass - go test ./internal/voiceartifacts and go test ./... passed.",
        "e2e_tests": "N/A - no user-facing execution flow is added.",
        "manual_tests": "N/A - no HTTP or CLI surface is added."
      },
      "overall_verdict": "ready",
      "blocking_issues": []
    }
  ]
}
```

## Verification

- `go test ./internal/voiceartifacts`
- `go test ./internal/voiceartifacts ./internal/voicefixtures ./internal/multimodaltrace ./internal/runevents`
- `go test ./...`

## Greptile Follow-Up

- `object_storage` artifacts now require `bucket` and `object_key`.
- Local size mismatch errors now distinguish computed bytes from manifest-declared bytes.
- Transcript fixture turn indexes now advance from caller turn 1 to agent turn 2.
- Stable JSON golden tests now explicitly assert fixture artifact refs are sorted by key before byte comparison.
