### PR TITLE
[Voice evals 13] Add CLI/API mode selection for voice evals

### DIFF
--- a/backend/internal/api/eval_session_service.go
+++ b/backend/internal/api/eval_session_service.go
@@ -465,7 +465,7 @@ func (m *RunCreationManager) CreateEvalSession(ctx context.Context, caller Calle
 			SeriesDeploymentLineup: spec.DeploymentLineup,
 		}
 		runInput.Seed = cloneInt64Ptr(spec.Seed)
-		executionPlan, err := buildExecutionPlan(runInput, specRunAgents)
+		executionPlan, err := buildExecutionPlan(runInput, specRunAgents, nil)
 		if err != nil {
 			return CreateEvalSessionResult{}, fmt.Errorf("build execution plan: %w", err)
 		}

--- a/backend/internal/api/run_reads.go
+++ b/backend/internal/api/run_reads.go
@@ -372,6 +372,9 @@ type getRunResponse struct {
 	Name                   string                         `json:"name"`
 	Status                 domain.RunStatus               `json:"status"`
 	ExecutionMode          string                         `json:"execution_mode"`
+	Mode                   string                         `json:"mode,omitempty"`
+	Modality               string                         `json:"modality,omitempty"`
+	Voice                  *runVoiceMetadataResponse      `json:"voice,omitempty"`
 	TemporalWorkflowID     *string                        `json:"temporal_workflow_id,omitempty"`
 	TemporalRunID          *string                        `json:"temporal_run_id,omitempty"`
 	QueuedAt               *time.Time                     `json:"queued_at,omitempty"`
@@ -582,6 +585,7 @@ func listRunsHandler(logger *slog.Logger, service RunReadService) http.HandlerFu
 }
 
 func buildGetRunResponse(run domain.Run, regressionCoverage *RunRegressionCoverage) getRunResponse {
+	mode, modality, voice := runMetadataFromExecutionPlan(run.ExecutionPlan)
 	response := getRunResponse{
 		ID:                     run.ID,
 		WorkspaceID:            run.WorkspaceID,
@@ -591,6 +595,9 @@ func buildGetRunResponse(run domain.Run, regressionCoverage *RunRegressionCovera
 		Name:                   run.Name,
 		Status:                 run.Status,
 		ExecutionMode:          run.ExecutionMode,
+		Mode:                   mode,
+		Modality:               modality,
+		Voice:                  voice,
 		TemporalWorkflowID:     run.TemporalWorkflowID,
 		TemporalRunID:          run.TemporalRunID,
 		QueuedAt:               run.QueuedAt,

--- a/backend/internal/api/run_service.go
+++ b/backend/internal/api/run_service.go
@@ -113,6 +113,10 @@ func (m *RunCreationManager) CreateRun(ctx context.Context, caller Caller, input
 			Message: "official_pack_mode must be either full or suite_only",
 		}
 	}
+	input.Mode = normalizeRunMode(input.Mode)
+	if err := validateRequestedRunMode(input.Mode); err != nil {
+		return CreateRunResult{}, err
+	}
 	if input.OfficialPackMode == domain.OfficialPackModeSuiteOnly &&
 		len(input.RegressionSuiteIDs) == 0 &&
 		len(input.RegressionCaseIDs) == 0 {
@@ -163,6 +167,10 @@ func (m *RunCreationManager) CreateRun(ctx context.Context, caller Caller, input
 	}
 	if input.MaxIterations == nil {
 		input.MaxIterations = challengePackDefaultMaxIterations(challengePackVersion.Manifest)
+	}
+	voiceMode, err := resolveRunVoiceMode(input.Mode, challengePackVersion.Manifest)
+	if err != nil {
+		return CreateRunResult{}, err
 	}
 
 	if input.ChallengeInputSetID != nil {
@@ -279,7 +287,7 @@ func (m *RunCreationManager) CreateRun(ctx context.Context, caller Caller, input
 		executionMode = "single_agent"
 	}
 
-	executionPlan, err := buildExecutionPlan(input, runAgents)
+	executionPlan, err := buildExecutionPlan(input, runAgents, voiceMode)
 	if err != nil {
 		return CreateRunResult{}, fmt.Errorf("build execution plan: %w", err)
 	}
@@ -473,7 +481,7 @@ func regressionCaseSelectableForRun(status domain.RegressionCaseStatus, includeP
 		(includeProposed && status == domain.RegressionCaseStatusProposed)
 }
 
-func buildExecutionPlan(input CreateRunInput, runAgents []repository.CreateQueuedRunAgentParams) (json.RawMessage, error) {
+func buildExecutionPlan(input CreateRunInput, runAgents []repository.CreateQueuedRunAgentParams, voiceMode *runVoiceMode) (json.RawMessage, error) {
 	type executionPlanRunAgent struct {
 		LaneIndex                 int32     `json:"lane_index"`
 		AgentDeploymentID         uuid.UUID `json:"agent_deployment_id"`
@@ -495,6 +503,9 @@ func buildExecutionPlan(input CreateRunInput, runAgents []repository.CreateQueue
 		ChallengePackVersionID uuid.UUID                   `json:"challenge_pack_version_id"`
 		ChallengeInputSetID    *uuid.UUID                  `json:"challenge_input_set_id,omitempty"`
 		OfficialPackMode       domain.OfficialPackMode     `json:"official_pack_mode"`
+		Mode                   string                      `json:"mode,omitempty"`
+		Modality               string                      `json:"modality,omitempty"`
+		Voice                  *runVoiceMetadataResponse   `json:"voice,omitempty"`
 		Participants           []executionPlanRunAgent     `json:"participants"`
 		RuntimeLimits          *executionPlanRuntimeLimits `json:"runtime_limits,omitempty"`
 		Seed                   *int64                      `json:"seed,omitempty"`
@@ -526,6 +537,15 @@ func buildExecutionPlan(input CreateRunInput, runAgents []repository.CreateQueue
 		plan.Series = &executionPlanSeries{
 			MatrixKey:        input.SeriesMatrixKey,
 			DeploymentLineup: input.SeriesDeploymentLineup,
+		}
+	}
+	if voiceMode != nil {
+		plan.Mode = voiceMode.Mode
+		plan.Modality = voiceMode.Modality
+		plan.Voice = &runVoiceMetadataResponse{
+			Mode:      voiceMode.Mode,
+			Modality:  voiceMode.Modality,
+			Transport: voiceMode.Transport,
 		}
 	}
 

--- a/backend/internal/api/run_service_test.go
+++ b/backend/internal/api/run_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -151,6 +152,149 @@ func TestRunCreationManagerAddsMaxIterationsToExecutionPlan(t *testing.T) {
 
 	if got := executionPlanTestMaxIterations(t, repo.createParams.ExecutionPlan); got != 7 {
 		t.Fatalf("execution plan max_iterations = %d, want 7", got)
+	}
+}
+
+func TestRunCreationManagerAcceptsTextSimForVoicePack(t *testing.T) {
+	workspaceID := uuid.New()
+	challengePackVersionID := uuid.New()
+	deploymentID := uuid.New()
+	caller := Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}
+	repo := &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{
+			ID:       challengePackVersionID,
+			Manifest: json.RawMessage(`{"modality":"voice","interface_spec":{"transports":["text_sim","sip"]}}`),
+		},
+		deployments: []repository.RunnableDeployment{
+			{
+				ID:                        deploymentID,
+				OrganizationID:            uuid.New(),
+				WorkspaceID:               workspaceID,
+				Name:                      "Voice Agent",
+				AgentDeploymentSnapshotID: uuid.New(),
+			},
+		},
+		createResult: repository.CreateQueuedRunResult{Run: domain.Run{ID: uuid.New(), WorkspaceID: workspaceID}},
+	}
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, &fakeRunWorkflowStarter{}, nil)
+
+	_, err := manager.CreateRun(context.Background(), caller, CreateRunInput{
+		WorkspaceID:            workspaceID,
+		ChallengePackVersionID: challengePackVersionID,
+		AgentDeploymentIDs:     []uuid.UUID{deploymentID},
+		Mode:                   "text-sim",
+	})
+	if err != nil {
+		t.Fatalf("CreateRun returned error: %v", err)
+	}
+
+	mode, modality, voice := executionPlanTestVoiceMetadata(t, repo.createParams.ExecutionPlan)
+	if mode != "text-sim" || modality != "voice" {
+		t.Fatalf("execution plan mode/modality = %q/%q, want text-sim/voice", mode, modality)
+	}
+	if voice == nil || voice.Mode != "text-sim" || voice.Transport != "text_sim" {
+		t.Fatalf("execution plan voice = %+v, want text-sim/text_sim", voice)
+	}
+}
+
+func TestRunCreationManagerRejectsFutureVoiceMode(t *testing.T) {
+	workspaceID := uuid.New()
+	repo := &fakeRunCreationRepository{}
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, &fakeRunWorkflowStarter{}, nil)
+
+	_, err := manager.CreateRun(context.Background(), Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}, CreateRunInput{
+		WorkspaceID:            workspaceID,
+		ChallengePackVersionID: uuid.New(),
+		AgentDeploymentIDs:     []uuid.UUID{uuid.New()},
+		Mode:                   "live-call",
+	})
+	var validationErr RunCreationValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error = %v, want RunCreationValidationError", err)
+	}
+	if validationErr.Code != "unsupported_mode" || !strings.Contains(validationErr.Message, "future voice eval support") {
+		t.Fatalf("validation error = %+v, want unsupported future mode", validationErr)
+	}
+	if repo.createParams != nil {
+		t.Fatalf("CreateQueuedRun was called for unsupported mode")
+	}
+}
+
+func TestRunCreationManagerRejectsTextSimForNonVoicePack(t *testing.T) {
+	workspaceID := uuid.New()
+	challengePackVersionID := uuid.New()
+	repo := &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{
+			ID:       challengePackVersionID,
+			Manifest: json.RawMessage(`{"pack":{"slug":"text-pack"}}`),
+		},
+	}
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, &fakeRunWorkflowStarter{}, nil)
+
+	_, err := manager.CreateRun(context.Background(), Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}, CreateRunInput{
+		WorkspaceID:            workspaceID,
+		ChallengePackVersionID: challengePackVersionID,
+		AgentDeploymentIDs:     []uuid.UUID{uuid.New()},
+		Mode:                   "text-sim",
+	})
+	var validationErr RunCreationValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error = %v, want RunCreationValidationError", err)
+	}
+	if validationErr.Code != "incompatible_mode" || !strings.Contains(validationErr.Message, "requires a voice challenge pack") {
+		t.Fatalf("validation error = %+v, want non-voice incompatibility", validationErr)
+	}
+	if repo.createParams != nil {
+		t.Fatalf("CreateQueuedRun was called for incompatible non-voice pack")
+	}
+}
+
+func TestRunCreationManagerRejectsTextSimWithoutTransport(t *testing.T) {
+	workspaceID := uuid.New()
+	challengePackVersionID := uuid.New()
+	repo := &fakeRunCreationRepository{
+		challengePackVersion: repository.RunnableChallengePackVersion{
+			ID:       challengePackVersionID,
+			Manifest: json.RawMessage(`{"modality":"voice","interface_spec":{"transports":["sip"]}}`),
+		},
+	}
+	manager := NewRunCreationManager(NewCallerWorkspaceAuthorizer(), repo, &fakeRunWorkflowStarter{}, nil)
+
+	_, err := manager.CreateRun(context.Background(), Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}, CreateRunInput{
+		WorkspaceID:            workspaceID,
+		ChallengePackVersionID: challengePackVersionID,
+		AgentDeploymentIDs:     []uuid.UUID{uuid.New()},
+		Mode:                   "text-sim",
+	})
+	var validationErr RunCreationValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error = %v, want RunCreationValidationError", err)
+	}
+	if validationErr.Code != "incompatible_mode" || !strings.Contains(validationErr.Message, "requires voice transport text_sim") {
+		t.Fatalf("validation error = %+v, want missing transport incompatibility", validationErr)
+	}
+	if repo.createParams != nil {
+		t.Fatalf("CreateQueuedRun was called for voice pack without text_sim transport")
 	}
 }
 
