### PR TITLE
fix: dataset QA follow-ups (nil tags, counts, provider match)

### DIFF
--- a/backend/db/queries/datasets.sql
+++ b/backend/db/queries/datasets.sql
@@ -25,9 +25,15 @@ WHERE w.id = @workspace_id
 RETURNING *;
 
 -- name: GetDatasetByID :one
-SELECT *
-FROM datasets
-WHERE id = @id
+SELECT
+    d.id, d.organization_id, d.workspace_id, d.slug, d.name, d.description, d.input_schema, d.input_schema_enforced, d.default_challenge_pack_version_id, d.created_by, d.created_at, d.updated_at, d.archived_at,
+    count(DISTINCT e.id) FILTER (WHERE e.status = 'active')::bigint AS active_example_count,
+    count(DISTINCT v.id)::bigint AS version_count
+FROM datasets d
+LEFT JOIN dataset_examples e ON e.dataset_id = d.id
+LEFT JOIN dataset_versions v ON v.dataset_id = d.id
+WHERE d.id = @id
+GROUP BY d.id
 LIMIT 1;
 
 -- name: LockActiveDatasetForVersion :one

--- a/backend/internal/api/datasets_generations.go
+++ b/backend/internal/api/datasets_generations.go
@@ -98,6 +98,12 @@ func (m *DatasetManager) StartDatasetGeneration(ctx context.Context, caller Call
 	if modelAlias.WorkspaceID == nil || *modelAlias.WorkspaceID != input.WorkspaceID {
 		return repository.DatasetGenerationJob{}, ErrForbidden
 	}
+	if !strings.EqualFold(providerAccount.ProviderKey, modelAlias.CatalogProviderKey) {
+		return repository.DatasetGenerationJob{}, errors.New("provider_account provider does not match model alias provider")
+	}
+	if modelAlias.ProviderAccountID != nil && *modelAlias.ProviderAccountID != input.ProviderAccountID {
+		return repository.DatasetGenerationJob{}, errors.New("provider_account_id does not match model alias provider account")
+	}
 
 	active := domain.DatasetExampleStatusActive
 	examples, err := genRepo.ListDatasetExamplesByDatasetID(ctx, repository.ListDatasetExamplesParams{

--- a/backend/internal/api/datasets_generations_test.go
+++ b/backend/internal/api/datasets_generations_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/agentclash/agentclash/backend/internal/domain"
@@ -85,6 +86,31 @@ func TestStartDatasetGenerationRequiresManageDatasets(t *testing.T) {
 	}
 }
 
+func TestStartDatasetGenerationRejectsProviderMismatch(t *testing.T) {
+	wsID := uuid.New()
+	datasetID := uuid.New()
+	providerID := uuid.New()
+	modelAliasID := uuid.New()
+	repo := &datasetGenerationFakeRepo{
+		datasetImportFakeRepo: newDatasetImportFakeRepo(wsID, datasetID),
+		providerAccount:       repository.ProviderAccountRow{ID: providerID, WorkspaceID: &wsID, ProviderKey: "openai"},
+		modelAlias: repository.ModelAliasRow{
+			ID: modelAliasID, WorkspaceID: &wsID, ProviderAccountID: &providerID, CatalogProviderKey: "google",
+		},
+	}
+	repo.examples = []repository.DatasetExample{{
+		ID: uuid.New(), DatasetID: datasetID, Input: json.RawMessage(`{"q":"seed"}`), Status: domain.DatasetExampleStatusActive,
+	}}
+	manager := NewDatasetManager(allowWorkspaceAuthorizer{}, repo).WithGenerationWorkflowStarter(datasetGenerationFakeStarter{})
+	_, err := manager.StartDatasetGeneration(context.Background(), Caller{UserID: uuid.New()}, StartDatasetGenerationInput{
+		WorkspaceID: wsID, DatasetID: datasetID, Strategy: "self_instruct", TargetCount: 1,
+		ProviderAccountID: providerID, ModelAliasID: modelAliasID,
+	})
+	if err == nil || !strings.Contains(err.Error(), "provider") {
+		t.Fatalf("expected provider mismatch error, got %v", err)
+	}
+}
+
 func TestStartDatasetGenerationCreatesJob(t *testing.T) {
 	wsID := uuid.New()
 	datasetID := uuid.New()
@@ -93,7 +119,9 @@ func TestStartDatasetGenerationCreatesJob(t *testing.T) {
 	repo := &datasetGenerationFakeRepo{
 		datasetImportFakeRepo: newDatasetImportFakeRepo(wsID, datasetID),
 		providerAccount:       repository.ProviderAccountRow{ID: providerID, WorkspaceID: &wsID, ProviderKey: "openai"},
-		modelAlias:            repository.ModelAliasRow{ID: modelAliasID, WorkspaceID: &wsID},
+		modelAlias: repository.ModelAliasRow{
+			ID: modelAliasID, WorkspaceID: &wsID, ProviderAccountID: &providerID, CatalogProviderKey: "openai",
+		},
 	}
 	repo.examples = []repository.DatasetExample{{
 		ID:        uuid.New(),

--- a/backend/internal/repository/datasets.go
+++ b/backend/internal/repository/datasets.go
@@ -163,7 +163,7 @@ func (r *Repository) GetDatasetByID(ctx context.Context, id uuid.UUID) (Dataset,
 		}
 		return Dataset{}, fmt.Errorf("get dataset by id: %w", err)
 	}
-	return mapDataset(row)
+	return mapDatasetDetailRow(row)
 }
 
 func (r *Repository) ListDatasetsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID, limit, offset int32) ([]Dataset, error) {
@@ -248,7 +248,15 @@ func (r *Repository) UpsertDatasetExample(ctx context.Context, params UpsertData
 	return mapDatasetExample(row)
 }
 
+func datasetExampleTags(tags []string) []string {
+	if tags == nil {
+		return []string{}
+	}
+	return tags
+}
+
 func upsertDatasetExampleWithQueries(ctx context.Context, q *repositorysqlc.Queries, params UpsertDatasetExampleParams) (repositorysqlc.DatasetExample, error) {
+	tags := datasetExampleTags(params.Tags)
 	var before *repositorysqlc.DatasetExample
 	if params.ExternalID != nil && strings.TrimSpace(*params.ExternalID) != "" {
 		row, err := q.GetDatasetExampleByExternalID(ctx, repositorysqlc.GetDatasetExampleByExternalIDParams{
@@ -271,13 +279,13 @@ func upsertDatasetExampleWithQueries(ctx context.Context, q *repositorysqlc.Quer
 		beforeJSON = datasetExampleRevisionJSON(*before)
 		row, err = q.UpdateDatasetExample(ctx, repositorysqlc.UpdateDatasetExampleParams{
 			ID: before.ID, Input: params.Input, Expected: nullableJSON(params.Expected), Metadata: datasetDefaultJSONObject(params.Metadata),
-			Tags: params.Tags, Status: string(params.Status), Source: string(params.Source), SourceRunID: params.SourceRunID,
+			Tags: tags, Status: string(params.Status), Source: string(params.Source), SourceRunID: params.SourceRunID,
 			SourceTraceID: params.SourceTraceID, SourcePlatform: params.SourcePlatform, ArtifactID: params.ArtifactID,
 		})
 	} else {
 		row, err = q.InsertDatasetExample(ctx, repositorysqlc.InsertDatasetExampleParams{
 			DatasetID: params.DatasetID, ExternalID: cleanStringPtr(params.ExternalID), Input: params.Input, Expected: nullableJSON(params.Expected),
-			Metadata: datasetDefaultJSONObject(params.Metadata), Tags: params.Tags, Status: string(params.Status), Source: string(params.Source),
+			Metadata: datasetDefaultJSONObject(params.Metadata), Tags: tags, Status: string(params.Status), Source: string(params.Source),
 			SourceRunID: params.SourceRunID, SourceTraceID: params.SourceTraceID, SourcePlatform: params.SourcePlatform,
 			ArtifactID: params.ArtifactID, CreatedBy: params.Actor,
 		})
@@ -508,6 +516,15 @@ func mapDataset(row repositorysqlc.Dataset) (Dataset, error) {
 }
 
 func mapDatasetListRow(row repositorysqlc.ListDatasetsByWorkspaceIDRow) (Dataset, error) {
+	return mapDatasetDetailRow(repositorysqlc.GetDatasetByIDRow{
+		ID: row.ID, OrganizationID: row.OrganizationID, WorkspaceID: row.WorkspaceID, Slug: row.Slug, Name: row.Name,
+		Description: row.Description, InputSchema: row.InputSchema, InputSchemaEnforced: row.InputSchemaEnforced,
+		DefaultChallengePackVersionID: row.DefaultChallengePackVersionID, CreatedBy: row.CreatedBy, CreatedAt: row.CreatedAt,
+		UpdatedAt: row.UpdatedAt, ArchivedAt: row.ArchivedAt, ActiveExampleCount: row.ActiveExampleCount, VersionCount: row.VersionCount,
+	})
+}
+
+func mapDatasetDetailRow(row repositorysqlc.GetDatasetByIDRow) (Dataset, error) {
 	dataset, err := mapDataset(repositorysqlc.Dataset{
 		ID: row.ID, OrganizationID: row.OrganizationID, WorkspaceID: row.WorkspaceID, Slug: row.Slug, Name: row.Name,
 		Description: row.Description, InputSchema: row.InputSchema, InputSchemaEnforced: row.InputSchemaEnforced,

--- a/backend/internal/repository/sqlc/datasets.sql.go
+++ b/backend/internal/repository/sqlc/datasets.sql.go
@@ -202,9 +202,15 @@ func (q *Queries) CreateDatasetVersion(ctx context.Context, arg CreateDatasetVer
 }
 
 const getDatasetByID = `-- name: GetDatasetByID :one
-SELECT id, organization_id, workspace_id, slug, name, description, input_schema, input_schema_enforced, default_challenge_pack_version_id, created_by, created_at, updated_at, archived_at
-FROM datasets
-WHERE id = $1
+SELECT
+    d.id, d.organization_id, d.workspace_id, d.slug, d.name, d.description, d.input_schema, d.input_schema_enforced, d.default_challenge_pack_version_id, d.created_by, d.created_at, d.updated_at, d.archived_at,
+    count(DISTINCT e.id) FILTER (WHERE e.status = 'active')::bigint AS active_example_count,
+    count(DISTINCT v.id)::bigint AS version_count
+FROM datasets d
+LEFT JOIN dataset_examples e ON e.dataset_id = d.id
+LEFT JOIN dataset_versions v ON v.dataset_id = d.id
+WHERE d.id = $1
+GROUP BY d.id
 LIMIT 1
 `
 
@@ -212,9 +218,27 @@ type GetDatasetByIDParams struct {
 	ID uuid.UUID
 }
 
-func (q *Queries) GetDatasetByID(ctx context.Context, arg GetDatasetByIDParams) (Dataset, error) {
+type GetDatasetByIDRow struct {
+	ID                            uuid.UUID
+	OrganizationID                uuid.UUID
+	WorkspaceID                   uuid.UUID
+	Slug                          string
+	Name                          string
+	Description                   string
+	InputSchema                   []byte
+	InputSchemaEnforced           bool
+	DefaultChallengePackVersionID *uuid.UUID
+	CreatedBy                     uuid.UUID
+	CreatedAt                     pgtype.Timestamptz
+	UpdatedAt                     pgtype.Timestamptz
+	ArchivedAt                    pgtype.Timestamptz
+	ActiveExampleCount            int64
+	VersionCount                  int64
+}
+
+func (q *Queries) GetDatasetByID(ctx context.Context, arg GetDatasetByIDParams) (GetDatasetByIDRow, error) {
 	row := q.db.QueryRow(ctx, getDatasetByID, arg.ID)
-	var i Dataset
+	var i GetDatasetByIDRow
 	err := row.Scan(
 		&i.ID,
 		&i.OrganizationID,
@@ -229,6 +253,8 @@ func (q *Queries) GetDatasetByID(ctx context.Context, arg GetDatasetByIDParams) 
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.ArchivedAt,
+		&i.ActiveExampleCount,
+		&i.VersionCount,
 	)
 	return i, err
 }

--- a/backend/internal/repository/sqlc/querier.go
+++ b/backend/internal/repository/sqlc/querier.go
@@ -67,7 +67,7 @@ type Querier interface {
 	GetChallengeIdentityForDatasetEval(ctx context.Context, arg GetChallengeIdentityForDatasetEvalParams) (uuid.UUID, error)
 	GetChallengeInputSetByID(ctx context.Context, arg GetChallengeInputSetByIDParams) (ChallengeInputSet, error)
 	GetDatasetBaselineByID(ctx context.Context, arg GetDatasetBaselineByIDParams) (DatasetBaseline, error)
-	GetDatasetByID(ctx context.Context, arg GetDatasetByIDParams) (Dataset, error)
+	GetDatasetByID(ctx context.Context, arg GetDatasetByIDParams) (GetDatasetByIDRow, error)
 	GetDatasetEvalRunByRunID(ctx context.Context, arg GetDatasetEvalRunByRunIDParams) (DatasetEvalRun, error)
 	GetDatasetExampleByExternalID(ctx context.Context, arg GetDatasetExampleByExternalIDParams) (DatasetExample, error)
 	GetDatasetExampleByID(ctx context.Context, arg GetDatasetExampleByIDParams) (DatasetExample, error)


### PR DESCRIPTION
## Summary
- Default nil dataset example tags to `[]` on upsert so `dataset example add` without `--tag` no longer returns HTTP 500.
- Include `active_example_count` and `version_count` on `GET /datasets/{id}` (same aggregation as list).
- Reject synthetic generation jobs when the provider account provider/key does not match the model alias (returns 400 instead of silent rejections at runtime).

## Test plan
- [x] `go test -short -race -count=1 ./internal/api ./internal/repository`
- [ ] Merge and redeploy API/worker
- [ ] Re-run production CLI QA: `dataset example add` without tags, `dataset view` counts, mismatched `dataset generate` → 400