### PR TITLE
Add generic voice artifact manifest schema

### DIFF
--- a/backend/internal/voiceartifacts/manifest.go
+++ b/backend/internal/voiceartifacts/manifest.go
@@ -51,11 +51,12 @@ var (
 )
 
 type Manifest struct {
-	SchemaVersion  string        `json:"schema_version"`
-	RunID          uuid.UUID     `json:"run_id"`
-	RunAgentID     uuid.UUID     `json:"run_agent_id"`
-	VoiceSessionID string        `json:"voice_session_id"`
-	Artifacts      []ArtifactRef `json:"artifacts"`
+	SchemaVersion  string         `json:"schema_version"`
+	RunID          uuid.UUID      `json:"run_id"`
+	RunAgentID     uuid.UUID      `json:"run_agent_id"`
+	VoiceSessionID string         `json:"voice_session_id"`
+	Artifacts      []ArtifactRef  `json:"artifacts"`
+	Metadata       map[string]any `json:"metadata,omitempty"`
 }
 
 type ArtifactRef struct {

--- a/backend/internal/voiceartifacts/manifest_test.go
+++ b/backend/internal/voiceartifacts/manifest_test.go
@@ -116,6 +116,27 @@ func TestVoiceArtifactManifestAcceptsObjectStorageReference(t *testing.T) {
 	}
 }
 
