### PR TITLE
feat(multi-turn): hybrid eval executor, human takeover, calibration, arena (#839)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,10 @@ go run . run list
 go run . run create --help
 # When the workspace already has challenge packs and deployments:
 go run . run create --follow
+
+# Multi-turn human takeover (while a run agent awaits operator input):
+go run . run turn status <runAgentId> --run <runId>
+go run . run turn submit <runAgentId> --run <runId> --message "Your message here"
 ```
 
 Resolution order for the API base URL is:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,7 @@ Production uses WorkOS AuthKit. Local dev uses `AUTH_MODE=dev` which reads `X-De
 - Optional services default to noop implementations (see `newRouter()` in routes.go)
 - Tool visibility per run is determined by the challenge pack's tool policy, not the LLM provider
 - Hosted external agents integrate via Temporal workflow signals (API callback → signal → workflow resumes)
+- Multi-turn packs use `execution_mode: multi_turn` with a per-case `user_simulator` manifest (scripted / LLM / human phases). See `docs/challenge-packs/multi-turn.md` and reference pack `examples/challenge-packs/multi-turn-refund-recovery.yaml`. Human turns use `agentclash run turn submit|status`; calibration reviews score 1–5; arena tasks are created post-run for eligible agent pairs.
 
 ## OpenAPI Specification
 

--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -99,6 +99,7 @@ func main() {
 		WithBudgetChecker(budgetChecker).
 		WithInsightsRateLimiter(insightsLimiter).
 		WithRunWorkflowControl(api.NewTemporalRunWorkflowCanceller(temporalClient))
+	multiTurnManager := api.NewMultiTurnManager(authorizer, repo, repository.NewMultiTurnHumanTurnStore(db))
 	if !runReadManager.InsightsConfigured() {
 		logger.Error("run ranking insights client is not configured")
 		os.Exit(1)
@@ -206,6 +207,7 @@ func main() {
 		publicShareManager,
 		billingManager,
 		eventSubscriber,
+		multiTurnManager,
 		cliAuthManager,
 	)
 

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -122,10 +122,19 @@ func main() {
 		providerRouter,
 		workerapp.NewBufferedPromptEvalObserverFactory(eventRecorder),
 	).WithSecretsLookup(repo)
+	multiTurnInvoker := workerapp.NewMultiTurnInvokerWithObserverFactory(
+		providerRouter,
+		sandboxProvider,
+		workerapp.NewBufferedMultiTurnObserverFactory(eventRecorder),
+	).WithSecretsLookup(repo).
+		WithAssetLoader(workerapp.NewArtifactAssetLoader(repo, artifactStore).WithMaxBytes(cfg.ArtifactStorage.MaxDownloadBytes)).
+		WithStandingsStore(standingsStore).
+		WithHumanTurnStore(repository.NewMultiTurnHumanTurnStore(db))
 	temporalWorker := workerapp.NewTemporalWorker(temporalClient, cfg, repo, providerRouter, sandboxProvider, githubClient, workflowpkg.FakeWorkHooks{
 		HostedRunStarter:   hostedRunClient,
 		NativeModelInvoker: nativeModelInvoker,
 		PromptEvalInvoker:  promptEvalInvoker,
+		MultiTurnInvoker:   multiTurnInvoker,
 	})
 	orphanRunReaper := workerapp.NewRepositoryOrphanRunReaper(repo, cfg.OrphanRunReaperInterval, cfg.OrphanRunReaperThreshold, logger)
 

--- a/backend/db/migrations/00047_multi_turn_human_calibration_arena.sql
+++ b/backend/db/migrations/00047_multi_turn_human_calibration_arena.sql
@@ -1,0 +1,82 @@
+-- +goose Up
+CREATE TABLE multi_turn_human_turns (
+    run_agent_id uuid NOT NULL REFERENCES run_agents (id) ON DELETE CASCADE,
+    turn_index integer NOT NULL CHECK (turn_index >= 0),
+    phase_id text NOT NULL,
+    prompt_hint text,
+    status text NOT NULL CHECK (status IN ('awaiting', 'submitted', 'expired')),
+    message text,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    submitted_at timestamptz,
+    PRIMARY KEY (run_agent_id, turn_index)
+);
+
+CREATE INDEX multi_turn_human_turns_awaiting_idx
+ON multi_turn_human_turns (run_agent_id)
+WHERE status = 'awaiting';
+
+CREATE TABLE calibration_reviews (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace_id uuid NOT NULL REFERENCES workspaces (id) ON DELETE CASCADE,
+    run_agent_id uuid NOT NULL REFERENCES run_agents (id) ON DELETE CASCADE,
+    turn_index integer NOT NULL CHECK (turn_index >= 0),
+    reviewer_user_id uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    score numeric(4,2) NOT NULL CHECK (score >= 1 AND score <= 5),
+    rubric_key text,
+    notes text,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX calibration_reviews_workspace_idx ON calibration_reviews (workspace_id, created_at DESC);
+
+CREATE TABLE workspace_arena_tasks (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace_id uuid NOT NULL REFERENCES workspaces (id) ON DELETE CASCADE,
+    case_key text NOT NULL,
+    left_run_agent_id uuid NOT NULL REFERENCES run_agents (id) ON DELETE CASCADE,
+    right_run_agent_id uuid NOT NULL REFERENCES run_agents (id) ON DELETE CASCADE,
+    status text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'completed')),
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX workspace_arena_tasks_pending_idx
+ON workspace_arena_tasks (workspace_id, status, created_at);
+
+CREATE TABLE workspace_arena_votes (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    task_id uuid NOT NULL REFERENCES workspace_arena_tasks (id) ON DELETE CASCADE,
+    voter_user_id uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    winner_run_agent_id uuid NOT NULL REFERENCES run_agents (id) ON DELETE CASCADE,
+    rubric_scores jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (task_id, voter_user_id)
+);
+
+CREATE TABLE multi_turn_run_agent_flags (
+    run_agent_id uuid PRIMARY KEY REFERENCES run_agents (id) ON DELETE CASCADE,
+    workspace_id uuid NOT NULL REFERENCES workspaces (id) ON DELETE CASCADE,
+    run_id uuid NOT NULL REFERENCES runs (id) ON DELETE CASCADE,
+    case_key text NOT NULL DEFAULT '',
+    calibration_candidate boolean NOT NULL DEFAULT false,
+    arena_eligible boolean NOT NULL DEFAULT false,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX multi_turn_run_agent_flags_run_idx ON multi_turn_run_agent_flags (run_id);
+CREATE INDEX multi_turn_run_agent_flags_arena_idx
+ON multi_turn_run_agent_flags (workspace_id, arena_eligible)
+WHERE arena_eligible;
+
+CREATE UNIQUE INDEX workspace_arena_tasks_pair_idx
+ON workspace_arena_tasks (
+    LEAST(left_run_agent_id, right_run_agent_id),
+    GREATEST(left_run_agent_id, right_run_agent_id)
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS workspace_arena_votes;
+DROP TABLE IF EXISTS workspace_arena_tasks;
+DROP TABLE IF EXISTS calibration_reviews;
+DROP TABLE IF EXISTS multi_turn_run_agent_flags;
+DROP TABLE IF EXISTS multi_turn_human_turns;

--- a/backend/internal/api/multi_turn.go
+++ b/backend/internal/api/multi_turn.go
@@ -1,0 +1,424 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/agentclash/agentclash/backend/internal/domain"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+const timeRFC3339Nano = "2006-01-02T15:04:05.999999999Z07:00"
+
+type MultiTurnService interface {
+	SubmitHumanTurn(ctx context.Context, caller Caller, workspaceID, runID, runAgentID uuid.UUID, message string) error
+	GetHumanTurnStatus(ctx context.Context, caller Caller, workspaceID, runID, runAgentID uuid.UUID) (*repository.HumanTurnStatus, error)
+	CreateCalibrationReview(ctx context.Context, caller Caller, workspaceID uuid.UUID, req CalibrationReviewRequest) error
+	ListCalibrationReviews(ctx context.Context, caller Caller, workspaceID uuid.UUID) ([]CalibrationReviewResponse, error)
+	ListArenaTasks(ctx context.Context, caller Caller, workspaceID uuid.UUID) ([]ArenaTaskResponse, error)
+	SubmitArenaVote(ctx context.Context, caller Caller, workspaceID uuid.UUID, req ArenaVoteRequest) error
+}
+
+type CalibrationReviewRequest struct {
+	RunAgentID uuid.UUID `json:"run_agent_id"`
+	TurnIndex  int       `json:"turn_index"`
+	Score      float64   `json:"score"`
+	RubricKey  string    `json:"rubric_key,omitempty"`
+	Notes      string    `json:"notes,omitempty"`
+}
+
+type CalibrationReviewResponse struct {
+	ID           uuid.UUID `json:"id"`
+	RunAgentID   uuid.UUID `json:"run_agent_id"`
+	TurnIndex    int       `json:"turn_index"`
+	Score        float64   `json:"score"`
+	RubricKey    string    `json:"rubric_key,omitempty"`
+	Notes        string    `json:"notes,omitempty"`
+	ReviewerID   uuid.UUID `json:"reviewer_user_id"`
+	CreatedAtRFC string    `json:"created_at"`
+}
+
+type ArenaTaskResponse struct {
+	ID                uuid.UUID `json:"id"`
+	CaseKey           string    `json:"case_key"`
+	LeftRunAgentID    uuid.UUID `json:"left_run_agent_id"`
+	RightRunAgentID   uuid.UUID `json:"right_run_agent_id"`
+	Status            string    `json:"status"`
+}
+
+type ArenaVoteRequest struct {
+	TaskID            uuid.UUID          `json:"task_id"`
+	WinnerRunAgentID  uuid.UUID          `json:"winner_run_agent_id"`
+	RubricScores      map[string]float64 `json:"rubric_scores,omitempty"`
+}
+
+type submitHumanTurnRequest struct {
+	Message string `json:"message"`
+}
+
+func submitMultiTurnHumanTurnHandler(logger *slog.Logger, service MultiTurnService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", err.Error())
+			return
+		}
+		workspaceID, err := workspaceIDFromURLParam("workspaceID")(r)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_workspace_id", err.Error())
+			return
+		}
+		runID, err := runIDFromURLParam("runID")(r)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_run_id", err.Error())
+			return
+		}
+		runAgentID, err := uuid.Parse(r.PathValue("runAgentID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_run_agent_id", err.Error())
+			return
+		}
+		var body submitHumanTurnRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_json", "request body must be valid JSON")
+			return
+		}
+		if err := service.SubmitHumanTurn(r.Context(), caller, workspaceID, runID, runAgentID, body.Message); err != nil {
+			writeMultiTurnError(w, logger, r, err)
+			return
+		}
+		writeJSON(w, http.StatusAccepted, map[string]string{"status": "submitted"})
+	}
+}
+
+func getMultiTurnHumanTurnStatusHandler(logger *slog.Logger, service MultiTurnService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", err.Error())
+			return
+		}
+		workspaceID, err := workspaceIDFromURLParam("workspaceID")(r)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_workspace_id", err.Error())
+			return
+		}
+		runID, err := runIDFromURLParam("runID")(r)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_run_id", err.Error())
+			return
+		}
+		runAgentID, err := uuid.Parse(r.PathValue("runAgentID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_run_agent_id", err.Error())
+			return
+		}
+		status, err := service.GetHumanTurnStatus(r.Context(), caller, workspaceID, runID, runAgentID)
+		if err != nil {
+			writeMultiTurnError(w, logger, r, err)
+			return
+		}
+		if status == nil {
+			writeJSON(w, http.StatusOK, map[string]any{"awaiting_human": false})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"awaiting_human": true,
+			"turn_index":     status.TurnIndex,
+			"phase_id":       status.PhaseID,
+			"prompt_hint":    status.PromptHint,
+		})
+	}
+}
+
+type MultiTurnManager struct {
+	authorizer WorkspaceAuthorizer
+	repo       *repository.Repository
+	humanTurns *repository.MultiTurnHumanTurnStore
+}
+
+func NewMultiTurnManager(authorizer WorkspaceAuthorizer, repo *repository.Repository, humanTurns *repository.MultiTurnHumanTurnStore) *MultiTurnManager {
+	return &MultiTurnManager{authorizer: authorizer, repo: repo, humanTurns: humanTurns}
+}
+
+func (m *MultiTurnManager) SubmitHumanTurn(ctx context.Context, caller Caller, workspaceID, runID, runAgentID uuid.UUID, message string) error {
+	if m.humanTurns == nil {
+		return errors.New("multi_turn human turns are not configured")
+	}
+	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, workspaceID); err != nil {
+		return err
+	}
+	run, err := m.repo.GetRunByID(ctx, runID)
+	if err != nil {
+		return err
+	}
+	if run.WorkspaceID != workspaceID {
+		return repository.ErrRunNotFound
+	}
+	runAgent, err := m.repo.GetRunAgentByID(ctx, runAgentID)
+	if err != nil {
+		return err
+	}
+	if runAgent.RunID != runID {
+		return repository.ErrRunAgentNotFound
+	}
+	if runAgent.Status != domain.RunAgentStatusExecuting {
+		return errors.New("run agent is not executing")
+	}
+	status, err := m.humanTurns.AwaitingTurn(ctx, runAgentID)
+	if err != nil {
+		return err
+	}
+	if status == nil {
+		return repository.ErrHumanTurnNotAwaiting
+	}
+	return m.humanTurns.SubmitHumanMessage(ctx, runAgentID, status.TurnIndex, message)
+}
+
+func (m *MultiTurnManager) GetHumanTurnStatus(ctx context.Context, caller Caller, workspaceID, runID, runAgentID uuid.UUID) (*repository.HumanTurnStatus, error) {
+	if m.humanTurns == nil {
+		return nil, errors.New("multi_turn human turns are not configured")
+	}
+	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, workspaceID); err != nil {
+		return nil, err
+	}
+	run, err := m.repo.GetRunByID(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	if run.WorkspaceID != workspaceID {
+		return nil, repository.ErrRunNotFound
+	}
+	runAgent, err := m.repo.GetRunAgentByID(ctx, runAgentID)
+	if err != nil {
+		return nil, err
+	}
+	if runAgent.RunID != runID {
+		return nil, repository.ErrRunAgentNotFound
+	}
+	return m.humanTurns.AwaitingTurn(ctx, runAgentID)
+}
+
+func (m *MultiTurnManager) CreateCalibrationReview(ctx context.Context, caller Caller, workspaceID uuid.UUID, req CalibrationReviewRequest) error {
+	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, workspaceID); err != nil {
+		return err
+	}
+	if req.Score < 1 || req.Score > 5 {
+		return fmt.Errorf("calibration score must be between 1 and 5")
+	}
+	return m.repo.CreateCalibrationReview(ctx, repository.CreateCalibrationReviewParams{
+		WorkspaceID:    workspaceID,
+		RunAgentID:     req.RunAgentID,
+		TurnIndex:      req.TurnIndex,
+		ReviewerUserID: caller.UserID,
+		Score:          req.Score,
+		RubricKey:      req.RubricKey,
+		Notes:          req.Notes,
+	})
+}
+
+func (m *MultiTurnManager) ListCalibrationReviews(ctx context.Context, caller Caller, workspaceID uuid.UUID) ([]CalibrationReviewResponse, error) {
+	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, workspaceID); err != nil {
+		return nil, err
+	}
+	rows, err := m.repo.ListCalibrationReviews(ctx, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]CalibrationReviewResponse, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, CalibrationReviewResponse{
+			ID:           row.ID,
+			RunAgentID:   row.RunAgentID,
+			TurnIndex:    row.TurnIndex,
+			Score:        row.Score,
+			RubricKey:    row.RubricKey,
+			Notes:        row.Notes,
+			ReviewerID:   row.ReviewerUserID,
+			CreatedAtRFC: row.CreatedAt.UTC().Format(timeRFC3339Nano),
+		})
+	}
+	return out, nil
+}
+
+func (m *MultiTurnManager) ListArenaTasks(ctx context.Context, caller Caller, workspaceID uuid.UUID) ([]ArenaTaskResponse, error) {
+	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, workspaceID); err != nil {
+		return nil, err
+	}
+	rows, err := m.repo.ListPendingArenaTasks(ctx, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ArenaTaskResponse, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, ArenaTaskResponse{
+			ID:              row.ID,
+			CaseKey:         row.CaseKey,
+			LeftRunAgentID:  row.LeftRunAgentID,
+			RightRunAgentID: row.RightRunAgentID,
+			Status:          row.Status,
+		})
+	}
+	return out, nil
+}
+
+func (m *MultiTurnManager) SubmitArenaVote(ctx context.Context, caller Caller, workspaceID uuid.UUID, req ArenaVoteRequest) error {
+	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, workspaceID); err != nil {
+		return err
+	}
+	return m.repo.SubmitArenaVote(ctx, repository.SubmitArenaVoteParams{
+		WorkspaceID:      workspaceID,
+		TaskID:           req.TaskID,
+		VoterUserID:      caller.UserID,
+		WinnerRunAgentID: req.WinnerRunAgentID,
+		RubricScores:     req.RubricScores,
+	})
+}
+
+func writeMultiTurnError(w http.ResponseWriter, logger *slog.Logger, r *http.Request, err error) {
+	if errors.Is(err, ErrForbidden) {
+		writeAuthzError(w, err)
+		return
+	}
+	if errors.Is(err, repository.ErrRunNotFound) || errors.Is(err, repository.ErrRunAgentNotFound) {
+		writeError(w, http.StatusNotFound, "not_found", err.Error())
+		return
+	}
+	if errors.Is(err, repository.ErrHumanTurnNotAwaiting) {
+		writeError(w, http.StatusConflict, "not_awaiting_human", err.Error())
+		return
+	}
+	logger.Error("multi_turn request failed",
+		"method", r.Method,
+		"path", r.URL.Path,
+		"error", err,
+	)
+	writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+}
+
+func createCalibrationReviewHandler(logger *slog.Logger, service MultiTurnService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", err.Error())
+			return
+		}
+		workspaceID, err := workspaceIDFromURLParam("workspaceID")(r)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_workspace_id", err.Error())
+			return
+		}
+		var body CalibrationReviewRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_json", "request body must be valid JSON")
+			return
+		}
+		if err := service.CreateCalibrationReview(r.Context(), caller, workspaceID, body); err != nil {
+			writeMultiTurnError(w, logger, r, err)
+			return
+		}
+		writeJSON(w, http.StatusCreated, map[string]string{"status": "created"})
+	}
+}
+
+func listCalibrationReviewsHandler(logger *slog.Logger, service MultiTurnService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", err.Error())
+			return
+		}
+		workspaceID, err := workspaceIDFromURLParam("workspaceID")(r)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_workspace_id", err.Error())
+			return
+		}
+		reviews, err := service.ListCalibrationReviews(r.Context(), caller, workspaceID)
+		if err != nil {
+			writeMultiTurnError(w, logger, r, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"items": reviews})
+	}
+}
+
+func listArenaTasksHandler(logger *slog.Logger, service MultiTurnService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", err.Error())
+			return
+		}
+		workspaceID, err := workspaceIDFromURLParam("workspaceID")(r)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_workspace_id", err.Error())
+			return
+		}
+		tasks, err := service.ListArenaTasks(r.Context(), caller, workspaceID)
+		if err != nil {
+			writeMultiTurnError(w, logger, r, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"items": tasks})
+	}
+}
+
+func submitArenaVoteHandler(logger *slog.Logger, service MultiTurnService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", err.Error())
+			return
+		}
+		workspaceID, err := workspaceIDFromURLParam("workspaceID")(r)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_workspace_id", err.Error())
+			return
+		}
+		var body ArenaVoteRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_json", "request body must be valid JSON")
+			return
+		}
+		if err := service.SubmitArenaVote(r.Context(), caller, workspaceID, body); err != nil {
+			writeMultiTurnError(w, logger, r, err)
+			return
+		}
+		writeJSON(w, http.StatusCreated, map[string]string{"status": "recorded"})
+	}
+}
+
+type noopMultiTurnService struct{}
+
+func (noopMultiTurnService) SubmitHumanTurn(context.Context, Caller, uuid.UUID, uuid.UUID, uuid.UUID, string) error {
+	return errors.New("multi_turn service is not configured")
+}
+
+func (noopMultiTurnService) GetHumanTurnStatus(context.Context, Caller, uuid.UUID, uuid.UUID, uuid.UUID) (*repository.HumanTurnStatus, error) {
+	return nil, errors.New("multi_turn service is not configured")
+}
+
+func (noopMultiTurnService) CreateCalibrationReview(context.Context, Caller, uuid.UUID, CalibrationReviewRequest) error {
+	return errors.New("multi_turn service is not configured")
+}
+
+func (noopMultiTurnService) ListCalibrationReviews(context.Context, Caller, uuid.UUID) ([]CalibrationReviewResponse, error) {
+	return nil, errors.New("multi_turn service is not configured")
+}
+
+func (noopMultiTurnService) ListArenaTasks(context.Context, Caller, uuid.UUID) ([]ArenaTaskResponse, error) {
+	return nil, errors.New("multi_turn service is not configured")
+}
+
+func (noopMultiTurnService) SubmitArenaVote(context.Context, Caller, uuid.UUID, ArenaVoteRequest) error {
+	return errors.New("multi_turn service is not configured")
+}

--- a/backend/internal/api/multi_turn.go
+++ b/backend/internal/api/multi_turn.go
@@ -297,6 +297,10 @@ func writeMultiTurnError(w http.ResponseWriter, logger *slog.Logger, r *http.Req
 		writeError(w, http.StatusConflict, "not_awaiting_human", err.Error())
 		return
 	}
