### PR TITLE
feat(try-cli): free-trial gateway + signed-in BYO tier for AI demos

### DIFF
--- a/docs/deployment/try-cli.md
+++ b/docs/deployment/try-cli.md
@@ -26,6 +26,44 @@ Deploy via existing Vercel Git integration on `main` after merge.
 
 Optional DNS: `try.agentclash.dev` → Vercel (rewrite to `/try` is in `next.config.ts`).
 
+## Free-trial gateway (anonymous AI demos)
+
+Anonymous visitors can try the AI coding agents with **no login and no API key**
+for a few minutes. This is served by a metered gateway built into the Try CLI
+service: the real provider keys live only on the service, each session gets a
+short-lived spend-capped proxy token, and the sandbox CLIs point their base URL
+at `/gw/<provider>`. Signed-in users instead bring their own credentials and get
+a longer session (so they cost us nothing).
+
+Set on the **Railway Try CLI service**:
+
+```env
+# Provider keys (server-side only — never sent to the sandbox)
+ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-...
+XAI_API_KEY=xai-...            # enables the Grok free trial
+# Where the sandbox CLIs reach the gateway (this service's own public URL)
+TRY_CLI_GATEWAY_URL=https://try-cli-production.up.railway.app
+# Durable daily spend ceiling (THE backstop) — reference the project's Redis
+REDIS_URL=${{Redis.REDIS_URL}}
+# Shared secret so the Vercel proxy can grant the signed-in (BYO) tier
+TRY_CLI_PROXY_SECRET=<random-string>
+# Caps (optional; shown with defaults)
+GW_DAILY_CEILING_USD=5
+GW_SESSION_BUDGET_USD=0.30
+GW_ANON_MINUTES=7
+GW_AUTH_MINUTES=20
+GW_MAX_OUTPUT_TOKENS=2048
+```
+
+On **Vercel** (web), set the matching `TRY_CLI_PROXY_SECRET` so the proxy attaches
+the signed-in user id. Without it, everyone is treated as anonymous (safe default).
+
+> The daily ceiling is Redis-backed so it survives restarts and multiple
+> instances — it's the hard cap on what an abuser can spend. The per-session
+> budget is the per-visitor comfort cap. If Redis is unreachable the gateway
+> fails **closed** (reports the ceiling as reached).
+
 ## E2B template (prerequisite)
 
 Demos boot from a shared E2B template (`agentclash-trycli`) with every CLI

