### PR TITLE
docs(skills): gh-skill publish bundle generator + install docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ services/try-cli/node_modules/
 cli/agentclash
 cli/dist/
 cli/cmd/ci-run-spec-*/
+# Generated `gh skill` publish bundle (scripts/build-skills-bundle.mjs)
+/dist/
 
 # Runtime state emitted by Claude Code's scheduler / background runners.
 .claude/scheduled_tasks.lock

--- a/README.md
+++ b/README.md
@@ -300,6 +300,32 @@ API URL resolution order:
 --api-url > AGENTCLASH_API_URL > saved user config > default
 ```
 
+## Agent Skills
+
+AgentClash ships [Agent Skills](https://agentskills.io) that teach coding agents
+(Claude Code, Codex, Cursor, Gemini CLI, Copilot) how to drive the CLI — set up
+auth, run evals, read scorecards, gate CI, and author challenge packs.
+
+Install them straight into your agent with the CLI (idempotent; writes only
+`SKILL.md` files, never your `CLAUDE.md`/`AGENTS.md`/`.mcp.json`):
+
+```bash
+agentclash integration claude install   # -> ~/.claude/skills/
+agentclash integration codex install    # -> ~/.agents/skills/
+agentclash integration claude doctor    # verify what's installed
+```
+
+Or, on [GitHub CLI](https://cli.github.com) 2.90+, install the published bundle
+into any supported host (Claude Code, Copilot, Cursor, Codex, Gemini CLI,
+Antigravity):
+
+```bash
+gh skill install agentclash/agentclash <skill>
+```
+
+See [Use with AI Tools](web/content/docs/guides/use-with-ai-tools.mdx) for usage
+and [Publishing Agent Skills](docs/agent-skills-publishing.md) for maintainers.
+
 ## Local CLI Development
 
 The CLI lives in `cli/` and can run against the hosted API:

--- a/docs/agent-skills-publishing.md
+++ b/docs/agent-skills-publishing.md
@@ -1,0 +1,77 @@
+# Publishing Agent Skills via `gh skill`
+
+AgentClash's Agent Skills (`web/content/agent-skills`) reach coding agents
+through two channels, both generated from that single canonical source:
+
+| Channel | For | How |
+| --- | --- | --- |
+| `agentclash integration <claude\|codex> install` | Users who already have the CLI | Embedded snapshot (`cli/internal/skills/snapshot`); see [CLI workflow handoff](cli-workflow-handoff.md). |
+| `gh skill install agentclash/agentclash <skill>` | Any [supported host](#supported-hosts) (incl. ones without the CLI) | Published GitHub release validated against the [agentskills.io](https://agentskills.io) spec. |
+
+`web/content/agent-skills` is the source of truth. Do **not** hand-edit either
+generated bundle.
+
+## Build the publishable bundle
+
+```bash
+node scripts/build-skills-bundle.mjs
+# -> dist/skills-bundle/skills/<name>/SKILL.md  (gitignored build artifact)
+```
+
+The script flattens the canonical skills into the `skills/*/SKILL.md` layout
+`gh skill` discovers and **self-validates** every skill against the rules
+`gh skill publish` enforces — kebab-case `name` ≤ 64 chars, `description`
+present and ≤ 1024 chars, folder name equal to the frontmatter `name`, and no
+duplicate names. A non-zero exit means the bundle is **not** publish-ready; fix
+the offending `SKILL.md` in `web/content/agent-skills` and rebuild.
+
+The root catalog (`web/content/agent-skills/SKILL.md`) is intentionally excluded:
+it is a docs-navigation hub, and a root-level `SKILL.md` trips `gh skill`'s
+`name="."` rejection ([cli/cli#13552](https://github.com/cli/cli/issues/13552)).
+
+## Prerequisites (one-time, maintainer)
+
+- **GitHub CLI ≥ 2.90.0** (`gh skill` ships in 2.90.0; check `gh --version`).
+- On the `agentclash/agentclash` repo: `gh skill publish` interactively adds an
+  `agent-skills` topic and cuts a GitHub release. It also validates/warns on tag
+  protection, secret scanning, and code scanning — enable those or be ready to
+  override. This needs repo-admin rights.
+- **Public preview:** `gh skill` and the Agent Skills spec are in public preview
+  and may change without notice. Pin the documented `gh` version and date-stamp
+  any screenshots/output you keep.
+
+## Validate and publish
+
+```bash
+# Validate locally first (no release is cut):
+gh skill preview dist/skills-bundle
+gh skill publish dist/skills-bundle --dry-run     # add --fix to auto-normalize
+
+# Publish (semver tag). Prefer folding this into the existing v* release flow
+# rather than ad hoc tags (see CLAUDE.md), once the cadence is decided:
+gh skill publish dist/skills-bundle --tag v0.<minor>.0
+```
+
+## Supported hosts
+
+`gh skill install` writes to the correct directory for **Claude Code, GitHub
+Copilot, Cursor, Codex, Gemini CLI, and Antigravity**. Users install a skill
+with:
+
+```bash
+gh skill install agentclash/agentclash <skill> --agent <host>
+```
+
+## Discoverability
+
+`gh skill publish` is repo-based, not a separate marketplace: discovery is via
+the `agent-skills` repo topic and `gh skill search`, plus the install-by-name
+path above. Surface the install command in the README and onboarding so users
+know it exists.
+
+## Notes
+
+- `web/content/agent-skills` remains canonical; rebuild the bundle (and the CLI
+  embed snapshot via `make cli-skills-snapshot`) whenever a skill changes.
+- Adding `license: MIT` to each `SKILL.md` frontmatter is an optional spec
+  enhancement; the repo `LICENSE` already applies.

--- a/scripts/build-skills-bundle.mjs
+++ b/scripts/build-skills-bundle.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// Build a `gh skill`-publishable bundle from the canonical Agent Skills
+// (web/content/agent-skills) into dist/skills-bundle/skills/<name>/SKILL.md.
+//
+// web/content stays the single source of truth; this is a generated publish
+// artifact (gitignored). The layout matches the agentskills.io discovery glob
+// `skills/*/SKILL.md`, so a maintainer can:
+//
+//   node scripts/build-skills-bundle.mjs
+//   gh skill publish dist/skills-bundle            # needs gh >= 2.90.0
+//
+// The script SELF-VALIDATES every skill against the spec rules `gh skill
+// publish` enforces (kebab-case name <= 64 chars, description present <= 1024,
+// folder name == frontmatter name, no duplicates) and exits non-zero on any
+// violation — so a green run means the bundle is publish-ready even without gh.
+import {
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..");
+const SRC = path.join(repoRoot, "web", "content", "agent-skills");
+const OUT = path.join(repoRoot, "dist", "skills-bundle");
+const SKILLS_DIR = path.join(OUT, "skills");
+// The catalog/hub at the root of agent-skills is a docs-navigation index, not a
+// standalone installable skill, and a root-level SKILL.md trips gh skill's
+// name="." rejection (cli/cli#13552). It is excluded from the published bundle.
+const ROOT_CATALOG = path.join(SRC, "SKILL.md");
+
+const NAME_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+function parseFrontmatter(content, file) {
+  if (!content.startsWith("---\n")) {
+    throw new Error(`${file}: missing YAML frontmatter`);
+  }
+  const end = content.indexOf("\n---", 4);
+  if (end === -1) {
+    throw new Error(`${file}: unterminated YAML frontmatter`);
+  }
+  const raw = content.slice(4, end).trim();
+  const fields = {};
+  let inMetadata = false;
+  for (const line of raw.split("\n")) {
+    if (/^\s*$/.test(line)) continue;
+    if (line === "metadata:") {
+      inMetadata = true;
+      continue;
+    }
+    const match = line.match(/^(\s*)([A-Za-z0-9_.-]+):\s*(.*)$/);
+    if (!match) continue;
+    const [, indent, key, rawValue] = match;
+    const value = rawValue.replace(/^["']|["']$/g, "");
+    if (inMetadata && indent.length > 0) {
+      fields[`metadata.${key}`] = value;
+    } else {
+      inMetadata = false;
+      fields[key] = value;
+    }
+  }
+  return fields;
+}
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(full));
+    else if (entry.name === "SKILL.md") out.push(full);
+  }
+  return out;
+}
+
+const files = walk(SRC).sort();
+
+rmSync(OUT, { recursive: true, force: true });
+mkdirSync(SKILLS_DIR, { recursive: true });
+
+const seen = new Set();
+let count = 0;
+
+for (const file of files) {
+  if (path.resolve(file) === path.resolve(ROOT_CATALOG)) continue;
+  const content = readFileSync(file, "utf8");
+  const meta = parseFrontmatter(content, file);
+
+  // Spec validation (mirrors what `gh skill publish` enforces).
+  if (!meta.name) throw new Error(`${file}: frontmatter missing 'name'`);
+  if (!NAME_RE.test(meta.name)) {
+    throw new Error(`${file}: name "${meta.name}" must be kebab-case [a-z0-9-]`);
+  }
+  if (meta.name.length > 64) {
+    throw new Error(`${file}: name "${meta.name}" exceeds 64 chars`);
+  }
+  if (!meta.description) throw new Error(`${file}: frontmatter missing 'description'`);
+  if (meta.description.length > 1024) {
+    throw new Error(`${file}: description exceeds 1024 chars`);
+  }
+  if (seen.has(meta.name)) {
+    throw new Error(`duplicate skill name "${meta.name}"`);
+  }
+  seen.add(meta.name);
+
+  // Folder name MUST equal the frontmatter name (a publish requirement).
+  const skillDir = path.join(SKILLS_DIR, meta.name);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(path.join(skillDir, "SKILL.md"), content);
+  count++;
+}
+
+console.log(
+  `Built ${count} publish-ready skills in ${path.relative(repoRoot, SKILLS_DIR)}\n` +
+    `Validation passed (kebab name <=64, description present <=1024, name==dirname, unique).\n` +
+    `Publish with: gh skill publish ${path.relative(repoRoot, OUT)}   (requires gh >= 2.90.0)`,
+);

