### PR TITLE
feat(try-cli): Kimi + Qwen demos via their own CLIs; opencode on Zen

### DIFF
--- a/docs/deployment/try-cli.md
+++ b/docs/deployment/try-cli.md
@@ -42,6 +42,8 @@ Set on the **Railway Try CLI service**:
 ANTHROPIC_API_KEY=sk-ant-...
 OPENAI_API_KEY=sk-...
 XAI_API_KEY=xai-...            # enables the Grok free trial
+OPENROUTER_API_KEY=sk-or-v1-... # enables Kimi K2 (kimi-cli) + Qwen3-Coder (qwen-code)
+OPENCODE_ZEN_API_KEY=sk-...      # enables the opencode demo on opencode Zen models
 # Where the sandbox CLIs reach the gateway (this service's own public URL)
 TRY_CLI_GATEWAY_URL=https://try-cli-production.up.railway.app
 # Durable daily spend ceiling (THE backstop) — reference the project's Redis

--- a/services/try-cli/scripts/build-template.ts
+++ b/services/try-cli/scripts/build-template.ts
@@ -30,6 +30,7 @@ const template = Template()
       "@openai/codex",
       "opencode-ai",
       "grok-dev",
+      "@qwen-code/qwen-code",
     ],
     { g: true },
   )
@@ -37,6 +38,8 @@ const template = Template()
   // user, so these install into ~/.local/bin (/home/user/.local/bin).
   .runCmd("curl -LsSf https://astral.sh/uv/install.sh | sh")
   .runCmd("curl -LsSf https://astral.sh/ruff/install.sh | sh")
+  // Kimi CLI (Moonshot) — Python; install via uv into ~/.local/bin.
+  .runCmd("/home/user/.local/bin/uv tool install kimi-cli")
   .setEnvs({
     PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/user/.local/bin",
   });

