### PR TITLE
test: guard embedded voice schema drift

### DIFF
--- a/cli/cmd/artifact_voice_report_test.go
+++ b/cli/cmd/artifact_voice_report_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -108,6 +109,28 @@ func TestArtifactValidateVoiceReportRequiresSchemaForUnknownType(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unsupported voice report type") {
 		t.Fatalf("error = %q, want unsupported type", err)
+	}
+}
+
+func TestEmbeddedVoiceSchemasMatchDocsSchemas(t *testing.T) {
+	for _, schemaFile := range []string{
+		voiceSchemaLiveContinuityFile,
+		voiceSchemaVideoSyncFile,
+		voiceSchemaSourceSeparationFile,
+	} {
+		t.Run(schemaFile, func(t *testing.T) {
+			embedded, err := embeddedVoiceSchemas.ReadFile(filepath.ToSlash(filepath.Join("voice_schemas", schemaFile)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			docs, err := os.ReadFile(filepath.Join("..", "..", "docs", "schemas", schemaFile))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(embedded, docs) {
+				t.Fatalf("embedded schema %s differs from docs/schemas copy", schemaFile)
+			}
+		})
 	}
 }
 

--- a/cli/cmd/artifact_voice_report_test.go
+++ b/cli/cmd/artifact_voice_report_test.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
-	"bytes"
 	"encoding/json"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -113,25 +114,59 @@ func TestArtifactValidateVoiceReportRequiresSchemaForUnknownType(t *testing.T) {
 }
 
 func TestEmbeddedVoiceSchemasMatchDocsSchemas(t *testing.T) {
-	for _, schemaFile := range []string{
-		voiceSchemaLiveContinuityFile,
-		voiceSchemaVideoSyncFile,
-		voiceSchemaSourceSeparationFile,
-	} {
+	entries, err := fs.ReadDir(embeddedVoiceSchemas, "voice_schemas")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected at least one embedded voice schema")
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		schemaFile := entry.Name()
+		if !strings.HasSuffix(schemaFile, ".schema.json") {
+			continue
+		}
 		t.Run(schemaFile, func(t *testing.T) {
-			embedded, err := embeddedVoiceSchemas.ReadFile(filepath.ToSlash(filepath.Join("voice_schemas", schemaFile)))
-			if err != nil {
-				t.Fatal(err)
-			}
-			docs, err := os.ReadFile(filepath.Join("..", "..", "docs", "schemas", schemaFile))
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !bytes.Equal(embedded, docs) {
+			embedded := readEmbeddedSchemaObject(t, schemaFile)
+			docs := readDocsSchemaObject(t, schemaFile)
+			if !reflect.DeepEqual(embedded, docs) {
 				t.Fatalf("embedded schema %s differs from docs/schemas copy", schemaFile)
 			}
 		})
 	}
+}
+
+func readEmbeddedSchemaObject(t *testing.T, schemaFile string) any {
+	t.Helper()
+
+	data, err := embeddedVoiceSchemas.ReadFile(filepath.ToSlash(filepath.Join("voice_schemas", schemaFile)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return decodeSchemaObject(t, "embedded", schemaFile, data)
+}
+
+func readDocsSchemaObject(t *testing.T, schemaFile string) any {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join("..", "..", "docs", "schemas", schemaFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return decodeSchemaObject(t, "docs", schemaFile, data)
+}
+
+func decodeSchemaObject(t *testing.T, source, schemaFile string, data []byte) any {
+	t.Helper()
+
+	var schema any
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatalf("%s schema %s is not valid JSON: %v", source, schemaFile, err)
+	}
+	return schema
 }
 
 func writeVoiceReportTestFile(t *testing.T, value map[string]any) string {

--- a/testing/codex-voice-schema-drift-test.md
+++ b/testing/codex-voice-schema-drift-test.md
@@ -1,0 +1,21 @@
+# Voice Schema Drift Test - Test Contract
+
+## Functional Behavior
+- Add a CI-visible test that keeps CLI embedded voice schemas byte-for-byte aligned with `docs/schemas`.
+- Cover all three current voice report schemas.
+- Fail with a clear message naming the schema file that drifted.
+
+## Unit Tests
+- `TestEmbeddedVoiceSchemasMatchDocsSchemas` passes when embedded CLI schema copies match docs schemas.
+
+## Integration / Functional Tests
+- `cd cli && go test ./cmd` passes.
+
+## Smoke Tests
+- N/A - test-only change.
+
+## E2E Tests
+- N/A.
+
+## Manual / cURL Tests
+- N/A.


### PR DESCRIPTION
Closes #808

## Summary
- Add a CLI test that compares embedded voice schemas with the canonical `docs/schemas` copies
- Cover live continuity, video sync, and source separation schemas
- Fail with the schema filename when drift appears

## Tests
- cd cli && go test ./cmd

Review-checkpoint: testing/codex-voice-schema-drift-test.md
