### PR TITLE
feat(cli): make `completion` validate its shell argument

### DIFF
--- a/cli/cmd/completion.go
+++ b/cli/cmd/completion.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	// Replace cobra's default `completion` command with our own. The default
+	// exits 0 on an unknown shell (e.g. `completion fish-shell` prints help and
+	// succeeds); ours validates the shell argument and errors cleanly. Disabling
+	// only affects the user-facing `completion` command — the hidden `__complete`
+	// runtime that powers interactive tab-completion is unaffected.
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
+	rootCmd.AddCommand(completionCmd)
+}
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate a shell completion script",
+	Long: `Generate a shell completion script for agentclash.
+
+Load completions for your shell:
+
+  Bash:
+    agentclash completion bash | sudo tee /etc/bash_completion.d/agentclash > /dev/null
+    # or, per-user: echo 'source <(agentclash completion bash)' >> ~/.bashrc
+
+  Zsh:
+    agentclash completion zsh > "${fpath[1]}/_agentclash"
+    # ensure 'autoload -U compinit && compinit' is in ~/.zshrc, then restart the shell
+
+  fish:
+    agentclash completion fish > ~/.config/fish/completions/agentclash.fish
+
+  PowerShell:
+    agentclash completion powershell | Out-String | Invoke-Expression`,
+	// ExactValidArgs(1) + ValidArgs rejects both a missing shell and an unknown
+	// shell with a non-zero exit, which is the behavior the default command lacks.
+	Args:                  cobra.ExactValidArgs(1),
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	DisableFlagsInUseLine: true,
+	// Completion scripts are shell code, not data — always written raw to stdout,
+	// never wrapped by --json/--output.
+	RunE: func(cmd *cobra.Command, args []string) error {
+		switch args[0] {
+		case "bash":
+			return cmd.Root().GenBashCompletionV2(os.Stdout, true)
+		case "zsh":
+			return cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			return cmd.Root().GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			return cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+		default:
+			// Unreachable given ExactValidArgs + ValidArgs, but explicit.
+			return fmt.Errorf("unsupported shell %q", args[0])
+		}
+	},
+}

--- a/cli/cmd/completion_test.go
+++ b/cli/cmd/completion_test.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCompletionEmitsScripts(t *testing.T) {
+	cases := []struct {
+		shell  string
+		needle string
+	}{
+		{"zsh", "#compdef agentclash"},
+		{"bash", "bash completion"},
+		{"fish", "complete -c agentclash"},
+		{"powershell", "Register-ArgumentCompleter"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.shell, func(t *testing.T) {
+			cap := captureStdout(t)
+			err := executeCommand(t, []string{"completion", tc.shell}, "http://unused")
+			out := cap.finish()
+			if err != nil {
+				t.Fatalf("completion %s returned error: %v", tc.shell, err)
+			}
+			if !strings.Contains(out, tc.needle) {
+				t.Errorf("completion %s output missing %q", tc.shell, tc.needle)
+			}
+		})
+	}
+}
+
+func TestCompletionUnknownShellFails(t *testing.T) {
+	err := executeCommand(t, []string{"completion", "fish-shell"}, "http://unused")
+	if err == nil {
+		t.Fatal("completion with an unknown shell should return a non-nil error")
+	}
+}
+
+func TestCompletionNoArgFails(t *testing.T) {
+	err := executeCommand(t, []string{"completion"}, "http://unused")
+	if err == nil {
+		t.Fatal("completion with no shell argument should return a non-nil error")
+	}
+}

--- a/docs/cli-distribution.md
+++ b/docs/cli-distribution.md
@@ -88,6 +88,27 @@ npm install:
 npm uninstall -g agentclash
 ```
 
+## Shell Completion
+
+`agentclash completion <shell>` prints a completion script to stdout for
+`bash`, `zsh`, `fish`, or `powershell`. An unknown or missing shell exits
+non-zero. Homebrew and the install scripts do not place completions
+automatically — run the one-liner for your shell:
+
+```bash
+# Bash
+agentclash completion bash | sudo tee /etc/bash_completion.d/agentclash > /dev/null
+# Zsh (ensure `autoload -U compinit && compinit` is in ~/.zshrc)
+agentclash completion zsh > "${fpath[1]}/_agentclash"
+# fish
+agentclash completion fish > ~/.config/fish/completions/agentclash.fish
+# PowerShell (add to your $PROFILE to persist)
+agentclash completion powershell | Out-String | Invoke-Expression
+```
+
+Interactive tab-completion of commands and flags works automatically once the
+script is sourced.
+
 ## Release Flow
 
 Stable releases are not cut on every merge. Release Please watches releasable `fix:`, `feat:`, and `feat!:` commits that touch `cli/` and opens a version bump PR for that CLI stream. Installer-only, docs-only, and release-config-only changes do not open a stable CLI release by themselves. Merging that release PR creates the `v*` tag, and the tag-triggered GoReleaser workflow publishes archives, checksums, Homebrew metadata, and npm packages.


### PR DESCRIPTION
## What

The default cobra `completion` command **exits 0 on an unknown or missing shell** — `agentclash completion fish-shell` printed help and succeeded, and bare `agentclash completion` also exited 0. This replaces it with a custom command that validates the shell arg via `ExactValidArgs(1)` + `ValidArgs{bash,zsh,fish,powershell}`, so an unknown/missing shell **exits non-zero**, while still emitting the exact same cobra-generated scripts.

`CompletionOptions.DisableDefaultCmd` only affects the user-facing `completion` command — the hidden `__complete` runtime that powers interactive tab-completion is unaffected (verified: `agentclash __complete ""` still lists commands). Adds per-shell install docs.

## Why

From the agent-first CLI research. This is primarily human ergonomics (agents invoke subcommands directly), but the "unknown shell errors cleanly" gap was a real correctness bug.

## Verification

- Happy: `completion {bash,zsh,fish,powershell}` each emit their script (asserted via output needles).
- Failure: `completion fish-shell` → **exit 1**; `completion` (no arg) → **exit 1** (both were exit 0 before).
- Dynamic completion intact: `__complete ""` still lists commands after disabling the default.
- `go build`, `go vet`, full `go test -short -race -count=1 ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)