### PR TITLE
feat(agent-skills): P0 workflow skills (hub, quickstart, compare-and-triage)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ testing/*
 !testing/feat-dataset-generation-892.md
 !testing/feat-changelog-page.md
 !testing/feat-docs-revamp.md
+!testing/feat-skills-p0-workflow.md

--- a/testing/feat-skills-p0-workflow.md
+++ b/testing/feat-skills-p0-workflow.md
@@ -1,0 +1,62 @@
+# feat/skills-p0-workflow — Test Contract
+
+## Functional Behavior
+
+P0 portable agent skills from issue #922 must ship in the canonical docs tree:
+
+- `web/content/agent-skills/agentclash-hub/SKILL.md` — workflow map, dependency order, UI links, hosted defaults.
+- `web/content/agent-skills/agentclash-quickstart/SKILL.md` — documents `agentclash quickstart` checks and next-command guidance.
+- `web/content/agent-skills/agentclash-compare-and-triage/SKILL.md` — documents `compare latest`, `compare gate`, `baseline`, and `replay triage`.
+- `web/content/agent-skills/agentclash-eval-runner/SKILL.md` — extended with `eval session list|get|follow` and `run series create|report`.
+- Catalog `SKILL.md` dependency order includes hub, quickstart, and compare-and-triage.
+- `web/src/lib/docs.ts` DOCS_NAV lists the three new top-level skills.
+- `web/src/lib/docs.test.ts` includes new skill markdown paths and resolves nav items.
+
+Each skill follows the catalog contract: frontmatter, Purpose, Use When, Do Not Use When, Inputs, Environment, Procedure, Commands, Expected Output, Failure Modes, Safety Notes, Report Back Format, Related Skills, Related Docs.
+
+## Unit Tests
+
+- `web/src/lib/docs.test.ts` — `generates an agent skills index page` still passes; index mentions new skills when present on disk.
+- `web/src/lib/docs.test.ts` — `includes the index and every skill in markdown paths` includes:
+  - `/docs-md/agent-skills/agentclash-hub`
+  - `/docs-md/agent-skills/agentclash-quickstart`
+  - `/docs-md/agent-skills/agentclash-compare-and-triage`
+- `web/src/lib/docs.test.ts` — `resolves every docs navigation item` passes for new nav entries.
+- `web/src/lib/docs.test.ts` — `includes platform pages, blog posts, and agent skills in llms.txt` includes new skill URLs.
+
+## Integration / Functional Tests
+
+- Docs generator discovers 20 skill files (17 existing + 3 new top-level).
+- Category pages unchanged for nested skills.
+
+## Smoke Tests
+
+```bash
+cd web && npm test -- docs.test.ts
+cd web && npm run lint
+```
+
+## E2E Tests
+
+N/A — documentation-only change; no browser E2E required.
+
+## Manual / cURL Tests
+
+```bash
+# After build or dev server, verify markdown exports exist (local):
+curl -sS http://localhost:3000/docs-md/agent-skills/agentclash-hub | head
+curl -sS http://localhost:3000/docs-md/agent-skills/agentclash-quickstart | head
+curl -sS http://localhost:3000/docs-md/agent-skills/agentclash-compare-and-triage | head
+curl -sS http://localhost:3000/llms.txt | rg 'agentclash-hub|agentclash-quickstart|agentclash-compare-and-triage'
+```
+
+Manual CLI spot-check (hosted, optional):
+
+```bash
+export AGENTCLASH_API_URL="https://api.agentclash.dev"
+agentclash quickstart --json
+agentclash compare latest --help
+agentclash replay triage --help
+agentclash eval session list --help
+agentclash run series report --help
+```

--- a/web/content/agent-skills/SKILL.md
+++ b/web/content/agent-skills/SKILL.md
@@ -143,22 +143,25 @@ go test -short -race -count=1 ./...
 Read related skills in this order so downstream workflows do not redefine upstream concepts:
 
 1. `agentclash-skill-catalog`
-2. `agentclash-cli-setup`
-3. `agentclash-runtime-resources-setup`
-4. `agentclash-agent-build-author`
-5. `agentclash-agent-deployment-setup`
-6. `agentclash-challenge-pack-planner`
-7. `agentclash-challenge-pack-yaml-author`
-8. `agentclash-challenge-pack-input-sets`
-9. `agentclash-challenge-pack-tools-sandbox`
-10. `agentclash-challenge-pack-artifacts`
-11. `agentclash-challenge-pack-scoring-validators`
-12. `agentclash-challenge-pack-llm-judges`
-13. `agentclash-challenge-pack-validation-publish`
-14. `agentclash-eval-runner`
-15. `agentclash-scorecard-reader`
-16. `agentclash-regression-flywheel`
-17. `agentclash-ci-release-gate`
+2. `agentclash-hub`
+3. `agentclash-cli-setup`
+4. `agentclash-quickstart`
+5. `agentclash-runtime-resources-setup`
+6. `agentclash-agent-build-author`
+7. `agentclash-agent-deployment-setup`
+8. `agentclash-challenge-pack-planner`
+9. `agentclash-challenge-pack-yaml-author`
+10. `agentclash-challenge-pack-input-sets`
+11. `agentclash-challenge-pack-tools-sandbox`
+12. `agentclash-challenge-pack-artifacts`
+13. `agentclash-challenge-pack-scoring-validators`
+14. `agentclash-challenge-pack-llm-judges`
+15. `agentclash-challenge-pack-validation-publish`
+16. `agentclash-eval-runner`
+17. `agentclash-scorecard-reader`
+18. `agentclash-compare-and-triage`
+19. `agentclash-regression-flywheel`
+20. `agentclash-ci-release-gate`
 
 ## Review Checklist
 - The folder path matches the taxonomy.

--- a/web/content/agent-skills/agentclash-ci-release-gate/SKILL.md
+++ b/web/content/agent-skills/agentclash-ci-release-gate/SKILL.md
@@ -345,6 +345,7 @@ Next command: <exact agentclash command or GitHub Actions fix>
 ```
 
 ## Related Skills
+- `agentclash-hub`: workflow map and dependency order.
 - `agentclash-cli-setup`: authenticate, select workspace, and configure hosted API.
 - `agentclash-runtime-resources-setup`: create runtime profiles, provider accounts, model aliases, secrets, and tools.
 - `agentclash-agent-build-author`: create the candidate build spec and ready build version.
@@ -352,6 +353,7 @@ Next command: <exact agentclash command or GitHub Actions fix>
 - `agentclash-challenge-pack-validation-publish`: publish the challenge pack version and optional input sets.
 - `agentclash-eval-runner`: run ad hoc evals before formal CI gates.
 - `agentclash-scorecard-reader`: inspect scorecard, comparison, replay, and failure evidence.
+- `agentclash-compare-and-triage`: baseline bookmarks, `compare latest --gate`, and replay triage.
 - `agentclash-regression-flywheel`: promote failures and manage regression suites/cases.
 
 ## Related Docs

--- a/web/content/agent-skills/agentclash-cli-setup/SKILL.md
+++ b/web/content/agent-skills/agentclash-cli-setup/SKILL.md
@@ -198,6 +198,11 @@ Next command: <single recommended command>
 Notes: <config precedence, local override, or token caveat if relevant>
 ```
 
+## Related Skills
+- `agentclash-hub` — load first for full workflow map and UI links
+- `agentclash-quickstart` — readiness checks after auth
+- `agentclash-eval-runner`
+
 ## Related Docs
 - `/docs-md/getting-started/quickstart`
 - `/docs-md/guides/use-with-ai-tools`

--- a/web/content/agent-skills/agentclash-compare-and-triage/SKILL.md
+++ b/web/content/agent-skills/agentclash-compare-and-triage/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: agentclash-compare-and-triage
+description: Use when comparing baseline vs candidate AgentClash runs, evaluating release gates, managing workspace baseline bookmarks, or building a replay triage envelope after an eval completes.
+metadata:
+  agentclash.role: comparison
+  agentclash.version: "1"
+  agentclash.requires_cli: "true"
+---
+
+# AgentClash Compare And Triage
+
+## Purpose
+Manage workspace baselines, compare runs for regressions, evaluate release gates for CI, and assemble replay triage evidence (ranking, failures, scorecard, replay steps) in one workflow.
+
+## Use When
+- A user asks whether a new run regressed vs a baseline.
+- CI needs `compare gate` exit codes for pass/fail verdicts.
+- A user wants the fastest path: `compare latest` against the saved baseline bookmark.
+- After a run completes, the user needs structured triage with suggested follow-up commands.
+
+## Do Not Use When
+- No completed runs exist yet — use `agentclash-eval-runner` first.
+- The task is only deep scorecard interpretation without comparison — use `agentclash-scorecard-reader`.
+- The task is authoring CI manifest files from scratch — use `agentclash-ci-release-gate` (this skill covers CLI compare/gate/triage commands).
+
+## Inputs Needed
+- Workspace with at least one completed candidate run.
+- Baseline bookmark (`baseline set`) for `compare latest`, or explicit run IDs for `compare runs` / `compare gate`.
+- Optional run agent ID or label when runs have multiple agents.
+- For triage: run ID or selector; optional `--agent`, `--cursor`, `--limit`.
+
+## Environment
+```bash
+export AGENTCLASH_API_URL="https://api.agentclash.dev"
+agentclash workspace use <WORKSPACE_ID>
+agentclash baseline show
+```
+
+## Procedure
+1. After a good eval, bookmark it: `agentclash baseline set [run] --agent <label>`.
+2. Run new evals with `agentclash eval start` (see eval-runner skill).
+3. Compare:
+   - Ad hoc: `agentclash compare runs --baseline <ID> --candidate <ID>`
+   - Fast path: `agentclash compare latest` (uses saved baseline vs latest non-baseline run)
+   - CI gate: `agentclash compare gate --baseline <ID> --candidate <ID>`
+   - Latest + gate: `agentclash compare latest --gate`
+4. Triage evidence: `agentclash replay triage <run> [--agent <label>]`.
+5. Follow `next_commands` from triage JSON for deeper replay or scorecard reads.
+
+## Commands
+
+### Baseline bookmark (workspace-scoped)
+```bash
+agentclash baseline set [run]
+agentclash baseline set [run] --agent <RUN_AGENT_ID_OR_LABEL>
+agentclash baseline show
+agentclash baseline clear
+```
+
+- `baseline set` with no run opens an interactive picker in a TTY.
+- Bookmark stores run ID, run agent ID, names, and timestamp in CLI config.
+- `compare latest` reads this bookmark as the baseline side.
+
+### Compare runs
+```bash
+agentclash compare runs \
+  --baseline <BASELINE_RUN_ID> \
+  --candidate <CANDIDATE_RUN_ID> \
+  --baseline-agent <RUN_AGENT_ID_OR_LABEL> \
+  --candidate-agent <RUN_AGENT_ID_OR_LABEL>
+
+agentclash run compare \
+  --baseline <BASELINE_RUN_ID> \
+  --candidate <CANDIDATE_RUN_ID>
+```
+
+Shared comparison flags (both `compare runs` and `run compare`):
+
+- `--baseline` (required)
+- `--candidate` (required)
+- `--baseline-agent` — optional; defaults to first agent or saved baseline agent when applicable
+- `--candidate-agent` — optional
+
+### Compare latest (baseline bookmark vs newest run)
+```bash
+agentclash compare latest
+agentclash compare latest --gate
+agentclash compare latest --agent <RUN_AGENT_ID_OR_LABEL>
+agentclash compare latest --baseline-agent <ID_OR_LABEL> --candidate-agent <ID_OR_LABEL>
+agentclash compare latest --json
+```
+
+- Requires a saved baseline bookmark unless baseline run is inferable from flags.
+- `--gate` evaluates release gate rules and returns nonzero exit for non-pass verdicts (same as `compare gate`).
+- Structured output includes comparison envelope and optional `release_gate` object.
+
+### Compare gate (explicit IDs, CI-friendly exit code)
+```bash
+agentclash compare gate \
+  --baseline <BASELINE_RUN_ID> \
+  --candidate <CANDIDATE_RUN_ID> \
+  --baseline-agent <RUN_AGENT_ID_OR_LABEL> \
+  --candidate-agent <RUN_AGENT_ID_OR_LABEL>
+```
+
+- `--baseline` and `--candidate` are required.
+- Non-pass gate verdicts exit nonzero for shell/CI scripts.
+
+### Replay triage envelope
+```bash
+agentclash replay triage <RUN_ID_OR_SELECTOR>
+agentclash replay triage <RUN_ID> --agent <RUN_AGENT_ID_OR_LABEL>
+agentclash replay triage <RUN_ID> --cursor 0 --limit 5
+agentclash replay triage <RUN_ID> --json
+```
+
+Flags:
+
+- `--agent` — run agent ID or label; required in non-interactive mode when multiple agents exist.
+- `--cursor` — replay step offset (default 0).
+- `--limit` — steps to include, 1–50 (default 5).
+
+Triage envelope includes:
+
+- `run`, `agents`, `selected_agent`, `ranking`, `failures`, `artifacts`
+- `scorecard` and `replay` when an agent is selected
+- `next_commands` — suggested follow-ups (e.g. deeper replay, scorecard, compare)
+
+## Expected Output
+- **Compare** — human tables or JSON with candidate/baseline metrics, deltas, and optional `release_gate.verdict`.
+- **compare latest --gate** — prints comparison then exits 1 on gate failure.
+- **replay triage** — consolidated evidence bundle; use `--json` for automation.
+
+## Failure Modes
+- No baseline bookmark for `compare latest` → run `agentclash baseline set` on a known-good run.
+- No candidate run newer than baseline → create a new eval first.
+- Multiple run agents without `--agent` on triage → pass `--agent` or use interactive TTY.
+- Gate pending scorecard → wait for run completion; check `agentclash run get <id>`.
+- Invalid agent selector → list agents with `agentclash run agents <run_id> --json`.
+
+## Safety Notes
+- Comparisons are read-only but may surface sensitive failure excerpts — do not paste into public channels.
+- Gate failures should block release; confirm with the user before overriding CI exit codes.
+
+## Report Back Format
+```text
+Baseline: <run_id> / agent <id or label>
+Candidate: <run_id> / agent <id or label>
+Compare command: <command used>
+Gate verdict: <pass|fail|pending|n/a>
+Key deltas: <summary>
+Triage agent: <selected agent>
+Failures: <count / top class>
+Next commands:
+- <from triage envelope>
+Recommendation: <ship|investigate|rerun>
+```
+
+## Related Skills
+- `agentclash-hub`
+- `agentclash-eval-runner`
+- `agentclash-scorecard-reader`
+- `agentclash-ci-release-gate`
+- `agentclash-regression-flywheel`
+
+## Related Docs
+- `/docs-md/guides/interpret-results`
+- `/docs-md/guides/ci-cd-agent-gates`
+- `/docs-md/concepts/replay-and-scorecards`
+- `/docs-md/reference/cli`

--- a/web/content/agent-skills/agentclash-eval-runner/SKILL.md
+++ b/web/content/agent-skills/agentclash-eval-runner/SKILL.md
@@ -207,6 +207,52 @@ Exact repetition behavior:
 
 In human output, the CLI prints eval session ID, status, repetitions, and child run IDs. In structured output, it prints the raw response envelope.
 
+## Eval Session Commands
+When an eval session already exists (from `--repetitions >= 2` or API), inspect and follow aggregation with:
+
+```bash
+agentclash eval session list
+agentclash eval session list --limit 20 --offset 0
+agentclash eval session get <EVAL_SESSION_ID>
+agentclash eval session follow <EVAL_SESSION_ID>
+agentclash eval session follow <EVAL_SESSION_ID> --poll-interval 5s --timeout 30m
+```
+
+Behavior:
+
+- `eval session list` — paginated workspace eval sessions (`--limit` 1–100, `--offset` ≥ 0).
+- `eval session get` — session detail plus aggregate metrics when available.
+- `eval session follow` — polls until aggregation finishes; `--timeout 0` disables timeout.
+- Requires workspace context like other eval commands.
+
+Use `eval session follow` after creating a multi-repetition eval when you need aggregated results before reading scorecards or comparisons.
+
+## Run Series Commands
+`run series` crosses deployment lineups with seeds for race-style series evals:
+
+```bash
+agentclash run series create \
+  --challenge-pack-version <CHALLENGE_PACK_VERSION_ID> \
+  --deployment-lineups <LINEUP_ID> \
+  --seeds 3 \
+  --name "Series smoke"
+
+agentclash run series report <EVAL_SESSION_ID>
+```
+
+`run series create` flags:
+
+- `--challenge-pack-version` — required pack version ID.
+- `--input-set` — optional challenge input set ID.
+- `--deployment-lineups` — repeatable lineup IDs crossed with `--seeds`.
+- `--seeds` — integer 1–100 per lineup.
+- `--name` — optional series name.
+- `--max-iter` — optional per-child-run iteration override (1–1000).
+
+`run series create` posts to `/v1/eval-sessions` and returns an eval session plus child run IDs (same family as `eval start --repetitions`).
+
+`run series report <eval-session-id>` reads `/v1/eval-sessions/<id>` and prints aggregate score, correctness, and cost for the series.
+
 ## Follow and Events
 Use `--follow` for interactive runs when you want immediate event visibility.
 
@@ -263,7 +309,7 @@ Read command notes:
 - `invalid_challenge_input_set_id`: the input set must belong to the selected challenge pack version.
 - `invalid_race_context`: race context requires at least two agents.
 - `--race-context-cadence must be 0 (backend default) or between 1 and 10`: fix the cadence value.
-- `--follow is not supported with --repetitions >= 2`: create the eval session, then stream individual child runs with `run events`.
+- `--follow is not supported with --repetitions >= 2`: create the eval session, then use `eval session follow` or stream individual child runs with `run events`.
 - `--scope suite_only requires at least one --suite or --case`: add a suite or case selection.
 - Scorecard pending or errored: report the state, then collect `run events`, `run agents`, and `run failures`.
 
@@ -293,6 +339,8 @@ Ranking: <summary or unavailable>
 Failures: <count/filter summary or unavailable>
 Scorecard: <state/link/summary or unavailable>
 Evidence commands:
+- agentclash eval session get <EVAL_SESSION_ID> --json
+- agentclash run series report <EVAL_SESSION_ID>
 - agentclash run get <RUN_ID> --json
 - agentclash run agents <RUN_ID> --json
 - agentclash run ranking <RUN_ID> --json
@@ -301,10 +349,13 @@ Next action: <recommendation>
 ```
 
 ## Related Skills
+- `agentclash-hub`
 - `agentclash-cli-setup`
+- `agentclash-quickstart`
 - `agentclash-agent-deployment-setup`
 - `agentclash-challenge-pack-validation-publish`
 - `agentclash-scorecard-reader`
+- `agentclash-compare-and-triage`
 - `agentclash-regression-flywheel`
 - `agentclash-ci-release-gate`
 

--- a/web/content/agent-skills/agentclash-hub/SKILL.md
+++ b/web/content/agent-skills/agentclash-hub/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: agentclash-hub
+description: Use when starting any AgentClash eval, CLI, or challenge-pack task. Load this skill first for the full workflow map, skill dependency order, product UI links, hosted defaults, and pointers to every other AgentClash skill.
+metadata:
+  agentclash.role: hub
+  agentclash.version: "1"
+  agentclash.requires_cli: "false"
+---
+
+# AgentClash Hub
+
+## Purpose
+Give coding agents maximum context to run AgentClash evals through the CLI and guide humans to the right web UI pages — without reading the AgentClash source repository.
+
+## Use When
+- A user asks to evaluate agents, run evals, compare models, or use AgentClash for the first time.
+- You need to pick the right downstream skill before acting.
+- You need hosted defaults, UI links, or the end-to-end eval workflow in one place.
+
+## Do Not Use When
+- A narrower skill already matches (e.g. only CLI auth repair → `agentclash-cli-setup`).
+- The task is only to edit AgentClash product source code in the monorepo.
+
+## Environment
+Use production unless the user explicitly runs a local stack:
+
+```bash
+export AGENTCLASH_API_URL="https://api.agentclash.dev"
+agentclash auth login --device
+agentclash link
+agentclash quickstart
+```
+
+Install the CLI: `npm i -g agentclash` or see `/docs-md/getting-started/quickstart`.
+
+Portable bundle install (copy skills to agent host): https://github.com/agentclash/agent-skills
+
+## Procedure
+1. Load this hub to pick the next skill.
+2. Run `agentclash quickstart` if CLI readiness is unknown.
+3. Follow dependency order for setup → pack → run → review → regression → CI.
+4. Send the user to the matching UI page when they need a visual surface.
+
+## End-To-End Eval Workflow (CLI)
+
+```text
+1. agentclash-cli-setup              → auth, workspace, doctor
+2. agentclash-quickstart             → readiness checks + next command
+3. agentclash-runtime-resources-setup → provider, model alias, runtime profile, secrets
+4. agentclash-agent-build-author     → build spec + ready build version
+5. agentclash-agent-deployment-setup → deployment ID for runs
+6. challenge-pack skills             → plan, YAML, validate, publish pack
+7. agentclash-eval-runner            → eval start / run create / follow / sessions / series
+8. agentclash-scorecard-reader       → rankings, scorecards, replay, artifacts
+9. agentclash-compare-and-triage     → baseline, compare latest/gate, replay triage
+10. agentclash-regression-flywheel   → promote failures, suite-only reruns
+11. agentclash-ci-release-gate       → CI manifest + gate (optional)
+```
+
+Human-friendly shortcut after setup:
+
+```bash
+agentclash quickstart
+agentclash eval start --follow
+agentclash baseline set
+agentclash eval scorecard
+agentclash compare latest --gate
+agentclash replay triage
+```
+
+## Skill Dependency Order
+Read skills in this order when multiple apply:
+
+1. `agentclash-hub` (this file)
+2. `agentclash-skill-catalog` (when authoring or changing skills)
+3. `agentclash-cli-setup`
+4. `agentclash-quickstart`
+5. `agentclash-runtime-resources-setup`
+6. `agentclash-agent-build-author`
+7. `agentclash-agent-deployment-setup`
+8. `agentclash-challenge-pack-planner`
+9. `agentclash-challenge-pack-yaml-author`
+10. `agentclash-challenge-pack-input-sets`
+11. `agentclash-challenge-pack-tools-sandbox`
+12. `agentclash-challenge-pack-artifacts`
+13. `agentclash-challenge-pack-scoring-validators`
+14. `agentclash-challenge-pack-llm-judges`
+15. `agentclash-challenge-pack-validation-publish`
+16. `agentclash-eval-runner`
+17. `agentclash-scorecard-reader`
+18. `agentclash-compare-and-triage`
+19. `agentclash-regression-flywheel`
+20. `agentclash-ci-release-gate`
+
+Each skill folder name matches its `name` in frontmatter. When a skill lists **Related Skills**, load those before mutating remote state.
+
+## All Skills In The Catalog
+
+| Skill folder | When to load |
+| --- | --- |
+| `agentclash-hub` | First — workflow map and UI links |
+| `agentclash-quickstart` | Readiness checks and suggested next command |
+| `agentclash-cli-setup` | Install, auth, workspace, doctor |
+| `agentclash-runtime-resources-setup` | Provider accounts, models, runtime profiles, secrets |
+| `agentclash-agent-build-author` | Agent build specs and build versions |
+| `agentclash-agent-deployment-setup` | Create/select deployments |
+| `agentclash-challenge-pack-planner` | Plan a pack before YAML |
+| `agentclash-challenge-pack-yaml-author` | Write pack YAML |
+| `agentclash-challenge-pack-input-sets` | Cases and input sets |
+| `agentclash-challenge-pack-tools-sandbox` | Tools and sandbox policy |
+| `agentclash-challenge-pack-artifacts` | Assets and artifact refs |
+| `agentclash-challenge-pack-scoring-validators` | Validators |
+| `agentclash-challenge-pack-llm-judges` | LLM judges |
+| `agentclash-challenge-pack-validation-publish` | Validate and publish |
+| `agentclash-eval-runner` | Start and follow evals, sessions, series |
+| `agentclash-scorecard-reader` | Interpret results |
+| `agentclash-compare-and-triage` | Baselines, compare, replay triage |
+| `agentclash-regression-flywheel` | Promote failures to regression suites |
+| `agentclash-ci-release-gate` | CI/CD gates |
+
+Nested folders: `agent-build-skills/` and `challenge-pack-skills/` mirror the table rows above.
+
+## Product UI — Where To Send The User
+
+Base URL: **https://agentclash.dev**
+
+| User goal | UI path |
+| --- | --- |
+| Sign in / account | https://agentclash.dev |
+| Docs home | https://agentclash.dev/docs |
+| Quickstart | https://agentclash.dev/docs/getting-started/quickstart |
+| First eval walkthrough | https://agentclash.dev/docs/getting-started/first-eval |
+| Agent skills (web catalog) | https://agentclash.dev/docs/agent-skills |
+| CLI reference | https://agentclash.dev/docs/reference/cli |
+| Challenge packs guide | https://agentclash.dev/docs/guides/write-a-challenge-pack |
+| Multi-turn packs | https://agentclash.dev/docs/challenge-packs/multi-turn |
+| Interpret results | https://agentclash.dev/docs/guides/interpret-results |
+| CI/CD gates | https://agentclash.dev/docs/guides/ci-cd-agent-gates |
+| Workspace runs (after login) | App dashboard → Runs list |
+| Live run events | Run detail page while status is running |
+| Scorecards & comparisons | Run detail → scorecard / ranking views after completion |
+
+When you create a run via CLI, tell the user:
+
+```text
+Open https://agentclash.dev and navigate to your workspace runs, or search for run ID <RUN_ID> after signing in.
+```
+
+## AgentClash Concepts (30-Second Model)
+
+- **Challenge pack** — versioned eval workload (cases, scoring, tools policy).
+- **Input set** — which cases run in a given eval.
+- **Agent build / deployment** — the agent under test (model + runtime + tools).
+- **Run** — one execution of pack × input set × deployments.
+- **Eval session** — repeated runs (`eval start --repetitions N` or `run series create`).
+- **Scorecard** — structured results, comparisons, release gate input.
+- **Baseline bookmark** — workspace default run/agent for `compare latest`.
+- **Regression suite** — promoted failures for suite-only reruns.
+
+## Expected Output
+After loading this skill you can name the next skill, 1–3 CLI commands, and the UI page the human should open.
+
+## Failure Modes
+- Skipping `agentclash-cli-setup` when auth or workspace is unset → commands fail with workspace errors.
+- Running evals before pack publish → no runnable pack version.
+- Using localhost API URL by mistake → empty workspace or auth failures against the wrong backend.
+
+## Safety Notes
+- Confirm before production-scale evals, publishes, or CI runs that spend budget.
+- Never paste tokens, secrets, or customer data into chat.
+- Prefer `agentclash doctor` and read-only list commands before writes.
+
+## Report Back Format
+```text
+Hub loaded: yes
+Next skill: <skill-folder-name>
+CLI status: <auth/workspace/doctor summary>
+UI for user: <https://agentclash.dev/...>
+Next commands: <1-3 commands>
+```
+
+## Related Skills
+Load all skills listed in **Skill Dependency Order** as needed; start with `agentclash-cli-setup` if CLI is not configured.
+
+## Related Docs
+- `/docs-md/agent-skills`
+- `/docs-md/agent-skills/agentclash-hub`
+- `/docs-md/guides/use-with-ai-tools`
+- `/docs-md/getting-started/quickstart`
+- `/docs-md/getting-started/first-eval`

--- a/web/content/agent-skills/agentclash-quickstart/SKILL.md
+++ b/web/content/agent-skills/agentclash-quickstart/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: agentclash-quickstart
+description: Use when checking whether a workspace is ready to run AgentClash evals, interpreting quickstart readiness checks, or choosing the next CLI command after auth and workspace selection.
+metadata:
+  agentclash.role: onboarding
+  agentclash.version: "1"
+  agentclash.requires_cli: "true"
+---
+
+# AgentClash Quickstart
+
+## Purpose
+Run `agentclash quickstart` to verify auth, workspace, challenge packs, deployments, and baseline bookmark state, then report the CLI's suggested next command for eval or comparison workflows.
+
+## Use When
+- A user asks "am I ready to run an eval?" or "what should I run next?"
+- Auth and workspace are configured but pack/deployment readiness is unknown.
+- An agent needs a single read-only command before proposing `eval start` or `compare latest`.
+
+## Do Not Use When
+- CLI is not installed or auth failed — use `agentclash-cli-setup` first.
+- The user needs deep doctor diagnostics — use `agentclash doctor`.
+- The task is to create packs, deployments, or runs — use the eval-runner or challenge-pack skills after quickstart passes.
+
+## Inputs Needed
+- API URL (default hosted production).
+- Workspace ID or saved workspace from config / `AGENTCLASH_WORKSPACE`.
+- Whether the user wants structured JSON output for automation.
+
+## Environment
+```bash
+export AGENTCLASH_API_URL="https://api.agentclash.dev"
+agentclash auth login --device
+agentclash workspace use <WORKSPACE_ID>
+```
+
+## Procedure
+1. Confirm auth with `agentclash auth status`.
+2. Run `agentclash quickstart` (human) or `agentclash quickstart --json` (automation).
+3. Read each check: `auth`, `workspace`, `challenge_packs`, `deployments`, `baseline`.
+4. Execute `next_command` from the result when checks are blocking; treat `info` baseline as advisory.
+5. When ready and baseline exists, quickstart suggests `agentclash eval start --follow` or comparison flows.
+
+## Commands
+```bash
+agentclash quickstart
+agentclash quickstart --json
+```
+
+Check names and statuses in structured output:
+
+| Check | ok | todo | info |
+| --- | --- | --- | --- |
+| `auth` | Token valid | Login required | — |
+| `workspace` | Workspace resolved | Set workspace | — |
+| `challenge_packs` | ≥1 pack visible | Init/publish pack | — |
+| `deployments` | ≥1 deployment | Create deployment | — |
+| `baseline` | Bookmark set | — | No baseline yet |
+
+Structured envelope fields:
+
+- `ready` — `true` when no blocking `todo` checks remain (`ok` and `info` are non-blocking).
+- `checks` — array of `{ name, status, detail, next_step?, metadata? }`.
+- `next_command` — first blocking `next_step`, or eval/compare suggestion when ready.
+- `next_steps` — ordered list including advisory baseline steps.
+
+When baseline is set and workspace is ready, quickstart may suggest:
+
+```bash
+agentclash eval start --follow
+agentclash compare latest --gate
+```
+
+## Expected Output
+Human output prints a bold **AgentClash Quickstart** header, per-check lines, and **Next Command** when applicable.
+
+JSON output prints the full envelope for scripting.
+
+## Failure Modes
+- `401` / auth errors → `agentclash auth login --device`.
+- No workspace → `agentclash link` or `agentclash workspace use <id>`.
+- Zero challenge packs → `agentclash challenge-pack init` then publish skills.
+- Zero deployments → `agentclash deployment create --from-file deployment.json`.
+- API unreachable → verify `AGENTCLASH_API_URL` and network.
+
+## Safety Notes
+- Quickstart is read-only; it does not create runs or spend provider budget.
+- Do not paste tokens from `--json` output into chat.
+
+## Report Back Format
+```text
+Quickstart ready: <yes/no>
+Checks:
+- auth: <status> — <detail>
+- workspace: <status> — <detail>
+- challenge_packs: <status> — <detail>
+- deployments: <status> — <detail>
+- baseline: <status> — <detail>
+Next command: <command or none>
+Next skill: <agentclash-eval-runner | agentclash-cli-setup | ...>
+```
+
+## Related Skills
+- `agentclash-hub`
+- `agentclash-cli-setup`
+- `agentclash-eval-runner`
+- `agentclash-compare-and-triage`
+
+## Related Docs
+- `/docs-md/getting-started/quickstart`
+- `/docs-md/getting-started/first-eval`
+- `/docs-md/reference/cli`

--- a/web/content/agent-skills/agentclash-regression-flywheel/SKILL.md
+++ b/web/content/agent-skills/agentclash-regression-flywheel/SKILL.md
@@ -503,10 +503,11 @@ Next action: <ship/fix/rerun/needs-review>
 ```
 
 ## Related Skills
+- `agentclash-hub`
 - `agentclash-cli-setup`
 - `agentclash-eval-runner`
 - `agentclash-scorecard-reader`
-- `agentclash-regression-flywheel`
+- `agentclash-compare-and-triage`
 - `agentclash-ci-release-gate`
 
 ## Related Docs

--- a/web/content/agent-skills/agentclash-scorecard-reader/SKILL.md
+++ b/web/content/agent-skills/agentclash-scorecard-reader/SKILL.md
@@ -463,9 +463,10 @@ Next skill: <agentclash-regression-flywheel | challenge-pack skill | none>
 ```
 
 ## Related Skills
+- `agentclash-hub`
 - `agentclash-cli-setup`
 - `agentclash-eval-runner`
-- `agentclash-scorecard-reader`
+- `agentclash-compare-and-triage`
 - `agentclash-regression-flywheel`
 - `agentclash-ci-release-gate`
 

--- a/web/src/lib/docs.test.ts
+++ b/web/src/lib/docs.test.ts
@@ -15,7 +15,10 @@ const skillSlugs = [
   "agent-build-skills/agentclash-runtime-resources-setup",
   "agentclash-ci-release-gate",
   "agentclash-cli-setup",
+  "agentclash-compare-and-triage",
   "agentclash-eval-runner",
+  "agentclash-hub",
+  "agentclash-quickstart",
   "agentclash-regression-flywheel",
   "agentclash-scorecard-reader",
   "challenge-pack-skills/agentclash-challenge-pack-artifacts",
@@ -35,6 +38,8 @@ describe("agent skill docs", () => {
     expect(doc?.title).toBe("Agent Skills");
     expect(doc?.content).toContain("web/content/agent-skills/.../SKILL.md");
     expect(doc?.content).toContain("agentclash-cli-setup");
+    expect(doc?.content).toContain("agentclash-hub");
+    expect(doc?.content).toContain("agentclash-quickstart");
     expect(doc?.content).toContain("Challenge Pack Skills");
     expect(doc?.content).toContain("name: agentclash-skill-catalog");
     expect(doc?.content).toContain("## Generated Docs Contract");
@@ -67,11 +72,42 @@ describe("agent skill docs", () => {
     expect(doc?.content).toContain("doctor --json");
   });
 
+  it("generates the hub skill with workflow map", () => {
+    const doc = getDocBySlug(["agent-skills", "agentclash-hub"]);
+
+    expect(doc?.title).toBe("Hub Skill");
+    expect(doc?.content).toContain("name: agentclash-hub");
+    expect(doc?.content).toContain("agentclash-quickstart");
+    expect(doc?.content).toContain("agentclash-compare-and-triage");
+    expect(doc?.content).toContain("https://agentclash.dev/docs/agent-skills");
+  });
+
+  it("generates the quickstart skill with readiness checks", () => {
+    const doc = getDocBySlug(["agent-skills", "agentclash-quickstart"]);
+
+    expect(doc?.title).toBe("Quickstart Skill");
+    expect(doc?.content).toContain("agentclash quickstart");
+    expect(doc?.content).toContain("next_command");
+    expect(doc?.content).toContain("challenge_packs");
+  });
+
+  it("generates the compare and triage skill with gate commands", () => {
+    const doc = getDocBySlug(["agent-skills", "agentclash-compare-and-triage"]);
+
+    expect(doc?.title).toBe("Compare And Triage Skill");
+    expect(doc?.content).toContain("agentclash compare latest");
+    expect(doc?.content).toContain("agentclash compare gate");
+    expect(doc?.content).toContain("agentclash replay triage");
+    expect(doc?.content).toContain("agentclash baseline set");
+  });
+
   it("generates the eval runner skill with source-backed details", () => {
     const doc = getDocBySlug(["agent-skills", "agentclash-eval-runner"]);
 
     expect(doc?.title).toBe("Eval Runner Skill");
     expect(doc?.content).toContain("agentclash eval start");
+    expect(doc?.content).toContain("agentclash eval session list");
+    expect(doc?.content).toContain("agentclash run series report");
     expect(doc?.content).toContain("--pack <PACK_ID_OR_SLUG_OR_EXACT_NAME>");
     expect(doc?.content).toContain("--deployment <DEPLOYMENT_ID_OR_EXACT_NAME>");
     expect(doc?.content).toContain("--deployments <AGENT_DEPLOYMENT_ID>");
@@ -502,6 +538,15 @@ describe("agent skill docs", () => {
     expect(index).toContain("https://example.test/docs-md/agent-skills");
     expect(index).toContain(
       "https://example.test/docs-md/agent-skills/agentclash-cli-setup",
+    );
+    expect(index).toContain(
+      "https://example.test/docs-md/agent-skills/agentclash-hub",
+    );
+    expect(index).toContain(
+      "https://example.test/docs-md/agent-skills/agentclash-quickstart",
+    );
+    expect(index).toContain(
+      "https://example.test/docs-md/agent-skills/agentclash-compare-and-triage",
     );
     expect(index).toContain(
       "https://example.test/docs-md/agent-skills/challenge-pack-skills/agentclash-challenge-pack-yaml-author",

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -408,6 +408,20 @@ export const DOCS_NAV: DocNavSection[] = [
         href: "/docs/agent-skills",
       },
       {
+        title: "Hub Skill",
+        description:
+          "Start here for workflow map, dependency order, UI links, and pointers to every AgentClash skill.",
+        slug: ["agent-skills", "agentclash-hub"],
+        href: "/docs/agent-skills/agentclash-hub",
+      },
+      {
+        title: "Quickstart Skill",
+        description:
+          "Run readiness checks and get the suggested next CLI command before evals.",
+        slug: ["agent-skills", "agentclash-quickstart"],
+        href: "/docs/agent-skills/agentclash-quickstart",
+      },
+      {
         title: "Challenge Pack Skills",
         description:
           "Focused skills for planning, YAML authoring, input sets, scoring, judges, tools, artifacts, and publication.",
@@ -441,6 +455,13 @@ export const DOCS_NAV: DocNavSection[] = [
           "Turn rankings, scorecards, and replay evidence into engineering findings.",
         slug: ["agent-skills", "agentclash-scorecard-reader"],
         href: "/docs/agent-skills/agentclash-scorecard-reader",
+      },
+      {
+        title: "Compare And Triage Skill",
+        description:
+          "Manage baselines, compare runs, evaluate gates, and build replay triage envelopes.",
+        slug: ["agent-skills", "agentclash-compare-and-triage"],
+        href: "/docs/agent-skills/agentclash-compare-and-triage",
       },
       {
         title: "Regression Flywheel Skill",


### PR DESCRIPTION
## Summary
- Adds three P0 portable agent skills from issue #922: `agentclash-hub`, `agentclash-quickstart`, and `agentclash-compare-and-triage`.
- Extends `agentclash-eval-runner` with `eval session` and `run series` command coverage.
- Updates catalog dependency order, docs navigation, cross-links, and docs generator tests.

## Test contract
Reviewed against `testing/feat-skills-p0-workflow.md` (13 checkpoint commits).

## Test plan
- [x] `cd web && npm test -- docs.test.ts`
- [x] `cd web && npm run lint`
- [ ] CI green on merge

Closes part of #922 (P0 workflow loop skills).