### PR TITLE
feat(web): public changelog page with SEO and discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ testing/*
 !testing/feat-dataset-evals-889.md
 !testing/feat-dataset-trace-ingest-890.md
 !testing/feat-dataset-generation-892.md
+!testing/feat-changelog-page.md

--- a/testing/feat-changelog-page.md
+++ b/testing/feat-changelog-page.md
@@ -1,0 +1,62 @@
+# feat/changelog-page — Test Contract
+
+## Functional Behavior
+
+- Public route `/changelog` renders without authentication.
+- Changelog content is grouped into **ten-day periods** from **2026-04-15** through the latest period ending **2026-06-01**.
+- Periods sort **newest first**; the latest period shows a **Latest** badge.
+- Each period shows: date label, headline, and bullet entries with category badges (**Added**, **Improved**, **Fixed**, **Security**).
+- Each period card exposes an anchor id (`#2026-05-25`, etc.) for deep links and structured data.
+- Marketing header and footer link to `/changelog`.
+- HTML sitemap page (`/sitemap`) lists the changelog with description.
+- XML sitemap (`/sitemap.xml`) includes `/changelog` with weekly change frequency.
+
+## Unit Tests
+
+- `getChangelogPeriods` returns periods sorted descending by `startDate`.
+- `getChangelogLatestModified` returns the newest period end date.
+- `changelogIndexSchema` emits BreadcrumbList, WebPage, ItemList, and FAQPage nodes with absolute URLs.
+- `renderChangelogMarkdown` exports all periods as markdown with source link.
+- Metadata tests in `public-canonical-metadata.test.ts` and `secondary-pages-metadata.test.ts` lock canonical and social tags.
+
+## Integration / Functional Tests
+
+- `buildLlmsIndex` includes a Changelog section and `/changelog` link.
+- `getDocsSearchIndex` includes a searchable changelog entry.
+- `buildLlmsFull` embeds the rendered changelog markdown bundle section.
+- Changelog page renders JSON-LD script `#agentclash-changelog-index-schema`.
+
+## Smoke Tests
+
+- `cd web && pnpm exec vitest run src/lib/changelog.test.ts src/components/marketing/json-ld.test.ts src/app/changelog/changelog-index-schema.test.tsx src/app/public-canonical-metadata.test.ts src/app/secondary-pages-metadata.test.ts src/app/sitemap.test.ts src/lib/docs.test.ts`
+- `cd web && pnpm lint`
+
+## E2E Tests
+
+- N/A — static marketing page; covered by unit/render tests and manual curl checks.
+
+## Manual / cURL Tests
+
+1. Fetch page HTML (after deploy or local dev):
+   ```bash
+   curl -sS http://localhost:3000/changelog | grep -E 'Changelog|Latest|Added|application/ld\\+json'
+   ```
+   Expected: page title, timeline content, JSON-LD script present.
+
+2. Verify sitemap entry:
+   ```bash
+   curl -sS http://localhost:3000/sitemap.xml | grep changelog
+   ```
+   Expected: `https://www.agentclash.dev/changelog`.
+
+3. Verify llms discovery:
+   ```bash
+   curl -sS http://localhost:3000/llms.txt | grep -i changelog
+   ```
+   Expected: changelog link in index.
+
+4. Verify metadata (canonical):
+   ```bash
+   curl -sS http://localhost:3000/changelog | grep 'rel="canonical"'
+   ```
+   Expected: canonical href `/changelog`.

--- a/web/src/app/changelog/changelog-index-schema.test.tsx
+++ b/web/src/app/changelog/changelog-index-schema.test.tsx
@@ -1,0 +1,74 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { SITE_URL } from "@/components/marketing/json-ld";
+import ChangelogPage from "./page";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function render(element: React.ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(element);
+  });
+}
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe("changelog index structured data", () => {
+  it("renders breadcrumb, WebPage, ItemList, and FAQ JSON-LD", () => {
+    render(<ChangelogPage />);
+
+    const script = container?.querySelector<HTMLScriptElement>(
+      "#agentclash-changelog-index-schema",
+    );
+    expect(script?.type).toBe("application/ld+json");
+
+    const jsonLd = JSON.parse(script?.textContent ?? "[]") as Array<
+      Record<string, unknown>
+    >;
+
+    expect(jsonLd.map((item) => item["@type"])).toEqual([
+      "BreadcrumbList",
+      "WebPage",
+      "ItemList",
+      "FAQPage",
+    ]);
+    expect(jsonLd[1]).toMatchObject({
+      "@type": "WebPage",
+      name: "AgentClash Changelog",
+      url: `${SITE_URL}/changelog`,
+      dateModified: "2026-06-01",
+    });
+    expect(jsonLd[2]).toMatchObject({
+      "@type": "ItemList",
+      numberOfItems: 5,
+    });
+    expect(
+      (jsonLd[2]?.itemListElement as Array<Record<string, unknown>>)[0],
+    ).toMatchObject({
+      "@type": "ListItem",
+      position: 1,
+      url: `${SITE_URL}/changelog#2026-05-25`,
+    });
+    expect(jsonLd[3]).toMatchObject({
+      "@type": "FAQPage",
+    });
+    expect(
+      (jsonLd[3]?.mainEntity as Array<Record<string, unknown>>)[0],
+    ).toMatchObject({
+      "@type": "Question",
+      name: "What is the AgentClash changelog?",
+    });
+  });
+});

--- a/web/src/app/changelog/changelog-index-schema.test.tsx
+++ b/web/src/app/changelog/changelog-index-schema.test.tsx
@@ -2,6 +2,10 @@ import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it } from "vitest";
 import { SITE_URL } from "@/components/marketing/json-ld";
+import {
+  getChangelogLatestModified,
+  getChangelogPeriods,
+} from "@/lib/changelog";
 import ChangelogPage from "./page";
 
 let root: Root | null = null;
@@ -27,6 +31,9 @@ afterEach(() => {
 
 describe("changelog index structured data", () => {
   it("renders breadcrumb, WebPage, ItemList, and FAQ JSON-LD", () => {
+    const periods = getChangelogPeriods();
+    const latestPeriod = periods[0];
+
     render(<ChangelogPage />);
 
     const script = container?.querySelector<HTMLScriptElement>(
@@ -48,18 +55,18 @@ describe("changelog index structured data", () => {
       "@type": "WebPage",
       name: "AgentClash Changelog",
       url: `${SITE_URL}/changelog`,
-      dateModified: "2026-06-01",
+      dateModified: getChangelogLatestModified(),
     });
     expect(jsonLd[2]).toMatchObject({
       "@type": "ItemList",
-      numberOfItems: 5,
+      numberOfItems: periods.length,
     });
     expect(
       (jsonLd[2]?.itemListElement as Array<Record<string, unknown>>)[0],
     ).toMatchObject({
       "@type": "ListItem",
       position: 1,
-      url: `${SITE_URL}/changelog#2026-05-25`,
+      url: `${SITE_URL}/changelog#${latestPeriod?.id}`,
     });
     expect(jsonLd[3]).toMatchObject({
       "@type": "FAQPage",

--- a/web/src/app/changelog/metadata.ts
+++ b/web/src/app/changelog/metadata.ts
@@ -1,0 +1,59 @@
+import type { Metadata } from "next";
+import { ogImageUrl } from "@/lib/seo";
+
+const PAGE_TITLE = "Changelog - AgentClash";
+const PAGE_DESCRIPTION =
+  "Everything shipped in AgentClash from day one — scoring, regression, security packs, datasets, and CLI updates, grouped every ten days.";
+const SOCIAL_IMAGE_ALT = "AgentClash product changelog social preview.";
+const SOCIAL_IMAGE = ogImageUrl({
+  title: "AgentClash Changelog",
+  subtitle: "Product updates every ten days since launch",
+  kind: "Changelog",
+});
+
+export const changelogMetadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  keywords: [
+    "AgentClash changelog",
+    "AgentClash release notes",
+    "AI agent evaluation updates",
+    "agent eval platform changelog",
+    "AgentClash product updates",
+    "what's new AgentClash",
+  ],
+  alternates: {
+    canonical: "/changelog",
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+  openGraph: {
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: "/changelog",
+    type: "website",
+    locale: "en_US",
+    siteName: "AgentClash",
+    images: [
+      {
+        url: SOCIAL_IMAGE,
+        width: 1200,
+        height: 630,
+        alt: SOCIAL_IMAGE_ALT,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    images: [
+      {
+        url: SOCIAL_IMAGE,
+        alt: SOCIAL_IMAGE_ALT,
+      },
+    ],
+  },
+};

--- a/web/src/app/changelog/page.tsx
+++ b/web/src/app/changelog/page.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import { ChangelogTimeline } from "@/components/marketing/changelog-timeline";
+import { JsonLd, changelogIndexSchema } from "@/components/marketing/json-ld";
+import { CHANGELOG_FAQ, getChangelogPeriods } from "@/lib/changelog";
+import { changelogMetadata } from "./metadata";
+
+export const metadata = changelogMetadata;
+
+export default function ChangelogPage() {
+  const periods = getChangelogPeriods();
+
+  return (
+    <>
+      <JsonLd
+        id="agentclash-changelog-index-schema"
+        data={changelogIndexSchema(
+          periods.map((period) => ({
+            id: period.id,
+            label: period.label,
+            headline: period.headline,
+            endDate: period.endDate,
+            entryCount: period.entries.length,
+          })),
+          [...CHANGELOG_FAQ],
+        )}
+      />
+      <main className="min-h-screen flex flex-col items-center px-6 py-16">
+        <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.18em] text-white/35">
+          Product updates
+        </p>
+        <h1 className="mt-4 font-[family-name:var(--font-display)] text-3xl sm:text-4xl text-center tracking-[-0.02em] leading-[1.15]">
+          Changelog
+        </h1>
+        <p className="mt-3 max-w-xl text-center text-sm leading-relaxed text-white/35">
+          What we shipped in AgentClash, grouped every ten days from the first
+          commit on April 15, 2026 through today.
+        </p>
+
+        <ChangelogTimeline periods={periods} />
+
+        <Link
+          href="/"
+          className="mt-12 text-xs text-white/30 hover:text-white/50 transition-colors"
+        >
+          &larr; Back to AgentClash
+        </Link>
+      </main>
+    </>
+  );
+}

--- a/web/src/app/public-canonical-metadata.test.ts
+++ b/web/src/app/public-canonical-metadata.test.ts
@@ -9,6 +9,7 @@ import { metadata as agentRegressionTestingMetadata } from "./platform/agent-reg
 import { metadata as sitemapMetadata } from "./sitemap/page";
 import { teamMetadata } from "./team/metadata";
 import { whyMetadata } from "./why/metadata";
+import { changelogMetadata } from "./changelog/metadata";
 
 const getPostBySlugMock = vi.hoisted(() => vi.fn());
 const getDocBySlugMock = vi.hoisted(() => vi.fn());
@@ -53,6 +54,7 @@ describe("public canonical metadata", () => {
     );
     expectCanonical(whyMetadata, "/why");
     expectCanonical(teamMetadata, "/team");
+    expectCanonical(changelogMetadata, "/changelog");
     expectCanonical(sitemapMetadata, "/sitemap");
   });
 

--- a/web/src/app/secondary-pages-metadata.test.ts
+++ b/web/src/app/secondary-pages-metadata.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { teamMetadata } from "./team/metadata";
 import { whyMetadata } from "./why/metadata";
+import { changelogMetadata } from "./changelog/metadata";
 
 describe("secondary public page social metadata", () => {
   it("adds explicit social metadata for the why page", () => {
@@ -95,5 +96,33 @@ describe("secondary public page social metadata", () => {
     };
     expect(openGraph.images?.[0]?.alt).toContain("AgentClash team");
     expect(twitter.images?.[0]?.alt).toBe(openGraph.images?.[0]?.alt);
+  });
+
+  it("adds explicit social metadata for the changelog page", () => {
+    expect(changelogMetadata).toMatchObject({
+      title: "Changelog - AgentClash",
+      description:
+        "Everything shipped in AgentClash from day one — scoring, regression, security packs, datasets, and CLI updates, grouped every ten days.",
+      alternates: {
+        canonical: "/changelog",
+      },
+      openGraph: {
+        title: "Changelog - AgentClash",
+        url: "/changelog",
+        type: "website",
+        locale: "en_US",
+        siteName: "AgentClash",
+      },
+      twitter: {
+        card: "summary_large_image",
+        title: "Changelog - AgentClash",
+      },
+    });
+
+    const openGraph = changelogMetadata.openGraph as {
+      images?: Array<{ url?: string; alt?: string }>;
+    };
+    expect(openGraph.images?.[0]?.url).toContain("/og?");
+    expect(openGraph.images?.[0]?.alt).toContain("changelog");
   });
 });

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -35,6 +35,11 @@ describe("sitemap", () => {
       changeFrequency: "weekly",
       priority: 0.8,
     });
+    expect(byUrl.get("https://www.agentclash.dev/changelog")).toMatchObject({
+      changeFrequency: "weekly",
+      priority: 0.75,
+      lastModified: new Date("2026-06-01"),
+    });
     expect(byUrl.get("https://www.agentclash.dev/why")).toMatchObject({
       changeFrequency: "monthly",
       priority: 0.7,

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getChangelogLatestModified } from "@/lib/changelog";
 import sitemap from "./sitemap";
 
 vi.mock("@/lib/blog", () => ({
@@ -38,7 +39,7 @@ describe("sitemap", () => {
     expect(byUrl.get("https://www.agentclash.dev/changelog")).toMatchObject({
       changeFrequency: "weekly",
       priority: 0.75,
-      lastModified: new Date("2026-06-01"),
+      lastModified: new Date(getChangelogLatestModified()),
     });
     expect(byUrl.get("https://www.agentclash.dev/why")).toMatchObject({
       changeFrequency: "monthly",

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from "next";
 import { getAllPosts } from "@/lib/blog";
+import { getChangelogLatestModified } from "@/lib/changelog";
 import { COMPETITORS } from "@/lib/comparison-data";
 import { DOCS_ORIGIN, getAllDocPaths } from "@/lib/docs";
 
@@ -42,6 +43,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 0.8,
+    },
+    {
+      url: `${DOCS_ORIGIN}/changelog`,
+      lastModified: new Date(getChangelogLatestModified()),
+      changeFrequency: "weekly",
+      priority: 0.75,
     },
     {
       url: `${DOCS_ORIGIN}/why`,

--- a/web/src/app/sitemap/page.tsx
+++ b/web/src/app/sitemap/page.tsx
@@ -68,6 +68,11 @@ const primaryPages = [
     description: "Engineering notes on AI agent evaluation and release gates.",
   },
   {
+    title: "Changelog",
+    href: "/changelog",
+    description: "Product updates shipped every ten days since launch.",
+  },
+  {
     title: "Why AgentClash",
     href: "/why",
     description: "Why real-task AI agent evaluation matters.",

--- a/web/src/components/marketing/changelog-timeline.tsx
+++ b/web/src/components/marketing/changelog-timeline.tsx
@@ -1,0 +1,81 @@
+import {
+  CHANGELOG_CATEGORY_LABELS,
+  type ChangelogCategory,
+  type ChangelogPeriod,
+} from "@/lib/changelog";
+
+const CATEGORY_STYLES: Record<ChangelogCategory, string> = {
+  added: "border-emerald-400/25 bg-emerald-400/10 text-emerald-200/90",
+  improved: "border-sky-400/25 bg-sky-400/10 text-sky-200/90",
+  fixed: "border-amber-400/25 bg-amber-400/10 text-amber-200/90",
+  security: "border-rose-400/25 bg-rose-400/10 text-rose-200/90",
+};
+
+function CategoryBadge({ category }: { category: ChangelogCategory }) {
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-[10px] font-[family-name:var(--font-mono)] uppercase tracking-[0.14em] ${CATEGORY_STYLES[category]}`}
+    >
+      {CHANGELOG_CATEGORY_LABELS[category]}
+    </span>
+  );
+}
+
+export function ChangelogTimeline({ periods }: { periods: ChangelogPeriod[] }) {
+  return (
+    <div className="relative mt-12 w-full max-w-3xl">
+      <div
+        aria-hidden
+        className="absolute bottom-3 left-[7px] top-3 w-px bg-gradient-to-b from-white/20 via-white/10 to-transparent"
+      />
+
+      <ol className="space-y-10">
+        {periods.map((period, index) => (
+          <li key={period.id} className="relative pl-8">
+            <span
+              aria-hidden
+              className="absolute left-0 top-2 flex size-4 items-center justify-center rounded-full border border-white/20 bg-[#060606] shadow-[0_0_0_4px_rgba(6,6,6,1)]"
+            >
+              <span className="size-1.5 rounded-full bg-white/70" />
+            </span>
+
+            <article
+              id={period.id}
+              className="scroll-mt-24 rounded-xl border border-white/[0.08] bg-white/[0.03] p-5 sm:p-6"
+            >
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                <time
+                  dateTime={period.endDate}
+                  className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.16em] text-white/45"
+                >
+                  {period.label}
+                </time>
+                {index === 0 ? (
+                  <span className="rounded-full border border-white/15 bg-white/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.12em] text-white/70">
+                    Latest
+                  </span>
+                ) : null}
+              </div>
+
+              <h2 className="mt-3 font-[family-name:var(--font-display)] text-xl leading-snug tracking-[-0.02em] text-white sm:text-2xl">
+                {period.headline}
+              </h2>
+
+              <ul className="mt-5 space-y-3">
+                {period.entries.map((entry) => (
+                  <li
+                    key={`${period.id}-${entry.text}`}
+                    className="flex items-start gap-3 text-sm leading-relaxed text-white/70"
+                  >
+                    <CategoryBadge category={entry.category} />
+                    <span>{entry.text}</span>
+                  </li>
+                ))}
+              </ul>
+            </article>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/web/src/components/marketing/json-ld.test.ts
+++ b/web/src/components/marketing/json-ld.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   articleSchema,
   blogIndexSchema,
+  changelogIndexSchema,
   docsPageSchema,
   organizationSchema,
   productSchema,
@@ -87,6 +88,66 @@ describe("blogIndexSchema", () => {
           },
         },
       ],
+    });
+  });
+});
+
+describe("changelogIndexSchema", () => {
+  it("builds breadcrumb, WebPage, ItemList, and FAQ structured data", () => {
+    const schema = changelogIndexSchema(
+      [
+        {
+          id: "2026-05-25",
+          label: "May 25 – Jun 01, 2026",
+          headline: "Datasets and /try demos",
+          endDate: "2026-06-01",
+          entryCount: 12,
+        },
+      ],
+      [
+        {
+          question: "What is the AgentClash changelog?",
+          answer: "Release notes grouped every ten days.",
+        },
+      ],
+    );
+
+    expect(schema).toHaveLength(4);
+    expect(schema[0]).toMatchObject({
+      "@type": "BreadcrumbList",
+    });
+    expect(schema[0].itemListElement).toEqual([
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: `${SITE_URL}/`,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Changelog",
+        item: `${SITE_URL}/changelog`,
+      },
+    ]);
+    expect(schema[1]).toMatchObject({
+      "@type": "WebPage",
+      url: `${SITE_URL}/changelog`,
+      dateModified: "2026-06-01",
+    });
+    expect(schema[2]).toMatchObject({
+      "@type": "ItemList",
+      numberOfItems: 1,
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          position: 1,
+          url: `${SITE_URL}/changelog#2026-05-25`,
+        },
+      ],
+    });
+    expect(schema[3]).toMatchObject({
+      "@type": "FAQPage",
     });
   });
 });

--- a/web/src/components/marketing/json-ld.tsx
+++ b/web/src/components/marketing/json-ld.tsx
@@ -233,6 +233,71 @@ export function blogIndexSchema(
   ];
 }
 
+type ChangelogIndexPeriod = {
+  id: string;
+  label: string;
+  headline: string;
+  endDate: string;
+  entryCount: number;
+};
+
+export function changelogIndexSchema(
+  periods: ChangelogIndexPeriod[],
+  faqItems: Array<{ question: string; answer: string }> = [],
+): Record<string, unknown>[] {
+  const pageUrl = `${SITE_URL}/changelog`;
+  const latestPeriod = periods[0];
+
+  return [
+    breadcrumbSchema([
+      { name: "Home", url: "/" },
+      { name: "Changelog", url: "/changelog" },
+    ]),
+    {
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      name: "AgentClash Changelog",
+      description:
+        "Everything shipped in AgentClash from day one — scoring, regression, security packs, datasets, and CLI updates, grouped every ten days.",
+      url: pageUrl,
+      ...(latestPeriod
+        ? {
+            dateModified: latestPeriod.endDate,
+          }
+        : {}),
+      isPartOf: {
+        "@type": "WebSite",
+        name: "AgentClash",
+        url: SITE_URL,
+      },
+      publisher: publisherSchema(),
+      mainEntity: {
+        "@type": "ItemList",
+        name: "AgentClash product updates",
+        numberOfItems: periods.length,
+      },
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "ItemList",
+      name: "AgentClash product updates",
+      url: pageUrl,
+      numberOfItems: periods.length,
+      itemListElement: periods.map((period, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        name: period.headline,
+        description: `${period.label} — ${period.entryCount} updates`,
+        url: `${pageUrl}#${period.id}`,
+        item: {
+          "@id": `${pageUrl}#${period.id}`,
+        },
+      })),
+    },
+    ...(faqItems.length ? [faqSchema(faqItems)] : []),
+  ];
+}
+
 export function docsPageSchema({
   title,
   description,

--- a/web/src/components/marketing/marketing-footer.tsx
+++ b/web/src/components/marketing/marketing-footer.tsx
@@ -31,6 +31,7 @@ const COLUMNS: Array<{
     heading: "Company",
     links: [
       { href: "/blog", label: "Blog" },
+      { href: "/changelog", label: "Changelog" },
       { href: "/team", label: "Team" },
       { href: "https://github.com/agentclash/agentclash", label: "GitHub", external: true },
     ],

--- a/web/src/components/marketing/marketing-header.tsx
+++ b/web/src/components/marketing/marketing-header.tsx
@@ -9,6 +9,7 @@ const DEFAULT_NAV: NavLink[] = [
   { href: "/#features", label: "Features" },
   { href: "/docs", label: "Docs" },
   { href: "/blog", label: "Blog" },
+  { href: "/changelog", label: "Changelog" },
 ];
 
 type Props = {

--- a/web/src/lib/changelog.test.ts
+++ b/web/src/lib/changelog.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  CHANGELOG_FAQ,
+  getChangelogLatestModified,
+  getChangelogPeriods,
+  renderChangelogMarkdown,
+} from "./changelog";
+
+describe("getChangelogPeriods", () => {
+  it("returns periods sorted newest first", () => {
+    const periods = getChangelogPeriods();
+
+    expect(periods.length).toBeGreaterThan(0);
+    expect(periods[0]?.id).toBe("2026-05-25");
+    expect(periods.at(-1)?.id).toBe("2026-04-15");
+    expect(
+      periods.every(
+        (period, index) =>
+          index === 0 ||
+          period.startDate <= periods[index - 1]!.startDate,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("getChangelogLatestModified", () => {
+  it("returns the newest period end date", () => {
+    expect(getChangelogLatestModified()).toBe("2026-06-01");
+  });
+});
+
+describe("renderChangelogMarkdown", () => {
+  it("exports all periods with source link and category labels", () => {
+    const markdown = renderChangelogMarkdown("https://example.test");
+
+    expect(markdown).toContain("# AgentClash Changelog");
+    expect(markdown).toContain("Source: https://example.test/changelog");
+    expect(markdown).toContain("## May 25 – Jun 01, 2026");
+    expect(markdown).toContain("**Added**: Datasets foundation");
+    expect(markdown).toContain("**Security**: SecurityPolicy schema");
+  });
+});
+
+describe("CHANGELOG_FAQ", () => {
+  it("includes discoverability questions for answer engines", () => {
+    expect(CHANGELOG_FAQ.length).toBeGreaterThanOrEqual(3);
+    expect(CHANGELOG_FAQ[0]?.question).toContain("changelog");
+  });
+});

--- a/web/src/lib/changelog.ts
+++ b/web/src/lib/changelog.ts
@@ -14,6 +14,13 @@ export interface ChangelogPeriod {
   entries: ChangelogEntry[];
 }
 
+export const CHANGELOG_CATEGORY_LABELS: Record<ChangelogCategory, string> = {
+  added: "Added",
+  improved: "Improved",
+  fixed: "Fixed",
+  security: "Security",
+};
+
 export const CHANGELOG_PERIODS: ChangelogPeriod[] = [
   {
     id: "2026-04-15",
@@ -330,10 +337,3 @@ export function renderChangelogMarkdown(origin = "https://www.agentclash.dev"): 
 
   return lines.join("\n").trim();
 }
-
-export const CHANGELOG_CATEGORY_LABELS: Record<ChangelogCategory, string> = {
-  added: "Added",
-  improved: "Improved",
-  fixed: "Fixed",
-  security: "Security",
-};

--- a/web/src/lib/changelog.ts
+++ b/web/src/lib/changelog.ts
@@ -1,0 +1,339 @@
+export type ChangelogCategory = "added" | "improved" | "fixed" | "security";
+
+export interface ChangelogEntry {
+  category: ChangelogCategory;
+  text: string;
+}
+
+export interface ChangelogPeriod {
+  id: string;
+  startDate: string;
+  endDate: string;
+  label: string;
+  headline: string;
+  entries: ChangelogEntry[];
+}
+
+export const CHANGELOG_PERIODS: ChangelogPeriod[] = [
+  {
+    id: "2026-04-15",
+    startDate: "2026-04-15",
+    endDate: "2026-04-24",
+    label: "Apr 15 – Apr 24, 2026",
+    headline: "Scoring depth, failure review, and the first regression suite UI",
+    entries: [
+      {
+        category: "added",
+        text: "Sandbox code-execution validator and math-equivalence scoring for deterministic checks.",
+      },
+      {
+        category: "added",
+        text: "LLM judge dimensions with n-wise comparisons, persisted results, and scorecard rationale cards in the UI.",
+      },
+      {
+        category: "added",
+        text: "Behavioral spec scoring — signal extraction, scorecards, and dimension contribution metadata.",
+      },
+      {
+        category: "added",
+        text: "Text-generation metrics and token F1 validator with evidence linked back to run events.",
+      },
+      {
+        category: "added",
+        text: "Failure review API and workspace Failures page with filters, detail drawer, and run links.",
+      },
+      {
+        category: "added",
+        text: "Regression suite CRUD, failure promotion flow, and full regression UI (suites, cases, promotion dialog).",
+      },
+      {
+        category: "added",
+        text: "xAI provider adapter wired into the execution engine.",
+      },
+      {
+        category: "added",
+        text: "Run replay step detail now surfaces model output and tool results.",
+      },
+      {
+        category: "added",
+        text: "Workspace invite emails via Resend.",
+      },
+      {
+        category: "improved",
+        text: "Run-agent scorecard redesigned with an inspector-style layout.",
+      },
+      {
+        category: "improved",
+        text: "Cross-platform CLI install scripts hardened for macOS, Linux, and Windows.",
+      },
+      {
+        category: "improved",
+        text: "Authenticated users redirect from the landing page straight to the dashboard.",
+      },
+    ],
+  },
+  {
+    id: "2026-04-25",
+    startDate: "2026-04-25",
+    endDate: "2026-05-04",
+    label: "Apr 25 – May 04, 2026",
+    headline: "Race context, CLI distribution, and a redesigned public site",
+    entries: [
+      {
+        category: "added",
+        text: "Live race context — standings injection at step boundaries, newswire formatting, and token split between agents vs race context.",
+      },
+      {
+        category: "added",
+        text: "CLI `--race-context` flags and UI toggle for race standings during live runs.",
+      },
+      {
+        category: "added",
+        text: "Workflow-first eval commands in the CLI.",
+      },
+      {
+        category: "added",
+        text: "Dedicated /why manifesto page and pricing section with tier cards and trial CTA.",
+      },
+      {
+        category: "added",
+        text: "Released CLI binaries now default to https://api.agentclash.dev.",
+      },
+      {
+        category: "improved",
+        text: "AgentClash-branded auth with liquid-glass login, starfield hero, and 3D clash mark on landing.",
+      },
+      {
+        category: "improved",
+        text: "Workspace navigation made instant with client-side prefetching.",
+      },
+      {
+        category: "improved",
+        text: "Run detail and replay pages restyled with instrument-panel aesthetics.",
+      },
+      {
+        category: "improved",
+        text: "Playground comparison workspace refactored for clearer side-by-side evals.",
+      },
+    ],
+  },
+  {
+    id: "2026-05-05",
+    startDate: "2026-05-05",
+    endDate: "2026-05-14",
+    label: "May 05 – May 14, 2026",
+    headline: "CI intelligence, prompt eval, and GitHub-native workflows",
+    entries: [
+      {
+        category: "added",
+        text: "Failure cluster rollups, identity keys, taxonomy classification, and trend charts in the web UI.",
+      },
+      {
+        category: "added",
+        text: "Regression provenance, validation signals, proposed-case queue, and remediation hints.",
+      },
+      {
+        category: "added",
+        text: "CI setup generators with workspace page and one-click setup pull request creation.",
+      },
+      {
+        category: "added",
+        text: "Prompt eval CLI commands — config validation, remote preflight, compile, follow, and GitHub Action mode.",
+      },
+      {
+        category: "added",
+        text: "AgentClash PR comment bot with links back to failure review in the UI.",
+      },
+      {
+        category: "added",
+        text: "E2B harness runners for Claude Code and OpenClaw agent execution.",
+      },
+      {
+        category: "added",
+        text: "Production failure capture and explicit validation runs for proposed regression cases.",
+      },
+      {
+        category: "improved",
+        text: "CLI preserves CI curation metadata and surfaces failure taxonomy in workflow output.",
+      },
+      {
+        category: "improved",
+        text: "Evaluator validity signals exposed in scorecards for clearer trust boundaries.",
+      },
+      {
+        category: "fixed",
+        text: "Dozens of CI, regression, and failure-review edge cases hardened across API and web.",
+      },
+    ],
+  },
+  {
+    id: "2026-05-15",
+    startDate: "2026-05-15",
+    endDate: "2026-05-24",
+    label: "May 15 – May 24, 2026",
+    headline: "Security packs, multi-turn eval, and replay polish",
+    entries: [
+      {
+        category: "security",
+        text: "SecurityPolicy schema and SecurityScore dimension for security-family challenge packs.",
+      },
+      {
+        category: "security",
+        text: "Canonical secret-hygiene and prompt-injection challenge packs shipped.",
+      },
+      {
+        category: "security",
+        text: "CLI `stress-run` subcommand with Anthropic Messages provider and --no-system-guard leak surfacing.",
+      },
+      {
+        category: "security",
+        text: "agent-vault-stress harness with real Vault SDK, function calling, campaign mode, and bundled HTTP mock.",
+      },
+      {
+        category: "security",
+        text: "Infisical and HashiCorp Vault boundary packs for vault-framed canary leak testing.",
+      },
+      {
+        category: "added",
+        text: "Multi-turn evaluation — user simulators, hybrid executor, human takeover, calibration reviews, and post-run arena.",
+      },
+      {
+        category: "added",
+        text: "Case template renderer and bundle validation for code-execution challenge packs.",
+      },
+      {
+        category: "added",
+        text: "Multi-turn conversation events with transcript helpers in the event model.",
+      },
+      {
+        category: "improved",
+        text: "Replay trace output upgraded with IDE-level syntax highlighting and rich text rendering.",
+      },
+      {
+        category: "improved",
+        text: "Planted secrets from security packs wired into sandbox provisioning.",
+      },
+    ],
+  },
+  {
+    id: "2026-05-25",
+    startDate: "2026-05-25",
+    endDate: "2026-06-01",
+    label: "May 25 – Jun 01, 2026",
+    headline: "Datasets, /try demos, multi-turn transcripts, and Hermes harness",
+    entries: [
+      {
+        category: "added",
+        text: "Datasets foundation — interop import/export, version snapshots, eval runs, baselines, CI gate verdicts, and JUnit output.",
+      },
+      {
+        category: "added",
+        text: "Self-Instruct synthetic dataset generation with async jobs and CLI parity.",
+      },
+      {
+        category: "added",
+        text: "Production trace ingest, trace candidates, and promote-to-example workflow.",
+      },
+      {
+        category: "added",
+        text: "Full dataset management UI in the workspace — import mapping, eval wait, dataset test flow, and generation history.",
+      },
+      {
+        category: "added",
+        text: "/try interactive terminal demos with E2B sandbox, free-trial gateway, and Kimi/Qwen/OpenCode integrations.",
+      },
+      {
+        category: "added",
+        text: "OpenAI Responses API as a first-class execution mode.",
+      },
+      {
+        category: "added",
+        text: "Multi-turn conversation transcript API with replay rendering, scorecard view, and PDF export.",
+      },
+      {
+        category: "added",
+        text: "Vibe eval draft persistence for in-progress eval configuration.",
+      },
+      {
+        category: "added",
+        text: "Hermes agent harness support in E2B templates and harness execution workflow.",
+      },
+      {
+        category: "added",
+        text: "PostHog usage analytics across backend, CLI, and web.",
+      },
+      {
+        category: "improved",
+        text: "SEO and AEO discoverability expanded across public marketing and docs surfaces.",
+      },
+      {
+        category: "improved",
+        text: "Landing page bar promoting /try CLI demos.",
+      },
+      {
+        category: "fixed",
+        text: "Dataset generation provider validation returns clear 400 errors instead of opaque failures.",
+      },
+    ],
+  },
+];
+
+export function getChangelogPeriods(): ChangelogPeriod[] {
+  return [...CHANGELOG_PERIODS].sort(
+    (a, b) => b.startDate.localeCompare(a.startDate),
+  );
+}
+
+export function getChangelogLatestModified(): string {
+  const [latest] = getChangelogPeriods();
+  return latest?.endDate ?? CHANGELOG_PERIODS[0]?.startDate ?? "2026-04-15";
+}
+
+export const CHANGELOG_FAQ = [
+  {
+    question: "What is the AgentClash changelog?",
+    answer:
+      "The AgentClash changelog lists product updates shipped since launch — features, improvements, fixes, and security work — grouped into ten-day release periods with category badges.",
+  },
+  {
+    question: "How often is the AgentClash changelog updated?",
+    answer:
+      "AgentClash groups changelog entries into ten-day windows. Each period summarizes everything merged during that window, from scoring and regression tooling to datasets, security packs, and CLI releases.",
+  },
+  {
+    question: "Where can I find AgentClash release notes?",
+    answer:
+      "Visit https://www.agentclash.dev/changelog for the public release timeline. For engineering deep dives, see the AgentClash blog at https://www.agentclash.dev/blog.",
+  },
+] as const;
+
+export function renderChangelogMarkdown(origin = "https://www.agentclash.dev"): string {
+  const periods = getChangelogPeriods();
+  const lines = [
+    "# AgentClash Changelog",
+    "",
+    "Product updates shipped in ten-day periods since April 15, 2026.",
+    "",
+    `Source: ${origin}/changelog`,
+    "",
+  ];
+
+  for (const period of periods) {
+    lines.push(`## ${period.label}`, "", period.headline, "");
+    for (const entry of period.entries) {
+      lines.push(
+        `- **${CHANGELOG_CATEGORY_LABELS[entry.category]}**: ${entry.text}`,
+      );
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n").trim();
+}
+
+export const CHANGELOG_CATEGORY_LABELS: Record<ChangelogCategory, string> = {
+  added: "Added",
+  improved: "Improved",
+  fixed: "Fixed",
+  security: "Security",
+};

--- a/web/src/lib/docs.test.ts
+++ b/web/src/lib/docs.test.ts
@@ -494,6 +494,8 @@ describe("agent skill docs", () => {
     expect(index).toContain(
       "https://example.test/blog/ai-agent-evaluation-regression-testing",
     );
+    expect(index).toContain("https://example.test/changelog");
+    expect(index).toContain("## Changelog");
     expect(index).toContain(
       "AI Agent Evaluation Needs Regression Testing, Not Just Benchmarks",
     );
@@ -519,6 +521,9 @@ describe("agent skill docs", () => {
       "/platform/agent-evaluation",
       "/platform/agent-regression-testing",
     ]);
+    const changelog = index.find((item) => item.href === "/changelog");
+    expect(changelog?.title).toBe("Product Changelog");
+    expect(changelog?.searchText).toContain("release notes");
     expect(evaluation?.title).toBe("AI Agent Evaluation Platform");
     expect(evaluation?.searchText).toContain("platform/agent-evaluation");
     expect(evaluation?.searchText).toContain("ai agent evaluation");
@@ -544,6 +549,8 @@ describe("agent skill docs", () => {
     expect(bundle).toContain(
       "Source: https://example.test/blog/ai-agent-evaluation-regression-testing",
     );
+    expect(bundle).toContain("# AgentClash Changelog");
+    expect(bundle).toContain("Source: https://example.test/changelog");
     expect(bundle).toContain(
       "[AI agent evaluation platform](https://example.test/platform/agent-evaluation)",
     );

--- a/web/src/lib/docs.test.ts
+++ b/web/src/lib/docs.test.ts
@@ -495,7 +495,7 @@ describe("agent skill docs", () => {
       "https://example.test/blog/ai-agent-evaluation-regression-testing",
     );
     expect(index).toContain("https://example.test/changelog");
-    expect(index).toContain("## Changelog");
+    expect(index.match(/https:\/\/example\.test\/changelog/g)?.length).toBe(1);
     expect(index).toContain(
       "AI Agent Evaluation Needs Regression Testing, Not Just Benchmarks",
     );

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -6,6 +6,7 @@ import {
   getPostBySlug,
   type BlogPostWithContent,
 } from "./blog";
+import { renderChangelogMarkdown } from "./changelog";
 
 const CONTENT_DIR = path.join(process.cwd(), "content", "docs");
 const AGENT_SKILLS_DIR = path.join(process.cwd(), "content", "agent-skills");
@@ -73,6 +74,14 @@ const PUBLIC_PRODUCT_PAGES: PublicProductPage[] = [
       "Compare AgentClash with Braintrust, LangSmith, Promptfoo, Langfuse, Arize Phoenix, and OpenAI Evals — agent evaluation versus prompt evaluation.",
     searchKeywords:
       "compare comparison alternative alternatives AgentClash vs Braintrust LangSmith Promptfoo Langfuse Arize Phoenix OpenAI Evals agent evaluation prompt evaluation best AI agent eval tools",
+  },
+  {
+    title: "Product Changelog",
+    href: "/changelog",
+    description:
+      "Public release notes for AgentClash — features, improvements, fixes, and security updates grouped every ten days since launch.",
+    searchKeywords:
+      "AgentClash changelog release notes product updates what's new shipped features AI agent evaluation platform updates",
   },
 ];
 
@@ -1655,6 +1664,10 @@ export function buildLlmsIndex(origin = DOCS_ORIGIN) {
       (page) => `- [${page.title}](${origin}${page.href}) - ${page.description}`,
     ),
     "",
+    "## Changelog",
+    "",
+    `- [Product Changelog](${origin}/changelog) - release notes grouped every ten days since April 15, 2026.`,
+    "",
     "## Blog posts",
     "",
     ...blogPosts.map(
@@ -1717,6 +1730,10 @@ export function buildLlmsFull(origin = DOCS_ORIGIN) {
     ...blogPosts.map(
       (post) => `- [${post.title}](${origin}/blog/${post.slug}) - ${post.description}`,
     ),
+    "",
+    "## Changelog bundle",
+    "",
+    renderChangelogMarkdown(origin),
   ];
 
   for (const post of blogPosts) {

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -1664,10 +1664,6 @@ export function buildLlmsIndex(origin = DOCS_ORIGIN) {
       (page) => `- [${page.title}](${origin}${page.href}) - ${page.description}`,
     ),
     "",
-    "## Changelog",
-    "",
-    `- [Product Changelog](${origin}/changelog) - release notes grouped every ten days since April 15, 2026.`,
-    "",
     "## Blog posts",
     "",
     ...blogPosts.map(


### PR DESCRIPTION
## Summary

- Adds a public `/changelog` route with a Linear-style vertical timeline of product updates grouped every ten days from April 15, 2026 through today.
- Ships SEO/AEO coverage: canonical metadata, dynamic OG image, keywords, JSON-LD (BreadcrumbList, WebPage, ItemList, FAQPage), semantic `<article>`/`<time>` anchors, and llms.txt/docs-search/sitemap discovery.
- Locks expectations in `testing/feat-changelog-page.md` and verifies with metadata, schema, sitemap, and docs bundle tests.

## Test plan

- [x] `cd web && pnpm exec vitest run src/lib/changelog.test.ts src/components/marketing/json-ld.test.ts src/app/changelog/changelog-index-schema.test.tsx src/app/public-canonical-metadata.test.ts src/app/secondary-pages-metadata.test.ts src/app/sitemap.test.ts src/lib/docs.test.ts`
- [x] `cd web && pnpm lint`
- [ ] Manual: open `/changelog` locally and confirm timeline, Latest badge, category badges, and JSON-LD in page source
- [ ] Manual: `curl -s localhost:3000/sitemap.xml | grep changelog`