### PR TITLE
[Voice evals 16] Add support-agent end-to-end smoke test

### DIFF
--- a/backend/internal/voicee2e/support_agent_smoke_test.go
+++ b/backend/internal/voicee2e/support_agent_smoke_test.go
@@ -1,0 +1,286 @@
+package voicee2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/challengepack"
+	"github.com/agentclash/agentclash/backend/internal/releasegate"
+	"github.com/agentclash/agentclash/backend/internal/runevents"
+	"github.com/agentclash/agentclash/backend/internal/voiceartifacts"
+	"github.com/agentclash/agentclash/backend/internal/voicedeployment"
+	"github.com/agentclash/agentclash/backend/internal/voiceeval"
+	"github.com/agentclash/agentclash/backend/internal/voicefixtures"
+	"github.com/agentclash/agentclash/backend/internal/voicereplay"
+	"github.com/agentclash/agentclash/backend/internal/voicescorecard"
+	"github.com/agentclash/agentclash/backend/internal/voicesim"
+	"github.com/agentclash/agentclash/backend/internal/voicetextsim"
+)
+
+// Smoke command: go test ./internal/voicee2e -run TestSupportAgentVoiceEvalLoopSmoke -count=1
+func TestSupportAgentVoiceEvalLoopSmoke(t *testing.T) {
+	fixture := loadSupportFixture(t)
+	bundle := parseSupportPack(t, fixture)
+	manifest := loadSupportManifest(t)
+	if err := manifest.VerifyLocalChecksums("../voiceartifacts/testdata/support_billing"); err != nil {
+		t.Fatalf("manifest VerifyLocalChecksums returned error: %v", err)
+	}
+
+	baseline := runSupportTextSim(t, bundle, fixture, voicedeployment.OutcomePass)
+	candidate := runSupportTextSim(t, bundle, fixture, voicedeployment.OutcomePass)
+	if !bytes.Equal(baseline.TraceJSON, candidate.TraceJSON) {
+		t.Fatalf("happy path trace JSON is not deterministic")
+	}
+	if !bytes.Equal(baseline.EventsJSON, candidate.EventsJSON) {
+		t.Fatalf("happy path events JSON is not deterministic")
+	}
+	assertCanonicalVoiceEvents(t, baseline.Events)
+
+	projection, err := voicereplay.Build(baseline.Events, manifest)
+	if err != nil {
+		t.Fatalf("voicereplay.Build returned error: %v", err)
+	}
+	projectionJSON, err := voicereplay.StableJSON(projection)
+	if err != nil {
+		t.Fatalf("voicereplay.StableJSON returned error: %v", err)
+	}
+	if len(projection.Turns) == 0 || !bytes.Contains(projectionJSON, []byte(`"turn_id": "turn-001"`)) {
+		t.Fatalf("projection missing support turn:\n%s", projectionJSON)
+	}
+	if len(projection.DegradedEvidence) != 0 {
+		t.Fatalf("projection degraded evidence = %v, want none", projection.DegradedEvidence)
+	}
+
+	expectations := scorecardExpectations(t, fixture)
+	baselineScorecard := generateScorecard(t, baseline, expectations)
+	candidateScorecard := generateScorecard(t, candidate, expectations)
+	if !baselineScorecard.Passed || baselineScorecard.HardGateFailed {
+		t.Fatalf("baseline scorecard = passed:%v hard_gate:%v, want passed/no hard gate", baselineScorecard.Passed, baselineScorecard.HardGateFailed)
+	}
+	if !candidateScorecard.Passed || candidateScorecard.HardGateFailed {
+		t.Fatalf("candidate scorecard = passed:%v hard_gate:%v, want passed/no hard gate", candidateScorecard.Passed, candidateScorecard.HardGateFailed)
+	}
+
+	passEvaluation := evaluateVoiceGate(t, baselineScorecard, candidateScorecard)
+	if passEvaluation.Verdict != releasegate.VerdictPass {
+		t.Fatalf("happy compare verdict = %q/%s, want pass", passEvaluation.Verdict, passEvaluation.ReasonCode)
+	}
+
+	badCandidate := runSupportTextSim(t, bundle, fixture, voicedeployment.OutcomeFail)
+	badScorecard := generateScorecard(t, badCandidate, expectations)
+	if badScorecard.Passed || !badScorecard.HardGateFailed {
+		t.Fatalf("bad candidate scorecard = passed:%v hard_gate:%v, want failed hard gate", badScorecard.Passed, badScorecard.HardGateFailed)
+	}
+	failEvaluation := evaluateVoiceGate(t, baselineScorecard, badScorecard)
+	if failEvaluation.Verdict != releasegate.VerdictFail || failEvaluation.ReasonCode != "scorecard_not_passed" {
+		t.Fatalf("bad compare verdict = %q/%s, want fail/scorecard_not_passed", failEvaluation.Verdict, failEvaluation.ReasonCode)
+	}
+}
+
+func loadSupportFixture(t *testing.T) voicefixtures.SupportBillingFixture {
+	t.Helper()
+	fixture, err := voicefixtures.LoadSupportBillingFixture()
+	if err != nil {
+		t.Fatalf("LoadSupportBillingFixture returned error: %v", err)
+	}
+	return fixture
+}
+
+func parseSupportPack(t *testing.T, fixture voicefixtures.SupportBillingFixture) challengepack.Bundle {
+	t.Helper()
+	bundle, err := challengepack.ParseYAML(fixture.ChallengePackYAML)
+	if err != nil {
+		t.Fatalf("ParseYAML returned error: %v", err)
+	}
+	if bundle.Modality != challengepack.ModalityVoice {
+		t.Fatalf("bundle modality = %q, want voice", bundle.Modality)
+	}
+	if bundle.InterfaceSpec == nil || !contains(bundle.InterfaceSpec.Transports, "text_sim") {
+		t.Fatalf("bundle interface spec = %+v, want text_sim transport", bundle.InterfaceSpec)
+	}
+	return bundle
+}
+
+func loadSupportManifest(t *testing.T) voiceartifacts.Manifest {
+	t.Helper()
+	manifest, err := voiceartifacts.Load("../voiceartifacts/testdata/support_billing/voice_artifact_manifest.json")
+	if err != nil {
+		t.Fatalf("voiceartifacts.Load returned error: %v", err)
+	}
+	return manifest
+}
+
+func runSupportTextSim(t *testing.T, bundle challengepack.Bundle, fixture voicefixtures.SupportBillingFixture, outcome voicedeployment.Outcome) voicetextsim.Result {
+	t.Helper()
+	script, err := voicesim.LoadScript("../voicesim/testdata/support_billing_script.json")
+	if err != nil {
+		t.Fatalf("LoadScript returned error: %v", err)
+	}
+	deployment, err := voicedeployment.NewFake(fakeDeploymentScript(t, script, fixture, outcome))
+	if err != nil {
+		t.Fatalf("NewFake returned error: %v", err)
+	}
+	result, err := voicetextsim.Run(context.Background(), voicetextsim.Input{
+		Bundle:     bundle,
+		Script:     script,
+		Deployment: deployment,
+	})
+	if err != nil {
+		t.Fatalf("voicetextsim.Run returned error: %v", err)
+	}
+	return result
+}
+
+func fakeDeploymentScript(t *testing.T, script voicesim.Script, fixture voicefixtures.SupportBillingFixture, outcome voicedeployment.Outcome) voicedeployment.Script {
+	t.Helper()
+	var toolCall struct {
+		CallID    string          `json:"call_id"`
+		ToolName  string          `json:"tool_name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if err := json.Unmarshal(fixture.ExpectedToolCallJSON, &toolCall); err != nil {
+		t.Fatalf("decode tool call: %v", err)
+	}
+	var structured struct {
+		SchemaRef string          `json:"schema_ref"`
+		Output    json.RawMessage `json:"output"`
+	}
+	if err := json.Unmarshal(fixture.ExpectedStructuredJSON, &structured); err != nil {
+		t.Fatalf("decode structured output: %v", err)
+	}
+
+	text := script.Steps[0].ExpectedAgentText
+	structuredOutput := structured.Output
+	if outcome == voicedeployment.OutcomeFail {
+		text = "I cannot find a duplicate charge."
+		structuredOutput = json.RawMessage(`{"resolution":"not_found"}`)
+	}
+	confidence := 1.0
+	return voicedeployment.Script{
+		ScenarioKey: script.ScenarioKey,
+		Turns: []voicedeployment.Turn{
+			{
+				TurnID:            script.Steps[0].TurnID,
+				ExpectedInputText: script.Steps[0].UserText,
+				Outcome:           outcome,
+				Response: voicedeployment.ResponseScript{
+					ExpectedToolCall: &voicedeployment.ExpectedToolCall{
+						CallID:    toolCall.CallID,
+						ToolName:  toolCall.ToolName,
+						Arguments: toolCall.Arguments,
+						OffsetMS:  700,
+					},
+					TextResponse: &voicedeployment.TextResponse{
+						Text:     text,
+						Language: script.Steps[0].Language,
+						OffsetMS: 1200,
+					},
+					SpokenAudioArtifact: &voicedeployment.SpokenAudioArtifact{
+						ArtifactRef: "voice://artifacts/agent-turn-001.wav",
+						Format:      "wav",
+						Channel:     "agent",
+						DurationMS:  2400,
+						OffsetMS:    1600,
+					},
+					TranscriptResponse: &voicedeployment.TranscriptResponse{
+						Text:       text,
+						Language:   script.Steps[0].Language,
+						Confidence: &confidence,
+						OffsetMS:   1700,
+					},
+					StructuredOutput: &voicedeployment.StructuredOutput{
+						SchemaRef: structured.SchemaRef,
+						Output:    structuredOutput,
+						OffsetMS:  1800,
+					},
+					TimingMarkers: []voicedeployment.TimingMarker{
+						{
+							Key:      voiceeval.KeyEndOfUserTextToFirstAgentTextLegacy,
+							ValueMS:  1200,
+							OffsetMS: 1800,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func scorecardExpectations(t *testing.T, fixture voicefixtures.SupportBillingFixture) voicescorecard.Expectations {
+	t.Helper()
+	var toolCall struct {
+		ToolName  string          `json:"tool_name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if err := json.Unmarshal(fixture.ExpectedToolCallJSON, &toolCall); err != nil {
+		t.Fatalf("decode expected tool call: %v", err)
+	}
+	return voicescorecard.Expectations{
+		TaskSuccessField: "resolution",
+		TaskSuccessValue: "refund_created",
+		ExpectedToolName: toolCall.ToolName,
+		ExpectedToolArgs: toolCall.Arguments,
+		ForbiddenPhrases: []string{"cannot find a duplicate charge"},
+		MaxTurns:         1,
+		LatencyTargetMS:  1200,
+		LatencyMaxMS:     1500,
+		CostUSD:          0,
+	}
+}
+
+func generateScorecard(t *testing.T, result voicetextsim.Result, expectations voicescorecard.Expectations) voicescorecard.Scorecard {
+	t.Helper()
+	scorecard, err := voicescorecard.Generate(voiceeval.Input{
+		Trace:  result.Trace,
+		Events: result.Events,
+	}, expectations)
+	if err != nil {
+		t.Fatalf("voicescorecard.Generate returned error: %v", err)
+	}
+	return scorecard
+}
+
+func evaluateVoiceGate(t *testing.T, baseline voicescorecard.Scorecard, candidate voicescorecard.Scorecard) releasegate.Evaluation {
+	t.Helper()
+	evaluation, err := releasegate.Evaluate(
+		releasegate.BuildVoiceComparisonSummary(baseline, candidate, releasegate.DefaultVoiceComparisonConfig()),
+		releasegate.VoicePolicy(releasegate.DefaultVoiceComparisonConfig()),
+	)
+	if err != nil {
+		t.Fatalf("releasegate.Evaluate returned error: %v", err)
+	}
+	return evaluation
+}
+
+func assertCanonicalVoiceEvents(t *testing.T, events []runevents.Envelope) {
+	t.Helper()
+	if len(events) == 0 {
+		t.Fatal("events are required")
+	}
+	foundCompleted := false
+	for idx, event := range events {
+		if event.SequenceNumber != int64(idx+1) {
+			t.Fatalf("events[%d].SequenceNumber = %d, want %d", idx, event.SequenceNumber, idx+1)
+		}
+		if err := event.ValidatePersisted(); err != nil {
+			t.Fatalf("events[%d] ValidatePersisted returned error: %v", idx, err)
+		}
+		if event.EventType == runevents.EventTypeSystemRunCompleted {
+			foundCompleted = true
+		}
+	}
+	if !foundCompleted {
+		t.Fatal("system.run.completed event not found")
+	}
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/voicee2e/support_agent_smoke_test.go
+++ b/backend/internal/voicee2e/support_agent_smoke_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/agentclash/agentclash/backend/internal/challengepack"
+	"github.com/agentclash/agentclash/backend/internal/multimodaltrace"
 	"github.com/agentclash/agentclash/backend/internal/releasegate"
 	"github.com/agentclash/agentclash/backend/internal/runevents"
 	"github.com/agentclash/agentclash/backend/internal/voiceartifacts"
@@ -22,6 +24,7 @@ import (
 // Smoke command: go test ./internal/voicee2e -run TestSupportAgentVoiceEvalLoopSmoke -count=1
 func TestSupportAgentVoiceEvalLoopSmoke(t *testing.T) {
 	fixture := loadSupportFixture(t)
+	assertSupportFixtureGoldens(t, fixture)
 	bundle := parseSupportPack(t, fixture)
 	manifest := loadSupportManifest(t)
 	if err := manifest.VerifyLocalChecksums("../voiceartifacts/testdata/support_billing"); err != nil {
@@ -36,6 +39,7 @@ func TestSupportAgentVoiceEvalLoopSmoke(t *testing.T) {
 	if !bytes.Equal(baseline.EventsJSON, candidate.EventsJSON) {
 		t.Fatalf("happy path events JSON is not deterministic")
 	}
+	assertAgentTextOutput(t, baseline.Trace.Segments, strings.TrimSpace(string(fixture.ExpectedAgentTextOutput)))
 	assertCanonicalVoiceEvents(t, baseline.Events)
 
 	projection, err := voicereplay.Build(baseline.Events, manifest)
@@ -86,6 +90,29 @@ func loadSupportFixture(t *testing.T) voicefixtures.SupportBillingFixture {
 		t.Fatalf("LoadSupportBillingFixture returned error: %v", err)
 	}
 	return fixture
+}
+
+func assertSupportFixtureGoldens(t *testing.T, fixture voicefixtures.SupportBillingFixture) {
+	t.Helper()
+	run, err := voicefixtures.RunSupportBillingScenario()
+	if err != nil {
+		t.Fatalf("RunSupportBillingScenario returned error: %v", err)
+	}
+	assertBytesEqual(t, "fixture tool result golden", fixture.ExpectedToolResultJSON, run.ToolResultJSON)
+	assertBytesEqual(t, "fixture agent text output golden", fixture.ExpectedAgentTextOutput, run.AgentTextOutput)
+	assertBytesEqual(t, "fixture trace golden", fixture.ExpectedTraceJSON, run.TraceJSON)
+	assertBytesEqual(t, "fixture scorecard golden", fixture.ExpectedScorecardJSON, run.ScorecardJSON)
+
+	var turns []voicefixtures.ScriptedUserTurn
+	if err := json.Unmarshal(fixture.ScriptedUserTurnsJSON, &turns); err != nil {
+		t.Fatalf("decode scripted user turns: %v", err)
+	}
+	if len(turns) != 1 {
+		t.Fatalf("scripted user turns = %d, want 1", len(turns))
+	}
+	if strings.TrimSpace(turns[0].Text) == "" || strings.TrimSpace(turns[0].AudioArtifactRef) == "" {
+		t.Fatalf("scripted user turn missing text/audio artifact: %+v", turns[0])
+	}
 }
 
 func parseSupportPack(t *testing.T, fixture voicefixtures.SupportBillingFixture) challengepack.Bundle {
@@ -151,7 +178,10 @@ func fakeDeploymentScript(t *testing.T, script voicesim.Script, fixture voicefix
 		t.Fatalf("decode structured output: %v", err)
 	}
 
-	text := script.Steps[0].ExpectedAgentText
+	text := strings.TrimSpace(string(fixture.ExpectedAgentTextOutput))
+	if text == "" {
+		t.Fatalf("expected agent text output fixture is empty")
+	}
 	structuredOutput := structured.Output
 	if outcome == voicedeployment.OutcomeFail {
 		text = "I cannot find a duplicate charge."
@@ -276,9 +306,33 @@ func assertCanonicalVoiceEvents(t *testing.T, events []runevents.Envelope) {
 	}
 }
 
+func assertAgentTextOutput(t *testing.T, segments []multimodaltrace.Segment, want string) {
+	t.Helper()
+	for _, segment := range segments {
+		if segment.Kind != multimodaltrace.SegmentKindTextOutput {
+			continue
+		}
+		if segment.Text == nil {
+			t.Fatalf("text output segment %q has nil payload", segment.SegmentID)
+		}
+		if segment.Text.Text != want {
+			t.Fatalf("agent text output = %q, want %q", segment.Text.Text, want)
+		}
+		return
+	}
+	t.Fatalf("text output segment not found")
+}
+
+func assertBytesEqual(t *testing.T, label string, want []byte, got []byte) {
+	t.Helper()
+	if !bytes.Equal(want, got) {
+		t.Fatalf("%s mismatch\nwant:\n%s\n got:\n%s", label, string(want), string(got))
+	}
+}
+
 func contains(values []string, want string) bool {
 	for _, value := range values {
-		if value == want {
+		if strings.TrimSpace(value) == want {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary
- Adds `backend/internal/voicee2e` with a deterministic support-agent voice eval smoke test.
- The smoke loads the existing billing/refund voice pack, runs `text_sim` with fake deployment/tool behavior, validates canonical events plus artifact manifest checksums, builds replay projection, generates scorecards, and evaluates voice compare gates.
- Documents the one-command verification path in the test contract and test file: `go test ./internal/voicee2e -run TestSupportAgentVoiceEvalLoopSmoke -count=1` from `backend/`.

Closes #770.
Parent: #754.

## Tests
- `go test ./internal/voicee2e -run TestSupportAgentVoiceEvalLoopSmoke -count=1`
- `go test ./internal/voicee2e ./internal/voicetextsim ./internal/voicereplay ./internal/voicescorecard ./internal/releasegate`
- `go test ./...`

## Test Contract

# codex/voice-support-e2e-smoke — Test Contract

## Functional Behavior
- Add a deterministic support-agent voice smoke test using the existing support billing/refund fixture pack.
- The test must exercise `modality: voice`, `text_sim` mode, scripted user simulator data, fake voice-agent deployment, fake tool call, canonical voice events, artifact manifest validation, replay projection, scorecard generation, and voice compare gate evaluation.
- A developer can verify the full first voice-evals slice after merge with one command: `go test ./internal/voicee2e -run TestSupportAgentVoiceEvalLoopSmoke -count=1` from `backend/`.
- The sample must not require an LLM API key, telephony/WebRTC, object storage, or external network calls.
- The happy path must produce a passing scorecard and non-empty replay projection.
- A companion failing candidate must fail the compare gate deterministically.

## Unit Tests
- `TestSupportAgentVoiceEvalLoopSmoke` loads the support-agent pack, runs text-sim with fake adapters, validates events/artifact manifest, builds replay projection, generates scorecards, and evaluates pass/fail compare gates.

## Integration / Functional Tests
- `go test ./internal/voicee2e` from `backend/` verifies the full deterministic smoke path.

## Smoke Tests
- `go test ./internal/voicee2e -run TestSupportAgentVoiceEvalLoopSmoke -count=1` from `backend/`.
- `go test ./internal/voicee2e ./internal/voicetextsim ./internal/voicereplay ./internal/voicescorecard ./internal/releasegate` from `backend/`.
- `go test ./...` from `backend/` if focused tests pass.

## E2E Tests
- Covered by the deterministic internal smoke test; no external service is required.

## Manual / cURL Tests
- N/A — this is a Go smoke test, not an HTTP route.


## Review Checkpoint JSON

```json
{
  "branch": "codex/voice-support-e2e-smoke",
  "test_contract": "/tmp/codex-voice-support-e2e-smoke-test-contract.md",
  "created_at": "2026-05-13T17:45:00Z",
  "steps": [
    {
      "step_number": 1,
      "title": "Add support-agent voice eval smoke test",
      "timestamp": "2026-05-13T17:52:00Z",
      "files_changed": [
        "backend/internal/voicee2e/support_agent_smoke_test.go"
      ],
      "what_changed": "Added a deterministic support-agent voice evaluation smoke test that loads the support billing fixture pack, runs text-sim with fake deployment/tool call behavior, validates canonical events and artifact manifest checksums, builds a replay projection, generates voice scorecards, and evaluates the voice compare gate for both happy and known-bad candidates.",
      "review_instructions": "Verify the test exercises the full #770 contract without external LLM, telephony/WebRTC, object storage, or network calls; verify the documented command works and that both the happy pass and failing gate paths are deterministic.",
      "review_result": {
        "status": "pass",
        "issues_found": [],
        "notes": "Self-review checked the one-command smoke path, fixture pack modality/text_sim checks, fake deployment/tool call wiring, event validation, manifest checksum verification, replay projection, scorecard pass, and compare gate failure. Focused, neighboring, and full backend tests passed."
      },
      "cumulative_review": {
        "previous_steps_still_valid": true,
        "integration_issues": [],
        "notes": "The smoke test composes existing voice packages without changing their behavior."
      }
    },
    {
      "step_number": "final",
      "title": "Final review against test contract",
      "timestamp": "2026-05-13T17:53:00Z",
      "test_contract_review": {
        "functional_behavior": "pass - the smoke test covers the support billing voice pack, text_sim, fake deployment/tool call, canonical events, manifest checksums, replay projection, scorecards, and pass/fail compare gate paths without external services.",
        "unit_tests": "pass - TestSupportAgentVoiceEvalLoopSmoke is present and covers the contract.",
        "integration_tests": "pass - go test ./internal/voicee2e verifies the full deterministic internal smoke path.",
        "smoke_tests": "pass - documented command, neighboring package set, and go test ./... from backend passed.",
        "e2e_tests": "pass - deterministic internal E2E-style smoke test covers the final voice-evals slice.",
        "manual_tests": "N/A - no HTTP/manual route in this slice."
      },
      "overall_verdict": "ready",
      "blocking_issues": []
    }
  ]
}

```
