### PR TITLE
feat(voice-evals): add deterministic voice validators and metrics

### DIFF
--- a/backend/internal/voiceeval/eval.go
+++ b/backend/internal/voiceeval/eval.go
@@ -197,18 +197,7 @@ func MetricEndOfUserTurnToFirstAgentOutput(input Input, key string) MetricResult
 			return MetricResult{Key: key, State: StatePassed, ValueMS: segment.TimingMarker.ValueMS}
 		}
 	}
-	userAt, ok := firstUserInputTime(input.Trace)
-	if !ok {
-		return unavailableMetric(key, "user input timestamp not found")
-	}
-	agentAt, ok := firstAgentOutputTime(input.Trace)
-	if !ok {
-		return unavailableMetric(key, "agent output timestamp not found")
-	}
-	if agentAt.Before(userAt) {
-		return unavailableMetric(key, "agent output occurs before user input")
-	}
-	return MetricResult{Key: key, State: StatePassed, ValueMS: millis(agentAt.Sub(userAt))}
+	return unavailableMetric(key, "explicit end-of-user-turn latency evidence not found")
 }
 
 func ValidateInput(input Input) error {
@@ -269,18 +258,18 @@ func metricRecordedValue(events []runevents.Envelope, key string) (int64, bool, 
 			continue
 		}
 		var payload struct {
-			ValueMS int64 `json:"value_ms"`
+			ValueMS *int64 `json:"value_ms"`
 		}
-		if err := json.Unmarshal(event.Payload, &payload); err != nil || payload.ValueMS < 0 {
+		if err := json.Unmarshal(event.Payload, &payload); err != nil || payload.ValueMS == nil || *payload.ValueMS < 0 {
 			return 0, true, false
 		}
-		return payload.ValueMS, true, true
+		return *payload.ValueMS, true, true
 	}
 	return 0, false, false
 }
 
 func orderedEventBounds(events []runevents.Envelope) (time.Time, time.Time, bool) {
-	if len(events) == 0 {
+	if len(events) < 2 {
 		return time.Time{}, time.Time{}, false
 	}
 	first, last := events[0].OccurredAt, events[0].OccurredAt
@@ -294,7 +283,7 @@ func orderedEventBounds(events []runevents.Envelope) (time.Time, time.Time, bool
 }
 
 func orderedSegmentBounds(segments []multimodaltrace.Segment) (time.Time, time.Time, bool) {
-	if len(segments) == 0 {
+	if len(segments) < 2 {
 		return time.Time{}, time.Time{}, false
 	}
 	first, last := segments[0].OccurredAt, segments[0].OccurredAt
@@ -305,24 +294,6 @@ func orderedSegmentBounds(segments []multimodaltrace.Segment) (time.Time, time.T
 		last = segment.OccurredAt
 	}
 	return first, last, true
-}
-
-func firstUserInputTime(trace multimodaltrace.Trace) (time.Time, bool) {
-	for _, segment := range trace.Segments {
-		if segment.Actor == multimodaltrace.ActorUser && (segment.Kind == multimodaltrace.SegmentKindTextInput || segment.Kind == multimodaltrace.SegmentKindAudioInput) {
-			return segment.OccurredAt, true
-		}
-	}
-	return time.Time{}, false
-}
-
-func firstAgentOutputTime(trace multimodaltrace.Trace) (time.Time, bool) {
-	for _, segment := range trace.Segments {
-		if segment.Actor == multimodaltrace.ActorAgent && (segment.Kind == multimodaltrace.SegmentKindTextOutput || segment.Kind == multimodaltrace.SegmentKindAudioOutput) {
-			return segment.OccurredAt, true
-		}
-	}
-	return time.Time{}, false
 }
 
 func segmentTurnID(segmentID string) string {

--- a/backend/internal/voiceeval/eval.go
+++ b/backend/internal/voiceeval/eval.go
@@ -1,0 +1,378 @@
+package voiceeval
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/multimodaltrace"
+	"github.com/agentclash/agentclash/backend/internal/runevents"
+)
+
+var ErrInvalidInput = errors.New("invalid voice eval input")
+
+type Input struct {
+	Trace  multimodaltrace.Trace
+	Events []runevents.Envelope
+}
+
+type State string
+
+const (
+	StatePassed      State = "passed"
+	StateFailed      State = "failed"
+	StateUnavailable State = "unavailable"
+)
+
+const (
+	KeyTaskSuccess                         = "task_success"
+	KeyToolCallName                        = "tool_call_name"
+	KeyToolCallArguments                   = "tool_call_arguments"
+	KeyNoForbiddenPhrase                   = "no_forbidden_phrase"
+	KeyMaxTurns                            = "max_turns"
+	KeyInterruptionHandled                 = "interruption_handled"
+	KeyTotalDurationMS                     = "total_duration_ms"
+	KeyEndOfUserTurnToFirstAgentOutputMS   = "end_of_user_turn_to_first_agent_output_ms"
+	KeyEndOfUserTextToFirstAgentTextLegacy = "end_of_user_text_to_first_agent_text"
+)
+
+type CheckResult struct {
+	Key     string
+	State   State
+	Message string
+}
+
+type MetricResult struct {
+	Key     string
+	State   State
+	ValueMS int64
+	Message string
+}
+
+func ValidateTaskSuccessStructured(input Input, key string, field string, expected any) CheckResult {
+	output, ok := latestStructuredOutput(input.Trace)
+	if !ok {
+		return unavailableCheck(key, "structured output not found")
+	}
+	actual, ok := output[field]
+	if !ok {
+		return unavailableCheck(key, fmt.Sprintf("structured output field %q not found", field))
+	}
+	if valuesEqual(actual, expected) {
+		return passedCheck(key)
+	}
+	return failedCheck(key, fmt.Sprintf("structured output field %q = %v, want %v", field, actual, expected))
+}
+
+func ValidateTaskSuccessEvent(input Input, key string, expectedEventType runevents.Type) CheckResult {
+	if len(input.Events) == 0 {
+		return unavailableCheck(key, "events not found")
+	}
+	for _, event := range input.Events {
+		if event.EventType == runevents.EventTypeSystemRunFailed {
+			return failedCheck(key, "system run failed event found")
+		}
+	}
+	for _, event := range input.Events {
+		if event.EventType == expectedEventType {
+			return passedCheck(key)
+		}
+	}
+	return unavailableCheck(key, fmt.Sprintf("event %q not found", expectedEventType))
+}
+
+func ValidateExactToolCallName(input Input, key string, expectedToolName string) CheckResult {
+	call, ok := firstToolCall(input.Trace)
+	if !ok {
+		return unavailableCheck(key, "tool call not found")
+	}
+	if call.ToolName == expectedToolName {
+		return passedCheck(key)
+	}
+	return failedCheck(key, fmt.Sprintf("tool name = %q, want %q", call.ToolName, expectedToolName))
+}
+
+func ValidateExactToolCallArguments(input Input, key string, expected json.RawMessage) CheckResult {
+	call, ok := firstToolCall(input.Trace)
+	if !ok {
+		return unavailableCheck(key, "tool call not found")
+	}
+	if !json.Valid(expected) {
+		return unavailableCheck(key, "expected arguments are not valid JSON")
+	}
+	if !json.Valid(call.Arguments) {
+		return unavailableCheck(key, "observed arguments are not valid JSON")
+	}
+	if bytes.Equal(normalizeJSON(call.Arguments), normalizeJSON(expected)) {
+		return passedCheck(key)
+	}
+	return failedCheck(key, fmt.Sprintf("tool arguments = %s, want %s", normalizeJSON(call.Arguments), normalizeJSON(expected)))
+}
+
+func ValidateNoForbiddenPhrase(input Input, key string, phrase string) CheckResult {
+	needle := strings.ToLower(strings.TrimSpace(phrase))
+	if needle == "" {
+		return unavailableCheck(key, "forbidden phrase is empty")
+	}
+	for _, text := range allTraceText(input.Trace) {
+		if strings.Contains(strings.ToLower(text), needle) {
+			return failedCheck(key, fmt.Sprintf("forbidden phrase %q found", phrase))
+		}
+	}
+	return passedCheck(key)
+}
+
+func ValidateMaxTurns(input Input, key string, maxTurns int) CheckResult {
+	if maxTurns <= 0 {
+		return unavailableCheck(key, "max_turns must be positive")
+	}
+	turns := map[string]struct{}{}
+	for _, segment := range input.Trace.Segments {
+		if segment.Actor == multimodaltrace.ActorUser {
+			turnID := segmentTurnID(segment.SegmentID)
+			if turnID != "" {
+				turns[turnID] = struct{}{}
+			}
+		}
+	}
+	if len(turns) == 0 {
+		return unavailableCheck(key, "user turns not found")
+	}
+	if len(turns) <= maxTurns {
+		return passedCheck(key)
+	}
+	return failedCheck(key, fmt.Sprintf("turns = %d, max_turns = %d", len(turns), maxTurns))
+}
+
+func ValidateInterruptionHandled(input Input, key string) CheckResult {
+	for _, segment := range input.Trace.Segments {
+		if segment.MediaControl != nil && segment.MediaControl.Action == "barge_in_detected" {
+			return passedCheck(key)
+		}
+	}
+	for _, event := range input.Events {
+		if event.EventType == runevents.EventTypeBargeInDetected {
+			return passedCheck(key)
+		}
+	}
+	return failedCheck(key, "barge-in marker not found")
+}
+
+func MetricTotalDuration(input Input, key string) MetricResult {
+	if len(input.Events) > 0 {
+		first, last, ok := orderedEventBounds(input.Events)
+		if !ok {
+			return unavailableMetric(key, "event timestamps are not monotonic")
+		}
+		return MetricResult{Key: key, State: StatePassed, ValueMS: millis(last.Sub(first))}
+	}
+	first, last, ok := orderedSegmentBounds(input.Trace.Segments)
+	if !ok {
+		return unavailableMetric(key, "monotonic timestamp evidence not found")
+	}
+	return MetricResult{Key: key, State: StatePassed, ValueMS: millis(last.Sub(first))}
+}
+
+func MetricEndOfUserTurnToFirstAgentOutput(input Input, key string) MetricResult {
+	if valueMS, found, valid := metricRecordedValue(input.Events, key); found {
+		if !valid {
+			return unavailableMetric(key, "voice metric event is invalid")
+		}
+		return MetricResult{Key: key, State: StatePassed, ValueMS: valueMS}
+	}
+	if key == KeyEndOfUserTurnToFirstAgentOutputMS {
+		if valueMS, found, valid := metricRecordedValue(input.Events, KeyEndOfUserTextToFirstAgentTextLegacy); found {
+			if !valid {
+				return unavailableMetric(key, "voice metric event is invalid")
+			}
+			return MetricResult{Key: key, State: StatePassed, ValueMS: valueMS}
+		}
+	}
+	for _, segment := range input.Trace.Segments {
+		if segment.Kind == multimodaltrace.SegmentKindTimingMarker && segment.TimingMarker != nil &&
+			(segment.TimingMarker.Key == key || segment.TimingMarker.Key == KeyEndOfUserTextToFirstAgentTextLegacy) {
+			return MetricResult{Key: key, State: StatePassed, ValueMS: segment.TimingMarker.ValueMS}
+		}
+	}
+	userAt, ok := firstUserInputTime(input.Trace)
+	if !ok {
+		return unavailableMetric(key, "user input timestamp not found")
+	}
+	agentAt, ok := firstAgentOutputTime(input.Trace)
+	if !ok {
+		return unavailableMetric(key, "agent output timestamp not found")
+	}
+	if agentAt.Before(userAt) {
+		return unavailableMetric(key, "agent output occurs before user input")
+	}
+	return MetricResult{Key: key, State: StatePassed, ValueMS: millis(agentAt.Sub(userAt))}
+}
+
+func ValidateInput(input Input) error {
+	if err := input.Trace.Validate(); err != nil {
+		return fmt.Errorf("%w: trace: %w", ErrInvalidInput, err)
+	}
+	for idx, event := range input.Events {
+		if err := event.ValidatePersisted(); err != nil {
+			return fmt.Errorf("%w: events[%d]: %w", ErrInvalidInput, idx, err)
+		}
+	}
+	return nil
+}
+
+func latestStructuredOutput(trace multimodaltrace.Trace) (map[string]any, bool) {
+	for idx := len(trace.Segments) - 1; idx >= 0; idx-- {
+		segment := trace.Segments[idx]
+		if segment.StructuredOutput == nil {
+			continue
+		}
+		var output map[string]any
+		if err := json.Unmarshal(segment.StructuredOutput.Output, &output); err != nil {
+			return nil, false
+		}
+		return output, true
+	}
+	return nil, false
+}
+
+func firstToolCall(trace multimodaltrace.Trace) (multimodaltrace.ToolCallPayload, bool) {
+	for _, segment := range trace.Segments {
+		if segment.ToolCall != nil {
+			return *segment.ToolCall, true
+		}
+	}
+	return multimodaltrace.ToolCallPayload{}, false
+}
+
+func allTraceText(trace multimodaltrace.Trace) []string {
+	var texts []string
+	for _, segment := range trace.Segments {
+		if segment.Text != nil {
+			texts = append(texts, segment.Text.Text)
+		}
+		if segment.Transcript != nil {
+			texts = append(texts, segment.Transcript.Text)
+		}
+		if segment.StructuredOutput != nil {
+			texts = append(texts, string(segment.StructuredOutput.Output))
+		}
+	}
+	return texts
+}
+
+func metricRecordedValue(events []runevents.Envelope, key string) (int64, bool, bool) {
+	for _, event := range events {
+		if event.EventType != runevents.EventTypeVoiceMetricRecorded || event.Summary.MetricKey != key {
+			continue
+		}
+		var payload struct {
+			ValueMS int64 `json:"value_ms"`
+		}
+		if err := json.Unmarshal(event.Payload, &payload); err != nil || payload.ValueMS < 0 {
+			return 0, true, false
+		}
+		return payload.ValueMS, true, true
+	}
+	return 0, false, false
+}
+
+func orderedEventBounds(events []runevents.Envelope) (time.Time, time.Time, bool) {
+	if len(events) == 0 {
+		return time.Time{}, time.Time{}, false
+	}
+	first, last := events[0].OccurredAt, events[0].OccurredAt
+	for _, event := range events[1:] {
+		if event.OccurredAt.Before(last) {
+			return time.Time{}, time.Time{}, false
+		}
+		last = event.OccurredAt
+	}
+	return first, last, true
+}
+
+func orderedSegmentBounds(segments []multimodaltrace.Segment) (time.Time, time.Time, bool) {
+	if len(segments) == 0 {
+		return time.Time{}, time.Time{}, false
+	}
+	first, last := segments[0].OccurredAt, segments[0].OccurredAt
+	for _, segment := range segments[1:] {
+		if segment.OccurredAt.Before(last) {
+			return time.Time{}, time.Time{}, false
+		}
+		last = segment.OccurredAt
+	}
+	return first, last, true
+}
+
+func firstUserInputTime(trace multimodaltrace.Trace) (time.Time, bool) {
+	for _, segment := range trace.Segments {
+		if segment.Actor == multimodaltrace.ActorUser && (segment.Kind == multimodaltrace.SegmentKindTextInput || segment.Kind == multimodaltrace.SegmentKindAudioInput) {
+			return segment.OccurredAt, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func firstAgentOutputTime(trace multimodaltrace.Trace) (time.Time, bool) {
+	for _, segment := range trace.Segments {
+		if segment.Actor == multimodaltrace.ActorAgent && (segment.Kind == multimodaltrace.SegmentKindTextOutput || segment.Kind == multimodaltrace.SegmentKindAudioOutput) {
+			return segment.OccurredAt, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func segmentTurnID(segmentID string) string {
+	before, _, ok := strings.Cut(segmentID, ":")
+	if !ok {
+		return ""
+	}
+	return before
+}
+
+func valuesEqual(actual any, expected any) bool {
+	actualJSON, err := json.Marshal(actual)
+	if err != nil {
+		return false
+	}
+	expectedJSON, err := json.Marshal(expected)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(normalizeJSON(actualJSON), normalizeJSON(expectedJSON))
+}
+
+func normalizeJSON(raw json.RawMessage) json.RawMessage {
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return append(json.RawMessage(nil), raw...)
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return append(json.RawMessage(nil), raw...)
+	}
+	return encoded
+}
+
+func passedCheck(key string) CheckResult {
+	return CheckResult{Key: key, State: StatePassed}
+}
+
+func failedCheck(key string, message string) CheckResult {
+	return CheckResult{Key: key, State: StateFailed, Message: message}
+}
+
+func unavailableCheck(key string, message string) CheckResult {
+	return CheckResult{Key: key, State: StateUnavailable, Message: message}
+}
+
+func unavailableMetric(key string, message string) MetricResult {
+	return MetricResult{Key: key, State: StateUnavailable, Message: message}
+}
+
+func millis(duration time.Duration) int64 {
+	return int64(duration / time.Millisecond)
+}

--- a/backend/internal/voiceeval/eval_test.go
+++ b/backend/internal/voiceeval/eval_test.go
@@ -1,0 +1,269 @@
+package voiceeval
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/multimodaltrace"
+	"github.com/agentclash/agentclash/backend/internal/runevents"
+)
+
+func TestVoiceValidatorsAgainstTextSimGolden(t *testing.T) {
+	input := loadGoldenInput(t)
+
+	checks := []struct {
+		name string
+		got  CheckResult
+		want State
+	}{
+		{"task success structured pass", ValidateTaskSuccessStructured(input, KeyTaskSuccess, "resolution", "refund_created"), StatePassed},
+		{"task success structured fail", ValidateTaskSuccessStructured(input, KeyTaskSuccess, "resolution", "not_found"), StateFailed},
+		{"task success structured missing evidence", ValidateTaskSuccessStructured(withoutStructuredOutput(input), KeyTaskSuccess, "resolution", "refund_created"), StateUnavailable},
+		{"task success event pass", ValidateTaskSuccessEvent(input, KeyTaskSuccess, runevents.EventTypeSystemRunCompleted), StatePassed},
+		{"task success event fail", ValidateTaskSuccessEvent(withFailedRunEvent(input), KeyTaskSuccess, runevents.EventTypeSystemRunCompleted), StateFailed},
+		{"task success event missing evidence", ValidateTaskSuccessEvent(withoutEvents(input), KeyTaskSuccess, runevents.EventTypeSystemRunCompleted), StateUnavailable},
+		{"tool name pass", ValidateExactToolCallName(input, KeyToolCallName, "refund_api"), StatePassed},
+		{"tool name fail", ValidateExactToolCallName(input, KeyToolCallName, "crm_lookup"), StateFailed},
+		{"tool name missing evidence", ValidateExactToolCallName(withoutToolCall(input), KeyToolCallName, "refund_api"), StateUnavailable},
+		{"tool args pass", ValidateExactToolCallArguments(input, KeyToolCallArguments, json.RawMessage(`{"reason":"duplicate_charge","account_id":"acct_123","amount_cents":4200,"currency":"USD","idempotency_key":"voice-fixture-42-refund"}`)), StatePassed},
+		{"tool args fail", ValidateExactToolCallArguments(input, KeyToolCallArguments, json.RawMessage(`{"reason":"wrong"}`)), StateFailed},
+		{"tool args missing evidence", ValidateExactToolCallArguments(withoutToolCall(input), KeyToolCallArguments, json.RawMessage(`{"reason":"duplicate_charge"}`)), StateUnavailable},
+		{"tool args degraded", ValidateExactToolCallArguments(input, KeyToolCallArguments, json.RawMessage(`{`)), StateUnavailable},
+		{"tool args degraded observed", ValidateExactToolCallArguments(withInvalidToolArguments(input), KeyToolCallArguments, json.RawMessage(`{"reason":"duplicate_charge"}`)), StateUnavailable},
+		{"forbidden phrase pass", ValidateNoForbiddenPhrase(input, KeyNoForbiddenPhrase, "unauthorized transfer"), StatePassed},
+		{"forbidden phrase fail", ValidateNoForbiddenPhrase(input, KeyNoForbiddenPhrase, "duplicate charge"), StateFailed},
+		{"forbidden phrase degraded", ValidateNoForbiddenPhrase(input, KeyNoForbiddenPhrase, ""), StateUnavailable},
+		{"max turns pass", ValidateMaxTurns(input, KeyMaxTurns, 1), StatePassed},
+		{"max turns fail", ValidateMaxTurns(withSecondUserTurn(input), KeyMaxTurns, 1), StateFailed},
+		{"max turns missing evidence", ValidateMaxTurns(withoutUserTurns(input), KeyMaxTurns, 1), StateUnavailable},
+		{"interruption handled fail", ValidateInterruptionHandled(input, KeyInterruptionHandled), StateFailed},
+		{"interruption handled pass", ValidateInterruptionHandled(withBargeIn(input), KeyInterruptionHandled), StatePassed},
+	}
+
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got.State != tc.want {
+				t.Fatalf("state = %q, want %q; result=%+v", tc.got.State, tc.want, tc.got)
+			}
+		})
+	}
+}
+
+func TestVoiceMetricsAgainstTextSimGolden(t *testing.T) {
+	input := loadGoldenInput(t)
+
+	metrics := []struct {
+		name    string
+		got     MetricResult
+		want    State
+		wantMS  int64
+		checkMS bool
+	}{
+		{"total duration", MetricTotalDuration(input, KeyTotalDurationMS), StatePassed, 5000, true},
+		{"total duration degraded event order", MetricTotalDuration(withBackwardsEventTime(input), KeyTotalDurationMS), StateUnavailable, 0, false},
+		{"latency from voice metric event", MetricEndOfUserTurnToFirstAgentOutput(input, KeyEndOfUserTurnToFirstAgentOutputMS), StatePassed, 1200, true},
+		{"latency degraded metric event", MetricEndOfUserTurnToFirstAgentOutput(withInvalidVoiceMetric(input), KeyEndOfUserTurnToFirstAgentOutputMS), StateUnavailable, 0, false},
+		{"latency unavailable without user input", MetricEndOfUserTurnToFirstAgentOutput(withoutUserTurns(withoutTimingMarkers(withoutVoiceMetric(input))), KeyEndOfUserTurnToFirstAgentOutputMS), StateUnavailable, 0, false},
+		{"latency unavailable when agent precedes user", MetricEndOfUserTurnToFirstAgentOutput(agentBeforeUser(withoutTimingMarkers(withoutVoiceMetric(input))), KeyEndOfUserTurnToFirstAgentOutputMS), StateUnavailable, 0, false},
+	}
+
+	for _, tc := range metrics {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got.State != tc.want {
+				t.Fatalf("state = %q, want %q; result=%+v", tc.got.State, tc.want, tc.got)
+			}
+			if tc.checkMS && tc.got.ValueMS != tc.wantMS {
+				t.Fatalf("value_ms = %d, want %d", tc.got.ValueMS, tc.wantMS)
+			}
+		})
+	}
+}
+
+func TestValidateInputRejectsMalformedEvidence(t *testing.T) {
+	input := loadGoldenInput(t)
+	input.Trace.Segments[0].SegmentID = ""
+
+	if err := ValidateInput(input); err == nil {
+		t.Fatalf("ValidateInput returned nil, want error")
+	}
+}
+
+func TestStableKeys(t *testing.T) {
+	keys := []string{
+		KeyTaskSuccess,
+		KeyToolCallName,
+		KeyToolCallArguments,
+		KeyNoForbiddenPhrase,
+		KeyMaxTurns,
+		KeyInterruptionHandled,
+		KeyTotalDurationMS,
+		KeyEndOfUserTurnToFirstAgentOutputMS,
+	}
+	for _, key := range keys {
+		if key == "" {
+			t.Fatalf("stable key must not be empty")
+		}
+	}
+}
+
+func loadGoldenInput(t *testing.T) Input {
+	t.Helper()
+	traceData, err := os.ReadFile("../voicetextsim/testdata/support_billing_expected_trace.json")
+	if err != nil {
+		t.Fatalf("read trace golden: %v", err)
+	}
+	eventsData, err := os.ReadFile("../voicetextsim/testdata/support_billing_expected_events.json")
+	if err != nil {
+		t.Fatalf("read events golden: %v", err)
+	}
+	var trace multimodaltrace.Trace
+	if err := json.Unmarshal(traceData, &trace); err != nil {
+		t.Fatalf("decode trace golden: %v", err)
+	}
+	var events []runevents.Envelope
+	if err := json.Unmarshal(eventsData, &events); err != nil {
+		t.Fatalf("decode events golden: %v", err)
+	}
+	input := Input{Trace: trace, Events: events}
+	if err := ValidateInput(input); err != nil {
+		t.Fatalf("ValidateInput(golden) returned error: %v", err)
+	}
+	return input
+}
+
+func withoutEvents(input Input) Input {
+	input.Events = nil
+	return input
+}
+
+func withFailedRunEvent(input Input) Input {
+	input.Events = append([]runevents.Envelope(nil), input.Events...)
+	failed := input.Events[len(input.Events)-1]
+	failed.EventID = failed.EventID + ":failed"
+	failed.SequenceNumber++
+	failed.EventType = runevents.EventTypeSystemRunFailed
+	failed.Summary.Status = "failed"
+	input.Events = append(input.Events, failed)
+	return input
+}
+
+func withoutVoiceMetric(input Input) Input {
+	events := make([]runevents.Envelope, 0, len(input.Events))
+	for _, event := range input.Events {
+		if event.EventType == runevents.EventTypeVoiceMetricRecorded {
+			continue
+		}
+		events = append(events, event)
+	}
+	input.Events = events
+	return input
+}
+
+func withInvalidVoiceMetric(input Input) Input {
+	input.Events = append([]runevents.Envelope(nil), input.Events...)
+	for idx := range input.Events {
+		if input.Events[idx].EventType == runevents.EventTypeVoiceMetricRecorded {
+			input.Events[idx].Payload = json.RawMessage(`{"metric_key":"end_of_user_text_to_first_agent_text","value_ms":-1}`)
+			return input
+		}
+	}
+	return input
+}
+
+func withBackwardsEventTime(input Input) Input {
+	input.Events = append([]runevents.Envelope(nil), input.Events...)
+	input.Events[len(input.Events)-1].OccurredAt = input.Events[0].OccurredAt.Add(-time.Second)
+	return input
+}
+
+func withInvalidToolArguments(input Input) Input {
+	for idx := range input.Trace.Segments {
+		if input.Trace.Segments[idx].ToolCall != nil {
+			input.Trace.Segments[idx].ToolCall.Arguments = json.RawMessage(`{`)
+			return input
+		}
+	}
+	return input
+}
+
+func withoutStructuredOutput(input Input) Input {
+	return filterSegments(input, func(segment multimodaltrace.Segment) bool {
+		return segment.Kind != multimodaltrace.SegmentKindStructuredOutput
+	})
+}
+
+func withoutToolCall(input Input) Input {
+	return filterSegments(input, func(segment multimodaltrace.Segment) bool {
+		return segment.Kind != multimodaltrace.SegmentKindToolCall
+	})
+}
+
+func withoutTimingMarkers(input Input) Input {
+	return filterSegments(input, func(segment multimodaltrace.Segment) bool {
+		return segment.Kind != multimodaltrace.SegmentKindTimingMarker
+	})
+}
+
+func withoutUserTurns(input Input) Input {
+	return filterSegments(input, func(segment multimodaltrace.Segment) bool {
+		return segment.Actor != multimodaltrace.ActorUser
+	})
+}
+
+func withSecondUserTurn(input Input) Input {
+	input.Trace.Segments = append(input.Trace.Segments, multimodaltrace.Segment{
+		SegmentID:      "turn-002:user-text",
+		SequenceNumber: int64(len(input.Trace.Segments) + 1),
+		Kind:           multimodaltrace.SegmentKindTextInput,
+		Actor:          multimodaltrace.ActorUser,
+		OccurredAt:     input.Trace.Segments[len(input.Trace.Segments)-1].OccurredAt.Add(time.Second),
+		Text: &multimodaltrace.TextPayload{
+			Text: "I need another refund.",
+		},
+	})
+	return input
+}
+
+func withBargeIn(input Input) Input {
+	input.Trace.Segments = append(input.Trace.Segments, multimodaltrace.Segment{
+		SegmentID:      "turn-001:barge-in",
+		SequenceNumber: int64(len(input.Trace.Segments) + 1),
+		Kind:           multimodaltrace.SegmentKindMediaControl,
+		Actor:          multimodaltrace.ActorSystem,
+		OccurredAt:     input.Trace.Segments[len(input.Trace.Segments)-1].OccurredAt.Add(time.Millisecond),
+		MediaControl: &multimodaltrace.MediaControlPayload{
+			Action:          "barge_in_detected",
+			TargetSegmentID: "turn-001:agent-audio",
+		},
+	})
+	return input
+}
+
+func agentBeforeUser(input Input) Input {
+	for idx := range input.Trace.Segments {
+		segment := input.Trace.Segments[idx]
+		if segment.Actor == multimodaltrace.ActorAgent &&
+			(segment.Kind == multimodaltrace.SegmentKindTextOutput || segment.Kind == multimodaltrace.SegmentKindAudioOutput) {
+			input.Trace.Segments[idx].OccurredAt = input.Trace.Segments[0].OccurredAt.Add(-time.Second)
+			return input
+		}
+	}
+	return input
+}
+
+func filterSegments(input Input, keep func(multimodaltrace.Segment) bool) Input {
+	segments := make([]multimodaltrace.Segment, 0, len(input.Trace.Segments))
+	nextSequence := int64(1)
+	for _, segment := range input.Trace.Segments {
+		if !keep(segment) {
+			continue
+		}
+		segment.SequenceNumber = nextSequence
+		nextSequence++
+		segments = append(segments, segment)
+	}
+	input.Trace.Segments = segments
+	return input
+}

--- a/backend/internal/voiceeval/eval_test.go
+++ b/backend/internal/voiceeval/eval_test.go
@@ -65,8 +65,12 @@ func TestVoiceMetricsAgainstTextSimGolden(t *testing.T) {
 		{"total duration degraded event order", MetricTotalDuration(withBackwardsEventTime(input), KeyTotalDurationMS), StateUnavailable, 0, false},
 		{"latency from voice metric event", MetricEndOfUserTurnToFirstAgentOutput(input, KeyEndOfUserTurnToFirstAgentOutputMS), StatePassed, 1200, true},
 		{"latency degraded metric event", MetricEndOfUserTurnToFirstAgentOutput(withInvalidVoiceMetric(input), KeyEndOfUserTurnToFirstAgentOutputMS), StateUnavailable, 0, false},
+		{"latency missing metric value", MetricEndOfUserTurnToFirstAgentOutput(withMissingVoiceMetricValue(input), KeyEndOfUserTurnToFirstAgentOutputMS), StateUnavailable, 0, false},
 		{"latency unavailable without user input", MetricEndOfUserTurnToFirstAgentOutput(withoutUserTurns(withoutTimingMarkers(withoutVoiceMetric(input))), KeyEndOfUserTurnToFirstAgentOutputMS), StateUnavailable, 0, false},
 		{"latency unavailable when agent precedes user", MetricEndOfUserTurnToFirstAgentOutput(agentBeforeUser(withoutTimingMarkers(withoutVoiceMetric(input))), KeyEndOfUserTurnToFirstAgentOutputMS), StateUnavailable, 0, false},
+		{"latency unavailable without explicit evidence", MetricEndOfUserTurnToFirstAgentOutput(withoutTimingMarkers(withoutVoiceMetric(input)), KeyEndOfUserTurnToFirstAgentOutputMS), StateUnavailable, 0, false},
+		{"total duration unavailable with one event", MetricTotalDuration(withOnlyOneEvent(input), KeyTotalDurationMS), StateUnavailable, 0, false},
+		{"total duration unavailable with one segment", MetricTotalDuration(withOnlyOneSegment(withoutEvents(input)), KeyTotalDurationMS), StateUnavailable, 0, false},
 	}
 
 	for _, tc := range metrics {
@@ -91,19 +95,29 @@ func TestValidateInputRejectsMalformedEvidence(t *testing.T) {
 }
 
 func TestStableKeys(t *testing.T) {
-	keys := []string{
-		KeyTaskSuccess,
-		KeyToolCallName,
-		KeyToolCallArguments,
-		KeyNoForbiddenPhrase,
-		KeyMaxTurns,
-		KeyInterruptionHandled,
-		KeyTotalDurationMS,
-		KeyEndOfUserTurnToFirstAgentOutputMS,
+	keys := map[string]string{
+		"task success":                  KeyTaskSuccess,
+		"tool call name":                KeyToolCallName,
+		"tool call arguments":           KeyToolCallArguments,
+		"no forbidden phrase":           KeyNoForbiddenPhrase,
+		"max turns":                     KeyMaxTurns,
+		"interruption handled":          KeyInterruptionHandled,
+		"total duration ms":             KeyTotalDurationMS,
+		"end user turn to agent output": KeyEndOfUserTurnToFirstAgentOutputMS,
 	}
-	for _, key := range keys {
-		if key == "" {
-			t.Fatalf("stable key must not be empty")
+	want := map[string]string{
+		"task success":                  "task_success",
+		"tool call name":                "tool_call_name",
+		"tool call arguments":           "tool_call_arguments",
+		"no forbidden phrase":           "no_forbidden_phrase",
+		"max turns":                     "max_turns",
+		"interruption handled":          "interruption_handled",
+		"total duration ms":             "total_duration_ms",
+		"end user turn to agent output": "end_of_user_turn_to_first_agent_output_ms",
+	}
+	for name, key := range keys {
+		if key != want[name] {
+			t.Fatalf("%s key = %q, want %q", name, key, want[name])
 		}
 	}
 }
@@ -169,6 +183,27 @@ func withInvalidVoiceMetric(input Input) Input {
 			return input
 		}
 	}
+	return input
+}
+
+func withMissingVoiceMetricValue(input Input) Input {
+	input.Events = append([]runevents.Envelope(nil), input.Events...)
+	for idx := range input.Events {
+		if input.Events[idx].EventType == runevents.EventTypeVoiceMetricRecorded {
+			input.Events[idx].Payload = json.RawMessage(`{"metric_key":"end_of_user_text_to_first_agent_text"}`)
+			return input
+		}
+	}
+	return input
+}
+
+func withOnlyOneEvent(input Input) Input {
+	input.Events = input.Events[:1]
+	return input
+}
+
+func withOnlyOneSegment(input Input) Input {
+	input.Trace.Segments = input.Trace.Segments[:1]
 	return input
 }
 


### PR DESCRIPTION
Closes #763.

## Summary

- Adds `backend/internal/voiceeval`, a deterministic evaluator package for voice-agent traces/events.
- Implements provider-neutral validators for task success, exact tool calls, forbidden phrases, max turns, and interruption markers.
- Implements stable-key metrics for total duration and user-turn-to-agent-output latency, returning `unavailable` for missing/degraded evidence instead of fabricating values.

## Test Contract

# codex/voice-validators-metrics - Test Contract

## Functional Behavior
- Deterministic voice validators and metrics consume only `multimodaltrace.Trace` and canonical `runevents.Envelope` data.
- Validators support task success from structured output, exact tool call name, exact tool call arguments, forbidden phrase/policy violation text, max turns, and interruption handled marker.
- Metrics support total duration from timestamps and end-of-user-turn to first agent-output latency from trace/event evidence.
- Missing or degraded metric evidence is marked unavailable instead of fabricated.
- Passing and failing examples are deterministic and provider-neutral.

## Unit Tests
- Table-driven tests cover pass, fail, missing evidence, and degraded/unavailable evidence for every validator/metric.
- Golden text-sim trace/events from `voicetextsim/testdata` are loaded and evaluated.
- Tests assert stable keys suitable for scorecards and compare gates.

## Integration / Functional Tests
- `go test ./internal/voiceeval ./internal/voicetextsim ./internal/multimodaltrace ./internal/runevents`

## Smoke Tests
- `go test ./internal/voiceeval`
- `go test ./...`

## E2E Tests
N/A - scorecard and compare-gate wiring are later issues.

## Manual / cURL Tests
N/A - backend package only.

## Verification

- `cd backend && go test ./internal/voiceeval`
- `cd backend && go test ./internal/voiceeval ./internal/voicetextsim ./internal/multimodaltrace ./internal/runevents`
- `cd backend && go test ./...`

## Review Checkpoint JSON

```json
{
  "branch": "codex/voice-validators-metrics",
  "test_contract": "/tmp/codex-voice-validators-metrics-test-contract.md",
  "created_at": "2026-05-13T14:39:02Z",
  "steps": [
    {
      "step_number": 1,
      "title": "Add deterministic voice validators and metrics",
      "timestamp": "2026-05-13T14:39:02Z",
      "files_changed": [
        "backend/internal/voiceeval/eval.go",
        "backend/internal/voiceeval/eval_test.go"
      ],
      "what_changed": "Added a provider-neutral voiceeval package that consumes multimodaltrace.Trace and runevents.Envelope evidence. It implements stable-key check and metric results, task success via structured output or terminal events, exact tool call name/arguments, forbidden phrase checks, max-turn checks, interruption markers, total duration, and end-of-user-turn to first agent output latency. Degraded metric evidence returns unavailable instead of fabricating values.",
      "review_instructions": "Verify validators only inspect trace/event data and do not call providers or LLMs. Check that metric keys are stable, total duration uses monotonic fake timestamps, latency prefers voice.metric.recorded events, and missing/degraded evidence returns unavailable. Run the focused and full backend tests.",
      "review_result": {
        "status": "pass",
        "issues_found": [],
        "notes": "Self-review found the initial draft lacked event-based task success and event-first latency; both were added before commit. Focused and full backend tests pass."
      },
      "cumulative_review": {
        "previous_steps_still_valid": true,
        "integration_issues": [],
        "notes": "Builds directly on the existing trace, run event, and text-sim golden fixtures without changing their contracts."
      }
    },
    {
      "step_number": "final",
      "title": "Final review against test contract",
      "timestamp": "2026-05-13T14:39:02Z",
      "test_contract_review": {
        "functional_behavior": "pass - deterministic validators and metrics consume multimodal traces and canonical run events only; no provider logs, LLM calls, API keys, or network are used.",
        "unit_tests": "pass - table-driven tests cover pass, fail, missing evidence, and degraded/unavailable evidence for validators and metrics using golden text-sim fixtures.",
        "integration_tests": "pass - go test ./internal/voiceeval ./internal/voicetextsim ./internal/multimodaltrace ./internal/runevents passed.",
        "smoke_tests": "pass - go test ./internal/voiceeval and go test ./... passed from backend/.",
        "e2e_tests": "N/A - scorecard and compare-gate wiring are later issues.",
        "manual_tests": "N/A - backend package only."
      },
      "overall_verdict": "ready",
      "blocking_issues": []
    }
  ]
}
```
