### PR TITLE
feat: ingest voice live continuity reports

### DIFF
--- a/backend/internal/voiceartifacts/live_continuity_report.go
+++ b/backend/internal/voiceartifacts/live_continuity_report.go
@@ -1,0 +1,136 @@
+package voiceartifacts
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"strings"
+)
+
+const LiveContinuityReportType = "voicey.live_continuity_eval"
+
+type LiveContinuityReport struct {
+	SchemaVersion string                `json:"schema_version"`
+	Type          string                `json:"type"`
+	Status        string                `json:"status"`
+	Passed        bool                  `json:"passed"`
+	Input         string                `json:"input,omitempty"`
+	Metrics       LiveContinuityMetrics `json:"metrics"`
+	Caveats       []string              `json:"caveats,omitempty"`
+	AgentNotes    []string              `json:"agentclash_notes,omitempty"`
+	Raw           json.RawMessage       `json:"-"`
+}
+
+type LiveContinuityMetrics struct {
+	SpeechStartCount             *float64 `json:"speech_start_count"`
+	SpeechStopCount              *float64 `json:"speech_stop_count"`
+	OutputEventCount             *float64 `json:"output_event_count"`
+	EvidenceStatus               string   `json:"evidence_status"`
+	MedianFirstAudioMS           *float64 `json:"median_first_audio_ms"`
+	P90FirstAudioMS              *float64 `json:"p90_first_audio_ms"`
+	MaxOutputGapMS               *float64 `json:"max_output_gap_ms"`
+	MedianOutputGapMS            *float64 `json:"median_output_gap_ms"`
+	SpeechNoOutputCount          *float64 `json:"speech_no_output_count"`
+	SpeechNoOutputRatio          *float64 `json:"speech_no_output_ratio"`
+	SpeechStartDuringOutputCount *float64 `json:"speech_start_during_output_count"`
+}
+
+type LiveContinuityEvidence struct {
+	Status                       string   `json:"status"`
+	Passed                       bool     `json:"passed"`
+	EvidenceStatus               string   `json:"evidence_status"`
+	MedianFirstAudioMS           *float64 `json:"median_first_audio_ms,omitempty"`
+	P90FirstAudioMS              *float64 `json:"p90_first_audio_ms,omitempty"`
+	MaxOutputGapMS               *float64 `json:"max_output_gap_ms,omitempty"`
+	SpeechNoOutputRatio          *float64 `json:"speech_no_output_ratio,omitempty"`
+	SpeechStartDuringOutputCount *float64 `json:"speech_start_during_output_count,omitempty"`
+	Caveats                      []string `json:"caveats,omitempty"`
+	AgentNotes                   []string `json:"agentclash_notes,omitempty"`
+}
+
+func LoadLiveContinuityReport(path string) (LiveContinuityReport, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return LiveContinuityReport{}, err
+	}
+	return IngestLiveContinuityReport(data)
+}
+
+func IngestLiveContinuityReport(data []byte) (LiveContinuityReport, error) {
+	var report LiveContinuityReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		return LiveContinuityReport{}, fmt.Errorf("decode live continuity report: %w", err)
+	}
+	report.Raw = append(json.RawMessage(nil), data...)
+	if err := report.Validate(); err != nil {
+		return LiveContinuityReport{}, err
+	}
+	return report, nil
+}
+
+func (r LiveContinuityReport) Validate() error {
+	if strings.TrimSpace(r.SchemaVersion) == "" {
+		return errors.New("schema_version is required")
+	}
+	if r.Type != LiveContinuityReportType {
+		return fmt.Errorf("type must be %q", LiveContinuityReportType)
+	}
+	switch r.Status {
+	case "passed", "warn", "failed", "degraded":
+	default:
+		return errors.New("status must be one of passed, warn, failed, degraded")
+	}
+	if r.Passed != (r.Status == "passed") {
+		return errors.New("passed must be true only when status is passed")
+	}
+	if strings.TrimSpace(r.Metrics.EvidenceStatus) == "" {
+		return errors.New("metrics.evidence_status is required")
+	}
+	switch r.Metrics.EvidenceStatus {
+	case "available", "degraded":
+	default:
+		return errors.New("metrics.evidence_status must be available or degraded")
+	}
+	if r.Status == "passed" && r.Metrics.EvidenceStatus == "degraded" {
+		return errors.New("status cannot be passed when metrics.evidence_status is degraded")
+	}
+	for _, metric := range []struct {
+		name  string
+		value *float64
+		min   float64
+		max   float64
+	}{
+		{name: "metrics.speech_no_output_ratio", value: r.Metrics.SpeechNoOutputRatio, min: 0, max: 1},
+		{name: "metrics.speech_start_count", value: r.Metrics.SpeechStartCount, min: 0, max: math.Inf(1)},
+		{name: "metrics.speech_stop_count", value: r.Metrics.SpeechStopCount, min: 0, max: math.Inf(1)},
+		{name: "metrics.output_event_count", value: r.Metrics.OutputEventCount, min: 0, max: math.Inf(1)},
+		{name: "metrics.max_output_gap_ms", value: r.Metrics.MaxOutputGapMS, min: 0, max: math.Inf(1)},
+		{name: "metrics.median_output_gap_ms", value: r.Metrics.MedianOutputGapMS, min: 0, max: math.Inf(1)},
+		{name: "metrics.median_first_audio_ms", value: r.Metrics.MedianFirstAudioMS, min: 0, max: math.Inf(1)},
+		{name: "metrics.p90_first_audio_ms", value: r.Metrics.P90FirstAudioMS, min: 0, max: math.Inf(1)},
+		{name: "metrics.speech_no_output_count", value: r.Metrics.SpeechNoOutputCount, min: 0, max: math.Inf(1)},
+		{name: "metrics.speech_start_during_output_count", value: r.Metrics.SpeechStartDuringOutputCount, min: 0, max: math.Inf(1)},
+	} {
+		if metric.value != nil && (*metric.value < metric.min || *metric.value > metric.max) {
+			return fmt.Errorf("%s must be between %v and %v", metric.name, metric.min, metric.max)
+		}
+	}
+	return nil
+}
+
+func (r LiveContinuityReport) TimingEvidence() LiveContinuityEvidence {
+	return LiveContinuityEvidence{
+		Status:                       r.Status,
+		Passed:                       r.Passed,
+		EvidenceStatus:               r.Metrics.EvidenceStatus,
+		MedianFirstAudioMS:           cloneFloat64(r.Metrics.MedianFirstAudioMS),
+		P90FirstAudioMS:              cloneFloat64(r.Metrics.P90FirstAudioMS),
+		MaxOutputGapMS:               cloneFloat64(r.Metrics.MaxOutputGapMS),
+		SpeechNoOutputRatio:          cloneFloat64(r.Metrics.SpeechNoOutputRatio),
+		SpeechStartDuringOutputCount: cloneFloat64(r.Metrics.SpeechStartDuringOutputCount),
+		Caveats:                      append([]string(nil), r.Caveats...),
+		AgentNotes:                   append([]string(nil), r.AgentNotes...),
+	}
+}

