### PR TITLE
feat(web): SEO landing pages for agent evaluation keywords

### DIFF
--- a/web/content/blog/pass-at-k-vs-pass-power-k.mdx
+++ b/web/content/blog/pass-at-k-vs-pass-power-k.mdx
@@ -1,0 +1,71 @@
+---
+title: "pass@k vs pass^k: What Agent Reliability Metrics Actually Measure"
+date: "2026-06-06"
+description: "A practical guide to pass@k and pass^k for agent evaluation — when independent retries and strict success-over-trials measure different kinds of reliability."
+author: "Atharva"
+---
+
+Agent teams borrow reliability metrics from coding benchmarks without always agreeing on what they mean. Two common names sound almost identical but answer different questions:
+
+- **pass@k** — did the agent succeed at least once in *k* independent attempts?
+- **pass^k** — did the agent succeed on *all k* attempts?
+
+That one-character difference changes release decisions.
+
+## Why the distinction matters for agents
+
+Agents are stochastic systems running in messy environments. A single lucky retry can hide a brittle tool strategy. A single unlucky timeout can hide a mostly-good harness.
+
+If your product promise is "this agent usually finishes the job," pass@k may be the right lens. If your product promise is "this agent must not fail twice in a row in production," pass^k is closer to the operational question.
+
+Neither metric replaces trajectory review. Both need replay evidence, artifact checks, and scorecards that explain *why* a run passed or failed.
+
+## pass@k: at least one success in k tries
+
+pass@k is optimistic about reliability. It asks whether the agent can produce an acceptable outcome within a retry budget.
+
+Use pass@k when:
+
+- users can safely retry or escalate
+- the cost of a failed attempt is bounded
+- you are comparing exploration-heavy agents on hard tasks
+- you want to know whether a model *can* solve a workload at all
+
+Caveat: a high pass@k with a low pass^1 means the agent is flaky. Shipping it without a retry policy can still create support load.
+
+## pass^k: success on every one of k tries
+
+pass^k is strict. It asks whether the agent is consistently reliable, not occasionally lucky.
+
+Use pass^k when:
+
+- failures are expensive or customer-visible
+- retries are limited by latency, quota, or policy
+- you are gating releases for production agents
+- you need stability across prompt, tool, or model drift
+
+Caveat: pass^k can be too harsh early in development. Teams often start with pass@k while learning the workload, then tighten to pass^k once the trajectory is stable.
+
+## How AgentClash fits the workflow
+
+AgentClash is built for workloads where the path matters. Challenge packs encode the task, tool policy, validators, and artifacts once. Each run keeps replay evidence and a scorecard so reviewers can see whether a pass was cheap, expensive, lucky, or repeatable.
+
+That makes it easier to use pass@k and pass^k honestly:
+
+1. **Freeze the workload** in a challenge pack so every attempt runs under the same constraints.
+2. **Run k independent attempts** for the candidate and baseline you care about.
+3. **Inspect replay** when attempts disagree — did failures cluster on the same tool call or validator?
+4. **Promote the workload into CI** once you know which reliability metric matches your release bar.
+
+For product context, see [agent reliability benchmark](/agent-reliability-benchmark) and [AI agent regression testing](/platform/agent-regression-testing). For implementation, start with [CI/CD agent gates](/docs/guides/ci-cd-agent-gates).
+
+## A simple decision rule
+
+Ask one question before picking the metric:
+
+> If this agent fails once in production, is that acceptable as long as a retry usually works?
+
+- **Yes** → track pass@k, but still inspect failure clusters in replay.
+- **No** → track pass^k, and treat any regression in strict success rate as a release blocker.
+
+The best teams use both over time: pass@k while discovering the workload, pass^k while hardening the release gate.

--- a/web/src/app/agent-evals/page.tsx
+++ b/web/src/app/agent-evals/page.tsx
@@ -1,0 +1,6 @@
+import { createSeoRoutePage } from "@/lib/seo-pages/create-route-page";
+
+const { metadata, Page } = createSeoRoutePage("/agent-evals");
+
+export { metadata };
+export default Page;

--- a/web/src/app/agent-evaluation-framework/page.tsx
+++ b/web/src/app/agent-evaluation-framework/page.tsx
@@ -1,0 +1,6 @@
+import { createSeoRoutePage } from "@/lib/seo-pages/create-route-page";
+
+const { metadata, Page } = createSeoRoutePage("/agent-evaluation-framework");
+
+export { metadata };
+export default Page;

--- a/web/src/app/agent-reliability-benchmark/page.tsx
+++ b/web/src/app/agent-reliability-benchmark/page.tsx
@@ -1,0 +1,6 @@
+import { createSeoRoutePage } from "@/lib/seo-pages/create-route-page";
+
+const { metadata, Page } = createSeoRoutePage("/agent-reliability-benchmark");
+
+export { metadata };
+export default Page;

--- a/web/src/app/agent-trajectory-evaluation/page.tsx
+++ b/web/src/app/agent-trajectory-evaluation/page.tsx
@@ -1,0 +1,6 @@
+import { createSeoRoutePage } from "@/lib/seo-pages/create-route-page";
+
+const { metadata, Page } = createSeoRoutePage("/agent-trajectory-evaluation");
+
+export { metadata };
+export default Page;

--- a/web/src/app/ai-agent-benchmark/page.tsx
+++ b/web/src/app/ai-agent-benchmark/page.tsx
@@ -1,0 +1,6 @@
+import { createSeoRoutePage } from "@/lib/seo-pages/create-route-page";
+
+const { metadata, Page } = createSeoRoutePage("/ai-agent-benchmark");
+
+export { metadata };
+export default Page;

--- a/web/src/app/ai-agent-testing/page.tsx
+++ b/web/src/app/ai-agent-testing/page.tsx
@@ -1,0 +1,6 @@
+import { createSeoRoutePage } from "@/lib/seo-pages/create-route-page";
+
+const { metadata, Page } = createSeoRoutePage("/ai-agent-testing");
+
+export { metadata };
+export default Page;

--- a/web/src/app/ci-cd-agent-evaluation/page.tsx
+++ b/web/src/app/ci-cd-agent-evaluation/page.tsx
@@ -1,0 +1,6 @@
+import { createSeoRoutePage } from "@/lib/seo-pages/create-route-page";
+
+const { metadata, Page } = createSeoRoutePage("/ci-cd-agent-evaluation");
+
+export { metadata };
+export default Page;

--- a/web/src/app/features/[slug]/page.tsx
+++ b/web/src/app/features/[slug]/page.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { SeoLandingPage } from "@/components/marketing/seo-landing-page";
+import {
+  createSeoPageMetadata,
+  getSeoPageByPath,
+  getSeoPagesByPrefix,
+} from "@/lib/seo-pages";
+
+type Props = {
+  params: Promise<{ slug: string }>;
+};
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return getSeoPagesByPrefix("/features").map((entry) => ({
+    slug: entry.path.replace("/features/", ""),
+  }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const config = getSeoPageByPath(`/features/${slug}`);
+  if (!config) {
+    return {};
+  }
+  return createSeoPageMetadata(config);
+}
+
+export default async function FeatureSeoPage({ params }: Props) {
+  const { slug } = await params;
+  const config = getSeoPageByPath(`/features/${slug}`);
+  if (!config) notFound();
+  return <SeoLandingPage config={config} />;
+}

--- a/web/src/app/features/page.tsx
+++ b/web/src/app/features/page.tsx
@@ -1,0 +1,31 @@
+import {
+  SeoCollectionPage,
+  createSeoCollectionMetadata,
+} from "@/components/marketing/seo-collection-page";
+import { getSeoPagesByPrefix } from "@/lib/seo-pages";
+
+const PAGE_PATH = "/features";
+const PAGE_TITLE = "Agent Evaluation Features - AgentClash";
+const PAGE_DESCRIPTION =
+  "Explore AgentClash features for agent scorecards, replay evidence, and challenge packs that turn real tasks into repeatable evaluations.";
+
+export const metadata = createSeoCollectionMetadata({
+  path: PAGE_PATH,
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+});
+
+export default function FeaturesIndexPage() {
+  return (
+    <SeoCollectionPage
+      path={PAGE_PATH}
+      title={PAGE_TITLE}
+      description={PAGE_DESCRIPTION}
+      eyebrow="Features"
+      h1="Agent evaluation features"
+      intro="See how AgentClash turns agent runs into reviewable scorecards, replay evidence, and reusable challenge packs for CI-ready evaluation."
+      pages={getSeoPagesByPrefix(PAGE_PATH)}
+      schemaId="agentclash-features-index-schema"
+    />
+  );
+}

--- a/web/src/app/llm-agent-evaluation/page.tsx
+++ b/web/src/app/llm-agent-evaluation/page.tsx
@@ -1,0 +1,6 @@
+import { createSeoRoutePage } from "@/lib/seo-pages/create-route-page";
+
+const { metadata, Page } = createSeoRoutePage("/llm-agent-evaluation");
+
+export { metadata };
+export default Page;

--- a/web/src/app/open-source-ai-agent-evaluation/page.tsx
+++ b/web/src/app/open-source-ai-agent-evaluation/page.tsx
@@ -1,0 +1,6 @@
+import { createSeoRoutePage } from "@/lib/seo-pages/create-route-page";
+
+const { metadata, Page } = createSeoRoutePage("/open-source-ai-agent-evaluation");
+
+export { metadata };
+export default Page;

--- a/web/src/app/seo-landing-pages.test.tsx
+++ b/web/src/app/seo-landing-pages.test.tsx
@@ -1,0 +1,62 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { SeoLandingPage } from "@/components/marketing/seo-landing-page";
+import { createSeoPageMetadata } from "@/lib/seo-pages/factory";
+import { getSeoPageByPath } from "@/lib/seo-pages";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function render(element: React.ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(element);
+  });
+}
+
+function getJsonLd(id: string) {
+  const script = container?.querySelector<HTMLScriptElement>(`#${id}`);
+  expect(script?.type).toBe("application/ld+json");
+  return JSON.parse(script?.textContent ?? "[]") as Array<Record<string, unknown>>;
+}
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe("SEO landing pages", () => {
+  it("emits structured data for a tier-S page", () => {
+    const config = getSeoPageByPath("/agent-evals");
+    expect(config).toBeDefined();
+    render(<SeoLandingPage config={config!} />);
+
+    const jsonLd = getJsonLd("agentclash-agent-evals-schema");
+    expect(jsonLd.map((item) => item["@type"])).toEqual([
+      "BreadcrumbList",
+      "FAQPage",
+      "SoftwareApplication",
+    ]);
+  });
+
+  it("locks canonical metadata for a feature page", () => {
+    const config = getSeoPageByPath("/features/challenge-packs");
+    expect(config).toBeDefined();
+
+    expect(createSeoPageMetadata(config!)).toMatchObject({
+      alternates: {
+        canonical: "/features/challenge-packs",
+      },
+      openGraph: {
+        url: "/features/challenge-packs",
+      },
+    });
+  });
+});

