### PR TITLE
feat: validate and publish Vibe Eval drafts

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -155,7 +155,7 @@ func main() {
 	onboardingManager := api.NewOnboardingManager(repo)
 	infraManager := api.NewInfrastructureManager(repo).WithProviderClient(providerRouter)
 	workspaceSecretsManager := api.NewWorkspaceSecretsManager(repo)
-	vibeEvalManager := api.NewVibeEvalManager(authorizer, repo)
+	vibeEvalManager := api.NewVibeEvalManager(authorizer, repo, challengePackAuthoringManager)
 	cliAuthManager := api.NewCLIAuthManager(repo, logger, cfg.FrontendURL)
 	cliTokenAuth := api.NewCLITokenAuthenticator(repo, logger)
 

--- a/backend/db/migrations/00050_vibe_eval_draft_events.sql
+++ b/backend/db/migrations/00050_vibe_eval_draft_events.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+CREATE TABLE vibe_eval_draft_events (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id uuid NOT NULL REFERENCES organizations (id) ON DELETE CASCADE,
+    workspace_id uuid NOT NULL,
+    conversation_id uuid NOT NULL,
+    draft_id uuid NOT NULL,
+    actor_user_id uuid NOT NULL REFERENCES users (id) ON DELETE RESTRICT,
+    action text NOT NULL CHECK (action IN ('validate_challenge_pack', 'publish_challenge_pack')),
+    payload_hash text NOT NULL,
+    request_payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+    result_payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    FOREIGN KEY (workspace_id, organization_id) REFERENCES workspaces (id, organization_id) ON DELETE CASCADE,
+    FOREIGN KEY (conversation_id, workspace_id) REFERENCES vibe_eval_conversations (id, workspace_id) ON DELETE CASCADE,
+    FOREIGN KEY (draft_id) REFERENCES vibe_eval_drafts (id) ON DELETE CASCADE
+);
+
+CREATE INDEX vibe_eval_draft_events_draft_idx
+    ON vibe_eval_draft_events (draft_id, created_at DESC);
+
+-- +goose Down
+DROP TABLE IF EXISTS vibe_eval_draft_events;

--- a/backend/db/queries/vibe_eval.sql
+++ b/backend/db/queries/vibe_eval.sql
@@ -83,3 +83,47 @@ SET
     updated_by_user_id = @updated_by_user_id
 WHERE id = @id
 RETURNING *;
+
+-- name: MarkVibeEvalDraftValidation :one
+UPDATE vibe_eval_drafts
+SET
+    validation_state = @validation_state,
+    validation_errors = @validation_errors,
+    updated_by_user_id = @updated_by_user_id
+WHERE id = @id
+RETURNING *;
+
+-- name: MarkVibeEvalDraftPublished :one
+UPDATE vibe_eval_drafts
+SET
+    validation_state = 'valid',
+    validation_errors = '[]'::jsonb,
+    published_challenge_pack_id = @published_challenge_pack_id,
+    published_challenge_pack_version_id = @published_challenge_pack_version_id,
+    updated_by_user_id = @updated_by_user_id
+WHERE id = @id
+RETURNING *;
+
+-- name: CreateVibeEvalDraftEvent :exec
+INSERT INTO vibe_eval_draft_events (
+    organization_id,
+    workspace_id,
+    conversation_id,
+    draft_id,
+    actor_user_id,
+    action,
+    payload_hash,
+    request_payload,
+    result_payload
+)
+VALUES (
+    @organization_id,
+    @workspace_id,
+    @conversation_id,
+    @draft_id,
+    @actor_user_id,
+    @action,
+    @payload_hash,
+    @request_payload,
+    @result_payload
+);

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -217,6 +217,10 @@ func registerProtectedRoutes(
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Patch("/workspaces/{workspaceID}/vibe-eval/drafts/{draftID}", updateVibeEvalDraftHandler(logger, vibeEvalService))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Post("/workspaces/{workspaceID}/vibe-eval/drafts/{draftID}/validate", validateVibeEvalDraftHandler(logger, vibeEvalService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
+		Post("/workspaces/{workspaceID}/vibe-eval/drafts/{draftID}/publish", publishVibeEvalDraftHandler(logger, vibeEvalService))
+	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Get("/workspaces/{workspaceID}/artifacts", listWorkspaceArtifactsHandler(logger, artifactService))
 	router.With(authorizeWorkspaceAccess(logger, authorizer, workspaceIDFromURLParam("workspaceID"))).
 		Post("/workspaces/{workspaceID}/artifacts", uploadArtifactHandler(logger, artifactService, artifactMaxUploadBytes))

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -421,6 +421,12 @@ func (noopVibeEvalService) GetDraft(context.Context, Caller, GetVibeEvalDraftInp
 func (noopVibeEvalService) UpdateDraft(context.Context, Caller, UpdateVibeEvalDraftInput) (repository.VibeEvalDraft, error) {
 	return repository.VibeEvalDraft{}, errors.New("vibe eval service is not configured")
 }
+func (noopVibeEvalService) ValidateDraft(context.Context, Caller, ValidateVibeEvalDraftInput) (ValidateVibeEvalDraftResult, error) {
+	return ValidateVibeEvalDraftResult{}, errors.New("vibe eval service is not configured")
+}
+func (noopVibeEvalService) PublishDraft(context.Context, Caller, PublishVibeEvalDraftInput) (PublishVibeEvalDraftResult, error) {
+	return PublishVibeEvalDraftResult{}, errors.New("vibe eval service is not configured")
+}
 
 type noopCompareReadService struct{}
 

--- a/backend/internal/api/vibe_eval.go
+++ b/backend/internal/api/vibe_eval.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -26,6 +28,9 @@ type VibeEvalRepository interface {
 	ListVibeEvalDraftsByConversationID(ctx context.Context, conversationID uuid.UUID) ([]repository.VibeEvalDraft, error)
 	GetVibeEvalDraftByID(ctx context.Context, id uuid.UUID) (repository.VibeEvalDraft, error)
 	UpdateVibeEvalDraft(ctx context.Context, params repository.UpdateVibeEvalDraftParams) (repository.VibeEvalDraft, error)
+	MarkVibeEvalDraftValidation(ctx context.Context, params repository.MarkVibeEvalDraftValidationParams) (repository.VibeEvalDraft, error)
+	MarkVibeEvalDraftPublished(ctx context.Context, params repository.MarkVibeEvalDraftPublishedParams) (repository.VibeEvalDraft, error)
+	CreateVibeEvalDraftEvent(ctx context.Context, params repository.CreateVibeEvalDraftEventParams) error
 }
 
 type VibeEvalService interface {
@@ -36,15 +41,18 @@ type VibeEvalService interface {
 	ListDrafts(ctx context.Context, caller Caller, input ListVibeEvalDraftsInput) ([]repository.VibeEvalDraft, error)
 	GetDraft(ctx context.Context, caller Caller, input GetVibeEvalDraftInput) (repository.VibeEvalDraft, error)
 	UpdateDraft(ctx context.Context, caller Caller, input UpdateVibeEvalDraftInput) (repository.VibeEvalDraft, error)
+	ValidateDraft(ctx context.Context, caller Caller, input ValidateVibeEvalDraftInput) (ValidateVibeEvalDraftResult, error)
+	PublishDraft(ctx context.Context, caller Caller, input PublishVibeEvalDraftInput) (PublishVibeEvalDraftResult, error)
 }
 
 type VibeEvalManager struct {
-	authorizer WorkspaceAuthorizer
-	repo       VibeEvalRepository
+	authorizer             WorkspaceAuthorizer
+	repo                   VibeEvalRepository
+	challengePackAuthoring ChallengePackAuthoringService
 }
 
-func NewVibeEvalManager(authorizer WorkspaceAuthorizer, repo VibeEvalRepository) *VibeEvalManager {
-	return &VibeEvalManager{authorizer: authorizer, repo: repo}
+func NewVibeEvalManager(authorizer WorkspaceAuthorizer, repo VibeEvalRepository, challengePackAuthoring ChallengePackAuthoringService) *VibeEvalManager {
+	return &VibeEvalManager{authorizer: authorizer, repo: repo, challengePackAuthoring: challengePackAuthoring}
 }
 
 type VibeEvalValidationError struct {
@@ -53,6 +61,13 @@ type VibeEvalValidationError struct {
 }
 
 func (e VibeEvalValidationError) Error() string { return e.Message }
+
+type VibeEvalConfirmationRequiredError struct {
+	PayloadHash string
+	Summary     string
+}
+
+func (e VibeEvalConfirmationRequiredError) Error() string { return "confirmation required" }
 
 type CreateVibeEvalConversationInput struct {
 	WorkspaceID uuid.UUID
@@ -90,6 +105,34 @@ type UpdateVibeEvalDraftInput struct {
 	Content          json.RawMessage
 	ValidationState  string
 	ValidationErrors json.RawMessage
+}
+
+type ValidateVibeEvalDraftInput struct {
+	WorkspaceID uuid.UUID
+	DraftID     uuid.UUID
+}
+
+type PublishVibeEvalDraftInput struct {
+	WorkspaceID       uuid.UUID
+	DraftID           uuid.UUID
+	ConfirmationToken string
+}
+
+type ValidateVibeEvalDraftResult struct {
+	Draft       repository.VibeEvalDraft
+	Valid       bool
+	Errors      []validationErrorDetail
+	PayloadHash string
+}
+
+type PublishVibeEvalDraftResult struct {
+	Draft                  repository.VibeEvalDraft
+	ChallengePackID        uuid.UUID
+	ChallengePackVersionID uuid.UUID
+	EvaluationSpecID       uuid.UUID
+	InputSetIDs            []uuid.UUID
+	BundleArtifactID       *uuid.UUID
+	PayloadHash            string
 }
 
 func (m *VibeEvalManager) CreateConversation(ctx context.Context, caller Caller, input CreateVibeEvalConversationInput) (repository.VibeEvalConversation, error) {
@@ -220,6 +263,139 @@ func (m *VibeEvalManager) UpdateDraft(ctx context.Context, caller Caller, input 
 	})
 }
 
+func (m *VibeEvalManager) ValidateDraft(ctx context.Context, caller Caller, input ValidateVibeEvalDraftInput) (ValidateVibeEvalDraftResult, error) {
+	draft, err := m.GetDraft(ctx, caller, GetVibeEvalDraftInput{WorkspaceID: input.WorkspaceID, DraftID: input.DraftID})
+	if err != nil {
+		return ValidateVibeEvalDraftResult{}, err
+	}
+	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, draft.WorkspaceID, ActionManageVibeEvalDrafts); err != nil {
+		return ValidateVibeEvalDraftResult{}, err
+	}
+	if draft.DraftKind != "challenge_pack" {
+		return ValidateVibeEvalDraftResult{}, VibeEvalValidationError{Code: "validation_error", Message: "draft must be a challenge_pack draft"}
+	}
+	if m.challengePackAuthoring == nil {
+		return ValidateVibeEvalDraftResult{}, errors.New("challenge pack authoring service is not configured")
+	}
+	bundleYAML, err := vibeEvalDraftBundleYAML(draft)
+	if err != nil {
+		return ValidateVibeEvalDraftResult{}, err
+	}
+	payloadHash := vibeEvalPayloadHash(bundleYAML)
+	validation, err := m.challengePackAuthoring.ValidateBundle(ctx, draft.WorkspaceID, bundleYAML)
+	if err != nil {
+		return ValidateVibeEvalDraftResult{}, err
+	}
+	validationErrors, err := json.Marshal(validation.Errors)
+	if err != nil {
+		return ValidateVibeEvalDraftResult{}, fmt.Errorf("marshal validation errors: %w", err)
+	}
+	state := "invalid"
+	if validation.Valid {
+		state = "valid"
+		validationErrors = []byte("[]")
+	}
+	updated, err := m.repo.MarkVibeEvalDraftValidation(ctx, repository.MarkVibeEvalDraftValidationParams{
+		ID:               draft.ID,
+		ValidationState:  state,
+		ValidationErrors: validationErrors,
+		UpdatedByUserID:  caller.UserID,
+	})
+	if err != nil {
+		return ValidateVibeEvalDraftResult{}, err
+	}
+	if err := m.auditVibeEvalDraftEvent(ctx, caller, updated, "validate_challenge_pack", payloadHash, map[string]any{
+		"draft_kind": draft.DraftKind,
+	}, map[string]any{
+		"valid":  validation.Valid,
+		"errors": validation.Errors,
+	}); err != nil {
+		return ValidateVibeEvalDraftResult{}, err
+	}
+	return ValidateVibeEvalDraftResult{
+		Draft:       updated,
+		Valid:       validation.Valid,
+		Errors:      validation.Errors,
+		PayloadHash: payloadHash,
+	}, nil
+}
+
+func (m *VibeEvalManager) PublishDraft(ctx context.Context, caller Caller, input PublishVibeEvalDraftInput) (PublishVibeEvalDraftResult, error) {
+	draft, err := m.GetDraft(ctx, caller, GetVibeEvalDraftInput{WorkspaceID: input.WorkspaceID, DraftID: input.DraftID})
+	if err != nil {
+		return PublishVibeEvalDraftResult{}, err
+	}
+	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, draft.WorkspaceID, ActionPublishChallengePack); err != nil {
+		return PublishVibeEvalDraftResult{}, err
+	}
+	if draft.DraftKind != "challenge_pack" {
+		return PublishVibeEvalDraftResult{}, VibeEvalValidationError{Code: "validation_error", Message: "draft must be a challenge_pack draft"}
+	}
+	if draft.ValidationState != "valid" {
+		return PublishVibeEvalDraftResult{}, VibeEvalValidationError{Code: "validation_error", Message: "draft must validate before publish"}
+	}
+	if m.challengePackAuthoring == nil {
+		return PublishVibeEvalDraftResult{}, errors.New("challenge pack authoring service is not configured")
+	}
+	bundleYAML, err := vibeEvalDraftBundleYAML(draft)
+	if err != nil {
+		return PublishVibeEvalDraftResult{}, err
+	}
+	payloadHash := vibeEvalPayloadHash(bundleYAML)
+	if strings.TrimSpace(input.ConfirmationToken) != payloadHash {
+		return PublishVibeEvalDraftResult{}, VibeEvalConfirmationRequiredError{
+			PayloadHash: payloadHash,
+			Summary:     "Publish this validated Vibe Eval draft as a runnable challenge pack.",
+		}
+	}
+	published, err := m.challengePackAuthoring.PublishBundle(ctx, draft.WorkspaceID, bundleYAML)
+	if err != nil {
+		var validationErr ChallengePackAuthoringValidationError
+		if errors.As(err, &validationErr) {
+			validationErrors, marshalErr := json.Marshal(validationErr.Errors)
+			if marshalErr != nil {
+				return PublishVibeEvalDraftResult{}, fmt.Errorf("marshal validation errors: %w", marshalErr)
+			}
+			_, _ = m.repo.MarkVibeEvalDraftValidation(ctx, repository.MarkVibeEvalDraftValidationParams{
+				ID:               draft.ID,
+				ValidationState:  "invalid",
+				ValidationErrors: validationErrors,
+				UpdatedByUserID:  caller.UserID,
+			})
+		}
+		return PublishVibeEvalDraftResult{}, err
+	}
+	updated, err := m.repo.MarkVibeEvalDraftPublished(ctx, repository.MarkVibeEvalDraftPublishedParams{
+		ID:                              draft.ID,
+		PublishedChallengePackID:        published.ChallengePackID,
+		PublishedChallengePackVersionID: published.ChallengePackVersionID,
+		UpdatedByUserID:                 caller.UserID,
+	})
+	if err != nil {
+		return PublishVibeEvalDraftResult{}, err
+	}
+	if err := m.auditVibeEvalDraftEvent(ctx, caller, updated, "publish_challenge_pack", payloadHash, map[string]any{
+		"confirmation_token": payloadHash,
+	}, map[string]any{
+		"challenge_pack_id":         published.ChallengePackID,
+		"challenge_pack_version_id": published.ChallengePackVersionID,
+		"evaluation_spec_id":        published.EvaluationSpecID,
+		"input_set_ids":             published.InputSetIDs,
+		"bundle_artifact_id":        published.BundleArtifactID,
+	}); err != nil {
+		return PublishVibeEvalDraftResult{}, err
+	}
+	return PublishVibeEvalDraftResult{
+		Draft:                  updated,
+		ChallengePackID:        published.ChallengePackID,
+		ChallengePackVersionID: published.ChallengePackVersionID,
+		EvaluationSpecID:       published.EvaluationSpecID,
+		InputSetIDs:            published.InputSetIDs,
+		BundleArtifactID:       published.BundleArtifactID,
+		PayloadHash:            payloadHash,
+	}, nil
+}
+
 func validVibeEvalPhase(phase string) bool {
 	switch phase {
 	case "plan", "author", "validate", "publish", "run", "analyze", "regress", "admin":
@@ -286,6 +462,58 @@ func normalizeArrayJSON(raw json.RawMessage) json.RawMessage {
 	return append(json.RawMessage(nil), raw...)
 }
 
+func vibeEvalDraftBundleYAML(draft repository.VibeEvalDraft) ([]byte, error) {
+	var content struct {
+		BundleYAML   string `json:"bundle_yaml"`
+		YAML         string `json:"yaml"`
+		ManifestYAML string `json:"manifest_yaml"`
+	}
+	if err := json.Unmarshal(draft.Content, &content); err != nil {
+		return nil, VibeEvalValidationError{Code: "validation_error", Message: "draft content must be a JSON object"}
+	}
+	bundleYAML := strings.TrimSpace(content.BundleYAML)
+	if bundleYAML == "" {
+		bundleYAML = strings.TrimSpace(content.YAML)
+	}
+	if bundleYAML == "" {
+		bundleYAML = strings.TrimSpace(content.ManifestYAML)
+	}
+	if bundleYAML == "" {
+		return nil, VibeEvalValidationError{Code: "validation_error", Message: "challenge_pack draft content must include bundle_yaml"}
+	}
+	return []byte(bundleYAML), nil
+}
+
+func vibeEvalPayloadHash(payload []byte) string {
+	sum := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func marshalVibeEvalEventPayload(payload map[string]any) json.RawMessage {
+	if len(payload) == 0 {
+		return json.RawMessage(`{}`)
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return json.RawMessage(`{"error":"payload_marshal_failed"}`)
+	}
+	return encoded
+}
+
+func (m *VibeEvalManager) auditVibeEvalDraftEvent(ctx context.Context, caller Caller, draft repository.VibeEvalDraft, action string, payloadHash string, request map[string]any, result map[string]any) error {
+	return m.repo.CreateVibeEvalDraftEvent(ctx, repository.CreateVibeEvalDraftEventParams{
+		OrganizationID: draft.OrganizationID,
+		WorkspaceID:    draft.WorkspaceID,
+		ConversationID: draft.ConversationID,
+		DraftID:        draft.ID,
+		ActorUserID:    caller.UserID,
+		Action:         action,
+		PayloadHash:    payloadHash,
+		RequestPayload: marshalVibeEvalEventPayload(request),
+		ResultPayload:  marshalVibeEvalEventPayload(result),
+	})
+}
+
 type vibeEvalConversationResponse struct {
 	ID              uuid.UUID  `json:"id"`
 	OrganizationID  uuid.UUID  `json:"organization_id"`
@@ -314,6 +542,23 @@ type vibeEvalDraftResponse struct {
 	UpdatedByUserID                 uuid.UUID       `json:"updated_by_user_id"`
 	CreatedAt                       string          `json:"created_at"`
 	UpdatedAt                       string          `json:"updated_at"`
+}
+
+type validateVibeEvalDraftResponse struct {
+	Draft       vibeEvalDraftResponse   `json:"draft"`
+	Valid       bool                    `json:"valid"`
+	Errors      []validationErrorDetail `json:"errors"`
+	PayloadHash string                  `json:"payload_hash"`
+}
+
+type publishVibeEvalDraftResponse struct {
+	Draft                  vibeEvalDraftResponse `json:"draft"`
+	ChallengePackID        uuid.UUID             `json:"challenge_pack_id"`
+	ChallengePackVersionID uuid.UUID             `json:"challenge_pack_version_id"`
+	EvaluationSpecID       uuid.UUID             `json:"evaluation_spec_id"`
+	InputSetIDs            []uuid.UUID           `json:"input_set_ids"`
+	BundleArtifactID       *uuid.UUID            `json:"bundle_artifact_id,omitempty"`
+	PayloadHash            string                `json:"payload_hash"`
 }
 
 func createVibeEvalConversationHandler(logger *slog.Logger, service VibeEvalService) http.HandlerFunc {
@@ -490,6 +735,67 @@ func updateVibeEvalDraftHandler(logger *slog.Logger, service VibeEvalService) ht
 	}
 }
 
+func validateVibeEvalDraftHandler(logger *slog.Logger, service VibeEvalService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, workspaceID, ok := vibeEvalCallerAndWorkspace(w, r)
+		if !ok {
+			return
+		}
+		draftID, ok := parseVibeEvalURLUUID(w, "draftID", "invalid_draft_id", r)
+		if !ok {
+			return
+		}
+		result, err := service.ValidateDraft(r.Context(), caller, ValidateVibeEvalDraftInput{WorkspaceID: workspaceID, DraftID: draftID})
+		if err != nil {
+			handleVibeEvalError(w, logger, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, validateVibeEvalDraftResponse{
+			Draft:       mapVibeEvalDraftResponse(result.Draft),
+			Valid:       result.Valid,
+			Errors:      result.Errors,
+			PayloadHash: result.PayloadHash,
+		})
+	}
+}
+
+func publishVibeEvalDraftHandler(logger *slog.Logger, service VibeEvalService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, workspaceID, ok := vibeEvalCallerAndWorkspace(w, r)
+		if !ok {
+			return
+		}
+		draftID, ok := parseVibeEvalURLUUID(w, "draftID", "invalid_draft_id", r)
+		if !ok {
+			return
+		}
+		var req struct {
+			ConfirmationToken string `json:"confirmation_token"`
+		}
+		if !decodeVibeEvalJSON(w, r, &req) {
+			return
+		}
+		result, err := service.PublishDraft(r.Context(), caller, PublishVibeEvalDraftInput{
+			WorkspaceID:       workspaceID,
+			DraftID:           draftID,
+			ConfirmationToken: req.ConfirmationToken,
+		})
+		if err != nil {
+			handleVibeEvalError(w, logger, err)
+			return
+		}
+		writeJSON(w, http.StatusCreated, publishVibeEvalDraftResponse{
+			Draft:                  mapVibeEvalDraftResponse(result.Draft),
+			ChallengePackID:        result.ChallengePackID,
+			ChallengePackVersionID: result.ChallengePackVersionID,
+			EvaluationSpecID:       result.EvaluationSpecID,
+			InputSetIDs:            result.InputSetIDs,
+			BundleArtifactID:       result.BundleArtifactID,
+			PayloadHash:            result.PayloadHash,
+		})
+	}
+}
+
 func vibeEvalCallerAndWorkspace(w http.ResponseWriter, r *http.Request) (Caller, uuid.UUID, bool) {
 	caller, err := CallerFromContext(r.Context())
 	if err != nil {
@@ -526,13 +832,29 @@ func decodeVibeEvalJSON(w http.ResponseWriter, r *http.Request, dest any) bool {
 
 func handleVibeEvalError(w http.ResponseWriter, logger *slog.Logger, err error) {
 	var validationErr VibeEvalValidationError
+	var confirmationErr VibeEvalConfirmationRequiredError
+	var challengePackValidationErr ChallengePackAuthoringValidationError
 	switch {
 	case errors.As(err, &validationErr):
 		writeError(w, http.StatusBadRequest, validationErr.Code, validationErr.Message)
+	case errors.As(err, &confirmationErr):
+		writeJSON(w, http.StatusConflict, map[string]any{
+			"error": map[string]any{
+				"code":         "confirmation_required",
+				"message":      confirmationErr.Summary,
+				"payload_hash": confirmationErr.PayloadHash,
+			},
+		})
+	case errors.As(err, &challengePackValidationErr):
+		writeJSON(w, http.StatusBadRequest, ValidateChallengePackResponse{Valid: false, Errors: challengePackValidationErr.Errors})
 	case errors.Is(err, repository.ErrVibeEvalConversationNotFound):
 		writeError(w, http.StatusNotFound, "conversation_not_found", "vibe eval conversation not found")
 	case errors.Is(err, repository.ErrVibeEvalDraftNotFound):
 		writeError(w, http.StatusNotFound, "draft_not_found", "vibe eval draft not found")
+	case errors.Is(err, repository.ErrChallengePackVersionExists):
+		writeError(w, http.StatusConflict, "challenge_pack_version_exists", err.Error())
+	case errors.Is(err, repository.ErrChallengePackMetadataConflict):
+		writeError(w, http.StatusConflict, "challenge_pack_metadata_conflict", err.Error())
 	case errors.Is(err, ErrForbidden):
 		writeAuthzError(w, err)
 	default:

--- a/backend/internal/api/vibe_eval_test.go
+++ b/backend/internal/api/vibe_eval_test.go
@@ -16,7 +16,7 @@ func TestVibeEvalManager_CreateConversationAndDraft(t *testing.T) {
 	orgID := uuid.New()
 	userID := uuid.New()
 	repo := newFakeVibeEvalRepo(orgID, workspaceID)
-	manager := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo)
+	manager := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo, fakeVibeEvalChallengePackAuthoring{})
 	caller := vibeEvalCaller(userID, workspaceID, RoleWorkspaceMember)
 
 	conversation, err := manager.CreateConversation(context.Background(), caller, CreateVibeEvalConversationInput{
@@ -60,7 +60,7 @@ func TestVibeEvalManager_ViewerCanReadButCannotWrite(t *testing.T) {
 	memberID := uuid.New()
 	viewerID := uuid.New()
 	repo := newFakeVibeEvalRepo(orgID, workspaceID)
-	manager := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo)
+	manager := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo, fakeVibeEvalChallengePackAuthoring{})
 	member := vibeEvalCaller(memberID, workspaceID, RoleWorkspaceMember)
 	viewer := vibeEvalCaller(viewerID, workspaceID, RoleWorkspaceViewer)
 
@@ -90,7 +90,7 @@ func TestVibeEvalManager_RejectsInvalidDraftPayload(t *testing.T) {
 	orgID := uuid.New()
 	userID := uuid.New()
 	repo := newFakeVibeEvalRepo(orgID, workspaceID)
-	manager := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo)
+	manager := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo, fakeVibeEvalChallengePackAuthoring{})
 	caller := vibeEvalCaller(userID, workspaceID, RoleWorkspaceMember)
 
 	conversation, err := manager.CreateConversation(context.Background(), caller, CreateVibeEvalConversationInput{
@@ -127,7 +127,7 @@ func TestVibeEvalManager_DraftReadChecksWorkspaceOwnership(t *testing.T) {
 	orgID := uuid.New()
 	userID := uuid.New()
 	repo := newFakeVibeEvalRepo(orgID, workspaceID)
-	manager := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo)
+	manager := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo, fakeVibeEvalChallengePackAuthoring{})
 	caller := vibeEvalCaller(userID, workspaceID, RoleWorkspaceMember)
 
 	conversation, err := manager.CreateConversation(context.Background(), caller, CreateVibeEvalConversationInput{
@@ -154,6 +154,192 @@ func TestVibeEvalManager_DraftReadChecksWorkspaceOwnership(t *testing.T) {
 	}
 }
 
+func TestVibeEvalManager_ValidateChallengePackDraft(t *testing.T) {
+	workspaceID := uuid.New()
+	orgID := uuid.New()
+	userID := uuid.New()
+	repo := newFakeVibeEvalRepo(orgID, workspaceID)
+	manager := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo, fakeVibeEvalChallengePackAuthoring{})
+	caller := vibeEvalCaller(userID, workspaceID, RoleWorkspaceMember)
+
+	conversation, err := manager.CreateConversation(context.Background(), caller, CreateVibeEvalConversationInput{
+		WorkspaceID: workspaceID,
+		Title:       "Validate pack",
+	})
+	if err != nil {
+		t.Fatalf("CreateConversation error = %v", err)
+	}
+	draft, err := manager.CreateDraft(context.Background(), caller, CreateVibeEvalDraftInput{
+		WorkspaceID:    workspaceID,
+		ConversationID: conversation.ID,
+		DraftKind:      "challenge_pack",
+		Content:        json.RawMessage(`{"bundle_yaml":"pack: {}"}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateDraft error = %v", err)
+	}
+
+	result, err := manager.ValidateDraft(context.Background(), caller, ValidateVibeEvalDraftInput{
+		WorkspaceID: workspaceID,
+		DraftID:     draft.ID,
+	})
+	if err != nil {
+		t.Fatalf("ValidateDraft error = %v", err)
+	}
+	if !result.Valid || result.Draft.ValidationState != "valid" {
+		t.Fatalf("validation result = %+v, want valid draft", result)
+	}
+	if result.PayloadHash == "" {
+		t.Fatal("payload hash was empty")
+	}
+	if len(repo.events) != 1 || repo.events[0].Action != "validate_challenge_pack" {
+		t.Fatalf("events = %+v, want validate audit event", repo.events)
+	}
+}
+
+func TestVibeEvalManager_ValidateChallengePackDraftRecordsErrors(t *testing.T) {
+	workspaceID := uuid.New()
+	orgID := uuid.New()
+	userID := uuid.New()
+	repo := newFakeVibeEvalRepo(orgID, workspaceID)
+	manager := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo, fakeVibeEvalChallengePackAuthoring{})
+	caller := vibeEvalCaller(userID, workspaceID, RoleWorkspaceMember)
+
+	conversation, err := manager.CreateConversation(context.Background(), caller, CreateVibeEvalConversationInput{
+		WorkspaceID: workspaceID,
+		Title:       "Invalid pack",
+	})
+	if err != nil {
+		t.Fatalf("CreateConversation error = %v", err)
+	}
+	draft, err := manager.CreateDraft(context.Background(), caller, CreateVibeEvalDraftInput{
+		WorkspaceID:    workspaceID,
+		ConversationID: conversation.ID,
+		DraftKind:      "challenge_pack",
+		Content:        json.RawMessage(`{"bundle_yaml":"invalid"}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateDraft error = %v", err)
+	}
+
+	result, err := manager.ValidateDraft(context.Background(), caller, ValidateVibeEvalDraftInput{
+		WorkspaceID: workspaceID,
+		DraftID:     draft.ID,
+	})
+	if err != nil {
+		t.Fatalf("ValidateDraft error = %v", err)
+	}
+	if result.Valid || result.Draft.ValidationState != "invalid" {
+		t.Fatalf("validation result = %+v, want invalid draft", result)
+	}
+	if got := string(result.Draft.ValidationErrors); got == "[]" {
+		t.Fatal("validation errors were not recorded")
+	}
+}
+
+func TestVibeEvalManager_PublishRequiresConfirmationAndValidDraft(t *testing.T) {
+	workspaceID := uuid.New()
+	orgID := uuid.New()
+	userID := uuid.New()
+	repo := newFakeVibeEvalRepo(orgID, workspaceID)
+	manager := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo, fakeVibeEvalChallengePackAuthoring{})
+	caller := vibeEvalCaller(userID, workspaceID, RoleWorkspaceMember)
+
+	conversation, err := manager.CreateConversation(context.Background(), caller, CreateVibeEvalConversationInput{
+		WorkspaceID: workspaceID,
+		Title:       "Publish pack",
+	})
+	if err != nil {
+		t.Fatalf("CreateConversation error = %v", err)
+	}
+	draft, err := manager.CreateDraft(context.Background(), caller, CreateVibeEvalDraftInput{
+		WorkspaceID:    workspaceID,
+		ConversationID: conversation.ID,
+		DraftKind:      "challenge_pack",
+		Content:        json.RawMessage(`{"bundle_yaml":"pack: {}"}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateDraft error = %v", err)
+	}
+
+	if _, err := manager.PublishDraft(context.Background(), caller, PublishVibeEvalDraftInput{
+		WorkspaceID: workspaceID,
+		DraftID:     draft.ID,
+	}); err == nil {
+		t.Fatal("PublishDraft before validation succeeded")
+	}
+
+	validation, err := manager.ValidateDraft(context.Background(), caller, ValidateVibeEvalDraftInput{
+		WorkspaceID: workspaceID,
+		DraftID:     draft.ID,
+	})
+	if err != nil {
+		t.Fatalf("ValidateDraft error = %v", err)
+	}
+	if _, err := manager.PublishDraft(context.Background(), caller, PublishVibeEvalDraftInput{
+		WorkspaceID: workspaceID,
+		DraftID:     draft.ID,
+	}); !isVibeEvalConfirmationRequired(err) {
+		t.Fatalf("PublishDraft without confirmation error = %v, want confirmation required", err)
+	}
+
+	published, err := manager.PublishDraft(context.Background(), caller, PublishVibeEvalDraftInput{
+		WorkspaceID:       workspaceID,
+		DraftID:           draft.ID,
+		ConfirmationToken: validation.PayloadHash,
+	})
+	if err != nil {
+		t.Fatalf("PublishDraft error = %v", err)
+	}
+	if published.Draft.PublishedChallengePackID == nil || published.Draft.PublishedChallengePackVersionID == nil {
+		t.Fatalf("published draft links = %+v, want challenge pack links", published.Draft)
+	}
+	if len(repo.events) != 2 || repo.events[1].Action != "publish_challenge_pack" {
+		t.Fatalf("events = %+v, want validate and publish audit events", repo.events)
+	}
+}
+
+func TestVibeEvalManager_ViewerCannotValidateOrPublish(t *testing.T) {
+	workspaceID := uuid.New()
+	orgID := uuid.New()
+	memberID := uuid.New()
+	viewerID := uuid.New()
+	repo := newFakeVibeEvalRepo(orgID, workspaceID)
+	manager := NewVibeEvalManager(fakeVibeEvalAuthorizer{}, repo, fakeVibeEvalChallengePackAuthoring{})
+	member := vibeEvalCaller(memberID, workspaceID, RoleWorkspaceMember)
+	viewer := vibeEvalCaller(viewerID, workspaceID, RoleWorkspaceViewer)
+
+	conversation, err := manager.CreateConversation(context.Background(), member, CreateVibeEvalConversationInput{
+		WorkspaceID: workspaceID,
+		Title:       "Viewer policy",
+	})
+	if err != nil {
+		t.Fatalf("CreateConversation error = %v", err)
+	}
+	draft, err := manager.CreateDraft(context.Background(), member, CreateVibeEvalDraftInput{
+		WorkspaceID:    workspaceID,
+		ConversationID: conversation.ID,
+		DraftKind:      "challenge_pack",
+		Content:        json.RawMessage(`{"bundle_yaml":"pack: {}"}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateDraft error = %v", err)
+	}
+
+	if _, err := manager.ValidateDraft(context.Background(), viewer, ValidateVibeEvalDraftInput{
+		WorkspaceID: workspaceID,
+		DraftID:     draft.ID,
+	}); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("ValidateDraft as viewer error = %v, want ErrForbidden", err)
+	}
+	if _, err := manager.PublishDraft(context.Background(), viewer, PublishVibeEvalDraftInput{
+		WorkspaceID: workspaceID,
+		DraftID:     draft.ID,
+	}); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("PublishDraft as viewer error = %v, want ErrForbidden", err)
+	}
+}
+
 type fakeVibeEvalAuthorizer struct{}
 
 func (fakeVibeEvalAuthorizer) AuthorizeWorkspace(_ context.Context, caller Caller, workspaceID uuid.UUID) error {
@@ -173,12 +359,47 @@ func vibeEvalCaller(userID, workspaceID uuid.UUID, role string) Caller {
 	}
 }
 
+func isVibeEvalConfirmationRequired(err error) bool {
+	var confirmationErr VibeEvalConfirmationRequiredError
+	return errors.As(err, &confirmationErr)
+}
+
+type fakeVibeEvalChallengePackAuthoring struct{}
+
+func (fakeVibeEvalChallengePackAuthoring) ValidateBundle(_ context.Context, _ uuid.UUID, bundleYAML []byte) (ValidateChallengePackResponse, error) {
+	if string(bundleYAML) == "invalid" {
+		return ValidateChallengePackResponse{
+			Valid: false,
+			Errors: []validationErrorDetail{{
+				Field:   "pack.slug",
+				Message: "slug is required",
+			}},
+		}, nil
+	}
+	return ValidateChallengePackResponse{Valid: true}, nil
+}
+
+func (fakeVibeEvalChallengePackAuthoring) PublishBundle(_ context.Context, _ uuid.UUID, bundleYAML []byte) (PublishChallengePackResponse, error) {
+	if string(bundleYAML) == "invalid" {
+		return PublishChallengePackResponse{}, ChallengePackAuthoringValidationError{
+			Errors: []validationErrorDetail{{Field: "pack.slug", Message: "slug is required"}},
+		}
+	}
+	return PublishChallengePackResponse{
+		ChallengePackID:        uuid.New(),
+		ChallengePackVersionID: uuid.New(),
+		EvaluationSpecID:       uuid.New(),
+		InputSetIDs:            []uuid.UUID{uuid.New()},
+	}, nil
+}
+
 type fakeVibeEvalRepo struct {
 	orgID         uuid.UUID
 	workspaceID   uuid.UUID
 	now           time.Time
 	conversations map[uuid.UUID]repository.VibeEvalConversation
 	drafts        map[uuid.UUID]repository.VibeEvalDraft
+	events        []repository.CreateVibeEvalDraftEventParams
 }
 
 func newFakeVibeEvalRepo(orgID, workspaceID uuid.UUID) *fakeVibeEvalRepo {
@@ -188,6 +409,7 @@ func newFakeVibeEvalRepo(orgID, workspaceID uuid.UUID) *fakeVibeEvalRepo {
 		now:           time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC),
 		conversations: map[uuid.UUID]repository.VibeEvalConversation{},
 		drafts:        map[uuid.UUID]repository.VibeEvalDraft{},
+		events:        []repository.CreateVibeEvalDraftEventParams{},
 	}
 }
 
@@ -292,4 +514,37 @@ func (r *fakeVibeEvalRepo) UpdateVibeEvalDraft(_ context.Context, params reposit
 	item.UpdatedAt = r.now.Add(time.Second)
 	r.drafts[item.ID] = item
 	return item, nil
+}
+
+func (r *fakeVibeEvalRepo) MarkVibeEvalDraftValidation(_ context.Context, params repository.MarkVibeEvalDraftValidationParams) (repository.VibeEvalDraft, error) {
+	item, ok := r.drafts[params.ID]
+	if !ok {
+		return repository.VibeEvalDraft{}, repository.ErrVibeEvalDraftNotFound
+	}
+	item.ValidationState = params.ValidationState
+	item.ValidationErrors = params.ValidationErrors
+	item.UpdatedByUserID = params.UpdatedByUserID
+	item.UpdatedAt = r.now.Add(time.Second)
+	r.drafts[item.ID] = item
+	return item, nil
+}
+
+func (r *fakeVibeEvalRepo) MarkVibeEvalDraftPublished(_ context.Context, params repository.MarkVibeEvalDraftPublishedParams) (repository.VibeEvalDraft, error) {
+	item, ok := r.drafts[params.ID]
+	if !ok {
+		return repository.VibeEvalDraft{}, repository.ErrVibeEvalDraftNotFound
+	}
+	item.ValidationState = "valid"
+	item.ValidationErrors = json.RawMessage(`[]`)
+	item.PublishedChallengePackID = &params.PublishedChallengePackID
+	item.PublishedChallengePackVersionID = &params.PublishedChallengePackVersionID
+	item.UpdatedByUserID = params.UpdatedByUserID
+	item.UpdatedAt = r.now.Add(time.Second)
+	r.drafts[item.ID] = item
+	return item, nil
+}
+
+func (r *fakeVibeEvalRepo) CreateVibeEvalDraftEvent(_ context.Context, params repository.CreateVibeEvalDraftEventParams) error {
+	r.events = append(r.events, params)
+	return nil
 }

--- a/backend/internal/repository/sqlc/querier.go
+++ b/backend/internal/repository/sqlc/querier.go
@@ -41,6 +41,7 @@ type Querier interface {
 	CreateRunCaseSelection(ctx context.Context, arg CreateRunCaseSelectionParams) (RunCaseSelection, error)
 	CreateVibeEvalConversation(ctx context.Context, arg CreateVibeEvalConversationParams) (VibeEvalConversation, error)
 	CreateVibeEvalDraft(ctx context.Context, arg CreateVibeEvalDraftParams) (VibeEvalDraft, error)
+	CreateVibeEvalDraftEvent(ctx context.Context, arg CreateVibeEvalDraftEventParams) error
 	DeletePlayground(ctx context.Context, arg DeletePlaygroundParams) error
 	DeletePlaygroundTestCase(ctx context.Context, arg DeletePlaygroundTestCaseParams) error
 	FindOrganizationByDodoSubscriptionOrCustomer(ctx context.Context, arg FindOrganizationByDodoSubscriptionOrCustomerParams) (uuid.UUID, error)
@@ -121,6 +122,8 @@ type Querier interface {
 	MarkHostedRunExecutionAccepted(ctx context.Context, arg MarkHostedRunExecutionAcceptedParams) (HostedRunExecution, error)
 	MarkHostedRunExecutionFailed(ctx context.Context, arg MarkHostedRunExecutionFailedParams) (HostedRunExecution, error)
 	MarkHostedRunExecutionTimedOut(ctx context.Context, arg MarkHostedRunExecutionTimedOutParams) (HostedRunExecution, error)
+	MarkVibeEvalDraftPublished(ctx context.Context, arg MarkVibeEvalDraftPublishedParams) (VibeEvalDraft, error)
+	MarkVibeEvalDraftValidation(ctx context.Context, arg MarkVibeEvalDraftValidationParams) (VibeEvalDraft, error)
 	PatchRegressionCase(ctx context.Context, arg PatchRegressionCaseParams) (WorkspaceRegressionCase, error)
 	PatchRegressionSuite(ctx context.Context, arg PatchRegressionSuiteParams) (WorkspaceRegressionSuite, error)
 	ResolveWorkspaceOrganization(ctx context.Context, arg ResolveWorkspaceOrganizationParams) (uuid.UUID, error)

--- a/backend/internal/repository/sqlc/vibe_eval.sql.go
+++ b/backend/internal/repository/sqlc/vibe_eval.sql.go
@@ -136,6 +136,58 @@ func (q *Queries) CreateVibeEvalDraft(ctx context.Context, arg CreateVibeEvalDra
 	return i, err
 }
 
+const createVibeEvalDraftEvent = `-- name: CreateVibeEvalDraftEvent :exec
+INSERT INTO vibe_eval_draft_events (
+    organization_id,
+    workspace_id,
+    conversation_id,
+    draft_id,
+    actor_user_id,
+    action,
+    payload_hash,
+    request_payload,
+    result_payload
+)
+VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    $6,
+    $7,
+    $8,
+    $9
+)
+`
+
+type CreateVibeEvalDraftEventParams struct {
+	OrganizationID uuid.UUID
+	WorkspaceID    uuid.UUID
+	ConversationID uuid.UUID
+	DraftID        uuid.UUID
+	ActorUserID    uuid.UUID
+	Action         string
+	PayloadHash    string
+	RequestPayload []byte
+	ResultPayload  []byte
+}
+
+func (q *Queries) CreateVibeEvalDraftEvent(ctx context.Context, arg CreateVibeEvalDraftEventParams) error {
+	_, err := q.db.Exec(ctx, createVibeEvalDraftEvent,
+		arg.OrganizationID,
+		arg.WorkspaceID,
+		arg.ConversationID,
+		arg.DraftID,
+		arg.ActorUserID,
+		arg.Action,
+		arg.PayloadHash,
+		arg.RequestPayload,
+		arg.ResultPayload,
+	)
+	return err
+}
+
 const getVibeEvalConversationByID = `-- name: GetVibeEvalConversationByID :one
 SELECT id, organization_id, workspace_id, created_by_user_id, title, phase, status, active_draft_id, created_at, updated_at, archived_at
 FROM vibe_eval_conversations
@@ -288,6 +340,96 @@ func (q *Queries) ListVibeEvalDraftsByConversationID(ctx context.Context, arg Li
 		return nil, err
 	}
 	return items, nil
+}
+
+const markVibeEvalDraftPublished = `-- name: MarkVibeEvalDraftPublished :one
+UPDATE vibe_eval_drafts
+SET
+    validation_state = 'valid',
+    validation_errors = '[]'::jsonb,
+    published_challenge_pack_id = $1,
+    published_challenge_pack_version_id = $2,
+    updated_by_user_id = $3
+WHERE id = $4
+RETURNING id, organization_id, workspace_id, conversation_id, draft_kind, content, validation_state, validation_errors, published_challenge_pack_id, published_challenge_pack_version_id, created_by_user_id, updated_by_user_id, created_at, updated_at
+`
+
+type MarkVibeEvalDraftPublishedParams struct {
+	PublishedChallengePackID        *uuid.UUID
+	PublishedChallengePackVersionID *uuid.UUID
+	UpdatedByUserID                 uuid.UUID
+	ID                              uuid.UUID
+}
+
+func (q *Queries) MarkVibeEvalDraftPublished(ctx context.Context, arg MarkVibeEvalDraftPublishedParams) (VibeEvalDraft, error) {
+	row := q.db.QueryRow(ctx, markVibeEvalDraftPublished,
+		arg.PublishedChallengePackID,
+		arg.PublishedChallengePackVersionID,
+		arg.UpdatedByUserID,
+		arg.ID,
+	)
+	var i VibeEvalDraft
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.WorkspaceID,
+		&i.ConversationID,
+		&i.DraftKind,
+		&i.Content,
+		&i.ValidationState,
+		&i.ValidationErrors,
+		&i.PublishedChallengePackID,
+		&i.PublishedChallengePackVersionID,
+		&i.CreatedByUserID,
+		&i.UpdatedByUserID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const markVibeEvalDraftValidation = `-- name: MarkVibeEvalDraftValidation :one
+UPDATE vibe_eval_drafts
+SET
+    validation_state = $1,
+    validation_errors = $2,
+    updated_by_user_id = $3
+WHERE id = $4
+RETURNING id, organization_id, workspace_id, conversation_id, draft_kind, content, validation_state, validation_errors, published_challenge_pack_id, published_challenge_pack_version_id, created_by_user_id, updated_by_user_id, created_at, updated_at
+`
+
+type MarkVibeEvalDraftValidationParams struct {
+	ValidationState  string
+	ValidationErrors []byte
+	UpdatedByUserID  uuid.UUID
+	ID               uuid.UUID
+}
+
+func (q *Queries) MarkVibeEvalDraftValidation(ctx context.Context, arg MarkVibeEvalDraftValidationParams) (VibeEvalDraft, error) {
+	row := q.db.QueryRow(ctx, markVibeEvalDraftValidation,
+		arg.ValidationState,
+		arg.ValidationErrors,
+		arg.UpdatedByUserID,
+		arg.ID,
+	)
+	var i VibeEvalDraft
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.WorkspaceID,
+		&i.ConversationID,
+		&i.DraftKind,
+		&i.Content,
+		&i.ValidationState,
+		&i.ValidationErrors,
+		&i.PublishedChallengePackID,
+		&i.PublishedChallengePackVersionID,
+		&i.CreatedByUserID,
+		&i.UpdatedByUserID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
 }
 
 const setVibeEvalConversationActiveDraft = `-- name: SetVibeEvalConversationActiveDraft :one

--- a/backend/internal/repository/vibe_eval.go
+++ b/backend/internal/repository/vibe_eval.go
@@ -76,6 +76,32 @@ type UpdateVibeEvalDraftParams struct {
 	UpdatedByUserID  uuid.UUID
 }
 
+type MarkVibeEvalDraftValidationParams struct {
+	ID               uuid.UUID
+	ValidationState  string
+	ValidationErrors json.RawMessage
+	UpdatedByUserID  uuid.UUID
+}
+
+type MarkVibeEvalDraftPublishedParams struct {
+	ID                              uuid.UUID
+	PublishedChallengePackID        uuid.UUID
+	PublishedChallengePackVersionID uuid.UUID
+	UpdatedByUserID                 uuid.UUID
+}
+
+type CreateVibeEvalDraftEventParams struct {
+	OrganizationID uuid.UUID
+	WorkspaceID    uuid.UUID
+	ConversationID uuid.UUID
+	DraftID        uuid.UUID
+	ActorUserID    uuid.UUID
+	Action         string
+	PayloadHash    string
+	RequestPayload json.RawMessage
+	ResultPayload  json.RawMessage
+}
+
 func (r *Repository) CreateVibeEvalConversation(ctx context.Context, params CreateVibeEvalConversationParams) (VibeEvalConversation, error) {
 	row, err := r.queries.CreateVibeEvalConversation(ctx, repositorysqlc.CreateVibeEvalConversationParams{
 		OrganizationID:  params.OrganizationID,
@@ -189,6 +215,52 @@ func (r *Repository) UpdateVibeEvalDraft(ctx context.Context, params UpdateVibeE
 		return VibeEvalDraft{}, err
 	}
 	return mapVibeEvalDraft(row)
+}
+
+func (r *Repository) MarkVibeEvalDraftValidation(ctx context.Context, params MarkVibeEvalDraftValidationParams) (VibeEvalDraft, error) {
+	row, err := r.queries.MarkVibeEvalDraftValidation(ctx, repositorysqlc.MarkVibeEvalDraftValidationParams{
+		ID:               params.ID,
+		ValidationState:  params.ValidationState,
+		ValidationErrors: params.ValidationErrors,
+		UpdatedByUserID:  params.UpdatedByUserID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return VibeEvalDraft{}, ErrVibeEvalDraftNotFound
+		}
+		return VibeEvalDraft{}, err
+	}
+	return mapVibeEvalDraft(row)
+}
+
+func (r *Repository) MarkVibeEvalDraftPublished(ctx context.Context, params MarkVibeEvalDraftPublishedParams) (VibeEvalDraft, error) {
+	row, err := r.queries.MarkVibeEvalDraftPublished(ctx, repositorysqlc.MarkVibeEvalDraftPublishedParams{
+		ID:                              params.ID,
+		PublishedChallengePackID:        &params.PublishedChallengePackID,
+		PublishedChallengePackVersionID: &params.PublishedChallengePackVersionID,
+		UpdatedByUserID:                 params.UpdatedByUserID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return VibeEvalDraft{}, ErrVibeEvalDraftNotFound
+		}
+		return VibeEvalDraft{}, err
+	}
+	return mapVibeEvalDraft(row)
+}
+
+func (r *Repository) CreateVibeEvalDraftEvent(ctx context.Context, params CreateVibeEvalDraftEventParams) error {
+	return r.queries.CreateVibeEvalDraftEvent(ctx, repositorysqlc.CreateVibeEvalDraftEventParams{
+		OrganizationID: params.OrganizationID,
+		WorkspaceID:    params.WorkspaceID,
+		ConversationID: params.ConversationID,
+		DraftID:        params.DraftID,
+		ActorUserID:    params.ActorUserID,
+		Action:         params.Action,
+		PayloadHash:    params.PayloadHash,
+		RequestPayload: []byte(params.RequestPayload),
+		ResultPayload:  []byte(params.ResultPayload),
+	})
 }
 
 func mapVibeEvalConversation(row repositorysqlc.VibeEvalConversation) (VibeEvalConversation, error) {

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -4369,6 +4369,66 @@ paths:
         "404":
           $ref: "#/components/responses/NotFoundError"
 
+  /v1/workspaces/{workspaceID}/vibe-eval/drafts/{draftID}/validate:
+    post:
+      operationId: validateVibeEvalDraft
+      summary: Validate a Vibe Eval challenge-pack draft
+      tags: [VibeEvals]
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+        - $ref: "#/components/parameters/VibeEvalDraftID"
+      responses:
+        "200":
+          description: Vibe Eval draft validation result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidateVibeEvalDraftResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
+  /v1/workspaces/{workspaceID}/vibe-eval/drafts/{draftID}/publish:
+    post:
+      operationId: publishVibeEvalDraft
+      summary: Publish a validated Vibe Eval challenge-pack draft
+      tags: [VibeEvals]
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+        - $ref: "#/components/parameters/VibeEvalDraftID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PublishVibeEvalDraftRequest"
+      responses:
+        "201":
+          description: Vibe Eval draft published
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PublishVibeEvalDraftResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "409":
+          $ref: "#/components/responses/ConflictError"
+
   /v1/workspaces/{workspaceID}/playgrounds:
     post:
       operationId: createPlayground
@@ -11007,6 +11067,53 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/VibeEvalDraftResponse"
+
+    ValidateVibeEvalDraftResponse:
+      type: object
+      required: [draft, valid, errors, payload_hash]
+      properties:
+        draft:
+          $ref: "#/components/schemas/VibeEvalDraftResponse"
+        valid:
+          type: boolean
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ValidationErrorDetail"
+        payload_hash:
+          type: string
+
+    PublishVibeEvalDraftRequest:
+      type: object
+      properties:
+        confirmation_token:
+          type: string
+
+    PublishVibeEvalDraftResponse:
+      type: object
+      required: [draft, challenge_pack_id, challenge_pack_version_id, evaluation_spec_id, input_set_ids, payload_hash]
+      properties:
+        draft:
+          $ref: "#/components/schemas/VibeEvalDraftResponse"
+        challenge_pack_id:
+          type: string
+          format: uuid
+        challenge_pack_version_id:
+          type: string
+          format: uuid
+        evaluation_spec_id:
+          type: string
+          format: uuid
+        input_set_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+        bundle_artifact_id:
+          type: string
+          format: uuid
+        payload_hash:
+          type: string
 
     # --- Playgrounds ---
 

--- a/testing/codex-vibe-eval-phase-2-validate-publish.md
+++ b/testing/codex-vibe-eval-phase-2-validate-publish.md
@@ -1,0 +1,41 @@
+# codex/vibe-eval-phase-2-validate-publish — Test Contract
+
+## Functional Behavior
+
+- Users can validate a Vibe Eval `challenge_pack` draft against the existing AgentClash challenge-pack validator.
+- Validation updates the draft with `valid` or `invalid` state and structured validation errors.
+- Validation does not publish challenge packs, create runs, create provider secrets, or spend credit.
+- Publishing requires an explicit confirmation token derived from a stable payload hash.
+- Publishing is allowed only after the current draft validates successfully.
+- Publishing promotes the validated draft through the existing challenge-pack publish path and links the resulting pack/version ids back to the draft.
+- Publish decisions are auditable with action, requester, workspace, draft, payload hash, and result ids.
+- Workspace viewers can read validation/publish state, but only workspace members/admins can validate or publish.
+
+## Unit Tests
+
+- API service tests cover:
+  - validating a challenge-pack draft records valid state and clears errors.
+  - validation errors are normalized into draft `validation_errors`.
+  - publish without confirmation is rejected with a payload hash summary.
+  - publish requires a valid draft and records published pack/version ids.
+  - viewers cannot validate or publish.
+
+## Integration / Functional Tests
+
+- `cd backend && go test ./internal/api ./internal/repository`
+- `cd backend && go test ./...` if time permits.
+
+## Smoke Tests
+
+- `git diff --check`
+- `cd backend && go test ./internal/api`
+
+## E2E Tests
+
+N/A — this slice extends backend draft validation/publish surfaces only; no workbench UI is implemented.
+
+## Manual / cURL Tests
+
+- `POST /v1/workspaces/{workspaceID}/vibe-eval/drafts/{draftID}/validate` validates a draft-only challenge pack.
+- `POST /v1/workspaces/{workspaceID}/vibe-eval/drafts/{draftID}/publish` without confirmation returns a required confirmation payload hash.
+- `POST /v1/workspaces/{workspaceID}/vibe-eval/drafts/{draftID}/publish` with the matching confirmation token publishes and links the draft.


### PR DESCRIPTION
## Summary
- adds Vibe Eval draft validation against the existing challenge-pack authoring validator
- adds confirmation-gated publish for validated challenge-pack drafts
- persists validation/publish audit events and links published pack/version ids back to drafts
- documents the new validate/publish endpoints in OpenAPI

## Review checkpoint
- Test contract: `testing/codex-vibe-eval-phase-2-validate-publish.md`
- Checkpoint step 1 verdict: pass

## Tests
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file("docs/api-server/openapi.yaml"); puts "openapi yaml ok"'`\n- `cd backend && go test ./internal/api ./internal/repository`\n- `cd backend && go test ./...`\n\nRefs #869