### PR TITLE
feat: OpenAI Responses API execution mode

### DIFF
--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -125,7 +125,9 @@ func main() {
 	responsesInvoker := workerapp.NewResponsesInvokerWithObserverFactory(
 		providerRouter,
 		workerapp.NewBufferedResponsesObserverFactory(eventRecorder),
-	).WithSecretsLookup(repo)
+	).WithSecretsLookup(repo).
+		WithSandboxProvider(sandboxProvider).
+		WithAssetLoader(workerapp.NewArtifactAssetLoader(repo, artifactStore).WithMaxBytes(cfg.ArtifactStorage.MaxDownloadBytes))
 	multiTurnInvoker := workerapp.NewMultiTurnInvokerWithObserverFactory(
 		providerRouter,
 		sandboxProvider,

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -122,6 +122,10 @@ func main() {
 		providerRouter,
 		workerapp.NewBufferedPromptEvalObserverFactory(eventRecorder),
 	).WithSecretsLookup(repo)
+	responsesInvoker := workerapp.NewResponsesInvokerWithObserverFactory(
+		providerRouter,
+		workerapp.NewBufferedResponsesObserverFactory(eventRecorder),
+	).WithSecretsLookup(repo)
 	multiTurnInvoker := workerapp.NewMultiTurnInvokerWithObserverFactory(
 		providerRouter,
 		sandboxProvider,
@@ -134,6 +138,7 @@ func main() {
 		HostedRunStarter:   hostedRunClient,
 		NativeModelInvoker: nativeModelInvoker,
 		PromptEvalInvoker:  promptEvalInvoker,
+		ResponsesInvoker:   responsesInvoker,
 		MultiTurnInvoker:   multiTurnInvoker,
 	})
 	orphanRunReaper := workerapp.NewRepositoryOrphanRunReaper(repo, cfg.OrphanRunReaperInterval, cfg.OrphanRunReaperThreshold, logger)

--- a/backend/db/migrations/00048_runtime_execution_targets.sql
+++ b/backend/db/migrations/00048_runtime_execution_targets.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+ALTER TABLE runtime_profiles DROP CONSTRAINT IF EXISTS runtime_profiles_execution_target_check;
+ALTER TABLE runtime_profiles ADD CONSTRAINT runtime_profiles_execution_target_check
+    CHECK (execution_target IN ('native', 'hosted_external', 'prompt_eval', 'responses', 'multi_turn'));
+
+-- +goose Down
+ALTER TABLE runtime_profiles DROP CONSTRAINT IF EXISTS runtime_profiles_execution_target_check;
+ALTER TABLE runtime_profiles ADD CONSTRAINT runtime_profiles_execution_target_check
+    CHECK (execution_target IN ('native', 'hosted_external'));

--- a/backend/internal/challengepack/bundle.go
+++ b/backend/internal/challengepack/bundle.go
@@ -62,6 +62,7 @@ type VersionMetadata struct {
 const (
 	ExecutionModeNative     = "native"
 	ExecutionModePromptEval = "prompt_eval"
+	ExecutionModeResponses  = "responses"
 	ExecutionModeMultiTurn  = "multi_turn"
 )
 

--- a/backend/internal/challengepack/bundle_test.go
+++ b/backend/internal/challengepack/bundle_test.go
@@ -1078,6 +1078,56 @@ func TestValidateBundleRejectsPromptEvalWithTools(t *testing.T) {
 	}
 }
 
+func TestValidateBundleAllowsResponsesWithSandboxAndToolPolicy(t *testing.T) {
+	err := ValidateBundle(Bundle{
+		Pack: PackMetadata{Slug: "research", Name: "Research", Family: "eval"},
+		Version: VersionMetadata{
+			Number:         1,
+			ExecutionMode:  ExecutionModeResponses,
+			EvaluationSpec: minimalSpec(),
+			Sandbox:        &SandboxConfig{NetworkAccess: true},
+			ToolPolicy:     map[string]any{"allow_shell": true, "allowed_tool_kinds": []any{"file", "network"}},
+		},
+		Challenges: []ChallengeDefinition{
+			{Key: "c1", Title: "C1", Category: "cat", Difficulty: "easy"},
+		},
+		InputSets: []InputSetDefinition{
+			{Key: "default", Name: "Default", Cases: []CaseDefinition{{ChallengeKey: "c1", CaseKey: "k"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ValidateBundle returned error: %v", err)
+	}
+}
+
+func TestValidateBundleRejectsResponsesWithPackTools(t *testing.T) {
+	err := ValidateBundle(Bundle{
+		Pack: PackMetadata{Slug: "research", Name: "Research", Family: "eval"},
+		Version: VersionMetadata{
+			Number:         1,
+			ExecutionMode:  ExecutionModeResponses,
+			EvaluationSpec: minimalSpec(),
+		},
+		Tools: map[string]any{"custom": []any{}},
+		Challenges: []ChallengeDefinition{
+			{Key: "c1", Title: "C1", Category: "cat", Difficulty: "easy"},
+		},
+		InputSets: []InputSetDefinition{
+			{Key: "default", Name: "Default", Cases: []CaseDefinition{{ChallengeKey: "c1", CaseKey: "k"}}},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected validation error for responses pack with tools")
+	}
+	errs, ok := err.(ValidationErrors)
+	if !ok {
+		t.Fatalf("expected ValidationErrors, got %T", err)
+	}
+	if !containsField(errs, "tools") {
+		t.Fatalf("expected tools validation error; got %v", errs)
+	}
+}
+
 func TestValidateBundleAllowsBrowserToolKind(t *testing.T) {
 	err := ValidateBundle(Bundle{
 		Pack: PackMetadata{Slug: "browser", Name: "Browser", Family: "browser"},

--- a/backend/internal/challengepack/validation.go
+++ b/backend/internal/challengepack/validation.go
@@ -73,7 +73,7 @@ func ValidateBundle(bundle Bundle) error {
 	default:
 		errs = append(errs, ValidationError{Field: "version.execution_mode", Message: fmt.Sprintf("must be one of %q, %q, %q, %q", ExecutionModeNative, ExecutionModePromptEval, ExecutionModeResponses, ExecutionModeMultiTurn)})
 	}
-	if bundle.Version.ExecutionMode == ExecutionModePromptEval || bundle.Version.ExecutionMode == ExecutionModeResponses {
+	if bundle.Version.ExecutionMode == ExecutionModePromptEval {
 		if len(bundle.Tools) > 0 {
 			errs = append(errs, ValidationError{Field: "tools", Message: fmt.Sprintf("must be empty when version.execution_mode is %s", bundle.Version.ExecutionMode)})
 		}
@@ -82,6 +82,11 @@ func ValidateBundle(bundle Bundle) error {
 		}
 		if len(bundle.Version.ToolPolicy) > 0 {
 			errs = append(errs, ValidationError{Field: "version.tool_policy", Message: fmt.Sprintf("must be empty when version.execution_mode is %s", bundle.Version.ExecutionMode)})
+		}
+	}
+	if bundle.Version.ExecutionMode == ExecutionModeResponses {
+		if len(bundle.Tools) > 0 {
+			errs = append(errs, ValidationError{Field: "tools", Message: "must be empty when version.execution_mode is responses (use OpenAI Responses tools, not pack-defined tools)"})
 		}
 	}
 	if len(bundle.Challenges) == 0 {

--- a/backend/internal/challengepack/validation.go
+++ b/backend/internal/challengepack/validation.go
@@ -69,19 +69,19 @@ func ValidateBundle(bundle Bundle) error {
 	}
 	errs = append(errs, validateModalityConfig(bundle)...)
 	switch bundle.Version.ExecutionMode {
-	case "", ExecutionModeNative, ExecutionModePromptEval, ExecutionModeMultiTurn:
+	case "", ExecutionModeNative, ExecutionModePromptEval, ExecutionModeResponses, ExecutionModeMultiTurn:
 	default:
-		errs = append(errs, ValidationError{Field: "version.execution_mode", Message: fmt.Sprintf("must be one of %q, %q, %q", ExecutionModeNative, ExecutionModePromptEval, ExecutionModeMultiTurn)})
+		errs = append(errs, ValidationError{Field: "version.execution_mode", Message: fmt.Sprintf("must be one of %q, %q, %q, %q", ExecutionModeNative, ExecutionModePromptEval, ExecutionModeResponses, ExecutionModeMultiTurn)})
 	}
-	if bundle.Version.ExecutionMode == ExecutionModePromptEval {
+	if bundle.Version.ExecutionMode == ExecutionModePromptEval || bundle.Version.ExecutionMode == ExecutionModeResponses {
 		if len(bundle.Tools) > 0 {
-			errs = append(errs, ValidationError{Field: "tools", Message: "must be empty when version.execution_mode is prompt_eval"})
+			errs = append(errs, ValidationError{Field: "tools", Message: fmt.Sprintf("must be empty when version.execution_mode is %s", bundle.Version.ExecutionMode)})
 		}
 		if bundle.Version.Sandbox != nil {
-			errs = append(errs, ValidationError{Field: "version.sandbox", Message: "must be omitted when version.execution_mode is prompt_eval"})
+			errs = append(errs, ValidationError{Field: "version.sandbox", Message: fmt.Sprintf("must be omitted when version.execution_mode is %s", bundle.Version.ExecutionMode)})
 		}
 		if len(bundle.Version.ToolPolicy) > 0 {
-			errs = append(errs, ValidationError{Field: "version.tool_policy", Message: "must be empty when version.execution_mode is prompt_eval"})
+			errs = append(errs, ValidationError{Field: "version.tool_policy", Message: fmt.Sprintf("must be empty when version.execution_mode is %s", bundle.Version.ExecutionMode)})
 		}
 	}
 	if len(bundle.Challenges) == 0 {

--- a/backend/internal/engine/executor_assets.go
+++ b/backend/internal/engine/executor_assets.go
@@ -16,7 +16,7 @@ type sandboxAssetLocation struct {
 	Asset challengepack.AssetReference
 }
 
-func (e NativeExecutor) stageArtifactBackedAssets(ctx context.Context, session sandbox.Session, executionContext repository.RunAgentExecutionContext) error {
+func stageArtifactBackedAssets(ctx context.Context, loader AssetLoader, session sandbox.Session, executionContext repository.RunAgentExecutionContext) error {
 	assets, err := collectSandboxAssetLocations(executionContext)
 	if err != nil {
 		return NewFailure(StopReasonSandboxError, "decode challenge pack asset references", err)
@@ -24,7 +24,7 @@ func (e NativeExecutor) stageArtifactBackedAssets(ctx context.Context, session s
 	if len(assets) == 0 {
 		return nil
 	}
-	if e.assetLoader == nil {
+	if loader == nil {
 		return NewFailure(StopReasonSandboxError, "artifact-backed challenge pack assets require an artifact loader", nil)
 	}
 
@@ -37,7 +37,7 @@ func (e NativeExecutor) stageArtifactBackedAssets(ctx context.Context, session s
 			return NewFailure(StopReasonSandboxError, fmt.Sprintf("%s.path is required", item.Field), nil)
 		}
 
-		content, err := e.assetLoader.LoadAsset(ctx, workspaceID, *item.Asset.ArtifactID)
+		content, err := loader.LoadAsset(ctx, workspaceID, *item.Asset.ArtifactID)
 		if err != nil {
 			return NewFailure(StopReasonSandboxError, fmt.Sprintf("load challenge pack asset %s", item.Field), err)
 		}

--- a/backend/internal/engine/executor_assets_test.go
+++ b/backend/internal/engine/executor_assets_test.go
@@ -62,7 +62,7 @@ func TestStageArtifactBackedAssetsUploadsManifestAndInputCaseAssets(t *testing.T
 	}
 
 	executor := NativeExecutor{}.WithAssetLoader(loader)
-	if err := executor.stageArtifactBackedAssets(ctx, session, executionContext); err != nil {
+	if err := stageArtifactBackedAssets(ctx, executor.assetLoader, session, executionContext); err != nil {
 		t.Fatalf("stageArtifactBackedAssets returned error: %v", err)
 	}
 
@@ -93,7 +93,7 @@ func TestStageArtifactBackedAssetsSkipsInlineAssetsWithoutLoader(t *testing.T) {
 	}
 
 	session := sandbox.NewFakeSession("inline-assets")
-	if err := (NativeExecutor{}).stageArtifactBackedAssets(context.Background(), session, executionContext); err != nil {
+	if err := stageArtifactBackedAssets(context.Background(), nil, session, executionContext); err != nil {
 		t.Fatalf("stageArtifactBackedAssets returned error: %v", err)
 	}
 	if files := session.Files(); len(files) != 0 {
@@ -116,7 +116,7 @@ func TestStageArtifactBackedAssetsFailsClosedWithoutLoader(t *testing.T) {
 	}
 
 	session := sandbox.NewFakeSession("missing-loader")
-	err := (NativeExecutor{}).stageArtifactBackedAssets(context.Background(), session, executionContext)
+	err := stageArtifactBackedAssets(context.Background(), nil, session, executionContext)
 	if err == nil {
 		t.Fatal("stageArtifactBackedAssets returned nil error")
 	}

--- a/backend/internal/engine/executor_sandbox.go
+++ b/backend/internal/engine/executor_sandbox.go
@@ -22,21 +22,44 @@ const (
 )
 
 func (e NativeExecutor) prepareSandbox(ctx context.Context, executionContext repository.RunAgentExecutionContext, request sandbox.CreateRequest) (sandbox.Session, error) {
-	session, err := e.sandboxProvider.Create(ctx, request)
+	return prepareRunSandbox(ctx, e.sandboxProvider, e.assetLoader, executionContext, request)
+}
+
+func prepareRunSandbox(ctx context.Context, sandboxProvider sandbox.Provider, assetLoader AssetLoader, executionContext repository.RunAgentExecutionContext, request sandbox.CreateRequest) (sandbox.Session, error) {
+	session, err := sandboxProvider.Create(ctx, request)
 	if err != nil {
-		return nil, NewFailure(StopReasonSandboxError, "create native sandbox", err)
+		return nil, NewFailure(StopReasonSandboxError, "create sandbox", err)
 	}
 
 	if err := stageSandboxInputs(ctx, session, executionContext); err != nil {
 		return nil, cleanupSandboxOnError(session, err)
 	}
-	if err := e.stageArtifactBackedAssets(ctx, session, executionContext); err != nil {
+	if err := stageArtifactBackedAssets(ctx, assetLoader, session, executionContext); err != nil {
 		return nil, cleanupSandboxOnError(session, err)
 	}
 	if err := applyPlantedSecretsToSession(ctx, session, executionContext.ChallengePackVersion.Manifest); err != nil {
 		return nil, cleanupSandboxOnError(session, err)
 	}
 	return session, nil
+}
+
+func manifestUsesE2BSandbox(manifest json.RawMessage) bool {
+	type manifestShape struct {
+		Sandbox    json.RawMessage `json:"sandbox"`
+		ToolPolicy json.RawMessage `json:"tool_policy"`
+	}
+
+	var decoded manifestShape
+	if err := json.Unmarshal(manifest, &decoded); err != nil {
+		return false
+	}
+	if len(decoded.Sandbox) > 0 && string(decoded.Sandbox) != "null" {
+		return true
+	}
+	if len(decoded.ToolPolicy) > 0 && string(decoded.ToolPolicy) != "null" && string(decoded.ToolPolicy) != "{}" {
+		return true
+	}
+	return false
 }
 
 func cleanupSandboxOnError(session sandbox.Session, originalErr error) error {

--- a/backend/internal/engine/responses_executor.go
+++ b/backend/internal/engine/responses_executor.go
@@ -1,0 +1,210 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+// ResponsesExecutor runs a single OpenAI Responses API call (deep research with
+// web_search_preview). No sandbox or tool loop — same Result shape as prompt_eval.
+type ResponsesExecutor struct {
+	researchClient provider.ResearchClient
+	observer       Observer
+	secretsLookup  SecretsLookup
+}
+
+func NewResponsesExecutor(researchClient provider.ResearchClient, observer Observer) ResponsesExecutor {
+	if observer == nil {
+		observer = NoopObserver{}
+	}
+	return ResponsesExecutor{
+		researchClient: researchClient,
+		observer:       observer,
+	}
+}
+
+func (e ResponsesExecutor) WithSecretsLookup(lookup SecretsLookup) ResponsesExecutor {
+	e.secretsLookup = lookup
+	return e
+}
+
+func (e ResponsesExecutor) loadWorkspaceSecrets(ctx context.Context, workspaceID uuid.UUID) (map[string]string, error) {
+	if e.secretsLookup == nil {
+		return map[string]string{}, nil
+	}
+	loaded, err := e.secretsLookup.LoadWorkspaceSecrets(ctx, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	if loaded == nil {
+		return map[string]string{}, nil
+	}
+	return loaded, nil
+}
+
+func (e ResponsesExecutor) Execute(ctx context.Context, executionContext repository.RunAgentExecutionContext) (result Result, err error) {
+	defer func() {
+		if err != nil {
+			if observerErr := e.observer.OnRunFailure(ctx, err); observerErr != nil {
+				err = errors.Join(err, NewFailure(StopReasonObserverError, "record responses terminal failure event", observerErr))
+			}
+			return
+		}
+		if observerErr := e.observer.OnRunComplete(ctx, result); observerErr != nil {
+			result = Result{}
+			err = NewFailure(StopReasonObserverError, "record responses terminal completion event", observerErr)
+		}
+	}()
+
+	if executionContext.Deployment.ProviderAccount == nil {
+		return Result{}, provider.NewFailure(
+			"",
+			provider.FailureCodeInvalidRequest,
+			"responses deployment is missing provider account in execution context",
+			false,
+			nil,
+		)
+	}
+	if executionContext.Deployment.ModelAlias == nil {
+		return Result{}, provider.NewFailure(
+			executionContext.Deployment.ProviderAccount.ProviderKey,
+			provider.FailureCodeInvalidRequest,
+			"responses deployment is missing model alias in execution context",
+			false,
+			nil,
+		)
+	}
+	if executionContext.Deployment.ProviderAccount.ProviderKey != "openai" {
+		return Result{}, provider.NewFailure(
+			executionContext.Deployment.ProviderAccount.ProviderKey,
+			provider.FailureCodeUnsupportedCapability,
+			"responses execution mode requires an OpenAI provider account",
+			false,
+			nil,
+		)
+	}
+
+	workspaceSecrets, err := e.loadWorkspaceSecrets(ctx, executionContext.Run.WorkspaceID)
+	if err != nil {
+		return Result{}, NewFailure(StopReasonSandboxError, fmt.Sprintf("load workspace secrets: %v", err), err)
+	}
+	runCtx := provider.WithWorkspaceSecrets(ctx, workspaceSecrets)
+	cancel := func() {}
+	if timeout := runTimeout(executionContext); timeout > 0 {
+		runCtx, cancel = context.WithTimeout(runCtx, timeout)
+	}
+	defer cancel()
+
+	messages, err := buildPromptEvalMessages(executionContext)
+	if err != nil {
+		return Result{}, provider.NewFailure(
+			executionContext.Deployment.ProviderAccount.ProviderKey,
+			provider.FailureCodeInvalidRequest,
+			"build responses messages",
+			false,
+			err,
+		)
+	}
+
+	instructions, userInput := splitResponsesMessages(messages)
+	metadata, err := buildProviderMetadata(executionContext)
+	if err != nil {
+		return Result{}, provider.NewFailure(
+			executionContext.Deployment.ProviderAccount.ProviderKey,
+			provider.FailureCodeInvalidRequest,
+			"marshal responses provider metadata",
+			false,
+			err,
+		)
+	}
+
+	if observerErr := e.observer.OnStepStart(runCtx, 1); observerErr != nil {
+		return Result{}, NewFailure(StopReasonObserverError, "record responses step start event", observerErr)
+	}
+
+	providerRequest := provider.Request{
+		ProviderKey:         executionContext.Deployment.ProviderAccount.ProviderKey,
+		ProviderAccountID:   executionContext.Deployment.ProviderAccount.ID.String(),
+		CredentialReference: executionContext.Deployment.ProviderAccount.CredentialReference,
+		Model:               executionContext.Deployment.ModelAlias.ModelCatalogEntry.ProviderModelID,
+		TraceMode:           executionContext.Deployment.RuntimeProfile.TraceMode,
+		StepTimeout:         stepTimeout(executionContext),
+		Messages:            messages,
+		Metadata:            metadata,
+	}
+	if observerErr := e.observer.OnProviderCall(runCtx, providerRequest); observerErr != nil {
+		return Result{}, NewFailure(StopReasonObserverError, "record responses provider call event", observerErr)
+	}
+
+	researchRequest := provider.ResearchRequest{
+		ProviderKey:         executionContext.Deployment.ProviderAccount.ProviderKey,
+		ProviderAccountID:   executionContext.Deployment.ProviderAccount.ID.String(),
+		CredentialReference: executionContext.Deployment.ProviderAccount.CredentialReference,
+		Model:               executionContext.Deployment.ModelAlias.ModelCatalogEntry.ProviderModelID,
+		TraceMode:           executionContext.Deployment.RuntimeProfile.TraceMode,
+		RunTimeout:          runTimeout(executionContext),
+		Instructions:        instructions,
+		Input:               userInput,
+		OutputSchema:        cloneJSON(executionContext.Deployment.AgentBuildVersion.OutputSchema),
+		Metadata:            metadata,
+		Background:          true,
+	}
+
+	response, invokeErr := e.researchClient.InvokeResearch(runCtx, researchRequest)
+	if invokeErr != nil {
+		if errors.Is(invokeErr, context.Canceled) {
+			return Result{}, invokeErr
+		}
+		if errors.Is(runCtx.Err(), context.Canceled) {
+			return Result{}, runCtx.Err()
+		}
+		if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+			return Result{}, NewFailure(StopReasonTimeout, "responses execution exceeded runtime budget", runCtx.Err())
+		}
+		if _, ok := provider.AsFailure(invokeErr); ok {
+			return Result{}, invokeErr
+		}
+		if failure, ok := AsFailure(invokeErr); ok {
+			return Result{}, failure
+		}
+		return Result{}, NewFailure(StopReasonProviderError, "responses provider call failed", invokeErr)
+	}
+
+	if observerErr := e.observer.OnProviderResponse(runCtx, response); observerErr != nil {
+		return Result{}, NewFailure(StopReasonObserverError, "record responses provider response event", observerErr)
+	}
+	if observerErr := e.observer.OnStepEnd(runCtx, 1); observerErr != nil {
+		return Result{}, NewFailure(StopReasonObserverError, "record responses step completion event", observerErr)
+	}
+
+	return Result{
+		FinalOutput:   response.OutputText,
+		StopReason:    StopReasonCompleted,
+		StepCount:     1,
+		ToolCallCount: 0,
+		Usage:         response.Usage,
+	}, nil
+}
+
+func splitResponsesMessages(messages []provider.Message) (instructions, userInput string) {
+	var sections []string
+	for _, message := range messages {
+		switch message.Role {
+		case "system", "developer":
+			if trimmed := strings.TrimSpace(message.Content); trimmed != "" {
+				sections = append(sections, trimmed)
+			}
+		case "user":
+			if trimmed := strings.TrimSpace(message.Content); trimmed != "" {
+				userInput = trimmed
+			}
+		}
+	}
+	return strings.Join(sections, "\n\n"), userInput
+}

--- a/backend/internal/engine/responses_executor.go
+++ b/backend/internal/engine/responses_executor.go
@@ -4,19 +4,24 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/agentclash/agentclash/backend/internal/provider"
 	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/sandbox"
 	"github.com/google/uuid"
 )
 
 // ResponsesExecutor runs a single OpenAI Responses API call (deep research with
-// web_search_preview). No sandbox or tool loop — same Result shape as prompt_eval.
+// web_search_preview). When the pack declares sandbox or tool_policy settings,
+// it provisions E2B to stage inputs/assets before the model call.
 type ResponsesExecutor struct {
-	researchClient provider.ResearchClient
-	observer       Observer
-	secretsLookup  SecretsLookup
+	researchClient  provider.ResearchClient
+	sandboxProvider sandbox.Provider
+	observer        Observer
+	secretsLookup   SecretsLookup
+	assetLoader     AssetLoader
 }
 
 func NewResponsesExecutor(researchClient provider.ResearchClient, observer Observer) ResponsesExecutor {
@@ -27,6 +32,16 @@ func NewResponsesExecutor(researchClient provider.ResearchClient, observer Obser
 		researchClient: researchClient,
 		observer:       observer,
 	}
+}
+
+func (e ResponsesExecutor) WithSandboxProvider(provider sandbox.Provider) ResponsesExecutor {
+	e.sandboxProvider = provider
+	return e
+}
+
+func (e ResponsesExecutor) WithAssetLoader(loader AssetLoader) ResponsesExecutor {
+	e.assetLoader = loader
+	return e
 }
 
 func (e ResponsesExecutor) WithSecretsLookup(lookup SecretsLookup) ResponsesExecutor {
@@ -94,6 +109,39 @@ func (e ResponsesExecutor) Execute(ctx context.Context, executionContext reposit
 	if err != nil {
 		return Result{}, NewFailure(StopReasonSandboxError, fmt.Sprintf("load workspace secrets: %v", err), err)
 	}
+
+	if manifestUsesE2BSandbox(executionContext.ChallengePackVersion.Manifest) {
+		if e.sandboxProvider == nil {
+			return Result{}, NewFailure(StopReasonSandboxError, sandbox.ErrProviderNotConfigured.Error(), sandbox.ErrProviderNotConfigured)
+		}
+		sandboxRequest, buildErr := nativeSandboxRequest(executionContext)
+		if buildErr != nil {
+			return Result{}, NewFailure(StopReasonSandboxError, "build responses sandbox request", buildErr)
+		}
+		session, prepErr := prepareRunSandbox(ctx, e.sandboxProvider, e.assetLoader, executionContext, sandboxRequest)
+		if prepErr != nil {
+			return Result{}, prepErr
+		}
+		defer func() {
+			if session == nil {
+				return
+			}
+			if destroyErr := destroySandbox(session); destroyErr != nil {
+				wrapped := NewFailure(StopReasonSandboxError, "destroy responses sandbox", destroyErr)
+				if err != nil {
+					err = errors.Join(err, wrapped)
+					return
+				}
+				slog.Default().Warn(
+					"sandbox destroy failed after successful responses execution",
+					"run_id", executionContext.Run.ID,
+					"run_agent_id", executionContext.RunAgent.ID,
+					"error", destroyErr,
+				)
+			}
+		}()
+	}
+
 	runCtx := provider.WithWorkspaceSecrets(ctx, workspaceSecrets)
 	cancel := func() {}
 	if timeout := runTimeout(executionContext); timeout > 0 {

--- a/backend/internal/engine/responses_executor_test.go
+++ b/backend/internal/engine/responses_executor_test.go
@@ -1,0 +1,66 @@
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/provider"
+)
+
+func TestResponsesExecutorSingleResearchCall(t *testing.T) {
+	client := &provider.FakeResearchClient{
+		FakeClient: provider.FakeClient{
+			Response: provider.Response{
+				ProviderKey:     "openai",
+				ProviderModelID: "o4-mini-deep-research",
+				FinishReason:    "completed",
+				OutputText:      `{"title":"CS224N"}`,
+				Usage:           provider.Usage{InputTokens: 100, OutputTokens: 200, TotalTokens: 300},
+			},
+		},
+	}
+	observer := &recordingObserver{}
+	executor := NewResponsesExecutor(client, observer)
+
+	ctx := promptEvalExecutionContext()
+	ctx.ChallengePackVersion.Manifest = []byte(`{"version":{"execution_mode":"responses"}}`)
+
+	result, err := executor.Execute(context.Background(), ctx)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.FinalOutput != `{"title":"CS224N"}` {
+		t.Fatalf("final output = %q", result.FinalOutput)
+	}
+	if len(client.ResearchRequests) != 1 {
+		t.Fatalf("research call count = %d, want 1", len(client.ResearchRequests))
+	}
+	req := client.ResearchRequests[0]
+	if !strings.Contains(req.Input, "French") {
+		t.Fatalf("research input missing rendered template vars: %q", req.Input)
+	}
+	if !strings.Contains(req.Instructions, "precise translator") {
+		t.Fatalf("research instructions missing policy text: %q", req.Instructions)
+	}
+	if !req.Background {
+		t.Fatalf("expected background research request")
+	}
+}
+
+func TestResponsesExecutorRejectsNonOpenAIProvider(t *testing.T) {
+	client := &provider.FakeResearchClient{}
+	executor := NewResponsesExecutor(client, &recordingObserver{})
+
+	ctx := promptEvalExecutionContext()
+	ctx.Deployment.ProviderAccount.ProviderKey = "anthropic"
+
+	_, err := executor.Execute(context.Background(), ctx)
+	if err == nil {
+		t.Fatal("expected error for non-openai provider")
+	}
+	failure, ok := provider.AsFailure(err)
+	if !ok || failure.Code != provider.FailureCodeUnsupportedCapability {
+		t.Fatalf("failure = %#v, want unsupported_capability", failure)
+	}
+}

--- a/backend/internal/engine/responses_executor_test.go
+++ b/backend/internal/engine/responses_executor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/agentclash/agentclash/backend/internal/sandbox"
 )
 
 func TestResponsesExecutorSingleResearchCall(t *testing.T) {
@@ -62,5 +63,56 @@ func TestResponsesExecutorRejectsNonOpenAIProvider(t *testing.T) {
 	failure, ok := provider.AsFailure(err)
 	if !ok || failure.Code != provider.FailureCodeUnsupportedCapability {
 		t.Fatalf("failure = %#v, want unsupported_capability", failure)
+	}
+}
+
+func TestResponsesExecutorProvisionsSandboxWhenConfigured(t *testing.T) {
+	client := &provider.FakeResearchClient{
+		FakeClient: provider.FakeClient{
+			Response: provider.Response{
+				ProviderKey:  "openai",
+				FinishReason: "completed",
+				OutputText:   `{"ok":true}`,
+			},
+		},
+	}
+	fakeSandbox := &sandbox.FakeProvider{}
+	executor := NewResponsesExecutor(client, &recordingObserver{}).WithSandboxProvider(fakeSandbox)
+
+	ctx := promptEvalExecutionContext()
+	ctx.ChallengePackVersion.Manifest = []byte(`{"version":{"execution_mode":"responses"},"sandbox":{"network_access":true}}`)
+
+	if _, err := executor.Execute(context.Background(), ctx); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if len(fakeSandbox.CreateRequests) != 1 {
+		t.Fatalf("sandbox create requests = %d, want 1", len(fakeSandbox.CreateRequests))
+	}
+	if !fakeSandbox.CreateRequests[0].ToolPolicy.AllowNetwork {
+		t.Fatal("expected sandbox network access from manifest")
+	}
+}
+
+func TestResponsesExecutorSkipsSandboxWithoutManifestConfig(t *testing.T) {
+	client := &provider.FakeResearchClient{
+		FakeClient: provider.FakeClient{
+			Response: provider.Response{
+				ProviderKey:  "openai",
+				FinishReason: "completed",
+				OutputText:   `{"ok":true}`,
+			},
+		},
+	}
+	fakeSandbox := &sandbox.FakeProvider{}
+	executor := NewResponsesExecutor(client, &recordingObserver{}).WithSandboxProvider(fakeSandbox)
+
+	ctx := promptEvalExecutionContext()
+	ctx.ChallengePackVersion.Manifest = []byte(`{"version":{"execution_mode":"responses"}}`)
+
+	if _, err := executor.Execute(context.Background(), ctx); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if len(fakeSandbox.CreateRequests) != 0 {
+		t.Fatalf("sandbox create requests = %d, want 0", len(fakeSandbox.CreateRequests))
 	}
 }

--- a/backend/internal/provider/fake.go
+++ b/backend/internal/provider/fake.go
@@ -19,6 +19,19 @@ func (f *FakeClient) InvokeModel(_ context.Context, request Request) (Response, 
 	return cloneResponse(f.Response), nil
 }
 
+type FakeResearchClient struct {
+	FakeClient
+	ResearchRequests []ResearchRequest
+}
+
+func (f *FakeResearchClient) InvokeResearch(_ context.Context, request ResearchRequest) (Response, error) {
+	f.ResearchRequests = append(f.ResearchRequests, request)
+	if f.Err != nil {
+		return Response{}, f.Err
+	}
+	return cloneResponse(f.Response), nil
+}
+
 func cloneRequest(request Request) Request {
 	cloned := request
 	cloned.Messages = make([]Message, 0, len(request.Messages))

--- a/backend/internal/provider/openai_responses.go
+++ b/backend/internal/provider/openai_responses.go
@@ -16,11 +16,11 @@ const (
 )
 
 type openAIResponsesCreateRequest struct {
-	Model     string                   `json:"model"`
-	Input     []openAIResponsesMessage   `json:"input"`
-	Tools     []openAIResponsesTool      `json:"tools,omitempty"`
-	Background bool                    `json:"background,omitempty"`
-	Reasoning *openAIResponsesReasoning  `json:"reasoning,omitempty"`
+	Model      string                    `json:"model"`
+	Input      []openAIResponsesMessage  `json:"input"`
+	Tools      []openAIResponsesTool     `json:"tools,omitempty"`
+	Background bool                      `json:"background,omitempty"`
+	Reasoning  *openAIResponsesReasoning `json:"reasoning,omitempty"`
 }
 
 type openAIResponsesReasoning struct {
@@ -28,7 +28,7 @@ type openAIResponsesReasoning struct {
 }
 
 type openAIResponsesMessage struct {
-	Role    string                      `json:"role"`
+	Role    string                        `json:"role"`
 	Content []openAIResponsesContentBlock `json:"content"`
 }
 
@@ -58,8 +58,8 @@ type openAIResponsesResponse struct {
 }
 
 type openAIResponsesOutputItem struct {
-	Type    string                      `json:"type"`
-	Role    string                      `json:"role,omitempty"`
+	Type    string                        `json:"type"`
+	Role    string                        `json:"role,omitempty"`
 	Content []openAIResponsesContentBlock `json:"content,omitempty"`
 }
 
@@ -97,17 +97,12 @@ func (c OpenAICompatibleClient) InvokeResearch(ctx context.Context, request Rese
 		},
 	})
 
-	background := request.Background
-	if !background {
-		background = true
-	}
-
 	body := openAIResponsesCreateRequest{
-		Model: request.Model,
-		Input: input,
-		Tools: []openAIResponsesTool{{Type: "web_search_preview"}},
-		Background: background,
-		Reasoning: &openAIResponsesReasoning{Summary: "auto"},
+		Model:      request.Model,
+		Input:      input,
+		Tools:      []openAIResponsesTool{{Type: "web_search_preview"}},
+		Background: true,
+		Reasoning:  &openAIResponsesReasoning{Summary: "auto"},
 	}
 
 	payload, err := json.Marshal(body)
@@ -130,14 +125,14 @@ func (c OpenAICompatibleClient) InvokeResearch(ctx context.Context, request Rese
 
 	finalResp := createResp
 	finalRaw := rawCreate
-	if background && createResp.Status != "completed" && createResp.Status != "failed" && createResp.Status != "cancelled" {
+	if createResp.Status != "completed" && createResp.Status != "failed" && createResp.Status != "cancelled" && createResp.Status != "incomplete" {
 		finalResp, finalRaw, err = c.pollResponsesUntilDone(callCtx, apiKey, createResp.ID)
 		if err != nil {
 			return Response{}, err
 		}
 	}
 
-	if finalResp.Status == "failed" || finalResp.Status == "cancelled" {
+	if finalResp.Status == "failed" || finalResp.Status == "cancelled" || finalResp.Status == "incomplete" {
 		message := fmt.Sprintf("responses job ended with status %q", finalResp.Status)
 		if finalResp.Error != nil && strings.TrimSpace(finalResp.Error.Message) != "" {
 			message = finalResp.Error.Message
@@ -172,11 +167,11 @@ func (c OpenAICompatibleClient) InvokeResearch(ctx context.Context, request Rese
 		OutputText:      outputText,
 		Usage:           usage,
 		Timing: Timing{
-			StartedAt:     startedAt,
-			FirstTokenAt:  startedAt,
-			CompletedAt:   completedAt,
-			TTFT:          0,
-			TotalLatency:  completedAt.Sub(startedAt),
+			StartedAt:    startedAt,
+			FirstTokenAt: startedAt,
+			CompletedAt:  completedAt,
+			TTFT:         0,
+			TotalLatency: completedAt.Sub(startedAt),
 		},
 		RawResponse: finalRaw,
 	}, nil

--- a/backend/internal/provider/openai_responses.go
+++ b/backend/internal/provider/openai_responses.go
@@ -1,0 +1,296 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	responsesPollInterval = 3 * time.Second
+)
+
+type openAIResponsesCreateRequest struct {
+	Model     string                   `json:"model"`
+	Input     []openAIResponsesMessage   `json:"input"`
+	Tools     []openAIResponsesTool      `json:"tools,omitempty"`
+	Background bool                    `json:"background,omitempty"`
+	Reasoning *openAIResponsesReasoning  `json:"reasoning,omitempty"`
+}
+
+type openAIResponsesReasoning struct {
+	Summary string `json:"summary,omitempty"`
+}
+
+type openAIResponsesMessage struct {
+	Role    string                      `json:"role"`
+	Content []openAIResponsesContentBlock `json:"content"`
+}
+
+type openAIResponsesContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+type openAIResponsesTool struct {
+	Type string `json:"type"`
+}
+
+type openAIResponsesResponse struct {
+	ID         string          `json:"id"`
+	Status     string          `json:"status"`
+	Model      string          `json:"model"`
+	Output     json.RawMessage `json:"output"`
+	OutputText string          `json:"output_text,omitempty"`
+	Usage      *struct {
+		PromptTokens     int64 `json:"prompt_tokens"`
+		CompletionTokens int64 `json:"completion_tokens"`
+		TotalTokens      int64 `json:"total_tokens"`
+	} `json:"usage,omitempty"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+type openAIResponsesOutputItem struct {
+	Type    string                      `json:"type"`
+	Role    string                      `json:"role,omitempty"`
+	Content []openAIResponsesContentBlock `json:"content,omitempty"`
+}
+
+func (c OpenAICompatibleClient) InvokeResearch(ctx context.Context, request ResearchRequest) (Response, error) {
+	apiKey, err := c.credentialResolver.Resolve(ctx, request.CredentialReference)
+	if err != nil {
+		return Response{}, normalizeCredentialError(request.ProviderKey, err)
+	}
+
+	instructions := strings.TrimSpace(request.Instructions)
+	if schema := strings.TrimSpace(string(request.OutputSchema)); schema != "" && schema != "{}" && schema != "null" {
+		if instructions != "" {
+			instructions += "\n\n"
+		}
+		instructions += "Final answer contract (respond with JSON matching this schema when finished):\n" + schema
+	}
+
+	input := make([]openAIResponsesMessage, 0, 2)
+	if instructions != "" {
+		input = append(input, openAIResponsesMessage{
+			Role: "developer",
+			Content: []openAIResponsesContentBlock{
+				{Type: "input_text", Text: instructions},
+			},
+		})
+	}
+	userText := strings.TrimSpace(request.Input)
+	if userText == "" {
+		return Response{}, NewFailure(request.ProviderKey, FailureCodeInvalidRequest, "responses input is empty", false, nil)
+	}
+	input = append(input, openAIResponsesMessage{
+		Role: "user",
+		Content: []openAIResponsesContentBlock{
+			{Type: "input_text", Text: userText},
+		},
+	})
+
+	background := request.Background
+	if !background {
+		background = true
+	}
+
+	body := openAIResponsesCreateRequest{
+		Model: request.Model,
+		Input: input,
+		Tools: []openAIResponsesTool{{Type: "web_search_preview"}},
+		Background: background,
+		Reasoning: &openAIResponsesReasoning{Summary: "auto"},
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return Response{}, NewFailure(request.ProviderKey, FailureCodeInvalidRequest, "marshal responses request", false, err)
+	}
+
+	callCtx := ctx
+	if request.RunTimeout > 0 {
+		var cancel context.CancelFunc
+		callCtx, cancel = context.WithTimeout(ctx, request.RunTimeout)
+		defer cancel()
+	}
+
+	startedAt := time.Now().UTC()
+	createResp, rawCreate, err := c.postResponses(callCtx, apiKey, "/responses", payload)
+	if err != nil {
+		return Response{}, err
+	}
+
+	finalResp := createResp
+	finalRaw := rawCreate
+	if background && createResp.Status != "completed" && createResp.Status != "failed" && createResp.Status != "cancelled" {
+		finalResp, finalRaw, err = c.pollResponsesUntilDone(callCtx, apiKey, createResp.ID)
+		if err != nil {
+			return Response{}, err
+		}
+	}
+
+	if finalResp.Status == "failed" || finalResp.Status == "cancelled" {
+		message := fmt.Sprintf("responses job ended with status %q", finalResp.Status)
+		if finalResp.Error != nil && strings.TrimSpace(finalResp.Error.Message) != "" {
+			message = finalResp.Error.Message
+		}
+		return Response{}, NewFailure(request.ProviderKey, FailureCodeUnavailable, message, false, nil)
+	}
+
+	outputText, err := extractResponsesOutputText(request.ProviderKey, finalResp)
+	if err != nil {
+		return Response{}, err
+	}
+
+	completedAt := time.Now().UTC()
+	usage := Usage{}
+	if finalResp.Usage != nil {
+		usage = Usage{
+			InputTokens:  int64(finalResp.Usage.PromptTokens),
+			OutputTokens: int64(finalResp.Usage.CompletionTokens),
+			TotalTokens:  int64(finalResp.Usage.TotalTokens),
+		}
+	}
+
+	modelID := strings.TrimSpace(finalResp.Model)
+	if modelID == "" {
+		modelID = request.Model
+	}
+
+	return Response{
+		ProviderKey:     request.ProviderKey,
+		ProviderModelID: modelID,
+		FinishReason:    finalResp.Status,
+		OutputText:      outputText,
+		Usage:           usage,
+		Timing: Timing{
+			StartedAt:     startedAt,
+			FirstTokenAt:  startedAt,
+			CompletedAt:   completedAt,
+			TTFT:          0,
+			TotalLatency:  completedAt.Sub(startedAt),
+		},
+		RawResponse: finalRaw,
+	}, nil
+}
+
+func (c OpenAICompatibleClient) postResponses(ctx context.Context, apiKey, path string, payload []byte) (openAIResponsesResponse, json.RawMessage, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(payload))
+	if err != nil {
+		return openAIResponsesResponse{}, nil, NewFailure("openai", FailureCodeInvalidRequest, "build responses request", false, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return openAIResponsesResponse{}, nil, classifyTransportError("openai", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return openAIResponsesResponse{}, nil, NewFailure("openai", FailureCodeUnavailable, "read responses body", true, err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return openAIResponsesResponse{}, nil, normalizeOpenAIErrorResponse("openai", resp.StatusCode, resp.Header, raw)
+	}
+
+	var decoded openAIResponsesResponse
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return openAIResponsesResponse{}, nil, NewFailure("openai", FailureCodeMalformedResponse, "decode responses body", false, err)
+	}
+	return decoded, json.RawMessage(raw), nil
+}
+
+func (c OpenAICompatibleClient) getResponses(ctx context.Context, apiKey, responseID string) (openAIResponsesResponse, json.RawMessage, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/responses/"+responseID, nil)
+	if err != nil {
+		return openAIResponsesResponse{}, nil, NewFailure("openai", FailureCodeInvalidRequest, "build responses poll request", false, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return openAIResponsesResponse{}, nil, classifyTransportError("openai", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return openAIResponsesResponse{}, nil, NewFailure("openai", FailureCodeUnavailable, "read responses poll body", true, err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return openAIResponsesResponse{}, nil, normalizeOpenAIErrorResponse("openai", resp.StatusCode, resp.Header, raw)
+	}
+
+	var decoded openAIResponsesResponse
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return openAIResponsesResponse{}, nil, NewFailure("openai", FailureCodeMalformedResponse, "decode responses poll body", false, err)
+	}
+	return decoded, json.RawMessage(raw), nil
+}
+
+func (c OpenAICompatibleClient) pollResponsesUntilDone(ctx context.Context, apiKey, responseID string) (openAIResponsesResponse, json.RawMessage, error) {
+	if strings.TrimSpace(responseID) == "" {
+		return openAIResponsesResponse{}, nil, NewFailure("openai", FailureCodeMalformedResponse, "responses create response missing id", false, nil)
+	}
+
+	ticker := time.NewTicker(responsesPollInterval)
+	defer ticker.Stop()
+
+	for {
+		decoded, raw, err := c.getResponses(ctx, apiKey, responseID)
+		if err != nil {
+			return openAIResponsesResponse{}, nil, err
+		}
+		switch decoded.Status {
+		case "completed", "failed", "cancelled", "incomplete":
+			return decoded, raw, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return openAIResponsesResponse{}, nil, NewFailure("openai", FailureCodeTimeout, "responses job polling exceeded runtime budget", false, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func extractResponsesOutputText(providerKey string, response openAIResponsesResponse) (string, error) {
+	if text := strings.TrimSpace(response.OutputText); text != "" {
+		return text, nil
+	}
+	if len(response.Output) == 0 {
+		return "", NewFailure(providerKey, FailureCodeMalformedResponse, "responses output is empty", false, nil)
+	}
+
+	var items []openAIResponsesOutputItem
+	if err := json.Unmarshal(response.Output, &items); err != nil {
+		return "", NewFailure(providerKey, FailureCodeMalformedResponse, "decode responses output array", false, err)
+	}
+
+	parts := make([]string, 0, 2)
+	for _, item := range items {
+		if item.Type != "message" {
+			continue
+		}
+		for _, block := range item.Content {
+			if block.Type == "output_text" && strings.TrimSpace(block.Text) != "" {
+				parts = append(parts, block.Text)
+			}
+		}
+	}
+	if len(parts) == 0 {
+		return "", NewFailure(providerKey, FailureCodeMalformedResponse, "responses output did not contain a message", false, nil)
+	}
+	return strings.Join(parts, "\n\n"), nil
+}

--- a/backend/internal/provider/openai_responses_test.go
+++ b/backend/internal/provider/openai_responses_test.go
@@ -86,6 +86,37 @@ func TestOpenAICompatibleClientInvokeResearchUsesOutputTextField(t *testing.T) {
 	}
 }
 
+func TestOpenAICompatibleClientInvokeResearchRejectsIncompleteStatus(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return jsonResponse(http.StatusOK, `{
+				"id":"resp_inc",
+				"status":"incomplete",
+				"model":"o4-mini-deep-research",
+				"output_text":"partial answer"
+			}`), nil
+		}),
+	}
+
+	client := NewOpenAICompatibleClient(httpClient, "https://example.com/v1", staticCredentialResolver{value: "test-key"})
+	_, err := client.InvokeResearch(context.Background(), ResearchRequest{
+		ProviderKey:         "openai",
+		CredentialReference: "env://OPENAI_API_KEY",
+		Model:               "o4-mini-deep-research",
+		Input:               "hello",
+	})
+	if err == nil {
+		t.Fatal("expected error for incomplete status")
+	}
+	failure, ok := AsFailure(err)
+	if !ok || failure.Code != FailureCodeUnavailable {
+		t.Fatalf("failure = %#v, want unavailable", failure)
+	}
+	if !strings.Contains(failure.Message, "incomplete") {
+		t.Fatalf("failure message = %q, want incomplete status", failure.Message)
+	}
+}
+
 func TestRouterInvokeResearchRejectsUnsupportedProvider(t *testing.T) {
 	router := NewRouter(map[string]Client{
 		"anthropic": NewAnthropicClient(&http.Client{}, "", "", staticCredentialResolver{value: "key"}),

--- a/backend/internal/provider/openai_responses_test.go
+++ b/backend/internal/provider/openai_responses_test.go
@@ -1,0 +1,105 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOpenAICompatibleClientInvokeResearchPollsUntilCompleted(t *testing.T) {
+	pollCount := 0
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			switch {
+			case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/responses"):
+				body := `{"id":"resp_123","status":"queued","model":"o4-mini-deep-research"}`
+				return jsonResponse(http.StatusOK, body), nil
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/responses/resp_123"):
+				pollCount++
+				if pollCount < 2 {
+					return jsonResponse(http.StatusOK, `{"id":"resp_123","status":"in_progress","model":"o4-mini-deep-research"}`), nil
+				}
+				return jsonResponse(http.StatusOK, `{
+					"id":"resp_123",
+					"status":"completed",
+					"model":"o4-mini-deep-research",
+					"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"{\"answer\":\"42\"}"}]}],
+					"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}
+				}`), nil
+			default:
+				t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+				return nil, nil
+			}
+		}),
+	}
+
+	client := NewOpenAICompatibleClient(httpClient, "https://example.com/v1", staticCredentialResolver{value: "test-key"})
+	response, err := client.InvokeResearch(context.Background(), ResearchRequest{
+		ProviderKey:         "openai",
+		CredentialReference: "env://OPENAI_API_KEY",
+		Model:               "o4-mini-deep-research",
+		RunTimeout:          5 * time.Second,
+		Instructions:        "Return JSON only.",
+		Input:               "Research syllabus topics for CS224N.",
+		Background:          true,
+	})
+	if err != nil {
+		t.Fatalf("InvokeResearch returned error: %v", err)
+	}
+	if pollCount < 2 {
+		t.Fatalf("poll count = %d, want at least 2", pollCount)
+	}
+	if response.OutputText != `{"answer":"42"}` {
+		t.Fatalf("output text = %q", response.OutputText)
+	}
+	if response.Usage.TotalTokens != 30 {
+		t.Fatalf("total tokens = %d, want 30", response.Usage.TotalTokens)
+	}
+}
+
+func TestOpenAICompatibleClientInvokeResearchUsesOutputTextField(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return jsonResponse(http.StatusOK, `{
+				"id":"resp_abc",
+				"status":"completed",
+				"model":"o4-mini-deep-research",
+				"output_text":"plain final answer"
+			}`), nil
+		}),
+	}
+
+	client := NewOpenAICompatibleClient(httpClient, "https://example.com/v1", staticCredentialResolver{value: "test-key"})
+	response, err := client.InvokeResearch(context.Background(), ResearchRequest{
+		ProviderKey:         "openai",
+		CredentialReference: "env://OPENAI_API_KEY",
+		Model:               "o4-mini-deep-research",
+		Input:               "hello",
+	})
+	if err != nil {
+		t.Fatalf("InvokeResearch returned error: %v", err)
+	}
+	if response.OutputText != "plain final answer" {
+		t.Fatalf("output text = %q", response.OutputText)
+	}
+}
+
+func TestRouterInvokeResearchRejectsUnsupportedProvider(t *testing.T) {
+	router := NewRouter(map[string]Client{
+		"anthropic": NewAnthropicClient(&http.Client{}, "", "", staticCredentialResolver{value: "key"}),
+	})
+	_, err := router.InvokeResearch(context.Background(), ResearchRequest{
+		ProviderKey: "anthropic",
+		Model:       "claude-sonnet-4-6",
+		Input:       "hello",
+	})
+	if err == nil {
+		t.Fatal("expected error for unsupported provider capability")
+	}
+	failure, ok := AsFailure(err)
+	if !ok || failure.Code != FailureCodeUnsupportedCapability {
+		t.Fatalf("failure = %#v, want unsupported_capability", failure)
+	}
+}

--- a/backend/internal/provider/research.go
+++ b/backend/internal/provider/research.go
@@ -1,0 +1,54 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// ResearchRequest describes a single OpenAI Responses API / deep-research call.
+// AgentClash uses this for challenge packs with execution_mode: responses.
+type ResearchRequest struct {
+	ProviderKey         string
+	ProviderAccountID   string
+	CredentialReference string
+	Model               string
+	TraceMode           string
+	RunTimeout          time.Duration
+	Instructions        string
+	Input               string
+	OutputSchema        json.RawMessage
+	Metadata            json.RawMessage
+	Background          bool
+}
+
+type ResearchClient interface {
+	InvokeResearch(ctx context.Context, request ResearchRequest) (Response, error)
+}
+
+func (r Router) InvokeResearch(ctx context.Context, request ResearchRequest) (Response, error) {
+	adapter, ok := r.adapters[request.ProviderKey]
+	if !ok {
+		return Response{}, NewFailure(
+			request.ProviderKey,
+			FailureCodeUnsupportedProvider,
+			fmt.Sprintf("provider %q is not supported", request.ProviderKey),
+			false,
+			ErrUnsupportedProvider,
+		)
+	}
+
+	researchClient, ok := adapter.(ResearchClient)
+	if !ok {
+		return Response{}, NewFailure(
+			request.ProviderKey,
+			FailureCodeUnsupportedCapability,
+			fmt.Sprintf("provider %q does not support OpenAI Responses / deep research", request.ProviderKey),
+			false,
+			nil,
+		)
+	}
+
+	return researchClient.InvokeResearch(ctx, request)
+}

--- a/backend/internal/repository/run_agent_execution_context.go
+++ b/backend/internal/repository/run_agent_execution_context.go
@@ -240,13 +240,22 @@ func mapRunAgentExecutionContext(row repositorysqlc.GetRunAgentExecutionContextB
 			Reason:     "snapshot model catalog entry reference is missing",
 		}
 	}
-	if row.SnapshotDeploymentType != row.RuntimeProfileExecutionTarget {
+	if row.SnapshotDeploymentType == "hosted_external" {
+		if row.RuntimeProfileExecutionTarget != "hosted_external" {
+			return RunAgentExecutionContext{}, FrozenExecutionContextError{
+				RunAgentID: row.RunAgentID,
+				Reason: fmt.Sprintf(
+					"hosted deployment snapshot requires runtime execution_target=hosted_external, got %q",
+					row.RuntimeProfileExecutionTarget,
+				),
+			}
+		}
+	} else if row.RuntimeProfileExecutionTarget == "hosted_external" {
 		return RunAgentExecutionContext{}, FrozenExecutionContextError{
 			RunAgentID: row.RunAgentID,
 			Reason: fmt.Sprintf(
-				"snapshot deployment_type=%q does not match runtime execution_target=%q",
+				"runtime execution_target=hosted_external requires hosted deployment snapshot, got %q",
 				row.SnapshotDeploymentType,
-				row.RuntimeProfileExecutionTarget,
 			),
 		}
 	}

--- a/backend/internal/runevents/envelope.go
+++ b/backend/internal/runevents/envelope.go
@@ -79,6 +79,7 @@ type Source string
 const (
 	SourceNativeEngine       Source = "native_engine"
 	SourcePromptEvalEngine   Source = "prompt_eval_engine"
+	SourceResponsesEngine    Source = "responses_engine"
 	SourceMultiTurnEngine    Source = "multi_turn_engine"
 	SourceHostedExternal     Source = "hosted_external"
 	SourceHostedCallback     Source = "hosted_callback"
@@ -243,6 +244,7 @@ func isValidSource(source Source) bool {
 	switch source {
 	case SourceNativeEngine,
 		SourcePromptEvalEngine,
+		SourceResponsesEngine,
 		SourceMultiTurnEngine,
 		SourceHostedExternal,
 		SourceHostedCallback,

--- a/backend/internal/worker/buffered_observer.go
+++ b/backend/internal/worker/buffered_observer.go
@@ -308,3 +308,17 @@ func NewBufferedPromptEvalObserverFactory(recorder RunEventRecorder) PromptEvalO
 		return NewBufferedObserver(inner), nil
 	}
 }
+
+func NewBufferedResponsesObserverFactory(recorder RunEventRecorder) ResponsesObserverFactory {
+	innerFactory := NewResponsesRunEventObserverFactory(recorder)
+	return func(executionContext repository.RunAgentExecutionContext) (engine.Observer, error) {
+		inner, err := innerFactory(executionContext)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := inner.(engine.NoopObserver); ok {
+			return inner, nil
+		}
+		return NewBufferedObserver(inner), nil
+	}
+}

--- a/backend/internal/worker/responses_event_observer.go
+++ b/backend/internal/worker/responses_event_observer.go
@@ -1,0 +1,235 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/engine"
+	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/runevents"
+)
+
+type ResponsesObserverFactory func(executionContext repository.RunAgentExecutionContext) (engine.Observer, error)
+
+type ResponsesRunEventObserver struct {
+	recorder         RunEventRecorder
+	executionContext repository.RunAgentExecutionContext
+
+	mu              sync.Mutex
+	eventIDSequence int64
+	outputRecorded  bool
+
+	started    sync.Once
+	startedErr error
+}
+
+func NewResponsesRunEventObserverFactory(recorder RunEventRecorder) ResponsesObserverFactory {
+	return func(executionContext repository.RunAgentExecutionContext) (engine.Observer, error) {
+		if recorder == nil {
+			return engine.NoopObserver{}, nil
+		}
+		return &ResponsesRunEventObserver{
+			recorder:         recorder,
+			executionContext: executionContext,
+		}, nil
+	}
+}
+
+func (o *ResponsesRunEventObserver) OnStepStart(ctx context.Context, _ int) error {
+	return o.ensureRunStarted(ctx)
+}
+
+func (o *ResponsesRunEventObserver) OnProviderCall(ctx context.Context, request provider.Request) error {
+	if err := o.ensureRunStarted(ctx); err != nil {
+		return err
+	}
+	return o.recordEvent(ctx, runevents.EventTypeModelCallStarted, map[string]any{
+		"provider_key":        request.ProviderKey,
+		"provider_account_id": request.ProviderAccountID,
+		"model":               request.Model,
+		"trace_mode":          request.TraceMode,
+		"step_timeout_ms":     request.StepTimeout.Milliseconds(),
+		"message_count":       len(request.Messages),
+		"metadata":            normalizeJSON(request.Metadata),
+		"api_surface":         "responses",
+	}, runevents.SummaryMetadata{
+		Status:          "running",
+		StepIndex:       1,
+		ProviderKey:     request.ProviderKey,
+		ProviderModelID: request.Model,
+		EvidenceLevel:   runevents.EvidenceLevelNativeStructured,
+	})
+}
+
+func (o *ResponsesRunEventObserver) OnProviderOutput(context.Context, provider.Request, provider.StreamDelta) error {
+	return nil
+}
+
+func (o *ResponsesRunEventObserver) OnProviderResponse(ctx context.Context, response provider.Response) error {
+	if err := o.ensureRunStarted(ctx); err != nil {
+		return err
+	}
+	o.mu.Lock()
+	alreadyRecorded := o.outputRecorded
+	o.outputRecorded = true
+	o.mu.Unlock()
+
+	if err := o.recordEvent(ctx, runevents.EventTypeModelCallCompleted, map[string]any{
+		"provider_key":      response.ProviderKey,
+		"provider_model_id": response.ProviderModelID,
+		"finish_reason":     response.FinishReason,
+		"output_text":       response.OutputText,
+		"tool_calls":        []any{},
+		"api_surface":       "responses",
+		"usage": map[string]int64{
+			"input_tokens":  response.Usage.InputTokens,
+			"output_tokens": response.Usage.OutputTokens,
+			"total_tokens":  response.Usage.TotalTokens,
+		},
+		"timing": map[string]int64{
+			"ttft_ms":          response.Timing.TTFT.Milliseconds(),
+			"total_latency_ms": response.Timing.TotalLatency.Milliseconds(),
+		},
+		"raw_response": normalizeJSON(response.RawResponse),
+	}, runevents.SummaryMetadata{
+		Status:          "running",
+		StepIndex:       1,
+		ProviderKey:     response.ProviderKey,
+		ProviderModelID: response.ProviderModelID,
+		EvidenceLevel:   runevents.EvidenceLevelNativeStructured,
+	}); err != nil {
+		return err
+	}
+	if alreadyRecorded {
+		return nil
+	}
+	return o.recordEvent(ctx, runevents.EventTypeSystemOutputFinalized, map[string]any{
+		"final_output": response.OutputText,
+		"source":       "responses_engine",
+	}, runevents.SummaryMetadata{
+		Status:        "running",
+		StepIndex:     1,
+		EvidenceLevel: runevents.EvidenceLevelNativeStructured,
+	})
+}
+
+func (o *ResponsesRunEventObserver) OnToolExecution(context.Context, engine.ToolExecutionRecord) error {
+	return nil
+}
+
+func (o *ResponsesRunEventObserver) OnStepEnd(context.Context, int) error {
+	return nil
+}
+
+func (o *ResponsesRunEventObserver) OnPostExecutionVerification(context.Context, []engine.PostExecutionVerificationResult) error {
+	return nil
+}
+
+func (o *ResponsesRunEventObserver) OnStandingsInjected(context.Context, engine.StandingsInjection) error {
+	return nil
+}
+
+func (o *ResponsesRunEventObserver) OnRunComplete(ctx context.Context, result engine.Result) error {
+	if err := o.ensureRunStarted(ctx); err != nil {
+		return err
+	}
+	return o.recordEvent(ctx, runevents.EventTypeSystemRunCompleted, map[string]any{
+		"final_output":    result.FinalOutput,
+		"stop_reason":     result.StopReason,
+		"step_count":      result.StepCount,
+		"tool_call_count": result.ToolCallCount,
+		"input_tokens":    result.Usage.InputTokens,
+		"output_tokens":   result.Usage.OutputTokens,
+		"total_tokens":    result.Usage.TotalTokens,
+	}, runevents.SummaryMetadata{
+		Status:        "completed",
+		StepIndex:     1,
+		EvidenceLevel: runevents.EvidenceLevelNativeStructured,
+	})
+}
+
+func (o *ResponsesRunEventObserver) OnRunFailure(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if startErr := o.ensureRunStarted(ctx); startErr != nil {
+		return startErr
+	}
+
+	payload := map[string]any{
+		"error":       err.Error(),
+		"step_index":  1,
+		"stop_reason": "",
+	}
+	if failure, ok := engine.AsFailure(err); ok {
+		payload["stop_reason"] = failure.StopReason
+	}
+	if failure, ok := provider.AsFailure(err); ok {
+		payload["provider_failure"] = map[string]any{
+			"provider_key": failure.ProviderKey,
+			"code":         failure.Code,
+			"retryable":    failure.Retryable,
+			"message":      failure.Message,
+		}
+	}
+
+	return o.recordEvent(ctx, runevents.EventTypeSystemRunFailed, payload, runevents.SummaryMetadata{
+		Status:        "failed",
+		StepIndex:     1,
+		EvidenceLevel: runevents.EvidenceLevelNativeStructured,
+	})
+}
+
+func (o *ResponsesRunEventObserver) ensureRunStarted(ctx context.Context) error {
+	o.started.Do(func() {
+		o.startedErr = o.recordEvent(ctx, runevents.EventTypeSystemRunStarted, map[string]any{
+			"deployment_type":  o.executionContext.Deployment.DeploymentType,
+			"execution_mode":   "responses",
+			"execution_target": o.executionContext.Deployment.RuntimeProfile.ExecutionTarget,
+			"trace_mode":       o.executionContext.Deployment.RuntimeProfile.TraceMode,
+			"api_surface":      "responses",
+			"started_at":       time.Now().UTC(),
+		}, runevents.SummaryMetadata{
+			Status:        "running",
+			EvidenceLevel: runevents.EvidenceLevelNativeStructured,
+		})
+	})
+	return o.startedErr
+}
+
+func (o *ResponsesRunEventObserver) nextEventID(eventType runevents.Type) string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.eventIDSequence++
+	return fmt.Sprintf("responses:%s:%s:%d", o.executionContext.RunAgent.ID.String(), eventType, o.eventIDSequence)
+}
+
+func (o *ResponsesRunEventObserver) recordEvent(ctx context.Context, eventType runevents.Type, payload map[string]any, summary runevents.SummaryMetadata) error {
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal responses event payload: %w", err)
+	}
+
+	summary.IdempotencyKey = o.nextEventID(eventType)
+	_, err = o.recorder.RecordRunEvent(ctx, repository.RecordRunEventParams{
+		Event: runevents.Envelope{
+			EventID:       summary.IdempotencyKey,
+			SchemaVersion: runevents.SchemaVersionV1,
+			RunID:         o.executionContext.Run.ID,
+			RunAgentID:    o.executionContext.RunAgent.ID,
+			EventType:     eventType,
+			Source:        runevents.SourceResponsesEngine,
+			OccurredAt:    time.Now().UTC(),
+			Payload:       payloadJSON,
+			Summary:       summary,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("record responses run event: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/worker/responses_event_observer_test.go
+++ b/backend/internal/worker/responses_event_observer_test.go
@@ -1,0 +1,100 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/agentclash/agentclash/backend/internal/runevents"
+)
+
+func TestResponsesInvokerPersistsCanonicalEvents(t *testing.T) {
+	recorder := &fakeRunEventRecorder{}
+	client := &provider.FakeResearchClient{
+		FakeClient: provider.FakeClient{
+			Response: provider.Response{
+				ProviderKey:     "openai",
+				ProviderModelID: "o4-mini-deep-research",
+				FinishReason:    "completed",
+				OutputText:      `{"ok":true}`,
+				Usage:           provider.Usage{InputTokens: 10, OutputTokens: 4, TotalTokens: 14},
+			},
+		},
+	}
+
+	invoker := NewResponsesInvokerWithObserverFactory(
+		client,
+		NewResponsesRunEventObserverFactory(recorder),
+	)
+
+	if _, err := invoker.InvokeResponses(context.Background(), responsesInvokerExecutionContext()); err != nil {
+		t.Fatalf("InvokeResponses returned error: %v", err)
+	}
+
+	want := []runevents.Type{
+		runevents.EventTypeSystemRunStarted,
+		runevents.EventTypeModelCallStarted,
+		runevents.EventTypeModelCallCompleted,
+		runevents.EventTypeSystemOutputFinalized,
+		runevents.EventTypeSystemRunCompleted,
+	}
+	if len(recorder.events) != len(want) {
+		t.Fatalf("event count = %d, want %d", len(recorder.events), len(want))
+	}
+	for i, event := range recorder.events {
+		if event.EventType != want[i] {
+			t.Fatalf("event[%d] type = %q, want %q", i, event.EventType, want[i])
+		}
+		if event.Source != runevents.SourceResponsesEngine {
+			t.Fatalf("event[%d] source = %q, want responses_engine", i, event.Source)
+		}
+		if event.SequenceNumber != int64(i+1) {
+			t.Fatalf("event[%d] sequence number = %d, want %d", i, event.SequenceNumber, i+1)
+		}
+		if !json.Valid(event.Payload) {
+			t.Fatalf("event[%d] payload is not valid JSON: %s", i, event.Payload)
+		}
+	}
+
+	var completedPayload map[string]any
+	if err := json.Unmarshal(recorder.events[4].Payload, &completedPayload); err != nil {
+		t.Fatalf("unmarshal run.completed payload: %v", err)
+	}
+	if completedPayload["final_output"] != `{"ok":true}` {
+		t.Fatalf("run.completed final_output = %v", completedPayload["final_output"])
+	}
+	if totalTokens, _ := completedPayload["total_tokens"].(float64); totalTokens != 14 {
+		t.Fatalf("run.completed total_tokens = %v, want 14", completedPayload["total_tokens"])
+	}
+}
+
+func TestResponsesInvokerRecordsRunFailedOnProviderError(t *testing.T) {
+	recorder := &fakeRunEventRecorder{}
+	client := &provider.FakeResearchClient{
+		FakeClient: provider.FakeClient{
+			Err: provider.NewFailure("openai", provider.FailureCodeAuth, "bad key", false, nil),
+		},
+	}
+
+	invoker := NewResponsesInvokerWithObserverFactory(
+		client,
+		NewResponsesRunEventObserverFactory(recorder),
+	)
+
+	if _, err := invoker.InvokeResponses(context.Background(), responsesInvokerExecutionContext()); err == nil {
+		t.Fatal("expected error")
+	}
+
+	var sawFailed bool
+	types := make([]runevents.Type, 0, len(recorder.events))
+	for _, event := range recorder.events {
+		types = append(types, event.EventType)
+		if event.EventType == runevents.EventTypeSystemRunFailed {
+			sawFailed = true
+		}
+	}
+	if !sawFailed {
+		t.Fatalf("expected system.run.failed event; got sequence %v", types)
+	}
+}

--- a/backend/internal/worker/responses_invoker.go
+++ b/backend/internal/worker/responses_invoker.go
@@ -1,0 +1,50 @@
+package worker
+
+import (
+	"context"
+
+	"github.com/agentclash/agentclash/backend/internal/engine"
+	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+)
+
+type ResponsesInvoker struct {
+	researchClient    provider.ResearchClient
+	observerFactory   ResponsesObserverFactory
+	secretsLookup     engine.SecretsLookup
+}
+
+func NewResponsesInvoker(researchClient provider.ResearchClient) ResponsesInvoker {
+	return NewResponsesInvokerWithObserverFactory(researchClient, nil)
+}
+
+func NewResponsesInvokerWithObserverFactory(researchClient provider.ResearchClient, observerFactory ResponsesObserverFactory) ResponsesInvoker {
+	return ResponsesInvoker{
+		researchClient:  researchClient,
+		observerFactory: observerFactory,
+	}
+}
+
+func (i ResponsesInvoker) WithSecretsLookup(lookup engine.SecretsLookup) ResponsesInvoker {
+	i.secretsLookup = lookup
+	return i
+}
+
+func (i ResponsesInvoker) InvokeResponses(ctx context.Context, executionContext repository.RunAgentExecutionContext) (engine.Result, error) {
+	observer := engine.Observer(engine.NoopObserver{})
+	if i.observerFactory != nil {
+		builtObserver, err := i.observerFactory(executionContext)
+		if err != nil {
+			return engine.Result{}, err
+		}
+		if builtObserver != nil {
+			observer = builtObserver
+		}
+	}
+
+	executor := engine.NewResponsesExecutor(i.researchClient, observer)
+	if i.secretsLookup != nil {
+		executor = executor.WithSecretsLookup(i.secretsLookup)
+	}
+	return executor.Execute(ctx, executionContext)
+}

--- a/backend/internal/worker/responses_invoker.go
+++ b/backend/internal/worker/responses_invoker.go
@@ -6,12 +6,15 @@ import (
 	"github.com/agentclash/agentclash/backend/internal/engine"
 	"github.com/agentclash/agentclash/backend/internal/provider"
 	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/sandbox"
 )
 
 type ResponsesInvoker struct {
-	researchClient    provider.ResearchClient
-	observerFactory   ResponsesObserverFactory
-	secretsLookup     engine.SecretsLookup
+	researchClient  provider.ResearchClient
+	sandboxProvider sandbox.Provider
+	observerFactory ResponsesObserverFactory
+	secretsLookup   engine.SecretsLookup
+	assetLoader     engine.AssetLoader
 }
 
 func NewResponsesInvoker(researchClient provider.ResearchClient) ResponsesInvoker {
@@ -23,6 +26,16 @@ func NewResponsesInvokerWithObserverFactory(researchClient provider.ResearchClie
 		researchClient:  researchClient,
 		observerFactory: observerFactory,
 	}
+}
+
+func (i ResponsesInvoker) WithSandboxProvider(provider sandbox.Provider) ResponsesInvoker {
+	i.sandboxProvider = provider
+	return i
+}
+
+func (i ResponsesInvoker) WithAssetLoader(loader engine.AssetLoader) ResponsesInvoker {
+	i.assetLoader = loader
+	return i
 }
 
 func (i ResponsesInvoker) WithSecretsLookup(lookup engine.SecretsLookup) ResponsesInvoker {
@@ -43,6 +56,12 @@ func (i ResponsesInvoker) InvokeResponses(ctx context.Context, executionContext 
 	}
 
 	executor := engine.NewResponsesExecutor(i.researchClient, observer)
+	if i.sandboxProvider != nil {
+		executor = executor.WithSandboxProvider(i.sandboxProvider)
+	}
+	if i.assetLoader != nil {
+		executor = executor.WithAssetLoader(i.assetLoader)
+	}
 	if i.secretsLookup != nil {
 		executor = executor.WithSecretsLookup(i.secretsLookup)
 	}

--- a/backend/internal/worker/responses_invoker_test.go
+++ b/backend/internal/worker/responses_invoker_test.go
@@ -1,0 +1,108 @@
+package worker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/challengepack"
+	"github.com/agentclash/agentclash/backend/internal/domain"
+	"github.com/agentclash/agentclash/backend/internal/engine"
+	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+func TestResponsesInvokerDelegatesToEngine(t *testing.T) {
+	client := &provider.FakeResearchClient{
+		FakeClient: provider.FakeClient{
+			Response: provider.Response{
+				ProviderKey:     "openai",
+				ProviderModelID: "o4-mini-deep-research",
+				FinishReason:    "completed",
+				OutputText:      `{"ok":true}`,
+				Usage:           provider.Usage{InputTokens: 10, OutputTokens: 4, TotalTokens: 14},
+			},
+		},
+	}
+	invoker := NewResponsesInvoker(client)
+	result, err := invoker.InvokeResponses(context.Background(), responsesInvokerExecutionContext())
+	if err != nil {
+		t.Fatalf("InvokeResponses returned error: %v", err)
+	}
+	if result.StopReason != engine.StopReasonCompleted {
+		t.Fatalf("stop reason = %s, want completed", result.StopReason)
+	}
+	if result.FinalOutput != `{"ok":true}` {
+		t.Fatalf("final output = %q", result.FinalOutput)
+	}
+	if len(client.ResearchRequests) != 1 {
+		t.Fatalf("research requests = %d, want 1", len(client.ResearchRequests))
+	}
+	if !client.ResearchRequests[0].Background {
+		t.Fatalf("expected background research request")
+	}
+}
+
+func responsesInvokerExecutionContext() repository.RunAgentExecutionContext {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+
+	return repository.RunAgentExecutionContext{
+		Run:      domain.Run{ID: runID},
+		RunAgent: domain.RunAgent{ID: runAgentID, RunID: runID, Status: domain.RunAgentStatusQueued, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()},
+		ChallengePackVersion: repository.ChallengePackVersionExecutionContext{
+			ID:       uuid.New(),
+			Manifest: []byte(`{"version":{"execution_mode":"responses"}}`),
+			Challenges: []repository.ChallengeDefinitionExecutionContext{
+				{
+					ID:           uuid.New(),
+					ChallengeKey: "translate",
+					Title:        "Translate",
+					Definition:   []byte(`{"instructions":"Translate {{text}} to French."}`),
+				},
+			},
+		},
+		ChallengeInputSet: &repository.ChallengeInputSetExecutionContext{
+			ID:       uuid.New(),
+			InputKey: "default",
+			Name:     "Default",
+			Cases: []repository.ChallengeCaseExecutionContext{
+				{
+					ID:           uuid.New(),
+					ChallengeKey: "translate",
+					CaseKey:      "hello",
+					Inputs: []challengepack.CaseInput{
+						{Key: "text", Kind: "text", Value: "hello"},
+					},
+				},
+			},
+		},
+		Deployment: repository.AgentDeploymentExecutionContext{
+			DeploymentType: "native",
+			SnapshotConfig: []byte(`{}`),
+			AgentBuildVersion: repository.AgentBuildVersionExecutionContext{
+				ID:         uuid.New(),
+				AgentKind:  "llm_agent",
+				AgentSpec:  []byte(`{}`),
+				PolicySpec: []byte(`{}`),
+			},
+			RuntimeProfile: repository.RuntimeProfileExecutionContext{
+				ExecutionTarget:   "responses",
+				TraceMode:         "preferred",
+				RunTimeoutSeconds: 900,
+				ProfileConfig:     []byte(`{}`),
+			},
+			ProviderAccount: &repository.ProviderAccountExecutionContext{
+				ID:                  uuid.New(),
+				ProviderKey:         "openai",
+				CredentialReference: "env://OPENAI_API_KEY",
+			},
+			ModelAlias: &repository.ModelAliasExecutionContext{
+				ModelCatalogEntry: repository.ModelCatalogEntryExecutionContext{
+					ProviderModelID: "o4-mini-deep-research",
+				},
+			},
+		},
+	}
+}

--- a/backend/internal/workflow/activities.go
+++ b/backend/internal/workflow/activities.go
@@ -34,6 +34,7 @@ const (
 	markHostedRunTimedOutActivityName                 = "workflow.mark_hosted_run_timed_out"
 	executeNativeModelStepActivityName                = "workflow.execute_native_model_step"
 	executePromptEvalStepActivityName                 = "workflow.execute_prompt_eval_step"
+	executeResponsesStepActivityName                  = "workflow.execute_responses_step"
 	executeMultiTurnStepActivityName                  = "workflow.execute_multi_turn_step"
 	finalizeMultiTurnPostRunActivityName              = "workflow.finalize_multi_turn_post_run"
 	scoreRunAgentActivityName                         = "workflow.score_run_agent"
@@ -67,7 +68,12 @@ type FakeWorkHooks struct {
 	HostedRunStarter     HostedRunStarter
 	NativeModelInvoker   NativeModelInvoker
 	PromptEvalInvoker    PromptEvalInvoker
+	ResponsesInvoker     ResponsesInvoker
 	MultiTurnInvoker     MultiTurnInvoker
+}
+
+type ResponsesInvoker interface {
+	InvokeResponses(ctx context.Context, executionContext repository.RunAgentExecutionContext) (engine.Result, error)
 }
 
 type NativeModelInvoker interface {
@@ -431,6 +437,24 @@ func (a *Activities) ExecutePromptEvalStep(ctx context.Context, input RunAgentWo
 	}
 
 	_, err = a.hooks.PromptEvalInvoker.InvokePromptEval(ctx, executionContext)
+	return wrapActivityError(err)
+}
+
+func (a *Activities) ExecuteResponsesStep(ctx context.Context, input RunAgentWorkflowInput) error {
+	if a.hooks.ResponsesInvoker == nil {
+		return temporal.NewNonRetryableApplicationError(
+			"responses invoker not configured",
+			"workflow.responses_invoker_missing",
+			nil,
+		)
+	}
+
+	executionContext, err := a.repo.GetRunAgentExecutionContextByID(ctx, input.RunAgentID)
+	if err != nil {
+		return wrapActivityError(err)
+	}
+
+	_, err = a.hooks.ResponsesInvoker.InvokeResponses(ctx, executionContext)
 	return wrapActivityError(err)
 }
 

--- a/backend/internal/workflow/activities_test.go
+++ b/backend/internal/workflow/activities_test.go
@@ -631,6 +631,60 @@ func TestExecutePromptEvalStep(t *testing.T) {
 	})
 }
 
+func TestExecuteResponsesStep(t *testing.T) {
+	t.Run("nil invoker returns non-retryable error", func(t *testing.T) {
+		runID := uuid.New()
+		runAgentID := uuid.New()
+		repo := newFakeRunRepository(
+			fixtureRun(runID, domain.RunStatusRunning),
+			fixtureRunAgent(runID, runAgentID, 0),
+		)
+		activities := NewActivities(repo, FakeWorkHooks{})
+
+		err := activities.ExecuteResponsesStep(context.Background(), RunAgentWorkflowInput{
+			RunID:      runID,
+			RunAgentID: runAgentID,
+		})
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		var appErr *temporal.ApplicationError
+		if !errors.As(err, &appErr) {
+			t.Fatalf("expected ApplicationError, got %T", err)
+		}
+		if !appErr.NonRetryable() {
+			t.Fatalf("nil invoker error should be non-retryable")
+		}
+		if appErr.Type() != "workflow.responses_invoker_missing" {
+			t.Fatalf("type = %q, want workflow.responses_invoker_missing", appErr.Type())
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		runID := uuid.New()
+		runAgentID := uuid.New()
+		repo := newFakeRunRepository(
+			fixtureRun(runID, domain.RunStatusRunning),
+			fixtureRunAgent(runID, runAgentID, 0),
+		)
+		repo.setExecutionContext(runAgentID, nativeExecutionContext(runID, runAgentID))
+
+		activities := NewActivities(repo, FakeWorkHooks{
+			ResponsesInvoker: &fakeResponsesInvoker{
+				result: engine.Result{FinalOutput: `{"ok":true}`, StopReason: engine.StopReasonCompleted},
+			},
+		})
+
+		err := activities.ExecuteResponsesStep(context.Background(), RunAgentWorkflowInput{
+			RunID:      runID,
+			RunAgentID: runAgentID,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
 func TestPrepareExecutionLane(t *testing.T) {
 	input := RunAgentWorkflowInput{RunID: uuid.New(), RunAgentID: uuid.New()}
 
@@ -866,6 +920,18 @@ type fakePromptEvalInvoker struct {
 }
 
 func (f *fakePromptEvalInvoker) InvokePromptEval(_ context.Context, _ repository.RunAgentExecutionContext) (engine.Result, error) {
+	if f.err != nil {
+		return engine.Result{}, f.err
+	}
+	return f.result, nil
+}
+
+type fakeResponsesInvoker struct {
+	result engine.Result
+	err    error
+}
+
+func (f *fakeResponsesInvoker) InvokeResponses(_ context.Context, _ repository.RunAgentExecutionContext) (engine.Result, error) {
 	if f.err != nil {
 		return engine.Result{}, f.err
 	}

--- a/backend/internal/workflow/execution_mode_test.go
+++ b/backend/internal/workflow/execution_mode_test.go
@@ -11,6 +11,7 @@ func TestExecutionModeFromManifest(t *testing.T) {
 		{"empty", "", ""},
 		{"native default", `{"version":{"number":1}}`, ""},
 		{"prompt_eval", `{"version":{"execution_mode":"prompt_eval"}}`, "prompt_eval"},
+		{"responses", `{"version":{"execution_mode":"responses"}}`, "responses"},
 		{"native explicit", `{"version":{"execution_mode":"native"}}`, "native"},
 		{"invalid json", `not json`, ""},
 		{"trimmed", `{"version":{"execution_mode":"  prompt_eval  "}}`, "prompt_eval"},

--- a/backend/internal/workflow/register.go
+++ b/backend/internal/workflow/register.go
@@ -31,6 +31,7 @@ func Register(registrar Registrar, activities *Activities) {
 	registrar.RegisterActivityWithOptions(activities.MarkHostedRunTimedOut, sdkactivity.RegisterOptions{Name: markHostedRunTimedOutActivityName})
 	registrar.RegisterActivityWithOptions(activities.ExecuteNativeModelStep, sdkactivity.RegisterOptions{Name: executeNativeModelStepActivityName})
 	registrar.RegisterActivityWithOptions(activities.ExecutePromptEvalStep, sdkactivity.RegisterOptions{Name: executePromptEvalStepActivityName})
+	registrar.RegisterActivityWithOptions(activities.ExecuteResponsesStep, sdkactivity.RegisterOptions{Name: executeResponsesStepActivityName})
 	registrar.RegisterActivityWithOptions(activities.ExecuteMultiTurnStep, sdkactivity.RegisterOptions{Name: executeMultiTurnStepActivityName})
 	registrar.RegisterActivityWithOptions(activities.FinalizeMultiTurnPostRun, sdkactivity.RegisterOptions{Name: finalizeMultiTurnPostRunActivityName})
 	registrar.RegisterActivityWithOptions(activities.ScoreRunAgent, sdkactivity.RegisterOptions{Name: scoreRunAgentActivityName})

--- a/backend/internal/workflow/run_agent_workflow.go
+++ b/backend/internal/workflow/run_agent_workflow.go
@@ -66,6 +66,10 @@ func runAgentWorkflow(ctx sdkworkflow.Context, input RunAgentWorkflowInput) erro
 		return runPromptEvalRunAgent(ctx, input, executionContext)
 	}
 
+	if executionModeFromManifest(executionContext.ChallengePackVersion.Manifest) == challengepack.ExecutionModeResponses {
+		return runResponsesRunAgent(ctx, input, executionContext)
+	}
+
 	if executionModeFromManifest(executionContext.ChallengePackVersion.Manifest) == challengepack.ExecutionModeMultiTurn {
 		return runMultiTurnRunAgent(ctx, input, executionContext)
 	}
@@ -97,6 +101,20 @@ func runPromptEvalRunAgent(ctx sdkworkflow.Context, input RunAgentWorkflowInput,
 	return nil
 }
 
+func runResponsesRunAgent(ctx sdkworkflow.Context, input RunAgentWorkflowInput, executionContext repository.RunAgentExecutionContext) error {
+	if err := transitionRunAgentStatus(ctx, input.RunAgentID, domain.RunAgentStatusExecuting, stringPtr("responses execution started"), nil); err != nil {
+		return err
+	}
+	if err := executeResponsesStep(ctx, input, executionContext).Get(ctx, nil); err != nil {
+		return err
+	}
+	if err := transitionRunAgentStatus(ctx, input.RunAgentID, domain.RunAgentStatusEvaluating, stringPtr("responses execution completed; parent scoring pending"), nil); err != nil {
+		return err
+	}
+	warnOnReplayBuildFailure(ctx, input.RunAgentID, "successful responses execution")
+	return nil
+}
+
 func runMultiTurnRunAgent(ctx sdkworkflow.Context, input RunAgentWorkflowInput, executionContext repository.RunAgentExecutionContext) error {
 	if err := transitionRunAgentStatus(ctx, input.RunAgentID, domain.RunAgentStatusExecuting, stringPtr("multi_turn execution started"), nil); err != nil {
 		return err
@@ -123,6 +141,14 @@ func executePromptEvalStep(ctx sdkworkflow.Context, input RunAgentWorkflowInput,
 	return sdkworkflow.ExecuteActivity(
 		sdkworkflow.WithActivityOptions(ctx, nativeModelActivityOptions(executionContext)),
 		executePromptEvalStepActivityName,
+		input,
+	)
+}
+
+func executeResponsesStep(ctx sdkworkflow.Context, input RunAgentWorkflowInput, executionContext repository.RunAgentExecutionContext) sdkworkflow.Future {
+	return sdkworkflow.ExecuteActivity(
+		sdkworkflow.WithActivityOptions(ctx, nativeModelActivityOptions(executionContext)),
+		executeResponsesStepActivityName,
 		input,
 	)
 }

--- a/backend/internal/workflow/workflow_test.go
+++ b/backend/internal/workflow/workflow_test.go
@@ -874,6 +874,36 @@ func TestExecutePromptEvalStepFailsWhenInvokerNotConfigured(t *testing.T) {
 	}
 }
 
+func TestExecuteResponsesStepFailsWhenInvokerNotConfigured(t *testing.T) {
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	repo := newFakeRunRepository(
+		fixtureRun(runID, domain.RunStatusRunning),
+		fixtureRunAgent(runID, runAgentID, 0),
+	)
+
+	activities := NewActivities(repo, FakeWorkHooks{})
+
+	err := activities.ExecuteResponsesStep(context.Background(), RunAgentWorkflowInput{
+		RunID:      runID,
+		RunAgentID: runAgentID,
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	var appErr *temporal.ApplicationError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected temporal application error, got %T", err)
+	}
+	if !appErr.NonRetryable() {
+		t.Fatalf("application error should be non-retryable, got %v", appErr)
+	}
+	if appErr.Type() != "workflow.responses_invoker_missing" {
+		t.Fatalf("application error type = %q, want workflow.responses_invoker_missing", appErr.Type())
+	}
+}
+
 func TestExecuteNativeModelStepWrapsNonRetryableProviderFailures(t *testing.T) {
 	runAgentID := uuid.New()
 	executionContext := nativeExecutionContext(uuid.New(), runAgentID)

--- a/cli/cmd/challenge_pack.go
+++ b/cli/cmd/challenge_pack.go
@@ -21,7 +21,7 @@ func init() {
 	challengePackCmd.AddCommand(cpPublishCmd)
 	challengePackCmd.AddCommand(cpValidateCmd)
 
-	cpInitCmd.Flags().String("template", "prompt_eval", "Starter template: prompt_eval or native")
+	cpInitCmd.Flags().String("template", "prompt_eval", "Starter template: prompt_eval, responses, or native")
 	cpInitCmd.Flags().String("name", "", "Challenge pack display name (defaults from the file name)")
 	cpInitCmd.Flags().String("slug", "", "Challenge pack slug (defaults from the file name)")
 	cpInitCmd.Flags().Bool("force", false, "Overwrite an existing file")
@@ -100,9 +100,9 @@ var cpInitCmd = &cobra.Command{
 
 		templateMode = strings.TrimSpace(templateMode)
 		switch templateMode {
-		case "prompt_eval", "native":
+		case "prompt_eval", "responses", "native":
 		default:
-			return fmt.Errorf("invalid template %q (want prompt_eval or native)", templateMode)
+			return fmt.Errorf("invalid template %q (want prompt_eval, responses, or native)", templateMode)
 		}
 
 		defaultName := defaultChallengePackName(targetPath)
@@ -142,6 +142,9 @@ var cpInitCmd = &cobra.Command{
 		rc.Output.PrintDetail("Template", templateMode)
 		if templateMode == "prompt_eval" {
 			rc.Output.PrintWarning("challenge-pack prompt_eval scaffolds challenge packs; for prompt eval CI configs, use `agentclash prompt-eval init .agentclash/prompt-eval.yaml`.")
+		}
+		if templateMode == "responses" {
+			rc.Output.PrintWarning("responses packs use OpenAI /v1/responses (deep research). Pair with a runtime profile whose execution_target is responses and an OpenAI provider account.")
 		}
 		return nil
 	},

--- a/cli/cmd/challenge_pack_init_test.go
+++ b/cli/cmd/challenge_pack_init_test.go
@@ -36,6 +36,34 @@ func TestChallengePackInitWritesStarterTemplate(t *testing.T) {
 	}
 }
 
+func TestChallengePackInitWritesResponsesTemplate(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "deep-research.yaml")
+
+	if err := executeCommand(t, []string{
+		"challenge-pack", "init", target,
+		"--template", "responses",
+		"--name", "Deep Research Eval",
+	}, "http://unused"); err != nil {
+		t.Fatalf("challenge-pack init error: %v", err)
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+
+	text := string(data)
+	for _, snippet := range []string{
+		"slug: deep-research-eval",
+		"name: Deep Research Eval",
+		"execution_mode: responses",
+	} {
+		if !strings.Contains(text, snippet) {
+			t.Fatalf("challenge-pack init output missing %q\n---\n%s", snippet, text)
+		}
+	}
+}
+
 func TestChallengePackInitRequiresForceToOverwrite(t *testing.T) {
 	target := filepath.Join(t.TempDir(), "support-eval.yaml")
 	if err := os.WriteFile(target, []byte("existing"), 0o644); err != nil {

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -6478,6 +6478,7 @@ components:
           type: string
         execution_target:
           type: string
+          enum: [native, hosted_external, prompt_eval, responses, multi_turn]
         trace_mode:
           type: string
         max_iterations:
@@ -6512,6 +6513,7 @@ components:
           type: string
         execution_target:
           type: string
+          enum: [native, hosted_external, prompt_eval, responses, multi_turn]
         trace_mode:
           type: string
         max_iterations:

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runtime-profiles/runtime-profiles-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runtime-profiles/runtime-profiles-client.tsx
@@ -39,6 +39,9 @@ export function RuntimeProfilesClient({ workspaceId }: { workspaceId: string }) 
               options: [
                 { value: "native", label: "Native" },
                 { value: "hosted_external", label: "Hosted External" },
+                { value: "prompt_eval", label: "Prompt Eval" },
+                { value: "responses", label: "OpenAI Responses" },
+                { value: "multi_turn", label: "Multi Turn" },
               ],
             },
             { key: "max_iterations", label: "Max Iterations", type: "number", placeholder: "1" },


### PR DESCRIPTION
## Summary

Adds **`execution_mode: responses`** as a first-class execution path for challenge packs that need OpenAI `/v1/responses` (deep-research models such as `o4-mini-deep-research`). These models reject Chat Completions with *"This model is only supported in v1/responses..."*.

This PR routes those packs through a dedicated executor → worker invoker → Temporal activity, with optional E2B sandbox staging when the manifest declares `sandbox` or `tool_policy`.

Also extends runtime profile **`execution_target`** with `prompt_eval`, `responses`, and `multi_turn` (migration + OpenAPI + UI).

### CLI changes

- `agentclash challenge-pack init --template responses` scaffolds a responses-mode starter pack
- `--template` help text documents `prompt_eval | responses | native`
- Warning when initializing a responses template: pair with runtime profile `execution_target: responses` and an OpenAI provider account
- Test: `TestChallengePackInitWritesResponsesTemplate`

### UI changes

- Runtime profile create dialog includes `prompt_eval`, `responses`, and `multi_turn` execution targets

---

## How it works

```mermaid
flowchart TD
  subgraph pack["Challenge pack"]
    A["execution_mode: responses"]
    B["Optional sandbox / tool_policy in manifest"]
  end

  subgraph control["Control plane"]
    C["Run created with runtime profile\nexecution_target = responses"]
  end

  subgraph temporal["Temporal worker"]
    D["RunAgentWorkflow"]
    E["ExecuteResponsesStep activity"]
    F["ResponsesExecutor"]
    G{"Manifest has\nsandbox or tool_policy?"}
    H["prepareRunSandbox → E2B\n(stage artifact-backed assets)"]
    I["ResponsesInvoker"]
  end

  subgraph openai["OpenAI"]
    J["POST /v1/responses\nbackground=true, web_search_preview"]
    K["Poll until completed / failed / cancelled / incomplete"]
  end

  subgraph scoring["Scoring"]
    L["Run events\nsource=responses_engine\napi_surface=responses"]
    M["Existing scoring pipeline"]
  end

  A --> C --> D --> E --> F --> G
  G -->|yes| H --> I
  G -->|no| I
  I --> J --> K --> L --> M
  B -.-> G
```

### Why a separate mode (not native chat)

| Concern | Native loop | `responses` mode |
|--------|-------------|------------------|
| API surface | Chat Completions + tool loop | Single `/v1/responses` call with built-in `web_search_preview` |
| Deep-research models | Fail on Completions | Supported |
| Tool policy | Pack-defined tools in loop | No pack tool loop; OpenAI built-in search only |
| Sandbox | Always available in native | Optional — provisioned when manifest declares sandbox/tool_policy |
| Timeouts | Shorter turn budget | Longer research timeout + background polling |

`prompt_eval` remains the no-sandbox, no-tools, single-shot path. **`responses`** is the deep-research path that can still use E2B when the pack needs staged assets.

---

## Greptile review — addressed

| Issue | Fix |
|-------|-----|
| P2: dead `background` variable always forced true | Request body sets `Background: true` directly |
| P2: `incomplete` treated as success | `incomplete` now fails with non-retryable `FailureCodeUnavailable` (poll + invoke) |
| P3: struct formatting | `gofmt` on `openAIResponsesCreateRequest` |
| — | Added `TestOpenAICompatibleClientInvokeResearchRejectsIncompleteStatus` |

---

## Test status

### Automated (run locally on this branch)

| Suite | Command | Result |
|-------|---------|--------|
| Backend | `cd backend && go test -short -race -count=1 ./...` | ✅ pass |
| CLI | `cd cli && go test -short -race -count=1 ./...` | ✅ pass |

**New / touched test files:**

- `backend/internal/provider/openai_responses_test.go` — polling, output extraction, incomplete/failed status, unsupported provider
- `backend/internal/engine/responses_executor_test.go` — single research call, non-OpenAI rejection, E2B when sandbox in manifest
- `backend/internal/worker/responses_invoker_test.go`, `responses_event_observer_test.go`
- `backend/internal/workflow/execution_mode_test.go`, activities/workflow tests
- `backend/internal/challengepack/bundle_test.go` — responses + sandbox allowed; pack-level tools rejected
- `cli/cmd/challenge_pack_init_test.go` — responses template scaffold

### Live smoke test (real OpenAI key)

**Not run in CI or during PR prep** — `OPENAI_API_KEY` was not available in the dev environment.

Recommended manual smoke after merge + migration:

1. Apply migration `00048_runtime_execution_targets.sql`
2. Create runtime profile with `execution_target: responses` + OpenAI credential
3. `agentclash challenge-pack init --template responses` (or use an existing responses pack)
4. `agentclash run create --follow` with model `o4-mini-deep-research` (or similar)
5. Confirm run events show `api_surface: responses` and final output is scored

---

## Test plan

- [x] Backend unit/integration tests (`go test -short -race -count=1 ./...`)
- [x] CLI tests including responses template init
- [x] Greptile review items fixed and pushed
- [ ] Manual live run against OpenAI deep-research model (requires API key + deployed migration)