--- a/web/src/app/sitemap-page.test.tsx
+++ b/web/src/app/sitemap-page.test.tsx
@@ -78,6 +78,8 @@ describe("HTML sitemap page", () => {
         "/platform/agent-evaluation",
         "/platform/agent-regression-testing",
         "/agent-evals",
+        "/use-cases",
+        "/features",
         "/features/challenge-packs",
         "/docs",
         "/blog",

--- a/web/src/app/sitemap-page.test.tsx
+++ b/web/src/app/sitemap-page.test.tsx
@@ -77,6 +77,8 @@ describe("HTML sitemap page", () => {
         "/",
         "/platform/agent-evaluation",
         "/platform/agent-regression-testing",
+        "/agent-evals",
+        "/features/challenge-packs",
         "/docs",
         "/blog",
         "/why",

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -78,6 +78,18 @@ describe("sitemap", () => {
       changeFrequency: "monthly",
       priority: 0.82,
     });
+    expect(
+      byUrl.get("https://www.agentclash.dev/agent-evals"),
+    ).toMatchObject({
+      changeFrequency: "monthly",
+      priority: 0.84,
+    });
+    expect(
+      byUrl.get("https://www.agentclash.dev/features/agent-replay"),
+    ).toMatchObject({
+      changeFrequency: "monthly",
+      priority: 0.76,
+    });
     expect(byUrl.get("https://www.agentclash.dev/llms.txt")).toMatchObject({
       changeFrequency: "weekly",
       priority: 0.6,

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -90,6 +90,14 @@ describe("sitemap", () => {
       changeFrequency: "monthly",
       priority: 0.76,
     });
+    expect(byUrl.get("https://www.agentclash.dev/use-cases")).toMatchObject({
+      changeFrequency: "monthly",
+      priority: 0.78,
+    });
+    expect(byUrl.get("https://www.agentclash.dev/features")).toMatchObject({
+      changeFrequency: "monthly",
+      priority: 0.78,
+    });
     expect(byUrl.get("https://www.agentclash.dev/llms.txt")).toMatchObject({
       changeFrequency: "weekly",
       priority: 0.6,

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/changelog";
 import { COMPETITORS } from "@/lib/comparison-data";
 import { DOCS_ORIGIN, getAllDocPaths } from "@/lib/docs";
+import { SEO_PAGE_REGISTRY, seoPageSitemapPriority } from "@/lib/seo-pages";
 import { ogImageUrl } from "@/lib/seo";
 
 // `MetadataRoute.Sitemap` `images` entries must be ABSOLUTE URLs, and the
@@ -171,6 +172,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
         ogImage({ title: "AI Agent Regression Testing", kind: "Platform" }),
       ],
     },
+    ...SEO_PAGE_REGISTRY.map((page) => ({
+      url: `${DOCS_ORIGIN}${page.path}`,
+      lastModified: new Date(),
+      changeFrequency: "monthly" as const,
+      priority: seoPageSitemapPriority(page.tier),
+      images: [ogImage({ title: page.sitemapTitle, kind: "SEO" })],
+    })),
     {
       url: `${DOCS_ORIGIN}/try`,
       lastModified: new Date(),

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -172,6 +172,20 @@ export default function sitemap(): MetadataRoute.Sitemap {
         ogImage({ title: "AI Agent Regression Testing", kind: "Platform" }),
       ],
     },
+    {
+      url: `${DOCS_ORIGIN}/use-cases`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.78,
+      images: [ogImage({ title: "Agent Evaluation Use Cases", kind: "SEO" })],
+    },
+    {
+      url: `${DOCS_ORIGIN}/features`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.78,
+      images: [ogImage({ title: "Agent Evaluation Features", kind: "SEO" })],
+    },
     ...SEO_PAGE_REGISTRY.map((page) => ({
       url: `${DOCS_ORIGIN}${page.path}`,
       lastModified: new Date(),

--- a/web/src/app/sitemap/page.tsx
+++ b/web/src/app/sitemap/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { DOCS_NAV } from "@/lib/docs";
 import { getAllPosts } from "@/lib/blog";
+import { SEO_PAGE_REGISTRY } from "@/lib/seo-pages";
 
 export const metadata: Metadata = {
   title: "Sitemap - AgentClash",
@@ -94,6 +95,12 @@ const primaryPages = [
   },
 ];
 
+const seoLandingPages = SEO_PAGE_REGISTRY.map((page) => ({
+  title: page.sitemapTitle,
+  href: page.path,
+  description: page.sitemapDescription,
+}));
+
 function LinkList({
   title,
   items,
@@ -151,6 +158,10 @@ export default function HtmlSitemapPage() {
 
         <div className="mt-12 grid gap-10 lg:grid-cols-2">
           <LinkList title="Core pages" items={primaryPages} />
+          <LinkList title="SEO landing pages" items={seoLandingPages} />
+        </div>
+
+        <div className="mt-12">
           <LinkList title="Blog posts" items={posts} />
         </div>
 

--- a/web/src/app/sitemap/page.tsx
+++ b/web/src/app/sitemap/page.tsx
@@ -59,6 +59,16 @@ const primaryPages = [
     description: "Catch AI agent regressions with baseline comparisons and CI gates.",
   },
   {
+    title: "Use cases",
+    href: "/use-cases",
+    description: "Coding, research, and support agent evaluation use cases.",
+  },
+  {
+    title: "Features",
+    href: "/features",
+    description: "Scorecards, replay, and challenge packs for agent evaluation.",
+  },
+  {
     title: "Docs",
     href: "/docs",
     description: "Guides and references for running AgentClash.",

--- a/web/src/app/use-cases/[slug]/page.tsx
+++ b/web/src/app/use-cases/[slug]/page.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { SeoLandingPage } from "@/components/marketing/seo-landing-page";
+import {
+  createSeoPageMetadata,
+  getSeoPageByPath,
+  getSeoPagesByPrefix,
+} from "@/lib/seo-pages";
+
+type Props = {
+  params: Promise<{ slug: string }>;
+};
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return getSeoPagesByPrefix("/use-cases").map((entry) => ({
+    slug: entry.path.replace("/use-cases/", ""),
+  }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const config = getSeoPageByPath(`/use-cases/${slug}`);
+  if (!config) {
+    return {};
+  }
+  return createSeoPageMetadata(config);
+}
+
+export default async function UseCaseSeoPage({ params }: Props) {
+  const { slug } = await params;
+  const config = getSeoPageByPath(`/use-cases/${slug}`);
+  if (!config) notFound();
+  return <SeoLandingPage config={config} />;
+}

--- a/web/src/app/use-cases/page.tsx
+++ b/web/src/app/use-cases/page.tsx
@@ -1,0 +1,31 @@
+import {
+  SeoCollectionPage,
+  createSeoCollectionMetadata,
+} from "@/components/marketing/seo-collection-page";
+import { getSeoPagesByPrefix } from "@/lib/seo-pages";
+
+const PAGE_PATH = "/use-cases";
+const PAGE_TITLE = "Agent Evaluation Use Cases - AgentClash";
+const PAGE_DESCRIPTION =
+  "Explore AgentClash use cases for coding, research, and customer support agent evaluation with replay evidence and CI gates.";
+
+export const metadata = createSeoCollectionMetadata({
+  path: PAGE_PATH,
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+});
+
+export default function UseCasesIndexPage() {
+  return (
+    <SeoCollectionPage
+      path={PAGE_PATH}
+      title={PAGE_TITLE}
+      description={PAGE_DESCRIPTION}
+      eyebrow="Use cases"
+      h1="Agent evaluation use cases"
+      intro="Pick the workload that matches your team — coding agents, research agents, or customer support agents — and evaluate them on real tasks with replay and scorecards."
+      pages={getSeoPagesByPrefix(PAGE_PATH)}
+      schemaId="agentclash-use-cases-index-schema"
+    />
+  );
+}

--- a/web/src/components/marketing/seo-collection-page.tsx
+++ b/web/src/components/marketing/seo-collection-page.tsx
@@ -1,0 +1,145 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { ClashMark } from "@/components/marketing/clash-mark";
+import { JsonLd, breadcrumbSchema } from "@/components/marketing/json-ld";
+import type { SeoPageConfig } from "@/lib/seo-pages/types";
+
+type SeoCollectionPageProps = {
+  path: string;
+  title: string;
+  description: string;
+  eyebrow: string;
+  h1: string;
+  intro: string;
+  pages: SeoPageConfig[];
+  schemaId: string;
+};
+
+export function createSeoCollectionMetadata({
+  path,
+  title,
+  description,
+}: Pick<SeoCollectionPageProps, "path" | "title" | "description">): Metadata {
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: path,
+    },
+    openGraph: {
+      title,
+      description,
+      url: path,
+      type: "website",
+      locale: "en_US",
+      siteName: "AgentClash",
+      images: [
+        {
+          url: "/og-image.png",
+          width: 1200,
+          height: 630,
+          alt: `${title} social preview.`,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [
+        {
+          url: "/twitter-image.png",
+          alt: `${title} social preview.`,
+        },
+      ],
+    },
+  };
+}
+
+export function SeoCollectionPage({
+  path,
+  title,
+  description,
+  eyebrow,
+  h1,
+  intro,
+  pages,
+  schemaId,
+}: SeoCollectionPageProps) {
+  return (
+    <>
+      <JsonLd
+        id={schemaId}
+        data={[
+          breadcrumbSchema([
+            { name: "Home", url: "/" },
+            { name: eyebrow, url: path },
+          ]),
+        ]}
+      />
+      <header className="border-b border-white/[0.06] px-5 py-5 sm:px-12 sm:py-6">
+        <div className="mx-auto flex max-w-[1440px] items-center justify-between gap-4">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2.5 text-white/90"
+          >
+            <ClashMark className="size-6" />
+            <span className="font-[family-name:var(--font-display)] text-xl tracking-normal">
+              AgentClash
+            </span>
+          </Link>
+          <Link
+            href="/auth/login"
+            className="inline-flex items-center gap-1.5 rounded-md bg-white px-3 py-1.5 text-xs font-medium text-[#060606] transition-colors hover:bg-white/90"
+          >
+            Start
+            <ArrowRight className="size-3.5" />
+          </Link>
+        </div>
+      </header>
+      <main className="min-h-screen bg-[#060606] px-6 py-20 text-white sm:px-12 sm:py-28">
+        <div className="mx-auto max-w-[960px]">
+          <nav className="flex items-center gap-2 text-xs text-white/35">
+            <Link href="/" className="transition-colors hover:text-white/70">
+              Home
+            </Link>
+            <span>/</span>
+            <span>{eyebrow}</span>
+          </nav>
+          <p className="mt-10 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-cyan-200/70">
+            {eyebrow}
+          </p>
+          <h1 className="mt-5 font-[family-name:var(--font-display)] text-5xl font-normal leading-none tracking-normal text-white sm:text-6xl">
+            {h1}
+          </h1>
+          <p className="mt-8 max-w-[58ch] text-base leading-8 text-white/62 sm:text-lg">
+            {intro}
+          </p>
+          <p className="sr-only">{description}</p>
+          <div className="mt-12 grid gap-3">
+            {pages.map((page) => (
+              <Link
+                key={page.path}
+                href={page.path}
+                className="group rounded-md border border-white/[0.08] bg-white/[0.03] p-5 transition-colors hover:border-white/20 hover:bg-white/[0.05]"
+              >
+                <div className="flex items-center justify-between gap-4">
+                  <div>
+                    <h2 className="text-base font-semibold tracking-normal text-white">
+                      {page.sitemapTitle}
+                    </h2>
+                    <p className="mt-2 text-sm leading-6 text-white/50">
+                      {page.sitemapDescription}
+                    </p>
+                  </div>
+                  <ArrowRight className="size-4 shrink-0 text-white/35 transition-colors group-hover:text-white/75" />
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/web/src/components/marketing/seo-landing-page.tsx
+++ b/web/src/components/marketing/seo-landing-page.tsx
@@ -1,0 +1,387 @@
+import Link from "next/link";
+import {
+  ArrowRight,
+  CheckCircle2,
+  Code2,
+  GitBranch,
+  Play,
+  ShieldCheck,
+  Sparkles,
+  Terminal,
+} from "lucide-react";
+import { ClashMark } from "@/components/marketing/clash-mark";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  faqSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+import type { SeoPageConfig } from "@/lib/seo-pages/types";
+
+const workflowIcons = [Code2, Play, Sparkles, GitBranch] as const;
+
+function StaticHeader() {
+  return (
+    <header className="border-b border-white/[0.06] px-5 py-5 sm:px-12 sm:py-6">
+      <div className="mx-auto flex max-w-[1440px] items-center justify-between gap-4">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2.5 text-white/90"
+        >
+          <ClashMark className="size-6" />
+          <span className="font-[family-name:var(--font-display)] text-xl tracking-normal">
+            AgentClash
+          </span>
+        </Link>
+        <nav className="flex items-center gap-2 text-xs">
+          <Link
+            href="/docs"
+            className="hidden px-3 py-1.5 text-white/55 transition-colors hover:text-white/85 sm:inline-flex"
+          >
+            Docs
+          </Link>
+          <a
+            href="https://github.com/agentclash/agentclash"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hidden px-3 py-1.5 text-white/55 transition-colors hover:text-white/85 sm:inline-flex"
+          >
+            GitHub
+          </a>
+          <Link
+            href="/auth/login"
+            className="inline-flex items-center gap-1.5 rounded-md bg-white px-3 py-1.5 font-medium text-[#060606] transition-colors hover:bg-white/90"
+          >
+            Start
+            <ArrowRight className="size-3.5" />
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}
+
+function StaticFooter() {
+  return (
+    <footer className="border-t border-white/[0.06] bg-[#060606] px-6 py-10 sm:px-12">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-5 text-sm text-white/45 sm:flex-row sm:items-center sm:justify-between">
+        <Link href="/" className="font-medium text-white/65">
+          AgentClash
+        </Link>
+        <nav className="flex flex-wrap gap-5">
+          <Link href="/docs" className="transition-colors hover:text-white/75">
+            Docs
+          </Link>
+          <Link href="/blog" className="transition-colors hover:text-white/75">
+            Blog
+          </Link>
+          <Link href="/team" className="transition-colors hover:text-white/75">
+            Team
+          </Link>
+          <a
+            href="https://github.com/agentclash/agentclash"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="transition-colors hover:text-white/75"
+          >
+            GitHub
+          </a>
+        </nav>
+      </div>
+    </footer>
+  );
+}
+
+function ProductVisual() {
+  return (
+    <div className="relative overflow-hidden rounded-md border border-white/[0.08] bg-[#090909] shadow-2xl shadow-cyan-950/20">
+      <div className="border-b border-white/[0.08] px-4 py-3">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-2">
+            <span className="size-2 rounded-full bg-emerald-300" />
+            <span className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/45">
+              live race
+            </span>
+          </div>
+          <span className="rounded-md border border-white/[0.08] px-2 py-1 font-[family-name:var(--font-mono)] text-[11px] text-white/45">
+            gate: pass
+          </span>
+        </div>
+      </div>
+      <div className="grid gap-px bg-white/[0.06] sm:grid-cols-3">
+        {[
+          ["Candidate", "92", "correct patch, low cost"],
+          ["Baseline", "88", "stable reference run"],
+          ["Control", "73", "missed edge case"],
+        ].map(([name, score, note]) => (
+          <div key={name} className="bg-[#090909] p-4">
+            <p className="text-sm font-medium text-white">{name}</p>
+            <div className="mt-5 flex items-end justify-between gap-3">
+              <span className="font-[family-name:var(--font-display)] text-5xl text-white">
+                {score}
+              </span>
+              <span className="mb-1 text-right text-xs leading-5 text-white/45">
+                {note}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="grid gap-px bg-white/[0.06] md:grid-cols-[1.1fr_0.9fr]">
+        <div className="bg-[#090909] p-5">
+          <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+            replay timeline
+          </p>
+          <div className="mt-4 space-y-3">
+            {[
+              "loaded task inputs and tool policy",
+              "ran sandbox actions and captured artifacts",
+              "scored trajectory and validator evidence",
+              "attached scorecard and release verdict",
+            ].map((item, index) => (
+              <div key={item} className="flex items-start gap-3">
+                <span className="mt-1 flex size-5 items-center justify-center rounded-md border border-cyan-300/25 bg-cyan-300/10 font-[family-name:var(--font-mono)] text-[10px] text-cyan-100">
+                  {index + 1}
+                </span>
+                <span className="text-sm leading-6 text-white/68">{item}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="bg-[#090909] p-5">
+          <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+            ci verdict
+          </p>
+          <div className="mt-4 rounded-md border border-emerald-300/15 bg-emerald-300/[0.06] p-4">
+            <div className="flex items-center gap-2 text-sm font-medium text-emerald-100">
+              <ShieldCheck className="size-4" />
+              Candidate clears release gate
+            </div>
+            <p className="mt-3 text-xs leading-5 text-emerald-50/60">
+              Correctness improved, latency within budget, and required
+              artifacts were preserved for review.
+            </p>
+          </div>
+          <pre className="mt-4 overflow-hidden rounded-md border border-white/[0.08] bg-black px-4 py-3 font-[family-name:var(--font-mono)] text-[11px] leading-5 text-white/55">
+            agentclash run create --follow
+          </pre>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function SeoLandingPage({ config }: { config: SeoPageConfig }) {
+  return (
+    <>
+      <JsonLd
+        id={config.schemaId}
+        data={[
+          breadcrumbSchema(config.breadcrumbs),
+          faqSchema(config.faqItems),
+          productSchema({
+            name: config.pageTitle,
+            description: config.metaDescription,
+            url: config.path,
+            applicationSubCategory: config.applicationSubCategory,
+            featureList: config.proofPoints,
+          }),
+        ]}
+      />
+      <StaticHeader />
+      <main className="min-h-screen bg-[#060606] text-white">
+        <section className="px-6 py-20 sm:px-12 sm:py-28">
+          <div className="mx-auto grid max-w-[1440px] gap-14 lg:grid-cols-[0.88fr_1.12fr] lg:items-center">
+            <div>
+              <nav className="flex flex-wrap items-center gap-2 text-xs text-white/35">
+                {config.breadcrumbs.map((crumb, index) => (
+                  <span key={crumb.url} className="inline-flex items-center gap-2">
+                    {index > 0 && <span>/</span>}
+                    {index < config.breadcrumbs.length - 1 ? (
+                      <Link
+                        href={crumb.url}
+                        className="transition-colors hover:text-white/70"
+                      >
+                        {crumb.name}
+                      </Link>
+                    ) : (
+                      <span>{crumb.name}</span>
+                    )}
+                  </span>
+                ))}
+              </nav>
+              <p className="mt-10 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-cyan-200/70">
+                {config.eyebrow}
+              </p>
+              <h1 className="mt-5 max-w-[14ch] font-[family-name:var(--font-display)] text-5xl font-normal leading-none tracking-normal text-white sm:text-7xl">
+                {config.h1}
+              </h1>
+              <p className="mt-8 max-w-[58ch] text-base leading-8 text-white/62 sm:text-lg">
+                {config.heroDescription}
+              </p>
+              <div className="mt-9 flex flex-col gap-3 sm:flex-row">
+                <Link
+                  href="/auth/login"
+                  className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-medium text-[#060606] transition-colors hover:bg-white/90"
+                >
+                  Start first race
+                  <ArrowRight className="size-4" />
+                </Link>
+                <Link
+                  href="/docs/getting-started/quickstart"
+                  className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 transition-colors hover:border-white/30 hover:text-white"
+                >
+                  Read quickstart
+                  <Terminal className="size-4" />
+                </Link>
+              </div>
+            </div>
+            <ProductVisual />
+          </div>
+        </section>
+
+        <section className="border-y border-white/[0.06] px-6 py-20 sm:px-12">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="max-w-3xl">
+              <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+                {config.proofSectionTitle}
+              </p>
+              <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">
+                Built for reviewable agent decisions
+              </h2>
+              <p className="mt-5 text-sm leading-7 text-white/55 sm:text-base">
+                {config.proofSectionDescription}
+              </p>
+            </div>
+            <div className="mt-12 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              {config.proofPoints.map((point) => (
+                <div
+                  key={point}
+                  className="rounded-md border border-white/[0.08] bg-white/[0.03] p-5"
+                >
+                  <CheckCircle2 className="size-5 text-emerald-200" />
+                  <p className="mt-4 text-sm leading-6 text-white/78">
+                    {point}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="px-6 py-20 sm:px-12 sm:py-28">
+          <div className="mx-auto max-w-[1440px]">
+            <div className="grid gap-12 lg:grid-cols-[0.7fr_1fr]">
+              <div>
+                <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+                  Workflow
+                </p>
+                <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">
+                  {config.workflowSectionTitle}
+                </h2>
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {config.workflow.map((item, index) => {
+                  const Icon = workflowIcons[index] ?? Code2;
+                  return (
+                    <div
+                      key={item.title}
+                      className="rounded-md border border-white/[0.08] bg-white/[0.03] p-5"
+                    >
+                      <Icon className="size-5 text-cyan-200" />
+                      <h3 className="mt-5 text-lg font-semibold tracking-normal text-white">
+                        {item.title}
+                      </h3>
+                      <p className="mt-3 text-sm leading-6 text-white/55">
+                        {item.text}
+                      </p>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="border-y border-white/[0.06] px-6 py-20 sm:px-12">
+          <div className="mx-auto grid max-w-[1440px] gap-10 lg:grid-cols-[0.8fr_1fr] lg:items-start">
+            <div>
+              <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+                {config.docsSectionTitle}
+              </p>
+              <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">
+                Bring your first workload into the loop
+              </h2>
+              <p className="mt-5 text-sm leading-7 text-white/55 sm:text-base">
+                {config.docsSectionDescription}
+              </p>
+            </div>
+            <div className="grid gap-3">
+              {config.relatedLinks.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className="group rounded-md border border-white/[0.08] bg-white/[0.03] p-5 transition-colors hover:border-white/20 hover:bg-white/[0.05]"
+                >
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <h3 className="text-base font-semibold tracking-normal text-white">
+                        {link.title}
+                      </h3>
+                      <p className="mt-2 text-sm leading-6 text-white/50">
+                        {link.text}
+                      </p>
+                    </div>
+                    <ArrowRight className="size-4 shrink-0 text-white/35 transition-colors group-hover:text-white/75" />
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="px-6 py-20 sm:px-12 sm:py-28">
+          <div className="mx-auto max-w-[960px]">
+            <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-white/35">
+              FAQ
+            </p>
+            <h2 className="mt-4 text-3xl font-semibold tracking-normal text-white sm:text-5xl">
+              {config.faqSectionTitle}
+            </h2>
+            <div className="mt-10 divide-y divide-white/[0.08] border-y border-white/[0.08]">
+              {config.faqItems.map((item) => (
+                <section key={item.question} className="py-6">
+                  <h3 className="text-lg font-semibold tracking-normal text-white">
+                    {item.question}
+                  </h3>
+                  <p className="mt-3 text-sm leading-7 text-white/55">
+                    {item.answer}
+                  </p>
+                </section>
+              ))}
+            </div>
+            <div className="mt-10 flex flex-col gap-3 sm:flex-row">
+              <Link
+                href="/auth/login"
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-medium text-[#060606] transition-colors hover:bg-white/90"
+              >
+                Start first race
+                <ArrowRight className="size-4" />
+              </Link>
+              <a
+                href="https://github.com/agentclash/agentclash"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 transition-colors hover:border-white/30 hover:text-white"
+              >
+                View on GitHub
+                <ArrowRight className="size-4" />
+              </a>
+            </div>
+          </div>
+        </section>
+      </main>
+      <StaticFooter />
+    </>
+  );
+}

--- a/web/src/components/marketing/seo-landing-page.tsx
+++ b/web/src/components/marketing/seo-landing-page.tsx
@@ -195,7 +195,10 @@ export function SeoLandingPage({ config }: { config: SeoPageConfig }) {
             <div>
               <nav className="flex flex-wrap items-center gap-2 text-xs text-white/35">
                 {config.breadcrumbs.map((crumb, index) => (
-                  <span key={crumb.url} className="inline-flex items-center gap-2">
+                  <span
+                    key={`${crumb.url}-${index}`}
+                    className="inline-flex items-center gap-2"
+                  >
                     {index > 0 && <span>/</span>}
                     {index < config.breadcrumbs.length - 1 ? (
                       <Link

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -7,6 +7,7 @@ import {
   type BlogPostWithContent,
 } from "./blog";
 import { renderChangelogMarkdown } from "./changelog";
+import { SEO_PAGE_REGISTRY } from "./seo-pages";
 
 const CONTENT_DIR = path.join(process.cwd(), "content", "docs");
 const AGENT_SKILLS_DIR = path.join(process.cwd(), "content", "agent-skills");
@@ -91,6 +92,12 @@ const PUBLIC_PRODUCT_PAGES: PublicProductPage[] = [
     searchKeywords:
       "AgentClash changelog release notes product updates what's new shipped features AI agent evaluation platform updates",
   },
+  ...SEO_PAGE_REGISTRY.map((page) => ({
+    title: page.sitemapTitle,
+    href: page.path,
+    description: page.sitemapDescription,
+    searchKeywords: page.searchKeywords,
+  })),
 ];
 
 export type DocNavItem = {

--- a/web/src/lib/seo-pages/create-route-page.tsx
+++ b/web/src/lib/seo-pages/create-route-page.tsx
@@ -1,0 +1,16 @@
+import { SeoLandingPage } from "@/components/marketing/seo-landing-page";
+import { createSeoPageMetadata, getSeoPageByPath } from "./index";
+
+export function createSeoRoutePage(path: string) {
+  const config = getSeoPageByPath(path);
+  if (!config) {
+    throw new Error(`Missing SEO page config for ${path}`);
+  }
+
+  return {
+    metadata: createSeoPageMetadata(config),
+    Page: function SeoRoutePage() {
+      return <SeoLandingPage config={config} />;
+    },
+  };
+}

--- a/web/src/lib/seo-pages/factory.ts
+++ b/web/src/lib/seo-pages/factory.ts
@@ -1,0 +1,39 @@
+import type { Metadata } from "next";
+import type { SeoPageConfig } from "./types";
+
+export function createSeoPageMetadata(config: SeoPageConfig): Metadata {
+  return {
+    title: config.pageTitle,
+    description: config.metaDescription,
+    alternates: {
+      canonical: config.path,
+    },
+    openGraph: {
+      title: config.pageTitle,
+      description: config.metaDescription,
+      url: config.path,
+      type: "website",
+      locale: "en_US",
+      siteName: "AgentClash",
+      images: [
+        {
+          url: "/og-image.png",
+          width: 1200,
+          height: 630,
+          alt: config.socialImageAlt,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: config.pageTitle,
+      description: config.metaDescription,
+      images: [
+        {
+          url: "/twitter-image.png",
+          alt: config.socialImageAlt,
+        },
+      ],
+    },
+  };
+}

--- a/web/src/lib/seo-pages/index.ts
+++ b/web/src/lib/seo-pages/index.ts
@@ -1,0 +1,9 @@
+export {
+  getAllSeoPagePaths,
+  getSeoPageByPath,
+  getSeoPagesByPrefix,
+  SEO_PAGE_REGISTRY,
+} from "./registry";
+export { createSeoPageMetadata } from "./factory";
+export { seoPageSitemapPriority } from "./sitemap-priority";
+export type { SeoPageConfig, SeoPageTier } from "./types";

--- a/web/src/lib/seo-pages/registry.test.ts
+++ b/web/src/lib/seo-pages/registry.test.ts
@@ -50,4 +50,28 @@ describe("SEO page registry", () => {
       expect(page.breadcrumbs.at(-1)?.url).toBe(page.path);
     }
   });
+
+  it("uses collection index URLs for nested page breadcrumbs", () => {
+    for (const page of getSeoPagesByPrefix("/use-cases")) {
+      expect(page.breadcrumbs).toEqual([
+        { name: "Home", url: "/" },
+        { name: "Use cases", url: "/use-cases" },
+        { name: expect.any(String), url: page.path },
+      ]);
+      expect(new Set(page.breadcrumbs.map((crumb) => crumb.url)).size).toBe(
+        page.breadcrumbs.length,
+      );
+    }
+
+    for (const page of getSeoPagesByPrefix("/features")) {
+      expect(page.breadcrumbs).toEqual([
+        { name: "Home", url: "/" },
+        { name: "Features", url: "/features" },
+        { name: expect.any(String), url: page.path },
+      ]);
+      expect(new Set(page.breadcrumbs.map((crumb) => crumb.url)).size).toBe(
+        page.breadcrumbs.length,
+      );
+    }
+  });
 });

--- a/web/src/lib/seo-pages/registry.test.ts
+++ b/web/src/lib/seo-pages/registry.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  getAllSeoPagePaths,
+  getSeoPageByPath,
+  getSeoPagesByPrefix,
+  SEO_PAGE_REGISTRY,
+} from "./registry";
+
+describe("SEO page registry", () => {
+  it("registers every planned landing page path once", () => {
+    expect(getAllSeoPagePaths()).toEqual([
+      "/open-source-ai-agent-evaluation",
+      "/agent-evals",
+      "/llm-agent-evaluation",
+      "/agent-evaluation-framework",
+      "/ai-agent-testing",
+      "/agent-trajectory-evaluation",
+      "/ci-cd-agent-evaluation",
+      "/ai-agent-benchmark",
+      "/agent-reliability-benchmark",
+      "/use-cases/coding-agent-evaluation",
+      "/use-cases/research-agent-evaluation",
+      "/use-cases/support-agent-evaluation",
+      "/features/agent-scorecards",
+      "/features/agent-replay",
+      "/features/challenge-packs",
+    ]);
+    expect(SEO_PAGE_REGISTRY).toHaveLength(15);
+  });
+
+  it("groups use-case and feature routes by prefix", () => {
+    expect(getSeoPagesByPrefix("/use-cases").map((page) => page.path)).toEqual([
+      "/use-cases/coding-agent-evaluation",
+      "/use-cases/research-agent-evaluation",
+      "/use-cases/support-agent-evaluation",
+    ]);
+    expect(getSeoPagesByPrefix("/features").map((page) => page.path)).toEqual([
+      "/features/agent-scorecards",
+      "/features/agent-replay",
+      "/features/challenge-packs",
+    ]);
+  });
+
+  it("includes canonical metadata fields for each page", () => {
+    for (const page of SEO_PAGE_REGISTRY) {
+      expect(getSeoPageByPath(page.path)).toBe(page);
+      expect(page.pageTitle.length).toBeGreaterThan(10);
+      expect(page.metaDescription.length).toBeGreaterThan(40);
+      expect(page.faqItems.length).toBeGreaterThanOrEqual(3);
+      expect(page.breadcrumbs.at(-1)?.url).toBe(page.path);
+    }
+  });
+});

--- a/web/src/lib/seo-pages/registry.ts
+++ b/web/src/lib/seo-pages/registry.ts
@@ -1,0 +1,902 @@
+import { AGENT_EVALUATION_FEATURES } from "@/lib/seo-features";
+import type { SeoPageConfig } from "./types";
+
+const sharedProofPoints = AGENT_EVALUATION_FEATURES;
+
+const sharedDocsLinks = [
+  {
+    title: "Quickstart",
+    text: "Validate the CLI and get to your first runnable command.",
+    href: "/docs/getting-started/quickstart",
+  },
+  {
+    title: "Write a challenge pack",
+    text: "Turn a real task into a repeatable agent evaluation.",
+    href: "/docs/guides/write-a-challenge-pack",
+  },
+  {
+    title: "CI/CD agent gates",
+    text: "Fail a pull request when an agent regresses.",
+    href: "/docs/guides/ci-cd-agent-gates",
+  },
+] as const;
+
+function page(
+  config: Omit<
+    SeoPageConfig,
+    "proofPoints" | "relatedLinks" | "workflow" | "faqItems"
+  > & {
+    proofPoints?: string[];
+    relatedLinks?: SeoPageConfig["relatedLinks"];
+    workflow?: SeoPageConfig["workflow"];
+    faqItems: SeoPageConfig["faqItems"];
+  },
+): SeoPageConfig {
+  return {
+    proofPoints: sharedProofPoints,
+    relatedLinks: [...sharedDocsLinks],
+    workflow: [
+      {
+        title: "Package the task",
+        text: "Describe the workload as a challenge pack with inputs, tools, scoring rules, and artifacts.",
+      },
+      {
+        title: "Race the agents",
+        text: "Run every candidate against the same task with the same constraints.",
+      },
+      {
+        title: "Replay the evidence",
+        text: "Inspect tool calls, outputs, artifacts, latency, cost, and judge evidence after the run.",
+      },
+      {
+        title: "Gate the release",
+        text: "Compare candidate and baseline runs, then fail CI before a regression reaches users.",
+      },
+    ],
+    ...config,
+  };
+}
+
+export const SEO_PAGE_REGISTRY: SeoPageConfig[] = [
+  page({
+    path: "/open-source-ai-agent-evaluation",
+    tier: "S",
+    keyword: "open source AI agent evaluation",
+    intent: "OSS users/founders",
+    pageTitle: "Open Source AI Agent Evaluation Platform - AgentClash",
+    metaDescription:
+      "AgentClash is an open-source AI agent evaluation platform for real-task races, replay evidence, scorecards, challenge packs, and CI regression gates.",
+    socialImageAlt: "AgentClash open source AI agent evaluation social preview.",
+    eyebrow: "Open source",
+    h1: "Open source AI agent evaluation for real tasks",
+    heroDescription:
+      "AgentClash is MIT-licensed and self-hostable. Run head-to-head agent races on your workloads, keep replay evidence, and turn failures into reusable regression gates without a black-box vendor loop.",
+    proofSectionTitle: "What open-source eval should include",
+    proofSectionDescription:
+      "Open source matters when your eval stack needs to run inside your repo, your CI, and your sandbox policy — not just inside someone else's hosted UI.",
+    workflowSectionTitle: "From local race to team-wide gate",
+    docsSectionTitle: "Start with the repo",
+    docsSectionDescription:
+      "Clone AgentClash, boot the local stack, and wire the same challenge packs into hosted runs or pull request gates.",
+    faqSectionTitle: "Questions OSS teams ask before adopting",
+    applicationSubCategory: "Open source AI agent evaluation platform",
+    breadcrumbs: [
+      { name: "Home", url: "/" },
+      { name: "Open source AI agent evaluation", url: "/open-source-ai-agent-evaluation" },
+    ],
+    schemaId: "agentclash-open-source-ai-agent-evaluation-schema",
+    searchKeywords:
+      "open source AI agent evaluation OSS agent eval platform self-hosted agent evaluation MIT agent benchmark replay scorecards challenge packs",
+    sitemapTitle: "Open source AI agent evaluation",
+    sitemapDescription:
+      "MIT-licensed, self-hostable AI agent evaluation with replay, scorecards, and CI gates.",
+    faqItems: [
+      {
+        question: "Is AgentClash actually open source?",
+        answer:
+          "Yes. AgentClash is MIT-licensed. You can self-host the API server, worker, and web app, or use the hosted product when that is faster for your team.",
+      },
+      {
+        question: "Can we run evals entirely on our own infrastructure?",
+        answer:
+          "Yes. AgentClash supports local stacks, self-hosted deployments, and sandbox providers you control. Challenge packs and scorecards work the same whether the run is local or hosted.",
+      },
+      {
+        question: "How does open source help with agent regression testing?",
+        answer:
+          "You can inspect scoring rules, pack definitions, replay artifacts, and CI gate manifests in git. That makes agent eval auditable instead of a dashboard-only black box.",
+      },
+    ],
+    relatedLinks: [
+      {
+        title: "Self-host guide",
+        text: "Boot Postgres, Temporal, API, and worker locally or in your cluster.",
+        href: "/docs/getting-started/self-host",
+      },
+      ...sharedDocsLinks,
+    ],
+  }),
+  page({
+    path: "/agent-evals",
+    tier: "S",
+    keyword: "agent evals",
+    intent: "Dev shorthand",
+    pageTitle: "Agent Evals for Real Tasks, Replay, and CI Gates - AgentClash",
+    metaDescription:
+      "Run agent evals on real tasks with same-tools races, replay evidence, scorecards, challenge packs, and regression gates — not just final-answer checks.",
+    socialImageAlt: "AgentClash agent evals social preview.",
+    eyebrow: "Agent evals",
+    h1: "Agent evals that cover the whole trajectory",
+    heroDescription:
+      "Agent evals should answer whether an agent can finish the job again under the same tools, budget, and constraints. AgentClash records replay evidence and scorecards so evals become release decisions.",
+    proofSectionTitle: "What good agent evals capture",
+    proofSectionDescription:
+      "If your agent eval only checks the final string, you miss the tool misuse, runaway loops, and artifact gaps that show up in production.",
+    workflowSectionTitle: "From one eval to a reusable gate",
+    docsSectionTitle: "Run your first agent eval",
+    docsSectionDescription:
+      "Use challenge packs for repeatable workloads, then promote failures into regression cases your team can run in CI.",
+    faqSectionTitle: "Agent eval FAQ",
+    applicationSubCategory: "Agent evaluation software",
+    breadcrumbs: [
+      { name: "Home", url: "/" },
+      { name: "Agent evals", url: "/agent-evals" },
+    ],
+    schemaId: "agentclash-agent-evals-schema",
+    searchKeywords:
+      "agent evals agent evaluation eval harness real task agent benchmark replay scorecards challenge packs CI gates",
+    sitemapTitle: "Agent evals",
+    sitemapDescription:
+      "Real-task agent evals with replay evidence, scorecards, and CI regression gates.",
+    faqItems: [
+      {
+        question: "What is an agent eval?",
+        answer:
+          "An agent eval is a repeatable test that runs an agent on a task, scores the full trajectory, and compares the result to a baseline or competitor.",
+      },
+      {
+        question: "How is AgentClash different from prompt evals?",
+        answer:
+          "Prompt evals score one model response. AgentClash evals multi-turn agents that use tools in a sandbox and scores correctness, cost, latency, and evidence quality across the run.",
+      },
+      {
+        question: "Can agent evals run in CI?",
+        answer:
+          "Yes. AgentClash can compare candidate and baseline scorecards and fail a pull request when the configured release gate regresses.",
+      },
+    ],
+  }),
+  page({
+    path: "/llm-agent-evaluation",
+    tier: "S",
+    keyword: "LLM agent evaluation",
+    intent: "Broad category",
+    pageTitle: "LLM Agent Evaluation on Real Workloads - AgentClash",
+    metaDescription:
+      "Evaluate LLM agents on real tasks with sandboxed tool use, head-to-head races, replay trails, scorecards, and CI regression gates.",
+    socialImageAlt: "AgentClash LLM agent evaluation social preview.",
+    eyebrow: "LLM agents",
+    h1: "LLM agent evaluation beyond single-turn answers",
+    heroDescription:
+      "LLM agents plan, call tools, inspect results, and recover from mistakes. AgentClash evaluates that full loop on your workloads so model swaps and prompt changes do not hide regressions.",
+    proofSectionTitle: "Evaluate the agent loop, not just the model",
+    proofSectionDescription:
+      "LLM agent evaluation needs the same task, same tools, and preserved evidence — otherwise you are comparing demos, not systems.",
+    workflowSectionTitle: "A practical LLM agent eval workflow",
+    docsSectionTitle: "Bring your workload into AgentClash",
+    docsSectionDescription:
+      "Start with one real failure, encode it as a challenge pack, then scale to model comparisons and CI gates.",
+    faqSectionTitle: "LLM agent evaluation FAQ",
+    applicationSubCategory: "LLM agent evaluation platform",
+    breadcrumbs: [
+      { name: "Home", url: "/" },
+      { name: "LLM agent evaluation", url: "/llm-agent-evaluation" },
+    ],
+    schemaId: "agentclash-llm-agent-evaluation-schema",
+    searchKeywords:
+      "LLM agent evaluation language model agent eval tool-using agents sandboxed workloads replay scorecards challenge packs",
+    sitemapTitle: "LLM agent evaluation",
+    sitemapDescription:
+      "Evaluate tool-using LLM agents on real tasks with replay and scorecards.",
+    faqItems: [
+      {
+        question: "What should LLM agent evaluation measure?",
+        answer:
+          "At minimum: task success, tool strategy, artifacts produced, cost, latency, and whether the agent stayed inside policy. AgentClash captures all of that in a scorecard.",
+      },
+      {
+        question: "Can we compare multiple LLM agents fairly?",
+        answer:
+          "Yes. AgentClash races candidates on the same challenge pack with the same tool policy, time budget, and sandbox resources.",
+      },
+      {
+        question: "Does AgentClash work with hosted model providers?",
+        answer:
+          "Yes. AgentClash routes to major LLM providers and normalizes tool-call shapes so evals stay comparable across models.",
+      },
+    ],
+  }),
+  page({
+    path: "/agent-evaluation-framework",
+    tier: "A",
+    keyword: "agent evaluation framework",
+    intent: "Devs comparing tools",
+    pageTitle: "Agent Evaluation Framework for Real Tasks - AgentClash",
+    metaDescription:
+      "Compare agent evaluation frameworks on what matters: sandboxed execution, replay evidence, scorecards, challenge packs, and CI regression gates.",
+    socialImageAlt: "AgentClash agent evaluation framework social preview.",
+    eyebrow: "Framework",
+    h1: "An agent evaluation framework built for production tasks",
+    heroDescription:
+      "Teams comparing agent evaluation frameworks should look past leaderboard scores. AgentClash gives you repeatable workloads, head-to-head races, replay evidence, and release gates you can audit in git.",
+    proofSectionTitle: "What a serious framework includes",
+    proofSectionDescription:
+      "A useful agent evaluation framework packages tasks, enforces fair constraints, scores trajectories, and makes failures reusable.",
+    workflowSectionTitle: "Framework workflow",
+    docsSectionTitle: "Evaluate before you commit",
+    docsSectionDescription:
+      "Use AgentClash alongside prompt-eval tools when you need end-to-end agent behavior, not single-call scoring.",
+    faqSectionTitle: "Framework comparison FAQ",
+    applicationSubCategory: "Agent evaluation framework",
+    breadcrumbs: [
+      { name: "Home", url: "/" },
+      { name: "Agent evaluation framework", url: "/agent-evaluation-framework" },
+    ],
+    schemaId: "agentclash-agent-evaluation-framework-schema",
+    searchKeywords:
+      "agent evaluation framework compare agent eval tools agent testing framework replay scorecards challenge packs CI gates",
+    sitemapTitle: "Agent evaluation framework",
+    sitemapDescription:
+      "Framework for real-task agent evaluation with replay, scorecards, and CI gates.",
+    faqItems: [
+      {
+        question: "How is AgentClash different from prompt-evaluation frameworks?",
+        answer:
+          "Prompt-evaluation frameworks score isolated model outputs. AgentClash is an agent-evaluation framework for multi-turn tool-using runs in a sandbox.",
+      },
+      {
+        question: "Can we compare AgentClash with other tools?",
+        answer:
+          "Yes. See the compare hub for side-by-side notes with Braintrust, LangSmith, Promptfoo, Langfuse, Arize Phoenix, and OpenAI Evals.",
+      },
+      {
+        question: "Does the framework support custom scoring?",
+        answer:
+          "Yes. Challenge packs carry scoring rules, validators, and judge configuration so teams can encode domain-specific pass conditions.",
+      },
+    ],
+    relatedLinks: [
+      {
+        title: "Compare tools",
+        text: "See how AgentClash differs from prompt-eval platforms.",
+        href: "/compare",
+      },
+      ...sharedDocsLinks,
+    ],
+  }),
+  page({
+    path: "/ai-agent-testing",
+    tier: "A",
+    keyword: "AI agent testing",
+    intent: "Simpler language",
+    pageTitle: "AI Agent Testing with Replay and Release Gates - AgentClash",
+    metaDescription:
+      "Test AI agents on real tasks with sandboxed execution, replay evidence, scorecards, challenge packs, and CI gates that block regressions.",
+    socialImageAlt: "AgentClash AI agent testing social preview.",
+    eyebrow: "Agent testing",
+    h1: "AI agent testing that looks like release engineering",
+    heroDescription:
+      "AI agent testing should feel closer to software testing than prompt tweaking. AgentClash turns real failures into repeatable challenge packs, compares candidates to baselines, and keeps the evidence reviewers need.",
+    proofSectionTitle: "What production-grade agent testing covers",
+    proofSectionDescription:
+      "Testing agents means checking behavior across the whole run — not approving a single polished answer from a cherry-picked prompt.",
+    workflowSectionTitle: "Test loop",
+    docsSectionTitle: "Start testing with docs",
+    docsSectionDescription:
+      "Write a challenge pack, run a race, inspect replay, then wire the same workload into CI.",
+    faqSectionTitle: "AI agent testing FAQ",
+    applicationSubCategory: "AI agent testing software",
+    breadcrumbs: [
+      { name: "Home", url: "/" },
+      { name: "AI agent testing", url: "/ai-agent-testing" },
+    ],
+    schemaId: "agentclash-ai-agent-testing-schema",
+    searchKeywords:
+      "AI agent testing test AI agents agent QA replay scorecards challenge packs regression testing CI gates",
+    sitemapTitle: "AI agent testing",
+    sitemapDescription:
+      "Test AI agents on real tasks with replay evidence and CI regression gates.",
+    faqItems: [
+      {
+        question: "Is AI agent testing different from LLM testing?",
+        answer:
+          "Yes. LLM testing often means scoring one response. AI agent testing evaluates plans, tool calls, artifacts, recovery behavior, and whether the task actually finished.",
+      },
+      {
+        question: "Can non-ML engineers review agent test failures?",
+        answer:
+          "Yes. Replay timelines, artifacts, and scorecards are designed for reviewers who need to understand what changed without reading raw model traces alone.",
+      },
+      {
+        question: "How do we keep tests from getting stale?",
+        answer:
+          "Promote escaped production failures into challenge packs and regression suites so the same mistake stays covered after the next model swap.",
+      },
+    ],
+  }),
+  page({
+    path: "/agent-trajectory-evaluation",
+    tier: "A",
+    keyword: "agent trajectory evaluation",
+    intent: "Technical buyer",
+    pageTitle: "Agent Trajectory Evaluation and Replay Evidence - AgentClash",
+    metaDescription:
+      "Evaluate agent trajectories with replay trails, tool-call evidence, scorecards, challenge packs, and CI gates for baseline versus candidate decisions.",
+    socialImageAlt: "AgentClash agent trajectory evaluation social preview.",
+    eyebrow: "Trajectories",
+    h1: "Agent trajectory evaluation with reviewable evidence",
+    heroDescription:
+      "The final answer is not enough. AgentClash evaluates the trajectory — tool choices, observations, retries, artifacts, and stop conditions — then preserves replay evidence for auditors and release owners.",
+    proofSectionTitle: "Why trajectories matter",
+    proofSectionDescription:
+      "Two agents can return the same answer while taking wildly different paths. Trajectory evaluation catches unsafe shortcuts, runaway loops, and brittle tool strategies.",
+    workflowSectionTitle: "Trajectory eval workflow",
+    docsSectionTitle: "Inspect runs with docs",
+    docsSectionDescription:
+      "Use replay and scorecards to debug trajectory regressions, then encode the workload as a challenge pack for CI.",
+    faqSectionTitle: "Trajectory evaluation FAQ",
+    applicationSubCategory: "Agent trajectory evaluation software",
+    breadcrumbs: [
+      { name: "Home", url: "/" },
+      { name: "Agent trajectory evaluation", url: "/agent-trajectory-evaluation" },
+    ],
+    schemaId: "agentclash-agent-trajectory-evaluation-schema",
+    searchKeywords:
+      "agent trajectory evaluation trajectory scoring tool call replay agent trace evaluation scorecards challenge packs",
+    sitemapTitle: "Agent trajectory evaluation",
+    sitemapDescription:
+      "Score full agent trajectories with replay evidence and release gates.",
+    faqItems: [
+      {
+        question: "What is agent trajectory evaluation?",
+        answer:
+          "Trajectory evaluation scores the sequence of actions and observations an agent took to complete a task, not just the final output string.",
+      },
+      {
+        question: "How does AgentClash store trajectory evidence?",
+        answer:
+          "Each run keeps replay events, tool calls, logs, artifacts, and scorecards so reviewers can reconstruct the path that produced the result.",
+      },
+      {
+        question: "Can trajectory evals gate releases?",
+        answer:
+          "Yes. Compare candidate and baseline trajectories via scorecards, then fail CI when correctness, cost, latency, or evidence quality regresses.",
+      },
+    ],
+    relatedLinks: [
+      {
+        title: "Agent replay",
+        text: "See how AgentClash preserves replay evidence for reviewers.",
+        href: "/features/agent-replay",
+      },
+      ...sharedDocsLinks,
+    ],
+  }),
+  page({
+    path: "/ci-cd-agent-evaluation",
+    tier: "A",
+    keyword: "agent evaluation CI/CD",
+    intent: "Release engineering",
+    pageTitle: "CI/CD Agent Evaluation and Regression Gates - AgentClash",
+    metaDescription:
+      "Wire agent evaluation into CI/CD with baseline comparisons, challenge packs, replay evidence, scorecards, and pull request gates.",
+    socialImageAlt: "AgentClash CI/CD agent evaluation social preview.",
+    eyebrow: "CI/CD",
+    h1: "CI/CD agent evaluation for pull request gates",
+    heroDescription:
+      "Model, prompt, and tool changes should not ship on vibes. AgentClash runs repeatable agent workloads in CI, compares candidate scorecards to baselines, and blocks merges when behavior regresses.",
+    proofSectionTitle: "What CI/CD agent eval needs",
+    proofSectionDescription:
+      "Release engineering needs deterministic workloads, stable scoring, and enough evidence to debug a failed gate without reproducing the issue manually.",
+    workflowSectionTitle: "CI gate workflow",
+    docsSectionTitle: "Wire gates with docs",
+    docsSectionDescription:
+      "Start with the CI/CD agent gates guide, then promote real failures into challenge packs your pipeline can rerun on every change.",
+    faqSectionTitle: "CI/CD agent evaluation FAQ",
+    applicationSubCategory: "CI/CD agent evaluation software",
+    breadcrumbs: [
+      { name: "Home", url: "/" },
+      { name: "CI/CD agent evaluation", url: "/ci-cd-agent-evaluation" },
+    ],
+    schemaId: "agentclash-ci-cd-agent-evaluation-schema",
+    searchKeywords:
+      "CI/CD agent evaluation agent eval CI pull request gates release gates baseline candidate regression testing challenge packs",
+    sitemapTitle: "CI/CD agent evaluation",
+    sitemapDescription:
+      "Run agent evaluation in CI/CD with scorecard gates and replay evidence.",
+    faqItems: [
+      {
+        question: "How do agent eval gates fit into CI/CD?",
+        answer:
+          "A challenge pack runs on every candidate change, AgentClash compares the scorecard to a baseline, and the pipeline fails when configured thresholds regress.",
+      },
+      {
+        question: "What happens when a gate fails?",
+        answer:
+          "Reviewers open replay evidence, inspect tool calls and artifacts, and either fix the regression or update the baseline intentionally.",
+      },
+      {
+        question: "Can gates cover cost and latency budgets?",
+        answer:
+          "Yes. Scorecards include correctness and evidence quality plus cost and latency signals you can enforce in release policy.",
+      },
+    ],
+    relatedLinks: [
+      {
+        title: "Agent regression testing",
+        text: "Product overview for baseline versus candidate agent testing.",
+        href: "/platform/agent-regression-testing",
+      },
+      ...sharedDocsLinks,
+    ],
+  }),
+  page({
+    path: "/ai-agent-benchmark",
+    tier: "A",
+    keyword: "AI agent benchmark",
+    intent: "Benchmark traffic",
+    pageTitle: "AI Agent Benchmark on Real Tasks - AgentClash",
+    metaDescription:
+      "Run AI agent benchmarks on real workloads with fair constraints, replay evidence, scorecards, and regression gates — not leaderboard-only snapshots.",
+    socialImageAlt: "AgentClash AI agent benchmark social preview.",
+    eyebrow: "Benchmarks",
+    h1: "AI agent benchmarks grounded in real workloads",
+    heroDescription:
+      "Leaderboards are a starting point, not a release decision. AgentClash lets teams benchmark agents on the tasks they actually ship — with the same tools, budgets, and evidence requirements.",
+    proofSectionTitle: "Better than a one-number benchmark",
+    proofSectionDescription:
+      "A useful AI agent benchmark reports correctness, cost, latency, tool strategy, and artifact quality on workloads your team owns.",
+    workflowSectionTitle: "Benchmark workflow",
+    docsSectionTitle: "Build a benchmark you can reuse",
+    docsSectionDescription:
+      "Encode workloads as challenge packs so benchmark runs become regression gates instead of one-off demos.",
+    faqSectionTitle: "AI agent benchmark FAQ",
+    applicationSubCategory: "AI agent benchmark software",
+    breadcrumbs: [
+      { name: "Home", url: "/" },
+      { name: "AI agent benchmark", url: "/ai-agent-benchmark" },
+    ],
+    schemaId: "agentclash-ai-agent-benchmark-schema",
+    searchKeywords:
+      "AI agent benchmark agent benchmark real task benchmark coding agent benchmark replay scorecards challenge packs",
+    sitemapTitle: "AI agent benchmark",
+    sitemapDescription:
+      "Benchmark AI agents on real tasks with replay and scorecards.",
+    faqItems: [
+      {
+        question: "How is AgentClash different from public leaderboards?",
+        answer:
+          "Public leaderboards summarize generic tasks. AgentClash benchmarks your agents on your tools, repositories, APIs, and release constraints.",
+      },
+      {
+        question: "Can we benchmark multiple agents head-to-head?",
+        answer:
+          "Yes. AgentClash races candidates on the same challenge pack with the same sandbox policy and produces comparable scorecards.",
+      },
+      {
+        question: "Can a benchmark become a regression test?",
+        answer:
+          "Yes. The same challenge pack can power ad-hoc benchmarks and CI gates once your team trusts the scoring rules.",
+      },
+    ],
+  }),
+  page({
+    path: "/agent-reliability-benchmark",
+    tier: "A",
+    keyword: "agent reliability benchmark",
+    intent: "Better than generic eval",
+    pageTitle: "Agent Reliability Benchmark and Regression Gates - AgentClash",
+    metaDescription:
+      "Measure agent reliability with repeatable workloads, pass-rate tracking, replay evidence, scorecards, and CI gates for baseline versus candidate runs.",
+    socialImageAlt: "AgentClash agent reliability benchmark social preview.",
+    eyebrow: "Reliability",
+    h1: "Agent reliability benchmarks your team can ship on",
+    heroDescription:
+      "Reliability is repeatability under constraint. AgentClash benchmarks how often agents finish real tasks correctly, how much evidence they produce, and whether new changes make outcomes worse.",
+    proofSectionTitle: "Reliability signals that matter",
+    proofSectionDescription:
+      "Track success rate, cost stability, latency drift, tool misuse, and promoted failures — not just whether one demo looked impressive.",
+    workflowSectionTitle: "Reliability workflow",
+    docsSectionTitle: "Turn reliability into gates",
+    docsSectionDescription:
+      "Use challenge packs and regression suites to keep reliability benchmarks current as models and tools change.",
+    faqSectionTitle: "Agent reliability FAQ",
+    applicationSubCategory: "Agent reliability benchmark software",
+    breadcrumbs: [
+      { name: "Home", url: "/" },
+      { name: "Agent reliability benchmark", url: "/agent-reliability-benchmark" },
+    ],
+    schemaId: "agentclash-agent-reliability-benchmark-schema",
+    searchKeywords:
+      "agent reliability benchmark reliability eval pass rate regression testing replay scorecards challenge packs",
+    sitemapTitle: "Agent reliability benchmark",
+    sitemapDescription:
+      "Benchmark agent reliability on real tasks with regression gates.",
+    faqItems: [
+      {
+        question: "What makes an agent reliability benchmark useful?",
+        answer:
+          "It reruns the same real workloads over time, tracks pass rates and cost/latency drift, and preserves evidence when a run fails.",
+      },
+      {
+        question: "How does AgentClash handle flaky agent behavior?",
+        answer:
+          "Teams can rerun workloads, inspect replay differences, and encode pass@k-style reliability policies in challenge packs and release gates.",
+      },
+      {
+        question: "Can reliability benchmarks block release?",
+        answer:
+          "Yes. Compare candidate and baseline scorecards in CI and fail the gate when reliability metrics cross your threshold.",
+      },
+    ],
+    relatedLinks: [
+      {
+        title: "pass@k vs pass^k",
+        text: "Read when strict success and independent retries measure different things.",
+        href: "/blog/pass-at-k-vs-pass-power-k",
+      },
+      ...sharedDocsLinks,
+    ],
+  }),
+  page({
+    path: "/use-cases/coding-agent-evaluation",
+    tier: "B",
+    keyword: "evaluate coding agents",
+    intent: "Use-case page",
+    pageTitle: "Coding Agent Evaluation on Real Repos - AgentClash",
+    metaDescription:
+      "Evaluate coding agents on real repositories with sandboxed execution, replay evidence, scorecards, challenge packs, and CI regression gates.",
+    socialImageAlt: "AgentClash coding agent evaluation social preview.",
+    eyebrow: "Use case",
+    h1: "Evaluate coding agents on real repositories",
+    heroDescription:
+      "Coding agents fail on messy repos, flaky tests, and tool limits — not on polished benchmark prompts. AgentClash evaluates patches, test runs, artifacts, and cost on workloads your team actually ships.",
+    proofSectionTitle: "What coding agent eval should check",
+    proofSectionDescription:
+      "Look for correct fixes, sane tool usage, reproducible artifacts, and stable cost/latency — not just a plausible diff in a demo.",
+    workflowSectionTitle: "Coding eval workflow",
+    docsSectionTitle: "Start with a real bug",
+    docsSectionDescription:
+      "Promote a failed coding-agent run into a challenge pack, then race model and harness changes before they reach users.",
+    faqSectionTitle: "Coding agent evaluation FAQ",
+    applicationSubCategory: "Coding agent evaluation software",
+    breadcrumbs: [
+      { name: "Home", url: "/" },
+      { name: "Use cases", url: "/use-cases/coding-agent-evaluation" },
+      { name: "Coding agent evaluation", url: "/use-cases/coding-agent-evaluation" },
+    ],
+    schemaId: "agentclash-coding-agent-evaluation-schema",
+    searchKeywords:
+      "coding agent evaluation evaluate coding agents software engineering agents repo eval replay scorecards challenge packs",
+    sitemapTitle: "Coding agent evaluation",
+    sitemapDescription:
+      "Evaluate coding agents on real repositories with replay and CI gates.",
+    faqItems: [
+      {
+        question: "Can AgentClash evaluate agents that edit code?",
+        answer:
+          "Yes. Challenge packs can run agents in sandboxes with repository fixtures, test commands, and artifact checks for patches and logs.",
+      },
+      {
+        question: "How do teams compare coding agents fairly?",
+        answer:
+          "Run every candidate on the same repo state, tool policy, and time budget, then compare scorecards and replay evidence.",
+      },
+      {
+        question: "Can coding agent evals run in CI?",
+        answer:
+          "Yes. Wire challenge packs into pull request gates so model, prompt, or tool changes cannot merge when correctness regresses.",
+      },
+    ],
+  }),
+  page({
+    path: "/use-cases/research-agent-evaluation",
+    tier: "B",
+    keyword: "evaluate research agents",
+    intent: "Use-case page",
+    pageTitle: "Research Agent Evaluation with Evidence Quality - AgentClash",
+    metaDescription:
+      "Evaluate research agents on real investigation tasks with replay evidence, artifact checks, scorecards, challenge packs, and regression gates.",
+    socialImageAlt: "AgentClash research agent evaluation social preview.",
+    eyebrow: "Use case",
+    h1: "Evaluate research agents with evidence quality",
+    heroDescription:
+      "Research agents live or die on sourcing, synthesis, and artifact quality. AgentClash scores whether an agent found the right evidence, cited it correctly, and finished the investigation under budget.",
+    proofSectionTitle: "Research eval signals",
+    proofSectionDescription:
+      "Measure coverage, citation quality, artifact completeness, and whether the agent stopped with a useful deliverable.",
+    workflowSectionTitle: "Research eval workflow",
+    docsSectionTitle: "Encode investigations as packs",
+    docsSectionDescription:
+      "Turn recurring research workflows into challenge packs so every model or prompt change reruns the same investigation fairly.",
+    faqSectionTitle: "Research agent evaluation FAQ",
+    applicationSubCategory: "Research agent evaluation software",
+    breadcrumbs: [
+      { name: "Home", url: "/" },
+      { name: "Use cases", url: "/use-cases/research-agent-evaluation" },
+      { name: "Research agent evaluation", url: "/use-cases/research-agent-evaluation" },
+    ],
+    schemaId: "agentclash-research-agent-evaluation-schema",
+    searchKeywords:
+      "research agent evaluation evaluate research agents investigation agents evidence quality replay scorecards challenge packs",
+    sitemapTitle: "Research agent evaluation",
+    sitemapDescription:
+      "Evaluate research agents on investigation tasks with replay and scorecards.",
+    faqItems: [
+      {
+        question: "What should research agent evaluation score?",
+        answer:
+          "Task completion, evidence quality, artifact completeness, tool discipline, and whether the final synthesis matches the sources collected.",
+      },
+      {
+        question: "Can evals include web or file tools?",
+        answer:
+          "Yes. Challenge packs define which tools agents may use and which artifacts must be produced for a pass.",
+      },
+      {
+        question: "How do teams debug a failed research run?",
+        answer:
+          "Replay shows each search, fetch, note, and synthesis step so reviewers can see where the investigation went off track.",
+      },
+    ],
+  }),
+  page({
+    path: "/use-cases/support-agent-evaluation",
+    tier: "B",
+    keyword: "evaluate customer support agents",
+    intent: "Use-case page",
+    pageTitle: "Customer Support Agent Evaluation - AgentClash",
+    metaDescription:
+      "Evaluate customer support agents on real resolution workflows with replay evidence, scorecards, challenge packs, and CI regression gates.",
+    socialImageAlt: "AgentClash support agent evaluation social preview.",
+    eyebrow: "Use case",
+    h1: "Evaluate customer support agents on real resolutions",
+    heroDescription:
+      "Support agents must resolve tickets safely, use the right tools, and leave an audit trail. AgentClash evaluates full support trajectories and keeps replay evidence when tone, policy, or resolution quality regresses.",
+    proofSectionTitle: "Support eval signals",
+    proofSectionDescription:
+      "Score resolution correctness, policy adherence, tool usage, escalation behavior, and customer-facing artifact quality.",
+    workflowSectionTitle: "Support eval workflow",
+    docsSectionTitle: "Start with escaped tickets",
+    docsSectionDescription:
+      "Promote real support failures into challenge packs and regression suites so the same mistake cannot return after a model update.",
+    faqSectionTitle: "Support agent evaluation FAQ",
+    applicationSubCategory: "Customer support agent evaluation software",
+    breadcrumbs: [
+      { name: "Home", url: "/" },
+      { name: "Use cases", url: "/use-cases/support-agent-evaluation" },
+      { name: "Support agent evaluation", url: "/use-cases/support-agent-evaluation" },
+    ],
+    schemaId: "agentclash-support-agent-evaluation-schema",
+    searchKeywords:
+      "customer support agent evaluation support agent eval ticket resolution replay scorecards challenge packs regression testing",
+    sitemapTitle: "Support agent evaluation",
+    sitemapDescription:
+      "Evaluate support agents on resolution workflows with replay and gates.",
+    faqItems: [
+      {
+        question: "Can AgentClash evaluate multi-turn support flows?",
+        answer:
+          "Yes. Multi-turn challenge packs support scripted, simulated, and human phases for realistic support conversations.",
+      },
+      {
+        question: "How do teams measure policy adherence?",
+        answer:
+          "Challenge packs encode required actions, forbidden tool use, and validator checks so scorecards reflect policy—not just friendly language.",
+      },
+      {
+        question: "Can support evals gate releases?",
+        answer:
+          "Yes. Compare candidate and baseline scorecards in CI before deploying a new support agent or model route.",
+      },
+    ],
+  }),
+  page({
+    path: "/features/agent-scorecards",
+    tier: "B",
+    keyword: "agent scorecard",
+    intent: "Feature keyword",
+    pageTitle: "Agent Scorecards for Correctness, Cost, and Evidence - AgentClash",
+    metaDescription:
+      "Agent scorecards summarize correctness, latency, cost, tool strategy, and evidence quality so teams can compare runs and gate releases.",
+    socialImageAlt: "AgentClash agent scorecards social preview.",
+    eyebrow: "Feature",
+    h1: "Agent scorecards that justify a release decision",
+    heroDescription:
+      "Scorecards turn long agent runs into a reviewable verdict. AgentClash aggregates correctness, cost, latency, tool strategy, and validator evidence so baselines and candidates are easy to compare.",
+    proofSectionTitle: "What scorecards include",
+    proofSectionDescription:
+      "A scorecard should be more than a single number — it should explain why a run passed or failed.",
+    workflowSectionTitle: "From run to scorecard",
+    docsSectionTitle: "Interpret results",
+    docsSectionDescription:
+      "Read the interpret-results guide, then wire scorecard thresholds into CI gates and release policy.",
+    faqSectionTitle: "Agent scorecard FAQ",
+    applicationSubCategory: "Agent scorecard software",
+    breadcrumbs: [
+      { name: "Home", url: "/" },
+      { name: "Features", url: "/features/agent-scorecards" },
+      { name: "Agent scorecards", url: "/features/agent-scorecards" },
+    ],
+    schemaId: "agentclash-agent-scorecards-schema",
+    searchKeywords:
+      "agent scorecard scorecards agent eval results correctness cost latency evidence quality release gates",
+    sitemapTitle: "Agent scorecards",
+    sitemapDescription:
+      "Scorecards for correctness, cost, latency, and evidence quality.",
+    faqItems: [
+      {
+        question: "What appears on an AgentClash scorecard?",
+        answer:
+          "Correctness signals, validator evidence, cost, latency, tool usage summaries, and dimension scores your challenge pack defines.",
+      },
+      {
+        question: "Can scorecards compare two runs?",
+        answer:
+          "Yes. Baseline versus candidate comparisons are first-class for regression testing and CI gates.",
+      },
+      {
+        question: "Can scorecards be exported or shared?",
+        answer:
+          "Yes. Runs keep scorecard views in the product and support shareable evidence for reviewers.",
+      },
+    ],
+    relatedLinks: [
+      {
+        title: "Interpret results",
+        text: "Learn how to read scorecards and replay evidence after a run.",
+        href: "/docs/guides/interpret-results",
+      },
+      ...sharedDocsLinks,
+    ],
+  }),
+  page({
+    path: "/features/agent-replay",
+    tier: "B",
+    keyword: "agent replay",
+    intent: "Feature keyword",
+    pageTitle: "Agent Replay for Debugging and Review - AgentClash",
+    metaDescription:
+      "Agent replay preserves tool calls, observations, artifacts, and scorecard evidence so teams can debug agent failures without reproducing them manually.",
+    socialImageAlt: "AgentClash agent replay social preview.",
+    eyebrow: "Feature",
+    h1: "Agent replay that makes failures reviewable",
+    heroDescription:
+      "When an agent gate fails, reviewers need the path — not a summary. AgentClash replay timelines show tool calls, observations, artifacts, and scorecard context in one place.",
+    proofSectionTitle: "Why replay matters",
+    proofSectionDescription:
+      "Replay turns agent eval from a score into an auditable story of what the agent tried and what the environment returned.",
+    workflowSectionTitle: "Replay workflow",
+    docsSectionTitle: "Debug with docs",
+    docsSectionDescription:
+      "Pair replay with interpret-results guidance and challenge packs so every debugged failure becomes a reusable test.",
+    faqSectionTitle: "Agent replay FAQ",
+    applicationSubCategory: "Agent replay software",
+    breadcrumbs: [
+      { name: "Home", url: "/" },
+      { name: "Features", url: "/features/agent-replay" },
+      { name: "Agent replay", url: "/features/agent-replay" },
+    ],
+    schemaId: "agentclash-agent-replay-schema",
+    searchKeywords:
+      "agent replay replay evidence tool call timeline agent trace debugging scorecards challenge packs",
+    sitemapTitle: "Agent replay",
+    sitemapDescription:
+      "Replay tool calls, artifacts, and evidence for agent debugging.",
+    faqItems: [
+      {
+        question: "What does AgentClash replay include?",
+        answer:
+          "Tool calls, observations, logs, artifacts, timing, and links to the scorecard dimensions that passed or failed.",
+      },
+      {
+        question: "Can replay be shared with reviewers?",
+        answer:
+          "Yes. Runs support shareable views so PMs, support leads, and engineers can review the same evidence.",
+      },
+      {
+        question: "How does replay help CI failures?",
+        answer:
+          "When a gate fails, replay shows exactly which step diverged from baseline so you do not guess from a single error string.",
+      },
+    ],
+    relatedLinks: [
+      {
+        title: "Trajectory evaluation",
+        text: "See how replay supports full-path agent scoring.",
+        href: "/agent-trajectory-evaluation",
+      },
+      ...sharedDocsLinks,
+    ],
+  }),
+  page({
+    path: "/features/challenge-packs",
+    tier: "B",
+    keyword: "challenge packs agent evaluation",
+    intent: "Your unique term",
+    pageTitle: "Challenge Packs for Agent Evaluation - AgentClash",
+    metaDescription:
+      "Challenge packs turn real agent tasks into repeatable evaluations with tools, scoring rules, artifacts, and CI-ready regression gates.",
+    socialImageAlt: "AgentClash challenge packs social preview.",
+    eyebrow: "Feature",
+    h1: "Challenge packs for repeatable agent evaluation",
+    heroDescription:
+      "Challenge packs are AgentClash's unit of agent evaluation: a real task, tool policy, scoring rules, and artifacts encoded once so every model or harness change reruns the same workload.",
+    proofSectionTitle: "What challenge packs encode",
+    proofSectionDescription:
+      "Inputs, sandbox resources, allowed tools, validators, judges, and pass conditions — everything needed for a fair, repeatable agent eval.",
+    workflowSectionTitle: "Pack lifecycle",
+    docsSectionTitle: "Author packs with docs",
+    docsSectionDescription:
+      "Read the challenge pack docs and authoring guide, then promote escaped failures into packs your whole team can run.",
+    faqSectionTitle: "Challenge packs FAQ",
+    applicationSubCategory: "Challenge pack agent evaluation software",
+    breadcrumbs: [
+      { name: "Home", url: "/" },
+      { name: "Features", url: "/features/challenge-packs" },
+      { name: "Challenge packs", url: "/features/challenge-packs" },
+    ],
+    schemaId: "agentclash-challenge-packs-schema",
+    searchKeywords:
+      "challenge packs agent evaluation repeatable agent tasks scoring rules validators CI regression packs",
+    sitemapTitle: "Challenge packs",
+    sitemapDescription:
+      "Repeatable agent evaluation workloads with scoring and CI gates.",
+    faqItems: [
+      {
+        question: "What is a challenge pack?",
+        answer:
+          "A challenge pack is a versioned agent evaluation workload with inputs, tool policy, scoring rules, and expected artifacts.",
+      },
+      {
+        question: "Can challenge packs run locally and in CI?",
+        answer:
+          "Yes. The same pack can power exploratory races, hosted runs, and pull request gates.",
+      },
+      {
+        question: "How do teams create challenge packs?",
+        answer:
+          "Start from a real failure or release risk, encode it as YAML, and iterate with replay evidence until the scoring rules match what reviewers expect.",
+      },
+    ],
+    relatedLinks: [
+      {
+        title: "Challenge packs docs",
+        text: "Overview of pack structure, scoring, and execution modes.",
+        href: "/docs/challenge-packs",
+      },
+      {
+        title: "Write a challenge pack",
+        text: "Step-by-step authoring guide for your first pack.",
+        href: "/docs/guides/write-a-challenge-pack",
+      },
+      ...sharedDocsLinks.slice(0, 2),
+    ],
+  }),
+];
+
+const SEO_PAGE_BY_PATH = new Map(
+  SEO_PAGE_REGISTRY.map((entry) => [entry.path, entry]),
+);
+
+export function getSeoPageByPath(path: string): SeoPageConfig | undefined {
+  return SEO_PAGE_BY_PATH.get(path);
+}
+
+export function getSeoPagesByPrefix(prefix: string): SeoPageConfig[] {
+  return SEO_PAGE_REGISTRY.filter((entry) => entry.path.startsWith(`${prefix}/`));
+}
+
+export function getAllSeoPagePaths(): string[] {
+  return SEO_PAGE_REGISTRY.map((entry) => entry.path);
+}

--- a/web/src/lib/seo-pages/registry.ts
+++ b/web/src/lib/seo-pages/registry.ts
@@ -572,7 +572,7 @@ export const SEO_PAGE_REGISTRY: SeoPageConfig[] = [
     applicationSubCategory: "Coding agent evaluation software",
     breadcrumbs: [
       { name: "Home", url: "/" },
-      { name: "Use cases", url: "/use-cases/coding-agent-evaluation" },
+      { name: "Use cases", url: "/use-cases" },
       { name: "Coding agent evaluation", url: "/use-cases/coding-agent-evaluation" },
     ],
     schemaId: "agentclash-coding-agent-evaluation-schema",
@@ -623,7 +623,7 @@ export const SEO_PAGE_REGISTRY: SeoPageConfig[] = [
     applicationSubCategory: "Research agent evaluation software",
     breadcrumbs: [
       { name: "Home", url: "/" },
-      { name: "Use cases", url: "/use-cases/research-agent-evaluation" },
+      { name: "Use cases", url: "/use-cases" },
       { name: "Research agent evaluation", url: "/use-cases/research-agent-evaluation" },
     ],
     schemaId: "agentclash-research-agent-evaluation-schema",
@@ -674,7 +674,7 @@ export const SEO_PAGE_REGISTRY: SeoPageConfig[] = [
     applicationSubCategory: "Customer support agent evaluation software",
     breadcrumbs: [
       { name: "Home", url: "/" },
-      { name: "Use cases", url: "/use-cases/support-agent-evaluation" },
+      { name: "Use cases", url: "/use-cases" },
       { name: "Support agent evaluation", url: "/use-cases/support-agent-evaluation" },
     ],
     schemaId: "agentclash-support-agent-evaluation-schema",
@@ -725,7 +725,7 @@ export const SEO_PAGE_REGISTRY: SeoPageConfig[] = [
     applicationSubCategory: "Agent scorecard software",
     breadcrumbs: [
       { name: "Home", url: "/" },
-      { name: "Features", url: "/features/agent-scorecards" },
+      { name: "Features", url: "/features" },
       { name: "Agent scorecards", url: "/features/agent-scorecards" },
     ],
     schemaId: "agentclash-agent-scorecards-schema",
@@ -784,7 +784,7 @@ export const SEO_PAGE_REGISTRY: SeoPageConfig[] = [
     applicationSubCategory: "Agent replay software",
     breadcrumbs: [
       { name: "Home", url: "/" },
-      { name: "Features", url: "/features/agent-replay" },
+      { name: "Features", url: "/features" },
       { name: "Agent replay", url: "/features/agent-replay" },
     ],
     schemaId: "agentclash-agent-replay-schema",
@@ -843,7 +843,7 @@ export const SEO_PAGE_REGISTRY: SeoPageConfig[] = [
     applicationSubCategory: "Challenge pack agent evaluation software",
     breadcrumbs: [
       { name: "Home", url: "/" },
-      { name: "Features", url: "/features/challenge-packs" },
+      { name: "Features", url: "/features" },
       { name: "Challenge packs", url: "/features/challenge-packs" },
     ],
     schemaId: "agentclash-challenge-packs-schema",

--- a/web/src/lib/seo-pages/sitemap-priority.ts
+++ b/web/src/lib/seo-pages/sitemap-priority.ts
@@ -1,0 +1,14 @@
+import type { SeoPageTier } from "./types";
+
+export function seoPageSitemapPriority(tier: SeoPageTier): number {
+  switch (tier) {
+    case "S":
+      return 0.84;
+    case "A":
+      return 0.8;
+    case "B":
+      return 0.76;
+    default:
+      return 0.75;
+  }
+}

--- a/web/src/lib/seo-pages/types.ts
+++ b/web/src/lib/seo-pages/types.ts
@@ -1,0 +1,51 @@
+export type SeoPageTier = "S" | "A" | "B";
+
+export type SeoPageWorkflowStep = {
+  title: string;
+  text: string;
+};
+
+export type SeoPageFaqItem = {
+  question: string;
+  answer: string;
+};
+
+export type SeoPageRelatedLink = {
+  title: string;
+  text: string;
+  href: string;
+};
+
+export type SeoPageBreadcrumb = {
+  name: string;
+  url: string;
+};
+
+export type SeoPageConfig = {
+  path: string;
+  tier: SeoPageTier;
+  keyword: string;
+  intent: string;
+  pageTitle: string;
+  metaDescription: string;
+  socialImageAlt: string;
+  eyebrow: string;
+  h1: string;
+  heroDescription: string;
+  proofSectionTitle: string;
+  proofSectionDescription: string;
+  proofPoints: string[];
+  workflowSectionTitle: string;
+  workflow: SeoPageWorkflowStep[];
+  docsSectionTitle: string;
+  docsSectionDescription: string;
+  relatedLinks: SeoPageRelatedLink[];
+  faqSectionTitle: string;
+  faqItems: SeoPageFaqItem[];
+  applicationSubCategory: string;
+  breadcrumbs: SeoPageBreadcrumb[];
+  schemaId: string;
+  searchKeywords: string;
+  sitemapTitle: string;
+  sitemapDescription: string;
+};


### PR DESCRIPTION
## Summary

Adds 15 new SEO landing pages plus a `pass@k vs pass^k` blog post, using a shared registry/component pattern. Pages are indexed in `sitemap.xml`, the HTML sitemap, and `llms.txt` product-page discovery.

### Page inventory

| Tier | Keyword | Path | Status before PR | Status after PR |
|------|---------|------|------------------|-----------------|
| S | AI agent evaluation platform | `/platform/agent-evaluation` | Already existed | Unchanged |
| S | AI agent regression testing | `/platform/agent-regression-testing` | Already existed | Unchanged |
| S | open source AI agent evaluation | `/open-source-ai-agent-evaluation` | **Missing** | Added |
| S | agent evals | `/agent-evals` | **Missing** | Added |
| S | LLM agent evaluation | `/llm-agent-evaluation` | **Missing** | Added |
| A | agent evaluation framework | `/agent-evaluation-framework` | **Missing** | Added |
| A | AI agent testing | `/ai-agent-testing` | **Missing** | Added |
| A | agent trajectory evaluation | `/agent-trajectory-evaluation` | **Missing** | Added |
| A | agent evaluation CI/CD | `/ci-cd-agent-evaluation` | **Missing** | Added |
| A | AI agent benchmark | `/ai-agent-benchmark` | **Missing** | Added |
| A | agent reliability benchmark | `/agent-reliability-benchmark` | **Missing** | Added |
| A | pass@k vs pass^k | `/blog/pass-at-k-vs-pass-power-k` | **Missing** | Added (blog MDX) |
| B | evaluate coding agents | `/use-cases/coding-agent-evaluation` | **Missing** | Added |
| B | evaluate research agents | `/use-cases/research-agent-evaluation` | **Missing** | Added |
| B | evaluate customer support agents | `/use-cases/support-agent-evaluation` | **Missing** | Added |
| B | agent scorecard | `/features/agent-scorecards` | **Missing** | Added |
| B | agent replay | `/features/agent-replay` | **Missing** | Added |
| B | challenge packs agent evaluation | `/features/challenge-packs` | **Missing** | Added |

**Before this PR:** 2/18 targets existed (both `/platform/*` pages).

**After this PR:** 18/18 targets exist. Nothing left from the keyword map.

### Implementation notes

- Shared config lives in `web/src/lib/seo-pages/registry.ts`
- Shared UI in `web/src/components/marketing/seo-landing-page.tsx`
- Root keyword pages use thin `page.tsx` wrappers; `/use-cases/*` and `/features/*` use dynamic routes with `generateStaticParams`

## Test plan

- [x] `pnpm exec vitest run src/lib/seo-pages/registry.test.ts src/app/seo-landing-pages.test.tsx src/app/sitemap.test.ts src/app/sitemap-page.test.tsx`
- [x] `pnpm exec tsc --noEmit`
- [ ] Spot-check a few live URLs after deploy: `/agent-evals`, `/features/challenge-packs`, `/blog/pass-at-k-vs-pass-power-k`