### PR TITLE
feat(web): add /benchmarks model race-report content section

### DIFF
--- a/docs/marketing/model-benchmark-workflow.md
+++ b/docs/marketing/model-benchmark-workflow.md
@@ -1,0 +1,129 @@
+# Model Benchmark Workflow (Race Report Runbook)
+
+This is the repeatable process for turning an AgentClash race into a published
+benchmark report on the marketing site. Run it **every time a major model
+launches** (≈ monthly) to ride the launch-week attention.
+
+The published surface is `/benchmarks` (index) and `/benchmarks/<slug>` (report),
+backed by MDX files in `web/content/benchmarks/`. There are no backend changes —
+a report is a content file with a structured scoreboard in its frontmatter plus a
+narrative body.
+
+## Why this exists
+
+AgentClash already produces the asset the AI ecosystem shares: head-to-head agent
+races on real tasks with defensible scoring. A "We raced **\<new model\>** against
+the field on 5 real agentic tasks — here's who won" post is high-signal, evergreen,
+and SEO-friendly. The workflow below makes producing one fast and consistent.
+
+## One-time setup
+
+- A workspace on the hosted backend with a challenge pack of **real agentic tasks**
+  (not trivia). The seed report uses five: an auth bug fix, a p99 latency hunt, a
+  flaky-test triage, a safe schema migration, and a log-driven incident RCA.
+- The `agentclash` CLI pointed at the hosted backend (see the repo `CLAUDE.md`,
+  "CLI Against Hosted Backend"):
+
+  ```bash
+  export AGENTCLASH_API_URL="https://api.agentclash.dev"
+  cd cli && go run . auth login --device
+  go run . workspace use <workspace-id>
+  ```
+
+## Per-launch steps
+
+### 1. Run the race
+
+Create a run with the model lineup (the new model plus the current field) on the
+challenge pack and follow it to completion:
+
+```bash
+cd cli
+go run . run create --follow   # pick the pack + the models when prompted
+```
+
+Note the **run ID** when it finishes.
+
+### 2. Export the ranking JSON
+
+Fetch the run's ranking (the scoreboard the backend computes — see
+`backend/internal/api/run_ranking.go`). Either save the CLI/API output to a file
+or pipe it straight into the scaffold:
+
+```bash
+# via the API directly:
+curl -s -H "Authorization: Bearer $AGENTCLASH_TOKEN" \
+  "$AGENTCLASH_API_URL/workspaces/$AGENTCLASH_WORKSPACE/runs/<run-id>/ranking" \
+  > ranking.json
+```
+
+The scaffold accepts either the full response (`{ state, ranking: {...} }`) or the
+bare `ranking` payload.
+
+### 3. Scaffold the report
+
+```bash
+node scripts/benchmarks/scaffold.mjs \
+  --ranking ranking.json \
+  --title "We raced <Model> against the field on 5 real agentic tasks" \
+  --model "<Model>" \
+  --slug <model>-vs-the-field \
+  --share-url "https://www.agentclash.dev/share/<token>"   # optional
+```
+
+This writes `web/content/benchmarks/<slug>.mdx` with:
+
+- `sample: false` (real data),
+- the **scoreboard pre-filled** from the ranking (rank, winner, composite,
+  correctness, reliability, latency, cost, $/correct), with a provider hint per
+  model, and
+- a prose skeleton (`How the race worked`, `The tasks`, `What we saw`, `Takeaway`).
+
+It refuses to overwrite an existing file unless you pass `--force`.
+
+### 4. Make a public share link (optional but recommended)
+
+So readers can drill into the live race, create a public share of the run
+scorecard and paste its URL into the report's `runShareUrl` frontmatter (the
+scaffold's `--share-url` does this for you). The report page renders a
+"View the live race scorecard" link to `/share/<token>`.
+
+### 5. Edit the narrative
+
+Fill in every `TODO` in the frontmatter (`verdict`, `challengePack`, each task's
+`name`/`summary`) and the body. Keep the verdict to one line — it's the OG-card
+subtitle and the index-card blurb. Confirm the provider on each scoreboard row.
+
+### 6. Verify locally
+
+```bash
+cd web
+npx tsc --noEmit
+pnpm lint
+pnpm test
+pnpm build
+pnpm dev    # open /benchmarks and /benchmarks/<slug>
+```
+
+Check: the scoreboard renders with the winner highlighted, the OG card
+(`/og?title=...&kind=Benchmark`) looks right, and the sample-data banner is
+**absent** (since `sample: false`).
+
+### 7. Publish & syndicate
+
+Merge to `main`. The report is automatically picked up by:
+
+- `/benchmarks` index and `/benchmarks/<slug>` page,
+- `sitemap.xml` (with a tailored OG image),
+- `/benchmarks/feed.xml` (RSS),
+- JSON-LD (`Article` + `Dataset`) for search/answer-engine discovery.
+
+Then post the link to X and Hacker News on launch day. The verdict line is your
+hook; the scoreboard is the proof.
+
+## Authoring a report by hand
+
+You don't need a real run to publish — set `sample: true` in the frontmatter and
+the page shows a clear "Sample data" banner. This is how the seed report
+(`claude-opus-4-8-vs-the-field.mdx`) works. Flip it to `false` once the numbers
+are real.

--- a/scripts/benchmarks/scaffold.mjs
+++ b/scripts/benchmarks/scaffold.mjs
@@ -83,7 +83,7 @@ function round(value, places) {
 // Provider is not in the ranking document; infer a hint from the model label so
 // the editor only has to confirm rather than fill from scratch.
 function guessProvider(label) {
-  const lower = label.toLowerCase();
+  const lower = String(label).toLowerCase();
   if (lower.includes("claude") || lower.includes("opus") || lower.includes("sonnet") || lower.includes("haiku")) return "Anthropic";
   if (lower.includes("gpt") || lower.includes("o1") || lower.includes("o3") || lower.includes("openai")) return "OpenAI";
   if (lower.includes("gemini")) return "Google";

--- a/scripts/benchmarks/scaffold.mjs
+++ b/scripts/benchmarks/scaffold.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+// Scaffold a benchmark report MDX from an AgentClash run-ranking JSON.
+//
+// The ranking JSON is what `GET /workspaces/{ws}/runs/{run}/ranking` returns
+// (see backend/internal/api/run_ranking.go) — either the full response
+// (`{ state, ranking: {...} }`) or just the `ranking` payload. Each item maps to
+// one scoreboard row; the winner is the item whose run_agent_id matches
+// ranking.winner.run_agent_id.
+//
+// Usage:
+//   node scripts/benchmarks/scaffold.mjs --ranking ranking.json \
+//     --title "We raced X against the field" --model "X" --slug x-vs-the-field \
+//     [--share-url https://www.agentclash.dev/share/TOKEN] [--out DIR] [--force]
+//
+//   # or pipe the JSON in:
+//   agentclash run ranking <run-id> --json | node scripts/benchmarks/scaffold.mjs \
+//     --title "..." --model "..." --slug "..."
+//
+// Output: an MDX file with `sample: false` and a prose skeleton to edit. Refuses
+// to overwrite an existing file unless --force is passed. No external deps.
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith("--")) continue;
+    const key = token.slice(2);
+    if (key === "force") {
+      args.force = true;
+      continue;
+    }
+    const value = argv[i + 1];
+    if (value === undefined || value.startsWith("--")) {
+      args[key] = true;
+    } else {
+      args[key] = value;
+      i += 1;
+    }
+  }
+  return args;
+}
+
+function fail(message) {
+  process.stderr.write(`scaffold: ${message}\n`);
+  process.exit(1);
+}
+
+function readInput(rankingPath) {
+  if (rankingPath && rankingPath !== true) {
+    return fs.readFileSync(rankingPath, "utf-8");
+  }
+  if (process.stdin.isTTY) {
+    fail("provide --ranking <file> or pipe ranking JSON on stdin");
+  }
+  return fs.readFileSync(0, "utf-8");
+}
+
+// Accept either the full ranking response or the bare ranking payload.
+function extractRanking(parsed) {
+  if (parsed && parsed.ranking && Array.isArray(parsed.ranking.items)) {
+    return parsed.ranking;
+  }
+  if (parsed && Array.isArray(parsed.items)) {
+    return parsed;
+  }
+  fail("could not find ranking.items[] in the JSON");
+  return null;
+}
+
+function num(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function round(value, places) {
+  if (value === null) return null;
+  return Number(value.toFixed(places));
+}
+
+// Provider is not in the ranking document; infer a hint from the model label so
+// the editor only has to confirm rather than fill from scratch.
+function guessProvider(label) {
+  const lower = label.toLowerCase();
+  if (lower.includes("claude") || lower.includes("opus") || lower.includes("sonnet") || lower.includes("haiku")) return "Anthropic";
+  if (lower.includes("gpt") || lower.includes("o1") || lower.includes("o3") || lower.includes("openai")) return "OpenAI";
+  if (lower.includes("gemini")) return "Google";
+  if (lower.includes("grok")) return "xAI";
+  if (lower.includes("mistral") || lower.includes("mixtral")) return "Mistral";
+  if (lower.includes("llama")) return "Meta";
+  return "";
+}
+
+// Minimal YAML scalar quoting — wrap in double quotes and escape backslashes and
+// quotes. The frontmatter schema is flat, so this is sufficient.
+function yamlString(value) {
+  return `"${String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function buildResultsYaml(items, winnerId) {
+  const lines = ["results:"];
+  for (const [index, item] of items.entries()) {
+    const label = item.label || `Lane ${item.lane_index ?? index}`;
+    const rank = num(item.rank) ?? index + 1;
+    const isWinner = winnerId && item.run_agent_id === winnerId;
+    lines.push(`  - model: ${yamlString(label)}`);
+    lines.push(`    provider: ${yamlString(guessProvider(label))}`);
+    lines.push(`    rank: ${rank}`);
+    if (isWinner) lines.push("    winner: true");
+    const fields = [
+      ["composite", round(num(item.composite_score), 2)],
+      ["correctness", round(num(item.correctness_score), 2)],
+      ["reliability", round(num(item.reliability_score), 2)],
+      ["latency", round(num(item.latency_score), 2)],
+      ["cost", round(num(item.cost_score), 2)],
+      ["costPerCorrectUsd", round(num(item.cost_per_correct_usd), 4)],
+    ];
+    for (const [key, value] of fields) {
+      if (value !== null) lines.push(`    ${key}: ${value}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function today() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function buildMdx({ title, model, shareUrl, results }) {
+  const frontmatter = [
+    "---",
+    `title: ${yamlString(title)}`,
+    `date: ${yamlString(today())}`,
+    `description: ${yamlString(`A head-to-head AgentClash race of ${model} against the field on real agentic tasks, scored on correctness, reliability, latency, and cost.`)}`,
+    `author: ${yamlString("AgentClash")}`,
+    `featuredModel: ${yamlString(model)}`,
+    `verdict: ${yamlString("TODO: one-line verdict — who won and the key trade-off.")}`,
+    `challengePack: ${yamlString("TODO: challenge pack name")}`,
+    "sample: false",
+    ...(shareUrl ? [`runShareUrl: ${yamlString(shareUrl)}`] : []),
+    "tasks:",
+    "  - id: task-1",
+    '    name: "TODO: task name"',
+    '    summary: "TODO: what the agent had to do and how it was verified."',
+    results,
+    "---",
+  ].join("\n");
+
+  const body = [
+    "",
+    "## How the race worked",
+    "",
+    "TODO: same tasks, same sandbox, same tools. Describe the lineup and the pack.",
+    "",
+    "## The tasks",
+    "",
+    "TODO: why these five tasks, and what counted as success on each.",
+    "",
+    "## What we saw",
+    "",
+    "TODO: the story behind the scoreboard — where the featured model won, where",
+    "the field stayed close, and any surprises.",
+    "",
+    "## Takeaway",
+    "",
+    "TODO: the trade-off a single number hides. Close with a CTA.",
+    "",
+    "[Run your own race →](/try)",
+    "",
+  ].join("\n");
+
+  return `${frontmatter}\n${body}`;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const title = args.title;
+  const model = args.model;
+  const slug = args.slug;
+  if (!title || title === true) fail("--title is required");
+  if (!model || model === true) fail("--model is required");
+  if (!slug || slug === true) fail("--slug is required");
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)) {
+    fail("--slug must be kebab-case (lowercase letters, digits, hyphens)");
+  }
+
+  const raw = readInput(args.ranking);
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    fail(`could not parse ranking JSON: ${err.message}`);
+  }
+  const ranking = extractRanking(parsed);
+  const winnerId = ranking.winner && ranking.winner.run_agent_id;
+  const resultsYaml = buildResultsYaml(ranking.items, winnerId);
+
+  const outDir =
+    args.out && args.out !== true
+      ? args.out
+      : path.join("web", "content", "benchmarks");
+  const outPath = path.join(outDir, `${slug}.mdx`);
+  if (fs.existsSync(outPath) && !args.force) {
+    fail(`${outPath} already exists (pass --force to overwrite)`);
+  }
+
+  const mdx = buildMdx({
+    title,
+    model,
+    shareUrl: args["share-url"] && args["share-url"] !== true ? args["share-url"] : "",
+    results: resultsYaml,
+  });
+
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(outPath, mdx, "utf-8");
+  process.stdout.write(`Wrote ${outPath}\n`);
+  process.stdout.write(
+    "Next: fill the TODO fields, verify the scoreboard, then publish.\n",
+  );
+}
+
+main();

