### PR TITLE
feat: ingest voice video sync reports

### DIFF
--- a/backend/internal/voiceartifacts/manifest.go
+++ b/backend/internal/voiceartifacts/manifest.go
@@ -27,6 +27,7 @@ const (
 	ArtifactKindWaveformTimeline     ArtifactKind = "waveform_timeline_json"
 	ArtifactKindMediaPolicyReport    ArtifactKind = "media_policy_report_json"
 	ArtifactKindLiveContinuityReport ArtifactKind = "live_continuity_report_json"
+	ArtifactKindVideoSyncReport      ArtifactKind = "video_sync_report_json"
 	ArtifactKindRawProviderTrace     ArtifactKind = "raw_provider_trace_json"
 	ArtifactKindStructuredOutput     ArtifactKind = "structured_output_json"
 	ArtifactKindRedactionMetadata    ArtifactKind = "redaction_metadata_json"
@@ -175,6 +176,7 @@ func (k ArtifactKind) IsValid() bool {
 		ArtifactKindWaveformTimeline,
 		ArtifactKindMediaPolicyReport,
 		ArtifactKindLiveContinuityReport,
+		ArtifactKindVideoSyncReport,
 		ArtifactKindRawProviderTrace,
 		ArtifactKindStructuredOutput,
 		ArtifactKindRedactionMetadata:

--- a/backend/internal/voiceartifacts/testdata/voicey_video_sync_report.json
+++ b/backend/internal/voiceartifacts/testdata/voicey_video_sync_report.json
@@ -1,0 +1,75 @@
+{
+  "inputs": {
+    "source_audio": "samples/downloaded/datacatalyst-hinglish/tts_hinglish_005.wav",
+    "translated_audio": "outputs/tts_hinglish_005.en.wav"
+  },
+  "summary": {
+    "duration_fit_score": 0.579,
+    "extra_translation_segments": 0,
+    "fail_duration_ratio_range": [
+      0.4,
+      2.5
+    ],
+    "fail_threshold_ms": 2500,
+    "first_onset_lag_ms": 520,
+    "interpretation": "Interpreter-style lag. Usable for comprehension, visibly behind lips.",
+    "max_duration_ratio": 4.075,
+    "median_duration_ratio": 3.059,
+    "median_onset_lag_ms": 520,
+    "min_duration_ratio": 1.659,
+    "missing_translation_segments": 2,
+    "p90_onset_lag_ms": 660,
+    "paired_segments": 3,
+    "segment_coverage_ratio": 0.6,
+    "source_span_ms": 7280,
+    "span_duration_ratio": 1.044,
+    "status": "fail",
+    "status_basis_ms": 840,
+    "status_reasons": [
+      "missing_source_segments",
+      "duration_ratio_outside_fail_threshold"
+    ],
+    "tail_lag_ms": 840,
+    "translated_span_ms": 7600,
+    "warn_duration_ratio_range": [
+      0.6,
+      1.8
+    ],
+    "warn_threshold_ms": 1200
+  },
+  "source_segments": [
+    {
+      "end_ms": 1440,
+      "start_ms": 560
+    },
+    {
+      "end_ms": 2340,
+      "start_ms": 1860
+    }
+  ],
+  "translated_segments": [
+    {
+      "end_ms": 2540,
+      "start_ms": 1080
+    }
+  ],
+  "pairs": [
+    {
+      "duration_ratio": 1.659,
+      "onset_lag_ms": 520,
+      "source_end_ms": 1440,
+      "source_index": 0,
+      "source_start_ms": 560,
+      "status": "paired",
+      "translated_end_ms": 2540,
+      "translated_index": 0,
+      "translated_start_ms": 1080
+    },
+    {
+      "source_index": 1,
+      "status": "missing_translation",
+      "translated_index": null
+    }
+  ],
+  "video_sync_note": "This measures translated-audio timing against source speech. True lip sync needs video mouth-motion or face-landmark scoring, then alignment against translated audio."
+}

--- a/backend/internal/voiceartifacts/testdata/voicey_video_sync_report.json
+++ b/backend/internal/voiceartifacts/testdata/voicey_video_sync_report.json
@@ -45,12 +45,32 @@
     {
       "end_ms": 2340,
       "start_ms": 1860
+    },
+    {
+      "end_ms": 3440,
+      "start_ms": 2880
+    },
+    {
+      "end_ms": 5279,
+      "start_ms": 4960
+    },
+    {
+      "end_ms": 7840,
+      "start_ms": 7500
     }
   ],
   "translated_segments": [
     {
       "end_ms": 2540,
       "start_ms": 1080
+    },
+    {
+      "end_ms": 6920,
+      "start_ms": 5620
+    },
+    {
+      "end_ms": 8680,
+      "start_ms": 7640
     }
   ],
   "pairs": [
@@ -69,6 +89,33 @@
       "source_index": 1,
       "status": "missing_translation",
       "translated_index": null
+    },
+    {
+      "source_index": 2,
+      "status": "missing_translation",
+      "translated_index": null
+    },
+    {
+      "duration_ratio": 4.075,
+      "onset_lag_ms": 660,
+      "source_end_ms": 5279,
+      "source_index": 3,
+      "source_start_ms": 4960,
+      "status": "paired",
+      "translated_end_ms": 6920,
+      "translated_index": 1,
+      "translated_start_ms": 5620
+    },
+    {
+      "duration_ratio": 3.059,
+      "onset_lag_ms": 140,
+      "source_end_ms": 7840,
+      "source_index": 4,
+      "source_start_ms": 7500,
+      "status": "paired",
+      "translated_end_ms": 8680,
+      "translated_index": 2,
+      "translated_start_ms": 7640
     }
   ],
   "video_sync_note": "This measures translated-audio timing against source speech. True lip sync needs video mouth-motion or face-landmark scoring, then alignment against translated audio."

