### PR TITLE
feat: add voice report JSON schemas

### DIFF
--- a/backend/internal/voiceartifacts/schema_test.go
+++ b/backend/internal/voiceartifacts/schema_test.go
@@ -1,0 +1,251 @@
+package voiceartifacts
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+func TestVoiceReportSchemasAcceptFixtures(t *testing.T) {
+	tests := []struct {
+		name       string
+		schemaPath string
+		reportPath string
+		reportType string
+	}{
+		{
+			name:       "live continuity",
+			schemaPath: filepath.Join("..", "..", "..", "docs", "schemas", "voice-live-continuity-report.schema.json"),
+			reportPath: filepath.Join("testdata", "voicey_live_continuity_report.json"),
+			reportType: LiveContinuityReportType,
+		},
+		{
+			name:       "source separation",
+			schemaPath: filepath.Join("..", "..", "..", "docs", "schemas", "voice-source-separation-report.schema.json"),
+			reportPath: filepath.Join("testdata", "voicey_source_separation_report.json"),
+			reportType: SourceSeparationReportType,
+		},
+		{
+			name:       "video sync",
+			schemaPath: filepath.Join("..", "..", "..", "docs", "schemas", "voice-video-sync-report.schema.json"),
+			reportPath: filepath.Join("testdata", "voicey_video_sync_report.json"),
+			reportType: VideoSyncReportType,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := loadVoiceReportSchema(t, tt.schemaPath)
+			report := loadJSONDocument(t, tt.reportPath)
+
+			if err := schema.Validate(report); err != nil {
+				t.Fatalf("schema rejected fixture: %v", err)
+			}
+
+			canonical := cloneJSONMap(t, report)
+			canonical["type"] = " " + tt.reportType + " "
+			if err := schema.Validate(canonical); err != nil {
+				t.Fatalf("schema rejected canonical report type: %v", err)
+			}
+		})
+	}
+}
+
+func TestVoiceReportSchemasRejectInvalidExamples(t *testing.T) {
+	tests := []struct {
+		name       string
+		schemaPath string
+		report     map[string]any
+		errSubstr  string
+	}{
+		{
+			name:       "live continuity cannot pass with degraded evidence",
+			schemaPath: filepath.Join("..", "..", "..", "docs", "schemas", "voice-live-continuity-report.schema.json"),
+			report: map[string]any{
+				"schema_version": "2026-05-13",
+				"type":           LiveContinuityReportType,
+				"status":         "passed",
+				"passed":         true,
+				"metrics": map[string]any{
+					"evidence_status": "degraded",
+				},
+			},
+		},
+		{
+			name:       "live continuity counts must be integers",
+			schemaPath: filepath.Join("..", "..", "..", "docs", "schemas", "voice-live-continuity-report.schema.json"),
+			report: map[string]any{
+				"schema_version": "2026-05-13",
+				"type":           LiveContinuityReportType,
+				"status":         "warn",
+				"passed":         false,
+				"metrics": map[string]any{
+					"evidence_status":    "available",
+					"speech_start_count": 1.5,
+				},
+			},
+		},
+		{
+			name:       "source separation passed mirrors status",
+			schemaPath: filepath.Join("..", "..", "..", "docs", "schemas", "voice-source-separation-report.schema.json"),
+			report: map[string]any{
+				"schema_version": "2026-05-13",
+				"type":           SourceSeparationReportType,
+				"status":         "passed",
+				"passed":         false,
+				"metrics": map[string]any{
+					"dialogue_retention_ratio":      0.9,
+					"background_preservation_ratio": 0.8,
+					"speech_drop_risk":              0.1,
+				},
+			},
+		},
+		{
+			name:       "source separation ratios stay bounded",
+			schemaPath: filepath.Join("..", "..", "..", "docs", "schemas", "voice-source-separation-report.schema.json"),
+			report: map[string]any{
+				"schema_version": "2026-05-13",
+				"type":           SourceSeparationReportType,
+				"status":         "failed",
+				"passed":         false,
+				"metrics": map[string]any{
+					"dialogue_retention_ratio":      1.2,
+					"background_preservation_ratio": 0.8,
+					"speech_drop_risk":              0.1,
+				},
+			},
+		},
+		{
+			name:       "video sync requires interpretation",
+			schemaPath: filepath.Join("..", "..", "..", "docs", "schemas", "voice-video-sync-report.schema.json"),
+			report: map[string]any{
+				"type": VideoSyncReportType,
+				"summary": map[string]any{
+					"status": "fail",
+				},
+			},
+		},
+		{
+			name:       "video sync counts must be integers",
+			schemaPath: filepath.Join("..", "..", "..", "docs", "schemas", "voice-video-sync-report.schema.json"),
+			report: map[string]any{
+				"type": VideoSyncReportType,
+				"summary": map[string]any{
+					"status":          "fail",
+					"interpretation":  "fractional counts should not validate",
+					"paired_segments": 1.5,
+				},
+			},
+		},
+		{
+			name:       "video sync rejects unsupported pair status",
+			schemaPath: filepath.Join("..", "..", "..", "docs", "schemas", "voice-video-sync-report.schema.json"),
+			report: map[string]any{
+				"type": VideoSyncReportType,
+				"summary": map[string]any{
+					"status":         "fail",
+					"interpretation": "extra_translation rows are represented by translated segment counts, not pair statuses",
+				},
+				"pairs": []map[string]any{
+					{"status": "extra_translation"},
+				},
+			},
+		},
+		{
+			name:       "video sync paired rows reject null required fields",
+			schemaPath: filepath.Join("..", "..", "..", "docs", "schemas", "voice-video-sync-report.schema.json"),
+			report: map[string]any{
+				"type": VideoSyncReportType,
+				"summary": map[string]any{
+					"status":         "fail",
+					"interpretation": "paired rows need concrete timing and index values",
+				},
+				"pairs": []map[string]any{
+					{
+						"status":              "paired",
+						"source_index":        0,
+						"translated_index":    nil,
+						"source_start_ms":     100,
+						"source_end_ms":       200,
+						"translated_start_ms": 250,
+						"translated_end_ms":   350,
+						"onset_lag_ms":        150,
+						"duration_ratio":      1,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := loadVoiceReportSchema(t, tt.schemaPath)
+			data, err := json.Marshal(tt.report)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var report any
+			if err := json.Unmarshal(data, &report); err != nil {
+				t.Fatal(err)
+			}
+
+			err = schema.Validate(report)
+			if err == nil {
+				t.Fatal("expected schema validation error")
+			}
+			if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+				t.Fatalf("error %q does not contain %q", err, tt.errSubstr)
+			}
+		})
+	}
+}
+
+func loadVoiceReportSchema(t *testing.T, path string) *jsonschema.Resolved {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var schema jsonschema.Schema
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := schema.Resolve(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resolved
+}
+
+func loadJSONDocument(t *testing.T, path string) any {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document any
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatal(err)
+	}
+	return document
+}
+
+func cloneJSONMap(t *testing.T, value any) map[string]any {
+	t.Helper()
+
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cloned map[string]any
+	if err := json.Unmarshal(data, &cloned); err != nil {
+		t.Fatal(err)
+	}
+	return cloned
+}

--- a/backend/internal/voiceartifacts/schema_test.go
+++ b/backend/internal/voiceartifacts/schema_test.go
@@ -65,6 +65,7 @@ func TestVoiceReportSchemasRejectInvalidExamples(t *testing.T) {
 		{
 			name:       "live continuity cannot pass with degraded evidence",
 			schemaPath: filepath.Join("..", "..", "..", "docs", "schemas", "voice-live-continuity-report.schema.json"),
+			errSubstr:  "voice-live-continuity-report.schema.json",
 			report: map[string]any{
 				"schema_version": "2026-05-13",
 				"type":           LiveContinuityReportType,
@@ -78,6 +79,7 @@ func TestVoiceReportSchemasRejectInvalidExamples(t *testing.T) {
 		{
 			name:       "live continuity counts must be integers",
 			schemaPath: filepath.Join("..", "..", "..", "docs", "schemas", "voice-live-continuity-report.schema.json"),
+			errSubstr:  "voice-live-continuity-report.schema.json",
 			report: map[string]any{
 				"schema_version": "2026-05-13",
 				"type":           LiveContinuityReportType,
@@ -92,6 +94,7 @@ func TestVoiceReportSchemasRejectInvalidExamples(t *testing.T) {
 		{
 			name:       "source separation passed mirrors status",
 			schemaPath: filepath.Join("..", "..", "..", "docs", "schemas", "voice-source-separation-report.schema.json"),
+			errSubstr:  "voice-source-separation-report.schema.json",
 			report: map[string]any{
 				"schema_version": "2026-05-13",
 				"type":           SourceSeparationReportType,
@@ -107,6 +110,7 @@ func TestVoiceReportSchemasRejectInvalidExamples(t *testing.T) {
 		{
 			name:       "source separation ratios stay bounded",
 			schemaPath: filepath.Join("..", "..", "..", "docs", "schemas", "voice-source-separation-report.schema.json"),
+			errSubstr:  "voice-source-separation-report.schema.json",
 			report: map[string]any{
 				"schema_version": "2026-05-13",
 				"type":           SourceSeparationReportType,
@@ -122,6 +126,7 @@ func TestVoiceReportSchemasRejectInvalidExamples(t *testing.T) {
 		{
 			name:       "video sync requires interpretation",
 			schemaPath: filepath.Join("..", "..", "..", "docs", "schemas", "voice-video-sync-report.schema.json"),
+			errSubstr:  "voice-video-sync-report.schema.json",
 			report: map[string]any{
 				"type": VideoSyncReportType,
 				"summary": map[string]any{
@@ -132,6 +137,7 @@ func TestVoiceReportSchemasRejectInvalidExamples(t *testing.T) {
 		{
 			name:       "video sync counts must be integers",
 			schemaPath: filepath.Join("..", "..", "..", "docs", "schemas", "voice-video-sync-report.schema.json"),
+			errSubstr:  "voice-video-sync-report.schema.json",
 			report: map[string]any{
 				"type": VideoSyncReportType,
 				"summary": map[string]any{
@@ -144,6 +150,7 @@ func TestVoiceReportSchemasRejectInvalidExamples(t *testing.T) {
 		{
 			name:       "video sync rejects unsupported pair status",
 			schemaPath: filepath.Join("..", "..", "..", "docs", "schemas", "voice-video-sync-report.schema.json"),
+			errSubstr:  "voice-video-sync-report.schema.json",
 			report: map[string]any{
 				"type": VideoSyncReportType,
 				"summary": map[string]any{
@@ -156,8 +163,21 @@ func TestVoiceReportSchemasRejectInvalidExamples(t *testing.T) {
 			},
 		},
 		{
+			name:       "video sync rejects empty type when present",
+			schemaPath: filepath.Join("..", "..", "..", "docs", "schemas", "voice-video-sync-report.schema.json"),
+			errSubstr:  "voice-video-sync-report.schema.json",
+			report: map[string]any{
+				"type": "",
+				"summary": map[string]any{
+					"status":         "fail",
+					"interpretation": "empty type should be omitted rather than emitted",
+				},
+			},
+		},
+		{
 			name:       "video sync paired rows reject null required fields",
 			schemaPath: filepath.Join("..", "..", "..", "docs", "schemas", "voice-video-sync-report.schema.json"),
+			errSubstr:  "voice-video-sync-report.schema.json",
 			report: map[string]any{
 				"type": VideoSyncReportType,
 				"summary": map[string]any{

--- a/docs/schemas/voice-live-continuity-report.schema.json
+++ b/docs/schemas/voice-live-continuity-report.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentclash.dev/schemas/voice-live-continuity-report.schema.json",
+  "title": "AgentClash Voice Live Continuity Report",
+  "type": "object",
+  "required": ["schema_version", "type", "status", "passed", "metrics"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "type": {
+      "type": "string",
+      "pattern": "^\\s*(agentclash\\.voice\\.live_continuity_eval\\.v1|voicey\\.live_continuity_eval)\\s*$"
+    },
+    "status": {
+      "enum": ["passed", "warn", "failed", "degraded"]
+    },
+    "passed": {
+      "type": "boolean"
+    },
+    "input": {
+      "type": "string"
+    },
+    "metrics": {
+      "type": "object",
+      "required": ["evidence_status"],
+      "additionalProperties": true,
+      "properties": {
+        "speech_start_count": { "type": "integer", "minimum": 0 },
+        "speech_stop_count": { "type": "integer", "minimum": 0 },
+        "output_event_count": { "type": "integer", "minimum": 0 },
+        "evidence_status": { "enum": ["available", "degraded"] },
+        "median_first_audio_ms": { "type": "number", "minimum": 0 },
+        "p90_first_audio_ms": { "type": "number", "minimum": 0 },
+        "max_output_gap_ms": { "type": "number", "minimum": 0 },
+        "median_output_gap_ms": { "type": "number", "minimum": 0 },
+        "speech_no_output_count": { "type": "integer", "minimum": 0 },
+        "speech_no_output_ratio": { "type": "number", "minimum": 0, "maximum": 1 },
+        "speech_start_during_output_count": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "caveats": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "agentclash_notes": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "oneOf": [
+    {
+      "properties": {
+        "status": { "const": "passed" },
+        "passed": { "const": true },
+        "metrics": {
+          "properties": {
+            "evidence_status": { "const": "available" }
+          }
+        }
+      }
+    },
+    {
+      "properties": {
+        "status": { "enum": ["warn", "failed", "degraded"] },
+        "passed": { "const": false }
+      }
+    }
+  ]
+}

--- a/docs/schemas/voice-source-separation-report.schema.json
+++ b/docs/schemas/voice-source-separation-report.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentclash.dev/schemas/voice-source-separation-report.schema.json",
+  "title": "AgentClash Voice Source Separation Report",
+  "type": "object",
+  "required": ["schema_version", "type", "status", "passed", "metrics"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "type": {
+      "type": "string",
+      "pattern": "^\\s*(agentclash\\.voice\\.source_separation_eval\\.v1|voicey\\.source_separation_eval)\\s*$"
+    },
+    "status": {
+      "enum": ["passed", "failed", "degraded"]
+    },
+    "passed": {
+      "type": "boolean"
+    },
+    "metrics": {
+      "type": "object",
+      "required": ["dialogue_retention_ratio", "background_preservation_ratio", "speech_drop_risk"],
+      "additionalProperties": true,
+      "properties": {
+        "dialogue_retention_ratio": { "type": "number", "minimum": 0, "maximum": 1 },
+        "background_preservation_ratio": { "type": "number", "minimum": 0, "maximum": 1 },
+        "speech_drop_risk": { "type": "number", "minimum": 0, "maximum": 1 },
+        "background_leakage_in_dialogue_ratio": { "type": "number", "minimum": 0, "maximum": 1 },
+        "dialogue_leakage_in_background_ratio": { "type": "number", "minimum": 0, "maximum": 1 }
+      }
+    },
+    "caveats": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "agentclash_notes": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    }
+  },
+  "oneOf": [
+    {
+      "properties": {
+        "status": { "const": "passed" },
+        "passed": { "const": true }
+      }
+    },
+    {
+      "properties": {
+        "status": { "enum": ["failed", "degraded"] },
+        "passed": { "const": false }
+      }
+    }
+  ]
+}

--- a/docs/schemas/voice-video-sync-report.schema.json
+++ b/docs/schemas/voice-video-sync-report.schema.json
@@ -11,7 +11,7 @@
     },
     "type": {
       "type": "string",
-      "pattern": "^\\s*(agentclash\\.voice\\.video_sync_eval\\.v1|voicey\\.video_sync_eval)?\\s*$"
+      "pattern": "^\\s*(agentclash\\.voice\\.video_sync_eval\\.v1|voicey\\.video_sync_eval)\\s*$"
     },
     "inputs": {
       "type": "object",

--- a/docs/schemas/voice-video-sync-report.schema.json
+++ b/docs/schemas/voice-video-sync-report.schema.json
@@ -1,0 +1,180 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentclash.dev/schemas/voice-video-sync-report.schema.json",
+  "title": "AgentClash Voice Video Sync Report",
+  "type": "object",
+  "required": ["summary"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string",
+      "pattern": "^\\s*(agentclash\\.voice\\.video_sync_eval\\.v1|voicey\\.video_sync_eval)?\\s*$"
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "summary": {
+      "type": "object",
+      "required": ["status", "interpretation"],
+      "additionalProperties": true,
+      "properties": {
+        "status": { "enum": ["pass", "warn", "fail"] },
+        "status_reasons": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "status_basis_ms": { "type": "number", "minimum": 0 },
+        "first_onset_lag_ms": { "type": "number" },
+        "median_onset_lag_ms": { "type": "number" },
+        "p90_onset_lag_ms": { "type": "number" },
+        "tail_lag_ms": { "type": "number" },
+        "paired_segments": { "type": "integer", "minimum": 0 },
+        "missing_translation_segments": { "type": "integer", "minimum": 0 },
+        "extra_translation_segments": { "type": "integer", "minimum": 0 },
+        "segment_coverage_ratio": { "type": "number", "minimum": 0, "maximum": 1 },
+        "duration_fit_score": { "type": "number", "minimum": 0, "maximum": 1 },
+        "median_duration_ratio": { "type": "number", "minimum": 0 },
+        "min_duration_ratio": { "type": "number", "minimum": 0 },
+        "max_duration_ratio": { "type": "number", "minimum": 0 },
+        "source_span_ms": { "type": "number", "minimum": 0 },
+        "translated_span_ms": { "type": "number", "minimum": 0 },
+        "span_duration_ratio": { "type": "number", "minimum": 0 },
+        "warn_threshold_ms": { "type": "number", "minimum": 0 },
+        "fail_threshold_ms": { "type": "number", "minimum": 0 },
+        "warn_duration_ratio_range": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": { "type": "number", "minimum": 0 }
+        },
+        "fail_duration_ratio_range": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": { "type": "number", "minimum": 0 }
+        },
+        "interpretation": { "type": "string", "minLength": 1 }
+      }
+    },
+    "source_segments": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/segment" }
+    },
+    "translated_segments": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/segment" }
+    },
+    "pairs": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/pair" }
+    },
+    "video_sync_note": {
+      "type": "string"
+    },
+    "provider_log_metrics": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "voicey_log_metrics": {
+      "type": "object",
+      "additionalProperties": true,
+      "deprecated": true
+    },
+    "mouth_motion_metrics": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "$defs": {
+    "segment": {
+      "type": "object",
+      "required": ["start_ms", "end_ms"],
+      "additionalProperties": true,
+      "properties": {
+        "start_ms": { "type": "number", "minimum": 0 },
+        "end_ms": { "type": "number", "minimum": 0 }
+      }
+    },
+    "nullableInteger": {
+      "oneOf": [
+        { "type": "integer", "minimum": 0 },
+        { "type": "null" }
+      ]
+    },
+    "nullableNumber": {
+      "oneOf": [
+        { "type": "number" },
+        { "type": "null" }
+      ]
+    },
+    "nullableNonNegativeNumber": {
+      "oneOf": [
+        { "type": "number", "minimum": 0 },
+        { "type": "null" }
+      ]
+    },
+    "pair": {
+      "type": "object",
+      "required": ["status"],
+      "additionalProperties": true,
+      "$comment": "Cross-field ordering checks such as source_end_ms >= source_start_ms are enforced by AgentClash ingestion.",
+      "properties": {
+        "source_index": { "$ref": "#/$defs/nullableInteger" },
+        "translated_index": { "$ref": "#/$defs/nullableInteger" },
+        "source_start_ms": { "$ref": "#/$defs/nullableNonNegativeNumber" },
+        "source_end_ms": { "$ref": "#/$defs/nullableNonNegativeNumber" },
+        "translated_start_ms": { "$ref": "#/$defs/nullableNonNegativeNumber" },
+        "translated_end_ms": { "$ref": "#/$defs/nullableNonNegativeNumber" },
+        "onset_lag_ms": { "$ref": "#/$defs/nullableNumber" },
+        "duration_ratio": { "$ref": "#/$defs/nullableNonNegativeNumber" },
+        "status": { "enum": ["paired", "missing_translation"] }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "status": { "const": "paired" } },
+            "required": ["status"]
+          },
+          "then": {
+            "required": [
+              "source_index",
+              "translated_index",
+              "source_start_ms",
+              "source_end_ms",
+              "translated_start_ms",
+              "translated_end_ms",
+              "onset_lag_ms",
+              "duration_ratio"
+            ],
+            "properties": {
+              "source_index": { "type": "integer", "minimum": 0 },
+              "translated_index": { "type": "integer", "minimum": 0 },
+              "source_start_ms": { "type": "number", "minimum": 0 },
+              "source_end_ms": { "type": "number", "minimum": 0 },
+              "translated_start_ms": { "type": "number", "minimum": 0 },
+              "translated_end_ms": { "type": "number", "minimum": 0 },
+              "onset_lag_ms": { "type": "number" },
+              "duration_ratio": { "type": "number", "minimum": 0 }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "status": { "const": "missing_translation" } },
+            "required": ["status"]
+          },
+          "then": {
+            "required": ["source_index"],
+            "properties": {
+              "source_index": { "type": "integer", "minimum": 0 }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/testing/codex-voice-report-json-schemas-cursor-review.md
+++ b/testing/codex-voice-report-json-schemas-cursor-review.md
@@ -1,0 +1,19 @@
+# Cursor Review - Voice Report JSON Schemas
+
+Model: `composer-2`
+
+## First pass
+
+Cursor found one direct schema contradiction and several limits to document:
+
+- `pairs[].status` allowed `extra_translation`, but the Go video-sync validator only accepts `paired` and `missing_translation`.
+- Paired video-sync rows could satisfy the schema with required fields set to `null`, while Go requires non-nil values.
+- Segment end/start ordering, duration-range ordering, pair index bounds, and summary/pair count consistency are Go-ingestion checks that JSON Schema does not fully express here.
+
+## Fixes made
+
+- Removed `extra_translation` from the pair status enum.
+- Added conditional non-null requirements for paired rows and missing-translation `source_index`.
+- Added non-negative constraints for pair indexes and timing fields where the Go validator requires them.
+- Added docs language that schemas are producer-side preflight checks and Go ingestion remains final for cross-field/cross-row invariants.
+- Added tests for canonical generic report types, whitespace-normalized types, unsupported pair statuses, and paired rows with null required fields.

--- a/testing/codex-voice-report-json-schemas.md
+++ b/testing/codex-voice-report-json-schemas.md
@@ -1,0 +1,26 @@
+# Voice Report JSON Schemas - Test Contract
+
+## Functional Behavior
+- Add machine-readable JSON Schemas for the generic AgentClash voice report payloads:
+  - `agentclash.voice.live_continuity_eval.v1`
+  - `agentclash.voice.video_sync_eval.v1`
+  - `agentclash.voice.source_separation_eval.v1`
+- Keep schemas producer-neutral and store them with the existing schema docs under `docs/schemas`.
+- Include current legacy aliases as compatibility values where the Go validators still ingest them.
+- Encode important validator footguns: report-specific statuses, `passed`/`status` coupling, degraded evidence rule, integer counts, ratio bounds, and required interpretation/ratios.
+
+## Unit Tests
+- `TestVoiceReportSchemasAcceptFixtures` - current voice report fixtures validate against their matching schema.
+- `TestVoiceReportSchemasRejectInvalidExamples` - schemas reject known invalid edge cases.
+
+## Integration / Functional Tests
+- `cd backend && go test ./internal/voiceartifacts` passes.
+
+## Smoke Tests
+- `jq empty docs/schemas/voice-*.schema.json` passes if `jq` is available.
+
+## E2E Tests
+- N/A - schema-only platform contract change.
+
+## Manual / cURL Tests
+- N/A - no HTTP endpoint change.

--- a/web/content/docs/concepts/voice-artifact-contracts.mdx
+++ b/web/content/docs/concepts/voice-artifact-contracts.mdx
@@ -109,6 +109,18 @@ Accepted legacy aliases are:
 
 Status vocabularies are report-specific. Live continuity uses `passed`, `warn`, `failed`, or `degraded`. Source separation uses `passed`, `failed`, or `degraded`. Video sync summary uses `pass`, `warn`, or `fail`.
 
+## JSON Schemas
+
+Producers can validate reports before upload with the machine-readable schemas in `docs/schemas`:
+
+- `voice-live-continuity-report.schema.json`
+- `voice-video-sync-report.schema.json`
+- `voice-source-separation-report.schema.json`
+
+The schemas encode the common producer mistakes that are easy to miss in prose: report-specific status values, `passed`/`status` coupling, integer count fields, bounded ratios, and required interpretation text.
+
+The schemas are a producer-side preflight, not a replacement for AgentClash ingestion. The Go validators still enforce cross-field and cross-row checks such as segment end times, pair index bounds, video-sync summary counts versus pair rows, and duration-range ordering.
+
 ## Live continuity report
 
 Use live continuity reports to evaluate whether a voice agent feels realtime: first-audio latency, long output gaps, missing responses, and user speech that arrives while output is already playing.


### PR DESCRIPTION
Closes #804\n\n## Summary\n- Add machine-readable JSON Schemas for live continuity, video sync, and source separation voice reports\n- Add backend tests that validate current fixtures, canonical generic report types, whitespace-normalized type values, and invalid edge cases\n- Link the schemas from the generic voice artifact contract docs\n\n## Tests\n- cd backend && go test ./internal/voiceartifacts\n- jq empty docs/schemas/voice-live-continuity-report.schema.json docs/schemas/voice-source-separation-report.schema.json docs/schemas/voice-video-sync-report.schema.json\n- Cursor Composer 2 read-only schema review; addressed pair-status and paired-row nullability findings\n\nReview-checkpoint: testing/codex-voice-report-json-schemas.md