### PR TITLE
feat: add voice report schema preflight CLI

### DIFF
--- a/cli/cmd/artifact_voice_report.go
+++ b/cli/cmd/artifact_voice_report.go
@@ -1,0 +1,145 @@
+package cmd
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/spf13/cobra"
+)
+
+const (
+	voiceSchemaLiveContinuityFile   = "voice-live-continuity-report.schema.json"
+	voiceSchemaVideoSyncFile        = "voice-video-sync-report.schema.json"
+	voiceSchemaSourceSeparationFile = "voice-source-separation-report.schema.json"
+)
+
+//go:embed voice_schemas/*.json
+var embeddedVoiceSchemas embed.FS
+
+var artifactValidateVoiceReportSchema string
+
+func init() {
+	artifactCmd.AddCommand(artifactValidateVoiceReportCmd)
+	artifactValidateVoiceReportCmd.Flags().StringVar(&artifactValidateVoiceReportSchema, "schema", "", "JSON Schema path (required when report type cannot be auto-detected)")
+}
+
+var artifactValidateVoiceReportCmd = &cobra.Command{
+	Use:   "validate-voice-report <file>",
+	Short: "Validate a voice report JSON file against an AgentClash schema",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		result, err := validateVoiceReportFile(args[0], artifactValidateVoiceReportSchema)
+		if err != nil {
+			return err
+		}
+
+		rc := GetRunContext(cmd)
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(result)
+		}
+		rc.Output.PrintDetail("Report", result.Path)
+		rc.Output.PrintDetail("Schema", result.Schema)
+		rc.Output.PrintDetail("Valid", fmt.Sprintf("%t", result.Valid))
+		return nil
+	},
+}
+
+type voiceReportValidationResult struct {
+	Path   string `json:"path"`
+	Schema string `json:"schema"`
+	Valid  bool   `json:"valid"`
+}
+
+func validateVoiceReportFile(reportPath, schemaOverride string) (voiceReportValidationResult, error) {
+	report, err := readJSONDocument(reportPath)
+	if err != nil {
+		return voiceReportValidationResult{}, fmt.Errorf("read report: %w", err)
+	}
+
+	schemaPath := strings.TrimSpace(schemaOverride)
+	embeddedSchema := false
+	if schemaPath == "" {
+		schemaPath, err = schemaPathForVoiceReport(report)
+		if err != nil {
+			return voiceReportValidationResult{}, err
+		}
+		embeddedSchema = true
+	}
+
+	schema, err := readJSONSchema(schemaPath, embeddedSchema)
+	if err != nil {
+		return voiceReportValidationResult{}, fmt.Errorf("read schema: %w", err)
+	}
+	if err := schema.Validate(report); err != nil {
+		return voiceReportValidationResult{}, fmt.Errorf("voice report schema validation failed: %w", err)
+	}
+
+	return voiceReportValidationResult{
+		Path:   reportPath,
+		Schema: schemaPath,
+		Valid:  true,
+	}, nil
+}
+
+func schemaPathForVoiceReport(report any) (string, error) {
+	object, ok := report.(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("voice report must be a JSON object")
+	}
+	reportType, _ := object["type"].(string)
+	reportType = strings.TrimSpace(reportType)
+
+	var schemaFile string
+	switch reportType {
+	case "agentclash.voice.live_continuity_eval.v1", "voicey.live_continuity_eval":
+		schemaFile = voiceSchemaLiveContinuityFile
+	case "agentclash.voice.video_sync_eval.v1", "voicey.video_sync_eval":
+		schemaFile = voiceSchemaVideoSyncFile
+	case "agentclash.voice.source_separation_eval.v1", "voicey.source_separation_eval":
+		schemaFile = voiceSchemaSourceSeparationFile
+	case "":
+		return "", fmt.Errorf("report type is empty; pass --schema for omitted-type reports")
+	default:
+		return "", fmt.Errorf("unsupported voice report type %q; pass --schema to validate with an explicit schema", reportType)
+	}
+
+	return schemaFile, nil
+}
+
+func readJSONSchema(path string, embeddedSchema bool) (*jsonschema.Resolved, error) {
+	var (
+		data []byte
+		err  error
+	)
+	if embeddedSchema {
+		data, err = fs.ReadFile(embeddedVoiceSchemas, filepath.ToSlash(filepath.Join("voice_schemas", path)))
+	} else {
+		data, err = os.ReadFile(path)
+	}
+	if err != nil {
+		return nil, err
+	}
+	var schema jsonschema.Schema
+	if err := json.Unmarshal(data, &schema); err != nil {
+		return nil, err
+	}
+	return schema.Resolve(nil)
+}
+
+func readJSONDocument(path string) (any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var document any
+	if err := json.Unmarshal(data, &document); err != nil {
+		return nil, err
+	}
+	return document, nil
+}