--- a/backend/internal/voiceartifacts/video_sync_report.go
+++ b/backend/internal/voiceartifacts/video_sync_report.go
@@ -292,7 +292,7 @@ func validateIndex(name string, value *float64, count int) error {
 	if err := validateVideoSyncMetric(name, value, 0, math.Inf(1), true); err != nil {
 		return err
 	}
-	if count > 0 && int(*value) >= count {
+	if count == 0 || int(*value) >= count {
 		return fmt.Errorf("%s is out of range", name)
 	}
 	return nil

--- a/backend/internal/voiceartifacts/video_sync_report.go
+++ b/backend/internal/voiceartifacts/video_sync_report.go
@@ -1,0 +1,299 @@
+package voiceartifacts
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"strings"
+)
+
+type VideoSyncReport struct {
+	Inputs             map[string]any     `json:"inputs,omitempty"`
+	Summary            VideoSyncSummary   `json:"summary"`
+	SourceSegments     []VideoSyncSegment `json:"source_segments,omitempty"`
+	TranslatedSegments []VideoSyncSegment `json:"translated_segments,omitempty"`
+	Pairs              []VideoSyncPair    `json:"pairs,omitempty"`
+	VideoSyncNote      string             `json:"video_sync_note,omitempty"`
+	VoiceyLogMetrics   map[string]any     `json:"voicey_log_metrics,omitempty"`
+	MouthMotionMetrics map[string]any     `json:"mouth_motion_metrics,omitempty"`
+	Raw                json.RawMessage    `json:"-"`
+}
+
+type VideoSyncSummary struct {
+	Status                     string    `json:"status"`
+	StatusReasons              []string  `json:"status_reasons,omitempty"`
+	StatusBasisMS              *float64  `json:"status_basis_ms"`
+	FirstOnsetLagMS            *float64  `json:"first_onset_lag_ms"`
+	MedianOnsetLagMS           *float64  `json:"median_onset_lag_ms"`
+	P90OnsetLagMS              *float64  `json:"p90_onset_lag_ms"`
+	TailLagMS                  *float64  `json:"tail_lag_ms"`
+	PairedSegments             *float64  `json:"paired_segments"`
+	MissingTranslationSegments *float64  `json:"missing_translation_segments"`
+	ExtraTranslationSegments   *float64  `json:"extra_translation_segments"`
+	SegmentCoverageRatio       *float64  `json:"segment_coverage_ratio"`
+	DurationFitScore           *float64  `json:"duration_fit_score"`
+	MedianDurationRatio        *float64  `json:"median_duration_ratio"`
+	MinDurationRatio           *float64  `json:"min_duration_ratio"`
+	MaxDurationRatio           *float64  `json:"max_duration_ratio"`
+	SourceSpanMS               *float64  `json:"source_span_ms"`
+	TranslatedSpanMS           *float64  `json:"translated_span_ms"`
+	SpanDurationRatio          *float64  `json:"span_duration_ratio"`
+	WarnThresholdMS            *float64  `json:"warn_threshold_ms"`
+	FailThresholdMS            *float64  `json:"fail_threshold_ms"`
+	WarnDurationRatioRange     []float64 `json:"warn_duration_ratio_range,omitempty"`
+	FailDurationRatioRange     []float64 `json:"fail_duration_ratio_range,omitempty"`
+	Interpretation             string    `json:"interpretation,omitempty"`
+}
+
+type VideoSyncSegment struct {
+	StartMS float64 `json:"start_ms"`
+	EndMS   float64 `json:"end_ms"`
+}
+
+type VideoSyncPair struct {
+	SourceIndex       *float64 `json:"source_index"`
+	TranslatedIndex   *float64 `json:"translated_index"`
+	SourceStartMS     *float64 `json:"source_start_ms"`
+	SourceEndMS       *float64 `json:"source_end_ms"`
+	TranslatedStartMS *float64 `json:"translated_start_ms"`
+	TranslatedEndMS   *float64 `json:"translated_end_ms"`
+	OnsetLagMS        *float64 `json:"onset_lag_ms"`
+	DurationRatio     *float64 `json:"duration_ratio"`
+	Status            string   `json:"status"`
+}
+
+type VideoSyncEvidence struct {
+	Status                     string   `json:"status"`
+	StatusReasons              []string `json:"status_reasons,omitempty"`
+	MedianOnsetLagMS           *float64 `json:"median_onset_lag_ms,omitempty"`
+	P90OnsetLagMS              *float64 `json:"p90_onset_lag_ms,omitempty"`
+	TailLagMS                  *float64 `json:"tail_lag_ms,omitempty"`
+	SegmentCoverageRatio       *float64 `json:"segment_coverage_ratio,omitempty"`
+	DurationFitScore           *float64 `json:"duration_fit_score,omitempty"`
+	MissingTranslationSegments *float64 `json:"missing_translation_segments,omitempty"`
+	ExtraTranslationSegments   *float64 `json:"extra_translation_segments,omitempty"`
+	MedianDurationRatio        *float64 `json:"median_duration_ratio,omitempty"`
+	MaxDurationRatio           *float64 `json:"max_duration_ratio,omitempty"`
+	Interpretation             string   `json:"interpretation,omitempty"`
+}
+
+func LoadVideoSyncReport(path string) (VideoSyncReport, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return VideoSyncReport{}, err
+	}
+	return IngestVideoSyncReport(data)
+}
+
+func IngestVideoSyncReport(data []byte) (VideoSyncReport, error) {
+	var report VideoSyncReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		return VideoSyncReport{}, fmt.Errorf("decode video sync report: %w", err)
+	}
+	report.Raw = append(json.RawMessage(nil), data...)
+	if err := report.Validate(); err != nil {
+		return VideoSyncReport{}, err
+	}
+	return report, nil
+}
+
+func (r VideoSyncReport) Validate() error {
+	switch r.Summary.Status {
+	case "pass", "warn", "fail":
+	default:
+		return errors.New("summary.status must be one of pass, warn, fail")
+	}
+	if strings.TrimSpace(r.Summary.Interpretation) == "" {
+		return errors.New("summary.interpretation is required")
+	}
+	for _, metric := range []struct {
+		name  string
+		value *float64
+		min   float64
+		max   float64
+		count bool
+	}{
+		{name: "summary.status_basis_ms", value: r.Summary.StatusBasisMS, min: 0, max: math.Inf(1)},
+		{name: "summary.first_onset_lag_ms", value: r.Summary.FirstOnsetLagMS, min: math.Inf(-1), max: math.Inf(1)},
+		{name: "summary.median_onset_lag_ms", value: r.Summary.MedianOnsetLagMS, min: math.Inf(-1), max: math.Inf(1)},
+		{name: "summary.p90_onset_lag_ms", value: r.Summary.P90OnsetLagMS, min: math.Inf(-1), max: math.Inf(1)},
+		{name: "summary.tail_lag_ms", value: r.Summary.TailLagMS, min: math.Inf(-1), max: math.Inf(1)},
+		{name: "summary.paired_segments", value: r.Summary.PairedSegments, min: 0, max: math.Inf(1), count: true},
+		{name: "summary.missing_translation_segments", value: r.Summary.MissingTranslationSegments, min: 0, max: math.Inf(1), count: true},
+		{name: "summary.extra_translation_segments", value: r.Summary.ExtraTranslationSegments, min: 0, max: math.Inf(1), count: true},
+		{name: "summary.segment_coverage_ratio", value: r.Summary.SegmentCoverageRatio, min: 0, max: 1},
+		{name: "summary.duration_fit_score", value: r.Summary.DurationFitScore, min: 0, max: 1},
+		{name: "summary.median_duration_ratio", value: r.Summary.MedianDurationRatio, min: 0, max: math.Inf(1)},
+		{name: "summary.min_duration_ratio", value: r.Summary.MinDurationRatio, min: 0, max: math.Inf(1)},
+		{name: "summary.max_duration_ratio", value: r.Summary.MaxDurationRatio, min: 0, max: math.Inf(1)},
+		{name: "summary.source_span_ms", value: r.Summary.SourceSpanMS, min: 0, max: math.Inf(1)},
+		{name: "summary.translated_span_ms", value: r.Summary.TranslatedSpanMS, min: 0, max: math.Inf(1)},
+		{name: "summary.span_duration_ratio", value: r.Summary.SpanDurationRatio, min: 0, max: math.Inf(1)},
+		{name: "summary.warn_threshold_ms", value: r.Summary.WarnThresholdMS, min: 0, max: math.Inf(1)},
+		{name: "summary.fail_threshold_ms", value: r.Summary.FailThresholdMS, min: 0, max: math.Inf(1)},
+	} {
+		if err := validateVideoSyncMetric(metric.name, metric.value, metric.min, metric.max, metric.count); err != nil {
+			return err
+		}
+	}
+	if err := validateRange("summary.warn_duration_ratio_range", r.Summary.WarnDurationRatioRange); err != nil {
+		return err
+	}
+	if err := validateRange("summary.fail_duration_ratio_range", r.Summary.FailDurationRatioRange); err != nil {
+		return err
+	}
+	for index, segment := range r.SourceSegments {
+		if err := validateSegment(fmt.Sprintf("source_segments[%d]", index), segment); err != nil {
+			return err
+		}
+	}
+	for index, segment := range r.TranslatedSegments {
+		if err := validateSegment(fmt.Sprintf("translated_segments[%d]", index), segment); err != nil {
+			return err
+		}
+	}
+	for index, pair := range r.Pairs {
+		if err := validatePair(fmt.Sprintf("pairs[%d]", index), pair, len(r.SourceSegments), len(r.TranslatedSegments)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r VideoSyncReport) TimingEvidence() VideoSyncEvidence {
+	return VideoSyncEvidence{
+		Status:                     r.Summary.Status,
+		StatusReasons:              append([]string(nil), r.Summary.StatusReasons...),
+		MedianOnsetLagMS:           cloneFloat64(r.Summary.MedianOnsetLagMS),
+		P90OnsetLagMS:              cloneFloat64(r.Summary.P90OnsetLagMS),
+		TailLagMS:                  cloneFloat64(r.Summary.TailLagMS),
+		SegmentCoverageRatio:       cloneFloat64(r.Summary.SegmentCoverageRatio),
+		DurationFitScore:           cloneFloat64(r.Summary.DurationFitScore),
+		MissingTranslationSegments: cloneFloat64(r.Summary.MissingTranslationSegments),
+		ExtraTranslationSegments:   cloneFloat64(r.Summary.ExtraTranslationSegments),
+		MedianDurationRatio:        cloneFloat64(r.Summary.MedianDurationRatio),
+		MaxDurationRatio:           cloneFloat64(r.Summary.MaxDurationRatio),
+		Interpretation:             r.Summary.Interpretation,
+	}
+}
+
+func validateVideoSyncMetric(name string, value *float64, min float64, max float64, count bool) error {
+	if value == nil {
+		return nil
+	}
+	if math.IsNaN(*value) || math.IsInf(*value, 0) {
+		return fmt.Errorf("%s must be finite", name)
+	}
+	if *value < min || *value > max {
+		return fmt.Errorf("%s must be between %v and %v", name, min, max)
+	}
+	if count && math.Trunc(*value) != *value {
+		return fmt.Errorf("%s must be a whole number", name)
+	}
+	return nil
+}
+
+func validateRange(name string, values []float64) error {
+	if len(values) == 0 {
+		return nil
+	}
+	if len(values) != 2 {
+		return fmt.Errorf("%s must contain exactly two values", name)
+	}
+	for index, value := range values {
+		if math.IsNaN(value) || math.IsInf(value, 0) || value < 0 {
+			return fmt.Errorf("%s[%d] must be a finite non-negative number", name, index)
+		}
+	}
+	if values[0] > values[1] {
+		return fmt.Errorf("%s lower bound must be <= upper bound", name)
+	}
+	return nil
+}
+
+func validateSegment(name string, segment VideoSyncSegment) error {
+	if math.IsNaN(segment.StartMS) || math.IsInf(segment.StartMS, 0) || segment.StartMS < 0 {
+		return fmt.Errorf("%s.start_ms must be a finite non-negative number", name)
+	}
+	if math.IsNaN(segment.EndMS) || math.IsInf(segment.EndMS, 0) || segment.EndMS < 0 {
+		return fmt.Errorf("%s.end_ms must be a finite non-negative number", name)
+	}
+	if segment.EndMS < segment.StartMS {
+		return fmt.Errorf("%s.end_ms must be >= start_ms", name)
+	}
+	return nil
+}
+
+func validatePair(name string, pair VideoSyncPair, sourceCount int, translatedCount int) error {
+	switch pair.Status {
+	case "paired":
+		for _, required := range []struct {
+			field string
+			value *float64
+		}{
+			{field: "source_index", value: pair.SourceIndex},
+			{field: "translated_index", value: pair.TranslatedIndex},
+			{field: "source_start_ms", value: pair.SourceStartMS},
+			{field: "source_end_ms", value: pair.SourceEndMS},
+			{field: "translated_start_ms", value: pair.TranslatedStartMS},
+			{field: "translated_end_ms", value: pair.TranslatedEndMS},
+			{field: "onset_lag_ms", value: pair.OnsetLagMS},
+			{field: "duration_ratio", value: pair.DurationRatio},
+		} {
+			if required.value == nil {
+				return fmt.Errorf("%s.%s is required for paired rows", name, required.field)
+			}
+		}
+	case "missing_translation":
+		if pair.SourceIndex == nil {
+			return fmt.Errorf("%s.source_index is required for missing_translation rows", name)
+		}
+	default:
+		return fmt.Errorf("%s.status must be paired or missing_translation", name)
+	}
+	if err := validateIndex(name+".source_index", pair.SourceIndex, sourceCount); err != nil {
+		return err
+	}
+	if err := validateIndex(name+".translated_index", pair.TranslatedIndex, translatedCount); err != nil {
+		return err
+	}
+	for _, metric := range []struct {
+		name  string
+		value *float64
+		min   float64
+		max   float64
+	}{
+		{name: name + ".source_start_ms", value: pair.SourceStartMS, min: 0, max: math.Inf(1)},
+		{name: name + ".source_end_ms", value: pair.SourceEndMS, min: 0, max: math.Inf(1)},
+		{name: name + ".translated_start_ms", value: pair.TranslatedStartMS, min: 0, max: math.Inf(1)},
+		{name: name + ".translated_end_ms", value: pair.TranslatedEndMS, min: 0, max: math.Inf(1)},
+		{name: name + ".onset_lag_ms", value: pair.OnsetLagMS, min: math.Inf(-1), max: math.Inf(1)},
+		{name: name + ".duration_ratio", value: pair.DurationRatio, min: 0, max: math.Inf(1)},
+	} {
+		if err := validateVideoSyncMetric(metric.name, metric.value, metric.min, metric.max, false); err != nil {
+			return err
+		}
+	}
+	if pair.SourceStartMS != nil && pair.SourceEndMS != nil && *pair.SourceEndMS < *pair.SourceStartMS {
+		return fmt.Errorf("%s.source_end_ms must be >= source_start_ms", name)
+	}
+	if pair.TranslatedStartMS != nil && pair.TranslatedEndMS != nil && *pair.TranslatedEndMS < *pair.TranslatedStartMS {
+		return fmt.Errorf("%s.translated_end_ms must be >= translated_start_ms", name)
+	}
+	return nil
+}
+
+func validateIndex(name string, value *float64, count int) error {
+	if value == nil {
+		return nil
+	}
+	if err := validateVideoSyncMetric(name, value, 0, math.Inf(1), true); err != nil {
+		return err
+	}
+	if count > 0 && int(*value) >= count {
+		return fmt.Errorf("%s is out of range", name)
+	}
+	return nil
+}

--- a/backend/internal/voiceartifacts/video_sync_report_test.go
+++ b/backend/internal/voiceartifacts/video_sync_report_test.go
@@ -1,0 +1,165 @@
+package voiceartifacts
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadVideoSyncReport(t *testing.T) {
+	report, err := LoadVideoSyncReport(filepath.Join("testdata", "voicey_video_sync_report.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if report.Summary.Status != "fail" {
+		t.Fatalf("status = %q", report.Summary.Status)
+	}
+	evidence := report.TimingEvidence()
+	if evidence.SegmentCoverageRatio == nil || *evidence.SegmentCoverageRatio != 0.6 {
+		t.Fatalf("coverage = %#v", evidence.SegmentCoverageRatio)
+	}
+	if evidence.DurationFitScore == nil || *evidence.DurationFitScore != 0.579 {
+		t.Fatalf("duration fit = %#v", evidence.DurationFitScore)
+	}
+	if evidence.MissingTranslationSegments == nil || *evidence.MissingTranslationSegments != 2 {
+		t.Fatalf("missing segments = %#v", evidence.MissingTranslationSegments)
+	}
+	*evidence.DurationFitScore = 1
+	if *report.Summary.DurationFitScore != 0.579 {
+		t.Fatal("evidence mutation should not mutate source report")
+	}
+}
+
+func TestIngestVideoSyncReport(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "voicey_video_sync_report.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	report, err := IngestVideoSyncReport(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Raw) == 0 {
+		t.Fatal("expected raw report copy")
+	}
+}
+
+func TestVideoSyncReportRejectsInvalidStatus(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeVideoSyncReport(t, path, map[string]any{
+		"summary": map[string]any{
+			"status":         "passed",
+			"interpretation": "not a Voicey video-sync status",
+		},
+	})
+
+	if _, err := LoadVideoSyncReport(path); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestVideoSyncReportRejectsOutOfRangeCoverage(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeVideoSyncReport(t, path, map[string]any{
+		"summary": map[string]any{
+			"status":                 "fail",
+			"interpretation":         "coverage cannot exceed 1",
+			"segment_coverage_ratio": 1.2,
+		},
+	})
+
+	if _, err := LoadVideoSyncReport(path); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestVideoSyncReportRejectsFractionalCount(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeVideoSyncReport(t, path, map[string]any{
+		"summary": map[string]any{
+			"status":          "fail",
+			"interpretation":  "count must be whole",
+			"paired_segments": 1.5,
+		},
+	})
+
+	if _, err := LoadVideoSyncReport(path); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestVideoSyncReportRejectsInvalidSegmentTimeline(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeVideoSyncReport(t, path, map[string]any{
+		"summary": map[string]any{
+			"status":         "fail",
+			"interpretation": "segment end cannot precede start",
+		},
+		"source_segments": []map[string]any{
+			{"start_ms": 500, "end_ms": 100},
+		},
+	})
+
+	if _, err := LoadVideoSyncReport(path); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestVideoSyncReportRejectsInvalidPairStatus(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeVideoSyncReport(t, path, map[string]any{
+		"summary": map[string]any{
+			"status":         "fail",
+			"interpretation": "pair status must be known",
+		},
+		"pairs": []map[string]any{
+			{"source_index": 0, "translated_index": 0, "status": "extra"},
+		},
+	})
+
+	if _, err := LoadVideoSyncReport(path); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestVideoSyncReportRejectsFractionalPairIndex(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeVideoSyncReport(t, path, map[string]any{
+		"summary": map[string]any{
+			"status":         "fail",
+			"interpretation": "pair indexes must be whole",
+		},
+		"pairs": []map[string]any{
+			{"source_index": 0.5, "status": "missing_translation"},
+		},
+	})
+
+	if _, err := LoadVideoSyncReport(path); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestVideoSyncArtifactKindIsValid(t *testing.T) {
+	if !ArtifactKindVideoSyncReport.IsValid() {
+		t.Fatal("video sync report artifact kind should be valid")
+	}
+}
+
+func writeVideoSyncReport(t *testing.T, path string, value map[string]any) {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/backend/internal/voiceartifacts/video_sync_report_test.go
+++ b/backend/internal/voiceartifacts/video_sync_report_test.go
@@ -147,6 +147,24 @@ func TestVideoSyncReportRejectsFractionalPairIndex(t *testing.T) {
 	}
 }
 
+func TestVideoSyncReportRejectsPairIndexWithoutSegments(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeVideoSyncReport(t, path, map[string]any{
+		"summary": map[string]any{
+			"status":         "fail",
+			"interpretation": "pair indexes must reference present segments",
+		},
+		"pairs": []map[string]any{
+			{"source_index": 0, "status": "missing_translation"},
+		},
+	})
+
+	if _, err := LoadVideoSyncReport(path); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
 func TestVideoSyncArtifactKindIsValid(t *testing.T) {
 	if !ArtifactKindVideoSyncReport.IsValid() {
 		t.Fatal("video sync report artifact kind should be valid")

--- a/testing/cursor-video-sync-report-import-review.md
+++ b/testing/cursor-video-sync-report-import-review.md
@@ -1,0 +1,15 @@
+Cursor Composer 2 review for `codex/video-sync-report-import`.
+
+Verdict: comment, no blocking issues.
+
+Primary review finding:
+
+- The first pass validated the report summary and segment timelines, but did not validate `pairs`. That left pair statuses, indexes, and paired timing fields too loose for downstream scoring.
+
+Follow-up applied:
+
+- Added pair validation for allowed statuses (`paired`, `missing_translation`).
+- Required timing and index fields for `paired` rows.
+- Required `source_index` for `missing_translation` rows.
+- Enforced whole-number indexes, optional bounds against available segment arrays, finite timing values, non-negative duration ratios, and start/end ordering.
+- Added tests for invalid pair status and fractional pair indexes.


### PR DESCRIPTION
## Summary
- add `video_sync_report_json` as an optional voice artifact kind
- ingest Voicey video-sync reports and project timing/pacing evidence for downstream scorecards
- validate summary metrics, segment timelines, and pair rows including count/index semantics

## Validation
- cd backend && go test ./internal/voiceartifacts ./internal/voicelive

## Review
- Cursor Composer 2 review: comment, no blockers
- Follow-up applied: pair validation and tests for invalid pair rows
