### PR TITLE
fix: allow non-manual dataset example sources in production

### DIFF
--- a/backend/db/migrations/00055_dataset_example_source_check.sql
+++ b/backend/db/migrations/00055_dataset_example_source_check.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- Production was observed rejecting non-manual example sources (import/trace/synthetic)
+-- with a check-constraint violation surfaced as HTTP 500. Re-assert the intended enum.
+ALTER TABLE dataset_examples DROP CONSTRAINT IF EXISTS dataset_examples_source_check;
+ALTER TABLE dataset_examples ADD CONSTRAINT dataset_examples_source_check
+    CHECK (source IN ('manual', 'import', 'trace', 'synthetic', 'promotion'));
+
+-- +goose Down
+ALTER TABLE dataset_examples DROP CONSTRAINT IF EXISTS dataset_examples_source_check;
+ALTER TABLE dataset_examples ADD CONSTRAINT dataset_examples_source_check
+    CHECK (source IN ('manual', 'import', 'trace', 'synthetic', 'promotion'));

--- a/backend/internal/repository/datasets.go
+++ b/backend/internal/repository/datasets.go
@@ -283,7 +283,7 @@ func upsertDatasetExampleWithQueries(ctx context.Context, q *repositorysqlc.Quer
 		})
 	}
 	if err != nil {
-		return repositorysqlc.DatasetExample{}, fmt.Errorf("upsert dataset example: %w", err)
+		return repositorysqlc.DatasetExample{}, mapDatasetExampleUpsertError(params.Source, err)
 	}
 	_, err = q.InsertDatasetExampleRevision(ctx, repositorysqlc.InsertDatasetExampleRevisionParams{
 		DatasetID: params.DatasetID, ExampleID: &row.ID, Operation: operation, Before: beforeJSON,
@@ -578,6 +578,19 @@ func datasetManifestChecksum(revisions []repositorysqlc.DatasetExampleRevision) 
 		h.Write(revision.After)
 	}
 	return "sha256:" + hex.EncodeToString(h.Sum(nil))
+}
+
+func mapDatasetExampleUpsertError(source domain.DatasetExampleSource, err error) error {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23514" {
+		switch {
+		case strings.Contains(pgErr.ConstraintName, "source"):
+			return fmt.Errorf("%w: %q", domain.ErrInvalidDatasetExampleSource, source)
+		case strings.Contains(pgErr.ConstraintName, "status"):
+			return fmt.Errorf("%w: invalid status", domain.ErrInvalidDatasetExampleStatus)
+		}
+	}
+	return fmt.Errorf("upsert dataset example: %w", err)
 }
 
 func nullableJSON(raw json.RawMessage) []byte {


### PR DESCRIPTION
## Summary
- Fixes production `dataset import` and any example with `source=import|trace|synthetic|promotion` returning HTTP 500.
- Adds migration `00055` to re-assert the intended `dataset_examples.source` check constraint.
- Maps Postgres check-constraint violations to `validation_error` instead of opaque `internal_error`.

## Root cause
CLI QA against `https://api.agentclash.dev` showed:
- `dataset example add --source manual` ✅
- `dataset example add --source import|trace` ❌ HTTP 500
- `dataset import` ❌ HTTP 500 (uses `source=import`)

Likely a stale DB check constraint on production despite migration `00050` defining the full enum.

## Test plan
- [x] `cd backend && go test -short -race -count=1 ./internal/repository/... ./internal/api/... -run 'Dataset|Import'`
- [ ] Apply migration on production (`make db-migrate` / deploy pipeline)
- [ ] Re-run: `agentclash dataset import <id> file.jsonl --format openai`
- [ ] Re-run: `agentclash dataset generate ...` after backend deploy from #906 lands