### PR TITLE
fix: cross-check video sync summary counts

### DIFF
--- a/backend/internal/voiceartifacts/video_sync_report.go
+++ b/backend/internal/voiceartifacts/video_sync_report.go
@@ -189,11 +189,9 @@ func (r VideoSyncReport) validateSummaryAgainstPairs() error {
 	if err := requireCountMatch("summary.missing_translation_segments", r.Summary.MissingTranslationSegments, missing); err != nil {
 		return err
 	}
-	if len(r.TranslatedSegments) > 0 {
-		extra := len(r.TranslatedSegments) - len(pairedTranslated)
-		if err := requireCountMatch("summary.extra_translation_segments", r.Summary.ExtraTranslationSegments, extra); err != nil {
-			return err
-		}
+	extra := len(r.TranslatedSegments) - len(pairedTranslated)
+	if err := requireCountMatch("summary.extra_translation_segments", r.Summary.ExtraTranslationSegments, extra); err != nil {
+		return err
 	}
 	if len(r.SourceSegments) > 0 && r.Summary.SegmentCoverageRatio != nil {
 		expected := float64(paired) / float64(len(r.SourceSegments))
@@ -345,7 +343,7 @@ func requireCountMatch(name string, value *float64, expected int) error {
 		return nil
 	}
 	if int(*value) != expected {
-		return fmt.Errorf("%s must match pair rows", name)
+		return fmt.Errorf("%s must match pair rows: got %d, want %d", name, int(*value), expected)
 	}
 	return nil
 }

--- a/backend/internal/voiceartifacts/video_sync_report.go
+++ b/backend/internal/voiceartifacts/video_sync_report.go
@@ -159,6 +159,48 @@ func (r VideoSyncReport) Validate() error {
 			return err
 		}
 	}
+	if err := r.validateSummaryAgainstPairs(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r VideoSyncReport) validateSummaryAgainstPairs() error {
+	if len(r.Pairs) == 0 {
+		return nil
+	}
+	paired := 0
+	missing := 0
+	pairedTranslated := make(map[int]struct{})
+	for _, pair := range r.Pairs {
+		switch pair.Status {
+		case "paired":
+			paired++
+			if pair.TranslatedIndex != nil {
+				pairedTranslated[int(*pair.TranslatedIndex)] = struct{}{}
+			}
+		case "missing_translation":
+			missing++
+		}
+	}
+	if err := requireCountMatch("summary.paired_segments", r.Summary.PairedSegments, paired); err != nil {
+		return err
+	}
+	if err := requireCountMatch("summary.missing_translation_segments", r.Summary.MissingTranslationSegments, missing); err != nil {
+		return err
+	}
+	if len(r.TranslatedSegments) > 0 {
+		extra := len(r.TranslatedSegments) - len(pairedTranslated)
+		if err := requireCountMatch("summary.extra_translation_segments", r.Summary.ExtraTranslationSegments, extra); err != nil {
+			return err
+		}
+	}
+	if len(r.SourceSegments) > 0 && r.Summary.SegmentCoverageRatio != nil {
+		expected := float64(paired) / float64(len(r.SourceSegments))
+		if math.Abs(*r.Summary.SegmentCoverageRatio-expected) > 0.001 {
+			return fmt.Errorf("summary.segment_coverage_ratio must match paired/source segment counts")
+		}
+	}
 	return nil
 }
 
@@ -294,6 +336,16 @@ func validateIndex(name string, value *float64, count int) error {
 	}
 	if count == 0 || int(*value) >= count {
 		return fmt.Errorf("%s is out of range", name)
+	}
+	return nil
+}
+
+func requireCountMatch(name string, value *float64, expected int) error {
+	if value == nil {
+		return nil
+	}
+	if int(*value) != expected {
+		return fmt.Errorf("%s must match pair rows", name)
 	}
 	return nil
 }

--- a/backend/internal/voiceartifacts/video_sync_report_test.go
+++ b/backend/internal/voiceartifacts/video_sync_report_test.go
@@ -280,6 +280,29 @@ func TestVideoSyncReportRejectsExtraTranslationCountMismatch(t *testing.T) {
 	}
 }
 
