### PR TITLE
feat(voice-evals): add voice compare gate policy

### DIFF
--- a/backend/internal/releasegate/voice.go
+++ b/backend/internal/releasegate/voice.go
@@ -1,0 +1,166 @@
+package releasegate
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/agentclash/agentclash/backend/internal/voicescorecard"
+)
+
+const (
+	VoiceDimensionOverallScore        = "voice_overall_score"
+	VoiceDimensionTaskBusinessSuccess = "task_business_success"
+	VoiceDimensionInteractionQuality  = "interaction_quality"
+	VoiceDimensionToolDataCorrectness = "tool_data_correctness"
+	VoiceDimensionLatencyMS           = "latency_ms"
+	VoiceDimensionMissingEvidence     = "voice_missing_evidence"
+)
+
+type VoiceComparisonConfig struct {
+	MissingEvidenceOutcome Verdict
+}
+
+func DefaultVoiceComparisonConfig() VoiceComparisonConfig {
+	return VoiceComparisonConfig{MissingEvidenceOutcome: VerdictFail}
+}
+
+func VoicePolicy(config VoiceComparisonConfig) Policy {
+	missingThreshold := DimensionThreshold{FailDelta: floatPtr(0.01)}
+	if config.MissingEvidenceOutcome == VerdictWarn {
+		missingThreshold = DimensionThreshold{WarnDelta: floatPtr(0.01)}
+	}
+	return Policy{
+		PolicyKey:              "voice-default",
+		PolicyVersion:          1,
+		RequireComparable:      true,
+		RequireEvidenceQuality: false,
+		RequireScorecardPass:   true,
+		RequiredDimensions: []string{
+			VoiceDimensionInteractionQuality,
+			VoiceDimensionMissingEvidence,
+			VoiceDimensionOverallScore,
+			VoiceDimensionTaskBusinessSuccess,
+			VoiceDimensionToolDataCorrectness,
+		},
+		Dimensions: map[string]DimensionThreshold{
+			VoiceDimensionOverallScore:        {WarnDelta: floatPtr(0.02), FailDelta: floatPtr(0.05)},
+			VoiceDimensionTaskBusinessSuccess: {FailDelta: floatPtr(0.01)},
+			VoiceDimensionInteractionQuality:  {FailDelta: floatPtr(0.01)},
+			VoiceDimensionToolDataCorrectness: {FailDelta: floatPtr(0.01)},
+			VoiceDimensionLatencyMS:           {WarnDelta: floatPtr(100), FailDelta: floatPtr(250)},
+			VoiceDimensionMissingEvidence:     missingThreshold,
+		},
+	}
+}
+
+func BuildVoiceComparisonSummary(baseline, candidate voicescorecard.Scorecard, config VoiceComparisonConfig) ComparisonSummary {
+	warnings := voiceWarnings(baseline, candidate)
+	return ComparisonSummary{
+		SchemaVersion: "2026-05-13",
+		Status:        "comparable",
+		DimensionDeltas: map[string]DimensionDelta{
+			VoiceDimensionOverallScore:        voiceDelta(baseline.OverallScore, candidate.OverallScore, "higher"),
+			VoiceDimensionTaskBusinessSuccess: voiceDimensionDelta(baseline, candidate, VoiceDimensionTaskBusinessSuccess, "higher"),
+			VoiceDimensionInteractionQuality:  voiceDimensionDelta(baseline, candidate, VoiceDimensionInteractionQuality, "higher"),
+			VoiceDimensionToolDataCorrectness: voiceDimensionDelta(baseline, candidate, VoiceDimensionToolDataCorrectness, "higher"),
+			VoiceDimensionLatencyMS:           voiceMetricDelta(baseline, candidate, "latency", "end_of_user_turn_to_first_agent_output_ms", "lower"),
+			VoiceDimensionMissingEvidence:     voiceDelta(float64(len(baseline.DegradedKeys)), float64(len(candidate.DegradedKeys)), "lower"),
+		},
+		ScorecardPass: &ScorecardPassSummary{
+			Baseline:  boolPtr(!baseline.HardGateFailed),
+			Candidate: boolPtr(!candidate.HardGateFailed),
+		},
+		FailureDivergence: FailureDivergence{
+			CandidateFailedBaselineOK: candidate.HardGateFailed && !baseline.HardGateFailed,
+			BothFailedDifferently:     candidate.HardGateFailed && baseline.HardGateFailed && voiceFailedHardGateKeys(candidate) != voiceFailedHardGateKeys(baseline),
+		},
+		ReplaySummaryDivergence: ReplayDivergence{State: "available"},
+		EvidenceQuality: compareEvidenceQuality{
+			Warnings: warnings,
+		},
+	}
+}
+
+func voiceDimensionDelta(baseline, candidate voicescorecard.Scorecard, key string, direction string) DimensionDelta {
+	baselineValue, baselineOK := voiceDimensionScore(baseline, key)
+	candidateValue, candidateOK := voiceDimensionScore(candidate, key)
+	if !baselineOK || !candidateOK {
+		return DimensionDelta{BetterDirection: direction, State: "unavailable"}
+	}
+	return voiceDelta(baselineValue, candidateValue, direction)
+}
+
+func voiceMetricDelta(baseline, candidate voicescorecard.Scorecard, dimensionKey string, metricKey string, direction string) DimensionDelta {
+	baselineValue, baselineOK := voiceMetricValueMS(baseline, dimensionKey, metricKey)
+	candidateValue, candidateOK := voiceMetricValueMS(candidate, dimensionKey, metricKey)
+	if !baselineOK || !candidateOK {
+		return DimensionDelta{BetterDirection: direction, State: "unavailable"}
+	}
+	return voiceDelta(float64(baselineValue), float64(candidateValue), direction)
+}
+
+func voiceDelta(baseline float64, candidate float64, direction string) DimensionDelta {
+	delta := candidate - baseline
+	return DimensionDelta{
+		BaselineValue:   floatPtr(baseline),
+		CandidateValue:  floatPtr(candidate),
+		Delta:           floatPtr(delta),
+		BetterDirection: direction,
+		State:           "available",
+	}
+}
+
+func voiceDimensionScore(scorecard voicescorecard.Scorecard, key string) (float64, bool) {
+	for _, dimension := range scorecard.Dimensions {
+		if dimension.Key == key && dimension.State != "" {
+			return dimension.Score, true
+		}
+	}
+	return 0, false
+}
+
+func voiceMetricValueMS(scorecard voicescorecard.Scorecard, dimensionKey string, metricKey string) (int64, bool) {
+	for _, dimension := range scorecard.Dimensions {
+		if dimension.Key != dimensionKey {
+			continue
+		}
+		for _, metric := range dimension.Metrics {
+			if metric.Key == metricKey && metric.ValueMS != nil {
+				return *metric.ValueMS, true
+			}
+		}
+	}
+	return 0, false
+}
+
+func voiceWarnings(baseline, candidate voicescorecard.Scorecard) []string {
+	warnings := make([]string, 0, 2)
+	if len(baseline.DegradedKeys) > 0 {
+		warnings = append(warnings, fmt.Sprintf("baseline voice evidence degraded: %s", strings.Join(sortedStrings(baseline.DegradedKeys), ", ")))
+	}
+	if len(candidate.DegradedKeys) > 0 {
+		warnings = append(warnings, fmt.Sprintf("candidate voice evidence degraded: %s", strings.Join(sortedStrings(candidate.DegradedKeys), ", ")))
+	}
+	return warnings
+}
+
+func voiceFailedHardGateKeys(scorecard voicescorecard.Scorecard) string {
+	keys := make([]string, 0)
+	for _, dimension := range scorecard.Dimensions {
+		if dimension.HardGate && dimension.State == "failed" {
+			keys = append(keys, dimension.Key)
+		}
+	}
+	return strings.Join(sortedStrings(keys), ",")
+}
+
+func sortedStrings(values []string) []string {
+	out := append([]string(nil), values...)
+	sort.Strings(out)
+	return out
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}