--- a/services/try-cli/server/daily-ledger.ts
+++ b/services/try-cli/server/daily-ledger.ts
@@ -1,0 +1,77 @@
+/**
+ * Durable per-day spend ledger for the free-trial gateway. Backed by Redis so
+ * the global daily ceiling survives restarts/redeploys and multiple instances
+ * (an in-memory counter would reset on every deploy — useless as a money cap).
+ * Falls back to in-memory when REDIS_URL is unset (local dev only).
+ */
+import type { DailyLedger } from "./gateway.ts";
+
+function todayKey(): string {
+  const d = new Date();
+  const day = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(
+    d.getUTCDate(),
+  ).padStart(2, "0")}`;
+  return `trycli:gw:daily:${day}`;
+}
+
+export function createDailyLedger(): DailyLedger {
+  const url = process.env.REDIS_URL || process.env.VALKEY_URL;
+
+  if (url) {
+    // Bun ships a native Redis client.
+    const { RedisClient } = require("bun") as typeof import("bun");
+    const client = new RedisClient(url);
+    let warned = false;
+    const safe = async <T>(fn: () => Promise<T>, fallback: T): Promise<T> => {
+      try {
+        return await fn();
+      } catch (err) {
+        if (!warned) {
+          warned = true;
+          console.error("[gw] redis ledger error — failing closed:", err);
+        }
+        return fallback;
+      }
+    };
+    return {
+      // Fail CLOSED on Redis error: report the ceiling as reached so we never
+      // overspend blind. (Returns Infinity so callers see "at/over ceiling".)
+      async get() {
+        return safe(async () => {
+          const v = await client.get(todayKey());
+          return v ? parseFloat(v) : 0;
+        }, Number.POSITIVE_INFINITY);
+      },
+      async add(usd) {
+        return safe(async () => {
+          const key = todayKey();
+          const total = await client.send("INCRBYFLOAT", [key, String(usd)]);
+          await client.send("EXPIRE", [key, "172800"]); // 48h
+          return parseFloat(String(total));
+        }, 0);
+      },
+    };
+  }
+
+  console.warn("[try-cli] REDIS_URL not set — daily gateway ceiling is in-memory (dev only)");
+  let day = todayKey();
+  let total = 0;
+  const roll = () => {
+    const k = todayKey();
+    if (k !== day) {
+      day = k;
+      total = 0;
+    }
+  };
+  return {
+    async get() {
+      roll();
+      return total;
+    },
+    async add(usd) {
+      roll();
+      total += usd;
+      return total;
+    },
+  };
+}

--- a/services/try-cli/server/daily-ledger.ts
+++ b/services/try-cli/server/daily-ledger.ts
@@ -43,12 +43,14 @@ export function createDailyLedger(): DailyLedger {
         }, Number.POSITIVE_INFINITY);
       },
       async add(usd) {
+        // Fail closed on error (Infinity), matching get(), so an intermittent
+        // Redis failure can't silently under-count the daily total.
         return safe(async () => {
           const key = todayKey();
           const total = await client.send("INCRBYFLOAT", [key, String(usd)]);
           await client.send("EXPIRE", [key, "172800"]); // 48h
           return parseFloat(String(total));
-        }, 0);
+        }, Number.POSITIVE_INFINITY);
       },
     };
   }

--- a/services/try-cli/server/gateway.ts
+++ b/services/try-cli/server/gateway.ts
@@ -24,6 +24,8 @@ interface ProviderConfig {
 
 const MAX_OUTPUT_TOKENS = Number(process.env.GW_MAX_OUTPUT_TOKENS ?? 2048);
 const MAX_REQUEST_BYTES = Number(process.env.GW_MAX_REQUEST_BYTES ?? 256 * 1024);
+// Conservative spend held per in-flight request until real usage is metered.
+const REQUEST_RESERVE_USD = Number(process.env.GW_REQUEST_RESERVE_USD ?? 0.05);
 
 function providers(): Record<string, ProviderConfig | undefined> {
   const anthropicKey = process.env.ANTHROPIC_API_KEY;
@@ -167,8 +169,10 @@ export async function handleGatewayRequest(
   const session = deps.sessions.validateGatewayToken(token);
   if (!session) return json({ error: "invalid or expired trial token" }, 401);
 
-  // Per-session budget.
-  if (session.gatewaySpentUsd >= session.gatewayBudgetUsd) {
+  // Per-session budget. Count in-flight reservations so concurrent requests
+  // can't all pass while a prior request is still streaming (metering only
+  // updates spend once the response completes).
+  if (session.gatewaySpentUsd + session.gatewayReservedUsd >= session.gatewayBudgetUsd) {
     return json(
       { error: "Free trial budget reached. Sign in with your own account to continue." },
       402,
@@ -205,6 +209,12 @@ export async function handleGatewayRequest(
   provider.applyAuth(headers);
   if (bodyInit !== undefined) headers.set("content-length", String(Buffer.byteLength(bodyInit as string)));
 
+  // Reserve estimated spend for this in-flight request; released once metered.
+  session.gatewayReservedUsd += REQUEST_RESERVE_USD;
+  const release = () => {
+    session.gatewayReservedUsd = Math.max(0, session.gatewayReservedUsd - REQUEST_RESERVE_USD);
+  };
+
   const target = `${provider.base}${m[2] ?? ""}${url.search}`;
   let upstream: Response;
   try {
@@ -216,17 +226,19 @@ export async function handleGatewayRequest(
       duplex: "half",
     });
   } catch (err) {
+    release();
     console.error(`[gw] upstream error ${providerName}:`, err);
     return json({ error: "upstream request failed" }, 502);
   }
 
   if (!upstream.body) {
+    release();
     return new Response(null, { status: upstream.status, headers: upstream.headers });
   }
 
   // Tee: one branch streams to the CLI, the other is drained to meter usage.
   const [toClient, toMeter] = upstream.body.tee();
-  void meter(toMeter, providerName, session, deps).catch(() => {});
+  void meter(toMeter, providerName, session, deps, release).catch(() => release());
 
   return new Response(toClient, {
     status: upstream.status,
@@ -239,23 +251,29 @@ async function meter(
   providerName: string,
   session: TerminalSession,
   deps: GatewayDeps,
+  release: () => void,
 ): Promise<void> {
-  const reader = stream.getReader();
-  const decoder = new TextDecoder();
-  let text = "";
-  // Cap accumulation so a runaway stream can't balloon memory.
-  const CAP = 8 * 1024 * 1024;
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    if (text.length < CAP) text += decoder.decode(value, { stream: true });
+  try {
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let text = "";
+    // Cap accumulation so a runaway stream can't balloon memory.
+    const CAP = 8 * 1024 * 1024;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (text.length < CAP) text += decoder.decode(value, { stream: true });
+    }
+    const usage = parseUsage(text);
+    if (!usage) return;
+    const usd = priceUsd(usage.model || defaultModel(providerName), usage.inTok, usage.outTok);
+    if (usd <= 0) return;
+    deps.sessions.addGatewaySpend(session.id, usd);
+    await deps.daily.add(usd);
+  } finally {
+    // Always release the in-flight reservation, even if parsing/metering failed.
+    release();
   }
-  const usage = parseUsage(text);
-  if (!usage) return;
-  const usd = priceUsd(usage.model || defaultModel(providerName), usage.inTok, usage.outTok);
-  if (usd <= 0) return;
-  deps.sessions.addGatewaySpend(session.id, usd);
-  await deps.daily.add(usd);
 }
 
 function defaultModel(provider: string): string {

--- a/services/try-cli/server/gateway.ts
+++ b/services/try-cli/server/gateway.ts
@@ -1,0 +1,265 @@
+/**
+ * Metered LLM gateway for the anonymous free trial.
+ *
+ * The real provider keys live ONLY here (server-side). Each anonymous session
+ * is minted a short-lived, spend-capped proxy token that the sandbox CLIs send
+ * as their API key while pointing their base URL at `/gw/<provider>`. The
+ * gateway validates the token against a live, in-budget session, swaps in the
+ * real key, streams the provider response straight back, and meters spend.
+ *
+ * Safety model (see PR discussion): a leaked proxy token is near-worthless —
+ * it only works through this gateway, expires with the session, and is bounded
+ * by both a per-session budget AND a durable global daily ceiling (Redis), which
+ * is the real backstop against a public no-login endpoint.
+ */
+import type { SessionManager, TerminalSession } from "./sessions.ts";
+
+interface ProviderConfig {
+  base: string;
+  /** Inject the real upstream credential. */
+  applyAuth: (h: Headers) => void;
+  /** Clamp the per-request output ceiling in the JSON body. */
+  clampBody: (body: Record<string, unknown>, maxOut: number) => void;
+}
+
+const MAX_OUTPUT_TOKENS = Number(process.env.GW_MAX_OUTPUT_TOKENS ?? 2048);
+const MAX_REQUEST_BYTES = Number(process.env.GW_MAX_REQUEST_BYTES ?? 256 * 1024);
+
+function providers(): Record<string, ProviderConfig | undefined> {
+  const anthropicKey = process.env.ANTHROPIC_API_KEY;
+  const openaiKey = process.env.OPENAI_API_KEY;
+  const xaiKey = process.env.XAI_API_KEY;
+  return {
+    anthropic: anthropicKey
+      ? {
+          base: "https://api.anthropic.com",
+          applyAuth: (h) => h.set("x-api-key", anthropicKey),
+          clampBody: (b, max) => {
+            if (typeof b.max_tokens !== "number" || b.max_tokens > max) b.max_tokens = max;
+          },
+        }
+      : undefined,
+    openai: openaiKey
+      ? {
+          base: "https://api.openai.com",
+          applyAuth: (h) => h.set("authorization", `Bearer ${openaiKey}`),
+          clampBody: (b, max) => {
+            if (typeof b.max_output_tokens === "number" && b.max_output_tokens > max)
+              b.max_output_tokens = max;
+            if (typeof b.max_tokens === "number" && b.max_tokens > max) b.max_tokens = max;
+          },
+        }
+      : undefined,
+    xai: xaiKey
+      ? {
+          base: "https://api.x.ai",
+          applyAuth: (h) => h.set("authorization", `Bearer ${xaiKey}`),
+          clampBody: (b, max) => {
+            if (typeof b.max_tokens === "number" && b.max_tokens > max) b.max_tokens = max;
+          },
+        }
+      : undefined,
+  };
+}
+
+/** Rough $/Mtok by model family — used only to bound spend, not to bill. */
+function priceUsd(model: string, inTok: number, outTok: number): number {
+  const m = model.toLowerCase();
+  let inP = 3,
+    outP = 15; // conservative default
+  if (m.includes("haiku")) [inP, outP] = [1, 5];
+  else if (m.includes("sonnet")) [inP, outP] = [3, 15];
+  else if (m.includes("opus")) [inP, outP] = [15, 75];
+  else if (m.includes("gpt-4o-mini") || m.includes("mini")) [inP, outP] = [0.15, 0.6];
+  else if (m.includes("gpt-4o") || m.includes("gpt-4.1")) [inP, outP] = [2.5, 10];
+  else if (m.includes("gpt-5") || m.includes("o3") || m.includes("o1")) [inP, outP] = [5, 20];
+  else if (m.includes("grok")) [inP, outP] = [2, 10];
+  return (inTok * inP + outTok * outP) / 1_000_000;
+}
+
+/** Parse usage from a provider response (SSE stream or JSON) — best effort. */
+function parseUsage(text: string): { model: string; inTok: number; outTok: number } | null {
+  // Anthropic streaming: message_start has input usage, message_delta has output.
+  let model = "";
+  let inTok = 0;
+  let outTok = 0;
+  let found = false;
+  // Try JSON (non-streaming) first.
+  try {
+    const j = JSON.parse(text);
+    const u = j.usage ?? j.response?.usage;
+    if (u) {
+      model = j.model ?? j.response?.model ?? "";
+      inTok = u.input_tokens ?? u.prompt_tokens ?? 0;
+      outTok = u.output_tokens ?? u.completion_tokens ?? 0;
+      return { model, inTok, outTok };
+    }
+  } catch {
+    /* not JSON — scan SSE */
+  }
+  for (const line of text.split("\n")) {
+    const t = line.trim();
+    if (!t.startsWith("data:")) continue;
+    const payload = t.slice(5).trim();
+    if (payload === "[DONE]") continue;
+    try {
+      const ev = JSON.parse(payload);
+      const u = ev.usage ?? ev.message?.usage ?? ev.response?.usage;
+      if (ev.model) model = ev.model;
+      if (ev.message?.model) model = ev.message.model;
+      if (ev.response?.model) model = ev.response.model;
+      if (u) {
+        if (typeof u.input_tokens === "number") inTok = Math.max(inTok, u.input_tokens);
+        if (typeof u.output_tokens === "number") outTok = Math.max(outTok, u.output_tokens);
+        if (typeof u.prompt_tokens === "number") inTok = Math.max(inTok, u.prompt_tokens);
+        if (typeof u.completion_tokens === "number") outTok = Math.max(outTok, u.completion_tokens);
+        found = true;
+      }
+    } catch {
+      /* ignore partial */
+    }
+  }
+  return found ? { model, inTok, outTok } : null;
+}
+
+export interface GatewayDeps {
+  sessions: SessionManager;
+  /** Durable daily spend ledger (Redis-backed in prod, in-memory in dev). */
+  daily: DailyLedger;
+}
+
+export interface DailyLedger {
+  /** Current spend in USD for today. */
+  get(): Promise<number>;
+  /** Add usd to today's total; returns the new total. */
+  add(usd: number): Promise<number>;
+}
+
+const DAILY_CEILING_USD = Number(process.env.GW_DAILY_CEILING_USD ?? 5);
+
+function json(data: unknown, status: number): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/**
+ * Handle a `/gw/<provider>/...` request. Returns the streamed provider response
+ * on success, or a JSON error (401/402/429/502) otherwise.
+ */
+export async function handleGatewayRequest(
+  req: Request,
+  url: URL,
+  deps: GatewayDeps,
+): Promise<Response> {
+  const m = url.pathname.match(/^\/gw\/(anthropic|openai|xai)(\/.*)?$/);
+  if (!m) return json({ error: "unknown gateway route" }, 404);
+  const providerName = m[1]!;
+  const provider = providers()[providerName];
+  if (!provider) return json({ error: `${providerName} not configured` }, 503);
+
+  // The CLI sends the proxy token where the real key would go.
+  const token =
+    req.headers.get("x-api-key") ??
+    req.headers.get("authorization")?.replace(/^Bearer\s+/i, "") ??
+    "";
+  const session = deps.sessions.validateGatewayToken(token);
+  if (!session) return json({ error: "invalid or expired trial token" }, 401);
+
+  // Per-session budget.
+  if (session.gatewaySpentUsd >= session.gatewayBudgetUsd) {
+    return json(
+      { error: "Free trial budget reached. Sign in with your own account to continue." },
+      402,
+    );
+  }
+  // Durable global daily ceiling — the real backstop.
+  if ((await deps.daily.get()) >= DAILY_CEILING_USD) {
+    return json({ error: "Daily free-trial capacity reached. Try again tomorrow or sign in." }, 429);
+  }
+
+  // Read + clamp the request body (these bodies are small; only the response streams).
+  let bodyInit: BodyInit | undefined;
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    const raw = await req.text();
+    if (raw.length > MAX_REQUEST_BYTES) return json({ error: "request too large" }, 413);
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as Record<string, unknown>;
+        provider.clampBody(parsed, MAX_OUTPUT_TOKENS);
+        bodyInit = JSON.stringify(parsed);
+      } catch {
+        bodyInit = raw; // non-JSON (rare) — forward verbatim
+      }
+    }
+  }
+
+  const headers = new Headers(req.headers);
+  headers.delete("host");
+  headers.delete("authorization");
+  headers.delete("x-api-key");
+  // Force identity encoding so the metering tee can read plaintext usage from
+  // the response (a gzipped body would parse to no usage → no spend recorded).
+  headers.set("accept-encoding", "identity");
+  provider.applyAuth(headers);
+  if (bodyInit !== undefined) headers.set("content-length", String(Buffer.byteLength(bodyInit as string)));
+
+  const target = `${provider.base}${m[2] ?? ""}${url.search}`;
+  let upstream: Response;
+  try {
+    upstream = await fetch(target, {
+      method: req.method,
+      headers,
+      body: bodyInit,
+      // @ts-expect-error bun supports half-duplex streaming
+      duplex: "half",
+    });
+  } catch (err) {
+    console.error(`[gw] upstream error ${providerName}:`, err);
+    return json({ error: "upstream request failed" }, 502);
+  }
+
+  if (!upstream.body) {
+    return new Response(null, { status: upstream.status, headers: upstream.headers });
+  }
+
+  // Tee: one branch streams to the CLI, the other is drained to meter usage.
+  const [toClient, toMeter] = upstream.body.tee();
+  void meter(toMeter, providerName, session, deps).catch(() => {});
+
+  return new Response(toClient, {
+    status: upstream.status,
+    headers: upstream.headers,
+  });
+}
+
+async function meter(
+  stream: ReadableStream<Uint8Array>,
+  providerName: string,
+  session: TerminalSession,
+  deps: GatewayDeps,
+): Promise<void> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  // Cap accumulation so a runaway stream can't balloon memory.
+  const CAP = 8 * 1024 * 1024;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (text.length < CAP) text += decoder.decode(value, { stream: true });
+  }
+  const usage = parseUsage(text);
+  if (!usage) return;
+  const usd = priceUsd(usage.model || defaultModel(providerName), usage.inTok, usage.outTok);
+  if (usd <= 0) return;
+  deps.sessions.addGatewaySpend(session.id, usd);
+  await deps.daily.add(usd);
+}
+
+function defaultModel(provider: string): string {
+  if (provider === "anthropic") return "sonnet";
+  if (provider === "xai") return "grok";
+  return "gpt-4o";
+}

--- a/services/try-cli/server/index.ts
+++ b/services/try-cli/server/index.ts
@@ -20,8 +20,11 @@ const PROXY_SECRET = process.env.TRY_CLI_PROXY_SECRET;
 function sessionTier(req: Request): "anonymous" | "authenticated" {
   const user = req.headers.get("x-agentclash-user");
   if (!user) return "anonymous";
-  if (PROXY_SECRET && req.headers.get("x-agentclash-proxy-secret") !== PROXY_SECRET) {
-    return "anonymous"; // header present but unsigned — don't trust it
+  // Require the secret to be BOTH configured and matching. If it's unset, fall
+  // back to anonymous so a misconfigured deploy never auto-grants the authed
+  // tier to anyone who knows the header name.
+  if (!PROXY_SECRET || req.headers.get("x-agentclash-proxy-secret") !== PROXY_SECRET) {
+    return "anonymous";
   }
   return "authenticated";
 }

--- a/services/try-cli/server/index.ts
+++ b/services/try-cli/server/index.ts
@@ -4,11 +4,27 @@ import { badgeSvg } from "@try-cli/core";
 import { registry } from "./registry.ts";
 import { sessions } from "./sessions.ts";
 import { demoToMeta } from "./types.ts";
+import { handleGatewayRequest } from "./gateway.ts";
+import { createDailyLedger } from "./daily-ledger.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = Number(process.env.PORT ?? 3001);
 const isProd = process.env.NODE_ENV === "production";
 const DIST = join(__dirname, "../dist");
+
+const gatewayDeps = { sessions, daily: createDailyLedger() };
+// Shared secret the Vercel proxy adds when forwarding an authenticated user, so
+// the public service can't be tricked into granting the (BYO) authed tier.
+const PROXY_SECRET = process.env.TRY_CLI_PROXY_SECRET;
+
+function sessionTier(req: Request): "anonymous" | "authenticated" {
+  const user = req.headers.get("x-agentclash-user");
+  if (!user) return "anonymous";
+  if (PROXY_SECRET && req.headers.get("x-agentclash-proxy-secret") !== PROXY_SECRET) {
+    return "anonymous"; // header present but unsigned — don't trust it
+  }
+  return "authenticated";
+}
 
 const CORS_ORIGINS = (process.env.TRY_CLI_CORS_ORIGINS ?? "http://localhost:3000,https://www.agentclash.dev,https://agentclash.dev,https://try.agentclash.dev")
   .split(",")
@@ -75,6 +91,12 @@ const server = Bun.serve<{ sessionId: string }>({
       return new Response(null, { status: 204, headers: corsHeaders(req) });
     }
 
+    // Metered LLM gateway for the anonymous free trial. Called by the sandbox
+    // CLIs (not the browser), so no CORS handling needed.
+    if (pathname.startsWith("/gw/")) {
+      return handleGatewayRequest(req, url, gatewayDeps);
+    }
+
     if (pathname.startsWith("/ws")) {
       const sessionId = url.searchParams.get("sessionId");
       if (!sessionId) return new Response("Missing sessionId", { status: 400 });
@@ -107,13 +129,14 @@ const server = Bun.serve<{ sessionId: string }>({
         const demo = registry.get(slug);
         if (!demo) return json({ error: "Demo not found" }, 404, req);
         const ip = getClientIp(req);
-        const session = await sessions.create(slug, demo, ip);
+        const session = await sessions.create(slug, demo, ip, sessionTier(req));
         return json({
           id: session.id,
           slug: session.slug,
           expiresAt: session.expiresAt,
           status: session.status,
           mock: session.mock,
+          tier: session.tier,
         }, 200, req);
       } catch (err) {
         return json({ error: err instanceof Error ? err.message : String(err) }, 429, req);
@@ -133,6 +156,10 @@ const server = Bun.serve<{ sessionId: string }>({
           status: session.status,
           error: session.error,
           mock: session.mock,
+          tier: session.tier,
+          trial: session.trialWired,
+          budgetUsd: session.gatewayBudgetUsd,
+          spentUsd: Math.round(session.gatewaySpentUsd * 1000) / 1000,
         }, 200, req);
       }
 
@@ -149,6 +176,7 @@ const server = Bun.serve<{ sessionId: string }>({
           expiresAt: newSession.expiresAt,
           status: newSession.status,
           mock: newSession.mock,
+          tier: newSession.tier,
         }, 200, req);
       }
     }

--- a/services/try-cli/server/sessions.ts
+++ b/services/try-cli/server/sessions.ts
@@ -2,11 +2,24 @@ import { Sandbox } from "e2b";
 import type { Demo } from "@try-cli/core";
 import type { ServerWebSocket } from "bun";
 
+export type SessionTier = "anonymous" | "authenticated";
+
 export interface TerminalSession {
   id: string;
   slug: string;
   demo: Demo;
   ip: string;
+  tier: SessionTier;
+  /** High-entropy credential the sandbox CLIs send to the gateway (NOT the
+   *  session id, which travels in loggable URLs/WS params). */
+  proxyToken: string;
+  /** Free-trial spend cap (USD) and running total, enforced by the gateway. */
+  gatewayBudgetUsd: number;
+  gatewaySpentUsd: number;
+  /** Whether this session's CLI is wired to the metered gateway (anon trial). */
+  trialWired: boolean;
+  /** Extra env injected into the PTY (gateway base URLs + proxy token). */
+  ptyEnv: Record<string, string>;
   sandbox: Sandbox | null;
   ptyPid: number | null;
   ws: ServerWebSocket<unknown> | null;
@@ -16,8 +29,30 @@ export interface TerminalSession {
   mock: boolean;
 }
 
+// Per-tier session length (minutes). Anonymous trials are short and run on our
+// keys; signed-in users get longer and bring their own credentials.
+const ANON_MAX_MINUTES = Number(process.env.GW_ANON_MINUTES ?? 7);
+const AUTH_MAX_MINUTES = Number(process.env.GW_AUTH_MINUTES ?? 20);
+const ANON_BUDGET_USD = Number(process.env.GW_SESSION_BUDGET_USD ?? 0.3);
+
+// Demos whose free trial routes through the gateway, and the provider they use.
+// Demos not listed are bring-your-own-credentials only (no anon trial).
+const TRIAL_PROVIDER: Record<string, "anthropic" | "openai" | "xai" | undefined> = {
+  "claude-code": "anthropic",
+  codex: "openai",
+  grok: "xai",
+};
+
+const PROVIDER_ENV_KEY: Record<string, string> = {
+  anthropic: "ANTHROPIC_API_KEY",
+  openai: "OPENAI_API_KEY",
+  xai: "XAI_API_KEY",
+};
+
 export class SessionManager {
   private sessions = new Map<string, TerminalSession>();
+  // Reverse index: gateway proxy token -> session, for O(1) gateway auth.
+  private byProxyToken = new Map<string, TerminalSession>();
   // Live (not yet destroyed) session count per IP. Incremented on create,
   // decremented on destroy, so a user who finishes/resets a session frees the slot.
   private liveSessionsPerIp = new Map<string, number>();
@@ -40,25 +75,39 @@ export class SessionManager {
     return this.sessions.get(id);
   }
 
-  async create(slug: string, demo: Demo, ip: string): Promise<TerminalSession> {
+  async create(
+    slug: string,
+    demo: Demo,
+    ip: string,
+    tier: SessionTier = "anonymous",
+  ): Promise<TerminalSession> {
     if (!this.hasCapacity(ip)) {
       throw new Error("Rate limit exceeded. Try again later.");
     }
 
     const id = crypto.randomUUID();
+    const maxMinutes = tier === "authenticated" ? AUTH_MAX_MINUTES : ANON_MAX_MINUTES;
+    const minutes = Math.min(demo.sessionMinutes ?? 10, maxMinutes);
     const session: TerminalSession = {
       id,
       slug,
       demo,
       ip,
+      tier,
+      proxyToken: `tct_${crypto.randomUUID().replace(/-/g, "")}${crypto.randomUUID().replace(/-/g, "")}`,
+      gatewayBudgetUsd: ANON_BUDGET_USD,
+      gatewaySpentUsd: 0,
+      trialWired: false,
+      ptyEnv: {},
       sandbox: null,
       ptyPid: null,
       ws: null,
-      expiresAt: Date.now() + (demo.sessionMinutes ?? 10) * 60 * 1000,
+      expiresAt: Date.now() + minutes * 60 * 1000,
       status: "starting",
       mock: !this.useE2B,
     };
     this.sessions.set(id, session);
+    this.byProxyToken.set(session.proxyToken, session);
     this.liveSessionsPerIp.set(ip, (this.liveSessionsPerIp.get(ip) ?? 0) + 1);
 
     if (this.useE2B) {
@@ -92,11 +141,75 @@ export class SessionManager {
       }
     }
 
+    await this.wireGatewayTrial(session);
     session.status = "ready";
 
     if (session.ws) {
       await this.attachPty(session, session.ws as ServerWebSocket<{ sessionId: string }>);
     }
+  }
+
+  /**
+   * For an anonymous trial of a supported AI CLI, point the CLI at the metered
+   * gateway with the session's proxy token. The real provider key never enters
+   * the sandbox. No-op for authenticated (BYO) sessions, non-AI demos, providers
+   * whose key isn't configured on the service, or when no gateway URL is set.
+   */
+  private async wireGatewayTrial(session: TerminalSession) {
+    if (session.tier !== "anonymous") return;
+    const provider = TRIAL_PROVIDER[session.slug];
+    if (!provider) return;
+    if (!process.env[PROVIDER_ENV_KEY[provider]]) return;
+    const gw = process.env.TRY_CLI_GATEWAY_URL;
+    if (!gw || !session.sandbox) return;
+    const base = gw.replace(/\/$/, "");
+    const token = session.proxyToken;
+    const env: Record<string, string> = {};
+
+    if (provider === "anthropic") {
+      // ANTHROPIC_AUTH_TOKEN (Bearer) is the gateway path and skips the
+      // first-use API-key approval prompt that ANTHROPIC_API_KEY triggers.
+      env.ANTHROPIC_BASE_URL = `${base}/gw/anthropic`;
+      env.ANTHROPIC_AUTH_TOKEN = token;
+    } else if (provider === "openai") {
+      env.OPENAI_API_KEY = token;
+      const model = process.env.GW_CODEX_MODEL ?? "gpt-5-codex";
+      const cfg =
+        `model = "${model}"\n` +
+        `model_provider = "trycli"\n` +
+        `[model_providers.trycli]\n` +
+        `name = "trycli"\n` +
+        `base_url = "${base}/gw/openai/v1"\n` +
+        `env_key = "OPENAI_API_KEY"\n` +
+        `wire_api = "responses"\n`;
+      try {
+        await session.sandbox.files.write("/home/user/.codex/config.toml", cfg);
+      } catch (err) {
+        console.error(`[session ${session.id}] codex config write failed:`, err);
+      }
+    } else if (provider === "xai") {
+      env.GROK_BASE_URL = `${base}/gw/xai/v1`;
+      env.XAI_API_KEY = token;
+      env.GROK_API_KEY = token;
+    }
+
+    session.ptyEnv = env;
+    session.trialWired = true;
+  }
+
+  /** Resolve + authorize a gateway proxy token. Returns the live anon session
+   *  that is still within its time window, or undefined. */
+  validateGatewayToken(token: string): TerminalSession | undefined {
+    if (!token) return undefined;
+    const s = this.byProxyToken.get(token);
+    if (!s || s.tier !== "anonymous" || !s.trialWired) return undefined;
+    if (s.status === "expired" || Date.now() > s.expiresAt) return undefined;
+    return s;
+  }
+
+  addGatewaySpend(id: string, usd: number) {
+    const s = this.sessions.get(id);
+    if (s) s.gatewaySpentUsd += usd;
   }
 
   async attachPty(session: TerminalSession, ws: ServerWebSocket<{ sessionId: string }>) {
@@ -123,6 +236,7 @@ export class SessionManager {
       envs: {
         TERM: "xterm-256color",
         PS1: "\\[\\033[01;32m\\]\\u@try-cli\\[\\033[00m\\]:\\[\\033[01;34m\\]\\w\\[\\033[00m\\]$ ",
+        ...session.ptyEnv,
       },
     });
 
@@ -131,9 +245,18 @@ export class SessionManager {
     // Render the welcome text directly to the terminal output instead of running
     // it through the shell — passing `demo.welcome` into a shell command would let
     // a `$(...)`/backtick payload in a demo config execute inside the sandbox.
+    const enc = new TextEncoder();
+    if (session.trialWired && ws.readyState === WebSocket.OPEN) {
+      ws.send(
+        enc.encode(
+          `\x1b[32m✓ Free trial active\x1b[0m — running on AgentClash credentials, no key needed. ` +
+            `Just run the command. Sign in to continue with your own account.\r\n\r\n`,
+        ),
+      );
+    }
     if (demo.welcome && ws.readyState === WebSocket.OPEN) {
       const text = demo.welcome.replace(/\r?\n/g, "\r\n");
-      ws.send(new TextEncoder().encode(`${text}\r\n`));
+      ws.send(enc.encode(`${text}\r\n`));
     }
   }
 
@@ -195,7 +318,7 @@ export class SessionManager {
     await this.destroy(session.id);
     // Reuse the original client IP so a reset (destroy + create) nets to the same
     // live-session count for that IP rather than charging a shared bucket.
-    return this.create(session.slug, session.demo, session.ip);
+    return this.create(session.slug, session.demo, session.ip, session.tier);
   }
 
   async destroy(id: string) {
@@ -204,6 +327,7 @@ export class SessionManager {
 
     // Remove from the maps first so concurrent/double destroys can't double-count.
     this.sessions.delete(id);
+    this.byProxyToken.delete(session.proxyToken);
     const live = (this.liveSessionsPerIp.get(session.ip) ?? 0) - 1;
     if (live > 0) {
       this.liveSessionsPerIp.set(session.ip, live);

--- a/services/try-cli/server/sessions.ts
+++ b/services/try-cli/server/sessions.ts
@@ -16,6 +16,9 @@ export interface TerminalSession {
   /** Free-trial spend cap (USD) and running total, enforced by the gateway. */
   gatewayBudgetUsd: number;
   gatewaySpentUsd: number;
+  /** Estimated spend for in-flight gateway requests, so concurrent requests
+   *  can't all pass the budget check before any of them finishes metering. */
+  gatewayReservedUsd: number;
   /** Whether this session's CLI is wired to the metered gateway (anon trial). */
   trialWired: boolean;
   /** Extra env injected into the PTY (gateway base URLs + proxy token). */
@@ -97,6 +100,7 @@ export class SessionManager {
       proxyToken: `tct_${crypto.randomUUID().replace(/-/g, "")}${crypto.randomUUID().replace(/-/g, "")}`,
       gatewayBudgetUsd: ANON_BUDGET_USD,
       gatewaySpentUsd: 0,
+      gatewayReservedUsd: 0,
       trialWired: false,
       ptyEnv: {},
       sandbox: null,

--- a/web/content/docs/concepts/try-cli.mdx
+++ b/web/content/docs/concepts/try-cli.mdx
@@ -32,9 +32,11 @@ E2B_API_KEY=... bun run scripts/build-template.ts
 
 The build runs in E2B's cloud (Build System 2.0 — no local Docker). The demo's `template:` field references the alias.
 
-## Bring-your-own credentials (AI agents)
+## Auth: free trial, then bring-your-own
 
-AI agent demos need a provider account. We **never inject our keys** into the sandbox (that would violate provider terms and expose the key to anyone in the shell). Instead each demo's `auth:` block shows the visitor how to sign in with their **own** credentials inside the disposable sandbox:
+**Anonymous free trial.** Visitors can try the AI agents for a few minutes with **no login and no key**. The CLI is wired to a metered server-side gateway that holds AgentClash's provider keys, mints a short-lived spend-capped token per session, and never lets the real key into the sandbox. A durable Redis-backed daily ceiling is the hard backstop.
+
+**Then sign in.** When the trial ends, signing in with AgentClash gives a longer session where you authenticate the CLI with your **own** account/key (running on your quota, not ours). We **never inject our keys** into the sandbox — that would violate provider terms and expose the key to anyone in the shell. Each demo's `auth:` block shows how to sign in with your own credentials:
 
 - **Claude Code** — `claude` → `/login` (paste-code) or `ANTHROPIC_API_KEY`
 - **Codex** — `codex login --device-auth` or an `OPENAI_API_KEY`

--- a/web/src/app/api/try/[[...path]]/route.ts
+++ b/web/src/app/api/try/[[...path]]/route.ts
@@ -1,9 +1,13 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
 import { NextRequest, NextResponse } from "next/server";
 
 // Server-side backend URL for the Try CLI service. Do NOT fall back to
 // NEXT_PUBLIC_TRY_CLI_API_URL — that is the public proxy path (`/api/try`), so
 // using it here would make this route proxy back to itself in a request loop.
 const TRY_CLI_SERVICE = process.env.TRY_CLI_API_URL ?? "http://localhost:3001";
+// Shared secret so the service can trust the forwarded user identity. Only sent
+// when configured — never forward an unsigned identity header.
+const PROXY_SECRET = process.env.TRY_CLI_PROXY_SECRET;
 
 async function proxy(req: NextRequest, pathSegments: string[]): Promise<NextResponse> {
   const path = pathSegments.join("/");
@@ -15,6 +19,21 @@ async function proxy(req: NextRequest, pathSegments: string[]): Promise<NextResp
   if (contentType) headers.set("content-type", contentType);
   const forwarded = req.headers.get("x-forwarded-for");
   if (forwarded) headers.set("x-forwarded-for", forwarded);
+
+  // Tell the service when the request is from a signed-in AgentClash user so it
+  // grants the longer (bring-your-own-credentials) tier. Gated on the shared
+  // secret so the public service can't be spoofed into the authed tier.
+  if (PROXY_SECRET) {
+    try {
+      const { user } = await withAuth();
+      if (user) {
+        headers.set("x-agentclash-user", user.id);
+        headers.set("x-agentclash-proxy-secret", PROXY_SECRET);
+      }
+    } catch {
+      /* not signed in — anonymous tier */
+    }
+  }
 
   const init: RequestInit = {
     method: req.method,

--- a/web/src/components/try-cli/demo-client.tsx
+++ b/web/src/components/try-cli/demo-client.tsx
@@ -29,6 +29,8 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
   const [remaining, setRemaining] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState<string | null>(null);
+  const [tier, setTier] = useState<"anonymous" | "authenticated">("anonymous");
+  const [trial, setTrial] = useState(false);
 
   // Track the in-flight poll timer so it can be cancelled on unmount / re-poll.
   const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -53,6 +55,8 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
           const res = await fetch(`${apiBase}/sessions/${id}`);
           const data = (await res.json()) as TrySession & { error?: string };
           setStatus(data.status);
+          if (data.tier) setTier(data.tier);
+          if (typeof data.trial === "boolean") setTrial(data.trial);
           if (data.status === "error") {
             setError(data.error ?? "Sandbox failed");
             return;
@@ -97,6 +101,7 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
     }
     setSessionId(data.id);
     setExpiresAt(data.expiresAt);
+    if (data.tier) setTier(data.tier);
     pollSession(data.id);
   }, [slug, apiBase, pollSession]);
 
@@ -214,6 +219,16 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
           </div>
         </div>
         <div className="flex items-center gap-3">
+          {trial && (
+            <span className="hidden items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-[11px] font-medium text-emerald-300 sm:inline-flex">
+              Free trial
+            </span>
+          )}
+          {tier === "authenticated" && (
+            <span className="hidden items-center gap-1.5 rounded-full border border-white/15 bg-white/[0.04] px-2.5 py-1 text-[11px] text-white/60 sm:inline-flex">
+              Your account
+            </span>
+          )}
           <span className="inline-flex items-center gap-1.5 font-[family-name:var(--font-mono)] text-xs text-white/45">
             <TimerReset className="size-3.5" />
             {remaining || "—"}
@@ -237,13 +252,34 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
 
       <div className="flex min-h-0 flex-1 flex-col md:flex-row">
         <aside className="w-full shrink-0 space-y-7 overflow-y-auto border-b border-white/[0.06] p-5 md:w-80 md:border-b-0 md:border-r">
+          {/* Free-trial card (anonymous, gateway-backed) */}
+          {trial && (
+            <div className="rounded-lg border border-emerald-500/25 bg-emerald-500/[0.06] p-4">
+              <h2 className="text-xs font-medium uppercase tracking-wide text-emerald-300">
+                Free trial · no key needed
+              </h2>
+              <p className="mt-2 text-xs leading-relaxed text-white/60">
+                Running on AgentClash credentials for a few minutes — just run the commands
+                below, no sign-in or API key. When it ends, sign in to keep going with your
+                own account.
+              </p>
+              <a
+                href={`/auth/login?returnPathname=/try/${slug}`}
+                className="mt-3 inline-flex items-center gap-1.5 rounded-md bg-white px-3 py-1.5 text-xs font-medium text-[#060606] transition-colors hover:bg-white/90"
+              >
+                Sign in to continue
+              </a>
+            </div>
+          )}
+
           {/* BYO auth panel */}
           {demo?.auth && (
             <div className="rounded-lg border border-white/[0.1] bg-white/[0.02] p-4">
               <div className="flex items-center gap-2">
                 <KeyRound className="size-3.5 text-white/70" />
                 <h2 className="text-xs font-medium uppercase tracking-wide text-white/70">
-                  Sign in {demo.auth.provider ? `· ${demo.auth.provider}` : ""}
+                  {trial ? "Use your own account" : "Sign in"}
+                  {demo.auth.provider ? ` · ${demo.auth.provider}` : ""}
                 </h2>
               </div>
               <p className="mt-2 text-xs leading-relaxed text-white/50">{demo.auth.summary}</p>

--- a/web/src/lib/try-cli/types.ts
+++ b/web/src/lib/try-cli/types.ts
@@ -26,4 +26,8 @@ export interface TrySession {
   status: string;
   mock?: boolean;
   error?: string;
+  tier?: "anonymous" | "authenticated";
+  trial?: boolean;
+  budgetUsd?: number;
+  spentUsd?: number;
 }


### PR DESCRIPTION
## Summary

Adds the **free trial + signed-in** auth model for the Try CLI AI agents, the safe way. Follow-up to #881.

- **Anonymous visitor:** try Claude Code / Codex / Grok for ~7 min with **no login, no API key**.
- **Sign in with AgentClash:** longer (~20 min) session where they bring their **own** provider credentials (runs on their quota, not ours).

## Why a gateway (and not key injection)
We **never** put our provider keys in the sandbox — that violates OpenAI/Anthropic terms and anyone in the shell can `cat` the key and drain the account. Instead a **metered passthrough gateway** lives in the try-cli service:

- Real `ANTHROPIC_/OPENAI_/XAI_API_KEY` live only on the service.
- Each anonymous session is minted a **short-lived, spend-capped proxy token** (separate from the loggable session id). The sandbox CLIs send it as their key and point their base URL at `/gw/<provider>`; the gateway validates it against a live, in-budget session, swaps in the real key, **streams the response straight back**, and meters real token usage.
- **Caps:** per-session USD budget **+ a durable Redis-backed global daily ceiling** (the real backstop for a public no-login endpoint — fails *closed* if Redis is down) + per-request output-token clamp + request body-size cap.
- Signed-in tier uses BYO creds (no gateway, no cost). The Vercel proxy forwards the user id behind a **shared secret** so the public service can't be spoofed into the authed tier.

## Verified end-to-end (real E2B sandbox)
- Claude Code & Codex actually route through a passthrough gateway when pointed at a custom base URL (Codex via `model_providers` config — the risky case, confirmed working).
- Valid token → 200; **invalid/expired token → 401**; spend accumulates and the **per-session cap returns 402** once crossed; the durable daily ledger accumulates across sessions.
- PTY env injection confirmed; metering parses real `usage` (forces identity encoding so it isn't reading gzip).
- Web `tsc` + `eslint` (0 errors) + `next build` pass.

## Tiers / wiring
| | Anonymous (free trial) | Signed-in |
|---|---|---|
| Length | ~7 min | ~20 min |
| Creds | our keys via gateway, capped | their own (BYO) |
| Claude Code | `ANTHROPIC_AUTH_TOKEN` + base URL | `/login` |
| Codex | `config.toml` custom provider | `--device-auth` |
| Grok | `GROK_BASE_URL` + token | own `XAI_API_KEY` |
| OpenCode | BYO-only (v1) | paste key |

## Deploy (post-merge) — env to set
On the **Railway try-cli service**: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `XAI_API_KEY`, `TRY_CLI_GATEWAY_URL` (its own public URL), `REDIS_URL` (project Redis), `TRY_CLI_PROXY_SECRET`, optional caps (`GW_DAILY_CEILING_USD`, `GW_SESSION_BUDGET_USD`, …). On **Vercel**: matching `TRY_CLI_PROXY_SECRET`. Full list in `docs/deployment/try-cli.md`.

Grok's free trial only activates once `XAI_API_KEY` is set on the service.
