### PR TITLE
Add CLI validation for voice artifact manifests

### DIFF
--- a/cli/cmd/artifact_voice_report.go
+++ b/cli/cmd/artifact_voice_report.go
@@ -14,6 +14,7 @@ import (
 )
 
 const (
+	voiceSchemaManifestFile         = "voice-artifact-manifest.schema.json"
 	voiceSchemaLiveContinuityFile   = "voice-live-continuity-report.schema.json"
 	voiceSchemaVideoSyncFile        = "voice-video-sync-report.schema.json"
 	voiceSchemaSourceSeparationFile = "voice-source-separation-report.schema.json"
@@ -26,6 +27,7 @@ var artifactValidateVoiceReportSchema string
 
 func init() {
 	artifactCmd.AddCommand(artifactValidateVoiceReportCmd)
+	artifactCmd.AddCommand(artifactValidateVoiceManifestCmd)
 	artifactValidateVoiceReportCmd.Flags().StringVar(&artifactValidateVoiceReportSchema, "schema", "", "JSON Schema path (required when report type cannot be auto-detected)")
 }
 
@@ -55,11 +57,65 @@ var artifactValidateVoiceReportCmd = &cobra.Command{
 	},
 }
 
+var artifactValidateVoiceManifestCmd = &cobra.Command{
+	Use:   "validate-voice-manifest <file>",
+	Short: "Validate a voice artifact manifest JSON file against the AgentClash schema",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		result, err := validateVoiceManifestFile(args[0])
+		rc := GetRunContext(cmd)
+		if err != nil {
+			if rc.Output.IsStructured() {
+				if printErr := rc.Output.PrintRaw(result); printErr != nil {
+					return printErr
+				}
+			}
+			return err
+		}
+
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(result)
+		}
+		rc.Output.PrintDetail("Manifest", result.Path)
+		rc.Output.PrintDetail("Schema", result.Schema)
+		rc.Output.PrintDetail("Valid", fmt.Sprintf("%t", result.Valid))
+		return nil
+	},
+}
+
 type voiceReportValidationResult struct {
 	Path   string   `json:"path"`
 	Schema string   `json:"schema,omitempty"`
 	Valid  bool     `json:"valid"`
 	Errors []string `json:"errors,omitempty"`
+}
+
+func validateVoiceManifestFile(manifestPath string) (voiceReportValidationResult, error) {
+	result := voiceReportValidationResult{
+		Path:   manifestPath,
+		Schema: voiceSchemaManifestFile,
+	}
+	manifest, err := readJSONDocument(manifestPath)
+	if err != nil {
+		err = fmt.Errorf("read manifest: %w", err)
+		result.Errors = []string{err.Error()}
+		return result, err
+	}
+
+	schema, err := readJSONSchema(voiceSchemaManifestFile, true)
+	if err != nil {
+		err = fmt.Errorf("read schema: %w", err)
+		result.Errors = []string{err.Error()}
+		return result, err
+	}
+	if err := schema.Validate(manifest); err != nil {
+		err = fmt.Errorf("voice manifest schema validation failed: %w", err)
+		result.Errors = []string{err.Error()}
+		return result, err
+	}
+
+	result.Valid = true
+	return result, nil
 }
 
 func validateVoiceReportFile(reportPath, schemaOverride string) (voiceReportValidationResult, error) {

--- a/cli/cmd/artifact_voice_report.go
+++ b/cli/cmd/artifact_voice_report.go
@@ -83,15 +83,15 @@ var artifactValidateVoiceManifestCmd = &cobra.Command{
 	},
 }
 