@@ -2137,6 +2281,19 @@ func executionPlanTestSeries(t *testing.T, payload json.RawMessage) (string, str
 		t.Fatalf("decode execution plan: %v", err)
 	}
 	return plan.Series.MatrixKey, plan.Series.DeploymentLineup
+}
+
+func executionPlanTestVoiceMetadata(t *testing.T, payload json.RawMessage) (string, string, *runVoiceMetadataResponse) {
+	t.Helper()
+	var plan struct {
+		Mode     string                    `json:"mode"`
+		Modality string                    `json:"modality"`
+		Voice    *runVoiceMetadataResponse `json:"voice"`
+	}
+	if err := json.Unmarshal(payload, &plan); err != nil {
+		t.Fatalf("decode execution plan: %v", err)
+	}
+	return plan.Mode, plan.Modality, plan.Voice
 }
 
 func (f *fakeRunCreationRepository) GetRunnableChallengePackVersionByID(_ context.Context, _ uuid.UUID) (repository.RunnableChallengePackVersion, error) {

--- a/backend/internal/api/run_voice_mode.go
+++ b/backend/internal/api/run_voice_mode.go
@@ -1,0 +1,137 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/agentclash/agentclash/backend/internal/challengepack"
+)
+
+const (
+	runModeTextSim      = "text-sim"
+	runModeAudioSim     = "audio-sim"
+	runModeLiveCall     = "live-call"
+	runModeReplayImport = "replay-import"
+
+	runVoiceTransportTextSim = "text_sim"
+)
+
+type runVoiceMode struct {
+	Mode      string
+	Modality  string
+	Transport string
+}
+
+type runVoiceMetadataResponse struct {
+	Mode      string `json:"mode"`
+	Modality  string `json:"modality"`
+	Transport string `json:"transport,omitempty"`
+}
+
+func normalizeRunMode(raw string) string {
+	return strings.ToLower(strings.TrimSpace(raw))
+}
+
+func validateRequestedRunMode(mode string) error {
+	switch mode {
+	case "":
+		return nil
+	case runModeTextSim:
+		return nil
+	case runModeAudioSim, runModeLiveCall, runModeReplayImport:
+		return RunCreationValidationError{
+			Code:    "unsupported_mode",
+			Message: fmt.Sprintf("mode %q is reserved for future voice eval support; supported mode is %s", mode, runModeTextSim),
+		}
+	default:
+		return RunCreationValidationError{
+			Code:    "unsupported_mode",
+			Message: fmt.Sprintf("mode must be %s; %s, %s, and %s are reserved for future voice eval support", runModeTextSim, runModeAudioSim, runModeLiveCall, runModeReplayImport),
+		}
+	}
+}
+
+func resolveRunVoiceMode(mode string, manifest json.RawMessage) (*runVoiceMode, error) {
+	if err := validateRequestedRunMode(mode); err != nil {
+		return nil, err
+	}
+	if mode == "" {
+		return nil, nil
+	}
+
+	var document struct {
+		Modality      string `json:"modality"`
+		InterfaceSpec struct {
+			Transports []string `json:"transports"`
+		} `json:"interface_spec"`
+	}
+	if len(manifest) > 0 {
+		if err := json.Unmarshal(manifest, &document); err != nil {
+			return nil, fmt.Errorf("decode challenge pack manifest voice metadata: %w", err)
+		}
+	}
+
+	if strings.TrimSpace(document.Modality) != challengepack.ModalityVoice {
+		return nil, RunCreationValidationError{
+			Code:    "incompatible_mode",
+			Message: fmt.Sprintf("mode %s requires a voice challenge pack", runModeTextSim),
+		}
+	}
+	if !containsTrimmedString(document.InterfaceSpec.Transports, runVoiceTransportTextSim) {
+		return nil, RunCreationValidationError{
+			Code:    "incompatible_mode",
+			Message: fmt.Sprintf("mode %s requires voice transport %s", runModeTextSim, runVoiceTransportTextSim),
+		}
+	}
+
+	return &runVoiceMode{
+		Mode:      mode,
+		Modality:  challengepack.ModalityVoice,
+		Transport: runVoiceTransportTextSim,
+	}, nil
+}
+
+func containsTrimmedString(values []string, target string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) == target {
+			return true
+		}
+	}
+	return false
+}
+
+func runMetadataFromExecutionPlan(executionPlan json.RawMessage) (string, string, *runVoiceMetadataResponse) {
+	var plan struct {
+		Mode     string                    `json:"mode"`
+		Modality string                    `json:"modality"`
+		Voice    *runVoiceMetadataResponse `json:"voice"`
+	}
+	if len(executionPlan) == 0 {
+		return "", "", nil
+	}
+	if err := json.Unmarshal(executionPlan, &plan); err != nil {
+		return "", "", nil
+	}
+
+	mode := strings.TrimSpace(plan.Mode)
+	modality := strings.TrimSpace(plan.Modality)
+	if plan.Voice == nil {
+		if mode == "" && modality == "" {
+			return "", "", nil
+		}
+		return mode, modality, nil
+	}
+
+	voice := *plan.Voice
+	voice.Mode = strings.TrimSpace(voice.Mode)
+	voice.Modality = strings.TrimSpace(voice.Modality)
+	voice.Transport = strings.TrimSpace(voice.Transport)
+	if mode == "" {
+		mode = voice.Mode
+	}
+	if modality == "" {
+		modality = voice.Modality
+	}
+	return mode, modality, &voice
+}