--- a/cli/cmd/artifact_voice_report.go
+++ b/cli/cmd/artifact_voice_report.go
@@ -35,11 +35,16 @@ var artifactValidateVoiceReportCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		result, err := validateVoiceReportFile(args[0], artifactValidateVoiceReportSchema)
+		rc := GetRunContext(cmd)
 		if err != nil {
+			if rc.Output.IsStructured() {
+				if printErr := rc.Output.PrintRaw(result); printErr != nil {
+					return printErr
+				}
+			}
 			return err
 		}
 
-		rc := GetRunContext(cmd)
 		if rc.Output.IsStructured() {
 			return rc.Output.PrintRaw(result)
 		}
@@ -51,15 +56,19 @@ var artifactValidateVoiceReportCmd = &cobra.Command{
 }
 
 type voiceReportValidationResult struct {
-	Path   string `json:"path"`
-	Schema string `json:"schema"`
-	Valid  bool   `json:"valid"`
+	Path   string   `json:"path"`
+	Schema string   `json:"schema,omitempty"`
+	Valid  bool     `json:"valid"`
+	Errors []string `json:"errors,omitempty"`
 }
 
 func validateVoiceReportFile(reportPath, schemaOverride string) (voiceReportValidationResult, error) {
+	result := voiceReportValidationResult{Path: reportPath}
 	report, err := readJSONDocument(reportPath)
 	if err != nil {
-		return voiceReportValidationResult{}, fmt.Errorf("read report: %w", err)
+		err = fmt.Errorf("read report: %w", err)
+		result.Errors = []string{err.Error()}
+		return result, err
 	}
 
 	schemaPath := strings.TrimSpace(schemaOverride)
@@ -67,24 +76,27 @@ func validateVoiceReportFile(reportPath, schemaOverride string) (voiceReportVali
 	if schemaPath == "" {
 		schemaPath, err = schemaPathForVoiceReport(report)
 		if err != nil {
-			return voiceReportValidationResult{}, err
+			result.Errors = []string{err.Error()}
+			return result, err
 		}
 		embeddedSchema = true
 	}
+	result.Schema = schemaPath
 
 	schema, err := readJSONSchema(schemaPath, embeddedSchema)
 	if err != nil {
-		return voiceReportValidationResult{}, fmt.Errorf("read schema: %w", err)
+		err = fmt.Errorf("read schema: %w", err)
+		result.Errors = []string{err.Error()}
+		return result, err
 	}
 	if err := schema.Validate(report); err != nil {
-		return voiceReportValidationResult{}, fmt.Errorf("voice report schema validation failed: %w", err)
+		err = fmt.Errorf("voice report schema validation failed: %w", err)
+		result.Errors = []string{err.Error()}
+		return result, err
 	}
 
-	return voiceReportValidationResult{
-		Path:   reportPath,
-		Schema: schemaPath,
-		Valid:  true,
-	}, nil
+	result.Valid = true
+	return result, nil
 }
 
 func schemaPathForVoiceReport(report any) (string, error) {

--- a/cli/cmd/artifact_voice_report_test.go
+++ b/cli/cmd/artifact_voice_report_test.go
@@ -9,12 +9,22 @@ import (
 )
 
 func TestArtifactValidateVoiceReportAutoDetectsLiveContinuity(t *testing.T) {
+	reportPath := writeVoiceReportTestFile(t, map[string]any{
+		"schema_version": "2026-05-13",
+		"type":           "agentclash.voice.live_continuity_eval.v1",
+		"status":         "passed",
+		"passed":         true,
+		"metrics": map[string]any{
+			"evidence_status": "available",
+		},
+	})
+
 	stdout := captureStdout(t)
 	err := executeCommand(t, []string{
 		"--json",
 		"artifact",
 		"validate-voice-report",
-		filepath.Join("..", "..", "backend", "internal", "voiceartifacts", "testdata", "voicey_live_continuity_report.json"),
+		reportPath,
 	}, "http://unused")
 	if err != nil {
 		t.Fatalf("validate voice report error: %v", err)
@@ -33,12 +43,20 @@ func TestArtifactValidateVoiceReportAutoDetectsLiveContinuity(t *testing.T) {
 }
 
 func TestArtifactValidateVoiceReportAcceptsExplicitSchemaForOmittedType(t *testing.T) {
+	reportPath := writeVoiceReportTestFile(t, map[string]any{
+		"summary": map[string]any{
+			"status":         "fail",
+			"interpretation": "valid omitted-type video sync report",
+		},
+	})
+	schemaPath := writeEmbeddedVoiceSchema(t, voiceSchemaVideoSyncFile)
+
 	err := executeCommand(t, []string{
 		"artifact",
 		"validate-voice-report",
-		filepath.Join("..", "..", "backend", "internal", "voiceartifacts", "testdata", "voicey_video_sync_report.json"),
+		reportPath,
 		"--schema",
-		filepath.Join("..", "..", "docs", "schemas", voiceSchemaVideoSyncFile),
+		schemaPath,
 	}, "http://unused")
 	if err != nil {
 		t.Fatalf("validate voice report with explicit schema error: %v", err)
@@ -58,12 +76,24 @@ func TestArtifactValidateVoiceReportRejectsInvalidReport(t *testing.T) {
 		},
 	})
 
-	err := executeCommand(t, []string{"artifact", "validate-voice-report", path}, "http://unused")
+	stdout := captureStdout(t)
+	err := executeCommand(t, []string{"--json", "artifact", "validate-voice-report", path}, "http://unused")
 	if err == nil {
 		t.Fatal("expected invalid report error")
 	}
 	if !strings.Contains(err.Error(), "voice report schema validation failed") {
 		t.Fatalf("error = %q, want schema validation failure", err)
+	}
+	var payload map[string]any
+	if decodeErr := json.Unmarshal([]byte(stdout.finish()), &payload); decodeErr != nil {
+		t.Fatalf("failure output is not JSON: %v", decodeErr)
+	}
+	if payload["valid"] != false {
+		t.Fatalf("valid = %v, want false", payload["valid"])
+	}
+	errors, ok := payload["errors"].([]any)
+	if !ok || len(errors) == 0 {
+		t.Fatalf("errors = %#v, want at least one structured error", payload["errors"])
 	}
 }
 
@@ -89,6 +119,20 @@ func writeVoiceReportTestFile(t *testing.T, value map[string]any) string {
 		t.Fatal(err)
 	}
 	path := filepath.Join(t.TempDir(), "report.json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func writeEmbeddedVoiceSchema(t *testing.T, schemaFile string) string {
+	t.Helper()
+
+	data, err := embeddedVoiceSchemas.ReadFile(filepath.ToSlash(filepath.Join("voice_schemas", schemaFile)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), schemaFile)
 	if err := os.WriteFile(path, data, 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/cli/cmd/artifact_voice_report_test.go
+++ b/cli/cmd/artifact_voice_report_test.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestArtifactValidateVoiceReportAutoDetectsLiveContinuity(t *testing.T) {
+	stdout := captureStdout(t)
+	err := executeCommand(t, []string{
+		"--json",
+		"artifact",
+		"validate-voice-report",
+		filepath.Join("..", "..", "backend", "internal", "voiceartifacts", "testdata", "voicey_live_continuity_report.json"),
+	}, "http://unused")
+	if err != nil {
+		t.Fatalf("validate voice report error: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(stdout.finish()), &payload); err != nil {
+		t.Fatalf("output is not JSON: %v", err)
+	}
+	if payload["valid"] != true {
+		t.Fatalf("valid = %v, want true", payload["valid"])
+	}
+	if !strings.Contains(str(payload["schema"]), voiceSchemaLiveContinuityFile) {
+		t.Fatalf("schema = %v, want live continuity schema", payload["schema"])
+	}
+}
+
+func TestArtifactValidateVoiceReportAcceptsExplicitSchemaForOmittedType(t *testing.T) {
+	err := executeCommand(t, []string{
+		"artifact",
+		"validate-voice-report",
+		filepath.Join("..", "..", "backend", "internal", "voiceartifacts", "testdata", "voicey_video_sync_report.json"),
+		"--schema",
+		filepath.Join("..", "..", "docs", "schemas", voiceSchemaVideoSyncFile),
+	}, "http://unused")
+	if err != nil {
+		t.Fatalf("validate voice report with explicit schema error: %v", err)
+	}
+}
+
+func TestArtifactValidateVoiceReportRejectsInvalidReport(t *testing.T) {
+	path := writeVoiceReportTestFile(t, map[string]any{
+		"schema_version": "2026-05-13",
+		"type":           "agentclash.voice.source_separation_eval.v1",
+		"status":         "passed",
+		"passed":         false,
+		"metrics": map[string]any{
+			"dialogue_retention_ratio":      0.9,
+			"background_preservation_ratio": 0.8,
+			"speech_drop_risk":              0.1,
+		},
+	})
+
+	err := executeCommand(t, []string{"artifact", "validate-voice-report", path}, "http://unused")
+	if err == nil {
+		t.Fatal("expected invalid report error")
+	}
+	if !strings.Contains(err.Error(), "voice report schema validation failed") {
+		t.Fatalf("error = %q, want schema validation failure", err)
+	}
+}
+
+func TestArtifactValidateVoiceReportRequiresSchemaForUnknownType(t *testing.T) {
+	path := writeVoiceReportTestFile(t, map[string]any{
+		"type": "example.voice_eval",
+	})
+
+	err := executeCommand(t, []string{"artifact", "validate-voice-report", path}, "http://unused")
+	if err == nil {
+		t.Fatal("expected unsupported type error")
+	}
+	if !strings.Contains(err.Error(), "unsupported voice report type") {
+		t.Fatalf("error = %q, want unsupported type", err)
+	}
+}
+
+func writeVoiceReportTestFile(t *testing.T, value map[string]any) string {
+	t.Helper()
+
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "report.json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/cli/cmd/voice_schemas/voice-live-continuity-report.schema.json
+++ b/cli/cmd/voice_schemas/voice-live-continuity-report.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentclash.dev/schemas/voice-live-continuity-report.schema.json",
+  "title": "AgentClash Voice Live Continuity Report",
+  "type": "object",
+  "required": ["schema_version", "type", "status", "passed", "metrics"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "type": {
+      "type": "string",
+      "pattern": "^\\s*(agentclash\\.voice\\.live_continuity_eval\\.v1|voicey\\.live_continuity_eval)\\s*$"
+    },
+    "status": {
+      "enum": ["passed", "warn", "failed", "degraded"]
+    },
+    "passed": {
+      "type": "boolean"
+    },
+    "input": {
+      "type": "string"
+    },
+    "metrics": {
+      "type": "object",
+      "required": ["evidence_status"],
+      "additionalProperties": true,
+      "properties": {
+        "speech_start_count": { "type": "integer", "minimum": 0 },
+        "speech_stop_count": { "type": "integer", "minimum": 0 },
+        "output_event_count": { "type": "integer", "minimum": 0 },
+        "evidence_status": { "enum": ["available", "degraded"] },
+        "median_first_audio_ms": { "type": "number", "minimum": 0 },
+        "p90_first_audio_ms": { "type": "number", "minimum": 0 },
+        "max_output_gap_ms": { "type": "number", "minimum": 0 },
+        "median_output_gap_ms": { "type": "number", "minimum": 0 },
+        "speech_no_output_count": { "type": "integer", "minimum": 0 },
+        "speech_no_output_ratio": { "type": "number", "minimum": 0, "maximum": 1 },
+        "speech_start_during_output_count": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "caveats": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "agentclash_notes": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "oneOf": [
+    {
+      "properties": {
+        "status": { "const": "passed" },
+        "passed": { "const": true },
+        "metrics": {
+          "properties": {
+            "evidence_status": { "const": "available" }
+          }
+        }
+      }
+    },
+    {
+      "properties": {
+        "status": { "enum": ["warn", "failed", "degraded"] },
+        "passed": { "const": false }
+      }
+    }
+  ]
+}

--- a/cli/cmd/voice_schemas/voice-source-separation-report.schema.json
+++ b/cli/cmd/voice_schemas/voice-source-separation-report.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentclash.dev/schemas/voice-source-separation-report.schema.json",
+  "title": "AgentClash Voice Source Separation Report",
+  "type": "object",
+  "required": ["schema_version", "type", "status", "passed", "metrics"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "type": {
+      "type": "string",
+      "pattern": "^\\s*(agentclash\\.voice\\.source_separation_eval\\.v1|voicey\\.source_separation_eval)\\s*$"
+    },
+    "status": {
+      "enum": ["passed", "failed", "degraded"]
+    },
+    "passed": {
+      "type": "boolean"
+    },
+    "metrics": {
+      "type": "object",
+      "required": ["dialogue_retention_ratio", "background_preservation_ratio", "speech_drop_risk"],
+      "additionalProperties": true,
+      "properties": {
+        "dialogue_retention_ratio": { "type": "number", "minimum": 0, "maximum": 1 },
+        "background_preservation_ratio": { "type": "number", "minimum": 0, "maximum": 1 },
+        "speech_drop_risk": { "type": "number", "minimum": 0, "maximum": 1 },
+        "background_leakage_in_dialogue_ratio": { "type": "number", "minimum": 0, "maximum": 1 },
+        "dialogue_leakage_in_background_ratio": { "type": "number", "minimum": 0, "maximum": 1 }
+      }
+    },
+    "caveats": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "agentclash_notes": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    }
+  },
+  "oneOf": [
+    {
+      "properties": {
+        "status": { "const": "passed" },
+        "passed": { "const": true }
+      }
+    },
+    {
+      "properties": {
+        "status": { "enum": ["failed", "degraded"] },
+        "passed": { "const": false }
+      }
+    }
+  ]
+}

--- a/cli/cmd/voice_schemas/voice-video-sync-report.schema.json
+++ b/cli/cmd/voice_schemas/voice-video-sync-report.schema.json
@@ -1,0 +1,180 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentclash.dev/schemas/voice-video-sync-report.schema.json",
+  "title": "AgentClash Voice Video Sync Report",
+  "type": "object",
+  "required": ["summary"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string",
+      "pattern": "^\\s*(agentclash\\.voice\\.video_sync_eval\\.v1|voicey\\.video_sync_eval)\\s*$"
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "summary": {
+      "type": "object",
+      "required": ["status", "interpretation"],
+      "additionalProperties": true,
+      "properties": {
+        "status": { "enum": ["pass", "warn", "fail"] },
+        "status_reasons": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "status_basis_ms": { "type": "number", "minimum": 0 },
+        "first_onset_lag_ms": { "type": "number" },
+        "median_onset_lag_ms": { "type": "number" },
+        "p90_onset_lag_ms": { "type": "number" },
+        "tail_lag_ms": { "type": "number" },
+        "paired_segments": { "type": "integer", "minimum": 0 },
+        "missing_translation_segments": { "type": "integer", "minimum": 0 },
+        "extra_translation_segments": { "type": "integer", "minimum": 0 },
+        "segment_coverage_ratio": { "type": "number", "minimum": 0, "maximum": 1 },
+        "duration_fit_score": { "type": "number", "minimum": 0, "maximum": 1 },
+        "median_duration_ratio": { "type": "number", "minimum": 0 },
+        "min_duration_ratio": { "type": "number", "minimum": 0 },
+        "max_duration_ratio": { "type": "number", "minimum": 0 },
+        "source_span_ms": { "type": "number", "minimum": 0 },
+        "translated_span_ms": { "type": "number", "minimum": 0 },
+        "span_duration_ratio": { "type": "number", "minimum": 0 },
+        "warn_threshold_ms": { "type": "number", "minimum": 0 },
+        "fail_threshold_ms": { "type": "number", "minimum": 0 },
+        "warn_duration_ratio_range": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": { "type": "number", "minimum": 0 }
+        },
+        "fail_duration_ratio_range": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": { "type": "number", "minimum": 0 }
+        },
+        "interpretation": { "type": "string", "minLength": 1 }
+      }
+    },
+    "source_segments": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/segment" }
+    },
+    "translated_segments": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/segment" }
+    },
+    "pairs": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/pair" }
+    },
+    "video_sync_note": {
+      "type": "string"
+    },
+    "provider_log_metrics": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "voicey_log_metrics": {
+      "type": "object",
+      "additionalProperties": true,
+      "deprecated": true
+    },
+    "mouth_motion_metrics": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "$defs": {
+    "segment": {
+      "type": "object",
+      "required": ["start_ms", "end_ms"],
+      "additionalProperties": true,
+      "properties": {
+        "start_ms": { "type": "number", "minimum": 0 },
+        "end_ms": { "type": "number", "minimum": 0 }
+      }
+    },
+    "nullableInteger": {
+      "oneOf": [
+        { "type": "integer", "minimum": 0 },
+        { "type": "null" }
+      ]
+    },
+    "nullableNumber": {
+      "oneOf": [
+        { "type": "number" },
+        { "type": "null" }
+      ]
+    },
+    "nullableNonNegativeNumber": {
+      "oneOf": [
+        { "type": "number", "minimum": 0 },
+        { "type": "null" }
+      ]
+    },
+    "pair": {
+      "type": "object",
+      "required": ["status"],
+      "additionalProperties": true,
+      "$comment": "Cross-field ordering checks such as source_end_ms >= source_start_ms are enforced by AgentClash ingestion.",
+      "properties": {
+        "source_index": { "$ref": "#/$defs/nullableInteger" },
+        "translated_index": { "$ref": "#/$defs/nullableInteger" },
+        "source_start_ms": { "$ref": "#/$defs/nullableNonNegativeNumber" },
+        "source_end_ms": { "$ref": "#/$defs/nullableNonNegativeNumber" },
+        "translated_start_ms": { "$ref": "#/$defs/nullableNonNegativeNumber" },
+        "translated_end_ms": { "$ref": "#/$defs/nullableNonNegativeNumber" },
+        "onset_lag_ms": { "$ref": "#/$defs/nullableNumber" },
+        "duration_ratio": { "$ref": "#/$defs/nullableNonNegativeNumber" },
+        "status": { "enum": ["paired", "missing_translation"] }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "status": { "const": "paired" } },
+            "required": ["status"]
+          },
+          "then": {
+            "required": [
+              "source_index",
+              "translated_index",
+              "source_start_ms",
+              "source_end_ms",
+              "translated_start_ms",
+              "translated_end_ms",
+              "onset_lag_ms",
+              "duration_ratio"
+            ],
+            "properties": {
+              "source_index": { "type": "integer", "minimum": 0 },
+              "translated_index": { "type": "integer", "minimum": 0 },
+              "source_start_ms": { "type": "number", "minimum": 0 },
+              "source_end_ms": { "type": "number", "minimum": 0 },
+              "translated_start_ms": { "type": "number", "minimum": 0 },
+              "translated_end_ms": { "type": "number", "minimum": 0 },
+              "onset_lag_ms": { "type": "number" },
+              "duration_ratio": { "type": "number", "minimum": 0 }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "status": { "const": "missing_translation" } },
+            "required": ["status"]
+          },
+          "then": {
+            "required": ["source_index"],
+            "properties": {
+              "source_index": { "type": "integer", "minimum": 0 }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -7,7 +7,9 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/briandowns/spinner v1.23.2
 	github.com/fatih/color v1.19.0
+	github.com/google/jsonschema-go v0.3.0
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	golang.org/x/term v0.42.0
 	golang.org/x/text v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -19,6 +21,5 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.21 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 )

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -14,6 +14,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.3.0 h1:6AH2TxVNtk3IlvkkhjrtbUc4S8AvO0Xii0DxIygDg+Q=
+github.com/google/jsonschema-go v0.3.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/testing/codex-voice-schema-cli-cursor-review.md
+++ b/testing/codex-voice-schema-cli-cursor-review.md
@@ -1,0 +1,20 @@
+# Cursor Review - Voice Schema CLI
+
+Model: `composer-2`
+
+## First pass
+
+Cursor found two blockers:
+
+- `github.com/google/jsonschema-go` was imported by CLI code but listed as an indirect dependency.
+- Auto-detection looked for `docs/schemas` by walking up from the process working directory, which would fail for shipped CLI installs outside a repository checkout.
+
+## Fixes made
+
+- Promoted `github.com/google/jsonschema-go` to a direct CLI dependency and ran `go mod tidy`.
+- Embedded the three voice schemas under `cli/cmd/voice_schemas`.
+- Kept `--schema` for explicit external schemas.
+
+## Second pass
+
+Cursor reported no blockers for embedded schema packaging, module hygiene, CLI UX, hidden network/API calls, or tests.

--- a/testing/codex-voice-schema-cli.md
+++ b/testing/codex-voice-schema-cli.md
@@ -1,0 +1,27 @@
+# Voice Schema CLI - Test Contract
+
+## Functional Behavior
+- Add a CLI preflight command for validating voice report JSON files against JSON Schemas.
+- Support `agentclash artifact validate-voice-report <file>`.
+- Auto-detect schemas from report `type` for live continuity, video sync, and source separation reports.
+- Support `--schema <path>` override, especially for video-sync reports where `type` may be omitted.
+- Return success and useful output for valid reports.
+- Return non-zero with useful error output for invalid reports or unknown schema selection.
+
+## Unit Tests
+- Valid live-continuity fixture auto-detects schema and passes.
+- Valid video-sync fixture passes with explicit `--schema`.
+- Invalid report returns an error.
+- Unknown type without `--schema` returns a schema selection error.
+
+## Integration / Functional Tests
+- `cd cli && go test ./cmd` passes.
+
+## Smoke Tests
+- N/A - CLI command tested through Cobra command execution.
+
+## E2E Tests
+- N/A - local preflight command only.
+
+## Manual / cURL Tests
+- N/A - no HTTP endpoint change.


### PR DESCRIPTION
Closes #806

## Summary
- Add `agentclash artifact validate-voice-report <file>` for local voice report schema preflight
- Embed the three generic voice schemas into the CLI for shipped auto-detection
- Keep `--schema <path>` for explicit validation, including omitted-type video-sync reports
- Add CLI tests for valid auto-detect, explicit schema, invalid payload, and unknown type errors

## Tests
- cd cli && go test ./cmd
- Cursor Composer 2 read-only review: no blockers after embedding schemas and tidying module dependency

Review-checkpoint: testing/codex-voice-schema-cli.md