-type voiceReportValidationResult struct {
+type voiceSchemaValidationResult struct {
 	Path   string   `json:"path"`
 	Schema string   `json:"schema,omitempty"`
 	Valid  bool     `json:"valid"`
 	Errors []string `json:"errors,omitempty"`
 }
 
-func validateVoiceManifestFile(manifestPath string) (voiceReportValidationResult, error) {
-	result := voiceReportValidationResult{
+func validateVoiceManifestFile(manifestPath string) (voiceSchemaValidationResult, error) {
+	result := voiceSchemaValidationResult{
 		Path:   manifestPath,
 		Schema: voiceSchemaManifestFile,
 	}
@@ -118,8 +118,8 @@ func validateVoiceManifestFile(manifestPath string) (voiceReportValidationResult
 	return result, nil
 }
 
-func validateVoiceReportFile(reportPath, schemaOverride string) (voiceReportValidationResult, error) {
-	result := voiceReportValidationResult{Path: reportPath}
+func validateVoiceReportFile(reportPath, schemaOverride string) (voiceSchemaValidationResult, error) {
+	result := voiceSchemaValidationResult{Path: reportPath}
 	report, err := readJSONDocument(reportPath)
 	if err != nil {
 		err = fmt.Errorf("read report: %w", err)

--- a/cli/cmd/artifact_voice_report_test.go
+++ b/cli/cmd/artifact_voice_report_test.go
@@ -140,28 +140,50 @@ func TestArtifactValidateVoiceManifestAcceptsValidManifest(t *testing.T) {
 }
 
 func TestArtifactValidateVoiceManifestRejectsInvalidManifest(t *testing.T) {
-	manifest := validVoiceManifestTestDocument()
-	manifest["run_id"] = "00000000-0000-0000-0000-000000000000"
-	path := writeVoiceReportTestFile(t, manifest)
+	tests := []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{
+			name: "nil run id",
+			mutate: func(manifest map[string]any) {
+				manifest["run_id"] = "00000000-0000-0000-0000-000000000000"
+			},
+		},
+		{
+			name: "missing required caller audio artifact",
+			mutate: func(manifest map[string]any) {
+				manifest["artifacts"] = filterVoiceManifestArtifacts(manifest["artifacts"].([]map[string]any), "caller_audio")
+			},
+		},
+	}
 
-	stdout := captureStdout(t)
-	err := executeCommand(t, []string{"--json", "artifact", "validate-voice-manifest", path}, "http://unused")
-	if err == nil {
-		t.Fatal("expected invalid manifest error")
-	}
-	if !strings.Contains(err.Error(), "voice manifest schema validation failed") {
-		t.Fatalf("error = %q, want manifest schema validation failure", err)
-	}
-	var payload map[string]any
-	if decodeErr := json.Unmarshal([]byte(stdout.finish()), &payload); decodeErr != nil {
-		t.Fatalf("failure output is not JSON: %v", decodeErr)
-	}
-	if payload["valid"] != false {
-		t.Fatalf("valid = %v, want false", payload["valid"])
-	}
-	errors, ok := payload["errors"].([]any)
-	if !ok || len(errors) == 0 {
-		t.Fatalf("errors = %#v, want at least one structured error", payload["errors"])
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest := validVoiceManifestTestDocument()
+			tt.mutate(manifest)
+			path := writeVoiceReportTestFile(t, manifest)
+
+			stdout := captureStdout(t)
+			err := executeCommand(t, []string{"--json", "artifact", "validate-voice-manifest", path}, "http://unused")
+			if err == nil {
+				t.Fatal("expected invalid manifest error")
+			}
+			if !strings.Contains(err.Error(), "voice manifest schema validation failed") {
+				t.Fatalf("error = %q, want manifest schema validation failure", err)
+			}
+			var payload map[string]any
+			if decodeErr := json.Unmarshal([]byte(stdout.finish()), &payload); decodeErr != nil {
+				t.Fatalf("failure output is not JSON: %v", decodeErr)
+			}
+			if payload["valid"] != false {
+				t.Fatalf("valid = %v, want false", payload["valid"])
+			}
+			errors, ok := payload["errors"].([]any)
+			if !ok || len(errors) == 0 {
+				t.Fatalf("errors = %#v, want at least one structured error", payload["errors"])
+			}
+		})
 	}
 }
 
@@ -251,6 +273,17 @@ func voiceManifestArtifact(key string, kind string) map[string]any {
 		"size_bytes":      1,
 		"checksum_sha256": strings.Repeat("1", 64),
 	}
+}
+
+func filterVoiceManifestArtifacts(artifacts []map[string]any, withoutKind string) []map[string]any {
+	filtered := make([]map[string]any, 0, len(artifacts))
+	for _, artifact := range artifacts {
+		if artifact["kind"] == withoutKind {
+			continue
+		}
+		filtered = append(filtered, artifact)
+	}
+	return filtered
 }
 
 func writeVoiceReportTestFile(t *testing.T, value map[string]any) string {

--- a/cli/cmd/artifact_voice_report_test.go
+++ b/cli/cmd/artifact_voice_report_test.go
@@ -113,6 +113,58 @@ func TestArtifactValidateVoiceReportRequiresSchemaForUnknownType(t *testing.T) {
 	}
 }
 
+func TestArtifactValidateVoiceManifestAcceptsValidManifest(t *testing.T) {
+	manifestPath := writeVoiceReportTestFile(t, validVoiceManifestTestDocument())
+
+	stdout := captureStdout(t)
+	err := executeCommand(t, []string{
+		"--json",
+		"artifact",
+		"validate-voice-manifest",
+		manifestPath,
+	}, "http://unused")
+	if err != nil {
+		t.Fatalf("validate voice manifest error: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(stdout.finish()), &payload); err != nil {
+		t.Fatalf("output is not JSON: %v", err)
+	}
+	if payload["valid"] != true {
+		t.Fatalf("valid = %v, want true", payload["valid"])
+	}
+	if !strings.Contains(str(payload["schema"]), voiceSchemaManifestFile) {
+		t.Fatalf("schema = %v, want manifest schema", payload["schema"])
+	}
+}
+
+func TestArtifactValidateVoiceManifestRejectsInvalidManifest(t *testing.T) {
+	manifest := validVoiceManifestTestDocument()
+	manifest["run_id"] = "00000000-0000-0000-0000-000000000000"
+	path := writeVoiceReportTestFile(t, manifest)
+
+	stdout := captureStdout(t)
+	err := executeCommand(t, []string{"--json", "artifact", "validate-voice-manifest", path}, "http://unused")
+	if err == nil {
+		t.Fatal("expected invalid manifest error")
+	}
+	if !strings.Contains(err.Error(), "voice manifest schema validation failed") {
+		t.Fatalf("error = %q, want manifest schema validation failure", err)
+	}
+	var payload map[string]any
+	if decodeErr := json.Unmarshal([]byte(stdout.finish()), &payload); decodeErr != nil {
+		t.Fatalf("failure output is not JSON: %v", decodeErr)
+	}
+	if payload["valid"] != false {
+		t.Fatalf("valid = %v, want false", payload["valid"])
+	}
+	errors, ok := payload["errors"].([]any)
+	if !ok || len(errors) == 0 {
+		t.Fatalf("errors = %#v, want at least one structured error", payload["errors"])
+	}
+}
+
 func TestEmbeddedVoiceSchemasMatchDocsSchemas(t *testing.T) {
 	entries, err := fs.ReadDir(embeddedVoiceSchemas, "voice_schemas")
 	if err != nil {
@@ -167,6 +219,38 @@ func decodeSchemaObject(t *testing.T, source, schemaFile string, data []byte) an
 		t.Fatalf("%s schema %s is not valid JSON: %v", source, schemaFile, err)
 	}
 	return schema
+}
+
+func validVoiceManifestTestDocument() map[string]any {
+	return map[string]any{
+		"schema_version":   "2026-05-13",
+		"run_id":           "33333333-3333-3333-3333-333333333333",
+		"run_agent_id":     "44444444-4444-4444-4444-444444444444",
+		"voice_session_id": "voice-session-cli-001",
+		"metadata": map[string]any{
+			"provider": "example-provider",
+			"model":    "example-realtime-model",
+		},
+		"artifacts": []map[string]any{
+			voiceManifestArtifact("caller", "caller_audio"),
+			voiceManifestArtifact("agent", "agent_audio"),
+			voiceManifestArtifact("transcript", "transcript_json"),
+			voiceManifestArtifact("timeline", "waveform_timeline_json"),
+			voiceManifestArtifact("structured-output", "structured_output_json"),
+		},
+	}
+}
+
+func voiceManifestArtifact(key string, kind string) map[string]any {
+	return map[string]any{
+		"key":             key,
+		"kind":            kind,
+		"location":        "local_path",
+		"path":            "artifacts/" + key,
+		"content_type":    "application/octet-stream",
+		"size_bytes":      1,
+		"checksum_sha256": strings.Repeat("1", 64),
+	}
 }
 
 func writeVoiceReportTestFile(t *testing.T, value map[string]any) string {

--- a/cli/cmd/voice_schemas/voice-artifact-manifest.schema.json
+++ b/cli/cmd/voice_schemas/voice-artifact-manifest.schema.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentclash.dev/schemas/voice-artifact-manifest.schema.json",
+  "title": "AgentClash Voice Artifact Manifest",
+  "type": "object",
+  "required": ["schema_version", "run_id", "run_agent_id", "voice_session_id", "artifacts"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "const": "2026-05-13"
+    },
+    "run_id": {
+      "type": "string",
+      "format": "uuid",
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      "not": {
+        "pattern": "^0{8}-0{4}-0{4}-0{4}-0{12}$"
+      }
+    },
+    "run_agent_id": {
+      "type": "string",
+      "format": "uuid",
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      "not": {
+        "pattern": "^0{8}-0{4}-0{4}-0{4}-0{12}$"
+      }
+    },
+    "voice_session_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/artifact_ref"
+      },
+      "allOf": [
+        { "contains": { "properties": { "kind": { "const": "caller_audio" } }, "required": ["kind"] } },
+        { "contains": { "properties": { "kind": { "const": "agent_audio" } }, "required": ["kind"] } },
+        { "contains": { "properties": { "kind": { "const": "transcript_json" } }, "required": ["kind"] } },
+        { "contains": { "properties": { "kind": { "const": "waveform_timeline_json" } }, "required": ["kind"] } },
+        { "contains": { "properties": { "kind": { "const": "structured_output_json" } }, "required": ["kind"] } }
+      ]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "provider": { "type": "string" },
+        "model": { "type": "string" },
+        "input_language": { "type": "string" },
+        "output_language": { "type": "string" },
+        "transport": { "type": "string" },
+        "streaming_mode": { "type": "string" }
+      }
+    }
+  },
+  "$defs": {
+    "artifact_kind": {
+      "enum": [
+        "caller_audio",
+        "agent_audio",
+        "mixed_audio",
+        "transcript_json",
+        "waveform_timeline_json",
+        "media_policy_report_json",
+        "live_continuity_report_json",
+        "video_sync_report_json",
+        "raw_provider_trace_json",
+        "structured_output_json",
+        "redaction_metadata_json"
+      ]
+    },
+    "artifact_ref": {
+      "type": "object",
+      "required": ["key", "kind", "location", "checksum_sha256"],
+      "additionalProperties": true,
+      "properties": {
+        "key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "$ref": "#/$defs/artifact_kind"
+        },
+        "location": {
+          "enum": ["local_path", "object_storage"]
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "bucket": {
+          "type": "string",
+          "minLength": 1
+        },
+        "object_key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content_type": {
+          "type": "string"
+        },
+        "size_bytes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "checksum_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "location": { "const": "local_path" } },
+            "required": ["location"]
+          },
+          "then": {
+            "required": ["path"],
+            "properties": {
+              "path": {
+                "allOf": [
+                  { "not": { "pattern": "^/" } },
+                  { "not": { "pattern": "^[A-Za-z]:" } },
+                  { "not": { "pattern": "(^|/)\\.\\.(/|$)" } }
+                ]
+              }
+            },
+            "not": {
+              "anyOf": [
+                { "required": ["bucket"] },
+                { "required": ["object_key"] }
+              ]
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "location": { "const": "object_storage" } },
+            "required": ["location"]
+          },
+          "then": {
+            "required": ["bucket", "object_key"],
+            "not": {
+              "required": ["path"]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/testing/codex-voice-manifest-cli.md
+++ b/testing/codex-voice-manifest-cli.md
@@ -1,0 +1,39 @@
+# Voice Manifest CLI — Test Contract
+
+## Functional Behavior
+
+- Add `agentclash artifact validate-voice-manifest <file>` for local producer preflight.
+- The command validates a JSON manifest against the generic AgentClash `voice-artifact-manifest.schema.json`.
+- The schema is embedded in the CLI so validation works outside an AgentClash repository checkout.
+- Human output prints the manifest path, schema, and validity for successful validation.
+- `--json` output emits `{ "path": "...", "schema": "...", "valid": true }` on success.
+- Validation failures return a nonzero exit and, with `--json`, emit `{ "valid": false, "errors": [...] }`.
+- The command remains producer-neutral and does not introduce Voicey-specific flags, aliases, or fields.
+
+## Unit Tests
+
+- `TestArtifactValidateVoiceManifestAcceptsValidManifest` validates a complete local-path manifest through the CLI.
+- `TestArtifactValidateVoiceManifestRejectsInvalidManifest` rejects an invalid manifest and returns structured JSON failure output.
+- `TestEmbeddedVoiceSchemasMatchDocsSchemas` continues to catch drift for every embedded voice schema, including the manifest schema.
+
+## Integration / Functional Tests
+
+- The manifest schema is copied into `cli/cmd/voice_schemas` and is covered by the embedded-vs-docs drift test.
+- The voice artifact contract docs mention the CLI preflight command.
+
+## Smoke Tests
+
+- `cd cli && go test ./cmd` passes.
+
+## E2E Tests
+
+- N/A — this is an offline CLI validation command.
+
+## Manual / cURL Tests
+
+```bash
+cd cli
+go test ./cmd
+```
+
+Expected: tests pass.

--- a/web/content/docs/concepts/voice-artifact-contracts.mdx
+++ b/web/content/docs/concepts/voice-artifact-contracts.mdx
@@ -66,6 +66,12 @@ Each artifact key must be unique. `checksum_sha256` must be 64 lowercase hex cha
 
 Producers can validate the manifest shape with `docs/schemas/voice-artifact-manifest.schema.json`. The schema covers required artifact kinds, supported artifact kinds, artifact locations, checksums, UUID fields, and common reference mistakes before upload.
 
+The CLI can run the same preflight without requiring a repository checkout:
+
+```bash
+agentclash artifact validate-voice-manifest ./voice_artifact_manifest.json
+```
+
 ## Required artifacts
 
 Every voice artifact manifest currently requires these kinds:

--- a/web/content/docs/concepts/voice-artifact-contracts.mdx
+++ b/web/content/docs/concepts/voice-artifact-contracts.mdx
@@ -64,6 +64,8 @@ A voice artifact bundle starts with a manifest using schema version `2026-05-13`
 
 Each artifact key must be unique. `checksum_sha256` must be 64 lowercase hex characters. `local_path` entries must use relative paths that do not traverse outside the bundle. `object_storage` entries must use `bucket` and `object_key` instead of `path`. If `size_bytes` is present, it must be non-negative.
 
+Some checksum tools print uppercase hex. Normalize those values to lowercase before writing the manifest so schema preflight and AgentClash ingestion agree.
+
 Producers can validate the manifest shape with `docs/schemas/voice-artifact-manifest.schema.json`. The schema covers required artifact kinds, supported artifact kinds, artifact locations, checksums, UUID fields, and common reference mistakes before upload.
 
 The CLI can run the same preflight without requiring a repository checkout:


### PR DESCRIPTION
Closes #813

## Summary
- adds `agentclash artifact validate-voice-manifest <file>`
- embeds the generic voice artifact manifest schema in the CLI
- adds CLI tests for valid manifests, invalid manifests, structured JSON failures, and embedded schema drift
- documents the manifest preflight command in the generic voice artifact contract docs

## Testing
- cd cli && go test ./cmd

## Review checkpoint
- testing/codex-voice-manifest-cli.md

This is producer-neutral AgentClash voice-eval infrastructure; it does not add Voicey-specific flags or schema fields.
