### PR TITLE
feat(web): multi-turn conversation transcript on replay page

### DIFF
--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/replay/replay-viewer-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/replay/replay-viewer-client.tsx
@@ -12,10 +12,13 @@ import type {
   RunAgentStatus,
   ReplayResponse,
   ReplayStep,
+  TranscriptResponse,
 } from "@/lib/api/types";
 import { isAgentAwaitingHumanInput, isRunActive } from "@/lib/run-status";
+import { getRunAgentTranscript } from "@/lib/api/multi-turn";
 import { Badge } from "@/components/ui/badge";
 import { ReplayTimeline } from "@/components/replay/replay-timeline";
+import { ConversationTranscript } from "@/components/replay/conversation-transcript";
 import { AwaitingHumanBanner } from "@/components/replay/awaiting-human-banner";
 import { Panel } from "../scorecard/components/panel";
 import { toast } from "sonner";
@@ -64,6 +67,7 @@ export function ReplayViewerClient({
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [liveAgent, setLiveAgent] = useState<RunAgent>(agent);
   const [liveRunStatus, setLiveRunStatus] = useState<Run["status"]>(run.status);
+  const [transcript, setTranscript] = useState<TranscriptResponse | null>(null);
 
   // When the inspector sheet deep-links in with ?step=<sequence>, the timeline
   // highlights + auto-scrolls to that step. NaN is filtered by the consumer.
@@ -103,6 +107,29 @@ export function ReplayViewerClient({
     const interval = setInterval(() => void refreshLiveStatus(), HUMAN_TURN_POLL_MS);
     return () => clearInterval(interval);
   }, [isRunActiveStatus, getAccessToken, run.id, agent.id]);
+
+  // Fetch the multi-turn transcript. Re-fetch while the run is active so the
+  // conversation grows live; single-turn runs simply return zero turns.
+  useEffect(() => {
+    let cancelled = false;
+    const fetchTranscript = async () => {
+      try {
+        const token = await getAccessToken();
+        const api = createApiClient(token);
+        const res = await getRunAgentTranscript(api, agent.id);
+        if (!cancelled) setTranscript(res);
+      } catch {
+        // Transcript is supplementary; ignore errors so the replay stays usable.
+      }
+    };
+    void fetchTranscript();
+    if (!isRunActiveStatus) return;
+    const interval = setInterval(() => void fetchTranscript(), HUMAN_TURN_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [getAccessToken, agent.id, isRunActiveStatus]);
 
   // Auto-poll when pending
   useEffect(() => {
@@ -271,6 +298,16 @@ export function ReplayViewerClient({
             </span>
           )}
         </Panel>
+      )}
+
+      {/* Multi-turn conversation transcript (only present for multi_turn runs) */}
+      {transcript && transcript.turns.length > 0 && (
+        <ConversationTranscript
+          turns={transcript.turns}
+          notice={
+            transcript.state === "errored" ? transcript.message : undefined
+          }
+        />
       )}
 
       {/* Timeline */}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/replay/replay-viewer-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/replay/replay-viewer-client.tsx
@@ -123,11 +123,15 @@ export function ReplayViewerClient({
       }
     };
     void fetchTranscript();
-    if (!isRunActiveStatus) return;
-    const interval = setInterval(() => void fetchTranscript(), HUMAN_TURN_POLL_MS);
+    // Always return a cleanup that flips `cancelled`, even on the inactive
+    // path. Otherwise a still-in-flight fetch from a prior render can resolve
+    // after a newer one and clobber the transcript with stale data.
+    const interval = isRunActiveStatus
+      ? setInterval(() => void fetchTranscript(), HUMAN_TURN_POLL_MS)
+      : undefined;
     return () => {
       cancelled = true;
-      clearInterval(interval);
+      if (interval !== undefined) clearInterval(interval);
     };
   }, [getAccessToken, agent.id, isRunActiveStatus]);
 

--- a/web/src/components/replay/conversation-transcript.tsx
+++ b/web/src/components/replay/conversation-transcript.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import type { ReactNode } from "react";
+import type { TranscriptTurn } from "@/lib/api/types";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Panel, PanelHeader } from "@/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/components/panel";
+import { cn } from "@/lib/utils";
+import {
+  MessagesSquare,
+  GraduationCap,
+  Bot,
+  User,
+  ScrollText,
+  AlertTriangle,
+  Clock,
+} from "lucide-react";
+
+interface ConversationTranscriptProps {
+  turns: TranscriptTurn[];
+  /** Optional actions rendered in the panel header (e.g. the export button). */
+  trailing?: ReactNode;
+  /** Banner text shown above the conversation (e.g. a failed-run warning). */
+  notice?: string;
+}
+
+/** Friendly label + icon for the simulated-user side of a turn. */
+function studentIdentity(actor?: string): { label: string; icon: ReactNode } {
+  switch (actor) {
+    case "llm":
+      return { label: "Student · LLM", icon: <GraduationCap className="size-3.5" /> };
+    case "human":
+      return { label: "Student · Human", icon: <User className="size-3.5" /> };
+    case "scripted":
+      return { label: "Student · Scripted", icon: <ScrollText className="size-3.5" /> };
+    default:
+      return { label: "Student", icon: <GraduationCap className="size-3.5" /> };
+  }
+}
+
+export function ConversationTranscript({
+  turns,
+  trailing,
+  notice,
+}: ConversationTranscriptProps) {
+  if (turns.length === 0) {
+    return (
+      <Panel className="overflow-hidden">
+        <PanelHeader title="Conversation" icon={<MessagesSquare className="size-4" />} trailing={trailing} />
+        <EmptyState
+          icon={<MessagesSquare className="size-10 text-muted-foreground" />}
+          title="No conversation turns"
+          description="This run did not record a multi-turn conversation."
+        />
+      </Panel>
+    );
+  }
+
+  return (
+    <Panel className="overflow-hidden">
+      <PanelHeader
+        title={`Conversation · ${turns.length} turn${turns.length === 1 ? "" : "s"}`}
+        icon={<MessagesSquare className="size-4" />}
+        trailing={trailing}
+      />
+
+      {notice && (
+        <div className="flex items-center gap-2 border-b border-amber-500/20 bg-amber-500/[0.05] px-4 py-2.5 text-xs text-amber-400/90">
+          <AlertTriangle className="size-3.5 shrink-0" />
+          <span>{notice}</span>
+        </div>
+      )}
+
+      <div className="divide-y divide-white/[0.05]">
+        {turns.map((turn) => (
+          <TurnBlock key={turn.turn_index} turn={turn} />
+        ))}
+      </div>
+    </Panel>
+  );
+}
+
+function TurnBlock({ turn }: { turn: TranscriptTurn }) {
+  const student = studentIdentity(turn.actor);
+  return (
+    <div className="px-4 py-4 sm:px-5">
+      {/* Turn header */}
+      <div className="mb-3 flex items-center gap-2">
+        <span className="font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.18em] text-white/35">
+          Turn {turn.turn_index}
+        </span>
+        {turn.phase_id && (
+          <Badge
+            variant="outline"
+            className="border-white/10 bg-white/[0.03] px-1.5 py-0 text-[10px] font-normal text-white/55"
+          >
+            {turn.phase_id}
+          </Badge>
+        )}
+        {turn.mismatch && (
+          <Badge variant="destructive" className="px-1.5 py-0 text-[10px]">
+            mismatch
+          </Badge>
+        )}
+        {turn.awaiting_human && (
+          <Badge
+            variant="outline"
+            className="flex items-center gap-1 border-amber-500/30 bg-amber-500/[0.06] px-1.5 py-0 text-[10px] font-normal text-amber-400/90"
+          >
+            <Clock className="size-3" /> awaiting human
+          </Badge>
+        )}
+      </div>
+
+      <div className="space-y-3">
+        {turn.user_message && (
+          <SpeakerRow
+            icon={student.icon}
+            label={student.label}
+            accent="student"
+            content={turn.user_message}
+          />
+        )}
+        {turn.assistant_message && (
+          <SpeakerRow
+            icon={<Bot className="size-3.5" />}
+            label="Agent"
+            accent="agent"
+            content={turn.assistant_message}
+          />
+        )}
+        {turn.awaiting_human && turn.awaiting_human_hint && (
+          <p className="pl-[1.6rem] text-xs italic text-amber-400/70">
+            {turn.awaiting_human_hint}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SpeakerRow({
+  icon,
+  label,
+  accent,
+  content,
+}: {
+  icon: ReactNode;
+  label: string;
+  accent: "student" | "agent";
+  content: string;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div
+        className={cn(
+          "flex items-center gap-1.5 text-[10px] uppercase tracking-[0.16em]",
+          accent === "student" ? "text-cyan-300/70" : "text-violet-300/70",
+        )}
+      >
+        <span className={accent === "student" ? "text-cyan-300/80" : "text-violet-300/80"}>
+          {icon}
+        </span>
+        {label}
+      </div>
+      <div
+        className={cn(
+          "rounded-md border px-3.5 py-2.5 text-[13px] leading-relaxed whitespace-pre-wrap break-words",
+          accent === "student"
+            ? "border-cyan-400/15 bg-cyan-400/[0.04] text-white/85"
+            : "border-violet-400/15 bg-violet-400/[0.04] text-white/85",
+        )}
+      >
+        {content}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/api/multi-turn.ts
+++ b/web/src/lib/api/multi-turn.ts
@@ -1,4 +1,19 @@
 import type { ApiClient } from "./client";
+import type { TranscriptResponse } from "./types";
+
+/**
+ * Fetch the reconstructed multi-turn conversation transcript for a run-agent.
+ * Allows 409 so a failed run's partial transcript is still readable from the
+ * response body.
+ */
+export async function getRunAgentTranscript(
+  api: ApiClient,
+  runAgentId: string,
+): Promise<TranscriptResponse> {
+  return api.get<TranscriptResponse>(`/v1/replays/${runAgentId}/transcript`, {
+    allowedStatuses: [202, 409],
+  });
+}
 
 export interface HumanTurnStatus {
   awaiting_human: boolean;

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -1256,6 +1256,33 @@ export interface ReplayResponse {
   pagination: ReplayPagination;
 }
 
+// --- Multi-turn transcript ---
+
+/** One reconstructed user↔assistant turn. Mirrors transcriptTurnPayload in Go. */
+export interface TranscriptTurn {
+  turn_index: number;
+  phase_id?: string;
+  actor?: string; // "scripted" | "llm" | "human"
+  user_message?: string;
+  assistant_message?: string;
+  mismatch: boolean;
+  completed: boolean;
+  awaiting_human: boolean;
+  awaiting_human_hint?: string;
+  user_simulated: boolean;
+}
+
+/** GET /v1/replays/{runAgentID}/transcript — mirrors getRunAgentTranscriptResponse in Go. */
+export interface TranscriptResponse {
+  state: ReplayState; // "ready" | "pending" | "errored"
+  message?: string;
+  run_agent_id: string;
+  run_id: string;
+  run_agent_status: RunAgentStatus;
+  turn_count: number;
+  turns: TranscriptTurn[];
+}
+
 // --- Scorecards ---
 
 /** GET /v1/scorecards/{runAgentID} — mirrors getRunAgentScorecardResponse in Go. */


### PR DESCRIPTION
**PR 2 of 4** in the multi-turn transcript-viewer stack. Builds on the transcript endpoint from #864 (merged).

## Summary

Renders the reconstructed multi-turn conversation on the run-agent replay page.

- **Types**: `TranscriptTurn` / `TranscriptResponse` mirroring the Go payload.
- **API helper**: `getRunAgentTranscript()` — allows `202`/`409` so a pending or failed run's *partial* transcript is still readable from the body.
- **`ConversationTranscript` component**: a scannable, full-width speaker-row layout — **student** (cyan) vs **agent** (violet) rows grouped by turn, with turn-index, phase, `mismatch`, and `awaiting-human` badges. Matches the existing instrument-panel aesthetic (`Panel`/`PanelHeader`, white-alpha hairlines, display/mono tokens). Chosen over chat bubbles because it reads cleanly on screen and translates well to the PDF export in PR 3.
- **Replay wiring**: fetches the transcript on load and re-fetches while the run is active (live-growing conversation); renders the component above the step timeline *only when turns exist*, so single-turn runs are visually unchanged. A failed-run notice banner surfaces the `errored` message.

## Test plan

- [x] `npx tsc --noEmit` — zero errors in the changed files (pre-existing repo errors from stale `.next/types` and an uninstalled `react-syntax-highlighter` are unrelated)
- [x] `npx eslint` on the three changed/new source files — clean
- [ ] **Visual QA (needs reviewer):** I can't run the authenticated web app + backend + a real multi-turn run in my environment, so the component is built to match existing design tokens but not yet screenshot-verified. Please eyeball it on a real multi_turn run (e.g. `syllabus-gen-multi-turn-v0`).

## Stack

1. ✅ backend transcript endpoint (#864, merged)
2. **← this PR** — transcript view on replay page
3. PDF export (`@react-pdf/renderer` + Download button)
4. scorecard embed

🤖 Generated with [Claude Code](https://claude.com/claude-code)