### PR TITLE
feat(voice-evals): add scripted user simulator

### DIFF
--- a/backend/internal/voicesim/simulator.go
+++ b/backend/internal/voicesim/simulator.go
@@ -1,0 +1,407 @@
+package voicesim
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/multimodaltrace"
+	"github.com/agentclash/agentclash/backend/internal/runevents"
+	"github.com/google/uuid"
+)
+
+const ScriptSchemaVersionV1 = "2026-05-13"
+
+var (
+	ErrInvalidScript           = errors.New("invalid scripted voice simulator script")
+	ErrMaxTurnsExceeded        = errors.New("scripted voice simulator max_turns exceeded")
+	ErrUnexpectedAgentResponse = errors.New("unexpected scripted voice agent response")
+	ErrResponseLatencyExceeded = errors.New("scripted voice agent response latency exceeded")
+)
+
+type Script struct {
+	SchemaVersion string    `json:"schema_version"`
+	TraceID       string    `json:"trace_id"`
+	RunID         uuid.UUID `json:"run_id"`
+	RunAgentID    uuid.UUID `json:"run_agent_id"`
+	ScenarioKey   string    `json:"scenario_key"`
+	MaxTurns      int       `json:"max_turns"`
+	BaseTime      time.Time `json:"base_time"`
+	Steps         []Step    `json:"steps"`
+}
+
+type Step struct {
+	TurnID               string        `json:"turn_id"`
+	UserText             string        `json:"user_text"`
+	Language             string        `json:"language,omitempty"`
+	OccurredAtOffsetMS   int64         `json:"occurred_at_offset_ms"`
+	ExpectedAgentText    string        `json:"expected_agent_text"`
+	MaxResponseLatencyMS int64         `json:"max_response_latency_ms,omitempty"`
+	Interruption         *Interruption `json:"interruption,omitempty"`
+}
+
+type Interruption struct {
+	OccurredAtOffsetMS int64 `json:"occurred_at_offset_ms"`
+	ClearBuffer        bool  `json:"clear_buffer,omitempty"`
+}
+
+type Agent interface {
+	Respond(step Step) (AgentResponse, error)
+}
+
+type AgentResponse struct {
+	Text      string
+	Language  string
+	LatencyMS int64
+}
+
+type Result struct {
+	Trace      multimodaltrace.Trace
+	Events     []runevents.Envelope
+	TraceJSON  []byte
+	EventsJSON []byte
+}
+
+type Simulator struct {
+	script Script
+}
+
+func LoadScript(path string) (Script, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Script{}, err
+	}
+	var script Script
+	if err := json.Unmarshal(data, &script); err != nil {
+		return Script{}, fmt.Errorf("decode scripted voice simulator script: %w", err)
+	}
+	if err := script.Validate(); err != nil {
+		return Script{}, err
+	}
+	return script, nil
+}
+
+func New(script Script) (*Simulator, error) {
+	if err := script.Validate(); err != nil {
+		return nil, err
+	}
+	return &Simulator{script: script}, nil
+}
+
+func (s Script) Validate() error {
+	if s.SchemaVersion != ScriptSchemaVersionV1 {
+		return fmt.Errorf("%w: schema_version must be %q", ErrInvalidScript, ScriptSchemaVersionV1)
+	}
+	if strings.TrimSpace(s.TraceID) == "" {
+		return fmt.Errorf("%w: trace_id is required", ErrInvalidScript)
+	}
+	if s.RunID == uuid.Nil {
+		return fmt.Errorf("%w: run_id is required", ErrInvalidScript)
+	}
+	if s.RunAgentID == uuid.Nil {
+		return fmt.Errorf("%w: run_agent_id is required", ErrInvalidScript)
+	}
+	if strings.TrimSpace(s.ScenarioKey) == "" {
+		return fmt.Errorf("%w: scenario_key is required", ErrInvalidScript)
+	}
+	if s.MaxTurns <= 0 {
+		return fmt.Errorf("%w: max_turns must be greater than zero", ErrInvalidScript)
+	}
+	if s.BaseTime.IsZero() {
+		return fmt.Errorf("%w: base_time is required", ErrInvalidScript)
+	}
+	if len(s.Steps) == 0 {
+		return fmt.Errorf("%w: steps must contain at least one step", ErrInvalidScript)
+	}
+	if len(s.Steps) > s.MaxTurns {
+		return fmt.Errorf("%w: steps=%d max_turns=%d", ErrMaxTurnsExceeded, len(s.Steps), s.MaxTurns)
+	}
+	var previousOffset int64 = -1
+	for idx, step := range s.Steps {
+		if err := step.Validate(); err != nil {
+			return fmt.Errorf("steps[%d]: %w", idx, err)
+		}
+		if step.OccurredAtOffsetMS <= previousOffset {
+			return fmt.Errorf("steps[%d]: %w: occurred_at_offset_ms must increase", idx, ErrInvalidScript)
+		}
+		previousOffset = step.OccurredAtOffsetMS
+	}
+	return nil
+}
+
+func (s Step) Validate() error {
+	if strings.TrimSpace(s.TurnID) == "" {
+		return fmt.Errorf("%w: turn_id is required", ErrInvalidScript)
+	}
+	if strings.TrimSpace(s.UserText) == "" {
+		return fmt.Errorf("%w: user_text is required", ErrInvalidScript)
+	}
+	if strings.TrimSpace(s.ExpectedAgentText) == "" {
+		return fmt.Errorf("%w: expected_agent_text is required", ErrInvalidScript)
+	}
+	if s.OccurredAtOffsetMS < 0 {
+		return fmt.Errorf("%w: occurred_at_offset_ms must be non-negative", ErrInvalidScript)
+	}
+	if s.MaxResponseLatencyMS < 0 {
+		return fmt.Errorf("%w: max_response_latency_ms must be non-negative", ErrInvalidScript)
+	}
+	if s.Interruption != nil && s.Interruption.OccurredAtOffsetMS < s.OccurredAtOffsetMS {
+		return fmt.Errorf("%w: interruption must not occur before the user turn", ErrInvalidScript)
+	}
+	return nil
+}
+
+func (s *Simulator) Run(agent Agent) (Result, error) {
+	if agent == nil {
+		return Result{}, fmt.Errorf("%w: agent is required", ErrInvalidScript)
+	}
+
+	segments := make([]multimodaltrace.Segment, 0, len(s.script.Steps)*4)
+	events := make([]runevents.Envelope, 0, len(s.script.Steps)*5+2)
+	eventSeq := int64(0)
+	appendEvent := func(eventType runevents.Type, occurredAt time.Time, payload any, summary runevents.SummaryMetadata) error {
+		eventSeq++
+		rawPayload, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("marshal event payload: %w", err)
+		}
+		if summary.EvidenceLevel == "" {
+			summary.EvidenceLevel = runevents.EvidenceLevelVoiceStructured
+		}
+		if summary.IdempotencyKey == "" {
+			summary.IdempotencyKey = fmt.Sprintf("%s:event:%03d", s.script.TraceID, eventSeq)
+		}
+		envelope := runevents.Envelope{
+			EventID:        fmt.Sprintf("voice-sim:%s:%03d", s.script.TraceID, eventSeq),
+			SchemaVersion:  runevents.SchemaVersionV1,
+			RunID:          s.script.RunID,
+			RunAgentID:     s.script.RunAgentID,
+			SequenceNumber: eventSeq,
+			EventType:      eventType,
+			Source:         runevents.SourceVoiceAdapter,
+			OccurredAt:     occurredAt.UTC(),
+			Payload:        rawPayload,
+			Summary:        summary,
+		}
+		if err := envelope.ValidatePersisted(); err != nil {
+			return err
+		}
+		events = append(events, envelope)
+		return nil
+	}
+
+	if err := appendEvent(runevents.EventTypeMediaSessionStarted, s.script.BaseTime, map[string]any{
+		"scenario_key":     s.script.ScenarioKey,
+		"voice_session_id": s.script.TraceID,
+		"mode":             "text-sim",
+	}, runevents.SummaryMetadata{
+		Status:         "running",
+		IdempotencyKey: s.script.TraceID + ":session_started",
+		EvidenceLevel:  runevents.EvidenceLevelVoiceStructured,
+	}); err != nil {
+		return Result{}, err
+	}
+
+	nextSegmentNumber := int64(1)
+	for idx, step := range s.script.Steps {
+		turnIndex := idx + 1
+		userOccurredAt := s.script.BaseTime.Add(time.Duration(step.OccurredAtOffsetMS) * time.Millisecond).UTC()
+		userSegmentID := fmt.Sprintf("%s:user-text", step.TurnID)
+		segments = append(segments, multimodaltrace.Segment{
+			SegmentID:      userSegmentID,
+			SequenceNumber: nextSegmentNumber,
+			Kind:           multimodaltrace.SegmentKindTextInput,
+			Actor:          multimodaltrace.ActorUser,
+			OccurredAt:     userOccurredAt,
+			Text: &multimodaltrace.TextPayload{
+				Text:     step.UserText,
+				Language: step.Language,
+			},
+		})
+		nextSegmentNumber++
+		if err := appendEvent(runevents.EventTypeTranscriptFinal, userOccurredAt, map[string]any{
+			"turn_id":    step.TurnID,
+			"text":       step.UserText,
+			"language":   step.Language,
+			"segment_id": userSegmentID,
+		}, turnSummary(turnIndex, "caller", "text")); err != nil {
+			return Result{}, err
+		}
+
+		response, err := agent.Respond(step)
+		if err != nil {
+			return Result{}, err
+		}
+		if response.LatencyMS < 0 {
+			return Result{}, fmt.Errorf("%w: latency_ms must be non-negative", ErrInvalidScript)
+		}
+		if step.MaxResponseLatencyMS > 0 && response.LatencyMS > step.MaxResponseLatencyMS {
+			return Result{}, fmt.Errorf("%w: turn_id=%s latency_ms=%d max_response_latency_ms=%d", ErrResponseLatencyExceeded, step.TurnID, response.LatencyMS, step.MaxResponseLatencyMS)
+		}
+		if response.Text != step.ExpectedAgentText {
+			if err := appendEvent(runevents.EventTypeSystemRunFailed, userOccurredAt, map[string]any{
+				"turn_id":  step.TurnID,
+				"expected": step.ExpectedAgentText,
+				"actual":   response.Text,
+			}, runevents.SummaryMetadata{
+				Status:         "failed",
+				IdempotencyKey: s.script.TraceID + ":" + step.TurnID + ":failed",
+			}); err != nil {
+				return Result{}, err
+			}
+			return Result{}, fmt.Errorf("%w: turn_id=%s expected %q got %q", ErrUnexpectedAgentResponse, step.TurnID, step.ExpectedAgentText, response.Text)
+		}
+
+		agentOccurredAt := userOccurredAt.Add(time.Duration(response.LatencyMS) * time.Millisecond).UTC()
+		agentSegmentID := fmt.Sprintf("%s:agent-text", step.TurnID)
+		responseLanguage := firstNonEmpty(response.Language, step.Language)
+		segments = append(segments, multimodaltrace.Segment{
+			SegmentID:      agentSegmentID,
+			SequenceNumber: nextSegmentNumber,
+			Kind:           multimodaltrace.SegmentKindTextOutput,
+			Actor:          multimodaltrace.ActorAgent,
+			OccurredAt:     agentOccurredAt,
+			Text: &multimodaltrace.TextPayload{
+				Text:     response.Text,
+				Language: responseLanguage,
+			},
+		})
+		nextSegmentNumber++
+
+		metricSegmentID := fmt.Sprintf("%s:latency", step.TurnID)
+		segments = append(segments, multimodaltrace.Segment{
+			SegmentID:      metricSegmentID,
+			SequenceNumber: nextSegmentNumber,
+			Kind:           multimodaltrace.SegmentKindTimingMarker,
+			Actor:          multimodaltrace.ActorEvaluator,
+			OccurredAt:     agentOccurredAt,
+			TimingMarker: &multimodaltrace.TimingMarkerPayload{
+				Key:     "end_of_user_text_to_agent_text",
+				ValueMS: response.LatencyMS,
+			},
+		})
+		nextSegmentNumber++
+
+		if err := appendEvent(runevents.EventTypeVoiceMetricRecorded, agentOccurredAt, map[string]any{
+			"turn_id":    step.TurnID,
+			"metric_key": "end_of_user_text_to_agent_text_ms",
+			"value_ms":   response.LatencyMS,
+		}, metricSummary(turnIndex, "end_of_user_text_to_agent_text_ms")); err != nil {
+			return Result{}, err
+		}
+		if err := appendEvent(runevents.EventTypeTurnCompleted, agentOccurredAt, map[string]any{
+			"turn_id":          step.TurnID,
+			"user_segment_id":  userSegmentID,
+			"agent_segment_id": agentSegmentID,
+		}, turnSummary(turnIndex, "agent", "text")); err != nil {
+			return Result{}, err
+		}
+
+		if step.Interruption != nil {
+			interruptionOccurredAt := s.script.BaseTime.Add(time.Duration(step.Interruption.OccurredAtOffsetMS) * time.Millisecond).UTC()
+			controlSegmentID := fmt.Sprintf("%s:interruption", step.TurnID)
+			segments = append(segments, multimodaltrace.Segment{
+				SegmentID:      controlSegmentID,
+				SequenceNumber: nextSegmentNumber,
+				Kind:           multimodaltrace.SegmentKindMediaControl,
+				Actor:          multimodaltrace.ActorSystem,
+				OccurredAt:     interruptionOccurredAt,
+				MediaControl: &multimodaltrace.MediaControlPayload{
+					Action:          "barge_in_detected",
+					TargetSegmentID: agentSegmentID,
+				},
+			})
+			nextSegmentNumber++
+			if err := appendEvent(runevents.EventTypeBargeInDetected, interruptionOccurredAt, map[string]any{
+				"turn_id":           step.TurnID,
+				"target_segment_id": agentSegmentID,
+			}, turnSummary(turnIndex, "caller", "text")); err != nil {
+				return Result{}, err
+			}
+			if step.Interruption.ClearBuffer {
+				if err := appendEvent(runevents.EventTypeAudioBufferCleared, interruptionOccurredAt, map[string]any{
+					"turn_id":           step.TurnID,
+					"target_segment_id": agentSegmentID,
+				}, turnSummary(turnIndex, "system", "text")); err != nil {
+					return Result{}, err
+				}
+			}
+		}
+	}
+
+	completedAt := s.script.BaseTime
+	if len(segments) > 0 {
+		completedAt = segments[len(segments)-1].OccurredAt
+	}
+	if err := appendEvent(runevents.EventTypeSystemRunCompleted, completedAt, map[string]any{
+		"scenario_key": s.script.ScenarioKey,
+		"turn_count":   len(s.script.Steps),
+	}, runevents.SummaryMetadata{
+		Status:         "completed",
+		IdempotencyKey: s.script.TraceID + ":completed",
+	}); err != nil {
+		return Result{}, err
+	}
+
+	trace := multimodaltrace.Trace{
+		TraceID:       s.script.TraceID,
+		SchemaVersion: multimodaltrace.SchemaVersionV1,
+		RunID:         s.script.RunID,
+		RunAgentID:    s.script.RunAgentID,
+		Segments:      segments,
+	}
+	if err := trace.Validate(); err != nil {
+		return Result{}, err
+	}
+
+	traceJSON, err := marshalStable(trace)
+	if err != nil {
+		return Result{}, err
+	}
+	eventsJSON, err := marshalStable(events)
+	if err != nil {
+		return Result{}, err
+	}
+
+	return Result{
+		Trace:      trace,
+		Events:     events,
+		TraceJSON:  traceJSON,
+		EventsJSON: eventsJSON,
+	}, nil
+}
+
+func turnSummary(turnIndex int, speaker string, channel string) runevents.SummaryMetadata {
+	return runevents.SummaryMetadata{
+		TurnIndex:     &turnIndex,
+		Speaker:       speaker,
+		Channel:       channel,
+		EvidenceLevel: runevents.EvidenceLevelVoiceStructured,
+	}
+}
+
+func metricSummary(turnIndex int, metricKey string) runevents.SummaryMetadata {
+	summary := turnSummary(turnIndex, "evaluator", "metric")
+	summary.MetricKey = metricKey
+	return summary
+}
+
+func marshalStable(value any) ([]byte, error) {
+	encoded, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(encoded, '\n'), nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/backend/internal/voicesim/simulator.go
+++ b/backend/internal/voicesim/simulator.go
@@ -120,10 +120,15 @@ func (s Script) Validate() error {
 		return fmt.Errorf("%w: steps=%d max_turns=%d", ErrMaxTurnsExceeded, len(s.Steps), s.MaxTurns)
 	}
 	var previousOffset int64 = -1
+	seenTurnIDs := make(map[string]struct{}, len(s.Steps))
 	for idx, step := range s.Steps {
 		if err := step.Validate(); err != nil {
 			return fmt.Errorf("steps[%d]: %w", idx, err)
 		}
+		if _, dup := seenTurnIDs[step.TurnID]; dup {
+			return fmt.Errorf("steps[%d]: %w: duplicate turn_id %q", idx, ErrInvalidScript, step.TurnID)
+		}
+		seenTurnIDs[step.TurnID] = struct{}{}
 		if step.OccurredAtOffsetMS <= previousOffset {
 			return fmt.Errorf("steps[%d]: %w: occurred_at_offset_ms must increase", idx, ErrInvalidScript)
 		}
@@ -241,8 +246,9 @@ func (s *Simulator) Run(agent Agent) (Result, error) {
 		if step.MaxResponseLatencyMS > 0 && response.LatencyMS > step.MaxResponseLatencyMS {
 			return Result{}, fmt.Errorf("%w: turn_id=%s latency_ms=%d max_response_latency_ms=%d", ErrResponseLatencyExceeded, step.TurnID, response.LatencyMS, step.MaxResponseLatencyMS)
 		}
+		agentOccurredAt := userOccurredAt.Add(time.Duration(response.LatencyMS) * time.Millisecond).UTC()
 		if response.Text != step.ExpectedAgentText {
-			if err := appendEvent(runevents.EventTypeSystemRunFailed, userOccurredAt, map[string]any{
+			if err := appendEvent(runevents.EventTypeSystemRunFailed, agentOccurredAt, map[string]any{
 				"turn_id":  step.TurnID,
 				"expected": step.ExpectedAgentText,
 				"actual":   response.Text,
@@ -255,7 +261,6 @@ func (s *Simulator) Run(agent Agent) (Result, error) {
 			return Result{}, fmt.Errorf("%w: turn_id=%s expected %q got %q", ErrUnexpectedAgentResponse, step.TurnID, step.ExpectedAgentText, response.Text)
 		}
 
-		agentOccurredAt := userOccurredAt.Add(time.Duration(response.LatencyMS) * time.Millisecond).UTC()
 		agentSegmentID := fmt.Sprintf("%s:agent-text", step.TurnID)
 		responseLanguage := firstNonEmpty(response.Language, step.Language)
 		segments = append(segments, multimodaltrace.Segment{
@@ -302,6 +307,14 @@ func (s *Simulator) Run(agent Agent) (Result, error) {
 
 		if step.Interruption != nil {
 			interruptionOccurredAt := s.script.BaseTime.Add(time.Duration(step.Interruption.OccurredAtOffsetMS) * time.Millisecond).UTC()
+			if !interruptionOccurredAt.After(agentOccurredAt) {
+				return Result{}, fmt.Errorf("%w: turn_id=%s interruption_at=%s must be after agent response at=%s",
+					ErrInvalidScript,
+					step.TurnID,
+					interruptionOccurredAt.Format(time.RFC3339Nano),
+					agentOccurredAt.Format(time.RFC3339Nano),
+				)
+			}
 			controlSegmentID := fmt.Sprintf("%s:interruption", step.TurnID)
 			segments = append(segments, multimodaltrace.Segment{
 				SegmentID:      controlSegmentID,

--- a/backend/internal/voicesim/simulator.go
+++ b/backend/internal/voicesim/simulator.go
@@ -258,7 +258,11 @@ func (s *Simulator) Run(agent Agent) (Result, error) {
 			}); err != nil {
 				return Result{}, err
 			}
-			return Result{}, fmt.Errorf("%w: turn_id=%s expected %q got %q", ErrUnexpectedAgentResponse, step.TurnID, step.ExpectedAgentText, response.Text)
+			result, err := s.buildResult(segments, events)
+			if err != nil {
+				return Result{}, err
+			}
+			return result, fmt.Errorf("%w: turn_id=%s expected %q got %q", ErrUnexpectedAgentResponse, step.TurnID, step.ExpectedAgentText, response.Text)
 		}
 
 		agentSegmentID := fmt.Sprintf("%s:agent-text", step.TurnID)
@@ -359,6 +363,10 @@ func (s *Simulator) Run(agent Agent) (Result, error) {
 		return Result{}, err
 	}
 
+	return s.buildResult(segments, events)
+}
+
+func (s *Simulator) buildResult(segments []multimodaltrace.Segment, events []runevents.Envelope) (Result, error) {
 	trace := multimodaltrace.Trace{
 		TraceID:       s.script.TraceID,
 		SchemaVersion: multimodaltrace.SchemaVersionV1,

--- a/backend/internal/voicesim/simulator_test.go
+++ b/backend/internal/voicesim/simulator_test.go
@@ -2,6 +2,7 @@ package voicesim
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -74,7 +75,7 @@ func TestScriptedSimulatorRejectsUnexpectedAgentResponse(t *testing.T) {
 	script := loadTestScript(t, "testdata/support_billing_script.json")
 	simulator := newTestSimulator(t, script)
 
-	_, err := simulator.Run(fakeAgent{
+	result, err := simulator.Run(fakeAgent{
 		"turn-001": {
 			Text:      "I cannot help with that.",
 			Language:  "en-US",
@@ -83,6 +84,33 @@ func TestScriptedSimulatorRejectsUnexpectedAgentResponse(t *testing.T) {
 	})
 	if !errors.Is(err, ErrUnexpectedAgentResponse) {
 		t.Fatalf("Run error = %v, want ErrUnexpectedAgentResponse", err)
+	}
+	assertEventTypes(t, result.Events, []runevents.Type{
+		runevents.EventTypeMediaSessionStarted,
+		runevents.EventTypeTranscriptFinal,
+		runevents.EventTypeSystemRunFailed,
+	})
+	if result.Trace.Segments[0].Text.Text != "I was charged twice for my last invoice." {
+		t.Fatalf("failure result user text = %q", result.Trace.Segments[0].Text.Text)
+	}
+	wantFailureTime := time.Date(2026, 5, 13, 10, 0, 2, 200_000_000, time.UTC)
+	failureEvent := result.Events[2]
+	if !failureEvent.OccurredAt.Equal(wantFailureTime) {
+		t.Fatalf("failure occurred_at = %s, want %s", failureEvent.OccurredAt, wantFailureTime)
+	}
+	var payload struct {
+		TurnID   string `json:"turn_id"`
+		Expected string `json:"expected"`
+		Actual   string `json:"actual"`
+	}
+	if err := json.Unmarshal(failureEvent.Payload, &payload); err != nil {
+		t.Fatalf("decode failure payload: %v", err)
+	}
+	if payload.TurnID != "turn-001" || payload.Expected != "I found the duplicate charge and created refund rf_123." || payload.Actual != "I cannot help with that." {
+		t.Fatalf("failure payload = %+v", payload)
+	}
+	if !bytes.Contains(result.EventsJSON, []byte(`"event_type": "system.run.failed"`)) {
+		t.Fatalf("EventsJSON missing system.run.failed:\n%s", result.EventsJSON)
 	}
 }
 

--- a/backend/internal/voicesim/simulator_test.go
+++ b/backend/internal/voicesim/simulator_test.go
@@ -1,0 +1,214 @@
+package voicesim
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/multimodaltrace"
+	"github.com/agentclash/agentclash/backend/internal/runevents"
+)
+
+func TestScriptedSimulatorHappyPathBillingScenario(t *testing.T) {
+	script := loadTestScript(t, "testdata/support_billing_script.json")
+	result := runTestScript(t, script, fakeAgent{
+		"turn-001": {
+			Text:      "I found the duplicate charge and created refund rf_123.",
+			Language:  "en-US",
+			LatencyMS: 1200,
+		},
+	})
+
+	if err := result.Trace.Validate(); err != nil {
+		t.Fatalf("trace validation failed: %v", err)
+	}
+	assertSegmentKinds(t, result.Trace.Segments, []multimodaltrace.SegmentKind{
+		multimodaltrace.SegmentKindTextInput,
+		multimodaltrace.SegmentKindTextOutput,
+		multimodaltrace.SegmentKindTimingMarker,
+	})
+	assertEventTypes(t, result.Events, []runevents.Type{
+		runevents.EventTypeMediaSessionStarted,
+		runevents.EventTypeTranscriptFinal,
+		runevents.EventTypeVoiceMetricRecorded,
+		runevents.EventTypeTurnCompleted,
+		runevents.EventTypeSystemRunCompleted,
+	})
+	if result.Trace.Segments[0].Text.Text != "I was charged twice for my last invoice." {
+		t.Fatalf("user text = %q", result.Trace.Segments[0].Text.Text)
+	}
+	if result.Trace.Segments[1].Text.Text != "I found the duplicate charge and created refund rf_123." {
+		t.Fatalf("agent text = %q", result.Trace.Segments[1].Text.Text)
+	}
+	if result.Trace.Segments[2].TimingMarker.ValueMS != 1200 {
+		t.Fatalf("latency marker = %d, want 1200", result.Trace.Segments[2].TimingMarker.ValueMS)
+	}
+	for idx, event := range result.Events {
+		if event.SequenceNumber != int64(idx+1) {
+			t.Fatalf("event[%d] sequence = %d, want %d", idx, event.SequenceNumber, idx+1)
+		}
+		if err := event.ValidatePersisted(); err != nil {
+			t.Fatalf("event[%d] validation failed: %v", idx, err)
+		}
+	}
+}
+
+func TestScriptedSimulatorRejectsMaxTurnOverflow(t *testing.T) {
+	script := loadTestScript(t, "testdata/support_billing_script.json")
+	script.MaxTurns = 1
+	script.Steps = append(script.Steps, Step{
+		TurnID:             "turn-002",
+		UserText:           "Thanks.",
+		Language:           "en-US",
+		OccurredAtOffsetMS: 5000,
+		ExpectedAgentText:  "You're welcome.",
+	})
+
+	if _, err := New(script); !errors.Is(err, ErrMaxTurnsExceeded) {
+		t.Fatalf("New error = %v, want ErrMaxTurnsExceeded", err)
+	}
+}
+
+func TestScriptedSimulatorRejectsUnexpectedAgentResponse(t *testing.T) {
+	script := loadTestScript(t, "testdata/support_billing_script.json")
+	simulator := newTestSimulator(t, script)
+
+	_, err := simulator.Run(fakeAgent{
+		"turn-001": {
+			Text:      "I cannot help with that.",
+			Language:  "en-US",
+			LatencyMS: 1200,
+		},
+	})
+	if !errors.Is(err, ErrUnexpectedAgentResponse) {
+		t.Fatalf("Run error = %v, want ErrUnexpectedAgentResponse", err)
+	}
+}
+
+func TestScriptedSimulatorEmitsScriptedInterruption(t *testing.T) {
+	script := loadTestScript(t, "testdata/interruption_script.json")
+	result := runTestScript(t, script, fakeAgent{
+		"turn-001": {
+			Text:      "Sure, tell me the invoice date.",
+			Language:  "en-US",
+			LatencyMS: 900,
+		},
+	})
+
+	assertSegmentKinds(t, result.Trace.Segments, []multimodaltrace.SegmentKind{
+		multimodaltrace.SegmentKindTextInput,
+		multimodaltrace.SegmentKindTextOutput,
+		multimodaltrace.SegmentKindTimingMarker,
+		multimodaltrace.SegmentKindMediaControl,
+	})
+	control := result.Trace.Segments[3].MediaControl
+	if control == nil {
+		t.Fatalf("media control segment missing payload")
+	}
+	if control.Action != "barge_in_detected" {
+		t.Fatalf("media control action = %q, want barge_in_detected", control.Action)
+	}
+	if control.TargetSegmentID != "turn-001:agent-text" {
+		t.Fatalf("media control target = %q, want agent text segment", control.TargetSegmentID)
+	}
+	assertEventTypes(t, result.Events, []runevents.Type{
+		runevents.EventTypeMediaSessionStarted,
+		runevents.EventTypeTranscriptFinal,
+		runevents.EventTypeVoiceMetricRecorded,
+		runevents.EventTypeTurnCompleted,
+		runevents.EventTypeBargeInDetected,
+		runevents.EventTypeAudioBufferCleared,
+		runevents.EventTypeSystemRunCompleted,
+	})
+}
+
+func TestScriptedSimulatorUsesStableFakeClockTimestamps(t *testing.T) {
+	script := loadTestScript(t, "testdata/support_billing_script.json")
+	agent := fakeAgent{
+		"turn-001": {
+			Text:      "I found the duplicate charge and created refund rf_123.",
+			Language:  "en-US",
+			LatencyMS: 1200,
+		},
+	}
+
+	first := runTestScript(t, script, agent)
+	second := runTestScript(t, script, agent)
+	if !bytes.Equal(first.TraceJSON, second.TraceJSON) {
+		t.Fatalf("trace JSON mismatch\nfirst:\n%s\nsecond:\n%s", first.TraceJSON, second.TraceJSON)
+	}
+	if !bytes.Equal(first.EventsJSON, second.EventsJSON) {
+		t.Fatalf("event JSON mismatch\nfirst:\n%s\nsecond:\n%s", first.EventsJSON, second.EventsJSON)
+	}
+
+	wantUserTime := time.Date(2026, 5, 13, 10, 0, 1, 0, time.UTC)
+	if !first.Trace.Segments[0].OccurredAt.Equal(wantUserTime) {
+		t.Fatalf("user occurred_at = %s, want %s", first.Trace.Segments[0].OccurredAt, wantUserTime)
+	}
+	wantAgentTime := time.Date(2026, 5, 13, 10, 0, 2, 200_000_000, time.UTC)
+	if !first.Trace.Segments[1].OccurredAt.Equal(wantAgentTime) {
+		t.Fatalf("agent occurred_at = %s, want %s", first.Trace.Segments[1].OccurredAt, wantAgentTime)
+	}
+}
+
+type fakeAgent map[string]AgentResponse
+
+func (a fakeAgent) Respond(step Step) (AgentResponse, error) {
+	response, ok := a[step.TurnID]
+	if !ok {
+		return AgentResponse{}, errors.New("missing fake response")
+	}
+	return response, nil
+}
+
+func loadTestScript(t *testing.T, path string) Script {
+	t.Helper()
+	script, err := LoadScript(path)
+	if err != nil {
+		t.Fatalf("LoadScript(%s) returned error: %v", path, err)
+	}
+	return script
+}
+
+func newTestSimulator(t *testing.T, script Script) *Simulator {
+	t.Helper()
+	simulator, err := New(script)
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	return simulator
+}
+
+func runTestScript(t *testing.T, script Script, agent Agent) Result {
+	t.Helper()
+	result, err := newTestSimulator(t, script).Run(agent)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	return result
+}
+
+func assertSegmentKinds(t *testing.T, segments []multimodaltrace.Segment, want []multimodaltrace.SegmentKind) {
+	t.Helper()
+	if len(segments) != len(want) {
+		t.Fatalf("segment count = %d, want %d", len(segments), len(want))
+	}
+	for idx, kind := range want {
+		if segments[idx].Kind != kind {
+			t.Fatalf("segments[%d].Kind = %q, want %q", idx, segments[idx].Kind, kind)
+		}
+	}
+}
+
+func assertEventTypes(t *testing.T, events []runevents.Envelope, want []runevents.Type) {
+	t.Helper()
+	if len(events) != len(want) {
+		t.Fatalf("event count = %d, want %d", len(events), len(want))
+	}
+	for idx, eventType := range want {
+		if events[idx].EventType != eventType {
+			t.Fatalf("events[%d].EventType = %q, want %q", idx, events[idx].EventType, eventType)
+		}
+	}
+}

--- a/backend/internal/voicesim/simulator_test.go
+++ b/backend/internal/voicesim/simulator_test.go
@@ -86,6 +86,39 @@ func TestScriptedSimulatorRejectsUnexpectedAgentResponse(t *testing.T) {
 	}
 }
 
+func TestScriptedSimulatorRejectsDuplicateTurnID(t *testing.T) {
+	script := loadTestScript(t, "testdata/support_billing_script.json")
+	script.MaxTurns = 2
+	script.Steps = append(script.Steps, Step{
+		TurnID:             "turn-001",
+		UserText:           "Thanks.",
+		Language:           "en-US",
+		OccurredAtOffsetMS: 5000,
+		ExpectedAgentText:  "You're welcome.",
+	})
+
+	if _, err := New(script); err == nil || !errors.Is(err, ErrInvalidScript) {
+		t.Fatalf("New error = %v, want ErrInvalidScript for duplicate turn_id", err)
+	}
+}
+
+func TestScriptedSimulatorRejectsInterruptionBeforeAgentResponse(t *testing.T) {
+	script := loadTestScript(t, "testdata/interruption_script.json")
+	script.Steps[0].Interruption.OccurredAtOffsetMS = 1500
+	simulator := newTestSimulator(t, script)
+
+	_, err := simulator.Run(fakeAgent{
+		"turn-001": {
+			Text:      "Sure, tell me the invoice date.",
+			Language:  "en-US",
+			LatencyMS: 900,
+		},
+	})
+	if err == nil || !errors.Is(err, ErrInvalidScript) {
+		t.Fatalf("Run error = %v, want ErrInvalidScript for interruption before agent response", err)
+	}
+}
+
 func TestScriptedSimulatorEmitsScriptedInterruption(t *testing.T) {
 	script := loadTestScript(t, "testdata/interruption_script.json")
 	result := runTestScript(t, script, fakeAgent{

--- a/backend/internal/voicesim/testdata/interruption_script.json
+++ b/backend/internal/voicesim/testdata/interruption_script.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "2026-05-13",
+  "trace_id": "trace-support-billing-scripted-interruption",
+  "run_id": "33333333-3333-3333-3333-333333333333",
+  "run_agent_id": "44444444-4444-4444-4444-444444444444",
+  "scenario_key": "support_billing_duplicate_charge",
+  "max_turns": 1,
+  "base_time": "2026-05-13T10:00:00Z",
+  "steps": [
+    {
+      "turn_id": "turn-001",
+      "user_text": "Wait, I need to clarify the invoice date.",
+      "language": "en-US",
+      "occurred_at_offset_ms": 1000,
+      "expected_agent_text": "Sure, tell me the invoice date.",
+      "max_response_latency_ms": 3000,
+      "interruption": {
+        "occurred_at_offset_ms": 2500,
+        "clear_buffer": true
+      }
+    }
+  ]
+}

--- a/backend/internal/voicesim/testdata/support_billing_script.json
+++ b/backend/internal/voicesim/testdata/support_billing_script.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "2026-05-13",
+  "trace_id": "trace-support-billing-scripted-sim",
+  "run_id": "33333333-3333-3333-3333-333333333333",
+  "run_agent_id": "44444444-4444-4444-4444-444444444444",
+  "scenario_key": "support_billing_duplicate_charge",
+  "max_turns": 2,
+  "base_time": "2026-05-13T10:00:00Z",
+  "steps": [
+    {
+      "turn_id": "turn-001",
+      "user_text": "I was charged twice for my last invoice.",
+      "language": "en-US",
+      "occurred_at_offset_ms": 1000,
+      "expected_agent_text": "I found the duplicate charge and created refund rf_123.",
+      "max_response_latency_ms": 3000
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #760. Parent: #754.

- Add `backend/internal/voicesim`, a deterministic scripted user simulator for voice evals.
- Load fixed JSON scripts with run/agent IDs, max turns, base time, expected response checkpoints, and optional interruption markers.
- Emit multimodal trace segments for text input/output, latency timing markers, and optional interruption media controls.
- Emit persisted canonical voice events for session start, transcript final, voice metrics, turn completion, barge-in/buffer-clear, and terminal completion/failure.
- Add fixture-driven tests with a fake agent only; no LLM, provider, network, STT/TTS, or telephony dependency.
- Address Greptile follow-up by rejecting duplicate turn IDs, timestamping mismatch failures at agent response time, and rejecting interruptions that occur before the agent has responded.

## Test Contract

```markdown
# codex/voice-scripted-simulator - Test Contract

## Functional Behavior
- Define a deterministic scripted user simulator that runs without an LLM or provider.
- Simulator reads fixed scenario steps from JSON fixtures.
- Simulator emits a multimodal trace with text input, text output, timing markers, and optional interruption media-control segments.
- Simulator emits canonical voice events for session start, transcript final, turn completion, optional barge-in, optional buffer clear, voice metric, and terminal completion/failure.
- Simulator enforces `max_turns`.
- Simulator validates expected agent response checkpoints and fails deterministically when the agent deviates.
- Simulator uses a fake clock/base time so timestamps are byte-stable.

## Unit Tests
- `TestScriptedSimulatorHappyPathBillingScenario` - runs the billing script with a fake agent and validates deterministic trace/events.
- `TestScriptedSimulatorRejectsMaxTurnOverflow` - fails clearly when script steps exceed max turns.
- `TestScriptedSimulatorRejectsUnexpectedAgentResponse` - fails clearly when agent text does not match the checkpoint.
- `TestScriptedSimulatorRejectsDuplicateTurnID` - rejects duplicate turn IDs at script validation time.
- `TestScriptedSimulatorRejectsInterruptionBeforeAgentResponse` - rejects interruption timing that would make trace timestamps regress.
- `TestScriptedSimulatorEmitsScriptedInterruption` - emits deterministic interruption trace segment and canonical events.
- `TestScriptedSimulatorUsesStableFakeClockTimestamps` - running the same script twice yields identical timestamps/output.

## Integration / Functional Tests
- `go test ./internal/voicesim ./internal/voicefixtures ./internal/multimodaltrace ./internal/runevents`

## Smoke Tests
- `go test ./internal/voicesim`
- `go test ./...`

## E2E Tests
N/A - this slice introduces the simulator contract only, not full execution mode wiring.

## Manual / cURL Tests
N/A - no HTTP or CLI surface is added in this slice.
```

## Review Checkpoint

```json
{
  "branch": "codex/voice-scripted-simulator",
  "test_contract": "/tmp/codex-voice-scripted-simulator-test-contract.md",
  "created_at": "2026-05-13T12:24:00Z",
  "steps": [
    {
      "step_number": 1,
      "title": "Implement deterministic scripted voice simulator",
      "timestamp": "2026-05-13T12:25:50Z",
      "files_changed": [
        "backend/internal/voicesim/simulator.go",
        "backend/internal/voicesim/simulator_test.go",
        "backend/internal/voicesim/testdata/support_billing_script.json",
        "backend/internal/voicesim/testdata/interruption_script.json"
      ],
      "what_changed": "Added a JSON-driven scripted simulator with fake-agent boundary, deterministic base-time offsets, text-only multimodal trace emission, canonical voice event emission, expected response checkpoints, max-turn validation, latency markers, and scripted interruption support.",
      "review_instructions": "Verify the simulator runs without LLM/provider/network dependencies, loads fixture scripts, emits valid multimodal traces and persisted canonical events, enforces max_turns, fails clearly on response mismatch, emits interruption markers/events, and produces byte-stable JSON across repeated runs.",
      "review_result": {
        "status": "pass",
        "issues_found": [],
        "notes": "Self-review found the implementation matches #760. go test ./internal/voicesim and the neighboring voice package set passed."
      },
      "cumulative_review": {
        "previous_steps_still_valid": true,
        "integration_issues": [],
        "notes": "This builds on the merged trace and canonical voice event contracts without changing their existing behavior."
      }
    },
    {
      "step_number": "final",
      "title": "Final review against test contract",
      "timestamp": "2026-05-13T12:26:26Z",
      "test_contract_review": {
        "functional_behavior": "pass - simulator loads JSON scripts, uses deterministic base-time offsets, emits multimodal trace segments and canonical voice events, enforces max turns, checks expected agent text, records latency markers, and emits scripted interruption markers/events.",
        "unit_tests": "pass - added tests for happy-path billing, max-turn overflow, unexpected agent response, scripted interruption, and stable fake-clock output.",
        "integration_tests": "pass - go test ./internal/voicesim ./internal/voicefixtures ./internal/multimodaltrace ./internal/runevents passed.",
        "smoke_tests": "pass - go test ./internal/voicesim and go test ./... passed.",
        "e2e_tests": "N/A - text-sim execution wiring is a later issue.",
        "manual_tests": "N/A - no HTTP or CLI surface is added."
      },
      "overall_verdict": "ready",
      "blocking_issues": []
    }
  ]
}
```

## Verification

- `go test ./internal/voicesim`
- `go test ./internal/voicesim ./internal/voicefixtures ./internal/multimodaltrace ./internal/runevents`
- `go test ./...`

## Greptile Follow-Up

- Duplicate `turn_id` values now fail script validation before they can produce duplicate segment IDs.
- Unexpected-response failure events now use the agent response timestamp.
- Scripted interruptions must occur after the agent response timestamp, preventing sequence/time regressions in traces.

## Review Follow-Up

- Unexpected agent-response mismatches now return the partial deterministic `Result` alongside `ErrUnexpectedAgentResponse`, so callers can observe the terminal `system.run.failed` event.
- `TestScriptedSimulatorRejectsUnexpectedAgentResponse` now verifies the failure event type, fake-clock timestamp, payload, and serialized `EventsJSON`.

```json
{
  "branch": "codex/voice-scripted-simulator",
  "test_contract": "/tmp/codex-voice-scripted-simulator-test-contract.md",
  "updated_at": "2026-05-13T18:12:00+05:30",
  "steps": [
    {
      "step_number": 3,
      "title": "Expose terminal failure event on checkpoint mismatch",
      "timestamp": "2026-05-13T18:12:00+05:30",
      "files_changed": [
        "backend/internal/voicesim/simulator.go",
        "backend/internal/voicesim/simulator_test.go"
      ],
      "what_changed": "Unexpected-response failures now return the partial deterministic Result containing the user trace segment, transcript event, and terminal system.run.failed event. The mismatch test now verifies the failure event type, timestamp, payload, and serialized event JSON.",
      "review_instructions": "Verify Run still returns ErrUnexpectedAgentResponse, but the returned Result exposes the canonical system.run.failed event at user turn time plus fake agent latency.",
      "review_result": {
        "status": "pass",
        "issues_found": [],
        "notes": "Failure event is now observable through the public Run API and deterministically testable."
      },
      "cumulative_review": {
        "previous_steps_still_valid": true,
        "integration_issues": [],
        "notes": "Successful runs still use the same result serialization helper; hard validation/runtime failures still return empty results."
      }
    },
    {
      "step_number": "final",
      "title": "Final review against test contract",
      "timestamp": "2026-05-13T18:14:00+05:30",
      "test_contract_review": {
        "functional_behavior": "pass - unexpected agent responses still return ErrUnexpectedAgentResponse and now expose the terminal system.run.failed event through Result.Events and Result.EventsJSON",
        "unit_tests": "pass - TestScriptedSimulatorRejectsUnexpectedAgentResponse now verifies event type, fake-clock timestamp, payload, and serialized JSON",
        "integration_tests": "pass - neighboring voice package tests passed",
        "smoke_tests": "pass - full backend go test ./... passed",
        "e2e_tests": "N/A - no E2E required for this backend package slice",
        "manual_tests": "N/A - deterministic unit coverage is the review surface"
      },
      "overall_verdict": "ready",
      "blocking_issues": []
    }
  ]
}
```
