### PR TITLE
feat(voice-evals): add voice replay projection

### DIFF
--- a/backend/internal/voicereplay/projection.go
+++ b/backend/internal/voicereplay/projection.go
@@ -1,0 +1,309 @@
+package voicereplay
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/agentclash/agentclash/backend/internal/runevents"
+	"github.com/agentclash/agentclash/backend/internal/voiceartifacts"
+)
+
+const SchemaVersionV1 = "2026-05-13"
+
+var ErrInvalidInput = errors.New("invalid voice replay input")
+
+type Projection struct {
+	SchemaVersion    string               `json:"schema_version"`
+	VoiceSessionID   string               `json:"voice_session_id"`
+	RunID            string               `json:"run_id"`
+	RunAgentID       string               `json:"run_agent_id"`
+	Turns            []Turn               `json:"turns"`
+	Artifacts        []ArtifactProjection `json:"artifacts"`
+	DegradedEvidence []string             `json:"degraded_evidence,omitempty"`
+}
+
+type Turn struct {
+	TurnID      string              `json:"turn_id"`
+	TurnIndex   int                 `json:"turn_index,omitempty"`
+	Events      []EventProjection   `json:"events"`
+	Transcripts []TranscriptSegment `json:"transcripts,omitempty"`
+	ToolCalls   []ToolCall          `json:"tool_calls,omitempty"`
+	Audio       []AudioReference    `json:"audio,omitempty"`
+	Metrics     []MetricMarker      `json:"metrics,omitempty"`
+}
+
+type EventProjection struct {
+	SequenceNumber int64  `json:"sequence_number"`
+	EventType      string `json:"event_type"`
+	OccurredAt     string `json:"occurred_at"`
+	Speaker        string `json:"speaker,omitempty"`
+	Channel        string `json:"channel,omitempty"`
+}
+
+type TranscriptSegment struct {
+	SequenceNumber int64  `json:"sequence_number"`
+	SegmentID      string `json:"segment_id,omitempty"`
+	Speaker        string `json:"speaker,omitempty"`
+	Channel        string `json:"channel,omitempty"`
+	Text           string `json:"text"`
+	Language       string `json:"language,omitempty"`
+}
+
+type ToolCall struct {
+	SequenceNumber int64           `json:"sequence_number"`
+	CallID         string          `json:"call_id"`
+	ToolName       string          `json:"tool_name"`
+	Arguments      json.RawMessage `json:"arguments,omitempty"`
+	Result         json.RawMessage `json:"result,omitempty"`
+	Error          string          `json:"error,omitempty"`
+}
+
+type AudioReference struct {
+	SequenceNumber int64  `json:"sequence_number"`
+	SegmentID      string `json:"segment_id,omitempty"`
+	ArtifactKey    string `json:"artifact_key"`
+	ArtifactRef    string `json:"artifact_ref,omitempty"`
+	DurationMS     int64  `json:"duration_ms,omitempty"`
+}
+
+type MetricMarker struct {
+	SequenceNumber int64  `json:"sequence_number"`
+	Key            string `json:"key"`
+	ValueMS        int64  `json:"value_ms"`
+}
+
+type ArtifactProjection struct {
+	Key            string `json:"key"`
+	Kind           string `json:"kind"`
+	Location       string `json:"location"`
+	Path           string `json:"path,omitempty"`
+	Bucket         string `json:"bucket,omitempty"`
+	ObjectKey      string `json:"object_key,omitempty"`
+	ContentType    string `json:"content_type,omitempty"`
+	SizeBytes      int64  `json:"size_bytes,omitempty"`
+	ChecksumSHA256 string `json:"checksum_sha256"`
+}
+
+func Build(events []runevents.Envelope, manifest voiceartifacts.Manifest) (Projection, error) {
+	if err := manifest.Validate(); err != nil {
+		return Projection{}, fmt.Errorf("%w: manifest: %w", ErrInvalidInput, err)
+	}
+	if len(events) == 0 {
+		return Projection{}, fmt.Errorf("%w: events are required", ErrInvalidInput)
+	}
+	ordered := append([]runevents.Envelope(nil), events...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].SequenceNumber < ordered[j].SequenceNumber
+	})
+	for idx, event := range ordered {
+		if err := event.ValidatePersisted(); err != nil {
+			return Projection{}, fmt.Errorf("%w: events[%d]: %w", ErrInvalidInput, idx, err)
+		}
+	}
+
+	builder := projectionBuilder{
+		projection: Projection{
+			SchemaVersion:  SchemaVersionV1,
+			VoiceSessionID: manifest.VoiceSessionID,
+			RunID:          manifest.RunID.String(),
+			RunAgentID:     manifest.RunAgentID.String(),
+			Artifacts:      artifacts(manifest.Artifacts),
+		},
+		artifactByKind: artifactsByKind(manifest.Artifacts),
+		turnByID:       map[string]int{},
+	}
+
+	for _, event := range ordered {
+		builder.addEvent(event)
+	}
+	builder.finalize()
+	return builder.projection, nil
+}
+
+func StableJSON(projection Projection) ([]byte, error) {
+	encoded, err := json.MarshalIndent(projection, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode voice replay projection: %w", err)
+	}
+	return append(encoded, '\n'), nil
+}
+
+type projectionBuilder struct {
+	projection     Projection
+	artifactByKind map[voiceartifacts.ArtifactKind]voiceartifacts.ArtifactRef
+	turnByID       map[string]int
+}
+
+func (b *projectionBuilder) addEvent(event runevents.Envelope) {
+	payload := decodePayload(event.Payload)
+	turnID := stringField(payload, "turn_id")
+	if turnID == "" {
+		turnID = "session"
+	}
+	turn := b.turn(turnID, event.Summary.TurnIndex)
+	turn.Events = append(turn.Events, EventProjection{
+		SequenceNumber: event.SequenceNumber,
+		EventType:      string(event.EventType),
+		OccurredAt:     event.OccurredAt.Format("2006-01-02T15:04:05.999999999Z07:00"),
+		Speaker:        event.Summary.Speaker,
+		Channel:        event.Summary.Channel,
+	})
+
+	switch event.EventType {
+	case runevents.EventTypeTranscriptFinal, runevents.EventTypeTranscriptPartial:
+		text := stringField(payload, "text")
+		if text != "" {
+			turn.Transcripts = append(turn.Transcripts, TranscriptSegment{
+				SequenceNumber: event.SequenceNumber,
+				SegmentID:      stringField(payload, "segment_id"),
+				Speaker:        event.Summary.Speaker,
+				Channel:        event.Summary.Channel,
+				Text:           text,
+				Language:       stringField(payload, "language"),
+			})
+		}
+	case runevents.EventTypeToolCallStarted, runevents.EventTypeToolCallCompleted, runevents.EventTypeToolCallFailed:
+		turn.ToolCalls = append(turn.ToolCalls, ToolCall{
+			SequenceNumber: event.SequenceNumber,
+			CallID:         stringField(payload, "call_id"),
+			ToolName:       stringField(payload, "tool_name"),
+			Arguments:      rawField(payload, "arguments"),
+			Result:         rawField(payload, "result"),
+			Error:          stringField(payload, "error"),
+		})
+	case runevents.EventTypeAgentAudioStarted, runevents.EventTypeAgentAudioCompleted:
+		turn.Audio = append(turn.Audio, b.audioReference(event, payload, voiceartifacts.ArtifactKindAgentAudio))
+	case runevents.EventTypeMediaFrameReceived, runevents.EventTypeSpeechStarted, runevents.EventTypeSpeechStopped:
+		turn.Audio = append(turn.Audio, b.audioReference(event, payload, voiceartifacts.ArtifactKindCallerAudio))
+	case runevents.EventTypeVoiceMetricRecorded:
+		turn.Metrics = append(turn.Metrics, MetricMarker{
+			SequenceNumber: event.SequenceNumber,
+			Key:            stringField(payload, "metric_key"),
+			ValueMS:        int64Field(payload, "value_ms"),
+		})
+	}
+	b.projection.Turns[b.turnByID[turnID]] = *turn
+}
+
+func (b *projectionBuilder) turn(turnID string, turnIndex *int) *Turn {
+	if idx, ok := b.turnByID[turnID]; ok {
+		return &b.projection.Turns[idx]
+	}
+	turn := Turn{TurnID: turnID}
+	if turnIndex != nil {
+		turn.TurnIndex = *turnIndex
+	}
+	b.turnByID[turnID] = len(b.projection.Turns)
+	b.projection.Turns = append(b.projection.Turns, turn)
+	return &b.projection.Turns[len(b.projection.Turns)-1]
+}
+
+func (b *projectionBuilder) audioReference(event runevents.Envelope, payload map[string]json.RawMessage, kind voiceartifacts.ArtifactKind) AudioReference {
+	ref := AudioReference{
+		SequenceNumber: event.SequenceNumber,
+		SegmentID:      stringField(payload, "segment_id"),
+		ArtifactRef:    stringField(payload, "artifact_ref"),
+		DurationMS:     int64Field(payload, "duration_ms"),
+	}
+	artifact, ok := b.artifactByKind[kind]
+	if ok {
+		ref.ArtifactKey = artifact.Key
+		return ref
+	}
+	ref.ArtifactKey = string(kind)
+	b.projection.DegradedEvidence = append(b.projection.DegradedEvidence, "missing_audio_artifact:"+string(kind))
+	return ref
+}
+
+func (b *projectionBuilder) finalize() {
+	if _, ok := b.artifactByKind[voiceartifacts.ArtifactKindMixedAudio]; !ok {
+		b.projection.DegradedEvidence = append(b.projection.DegradedEvidence, "missing_audio_artifact:"+string(voiceartifacts.ArtifactKindMixedAudio))
+	}
+	b.projection.DegradedEvidence = uniqueStrings(b.projection.DegradedEvidence)
+	sort.Strings(b.projection.DegradedEvidence)
+}
+
+func artifacts(refs []voiceartifacts.ArtifactRef) []ArtifactProjection {
+	out := make([]ArtifactProjection, 0, len(refs))
+	for _, ref := range refs {
+		out = append(out, ArtifactProjection{
+			Key:            ref.Key,
+			Kind:           string(ref.Kind),
+			Location:       string(ref.Location),
+			Path:           ref.Path,
+			Bucket:         ref.Bucket,
+			ObjectKey:      ref.ObjectKey,
+			ContentType:    ref.ContentType,
+			SizeBytes:      ref.SizeBytes,
+			ChecksumSHA256: ref.ChecksumSHA256,
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	return out
+}
+
+func artifactsByKind(refs []voiceartifacts.ArtifactRef) map[voiceartifacts.ArtifactKind]voiceartifacts.ArtifactRef {
+	byKind := make(map[voiceartifacts.ArtifactKind]voiceartifacts.ArtifactRef, len(refs))
+	for _, ref := range refs {
+		byKind[ref.Kind] = ref
+	}
+	return byKind
+}
+
+func decodePayload(raw json.RawMessage) map[string]json.RawMessage {
+	payload := map[string]json.RawMessage{}
+	_ = json.Unmarshal(raw, &payload)
+	return payload
+}
+
+func rawField(payload map[string]json.RawMessage, key string) json.RawMessage {
+	raw := payload[key]
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var normalized any
+	if err := json.Unmarshal(raw, &normalized); err != nil {
+		return nil
+	}
+	encoded, err := json.Marshal(normalized)
+	if err != nil {
+		return nil
+	}
+	return encoded
+}
+
+func stringField(payload map[string]json.RawMessage, key string) string {
+	raw := payload[key]
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return ""
+	}
+	return value
+}
+
+func int64Field(payload map[string]json.RawMessage, key string) int64 {
+	raw := payload[key]
+	var value int64
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return 0
+	}
+	return value
+}
+
+func uniqueStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	unique := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		unique = append(unique, value)
+	}
+	return unique
+}

