### PR TITLE
feat(voice-evals): add fake voice deployment harness

### DIFF
--- a/backend/internal/voicedeployment/fake.go
+++ b/backend/internal/voicedeployment/fake.go
@@ -13,9 +13,10 @@ import (
 )
 
 var (
-	ErrInvalidScript   = errors.New("invalid fake voice deployment script")
-	ErrTurnNotFound    = errors.New("fake voice deployment turn not found")
-	ErrUnexpectedInput = errors.New("unexpected fake voice deployment input")
+	ErrInvalidScript     = errors.New("invalid fake voice deployment script")
+	ErrInvalidInvocation = errors.New("invalid fake voice deployment invocation")
+	ErrTurnNotFound      = errors.New("fake voice deployment turn not found")
+	ErrUnexpectedInput   = errors.New("unexpected fake voice deployment input")
 )
 
 type Deployment interface {
@@ -253,13 +254,13 @@ func (d *FakeDeployment) Invoke(ctx context.Context, input Invocation) (Result, 
 		return Result{}, err
 	}
 	if strings.TrimSpace(input.TraceID) == "" {
-		return Result{}, fmt.Errorf("%w: trace_id is required", ErrInvalidScript)
+		return Result{}, fmt.Errorf("%w: trace_id is required", ErrInvalidInvocation)
 	}
 	if input.RunID == uuid.Nil {
-		return Result{}, fmt.Errorf("%w: run_id is required", ErrInvalidScript)
+		return Result{}, fmt.Errorf("%w: run_id is required", ErrInvalidInvocation)
 	}
 	if input.RunAgentID == uuid.Nil {
-		return Result{}, fmt.Errorf("%w: run_agent_id is required", ErrInvalidScript)
+		return Result{}, fmt.Errorf("%w: run_agent_id is required", ErrInvalidInvocation)
 	}
 	turn, ok := d.turns[input.TurnID]
 	if !ok {
@@ -404,7 +405,7 @@ func validateInputSegments(segments []multimodaltrace.Segment) error {
 		Segments:      segments,
 	}
 	if err := trace.Validate(); err != nil {
-		return fmt.Errorf("%w: input_segments: %w", ErrInvalidScript, err)
+		return fmt.Errorf("%w: input_segments: %w", ErrInvalidInvocation, err)
 	}
 	return nil
 }

--- a/backend/internal/voicedeployment/fake.go
+++ b/backend/internal/voicedeployment/fake.go
@@ -1,0 +1,467 @@
+package voicedeployment
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/multimodaltrace"
+	"github.com/google/uuid"
+)
+
+var (
+	ErrInvalidScript   = errors.New("invalid fake voice deployment script")
+	ErrTurnNotFound    = errors.New("fake voice deployment turn not found")
+	ErrUnexpectedInput = errors.New("unexpected fake voice deployment input")
+)
+
+type Deployment interface {
+	Invoke(context.Context, Invocation) (Result, error)
+}
+
+type Invocation struct {
+	TraceID       string
+	RunID         uuid.UUID
+	RunAgentID    uuid.UUID
+	TurnID        string
+	InputSegments []multimodaltrace.Segment
+}
+
+type Result struct {
+	Outcome  Outcome
+	Segments []multimodaltrace.Segment
+}
+
+type Outcome string
+
+const (
+	OutcomePass Outcome = "pass"
+	OutcomeFail Outcome = "fail"
+)
+
+type Script struct {
+	ScenarioKey string `json:"scenario_key"`
+	Turns       []Turn `json:"turns"`
+}
+
+type Turn struct {
+	TurnID            string         `json:"turn_id"`
+	ExpectedInputText string         `json:"expected_input_text"`
+	Outcome           Outcome        `json:"outcome,omitempty"`
+	Response          ResponseScript `json:"response"`
+}
+
+type ResponseScript struct {
+	TextResponse        *TextResponse        `json:"text_response,omitempty"`
+	TranscriptResponse  *TranscriptResponse  `json:"transcript_response,omitempty"`
+	StructuredOutput    *StructuredOutput    `json:"structured_output,omitempty"`
+	ExpectedToolCall    *ExpectedToolCall    `json:"expected_tool_call,omitempty"`
+	SpokenAudioArtifact *SpokenAudioArtifact `json:"spoken_audio_artifact,omitempty"`
+	TimingMarkers       []TimingMarker       `json:"timing_markers,omitempty"`
+}
+
+type TextResponse struct {
+	Text      string `json:"text"`
+	Language  string `json:"language,omitempty"`
+	OffsetMS  int64  `json:"offset_ms"`
+	SegmentID string `json:"segment_id,omitempty"`
+}
+
+type TranscriptResponse struct {
+	Text       string   `json:"text"`
+	Language   string   `json:"language,omitempty"`
+	Confidence *float64 `json:"confidence,omitempty"`
+	OffsetMS   int64    `json:"offset_ms"`
+	SegmentID  string   `json:"segment_id,omitempty"`
+}
+
+type StructuredOutput struct {
+	SchemaRef string          `json:"schema_ref,omitempty"`
+	Output    json.RawMessage `json:"output"`
+	OffsetMS  int64           `json:"offset_ms"`
+	SegmentID string          `json:"segment_id,omitempty"`
+}
+
+type ExpectedToolCall struct {
+	CallID    string          `json:"call_id"`
+	ToolName  string          `json:"tool_name"`
+	Arguments json.RawMessage `json:"arguments"`
+	OffsetMS  int64           `json:"offset_ms"`
+	SegmentID string          `json:"segment_id,omitempty"`
+}
+
+type SpokenAudioArtifact struct {
+	ArtifactRef string `json:"artifact_ref"`
+	Format      string `json:"format"`
+	Channel     string `json:"channel,omitempty"`
+	DurationMS  int64  `json:"duration_ms,omitempty"`
+	OffsetMS    int64  `json:"offset_ms"`
+	SegmentID   string `json:"segment_id,omitempty"`
+}
+
+type TimingMarker struct {
+	Key       string `json:"key"`
+	ValueMS   int64  `json:"value_ms"`
+	OffsetMS  int64  `json:"offset_ms"`
+	SegmentID string `json:"segment_id,omitempty"`
+}
+
+type FakeDeployment struct {
+	turns map[string]Turn
+}
+
+func NewFake(script Script) (*FakeDeployment, error) {
+	if err := script.Validate(); err != nil {
+		return nil, err
+	}
+	turns := make(map[string]Turn, len(script.Turns))
+	for _, turn := range script.Turns {
+		turns[turn.TurnID] = turn
+	}
+	return &FakeDeployment{turns: turns}, nil
+}
+
+func (s Script) Validate() error {
+	if strings.TrimSpace(s.ScenarioKey) == "" {
+		return fmt.Errorf("%w: scenario_key is required", ErrInvalidScript)
+	}
+	if len(s.Turns) == 0 {
+		return fmt.Errorf("%w: turns must contain at least one turn", ErrInvalidScript)
+	}
+	seen := make(map[string]struct{}, len(s.Turns))
+	for idx, turn := range s.Turns {
+		if err := turn.Validate(); err != nil {
+			return fmt.Errorf("turns[%d]: %w", idx, err)
+		}
+		if _, ok := seen[turn.TurnID]; ok {
+			return fmt.Errorf("turns[%d]: %w: duplicate turn_id %q", idx, ErrInvalidScript, turn.TurnID)
+		}
+		seen[turn.TurnID] = struct{}{}
+	}
+	return nil
+}
+
+func (t Turn) Validate() error {
+	if strings.TrimSpace(t.TurnID) == "" {
+		return fmt.Errorf("%w: turn_id is required", ErrInvalidScript)
+	}
+	if strings.TrimSpace(t.ExpectedInputText) == "" {
+		return fmt.Errorf("%w: expected_input_text is required", ErrInvalidScript)
+	}
+	if t.Outcome != "" && t.Outcome != OutcomePass && t.Outcome != OutcomeFail {
+		return fmt.Errorf("%w: unsupported outcome %q", ErrInvalidScript, t.Outcome)
+	}
+	if err := t.Response.Validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r ResponseScript) Validate() error {
+	count := 0
+	previousOffset := int64(-1)
+	validateOffset := func(label string, offsetMS int64) error {
+		if offsetMS < 0 {
+			return fmt.Errorf("%w: %s.offset_ms must be non-negative", ErrInvalidScript, label)
+		}
+		if offsetMS < previousOffset {
+			return fmt.Errorf("%w: %s.offset_ms must not go backward", ErrInvalidScript, label)
+		}
+		previousOffset = offsetMS
+		return nil
+	}
+	if r.ExpectedToolCall != nil {
+		count++
+		if strings.TrimSpace(r.ExpectedToolCall.CallID) == "" {
+			return fmt.Errorf("%w: expected_tool_call.call_id is required", ErrInvalidScript)
+		}
+		if strings.TrimSpace(r.ExpectedToolCall.ToolName) == "" {
+			return fmt.Errorf("%w: expected_tool_call.tool_name is required", ErrInvalidScript)
+		}
+		if len(r.ExpectedToolCall.Arguments) == 0 || !json.Valid(r.ExpectedToolCall.Arguments) {
+			return fmt.Errorf("%w: expected_tool_call.arguments must be valid JSON", ErrInvalidScript)
+		}
+		if err := validateOffset("expected_tool_call", r.ExpectedToolCall.OffsetMS); err != nil {
+			return err
+		}
+	}
+	if r.TextResponse != nil {
+		count++
+		if strings.TrimSpace(r.TextResponse.Text) == "" {
+			return fmt.Errorf("%w: text_response.text is required", ErrInvalidScript)
+		}
+		if err := validateOffset("text_response", r.TextResponse.OffsetMS); err != nil {
+			return err
+		}
+	}
+	if r.SpokenAudioArtifact != nil {
+		count++
+		if strings.TrimSpace(r.SpokenAudioArtifact.ArtifactRef) == "" {
+			return fmt.Errorf("%w: spoken_audio_artifact.artifact_ref is required", ErrInvalidScript)
+		}
+		if strings.TrimSpace(r.SpokenAudioArtifact.Format) == "" {
+			return fmt.Errorf("%w: spoken_audio_artifact.format is required", ErrInvalidScript)
+		}
+		if r.SpokenAudioArtifact.DurationMS < 0 {
+			return fmt.Errorf("%w: spoken_audio_artifact.duration_ms must be non-negative", ErrInvalidScript)
+		}
+		if err := validateOffset("spoken_audio_artifact", r.SpokenAudioArtifact.OffsetMS); err != nil {
+			return err
+		}
+	}
+	if r.TranscriptResponse != nil {
+		count++
+		if strings.TrimSpace(r.TranscriptResponse.Text) == "" {
+			return fmt.Errorf("%w: transcript_response.text is required", ErrInvalidScript)
+		}
+		if err := validateOffset("transcript_response", r.TranscriptResponse.OffsetMS); err != nil {
+			return err
+		}
+	}
+	if r.StructuredOutput != nil {
+		count++
+		if len(r.StructuredOutput.Output) == 0 || !json.Valid(r.StructuredOutput.Output) {
+			return fmt.Errorf("%w: structured_output.output must be valid JSON", ErrInvalidScript)
+		}
+		if err := validateOffset("structured_output", r.StructuredOutput.OffsetMS); err != nil {
+			return err
+		}
+	}
+	for idx, marker := range r.TimingMarkers {
+		count++
+		if strings.TrimSpace(marker.Key) == "" {
+			return fmt.Errorf("%w: timing_markers[%d].key is required", ErrInvalidScript, idx)
+		}
+		if marker.ValueMS < 0 {
+			return fmt.Errorf("%w: timing_markers[%d].value_ms must be non-negative", ErrInvalidScript, idx)
+		}
+		if err := validateOffset(fmt.Sprintf("timing_markers[%d]", idx), marker.OffsetMS); err != nil {
+			return err
+		}
+	}
+	if count == 0 {
+		return fmt.Errorf("%w: response must contain at least one scripted segment", ErrInvalidScript)
+	}
+	return nil
+}
+
+func (d *FakeDeployment) Invoke(ctx context.Context, input Invocation) (Result, error) {
+	if err := ctx.Err(); err != nil {
+		return Result{}, err
+	}
+	if strings.TrimSpace(input.TraceID) == "" {
+		return Result{}, fmt.Errorf("%w: trace_id is required", ErrInvalidScript)
+	}
+	if input.RunID == uuid.Nil {
+		return Result{}, fmt.Errorf("%w: run_id is required", ErrInvalidScript)
+	}
+	if input.RunAgentID == uuid.Nil {
+		return Result{}, fmt.Errorf("%w: run_agent_id is required", ErrInvalidScript)
+	}
+	turn, ok := d.turns[input.TurnID]
+	if !ok {
+		return Result{}, fmt.Errorf("%w: %q", ErrTurnNotFound, input.TurnID)
+	}
+	if err := validateInputSegments(input.InputSegments); err != nil {
+		return Result{}, err
+	}
+	if !inputContainsText(input.InputSegments, turn.ExpectedInputText) {
+		return Result{}, fmt.Errorf("%w: turn_id=%s expected text %q", ErrUnexpectedInput, input.TurnID, turn.ExpectedInputText)
+	}
+
+	outcome := turn.Outcome
+	if outcome == "" {
+		outcome = OutcomePass
+	}
+	segments := make([]multimodaltrace.Segment, 0, 6+len(turn.Response.TimingMarkers))
+	nextSequence := nextSequenceNumber(input.InputSegments)
+	anchor := latestOccurredAt(input.InputSegments)
+	appendSegment := func(segment multimodaltrace.Segment) error {
+		segment.SequenceNumber = nextSequence
+		nextSequence++
+		if err := segment.Validate(); err != nil {
+			return err
+		}
+		segments = append(segments, segment)
+		return nil
+	}
+
+	if call := turn.Response.ExpectedToolCall; call != nil {
+		if err := appendSegment(multimodaltrace.Segment{
+			SegmentID:  firstNonEmpty(call.SegmentID, input.TurnID+":tool-call"),
+			Kind:       multimodaltrace.SegmentKindToolCall,
+			Actor:      multimodaltrace.ActorAgent,
+			OccurredAt: atOffset(anchor, call.OffsetMS),
+			ToolCall: &multimodaltrace.ToolCallPayload{
+				CallID:    call.CallID,
+				ToolName:  call.ToolName,
+				Arguments: normalizeJSON(call.Arguments),
+			},
+		}); err != nil {
+			return Result{}, err
+		}
+	}
+	if text := turn.Response.TextResponse; text != nil {
+		if err := appendSegment(multimodaltrace.Segment{
+			SegmentID:  firstNonEmpty(text.SegmentID, input.TurnID+":agent-text"),
+			Kind:       multimodaltrace.SegmentKindTextOutput,
+			Actor:      multimodaltrace.ActorAgent,
+			OccurredAt: atOffset(anchor, text.OffsetMS),
+			Text: &multimodaltrace.TextPayload{
+				Text:     text.Text,
+				Language: text.Language,
+			},
+		}); err != nil {
+			return Result{}, err
+		}
+	}
+
+	audioSegmentID := ""
+	if audio := turn.Response.SpokenAudioArtifact; audio != nil {
+		audioSegmentID = firstNonEmpty(audio.SegmentID, input.TurnID+":agent-audio")
+		if err := appendSegment(multimodaltrace.Segment{
+			SegmentID:  audioSegmentID,
+			Kind:       multimodaltrace.SegmentKindAudioOutput,
+			Actor:      multimodaltrace.ActorAgent,
+			OccurredAt: atOffset(anchor, audio.OffsetMS),
+			Audio: &multimodaltrace.AudioPayload{
+				ArtifactRef: audio.ArtifactRef,
+				Format:      audio.Format,
+				Channel:     audio.Channel,
+				DurationMS:  audio.DurationMS,
+			},
+		}); err != nil {
+			return Result{}, err
+		}
+	}
+	if transcript := turn.Response.TranscriptResponse; transcript != nil {
+		if err := appendSegment(multimodaltrace.Segment{
+			SegmentID:  firstNonEmpty(transcript.SegmentID, input.TurnID+":agent-transcript"),
+			Kind:       multimodaltrace.SegmentKindTranscriptFinal,
+			Actor:      multimodaltrace.ActorSystem,
+			OccurredAt: atOffset(anchor, transcript.OffsetMS),
+			Transcript: &multimodaltrace.TranscriptPayload{
+				Text:            transcript.Text,
+				Language:        transcript.Language,
+				Confidence:      transcript.Confidence,
+				SourceSegmentID: audioSegmentID,
+			},
+		}); err != nil {
+			return Result{}, err
+		}
+	}
+	if structured := turn.Response.StructuredOutput; structured != nil {
+		if err := appendSegment(multimodaltrace.Segment{
+			SegmentID:  firstNonEmpty(structured.SegmentID, input.TurnID+":structured-output"),
+			Kind:       multimodaltrace.SegmentKindStructuredOutput,
+			Actor:      multimodaltrace.ActorAgent,
+			OccurredAt: atOffset(anchor, structured.OffsetMS),
+			StructuredOutput: &multimodaltrace.StructuredOutputPayload{
+				SchemaRef: structured.SchemaRef,
+				Output:    normalizeJSON(structured.Output),
+			},
+		}); err != nil {
+			return Result{}, err
+		}
+	}
+	for idx, marker := range turn.Response.TimingMarkers {
+		if err := appendSegment(multimodaltrace.Segment{
+			SegmentID:  firstNonEmpty(marker.SegmentID, fmt.Sprintf("%s:timing:%03d", input.TurnID, idx+1)),
+			Kind:       multimodaltrace.SegmentKindTimingMarker,
+			Actor:      multimodaltrace.ActorEvaluator,
+			OccurredAt: atOffset(anchor, marker.OffsetMS),
+			TimingMarker: &multimodaltrace.TimingMarkerPayload{
+				Key:     marker.Key,
+				ValueMS: marker.ValueMS,
+			},
+		}); err != nil {
+			return Result{}, err
+		}
+	}
+
+	trace := multimodaltrace.Trace{
+		TraceID:       input.TraceID,
+		SchemaVersion: multimodaltrace.SchemaVersionV1,
+		RunID:         input.RunID,
+		RunAgentID:    input.RunAgentID,
+		Segments:      append(append([]multimodaltrace.Segment(nil), input.InputSegments...), segments...),
+	}
+	if err := trace.Validate(); err != nil {
+		return Result{}, err
+	}
+	return Result{Outcome: outcome, Segments: segments}, nil
+}
+
+func validateInputSegments(segments []multimodaltrace.Segment) error {
+	trace := multimodaltrace.Trace{
+		TraceID:       "fake-input-validation",
+		SchemaVersion: multimodaltrace.SchemaVersionV1,
+		RunID:         uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+		RunAgentID:    uuid.MustParse("22222222-2222-2222-2222-222222222222"),
+		Segments:      segments,
+	}
+	if err := trace.Validate(); err != nil {
+		return fmt.Errorf("%w: input_segments: %w", ErrInvalidScript, err)
+	}
+	return nil
+}
+
+func inputContainsText(segments []multimodaltrace.Segment, expected string) bool {
+	for _, segment := range segments {
+		if segment.Text != nil && segment.Text.Text == expected {
+			return true
+		}
+		if segment.Transcript != nil && segment.Transcript.Text == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func nextSequenceNumber(segments []multimodaltrace.Segment) int64 {
+	var maxSequence int64
+	for _, segment := range segments {
+		if segment.SequenceNumber > maxSequence {
+			maxSequence = segment.SequenceNumber
+		}
+	}
+	return maxSequence + 1
+}
+
+func latestOccurredAt(segments []multimodaltrace.Segment) time.Time {
+	var latest time.Time
+	for _, segment := range segments {
+		if segment.OccurredAt.After(latest) {
+			latest = segment.OccurredAt
+		}
+	}
+	return latest
+}
+
+func atOffset(anchor time.Time, offsetMS int64) time.Time {
+	return anchor.Add(time.Duration(offsetMS) * time.Millisecond).UTC()
+}
+
+func normalizeJSON(raw json.RawMessage) json.RawMessage {
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return append(json.RawMessage(nil), raw...)
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return append(json.RawMessage(nil), raw...)
+	}
+	return encoded
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/backend/internal/voicedeployment/fake.go
+++ b/backend/internal/voicedeployment/fake.go
@@ -268,7 +268,7 @@ func (d *FakeDeployment) Invoke(ctx context.Context, input Invocation) (Result, 
 	if err := validateInputSegments(input.InputSegments); err != nil {
 		return Result{}, err
 	}
-	if !inputContainsText(input.InputSegments, turn.ExpectedInputText) {
+	if !currentTurnInputMatches(input.InputSegments, input.TurnID, turn.ExpectedInputText) {
 		return Result{}, fmt.Errorf("%w: turn_id=%s expected text %q", ErrUnexpectedInput, input.TurnID, turn.ExpectedInputText)
 	}
 
@@ -409,12 +409,15 @@ func validateInputSegments(segments []multimodaltrace.Segment) error {
 	return nil
 }
 
-func inputContainsText(segments []multimodaltrace.Segment, expected string) bool {
+func currentTurnInputMatches(segments []multimodaltrace.Segment, turnID string, expected string) bool {
 	for _, segment := range segments {
-		if segment.Text != nil && segment.Text.Text == expected {
+		if segment.Actor != multimodaltrace.ActorUser || !strings.HasPrefix(segment.SegmentID, turnID+":") {
+			continue
+		}
+		if segment.Kind == multimodaltrace.SegmentKindTextInput && segment.Text != nil && segment.Text.Text == expected {
 			return true
 		}
-		if segment.Transcript != nil && segment.Transcript.Text == expected {
+		if segment.Kind == multimodaltrace.SegmentKindTranscriptFinal && segment.Transcript != nil && segment.Transcript.Text == expected {
 			return true
 		}
 	}

--- a/backend/internal/voicedeployment/fake_test.go
+++ b/backend/internal/voicedeployment/fake_test.go
@@ -1,0 +1,206 @@
+package voicedeployment
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/multimodaltrace"
+	"github.com/google/uuid"
+)
+
+func TestFakeDeploymentInvokeEmitsScriptedAgentSegments(t *testing.T) {
+	deployment := newTestDeployment(t, OutcomePass)
+	result, err := deployment.Invoke(context.Background(), testInvocation("I was charged twice for my last invoice."))
+	if err != nil {
+		t.Fatalf("Invoke returned error: %v", err)
+	}
+	if result.Outcome != OutcomePass {
+		t.Fatalf("outcome = %q, want pass", result.Outcome)
+	}
+	assertSegmentKinds(t, result.Segments, []multimodaltrace.SegmentKind{
+		multimodaltrace.SegmentKindToolCall,
+		multimodaltrace.SegmentKindTextOutput,
+		multimodaltrace.SegmentKindAudioOutput,
+		multimodaltrace.SegmentKindTranscriptFinal,
+		multimodaltrace.SegmentKindStructuredOutput,
+		multimodaltrace.SegmentKindTimingMarker,
+	})
+
+	toolCall := result.Segments[0].ToolCall
+	if toolCall.ToolName != "refund_api" || toolCall.CallID != "call-refund-001" {
+		t.Fatalf("tool call = %+v", toolCall)
+	}
+	assertJSONEqual(t, "tool call arguments", json.RawMessage(`{"amount_cents":4200,"invoice_id":"inv_123"}`), toolCall.Arguments)
+
+	if got := result.Segments[1].Text.Text; got != "I found the duplicate charge and created refund rf_123." {
+		t.Fatalf("text response = %q", got)
+	}
+	audio := result.Segments[2].Audio
+	if audio.ArtifactRef != "voice://artifacts/agent-turn-001.wav" || audio.Format != "wav" || audio.Channel != "agent" || audio.DurationMS != 2400 {
+		t.Fatalf("audio payload = %+v", audio)
+	}
+	transcript := result.Segments[3].Transcript
+	if transcript.Text != "I found the duplicate charge and created refund rf_123." || transcript.SourceSegmentID != "turn-001:agent-audio" {
+		t.Fatalf("transcript payload = %+v", transcript)
+	}
+	structured := result.Segments[4].StructuredOutput
+	if structured.SchemaRef != "voice://schemas/support_resolution.v1" {
+		t.Fatalf("schema_ref = %q", structured.SchemaRef)
+	}
+	assertJSONEqual(t, "structured output", json.RawMessage(`{"resolution":"refund_created","refund_id":"rf_123"}`), structured.Output)
+	marker := result.Segments[5].TimingMarker
+	if marker.Key != "end_of_user_text_to_first_agent_text" || marker.ValueMS != 1200 {
+		t.Fatalf("timing marker = %+v", marker)
+	}
+	if got, want := result.Segments[0].SequenceNumber, int64(2); got != want {
+		t.Fatalf("first response sequence = %d, want %d", got, want)
+	}
+	wantTime := time.Date(2026, 5, 13, 10, 0, 2, 200_000_000, time.UTC)
+	if !result.Segments[1].OccurredAt.Equal(wantTime) {
+		t.Fatalf("text occurred_at = %s, want %s", result.Segments[1].OccurredAt, wantTime)
+	}
+}
+
+func TestFakeDeploymentRejectsUnexpectedInputText(t *testing.T) {
+	deployment := newTestDeployment(t, OutcomePass)
+	_, err := deployment.Invoke(context.Background(), testInvocation("I want to change my email address."))
+	if !errors.Is(err, ErrUnexpectedInput) {
+		t.Fatalf("Invoke error = %v, want ErrUnexpectedInput", err)
+	}
+}
+
+func TestFakeDeploymentCanProduceFailingTrace(t *testing.T) {
+	deployment := newTestDeployment(t, OutcomeFail)
+	result, err := deployment.Invoke(context.Background(), testInvocation("I was charged twice for my last invoice."))
+	if err != nil {
+		t.Fatalf("Invoke returned error: %v", err)
+	}
+	if result.Outcome != OutcomeFail {
+		t.Fatalf("outcome = %q, want fail", result.Outcome)
+	}
+	if result.Segments[1].Text.Text != "I cannot find a duplicate charge." {
+		t.Fatalf("failing text response = %q", result.Segments[1].Text.Text)
+	}
+	assertJSONEqual(t, "failing structured output", json.RawMessage(`{"resolution":"not_found"}`), result.Segments[4].StructuredOutput.Output)
+}
+
+func TestFakeDeploymentRejectsInvalidScript(t *testing.T) {
+	script := validScript(OutcomePass)
+	script.Turns[0].Response.ExpectedToolCall.Arguments = json.RawMessage(`{bad json`)
+
+	if _, err := NewFake(script); !errors.Is(err, ErrInvalidScript) {
+		t.Fatalf("NewFake error = %v, want ErrInvalidScript", err)
+	}
+}
+
+func newTestDeployment(t *testing.T, outcome Outcome) *FakeDeployment {
+	t.Helper()
+	deployment, err := NewFake(validScript(outcome))
+	if err != nil {
+		t.Fatalf("NewFake returned error: %v", err)
+	}
+	return deployment
+}
+
+func validScript(outcome Outcome) Script {
+	text := "I found the duplicate charge and created refund rf_123."
+	structured := json.RawMessage(`{"refund_id":"rf_123","resolution":"refund_created"}`)
+	if outcome == OutcomeFail {
+		text = "I cannot find a duplicate charge."
+		structured = json.RawMessage(`{"resolution":"not_found"}`)
+	}
+	confidence := 1.0
+	return Script{
+		ScenarioKey: "support_billing_duplicate_charge",
+		Turns: []Turn{
+			{
+				TurnID:            "turn-001",
+				ExpectedInputText: "I was charged twice for my last invoice.",
+				Outcome:           outcome,
+				Response: ResponseScript{
+					ExpectedToolCall: &ExpectedToolCall{
+						CallID:    "call-refund-001",
+						ToolName:  "refund_api",
+						Arguments: json.RawMessage(`{"invoice_id":"inv_123","amount_cents":4200}`),
+						OffsetMS:  700,
+					},
+					TextResponse: &TextResponse{
+						Text:     text,
+						Language: "en-US",
+						OffsetMS: 1200,
+					},
+					SpokenAudioArtifact: &SpokenAudioArtifact{
+						ArtifactRef: "voice://artifacts/agent-turn-001.wav",
+						Format:      "wav",
+						Channel:     "agent",
+						DurationMS:  2400,
+						OffsetMS:    1600,
+					},
+					TranscriptResponse: &TranscriptResponse{
+						Text:       text,
+						Language:   "en-US",
+						Confidence: &confidence,
+						OffsetMS:   1700,
+					},
+					StructuredOutput: &StructuredOutput{
+						SchemaRef: "voice://schemas/support_resolution.v1",
+						Output:    structured,
+						OffsetMS:  1800,
+					},
+					TimingMarkers: []TimingMarker{
+						{
+							Key:      "end_of_user_text_to_first_agent_text",
+							ValueMS:  1200,
+							OffsetMS: 1800,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func testInvocation(text string) Invocation {
+	return Invocation{
+		TraceID:    "trace-support-billing-seed-42",
+		RunID:      uuid.MustParse("33333333-3333-3333-3333-333333333333"),
+		RunAgentID: uuid.MustParse("44444444-4444-4444-4444-444444444444"),
+		TurnID:     "turn-001",
+		InputSegments: []multimodaltrace.Segment{
+			{
+				SegmentID:      "turn-001:user-text",
+				SequenceNumber: 1,
+				Kind:           multimodaltrace.SegmentKindTextInput,
+				Actor:          multimodaltrace.ActorUser,
+				OccurredAt:     time.Date(2026, 5, 13, 10, 0, 1, 0, time.UTC),
+				Text: &multimodaltrace.TextPayload{
+					Text:     text,
+					Language: "en-US",
+				},
+			},
+		},
+	}
+}
+
+func assertSegmentKinds(t *testing.T, segments []multimodaltrace.Segment, want []multimodaltrace.SegmentKind) {
+	t.Helper()
+	if len(segments) != len(want) {
+		t.Fatalf("segment count = %d, want %d", len(segments), len(want))
+	}
+	for idx, kind := range want {
+		if segments[idx].Kind != kind {
+			t.Fatalf("segments[%d].Kind = %q, want %q", idx, segments[idx].Kind, kind)
+		}
+	}
+}
+
+func assertJSONEqual(t *testing.T, label string, want json.RawMessage, got json.RawMessage) {
+	t.Helper()
+	if !bytes.Equal(normalizeJSON(want), normalizeJSON(got)) {
+		t.Fatalf("%s mismatch\nwant: %s\n got: %s", label, normalizeJSON(want), normalizeJSON(got))
+	}
+}

--- a/backend/internal/voicedeployment/fake_test.go
+++ b/backend/internal/voicedeployment/fake_test.go
@@ -142,10 +142,32 @@ func TestFakeDeploymentCanProduceFailingTrace(t *testing.T) {
 	if result.Outcome != OutcomeFail {
 		t.Fatalf("outcome = %q, want fail", result.Outcome)
 	}
+	assertSegmentKinds(t, result.Segments, []multimodaltrace.SegmentKind{
+		multimodaltrace.SegmentKindToolCall,
+		multimodaltrace.SegmentKindTextOutput,
+		multimodaltrace.SegmentKindAudioOutput,
+		multimodaltrace.SegmentKindTranscriptFinal,
+		multimodaltrace.SegmentKindStructuredOutput,
+		multimodaltrace.SegmentKindTimingMarker,
+	})
 	if result.Segments[1].Text.Text != "I cannot find a duplicate charge." {
 		t.Fatalf("failing text response = %q", result.Segments[1].Text.Text)
 	}
 	assertJSONEqual(t, "failing structured output", json.RawMessage(`{"resolution":"not_found"}`), result.Segments[4].StructuredOutput.Output)
+}
+
+func TestFakeDeploymentRejectsInvalidInvocationSeparatelyFromInvalidScript(t *testing.T) {
+	deployment := newTestDeployment(t, OutcomePass)
+	invocation := testInvocation("I was charged twice for my last invoice.")
+	invocation.TraceID = ""
+
+	_, err := deployment.Invoke(context.Background(), invocation)
+	if !errors.Is(err, ErrInvalidInvocation) {
+		t.Fatalf("Invoke error = %v, want ErrInvalidInvocation", err)
+	}
+	if errors.Is(err, ErrInvalidScript) {
+		t.Fatalf("Invoke error = %v, should not match ErrInvalidScript", err)
+	}
 }
 
 func TestFakeDeploymentRejectsInvalidScript(t *testing.T) {

--- a/backend/internal/voicedeployment/fake_test.go
+++ b/backend/internal/voicedeployment/fake_test.go
@@ -73,6 +73,66 @@ func TestFakeDeploymentRejectsUnexpectedInputText(t *testing.T) {
 	}
 }
 
+func TestFakeDeploymentRejectsWrongCurrentTurnEvenWhenPriorSegmentMatches(t *testing.T) {
+	deployment, err := NewFake(Script{
+		ScenarioKey: "support_billing_duplicate_charge",
+		Turns: []Turn{
+			{
+				TurnID:            "turn-002",
+				ExpectedInputText: "Please refund the duplicate invoice.",
+				Response:          minimalResponseScript("Refund created."),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewFake returned error: %v", err)
+	}
+
+	invocation := Invocation{
+		TraceID:    "trace-support-billing-seed-42",
+		RunID:      uuid.MustParse("33333333-3333-3333-3333-333333333333"),
+		RunAgentID: uuid.MustParse("44444444-4444-4444-4444-444444444444"),
+		TurnID:     "turn-002",
+		InputSegments: []multimodaltrace.Segment{
+			{
+				SegmentID:      "turn-001:user-text",
+				SequenceNumber: 1,
+				Kind:           multimodaltrace.SegmentKindTextInput,
+				Actor:          multimodaltrace.ActorUser,
+				OccurredAt:     time.Date(2026, 5, 13, 10, 0, 1, 0, time.UTC),
+				Text: &multimodaltrace.TextPayload{
+					Text: "Please refund the duplicate invoice.",
+				},
+			},
+			{
+				SegmentID:      "turn-001:agent-text",
+				SequenceNumber: 2,
+				Kind:           multimodaltrace.SegmentKindTextOutput,
+				Actor:          multimodaltrace.ActorAgent,
+				OccurredAt:     time.Date(2026, 5, 13, 10, 0, 2, 0, time.UTC),
+				Text: &multimodaltrace.TextPayload{
+					Text: "Please refund the duplicate invoice.",
+				},
+			},
+			{
+				SegmentID:      "turn-002:user-text",
+				SequenceNumber: 3,
+				Kind:           multimodaltrace.SegmentKindTextInput,
+				Actor:          multimodaltrace.ActorUser,
+				OccurredAt:     time.Date(2026, 5, 13, 10, 0, 3, 0, time.UTC),
+				Text: &multimodaltrace.TextPayload{
+					Text: "Actually, I need to change my email.",
+				},
+			},
+		},
+	}
+
+	_, err = deployment.Invoke(context.Background(), invocation)
+	if !errors.Is(err, ErrUnexpectedInput) {
+		t.Fatalf("Invoke error = %v, want ErrUnexpectedInput", err)
+	}
+}
+
 func TestFakeDeploymentCanProduceFailingTrace(t *testing.T) {
 	deployment := newTestDeployment(t, OutcomeFail)
 	result, err := deployment.Invoke(context.Background(), testInvocation("I was charged twice for my last invoice."))
@@ -160,6 +220,16 @@ func validScript(outcome Outcome) Script {
 					},
 				},
 			},
+		},
+	}
+}
+
+func minimalResponseScript(text string) ResponseScript {
+	return ResponseScript{
+		TextResponse: &TextResponse{
+			Text:     text,
+			Language: "en-US",
+			OffsetMS: 1000,
 		},
 	}
 }


### PR DESCRIPTION
## Summary

Implements #761 under parent #754.

Adds a reusable deterministic fake voice-agent deployment harness for later voice executor, scoring, replay, and compare-gate work. The harness consumes prior multimodal trace segments and returns scripted agent segments without calling any real model, tool, TTS, STT, or network endpoint.

## What Changed

- Added `backend/internal/voicedeployment.Deployment` with `Invoke(context.Context, Invocation) (Result, error)`.
- Added `NewFake` scripted deployment implementation.
- Supports scripted agent outputs for:
  - text response
  - transcript response
  - structured output
  - expected tool call
  - fake spoken-audio artifact reference
  - deterministic timing markers
- Validates scripts, input trace segments, required IDs, turn lookup, expected input text, JSON payloads, and monotonic response offsets.
- Supports intentional `pass` and `fail` scripted outcomes while still returning deterministic trace segments.

## Test Contract

# codex/voice-fake-deployment - Test Contract

## Functional Behavior
- A fake voice-agent deployment implements a provider-neutral invocation boundary for later hosted/native deployments.
- Input is a deterministic invocation containing run IDs, trace ID, turn ID, and prior multimodal trace segments.
- The fake deployment never calls a model, tool endpoint, TTS, STT, or network API.
- For a matching turn, it returns scripted agent segments with deterministic sequence numbers and timestamps.
- Supported scripted segment outputs: text response, transcript response, structured output, expected tool call, fake spoken-audio artifact reference, and timing marker.
- The harness can intentionally return passing or failing scripted traces without changing control flow.
- Input mismatches fail clearly and deterministically.

## Unit Tests
- `TestFakeDeploymentInvokeEmitsScriptedAgentSegments` - verifies exact response text, transcript, tool-call arguments, structured output, timing marker, and artifact reference.
- `TestFakeDeploymentRejectsUnexpectedInputText` - verifies an input mismatch returns `ErrUnexpectedInput`.
- `TestFakeDeploymentCanProduceFailingTrace` - verifies a scripted failing outcome returns deterministic segments and marks the result as failing.
- `TestFakeDeploymentRejectsInvalidScript` - verifies malformed scripts are rejected before invocation.

## Integration / Functional Tests
- `go test ./internal/voicedeployment ./internal/multimodaltrace`

## Smoke Tests
- `go test ./internal/voicedeployment`
- `go test ./...`

## E2E Tests
N/A - execution-mode wiring is handled by later voice-eval issues.

## Manual / cURL Tests
N/A - this slice adds a backend package only, with no HTTP/CLI surface.

## Review Checkpoint

```json
{
  "branch": "codex/voice-fake-deployment",
  "test_contract": "/tmp/codex-voice-fake-deployment-test-contract.md",
  "created_at": "2026-05-13T18:25:00+05:30",
  "steps": [
    {
      "step_number": 1,
      "title": "Implement reusable fake voice deployment harness",
      "timestamp": "2026-05-13T18:36:00+05:30",
      "files_changed": [
        "backend/internal/voicedeployment/fake.go",
        "backend/internal/voicedeployment/fake_test.go"
      ],
      "what_changed": "Added a provider-neutral Deployment interface and deterministic fake implementation that consumes prior multimodal trace segments and returns scripted agent segments for tool calls, text output, spoken-audio artifacts, transcripts, structured output, and timing markers. Added tests for exact scripted outputs, unexpected input rejection, intentional failing traces, and invalid script rejection.",
      "review_instructions": "Verify the fake harness has no model/tool/TTS/STT/network side effects, validates scripts before invocation, validates input trace segments, emits response sequence numbers after the input, and uses deterministic timestamps from input segment time plus scripted offsets.",
      "review_result": {
        "status": "pass",
        "issues_found": [],
        "notes": "Self-review found the implementation matches #761 and keeps output offsets monotonic in generation order."
      },
      "cumulative_review": {
        "previous_steps_still_valid": true,
        "integration_issues": [],
        "notes": "The harness builds on the merged multimodal trace contract and does not modify existing voice fixture/simulator behavior."
      }
    },
    {
      "step_number": "final",
      "title": "Final review against test contract",
      "timestamp": "2026-05-13T18:37:00+05:30",
      "test_contract_review": {
        "functional_behavior": "pass - fake deployment implements a deterministic boundary, consumes trace segments, emits scripted agent segments, rejects input mismatch, and supports pass/fail outcomes without external calls",
        "unit_tests": "pass - exact text, transcript, tool-call args, structured output, timing markers, artifact refs, failing output, and invalid script behavior are covered",
        "integration_tests": "pass - go test ./internal/voicedeployment ./internal/multimodaltrace ./internal/voicefixtures ./internal/voicesim passed",
        "smoke_tests": "pass - go test ./internal/voicedeployment and go test ./... passed",
        "e2e_tests": "N/A - execution-mode wiring is a later issue",
        "manual_tests": "N/A - backend package only"
      },
      "overall_verdict": "ready",
      "blocking_issues": []
    }
  ]
}
```

## Verification

- `go test ./internal/voicedeployment`
- `go test ./internal/voicedeployment ./internal/multimodaltrace ./internal/voicefixtures ./internal/voicesim`
- `go test ./...`


## Review Follow-Up

- Scoped expected-input validation to the invoked turn's current user segment.
- Only `ActorUser` `text_input` or `transcript_final` segments whose `segment_id` starts with `turn_id + ":"` can satisfy the expected input.
- Added `TestFakeDeploymentRejectsWrongCurrentTurnEvenWhenPriorSegmentMatches` to prevent false-passing against unrelated prior user/agent text.

```json
{
  "branch": "codex/voice-fake-deployment",
  "test_contract": "/tmp/codex-voice-fake-deployment-test-contract.md",
  "updated_at": "2026-05-13T19:03:00+05:30",
  "steps": [
    {
      "step_number": 2,
      "title": "Scope expected input matching to invoked turn",
      "timestamp": "2026-05-13T19:03:00+05:30",
      "files_changed": [
        "backend/internal/voicedeployment/fake.go",
        "backend/internal/voicedeployment/fake_test.go"
      ],
      "what_changed": "Replaced broad input text scanning with current-turn matching that only accepts user-authored text_input or transcript_final segments whose segment_id starts with the invoked turn_id. Added a multi-turn regression test proving turn-002 fails when its current user input is wrong even if earlier user or agent segments contain the expected text.",
      "review_instructions": "Verify Invoke no longer accepts unrelated prior text/transcript segments for expected-input validation, and that only the current turn's user segment can satisfy the scripted input.",
      "review_result": {
        "status": "pass",
        "issues_found": [],
        "notes": "Regression test covers the false-pass case from review."
      },
      "cumulative_review": {
        "previous_steps_still_valid": true,
        "integration_issues": [],
        "notes": "Output generation remains deterministic; only input validation scope changed."
      }
    },
    {
      "step_number": "final",
      "title": "Final review against test contract",
      "timestamp": "2026-05-13T19:04:00+05:30",
      "test_contract_review": {
        "functional_behavior": "pass - input mismatch validation is now scoped to the invoked turn's current user text/transcript segment",
        "unit_tests": "pass - added multi-turn wrong-current-turn regression coverage plus existing exact output tests",
        "integration_tests": "pass - go test ./internal/voicedeployment ./internal/multimodaltrace ./internal/voicefixtures ./internal/voicesim passed",
        "smoke_tests": "pass - go test ./internal/voicedeployment and go test ./... passed",
        "e2e_tests": "N/A - execution-mode wiring is a later issue",
        "manual_tests": "N/A - backend package only"
      },
      "overall_verdict": "ready",
      "blocking_issues": []
    }
  ]
}
```


## Greptile Follow-Up

- Added `ErrInvalidInvocation` so runtime caller/input failures from `Invoke` are distinct from script-validation failures in `NewFake`.
- `validateInputSegments` now wraps malformed input trace data with `ErrInvalidInvocation`, not `ErrInvalidScript`.
- Added a segment-kind/count guard to the failing-trace test before indexed assertions.

```json
{
  "branch": "codex/voice-fake-deployment",
  "test_contract": "/tmp/codex-voice-fake-deployment-test-contract.md",
  "updated_at": "2026-05-13T19:10:00+05:30",
  "steps": [
    {
      "step_number": 3,
      "title": "Separate invalid invocation errors from script errors",
      "timestamp": "2026-05-13T19:10:00+05:30",
      "files_changed": [
        "backend/internal/voicedeployment/fake.go",
        "backend/internal/voicedeployment/fake_test.go"
      ],
      "what_changed": "Added ErrInvalidInvocation for runtime caller/input problems, changed Invoke ID validation and input segment validation to use it instead of ErrInvalidScript, and added a unit test proving invalid invocations do not match ErrInvalidScript. Also added an explicit segment-kind guard to the failing-trace test.",
      "review_instructions": "Verify NewFake script validation still uses ErrInvalidScript, while Invoke caller/input validation uses ErrInvalidInvocation. Verify failing outcome tests assert segment count/order before indexed access.",
      "review_result": {
        "status": "pass",
        "issues_found": [],
        "notes": "Addresses Greptile comments on sentinel overloading and panic-prone test indexing."
      },
      "cumulative_review": {
        "previous_steps_still_valid": true,
        "integration_issues": [],
        "notes": "Current-turn input matching from step 2 remains intact."
      }
    },
    {
      "step_number": "final",
      "title": "Final review against test contract",
      "timestamp": "2026-05-13T19:11:00+05:30",
      "test_contract_review": {
        "functional_behavior": "pass - invoked-turn input matching is scoped correctly and invocation errors are distinguishable from script errors",
        "unit_tests": "pass - added regression coverage for wrong current turn, invalid invocation sentinel behavior, and failing trace segment ordering",
        "integration_tests": "pass - go test ./internal/voicedeployment ./internal/multimodaltrace ./internal/voicefixtures ./internal/voicesim passed",
        "smoke_tests": "pass - go test ./internal/voicedeployment and go test ./... passed",
        "e2e_tests": "N/A - execution-mode wiring is a later issue",
        "manual_tests": "N/A - backend package only"
      },
      "overall_verdict": "ready",
      "blocking_issues": []
    }
  ]
}
```
