### PR TITLE
fix(multi-turn): preserve submit tool history and human-input UI

### DIFF
--- a/backend/internal/engine/execution_mode.go
+++ b/backend/internal/engine/execution_mode.go
@@ -1,0 +1,21 @@
+package engine
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+func executionModeFromManifest(manifest json.RawMessage) string {
+	if len(manifest) == 0 {
+		return ""
+	}
+	var decoded struct {
+		Version struct {
+			ExecutionMode string `json:"execution_mode"`
+		} `json:"version"`
+	}
+	if err := json.Unmarshal(manifest, &decoded); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(decoded.Version.ExecutionMode)
+}

--- a/backend/internal/engine/executor_builders.go
+++ b/backend/internal/engine/executor_builders.go
@@ -231,6 +231,7 @@ func (e NativeExecutor) executeToolCalls(
 	networkAllowlist []string,
 	toolCallsUsedSoFar int,
 	toolCalls []provider.ToolCall,
+	preserveSubmitToolMessage bool,
 ) ([]provider.Message, string, bool, int, error) {
 	toolMessages := make([]provider.Message, 0, len(toolCalls))
 	toolCallsUsed := 0
@@ -305,6 +306,9 @@ func (e NativeExecutor) executeToolCalls(
 		if executionResult.Completed {
 			if executionResult.IsError {
 				return toolMessages, "", false, toolCallsUsed, nil
+			}
+			if preserveSubmitToolMessage {
+				return toolMessages, executionResult.FinalOutput, true, toolCallsUsed, nil
 			}
 			return toolMessages[:len(toolMessages)-1], executionResult.FinalOutput, true, toolCallsUsed, nil
 		}

--- a/backend/internal/engine/executor_builders_test.go
+++ b/backend/internal/engine/executor_builders_test.go
@@ -1,0 +1,62 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/agentclash/agentclash/backend/internal/sandbox"
+)
+
+func TestExecuteToolCallsPreservesSubmitToolMessageWhenRequested(t *testing.T) {
+	executor := NewNativeExecutor(&provider.FakeClient{}, nil, NoopObserver{})
+	registry := &Registry{visible: nativePrimitiveTools(sandbox.ToolPolicy{})}
+
+	toolCalls := []provider.ToolCall{{
+		ID:        "call-submit",
+		Name:      submitToolName,
+		Arguments: []byte(`{"answer":"done"}`),
+	}}
+
+	withoutPreserve, finalOutput, completed, _, err := executor.executeToolCalls(
+		t.Context(),
+		nil,
+		registry,
+		sandbox.ToolPolicy{},
+		nil,
+		0,
+		toolCalls,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("executeToolCalls returned error: %v", err)
+	}
+	if !completed || finalOutput != "done" {
+		t.Fatalf("completed=%v finalOutput=%q, want completed with done", completed, finalOutput)
+	}
+	if len(withoutPreserve) != 0 {
+		t.Fatalf("tool message count = %d, want 0 when submit message is stripped", len(withoutPreserve))
+	}
+
+	withPreserve, finalOutput, completed, _, err := executor.executeToolCalls(
+		t.Context(),
+		nil,
+		registry,
+		sandbox.ToolPolicy{},
+		nil,
+		0,
+		toolCalls,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("executeToolCalls returned error: %v", err)
+	}
+	if !completed || finalOutput != "done" {
+		t.Fatalf("completed=%v finalOutput=%q, want completed with done", completed, finalOutput)
+	}
+	if len(withPreserve) != 1 {
+		t.Fatalf("tool message count = %d, want 1 when submit message is preserved", len(withPreserve))
+	}
+	if withPreserve[0].ToolCallID != "call-submit" {
+		t.Fatalf("tool call id = %q, want call-submit", withPreserve[0].ToolCallID)
+	}
+}

--- a/backend/internal/engine/native_executor.go
+++ b/backend/internal/engine/native_executor.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/agentclash/agentclash/backend/internal/challengepack"
 	"github.com/agentclash/agentclash/backend/internal/provider"
 	"github.com/agentclash/agentclash/backend/internal/racecontext"
 	"github.com/agentclash/agentclash/backend/internal/repository"
@@ -422,7 +423,8 @@ func (e NativeExecutor) runAgentLoop(
 			return Result{}, NewFailure(StopReasonProviderError, "assistant response did not contain a tool call or submit action", nil)
 		}
 
-		toolMessages, finalOutput, completed, toolCallCount, toolErr := e.executeToolCalls(runCtx, session, registry, sandboxRequest.ToolPolicy, sandboxRequest.NetworkAllowlist, state.toolCallCount, response.ToolCalls)
+		preserveSubmitToolMessage := executionModeFromManifest(executionContext.ChallengePackVersion.Manifest) == challengepack.ExecutionModeMultiTurn
+		toolMessages, finalOutput, completed, toolCallCount, toolErr := e.executeToolCalls(runCtx, session, registry, sandboxRequest.ToolPolicy, sandboxRequest.NetworkAllowlist, state.toolCallCount, response.ToolCalls, preserveSubmitToolMessage)
 		state.toolCallCount += toolCallCount
 		if toolErr != nil {
 			return Result{}, toolErr

--- a/backend/internal/engine/native_executor.go
+++ b/backend/internal/engine/native_executor.go
@@ -351,6 +351,7 @@ func (e NativeExecutor) runAgentLoop(
 	metadata json.RawMessage,
 	state *loopState,
 ) (Result, error) {
+	preserveSubmitToolMessage := executionModeFromManifest(executionContext.ChallengePackVersion.Manifest) == challengepack.ExecutionModeMultiTurn
 	for {
 		if loopErr := runCtx.Err(); loopErr != nil {
 			if errors.Is(loopErr, context.Canceled) {
@@ -423,7 +424,6 @@ func (e NativeExecutor) runAgentLoop(
 			return Result{}, NewFailure(StopReasonProviderError, "assistant response did not contain a tool call or submit action", nil)
 		}
 
-		preserveSubmitToolMessage := executionModeFromManifest(executionContext.ChallengePackVersion.Manifest) == challengepack.ExecutionModeMultiTurn
 		toolMessages, finalOutput, completed, toolCallCount, toolErr := e.executeToolCalls(runCtx, session, registry, sandboxRequest.ToolPolicy, sandboxRequest.NetworkAllowlist, state.toolCallCount, response.ToolCalls, preserveSubmitToolMessage)
 		state.toolCallCount += toolCallCount
 		if toolErr != nil {

--- a/backend/internal/engine/native_executor_test.go
+++ b/backend/internal/engine/native_executor_test.go
@@ -492,6 +492,7 @@ func TestNativeExecutorDoesNotDuplicateCompletedErrorToolMessages(t *testing.T) 
 			ID:   "call-completed-error",
 			Name: "fail_complete",
 		}},
+		false,
 	)
 	if err != nil {
 		t.Fatalf("executeToolCalls returned error: %v", err)

--- a/backend/internal/engine/tool_registry_test.go
+++ b/backend/internal/engine/tool_registry_test.go
@@ -138,6 +138,7 @@ func TestRegistryResolve_ReturnsStructuredUnknownToolErrorPath(t *testing.T) {
 			ID:   "call-unknown",
 			Name: "does_not_exist",
 		}},
+		false,
 	)
 	if err != nil {
 		t.Fatalf("executeToolCalls returned error: %v", err)

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/replay/replay-viewer-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/replay/replay-viewer-client.tsx
@@ -10,6 +10,7 @@ import type {
   Run,
   RunAgent,
   RunAgentStatus,
+  RunStatus,
   ReplayResponse,
   ReplayStep,
 } from "@/lib/api/types";
@@ -30,6 +31,14 @@ import {
 } from "lucide-react";
 
 const POLL_MS = 5000;
+const HUMAN_TURN_POLL_MS = 3000;
+
+const ACTIVE_RUN_STATUSES: RunStatus[] = [
+  "queued",
+  "provisioning",
+  "running",
+  "scoring",
+];
 
 const agentStatusVariant: Record<
   RunAgentStatus,
@@ -60,6 +69,8 @@ export function ReplayViewerClient({
   const [replayData, setReplayData] = useState<ReplayResponse>(initialReplay);
   const [steps, setSteps] = useState<ReplayStep[]>(initialReplay.steps);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [liveAgent, setLiveAgent] = useState<RunAgent>(agent);
+  const [liveRunStatus, setLiveRunStatus] = useState<Run["status"]>(run.status);
 
   // When the inspector sheet deep-links in with ?step=<sequence>, the timeline
   // highlights + auto-scrolls to that step. NaN is filtered by the consumer.
@@ -74,8 +85,34 @@ export function ReplayViewerClient({
   const isPending = replayData.state === "pending";
   const isErrored = replayData.state === "errored";
   const isReady = replayData.state === "ready";
+  const isRunActive = ACTIVE_RUN_STATUSES.includes(liveRunStatus);
   const awaitingHumanEnabled =
-    agent.status === "executing" || agent.status === "evaluating";
+    isRunActive ||
+    liveAgent.status === "executing" ||
+    liveAgent.status === "evaluating";
+
+  // Keep agent/run status fresh while the run is active so the human-input banner can appear.
+  useEffect(() => {
+    if (!isRunActive) return;
+    const refreshLiveStatus = async () => {
+      try {
+        const token = await getAccessToken();
+        const api = createApiClient(token);
+        const [runRes, agentsRes] = await Promise.all([
+          api.get<Run>(`/v1/runs/${run.id}`),
+          api.get<{ items: RunAgent[] }>(`/v1/runs/${run.id}/agents`),
+        ]);
+        setLiveRunStatus(runRes.status);
+        const nextAgent = agentsRes.items.find((item) => item.id === agent.id);
+        if (nextAgent) setLiveAgent(nextAgent);
+      } catch {
+        // Ignore polling errors; replay page stays usable.
+      }
+    };
+    void refreshLiveStatus();
+    const interval = setInterval(() => void refreshLiveStatus(), HUMAN_TURN_POLL_MS);
+    return () => clearInterval(interval);
+  }, [isRunActive, getAccessToken, run.id, agent.id]);
 
   // Auto-poll when pending
   useEffect(() => {
@@ -132,15 +169,15 @@ export function ReplayViewerClient({
           <div className="flex items-center justify-between gap-4">
             <div className="flex items-center gap-3">
               <h1 className="font-[family-name:var(--font-display)] text-2xl leading-none tracking-[-0.01em] text-white/95">
-                {agent.label}
+                {liveAgent.label}
               </h1>
               <Badge
                 variant={
-                  agentStatusVariant[agent.status as RunAgentStatus] ?? "outline"
+                  agentStatusVariant[liveAgent.status as RunAgentStatus] ?? "outline"
                 }
                 className="bg-white/5 text-white/80 border-white/10 hover:bg-white/10"
               >
-                {agent.status}
+                {liveAgent.status}
               </Badge>
             </div>
             {isReady && (

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/replay/replay-viewer-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/replay/replay-viewer-client.tsx
@@ -10,10 +10,10 @@ import type {
   Run,
   RunAgent,
   RunAgentStatus,
-  RunStatus,
   ReplayResponse,
   ReplayStep,
 } from "@/lib/api/types";
+import { isAgentAwaitingHumanInput, isRunActive } from "@/lib/run-status";
 import { Badge } from "@/components/ui/badge";
 import { ReplayTimeline } from "@/components/replay/replay-timeline";
 import { AwaitingHumanBanner } from "@/components/replay/awaiting-human-banner";
@@ -32,13 +32,6 @@ import {
 
 const POLL_MS = 5000;
 const HUMAN_TURN_POLL_MS = 3000;
-
-const ACTIVE_RUN_STATUSES: RunStatus[] = [
-  "queued",
-  "provisioning",
-  "running",
-  "scoring",
-];
 
 const agentStatusVariant: Record<
   RunAgentStatus,
@@ -85,15 +78,12 @@ export function ReplayViewerClient({
   const isPending = replayData.state === "pending";
   const isErrored = replayData.state === "errored";
   const isReady = replayData.state === "ready";
-  const isRunActive = ACTIVE_RUN_STATUSES.includes(liveRunStatus);
-  const awaitingHumanEnabled =
-    isRunActive ||
-    liveAgent.status === "executing" ||
-    liveAgent.status === "evaluating";
+  const isRunActiveStatus = isRunActive(liveRunStatus);
+  const awaitingHumanEnabled = isAgentAwaitingHumanInput(liveAgent.status);
 
   // Keep agent/run status fresh while the run is active so the human-input banner can appear.
   useEffect(() => {
-    if (!isRunActive) return;
+    if (!isRunActiveStatus) return;
     const refreshLiveStatus = async () => {
       try {
         const token = await getAccessToken();
@@ -112,7 +102,7 @@ export function ReplayViewerClient({
     void refreshLiveStatus();
     const interval = setInterval(() => void refreshLiveStatus(), HUMAN_TURN_POLL_MS);
     return () => clearInterval(interval);
-  }, [isRunActive, getAccessToken, run.id, agent.id]);
+  }, [isRunActiveStatus, getAccessToken, run.id, agent.id]);
 
   // Auto-poll when pending
   useEffect(() => {

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
@@ -17,6 +17,11 @@ import { useArenaMode } from "@/hooks/use-arena-mode";
 import { useRunEvents, type RunEvent } from "@/hooks/use-run-events";
 import { createApiClient } from "@/lib/api/client";
 import { scorePercent } from "@/lib/scores";
+import {
+  ACTIVE_AGENT_STATUSES,
+  isAgentAwaitingHumanInput,
+  isRunActive,
+} from "@/lib/run-status";
 import { isVoiceRun, voiceRunMode, voiceRunTransport } from "@/lib/voice-evals";
 import type {
   Run,
@@ -74,18 +79,6 @@ const runStatusVariant: Record<
   cancelled: "secondary",
 };
 
-const ACTIVE_RUN_STATUSES: RunStatus[] = [
-  "queued",
-  "provisioning",
-  "running",
-  "scoring",
-];
-const ACTIVE_AGENT_STATUSES: RunAgentStatus[] = [
-  "queued",
-  "ready",
-  "executing",
-  "evaluating",
-];
 const POLL_MS = 5000;
 
 const LEGACY_SORT_OPTIONS = [
@@ -189,7 +182,7 @@ export function RunDetailClient({
   const [arenaMode, setArenaMode] = useArenaMode();
 
   const isActive =
-    ACTIVE_RUN_STATUSES.includes(run.status) ||
+    isRunActive(run.status) ||
     agents.some((a) => ACTIVE_AGENT_STATUSES.includes(a.status));
 
   const fetchAll = useCallback(async () => {
@@ -531,9 +524,7 @@ export function RunDetailClient({
 
       {isActive &&
         sortedAgents
-          .filter(
-            (a) => a.status === "executing" || a.status === "evaluating",
-          )
+          .filter((a) => isAgentAwaitingHumanInput(a.status))
           .map((a) => (
             <AwaitingHumanBanner
               key={a.id}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/run-detail-client.tsx
@@ -56,6 +56,7 @@ import { CompareRunPicker } from "./compare-run-picker";
 import { Panel } from "./agents/[runAgentId]/scorecard/components/panel";
 import { RunRankingInsightsCard } from "./run-ranking-insights-card";
 import { ScorecardSummaryCard } from "./scorecard-summary-card";
+import { AwaitingHumanBanner } from "@/components/replay/awaiting-human-banner";
 
 // --- Status variant maps ---
 
@@ -527,6 +528,22 @@ export function RunDetailClient({
           )}
         </div>
       </Panel>
+
+      {isActive &&
+        sortedAgents
+          .filter(
+            (a) => a.status === "executing" || a.status === "evaluating",
+          )
+          .map((a) => (
+            <AwaitingHumanBanner
+              key={a.id}
+              getAccessToken={getAccessToken}
+              workspaceId={workspaceId}
+              runId={run.id}
+              runAgentId={a.id}
+              enabled
+            />
+          ))}
 
       {/* === Agent Lanes === */}
       <div>

--- a/web/src/lib/run-status.ts
+++ b/web/src/lib/run-status.ts
@@ -1,0 +1,23 @@
+import type { RunAgentStatus, RunStatus } from "@/lib/api/types";
+
+export const ACTIVE_RUN_STATUSES: RunStatus[] = [
+  "queued",
+  "provisioning",
+  "running",
+  "scoring",
+];
+
+export const ACTIVE_AGENT_STATUSES: RunAgentStatus[] = [
+  "queued",
+  "ready",
+  "executing",
+  "evaluating",
+];
+
+export function isRunActive(status: RunStatus): boolean {
+  return ACTIVE_RUN_STATUSES.includes(status);
+}
+
+export function isAgentAwaitingHumanInput(status: RunAgentStatus): boolean {
+  return status === "executing" || status === "evaluating";
+}


### PR DESCRIPTION
## Summary
- Keep `submit` tool response messages in the native conversation history when the challenge pack uses `execution_mode: multi_turn`, so a later user/human turn does not send an invalid OpenAI message chain.
- Poll live run and agent status on the replay page and show the awaiting-human banner on the run detail page (not only replay), so human takeover is visible while a run is active.

## Test plan
- [x] `go test -short -race -count=1 ./internal/engine -run TestExecuteToolCallsPreservesSubmitToolMessageWhenRequested`
- [x] `pnpm exec tsc --noEmit` in `web/`
- [ ] Re-run `multi-turn-refund-recovery` on hosted API through human phase and confirm run completes
- [ ] Open run detail + replay while awaiting human input and confirm amber banner appears