### PR TITLE
fix(multi-turn): surface turn events + let llm phases pin a model

### DIFF
--- a/backend/internal/challengepack/user_simulator.go
+++ b/backend/internal/challengepack/user_simulator.go
@@ -45,6 +45,15 @@ type UserSimulatorPhase struct {
 	Until     []string            `yaml:"until,omitempty" json:"until,omitempty"`
 	TimeoutMS int64               `yaml:"timeout_ms,omitempty" json:"timeout_ms,omitempty"`
 	OnTimeout string              `yaml:"on_timeout,omitempty" json:"on_timeout,omitempty"`
+	// Model optionally overrides the simulator's LLM model id for `actor: llm`
+	// phases. When empty, the simulator inherits the deployment's model — but
+	// some deployments use models that only support /v1/responses (e.g.
+	// o4-mini, o3, o4-mini-deep-research) while the simulator's provider
+	// client uses /v1/chat/completions. Setting Model to a chat-compatible
+	// id (e.g. gpt-4o-mini, claude-haiku-4-5-20251001) avoids that mismatch.
+	// Provider and credentials are still inherited from the deployment, so
+	// the override must name a model that the deployment's provider serves.
+	Model string `yaml:"model,omitempty" json:"model,omitempty"`
 }
 
 type UserSimulatorTurn struct {

--- a/backend/internal/challengepack/user_simulator_test.go
+++ b/backend/internal/challengepack/user_simulator_test.go
@@ -74,6 +74,56 @@ func TestValidateUserSimulator_LLMPhaseRequiresPersona(t *testing.T) {
 	}
 }
 
+func TestValidateUserSimulator_AcceptsModelOverrideOnLLMPhase(t *testing.T) {
+	spec := validUserSimulatorSpec()
+	spec.Phases = append(spec.Phases, UserSimulatorPhase{
+		ID:       "dynamic",
+		Actor:    UserSimulatorActorLLM,
+		Trigger:  UserSimulatorTriggerOnAssistantMismatch,
+		Persona:  "Frustrated customer",
+		MaxTurns: 3,
+		Model:    "gpt-4o-mini",
+	})
+	errs := validateUserSimulatorSpec("user_simulator", spec, CaseDefinition{
+		Payload: map[string]any{"order_id": "123"},
+	}, nil)
+	if len(errs) > 0 {
+		t.Fatalf("validateUserSimulatorSpec rejected a valid llm phase with model override: %v", errs)
+	}
+}
+
+func TestValidateUserSimulator_RejectsModelOverrideOnNonLLMPhase(t *testing.T) {
+	cases := []struct {
+		name  string
+		actor string
+		turns []UserSimulatorTurn
+	}{
+		{name: "scripted", actor: UserSimulatorActorScripted, turns: []UserSimulatorTurn{{Message: "hi"}}},
+		{name: "human", actor: UserSimulatorActorHuman, turns: nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := validUserSimulatorSpec()
+			spec.Phases = append(spec.Phases, UserSimulatorPhase{
+				ID:      "extra",
+				Actor:   tc.actor,
+				Trigger: UserSimulatorTriggerOnAssistantMismatch,
+				Turns:   tc.turns,
+				Model:   "gpt-4o-mini",
+			})
+			errs := validateUserSimulatorSpec("user_simulator", spec, CaseDefinition{
+				Payload: map[string]any{"order_id": "123"},
+			}, nil)
+			if len(errs) == 0 {
+				t.Fatal("expected validation error for model on non-llm phase")
+			}
+			if !strings.Contains(errs.Error(), "model") {
+				t.Fatalf("error = %v, want a .model field error", errs)
+			}
+		})
+	}
+}
+
 func TestValidateUserSimulator_CalibrationRequiresPositiveSampleRate(t *testing.T) {
 	spec := validUserSimulatorSpec()
 	spec.Calibration = &UserSimulatorCalibration{Enabled: true}

--- a/backend/internal/challengepack/user_simulator_test.go
+++ b/backend/internal/challengepack/user_simulator_test.go
@@ -124,6 +124,43 @@ func TestValidateUserSimulator_RejectsModelOverrideOnNonLLMPhase(t *testing.T) {
 	}
 }
 