+	if errors.Is(err, repository.ErrInvalidArenaVoteWinner) {
+		writeError(w, http.StatusBadRequest, "invalid_arena_vote", err.Error())
+		return
+	}
 	logger.Error("multi_turn request failed",
 		"method", r.Method,
 		"path", r.URL.Path,
@@ -307,6 +311,10 @@ func writeMultiTurnError(w http.ResponseWriter, logger *slog.Logger, r *http.Req
 
 func createCalibrationReviewHandler(logger *slog.Logger, service MultiTurnService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
 		caller, err := CallerFromContext(r.Context())
 		if err != nil {
 			writeError(w, http.StatusUnauthorized, "unauthorized", err.Error())
@@ -374,6 +382,10 @@ func listArenaTasksHandler(logger *slog.Logger, service MultiTurnService) http.H
 
 func submitArenaVoteHandler(logger *slog.Logger, service MultiTurnService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if err := requireJSONContentType(r); err != nil {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type", err.Error())
+			return
+		}
 		caller, err := CallerFromContext(r.Context())
 		if err != nil {
 			writeError(w, http.StatusUnauthorized, "unauthorized", err.Error())

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -38,6 +38,7 @@ func registerProtectedRoutes(
 	cliAuthService CLIAuthService,
 	publicShareService PublicShareService,
 	billingService BillingService,
+	multiTurnService MultiTurnService,
 ) {
 	entitlementGate := entitlementGateFromBillingService(billingService)
 
@@ -86,6 +87,18 @@ func registerProtectedRoutes(
 	// so cross-workspace requests return 404 instead of leaking run existence via middleware.
 	router.Get("/workspaces/{workspaceID}/runs/{runID}/failures", listRunFailuresHandler(logger, runReadService))
 	router.Post("/workspaces/{workspaceID}/runs/{runID}/failures/{challengeIdentityID}/promote", promoteFailureHandler(logger, regressionService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Post("/workspaces/{workspaceID}/runs/{runID}/run-agents/{runAgentID}/turns", submitMultiTurnHumanTurnHandler(logger, multiTurnService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Get("/workspaces/{workspaceID}/runs/{runID}/run-agents/{runAgentID}/turns/status", getMultiTurnHumanTurnStatusHandler(logger, multiTurnService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Post("/workspaces/{workspaceID}/calibration-reviews", createCalibrationReviewHandler(logger, multiTurnService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Get("/workspaces/{workspaceID}/calibration-reviews", listCalibrationReviewsHandler(logger, multiTurnService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Get("/workspaces/{workspaceID}/arena/tasks", listArenaTasksHandler(logger, multiTurnService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Post("/workspaces/{workspaceID}/arena/votes", submitArenaVoteHandler(logger, multiTurnService))
 	router.Get("/compare", getRunComparisonHandler(logger, compareReadService))
 	router.Get("/compare/viewer", getRunComparisonViewerHandler(logger))
 	router.Get("/release-gates", listReleaseGatesHandler(logger, releaseGateService))

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -55,6 +55,7 @@ type routerOptions struct {
 	billingService             BillingService
 	eventSubscriber            pubsub.EventSubscriber
 	cliAuthServices            []CLIAuthService
+	multiTurnService           MultiTurnService
 }
 
 func NewServer(
@@ -88,6 +89,7 @@ func NewServer(
 	publicShareService PublicShareService,
 	billingService BillingService,
 	eventSubscriber pubsub.EventSubscriber,
+	multiTurnService MultiTurnService,
 	cliAuthServices ...CLIAuthService,
 ) *Server {
 	router := buildRouter(routerOptions{
@@ -123,6 +125,7 @@ func NewServer(
 		publicShareService:         publicShareService,
 		billingService:             billingService,
 		eventSubscriber:            eventSubscriber,
+		multiTurnService:           multiTurnService,
 		cliAuthServices:            cliAuthServices,
 	})
 
@@ -267,6 +270,7 @@ func buildRouter(opts routerOptions) http.Handler {
 	workspaceSecretsService := opts.workspaceSecretsService
 	publicShareService := opts.publicShareService
 	billingService := opts.billingService
+	multiTurnService := opts.multiTurnService
 	eventSubscriber := opts.eventSubscriber
 	var cliAuthService CLIAuthService
 	if len(opts.cliAuthServices) > 0 {
@@ -312,6 +316,9 @@ func buildRouter(opts routerOptions) http.Handler {
 	}
 	if billingService == nil {
 		billingService = noopBillingService{}
+	}
+	if multiTurnService == nil {
+		multiTurnService = noopMultiTurnService{}
 	}
 
 	router := chi.NewRouter()
@@ -364,7 +371,7 @@ func buildRouter(opts routerOptions) http.Handler {
 	router.Route("/v1", func(r chi.Router) {
 		r.Use(authenticateRequest(logger, authenticator))
 		r.Use(rateLimiter.Middleware("default", extractWorkspaceID))
-		registerProtectedRoutes(r, logger, authorizer, playgroundService, artifactService, artifactMaxUploadBytes, runCreationService, runReadService, replayReadService, compareReadService, releaseGateService, regressionService, agentDeploymentReadService, agentHarnessService, githubIntegrationService, challengePackReadService, challengePackAuthoringService, agentBuildService, userService, orgService, wsService, orgMembershipService, wsMembershipService, onboardingService, infraService, workspaceSecretsService, cliAuthService, publicShareService, billingService)
+		registerProtectedRoutes(r, logger, authorizer, playgroundService, artifactService, artifactMaxUploadBytes, runCreationService, runReadService, replayReadService, compareReadService, releaseGateService, regressionService, agentDeploymentReadService, agentHarnessService, githubIntegrationService, challengePackReadService, challengePackAuthoringService, agentBuildService, userService, orgService, wsService, orgMembershipService, wsMembershipService, onboardingService, infraService, workspaceSecretsService, cliAuthService, publicShareService, billingService, multiTurnService)
 	})
 
 	return router

--- a/backend/internal/challengepack/bundle.go
+++ b/backend/internal/challengepack/bundle.go
@@ -138,13 +138,14 @@ type CaseExpectation struct {
 }
 
 type StoredCaseDocument struct {
-	SchemaVersion int32             `json:"schema_version,omitempty"`
-	CaseKey       string            `json:"case_key,omitempty"`
-	Payload       map[string]any    `json:"payload,omitempty"`
-	Inputs        []CaseInput       `json:"inputs,omitempty"`
-	Expectations  []CaseExpectation `json:"expectations,omitempty"`
-	Artifacts     []ArtifactRef     `json:"artifacts,omitempty"`
-	Assets        []AssetReference  `json:"assets,omitempty"`
+	SchemaVersion int32              `json:"schema_version,omitempty"`
+	CaseKey       string             `json:"case_key,omitempty"`
+	Payload       map[string]any     `json:"payload,omitempty"`
+	Inputs        []CaseInput        `json:"inputs,omitempty"`
+	Expectations  []CaseExpectation  `json:"expectations,omitempty"`
+	UserSimulator *UserSimulatorSpec `json:"user_simulator,omitempty"`
+	Artifacts     []ArtifactRef      `json:"artifacts,omitempty"`
+	Assets        []AssetReference   `json:"assets,omitempty"`
 }
 
 type LegacyItemDefinition struct {
@@ -497,7 +498,7 @@ func (c CaseDefinition) IsLegacyPayloadOnly() bool {
 	// Legacy packs only used raw payload blobs keyed by item_key. We keep that
 	// storage shape for backward compatibility when no generalized case fields
 	// are present.
-	return len(c.Inputs) == 0 && len(c.Expectations) == 0 && len(c.Artifacts) == 0 && len(c.Assets) == 0
+	return len(c.Inputs) == 0 && len(c.Expectations) == 0 && c.UserSimulator == nil && len(c.Artifacts) == 0 && len(c.Assets) == 0
 }
 
 func (c CaseDefinition) StoredPayload() (json.RawMessage, error) {
@@ -514,6 +515,7 @@ func (c CaseDefinition) StoredPayload() (json.RawMessage, error) {
 		Payload:       cloneObject(c.Payload),
 		Inputs:        append([]CaseInput(nil), c.Inputs...),
 		Expectations:  append([]CaseExpectation(nil), c.Expectations...),
+		UserSimulator: cloneUserSimulatorSpec(c.UserSimulator),
 		Artifacts:     append([]ArtifactRef(nil), c.Artifacts...),
 		Assets:        normalizeAssets(c.Assets),
 	})

--- a/backend/internal/challengepack/multi_turn_refund_recovery_example_test.go
+++ b/backend/internal/challengepack/multi_turn_refund_recovery_example_test.go
@@ -1,0 +1,56 @@
+package challengepack_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/challengepack"
+	"github.com/agentclash/agentclash/backend/internal/scoring"
+)
+
+func TestExamplePack_MultiTurnRefundRecovery_LoadsAndValidates(t *testing.T) {
+	path := repoRelative(t, "examples/challenge-packs/multi-turn-refund-recovery.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read pack: %v", err)
+	}
+	bundle, err := challengepack.ParseYAML(data)
+	if err != nil {
+		t.Fatalf("ParseYAML: %v", err)
+	}
+	if bundle.Pack.Slug != "multi-turn-refund-recovery" {
+		t.Fatalf("slug = %q; want multi-turn-refund-recovery", bundle.Pack.Slug)
+	}
+	if bundle.Version.ExecutionMode != challengepack.ExecutionModeMultiTurn {
+		t.Fatalf("execution_mode = %q; want multi_turn", bundle.Version.ExecutionMode)
+	}
+	if len(bundle.InputSets) != 1 || len(bundle.InputSets[0].Cases) != 1 {
+		t.Fatalf("expected one default case; got input_sets=%d", len(bundle.InputSets))
+	}
+	sim := bundle.InputSets[0].Cases[0].UserSimulator
+	if sim == nil {
+		t.Fatal("user_simulator is required for multi_turn packs")
+	}
+	if len(sim.Phases) < 3 {
+		t.Fatalf("expected hybrid phases; got %d", len(sim.Phases))
+	}
+	spec := bundle.Version.EvaluationSpec
+	if spec.JudgeMode != scoring.JudgeModeHybrid {
+		t.Fatalf("judge_mode = %q; want hybrid", spec.JudgeMode)
+	}
+	foundJudge := false
+	for _, judge := range spec.LLMJudges {
+		if judge.Key == "recovery_after_mismatch" {
+			foundJudge = true
+			for _, ref := range judge.ContextFrom {
+				if ref == "transcript.from_mismatch" {
+					return
+				}
+			}
+			t.Fatal("recovery_after_mismatch judge missing transcript.from_mismatch context")
+		}
+	}
+	if !foundJudge {
+		t.Fatal("expected recovery_after_mismatch llm_judge")
+	}
+}

--- a/backend/internal/challengepack/multi_turn_runtime.go
+++ b/backend/internal/challengepack/multi_turn_runtime.go
@@ -1,0 +1,92 @@
+package challengepack
+
+import (
+	"hash/fnv"
+
+	"github.com/google/uuid"
+)
+
+// FirstCaseUserSimulator returns the user_simulator on the first case, if any.
+func FirstCaseUserSimulator(cases []StoredCaseDocument) *UserSimulatorSpec {
+	if len(cases) == 0 || cases[0].UserSimulator == nil {
+		return nil
+	}
+	return CloneUserSimulatorSpec(cases[0].UserSimulator)
+}
+
+// ShouldSampleCalibration deterministically samples run agents for H2 calibration review.
+func ShouldSampleCalibration(runAgentID uuid.UUID, sampleRate float64) bool {
+	if sampleRate <= 0 {
+		return false
+	}
+	if sampleRate >= 1 {
+		return true
+	}
+	h := fnv.New32a()
+	_, _ = h.Write(runAgentID[:])
+	bucket := h.Sum32() % 10000
+	return float64(bucket) < sampleRate*10000
+}
+
+// NormalizeHumanOnTimeout returns the effective human-phase timeout policy.
+func NormalizeHumanOnTimeout(raw string) string {
+	switch raw {
+	case UserSimulatorHumanOnTimeoutFail:
+		return UserSimulatorHumanOnTimeoutFail
+	default:
+		return UserSimulatorHumanOnTimeoutStop
+	}
+}
+
+// ArenaEligibleFromSpec reports whether post-run arena comparison is enabled.
+func ArenaEligibleFromSpec(spec *UserSimulatorSpec) bool {
+	if spec == nil || spec.PostRun == nil || spec.PostRun.Arena == nil {
+		return false
+	}
+	return spec.PostRun.Arena.Enabled
+}
+
+// ArenaEligibleAgent is a run agent queued for pairwise arena comparison.
+type ArenaEligibleAgent struct {
+	RunAgentID uuid.UUID
+	CaseKey    string
+	LaneIndex  int32
+}
+
+// PairArenaAgents groups eligible agents by case_key and returns adjacent lane pairs.
+func PairArenaAgents(agents []ArenaEligibleAgent) [][2]uuid.UUID {
+	if len(agents) < 2 {
+		return nil
+	}
+	byCase := map[string][]ArenaEligibleAgent{}
+	for _, agent := range agents {
+		key := agent.CaseKey
+		if key == "" {
+			key = "_default"
+		}
+		byCase[key] = append(byCase[key], agent)
+	}
+
+	var pairs [][2]uuid.UUID
+	for _, group := range byCase {
+		if len(group) < 2 {
+			continue
+		}
+		sortArenaAgents(group)
+		for i := 0; i+1 < len(group); i += 2 {
+			pairs = append(pairs, [2]uuid.UUID{group[i].RunAgentID, group[i+1].RunAgentID})
+		}
+	}
+	return pairs
+}
+
+func sortArenaAgents(agents []ArenaEligibleAgent) {
+	for i := 0; i < len(agents); i++ {
+		for j := i + 1; j < len(agents); j++ {
+			if agents[j].LaneIndex < agents[i].LaneIndex ||
+				(agents[j].LaneIndex == agents[i].LaneIndex && agents[j].RunAgentID.String() < agents[i].RunAgentID.String()) {
+				agents[i], agents[j] = agents[j], agents[i]
+			}
+		}
+	}
+}

--- a/backend/internal/challengepack/multi_turn_runtime_test.go
+++ b/backend/internal/challengepack/multi_turn_runtime_test.go
@@ -1,0 +1,43 @@
+package challengepack
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestShouldSampleCalibration_IsDeterministic(t *testing.T) {
+	t.Parallel()
+	id := uuid.MustParse("11111111-1111-4111-8111-111111111111")
+	first := ShouldSampleCalibration(id, 0.25)
+	second := ShouldSampleCalibration(id, 0.25)
+	if first != second {
+		t.Fatal("expected deterministic sampling for the same run agent id")
+	}
+}
+
+func TestShouldSampleCalibration_AlwaysWhenRateOne(t *testing.T) {
+	t.Parallel()
+	if !ShouldSampleCalibration(uuid.New(), 1) {
+		t.Fatal("expected sample when rate is 1")
+	}
+}
+
+func TestPairArenaAgents_AdjacentLanesPerCase(t *testing.T) {
+	t.Parallel()
+	left := uuid.MustParse("11111111-1111-4111-8111-111111111111")
+	right := uuid.MustParse("22222222-2222-4222-8222-222222222222")
+	otherCase := uuid.MustParse("33333333-3333-4333-8333-333333333333")
+
+	pairs := PairArenaAgents([]ArenaEligibleAgent{
+		{RunAgentID: right, CaseKey: "case-a", LaneIndex: 1},
+		{RunAgentID: left, CaseKey: "case-a", LaneIndex: 0},
+		{RunAgentID: otherCase, CaseKey: "case-b", LaneIndex: 0},
+	})
+	if len(pairs) != 1 {
+		t.Fatalf("len(pairs) = %d; want 1", len(pairs))
+	}
+	if pairs[0][0] != left || pairs[0][1] != right {
+		t.Fatalf("unexpected pair order: %v", pairs[0])
+	}
+}

--- a/backend/internal/challengepack/user_simulator.go
+++ b/backend/internal/challengepack/user_simulator.go
@@ -20,6 +20,9 @@ const (
 	UserSimulatorTriggerNever               = "never"
 
 	UserSimulatorArenaComparisonPairwise = "pairwise"
+
+	UserSimulatorHumanOnTimeoutStop = "stop"
+	UserSimulatorHumanOnTimeoutFail = "fail"
 )
 
 // UserSimulatorSpec defines the per-case hybrid user actor manifest for multi_turn packs.
@@ -41,6 +44,7 @@ type UserSimulatorPhase struct {
 	MaxTurns  int32               `yaml:"max_turns,omitempty" json:"max_turns,omitempty"`
 	Until     []string            `yaml:"until,omitempty" json:"until,omitempty"`
 	TimeoutMS int64               `yaml:"timeout_ms,omitempty" json:"timeout_ms,omitempty"`
+	OnTimeout string              `yaml:"on_timeout,omitempty" json:"on_timeout,omitempty"`
 }
 
 type UserSimulatorTurn struct {
@@ -89,4 +93,39 @@ func normalizeUserSimulatorTrigger(trigger string) string {
 		return UserSimulatorTriggerAlways
 	}
 	return trigger
+}
+
+func CloneUserSimulatorSpec(spec *UserSimulatorSpec) *UserSimulatorSpec {
+	return cloneUserSimulatorSpec(spec)
+}
+
+func cloneUserSimulatorSpec(spec *UserSimulatorSpec) *UserSimulatorSpec {
+	if spec == nil {
+		return nil
+	}
+	cloned := *spec
+	if len(spec.Phases) > 0 {
+		cloned.Phases = append([]UserSimulatorPhase(nil), spec.Phases...)
+		for i, phase := range spec.Phases {
+			if len(phase.Turns) > 0 {
+				cloned.Phases[i].Turns = append([]UserSimulatorTurn(nil), phase.Turns...)
+			}
+			if len(phase.Until) > 0 {
+				cloned.Phases[i].Until = append([]string(nil), phase.Until...)
+			}
+		}
+	}
+	if spec.Calibration != nil {
+		calibration := *spec.Calibration
+		cloned.Calibration = &calibration
+	}
+	if spec.PostRun != nil {
+		postRun := *spec.PostRun
+		if spec.PostRun.Arena != nil {
+			arena := *spec.PostRun.Arena
+			postRun.Arena = &arena
+		}
+		cloned.PostRun = &postRun
+	}
+	return &cloned
 }

--- a/backend/internal/engine/executor_util.go
+++ b/backend/internal/engine/executor_util.go
@@ -125,6 +125,7 @@ func cloneChallengeInputSet(inputSet *repository.ChallengeInputSetExecutionConte
 			Payload:             cloneJSON(item.Payload),
 			Inputs:              append([]challengepack.CaseInput(nil), item.Inputs...),
 			Expectations:        append([]challengepack.CaseExpectation(nil), item.Expectations...),
+			UserSimulator:       challengepack.CloneUserSimulatorSpec(item.UserSimulator),
 			Artifacts:           append([]challengepack.ArtifactRef(nil), item.Artifacts...),
 			Assets:              append([]challengepack.AssetReference(nil), item.Assets...),
 		})

--- a/backend/internal/engine/human_turn_gate.go
+++ b/backend/internal/engine/human_turn_gate.go
@@ -1,0 +1,92 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var ErrHumanTurnTimeout = errors.New("human turn timed out")
+
+// HumanTurnRequest identifies an in-run human actor pause.
+type HumanTurnRequest struct {
+	RunAgentID uuid.UUID
+	TurnIndex  int
+	PhaseID    string
+	PromptHint string
+	Timeout    time.Duration
+}
+
+// HumanTurnGate blocks until an operator submits the next user message.
+type HumanTurnGate interface {
+	WaitForHumanTurn(ctx context.Context, req HumanTurnRequest) (message string, err error)
+}
+
+type noopHumanTurnGate struct{}
+
+func (noopHumanTurnGate) WaitForHumanTurn(context.Context, HumanTurnRequest) (string, error) {
+	return "", errors.New("human turn gate is not configured")
+}
+
+func NoopHumanTurnGate() HumanTurnGate {
+	return noopHumanTurnGate{}
+}
+
+// PollHumanTurnGate polls a HumanTurnStore until a message arrives or timeout.
+type PollHumanTurnGate struct {
+	store HumanTurnStore
+}
+
+type HumanTurnStore interface {
+	MarkAwaitingHuman(ctx context.Context, req HumanTurnRequest) error
+	PollHumanMessage(ctx context.Context, runAgentID uuid.UUID, turnIndex int) (message string, ready bool, err error)
+	MarkHumanTurnExpired(ctx context.Context, runAgentID uuid.UUID, turnIndex int) error
+}
+
+func NewPollHumanTurnGate(store HumanTurnStore) PollHumanTurnGate {
+	return PollHumanTurnGate{store: store}
+}
+
+func (g PollHumanTurnGate) WaitForHumanTurn(ctx context.Context, req HumanTurnRequest) (string, error) {
+	if g.store == nil {
+		return "", errors.New("human turn store is not configured")
+	}
+	if err := g.store.MarkAwaitingHuman(ctx, req); err != nil {
+		return "", err
+	}
+
+	if req.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, req.Timeout)
+		defer cancel()
+	}
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		message, ready, err := g.store.PollHumanMessage(ctx, req.RunAgentID, req.TurnIndex)
+		if err != nil {
+			return "", err
+		}
+		if ready {
+			if strings.TrimSpace(message) == "" {
+				return "", errors.New("human turn message is empty")
+			}
+			return message, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			if req.Timeout > 0 {
+				_ = g.store.MarkHumanTurnExpired(ctx, req.RunAgentID, req.TurnIndex)
+				return "", ErrHumanTurnTimeout
+			}
+			return "", ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}

--- a/backend/internal/engine/human_turn_gate.go
+++ b/backend/internal/engine/human_turn_gate.go
@@ -82,7 +82,9 @@ func (g PollHumanTurnGate) WaitForHumanTurn(ctx context.Context, req HumanTurnRe
 		select {
 		case <-ctx.Done():
 			if req.Timeout > 0 {
-				_ = g.store.MarkHumanTurnExpired(ctx, req.RunAgentID, req.TurnIndex)
+				cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				_ = g.store.MarkHumanTurnExpired(cleanupCtx, req.RunAgentID, req.TurnIndex)
+				cancel()
 				return "", ErrHumanTurnTimeout
 			}
 			return "", ctx.Err()

--- a/backend/internal/engine/multi_turn_executor.go
+++ b/backend/internal/engine/multi_turn_executor.go
@@ -1,0 +1,472 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/challengepack"
+	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/runevents"
+	"github.com/agentclash/agentclash/backend/internal/simulator"
+	"github.com/google/uuid"
+)
+
+const StopReasonMaxTurns StopReason = "max_turns"
+const StopReasonSimulatorError StopReason = "simulator_error"
+const StopReasonHumanTurnTimeout StopReason = "human_turn_timeout"
+
+// MultiTurnConversationSummary is emitted on conversation.completed.
+type MultiTurnConversationSummary struct {
+	TurnCount      int      `json:"turn_count"`
+	ActorsUsed     []string `json:"actors_used"`
+	MismatchTurns  []int    `json:"mismatch_turns"`
+	HumanTurnCount int      `json:"human_turn_count"`
+	StopReason     string   `json:"stop_reason,omitempty"`
+	FinalOutput    string   `json:"final_output,omitempty"`
+}
+
+// MultiTurnEventRecorder records outer-loop turn events.
+type MultiTurnEventRecorder interface {
+	RecordTurnUserMessage(ctx context.Context, turnIndex int, phaseID, actor, content string) error
+	RecordTurnUserSimulated(ctx context.Context, turnIndex int, phaseID string, metadata simulator.Metadata) error
+	RecordTurnAssistantMessage(ctx context.Context, turnIndex int, phaseID, content string) error
+	RecordTurnCompleted(ctx context.Context, turnIndex int, phaseID, actor string, mismatch bool) error
+	RecordTurnAwaitingHuman(ctx context.Context, turnIndex int, phaseID, promptHint string) error
+	RecordConversationCompleted(ctx context.Context, summary MultiTurnConversationSummary) error
+}
+
+type noopMultiTurnEventRecorder struct{}
+
+func (noopMultiTurnEventRecorder) RecordTurnUserMessage(context.Context, int, string, string, string) error {
+	return nil
+}
+func (noopMultiTurnEventRecorder) RecordTurnUserSimulated(context.Context, int, string, simulator.Metadata) error {
+	return nil
+}
+func (noopMultiTurnEventRecorder) RecordTurnAssistantMessage(context.Context, int, string, string) error {
+	return nil
+}
+func (noopMultiTurnEventRecorder) RecordTurnCompleted(context.Context, int, string, string, bool) error {
+	return nil
+}
+func (noopMultiTurnEventRecorder) RecordTurnAwaitingHuman(context.Context, int, string, string) error {
+	return nil
+}
+func (noopMultiTurnEventRecorder) RecordConversationCompleted(context.Context, MultiTurnConversationSummary) error {
+	return nil
+}
+
+func multiTurnRecorder(observer Observer) MultiTurnEventRecorder {
+	if recorder, ok := observer.(MultiTurnEventRecorder); ok {
+		return recorder
+	}
+	return noopMultiTurnEventRecorder{}
+}
+
+// MultiTurnExecutor runs hybrid user-simulator phases with a native inner loop per turn.
+type MultiTurnExecutor struct {
+	nativeExecutor NativeExecutor
+	observer       Observer
+	simulator      TurnMessageGenerator
+	humanGate      HumanTurnGate
+}
+
+func NewMultiTurnExecutor(nativeExecutor NativeExecutor, observer Observer) MultiTurnExecutor {
+	if observer == nil {
+		observer = NoopObserver{}
+	}
+	return MultiTurnExecutor{
+		nativeExecutor: nativeExecutor,
+		observer:       observer,
+		humanGate:      NoopHumanTurnGate(),
+	}
+}
+
+func (e MultiTurnExecutor) WithSecretsLookup(lookup SecretsLookup) MultiTurnExecutor {
+	e.nativeExecutor = e.nativeExecutor.WithSecretsLookup(lookup)
+	return e
+}
+
+func (e MultiTurnExecutor) WithAssetLoader(loader AssetLoader) MultiTurnExecutor {
+	e.nativeExecutor = e.nativeExecutor.WithAssetLoader(loader)
+	return e
+}
+
+func (e MultiTurnExecutor) WithSimulator(generator TurnMessageGenerator) MultiTurnExecutor {
+	e.simulator = generator
+	return e
+}
+
+func (e MultiTurnExecutor) WithHumanTurnGate(gate HumanTurnGate) MultiTurnExecutor {
+	if gate != nil {
+		e.humanGate = gate
+	}
+	return e
+}
+
+func (e MultiTurnExecutor) Execute(ctx context.Context, executionContext repository.RunAgentExecutionContext) (result Result, err error) {
+	recorder := multiTurnRecorder(e.observer)
+	defer func() {
+		if err != nil {
+			if observerErr := e.observer.OnRunFailure(ctx, err); observerErr != nil {
+				err = errors.Join(err, NewFailure(StopReasonObserverError, "record multi_turn terminal failure event", observerErr))
+			}
+			return
+		}
+		if observerErr := e.observer.OnRunComplete(ctx, result); observerErr != nil {
+			result = Result{}
+			err = NewFailure(StopReasonObserverError, "record multi_turn terminal completion event", observerErr)
+		}
+	}()
+
+	spec, err := userSimulatorForExecution(executionContext)
+	if err != nil {
+		return Result{}, err
+	}
+
+	conversation, cleanup, err := e.nativeExecutor.BeginConversation(ctx, executionContext)
+	if err != nil {
+		return Result{}, err
+	}
+	defer cleanup()
+
+	summary, stopReason, execErr := e.runHybridConversation(ctx, executionContext, spec, conversation, recorder)
+	if execErr != nil {
+		return Result{}, execErr
+	}
+	if finalizeErr := conversation.Finalize(ctx); finalizeErr != nil {
+		return Result{}, finalizeErr
+	}
+	if err := recorder.RecordConversationCompleted(ctx, summary); err != nil {
+		return Result{}, NewFailure(StopReasonObserverError, "record conversation.completed event", err)
+	}
+
+	return Result{
+		FinalOutput:   summary.FinalOutput,
+		StopReason:    stopReason,
+		StepCount:     conversation.AggregateSteps(),
+		ToolCallCount: conversation.AggregateToolCalls(),
+		Usage:         conversation.AggregateUsage(),
+	}, nil
+}
+
+func (e MultiTurnExecutor) runHybridConversation(
+	ctx context.Context,
+	executionContext repository.RunAgentExecutionContext,
+	spec *challengepack.UserSimulatorSpec,
+	conversation *NativeConversation,
+	recorder MultiTurnEventRecorder,
+) (MultiTurnConversationSummary, StopReason, error) {
+	maxTurns := int(spec.MaxTurns)
+	if maxTurns <= 0 {
+		maxTurns = 50
+	}
+
+	state := hybridConversationState{
+		turnIndex:      0,
+		lastMismatch:   false,
+		finalOutput:    "",
+		mismatchTurns:  []int{},
+		seenActors:     map[string]struct{}{},
+		humanTurnCount: 0,
+		transcript:     []simulator.TranscriptTurn{},
+	}
+
+	for _, phase := range spec.Phases {
+		if !shouldRunPhase(phase, state.lastMismatch) {
+			continue
+		}
+		state.seenActors[phase.Actor] = struct{}{}
+
+		switch phase.Actor {
+		case challengepack.UserSimulatorActorScripted:
+			if err := e.runScriptedPhase(ctx, executionContext, phase, maxTurns, conversation, recorder, &state); err != nil {
+				return MultiTurnConversationSummary{}, "", err
+			}
+		case challengepack.UserSimulatorActorLLM:
+			if err := e.runLLMPhase(ctx, executionContext, phase, maxTurns, conversation, recorder, &state); err != nil {
+				return MultiTurnConversationSummary{}, "", err
+			}
+		case challengepack.UserSimulatorActorHuman:
+			if err := e.runHumanPhase(ctx, executionContext, phase, maxTurns, conversation, recorder, &state); err != nil {
+				return MultiTurnConversationSummary{}, "", err
+			}
+		}
+
+		if state.stopReason != "" {
+			summary := buildConversationSummary(state.turnIndex, actorKeys(state.seenActors), state.mismatchTurns, state.finalOutput, state.humanTurnCount, state.stopReason)
+			return summary, state.stopReason, nil
+		}
+	}
+
+	summary := buildConversationSummary(state.turnIndex, actorKeys(state.seenActors), state.mismatchTurns, state.finalOutput, state.humanTurnCount, StopReasonCompleted)
+	return summary, StopReasonCompleted, nil
+}
+
+type hybridConversationState struct {
+	turnIndex      int
+	lastMismatch   bool
+	finalOutput    string
+	mismatchTurns  []int
+	seenActors     map[string]struct{}
+	humanTurnCount int
+	transcript     []simulator.TranscriptTurn
+	stopReason     StopReason
+}
+
+func (e MultiTurnExecutor) runScriptedPhase(
+	ctx context.Context,
+	executionContext repository.RunAgentExecutionContext,
+	phase challengepack.UserSimulatorPhase,
+	maxTurns int,
+	conversation *NativeConversation,
+	recorder MultiTurnEventRecorder,
+	state *hybridConversationState,
+) error {
+	for _, turn := range phase.Turns {
+		if state.turnIndex >= maxTurns {
+			state.stopReason = StopReasonMaxTurns
+			return nil
+		}
+		message, err := renderScriptedTurnMessage(turn.Message, executionContext)
+		if err != nil {
+			return err
+		}
+		mismatch, err := e.executeUserTurn(ctx, phase.ID, challengepack.UserSimulatorActorScripted, message, turn.Expects, conversation, recorder, state)
+		if err != nil {
+			return err
+		}
+		state.lastMismatch = mismatch
+	}
+	return nil
+}
+
+func (e MultiTurnExecutor) runLLMPhase(
+	ctx context.Context,
+	executionContext repository.RunAgentExecutionContext,
+	phase challengepack.UserSimulatorPhase,
+	maxTurns int,
+	conversation *NativeConversation,
+	recorder MultiTurnEventRecorder,
+	state *hybridConversationState,
+) error {
+	if e.simulator == nil {
+		return provider.NewFailure("", provider.FailureCodeInvalidRequest, "llm simulator is not configured", false, nil)
+	}
+	providerKey, providerAccountID, credentialRef, model, err := simulator.ResolveTarget(executionContext)
+	if err != nil {
+		return err
+	}
+
+	phaseMax := int(phase.MaxTurns)
+	if phaseMax <= 0 {
+		phaseMax = maxTurns
+	}
+	phaseTurns := 0
+
+	for phaseTurns < phaseMax && state.turnIndex < maxTurns {
+		message, metadata, err := e.simulator.GenerateUserMessage(ctx, simulator.Input{
+			Persona:           phase.Persona,
+			Transcript:        append([]simulator.TranscriptTurn(nil), state.transcript...),
+			CasePayload:       casePayloadMap(executionContext),
+			PhaseID:           phase.ID,
+			ProviderKey:       providerKey,
+			ProviderAccountID: providerAccountID,
+			CredentialRef:     credentialRef,
+			Model:             model,
+		})
+		if err != nil {
+			return NewFailure(StopReasonSimulatorError, "generate llm user message", err)
+		}
+
+		if err := recorder.RecordTurnUserSimulated(ctx, state.turnIndex, phase.ID, metadata); err != nil {
+			return NewFailure(StopReasonObserverError, "record turn.user.simulated event", err)
+		}
+
+		mismatch, err := e.executeUserTurn(ctx, phase.ID, challengepack.UserSimulatorActorLLM, message, nil, conversation, recorder, state)
+		if err != nil {
+			return err
+		}
+		state.lastMismatch = mismatch
+		phaseTurns++
+
+		if phaseUntilSatisfied(phase.Until, untilEvalContext{
+			AssistantText: state.finalOutput,
+			UserMessage:   message,
+			TurnIndex:     state.turnIndex - 1,
+			PhaseTurns:    phaseTurns,
+			MaxPhaseTurns: phaseMax,
+		}) {
+			break
+		}
+	}
+	return nil
+}
+
+func (e MultiTurnExecutor) runHumanPhase(
+	ctx context.Context,
+	executionContext repository.RunAgentExecutionContext,
+	phase challengepack.UserSimulatorPhase,
+	maxTurns int,
+	conversation *NativeConversation,
+	recorder MultiTurnEventRecorder,
+	state *hybridConversationState,
+) error {
+	if state.turnIndex >= maxTurns {
+		state.stopReason = StopReasonMaxTurns
+		return nil
+	}
+
+	promptHint := strings.TrimSpace(phase.Persona)
+	if err := recorder.RecordTurnAwaitingHuman(ctx, state.turnIndex, phase.ID, promptHint); err != nil {
+		return NewFailure(StopReasonObserverError, "record turn.awaiting_human event", err)
+	}
+
+	timeout := time.Duration(phase.TimeoutMS) * time.Millisecond
+	if timeout <= 0 {
+		timeout = 30 * time.Minute
+	}
+
+	message, err := e.humanGate.WaitForHumanTurn(ctx, HumanTurnRequest{
+		RunAgentID: executionContext.RunAgent.ID,
+		TurnIndex:  state.turnIndex,
+		PhaseID:    phase.ID,
+		PromptHint: promptHint,
+		Timeout:    timeout,
+	})
+	if err != nil {
+		if errors.Is(err, ErrHumanTurnTimeout) {
+			switch challengepack.NormalizeHumanOnTimeout(phase.OnTimeout) {
+			case challengepack.UserSimulatorHumanOnTimeoutFail:
+				return NewFailure(StopReasonHumanTurnTimeout, "human turn timed out", err)
+			default:
+				state.stopReason = StopReasonHumanTurnTimeout
+				return nil
+			}
+		}
+		return err
+	}
+
+	state.humanTurnCount++
+	_, err = e.executeUserTurn(ctx, phase.ID, challengepack.UserSimulatorActorHuman, message, nil, conversation, recorder, state)
+	return err
+}
+
+func (e MultiTurnExecutor) executeUserTurn(
+	ctx context.Context,
+	phaseID string,
+	actor string,
+	message string,
+	expects []challengepack.CaseExpectation,
+	conversation *NativeConversation,
+	recorder MultiTurnEventRecorder,
+	state *hybridConversationState,
+) (bool, error) {
+	if err := recorder.RecordTurnUserMessage(ctx, state.turnIndex, phaseID, actor, message); err != nil {
+		return false, NewFailure(StopReasonObserverError, "record turn.user.message event", err)
+	}
+
+	turnResult, err := conversation.RunTurn(ctx, message)
+	if err != nil {
+		return false, err
+	}
+	state.finalOutput = turnResult.AssistantText
+
+	if err := recorder.RecordTurnAssistantMessage(ctx, state.turnIndex, phaseID, turnResult.AssistantText); err != nil {
+		return false, NewFailure(StopReasonObserverError, "record turn.assistant.message event", err)
+	}
+
+	mismatch := evaluateTurnExpects(turnResult.AssistantText, expects)
+	if mismatch {
+		state.mismatchTurns = append(state.mismatchTurns, state.turnIndex)
+	}
+	if err := recorder.RecordTurnCompleted(ctx, state.turnIndex, phaseID, actor, mismatch); err != nil {
+		return false, NewFailure(StopReasonObserverError, "record turn.completed event", err)
+	}
+
+	state.transcript = append(state.transcript, simulator.TranscriptTurn{Actor: actor, Content: message, PhaseID: phaseID})
+	state.transcript = append(state.transcript, simulator.TranscriptTurn{Actor: "assistant", Content: turnResult.AssistantText, PhaseID: phaseID})
+	state.turnIndex++
+	return mismatch, nil
+}
+
+func userSimulatorForExecution(executionContext repository.RunAgentExecutionContext) (*challengepack.UserSimulatorSpec, error) {
+	if executionContext.ChallengeInputSet == nil || len(executionContext.ChallengeInputSet.Cases) == 0 {
+		return nil, provider.NewFailure("", provider.FailureCodeInvalidRequest, "multi_turn execution requires a challenge case", false, nil)
+	}
+	first := executionContext.ChallengeInputSet.Cases[0]
+	if first.UserSimulator == nil {
+		return nil, provider.NewFailure("", provider.FailureCodeInvalidRequest, "multi_turn execution requires user_simulator on the case", false, nil)
+	}
+	return challengepack.CloneUserSimulatorSpec(first.UserSimulator), nil
+}
+
+func renderScriptedTurnMessage(template string, executionContext repository.RunAgentExecutionContext) (string, error) {
+	ctx := caseTemplateContextForExecution(executionContext)
+	rendered, err := challengepack.RenderCaseTemplate(template, ctx)
+	if err != nil {
+		rendered = challengepack.RenderCaseTemplateLenient(template, ctx)
+	}
+	if strings.TrimSpace(rendered) == "" {
+		return "", provider.NewFailure("", provider.FailureCodeInvalidRequest, "scripted turn message rendered empty", false, fmt.Errorf("empty scripted turn message"))
+	}
+	return rendered, nil
+}
+
+func buildConversationSummary(turnCount int, actorsUsed []string, mismatchTurns []int, finalOutput string, humanTurnCount int, stopReason StopReason) MultiTurnConversationSummary {
+	return MultiTurnConversationSummary{
+		TurnCount:      turnCount,
+		ActorsUsed:     append([]string(nil), actorsUsed...),
+		MismatchTurns:  append([]int(nil), mismatchTurns...),
+		HumanTurnCount: humanTurnCount,
+		StopReason:     string(stopReason),
+		FinalOutput:    finalOutput,
+	}
+}
+
+func actorKeys(seen map[string]struct{}) []string {
+	out := make([]string, 0, len(seen))
+	for actor := range seen {
+		out = append(out, actor)
+	}
+	return out
+}
+
+func casePayloadMap(executionContext repository.RunAgentExecutionContext) map[string]any {
+	if executionContext.ChallengeInputSet == nil || len(executionContext.ChallengeInputSet.Cases) == 0 {
+		return nil
+	}
+	payload := executionContext.ChallengeInputSet.Cases[0].Payload
+	if len(payload) == 0 {
+		return nil
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return map[string]any{"raw": string(payload)}
+	}
+	return decoded
+}
+
+// RunAgentIDForHumanTurn returns the run agent id used for human turn gates.
+func RunAgentIDForHumanTurn(executionContext repository.RunAgentExecutionContext) uuid.UUID {
+	return executionContext.RunAgent.ID
+}
+
+// ActorForRecorder maps pack actor strings to run event actors.
+func ActorForRecorder(actor string) string {
+	switch strings.TrimSpace(actor) {
+	case challengepack.UserSimulatorActorScripted:
+		return runevents.ConversationActorScripted
+	case challengepack.UserSimulatorActorLLM:
+		return runevents.ConversationActorLLM
+	case challengepack.UserSimulatorActorHuman:
+		return runevents.ConversationActorHuman
+	default:
+		return strings.TrimSpace(actor)
+	}
+}

--- a/backend/internal/engine/multi_turn_executor_test.go
+++ b/backend/internal/engine/multi_turn_executor_test.go
@@ -1,0 +1,44 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/challengepack"
+	"github.com/agentclash/agentclash/backend/internal/scoring"
+)
+
+func TestEvaluateTurnExpects_Contains(t *testing.T) {
+	expects := []challengepack.CaseExpectation{
+		{Key: "mentions_refund", Kind: string(scoring.ValidatorTypeContains), Value: "refund"},
+	}
+	if !evaluateTurnExpects("sorry, I cannot help", expects) {
+		t.Fatal("expected mismatch when assistant output lacks required substring")
+	}
+	if evaluateTurnExpects("your refund is processing", expects) {
+		t.Fatal("expected match when assistant output contains required substring")
+	}
+}
+
+func TestShouldRunPhase_OnAssistantMismatch(t *testing.T) {
+	phase := challengepack.UserSimulatorPhase{
+		ID:      "pushback",
+		Actor:   challengepack.UserSimulatorActorScripted,
+		Trigger: challengepack.UserSimulatorTriggerOnAssistantMismatch,
+	}
+	if shouldRunPhase(phase, false) {
+		t.Fatal("expected phase to stay inactive without prior mismatch")
+	}
+	if !shouldRunPhase(phase, true) {
+		t.Fatal("expected phase to run after mismatch")
+	}
+}
+
+func TestPhaseUntilSatisfied_AssistantEmitted(t *testing.T) {
+	until := []string{"assistant_emitted:refund"}
+	if phaseUntilSatisfied(until, untilEvalContext{AssistantText: "still working on it"}) {
+		t.Fatal("expected until unsatisfied without refund token")
+	}
+	if !phaseUntilSatisfied(until, untilEvalContext{AssistantText: "refund approved"}) {
+		t.Fatal("expected until satisfied when assistant emitted token")
+	}
+}

--- a/backend/internal/engine/native_conversation.go
+++ b/backend/internal/engine/native_conversation.go
@@ -1,0 +1,197 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/sandbox"
+)
+
+// NativeConversation reuses one sandbox session and message history across
+// multiple user turns for multi_turn execution.
+type NativeConversation struct {
+	executor         NativeExecutor
+	runCtx           context.Context
+	executionContext repository.RunAgentExecutionContext
+	session          sandbox.Session
+	registry         *Registry
+	sandboxRequest   sandbox.CreateRequest
+	metadata         json.RawMessage
+	state            loopState
+}
+
+// TurnResult is the outcome of one native inner loop invocation.
+type TurnResult struct {
+	AssistantText string
+	Completed     bool
+	StepCount     int
+	ToolCallCount int
+	Usage         provider.Usage
+}
+
+func (e NativeExecutor) BeginConversation(ctx context.Context, executionContext repository.RunAgentExecutionContext) (*NativeConversation, func(), error) {
+	if executionContext.Deployment.ProviderAccount == nil {
+		return nil, nil, provider.NewFailure(
+			"",
+			provider.FailureCodeInvalidRequest,
+			"multi_turn native deployment is missing provider account in execution context",
+			false,
+			nil,
+		)
+	}
+	if executionContext.Deployment.ModelAlias == nil {
+		return nil, nil, provider.NewFailure(
+			executionContext.Deployment.ProviderAccount.ProviderKey,
+			provider.FailureCodeInvalidRequest,
+			"multi_turn native deployment is missing model alias in execution context",
+			false,
+			nil,
+		)
+	}
+	if e.sandboxProvider == nil {
+		return nil, nil, NewFailure(StopReasonSandboxError, sandbox.ErrProviderNotConfigured.Error(), sandbox.ErrProviderNotConfigured)
+	}
+
+	sandboxRequest, err := nativeSandboxRequest(executionContext)
+	if err != nil {
+		return nil, nil, NewFailure(StopReasonSandboxError, "build native sandbox request", err)
+	}
+
+	workspaceSecrets, err := e.loadWorkspaceSecrets(ctx, executionContext.Run.WorkspaceID)
+	if err != nil {
+		return nil, nil, NewFailure(StopReasonSandboxError, fmt.Sprintf("load workspace secrets: %v", err), err)
+	}
+
+	session, err := e.prepareSandbox(ctx, executionContext, sandboxRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	runCtx := provider.WithWorkspaceSecrets(ctx, workspaceSecrets)
+	cancel := func() {}
+	if timeout := runTimeout(executionContext); timeout > 0 {
+		runCtx, cancel = context.WithTimeout(runCtx, timeout)
+	}
+
+	initialMessages, err := buildInitialMessages(executionContext)
+	if err != nil {
+		cancel()
+		_ = destroySandbox(session)
+		return nil, nil, provider.NewFailure(
+			executionContext.Deployment.ProviderAccount.ProviderKey,
+			provider.FailureCodeInvalidRequest,
+			"build native prompt context",
+			false,
+			err,
+		)
+	}
+
+	metadata, err := buildProviderMetadata(executionContext)
+	if err != nil {
+		cancel()
+		_ = destroySandbox(session)
+		return nil, nil, provider.NewFailure(
+			executionContext.Deployment.ProviderAccount.ProviderKey,
+			provider.FailureCodeInvalidRequest,
+			"marshal native provider metadata",
+			false,
+			err,
+		)
+	}
+
+	registry, err := buildToolRegistry(
+		sandboxRequest.ToolPolicy,
+		executionContext.ChallengePackVersion.Manifest,
+		executionContext.Deployment.SnapshotConfig,
+		workspaceSecrets,
+	)
+	if err != nil {
+		cancel()
+		_ = destroySandbox(session)
+		return nil, nil, provider.NewFailure(
+			executionContext.Deployment.ProviderAccount.ProviderKey,
+			provider.FailureCodeInvalidRequest,
+			"build native tool registry",
+			false,
+			err,
+		)
+	}
+
+	conversation := &NativeConversation{
+		executor:         e,
+		runCtx:           runCtx,
+		executionContext: executionContext,
+		session:          session,
+		registry:         registry,
+		sandboxRequest:   sandboxRequest,
+		metadata:         metadata,
+		state: loopState{
+			messages:  initialMessages,
+			startedAt: time.Now().UTC(),
+		},
+	}
+
+	cleanup := func() {
+		cancel()
+		if destroyErr := destroySandbox(session); destroyErr != nil {
+			_ = destroyErr
+		}
+	}
+	return conversation, cleanup, nil
+}
+
+func (c *NativeConversation) RunTurn(_ context.Context, userMessage string) (TurnResult, error) {
+	if strings.TrimSpace(userMessage) == "" {
+		return TurnResult{}, provider.NewFailure(
+			c.executionContext.Deployment.ProviderAccount.ProviderKey,
+			provider.FailureCodeInvalidRequest,
+			"multi_turn user message is empty",
+			false,
+			nil,
+		)
+	}
+
+	c.state.messages = append(c.state.messages, provider.Message{
+		Role:    "user",
+		Content: userMessage,
+	})
+
+	result, err := c.executor.runAgentLoop(c.runCtx, c.executionContext, c.session, c.registry, c.sandboxRequest, c.metadata, &c.state)
+	if err != nil {
+		return TurnResult{}, err
+	}
+
+	return TurnResult{
+		AssistantText: result.FinalOutput,
+		Completed:     result.StopReason == StopReasonCompleted,
+		StepCount:     result.StepCount,
+		ToolCallCount: result.ToolCallCount,
+		Usage:         result.Usage,
+	}, nil
+}
+
+func (c *NativeConversation) Finalize(ctx context.Context) error {
+	if verificationResults := collectPostExecutionVerification(c.runCtx, c.session, c.executionContext); len(verificationResults) > 0 {
+		if observerErr := c.executor.observer.OnPostExecutionVerification(ctx, verificationResults); observerErr != nil {
+			return NewFailure(StopReasonObserverError, "record post-execution verification events", observerErr)
+		}
+	}
+	return nil
+}
+
+func (c *NativeConversation) AggregateUsage() provider.Usage {
+	return c.state.usage
+}
+
+func (c *NativeConversation) AggregateSteps() int {
+	return c.state.stepCount
+}
+
+func (c *NativeConversation) AggregateToolCalls() int {
+	return c.state.toolCallCount
+}

--- a/backend/internal/engine/native_executor.go
+++ b/backend/internal/engine/native_executor.go
@@ -324,6 +324,32 @@ func (e NativeExecutor) Execute(ctx context.Context, executionContext repository
 		startedAt: time.Now().UTC(),
 	}
 
+	result, loopErr := e.runAgentLoop(runCtx, executionContext, session, registry, sandboxRequest, metadata, &state)
+	if loopErr != nil {
+		return Result{}, loopErr
+	}
+
+	if verificationResults := collectPostExecutionVerification(runCtx, session, executionContext); len(verificationResults) > 0 {
+		if observerErr := e.observer.OnPostExecutionVerification(runCtx, verificationResults); observerErr != nil {
+			slog.Default().Warn("post-execution verification observer error",
+				"run_id", executionContext.Run.ID,
+				"run_agent_id", executionContext.RunAgent.ID,
+				"error", observerErr,
+			)
+		}
+	}
+	return result, nil
+}
+
+func (e NativeExecutor) runAgentLoop(
+	runCtx context.Context,
+	executionContext repository.RunAgentExecutionContext,
+	session sandbox.Session,
+	registry *Registry,
+	sandboxRequest sandbox.CreateRequest,
+	metadata json.RawMessage,
+	state *loopState,
+) (Result, error) {
 	for {
 		if loopErr := runCtx.Err(); loopErr != nil {
 			if errors.Is(loopErr, context.Canceled) {
@@ -339,9 +365,9 @@ func (e NativeExecutor) Execute(ctx context.Context, executionContext repository
 		if observerErr := e.observer.OnStepStart(runCtx, state.stepCount); observerErr != nil {
 			return Result{}, NewFailure(StopReasonObserverError, "record native step start event", observerErr)
 		}
-		e.syncRaceContextStepStart(runCtx, executionContext, &state)
+		e.syncRaceContextStepStart(runCtx, executionContext, state)
 
-		if injectErr := e.maybeInjectRaceStandings(runCtx, executionContext, &state); injectErr != nil {
+		if injectErr := e.maybeInjectRaceStandings(runCtx, executionContext, state); injectErr != nil {
 			return Result{}, NewFailure(StopReasonObserverError, "record race-context standings injection", injectErr)
 		}
 
@@ -407,17 +433,6 @@ func (e NativeExecutor) Execute(ctx context.Context, executionContext repository
 		}
 
 		if completed {
-			// Post-execution verification must finish before sandbox teardown so
-			// validators and file captures see the live workspace state.
-			if verificationResults := collectPostExecutionVerification(runCtx, session, executionContext); len(verificationResults) > 0 {
-				if observerErr := e.observer.OnPostExecutionVerification(runCtx, verificationResults); observerErr != nil {
-					slog.Default().Warn("post-execution verification observer error",
-						"run_id", executionContext.Run.ID,
-						"run_agent_id", executionContext.RunAgent.ID,
-						"error", observerErr,
-					)
-				}
-			}
 			return Result{
 				FinalOutput:   finalOutput,
 				StopReason:    StopReasonCompleted,

--- a/backend/internal/engine/phase_until.go
+++ b/backend/internal/engine/phase_until.go
@@ -1,0 +1,66 @@
+package engine
+
+import (
+	"strings"
+
+	"github.com/agentclash/agentclash/backend/internal/challengepack"
+)
+
+type untilEvalContext struct {
+	AssistantText string
+	UserMessage   string
+	TurnIndex     int
+	PhaseTurns    int
+	MaxPhaseTurns int
+}
+
+func phaseUntilSatisfied(conditions []string, ctx untilEvalContext) bool {
+	if len(conditions) == 0 {
+		return false
+	}
+	for _, raw := range conditions {
+		cond := strings.TrimSpace(raw)
+		if cond == "" {
+			continue
+		}
+		if !untilConditionMet(cond, ctx) {
+			return false
+		}
+	}
+	return true
+}
+
+func untilConditionMet(condition string, ctx untilEvalContext) bool {
+	switch {
+	case condition == "max_turns":
+		if ctx.MaxPhaseTurns <= 0 {
+			return false
+		}
+		return ctx.PhaseTurns >= ctx.MaxPhaseTurns
+	case strings.HasPrefix(condition, "assistant_emitted:"):
+		token := strings.TrimSpace(strings.TrimPrefix(condition, "assistant_emitted:"))
+		return token != "" && strings.Contains(strings.ToLower(ctx.AssistantText), strings.ToLower(token))
+	case strings.HasPrefix(condition, "user_token:"):
+		token := strings.TrimSpace(strings.TrimPrefix(condition, "user_token:"))
+		return token != "" && strings.Contains(strings.ToLower(ctx.UserMessage), strings.ToLower(token))
+	default:
+		return false
+	}
+}
+
+func shouldRunPhase(phase challengepack.UserSimulatorPhase, lastMismatch bool) bool {
+	trigger := strings.TrimSpace(phase.Trigger)
+	if trigger == "" {
+		trigger = challengepack.UserSimulatorTriggerAlways
+	}
+	switch trigger {
+	case challengepack.UserSimulatorTriggerNever:
+		return false
+	case challengepack.UserSimulatorTriggerOnAssistantMismatch:
+		return lastMismatch
+	case challengepack.UserSimulatorTriggerManual:
+		return true
+	default:
+		return true
+	}
+}

--- a/backend/internal/engine/simulator_turn_generator.go
+++ b/backend/internal/engine/simulator_turn_generator.go
@@ -1,0 +1,24 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/agentclash/agentclash/backend/internal/simulator"
+)
+
+// TurnMessageGenerator produces the next user message for LLM simulator phases.
+type TurnMessageGenerator interface {
+	GenerateUserMessage(ctx context.Context, input simulator.Input) (message string, metadata simulator.Metadata, err error)
+}
+
+type simulatorTurnGenerator struct {
+	generator simulator.Generator
+}
+
+func NewSimulatorTurnGenerator(generator simulator.Generator) TurnMessageGenerator {
+	return simulatorTurnGenerator{generator: generator}
+}
+
+func (g simulatorTurnGenerator) GenerateUserMessage(ctx context.Context, input simulator.Input) (string, simulator.Metadata, error) {
+	return g.generator.GenerateUserMessage(ctx, input)
+}

--- a/backend/internal/engine/turn_expects.go
+++ b/backend/internal/engine/turn_expects.go
@@ -1,0 +1,51 @@
+package engine
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/agentclash/agentclash/backend/internal/challengepack"
+	"github.com/agentclash/agentclash/backend/internal/scoring"
+)
+
+// evaluateTurnExpects returns true when any declared expectation fails (mismatch).
+func evaluateTurnExpects(assistantText string, expects []challengepack.CaseExpectation) bool {
+	if len(expects) == 0 {
+		return false
+	}
+	for _, expectation := range expects {
+		if !turnExpectationMet(assistantText, expectation) {
+			return true
+		}
+	}
+	return false
+}
+
+func turnExpectationMet(assistantText string, expectation challengepack.CaseExpectation) bool {
+	expected, err := expectedTurnValue(expectation)
+	if err != nil {
+		return false
+	}
+	switch strings.TrimSpace(expectation.Kind) {
+	case string(scoring.ValidatorTypeExactMatch):
+		return strings.TrimSpace(assistantText) == expected
+	case string(scoring.ValidatorTypeContains):
+		return strings.Contains(assistantText, expected)
+	default:
+		return false
+	}
+}
+
+func expectedTurnValue(expectation challengepack.CaseExpectation) (string, error) {
+	if expectation.Value == nil {
+		return "", fmt.Errorf("expectation value is required")
+	}
+	switch typed := expectation.Value.(type) {
+	case string:
+		return typed, nil
+	case fmt.Stringer:
+		return typed.String(), nil
+	default:
+		return fmt.Sprint(typed), nil
+	}
+}

--- a/backend/internal/repository/errors.go
+++ b/backend/internal/repository/errors.go
@@ -54,6 +54,7 @@ var (
 	ErrWorkspaceCIProfileNameConflict        = errors.New("workspace ci profile name already exists")
 	ErrSecretsCipherUnset                    = errors.New("secrets cipher is not configured")
 	ErrInvalidSecretKey                      = errors.New("secret key must match [A-Za-z_][A-Za-z0-9_]* and be 1..128 characters")
+	ErrInvalidArenaVoteWinner              = errors.New("arena vote winner must be one of the task contestants")
 )
 
 type InvalidTransitionError struct {

--- a/backend/internal/repository/multi_turn_extensions.go
+++ b/backend/internal/repository/multi_turn_extensions.go
@@ -1,0 +1,179 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type CreateCalibrationReviewParams struct {
+	WorkspaceID    uuid.UUID
+	RunAgentID     uuid.UUID
+	TurnIndex      int
+	ReviewerUserID uuid.UUID
+	Score          float64
+	RubricKey      string
+	Notes          string
+}
+
+type CalibrationReviewRow struct {
+	ID             uuid.UUID
+	RunAgentID     uuid.UUID
+	TurnIndex      int
+	ReviewerUserID uuid.UUID
+	Score          float64
+	RubricKey      string
+	Notes          string
+	CreatedAt      time.Time
+}
+
+type ArenaTaskRow struct {
+	ID              uuid.UUID
+	CaseKey         string
+	LeftRunAgentID  uuid.UUID
+	RightRunAgentID uuid.UUID
+	Status          string
+}
+
+type SubmitArenaVoteParams struct {
+	WorkspaceID      uuid.UUID
+	TaskID           uuid.UUID
+	VoterUserID      uuid.UUID
+	WinnerRunAgentID uuid.UUID
+	RubricScores     map[string]float64
+}
+
+func (r *Repository) CreateCalibrationReview(ctx context.Context, params CreateCalibrationReviewParams) error {
+	if r.db == nil {
+		return fmt.Errorf("database is not configured")
+	}
+	_, err := r.db.Exec(ctx, `
+INSERT INTO calibration_reviews (workspace_id, run_agent_id, turn_index, reviewer_user_id, score, rubric_key, notes)
+VALUES ($1, $2, $3, $4, $5, NULLIF($6, ''), NULLIF($7, ''))
+`, params.WorkspaceID, params.RunAgentID, params.TurnIndex, params.ReviewerUserID, params.Score, params.RubricKey, params.Notes)
+	return err
+}
+
+func (r *Repository) ListCalibrationReviews(ctx context.Context, workspaceID uuid.UUID) ([]CalibrationReviewRow, error) {
+	if r.db == nil {
+		return nil, fmt.Errorf("database is not configured")
+	}
+	rows, err := r.db.Query(ctx, `
+SELECT id, run_agent_id, turn_index, reviewer_user_id, score::float8, COALESCE(rubric_key, ''), COALESCE(notes, ''), created_at
+FROM calibration_reviews
+WHERE workspace_id = $1
+ORDER BY created_at DESC
+LIMIT 100
+`, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []CalibrationReviewRow{}
+	for rows.Next() {
+		var row CalibrationReviewRow
+		if err := rows.Scan(&row.ID, &row.RunAgentID, &row.TurnIndex, &row.ReviewerUserID, &row.Score, &row.RubricKey, &row.Notes, &row.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+func (r *Repository) ListPendingArenaTasks(ctx context.Context, workspaceID uuid.UUID) ([]ArenaTaskRow, error) {
+	if r.db == nil {
+		return nil, fmt.Errorf("database is not configured")
+	}
+	rows, err := r.db.Query(ctx, `
+SELECT id, case_key, left_run_agent_id, right_run_agent_id, status
+FROM workspace_arena_tasks
+WHERE workspace_id = $1 AND status = 'pending'
+ORDER BY created_at ASC
+LIMIT 20
+`, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []ArenaTaskRow{}
+	for rows.Next() {
+		var row ArenaTaskRow
+		if err := rows.Scan(&row.ID, &row.CaseKey, &row.LeftRunAgentID, &row.RightRunAgentID, &row.Status); err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+func (r *Repository) SubmitArenaVote(ctx context.Context, params SubmitArenaVoteParams) error {
+	if r.db == nil {
+		return fmt.Errorf("database is not configured")
+	}
+	scoresJSON, err := json.Marshal(params.RubricScores)
+	if err != nil {
+		return err
+	}
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	var workspaceID uuid.UUID
+	if err := tx.QueryRow(ctx, `
+SELECT workspace_id FROM workspace_arena_tasks WHERE id = $1 AND status = 'pending'
+`, params.TaskID).Scan(&workspaceID); err != nil {
+		return err
+	}
+	if workspaceID != params.WorkspaceID {
+		return ErrRunNotFound
+	}
+
+	_, err = tx.Exec(ctx, `
+INSERT INTO workspace_arena_votes (task_id, voter_user_id, winner_run_agent_id, rubric_scores)
+VALUES ($1, $2, $3, $4::jsonb)
+ON CONFLICT (task_id, voter_user_id) DO UPDATE SET
+  winner_run_agent_id = EXCLUDED.winner_run_agent_id,
+  rubric_scores = EXCLUDED.rubric_scores,
+  created_at = now()
+`, params.TaskID, params.VoterUserID, params.WinnerRunAgentID, scoresJSON)
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(ctx, `UPDATE workspace_arena_tasks SET status = 'completed' WHERE id = $1`, params.TaskID)
+	if err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func (r *Repository) HumanPreferenceScore(ctx context.Context, runAgentID uuid.UUID) (*float64, error) {
+	if r.db == nil {
+		return nil, nil
+	}
+	var wins int
+	var total int
+	err := r.db.QueryRow(ctx, `
+SELECT
+  COUNT(*) FILTER (WHERE winner_run_agent_id = $1),
+  COUNT(*)
+FROM workspace_arena_votes v
+JOIN workspace_arena_tasks t ON t.id = v.task_id
+WHERE $1 IN (t.left_run_agent_id, t.right_run_agent_id)
+`, runAgentID).Scan(&wins, &total)
+	if err != nil || total == 0 {
+		return nil, err
+	}
+	score := float64(wins) / float64(total)
+	return &score, nil
+}
+
+// db accessor for raw queries in multi-turn extensions.
+func (r *Repository) DB() *pgxpool.Pool {
+	return r.db
+}

--- a/backend/internal/repository/multi_turn_extensions.go
+++ b/backend/internal/repository/multi_turn_extensions.go
@@ -125,13 +125,20 @@ func (r *Repository) SubmitArenaVote(ctx context.Context, params SubmitArenaVote
 	defer tx.Rollback(ctx)
 
 	var workspaceID uuid.UUID
+	var leftRunAgentID uuid.UUID
+	var rightRunAgentID uuid.UUID
 	if err := tx.QueryRow(ctx, `
-SELECT workspace_id FROM workspace_arena_tasks WHERE id = $1 AND status = 'pending'
-`, params.TaskID).Scan(&workspaceID); err != nil {
+SELECT workspace_id, left_run_agent_id, right_run_agent_id
+FROM workspace_arena_tasks
+WHERE id = $1 AND status = 'pending'
+`, params.TaskID).Scan(&workspaceID, &leftRunAgentID, &rightRunAgentID); err != nil {
 		return err
 	}
 	if workspaceID != params.WorkspaceID {
 		return ErrRunNotFound
+	}
+	if params.WinnerRunAgentID != leftRunAgentID && params.WinnerRunAgentID != rightRunAgentID {
+		return ErrInvalidArenaVoteWinner
 	}
 
 	_, err = tx.Exec(ctx, `

--- a/backend/internal/repository/multi_turn_human.go
+++ b/backend/internal/repository/multi_turn_human.go
@@ -1,0 +1,220 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+var ErrHumanTurnNotAwaiting = errors.New("run agent is not awaiting a human turn")
+
+type HumanTurnWaitParams struct {
+	RunAgentID uuid.UUID
+	TurnIndex  int
+	PhaseID    string
+	PromptHint string
+	Timeout    time.Duration
+}
+
+type humanTurnRow struct {
+	runAgentID uuid.UUID
+	turnIndex  int
+	phaseID    string
+	promptHint string
+	message    string
+	status     string
+}
+
+// MultiTurnHumanTurnStore persists in-run human turn submissions.
+type MultiTurnHumanTurnStore struct {
+	pool *pgxpool.Pool
+
+	mu    sync.Mutex
+	local map[string]humanTurnRow
+}
+
+func NewMultiTurnHumanTurnStore(pool *pgxpool.Pool) *MultiTurnHumanTurnStore {
+	return &MultiTurnHumanTurnStore{
+		pool:  pool,
+		local: make(map[string]humanTurnRow),
+	}
+}
+
+func (s *MultiTurnHumanTurnStore) MarkAwaitingHuman(ctx context.Context, req HumanTurnWaitParams) error {
+	key := humanTurnKey(req.RunAgentID, req.TurnIndex)
+	if s.pool == nil {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		s.local[key] = humanTurnRow{
+			runAgentID: req.RunAgentID,
+			turnIndex:  req.TurnIndex,
+			phaseID:    req.PhaseID,
+			promptHint: req.PromptHint,
+			status:     "awaiting",
+		}
+		return nil
+	}
+	_, err := s.pool.Exec(ctx, `
+INSERT INTO multi_turn_human_turns (run_agent_id, turn_index, phase_id, prompt_hint, status, created_at, updated_at)
+VALUES ($1, $2, $3, $4, 'awaiting', now(), now())
+ON CONFLICT (run_agent_id, turn_index) DO UPDATE SET
+  phase_id = EXCLUDED.phase_id,
+  prompt_hint = EXCLUDED.prompt_hint,
+  status = 'awaiting',
+  message = NULL,
+  submitted_at = NULL,
+  updated_at = now()
+`, req.RunAgentID, req.TurnIndex, req.PhaseID, nullIfEmpty(req.PromptHint))
+	if err != nil {
+		return fmt.Errorf("mark awaiting human turn: %w", err)
+	}
+	return nil
+}
+
+func (s *MultiTurnHumanTurnStore) PollHumanMessage(ctx context.Context, runAgentID uuid.UUID, turnIndex int) (string, bool, error) {
+	key := humanTurnKey(runAgentID, turnIndex)
+	if s.pool == nil {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		row, ok := s.local[key]
+		if !ok || row.status != "submitted" {
+			return "", false, nil
+		}
+		return row.message, true, nil
+	}
+	var message *string
+	var status string
+	err := s.pool.QueryRow(ctx, `
+SELECT status, message
+FROM multi_turn_human_turns
+WHERE run_agent_id = $1 AND turn_index = $2
+`, runAgentID, turnIndex).Scan(&status, &message)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("poll human turn: %w", err)
+	}
+	if status != "submitted" || message == nil {
+		return "", false, nil
+	}
+	return *message, true, nil
+}
+
+func (s *MultiTurnHumanTurnStore) SubmitHumanMessage(ctx context.Context, runAgentID uuid.UUID, turnIndex int, message string) error {
+	message = strings.TrimSpace(message)
+	if message == "" {
+		return fmt.Errorf("human turn message is required")
+	}
+	key := humanTurnKey(runAgentID, turnIndex)
+	if s.pool == nil {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		row, ok := s.local[key]
+		if !ok || row.status != "awaiting" {
+			return ErrHumanTurnNotAwaiting
+		}
+		row.status = "submitted"
+		row.message = message
+		s.local[key] = row
+		return nil
+	}
+	tag, err := s.pool.Exec(ctx, `
+UPDATE multi_turn_human_turns
+SET status = 'submitted', message = $3, submitted_at = now(), updated_at = now()
+WHERE run_agent_id = $1 AND turn_index = $2 AND status = 'awaiting'
+`, runAgentID, turnIndex, message)
+	if err != nil {
+		return fmt.Errorf("submit human turn: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrHumanTurnNotAwaiting
+	}
+	return nil
+}
+
+func (s *MultiTurnHumanTurnStore) AwaitingTurn(ctx context.Context, runAgentID uuid.UUID) (*HumanTurnStatus, error) {
+	if s.pool == nil {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		for _, row := range s.local {
+			if row.runAgentID == runAgentID && row.status == "awaiting" {
+				return &HumanTurnStatus{
+					TurnIndex:  row.turnIndex,
+					PhaseID:    row.phaseID,
+					PromptHint: row.promptHint,
+				}, nil
+			}
+		}
+		return nil, nil
+	}
+	var turnIndex int
+	var phaseID string
+	var promptHint *string
+	err := s.pool.QueryRow(ctx, `
+SELECT turn_index, phase_id, prompt_hint
+FROM multi_turn_human_turns
+WHERE run_agent_id = $1 AND status = 'awaiting'
+ORDER BY turn_index DESC
+LIMIT 1
+`, runAgentID).Scan(&turnIndex, &phaseID, &promptHint)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load awaiting human turn: %w", err)
+	}
+	status := &HumanTurnStatus{TurnIndex: turnIndex, PhaseID: phaseID}
+	if promptHint != nil {
+		status.PromptHint = *promptHint
+	}
+	return status, nil
+}
+
+func (s *MultiTurnHumanTurnStore) MarkHumanTurnExpired(ctx context.Context, runAgentID uuid.UUID, turnIndex int) error {
+	key := humanTurnKey(runAgentID, turnIndex)
+	if s.pool == nil {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		row, ok := s.local[key]
+		if !ok || row.status != "awaiting" {
+			return nil
+		}
+		row.status = "expired"
+		s.local[key] = row
+		return nil
+	}
+	_, err := s.pool.Exec(ctx, `
+UPDATE multi_turn_human_turns
+SET status = 'expired', updated_at = now()
+WHERE run_agent_id = $1 AND turn_index = $2 AND status = 'awaiting'
+`, runAgentID, turnIndex)
+	if err != nil {
+		return fmt.Errorf("expire human turn: %w", err)
+	}
+	return nil
+}
+
+type HumanTurnStatus struct {
+	TurnIndex  int
+	PhaseID    string
+	PromptHint string
+}
+
+func humanTurnKey(runAgentID uuid.UUID, turnIndex int) string {
+	return runAgentID.String() + ":" + fmt.Sprintf("%d", turnIndex)
+}
+
+func nullIfEmpty(value string) any {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return value
+}

--- a/backend/internal/repository/multi_turn_post_run.go
+++ b/backend/internal/repository/multi_turn_post_run.go
@@ -1,0 +1,147 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/agentclash/agentclash/backend/internal/challengepack"
+	"github.com/google/uuid"
+)
+
+type UpsertMultiTurnRunAgentFlagsParams struct {
+	RunAgentID           uuid.UUID
+	WorkspaceID          uuid.UUID
+	RunID                uuid.UUID
+	CaseKey              string
+	CalibrationCandidate bool
+	ArenaEligible        bool
+}
+
+type MultiTurnRunAgentFlags struct {
+	RunAgentID           uuid.UUID
+	CaseKey              string
+	CalibrationCandidate bool
+	ArenaEligible        bool
+}
+
+// UpsertMultiTurnRunAgentFlagsFromExecution records calibration/arena flags for a multi_turn run agent.
+func (r *Repository) UpsertMultiTurnRunAgentFlagsFromExecution(ctx context.Context, executionContext RunAgentExecutionContext) error {
+	if r.db == nil {
+		return nil
+	}
+	if executionContext.ChallengeInputSet == nil || len(executionContext.ChallengeInputSet.Cases) == 0 {
+		return nil
+	}
+	firstCase := executionContext.ChallengeInputSet.Cases[0]
+	spec := challengepack.CloneUserSimulatorSpec(firstCase.UserSimulator)
+	if spec == nil {
+		return nil
+	}
+
+	calibrationCandidate := false
+	if spec.Calibration != nil && spec.Calibration.Enabled {
+		calibrationCandidate = challengepack.ShouldSampleCalibration(executionContext.RunAgent.ID, spec.Calibration.SampleRate)
+	}
+
+	return r.UpsertMultiTurnRunAgentFlags(ctx, UpsertMultiTurnRunAgentFlagsParams{
+		RunAgentID:           executionContext.RunAgent.ID,
+		WorkspaceID:          executionContext.Run.WorkspaceID,
+		RunID:                executionContext.Run.ID,
+		CaseKey:              firstCase.CaseKey,
+		CalibrationCandidate: calibrationCandidate,
+		ArenaEligible:        challengepack.ArenaEligibleFromSpec(spec),
+	})
+}
+
+func (r *Repository) UpsertMultiTurnRunAgentFlags(ctx context.Context, params UpsertMultiTurnRunAgentFlagsParams) error {
+	if r.db == nil {
+		return fmt.Errorf("database is not configured")
+	}
+	_, err := r.db.Exec(ctx, `
+INSERT INTO multi_turn_run_agent_flags (
+  run_agent_id, workspace_id, run_id, case_key, calibration_candidate, arena_eligible
+) VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (run_agent_id) DO UPDATE SET
+  case_key = EXCLUDED.case_key,
+  calibration_candidate = EXCLUDED.calibration_candidate,
+  arena_eligible = EXCLUDED.arena_eligible
+`, params.RunAgentID, params.WorkspaceID, params.RunID, params.CaseKey, params.CalibrationCandidate, params.ArenaEligible)
+	return err
+}
+
+// FinalizeMultiTurnPostRunForRun creates pending arena tasks for eligible agent pairs on a completed run.
+func (r *Repository) FinalizeMultiTurnPostRunForRun(ctx context.Context, runID uuid.UUID) (int, error) {
+	if r.db == nil {
+		return 0, nil
+	}
+
+	run, err := r.GetRunByID(ctx, runID)
+	if err != nil {
+		return 0, err
+	}
+
+	rows, err := r.db.Query(ctx, `
+SELECT f.run_agent_id, f.case_key, ra.lane_index
+FROM multi_turn_run_agent_flags f
+JOIN run_agents ra ON ra.id = f.run_agent_id
+WHERE f.run_id = $1 AND f.arena_eligible = true
+ORDER BY f.case_key ASC, ra.lane_index ASC
+`, runID)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+
+	eligible := []challengepack.ArenaEligibleAgent{}
+	for rows.Next() {
+		var agentID uuid.UUID
+		var caseKey string
+		var laneIndex int32
+		if err := rows.Scan(&agentID, &caseKey, &laneIndex); err != nil {
+			return 0, err
+		}
+		eligible = append(eligible, challengepack.ArenaEligibleAgent{
+			RunAgentID: agentID,
+			CaseKey:    caseKey,
+			LaneIndex:  laneIndex,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	created := 0
+	for _, pair := range challengepack.PairArenaAgents(eligible) {
+		tag, err := r.db.Exec(ctx, `
+INSERT INTO workspace_arena_tasks (workspace_id, case_key, left_run_agent_id, right_run_agent_id, status)
+VALUES ($1, $2, $3, $4, 'pending')
+ON CONFLICT DO NOTHING
+`, run.WorkspaceID, arenaCaseKeyForPair(eligible, pair[0]), pair[0], pair[1])
+		if err != nil {
+			return created, err
+		}
+		created += int(tag.RowsAffected())
+	}
+	return created, nil
+}
+
+func arenaCaseKeyForPair(agents []challengepack.ArenaEligibleAgent, runAgentID uuid.UUID) string {
+	for _, agent := range agents {
+		if agent.RunAgentID == runAgentID {
+			return agent.CaseKey
+		}
+	}
+	return ""
+}
+
+func (r *Repository) CreateArenaTask(ctx context.Context, workspaceID uuid.UUID, caseKey string, leftRunAgentID, rightRunAgentID uuid.UUID) error {
+	if r.db == nil {
+		return fmt.Errorf("database is not configured")
+	}
+	_, err := r.db.Exec(ctx, `
+INSERT INTO workspace_arena_tasks (workspace_id, case_key, left_run_agent_id, right_run_agent_id, status)
+VALUES ($1, $2, $3, $4, 'pending')
+ON CONFLICT DO NOTHING
+`, workspaceID, caseKey, leftRunAgentID, rightRunAgentID)
+	return err
+}

--- a/backend/internal/repository/run_agent_evaluation.go
+++ b/backend/internal/repository/run_agent_evaluation.go
@@ -46,6 +46,9 @@ func (r *Repository) EvaluateRunAgent(ctx context.Context, params EvaluateRunAge
 	if err != nil {
 		return scoring.RunAgentEvaluation{}, fmt.Errorf("map evaluation input: %w", err)
 	}
+	if humanPref, prefErr := r.HumanPreferenceScore(ctx, params.RunAgentID); prefErr == nil {
+		evaluationInput.HumanPreferenceScore = humanPref
+	}
 
 	evaluation, err := scoring.EvaluateRunAgent(evaluationInput, spec)
 	if err != nil {

--- a/backend/internal/repository/run_agent_execution_context.go
+++ b/backend/internal/repository/run_agent_execution_context.go
@@ -65,6 +65,7 @@ type ChallengeCaseExecutionContext struct {
 	Payload             json.RawMessage                 `json:"payload,omitempty"`
 	Inputs              []challengepack.CaseInput       `json:"inputs,omitempty"`
 	Expectations        []challengepack.CaseExpectation `json:"expectations,omitempty"`
+	UserSimulator       *challengepack.UserSimulatorSpec `json:"user_simulator,omitempty"`
 	Artifacts           []challengepack.ArtifactRef     `json:"artifacts,omitempty"`
 	Assets              []challengepack.AssetReference  `json:"assets,omitempty"`
 }
@@ -448,6 +449,7 @@ func decodeChallengeCases(items []ChallengeInputItemExecutionContext) ([]Challen
 			Payload:             payload,
 			Inputs:              append([]challengepack.CaseInput(nil), caseDoc.Inputs...),
 			Expectations:        append([]challengepack.CaseExpectation(nil), caseDoc.Expectations...),
+			UserSimulator:       challengepack.CloneUserSimulatorSpec(caseDoc.UserSimulator),
 			Artifacts:           append([]challengepack.ArtifactRef(nil), caseDoc.Artifacts...),
 			Assets:              append([]challengepack.AssetReference(nil), caseDoc.Assets...),
 		})

--- a/backend/internal/repository/run_agent_replay_builder.go
+++ b/backend/internal/repository/run_agent_replay_builder.go
@@ -58,6 +58,8 @@ type runAgentReplayStepDocument struct {
 	EventTypes        []runevents.Type `json:"event_types"`
 	ArtifactIDs       []uuid.UUID      `json:"artifact_ids,omitempty"`
 	StepIndex         *int             `json:"step_index,omitempty"`
+	TurnIndex         *int             `json:"turn_index,omitempty"`
+	Mismatch          bool             `json:"mismatch,omitempty"`
 	ProviderKey       string           `json:"provider_key,omitempty"`
 	ProviderModelID   string           `json:"provider_model_id,omitempty"`
 	ToolName          string           `json:"tool_name,omitempty"`
@@ -232,6 +234,12 @@ func newReplayStepDocument(event RunEvent, payload map[string]any, stepType stri
 func enrichReplayStep(step *runAgentReplayStepDocument, payload map[string]any) {
 	if stepIndex, ok := replayInt(payload, "step_index"); ok {
 		step.StepIndex = &stepIndex
+	}
+	if turnIndex, ok := replayInt(payload, "turn_index"); ok {
+		step.TurnIndex = &turnIndex
+	}
+	if mismatch, ok := payload["mismatch"].(bool); ok && mismatch {
+		step.Mismatch = true
 	}
 	if providerKey := replayString(payload, "provider_key"); providerKey != "" {
 		step.ProviderKey = providerKey

--- a/backend/internal/runevents/envelope.go
+++ b/backend/internal/runevents/envelope.go
@@ -79,6 +79,7 @@ type Source string
 const (
 	SourceNativeEngine       Source = "native_engine"
 	SourcePromptEvalEngine   Source = "prompt_eval_engine"
+	SourceMultiTurnEngine    Source = "multi_turn_engine"
 	SourceHostedExternal     Source = "hosted_external"
 	SourceHostedCallback     Source = "hosted_callback"
 	SourceAgentHarnessWorker Source = "agent_harness_worker"
@@ -242,6 +243,7 @@ func isValidSource(source Source) bool {
 	switch source {
 	case SourceNativeEngine,
 		SourcePromptEvalEngine,
+		SourceMultiTurnEngine,
 		SourceHostedExternal,
 		SourceHostedCallback,
 		SourceAgentHarnessWorker,

--- a/backend/internal/scoring/engine.go
+++ b/backend/internal/scoring/engine.go
@@ -82,10 +82,11 @@ type Event struct {
 }
 
 type EvaluationInput struct {
-	RunAgentID       uuid.UUID       `json:"run_agent_id"`
-	EvaluationSpecID uuid.UUID       `json:"evaluation_spec_id"`
-	ChallengeInputs  []EvidenceInput `json:"challenge_inputs"`
-	Events           []Event         `json:"events"`
+	RunAgentID            uuid.UUID       `json:"run_agent_id"`
+	EvaluationSpecID      uuid.UUID       `json:"evaluation_spec_id"`
+	ChallengeInputs       []EvidenceInput `json:"challenge_inputs"`
+	Events                []Event         `json:"events"`
+	HumanPreferenceScore  *float64        `json:"human_preference_score,omitempty"`
 }
 
 type RunAgentEvaluation struct {
@@ -212,6 +213,9 @@ func evaluateRunAgentWithResolvedJudges(
 	events := orderedEvaluationEvents(input.Events)
 
 	evidence := buildEvidence(input.ChallengeInputs, events)
+	if input.HumanPreferenceScore != nil {
+		evidence.humanPreferenceScore = input.HumanPreferenceScore
+	}
 	validatorResults, warnings := evaluateValidators(spec.Validators, evidence)
 	metricResults, metricWarnings := evaluateMetrics(spec.Metrics, evidence, validatorResults, spec)
 	warnings = append(warnings, metricWarnings...)
@@ -222,6 +226,9 @@ func evaluateRunAgentWithResolvedJudges(
 func finalizeRunAgentEvaluation(input EvaluationInput, spec EvaluationSpec, validatorResults []ValidatorResult, metricResults []MetricResult, llmJudgeResults []LLMJudgeResult, warnings []string) RunAgentEvaluation {
 	events := orderedEvaluationEvents(input.Events)
 	evidence := buildEvidence(input.ChallengeInputs, events)
+	if input.HumanPreferenceScore != nil {
+		evidence.humanPreferenceScore = input.HumanPreferenceScore
+	}
 	return finalizeRunAgentEvaluationWithEvidence(input, spec, evidence, validatorResults, metricResults, llmJudgeResults, warnings)
 }
 

--- a/backend/internal/scoring/engine_behavioral.go
+++ b/backend/internal/scoring/engine_behavioral.go
@@ -30,7 +30,7 @@ func behavioralDimensionScore(spec EvaluationSpec, evidence extractedEvidence, v
 	)
 
 	for _, signal := range spec.Behavioral.Signals {
-		score, reason, state := behavioralSignalScore(signal.Key, evidence.toolCallTrace, validators)
+		score, reason, state := behavioralSignalScore(signal.Key, evidence.toolCallTrace, evidence.transcriptTurns, validators)
 		if state != OutputStateAvailable || score == nil {
 			return nil, fmt.Sprintf("behavioral signal %q is unavailable: %s", signal.Key, firstNonEmpty(reason, "signal is unavailable")), OutputStateUnavailable
 		}
@@ -53,9 +53,12 @@ func behavioralDimensionScore(spec EvaluationSpec, evidence extractedEvidence, v
 	return &score, "", OutputStateAvailable
 }
 
-func behavioralSignalScore(key BehavioralSignalKey, trace []toolCallTraceEntry, validators []ValidatorResult) (*float64, string, OutputState) {
+func behavioralSignalScore(key BehavioralSignalKey, trace []toolCallTraceEntry, transcript []transcriptTurnEvidence, validators []ValidatorResult) (*float64, string, OutputState) {
 	switch key {
 	case BehavioralSignalRecoveryBehavior:
+		if len(transcript) > 0 {
+			return multiTurnRecoveryScore(transcript, validators)
+		}
 		return recoveryBehaviorScore(trace)
 	case BehavioralSignalExplorationEfficiency:
 		return explorationEfficiencyScore(trace)

--- a/backend/internal/scoring/engine_dimensions.go
+++ b/backend/internal/scoring/engine_dimensions.go
@@ -24,9 +24,11 @@ func evaluateDimensions(spec EvaluationSpec, evidence extractedEvidence, validat
 			score, reason, state = behavioralDimensionScore(spec, evidence, validators)
 		case DimensionSourceMetric:
 			score, reason, state = metricDimensionScore(dim, metrics)
-		case DimensionSourceLLMJudge:
-			score, reason, state = llmJudgeDimensionScore(dim, llmJudges)
-		default:
+	case DimensionSourceLLMJudge:
+		score, reason, state = llmJudgeDimensionScore(dim, llmJudges)
+	case DimensionSourceHumanPreference:
+		score, reason, state = humanPreferenceDimensionScore(dim, evidence)
+	default:
 			state = OutputStateError
 			reason = fmt.Sprintf("unsupported dimension source %q", dim.Source)
 		}

--- a/backend/internal/scoring/engine_evidence.go
+++ b/backend/internal/scoring/engine_evidence.go
@@ -60,6 +60,8 @@ type extractedEvidence struct {
 	codeExecutionResults      map[string]CodeExecutionResult
 	codeExecutionSources      map[string]eventRef
 	toolCallTrace             []toolCallTraceEntry
+	transcriptTurns           []transcriptTurnEvidence
+	humanPreferenceScore      *float64
 	warnings                  []string
 }
 
@@ -328,6 +330,7 @@ func buildEvidence(challengeInputs []EvidenceInput, events []Event) extractedEvi
 	if evidence.completedSuccessfully == nil {
 		evidence.warnings = append(evidence.warnings, "terminal run evidence is unavailable")
 	}
+	evidence.transcriptTurns = buildTranscriptFromEvents(events)
 
 	return evidence
 }

--- a/backend/internal/scoring/engine_metrics.go
+++ b/backend/internal/scoring/engine_metrics.go
@@ -169,7 +169,7 @@ func collectMetric(metric MetricDeclaration, evidence extractedEvidence, validat
 }
 
 func behavioralMetricResult(metric MetricDeclaration, key BehavioralSignalKey, evidence extractedEvidence, validators []ValidatorResult) (OutputState, *float64, *string, *bool, string, json.RawMessage) {
-	score, reason, state := behavioralSignalScore(key, evidence.toolCallTrace, validators)
+	score, reason, state := behavioralSignalScore(key, evidence.toolCallTrace, evidence.transcriptTurns, validators)
 	if state != OutputStateAvailable || score == nil {
 		return unavailableMetric(firstNonEmpty(reason, fmt.Sprintf("behavioral signal %q is unavailable", key)), metric)
 	}

--- a/backend/internal/scoring/engine_resolution.go
+++ b/backend/internal/scoring/engine_resolution.go
@@ -49,7 +49,14 @@ func resolveEvidenceValue(source string, evidence extractedEvidence) (*string, *
 	case strings.HasPrefix(source, "literal:"):
 		value := strings.TrimPrefix(source, "literal:")
 		return &value, nil, "", nil
+	case source == "transcript.full", source == "transcript.from_mismatch", source == "turn.expectations":
+		value, reason, err := resolveTranscriptEvidence(source, evidence.transcriptTurns)
+		return value, nil, reason, err
 	default:
+		if strings.HasPrefix(source, "transcript.last_n:") {
+			value, reason, err := resolveTranscriptEvidence(source, evidence.transcriptTurns)
+			return value, nil, reason, err
+		}
 		return nil, nil, "", fmt.Errorf("unsupported evidence source %q", source)
 	}
 }

--- a/backend/internal/scoring/human_preference_dimension.go
+++ b/backend/internal/scoring/human_preference_dimension.go
@@ -1,0 +1,9 @@
+package scoring
+
+func humanPreferenceDimensionScore(dim DimensionDeclaration, evidence extractedEvidence) (*float64, string, OutputState) {
+	if evidence.humanPreferenceScore == nil {
+		return nil, "human preference evidence is unavailable", OutputStateUnavailable
+	}
+	score := *evidence.humanPreferenceScore
+	return &score, "", OutputStateAvailable
+}

--- a/backend/internal/scoring/spec.go
+++ b/backend/internal/scoring/spec.go
@@ -83,6 +83,7 @@ const (
 	DimensionSourceCost        DimensionSource = "cost"
 	DimensionSourceBehavioral  DimensionSource = "behavioral"
 	DimensionSourceLLMJudge    DimensionSource = "llm_judge"
+	DimensionSourceHumanPreference DimensionSource = "human_preference"
 )
 
 type BehavioralSignalKey string
@@ -382,7 +383,7 @@ func (t MetricType) IsValid() bool {
 
 func (s DimensionSource) IsValid() bool {
 	switch s {
-	case DimensionSourceValidators, DimensionSourceMetric, DimensionSourceReliability, DimensionSourceLatency, DimensionSourceCost, DimensionSourceBehavioral, DimensionSourceLLMJudge:
+	case DimensionSourceValidators, DimensionSourceMetric, DimensionSourceReliability, DimensionSourceLatency, DimensionSourceCost, DimensionSourceBehavioral, DimensionSourceLLMJudge, DimensionSourceHumanPreference:
 		return true
 	default:
 		return false

--- a/backend/internal/scoring/transcript_evidence.go
+++ b/backend/internal/scoring/transcript_evidence.go
@@ -1,0 +1,183 @@
+package scoring
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type transcriptTurnEvidence struct {
+	TurnIndex        int
+	PhaseID          string
+	Actor            string
+	UserMessage      string
+	AssistantMessage string
+	Mismatch         bool
+}
+
+func buildTranscriptFromEvents(events []Event) []transcriptTurnEvidence {
+	if len(events) == 0 {
+		return nil
+	}
+	sorted := append([]Event(nil), events...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if sorted[i].SequenceNumber > 0 && sorted[j].SequenceNumber > 0 {
+			return sorted[i].SequenceNumber < sorted[j].SequenceNumber
+		}
+		return sorted[i].OccurredAt.Before(sorted[j].OccurredAt)
+	})
+
+	byIndex := map[int]*transcriptTurnEvidence{}
+	order := []int{}
+	ensure := func(turnIndex int) *transcriptTurnEvidence {
+		if turn, ok := byIndex[turnIndex]; ok {
+			return turn
+		}
+		turn := &transcriptTurnEvidence{TurnIndex: turnIndex}
+		byIndex[turnIndex] = turn
+		order = append(order, turnIndex)
+		return turn
+	}
+
+	for _, event := range sorted {
+		payload := decodePayload(event.Payload)
+		turnIndex, ok := intValue(payload, "turn_index")
+		if !ok {
+			continue
+		}
+		turn := ensure(turnIndex)
+		if phaseID, ok := stringValue(payload, "phase_id"); ok {
+			turn.PhaseID = phaseID
+		}
+		switch event.Type {
+		case "turn.user.message":
+			if content, ok := stringValue(payload, "content"); ok {
+				turn.UserMessage = content
+			}
+			if actor, ok := stringValue(payload, "actor"); ok {
+				turn.Actor = actor
+			}
+		case "turn.assistant.message":
+			if content, ok := stringValue(payload, "content"); ok {
+				turn.AssistantMessage = content
+			}
+		case "turn.completed":
+			if mismatch, ok := payload["mismatch"].(bool); ok {
+				turn.Mismatch = mismatch
+			}
+			if actor, ok := stringValue(payload, "actor"); ok && turn.Actor == "" {
+				turn.Actor = actor
+			}
+		}
+	}
+
+	sort.Ints(order)
+	out := make([]transcriptTurnEvidence, 0, len(order))
+	for _, idx := range order {
+		out = append(out, *byIndex[idx])
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func resolveTranscriptEvidence(source string, turns []transcriptTurnEvidence) (*string, string, error) {
+	switch source {
+	case "transcript.full":
+		return stringifyTranscript(turns)
+	case "turn.expectations":
+		return stringifyTurnExpectations(turns)
+	default:
+		if strings.HasPrefix(source, "transcript.last_n:") {
+			nRaw := strings.TrimPrefix(source, "transcript.last_n:")
+			n, err := strconv.Atoi(strings.TrimSpace(nRaw))
+			if err != nil || n <= 0 {
+				return nil, "", fmt.Errorf("unsupported evidence source %q", source)
+			}
+			if len(turns) == 0 {
+				return nil, "transcript evidence is unavailable", nil
+			}
+			start := len(turns) - n
+			if start < 0 {
+				start = 0
+			}
+			return stringifyTranscript(turns[start:])
+		}
+		if source == "transcript.from_mismatch" {
+			firstMismatch := -1
+			for i, turn := range turns {
+				if turn.Mismatch {
+					firstMismatch = i
+					break
+				}
+			}
+			if firstMismatch < 0 {
+				return nil, "transcript mismatch evidence is unavailable", nil
+			}
+			return stringifyTranscript(turns[firstMismatch:])
+		}
+		return nil, "", fmt.Errorf("unsupported evidence source %q", source)
+	}
+}
+
+func stringifyTranscript(turns []transcriptTurnEvidence) (*string, string, error) {
+	if len(turns) == 0 {
+		return nil, "transcript evidence is unavailable", nil
+	}
+	lines := make([]string, 0, len(turns)*2)
+	for _, turn := range turns {
+		if strings.TrimSpace(turn.UserMessage) != "" {
+			lines = append(lines, fmt.Sprintf("user[%d]: %s", turn.TurnIndex, turn.UserMessage))
+		}
+		if strings.TrimSpace(turn.AssistantMessage) != "" {
+			lines = append(lines, fmt.Sprintf("assistant[%d]: %s", turn.TurnIndex, turn.AssistantMessage))
+		}
+	}
+	value := strings.Join(lines, "\n")
+	return &value, "", nil
+}
+
+func stringifyTurnExpectations(turns []transcriptTurnEvidence) (*string, string, error) {
+	if len(turns) == 0 {
+		return nil, "turn expectations evidence is unavailable", nil
+	}
+	type row struct {
+		TurnIndex int    `json:"turn_index"`
+		PhaseID   string `json:"phase_id,omitempty"`
+		Mismatch  bool   `json:"mismatch"`
+	}
+	rows := make([]row, 0, len(turns))
+	for _, turn := range turns {
+		rows = append(rows, row{TurnIndex: turn.TurnIndex, PhaseID: turn.PhaseID, Mismatch: turn.Mismatch})
+	}
+	encoded, err := json.Marshal(rows)
+	if err != nil {
+		return nil, "", err
+	}
+	value := string(encoded)
+	return &value, "", nil
+}
+
+func multiTurnRecoveryScore(turns []transcriptTurnEvidence, validators []ValidatorResult) (*float64, string, OutputState) {
+	hadMismatch := false
+	for _, turn := range turns {
+		if turn.Mismatch {
+			hadMismatch = true
+			break
+		}
+	}
+	if !hadMismatch {
+		return floatPtr(1), "", OutputStateAvailable
+	}
+	outcome, reason, ok := validatorBinaryOutcome(validators)
+	if !ok {
+		return nil, firstNonEmpty(reason, "validator outcome is unavailable"), OutputStateUnavailable
+	}
+	if outcome >= 1 {
+		return floatPtr(1), "", OutputStateAvailable
+	}
+	return floatPtr(0), "conversation mismatch without final validator recovery", OutputStateAvailable
+}

--- a/backend/internal/scoring/transcript_evidence_test.go
+++ b/backend/internal/scoring/transcript_evidence_test.go
@@ -1,0 +1,73 @@
+package scoring
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildTranscriptFromEvents_GroupsTurnPayloads(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	events := []Event{
+		{Type: "turn.user.message", SequenceNumber: 1, OccurredAt: now, Payload: mustJSON(t, map[string]any{
+			"turn_index": 0, "phase_id": "open", "actor": "scripted", "content": "Refund please",
+		})},
+		{Type: "turn.assistant.message", SequenceNumber: 2, OccurredAt: now, Payload: mustJSON(t, map[string]any{
+			"turn_index": 0, "content": "Sure, checking order.",
+		})},
+		{Type: "turn.completed", SequenceNumber: 3, OccurredAt: now, Payload: mustJSON(t, map[string]any{
+			"turn_index": 0, "mismatch": true,
+		})},
+	}
+
+	turns := buildTranscriptFromEvents(events)
+	if len(turns) != 1 {
+		t.Fatalf("len(turns) = %d; want 1", len(turns))
+	}
+	if turns[0].UserMessage != "Refund please" || turns[0].AssistantMessage != "Sure, checking order." {
+		t.Fatalf("unexpected turn content: %+v", turns[0])
+	}
+	if !turns[0].Mismatch {
+		t.Fatal("expected mismatch=true on turn.completed")
+	}
+
+	full, reason, err := resolveTranscriptEvidence("transcript.full", turns)
+	if err != nil || reason != "" {
+		t.Fatalf("transcript.full err=%v reason=%q", err, reason)
+	}
+	if full == nil || !strings.Contains(*full, "user[0]: Refund please") {
+		t.Fatalf("transcript.full = %v", full)
+	}
+
+	fromMismatch, reason, err := resolveTranscriptEvidence("transcript.from_mismatch", turns)
+	if err != nil || reason != "" {
+		t.Fatalf("transcript.from_mismatch err=%v reason=%q", err, reason)
+	}
+	if fromMismatch == nil {
+		t.Fatal("expected transcript from mismatch")
+	}
+}
+
+func TestMultiTurnRecoveryScore_RecoversWhenValidatorsPass(t *testing.T) {
+	t.Parallel()
+
+	turns := []transcriptTurnEvidence{{TurnIndex: 0, Mismatch: true}}
+	score, reason, state := multiTurnRecoveryScore(turns, []ValidatorResult{{
+		Key: "ok", State: OutputStateAvailable, NormalizedScore: floatPtr(1),
+	}})
+	if state != OutputStateAvailable || score == nil || *score != 1 {
+		t.Fatalf("recovery score = %v state=%v reason=%q; want 1 available", score, state, reason)
+	}
+}
+
+func mustJSON(t *testing.T, v map[string]any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}

--- a/backend/internal/scoring/validation.go
+++ b/backend/internal/scoring/validation.go
@@ -2,6 +2,7 @@ package scoring
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -635,6 +636,12 @@ func isSupportedEvidenceReference(value string) bool {
 		return strings.TrimSpace(remainder) != ""
 	case strings.HasPrefix(value, "literal:"):
 		return true
+	case value == "transcript.full", value == "transcript.from_mismatch", value == "turn.expectations":
+		return true
+	case strings.HasPrefix(value, "transcript.last_n:"):
+		nRaw := strings.TrimPrefix(value, "transcript.last_n:")
+		n, err := strconv.Atoi(strings.TrimSpace(nRaw))
+		return err == nil && n > 0
 	default:
 		return false
 	}

--- a/backend/internal/simulator/generator.go
+++ b/backend/internal/simulator/generator.go
@@ -1,0 +1,153 @@
+package simulator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/runevents"
+)
+
+const defaultSimulatorTimeout = 60 * time.Second
+
+// TranscriptTurn is one conversational turn for simulator context.
+type TranscriptTurn struct {
+	Actor   string
+	Content string
+	PhaseID string
+}
+
+// Input drives LLM user message generation.
+type Input struct {
+	Persona          string
+	Transcript       []TranscriptTurn
+	CasePayload      map[string]any
+	PhaseID          string
+	MaxOutputTokens  int32
+	ProviderKey      string
+	ProviderAccountID string
+	CredentialRef    string
+	Model            string
+}
+
+// Metadata describes the simulator provider call.
+type Metadata struct {
+	ProviderKey     string `json:"provider_key"`
+	ProviderModelID string `json:"provider_model_id"`
+	PhaseID         string `json:"phase_id"`
+}
+
+// Generator produces the next simulated user message.
+type Generator struct {
+	client provider.Client
+}
+
+func NewGenerator(client provider.Client) Generator {
+	return Generator{client: client}
+}
+
+func (g Generator) GenerateUserMessage(ctx context.Context, input Input) (message string, metadata Metadata, err error) {
+	if g.client == nil {
+		return "", Metadata{}, provider.NewFailure("", provider.FailureCodeInvalidRequest, "simulator provider client is not configured", false, nil)
+	}
+	if strings.TrimSpace(input.Persona) == "" {
+		return "", Metadata{}, provider.NewFailure(input.ProviderKey, provider.FailureCodeInvalidRequest, "llm simulator persona is required", false, nil)
+	}
+	if strings.TrimSpace(input.Model) == "" {
+		return "", Metadata{}, provider.NewFailure(input.ProviderKey, provider.FailureCodeInvalidRequest, "llm simulator model is required", false, nil)
+	}
+
+	prompt := buildSimulatorPrompt(input)
+	request := provider.Request{
+		ProviderKey:         input.ProviderKey,
+		ProviderAccountID:   input.ProviderAccountID,
+		CredentialReference: input.CredentialRef,
+		Model:               input.Model,
+		StepTimeout:         defaultSimulatorTimeout,
+		Messages: []provider.Message{
+			{Role: "user", Content: prompt},
+		},
+	}
+
+	callCtx := ctx
+	cancel := func() {}
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		callCtx, cancel = context.WithTimeout(ctx, defaultSimulatorTimeout)
+	}
+	defer cancel()
+
+	response, invokeErr := g.client.InvokeModel(callCtx, request)
+	if invokeErr != nil {
+		return "", Metadata{}, invokeErr
+	}
+
+	message = strings.TrimSpace(response.OutputText)
+	if message == "" {
+		return "", Metadata{}, provider.NewFailure(response.ProviderKey, provider.FailureCodeInvalidRequest, "llm simulator returned empty message", false, nil)
+	}
+
+	return message, Metadata{
+		ProviderKey:     response.ProviderKey,
+		ProviderModelID: response.ProviderModelID,
+		PhaseID:         input.PhaseID,
+	}, nil
+}
+
+func buildSimulatorPrompt(input Input) string {
+	var b strings.Builder
+	b.WriteString("You are simulating an end user in a multi-turn evaluation.\n\n")
+	b.WriteString("Persona:\n")
+	b.WriteString(strings.TrimSpace(input.Persona))
+	b.WriteString("\n\nConversation so far:\n")
+	if len(input.Transcript) == 0 {
+		b.WriteString("(no prior turns)\n")
+	} else {
+		for _, turn := range input.Transcript {
+			actor := strings.TrimSpace(turn.Actor)
+			if actor == "" {
+				actor = "user"
+			}
+			b.WriteString(fmt.Sprintf("%s: %s\n", actor, strings.TrimSpace(turn.Content)))
+		}
+	}
+	if len(input.CasePayload) > 0 {
+		encoded, _ := json.Marshal(input.CasePayload)
+		b.WriteString("\nCase context JSON:\n")
+		b.Write(encoded)
+		b.WriteByte('\n')
+	}
+	b.WriteString("\nWrite the next user message only. Do not include role prefixes or explanations.")
+	return b.String()
+}
+
+// ResolveTarget picks provider credentials from the run agent execution context.
+// Falls back to the deployment's provider account when simulator-specific config is absent.
+func ResolveTarget(executionContext repository.RunAgentExecutionContext) (providerKey, providerAccountID, credentialRef, model string, err error) {
+	if executionContext.Deployment.ProviderAccount == nil || executionContext.Deployment.ModelAlias == nil {
+		return "", "", "", "", provider.NewFailure("", provider.FailureCodeInvalidRequest, "multi_turn llm simulator requires deployment provider account and model alias", false, nil)
+	}
+	return executionContext.Deployment.ProviderAccount.ProviderKey,
+		executionContext.Deployment.ProviderAccount.ID.String(),
+		executionContext.Deployment.ProviderAccount.CredentialReference,
+		executionContext.Deployment.ModelAlias.ModelCatalogEntry.ProviderModelID,
+		nil
+}
+
+// TranscriptFromTurns converts engine transcript turns to simulator input.
+func TranscriptFromTurns(turns []TranscriptTurn) []TranscriptTurn {
+	return append([]TranscriptTurn(nil), turns...)
+}
+
+// ActorForEvent maps run event actors to transcript labels.
+func ActorForEvent(actor string) string {
+	switch strings.TrimSpace(actor) {
+	case runevents.ConversationActorScripted, runevents.ConversationActorLLM, runevents.ConversationActorHuman:
+		return "user"
+	default:
+		return strings.TrimSpace(actor)
+	}
+}

--- a/backend/internal/simulator/generator_test.go
+++ b/backend/internal/simulator/generator_test.go
@@ -1,0 +1,39 @@
+package simulator_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/simulator"
+)
+
+func TestTranscriptFromTurns_ClonesInput(t *testing.T) {
+	t.Parallel()
+
+	src := []simulator.TranscriptTurn{{Actor: "user", Content: "hello"}}
+	cloned := simulator.TranscriptFromTurns(src)
+	src[0].Content = "mutated"
+	if cloned[0].Content != "hello" {
+		t.Fatalf("TranscriptFromTurns() should clone; got %q", cloned[0].Content)
+	}
+}
+
+func TestActorForEvent_MapsConversationActors(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		in, want string
+	}{
+		{"scripted", "user"},
+		{"llm", "user"},
+		{"human", "user"},
+		{"assistant", "assistant"},
+	} {
+		if got := simulator.ActorForEvent(tc.in); got != tc.want {
+			t.Fatalf("ActorForEvent(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+	if strings.TrimSpace(simulator.ActorForEvent("  human  ")) != "user" {
+		t.Fatal("ActorForEvent should trim whitespace")
+	}
+}

--- a/backend/internal/worker/human_turn_gate.go
+++ b/backend/internal/worker/human_turn_gate.go
@@ -1,0 +1,46 @@
+package worker
+
+import (
+	"context"
+
+	"github.com/agentclash/agentclash/backend/internal/engine"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+type repositoryHumanTurnGate struct {
+	store *repository.MultiTurnHumanTurnStore
+}
+
+func NewRepositoryHumanTurnGate(store *repository.MultiTurnHumanTurnStore) engine.HumanTurnGate {
+	if store == nil {
+		return engine.NoopHumanTurnGate()
+	}
+	return repositoryHumanTurnGate{store: store}
+}
+
+func (g repositoryHumanTurnGate) WaitForHumanTurn(ctx context.Context, req engine.HumanTurnRequest) (string, error) {
+	return engine.NewPollHumanTurnGate(humanTurnStoreAdapter{store: g.store}).WaitForHumanTurn(ctx, req)
+}
+
+type humanTurnStoreAdapter struct {
+	store *repository.MultiTurnHumanTurnStore
+}
+
+func (a humanTurnStoreAdapter) MarkAwaitingHuman(ctx context.Context, req engine.HumanTurnRequest) error {
+	return a.store.MarkAwaitingHuman(ctx, repository.HumanTurnWaitParams{
+		RunAgentID: req.RunAgentID,
+		TurnIndex:  req.TurnIndex,
+		PhaseID:    req.PhaseID,
+		PromptHint: req.PromptHint,
+		Timeout:    req.Timeout,
+	})
+}
+
+func (a humanTurnStoreAdapter) PollHumanMessage(ctx context.Context, runAgentID uuid.UUID, turnIndex int) (string, bool, error) {
+	return a.store.PollHumanMessage(ctx, runAgentID, turnIndex)
+}
+
+func (a humanTurnStoreAdapter) MarkHumanTurnExpired(ctx context.Context, runAgentID uuid.UUID, turnIndex int) error {
+	return a.store.MarkHumanTurnExpired(ctx, runAgentID, turnIndex)
+}

--- a/backend/internal/worker/multi_turn_event_observer.go
+++ b/backend/internal/worker/multi_turn_event_observer.go
@@ -1,0 +1,270 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/engine"
+	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/runevents"
+	"github.com/agentclash/agentclash/backend/internal/simulator"
+)
+
+type MultiTurnObserverFactory func(executionContext repository.RunAgentExecutionContext) (engine.Observer, error)
+
+// MultiTurnRunEventObserver delegates native inner-loop events to a native
+// observer and records outer-loop multi-turn conversation events.
+type MultiTurnRunEventObserver struct {
+	native           *NativeRunEventObserver
+	recorder         RunEventRecorder
+	executionContext repository.RunAgentExecutionContext
+
+	mu           sync.Mutex
+	turnEventSeq int64
+}
+
+func NewMultiTurnRunEventObserverFactory(recorder RunEventRecorder) MultiTurnObserverFactory {
+	nativeFactory := NewNativeRunEventObserverFactory(recorder)
+	return func(executionContext repository.RunAgentExecutionContext) (engine.Observer, error) {
+		if recorder == nil {
+			return engine.NoopObserver{}, nil
+		}
+		native, err := nativeFactory(executionContext)
+		if err != nil {
+			return nil, err
+		}
+		nativeObserver, ok := native.(*NativeRunEventObserver)
+		if !ok {
+			return native, nil
+		}
+		return &MultiTurnRunEventObserver{
+			native:           nativeObserver,
+			recorder:         recorder,
+			executionContext: executionContext,
+		}, nil
+	}
+}
+
+func (o *MultiTurnRunEventObserver) OnStepStart(ctx context.Context, step int) error {
+	return o.native.OnStepStart(ctx, step)
+}
+
+func (o *MultiTurnRunEventObserver) OnProviderCall(ctx context.Context, request provider.Request) error {
+	return o.native.OnProviderCall(ctx, request)
+}
+
+func (o *MultiTurnRunEventObserver) OnProviderOutput(ctx context.Context, request provider.Request, delta provider.StreamDelta) error {
+	return o.native.OnProviderOutput(ctx, request, delta)
+}
+
+func (o *MultiTurnRunEventObserver) OnProviderResponse(ctx context.Context, response provider.Response) error {
+	return o.native.OnProviderResponse(ctx, response)
+}
+
+func (o *MultiTurnRunEventObserver) OnToolExecution(ctx context.Context, record engine.ToolExecutionRecord) error {
+	return o.native.OnToolExecution(ctx, record)
+}
+
+func (o *MultiTurnRunEventObserver) OnStepEnd(ctx context.Context, step int) error {
+	return o.native.OnStepEnd(ctx, step)
+}
+
+func (o *MultiTurnRunEventObserver) OnPostExecutionVerification(ctx context.Context, results []engine.PostExecutionVerificationResult) error {
+	return o.native.OnPostExecutionVerification(ctx, results)
+}
+
+func (o *MultiTurnRunEventObserver) OnStandingsInjected(ctx context.Context, injection engine.StandingsInjection) error {
+	return o.native.OnStandingsInjected(ctx, injection)
+}
+
+func (o *MultiTurnRunEventObserver) OnRunComplete(ctx context.Context, result engine.Result) error {
+	return o.native.OnRunComplete(ctx, result)
+}
+
+func (o *MultiTurnRunEventObserver) OnRunFailure(ctx context.Context, err error) error {
+	return o.native.OnRunFailure(ctx, err)
+}
+
+func (o *MultiTurnRunEventObserver) RecordTurnUserMessage(ctx context.Context, turnIndex int, phaseID, actor, content string) error {
+	if err := o.ensureRunStarted(ctx); err != nil {
+		return err
+	}
+	turn := turnIndex
+	eventActor := engine.ActorForRecorder(actor)
+	return o.recordTurnEvent(ctx, runevents.EventTypeTurnUserMessage, map[string]any{
+		"content":    content,
+		"actor":      eventActor,
+		"phase_id":   phaseID,
+		"turn_index": turnIndex,
+	}, runevents.SummaryMetadata{
+		Status:        "running",
+		TurnIndex:     &turn,
+		PhaseID:       phaseID,
+		Actor:         eventActor,
+		EvidenceLevel: runevents.EvidenceLevelNativeStructured,
+	})
+}
+
+func (o *MultiTurnRunEventObserver) RecordTurnUserSimulated(ctx context.Context, turnIndex int, phaseID string, metadata simulator.Metadata) error {
+	if err := o.ensureRunStarted(ctx); err != nil {
+		return err
+	}
+	turn := turnIndex
+	return o.recordTurnEvent(ctx, runevents.EventTypeTurnUserSimulated, map[string]any{
+		"provider_key":      metadata.ProviderKey,
+		"provider_model_id": metadata.ProviderModelID,
+		"phase_id":          metadata.PhaseID,
+		"turn_index":        turnIndex,
+	}, runevents.SummaryMetadata{
+		Status:        "running",
+		TurnIndex:     &turn,
+		PhaseID:       firstNonEmpty(metadata.PhaseID, phaseID),
+		Actor:         runevents.ConversationActorLLM,
+		EvidenceLevel: runevents.EvidenceLevelNativeStructured,
+	})
+}
+
+func (o *MultiTurnRunEventObserver) RecordTurnAwaitingHuman(ctx context.Context, turnIndex int, phaseID, promptHint string) error {
+	if err := o.ensureRunStarted(ctx); err != nil {
+		return err
+	}
+	turn := turnIndex
+	return o.recordTurnEvent(ctx, runevents.EventTypeTurnAwaitingHuman, map[string]any{
+		"phase_id":    phaseID,
+		"prompt_hint": promptHint,
+		"turn_index":  turnIndex,
+	}, runevents.SummaryMetadata{
+		Status:        "running",
+		TurnIndex:     &turn,
+		PhaseID:       phaseID,
+		Actor:         runevents.ConversationActorHuman,
+		EvidenceLevel: runevents.EvidenceLevelNativeStructured,
+	})
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func (o *MultiTurnRunEventObserver) RecordTurnAssistantMessage(ctx context.Context, turnIndex int, phaseID, content string) error {
+	if err := o.ensureRunStarted(ctx); err != nil {
+		return err
+	}
+	turn := turnIndex
+	return o.recordTurnEvent(ctx, runevents.EventTypeTurnAssistantMessage, map[string]any{
+		"content":    content,
+		"phase_id":   phaseID,
+		"turn_index": turnIndex,
+	}, runevents.SummaryMetadata{
+		Status:        "running",
+		TurnIndex:     &turn,
+		PhaseID:       phaseID,
+		EvidenceLevel: runevents.EvidenceLevelNativeStructured,
+	})
+}
+
+func (o *MultiTurnRunEventObserver) RecordTurnCompleted(ctx context.Context, turnIndex int, phaseID, actor string, mismatch bool) error {
+	if err := o.ensureRunStarted(ctx); err != nil {
+		return err
+	}
+	turn := turnIndex
+	mismatchCopy := mismatch
+	return o.recordTurnEvent(ctx, runevents.EventTypeTurnCompleted, map[string]any{
+		"turn_index": turnIndex,
+		"mismatch":   mismatch,
+	}, runevents.SummaryMetadata{
+		Status:        "running",
+		TurnIndex:     &turn,
+		PhaseID:       phaseID,
+		Actor:         actor,
+		Mismatch:      &mismatchCopy,
+		EvidenceLevel: runevents.EvidenceLevelNativeStructured,
+	})
+}
+
+func (o *MultiTurnRunEventObserver) RecordConversationCompleted(ctx context.Context, summary engine.MultiTurnConversationSummary) error {
+	if err := o.ensureRunStarted(ctx); err != nil {
+		return err
+	}
+	payload, err := json.Marshal(summary)
+	if err != nil {
+		return fmt.Errorf("marshal conversation.completed payload: %w", err)
+	}
+	return o.recordTurnEvent(ctx, runevents.EventTypeConversationCompleted, jsonRawToMap(payload), runevents.SummaryMetadata{
+		Status:        "running",
+		EvidenceLevel: runevents.EvidenceLevelNativeStructured,
+	})
+}
+
+func (o *MultiTurnRunEventObserver) ensureRunStarted(ctx context.Context) error {
+	return o.native.ensureRunStarted(ctx)
+}
+
+func (o *MultiTurnRunEventObserver) recordTurnEvent(ctx context.Context, eventType runevents.Type, payload map[string]any, summary runevents.SummaryMetadata) error {
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal multi_turn event payload: %w", err)
+	}
+
+	summary.IdempotencyKey = o.nextTurnEventID(eventType)
+	_, err = o.recorder.RecordRunEvent(ctx, repository.RecordRunEventParams{
+		Event: runevents.Envelope{
+			EventID:       summary.IdempotencyKey,
+			SchemaVersion: runevents.SchemaVersionV1,
+			RunID:         o.executionContext.Run.ID,
+			RunAgentID:    o.executionContext.RunAgent.ID,
+			EventType:     eventType,
+			Source:        runevents.SourceMultiTurnEngine,
+			OccurredAt:    time.Now().UTC(),
+			Payload:       payloadJSON,
+			Summary:       summary,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("record multi_turn run event: %w", err)
+	}
+	return nil
+}
+
+func (o *MultiTurnRunEventObserver) nextTurnEventID(eventType runevents.Type) string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.turnEventSeq++
+	return fmt.Sprintf("multi_turn:%s:%s:%d", o.executionContext.RunAgent.ID.String(), eventType, o.turnEventSeq)
+}
+
+func jsonRawToMap(payload json.RawMessage) map[string]any {
+	if len(payload) == 0 {
+		return map[string]any{}
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return map[string]any{"raw": string(payload)}
+	}
+	return decoded
+}
+
+// NewBufferedMultiTurnObserverFactory wraps the multi-turn observer factory with buffering.
+func NewBufferedMultiTurnObserverFactory(recorder RunEventRecorder) MultiTurnObserverFactory {
+	innerFactory := NewMultiTurnRunEventObserverFactory(recorder)
+	return func(executionContext repository.RunAgentExecutionContext) (engine.Observer, error) {
+		inner, err := innerFactory(executionContext)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := inner.(engine.NoopObserver); ok {
+			return inner, nil
+		}
+		return NewBufferedObserver(inner), nil
+	}
+}

--- a/backend/internal/worker/multi_turn_invoker.go
+++ b/backend/internal/worker/multi_turn_invoker.go
@@ -1,0 +1,93 @@
+package worker
+
+import (
+	"context"
+
+	"github.com/agentclash/agentclash/backend/internal/engine"
+	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/agentclash/agentclash/backend/internal/racecontext"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/sandbox"
+	"github.com/agentclash/agentclash/backend/internal/simulator"
+)
+
+type MultiTurnInvoker struct {
+	client          provider.Client
+	sandboxProvider sandbox.Provider
+	observerFactory MultiTurnObserverFactory
+	secretsLookup   engine.SecretsLookup
+	assetLoader     engine.AssetLoader
+	standingsStore  racecontext.Store
+	humanTurnStore  *repository.MultiTurnHumanTurnStore
+}
+
+func NewMultiTurnInvoker(client provider.Client, sandboxProvider sandbox.Provider) MultiTurnInvoker {
+	return NewMultiTurnInvokerWithObserverFactory(client, sandboxProvider, nil)
+}
+
+func NewMultiTurnInvokerWithObserverFactory(client provider.Client, sandboxProvider sandbox.Provider, observerFactory MultiTurnObserverFactory) MultiTurnInvoker {
+	return MultiTurnInvoker{
+		client:          client,
+		sandboxProvider: sandboxProvider,
+		observerFactory: observerFactory,
+	}
+}
+
+func (i MultiTurnInvoker) WithSecretsLookup(lookup engine.SecretsLookup) MultiTurnInvoker {
+	i.secretsLookup = lookup
+	return i
+}
+
+func (i MultiTurnInvoker) WithAssetLoader(loader engine.AssetLoader) MultiTurnInvoker {
+	i.assetLoader = loader
+	return i
+}
+
+func (i MultiTurnInvoker) WithStandingsStore(store racecontext.Store) MultiTurnInvoker {
+	i.standingsStore = store
+	return i
+}
+
+func (i MultiTurnInvoker) WithHumanTurnStore(store *repository.MultiTurnHumanTurnStore) MultiTurnInvoker {
+	i.humanTurnStore = store
+	return i
+}
+
+func (i MultiTurnInvoker) InvokeMultiTurn(ctx context.Context, executionContext repository.RunAgentExecutionContext) (engine.Result, error) {
+	observer := engine.Observer(engine.NoopObserver{})
+	if i.observerFactory != nil {
+		builtObserver, err := i.observerFactory(executionContext)
+		if err != nil {
+			return engine.Result{}, err
+		}
+		if builtObserver != nil {
+			observer = builtObserver
+		}
+	}
+
+	nativeExecutor := engine.NewNativeExecutor(i.client, i.sandboxProvider, observer)
+	if i.secretsLookup != nil {
+		nativeExecutor = nativeExecutor.WithSecretsLookup(i.secretsLookup)
+	}
+	if i.assetLoader != nil {
+		nativeExecutor = nativeExecutor.WithAssetLoader(i.assetLoader)
+	}
+	if i.standingsStore != nil {
+		nativeExecutor = nativeExecutor.WithStandingsStore(i.standingsStore)
+	}
+
+	executor := engine.NewMultiTurnExecutor(nativeExecutor, observer)
+	if i.secretsLookup != nil {
+		executor = executor.WithSecretsLookup(i.secretsLookup)
+	}
+	if i.assetLoader != nil {
+		executor = executor.WithAssetLoader(i.assetLoader)
+	}
+	if i.client != nil {
+		executor = executor.WithSimulator(engine.NewSimulatorTurnGenerator(simulator.NewGenerator(i.client)))
+	}
+	if i.humanTurnStore != nil {
+		executor = executor.WithHumanTurnGate(NewRepositoryHumanTurnGate(i.humanTurnStore))
+	}
+	return executor.Execute(ctx, executionContext)
+}

--- a/backend/internal/workflow/activities.go
+++ b/backend/internal/workflow/activities.go
@@ -34,6 +34,8 @@ const (
 	markHostedRunTimedOutActivityName                 = "workflow.mark_hosted_run_timed_out"
 	executeNativeModelStepActivityName                = "workflow.execute_native_model_step"
 	executePromptEvalStepActivityName                 = "workflow.execute_prompt_eval_step"
+	executeMultiTurnStepActivityName                  = "workflow.execute_multi_turn_step"
+	finalizeMultiTurnPostRunActivityName              = "workflow.finalize_multi_turn_post_run"
 	scoreRunAgentActivityName                         = "workflow.score_run_agent"
 	buildRunScorecardActivityName                     = "workflow.build_run_scorecard"
 	buildRunAgentReplayActivityName                   = "workflow.build_run_agent_replay"
@@ -65,6 +67,7 @@ type FakeWorkHooks struct {
 	HostedRunStarter     HostedRunStarter
 	NativeModelInvoker   NativeModelInvoker
 	PromptEvalInvoker    PromptEvalInvoker
+	MultiTurnInvoker     MultiTurnInvoker
 }
 
 type NativeModelInvoker interface {
@@ -73,6 +76,10 @@ type NativeModelInvoker interface {
 
 type PromptEvalInvoker interface {
 	InvokePromptEval(ctx context.Context, executionContext repository.RunAgentExecutionContext) (engine.Result, error)
+}
+
+type MultiTurnInvoker interface {
+	InvokeMultiTurn(ctx context.Context, executionContext repository.RunAgentExecutionContext) (engine.Result, error)
 }
 
 type Activities struct {
@@ -424,6 +431,33 @@ func (a *Activities) ExecutePromptEvalStep(ctx context.Context, input RunAgentWo
 	}
 
 	_, err = a.hooks.PromptEvalInvoker.InvokePromptEval(ctx, executionContext)
+	return wrapActivityError(err)
+}
+
+func (a *Activities) ExecuteMultiTurnStep(ctx context.Context, input RunAgentWorkflowInput) error {
+	if a.hooks.MultiTurnInvoker == nil {
+		return temporal.NewNonRetryableApplicationError(
+			"multi_turn invoker not configured",
+			"workflow.multi_turn_invoker_missing",
+			nil,
+		)
+	}
+
+	executionContext, err := a.repo.GetRunAgentExecutionContextByID(ctx, input.RunAgentID)
+	if err != nil {
+		return wrapActivityError(err)
+	}
+
+	if err := a.repo.UpsertMultiTurnRunAgentFlagsFromExecution(ctx, executionContext); err != nil {
+		return wrapActivityError(err)
+	}
+
+	_, err = a.hooks.MultiTurnInvoker.InvokeMultiTurn(ctx, executionContext)
+	return wrapActivityError(err)
+}
+
+func (a *Activities) FinalizeMultiTurnPostRun(ctx context.Context, input RunWorkflowInput) error {
+	_, err := a.repo.FinalizeMultiTurnPostRunForRun(ctx, input.RunID)
 	return wrapActivityError(err)
 }
 

--- a/backend/internal/workflow/register.go
+++ b/backend/internal/workflow/register.go
@@ -31,6 +31,8 @@ func Register(registrar Registrar, activities *Activities) {
 	registrar.RegisterActivityWithOptions(activities.MarkHostedRunTimedOut, sdkactivity.RegisterOptions{Name: markHostedRunTimedOutActivityName})
 	registrar.RegisterActivityWithOptions(activities.ExecuteNativeModelStep, sdkactivity.RegisterOptions{Name: executeNativeModelStepActivityName})
 	registrar.RegisterActivityWithOptions(activities.ExecutePromptEvalStep, sdkactivity.RegisterOptions{Name: executePromptEvalStepActivityName})
+	registrar.RegisterActivityWithOptions(activities.ExecuteMultiTurnStep, sdkactivity.RegisterOptions{Name: executeMultiTurnStepActivityName})
+	registrar.RegisterActivityWithOptions(activities.FinalizeMultiTurnPostRun, sdkactivity.RegisterOptions{Name: finalizeMultiTurnPostRunActivityName})
 	registrar.RegisterActivityWithOptions(activities.ScoreRunAgent, sdkactivity.RegisterOptions{Name: scoreRunAgentActivityName})
 	registrar.RegisterActivityWithOptions(activities.BuildRunScorecard, sdkactivity.RegisterOptions{Name: buildRunScorecardActivityName})
 	registrar.RegisterActivityWithOptions(activities.BuildRunAgentReplay, sdkactivity.RegisterOptions{Name: buildRunAgentReplayActivityName})

--- a/backend/internal/workflow/repository.go
+++ b/backend/internal/workflow/repository.go
@@ -34,6 +34,9 @@ type RunRepository interface {
 	ListRunEventsByRunAgentID(ctx context.Context, runAgentID uuid.UUID) ([]repository.RunEvent, error)
 	RecordRunEvent(ctx context.Context, params repository.RecordRunEventParams) (repository.RunEvent, error)
 	StoreRunAgentEvaluationResults(ctx context.Context, evaluation scoring.RunAgentEvaluation) error
+	HumanPreferenceScore(ctx context.Context, runAgentID uuid.UUID) (*float64, error)
+	UpsertMultiTurnRunAgentFlagsFromExecution(ctx context.Context, executionContext repository.RunAgentExecutionContext) error
+	FinalizeMultiTurnPostRunForRun(ctx context.Context, runID uuid.UUID) (int, error)
 	BuildRunScorecard(ctx context.Context, runID uuid.UUID) (repository.RunScorecard, error)
 	BuildRunAgentReplay(ctx context.Context, runAgentID uuid.UUID) (repository.RunAgentReplay, error)
 	SetRunTemporalIDs(ctx context.Context, params repository.SetRunTemporalIDsParams) (domain.Run, error)

--- a/backend/internal/workflow/run_agent_workflow.go
+++ b/backend/internal/workflow/run_agent_workflow.go
@@ -172,6 +172,8 @@ func nativeModelActivityOptions(executionContext repository.RunAgentExecutionCon
 				engineFailureErrorTypePrefix + string(engine.StopReasonToolLimit),
 				engineFailureErrorTypePrefix + string(engine.StopReasonTimeout),
 				engineFailureErrorTypePrefix + string(engine.StopReasonMaxTurns),
+				engineFailureErrorTypePrefix + string(engine.StopReasonHumanTurnTimeout),
+				engineFailureErrorTypePrefix + string(engine.StopReasonSimulatorError),
 				engineFailureErrorTypePrefix + string(engine.StopReasonProviderError),
 				engineFailureErrorTypePrefix + string(engine.StopReasonObserverError),
 				providerFailureErrorTypePrefix + string(provider.FailureCodeAuth),

--- a/backend/internal/workflow/run_agent_workflow.go
+++ b/backend/internal/workflow/run_agent_workflow.go
@@ -66,6 +66,10 @@ func runAgentWorkflow(ctx sdkworkflow.Context, input RunAgentWorkflowInput) erro
 		return runPromptEvalRunAgent(ctx, input, executionContext)
 	}
 
+	if executionModeFromManifest(executionContext.ChallengePackVersion.Manifest) == challengepack.ExecutionModeMultiTurn {
+		return runMultiTurnRunAgent(ctx, input, executionContext)
+	}
+
 	if err := transitionRunAgentStatus(ctx, input.RunAgentID, domain.RunAgentStatusExecuting, stringPtr("native execution started"), nil); err != nil {
 		return err
 	}
@@ -91,6 +95,28 @@ func runPromptEvalRunAgent(ctx sdkworkflow.Context, input RunAgentWorkflowInput,
 	}
 	warnOnReplayBuildFailure(ctx, input.RunAgentID, "successful prompt_eval execution")
 	return nil
+}
+
+func runMultiTurnRunAgent(ctx sdkworkflow.Context, input RunAgentWorkflowInput, executionContext repository.RunAgentExecutionContext) error {
+	if err := transitionRunAgentStatus(ctx, input.RunAgentID, domain.RunAgentStatusExecuting, stringPtr("multi_turn execution started"), nil); err != nil {
+		return err
+	}
+	if err := executeMultiTurnStep(ctx, input, executionContext).Get(ctx, nil); err != nil {
+		return err
+	}
+	if err := transitionRunAgentStatus(ctx, input.RunAgentID, domain.RunAgentStatusEvaluating, stringPtr("multi_turn execution completed; parent scoring pending"), nil); err != nil {
+		return err
+	}
+	warnOnReplayBuildFailure(ctx, input.RunAgentID, "successful multi_turn execution")
+	return nil
+}
+
+func executeMultiTurnStep(ctx sdkworkflow.Context, input RunAgentWorkflowInput, executionContext repository.RunAgentExecutionContext) sdkworkflow.Future {
+	return sdkworkflow.ExecuteActivity(
+		sdkworkflow.WithActivityOptions(ctx, nativeModelActivityOptions(executionContext)),
+		executeMultiTurnStepActivityName,
+		input,
+	)
 }
 
 func executePromptEvalStep(ctx sdkworkflow.Context, input RunAgentWorkflowInput, executionContext repository.RunAgentExecutionContext) sdkworkflow.Future {
@@ -145,6 +171,7 @@ func nativeModelActivityOptions(executionContext repository.RunAgentExecutionCon
 				engineFailureErrorTypePrefix + string(engine.StopReasonStepLimit),
 				engineFailureErrorTypePrefix + string(engine.StopReasonToolLimit),
 				engineFailureErrorTypePrefix + string(engine.StopReasonTimeout),
+				engineFailureErrorTypePrefix + string(engine.StopReasonMaxTurns),
 				engineFailureErrorTypePrefix + string(engine.StopReasonProviderError),
 				engineFailureErrorTypePrefix + string(engine.StopReasonObserverError),
 				providerFailureErrorTypePrefix + string(provider.FailureCodeAuth),

--- a/backend/internal/workflow/run_workflow.go
+++ b/backend/internal/workflow/run_workflow.go
@@ -86,7 +86,7 @@ func runWorkflow(ctx sdkworkflow.Context, input RunWorkflowInput) error {
 	if err != nil {
 		return err
 	}
-	scoreSummary, err := scoreEvaluatingRunAgents(ctx, updatedRunAgents)
+	scoreSummary, err := scoreEvaluatingRunAgents(ctx, input.RunID, updatedRunAgents)
 	if err != nil {
 		return err
 	}
@@ -147,7 +147,7 @@ func selectRunAgentChildError(childErrors map[uuid.UUID]error) error {
 	return firstActionable
 }
 
-func scoreEvaluatingRunAgents(ctx sdkworkflow.Context, runAgents []domain.RunAgent) (string, error) {
+func scoreEvaluatingRunAgents(ctx sdkworkflow.Context, runID uuid.UUID, runAgents []domain.RunAgent) (string, error) {
 	outcomes := make(map[uuid.UUID]string, len(runAgents))
 	completedRunAgents := make([]domain.RunAgent, 0, len(runAgents))
 	for _, runAgent := range runAgents {
@@ -212,6 +212,10 @@ func scoreEvaluatingRunAgents(ctx sdkworkflow.Context, runAgents []domain.RunAge
 		if err := buildRunScorecard(ctx, runAgents[0].RunID); err != nil {
 			return "", err
 		}
+	}
+
+	if err := sdkworkflow.ExecuteActivity(ctx, finalizeMultiTurnPostRunActivityName, RunWorkflowInput{RunID: runID}).Get(ctx, nil); err != nil {
+		sdkworkflow.GetLogger(ctx).Warn("multi_turn post-run finalization failed", "run_id", runID.String(), "error", err)
 	}
 
 	return summarizeScoreOutcomes(outcomes), nil

--- a/backend/internal/workflow/scoring.go
+++ b/backend/internal/workflow/scoring.go
@@ -65,11 +65,14 @@ func (a *Activities) executeRunAgentEvaluation(ctx context.Context, runAgentID u
 		return scoring.RunAgentEvaluation{}, fmt.Errorf("map challenge inputs: %w", err)
 	}
 
+	humanPref, _ := a.repo.HumanPreferenceScore(ctx, runAgentID)
+
 	evaluationInput := scoring.EvaluationInput{
-		RunAgentID:       runAgentID,
-		EvaluationSpecID: specRecord.ID,
-		ChallengeInputs:  challengeInputs,
-		Events:           mapRunEvents(events),
+		RunAgentID:           runAgentID,
+		EvaluationSpecID:     specRecord.ID,
+		ChallengeInputs:      challengeInputs,
+		Events:               mapRunEvents(events),
+		HumanPreferenceScore: humanPref,
 	}
 
 	var evaluation scoring.RunAgentEvaluation

--- a/backend/internal/workflow/workflow_test.go
+++ b/backend/internal/workflow/workflow_test.go
@@ -539,6 +539,9 @@ func TestRunWorkflowHappyPath(t *testing.T) {
 	if repo.callCountWithPrefix("BuildRunScorecard:") != 1 {
 		t.Fatalf("BuildRunScorecard call count = %d, want 1", repo.callCountWithPrefix("BuildRunScorecard:"))
 	}
+	if repo.callCountWithPrefix("FinalizeMultiTurnPostRunForRun:") != 1 {
+		t.Fatalf("FinalizeMultiTurnPostRunForRun call count = %d, want 1", repo.callCountWithPrefix("FinalizeMultiTurnPostRunForRun:"))
+	}
 }
 
 func TestRunWorkflowStartsOneChildPerRunAgent(t *testing.T) {
@@ -1743,6 +1746,21 @@ func (r *fakeRunRepository) StoreRunAgentEvaluationResults(_ context.Context, ev
 	return nil
 }
 
+func (r *fakeRunRepository) HumanPreferenceScore(_ context.Context, _ uuid.UUID) (*float64, error) {
+	return nil, nil
+}
+
+func (r *fakeRunRepository) UpsertMultiTurnRunAgentFlagsFromExecution(_ context.Context, _ repository.RunAgentExecutionContext) error {
+	return nil
+}
+
+func (r *fakeRunRepository) FinalizeMultiTurnPostRunForRun(_ context.Context, runID uuid.UUID) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.callLog = append(r.callLog, fmt.Sprintf("FinalizeMultiTurnPostRunForRun:%s", runID))
+	return 0, nil
+}
+
 func (r *fakeRunRepository) BuildRunScorecard(_ context.Context, runID uuid.UUID) (repository.RunScorecard, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -2475,6 +2493,7 @@ func TestNativeModelActivityOptionsNonRetryableTypes(t *testing.T) {
 		engineFailureErrorTypePrefix + string(engine.StopReasonStepLimit),
 		engineFailureErrorTypePrefix + string(engine.StopReasonToolLimit),
 		engineFailureErrorTypePrefix + string(engine.StopReasonTimeout),
+		engineFailureErrorTypePrefix + string(engine.StopReasonMaxTurns),
 		engineFailureErrorTypePrefix + string(engine.StopReasonProviderError),
 		engineFailureErrorTypePrefix + string(engine.StopReasonObserverError),
 		providerFailureErrorTypePrefix + string(provider.FailureCodeAuth),

--- a/backend/internal/workflow/workflow_test.go
+++ b/backend/internal/workflow/workflow_test.go
@@ -2494,6 +2494,8 @@ func TestNativeModelActivityOptionsNonRetryableTypes(t *testing.T) {
 		engineFailureErrorTypePrefix + string(engine.StopReasonToolLimit),
 		engineFailureErrorTypePrefix + string(engine.StopReasonTimeout),
 		engineFailureErrorTypePrefix + string(engine.StopReasonMaxTurns),
+		engineFailureErrorTypePrefix + string(engine.StopReasonHumanTurnTimeout),
+		engineFailureErrorTypePrefix + string(engine.StopReasonSimulatorError),
 		engineFailureErrorTypePrefix + string(engine.StopReasonProviderError),
 		engineFailureErrorTypePrefix + string(engine.StopReasonObserverError),
 		providerFailureErrorTypePrefix + string(provider.FailureCodeAuth),

--- a/cli/cmd/run_turn.go
+++ b/cli/cmd/run_turn.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	runCmd.AddCommand(runTurnCmd)
+	runTurnCmd.AddCommand(runTurnSubmitCmd)
+	runTurnCmd.AddCommand(runTurnStatusCmd)
+	runTurnSubmitCmd.Flags().String("message", "", "Human user message for the awaiting turn")
+	runTurnSubmitCmd.Flags().String("run", "", "Run ID")
+	runTurnStatusCmd.Flags().String("run", "", "Run ID")
+}
+
+var runTurnCmd = &cobra.Command{
+	Use:   "turn",
+	Short: "Multi-turn human takeover helpers",
+}
+
+var runTurnSubmitCmd = &cobra.Command{
+	Use:   "submit <runAgentId>",
+	Short: "Submit a human user message for an awaiting multi_turn phase",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		message, _ := cmd.Flags().GetString("message")
+		message = strings.TrimSpace(message)
+		if message == "" {
+			return fmt.Errorf("--message is required")
+		}
+		runID, _ := cmd.Flags().GetString("run")
+		runID = strings.TrimSpace(runID)
+		if runID == "" {
+			return fmt.Errorf("--run is required")
+		}
+		workspaceID := RequireWorkspace(cmd)
+		path := fmt.Sprintf("/v1/workspaces/%s/runs/%s/run-agents/%s/turns", workspaceID, runID, args[0])
+		resp, err := rc.Client.Post(cmd.Context(), path, map[string]string{"message": message})
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(map[string]string{"status": "submitted"})
+		}
+		rc.Output.PrintSuccess("Human turn submitted")
+		return nil
+	},
+}
+
+var runTurnStatusCmd = &cobra.Command{
+	Use:   "status <runAgentId>",
+	Short: "Check whether a run agent is awaiting human input",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		runID, _ := cmd.Flags().GetString("run")
+		runID = strings.TrimSpace(runID)
+		if runID == "" {
+			return fmt.Errorf("--run is required")
+		}
+		workspaceID := RequireWorkspace(cmd)
+		path := fmt.Sprintf("/v1/workspaces/%s/runs/%s/run-agents/%s/turns/status", workspaceID, runID, args[0])
+		resp, err := rc.Client.Get(cmd.Context(), path, nil)
+		if err != nil {
+			return err
+		}
+		if apiErr := resp.ParseError(); apiErr != nil {
+			return apiErr
+		}
+		var body map[string]any
+		if err := resp.DecodeJSON(&body); err != nil {
+			return err
+		}
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(body)
+		}
+		if awaiting, _ := body["awaiting_human"].(bool); !awaiting {
+			rc.Output.PrintDetail("Awaiting human", "no")
+			return nil
+		}
+		rc.Output.PrintDetail("Awaiting human", "yes")
+		rc.Output.PrintDetail("Turn index", fmt.Sprintf("%v", body["turn_index"]))
+		rc.Output.PrintDetail("Phase", fmt.Sprintf("%v", body["phase_id"]))
+		if hint, ok := body["prompt_hint"].(string); ok && strings.TrimSpace(hint) != "" {
+			rc.Output.PrintDetail("Prompt hint", hint)
+		}
+		return nil
+	},
+}

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -2898,6 +2898,170 @@ paths:
         "404":
           $ref: "#/components/responses/NotFoundError"
 
+  /v1/workspaces/{workspaceID}/runs/{runID}/run-agents/{runAgentID}/turns:
+    post:
+      operationId: submitMultiTurnHumanTurn
+      tags: [Runs, MultiTurn]
+      summary: Submit a human user message for an awaiting multi-turn phase
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+        - $ref: "#/components/parameters/RunID"
+        - $ref: "#/components/parameters/RunAgentID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SubmitHumanTurnRequest"
+      responses:
+        "202":
+          description: Human message accepted for the active turn
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SubmitHumanTurnResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "409":
+          description: Run agent is not awaiting human input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
+
+  /v1/workspaces/{workspaceID}/runs/{runID}/run-agents/{runAgentID}/turns/status:
+    get:
+      operationId: getMultiTurnHumanTurnStatus
+      tags: [Runs, MultiTurn]
+      summary: Poll whether a run agent is awaiting human input
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+        - $ref: "#/components/parameters/RunID"
+        - $ref: "#/components/parameters/RunAgentID"
+      responses:
+        "200":
+          description: Current human-turn gate state
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HumanTurnStatusResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
+  /v1/workspaces/{workspaceID}/calibration-reviews:
+    post:
+      operationId: createCalibrationReview
+      tags: [MultiTurn]
+      summary: Record a human calibration score for a multi-turn turn
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CalibrationReviewRequest"
+      responses:
+        "201":
+          description: Calibration review recorded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MultiTurnStatusResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+    get:
+      operationId: listCalibrationReviews
+      tags: [MultiTurn]
+      summary: List recent calibration reviews for a workspace
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+      responses:
+        "200":
+          description: Calibration reviews
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListCalibrationReviewsResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+
+  /v1/workspaces/{workspaceID}/arena/tasks:
+    get:
+      operationId: listArenaTasks
+      tags: [MultiTurn]
+      summary: List pending pairwise arena comparison tasks
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+      responses:
+        "200":
+          description: Pending arena tasks
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListArenaTasksResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+
+  /v1/workspaces/{workspaceID}/arena/votes:
+    post:
+      operationId: submitArenaVote
+      tags: [MultiTurn]
+      summary: Submit a human preference vote for an arena task
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ArenaVoteRequest"
+      responses:
+        "201":
+          description: Arena vote recorded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MultiTurnStatusResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+
   /v1/runs/{runID}/events/stream:
     get:
       operationId: streamRunEvents
@@ -8953,6 +9117,140 @@ components:
           type: array
           items:
             type: string
+
+    # --- Multi-turn ---
+
+    SubmitHumanTurnRequest:
+      type: object
+      required: [message]
+      properties:
+        message:
+          type: string
+          minLength: 1
+
+    SubmitHumanTurnResponse:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          enum: [submitted]
+
+    HumanTurnStatusResponse:
+      type: object
+      required: [awaiting_human]
+      properties:
+        awaiting_human:
+          type: boolean
+        turn_index:
+          type: integer
+          minimum: 0
+        phase_id:
+          type: string
+        prompt_hint:
+          type: string
+
+    CalibrationReviewRequest:
+      type: object
+      required: [run_agent_id, turn_index, score]
+      properties:
+        run_agent_id:
+          type: string
+          format: uuid
+        turn_index:
+          type: integer
+          minimum: 0
+        score:
+          type: number
+          minimum: 1
+          maximum: 5
+        rubric_key:
+          type: string
+        notes:
+          type: string
+
+    CalibrationReview:
+      type: object
+      required: [id, run_agent_id, turn_index, score, reviewer_user_id, created_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+        run_agent_id:
+          type: string
+          format: uuid
+        turn_index:
+          type: integer
+        score:
+          type: number
+        rubric_key:
+          type: string
+        notes:
+          type: string
+        reviewer_user_id:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+
+    ListCalibrationReviewsResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/CalibrationReview"
+
+    ArenaTask:
+      type: object
+      required: [id, case_key, left_run_agent_id, right_run_agent_id, status]
+      properties:
+        id:
+          type: string
+          format: uuid
+        case_key:
+          type: string
+        left_run_agent_id:
+          type: string
+          format: uuid
+        right_run_agent_id:
+          type: string
+          format: uuid
+        status:
+          type: string
+
+    ListArenaTasksResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/ArenaTask"
+
+    ArenaVoteRequest:
+      type: object
+      required: [task_id, winner_run_agent_id]
+      properties:
+        task_id:
+          type: string
+          format: uuid
+        winner_run_agent_id:
+          type: string
+          format: uuid
+        rubric_scores:
+          type: object
+          additionalProperties:
+            type: number
+
+    MultiTurnStatusResponse:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
 
     # --- Replays ---
 

--- a/docs/challenge-packs/multi-turn.md
+++ b/docs/challenge-packs/multi-turn.md
@@ -1,0 +1,46 @@
+# Multi-turn challenge packs
+
+Hybrid `multi_turn` execution runs a conversation loop outside the native multi-step tool loop. Each case declares a `user_simulator` manifest with scripted, LLM, and human phases.
+
+## Execution flow
+
+1. Worker routes `execution_mode: multi_turn` to `MultiTurnExecutor`.
+2. Phases emit `turn.*` events (see [multi-turn-events.md](./multi-turn-events.md)).
+3. Human phases block on operator input via API/CLI until timeout.
+4. Scoring builds a transcript from events and evaluates `recovery_behavior` plus optional `human_preference` from arena votes.
+
+## Operator APIs
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/v1/workspaces/{ws}/runs/{runId}/run-agents/{runAgentId}/turns` | Submit human user message |
+| `GET` | `/v1/workspaces/{ws}/runs/{runId}/run-agents/{runAgentId}/turns/status` | Poll awaiting-human state |
+| `POST` | `/v1/workspaces/{ws}/calibration-reviews` | Record H2 calibration score (1–5) |
+| `GET` | `/v1/workspaces/{ws}/calibration-reviews` | List recent calibration reviews |
+| `GET` | `/v1/workspaces/{ws}/arena/tasks` | List pending pairwise arena tasks |
+| `POST` | `/v1/workspaces/{ws}/arena/votes` | Submit arena preference vote |
+
+## CLI
+
+```bash
+export AGENTCLASH_WORKSPACE="<workspace-id>"
+
+# While a run agent is executing and awaiting human input:
+agentclash run turn status <runAgentId> --run <runId>
+agentclash run turn submit <runAgentId> --run <runId> --message "Fine, email me when it posts."
+```
+
+## Web UI
+
+The run-agent replay page groups steps by `turn_index`, shows mismatch badges, and surfaces an awaiting-human banner with a submit form while the agent is executing.
+
+## Reference pack
+
+Publish and run [`examples/challenge-packs/multi-turn-refund-recovery.yaml`](../../examples/challenge-packs/multi-turn-refund-recovery.yaml) for an end-to-end smoke test.
+
+## Related
+
+- [user-simulator.md](./user-simulator.md) — schema and triggers
+- [multi-turn-events.md](./multi-turn-events.md) — event types and transcript
+- [case-templating.md](./case-templating.md) — `{{placeholder}}` in scripted messages
+- Epic [#839](https://github.com/agentclash/agentclash/issues/839)

--- a/examples/challenge-packs/multi-turn-refund-recovery.yaml
+++ b/examples/challenge-packs/multi-turn-refund-recovery.yaml
@@ -1,0 +1,126 @@
+###############################################################################
+# Challenge Pack: Multi-turn Refund Recovery (reference)
+#
+# Demonstrates hybrid user_simulator phases (scripted → LLM → human) on
+# execution_mode: multi_turn. Use for docs, CLI `run turn submit`, and replay
+# turn grouping smoke tests.
+###############################################################################
+
+pack:
+  slug: multi-turn-refund-recovery
+  name: Multi-turn Refund Recovery
+  family: support
+
+version:
+  number: 1
+  execution_mode: multi_turn
+  sandbox:
+    network_access: false
+
+  tool_policy:
+    allow_shell: false
+    allowed_tool_kinds: []
+
+  evaluation_spec:
+    name: multi-turn-refund-recovery-v1
+    version_number: 1
+    judge_mode: hybrid
+
+    validators:
+      - key: mentions_refund
+        type: contains
+        target: final_output
+        expected_from: "literal:refund"
+
+    llm_judges:
+      - key: recovery_after_mismatch
+        mode: assertion
+        model: claude-haiku-4-5-20251001
+        samples: 1
+        context_from:
+          - transcript.from_mismatch
+        assertion: |
+          After the first assistant mismatch, the assistant stays polite and gives a
+          concrete refund timeline or next step instead of deflecting.
+
+    runtime_limits:
+      max_duration_ms: 600000
+      max_total_tokens: 16000
+
+    behavioral:
+      signals:
+        - key: recovery_behavior
+          weight: 1.0
+          gate: true
+          pass_threshold: 0.5
+
+    scorecard:
+      strategy: hybrid
+      pass_threshold: 0.75
+      dimensions:
+        - key: recovery
+          source: behavioral
+          better_direction: higher
+          gate: true
+          pass_threshold: 0.5
+          weight: 0.5
+        - key: mismatch_recovery_judge
+          source: llm_judge
+          judge_key: recovery_after_mismatch
+          better_direction: higher
+          weight: 0.5
+
+challenges:
+  - key: refund-recovery
+    title: Recover a frustrated refund request
+    category: support
+    difficulty: medium
+    instructions: |
+      You are a support agent helping a customer refund order {{order_id}}.
+      Acknowledge the issue, verify the order, and explain refund status clearly.
+      When the customer pushes back, stay polite and specific.
+
+input_sets:
+  - key: default
+    name: Default
+    cases:
+      - challenge_key: refund-recovery
+        case_key: wrong-order-pushback
+        payload:
+          order_id: "ORD-9912"
+        user_simulator:
+          schema_version: 1
+          kind: hybrid
+          max_turns: 12
+          phases:
+            - id: open
+              actor: scripted
+              turns:
+                - message: "I need a refund for order {{order_id}} right now."
+                  expects:
+                    - key: acknowledges_refund
+                      kind: contains
+                      value: refund
+            - id: pushback
+              actor: scripted
+              trigger: on_assistant_mismatch
+              turns:
+                - message: "You quoted the wrong policy. I want a full refund today."
+            - id: llm_escalation
+              actor: llm
+              trigger: on_assistant_mismatch
+              persona: "Frustrated customer who will accept a clear timeline if empathetic"
+              max_turns: 3
+              until:
+                - "assistant_emitted:timeline"
+            - id: human_takeover
+              actor: human
+              trigger: manual
+              timeout_ms: 900000
+          calibration:
+            enabled: true
+            sample_rate: 0.1
+          post_run:
+            arena:
+              enabled: true
+              comparison: pairwise

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/replay/replay-viewer-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/replay/replay-viewer-client.tsx
@@ -15,6 +15,7 @@ import type {
 } from "@/lib/api/types";
 import { Badge } from "@/components/ui/badge";
 import { ReplayTimeline } from "@/components/replay/replay-timeline";
+import { AwaitingHumanBanner } from "@/components/replay/awaiting-human-banner";
 import { Panel } from "../scorecard/components/panel";
 import { toast } from "sonner";
 import {
@@ -73,6 +74,8 @@ export function ReplayViewerClient({
   const isPending = replayData.state === "pending";
   const isErrored = replayData.state === "errored";
   const isReady = replayData.state === "ready";
+  const awaitingHumanEnabled =
+    agent.status === "executing" || agent.status === "evaluating";
 
   // Auto-poll when pending
   useEffect(() => {
@@ -190,6 +193,14 @@ export function ReplayViewerClient({
           )}
         </Panel>
       )}
+
+      <AwaitingHumanBanner
+        getAccessToken={getAccessToken}
+        workspaceId={workspaceId}
+        runId={run.id}
+        runAgentId={agent.id}
+        enabled={awaitingHumanEnabled}
+      />
 
       {/* Summary stats */}
       {isReady && counts && (

--- a/web/src/components/replay/awaiting-human-banner.tsx
+++ b/web/src/components/replay/awaiting-human-banner.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { createApiClient } from "@/lib/api/client";
+import { Button } from "@/components/ui/button";
+import { Panel } from "@/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/panel";
+import {
+  getHumanTurnStatus,
+  submitHumanTurn,
+  type HumanTurnStatus,
+} from "@/lib/api/multi-turn";
+import { Loader2, UserRound } from "lucide-react";
+import { toast } from "sonner";
+
+interface AwaitingHumanBannerProps {
+  getAccessToken: () => Promise<string | undefined>;
+  workspaceId: string;
+  runId: string;
+  runAgentId: string;
+  enabled: boolean;
+}
+
+export function AwaitingHumanBanner({
+  getAccessToken,
+  workspaceId,
+  runId,
+  runAgentId,
+  enabled,
+}: AwaitingHumanBannerProps) {
+  const [status, setStatus] = useState<HumanTurnStatus | null>(null);
+  const [message, setMessage] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!enabled) {
+      setStatus(null);
+      return;
+    }
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      const next = await getHumanTurnStatus(api, workspaceId, runId, runAgentId);
+      setStatus(next);
+    } catch {
+      // Ignore polling errors; replay page stays usable.
+    }
+  }, [getAccessToken, enabled, workspaceId, runId, runAgentId]);
+
+  useEffect(() => {
+    void refresh();
+    if (!enabled) return;
+    const interval = setInterval(() => void refresh(), 3000);
+    return () => clearInterval(interval);
+  }, [enabled, refresh]);
+
+  if (!enabled || !status?.awaiting_human) {
+    return null;
+  }
+
+  async function handleSubmit() {
+    const trimmed = message.trim();
+    if (!trimmed) return;
+    setSubmitting(true);
+    try {
+      const token = await getAccessToken();
+      const api = createApiClient(token);
+      await submitHumanTurn(api, workspaceId, runId, runAgentId, trimmed);
+      setMessage("");
+      toast.success("Human turn submitted");
+      await refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to submit turn");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Panel className="mb-4 border-amber-500/40 bg-amber-500/5 p-4">
+      <div className="mb-3 flex items-center gap-2 text-sm font-medium">
+        <UserRound className="size-4 text-amber-600" />
+        Awaiting human input — turn {status.turn_index ?? "?"}
+        {status.phase_id ? ` (${status.phase_id})` : ""}
+      </div>
+      {status.prompt_hint && (
+        <p className="mb-3 text-sm text-muted-foreground">{status.prompt_hint}</p>
+      )}
+      <textarea
+        value={message}
+        onChange={(e) => setMessage(e.target.value)}
+        placeholder="Type the user message to continue the conversation…"
+        rows={3}
+        className="mb-3 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+      />
+      <Button size="sm" onClick={() => void handleSubmit()} disabled={submitting}>
+        {submitting && <Loader2 className="mr-1.5 size-4 animate-spin" />}
+        Submit turn
+      </Button>
+    </Panel>
+  );
+}

--- a/web/src/components/replay/replay-timeline.tsx
+++ b/web/src/components/replay/replay-timeline.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { ReplayStep } from "@/lib/api/types";
 import { ReplayStepCard } from "./replay-step-card";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Panel } from "@/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/panel";
+import { Badge } from "@/components/ui/badge";
 import { Loader2, ListTree } from "lucide-react";
 import { findHighlightIndex } from "./replay-highlight";
 
@@ -14,12 +15,32 @@ interface ReplayTimelineProps {
   hasMore: boolean;
   isLoadingMore: boolean;
   onLoadMore: () => void;
-  /**
-   * When set, the step whose sequence range contains this value is visually
-   * highlighted and scrolled into view on mount. Used by the scorecard
-   * Inspector Sheet's "View in replay" deep link.
-   */
   highlightSequence?: number;
+}
+
+type TurnGroup = {
+  turnIndex: number | null;
+  steps: ReplayStep[];
+  hasMismatch: boolean;
+};
+
+function groupStepsByTurn(steps: ReplayStep[]): TurnGroup[] {
+  const groups: TurnGroup[] = [];
+  for (const step of steps) {
+    const turnIndex = step.turn_index ?? null;
+    const last = groups[groups.length - 1];
+    if (last && last.turnIndex === turnIndex) {
+      last.steps.push(step);
+      if (step.mismatch) last.hasMismatch = true;
+      continue;
+    }
+    groups.push({
+      turnIndex,
+      steps: [step],
+      hasMismatch: Boolean(step.mismatch),
+    });
+  }
+  return groups;
 }
 
 export function ReplayTimeline({
@@ -33,6 +54,15 @@ export function ReplayTimeline({
     if (highlightSequence == null) return -1;
     return findHighlightIndex(steps, highlightSequence);
   }, [steps, highlightSequence]);
+
+  const flatIndexByStep = useMemo(() => {
+    const map = new Map<ReplayStep, number>();
+    steps.forEach((step, index) => map.set(step, index));
+    return map;
+  }, [steps]);
+
+  const groups = useMemo(() => groupStepsByTurn(steps), [steps]);
+  const hasTurnGroups = groups.some((g) => g.turnIndex != null);
 
   const highlightRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
@@ -52,23 +82,38 @@ export function ReplayTimeline({
 
   return (
     <div>
-      {/* Timeline */}
       <Panel className="overflow-hidden">
-        {steps.map((step, i) => (
-          <div
-            key={`${step.started_sequence}-${i}`}
-            ref={i === highlightedIndex ? highlightRef : undefined}
-          >
-            <ReplayStepCard
-              step={step}
-              index={i}
-              highlighted={i === highlightedIndex}
-            />
+        {groups.map((group, groupIndex) => (
+          <div key={`turn-${group.turnIndex ?? "none"}-${groupIndex}`}>
+            {hasTurnGroups && group.turnIndex != null && (
+              <div className="flex items-center gap-2 border-b bg-muted/30 px-4 py-2 text-sm font-medium">
+                <span>Turn {group.turnIndex}</span>
+                {group.hasMismatch && (
+                  <Badge variant="destructive" className="text-xs">
+                    mismatch
+                  </Badge>
+                )}
+              </div>
+            )}
+            {group.steps.map((step) => {
+              const flatIndex = flatIndexByStep.get(step) ?? -1;
+              return (
+                <div
+                  key={`${step.started_sequence}-${flatIndex}`}
+                  ref={flatIndex === highlightedIndex ? highlightRef : undefined}
+                >
+                  <ReplayStepCard
+                    step={step}
+                    index={flatIndex}
+                    highlighted={flatIndex === highlightedIndex}
+                  />
+                </div>
+              );
+            })}
           </div>
         ))}
       </Panel>
 
-      {/* Load more */}
       {hasMore && (
         <div className="mt-4 flex justify-center">
           <Button

--- a/web/src/lib/api/multi-turn.ts
+++ b/web/src/lib/api/multi-turn.ts
@@ -1,0 +1,32 @@
+import type { ApiClient } from "./client";
+
+export interface HumanTurnStatus {
+  awaiting_human: boolean;
+  turn_index?: number;
+  phase_id?: string;
+  prompt_hint?: string;
+}
+
+export async function getHumanTurnStatus(
+  api: ApiClient,
+  workspaceId: string,
+  runId: string,
+  runAgentId: string,
+): Promise<HumanTurnStatus> {
+  return api.get<HumanTurnStatus>(
+    `/v1/workspaces/${workspaceId}/runs/${runId}/run-agents/${runAgentId}/turns/status`,
+  );
+}
+
+export async function submitHumanTurn(
+  api: ApiClient,
+  workspaceId: string,
+  runId: string,
+  runAgentId: string,
+  message: string,
+): Promise<{ status: string }> {
+  return api.post<{ status: string }>(
+    `/v1/workspaces/${workspaceId}/runs/${runId}/run-agents/${runAgentId}/turns`,
+    { message },
+  );
+}

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -1187,6 +1187,8 @@ export interface ReplayStep {
   event_types: string[];
   artifact_ids?: string[];
   step_index?: number;
+  turn_index?: number;
+  mismatch?: boolean;
   provider_key?: string;
   provider_model_id?: string;
   tool_name?: string;


### PR DESCRIPTION
## Summary

Completes epic #839 (multi-turn hybrid eval) after merged foundations #840–#842:

- **#843–#844**: `MultiTurnExecutor` with scripted/LLM/human `user_simulator` phases and workflow routing
- **#845**: In-run human takeover (DB polling gate, REST API, `agentclash run turn submit|status`, replay banner)
- **#846**: Transcript evidence + `recovery_behavior` / `transcript.from_mismatch` scoring
- **#847**: Calibration review API (1–5 scores) + deterministic sampling flags
- **#848**: Arena tasks/votes + post-run pairwise task creation
- **#849**: Turn-grouped replay UI with mismatch badges
- **#850**: Reference pack, docs, OpenAPI, tests

## Test plan

- [x] `cd backend && go test -short -race -count=1 ./...`
- [x] `cd cli && go build ./... && go test -short -count=1 ./...`
- [x] `cd web && pnpm exec tsc --noEmit`
- [ ] Apply migration `00047_multi_turn_human_calibration_arena.sql` in staging
- [ ] Smoke: publish reference pack and run with human phase + calibration/arena flags

Closes #843, #844, #845, #846, #847, #848, #849, #850