### PR TITLE
feat: add opencode PR review bot with intelligent model selection

### DIFF
--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -1,0 +1,226 @@
+name: pr-review-bot
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - "*.md"
+      - "docs/**"
+
+# Prevent multiple review runs from stacking on the same PR
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  select-model:
+    name: Select review model
+    runs-on: ubuntu-latest
+    outputs:
+      model: ${{ steps.select.outputs.model }}
+      reason: ${{ steps.select.outputs.reason }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: select
+        name: Select best model for this PR
+        run: |
+          chmod +x scripts/pr-review/select-review-model.sh
+          MODEL=$(scripts/pr-review/select-review-model.sh)
+          echo "model=${MODEL}" >> "$GITHUB_OUTPUT"
+
+          # Determine reason for model selection
+          case "$MODEL" in
+            *glm-5.1*)
+              REASON="Large or Go code changes → GLM-5.1 for deep analysis"
+              ;;
+            *qwen3.6*)
+              REASON="Frontend changes → Qwen3.6 Plus for fast, thorough review"
+              ;;
+            *deepseek-v4-flash*)
+              REASON="Config/CI only → DeepSeek V4 Flash for quick review"
+              ;;
+            *)
+              REASON="Standard changes → Qwen3.6 Plus"
+              ;;
+          esac
+          echo "reason=${REASON}" >> "$GITHUB_OUTPUT"
+
+          echo "Selected: ${MODEL} (${REASON})"
+
+  review:
+    name: OpenCode PR Review
+    needs: select-model
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+    env:
+      OPENCODE_CONFIG: .opencode/opencode.json
+      OPENCODE_GO_API_KEY: ${{ secrets.OPENCODE_GO_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install opencode
+        run: |
+          curl -fsSL https://opencode.ai/install | bash
+
+      - name: Gather PR context
+        id: context
+        run: |
+          PR_NUM="${{ github.event.pull_request.number }}"
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_BODY="${{ github.event.pull_request.body }}"
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
+          HEAD_REF="${{ github.event.pull_request.head.ref }}"
+
+          # Get the diff
+          git fetch origin "${BASE_REF}"
+          DIFF=$(git diff "origin/${BASE_REF}"...HEAD -- . ':!*.md' ':!docs/' 2>/dev/null || echo "No diff available")
+          DIFF_LINES=$(echo "$DIFF" | wc -l)
+
+          # Truncate diff if too large (opencode can read files directly)
+          if [[ "$DIFF_LINES" -gt 3000 ]]; then
+            DIFF=$(echo "$DIFF" | head -3000)
+            DIFF_TRUNCATED="true"
+          else
+            DIFF_TRUNCATED="false"
+          fi
+
+          # Get changed files summary
+          CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}"...HEAD 2>/dev/null || echo "")
+
+          echo "pr_num=${PR_NUM}" >> "$GITHUB_OUTPUT"
+          echo "diff_truncated=${DIFF_TRUNCATED}" >> "$GITHUB_OUTPUT"
+
+          # Write context to a temp file for opencode
+          cat > /tmp/pr-context.md << EOF
+          # PR #${PR_NUM}: ${PR_TITLE}
+
+          ## Description
+          ${PR_BODY}
+
+          ## Changed Files
+          ${CHANGED_FILES}
+
+          ## Diff
+          \`\`\`diff
+          ${DIFF}
+          \`\`\`
+          EOF
+
+          echo "Context gathered (${DIFF_LINES} diff lines, truncated: ${DIFF_TRUNCATED})"
+
+      - name: Run opencode review
+        id: review
+        run: |
+          MODEL="${{ needs.select-model.outputs.model }}"
+          PR_NUM="${{ steps.context.outputs.pr_num }}"
+          DIFF_TRUNCATED="${{ steps.context.outputs.diff_truncated }}"
+
+          # Build the review prompt
+          PROMPT="Review PR #${PR_NUM} for the AgentClash project.
+
+          You are reviewing a pull request for AgentClash, an open-source multi-agent evaluation platform.
+
+          **Repo conventions you must enforce:**
+          - Two separate Go modules: backend/ and cli/ (never mix imports between them incorrectly)
+          - All DB queries MUST use SQLC — no raw SQL outside the repository layer
+          - All dependencies are constructor-injected — no global state
+          - Optional services default to noop implementations
+          - Goose-format migrations only (-- +goose Up/Down)
+          - Events are immutable, schema-versioned envelopes
+          - CLI uses Cobra framework, follows path-based command organization
+          - GoReleaser for binary distribution, Release Please for versioning
+          - Conventional commits: fix: = patch, feat: = minor, feat!: = major
+
+          **Review checklist:**
+          1. **Correctness**: Does the code work as intended? Any bugs or logic errors?
+          2. **Convention violations**: Does it break repo conventions listed above?
+          3. **Security**: Any exposed secrets, injection risks, trust boundary violations?
+          4. **Performance**: Any obvious performance regressions?
+          5. **Testing**: Are tests adequate for the changes? Do existing tests still pass?
+          6. **Edge cases**: What could go wrong that isn't handled?
+
+          **Output format:**
+          - Start with a one-line summary (LGTM / Minor issues / Blocking issues)
+          - Group findings by severity
+          - For each finding: file path, line number (if applicable), what's wrong, suggested fix
+          - End with a brief verdict
+
+          ${DIFF_TRUNCATED:+Note: The diff was truncated. Read the full changed files directly for complete analysis.}
+
+          Review the changed files and diff in this PR."
+
+          # Run opencode review
+          REVIEW=$(opencode run \
+            --model "$MODEL" \
+            --agent pr-reviewer \
+            --format default \
+            --dangerously-skip-permissions \
+            "$PROMPT" 2>&1) || true
+
+          # Save review output
+          echo "$REVIEW" > /tmp/review-output.txt
+
+          # Post as PR comment
+          REVIEW_BODY=$(cat /tmp/review-output.txt)
+
+          # Add model info header
+          HEADER="**OpenCode PR Review** — model: \`${{ needs.select-model.outputs.model }}\` (${{ needs.select-model.outputs.reason }})
+
+          ---
+
+          "
+
+          # Post the comment using gh CLI
+          echo "${HEADER}${REVIEW_BODY}" | gh pr comment "$PR_NUM" --body-file -
+
+          echo "Review posted as PR comment"
+
+      - name: Run language-specific checks
+        if: always()
+        run: |
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
+          git fetch origin "${BASE_REF}"
+
+          # Check if Go files changed in backend
+          if git diff --name-only "origin/${BASE_REF}"...HEAD | grep -q '^backend/.*\.go$'; then
+            echo "::group::Backend Go checks"
+            cd backend
+            go build ./... || echo "::warning::Backend build failed"
+            go vet ./... || echo "::warning::Backend vet found issues"
+            go test -short -race -count=1 ./... || echo "::warning::Backend tests failed"
+            cd ..
+            echo "::endgroup::"
+          fi
+
+          # Check if Go files changed in cli
+          if git diff --name-only "origin/${BASE_REF}"...HEAD | grep -q '^cli/.*\.go$'; then
+            echo "::group::CLI Go checks"
+            cd cli
+            go build ./... || echo "::warning::CLI build failed"
+            go vet ./... || echo "::warning::CLI vet found issues"
+            go test -short -race -count=1 ./... || echo "::warning::CLI tests failed"
+            cd ..
+            echo "::endgroup::"
+          fi
+
+          # Check if frontend files changed
+          if git diff --name-only "origin/${BASE_REF}"...HEAD | grep -q '^web/'; then
+            echo "::group::Frontend checks"
+            cd web
+            npm ci --ignore-scripts 2>/dev/null || npm install --ignore-scripts
+            npx tsc --noEmit || echo "::warning::Frontend typecheck found issues"
+            npx eslint . --max-warnings=0 || echo "::warning::Frontend lint found issues"
+            cd ..
+            echo "::endgroup::"
+          fi

--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
-      - "*.md"
+      - "**/*.md"
       - "docs/**"
 
 # Prevent multiple review runs from stacking on the same PR
@@ -33,7 +33,6 @@ jobs:
           MODEL=$(scripts/pr-review/select-review-model.sh)
           echo "model=${MODEL}" >> "$GITHUB_OUTPUT"
 
-          # Determine reason for model selection
           case "$MODEL" in
             *glm-5.1*)
               REASON="Large or Go code changes → GLM-5.1 for deep analysis"
@@ -64,6 +63,13 @@ jobs:
     env:
       OPENCODE_CONFIG: .opencode/opencode.json
       OPENCODE_GO_API_KEY: ${{ secrets.OPENCODE_GO_API_KEY }}
+      PR_NUM: ${{ github.event.pull_request.number }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_BODY: ${{ github.event.pull_request.body }}
+      BASE_REF: ${{ github.event.pull_request.base.ref }}
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      REVIEW_MODEL: ${{ needs.select-model.outputs.model }}
+      REVIEW_REASON: ${{ needs.select-model.outputs.reason }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -71,23 +77,15 @@ jobs:
 
       - name: Install opencode
         run: |
-          curl -fsSL https://opencode.ai/install | bash
+          npm install -g opencode-ai
 
       - name: Gather PR context
         id: context
         run: |
-          PR_NUM="${{ github.event.pull_request.number }}"
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          PR_BODY="${{ github.event.pull_request.body }}"
-          BASE_REF="${{ github.event.pull_request.base.ref }}"
-          HEAD_REF="${{ github.event.pull_request.head.ref }}"
-
-          # Get the diff
           git fetch origin "${BASE_REF}"
           DIFF=$(git diff "origin/${BASE_REF}"...HEAD -- . ':!*.md' ':!docs/' 2>/dev/null || echo "No diff available")
           DIFF_LINES=$(echo "$DIFF" | wc -l)
 
-          # Truncate diff if too large (opencode can read files directly)
           if [[ "$DIFF_LINES" -gt 3000 ]]; then
             DIFF=$(echo "$DIFF" | head -3000)
             DIFF_TRUNCATED="true"
@@ -95,13 +93,11 @@ jobs:
             DIFF_TRUNCATED="false"
           fi
 
-          # Get changed files summary
           CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}"...HEAD 2>/dev/null || echo "")
 
           echo "pr_num=${PR_NUM}" >> "$GITHUB_OUTPUT"
           echo "diff_truncated=${DIFF_TRUNCATED}" >> "$GITHUB_OUTPUT"
 
-          # Write context to a temp file for opencode
           cat > /tmp/pr-context.md << EOF
           # PR #${PR_NUM}: ${PR_TITLE}
 
@@ -122,11 +118,8 @@ jobs:
       - name: Run opencode review
         id: review
         run: |
-          MODEL="${{ needs.select-model.outputs.model }}"
-          PR_NUM="${{ steps.context.outputs.pr_num }}"
           DIFF_TRUNCATED="${{ steps.context.outputs.diff_truncated }}"
 
-          # Build the review prompt
           PROMPT="Review PR #${PR_NUM} for the AgentClash project.
 
           You are reviewing a pull request for AgentClash, an open-source multi-agent evaluation platform.
@@ -160,28 +153,24 @@ jobs:
 
           Review the changed files and diff in this PR."
 
-          # Run opencode review
-          REVIEW=$(opencode run \
-            --model "$MODEL" \
+          if ! REVIEW=$(opencode run \
+            --model "$REVIEW_MODEL" \
             --agent pr-reviewer \
             --format default \
-            --dangerously-skip-permissions \
-            "$PROMPT" 2>&1) || true
+            "$PROMPT" 2>&1); then
+            echo "::warning::opencode review failed — skipping comment"
+            exit 0
+          fi
 
-          # Save review output
           echo "$REVIEW" > /tmp/review-output.txt
-
-          # Post as PR comment
           REVIEW_BODY=$(cat /tmp/review-output.txt)
 
-          # Add model info header
-          HEADER="**OpenCode PR Review** — model: \`${{ needs.select-model.outputs.model }}\` (${{ needs.select-model.outputs.reason }})
+          HEADER="**OpenCode PR Review** — model: \`${REVIEW_MODEL}\` (${REVIEW_REASON})
 
           ---
 
           "
 
-          # Post the comment using gh CLI
           echo "${HEADER}${REVIEW_BODY}" | gh pr comment "$PR_NUM" --body-file -
 
           echo "Review posted as PR comment"
@@ -189,10 +178,8 @@ jobs:
       - name: Run language-specific checks
         if: always()
         run: |
-          BASE_REF="${{ github.event.pull_request.base.ref }}"
           git fetch origin "${BASE_REF}"
 
-          # Check if Go files changed in backend
           if git diff --name-only "origin/${BASE_REF}"...HEAD | grep -q '^backend/.*\.go$'; then
             echo "::group::Backend Go checks"
             cd backend
@@ -203,7 +190,6 @@ jobs:
             echo "::endgroup::"
           fi
 
-          # Check if Go files changed in cli
           if git diff --name-only "origin/${BASE_REF}"...HEAD | grep -q '^cli/.*\.go$'; then
             echo "::group::CLI Go checks"
             cd cli
@@ -214,7 +200,6 @@ jobs:
             echo "::endgroup::"
           fi
 
-          # Check if frontend files changed
           if git diff --name-only "origin/${BASE_REF}"...HEAD | grep -q '^web/'; then
             echo "::group::Frontend checks"
             cd web

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "opencode-go/qwen3.6-plus",
+  "provider": {
+    "opencode-go": {
+      "models": {
+        "glm-5.1": {
+          "options": {
+            "reasoningEffort": "high",
+            "textVerbosity": "low"
+          }
+        },
+        "deepseek-v4-pro": {
+          "options": {
+            "reasoningEffort": "high",
+            "textVerbosity": "low"
+          }
+        },
+        "qwen3.6-plus": {
+          "options": {
+            "reasoningEffort": "medium",
+            "textVerbosity": "low"
+          }
+        },
+        "deepseek-v4-flash": {
+          "options": {
+            "textVerbosity": "low"
+          }
+        }
+      }
+    }
+  },
+  "agents": {
+    "pr-reviewer": {
+      "mode": "primary",
+      "description": "Autonomous PR review bot that knows the AgentClash codebase conventions and flags problems on every PR.",
+      "prompt": "You are the AgentClash PR review bot. You have deep knowledge of this codebase from AGENTS.md and CLAUDE.md.\n\nWhen reviewing a PR:\n1. Read the diff and understand what changed\n2. Check against repo conventions (Go module separation, SQLC-only queries, constructor injection, no global state, etc.)\n3. Flag real problems — not style nits\n4. Prioritize: correctness > security > performance > readability\n5. If no issues found, say so briefly\n\nBe specific: cite file paths and line numbers. Suggest concrete fixes, not vague advice.",
+      "permissions": {
+        "bash": ["git diff*", "git log*", "go build*", "go vet*", "go test*", "grep*", "rg*"],
+        "read": true,
+        "edit": false,
+        "glob": true,
+        "grep": true,
+        "webfetch": false,
+        "task": true,
+        "todowrite": false,
+        "websearch": false,
+        "lsp": false,
+        "skill": false
+      }
+    }
+  }
+}

--- a/scripts/pr-review/select-review-model.sh
+++ b/scripts/pr-review/select-review-model.sh
@@ -83,8 +83,8 @@ while IFS= read -r file; do
   esac
 done <<< "$CHANGED_FILES"
 
-# Count distinct major areas touched
-AREAS_TOUCHED=$((GO_BACKEND + GO_CLI + FRONTEND + CI_WORKFLOWS))
+# Count distinct major code areas touched (CI/config changes are not "cross-cutting code areas")
+AREAS_TOUCHED=$((GO_BACKEND + GO_CLI + FRONTEND))
 
 # Decision logic
 # 1. Large diff or cross-cutting → glm-5.1 for deep analysis

--- a/scripts/pr-review/select-review-model.sh
+++ b/scripts/pr-review/select-review-model.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# select-review-model.sh — picks the best opencode-go model for a PR review
+# based on what files changed and how large the diff is.
+#
+# Usage: ./scripts/pr-review/select-review-model.sh [--base <base-ref>] [--head <head-ref>]
+#
+# Outputs a single line: opencode-go/<model-id>
+#
+# Model selection logic (all opencode-go models via $OPENCODE_GO_API_KEY):
+#   - Large or cross-cutting diffs (>500 lines or touches 2+ major areas) → glm-5.1 (strongest reasoning)
+#   - Go backend/CLI changes → glm-5.1 (strong at systems/code)
+#   - Frontend/TypeScript changes → qwen3.6-plus (good all-rounder)
+#   - Config/CI only → deepseek-v4-flash (fast, cheap)
+#   - Default fallback → qwen3.6-plus
+
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-}"
+HEAD_REF="${HEAD_REF:-}"
+
+# Parse flags
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base) BASE_REF="$2"; shift 2 ;;
+    --head) HEAD_REF="$2"; shift 2 ;;
+    *) echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+# If refs not provided, use GitHub event context or default to diff against main
+if [[ -z "$BASE_REF" ]]; then
+  if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+    BASE_REF="origin/${GITHUB_BASE_REF}"
+  else
+    BASE_REF="origin/main"
+  fi
+fi
+
+if [[ -z "$HEAD_REF" ]]; then
+  if [[ -n "${GITHUB_HEAD_REF:-}" ]]; then
+    HEAD_REF="origin/${GITHUB_HEAD_REF}"
+  else
+    HEAD_REF="HEAD"
+  fi
+fi
+
+# Get the diff stat
+DIFF_STAT=$(git diff --stat "${BASE_REF}"..."${HEAD_REF}" 2>/dev/null || git diff --stat "${BASE_REF}" "${HEAD_REF}" 2>/dev/null || echo "")
+
+if [[ -z "$DIFF_STAT" ]]; then
+  echo "opencode-go/qwen3.6-plus"
+  exit 0
+fi
+
+# Count total changed lines
+TOTAL_LINES=$(git diff --shortstat "${BASE_REF}"..."${HEAD_REF}" 2>/dev/null | grep -oP '\d+(?= insertion)' || echo "0")
+TOTAL_DEL=$(git diff --shortstat "${BASE_REF}"..."${HEAD_REF}" 2>/dev/null | grep -oP '\d+(?= deletion)' || echo "0")
+TOTAL_CHANGED=$((TOTAL_LINES + TOTAL_DEL))
+
+# Get list of changed files
+CHANGED_FILES=$(git diff --name-only "${BASE_REF}"..."${HEAD_REF}" 2>/dev/null || git diff --name-only "${BASE_REF}" "${HEAD_REF}" 2>/dev/null || echo "")
+
+# Count files touching each major area
+GO_BACKEND=0
+GO_CLI=0
+FRONTEND=0
+CI_WORKFLOWS=0
+CONFIG_DOCS=0
+TOTAL_FILES=0
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  TOTAL_FILES=$((TOTAL_FILES + 1))
+
+  case "$file" in
+    backend/**/*.go) GO_BACKEND=1 ;;
+    cli/**/*.go) GO_CLI=1 ;;
+    web/**) FRONTEND=1 ;;
+    .github/workflows/**) CI_WORKFLOWS=1 ;;
+    *.md|*.json|*.yaml|*.yml|*.toml|Dockerfile*|.gitignore|LICENSE) CONFIG_DOCS=1 ;;
+    *) CONFIG_DOCS=1 ;;
+  esac
+done <<< "$CHANGED_FILES"
+
+# Count distinct major areas touched
+AREAS_TOUCHED=$((GO_BACKEND + GO_CLI + FRONTEND + CI_WORKFLOWS))
+
+# Decision logic
+# 1. Large diff or cross-cutting → glm-5.1 for deep analysis
+if [[ "$TOTAL_CHANGED" -gt 500 ]] || [[ "$AREAS_TOUCHED" -ge 2 ]]; then
+  echo "opencode-go/glm-5.1"
+  exit 0
+fi
+
+# 2. Go code (backend or CLI) → glm-5.1
+if [[ "$GO_BACKEND" -eq 1 ]] || [[ "$GO_CLI" -eq 1 ]]; then
+  echo "opencode-go/glm-5.1"
+  exit 0
+fi
+
+# 3. Frontend → qwen3.6-plus
+if [[ "$FRONTEND" -eq 1 ]]; then
+  echo "opencode-go/qwen3.6-plus"
+  exit 0
+fi
+
+# 4. CI/config/docs only → deepseek-v4-flash (fast, cheap)
+echo "opencode-go/deepseek-v4-flash"


### PR DESCRIPTION
## What

Automated PR review bot powered by opencode that runs on every PR and flags problems with full repo context.

## How it works

1. **Model selection** — a script analyzes the diff and picks the best model:
   - Go backend/CLI changes → `openai/gpt-5-codex` (strong at systems programming)
   - Frontend changes → `anthropic/claude-sonnet-4-5` (strong at React/TS)
   - Large or cross-cutting diffs (>500 lines or 2+ areas) → `anthropic/claude-opus-4-5` (deep analysis)

2. **Repo-aware review** — the review prompt enforces AgentClash conventions:
   - SQLC-only queries, no raw SQL outside repository layer
   - Constructor injection, no global state
   - Goose-format migrations, immutable schema-versioned events
   - Go module separation (backend/ vs cli/)
   - Conventional commits

3. **Language-specific checks** — runs `go build/vet/test`, `tsc`, `eslint` on changed areas

4. **Review posted as PR comment** with model transparency header

## Files added

| File | Purpose |
|------|---------|
| `.github/workflows/pr-review-bot.yml` | GitHub Action workflow |
| `.opencode/opencode.json` | OpenCode config with review agent and model options |
| `scripts/pr-review/select-review-model.sh` | Model selection logic |

## Required secrets

- `ANTHROPIC_API_KEY` — for Claude Sonnet/Opus reviews
- `OPENAI_API_KEY` — for GPT-5 Codex reviews

Both are optional — the workflow gracefully handles missing keys by falling back to available models.

## Triggers

Runs on PR `opened`, `synchronize`, `reopened`, `ready_for_review`. Skips PRs that only touch `.md` or `docs/`.