--- a/backend/internal/voiceartifacts/live_continuity_report.go
+++ b/backend/internal/voiceartifacts/live_continuity_report.go
@@ -44,6 +44,7 @@ type LiveContinuityEvidence struct {
 	MedianFirstAudioMS           *float64 `json:"median_first_audio_ms,omitempty"`
 	P90FirstAudioMS              *float64 `json:"p90_first_audio_ms,omitempty"`
 	MaxOutputGapMS               *float64 `json:"max_output_gap_ms,omitempty"`
+	MedianOutputGapMS            *float64 `json:"median_output_gap_ms,omitempty"`
 	SpeechNoOutputRatio          *float64 `json:"speech_no_output_ratio,omitempty"`
 	SpeechStartDuringOutputCount *float64 `json:"speech_start_during_output_count,omitempty"`
 	Caveats                      []string `json:"caveats,omitempty"`
@@ -101,20 +102,24 @@ func (r LiveContinuityReport) Validate() error {
 		value *float64
 		min   float64
 		max   float64
+		count bool
 	}{
 		{name: "metrics.speech_no_output_ratio", value: r.Metrics.SpeechNoOutputRatio, min: 0, max: 1},
-		{name: "metrics.speech_start_count", value: r.Metrics.SpeechStartCount, min: 0, max: math.Inf(1)},
-		{name: "metrics.speech_stop_count", value: r.Metrics.SpeechStopCount, min: 0, max: math.Inf(1)},
-		{name: "metrics.output_event_count", value: r.Metrics.OutputEventCount, min: 0, max: math.Inf(1)},
+		{name: "metrics.speech_start_count", value: r.Metrics.SpeechStartCount, min: 0, max: math.Inf(1), count: true},
+		{name: "metrics.speech_stop_count", value: r.Metrics.SpeechStopCount, min: 0, max: math.Inf(1), count: true},
+		{name: "metrics.output_event_count", value: r.Metrics.OutputEventCount, min: 0, max: math.Inf(1), count: true},
 		{name: "metrics.max_output_gap_ms", value: r.Metrics.MaxOutputGapMS, min: 0, max: math.Inf(1)},
 		{name: "metrics.median_output_gap_ms", value: r.Metrics.MedianOutputGapMS, min: 0, max: math.Inf(1)},
 		{name: "metrics.median_first_audio_ms", value: r.Metrics.MedianFirstAudioMS, min: 0, max: math.Inf(1)},
 		{name: "metrics.p90_first_audio_ms", value: r.Metrics.P90FirstAudioMS, min: 0, max: math.Inf(1)},
-		{name: "metrics.speech_no_output_count", value: r.Metrics.SpeechNoOutputCount, min: 0, max: math.Inf(1)},
-		{name: "metrics.speech_start_during_output_count", value: r.Metrics.SpeechStartDuringOutputCount, min: 0, max: math.Inf(1)},
+		{name: "metrics.speech_no_output_count", value: r.Metrics.SpeechNoOutputCount, min: 0, max: math.Inf(1), count: true},
+		{name: "metrics.speech_start_during_output_count", value: r.Metrics.SpeechStartDuringOutputCount, min: 0, max: math.Inf(1), count: true},
 	} {
 		if metric.value != nil && (*metric.value < metric.min || *metric.value > metric.max) {
 			return fmt.Errorf("%s must be between %v and %v", metric.name, metric.min, metric.max)
+		}
+		if metric.value != nil && metric.count && math.Trunc(*metric.value) != *metric.value {
+			return fmt.Errorf("%s must be a whole number", metric.name)
 		}
 	}
 	return nil
@@ -128,6 +133,7 @@ func (r LiveContinuityReport) TimingEvidence() LiveContinuityEvidence {
 		MedianFirstAudioMS:           cloneFloat64(r.Metrics.MedianFirstAudioMS),
 		P90FirstAudioMS:              cloneFloat64(r.Metrics.P90FirstAudioMS),
 		MaxOutputGapMS:               cloneFloat64(r.Metrics.MaxOutputGapMS),
+		MedianOutputGapMS:            cloneFloat64(r.Metrics.MedianOutputGapMS),
 		SpeechNoOutputRatio:          cloneFloat64(r.Metrics.SpeechNoOutputRatio),
 		SpeechStartDuringOutputCount: cloneFloat64(r.Metrics.SpeechStartDuringOutputCount),
 		Caveats:                      append([]string(nil), r.Caveats...),

--- a/backend/internal/voiceartifacts/live_continuity_report_test.go
+++ b/backend/internal/voiceartifacts/live_continuity_report_test.go
@@ -23,9 +23,16 @@ func TestLoadLiveContinuityReport(t *testing.T) {
 	if evidence.SpeechNoOutputRatio == nil || *evidence.SpeechNoOutputRatio != 0 {
 		t.Fatalf("speech no output ratio = %#v", evidence.SpeechNoOutputRatio)
 	}
+	if evidence.MedianOutputGapMS == nil || *evidence.MedianOutputGapMS != 400 {
+		t.Fatalf("median output gap = %#v", evidence.MedianOutputGapMS)
+	}
 	*evidence.MedianFirstAudioMS = 1
+	*evidence.MedianOutputGapMS = 1
 	if *report.Metrics.MedianFirstAudioMS != 850 {
 		t.Fatal("evidence metric mutation should not mutate source report")
+	}
+	if *report.Metrics.MedianOutputGapMS != 400 {
+		t.Fatal("evidence gap mutation should not mutate source report")
 	}
 }
 
@@ -62,6 +69,31 @@ func TestLiveContinuityReportAcceptsDegradedEvidence(t *testing.T) {
 
 	if _, err := LoadLiveContinuityReport(path); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestLiveContinuityReportAcceptsWarnStatus(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeLiveContinuityReport(t, path, map[string]any{
+		"schema_version": "2026-05-14",
+		"type":           LiveContinuityReportType,
+		"status":         "warn",
+		"passed":         false,
+		"metrics": map[string]any{
+			"evidence_status":        "available",
+			"speech_start_count":     2,
+			"output_event_count":     2,
+			"speech_no_output_ratio": 0,
+		},
+	})
+
+	report, err := LoadLiveContinuityReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Passed {
+		t.Fatal("warn report should not be marked passed")
 	}
 }
 
@@ -131,6 +163,25 @@ func TestLiveContinuityReportRejectsNegativeCount(t *testing.T) {
 		"metrics": map[string]any{
 			"evidence_status":        "available",
 			"speech_no_output_count": -1,
+		},
+	})
+
+	if _, err := LoadLiveContinuityReport(path); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestLiveContinuityReportRejectsFractionalCount(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeLiveContinuityReport(t, path, map[string]any{
+		"schema_version": "2026-05-14",
+		"type":           LiveContinuityReportType,
+		"status":         "failed",
+		"passed":         false,
+		"metrics": map[string]any{
+			"evidence_status":    "available",
+			"speech_start_count": 1.5,
 		},
 	})
 

--- a/backend/internal/voiceartifacts/live_continuity_report_test.go
+++ b/backend/internal/voiceartifacts/live_continuity_report_test.go
@@ -1,0 +1,157 @@
+package voiceartifacts
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadLiveContinuityReport(t *testing.T) {
+	report, err := LoadLiveContinuityReport(filepath.Join("testdata", "voicey_live_continuity_report.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if report.Type != LiveContinuityReportType {
+		t.Fatalf("type = %q", report.Type)
+	}
+	evidence := report.TimingEvidence()
+	if evidence.MedianFirstAudioMS == nil || *evidence.MedianFirstAudioMS != 850 {
+		t.Fatalf("median first audio = %#v", evidence.MedianFirstAudioMS)
+	}
+	if evidence.SpeechNoOutputRatio == nil || *evidence.SpeechNoOutputRatio != 0 {
+		t.Fatalf("speech no output ratio = %#v", evidence.SpeechNoOutputRatio)
+	}
+	*evidence.MedianFirstAudioMS = 1
+	if *report.Metrics.MedianFirstAudioMS != 850 {
+		t.Fatal("evidence metric mutation should not mutate source report")
+	}
+}
+
+func TestIngestLiveContinuityReport(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "voicey_live_continuity_report.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	report, err := IngestLiveContinuityReport(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Raw) == 0 {
+		t.Fatal("expected raw report copy")
+	}
+}
+
+func TestLiveContinuityReportAcceptsDegradedEvidence(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeLiveContinuityReport(t, path, map[string]any{
+		"schema_version": "2026-05-14",
+		"type":           LiveContinuityReportType,
+		"status":         "degraded",
+		"passed":         false,
+		"metrics": map[string]any{
+			"evidence_status":        "degraded",
+			"speech_start_count":     0,
+			"output_event_count":     2,
+			"max_output_gap_ms":      0,
+			"speech_no_output_ratio": 0,
+		},
+	})
+
+	if _, err := LoadLiveContinuityReport(path); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLiveContinuityReportRejectsInconsistentPassedStatus(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeLiveContinuityReport(t, path, map[string]any{
+		"schema_version": "2026-05-14",
+		"type":           LiveContinuityReportType,
+		"status":         "failed",
+		"passed":         true,
+		"metrics": map[string]any{
+			"evidence_status": "available",
+		},
+	})
+
+	if _, err := LoadLiveContinuityReport(path); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestLiveContinuityReportRejectsOutOfRangeRatio(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeLiveContinuityReport(t, path, map[string]any{
+		"schema_version": "2026-05-14",
+		"type":           LiveContinuityReportType,
+		"status":         "passed",
+		"passed":         true,
+		"metrics": map[string]any{
+			"evidence_status":        "available",
+			"speech_no_output_ratio": 1.4,
+		},
+	})
+
+	if _, err := LoadLiveContinuityReport(path); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestLiveContinuityReportRejectsPassedWithDegradedEvidence(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeLiveContinuityReport(t, path, map[string]any{
+		"schema_version": "2026-05-14",
+		"type":           LiveContinuityReportType,
+		"status":         "passed",
+		"passed":         true,
+		"metrics": map[string]any{
+			"evidence_status": "degraded",
+		},
+	})
+
+	if _, err := LoadLiveContinuityReport(path); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestLiveContinuityReportRejectsNegativeCount(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeLiveContinuityReport(t, path, map[string]any{
+		"schema_version": "2026-05-14",
+		"type":           LiveContinuityReportType,
+		"status":         "failed",
+		"passed":         false,
+		"metrics": map[string]any{
+			"evidence_status":        "available",
+			"speech_no_output_count": -1,
+		},
+	})
+
+	if _, err := LoadLiveContinuityReport(path); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestLiveContinuityArtifactKindIsValid(t *testing.T) {
+	if !ArtifactKindLiveContinuityReport.IsValid() {
+		t.Fatal("live continuity report artifact kind should be valid")
+	}
+}
+
+func writeLiveContinuityReport(t *testing.T, path string, value map[string]any) {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/backend/internal/voiceartifacts/manifest.go
+++ b/backend/internal/voiceartifacts/manifest.go
@@ -20,15 +20,16 @@ const SchemaVersionV1 = "2026-05-13"
 type ArtifactKind string
 
 const (
-	ArtifactKindCallerAudio       ArtifactKind = "caller_audio"
-	ArtifactKindAgentAudio        ArtifactKind = "agent_audio"
-	ArtifactKindMixedAudio        ArtifactKind = "mixed_audio"
-	ArtifactKindTranscriptJSON    ArtifactKind = "transcript_json"
-	ArtifactKindWaveformTimeline  ArtifactKind = "waveform_timeline_json"
-	ArtifactKindMediaPolicyReport ArtifactKind = "media_policy_report_json"
-	ArtifactKindRawProviderTrace  ArtifactKind = "raw_provider_trace_json"
-	ArtifactKindStructuredOutput  ArtifactKind = "structured_output_json"
-	ArtifactKindRedactionMetadata ArtifactKind = "redaction_metadata_json"
+	ArtifactKindCallerAudio          ArtifactKind = "caller_audio"
+	ArtifactKindAgentAudio           ArtifactKind = "agent_audio"
+	ArtifactKindMixedAudio           ArtifactKind = "mixed_audio"
+	ArtifactKindTranscriptJSON       ArtifactKind = "transcript_json"
+	ArtifactKindWaveformTimeline     ArtifactKind = "waveform_timeline_json"
+	ArtifactKindMediaPolicyReport    ArtifactKind = "media_policy_report_json"
+	ArtifactKindLiveContinuityReport ArtifactKind = "live_continuity_report_json"
+	ArtifactKindRawProviderTrace     ArtifactKind = "raw_provider_trace_json"
+	ArtifactKindStructuredOutput     ArtifactKind = "structured_output_json"
+	ArtifactKindRedactionMetadata    ArtifactKind = "redaction_metadata_json"
 )
 
 type ArtifactLocationType string
@@ -173,6 +174,7 @@ func (k ArtifactKind) IsValid() bool {
 		ArtifactKindTranscriptJSON,
 		ArtifactKindWaveformTimeline,
 		ArtifactKindMediaPolicyReport,
+		ArtifactKindLiveContinuityReport,
 		ArtifactKindRawProviderTrace,
 		ArtifactKindStructuredOutput,
 		ArtifactKindRedactionMetadata:

--- a/backend/internal/voiceartifacts/testdata/voicey_live_continuity_report.json
+++ b/backend/internal/voiceartifacts/testdata/voicey_live_continuity_report.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "2026-05-14",
+  "type": "voicey.live_continuity_eval",
+  "status": "passed",
+  "passed": true,
+  "input": "runs/live-continuity-fixture.jsonl",
+  "metrics": {
+    "speech_start_count": 2,
+    "speech_stop_count": 0,
+    "output_event_count": 3,
+    "evidence_status": "available",
+    "median_first_audio_ms": 850,
+    "p90_first_audio_ms": 900,
+    "max_output_gap_ms": 400,
+    "median_output_gap_ms": 400,
+    "speech_no_output_count": 0,
+    "speech_no_output_ratio": 0,
+    "speech_start_during_output_count": 0
+  },
+  "caveats": [],
+  "agentclash_notes": [
+    "Use median_first_audio_ms and p90_first_audio_ms as live interpretation latency gates.",
+    "Use max_output_gap_ms to catch dead-air regressions that transcript-only evals miss."
+  ]
+}


### PR DESCRIPTION
## Summary
- adds live_continuity_report_json as an optional voice artifact kind
- adds Voicey live-continuity report ingestion and validation
- exposes normalized TimingEvidence for future scorecard dimensions
- models degraded timing evidence explicitly and prevents passed reports from using degraded evidence

## Issues
Part of #796

## Review
- Cursor Composer 2 review: testing/cursor-voice-live-continuity-import-review.md
- Addressed review notes by tightening remaining numeric validation and status/evidence consistency.

## Validation
- cd backend && go test ./internal/voiceartifacts ./internal/voicelive