--- a/web/content/benchmarks/claude-opus-4-8-vs-the-field.mdx
+++ b/web/content/benchmarks/claude-opus-4-8-vs-the-field.mdx
@@ -1,0 +1,111 @@
+---
+title: "We raced Claude Opus 4.8 against the field on 5 real agentic tasks"
+date: "2026-06-06"
+description: "A head-to-head AgentClash race of Claude Opus 4.8 against four frontier models on five real agentic engineering tasks — scored on correctness, reliability, latency, and cost."
+author: "AgentClash"
+featuredModel: "Claude Opus 4.8"
+verdict: "Opus 4.8 took 4 of 5 tasks and the overall composite; the field stayed close on cost, and Gemini 3 Pro won the latency-sensitive incident triage."
+challengePack: "Real-World Agentic Tasks v1"
+sample: true
+tasks:
+  - id: auth-bug
+    name: "Fix the auth bug"
+    summary: "Diagnose and patch a broken JWT refresh flow that silently logs users out, then prove the fix with a passing test."
+  - id: p99-latency
+    name: "Hunt the p99 latency regression"
+    summary: "Given a service and its traces, find the endpoint whose p99 regressed and identify the offending change."
+  - id: flaky-test
+    name: "Triage a flaky test"
+    summary: "Isolate a non-deterministic test, find the race condition behind it, and make it deterministic without disabling it."
+  - id: schema-migration
+    name: "Write a safe schema migration"
+    summary: "Add a non-null column to a hot table with a backfill and a reversible migration that won't lock writes."
+  - id: incident-rca
+    name: "Run a log-driven incident RCA"
+    summary: "From raw logs of a partial outage, reconstruct the timeline and name the root cause with evidence."
+results:
+  - model: "Claude Opus 4.8"
+    provider: "Anthropic"
+    rank: 1
+    winner: true
+    composite: 0.91
+    correctness: 0.95
+    reliability: 0.93
+    latency: 0.78
+    cost: 0.74
+    costPerCorrectUsd: 0.14
+  - model: "GPT-5.1"
+    provider: "OpenAI"
+    rank: 2
+    composite: 0.86
+    correctness: 0.90
+    reliability: 0.88
+    latency: 0.81
+    cost: 0.71
+    costPerCorrectUsd: 0.17
+  - model: "Gemini 3 Pro"
+    provider: "Google"
+    rank: 3
+    composite: 0.84
+    correctness: 0.86
+    reliability: 0.83
+    latency: 0.92
+    cost: 0.76
+    costPerCorrectUsd: 0.15
+  - model: "Grok 4"
+    provider: "xAI"
+    rank: 4
+    composite: 0.79
+    correctness: 0.82
+    reliability: 0.77
+    latency: 0.80
+    cost: 0.69
+    costPerCorrectUsd: 0.21
+  - model: "Mistral Large 3"
+    provider: "Mistral"
+    rank: 5
+    composite: 0.71
+    correctness: 0.74
+    reliability: 0.70
+    latency: 0.75
+    cost: 0.83
+    costPerCorrectUsd: 0.11
+---
+
+> **This is a sample report.** The numbers above are representative, not measured.
+> It exists to demonstrate the format. See
+> [the workflow runbook](https://github.com/agentclash/agentclash/blob/main/docs/marketing/model-benchmark-workflow.md)
+> for how to produce a real one from an AgentClash race.
+
+## How the race worked
+
+Every model got the **same five tasks, the same sandbox, and the same tools**. No
+task was a trivia question — each one is a slice of real engineering work with a
+verifiable outcome: a test that has to pass, a regression that has to be named, a
+migration that has to be reversible. AgentClash scores the whole trajectory, not
+just the final answer, across four vantages — deterministic checks, numeric
+metrics, behavioral signals, and LLM judges — and folds them into one composite
+verdict. (More on that in
+[how AgentClash scores agent trajectories](/blog/how-agentclash-scores-agent-trajectories).)
+
+## What we saw
+
+**Opus 4.8 won on correctness and reliability.** It was the only model to land the
+schema migration with a reversible down-migration on the first try, and it
+recovered cleanly when the flaky-test sandbox surfaced an unexpected race.
+
+**The field stayed close on cost.** Composite scores spread by 20 points, but
+cost-per-correct-answer was tighter — the cheaper models simply needed more
+attempts to get there.
+
+**Latency had a different winner.** On the log-driven incident RCA, where
+wall-clock time matters most, Gemini 3 Pro reconstructed the timeline fastest
+without sacrificing the root-cause evidence.
+
+## Takeaway
+
+A single benchmark number hides the trade-off that actually decides which model
+you ship. Race them on *your* tasks, with your tools, and read the whole
+scoreboard — correctness, reliability, latency, and cost — before you pick.
+
+[Run your own race →](/try)

--- a/web/src/app/benchmarks/[slug]/page.tsx
+++ b/web/src/app/benchmarks/[slug]/page.tsx
@@ -1,0 +1,159 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { MDXRemote } from "next-mdx-remote/rsc";
+import { ArrowUpRight } from "lucide-react";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { BenchmarkScoreboard } from "@/components/marketing/benchmark-scoreboard";
+import {
+  JsonLd,
+  benchmarkReportSchema,
+} from "@/components/marketing/json-ld";
+import { getAllSlugs, getReportBySlug } from "@/lib/benchmarks";
+import { mdxRemoteOptions } from "@/lib/mdx-options";
+import { benchmarkRssAlternate, ogImageUrl } from "@/lib/seo";
+
+type Props = {
+  params: Promise<{ slug: string }>;
+};
+
+export function generateStaticParams() {
+  return getAllSlugs().map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const report = getReportBySlug(slug);
+  if (!report) return {};
+  const title = `${report.title} — AgentClash`;
+  const ogImage = ogImageUrl({
+    title: report.title,
+    subtitle: report.verdict,
+    kind: "Benchmark",
+  });
+
+  return {
+    title,
+    description: report.description,
+    alternates: {
+      canonical: `/benchmarks/${report.slug}`,
+      types: benchmarkRssAlternate,
+    },
+    openGraph: {
+      type: "article",
+      title,
+      description: report.description,
+      url: `/benchmarks/${report.slug}`,
+      locale: "en_US",
+      siteName: "AgentClash",
+      publishedTime: report.date,
+      authors: [report.author],
+      images: [{ url: ogImage, width: 1200, height: 630, alt: report.title }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description: report.description,
+      images: [{ url: ogImage, alt: report.title }],
+    },
+  };
+}
+
+export default async function BenchmarkReportPage({ params }: Props) {
+  const { slug } = await params;
+  const report = getReportBySlug(slug);
+  if (!report) notFound();
+
+  return (
+    <MarketingShell>
+      <JsonLd
+        id={`agentclash-benchmark-${report.slug}-schema`}
+        data={benchmarkReportSchema(report)}
+      />
+      <article className="mx-auto w-full max-w-3xl px-6 py-16">
+        <Link
+          href="/benchmarks"
+          className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35 transition-colors hover:text-white/55"
+        >
+          &larr; Benchmarks
+        </Link>
+
+        <header className="mt-6">
+          <p className="font-[family-name:var(--font-mono)] text-[11px] text-white/40">
+            {report.date} &middot; {report.featuredModel}
+            {report.challengePack ? ` · ${report.challengePack}` : ""}
+          </p>
+          <h1 className="mt-3 font-[family-name:var(--font-display)] text-3xl tracking-[-0.02em] leading-[1.15] sm:text-4xl">
+            {report.title}
+          </h1>
+          <p className="mt-4 text-base leading-relaxed text-white/60">
+            {report.verdict}
+          </p>
+        </header>
+
+        {report.sample && (
+          <div className="mt-6 rounded-lg border border-amber-400/25 bg-amber-400/[0.06] px-4 py-3 text-xs leading-relaxed text-amber-200/80">
+            <span className="font-medium text-amber-200">Sample data.</span>{" "}
+            This report uses representative numbers to illustrate the format. Run
+            the race to publish a report with real results.
+          </div>
+        )}
+
+        <section className="mt-8">
+          <h2 className="mb-3 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35">
+            Scoreboard
+          </h2>
+          <BenchmarkScoreboard
+            results={report.results}
+            featuredModel={report.featuredModel}
+          />
+          {report.runShareUrl && (
+            <a
+              href={report.runShareUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-3 inline-flex items-center gap-1 text-xs text-white/45 transition-colors hover:text-white/75"
+            >
+              View the live race scorecard
+              <ArrowUpRight className="size-3" />
+            </a>
+          )}
+        </section>
+
+        {report.tasks.length > 0 && (
+          <section className="mt-10">
+            <h2 className="mb-3 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35">
+              The tasks
+            </h2>
+            <ol className="flex flex-col gap-2">
+              {report.tasks.map((task, index) => (
+                <li
+                  key={task.id}
+                  className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3"
+                >
+                  <div className="flex items-baseline gap-2">
+                    <span className="font-[family-name:var(--font-mono)] text-[11px] text-white/30">
+                      {String(index + 1).padStart(2, "0")}
+                    </span>
+                    <span className="text-sm font-medium text-white/85">
+                      {task.name}
+                    </span>
+                  </div>
+                  {task.summary && (
+                    <p className="mt-1 pl-6 text-xs leading-relaxed text-white/40">
+                      {task.summary}
+                    </p>
+                  )}
+                </li>
+              ))}
+            </ol>
+          </section>
+        )}
+
+        <div className="prose-agentclash mt-12">
+          <MDXRemote source={report.content} options={mdxRemoteOptions} />
+        </div>
+      </article>
+    </MarketingShell>
+  );
+}

--- a/web/src/app/benchmarks/[slug]/page.tsx
+++ b/web/src/app/benchmarks/[slug]/page.tsx
@@ -35,6 +35,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title,
     description: report.description,
+    // Sample reports use illustrative numbers — keep them reachable for humans
+    // but out of the search index so engines never treat them as real data.
+    robots: report.sample ? { index: false, follow: true } : undefined,
     alternates: {
       canonical: `/benchmarks/${report.slug}`,
       types: benchmarkRssAlternate,
@@ -66,10 +69,14 @@ export default async function BenchmarkReportPage({ params }: Props) {
 
   return (
     <MarketingShell>
-      <JsonLd
-        id={`agentclash-benchmark-${report.slug}-schema`}
-        data={benchmarkReportSchema(report)}
-      />
+      {/* Sample reports carry illustrative numbers — don't emit a Dataset/Article
+          that would present them to answer engines as real, measured data. */}
+      {!report.sample && (
+        <JsonLd
+          id={`agentclash-benchmark-${report.slug}-schema`}
+          data={benchmarkReportSchema(report)}
+        />
+      )}
       <article className="mx-auto w-full max-w-3xl px-6 py-16">
         <Link
           href="/benchmarks"

--- a/web/src/app/benchmarks/benchmarks-metadata.test.ts
+++ b/web/src/app/benchmarks/benchmarks-metadata.test.ts
@@ -112,4 +112,44 @@ describe("benchmarks report social metadata", () => {
     });
     expect(metadata).toEqual({});
   });
+
+  it("noindexes a sample report so engines never index illustrative numbers", async () => {
+    getReportBySlugMock.mockReturnValue({
+      slug: "sample-report",
+      title: "Sample Report",
+      date: "2026-06-06",
+      description: "Illustrative.",
+      author: "AgentClash",
+      featuredModel: "Claude Opus 4.8",
+      verdict: "Representative only.",
+      sample: true,
+      content: "",
+    });
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: "sample-report" }),
+    });
+
+    expect(metadata.robots).toEqual({ index: false, follow: true });
+  });
+
+  it("leaves a real (non-sample) report indexable", async () => {
+    getReportBySlugMock.mockReturnValue({
+      slug: "real-report",
+      title: "Real Report",
+      date: "2026-06-06",
+      description: "Measured.",
+      author: "AgentClash",
+      featuredModel: "Claude Opus 4.8",
+      verdict: "Opus won.",
+      sample: false,
+      content: "",
+    });
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: "real-report" }),
+    });
+
+    expect(metadata.robots).toBeUndefined();
+  });
 });