--- a/backend/internal/voicereplay/projection_test.go
+++ b/backend/internal/voicereplay/projection_test.go
@@ -1,0 +1,140 @@
+package voicereplay
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/runevents"
+	"github.com/agentclash/agentclash/backend/internal/voiceartifacts"
+)
+
+func TestBuildSupportBillingReplayGoldenJSON(t *testing.T) {
+	projection := buildProjection(t, loadEvents(t), loadManifest(t))
+	got := stableString(t, projection)
+	want, err := os.ReadFile("testdata/support_billing_replay.json")
+	if err != nil {
+		t.Fatalf("read replay golden: %v", err)
+	}
+	if got != strings.TrimSpace(string(want)) {
+		t.Fatalf("replay JSON mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+func TestBuildMarksMissingOptionalAudioArtifactAsDegraded(t *testing.T) {
+	manifest := loadManifest(t)
+	manifest.Artifacts = filterArtifacts(manifest.Artifacts, voiceartifacts.ArtifactKindMixedAudio)
+
+	projection := buildProjection(t, loadEvents(t), manifest)
+
+	if !contains(projection.DegradedEvidence, "missing_audio_artifact:mixed_audio") {
+		t.Fatalf("degraded evidence = %v, want missing mixed audio marker", projection.DegradedEvidence)
+	}
+	if len(projection.Turns) == 0 {
+		t.Fatalf("projection should still contain turns")
+	}
+}
+
+func TestBuildOrdersEventsByCanonicalSequence(t *testing.T) {
+	events := loadEvents(t)
+	events[1].OccurredAt = events[len(events)-1].OccurredAt.Add(time.Hour)
+	reversed := append([]runevents.Envelope(nil), events...)
+	for left, right := 0, len(reversed)-1; left < right; left, right = left+1, right-1 {
+		reversed[left], reversed[right] = reversed[right], reversed[left]
+	}
+
+	projection := buildProjection(t, reversed, loadManifest(t))
+	firstTurn := findTurn(t, projection, "turn-001")
+
+	if firstTurn.Events[0].SequenceNumber != 2 {
+		t.Fatalf("first turn event sequence = %d, want 2", firstTurn.Events[0].SequenceNumber)
+	}
+	for idx := 1; idx < len(firstTurn.Events); idx++ {
+		if firstTurn.Events[idx].SequenceNumber <= firstTurn.Events[idx-1].SequenceNumber {
+			t.Fatalf("events not ordered by sequence at %d: %+v", idx, firstTurn.Events)
+		}
+	}
+	if firstTurn.Events[0].OccurredAt != "2026-05-13T11:00:05Z" {
+		t.Fatalf("occurred_at = %q, want timestamp preserved despite sequence ordering", firstTurn.Events[0].OccurredAt)
+	}
+}
+
+func TestBuildRejectsInvalidInput(t *testing.T) {
+	if _, err := Build(nil, loadManifest(t)); err == nil {
+		t.Fatalf("Build returned nil error for missing events")
+	}
+}
+
+func buildProjection(t *testing.T, events []runevents.Envelope, manifest voiceartifacts.Manifest) Projection {
+	t.Helper()
+	projection, err := Build(events, manifest)
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+	return projection
+}
+
+func loadEvents(t *testing.T) []runevents.Envelope {
+	t.Helper()
+	data, err := os.ReadFile("../voicetextsim/testdata/support_billing_expected_events.json")
+	if err != nil {
+		t.Fatalf("read events fixture: %v", err)
+	}
+	var events []runevents.Envelope
+	if err := json.Unmarshal(data, &events); err != nil {
+		t.Fatalf("decode events fixture: %v", err)
+	}
+	return events
+}
+
+func loadManifest(t *testing.T) voiceartifacts.Manifest {
+	t.Helper()
+	manifest, err := voiceartifacts.Load(filepath.Join("../voiceartifacts/testdata/support_billing", "voice_artifact_manifest.json"))
+	if err != nil {
+		t.Fatalf("load manifest fixture: %v", err)
+	}
+	return manifest
+}
+
+func stableString(t *testing.T, projection Projection) string {
+	t.Helper()
+	encoded, err := StableJSON(projection)
+	if err != nil {
+		t.Fatalf("StableJSON returned error: %v", err)
+	}
+	return strings.TrimSpace(string(encoded))
+}
+
+func findTurn(t *testing.T, projection Projection, turnID string) Turn {
+	t.Helper()
+	for _, turn := range projection.Turns {
+		if turn.TurnID == turnID {
+			return turn
+		}
+	}
+	t.Fatalf("turn %q not found", turnID)
+	return Turn{}
+}
+
+func filterArtifacts(artifacts []voiceartifacts.ArtifactRef, without voiceartifacts.ArtifactKind) []voiceartifacts.ArtifactRef {
+	filtered := make([]voiceartifacts.ArtifactRef, 0, len(artifacts))
+	for _, artifact := range artifacts {
+		if artifact.Kind == without {
+			continue
+		}
+		filtered = append(filtered, artifact)
+	}
+	return filtered
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/voicereplay/testdata/support_billing_replay.json
+++ b/backend/internal/voicereplay/testdata/support_billing_replay.json
@@ -1,0 +1,206 @@
+{
+  "schema_version": "2026-05-13",
+  "voice_session_id": "voice-session-support-billing-seed-42",
+  "run_id": "33333333-3333-3333-3333-333333333333",
+  "run_agent_id": "44444444-4444-4444-4444-444444444444",
+  "turns": [
+    {
+      "turn_id": "session",
+      "events": [
+        {
+          "sequence_number": 1,
+          "event_type": "media.session.started",
+          "occurred_at": "2026-05-13T10:00:00Z"
+        },
+        {
+          "sequence_number": 9,
+          "event_type": "system.run.completed",
+          "occurred_at": "2026-05-13T10:00:05Z"
+        }
+      ]
+    },
+    {
+      "turn_id": "turn-001",
+      "turn_index": 1,
+      "events": [
+        {
+          "sequence_number": 2,
+          "event_type": "transcript.final",
+          "occurred_at": "2026-05-13T10:00:01Z",
+          "speaker": "caller",
+          "channel": "text"
+        },
+        {
+          "sequence_number": 3,
+          "event_type": "tool.call.started",
+          "occurred_at": "2026-05-13T10:00:01.7Z",
+          "speaker": "agent",
+          "channel": "tool"
+        },
+        {
+          "sequence_number": 4,
+          "event_type": "agent.audio.started",
+          "occurred_at": "2026-05-13T10:00:02.6Z",
+          "speaker": "agent",
+          "channel": "audio"
+        },
+        {
+          "sequence_number": 5,
+          "event_type": "transcript.final",
+          "occurred_at": "2026-05-13T10:00:02.7Z",
+          "speaker": "agent",
+          "channel": "text"
+        },
+        {
+          "sequence_number": 6,
+          "event_type": "turn.completed",
+          "occurred_at": "2026-05-13T10:00:02.8Z",
+          "speaker": "agent",
+          "channel": "text"
+        },
+        {
+          "sequence_number": 7,
+          "event_type": "voice.metric.recorded",
+          "occurred_at": "2026-05-13T10:00:02.8Z",
+          "speaker": "evaluator",
+          "channel": "metric"
+        },
+        {
+          "sequence_number": 8,
+          "event_type": "agent.audio.completed",
+          "occurred_at": "2026-05-13T10:00:05Z",
+          "speaker": "agent",
+          "channel": "audio"
+        }
+      ],
+      "transcripts": [
+        {
+          "sequence_number": 2,
+          "segment_id": "turn-001:user-text",
+          "speaker": "caller",
+          "channel": "text",
+          "text": "I was charged twice for my last invoice.",
+          "language": "en-US"
+        },
+        {
+          "sequence_number": 5,
+          "segment_id": "turn-001:agent-transcript",
+          "speaker": "agent",
+          "channel": "text",
+          "text": "I found the duplicate charge and created refund rf_123.",
+          "language": "en-US"
+        }
+      ],
+      "tool_calls": [
+        {
+          "sequence_number": 3,
+          "call_id": "call-refund-001",
+          "tool_name": "refund_api",
+          "arguments": {
+            "account_id": "acct_123",
+            "amount_cents": 4200,
+            "currency": "USD",
+            "idempotency_key": "voice-fixture-42-refund",
+            "reason": "duplicate_charge"
+          }
+        }
+      ],
+      "audio": [
+        {
+          "sequence_number": 4,
+          "segment_id": "turn-001:agent-audio",
+          "artifact_key": "agent_audio",
+          "artifact_ref": "voice://artifacts/agent-turn-001.wav"
+        },
+        {
+          "sequence_number": 8,
+          "segment_id": "turn-001:agent-audio",
+          "artifact_key": "agent_audio",
+          "artifact_ref": "voice://artifacts/agent-turn-001.wav",
+          "duration_ms": 2400
+        }
+      ],
+      "metrics": [
+        {
+          "sequence_number": 7,
+          "key": "end_of_user_text_to_first_agent_text",
+          "value_ms": 1200
+        }
+      ]
+    }
+  ],
+  "artifacts": [
+    {
+      "key": "agent_audio",
+      "kind": "agent_audio",
+      "location": "local_path",
+      "path": "artifacts/agent-turn-001.wav",
+      "content_type": "audio/wav",
+      "size_bytes": 30,
+      "checksum_sha256": "d95869356aa66d7543cc9e21a4d68534034d2e91a33039b43bbac661d753fb49"
+    },
+    {
+      "key": "caller_audio",
+      "kind": "caller_audio",
+      "location": "local_path",
+      "path": "artifacts/caller-turn-001.wav",
+      "content_type": "audio/wav",
+      "size_bytes": 31,
+      "checksum_sha256": "8f1415ad8c350a9547df1f13cd0836d7ffb8b459f587ad5d423f471fada0197e"
+    },
+    {
+      "key": "mixed_audio",
+      "kind": "mixed_audio",
+      "location": "local_path",
+      "path": "artifacts/mixed-session.wav",
+      "content_type": "audio/wav",
+      "size_bytes": 30,
+      "checksum_sha256": "bcf377986e5fc44d7699278e4607bfbb6602d844cf512a678267d732dac3f2fc"
+    },
+    {
+      "key": "raw_provider_trace",
+      "kind": "raw_provider_trace_json",
+      "location": "local_path",
+      "path": "artifacts/raw_provider_trace.json",
+      "content_type": "application/json",
+      "size_bytes": 116,
+      "checksum_sha256": "2b0de1dfc776dbe85ba4813758eeace9b99c310b0448ceb67659ef9e37be4031"
+    },
+    {
+      "key": "redaction_metadata",
+      "kind": "redaction_metadata_json",
+      "location": "local_path",
+      "path": "artifacts/redaction_metadata.json",
+      "content_type": "application/json",
+      "size_bytes": 76,
+      "checksum_sha256": "0ea5f85848b67f3852ddf7292dd7d76a5d90e249f8aceac1699a301990d4eb1b"
+    },
+    {
+      "key": "structured_output",
+      "kind": "structured_output_json",
+      "location": "local_path",
+      "path": "artifacts/structured_output.json",
+      "content_type": "application/json",
+      "size_bytes": 131,
+      "checksum_sha256": "f2475c7d3db11f1ff5aa8109cf9d3a8cbf75cc36eeadacc6f0e8f9083fbca989"
+    },
+    {
+      "key": "transcript",
+      "kind": "transcript_json",
+      "location": "local_path",
+      "path": "artifacts/transcript.json",
+      "content_type": "application/json",
+      "size_bytes": 328,
+      "checksum_sha256": "6f380a999d74c02d7dd29d1c85eb0c697762abddff18215f6c424cdf167aee73"
+    },
+    {
+      "key": "waveform_timeline",
+      "kind": "waveform_timeline_json",
+      "location": "local_path",
+      "path": "artifacts/waveform_timeline.json",
+      "content_type": "application/json",
+      "size_bytes": 335,
+      "checksum_sha256": "f33379b417f077ba9a8ab8427dbec74d3732ded995c4bb9563d119b251d52a0d"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #765.

## Summary

- Adds `backend/internal/voicereplay` to build stable replay projections from canonical voice events and artifact manifests.
- Groups transcript, tool, audio, metric, and event evidence by turn while preserving canonical event sequence order.
- Marks missing optional mixed-audio artifacts as degraded evidence without crashing projection generation.

## Test Contract

# codex/voice-replay-projection - Test Contract

## Functional Behavior
- Build deterministic voice replay projection JSON from canonical `runevents.Envelope` events and `voiceartifacts.Manifest` artifacts.
- Projection preserves event order by canonical `sequence_number`, even when occurrence timestamps are out of order.
- Projection groups transcript segments, tool calls/results, timing/metric markers, and audio artifact references by turn.
- Missing optional audio artifact references do not crash projection and are surfaced in `degraded_evidence`.
- Output is stable JSON for support-billing golden fixtures.

## Unit Tests
- Golden replay JSON test loads fixture events plus artifact manifest.
- Missing optional audio artifact test verifies degraded evidence without panic/error.
- Out-of-order occurrence timestamp test verifies canonical sequence-number ordering.

## Integration / Functional Tests
- `go test ./internal/voicereplay ./internal/voiceartifacts ./internal/voicetextsim ./internal/runevents`

## Smoke Tests
- `go test ./internal/voicereplay`
- `go test ./...`

## E2E Tests
N/A - UI/API replay wiring is later.

## Manual / cURL Tests
N/A - backend package only.

## Verification

- `cd backend && go test ./internal/voicereplay`
- `cd backend && go test ./internal/voicereplay ./internal/voiceartifacts ./internal/voicetextsim ./internal/runevents`
- `cd backend && go test ./...`

## Review Checkpoint JSON

```json
{
  "branch": "codex/voice-replay-projection",
  "test_contract": "/tmp/codex-voice-replay-projection-test-contract.md",
  "created_at": "2026-05-13T14:59:00Z",
  "steps": [
    {
      "step_number": 1,
      "title": "Add deterministic voice replay projection",
      "timestamp": "2026-05-13T14:59:00Z",
      "files_changed": [
        "backend/internal/voicereplay/projection.go",
        "backend/internal/voicereplay/projection_test.go",
        "backend/internal/voicereplay/testdata/support_billing_replay.json"
      ],
      "what_changed": "Added a voicereplay package that builds stable replay projection JSON from canonical run events and voice artifact manifests. It groups events, transcripts, tool calls/results, audio references, and metric markers by turn; sorts by canonical sequence number; includes artifact index data; and marks missing optional mixed audio as degraded evidence without failing projection.",
      "review_instructions": "Verify projection uses canonical event sequence ordering, not occurrence timestamp ordering; groups evidence by turn; links audio refs through artifact manifest kinds; keeps stable golden JSON; and degrades missing optional audio evidence instead of crashing.",
      "review_result": {
        "status": "pass",
        "issues_found": [],
        "notes": "Self-review found no browser, network, LLM, or provider dependency. Focused, integration, and full backend tests pass."
      },
      "cumulative_review": {
        "previous_steps_still_valid": true,
        "integration_issues": [],
        "notes": "Uses the #758 run event model, #759 artifact manifest, and #762 text-sim fixtures without changing their contracts."
      }
    },
    {
      "step_number": "final",
      "title": "Final review against test contract",
      "timestamp": "2026-05-13T14:59:00Z",
      "test_contract_review": {
        "functional_behavior": "pass - projection builds from events/artifacts, preserves sequence ordering, groups turn evidence, links artifacts, and marks missing optional audio degraded.",
        "unit_tests": "pass - golden replay JSON, missing optional audio artifact, out-of-order timestamps, and invalid input tests are covered.",
        "integration_tests": "pass - go test ./internal/voicereplay ./internal/voiceartifacts ./internal/voicetextsim ./internal/runevents passed.",
        "smoke_tests": "pass - go test ./internal/voicereplay and go test ./... passed from backend/.",
        "e2e_tests": "N/A - UI/API replay wiring is later.",
        "manual_tests": "N/A - backend package only."
      },
      "overall_verdict": "ready",
      "blocking_issues": []
    }
  ]
}
```
