### PR TITLE
fix(engine): give multi_turn LLM simulator the secret-injected ctx

### DIFF
--- a/backend/internal/engine/multi_turn_executor.go
+++ b/backend/internal/engine/multi_turn_executor.go
@@ -269,8 +269,15 @@ func (e MultiTurnExecutor) runLLMPhase(
 	}
 	phaseTurns := 0
 
+	// The simulator issues its own provider call (separate from the agent
+	// loop in conversation.RunTurn) and therefore needs the conversation's
+	// run context — which has workspace secrets injected. The outer ctx
+	// here does NOT carry those secrets, so passing it would cause
+	// workspace-secret:// credential references to fail to resolve.
+	simulatorCtx := conversation.Context()
+
 	for phaseTurns < phaseMax && state.turnIndex < maxTurns {
-		message, metadata, err := e.simulator.GenerateUserMessage(ctx, simulator.Input{
+		message, metadata, err := e.simulator.GenerateUserMessage(simulatorCtx, simulator.Input{
 			Persona:           phase.Persona,
 			Transcript:        append([]simulator.TranscriptTurn(nil), state.transcript...),
 			CasePayload:       casePayloadMap(executionContext),

--- a/backend/internal/engine/native_conversation.go
+++ b/backend/internal/engine/native_conversation.go
@@ -145,6 +145,16 @@ func (e NativeExecutor) BeginConversation(ctx context.Context, executionContext 
 	return conversation, cleanup, nil
 }
 
+// Context returns the run context that BeginConversation prepared for this
+// conversation. The returned context already has workspace secrets injected
+// (see provider.WithWorkspaceSecrets) and any run-level timeout applied. Use
+// it whenever you need to invoke a provider on behalf of this conversation
+// from outside RunTurn — notably the multi_turn user simulator, which lives
+// alongside the conversation but issues its own provider calls.
+func (c *NativeConversation) Context() context.Context {
+	return c.runCtx
+}
+
 func (c *NativeConversation) RunTurn(_ context.Context, userMessage string) (TurnResult, error) {
 	if strings.TrimSpace(userMessage) == "" {
 		return TurnResult{}, provider.NewFailure(

--- a/backend/internal/engine/native_conversation_context_test.go
+++ b/backend/internal/engine/native_conversation_context_test.go
@@ -1,0 +1,36 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/provider"
+)
+
+// TestNativeConversationContext_ExposesRunCtxForSimulator guards the contract
+// that NativeConversation.Context() returns the run context prepared by
+// BeginConversation — which has workspace secrets injected. The multi_turn
+// executor's LLM user-simulator depends on this; without it, the simulator's
+// own provider.InvokeModel call fails with
+// `workspace secrets not available for "workspace-secret://..."`.
+func TestNativeConversationContext_ExposesRunCtxForSimulator(t *testing.T) {
+	secrets := map[string]string{"PROVIDER_FOO_API_KEY": "sk-test-value"}
+	runCtx := provider.WithWorkspaceSecrets(context.Background(), secrets)
+
+	c := &NativeConversation{runCtx: runCtx}
+
+	resolver := provider.EnvCredentialResolver{}
+	got, err := resolver.Resolve(c.Context(), "workspace-secret://PROVIDER_FOO_API_KEY")
+	if err != nil {
+		t.Fatalf("resolver.Resolve via Context() should find the injected workspace secret, got err=%v", err)
+	}
+	if got != "sk-test-value" {
+		t.Fatalf("resolver returned wrong value via Context(); got=%q want=%q", got, "sk-test-value")
+	}
+
+	// Sanity check the inverse: a fresh background context must NOT resolve
+	// the secret, ensuring the test isn't passing for the wrong reason.
+	if _, err := resolver.Resolve(context.Background(), "workspace-secret://PROVIDER_FOO_API_KEY"); err == nil {
+		t.Fatal("background context should not resolve workspace-secret references; the test is not asserting anything meaningful")
+	}
+}


### PR DESCRIPTION
## Summary

The multi-turn user-simulator's **LLM phase** invokes a provider on its own (`simulator.GenerateUserMessage` → `provider.Client.InvokeModel`), independent of the agent's `conversation.RunTurn`. Today that call receives the **outer ctx** which has not had workspace secrets injected, so any deployment whose credential reference is `workspace-secret://...` fails immediately with:

```
activity error (type: workflow.execute_multi_turn_step, ...):
  generate llm user message (type: engine.simulator_error, retryable: false):
    workspace secrets not available for "workspace-secret://PROVIDER_OPENAI_API_KEY"
```

`NativeConversation.BeginConversation` already loads workspace secrets and injects them via `provider.WithWorkspaceSecrets` into a local `runCtx` ([`native_conversation.go:75`](https://github.com/agentclash/agentclash/blob/main/backend/internal/engine/native_conversation.go#L75)) — but that ctx never escapes the conversation object, so the simulator can't reach it. The single-turn `ResponsesExecutor` and `NativeExecutor` don't hit this because they use that same `runCtx` for their own `InvokeModel` calls.

## Fix

- Expose `NativeConversation.Context()` returning the secret-injected `runCtx`.
- In `MultiTurnExecutor.runLLMPhase`, pass `conversation.Context()` to `e.simulator.GenerateUserMessage` instead of the bare outer ctx.

Scripted and human phases are unaffected — they don't issue provider calls.

### Trace of the bug

| File:line | What happens today |
|---|---|
| `engine/native_conversation.go:65-75` | Loads workspace secrets, injects via `provider.WithWorkspaceSecrets(ctx, ...)` into a **local** `runCtx` — never returned to the caller |
| `engine/multi_turn_executor.go:138` | `runHybridConversation(ctx, ...)` continues with the **outer** `ctx` (no secrets) |
| `engine/multi_turn_executor.go:273` | `simulator.GenerateUserMessage(ctx, ...)` — passes that secret-less ctx down |
| `simulator/generator.go:83` | `client.InvokeModel(callCtx, request)` → resolver hits `workspaceSecretsFromContext(ctx) == nil` |
| `provider/env_resolver.go:54-58` | Returns `"workspace secrets not available for %q"` |

## Reproducer

Any `multi_turn` pack that uses `actor: llm` with a deployment bound to a `workspace-secret://` credential reference. For instance:

- `examples/challenge-packs/multi-turn-refund-recovery.yaml` against any deployment with `CredentialReference: workspace-secret://PROVIDER_OPENAI_API_KEY`
- Repro'd in workspace 511e2d3e-9076-4db3-b9f2-5ef54ab591d5 on run `db8e17fb-5dad-4d79-b315-40f3cd7bfb07` (and again on `0ac9a9c4-...`).

## Test plan

- [x] `cd backend && go build ./...` — green
- [x] `cd backend && go test -short -race -count=1 ./internal/engine/...` — 4.149s, all green
- [x] New unit test `TestNativeConversationContext_ExposesRunCtxForSimulator` covers the contract:
  - `Context()` returns a ctx from which `EnvCredentialResolver.Resolve("workspace-secret://...")` succeeds when secrets are injected
  - Inverse check on `context.Background()` to ensure the test asserts something meaningful
- [ ] Manual: re-run a multi-turn eval with an `actor: llm` phase against a workspace-secret-bound deployment. Without this PR: `engine.simulator_error`. With this PR: simulator generates user messages and the conversation progresses to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)