### PR TITLE
feat(cli): add voice eval CLI parity

### DIFF
--- a/cli/cmd/challenge_pack.go
+++ b/cli/cmd/challenge_pack.go
@@ -59,7 +59,7 @@ var cpListCmd = &cobra.Command{
 			return rc.Output.PrintRaw(result)
 		}
 
-		cols := []output.Column{{Header: "ID"}, {Header: "Name"}, {Header: "Slug"}, {Header: "Status"}, {Header: "Versions"}}
+		cols := []output.Column{{Header: "ID"}, {Header: "Name"}, {Header: "Slug"}, {Header: "Status"}, {Header: "Modality"}, {Header: "Versions"}}
 		rows := make([][]string, len(result.Items))
 		for i, item := range result.Items {
 			versionCount := "0"
@@ -71,6 +71,7 @@ var cpListCmd = &cobra.Command{
 				str(item["name"]),
 				str(item["slug"]),
 				output.StatusColor(str(item["lifecycle_status"])),
+				challengePackMapModalitySummary(item),
 				versionCount,
 			}
 		}

--- a/cli/cmd/ci.go
+++ b/cli/cmd/ci.go
@@ -297,6 +297,7 @@ type ciManifestCandidateDeployment struct {
 type ciManifestEvaluation struct {
 	ChallengePackVersionID string   `yaml:"challenge_pack_version_id" json:"challenge_pack_version_id"`
 	InputSetID             string   `yaml:"input_set_id,omitempty" json:"input_set_id,omitempty"`
+	Mode                   string   `yaml:"mode,omitempty" json:"mode,omitempty"`
 	RegressionSuites       []string `yaml:"regression_suites,omitempty" json:"regression_suites,omitempty"`
 	RegressionCases        []string `yaml:"regression_cases,omitempty" json:"regression_cases,omitempty"`
 }
@@ -421,6 +422,7 @@ candidate:
 evaluation:
   challenge_pack_version_id: 00000000-0000-0000-0000-000000000005
   input_set_id: 00000000-0000-0000-0000-000000000006
+  # For deterministic voice eval packs, set: mode: text-sim
   regression_suites:
     - 00000000-0000-0000-0000-000000000007
 baseline:
@@ -912,6 +914,9 @@ func validateCIManifest(manifest ciManifest) []string {
 	}
 	if strings.TrimSpace(manifest.Evaluation.ChallengePackVersionID) == "" {
 		errors = append(errors, "evaluation.challenge_pack_version_id is required")
+	}
+	if _, err := normalizeCIManifestEvaluationMode(manifest.Evaluation.Mode); err != nil {
+		errors = append(errors, err.Error())
 	}
 	if hasBlankString(manifest.Evaluation.RegressionSuites) {
 		errors = append(errors, "evaluation.regression_suites cannot include blank entries")

--- a/cli/cmd/ci_run.go
+++ b/cli/cmd/ci_run.go
@@ -430,6 +430,10 @@ func ciRunDeploymentName(manifest ciManifest) string {
 }
 
 func createCIRun(cmd *cobra.Command, rc *RunContext, workspaceID string, manifest ciManifest, deploymentID string, ciMetadata map[string]any) (map[string]any, error) {
+	mode, err := normalizeCIManifestEvaluationMode(manifest.Evaluation.Mode)
+	if err != nil {
+		return nil, err
+	}
 	request := runCreateRequest{
 		ChallengePackVersionID: manifest.Evaluation.ChallengePackVersionID,
 		ChallengeInputSetID:    manifest.Evaluation.InputSetID,
@@ -437,6 +441,7 @@ func createCIRun(cmd *cobra.Command, rc *RunContext, workspaceID string, manifes
 		OfficialPackMode:       "full",
 		RegressionSuiteIDs:     manifest.Evaluation.RegressionSuites,
 		RegressionCaseIDs:      manifest.Evaluation.RegressionCases,
+		Mode:                   mode,
 		Name:                   ciRunName(manifest),
 		CIMetadata:             ciMetadata,
 	}

--- a/cli/cmd/ci_run_test.go
+++ b/cli/cmd/ci_run_test.go
@@ -55,6 +55,32 @@ func TestCIRunCreatesCandidateRunAndEvaluatesPassingGate(t *testing.T) {
 	}
 }
 
+func TestCIRunPropagatesTextSimEvaluationMode(t *testing.T) {
+	target := writeCIRunManifestWith(t, func(manifest string) string {
+		return strings.Replace(
+			manifest,
+			"  input_set_id: 00000000-0000-0000-0000-000000000006\n",
+			"  input_set_id: 00000000-0000-0000-0000-000000000006\n  mode: text-sim\n",
+			1,
+		)
+	})
+	captures := &ciRunRouteCaptures{}
+	srv := fakeAPI(t, ciRunRoutes(t, captures, nil))
+	defer srv.Close()
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+
+	result, err, _ := runCIRunJSON(t, []string{"ci", "run", "--manifest", target, "-w", "ws-1", "--json", "--poll-interval", "1ms", "--timeout", "1s"}, srv.URL)
+	if err != nil {
+		t.Fatalf("ci run error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if captures.RunBody["mode"] != "text-sim" {
+		t.Fatalf("run body mode = %v, want text-sim", captures.RunBody["mode"])
+	}
+}
+
 func TestCIRunWritesSummaryAndArtifacts(t *testing.T) {
 	target := writeCIRunManifest(t)
 	captures := &ciRunRouteCaptures{}

--- a/cli/cmd/ci_test.go
+++ b/cli/cmd/ci_test.go
@@ -102,6 +102,30 @@ func TestCIValidateJSONOutput(t *testing.T) {
 	}
 }
 
+func TestCIValidateAcceptsTextSimEvaluationMode(t *testing.T) {
+	target := writeCIManifest(t, strings.Replace(
+		sampleCIManifestYAML,
+		"  input_set_id: 00000000-0000-0000-0000-000000000006\n",
+		"  input_set_id: 00000000-0000-0000-0000-000000000006\n  mode: text-sim\n",
+		1,
+	))
+	stdout := captureStdout(t)
+
+	err := executeCommand(t, []string{"ci", "validate", target, "--json"}, "http://unused")
+	out := stdout.finish()
+	if err != nil {
+		t.Fatalf("ci validate --json error: %v", err)
+	}
+
+	var result ciManifestValidationResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("json output parse error: %v\n---\n%s", err, out)
+	}
+	if !result.Valid || result.Manifest == nil || result.Manifest.Evaluation.Mode != "text-sim" {
+		t.Fatalf("validation result = %+v, want text-sim mode preserved", result)
+	}
+}
+
 func TestCIValidateRejectsInvalidManifests(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -193,6 +217,30 @@ regressions:
   promote_failures: proposed
 `,
 			want: "evaluation.challenge_pack_version_id",
+		},
+		{
+			name: "unsupported evaluation mode",
+			manifest: `version: 1
+trigger:
+  paths:
+    - .agentclash/agent.json
+candidate:
+  build:
+    agent_build_id: build-1
+    spec_file: .agentclash/agent.json
+  deployment:
+    runtime_profile_id: runtime-1
+evaluation:
+  challenge_pack_version_id: pack-version-1
+  mode: live-call
+baseline:
+  run_id: run-1
+gate:
+  fail_on: regression
+regressions:
+  promote_failures: proposed
+`,
+			want: "evaluation.mode",
 		},
 		{
 			name: "missing baseline",

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -171,7 +171,7 @@ var runListCmd = &cobra.Command{
 			return rc.Output.PrintRaw(result)
 		}
 
-		cols := []output.Column{{Header: "ID"}, {Header: "Name"}, {Header: "Status"}, {Header: "Agents"}, {Header: "Created"}}
+		cols := []output.Column{{Header: "ID"}, {Header: "Name"}, {Header: "Status"}, {Header: "Mode"}, {Header: "Agents"}, {Header: "Created"}}
 		rows := make([][]string, len(result.Items))
 		for i, item := range result.Items {
 			agentCount := "-"
@@ -182,6 +182,7 @@ var runListCmd = &cobra.Command{
 				str(item["id"]),
 				str(item["name"]),
 				output.StatusColor(str(item["status"])),
+				runModeSummary(item),
 				agentCount,
 				str(item["created_at"]),
 			}
@@ -307,6 +308,15 @@ var runGetCmd = &cobra.Command{
 		rc.Output.PrintDetail("Name", str(run["name"]))
 		rc.Output.PrintDetail("Status", output.StatusColor(str(run["status"])))
 		rc.Output.PrintDetail("Workspace", str(run["workspace_id"]))
+		if executionMode := mapString(run, "execution_mode"); executionMode != "" {
+			rc.Output.PrintDetail("Execution Mode", executionMode)
+		}
+		if mode := voiceRunMode(run); mode != "" {
+			rc.Output.PrintDetail("Mode", humanVoiceMode(mode))
+		}
+		if voiceSummary := voiceRunSummary(run); voiceSummary != "" {
+			rc.Output.PrintDetail("Voice", voiceSummary)
+		}
 		rc.Output.PrintDetail("Created", str(run["created_at"]))
 		if str(run["started_at"]) != "" {
 			rc.Output.PrintDetail("Started", str(run["started_at"]))
@@ -413,6 +423,9 @@ For CI and other non-interactive use, keep passing explicit IDs via flags.`,
 		request.ChallengePackVersionID = selections.challengePackVersionID
 		request.ChallengeInputSetID = selections.challengeInputSetID
 		request.DeploymentIDs = selections.deploymentIDs
+		if request.Mode == "" {
+			request.Mode = selections.mode
+		}
 
 		if request.Seeds > 0 {
 			if follow {

--- a/cli/cmd/run_create_helpers.go
+++ b/cli/cmd/run_create_helpers.go
@@ -122,6 +122,14 @@ func runCreateRequestFromFlags(cmd *cobra.Command, base runCreateRequest) (runCr
 }
 
 func normalizeRunCreateMode(raw string) (string, error) {
+	return normalizeVoiceEvalMode(raw, "--mode")
+}
+
+func normalizeCIManifestEvaluationMode(raw string) (string, error) {
+	return normalizeVoiceEvalMode(raw, "evaluation.mode")
+}
+
+func normalizeVoiceEvalMode(raw, field string) (string, error) {
 	mode := strings.ToLower(strings.TrimSpace(raw))
 	switch mode {
 	case "":
@@ -129,9 +137,9 @@ func normalizeRunCreateMode(raw string) (string, error) {
 	case runCreateModeTextSim:
 		return mode, nil
 	case runCreateModeAudioSim, runCreateModeLiveCall, runCreateModeReplayImport:
-		return "", fmt.Errorf("--mode %q is reserved for future voice eval support; supported mode: %s", mode, runCreateModeTextSim)
+		return "", fmt.Errorf("%s %q is reserved for future voice eval support; supported mode: %s", field, mode, runCreateModeTextSim)
 	default:
-		return "", fmt.Errorf("unsupported --mode %q (supported mode: %s)", raw, runCreateModeTextSim)
+		return "", fmt.Errorf("unsupported %s %q (supported mode: %s)", field, raw, runCreateModeTextSim)
 	}
 }
 

--- a/cli/cmd/run_create_interactive.go
+++ b/cli/cmd/run_create_interactive.go
@@ -15,10 +15,12 @@ type challengePackSummary struct {
 }
 
 type challengePackVersionBrief struct {
-	ID                 string              `json:"id"`
-	VersionNumber      int                 `json:"version_number"`
-	LifecycleStatus    string              `json:"lifecycle_status"`
-	DeploymentDefaults *deploymentDefaults `json:"deployment_defaults,omitempty"`
+	ID                  string              `json:"id"`
+	VersionNumber       int                 `json:"version_number"`
+	LifecycleStatus     string              `json:"lifecycle_status"`
+	Modality            string              `json:"modality,omitempty"`
+	InterfaceTransports []string            `json:"interface_transports,omitempty"`
+	DeploymentDefaults  *deploymentDefaults `json:"deployment_defaults,omitempty"`
 }
 
 type deploymentDefaults struct {
@@ -43,6 +45,7 @@ type runCreateSelections struct {
 	challengePackVersionID string
 	challengeInputSetID    string
 	deploymentIDs          []string
+	mode                   string
 }
 
 func resolveRunCreateSelections(cmd *cobra.Command, rc *RunContext, workspaceID string) (runCreateSelections, error) {
@@ -93,7 +96,8 @@ func resolveRunCreateSelections(cmd *cobra.Command, rc *RunContext, workspaceID 
 		if err != nil {
 			return runCreateSelections{}, err
 		}
-		selections.challengePackVersionID = selectedVersion
+		selections.challengePackVersionID = selectedVersion.ID
+		selections.mode = suggestedRunModeForVersion(selectedVersion)
 	}
 
 	// Always offer the input-set picker when --input-set was omitted in a
@@ -150,10 +154,10 @@ func missingRunCreateFlags(selections runCreateSelections) []string {
 	return missing
 }
 
-func promptForChallengePackVersion(cmd *cobra.Command, rc *RunContext, workspaceID string, picker interactivePicker) (string, error) {
+func promptForChallengePackVersion(cmd *cobra.Command, rc *RunContext, workspaceID string, picker interactivePicker) (challengePackVersionBrief, error) {
 	packs, err := listChallengePacks(cmd, rc, workspaceID)
 	if err != nil {
-		return "", err
+		return challengePackVersionBrief{}, err
 	}
 
 	options := make([]pickerOption, 0, len(packs))
@@ -162,15 +166,15 @@ func promptForChallengePackVersion(cmd *cobra.Command, rc *RunContext, workspace
 			continue
 		}
 		options = append(options, pickerOption{
-			Label:       pack.Name,
-			Description: fmt.Sprintf("%d runnable version(s) • %s", len(pack.Versions), pack.ID),
+			Label:       challengePackPickerLabel(pack),
+			Description: challengePackPickerDescription(pack),
 			Value:       pack.ID,
 		})
 	}
 
 	selectedPack, err := selectOneOrAuto(picker, "Choose a challenge pack", options)
 	if err != nil {
-		return "", err
+		return challengePackVersionBrief{}, err
 	}
 
 	var versions []challengePackVersionBrief
@@ -187,17 +191,22 @@ func promptForChallengePackVersion(cmd *cobra.Command, rc *RunContext, workspace
 	versionOptions := make([]pickerOption, 0, len(versions))
 	for _, version := range versions {
 		versionOptions = append(versionOptions, pickerOption{
-			Label:       fmt.Sprintf("v%d", version.VersionNumber),
-			Description: fmt.Sprintf("status: %s • %s", version.LifecycleStatus, version.ID),
+			Label:       challengePackVersionPickerLabel(version),
+			Description: challengePackVersionPickerDescription(version),
 			Value:       version.ID,
 		})
 	}
 
 	selectedVersion, err := selectOneOrAuto(picker, "Choose a challenge pack version", versionOptions)
 	if err != nil {
-		return "", err
+		return challengePackVersionBrief{}, err
 	}
-	return selectedVersion.Value, nil
+	for _, version := range versions {
+		if version.ID == selectedVersion.Value {
+			return version, nil
+		}
+	}
+	return challengePackVersionBrief{}, fmt.Errorf("selected challenge pack version %s was not found", selectedVersion.Value)
 }
 
 func maybePromptForChallengeInputSet(cmd *cobra.Command, rc *RunContext, workspaceID, challengePackVersionID string, picker interactivePicker) (string, error) {

--- a/cli/cmd/voice_eval_cli_test.go
+++ b/cli/cmd/voice_eval_cli_test.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestChallengePackListShowsVoiceMetadata(t *testing.T) {
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/challenge-packs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":               "pack-voice",
+				"name":             "Voice Support",
+				"slug":             "voice-support",
+				"lifecycle_status": "active",
+				"versions": []map[string]any{{
+					"id":                   "cpv-voice",
+					"version_number":       2,
+					"lifecycle_status":     "runnable",
+					"modality":             "voice",
+					"interface_transports": []string{"text_sim"},
+				}},
+			}},
+		}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+	if err := executeCommand(t, []string{"challenge-pack", "list", "-w", "ws-1"}, srv.URL); err != nil {
+		t.Fatalf("challenge-pack list error: %v", err)
+	}
+
+	out := stdout.finish()
+	for _, want := range []string{"MODALITY", "Voice Support", "voice / text_sim"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("challenge-pack list missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestRunListShowsVoiceMetadata(t *testing.T) {
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/runs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":             "run-voice",
+				"name":           "Voice run",
+				"status":         "completed",
+				"execution_mode": "single_agent",
+				"agent_count":    1,
+				"created_at":     "2026-05-13T18:00:00Z",
+				"voice": map[string]any{
+					"mode":      "text-sim",
+					"modality":  "voice",
+					"transport": "text_sim",
+				},
+			}},
+		}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+	if err := executeCommand(t, []string{"run", "list", "-w", "ws-1"}, srv.URL); err != nil {
+		t.Fatalf("run list error: %v", err)
+	}
+
+	out := stdout.finish()
+	for _, want := range []string{"MODE", "single_agent; voice / Text simulation / text_sim"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("run list missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestRunGetShowsNestedVoiceMetadata(t *testing.T) {
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/runs/run-voice": jsonHandler(200, map[string]any{
+			"id":             "run-voice",
+			"name":           "Voice run",
+			"status":         "completed",
+			"workspace_id":   "ws-1",
+			"execution_mode": "single_agent",
+			"created_at":     "2026-05-13T18:00:00Z",
+			"voice": map[string]any{
+				"mode":      "text-sim",
+				"modality":  "voice",
+				"transport": "text_sim",
+			},
+		}),
+	})
+	defer srv.Close()
+
+	stdout := captureStdout(t)
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+	if err := executeCommand(t, []string{"run", "get", "run-voice"}, srv.URL); err != nil {
+		t.Fatalf("run get error: %v", err)
+	}
+
+	out := stdout.finish()
+	for _, want := range []string{"Execution Mode", "single_agent", "Mode", "Text simulation", "Voice", "voice / Text simulation / text_sim"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("run get missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestChallengePackPickerLabelsVoiceVersions(t *testing.T) {
+	pack := challengePackSummary{
+		ID:   "pack-voice",
+		Name: "Voice Support",
+		Versions: []challengePackVersionBrief{{
+			ID:                  "cpv-voice",
+			VersionNumber:       3,
+			LifecycleStatus:     "runnable",
+			Modality:            "voice",
+			InterfaceTransports: []string{"text_sim"},
+		}},
+	}
+
+	if got := challengePackPickerLabel(pack); got != "Voice Support (voice)" {
+		t.Fatalf("challengePackPickerLabel() = %q", got)
+	}
+	if got := challengePackPickerDescription(pack); !strings.Contains(got, "text_sim") {
+		t.Fatalf("challengePackPickerDescription() = %q, want transport", got)
+	}
+	if got := challengePackVersionPickerLabel(pack.Versions[0]); got != "v3 (voice)" {
+		t.Fatalf("challengePackVersionPickerLabel() = %q", got)
+	}
+	if got := suggestedRunModeForVersion(pack.Versions[0]); got != "text-sim" {
+		t.Fatalf("suggestedRunModeForVersion() = %q, want text-sim", got)
+	}
+}
+
+func TestRunCreateGuidedVoiceSelectionAutoPostsTextSimMode(t *testing.T) {
+	oldInteractive := isInteractiveTerminal
+	oldPickerFactory := newInteractivePicker
+	isInteractiveTerminal = func(*RunContext) bool { return true }
+	newInteractivePicker = func() interactivePicker { return &fakePicker{} }
+	t.Cleanup(func() {
+		isInteractiveTerminal = oldInteractive
+		newInteractivePicker = oldPickerFactory
+	})
+
+	var gotBody map[string]any
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/challenge-packs": jsonHandler(200, map[string]any{
+			"items": []map[string]any{{
+				"id":   "pack-voice",
+				"name": "Voice Support",
+				"versions": []map[string]any{{
+					"id":                   "cpv-voice",
+					"version_number":       1,
+					"lifecycle_status":     "runnable",
+					"modality":             "voice",
+					"interface_transports": []string{"text_sim"},
+				}},
+			}},
+		}),
+		"GET /v1/workspaces/ws-1/challenge-pack-versions/cpv-voice/input-sets": jsonHandler(200, map[string]any{
+			"items": []map[string]any{},
+		}),
+		"POST /v1/runs": func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			jsonHandler(http.StatusCreated, map[string]any{
+				"id":     "run-voice",
+				"status": "queued",
+			})(w, r)
+		},
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-token")
+	if err := executeCommand(t, []string{"run", "create", "-w", "ws-1", "--deployments", "dep-1"}, srv.URL); err != nil {
+		t.Fatalf("run create error: %v", err)
+	}
+	if gotBody["mode"] != "text-sim" {
+		t.Fatalf("mode = %v, want text-sim in guided voice run", gotBody["mode"])
+	}
+}

--- a/cli/cmd/voice_eval_helpers.go
+++ b/cli/cmd/voice_eval_helpers.go
@@ -1,0 +1,233 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const voiceEvalModality = "voice"
+
+func normalizeVoiceValue(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func humanVoiceMode(value string) string {
+	switch normalizeVoiceValue(value) {
+	case runCreateModeTextSim:
+		return "Text simulation"
+	case runCreateModeAudioSim:
+		return "Audio simulation"
+	case runCreateModeLiveCall:
+		return "Live call"
+	case runCreateModeReplayImport:
+		return "Replay import"
+	default:
+		if strings.TrimSpace(value) == "" {
+			return "Voice"
+		}
+		return strings.TrimSpace(value)
+	}
+}
+
+func voiceModeSummary(mode, transport string) string {
+	parts := []string{voiceEvalModality}
+	if strings.TrimSpace(mode) != "" {
+		parts = append(parts, humanVoiceMode(mode))
+	}
+	if strings.TrimSpace(transport) != "" {
+		parts = append(parts, strings.TrimSpace(transport))
+	}
+	return strings.Join(parts, " / ")
+}
+
+func voiceRunModality(run map[string]any) string {
+	if voice := mapObject(run, "voice"); voice != nil {
+		if modality := mapString(voice, "modality"); modality != "" {
+			return modality
+		}
+	}
+	return mapString(run, "modality")
+}
+
+func voiceRunMode(run map[string]any) string {
+	if voice := mapObject(run, "voice"); voice != nil {
+		if mode := mapString(voice, "mode"); mode != "" {
+			return mode
+		}
+	}
+	return mapString(run, "mode")
+}
+
+func voiceRunTransport(run map[string]any) string {
+	if voice := mapObject(run, "voice"); voice != nil {
+		return mapString(voice, "transport")
+	}
+	return ""
+}
+
+func voiceRunSummary(run map[string]any) string {
+	modality := voiceRunModality(run)
+	mode := voiceRunMode(run)
+	transport := voiceRunTransport(run)
+	if normalizeVoiceValue(modality) != voiceEvalModality && mode == "" && transport == "" {
+		return ""
+	}
+	if normalizeVoiceValue(modality) != voiceEvalModality {
+		parts := []string{strings.TrimSpace(modality)}
+		if mode != "" {
+			parts = append(parts, humanVoiceMode(mode))
+		}
+		if transport != "" {
+			parts = append(parts, strings.TrimSpace(transport))
+		}
+		return strings.Join(compactNonEmptyStrings(parts), " / ")
+	}
+	return voiceModeSummary(mode, transport)
+}
+
+func runModeSummary(run map[string]any) string {
+	executionMode := mapString(run, "execution_mode")
+	voiceSummary := voiceRunSummary(run)
+	switch {
+	case executionMode != "" && voiceSummary != "":
+		return fmt.Sprintf("%s; %s", executionMode, voiceSummary)
+	case voiceSummary != "":
+		return voiceSummary
+	case executionMode != "":
+		return executionMode
+	default:
+		return "-"
+	}
+}
+
+func latestChallengePackVersionMap(pack map[string]any) map[string]any {
+	versions := mapSlice(pack, "versions")
+	if len(versions) == 0 {
+		return nil
+	}
+	var latest map[string]any
+	for _, raw := range versions {
+		version, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if latest == nil || versionNumber(version["version_number"]) > versionNumber(latest["version_number"]) {
+			latest = version
+		}
+	}
+	return latest
+}
+
+func challengePackMapModalitySummary(pack map[string]any) string {
+	version := latestChallengePackVersionMap(pack)
+	if version == nil {
+		return "-"
+	}
+	modality := mapString(version, "modality")
+	transports := mapStringSlice(version, "interface_transports")
+	if normalizeVoiceValue(modality) != voiceEvalModality {
+		if strings.TrimSpace(modality) != "" {
+			return strings.TrimSpace(modality)
+		}
+		return "-"
+	}
+	if len(transports) == 0 {
+		return voiceEvalModality
+	}
+	return voiceEvalModality + " / " + strings.Join(transports, ", ")
+}
+
+func versionNumber(value any) float64 {
+	switch typed := value.(type) {
+	case int:
+		return float64(typed)
+	case int64:
+		return float64(typed)
+	case float64:
+		return typed
+	case string:
+		parsed, _ := strconv.ParseFloat(strings.TrimSpace(typed), 64)
+		return parsed
+	default:
+		return 0
+	}
+}
+
+func challengePackHasVoiceVersion(pack challengePackSummary) bool {
+	for _, version := range pack.Versions {
+		if normalizeVoiceValue(version.Modality) == voiceEvalModality {
+			return true
+		}
+	}
+	return false
+}
+
+func challengePackTransportSummary(pack challengePackSummary) string {
+	seen := map[string]bool{}
+	var transports []string
+	for _, version := range pack.Versions {
+		if normalizeVoiceValue(version.Modality) != voiceEvalModality {
+			continue
+		}
+		for _, transport := range version.InterfaceTransports {
+			normalized := strings.TrimSpace(transport)
+			if normalized == "" || seen[normalized] {
+				continue
+			}
+			seen[normalized] = true
+			transports = append(transports, normalized)
+		}
+	}
+	return strings.Join(transports, ", ")
+}
+
+func challengePackPickerLabel(pack challengePackSummary) string {
+	if challengePackHasVoiceVersion(pack) {
+		return strings.TrimSpace(pack.Name) + " (voice)"
+	}
+	return pack.Name
+}
+
+func challengePackPickerDescription(pack challengePackSummary) string {
+	description := fmt.Sprintf("%d runnable version(s) • %s", len(pack.Versions), pack.ID)
+	if transports := challengePackTransportSummary(pack); transports != "" {
+		description += " • " + transports
+	}
+	return description
+}
+
+func challengePackVersionPickerLabel(version challengePackVersionBrief) string {
+	label := fmt.Sprintf("v%d", version.VersionNumber)
+	if normalizeVoiceValue(version.Modality) == voiceEvalModality {
+		label += " (voice)"
+	}
+	return label
+}
+
+func challengePackVersionPickerDescription(version challengePackVersionBrief) string {
+	description := fmt.Sprintf("status: %s • %s", version.LifecycleStatus, version.ID)
+	if len(version.InterfaceTransports) > 0 {
+		description += " • " + strings.Join(version.InterfaceTransports, ", ")
+	}
+	return description
+}
+
+func versionSupportsTextSimBrief(version challengePackVersionBrief) bool {
+	if normalizeVoiceValue(version.Modality) != voiceEvalModality {
+		return false
+	}
+	for _, transport := range version.InterfaceTransports {
+		if normalizeVoiceValue(transport) == "text_sim" {
+			return true
+		}
+	}
+	return false
+}
+
+func suggestedRunModeForVersion(version challengePackVersionBrief) string {
+	if versionSupportsTextSimBrief(version) {
+		return runCreateModeTextSim
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary
- Adds CLI voice/text_sim affordances matching the merged web UI: challenge-pack list, guided run create, run list, and run get now surface voice metadata in human output.
- Auto-selects `mode: text-sim` in guided `run create` when the selected voice challenge-pack version supports `text_sim`.
- Adds `evaluation.mode: text-sim` support for CI manifests and forwards it into candidate run creation.

## Release Notes
- This is a CLI feature commit (`feat(cli): ...`) so the normal Release Please flow should publish the next npm CLI release after merge.
- No manual npm publish was performed.

## Tests
- `cd cli && go test ./cmd -run 'Voice|TextSim|CI' -count=1`
- `cd cli && go test ./...`
- `cd cli && go build ./...`
- `cd cli && go vet ./...`
- `cd cli && go run github.com/goreleaser/goreleaser/v2@latest check`
- `cd cli && go run github.com/goreleaser/goreleaser/v2@latest release --snapshot --clean`
- `cd cli && go test -short -race -count=1 ./...`
- `git diff --check`

## Test Contract

# codex/voice-evals-cli-parity — Test Contract

## Functional Behavior
- `agentclash challenge-pack list` exposes voice pack affordances in human output without changing structured JSON output.
- Guided `agentclash run create` labels voice/text_sim challenge packs and versions so CLI users can discover voice eval packs before selecting them.
- `agentclash run list` and `agentclash run get` expose returned `mode`, `modality`, and nested `voice.transport` metadata in human output while preserving raw JSON/YAML output.
- `agentclash run create --mode text-sim` remains supported, future voice modes remain locally rejected, and seeded/lineup modes keep existing constraints.
- `.agentclash/ci.yaml` can set `evaluation.mode: text-sim`; `agentclash ci validate` accepts it and `agentclash ci run` forwards it to the run-create request.
- Unsupported CI evaluation modes fail locally with deterministic error text before any API run is launched.

## Unit Tests
- CLI tests cover challenge-pack list voice metadata rendering.
- CLI tests cover run list/get voice metadata rendering from top-level and nested voice metadata.
- Existing run create tests continue to prove `--mode text-sim` posts `mode` and future modes are rejected.
- CI tests cover manifest `evaluation.mode: text-sim` validation and CI run request propagation.
- CI tests cover unsupported `evaluation.mode` local validation.

## Integration / Functional Tests
- `cd cli && go test ./cmd -run 'Voice|TextSim|CI' -count=1` passes.
- `cd cli && go test ./...` passes.

## Smoke Tests
- `cd cli && go build ./...` passes.
- `cd cli && go vet ./...` passes.

## E2E Tests
- N/A — this is CLI/API contract coverage with fake API servers; no live hosted backend mutation is required.

## Manual / cURL Tests
```bash
export AGENTCLASH_API_URL=https://api.agentclash.dev
agentclash run create --workspace <workspace-id> --challenge-pack-version <voice-version-id> --deployments <deployment-id> --mode text-sim --json
# Expected: POST body includes mode=text-sim; response includes mode/modality/voice metadata when backend returns it.
```


## Review Checkpoint JSON

```json
{
  "branch": "codex/voice-evals-cli-parity",
  "test_contract": "/tmp/codex-voice-evals-cli-parity-test-contract.md",
  "created_at": "2026-05-13T20:00:06.940165+00:00",
  "steps": [
    {
      "step_number": 1,
      "title": "Add CLI voice eval surfaces and guided text-sim selection",
      "timestamp": "2026-05-13T20:04:02.039826+00:00",
      "files_changed": [
        "cli/cmd/voice_eval_helpers.go",
        "cli/cmd/voice_eval_cli_test.go",
        "cli/cmd/challenge_pack.go",
        "cli/cmd/run.go",
        "cli/cmd/run_create_helpers.go",
        "cli/cmd/run_create_interactive.go"
      ],
      "what_changed": "Challenge-pack list, run list, and run get now render voice/text_sim metadata in human output; guided run create labels voice packs/versions and automatically sends mode text-sim when a selected voice version supports text_sim.",
      "review_instructions": "Verify structured output remains raw, human tables/details include mode/modality/transport, future voice modes remain locally rejected, and guided text_sim auto-selection only applies to selected voice text_sim versions.",
      "review_result": {
        "status": "pass",
        "issues_found": [],
        "notes": "Focused go test ./cmd -run 'Voice|TextSim|CI' passed after the guided mode handoff fix."
      },
      "cumulative_review": {
        "previous_steps_still_valid": true,
        "integration_issues": [],
        "notes": "These changes reuse the existing run create mode field and do not add new API endpoints."
      }
    },
    {
      "step_number": 2,
      "title": "Add CI manifest voice mode support",
      "timestamp": "2026-05-13T20:05:48.351671+00:00",
      "files_changed": [
        "cli/cmd/ci.go",
        "cli/cmd/ci_run.go",
        "cli/cmd/ci_test.go",
        "cli/cmd/ci_run_test.go"
      ],
      "what_changed": "CI manifests now accept evaluation.mode: text-sim, reject unsupported voice modes locally, and forward the normalized mode into the candidate run-create request.",
      "review_instructions": "Verify known-fields YAML parsing accepts evaluation.mode, validation rejects future modes deterministically, and ci run propagates text-sim into POST /v1/runs without changing existing manifest behavior.",
      "review_result": {
        "status": "pass",
        "issues_found": [],
        "notes": "Focused CI tests, full CLI tests, race tests, build, vet, GoReleaser check, and snapshot release rehearsal passed."
      },
      "cumulative_review": {
        "previous_steps_still_valid": true,
        "integration_issues": [],
        "notes": "CI uses the same normalization as run create, so CLI flag and manifest behavior stay aligned."
      }
    },
    {
      "step_number": "final",
      "title": "Final review against test contract",
      "timestamp": "2026-05-13T20:05:48.351908+00:00",
      "test_contract_review": {
        "functional_behavior": "pass - CLI human output surfaces voice metadata, guided run create auto-selects text-sim for voice text_sim versions, and CI manifests can launch text-sim voice evals.",
        "unit_tests": "pass - voice CLI rendering, guided selection, run create mode, and CI mode tests exist and pass.",
        "integration_tests": "pass - go test ./cmd -run Voice|TextSim|CI and go test ./... passed.",
        "smoke_tests": "pass - go build ./..., go vet ./..., GoReleaser check, and GoReleaser snapshot release rehearsal passed.",
        "e2e_tests": "N/A - fake API coverage validates CLI/API contracts without live hosted mutations.",
        "manual_tests": "not run - manual hosted run requires real workspace/deployment IDs; command documented in the contract."
      },
      "overall_verdict": "ready",
      "blocking_issues": []
    }
  ]
}

```
