### PR TITLE
feat(api): multi-turn conversation transcript endpoint

### DIFF
--- a/backend/internal/api/replay_reads.go
+++ b/backend/internal/api/replay_reads.go
@@ -28,11 +28,13 @@ type ReplayReadRepository interface {
 	GetRunAgentScorecardByRunAgentID(ctx context.Context, runAgentID uuid.UUID) (repository.RunAgentScorecard, error)
 	GetEvaluationSpecByID(ctx context.Context, id uuid.UUID) (repository.EvaluationSpecRecord, error)
 	ListLLMJudgeResultsByRunAgentAndEvaluationSpec(ctx context.Context, runAgentID uuid.UUID, evaluationSpecID uuid.UUID) ([]repository.LLMJudgeResultRecord, error)
+	ListRunEventsByRunAgentID(ctx context.Context, runAgentID uuid.UUID) ([]repository.RunEvent, error)
 }
 
 type ReplayReadService interface {
 	GetRunAgentReplay(ctx context.Context, caller Caller, runAgentID uuid.UUID, page ReplayStepPageParams) (GetRunAgentReplayResult, error)
 	GetRunAgentScorecard(ctx context.Context, caller Caller, runAgentID uuid.UUID) (GetRunAgentScorecardResult, error)
+	GetRunAgentTranscript(ctx context.Context, caller Caller, runAgentID uuid.UUID) (GetRunAgentTranscriptResult, error)
 }
 
 type ReplayState string

