### PR TITLE
feat(try-cli): AI coding agent demos, prebaked E2B template, redesigned UI

### DIFF
--- a/docs/deployment/try-cli.md
+++ b/docs/deployment/try-cli.md
@@ -26,6 +26,21 @@ Deploy via existing Vercel Git integration on `main` after merge.
 
 Optional DNS: `try.agentclash.dev` → Vercel (rewrite to `/try` is in `next.config.ts`).
 
+## E2B template (prerequisite)
+
+Demos boot from a shared E2B template (`agentclash-trycli`) with every CLI
+pre-installed, so sandboxes start in ~1–2s instead of installing on each visit.
+Build it (runs in E2B's cloud — no local Docker) before the first deploy and
+again whenever the tool set changes:
+
+```bash
+cd services/try-cli
+E2B_API_KEY=... bun run scripts/build-template.ts
+```
+
+The same `E2B_API_KEY` must be set on the Try CLI service so it can launch the
+template at runtime (`Sandbox.create("agentclash-trycli", …)`).
+
 ## Try CLI service (Railway recommended)
 
 Deploy `services/try-cli/` as a **separate Railway service** in the same project as the backend:

--- a/services/try-cli/scripts/build-template.ts
+++ b/services/try-cli/scripts/build-template.ts
@@ -1,0 +1,56 @@
+/**
+ * Builds the `agentclash-trycli` E2B sandbox template in E2B's cloud
+ * (Build System 2.0 — no local Docker required).
+ *
+ * Every CLI offered by a Try CLI demo is pre-installed here so sandboxes boot
+ * ready in ~1-2s instead of running a download+install on every visit.
+ *
+ * Usage:
+ *   cd services/try-cli
+ *   E2B_API_KEY=e2b_... bun run scripts/build-template.ts
+ *
+ * The positional alias ("agentclash-trycli") is what the runtime references via
+ * Sandbox.create("agentclash-trycli", ...). Re-run after changing tool versions.
+ */
+import { Template, defaultBuildLogger } from "e2b";
+
+export const TEMPLATE_ALIAS = "agentclash-trycli";
+
+const template = Template()
+  .fromNodeImage("22")
+  // System tools (aptInstall runs privileged)
+  .aptInstall(["ripgrep", "git", "curl", "ca-certificates", "unzip"])
+  // Dev tools + AI coding CLIs as global npm binaries. npmInstall runs as root,
+  // so these land in /usr/local/bin (on PATH for the sandbox user).
+  .npmInstall(
+    [
+      "bun",
+      "@biomejs/biome",
+      "@anthropic-ai/claude-code",
+      "@openai/codex",
+      "opencode-ai",
+      "grok-dev",
+    ],
+    { g: true },
+  )
+  // uv + ruff (Astral installers). runCmd runs as the unprivileged sandbox
+  // user, so these install into ~/.local/bin (/home/user/.local/bin).
+  .runCmd("curl -LsSf https://astral.sh/uv/install.sh | sh")
+  .runCmd("curl -LsSf https://astral.sh/ruff/install.sh | sh")
+  .setEnvs({
+    PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/user/.local/bin",
+  });
+
+async function main() {
+  await Template.build(template, TEMPLATE_ALIAS, {
+    cpuCount: 2,
+    memoryMB: 2048,
+    onBuildLogs: defaultBuildLogger(),
+  });
+  console.log(`\n✓ Built E2B template alias: ${TEMPLATE_ALIAS}`);
+}
+
+main().catch((err) => {
+  console.error("Template build failed:", err);
+  process.exit(1);
+});

--- a/services/try-cli/server/sessions.ts
+++ b/services/try-cli/server/sessions.ts
@@ -78,10 +78,11 @@ export class SessionManager {
     const { demo } = session;
     const timeoutMs = (demo.sessionMinutes ?? 10) * 60 * 1000;
 
-    const sandbox = await Sandbox.create({
-      timeoutMs,
-      ...(demo.template ? { template: demo.template } : {}),
-    });
+    // e2b v2 takes the template alias as a positional arg — passing it inside
+    // the options object is silently ignored and falls back to the base image.
+    const sandbox = demo.template
+      ? await Sandbox.create(demo.template, { timeoutMs })
+      : await Sandbox.create({ timeoutMs });
     session.sandbox = sandbox;
 
     for (const cmd of demo.install ?? []) {

--- a/services/try-cli/server/types.ts
+++ b/services/try-cli/server/types.ts
@@ -1,4 +1,4 @@
-import type { Demo } from "@try-cli/core";
+import type { Demo, DemoAuth } from "@try-cli/core";
 
 export interface SessionInfo {
   id: string;
@@ -11,10 +11,13 @@ export interface SessionInfo {
 export interface DemoMeta {
   slug: string;
   name: string;
+  tagline?: string;
+  category?: string;
   docs?: string;
   github?: string;
   welcome?: string;
   commands: { label: string; run: string }[];
+  auth?: DemoAuth;
   sessionMinutes: number;
 }
 
@@ -22,10 +25,13 @@ export function demoToMeta(demo: Demo): DemoMeta {
   return {
     slug: demo.slug,
     name: demo.name,
+    tagline: demo.tagline,
+    category: demo.category,
     docs: demo.docs,
     github: demo.github,
     welcome: demo.welcome,
     commands: demo.commands,
+    auth: demo.auth,
     sessionMinutes: demo.sessionMinutes,
   };
 }

--- a/try-cli/README.md
+++ b/try-cli/README.md
@@ -1,6 +1,6 @@
 # AgentClash Try CLI
 
-Interactive README demos for developer tools — an AgentClash platform primitive.
+Interactive README demos for developer tools **and AI coding agents** — an AgentClash platform primitive. Run Claude Code, Codex, OpenCode, Grok, bun, uv, ruff, biome, or ripgrep in a disposable cloud terminal, no install.
 
 **Live:** [agentclash.dev/try](https://www.agentclash.dev/try)
 
@@ -10,10 +10,18 @@ Interactive README demos for developer tools — an AgentClash platform primitiv
 try-cli/
   packages/core/    # .trycli.yml schema, badge SVG
   packages/cli/     # npx @agentclash/try-cli
-  demos/            # Curated demo configs
+  demos/            # Curated demo configs (AI agents + dev tools)
 
-services/try-cli/   # Bun + E2B PTY WebSocket service (deploy to Fly)
-web/src/app/try/    # Next.js UI (deploy to Vercel)
+services/try-cli/         # Bun + E2B PTY WebSocket service (deploy to Railway)
+services/try-cli/scripts/ # build-template.ts — builds the prebaked E2B template
+web/src/app/try/          # Next.js UI (deploy to Vercel)
+```
+
+All demo tools are pre-installed in a shared E2B template (`agentclash-trycli`)
+so sandboxes boot ready. Rebuild it after changing tools:
+
+```bash
+cd services/try-cli && E2B_API_KEY=... bun run scripts/build-template.ts
 ```
 
 ## Local development

--- a/try-cli/demos/biome.trycli.yml
+++ b/try-cli/demos/biome.trycli.yml
@@ -1,12 +1,10 @@
 name: "Biome"
 slug: biome
+tagline: "Fast formatter & linter for JS/TS"
+category: "Developer tools"
+template: agentclash-trycli
 docs: "https://biomejs.dev/"
 github: "https://github.com/biomejs/biome"
-
-install:
-  - "curl -fsSL https://bun.sh/install | bash"
-  - "export BUN_INSTALL=\"$HOME/.bun\" && export PATH=\"$BUN_INSTALL/bin:$PATH\""
-  - "bun add -g @biomejs/biome"
 
 welcome: |
   Biome is ready! Fast formatter and linter for JS/TS.
@@ -20,9 +18,9 @@ commands:
     run: "biome --version"
   - label: "Init config"
     run: "mkdir demo && cd demo && biome init"
-  - label: "Check sample file"
+  - label: "Check a sample file"
     run: "echo 'const  x=1+2;console.log(x)' > demo/app.js && biome check demo/app.js"
-  - label: "Format file"
+  - label: "Format the file"
     run: "biome format --write demo/app.js && cat demo/app.js"
 
 sessionMinutes: 10

--- a/try-cli/demos/bun.trycli.yml
+++ b/try-cli/demos/bun.trycli.yml
@@ -1,11 +1,10 @@
 name: "Bun"
 slug: bun
+tagline: "Ultra-fast JavaScript runtime & toolkit"
+category: "Developer tools"
+template: agentclash-trycli
 docs: "https://bun.sh/docs"
 github: "https://github.com/oven-sh/bun"
-
-install:
-  - "curl -fsSL https://bun.sh/install | bash"
-  - "export BUN_INSTALL=\"$HOME/.bun\" && export PATH=\"$BUN_INSTALL/bin:$PATH\" && echo 'export BUN_INSTALL=\"$HOME/.bun\"' >> ~/.bashrc && echo 'export PATH=\"$BUN_INSTALL/bin:$PATH\"' >> ~/.bashrc"
 
 welcome: |
   Bun is ready! Ultra-fast JavaScript runtime & toolkit.

--- a/try-cli/demos/claude-code.trycli.yml
+++ b/try-cli/demos/claude-code.trycli.yml
@@ -1,0 +1,32 @@
+name: "Claude Code"
+slug: claude-code
+tagline: "Anthropic's agentic coding CLI"
+category: "AI coding agents"
+template: agentclash-trycli
+docs: "https://code.claude.com/docs"
+github: "https://github.com/anthropics/claude-code"
+
+auth:
+  provider: "Anthropic"
+  summary: "Sign in with your own Claude account (Pro/Max) or an Anthropic API key. Credentials live only in this disposable sandbox and are wiped when it ends."
+  steps:
+    - "Run: claude"
+    - "At the prompt, type /login"
+    - "Open the printed URL on your own machine, approve, and paste the code back"
+    - "Prefer a key? export ANTHROPIC_API_KEY=sk-ant-... then run claude"
+  envKey: "ANTHROPIC_API_KEY"
+  signupUrl: "https://console.anthropic.com/"
+
+welcome: |
+  Claude Code is installed. Sign in using the panel on the left
+  (run `claude`, then type /login), then start building.
+
+commands:
+  - label: "Show version"
+    run: "claude --version"
+  - label: "Start Claude Code"
+    run: "claude"
+  - label: "Make a file to work on"
+    run: "printf 'def add(a, b):\\n    return a + b\\n' > math.py && cat math.py"
+
+sessionMinutes: 10

--- a/try-cli/demos/codex.trycli.yml
+++ b/try-cli/demos/codex.trycli.yml
@@ -1,0 +1,32 @@
+name: "Codex CLI"
+slug: codex
+tagline: "OpenAI's coding agent in your terminal"
+category: "AI coding agents"
+template: agentclash-trycli
+docs: "https://developers.openai.com/codex/cli"
+github: "https://github.com/openai/codex"
+
+auth:
+  provider: "OpenAI"
+  summary: "Sign in with your ChatGPT account via device code, or use an OpenAI API key. Everything stays in this disposable sandbox."
+  steps:
+    - "Run: codex login --device-auth"
+    - "Open the URL on your own machine and enter the one-time code"
+    - "Prefer a key? Run: codex login --with-api-key (then paste your key)"
+    - "Then start it: codex"
+  envKey: "OPENAI_API_KEY"
+  signupUrl: "https://platform.openai.com/api-keys"
+
+welcome: |
+  Codex CLI is installed. Sign in using the panel on the left
+  (codex login --device-auth), then run `codex` to start.
+
+commands:
+  - label: "Show version"
+    run: "codex --version"
+  - label: "Sign in (device code)"
+    run: "codex login --device-auth"
+  - label: "Start Codex"
+    run: "codex"
+
+sessionMinutes: 10

--- a/try-cli/demos/grok.trycli.yml
+++ b/try-cli/demos/grok.trycli.yml
@@ -23,8 +23,8 @@ welcome: |
 commands:
   - label: "Show version"
     run: "grok --version"
-  - label: "Set your key"
-    run: "export XAI_API_KEY=YOUR_KEY_HERE"
+  - label: "Set your key (prompts you)"
+    run: "read -rsp 'Paste your xAI API key: ' XAI_API_KEY && export XAI_API_KEY && echo ' ✓ key set'"
   - label: "Start Grok"
     run: "grok"
 

--- a/try-cli/demos/grok.trycli.yml
+++ b/try-cli/demos/grok.trycli.yml
@@ -1,0 +1,31 @@
+name: "Grok CLI"
+slug: grok
+tagline: "xAI's Grok, agentic in your terminal"
+category: "AI coding agents"
+template: agentclash-trycli
+docs: "https://docs.vibekit.sh/agents/grok"
+github: "https://github.com/superagent-ai/grok-cli"
+
+auth:
+  provider: "xAI"
+  summary: "Grok CLI is fully key-based — paste your own xAI API key. It stays in this disposable sandbox."
+  steps:
+    - "Grab a key from console.x.ai"
+    - "Run: export XAI_API_KEY=xai-..."
+    - "Then start it: grok"
+  envKey: "XAI_API_KEY"
+  signupUrl: "https://console.x.ai/"
+
+welcome: |
+  Grok CLI is installed. Add your xAI API key from the panel on the left
+  (export XAI_API_KEY=...), then run `grok`.
+
+commands:
+  - label: "Show version"
+    run: "grok --version"
+  - label: "Set your key"
+    run: "export XAI_API_KEY=YOUR_KEY_HERE"
+  - label: "Start Grok"
+    run: "grok"
+
+sessionMinutes: 10

--- a/try-cli/demos/opencode.trycli.yml
+++ b/try-cli/demos/opencode.trycli.yml
@@ -1,0 +1,30 @@
+name: "OpenCode"
+slug: opencode
+tagline: "Open-source AI coding agent by SST"
+category: "AI coding agents"
+template: agentclash-trycli
+docs: "https://opencode.ai/docs/"
+github: "https://github.com/sst/opencode"
+
+auth:
+  provider: "any model provider"
+  summary: "Add an API key for the provider you want (Anthropic, OpenAI, xAI, and 75+ more). Subscription OAuth isn't supported — use a key."
+  steps:
+    - "Run: opencode auth login"
+    - "Pick a provider, then choose 'Manually enter API key'"
+    - "Paste your key, then run: opencode"
+  signupUrl: "https://models.dev/"
+
+welcome: |
+  OpenCode is installed. Add a provider key from the panel on the left
+  (opencode auth login), then run `opencode`.
+
+commands:
+  - label: "Show version"
+    run: "opencode --version"
+  - label: "Sign in (add a key)"
+    run: "opencode auth login"
+  - label: "Start OpenCode"
+    run: "opencode"
+
+sessionMinutes: 10

--- a/try-cli/demos/ripgrep.trycli.yml
+++ b/try-cli/demos/ripgrep.trycli.yml
@@ -1,10 +1,10 @@
 name: "ripgrep"
 slug: ripgrep
+tagline: "Recursively search code with regex, fast"
+category: "Developer tools"
+template: agentclash-trycli
 docs: "https://github.com/BurntSushi/ripgrep"
 github: "https://github.com/BurntSushi/ripgrep"
-
-install:
-  - "apt-get update -qq && apt-get install -y -qq ripgrep"
 
 welcome: |
   ripgrep (rg) is ready! Recursively search directories for regex patterns.
@@ -16,7 +16,7 @@ welcome: |
 commands:
   - label: "Show version"
     run: "rg --version"
-  - label: "Search in home"
+  - label: "Search a file"
     run: "rg --line-number 'root' /etc/passwd"
   - label: "Create & search files"
     run: "mkdir src && echo 'fn main() {}' > src/main.rs && echo 'struct Foo;' > src/lib.rs && rg 'fn|struct' src/"

--- a/try-cli/demos/ruff.trycli.yml
+++ b/try-cli/demos/ruff.trycli.yml
@@ -1,11 +1,10 @@
 name: "Ruff"
 slug: ruff
+tagline: "Extremely fast Python linter & formatter"
+category: "Developer tools"
+template: agentclash-trycli
 docs: "https://docs.astral.sh/ruff/"
 github: "https://github.com/astral-sh/ruff"
-
-install:
-  - "curl -LsSf https://astral.sh/ruff/install.sh | sh"
-  - "echo 'export PATH=\"$HOME/.local/bin:$PATH\"' >> ~/.bashrc && export PATH=\"$HOME/.local/bin:$PATH\""
 
 welcome: |
   Ruff is ready! Extremely fast Python linter & formatter.
@@ -18,7 +17,7 @@ commands:
   - label: "Show version"
     run: "ruff --version"
   - label: "Lint sample code"
-    run: "echo 'import os,sys\nx=1+2\nprint(x)' > bad.py && ruff check bad.py"
+    run: "printf 'import os,sys\\nx=1+2\\nprint(x)\\n' > bad.py && ruff check bad.py"
   - label: "Auto-fix issues"
     run: "ruff check bad.py --fix && cat bad.py"
   - label: "Format code"

--- a/try-cli/demos/uv.trycli.yml
+++ b/try-cli/demos/uv.trycli.yml
@@ -1,11 +1,10 @@
 name: "uv"
 slug: uv
+tagline: "Blazing-fast Python package manager"
+category: "Developer tools"
+template: agentclash-trycli
 docs: "https://docs.astral.sh/uv/"
 github: "https://github.com/astral-sh/uv"
-
-install:
-  - "curl -LsSf https://astral.sh/uv/install.sh | sh"
-  - "echo 'export PATH=\"$HOME/.local/bin:$PATH\"' >> ~/.bashrc && export PATH=\"$HOME/.local/bin:$PATH\""
 
 welcome: |
   uv is ready! Blazing-fast Python package manager.

--- a/try-cli/packages/core/src/schema.ts
+++ b/try-cli/packages/core/src/schema.ts
@@ -5,9 +5,22 @@ export const CommandSchema = z.object({
   run: z.string(),
 });
 
+// Optional "bring your own credentials" block. When present, the UI shows an
+// auth panel telling the visitor how to sign in with their own account/key
+// inside the sandbox (we never inject provider keys).
+export const AuthSchema = z.object({
+  provider: z.string().optional(),
+  summary: z.string(),
+  steps: z.array(z.string()).default([]),
+  envKey: z.string().optional(),
+  signupUrl: z.string().url().optional(),
+});
+
 export const TryCliConfigSchema = z.object({
   name: z.string().min(1),
   slug: z.string().regex(/^[a-z0-9-]+$/).optional(),
+  tagline: z.string().optional(),
+  category: z.string().optional(),
   image: z.string().default("ubuntu:24.04"),
   template: z.string().optional(),
   docs: z.string().url().optional(),
@@ -15,11 +28,13 @@ export const TryCliConfigSchema = z.object({
   install: z.array(z.string()).default([]),
   welcome: z.string().optional(),
   commands: z.array(CommandSchema).default([]),
+  auth: AuthSchema.optional(),
   sessionMinutes: z.number().int().min(1).max(30).default(10),
 });
 
 export type TryCliConfig = z.infer<typeof TryCliConfigSchema>;
 export type DemoCommand = z.infer<typeof CommandSchema>;
+export type DemoAuth = z.infer<typeof AuthSchema>;
 
 export interface Demo extends TryCliConfig {
   slug: string;

--- a/web/content/docs/concepts/try-cli.mdx
+++ b/web/content/docs/concepts/try-cli.mdx
@@ -3,7 +3,7 @@ title: Try CLI — interactive terminal demos
 description: AgentClash primitive for one-click disposable terminal demos. README badges, E2B sandboxes, xterm.js.
 ---
 
-**Try CLI** is an AgentClash platform primitive: interactive, disposable terminal demos for CLI and TUI tools.
+**Try CLI** is an AgentClash platform primitive: interactive, disposable terminal demos for CLI and TUI tools — including AI coding agents.
 
 > Let users try your CLI before they install it — not a cloud IDE, not “run any repo.”
 
@@ -14,9 +14,34 @@ description: AgentClash primitive for one-click disposable terminal demos. READM
 | Demo hub | [agentclash.dev/try](https://www.agentclash.dev/try) |
 | Per-tool demo | `https://www.agentclash.dev/try/{slug}` (e.g. `/try/bun`) |
 | README badge | `https://www.agentclash.dev/api/try/badge/{slug}.svg` |
-| WebSocket API | `try-api.agentclash.dev` (Fly.io service) |
+| WebSocket API | Railway service (`NEXT_PUBLIC_TRY_CLI_WS_URL`) |
 
-The browser UI ships on **Vercel** with the AgentClash web app. PTY sessions run on a **long-lived Bun service** backed by **E2B** sandboxes (WebSockets cannot run on Vercel serverless).
+The browser UI ships on **Vercel** with the AgentClash web app. PTY sessions run on a **long-lived Bun service** (Railway) backed by **E2B** sandboxes (WebSockets cannot run on Vercel serverless).
+
+## Demos
+
+**AI coding agents** — Claude Code, Codex CLI, OpenCode, Grok CLI.
+**Developer tools** — bun, uv, ruff, biome, ripgrep.
+
+Every tool is pre-installed in a shared E2B template (`agentclash-trycli`), so sandboxes boot ready in ~1–2s instead of installing on each visit. Rebuild the template after changing tools:
+
+```bash
+cd services/try-cli
+E2B_API_KEY=... bun run scripts/build-template.ts
+```
+
+The build runs in E2B's cloud (Build System 2.0 — no local Docker). The demo's `template:` field references the alias.
+
+## Bring-your-own credentials (AI agents)
+
+AI agent demos need a provider account. We **never inject our keys** into the sandbox (that would violate provider terms and expose the key to anyone in the shell). Instead each demo's `auth:` block shows the visitor how to sign in with their **own** credentials inside the disposable sandbox:
+
+- **Claude Code** — `claude` → `/login` (paste-code) or `ANTHROPIC_API_KEY`
+- **Codex** — `codex login --device-auth` or an `OPENAI_API_KEY`
+- **OpenCode** — `opencode auth login` (paste a provider key)
+- **Grok** — `export XAI_API_KEY=…`
+
+Credentials live only in that sandbox and are wiped when it expires.
 
 ## Maintainer workflow
 
@@ -54,18 +79,19 @@ Use **`exec`** inside the sandbox to validate CLI behavior in eval runs; use **T
 ## Architecture
 
 ```
-web (Next.js / Vercel)     →  /try, /api/try/* proxy
-services/try-cli (Bun/Fly) →  E2B PTY ↔ WebSocket
-try-cli/packages/core      →  .trycli.yml schema + badges
-try-cli/demos              →  Curated demos (bun, uv, ruff, …)
+web (Next.js / Vercel)        →  /try, /api/try/* proxy
+services/try-cli (Bun/Railway)→  E2B PTY ↔ WebSocket
+services/try-cli/scripts      →  build-template.ts (E2B template build)
+try-cli/packages/core         →  .trycli.yml schema + badges
+try-cli/demos                 →  Curated demos (AI agents + dev tools)
 ```
 
 ## Session limits (MVP)
 
 - 10 minute sessions (configurable per demo)
-- 3 sessions per IP per hour
-- Sandboxes destroyed on expiry
-- No auth for anonymous public demos
+- Max 3 concurrent sessions per IP (freed when a session ends)
+- Sandboxes destroyed on expiry — credentials wiped with them
+- Anonymous; AI agent demos use the visitor's own provider credentials (BYO)
 
 ## See also
 

--- a/web/src/app/try/layout.tsx
+++ b/web/src/app/try/layout.tsx
@@ -1,25 +1,54 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { Star } from "lucide-react";
+import { GridBackdrop, Wordmark } from "@/components/try-cli/chrome";
 
 export const metadata: Metadata = {
   title: "Try CLI — Interactive terminal demos | AgentClash",
   description:
-    "Let users try your CLI before they install it. Disposable E2B sandboxes, README badges, zero install.",
+    "Run any CLI in a disposable cloud terminal before you install it. AI coding agents and dev tools, zero setup, powered by E2B sandboxes.",
   openGraph: {
     title: "AgentClash Try CLI",
-    description: "Interactive README demos for developer tools.",
+    description: "Run any CLI in a disposable cloud terminal — zero install.",
     url: "https://www.agentclash.dev/try",
   },
 };
 
 export default function TryCliLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <nav className="border-b border-border px-4 py-3">
-        <Link href="/" className="text-sm text-muted-foreground hover:text-foreground">
-          ← AgentClash
-        </Link>
-      </nav>
+    <div className="relative min-h-screen bg-[#060606] text-white antialiased">
+      <GridBackdrop />
+      <header className="sticky top-0 z-40 h-16 border-b border-white/[0.06] bg-[#060606]/70 backdrop-blur-md">
+        <div className="mx-auto flex h-full max-w-[1400px] items-center justify-between px-5 sm:px-8">
+          <div className="flex items-center gap-3">
+            <Wordmark />
+            <span className="hidden select-none text-white/20 sm:inline">/</span>
+            <Link
+              href="/try"
+              className="hidden text-sm text-white/55 transition-colors hover:text-white/90 sm:inline"
+            >
+              Try
+            </Link>
+          </div>
+          <nav className="flex items-center gap-1.5 text-xs">
+            <Link
+              href="/docs/concepts/try-cli"
+              className="px-3 py-1.5 text-white/55 transition-colors hover:text-white/85"
+            >
+              Docs
+            </Link>
+            <a
+              href="https://github.com/agentclash/agentclash"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.03] px-3 py-1.5 text-white/60 transition-colors hover:border-white/15 hover:text-white/85"
+            >
+              <Star className="size-3.5" />
+              <span className="hidden sm:inline">GitHub</span>
+            </a>
+          </nav>
+        </div>
+      </header>
       {children}
     </div>
   );

--- a/web/src/components/try-cli/chrome.tsx
+++ b/web/src/components/try-cli/chrome.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+
+/**
+ * Shared visual chrome for the Try CLI surface, matching the AgentClash landing
+ * aesthetic: near-black canvas, a faint dotted grid that fades at the edges,
+ * Instrument Serif wordmark.
+ */
+
+export function GridBackdrop({ className = "" }: { className?: string }) {
+  return (
+    <div
+      aria-hidden
+      className={`pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_1px_1px,rgba(255,255,255,0.06)_1px,transparent_0)] [background-size:14px_14px] [mask-image:radial-gradient(ellipse_120%_80%_at_50%_-10%,#000_30%,transparent_75%)] ${className}`}
+    />
+  );
+}
+
+export function ClashMark({ className = "" }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 512 512" className={className} role="img" aria-label="AgentClash">
+      <defs>
+        <linearGradient id="trycli-clash" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="#fff" stopOpacity="0.85" />
+          <stop offset="100%" stopColor="#fff" stopOpacity="0.45" />
+        </linearGradient>
+      </defs>
+      <path d="M232 256 96 136v240z" fill="url(#trycli-clash)" />
+      <path d="M280 256 416 136v240z" fill="url(#trycli-clash)" />
+    </svg>
+  );
+}
+
+export function Wordmark() {
+  return (
+    <Link href="/" className="inline-flex items-center gap-2.5 text-white/90">
+      <ClashMark className="size-5" />
+      <span className="font-[family-name:var(--font-display)] text-xl tracking-[-0.01em]">
+        AgentClash
+      </span>
+    </Link>
+  );
+}

--- a/web/src/components/try-cli/chrome.tsx
+++ b/web/src/components/try-cli/chrome.tsx
@@ -16,16 +16,12 @@ export function GridBackdrop({ className = "" }: { className?: string }) {
 }
 
 export function ClashMark({ className = "" }: { className?: string }) {
+  // Solid fills with per-triangle opacity — no gradient <defs>/id, so the mark
+  // is safe to render more than once on a page without id collisions.
   return (
     <svg viewBox="0 0 512 512" className={className} role="img" aria-label="AgentClash">
-      <defs>
-        <linearGradient id="trycli-clash" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#fff" stopOpacity="0.85" />
-          <stop offset="100%" stopColor="#fff" stopOpacity="0.45" />
-        </linearGradient>
-      </defs>
-      <path d="M232 256 96 136v240z" fill="url(#trycli-clash)" />
-      <path d="M280 256 416 136v240z" fill="url(#trycli-clash)" />
+      <path d="M232 256 96 136v240z" fill="#fff" fillOpacity="0.85" />
+      <path d="M280 256 416 136v240z" fill="#fff" fillOpacity="0.5" />
     </svg>
   );
 }

--- a/web/src/components/try-cli/demo-client.tsx
+++ b/web/src/components/try-cli/demo-client.tsx
@@ -2,7 +2,15 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { ExternalLink, RotateCcw } from "lucide-react";
+import {
+  ArrowLeft,
+  Check,
+  Copy,
+  ExternalLink,
+  KeyRound,
+  RotateCcw,
+  TimerReset,
+} from "lucide-react";
 import { TryCliTerminal } from "@/components/try-cli/terminal";
 import { getTryCliApiBase, tryCliPublicOrigin } from "@/lib/try-cli/config";
 import type { DemoMeta, TrySession } from "@/lib/try-cli/types";
@@ -149,11 +157,16 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
 
   if (error && !demo) {
     return (
-      <div className="mx-auto max-w-lg px-6 py-24 text-center">
-        <h1 className="text-xl font-semibold">Demo not found</h1>
-        <p className="mt-2 text-muted-foreground">{error}</p>
-        <Link href="/try" className="mt-6 inline-block text-sm underline">
-          ← All demos
+      <div className="mx-auto max-w-lg px-6 py-32 text-center">
+        <h1 className="font-[family-name:var(--font-display)] text-3xl tracking-[-0.02em]">
+          Demo not found
+        </h1>
+        <p className="mt-3 text-white/50">{error}</p>
+        <Link
+          href="/try"
+          className="mt-8 inline-flex items-center gap-1.5 text-sm text-white/70 underline-offset-4 hover:text-white hover:underline"
+        >
+          <ArrowLeft className="size-3.5" /> All demos
         </Link>
       </div>
     );
@@ -161,68 +174,158 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
 
   return (
     <div className="flex h-[calc(100vh-4rem)] flex-col">
-      <header className="flex shrink-0 items-center justify-between border-b border-border px-4 py-3">
+      {/* Demo toolbar */}
+      <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-white/[0.06] px-5 py-3 sm:px-8">
         <div className="flex items-center gap-3">
-          <Link href="/try" className="text-sm font-medium text-muted-foreground hover:text-foreground">
-            AgentClash Try
+          <Link
+            href="/try"
+            className="text-white/40 transition-colors hover:text-white/80"
+            aria-label="All demos"
+          >
+            <ArrowLeft className="size-4" />
           </Link>
-          <span className="text-muted-foreground">/</span>
-          <h1 className="text-sm font-semibold">{demo?.name ?? slug}</h1>
-          {demo?.github && (
-            <a href={demo.github} target="_blank" rel="noreferrer" className="text-xs text-muted-foreground hover:text-foreground">
-              GitHub <ExternalLink className="inline size-3" />
-            </a>
+          <h1 className="font-[family-name:var(--font-display)] text-xl tracking-[-0.01em]">
+            {demo?.name ?? slug}
+          </h1>
+          {demo?.tagline && (
+            <span className="hidden text-sm text-white/40 lg:inline">{demo.tagline}</span>
           )}
-          {demo?.docs && (
-            <a href={demo.docs} target="_blank" rel="noreferrer" className="text-xs text-muted-foreground hover:text-foreground">
-              Docs <ExternalLink className="inline size-3" />
-            </a>
-          )}
+          <div className="flex items-center gap-3 pl-1">
+            {demo?.github && (
+              <a
+                href={demo.github}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-xs text-white/40 hover:text-white/80"
+              >
+                GitHub <ExternalLink className="size-3" />
+              </a>
+            )}
+            {demo?.docs && (
+              <a
+                href={demo.docs}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-xs text-white/40 hover:text-white/80"
+              >
+                Docs <ExternalLink className="size-3" />
+              </a>
+            )}
+          </div>
         </div>
         <div className="flex items-center gap-3">
-          <span className="font-mono text-xs text-muted-foreground">⏱ {remaining || "—"}</span>
+          <span className="inline-flex items-center gap-1.5 font-[family-name:var(--font-mono)] text-xs text-white/45">
+            <TimerReset className="size-3.5" />
+            {remaining || "—"}
+          </span>
           <button
             type="button"
             onClick={() => void reset()}
-            className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs hover:bg-muted"
+            className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.1] bg-white/[0.03] px-2.5 py-1.5 text-xs text-white/70 transition-colors hover:border-white/20 hover:text-white"
           >
             <RotateCcw className="size-3" />
             Reset
           </button>
         </div>
-      </header>
+      </div>
 
       {error && (
-        <div className="bg-destructive/10 px-4 py-2 text-sm text-destructive">{error}</div>
+        <div className="border-b border-red-500/20 bg-red-500/10 px-5 py-2 text-sm text-red-300 sm:px-8">
+          {error}
+        </div>
       )}
 
       <div className="flex min-h-0 flex-1 flex-col md:flex-row">
-        <aside className="w-full shrink-0 overflow-y-auto border-b border-border p-4 md:w-72 md:border-b-0 md:border-r">
-          <h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-            Suggested commands
-          </h2>
-          <p className="mt-1 text-xs text-muted-foreground">Click to copy, paste in terminal</p>
-          <ul className="mt-3 space-y-2">
-            {demo?.commands.map((c) => (
-              <li key={c.run}>
-                <button
-                  type="button"
-                  onClick={() => copyCmd(c.run)}
-                  className="w-full rounded-md border border-border bg-muted/30 px-3 py-2 text-left text-sm hover:border-foreground/20"
+        <aside className="w-full shrink-0 space-y-7 overflow-y-auto border-b border-white/[0.06] p-5 md:w-80 md:border-b-0 md:border-r">
+          {/* BYO auth panel */}
+          {demo?.auth && (
+            <div className="rounded-lg border border-white/[0.1] bg-white/[0.02] p-4">
+              <div className="flex items-center gap-2">
+                <KeyRound className="size-3.5 text-white/70" />
+                <h2 className="text-xs font-medium uppercase tracking-wide text-white/70">
+                  Sign in {demo.auth.provider ? `· ${demo.auth.provider}` : ""}
+                </h2>
+              </div>
+              <p className="mt-2 text-xs leading-relaxed text-white/50">{demo.auth.summary}</p>
+              {demo.auth.steps.length > 0 && (
+                <ol className="mt-3 space-y-2">
+                  {demo.auth.steps.map((step, i) => (
+                    <li key={step} className="flex gap-2.5 text-xs text-white/70">
+                      <span className="font-[family-name:var(--font-mono)] text-white/30">
+                        {String(i + 1).padStart(2, "0")}
+                      </span>
+                      <span className="leading-relaxed">{step}</span>
+                    </li>
+                  ))}
+                </ol>
+              )}
+              {demo.auth.signupUrl && (
+                <a
+                  href={demo.auth.signupUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="mt-3 inline-flex items-center gap-1 text-xs text-white/70 underline-offset-4 hover:text-white hover:underline"
                 >
-                  <span className="font-medium">{c.label}</span>
-                  <code className="mt-1 block text-xs text-muted-foreground">{c.run}</code>
-                  {copied === c.run && <span className="text-xs text-green-500">Copied</span>}
-                </button>
-              </li>
-            ))}
-          </ul>
-          <div className="mt-6 border-t border-border pt-4">
-            <h3 className="text-xs font-medium uppercase text-muted-foreground">README badge</h3>
-            <code className="mt-2 block break-all rounded bg-muted/50 p-2 text-[10px]">{badgeMd}</code>
+                  Get a key <ExternalLink className="size-3" />
+                </a>
+              )}
+            </div>
+          )}
+
+          {/* Suggested commands */}
+          <div>
+            <h2 className="text-xs font-medium uppercase tracking-wide text-white/40">
+              Suggested commands
+            </h2>
+            <p className="mt-1 text-xs text-white/30">Click to copy · paste in the terminal</p>
+            <ul className="mt-3 space-y-2">
+              {demo?.commands.map((c) => (
+                <li key={c.run}>
+                  <button
+                    type="button"
+                    onClick={() => copyCmd(c.run)}
+                    className="group w-full rounded-lg border border-white/[0.08] bg-white/[0.02] px-3 py-2.5 text-left transition-colors hover:border-white/20 hover:bg-white/[0.04]"
+                  >
+                    <span className="flex items-center justify-between">
+                      <span className="text-sm font-medium text-white/85">{c.label}</span>
+                      {copied === c.run ? (
+                        <Check className="size-3.5 text-emerald-400" />
+                      ) : (
+                        <Copy className="size-3.5 text-white/25 transition-colors group-hover:text-white/60" />
+                      )}
+                    </span>
+                    <code className="mt-1 block truncate font-[family-name:var(--font-mono)] text-xs text-white/40">
+                      {c.run}
+                    </code>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Badge */}
+          <div className="border-t border-white/[0.06] pt-5">
+            <button
+              type="button"
+              onClick={() => copyCmd(badgeMd)}
+              className="group flex w-full items-center justify-between text-left"
+            >
+              <h3 className="text-xs font-medium uppercase tracking-wide text-white/40">
+                README badge
+              </h3>
+              {copied === badgeMd ? (
+                <Check className="size-3.5 text-emerald-400" />
+              ) : (
+                <Copy className="size-3.5 text-white/25 transition-colors group-hover:text-white/60" />
+              )}
+            </button>
+            <code className="mt-2 block break-all rounded-md bg-white/[0.03] p-2.5 font-[family-name:var(--font-mono)] text-[10px] leading-relaxed text-white/45">
+              {badgeMd}
+            </code>
           </div>
         </aside>
-        <main className="min-h-0 flex-1 p-4">
+
+        <main className="min-h-0 flex-1 p-4 sm:p-5">
           <TryCliTerminal sessionId={sessionId} status={status} />
         </main>
       </div>

--- a/web/src/components/try-cli/landing-client.tsx
+++ b/web/src/components/try-cli/landing-client.tsx
@@ -1,70 +1,162 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { ArrowRight, Terminal } from "lucide-react";
+import { ArrowRight, ArrowUpRight, Terminal } from "lucide-react";
 import { getTryCliApiBase } from "@/lib/try-cli/config";
 import type { DemoMeta } from "@/lib/try-cli/types";
 
+const CATEGORY_ORDER = ["AI coding agents", "Developer tools"];
+
+function categoryRank(category: string): number {
+  const i = CATEGORY_ORDER.indexOf(category);
+  return i === -1 ? CATEGORY_ORDER.length : i;
+}
+
 export function TryCliLandingClient() {
   const [demos, setDemos] = useState<DemoMeta[]>([]);
+  const [loaded, setLoaded] = useState(false);
   const apiBase = getTryCliApiBase();
 
   useEffect(() => {
     fetch(`${apiBase}/demos`)
       .then((r) => r.json())
-      .then(setDemos)
-      .catch(() => setDemos([]));
+      .then((d) => setDemos(Array.isArray(d) ? d : []))
+      .catch(() => setDemos([]))
+      .finally(() => setLoaded(true));
   }, [apiBase]);
 
-  return (
-    <div className="mx-auto max-w-4xl px-6 py-16">
-      <div className="inline-flex items-center gap-2 rounded-full border border-border px-3 py-1 text-xs text-muted-foreground">
-        <Terminal className="size-3.5" />
-        AgentClash primitive · E2B sandboxes
-      </div>
-      <h1 className="mt-6 text-3xl font-semibold tracking-tight md:text-4xl">
-        Try any CLI in your browser before you install it
-      </h1>
-      <p className="mt-4 max-w-2xl text-muted-foreground">
-        Interactive README demos for developer tools. One badge, disposable Linux terminal,
-        pre-installed CLIs — powered by AgentClash and E2B.
-      </p>
-      <pre className="mt-6 overflow-x-auto rounded-lg border border-border bg-muted/30 p-4 text-sm">
-        npx @agentclash/try-cli init && npx @agentclash/try-cli publish
-      </pre>
+  const groups = useMemo(() => {
+    const byCat = new Map<string, DemoMeta[]>();
+    for (const d of demos) {
+      const cat = d.category ?? "Developer tools";
+      byCat.set(cat, [...(byCat.get(cat) ?? []), d]);
+    }
+    return [...byCat.entries()].sort((a, b) => categoryRank(a[0]) - categoryRank(b[0]));
+  }, [demos]);
 
-      <section className="mt-12">
-        <h2 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
-          Live demos
-        </h2>
-        <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {demos.map((d) => (
-            <Link
-              key={d.slug}
-              href={`/try/${d.slug}`}
-              className="group rounded-lg border border-border p-4 transition-colors hover:border-foreground/30 hover:bg-muted/20"
-            >
-              <span className="font-medium">{d.name}</span>
-              <span className="mt-1 flex items-center gap-1 text-xs text-muted-foreground group-hover:text-foreground">
-                Open terminal <ArrowRight className="size-3" />
-              </span>
-            </Link>
+  return (
+    <main className="mx-auto max-w-[1400px] px-5 pb-28 sm:px-8">
+      {/* Hero */}
+      <section className="pt-20 sm:pt-28">
+        <div className="inline-flex items-center gap-2 rounded-full border border-white/[0.08] bg-white/[0.03] px-3 py-1 text-xs text-white/55">
+          <Terminal className="size-3.5" />
+          AgentClash primitive · live E2B sandboxes
+        </div>
+        <h1 className="mt-8 max-w-[18ch] font-[family-name:var(--font-display)] text-[clamp(2.75rem,6.5vw,6rem)] font-normal leading-[0.95] tracking-[-0.04em]">
+          Run any CLI.
+          <br />
+          <span className="text-white/45">In your browser.</span>
+        </h1>
+        <p className="mt-8 max-w-[52ch] text-lg leading-[1.55] text-white/55">
+          Spin up a disposable cloud terminal and try AI coding agents and developer
+          tools before you install a thing. No setup, no signup — just type.
+        </p>
+        <div className="mt-10 flex flex-wrap items-center gap-3">
+          <a
+            href="#demos"
+            className="inline-flex items-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-medium text-[#060606] transition-colors hover:bg-white/90"
+          >
+            Browse demos
+            <ArrowRight className="size-4" />
+          </a>
+          <Link
+            href="/docs/concepts/try-cli"
+            className="inline-flex items-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm text-white/80 transition-colors hover:border-white/25 hover:text-white"
+          >
+            How it works
+          </Link>
+        </div>
+      </section>
+
+      {/* Demos */}
+      <section id="demos" className="mt-24 scroll-mt-24">
+        {!loaded && (
+          <div className="grid gap-px overflow-hidden rounded-xl border border-white/[0.08] bg-white/[0.06] sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="h-[132px] animate-pulse bg-[#0a0a0a]" />
+            ))}
+          </div>
+        )}
+
+        {loaded && demos.length === 0 && (
+          <p className="text-sm text-white/40">No demos available right now.</p>
+        )}
+
+        <div className="space-y-16">
+          {groups.map(([category, items]) => (
+            <div key={category}>
+              <div className="mb-5 flex items-baseline justify-between">
+                <h2 className="font-[family-name:var(--font-display)] text-2xl tracking-[-0.02em] text-white/90">
+                  {category}
+                </h2>
+                <span className="text-xs text-white/35">{items.length} demos</span>
+              </div>
+              <div className="grid gap-px overflow-hidden rounded-xl border border-white/[0.08] bg-white/[0.06] sm:grid-cols-2 lg:grid-cols-3">
+                {items.map((d) => (
+                  <Link
+                    key={d.slug}
+                    href={`/try/${d.slug}`}
+                    className="group relative flex min-h-[132px] flex-col justify-between bg-[#0a0a0a] p-5 transition-colors hover:bg-white/[0.02]"
+                  >
+                    <div>
+                      <div className="flex items-center justify-between">
+                        <span className="font-[family-name:var(--font-display)] text-xl tracking-[-0.01em] text-white">
+                          {d.name}
+                        </span>
+                        <ArrowUpRight className="size-4 text-white/25 transition-all group-hover:translate-x-0.5 group-hover:-translate-y-0.5 group-hover:text-white/70" />
+                      </div>
+                      {d.tagline && (
+                        <p className="mt-2 text-sm leading-snug text-white/45">{d.tagline}</p>
+                      )}
+                    </div>
+                    <span className="mt-4 inline-flex items-center gap-1.5 text-xs text-white/35 transition-colors group-hover:text-white/70">
+                      Open terminal
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            </div>
           ))}
         </div>
       </section>
 
-      <section className="mt-12 rounded-lg border border-border p-6">
-        <h2 className="font-medium">For maintainers</h2>
-        <ol className="mt-3 list-decimal space-y-2 pl-5 text-sm text-muted-foreground">
-          <li>Add <code className="text-foreground">.trycli.yml</code> to your repo</li>
-          <li>Run <code className="text-foreground">npx @agentclash/try-cli publish</code></li>
-          <li>Users click your badge → real terminal on AgentClash</li>
-        </ol>
-        <Link href="/docs/concepts/try-cli" className="mt-4 inline-block text-sm underline">
-          Read the docs →
-        </Link>
+      {/* Maintainers */}
+      <section className="mt-28 grid gap-12 border-t border-white/[0.06] pt-16 md:grid-cols-[1fr_1.1fr] md:gap-20">
+        <div>
+          <h2 className="font-[family-name:var(--font-display)] text-[clamp(1.75rem,3vw,2.75rem)] font-normal leading-[1.05] tracking-[-0.03em]">
+            Ship a live demo of <span className="text-white/45">your</span> CLI.
+          </h2>
+          <p className="mt-6 max-w-[44ch] text-white/55">
+            Drop a <code className="font-[family-name:var(--font-mono)] text-white/80">.trycli.yml</code>{" "}
+            in your repo, publish a badge, and let anyone try your tool in one click —
+            running on AgentClash sandboxes.
+          </p>
+          <Link
+            href="/docs/concepts/try-cli"
+            className="mt-8 inline-flex items-center gap-1.5 text-sm text-white/80 underline-offset-4 transition-colors hover:text-white hover:underline"
+          >
+            Read the docs <ArrowRight className="size-3.5" />
+          </Link>
+        </div>
+        <div className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-6">
+          <ol className="space-y-5">
+            {[
+              { k: "01", t: "Add a config", d: "npx @agentclash/try-cli init" },
+              { k: "02", t: "Publish a badge", d: "npx @agentclash/try-cli publish" },
+              { k: "03", t: "Users click → real terminal", d: "No install. Just your tool, live." },
+            ].map((s) => (
+              <li key={s.k} className="flex gap-4">
+                <span className="font-[family-name:var(--font-mono)] text-sm text-white/30">{s.k}</span>
+                <div>
+                  <div className="text-sm font-medium text-white/90">{s.t}</div>
+                  <div className="mt-1 font-[family-name:var(--font-mono)] text-xs text-white/45">{s.d}</div>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </div>
       </section>
-    </div>
+    </main>
   );
 }

--- a/web/src/components/try-cli/terminal.tsx
+++ b/web/src/components/try-cli/terminal.tsx
@@ -15,10 +15,22 @@ export function TryCliTerminal({ sessionId, status, onReady }: Props) {
   const termRef = useRef<import("@xterm/xterm").Terminal | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const fitRef = useRef<import("@xterm/addon-fit").FitAddon | null>(null);
+  // The session id we've already opened a socket for. The server holds a
+  // socket opened during "starting" and attaches the PTY once the sandbox is
+  // ready, so we must connect exactly once per id — reconnecting on the
+  // starting→ready transition is what produced the "[session disconnected]"
+  // flash and a duplicated welcome banner.
+  const connectedIdRef = useRef<string | null>(null);
 
   const connect = useCallback(
     (id: string) => {
-      wsRef.current?.close();
+      // Detach the previous socket's handler so an intentional swap (reset)
+      // doesn't print the disconnect notice.
+      const prev = wsRef.current;
+      if (prev) {
+        prev.onclose = null;
+        prev.close();
+      }
       const wsBase = getTryCliWsBase();
       const ws = new WebSocket(`${wsBase}/ws?sessionId=${id}`);
       ws.binaryType = "arraybuffer";
@@ -102,27 +114,46 @@ export function TryCliTerminal({ sessionId, status, onReady }: Props) {
     return () => {
       disposed = true;
       removeResizeListener?.();
-      wsRef.current?.close();
+      const ws = wsRef.current;
+      if (ws) {
+        ws.onclose = null;
+        ws.close();
+      }
       termRef.current?.dispose();
     };
   }, []);
 
   useEffect(() => {
-    if (sessionId && (status === "ready" || status === "starting")) {
-      connect(sessionId);
-    }
+    if (!sessionId) return;
+    if (status !== "ready" && status !== "starting") return;
+    // Connect once per session id; the server attaches the PTY when the
+    // sandbox becomes ready, so we don't reconnect on the status change.
+    if (connectedIdRef.current === sessionId) return;
+    connectedIdRef.current = sessionId;
+    connect(sessionId);
   }, [sessionId, status, connect]);
 
   return (
-    <div className="relative h-full min-h-[320px] w-full rounded-lg border border-border bg-[#0a0a0a]">
-      {status === "starting" && (
-        <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 bg-black/80 text-sm text-muted-foreground">
-          <div className="size-8 animate-spin rounded-full border-2 border-muted border-t-foreground" />
-          <p>Starting sandbox…</p>
-          <p className="text-xs">First launch may take 15–30s while tools install</p>
-        </div>
-      )}
-      <div ref={containerRef} className="h-full w-full p-2" />
+    <div className="relative flex h-full min-h-[320px] w-full flex-col overflow-hidden rounded-xl border border-white/[0.1] bg-[#0a0a0a] shadow-[0_0_0_1px_rgba(0,0,0,0.4),0_24px_60px_-24px_rgba(0,0,0,0.8)]">
+      <div className="flex shrink-0 items-center gap-2 border-b border-white/[0.06] bg-white/[0.02] px-4 py-2.5">
+        <span className="size-2.5 rounded-full bg-white/15" />
+        <span className="size-2.5 rounded-full bg-white/15" />
+        <span className="size-2.5 rounded-full bg-white/15" />
+        <span className="ml-2 font-[family-name:var(--font-mono)] text-[11px] text-white/30">
+          e2b · disposable sandbox
+        </span>
+      </div>
+      <div className="relative min-h-0 flex-1">
+        {status === "starting" && (
+          <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-[#0a0a0a]/85 text-sm text-white/60 backdrop-blur-sm">
+            <div className="size-7 animate-spin rounded-full border-2 border-white/15 border-t-white/70" />
+            <p className="font-[family-name:var(--font-mono)] text-xs tracking-wide">
+              booting sandbox…
+            </p>
+          </div>
+        )}
+        <div ref={containerRef} className="h-full w-full p-3" />
+      </div>
     </div>
   );
 }

--- a/web/src/components/try-cli/terminal.tsx
+++ b/web/src/components/try-cli/terminal.tsx
@@ -120,6 +120,9 @@ export function TryCliTerminal({ sessionId, status, onReady }: Props) {
         ws.close();
       }
       termRef.current?.dispose();
+      // Allow a remount to reconnect to the same session id (refs survive an
+      // effect cleanup, e.g. React strict-mode mount→cleanup→remount).
+      connectedIdRef.current = null;
     };
   }, []);
 

--- a/web/src/lib/try-cli/types.ts
+++ b/web/src/lib/try-cli/types.ts
@@ -1,10 +1,21 @@
+export interface DemoAuth {
+  provider?: string;
+  summary: string;
+  steps: string[];
+  envKey?: string;
+  signupUrl?: string;
+}
+
 export interface DemoMeta {
   slug: string;
   name: string;
+  tagline?: string;
+  category?: string;
   docs?: string;
   github?: string;
   welcome?: string;
   commands: { label: string; run: string }[];
+  auth?: DemoAuth;
   sessionMinutes: number;
 }
 


### PR DESCRIPTION
## Summary

Makes Try CLI **fast**, **smooth**, and adds **AI coding agents**. Follow-up to #880.

Three things the current `/try` needed: it showed a `[session disconnected]` flash, sandboxes were very slow to start, and the UI felt generic. This fixes all three and adds the four AI CLIs (Claude Code, Codex, OpenCode, Grok) with a bring-your-own-credentials auth model.

## What changed

**⚡ Speed — prebaked E2B template.** Every demo tool is now pre-installed in a shared E2B template (`agentclash-trycli`), built in E2B's cloud via Build System 2.0 (`services/try-cli/scripts/build-template.ts` — no local Docker). Demos drop their per-session install steps and reference the template, so sandboxes boot ready in ~1–2s instead of 15–30s.
- Also fixes a latent bug: the service passed the template *inside* the options object, which e2b v2 silently ignores — it now passes it positionally, so custom templates actually apply.

**🔌 "Stream disconnected" fix.** The terminal opened a second WebSocket on the `starting → ready` transition, which closed the first (the `[session disconnected]` flash) and re-sent the welcome banner. It now connects once per session id and suppresses the notice on intentional swaps. Verified: the welcome renders exactly once.

**🤖 AI coding agent demos** — Claude Code, Codex CLI, OpenCode, Grok CLI.
- **Auth = bring-your-own-credentials.** Each demo carries an `auth` block telling the visitor how to sign in with their **own** account/key inside the disposable sandbox (Claude Code `/login` paste-code, Codex `--device-auth`, OpenCode/Grok paste a key). We deliberately do **not** inject provider keys — that violates OpenAI/Anthropic terms and would let anyone in the shell exfiltrate the key. A spend-capped server-side proxy is the future path for a true zero-input free trial.

**🎨 Redesigned `/try` UI** to the AgentClash landing language: near-black canvas with a fading dotted grid, Instrument Serif display headings, monochrome pill buttons, category-grouped hairline demo cards, a BYO-auth side panel, and a framed terminal with a smoother boot state.

**Schema.** Optional `tagline`, `category`, and `auth` fields on `.trycli.yml`, threaded core → service `DemoMeta` → web types.

## Verified
- E2B template built; spun up a real sandbox and confirmed all 11 tools present and on PATH (claude 2.1, codex 0.135, opencode 1.15, grok 1.1.7, bun, biome, uv, ruff, rg, node, git).
- Web: `tsc --noEmit`, `eslint` (0 errors), and `next build` all pass.
- Local end-to-end: hub + `/try/claude-code` render the new UI, the terminal boots from the template and shows a single welcome (no disconnect flash), 0 console errors.

## Deploy notes (post-merge)
- The E2B template is already built under the project's `E2B_API_KEY` (same key the Railway service uses). Rebuild after tool changes: `cd services/try-cli && bun run scripts/build-template.ts`.
- Railway (try-cli service) and Vercel (web) auto-deploy on merge to `main`; env vars are already set from #880.

## Follow-ups (not in this PR)
- Server-side key proxy for a true zero-input free trial (spend/rate caps; CLIs point at it via `*_BASE_URL`).
- Remove the unused `/try-api/*` rewrite in `web/vercel.json`.
