### PR TITLE
feat(cli): add agentclash skills export for offline install (#922)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,5 @@ testing/*
 !testing/feat-skills-p3-workflow.md
 !testing/feat-sync-cli-skills-snapshot-p1.md
 !testing/feat-sync-cli-skills-snapshot-p3.md
+!testing/feat-skills-export.md
 !testing/feat-integration-all-hosts.md

--- a/cli/cmd/integration.go
+++ b/cli/cmd/integration.go
@@ -30,7 +30,11 @@ directory, and verify the integration.
 
 The skills teach an agent to drive the AgentClash CLI. install is idempotent and
 writes only SKILL.md files — it never modifies CLAUDE.md, AGENTS.md, .mcp.json,
-or any other project config.`,
+or any other project config.
+
+To export the same bundle for offline install, use:
+
+  agentclash skills export --dir ./bundle.tar.gz --host claude --format tar.gz`,
 }
 
 func agentLabel(agent string) string {

--- a/cli/cmd/skills.go
+++ b/cli/cmd/skills.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/agentclash/agentclash/cli/internal/skills"
+	"github.com/spf13/cobra"
+)
+
+var skillsCmd = &cobra.Command{
+	Use:   "skills",
+	Short: "Export bundled AgentClash Agent Skills",
+	Long: `Commands for the embedded AgentClash Agent Skills snapshot synced from
+web/content/agent-skills.
+
+Use export to write the bundle to a directory or .tar.gz archive for offline
+install or air-gapped environments. For direct install into a coding agent's
+skills directory, prefer:
+
+  agentclash integration <host> install`,
+}
+
+var skillsExportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Export bundled skills to a directory or tarball",
+	Long: `Write every bundled AgentClash skill to disk for offline install.
+
+Directory export (flat layout):
+
+  agentclash skills export --dir ./agentclash-skills
+  # -> ./agentclash-skills/<skill>/SKILL.md
+
+Host layout (ready to merge into a home or project directory):
+
+  agentclash skills export --dir ./out --host claude
+  # -> ./out/.claude/skills/<skill>/SKILL.md
+
+Tarball export:
+
+  agentclash skills export --dir ./bundle.tar.gz --format tar.gz
+  agentclash skills export --dir ./claude-skills.tar.gz --host claude --format tar.gz
+
+Extract a host tarball into $HOME (or a project root) to match integration install paths.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rc := GetRunContext(cmd)
+		dir, _ := cmd.Flags().GetString("dir")
+		host, _ := cmd.Flags().GetString("host")
+		formatRaw, _ := cmd.Flags().GetString("format")
+
+		if dir == "" {
+			return fmt.Errorf("--dir is required")
+		}
+		format, err := skills.ParseExportFormat(formatRaw)
+		if err != nil {
+			return err
+		}
+		if host != "" {
+			if _, err := skills.AgentSubdir(host); err != nil {
+				return err
+			}
+		}
+
+		report, err := skills.Export(dir, host, format)
+		if err != nil {
+			return err
+		}
+		if rc.Output.IsStructured() {
+			return rc.Output.PrintRaw(report)
+		}
+		w := rc.Output.Writer()
+		fmt.Fprintf(w, "Exported %d skills (snapshot v%s)\n", report.Count, report.SnapshotVersion)
+		fmt.Fprintf(w, "  format: %s\n", report.Format)
+		if report.Host != "" {
+			fmt.Fprintf(w, "  host layout: %s\n", report.Host)
+		}
+		fmt.Fprintf(w, "  path: %s\n", report.Path)
+		rc.Output.PrintSuccess("Extract or copy the exported tree into your agent skills directory.")
+		return nil
+	},
+}
+
+func init() {
+	skillsExportCmd.Flags().String("dir", "", "Output directory or .tar.gz archive path (required)")
+	skillsExportCmd.Flags().String("host", "", "Layout for a coding agent host (claude, codex, cursor, openclaw, hermes, opencode)")
+	skillsExportCmd.Flags().String("format", "dir", "Output format: dir or tar.gz")
+	skillsCmd.AddCommand(skillsExportCmd)
+	rootCmd.AddCommand(skillsCmd)
+}

--- a/cli/cmd/skills_test.go
+++ b/cli/cmd/skills_test.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSkillsCommandTree(t *testing.T) {
+	skills := findSubcommand(rootCmd, "skills")
+	if skills == nil {
+		t.Fatal("missing `skills` command")
+	}
+	export := findSubcommand(skills, "export")
+	if export == nil {
+		t.Fatal("missing `skills export`")
+	}
+	for _, flag := range []string{"dir", "host", "format"} {
+		if export.Flags().Lookup(flag) == nil {
+			t.Errorf("`skills export` missing --%s", flag)
+		}
+	}
+}
+
+func TestSkillsExportCmd(t *testing.T) {
+	home := t.TempDir()
+	out := filepath.Join(home, "skills-out")
+	if err := executeCommand(t, []string{"skills", "export", "--dir", out, "--json"}, "http://unused"); err != nil {
+		t.Fatalf("skills export: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(out, "agentclash-cli-setup", "SKILL.md")); err != nil {
+		t.Fatalf("expected exported skill: %v", err)
+	}
+}
+
+func TestSkillsExportRequiresDir(t *testing.T) {
+	if err := executeCommand(t, []string{"skills", "export"}, "http://unused"); err == nil {
+		t.Fatal("expected error when --dir is missing")
+	}
+}

--- a/cli/cmd/testdata/schema_snapshot.json
+++ b/cli/cmd/testdata/schema_snapshot.json
@@ -3974,6 +3974,38 @@
       ]
     },
     {
+      "name": "skills",
+      "path": "agentclash skills",
+      "short": "Export bundled AgentClash Agent Skills",
+      "runnable": false,
+      "subcommands": [
+        {
+          "name": "export",
+          "path": "agentclash skills export",
+          "short": "Export bundled skills to a directory or tarball",
+          "runnable": true,
+          "flags": [
+            {
+              "name": "dir",
+              "usage": "Output directory or .tar.gz archive path (required)",
+              "type": "string"
+            },
+            {
+              "name": "format",
+              "usage": "Output format: dir or tar.gz",
+              "type": "string",
+              "default": "dir"
+            },
+            {
+              "name": "host",
+              "usage": "Layout for a coding agent host (claude, codex, cursor, openclaw, hermes, opencode)",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "version",
       "path": "agentclash version",
       "short": "Show CLI version information",

--- a/cli/internal/skills/export.go
+++ b/cli/internal/skills/export.go
@@ -1,0 +1,187 @@
+package skills
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ExportFormat selects directory or tarball output.
+type ExportFormat string
+
+const (
+	ExportFormatDir   ExportFormat = "dir"
+	ExportFormatTarGz ExportFormat = "tar.gz"
+)
+
+// ExportReport summarises an export.
+type ExportReport struct {
+	Format          ExportFormat `json:"format"`
+	Path            string       `json:"path"`
+	Host            string       `json:"host,omitempty"`
+	SnapshotVersion string       `json:"snapshot_version"`
+	Skills          []string     `json:"skills"`
+	Count           int          `json:"count"`
+}
+
+func parseExportFormat(raw string) (ExportFormat, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "dir", "":
+		return ExportFormatDir, nil
+	case "tar.gz", "tgz":
+		return ExportFormatTarGz, nil
+	default:
+		return "", fmt.Errorf("unknown export format %q (want dir or tar.gz)", raw)
+	}
+}
+
+func exportRoot(dest, agent string) (string, error) {
+	if agent == "" {
+		return dest, nil
+	}
+	subdir, err := agentSubdir(agent)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dest, subdir), nil
+}
+
+// Export writes the bundled skills to dest.
+// For ExportFormatDir, dest is an output directory (created if needed).
+// For ExportFormatTarGz, dest is the archive file path.
+// When agent is non-empty, files are placed under the host skills subdir.
+func Export(dest, agent string, format ExportFormat) (ExportReport, error) {
+	f, err := parseExportFormat(string(format))
+	if err != nil {
+		return ExportReport{}, err
+	}
+	m, err := loadManifest()
+	if err != nil {
+		return ExportReport{}, err
+	}
+	report := ExportReport{
+		Format:          f,
+		Path:            dest,
+		Host:            agent,
+		SnapshotVersion: m.SnapshotVersion,
+	}
+	switch f {
+	case ExportFormatDir:
+		root, err := exportRoot(dest, agent)
+		if err != nil {
+			return report, err
+		}
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			return report, err
+		}
+		for _, s := range m.Skills {
+			if err := writeSkillToDir(root, s.Name); err != nil {
+				return report, err
+			}
+			report.Skills = append(report.Skills, s.Name)
+		}
+		report.Count = len(report.Skills)
+		return report, nil
+	case ExportFormatTarGz:
+		tmp, err := os.MkdirTemp("", "agentclash-skills-export-*")
+		if err != nil {
+			return report, err
+		}
+		defer os.RemoveAll(tmp)
+		root, err := exportRoot(tmp, agent)
+		if err != nil {
+			return report, err
+		}
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			return report, err
+		}
+		for _, s := range m.Skills {
+			if err := writeSkillToDir(root, s.Name); err != nil {
+				return report, err
+			}
+			report.Skills = append(report.Skills, s.Name)
+		}
+		report.Count = len(report.Skills)
+		if err := writeTarGz(dest, tmp); err != nil {
+			return report, err
+		}
+		return report, nil
+	default:
+		return report, fmt.Errorf("unsupported export format %q", f)
+	}
+}
+
+func writeSkillToDir(root, name string) error {
+	body, err := embeddedBody(name)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "SKILL.md"), body, 0o644)
+}
+
+func writeTarGz(archivePath, srcDir string) error {
+	if err := os.MkdirAll(filepath.Dir(archivePath), 0o755); err != nil && filepath.Dir(archivePath) != "." {
+		return err
+	}
+	f, err := os.Create(archivePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gw := gzip.NewWriter(f)
+	defer gw.Close()
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+
+	return filepath.WalkDir(srcDir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		hdr, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+		hdr.Name = rel
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(tw, file)
+		file.Close()
+		return err
+	})
+}
+
+// ParseExportFormat validates a user-facing format flag.
+func ParseExportFormat(raw string) (ExportFormat, error) {
+	return parseExportFormat(raw)
+}
+
+// AgentSubdir returns the host skills directory relative to an install root.
+func AgentSubdir(agent string) (string, error) {
+	return agentSubdir(agent)
+}

--- a/cli/internal/skills/export.go
+++ b/cli/internal/skills/export.go
@@ -127,7 +127,7 @@ func writeSkillToDir(root, name string) error {
 	return os.WriteFile(filepath.Join(dir, "SKILL.md"), body, 0o644)
 }
 
-func writeTarGz(archivePath, srcDir string) error {
+func writeTarGz(archivePath, srcDir string) (err error) {
 	if err := os.MkdirAll(filepath.Dir(archivePath), 0o755); err != nil && filepath.Dir(archivePath) != "." {
 		return err
 	}
@@ -135,14 +135,16 @@ func writeTarGz(archivePath, srcDir string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		if closeErr := f.Close(); err == nil {
+			err = closeErr
+		}
+	}()
 
 	gw := gzip.NewWriter(f)
-	defer gw.Close()
 	tw := tar.NewWriter(gw)
-	defer tw.Close()
 
-	return filepath.WalkDir(srcDir, func(path string, d os.DirEntry, walkErr error) error {
+	if walkErr := filepath.WalkDir(srcDir, func(path string, d os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -173,7 +175,16 @@ func writeTarGz(archivePath, srcDir string) error {
 		_, err = io.Copy(tw, file)
 		file.Close()
 		return err
-	})
+	}); walkErr != nil {
+		return walkErr
+	}
+	if err := tw.Close(); err != nil {
+		return err
+	}
+	if err := gw.Close(); err != nil {
+		return err
+	}
+	return nil
 }
 
 // ParseExportFormat validates a user-facing format flag.

--- a/cli/internal/skills/export_test.go
+++ b/cli/internal/skills/export_test.go
@@ -1,0 +1,83 @@
+package skills
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExportDirFlat(t *testing.T) {
+	root := t.TempDir()
+	report, err := Export(root, "", ExportFormatDir)
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	if report.Count == 0 {
+		t.Fatal("expected skills in export")
+	}
+	if _, err := os.Stat(filepath.Join(root, sampleSkill, "SKILL.md")); err != nil {
+		t.Fatalf("missing exported skill: %v", err)
+	}
+}
+
+func TestExportDirHostLayout(t *testing.T) {
+	root := t.TempDir()
+	if _, err := Export(root, "cursor", ExportFormatDir); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".cursor", "skills", sampleSkill, "SKILL.md")); err != nil {
+		t.Fatalf("cursor layout: %v", err)
+	}
+}
+
+func TestExportTarGzHostLayout(t *testing.T) {
+	root := t.TempDir()
+	archive := filepath.Join(root, "bundle.tar.gz")
+	report, err := Export(archive, "claude", ExportFormatTarGz)
+	if err != nil {
+		t.Fatalf("export tar.gz: %v", err)
+	}
+	if report.Count == 0 {
+		t.Fatal("expected skills")
+	}
+	f, err := os.Open(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	found := false
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if hdr.Name == ".claude/skills/"+sampleSkill+"/SKILL.md" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("tar missing .claude/skills/%s/SKILL.md", sampleSkill)
+	}
+}
+
+func TestParseExportFormat(t *testing.T) {
+	if _, err := ParseExportFormat("tar.gz"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParseExportFormat("nope"); err == nil {
+		t.Fatal("expected error for unknown format")
+	}
+}

--- a/docs/agent-skills-publishing.md
+++ b/docs/agent-skills-publishing.md
@@ -5,7 +5,8 @@ through two channels, both generated from that single canonical source:
 
 | Channel | For | How |
 | --- | --- | --- |
-| `agentclash integration <claude\|codex> install` | Users who already have the CLI | Embedded snapshot (`cli/internal/skills/snapshot`); see [CLI workflow handoff](cli-workflow-handoff.md). |
+| `agentclash integration <host> install` | Users who already have the CLI | Embedded snapshot (`cli/internal/skills/snapshot`); see [CLI workflow handoff](cli-workflow-handoff.md). |
+| `agentclash skills export` | Offline or air-gapped install | Directory or `.tar.gz` from the same embedded snapshot; see [Use with AI tools](guides/use-with-ai-tools.mdx) in the web docs tree. |
 | `gh skill install agentclash/agentclash <skill>` | Any [supported host](#supported-hosts) (incl. ones without the CLI) | Published GitHub release validated against the [agentskills.io](https://agentskills.io) spec. |
 
 `web/content/agent-skills` is the source of truth. Do **not** hand-edit either

--- a/testing/feat-skills-export.md
+++ b/testing/feat-skills-export.md
@@ -1,0 +1,31 @@
+# feat/skills-export — Test Contract
+
+## Functional Behavior
+
+`agentclash skills export` writes the embedded skills snapshot to a directory
+or `.tar.gz` archive for offline install (issue #922 P2).
+
+- Default `--format dir` writes `<skill>/SKILL.md` under `--dir`.
+- With `--host`, writes host-relative paths (e.g. `.claude/skills/<skill>/SKILL.md`).
+- `--format tar.gz` packages the same tree into a single archive.
+
+## Unit Tests
+
+```bash
+cd cli && go test -short -count=1 ./internal/skills/... -run Export
+cd cli && go test -short -count=1 ./cmd/... -run SkillsExport
+go test ./cmd -run TestSchemaJSONMatchesGoldenSnapshot -update  # when command tree changes
+```
+
+## Smoke Tests
+
+```bash
+agentclash skills export --dir /tmp/ac-skills --format dir
+agentclash skills export --dir /tmp/ac-skills-claude.tar.gz --host claude --format tar.gz
+tar -tzf /tmp/ac-skills-claude.tar.gz | head
+```
+
+## Manual Tests
+
+Extract tarball on a machine without network; copy into agent skills dir; run
+`agentclash integration <host> doctor`.

--- a/web/content/docs/guides/use-with-ai-tools.mdx
+++ b/web/content/docs/guides/use-with-ai-tools.mdx
@@ -110,6 +110,18 @@ Project-local OpenCode installs use `.opencode/skills/` — use the
 [agent-skills bundle](https://github.com/agentclash/agent-skills) installer with
 `--project` until the CLI adds a project scope flag.
 
+### Offline export
+
+For air-gapped machines, export the embedded snapshot to a directory or tarball,
+then copy or extract into the agent skills path:
+
+```bash
+agentclash skills export --dir ./agentclash-skills
+agentclash skills export --dir ./claude-skills.tar.gz --host claude --format tar.gz
+tar -xzf claude-skills.tar.gz -C ~
+agentclash integration claude doctor
+```
+
 Or install the published bundle with [GitHub CLI](https://cli.github.com) 2.90+,
 which drops skills into the correct directory for Claude Code, Copilot, Cursor,
 Codex, Gemini CLI, or Antigravity:


### PR DESCRIPTION
## Summary
- Add `agentclash skills export` to write the embedded 25-skill snapshot to a directory or `.tar.gz` archive.
- Support flat layout or host-relative paths (`--host claude` → `.claude/skills/...`).
- Document offline export in `use-with-ai-tools` and `agent-skills-publishing`.

Closes the P2 distribution gap from #922 (`skills export` tarball for offline install).

## Test plan
- [x] `cd cli && go test -short -count=1 ./internal/skills/... ./cmd/... -run 'Export|Skills'`
- [x] `cd cli && go test -short -count=1 ./...`
- [x] Schema snapshot updated
- [ ] Greptile review