--- a/web/src/app/benchmarks/benchmarks-metadata.test.ts
+++ b/web/src/app/benchmarks/benchmarks-metadata.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import { benchmarkRssAlternate, ogImageUrl } from "@/lib/seo";
+import { metadata as benchmarksMetadata } from "./page";
+import { generateMetadata } from "./[slug]/page";
+
+const getReportBySlugMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  withAuth: vi.fn(),
+}));
+
+vi.mock("next-mdx-remote/rsc", () => ({
+  MDXRemote: () => null,
+}));
+
+vi.mock("@/lib/benchmarks", () => ({
+  getAllReports: vi.fn(() => []),
+  getAllSlugs: vi.fn(() => []),
+  getReportBySlug: getReportBySlugMock,
+}));
+
+describe("benchmarks RSS autodiscovery metadata", () => {
+  it("links the benchmarks RSS feed from the index metadata", () => {
+    expect(benchmarksMetadata.alternates).toMatchObject({
+      canonical: "/benchmarks",
+      types: benchmarkRssAlternate,
+    });
+  });
+
+  it("links the benchmarks RSS feed from report metadata", async () => {
+    getReportBySlugMock.mockReturnValue({
+      slug: "fixture-report",
+      title: "Fixture Report",
+      date: "2026-06-06",
+      description: "Fixture description.",
+      author: "AgentClash",
+      featuredModel: "Claude Opus 4.8",
+      verdict: "Opus won.",
+      content: "",
+    });
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: "fixture-report" }),
+    });
+
+    expect(metadata.alternates).toMatchObject({
+      canonical: "/benchmarks/fixture-report",
+      types: benchmarkRssAlternate,
+    });
+  });
+});
+
+describe("benchmarks index social metadata", () => {
+  it("adds Open Graph and Twitter card metadata", () => {
+    expect(benchmarksMetadata).toMatchObject({
+      openGraph: {
+        url: "/benchmarks",
+        type: "website",
+        siteName: "AgentClash",
+      },
+      twitter: {
+        card: "summary_large_image",
+      },
+    });
+  });
+});
+
+describe("benchmarks report social metadata", () => {
+  it("uses a Benchmark-kind OG image keyed off the verdict", async () => {
+    getReportBySlugMock.mockReturnValue({
+      slug: "fixture-report",
+      title: "Fixture Report",
+      date: "2026-06-06",
+      description: "Fixture description.",
+      author: "AgentClash",
+      featuredModel: "Claude Opus 4.8",
+      verdict: "Opus won.",
+      content: "",
+    });
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: "fixture-report" }),
+    });
+
+    const expectedImage = ogImageUrl({
+      title: "Fixture Report",
+      subtitle: "Opus won.",
+      kind: "Benchmark",
+    });
+
+    expect(metadata).toMatchObject({
+      title: "Fixture Report — AgentClash",
+      description: "Fixture description.",
+      openGraph: {
+        type: "article",
+        url: "/benchmarks/fixture-report",
+        publishedTime: "2026-06-06",
+        authors: ["AgentClash"],
+        images: [{ url: expectedImage, width: 1200, height: 630 }],
+      },
+      twitter: {
+        card: "summary_large_image",
+        images: [{ url: expectedImage }],
+      },
+    });
+  });
+
+  it("returns empty metadata for an unknown slug", async () => {
+    getReportBySlugMock.mockReturnValue(null);
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: "missing" }),
+    });
+    expect(metadata).toEqual({});
+  });
+});

--- a/web/src/app/benchmarks/feed.xml/route.ts
+++ b/web/src/app/benchmarks/feed.xml/route.ts
@@ -1,0 +1,12 @@
+import { buildBenchmarkRssFeed } from "@/lib/rss";
+
+export const revalidate = 3600;
+
+export function GET() {
+  return new Response(buildBenchmarkRssFeed(), {
+    headers: {
+      "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+      "Content-Type": "application/rss+xml; charset=utf-8",
+    },
+  });
+}

--- a/web/src/app/benchmarks/page.tsx
+++ b/web/src/app/benchmarks/page.tsx
@@ -1,0 +1,89 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { JsonLd, benchmarkIndexSchema } from "@/components/marketing/json-ld";
+import { getAllReports } from "@/lib/benchmarks";
+import { benchmarkRssAlternate, ogImageUrl } from "@/lib/seo";
+
+const PAGE_TITLE = "AI Agent Benchmarks - Models Raced Head-to-Head | AgentClash";
+const PAGE_DESCRIPTION =
+  "Head-to-head AI agent benchmarks: every major model launch raced against the field on real agentic tasks, scored on correctness, reliability, latency, and cost.";
+const SOCIAL_IMAGE = ogImageUrl({
+  title: "AI Agent Benchmarks",
+  subtitle: "New models raced against the field on real agentic tasks",
+  kind: "Benchmark",
+});
+
+export const metadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  alternates: {
+    canonical: "/benchmarks",
+    types: benchmarkRssAlternate,
+  },
+  openGraph: {
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: "/benchmarks",
+    type: "website",
+    locale: "en_US",
+    siteName: "AgentClash",
+    images: [{ url: SOCIAL_IMAGE, width: 1200, height: 630, alt: PAGE_TITLE }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    images: [{ url: SOCIAL_IMAGE, alt: PAGE_TITLE }],
+  },
+};
+
+export default function BenchmarksPage() {
+  const reports = getAllReports();
+
+  return (
+    <MarketingShell>
+      <JsonLd
+        id="agentclash-benchmarks-index-schema"
+        data={benchmarkIndexSchema(reports)}
+      />
+      <section className="mx-auto w-full max-w-3xl px-6 py-16">
+        <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35">
+          Benchmarks
+        </p>
+        <h1 className="mt-3 font-[family-name:var(--font-display)] text-3xl tracking-[-0.02em] leading-[1.15] sm:text-4xl">
+          Models, raced head-to-head
+        </h1>
+        <p className="mt-3 max-w-xl text-sm leading-relaxed text-white/45">
+          When a new model ships, we race it against the field on real agentic
+          tasks — same challenge, same tools — and score the whole trajectory on
+          correctness, reliability, latency, and cost. Here is who won.
+        </p>
+
+        <div className="mt-10 flex flex-col gap-3">
+          {reports.map((report) => (
+            <Link
+              key={report.slug}
+              href={`/benchmarks/${report.slug}`}
+              className="group flex flex-col gap-1.5 rounded-lg border border-white/[0.08] bg-white/[0.03] px-5 py-4 transition-colors hover:border-white/15"
+            >
+              <span className="font-[family-name:var(--font-mono)] text-[11px] text-white/40">
+                {report.date} &middot; {report.featuredModel}
+              </span>
+              <span className="text-base font-medium text-white group-hover:text-white/90">
+                {report.title}
+              </span>
+              <span className="text-xs leading-relaxed text-white/40">
+                {report.verdict}
+              </span>
+            </Link>
+          ))}
+        </div>
+
+        {reports.length === 0 && (
+          <p className="mt-10 text-xs text-white/20">No benchmarks yet.</p>
+        )}
+      </section>
+    </MarketingShell>
+  );
+}

