### PR TITLE
feat(web): first-run activation flow, run-loop CTAs, unified breadcrumbs

### DIFF
--- a/web/src/app/(workspace)/workspaces/[workspaceId]/layout.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/layout.tsx
@@ -4,6 +4,7 @@ import { Sidebar } from "@/components/app-shell/sidebar";
 import { TopBar } from "@/components/app-shell/top-bar";
 import { TrialUpgradePrompt } from "@/components/billing/trial-upgrade-prompt";
 import { WorkspaceBillingBanner } from "@/components/billing/workspace-billing-banner";
+import { ActivationBanner } from "@/components/onboarding/activation-banner";
 import { PostHogIdentify } from "@/components/posthog-identify";
 
 export default async function WorkspaceLayout({
@@ -67,6 +68,7 @@ export default async function WorkspaceLayout({
             isOrgAdmin={orgRole === "org_admin"}
           />
           <WorkspaceBillingBanner workspaceId={workspaceId} orgSlug={orgSlug} />
+          <ActivationBanner workspaceId={workspaceId} />
           <main className="flex-1 overflow-y-auto p-6">{children}</main>
         </div>
       </div>

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/replay/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/replay/page.tsx
@@ -1,9 +1,9 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { redirect, notFound } from "next/navigation";
-import Link from "next/link";
 import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";
 import type { Run, RunAgent, ReplayResponse } from "@/lib/api/types";
+import { Breadcrumbs } from "@/components/ui/breadcrumbs";
 import { ReplayViewerClient } from "./replay-viewer-client";
 
 export default async function ReplayPage({
@@ -42,24 +42,14 @@ export default async function ReplayPage({
 
   return (
     <div>
-      {/* Breadcrumb */}
-      <div className="flex items-center gap-3 mb-6 text-[11px] uppercase tracking-[0.14em] font-medium">
-        <Link
-          href={`/workspaces/${workspaceId}/runs`}
-          className="text-white/40 hover:text-white transition-colors"
-        >
-          Runs
-        </Link>
-        <span className="text-white/20">/</span>
-        <Link
-          href={`/workspaces/${workspaceId}/runs/${runId}`}
-          className="text-white/40 hover:text-white transition-colors"
-        >
-          {run.name}
-        </Link>
-        <span className="text-white/20">/</span>
-        <span className="text-white/80">{agent.label} — Replay</span>
-      </div>
+      <Breadcrumbs
+        className="mb-6"
+        entries={[
+          { label: "Runs", href: `/workspaces/${workspaceId}/runs` },
+          { label: run.name, href: `/workspaces/${workspaceId}/runs/${runId}` },
+          { label: `${agent.label} — Replay` },
+        ]}
+      />
 
       <ReplayViewerClient
         initialReplay={replay}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/agents/[runAgentId]/scorecard/page.tsx
@@ -1,9 +1,9 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { redirect, notFound } from "next/navigation";
-import Link from "next/link";
 import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";
 import type { Run, RunAgent, ScorecardResponse } from "@/lib/api/types";
+import { Breadcrumbs } from "@/components/ui/breadcrumbs";
 import { ScorecardClient } from "./scorecard-client";
 
 export default async function ScorecardPage({
@@ -41,24 +41,14 @@ export default async function ScorecardPage({
 
   return (
     <div>
-      {/* Breadcrumb */}
-      <div className="flex items-center gap-2 mb-4 text-sm">
-        <Link
-          href={`/workspaces/${workspaceId}/runs`}
-          className="text-muted-foreground hover:text-foreground transition-colors"
-        >
-          Runs
-        </Link>
-        <span className="text-muted-foreground/40">/</span>
-        <Link
-          href={`/workspaces/${workspaceId}/runs/${runId}`}
-          className="text-muted-foreground hover:text-foreground transition-colors"
-        >
-          {run.name}
-        </Link>
-        <span className="text-muted-foreground/40">/</span>
-        <span className="text-foreground">{agent.label} — Scorecard</span>
-      </div>
+      <Breadcrumbs
+        className="mb-4"
+        entries={[
+          { label: "Runs", href: `/workspaces/${workspaceId}/runs` },
+          { label: run.name, href: `/workspaces/${workspaceId}/runs/${runId}` },
+          { label: `${agent.label} — Scorecard` },
+        ]}
+      />
 
       <ScorecardClient
         initialScorecard={scorecard}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/page.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/[runId]/page.tsx
@@ -1,9 +1,9 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { redirect, notFound } from "next/navigation";
-import Link from "next/link";
 import { createApiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/errors";
 import type { Run, RunAgent } from "@/lib/api/types";
+import { Breadcrumbs } from "@/components/ui/breadcrumbs";
 import { RunDetailClient } from "./run-detail-client";
 
 export default async function RunDetailPage({
@@ -34,17 +34,13 @@ export default async function RunDetailPage({
 
   return (
     <div>
-      {/* Breadcrumb */}
-      <div className="flex items-center gap-3 mb-6 text-[11px] uppercase tracking-[0.14em] font-medium">
-        <Link
-          href={`/workspaces/${workspaceId}/runs`}
-          className="text-white/40 hover:text-white transition-colors"
-        >
-          Runs
-        </Link>
-        <span className="text-white/20">/</span>
-        <span className="text-white/80">{run.name}</span>
-      </div>
+      <Breadcrumbs
+        className="mb-6"
+        entries={[
+          { label: "Runs", href: `/workspaces/${workspaceId}/runs` },
+          { label: run.name },
+        ]}
+      />
 
       <RunDetailClient
         initialRun={run}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.test.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.test.tsx
@@ -128,6 +128,7 @@ vi.mock("@/components/ui/dialog", async () => {
 });
 
 vi.mock("lucide-react", () => ({
+  ArrowUpRight: () => React.createElement("span", null, "arrow-up-right"),
   Headphones: () => React.createElement("span", null, "headphones"),
   Loader2: () => React.createElement("span", null, "loader"),
   Plus: () => React.createElement("span", null, "plus"),

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/create-run-dialog.tsx
@@ -39,20 +39,58 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { toast } from "sonner";
-import { Loader2, Plus } from "lucide-react";
+import Link from "next/link";
+import { ArrowUpRight, Loader2, Plus } from "lucide-react";
 import { captureWebEvent } from "@/lib/analytics/posthog-client";
 import { WEB_EVENTS } from "@/lib/analytics/events";
 
-interface CreateRunDialogProps {
-  workspaceId: string;
+/** Inline link that turns an empty dependency state into a next step. */
+function InlineSetupLink({
+  href,
+  onNavigate,
+  children,
+}: {
+  href: string;
+  onNavigate: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <Link
+      href={href}
+      onClick={onNavigate}
+      className="inline-flex items-center gap-1 font-medium text-foreground underline underline-offset-4 hover:text-foreground/80"
+    >
+      {children}
+      <ArrowUpRight className="size-3.5" />
+    </Link>
+  );
 }
 
-export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
+interface CreateRunDialogProps {
+  workspaceId: string;
+  /** Controlled open state. Falls back to internal state when omitted. */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /** Hide the built-in "New Run" trigger (e.g. when opened from elsewhere). */
+  showTrigger?: boolean;
+}
+
+export function CreateRunDialog({
+  workspaceId,
+  open: controlledOpen,
+  onOpenChange,
+  showTrigger = true,
+}: CreateRunDialogProps) {
   const router = useRouter();
   const { getAccessToken } = useAccessToken();
   const { mutate, mutateMany } = useApiMutator();
 
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = controlledOpen ?? internalOpen;
+  const setOpen = (next: boolean) => {
+    setInternalOpen(next);
+    onOpenChange?.(next);
+  };
   const [name, setName] = useState("");
   const [selectedPackId, setSelectedPackId] = useState("");
   const [selectedVersionId, setSelectedVersionId] = useState("");
@@ -86,7 +124,9 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
   const [suiteCases, setSuiteCases] = useState<Record<string, RegressionCase[]>>(
     {},
   );
-  const [loading, setLoading] = useState(false);
+  // Start true so the dialog's first painted frame shows the loading affordance
+  // rather than flashing the empty-state setup CTAs before loadData() runs.
+  const [loading, setLoading] = useState(true);
   const [loadingInputSets, setLoadingInputSets] = useState(false);
   const [loadingRegression, setLoadingRegression] = useState(false);
   const [regressionLoadError, setRegressionLoadError] = useState<string | null>(
@@ -430,10 +470,12 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger render={<Button size="sm" />}>
-        <Plus data-icon="inline-start" className="size-4" />
-        New Run
-      </DialogTrigger>
+      {showTrigger && (
+        <DialogTrigger render={<Button size="sm" />}>
+          <Plus data-icon="inline-start" className="size-4" />
+          New Run
+        </DialogTrigger>
+      )}
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>New Run</DialogTitle>
@@ -443,6 +485,13 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
         </DialogHeader>
 
         <div className="space-y-4 py-2 max-h-[60vh] overflow-y-auto">
+          {loading && (
+            <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/20 px-3 py-2 text-sm text-muted-foreground">
+              <Loader2 className="size-3.5 animate-spin" />
+              Loading challenge packs and deployments…
+            </div>
+          )}
+
           {/* Name */}
           <div>
             <label className="mb-1.5 block text-sm font-medium">
@@ -482,6 +531,17 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
                 </option>
               ))}
             </select>
+            {!loading && packs.length === 0 && (
+              <p className="mt-1.5 text-sm text-muted-foreground">
+                No challenge packs yet.{" "}
+                <InlineSetupLink
+                  href={`/workspaces/${workspaceId}/challenge-packs`}
+                  onNavigate={() => setOpen(false)}
+                >
+                  Add a challenge pack
+                </InlineSetupLink>
+              </p>
+            )}
           </div>
 
           {/* Pack Version */}
@@ -510,6 +570,17 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
                 </option>
               ))}
             </select>
+            {selectedPackId && runnableVersions.length === 0 && (
+              <p className="mt-1.5 text-sm text-muted-foreground">
+                This pack has no runnable version yet.{" "}
+                <InlineSetupLink
+                  href={`/workspaces/${workspaceId}/challenge-packs/${selectedPackId}`}
+                  onNavigate={() => setOpen(false)}
+                >
+                  Publish a runnable version
+                </InlineSetupLink>
+              </p>
+            )}
           </div>
 
           {selectedVersionIsVoice && selectedVersion && (
@@ -746,7 +817,13 @@ export function CreateRunDialog({ workspaceId }: CreateRunDialogProps) {
               <p className="text-sm text-muted-foreground">Loading...</p>
             ) : deployments.length === 0 ? (
               <p className="text-sm text-muted-foreground">
-                No active deployments — create one first.
+                No active deployments.{" "}
+                <InlineSetupLink
+                  href={`/workspaces/${workspaceId}/deployments`}
+                  onNavigate={() => setOpen(false)}
+                >
+                  Create a deployment
+                </InlineSetupLink>
               </p>
             ) : (
               <div className="space-y-1.5 rounded-lg border border-input p-2 max-h-40 overflow-y-auto">

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/run-list.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/run-list.tsx
@@ -9,6 +9,8 @@ import { workspacePageSizes } from "@/lib/workspace-resource";
 import { WorkspaceListLoading } from "@/components/app-shell/workspace-loading";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
+import { ActivationChecklist } from "@/components/onboarding/activation-checklist";
+import { useWorkspaceReadiness } from "@/lib/workspace-readiness";
 import {
   Table,
   TableBody,
@@ -33,12 +35,19 @@ const POLL_INTERVAL_MS = 5000;
 
 const PAGE_SIZE = workspacePageSizes.runs;
 
-export function RunList({ workspaceId }: { workspaceId: string }) {
+export function RunList({
+  workspaceId,
+  onCreateRun,
+}: {
+  workspaceId: string;
+  onCreateRun?: () => void;
+}) {
   const router = useRouter();
   const [offset, setOffset] = useState(0);
   const [selected, setSelected] = useState<Set<string>>(new Set());
+  const readiness = useWorkspaceReadiness(workspaceId);
 
-  const { data, error, isLoading } = usePaginatedApiQuery<Run>(
+  const { data, error, isLoading, mutate } = usePaginatedApiQuery<Run>(
     `/v1/workspaces/${workspaceId}/runs`,
     { limit: PAGE_SIZE, offset },
     {
@@ -93,18 +102,34 @@ export function RunList({ workspaceId }: { workspaceId: string }) {
 
   if (error) {
     return (
-      <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-4 text-sm text-destructive">
-        Failed to load runs.
+      <div className="flex items-center justify-between gap-3 rounded-lg border border-destructive/20 bg-destructive/5 p-4 text-sm text-destructive">
+        <span>Failed to load runs.</span>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => mutate()}
+        >
+          Retry
+        </Button>
       </div>
     );
   }
 
   if (runs.length === 0 && offset === 0) {
+    // Not yet able to run — guide the user through setup instead of a dead-end.
+    if (!readiness.ready && !readiness.isLoading) {
+      return <ActivationChecklist workspaceId={workspaceId} readiness={readiness} />;
+    }
     return (
       <EmptyState
         icon={<Play className="size-10" />}
         title="No runs yet"
         description="Create a run to benchmark your agent deployments against challenge packs."
+        action={
+          onCreateRun
+            ? { label: "Create your first run", onClick: onCreateRun }
+            : undefined
+        }
       />
     );
   }

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/runs-page-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/runs-page-client.tsx
@@ -15,6 +15,7 @@ export function RunsPageClient({ workspaceId }: { workspaceId: string }) {
     <div>
       <PageHeader
         title="Runs"
+        description="Benchmark single runs and repeated eval sessions against challenge packs."
         actions={
           <>
             <CreateEvalSessionDialog workspaceId={workspaceId} />
@@ -26,9 +27,6 @@ export function RunsPageClient({ workspaceId }: { workspaceId: string }) {
           </>
         }
       />
-      <p className="-mt-4 mb-6 text-sm text-muted-foreground">
-        Benchmark single runs and repeated eval sessions against challenge packs.
-      </p>
 
       <Tabs defaultValue="runs" className="w-full">
         <TabsList variant="line">

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/runs/runs-page-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/runs/runs-page-client.tsx
@@ -1,26 +1,34 @@
 "use client";
 
+import { useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { PageHeader } from "@/components/ui/page-header";
 import { RunList } from "./run-list";
 import { CreateRunDialog } from "./create-run-dialog";
 import { CreateEvalSessionDialog } from "./create-eval-session-dialog";
 import { EvalSessionList } from "./eval-session-list";
 
 export function RunsPageClient({ workspaceId }: { workspaceId: string }) {
+  const [createRunOpen, setCreateRunOpen] = useState(false);
+
   return (
     <div>
-      <div className="mb-6 flex items-center justify-between">
-        <div>
-          <h1 className="text-lg font-semibold tracking-tight">Runs</h1>
-          <p className="mt-0.5 text-sm text-muted-foreground">
-            Benchmark single runs and repeated eval sessions against challenge packs.
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <CreateEvalSessionDialog workspaceId={workspaceId} />
-          <CreateRunDialog workspaceId={workspaceId} />
-        </div>
-      </div>
+      <PageHeader
+        title="Runs"
+        actions={
+          <>
+            <CreateEvalSessionDialog workspaceId={workspaceId} />
+            <CreateRunDialog
+              workspaceId={workspaceId}
+              open={createRunOpen}
+              onOpenChange={setCreateRunOpen}
+            />
+          </>
+        }
+      />
+      <p className="-mt-4 mb-6 text-sm text-muted-foreground">
+        Benchmark single runs and repeated eval sessions against challenge packs.
+      </p>
 
       <Tabs defaultValue="runs" className="w-full">
         <TabsList variant="line">
@@ -29,7 +37,10 @@ export function RunsPageClient({ workspaceId }: { workspaceId: string }) {
         </TabsList>
 
         <TabsContent value="runs" className="pt-4">
-          <RunList workspaceId={workspaceId} />
+          <RunList
+            workspaceId={workspaceId}
+            onCreateRun={() => setCreateRunOpen(true)}
+          />
         </TabsContent>
 
         <TabsContent value="eval-sessions" className="pt-4">

--- a/web/src/components/onboarding/activation-banner.tsx
+++ b/web/src/components/onboarding/activation-banner.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { ArrowRight, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
+import { useWorkspaceReadiness } from "@/lib/workspace-readiness";
+
+function dismissKey(workspaceId: string): string {
+  return `agentclash:activation-dismissed:${workspaceId}`;
+}
+
+/**
+ * Compact, dismissible setup nudge mounted in the workspace shell. Shows only
+ * while the workspace cannot yet create a run, pointing at the next step.
+ */
+export function ActivationBanner({ workspaceId }: { workspaceId: string }) {
+  const { ready, isLoading, nextStep, steps } =
+    useWorkspaceReadiness(workspaceId);
+  // Lazy init reads persisted dismissal once, client-side only. SSR returns
+  // false, but the banner renders null until SWR data loads (post-hydration),
+  // so there is no hydration mismatch.
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    try {
+      return window.localStorage.getItem(dismissKey(workspaceId)) === "1";
+    } catch {
+      return false;
+    }
+  });
+
+  if (isLoading || ready || dismissed || !nextStep) return null;
+
+  const doneCount = steps.filter((s) => s.done).length;
+
+  function handleDismiss() {
+    setDismissed(true);
+    try {
+      window.localStorage.setItem(dismissKey(workspaceId), "1");
+    } catch {
+      // Non-fatal: banner just won't persist its dismissal.
+    }
+  }
+
+  return (
+    <div className="border-b border-white/[0.06] bg-white/[0.03] px-4 py-2">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+        <span className="font-medium text-foreground">Finish setup</span>
+        <span className="tabular-nums">
+          {doneCount}/{steps.length}
+        </span>
+        <span className="text-muted-foreground/60">·</span>
+        <span>
+          Next: <span className="text-foreground">{nextStep.label}</span>
+        </span>
+        <Link
+          href={nextStep.href}
+          className={cn(
+            buttonVariants({ variant: "outline", size: "xs" }),
+            "ml-auto",
+          )}
+        >
+          {nextStep.cta}
+          <ArrowRight data-icon="inline-end" className="size-3" />
+        </Link>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss setup banner"
+          className="rounded p-1 text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/onboarding/activation-checklist.tsx
+++ b/web/src/components/onboarding/activation-checklist.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import Link from "next/link";
+import { CheckCircle2, Circle, ArrowRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
+import {
+  useWorkspaceReadiness,
+  type ReadinessStep,
+  type WorkspaceReadiness,
+} from "@/lib/workspace-readiness";
+
+interface ActivationChecklistProps {
+  workspaceId: string;
+  /** Pass a shared readiness result to avoid duplicate fetches. */
+  readiness?: WorkspaceReadiness;
+  className?: string;
+}
+
+/**
+ * Full "get to your first run" checklist, shown in the runs empty state while a
+ * workspace is not yet ready. Mirrors the CLI `quickstart` next-step model.
+ */
+export function ActivationChecklist({
+  workspaceId,
+  readiness,
+  className,
+}: ActivationChecklistProps) {
+  const fallback = useWorkspaceReadiness(workspaceId);
+  const { steps, nextStep } = readiness ?? fallback;
+  const doneCount = steps.filter((s) => s.done).length;
+
+  return (
+    <div
+      className={cn(
+        "mx-auto w-full max-w-xl rounded-xl border border-border bg-white/[0.02] p-6",
+        className,
+      )}
+    >
+      <div className="mb-1 flex items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold text-foreground">
+          Get to your first run
+        </h3>
+        <span className="text-xs text-muted-foreground">
+          {doneCount} of {steps.length} done
+        </span>
+      </div>
+      <p className="mb-5 text-sm text-muted-foreground">
+        A few one-time steps connect your models and agents. Knock these out and
+        you can race.
+      </p>
+
+      <ol className="space-y-1">
+        {steps.map((step) => (
+          <ChecklistRow
+            key={step.key}
+            step={step}
+            isNext={nextStep?.key === step.key}
+          />
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+function ChecklistRow({
+  step,
+  isNext,
+}: {
+  step: ReadinessStep;
+  isNext: boolean;
+}) {
+  return (
+    <li
+      className={cn(
+        "flex items-start gap-3 rounded-lg px-3 py-2.5 transition-colors",
+        isNext && "bg-white/[0.03] ring-1 ring-white/[0.06]",
+      )}
+    >
+      <span className="mt-0.5 shrink-0">
+        {step.done ? (
+          <CheckCircle2 className="size-4 text-foreground" />
+        ) : (
+          <Circle
+            className={cn(
+              "size-4",
+              isNext ? "text-foreground" : "text-muted-foreground/50",
+            )}
+          />
+        )}
+      </span>
+      <div className="min-w-0 flex-1">
+        <p
+          className={cn(
+            "text-sm font-medium",
+            step.done
+              ? "text-muted-foreground line-through decoration-muted-foreground/40"
+              : "text-foreground",
+          )}
+        >
+          {step.label}
+        </p>
+        {!step.done && (
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {step.description}
+          </p>
+        )}
+      </div>
+      {isNext && (
+        <Link
+          href={step.href}
+          className={cn(buttonVariants({ variant: "default", size: "sm" }), "shrink-0")}
+        >
+          {step.cta}
+          <ArrowRight data-icon="inline-end" className="size-3.5" />
+        </Link>
+      )}
+    </li>
+  );
+}

--- a/web/src/components/ui/breadcrumbs.tsx
+++ b/web/src/components/ui/breadcrumbs.tsx
@@ -1,0 +1,50 @@
+import { Fragment } from "react";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+
+export interface BreadcrumbEntry {
+  label: string;
+  href?: string;
+}
+
+/**
+ * Single breadcrumb implementation shared across the app. Replaces the
+ * previously hand-rolled, inconsistent breadcrumbs on run / scorecard / replay
+ * pages so every trail looks and behaves the same.
+ */
+export function Breadcrumbs({
+  entries,
+  className,
+}: {
+  entries: BreadcrumbEntry[];
+  className?: string;
+}) {
+  if (entries.length === 0) return null;
+  return (
+    <Breadcrumb className={className}>
+      <BreadcrumbList>
+        {entries.map((crumb, i) => {
+          const isLast = i === entries.length - 1;
+          return (
+            <Fragment key={`${crumb.label}-${i}`}>
+              <BreadcrumbItem>
+                {isLast || !crumb.href ? (
+                  <BreadcrumbPage>{crumb.label}</BreadcrumbPage>
+                ) : (
+                  <BreadcrumbLink href={crumb.href}>{crumb.label}</BreadcrumbLink>
+                )}
+              </BreadcrumbItem>
+              {!isLast && <BreadcrumbSeparator />}
+            </Fragment>
+          );
+        })}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/web/src/components/ui/empty-state.tsx
+++ b/web/src/components/ui/empty-state.tsx
@@ -1,14 +1,21 @@
 import type { ReactNode } from "react";
+import Link from "next/link";
 import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 
 interface EmptyStateProps {
   icon?: ReactNode;
   title: string;
   description?: string;
+  /**
+   * Optional primary action. Provide `onClick` for in-page actions (e.g. open a
+   * dialog) or `href` to route the user to a prerequisite page so empty states
+   * never become dead-ends.
+   */
   action?: {
     label: string;
-    onClick: () => void;
+    onClick?: () => void;
+    href?: string;
   };
   className?: string;
 }
@@ -36,16 +43,24 @@ export function EmptyState({
           {description}
         </p>
       )}
-      {action && (
-        <Button
-          variant="outline"
-          size="sm"
-          className="mt-4"
-          onClick={action.onClick}
-        >
-          {action.label}
-        </Button>
-      )}
+      {action &&
+        (action.href ? (
+          <Link
+            href={action.href}
+            className={cn(buttonVariants({ variant: "outline", size: "sm" }), "mt-4")}
+          >
+            {action.label}
+          </Link>
+        ) : (
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-4"
+            onClick={action.onClick}
+          >
+            {action.label}
+          </Button>
+        ))}
     </div>
   );
 }

--- a/web/src/components/ui/page-header.tsx
+++ b/web/src/components/ui/page-header.tsx
@@ -1,19 +1,8 @@
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
-import { Fragment } from "react";
+import { Breadcrumbs, type BreadcrumbEntry } from "@/components/ui/breadcrumbs";
 
-export interface BreadcrumbEntry {
-  label: string;
-  href?: string;
-}
+export type { BreadcrumbEntry };
 
 interface PageHeaderProps {
   title: string;
@@ -31,27 +20,7 @@ export function PageHeader({
   return (
     <div className={cn("flex flex-col gap-2 pb-6", className)}>
       {breadcrumbs && breadcrumbs.length > 0 && (
-        <Breadcrumb>
-          <BreadcrumbList>
-            {breadcrumbs.map((crumb, i) => {
-              const isLast = i === breadcrumbs.length - 1;
-              return (
-                <Fragment key={crumb.label}>
-                  <BreadcrumbItem>
-                    {isLast || !crumb.href ? (
-                      <BreadcrumbPage>{crumb.label}</BreadcrumbPage>
-                    ) : (
-                      <BreadcrumbLink href={crumb.href}>
-                        {crumb.label}
-                      </BreadcrumbLink>
-                    )}
-                  </BreadcrumbItem>
-                  {!isLast && <BreadcrumbSeparator />}
-                </Fragment>
-              );
-            })}
-          </BreadcrumbList>
-        </Breadcrumb>
+        <Breadcrumbs entries={breadcrumbs} />
       )}
       <div className="flex items-center justify-between gap-4">
         <h1 className="text-lg font-semibold tracking-tight">{title}</h1>

--- a/web/src/components/ui/page-header.tsx
+++ b/web/src/components/ui/page-header.tsx
@@ -6,6 +6,7 @@ export type { BreadcrumbEntry };
 
 interface PageHeaderProps {
   title: string;
+  description?: ReactNode;
   breadcrumbs?: BreadcrumbEntry[];
   actions?: ReactNode;
   className?: string;
@@ -13,6 +14,7 @@ interface PageHeaderProps {
 
 export function PageHeader({
   title,
+  description,
   breadcrumbs,
   actions,
   className,
@@ -26,6 +28,9 @@ export function PageHeader({
         <h1 className="text-lg font-semibold tracking-tight">{title}</h1>
         {actions && <div className="flex items-center gap-2">{actions}</div>}
       </div>
+      {description && (
+        <p className="text-sm text-muted-foreground">{description}</p>
+      )}
     </div>
   );
 }

--- a/web/src/lib/workspace-readiness.test.tsx
+++ b/web/src/lib/workspace-readiness.test.tsx
@@ -1,0 +1,162 @@
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AgentDeployment, ChallengePack } from "@/lib/api/types";
+import { useWorkspaceReadiness } from "./workspace-readiness";
+
+// Controllable per-endpoint SWR state.
+const { state } = vi.hoisted(() => ({
+  state: {
+    providers: [] as unknown[],
+    deployments: [] as Partial<AgentDeployment>[],
+    packs: [] as Partial<ChallengePack>[],
+    runsTotal: 0,
+    loading: false,
+  },
+}));
+
+vi.mock("@/lib/api/swr", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api/swr")>();
+  return {
+    ...actual,
+    useApiListQuery: (path: string) => {
+      const items = path.endsWith("/provider-accounts")
+        ? state.providers
+        : path.endsWith("/agent-deployments")
+          ? state.deployments
+          : path.endsWith("/challenge-packs")
+            ? state.packs
+            : [];
+      return {
+        data: state.loading ? undefined : { items },
+        isLoading: state.loading,
+        error: null,
+        mutate: vi.fn(),
+      };
+    },
+    usePaginatedApiQuery: () => ({
+      data: state.loading
+        ? undefined
+        : { items: [], total: state.runsTotal, limit: 1, offset: 0 },
+      isLoading: state.loading,
+      error: null,
+      mutate: vi.fn(),
+    }),
+  };
+});
+
+// Render readiness to the DOM and read it back (avoids mutating outer scope
+// from inside the component, matching the repo's other hook tests).
+function Harness() {
+  const r = useWorkspaceReadiness("ws_1");
+  return React.createElement(
+    "div",
+    { "data-testid": "out" },
+    JSON.stringify({
+      ready: r.ready,
+      allComplete: r.allComplete,
+      nextStep: r.nextStep?.key ?? null,
+      isLoading: r.isLoading,
+      done: r.steps.map((s) => s.done),
+    }),
+  );
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+interface Snapshot {
+  ready: boolean;
+  allComplete: boolean;
+  nextStep: string | null;
+  isLoading: boolean;
+  done: boolean[];
+}
+
+function render(): Snapshot {
+  act(() => {
+    root.render(React.createElement(Harness));
+  });
+  const text = container.querySelector("[data-testid=out]")?.textContent ?? "{}";
+  return JSON.parse(text) as Snapshot;
+}
+
+beforeEach(() => {
+  state.providers = [];
+  state.deployments = [];
+  state.packs = [];
+  state.runsTotal = 0;
+  state.loading = false;
+  container = document.createElement("div");
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+});
+
+const runnablePack: Partial<ChallengePack> = {
+  id: "p1",
+  versions: [{ lifecycle_status: "runnable" } as ChallengePack["versions"][number]],
+};
+const activeDeployment: Partial<AgentDeployment> = { id: "d1", status: "active" };
+
+describe("useWorkspaceReadiness", () => {
+  it("orders the chain from a fresh workspace", () => {
+    const r = render();
+    expect(r.ready).toBe(false);
+    expect(r.allComplete).toBe(false);
+    expect(r.nextStep).toBe("provider");
+    expect(r.done).toEqual([false, false, false, false]);
+  });
+
+  it("advances to deployment once a provider exists", () => {
+    state.providers = [{ id: "pa1" }];
+    const r = render();
+    expect(r.nextStep).toBe("deployment");
+    expect(r.done[0]).toBe(true);
+  });
+
+  it("does not count a non-active deployment", () => {
+    state.providers = [{ id: "pa1" }];
+    state.deployments = [{ id: "d1", status: "paused" }];
+    const r = render();
+    expect(r.nextStep).toBe("deployment");
+  });
+
+  it("does not count a pack without a runnable version", () => {
+    state.providers = [{ id: "pa1" }];
+    state.deployments = [activeDeployment];
+    state.packs = [{ id: "p1", versions: [] }];
+    const r = render();
+    expect(r.nextStep).toBe("challenge_pack");
+    expect(r.ready).toBe(false);
+  });
+
+  it("is ready to run with provider + active deployment + runnable pack", () => {
+    state.providers = [{ id: "pa1" }];
+    state.deployments = [activeDeployment];
+    state.packs = [runnablePack];
+    const r = render();
+    expect(r.ready).toBe(true);
+    expect(r.allComplete).toBe(false);
+    expect(r.nextStep).toBe("first_run");
+  });
+
+  it("is fully complete once a run exists", () => {
+    state.providers = [{ id: "pa1" }];
+    state.deployments = [activeDeployment];
+    state.packs = [runnablePack];
+    state.runsTotal = 1;
+    const r = render();
+    expect(r.allComplete).toBe(true);
+    expect(r.nextStep).toBeNull();
+  });
+
+  it("reports loading while data is in flight", () => {
+    state.loading = true;
+    const r = render();
+    expect(r.isLoading).toBe(true);
+  });
+});

--- a/web/src/lib/workspace-readiness.ts
+++ b/web/src/lib/workspace-readiness.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import { useCallback, useMemo } from "react";
 import { useApiListQuery, usePaginatedApiQuery } from "@/lib/api/swr";
 import type {
   AgentDeployment,
@@ -45,16 +44,13 @@ export interface WorkspaceReadiness {
   nextStep: ReadinessStep | null;
   isLoading: boolean;
   error: boolean;
-  refresh: () => void;
 }
 
 function hasRunnableVersion(pack: ChallengePack): boolean {
   return (pack.versions ?? []).some((v) => v.lifecycle_status === "runnable");
 }
 
-export function useWorkspaceReadiness(
-  workspaceId: string,
-): WorkspaceReadiness {
+export function useWorkspaceReadiness(workspaceId: string): WorkspaceReadiness {
   const providers = useApiListQuery<ProviderAccount>(
     `/v1/workspaces/${workspaceId}/provider-accounts`,
   );
@@ -65,90 +61,70 @@ export function useWorkspaceReadiness(
     `/v1/workspaces/${workspaceId}/challenge-packs`,
   );
   // Only need to know whether *any* run exists.
-  const runs = usePaginatedApiQuery<Run>(
-    `/v1/workspaces/${workspaceId}/runs`,
-    { limit: 1, offset: 0 },
+  const runs = usePaginatedApiQuery<Run>(`/v1/workspaces/${workspaceId}/runs`, {
+    limit: 1,
+    offset: 0,
+  });
+
+  // No manual memoization: this project's React Compiler lint owns memoization,
+  // and the returned object is cheap to recompute (no consumer keys on its
+  // identity). SWR dedupes the underlying requests across every caller.
+  const hasProvider = (providers.data?.items.length ?? 0) > 0;
+  const hasDeployment = (deployments.data?.items ?? []).some(
+    (d) => d.status === "active",
+  );
+  const hasRunnablePack = (packs.data?.items ?? []).some(hasRunnableVersion);
+  const hasRun = (runs.data?.total ?? 0) > 0;
+
+  const steps: ReadinessStep[] = [
+    {
+      key: "provider",
+      label: "Connect a provider",
+      description:
+        "Add an LLM provider account so your agents can call models.",
+      href: `/workspaces/${workspaceId}/provider-accounts`,
+      cta: "Add provider",
+      done: hasProvider,
+    },
+    {
+      key: "deployment",
+      label: "Deploy an agent",
+      description: "Create an agent deployment to compete in your evals.",
+      href: `/workspaces/${workspaceId}/deployments`,
+      cta: "Create deployment",
+      done: hasDeployment,
+    },
+    {
+      key: "challenge_pack",
+      label: "Add a challenge pack",
+      description:
+        "Publish a challenge pack with a runnable version to benchmark against.",
+      href: `/workspaces/${workspaceId}/challenge-packs`,
+      cta: "Add challenge pack",
+      done: hasRunnablePack,
+    },
+    {
+      key: "first_run",
+      label: "Run your first eval",
+      description: "Race your deployments against a challenge pack.",
+      href: `/workspaces/${workspaceId}/runs`,
+      cta: "Create run",
+      done: hasRun,
+    },
+  ];
+
+  const ready = hasProvider && hasDeployment && hasRunnablePack;
+  const allComplete = ready && hasRun;
+  const nextStep = steps.find((s) => !s.done) ?? null;
+
+  const isLoading =
+    (providers.isLoading && !providers.data) ||
+    (deployments.isLoading && !deployments.data) ||
+    (packs.isLoading && !packs.data) ||
+    (runs.isLoading && !runs.data);
+  const error = Boolean(
+    providers.error || deployments.error || packs.error || runs.error,
   );
 
-  const refresh = useCallback(() => {
-    void providers.mutate();
-    void deployments.mutate();
-    void packs.mutate();
-    void runs.mutate();
-  }, [providers, deployments, packs, runs]);
-
-  return useMemo<WorkspaceReadiness>(() => {
-    const hasProvider = (providers.data?.items.length ?? 0) > 0;
-    const hasDeployment = (deployments.data?.items ?? []).some(
-      (d) => d.status === "active",
-    );
-    const hasRunnablePack = (packs.data?.items ?? []).some(hasRunnableVersion);
-    const hasRun = (runs.data?.total ?? 0) > 0;
-
-    const steps: ReadinessStep[] = [
-      {
-        key: "provider",
-        label: "Connect a provider",
-        description: "Add an LLM provider account so your agents can call models.",
-        href: `/workspaces/${workspaceId}/provider-accounts`,
-        cta: "Add provider",
-        done: hasProvider,
-      },
-      {
-        key: "deployment",
-        label: "Deploy an agent",
-        description: "Create an agent deployment to compete in your evals.",
-        href: `/workspaces/${workspaceId}/deployments`,
-        cta: "Create deployment",
-        done: hasDeployment,
-      },
-      {
-        key: "challenge_pack",
-        label: "Add a challenge pack",
-        description:
-          "Publish a challenge pack with a runnable version to benchmark against.",
-        href: `/workspaces/${workspaceId}/challenge-packs`,
-        cta: "Add challenge pack",
-        done: hasRunnablePack,
-      },
-      {
-        key: "first_run",
-        label: "Run your first eval",
-        description: "Race your deployments against a challenge pack.",
-        href: `/workspaces/${workspaceId}/runs`,
-        cta: "Create run",
-        done: hasRun,
-      },
-    ];
-
-    const ready = hasProvider && hasDeployment && hasRunnablePack;
-    const allComplete = ready && hasRun;
-    const nextStep = steps.find((s) => !s.done) ?? null;
-
-    const isLoading =
-      (providers.isLoading && !providers.data) ||
-      (deployments.isLoading && !deployments.data) ||
-      (packs.isLoading && !packs.data) ||
-      (runs.isLoading && !runs.data);
-    const error = Boolean(
-      providers.error || deployments.error || packs.error || runs.error,
-    );
-
-    return { steps, ready, allComplete, nextStep, isLoading, error, refresh };
-  }, [
-    workspaceId,
-    providers.data,
-    providers.isLoading,
-    providers.error,
-    deployments.data,
-    deployments.isLoading,
-    deployments.error,
-    packs.data,
-    packs.isLoading,
-    packs.error,
-    runs.data,
-    runs.isLoading,
-    runs.error,
-    refresh,
-  ]);
+  return { steps, ready, allComplete, nextStep, isLoading, error };
 }

--- a/web/src/lib/workspace-readiness.ts
+++ b/web/src/lib/workspace-readiness.ts
@@ -1,0 +1,154 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { useApiListQuery, usePaginatedApiQuery } from "@/lib/api/swr";
+import type {
+  AgentDeployment,
+  ChallengePack,
+  ProviderAccount,
+  Run,
+} from "@/lib/api/types";
+
+/**
+ * Web-side mirror of the CLI `agentclash quickstart` readiness model
+ * (see cli/cmd/quickstart.go). There is no backend readiness endpoint, so we
+ * compose readiness client-side from the same list endpoints the rest of the
+ * app already uses.
+ *
+ * The ordered chain a brand-new workspace must complete before it can run an
+ * eval: connect a provider -> deploy an agent -> add a challenge pack -> run.
+ * (Agent builds are folded into the deploy step: a build is only meaningful as
+ * an input to a deployment, so surfacing it separately is friction, not signal.)
+ */
+export type ReadinessStepKey =
+  | "provider"
+  | "deployment"
+  | "challenge_pack"
+  | "first_run";
+
+export interface ReadinessStep {
+  key: ReadinessStepKey;
+  label: string;
+  description: string;
+  href: string;
+  cta: string;
+  done: boolean;
+}
+
+export interface WorkspaceReadiness {
+  steps: ReadinessStep[];
+  /** True once a run can be created (provider + deployment + challenge pack). */
+  ready: boolean;
+  /** True once every step — including the first run — is complete. */
+  allComplete: boolean;
+  /** The first incomplete step, or null when allComplete. */
+  nextStep: ReadinessStep | null;
+  isLoading: boolean;
+  error: boolean;
+  refresh: () => void;
+}
+
+function hasRunnableVersion(pack: ChallengePack): boolean {
+  return (pack.versions ?? []).some((v) => v.lifecycle_status === "runnable");
+}
+
+export function useWorkspaceReadiness(
+  workspaceId: string,
+): WorkspaceReadiness {
+  const providers = useApiListQuery<ProviderAccount>(
+    `/v1/workspaces/${workspaceId}/provider-accounts`,
+  );
+  const deployments = useApiListQuery<AgentDeployment>(
+    `/v1/workspaces/${workspaceId}/agent-deployments`,
+  );
+  const packs = useApiListQuery<ChallengePack>(
+    `/v1/workspaces/${workspaceId}/challenge-packs`,
+  );
+  // Only need to know whether *any* run exists.
+  const runs = usePaginatedApiQuery<Run>(
+    `/v1/workspaces/${workspaceId}/runs`,
+    { limit: 1, offset: 0 },
+  );
+
+  const refresh = useCallback(() => {
+    void providers.mutate();
+    void deployments.mutate();
+    void packs.mutate();
+    void runs.mutate();
+  }, [providers, deployments, packs, runs]);
+
+  return useMemo<WorkspaceReadiness>(() => {
+    const hasProvider = (providers.data?.items.length ?? 0) > 0;
+    const hasDeployment = (deployments.data?.items ?? []).some(
+      (d) => d.status === "active",
+    );
+    const hasRunnablePack = (packs.data?.items ?? []).some(hasRunnableVersion);
+    const hasRun = (runs.data?.total ?? 0) > 0;
+
+    const steps: ReadinessStep[] = [
+      {
+        key: "provider",
+        label: "Connect a provider",
+        description: "Add an LLM provider account so your agents can call models.",
+        href: `/workspaces/${workspaceId}/provider-accounts`,
+        cta: "Add provider",
+        done: hasProvider,
+      },
+      {
+        key: "deployment",
+        label: "Deploy an agent",
+        description: "Create an agent deployment to compete in your evals.",
+        href: `/workspaces/${workspaceId}/deployments`,
+        cta: "Create deployment",
+        done: hasDeployment,
+      },
+      {
+        key: "challenge_pack",
+        label: "Add a challenge pack",
+        description:
+          "Publish a challenge pack with a runnable version to benchmark against.",
+        href: `/workspaces/${workspaceId}/challenge-packs`,
+        cta: "Add challenge pack",
+        done: hasRunnablePack,
+      },
+      {
+        key: "first_run",
+        label: "Run your first eval",
+        description: "Race your deployments against a challenge pack.",
+        href: `/workspaces/${workspaceId}/runs`,
+        cta: "Create run",
+        done: hasRun,
+      },
+    ];
+
+    const ready = hasProvider && hasDeployment && hasRunnablePack;
+    const allComplete = ready && hasRun;
+    const nextStep = steps.find((s) => !s.done) ?? null;
+
+    const isLoading =
+      (providers.isLoading && !providers.data) ||
+      (deployments.isLoading && !deployments.data) ||
+      (packs.isLoading && !packs.data) ||
+      (runs.isLoading && !runs.data);
+    const error = Boolean(
+      providers.error || deployments.error || packs.error || runs.error,
+    );
+
+    return { steps, ready, allComplete, nextStep, isLoading, error, refresh };
+  }, [
+    workspaceId,
+    providers.data,
+    providers.isLoading,
+    providers.error,
+    deployments.data,
+    deployments.isLoading,
+    deployments.error,
+    packs.data,
+    packs.isLoading,
+    packs.error,
+    runs.data,
+    runs.isLoading,
+    runs.error,
+    refresh,
+  ]);
+}


### PR DESCRIPTION
## Context

The web app has the features but the UX undersells them. A product-design pass over the authenticated journey surfaced one structural gap and some polish debt. This PR keeps the current dark aesthetic and design system — no re-skin. Scope: **activation/first-run**, **core-loop UX**, **consistency**. (IA/nav restructuring intentionally out of scope.)

## What changed

### Activation / first-run (the highest-leverage gap)
A brand-new user finishes onboarding and lands on *"No runs yet"* — but to run anything they first need a provider account → deployment → published challenge pack. Nothing guided that chain (the CLI's `quickstart`/`doctor` did; the web had no equivalent).

- **`useWorkspaceReadiness`** (`web/src/lib/workspace-readiness.ts`) — mirrors the CLI `quickstart` model, composing readiness from existing list endpoints. No backend change.
- **`ActivationChecklist`** — replaces the inert runs empty state when the workspace can't yet run, with a current-step highlight + CTA.
- **`ActivationBanner`** — compact, dismissible setup nudge in the workspace shell while `!ready` (persists dismissal per workspace).
- **`EmptyState`** gains an optional `href` action so empty states route to prerequisites instead of dead-ending.

### Core-loop UX
- New Run dialog's "no packs / no deployments / no runnable version" states now **link to the page that fixes them**; added an initial loading affordance and init `loading: true` to avoid a one-frame CTA flash on open.
- Run-list fetch errors now offer **Retry**.

### Consistency
- Unified the **three** hand-rolled breadcrumb implementations (run detail, scorecard, replay) onto a shared `ui/breadcrumbs` component that `PageHeader` also reuses — removes the scattered `text-white/NN` opacity in those trails.
- Runs page adopts `PageHeader`.

## Deliberately *not* done
- **Status-badge map consolidation** — the ~10 "local" maps are different domain enums (build status vs pack lifecycle vs member roles), render identical `Badge`s, and aren't user-visible. Forcing them into one file is churn without payoff.
- **Scorecard/replay pending state** — already handled in-code (pending banners + polling); no change needed.

## Verification
- `tsc --noEmit`: clean · `pnpm lint`: clean · `pnpm build`: ✓ (137 pages) · `pnpm test`: **403 pass** (+7 new `useWorkspaceReadiness` unit tests; dialog/run-list tests updated).
- One pre-existing, unrelated failure remains on `main`: `marketing/json-ld.test.ts` (changelog SEO schema) — fails independently of this branch.
- Live browser dogfooding of the authenticated activation flow requires the full local stack (Postgres + Temporal + API + worker + seeded workspace); the core logic is covered by unit tests instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)