### PR TITLE
feat: ingest voice source separation reports

### DIFF
--- a/backend/internal/voiceartifacts/manifest.go
+++ b/backend/internal/voiceartifacts/manifest.go
@@ -25,6 +25,7 @@ const (
 	ArtifactKindMixedAudio        ArtifactKind = "mixed_audio"
 	ArtifactKindTranscriptJSON    ArtifactKind = "transcript_json"
 	ArtifactKindWaveformTimeline  ArtifactKind = "waveform_timeline_json"
+	ArtifactKindMediaPolicyReport ArtifactKind = "media_policy_report_json"
 	ArtifactKindRawProviderTrace  ArtifactKind = "raw_provider_trace_json"
 	ArtifactKindStructuredOutput  ArtifactKind = "structured_output_json"
 	ArtifactKindRedactionMetadata ArtifactKind = "redaction_metadata_json"
@@ -171,6 +172,7 @@ func (k ArtifactKind) IsValid() bool {
 		ArtifactKindMixedAudio,
 		ArtifactKindTranscriptJSON,
 		ArtifactKindWaveformTimeline,
+		ArtifactKindMediaPolicyReport,
 		ArtifactKindRawProviderTrace,
 		ArtifactKindStructuredOutput,
 		ArtifactKindRedactionMetadata:

--- a/backend/internal/voiceartifacts/source_separation_report.go
+++ b/backend/internal/voiceartifacts/source_separation_report.go
@@ -47,6 +47,10 @@ func LoadSourceSeparationReport(path string) (SourceSeparationReport, error) {
 	if err != nil {
 		return SourceSeparationReport{}, err
 	}
+	return IngestSourceSeparationReport(data)
+}
+
+func IngestSourceSeparationReport(data []byte) (SourceSeparationReport, error) {
 	var report SourceSeparationReport
 	if err := json.Unmarshal(data, &report); err != nil {
 		return SourceSeparationReport{}, fmt.Errorf("decode source separation report: %w", err)
@@ -82,13 +86,18 @@ func (r SourceSeparationReport) Validate() error {
 	if r.Metrics.SpeechDropRisk == nil {
 		return errors.New("metrics.speech_drop_risk is required")
 	}
-	for name, value := range map[string]*float64{
-		"metrics.dialogue_retention_ratio":             r.Metrics.DialogueRetentionRatio,
-		"metrics.background_preservation_ratio":        r.Metrics.BackgroundPreservationRatio,
-		"metrics.speech_drop_risk":                     r.Metrics.SpeechDropRisk,
-		"metrics.background_leakage_in_dialogue_ratio": r.Metrics.BackgroundLeakageInDialogueRatio,
-		"metrics.dialogue_leakage_in_background_ratio": r.Metrics.DialogueLeakageInBackgroundRatio,
+	for _, metric := range []struct {
+		name  string
+		value *float64
+	}{
+		{name: "metrics.dialogue_retention_ratio", value: r.Metrics.DialogueRetentionRatio},
+		{name: "metrics.background_preservation_ratio", value: r.Metrics.BackgroundPreservationRatio},
+		{name: "metrics.speech_drop_risk", value: r.Metrics.SpeechDropRisk},
+		{name: "metrics.background_leakage_in_dialogue_ratio", value: r.Metrics.BackgroundLeakageInDialogueRatio},
+		{name: "metrics.dialogue_leakage_in_background_ratio", value: r.Metrics.DialogueLeakageInBackgroundRatio},
 	} {
+		name := metric.name
+		value := metric.value
 		if value != nil && (*value < 0 || *value > 1) {
 			return fmt.Errorf("%s must be between 0 and 1", name)
 		}
@@ -100,12 +109,20 @@ func (r SourceSeparationReport) MediaPolicyEvidence() MediaPolicyEvidence {
 	return MediaPolicyEvidence{
 		Status:                           r.Status,
 		Passed:                           r.Passed,
-		DialogueRetentionRatio:           r.Metrics.DialogueRetentionRatio,
-		BackgroundPreservationRatio:      r.Metrics.BackgroundPreservationRatio,
-		SpeechDropRisk:                   r.Metrics.SpeechDropRisk,
-		BackgroundLeakageInDialogueRatio: r.Metrics.BackgroundLeakageInDialogueRatio,
-		DialogueLeakageInBackgroundRatio: r.Metrics.DialogueLeakageInBackgroundRatio,
+		DialogueRetentionRatio:           cloneFloat64(r.Metrics.DialogueRetentionRatio),
+		BackgroundPreservationRatio:      cloneFloat64(r.Metrics.BackgroundPreservationRatio),
+		SpeechDropRisk:                   cloneFloat64(r.Metrics.SpeechDropRisk),
+		BackgroundLeakageInDialogueRatio: cloneFloat64(r.Metrics.BackgroundLeakageInDialogueRatio),
+		DialogueLeakageInBackgroundRatio: cloneFloat64(r.Metrics.DialogueLeakageInBackgroundRatio),
 		Caveats:                          append([]string(nil), r.Caveats...),
 		AgentNotes:                       append([]string(nil), r.AgentNotes...),
 	}
+}
+
+func cloneFloat64(value *float64) *float64 {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
 }

--- a/backend/internal/voiceartifacts/source_separation_report.go
+++ b/backend/internal/voiceartifacts/source_separation_report.go
@@ -1,0 +1,111 @@
+package voiceartifacts
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+const SourceSeparationReportType = "voicey.source_separation_eval"
+
+type SourceSeparationReport struct {
+	SchemaVersion string            `json:"schema_version"`
+	Type          string            `json:"type"`
+	Status        string            `json:"status"`
+	Passed        bool              `json:"passed"`
+	Metrics       SourceMixMetrics  `json:"metrics"`
+	Caveats       []string          `json:"caveats,omitempty"`
+	AgentNotes    []string          `json:"agentclash_notes,omitempty"`
+	Artifacts     map[string]string `json:"artifacts,omitempty"`
+	Raw           json.RawMessage   `json:"-"`
+}
+
+type SourceMixMetrics struct {
+	DialogueRetentionRatio           *float64 `json:"dialogue_retention_ratio"`
+	BackgroundPreservationRatio      *float64 `json:"background_preservation_ratio"`
+	SpeechDropRisk                   *float64 `json:"speech_drop_risk"`
+	BackgroundLeakageInDialogueRatio *float64 `json:"background_leakage_in_dialogue_ratio"`
+	DialogueLeakageInBackgroundRatio *float64 `json:"dialogue_leakage_in_background_ratio"`
+}
+
+type MediaPolicyEvidence struct {
+	Status                           string   `json:"status"`
+	Passed                           bool     `json:"passed"`
+	DialogueRetentionRatio           *float64 `json:"dialogue_retention_ratio,omitempty"`
+	BackgroundPreservationRatio      *float64 `json:"background_preservation_ratio,omitempty"`
+	SpeechDropRisk                   *float64 `json:"speech_drop_risk,omitempty"`
+	BackgroundLeakageInDialogueRatio *float64 `json:"background_leakage_in_dialogue_ratio,omitempty"`
+	DialogueLeakageInBackgroundRatio *float64 `json:"dialogue_leakage_in_background_ratio,omitempty"`
+	Caveats                          []string `json:"caveats,omitempty"`
+	AgentNotes                       []string `json:"agentclash_notes,omitempty"`
+}
+
+func LoadSourceSeparationReport(path string) (SourceSeparationReport, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return SourceSeparationReport{}, err
+	}
+	var report SourceSeparationReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		return SourceSeparationReport{}, fmt.Errorf("decode source separation report: %w", err)
+	}
+	report.Raw = append(json.RawMessage(nil), data...)
+	if err := report.Validate(); err != nil {
+		return SourceSeparationReport{}, err
+	}
+	return report, nil
+}
+
+func (r SourceSeparationReport) Validate() error {
+	if strings.TrimSpace(r.SchemaVersion) == "" {
+		return errors.New("schema_version is required")
+	}
+	if r.Type != SourceSeparationReportType {
+		return fmt.Errorf("type must be %q", SourceSeparationReportType)
+	}
+	switch r.Status {
+	case "passed", "failed", "degraded":
+	default:
+		return errors.New("status must be one of passed, failed, degraded")
+	}
+	if r.Passed != (r.Status == "passed") {
+		return errors.New("passed must be true only when status is passed")
+	}
+	if r.Metrics.DialogueRetentionRatio == nil {
+		return errors.New("metrics.dialogue_retention_ratio is required")
+	}
+	if r.Metrics.BackgroundPreservationRatio == nil {
+		return errors.New("metrics.background_preservation_ratio is required")
+	}
+	if r.Metrics.SpeechDropRisk == nil {
+		return errors.New("metrics.speech_drop_risk is required")
+	}
+	for name, value := range map[string]*float64{
+		"metrics.dialogue_retention_ratio":             r.Metrics.DialogueRetentionRatio,
+		"metrics.background_preservation_ratio":        r.Metrics.BackgroundPreservationRatio,
+		"metrics.speech_drop_risk":                     r.Metrics.SpeechDropRisk,
+		"metrics.background_leakage_in_dialogue_ratio": r.Metrics.BackgroundLeakageInDialogueRatio,
+		"metrics.dialogue_leakage_in_background_ratio": r.Metrics.DialogueLeakageInBackgroundRatio,
+	} {
+		if value != nil && (*value < 0 || *value > 1) {
+			return fmt.Errorf("%s must be between 0 and 1", name)
+		}
+	}
+	return nil
+}
+
+func (r SourceSeparationReport) MediaPolicyEvidence() MediaPolicyEvidence {
+	return MediaPolicyEvidence{
+		Status:                           r.Status,
+		Passed:                           r.Passed,
+		DialogueRetentionRatio:           r.Metrics.DialogueRetentionRatio,
+		BackgroundPreservationRatio:      r.Metrics.BackgroundPreservationRatio,
+		SpeechDropRisk:                   r.Metrics.SpeechDropRisk,
+		BackgroundLeakageInDialogueRatio: r.Metrics.BackgroundLeakageInDialogueRatio,
+		DialogueLeakageInBackgroundRatio: r.Metrics.DialogueLeakageInBackgroundRatio,
+		Caveats:                          append([]string(nil), r.Caveats...),
+		AgentNotes:                       append([]string(nil), r.AgentNotes...),
+	}
+}

--- a/backend/internal/voiceartifacts/source_separation_report_test.go
+++ b/backend/internal/voiceartifacts/source_separation_report_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -28,6 +29,24 @@ func TestLoadSourceSeparationReport(t *testing.T) {
 	}
 	if len(evidence.AgentNotes) == 0 {
 		t.Fatal("expected AgentClash notes")
+	}
+	*evidence.BackgroundPreservationRatio = 0.01
+	if *report.Metrics.BackgroundPreservationRatio != 0.91 {
+		t.Fatal("evidence metric mutation should not mutate source report")
+	}
+}
+
+func TestIngestSourceSeparationReport(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "voicey_source_separation_report.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	report, err := IngestSourceSeparationReport(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Raw) == 0 {
+		t.Fatal("expected raw report copy")
 	}
 }
 
@@ -88,6 +107,45 @@ func TestSourceSeparationReportRejectsOutOfRangeMetric(t *testing.T) {
 
 	if _, err := LoadSourceSeparationReport(path); err == nil {
 		t.Fatal("expected validation error")
+	}
+}
+
+func TestSourceSeparationReportRejectsMissingRequiredMetric(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeReport(t, path, map[string]any{
+		"schema_version": "2026-05-14",
+		"type":           SourceSeparationReportType,
+		"status":         "passed",
+		"passed":         true,
+		"metrics": map[string]any{
+			"background_preservation_ratio": 0.9,
+			"speech_drop_risk":              0.1,
+		},
+	})
+
+	if _, err := LoadSourceSeparationReport(path); err == nil || !strings.Contains(err.Error(), "dialogue_retention_ratio") {
+		t.Fatalf("expected missing dialogue retention error, got %v", err)
+	}
+}
+
+func TestSourceSeparationReportAcceptsDegradedStatus(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeReport(t, path, map[string]any{
+		"schema_version": "2026-05-14",
+		"type":           SourceSeparationReportType,
+		"status":         "degraded",
+		"passed":         false,
+		"metrics": map[string]any{
+			"dialogue_retention_ratio":      0.9,
+			"background_preservation_ratio": 0.9,
+			"speech_drop_risk":              0.1,
+		},
+	})
+
+	if _, err := LoadSourceSeparationReport(path); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/backend/internal/voiceartifacts/source_separation_report_test.go
+++ b/backend/internal/voiceartifacts/source_separation_report_test.go
@@ -1,0 +1,109 @@
+package voiceartifacts
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadSourceSeparationReport(t *testing.T) {
+	report, err := LoadSourceSeparationReport(filepath.Join("testdata", "voicey_source_separation_report.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if report.Type != SourceSeparationReportType {
+		t.Fatalf("type = %q", report.Type)
+	}
+	evidence := report.MediaPolicyEvidence()
+	if evidence.BackgroundPreservationRatio == nil || *evidence.BackgroundPreservationRatio != 0.91 {
+		t.Fatalf("background preservation = %#v", evidence.BackgroundPreservationRatio)
+	}
+	if evidence.SpeechDropRisk == nil || *evidence.SpeechDropRisk != 0.08 {
+		t.Fatalf("speech drop risk = %#v", evidence.SpeechDropRisk)
+	}
+	if evidence.BackgroundLeakageInDialogueRatio == nil || *evidence.BackgroundLeakageInDialogueRatio != 0.04 {
+		t.Fatalf("background leakage = %#v", evidence.BackgroundLeakageInDialogueRatio)
+	}
+	if len(evidence.AgentNotes) == 0 {
+		t.Fatal("expected AgentClash notes")
+	}
+}
+
+func TestSourceSeparationReportRejectsWrongType(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeReport(t, path, map[string]any{
+		"schema_version": "2026-05-14",
+		"type":           "other",
+		"status":         "passed",
+		"passed":         true,
+		"metrics": map[string]any{
+			"dialogue_retention_ratio":      0.9,
+			"background_preservation_ratio": 0.9,
+			"speech_drop_risk":              0.1,
+		},
+	})
+
+	if _, err := LoadSourceSeparationReport(path); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestSourceSeparationReportRejectsInconsistentPassedStatus(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeReport(t, path, map[string]any{
+		"schema_version": "2026-05-14",
+		"type":           SourceSeparationReportType,
+		"status":         "failed",
+		"passed":         true,
+		"metrics": map[string]any{
+			"dialogue_retention_ratio":      0.9,
+			"background_preservation_ratio": 0.9,
+			"speech_drop_risk":              0.1,
+		},
+	})
+
+	if _, err := LoadSourceSeparationReport(path); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestSourceSeparationReportRejectsOutOfRangeMetric(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeReport(t, path, map[string]any{
+		"schema_version": "2026-05-14",
+		"type":           SourceSeparationReportType,
+		"status":         "passed",
+		"passed":         true,
+		"metrics": map[string]any{
+			"dialogue_retention_ratio":      1.2,
+			"background_preservation_ratio": 0.9,
+			"speech_drop_risk":              0.1,
+		},
+	})
+
+	if _, err := LoadSourceSeparationReport(path); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestMediaPolicyArtifactKindIsValid(t *testing.T) {
+	if !ArtifactKindMediaPolicyReport.IsValid() {
+		t.Fatal("media policy report artifact kind should be valid")
+	}
+}
+
+func writeReport(t *testing.T, path string, value map[string]any) {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/backend/internal/voiceartifacts/testdata/voicey_source_separation_report.json
+++ b/backend/internal/voiceartifacts/testdata/voicey_source_separation_report.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "2026-05-14",
+  "type": "voicey.source_separation_eval",
+  "status": "passed",
+  "passed": true,
+  "metrics": {
+    "dialogue_retention_ratio": 0.92,
+    "background_preservation_ratio": 0.91,
+    "speech_drop_risk": 0.08,
+    "background_leakage_in_dialogue_ratio": 0.04,
+    "dialogue_leakage_in_background_ratio": 0.03
+  },
+  "caveats": [],
+  "agentclash_notes": [
+    "Use background_preservation_ratio as the core Watch Mode music/SFX metric.",
+    "Use speech_drop_risk as a hard gate: preserving music is useless if dialogue is lost."
+  ]
+}


### PR DESCRIPTION
## Summary\n- adds media_policy_report_json as an optional voice artifact kind\n- adds SourceSeparationReport ingestion for Voicey source-separation eval JSON\n- exposes normalized MediaPolicyEvidence for later scoring dimensions\n- validates required metrics, status/pass consistency, and ratio bounds\n\n## Issues\nPart of #791\n\n## Review\n- Cursor Composer 2 review: testing/cursor-voice-source-separation-import-review.md\n- Addressed reviewer notes by cross-checking status/pass, validating metric ranges, and retaining leakage metrics in evidence.\n\n## Validation\n- cd backend && go test ./internal/voiceartifacts ./internal/voicelive\n