### PR TITLE
fix(auth): repair WorkOS login callback and session issuer

### DIFF
--- a/backend/internal/api/auth_workos.go
+++ b/backend/internal/api/auth_workos.go
@@ -65,7 +65,7 @@ type WorkOSAuthenticatorConfig struct {
 	// ClientID is the WorkOS client ID (e.g. "client_01...").
 	ClientID string
 	// Issuer is the expected JWT issuer.
-	// Defaults to "https://api.workos.com/user_management/{ClientID}".
+	// Defaults to "https://api.workos.com".
 	// Set to your custom auth domain if configured in WorkOS.
 	Issuer string
 }
@@ -75,7 +75,7 @@ func NewWorkOSAuthenticator(cfg WorkOSAuthenticatorConfig, repo UserRepository, 
 	jwksURL := "https://api.workos.com/sso/jwks/" + cfg.ClientID
 	issuer := cfg.Issuer
 	if issuer == "" {
-		issuer = defaultWorkOSIssuer + "/user_management/" + cfg.ClientID
+		issuer = defaultWorkOSIssuer
 	}
 	return newWorkOSAuthenticator(jwksURL, cfg.ClientID, issuer, repo, logger)
 }

--- a/backend/internal/api/auth_workos_test.go
+++ b/backend/internal/api/auth_workos_test.go
@@ -1116,3 +1116,48 @@ func TestWorkOSAuthenticator_CustomIssuer(t *testing.T) {
 		t.Fatal("expected error for token with default issuer when custom issuer is configured")
 	}
 }
