### PR TITLE
[codex] score voice media preservation metrics

### DIFF
--- a/backend/internal/releasegate/voice.go
+++ b/backend/internal/releasegate/voice.go
@@ -9,12 +9,15 @@ import (
 )
 
 const (
-	VoiceDimensionOverallScore        = "voice_overall_score"
-	VoiceDimensionTaskBusinessSuccess = "task_business_success"
-	VoiceDimensionInteractionQuality  = "interaction_quality"
-	VoiceDimensionToolDataCorrectness = "tool_data_correctness"
-	VoiceDimensionLatencyMS           = "latency_ms"
-	VoiceDimensionMissingEvidence     = "voice_missing_evidence"
+	VoiceDimensionOverallScore                = "voice_overall_score"
+	VoiceDimensionTaskBusinessSuccess         = "task_business_success"
+	VoiceDimensionInteractionQuality          = "interaction_quality"
+	VoiceDimensionToolDataCorrectness         = "tool_data_correctness"
+	VoiceDimensionLatencyMS                   = "latency_ms"
+	VoiceDimensionMediaPolicy                 = "media_policy"
+	VoiceDimensionBackgroundPreservationRatio = "background_preservation_ratio"
+	VoiceDimensionSpeechDropRisk              = "speech_drop_risk"
+	VoiceDimensionMissingEvidence             = "voice_missing_evidence"
 )
 
 type VoiceComparisonConfig struct {
@@ -44,12 +47,15 @@ func VoicePolicy(config VoiceComparisonConfig) Policy {
 			VoiceDimensionToolDataCorrectness,
 		},
 		Dimensions: map[string]DimensionThreshold{
-			VoiceDimensionOverallScore:        {WarnDelta: floatPtr(0.02), FailDelta: floatPtr(0.05)},
-			VoiceDimensionTaskBusinessSuccess: {FailDelta: floatPtr(0.01)},
-			VoiceDimensionInteractionQuality:  {FailDelta: floatPtr(0.01)},
-			VoiceDimensionToolDataCorrectness: {FailDelta: floatPtr(0.01)},
-			VoiceDimensionLatencyMS:           {WarnDelta: floatPtr(100), FailDelta: floatPtr(250)},
-			VoiceDimensionMissingEvidence:     missingThreshold,
+			VoiceDimensionOverallScore:                {WarnDelta: floatPtr(0.02), FailDelta: floatPtr(0.05)},
+			VoiceDimensionTaskBusinessSuccess:         {FailDelta: floatPtr(0.01)},
+			VoiceDimensionInteractionQuality:          {FailDelta: floatPtr(0.01)},
+			VoiceDimensionToolDataCorrectness:         {FailDelta: floatPtr(0.01)},
+			VoiceDimensionLatencyMS:                   {WarnDelta: floatPtr(100), FailDelta: floatPtr(250)},
+			VoiceDimensionMediaPolicy:                 {FailDelta: floatPtr(0.01)},
+			VoiceDimensionBackgroundPreservationRatio: {WarnDelta: floatPtr(0.02), FailDelta: floatPtr(0.05)},
+			VoiceDimensionSpeechDropRisk:              {WarnDelta: floatPtr(0.02), FailDelta: floatPtr(0.05)},
+			VoiceDimensionMissingEvidence:             missingThreshold,
 		},
 	}
 }
