### PR TITLE
feat: support generic voice report types

### DIFF
--- a/backend/internal/voiceartifacts/live_continuity_report.go
+++ b/backend/internal/voiceartifacts/live_continuity_report.go
@@ -74,10 +74,11 @@ func IngestLiveContinuityReport(data []byte) (LiveContinuityReport, error) {
 	return report, nil
 }
 
-func (r LiveContinuityReport) Validate() error {
+func (r *LiveContinuityReport) Validate() error {
 	if strings.TrimSpace(r.SchemaVersion) == "" {
 		return errors.New("schema_version is required")
 	}
+	r.Type = normalizeReportType(r.Type)
 	if !isAcceptedReportType(r.Type, LiveContinuityReportType, VoiceyLiveContinuityReportType) {
 		return fmt.Errorf("type must be %q or %q", LiveContinuityReportType, VoiceyLiveContinuityReportType)
 	}

--- a/backend/internal/voiceartifacts/live_continuity_report.go
+++ b/backend/internal/voiceartifacts/live_continuity_report.go
@@ -9,7 +9,10 @@ import (
 	"strings"
 )
 
-const LiveContinuityReportType = "voicey.live_continuity_eval"
+const (
+	LiveContinuityReportType       = "agentclash.voice.live_continuity_eval.v1"
+	VoiceyLiveContinuityReportType = "voicey.live_continuity_eval"
+)
 
 type LiveContinuityReport struct {
 	SchemaVersion string                `json:"schema_version"`
@@ -75,8 +78,8 @@ func (r LiveContinuityReport) Validate() error {
 	if strings.TrimSpace(r.SchemaVersion) == "" {
 		return errors.New("schema_version is required")
 	}
-	if r.Type != LiveContinuityReportType {
-		return fmt.Errorf("type must be %q", LiveContinuityReportType)
+	if !isAcceptedReportType(r.Type, LiveContinuityReportType, VoiceyLiveContinuityReportType) {
+		return fmt.Errorf("type must be %q or %q", LiveContinuityReportType, VoiceyLiveContinuityReportType)
 	}
 	switch r.Status {
 	case "passed", "warn", "failed", "degraded":

--- a/backend/internal/voiceartifacts/live_continuity_report_test.go
+++ b/backend/internal/voiceartifacts/live_continuity_report_test.go
@@ -60,6 +60,20 @@ func TestLiveContinuityReportAcceptsGenericType(t *testing.T) {
 	}
 }
 
+func TestLiveContinuityReportNormalizesType(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeLiveContinuityReport(t, path, validLiveContinuityReport(" "+LiveContinuityReportType+" "))
+
+	report, err := LoadLiveContinuityReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Type != LiveContinuityReportType {
+		t.Fatalf("type was not normalized: %q", report.Type)
+	}
+}
+
 func TestLiveContinuityReportAcceptsLegacyVoiceyType(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "report.json")

--- a/backend/internal/voiceartifacts/live_continuity_report_test.go
+++ b/backend/internal/voiceartifacts/live_continuity_report_test.go
@@ -13,7 +13,7 @@ func TestLoadLiveContinuityReport(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if report.Type != LiveContinuityReportType {
+	if report.Type != VoiceyLiveContinuityReportType {
 		t.Fatalf("type = %q", report.Type)
 	}
 	evidence := report.TimingEvidence()
@@ -47,6 +47,36 @@ func TestIngestLiveContinuityReport(t *testing.T) {
 	}
 	if len(report.Raw) == 0 {
 		t.Fatal("expected raw report copy")
+	}
+}
+
+func TestLiveContinuityReportAcceptsGenericType(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeLiveContinuityReport(t, path, validLiveContinuityReport(LiveContinuityReportType))
+
+	if _, err := LoadLiveContinuityReport(path); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLiveContinuityReportAcceptsLegacyVoiceyType(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeLiveContinuityReport(t, path, validLiveContinuityReport(VoiceyLiveContinuityReportType))
+
+	if _, err := LoadLiveContinuityReport(path); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLiveContinuityReportRejectsWrongType(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeLiveContinuityReport(t, path, validLiveContinuityReport("other.live_continuity_eval"))
+
+	if _, err := LoadLiveContinuityReport(path); err == nil {
+		t.Fatal("expected validation error")
 	}
 }
 
@@ -193,6 +223,21 @@ func TestLiveContinuityReportRejectsFractionalCount(t *testing.T) {
 func TestLiveContinuityArtifactKindIsValid(t *testing.T) {
 	if !ArtifactKindLiveContinuityReport.IsValid() {
 		t.Fatal("live continuity report artifact kind should be valid")
+	}
+}
+
+func validLiveContinuityReport(reportType string) map[string]any {
+	return map[string]any{
+		"schema_version": "2026-05-14",
+		"type":           reportType,
+		"status":         "passed",
+		"passed":         true,
+		"metrics": map[string]any{
+			"evidence_status":        "available",
+			"speech_start_count":     1,
+			"output_event_count":     1,
+			"speech_no_output_ratio": 0,
+		},
 	}
 }
 

--- a/backend/internal/voiceartifacts/source_separation_report.go
+++ b/backend/internal/voiceartifacts/source_separation_report.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 )
 
-const SourceSeparationReportType = "voicey.source_separation_eval"
+const (
+	SourceSeparationReportType       = "agentclash.voice.source_separation_eval.v1"
+	VoiceySourceSeparationReportType = "voicey.source_separation_eval"
+)
 
 type SourceSeparationReport struct {
 	SchemaVersion string            `json:"schema_version"`
@@ -66,8 +69,8 @@ func (r SourceSeparationReport) Validate() error {
 	if strings.TrimSpace(r.SchemaVersion) == "" {
 		return errors.New("schema_version is required")
 	}
-	if r.Type != SourceSeparationReportType {
-		return fmt.Errorf("type must be %q", SourceSeparationReportType)
+	if !isAcceptedReportType(r.Type, SourceSeparationReportType, VoiceySourceSeparationReportType) {
+		return fmt.Errorf("type must be %q or %q", SourceSeparationReportType, VoiceySourceSeparationReportType)
 	}
 	switch r.Status {
 	case "passed", "failed", "degraded":
@@ -125,4 +128,14 @@ func cloneFloat64(value *float64) *float64 {
 	}
 	clone := *value
 	return &clone
+}
+
+func isAcceptedReportType(value string, accepted ...string) bool {
+	value = strings.TrimSpace(value)
+	for _, candidate := range accepted {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
 }

--- a/backend/internal/voiceartifacts/source_separation_report.go
+++ b/backend/internal/voiceartifacts/source_separation_report.go
@@ -65,10 +65,11 @@ func IngestSourceSeparationReport(data []byte) (SourceSeparationReport, error) {
 	return report, nil
 }
 
-func (r SourceSeparationReport) Validate() error {
+func (r *SourceSeparationReport) Validate() error {
 	if strings.TrimSpace(r.SchemaVersion) == "" {
 		return errors.New("schema_version is required")
 	}
+	r.Type = normalizeReportType(r.Type)
 	if !isAcceptedReportType(r.Type, SourceSeparationReportType, VoiceySourceSeparationReportType) {
 		return fmt.Errorf("type must be %q or %q", SourceSeparationReportType, VoiceySourceSeparationReportType)
 	}
@@ -131,11 +132,15 @@ func cloneFloat64(value *float64) *float64 {
 }
 
 func isAcceptedReportType(value string, accepted ...string) bool {
-	value = strings.TrimSpace(value)
+	value = normalizeReportType(value)
 	for _, candidate := range accepted {
 		if value == candidate {
 			return true
 		}
 	}
 	return false
+}
+
+func normalizeReportType(value string) string {
+	return strings.TrimSpace(value)
 }

--- a/backend/internal/voiceartifacts/source_separation_report_test.go
+++ b/backend/internal/voiceartifacts/source_separation_report_test.go
@@ -60,6 +60,20 @@ func TestSourceSeparationReportAcceptsGenericType(t *testing.T) {
 	}
 }
 
+func TestSourceSeparationReportNormalizesType(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeReport(t, path, validSourceSeparationReport(" "+SourceSeparationReportType+" "))
+
+	report, err := LoadSourceSeparationReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Type != SourceSeparationReportType {
+		t.Fatalf("type was not normalized: %q", report.Type)
+	}
+}
+
 func TestSourceSeparationReportAcceptsLegacyVoiceyType(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "report.json")

--- a/backend/internal/voiceartifacts/source_separation_report_test.go
+++ b/backend/internal/voiceartifacts/source_separation_report_test.go
@@ -14,7 +14,7 @@ func TestLoadSourceSeparationReport(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if report.Type != SourceSeparationReportType {
+	if report.Type != VoiceySourceSeparationReportType {
 		t.Fatalf("type = %q", report.Type)
 	}
 	evidence := report.MediaPolicyEvidence()
@@ -47,6 +47,26 @@ func TestIngestSourceSeparationReport(t *testing.T) {
 	}
 	if len(report.Raw) == 0 {
 		t.Fatal("expected raw report copy")
+	}
+}
+
+func TestSourceSeparationReportAcceptsGenericType(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeReport(t, path, validSourceSeparationReport(SourceSeparationReportType))
+
+	if _, err := LoadSourceSeparationReport(path); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSourceSeparationReportAcceptsLegacyVoiceyType(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeReport(t, path, validSourceSeparationReport(VoiceySourceSeparationReportType))
+
+	if _, err := LoadSourceSeparationReport(path); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -152,6 +172,20 @@ func TestSourceSeparationReportAcceptsDegradedStatus(t *testing.T) {
 func TestMediaPolicyArtifactKindIsValid(t *testing.T) {
 	if !ArtifactKindMediaPolicyReport.IsValid() {
 		t.Fatal("media policy report artifact kind should be valid")
+	}
+}
+
+func validSourceSeparationReport(reportType string) map[string]any {
+	return map[string]any{
+		"schema_version": "2026-05-14",
+		"type":           reportType,
+		"status":         "passed",
+		"passed":         true,
+		"metrics": map[string]any{
+			"dialogue_retention_ratio":      0.9,
+			"background_preservation_ratio": 0.9,
+			"speech_drop_risk":              0.1,
+		},
 	}
 }
 

--- a/backend/internal/voiceartifacts/video_sync_report.go
+++ b/backend/internal/voiceartifacts/video_sync_report.go
@@ -106,7 +106,8 @@ func IngestVideoSyncReport(data []byte) (VideoSyncReport, error) {
 	return report, nil
 }
 
-func (r VideoSyncReport) Validate() error {
+func (r *VideoSyncReport) Validate() error {
+	r.Type = normalizeReportType(r.Type)
 	if strings.TrimSpace(r.Type) != "" && !isAcceptedReportType(r.Type, VideoSyncReportType, VoiceyVideoSyncReportType) {
 		return fmt.Errorf("type must be %q or %q", VideoSyncReportType, VoiceyVideoSyncReportType)
 	}

--- a/backend/internal/voiceartifacts/video_sync_report.go
+++ b/backend/internal/voiceartifacts/video_sync_report.go
@@ -9,7 +9,14 @@ import (
 	"strings"
 )
 
+const (
+	VideoSyncReportType       = "agentclash.voice.video_sync_eval.v1"
+	VoiceyVideoSyncReportType = "voicey.video_sync_eval"
+)
+
 type VideoSyncReport struct {
+	SchemaVersion      string             `json:"schema_version,omitempty"`
+	Type               string             `json:"type,omitempty"`
 	Inputs             map[string]any     `json:"inputs,omitempty"`
 	Summary            VideoSyncSummary   `json:"summary"`
 	SourceSegments     []VideoSyncSegment `json:"source_segments,omitempty"`
@@ -100,6 +107,9 @@ func IngestVideoSyncReport(data []byte) (VideoSyncReport, error) {
 }
 
 func (r VideoSyncReport) Validate() error {
+	if strings.TrimSpace(r.Type) != "" && !isAcceptedReportType(r.Type, VideoSyncReportType, VoiceyVideoSyncReportType) {
+		return fmt.Errorf("type must be %q or %q", VideoSyncReportType, VoiceyVideoSyncReportType)
+	}
 	switch r.Summary.Status {
 	case "pass", "warn", "fail":
 	default:

--- a/backend/internal/voiceartifacts/video_sync_report_test.go
+++ b/backend/internal/voiceartifacts/video_sync_report_test.go
@@ -56,6 +56,20 @@ func TestVideoSyncReportAcceptsGenericType(t *testing.T) {
 	}
 }
 
+func TestVideoSyncReportNormalizesType(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeVideoSyncReport(t, path, validVideoSyncReport(" "+VideoSyncReportType+" "))
+
+	report, err := LoadVideoSyncReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Type != VideoSyncReportType {
+		t.Fatalf("type was not normalized: %q", report.Type)
+	}
+}
+
 func TestVideoSyncReportAcceptsLegacyVoiceyType(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "report.json")

--- a/backend/internal/voiceartifacts/video_sync_report_test.go
+++ b/backend/internal/voiceartifacts/video_sync_report_test.go
@@ -46,6 +46,36 @@ func TestIngestVideoSyncReport(t *testing.T) {
 	}
 }
 
+func TestVideoSyncReportAcceptsGenericType(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeVideoSyncReport(t, path, validVideoSyncReport(VideoSyncReportType))
+
+	if _, err := LoadVideoSyncReport(path); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVideoSyncReportAcceptsLegacyVoiceyType(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeVideoSyncReport(t, path, validVideoSyncReport(VoiceyVideoSyncReportType))
+
+	if _, err := LoadVideoSyncReport(path); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVideoSyncReportRejectsWrongType(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	writeVideoSyncReport(t, path, validVideoSyncReport("other.video_sync_eval"))
+
+	if _, err := LoadVideoSyncReport(path); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
 func TestVideoSyncReportRejectsInvalidStatus(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "report.json")
@@ -306,6 +336,38 @@ func TestVideoSyncReportRejectsExtraTranslationCountWithoutTranslatedSegments(t 
 func TestVideoSyncArtifactKindIsValid(t *testing.T) {
 	if !ArtifactKindVideoSyncReport.IsValid() {
 		t.Fatal("video sync report artifact kind should be valid")
+	}
+}
+
+func validVideoSyncReport(reportType string) map[string]any {
+	return map[string]any{
+		"schema_version": "2026-05-14",
+		"type":           reportType,
+		"summary": map[string]any{
+			"status":                 "pass",
+			"interpretation":         "generic video sync report",
+			"paired_segments":        1,
+			"segment_coverage_ratio": 1,
+		},
+		"source_segments": []map[string]any{
+			{"start_ms": 0, "end_ms": 100},
+		},
+		"translated_segments": []map[string]any{
+			{"start_ms": 10, "end_ms": 110},
+		},
+		"pairs": []map[string]any{
+			{
+				"source_index":        0,
+				"translated_index":    0,
+				"source_start_ms":     0,
+				"source_end_ms":       100,
+				"translated_start_ms": 10,
+				"translated_end_ms":   110,
+				"onset_lag_ms":        10,
+				"duration_ratio":      1,
+				"status":              "paired",
+			},
+		},
 	}
 }
 

--- a/testing/codex-generic-voice-report-types.md
+++ b/testing/codex-generic-voice-report-types.md
@@ -1,0 +1,29 @@
+# Generic Voice Report Types — Test Contract
+
+## Functional Behavior
+- AgentClash voice artifact ingestion should prefer provider-neutral report `type` strings under the `agentclash.voice.*.v1` namespace.
+- Existing Voicey-produced report `type` strings must remain accepted for backwards compatibility.
+- Source-separation and live-continuity reports should reject unrelated type strings.
+- Video-sync reports should support optional `schema_version` and `type` fields: omitted fields remain valid for older reports, generic AgentClash type is valid, Voicey legacy type is valid, unrelated type is rejected.
+- Public evidence projections and artifact kinds should remain unchanged.
+
+## Unit Tests
+- `TestSourceSeparationReportAcceptsGenericType` — generic type ingests successfully.
+- `TestSourceSeparationReportAcceptsLegacyVoiceyType` — legacy Voicey type ingests successfully.
+- `TestLiveContinuityReportAcceptsGenericType` — generic type ingests successfully.
+- `TestLiveContinuityReportAcceptsLegacyVoiceyType` — legacy Voicey type ingests successfully.
+- `TestVideoSyncReportAcceptsGenericType` — generic type ingests successfully.
+- `TestVideoSyncReportAcceptsLegacyVoiceyType` — legacy Voicey type ingests successfully.
+- `TestVideoSyncReportRejectsWrongType` — unrelated type fails validation.
+
+## Integration / Functional Tests
+- `cd backend && go test ./internal/voiceartifacts ./internal/voicelive` passes.
+
+## Smoke Tests
+- N/A — backend artifact validator-only change.
+
+## E2E Tests
+- N/A — no user-facing workflow changes.
+
+## Manual / cURL Tests
+- N/A — no HTTP endpoint changes.

--- a/testing/cursor-generic-voice-report-types-review.md
+++ b/testing/cursor-generic-voice-report-types-review.md
@@ -1,0 +1,14 @@
+Cursor Composer 2 review for `codex/generic-voice-report-types`.
+
+Verdict: comment, no blockers.
+
+Notes:
+
+- Provider-neutral `agentclash.voice.*.v1` report types are wired while Voicey legacy `voicey.*` types remain accepted.
+- Existing Voicey fixtures still ingest.
+- Video-sync type/schema fields are optional for older reports; when present, type is validated.
+
+Follow-up applied:
+
+- Added `TestLiveContinuityReportRejectsWrongType` for symmetry with source separation and video sync.
+- Normalized report type comparison with `strings.TrimSpace` before allowlist matching.


### PR DESCRIPTION
## Summary
- make voice artifact report `type` contracts provider-neutral with `agentclash.voice.*.v1` values
- keep existing Voicey `voicey.*` report types accepted as legacy producer aliases
- add optional type/schema handling for video-sync reports while keeping old omitted-type reports valid

## Validation
- cd backend && go test ./internal/voiceartifacts ./internal/voicelive

## Review
- Test contract committed first: `testing/codex-generic-voice-report-types.md`
- Cursor Composer 2 review: comment, no blockers
- Follow-ups applied: live-continuity wrong-type test and trimmed type comparisons