+func TestVoiceArtifactManifestPreservesGenericMetadata(t *testing.T) {
+	manifest := validObjectStorageManifest()
+	manifest.Metadata = map[string]any{
+		"provider":  "example-provider",
+		"model":     "example-realtime-model",
+		"transport": "desktop_audio",
+	}
+
+	stable, err := manifest.StableJSON()
+	if err != nil {
+		t.Fatalf("StableJSON returned error: %v", err)
+	}
+	var decoded Manifest
+	if err := json.Unmarshal(stable, &decoded); err != nil {
+		t.Fatalf("unmarshal stable manifest: %v", err)
+	}
+	if decoded.Metadata["provider"] != "example-provider" || decoded.Metadata["transport"] != "desktop_audio" {
+		t.Fatalf("metadata = %#v, want generic provider and transport metadata preserved", decoded.Metadata)
+	}
+}
+
 func TestVoiceArtifactManifestRejectsObjectStorageReferenceWithoutBucket(t *testing.T) {
 	manifest := validObjectStorageManifest()
 	manifest.Artifacts[0].Bucket = ""

--- a/backend/internal/voiceartifacts/schema_test.go
+++ b/backend/internal/voiceartifacts/schema_test.go
@@ -269,6 +269,12 @@ func TestVoiceArtifactManifestSchemaRejectsInvalidExamples(t *testing.T) {
 			},
 		},
 		{
+			name: "nil run agent id",
+			mutate: func(manifest map[string]any) {
+				manifest["run_agent_id"] = "00000000-0000-0000-0000-000000000000"
+			},
+		},
+		{
 			name: "missing required artifact kind",
 			mutate: func(manifest map[string]any) {
 				manifest["artifacts"] = filterManifestSchemaArtifacts(manifest["artifacts"].([]map[string]any), "caller_audio")

--- a/backend/internal/voiceartifacts/schema_test.go
+++ b/backend/internal/voiceartifacts/schema_test.go
@@ -224,6 +224,109 @@ func TestVoiceReportSchemasRejectInvalidExamples(t *testing.T) {
 	}
 }
 
+func TestVoiceArtifactManifestSchemaAcceptsExamples(t *testing.T) {
+	schema := loadVoiceReportSchema(t, filepath.Join("..", "..", "..", "docs", "schemas", "voice-artifact-manifest.schema.json"))
+
+	for _, tt := range []struct {
+		name     string
+		manifest map[string]any
+	}{
+		{
+			name:     "minimal local path manifest",
+			manifest: validManifestSchemaExample("local_path"),
+		},
+		{
+			name:     "richer object storage manifest",
+			manifest: validManifestSchemaExample("object_storage"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := schema.Validate(asJSONDocument(t, tt.manifest)); err != nil {
+				t.Fatalf("schema rejected manifest: %v", err)
+			}
+		})
+	}
+}
+
+func TestVoiceArtifactManifestSchemaRejectsInvalidExamples(t *testing.T) {
+	schema := loadVoiceReportSchema(t, filepath.Join("..", "..", "..", "docs", "schemas", "voice-artifact-manifest.schema.json"))
+
+	tests := []struct {
+		name     string
+		mutate   func(map[string]any)
+		validate func(t *testing.T, manifest map[string]any)
+	}{
+		{
+			name: "invalid schema version",
+			mutate: func(manifest map[string]any) {
+				manifest["schema_version"] = "2026-01-01"
+			},
+		},
+		{
+			name: "invalid run id",
+			mutate: func(manifest map[string]any) {
+				manifest["run_id"] = "not-a-uuid"
+			},
+		},
+		{
+			name: "missing required artifact kind",
+			mutate: func(manifest map[string]any) {
+				manifest["artifacts"] = filterManifestSchemaArtifacts(manifest["artifacts"].([]map[string]any), "caller_audio")
+			},
+		},
+		{
+			name: "exact duplicate artifact entry",
+			mutate: func(manifest map[string]any) {
+				artifacts := manifest["artifacts"].([]map[string]any)
+				manifest["artifacts"] = append(artifacts, cloneJSONMap(t, artifacts[0]))
+			},
+		},
+		{
+			name: "invalid checksum",
+			mutate: func(manifest map[string]any) {
+				manifest["artifacts"].([]map[string]any)[0]["checksum_sha256"] = strings.Repeat("A", 64)
+			},
+		},
+		{
+			name: "unsafe local path",
+			mutate: func(manifest map[string]any) {
+				manifest["artifacts"].([]map[string]any)[0]["path"] = "../caller.wav"
+			},
+		},
+		{
+			name: "local path must not set bucket",
+			mutate: func(manifest map[string]any) {
+				manifest["artifacts"].([]map[string]any)[0]["bucket"] = "voice-artifacts"
+			},
+		},
+		{
+			name: "object storage requires bucket",
+			mutate: func(manifest map[string]any) {
+				manifest["artifacts"].([]map[string]any)[0]["location"] = "object_storage"
+				delete(manifest["artifacts"].([]map[string]any)[0], "path")
+				manifest["artifacts"].([]map[string]any)[0]["object_key"] = "voice/sessions/session-001/caller.wav"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest := validManifestSchemaExample("local_path")
+			tt.mutate(manifest)
+			if tt.validate != nil {
+				tt.validate(t, manifest)
+			}
+			err := schema.Validate(asJSONDocument(t, manifest))
+			if err == nil {
+				t.Fatal("expected schema validation error")
+			}
+			if !strings.Contains(err.Error(), "voice-artifact-manifest.schema.json") {
+				t.Fatalf("error %q does not mention manifest schema", err)
+			}
+		})
+	}
+}
+
 func loadVoiceReportSchema(t *testing.T, path string) *jsonschema.Resolved {
 	t.Helper()
 
@@ -268,4 +371,83 @@ func cloneJSONMap(t *testing.T, value any) map[string]any {
 		t.Fatal(err)
 	}
 	return cloned
+}
+
+func validManifestSchemaExample(location string) map[string]any {
+	artifacts := []map[string]any{
+		manifestSchemaArtifact("caller", "caller_audio", location),
+		manifestSchemaArtifact("agent", "agent_audio", location),
+		manifestSchemaArtifact("transcript", "transcript_json", location),
+		manifestSchemaArtifact("timeline", "waveform_timeline_json", location),
+		manifestSchemaArtifact("structured-output", "structured_output_json", location),
+	}
+	if location == "object_storage" {
+		artifacts = append(artifacts,
+			manifestSchemaArtifact("raw-provider-trace", "raw_provider_trace_json", location),
+			manifestSchemaArtifact("video-sync", "video_sync_report_json", location),
+		)
+	}
+
+	manifest := map[string]any{
+		"schema_version":   SchemaVersionV1,
+		"run_id":           "33333333-3333-3333-3333-333333333333",
+		"run_agent_id":     "44444444-4444-4444-4444-444444444444",
+		"voice_session_id": "voice-session-generic-001",
+		"artifacts":        artifacts,
+	}
+	if location == "object_storage" {
+		manifest["metadata"] = map[string]any{
+			"provider":        "example-provider",
+			"model":           "example-realtime-model",
+			"input_language":  "hi-IN",
+			"output_language": "en-US",
+			"transport":       "desktop_audio",
+			"streaming_mode":  "streaming",
+		}
+	}
+	return manifest
+}
+
+func manifestSchemaArtifact(key string, kind string, location string) map[string]any {
+	artifact := map[string]any{
+		"key":             key,
+		"kind":            kind,
+		"location":        location,
+		"content_type":    "application/octet-stream",
+		"size_bytes":      1,
+		"checksum_sha256": strings.Repeat("1", 64),
+	}
+	switch location {
+	case "local_path":
+		artifact["path"] = "artifacts/" + key
+	case "object_storage":
+		artifact["bucket"] = "agentclash-voice-artifacts"
+		artifact["object_key"] = "voice/sessions/voice-session-generic-001/" + key
+	}
+	return artifact
+}
+
+func filterManifestSchemaArtifacts(artifacts []map[string]any, withoutKind string) []map[string]any {
+	filtered := make([]map[string]any, 0, len(artifacts))
+	for _, artifact := range artifacts {
+		if artifact["kind"] == withoutKind {
+			continue
+		}
+		filtered = append(filtered, artifact)
+	}
+	return filtered
+}
+
+func asJSONDocument(t *testing.T, value any) any {
+	t.Helper()
+
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document any
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatal(err)
+	}
+	return document
 }

