### PR TITLE
fix(web): sync package-lock.json with @vercel/speed-insights

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,6 +16,7 @@
         "@react-three/fiber": "^9.6.0",
         "@vercel/analytics": "^2.0.1",
         "@vercel/blob": "^2.3.1",
+        "@vercel/speed-insights": "^2.0.0",
         "@workos-inc/authkit-nextjs": "^3.0.0",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-web-links": "^0.11.0",
@@ -8268,6 +8269,44 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react": {


### PR DESCRIPTION
Unbreaks main CI after #902. CI uses `npm ci` (package-lock.json), but the new `@vercel/speed-insights` dep was only synced into `pnpm-lock.yaml`, so `npm ci` failed with "Missing: @vercel/speed-insights from lock file". This syncs `package-lock.json` (+39 lines, lock-only). Validated locally: `npm ci` resolves cleanly, plus tsc/lint/test/build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)