+func TestValidateUserSimulator_EmptyActorDoesNotEmitSpuriousModelError(t *testing.T) {
+	// Regression for greptile P2 on PR #863: when actor is omitted, the
+	// "actor is required" error must fire WITHOUT a misleading second
+	// "model is only valid on phases with actor: llm" error. The second
+	// hint implies adding `actor: llm` would fix the problem when the real
+	// issue is the missing actor field.
+	spec := validUserSimulatorSpec()
+	spec.Phases = append(spec.Phases, UserSimulatorPhase{
+		ID:      "extra",
+		Actor:   "",
+		Trigger: UserSimulatorTriggerOnAssistantMismatch,
+		Model:   "gpt-4o-mini",
+	})
+	errs := validateUserSimulatorSpec("user_simulator", spec, CaseDefinition{
+		Payload: map[string]any{"order_id": "123"},
+	}, nil)
+	if len(errs) == 0 {
+		t.Fatal("expected validation errors for the empty-actor phase")
+	}
+
+	var hasActorRequired, hasModelHint bool
+	for _, e := range errs {
+		if strings.Contains(e.Field, "phases[1].actor") && strings.Contains(e.Message, "required") {
+			hasActorRequired = true
+		}
+		if strings.Contains(e.Field, "phases[1].model") {
+			hasModelHint = true
+		}
+	}
+	if !hasActorRequired {
+		t.Fatalf("expected an actor-required error; got %v", errs)
+	}
+	if hasModelHint {
+		t.Fatalf("did not expect a model-field error when actor is empty (it misleads the author); got %v", errs)
+	}
+}
+
 func TestValidateUserSimulator_CalibrationRequiresPositiveSampleRate(t *testing.T) {
 	spec := validUserSimulatorSpec()
 	spec.Calibration = &UserSimulatorCalibration{Enabled: true}

--- a/backend/internal/challengepack/user_simulator_validate.go
+++ b/backend/internal/challengepack/user_simulator_validate.go
@@ -139,6 +139,16 @@ func validateUserSimulatorPhase(path string, phase UserSimulatorPhase, isFirst b
 		}
 	}
 
+	// Model is optional and only applies to llm-actor phases. Reject if set
+	// on a non-llm actor so pack authors get an early signal rather than a
+	// silent ignore.
+	if strings.TrimSpace(phase.Model) != "" && actor != UserSimulatorActorLLM {
+		errs = append(errs, ValidationError{
+			Field:   path + ".model",
+			Message: "is only valid on phases with actor: llm",
+		})
+	}
+
 	return errs
 }
 