--- a/backend/internal/api/runs.go
+++ b/backend/internal/api/runs.go
@@ -34,6 +34,7 @@ type createRunRequest struct {
 	ChallengePackVersionID string   `json:"challenge_pack_version_id"`
 	ChallengeInputSetID    *string  `json:"challenge_input_set_id,omitempty"`
 	Name                   string   `json:"name,omitempty"`
+	Mode                   string   `json:"mode,omitempty"`
 	AgentDeploymentIDs     []string `json:"agent_deployment_ids"`
 	RegressionSuiteIDs     []string `json:"regression_suite_ids,omitempty"`
 	RegressionCaseIDs      []string `json:"regression_case_ids,omitempty"`
@@ -57,6 +58,7 @@ type CreateRunInput struct {
 	ChallengeInputSetID        *uuid.UUID
 	OfficialPackMode           domain.OfficialPackMode
 	Name                       string
+	Mode                       string
 	AgentDeploymentIDs         []uuid.UUID
 	RegressionSuiteIDs         []uuid.UUID
 	RegressionCaseIDs          []uuid.UUID
@@ -75,19 +77,22 @@ type CreateRunResult struct {
 }
 
 type createRunResponse struct {
-	ID                     uuid.UUID             `json:"id"`
-	WorkspaceID            uuid.UUID             `json:"workspace_id"`
-	ChallengePackVersionID uuid.UUID             `json:"challenge_pack_version_id"`
-	ChallengeInputSetID    *uuid.UUID            `json:"challenge_input_set_id,omitempty"`
-	OfficialPackMode       string                `json:"official_pack_mode"`
-	Status                 domain.RunStatus      `json:"status"`
-	ExecutionMode          string                `json:"execution_mode"`
-	CreatedAt              time.Time             `json:"created_at"`
-	QueuedAt               *time.Time            `json:"queued_at,omitempty"`
-	RaceContext            bool                  `json:"race_context"`
-	RaceContextMinStepGap  *int32                `json:"race_context_min_step_gap,omitempty"`
-	CIMetadata             *domain.RunCIMetadata `json:"ci_metadata,omitempty"`
-	Links                  runLinksResponse      `json:"links"`
+	ID                     uuid.UUID                 `json:"id"`
+	WorkspaceID            uuid.UUID                 `json:"workspace_id"`
+	ChallengePackVersionID uuid.UUID                 `json:"challenge_pack_version_id"`
+	ChallengeInputSetID    *uuid.UUID                `json:"challenge_input_set_id,omitempty"`
+	OfficialPackMode       string                    `json:"official_pack_mode"`
+	Status                 domain.RunStatus          `json:"status"`
+	ExecutionMode          string                    `json:"execution_mode"`
+	Mode                   string                    `json:"mode,omitempty"`
+	Modality               string                    `json:"modality,omitempty"`
+	Voice                  *runVoiceMetadataResponse `json:"voice,omitempty"`
+	CreatedAt              time.Time                 `json:"created_at"`
+	QueuedAt               *time.Time                `json:"queued_at,omitempty"`
+	RaceContext            bool                      `json:"race_context"`
+	RaceContextMinStepGap  *int32                    `json:"race_context_min_step_gap,omitempty"`
+	CIMetadata             *domain.RunCIMetadata     `json:"ci_metadata,omitempty"`
+	Links                  runLinksResponse          `json:"links"`
 }
 
 type runLinksResponse struct {
@@ -207,6 +212,7 @@ type runWorkflowErrorResponse struct {
 }
 
 func buildCreateRunResponse(run domain.Run) createRunResponse {
+	mode, modality, voice := runMetadataFromExecutionPlan(run.ExecutionPlan)
 	return createRunResponse{
 		ID:                     run.ID,
 		WorkspaceID:            run.WorkspaceID,
@@ -215,6 +221,9 @@ func buildCreateRunResponse(run domain.Run) createRunResponse {
 		OfficialPackMode:       string(run.OfficialPackMode),
 		Status:                 run.Status,
 		ExecutionMode:          run.ExecutionMode,
+		Mode:                   mode,
+		Modality:               modality,
+		Voice:                  voice,
 		CreatedAt:              run.CreatedAt,
 		QueuedAt:               run.QueuedAt,
 		RaceContext:            run.RaceContext,
@@ -393,6 +402,7 @@ func decodeCreateRunRequest(r *http.Request) (CreateRunInput, error) {
 	if err != nil {
 		return CreateRunInput{}, err
 	}
+	mode := normalizeRunMode(body.Mode)
 
 	return CreateRunInput{
 		WorkspaceID:                workspaceID,
@@ -400,6 +410,7 @@ func decodeCreateRunRequest(r *http.Request) (CreateRunInput, error) {
 		ChallengeInputSetID:        challengeInputSetID,
 		OfficialPackMode:           officialPackMode,
 		Name:                       strings.TrimSpace(body.Name),
+		Mode:                       mode,
 		AgentDeploymentIDs:         deploymentIDs,
 		RegressionSuiteIDs:         regressionSuiteIDs,
 		RegressionCaseIDs:          regressionCaseIDs,

--- a/backend/internal/api/runs_test.go
+++ b/backend/internal/api/runs_test.go
@@ -189,6 +189,82 @@ func TestCreateRunEndpointPropagatesCIMetadata(t *testing.T) {
 	}
 }
 
+func TestCreateRunEndpointPropagatesModeAndReturnsVoiceMetadata(t *testing.T) {
+	userID := uuid.New()
+	workspaceID := uuid.New()
+	runID := uuid.New()
+	service := &fakeRunCreationService{
+		result: CreateRunResult{
+			Run: domain.Run{
+				ID:                     runID,
+				WorkspaceID:            workspaceID,
+				ChallengePackVersionID: uuid.New(),
+				Status:                 domain.RunStatusQueued,
+				ExecutionMode:          "single_agent",
+				ExecutionPlan:          json.RawMessage(`{"mode":"text-sim","modality":"voice","voice":{"mode":"text-sim","modality":"voice","transport":"text_sim"}}`),
+				CreatedAt:              time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/runs", bytes.NewBufferString(`{
+		"workspace_id":"`+workspaceID.String()+`",
+		"challenge_pack_version_id":"`+uuid.New().String()+`",
+		"agent_deployment_ids":["`+uuid.New().String()+`"],
+		"mode":" text-sim "
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(headerUserID, userID.String())
+	req.Header.Set(headerWorkspaceMemberships, workspaceID.String()+":workspace_member")
+	recorder := httptest.NewRecorder()
+
+	newRouter("dev", nil,
+		slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		NewDevelopmentAuthenticator(),
+		NewCallerWorkspaceAuthorizer(),
+		nil,
+		0,
+		service,
+		&fakeRunReadService{},
+		&fakeReplayReadService{},
+		stubHostedRunIngestionService{},
+		nil,
+		stubAgentDeploymentReadService{},
+		stubChallengePackReadService{},
+		stubAgentBuildService{},
+		noopReleaseGateService{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	).ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d\n%s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+	if service.input.Mode != "text-sim" {
+		t.Fatalf("service input mode = %q, want text-sim", service.input.Mode)
+	}
+
+	var response createRunResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Mode != "text-sim" || response.Modality != "voice" {
+		t.Fatalf("response mode/modality = %q/%q, want text-sim/voice", response.Mode, response.Modality)
+	}
+	if response.Voice == nil || response.Voice.Mode != "text-sim" || response.Voice.Transport != "text_sim" {
+		t.Fatalf("response voice = %+v, want text-sim/text_sim", response.Voice)
+	}
+}
+
 func TestCreateRunEndpointRejectsInvalidCIMetadata(t *testing.T) {
 	workspaceID := uuid.New()
 	req := httptest.NewRequest(http.MethodPost, "/v1/runs", bytes.NewBufferString(`{
@@ -635,6 +711,24 @@ func TestDecodeCreateRunRequestAcceptsMaxIterations(t *testing.T) {
 	}
 	if input.MaxIterations == nil || *input.MaxIterations != 7 {
 		t.Fatalf("MaxIterations = %v, want 7", input.MaxIterations)
+	}
+}
+
+func TestDecodeCreateRunRequestAcceptsMode(t *testing.T) {
+	workspaceID := uuid.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/runs", bytes.NewBufferString(`{
+		"workspace_id":"`+workspaceID.String()+`",
+		"challenge_pack_version_id":"`+uuid.New().String()+`",
+		"agent_deployment_ids":["`+uuid.New().String()+`"],
+		"mode":" TEXT-SIM "
+	}`))
+
+	input, err := decodeCreateRunRequest(req)
+	if err != nil {
+		t.Fatalf("decodeCreateRunRequest returned error: %v", err)
+	}
+	if input.Mode != "text-sim" {
+		t.Fatalf("Mode = %q, want text-sim", input.Mode)
 	}
 }
 

--- a/cli/cmd/contract_alignment_test.go
+++ b/cli/cmd/contract_alignment_test.go
@@ -95,6 +95,93 @@ func TestRunCreateUsesRegressionSelectorsAndOfficialPackMode(t *testing.T) {
 	}
 }
 
+func TestRunCreateTextSimModePostsMode(t *testing.T) {
+	var gotBody map[string]any
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/runs": func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":             "run-voice-1",
+				"status":         "queued",
+				"execution_mode": "single_agent",
+				"mode":           "text-sim",
+				"modality":       "voice",
+				"voice": map[string]any{
+					"mode":      "text-sim",
+					"modality":  "voice",
+					"transport": "text_sim",
+				},
+			})
+		},
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{
+		"run", "create",
+		"-w", "ws-1",
+		"--challenge-pack-version", "voice-ver-1",
+		"--deployments", "dep-1",
+		"--mode", "text-sim",
+		"--json",
+	}, srv.URL)
+	if err != nil {
+		t.Fatalf("run create error: %v", err)
+	}
+	if gotBody["mode"] != "text-sim" {
+		t.Fatalf("mode = %v, want text-sim", gotBody["mode"])
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal([]byte(stdout.finish()), &response); err != nil {
+		t.Fatalf("decode stdout JSON: %v", err)
+	}
+	if response["mode"] != "text-sim" || response["modality"] != "voice" {
+		t.Fatalf("response mode/modality = %v/%v, want text-sim/voice", response["mode"], response["modality"])
+	}
+	voice, ok := response["voice"].(map[string]any)
+	if !ok {
+		t.Fatalf("response voice metadata = %#v, want object", response["voice"])
+	}
+	if voice["transport"] != "text_sim" {
+		t.Fatalf("voice.transport = %v, want text_sim", voice["transport"])
+	}
+}
+
+func TestRunCreateRejectsFutureVoiceModeLocally(t *testing.T) {
+	requests := 0
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/runs": func(w http.ResponseWriter, r *http.Request) {
+			requests++
+			w.WriteHeader(http.StatusCreated)
+		},
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{
+		"run", "create",
+		"-w", "ws-1",
+		"--challenge-pack-version", "voice-ver-1",
+		"--deployments", "dep-1",
+		"--mode", "live-call",
+	}, srv.URL)
+	if err == nil {
+		t.Fatal("expected unsupported future mode error")
+	}
+	if !strings.Contains(err.Error(), `--mode "live-call"`) || !strings.Contains(err.Error(), "supported mode: text-sim") {
+		t.Fatalf("error = %q, want deterministic future-mode validation", err)
+	}
+	if requests != 0 {
+		t.Fatalf("POST /v1/runs called %d time(s), want local rejection before API", requests)
+	}
+}
+
 func TestCompareRunsUsesKeyDeltasAndRegressionReasons(t *testing.T) {
 	srv := fakeAPI(t, map[string]http.HandlerFunc{
 		"GET /v1/compare": jsonHandler(200, map[string]any{

--- a/cli/cmd/eval_session_helpers.go
+++ b/cli/cmd/eval_session_helpers.go
@@ -43,6 +43,9 @@ func buildEvalSessionBody(workspaceID string, request runCreateRequest, repetiti
 	if request.RaceContext || request.RaceContextCadence > 0 {
 		return nil, fmt.Errorf("--race-context flags are not supported with --repetitions >= 2")
 	}
+	if request.Mode != "" {
+		return nil, fmt.Errorf("--mode is not supported with --repetitions >= 2 or --seeds")
+	}
 	if request.MaxIterations > 0 {
 		return nil, fmt.Errorf("--max-iter is not supported with --repetitions >= 2")
 	}

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -47,6 +47,7 @@ func init() {
 	runCreateCmd.Flags().Int("race-context-cadence", 0, "Override race-context cadence; minimum steps between standings injections, [1, 10]. 0 uses the backend default.")
 	runCreateCmd.Flags().Int("max-iter", 0, "Override max iterations for this run (1-1000). 0 uses the pack/runtime default.")
 	runCreateCmd.Flags().Int("seeds", 0, "Create a seeded eval session with N child runs, one per seed (1-100). 0 creates a single run.")
+	runCreateCmd.Flags().String("mode", "", "Voice eval mode: text-sim (future: audio-sim, live-call, replay-import)")
 	runEventsCmd.Flags().StringSlice("filter", nil, "Filter streamed events by event type pattern (exact, comma-separated, or glob; '*' matches any non-slash chars, so 'model.*' matches 'model.call.started'; repeatable)")
 
 	runRankingCmd.Flags().String("sort-by", "", "Sort by: composite, correctness, reliability, latency, cost")

--- a/cli/cmd/run_create_helpers.go
+++ b/cli/cmd/run_create_helpers.go
@@ -13,6 +13,13 @@ import (
 const maxRunCreateMaxIter = 1000
 const maxRunCreateSeeds = 100
 
+const (
+	runCreateModeTextSim      = "text-sim"
+	runCreateModeAudioSim     = "audio-sim"
+	runCreateModeLiveCall     = "live-call"
+	runCreateModeReplayImport = "replay-import"
+)
+
 type runCreateRequest struct {
 	ChallengePackVersionID     string
 	ChallengeInputSetID        string
@@ -28,6 +35,7 @@ type runCreateRequest struct {
 	RaceContextCadence         int
 	MaxIterations              int
 	Seeds                      int
+	Mode                       string
 	CIMetadata                 map[string]any
 }
 
@@ -101,7 +109,30 @@ func runCreateRequestFromFlags(cmd *cobra.Command, base runCreateRequest) (runCr
 	seeds, _ := cmd.Flags().GetInt("seeds")
 	request.Seeds = seeds
 
+	if cmd.Flags().Lookup("mode") != nil {
+		mode, _ := cmd.Flags().GetString("mode")
+		normalizedMode, err := normalizeRunCreateMode(mode)
+		if err != nil {
+			return runCreateRequest{}, err
+		}
+		request.Mode = normalizedMode
+	}
+
 	return request, nil
+}
+
+func normalizeRunCreateMode(raw string) (string, error) {
+	mode := strings.ToLower(strings.TrimSpace(raw))
+	switch mode {
+	case "":
+		return "", nil
+	case runCreateModeTextSim:
+		return mode, nil
+	case runCreateModeAudioSim, runCreateModeLiveCall, runCreateModeReplayImport:
+		return "", fmt.Errorf("--mode %q is reserved for future voice eval support; supported mode: %s", mode, runCreateModeTextSim)
+	default:
+		return "", fmt.Errorf("unsupported --mode %q (supported mode: %s)", raw, runCreateModeTextSim)
+	}
 }
 
 func buildRunCreateBody(workspaceID string, request runCreateRequest) (map[string]any, error) {
@@ -153,6 +184,9 @@ func buildRunCreateBody(workspaceID string, request runCreateRequest) (map[strin
 	}
 	if request.MaxIterations > 0 {
 		body["max_iterations"] = request.MaxIterations
+	}
+	if request.Mode != "" {
+		body["mode"] = request.Mode
 	}
 	if len(request.CIMetadata) > 0 {
 		body["ci_metadata"] = request.CIMetadata
@@ -225,6 +259,9 @@ func buildSeriesEvalSessionBody(workspaceID string, request runCreateRequest) (m
 	}
 	if request.RaceContext || request.RaceContextCadence > 0 {
 		return nil, fmt.Errorf("--race-context flags are not supported with --deployment-lineups")
+	}
+	if request.Mode != "" {
+		return nil, fmt.Errorf("--mode is not supported with --deployment-lineups")
 	}
 
 	executionMode := "single_agent"


### PR DESCRIPTION
## Summary

- Adds `agentclash run create --mode text-sim` for single-run voice eval mode selection.
- Validates future modes (`audio-sim`, `live-call`, `replay-import`) with deterministic local/API errors.
- Persists voice mode/modality metadata in `execution_plan` and surfaces it in run JSON responses.

Closes #767

## Tests

- `cd cli && go test ./cmd`
- `cd cli && go test ./...`
- `cd backend && go test ./internal/api`
- `cd backend && go test ./...`

## Test Contract

> # codex/voice-mode-selection — Test Contract
> 
> ## Functional Behavior
> - `agentclash run create --mode text-sim` includes `"mode":"text-sim"` in the `POST /v1/runs` body for a single run.
> - The backend `POST /v1/runs` accepts `"mode":"text-sim"` only when the selected challenge-pack manifest declares `modality:"voice"` and `interface_spec.transports` contains `"text_sim"`.
> - The backend rejects unsupported or future voice modes such as `live-call`, `audio-sim`, and `replay-import` with deterministic validation errors and no queued run.
> - The backend rejects `text-sim` for non-voice challenge packs or voice packs that do not support the `text_sim` transport.
> - Non-voice run creation without `mode` preserves current behavior, execution mode, and request/response shape aside from omitted new metadata fields.
> - Created run JSON responses include deterministic mode/modality metadata for voice runs selected with `text-sim`.
> 
> ## Unit Tests
> - CLI test: `TestRunCreateTextSimModePostsMode` verifies a fake API receives `"mode":"text-sim"` and the structured output contains returned voice metadata.
> - CLI test: `TestRunCreateRejectsFutureVoiceModeLocally` verifies `--mode live-call` fails locally before any API request.
> - Backend decode test: `TestDecodeCreateRunRequestAcceptsMode` verifies `"mode":"text-sim"` is decoded into `CreateRunInput`.
> - Backend endpoint test: `TestCreateRunEndpointPropagatesModeAndReturnsVoiceMetadata` verifies `mode` reaches the service and response JSON includes `mode`, `modality`, and `voice`.
> - Backend service test: `TestRunCreationManagerAcceptsTextSimForVoicePack` verifies voice text-sim runs queue with voice mode metadata in `execution_plan`.
> - Backend service test: `TestRunCreationManagerRejectsFutureVoiceMode` verifies `live-call` returns a deterministic validation error before repository persistence.
> - Backend service test: `TestRunCreationManagerRejectsTextSimForNonVoicePack` verifies text-sim cannot run on non-voice packs.
> - Backend service test: `TestRunCreationManagerRejectsTextSimWithoutTransport` verifies voice packs lacking `text_sim` reject text-sim.
> - Backend service test: existing non-voice creation tests remain passing and do not require mode.
> 
> ## Integration / Functional Tests
> - N/A — no hosted backend, provider, telephony, or database migration is required for this slice.
> 
> ## Smoke Tests
> - `go test ./cmd` from `cli/`.
> - `go test ./internal/api` from `backend/`.
> - `go test ./...` from `backend/` if focused tests pass.
> 
> ## E2E Tests
> - N/A — mode selection is a request/validation contract only in this slice.
> 
> ## Manual / cURL Tests
> - N/A — fake server and service tests cover the deterministic contract without live infrastructure.

## Review Checkpoint JSON

```json
{
    "branch": "codex/voice-mode-selection",
    "test_contract": "/tmp/codex-voice-mode-selection-test-contract.md",
    "created_at": "2026-05-13T16:34:52Z",
    "steps": [
        {
            "step_number": 1,
            "title": "Add deterministic voice mode selection for run creation",
            "timestamp": "2026-05-13T16:37:57Z",
            "files_changed": [
                "cli/cmd/run.go",
                "cli/cmd/run_create_helpers.go",
                "cli/cmd/eval_session_helpers.go",
                "cli/cmd/contract_alignment_test.go",
                "backend/internal/api/run_voice_mode.go",
                "backend/internal/api/runs.go",
                "backend/internal/api/run_reads.go",
                "backend/internal/api/run_service.go",
                "backend/internal/api/eval_session_service.go",
                "backend/internal/api/runs_test.go",
                "backend/internal/api/run_service_test.go"
            ],
            "what_changed": "Added a single-run voice mode contract for --mode text-sim. The CLI validates future modes locally and sends mode only for supported single-run creation. The backend decodes mode, rejects unsupported/future modes, verifies text-sim against voice manifests with text_sim transport, stores voice metadata in execution_plan, and surfaces mode/modality/voice metadata in create/get/list run JSON responses.",
            "review_instructions": "Verify mode validation is deterministic and provider-neutral: no live provider, LLM, or telephony calls; text-sim requires modality voice plus text_sim transport; future modes fail before repository persistence; non-voice run creation without mode stays unchanged.",
            "review_result": {
                "status": "pass",
                "issues_found": [],
                "notes": "Self-review checked CLI request construction, backend decode/service validation, execution_plan metadata, response builders, and focused tests. go test ./cmd and go test ./internal/api passed."
            },
            "cumulative_review": {
                "previous_steps_still_valid": true,
                "integration_issues": [],
                "notes": "This is the first checkpoint step for the PR."
            }
        },
        {
            "step_number": "final",
            "title": "Final review against test contract",
            "timestamp": "2026-05-13T16:38:31Z",
            "test_contract_review": {
                "functional_behavior": "pass - CLI sends text-sim mode for single run creation; backend accepts it only for voice manifests with text_sim transport; future/unsupported and incompatible modes return deterministic validation errors; non-voice creation without mode remains unchanged; responses include mode/modality/voice metadata from execution_plan.",
                "unit_tests": "pass - named CLI and backend decode/endpoint/service tests were added and passed.",
                "integration_tests": "N/A - no hosted backend/provider/telephony/database integration required.",
                "smoke_tests": "pass - go test ./cmd from cli, go test ./... from cli, go test ./internal/api from backend, and go test ./... from backend passed.",
                "e2e_tests": "N/A - mode selection is a request/validation contract in this slice.",
                "manual_tests": "N/A - fake API and service tests cover the deterministic contract."
            },
            "overall_verdict": "ready",
            "blocking_issues": []
        }
    ]
}

```
