### PR TITLE
feat(cli): sync embedded skills snapshot to 23 P1 skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ testing/*
 !testing/feat-skills-p0-workflow.md
 !testing/feat-sync-cli-skills-snapshot-p0.md
 !testing/feat-skills-p1-workflow.md
+!testing/feat-sync-cli-skills-snapshot-p1.md

--- a/cli/internal/skills/snapshot/agentclash-agent-harness-setup/SKILL.md
+++ b/cli/internal/skills/snapshot/agentclash-agent-harness-setup/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: agentclash-agent-harness-setup
+description: Use when creating, running, or ranking Agent Harness coding-agent tasks via the CLI, including harness specs, E2B runner kinds, suite task banks, executions, failure review, and promote-to-task flows.
+metadata:
+  agentclash.role: harness
+  agentclash.version: "1"
+  agentclash.requires_cli: "true"
+---
+
+# AgentClash Agent Harness Setup
+
+## Purpose
+Configure and operate Agent Harnesses — workspace-scoped autonomous coding tasks with E2B runners, evaluation config, suite rankings, and failure curation. Agent Harnesses are not challenge packs.
+
+## Use When
+- A user wants long-running coding-agent checks against a repository with validators or LLM judges.
+- You need to create harnesses for Codex, Claude, Hermes, or OpenClaw runners on E2B.
+- The workflow involves suite task banks, multi-harness suite runs, or promoting failed executions into private tasks.
+
+## Do Not Use When
+- The workload is a standard challenge-pack eval — use `agentclash-eval-runner`.
+- The user only needs deployments or runtime resources — use agent-build skills first.
+- The task is prompt A/B testing without a repo harness — use `agentclash-prompt-eval-playground`.
+
+## Inputs Needed
+- Workspace with provider secrets configured (`openai_api_key_secret_name` or `--api-key-secret`).
+- Task prompt, repository URL, and harness kind.
+- Optional evaluation config JSON (validators, LLM judges).
+- For suite runs: suite ID, harness IDs, optional task filters.
+
+## Environment
+```bash
+export AGENTCLASH_API_URL="https://api.agentclash.dev"
+agentclash workspace use <WORKSPACE_ID>
+agentclash secret list --json
+```
+
+## Procedure
+1. List or inspect existing harnesses.
+2. Create a harness with `--name`, `--task`, `--auth-mode`, and API key secret.
+3. Run a harness execution; use `--follow` to poll to terminal status.
+4. Inspect executions, failure summaries, and failure reviews.
+5. Optionally create suites, run across harnesses, read rankings, promote executions to private tasks.
+
+## Commands
+
+### Harness CRUD and runs
+```bash
+agentclash agent-harness list
+agentclash agent-harness get <harness-id>
+agentclash agent-harness create \
+  --name "Refund fix" \
+  --task "Fix the refund bug in services/refund.go" \
+  --harness-kind codex_e2b \
+  --auth-mode api_key_secret \
+  --api-key-secret OPENAI_API_KEY \
+  --repository-url https://github.com/org/repo \
+  --base-branch main
+
+agentclash agent-harness run <harness-id> --follow
+agentclash agent-harness executions <harness-id>
+```
+
+`--harness-kind` values: `codex_e2b` (default), `claude_e2b`, `hermes_e2b`, `openclaw_e2b`.
+
+Create from JSON:
+```bash
+agentclash agent-harness create --from-file harness.json
+```
+
+Optional flags: `--codex-template`, `--codex-model`, `--execution-config`, `--evaluation-config`, `--evaluation-config-file`.
+
+### Executions
+```bash
+agentclash agent-harness execution get <execution-id>
+agentclash agent-harness execution cancel <execution-id>
+agentclash agent-harness execution retry <execution-id> --idempotency-key cli-retry-1
+```
+
+### Suites and rankings
+```bash
+agentclash agent-harness suite list
+agentclash agent-harness suite create --name "Private bank" --task-json '{"title":"Task 1","public_prompt":"..."}'
+agentclash agent-harness suite tasks <suite-id>
+agentclash agent-harness suite run <suite-id> --harness <harness-id-1> --harness <harness-id-2>
+agentclash agent-harness suite rankings <suite-id> --k 3
+```
+
+### Failures and promotion
+```bash
+agentclash agent-harness failures summary
+agentclash agent-harness execution failure-review get <execution-id>
+agentclash agent-harness execution failure-review update <execution-id> --human-class timeout --human-summary "Sandbox timed out"
+agentclash agent-harness execution promote-task <execution-id> --suite <suite-id> --title "Promoted failure case"
+```
+
+Alias: `agentclash harness` = `agentclash agent-harness`.
+
+## Expected Output
+- Create returns harness ID, kind, auth mode, template.
+- Run returns execution ID; `--follow` polls until `completed`, `failed`, or `cancelled`.
+- Suite rankings table shows success@1, pass@k, cost, latency per harness.
+
+## Failure Modes
+- Missing `--api-key-secret` on create → pass workspace secret name containing provider key.
+- Missing required suite flags → `--harness` required on `suite run`; `--task-json` or `--from-file` on suite create.
+- Non-terminal execution on retry → only terminal executions can retry.
+- Wrong harness kind for template → defaults: `codex`, `agentclash-claude-fullstack`, `agentclash-hermes-fullstack`, `agentclash-openclaw-fullstack`.
+
+## Safety Notes
+- Harness runs execute code in E2B sandboxes with repository access — confirm repo and secrets before running.
+- Promoted tasks may contain sensitive failure excerpts — sanitize `public_prompt`.
+- Do not paste API keys or secret values into chat.
+
+## Report Back Format
+```text
+Harness: <id> (<name>, <kind>)
+Execution: <id> — <status>
+Suite: <id or n/a>
+Ranking summary: <top harness or n/a>
+Failure review: <effective_class or n/a>
+Next commands: <1-3>
+```
+
+## Related Skills
+- `agentclash-hub`
+- `agentclash-cli-setup`
+- `agentclash-runtime-resources-setup`
+- `agentclash-eval-runner`
+- `agentclash-scorecard-reader`
+- `agentclash-regression-flywheel`
+
+## Related Docs
+- `/docs-md/guides/ci-cd-workload-recipes`
+- `/docs-md/reference/cli`

--- a/cli/internal/skills/snapshot/agentclash-ci-release-gate/SKILL.md
+++ b/cli/internal/skills/snapshot/agentclash-ci-release-gate/SKILL.md
@@ -355,6 +355,7 @@ Next command: <exact agentclash command or GitHub Actions fix>
 - `agentclash-scorecard-reader`: inspect scorecard, comparison, replay, and failure evidence.
 - `agentclash-compare-and-triage`: baseline bookmarks, `compare latest --gate`, and replay triage.
 - `agentclash-regression-flywheel`: promote failures and manage regression suites/cases.
+- `agentclash-dataset-workflows`: dataset eval gates with `--format junit` for CI pipelines.
 
 ## Related Docs
 - `/docs-md/guides/ci-cd-agent-gates`

--- a/cli/internal/skills/snapshot/agentclash-dataset-workflows/SKILL.md
+++ b/cli/internal/skills/snapshot/agentclash-dataset-workflows/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: agentclash-dataset-workflows
+description: Use when managing AgentClash datasets via CLI — create versions, import/export examples, run evals, CI gates, synthetic generation, trace import, candidate review, and regression suite sync.
+metadata:
+  agentclash.role: dataset
+  agentclash.version: "1"
+  agentclash.requires_cli: "true"
+---
+
+# AgentClash Dataset Workflows
+
+## Purpose
+End-to-end dataset operations in a workspace: versioned example banks, eval runs against challenge packs, CI gating, synthetic generation, production trace import, and promotion into regression suites.
+
+## Use When
+- Building or curating labeled examples for prompt or agent evals.
+- Gating merges on dataset eval pass rate vs a baseline.
+- Importing OTEL/Braintrust/LangSmith/Phoenix/AgentClash traces as reviewable candidates.
+- Syncing a dataset version into a linked regression suite.
+
+## Do Not Use When
+- The user only needs a one-off challenge-pack run — use `agentclash-eval-runner`.
+- Prompt matrix experiments without a dataset artifact — use `agentclash-prompt-eval-playground`.
+- Harness coding tasks — use `agentclash-agent-harness-setup`.
+
+## Inputs Needed
+- Workspace ID and dataset ID (create datasets via API/UI if none exist).
+- For eval/gate: dataset version ID, challenge pack version ID, challenge key, deployment IDs.
+- For gate: baseline ID and candidate run ID (or `--eval` to start eval inline).
+- For generate: `--count`, `--provider-account`, `--model-alias`.
+
+## Environment
+```bash
+export AGENTCLASH_API_URL="https://api.agentclash.dev"
+agentclash workspace use <WORKSPACE_ID>
+agentclash dataset list
+agentclash dataset get <DATASET_ID> --json
+```
+
+## Procedure
+1. Inspect dataset and versions (`list`, `get`, `versions list`).
+2. Import or export examples; optionally create a version snapshot.
+3. Run a dataset eval or attach an existing run.
+4. Gate with `dataset test` against a baseline (CI-friendly `--format junit`).
+5. Optionally generate synthetic examples, import traces, promote candidates, sync regression suite.
+
+## Commands
+
+### Inspect and mutate examples
+```bash
+agentclash dataset list
+agentclash dataset get <dataset-id>
+agentclash dataset versions list <dataset-id>
+agentclash dataset versions create <dataset-id> --label "v2-seeds"
+agentclash dataset import <dataset-id> examples.jsonl
+agentclash dataset export <dataset-id> --version <version-id> -o out.jsonl
+agentclash dataset examples list <dataset-id> --version <version-id>
+agentclash dataset examples add <dataset-id> --input '{"messages":[...]}' --expected '{"score":1}'
+agentclash dataset examples update <dataset-id> <example-id> --expected-file expected.json
+agentclash dataset examples delete <dataset-id> <example-id>
+```
+
+### Eval and CI gate
+```bash
+agentclash dataset eval <dataset-id> \
+  --version <version-id> \
+  --pack <pack-version-id> \
+  --challenge <challenge-key> \
+  --deployment <deployment-id>
+
+agentclash dataset test <dataset-id> \
+  --baseline <baseline-id> \
+  --run <run-id> \
+  --min-pass-rate 0.9 \
+  --max-regressions 0 \
+  --format junit
+
+# Start eval then gate in one command
+agentclash dataset test <dataset-id> \
+  --eval \
+  --version <version-id> \
+  --pack <pack-version-id> \
+  --challenge <challenge-key> \
+  --deployment <deployment-id> \
+  --baseline <baseline-id> \
+  --timeout 30m
+```
+
+### Synthetic generation
+```bash
+agentclash dataset generate <dataset-id> \
+  --count 50 \
+  --provider-account <account-id> \
+  --model-alias <alias-id> \
+  --create-version \
+  --version-label "synthetic-v1" \
+  --follow
+```
+
+### Trace import and promotion
+```bash
+agentclash dataset import-traces <dataset-id> traces.json --source otel
+agentclash dataset import-traces <dataset-id> --source agentclash --run <run-id> --run-agent <run-agent-id>
+agentclash dataset trace-candidates list <dataset-id> --status pending
+agentclash dataset promote <dataset-id> <candidate-id> --tag production --expected-file edited.json
+```
+
+### Regression suite sync
+```bash
+agentclash dataset sync-regression-suite <dataset-id> \
+  --version <version-id> \
+  --pack <pack-version-id> \
+  --challenge <challenge-key> \
+  --suite-name "Dataset regression bank"
+```
+
+## Expected Output
+- Eval creates a run; gate returns pass/fail with regression counts.
+- `dataset test --format junit` exits 0 on pass, 1 on gate failure (422).
+- Generate with `--follow` polls job until completion.
+
+## Failure Modes
+- Gate without `--baseline` → required.
+- Gate without `--run` and without `--eval` → provide one.
+- Generate missing provider/model → all three of count, provider-account, model-alias required.
+- Sync regression without version/pack/challenge → all three flags required.
+
+## Safety Notes
+- Trace imports may contain production data — apply `--redaction` JSON when importing sensitive metadata.
+- Baseline comparisons affect release gates — confirm baseline ID before CI integration.
+- Exported JSONL may include prompts with secrets — scrub before sharing externally.
+
+## Report Back Format
+```text
+Dataset: <id>
+Version: <version-id or n/a>
+Eval run: <run-id or n/a>
+Gate: <pass/fail> — pass rate <x>, regressions <n>
+Candidates: <pending count or n/a>
+Regression suite: <suite-id or n/a>
+Next: agentclash run scorecard <run-id>
+```
+
+## Related Skills
+- `agentclash-hub`
+- `agentclash-eval-runner`
+- `agentclash-regression-flywheel`
+- `agentclash-ci-release-gate`
+- `agentclash-scorecard-reader`
+- `agentclash-prompt-eval-playground`
+
+## Related Docs
+- `/docs-md/guides/datasets-overview`
+- `/docs-md/guides/ci-cd-workflow-recipes`
+- `/docs-md/reference/cli`

--- a/cli/internal/skills/snapshot/agentclash-dataset-workflows/SKILL.md
+++ b/cli/internal/skills/snapshot/agentclash-dataset-workflows/SKILL.md
@@ -151,5 +151,5 @@ Next: agentclash run scorecard <run-id>
 
 ## Related Docs
 - `/docs-md/guides/datasets-overview`
-- `/docs-md/guides/ci-cd-workflow-recipes`
+- `/docs-md/guides/ci-cd-workload-recipes`
 - `/docs-md/reference/cli`

--- a/cli/internal/skills/snapshot/agentclash-eval-runner/SKILL.md
+++ b/cli/internal/skills/snapshot/agentclash-eval-runner/SKILL.md
@@ -356,6 +356,7 @@ Next action: <recommendation>
 - `agentclash-challenge-pack-validation-publish`
 - `agentclash-scorecard-reader`
 - `agentclash-compare-and-triage`
+- `agentclash-multi-turn-operator`
 - `agentclash-regression-flywheel`
 - `agentclash-ci-release-gate`
 

--- a/cli/internal/skills/snapshot/agentclash-hub/SKILL.md
+++ b/cli/internal/skills/snapshot/agentclash-hub/SKILL.md
@@ -57,6 +57,15 @@ Portable bundle install (copy skills to agent host): https://github.com/agentcla
 11. agentclash-ci-release-gate       → CI manifest + gate (optional)
 ```
 
+Optional branches (load when the workflow applies):
+
+```text
+• agentclash-multi-turn-operator     → human takeover during multi_turn runs
+• agentclash-dataset-workflows       → dataset eval, gate, traces, regression sync
+• agentclash-prompt-eval-playground  → prompt-eval YAML + playground experiments
+• agentclash-agent-harness-setup     → E2B coding-agent harness tasks and suites
+```
+
 Human-friendly shortcut after setup:
 
 ```bash
@@ -91,6 +100,10 @@ Read skills in this order when multiple apply:
 18. `agentclash-compare-and-triage`
 19. `agentclash-regression-flywheel`
 20. `agentclash-ci-release-gate`
+21. `agentclash-agent-harness-setup`
+22. `agentclash-multi-turn-operator`
+23. `agentclash-dataset-workflows`
+24. `agentclash-prompt-eval-playground`
 
 Each skill folder name matches its `name` in frontmatter. When a skill lists **Related Skills**, load those before mutating remote state.
 
@@ -117,6 +130,10 @@ Each skill folder name matches its `name` in frontmatter. When a skill lists **R
 | `agentclash-compare-and-triage` | Baselines, compare, replay triage |
 | `agentclash-regression-flywheel` | Promote failures to regression suites |
 | `agentclash-ci-release-gate` | CI/CD gates |
+| `agentclash-agent-harness-setup` | E2B coding-agent harness tasks, suites, failure review |
+| `agentclash-multi-turn-operator` | Human takeover turns in multi_turn packs |
+| `agentclash-dataset-workflows` | Dataset eval, CI gate, traces, regression sync |
+| `agentclash-prompt-eval-playground` | Prompt eval YAML and playground experiments |
 
 Nested folders: `agent-build-skills/` and `challenge-pack-skills/` mirror the table rows above.
 

--- a/cli/internal/skills/snapshot/agentclash-multi-turn-operator/SKILL.md
+++ b/cli/internal/skills/snapshot/agentclash-multi-turn-operator/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: agentclash-multi-turn-operator
+description: Use when a multi_turn challenge pack run agent is awaiting human input and you need to check turn status or submit an operator message with agentclash run turn.
+metadata:
+  agentclash.role: multi-turn
+  agentclash.version: "1"
+  agentclash.requires_cli: "true"
+---
+
+# AgentClash Multi-Turn Operator
+
+## Purpose
+Operate human takeover phases in multi-turn challenge packs: detect when a run agent awaits operator input and submit the next user message so the eval can continue.
+
+## Use When
+- A multi_turn pack includes a `human` phase in its user simulator manifest.
+- CLI or UI shows a run agent waiting for human input mid-run.
+- An operator must reply as the end user during live eval observation.
+
+## Do Not Use When
+- The pack is single-turn or fully scripted/LLM-simulated — no human turns exist.
+- The run has not started — use `agentclash-eval-runner` first.
+- The task is authoring multi-turn pack YAML — see `/docs-md/challenge-packs/multi-turn` and challenge-pack skills.
+
+## Inputs Needed
+- Workspace ID and run ID.
+- Run agent ID (from `agentclash run agents <runId> --json`).
+- Human message text for the awaiting turn.
+- Pack must use `execution_mode: multi_turn` with a human phase.
+
+## Environment
+```bash
+export AGENTCLASH_API_URL="https://api.agentclash.dev"
+agentclash workspace use <WORKSPACE_ID>
+agentclash run get <RUN_ID> --json
+agentclash run agents <RUN_ID> --json
+```
+
+## Procedure
+1. Confirm the run is `running` and the target run agent exists.
+2. Check `agentclash run turn status <runAgentId> --run <runId>`.
+3. If `awaiting_human` is true, read `turn_index`, `phase_id`, and optional `prompt_hint`.
+4. Submit the operator message with `agentclash run turn submit`.
+5. Re-check status or follow run events until the agent completes the turn.
+
+## Commands
+```bash
+agentclash run turn status <RUN_AGENT_ID> --run <RUN_ID>
+agentclash run turn status <RUN_AGENT_ID> --run <RUN_ID> --json
+
+agentclash run turn submit <RUN_AGENT_ID> --run <RUN_ID> --message "I still want a full refund, not store credit."
+agentclash run turn submit <RUN_AGENT_ID> --run <RUN_ID> --message "..." --json
+```
+
+API paths (for debugging):
+- Status: `GET /v1/workspaces/{ws}/runs/{run}/run-agents/{runAgent}/turns/status`
+- Submit: `POST /v1/workspaces/{ws}/runs/{run}/run-agents/{runAgent}/turns` with `{"message":"..."}`
+
+Structured status fields:
+- `awaiting_human` — boolean
+- `turn_index` — current turn number when awaiting
+- `phase_id` — manifest phase identifier
+- `prompt_hint` — optional operator guidance from the pack
+
+## Expected Output
+- Status with no wait: `Awaiting human: no`
+- Status when blocked: `Awaiting human: yes` plus turn index and phase
+- Submit success: `Human turn submitted` (human) or `{"status":"submitted"}` (JSON)
+
+## Failure Modes
+- Missing `--run` → both commands require `--run <RUN_ID>`.
+- Missing `--message` on submit → required non-empty string.
+- Agent not awaiting human → API may reject submit; check status first.
+- Wrong run agent ID → list agents on the run before submitting.
+
+## Safety Notes
+- Operator messages become part of the eval transcript — avoid real customer PII.
+- Human turns affect scoring and calibration; confirm message intent with the operator when ambiguous.
+
+## Report Back Format
+```text
+Run: <run_id>
+Run agent: <run_agent_id> (<label>)
+Awaiting human: <yes/no>
+Turn index: <n or n/a>
+Phase: <phase_id or n/a>
+Message submitted: <yes/no>
+Prompt hint: <summary or n/a>
+Next: agentclash run events <run_id>
+```
+
+## Related Skills
+- `agentclash-hub`
+- `agentclash-eval-runner`
+- `agentclash-scorecard-reader`
+- `agentclash-challenge-pack-planner`
+
+## Related Docs
+- `/docs-md/challenge-packs/multi-turn`
+- `/docs-md/getting-started/first-eval`
+- `/docs-md/reference/cli`

--- a/cli/internal/skills/snapshot/agentclash-prompt-eval-playground/SKILL.md
+++ b/cli/internal/skills/snapshot/agentclash-prompt-eval-playground/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: agentclash-prompt-eval-playground
+description: Use when scaffolding, validating, or running prompt eval YAML configs and managing playground experiments, test cases, and prompt variants via the AgentClash CLI.
+metadata:
+  agentclash.role: prompt-eval
+  agentclash.version: "1"
+  agentclash.requires_cli: "true"
+---
+
+# AgentClash Prompt Eval Playground
+
+## Purpose
+Local-first prompt evaluation workflows: scaffold `.agentclash/prompt-eval.yaml`, validate locally or remotely, compile configs into playground experiments, fetch results, import Promptfoo subsets, and manage playground CRUD from the CLI.
+
+## Use When
+- Comparing prompt variants or model aliases on fixed test cases before a full challenge-pack run.
+- CI needs `prompt-eval validate --ci --remote` or `prompt-eval run --ci --follow`.
+- Migrating a Promptfoo config into AgentClash format.
+- Inspecting or rerunning playground experiments linked to prompt eval runs.
+
+## Do Not Use When
+- The eval is a full agent deployment on a challenge pack — use `agentclash-eval-runner`.
+- The workflow is dataset versioning and baseline gates — use `agentclash-dataset-workflows`.
+- The user needs harness repo tasks — use `agentclash-agent-harness-setup`.
+
+## Inputs Needed
+- Workspace with provider accounts and deployments referenced in the YAML.
+- Prompt eval config path (default `.agentclash/prompt-eval.yaml`).
+- For playground commands: playground ID from list/create output.
+- Optional Promptfoo YAML for import.
+
+## Environment
+```bash
+export AGENTCLASH_API_URL="https://api.agentclash.dev"
+agentclash workspace use <WORKSPACE_ID>
+agentclash prompt-eval init
+agentclash prompt-eval validate --remote
+```
+
+## Procedure
+1. Scaffold or import a prompt eval config.
+2. Validate locally; add `--remote` (and `--ci` in pipelines) for workspace-safe checks.
+3. Run to compile and launch playground experiments; use `--follow` in CI.
+4. Fetch results by experiment ID; compare assertion pass rates vs threshold.
+5. Use `playground` subcommands for manual experiment CRUD when not driven by YAML.
+
+## Commands
+
+### Prompt eval lifecycle
+```bash
+agentclash prompt-eval init
+agentclash prompt-eval init my-eval.yaml --name "Refund prompts"
+agentclash prompt-eval validate
+agentclash prompt-eval validate --remote --ci
+agentclash prompt-eval run --follow --ci --threshold 0.95
+agentclash prompt-eval results <experiment-id> --threshold 0.95
+agentclash prompt-eval import-promptfoo promptfoo.yaml --out .agentclash/prompt-eval.yaml
+```
+
+Useful flags on `run`: `--max-cases`, `--poll-interval`, `--timeout`, `--threshold`.
+
+### Playground CRUD (alias `pg`)
+```bash
+agentclash playground list
+agentclash playground create --name "Refund A/B" --description "Tone variants"
+agentclash playground get <playground-id>
+agentclash playground update <playground-id> --name "Updated name"
+agentclash playground delete <playground-id>
+
+agentclash playground test-cases list <playground-id>
+agentclash playground test-cases create <playground-id> --input '{"messages":[...]}'
+agentclash playground test-cases update <playground-id> <case-id> --expected-file out.json
+agentclash playground test-cases delete <playground-id> <case-id>
+
+agentclash playground experiments list <playground-id>
+agentclash playground experiments create <playground-id> --prompt-variant <variant-id>
+agentclash playground experiments get <playground-id> <experiment-id>
+agentclash playground experiments run <playground-id> <experiment-id> --follow
+```
+
+Config default path: `.agentclash/prompt-eval.yaml`. Schema version is stamped on `init`.
+
+## Expected Output
+- Validate prints errors/warnings; exits non-zero when invalid.
+- Run compiles cases into experiments; `--follow` waits for completion.
+- Results envelope includes assertion pass rate; sub-threshold exits non-zero in CI mode.
+
+## Failure Modes
+- `--ci` without `--remote` on validate → CI-safe remote checks required.
+- Missing workspace references in YAML → fix provider accounts/deployments or run `--remote` validate.
+- Import Promptfoo with unsupported features → use `--lossy` or edit converted YAML manually.
+- Experiment not found → list experiments on the playground first.
+
+## Safety Notes
+- Remote validate/run touches live provider accounts — use CI workspace tokens, not personal prod keys in shared logs.
+- Promptfoo import may drop unsupported assertions — review converted YAML before merging.
+- Playground experiments incur model cost — cap `--max-cases` in exploratory runs.
+
+## Report Back Format
+```text
+Config: <path>
+Validate: <pass/fail> (<error count> errors)
+Experiment: <id or n/a>
+Pass rate: <rate vs threshold>
+Playground: <id or n/a>
+Next: agentclash eval-runner ... OR prompt-eval results <id>
+```
+
+## Related Skills
+- `agentclash-hub`
+- `agentclash-cli-setup`
+- `agentclash-eval-runner`
+- `agentclash-dataset-workflows`
+- `agentclash-scorecard-reader`
+- `agentclash-regression-flywheel`
+
+## Related Docs
+- `/docs-md/guides/datasets-overview`
+- `/docs-md/reference/cli`
+- `/docs-md/getting-started/first-eval`

--- a/cli/internal/skills/snapshot/agentclash-prompt-eval-playground/SKILL.md
+++ b/cli/internal/skills/snapshot/agentclash-prompt-eval-playground/SKILL.md
@@ -115,6 +115,6 @@ Next: agentclash eval-runner ... OR prompt-eval results <id>
 - `agentclash-regression-flywheel`
 
 ## Related Docs
-- `/docs-md/guides/datasets-overview`
+- `/docs-md/guides/use-with-ai-tools`
 - `/docs-md/reference/cli`
 - `/docs-md/getting-started/first-eval`

--- a/cli/internal/skills/snapshot/manifest.json
+++ b/cli/internal/skills/snapshot/manifest.json
@@ -1,5 +1,5 @@
 {
-  "snapshot_version": "6a7773c59769",
+  "snapshot_version": "11476048adb7",
   "skills": [
     {
       "name": "agentclash-agent-build-author",
@@ -12,6 +12,12 @@
       "role": "agent-deployments",
       "requires_cli": true,
       "sha256": "4c14f26a7c53de60add3aecd46e5a0f65e1d9cb9e42b732ee83a5b281c1a83bc"
+    },
+    {
+      "name": "agentclash-agent-harness-setup",
+      "role": "harness",
+      "requires_cli": true,
+      "sha256": "f5524ad01df7397c0df95607733bb2d7935076ed198e6d157f513ec175f23816"
     },
     {
       "name": "agentclash-challenge-pack-artifacts",
@@ -65,7 +71,7 @@
       "name": "agentclash-ci-release-gate",
       "role": "ci",
       "requires_cli": true,
-      "sha256": "97a365fc9753329d8c7abfe2186285b0df61a117d44ef5c438226bcc3b7f3e74"
+      "sha256": "3ec8b36bdea2ccf626fe308b51693283c511e46aee2518847d955b6e101320bf"
     },
     {
       "name": "agentclash-cli-setup",
@@ -80,16 +86,34 @@
       "sha256": "7dc98137d33407605a877f145a5cd27d958b13930ba763d07c7818220a6fd48c"
     },
     {
+      "name": "agentclash-dataset-workflows",
+      "role": "dataset",
+      "requires_cli": true,
+      "sha256": "cc95ed94b624bb88eab5f1852c5b3162fe9382a606d953a4bcfa0b0ecfdae495"
+    },
+    {
       "name": "agentclash-eval-runner",
       "role": "running",
       "requires_cli": true,
-      "sha256": "b29326cdd88a2a71960bac4e18743cb837352b8325b8c5b345130fceb05b67c0"
+      "sha256": "77867733082836e249a3c45fa3648035eb59d1449a1f797b8ebf18d231be2acb"
     },
     {
       "name": "agentclash-hub",
       "role": "hub",
       "requires_cli": false,
-      "sha256": "812286581c1a05468cb5bc6192a0c476efe07c9fb53a73004b0c0a4c3f54d0e9"
+      "sha256": "f5c25234903db702436c679f7658b1d14538a3ed18c782ed824c022f2ece902f"
+    },
+    {
+      "name": "agentclash-multi-turn-operator",
+      "role": "multi-turn",
+      "requires_cli": true,
+      "sha256": "f693d8bc81940b23b0ed2a730fa6ef2d20675cf7150501260ffb602c117f7e5c"
+    },
+    {
+      "name": "agentclash-prompt-eval-playground",
+      "role": "prompt-eval",
+      "requires_cli": true,
+      "sha256": "a1ee2266cc31184768c5d036601bfe61574c3371359a19b8d5dc72aca3a6a044"
     },
     {
       "name": "agentclash-quickstart",

--- a/cli/internal/skills/snapshot/manifest.json
+++ b/cli/internal/skills/snapshot/manifest.json
@@ -1,5 +1,5 @@
 {
-  "snapshot_version": "11476048adb7",
+  "snapshot_version": "0530fa3df936",
   "skills": [
     {
       "name": "agentclash-agent-build-author",
@@ -89,7 +89,7 @@
       "name": "agentclash-dataset-workflows",
       "role": "dataset",
       "requires_cli": true,
-      "sha256": "cc95ed94b624bb88eab5f1852c5b3162fe9382a606d953a4bcfa0b0ecfdae495"
+      "sha256": "4947e24a77204157ac9233ee5dddd9ea3fa791abc463e5079ff21f43fe43b99b"
     },
     {
       "name": "agentclash-eval-runner",
@@ -113,7 +113,7 @@
       "name": "agentclash-prompt-eval-playground",
       "role": "prompt-eval",
       "requires_cli": true,
-      "sha256": "a1ee2266cc31184768c5d036601bfe61574c3371359a19b8d5dc72aca3a6a044"
+      "sha256": "8e56f23102f1bf343859abbdbae2de0a9153fd36c3204eb287b95eb474c6857f"
     },
     {
       "name": "agentclash-quickstart",

--- a/testing/feat-sync-cli-skills-snapshot-p1.md
+++ b/testing/feat-sync-cli-skills-snapshot-p1.md
@@ -1,0 +1,32 @@
+# feat/sync-cli-skills-snapshot-p1 — Test Contract
+
+## Functional Behavior
+
+Regenerate CLI embedded skills snapshot after P1 skills merge (23 skills total).
+
+## Unit Tests
+
+```bash
+node scripts/sync-cli-skills-snapshot.mjs
+cd cli && go test -short -count=1 ./internal/skills/...
+```
+
+## Integration Tests
+
+```bash
+cd cli && go test -short -count=1 ./cmd/... -run Integration
+```
+
+## Smoke Tests
+
+Snapshot manifest lists 23 skills including harness, multi-turn, dataset, prompt-eval.
+
+## E2E Tests
+
+N/A.
+
+## Manual Tests
+
+```bash
+agentclash integration claude doctor
+```

--- a/web/content/agent-skills/agentclash-dataset-workflows/SKILL.md
+++ b/web/content/agent-skills/agentclash-dataset-workflows/SKILL.md
@@ -151,5 +151,5 @@ Next: agentclash run scorecard <run-id>
 
 ## Related Docs
 - `/docs-md/guides/datasets-overview`
-- `/docs-md/guides/ci-cd-workflow-recipes`
+- `/docs-md/guides/ci-cd-workload-recipes`
 - `/docs-md/reference/cli`

--- a/web/content/agent-skills/agentclash-prompt-eval-playground/SKILL.md
+++ b/web/content/agent-skills/agentclash-prompt-eval-playground/SKILL.md
@@ -115,6 +115,6 @@ Next: agentclash eval-runner ... OR prompt-eval results <id>
 - `agentclash-regression-flywheel`
 
 ## Related Docs
-- `/docs-md/guides/datasets-overview`
+- `/docs-md/guides/use-with-ai-tools`
 - `/docs-md/reference/cli`
 - `/docs-md/getting-started/first-eval`


### PR DESCRIPTION
## Summary
- Regenerates `cli/internal/skills/snapshot/` after #925 merged four P1 portable skills (23 total).
- Refreshes hub, eval-runner, and ci-release-gate snapshots with cross-link updates.

## Test plan
- [x] `node scripts/sync-cli-skills-snapshot.mjs`
- [x] `cd cli && go test -short -count=1 ./internal/skills/... ./cmd/... -run Integration`