--- a/backend/internal/challengepack/user_simulator_validate.go
+++ b/backend/internal/challengepack/user_simulator_validate.go
@@ -141,8 +141,10 @@ func validateUserSimulatorPhase(path string, phase UserSimulatorPhase, isFirst b
 
 	// Model is optional and only applies to llm-actor phases. Reject if set
 	// on a non-llm actor so pack authors get an early signal rather than a
-	// silent ignore.
-	if strings.TrimSpace(phase.Model) != "" && actor != UserSimulatorActorLLM {
+	// silent ignore. Skip when actor is empty — the missing-actor error
+	// above already covers that case, and emitting a second "actor: llm"
+	// hint here would mislead the author into thinking that's the fix.
+	if strings.TrimSpace(phase.Model) != "" && actor != "" && actor != UserSimulatorActorLLM {
 		errs = append(errs, ValidationError{
 			Field:   path + ".model",
 			Message: "is only valid on phases with actor: llm",

--- a/backend/internal/engine/multi_turn_executor.go
+++ b/backend/internal/engine/multi_turn_executor.go
@@ -262,6 +262,14 @@ func (e MultiTurnExecutor) runLLMPhase(
 	if err != nil {
 		return err
 	}
+	// Pack-author override: an LLM phase may pin a chat-compatible model id
+	// when the deployment runs on a model that only supports /v1/responses
+	// (e.g. o-series reasoning models). Provider and credentials still come
+	// from the deployment, so the override must name a model the deployment's
+	// provider serves.
+	if override := strings.TrimSpace(phase.Model); override != "" {
+		model = override
+	}
 
 	phaseMax := int(phase.MaxTurns)
 	if phaseMax <= 0 {

--- a/backend/internal/worker/buffered_observer.go
+++ b/backend/internal/worker/buffered_observer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/agentclash/agentclash/backend/internal/engine"
 	"github.com/agentclash/agentclash/backend/internal/provider"
 	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/simulator"
 )
 
 type observerCall struct {
@@ -167,6 +168,111 @@ func (b *BufferedObserver) OnRunFailure(ctx context.Context, runErr error) error
 	err := b.inner.OnRunFailure(ctx, runErr)
 	b.shutdown()
 	return err
+}
+
+// --- MultiTurnEventRecorder forwarding ---
+//
+// BufferedObserver wraps an arbitrary engine.Observer. When the inner observer
+// also implements engine.MultiTurnEventRecorder (i.e. it is the multi_turn
+// observer), the wrapper must expose those methods too — otherwise the type
+// assertion in engine.multiTurnRecorder() fails and the multi_turn executor
+// silently falls back to the noop recorder, dropping every turn.* event and
+// breaking transcript-based scoring.
+//
+// These forwarders buffer turn lifecycle events through the same queue as the
+// rest of the observer stream so per-step events and per-turn events stay in
+// write order. If the inner observer is not a MultiTurnEventRecorder (single-
+// turn execution path), the calls are silent no-ops — single-turn observers
+// have nothing to do with turn lifecycle events.
+
+func (b *BufferedObserver) RecordTurnUserMessage(ctx context.Context, turnIndex int, phaseID, actor, content string) error {
+	inner, ok := b.inner.(engine.MultiTurnEventRecorder)
+	if !ok {
+		return nil
+	}
+	if err := b.checkBgError(); err != nil {
+		return err
+	}
+	bgCtx := context.WithoutCancel(ctx)
+	b.enqueue(func() error {
+		return inner.RecordTurnUserMessage(bgCtx, turnIndex, phaseID, actor, content)
+	})
+	return nil
+}
+
+func (b *BufferedObserver) RecordTurnUserSimulated(ctx context.Context, turnIndex int, phaseID string, metadata simulator.Metadata) error {
+	inner, ok := b.inner.(engine.MultiTurnEventRecorder)
+	if !ok {
+		return nil
+	}
+	if err := b.checkBgError(); err != nil {
+		return err
+	}
+	bgCtx := context.WithoutCancel(ctx)
+	b.enqueue(func() error {
+		return inner.RecordTurnUserSimulated(bgCtx, turnIndex, phaseID, metadata)
+	})
+	return nil
+}
+
+func (b *BufferedObserver) RecordTurnAssistantMessage(ctx context.Context, turnIndex int, phaseID, content string) error {
+	inner, ok := b.inner.(engine.MultiTurnEventRecorder)
+	if !ok {
+		return nil
+	}
+	if err := b.checkBgError(); err != nil {
+		return err
+	}
+	bgCtx := context.WithoutCancel(ctx)
+	b.enqueue(func() error {
+		return inner.RecordTurnAssistantMessage(bgCtx, turnIndex, phaseID, content)
+	})
+	return nil
+}
+
+func (b *BufferedObserver) RecordTurnCompleted(ctx context.Context, turnIndex int, phaseID, actor string, mismatch bool) error {
+	inner, ok := b.inner.(engine.MultiTurnEventRecorder)
+	if !ok {
+		return nil
+	}
+	if err := b.checkBgError(); err != nil {
+		return err
+	}
+	bgCtx := context.WithoutCancel(ctx)
+	b.enqueue(func() error {
+		return inner.RecordTurnCompleted(bgCtx, turnIndex, phaseID, actor, mismatch)
+	})
+	return nil
+}
+
+func (b *BufferedObserver) RecordTurnAwaitingHuman(ctx context.Context, turnIndex int, phaseID, promptHint string) error {
+	inner, ok := b.inner.(engine.MultiTurnEventRecorder)
+	if !ok {
+		return nil
+	}
+	if err := b.checkBgError(); err != nil {
+		return err
+	}
+	bgCtx := context.WithoutCancel(ctx)
+	b.enqueue(func() error {
+		return inner.RecordTurnAwaitingHuman(bgCtx, turnIndex, phaseID, promptHint)
+	})
+	return nil
+}
+
+func (b *BufferedObserver) RecordConversationCompleted(ctx context.Context, summary engine.MultiTurnConversationSummary) error {
+	inner, ok := b.inner.(engine.MultiTurnEventRecorder)
+	if !ok {
+		return nil
+	}
+	if err := b.checkBgError(); err != nil {
+		return err
+	}
+	bgCtx := context.WithoutCancel(ctx)
+	b.enqueue(func() error {
+		return inner.RecordConversationCompleted(bgCtx, summary)
+	})
+	return nil
 }
 
 // --- Internal machinery ---

--- a/backend/internal/worker/buffered_observer_multi_turn_test.go
+++ b/backend/internal/worker/buffered_observer_multi_turn_test.go
@@ -1,0 +1,204 @@
+package worker
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/engine"
+	"github.com/agentclash/agentclash/backend/internal/provider"
+	"github.com/agentclash/agentclash/backend/internal/simulator"
+)
+
+// recordingMultiTurnObserver records both base engine.Observer calls and
+// engine.MultiTurnEventRecorder calls so the test can assert that the
+// buffered wrapper correctly forwards turn lifecycle events to a multi-turn
+// inner observer.
+type recordingMultiTurnObserver struct {
+	mu               sync.Mutex
+	turnCalls        []string
+	conversationDone bool
+}
+
+func (o *recordingMultiTurnObserver) record(name string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.turnCalls = append(o.turnCalls, name)
+}
+
+func (o *recordingMultiTurnObserver) getTurnCalls() []string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	cp := make([]string, len(o.turnCalls))
+	copy(cp, o.turnCalls)
+	return cp
+}
+
+// engine.Observer surface (no-ops; not what this test exercises).
+func (o *recordingMultiTurnObserver) OnStepStart(context.Context, int) error { return nil }
+func (o *recordingMultiTurnObserver) OnProviderCall(context.Context, provider.Request) error {
+	return nil
+}
+func (o *recordingMultiTurnObserver) OnProviderOutput(context.Context, provider.Request, provider.StreamDelta) error {
+	return nil
+}
+func (o *recordingMultiTurnObserver) OnProviderResponse(context.Context, provider.Response) error {
+	return nil
+}
+func (o *recordingMultiTurnObserver) OnToolExecution(context.Context, engine.ToolExecutionRecord) error {
+	return nil
+}
+func (o *recordingMultiTurnObserver) OnStepEnd(context.Context, int) error { return nil }
+func (o *recordingMultiTurnObserver) OnPostExecutionVerification(context.Context, []engine.PostExecutionVerificationResult) error {
+	return nil
+}
+func (o *recordingMultiTurnObserver) OnStandingsInjected(context.Context, engine.StandingsInjection) error {
+	return nil
+}
+func (o *recordingMultiTurnObserver) OnRunComplete(context.Context, engine.Result) error {
+	return nil
+}
+func (o *recordingMultiTurnObserver) OnRunFailure(context.Context, error) error { return nil }
+
+// engine.MultiTurnEventRecorder surface (the thing under test).
+func (o *recordingMultiTurnObserver) RecordTurnUserMessage(_ context.Context, _ int, _, _, _ string) error {
+	o.record("RecordTurnUserMessage")
+	return nil
+}
+func (o *recordingMultiTurnObserver) RecordTurnUserSimulated(_ context.Context, _ int, _ string, _ simulator.Metadata) error {
+	o.record("RecordTurnUserSimulated")
+	return nil
+}
+func (o *recordingMultiTurnObserver) RecordTurnAssistantMessage(_ context.Context, _ int, _, _ string) error {
+	o.record("RecordTurnAssistantMessage")
+	return nil
+}
+func (o *recordingMultiTurnObserver) RecordTurnCompleted(_ context.Context, _ int, _, _ string, _ bool) error {
+	o.record("RecordTurnCompleted")
+	return nil
+}
+func (o *recordingMultiTurnObserver) RecordTurnAwaitingHuman(_ context.Context, _ int, _, _ string) error {
+	o.record("RecordTurnAwaitingHuman")
+	return nil
+}
+func (o *recordingMultiTurnObserver) RecordConversationCompleted(_ context.Context, _ engine.MultiTurnConversationSummary) error {
+	o.record("RecordConversationCompleted")
+	return nil
+}
+
+// TestBufferedObserver_ForwardsMultiTurnEvents is the regression guard for the
+// bug where BufferedObserver did not implement engine.MultiTurnEventRecorder.
+// Before the fix:
+//   - the multi_turn_executor's `multiTurnRecorder()` type-assertion on the
+//     buffered wrapper failed silently
+//   - the executor used noopMultiTurnEventRecorder
+//   - every turn.* and conversation.completed event was silently dropped
+//   - transcript-dependent judges (transcript.full, transcript.from_mismatch,
+//     transcript.last_n:N, turn.expectations) all skipped with
+//     "transcript evidence is unavailable"
+//
+// This test asserts that BufferedObserver satisfies the interface and forwards
+// each method to a multi-turn-aware inner observer.
+func TestBufferedObserver_ForwardsMultiTurnEvents(t *testing.T) {
+	t.Parallel()
+
+	inner := &recordingMultiTurnObserver{}
+	buffered := NewBufferedObserver(inner)
+
+	// Static interface check: the wrapper MUST implement the recorder so the
+	// multi_turn_executor's type assertion succeeds.
+	var _ engine.MultiTurnEventRecorder = buffered
+
+	ctx := context.Background()
+
+	if err := buffered.RecordTurnUserMessage(ctx, 0, "phase-a", "scripted", "hello"); err != nil {
+		t.Fatalf("RecordTurnUserMessage: %v", err)
+	}
+	if err := buffered.RecordTurnUserSimulated(ctx, 0, "phase-a", simulator.Metadata{ProviderKey: "test"}); err != nil {
+		t.Fatalf("RecordTurnUserSimulated: %v", err)
+	}
+	if err := buffered.RecordTurnAssistantMessage(ctx, 0, "phase-a", "reply"); err != nil {
+		t.Fatalf("RecordTurnAssistantMessage: %v", err)
+	}
+	if err := buffered.RecordTurnCompleted(ctx, 0, "phase-a", "scripted", false); err != nil {
+		t.Fatalf("RecordTurnCompleted: %v", err)
+	}
+	if err := buffered.RecordTurnAwaitingHuman(ctx, 0, "phase-b", "press enter"); err != nil {
+		t.Fatalf("RecordTurnAwaitingHuman: %v", err)
+	}
+	if err := buffered.RecordConversationCompleted(ctx, engine.MultiTurnConversationSummary{TurnCount: 1}); err != nil {
+		t.Fatalf("RecordConversationCompleted: %v", err)
+	}
+
+	// Terminal call drains the queue + delegates synchronously.
+	if err := buffered.OnRunComplete(ctx, engine.Result{}); err != nil {
+		t.Fatalf("OnRunComplete: %v", err)
+	}
+
+	got := inner.getTurnCalls()
+	want := []string{
+		"RecordTurnUserMessage",
+		"RecordTurnUserSimulated",
+		"RecordTurnAssistantMessage",
+		"RecordTurnCompleted",
+		"RecordTurnAwaitingHuman",
+		"RecordConversationCompleted",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("turn-event call count = %d, want %d\ngot=%v\nwant=%v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("turn-event order mismatch at index %d: got=%q want=%q\nfull=%v", i, got[i], want[i], got)
+		}
+	}
+}
+
+// nonMultiTurnObserver implements only engine.Observer. The buffered wrapper
+// must still satisfy engine.MultiTurnEventRecorder when wrapping it, but the
+// record-turn methods should be no-ops (no panic, no error).
+type nonMultiTurnObserver struct{}
+
+func (nonMultiTurnObserver) OnStepStart(context.Context, int) error            { return nil }
+func (nonMultiTurnObserver) OnProviderCall(context.Context, provider.Request) error { return nil }
+func (nonMultiTurnObserver) OnProviderOutput(context.Context, provider.Request, provider.StreamDelta) error {
+	return nil
+}
+func (nonMultiTurnObserver) OnProviderResponse(context.Context, provider.Response) error { return nil }
+func (nonMultiTurnObserver) OnToolExecution(context.Context, engine.ToolExecutionRecord) error {
+	return nil
+}
+func (nonMultiTurnObserver) OnStepEnd(context.Context, int) error { return nil }
+func (nonMultiTurnObserver) OnPostExecutionVerification(context.Context, []engine.PostExecutionVerificationResult) error {
+	return nil
+}
+func (nonMultiTurnObserver) OnStandingsInjected(context.Context, engine.StandingsInjection) error {
+	return nil
+}
+func (nonMultiTurnObserver) OnRunComplete(context.Context, engine.Result) error { return nil }
+func (nonMultiTurnObserver) OnRunFailure(context.Context, error) error          { return nil }
+
+// TestBufferedObserver_NoOpForSingleTurnObserver guards that wrapping a
+// non-multi-turn observer (e.g. a single-turn native observer) does not blow
+// up when the record-turn methods are called — they must be silent no-ops.
+// Defensive: in practice the multi_turn_executor only calls these when the
+// pack is multi_turn, but we don't want the wrapper to panic if the dispatch
+// ever changes.
+func TestBufferedObserver_NoOpForSingleTurnObserver(t *testing.T) {
+	t.Parallel()
+
+	buffered := NewBufferedObserver(nonMultiTurnObserver{})
+	var _ engine.MultiTurnEventRecorder = buffered
+
+	ctx := context.Background()
+
+	if err := buffered.RecordTurnUserMessage(ctx, 0, "phase", "scripted", "msg"); err != nil {
+		t.Fatalf("RecordTurnUserMessage: %v", err)
+	}
+	if err := buffered.RecordConversationCompleted(ctx, engine.MultiTurnConversationSummary{}); err != nil {
+		t.Fatalf("RecordConversationCompleted: %v", err)
+	}
+	if err := buffered.OnRunComplete(ctx, engine.Result{}); err != nil {
+		t.Fatalf("OnRunComplete: %v", err)
+	}
+}

--- a/docs/challenge-packs/user-simulator.md
+++ b/docs/challenge-packs/user-simulator.md
@@ -39,11 +39,34 @@ input_sets:
 
 ## Actors
 
-| Actor | Required fields |
-| --- | --- |
-| `scripted` | `turns[].message` |
-| `llm` | `persona` |
-| `human` | optional `timeout_ms` |
+| Actor | Required fields | Optional fields |
+| --- | --- | --- |
+| `scripted` | `turns[].message` | — |
+| `llm` | `persona` | `model` (override the inherited simulator model — see below) |
+| `human` | — | `timeout_ms` |
+
+### LLM phase `model` override
+
+`actor: llm` phases inherit provider, credentials, and **model** from the
+agent deployment by default. If the deployment runs on a model that only
+supports `/v1/responses` (e.g. `o3`, `o4-mini`, `o4-mini-deep-research`),
+inheritance fails because the simulator's provider client uses
+`/v1/chat/completions`. Pin a chat-compatible model id with `model:` to
+avoid the mismatch:
+
+```yaml
+phases:
+  - id: dynamic
+    actor: llm
+    trigger: on_assistant_mismatch
+    persona: "Frustrated customer"
+    model: "gpt-4o-mini"   # overrides the inherited reasoning-model id
+```
+
+The override only applies to `actor: llm` phases — setting `model:` on
+`scripted` or `human` phases is rejected at pack validation time. Provider
+and credentials are still inherited from the deployment, so the override
+must name a model the deployment's provider serves.
 
 ## Triggers
 


### PR DESCRIPTION
## Summary

Hardens the multi_turn execution path so transcript-dependent scoring works end to end and so packs can be evaluated against deployments that run on reasoning-only models. Two distinct bugs share one PR because both surfaced on the same run and both block any real multi-turn eval signal today.

## Bug 1 — `BufferedObserver` hid every turn lifecycle event

The worker wires the multi_turn observer behind `NewBufferedObserver` ([`buffered_observer.go:268`](https://github.com/agentclash/agentclash/blob/main/backend/internal/worker/multi_turn_event_observer.go#L268)). The buffered wrapper implemented `engine.Observer` but **not** `engine.MultiTurnEventRecorder`, so the type-assertion in [`engine.multiTurnRecorder()`](https://github.com/agentclash/agentclash/blob/main/backend/internal/engine/multi_turn_executor.go#L64) fell through to `noopMultiTurnEventRecorder` and silently dropped every `turn.user.message`, `turn.user.simulated`, `turn.assistant.message`, `turn.completed`, `turn.awaiting_human`, and `conversation.completed` event.

**Symptom in production:** multi_turn runs complete on the agent side, but every transcript-based judge skips with `transcript evidence is unavailable` and the overall scorecard is `0.0`. Reproduced against pack `syllabus-gen-multi-turn-v0` v2 + `SyllabusGen Anthropic Sonnet 4.6` (run `b0b07445-de73-48e8-b433-0d866c232fe2`): Sonnet did 10 conversational `submit` calls but zero `turn.*` events landed in the run stream.

**Fix.** `BufferedObserver` now implements `engine.MultiTurnEventRecorder`. Each forwarder type-asserts the inner observer at call time; when the inner observer is single-turn (e.g. native or responses), the methods are silent no-ops, which keeps the wrapper safe to use as a generic buffer.

## Bug 2 — LLM-phase simulator inherited the deployment's reasoning model

`simulator.ResolveTarget` returns the deployment's `provider_model_id` verbatim, and the simulator's provider client routes via `/v1/chat/completions`. For deployments on `o3`, `o4-mini`, or `o4-mini-deep-research`, the simulator's first `InvokeModel` call returns:

```
engine.simulator_error: This model is only supported in v1/responses
and not in v1/chat/completions.
```

— making multi_turn packs unrunnable against any reasoning-model deployment.

**Fix.** `UserSimulatorPhase` gains an optional `model` field that overrides the inherited simulator model id for `actor: llm` phases only. Provider + credentials still come from the deployment. The validator rejects `model:` on scripted/human phases so authors get an early signal instead of a silent ignore. The override is documented in [`docs/challenge-packs/user-simulator.md`](docs/challenge-packs/user-simulator.md) with the rationale and a code example.

```yaml
phases:
  - id: dynamic
    actor: llm
    trigger: on_assistant_mismatch
    persona: "Frustrated customer"
    model: "gpt-4o-mini"   # overrides the inherited reasoning-model id
```

## Test plan

- [x] `cd backend && go build ./...` — clean
- [x] `cd backend && go vet ./...` — clean
- [x] `cd backend && go test -short -race -count=1 ./internal/engine/... ./internal/challengepack/... ./internal/worker/... ./internal/simulator/... ./internal/scoring/...` — green
- [x] New tests:
  - `worker.TestBufferedObserver_ForwardsMultiTurnEvents` — asserts the buffered wrapper satisfies `engine.MultiTurnEventRecorder` at compile time AND forwards each method through to the inner observer in order. Regression guard for bug 1.
  - `worker.TestBufferedObserver_NoOpForSingleTurnObserver` — defensive: a single-turn observer wrapped by `BufferedObserver` does not panic when `RecordTurn*` is called.
  - `challengepack.TestValidateUserSimulator_AcceptsModelOverrideOnLLMPhase` and `RejectsModelOverrideOnNonLLMPhase` — validation surface for the new `model` field.
- [ ] Post-deploy manual: re-run a multi_turn smoke eval (e.g. `syllabus-gen-multi-turn-v0` v2 + `SyllabusGen Anthropic Sonnet 4.6`). Expect `turn.*` events in the run stream, `transcript.full` resolving in judges, and a non-zero scorecard reflecting actual interview quality.

## Scope notes

- The runtime-budget timeout (~15 min for `o4-mini-deep-research`) is intentionally **not** addressed here — it's a deployment-configuration concern, not a platform bug.
- Auto-detecting reasoning-only models and inferring a chat-compatible default was considered and rejected: model capability flags are a separate refactor, and the `model:` override gives pack authors explicit control without an inference layer that could silently swap models behind their back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)