--- a/web/src/app/benchmarks/page.tsx
+++ b/web/src/app/benchmarks/page.tsx
@@ -45,7 +45,7 @@ export default function BenchmarksPage() {
     <MarketingShell>
       <JsonLd
         id="agentclash-benchmarks-index-schema"
-        data={benchmarkIndexSchema(reports)}
+        data={benchmarkIndexSchema(reports.filter((report) => !report.sample))}
       />
       <section className="mx-auto w-full max-w-3xl px-6 py-16">
         <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35">
@@ -69,6 +69,11 @@ export default function BenchmarksPage() {
             >
               <span className="font-[family-name:var(--font-mono)] text-[11px] text-white/40">
                 {report.date} &middot; {report.featuredModel}
+                {report.sample && (
+                  <span className="ml-2 rounded-full border border-amber-400/25 bg-amber-400/[0.06] px-1.5 py-0.5 text-[9px] uppercase tracking-[0.12em] text-amber-200/80">
+                    Sample
+                  </span>
+                )}
               </span>
               <span className="text-base font-medium text-white group-hover:text-white/90">
                 {report.title}

--- a/web/src/app/public-canonical-metadata.test.ts
+++ b/web/src/app/public-canonical-metadata.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it, vi } from "vitest";
 import { metadata as homeMetadata } from "./page";
 import { metadata as blogMetadata } from "./blog/page";
 import { generateMetadata as generateBlogPostMetadata } from "./blog/[slug]/page";
+import { metadata as benchmarksMetadata } from "./benchmarks/page";
+import { generateMetadata as generateBenchmarkMetadata } from "./benchmarks/[slug]/page";
 import { generateMetadata as generateDocsMetadata } from "./docs/[[...slug]]/page";
 import { metadata as agentEvaluationMetadata } from "./platform/agent-evaluation/page";
 import { metadata as agentRegressionTestingMetadata } from "./platform/agent-regression-testing/page";
@@ -32,6 +34,14 @@ vi.mock("@/lib/blog", () => ({
   getPostBySlug: getPostBySlugMock,
 }));
 
+const getReportBySlugMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/benchmarks", () => ({
+  getAllReports: vi.fn(() => []),
+  getAllSlugs: vi.fn(() => []),
+  getReportBySlug: getReportBySlugMock,
+}));
+
 vi.mock("@/lib/docs", () => ({
   DOCS_NAV: [],
   getAllDocSlugs: vi.fn(() => []),
@@ -47,6 +57,7 @@ describe("public canonical metadata", () => {
   it("locks static public page canonicals", () => {
     expectCanonical(homeMetadata, "/");
     expectCanonical(blogMetadata, "/blog");
+    expectCanonical(benchmarksMetadata, "/benchmarks");
     expectCanonical(agentEvaluationMetadata, "/platform/agent-evaluation");
     expectCanonical(
       agentRegressionTestingMetadata,
@@ -73,6 +84,25 @@ describe("public canonical metadata", () => {
     });
 
     expectCanonical(metadata, "/blog/fixture-post");
+  });
+
+  it("locks benchmark report canonical metadata", async () => {
+    getReportBySlugMock.mockReturnValue({
+      slug: "fixture-report",
+      title: "Fixture Report",
+      date: "2026-06-06",
+      description: "Fixture description.",
+      author: "AgentClash",
+      featuredModel: "Claude Opus 4.8",
+      verdict: "Opus won.",
+      content: "",
+    });
+
+    const metadata = await generateBenchmarkMetadata({
+      params: Promise.resolve({ slug: "fixture-report" }),
+    });
+
+    expectCanonical(metadata, "/benchmarks/fixture-report");
   });
 
   it("locks docs canonical metadata", async () => {

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -21,6 +21,17 @@ vi.mock("@/lib/docs", () => ({
   ]),
 }));
 
+vi.mock("@/lib/benchmarks", () => ({
+  getAllReports: vi.fn(() => [
+    {
+      slug: "claude-opus-4-8-vs-the-field",
+      title: "Claude Opus 4.8 vs the field",
+      date: "2026-06-06",
+      verdict: "Opus 4.8 took 4 of 5.",
+    },
+  ]),
+}));
+
 describe("sitemap", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -133,6 +144,29 @@ describe("sitemap", () => {
       changeFrequency: "monthly",
       priority: 0.7,
     });
+  });
+
+  it("includes the benchmarks index and per-report pages", () => {
+    const entries = sitemap();
+    const byUrl = new Map(entries.map((entry) => [entry.url, entry]));
+
+    expect(
+      byUrl.get("https://www.agentclash.dev/benchmarks"),
+    ).toMatchObject({
+      changeFrequency: "weekly",
+      priority: 0.8,
+    });
+    const report = byUrl.get(
+      "https://www.agentclash.dev/benchmarks/claude-opus-4-8-vs-the-field",
+    );
+    expect(report).toMatchObject({
+      lastModified: new Date("2026-06-06"),
+      changeFrequency: "monthly",
+      priority: 0.75,
+    });
+    const image = report?.images?.[0] ?? "";
+    expect(image.startsWith("https://www.agentclash.dev/og?")).toBe(true);
+    expect(image).toContain("kind=Benchmark");
   });
 
   it("includes the comparison hub and per-competitor pages", () => {

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -28,6 +28,21 @@ vi.mock("@/lib/benchmarks", () => ({
       title: "Claude Opus 4.8 vs the field",
       date: "2026-06-06",
       verdict: "Opus 4.8 took 4 of 5.",
+      sample: false,
+    },
+    {
+      slug: "sample-illustrative",
+      title: "Sample illustrative report",
+      date: "2026-06-06",
+      verdict: "Representative numbers only.",
+      sample: true,
+    },
+    {
+      slug: "bad-date-report",
+      title: "Report with an unparseable date",
+      date: "Q2 2026",
+      verdict: "Date will not parse.",
+      sample: false,
     },
   ]),
 }));
@@ -254,5 +269,24 @@ describe("sitemap", () => {
     expect(multi).toBeDefined();
     expect(multi).toContain("&amp;");
     expect(/&(?!amp;|lt;|gt;|quot;|#39;)/.test(multi ?? "")).toBe(false);
+  });
+
+  it("excludes sample reports so fabricated numbers are never indexed", () => {
+    const urls = new Set(sitemap().map((entry) => entry.url));
+    expect(
+      urls.has("https://www.agentclash.dev/benchmarks/sample-illustrative"),
+    ).toBe(false);
+  });
+
+  it("survives an unparseable report date without crashing the whole sitemap", () => {
+    const byUrl = new Map(sitemap().map((entry) => [entry.url, entry]));
+    const bad = byUrl.get(
+      "https://www.agentclash.dev/benchmarks/bad-date-report",
+    );
+    // Still listed, but with no Invalid Date lastModified that would make Next's
+    // serializer throw on .toISOString() and take down the entire sitemap.xml.
+    expect(bad).toBeDefined();
+    expect(bad?.lastModified).toBeUndefined();
+    expect(() => JSON.stringify(sitemap())).not.toThrow();
   });
 });

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -57,19 +57,28 @@ export default function sitemap(): MetadataRoute.Sitemap {
       ogImage({ title: post.title, subtitle: post.description, kind: "Blog" }),
     ],
   }));
-  const benchmarks = getAllReports().map((report) => ({
-    url: `${DOCS_ORIGIN}/benchmarks/${report.slug}`,
-    lastModified: new Date(report.date),
-    changeFrequency: "monthly" as const,
-    priority: 0.75,
-    images: [
-      ogImage({
-        title: report.title,
-        subtitle: report.verdict,
-        kind: "Benchmark",
-      }),
-    ],
-  }));
+  // Exclude `sample` reports (illustrative numbers) so search engines never
+  // index fabricated data. Guard the date: a report whose `date` does not parse
+  // would become an Invalid Date and make Next's serializer throw on
+  // .toISOString(), taking down the entire sitemap.xml.
+  const benchmarks = getAllReports()
+    .filter((report) => !report.sample)
+    .map((report) => {
+      const lastModified = new Date(report.date);
+      return {
+        url: `${DOCS_ORIGIN}/benchmarks/${report.slug}`,
+        ...(Number.isNaN(lastModified.getTime()) ? {} : { lastModified }),
+        changeFrequency: "monthly" as const,
+        priority: 0.75,
+        images: [
+          ogImage({
+            title: report.title,
+            subtitle: report.verdict,
+            kind: "Benchmark",
+          }),
+        ],
+      };
+    });
   const docs = getAllDocPaths().map((docPath) => ({
     url: `${DOCS_ORIGIN}${docPath}`,
     lastModified: new Date(),

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from "next";
 import { getAllPosts } from "@/lib/blog";
+import { getAllReports } from "@/lib/benchmarks";
 import {
   getChangelogLatestModified,
   getChangelogPeriodHref,
@@ -56,6 +57,19 @@ export default function sitemap(): MetadataRoute.Sitemap {
       ogImage({ title: post.title, subtitle: post.description, kind: "Blog" }),
     ],
   }));
+  const benchmarks = getAllReports().map((report) => ({
+    url: `${DOCS_ORIGIN}/benchmarks/${report.slug}`,
+    lastModified: new Date(report.date),
+    changeFrequency: "monthly" as const,
+    priority: 0.75,
+    images: [
+      ogImage({
+        title: report.title,
+        subtitle: report.verdict,
+        kind: "Benchmark",
+      }),
+    ],
+  }));
   const docs = getAllDocPaths().map((docPath) => ({
     url: `${DOCS_ORIGIN}${docPath}`,
     lastModified: new Date(),
@@ -105,6 +119,19 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "weekly",
       priority: 0.8,
       images: [DEFAULT_OG],
+    },
+    {
+      url: `${DOCS_ORIGIN}/benchmarks`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.8,
+      images: [
+        ogImage({
+          title: "AI Agent Benchmarks",
+          subtitle: "New models raced against the field on real agentic tasks",
+          kind: "Benchmark",
+        }),
+      ],
     },
     {
       url: `${DOCS_ORIGIN}/changelog`,
@@ -216,5 +243,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
     ...compare,
     ...docs,
     ...posts,
+    ...benchmarks,
   ];
 }

--- a/web/src/components/marketing/benchmark-scoreboard.test.tsx
+++ b/web/src/components/marketing/benchmark-scoreboard.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { BenchmarkResult } from "@/lib/benchmarks";
+import { BenchmarkScoreboard } from "./benchmark-scoreboard";
+
+const EM_DASH = "—";
+
+function row(overrides: Partial<BenchmarkResult>): BenchmarkResult {
+  return {
+    model: "Model",
+    provider: "Provider",
+    rank: 1,
+    winner: false,
+    composite: 0.5,
+    correctness: 0.5,
+    reliability: 0.5,
+    latency: 0.5,
+    cost: 0.5,
+    costPerCorrectUsd: 0.5,
+    ...overrides,
+  };
+}
+
+describe("BenchmarkScoreboard", () => {
+  it("preserves a sub-cent $/correct instead of flattening to $0.00", () => {
+    const html = renderToStaticMarkup(
+      <BenchmarkScoreboard
+        results={[row({ model: "Frugal", costPerCorrectUsd: 0.0042 })]}
+      />,
+    );
+    // Cell renders the full sub-cent value; the old toFixed(2) path would have
+    // produced exactly "$0.00" in the cell ("$0.0042" trivially contains the
+    // substring "$0.00", so assert on the whole cell, not a substring).
+    expect(html).toContain(">$0.0042</td>");
+    expect(html).not.toContain(">$0.00</td>");
+  });
+
+  it("renders a missing score as an em dash, never NaN", () => {
+    const html = renderToStaticMarkup(
+      <BenchmarkScoreboard results={[row({ composite: null })]} />,
+    );
+    expect(html).not.toContain("NaN");
+    expect(html).toContain(EM_DASH);
+  });
+
+  it("renders the distinct rank each row carries", () => {
+    const html = renderToStaticMarkup(
+      <BenchmarkScoreboard
+        results={[
+          row({ model: "Alpha", rank: 1 }),
+          row({ model: "Bravo", rank: 2 }),
+        ]}
+      />,
+    );
+    // Rank cells render the raw number; both must appear, distinct.
+    expect(html).toContain(">1</td>");
+    expect(html).toContain(">2</td>");
+  });
+});

--- a/web/src/components/marketing/benchmark-scoreboard.tsx
+++ b/web/src/components/marketing/benchmark-scoreboard.tsx
@@ -14,11 +14,23 @@ function formatScore(value: number | null): string {
 
 function formatCost(value: number | null): string {
   if (value === null) return "—";
+  // Cost-per-correct is an absolute dollar amount that can fall below a cent as
+  // models get cheaper; toFixed(2) alone would flatten e.g. 0.0042 to "$0.00".
+  if (value > 0 && value < 0.01) return `$${value.toPrecision(2)}`;
   return `$${value.toFixed(2)}`;
 }
 
+// Restrict columns to numeric (number | null) fields. This excludes string/
+// boolean keys like `model`/`provider`/`winner`, so adding a non-numeric column
+// is a compile error instead of a silent NaN at render time.
+type NumericResultKey = {
+  [K in keyof BenchmarkResult]: BenchmarkResult[K] extends number | null
+    ? K
+    : never;
+}[keyof BenchmarkResult];
+
 type Column = {
-  key: keyof BenchmarkResult;
+  key: NumericResultKey;
   label: string;
   format: (value: number | null) => string;
 };
@@ -98,7 +110,7 @@ export function BenchmarkScoreboard({ results, featuredModel }: Props) {
                     key={col.key}
                     className="px-4 py-3 text-right font-[family-name:var(--font-mono)] text-sm tabular-nums text-white/70"
                   >
-                    {col.format(result[col.key] as number | null)}
+                    {col.format(result[col.key])}
                   </td>
                 ))}
               </tr>

--- a/web/src/components/marketing/benchmark-scoreboard.tsx
+++ b/web/src/components/marketing/benchmark-scoreboard.tsx
@@ -1,0 +1,111 @@
+import type { BenchmarkResult } from "@/lib/benchmarks";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  results: BenchmarkResult[];
+  featuredModel?: string;
+};
+
+// 0–1 score → "NN" on a 0–100 scale, or an em dash when missing.
+function formatScore(value: number | null): string {
+  if (value === null) return "—";
+  return Math.round(value * 100).toString();
+}
+
+function formatCost(value: number | null): string {
+  if (value === null) return "—";
+  return `$${value.toFixed(2)}`;
+}
+
+type Column = {
+  key: keyof BenchmarkResult;
+  label: string;
+  format: (value: number | null) => string;
+};
+
+const COLUMNS: Column[] = [
+  { key: "composite", label: "Composite", format: formatScore },
+  { key: "correctness", label: "Correctness", format: formatScore },
+  { key: "reliability", label: "Reliability", format: formatScore },
+  { key: "latency", label: "Latency", format: formatScore },
+  { key: "cost", label: "Cost", format: formatScore },
+  { key: "costPerCorrectUsd", label: "$/correct", format: formatCost },
+];
+
+export function BenchmarkScoreboard({ results, featuredModel }: Props) {
+  if (results.length === 0) return null;
+
+  return (
+    <div className="w-full overflow-x-auto rounded-xl border border-white/[0.08] bg-white/[0.02]">
+      <table className="w-full min-w-[680px] border-collapse text-left">
+        <thead>
+          <tr className="border-b border-white/[0.08]">
+            <th className="px-4 py-3 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35">
+              #
+            </th>
+            <th className="px-4 py-3 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35">
+              Model
+            </th>
+            {COLUMNS.map((col) => (
+              <th
+                key={col.key}
+                className="px-4 py-3 text-right font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35"
+              >
+                {col.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {results.map((result) => {
+            const isFeatured =
+              !!featuredModel && result.model === featuredModel;
+            return (
+              <tr
+                key={`${result.rank}-${result.model}`}
+                className={cn(
+                  "border-b border-white/[0.05] last:border-b-0 transition-colors",
+                  result.winner ? "bg-white/[0.04]" : "hover:bg-white/[0.02]",
+                )}
+              >
+                <td className="px-4 py-3 font-[family-name:var(--font-mono)] text-sm text-white/45">
+                  {result.rank}
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span
+                      className={cn(
+                        "text-sm font-medium",
+                        isFeatured ? "text-white" : "text-white/85",
+                      )}
+                    >
+                      {result.model}
+                    </span>
+                    {result.winner && (
+                      <span className="rounded-full border border-emerald-400/30 bg-emerald-400/10 px-2 py-0.5 font-[family-name:var(--font-mono)] text-[10px] uppercase tracking-[0.12em] text-emerald-300">
+                        Winner
+                      </span>
+                    )}
+                  </div>
+                  {result.provider && (
+                    <span className="mt-0.5 block text-[11px] text-white/35">
+                      {result.provider}
+                    </span>
+                  )}
+                </td>
+                {COLUMNS.map((col) => (
+                  <td
+                    key={col.key}
+                    className="px-4 py-3 text-right font-[family-name:var(--font-mono)] text-sm tabular-nums text-white/70"
+                  >
+                    {col.format(result[col.key] as number | null)}
+                  </td>
+                ))}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/web/src/components/marketing/json-ld.test.ts
+++ b/web/src/components/marketing/json-ld.test.ts
@@ -6,6 +6,7 @@ import {
   docsPageSchema,
   organizationSchema,
   productSchema,
+  serializeJsonLd,
   SITE_URL,
   websiteSchema,
 } from "./json-ld";
@@ -370,5 +371,34 @@ describe("docsPageSchema freshness dates", () => {
 
     expect(techArticle?.datePublished).toBeUndefined();
     expect(techArticle?.dateModified).toBeUndefined();
+  });
+});
+
+describe("serializeJsonLd", () => {
+  const LS = String.fromCharCode(0x2028);
+  const PS = String.fromCharCode(0x2029);
+
+  it("escapes </script> so author content cannot break out of the tag", () => {
+    const out = serializeJsonLd({
+      "@type": "Dataset",
+      description: "Opus beat </script><script>alert(1)</script> the field",
+    });
+    expect(out).not.toContain("</script>");
+    expect(out).toContain("\\u003c/script>");
+  });
+
+  it("escapes the U+2028 / U+2029 separators", () => {
+    const out = serializeJsonLd({ note: `a${LS}b${PS}c` });
+    expect(out).not.toContain(LS);
+    expect(out).not.toContain(PS);
+    expect(out).toContain("\\u2028");
+    expect(out).toContain("\\u2029");
+  });
+
+  it("leaves ordinary content (including spaces) intact and round-trips", () => {
+    const data = { "@type": "Dataset", name: "a b c </script>", n: 1 };
+    const out = serializeJsonLd(data);
+    expect(out).toContain("a b c"); // spaces must not be corrupted
+    expect(JSON.parse(out)).toEqual(data);
   });
 });

--- a/web/src/components/marketing/json-ld.tsx
+++ b/web/src/components/marketing/json-ld.tsx
@@ -308,6 +308,117 @@ export function blogIndexSchema(
   ];
 }
 
+type BenchmarkReportSchemaInput = {
+  slug: string;
+  title: string;
+  description: string;
+  date: string;
+  author: string;
+  verdict: string;
+  results: Array<{ model: string; provider: string }>;
+};
+
+// A benchmark report carries both an editorial article and a structured
+// comparison. We emit a breadcrumb, a BlogPosting (via articleSchema), and a
+// Dataset node — the Dataset is what makes the head-to-head legible to search
+// and answer engines for "benchmark" intent.
+export function benchmarkReportSchema(
+  report: BenchmarkReportSchemaInput,
+): Record<string, unknown>[] {
+  const url = `${SITE_URL}/benchmarks/${report.slug}`;
+  return [
+    breadcrumbSchema([
+      { name: "Home", url: "/" },
+      { name: "Benchmarks", url: "/benchmarks" },
+      { name: report.title, url: `/benchmarks/${report.slug}` },
+    ]),
+    articleSchema({
+      headline: report.title,
+      description: report.description,
+      url: `/benchmarks/${report.slug}`,
+      datePublished: report.date,
+      authorName: report.author,
+    }),
+    {
+      "@context": "https://schema.org",
+      "@type": "Dataset",
+      name: report.title,
+      description: report.verdict || report.description,
+      url,
+      datePublished: report.date,
+      keywords: [
+        "AI agent benchmark",
+        "LLM agent evaluation",
+        "head-to-head model comparison",
+        ...report.results.map((result) => result.model),
+      ],
+      variableMeasured: [
+        "Composite score",
+        "Correctness",
+        "Reliability",
+        "Latency",
+        "Cost",
+        "Cost per correct answer",
+      ],
+      creator: publisherSchema(),
+      publisher: publisherSchema(),
+    },
+  ];
+}
+
+type BenchmarkIndexReport = {
+  slug: string;
+  title: string;
+  description: string;
+};
+
+export function benchmarkIndexSchema(
+  reports: BenchmarkIndexReport[],
+): Record<string, unknown>[] {
+  const pageUrl = `${SITE_URL}/benchmarks`;
+  const items = reports.map((report) => ({
+    url: `${SITE_URL}/benchmarks/${report.slug}`,
+    title: report.title,
+    description: report.description,
+  }));
+
+  return [
+    breadcrumbSchema([
+      { name: "Home", url: "/" },
+      { name: "Benchmarks", url: "/benchmarks" },
+    ]),
+    {
+      "@context": "https://schema.org",
+      "@type": "CollectionPage",
+      name: "AgentClash Model Benchmarks",
+      description:
+        "Head-to-head AI agent benchmarks — new models raced against the field on real agentic tasks with deterministic, behavioral, and cost scoring.",
+      url: pageUrl,
+      isPartOf: {
+        "@type": "WebSite",
+        name: "AgentClash",
+        url: SITE_URL,
+      },
+      publisher: publisherSchema(),
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "ItemList",
+      name: "AgentClash Model Benchmarks",
+      url: pageUrl,
+      numberOfItems: items.length,
+      itemListElement: items.map((item, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        name: item.title,
+        description: item.description,
+        url: item.url,
+        item: { "@id": item.url },
+      })),
+    },
+  ];
+}
+
 type ChangelogIndexPeriod = {
   id: string;
   label: string;

--- a/web/src/components/marketing/json-ld.tsx
+++ b/web/src/components/marketing/json-ld.tsx
@@ -5,12 +5,26 @@ type Props = {
   data: Record<string, unknown> | Record<string, unknown>[];
 };
 
+// Escape characters that can break out of an inline <script>: a literal
+// `</script>` (or `<`) closes the element early, and U+2028/U+2029 terminate
+// an inline script. Replacing each with its \uXXXX escape keeps the
+// JSON-LD valid. Protects every JsonLd caller, not just benchmarks.
+export function serializeJsonLd(
+  data: Record<string, unknown> | Record<string, unknown>[],
+): string {
+  return JSON.stringify(data).replace(
+    /[<\u2028\u2029]/g,
+    (char) =>
+      "\\u" + char.charCodeAt(0).toString(16).padStart(4, "0"),
+  );
+}
+
 export function JsonLd({ id, data }: Props) {
   return (
     <script
       id={id}
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+      dangerouslySetInnerHTML={{ __html: serializeJsonLd(data) }}
     />
   );
 }

--- a/web/src/components/marketing/marketing-footer.tsx
+++ b/web/src/components/marketing/marketing-footer.tsx
@@ -30,6 +30,7 @@ const COLUMNS: Array<{
   {
     heading: "Company",
     links: [
+      { href: "/benchmarks", label: "Benchmarks" },
       { href: "/blog", label: "Blog" },
       { href: "/changelog", label: "Changelog" },
       { href: "/team", label: "Team" },

--- a/web/src/components/marketing/marketing-header.tsx
+++ b/web/src/components/marketing/marketing-header.tsx
@@ -8,6 +8,7 @@ type NavLink = { href: string; label: string; external?: boolean };
 const DEFAULT_NAV: NavLink[] = [
   { href: "/#features", label: "Features" },
   { href: "/docs", label: "Docs" },
+  { href: "/benchmarks", label: "Benchmarks" },
   { href: "/blog", label: "Blog" },
   { href: "/changelog", label: "Changelog" },
 ];

--- a/web/src/lib/benchmarks.test.ts
+++ b/web/src/lib/benchmarks.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { parseBenchmarkReport } from "./benchmarks";
 
 const VALID = `---
@@ -33,6 +33,18 @@ Body content.
 `;
 
 describe("parseBenchmarkReport", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Parse/validation failures now warn instead of failing silently — keep the
+    // output clean and assert on the warning where it matters.
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
   it("parses valid frontmatter and body", () => {
     const report = parseBenchmarkReport("race-report", VALID);
     expect(report).not.toBeNull();
@@ -94,5 +106,93 @@ Body.
 
   it("returns null for unparseable input", () => {
     expect(parseBenchmarkReport("x", "---\n: : :\n---")).toBeNull();
+  });
+
+  it("warns (instead of silently dropping) when a required field is missing", () => {
+    const missingVerdict = VALID.replace(
+      'verdict: "Opus 4.8 won 4 of 5."\n',
+      "",
+    );
+    expect(parseBenchmarkReport("missing-verdict", missingVerdict)).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("verdict"));
+  });
+
+  it("returns null and warns when the date is non-empty but unparseable", () => {
+    const badDate = VALID.replace('date: "2026-06-06"', 'date: "Q2 2026"');
+    expect(parseBenchmarkReport("bad-date", badDate)).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("date (unparseable"),
+    );
+  });
+
+  it("drops a score outside the 0-1 range and warns, leaving the cell empty", () => {
+    // A common authoring typo: `91` meant `0.91`. Must not render as "9100".
+    const outOfRange = VALID.replace("composite: 0.91", "composite: 91");
+    const report = parseBenchmarkReport("race-report", outOfRange);
+    const opus = report?.results.find((r) => r.model === "Claude Opus 4.8");
+    expect(opus?.composite).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("outside the"));
+  });
+
+  it("keeps costPerCorrectUsd above 1 (a dollar amount, not a 0-1 score)", () => {
+    const pricey = VALID.replace(
+      "costPerCorrectUsd: 0.14",
+      "costPerCorrectUsd: 4.2",
+    );
+    const opus = parseBenchmarkReport("race-report", pricey)?.results.find(
+      (r) => r.model === "Claude Opus 4.8",
+    );
+    expect(opus?.costPerCorrectUsd).toBe(4.2);
+  });
+
+  it("assigns unique sequential ranks when only some rows specify rank", () => {
+    const partial = `---
+title: "R"
+date: "2026-06-06"
+description: "d"
+author: "a"
+featuredModel: "m"
+verdict: "v"
+results:
+  - model: "A"
+    composite: 0.7
+  - model: "B"
+    rank: 1
+    composite: 0.6
+  - model: "C"
+    composite: 0.8
+---
+body
+`;
+    const report = parseBenchmarkReport("partial-ranks", partial);
+    const ranks = report?.results.map((r) => r.rank);
+    expect(ranks).toEqual([1, 2, 3]);
+    expect(new Set(ranks).size).toBe(3);
+    // B (explicit rank 1) leads; A and C (unranked) follow by composite desc.
+    expect(report?.results.map((r) => r.model)).toEqual(["B", "C", "A"]);
+  });
+
+  it("never emits duplicate ranks even when explicit ranks collide", () => {
+    const dup = `---
+title: "R"
+date: "2026-06-06"
+description: "d"
+author: "a"
+featuredModel: "m"
+verdict: "v"
+results:
+  - model: "A"
+    rank: 1
+    composite: 0.5
+  - model: "B"
+    rank: 1
+    composite: 0.9
+---
+body
+`;
+    const ranks = parseBenchmarkReport("dup-ranks", dup)?.results.map(
+      (r) => r.rank,
+    );
+    expect(ranks).toEqual([1, 2]);
   });
 });

--- a/web/src/lib/benchmarks.test.ts
+++ b/web/src/lib/benchmarks.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { parseBenchmarkReport } from "./benchmarks";
+
+const VALID = `---
+title: "Race report"
+date: "2026-06-06"
+description: "A head-to-head race."
+author: "AgentClash"
+featuredModel: "Claude Opus 4.8"
+verdict: "Opus 4.8 won 4 of 5."
+challengePack: "Real-World Agentic Tasks v1"
+sample: true
+runShareUrl: "https://www.agentclash.dev/share/abc"
+tasks:
+  - id: auth-bug
+    name: "Fix the auth bug"
+    summary: "Patch the JWT refresh flow."
+results:
+  - model: "GPT-5.1"
+    provider: "OpenAI"
+    rank: 2
+    composite: 0.86
+    correctness: "0.90"
+  - model: "Claude Opus 4.8"
+    provider: "Anthropic"
+    rank: 1
+    winner: true
+    composite: 0.91
+    costPerCorrectUsd: 0.14
+---
+
+Body content.
+`;
+
+describe("parseBenchmarkReport", () => {
+  it("parses valid frontmatter and body", () => {
+    const report = parseBenchmarkReport("race-report", VALID);
+    expect(report).not.toBeNull();
+    expect(report?.title).toBe("Race report");
+    expect(report?.featuredModel).toBe("Claude Opus 4.8");
+    expect(report?.sample).toBe(true);
+    expect(report?.runShareUrl).toBe("https://www.agentclash.dev/share/abc");
+    expect(report?.tasks).toEqual([
+      {
+        id: "auth-bug",
+        name: "Fix the auth bug",
+        summary: "Patch the JWT refresh flow.",
+      },
+    ]);
+    expect(report?.content.trim()).toBe("Body content.");
+  });
+
+  it("sorts results by rank ascending", () => {
+    const report = parseBenchmarkReport("race-report", VALID);
+    expect(report?.results.map((r) => r.model)).toEqual([
+      "Claude Opus 4.8",
+      "GPT-5.1",
+    ]);
+    expect(report?.results[0].winner).toBe(true);
+    expect(report?.results[1].winner).toBe(false);
+  });
+
+  it("coerces numeric scores and defaults missing ones to null", () => {
+    const report = parseBenchmarkReport("race-report", VALID);
+    const gpt = report?.results.find((r) => r.model === "GPT-5.1");
+    expect(gpt?.correctness).toBe(0.9); // coerced from string
+    expect(gpt?.reliability).toBeNull(); // absent
+    const opus = report?.results.find((r) => r.model === "Claude Opus 4.8");
+    expect(opus?.costPerCorrectUsd).toBe(0.14);
+  });
+
+  it("returns null when a required field is missing", () => {
+    const missingModel = VALID.replace(
+      'featuredModel: "Claude Opus 4.8"\n',
+      "",
+    );
+    expect(parseBenchmarkReport("x", missingModel)).toBeNull();
+  });
+
+  it("returns null when the results array is empty", () => {
+    const noResults = `---
+title: "Race report"
+date: "2026-06-06"
+description: "A head-to-head race."
+author: "AgentClash"
+featuredModel: "Claude Opus 4.8"
+verdict: "Nobody raced."
+results: []
+---
+Body.
+`;
+    expect(parseBenchmarkReport("x", noResults)).toBeNull();
+  });
+
+  it("returns null for unparseable input", () => {
+    expect(parseBenchmarkReport("x", "---\n: : :\n---")).toBeNull();
+  });
+});

--- a/web/src/lib/benchmarks.ts
+++ b/web/src/lib/benchmarks.ts
@@ -80,76 +80,144 @@ function parseTasks(value: unknown): BenchmarkTask[] {
   return tasks;
 }
 
-function parseResults(value: unknown): BenchmarkResult[] {
+// Coerce + range-check a 0–1 score field. A value outside [0,1] is almost always
+// an authoring mistake (e.g. `91` meant `0.91`), so warn and treat it as missing
+// rather than let formatScore render an absurd "9100". Does NOT apply to
+// costPerCorrectUsd (an absolute dollar amount) or rank.
+function score01(
+  value: unknown,
+  field: string,
+  model: string,
+  slug: string,
+): number | null {
+  const parsed = scoreOrNull(value);
+  if (parsed === null) return null;
+  if (parsed < 0 || parsed > 1) {
+    console.warn(
+      `[benchmarks] ${slug}: ${model} ${field}=${parsed} is outside the 0–1 range; treating as missing.`,
+    );
+    return null;
+  }
+  return parsed;
+}
+
+function parseResults(value: unknown, slug: string): BenchmarkResult[] {
   if (!Array.isArray(value)) return [];
-  const results: BenchmarkResult[] = [];
+  const rows: Array<
+    BenchmarkResult & { explicitRank: number | null; order: number }
+  > = [];
   for (const [index, raw] of value.entries()) {
     if (typeof raw !== "object" || raw === null) continue;
     const entry = raw as Record<string, unknown>;
     const model = requiredText(entry.model);
     if (!model) continue;
-    const rankValue = scoreOrNull(entry.rank);
-    results.push({
+    const explicitRank = scoreOrNull(entry.rank);
+    rows.push({
       model,
       provider: optionalText(entry.provider),
-      rank: rankValue === null ? index + 1 : Math.round(rankValue),
+      rank: 0,
       winner: entry.winner === true,
-      composite: scoreOrNull(entry.composite),
-      correctness: scoreOrNull(entry.correctness),
-      reliability: scoreOrNull(entry.reliability),
-      latency: scoreOrNull(entry.latency),
-      cost: scoreOrNull(entry.cost),
+      composite: score01(entry.composite, "composite", model, slug),
+      correctness: score01(entry.correctness, "correctness", model, slug),
+      reliability: score01(entry.reliability, "reliability", model, slug),
+      latency: score01(entry.latency, "latency", model, slug),
+      cost: score01(entry.cost, "cost", model, slug),
       costPerCorrectUsd: scoreOrNull(entry.costPerCorrectUsd),
+      explicitRank: explicitRank === null ? null : Math.round(explicitRank),
+      order: index,
     });
   }
-  results.sort((a, b) => a.rank - b.rank);
-  return results;
+  // Order by explicit rank first (unranked rows last), then composite desc, then
+  // input order — then assign unique sequential 1..N display ranks. Deriving the
+  // "#" from final position (instead of the raw per-row rank) means partial or
+  // duplicate `rank:` values can never collide in the scoreboard.
+  rows.sort((a, b) => {
+    const ar = a.explicitRank ?? Number.POSITIVE_INFINITY;
+    const br = b.explicitRank ?? Number.POSITIVE_INFINITY;
+    if (ar !== br) return ar - br;
+    const ac = a.composite ?? Number.NEGATIVE_INFINITY;
+    const bc = b.composite ?? Number.NEGATIVE_INFINITY;
+    if (ac !== bc) return bc - ac;
+    return a.order - b.order;
+  });
+  return rows.map((row, index) => ({
+    model: row.model,
+    provider: row.provider,
+    rank: index + 1,
+    winner: row.winner,
+    composite: row.composite,
+    correctness: row.correctness,
+    reliability: row.reliability,
+    latency: row.latency,
+    cost: row.cost,
+    costPerCorrectUsd: row.costPerCorrectUsd,
+  }));
 }
 
 export function parseBenchmarkReport(
   slug: string,
   raw: string,
 ): BenchmarkReportWithContent | null {
+  let parsed: ReturnType<typeof matter>;
   try {
-    const { data, content } = matter(raw);
-    const title = requiredText(data.title);
-    const date = requiredText(data.date);
-    const description = requiredText(data.description);
-    const author = requiredText(data.author);
-    const featuredModel = requiredText(data.featuredModel);
-    const verdict = requiredText(data.verdict);
-    const results = parseResults(data.results);
-
-    if (
-      !title ||
-      !date ||
-      !description ||
-      !author ||
-      !featuredModel ||
-      !verdict ||
-      results.length === 0
-    ) {
-      return null;
-    }
-
-    return {
-      slug,
-      title,
-      date,
-      description,
-      author,
-      featuredModel,
-      verdict,
-      challengePack: optionalText(data.challengePack),
-      sample: data.sample === true,
-      runShareUrl: optionalText(data.runShareUrl),
-      tasks: parseTasks(data.tasks),
-      results,
-      content,
-    };
-  } catch {
+    parsed = matter(raw);
+  } catch (error) {
+    console.warn(
+      `[benchmarks] ${slug}.mdx: could not parse frontmatter — skipping.`,
+      error,
+    );
     return null;
   }
+
+  const { data, content } = parsed;
+  const title = requiredText(data.title);
+  const date = requiredText(data.date);
+  const description = requiredText(data.description);
+  const author = requiredText(data.author);
+  const featuredModel = requiredText(data.featuredModel);
+  const verdict = requiredText(data.verdict);
+  const results = parseResults(data.results, slug);
+
+  // Surface authoring mistakes loudly instead of silently dropping the report
+  // (a silent drop makes it vanish from the page, sitemap, RSS, and static
+  // params on a green build). A misspelled/omitted required field — or a date
+  // that does not parse (which would otherwise crash the sitemap) — leaves the
+  // report unpublished, so name exactly what is wrong.
+  const problems: string[] = [];
+  if (!title) problems.push("title");
+  if (!description) problems.push("description");
+  if (!author) problems.push("author");
+  if (!featuredModel) problems.push("featuredModel");
+  if (!verdict) problems.push("verdict");
+  if (results.length === 0) problems.push("results");
+  if (!date) {
+    problems.push("date");
+  } else if (Number.isNaN(new Date(date).getTime())) {
+    problems.push(`date (unparseable: "${date}")`);
+  }
+
+  if (problems.length > 0) {
+    console.warn(
+      `[benchmarks] ${slug}.mdx: skipped — missing or invalid field(s): ${problems.join(", ")}.`,
+    );
+    return null;
+  }
+
+  return {
+    slug,
+    title,
+    date,
+    description,
+    author,
+    featuredModel,
+    verdict,
+    challengePack: optionalText(data.challengePack),
+    sample: data.sample === true,
+    runShareUrl: optionalText(data.runShareUrl),
+    tasks: parseTasks(data.tasks),
+    results,
+    content,
+  };
 }
 
 function readReportBySlug(slug: string): BenchmarkReportWithContent | null {

--- a/web/src/lib/benchmarks.ts
+++ b/web/src/lib/benchmarks.ts
@@ -1,0 +1,193 @@
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+
+const CONTENT_DIR = path.join(process.cwd(), "content", "benchmarks");
+
+// A single task in the head-to-head race (e.g. "Fix the auth bug").
+export type BenchmarkTask = {
+  id: string;
+  name: string;
+  summary: string;
+};
+
+// One model's row on the scoreboard. Scores are 0–1 floats, matching the
+// run-ranking document the backend emits (see backend/internal/api/run_ranking.go).
+export type BenchmarkResult = {
+  model: string;
+  provider: string;
+  rank: number;
+  winner: boolean;
+  composite: number | null;
+  correctness: number | null;
+  reliability: number | null;
+  latency: number | null;
+  cost: number | null;
+  costPerCorrectUsd: number | null;
+};
+
+export type BenchmarkReport = {
+  slug: string;
+  title: string;
+  date: string;
+  description: string;
+  author: string;
+  featuredModel: string;
+  verdict: string;
+  challengePack: string;
+  // True when the scoreboard holds representative/illustrative data rather than
+  // numbers from a real race. Drives the disclaimer banner on the report page.
+  sample: boolean;
+  runShareUrl: string;
+  tasks: BenchmarkTask[];
+  results: BenchmarkResult[];
+};
+
+export type BenchmarkReportWithContent = BenchmarkReport & {
+  content: string;
+};
+
+function requiredText(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function optionalText(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+// Coerce a frontmatter value into a 0–1 score, or null when absent/invalid.
+function scoreOrNull(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function parseTasks(value: unknown): BenchmarkTask[] {
+  if (!Array.isArray(value)) return [];
+  const tasks: BenchmarkTask[] = [];
+  for (const raw of value) {
+    if (typeof raw !== "object" || raw === null) continue;
+    const entry = raw as Record<string, unknown>;
+    const id = requiredText(entry.id);
+    const name = requiredText(entry.name);
+    const summary = requiredText(entry.summary);
+    if (!id || !name) continue;
+    tasks.push({ id, name, summary });
+  }
+  return tasks;
+}
+
+function parseResults(value: unknown): BenchmarkResult[] {
+  if (!Array.isArray(value)) return [];
+  const results: BenchmarkResult[] = [];
+  for (const [index, raw] of value.entries()) {
+    if (typeof raw !== "object" || raw === null) continue;
+    const entry = raw as Record<string, unknown>;
+    const model = requiredText(entry.model);
+    if (!model) continue;
+    const rankValue = scoreOrNull(entry.rank);
+    results.push({
+      model,
+      provider: optionalText(entry.provider),
+      rank: rankValue === null ? index + 1 : Math.round(rankValue),
+      winner: entry.winner === true,
+      composite: scoreOrNull(entry.composite),
+      correctness: scoreOrNull(entry.correctness),
+      reliability: scoreOrNull(entry.reliability),
+      latency: scoreOrNull(entry.latency),
+      cost: scoreOrNull(entry.cost),
+      costPerCorrectUsd: scoreOrNull(entry.costPerCorrectUsd),
+    });
+  }
+  results.sort((a, b) => a.rank - b.rank);
+  return results;
+}
+
+export function parseBenchmarkReport(
+  slug: string,
+  raw: string,
+): BenchmarkReportWithContent | null {
+  try {
+    const { data, content } = matter(raw);
+    const title = requiredText(data.title);
+    const date = requiredText(data.date);
+    const description = requiredText(data.description);
+    const author = requiredText(data.author);
+    const featuredModel = requiredText(data.featuredModel);
+    const verdict = requiredText(data.verdict);
+    const results = parseResults(data.results);
+
+    if (
+      !title ||
+      !date ||
+      !description ||
+      !author ||
+      !featuredModel ||
+      !verdict ||
+      results.length === 0
+    ) {
+      return null;
+    }
+
+    return {
+      slug,
+      title,
+      date,
+      description,
+      author,
+      featuredModel,
+      verdict,
+      challengePack: optionalText(data.challengePack),
+      sample: data.sample === true,
+      runShareUrl: optionalText(data.runShareUrl),
+      tasks: parseTasks(data.tasks),
+      results,
+      content,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function readReportBySlug(slug: string): BenchmarkReportWithContent | null {
+  const filePath = path.join(CONTENT_DIR, `${slug}.mdx`);
+
+  if (!fs.existsSync(filePath)) return null;
+
+  try {
+    return parseBenchmarkReport(slug, fs.readFileSync(filePath, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+function stripContent(report: BenchmarkReportWithContent): BenchmarkReport {
+  const { content: _content, ...meta } = report;
+  void _content;
+  return meta;
+}
+
+export function getAllReports(): BenchmarkReport[] {
+  if (!fs.existsSync(CONTENT_DIR)) return [];
+  const files = fs.readdirSync(CONTENT_DIR).filter((f) => f.endsWith(".mdx"));
+  const reports: BenchmarkReport[] = [];
+
+  for (const filename of files) {
+    const report = readReportBySlug(filename.replace(/\.mdx$/, ""));
+    if (!report) continue;
+    reports.push(stripContent(report));
+  }
+
+  return reports.sort((a, b) => (a.date > b.date ? -1 : 1));
+}
+
+export function getReportBySlug(slug: string): BenchmarkReportWithContent | null {
+  return readReportBySlug(slug);
+}
+
+export function getAllSlugs(): string[] {
+  return getAllReports().map((report) => report.slug);
+}

--- a/web/src/lib/rss.test.ts
+++ b/web/src/lib/rss.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { BlogPost } from "./blog";
-import { buildBlogRssFeed, escapeXml, formatRssDate } from "./rss";
+import type { BenchmarkReport } from "./benchmarks";
+import {
+  buildBenchmarkRssFeed,
+  buildBlogRssFeed,
+  escapeXml,
+  formatRssDate,
+} from "./rss";
 
 const posts = [
   {
@@ -75,5 +81,38 @@ describe("rss feed", () => {
     expect(feed).toContain("<title>Older Post</title>");
     expect(feed).not.toContain("invalid-date");
     expect(feed).not.toContain("missing-title");
+  });
+});
+
+describe("benchmark rss feed", () => {
+  const base = {
+    date: "2026-06-06",
+    description: "Head-to-head race.",
+    author: "AgentClash",
+    featuredModel: "Claude Opus 4.8",
+    verdict: "Opus won.",
+    challengePack: "",
+    runShareUrl: "",
+    tasks: [],
+    results: [],
+  } satisfies Partial<BenchmarkReport>;
+
+  it("excludes sample reports so illustrative numbers are never syndicated", () => {
+    const feed = buildBenchmarkRssFeed("https://example.test", [
+      { ...base, slug: "real-report", title: "Real Report", sample: false },
+      {
+        ...base,
+        slug: "sample-report",
+        title: "Illustrative Sample",
+        sample: true,
+      },
+    ]);
+
+    expect(feed).toContain("<title>Real Report</title>");
+    expect(feed).toContain(
+      "<link>https://example.test/benchmarks/real-report</link>",
+    );
+    expect(feed).not.toContain("sample-report");
+    expect(feed).not.toContain("Illustrative Sample");
   });
 });

--- a/web/src/lib/rss.ts
+++ b/web/src/lib/rss.ts
@@ -128,7 +128,9 @@ export function buildBenchmarkRssFeed(
   origin = SITE_URL,
   reports: BenchmarkReport[] = getAllReports(),
 ) {
+  // Exclude `sample` reports so illustrative numbers are never syndicated.
   const rssReports = reports
+    .filter((report) => !report.sample)
     .map(toRssBenchmark)
     .filter((report) => report !== null)
     .sort((a, b) => b.publishedAtMs - a.publishedAtMs);

--- a/web/src/lib/rss.ts
+++ b/web/src/lib/rss.ts
@@ -1,4 +1,5 @@
 import { getAllPosts, type BlogPost } from "./blog";
+import { getAllReports, type BenchmarkReport } from "./benchmarks";
 
 const SITE_URL = "https://www.agentclash.dev";
 
@@ -93,6 +94,71 @@ export function buildBlogRssFeed(
     `    <link>${escapeXml(blogUrl)}</link>`,
     `    <atom:link href="${escapeXml(feedUrl)}" rel="self" type="application/rss+xml" />`,
     "    <description>Engineering notes on AI agent evaluation, replayable failures, scorecards, and CI regression gates.</description>",
+    "    <language>en</language>",
+    `    <lastBuildDate>${lastBuildDate}</lastBuildDate>`,
+    ...items,
+    "  </channel>",
+    "</rss>",
+  ].join("\n");
+}
+
+function toRssBenchmark(report: BenchmarkReport) {
+  const slug = requiredText(report.slug);
+  const title = requiredText(report.title);
+  const date = requiredText(report.date);
+  const description = requiredText(report.description);
+  const author = requiredText(report.author);
+  const rssDate = parseRssDate(date);
+
+  if (!slug || !title || !date || !description || !author || !rssDate) {
+    return null;
+  }
+
+  return {
+    slug,
+    title,
+    description,
+    author,
+    pubDate: rssDate.toUTCString(),
+    publishedAtMs: rssDate.getTime(),
+  };
+}
+
+export function buildBenchmarkRssFeed(
+  origin = SITE_URL,
+  reports: BenchmarkReport[] = getAllReports(),
+) {
+  const rssReports = reports
+    .map(toRssBenchmark)
+    .filter((report) => report !== null)
+    .sort((a, b) => b.publishedAtMs - a.publishedAtMs);
+  const indexUrl = `${origin}/benchmarks`;
+  const feedUrl = `${origin}/benchmarks/feed.xml`;
+  const lastBuildDate = rssReports[0]?.pubDate ?? new Date().toUTCString();
+
+  const items = rssReports.map((report) => {
+    const url = `${origin}/benchmarks/${report.slug}`;
+
+    return [
+      "    <item>",
+      `      <title>${escapeXml(report.title)}</title>`,
+      `      <link>${escapeXml(url)}</link>`,
+      `      <guid isPermaLink="true">${escapeXml(url)}</guid>`,
+      `      <pubDate>${report.pubDate}</pubDate>`,
+      `      <dc:creator>${escapeXml(report.author)}</dc:creator>`,
+      `      <description>${escapeXml(report.description)}</description>`,
+      "    </item>",
+    ].join("\n");
+  });
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">',
+    "  <channel>",
+    "    <title>AgentClash Model Benchmarks</title>",
+    `    <link>${escapeXml(indexUrl)}</link>`,
+    `    <atom:link href="${escapeXml(feedUrl)}" rel="self" type="application/rss+xml" />`,
+    "    <description>Head-to-head AI agent benchmarks — new models raced against the field on real agentic tasks.</description>",
     "    <language>en</language>",
     `    <lastBuildDate>${lastBuildDate}</lastBuildDate>`,
     ...items,

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -11,6 +11,15 @@ export const blogRssAlternate = {
   ],
 } satisfies AlternateTypes;
 
+export const benchmarkRssAlternate = {
+  "application/rss+xml": [
+    {
+      title: "AgentClash Model Benchmarks",
+      url: "/benchmarks/feed.xml",
+    },
+  ],
+} satisfies AlternateTypes;
+
 // Root-relative URL for the dynamic Open Graph image route (app/og/route.tsx).
 // metadataBase upgrades it to absolute in the rendered OG/Twitter tags, so each
 // page gets a tailored social card instead of one shared static image.


### PR DESCRIPTION
## What & why

AgentClash produces exactly the asset the AI ecosystem shares — head-to-head agent races on real tasks with defensible scoring — but there was no public surface for *publishing* those results as content. This adds a `/benchmarks` section so every major model launch can ship a **"we raced \<new model\> against the field on 5 real agentic tasks — here's who won"** report. High-ROI SEO/distribution that turns product output (races) into shareable, evergreen content, and it's **repeatable** so we can ride each launch (~monthly).

Modeled on the existing **blog** pattern so it reuses proven infra (gray-matter, MDXRemote, dynamic OG cards, JSON-LD, sitemap, RSS, `MarketingShell`) and adds **zero backend changes**.

## The publishing surface

- `web/content/benchmarks/*.mdx` → typed `web/src/lib/benchmarks.ts` → `/benchmarks` (index) + `/benchmarks/[slug]` (report).
- `BenchmarkScoreboard` component — clean ranked table (rank · model/provider · composite · correctness · reliability · latency · cost · $/correct), winner row highlighted, featured model emphasized, responsive.
- Full SEO: tailored OG cards (`kind=Benchmark`), JSON-LD `Article` + **`Dataset`** (high-value for "benchmark" search intent), sitemap entries, a dedicated `/benchmarks/feed.xml` RSS feed, and **Benchmarks** links in the header nav + footer.
- A "sample data" disclaimer banner driven by `sample: true`, and an optional deep-link to the live `/share/[token]` scorecard.

## The repeatable workflow

- `scripts/benchmarks/scaffold.mjs` (Node built-ins, no new deps) — converts a finished run's ranking JSON (the existing `GET .../runs/{id}/ranking`, see `backend/internal/api/run_ranking.go`) into a ready-to-edit MDX with the scoreboard pre-filled and the winner auto-detected.
- `docs/marketing/model-benchmark-workflow.md` — the per-launch runbook (race → export ranking → scaffold → edit → publish → post to X/HN).
- One clearly-labeled **sample** seed report (`claude-opus-4-8-vs-the-field.mdx`) with 5 real agentic tasks (auth bug fix, p99 latency hunt, flaky-test triage, schema migration, log-driven incident RCA).

## Verification

- `npx tsc --noEmit` — clean
- `pnpm lint` — clean (only pre-existing warnings in unrelated files)
- `pnpm build` — green; seed report SSG'd at `/benchmarks/claude-opus-4-8-vs-the-field`, `/benchmarks/feed.xml` built
- Tests: 23 pass across the new + affected suites (`benchmarks.test.ts`, `benchmarks-metadata.test.ts`, `sitemap.test.ts`, `public-canonical-metadata.test.ts`); scaffold smoke-tested end-to-end

## Notes for reviewers

- The `/benchmarks` **index renders dynamically (ƒ)** because `MarketingShell`'s header calls `withAuth` — same behavior as other shell-wrapped pages; detail pages are SSG. Still fully crawlable. Can split the header to make the index fully static if preferred.
- One **pre-existing** test failure in `json-ld.test.ts` (a changelog anchor-vs-path URL mismatch) fails on `main` independent of this change — left untouched as out of scope. Happy to fix separately.

https://claude.ai/code/session_01Rjgy1CuadVwmMf8NuCTtbW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rjgy1CuadVwmMf8NuCTtbW)_