### PR TITLE
feat(runevents): multi-turn run events + transcript model (#842)

### DIFF
--- a/backend/internal/runevents/envelope.go
+++ b/backend/internal/runevents/envelope.go
@@ -48,15 +48,21 @@ const (
 
 	EventTypeRaceStandingsInjected Type = "race.standings.injected"
 
-	EventTypeMediaSessionStarted Type = "media.session.started"
-	EventTypeMediaFrameReceived  Type = "media.frame.received"
-	EventTypeSpeechStarted       Type = "speech.started"
-	EventTypeSpeechStopped       Type = "speech.stopped"
-	EventTypeTranscriptPartial   Type = "transcript.partial"
-	EventTypeTranscriptFinal     Type = "transcript.final"
-	EventTypeTurnCompleted       Type = "turn.completed"
-	EventTypeAgentAudioStarted   Type = "agent.audio.started"
-	EventTypeAgentAudioCompleted Type = "agent.audio.completed"
+	EventTypeMediaSessionStarted   Type = "media.session.started"
+	EventTypeMediaFrameReceived    Type = "media.frame.received"
+	EventTypeSpeechStarted         Type = "speech.started"
+	EventTypeSpeechStopped         Type = "speech.stopped"
+	EventTypeTranscriptPartial     Type = "transcript.partial"
+	EventTypeTranscriptFinal       Type = "transcript.final"
+	EventTypeTurnUserMessage       Type = "turn.user.message"
+	EventTypeTurnUserSimulated     Type = "turn.user.simulated"
+	EventTypeTurnAssistantMessage  Type = "turn.assistant.message"
+	EventTypeTurnCompleted         Type = "turn.completed"
+	EventTypeTurnAwaitingHuman     Type = "turn.awaiting_human"
+	EventTypeTurnStateCaptured     Type = "turn.state.captured"
+	EventTypeConversationCompleted Type = "conversation.completed"
+	EventTypeAgentAudioStarted     Type = "agent.audio.started"
+	EventTypeAgentAudioCompleted   Type = "agent.audio.completed"
 	// Barge-in is specified as one domain term in #758, so the canonical value intentionally keeps the underscore.
 	EventTypeBargeInDetected     Type = "barge_in.detected"
 	EventTypeAudioBufferCleared  Type = "audio.buffer.cleared"
@@ -108,6 +114,9 @@ type SummaryMetadata struct {
 	SandboxAction   string        `json:"sandbox_action,omitempty"`
 	MetricKey       string        `json:"metric_key,omitempty"`
 	TurnIndex       *int          `json:"turn_index,omitempty"`
+	PhaseID         string        `json:"phase_id,omitempty"`
+	Actor           string        `json:"actor,omitempty"`
+	Mismatch        *bool         `json:"mismatch,omitempty"`
 	Speaker         string        `json:"speaker,omitempty"`
 	Channel         string        `json:"channel,omitempty"`
 	ExternalRunID   string        `json:"external_run_id,omitempty"`
@@ -206,7 +215,13 @@ func isValidType(eventType Type) bool {
 		EventTypeSpeechStopped,
 		EventTypeTranscriptPartial,
 		EventTypeTranscriptFinal,
+		EventTypeTurnUserMessage,
+		EventTypeTurnUserSimulated,
+		EventTypeTurnAssistantMessage,
 		EventTypeTurnCompleted,
+		EventTypeTurnAwaitingHuman,
+		EventTypeTurnStateCaptured,
+		EventTypeConversationCompleted,
 		EventTypeAgentAudioStarted,
 		EventTypeAgentAudioCompleted,
 		EventTypeBargeInDetected,

--- a/backend/internal/runevents/hosted.go
+++ b/backend/internal/runevents/hosted.go
@@ -35,6 +35,9 @@ type hostedTraceSummaryDocument struct {
 	SandboxAction   string `json:"sandbox_action,omitempty"`
 	MetricKey       string `json:"metric_key,omitempty"`
 	TurnIndex       *int   `json:"turn_index,omitempty"`
+	PhaseID         string `json:"phase_id,omitempty"`
+	Actor           string `json:"actor,omitempty"`
+	Mismatch        *bool  `json:"mismatch,omitempty"`
 	Speaker         string `json:"speaker,omitempty"`
 	Channel         string `json:"channel,omitempty"`
 	ExternalRunID   string `json:"external_run_id,omitempty"`
@@ -243,6 +246,9 @@ func normalizeHostedTraceSummary(raw json.RawMessage, event hostedruns.Event) (S
 	summary.SandboxAction = decoded.SandboxAction
 	summary.MetricKey = decoded.MetricKey
 	summary.TurnIndex = decoded.TurnIndex
+	summary.PhaseID = decoded.PhaseID
+	summary.Actor = decoded.Actor
+	summary.Mismatch = decoded.Mismatch
 	summary.Speaker = decoded.Speaker
 	summary.Channel = decoded.Channel
 	if decoded.ExternalRunID != "" {

--- a/backend/internal/runevents/multi_turn.go
+++ b/backend/internal/runevents/multi_turn.go
@@ -1,0 +1,223 @@
+package runevents
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	ConversationActorScripted = "scripted"
+	ConversationActorLLM      = "llm"
+	ConversationActorHuman    = "human"
+)
+
+var (
+	ErrMultiTurnSummaryRequired = errors.New("multi-turn event summary field is required")
+	ErrMultiTurnPayloadRequired = errors.New("multi-turn event payload field is required")
+	ErrMultiTurnInvalidActor    = errors.New("invalid multi-turn conversation actor")
+)
+
+type turnUserMessagePayload struct {
+	Content string `json:"content"`
+	Actor   string `json:"actor"`
+	PhaseID string `json:"phase_id"`
+}
+
+type turnAssistantMessagePayload struct {
+	Content string `json:"content"`
+	PhaseID string `json:"phase_id,omitempty"`
+}
+
+type turnAwaitingHumanPayload struct {
+	PromptHint string `json:"prompt_hint,omitempty"`
+	PhaseID    string `json:"phase_id"`
+}
+
+type turnStateCapturedPayload struct {
+	SnapshotRef string `json:"snapshot_ref"`
+}
+
+type conversationCompletedPayload struct {
+	StopReason string `json:"stop_reason,omitempty"`
+	TurnCount  int    `json:"turn_count,omitempty"`
+}
+
+func IsMultiTurnConversationEventType(eventType Type) bool {
+	switch eventType {
+	case EventTypeTurnUserMessage,
+		EventTypeTurnUserSimulated,
+		EventTypeTurnAssistantMessage,
+		EventTypeTurnAwaitingHuman,
+		EventTypeTurnStateCaptured,
+		EventTypeConversationCompleted:
+		return true
+	case EventTypeTurnCompleted:
+		return true
+	default:
+		return false
+	}
+}
+
+func ValidateMultiTurnEvent(envelope Envelope) error {
+	if err := envelope.ValidatePending(); err != nil {
+		return err
+	}
+	if !IsMultiTurnConversationEventType(envelope.EventType) {
+		return fmt.Errorf("not a multi-turn conversation event type: %q", envelope.EventType)
+	}
+
+	switch envelope.EventType {
+	case EventTypeTurnUserMessage:
+		return validateTurnUserMessage(envelope)
+	case EventTypeTurnUserSimulated:
+		return validateTurnUserSimulated(envelope)
+	case EventTypeTurnAssistantMessage:
+		return validateTurnAssistantMessage(envelope)
+	case EventTypeTurnCompleted:
+		return validateTurnCompleted(envelope)
+	case EventTypeTurnAwaitingHuman:
+		return validateTurnAwaitingHuman(envelope)
+	case EventTypeTurnStateCaptured:
+		return validateTurnStateCaptured(envelope)
+	case EventTypeConversationCompleted:
+		return nil
+	default:
+		return fmt.Errorf("unsupported multi-turn event type: %q", envelope.EventType)
+	}
+}
+
+func validateTurnIndex(summary SummaryMetadata) error {
+	if summary.TurnIndex == nil {
+		return fmt.Errorf("%w: turn_index", ErrMultiTurnSummaryRequired)
+	}
+	if *summary.TurnIndex < 0 {
+		return fmt.Errorf("turn_index must be >= 0")
+	}
+	return nil
+}
+
+func validatePhaseID(summary SummaryMetadata, payloadPhaseID string) error {
+	phaseID := strings.TrimSpace(summary.PhaseID)
+	if phaseID == "" {
+		phaseID = strings.TrimSpace(payloadPhaseID)
+	}
+	if phaseID == "" {
+		return fmt.Errorf("%w: phase_id", ErrMultiTurnSummaryRequired)
+	}
+	return nil
+}
+
+func validateConversationActor(actor string) error {
+	switch strings.TrimSpace(actor) {
+	case ConversationActorScripted, ConversationActorLLM, ConversationActorHuman:
+		return nil
+	default:
+		return fmt.Errorf("%w: %q", ErrMultiTurnInvalidActor, actor)
+	}
+}
+
+func validateTurnUserMessage(envelope Envelope) error {
+	if err := validateTurnIndex(envelope.Summary); err != nil {
+		return err
+	}
+	var payload turnUserMessagePayload
+	if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
+		return fmt.Errorf("decode turn.user.message payload: %w", err)
+	}
+	if strings.TrimSpace(payload.Content) == "" {
+		return fmt.Errorf("%w: content", ErrMultiTurnPayloadRequired)
+	}
+	actor := strings.TrimSpace(envelope.Summary.Actor)
+	if actor == "" {
+		actor = strings.TrimSpace(payload.Actor)
+	}
+	if err := validateConversationActor(actor); err != nil {
+		return err
+	}
+	return validatePhaseID(envelope.Summary, payload.PhaseID)
+}
+
+func validateTurnUserSimulated(envelope Envelope) error {
+	if err := validateTurnIndex(envelope.Summary); err != nil {
+		return err
+	}
+	return validatePhaseID(envelope.Summary, "")
+}
+
+func validateTurnAssistantMessage(envelope Envelope) error {
+	if err := validateTurnIndex(envelope.Summary); err != nil {
+		return err
+	}
+	var payload turnAssistantMessagePayload
+	if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
+		return fmt.Errorf("decode turn.assistant.message payload: %w", err)
+	}
+	if strings.TrimSpace(payload.Content) == "" {
+		return fmt.Errorf("%w: content", ErrMultiTurnPayloadRequired)
+	}
+	return validatePhaseID(envelope.Summary, payload.PhaseID)
+}
+
+func validateTurnCompleted(envelope Envelope) error {
+	// Voice adapter events may omit phase_id/actor; native multi-turn emitters must set them.
+	if envelope.Source == SourceVoiceAdapter || envelope.Source == SourceMediaGateway {
+		return nil
+	}
+	if err := validateTurnIndex(envelope.Summary); err != nil {
+		return err
+	}
+	actor := strings.TrimSpace(envelope.Summary.Actor)
+	if actor == "" {
+		return fmt.Errorf("%w: actor", ErrMultiTurnSummaryRequired)
+	}
+	if err := validateConversationActor(actor); err != nil {
+		return err
+	}
+	if envelope.Summary.Mismatch == nil {
+		return fmt.Errorf("%w: mismatch", ErrMultiTurnSummaryRequired)
+	}
+	return validatePhaseID(envelope.Summary, "")
+}
+
+func validateTurnAwaitingHuman(envelope Envelope) error {
+	if err := validateTurnIndex(envelope.Summary); err != nil {
+		return err
+	}
+	var payload turnAwaitingHumanPayload
+	if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
+		return fmt.Errorf("decode turn.awaiting_human payload: %w", err)
+	}
+	return validatePhaseID(envelope.Summary, payload.PhaseID)
+}
+
+func validateTurnStateCaptured(envelope Envelope) error {
+	if envelope.Summary.TurnIndex != nil && *envelope.Summary.TurnIndex < 0 {
+		return fmt.Errorf("turn_index must be >= 0")
+	}
+	var payload turnStateCapturedPayload
+	if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
+		return fmt.Errorf("decode turn.state.captured payload: %w", err)
+	}
+	if strings.TrimSpace(payload.SnapshotRef) == "" {
+		return fmt.Errorf("%w: snapshot_ref", ErrMultiTurnPayloadRequired)
+	}
+	return nil
+}
+
+func decodeTurnUserMessageContent(payload json.RawMessage) (string, error) {
+	var decoded turnUserMessagePayload
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return "", err
+	}
+	return decoded.Content, nil
+}
+
+func decodeTurnAssistantMessageContent(payload json.RawMessage) (string, error) {
+	var decoded turnAssistantMessagePayload
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return "", err
+	}
+	return decoded.Content, nil
+}

