### PR TITLE
feat(web): multi-turn transcript + PDF export on scorecard

### DIFF
--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/scorecard-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/scorecard-client.tsx
@@ -162,7 +162,9 @@ export function ScorecardClient({
             <MetricsPanel metrics={metrics} onInspect={setInspected} />
             <JudgesPanel judges={judges} onInspect={setInspected} />
 
-            {transcript && transcript.turns.length > 0 && (
+            {transcript &&
+              (transcript.turns.length > 0 ||
+                transcript.state === "errored") && (
               <ConversationTranscript
                 turns={transcript.turns}
                 notice={

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/scorecard-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/scorecard-client.tsx
@@ -9,7 +9,11 @@ import type {
   RunAgent,
   RunRankingResponse,
   ScorecardResponse,
+  TranscriptResponse,
 } from "@/lib/api/types";
+import { getRunAgentTranscript } from "@/lib/api/multi-turn";
+import { ConversationTranscript } from "@/components/replay/conversation-transcript";
+import { DownloadTranscriptButton } from "@/components/replay/download-transcript-button";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Loader2, AlertTriangle } from "lucide-react";
 
@@ -44,6 +48,7 @@ export function ScorecardClient({
   const [scorecard, setScorecard] = useState<ScorecardResponse>(initialScorecard);
   const [ranking, setRanking] = useState<RunRankingResponse | null>(null);
   const [inspected, setInspected] = useState<InspectorTarget | null>(null);
+  const [transcript, setTranscript] = useState<TranscriptResponse | null>(null);
 
   const isPending = scorecard.state === "pending";
   const isErrored = scorecard.state === "errored";
@@ -93,6 +98,26 @@ export function ScorecardClient({
     };
   }, [isReady, getAccessToken, run.id]);
 
+  // Fetch the multi-turn transcript once scoring has settled. Single-turn
+  // runs return zero turns and the section stays hidden.
+  useEffect(() => {
+    if (!isReady) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = await getAccessToken();
+        const api = createApiClient(token);
+        const res = await getRunAgentTranscript(api, agent.id);
+        if (!cancelled) setTranscript(res);
+      } catch {
+        // Transcript is supplementary; ignore errors.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isReady, getAccessToken, agent.id]);
+
   const doc = scorecard.scorecard;
   const validators = doc?.validator_details ?? [];
   const metrics = doc?.metric_details ?? [];
@@ -136,6 +161,26 @@ export function ScorecardClient({
             />
             <MetricsPanel metrics={metrics} onInspect={setInspected} />
             <JudgesPanel judges={judges} onInspect={setInspected} />
+
+            {transcript && transcript.turns.length > 0 && (
+              <ConversationTranscript
+                turns={transcript.turns}
+                notice={
+                  transcript.state === "errored" ? transcript.message : undefined
+                }
+                trailing={
+                  <DownloadTranscriptButton
+                    turns={transcript.turns}
+                    meta={{
+                      agentLabel: agent.label,
+                      runName: run.name,
+                      runId: run.id,
+                      runAgentId: agent.id,
+                    }}
+                  />
+                }
+              />
+            )}
           </>
         )}
 

--- a/web/src/components/replay/conversation-transcript.tsx
+++ b/web/src/components/replay/conversation-transcript.tsx
@@ -47,10 +47,20 @@ export function ConversationTranscript({
     return (
       <Panel className="overflow-hidden">
         <PanelHeader title="Conversation" icon={<MessagesSquare className="size-4" />} trailing={trailing} />
+        {notice && (
+          <div className="flex items-center gap-2 border-b border-amber-500/20 bg-amber-500/[0.05] px-4 py-2.5 text-xs text-amber-400/90">
+            <AlertTriangle className="size-3.5 shrink-0" />
+            <span>{notice}</span>
+          </div>
+        )}
         <EmptyState
           icon={<MessagesSquare className="size-10 text-muted-foreground" />}
           title="No conversation turns"
-          description="This run did not record a multi-turn conversation."
+          description={
+            notice
+              ? "The run ended before any conversation turns were recorded."
+              : "This run did not record a multi-turn conversation."
+          }
         />
       </Panel>
     );


### PR DESCRIPTION
**PR 4 of 4 (final)** in the multi-turn transcript-viewer stack. Builds on #864, #865, #866 (all merged).

## Summary

Surfaces the conversation transcript on the **scorecard** page, so the multi-turn conversation can be read and exported right alongside the scores — reusing the components built in the replay PRs (no new UI primitives).

- Fetches the transcript once scoring has settled (`isReady`); single-turn runs return zero turns and the section stays hidden.
- Renders the `ConversationTranscript` below the judges panel, with the `DownloadTranscriptButton` (Export PDF) in the header's `trailing` slot — identical UX to the replay page.
- Failed-run notice banner surfaces the `errored` message.

## Test plan

- [x] `npx tsc --noEmit` — zero errors in the changed file
- [x] `npx eslint` — clean
- [ ] **Visual QA (needs reviewer):** placement/spacing on the scorecard page on a real multi-turn run. Components themselves were shipped in #865/#866.

## Stack — complete after this merges

1. ✅ backend transcript endpoint (#864)
2. ✅ transcript view on replay page (#865)
3. ✅ PDF export (#866)
4. **← this PR** — scorecard embed

## Net feature

A multi-turn eval (LLM student vs. LLM agent-under-test) now renders its full conversation on both the replay and scorecard pages, with a one-click beautiful PDF export from either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)