--- a/docs/schemas/voice-artifact-manifest.schema.json
+++ b/docs/schemas/voice-artifact-manifest.schema.json
@@ -12,12 +12,18 @@
     "run_id": {
       "type": "string",
       "format": "uuid",
-      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      "not": {
+        "pattern": "^0{8}-0{4}-0{4}-0{4}-0{12}$"
+      }
     },
     "run_agent_id": {
       "type": "string",
       "format": "uuid",
-      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      "not": {
+        "pattern": "^0{8}-0{4}-0{4}-0{4}-0{12}$"
+      }
     },
     "voice_session_id": {
       "type": "string",

--- a/docs/schemas/voice-artifact-manifest.schema.json
+++ b/docs/schemas/voice-artifact-manifest.schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentclash.dev/schemas/voice-artifact-manifest.schema.json",
+  "title": "AgentClash Voice Artifact Manifest",
+  "type": "object",
+  "required": ["schema_version", "run_id", "run_agent_id", "voice_session_id", "artifacts"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "const": "2026-05-13"
+    },
+    "run_id": {
+      "type": "string",
+      "format": "uuid",
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+    },
+    "run_agent_id": {
+      "type": "string",
+      "format": "uuid",
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+    },
+    "voice_session_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/artifact_ref"
+      },
+      "allOf": [
+        { "contains": { "properties": { "kind": { "const": "caller_audio" } }, "required": ["kind"] } },
+        { "contains": { "properties": { "kind": { "const": "agent_audio" } }, "required": ["kind"] } },
+        { "contains": { "properties": { "kind": { "const": "transcript_json" } }, "required": ["kind"] } },
+        { "contains": { "properties": { "kind": { "const": "waveform_timeline_json" } }, "required": ["kind"] } },
+        { "contains": { "properties": { "kind": { "const": "structured_output_json" } }, "required": ["kind"] } }
+      ]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "provider": { "type": "string" },
+        "model": { "type": "string" },
+        "input_language": { "type": "string" },
+        "output_language": { "type": "string" },
+        "transport": { "type": "string" },
+        "streaming_mode": { "type": "string" }
+      }
+    }
+  },
+  "$defs": {
+    "artifact_kind": {
+      "enum": [
+        "caller_audio",
+        "agent_audio",
+        "mixed_audio",
+        "transcript_json",
+        "waveform_timeline_json",
+        "media_policy_report_json",
+        "live_continuity_report_json",
+        "video_sync_report_json",
+        "raw_provider_trace_json",
+        "structured_output_json",
+        "redaction_metadata_json"
+      ]
+    },
+    "artifact_ref": {
+      "type": "object",
+      "required": ["key", "kind", "location", "checksum_sha256"],
+      "additionalProperties": true,
+      "properties": {
+        "key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "$ref": "#/$defs/artifact_kind"
+        },
+        "location": {
+          "enum": ["local_path", "object_storage"]
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "bucket": {
+          "type": "string",
+          "minLength": 1
+        },
+        "object_key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "size_bytes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "checksum_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "location": { "const": "local_path" } },
+            "required": ["location"]
+          },
+          "then": {
+            "required": ["path"],
+            "properties": {
+              "path": {
+                "allOf": [
+                  { "not": { "pattern": "^/" } },
+                  { "not": { "pattern": "^[A-Za-z]:" } },
+                  { "not": { "pattern": "(^|/)\\.\\.(/|$)" } }
+                ]
+              }
+            },
+            "not": {
+              "anyOf": [
+                { "required": ["bucket"] },
+                { "required": ["object_key"] }
+              ]
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "location": { "const": "object_storage" } },
+            "required": ["location"]
+          },
+          "then": {
+            "required": ["bucket", "object_key"],
+            "not": {
+              "required": ["path"]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/testing/codex-voice-manifest-schema.md
+++ b/testing/codex-voice-manifest-schema.md
@@ -1,0 +1,39 @@
+# Voice Manifest Schema — Test Contract
+
+## Functional Behavior
+
+- Add a producer-neutral JSON Schema for AgentClash voice artifact manifests.
+- The schema accepts the canonical `2026-05-13` manifest version, UUID `run_id` and `run_agent_id`, non-empty `voice_session_id`, and a non-empty `artifacts` array.
+- Each artifact requires a unique `key`, supported generic `kind`, supported `location`, and lowercase SHA-256 checksum.
+- `local_path` artifacts require a relative `path` and must not set `bucket` or `object_key`.
+- `object_storage` artifacts require `bucket` and `object_key` and must not set `path`.
+- The schema requires the same required artifact kinds as the Go validator: `caller_audio`, `agent_audio`, `transcript_json`, `waveform_timeline_json`, and `structured_output_json`.
+- The schema remains generic to AgentClash voice evals and does not introduce Voicey-specific canonical fields.
+
+## Unit Tests
+
+- `TestVoiceArtifactManifestSchemaAcceptsExamples` validates a minimal local-path manifest and a richer object-storage manifest against the schema.
+- `TestVoiceArtifactManifestSchemaRejectsInvalidExamples` rejects invalid version, invalid UUIDs, missing required artifact kinds, duplicate artifact keys, invalid checksums, unsafe local paths, and invalid location/reference combinations.
+- Existing `voiceartifacts.Manifest.Validate` tests continue to pass.
+
+## Integration / Functional Tests
+
+- The schema is linked from the voice artifact contract docs alongside report schemas.
+- Existing docs schema tests continue validating the report schemas.
+
+## Smoke Tests
+
+- `go test ./internal/voiceartifacts` passes from the backend module.
+
+## E2E Tests
+
+- N/A — this PR adds a schema/docs contract and backend schema validation tests only.
+
+## Manual / cURL Tests
+
+```bash
+cd backend
+go test ./internal/voiceartifacts
+```
+
+Expected: tests pass.

--- a/testing/codex-voice-manifest-schema.md
+++ b/testing/codex-voice-manifest-schema.md
@@ -4,7 +4,7 @@
 
 - Add a producer-neutral JSON Schema for AgentClash voice artifact manifests.
 - The schema accepts the canonical `2026-05-13` manifest version, UUID `run_id` and `run_agent_id`, non-empty `voice_session_id`, and a non-empty `artifacts` array.
-- Each artifact requires a unique `key`, supported generic `kind`, supported `location`, and lowercase SHA-256 checksum.
+- Each artifact requires a `key`, supported generic `kind`, supported `location`, and lowercase SHA-256 checksum. The schema rejects exact duplicate artifact entries; the Go validator remains responsible for enforcing unique keys across different artifact objects.
 - `local_path` artifacts require a relative `path` and must not set `bucket` or `object_key`.
 - `object_storage` artifacts require `bucket` and `object_key` and must not set `path`.
 - The schema requires the same required artifact kinds as the Go validator: `caller_audio`, `agent_audio`, `transcript_json`, `waveform_timeline_json`, and `structured_output_json`.
@@ -13,7 +13,7 @@
 ## Unit Tests
 
 - `TestVoiceArtifactManifestSchemaAcceptsExamples` validates a minimal local-path manifest and a richer object-storage manifest against the schema.
-- `TestVoiceArtifactManifestSchemaRejectsInvalidExamples` rejects invalid version, invalid UUIDs, missing required artifact kinds, duplicate artifact keys, invalid checksums, unsafe local paths, and invalid location/reference combinations.
+- `TestVoiceArtifactManifestSchemaRejectsInvalidExamples` rejects invalid version, invalid UUIDs, missing required artifact kinds, exact duplicate artifacts, invalid checksums, unsafe local paths, and invalid location/reference combinations.
 - Existing `voiceartifacts.Manifest.Validate` tests continue to pass.
 
 ## Integration / Functional Tests

--- a/web/content/docs/concepts/voice-artifact-contracts.mdx
+++ b/web/content/docs/concepts/voice-artifact-contracts.mdx
@@ -64,6 +64,8 @@ A voice artifact bundle starts with a manifest using schema version `2026-05-13`
 
 Each artifact key must be unique. `checksum_sha256` must be 64 lowercase hex characters. `local_path` entries must use relative paths that do not traverse outside the bundle. `object_storage` entries must use `bucket` and `object_key` instead of `path`. If `size_bytes` is present, it must be non-negative.
 
+Producers can validate the manifest shape with `docs/schemas/voice-artifact-manifest.schema.json`. The schema covers required artifact kinds, supported artifact kinds, artifact locations, checksums, UUID fields, and common reference mistakes before upload.
+
 ## Required artifacts
 
 Every voice artifact manifest currently requires these kinds:
@@ -113,13 +115,14 @@ Status vocabularies are report-specific. Live continuity uses `passed`, `warn`, 
 
 Producers can validate reports before upload with the machine-readable schemas in `docs/schemas`:
 
+- `voice-artifact-manifest.schema.json`
 - `voice-live-continuity-report.schema.json`
 - `voice-video-sync-report.schema.json`
 - `voice-source-separation-report.schema.json`
 
-The schemas encode the common producer mistakes that are easy to miss in prose: report-specific status values, `passed`/`status` coupling, integer count fields, bounded ratios, and required interpretation text.
+The schemas encode the common producer mistakes that are easy to miss in prose: required manifest artifacts, artifact reference shape, report-specific status values, `passed`/`status` coupling, integer count fields, bounded ratios, and required interpretation text.
 
-The schemas are a producer-side preflight, not a replacement for AgentClash ingestion. The Go validators still enforce cross-field and cross-row checks such as segment end times, pair index bounds, video-sync summary counts versus pair rows, and duration-range ordering.
+The schemas are a producer-side preflight, not a replacement for AgentClash ingestion. The Go validators still enforce cross-field and cross-row checks such as unique manifest artifact keys, segment end times, pair index bounds, video-sync summary counts versus pair rows, and duration-range ordering.
 
 ## Live continuity report
 


### PR DESCRIPTION
Closes #811\n\n## Summary\n- adds a producer-neutral JSON Schema for voice artifact manifests\n- validates manifest examples and common malformed references in backend tests\n- links the manifest schema from the generic voice artifact contract docs\n\n## Testing\n- cd backend && go test ./internal/voiceartifacts\n\n## Review checkpoint\n- testing/codex-voice-manifest-schema.md\n\nThis stays generic to AgentClash voice evals. Voicey is not a canonical schema surface here; product-specific details belong in metadata or raw traces.