+
+func TestWorkOSAuthenticator_DefaultIssuerFromConfig(t *testing.T) {
+	privKey, jwksServer := testJWKS(t)
+
+	repo := stubUserRepo{
+		user: repository.User{
+			ID:           uuid.New(),
+			WorkOSUserID: "user_01ABC",
+			Email:        "test@example.com",
+		},
+		memberships: []repository.WorkspaceMembershipRow{},
+	}
+
+	cfg := WorkOSAuthenticatorConfig{ClientID: "test-client"}
+	issuer := cfg.Issuer
+	if issuer == "" {
+		issuer = defaultWorkOSIssuer
+	}
+	if issuer != "https://api.workos.com" {
+		t.Fatalf("default issuer = %q, want %q", issuer, defaultWorkOSIssuer)
+	}
+
+	auth, err := newWorkOSAuthenticator(jwksServer.URL, cfg.ClientID, issuer, repo, authTestLogger)
+	if err != nil {
+		t.Fatalf("create authenticator: %v", err)
+	}
+
+	token := signTestJWT(t, privKey, map[string]interface{}{
+		"sub": "user_01ABC",
+		"iss": "https://api.workos.com",
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(5 * time.Minute).Unix(),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/session", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	caller, err := auth.Authenticate(req)
+	if err != nil {
+		t.Fatalf("expected success for default WorkOS issuer, got: %v", err)
+	}
+	if caller.WorkOSUserID != "user_01ABC" {
+		t.Errorf("WorkOSUserID = %q, want %q", caller.WorkOSUserID, "user_01ABC")
+	}
+}

--- a/backend/internal/api/config.go
+++ b/backend/internal/api/config.go
@@ -44,7 +44,7 @@ type Config struct {
 	AppEnvironment            string
 	AuthMode                  string // "dev" or "workos"
 	WorkOSClientID            string // required when AuthMode is "workos"
-	WorkOSIssuer              string // optional; defaults to "https://api.workos.com/user_management/{ClientID}"
+	WorkOSIssuer              string // optional; defaults to "https://api.workos.com"
 	BindAddress               string
 	DatabaseURL               string
 	TemporalAddress           string

--- a/docs/frontend/auth-login-workos.md
+++ b/docs/frontend/auth-login-workos.md
@@ -33,10 +33,13 @@ login entry point inside the AgentClash app at `/auth/login`.
 
 ## Production Checklist
 
-- Configure WorkOS Redirect URI to the deployed callback, for example
-  `https://agentclash.dev/auth/callback`.
-- Configure the WorkOS sign-in endpoint to the deployed login page, for example
-  `https://agentclash.dev/auth/login`.
+- Configure WorkOS Redirect URI to the deployed callback:
+  `https://www.agentclash.dev/auth/callback`.
+- Configure the WorkOS sign-in endpoint to the deployed login page:
+  `https://www.agentclash.dev/auth/login`.
+- On Vercel, set `NEXT_PUBLIC_WORKOS_REDIRECT_URI` to the same www callback URL.
+- Optionally set `WORKOS_COOKIE_DOMAIN=.agentclash.dev` so PKCE cookies work when
+  users enter via the apex host (`agentclash.dev` redirects to www).
 - Configure the WorkOS sign-out redirect location to an AgentClash-owned route.
 - Use WorkOS dashboard branding to match AgentClash copy, assets, colors, and
   page layout while the app stays on the hosted AuthKit flow.

--- a/web/.env.local.example
+++ b/web/.env.local.example
@@ -3,6 +3,9 @@ WORKOS_CLIENT_ID=client_01...
 WORKOS_API_KEY=sk_test_...
 WORKOS_COOKIE_PASSWORD=<generate with: openssl rand -base64 24>
 NEXT_PUBLIC_WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
+# Production (Vercel): use the www-canonical host and share cookies across subdomains.
+# NEXT_PUBLIC_WORKOS_REDIRECT_URI=https://www.agentclash.dev/auth/callback
+# WORKOS_COOKIE_DOMAIN=.agentclash.dev
 
 # Backend API URL
 NEXT_PUBLIC_API_URL=http://localhost:8080

--- a/web/src/app/auth/callback/route.ts
+++ b/web/src/app/auth/callback/route.ts
@@ -1,3 +1,29 @@
 import { handleAuth } from "@workos-inc/authkit-nextjs";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
-export const GET = handleAuth({ returnPathname: "/dashboard" });
+const AUTH_CALLBACK_ERROR = {
+  error: {
+    message: "Something went wrong",
+    description:
+      "Couldn't sign in. If you are not sure what happened, please contact your organization admin.",
+  },
+} as const;
+
+function logAuthCallbackError(error: unknown, request: NextRequest) {
+  console.error("[auth/callback]", {
+    message: error instanceof Error ? error.message : String(error),
+    path: request.nextUrl.pathname,
+    hasCode: request.nextUrl.searchParams.has("code"),
+    hasState: request.nextUrl.searchParams.has("state"),
+    hasPkceCookie: request.cookies.has("wos-auth-verifier"),
+  });
+}
+
+export const GET = handleAuth({
+  returnPathname: "/dashboard",
+  onError: ({ error, request }) => {
+    logAuthCallbackError(error, request);
+    return NextResponse.json(AUTH_CALLBACK_ERROR, { status: 500 });
+  },
+});

--- a/web/src/components/try-cli/demo-client.tsx
+++ b/web/src/components/try-cli/demo-client.tsx
@@ -36,7 +36,7 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
   const [trial, setTrial] = useState(false);
   const [trialUsed, setTrialUsed] = useState(false);
 
-  const loginHref = `/auth/login?returnPathname=/try/${slug}`;
+  const loginHref = `/auth/login?returnTo=${encodeURIComponent(`/try/${slug}`)}`;
   const SESSION_KEY = "trycli:session";
   const saveSession = (id: string, exp: number) => {
     try {
@@ -383,7 +383,7 @@ export function TryCliDemoClient({ slug, initialDemo = null }: Props) {
                 own account.
               </p>
               <a
-                href={`/auth/login?returnPathname=/try/${slug}`}
+                href={`/auth/login?returnTo=${encodeURIComponent(`/try/${slug}`)}`}
                 className="mt-3 inline-flex items-center gap-1.5 rounded-md bg-white px-3 py-1.5 text-xs font-medium text-[#060606] transition-colors hover:bg-white/90"
               >
                 Sign in to continue

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -8,7 +8,8 @@
   },
   "env": {
     "NEXT_PUBLIC_TRY_CLI_API_URL": "/api/try",
-    "NEXT_PUBLIC_TRY_CLI_PUBLIC_URL": "https://www.agentclash.dev/try"
+    "NEXT_PUBLIC_TRY_CLI_PUBLIC_URL": "https://www.agentclash.dev/try",
+    "WORKOS_COOKIE_DOMAIN": ".agentclash.dev"
   },
   "rewrites": [
     {


### PR DESCRIPTION
## Summary
- Add structured `[auth/callback]` error logging so production AuthKit failures are diagnosable without exposing secrets to users.
- Set `WORKOS_COOKIE_DOMAIN=.agentclash.dev` in Vercel config and document www-canonical redirect/cookie settings for production.
- Restore the backend WorkOS JWT issuer default to `https://api.workos.com` so post-login `/v1/auth/session` validation succeeds.
- Fix try-cli login links to use the `returnTo` query param expected by `/auth/login`.

## Test plan
- [x] `go test -short -race -count=1 ./internal/api -run TestWorkOSAuthenticator`
- [x] `cd web && pnpm build`
- [x] `cd web && npx tsc --noEmit`
- [ ] After deploy, confirm Vercel env uses `NEXT_PUBLIC_WORKOS_REDIRECT_URI=https://www.agentclash.dev/auth/callback`
- [ ] After deploy, complete login at `https://www.agentclash.dev/auth/login` and land on `/dashboard`
- [ ] After deploy, confirm `/v1/auth/session` loads without "Unable to load your session"
- [ ] If callback still fails, inspect Vercel logs for `[auth/callback]` / `[AuthKit callback error]`


Made with [Cursor](https://cursor.com)