### PR TITLE
feat(skills): add P1 portable agent skills (harness, multi-turn, dataset, prompt-eval)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ testing/*
 !testing/feat-docs-revamp.md
 !testing/feat-skills-p0-workflow.md
 !testing/feat-sync-cli-skills-snapshot-p0.md
+!testing/feat-skills-p1-workflow.md

--- a/testing/feat-skills-p1-workflow.md
+++ b/testing/feat-skills-p1-workflow.md
@@ -1,0 +1,42 @@
+# feat/skills-p1-workflow — Test Contract
+
+## Functional Behavior
+
+P1 portable agent skills from issue #922:
+
+- `agentclash-agent-harness-setup` — harness create/run/suite/execution/failure-review CLI.
+- `agentclash-multi-turn-operator` — `run turn status|submit` for human takeover phases.
+- `agentclash-dataset-workflows` — dataset CRUD, import/export, eval, test gate, generate, traces, sync-regression-suite.
+- `agentclash-prompt-eval-playground` — `prompt-eval` and `playground` command workflows.
+- Catalog, hub, docs nav, and docs tests updated.
+
+## Unit Tests
+
+- `web/src/lib/docs.test.ts` — new markdown paths and page content assertions.
+
+## Integration Tests
+
+```bash
+cd web && npm test -- docs.test.ts
+cd web && npm run lint
+node scripts/sync-cli-skills-snapshot.mjs
+cd cli && go test -short -count=1 ./internal/skills/...
+```
+
+## Smoke Tests
+
+All four skills appear in `/docs-md/agent-skills/<name>` and `llms.txt`.
+
+## E2E Tests
+
+N/A.
+
+## Manual Tests
+
+```bash
+agentclash agent-harness list --help
+agentclash run turn status --help
+agentclash dataset test --help
+agentclash prompt-eval validate --help
+agentclash playground list --help
+```

--- a/web/content/agent-skills/SKILL.md
+++ b/web/content/agent-skills/SKILL.md
@@ -162,6 +162,10 @@ Read related skills in this order so downstream workflows do not redefine upstre
 18. `agentclash-compare-and-triage`
 19. `agentclash-regression-flywheel`
 20. `agentclash-ci-release-gate`
+21. `agentclash-agent-harness-setup`
+22. `agentclash-multi-turn-operator`
+23. `agentclash-dataset-workflows`
+24. `agentclash-prompt-eval-playground`
 
 ## Review Checklist
 - The folder path matches the taxonomy.

--- a/web/content/agent-skills/agentclash-agent-harness-setup/SKILL.md
+++ b/web/content/agent-skills/agentclash-agent-harness-setup/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: agentclash-agent-harness-setup
+description: Use when creating, running, or ranking Agent Harness coding-agent tasks via the CLI, including harness specs, E2B runner kinds, suite task banks, executions, failure review, and promote-to-task flows.
+metadata:
+  agentclash.role: harness
+  agentclash.version: "1"
+  agentclash.requires_cli: "true"
+---
+
+# AgentClash Agent Harness Setup
+
+## Purpose
+Configure and operate Agent Harnesses — workspace-scoped autonomous coding tasks with E2B runners, evaluation config, suite rankings, and failure curation. Agent Harnesses are not challenge packs.
+
+## Use When
+- A user wants long-running coding-agent checks against a repository with validators or LLM judges.
+- You need to create harnesses for Codex, Claude, Hermes, or OpenClaw runners on E2B.
+- The workflow involves suite task banks, multi-harness suite runs, or promoting failed executions into private tasks.
+
+## Do Not Use When
+- The workload is a standard challenge-pack eval — use `agentclash-eval-runner`.
+- The user only needs deployments or runtime resources — use agent-build skills first.
+- The task is prompt A/B testing without a repo harness — use `agentclash-prompt-eval-playground`.
+
+## Inputs Needed
+- Workspace with provider secrets configured (`openai_api_key_secret_name` or `--api-key-secret`).
+- Task prompt, repository URL, and harness kind.
+- Optional evaluation config JSON (validators, LLM judges).
+- For suite runs: suite ID, harness IDs, optional task filters.
+
+## Environment
+```bash
+export AGENTCLASH_API_URL="https://api.agentclash.dev"
+agentclash workspace use <WORKSPACE_ID>
+agentclash secret list --json
+```
+
+## Procedure
+1. List or inspect existing harnesses.
+2. Create a harness with `--name`, `--task`, `--auth-mode`, and API key secret.
+3. Run a harness execution; use `--follow` to poll to terminal status.
+4. Inspect executions, failure summaries, and failure reviews.
+5. Optionally create suites, run across harnesses, read rankings, promote executions to private tasks.
+
+## Commands
+
+### Harness CRUD and runs
+```bash
+agentclash agent-harness list
+agentclash agent-harness get <harness-id>
+agentclash agent-harness create \
+  --name "Refund fix" \
+  --task "Fix the refund bug in services/refund.go" \
+  --harness-kind codex_e2b \
+  --auth-mode api_key_secret \
+  --api-key-secret OPENAI_API_KEY \
+  --repository-url https://github.com/org/repo \
+  --base-branch main
+
+agentclash agent-harness run <harness-id> --follow
+agentclash agent-harness executions <harness-id>
+```
+
+`--harness-kind` values: `codex_e2b` (default), `claude_e2b`, `hermes_e2b`, `openclaw_e2b`.
+
+Create from JSON:
+```bash
+agentclash agent-harness create --from-file harness.json
+```
+
+Optional flags: `--codex-template`, `--codex-model`, `--execution-config`, `--evaluation-config`, `--evaluation-config-file`.
+
+### Executions
+```bash
+agentclash agent-harness execution get <execution-id>
+agentclash agent-harness execution cancel <execution-id>
+agentclash agent-harness execution retry <execution-id> --idempotency-key cli-retry-1
+```
+
+### Suites and rankings
+```bash
+agentclash agent-harness suite list
+agentclash agent-harness suite create --name "Private bank" --task-json '{"title":"Task 1","public_prompt":"..."}'
+agentclash agent-harness suite tasks <suite-id>
+agentclash agent-harness suite run <suite-id> --harness <harness-id-1> --harness <harness-id-2>
+agentclash agent-harness suite rankings <suite-id> --k 3
+```
+
+### Failures and promotion
+```bash
+agentclash agent-harness failures summary
+agentclash agent-harness execution failure-review get <execution-id>
+agentclash agent-harness execution failure-review update <execution-id> --human-class timeout --human-summary "Sandbox timed out"
+agentclash agent-harness execution promote-task <execution-id> --suite <suite-id> --title "Promoted failure case"
+```
+
+Alias: `agentclash harness` = `agentclash agent-harness`.
+
+## Expected Output
+- Create returns harness ID, kind, auth mode, template.
+- Run returns execution ID; `--follow` polls until `completed`, `failed`, or `cancelled`.
+- Suite rankings table shows success@1, pass@k, cost, latency per harness.
+
+## Failure Modes
+- Missing `--api-key-secret` on create → pass workspace secret name containing provider key.
+- Missing required suite flags → `--harness` required on `suite run`; `--task-json` or `--from-file` on suite create.
+- Non-terminal execution on retry → only terminal executions can retry.
+- Wrong harness kind for template → defaults: `codex`, `agentclash-claude-fullstack`, `agentclash-hermes-fullstack`, `agentclash-openclaw-fullstack`.
+
+## Safety Notes
+- Harness runs execute code in E2B sandboxes with repository access — confirm repo and secrets before running.
+- Promoted tasks may contain sensitive failure excerpts — sanitize `public_prompt`.
+- Do not paste API keys or secret values into chat.
+
+## Report Back Format
+```text
+Harness: <id> (<name>, <kind>)
+Execution: <id> — <status>
+Suite: <id or n/a>
+Ranking summary: <top harness or n/a>
+Failure review: <effective_class or n/a>
+Next commands: <1-3>
+```
+
+## Related Skills
+- `agentclash-hub`
+- `agentclash-cli-setup`
+- `agentclash-runtime-resources-setup`
+- `agentclash-eval-runner`
+- `agentclash-scorecard-reader`
+- `agentclash-regression-flywheel`
+
+## Related Docs
+- `/docs-md/guides/ci-cd-workload-recipes`
+- `/docs-md/reference/cli`

--- a/web/content/agent-skills/agentclash-ci-release-gate/SKILL.md
+++ b/web/content/agent-skills/agentclash-ci-release-gate/SKILL.md
@@ -355,6 +355,7 @@ Next command: <exact agentclash command or GitHub Actions fix>
 - `agentclash-scorecard-reader`: inspect scorecard, comparison, replay, and failure evidence.
 - `agentclash-compare-and-triage`: baseline bookmarks, `compare latest --gate`, and replay triage.
 - `agentclash-regression-flywheel`: promote failures and manage regression suites/cases.
+- `agentclash-dataset-workflows`: dataset eval gates with `--format junit` for CI pipelines.
 
 ## Related Docs
 - `/docs-md/guides/ci-cd-agent-gates`

--- a/web/content/agent-skills/agentclash-dataset-workflows/SKILL.md
+++ b/web/content/agent-skills/agentclash-dataset-workflows/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: agentclash-dataset-workflows
+description: Use when managing AgentClash datasets via CLI — create versions, import/export examples, run evals, CI gates, synthetic generation, trace import, candidate review, and regression suite sync.
+metadata:
+  agentclash.role: dataset
+  agentclash.version: "1"
+  agentclash.requires_cli: "true"
+---
+
+# AgentClash Dataset Workflows
+
+## Purpose
+End-to-end dataset operations in a workspace: versioned example banks, eval runs against challenge packs, CI gating, synthetic generation, production trace import, and promotion into regression suites.
+
+## Use When
+- Building or curating labeled examples for prompt or agent evals.
+- Gating merges on dataset eval pass rate vs a baseline.
+- Importing OTEL/Braintrust/LangSmith/Phoenix/AgentClash traces as reviewable candidates.
+- Syncing a dataset version into a linked regression suite.
+
+## Do Not Use When
+- The user only needs a one-off challenge-pack run — use `agentclash-eval-runner`.
+- Prompt matrix experiments without a dataset artifact — use `agentclash-prompt-eval-playground`.
+- Harness coding tasks — use `agentclash-agent-harness-setup`.
+
+## Inputs Needed
+- Workspace ID and dataset ID (create datasets via API/UI if none exist).
+- For eval/gate: dataset version ID, challenge pack version ID, challenge key, deployment IDs.
+- For gate: baseline ID and candidate run ID (or `--eval` to start eval inline).
+- For generate: `--count`, `--provider-account`, `--model-alias`.
+
+## Environment
+```bash
+export AGENTCLASH_API_URL="https://api.agentclash.dev"
+agentclash workspace use <WORKSPACE_ID>
+agentclash dataset list
+agentclash dataset get <DATASET_ID> --json
+```
+
+## Procedure
+1. Inspect dataset and versions (`list`, `get`, `versions list`).
+2. Import or export examples; optionally create a version snapshot.
+3. Run a dataset eval or attach an existing run.
+4. Gate with `dataset test` against a baseline (CI-friendly `--format junit`).
+5. Optionally generate synthetic examples, import traces, promote candidates, sync regression suite.
+
+## Commands
+
+### Inspect and mutate examples
+```bash
+agentclash dataset list
+agentclash dataset get <dataset-id>
+agentclash dataset versions list <dataset-id>
+agentclash dataset versions create <dataset-id> --label "v2-seeds"
+agentclash dataset import <dataset-id> examples.jsonl
+agentclash dataset export <dataset-id> --version <version-id> -o out.jsonl
+agentclash dataset examples list <dataset-id> --version <version-id>
+agentclash dataset examples add <dataset-id> --input '{"messages":[...]}' --expected '{"score":1}'
+agentclash dataset examples update <dataset-id> <example-id> --expected-file expected.json
+agentclash dataset examples delete <dataset-id> <example-id>
+```
+
+### Eval and CI gate
+```bash
+agentclash dataset eval <dataset-id> \
+  --version <version-id> \
+  --pack <pack-version-id> \
+  --challenge <challenge-key> \
+  --deployment <deployment-id>
+
+agentclash dataset test <dataset-id> \
+  --baseline <baseline-id> \
+  --run <run-id> \
+  --min-pass-rate 0.9 \
+  --max-regressions 0 \
+  --format junit
+
+# Start eval then gate in one command
+agentclash dataset test <dataset-id> \
+  --eval \
+  --version <version-id> \
+  --pack <pack-version-id> \
+  --challenge <challenge-key> \
+  --deployment <deployment-id> \
+  --baseline <baseline-id> \
+  --timeout 30m
+```
+
+### Synthetic generation
+```bash
+agentclash dataset generate <dataset-id> \
+  --count 50 \
+  --provider-account <account-id> \
+  --model-alias <alias-id> \
+  --create-version \
+  --version-label "synthetic-v1" \
+  --follow
+```
+
+### Trace import and promotion
+```bash
+agentclash dataset import-traces <dataset-id> traces.json --source otel
+agentclash dataset import-traces <dataset-id> --source agentclash --run <run-id> --run-agent <run-agent-id>
+agentclash dataset trace-candidates list <dataset-id> --status pending
+agentclash dataset promote <dataset-id> <candidate-id> --tag production --expected-file edited.json
+```
+
+### Regression suite sync
+```bash
+agentclash dataset sync-regression-suite <dataset-id> \
+  --version <version-id> \
+  --pack <pack-version-id> \
+  --challenge <challenge-key> \
+  --suite-name "Dataset regression bank"
+```
+
+## Expected Output
+- Eval creates a run; gate returns pass/fail with regression counts.
+- `dataset test --format junit` exits 0 on pass, 1 on gate failure (422).
+- Generate with `--follow` polls job until completion.
+
+## Failure Modes
+- Gate without `--baseline` → required.
+- Gate without `--run` and without `--eval` → provide one.
+- Generate missing provider/model → all three of count, provider-account, model-alias required.
+- Sync regression without version/pack/challenge → all three flags required.
+
+## Safety Notes
+- Trace imports may contain production data — apply `--redaction` JSON when importing sensitive metadata.
+- Baseline comparisons affect release gates — confirm baseline ID before CI integration.
+- Exported JSONL may include prompts with secrets — scrub before sharing externally.
+
+## Report Back Format
+```text
+Dataset: <id>
+Version: <version-id or n/a>
+Eval run: <run-id or n/a>
+Gate: <pass/fail> — pass rate <x>, regressions <n>
+Candidates: <pending count or n/a>
+Regression suite: <suite-id or n/a>
+Next: agentclash run scorecard <run-id>
+```
+
+## Related Skills
+- `agentclash-hub`
+- `agentclash-eval-runner`
+- `agentclash-regression-flywheel`
+- `agentclash-ci-release-gate`
+- `agentclash-scorecard-reader`
+- `agentclash-prompt-eval-playground`
+
+## Related Docs
+- `/docs-md/guides/datasets-overview`
+- `/docs-md/guides/ci-cd-workflow-recipes`
+- `/docs-md/reference/cli`

--- a/web/content/agent-skills/agentclash-eval-runner/SKILL.md
+++ b/web/content/agent-skills/agentclash-eval-runner/SKILL.md
@@ -356,6 +356,7 @@ Next action: <recommendation>
 - `agentclash-challenge-pack-validation-publish`
 - `agentclash-scorecard-reader`
 - `agentclash-compare-and-triage`
+- `agentclash-multi-turn-operator`
 - `agentclash-regression-flywheel`
 - `agentclash-ci-release-gate`
 

--- a/web/content/agent-skills/agentclash-hub/SKILL.md
+++ b/web/content/agent-skills/agentclash-hub/SKILL.md
@@ -57,6 +57,15 @@ Portable bundle install (copy skills to agent host): https://github.com/agentcla
 11. agentclash-ci-release-gate       → CI manifest + gate (optional)
 ```
 
+Optional branches (load when the workflow applies):
+
+```text
+• agentclash-multi-turn-operator     → human takeover during multi_turn runs
+• agentclash-dataset-workflows       → dataset eval, gate, traces, regression sync
+• agentclash-prompt-eval-playground  → prompt-eval YAML + playground experiments
+• agentclash-agent-harness-setup     → E2B coding-agent harness tasks and suites
+```
+
 Human-friendly shortcut after setup:
 
 ```bash
@@ -91,6 +100,10 @@ Read skills in this order when multiple apply:
 18. `agentclash-compare-and-triage`
 19. `agentclash-regression-flywheel`
 20. `agentclash-ci-release-gate`
+21. `agentclash-agent-harness-setup`
+22. `agentclash-multi-turn-operator`
+23. `agentclash-dataset-workflows`
+24. `agentclash-prompt-eval-playground`
 
 Each skill folder name matches its `name` in frontmatter. When a skill lists **Related Skills**, load those before mutating remote state.
 
@@ -117,6 +130,10 @@ Each skill folder name matches its `name` in frontmatter. When a skill lists **R
 | `agentclash-compare-and-triage` | Baselines, compare, replay triage |
 | `agentclash-regression-flywheel` | Promote failures to regression suites |
 | `agentclash-ci-release-gate` | CI/CD gates |
+| `agentclash-agent-harness-setup` | E2B coding-agent harness tasks, suites, failure review |
+| `agentclash-multi-turn-operator` | Human takeover turns in multi_turn packs |
+| `agentclash-dataset-workflows` | Dataset eval, CI gate, traces, regression sync |
+| `agentclash-prompt-eval-playground` | Prompt eval YAML and playground experiments |
 
 Nested folders: `agent-build-skills/` and `challenge-pack-skills/` mirror the table rows above.
 

--- a/web/content/agent-skills/agentclash-multi-turn-operator/SKILL.md
+++ b/web/content/agent-skills/agentclash-multi-turn-operator/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: agentclash-multi-turn-operator
+description: Use when a multi_turn challenge pack run agent is awaiting human input and you need to check turn status or submit an operator message with agentclash run turn.
+metadata:
+  agentclash.role: multi-turn
+  agentclash.version: "1"
+  agentclash.requires_cli: "true"
+---
+
+# AgentClash Multi-Turn Operator
+
+## Purpose
+Operate human takeover phases in multi-turn challenge packs: detect when a run agent awaits operator input and submit the next user message so the eval can continue.
+
+## Use When
+- A multi_turn pack includes a `human` phase in its user simulator manifest.
+- CLI or UI shows a run agent waiting for human input mid-run.
+- An operator must reply as the end user during live eval observation.
+
+## Do Not Use When
+- The pack is single-turn or fully scripted/LLM-simulated — no human turns exist.
+- The run has not started — use `agentclash-eval-runner` first.
+- The task is authoring multi-turn pack YAML — see `/docs-md/challenge-packs/multi-turn` and challenge-pack skills.
+
+## Inputs Needed
+- Workspace ID and run ID.
+- Run agent ID (from `agentclash run agents <runId> --json`).
+- Human message text for the awaiting turn.
+- Pack must use `execution_mode: multi_turn` with a human phase.
+
+## Environment
+```bash
+export AGENTCLASH_API_URL="https://api.agentclash.dev"
+agentclash workspace use <WORKSPACE_ID>
+agentclash run get <RUN_ID> --json
+agentclash run agents <RUN_ID> --json
+```
+
+## Procedure
+1. Confirm the run is `running` and the target run agent exists.
+2. Check `agentclash run turn status <runAgentId> --run <runId>`.
+3. If `awaiting_human` is true, read `turn_index`, `phase_id`, and optional `prompt_hint`.
+4. Submit the operator message with `agentclash run turn submit`.
+5. Re-check status or follow run events until the agent completes the turn.
+
+## Commands
+```bash
+agentclash run turn status <RUN_AGENT_ID> --run <RUN_ID>
+agentclash run turn status <RUN_AGENT_ID> --run <RUN_ID> --json
+
+agentclash run turn submit <RUN_AGENT_ID> --run <RUN_ID> --message "I still want a full refund, not store credit."
+agentclash run turn submit <RUN_AGENT_ID> --run <RUN_ID> --message "..." --json
+```
+
+API paths (for debugging):
+- Status: `GET /v1/workspaces/{ws}/runs/{run}/run-agents/{runAgent}/turns/status`
+- Submit: `POST /v1/workspaces/{ws}/runs/{run}/run-agents/{runAgent}/turns` with `{"message":"..."}`
+
+Structured status fields:
+- `awaiting_human` — boolean
+- `turn_index` — current turn number when awaiting
+- `phase_id` — manifest phase identifier
+- `prompt_hint` — optional operator guidance from the pack
+
+## Expected Output
+- Status with no wait: `Awaiting human: no`
+- Status when blocked: `Awaiting human: yes` plus turn index and phase
+- Submit success: `Human turn submitted` (human) or `{"status":"submitted"}` (JSON)
+
+## Failure Modes
+- Missing `--run` → both commands require `--run <RUN_ID>`.
+- Missing `--message` on submit → required non-empty string.
+- Agent not awaiting human → API may reject submit; check status first.
+- Wrong run agent ID → list agents on the run before submitting.
+
+## Safety Notes
+- Operator messages become part of the eval transcript — avoid real customer PII.
+- Human turns affect scoring and calibration; confirm message intent with the operator when ambiguous.
+
+## Report Back Format
+```text
+Run: <run_id>
+Run agent: <run_agent_id> (<label>)
+Awaiting human: <yes/no>
+Turn index: <n or n/a>
+Phase: <phase_id or n/a>
+Message submitted: <yes/no>
+Prompt hint: <summary or n/a>
+Next: agentclash run events <run_id>
+```
+
+## Related Skills
+- `agentclash-hub`
+- `agentclash-eval-runner`
+- `agentclash-scorecard-reader`
+- `agentclash-challenge-pack-planner`
+
+## Related Docs
+- `/docs-md/challenge-packs/multi-turn`
+- `/docs-md/getting-started/first-eval`
+- `/docs-md/reference/cli`

--- a/web/content/agent-skills/agentclash-prompt-eval-playground/SKILL.md
+++ b/web/content/agent-skills/agentclash-prompt-eval-playground/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: agentclash-prompt-eval-playground
+description: Use when scaffolding, validating, or running prompt eval YAML configs and managing playground experiments, test cases, and prompt variants via the AgentClash CLI.
+metadata:
+  agentclash.role: prompt-eval
+  agentclash.version: "1"
+  agentclash.requires_cli: "true"
+---
+
+# AgentClash Prompt Eval Playground
+
+## Purpose
+Local-first prompt evaluation workflows: scaffold `.agentclash/prompt-eval.yaml`, validate locally or remotely, compile configs into playground experiments, fetch results, import Promptfoo subsets, and manage playground CRUD from the CLI.
+
+## Use When
+- Comparing prompt variants or model aliases on fixed test cases before a full challenge-pack run.
+- CI needs `prompt-eval validate --ci --remote` or `prompt-eval run --ci --follow`.
+- Migrating a Promptfoo config into AgentClash format.
+- Inspecting or rerunning playground experiments linked to prompt eval runs.
+
+## Do Not Use When
+- The eval is a full agent deployment on a challenge pack — use `agentclash-eval-runner`.
+- The workflow is dataset versioning and baseline gates — use `agentclash-dataset-workflows`.
+- The user needs harness repo tasks — use `agentclash-agent-harness-setup`.
+
+## Inputs Needed
+- Workspace with provider accounts and deployments referenced in the YAML.
+- Prompt eval config path (default `.agentclash/prompt-eval.yaml`).
+- For playground commands: playground ID from list/create output.
+- Optional Promptfoo YAML for import.
+
+## Environment
+```bash
+export AGENTCLASH_API_URL="https://api.agentclash.dev"
+agentclash workspace use <WORKSPACE_ID>
+agentclash prompt-eval init
+agentclash prompt-eval validate --remote
+```
+
+## Procedure
+1. Scaffold or import a prompt eval config.
+2. Validate locally; add `--remote` (and `--ci` in pipelines) for workspace-safe checks.
+3. Run to compile and launch playground experiments; use `--follow` in CI.
+4. Fetch results by experiment ID; compare assertion pass rates vs threshold.
+5. Use `playground` subcommands for manual experiment CRUD when not driven by YAML.
+
+## Commands
+
+### Prompt eval lifecycle
+```bash
+agentclash prompt-eval init
+agentclash prompt-eval init my-eval.yaml --name "Refund prompts"
+agentclash prompt-eval validate
+agentclash prompt-eval validate --remote --ci
+agentclash prompt-eval run --follow --ci --threshold 0.95
+agentclash prompt-eval results <experiment-id> --threshold 0.95
+agentclash prompt-eval import-promptfoo promptfoo.yaml --out .agentclash/prompt-eval.yaml
+```
+
+Useful flags on `run`: `--max-cases`, `--poll-interval`, `--timeout`, `--threshold`.
+
+### Playground CRUD (alias `pg`)
+```bash
+agentclash playground list
+agentclash playground create --name "Refund A/B" --description "Tone variants"
+agentclash playground get <playground-id>
+agentclash playground update <playground-id> --name "Updated name"
+agentclash playground delete <playground-id>
+
+agentclash playground test-cases list <playground-id>
+agentclash playground test-cases create <playground-id> --input '{"messages":[...]}'
+agentclash playground test-cases update <playground-id> <case-id> --expected-file out.json
+agentclash playground test-cases delete <playground-id> <case-id>
+
+agentclash playground experiments list <playground-id>
+agentclash playground experiments create <playground-id> --prompt-variant <variant-id>
+agentclash playground experiments get <playground-id> <experiment-id>
+agentclash playground experiments run <playground-id> <experiment-id> --follow
+```
+
+Config default path: `.agentclash/prompt-eval.yaml`. Schema version is stamped on `init`.
+
+## Expected Output
+- Validate prints errors/warnings; exits non-zero when invalid.
+- Run compiles cases into experiments; `--follow` waits for completion.
+- Results envelope includes assertion pass rate; sub-threshold exits non-zero in CI mode.
+
+## Failure Modes
+- `--ci` without `--remote` on validate → CI-safe remote checks required.
+- Missing workspace references in YAML → fix provider accounts/deployments or run `--remote` validate.
+- Import Promptfoo with unsupported features → use `--lossy` or edit converted YAML manually.
+- Experiment not found → list experiments on the playground first.
+
+## Safety Notes
+- Remote validate/run touches live provider accounts — use CI workspace tokens, not personal prod keys in shared logs.
+- Promptfoo import may drop unsupported assertions — review converted YAML before merging.
+- Playground experiments incur model cost — cap `--max-cases` in exploratory runs.
+
+## Report Back Format
+```text
+Config: <path>
+Validate: <pass/fail> (<error count> errors)
+Experiment: <id or n/a>
+Pass rate: <rate vs threshold>
+Playground: <id or n/a>
+Next: agentclash eval-runner ... OR prompt-eval results <id>
+```
+
+## Related Skills
+- `agentclash-hub`
+- `agentclash-cli-setup`
+- `agentclash-eval-runner`
+- `agentclash-dataset-workflows`
+- `agentclash-scorecard-reader`
+- `agentclash-regression-flywheel`
+
+## Related Docs
+- `/docs-md/guides/datasets-overview`
+- `/docs-md/reference/cli`
+- `/docs-md/getting-started/first-eval`

--- a/web/src/lib/docs.test.ts
+++ b/web/src/lib/docs.test.ts
@@ -13,11 +13,15 @@ const skillSlugs = [
   "agent-build-skills/agentclash-agent-build-author",
   "agent-build-skills/agentclash-agent-deployment-setup",
   "agent-build-skills/agentclash-runtime-resources-setup",
+  "agentclash-agent-harness-setup",
   "agentclash-ci-release-gate",
   "agentclash-cli-setup",
   "agentclash-compare-and-triage",
+  "agentclash-dataset-workflows",
   "agentclash-eval-runner",
   "agentclash-hub",
+  "agentclash-multi-turn-operator",
+  "agentclash-prompt-eval-playground",
   "agentclash-quickstart",
   "agentclash-regression-flywheel",
   "agentclash-scorecard-reader",
@@ -79,7 +83,44 @@ describe("agent skill docs", () => {
     expect(doc?.content).toContain("name: agentclash-hub");
     expect(doc?.content).toContain("agentclash-quickstart");
     expect(doc?.content).toContain("agentclash-compare-and-triage");
+    expect(doc?.content).toContain("agentclash-dataset-workflows");
     expect(doc?.content).toContain("https://agentclash.dev/docs/agent-skills");
+  });
+
+  it("generates the agent harness setup skill", () => {
+    const doc = getDocBySlug(["agent-skills", "agentclash-agent-harness-setup"]);
+
+    expect(doc?.title).toBe("Agent Harness Setup Skill");
+    expect(doc?.content).toContain("agentclash agent-harness create");
+    expect(doc?.content).toContain("agentclash agent-harness suite run");
+    expect(doc?.content).toContain("codex_e2b");
+  });
+
+  it("generates the multi-turn operator skill", () => {
+    const doc = getDocBySlug(["agent-skills", "agentclash-multi-turn-operator"]);
+
+    expect(doc?.title).toBe("Multi Turn Operator Skill");
+    expect(doc?.content).toContain("agentclash run turn status");
+    expect(doc?.content).toContain("agentclash run turn submit");
+    expect(doc?.content).toContain("awaiting_human");
+  });
+
+  it("generates the dataset workflows skill", () => {
+    const doc = getDocBySlug(["agent-skills", "agentclash-dataset-workflows"]);
+
+    expect(doc?.title).toBe("Dataset Workflows Skill");
+    expect(doc?.content).toContain("agentclash dataset test");
+    expect(doc?.content).toContain("agentclash dataset sync-regression-suite");
+    expect(doc?.content).toContain("agentclash dataset import-traces");
+  });
+
+  it("generates the prompt eval playground skill", () => {
+    const doc = getDocBySlug(["agent-skills", "agentclash-prompt-eval-playground"]);
+
+    expect(doc?.title).toBe("Prompt Eval Playground Skill");
+    expect(doc?.content).toContain("agentclash prompt-eval validate");
+    expect(doc?.content).toContain("agentclash prompt-eval run");
+    expect(doc?.content).toContain("agentclash playground list");
   });
 
   it("generates the quickstart skill with readiness checks", () => {

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -485,7 +485,7 @@ export const DOCS_NAV: DocNavSection[] = [
         href: "/docs/agent-skills/agentclash-agent-harness-setup",
       },
       {
-        title: "Multi-Turn Operator Skill",
+        title: "Multi Turn Operator Skill",
         description:
           "Submit human operator messages when multi_turn run agents await input.",
         slug: ["agent-skills", "agentclash-multi-turn-operator"],

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -477,6 +477,34 @@ export const DOCS_NAV: DocNavSection[] = [
         slug: ["agent-skills", "agentclash-ci-release-gate"],
         href: "/docs/agent-skills/agentclash-ci-release-gate",
       },
+      {
+        title: "Agent Harness Setup Skill",
+        description:
+          "Create and run Agent Harness coding tasks, suites, executions, and failure review.",
+        slug: ["agent-skills", "agentclash-agent-harness-setup"],
+        href: "/docs/agent-skills/agentclash-agent-harness-setup",
+      },
+      {
+        title: "Multi-Turn Operator Skill",
+        description:
+          "Submit human operator messages when multi_turn run agents await input.",
+        slug: ["agent-skills", "agentclash-multi-turn-operator"],
+        href: "/docs/agent-skills/agentclash-multi-turn-operator",
+      },
+      {
+        title: "Dataset Workflows Skill",
+        description:
+          "Manage datasets, eval gates, synthetic generation, traces, and regression sync.",
+        slug: ["agent-skills", "agentclash-dataset-workflows"],
+        href: "/docs/agent-skills/agentclash-dataset-workflows",
+      },
+      {
+        title: "Prompt Eval Playground Skill",
+        description:
+          "Scaffold, validate, and run prompt eval configs and playground experiments.",
+        slug: ["agent-skills", "agentclash-prompt-eval-playground"],
+        href: "/docs/agent-skills/agentclash-prompt-eval-playground",
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Adds four P1 portable agent skills from #922: `agentclash-agent-harness-setup`, `agentclash-multi-turn-operator`, `agentclash-dataset-workflows`, and `agentclash-prompt-eval-playground`.
- Updates catalog dependency order, hub workflow map, docs navigation, and docs generator tests (23 skills total).
- Cross-links eval-runner and CI release gate skills to the new workflows.

## Test plan
- [x] `cd web && npm test -- docs.test.ts`
- [x] `cd web && npm run lint`
- [ ] CI green on merge