--- a/backend/internal/releasegate/voice.go
+++ b/backend/internal/releasegate/voice.go
@@ -65,7 +65,7 @@ func BuildVoiceComparisonSummary(baseline, candidate voicescorecard.Scorecard, c
 			VoiceDimensionInteractionQuality:  voiceDimensionDelta(baseline, candidate, VoiceDimensionInteractionQuality, "higher"),
 			VoiceDimensionToolDataCorrectness: voiceDimensionDelta(baseline, candidate, VoiceDimensionToolDataCorrectness, "higher"),
 			VoiceDimensionLatencyMS:           voiceMetricDelta(baseline, candidate, "latency", "end_of_user_turn_to_first_agent_output_ms", "lower"),
-			VoiceDimensionMissingEvidence:     voiceDelta(float64(len(baseline.DegradedKeys)), float64(len(candidate.DegradedKeys)), "lower"),
+			VoiceDimensionMissingEvidence:     voiceDelta(0, float64(newCandidateDegradedKeyCount(baseline.DegradedKeys, candidate.DegradedKeys)), "lower"),
 		},
 		ScorecardPass: &ScorecardPassSummary{
 			Baseline:  boolPtr(!baseline.HardGateFailed),
@@ -80,6 +80,25 @@ func BuildVoiceComparisonSummary(baseline, candidate voicescorecard.Scorecard, c
 			Warnings: warnings,
 		},
 	}
