### PR TITLE
feat(voice-evals): add text-sim execution mode

### DIFF
--- a/backend/internal/voicetextsim/executor.go
+++ b/backend/internal/voicetextsim/executor.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -48,9 +49,7 @@ func Run(ctx context.Context, input Input) (Result, error) {
 	}
 	segments := make([]multimodaltrace.Segment, 0, len(input.Script.Steps)*8)
 	events := make([]runevents.Envelope, 0, len(input.Script.Steps)*8+2)
-	eventSeq := int64(0)
 	appendEvent := func(eventType runevents.Type, occurredAt time.Time, payload any, summary runevents.SummaryMetadata) error {
-		eventSeq++
 		rawPayload, err := json.Marshal(payload)
 		if err != nil {
 			return fmt.Errorf("marshal event payload: %w", err)
@@ -59,21 +58,20 @@ func Run(ctx context.Context, input Input) (Result, error) {
 			summary.EvidenceLevel = runevents.EvidenceLevelVoiceStructured
 		}
 		if summary.IdempotencyKey == "" {
-			summary.IdempotencyKey = fmt.Sprintf("%s:text-sim:event:%03d", input.Script.TraceID, eventSeq)
+			summary.IdempotencyKey = fmt.Sprintf("%s:text-sim:%s:%s", input.Script.TraceID, eventType, occurredAt.UTC().Format(time.RFC3339Nano))
 		}
 		envelope := runevents.Envelope{
-			EventID:        fmt.Sprintf("voice-text-sim:%s:%03d", input.Script.TraceID, eventSeq),
-			SchemaVersion:  runevents.SchemaVersionV1,
-			RunID:          input.Script.RunID,
-			RunAgentID:     input.Script.RunAgentID,
-			SequenceNumber: eventSeq,
-			EventType:      eventType,
-			Source:         runevents.SourceVoiceAdapter,
-			OccurredAt:     occurredAt.UTC(),
-			Payload:        rawPayload,
-			Summary:        summary,
+			EventID:       summary.IdempotencyKey,
+			SchemaVersion: runevents.SchemaVersionV1,
+			RunID:         input.Script.RunID,
+			RunAgentID:    input.Script.RunAgentID,
+			EventType:     eventType,
+			Source:        runevents.SourceVoiceAdapter,
+			OccurredAt:    occurredAt.UTC(),
+			Payload:       rawPayload,
+			Summary:       summary,
 		}
-		if err := envelope.ValidatePersisted(); err != nil {
+		if err := envelope.ValidatePending(); err != nil {
 			return err
 		}
 		events = append(events, envelope)
@@ -152,7 +150,7 @@ func Run(ctx context.Context, input Input) (Result, error) {
 		}
 		if deploymentResult.Outcome == voicedeployment.OutcomeFail {
 			failureReason := fmt.Sprintf("turn_id=%s deployment outcome failed", step.TurnID)
-			if err := appendEvent(runevents.EventTypeSystemRunFailed, latestSegmentTime(deploymentResult.Segments, userOccurredAt), map[string]any{
+			if err := appendEvent(runevents.EventTypeSystemRunFailed, latestEventTime(events, userOccurredAt), map[string]any{
 				"turn_id": step.TurnID,
 				"reason":  failureReason,
 			}, runevents.SummaryMetadata{
@@ -167,7 +165,7 @@ func Run(ctx context.Context, input Input) (Result, error) {
 			}
 			return result, nil
 		}
-		if err := appendEvent(runevents.EventTypeTurnCompleted, latestSegmentTime(deploymentResult.Segments, userOccurredAt), map[string]any{
+		if err := appendEvent(runevents.EventTypeTurnCompleted, latestResponseTime(deploymentResult.Segments, userOccurredAt), map[string]any{
 			"turn_id":         step.TurnID,
 			"user_segment_id": userSegmentID,
 			"segment_count":   len(deploymentResult.Segments) + 1,
@@ -176,10 +174,7 @@ func Run(ctx context.Context, input Input) (Result, error) {
 		}
 	}
 
-	completedAt := input.Script.BaseTime
-	if len(segments) > 0 {
-		completedAt = segments[len(segments)-1].OccurredAt
-	}
+	completedAt := latestEventTime(events, input.Script.BaseTime)
 	if err := appendEvent(runevents.EventTypeSystemRunCompleted, completedAt, map[string]any{
 		"mode":         "text-sim",
 		"scenario_key": input.Script.ScenarioKey,
@@ -275,7 +270,11 @@ func buildResult(input Input, status Status, failureReason string, segments []mu
 	if err != nil {
 		return Result{}, err
 	}
-	eventsJSON, err := marshalStable(events)
+	finalEvents, err := finalizeEvents(events)
+	if err != nil {
+		return Result{}, err
+	}
+	eventsJSON, err := marshalStable(finalEvents)
 	if err != nil {
 		return Result{}, err
 	}
@@ -283,7 +282,7 @@ func buildResult(input Input, status Status, failureReason string, segments []mu
 		Status:        status,
 		FailureReason: failureReason,
 		Trace:         trace,
-		Events:        events,
+		Events:        finalEvents,
 		TraceJSON:     traceJSON,
 		EventsJSON:    eventsJSON,
 	}, nil
@@ -310,14 +309,51 @@ func metricSummary(turnIndex int, metricKey string) runevents.SummaryMetadata {
 	return summary
 }
 
-func latestSegmentTime(segments []multimodaltrace.Segment, fallback time.Time) time.Time {
+func latestResponseTime(segments []multimodaltrace.Segment, fallback time.Time) time.Time {
 	latest := fallback
 	for _, segment := range segments {
+		if segment.Kind == multimodaltrace.SegmentKindAudioOutput {
+			continue
+		}
 		if segment.OccurredAt.After(latest) {
 			latest = segment.OccurredAt
 		}
 	}
 	return latest.UTC()
+}
+
+func latestEventTime(events []runevents.Envelope, fallback time.Time) time.Time {
+	latest := fallback
+	for _, event := range events {
+		if event.OccurredAt.After(latest) {
+			latest = event.OccurredAt
+		}
+	}
+	return latest.UTC()
+}
+
+func finalizeEvents(events []runevents.Envelope) ([]runevents.Envelope, error) {
+	finalEvents := append([]runevents.Envelope(nil), events...)
+	sort.SliceStable(finalEvents, func(i, j int) bool {
+		if !finalEvents[i].OccurredAt.Equal(finalEvents[j].OccurredAt) {
+			return finalEvents[i].OccurredAt.Before(finalEvents[j].OccurredAt)
+		}
+		if finalEvents[i].EventType != finalEvents[j].EventType {
+			return finalEvents[i].EventType < finalEvents[j].EventType
+		}
+		if finalEvents[i].Summary.IdempotencyKey != finalEvents[j].Summary.IdempotencyKey {
+			return finalEvents[i].Summary.IdempotencyKey < finalEvents[j].Summary.IdempotencyKey
+		}
+		return string(finalEvents[i].Payload) < string(finalEvents[j].Payload)
+	})
+	for idx := range finalEvents {
+		finalEvents[idx].SequenceNumber = int64(idx + 1)
+		finalEvents[idx].EventID = fmt.Sprintf("voice-text-sim:%s:%03d", finalEvents[idx].RunAgentID, idx+1)
+		if err := finalEvents[idx].ValidatePersisted(); err != nil {
+			return nil, fmt.Errorf("validate finalized event[%d]: %w", idx, err)
+		}
+	}
+	return finalEvents, nil
 }
 
 func marshalStable(value any) ([]byte, error) {

--- a/backend/internal/voicetextsim/executor.go
+++ b/backend/internal/voicetextsim/executor.go
@@ -1,0 +1,338 @@
+package voicetextsim
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/challengepack"
+	"github.com/agentclash/agentclash/backend/internal/multimodaltrace"
+	"github.com/agentclash/agentclash/backend/internal/runevents"
+	"github.com/agentclash/agentclash/backend/internal/voicedeployment"
+	"github.com/agentclash/agentclash/backend/internal/voicesim"
+)
+
+var (
+	ErrInvalidInput = errors.New("invalid text-sim voice execution input")
+	ErrRunFailed    = errors.New("text-sim voice execution failed")
+)
+
+type Status string
+
+const (
+	StatusCompleted Status = "completed"
+	StatusFailed    Status = "failed"
+)
+
+type Input struct {
+	Bundle     challengepack.Bundle
+	Script     voicesim.Script
+	Deployment voicedeployment.Deployment
+}
+
+type Result struct {
+	Status        Status
+	FailureReason string
+	Trace         multimodaltrace.Trace
+	Events        []runevents.Envelope
+	TraceJSON     []byte
+	EventsJSON    []byte
+}
+
+func Run(ctx context.Context, input Input) (Result, error) {
+	if err := validateInput(input); err != nil {
+		return Result{}, err
+	}
+	segments := make([]multimodaltrace.Segment, 0, len(input.Script.Steps)*8)
+	events := make([]runevents.Envelope, 0, len(input.Script.Steps)*8+2)
+	eventSeq := int64(0)
+	appendEvent := func(eventType runevents.Type, occurredAt time.Time, payload any, summary runevents.SummaryMetadata) error {
+		eventSeq++
+		rawPayload, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("marshal event payload: %w", err)
+		}
+		if summary.EvidenceLevel == "" {
+			summary.EvidenceLevel = runevents.EvidenceLevelVoiceStructured
+		}
+		if summary.IdempotencyKey == "" {
+			summary.IdempotencyKey = fmt.Sprintf("%s:text-sim:event:%03d", input.Script.TraceID, eventSeq)
+		}
+		envelope := runevents.Envelope{
+			EventID:        fmt.Sprintf("voice-text-sim:%s:%03d", input.Script.TraceID, eventSeq),
+			SchemaVersion:  runevents.SchemaVersionV1,
+			RunID:          input.Script.RunID,
+			RunAgentID:     input.Script.RunAgentID,
+			SequenceNumber: eventSeq,
+			EventType:      eventType,
+			Source:         runevents.SourceVoiceAdapter,
+			OccurredAt:     occurredAt.UTC(),
+			Payload:        rawPayload,
+			Summary:        summary,
+		}
+		if err := envelope.ValidatePersisted(); err != nil {
+			return err
+		}
+		events = append(events, envelope)
+		return nil
+	}
+
+	if err := appendEvent(runevents.EventTypeMediaSessionStarted, input.Script.BaseTime, map[string]any{
+		"mode":             "text-sim",
+		"scenario_key":     input.Script.ScenarioKey,
+		"voice_session_id": input.Script.TraceID,
+		"pack_slug":        input.Bundle.Pack.Slug,
+	}, runevents.SummaryMetadata{
+		Status:         string(StatusCompleted),
+		IdempotencyKey: input.Script.TraceID + ":text-sim:session-started",
+	}); err != nil {
+		return Result{}, err
+	}
+
+	nextSequence := int64(1)
+	for idx, step := range input.Script.Steps {
+		turnIndex := idx + 1
+		userOccurredAt := input.Script.BaseTime.Add(time.Duration(step.OccurredAtOffsetMS) * time.Millisecond).UTC()
+		userSegmentID := step.TurnID + ":user-text"
+		userSegment := multimodaltrace.Segment{
+			SegmentID:      userSegmentID,
+			SequenceNumber: nextSequence,
+			Kind:           multimodaltrace.SegmentKindTextInput,
+			Actor:          multimodaltrace.ActorUser,
+			OccurredAt:     userOccurredAt,
+			Text: &multimodaltrace.TextPayload{
+				Text:     step.UserText,
+				Language: step.Language,
+			},
+		}
+		segments = append(segments, userSegment)
+		nextSequence++
+		if err := appendEvent(runevents.EventTypeTranscriptFinal, userOccurredAt, map[string]any{
+			"turn_id":    step.TurnID,
+			"text":       step.UserText,
+			"language":   step.Language,
+			"segment_id": userSegmentID,
+		}, turnSummary(turnIndex, "caller", "text")); err != nil {
+			return Result{}, err
+		}
+
+		deploymentResult, err := input.Deployment.Invoke(ctx, voicedeployment.Invocation{
+			TraceID:       input.Script.TraceID,
+			RunID:         input.Script.RunID,
+			RunAgentID:    input.Script.RunAgentID,
+			TurnID:        step.TurnID,
+			InputSegments: append([]multimodaltrace.Segment(nil), segments...),
+		})
+		if err != nil {
+			failureReason := err.Error()
+			if eventErr := appendEvent(runevents.EventTypeSystemRunFailed, userOccurredAt, map[string]any{
+				"turn_id": step.TurnID,
+				"reason":  failureReason,
+			}, runevents.SummaryMetadata{
+				Status:         string(StatusFailed),
+				IdempotencyKey: input.Script.TraceID + ":" + step.TurnID + ":failed",
+			}); eventErr != nil {
+				return Result{}, eventErr
+			}
+			result, buildErr := buildResult(input, StatusFailed, failureReason, segments, events)
+			if buildErr != nil {
+				return Result{}, buildErr
+			}
+			return result, nil
+		}
+
+		segments = append(segments, deploymentResult.Segments...)
+		for _, segment := range deploymentResult.Segments {
+			if err := appendSegmentEvent(appendEvent, turnIndex, step.TurnID, segment); err != nil {
+				return Result{}, err
+			}
+		}
+		if deploymentResult.Outcome == voicedeployment.OutcomeFail {
+			failureReason := fmt.Sprintf("turn_id=%s deployment outcome failed", step.TurnID)
+			if err := appendEvent(runevents.EventTypeSystemRunFailed, latestSegmentTime(deploymentResult.Segments, userOccurredAt), map[string]any{
+				"turn_id": step.TurnID,
+				"reason":  failureReason,
+			}, runevents.SummaryMetadata{
+				Status:         string(StatusFailed),
+				IdempotencyKey: input.Script.TraceID + ":" + step.TurnID + ":failed",
+			}); err != nil {
+				return Result{}, err
+			}
+			result, err := buildResult(input, StatusFailed, failureReason, segments, events)
+			if err != nil {
+				return Result{}, err
+			}
+			return result, nil
+		}
+		if err := appendEvent(runevents.EventTypeTurnCompleted, latestSegmentTime(deploymentResult.Segments, userOccurredAt), map[string]any{
+			"turn_id":         step.TurnID,
+			"user_segment_id": userSegmentID,
+			"segment_count":   len(deploymentResult.Segments) + 1,
+		}, turnSummary(turnIndex, "agent", "text")); err != nil {
+			return Result{}, err
+		}
+	}
+
+	completedAt := input.Script.BaseTime
+	if len(segments) > 0 {
+		completedAt = segments[len(segments)-1].OccurredAt
+	}
+	if err := appendEvent(runevents.EventTypeSystemRunCompleted, completedAt, map[string]any{
+		"mode":         "text-sim",
+		"scenario_key": input.Script.ScenarioKey,
+		"turn_count":   len(input.Script.Steps),
+	}, runevents.SummaryMetadata{
+		Status:         string(StatusCompleted),
+		IdempotencyKey: input.Script.TraceID + ":text-sim:completed",
+	}); err != nil {
+		return Result{}, err
+	}
+	return buildResult(input, StatusCompleted, "", segments, events)
+}
+
+func validateInput(input Input) error {
+	if input.Deployment == nil {
+		return fmt.Errorf("%w: deployment is required", ErrInvalidInput)
+	}
+	if input.Bundle.Modality != challengepack.ModalityVoice {
+		return fmt.Errorf("%w: bundle.modality must be %q", ErrInvalidInput, challengepack.ModalityVoice)
+	}
+	if input.Bundle.InterfaceSpec == nil {
+		return fmt.Errorf("%w: bundle.interface_spec is required", ErrInvalidInput)
+	}
+	if !contains(input.Bundle.InterfaceSpec.Transports, "text_sim") {
+		return fmt.Errorf("%w: bundle.interface_spec.transports must include text_sim", ErrInvalidInput)
+	}
+	if err := input.Script.Validate(); err != nil {
+		return fmt.Errorf("%w: script: %w", ErrInvalidInput, err)
+	}
+	if input.Bundle.Scenario != nil && input.Bundle.Scenario.MaxTurns > 0 && len(input.Script.Steps) > int(input.Bundle.Scenario.MaxTurns) {
+		return fmt.Errorf("%w: script has %d steps but scenario.max_turns=%d", ErrInvalidInput, len(input.Script.Steps), input.Bundle.Scenario.MaxTurns)
+	}
+	return nil
+}
+
+func appendSegmentEvent(appendEvent func(runevents.Type, time.Time, any, runevents.SummaryMetadata) error, turnIndex int, turnID string, segment multimodaltrace.Segment) error {
+	switch segment.Kind {
+	case multimodaltrace.SegmentKindToolCall:
+		return appendEvent(runevents.EventTypeToolCallStarted, segment.OccurredAt, map[string]any{
+			"turn_id":    turnID,
+			"segment_id": segment.SegmentID,
+			"call_id":    segment.ToolCall.CallID,
+			"tool_name":  segment.ToolCall.ToolName,
+			"arguments":  json.RawMessage(segment.ToolCall.Arguments),
+		}, toolSummary(turnIndex, segment.ToolCall.ToolName))
+	case multimodaltrace.SegmentKindTextOutput:
+		return nil
+	case multimodaltrace.SegmentKindAudioOutput:
+		if err := appendEvent(runevents.EventTypeAgentAudioStarted, segment.OccurredAt, map[string]any{
+			"turn_id":      turnID,
+			"segment_id":   segment.SegmentID,
+			"artifact_ref": segment.Audio.ArtifactRef,
+		}, turnSummary(turnIndex, "agent", "audio")); err != nil {
+			return err
+		}
+		completedAt := segment.OccurredAt.Add(time.Duration(segment.Audio.DurationMS) * time.Millisecond).UTC()
+		return appendEvent(runevents.EventTypeAgentAudioCompleted, completedAt, map[string]any{
+			"turn_id":      turnID,
+			"segment_id":   segment.SegmentID,
+			"artifact_ref": segment.Audio.ArtifactRef,
+			"duration_ms":  segment.Audio.DurationMS,
+		}, turnSummary(turnIndex, "agent", "audio"))
+	case multimodaltrace.SegmentKindTranscriptFinal:
+		return appendEvent(runevents.EventTypeTranscriptFinal, segment.OccurredAt, map[string]any{
+			"turn_id":    turnID,
+			"text":       segment.Transcript.Text,
+			"language":   segment.Transcript.Language,
+			"segment_id": segment.SegmentID,
+		}, turnSummary(turnIndex, "agent", "text"))
+	case multimodaltrace.SegmentKindTimingMarker:
+		return appendEvent(runevents.EventTypeVoiceMetricRecorded, segment.OccurredAt, map[string]any{
+			"turn_id":    turnID,
+			"metric_key": segment.TimingMarker.Key,
+			"value_ms":   segment.TimingMarker.ValueMS,
+		}, metricSummary(turnIndex, segment.TimingMarker.Key))
+	default:
+		return nil
+	}
+}
+
+func buildResult(input Input, status Status, failureReason string, segments []multimodaltrace.Segment, events []runevents.Envelope) (Result, error) {
+	trace := multimodaltrace.Trace{
+		TraceID:       input.Script.TraceID,
+		SchemaVersion: multimodaltrace.SchemaVersionV1,
+		RunID:         input.Script.RunID,
+		RunAgentID:    input.Script.RunAgentID,
+		Segments:      segments,
+	}
+	if err := trace.Validate(); err != nil {
+		return Result{}, err
+	}
+	traceJSON, err := marshalStable(trace)
+	if err != nil {
+		return Result{}, err
+	}
+	eventsJSON, err := marshalStable(events)
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{
+		Status:        status,
+		FailureReason: failureReason,
+		Trace:         trace,
+		Events:        events,
+		TraceJSON:     traceJSON,
+		EventsJSON:    eventsJSON,
+	}, nil
+}
+
+func turnSummary(turnIndex int, speaker string, channel string) runevents.SummaryMetadata {
+	return runevents.SummaryMetadata{
+		TurnIndex:     &turnIndex,
+		Speaker:       speaker,
+		Channel:       channel,
+		EvidenceLevel: runevents.EvidenceLevelVoiceStructured,
+	}
+}
+
+func toolSummary(turnIndex int, toolName string) runevents.SummaryMetadata {
+	summary := turnSummary(turnIndex, "agent", "tool")
+	summary.ToolName = toolName
+	return summary
+}
+
+func metricSummary(turnIndex int, metricKey string) runevents.SummaryMetadata {
+	summary := turnSummary(turnIndex, "evaluator", "metric")
+	summary.MetricKey = metricKey
+	return summary
+}
+
+func latestSegmentTime(segments []multimodaltrace.Segment, fallback time.Time) time.Time {
+	latest := fallback
+	for _, segment := range segments {
+		if segment.OccurredAt.After(latest) {
+			latest = segment.OccurredAt
+		}
+	}
+	return latest.UTC()
+}
+
+func marshalStable(value any) ([]byte, error) {
+	encoded, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(encoded, '\n'), nil
+}
+
+func contains(values []string, needle string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/voicetextsim/executor_test.go
+++ b/backend/internal/voicetextsim/executor_test.go
@@ -1,0 +1,224 @@
+package voicetextsim
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/challengepack"
+	"github.com/agentclash/agentclash/backend/internal/multimodaltrace"
+	"github.com/agentclash/agentclash/backend/internal/runevents"
+	"github.com/agentclash/agentclash/backend/internal/voicedeployment"
+	"github.com/agentclash/agentclash/backend/internal/voicefixtures"
+	"github.com/agentclash/agentclash/backend/internal/voicesim"
+)
+
+func TestTextSimRunsSupportBillingFixtureDeterministically(t *testing.T) {
+	input := supportBillingInput(t, voicedeployment.OutcomePass)
+
+	first, err := Run(context.Background(), input)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	second, err := Run(context.Background(), input)
+	if err != nil {
+		t.Fatalf("second Run returned error: %v", err)
+	}
+
+	if first.Status != StatusCompleted {
+		t.Fatalf("status = %q, want completed", first.Status)
+	}
+	if !bytes.Equal(first.TraceJSON, second.TraceJSON) {
+		t.Fatalf("trace JSON is not stable\nfirst:\n%s\nsecond:\n%s", first.TraceJSON, second.TraceJSON)
+	}
+	if !bytes.Equal(first.EventsJSON, second.EventsJSON) {
+		t.Fatalf("events JSON is not stable\nfirst:\n%s\nsecond:\n%s", first.EventsJSON, second.EventsJSON)
+	}
+	if err := first.Trace.Validate(); err != nil {
+		t.Fatalf("trace validation failed: %v", err)
+	}
+	assertSegmentKinds(t, first.Trace.Segments, []multimodaltrace.SegmentKind{
+		multimodaltrace.SegmentKindTextInput,
+		multimodaltrace.SegmentKindToolCall,
+		multimodaltrace.SegmentKindTextOutput,
+		multimodaltrace.SegmentKindAudioOutput,
+		multimodaltrace.SegmentKindTranscriptFinal,
+		multimodaltrace.SegmentKindStructuredOutput,
+		multimodaltrace.SegmentKindTimingMarker,
+	})
+	assertEventTypes(t, first.Events, []runevents.Type{
+		runevents.EventTypeMediaSessionStarted,
+		runevents.EventTypeTranscriptFinal,
+		runevents.EventTypeToolCallStarted,
+		runevents.EventTypeAgentAudioStarted,
+		runevents.EventTypeAgentAudioCompleted,
+		runevents.EventTypeTranscriptFinal,
+		runevents.EventTypeVoiceMetricRecorded,
+		runevents.EventTypeTurnCompleted,
+		runevents.EventTypeSystemRunCompleted,
+	})
+	if got := first.Trace.Segments[2].Text.Text; got != "I found the duplicate charge and created refund rf_123." {
+		t.Fatalf("agent text = %q", got)
+	}
+	if got := first.Trace.Segments[3].Audio.ArtifactRef; got != "voice://artifacts/agent-turn-001.wav" {
+		t.Fatalf("audio artifact ref = %q", got)
+	}
+	if !bytes.Contains(first.EventsJSON, []byte(`"event_type": "system.run.completed"`)) {
+		t.Fatalf("events JSON missing completion event:\n%s", first.EventsJSON)
+	}
+}
+
+func TestTextSimFailsDeterministicallyForFakeDeploymentFailure(t *testing.T) {
+	result, err := Run(context.Background(), supportBillingInput(t, voicedeployment.OutcomeFail))
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if result.Status != StatusFailed {
+		t.Fatalf("status = %q, want failed", result.Status)
+	}
+	if !strings.Contains(result.FailureReason, "deployment outcome failed") {
+		t.Fatalf("failure reason = %q", result.FailureReason)
+	}
+	if got := result.Events[len(result.Events)-1].EventType; got != runevents.EventTypeSystemRunFailed {
+		t.Fatalf("last event = %q, want system.run.failed", got)
+	}
+	if !bytes.Contains(result.EventsJSON, []byte(`"event_type": "system.run.failed"`)) {
+		t.Fatalf("events JSON missing failed event:\n%s", result.EventsJSON)
+	}
+}
+
+func TestTextSimRejectsNonVoicePack(t *testing.T) {
+	input := supportBillingInput(t, voicedeployment.OutcomePass)
+	input.Bundle.Modality = ""
+
+	_, err := Run(context.Background(), input)
+	if !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("Run error = %v, want ErrInvalidInput", err)
+	}
+}
+
+func supportBillingInput(t *testing.T, outcome voicedeployment.Outcome) Input {
+	t.Helper()
+	fixture, err := voicefixtures.LoadSupportBillingFixture()
+	if err != nil {
+		t.Fatalf("LoadSupportBillingFixture returned error: %v", err)
+	}
+	bundle, err := challengepack.ParseYAML(fixture.ChallengePackYAML)
+	if err != nil {
+		t.Fatalf("ParseYAML returned error: %v", err)
+	}
+	script, err := voicesim.LoadScript("../voicesim/testdata/support_billing_script.json")
+	if err != nil {
+		t.Fatalf("LoadScript returned error: %v", err)
+	}
+	deployment, err := voicedeployment.NewFake(fakeDeploymentScript(t, script, fixture, outcome))
+	if err != nil {
+		t.Fatalf("NewFake returned error: %v", err)
+	}
+	return Input{
+		Bundle:     bundle,
+		Script:     script,
+		Deployment: deployment,
+	}
+}
+
+func fakeDeploymentScript(t *testing.T, script voicesim.Script, fixture voicefixtures.SupportBillingFixture, outcome voicedeployment.Outcome) voicedeployment.Script {
+	t.Helper()
+	var toolCall struct {
+		CallID    string          `json:"call_id"`
+		ToolName  string          `json:"tool_name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if err := json.Unmarshal(fixture.ExpectedToolCallJSON, &toolCall); err != nil {
+		t.Fatalf("decode tool call: %v", err)
+	}
+	var structured struct {
+		SchemaRef string          `json:"schema_ref"`
+		Output    json.RawMessage `json:"output"`
+	}
+	if err := json.Unmarshal(fixture.ExpectedStructuredJSON, &structured); err != nil {
+		t.Fatalf("decode structured output: %v", err)
+	}
+	text := script.Steps[0].ExpectedAgentText
+	structuredOutput := structured.Output
+	if outcome == voicedeployment.OutcomeFail {
+		text = "I cannot find a duplicate charge."
+		structuredOutput = json.RawMessage(`{"resolution":"not_found"}`)
+	}
+	confidence := 1.0
+	return voicedeployment.Script{
+		ScenarioKey: script.ScenarioKey,
+		Turns: []voicedeployment.Turn{
+			{
+				TurnID:            script.Steps[0].TurnID,
+				ExpectedInputText: script.Steps[0].UserText,
+				Outcome:           outcome,
+				Response: voicedeployment.ResponseScript{
+					ExpectedToolCall: &voicedeployment.ExpectedToolCall{
+						CallID:    toolCall.CallID,
+						ToolName:  toolCall.ToolName,
+						Arguments: toolCall.Arguments,
+						OffsetMS:  700,
+					},
+					TextResponse: &voicedeployment.TextResponse{
+						Text:     text,
+						Language: script.Steps[0].Language,
+						OffsetMS: 1200,
+					},
+					SpokenAudioArtifact: &voicedeployment.SpokenAudioArtifact{
+						ArtifactRef: "voice://artifacts/agent-turn-001.wav",
+						Format:      "wav",
+						Channel:     "agent",
+						DurationMS:  2400,
+						OffsetMS:    1600,
+					},
+					TranscriptResponse: &voicedeployment.TranscriptResponse{
+						Text:       text,
+						Language:   script.Steps[0].Language,
+						Confidence: &confidence,
+						OffsetMS:   1700,
+					},
+					StructuredOutput: &voicedeployment.StructuredOutput{
+						SchemaRef: structured.SchemaRef,
+						Output:    structuredOutput,
+						OffsetMS:  1800,
+					},
+					TimingMarkers: []voicedeployment.TimingMarker{
+						{
+							Key:      "end_of_user_text_to_first_agent_text",
+							ValueMS:  1200,
+							OffsetMS: 1800,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func assertSegmentKinds(t *testing.T, segments []multimodaltrace.Segment, want []multimodaltrace.SegmentKind) {
+	t.Helper()
+	if len(segments) != len(want) {
+		t.Fatalf("segment count = %d, want %d", len(segments), len(want))
+	}
+	for idx, kind := range want {
+		if segments[idx].Kind != kind {
+			t.Fatalf("segments[%d].Kind = %q, want %q", idx, segments[idx].Kind, kind)
+		}
+	}
+}
+
+func assertEventTypes(t *testing.T, events []runevents.Envelope, want []runevents.Type) {
+	t.Helper()
+	if len(events) != len(want) {
+		t.Fatalf("event count = %d, want %d", len(events), len(want))
+	}
+	for idx, eventType := range want {
+		if events[idx].EventType != eventType {
+			t.Fatalf("events[%d].EventType = %q, want %q", idx, events[idx].EventType, eventType)
+		}
+	}
+}

--- a/backend/internal/voicetextsim/executor_test.go
+++ b/backend/internal/voicetextsim/executor_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
+	"os"
 	"strings"
 	"testing"
 
@@ -15,6 +17,8 @@ import (
 	"github.com/agentclash/agentclash/backend/internal/voicefixtures"
 	"github.com/agentclash/agentclash/backend/internal/voicesim"
 )
+
+var updateGoldens = flag.Bool("update", false, "update generated text-sim golden files")
 
 func TestTextSimRunsSupportBillingFixtureDeterministically(t *testing.T) {
 	input := supportBillingInput(t, voicedeployment.OutcomePass)
@@ -40,6 +44,14 @@ func TestTextSimRunsSupportBillingFixtureDeterministically(t *testing.T) {
 	if err := first.Trace.Validate(); err != nil {
 		t.Fatalf("trace validation failed: %v", err)
 	}
+	for idx, event := range first.Events {
+		if event.SequenceNumber != int64(idx+1) {
+			t.Fatalf("events[%d].SequenceNumber = %d, want %d", idx, event.SequenceNumber, idx+1)
+		}
+		if idx > 0 && event.OccurredAt.Before(first.Events[idx-1].OccurredAt) {
+			t.Fatalf("events[%d].OccurredAt = %s before previous event time %s", idx, event.OccurredAt, first.Events[idx-1].OccurredAt)
+		}
+	}
 	assertSegmentKinds(t, first.Trace.Segments, []multimodaltrace.SegmentKind{
 		multimodaltrace.SegmentKindTextInput,
 		multimodaltrace.SegmentKindToolCall,
@@ -54,12 +66,18 @@ func TestTextSimRunsSupportBillingFixtureDeterministically(t *testing.T) {
 		runevents.EventTypeTranscriptFinal,
 		runevents.EventTypeToolCallStarted,
 		runevents.EventTypeAgentAudioStarted,
-		runevents.EventTypeAgentAudioCompleted,
 		runevents.EventTypeTranscriptFinal,
-		runevents.EventTypeVoiceMetricRecorded,
 		runevents.EventTypeTurnCompleted,
+		runevents.EventTypeVoiceMetricRecorded,
+		runevents.EventTypeAgentAudioCompleted,
 		runevents.EventTypeSystemRunCompleted,
 	})
+	if *updateGoldens {
+		writeGolden(t, "testdata/support_billing_expected_trace.json", first.TraceJSON)
+		writeGolden(t, "testdata/support_billing_expected_events.json", first.EventsJSON)
+	}
+	assertGolden(t, "trace golden", "testdata/support_billing_expected_trace.json", first.TraceJSON)
+	assertGolden(t, "events golden", "testdata/support_billing_expected_events.json", first.EventsJSON)
 	if got := first.Trace.Segments[2].Text.Text; got != "I found the duplicate charge and created refund rf_123." {
 		t.Fatalf("agent text = %q", got)
 	}
@@ -220,5 +238,23 @@ func assertEventTypes(t *testing.T, events []runevents.Envelope, want []runevent
 		if events[idx].EventType != eventType {
 			t.Fatalf("events[%d].EventType = %q, want %q", idx, events[idx].EventType, eventType)
 		}
+	}
+}
+
+func assertGolden(t *testing.T, label string, path string, got []byte) {
+	t.Helper()
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if !bytes.Equal(want, got) {
+		t.Fatalf("%s mismatch\nwant:\n%s\n got:\n%s", label, want, got)
+	}
+}
+
+func writeGolden(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
 	}
 }

--- a/backend/internal/voicetextsim/testdata/support_billing_expected_events.json
+++ b/backend/internal/voicetextsim/testdata/support_billing_expected_events.json
@@ -1,0 +1,210 @@
+[
+  {
+    "event_id": "voice-text-sim:44444444-4444-4444-4444-444444444444:001",
+    "schema_version": "2026-03-15",
+    "run_id": "33333333-3333-3333-3333-333333333333",
+    "run_agent_id": "44444444-4444-4444-4444-444444444444",
+    "sequence_number": 1,
+    "event_type": "media.session.started",
+    "source": "voice_adapter",
+    "occurred_at": "2026-05-13T10:00:00Z",
+    "payload": {
+      "mode": "text-sim",
+      "pack_slug": "voice-support-billing-fixture",
+      "scenario_key": "support_billing_duplicate_charge",
+      "voice_session_id": "trace-support-billing-scripted-sim"
+    },
+    "summary": {
+      "status": "completed",
+      "evidence_level": "voice_structured",
+      "idempotency_key": "trace-support-billing-scripted-sim:text-sim:session-started"
+    }
+  },
+  {
+    "event_id": "voice-text-sim:44444444-4444-4444-4444-444444444444:002",
+    "schema_version": "2026-03-15",
+    "run_id": "33333333-3333-3333-3333-333333333333",
+    "run_agent_id": "44444444-4444-4444-4444-444444444444",
+    "sequence_number": 2,
+    "event_type": "transcript.final",
+    "source": "voice_adapter",
+    "occurred_at": "2026-05-13T10:00:01Z",
+    "payload": {
+      "language": "en-US",
+      "segment_id": "turn-001:user-text",
+      "text": "I was charged twice for my last invoice.",
+      "turn_id": "turn-001"
+    },
+    "summary": {
+      "turn_index": 1,
+      "speaker": "caller",
+      "channel": "text",
+      "evidence_level": "voice_structured",
+      "idempotency_key": "trace-support-billing-scripted-sim:text-sim:transcript.final:2026-05-13T10:00:01Z"
+    }
+  },
+  {
+    "event_id": "voice-text-sim:44444444-4444-4444-4444-444444444444:003",
+    "schema_version": "2026-03-15",
+    "run_id": "33333333-3333-3333-3333-333333333333",
+    "run_agent_id": "44444444-4444-4444-4444-444444444444",
+    "sequence_number": 3,
+    "event_type": "tool.call.started",
+    "source": "voice_adapter",
+    "occurred_at": "2026-05-13T10:00:01.7Z",
+    "payload": {
+      "arguments": {
+        "account_id": "acct_123",
+        "amount_cents": 4200,
+        "currency": "USD",
+        "idempotency_key": "voice-fixture-42-refund",
+        "reason": "duplicate_charge"
+      },
+      "call_id": "call-refund-001",
+      "segment_id": "turn-001:tool-call",
+      "tool_name": "refund_api",
+      "turn_id": "turn-001"
+    },
+    "summary": {
+      "tool_name": "refund_api",
+      "turn_index": 1,
+      "speaker": "agent",
+      "channel": "tool",
+      "evidence_level": "voice_structured",
+      "idempotency_key": "trace-support-billing-scripted-sim:text-sim:tool.call.started:2026-05-13T10:00:01.7Z"
+    }
+  },
+  {
+    "event_id": "voice-text-sim:44444444-4444-4444-4444-444444444444:004",
+    "schema_version": "2026-03-15",
+    "run_id": "33333333-3333-3333-3333-333333333333",
+    "run_agent_id": "44444444-4444-4444-4444-444444444444",
+    "sequence_number": 4,
+    "event_type": "agent.audio.started",
+    "source": "voice_adapter",
+    "occurred_at": "2026-05-13T10:00:02.6Z",
+    "payload": {
+      "artifact_ref": "voice://artifacts/agent-turn-001.wav",
+      "segment_id": "turn-001:agent-audio",
+      "turn_id": "turn-001"
+    },
+    "summary": {
+      "turn_index": 1,
+      "speaker": "agent",
+      "channel": "audio",
+      "evidence_level": "voice_structured",
+      "idempotency_key": "trace-support-billing-scripted-sim:text-sim:agent.audio.started:2026-05-13T10:00:02.6Z"
+    }
+  },
+  {
+    "event_id": "voice-text-sim:44444444-4444-4444-4444-444444444444:005",
+    "schema_version": "2026-03-15",
+    "run_id": "33333333-3333-3333-3333-333333333333",
+    "run_agent_id": "44444444-4444-4444-4444-444444444444",
+    "sequence_number": 5,
+    "event_type": "transcript.final",
+    "source": "voice_adapter",
+    "occurred_at": "2026-05-13T10:00:02.7Z",
+    "payload": {
+      "language": "en-US",
+      "segment_id": "turn-001:agent-transcript",
+      "text": "I found the duplicate charge and created refund rf_123.",
+      "turn_id": "turn-001"
+    },
+    "summary": {
+      "turn_index": 1,
+      "speaker": "agent",
+      "channel": "text",
+      "evidence_level": "voice_structured",
+      "idempotency_key": "trace-support-billing-scripted-sim:text-sim:transcript.final:2026-05-13T10:00:02.7Z"
+    }
+  },
+  {
+    "event_id": "voice-text-sim:44444444-4444-4444-4444-444444444444:006",
+    "schema_version": "2026-03-15",
+    "run_id": "33333333-3333-3333-3333-333333333333",
+    "run_agent_id": "44444444-4444-4444-4444-444444444444",
+    "sequence_number": 6,
+    "event_type": "turn.completed",
+    "source": "voice_adapter",
+    "occurred_at": "2026-05-13T10:00:02.8Z",
+    "payload": {
+      "segment_count": 7,
+      "turn_id": "turn-001",
+      "user_segment_id": "turn-001:user-text"
+    },
+    "summary": {
+      "turn_index": 1,
+      "speaker": "agent",
+      "channel": "text",
+      "evidence_level": "voice_structured",
+      "idempotency_key": "trace-support-billing-scripted-sim:text-sim:turn.completed:2026-05-13T10:00:02.8Z"
+    }
+  },
+  {
+    "event_id": "voice-text-sim:44444444-4444-4444-4444-444444444444:007",
+    "schema_version": "2026-03-15",
+    "run_id": "33333333-3333-3333-3333-333333333333",
+    "run_agent_id": "44444444-4444-4444-4444-444444444444",
+    "sequence_number": 7,
+    "event_type": "voice.metric.recorded",
+    "source": "voice_adapter",
+    "occurred_at": "2026-05-13T10:00:02.8Z",
+    "payload": {
+      "metric_key": "end_of_user_text_to_first_agent_text",
+      "turn_id": "turn-001",
+      "value_ms": 1200
+    },
+    "summary": {
+      "metric_key": "end_of_user_text_to_first_agent_text",
+      "turn_index": 1,
+      "speaker": "evaluator",
+      "channel": "metric",
+      "evidence_level": "voice_structured",
+      "idempotency_key": "trace-support-billing-scripted-sim:text-sim:voice.metric.recorded:2026-05-13T10:00:02.8Z"
+    }
+  },
+  {
+    "event_id": "voice-text-sim:44444444-4444-4444-4444-444444444444:008",
+    "schema_version": "2026-03-15",
+    "run_id": "33333333-3333-3333-3333-333333333333",
+    "run_agent_id": "44444444-4444-4444-4444-444444444444",
+    "sequence_number": 8,
+    "event_type": "agent.audio.completed",
+    "source": "voice_adapter",
+    "occurred_at": "2026-05-13T10:00:05Z",
+    "payload": {
+      "artifact_ref": "voice://artifacts/agent-turn-001.wav",
+      "duration_ms": 2400,
+      "segment_id": "turn-001:agent-audio",
+      "turn_id": "turn-001"
+    },
+    "summary": {
+      "turn_index": 1,
+      "speaker": "agent",
+      "channel": "audio",
+      "evidence_level": "voice_structured",
+      "idempotency_key": "trace-support-billing-scripted-sim:text-sim:agent.audio.completed:2026-05-13T10:00:05Z"
+    }
+  },
+  {
+    "event_id": "voice-text-sim:44444444-4444-4444-4444-444444444444:009",
+    "schema_version": "2026-03-15",
+    "run_id": "33333333-3333-3333-3333-333333333333",
+    "run_agent_id": "44444444-4444-4444-4444-444444444444",
+    "sequence_number": 9,
+    "event_type": "system.run.completed",
+    "source": "voice_adapter",
+    "occurred_at": "2026-05-13T10:00:05Z",
+    "payload": {
+      "mode": "text-sim",
+      "scenario_key": "support_billing_duplicate_charge",
+      "turn_count": 1
+    },
+    "summary": {
+      "status": "completed",
+      "evidence_level": "voice_structured",
+      "idempotency_key": "trace-support-billing-scripted-sim:text-sim:completed"
+    }
+  }
+]

--- a/backend/internal/voicetextsim/testdata/support_billing_expected_trace.json
+++ b/backend/internal/voicetextsim/testdata/support_billing_expected_trace.json
@@ -1,0 +1,101 @@
+{
+  "trace_id": "trace-support-billing-scripted-sim",
+  "schema_version": "2026-05-13",
+  "run_id": "33333333-3333-3333-3333-333333333333",
+  "run_agent_id": "44444444-4444-4444-4444-444444444444",
+  "segments": [
+    {
+      "segment_id": "turn-001:user-text",
+      "sequence_number": 1,
+      "kind": "text_input",
+      "actor": "user",
+      "occurred_at": "2026-05-13T10:00:01Z",
+      "text": {
+        "text": "I was charged twice for my last invoice.",
+        "language": "en-US"
+      }
+    },
+    {
+      "segment_id": "turn-001:tool-call",
+      "sequence_number": 2,
+      "kind": "tool_call",
+      "actor": "agent",
+      "occurred_at": "2026-05-13T10:00:01.7Z",
+      "tool_call": {
+        "call_id": "call-refund-001",
+        "tool_name": "refund_api",
+        "arguments": {
+          "account_id": "acct_123",
+          "amount_cents": 4200,
+          "currency": "USD",
+          "idempotency_key": "voice-fixture-42-refund",
+          "reason": "duplicate_charge"
+        }
+      }
+    },
+    {
+      "segment_id": "turn-001:agent-text",
+      "sequence_number": 3,
+      "kind": "text_output",
+      "actor": "agent",
+      "occurred_at": "2026-05-13T10:00:02.2Z",
+      "text": {
+        "text": "I found the duplicate charge and created refund rf_123.",
+        "language": "en-US"
+      }
+    },
+    {
+      "segment_id": "turn-001:agent-audio",
+      "sequence_number": 4,
+      "kind": "audio_output",
+      "actor": "agent",
+      "occurred_at": "2026-05-13T10:00:02.6Z",
+      "audio": {
+        "artifact_ref": "voice://artifacts/agent-turn-001.wav",
+        "format": "wav",
+        "channel": "agent",
+        "duration_ms": 2400
+      }
+    },
+    {
+      "segment_id": "turn-001:agent-transcript",
+      "sequence_number": 5,
+      "kind": "transcript_final",
+      "actor": "system",
+      "occurred_at": "2026-05-13T10:00:02.7Z",
+      "transcript": {
+        "text": "I found the duplicate charge and created refund rf_123.",
+        "language": "en-US",
+        "confidence": 1,
+        "source_segment_id": "turn-001:agent-audio"
+      }
+    },
+    {
+      "segment_id": "turn-001:structured-output",
+      "sequence_number": 6,
+      "kind": "structured_output",
+      "actor": "agent",
+      "occurred_at": "2026-05-13T10:00:02.8Z",
+      "structured_output": {
+        "schema_ref": "voice.support.resolution.v1",
+        "output": {
+          "final_message": "I found the duplicate charge and created refund rf_123 for $42.00.",
+          "refund_id": "rf_123",
+          "requires_human_transfer": false,
+          "resolution": "refund_created"
+        }
+      }
+    },
+    {
+      "segment_id": "turn-001:timing:001",
+      "sequence_number": 7,
+      "kind": "timing_marker",
+      "actor": "evaluator",
+      "occurred_at": "2026-05-13T10:00:02.8Z",
+      "timing_marker": {
+        "key": "end_of_user_text_to_first_agent_text",
+        "value_ms": 1200
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Implements #762.

## Summary

Adds the first executable voice eval mode: deterministic `text-sim` execution. The executor validates a voice challenge pack, runs scripted user turns through the voice deployment boundary, emits a multimodal trace, emits canonical voice/run events, and returns terminal completed/failed status without any real LLM/provider/STT/TTS/telephony dependency.

## Test Contract

# codex/voice-text-sim-execution - Test Contract

## Functional Behavior
- A validated `modality: voice` challenge pack with `text_sim` transport can run through a deterministic `text-sim` executor.
- The executor consumes a scripted user simulator script and a deployment implementing the fake/real voice deployment boundary.
- The executor emits a multimodal trace using text input plus deployment response segments.
- The executor emits canonical run/voice events with deterministic IDs, sequence numbers, timestamps, and payloads.
- Successful fake deployment outcomes produce terminal status `completed`.
- Failing fake deployment outcomes or invocation mismatches produce terminal status `failed` with a clear failure reason and a `system.run.failed` event.
- The executor uses no real LLM, provider, STT, TTS, telephony, or network dependency.

## Unit Tests
- `TestTextSimRunsSupportBillingFixtureDeterministically` - loads the billing voice fixture, runs text-sim against the fake deployment twice, asserts terminal success, stable trace JSON, stable events JSON, exact key segment kinds, and exact event types.
- `TestTextSimFailsDeterministicallyForFakeDeploymentFailure` - runs the same fixture with a failing fake deployment and asserts terminal failure plus `system.run.failed`.
- `TestTextSimRejectsNonVoicePack` - rejects a non-voice challenge pack before running.

## Integration / Functional Tests
- `go test ./internal/voicetextsim ./internal/voicedeployment ./internal/voicesim ./internal/voicefixtures ./internal/multimodaltrace ./internal/runevents`

## Smoke Tests
- `go test ./internal/voicetextsim`
- `go test ./...`

## E2E Tests
N/A - this slice adds backend execution-mode plumbing only. CLI/API selection is later issue #767.

## Manual / cURL Tests
N/A - no HTTP or CLI surface is added in this slice.

## Review Checkpoint

```json
{
  "branch": "codex/voice-text-sim-execution",
  "test_contract": "/tmp/codex-voice-text-sim-execution-test-contract.md",
  "created_at": "2026-05-13T20:02:00+05:30",
  "steps": [
    {
      "step_number": 1,
      "title": "Implement deterministic text-sim voice executor",
      "timestamp": "2026-05-13T20:11:00+05:30",
      "files_changed": [
        "backend/internal/voicetextsim/executor.go",
        "backend/internal/voicetextsim/executor_test.go"
      ],
      "what_changed": "Added a text-sim executor that validates voice challenge-pack modality and text_sim transport, consumes a scripted user simulator script, invokes a voice deployment boundary, emits multimodal trace segments and canonical run/voice events, returns terminal completed/failed status, and serializes stable trace/events JSON. Added deterministic fixture tests for success, failure, and non-voice pack rejection.",
      "review_instructions": "Verify the executor has no external/provider/network dependencies, validates the voice pack before execution, emits canonical events and multimodal trace segments, returns completed for pass outcomes, returns failed with a clear reason for fake deployment failure, and produces byte-stable JSON across repeated runs.",
      "review_result": {
        "status": "pass",
        "issues_found": [],
        "notes": "Self-review found the implementation matches #762. Focused, neighboring, and full backend tests passed."
      },
      "cumulative_review": {
        "previous_steps_still_valid": true,
        "integration_issues": [],
        "notes": "Builds on merged challenge-pack validation, scripted simulator, fake deployment, multimodal trace, and canonical event contracts without changing their APIs."
      }
    },
    {
      "step_number": "final",
      "title": "Final review against test contract",
      "timestamp": "2026-05-13T20:12:00+05:30",
      "test_contract_review": {
        "functional_behavior": "pass - voice text-sim execution runs validated voice packs through scripted user turns and deployment boundary with deterministic completed/failed terminal statuses",
        "unit_tests": "pass - added success determinism, deterministic failure, and non-voice rejection tests",
        "integration_tests": "pass - go test ./internal/voicetextsim ./internal/voicedeployment ./internal/voicesim ./internal/voicefixtures ./internal/multimodaltrace ./internal/runevents passed",
        "smoke_tests": "pass - go test ./internal/voicetextsim and go test ./... passed",
        "e2e_tests": "N/A - CLI/API mode selection is later issue #767",
        "manual_tests": "N/A - backend package only"
      },
      "overall_verdict": "ready",
      "blocking_issues": []
    }
  ]
}
```

## Verification

- `go test ./internal/voicetextsim`
- `go test ./internal/voicetextsim ./internal/voicedeployment ./internal/voicesim ./internal/voicefixtures ./internal/multimodaltrace ./internal/runevents`
- `go test ./...`


## Codex Review Follow-Up

- Finalizes text-sim events by chronological order before assigning sequence numbers and persisted event IDs.
- Sets `system.run.completed` after the latest emitted event, including agent audio completion.
- Adds checked-in golden trace/events fixtures and asserts exact JSON output in the deterministic success test.

```json
{
  "branch": "codex/voice-text-sim-execution",
  "test_contract": "/tmp/codex-voice-text-sim-execution-test-contract.md",
  "updated_at": "2026-05-13T20:20:00+05:30",
  "steps": [
    {
      "step_number": 2,
      "title": "Fix canonical event ordering and add golden assertions",
      "timestamp": "2026-05-13T20:20:00+05:30",
      "files_changed": [
        "backend/internal/voicetextsim/executor.go",
        "backend/internal/voicetextsim/executor_test.go",
        "backend/internal/voicetextsim/testdata/support_billing_expected_trace.json",
        "backend/internal/voicetextsim/testdata/support_billing_expected_events.json"
      ],
      "what_changed": "Finalized text-sim events by sorting chronologically before assigning persisted sequence numbers and deterministic event IDs. Completion now occurs after all emitted events, including audio completion. Added checked-in golden trace and event JSON fixtures and updated the success test to compare emitted trace/events against those goldens.",
      "review_instructions": "Verify event sequence numbers are assigned after chronological sorting, no later sequence has an earlier occurred_at, system.run.completed does not precede audio completion, and the test compares exact trace/events JSON against checked-in fixtures.",
      "review_result": {
        "status": "pass",
        "issues_found": [],
        "notes": "Addresses Codex reviewer blockers for #778."
      },
      "cumulative_review": {
        "previous_steps_still_valid": true,
        "integration_issues": [],
        "notes": "Original success/failure/non-voice behavior remains covered; golden files make deterministic output regressions visible."
      }
    },
    {
      "step_number": "final",
      "title": "Final review against test contract",
      "timestamp": "2026-05-13T20:21:00+05:30",
      "test_contract_review": {
        "functional_behavior": "pass - text-sim emits chronological canonical events and byte-stable trace/events output",
        "unit_tests": "pass - success path compares against checked-in golden trace and event JSON; failure and validation tests still pass",
        "integration_tests": "pass - go test ./internal/voicetextsim ./internal/voicedeployment ./internal/voicesim ./internal/voicefixtures ./internal/multimodaltrace ./internal/runevents passed",
        "smoke_tests": "pass - go test ./internal/voicetextsim and go test ./... passed",
        "e2e_tests": "N/A - CLI/API mode selection is later issue #767",
        "manual_tests": "N/A - backend package only"
      },
      "overall_verdict": "ready",
      "blocking_issues": []
    }
  ]
}
```