+func TestVideoSyncReportRejectsExtraTranslationCountWithoutTranslatedSegments(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeVideoSyncReport(t, path, map[string]any{
+		"summary": map[string]any{
+			"status":                       "fail",
+			"interpretation":               "zero translated segments means zero extras",
+			"missing_translation_segments": 1,
+			"extra_translation_segments":   5,
+		},
+		"source_segments": []map[string]any{
+			{"start_ms": 0, "end_ms": 100},
+		},
+		"pairs": []map[string]any{
+			{"source_index": 0, "status": "missing_translation"},
+		},
+	})
+
+	if _, err := LoadVideoSyncReport(path); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
 func TestVideoSyncArtifactKindIsValid(t *testing.T) {
 	if !ArtifactKindVideoSyncReport.IsValid() {
 		t.Fatal("video sync report artifact kind should be valid")

--- a/backend/internal/voiceartifacts/video_sync_report_test.go
+++ b/backend/internal/voiceartifacts/video_sync_report_test.go
@@ -165,6 +165,121 @@ func TestVideoSyncReportRejectsPairIndexWithoutSegments(t *testing.T) {
 	}
 }
 
+func TestVideoSyncReportRejectsSummaryCountMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeVideoSyncReport(t, path, map[string]any{
+		"summary": map[string]any{
+			"status":                       "fail",
+			"interpretation":               "summary counts must match pairs",
+			"paired_segments":              2,
+			"missing_translation_segments": 0,
+			"segment_coverage_ratio":       1,
+		},
+		"source_segments": []map[string]any{
+			{"start_ms": 0, "end_ms": 100},
+		},
+		"translated_segments": []map[string]any{
+			{"start_ms": 10, "end_ms": 110},
+		},
+		"pairs": []map[string]any{
+			{
+				"source_index":        0,
+				"translated_index":    0,
+				"source_start_ms":     0,
+				"source_end_ms":       100,
+				"translated_start_ms": 10,
+				"translated_end_ms":   110,
+				"onset_lag_ms":        10,
+				"duration_ratio":      1,
+				"status":              "paired",
+			},
+		},
+	})
+
+	if _, err := LoadVideoSyncReport(path); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestVideoSyncReportRejectsCoverageMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeVideoSyncReport(t, path, map[string]any{
+		"summary": map[string]any{
+			"status":                       "fail",
+			"interpretation":               "coverage must match pair counts",
+			"paired_segments":              1,
+			"missing_translation_segments": 1,
+			"segment_coverage_ratio":       1,
+		},
+		"source_segments": []map[string]any{
+			{"start_ms": 0, "end_ms": 100},
+			{"start_ms": 200, "end_ms": 300},
+		},
+		"translated_segments": []map[string]any{
+			{"start_ms": 10, "end_ms": 110},
+		},
+		"pairs": []map[string]any{
+			{
+				"source_index":        0,
+				"translated_index":    0,
+				"source_start_ms":     0,
+				"source_end_ms":       100,
+				"translated_start_ms": 10,
+				"translated_end_ms":   110,
+				"onset_lag_ms":        10,
+				"duration_ratio":      1,
+				"status":              "paired",
+			},
+			{"source_index": 1, "status": "missing_translation"},
+		},
+	})
+
+	if _, err := LoadVideoSyncReport(path); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestVideoSyncReportRejectsExtraTranslationCountMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeVideoSyncReport(t, path, map[string]any{
+		"summary": map[string]any{
+			"status":                       "fail",
+			"interpretation":               "extra count must match unpaired translated segments",
+			"paired_segments":              1,
+			"missing_translation_segments": 0,
+			"extra_translation_segments":   0,
+			"segment_coverage_ratio":       1,
+		},
+		"source_segments": []map[string]any{
+			{"start_ms": 0, "end_ms": 100},
+		},
+		"translated_segments": []map[string]any{
+			{"start_ms": 10, "end_ms": 110},
+			{"start_ms": 200, "end_ms": 300},
+		},
+		"pairs": []map[string]any{
+			{
+				"source_index":        0,
+				"translated_index":    0,
+				"source_start_ms":     0,
+				"source_end_ms":       100,
+				"translated_start_ms": 10,
+				"translated_end_ms":   110,
+				"onset_lag_ms":        10,
+				"duration_ratio":      1,
+				"status":              "paired",
+			},
+		},
+	})
+
+	if _, err := LoadVideoSyncReport(path); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
 func TestVideoSyncArtifactKindIsValid(t *testing.T) {
 	if !ArtifactKindVideoSyncReport.IsValid() {
 		t.Fatal("video sync report artifact kind should be valid")

--- a/testing/cursor-video-sync-summary-crosschecks-review.md
+++ b/testing/cursor-video-sync-summary-crosschecks-review.md
@@ -1,0 +1,13 @@
+Cursor Composer 2 review for `codex/video-sync-summary-crosschecks`.
+
+Verdict: comment, no blockers.
+
+Notes:
+
+- Summary/pair crosschecks match the golden fixture arithmetic: five source segments, three paired rows, two missing rows, and 0.6 coverage.
+- Numeric summary fields remain optional; crosschecks only enforce fields that are present.
+- Review suggested adding a symmetric test for `extra_translation_segments` mismatches.
+
+Follow-up applied:
+
+- Added `TestVideoSyncReportRejectsExtraTranslationCountMismatch`.


### PR DESCRIPTION
## Summary
- cross-check Voicey video-sync summary counts against pair rows when pair evidence is present
- verify segment coverage ratio against paired/source counts
- add regression coverage for paired, missing, extra, and coverage mismatches

## Validation
- cd backend && go test ./internal/voiceartifacts ./internal/voicelive

## Review
- Cursor Composer 2 review: comment, no blockers
- Follow-up applied: added extra-translation count mismatch test