+}
+
+func newCandidateDegradedKeyCount(baselineKeys []string, candidateKeys []string) int {
+	baselineSet := make(map[string]struct{}, len(baselineKeys))
+	for _, key := range baselineKeys {
+		baselineSet[strings.TrimSpace(key)] = struct{}{}
+	}
+	count := 0
+	for _, key := range candidateKeys {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if _, ok := baselineSet[key]; ok {
+			continue
+		}
+		count++
+	}
+	return count
 }
 
 func voiceDimensionDelta(baseline, candidate voicescorecard.Scorecard, key string, direction string) DimensionDelta {

--- a/backend/internal/releasegate/voice_test.go
+++ b/backend/internal/releasegate/voice_test.go
@@ -1,0 +1,207 @@
+package releasegate
+
+import (
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/voiceeval"
+	"github.com/agentclash/agentclash/backend/internal/voicescorecard"
+)
+
+func TestEvaluateVoiceComparisonNoRegressionPasses(t *testing.T) {
+	evaluation := evaluateVoice(t, voiceScorecard(), voiceScorecard(), DefaultVoiceComparisonConfig())
+
+	if evaluation.Verdict != VerdictPass {
+		t.Fatalf("verdict = %q, want %q", evaluation.Verdict, VerdictPass)
+	}
+	if evaluation.ReasonCode != "within_thresholds" {
+		t.Fatalf("reason code = %q, want within_thresholds", evaluation.ReasonCode)
+	}
+}
+
+func TestEvaluateVoiceComparisonLatencyRegressionFails(t *testing.T) {
+	candidate := voiceScorecard()
+	setVoiceLatencyMS(&candidate, 1600)
+
+	evaluation := evaluateVoice(t, voiceScorecard(), candidate, DefaultVoiceComparisonConfig())
+
+	if evaluation.Verdict != VerdictFail {
+		t.Fatalf("verdict = %q, want %q", evaluation.Verdict, VerdictFail)
+	}
+	if evaluation.ReasonCode != "threshold_fail_latency_ms" {
+		t.Fatalf("reason code = %q, want threshold_fail_latency_ms", evaluation.ReasonCode)
+	}
+}
+
+func TestEvaluateVoiceComparisonTaskSuccessRegressionFails(t *testing.T) {
+	candidate := voiceScorecard()
+	setVoiceDimensionScore(&candidate, VoiceDimensionTaskBusinessSuccess, 0.98)
+
+	evaluation := evaluateVoice(t, voiceScorecard(), candidate, DefaultVoiceComparisonConfig())
+
+	if evaluation.Verdict != VerdictFail {
+		t.Fatalf("verdict = %q, want %q", evaluation.Verdict, VerdictFail)
+	}
+	if evaluation.ReasonCode != "threshold_fail_task_business_success" {
+		t.Fatalf("reason code = %q, want threshold_fail_task_business_success", evaluation.ReasonCode)
+	}
+}
+
+func TestEvaluateVoiceComparisonPolicyHardGateFails(t *testing.T) {
+	candidate := voiceScorecard()
+	candidate.Passed = false
+	candidate.HardGateFailed = true
+	setVoiceDimensionState(&candidate, VoiceDimensionInteractionQuality, voiceeval.StateFailed)
+
+	evaluation := evaluateVoice(t, voiceScorecard(), candidate, DefaultVoiceComparisonConfig())
+
+	if evaluation.Verdict != VerdictFail {
+		t.Fatalf("verdict = %q, want %q", evaluation.Verdict, VerdictFail)
+	}
+	if evaluation.ReasonCode != "scorecard_not_passed" {
+		t.Fatalf("reason code = %q, want scorecard_not_passed", evaluation.ReasonCode)
+	}
+}
+
+func TestEvaluateVoiceComparisonMissingMetricCanFailOrWarnByPolicy(t *testing.T) {
+	candidate := voiceScorecard()
+	candidate.Passed = false
+	candidate.DegradedKeys = []string{"end_of_user_turn_to_first_agent_output_ms"}
+	removeVoiceLatencyMetric(&candidate)
+
+	failEvaluation := evaluateVoice(t, voiceScorecard(), candidate, VoiceComparisonConfig{MissingEvidenceOutcome: VerdictFail})
+	if failEvaluation.Verdict != VerdictFail {
+		t.Fatalf("fail policy verdict = %q, want %q", failEvaluation.Verdict, VerdictFail)
+	}
+	if failEvaluation.ReasonCode != "threshold_fail_voice_missing_evidence" {
+		t.Fatalf("fail policy reason = %q, want threshold_fail_voice_missing_evidence", failEvaluation.ReasonCode)
+	}
+
+	warnEvaluation := evaluateVoice(t, voiceScorecard(), candidate, VoiceComparisonConfig{MissingEvidenceOutcome: VerdictWarn})
+	if warnEvaluation.Verdict != VerdictWarn {
+		t.Fatalf("warn policy verdict = %q, want %q", warnEvaluation.Verdict, VerdictWarn)
+	}
+	if warnEvaluation.ReasonCode != "threshold_warn_voice_missing_evidence" {
+		t.Fatalf("warn policy reason = %q, want threshold_warn_voice_missing_evidence", warnEvaluation.ReasonCode)
+	}
+	if len(warnEvaluation.Details.Warnings) == 0 {
+		t.Fatalf("warnings = %v, want degraded evidence warning", warnEvaluation.Details.Warnings)
+	}
+}
+
+func TestExistingNonVoiceCompareFixtureStillPasses(t *testing.T) {
+	evaluation, err := Evaluate(testSummary(t, `{
+		"status":"comparable",
+		"dimension_deltas":{
+			"correctness":{"delta":-0.01,"better_direction":"higher","state":"available"},
+			"reliability":{"delta":-0.01,"better_direction":"higher","state":"available"},
+			"latency":{"delta":0.02,"better_direction":"lower","state":"available"},
+			"cost":{"delta":0.03,"better_direction":"lower","state":"available"}
+		},
+		"failure_divergence":{"candidate_failed_baseline_succeeded":false,"both_failed_differently":false},
+		"replay_summary_divergence":{"state":"available"},
+		"evidence_quality":{}
+	}`), DefaultPolicy())
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if evaluation.Verdict != VerdictPass {
+		t.Fatalf("verdict = %q, want %q", evaluation.Verdict, VerdictPass)
+	}
+}
+
+func evaluateVoice(t *testing.T, baseline voicescorecard.Scorecard, candidate voicescorecard.Scorecard, config VoiceComparisonConfig) Evaluation {
+	t.Helper()
+	evaluation, err := Evaluate(BuildVoiceComparisonSummary(baseline, candidate, config), VoicePolicy(config))
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	return evaluation
+}
+
+func voiceScorecard() voicescorecard.Scorecard {
+	return voicescorecard.Scorecard{
+		SchemaVersion:  "2026-05-13",
+		Type:           "voice",
+		OverallScore:   1,
+		Passed:         true,
+		HardGateFailed: false,
+		Dimensions: []voicescorecard.Dimension{
+			voiceDimension(VoiceDimensionTaskBusinessSuccess, 1, voiceeval.StatePassed, true),
+			voiceDimension(VoiceDimensionInteractionQuality, 1, voiceeval.StatePassed, true),
+			{
+				Key:      "latency",
+				Name:     "Latency",
+				Score:    1,
+				State:    voiceeval.StatePassed,
+				HardGate: false,
+				Metrics: []voicescorecard.MetricDetail{
+					{
+						Key:     "end_of_user_turn_to_first_agent_output_ms",
+						State:   voiceeval.StatePassed,
+						ValueMS: int64PtrForVoiceTest(1200),
+					},
+				},
+			},
+			voiceDimension("robustness", 1, voiceeval.StatePassed, false),
+			voiceDimension(VoiceDimensionToolDataCorrectness, 1, voiceeval.StatePassed, true),
+			voiceDimension("cost", 1, voiceeval.StatePassed, false),
+		},
+	}
+}
+
+func voiceDimension(key string, score float64, state voiceeval.State, hardGate bool) voicescorecard.Dimension {
+	return voicescorecard.Dimension{
+		Key:      key,
+		Name:     key,
+		Score:    score,
+		State:    state,
+		HardGate: hardGate,
+	}
+}
+
+func setVoiceLatencyMS(scorecard *voicescorecard.Scorecard, value int64) {
+	for dimIdx := range scorecard.Dimensions {
+		if scorecard.Dimensions[dimIdx].Key != "latency" {
+			continue
+		}
+		for metricIdx := range scorecard.Dimensions[dimIdx].Metrics {
+			if scorecard.Dimensions[dimIdx].Metrics[metricIdx].Key == "end_of_user_turn_to_first_agent_output_ms" {
+				scorecard.Dimensions[dimIdx].Metrics[metricIdx].ValueMS = int64PtrForVoiceTest(value)
+				return
+			}
+		}
+	}
+}
+
+func removeVoiceLatencyMetric(scorecard *voicescorecard.Scorecard) {
+	for dimIdx := range scorecard.Dimensions {
+		if scorecard.Dimensions[dimIdx].Key == "latency" {
+			scorecard.Dimensions[dimIdx].Metrics = nil
+			scorecard.Dimensions[dimIdx].State = voiceeval.StateUnavailable
+			scorecard.Dimensions[dimIdx].Score = 0.5
+		}
+	}
+}
+
+func setVoiceDimensionScore(scorecard *voicescorecard.Scorecard, key string, score float64) {
+	for idx := range scorecard.Dimensions {
+		if scorecard.Dimensions[idx].Key == key {
+			scorecard.Dimensions[idx].Score = score
+			return
+		}
+	}
+}
+
+func setVoiceDimensionState(scorecard *voicescorecard.Scorecard, key string, state voiceeval.State) {
+	for idx := range scorecard.Dimensions {
+		if scorecard.Dimensions[idx].Key == key {
+			scorecard.Dimensions[idx].State = state
+			scorecard.Dimensions[idx].Score = 0
+			return
+		}
+	}
+}
+
+func int64PtrForVoiceTest(value int64) *int64 {
+	return &value
+}

--- a/backend/internal/releasegate/voice_test.go
+++ b/backend/internal/releasegate/voice_test.go
@@ -88,6 +88,30 @@ func TestEvaluateVoiceComparisonMissingMetricCanFailOrWarnByPolicy(t *testing.T)
 	}
 }
 
