### PR TITLE
feat(voice): add voice eval UI affordances

### DIFF
--- a/backend/internal/api/challenge_packs.go
+++ b/backend/internal/api/challenge_packs.go
@@ -265,13 +265,15 @@ type challengePackResponse struct {
 }
 
 type challengePackVersionResponse struct {
-	ID                 uuid.UUID       `json:"id"`
-	ChallengePackID    uuid.UUID       `json:"challenge_pack_id"`
-	VersionNumber      int32           `json:"version_number"`
-	LifecycleStatus    string          `json:"lifecycle_status"`
-	DeploymentDefaults json.RawMessage `json:"deployment_defaults,omitempty"`
-	CreatedAt          time.Time       `json:"created_at"`
-	UpdatedAt          time.Time       `json:"updated_at"`
+	ID                  uuid.UUID       `json:"id"`
+	ChallengePackID     uuid.UUID       `json:"challenge_pack_id"`
+	VersionNumber       int32           `json:"version_number"`
+	LifecycleStatus     string          `json:"lifecycle_status"`
+	DeploymentDefaults  json.RawMessage `json:"deployment_defaults,omitempty"`
+	Modality            string          `json:"modality,omitempty"`
+	InterfaceTransports []string        `json:"interface_transports,omitempty"`
+	CreatedAt           time.Time       `json:"created_at"`
+	UpdatedAt           time.Time       `json:"updated_at"`
 }
 
 type listChallengePacksResponse struct {
@@ -307,13 +309,15 @@ func listChallengePacksHandler(logger *slog.Logger, service ChallengePackReadSer
 			versions := make([]challengePackVersionResponse, 0, len(packWithVersions.Versions))
 			for _, v := range packWithVersions.Versions {
 				versions = append(versions, challengePackVersionResponse{
-					ID:                 v.ID,
-					ChallengePackID:    v.ChallengePackID,
-					VersionNumber:      v.VersionNumber,
-					LifecycleStatus:    v.LifecycleStatus,
-					DeploymentDefaults: v.DeploymentDefaults,
-					CreatedAt:          v.CreatedAt,
-					UpdatedAt:          v.UpdatedAt,
+					ID:                  v.ID,
+					ChallengePackID:     v.ChallengePackID,
+					VersionNumber:       v.VersionNumber,
+					LifecycleStatus:     v.LifecycleStatus,
+					DeploymentDefaults:  v.DeploymentDefaults,
+					Modality:            v.Modality,
+					InterfaceTransports: append([]string(nil), v.InterfaceTransports...),
+					CreatedAt:           v.CreatedAt,
+					UpdatedAt:           v.UpdatedAt,
 				})
 			}
 

--- a/backend/internal/api/challenge_packs_test.go
+++ b/backend/internal/api/challenge_packs_test.go
@@ -19,11 +19,13 @@ import (
 )
 
 type fakeChallengePackReadRepository struct {
-	lastWorkspaceID uuid.UUID
-	runnableVersion repository.RunnableChallengePackVersion
-	inputSets       []repository.ChallengeInputSetSummary
-	versionDefaults json.RawMessage
-	publicPacks     bool
+	lastWorkspaceID   uuid.UUID
+	runnableVersion   repository.RunnableChallengePackVersion
+	inputSets         []repository.ChallengeInputSetSummary
+	versionDefaults   json.RawMessage
+	versionModality   string
+	versionTransports []string
+	publicPacks       bool
 }
 
 func (f *fakeChallengePackReadRepository) ListVisibleChallengePacks(_ context.Context, workspaceID uuid.UUID) ([]repository.ChallengePackSummary, error) {
@@ -47,13 +49,15 @@ func (f *fakeChallengePackReadRepository) WorkspacePublicPacksEnabled(_ context.
 func (f *fakeChallengePackReadRepository) ListRunnableChallengePVersionsByPackID(_ context.Context, challengePackID uuid.UUID) ([]repository.ChallengePackVersionSummary, error) {
 	return []repository.ChallengePackVersionSummary{
 		{
-			ID:                 uuid.New(),
-			ChallengePackID:    challengePackID,
-			VersionNumber:      1,
-			LifecycleStatus:    "runnable",
-			DeploymentDefaults: f.versionDefaults,
-			CreatedAt:          time.Now().UTC(),
-			UpdatedAt:          time.Now().UTC(),
+			ID:                  uuid.New(),
+			ChallengePackID:     challengePackID,
+			VersionNumber:       1,
+			LifecycleStatus:     "runnable",
+			DeploymentDefaults:  f.versionDefaults,
+			Modality:            f.versionModality,
+			InterfaceTransports: append([]string(nil), f.versionTransports...),
+			CreatedAt:           time.Now().UTC(),
+			UpdatedAt:           time.Now().UTC(),
 		},
 	}, nil
 }
@@ -224,6 +228,40 @@ func TestListChallengePacksHandlerIncludesDeploymentDefaults(t *testing.T) {
 	}
 	if got := defaults.Lineups["default"]; len(got) != 1 || got[0] != "candidate" {
 		t.Fatalf("default lineup = %#v, want [candidate]", got)
+	}
+}
+
+func TestListChallengePacksHandlerIncludesVoiceVersionMetadata(t *testing.T) {
+	workspaceID := uuid.New()
+	manager := NewChallengePackReadManager(&fakeChallengePackReadRepository{
+		versionModality:   "voice",
+		versionTransports: []string{"text_sim", "sip"},
+	})
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	handler := listChallengePacksHandler(logger, manager)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/workspaces/"+workspaceID.String()+"/challenge-packs", nil)
+	req = req.WithContext(context.WithValue(req.Context(), workspaceIDContextKey{}, workspaceID))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var response listChallengePacksResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Items) != 1 || len(response.Items[0].Versions) != 1 {
+		t.Fatalf("versions = %+v, want one version", response.Items)
+	}
+	version := response.Items[0].Versions[0]
+	if version.Modality != "voice" {
+		t.Fatalf("modality = %q, want voice", version.Modality)
+	}
+	if len(version.InterfaceTransports) != 2 || version.InterfaceTransports[0] != "text_sim" || version.InterfaceTransports[1] != "sip" {
+		t.Fatalf("interface_transports = %#v, want [text_sim sip]", version.InterfaceTransports)
 	}
 }
 

--- a/backend/internal/repository/challenge_pack_defaults_test.go
+++ b/backend/internal/repository/challenge_pack_defaults_test.go
@@ -32,3 +32,30 @@ func TestChallengePackDeploymentDefaultsRejectsMalformedManifest(t *testing.T) {
 		t.Fatalf("error = %q, want decode context", err.Error())
 	}
 }
+
+func TestChallengePackVersionMetadataExtractsVoiceHints(t *testing.T) {
+	metadata, err := challengePackVersionMetadata([]byte(`{
+		"schema_version": 1,
+		"modality": " voice ",
+		"interface_spec": {
+			"transports": [" text_sim ", "sip", ""]
+		},
+		"version": {
+			"deployment_defaults": {
+				"aliases": {"candidate": "Candidate Agent"}
+			}
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("challengePackVersionMetadata returned error: %v", err)
+	}
+	if metadata.Modality != "voice" {
+		t.Fatalf("modality = %q, want voice", metadata.Modality)
+	}
+	if len(metadata.InterfaceTransports) != 2 || metadata.InterfaceTransports[0] != "text_sim" || metadata.InterfaceTransports[1] != "sip" {
+		t.Fatalf("interface transports = %#v, want [text_sim sip]", metadata.InterfaceTransports)
+	}
+	if !strings.Contains(string(metadata.DeploymentDefaults), `"candidate"`) {
+		t.Fatalf("deployment defaults = %s, want candidate alias", metadata.DeploymentDefaults)
+	}
+}

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -2891,13 +2891,15 @@ type ChallengePackSummary struct {
 }
 
 type ChallengePackVersionSummary struct {
-	ID                 uuid.UUID
-	ChallengePackID    uuid.UUID
-	VersionNumber      int32
-	LifecycleStatus    string
-	DeploymentDefaults json.RawMessage
-	CreatedAt          time.Time
-	UpdatedAt          time.Time
+	ID                  uuid.UUID
+	ChallengePackID     uuid.UUID
+	VersionNumber       int32
+	LifecycleStatus     string
+	DeploymentDefaults  json.RawMessage
+	Modality            string
+	InterfaceTransports []string
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
 }
 
 func (r *Repository) ListChallengePacks(ctx context.Context) ([]ChallengePackSummary, error) {
@@ -2948,42 +2950,70 @@ func (r *Repository) ListRunnableChallengePVersionsByPackID(ctx context.Context,
 			return nil, err
 		}
 
-		deploymentDefaults, err := challengePackDeploymentDefaults(row.Manifest)
+		metadata, err := challengePackVersionMetadata(row.Manifest)
 		if err != nil {
-			return nil, fmt.Errorf("extract deployment defaults for challenge pack version %s: %w", row.ID, err)
+			return nil, fmt.Errorf("extract metadata for challenge pack version %s: %w", row.ID, err)
 		}
 
 		versions = append(versions, ChallengePackVersionSummary{
-			ID:                 row.ID,
-			ChallengePackID:    row.ChallengePackID,
-			VersionNumber:      row.VersionNumber,
-			LifecycleStatus:    row.LifecycleStatus,
-			DeploymentDefaults: deploymentDefaults,
-			CreatedAt:          createdAt,
-			UpdatedAt:          updatedAt,
+			ID:                  row.ID,
+			ChallengePackID:     row.ChallengePackID,
+			VersionNumber:       row.VersionNumber,
+			LifecycleStatus:     row.LifecycleStatus,
+			DeploymentDefaults:  metadata.DeploymentDefaults,
+			Modality:            metadata.Modality,
+			InterfaceTransports: metadata.InterfaceTransports,
+			CreatedAt:           createdAt,
+			UpdatedAt:           updatedAt,
 		})
 	}
 
 	return versions, nil
 }
 
+type challengePackVersionMetadataResult struct {
+	DeploymentDefaults  json.RawMessage
+	Modality            string
+	InterfaceTransports []string
+}
+
 func challengePackDeploymentDefaults(manifest json.RawMessage) (json.RawMessage, error) {
+	metadata, err := challengePackVersionMetadata(manifest)
+	if err != nil {
+		return nil, err
+	}
+	return metadata.DeploymentDefaults, nil
+}
+
+func challengePackVersionMetadata(manifest json.RawMessage) (challengePackVersionMetadataResult, error) {
 	if len(manifest) == 0 {
-		return nil, nil
+		return challengePackVersionMetadataResult{}, nil
 	}
 
 	var decoded struct {
+		Modality      string `json:"modality"`
+		InterfaceSpec struct {
+			Transports []string `json:"transports"`
+		} `json:"interface_spec"`
 		Version struct {
 			DeploymentDefaults json.RawMessage `json:"deployment_defaults"`
 		} `json:"version"`
 	}
 	if err := json.Unmarshal(manifest, &decoded); err != nil {
-		return nil, fmt.Errorf("decode challenge pack manifest: %w", err)
+		return challengePackVersionMetadataResult{}, fmt.Errorf("decode challenge pack manifest: %w", err)
 	}
-	if len(decoded.Version.DeploymentDefaults) == 0 || string(decoded.Version.DeploymentDefaults) == "null" {
-		return nil, nil
+	result := challengePackVersionMetadataResult{
+		Modality: strings.TrimSpace(decoded.Modality),
 	}
-	return cloneJSON(decoded.Version.DeploymentDefaults), nil
+	for _, transport := range decoded.InterfaceSpec.Transports {
+		if trimmed := strings.TrimSpace(transport); trimmed != "" {
+			result.InterfaceTransports = append(result.InterfaceTransports, trimmed)
+		}
+	}
+	if len(decoded.Version.DeploymentDefaults) > 0 && string(decoded.Version.DeploymentDefaults) != "null" {
+		result.DeploymentDefaults = cloneJSON(decoded.Version.DeploymentDefaults)
+	}
+	return result, nil
 }
 
 var (

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/[packId]/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/[packId]/page.tsx
@@ -6,6 +6,7 @@ import type { ChallengePack } from "@/lib/api/types";
 import { Badge } from "@/components/ui/badge";
 import { CreatePublicShareButton } from "@/components/share/create-public-share-button";
 import { EmptyState } from "@/components/ui/empty-state";
+import { VoiceModeBadges } from "@/components/voice/voice-mode-badges";
 import {
   Table,
   TableBody,
@@ -118,6 +119,7 @@ export default async function PackDetailPage({
               <TableRow>
                 <TableHead>Version</TableHead>
                 <TableHead>Status</TableHead>
+                <TableHead>Modality</TableHead>
                 <TableHead>Created</TableHead>
                 <TableHead className="text-right">Share</TableHead>
               </TableRow>
@@ -136,6 +138,18 @@ export default async function PackDetailPage({
                     >
                       {v.lifecycle_status}
                     </Badge>
+                  </TableCell>
+                  <TableCell>
+                    {v.modality ? (
+                      <VoiceModeBadges
+                        modality={v.modality}
+                        transports={v.interface_transports}
+                      />
+                    ) : (
+                      <span className="text-sm text-muted-foreground">
+                        {"\u2014"}
+                      </span>
+                    )}
                   </TableCell>
                   <TableCell className="text-muted-foreground">
                     {new Date(v.created_at).toLocaleDateString()}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/challenge-packs-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/challenge-packs-client.tsx
@@ -6,6 +6,8 @@ import { useApiListQuery } from "@/lib/api/swr";
 import { WorkspaceListLoading } from "@/components/app-shell/workspace-loading";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
+import { VoiceModeBadges } from "@/components/voice/voice-mode-badges";
+import { latestChallengePackVersion } from "@/lib/voice-evals";
 import {
   Table,
   TableBody,
@@ -64,6 +66,7 @@ export function ChallengePacksClient({ workspaceId }: { workspaceId: string }) {
             <TableHeader>
               <TableRow>
                 <TableHead>Name</TableHead>
+                <TableHead>Modality</TableHead>
                 <TableHead>Description</TableHead>
                 <TableHead>Versions</TableHead>
                 <TableHead>Latest Status</TableHead>
@@ -72,12 +75,7 @@ export function ChallengePacksClient({ workspaceId }: { workspaceId: string }) {
             </TableHeader>
             <TableBody>
               {packs.map((pack) => {
-                const latestVersion =
-                  pack.versions.length > 0
-                    ? pack.versions.reduce((left, right) =>
-                        left.version_number > right.version_number ? left : right,
-                      )
-                    : null;
+                const latestVersion = latestChallengePackVersion(pack);
 
                 return (
                   <TableRow key={pack.id}>
@@ -88,6 +86,18 @@ export function ChallengePacksClient({ workspaceId }: { workspaceId: string }) {
                       >
                         {pack.name}
                       </Link>
+                    </TableCell>
+                    <TableCell>
+                      {latestVersion?.modality ? (
+                        <VoiceModeBadges
+                          modality={latestVersion.modality}
+                          transports={latestVersion.interface_transports}
+                        />
+                      ) : (
+                        <span className="text-sm text-muted-foreground">
+                          {"\u2014"}
+                        </span>
+                      )}
                     </TableCell>
                     <TableCell className="max-w-xs truncate text-sm text-muted-foreground">
                       {pack.description ?? "\u2014"}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.test.tsx
@@ -98,7 +98,6 @@ function renderClient(options?: { workflowRunURL?: string }) {
           status: "running",
           execution_mode: "comparison",
           mode: "text-sim",
-          modality: "voice",
           voice: {
             mode: "text-sim",
             modality: "voice",

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.test.tsx
@@ -97,6 +97,13 @@ function renderClient(options?: { workflowRunURL?: string }) {
           name: "Live Arena Run",
           status: "running",
           execution_mode: "comparison",
+          mode: "text-sim",
+          modality: "voice",
+          voice: {
+            mode: "text-sim",
+            modality: "voice",
+            transport: "text_sim",
+          },
           ci_metadata: {
             provider: "github_actions",
             repository: "acme/agent",
@@ -171,6 +178,9 @@ describe("RunDetailClient", () => {
     expect(container.textContent).toContain("PR #42");
     expect(container.textContent).toContain("abc1234");
     expect(container.textContent).toContain("AgentClash gate");
+    expect(container.textContent).toContain("Voice");
+    expect(container.textContent).toContain("Text simulation");
+    expect(container.textContent).toContain("text_sim");
     expect(
       container.querySelector(
         'a[href="https://github.com/acme/agent/actions/runs/99"]',

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
@@ -378,7 +378,7 @@ export function RunDetailClient({
             </Badge>
             {voiceRun && (
               <VoiceModeBadges
-                modality={run.modality}
+                modality={run.voice?.modality ?? run.modality}
                 mode={voiceRunMode(run)}
                 transport={voiceRunTransport(run)}
               />

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
@@ -10,12 +10,14 @@ import { UploadArtifactDialog } from "@/components/artifacts/upload-artifact-dia
 import { CreatePublicShareButton } from "@/components/share/create-public-share-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { VoiceModeBadges } from "@/components/voice/voice-mode-badges";
 import { useAgentArena, EMPTY_LANE } from "@/hooks/use-agent-arena";
 import { useAgentCommentary } from "@/hooks/use-agent-commentary";
 import { useArenaMode } from "@/hooks/use-arena-mode";
 import { useRunEvents, type RunEvent } from "@/hooks/use-run-events";
 import { createApiClient } from "@/lib/api/client";
 import { scorePercent } from "@/lib/scores";
+import { isVoiceRun, voiceRunMode, voiceRunTransport } from "@/lib/voice-evals";
 import type {
   Run,
   RunStatus,
@@ -340,6 +342,7 @@ export function RunDetailClient({
   const ciMetadata = run.ci_metadata;
   const ciCommit = shortCommit(ciMetadata?.commit_sha);
   const ciWorkflowURL = safeHTTPURL(ciMetadata?.workflow_run_url);
+  const voiceRun = isVoiceRun(run);
 
   return (
     <div className="space-y-8">
@@ -373,6 +376,13 @@ export function RunDetailClient({
                 ? "Comparison"
                 : "Single Agent"}
             </Badge>
+            {voiceRun && (
+              <VoiceModeBadges
+                modality={run.modality}
+                mode={voiceRunMode(run)}
+                transport={voiceRunTransport(run)}
+              />
+            )}
           </div>
           
           <div className="flex items-center gap-2">
@@ -451,6 +461,15 @@ export function RunDetailClient({
             <span>Agents:</span>
             <span className="font-[family-name:var(--font-mono)] normal-case tracking-normal text-white/70">{agents.length}</span>
           </div>
+          {voiceRun && (
+            <div className="flex items-center gap-2">
+              <span>Voice:</span>
+              <span className="font-[family-name:var(--font-mono)] normal-case tracking-normal text-white/70">
+                {voiceRunMode(run) || "voice"}
+                {voiceRunTransport(run) ? ` / ${voiceRunTransport(run)}` : ""}
+              </span>
+            </div>
+          )}
           <div className="flex items-center gap-2">
             <span>Run ID:</span>
             <code className="font-[family-name:var(--font-mono)] normal-case tracking-normal text-white/70">

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/scorecard-summary-card.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/scorecard-summary-card.tsx
@@ -11,6 +11,8 @@ import {
   CheckCircle2,
   XCircle,
   BarChart3,
+  MessageCircle,
+  Wrench,
 } from "lucide-react";
 import { scorePercent, scoreColor } from "@/lib/scores";
 
@@ -22,6 +24,10 @@ const LEGACY_DIM_META: Record<
   reliability: { label: "REL", icon: Shield },
   latency: { label: "LAT", icon: Zap },
   cost: { label: "CST", icon: DollarSign },
+  task_business_success: { label: "TASK", icon: Target },
+  interaction_quality: { label: "IQ", icon: MessageCircle },
+  robustness: { label: "ROB", icon: Shield },
+  tool_data_correctness: { label: "TOOL", icon: Wrench },
 };
 
 interface ScorecardSummaryCardProps {
@@ -64,7 +70,16 @@ export function ScorecardSummaryCard({
   const dimensions = scorecard.scorecard?.dimensions ?? {};
   const dimKeys = Object.keys(dimensions).sort((a, b) => {
     // Legacy dims first in canonical order, then custom dims alphabetically.
-    const order = ["correctness", "reliability", "latency", "cost"];
+    const order = [
+      "correctness",
+      "task_business_success",
+      "reliability",
+      "interaction_quality",
+      "latency",
+      "robustness",
+      "tool_data_correctness",
+      "cost",
+    ];
     const ai = order.indexOf(a);
     const bi = order.indexOf(b);
     if (ai !== -1 && bi !== -1) return ai - bi;

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/scorecard-summary-card.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/scorecard-summary-card.tsx
@@ -26,7 +26,7 @@ const LEGACY_DIM_META: Record<
   cost: { label: "CST", icon: DollarSign },
   task_business_success: { label: "TASK", icon: Target },
   interaction_quality: { label: "IQ", icon: MessageCircle },
-  robustness: { label: "ROB", icon: Shield },
+  robustness: { label: "ROB", icon: Wrench },
   tool_data_correctness: { label: "TOOL", icon: Wrench },
 };
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.test.tsx
@@ -517,6 +517,7 @@ describe("CreateRunDialog", () => {
       expect(voiceModeSelect.disabled).toBe(false);
 
       clickElement(findCheckboxByLabel("Primary Agent"));
+      expect(document.body.textContent).toContain("using Text simulation");
       clickElement(findButton("Create Run"));
 
       await waitFor(() => {

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.test.tsx
@@ -128,6 +128,7 @@ vi.mock("@/components/ui/dialog", async () => {
 });
 
 vi.mock("lucide-react", () => ({
+  Headphones: () => React.createElement("span", null, "headphones"),
   Loader2: () => React.createElement("span", null, "loader"),
   Plus: () => React.createElement("span", null, "plus"),
 }));
@@ -243,6 +244,8 @@ interface BuildApiMockOptions {
     id: string;
     version_number: number;
     lifecycle_status?: string;
+    modality?: string;
+    interface_transports?: string[];
   }>;
   inputSetsByVersionId?: Record<
     string,
@@ -456,6 +459,78 @@ describe("CreateRunDialog", () => {
           official_pack_mode: "suite_only",
           include_proposed_regressions: false,
           race_context: false,
+        });
+      });
+    } finally {
+      view.cleanup();
+    }
+  });
+
+  it("submits text-sim mode when a voice challenge pack version is selected", async () => {
+    const api = buildApiMock({
+      versions: [
+        {
+          id: "version-voice",
+          version_number: 1,
+          lifecycle_status: "runnable",
+          modality: "voice",
+          interface_transports: ["text_sim"],
+        },
+      ],
+      inputSetsByVersionId: {
+        "version-voice": [],
+      },
+    });
+    mockCreateApiClient.mockReturnValue(api);
+
+    const view = renderDialog();
+    try {
+      clickElement(findButton("New Run"));
+
+      await waitFor(() => {
+        expect(api.get).toHaveBeenCalledWith(
+          "/v1/workspaces/ws-1/challenge-packs",
+        );
+      });
+
+      const packSelect = document.querySelector(
+        'select[aria-label="Challenge Pack"]',
+      );
+      if (!(packSelect instanceof HTMLSelectElement)) {
+        throw new Error("Challenge Pack select not found");
+      }
+      changeSelect(packSelect, "pack-1");
+
+      await waitFor(() => {
+        expect(api.get).toHaveBeenCalledWith(
+          "/v1/workspaces/ws-1/challenge-pack-versions/version-voice/input-sets",
+        );
+      });
+
+      const voiceModeSelect = document.querySelector(
+        'select[aria-label="Voice Execution Mode"]',
+      );
+      if (!(voiceModeSelect instanceof HTMLSelectElement)) {
+        throw new Error("Voice Execution Mode select not found");
+      }
+      expect(voiceModeSelect.value).toBe("text-sim");
+      expect(voiceModeSelect.disabled).toBe(false);
+
+      clickElement(findCheckboxByLabel("Primary Agent"));
+      clickElement(findButton("Create Run"));
+
+      await waitFor(() => {
+        expect(api.post).toHaveBeenCalledWith("/v1/runs", {
+          workspace_id: "ws-1",
+          challenge_pack_version_id: "version-voice",
+          challenge_input_set_id: undefined,
+          name: undefined,
+          agent_deployment_ids: ["deploy-1"],
+          regression_suite_ids: undefined,
+          regression_case_ids: undefined,
+          official_pack_mode: undefined,
+          race_context: false,
+          mode: "text-sim",
         });
       });
     } finally {

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
@@ -11,6 +11,7 @@ import { workspaceMutationKeys, workspaceResourceKeys } from "@/lib/workspace-re
 import { VoiceModeBadges } from "@/components/voice/voice-mode-badges";
 import {
   hasVoiceVersion,
+  humanVoiceMode,
   isVoiceVersion,
   versionSupportsTextSim,
   VOICE_MODE_TEXT_SIM,
@@ -803,7 +804,7 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
                 <>
                   {" "}using{" "}
                   <span className="text-foreground font-medium">
-                    text simulation
+                    {humanVoiceMode(selectedMode)}
                   </span>
                 </>
               )}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
@@ -8,6 +8,13 @@ import { useApiMutator } from "@/lib/api/swr";
 import { ApiError } from "@/lib/api/errors";
 import { billingGateToastMessage } from "@/lib/billing";
 import { workspaceMutationKeys, workspaceResourceKeys } from "@/lib/workspace-resource";
+import { VoiceModeBadges } from "@/components/voice/voice-mode-badges";
+import {
+  hasVoiceVersion,
+  isVoiceVersion,
+  versionSupportsTextSim,
+  VOICE_MODE_TEXT_SIM,
+} from "@/lib/voice-evals";
 import type {
   AgentDeployment,
   ChallengePack,
@@ -46,6 +53,7 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
   const [name, setName] = useState("");
   const [selectedPackId, setSelectedPackId] = useState("");
   const [selectedVersionId, setSelectedVersionId] = useState("");
+  const [selectedMode, setSelectedMode] = useState("");
   const [inputSetId, setInputSetId] = useState("");
   const [selectedDeploymentIds, setSelectedDeploymentIds] = useState<string[]>(
     [],
@@ -129,6 +137,7 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
   function handlePackChange(packId: string) {
     setSelectedPackId(packId);
     setSelectedVersionId("");
+    setSelectedMode("");
     setInputSetId("");
     setInputSets([]);
     setSelectedRegressionSuiteIds([]);
@@ -142,10 +151,21 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
         (v) => v.lifecycle_status === "runnable",
       );
       setRunnableVersions(runnable);
-      if (runnable.length === 1) setSelectedVersionId(runnable[0].id);
+      if (runnable.length === 1) {
+        setSelectedVersionId(runnable[0].id);
+        setSelectedMode(
+          versionSupportsTextSim(runnable[0]) ? VOICE_MODE_TEXT_SIM : "",
+        );
+      }
     } else {
       setRunnableVersions([]);
     }
+  }
+
+  function handleVersionChange(versionId: string) {
+    setSelectedVersionId(versionId);
+    const version = runnableVersions.find((candidate) => candidate.id === versionId);
+    setSelectedMode(versionSupportsTextSim(version) ? VOICE_MODE_TEXT_SIM : "");
   }
 
   function toggleDeployment(id: string) {
@@ -339,6 +359,7 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
           ? includeProposedRegressions
           : undefined,
         race_context: raceContext,
+        ...(selectedMode ? { mode: selectedMode } : {}),
       };
       const result = await api.post<CreateRunResponse>("/v1/runs", request);
       toast.success("Run created");
@@ -364,6 +385,7 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
     setName("");
     setSelectedPackId("");
     setSelectedVersionId("");
+    setSelectedMode("");
     setInputSetId("");
     setInputSets([]);
     setSelectedDeploymentIds([]);
@@ -378,10 +400,16 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
 
   const executionMode =
     selectedDeploymentIds.length > 1 ? "comparison" : "single_agent";
+  const selectedVersion = runnableVersions.find(
+    (version) => version.id === selectedVersionId,
+  );
+  const selectedVersionIsVoice = isVoiceVersion(selectedVersion);
+  const selectedVersionSupportsTextSim = versionSupportsTextSim(selectedVersion);
   const requiresInputSetSelection = inputSets.length > 1;
   const canSubmit =
     Boolean(selectedVersionId) &&
     selectedDeploymentIds.length > 0 &&
+    (!selectedVersionIsVoice || Boolean(selectedMode)) &&
     !loadingInputSets &&
     (!requiresInputSetSelection || Boolean(inputSetId));
   const eligibleRegressionSuites = regressionSuites.filter(
@@ -443,6 +471,7 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
               {packs.map((p) => (
                 <option key={p.id} value={p.id}>
                   {p.name}
+                  {hasVoiceVersion(p) ? " (voice)" : ""}
                 </option>
               ))}
             </select>
@@ -459,7 +488,7 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
             <select
               aria-label="Challenge Pack Version"
               value={selectedVersionId}
-              onChange={(e) => setSelectedVersionId(e.target.value)}
+              onChange={(e) => handleVersionChange(e.target.value)}
               disabled={!selectedPackId}
               className={selectClass}
             >
@@ -475,6 +504,40 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
               ))}
             </select>
           </div>
+
+          {selectedVersionIsVoice && selectedVersion && (
+            <div className="space-y-2 rounded-lg border border-border bg-muted/20 p-3">
+              <div className="flex items-center justify-between gap-3">
+                <label className="text-sm font-medium">
+                  Voice Mode
+                </label>
+                <VoiceModeBadges
+                  modality={selectedVersion.modality}
+                  mode={selectedMode || undefined}
+                  transports={selectedVersion.interface_transports}
+                />
+              </div>
+              <select
+                aria-label="Voice Execution Mode"
+                value={selectedMode}
+                onChange={(e) => setSelectedMode(e.target.value)}
+                disabled={!selectedVersionSupportsTextSim}
+                className={selectClass}
+              >
+                {selectedVersionSupportsTextSim ? (
+                  <option value={VOICE_MODE_TEXT_SIM}>Text simulation</option>
+                ) : (
+                  <option value="">No supported voice mode</option>
+                )}
+                <option disabled value="audio-sim">
+                  Audio simulation
+                </option>
+                <option disabled value="live-call">
+                  Live call
+                </option>
+              </select>
+            </div>
+          )}
 
           {/* Input Set */}
           <div>
@@ -736,6 +799,14 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
                   : "single-agent"}{" "}
                 mode
               </span>
+              {selectedMode && (
+                <>
+                  {" "}using{" "}
+                  <span className="text-foreground font-medium">
+                    text simulation
+                  </span>
+                </>
+              )}
               {regressionSelectionCount > 0 && (
                 <>
                   {" "}with{" "}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/run-list.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/run-list.test.tsx
@@ -1,0 +1,168 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Run } from "@/lib/api/types";
+
+import { RunList } from "./run-list";
+
+const { mockPush, mockRunsPage } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockRunsPage: {
+    current: undefined as
+      | {
+          items: Run[];
+          total: number;
+          limit: number;
+          offset: number;
+        }
+      | undefined,
+  },
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) =>
+    React.createElement("a", { href, ...props }, children),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("@/lib/api/swr", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api/swr")>();
+  return {
+    ...actual,
+    usePaginatedApiQuery: () => ({
+      data: mockRunsPage.current,
+      isLoading: false,
+      error: null,
+    }),
+  };
+});
+
+vi.mock("@/components/app-shell/workspace-loading", () => ({
+  WorkspaceListLoading: () => React.createElement("div", null, "loading"),
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLSpanElement>) =>
+    React.createElement("span", props, children),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
+    React.createElement("button", props, children),
+}));
+
+vi.mock("@/components/ui/empty-state", () => ({
+  EmptyState: ({ title }: { title: string }) =>
+    React.createElement("div", null, title),
+}));
+
+vi.mock("@/components/ui/table", () => ({
+  Table: ({ children }: { children: React.ReactNode }) =>
+    React.createElement("table", null, children),
+  TableBody: ({ children }: { children: React.ReactNode }) =>
+    React.createElement("tbody", null, children),
+  TableCell: ({ children }: { children: React.ReactNode }) =>
+    React.createElement("td", null, children),
+  TableHead: ({ children }: { children: React.ReactNode }) =>
+    React.createElement("th", null, children),
+  TableHeader: ({ children }: { children: React.ReactNode }) =>
+    React.createElement("thead", null, children),
+  TableRow: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLTableRowElement>) =>
+    React.createElement("tr", props, children),
+}));
+
+vi.mock("lucide-react", () => {
+  const icon = () => React.createElement("span", null);
+  return {
+    ChevronLeft: icon,
+    ChevronRight: icon,
+    GitCompare: icon,
+    Headphones: icon,
+    Play: icon,
+  };
+});
+
+function renderRunList() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+
+  act(() => {
+    root.render(React.createElement(RunList, { workspaceId: "ws-1" }));
+  });
+
+  return {
+    container,
+    cleanup() {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+describe("RunList", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    mockPush.mockReset();
+    mockRunsPage.current = {
+      items: [
+        {
+          id: "run-1",
+          workspace_id: "ws-1",
+          challenge_pack_version_id: "cpv-1",
+          official_pack_mode: "full",
+          name: "Voice nested metadata run",
+          status: "completed",
+          execution_mode: "single_agent",
+          race_context: false,
+          mode: "text-sim",
+          voice: {
+            mode: "text-sim",
+            modality: "voice",
+            transport: "text_sim",
+          },
+          created_at: "2026-05-13T18:00:00Z",
+          updated_at: "2026-05-13T18:00:00Z",
+          links: {
+            self: "/v1/runs/run-1",
+            agents: "/v1/runs/run-1/agents",
+          },
+        },
+      ],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    };
+  });
+
+  it("shows the voice badge when modality is only nested under voice metadata", () => {
+    const { container, cleanup } = renderRunList();
+    try {
+      expect(container.textContent).toContain("Voice nested metadata run");
+      expect(container.textContent).toContain("Voice");
+      expect(container.textContent).toContain("Text simulation");
+      expect(container.textContent).toContain("text_sim");
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/run-list.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/run-list.tsx
@@ -185,7 +185,7 @@ export function RunList({ workspaceId }: { workspaceId: string }) {
                     </div>
                     {isVoiceRun(run) && (
                       <VoiceModeBadges
-                        modality={run.modality}
+                        modality={run.voice?.modality ?? run.modality}
                         mode={voiceRunMode(run)}
                         transport={voiceRunTransport(run)}
                       />

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/run-list.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/run-list.tsx
@@ -18,6 +18,8 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
+import { VoiceModeBadges } from "@/components/voice/voice-mode-badges";
+import { isVoiceRun, voiceRunMode, voiceRunTransport } from "@/lib/voice-evals";
 import { Play, ChevronLeft, ChevronRight, GitCompare } from "lucide-react";
 import { runStatusVariant } from "./status-variant";
 
@@ -175,9 +177,20 @@ export function RunList({ workspaceId }: { workspaceId: string }) {
                   </Badge>
                 </TableCell>
                 <TableCell className="text-muted-foreground text-sm">
-                  {run.execution_mode === "comparison"
-                    ? "Comparison"
-                    : "Single Agent"}
+                  <div className="space-y-1">
+                    <div>
+                      {run.execution_mode === "comparison"
+                        ? "Comparison"
+                        : "Single Agent"}
+                    </div>
+                    {isVoiceRun(run) && (
+                      <VoiceModeBadges
+                        modality={run.modality}
+                        mode={voiceRunMode(run)}
+                        transport={voiceRunTransport(run)}
+                      />
+                    )}
+                  </div>
                 </TableCell>
                 <TableCell className="text-muted-foreground text-sm">
                   {new Date(run.created_at).toLocaleDateString()}

--- a/web/src/components/voice/voice-mode-badges.tsx
+++ b/web/src/components/voice/voice-mode-badges.tsx
@@ -1,0 +1,53 @@
+import { Headphones } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  humanVoiceMode,
+  normalizedVoiceValue,
+  VOICE_TRANSPORT_TEXT_SIM,
+} from "@/lib/voice-evals";
+
+interface VoiceModeBadgesProps {
+  modality?: string;
+  mode?: string;
+  transport?: string;
+  transports?: string[];
+}
+
+export function VoiceModeBadges({
+  modality,
+  mode,
+  transport,
+  transports,
+}: VoiceModeBadgesProps) {
+  const normalizedModality = normalizedVoiceValue(modality);
+  const normalizedTransport = normalizedVoiceValue(transport);
+  const normalizedTransports = (transports ?? []).map(normalizedVoiceValue);
+  const hasTextSimTransport =
+    normalizedTransport === VOICE_TRANSPORT_TEXT_SIM ||
+    normalizedTransports.includes(VOICE_TRANSPORT_TEXT_SIM);
+
+  if (
+    normalizedModality !== "voice" &&
+    !mode &&
+    !normalizedTransport &&
+    normalizedTransports.length === 0
+  ) {
+    return null;
+  }
+
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1.5">
+      {normalizedModality === "voice" && (
+        <Badge variant="outline" className="gap-1">
+          <Headphones className="size-3" />
+          Voice
+        </Badge>
+      )}
+      {mode && <Badge variant="secondary">{humanVoiceMode(mode)}</Badge>}
+      {hasTextSimTransport && (
+        <Badge variant="outline">text_sim</Badge>
+      )}
+    </span>
+  );
+}

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -596,6 +596,9 @@ export interface ChallengePackVersion {
   challenge_pack_id: string;
   version_number: number;
   lifecycle_status: string; // "draft" | "runnable" | "deprecated" | "archived"
+  deployment_defaults?: unknown;
+  modality?: string;
+  interface_transports?: string[];
   created_at: string;
   updated_at: string;
 }
@@ -668,6 +671,9 @@ export interface Run {
   name: string;
   status: RunStatus;
   execution_mode: string; // "single_agent" | "comparison"
+  mode?: string;
+  modality?: string;
+  voice?: RunVoiceMetadata;
   race_context: boolean;
   race_context_min_step_gap?: number;
   ci_metadata?: RunCIMetadata;
@@ -700,6 +706,12 @@ export interface RunCIMetadata {
   workflow_run_url?: string;
   event_name?: string;
   default_branch?: string;
+}
+
+export interface RunVoiceMetadata {
+  mode: string;
+  modality: string;
+  transport?: string;
 }
 
 export interface RunRegressionCoverage {
@@ -739,6 +751,7 @@ export interface CreateRunRequest {
   challenge_pack_version_id: string;
   challenge_input_set_id?: string;
   name?: string;
+  mode?: string;
   agent_deployment_ids: string[];
   regression_suite_ids?: string[];
   regression_case_ids?: string[];
@@ -758,6 +771,9 @@ export interface CreateRunResponse {
   official_pack_mode: OfficialPackMode;
   status: RunStatus;
   execution_mode: string;
+  mode?: string;
+  modality?: string;
+  voice?: RunVoiceMetadata;
   created_at: string;
   queued_at?: string;
   ci_metadata?: RunCIMetadata;

--- a/web/src/lib/voice-evals.ts
+++ b/web/src/lib/voice-evals.ts
@@ -1,0 +1,66 @@
+import type { ChallengePack, ChallengePackVersion, Run } from "@/lib/api/types";
+
+export const VOICE_MODALITY = "voice";
+export const VOICE_MODE_TEXT_SIM = "text-sim";
+export const VOICE_TRANSPORT_TEXT_SIM = "text_sim";
+
+export function normalizedVoiceValue(value?: string): string {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+export function isVoiceVersion(version?: ChallengePackVersion | null): boolean {
+  return normalizedVoiceValue(version?.modality) === VOICE_MODALITY;
+}
+
+export function versionSupportsTextSim(
+  version?: ChallengePackVersion | null,
+): boolean {
+  if (!isVoiceVersion(version)) return false;
+  return (version?.interface_transports ?? []).some(
+    (transport) =>
+      normalizedVoiceValue(transport) === VOICE_TRANSPORT_TEXT_SIM,
+  );
+}
+
+export function latestChallengePackVersion(
+  pack: ChallengePack,
+): ChallengePackVersion | null {
+  if (pack.versions.length === 0) return null;
+  return pack.versions.reduce((left, right) =>
+    left.version_number > right.version_number ? left : right,
+  );
+}
+
+export function hasVoiceVersion(pack: ChallengePack): boolean {
+  return pack.versions.some(isVoiceVersion);
+}
+
+export function isVoiceRun(run: Pick<Run, "modality" | "voice">): boolean {
+  return (
+    normalizedVoiceValue(run.modality) === VOICE_MODALITY ||
+    normalizedVoiceValue(run.voice?.modality) === VOICE_MODALITY
+  );
+}
+
+export function voiceRunMode(run: Pick<Run, "mode" | "voice">): string {
+  return run.voice?.mode || run.mode || "";
+}
+
+export function voiceRunTransport(run: Pick<Run, "voice">): string {
+  return run.voice?.transport || "";
+}
+
+export function humanVoiceMode(value?: string): string {
+  switch (normalizedVoiceValue(value)) {
+    case VOICE_MODE_TEXT_SIM:
+      return "Text simulation";
+    case "audio-sim":
+      return "Audio simulation";
+    case "live-call":
+      return "Live call";
+    case "replay-import":
+      return "Replay import";
+    default:
+      return value || "Voice";
+  }
+}


### PR DESCRIPTION
## Summary
- Shows voice/text_sim metadata on challenge pack list/detail and run list/detail surfaces.
- Adds a Voice Mode selector to New Run for voice packs that support text_sim and submits `mode: text-sim`.
- Adds readable labels/icons for deterministic voice scorecard dimensions.

## Tests
- `cd backend && go test ./internal/api -run 'TestListChallengePacksHandlerIncludes(DeploymentDefaults|VoiceVersionMetadata)|TestCreateRunEndpointPropagatesModeAndReturnsVoiceMetadata' -count=1`
- `cd backend && go test ./internal/repository -run 'TestChallengePack(DeploymentDefaults|VersionMetadata)' -count=1`
- `cd backend && go test ./internal/api ./internal/repository`
- `cd backend && go test ./...`
- `cd web && pnpm exec vitest run 'src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.test.tsx' 'src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.test.tsx'`
- `cd web && pnpm lint`
- `cd web && pnpm test`
- `cd web && pnpm build`
- `git diff --check origin/main...HEAD`

## Test Contract

# codex/voice-evals-ui — Test Contract

## Functional Behavior
- Challenge pack list and detail screens surface the latest/version modality for voice packs without hiding existing status/version data.
- The New Run dialog detects runnable voice versions from API metadata and exposes deterministic `text-sim` mode for voice packs that support `text_sim` transport.
- Creating a voice run sends `mode: "text-sim"`; creating a non-voice run does not send `mode`.
- Run list/detail screens render returned `modality`, `mode`, and `voice.transport` metadata so users can recognize voice text-sim runs after creation.
- Scorecard lane summaries use readable labels for deterministic voice scorecard dimensions.
- No audio upload/player/live-call UI is added in this PR; this is the first UI affordance for the already-merged deterministic voice substrate.

## Unit Tests
- Backend API challenge-pack response test proves version metadata includes `modality: voice` and `interface_transports: ["text_sim"]` parsed from manifest.
- `CreateRunDialog` tests prove voice selection submits `mode: "text-sim"` and non-voice selection omits `mode`.
- Existing run detail/create-run tests continue to pass with the added optional fields.

## Integration / Functional Tests
- Backend focused API tests pass for challenge-pack and run-mode response behavior.
- Web focused Vitest tests pass for create-run dialog and run-detail/client surfaces touched by this PR.

## Smoke Tests
- `cd backend && go test ./internal/api -run 'TestListChallengePacks|TestCreateRunEndpointPropagatesModeAndReturnsVoiceMetadata' -count=1`
- `cd web && pnpm exec vitest run 'src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.test.tsx'`

## E2E Tests
- N/A — this PR does not add a browser-driven authenticated E2E flow; it adds deterministic component/API coverage.

## Manual / cURL Tests
- Publish or seed a voice challenge pack, open New Run, select the voice pack/version, verify the dialog shows `text_sim`, create the run, and verify the run detail header shows Voice/Text simulation metadata.


## Review Checkpoint JSON

```json
{
  "branch": "codex/voice-evals-ui",
  "test_contract": "/tmp/codex-voice-evals-ui-test-contract.md",
  "created_at": "2026-05-13T18:32:16.372293+00:00",
  "steps": [
    {
      "step_number": 1,
      "title": "Expose voice challenge-pack version metadata to the UI",
      "timestamp": "2026-05-13T18:32:16.372293+00:00",
      "files_changed": [
        "backend/internal/repository/repository.go",
        "backend/internal/repository/challenge_pack_defaults_test.go",
        "backend/internal/api/challenge_packs.go",
        "backend/internal/api/challenge_packs_test.go"
      ],
      "what_changed": "Challenge-pack version summaries now include modality and interface_transports parsed from the manifest, and the list API returns those fields so the web UI can identify voice text_sim packs before run creation.",
      "review_instructions": "Verify the metadata is parsed from the existing manifest, empty values remain omitted, deployment_defaults still works, and API/repository focused tests cover voice metadata and existing defaults.",
      "review_result": {
        "status": "pass",
        "issues_found": [],
        "notes": "Focused backend tests passed. Existing deployment_defaults extraction now delegates to the shared metadata parser."
      },
      "cumulative_review": {
        "previous_steps_still_valid": true,
        "integration_issues": [],
        "notes": "This is the API prerequisite for the UI and does not change run creation semantics."
      }
    },
    {
      "step_number": 2,
      "title": "Add voice eval affordances to pack, run, and scorecard UI",
      "timestamp": "2026-05-13T18:32:16.372293+00:00",
      "files_changed": [
        "web/src/lib/api/types.ts",
        "web/src/lib/voice-evals.ts",
        "web/src/components/voice/voice-mode-badges.tsx",
        "web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/challenge-packs-client.tsx",
        "web/src/app/(workspace)/workspaces/[workspaceId]/challenge-packs/[packId]/page.tsx",
        "web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx",
        "web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.test.tsx",
        "web/src/app/(workspace)/workspaces/[workspaceId]/runs/run-list.tsx",
        "web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx",
        "web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.test.tsx",
        "web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/scorecard-summary-card.tsx"
      ],
      "what_changed": "Added typed voice metadata, reusable voice badges/helpers, challenge-pack modality display, text-sim mode selection in New Run, run list/detail voice metadata display, and readable labels for voice scorecard dimensions.",
      "review_instructions": "Verify voice packs are detected from modality/interface_transports, only voice text_sim versions send mode text-sim, non-voice runs continue omitting mode, run list/detail render returned voice metadata, and the UI remains lint/build/test clean.",
      "review_result": {
        "status": "pass",
        "issues_found": [],
        "notes": "Focused Vitest files passed, web lint passed, full pnpm test passed, pnpm build passed. The transport badge detects text_sim anywhere in the transport list."
      },
      "cumulative_review": {
        "previous_steps_still_valid": true,
        "integration_issues": [],
        "notes": "The UI consumes the new API metadata from step 1 and the create-run request uses the already-merged backend mode field."
      }
    },
    {
      "step_number": "final",
      "title": "Final review against test contract",
      "timestamp": "2026-05-13T18:32:40.121711+00:00",
      "test_contract_review": {
        "functional_behavior": "pass - pack list/detail, New Run, run list/detail, and scorecard summary now expose deterministic voice/text_sim affordances without adding unsupported audio/live-call UI.",
        "unit_tests": "pass - backend API/repository tests cover version metadata; CreateRunDialog covers voice mode submission; RunDetailClient covers rendered voice metadata.",
        "integration_tests": "pass - go test ./internal/api ./internal/repository, focused Vitest tests, and full web/backend suites passed.",
        "smoke_tests": "pass - documented focused backend and web smoke commands passed; pnpm build passed with pre-existing WorkOS Edge-runtime warnings.",
        "e2e_tests": "N/A - authenticated browser E2E not added for this UI affordance slice.",
        "manual_tests": "not run - requires seeded/authenticated workspace; manual steps are included in the contract."
      },
      "overall_verdict": "ready",
      "blocking_issues": []
    }
  ]
}

```
