### PR TITLE
feat(challengepack): per-case {{placeholder}} templating for test_command (#840)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ testing/codex-issue-324-promote-failure-dialog.md
 
 # Local agent checkpoint/test contracts. Existing tracked files remain tracked.
 testing/
+!testing/feat-case-templating-840.md

--- a/backend/internal/challengepack/case_template.go
+++ b/backend/internal/challengepack/case_template.go
@@ -45,7 +45,10 @@ func decodeCaseTemplatePayload(payload json.RawMessage) (map[string]any, error) 
 	}
 
 	var stored StoredCaseDocument
-	if err := json.Unmarshal(payload, &stored); err == nil && (stored.SchemaVersion > 0 || len(stored.Inputs) > 0 || len(stored.Expectations) > 0) {
+	if err := json.Unmarshal(payload, &stored); err == nil && stored.SchemaVersion != 0 {
+		if stored.Payload == nil {
+			return map[string]any{}, nil
+		}
 		return cloneObject(stored.Payload), nil
 	}
 
@@ -135,15 +138,19 @@ func RenderCaseTemplateLenient(template string, ctx CaseTemplateContext) string 
 
 // ValidateCaseTemplate ensures every placeholder in template resolves in ctx.
 func ValidateCaseTemplate(template string, ctx CaseTemplateContext, fieldPath string) error {
+	var errs ValidationErrors
 	for _, placeholder := range ExtractCaseTemplatePlaceholders(template) {
 		if _, ok, err := resolveCaseTemplatePath(placeholder, ctx); err != nil {
-			return ValidationError{Field: fieldPath, Message: err.Error()}
+			errs = append(errs, ValidationError{Field: fieldPath, Message: err.Error()})
 		} else if !ok {
-			return ValidationError{
+			errs = append(errs, ValidationError{
 				Field:   fieldPath,
 				Message: fmt.Sprintf("unresolved placeholder {{%s}} for case template context", placeholder),
-			}
+			})
 		}
+	}
+	if len(errs) > 0 {
+		return errs
 	}
 	return nil
 }

--- a/backend/internal/challengepack/case_template.go
+++ b/backend/internal/challengepack/case_template.go
@@ -1,0 +1,219 @@
+package challengepack
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var caseTemplatePattern = regexp.MustCompile(`\{\{\s*([A-Za-z_][A-Za-z0-9_.]*)\s*\}\}`)
+
+// CaseTemplateContext holds per-case values available to {{placeholder}} rendering.
+type CaseTemplateContext map[string]any
+
+// BuildCaseTemplateContext merges case payload and inputs. Input keys override payload keys.
+func BuildCaseTemplateContext(payload map[string]any, inputs []CaseInput) CaseTemplateContext {
+	ctx := CaseTemplateContext{}
+	for key, value := range payload {
+		ctx[key] = cloneCaseTemplateValue(value)
+	}
+	for _, input := range inputs {
+		key := strings.TrimSpace(input.Key)
+		if key == "" {
+			continue
+		}
+		if value, ok := caseInputTemplateValue(input); ok {
+			ctx[key] = value
+		}
+	}
+	return ctx
+}
+
+// BuildCaseTemplateContextFromPayload decodes a stored case payload blob then merges inputs.
+func BuildCaseTemplateContextFromPayload(payload json.RawMessage, inputs []CaseInput) (CaseTemplateContext, error) {
+	decoded, err := decodeCaseTemplatePayload(payload)
+	if err != nil {
+		return nil, err
+	}
+	return BuildCaseTemplateContext(decoded, inputs), nil
+}
+
+func decodeCaseTemplatePayload(payload json.RawMessage) (map[string]any, error) {
+	if len(payload) == 0 {
+		return map[string]any{}, nil
+	}
+
+	var stored StoredCaseDocument
+	if err := json.Unmarshal(payload, &stored); err == nil && (stored.SchemaVersion > 0 || len(stored.Inputs) > 0 || len(stored.Expectations) > 0) {
+		return cloneObject(stored.Payload), nil
+	}
+
+	var object map[string]any
+	if err := json.Unmarshal(payload, &object); err != nil {
+		return nil, fmt.Errorf("decode case payload: %w", err)
+	}
+	return object, nil
+}
+
+func caseInputTemplateValue(input CaseInput) (any, bool) {
+	if input.Value == nil {
+		return nil, false
+	}
+	return cloneCaseTemplateValue(input.Value), true
+}
+
+// ExtractCaseTemplatePlaceholders returns unique placeholder paths in template order of first appearance.
+func ExtractCaseTemplatePlaceholders(template string) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0)
+	for _, match := range caseTemplatePattern.FindAllStringSubmatch(template, -1) {
+		if len(match) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(match[1])
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, key)
+	}
+	return out
+}
+
+// RenderCaseTemplate replaces {{placeholders}} using ctx. Unresolved placeholders return an error.
+func RenderCaseTemplate(template string, ctx CaseTemplateContext) (string, error) {
+	var firstErr error
+	rendered := caseTemplatePattern.ReplaceAllStringFunc(template, func(match string) string {
+		groups := caseTemplatePattern.FindStringSubmatch(match)
+		if len(groups) != 2 {
+			return match
+		}
+		value, ok, err := resolveCaseTemplatePath(groups[1], ctx)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			return match
+		}
+		if !ok {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("unresolved placeholder {{%s}}", strings.TrimSpace(groups[1]))
+			}
+			return match
+		}
+		return formatCaseTemplateValue(value)
+	})
+	if firstErr != nil {
+		return rendered, firstErr
+	}
+	return rendered, nil
+}
+
+// FindUnresolvedCaseTemplateLiterals returns {{...}} tokens still present after lenient rendering.
+func FindUnresolvedCaseTemplateLiterals(rendered string) []string {
+	return caseTemplatePattern.FindAllString(rendered, -1)
+}
+
+// RenderCaseTemplateLenient replaces known placeholders and leaves unknown {{tokens}} literal.
+func RenderCaseTemplateLenient(template string, ctx CaseTemplateContext) string {
+	return caseTemplatePattern.ReplaceAllStringFunc(template, func(match string) string {
+		groups := caseTemplatePattern.FindStringSubmatch(match)
+		if len(groups) != 2 {
+			return match
+		}
+		value, ok, err := resolveCaseTemplatePath(groups[1], ctx)
+		if err != nil || !ok {
+			return match
+		}
+		return formatCaseTemplateValue(value)
+	})
+}
+
+// ValidateCaseTemplate ensures every placeholder in template resolves in ctx.
+func ValidateCaseTemplate(template string, ctx CaseTemplateContext, fieldPath string) error {
+	for _, placeholder := range ExtractCaseTemplatePlaceholders(template) {
+		if _, ok, err := resolveCaseTemplatePath(placeholder, ctx); err != nil {
+			return ValidationError{Field: fieldPath, Message: err.Error()}
+		} else if !ok {
+			return ValidationError{
+				Field:   fieldPath,
+				Message: fmt.Sprintf("unresolved placeholder {{%s}} for case template context", placeholder),
+			}
+		}
+	}
+	return nil
+}
+
+func resolveCaseTemplatePath(path string, ctx CaseTemplateContext) (any, bool, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, false, fmt.Errorf("empty placeholder path")
+	}
+	segments := strings.Split(path, ".")
+	current := any(ctx)
+	for _, segment := range segments {
+		segment = strings.TrimSpace(segment)
+		if segment == "" {
+			return nil, false, fmt.Errorf("invalid placeholder path %q", path)
+		}
+		object, ok := current.(map[string]any)
+		if !ok {
+			if typed, isCaseCtx := current.(CaseTemplateContext); isCaseCtx {
+				object = map[string]any(typed)
+			} else {
+				return nil, false, nil
+			}
+		}
+		next, exists := object[segment]
+		if !exists {
+			return nil, false, nil
+		}
+		current = next
+	}
+	return current, true, nil
+}
+
+func formatCaseTemplateValue(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case bool:
+		if typed {
+			return "true"
+		}
+		return "false"
+	case int:
+		return fmt.Sprintf("%d", typed)
+	case int32:
+		return fmt.Sprintf("%d", typed)
+	case int64:
+		return fmt.Sprintf("%d", typed)
+	case float64:
+		return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%f", typed), "0"), ".")
+	default:
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return fmt.Sprintf("%v", value)
+		}
+		return string(encoded)
+	}
+}
+
+func cloneCaseTemplateValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneObject(typed)
+	case []any:
+		cloned := make([]any, len(typed))
+		for i, item := range typed {
+			cloned[i] = cloneCaseTemplateValue(item)
+		}
+		return cloned
+	default:
+		return typed
+	}
+}