--- a/services/try-cli/server/gateway.ts
+++ b/services/try-cli/server/gateway.ts
@@ -31,7 +31,17 @@ function providers(): Record<string, ProviderConfig | undefined> {
   const anthropicKey = process.env.ANTHROPIC_API_KEY;
   const openaiKey = process.env.OPENAI_API_KEY;
   const xaiKey = process.env.XAI_API_KEY;
+  const openrouterKey = process.env.OPENROUTER_API_KEY;
   return {
+    openrouter: openrouterKey
+      ? {
+          base: "https://openrouter.ai",
+          applyAuth: (h) => h.set("authorization", `Bearer ${openrouterKey}`),
+          clampBody: (b, max) => {
+            if (typeof b.max_tokens === "number" && b.max_tokens > max) b.max_tokens = max;
+          },
+        }
+      : undefined,
     anthropic: anthropicKey
       ? {
           base: "https://api.anthropic.com",
@@ -155,7 +165,7 @@ export async function handleGatewayRequest(
   url: URL,
   deps: GatewayDeps,
 ): Promise<Response> {
-  const m = url.pathname.match(/^\/gw\/(anthropic|openai|xai)(\/.*)?$/);
+  const m = url.pathname.match(/^\/gw\/(anthropic|openai|xai|openrouter)(\/.*)?$/);
   if (!m) return json({ error: "unknown gateway route" }, 404);
   const providerName = m[1]!;
   const provider = providers()[providerName];

--- a/services/try-cli/server/index.ts
+++ b/services/try-cli/server/index.ts
@@ -6,6 +6,7 @@ import { sessions } from "./sessions.ts";
 import { demoToMeta } from "./types.ts";
 import { handleGatewayRequest } from "./gateway.ts";
 import { createDailyLedger } from "./daily-ledger.ts";
+import { createTrialGate } from "./trial-gate.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = Number(process.env.PORT ?? 3001);
@@ -13,6 +14,7 @@ const isProd = process.env.NODE_ENV === "production";
 const DIST = join(__dirname, "../dist");
 
 const gatewayDeps = { sessions, daily: createDailyLedger() };
+const trialGate = createTrialGate();
 // Shared secret the Vercel proxy adds when forwarding an authenticated user, so
 // the public service can't be tricked into granting the (BYO) authed tier.
 const PROXY_SECRET = process.env.TRY_CLI_PROXY_SECRET;
@@ -132,7 +134,21 @@ const server = Bun.serve<{ sessionId: string }>({
         const demo = registry.get(slug);
         if (!demo) return json({ error: "Demo not found" }, 404, req);
         const ip = getClientIp(req);
-        const session = await sessions.create(slug, demo, ip, sessionTier(req));
+        const tier = sessionTier(req);
+        // One free trial per anonymous IP — a reload after that prompts sign-in.
+        if (tier === "anonymous" && (await trialGate.isUsed(ip))) {
+          return json(
+            {
+              error: "free_trial_used",
+              trialUsed: true,
+              message: "You've used your free trial. Sign in to keep going.",
+            },
+            403,
+            req,
+          );
+        }
+        const session = await sessions.create(slug, demo, ip, tier);
+        if (tier === "anonymous") await trialGate.markUsed(ip);
         return json({
           id: session.id,
           slug: session.slug,

--- a/services/try-cli/server/sessions.ts
+++ b/services/try-cli/server/sessions.ts
@@ -38,6 +38,9 @@ const ANON_MAX_MINUTES = Number(process.env.GW_ANON_MINUTES ?? 7);
 const AUTH_MAX_MINUTES = Number(process.env.GW_AUTH_MINUTES ?? 20);
 const ANON_BUDGET_USD = Number(process.env.GW_SESSION_BUDGET_USD ?? 0.3);
 const SANDBOX_WORKDIR = "/home/user/project";
+// Global cap on concurrent live sandboxes, to stay under E2B's per-team
+// concurrency/rate limits (cost isn't the concern — rate limiting is).
+const MAX_CONCURRENT_SANDBOXES = Number(process.env.TRY_CLI_MAX_CONCURRENT_SANDBOXES ?? 40);
 
 // Demos whose free trial routes through the gateway, and the provider they use.
 // Demos not listed are bring-your-own-credentials only (no anon trial).
@@ -74,6 +77,8 @@ export class SessionManager {
   // decremented on destroy, so a user who finishes/resets a session frees the slot.
   private liveSessionsPerIp = new Map<string, number>();
   private readonly maxSessionsPerIp = 3;
+  // Count of live sandboxes we've reserved capacity for (E2B sessions).
+  private activeSandboxes = 0;
   private readonly useE2B: boolean;
 
   constructor() {
@@ -100,6 +105,9 @@ export class SessionManager {
   ): Promise<TerminalSession> {
     if (!this.hasCapacity(ip)) {
       throw new Error("Rate limit exceeded. Try again later.");
+    }
+    if (this.useE2B && this.activeSandboxes >= MAX_CONCURRENT_SANDBOXES) {
+      throw new Error("Try CLI is at capacity right now — please try again in a moment.");
     }
 
     const id = crypto.randomUUID();
@@ -129,6 +137,7 @@ export class SessionManager {
     this.liveSessionsPerIp.set(ip, (this.liveSessionsPerIp.get(ip) ?? 0) + 1);
 
     if (this.useE2B) {
+      this.activeSandboxes++; // reserve a concurrency slot (released in destroy)
       this.bootstrapE2B(session).catch((err) => {
         session.status = "error";
         session.error = err instanceof Error ? err.message : String(err);
@@ -141,15 +150,31 @@ export class SessionManager {
     return session;
   }
 
+  // e2b v2 takes the template alias as a positional arg — passing it inside the
+  // options object is silently ignored. Retries on transient E2B rate limits.
+  private async createSandboxWithRetry(template: string | undefined, timeoutMs: number) {
+    let lastErr: unknown;
+    for (let attempt = 0; attempt < 4; attempt++) {
+      try {
+        return template
+          ? await Sandbox.create(template, { timeoutMs })
+          : await Sandbox.create({ timeoutMs });
+      } catch (err) {
+        lastErr = err;
+        const msg = err instanceof Error ? err.message : String(err);
+        const rateLimited = /rate.?limit|429|too many requests/i.test(msg);
+        if (!rateLimited || attempt === 3) throw err;
+        await new Promise((r) => setTimeout(r, 500 * 2 ** attempt));
+      }
+    }
+    throw lastErr;
+  }
+
   private async bootstrapE2B(session: TerminalSession) {
     const { demo } = session;
     const timeoutMs = (demo.sessionMinutes ?? 10) * 60 * 1000;
 
-    // e2b v2 takes the template alias as a positional arg — passing it inside
-    // the options object is silently ignored and falls back to the base image.
-    const sandbox = demo.template
-      ? await Sandbox.create(demo.template, { timeoutMs })
-      : await Sandbox.create({ timeoutMs });
+    const sandbox = await this.createSandboxWithRetry(demo.template, timeoutMs);
     session.sandbox = sandbox;
 
     for (const cmd of demo.install ?? []) {
@@ -243,7 +268,11 @@ export class SessionManager {
         env.OPENAI_API_KEY = token;
         // Kimi CLI schema: provider block + a top-level [models.<id>] entry that
         // default_model references by id (not the raw model name).
+        // Top-level keys MUST precede any [section] in TOML, or they get parsed
+        // into the preceding table — so default_provider/default_model come first.
         const cfg =
+          `default_provider = "trycli"\n` +
+          `default_model = "trycli-default"\n\n` +
           `[providers.trycli]\n` +
           `type = "openai_legacy"\n` +
           `base_url = "${orBase}"\n` +
@@ -251,9 +280,7 @@ export class SessionManager {
           `[models.trycli-default]\n` +
           `provider = "trycli"\n` +
           `model = "${model}"\n` +
-          `max_context_size = 131072\n\n` +
-          `default_provider = "trycli"\n` +
-          `default_model = "trycli-default"\n`;
+          `max_context_size = 131072\n`;
         try {
           await session.sandbox.commands.run("mkdir -p /home/user/.kimi");
           await session.sandbox.files.write("/home/user/.kimi/config.toml", cfg);
@@ -386,10 +413,16 @@ export class SessionManager {
   }
 
   async reset(session: TerminalSession): Promise<TerminalSession> {
+    const originalExpiry = session.expiresAt;
+    const tier = session.tier;
     await this.destroy(session.id);
     // Reuse the original client IP so a reset (destroy + create) nets to the same
     // live-session count for that IP rather than charging a shared bucket.
-    return this.create(session.slug, session.demo, session.ip, session.tier);
+    const next = await this.create(session.slug, session.demo, session.ip, tier);
+    // A reset must not extend an anonymous trial past its original deadline —
+    // carry over the original expiry so the free window stays hard-capped.
+    if (tier === "anonymous") next.expiresAt = originalExpiry;
+    return next;
   }
 
   async destroy(id: string) {
@@ -399,6 +432,7 @@ export class SessionManager {
     // Remove from the maps first so concurrent/double destroys can't double-count.
     this.sessions.delete(id);
     this.byProxyToken.delete(session.proxyToken);
+    if (!session.mock) this.activeSandboxes = Math.max(0, this.activeSandboxes - 1);
     const live = (this.liveSessionsPerIp.get(session.ip) ?? 0) - 1;
     if (live > 0) {
       this.liveSessionsPerIp.set(session.ip, live);

--- a/services/try-cli/server/sessions.ts
+++ b/services/try-cli/server/sessions.ts
@@ -37,19 +37,33 @@ export interface TerminalSession {
 const ANON_MAX_MINUTES = Number(process.env.GW_ANON_MINUTES ?? 7);
 const AUTH_MAX_MINUTES = Number(process.env.GW_AUTH_MINUTES ?? 20);
 const ANON_BUDGET_USD = Number(process.env.GW_SESSION_BUDGET_USD ?? 0.3);
+const SANDBOX_WORKDIR = "/home/user/project";
 
 // Demos whose free trial routes through the gateway, and the provider they use.
 // Demos not listed are bring-your-own-credentials only (no anon trial).
-const TRIAL_PROVIDER: Record<string, "anthropic" | "openai" | "xai" | undefined> = {
+const TRIAL_PROVIDER: Record<
+  string,
+  "anthropic" | "openai" | "xai" | "openrouter" | undefined
+> = {
   "claude-code": "anthropic",
   codex: "openai",
   grok: "xai",
+  // Each runs its OWN dedicated CLI pointed at OpenRouter through the gateway.
+  "kimi-k2": "openrouter", // kimi-cli
+  "qwen3-coder": "openrouter", // @qwen-code/qwen-code
 };
 
 const PROVIDER_ENV_KEY: Record<string, string> = {
   anthropic: "ANTHROPIC_API_KEY",
   openai: "OPENAI_API_KEY",
   xai: "XAI_API_KEY",
+  openrouter: "OPENROUTER_API_KEY",
+};
+
+// OpenRouter model id per demo slug.
+const OPENROUTER_MODEL: Record<string, string> = {
+  "kimi-k2": "moonshotai/kimi-k2",
+  "qwen3-coder": "qwen/qwen3-coder",
 };
 
 export class SessionManager {
@@ -145,6 +159,14 @@ export class SessionManager {
       }
     }
 
+    // Start the user in a project dir, not $HOME — some agent CLIs (e.g. Qwen
+    // Code) refuse to run in the home directory.
+    try {
+      await session.sandbox.commands.run(`mkdir -p ${SANDBOX_WORKDIR}`);
+    } catch {
+      /* non-fatal */
+    }
+
     await this.wireGatewayTrial(session);
     session.status = "ready";
 
@@ -161,6 +183,17 @@ export class SessionManager {
    */
   private async wireGatewayTrial(session: TerminalSession) {
     if (session.tier !== "anonymous") return;
+
+    // opencode runs on opencode's own hosted "Zen" models with the operator's
+    // Zen key injected directly (its own account, not routed through our gateway).
+    if (session.slug === "opencode") {
+      const zen = process.env.OPENCODE_ZEN_API_KEY;
+      if (!zen) return;
+      session.ptyEnv = { OPENCODE_API_KEY: zen };
+      session.trialWired = true;
+      return;
+    }
+
     const provider = TRIAL_PROVIDER[session.slug];
     if (!provider) return;
     if (!process.env[PROVIDER_ENV_KEY[provider]]) return;
@@ -195,6 +228,39 @@ export class SessionManager {
       env.GROK_BASE_URL = `${base}/gw/xai/v1`;
       env.XAI_API_KEY = token;
       env.GROK_API_KEY = token;
+    } else if (provider === "openrouter") {
+      const model = OPENROUTER_MODEL[session.slug];
+      if (!model) return;
+      const orBase = `${base}/gw/openrouter/api/v1`;
+
+      if (session.slug === "qwen3-coder") {
+        // Qwen Code reads OPENAI_* env vars first-class.
+        env.OPENAI_API_KEY = token;
+        env.OPENAI_BASE_URL = orBase;
+        env.OPENAI_MODEL = model;
+      } else if (session.slug === "kimi-k2") {
+        // Kimi CLI: an `openai_legacy` provider whose key comes from OPENAI_API_KEY.
+        env.OPENAI_API_KEY = token;
+        // Kimi CLI schema: provider block + a top-level [models.<id>] entry that
+        // default_model references by id (not the raw model name).
+        const cfg =
+          `[providers.trycli]\n` +
+          `type = "openai_legacy"\n` +
+          `base_url = "${orBase}"\n` +
+          `api_key = "${token}"\n\n` +
+          `[models.trycli-default]\n` +
+          `provider = "trycli"\n` +
+          `model = "${model}"\n` +
+          `max_context_size = 131072\n\n` +
+          `default_provider = "trycli"\n` +
+          `default_model = "trycli-default"\n`;
+        try {
+          await session.sandbox.commands.run("mkdir -p /home/user/.kimi");
+          await session.sandbox.files.write("/home/user/.kimi/config.toml", cfg);
+        } catch (err) {
+          console.error(`[session ${session.id}] kimi config write failed:`, err);
+        }
+      }
     }
 
     session.ptyEnv = env;
@@ -231,6 +297,7 @@ export class SessionManager {
     const handle = await sandbox.pty.create({
       cols: 80,
       rows: 24,
+      cwd: SANDBOX_WORKDIR,
       timeoutMs: 0,
       onData: (data) => {
         if (ws.readyState === WebSocket.OPEN) {

--- a/services/try-cli/server/trial-gate.ts
+++ b/services/try-cli/server/trial-gate.ts
@@ -1,0 +1,59 @@
+/**
+ * One-shot free-trial gate for anonymous users. Once an IP has started a free
+ * trial, it can't start another until the window resets — a reload just tells
+ * them to sign in. Redis-backed so it survives restarts; in-memory fallback for
+ * local dev. (IP-based: imperfect behind shared NATs, but a low-friction
+ * anti-abuse gate, not a hard wall — signing in is always the escape hatch.)
+ */
+const RESET_HOURS = Number(process.env.GW_TRIAL_RESET_HOURS ?? 24);
+const TTL_SECONDS = Math.max(1, Math.floor(RESET_HOURS * 3600));
+
+export interface TrialGate {
+  isUsed(ip: string): Promise<boolean>;
+  markUsed(ip: string): Promise<void>;
+}
+
+function key(ip: string): string {
+  return `trycli:trial:used:${ip}`;
+}
+
+export function createTrialGate(): TrialGate {
+  const url = process.env.REDIS_URL || process.env.VALKEY_URL;
+
+  if (url) {
+    const { RedisClient } = require("bun") as typeof import("bun");
+    const client = new RedisClient(url);
+    return {
+      async isUsed(ip) {
+        try {
+          return Boolean(await client.get(key(ip)));
+        } catch (err) {
+          // Fail OPEN: a Redis blip shouldn't lock everyone out of the trial.
+          console.error("[trial-gate] redis read error — allowing:", err);
+          return false;
+        }
+      },
+      async markUsed(ip) {
+        try {
+          await client.set(key(ip), "1", "EX", TTL_SECONDS);
+        } catch (err) {
+          console.error("[trial-gate] redis write error:", err);
+        }
+      },
+    };
+  }
+
+  console.warn("[try-cli] REDIS_URL not set — trial gate is in-memory (dev only)");
+  const used = new Map<string, number>();
+  return {
+    async isUsed(ip) {
+      const exp = used.get(ip);
+      if (exp && exp > Date.now()) return true;
+      if (exp) used.delete(ip);
+      return false;
+    },
+    async markUsed(ip) {
+      used.set(ip, Date.now() + TTL_SECONDS * 1000);
+    },
+  };
+}

--- a/try-cli/demos/kimi-k2.trycli.yml
+++ b/try-cli/demos/kimi-k2.trycli.yml
@@ -1,0 +1,29 @@
+name: "Kimi K2"
+slug: kimi-k2
+tagline: "Moonshot's agentic coding model"
+category: "AI coding agents"
+template: agentclash-trycli
+docs: "https://moonshotai.github.io/kimi-cli/"
+github: "https://github.com/MoonshotAI/kimi-cli"
+
+auth:
+  provider: "OpenRouter / Moonshot"
+  summary: "Free trial runs Kimi K2 via the Kimi CLI on AgentClash credentials — no key needed. To use your own, point Kimi CLI at Moonshot or OpenRouter with your key."
+  steps:
+    - "Free trial: just run `kimi` (preconfigured for Kimi K2)"
+    - "Your own key: edit ~/.kimi/config.toml with your provider + key"
+  signupUrl: "https://platform.moonshot.ai/"
+
+welcome: |
+  Kimi K2 is ready via the Kimi CLI. On the free trial, just run:
+    kimi
+
+commands:
+  - label: "Start Kimi CLI"
+    run: "kimi"
+  - label: "Version"
+    run: "kimi --version"
+  - label: "Make a file to work on"
+    run: "echo 'def add(a, b): return a + b' > math.py && cat math.py"
+
+sessionMinutes: 10

--- a/try-cli/demos/opencode.trycli.yml
+++ b/try-cli/demos/opencode.trycli.yml
@@ -7,24 +7,23 @@ docs: "https://opencode.ai/docs/"
 github: "https://github.com/sst/opencode"
 
 auth:
-  provider: "any model provider"
-  summary: "Add an API key for the provider you want (Anthropic, OpenAI, xAI, and 75+ more). Subscription OAuth isn't supported — use a key."
+  provider: "opencode Zen"
+  summary: "Free trial runs opencode on its hosted Zen models, on AgentClash credentials — no key needed. To use your own provider, run opencode auth login."
   steps:
-    - "Run: opencode auth login"
-    - "Pick a provider, then choose 'Manually enter API key'"
-    - "Paste your key, then run: opencode"
-  signupUrl: "https://models.dev/"
+    - "Free trial: just run `opencode`"
+    - "Your own key: opencode auth login → pick a provider → paste your key"
+  signupUrl: "https://opencode.ai/auth"
 
 welcome: |
-  OpenCode is installed. Add a provider key from the panel on the left
-  (opencode auth login), then run `opencode`.
+  opencode is ready (opencode Zen). On the free trial, just run:
+    opencode
 
 commands:
-  - label: "Show version"
-    run: "opencode --version"
-  - label: "Sign in (add a key)"
-    run: "opencode auth login"
-  - label: "Start OpenCode"
+  - label: "Start opencode"
     run: "opencode"
+  - label: "Version"
+    run: "opencode --version"
+  - label: "Use your own provider"
+    run: "opencode auth login"
 
 sessionMinutes: 10

--- a/try-cli/demos/qwen3-coder.trycli.yml
+++ b/try-cli/demos/qwen3-coder.trycli.yml
@@ -1,0 +1,29 @@
+name: "Qwen3 Coder"
+slug: qwen3-coder
+tagline: "Alibaba's coding-tuned agent"
+category: "AI coding agents"
+template: agentclash-trycli
+docs: "https://github.com/QwenLM/qwen-code"
+github: "https://github.com/QwenLM/qwen-code"
+
+auth:
+  provider: "OpenRouter / DashScope"
+  summary: "Free trial runs Qwen3 Coder via Qwen Code on AgentClash credentials — no key needed. To use your own, set OPENAI_BASE_URL/OPENAI_API_KEY or run qwen and sign in."
+  steps:
+    - "Free trial: just run `qwen` (preconfigured for Qwen3 Coder)"
+    - "Your own key: export OPENAI_API_KEY + OPENAI_BASE_URL, then run qwen"
+  signupUrl: "https://openrouter.ai/keys"
+
+welcome: |
+  Qwen3 Coder is ready via Qwen Code. On the free trial, just run:
+    qwen
+
+commands:
+  - label: "Start Qwen Code"
+    run: "qwen"
+  - label: "Version"
+    run: "qwen --version"
+  - label: "Make a file to work on"
+    run: "echo 'def add(a, b): return a + b' > math.py && cat math.py"
+
+sessionMinutes: 10

--- a/web/src/components/try-cli/demo-client.tsx
+++ b/web/src/components/try-cli/demo-client.tsx
@@ -8,7 +8,9 @@ import {
   Copy,
   ExternalLink,
   KeyRound,
+  LogIn,
   RotateCcw,
+  Sparkles,
   TimerReset,
 } from "lucide-react";
 import { TryCliTerminal } from "@/components/try-cli/terminal";
@@ -27,10 +29,29 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
   const [status, setStatus] = useState("loading");
   const [expiresAt, setExpiresAt] = useState(0);
   const [remaining, setRemaining] = useState("");
+  const [low, setLow] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState<string | null>(null);
   const [tier, setTier] = useState<"anonymous" | "authenticated">("anonymous");
   const [trial, setTrial] = useState(false);
+  const [trialUsed, setTrialUsed] = useState(false);
+
+  const loginHref = `/auth/login?returnPathname=/try/${slug}`;
+  const SESSION_KEY = "trycli:session";
+  const saveSession = (id: string, exp: number) => {
+    try {
+      localStorage.setItem(SESSION_KEY, JSON.stringify({ id, slug, expiresAt: exp }));
+    } catch {
+      /* ignore */
+    }
+  };
+  const clearSaved = () => {
+    try {
+      localStorage.removeItem(SESSION_KEY);
+    } catch {
+      /* ignore */
+    }
+  };
 
   // Track the in-flight poll timer so it can be cancelled on unmount / re-poll.
   const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -94,6 +115,12 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
       body: JSON.stringify({ slug }),
     });
     const data = await res.json();
+    if (res.status === 403 && data.trialUsed) {
+      setTrialUsed(true);
+      setStatus("trial_used");
+      clearSaved();
+      return;
+    }
     if (!res.ok) {
       setError(data.error ?? "Failed to start session");
       setStatus("error");
@@ -102,7 +129,9 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
     setSessionId(data.id);
     setExpiresAt(data.expiresAt);
     if (data.tier) setTier(data.tier);
+    saveSession(data.id, data.expiresAt);
     pollSession(data.id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [slug, apiBase, pollSession]);
 
   useEffect(() => {
@@ -117,11 +146,41 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
         return;
       }
       setDemo(d);
+
+      // Resume an existing live session for this demo on reload (so a refresh
+      // doesn't burn the one free trial); otherwise start a fresh one.
+      let saved: { id: string; slug: string; expiresAt: number } | null = null;
+      try {
+        const raw = localStorage.getItem(SESSION_KEY);
+        if (raw) saved = JSON.parse(raw);
+      } catch {
+        /* ignore */
+      }
+      if (saved && saved.slug === slug && saved.expiresAt > Date.now()) {
+        const r = await fetch(`${apiBase}/sessions/${saved.id}`);
+        if (!cancelled && r.ok) {
+          const s = (await r.json()) as TrySession;
+          if (
+            (s.status === "ready" || s.status === "starting") &&
+            (s.expiresAt ?? 0) > Date.now()
+          ) {
+            setSessionId(saved.id);
+            setExpiresAt(s.expiresAt);
+            setStatus(s.status);
+            if (s.tier) setTier(s.tier);
+            if (typeof s.trial === "boolean") setTrial(s.trial);
+            if (s.status === "starting") pollSession(saved.id);
+            return;
+          }
+        }
+        if (cancelled) return;
+      }
       await createSession();
     })();
     return () => {
       cancelled = true;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [slug, apiBase, createSession]);
 
   useEffect(() => {
@@ -130,16 +189,23 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
       const ms = expiresAt - Date.now();
       if (ms <= 0) {
         setRemaining("Expired");
+        // Anonymous trial is over — gate to sign-in instead of a dead terminal.
+        if (tier === "anonymous") {
+          setTrialUsed(true);
+          setStatus("trial_used");
+          clearSaved();
+        }
         return;
       }
       const m = Math.floor(ms / 60000);
       const s = Math.floor((ms % 60000) / 1000);
       setRemaining(`${m}:${s.toString().padStart(2, "0")}`);
+      setLow(ms < 120000);
     };
     tick();
     const id = setInterval(tick, 1000);
     return () => clearInterval(id);
-  }, [expiresAt]);
+  }, [expiresAt, tier]);
 
   const reset = async () => {
     if (!sessionId) return;
@@ -148,6 +214,7 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
     setSessionId(data.id);
     setExpiresAt(data.expiresAt);
     setStatus(data.status);
+    saveSession(data.id, data.expiresAt);
     if (data.status === "starting") pollSession(data.id);
   };
 
@@ -159,6 +226,44 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
 
   const publicOrigin = tryCliPublicOrigin().replace(/\/$/, "");
   const badgeMd = `[![Try on AgentClash](${publicOrigin}/api/try/badge/${slug}.svg)](${publicOrigin}/try/${slug})`;
+
+  if (trialUsed) {
+    return (
+      <div className="relative flex min-h-[calc(100vh-4rem)] items-center justify-center px-6 py-20">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute left-1/2 top-1/3 -z-10 h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle,rgba(255,255,255,0.10),transparent_70%)] blur-2xl"
+        />
+        <div className="w-full max-w-md text-center">
+          <div className="mx-auto mb-6 inline-flex size-12 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.04]">
+            <Sparkles className="size-5 text-white/80" />
+          </div>
+          <h1 className="font-[family-name:var(--font-display)] text-[clamp(2rem,4vw,3rem)] font-normal leading-[1.05] tracking-[-0.03em]">
+            That&apos;s your free trial.
+          </h1>
+          <p className="mx-auto mt-4 max-w-sm text-white/55">
+            Hope {demo?.name ?? "it"} felt good. Sign in with AgentClash to keep going —
+            longer sessions, your own account, no limits.
+          </p>
+          <div className="mt-8 flex flex-col items-center gap-3">
+            <a
+              href={loginHref}
+              className="inline-flex w-full max-w-xs items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-medium text-[#060606] transition-colors hover:bg-white/90"
+            >
+              <LogIn className="size-4" />
+              Sign in to continue
+            </a>
+            <Link
+              href="/try"
+              className="inline-flex items-center gap-1.5 text-sm text-white/50 underline-offset-4 transition-colors hover:text-white/80 hover:underline"
+            >
+              <ArrowLeft className="size-3.5" /> Back to all demos
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   if (error && !demo) {
     return (
@@ -219,20 +324,34 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
           </div>
         </div>
         <div className="flex items-center gap-3">
-          {trial && (
-            <span className="hidden items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-[11px] font-medium text-emerald-300 sm:inline-flex">
-              Free trial
+          {tier === "anonymous" ? (
+            <span
+              className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 font-[family-name:var(--font-mono)] text-[11px] transition-colors ${
+                low
+                  ? "border-amber-500/40 bg-amber-500/10 text-amber-300"
+                  : "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
+              }`}
+            >
+              <span className="relative flex size-1.5">
+                <span
+                  className={`absolute inline-flex size-full animate-ping rounded-full opacity-75 ${
+                    low ? "bg-amber-400" : "bg-emerald-400"
+                  }`}
+                />
+                <span
+                  className={`relative inline-flex size-1.5 rounded-full ${
+                    low ? "bg-amber-400" : "bg-emerald-400"
+                  }`}
+                />
+              </span>
+              Free trial · {remaining || "—"}
+            </span>
+          ) : (
+            <span className="inline-flex items-center gap-1.5 font-[family-name:var(--font-mono)] text-xs text-white/45">
+              <TimerReset className="size-3.5" />
+              {remaining || "—"}
             </span>
           )}
-          {tier === "authenticated" && (
-            <span className="hidden items-center gap-1.5 rounded-full border border-white/15 bg-white/[0.04] px-2.5 py-1 text-[11px] text-white/60 sm:inline-flex">
-              Your account
-            </span>
-          )}
-          <span className="inline-flex items-center gap-1.5 font-[family-name:var(--font-mono)] text-xs text-white/45">
-            <TimerReset className="size-3.5" />
-            {remaining || "—"}
-          </span>
           <button
             type="button"
             onClick={() => void reset()}

--- a/web/src/components/try-cli/landing-client.tsx
+++ b/web/src/components/try-cli/landing-client.tsx
@@ -38,7 +38,11 @@ export function TryCliLandingClient() {
   return (
     <main className="mx-auto max-w-[1400px] px-5 pb-28 sm:px-8">
       {/* Hero */}
-      <section className="pt-20 sm:pt-28">
+      <section className="relative pt-20 sm:pt-28">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute -top-10 left-0 -z-10 h-[340px] w-[680px] max-w-full rounded-full bg-[radial-gradient(ellipse_at_left,rgba(255,255,255,0.08),transparent_70%)] blur-2xl"
+        />
         <div className="inline-flex items-center gap-2 rounded-full border border-white/[0.08] bg-white/[0.03] px-3 py-1 text-xs text-white/55">
           <Terminal className="size-3.5" />
           AgentClash primitive · live E2B sandboxes
@@ -97,7 +101,7 @@ export function TryCliLandingClient() {
                   <Link
                     key={d.slug}
                     href={`/try/${d.slug}`}
-                    className="group relative flex min-h-[132px] flex-col justify-between bg-[#0a0a0a] p-5 transition-colors hover:bg-white/[0.02]"
+                    className="group relative flex min-h-[132px] flex-col justify-between bg-[#0a0a0a] p-5 transition-all duration-200 hover:bg-white/[0.03] hover:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.12)]"
                   >
                     <div>
                       <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary

Adds two more AI coding agents to Try CLI — **Kimi K2** and **Qwen3 Coder** — each running its **own dedicated CLI** routed through the metered gateway, and wires the **opencode** demo to opencode's hosted **Zen** models. Follow-up to #882.

## What changed
- **Gateway:** new `openrouter` passthrough provider (`/gw/openrouter`) — metered + capped like the others.
- **Kimi K2** → `kimi-cli` (Moonshot), baked into the E2B template; configured via `~/.kimi/config.toml` (`openai_legacy` provider → gateway).
- **Qwen3 Coder** → `@qwen-code/qwen-code`, baked in; configured via `OPENAI_BASE_URL`/`OPENAI_API_KEY`/`OPENAI_MODEL` → gateway.
- **opencode** → runs on opencode **Zen** with the operator's `OPENCODE_ZEN_API_KEY` injected (opencode's own account; not via our gateway, per your call).
- **GLM + DeepSeek dropped** — neither has a real dedicated CLI that can be pointed at our gateway (z.ai ships a GUI; DeepSeek has no official CLI), so per "skip if no real CLI" they're out rather than funneled through opencode.
- Sessions now start in `/home/user/project` (Qwen Code refuses to run in `$HOME`).
- Template rebuilt to add `kimi-cli` + `qwen-code`; all six agent CLIs confirmed on PATH.

## Verified end-to-end (real E2B sandbox + gateway)
- **Kimi** → routes through `/gw/openrouter`, response returned, **$0.034 metered** on the session.
- **Qwen** → routes through the gateway, real model reply (`QWEN_OK`).
- Gateway OpenRouter route proven for the `moonshotai/kimi-k2` model with a real session token.
- Template: `kimi 1.46`, `qwen 0.17`, `opencode 1.15`, `claude 2.1`, `codex 0.135`, `grok 1.1.7` all present.

## Deploy (post-merge)
Set on the **try-cli Railway service**: `OPENROUTER_API_KEY` (Kimi + Qwen) and `OPENCODE_ZEN_API_KEY` (opencode). The keys used for verification were temporary — **permanent keys needed for live**. Then redeploy the service (`railway redeploy --from-source`, since it doesn't auto-deploy). Grok still needs `XAI_API_KEY` whenever available.

Six AI agents total: Claude Code, Codex, Grok, opencode, Kimi K2, Qwen3 Coder.