+func TestEvaluateVoiceComparisonMissingEvidenceKeySwapFails(t *testing.T) {
+	baseline := voiceScorecard()
+	baseline.Passed = false
+	baseline.DegradedKeys = []string{"transcript_available"}
+
+	candidate := voiceScorecard()
+	candidate.Passed = false
+	candidate.DegradedKeys = []string{"end_of_user_turn_to_first_agent_output_ms"}
+	removeVoiceLatencyMetric(&candidate)
+
+	evaluation := evaluateVoice(t, baseline, candidate, VoiceComparisonConfig{MissingEvidenceOutcome: VerdictFail})
+
+	if evaluation.Verdict != VerdictFail {
+		t.Fatalf("verdict = %q, want %q", evaluation.Verdict, VerdictFail)
+	}
+	if evaluation.ReasonCode != "threshold_fail_voice_missing_evidence" {
+		t.Fatalf("reason code = %q, want threshold_fail_voice_missing_evidence", evaluation.ReasonCode)
+	}
+	result := evaluation.Details.DimensionResults[VoiceDimensionMissingEvidence]
+	if result.ObservedDelta == nil || *result.ObservedDelta != 1 {
+		t.Fatalf("missing evidence delta = %v, want 1", result.ObservedDelta)
+	}
+}
+
 func TestExistingNonVoiceCompareFixtureStillPasses(t *testing.T) {
 	evaluation, err := Evaluate(testSummary(t, `{
 		"status":"comparable",


### PR DESCRIPTION
Closes #766.

## Summary

- Adds voice-specific release-gate comparison summaries and policies for deterministic voice scorecards.
- Supports aggregate score, task/business success, policy/interaction quality, tool/data correctness, latency-ms, and missing-evidence thresholds.
- Keeps existing non-voice release gates unchanged while allowing missing voice metric evidence to fail or warn by policy.

## Test Contract

# codex/voice-compare-gate - Test Contract

## Functional Behavior
- Compare baseline/candidate voice scorecards deterministically through release-gate summaries and policies.
- Voice compare support includes stable metric/dimension keys for aggregate score, task/business success, interaction quality, tool/data correctness, latency, and missing evidence.
- Hard-gate voice scorecard failures fail the release gate.
- Missing/degraded metric evidence is explicit and can fail or warn according to configured voice policy thresholds.
- Existing non-voice release-gate behavior and default policy serialization remain unchanged.

## Unit Tests
- No-regression voice comparison passes.
- Latency regression crosses fail threshold.
- Task success regression crosses fail threshold.
- Policy/hard-gate failure fails via scorecard pass requirement.
- Missing metric/evidence can fail or warn according to configured policy.
- Existing non-voice default compare fixture still passes and default policy JSON remains stable.

## Integration / Functional Tests
- `go test ./internal/releasegate ./internal/voicescorecard`

## Smoke Tests
- `go test ./internal/releasegate`
- `go test ./...`

## E2E Tests
N/A - CLI/API mode selection is later.

## Manual / cURL Tests
N/A - backend package only.

## Verification

- `cd backend && go test ./internal/releasegate`
- `cd backend && go test ./internal/releasegate ./internal/voicescorecard`
- `cd backend && go test ./...`

## Review Checkpoint JSON

```json
{
  "branch": "codex/voice-compare-gate",
  "test_contract": "/tmp/codex-voice-compare-gate-test-contract.md",
  "created_at": "2026-05-13T15:08:00Z",
  "steps": [
    {
      "step_number": 1,
      "title": "Wire deterministic voice compare gate policy",
      "timestamp": "2026-05-13T15:08:00Z",
      "files_changed": [
        "backend/internal/releasegate/voice.go",
        "backend/internal/releasegate/voice_test.go"
      ],
      "what_changed": "Added voice-specific release gate comparison support that builds ComparisonSummary values from baseline/candidate voice scorecards and evaluates them with voice metric thresholds. The policy covers aggregate score, task/business success, interaction quality, tool/data correctness, latency in ms, and missing evidence. Hard-gate voice failures use scorecard pass semantics; degraded/missing metric evidence can fail or warn by policy.",
      "review_instructions": "Verify this is deterministic from scorecard inputs, existing DefaultPolicy serialization remains unchanged, voice latency uses lower-is-better millisecond deltas, hard gates fail via RequireScorecardPass, and missing evidence is explicit through voice_missing_evidence thresholds.",
      "review_result": {
        "status": "pass",
        "issues_found": [],
        "notes": "Self-review confirmed existing non-voice release gate tests still pass and full backend tests pass."
      },
      "cumulative_review": {
        "previous_steps_still_valid": true,
        "integration_issues": [],
        "notes": "Composes the #764 voicescorecard package without changing generic release gate behavior."
      }
    },
    {
      "step_number": "final",
      "title": "Final review against test contract",
      "timestamp": "2026-05-13T15:08:00Z",
      "test_contract_review": {
        "functional_behavior": "pass - baseline/candidate voice scorecards can be compared through deterministic release gate summaries and policies with hard-gate and missing-evidence behavior.",
        "unit_tests": "pass - no regression, latency fail, task success fail, policy hard gate fail, missing metric fail/warn, and non-voice pass fixture are covered.",
        "integration_tests": "pass - go test ./internal/releasegate ./internal/voicescorecard passed.",
        "smoke_tests": "pass - go test ./internal/releasegate and go test ./... passed from backend/.",
        "e2e_tests": "N/A - CLI/API mode selection is later.",
        "manual_tests": "N/A - backend package only."
      },
      "overall_verdict": "ready",
      "blocking_issues": []
    }
  ]
}
```
