### PR TITLE
feat(web): expand SEO + AEO discoverability (compare pages, AI-crawler rules, structured data)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
     "@react-pdf/renderer": "^4.5.1",
     "@react-three/fiber": "^9.6.0",
     "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@vercel/blob':
         specifier: ^2.3.1
         version: 2.3.3
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@workos-inc/authkit-nextjs':
         specifier: ^3.0.0
         version: 3.0.0(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
@@ -2778,6 +2781,32 @@ packages:
   '@vercel/blob@2.3.3':
     resolution: {integrity: sha512-MtD7VLo6hU07eHR7bmk5SIMD290q574UaNYTe46qeyRT+hWrCy26CoAqfd7PnIefVXvRehRZBzukxuTO9iGTVg==}
     engines: {node: '>=20.0.0'}
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
@@ -9633,6 +9662,11 @@ snapshots:
       is-node-process: 1.2.0
       throttleit: 2.1.0
       undici: 6.24.1
+
+  '@vercel/speed-insights@2.0.0(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+    optionalDependencies:
+      next: 15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
 
   '@vitejs/plugin-react@6.0.1(vite@8.0.8(@types/node@20.19.39)(esbuild@0.25.12)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:

--- a/web/src/app/blog/[slug]/page.tsx
+++ b/web/src/app/blog/[slug]/page.tsx
@@ -8,7 +8,7 @@ import {
   breadcrumbSchema,
 } from "@/components/marketing/json-ld";
 import { getAllSlugs, getPostBySlug } from "@/lib/blog";
-import { blogRssAlternate } from "@/lib/seo";
+import { blogRssAlternate, ogImageUrl } from "@/lib/seo";
 
 type Props = {
   params: Promise<{ slug: string }>;
@@ -24,6 +24,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!post) return {};
   const title = `${post.title} — AgentClash`;
   const imageAlt = `${post.title} — ${post.description}`;
+  const ogImage = ogImageUrl({
+    title: post.title,
+    subtitle: post.description,
+    kind: "Blog",
+  });
 
   return {
     title,
@@ -43,7 +48,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       authors: [post.author],
       images: [
         {
-          url: "/og-image.png",
+          url: ogImage,
           width: 1200,
           height: 630,
           alt: imageAlt,
@@ -56,7 +61,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       description: post.description,
       images: [
         {
-          url: "/twitter-image.png",
+          url: ogImage,
           alt: imageAlt,
         },
       ],

--- a/web/src/app/blog/blog-metadata.test.ts
+++ b/web/src/app/blog/blog-metadata.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { blogRssAlternate } from "@/lib/seo";
+import { blogRssAlternate, ogImageUrl } from "@/lib/seo";
 import { metadata as blogMetadata } from "./page";
 import { generateMetadata } from "./[slug]/page";
 
@@ -108,6 +108,12 @@ describe("blog post social metadata", () => {
       }),
     });
 
+    const expectedImage = ogImageUrl({
+      title: "Fixture Post",
+      subtitle: "Fixture description.",
+      kind: "Blog",
+    });
+
     expect(metadata).toMatchObject({
       title: "Fixture Post — AgentClash",
       description: "Fixture description.",
@@ -122,7 +128,7 @@ describe("blog post social metadata", () => {
         authors: ["AgentClash"],
         images: [
           {
-            url: "/og-image.png",
+            url: expectedImage,
             width: 1200,
             height: 630,
             alt: "Fixture Post — Fixture description.",
@@ -135,7 +141,7 @@ describe("blog post social metadata", () => {
         description: "Fixture description.",
         images: [
           {
-            url: "/twitter-image.png",
+            url: expectedImage,
             alt: "Fixture Post — Fixture description.",
           },
         ],

--- a/web/src/app/compare/[competitor]/page.tsx
+++ b/web/src/app/compare/[competitor]/page.tsx
@@ -1,0 +1,256 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowRight, CheckCircle2 } from "lucide-react";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  faqSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+import {
+  COMPETITORS,
+  MARK_LABEL,
+  competitorFaq,
+  competitorRows,
+  getCompetitorBySlug,
+} from "@/lib/comparison-data";
+import { ogImageUrl } from "@/lib/seo";
+import { AGENT_EVALUATION_FEATURES } from "@/lib/seo-features";
+import { CompareShell } from "../_components/compare-shell";
+
+type Props = {
+  params: Promise<{ competitor: string }>;
+};
+
+// Only the known competitor slugs are valid; anything else 404s.
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return COMPETITORS.map((competitor) => ({ competitor: competitor.slug }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { competitor: slug } = await params;
+  const competitor = getCompetitorBySlug(slug);
+  if (!competitor) return {};
+
+  const title = `AgentClash vs ${competitor.name}: Agent Evaluation vs Prompt Evaluation`;
+  const description = `How AgentClash compares to ${competitor.name}. ${competitor.name} is a ${competitor.tag} tool; AgentClash races tool-using agents head-to-head in a sandbox, scores the full trajectory, and gates CI on regressions.`;
+  const path = `/compare/${competitor.slug}`;
+  const image = ogImageUrl({
+    title: `AgentClash vs ${competitor.name}`,
+    subtitle: "Agent eval vs prompt eval",
+    kind: "Compare",
+  });
+
+  return {
+    title,
+    description,
+    alternates: { canonical: path },
+    openGraph: {
+      title,
+      description,
+      url: path,
+      type: "website",
+      locale: "en_US",
+      siteName: "AgentClash",
+      images: [{ url: image, width: 1200, height: 630, alt: title }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [{ url: image, alt: title }],
+    },
+  };
+}
+
+export default async function CompareCompetitorPage({ params }: Props) {
+  const { competitor: slug } = await params;
+  const competitor = getCompetitorBySlug(slug);
+  if (!competitor) notFound();
+
+  const path = `/compare/${competitor.slug}`;
+  const rows = competitorRows(competitor);
+  const faq = competitorFaq(competitor);
+
+  return (
+    <>
+      <JsonLd
+        id={`agentclash-compare-${competitor.slug}-schema`}
+        data={[
+          breadcrumbSchema([
+            { name: "Home", url: "/" },
+            { name: "Compare", url: "/compare" },
+            { name: `AgentClash vs ${competitor.name}`, url: path },
+          ]),
+          faqSchema(faq),
+          productSchema({
+            name: "AgentClash",
+            description: `AgentClash is an agent-evaluation engine — an alternative to ${competitor.name} for teams evaluating tool-using agents head-to-head on real tasks.`,
+            url: path,
+            applicationSubCategory: "AI agent evaluation platform",
+            featureList: AGENT_EVALUATION_FEATURES,
+          }),
+        ]}
+      />
+      <CompareShell>
+        <section className="px-6 py-20 sm:px-12 sm:py-24">
+          <div className="mx-auto max-w-[1080px]">
+            <nav className="flex items-center gap-2 text-xs text-white/35">
+              <Link href="/" className="transition-colors hover:text-white/70">
+                Home
+              </Link>
+              <span>/</span>
+              <Link
+                href="/compare"
+                className="transition-colors hover:text-white/70"
+              >
+                Compare
+              </Link>
+              <span>/</span>
+              <span>AgentClash vs {competitor.name}</span>
+            </nav>
+            <p className="mt-10 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-cyan-200/70">
+              agent eval vs {competitor.tag}
+            </p>
+            <h1 className="mt-5 font-[family-name:var(--font-display)] text-4xl font-normal leading-[1.05] tracking-tight text-white sm:text-6xl">
+              AgentClash vs {competitor.name}
+            </h1>
+            <p className="mt-8 max-w-[64ch] text-base leading-8 text-white/62 sm:text-lg">
+              {competitor.name} is excellent at {competitor.tag}. AgentClash is
+              built for agent evaluation: it races tool-using agents
+              head-to-head in a fresh sandbox, scores the whole trajectory, and
+              turns failures into CI regression gates.
+            </p>
+          </div>
+        </section>
+
+        <section className="border-y border-white/[0.06] px-6 py-16 sm:px-12">
+          <div className="mx-auto max-w-[1080px]">
+            <h2 className="text-2xl font-semibold tracking-tight text-white sm:text-3xl">
+              AgentClash vs {competitor.name}, capability by capability
+            </h2>
+            <div className="mt-10 overflow-x-auto">
+              <table className="w-full min-w-[640px] border-collapse text-left">
+                <thead>
+                  <tr className="border-b border-white/[0.14]">
+                    <th
+                      scope="col"
+                      className="py-4 pr-4 text-[11px] font-medium uppercase tracking-[0.16em] text-white/40"
+                    >
+                      Capability
+                    </th>
+                    <th
+                      scope="col"
+                      className="px-3 py-4 text-center text-sm font-semibold text-white"
+                    >
+                      AgentClash
+                    </th>
+                    <th
+                      scope="col"
+                      className="px-3 py-4 text-center text-sm font-semibold text-white/55"
+                    >
+                      {competitor.name}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((row) => (
+                    <tr
+                      key={row.label}
+                      className="border-b border-white/[0.06] align-top"
+                    >
+                      <th scope="row" className="py-5 pr-6 font-normal">
+                        <span className="block text-[15px] text-white/85">
+                          {row.label}
+                        </span>
+                        <span className="mt-1 block max-w-[52ch] text-[12px] leading-5 text-white/40">
+                          {row.sub}
+                        </span>
+                      </th>
+                      <td className="px-3 py-5 text-center text-sm font-medium text-white">
+                        {MARK_LABEL[row.agentclash]}
+                      </td>
+                      <td className="px-3 py-5 text-center text-sm text-white/55">
+                        {MARK_LABEL[row.competitor]}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+
+        <section className="px-6 py-16 sm:px-12 sm:py-20">
+          <div className="mx-auto grid max-w-[1080px] gap-6 lg:grid-cols-2">
+            <div className="rounded-md border border-white/[0.08] bg-white/[0.03] p-6">
+              <h2 className="text-lg font-semibold tracking-tight text-white">
+                Where {competitor.name} is the better fit
+              </h2>
+              <p className="mt-4 text-sm leading-7 text-white/60">
+                {competitor.whereItFits}
+              </p>
+            </div>
+            <div className="rounded-md border border-white/[0.08] bg-white/[0.03] p-6">
+              <h2 className="text-lg font-semibold tracking-tight text-white">
+                Where AgentClash is the better fit
+              </h2>
+              <ul className="mt-4 space-y-3">
+                {AGENT_EVALUATION_FEATURES.map((feature) => (
+                  <li
+                    key={feature}
+                    className="flex items-start gap-3 text-sm leading-6 text-white/70"
+                  >
+                    <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-emerald-200" />
+                    {feature}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        <section className="border-t border-white/[0.06] px-6 py-16 sm:px-12 sm:py-24">
+          <div className="mx-auto max-w-[960px]">
+            <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+              FAQ
+            </p>
+            <h2 className="mt-4 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+              AgentClash vs {competitor.name}
+            </h2>
+            <div className="mt-10 divide-y divide-white/[0.08] border-y border-white/[0.08]">
+              {faq.map((item) => (
+                <section key={item.question} className="py-6">
+                  <h3 className="text-lg font-semibold tracking-tight text-white">
+                    {item.question}
+                  </h3>
+                  <p className="mt-3 text-sm leading-7 text-white/55">
+                    {item.answer}
+                  </p>
+                </section>
+              ))}
+            </div>
+            <div className="mt-10 flex flex-col gap-3 sm:flex-row">
+              <Link
+                href="/auth/login"
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-medium text-[#060606] transition-colors hover:bg-white/90"
+              >
+                Start first race
+                <ArrowRight className="size-4" />
+              </Link>
+              <Link
+                href="/compare"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 transition-colors hover:border-white/30 hover:text-white"
+              >
+                See all comparisons
+              </Link>
+            </div>
+          </div>
+        </section>
+      </CompareShell>
+    </>
+  );
+}

--- a/web/src/app/compare/_components/compare-shell.tsx
+++ b/web/src/app/compare/_components/compare-shell.tsx
@@ -1,0 +1,82 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { ClashMark } from "@/components/marketing/clash-mark";
+
+// Shared header + footer chrome for the /compare hub and per-competitor pages,
+// mirroring the platform marketing pages. Server component (no client hooks).
+export function CompareShell({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <header className="border-b border-white/[0.06] px-5 py-5 sm:px-12 sm:py-6">
+        <div className="mx-auto flex max-w-[1440px] items-center justify-between gap-4">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2.5 text-white/90"
+          >
+            <ClashMark className="size-6" />
+            <span className="font-[family-name:var(--font-display)] text-xl tracking-normal">
+              AgentClash
+            </span>
+          </Link>
+          <nav className="flex items-center gap-2 text-xs">
+            <Link
+              href="/compare"
+              className="hidden px-3 py-1.5 text-white/55 transition-colors hover:text-white/85 sm:inline-flex"
+            >
+              Compare
+            </Link>
+            <Link
+              href="/docs"
+              className="hidden px-3 py-1.5 text-white/55 transition-colors hover:text-white/85 sm:inline-flex"
+            >
+              Docs
+            </Link>
+            <a
+              href="https://github.com/agentclash/agentclash"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hidden px-3 py-1.5 text-white/55 transition-colors hover:text-white/85 sm:inline-flex"
+            >
+              GitHub
+            </a>
+            <Link
+              href="/auth/login"
+              className="inline-flex items-center gap-1.5 rounded-md bg-white px-3 py-1.5 font-medium text-[#060606] transition-colors hover:bg-white/90"
+            >
+              Start
+              <ArrowRight className="size-3.5" />
+            </Link>
+          </nav>
+        </div>
+      </header>
+      <main className="min-h-screen bg-[#060606] text-white">{children}</main>
+      <footer className="border-t border-white/[0.06] bg-[#060606] px-6 py-10 sm:px-12">
+        <div className="mx-auto flex max-w-[1440px] flex-col gap-5 text-sm text-white/45 sm:flex-row sm:items-center sm:justify-between">
+          <Link href="/" className="font-medium text-white/65">
+            AgentClash
+          </Link>
+          <nav className="flex flex-wrap gap-5">
+            <Link href="/compare" className="transition-colors hover:text-white/75">
+              Compare
+            </Link>
+            <Link href="/docs" className="transition-colors hover:text-white/75">
+              Docs
+            </Link>
+            <Link href="/blog" className="transition-colors hover:text-white/75">
+              Blog
+            </Link>
+            <a
+              href="https://github.com/agentclash/agentclash"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="transition-colors hover:text-white/75"
+            >
+              GitHub
+            </a>
+          </nav>
+        </div>
+      </footer>
+    </>
+  );
+}

--- a/web/src/app/compare/compare-metadata.test.ts
+++ b/web/src/app/compare/compare-metadata.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { COMPETITORS } from "@/lib/comparison-data";
+import { metadata as compareHubMetadata } from "./page";
+import {
+  generateMetadata as generateCompetitorMetadata,
+  generateStaticParams,
+} from "./[competitor]/page";
+
+describe("compare hub metadata", () => {
+  it("locks the canonical and emits a dynamic OG image", () => {
+    expect(compareHubMetadata.alternates).toMatchObject({
+      canonical: "/compare",
+    });
+
+    const openGraph = compareHubMetadata.openGraph as {
+      images?: Array<{ url?: string }>;
+    };
+    expect(openGraph.images?.[0]?.url?.startsWith("/og?")).toBe(true);
+  });
+});
+
+describe("compare competitor pages", () => {
+  it("generates one static param per competitor", () => {
+    const params = generateStaticParams();
+
+    expect(params).toHaveLength(COMPETITORS.length);
+    expect(params).toContainEqual({ competitor: "agentclash-vs-langsmith" });
+  });
+
+  it("locks per-competitor canonical metadata and titles", async () => {
+    const metadata = await generateCompetitorMetadata({
+      params: Promise.resolve({ competitor: "agentclash-vs-langsmith" }),
+    });
+
+    expect(metadata.alternates).toMatchObject({
+      canonical: "/compare/agentclash-vs-langsmith",
+    });
+    expect(metadata.title).toContain("LangSmith");
+
+    const openGraph = metadata.openGraph as {
+      images?: Array<{ url?: string }>;
+    };
+    expect(openGraph.images?.[0]?.url?.startsWith("/og?")).toBe(true);
+  });
+
+  it("returns empty metadata for an unknown competitor", async () => {
+    const metadata = await generateCompetitorMetadata({
+      params: Promise.resolve({ competitor: "agentclash-vs-unknown" }),
+    });
+
+    expect(metadata).toEqual({});
+  });
+});

--- a/web/src/app/compare/page.tsx
+++ b/web/src/app/compare/page.tsx
@@ -1,0 +1,274 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import {
+  JsonLd,
+  SITE_URL,
+  breadcrumbSchema,
+  faqSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+import {
+  COMPARISON_COLUMNS,
+  COMPARISON_ROWS,
+  COMPETITORS,
+  MARK_LABEL,
+} from "@/lib/comparison-data";
+import { ogImageUrl } from "@/lib/seo";
+import { AGENT_EVALUATION_FEATURES } from "@/lib/seo-features";
+import { CompareShell } from "./_components/compare-shell";
+
+const PAGE_PATH = "/compare";
+const PAGE_TITLE =
+  "Best AI Agent Evaluation Tools: AgentClash vs Prompt-Eval Platforms";
+const PAGE_DESCRIPTION =
+  "Compare AgentClash with Braintrust, LangSmith, Promptfoo, Langfuse, Arize Phoenix, and OpenAI Evals. See how sandboxed, multi-turn, head-to-head agent evaluation differs from prompt evaluation.";
+const SOCIAL_IMAGE = ogImageUrl({
+  title: "AgentClash vs prompt-eval tools",
+  subtitle: "Agent evaluation, not prompt evaluation",
+  kind: "Compare",
+});
+
+const faqItems = [
+  {
+    question:
+      "What is the difference between agent evaluation and prompt evaluation?",
+    answer:
+      "Prompt evaluation scores the text a model returns from a single call against a dataset or rubric. Agent evaluation runs a model as an agent — it takes actions, calls tools, and works for minutes in a real environment — then scores the whole trajectory, not just the final answer. AgentClash is built for agent evaluation; most other tools focus on prompt evaluation.",
+  },
+  {
+    question: "What are the best AI agent evaluation tools?",
+    answer:
+      "Braintrust, LangSmith, Promptfoo, Langfuse, Arize Phoenix, and OpenAI Evals are excellent for prompt-level evaluation, tracing, and observability. AgentClash is purpose-built for evaluating tool-using agents head-to-head in a sandbox, with replay, scorecards, and CI regression gates.",
+  },
+  {
+    question: "Is AgentClash open source?",
+    answer:
+      "Yes. AgentClash is open source under the MIT license. You can self-host it or run against the hosted backend, and the CLI ships on npm as the agentclash package.",
+  },
+  {
+    question: "Which AgentClash alternative should I choose?",
+    answer:
+      "If you mainly need prompt and output scoring, datasets, and tracing, a prompt-eval tool may be enough. If you need to evaluate multi-turn, tool-using agents end-to-end — with sandboxed execution, trajectory scoring, and CI gates — AgentClash is the closer fit. Many teams use both.",
+  },
+];
+
+export const metadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  alternates: { canonical: PAGE_PATH },
+  openGraph: {
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: PAGE_PATH,
+    type: "website",
+    locale: "en_US",
+    siteName: "AgentClash",
+    images: [{ url: SOCIAL_IMAGE, width: 1200, height: 630, alt: PAGE_TITLE }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    images: [{ url: SOCIAL_IMAGE, alt: PAGE_TITLE }],
+  },
+};
+
+const itemListSchema = {
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  name: "AgentClash comparisons",
+  url: `${SITE_URL}${PAGE_PATH}`,
+  itemListElement: COMPETITORS.map((competitor, index) => ({
+    "@type": "ListItem",
+    position: index + 1,
+    name: `AgentClash vs ${competitor.name}`,
+    url: `${SITE_URL}/compare/${competitor.slug}`,
+  })),
+};
+
+export default function ComparePage() {
+  return (
+    <>
+      <JsonLd
+        id="agentclash-compare-hub-schema"
+        data={[
+          breadcrumbSchema([
+            { name: "Home", url: "/" },
+            { name: "Compare", url: PAGE_PATH },
+          ]),
+          faqSchema(faqItems),
+          productSchema({
+            name: "AgentClash",
+            description: PAGE_DESCRIPTION,
+            url: PAGE_PATH,
+            applicationSubCategory: "AI agent evaluation platform",
+            featureList: AGENT_EVALUATION_FEATURES,
+          }),
+          itemListSchema,
+        ]}
+      />
+      <CompareShell>
+        <section className="px-6 py-20 sm:px-12 sm:py-28">
+          <div className="mx-auto max-w-[1440px]">
+            <nav className="flex items-center gap-2 text-xs text-white/35">
+              <Link href="/" className="transition-colors hover:text-white/70">
+                Home
+              </Link>
+              <span>/</span>
+              <span>Compare</span>
+            </nav>
+            <p className="mt-10 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-cyan-200/70">
+              Agent eval vs prompt eval
+            </p>
+            <h1 className="mt-5 max-w-[18ch] font-[family-name:var(--font-display)] text-4xl font-normal leading-[1.05] tracking-tight text-white sm:text-6xl">
+              They test prompts. AgentClash races agents.
+            </h1>
+            <p className="mt-8 max-w-[64ch] text-base leading-8 text-white/62 sm:text-lg">
+              {PAGE_DESCRIPTION}
+            </p>
+          </div>
+        </section>
+
+        <section className="border-y border-white/[0.06] px-6 py-16 sm:px-12">
+          <div className="mx-auto max-w-[1440px]">
+            <h2 className="text-2xl font-semibold tracking-tight text-white sm:text-3xl">
+              Capability comparison
+            </h2>
+            <p className="mt-3 max-w-[70ch] text-sm leading-7 text-white/55">
+              The tools below are excellent at prompt engineering — scoring the
+              text a model produces from a single call. AgentClash is built for
+              the next problem over: evaluating agents that take actions, use
+              tools, and run for minutes at a time in a real sandbox.
+            </p>
+            <div className="mt-10 overflow-x-auto">
+              <table className="w-full min-w-[900px] border-collapse text-left">
+                <thead>
+                  <tr className="border-b border-white/[0.14]">
+                    <th
+                      scope="col"
+                      className="py-4 pr-4 text-[11px] font-medium uppercase tracking-[0.16em] text-white/40"
+                    >
+                      Capability
+                    </th>
+                    {COMPARISON_COLUMNS.map((column) => (
+                      <th
+                        key={column.name}
+                        scope="col"
+                        className={`px-3 py-4 text-center align-bottom ${
+                          column.highlight ? "text-white" : "text-white/55"
+                        }`}
+                      >
+                        <span className="block text-sm font-semibold">
+                          {column.name}
+                        </span>
+                        <span className="mt-1 block text-[9px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] text-white/35">
+                          {column.tag}
+                        </span>
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {COMPARISON_ROWS.map((row) => (
+                    <tr
+                      key={row.label}
+                      className="border-b border-white/[0.06] align-top"
+                    >
+                      <th scope="row" className="py-5 pr-6 font-normal">
+                        <span className="block text-[15px] text-white/85">
+                          {row.label}
+                        </span>
+                        <span className="mt-1 block max-w-[42ch] text-[12px] leading-5 text-white/40">
+                          {row.sub}
+                        </span>
+                      </th>
+                      {row.cells.map((cell, index) => (
+                        <td
+                          key={COMPARISON_COLUMNS[index].name}
+                          className={`px-3 py-5 text-center text-sm ${
+                            index === 0
+                              ? "font-medium text-white"
+                              : "text-white/55"
+                          }`}
+                        >
+                          {MARK_LABEL[cell]}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+
+        <section className="px-6 py-16 sm:px-12 sm:py-24">
+          <div className="mx-auto max-w-[1440px]">
+            <h2 className="text-2xl font-semibold tracking-tight text-white sm:text-3xl">
+              Compare AgentClash head-to-head
+            </h2>
+            <div className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {COMPETITORS.map((competitor) => (
+                <Link
+                  key={competitor.slug}
+                  href={`/compare/${competitor.slug}`}
+                  className="group rounded-md border border-white/[0.08] bg-white/[0.03] p-5 transition-colors hover:border-white/20 hover:bg-white/[0.05]"
+                >
+                  <div className="flex items-center justify-between gap-4">
+                    <span className="text-base font-semibold text-white">
+                      AgentClash vs {competitor.name}
+                    </span>
+                    <ArrowRight className="size-4 shrink-0 text-white/35 transition-colors group-hover:text-white/75" />
+                  </div>
+                  <span className="mt-2 block text-sm leading-6 text-white/50">
+                    How agent evaluation differs from {competitor.name}’s{" "}
+                    {competitor.tag}.
+                  </span>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="border-t border-white/[0.06] px-6 py-16 sm:px-12 sm:py-24">
+          <div className="mx-auto max-w-[960px]">
+            <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+              FAQ
+            </p>
+            <h2 className="mt-4 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+              Agent evaluation vs prompt evaluation
+            </h2>
+            <div className="mt-10 divide-y divide-white/[0.08] border-y border-white/[0.08]">
+              {faqItems.map((item) => (
+                <section key={item.question} className="py-6">
+                  <h3 className="text-lg font-semibold tracking-tight text-white">
+                    {item.question}
+                  </h3>
+                  <p className="mt-3 text-sm leading-7 text-white/55">
+                    {item.answer}
+                  </p>
+                </section>
+              ))}
+            </div>
+            <div className="mt-10 flex flex-col gap-3 sm:flex-row">
+              <Link
+                href="/auth/login"
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-medium text-[#060606] transition-colors hover:bg-white/90"
+              >
+                Start first race
+                <ArrowRight className="size-4" />
+              </Link>
+              <Link
+                href="/docs/getting-started/quickstart"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 transition-colors hover:border-white/30 hover:text-white"
+              >
+                Read quickstart
+              </Link>
+            </div>
+          </div>
+        </section>
+      </CompareShell>
+    </>
+  );
+}

--- a/web/src/app/docs/[[...slug]]/page.tsx
+++ b/web/src/app/docs/[[...slug]]/page.tsx
@@ -11,6 +11,7 @@ import {
   getDocBySlug,
   getDocNeighbors,
 } from "@/lib/docs";
+import { ogImageUrl } from "@/lib/seo";
 import { docsSchemaId } from "../docs-schema-id";
 
 type Props = {
@@ -48,6 +49,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const description =
     typeof doc.description === "string" ? doc.description.trim() : "";
   const imageAlt = description ? `${doc.title} — ${description}` : doc.title;
+  const ogImage = ogImageUrl({
+    title: doc.title,
+    subtitle: description || undefined,
+    kind: "Docs",
+  });
 
   return {
     title,
@@ -64,7 +70,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       siteName: "AgentClash",
       images: [
         {
-          url: "/og-image.png",
+          url: ogImage,
           width: 1200,
           height: 630,
           alt: imageAlt,
@@ -77,7 +83,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       description: doc.description,
       images: [
         {
-          url: "/twitter-image.png",
+          url: ogImage,
           alt: imageAlt,
         },
       ],
@@ -109,6 +115,8 @@ export default async function DocsPage({ params }: Props) {
           description: doc.description,
           href: doc.href,
           faqItems: isHome ? DOCS_HOME_FAQ : undefined,
+          datePublished: doc.datePublished,
+          dateModified: doc.dateModified,
         })}
       />
 

--- a/web/src/app/docs/docs-metadata.test.ts
+++ b/web/src/app/docs/docs-metadata.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { ogImageUrl } from "@/lib/seo";
 import { generateMetadata } from "./[[...slug]]/page";
 
 const getDocBySlugMock = vi.hoisted(() => vi.fn());
@@ -24,6 +25,12 @@ describe("docs metadata", () => {
       }),
     });
 
+    const expectedImage = ogImageUrl({
+      title: "Quickstart",
+      subtitle: "Run your first AgentClash eval.",
+      kind: "Docs",
+    });
+
     expect(metadata).toMatchObject({
       title: "Quickstart — AgentClash Docs",
       description: "Run your first AgentClash eval.",
@@ -39,7 +46,7 @@ describe("docs metadata", () => {
         siteName: "AgentClash",
         images: [
           {
-            url: "/og-image.png",
+            url: expectedImage,
             width: 1200,
             height: 630,
             alt: "Quickstart — Run your first AgentClash eval.",
@@ -52,7 +59,7 @@ describe("docs metadata", () => {
         description: "Run your first AgentClash eval.",
         images: [
           {
-            url: "/twitter-image.png",
+            url: expectedImage,
             alt: "Quickstart — Run your first AgentClash eval.",
           },
         ],

--- a/web/src/app/landing.tsx
+++ b/web/src/app/landing.tsx
@@ -19,6 +19,8 @@ import { PricingBlock } from "@/components/marketing/pricing-block";
 import { ExpandedCardsBlock } from "@/components/marketing/expanded-cards-block";
 import { TrackBox } from "@/components/marketing/track-box";
 import { TryCliBanner } from "@/components/marketing/try-cli-banner";
+import { COMPARISON_COLUMNS, COMPARISON_ROWS } from "@/lib/comparison-data";
+import { HOME_FAQ } from "@/lib/home-faq";
 
 const DEMO_LINK = "atharva-kanherkar-epgztu/agentclash-demo";
 const DEMO_BUTTON_CONFIG = JSON.stringify({ layout: "month_view" });
@@ -1429,63 +1431,8 @@ const LANDING_FEATURES: Array<{
   },
 ];
 
-type MarkKind = "yes" | "partial" | "no";
-
-const COMPARISON_COLUMNS: Array<{
-  name: string;
-  tag: string;
-  highlight?: boolean;
-}> = [
-  { name: "AgentClash", tag: "agent eval", highlight: true },
-  { name: "Braintrust", tag: "prompt eval" },
-  { name: "LangSmith", tag: "prompt eval" },
-  { name: "Promptfoo", tag: "prompt eval" },
-  { name: "Langfuse", tag: "prompt eval" },
-  { name: "Arize Phoenix", tag: "prompt eval" },
-  { name: "OpenAI Evals", tag: "prompt eval" },
-];
-
-const COMPARISON_ROWS: Array<{
-  label: string;
-  sub: string;
-  cells: readonly MarkKind[];
-}> = [
-  {
-    label: "Multi-turn agent loops",
-    sub: "Think → tool → observe → repeat, for minutes, with a fresh environment. Not one prompt → one response.",
-    cells: ["yes", "partial", "partial", "no", "partial", "partial", "partial"],
-  },
-  {
-    label: "Sandboxed tool execution",
-    sub: "A fresh microVM per agent — real files, real shell, real network, real side effects.",
-    cells: ["yes", "no", "no", "no", "no", "no", "no"],
-  },
-  {
-    label: "Head-to-head concurrent race",
-    sub: "Every model runs the same task at the same time, on the same budget. No staggered runs, no warm caches.",
-    cells: ["yes", "no", "no", "no", "no", "no", "no"],
-  },
-  {
-    label: "Trajectory scoring",
-    sub: "Judges the path, not just the final answer — tool-choice efficiency, recovery from error, scope discipline.",
-    cells: ["yes", "partial", "partial", "no", "partial", "partial", "no"],
-  },
-  {
-    label: "Cross-provider tool-call normalisation",
-    sub: "One schema across OpenAI, Anthropic, Gemini, xAI, Mistral, OpenRouter. Errors classified, retries sane.",
-    cells: ["yes", "partial", "partial", "partial", "partial", "partial", "no"],
-  },
-  {
-    label: "Four-vantage composite verdict",
-    sub: "Deterministic + mathematic + behavioural + LLM, with consensus aggregation and weights you control.",
-    cells: ["yes", "partial", "partial", "partial", "partial", "partial", "partial"],
-  },
-  {
-    label: "Failures auto-promote to regression",
-    sub: "Flunked traces freeze into permanent tests and replay in every future race, by default.",
-    cells: ["yes", "partial", "partial", "partial", "partial", "partial", "no"],
-  },
-];
+// COMPARISON_COLUMNS and COMPARISON_ROWS now live in @/lib/comparison-data,
+// shared with the /compare pages so the matrix never drifts between surfaces.
 
 export default function HomePage() {
   const { user, loading: authLoading } = useAuth();
@@ -2169,6 +2116,16 @@ export default function HomePage() {
             <span className="text-white/30">—</span>&nbsp;&nbsp;not a core
             capability
           </p>
+
+          <p className="mt-8 text-sm">
+            <Link
+              href="/compare"
+              className="text-white/65 underline-offset-4 transition-colors hover:text-white hover:underline"
+            >
+              See the full comparison — AgentClash vs Braintrust, LangSmith,
+              Promptfoo, Langfuse, Arize Phoenix &amp; OpenAI Evals →
+            </Link>
+          </p>
         </div>
       </section>
 
@@ -2377,6 +2334,27 @@ export default function HomePage() {
             {/* Was <TransparentFrame /> (flat 2D SVG, still defined above). */}
             {/* To revert if the 3D version doesn't land, swap this line.   */}
             <TrackBox />
+          </div>
+        </div>
+      </section>
+
+      {/* ── FAQ ─────────────────────────────────────────────────── */}
+      <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-44">
+        <div className="mx-auto max-w-[920px]">
+          <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.05] text-[clamp(2.25rem,5vw,4rem)]">
+            Questions, answered.
+          </h2>
+          <div className="mt-12 divide-y divide-white/[0.08] border-y border-white/[0.08]">
+            {HOME_FAQ.map((item) => (
+              <div key={item.question} className="py-7">
+                <h3 className="text-lg font-medium leading-snug text-white/90">
+                  {item.question}
+                </h3>
+                <p className="mt-3 text-[15px] leading-[1.7] text-white/55">
+                  {item.answer}
+                </p>
+              </div>
+            ))}
           </div>
         </div>
       </section>

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import {
   Instrument_Serif,
   DM_Sans,
@@ -8,6 +8,7 @@ import {
   Fraunces,
 } from "next/font/google";
 import { Analytics } from "@vercel/analytics/react";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Toaster } from "@/components/ui/sonner";
 import { AppProviders } from "@/app/providers";
 import "./globals.css";
@@ -51,6 +52,15 @@ const geistMono = Geist_Mono({
 const siteUrl = "https://www.agentclash.dev";
 const siteDescription =
   "AgentClash is an open-source AI agent evaluation platform. Race coding, research, support, and ops agents head-to-head on real tasks with sandboxed tools, live replay, scorecards, and CI regression gates.";
+
+// Public webmaster-verification tokens (safe to expose — they live in the HTML
+// head). Set via env so tokens aren't hard-coded; omitted entirely when unset.
+const googleVerification = process.env.NEXT_PUBLIC_GSC_VERIFICATION;
+const bingVerification = process.env.NEXT_PUBLIC_BING_VERIFICATION;
+
+export const viewport: Viewport = {
+  themeColor: "#060606",
+};
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
@@ -100,6 +110,16 @@ export const metadata: Metadata = {
       follow: true,
     },
   },
+  ...(googleVerification || bingVerification
+    ? {
+        verification: {
+          ...(googleVerification ? { google: googleVerification } : {}),
+          ...(bingVerification
+            ? { other: { "msvalidate.01": bingVerification } }
+            : {}),
+        },
+      }
+    : {}),
   icons: {
     icon: [
       { url: "/favicon-16x16.png", sizes: "16x16", type: "image/png" },
@@ -125,6 +145,7 @@ export default function RootLayout({
         <AppProviders>{children}</AppProviders>
         <Toaster position="bottom-right" />
         <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/web/src/app/manifest.test.ts
+++ b/web/src/app/manifest.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import manifest from "./manifest";
+
+describe("manifest", () => {
+  it("uses brand colors and the existing android-chrome icons", () => {
+    const result = manifest();
+
+    expect(result.name).toContain("AgentClash");
+    expect(result.short_name).toBe("AgentClash");
+    expect(result.display).toBe("standalone");
+    expect(result.theme_color).toBe("#060606");
+    expect(result.background_color).toBe("#060606");
+    expect(result.icons).toEqual([
+      {
+        src: "/android-chrome-192x192.png",
+        sizes: "192x192",
+        type: "image/png",
+      },
+      {
+        src: "/android-chrome-512x512.png",
+        sizes: "512x512",
+        type: "image/png",
+      },
+    ]);
+  });
+});

--- a/web/src/app/manifest.ts
+++ b/web/src/app/manifest.ts
@@ -1,0 +1,28 @@
+import type { MetadataRoute } from "next";
+
+// Web app manifest. Next.js serves this at /manifest.webmanifest and auto-links
+// it from every page. Reuses the android-chrome icons already in public/.
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "AgentClash — Open-source AI Agent Evaluation Platform",
+    short_name: "AgentClash",
+    description:
+      "Race AI agents head-to-head on real tasks with sandboxed tools, replay, scorecards, and CI regression gates.",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#060606",
+    theme_color: "#060606",
+    icons: [
+      {
+        src: "/android-chrome-192x192.png",
+        sizes: "192x192",
+        type: "image/png",
+      },
+      {
+        src: "/android-chrome-512x512.png",
+        sizes: "512x512",
+        type: "image/png",
+      },
+    ],
+  };
+}

--- a/web/src/app/og/route.tsx
+++ b/web/src/app/og/route.tsx
@@ -1,0 +1,119 @@
+import { ImageResponse } from "next/og";
+
+// Dynamic Open Graph image. Pages point openGraph/twitter images at
+// /og?title=...&subtitle=...&kind=... (see lib/seo.ts `ogImageUrl`) so blog
+// posts, docs, and comparison pages get tailored social cards instead of one
+// shared static image. Flexbox-only layout per Satori's CSS subset.
+export const runtime = "nodejs";
+
+// ImageResponse sets the image/png Content-Type header itself; a `contentType`
+// export is only valid on the opengraph-image file convention, not a Route
+// Handler, so it must not be exported here.
+const SIZE = { width: 1200, height: 630 } as const;
+
+export function GET(request: Request): Response {
+  try {
+    const { searchParams } = new URL(request.url);
+    const title = (searchParams.get("title") || "AgentClash").slice(0, 110);
+    const subtitle = (
+      searchParams.get("subtitle") ||
+      "Open-source AI agent evaluation platform"
+    ).slice(0, 160);
+    const eyebrow = (searchParams.get("kind") || "").slice(0, 40);
+
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            width: "100%",
+            height: "100%",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "space-between",
+            padding: "72px 80px",
+            backgroundColor: "#060606",
+            backgroundImage:
+              "linear-gradient(135deg, #101012 0%, #060606 55%)",
+            color: "#ffffff",
+            fontFamily: "sans-serif",
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: "18px" }}>
+            <div
+              style={{
+                width: "30px",
+                height: "30px",
+                borderRadius: "9999px",
+                border: "3px solid rgba(255,255,255,0.85)",
+                display: "flex",
+              }}
+            />
+            <div
+              style={{
+                fontSize: "30px",
+                fontWeight: 600,
+                letterSpacing: "-0.02em",
+              }}
+            >
+              AgentClash
+            </div>
+          </div>
+
+          <div
+            style={{ display: "flex", flexDirection: "column", gap: "22px" }}
+          >
+            {eyebrow ? (
+              <div
+                style={{
+                  fontSize: "22px",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.22em",
+                  color: "rgba(255,255,255,0.45)",
+                }}
+              >
+                {eyebrow}
+              </div>
+            ) : null}
+            <div
+              style={{
+                fontSize: "70px",
+                fontWeight: 600,
+                lineHeight: 1.05,
+                letterSpacing: "-0.03em",
+                maxWidth: "1000px",
+              }}
+            >
+              {title}
+            </div>
+            <div
+              style={{
+                fontSize: "30px",
+                lineHeight: 1.35,
+                color: "rgba(255,255,255,0.6)",
+                maxWidth: "940px",
+              }}
+            >
+              {subtitle}
+            </div>
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              fontSize: "23px",
+              color: "rgba(255,255,255,0.5)",
+            }}
+          >
+            <div>agentclash.dev</div>
+            <div>Same challenge. Same tools. Agents race head-to-head.</div>
+          </div>
+        </div>
+      ),
+      SIZE,
+    );
+  } catch {
+    return new Response("Failed to generate the image", { status: 500 });
+  }
+}

--- a/web/src/app/og/route.tsx
+++ b/web/src/app/og/route.tsx
@@ -11,6 +11,11 @@ export const runtime = "nodejs";
 // Handler, so it must not be exported here.
 const SIZE = { width: 1200, height: 630 } as const;
 
+// The image is fully determined by its query params, so cache it hard — social
+// unfurlers (Slack, Telegram, crawlers) request these repeatedly, and
+// stale-while-revalidate still lets a template change propagate.
+const CACHE_CONTROL = "public, max-age=86400, stale-while-revalidate=604800";
+
 export function GET(request: Request): Response {
   try {
     const { searchParams } = new URL(request.url);
@@ -111,7 +116,7 @@ export function GET(request: Request): Response {
           </div>
         </div>
       ),
-      SIZE,
+      { ...SIZE, headers: { "Cache-Control": CACHE_CONTROL } },
     );
   } catch {
     return new Response("Failed to generate the image", { status: 500 });

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,7 +1,15 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
-import { JsonLd, SITE_URL, productSchema } from "@/components/marketing/json-ld";
+import {
+  JsonLd,
+  SITE_URL,
+  faqSchema,
+  organizationSchema,
+  productSchema,
+  websiteSchema,
+} from "@/components/marketing/json-ld";
+import { HOME_FAQ } from "@/lib/home-faq";
 import { AGENT_EVALUATION_FEATURES } from "@/lib/seo-features";
 import HomePage from "./landing";
 
@@ -21,19 +29,6 @@ const softwareApplicationSchema = productSchema({
   featureList: AGENT_EVALUATION_FEATURES,
 });
 
-const organizationSchema = {
-  "@context": "https://schema.org",
-  "@type": "Organization",
-  name: "AgentClash",
-  alternateName: "Agent Clash",
-  url: SITE_URL,
-  logo: `${SITE_URL}/icon.svg`,
-  sameAs: [
-    "https://github.com/agentclash/agentclash",
-    "https://www.npmjs.com/package/agentclash",
-  ],
-};
-
 export default async function RootPage() {
   const { user } = await withAuth();
   if (user) redirect("/dashboard");
@@ -41,7 +36,12 @@ export default async function RootPage() {
     <>
       <JsonLd
         id="agentclash-homepage-schema"
-        data={[softwareApplicationSchema, organizationSchema]}
+        data={[
+          softwareApplicationSchema,
+          organizationSchema(),
+          websiteSchema(),
+          faqSchema(HOME_FAQ),
+        ]}
       />
       <HomePage />
     </>

--- a/web/src/app/platform/agent-evaluation/page.tsx
+++ b/web/src/app/platform/agent-evaluation/page.tsx
@@ -42,6 +42,11 @@ const faqItems = [
     answer:
       "Yes. AgentClash can compare a candidate run against a baseline and fail CI when the candidate regresses on the scorecard or release gate you define.",
   },
+  {
+    question: "How is AgentClash different from prompt-evaluation tools?",
+    answer:
+      "Prompt-evaluation tools score the text a model returns from a single call. AgentClash evaluates multi-turn agents that take actions in a sandbox and scores the whole trajectory. See agentclash.dev/compare for a side-by-side with Braintrust, LangSmith, Promptfoo, Langfuse, Arize Phoenix, and OpenAI Evals.",
+  },
 ];
 
 const workflow = [

--- a/web/src/app/robots.test.ts
+++ b/web/src/app/robots.test.ts
@@ -1,11 +1,30 @@
 import { describe, expect, it } from "vitest";
-import robots from "./robots";
+import robots, { AI_CRAWLERS } from "./robots";
 
 describe("robots", () => {
   it("keeps public crawling open and advertises the canonical sitemap", () => {
-    expect(robots()).toEqual({
-      rules: [{ userAgent: "*", allow: "/" }],
-      sitemap: "https://www.agentclash.dev/sitemap.xml",
-    });
+    const result = robots();
+    const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
+
+    expect(rules[0]).toEqual({ userAgent: "*", allow: "/" });
+    expect(result.sitemap).toBe("https://www.agentclash.dev/sitemap.xml");
+  });
+
+  it("explicitly allows every AI crawler (training + answer engines)", () => {
+    const result = robots();
+    const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
+
+    for (const userAgent of AI_CRAWLERS) {
+      expect(rules).toContainEqual({ userAgent, allow: "/" });
+    }
+  });
+
+  it("never disallows any path", () => {
+    const result = robots();
+    const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
+
+    for (const rule of rules) {
+      expect(rule.disallow).toBeUndefined();
+    }
   });
 });

--- a/web/src/app/robots.ts
+++ b/web/src/app/robots.ts
@@ -1,8 +1,36 @@
 import type { MetadataRoute } from "next";
 
+// AI crawlers we explicitly welcome. Two families, both allowed on purpose:
+//   - answer/search bots (OAI-SearchBot, PerplexityBot, Claude-SearchBot, …)
+//     power live, cited AI answers — being crawlable here = being citable.
+//   - training bots (GPTBot, ClaudeBot, Google-Extended, CCBot, …) feed future
+//     models, so the next generation "knows" AgentClash and can recommend it.
+// For an open-source tool, broad allow maximizes discoverability. Default
+// "*: allow /" already lets these through; listing them is a deliberate,
+// documented signal of intent and a single place to change posture later.
+export const AI_CRAWLERS = [
+  "GPTBot",
+  "OAI-SearchBot",
+  "ChatGPT-User",
+  "ClaudeBot",
+  "Claude-User",
+  "Claude-SearchBot",
+  "PerplexityBot",
+  "Perplexity-User",
+  "Google-Extended",
+  "CCBot",
+  "Bytespider",
+  "meta-externalagent",
+  "Applebot-Extended",
+  "Amazonbot",
+] as const;
+
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: [{ userAgent: "*", allow: "/" }],
+    rules: [
+      { userAgent: "*", allow: "/" },
+      ...AI_CRAWLERS.map((userAgent) => ({ userAgent, allow: "/" })),
+    ],
     sitemap: "https://www.agentclash.dev/sitemap.xml",
   };
 }

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -97,4 +97,14 @@ describe("sitemap", () => {
       priority: 0.7,
     });
   });
+
+  it("includes the comparison hub and per-competitor pages", () => {
+    const entries = sitemap();
+    const urls = new Set(entries.map((entry) => entry.url));
+
+    expect(urls.has("https://www.agentclash.dev/compare")).toBe(true);
+    expect(
+      urls.has("https://www.agentclash.dev/compare/agentclash-vs-langsmith"),
+    ).toBe(true);
+  });
 });

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from "next";
 import { getAllPosts } from "@/lib/blog";
+import { COMPETITORS } from "@/lib/comparison-data";
 import { DOCS_ORIGIN, getAllDocPaths } from "@/lib/docs";
 
 export default function sitemap(): MetadataRoute.Sitemap {
@@ -15,6 +16,20 @@ export default function sitemap(): MetadataRoute.Sitemap {
     changeFrequency: "weekly" as const,
     priority: docPath === "/docs" ? 0.85 : 0.75,
   }));
+  const compare = [
+    {
+      url: `${DOCS_ORIGIN}/compare`,
+      lastModified: new Date(),
+      changeFrequency: "monthly" as const,
+      priority: 0.8,
+    },
+    ...COMPETITORS.map((competitor) => ({
+      url: `${DOCS_ORIGIN}/compare/${competitor.slug}`,
+      lastModified: new Date(),
+      changeFrequency: "monthly" as const,
+      priority: 0.75,
+    })),
+  ];
   return [
     {
       url: DOCS_ORIGIN,
@@ -76,6 +91,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "weekly",
       priority: 0.55,
     },
+    ...compare,
     ...docs,
     ...posts,
   ];

--- a/web/src/components/marketing/json-ld.test.ts
+++ b/web/src/components/marketing/json-ld.test.ts
@@ -3,8 +3,10 @@ import {
   articleSchema,
   blogIndexSchema,
   docsPageSchema,
+  organizationSchema,
   productSchema,
   SITE_URL,
+  websiteSchema,
 } from "./json-ld";
 
 describe("productSchema", () => {
@@ -247,5 +249,65 @@ describe("docsPageSchema", () => {
         ],
       }),
     ).toThrow("docsPageSchema faqItems are only supported for /docs");
+  });
+});
+
+describe("organizationSchema", () => {
+  it("builds a rich Organization node with site URL and social profiles", () => {
+    expect(organizationSchema()).toMatchObject({
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      name: "AgentClash",
+      url: SITE_URL,
+      sameAs: [
+        "https://github.com/agentclash/agentclash",
+        "https://www.npmjs.com/package/agentclash",
+      ],
+    });
+  });
+});
+
+describe("websiteSchema", () => {
+  it("builds a WebSite entity without a non-functional SearchAction", () => {
+    const schema = websiteSchema();
+
+    expect(schema).toMatchObject({
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      name: "AgentClash",
+      url: SITE_URL,
+      publisher: { "@type": "Organization", name: "AgentClash" },
+    });
+    expect(schema.potentialAction).toBeUndefined();
+  });
+});
+
+describe("docsPageSchema freshness dates", () => {
+  it("emits datePublished and dateModified on the TechArticle when provided", () => {
+    const schema = docsPageSchema({
+      title: "Quickstart",
+      description: "Run your first AgentClash eval.",
+      href: "/docs/getting-started/quickstart",
+      datePublished: "2026-01-01",
+      dateModified: "2026-05-01",
+    });
+    const techArticle = schema.find((node) => node["@type"] === "TechArticle");
+
+    expect(techArticle).toMatchObject({
+      datePublished: "2026-01-01",
+      dateModified: "2026-05-01",
+    });
+  });
+
+  it("omits dates when none are provided", () => {
+    const schema = docsPageSchema({
+      title: "Quickstart",
+      description: "Run your first AgentClash eval.",
+      href: "/docs/getting-started/quickstart",
+    });
+    const techArticle = schema.find((node) => node["@type"] === "TechArticle");
+
+    expect(techArticle?.datePublished).toBeUndefined();
+    expect(techArticle?.dateModified).toBeUndefined();
   });
 });

--- a/web/src/components/marketing/json-ld.tsx
+++ b/web/src/components/marketing/json-ld.tsx
@@ -93,10 +93,44 @@ export function publisherSchema(): Record<string, unknown> {
   return {
     "@type": "Organization",
     name: "AgentClash",
+    alternateName: "Agent Clash",
+    url: SITE_URL,
+    description:
+      "Open-source AI agent evaluation platform for racing agents head-to-head on real tasks with sandboxed tools, replay, scorecards, and CI regression gates.",
     logo: {
       "@type": "ImageObject",
       url: `${SITE_URL}/icon.svg`,
     },
+    sameAs: [
+      "https://github.com/agentclash/agentclash",
+      "https://www.npmjs.com/package/agentclash",
+    ],
+  };
+}
+
+// Standalone Organization node (with @context) for top-level use on the
+// homepage. Nested usages (publisher/author) keep using publisherSchema().
+export function organizationSchema(): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    ...publisherSchema(),
+  };
+}
+
+// WebSite entity establishes AgentClash as a named site/entity for search and
+// answer engines. No SearchAction: docs search is client-side with no
+// query-param results URL, and a non-functional sitelinks searchbox can be
+// flagged — entity establishment is the valuable part here.
+export function websiteSchema(): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: "AgentClash",
+    alternateName: "Agent Clash",
+    url: SITE_URL,
+    description:
+      "Open-source AI agent evaluation platform. Race agents head-to-head on real tasks with sandboxed tools, replay, scorecards, and CI regression gates.",
+    publisher: publisherSchema(),
   };
 }
 
@@ -105,12 +139,14 @@ export function articleSchema({
   description,
   url,
   datePublished,
+  dateModified,
   authorName,
 }: {
   headline: string;
   description: string;
   url: string;
   datePublished: string;
+  dateModified?: string;
   authorName: string;
 }): Record<string, unknown> {
   const absoluteUrl = url.startsWith("http") ? url : `${SITE_URL}${url}`;
@@ -133,7 +169,7 @@ export function articleSchema({
       height: 630,
     },
     datePublished,
-    dateModified: datePublished,
+    dateModified: dateModified ?? datePublished,
     author: {
       "@type": "Person",
       name: authorName,
@@ -202,11 +238,15 @@ export function docsPageSchema({
   description,
   href,
   faqItems = [],
+  datePublished,
+  dateModified,
 }: {
   title: string;
   description: string;
   href: string;
   faqItems?: Array<{ question: string; answer: string }>;
+  datePublished?: string;
+  dateModified?: string;
 }): Record<string, unknown>[] {
   const absoluteUrl = href.startsWith("http") ? href : `${SITE_URL}${href}`;
   const pathname = href.replace(/^https?:\/\/[^/]+/, "").replace(/\/+$/, "");
@@ -240,6 +280,10 @@ export function docsPageSchema({
       headline: title,
       description,
       url: absoluteUrl,
+      ...(datePublished ? { datePublished } : {}),
+      ...(dateModified ?? datePublished
+        ? { dateModified: dateModified ?? datePublished }
+        : {}),
       mainEntityOfPage: {
         "@type": "WebPage",
         "@id": absoluteUrl,

--- a/web/src/components/marketing/marketing-footer.tsx
+++ b/web/src/components/marketing/marketing-footer.tsx
@@ -9,6 +9,7 @@ const COLUMNS: Array<{
     links: [
       { href: "/#features", label: "Features" },
       { href: "/platform/agent-evaluation", label: "Agent evaluation" },
+      { href: "/compare", label: "Compare tools" },
       { href: "/docs", label: "Docs" },
       { href: "/docs/getting-started/quickstart", label: "Quickstart" },
       { href: "/docs/getting-started/self-host", label: "Self-host" },

--- a/web/src/lib/comparison-data.test.ts
+++ b/web/src/lib/comparison-data.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENTCLASH_COLUMN_INDEX,
+  COMPARISON_COLUMNS,
+  COMPARISON_ROWS,
+  COMPETITORS,
+  competitorFaq,
+  competitorRows,
+  competitorSlug,
+  getCompetitorBySlug,
+} from "./comparison-data";
+
+describe("comparison data", () => {
+  it("puts AgentClash first and highlighted", () => {
+    expect(AGENTCLASH_COLUMN_INDEX).toBe(0);
+    expect(COMPARISON_COLUMNS[0]).toMatchObject({
+      name: "AgentClash",
+      highlight: true,
+    });
+  });
+
+  it("keeps every row's cell count aligned with the columns", () => {
+    for (const row of COMPARISON_ROWS) {
+      expect(row.cells).toHaveLength(COMPARISON_COLUMNS.length);
+    }
+  });
+
+  it("derives one competitor per non-AgentClash column", () => {
+    expect(COMPETITORS).toHaveLength(COMPARISON_COLUMNS.length - 1);
+    for (const competitor of COMPETITORS) {
+      expect(COMPARISON_COLUMNS[competitor.columnIndex].highlight).toBeFalsy();
+      expect(competitor.whereItFits.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("builds vs-style slugs and resolves them back", () => {
+    expect(competitorSlug("LangSmith")).toBe("agentclash-vs-langsmith");
+    expect(competitorSlug("Arize Phoenix")).toBe("agentclash-vs-arize-phoenix");
+    expect(competitorSlug("OpenAI Evals")).toBe("agentclash-vs-openai-evals");
+
+    const langsmith = getCompetitorBySlug("agentclash-vs-langsmith");
+    expect(langsmith?.name).toBe("LangSmith");
+    expect(getCompetitorBySlug("does-not-exist")).toBeUndefined();
+  });
+
+  it("pairs AgentClash and competitor verdicts per row", () => {
+    const langsmith = getCompetitorBySlug("agentclash-vs-langsmith");
+    expect(langsmith).toBeDefined();
+    const rows = competitorRows(langsmith!);
+
+    expect(rows).toHaveLength(COMPARISON_ROWS.length);
+    expect(rows[0]).toMatchObject({
+      label: "Multi-turn agent loops",
+      agentclash: "yes",
+    });
+    expect(rows.every((row) => ["yes", "partial", "no"].includes(row.competitor))).toBe(
+      true,
+    );
+  });
+
+  it("generates three answer-shaped FAQ entries per competitor", () => {
+    const langsmith = getCompetitorBySlug("agentclash-vs-langsmith")!;
+    const faq = competitorFaq(langsmith);
+
+    expect(faq).toHaveLength(3);
+    expect(faq[0].question).toContain("LangSmith");
+    for (const entry of faq) {
+      expect(entry.answer.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/web/src/lib/comparison-data.ts
+++ b/web/src/lib/comparison-data.ts
@@ -1,0 +1,170 @@
+// Single source of truth for the AgentClash competitor comparison.
+//
+// These columns and rows power BOTH the landing-page comparison section and the
+// /compare pages (hub + per-competitor). Keeping them here prevents the two from
+// drifting apart. Verdicts are the positioning AgentClash already publishes on
+// the landing page: prompt-eval tools score single model calls; AgentClash races
+// tool-using agents head-to-head in a sandbox and scores the whole trajectory.
+
+export type MarkKind = "yes" | "partial" | "no";
+
+export type ComparisonColumn = {
+  name: string;
+  tag: string;
+  highlight?: boolean;
+};
+
+export const COMPARISON_COLUMNS: ComparisonColumn[] = [
+  { name: "AgentClash", tag: "agent eval", highlight: true },
+  { name: "Braintrust", tag: "prompt eval" },
+  { name: "LangSmith", tag: "prompt eval" },
+  { name: "Promptfoo", tag: "prompt eval" },
+  { name: "Langfuse", tag: "prompt eval" },
+  { name: "Arize Phoenix", tag: "prompt eval" },
+  { name: "OpenAI Evals", tag: "prompt eval" },
+];
+
+export type ComparisonRow = {
+  label: string;
+  sub: string;
+  cells: readonly MarkKind[];
+};
+
+export const COMPARISON_ROWS: ComparisonRow[] = [
+  {
+    label: "Multi-turn agent loops",
+    sub: "Think → tool → observe → repeat, for minutes, with a fresh environment. Not one prompt → one response.",
+    cells: ["yes", "partial", "partial", "no", "partial", "partial", "partial"],
+  },
+  {
+    label: "Sandboxed tool execution",
+    sub: "A fresh microVM per agent — real files, real shell, real network, real side effects.",
+    cells: ["yes", "no", "no", "no", "no", "no", "no"],
+  },
+  {
+    label: "Head-to-head concurrent race",
+    sub: "Every model runs the same task at the same time, on the same budget. No staggered runs, no warm caches.",
+    cells: ["yes", "no", "no", "no", "no", "no", "no"],
+  },
+  {
+    label: "Trajectory scoring",
+    sub: "Judges the path, not just the final answer — tool-choice efficiency, recovery from error, scope discipline.",
+    cells: ["yes", "partial", "partial", "no", "partial", "partial", "no"],
+  },
+  {
+    label: "Cross-provider tool-call normalisation",
+    sub: "One schema across OpenAI, Anthropic, Gemini, xAI, Mistral, OpenRouter. Errors classified, retries sane.",
+    cells: ["yes", "partial", "partial", "partial", "partial", "partial", "no"],
+  },
+  {
+    label: "Four-vantage composite verdict",
+    sub: "Deterministic + mathematic + behavioural + LLM, with consensus aggregation and weights you control.",
+    cells: ["yes", "partial", "partial", "partial", "partial", "partial", "partial"],
+  },
+  {
+    label: "Failures auto-promote to regression",
+    sub: "Flunked traces freeze into permanent tests and replay in every future race, by default.",
+    cells: ["yes", "partial", "partial", "partial", "partial", "partial", "no"],
+  },
+];
+
+// Human-readable, crawlable cell labels for the semantic comparison <table> on
+// the /compare pages (the landing page renders dot glyphs instead).
+export const MARK_LABEL: Record<MarkKind, string> = {
+  yes: "Yes",
+  partial: "Partial",
+  no: "No",
+};
+
+export const AGENTCLASH_COLUMN_INDEX = COMPARISON_COLUMNS.findIndex(
+  (column) => column.highlight,
+);
+
+function toKebabCase(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function competitorSlug(name: string): string {
+  return `agentclash-vs-${toKebabCase(name)}`;
+}
+
+export type Competitor = {
+  name: string;
+  tag: string;
+  slug: string;
+  columnIndex: number;
+  // Honest, category-level note on where the competitor is the stronger fit.
+  // Complimentary by design — establishes credibility and avoids overclaiming.
+  whereItFits: string;
+};
+
+const COMPETITOR_NOTES: Record<string, string> = {
+  Braintrust:
+    "Braintrust is a strong choice for prompt and LLM evaluation — datasets, scoring functions, and logging across your app's model calls. Reach for it when the unit you evaluate is a prompt or a single model response.",
+  LangSmith:
+    "LangSmith excels at tracing, debugging, and evaluating LLM and LangChain apps — deep observability over your chains and prompts. Pick it when tracing and prompt/dataset evals are the priority.",
+  Promptfoo:
+    "Promptfoo is an excellent open-source, config-first tool for prompt testing and red-teaming across providers. It's a great fit for fast, declarative assertions over model outputs.",
+  Langfuse:
+    "Langfuse is a strong open-source LLM observability and tracing platform with evals layered on top. Choose it when tracing and analytics over production LLM calls matter most.",
+  "Arize Phoenix":
+    "Arize Phoenix is great for LLM and ML observability, tracing, and evaluation — especially RAG inspection and production monitoring. Use it when observability and offline evals are the focus.",
+  "OpenAI Evals":
+    "OpenAI Evals is a solid open framework for building and running model and prompt evals, especially within the OpenAI ecosystem. It fits when you're scoring model outputs against datasets.",
+};
+
+export const COMPETITORS: Competitor[] = COMPARISON_COLUMNS.map(
+  (column, columnIndex) => ({ column, columnIndex }),
+)
+  .filter(({ column }) => !column.highlight)
+  .map(({ column, columnIndex }) => ({
+    name: column.name,
+    tag: column.tag,
+    slug: competitorSlug(column.name),
+    columnIndex,
+    whereItFits: COMPETITOR_NOTES[column.name] ?? "",
+  }));
+
+export function getCompetitorBySlug(slug: string): Competitor | undefined {
+  return COMPETITORS.find((competitor) => competitor.slug === slug);
+}
+
+export type CompetitorRow = {
+  label: string;
+  sub: string;
+  agentclash: MarkKind;
+  competitor: MarkKind;
+};
+
+// Per-row AgentClash-vs-competitor verdict pairs for a single competitor page.
+export function competitorRows(competitor: Competitor): CompetitorRow[] {
+  return COMPARISON_ROWS.map((row) => ({
+    label: row.label,
+    sub: row.sub,
+    agentclash: row.cells[AGENTCLASH_COLUMN_INDEX],
+    competitor: row.cells[competitor.columnIndex],
+  }));
+}
+
+// Answer-shaped Q&A for a competitor page (rendered visibly + as FAQPage JSON-LD).
+export function competitorFaq(
+  competitor: Competitor,
+): Array<{ question: string; answer: string }> {
+  return [
+    {
+      question: `Is AgentClash a ${competitor.name} alternative?`,
+      answer: `AgentClash and ${competitor.name} overlap but solve different problems. ${competitor.name} is a ${competitor.tag} tool, while AgentClash is an agent-evaluation engine that races agents head-to-head on real tasks in a sandbox, scores the full trajectory, and gates CI on regressions. If you need to evaluate tool-using agents end-to-end, AgentClash is the closer fit; for single-call prompt and output scoring, ${competitor.name} may be all you need.`,
+    },
+    {
+      question: `What is the difference between AgentClash and ${competitor.name}?`,
+      answer: `${competitor.whereItFits} AgentClash focuses on multi-turn agents that take actions: each model gets a fresh microVM, real tools, the same time budget, and a head-to-head race, and the verdict scores the trajectory — not just the final text.`,
+    },
+    {
+      question: `Can I use AgentClash and ${competitor.name} together?`,
+      answer: `Yes. Many teams keep ${competitor.name} for prompt-level evaluation and observability and add AgentClash for end-to-end, sandboxed agent races and CI regression gates. They are complementary layers of an evaluation stack.`,
+    },
+  ];
+}

--- a/web/src/lib/comparison-data.ts
+++ b/web/src/lib/comparison-data.ts
@@ -24,10 +24,23 @@ export const COMPARISON_COLUMNS: ComparisonColumn[] = [
   { name: "OpenAI Evals", tag: "prompt eval" },
 ];
 
+// One cell per COMPARISON_COLUMNS entry. Fixed-length tuple so a row with the
+// wrong number of cells fails to compile (keep the length in sync with the
+// number of columns if a competitor is ever added or removed).
+export type Cells = readonly [
+  MarkKind,
+  MarkKind,
+  MarkKind,
+  MarkKind,
+  MarkKind,
+  MarkKind,
+  MarkKind,
+];
+
 export type ComparisonRow = {
   label: string;
   sub: string;
-  cells: readonly MarkKind[];
+  cells: Cells;
 };
 
 export const COMPARISON_ROWS: ComparisonRow[] = [

--- a/web/src/lib/docs.test.ts
+++ b/web/src/lib/docs.test.ts
@@ -563,4 +563,20 @@ describe("agent skill docs", () => {
     expect(bundle).toContain("name: agentclash-runtime-resources-setup");
     expect(bundle).toContain("credential_reference: \"workspace-secret://KEY\"");
   });
+
+  it("includes a Highlights block and the comparison page in llms.txt", () => {
+    const index = buildLlmsIndex("https://example.test");
+
+    expect(index).toContain("## Highlights");
+    expect(index).toContain("Agent evaluation, not prompt evaluation");
+    expect(index).toContain("https://example.test/compare");
+  });
+
+  it("lists the comparison hub as a public product page in search data", () => {
+    const index = getDocsSearchIndex();
+    const compare = index.find((item) => item.href === "/compare");
+
+    expect(compare?.title).toBe("AgentClash vs prompt-eval tools");
+    expect(compare?.searchText).toContain("alternative");
+  });
 });

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -36,6 +36,12 @@ const BACKEND_ENV_FILE = path.join(REPO_ROOT, "backend", ".env.example");
 
 export const DOCS_ORIGIN = "https://www.agentclash.dev";
 
+// Build/generation timestamp. Used as an honest `dateModified` fallback for docs
+// that carry no frontmatter date — these pages (including generated CLI/config
+// references and agent-skill pages) are regenerated from source on each build,
+// so "last generated" is a truthful freshness signal for answer engines.
+export const SITE_GENERATED_AT = new Date().toISOString();
+
 type PublicProductPage = {
   title: string;
   href: string;
@@ -59,6 +65,14 @@ const PUBLIC_PRODUCT_PAGES: PublicProductPage[] = [
       "Public page for baseline-versus-candidate agent regression testing, pull request gates, and release evidence.",
     searchKeywords:
       "AI agent regression testing agent evaluation CI gates pull request gates release gates baseline candidate comparisons replay evidence scorecards challenge packs agent eval regression suite",
+  },
+  {
+    title: "AgentClash vs prompt-eval tools",
+    href: "/compare",
+    description:
+      "Compare AgentClash with Braintrust, LangSmith, Promptfoo, Langfuse, Arize Phoenix, and OpenAI Evals — agent evaluation versus prompt evaluation.",
+    searchKeywords:
+      "compare comparison alternative alternatives AgentClash vs Braintrust LangSmith Promptfoo Langfuse Arize Phoenix OpenAI Evals agent evaluation prompt evaluation best AI agent eval tools",
   },
 ];
 
@@ -95,6 +109,8 @@ export type DocPage = {
   description: string;
   content: string;
   sectionTitle?: string;
+  datePublished?: string;
+  dateModified?: string;
   headings: DocHeading[];
 };
 
@@ -890,6 +906,7 @@ function createDocPage(
   description: string,
   content: string,
   sectionTitle?: string,
+  dates?: { datePublished?: string; dateModified?: string },
 ): DocPage {
   return {
     slug,
@@ -898,6 +915,9 @@ function createDocPage(
     description,
     content,
     sectionTitle,
+    datePublished: dates?.datePublished,
+    dateModified:
+      dates?.dateModified ?? dates?.datePublished ?? SITE_GENERATED_AT,
     headings: extractHeadings(content),
   };
 }
@@ -910,12 +930,17 @@ function getFileDocBySlug(slug: string[]) {
   const { data, content } = matter(raw);
   const href = slugToHref(slug);
 
+  const datePublished = typeof data.date === "string" ? data.date : undefined;
+  const dateModified =
+    typeof data.updated === "string" ? data.updated : datePublished;
+
   return createDocPage(
     slug,
     data.title as string,
     data.description as string,
     content,
     findSectionTitle(href),
+    { datePublished, dateModified },
   );
 }
 
@@ -1597,6 +1622,15 @@ export function buildLlmsIndex(origin = DOCS_ORIGIN) {
     "",
     "Use this index when you want the shortest machine-readable map of the public docs and selected product pages. Fetch `/llms-full.txt` for the bundled corpus, or use the `/docs-md/...` links below for page-level markdown exports.",
     "",
+    "## Highlights",
+    "",
+    "- Open-source (MIT), self-hostable AI agent evaluation platform; CLI on npm as `agentclash`.",
+    "- Races agents head-to-head on the same task, tools, and time budget in a fresh per-agent sandbox (microVM).",
+    "- 300+ models via OpenRouter, plus first-class OpenAI, Anthropic, Gemini, xAI, Mistral, and OpenRouter providers.",
+    "- Scores the whole trajectory — correctness, cost, latency, and tool strategy — with replay evidence and scorecards.",
+    "- Promotes failures into reusable regression tests and gates CI on baseline-versus-candidate comparisons.",
+    `- Agent evaluation, not prompt evaluation — compare AgentClash with Braintrust, LangSmith, Promptfoo, Langfuse, Arize Phoenix, and OpenAI Evals at ${origin}/compare.`,
+    "",
     "## Core entrypoints",
     "",
     `- [Docs home](${origin}/docs-md) - overview, navigation, and starting points.`,
@@ -1662,6 +1696,8 @@ export function buildLlmsFull(origin = DOCS_ORIGIN) {
     `Machine-readable index: ${origin}/llms.txt`,
     "",
     "This file concatenates the currently shipped AgentClash docs pages and selected product page links into one markdown-oriented bundle for assistants, coding agents, and local retrieval pipelines.",
+    "",
+    "AgentClash is an open-source (MIT) AI agent evaluation platform: it races agents head-to-head on the same task, tools, and time budget in a fresh per-agent sandbox, scores the whole trajectory, and gates CI on regressions. It is agent evaluation, not prompt evaluation.",
     "",
     "## Public product pages",
     "",

--- a/web/src/lib/home-faq.test.ts
+++ b/web/src/lib/home-faq.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { HOME_FAQ } from "./home-faq";
+
+describe("HOME_FAQ", () => {
+  it("provides several non-empty, answer-shaped Q&A entries", () => {
+    expect(HOME_FAQ.length).toBeGreaterThanOrEqual(5);
+    for (const entry of HOME_FAQ) {
+      expect(entry.question.trim().length).toBeGreaterThan(0);
+      expect(entry.question.trim().endsWith("?")).toBe(true);
+      expect(entry.answer.trim().length).toBeGreaterThan(40);
+    }
+  });
+
+  it("covers the agent-eval-vs-prompt-eval positioning", () => {
+    const joined = HOME_FAQ.map((entry) => entry.question).join(" ");
+    expect(joined).toContain("What is AgentClash?");
+    expect(joined.toLowerCase()).toContain("prompt-evaluation");
+  });
+});

--- a/web/src/lib/home-faq.ts
+++ b/web/src/lib/home-faq.ts
@@ -1,0 +1,38 @@
+// Homepage FAQ. Rendered visibly in the landing page AND emitted as FAQPage
+// JSON-LD on the homepage (see app/page.tsx) — kept in one place so the
+// structured data always mirrors the visible content (a Google requirement).
+// Answers are self-contained and answer-shaped so answer engines can extract
+// them directly.
+export const HOME_FAQ: Array<{ question: string; answer: string }> = [
+  {
+    question: "What is AgentClash?",
+    answer:
+      "AgentClash is an open-source AI agent evaluation platform. It races coding, research, support, and ops agents head-to-head on the same real task — same tools, same constraints, same time budget — then scores the full trajectory and lets you replay every action.",
+  },
+  {
+    question:
+      "How is AgentClash different from prompt-evaluation tools like LangSmith or Braintrust?",
+    answer:
+      "Prompt-evaluation tools score the text a model returns from a single call. AgentClash evaluates multi-turn agents that take actions in a real sandbox and scores the whole trajectory — tool choices, cost, latency, and recovery — not just the final answer. See agentclash.dev/compare for a side-by-side.",
+  },
+  {
+    question: "Can I run AgentClash in CI?",
+    answer:
+      "Yes. AgentClash compares a candidate run against a baseline and fails CI when the candidate regresses on the scorecard or release gate you define. Failed runs can be promoted into permanent regression tests that replay in every future race.",
+  },
+  {
+    question: "Is AgentClash open source, and can I self-host it?",
+    answer:
+      "Yes. AgentClash is open source under the MIT license. You can self-host the full stack or run against the hosted backend, and the CLI installs from npm as the agentclash package.",
+  },
+  {
+    question: "Which models and providers does AgentClash support?",
+    answer:
+      "300+ models via OpenRouter, plus first-class OpenAI, Anthropic, Gemini, xAI, Mistral, and OpenRouter providers. Tool calls are normalised to a single schema across providers so races stay fair.",
+  },
+  {
+    question: "How do I get started with AgentClash?",
+    answer:
+      "Install the CLI with npm install -g agentclash (or run against the hosted backend), then follow the quickstart to author a challenge pack and start your first head-to-head race.",
+  },
+];

--- a/web/src/lib/seo.test.ts
+++ b/web/src/lib/seo.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { ogImageUrl } from "./seo";
+
+describe("ogImageUrl", () => {
+  it("builds a root-relative /og URL with encoded params", () => {
+    const url = ogImageUrl({
+      title: "AgentClash vs LangSmith",
+      subtitle: "agent eval vs prompt eval",
+      kind: "Compare",
+    });
+
+    expect(url.startsWith("/og?")).toBe(true);
+    const params = new URLSearchParams(url.slice("/og?".length));
+    expect(params.get("title")).toBe("AgentClash vs LangSmith");
+    expect(params.get("subtitle")).toBe("agent eval vs prompt eval");
+    expect(params.get("kind")).toBe("Compare");
+  });
+
+  it("omits optional params when not provided", () => {
+    const url = ogImageUrl({ title: "AgentClash" });
+
+    const params = new URLSearchParams(url.slice("/og?".length));
+    expect(params.get("title")).toBe("AgentClash");
+    expect(params.has("subtitle")).toBe(false);
+    expect(params.has("kind")).toBe(false);
+  });
+});

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -10,3 +10,21 @@ export const blogRssAlternate = {
     },
   ],
 } satisfies AlternateTypes;
+
+// Root-relative URL for the dynamic Open Graph image route (app/og/route.tsx).
+// metadataBase upgrades it to absolute in the rendered OG/Twitter tags, so each
+// page gets a tailored social card instead of one shared static image.
+export function ogImageUrl({
+  title,
+  subtitle,
+  kind,
+}: {
+  title: string;
+  subtitle?: string;
+  kind?: string;
+}): string {
+  const search = new URLSearchParams({ title });
+  if (subtitle) search.set("subtitle", subtitle);
+  if (kind) search.set("kind", kind);
+  return `/og?${search.toString()}`;
+}


### PR DESCRIPTION
## What & why

Maximize discoverability for both **search engines** (SEO) and **AI agents / answer engines** (AEO/GEO). An audit found the foundation was already strong (metadata, canonicals, sitemap, core JSON-LD, `llms.txt`/`llms-full.txt`/`docs-md`, `AGENTS.md`, Agent Skills), so this is **gap-closing + leverage** — not a rebuild. The biggest content lever: the team's competitor matrix lived only inside the landing page; this turns it into indexable, AI-citable pages.

## Changes

**Technical**
- `robots.ts` — explicitly allow all major AI crawlers (GPTBot, ClaudeBot, OAI-SearchBot, PerplexityBot, Claude-SearchBot, Google-Extended, CCBot, …), both training and answer/search bots, to maximize being learned-by and cited-by models.
- JSON-LD — add a `WebSite` entity, enrich `Organization` (url, description, sameAs), add a homepage `FAQPage`, and add freshness dates to docs (`TechArticle`) + articles (honest: frontmatter date, else build/deploy time — no fabricated dates).
- Dynamic per-page OG images via `next/og` `ImageResponse` (`/og` route); blog, docs, and compare pages now get tailored social cards.
- Web manifest (`manifest.ts`), `theme-color` (viewport export), Vercel Speed Insights, and env-driven Google/Bing verification (`NEXT_PUBLIC_GSC_VERIFICATION` / `NEXT_PUBLIC_BING_VERIFICATION`).
- `llms.txt` Highlights block (stats + comparison pointer).

**Content**
- `web/src/lib/comparison-data.ts` — single source of truth for the competitor matrix, reused by the landing page (no drift).
- `/compare` hub + `/compare/agentclash-vs-{braintrust,langsmith,promptfoo,langfuse,arize-phoenix,openai-evals}` — semantic comparison tables, "agent eval vs prompt eval" framing, honest "where X fits" sections, and `FAQPage`/`BreadcrumbList`/`TechArticle` JSON-LD. Statically generated; unknown slugs 404.
- Homepage FAQ (visible + `FAQPage` schema) and a cross-linking FAQ entry on the agent-evaluation page.
- Wired `/compare` into `sitemap.ts`, `llms.txt`, docs search, and the footer.

## Verification
- `npx tsc --noEmit` ✓ · `pnpm lint` ✓ (0 errors) · `pnpm test` ✓ **358 pass / 3 skipped** (added happy + failure tests) · `pnpm build` ✓ **92/92 static pages**, compare pages prerendered SSG.
- Runtime curl checks on the built server: `robots.txt` lists AI crawlers, `llms.txt` has Highlights, `/compare` 200 + JSON-LD, `/compare/agentclash-vs-langsmith` 200, `/og?...` → `image/png` 1200×630, unknown competitor → 404, homepage emits `WebSite` + `FAQPage`.

## ⚠️ Before merge / reviewer note
- **Review the `/compare` competitor claims** — drawn from verdicts already on the landing page and phrased category-level, but they're public statements about other products (Braintrust, LangSmith, Promptfoo, Langfuse, Arize Phoenix, OpenAI Evals).
- Set `NEXT_PUBLIC_GSC_VERIFICATION` / `NEXT_PUBLIC_BING_VERIFICATION` in Vercel env once the Search Console / Bing properties exist (renders nothing until set).
- Confirm apex → `www` 301 so the canonical host stays consistent.

## Off-page follow-ups (intentionally not committed to the OSS repo)
GitHub repo topics + About website + README badges; npm `keywords`/`description`/`homepage`; submit to awesome-* lists and Agent Skills marketplaces; Show HN / Product Hunt / dev.to posts; submit `sitemap.xml` to Search Console + Bing; monthly AI-citation checks (ask ChatGPT/Perplexity/Claude the target questions) + AI-referral tracking in analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