--- a/backend/internal/runevents/multi_turn.go
+++ b/backend/internal/runevents/multi_turn.go
@@ -39,21 +39,15 @@ type turnStateCapturedPayload struct {
 	SnapshotRef string `json:"snapshot_ref"`
 }
 
-type conversationCompletedPayload struct {
-	StopReason string `json:"stop_reason,omitempty"`
-	TurnCount  int    `json:"turn_count,omitempty"`
-}
-
 func IsMultiTurnConversationEventType(eventType Type) bool {
 	switch eventType {
 	case EventTypeTurnUserMessage,
 		EventTypeTurnUserSimulated,
 		EventTypeTurnAssistantMessage,
+		EventTypeTurnCompleted,
 		EventTypeTurnAwaitingHuman,
 		EventTypeTurnStateCaptured,
 		EventTypeConversationCompleted:
-		return true
-	case EventTypeTurnCompleted:
 		return true
 	default:
 		return false
@@ -185,16 +179,23 @@ func validateTurnAwaitingHuman(envelope Envelope) error {
 	if err := validateTurnIndex(envelope.Summary); err != nil {
 		return err
 	}
-	var payload turnAwaitingHumanPayload
-	if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
-		return fmt.Errorf("decode turn.awaiting_human payload: %w", err)
+	payloadPhaseID := ""
+	if len(envelope.Payload) > 0 {
+		var payload turnAwaitingHumanPayload
+		if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
+			return fmt.Errorf("decode turn.awaiting_human payload: %w", err)
+		}
+		payloadPhaseID = payload.PhaseID
 	}
-	return validatePhaseID(envelope.Summary, payload.PhaseID)
+	return validatePhaseID(envelope.Summary, payloadPhaseID)
 }
 
 func validateTurnStateCaptured(envelope Envelope) error {
 	if envelope.Summary.TurnIndex != nil && *envelope.Summary.TurnIndex < 0 {
 		return fmt.Errorf("turn_index must be >= 0")
+	}
+	if len(envelope.Payload) == 0 {
+		return fmt.Errorf("%w: payload", ErrMultiTurnPayloadRequired)
 	}
 	var payload turnStateCapturedPayload
 	if err := json.Unmarshal(envelope.Payload, &payload); err != nil {

--- a/backend/internal/runevents/multi_turn_test.go
+++ b/backend/internal/runevents/multi_turn_test.go
@@ -1,0 +1,206 @@
+package runevents
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestMultiTurnEventTypesAreValid(t *testing.T) {
+	eventTypes := []Type{
+		EventTypeTurnUserMessage,
+		EventTypeTurnUserSimulated,
+		EventTypeTurnAssistantMessage,
+		EventTypeTurnAwaitingHuman,
+		EventTypeTurnStateCaptured,
+		EventTypeConversationCompleted,
+	}
+
+	for _, eventType := range eventTypes {
+		t.Run(string(eventType), func(t *testing.T) {
+			envelope := baseMultiTurnEnvelope(eventType, json.RawMessage(`{"content":"hello","actor":"scripted","phase_id":"open"}`))
+			if err := envelope.ValidatePending(); err != nil {
+				t.Fatalf("ValidatePending() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateMultiTurnEventRequiredFields(t *testing.T) {
+	t.Run("turn.user.message requires turn_index and content", func(t *testing.T) {
+		envelope := baseMultiTurnEnvelope(EventTypeTurnUserMessage, json.RawMessage(`{"content":"","actor":"scripted","phase_id":"open"}`))
+		if err := ValidateMultiTurnEvent(envelope); err == nil {
+			t.Fatal("expected validation error for empty content")
+		}
+	})
+
+	t.Run("turn.assistant.message requires content", func(t *testing.T) {
+		envelope := baseMultiTurnEnvelope(EventTypeTurnAssistantMessage, json.RawMessage(`{"content":"done","phase_id":"open"}`))
+		envelope.Summary.TurnIndex = intPtr(0)
+		envelope.Summary.PhaseID = "open"
+		if err := ValidateMultiTurnEvent(envelope); err != nil {
+			t.Fatalf("ValidateMultiTurnEvent() error = %v", err)
+		}
+	})
+
+	t.Run("native turn.completed requires actor and mismatch", func(t *testing.T) {
+		envelope := baseMultiTurnEnvelope(EventTypeTurnCompleted, json.RawMessage(`{}`))
+		envelope.Source = SourceNativeEngine
+		envelope.Summary.TurnIndex = intPtr(1)
+		envelope.Summary.PhaseID = "open"
+		if err := ValidateMultiTurnEvent(envelope); err == nil {
+			t.Fatal("expected validation error for missing actor/mismatch")
+		}
+	})
+}
+
+func TestVoiceTurnCompletedStillValidWithoutPhaseID(t *testing.T) {
+	envelope := Envelope{
+		EventID:       "evt-voice-turn",
+		SchemaVersion: SchemaVersionV1,
+		RunID:         uuid.New(),
+		RunAgentID:    uuid.New(),
+		EventType:     EventTypeTurnCompleted,
+		Source:        SourceVoiceAdapter,
+		OccurredAt:    time.Date(2026, 5, 13, 11, 30, 0, 0, time.UTC),
+		Payload:       json.RawMessage(`{"turn_id":"turn-001"}`),
+		Summary: SummaryMetadata{
+			TurnIndex:     intPtr(1),
+			Speaker:       "agent",
+			EvidenceLevel: EvidenceLevelVoiceStructured,
+		},
+	}
+	if err := envelope.ValidatePending(); err != nil {
+		t.Fatalf("ValidatePending() error = %v", err)
+	}
+	if err := ValidateMultiTurnEvent(envelope); err != nil {
+		t.Fatalf("ValidateMultiTurnEvent() voice event error = %v", err)
+	}
+}
+
+func TestTranscriptFromEventsOrdersAndGroupsTurns(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	occurredAt := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+
+	events := []Envelope{
+		multiTurnEvent(1, EventTypeTurnUserMessage, runID, runAgentID, occurredAt, SummaryMetadata{
+			TurnIndex: intPtr(0),
+			PhaseID:   "open",
+			Actor:     ConversationActorScripted,
+		}, `{"content":"Refund order 42","actor":"scripted","phase_id":"open"}`),
+		multiTurnEvent(3, EventTypeTurnAssistantMessage, runID, runAgentID, occurredAt, SummaryMetadata{
+			TurnIndex: intPtr(0),
+			PhaseID:   "open",
+		}, `{"content":"Checking order 42","phase_id":"open"}`),
+		multiTurnEvent(2, EventTypeTurnUserSimulated, runID, runAgentID, occurredAt, SummaryMetadata{
+			TurnIndex: intPtr(1),
+			PhaseID:   "dynamic",
+		}, `{"provider_key":"openai","model":"gpt-4.1-mini"}`),
+		multiTurnEvent(4, EventTypeTurnCompleted, runID, runAgentID, occurredAt, SummaryMetadata{
+			TurnIndex: intPtr(0),
+			PhaseID:   "open",
+			Actor:     ConversationActorScripted,
+			Mismatch:  boolPtr(false),
+		}, `{}`),
+	}
+
+	transcript, err := TranscriptFromEvents(events)
+	if err != nil {
+		t.Fatalf("TranscriptFromEvents() error = %v", err)
+	}
+	if len(transcript) != 2 {
+		t.Fatalf("len(transcript) = %d, want 2", len(transcript))
+	}
+	if transcript[0].UserMessage != "Refund order 42" || transcript[0].AssistantMessage != "Checking order 42" {
+		t.Fatalf("turn 0 = %+v, want user+assistant messages", transcript[0])
+	}
+	if !transcript[0].Completed || transcript[0].FirstSequence != 1 || transcript[0].LastSequence != 4 {
+		t.Fatalf("turn 0 metadata = %+v", transcript[0])
+	}
+	if !transcript[1].UserSimulated || transcript[1].PhaseID != "dynamic" {
+		t.Fatalf("turn 1 = %+v, want simulated phase", transcript[1])
+	}
+}
+
+func TestTranscriptFromEventsPreservesMismatch(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	occurredAt := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+
+	events := []Envelope{
+		multiTurnEvent(1, EventTypeTurnUserMessage, runID, runAgentID, occurredAt, SummaryMetadata{
+			TurnIndex: intPtr(0),
+			PhaseID:   "open",
+			Actor:     ConversationActorScripted,
+		}, `{"content":"Hi","actor":"scripted","phase_id":"open"}`),
+		multiTurnEvent(2, EventTypeTurnCompleted, runID, runAgentID, occurredAt, SummaryMetadata{
+			TurnIndex: intPtr(0),
+			PhaseID:   "open",
+			Actor:     ConversationActorScripted,
+			Mismatch:  boolPtr(true),
+		}, `{}`),
+	}
+
+	transcript, err := TranscriptFromEvents(events)
+	if err != nil {
+		t.Fatalf("TranscriptFromEvents() error = %v", err)
+	}
+	if len(transcript) != 1 || !transcript[0].Mismatch {
+		t.Fatalf("transcript = %+v, want mismatch true", transcript)
+	}
+
+	encoded, err := json.Marshal(events[1].Summary)
+	if err != nil {
+		t.Fatalf("marshal summary: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"mismatch":true`) {
+		t.Fatalf("encoded summary = %s, want explicit mismatch true", encoded)
+	}
+}
+
+func TestValidateMultiTurnEventRejectsInvalidActor(t *testing.T) {
+	envelope := baseMultiTurnEnvelope(EventTypeTurnUserMessage, json.RawMessage(`{"content":"Hi","actor":"bot","phase_id":"open"}`))
+	envelope.Summary.TurnIndex = intPtr(0)
+	envelope.Summary.Actor = "bot"
+	if err := ValidateMultiTurnEvent(envelope); !errors.Is(err, ErrMultiTurnInvalidActor) {
+		t.Fatalf("error = %v, want ErrMultiTurnInvalidActor", err)
+	}
+}
+
+func baseMultiTurnEnvelope(eventType Type, payload json.RawMessage) Envelope {
+	return Envelope{
+		EventID:       "evt-mt",
+		SchemaVersion: SchemaVersionV1,
+		RunID:         uuid.New(),
+		RunAgentID:    uuid.New(),
+		EventType:     eventType,
+		Source:        SourceNativeEngine,
+		OccurredAt:    time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC),
+		Payload:       payload,
+		Summary:       SummaryMetadata{},
+	}
+}
+
+func multiTurnEvent(seq int64, eventType Type, runID uuid.UUID, runAgentID uuid.UUID, occurredAt time.Time, summary SummaryMetadata, payload string) Envelope {
+	return Envelope{
+		EventID:        "evt-" + string(eventType),
+		SchemaVersion:  SchemaVersionV1,
+		RunID:          runID,
+		RunAgentID:     runAgentID,
+		SequenceNumber: seq,
+		EventType:      eventType,
+		Source:         SourceNativeEngine,
+		OccurredAt:     occurredAt,
+		Payload:        json.RawMessage(payload),
+		Summary:        summary,
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}

--- a/backend/internal/runevents/multi_turn_test.go
+++ b/backend/internal/runevents/multi_turn_test.go
@@ -31,8 +31,18 @@ func TestMultiTurnEventTypesAreValid(t *testing.T) {
 }
 
 func TestValidateMultiTurnEventRequiredFields(t *testing.T) {
-	t.Run("turn.user.message requires turn_index and content", func(t *testing.T) {
+	t.Run("turn.user.message requires turn_index", func(t *testing.T) {
+		envelope := baseMultiTurnEnvelope(EventTypeTurnUserMessage, json.RawMessage(`{"content":"Hi","actor":"scripted","phase_id":"open"}`))
+		if err := ValidateMultiTurnEvent(envelope); err == nil {
+			t.Fatal("expected validation error for missing turn_index")
+		}
+	})
+
+	t.Run("turn.user.message requires content", func(t *testing.T) {
 		envelope := baseMultiTurnEnvelope(EventTypeTurnUserMessage, json.RawMessage(`{"content":"","actor":"scripted","phase_id":"open"}`))
+		envelope.Summary.TurnIndex = intPtr(0)
+		envelope.Summary.PhaseID = "open"
+		envelope.Summary.Actor = ConversationActorScripted
 		if err := ValidateMultiTurnEvent(envelope); err == nil {
 			t.Fatal("expected validation error for empty content")
 		}
@@ -160,6 +170,15 @@ func TestTranscriptFromEventsPreservesMismatch(t *testing.T) {
 	}
 	if !strings.Contains(string(encoded), `"mismatch":true`) {
 		t.Fatalf("encoded summary = %s, want explicit mismatch true", encoded)
+	}
+}
+
+func TestValidateTurnAwaitingHumanAcceptsSummaryOnlyPhaseID(t *testing.T) {
+	envelope := baseMultiTurnEnvelope(EventTypeTurnAwaitingHuman, nil)
+	envelope.Summary.TurnIndex = intPtr(2)
+	envelope.Summary.PhaseID = "human"
+	if err := ValidateMultiTurnEvent(envelope); err != nil {
+		t.Fatalf("ValidateMultiTurnEvent() error = %v", err)
 	}
 }
 

--- a/backend/internal/runevents/transcript.go
+++ b/backend/internal/runevents/transcript.go
@@ -33,18 +33,15 @@ func TranscriptFromEvents(events []Envelope) ([]TranscriptTurn, error) {
 
 	sorted := append([]Envelope(nil), events...)
 	sort.SliceStable(sorted, func(i, j int) bool {
-		left := sorted[i].SequenceNumber
-		right := sorted[j].SequenceNumber
-		if left == 0 && right == 0 {
-			return sorted[i].OccurredAt.Before(sorted[j].OccurredAt)
+		left := sorted[i]
+		right := sorted[j]
+		if left.SequenceNumber > 0 && right.SequenceNumber > 0 {
+			return left.SequenceNumber < right.SequenceNumber
 		}
-		if left == 0 {
-			return true
+		if !left.OccurredAt.Equal(right.OccurredAt) {
+			return left.OccurredAt.Before(right.OccurredAt)
 		}
-		if right == 0 {
-			return false
-		}
-		return left < right
+		return left.EventID < right.EventID
 	})
 
 	byIndex := make(map[int]*TranscriptTurn)

--- a/backend/internal/runevents/transcript.go
+++ b/backend/internal/runevents/transcript.go
@@ -1,0 +1,175 @@
+package runevents
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// TranscriptTurn is one user↔assistant turn reconstructed from run events.
+type TranscriptTurn struct {
+	TurnIndex         int
+	PhaseID           string
+	Actor             string
+	UserMessage       string
+	AssistantMessage  string
+	Mismatch          bool
+	Completed         bool
+	AwaitingHuman     bool
+	AwaitingHumanHint string
+	UserSimulated     bool
+	StateSnapshotRef  string
+	FirstSequence     int64
+	LastSequence      int64
+}
+
+// TranscriptFromEvents builds ordered transcript turns from persisted run events.
+// Events are sorted by sequence_number; turn_index groups user and assistant messages.
+func TranscriptFromEvents(events []Envelope) ([]TranscriptTurn, error) {
+	if len(events) == 0 {
+		return nil, nil
+	}
+
+	sorted := append([]Envelope(nil), events...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		left := sorted[i].SequenceNumber
+		right := sorted[j].SequenceNumber
+		if left == 0 && right == 0 {
+			return sorted[i].OccurredAt.Before(sorted[j].OccurredAt)
+		}
+		if left == 0 {
+			return true
+		}
+		if right == 0 {
+			return false
+		}
+		return left < right
+	})
+
+	byIndex := make(map[int]*TranscriptTurn)
+	order := make([]int, 0)
+
+	ensureTurn := func(turnIndex int) *TranscriptTurn {
+		if turn, ok := byIndex[turnIndex]; ok {
+			return turn
+		}
+		turn := &TranscriptTurn{TurnIndex: turnIndex}
+		byIndex[turnIndex] = turn
+		order = append(order, turnIndex)
+		return turn
+	}
+
+	for _, event := range sorted {
+		seq := event.SequenceNumber
+		switch event.EventType {
+		case EventTypeTurnUserMessage:
+			if event.Summary.TurnIndex == nil {
+				return nil, fmt.Errorf("turn.user.message missing turn_index at sequence %d", seq)
+			}
+			turn := ensureTurn(*event.Summary.TurnIndex)
+			content, err := decodeTurnUserMessageContent(event.Payload)
+			if err != nil {
+				return nil, fmt.Errorf("sequence %d: %w", seq, err)
+			}
+			turn.UserMessage = content
+			turn.PhaseID = firstNonEmpty(event.Summary.PhaseID, turn.PhaseID)
+			turn.Actor = firstNonEmpty(event.Summary.Actor, turn.Actor)
+			turn.trackSequence(seq)
+
+		case EventTypeTurnUserSimulated:
+			if event.Summary.TurnIndex == nil {
+				return nil, fmt.Errorf("turn.user.simulated missing turn_index at sequence %d", seq)
+			}
+			turn := ensureTurn(*event.Summary.TurnIndex)
+			turn.UserSimulated = true
+			turn.PhaseID = firstNonEmpty(event.Summary.PhaseID, turn.PhaseID)
+			turn.trackSequence(seq)
+
+		case EventTypeTurnAssistantMessage:
+			if event.Summary.TurnIndex == nil {
+				return nil, fmt.Errorf("turn.assistant.message missing turn_index at sequence %d", seq)
+			}
+			turn := ensureTurn(*event.Summary.TurnIndex)
+			content, err := decodeTurnAssistantMessageContent(event.Payload)
+			if err != nil {
+				return nil, fmt.Errorf("sequence %d: %w", seq, err)
+			}
+			turn.AssistantMessage = content
+			turn.PhaseID = firstNonEmpty(event.Summary.PhaseID, turn.PhaseID)
+			turn.trackSequence(seq)
+
+		case EventTypeTurnCompleted:
+			if event.Summary.TurnIndex == nil {
+				continue
+			}
+			turn := ensureTurn(*event.Summary.TurnIndex)
+			turn.Completed = true
+			turn.PhaseID = firstNonEmpty(event.Summary.PhaseID, turn.PhaseID)
+			turn.Actor = firstNonEmpty(event.Summary.Actor, turn.Actor)
+			if event.Summary.Mismatch != nil {
+				turn.Mismatch = *event.Summary.Mismatch
+			}
+			turn.trackSequence(seq)
+
+		case EventTypeTurnAwaitingHuman:
+			if event.Summary.TurnIndex == nil {
+				return nil, fmt.Errorf("turn.awaiting_human missing turn_index at sequence %d", seq)
+			}
+			turn := ensureTurn(*event.Summary.TurnIndex)
+			turn.AwaitingHuman = true
+			turn.PhaseID = firstNonEmpty(event.Summary.PhaseID, turn.PhaseID)
+			var payload turnAwaitingHumanPayload
+			if len(event.Payload) > 0 {
+				if err := json.Unmarshal(event.Payload, &payload); err != nil {
+					return nil, fmt.Errorf("sequence %d: decode turn.awaiting_human: %w", seq, err)
+				}
+			}
+			turn.AwaitingHumanHint = payload.PromptHint
+			turn.trackSequence(seq)
+
+		case EventTypeTurnStateCaptured:
+			if event.Summary.TurnIndex == nil {
+				continue
+			}
+			turn := ensureTurn(*event.Summary.TurnIndex)
+			var payload turnStateCapturedPayload
+			if err := json.Unmarshal(event.Payload, &payload); err != nil {
+				return nil, fmt.Errorf("sequence %d: decode turn.state.captured: %w", seq, err)
+			}
+			turn.StateSnapshotRef = payload.SnapshotRef
+			turn.trackSequence(seq)
+
+		case EventTypeConversationCompleted:
+			// Terminal marker; transcript turns already captured.
+		}
+	}
+
+	sort.Ints(order)
+	out := make([]TranscriptTurn, 0, len(order))
+	for _, idx := range order {
+		out = append(out, *byIndex[idx])
+	}
+	return out, nil
+}
+
+func (t *TranscriptTurn) trackSequence(seq int64) {
+	if seq <= 0 {
+		return
+	}
+	if t.FirstSequence == 0 || seq < t.FirstSequence {
+		t.FirstSequence = seq
+	}
+	if seq > t.LastSequence {
+		t.LastSequence = seq
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/docs/challenge-packs/multi-turn-events.md
+++ b/docs/challenge-packs/multi-turn-events.md
@@ -1,0 +1,35 @@
+# Multi-turn run events and transcript
+
+Challenge-pack multi-turn evals emit sequence-numbered conversation events alongside the existing native multi-step tool loop. Scoring, replay, and human workflows reconstruct turns from these events.
+
+## Event types
+
+| Type | Purpose |
+|------|---------|
+| `turn.user.message` | Scripted, LLM, or human user message for a turn |
+| `turn.user.simulated` | LLM simulator metadata (model, token usage) |
+| `turn.assistant.message` | Final assistant text summary for the turn |
+| `turn.completed` | Turn boundary; includes `mismatch` when expects fail |
+| `turn.awaiting_human` | H3 blocked state waiting for operator input |
+| `turn.state.captured` | Optional snapshot reference |
+| `conversation.completed` | Outer loop terminal marker |
+
+## Summary metadata
+
+Multi-turn events reuse envelope `summary` fields:
+
+- `turn_index` — zero-based outer turn counter
+- `phase_id` — active `user_simulator` phase
+- `actor` — `scripted`, `llm`, or `human`
+- `mismatch` — explicit bool on `turn.completed` for native multi-turn runs
+
+Voice adapter `turn.completed` events remain valid without `phase_id` / `actor`.
+
+## Transcript helper
+
+`runevents.TranscriptFromEvents([]Envelope)` sorts by `sequence_number` and groups user + assistant content per `turn_index`. Emitters land in sub-issue #843; this issue defines types, validation, and reconstruction only.
+
+## Validation
+
+- `Envelope.ValidatePending()` — generic envelope checks (all event types)
+- `ValidateMultiTurnEvent()` — stricter checks for native multi-turn emitters


### PR DESCRIPTION
## Summary

- Adds multi-turn conversation run event types (`turn.user.message`, `turn.user.simulated`, `turn.assistant.message`, `turn.awaiting_human`, `turn.state.captured`, `conversation.completed`) and extends `turn.completed` summary metadata (`phase_id`, `actor`, `mismatch`).
- Introduces `ValidateMultiTurnEvent` for native emitters while keeping voice `turn.completed` events backward compatible.
- Adds `TranscriptFromEvents` to reconstruct ordered user↔assistant turns for scoring/replay (#843+).

Closes #842

## Test plan

- [x] `cd backend && go test -short -race -count=1 ./internal/runevents/...`
- [ ] Greptile review
- [ ] Claude Code review