### PR TITLE
fix(web): keep docs header "Get Started" button from overflowing

### DIFF
--- a/web/src/components/docs/docs-shell.tsx
+++ b/web/src/components/docs/docs-shell.tsx
@@ -50,7 +50,7 @@ export function DocsShell({
               href="https://cal.com/agentclash/demo"
               target="_blank"
               rel="noopener noreferrer"
-              className="hidden rounded-full bg-emerald-600 px-4 py-1.5 text-sm font-medium text-white transition-colors hover:bg-emerald-700 sm:block"
+              className="hidden shrink-0 whitespace-nowrap rounded-full bg-emerald-600 px-4 py-1.5 text-sm font-medium text-white transition-colors hover:bg-emerald-700 sm:block"
             >
               Get Started &rarr;
             </a>


### PR DESCRIPTION
## Problem

On `/docs`, the green **"Get Started →"** button in the header rendered as an oversized green blob that overflowed below the header border at narrower viewport widths.

## Root cause

In `web/src/components/docs/docs-shell.tsx` the button shares a flex row with the search box as a *shrinkable* flex item with no `whitespace-nowrap`. In the 640–767px (`sm`→`md`) band the container is `flex-1` and the search box claims up to 384px, so the button was squeezed below its single-line width — the label wrapped to multiple lines, its height grew past the `h-16` header, and `rounded-full` (border-radius 9999px) rendered the tall box as a blob. Above `md` the container is `flex-none` (content-sized), so the bug was invisible on wide desktop.

## Fix

Add `shrink-0 whitespace-nowrap` to the button:

```diff
-  className="hidden rounded-full bg-emerald-600 px-4 py-1.5 ... sm:block"
+  className="hidden shrink-0 whitespace-nowrap rounded-full bg-emerald-600 px-4 py-1.5 ... sm:block"
```

- `shrink-0` keeps the button at its natural single-line width; the sibling search box (already `flex-shrink:1` + `max-w-[24rem]`) absorbs the squeeze instead.
- `whitespace-nowrap` guarantees the label can never wrap to a second line, so `rounded-full` can never balloon into a blob again.

## Verification

Ran the dev server and screenshotted `/docs` across widths:

| Width | Result |
|---|---|
| 375px (mobile) | button hidden, no horizontal overflow |
| 645px (tightest in failing band) | compact pill, search narrows to fit |
| 700px (failing band) | compact pill, no blob |
| 1280px (desktop) | unchanged, no regression |

`npx tsc --noEmit` and `eslint` on the file both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