--- a/backend/internal/challengepack/case_template_test.go
+++ b/backend/internal/challengepack/case_template_test.go
@@ -1,0 +1,173 @@
+package challengepack
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/scoring"
+)
+
+func TestBuildCaseTemplateContext_MergesPayloadAndInputs(t *testing.T) {
+	ctx := BuildCaseTemplateContext(map[string]any{
+		"order_id": "from-payload",
+		"nested": map[string]any{
+			"id": "payload-nested",
+		},
+	}, []CaseInput{
+		{Key: "order_id", Kind: "text", Value: "from-input"},
+		{Key: "language", Kind: "text", Value: "French"},
+	})
+
+	if ctx["order_id"] != "from-input" {
+		t.Fatalf("order_id = %v, want from-input", ctx["order_id"])
+	}
+	if ctx["language"] != "French" {
+		t.Fatalf("language = %v, want French", ctx["language"])
+	}
+	nested, ok := ctx["nested"].(map[string]any)
+	if !ok || nested["id"] != "payload-nested" {
+		t.Fatalf("nested.id = %#v, want payload-nested", ctx["nested"])
+	}
+}
+
+func TestRenderCaseTemplate_ResolvesTopLevelAndNestedPaths(t *testing.T) {
+	ctx := BuildCaseTemplateContext(map[string]any{
+		"order_id": "ord-1",
+		"customer": map[string]any{
+			"id": "cust-9",
+		},
+	}, nil)
+
+	got, err := RenderCaseTemplate("pytest tests/test_{{order_id}}.py --customer {{customer.id}}", ctx)
+	if err != nil {
+		t.Fatalf("RenderCaseTemplate returned error: %v", err)
+	}
+	want := "pytest tests/test_ord-1.py --customer cust-9"
+	if got != want {
+		t.Fatalf("rendered = %q, want %q", got, want)
+	}
+}
+
+func TestRenderCaseTemplate_StrictMissingKey(t *testing.T) {
+	_, err := RenderCaseTemplate("echo {{missing}}", CaseTemplateContext{})
+	if err == nil {
+		t.Fatal("expected error for missing placeholder")
+	}
+	if !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("error = %v, want missing placeholder mention", err)
+	}
+}
+
+func TestRenderCaseTemplateLenient_LeavesUnresolved(t *testing.T) {
+	got := RenderCaseTemplateLenient("echo {{missing}}", CaseTemplateContext{})
+	if got != "echo {{missing}}" {
+		t.Fatalf("rendered = %q, want literal placeholder preserved", got)
+	}
+}
+
+func TestExtractCaseTemplatePlaceholders(t *testing.T) {
+	keys := ExtractCaseTemplatePlaceholders("{{order_id}} and {{customer.id}} and {{order_id}}")
+	if len(keys) != 2 || keys[0] != "order_id" || keys[1] != "customer.id" {
+		t.Fatalf("keys = %#v, want [order_id customer.id]", keys)
+	}
+}
+
+func TestValidateBundleCaseTemplates_RejectsUnresolvedPlaceholder(t *testing.T) {
+	errs := validateBundleCaseTemplates(caseTemplateTestBundle(`pytest {{missing}}`))
+	if len(errs) == 0 {
+		t.Fatal("expected validation errors")
+	}
+	if !strings.Contains(errs.Error(), "missing") {
+		t.Fatalf("error = %v, want unresolved placeholder", errs)
+	}
+}
+
+func TestValidateBundleCaseTemplates_AcceptsResolvedPlaceholder(t *testing.T) {
+	errs := validateBundleCaseTemplates(caseTemplateTestBundle(`pytest {{order_id}}`))
+	if len(errs) > 0 {
+		t.Fatalf("validateBundleCaseTemplates returned errors: %v", errs)
+	}
+}
+
+func TestValidateBundle_AcceptsCaseTemplateTestCommand(t *testing.T) {
+	bundle := caseTemplateTestBundle(`pytest tests/test_{{order_id}}.py`)
+	bundle.Version.EvaluationSpec.PostExecutionChecks = []scoring.PostExecutionCheck{
+		{Key: "generated_code", Type: scoring.PostExecutionCheckTypeFileCapture, Path: "/workspace/app.py"},
+	}
+	if err := ValidateBundle(bundle); err != nil {
+		t.Fatalf("ValidateBundle returned error: %v", err)
+	}
+}
+
+func TestBuildCaseTemplateContextFromPayload_StoredCaseDocument(t *testing.T) {
+	payload, err := json.Marshal(StoredCaseDocument{
+		SchemaVersion: 1,
+		CaseKey:       "case-1",
+		Payload:       map[string]any{"order_id": "stored"},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	ctx, err := BuildCaseTemplateContextFromPayload(payload, nil)
+	if err != nil {
+		t.Fatalf("BuildCaseTemplateContextFromPayload returned error: %v", err)
+	}
+	rendered, err := RenderCaseTemplate("echo {{order_id}}", ctx)
+	if err != nil {
+		t.Fatalf("RenderCaseTemplate returned error: %v", err)
+	}
+	if rendered != "echo stored" {
+		t.Fatalf("rendered = %q, want echo stored", rendered)
+	}
+}
+
+func caseTemplateTestBundle(testCommand string) Bundle {
+	bundle := Bundle{
+		Pack: PackMetadata{Slug: "demo", Name: "Demo", Family: "demo"},
+		Version: VersionMetadata{
+			Number: 1,
+			EvaluationSpec: scoring.EvaluationSpec{
+				Name:          "demo",
+				VersionNumber: 1,
+				JudgeMode:     scoring.JudgeModeDeterministic,
+				Validators: []scoring.ValidatorDeclaration{
+					{
+						Key:    "tests",
+						Type:   scoring.ValidatorTypeCodeExecution,
+						Target: "file:generated_code",
+						Config: json.RawMessage(`{"test_command":` + jsonString(testCommand) + `,"scoring":"all_or_nothing"}`),
+					},
+				},
+				Scorecard: scoring.ScorecardDeclaration{
+					Dimensions: []scoring.DimensionDeclaration{{Key: scoring.ScorecardDimensionCorrectness}},
+				},
+			},
+		},
+		Challenges: []ChallengeDefinition{
+			{Key: "c1", Title: "C1", Category: "demo", Difficulty: "easy"},
+		},
+		InputSets: []InputSetDefinition{
+			{
+				Key:  "default",
+				Name: "Default",
+				Cases: []CaseDefinition{
+					{
+						ChallengeKey: "c1",
+						CaseKey:      "case-1",
+						Payload:      map[string]any{"order_id": "123"},
+					},
+				},
+			},
+		},
+	}
+	return bundle
+}
+
+func jsonString(value string) string {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return string(encoded)
+}

--- a/backend/internal/challengepack/case_template_test.go
+++ b/backend/internal/challengepack/case_template_test.go
@@ -122,6 +122,41 @@ func TestBuildCaseTemplateContextFromPayload_StoredCaseDocument(t *testing.T) {
 	}
 }
 
+func TestBuildCaseTemplateContextFromPayload_PlainPayloadWithInputsKey(t *testing.T) {
+	payload, err := json.Marshal(map[string]any{
+		"inputs":   []any{"raw-input-list"},
+		"order_id": "123",
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	ctx, err := BuildCaseTemplateContextFromPayload(payload, nil)
+	if err != nil {
+		t.Fatalf("BuildCaseTemplateContextFromPayload returned error: %v", err)
+	}
+	rendered, err := RenderCaseTemplate("pytest tests/test_{{order_id}}.py", ctx)
+	if err != nil {
+		t.Fatalf("RenderCaseTemplate returned error: %v", err)
+	}
+	if rendered != "pytest tests/test_123.py" {
+		t.Fatalf("rendered = %q, want pytest tests/test_123.py", rendered)
+	}
+}
+
+func TestValidateCaseTemplate_ReportsAllUnresolvedPlaceholders(t *testing.T) {
+	err := ValidateCaseTemplate("echo {{missing_a}} {{missing_b}}", CaseTemplateContext{}, "test_command")
+	if err == nil {
+		t.Fatal("expected validation errors")
+	}
+	errs, ok := err.(ValidationErrors)
+	if !ok {
+		t.Fatalf("error type = %T, want ValidationErrors", err)
+	}
+	if len(errs) != 2 {
+		t.Fatalf("error count = %d, want 2", len(errs))
+	}
+}
+
 func caseTemplateTestBundle(testCommand string) Bundle {
 	bundle := Bundle{
 		Pack: PackMetadata{Slug: "demo", Name: "Demo", Family: "demo"},

--- a/backend/internal/challengepack/case_template_validate.go
+++ b/backend/internal/challengepack/case_template_validate.go
@@ -1,0 +1,56 @@
+package challengepack
+
+import (
+	"fmt"
+
+	"github.com/agentclash/agentclash/backend/internal/scoring"
+)
+
+func validateBundleCaseTemplates(bundle Bundle) ValidationErrors {
+	var errs ValidationErrors
+	if len(bundle.Version.EvaluationSpec.Validators) == 0 {
+		return errs
+	}
+
+	type templatedCommand struct {
+		fieldPath   string
+		testCommand string
+	}
+	commands := make([]templatedCommand, 0)
+	for i, validator := range bundle.Version.EvaluationSpec.Validators {
+		if validator.Type != scoring.ValidatorTypeCodeExecution {
+			continue
+		}
+		cfg, err := scoring.ParseCodeExecutionConfig(validator.Config)
+		if err != nil {
+			continue
+		}
+		if len(ExtractCaseTemplatePlaceholders(cfg.TestCommand)) == 0 {
+			continue
+		}
+		commands = append(commands, templatedCommand{
+			fieldPath:   fmt.Sprintf("version.evaluation_spec.validators[%d].config.test_command", i),
+			testCommand: cfg.TestCommand,
+		})
+	}
+	if len(commands) == 0 {
+		return errs
+	}
+
+	for inputSetIndex, inputSet := range bundle.InputSets {
+		for caseIndex, caseDef := range inputSet.Cases {
+			ctx := BuildCaseTemplateContext(cloneObject(caseDef.Payload), caseDef.Inputs)
+			casePath := fmt.Sprintf("input_sets[%d].cases[%d]", inputSetIndex, caseIndex)
+			for _, command := range commands {
+				fieldPath := command.fieldPath + " (" + casePath + ")"
+				if err := ValidateCaseTemplate(command.testCommand, ctx, fieldPath); err != nil {
+					if validationErr, ok := err.(ValidationError); ok {
+						errs = append(errs, validationErr)
+					}
+				}
+			}
+		}
+	}
+
+	return errs
+}

--- a/backend/internal/challengepack/case_template_validate.go
+++ b/backend/internal/challengepack/case_template_validate.go
@@ -44,8 +44,11 @@ func validateBundleCaseTemplates(bundle Bundle) ValidationErrors {
 			for _, command := range commands {
 				fieldPath := command.fieldPath + " (" + casePath + ")"
 				if err := ValidateCaseTemplate(command.testCommand, ctx, fieldPath); err != nil {
-					if validationErr, ok := err.(ValidationError); ok {
-						errs = append(errs, validationErr)
+					switch typed := err.(type) {
+					case ValidationError:
+						errs = append(errs, typed)
+					case ValidationErrors:
+						errs = append(errs, typed...)
 					}
 				}
 			}

--- a/backend/internal/challengepack/validation.go
+++ b/backend/internal/challengepack/validation.go
@@ -198,6 +198,7 @@ func ValidateBundle(bundle Bundle) error {
 			errs = append(errs, ValidationError{Field: "version.evaluation_spec", Message: err.Error()})
 		}
 	}
+	errs = append(errs, validateBundleCaseTemplates(bundle)...)
 	errs = append(errs, validateAssets("version.assets", bundle.Version.Assets)...)
 
 	if len(errs) > 0 {

--- a/backend/internal/engine/case_template_runtime.go
+++ b/backend/internal/engine/case_template_runtime.go
@@ -1,0 +1,46 @@
+package engine
+
+import (
+	"log/slog"
+
+	"github.com/agentclash/agentclash/backend/internal/challengepack"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+)
+
+func caseTemplateContextForExecution(executionContext repository.RunAgentExecutionContext) challengepack.CaseTemplateContext {
+	if executionContext.ChallengeInputSet == nil || len(executionContext.ChallengeInputSet.Cases) == 0 {
+		return challengepack.CaseTemplateContext{}
+	}
+	if n := len(executionContext.ChallengeInputSet.Cases); n > 1 {
+		slog.Default().Warn(
+			"case template rendering using first case only; additional cases ignored",
+			"run_agent_id", executionContext.RunAgent.ID.String(),
+			"case_count", n,
+		)
+	}
+	first := executionContext.ChallengeInputSet.Cases[0]
+	ctx, err := challengepack.BuildCaseTemplateContextFromPayload(first.Payload, first.Inputs)
+	if err != nil {
+		slog.Default().Warn(
+			"case template context decode failed; rendering with empty context",
+			"run_agent_id", executionContext.RunAgent.ID.String(),
+			"error", err,
+		)
+		return challengepack.CaseTemplateContext{}
+	}
+	return ctx
+}
+
+func renderCaseTemplateCommand(template string, executionContext repository.RunAgentExecutionContext) string {
+	ctx := caseTemplateContextForExecution(executionContext)
+	rendered, err := challengepack.RenderCaseTemplate(template, ctx)
+	if err != nil {
+		slog.Default().Warn(
+			"code execution test_command rendered with unresolved placeholders",
+			"run_agent_id", executionContext.RunAgent.ID.String(),
+			"error", err,
+		)
+		return challengepack.RenderCaseTemplateLenient(template, ctx)
+	}
+	return rendered
+}

--- a/backend/internal/engine/executor_verification.go
+++ b/backend/internal/engine/executor_verification.go
@@ -41,7 +41,7 @@ func collectPostExecutionVerification(
 ) []PostExecutionVerificationResult {
 	results := []PostExecutionVerificationResult{}
 	if checks := extractCodeExecutionChecks(executionContext); len(checks) > 0 {
-		results = append(results, executeCodeExecutionChecks(ctx, session, checks)...)
+		results = append(results, executeCodeExecutionChecks(ctx, session, executionContext, checks)...)
 	}
 	if checks := extractPostExecutionChecks(executionContext); len(checks) > 0 {
 		results = append(results, executePostExecutionChecks(ctx, session, checks)...)
@@ -135,11 +135,12 @@ func executePostExecutionChecks(
 func executeCodeExecutionChecks(
 	ctx context.Context,
 	session sandbox.Session,
+	executionContext repository.RunAgentExecutionContext,
 	checks []codeExecutionCheck,
 ) []PostExecutionVerificationResult {
 	results := make([]PostExecutionVerificationResult, 0, len(checks))
 	for _, check := range checks {
-		payload, err := json.Marshal(executeCodeExecutionCheck(ctx, session, check))
+		payload, err := json.Marshal(executeCodeExecutionCheck(ctx, session, executionContext, check))
 		if err != nil {
 			slog.Default().Warn("marshal code execution result", "validator_key", check.ValidatorKey, "error", err)
 			continue
@@ -230,13 +231,15 @@ func executeDirectoryListingCheck(
 func executeCodeExecutionCheck(
 	ctx context.Context,
 	session sandbox.Session,
+	executionContext repository.RunAgentExecutionContext,
 	check codeExecutionCheck,
 ) scoring.CodeExecutionResult {
+	testCommand := renderCaseTemplateCommand(check.Config.TestCommand, executionContext)
 	result := scoring.CodeExecutionResult{
 		ValidatorKey:  check.ValidatorKey,
 		Target:        check.Target,
 		TargetPath:    check.TargetPath,
-		TestCommand:   check.Config.TestCommand,
+		TestCommand:   testCommand,
 		TimeoutMS:     check.Config.EffectiveTimeoutMS(),
 		Scoring:       string(check.Config.Scoring),
 		PassThreshold: check.Config.PassThreshold,
@@ -247,7 +250,7 @@ func executeCodeExecutionCheck(
 		// can supply normal test commands (pipelines, env var expansion, `cd`,
 		// etc.). This is safe here because the command executes inside the same
 		// isolated ephemeral sandbox as the generated code under evaluation.
-		Command:          []string{"sh", "-lc", check.Config.TestCommand},
+		Command:          []string{"sh", "-lc", testCommand},
 		WorkingDirectory: defaultCodeExecutionWorkingDirectory(check.TargetPath),
 		Timeout:          check.Config.EffectiveTimeout(),
 	})

--- a/backend/internal/engine/executor_verification_test.go
+++ b/backend/internal/engine/executor_verification_test.go
@@ -236,7 +236,7 @@ func TestExecuteCodeExecutionCheck_ParsesPytestCounts(t *testing.T) {
 		},
 	}
 
-	result := executeCodeExecutionCheck(context.Background(), session, codeExecutionCheck{
+	result := executeCodeExecutionCheck(context.Background(), session, repository.RunAgentExecutionContext{}, codeExecutionCheck{
 		ValidatorKey: "tests_pass",
 		Target:       "file:generated_code",
 		TargetPath:   "/workspace/app.py",
@@ -260,10 +260,42 @@ func TestExecuteCodeExecutionCheck_ParsesPytestCounts(t *testing.T) {
 	}
 }
 
+func TestExecuteCodeExecutionCheck_RendersTestCommand(t *testing.T) {
+	session := &fakeSandboxSession{
+		execResult: sandbox.ExecResult{ExitCode: 0, Stdout: "1 passed in 0.01s"},
+	}
+	payload, err := json.Marshal(map[string]any{"order_id": "case-42"})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	executionContext := repository.RunAgentExecutionContext{
+		ChallengeInputSet: &repository.ChallengeInputSetExecutionContext{
+			Cases: []repository.ChallengeCaseExecutionContext{
+				{Payload: payload},
+			},
+		},
+	}
+
+	result := executeCodeExecutionCheck(context.Background(), session, executionContext, codeExecutionCheck{
+		ValidatorKey: "tests_pass",
+		Target:       "file:generated_code",
+		TargetPath:   "/workspace/app.py",
+		Config: scoring.CodeExecutionConfig{
+			TestCommand: "pytest tests/test_{{order_id}}.py -q",
+			Scoring:     scoring.CodeExecutionScoringAllOrNothing,
+		},
+	})
+
+	want := "pytest tests/test_case-42.py -q"
+	if result.TestCommand != want {
+		t.Fatalf("TestCommand = %q, want %q", result.TestCommand, want)
+	}
+}
+
 func TestExecuteCodeExecutionCheck_Timeout(t *testing.T) {
 	session := &fakeSandboxSession{execErr: context.DeadlineExceeded}
 
-	result := executeCodeExecutionCheck(context.Background(), session, codeExecutionCheck{
+	result := executeCodeExecutionCheck(context.Background(), session, repository.RunAgentExecutionContext{}, codeExecutionCheck{
 		ValidatorKey: "tests_pass",
 		Target:       "file:generated_code",
 		TargetPath:   "/workspace/app.py",

--- a/backend/internal/engine/prompt_eval_executor.go
+++ b/backend/internal/engine/prompt_eval_executor.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"regexp"
 	"strings"
 
 	"github.com/agentclash/agentclash/backend/internal/challengepack"
@@ -194,9 +193,9 @@ func buildPromptEvalMessages(executionContext repository.RunAgentExecutionContex
 		return nil, fmt.Errorf("challenge %q is missing instructions required for prompt_eval", challenge.ChallengeKey)
 	}
 
-	vars := promptEvalVariables(executionContext)
-	rendered := renderPromptTemplate(instructions, vars)
-	if leftovers := promptEvalTemplatePattern.FindAllString(rendered, -1); len(leftovers) > 0 {
+	vars := caseTemplateContextForExecution(executionContext)
+	rendered := challengepack.RenderCaseTemplateLenient(instructions, vars)
+	if leftovers := challengepack.FindUnresolvedCaseTemplateLiterals(rendered); len(leftovers) > 0 {
 		slog.Default().Warn(
 			"prompt_eval executor rendered prompt with unresolved template tokens",
 			"run_agent_id", executionContext.RunAgent.ID.String(),
@@ -241,70 +240,10 @@ func extractChallengeInstructions(definition json.RawMessage) (string, error) {
 	return decoded.Instructions, nil
 }
 
-func promptEvalVariables(executionContext repository.RunAgentExecutionContext) map[string]string {
-	vars := map[string]string{}
-	if executionContext.ChallengeInputSet == nil || len(executionContext.ChallengeInputSet.Cases) == 0 {
-		return vars
-	}
-	if n := len(executionContext.ChallengeInputSet.Cases); n > 1 {
-		slog.Default().Warn(
-			"prompt_eval executor using first case only; additional cases ignored",
-			"run_agent_id", executionContext.RunAgent.ID.String(),
-			"case_count", n,
-		)
-	}
-	first := executionContext.ChallengeInputSet.Cases[0]
-	for _, input := range first.Inputs {
-		if input.Key == "" {
-			continue
-		}
-		if rendered, ok := promptEvalRenderInputValue(input); ok {
-			vars[input.Key] = rendered
-		}
-	}
-	return vars
-}
-
-func promptEvalRenderInputValue(input challengepack.CaseInput) (string, bool) {
-	if input.Value == nil {
-		return "", false
-	}
-	switch typed := input.Value.(type) {
-	case string:
-		return typed, true
-	case bool:
-		if typed {
-			return "true", true
-		}
-		return "false", true
-	case int:
-		return fmt.Sprintf("%d", typed), true
-	case float64:
-		return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%f", typed), "0"), "."), true
-	default:
-		encoded, err := json.Marshal(typed)
-		if err != nil {
-			return "", false
-		}
-		return string(encoded), true
-	}
-}
-
-var promptEvalTemplatePattern = regexp.MustCompile(`\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}`)
-
-func renderPromptTemplate(template string, vars map[string]string) string {
-	return promptEvalTemplatePattern.ReplaceAllStringFunc(template, func(match string) string {
-		groups := promptEvalTemplatePattern.FindStringSubmatch(match)
-		if len(groups) != 2 {
-			return match
-		}
-		if value, ok := vars[groups[1]]; ok {
-			return value
-		}
-		return match
-	})
-}
-
 func RenderPromptTemplate(template string, vars map[string]string) string {
-	return renderPromptTemplate(template, vars)
+	ctx := challengepack.CaseTemplateContext{}
+	for key, value := range vars {
+		ctx[key] = value
+	}
+	return challengepack.RenderCaseTemplateLenient(template, ctx)
 }

--- a/docs/challenge-packs/case-templating.md
+++ b/docs/challenge-packs/case-templating.md
@@ -1,0 +1,44 @@
+# Case templating
+
+Challenge pack cases can parameterize strings with `{{placeholder}}` syntax. Placeholders resolve from each case's `payload` object and from structured `inputs[]` entries (inputs override payload keys).
+
+## Syntax
+
+- Top-level: `{{order_id}}`
+- Nested payload paths: `{{customer.id}}`
+- Placeholder names match `[A-Za-z_][A-Za-z0-9_.]*`
+
+## Supported fields (v1)
+
+| Field | When validated | When rendered |
+| --- | --- | --- |
+| `code_execution.config.test_command` | Bundle load (`ValidateBundle`) | Run post-execution verification |
+| `prompt_eval` challenge `instructions` | N/A (lenient at runtime) | Prompt eval executor |
+
+Future multi-turn `user_simulator` turn messages will use the same renderer (#841).
+
+## Example
+
+```yaml
+validators:
+  - key: tests
+    type: code_execution
+    target: file:generated_code
+    config:
+      test_command: pytest tests/test_{{order_id}}.py -q
+
+input_sets:
+  - key: default
+    cases:
+      - challenge_key: fix-order
+        case_key: case-1
+        payload:
+          order_id: "12345"
+```
+
+At bundle validation, `test_command` must resolve for every case. At run time, the first case in the run agent's input set supplies values.
+
+## Related
+
+- Tool argument templating uses `${...}` via `templateutil` (different syntax).
+- Stored case payloads may use the canonical `StoredCaseDocument` envelope; nested values under `payload` are available to placeholders.

--- a/testing/feat-case-templating-840.md
+++ b/testing/feat-case-templating-840.md
@@ -1,0 +1,35 @@
+# feat/case-templating-840 — Test Contract
+
+## Functional Behavior
+
+- Challenge pack authors can use `{{key}}` and nested `{{parent.child}}` placeholders in `code_execution` validator `test_command` strings.
+- Placeholders resolve from the per-case `payload` map and from structured `inputs[]` keys (input values override payload keys on conflict).
+- At bundle validation time, every `test_command` containing placeholders must resolve for **every** case in every input set (strict mode).
+- At run time, `code_execution` checks use the active run agent's first input-set case to render `test_command` before sandbox exec.
+- `prompt_eval` challenge `instructions` use the same renderer (payload + inputs), not inputs-only.
+
+## Unit Tests
+
+- `TestBuildCaseTemplateContext_MergesPayloadAndInputs` — input overrides payload key
+- `TestRenderCaseTemplate_ResolvesTopLevelAndNestedPaths` — `{{order_id}}`, `{{customer.id}}`
+- `TestRenderCaseTemplate_StrictMissingKey` — returns error for unresolved placeholder
+- `TestRenderCaseTemplateLenient_LeavesUnresolved` — non-strict leaves literal `{{missing}}`
+- `TestExtractCaseTemplatePlaceholders` — dedupe / syntax
+- `TestValidateBundleCaseTemplates_*` — pass/fail bundle validation cases
+- `TestExecuteCodeExecutionCheck_RendersTestCommand` — engine substitutes before exec
+
+## Integration / Functional Tests
+
+- N/A — bundle validation + engine unit tests cover integration surface for this change.
+
+## Smoke Tests
+
+- `cd backend && go test -short -race -count=1 ./internal/challengepack/... ./internal/engine/... -run 'CaseTemplate|CodeExecutionCheck_Renders'`
+
+## E2E Tests
+
+- N/A — no full stack run required for templating-only change.
+
+## Manual / cURL Tests
+
+- N/A — validation is exercised via `challengepack.ValidateBundle` in tests and existing pack upload paths.


### PR DESCRIPTION
## Summary

- Adds shared `{{key}}` and `{{parent.child}}` case templating for challenge pack cases, resolving values from case `payload` and `inputs[]` (inputs override payload).
- Validates `code_execution.config.test_command` placeholders at bundle load for **every** case in every input set.
- Renders `test_command` at run time from the run agent's first input-set case before sandbox exec; aligns `prompt_eval` instructions with the same renderer.

Implements sub-issue 1 of the multi-turn eval epic ([#839](https://github.com/agentclash/agentclash/issues/839)).

Closes #840

## Review checkpoint

Test contract (locked before implementation): `testing/feat-case-templating-840.md`

Implementation commits follow review-checkpoint steps 1–2 with self-review against that contract.

## Test plan

- [x] `cd backend && go test -short -race -count=1 ./internal/challengepack/... ./internal/engine/...`
- [x] Case template unit tests (`RenderCaseTemplate`, bundle validation pass/fail)
- [x] `TestExecuteCodeExecutionCheck_RendersTestCommand` — runtime substitution
- [x] Docs: `docs/challenge-packs/case-templating.md`