### PR TITLE
feat: use generic provider log metrics

### DIFF
--- a/backend/internal/voiceartifacts/video_sync_report.go
+++ b/backend/internal/voiceartifacts/video_sync_report.go
@@ -30,17 +30,18 @@ type VideoSyncReport struct {
 
 func (r *VideoSyncReport) UnmarshalJSON(data []byte) error {
 	type reportAlias VideoSyncReport
-	aux := struct {
-		*reportAlias
-		LegacyVoiceyLogMetrics map[string]any `json:"voicey_log_metrics,omitempty"`
-	}{
-		reportAlias: (*reportAlias)(r),
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	legacy := struct {
+		ProviderLogMetrics     json.RawMessage `json:"provider_log_metrics"`
+		LegacyVoiceyLogMetrics map[string]any  `json:"voicey_log_metrics,omitempty"`
+	}{}
+	if err := json.Unmarshal(data, (*reportAlias)(r)); err != nil {
 		return err
 	}
-	if r.ProviderLogMetrics == nil && aux.LegacyVoiceyLogMetrics != nil {
-		r.ProviderLogMetrics = aux.LegacyVoiceyLogMetrics
+	if err := json.Unmarshal(data, &legacy); err != nil {
+		return err
+	}
+	if len(legacy.ProviderLogMetrics) == 0 && legacy.LegacyVoiceyLogMetrics != nil {
+		r.ProviderLogMetrics = legacy.LegacyVoiceyLogMetrics
 	}
 	return nil
 }

--- a/backend/internal/voiceartifacts/video_sync_report.go
+++ b/backend/internal/voiceartifacts/video_sync_report.go
@@ -23,9 +23,26 @@ type VideoSyncReport struct {
 	TranslatedSegments []VideoSyncSegment `json:"translated_segments,omitempty"`
 	Pairs              []VideoSyncPair    `json:"pairs,omitempty"`
 	VideoSyncNote      string             `json:"video_sync_note,omitempty"`
-	VoiceyLogMetrics   map[string]any     `json:"voicey_log_metrics,omitempty"`
+	ProviderLogMetrics map[string]any     `json:"provider_log_metrics,omitempty"`
 	MouthMotionMetrics map[string]any     `json:"mouth_motion_metrics,omitempty"`
 	Raw                json.RawMessage    `json:"-"`
+}
+
+func (r *VideoSyncReport) UnmarshalJSON(data []byte) error {
+	type reportAlias VideoSyncReport
+	aux := struct {
+		*reportAlias
+		LegacyVoiceyLogMetrics map[string]any `json:"voicey_log_metrics,omitempty"`
+	}{
+		reportAlias: (*reportAlias)(r),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if r.ProviderLogMetrics == nil && aux.LegacyVoiceyLogMetrics != nil {
+		r.ProviderLogMetrics = aux.LegacyVoiceyLogMetrics
+	}
+	return nil
 }
 
 type VideoSyncSummary struct {

--- a/backend/internal/voiceartifacts/video_sync_report_test.go
+++ b/backend/internal/voiceartifacts/video_sync_report_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -87,6 +88,75 @@ func TestVideoSyncReportRejectsWrongType(t *testing.T) {
 
 	if _, err := LoadVideoSyncReport(path); err == nil {
 		t.Fatal("expected validation error")
+	}
+}
+
+func TestVideoSyncReportAcceptsProviderLogMetrics(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	report := validVideoSyncReport(VideoSyncReportType)
+	report["provider_log_metrics"] = map[string]any{"audio_input_sent": 10}
+	writeVideoSyncReport(t, path, report)
+
+	loaded, err := LoadVideoSyncReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.ProviderLogMetrics["audio_input_sent"] != float64(10) {
+		t.Fatalf("provider log metrics = %#v", loaded.ProviderLogMetrics)
+	}
+	encoded, err := json.Marshal(loaded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "voicey_log_metrics") {
+		t.Fatalf("marshal should not emit legacy voicey_log_metrics: %s", encoded)
+	}
+	if !strings.Contains(string(encoded), "provider_log_metrics") {
+		t.Fatalf("marshal should emit provider_log_metrics: %s", encoded)
+	}
+}
+
+func TestVideoSyncReportAcceptsLegacyVoiceyLogMetrics(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	report := validVideoSyncReport(VoiceyVideoSyncReportType)
+	report["voicey_log_metrics"] = map[string]any{"audio_input_sent": 10}
+	writeVideoSyncReport(t, path, report)
+
+	loaded, err := LoadVideoSyncReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.ProviderLogMetrics["audio_input_sent"] != float64(10) {
+		t.Fatalf("provider log metrics = %#v", loaded.ProviderLogMetrics)
+	}
+	encoded, err := json.Marshal(loaded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "voicey_log_metrics") {
+		t.Fatalf("marshal should not emit legacy voicey_log_metrics: %s", encoded)
+	}
+	if !strings.Contains(string(encoded), "provider_log_metrics") {
+		t.Fatalf("marshal should emit provider_log_metrics: %s", encoded)
+	}
+}
+
+func TestVideoSyncReportProviderLogMetricsWinsOverLegacy(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	report := validVideoSyncReport(VideoSyncReportType)
+	report["provider_log_metrics"] = map[string]any{"source": "generic"}
+	report["voicey_log_metrics"] = map[string]any{"source": "legacy"}
+	writeVideoSyncReport(t, path, report)
+
+	loaded, err := LoadVideoSyncReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.ProviderLogMetrics["source"] != "generic" {
+		t.Fatalf("provider log metrics = %#v", loaded.ProviderLogMetrics)
 	}
 }
 

--- a/backend/internal/voiceartifacts/video_sync_report_test.go
+++ b/backend/internal/voiceartifacts/video_sync_report_test.go
@@ -158,6 +158,40 @@ func TestVideoSyncReportProviderLogMetricsWinsOverLegacy(t *testing.T) {
 	if loaded.ProviderLogMetrics["source"] != "generic" {
 		t.Fatalf("provider log metrics = %#v", loaded.ProviderLogMetrics)
 	}
+	encoded, err := json.Marshal(loaded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "voicey_log_metrics") {
+		t.Fatalf("marshal should not emit legacy voicey_log_metrics: %s", encoded)
+	}
+	if !strings.Contains(string(encoded), "provider_log_metrics") {
+		t.Fatalf("marshal should emit provider_log_metrics: %s", encoded)
+	}
+}
+
+func TestVideoSyncReportProviderLogMetricsNullWinsOverLegacy(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	report := validVideoSyncReport(VideoSyncReportType)
+	report["provider_log_metrics"] = nil
+	report["voicey_log_metrics"] = map[string]any{"source": "legacy"}
+	writeVideoSyncReport(t, path, report)
+
+	loaded, err := LoadVideoSyncReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.ProviderLogMetrics != nil {
+		t.Fatalf("provider log metrics should honor explicit null: %#v", loaded.ProviderLogMetrics)
+	}
+	encoded, err := json.Marshal(loaded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "voicey_log_metrics") {
+		t.Fatalf("marshal should not emit legacy voicey_log_metrics: %s", encoded)
+	}
 }
 
 func TestVideoSyncReportRejectsInvalidStatus(t *testing.T) {

--- a/testing/codex-generic-provider-log-metrics.md
+++ b/testing/codex-generic-provider-log-metrics.md
@@ -1,0 +1,26 @@
+# Generic Provider Log Metrics — Test Contract
+
+## Functional Behavior
+- Video-sync reports should expose provider log metrics through a provider-neutral `provider_log_metrics` field on `VideoSyncReport`.
+- Legacy Voicey reports using `voicey_log_metrics` must continue to ingest and populate `ProviderLogMetrics`.
+- If both generic and legacy metrics are present, the generic `provider_log_metrics` field wins.
+- Marshal output should use `provider_log_metrics`; AgentClash should not emit new `voicey_log_metrics` keys.
+- Existing summary, segment, pair, and timing evidence validation behavior must remain unchanged.
+
+## Unit Tests
+- `TestVideoSyncReportAcceptsProviderLogMetrics` — generic field ingests into `ProviderLogMetrics`.
+- `TestVideoSyncReportAcceptsLegacyVoiceyLogMetrics` — legacy field ingests into `ProviderLogMetrics`.
+- `TestVideoSyncReportProviderLogMetricsWinsOverLegacy` — generic value wins when both fields exist.
+- Existing video-sync validation tests continue passing.
+
+## Integration / Functional Tests
+- `cd backend && go test ./internal/voiceartifacts ./internal/voicelive` passes.
+
+## Smoke Tests
+- N/A — backend artifact validator-only change.
+
+## E2E Tests
+- N/A — no user-facing workflow changes.
+
+## Manual / cURL Tests
+- N/A — no HTTP endpoint changes.

--- a/testing/cursor-generic-provider-log-metrics-review.md
+++ b/testing/cursor-generic-provider-log-metrics-review.md
@@ -1,0 +1,14 @@
+Cursor Composer 2 review for `codex/generic-provider-log-metrics`.
+
+Verdict: comment, no blockers.
+
+Notes:
+
+- `VideoSyncReport` now exposes provider-neutral `provider_log_metrics`.
+- Legacy `voicey_log_metrics` decodes into `ProviderLogMetrics`.
+- Generic metrics win when both generic and legacy keys are present.
+- Default marshaling emits `provider_log_metrics` and no legacy `voicey_log_metrics` field.
+
+Follow-up applied:
+
+- Added a legacy-ingest marshal assertion so old Voicey payloads are re-emitted with the generic key only.


### PR DESCRIPTION
## Summary
- replace the public video-sync `voicey_log_metrics` field with provider-neutral `provider_log_metrics`
- keep legacy `voicey_log_metrics` payloads decode-compatible by mapping them into `ProviderLogMetrics`
- ensure marshaled reports emit only `provider_log_metrics`

## Validation
- cd backend && go test ./internal/voiceartifacts ./internal/voicelive

## Review
- Test contract committed first: `testing/codex-generic-provider-log-metrics.md`
- Cursor Composer 2 review: comment, no blockers
- Follow-up applied: legacy-ingest marshal assertion