--- a/backend/internal/api/replay_reads_test.go
+++ b/backend/internal/api/replay_reads_test.go
@@ -1100,10 +1100,16 @@ type fakeReplayReadRepository struct {
 	evaluationSpecErr  error
 	llmJudgeResults    []repository.LLMJudgeResultRecord
 	llmJudgeResultsErr error
+	runEvents          []repository.RunEvent
+	runEventsErr       error
 }
 
 func (f *fakeReplayReadRepository) GetRunAgentByID(_ context.Context, _ uuid.UUID) (domain.RunAgent, error) {
 	return f.runAgent, f.runAgentErr
+}
+
+func (f *fakeReplayReadRepository) ListRunEventsByRunAgentID(_ context.Context, _ uuid.UUID) ([]repository.RunEvent, error) {
+	return f.runEvents, f.runEventsErr
 }
 
 func (f *fakeReplayReadRepository) GetRunAgentReplayByRunAgentID(_ context.Context, _ uuid.UUID) (repository.RunAgentReplay, error) {
@@ -1127,6 +1133,8 @@ type fakeReplayReadService struct {
 	replayErr       error
 	scorecardResult GetRunAgentScorecardResult
 	scorecardErr    error
+	transcriptResult GetRunAgentTranscriptResult
+	transcriptErr    error
 }
 
 func (f *fakeReplayReadService) GetRunAgentReplay(_ context.Context, _ Caller, _ uuid.UUID, _ ReplayStepPageParams) (GetRunAgentReplayResult, error) {
@@ -1135,6 +1143,10 @@ func (f *fakeReplayReadService) GetRunAgentReplay(_ context.Context, _ Caller, _
 
 func (f *fakeReplayReadService) GetRunAgentScorecard(_ context.Context, _ Caller, _ uuid.UUID) (GetRunAgentScorecardResult, error) {
 	return f.scorecardResult, f.scorecardErr
+}
+
+func (f *fakeReplayReadService) GetRunAgentTranscript(_ context.Context, _ Caller, _ uuid.UUID) (GetRunAgentTranscriptResult, error) {
+	return f.transcriptResult, f.transcriptErr
 }
 
 func decodeReplayPayload(t *testing.T, payload []byte) map[string]any {

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -116,6 +116,7 @@ func registerProtectedRoutes(
 	router.Patch("/workspaces/{workspaceID}/regression-cases/{caseID}", patchRegressionCaseHandler(logger, regressionService))
 	router.Get("/replays/{runAgentID}/viewer", getRunAgentReplayViewerHandler(logger))
 	router.Get("/replays/{runAgentID}", getRunAgentReplayHandler(logger, replayReadService))
+	router.Get("/replays/{runAgentID}/transcript", getRunAgentTranscriptHandler(logger, replayReadService))
 	router.Get("/scorecards/{runAgentID}", getRunAgentScorecardHandler(logger, replayReadService))
 	router.Post("/share-links", createShareLinkHandler(logger, publicShareService))
 	router.Delete("/share-links/{shareID}", revokeShareLinkHandler(logger, publicShareService))

--- a/backend/internal/api/server_test.go
+++ b/backend/internal/api/server_test.go
@@ -88,6 +88,10 @@ func (stubReplayReadService) GetRunAgentScorecard(_ context.Context, _ Caller, _
 	return GetRunAgentScorecardResult{}, errors.New("not implemented")
 }
 
+func (stubReplayReadService) GetRunAgentTranscript(_ context.Context, _ Caller, _ uuid.UUID) (GetRunAgentTranscriptResult, error) {
+	return GetRunAgentTranscriptResult{}, errors.New("not implemented")
+}
+
 func TestHealthzReturnsJSONSuccessPayload(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	recorder := httptest.NewRecorder()

--- a/backend/internal/api/transcript_reads.go
+++ b/backend/internal/api/transcript_reads.go
@@ -114,6 +114,15 @@ func transcriptSummaryFromPayload(payload json.RawMessage) runevents.SummaryMeta
 
 func transcriptState(status domain.RunAgentStatus, turnCount int) (ReplayState, string) {
 	switch status {
+	case domain.RunAgentStatusCompleted:
+		return ReplayStateReady, ""
+	case domain.RunAgentStatusFailed:
+		// Mirror the replay/scorecard endpoints: a failed run-agent surfaces
+		// `errored` (HTTP 409) so a consumer checking `state == "ready"`
+		// never mistakes an interrupted conversation for a clean finish. The
+		// reconstructed turns are still returned in the body, so callers that
+		// opt in (allowedStatuses: [409]) can render the partial transcript.
+		return ReplayStateErrored, "the run-agent failed; the transcript may be partial"
 	case domain.RunAgentStatusQueued,
 		domain.RunAgentStatusReady,
 		domain.RunAgentStatusExecuting,
@@ -124,7 +133,7 @@ func transcriptState(status domain.RunAgentStatus, turnCount int) (ReplayState, 
 		}
 		return ReplayStatePending, "transcript is being recorded"
 	default:
-		return ReplayStateReady, ""
+		return ReplayStatePending, "transcript is being recorded"
 	}
 }
 

--- a/backend/internal/api/transcript_reads.go
+++ b/backend/internal/api/transcript_reads.go
@@ -1,0 +1,225 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/agentclash/agentclash/backend/internal/domain"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/runevents"
+	"github.com/google/uuid"
+)
+
+type GetRunAgentTranscriptResult struct {
+	RunAgent domain.RunAgent
+	State    ReplayState
+	Message  string
+	Turns    []runevents.TranscriptTurn
+}
+
+func (m *ReplayReadManager) GetRunAgentTranscript(ctx context.Context, caller Caller, runAgentID uuid.UUID) (GetRunAgentTranscriptResult, error) {
+	runAgent, err := m.repo.GetRunAgentByID(ctx, runAgentID)
+	if err != nil {
+		return GetRunAgentTranscriptResult{}, err
+	}
+	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, runAgent.WorkspaceID); err != nil {
+		return GetRunAgentTranscriptResult{}, err
+	}
+
+	events, err := m.repo.ListRunEventsByRunAgentID(ctx, runAgentID)
+	if err != nil {
+		return GetRunAgentTranscriptResult{}, err
+	}
+
+	envelopes := transcriptEnvelopesFromRunEvents(events)
+	turns, err := runevents.TranscriptFromEvents(envelopes)
+	if err != nil {
+		return GetRunAgentTranscriptResult{}, err
+	}
+
+	// A transcript is "ready" whenever the run-agent has reached a terminal
+	// state, even if there are zero turns (a single-turn run simply has none).
+	// While the run-agent is still progressing, surface pending so the client
+	// can poll.
+	state, message := transcriptState(runAgent.Status, len(turns))
+	return GetRunAgentTranscriptResult{
+		RunAgent: runAgent,
+		State:    state,
+		Message:  message,
+		Turns:    turns,
+	}, nil
+}
+
+// transcriptEnvelopesFromRunEvents adapts stored run events into the envelope
+// shape TranscriptFromEvents consumes. The summary fields the reconstruction
+// relies on (turn_index, phase_id, actor, mismatch) are written into each
+// turn event's payload by the multi-turn observer, so we lift them back out
+// here rather than depend on the separately-stored summary column.
+func transcriptEnvelopesFromRunEvents(events []repository.RunEvent) []runevents.Envelope {
+	envelopes := make([]runevents.Envelope, 0, len(events))
+	for _, event := range events {
+		if !isTranscriptEventType(event.EventType) {
+			continue
+		}
+		envelopes = append(envelopes, runevents.Envelope{
+			SchemaVersion:  runevents.SchemaVersionV1,
+			RunID:          event.RunID,
+			RunAgentID:     event.RunAgentID,
+			SequenceNumber: event.SequenceNumber,
+			EventType:      event.EventType,
+			Source:         event.Source,
+			OccurredAt:     event.OccurredAt,
+			Payload:        event.Payload,
+			Summary:        transcriptSummaryFromPayload(event.Payload),
+		})
+	}
+	return envelopes
+}
+
+func isTranscriptEventType(eventType runevents.Type) bool {
+	switch eventType {
+	case runevents.EventTypeTurnUserMessage,
+		runevents.EventTypeTurnUserSimulated,
+		runevents.EventTypeTurnAssistantMessage,
+		runevents.EventTypeTurnCompleted,
+		runevents.EventTypeTurnAwaitingHuman,
+		runevents.EventTypeTurnStateCaptured,
+		runevents.EventTypeConversationCompleted:
+		return true
+	default:
+		return false
+	}
+}
+
+func transcriptSummaryFromPayload(payload json.RawMessage) runevents.SummaryMetadata {
+	var fields struct {
+		TurnIndex *int   `json:"turn_index"`
+		PhaseID   string `json:"phase_id"`
+		Actor     string `json:"actor"`
+		Mismatch  *bool  `json:"mismatch"`
+	}
+	if len(payload) > 0 {
+		_ = json.Unmarshal(payload, &fields)
+	}
+	return runevents.SummaryMetadata{
+		TurnIndex: fields.TurnIndex,
+		PhaseID:   fields.PhaseID,
+		Actor:     fields.Actor,
+		Mismatch:  fields.Mismatch,
+	}
+}
+
+func transcriptState(status domain.RunAgentStatus, turnCount int) (ReplayState, string) {
+	switch status {
+	case domain.RunAgentStatusQueued,
+		domain.RunAgentStatusReady,
+		domain.RunAgentStatusExecuting,
+		domain.RunAgentStatusEvaluating:
+		if turnCount > 0 {
+			// Turns are streaming in while the run is still active.
+			return ReplayStateReady, ""
+		}
+		return ReplayStatePending, "transcript is being recorded"
+	default:
+		return ReplayStateReady, ""
+	}
+}
+
+// --- HTTP layer ---
+
+type transcriptTurnPayload struct {
+	TurnIndex         int    `json:"turn_index"`
+	PhaseID           string `json:"phase_id,omitempty"`
+	Actor             string `json:"actor,omitempty"`
+	UserMessage       string `json:"user_message,omitempty"`
+	AssistantMessage  string `json:"assistant_message,omitempty"`
+	Mismatch          bool   `json:"mismatch"`
+	Completed         bool   `json:"completed"`
+	AwaitingHuman     bool   `json:"awaiting_human"`
+	AwaitingHumanHint string `json:"awaiting_human_hint,omitempty"`
+	UserSimulated     bool   `json:"user_simulated"`
+}
+
+type getRunAgentTranscriptResponse struct {
+	State          ReplayState             `json:"state"`
+	Message        string                  `json:"message,omitempty"`
+	RunAgentID     uuid.UUID               `json:"run_agent_id"`
+	RunID          uuid.UUID               `json:"run_id"`
+	RunAgentStatus domain.RunAgentStatus   `json:"run_agent_status"`
+	TurnCount      int                     `json:"turn_count"`
+	Turns          []transcriptTurnPayload `json:"turns"`
+}
+
+func getRunAgentTranscriptHandler(logger *slog.Logger, service ReplayReadService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+
+		runAgentID, err := runAgentIDFromURLParam("runAgentID")(r)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_run_agent_id", err.Error())
+			return
+		}
+
+		result, err := service.GetRunAgentTranscript(r.Context(), caller, runAgentID)
+		if err != nil {
+			switch {
+			case errors.Is(err, repository.ErrRunAgentNotFound):
+				writeError(w, http.StatusNotFound, "run_agent_not_found", "run agent not found")
+			case errors.Is(err, ErrForbidden):
+				writeAuthzError(w, err)
+			default:
+				logger.Error("get run-agent transcript request failed",
+					"method", r.Method,
+					"path", r.URL.Path,
+					"run_agent_id", runAgentID,
+					"error", err,
+				)
+				writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+			}
+			return
+		}
+
+		statusCode := http.StatusOK
+		switch result.State {
+		case ReplayStatePending:
+			statusCode = http.StatusAccepted
+		case ReplayStateErrored:
+			statusCode = http.StatusConflict
+		}
+		writeJSON(w, statusCode, buildRunAgentTranscriptResponse(result))
+	}
+}
+
+func buildRunAgentTranscriptResponse(result GetRunAgentTranscriptResult) getRunAgentTranscriptResponse {
+	turns := make([]transcriptTurnPayload, 0, len(result.Turns))
+	for _, turn := range result.Turns {
+		turns = append(turns, transcriptTurnPayload{
+			TurnIndex:         turn.TurnIndex,
+			PhaseID:           turn.PhaseID,
+			Actor:             turn.Actor,
+			UserMessage:       turn.UserMessage,
+			AssistantMessage:  turn.AssistantMessage,
+			Mismatch:          turn.Mismatch,
+			Completed:         turn.Completed,
+			AwaitingHuman:     turn.AwaitingHuman,
+			AwaitingHumanHint: turn.AwaitingHumanHint,
+			UserSimulated:     turn.UserSimulated,
+		})
+	}
+	return getRunAgentTranscriptResponse{
+		State:          result.State,
+		Message:        result.Message,
+		RunAgentID:     result.RunAgent.ID,
+		RunID:          result.RunAgent.RunID,
+		RunAgentStatus: result.RunAgent.Status,
+		TurnCount:      len(turns),
+		Turns:          turns,
+	}
+}

--- a/backend/internal/api/transcript_reads_test.go
+++ b/backend/internal/api/transcript_reads_test.go
@@ -131,6 +131,48 @@ func TestReplayReadManager_GetRunAgentTranscript_SingleTurnHasNoTurns(t *testing
 	}
 }
 
+func TestReplayReadManager_GetRunAgentTranscript_FailedRunIsErroredButKeepsPartialTurns(t *testing.T) {
+	workspaceID := uuid.New()
+	runAgentID := uuid.New()
+
+	// A run that recorded one turn then failed: the transcript must surface
+	// `errored` (so callers don't mistake it for a clean finish) while still
+	// returning the partial conversation in the body.
+	events := []repository.RunEvent{
+		turnEvent(1, runevents.EventTypeTurnUserMessage, map[string]any{
+			"turn_index": 0, "actor": "llm", "content": "Hi",
+		}),
+		turnEvent(2, runevents.EventTypeTurnAssistantMessage, map[string]any{
+			"turn_index": 0, "content": "Hello — what's your goal?",
+		}),
+	}
+
+	manager := NewReplayReadManager(NewCallerWorkspaceAuthorizer(), &fakeReplayReadRepository{
+		runAgent: domain.RunAgent{
+			ID:          runAgentID,
+			RunID:       uuid.New(),
+			WorkspaceID: workspaceID,
+			Status:      domain.RunAgentStatusFailed,
+		},
+		runEvents: events,
+	})
+
+	result, err := manager.GetRunAgentTranscript(
+		context.Background(),
+		callerForWorkspace(workspaceID),
+		runAgentID,
+	)
+	if err != nil {
+		t.Fatalf("GetRunAgentTranscript: %v", err)
+	}
+	if result.State != ReplayStateErrored {
+		t.Fatalf("state = %q, want errored for a failed run", result.State)
+	}
+	if len(result.Turns) != 1 {
+		t.Fatalf("turn count = %d, want 1 partial turn retained", len(result.Turns))
+	}
+}
+
 func TestReplayReadManager_GetRunAgentTranscript_DeniesOtherWorkspace(t *testing.T) {
 	manager := NewReplayReadManager(NewCallerWorkspaceAuthorizer(), &fakeReplayReadRepository{
 		runAgent: domain.RunAgent{

--- a/backend/internal/api/transcript_reads_test.go
+++ b/backend/internal/api/transcript_reads_test.go
@@ -1,0 +1,161 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/domain"
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/agentclash/agentclash/backend/internal/runevents"
+	"github.com/google/uuid"
+)
+
+func turnEvent(seq int64, eventType runevents.Type, payload map[string]any) repository.RunEvent {
+	raw, _ := json.Marshal(payload)
+	return repository.RunEvent{
+		RunID:          uuid.New(),
+		RunAgentID:     uuid.New(),
+		SequenceNumber: seq,
+		EventType:      eventType,
+		Source:         runevents.SourceMultiTurnEngine,
+		Payload:        raw,
+	}
+}
+
+func TestReplayReadManager_GetRunAgentTranscript_ReconstructsTurns(t *testing.T) {
+	workspaceID := uuid.New()
+	runAgentID := uuid.New()
+
+	events := []repository.RunEvent{
+		turnEvent(1, runevents.EventTypeTurnUserMessage, map[string]any{
+			"turn_index": 0, "actor": "llm", "phase_id": "interview",
+			"content": "Where do I start?",
+		}),
+		turnEvent(2, runevents.EventTypeTurnAssistantMessage, map[string]any{
+			"turn_index": 0, "phase_id": "interview",
+			"content": "What languages do you know?",
+		}),
+		turnEvent(3, runevents.EventTypeTurnCompleted, map[string]any{
+			"turn_index": 0, "mismatch": true,
+		}),
+		turnEvent(4, runevents.EventTypeTurnUserMessage, map[string]any{
+			"turn_index": 1, "actor": "llm", "phase_id": "interview",
+			"content": "No Python.",
+		}),
+		turnEvent(5, runevents.EventTypeTurnAssistantMessage, map[string]any{
+			"turn_index": 1, "phase_id": "interview",
+			"content": "We'll start with Python then.",
+		}),
+		turnEvent(6, runevents.EventTypeConversationCompleted, map[string]any{
+			"turn_count": 2,
+		}),
+	}
+
+	manager := NewReplayReadManager(NewCallerWorkspaceAuthorizer(), &fakeReplayReadRepository{
+		runAgent: domain.RunAgent{
+			ID:          runAgentID,
+			RunID:       uuid.New(),
+			WorkspaceID: workspaceID,
+			Status:      domain.RunAgentStatusCompleted,
+		},
+		runEvents: events,
+	})
+
+	result, err := manager.GetRunAgentTranscript(
+		context.Background(),
+		callerForWorkspace(workspaceID),
+		runAgentID,
+	)
+	if err != nil {
+		t.Fatalf("GetRunAgentTranscript: %v", err)
+	}
+	if result.State != ReplayStateReady {
+		t.Fatalf("state = %q, want ready", result.State)
+	}
+	if len(result.Turns) != 2 {
+		t.Fatalf("turn count = %d, want 2", len(result.Turns))
+	}
+
+	first := result.Turns[0]
+	if first.UserMessage != "Where do I start?" || first.AssistantMessage != "What languages do you know?" {
+		t.Fatalf("turn 0 content mismatch: user=%q assistant=%q", first.UserMessage, first.AssistantMessage)
+	}
+	if !first.Mismatch {
+		t.Fatal("turn 0 should be flagged mismatch (from turn.completed payload)")
+	}
+	if first.Actor != "llm" || first.PhaseID != "interview" {
+		t.Fatalf("turn 0 metadata mismatch: actor=%q phase=%q", first.Actor, first.PhaseID)
+	}
+
+	second := result.Turns[1]
+	if second.UserMessage != "No Python." || second.AssistantMessage != "We'll start with Python then." {
+		t.Fatalf("turn 1 content mismatch: user=%q assistant=%q", second.UserMessage, second.AssistantMessage)
+	}
+}
+
+func TestReplayReadManager_GetRunAgentTranscript_SingleTurnHasNoTurns(t *testing.T) {
+	workspaceID := uuid.New()
+	runAgentID := uuid.New()
+
+	// A single-turn (native) run emits no turn.* events — only model/tool/run
+	// events. The transcript should resolve to ready with zero turns, not error.
+	events := []repository.RunEvent{
+		turnEvent(1, runevents.EventTypeModelCallCompleted, map[string]any{"output_text": "hi"}),
+		turnEvent(2, runevents.EventTypeSystemRunCompleted, map[string]any{}),
+	}
+
+	manager := NewReplayReadManager(NewCallerWorkspaceAuthorizer(), &fakeReplayReadRepository{
+		runAgent: domain.RunAgent{
+			ID:          runAgentID,
+			RunID:       uuid.New(),
+			WorkspaceID: workspaceID,
+			Status:      domain.RunAgentStatusCompleted,
+		},
+		runEvents: events,
+	})
+
+	result, err := manager.GetRunAgentTranscript(
+		context.Background(),
+		callerForWorkspace(workspaceID),
+		runAgentID,
+	)
+	if err != nil {
+		t.Fatalf("GetRunAgentTranscript: %v", err)
+	}
+	if result.State != ReplayStateReady {
+		t.Fatalf("state = %q, want ready", result.State)
+	}
+	if len(result.Turns) != 0 {
+		t.Fatalf("turn count = %d, want 0 for single-turn run", len(result.Turns))
+	}
+}
+
+func TestReplayReadManager_GetRunAgentTranscript_DeniesOtherWorkspace(t *testing.T) {
+	manager := NewReplayReadManager(NewCallerWorkspaceAuthorizer(), &fakeReplayReadRepository{
+		runAgent: domain.RunAgent{
+			ID:          uuid.New(),
+			RunID:       uuid.New(),
+			WorkspaceID: uuid.New(),
+			Status:      domain.RunAgentStatusCompleted,
+		},
+	})
+
+	_, err := manager.GetRunAgentTranscript(
+		context.Background(),
+		callerForWorkspace(uuid.New()), // different workspace
+		uuid.New(),
+	)
+	if err == nil {
+		t.Fatal("expected authorization error for caller from a different workspace")
+	}
+}
+
+func callerForWorkspace(workspaceID uuid.UUID) Caller {
+	return Caller{
+		UserID: uuid.New(),
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: "workspace_member"},
+		},
+	}
+}

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -3512,6 +3512,42 @@ paths:
               schema:
                 $ref: "#/components/schemas/ReplayResponse"
 
+  /v1/replays/{runAgentID}/transcript:
+    get:
+      operationId: getReplayTranscript
+      tags: [Replays]
+      summary: Get multi-turn conversation transcript
+      description: >
+        Returns the reconstructed multi-turn conversation transcript for an
+        agent — ordered user/assistant turns with phase, actor, and mismatch
+        metadata. Single-turn (native) runs return an empty turns array.
+        Returns 202 while the transcript is still being recorded.
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/RunAgentID"
+      responses:
+        "200":
+          description: Transcript ready
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TranscriptResponse"
+        "202":
+          description: Transcript recording pending
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TranscriptResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
   /v1/replays/{runAgentID}/viewer:
     get:
       operationId: getReplayViewer
@@ -9281,6 +9317,55 @@ components:
             additionalProperties: true
         pagination:
           $ref: "#/components/schemas/ReplayPagination"
+
+    TranscriptResponse:
+      type: object
+      required: [state, run_agent_id, run_id, run_agent_status, turn_count, turns]
+      properties:
+        state:
+          $ref: "#/components/schemas/ReplayState"
+        message:
+          type: string
+        run_agent_id:
+          type: string
+          format: uuid
+        run_id:
+          type: string
+          format: uuid
+        run_agent_status:
+          $ref: "#/components/schemas/RunAgentStatus"
+        turn_count:
+          type: integer
+        turns:
+          type: array
+          items:
+            $ref: "#/components/schemas/TranscriptTurn"
+
+    TranscriptTurn:
+      type: object
+      required: [turn_index, mismatch, completed, awaiting_human, user_simulated]
+      properties:
+        turn_index:
+          type: integer
+        phase_id:
+          type: string
+        actor:
+          type: string
+          description: scripted, llm, or human
+        user_message:
+          type: string
+        assistant_message:
+          type: string
+        mismatch:
+          type: boolean
+        completed:
+          type: boolean
+        awaiting_human:
+          type: boolean
+        awaiting_human_hint:
+          type: string
+        user_simulated:
+          type: boolean
 
     ReplayPayload:
       type: object


### PR DESCRIPTION
**PR 1 of 4** in the multi-turn transcript-viewer stack. Backend only — adds the data source the frontend PRs will consume.

## Summary

Adds `GET /v1/replays/{runAgentID}/transcript`, which reconstructs the ordered user↔assistant turns of a `multi_turn` run from persisted run events and returns them as structured JSON.

- Reuses `runevents.TranscriptFromEvents` for grouping/ordering. Turn lifecycle events carry `turn_index` / `phase_id` / `actor` / `mismatch` in their payloads (written by the multi-turn observer), so the manager lifts those into the envelope `Summary` before reconstruction rather than depending on the separately-stored summary column.
- Single-turn (native) runs emit no `turn.*` events → resolve to a **ready** state with an empty `turns` array (not an error), so the frontend can always call it safely.
- Authorization mirrors the replay/scorecard reads (workspace-scoped).
- Folded into the existing `ReplayReadService` / `ReplayReadManager` rather than threading a new service through `server.go` + `routes.go`.

## API shape

```
GET /v1/replays/{runAgentID}/transcript
→ { state, run_agent_id, run_id, run_agent_status, turn_count,
    turns: [{ turn_index, phase_id, actor, user_message,
              assistant_message, mismatch, completed,
              awaiting_human, awaiting_human_hint, user_simulated }] }
```

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/api/` clean
- [x] `go test -short -race -count=1 ./internal/api/` green
- [x] New tests: `ReconstructsTurns` (2-turn conversation + mismatch + metadata), `SingleTurnHasNoTurns` (native run → ready, 0 turns), `DeniesOtherWorkspace` (cross-workspace caller rejected)
- [x] OpenAPI documents the endpoint + `TranscriptResponse` / `TranscriptTurn` schemas; redocly lint introduces **no new errors** (the 10 errors present are pre-existing on main)

## Stack

1. **← this PR** — backend transcript endpoint
2. frontend types + API client + `ConversationTranscript` component (replay page)
3. PDF export (`@react-pdf/renderer` + Download button)
4. scorecard embed

🤖 Generated with [Claude Code](https://claude.com/claude-code)