### PR TITLE
feat(cli): integration install for all six agent hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ testing/*
 !testing/feat-sync-cli-skills-snapshot-p0.md
 !testing/feat-skills-p1-workflow.md
 !testing/feat-sync-cli-skills-snapshot-p1.md
+!testing/feat-integration-all-hosts.md

--- a/cli/cmd/integration.go
+++ b/cli/cmd/integration.go
@@ -8,10 +8,9 @@ import (
 )
 
 func init() {
-	integrationCmd.AddCommand(
-		newIntegrationAgentCmd("claude"),
-		newIntegrationAgentCmd("codex"),
-	)
+	for _, agent := range []string{"claude", "codex", "cursor", "openclaw", "hermes", "opencode"} {
+		integrationCmd.AddCommand(newIntegrationAgentCmd(agent))
+	}
 	rootCmd.AddCommand(integrationCmd)
 }
 
@@ -22,7 +21,11 @@ var integrationCmd = &cobra.Command{
 directory, and verify the integration.
 
   agentclash integration claude install   # -> ~/.claude/skills/<skill>/SKILL.md
-  agentclash integration codex  install   # -> ~/.agents/skills/<skill>/SKILL.md
+  agentclash integration codex install    # -> ~/.agents/skills/<skill>/SKILL.md
+  agentclash integration cursor install   # -> ~/.cursor/skills/<skill>/SKILL.md
+  agentclash integration openclaw install # -> ~/.openclaw/skills/<skill>/SKILL.md
+  agentclash integration hermes install   # -> ~/.hermes/skills/<skill>/SKILL.md
+  agentclash integration opencode install # -> ~/.config/opencode/skills/<skill>/SKILL.md
   agentclash integration claude doctor    # report installed / missing / drifted skills
 
 The skills teach an agent to drive the AgentClash CLI. install is idempotent and
@@ -36,6 +39,14 @@ func agentLabel(agent string) string {
 		return "Claude Code"
 	case "codex":
 		return "Codex"
+	case "cursor":
+		return "Cursor"
+	case "openclaw":
+		return "OpenClaw"
+	case "hermes":
+		return "Hermes"
+	case "opencode":
+		return "OpenCode"
 	default:
 		return agent
 	}

--- a/cli/cmd/integration_test.go
+++ b/cli/cmd/integration_test.go
@@ -21,14 +21,14 @@ func findSubcommand(parent *cobra.Command, name string) *cobra.Command {
 }
 
 // TestIntegrationCommandTree is the Cobra-grep contract test: it pins the
-// integration -> {claude,codex} -> {install,doctor} shape and the flags, so a
-// refactor that renames or drops a subcommand/flag fails loudly.
+// integration -> {claude,codex,cursor,openclaw,hermes,opencode} -> {install,doctor}
+// shape and the flags, so a refactor that renames or drops a subcommand/flag fails loudly.
 func TestIntegrationCommandTree(t *testing.T) {
 	integ := findSubcommand(rootCmd, "integration")
 	if integ == nil {
 		t.Fatal("missing `integration` command")
 	}
-	for _, agent := range []string{"claude", "codex"} {
+	for _, agent := range []string{"claude", "codex", "cursor", "openclaw", "hermes", "opencode"} {
 		a := findSubcommand(integ, agent)
 		if a == nil {
 			t.Fatalf("missing `integration %s`", agent)
@@ -45,6 +45,21 @@ func TestIntegrationCommandTree(t *testing.T) {
 				t.Errorf("`integration %s %s` missing --with-mcp", agent, sub)
 			}
 		}
+	}
+}
+
+func TestIntegrationCursorInstallThenDoctor(t *testing.T) {
+	home := t.TempDir()
+
+	if err := executeCommand(t, []string{"integration", "cursor", "install", "--dir", home}, "http://unused"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	skillPath := filepath.Join(home, ".cursor", "skills", "agentclash-cli-setup", "SKILL.md")
+	if _, err := os.Stat(skillPath); err != nil {
+		t.Fatalf("expected installed skill at %s: %v", skillPath, err)
+	}
+	if err := executeCommand(t, []string{"integration", "cursor", "doctor", "--dir", home}, "http://unused"); err != nil {
+		t.Fatalf("doctor after install should pass, got: %v", err)
 	}
 }
 

--- a/cli/cmd/integration_test.go
+++ b/cli/cmd/integration_test.go
@@ -61,6 +61,27 @@ func TestIntegrationCursorInstallThenDoctor(t *testing.T) {
 	if err := executeCommand(t, []string{"integration", "cursor", "doctor", "--dir", home}, "http://unused"); err != nil {
 		t.Fatalf("doctor after install should pass, got: %v", err)
 	}
+	for _, forbidden := range []string{"CLAUDE.md", "AGENTS.md", ".mcp.json"} {
+		assertNoFileNamed(t, home, forbidden)
+	}
+}
+
+func TestIntegrationOpencodeInstallThenDoctor(t *testing.T) {
+	home := t.TempDir()
+
+	if err := executeCommand(t, []string{"integration", "opencode", "install", "--dir", home}, "http://unused"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	skillPath := filepath.Join(home, ".config", "opencode", "skills", "agentclash-cli-setup", "SKILL.md")
+	if _, err := os.Stat(skillPath); err != nil {
+		t.Fatalf("expected installed skill at %s: %v", skillPath, err)
+	}
+	if err := executeCommand(t, []string{"integration", "opencode", "doctor", "--dir", home}, "http://unused"); err != nil {
+		t.Fatalf("doctor after install should pass, got: %v", err)
+	}
+	for _, forbidden := range []string{"CLAUDE.md", "AGENTS.md", ".mcp.json"} {
+		assertNoFileNamed(t, home, forbidden)
+	}
 }
 
 func TestIntegrationClaudeInstallThenDoctor(t *testing.T) {

--- a/cli/cmd/testdata/schema_snapshot.json
+++ b/cli/cmd/testdata/schema_snapshot.json
@@ -2301,6 +2301,190 @@
               ]
             }
           ]
+        },
+        {
+          "name": "cursor",
+          "path": "agentclash integration cursor",
+          "short": "Manage the AgentClash skills integration for Cursor",
+          "runnable": false,
+          "subcommands": [
+            {
+              "name": "doctor",
+              "path": "agentclash integration cursor doctor",
+              "short": "Verify the AgentClash skills integration for Cursor",
+              "runnable": true,
+              "flags": [
+                {
+                  "name": "dir",
+                  "usage": "Install root (defaults to your home directory)",
+                  "type": "string"
+                },
+                {
+                  "name": "with-mcp",
+                  "usage": "Reserved: also configure an MCP server (not available yet)",
+                  "type": "bool",
+                  "default": "false"
+                }
+              ]
+            },
+            {
+              "name": "install",
+              "path": "agentclash integration cursor install",
+              "short": "Install AgentClash skills for Cursor",
+              "runnable": true,
+              "flags": [
+                {
+                  "name": "dir",
+                  "usage": "Install root (defaults to your home directory)",
+                  "type": "string"
+                },
+                {
+                  "name": "with-mcp",
+                  "usage": "Reserved: also configure an MCP server (not available yet)",
+                  "type": "bool",
+                  "default": "false"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "hermes",
+          "path": "agentclash integration hermes",
+          "short": "Manage the AgentClash skills integration for Hermes",
+          "runnable": false,
+          "subcommands": [
+            {
+              "name": "doctor",
+              "path": "agentclash integration hermes doctor",
+              "short": "Verify the AgentClash skills integration for Hermes",
+              "runnable": true,
+              "flags": [
+                {
+                  "name": "dir",
+                  "usage": "Install root (defaults to your home directory)",
+                  "type": "string"
+                },
+                {
+                  "name": "with-mcp",
+                  "usage": "Reserved: also configure an MCP server (not available yet)",
+                  "type": "bool",
+                  "default": "false"
+                }
+              ]
+            },
+            {
+              "name": "install",
+              "path": "agentclash integration hermes install",
+              "short": "Install AgentClash skills for Hermes",
+              "runnable": true,
+              "flags": [
+                {
+                  "name": "dir",
+                  "usage": "Install root (defaults to your home directory)",
+                  "type": "string"
+                },
+                {
+                  "name": "with-mcp",
+                  "usage": "Reserved: also configure an MCP server (not available yet)",
+                  "type": "bool",
+                  "default": "false"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "openclaw",
+          "path": "agentclash integration openclaw",
+          "short": "Manage the AgentClash skills integration for OpenClaw",
+          "runnable": false,
+          "subcommands": [
+            {
+              "name": "doctor",
+              "path": "agentclash integration openclaw doctor",
+              "short": "Verify the AgentClash skills integration for OpenClaw",
+              "runnable": true,
+              "flags": [
+                {
+                  "name": "dir",
+                  "usage": "Install root (defaults to your home directory)",
+                  "type": "string"
+                },
+                {
+                  "name": "with-mcp",
+                  "usage": "Reserved: also configure an MCP server (not available yet)",
+                  "type": "bool",
+                  "default": "false"
+                }
+              ]
+            },
+            {
+              "name": "install",
+              "path": "agentclash integration openclaw install",
+              "short": "Install AgentClash skills for OpenClaw",
+              "runnable": true,
+              "flags": [
+                {
+                  "name": "dir",
+                  "usage": "Install root (defaults to your home directory)",
+                  "type": "string"
+                },
+                {
+                  "name": "with-mcp",
+                  "usage": "Reserved: also configure an MCP server (not available yet)",
+                  "type": "bool",
+                  "default": "false"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "opencode",
+          "path": "agentclash integration opencode",
+          "short": "Manage the AgentClash skills integration for OpenCode",
+          "runnable": false,
+          "subcommands": [
+            {
+              "name": "doctor",
+              "path": "agentclash integration opencode doctor",
+              "short": "Verify the AgentClash skills integration for OpenCode",
+              "runnable": true,
+              "flags": [
+                {
+                  "name": "dir",
+                  "usage": "Install root (defaults to your home directory)",
+                  "type": "string"
+                },
+                {
+                  "name": "with-mcp",
+                  "usage": "Reserved: also configure an MCP server (not available yet)",
+                  "type": "bool",
+                  "default": "false"
+                }
+              ]
+            },
+            {
+              "name": "install",
+              "path": "agentclash integration opencode install",
+              "short": "Install AgentClash skills for OpenCode",
+              "runnable": true,
+              "flags": [
+                {
+                  "name": "dir",
+                  "usage": "Install root (defaults to your home directory)",
+                  "type": "string"
+                },
+                {
+                  "name": "with-mcp",
+                  "usage": "Reserved: also configure an MCP server (not available yet)",
+                  "type": "bool",
+                  "default": "false"
+                }
+              ]
+            }
+          ]
         }
       ]
     },

--- a/cli/internal/skills/skills.go
+++ b/cli/internal/skills/skills.go
@@ -61,8 +61,16 @@ func agentSubdir(agent string) (string, error) {
 		return filepath.Join(".claude", "skills"), nil
 	case "codex":
 		return filepath.Join(".agents", "skills"), nil
+	case "cursor":
+		return filepath.Join(".cursor", "skills"), nil
+	case "openclaw":
+		return filepath.Join(".openclaw", "skills"), nil
+	case "hermes":
+		return filepath.Join(".hermes", "skills"), nil
+	case "opencode":
+		return filepath.Join(".config", "opencode", "skills"), nil
 	default:
-		return "", fmt.Errorf("unknown agent %q (want claude or codex)", agent)
+		return "", fmt.Errorf("unknown agent %q (want claude, codex, cursor, openclaw, hermes, or opencode)", agent)
 	}
 }
 

--- a/cli/internal/skills/skills_test.go
+++ b/cli/internal/skills/skills_test.go
@@ -102,11 +102,37 @@ func TestCodexUsesAgentsDir(t *testing.T) {
 }
 
 func TestUnknownAgentErrors(t *testing.T) {
-	if _, err := Install("cursor", t.TempDir()); err == nil {
+	if _, err := Install("invalid", t.TempDir()); err == nil {
 		t.Fatal("Install should error for an unknown agent")
 	}
-	if _, err := Audit("cursor", t.TempDir()); err == nil {
+	if _, err := Audit("invalid", t.TempDir()); err == nil {
 		t.Fatal("Audit should error for an unknown agent")
+	}
+}
+
+func TestHostInstallPaths(t *testing.T) {
+	root := t.TempDir()
+	cases := []struct {
+		agent string
+		rel   string
+	}{
+		{"claude", filepath.Join(".claude", "skills", sampleSkill, "SKILL.md")},
+		{"codex", filepath.Join(".agents", "skills", sampleSkill, "SKILL.md")},
+		{"cursor", filepath.Join(".cursor", "skills", sampleSkill, "SKILL.md")},
+		{"openclaw", filepath.Join(".openclaw", "skills", sampleSkill, "SKILL.md")},
+		{"hermes", filepath.Join(".hermes", "skills", sampleSkill, "SKILL.md")},
+		{"opencode", filepath.Join(".config", "opencode", "skills", sampleSkill, "SKILL.md")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.agent, func(t *testing.T) {
+			dir := filepath.Join(root, tc.agent)
+			if _, err := Install(tc.agent, dir); err != nil {
+				t.Fatalf("install: %v", err)
+			}
+			if _, err := os.Stat(filepath.Join(dir, tc.rel)); err != nil {
+				t.Fatalf("expected skill at %s: %v", tc.rel, err)
+			}
+		})
 	}
 }
 

--- a/testing/feat-integration-all-hosts.md
+++ b/testing/feat-integration-all-hosts.md
@@ -1,0 +1,31 @@
+# feat/integration-all-hosts — Test Contract
+
+## Functional Behavior
+
+Extend `agentclash integration` install/doctor to cursor, openclaw, hermes, and opencode (matching agent-skills bundle paths).
+
+## Unit Tests
+
+```bash
+cd cli && go test -short -count=1 ./internal/skills/... -run HostInstall
+cd cli && go test -short -count=1 ./cmd/... -run Integration
+```
+
+## Integration Tests
+
+N/A.
+
+## Smoke Tests
+
+Each host writes `agentclash-cli-setup/SKILL.md` under the expected relative path.
+
+## E2E Tests
+
+N/A.
+
+## Manual Tests
+
+```bash
+agentclash integration cursor install --dir /tmp/ac-skills-test
+agentclash integration cursor doctor --dir /tmp/ac-skills-test
+```

--- a/web/content/docs/guides/use-with-ai-tools.mdx
+++ b/web/content/docs/guides/use-with-ai-tools.mdx
@@ -97,10 +97,18 @@ Install them with the AgentClash CLI. It is idempotent and writes only
 `SKILL.md` files — never your `CLAUDE.md`, `AGENTS.md`, or `.mcp.json`:
 
 ```bash
-agentclash integration claude install   # -> ~/.claude/skills/
-agentclash integration codex install    # -> ~/.agents/skills/
+agentclash integration claude install    # -> ~/.claude/skills/
+agentclash integration codex install     # -> ~/.agents/skills/
+agentclash integration cursor install    # -> ~/.cursor/skills/
+agentclash integration openclaw install  # -> ~/.openclaw/skills/
+agentclash integration hermes install    # -> ~/.hermes/skills/
+agentclash integration opencode install  # -> ~/.config/opencode/skills/
 agentclash integration claude doctor     # verify installed / missing / drifted
 ```
+
+Project-local OpenCode installs use `.opencode/skills/` — use the
+[agent-skills bundle](https://github.com/agentclash/agent-skills) installer with
+`--project` until the CLI adds a project scope flag.
 
 Or install the published bundle with [GitHub CLI](https://cli.github.com) 2.90+,
 which drops skills into the correct directory for Claude Code, Copilot, Cursor,


### PR DESCRIPTION
## Summary
- Extends `agentclash integration <host> install|doctor` to cursor, openclaw, hermes, and opencode.
- Maps each host to the same paths as the [agent-skills](https://github.com/agentclash/agent-skills) bundle installer.
- Updates `use-with-ai-tools.mdx` with install commands for all hosts.

## Test plan
- [x] `cd cli && go test -short -count=1 ./internal/skills/... ./cmd/... -run 'Integration|HostInstall'`
- [ ] Greptile + CI green