--- a/web/content/docs/guides/use-with-ai-tools.mdx
+++ b/web/content/docs/guides/use-with-ai-tools.mdx
@@ -1,7 +1,7 @@
 ---
 title: Use with AI Tools
-description: Feed AgentClash docs into ChatGPT, Codex, Claude Code, and similar tools using llms.txt and markdown exports.
-dateModified: 2026-06-01
+description: Feed AgentClash docs into ChatGPT, Codex, Claude Code, and similar tools using llms.txt and markdown exports, and install the AgentClash Agent Skills.
+dateModified: 2026-06-02
 ---
 
 Goal: give an assistant or coding agent enough AgentClash context to answer questions, draft workflows, or transform the docs into internal runbooks.
@@ -86,6 +86,32 @@ Use a narrower `/docs-md/...` page instead of the full bundle.
 ### The answer mixes product claims with guesses
 
 Tell the tool to answer only from the supplied docs export and cite the page title it used.
+
+## Install AgentClash Agent Skills
+
+Beyond feeding docs into a tool, AgentClash ships **Agent Skills** that teach a
+coding agent to operate the CLI directly — setup, eval runs, scorecard reading,
+CI gates, and challenge-pack authoring.
+
+Install them with the AgentClash CLI. It is idempotent and writes only
+`SKILL.md` files — never your `CLAUDE.md`, `AGENTS.md`, or `.mcp.json`:
+
+```bash
+agentclash integration claude install   # -> ~/.claude/skills/
+agentclash integration codex install    # -> ~/.agents/skills/
+agentclash integration claude doctor     # verify installed / missing / drifted
+```
+
+Or install the published bundle with [GitHub CLI](https://cli.github.com) 2.90+,
+which drops skills into the correct directory for Claude Code, Copilot, Cursor,
+Codex, Gemini CLI, or Antigravity:
+
+```bash
+gh skill install agentclash/agentclash <skill>
+```
+
+The skills assume the `agentclash` CLI is on your PATH (`requires_cli: true`).
+After installing, reload skills in your agent.
 
 ## See also
 


### PR DESCRIPTION
## What

Closes the loop on agent-skill distribution: a generator that produces a **`gh skill`-publishable bundle** from the canonical `web/content/agent-skills`, plus user + maintainer docs.

- **`scripts/build-skills-bundle.mjs`** — flattens the canonical skills into the `skills/*/SKILL.md` layout `gh skill` discovers (→ `dist/skills-bundle/`, gitignored), and **self-validates** each skill against the rules `gh skill publish` enforces: kebab `name` ≤ 64, `description` present ≤ 1024, folder name == frontmatter `name`, no duplicates. A green run = publish-ready. Excludes the root catalog hub ([cli/cli#13552](https://github.com/cli/cli/issues/13552)).
- **README** "Agent Skills" section + **use-with-ai-tools** guide: both the CLI path (`agentclash integration <agent> install`, from #919) and `gh skill install agentclash/agentclash <skill>`.
- **`docs/agent-skills-publishing.md`** — maintainer recipe (build → validate → publish).

This honors the chosen approach: `web/content` stays the single source of truth; both the CLI embed snapshot (#919) and this bundle are generated from it.

## ⚠️ Needs you (can't run/verify here)

`gh skill publish` requires **`gh ≥ 2.90.0`** (this machine has 2.86) and **repo-admin settings** (an `agent-skills` topic + tag/secret/code-scanning, added interactively on publish). The generator + validation are fully verified; the publish step is yours. `gh skill` is also in **public preview**.

## Verification

- `node scripts/build-skills-bundle.mjs` → builds **16 skills, validation passes**, and an external check confirmed `name == dirname` for all.
- `dist/` is gitignored (no generated artifact committed).
- `docs.test.ts` (27/27) still passes after the `use-with-ai-tools.mdx` edit.
- No conflicts with the other open PRs (touches only files they don't).

Part of the SEO/AEO + agent-first series (#915, #916, #917, #918, #919).

🤖 Generated with [Claude Code](https://claude.com/claude-code)