@@ -60,12 +66,15 @@ func BuildVoiceComparisonSummary(baseline, candidate voicescorecard.Scorecard, c
 		SchemaVersion: "2026-05-13",
 		Status:        "comparable",
 		DimensionDeltas: map[string]DimensionDelta{
-			VoiceDimensionOverallScore:        voiceDelta(baseline.OverallScore, candidate.OverallScore, "higher"),
-			VoiceDimensionTaskBusinessSuccess: voiceDimensionDelta(baseline, candidate, VoiceDimensionTaskBusinessSuccess, "higher"),
-			VoiceDimensionInteractionQuality:  voiceDimensionDelta(baseline, candidate, VoiceDimensionInteractionQuality, "higher"),
-			VoiceDimensionToolDataCorrectness: voiceDimensionDelta(baseline, candidate, VoiceDimensionToolDataCorrectness, "higher"),
-			VoiceDimensionLatencyMS:           voiceMetricDelta(baseline, candidate, "latency", "end_of_user_turn_to_first_agent_output_ms", "lower"),
-			VoiceDimensionMissingEvidence:     voiceDelta(0, float64(newCandidateDegradedKeyCount(baseline.DegradedKeys, candidate.DegradedKeys)), "lower"),
+			VoiceDimensionOverallScore:                voiceDelta(baseline.OverallScore, candidate.OverallScore, "higher"),
+			VoiceDimensionTaskBusinessSuccess:         voiceDimensionDelta(baseline, candidate, VoiceDimensionTaskBusinessSuccess, "higher"),
+			VoiceDimensionInteractionQuality:          voiceDimensionDelta(baseline, candidate, VoiceDimensionInteractionQuality, "higher"),
+			VoiceDimensionToolDataCorrectness:         voiceDimensionDelta(baseline, candidate, VoiceDimensionToolDataCorrectness, "higher"),
+			VoiceDimensionLatencyMS:                   voiceMetricDelta(baseline, candidate, "latency", "end_of_user_turn_to_first_agent_output_ms", "lower"),
+			VoiceDimensionMediaPolicy:                 voiceDimensionDelta(baseline, candidate, VoiceDimensionMediaPolicy, "higher"),
+			VoiceDimensionBackgroundPreservationRatio: voiceMetricRatioDelta(baseline, candidate, VoiceDimensionMediaPolicy, VoiceDimensionBackgroundPreservationRatio, "higher"),
+			VoiceDimensionSpeechDropRisk:              voiceMetricRatioDelta(baseline, candidate, VoiceDimensionMediaPolicy, VoiceDimensionSpeechDropRisk, "lower"),
+			VoiceDimensionMissingEvidence:             voiceDelta(0, float64(newCandidateDegradedKeyCount(baseline.DegradedKeys, candidate.DegradedKeys)), "lower"),
 		},
 		ScorecardPass: &ScorecardPassSummary{
 			Baseline:  boolPtr(!baseline.HardGateFailed),
@@ -119,6 +128,15 @@ func voiceMetricDelta(baseline, candidate voicescorecard.Scorecard, dimensionKey
 	return voiceDelta(float64(baselineValue), float64(candidateValue), direction)
 }
 
+func voiceMetricRatioDelta(baseline, candidate voicescorecard.Scorecard, dimensionKey string, metricKey string, direction string) DimensionDelta {
+	baselineValue, baselineOK := voiceMetricValue(baseline, dimensionKey, metricKey)
+	candidateValue, candidateOK := voiceMetricValue(candidate, dimensionKey, metricKey)
+	if !baselineOK || !candidateOK {
+		return DimensionDelta{BetterDirection: direction, State: "unavailable"}
+	}
+	return voiceDelta(baselineValue, candidateValue, direction)
+}
+
 func voiceDelta(baseline float64, candidate float64, direction string) DimensionDelta {
 	delta := candidate - baseline
 	return DimensionDelta{
@@ -147,6 +165,20 @@ func voiceMetricValueMS(scorecard voicescorecard.Scorecard, dimensionKey string,
 		for _, metric := range dimension.Metrics {
 			if metric.Key == metricKey && metric.ValueMS != nil {
 				return *metric.ValueMS, true
+			}
+		}
+	}
+	return 0, false
+}
+
+func voiceMetricValue(scorecard voicescorecard.Scorecard, dimensionKey string, metricKey string) (float64, bool) {
+	for _, dimension := range scorecard.Dimensions {
+		if dimension.Key != dimensionKey {
+			continue
+		}
+		for _, metric := range dimension.Metrics {
+			if metric.Key == metricKey && metric.Value != nil {
+				return *metric.Value, true
 			}
 		}
 	}

--- a/backend/internal/releasegate/voice_test.go
+++ b/backend/internal/releasegate/voice_test.go
@@ -46,6 +46,34 @@ func TestEvaluateVoiceComparisonTaskSuccessRegressionFails(t *testing.T) {
 	}
 }
 
+func TestEvaluateVoiceComparisonBackgroundPreservationRegressionFails(t *testing.T) {
+	baseline := withVoiceMediaPolicy(voiceScorecard(), 0.96, 0.94, 0.02)
+	candidate := withVoiceMediaPolicy(voiceScorecard(), 0.96, 0.84, 0.02)
+
+	evaluation := evaluateVoice(t, baseline, candidate, DefaultVoiceComparisonConfig())
+
+	if evaluation.Verdict != VerdictFail {
+		t.Fatalf("verdict = %q, want %q", evaluation.Verdict, VerdictFail)
+	}
+	if evaluation.ReasonCode != "threshold_fail_background_preservation_ratio" {
+		t.Fatalf("reason code = %q, want threshold_fail_background_preservation_ratio", evaluation.ReasonCode)
+	}
+}
+
+func TestEvaluateVoiceComparisonSpeechDropRegressionFails(t *testing.T) {
+	baseline := withVoiceMediaPolicy(voiceScorecard(), 0.96, 0.94, 0.02)
+	candidate := withVoiceMediaPolicy(voiceScorecard(), 0.96, 0.94, 0.1)
+
+	evaluation := evaluateVoice(t, baseline, candidate, DefaultVoiceComparisonConfig())
+
+	if evaluation.Verdict != VerdictFail {
+		t.Fatalf("verdict = %q, want %q", evaluation.Verdict, VerdictFail)
+	}
+	if evaluation.ReasonCode != "threshold_fail_speech_drop_risk" {
+		t.Fatalf("reason code = %q, want threshold_fail_speech_drop_risk", evaluation.ReasonCode)
+	}
+}
+
 func TestEvaluateVoiceComparisonPolicyHardGateFails(t *testing.T) {
 	candidate := voiceScorecard()
 	candidate.Passed = false
@@ -183,6 +211,34 @@ func voiceDimension(key string, score float64, state voiceeval.State, hardGate b
 	}
 }
 
+func withVoiceMediaPolicy(scorecard voicescorecard.Scorecard, dialogueRetention float64, backgroundPreservation float64, speechDropRisk float64) voicescorecard.Scorecard {
+	scorecard.Dimensions = append(scorecard.Dimensions, voicescorecard.Dimension{
+		Key:      VoiceDimensionMediaPolicy,
+		Name:     "Media policy",
+		Score:    1,
+		State:    voiceeval.StatePassed,
+		HardGate: true,
+		Metrics: []voicescorecard.MetricDetail{
+			{
+				Key:   voiceeval.KeyDialogueRetentionRatio,
+				State: voiceeval.StatePassed,
+				Value: float64PtrForVoiceTest(dialogueRetention),
+			},
+			{
+				Key:   voiceeval.KeyBackgroundPreservationRatio,
+				State: voiceeval.StatePassed,
+				Value: float64PtrForVoiceTest(backgroundPreservation),
+			},
+			{
+				Key:   voiceeval.KeySpeechDropRisk,
+				State: voiceeval.StatePassed,
+				Value: float64PtrForVoiceTest(speechDropRisk),
+			},
+		},
+	})
+	return scorecard
+}
+
 func setVoiceLatencyMS(scorecard *voicescorecard.Scorecard, value int64) {
 	for dimIdx := range scorecard.Dimensions {
 		if scorecard.Dimensions[dimIdx].Key != "latency" {
@@ -227,5 +283,9 @@ func setVoiceDimensionState(scorecard *voicescorecard.Scorecard, key string, sta
 }
 
 func int64PtrForVoiceTest(value int64) *int64 {
+	return &value
+}
+
+func float64PtrForVoiceTest(value float64) *float64 {
 	return &value
 }

--- a/backend/internal/voiceeval/eval.go
+++ b/backend/internal/voiceeval/eval.go
@@ -37,6 +37,9 @@ const (
 	KeyTotalDurationMS                     = "total_duration_ms"
 	KeyEndOfUserTurnToFirstAgentOutputMS   = "end_of_user_turn_to_first_agent_output_ms"
 	KeyEndOfUserTextToFirstAgentTextLegacy = "end_of_user_text_to_first_agent_text"
+	KeyDialogueRetentionRatio              = "dialogue_retention_ratio"
+	KeyBackgroundPreservationRatio         = "background_preservation_ratio"
+	KeySpeechDropRisk                      = "speech_drop_risk"
 )
 
 type CheckResult struct {
@@ -49,6 +52,13 @@ type MetricResult struct {
 	Key     string
 	State   State
 	ValueMS int64
+	Message string
+}
+
+type RatioMetricResult struct {
+	Key     string
+	State   State
+	Value   float64
 	Message string
 }
 
@@ -200,6 +210,16 @@ func MetricEndOfUserTurnToFirstAgentOutput(input Input, key string) MetricResult
 	return unavailableMetric(key, "explicit end-of-user-turn latency evidence not found")
 }
 
+func MetricRecordedRatio(input Input, key string) RatioMetricResult {
+	if value, found, valid := ratioMetricRecordedValue(input.Events, key); found {
+		if !valid {
+			return unavailableRatioMetric(key, "voice ratio metric event is invalid")
+		}
+		return RatioMetricResult{Key: key, State: StatePassed, Value: value}
+	}
+	return unavailableRatioMetric(key, "voice ratio metric evidence not found")
+}
+
 func ValidateInput(input Input) error {
 	if err := input.Trace.Validate(); err != nil {
 		return fmt.Errorf("%w: trace: %w", ErrInvalidInput, err)
@@ -266,6 +286,37 @@ func metricRecordedValue(events []runevents.Envelope, key string) (int64, bool, 
 		return *payload.ValueMS, true, true
 	}
 	return 0, false, false
+}
+
+func ratioMetricRecordedValue(events []runevents.Envelope, key string) (float64, bool, bool) {
+	for _, event := range events {
+		if event.EventType != runevents.EventTypeVoiceMetricRecorded || event.Summary.MetricKey != key {
+			continue
+		}
+		var payload struct {
+			Value      *float64 `json:"value"`
+			ValueRatio *float64 `json:"value_ratio"`
+			Ratio      *float64 `json:"ratio"`
+		}
+		if err := json.Unmarshal(event.Payload, &payload); err != nil {
+			return 0, true, false
+		}
+		value := firstFloat(payload.Value, payload.ValueRatio, payload.Ratio)
+		if value == nil || *value < 0 || *value > 1 {
+			return 0, true, false
+		}
+		return *value, true, true
+	}
+	return 0, false, false
+}
+
+func firstFloat(values ...*float64) *float64 {
+	for _, value := range values {
+		if value != nil {
+			return value
+		}
+	}
+	return nil
 }
 
 func orderedEventBounds(events []runevents.Envelope) (time.Time, time.Time, bool) {
@@ -342,6 +393,10 @@ func unavailableCheck(key string, message string) CheckResult {
 
 func unavailableMetric(key string, message string) MetricResult {
 	return MetricResult{Key: key, State: StateUnavailable, Message: message}
+}
+
+func unavailableRatioMetric(key string, message string) RatioMetricResult {
+	return RatioMetricResult{Key: key, State: StateUnavailable, Message: message}
 }
 
 func millis(duration time.Duration) int64 {

--- a/backend/internal/voiceeval/eval_test.go
+++ b/backend/internal/voiceeval/eval_test.go
@@ -85,6 +85,34 @@ func TestVoiceMetricsAgainstTextSimGolden(t *testing.T) {
 	}
 }
 
+func TestVoiceRatioMetricsAgainstRecordedEvents(t *testing.T) {
+	input := withRatioMetric(loadGoldenInput(t), KeyBackgroundPreservationRatio, `{"value":0.92}`)
+
+	result := MetricRecordedRatio(input, KeyBackgroundPreservationRatio)
+	if result.State != StatePassed {
+		t.Fatalf("state = %q, want %q; result=%+v", result.State, StatePassed, result)
+	}
+	if result.Value != 0.92 {
+		t.Fatalf("value = %.2f, want 0.92", result.Value)
+	}
+
+	aliasInput := withRatioMetric(loadGoldenInput(t), KeyDialogueRetentionRatio, `{"value_ratio":0.88}`)
+	aliasResult := MetricRecordedRatio(aliasInput, KeyDialogueRetentionRatio)
+	if aliasResult.State != StatePassed || aliasResult.Value != 0.88 {
+		t.Fatalf("alias result = %+v, want passed 0.88", aliasResult)
+	}
+}
+
+func TestVoiceRatioMetricsRejectInvalidOrMissingEvidence(t *testing.T) {
+	invalid := withRatioMetric(loadGoldenInput(t), KeySpeechDropRisk, `{"value":1.2}`)
+	if got := MetricRecordedRatio(invalid, KeySpeechDropRisk); got.State != StateUnavailable {
+		t.Fatalf("invalid state = %q, want unavailable", got.State)
+	}
+	if got := MetricRecordedRatio(loadGoldenInput(t), KeyBackgroundPreservationRatio); got.State != StateUnavailable {
+		t.Fatalf("missing state = %q, want unavailable", got.State)
+	}
+}
+
 func TestValidateInputRejectsMalformedEvidence(t *testing.T) {
 	input := loadGoldenInput(t)
 	input.Trace.Segments[0].SegmentID = ""
@@ -194,6 +222,28 @@ func withMissingVoiceMetricValue(input Input) Input {
 			return input
 		}
 	}
+	return input
+}
+
+func withRatioMetric(input Input, key string, payload string) Input {
+	input.Events = append([]runevents.Envelope(nil), input.Events...)
+	last := input.Events[len(input.Events)-1]
+	metric := runevents.Envelope{
+		EventID:        "voice-test:" + key,
+		SchemaVersion:  runevents.SchemaVersionV1,
+		RunID:          last.RunID,
+		RunAgentID:     last.RunAgentID,
+		SequenceNumber: int64(len(input.Events) + 1),
+		EventType:      runevents.EventTypeVoiceMetricRecorded,
+		Source:         runevents.SourceVoiceAdapter,
+		OccurredAt:     last.OccurredAt.Add(time.Millisecond),
+		Payload:        json.RawMessage(payload),
+		Summary: runevents.SummaryMetadata{
+			MetricKey:     key,
+			EvidenceLevel: runevents.EvidenceLevelVoiceStructured,
+		},
+	}
+	input.Events = append(input.Events, metric)
 	return input
 }
 

--- a/backend/internal/voicescorecard/scorecard.go
+++ b/backend/internal/voicescorecard/scorecard.go
@@ -28,9 +28,9 @@ type Expectations struct {
 	RequireInterruption bool
 	RequireMediaPolicy  bool
 
-	MinDialogueRetentionRatio      float64
-	MinBackgroundPreservationRatio float64
-	MaxSpeechDropRisk              float64
+	MinDialogueRetentionRatio      *float64
+	MinBackgroundPreservationRatio *float64
+	MaxSpeechDropRisk              *float64
 }
 
 type Scorecard struct {
@@ -395,9 +395,9 @@ func ptrFloat64(value float64) *float64 {
 	return &value
 }
 
-func ratioOrDefault(value float64, fallback float64) float64 {
-	if value > 0 {
-		return value
+func ratioOrDefault(value *float64, fallback float64) float64 {
+	if value != nil {
+		return *value
 	}
 	return fallback
 }

--- a/backend/internal/voicescorecard/scorecard.go
+++ b/backend/internal/voicescorecard/scorecard.go
@@ -26,6 +26,11 @@ type Expectations struct {
 	LatencyMaxMS        int64
 	CostUSD             float64
 	RequireInterruption bool
+	RequireMediaPolicy  bool
+
+	MinDialogueRetentionRatio      float64
+	MinBackgroundPreservationRatio float64
+	MaxSpeechDropRisk              float64
 }
 
 type Scorecard struct {
@@ -57,9 +62,12 @@ type CheckDetail struct {
 type MetricDetail struct {
 	Key      string          `json:"key"`
 	State    voiceeval.State `json:"state"`
+	Value    *float64        `json:"value,omitempty"`
 	ValueMS  *int64          `json:"value_ms,omitempty"`
 	TargetMS *int64          `json:"target_ms,omitempty"`
 	MaxMS    *int64          `json:"max_ms,omitempty"`
+	Min      *float64        `json:"min,omitempty"`
+	Max      *float64        `json:"max,omitempty"`
 	ValueUSD *float64        `json:"value_usd,omitempty"`
 	Message  string          `json:"message,omitempty"`
 }
@@ -87,8 +95,11 @@ func Generate(input voiceeval.Input, expectations Expectations) (Scorecard, erro
 		latencyDimension(input, expectations),
 		robustnessDimension(input, expectations),
 		toolDataCorrectnessDimension(input, expectations),
-		costDimension(expectations),
 	}
+	if expectations.RequireMediaPolicy {
+		dimensions = append(dimensions, mediaPolicyDimension(input, expectations))
+	}
+	dimensions = append(dimensions, costDimension(expectations))
 	scorecard := Scorecard{
 		SchemaVersion: SchemaVersionV1,
 		Type:          "voice",
@@ -186,6 +197,69 @@ func toolDataCorrectnessDimension(input voiceeval.Input, expectations Expectatio
 	return checkDimension("tool_data_correctness", "Tool / data correctness", true, checks)
 }
 
+func mediaPolicyDimension(input voiceeval.Input, expectations Expectations) Dimension {
+	minDialogueRetention := ratioOrDefault(expectations.MinDialogueRetentionRatio, 0.85)
+	minBackgroundPreservation := ratioOrDefault(expectations.MinBackgroundPreservationRatio, 0.75)
+	maxSpeechDropRisk := ratioOrDefault(expectations.MaxSpeechDropRisk, 0.15)
+
+	dialogueRetention := ratioMetricDetail(voiceeval.MetricRecordedRatio(input, voiceeval.KeyDialogueRetentionRatio))
+	dialogueRetention.Min = ptrFloat64(minDialogueRetention)
+	backgroundPreservation := ratioMetricDetail(voiceeval.MetricRecordedRatio(input, voiceeval.KeyBackgroundPreservationRatio))
+	backgroundPreservation.Min = ptrFloat64(minBackgroundPreservation)
+	speechDropRisk := ratioMetricDetail(voiceeval.MetricRecordedRatio(input, voiceeval.KeySpeechDropRisk))
+	speechDropRisk.Max = ptrFloat64(maxSpeechDropRisk)
+
+	metrics := []MetricDetail{dialogueRetention, backgroundPreservation, speechDropRisk}
+	state := voiceeval.StatePassed
+	score := 1.0
+	for idx := range metrics {
+		metric := &metrics[idx]
+		switch metric.State {
+		case voiceeval.StateUnavailable:
+			if state != voiceeval.StateFailed {
+				state = voiceeval.StateUnavailable
+				score = math.Min(score, 0.5)
+			}
+		case voiceeval.StatePassed:
+			if metric.Value == nil {
+				continue
+			}
+			switch metric.Key {
+			case voiceeval.KeyDialogueRetentionRatio:
+				if *metric.Value < minDialogueRetention {
+					metric.State = voiceeval.StateFailed
+					metric.Message = fmt.Sprintf("value = %.4f, min = %.4f", *metric.Value, minDialogueRetention)
+					state = voiceeval.StateFailed
+					score = 0
+				}
+			case voiceeval.KeyBackgroundPreservationRatio:
+				if *metric.Value < minBackgroundPreservation {
+					metric.State = voiceeval.StateFailed
+					metric.Message = fmt.Sprintf("value = %.4f, min = %.4f", *metric.Value, minBackgroundPreservation)
+					state = voiceeval.StateFailed
+					score = 0
+				}
+			case voiceeval.KeySpeechDropRisk:
+				if *metric.Value > maxSpeechDropRisk {
+					metric.State = voiceeval.StateFailed
+					metric.Message = fmt.Sprintf("value = %.4f, max = %.4f", *metric.Value, maxSpeechDropRisk)
+					state = voiceeval.StateFailed
+					score = 0
+				}
+			}
+		}
+	}
+
+	return Dimension{
+		Key:      "media_policy",
+		Name:     "Media policy",
+		Score:    score,
+		State:    state,
+		HardGate: true,
+		Metrics:  metrics,
+	}
+}
+
 func costDimension(expectations Expectations) Dimension {
 	cost := expectations.CostUSD
 	return Dimension{
@@ -257,6 +331,18 @@ func metricDetail(result voiceeval.MetricResult) MetricDetail {
 	return detail
 }
 
+func ratioMetricDetail(result voiceeval.RatioMetricResult) MetricDetail {
+	detail := MetricDetail{
+		Key:     result.Key,
+		State:   result.State,
+		Message: result.Message,
+	}
+	if result.State == voiceeval.StatePassed {
+		detail.Value = ptrFloat64(result.Value)
+	}
+	return detail
+}
+
 func degradedKeys(dimensions []Dimension) []string {
 	var keys []string
 	for _, dimension := range dimensions {
@@ -303,4 +389,15 @@ func roundScore(score float64) float64 {
 
 func ptrInt64(value int64) *int64 {
 	return &value
+}
+
+func ptrFloat64(value float64) *float64 {
+	return &value
+}
+
+func ratioOrDefault(value float64, fallback float64) float64 {
+	if value > 0 {
+		return value
+	}
+	return fallback
 }

--- a/backend/internal/voicescorecard/scorecard_test.go
+++ b/backend/internal/voicescorecard/scorecard_test.go
@@ -112,9 +112,9 @@ func TestGenerateScorecardMediaPolicyCases(t *testing.T) {
 	input := withMediaPolicyMetrics(loadGoldenInput(t), 0.94, 0.91, 0.04)
 	expectations := defaultExpectations()
 	expectations.RequireMediaPolicy = true
-	expectations.MinDialogueRetentionRatio = 0.9
-	expectations.MinBackgroundPreservationRatio = 0.85
-	expectations.MaxSpeechDropRisk = 0.1
+	expectations.MinDialogueRetentionRatio = ptrFloat64(0.9)
+	expectations.MinBackgroundPreservationRatio = ptrFloat64(0.85)
+	expectations.MaxSpeechDropRisk = ptrFloat64(0.1)
 
 	scorecard := generateScorecard(t, input, expectations)
 	if !scorecard.Passed {
@@ -142,6 +142,13 @@ func TestGenerateScorecardMediaPolicyCases(t *testing.T) {
 	}
 	if !contains(degraded.DegradedKeys, voiceeval.KeyBackgroundPreservationRatio) {
 		t.Fatalf("degraded keys = %v, want background preservation key", degraded.DegradedKeys)
+	}
+
+	strict := expectations
+	strict.MaxSpeechDropRisk = ptrFloat64(0)
+	strictScorecard := generateScorecard(t, input, strict)
+	if !strictScorecard.HardGateFailed {
+		t.Fatalf("strict zero MaxSpeechDropRisk should hard-fail when speech drop risk is non-zero")
 	}
 }
 

--- a/backend/internal/voicescorecard/scorecard_test.go
+++ b/backend/internal/voicescorecard/scorecard_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/multimodaltrace"
 	"github.com/agentclash/agentclash/backend/internal/runevents"
@@ -104,6 +105,43 @@ func TestGenerateScorecardFailureAndDegradationCases(t *testing.T) {
 				t.Fatalf("degraded keys = %v, want containing %q", scorecard.DegradedKeys, tc.wantDegradedContains)
 			}
 		})
+	}
+}
+
+func TestGenerateScorecardMediaPolicyCases(t *testing.T) {
+	input := withMediaPolicyMetrics(loadGoldenInput(t), 0.94, 0.91, 0.04)
+	expectations := defaultExpectations()
+	expectations.RequireMediaPolicy = true
+	expectations.MinDialogueRetentionRatio = 0.9
+	expectations.MinBackgroundPreservationRatio = 0.85
+	expectations.MaxSpeechDropRisk = 0.1
+
+	scorecard := generateScorecard(t, input, expectations)
+	if !scorecard.Passed {
+		t.Fatalf("Passed = false, want true; scorecard=%+v", scorecard)
+	}
+	mediaPolicy := findDimension(t, scorecard, "media_policy")
+	if mediaPolicy.State != voiceeval.StatePassed {
+		t.Fatalf("media_policy state = %q, want passed", mediaPolicy.State)
+	}
+
+	failing := generateScorecard(t, withMediaPolicyMetrics(loadGoldenInput(t), 0.94, 0.4, 0.04), expectations)
+	if !failing.HardGateFailed {
+		t.Fatalf("HardGateFailed = false, want true")
+	}
+	if got := findDimension(t, failing, "media_policy"); got.State != voiceeval.StateFailed {
+		t.Fatalf("media_policy state = %q, want failed", got.State)
+	}
+
+	degraded := generateScorecard(t, loadGoldenInput(t), expectations)
+	if degraded.Passed {
+		t.Fatalf("degraded Passed = true, want false")
+	}
+	if got := findDimension(t, degraded, "media_policy"); got.State != voiceeval.StateUnavailable {
+		t.Fatalf("media_policy state = %q, want unavailable", got.State)
+	}
+	if !contains(degraded.DegradedKeys, voiceeval.KeyBackgroundPreservationRatio) {
+		t.Fatalf("degraded keys = %v, want background preservation key", degraded.DegradedKeys)
 	}
 }
 
@@ -239,6 +277,35 @@ func withoutTranscriptEvidence(input voiceeval.Input) voiceeval.Input {
 	input = cloneInput(input)
 	input.Trace.Segments = filterSegments(input.Trace.Segments, func(segment multimodaltrace.Segment) bool {
 		return segment.Kind != multimodaltrace.SegmentKindTranscriptFinal && segment.Kind != multimodaltrace.SegmentKindTranscriptPartial
+	})
+	return input
+}
+
+func withMediaPolicyMetrics(input voiceeval.Input, dialogueRetention float64, backgroundPreservation float64, speechDropRisk float64) voiceeval.Input {
+	input = withRatioMetric(input, voiceeval.KeyDialogueRetentionRatio, dialogueRetention)
+	input = withRatioMetric(input, voiceeval.KeyBackgroundPreservationRatio, backgroundPreservation)
+	input = withRatioMetric(input, voiceeval.KeySpeechDropRisk, speechDropRisk)
+	return input
+}
+
+func withRatioMetric(input voiceeval.Input, key string, value float64) voiceeval.Input {
+	input = cloneInput(input)
+	last := input.Events[len(input.Events)-1]
+	payload, _ := json.Marshal(map[string]float64{"value": value})
+	input.Events = append(input.Events, runevents.Envelope{
+		EventID:        "voice-scorecard-test:" + key,
+		SchemaVersion:  runevents.SchemaVersionV1,
+		RunID:          last.RunID,
+		RunAgentID:     last.RunAgentID,
+		SequenceNumber: int64(len(input.Events) + 1),
+		EventType:      runevents.EventTypeVoiceMetricRecorded,
+		Source:         runevents.SourceVoiceAdapter,
+		OccurredAt:     last.OccurredAt.Add(time.Millisecond),
+		Payload:        payload,
+		Summary: runevents.SummaryMetadata{
+			MetricKey:     key,
+			EvidenceLevel: runevents.EvidenceLevelVoiceStructured,
+		},
 	})
 	return input
 }

--- a/testing/codex-voice-source-separation-evals.md
+++ b/testing/codex-voice-source-separation-evals.md
@@ -41,4 +41,3 @@ go test ./internal/voiceeval ./internal/voicescorecard ./internal/releasegate
 ## Manual / cURL Tests
 
 - N/A — no API routes are changed in this slice.
-

--- a/testing/codex-voice-source-separation-evals.md
+++ b/testing/codex-voice-source-separation-evals.md
@@ -1,0 +1,44 @@
+# codex/voice-source-separation-evals — Test Contract
+
+## Functional Behavior
+
+- Add voice eval metric support for float/ratio `voice.metric.recorded` events.
+- Add stable metric keys for:
+  - `dialogue_retention_ratio`
+  - `background_preservation_ratio`
+  - `speech_drop_risk`
+- Allow voice scorecards to opt into a `media_policy` dimension when expectations require media preservation.
+- `media_policy` should:
+  - pass when dialogue retention and background preservation meet minimums and speech drop risk stays below the maximum
+  - fail as a hard gate when any required metric violates its threshold
+  - degrade when required source-separation evidence is missing
+- Add release-gate deltas for media-policy score, background preservation, and speech drop risk.
+
+## Unit Tests
+
+- `backend/internal/voiceeval` tests ratio metric parsing, invalid ratio payloads, and missing metric evidence.
+- `backend/internal/voicescorecard` tests media-policy pass, hard failure, and degraded evidence.
+- `backend/internal/releasegate` tests media-policy release-gate regressions.
+
+## Integration / Functional Tests
+
+- Run focused backend Go tests:
+
+```bash
+cd backend
+go test ./internal/voiceeval ./internal/voicescorecard ./internal/releasegate
+```
+
+## Smoke Tests
+
+- Existing non-voice release-gate fixtures must still pass.
+- Existing default voice scorecard tests must keep their current behavior unless media-policy expectations are explicitly enabled.
+
+## E2E Tests
+
+- N/A — this PR adds scoring primitives only. Voicey emits the source-separation report separately.
+
+## Manual / cURL Tests
+
+- N/A — no API routes are changed in this slice.
+


### PR DESCRIPTION
## Summary
- adds float/ratio metric support for `voice.metric.recorded` events
- adds optional voice `media_policy` scorecard dimension for source-separation evidence
- adds release-gate deltas for background preservation and speech-drop risk
- preserves explicit zero media thresholds with pointer expectations

## Tests
- `cd backend && go test ./internal/voiceeval ./internal/voicescorecard ./internal/releasegate`
- `git diff --check`

## Review Checkpoint
```json
{
  "branch": "codex/voice-source-separation-evals",
  "test_contract": "testing/codex-voice-source-separation-evals.md",
  "created_at": "2026-05-13T20:11:07.665938+00:00",
  "steps": [
    {
      "step_number": 1,
      "title": "Add voice media-policy scoring primitives",
      "timestamp": "2026-05-13T20:13:20.439936+00:00",
      "files_changed": [
        "backend/internal/voiceeval/eval.go",
        "backend/internal/voiceeval/eval_test.go",
        "backend/internal/voicescorecard/scorecard.go",
        "backend/internal/voicescorecard/scorecard_test.go",
        "backend/internal/releasegate/voice.go",
        "backend/internal/releasegate/voice_test.go"
      ],
      "what_changed": "Added ratio metric parsing for voice.metric.recorded events, optional media_policy voice scorecard dimension, and release-gate deltas for background preservation and speech drop risk.",
      "review_instructions": "Verify media-policy expectations are opt-in, missing ratio evidence degrades scorecards, threshold violations hard-fail the media_policy dimension, and release gates fail on media regressions.",
      "review_result": {
        "status": "pass",
        "issues_found": [],
        "notes": "Focused Go tests pass and git diff --check passes."
      },
      "cumulative_review": {
        "previous_steps_still_valid": true,
        "integration_issues": [],
        "notes": "The test contract remains valid; no API routes or existing default voice scorecard dimensions are changed unless media policy is enabled."
      }
    },
    {
      "step_number": 2,
      "title": "Preserve explicit zero media thresholds",
      "timestamp": "2026-05-13T20:18:07.106032+00:00",
      "files_changed": [
        "backend/internal/voicescorecard/scorecard.go",
        "backend/internal/voicescorecard/scorecard_test.go"
      ],
      "what_changed": "Changed optional media-policy thresholds to pointers so callers can distinguish default thresholds from explicit zero values, especially strict zero speech-drop risk.",
      "review_instructions": "Verify media-policy defaults still apply when nil and explicit zero MaxSpeechDropRisk hard-fails non-zero speech-drop risk.",
      "review_result": {
        "status": "pass",
        "issues_found": [],
        "notes": "Focused Go tests pass and git diff --check passes."
      },
      "cumulative_review": {
        "previous_steps_still_valid": true,
        "integration_issues": [],
        "notes": "Addresses independent review P3 without changing the metric/event contract."
      }
    },
    {
      "step_number": 3,
      "title": "Clean test contract EOF whitespace",
      "timestamp": "2026-05-13T20:18:48.126862+00:00",
      "files_changed": [
        "testing/codex-voice-source-separation-evals.md"
      ],
      "what_changed": "Removed extra blank line at EOF in the committed review-checkpoint test contract so git diff --check passes against origin/main.",
      "review_instructions": "Verify git diff --check passes.",
      "review_result": {
        "status": "pass",
        "issues_found": [],
        "notes": "git diff --check passes after cleanup."
      },
      "cumulative_review": {
        "previous_steps_still_valid": true,
        "integration_issues": [],
        "notes": "Whitespace-only cleanup; no scoring behavior changed."
      }
    },
    {
      "step_number": "final",
      "title": "Final review against test contract",
      "timestamp": "2026-05-13T20:13:38.468522+00:00",
      "test_contract_review": {
        "functional_behavior": "pass - voice ratio metrics, media_policy dimension, and release-gate deltas implemented",
        "unit_tests": "pass - focused Go tests for voiceeval, voicescorecard, and releasegate",
        "integration_tests": "pass - cd backend && go test ./internal/voiceeval ./internal/voicescorecard ./internal/releasegate",
        "smoke_tests": "pass - existing non-voice release-gate fixture test still passes in package test",
        "e2e_tests": "pass - N/A for scoring primitive slice",
        "manual_tests": "pass - N/A, no API route changes"
      },
      "overall_verdict": "ready",
      "blocking_issues": []
    }
  ]
}
```
