### PR TITLE
feat(agent-tryouts): execute tryouts through harness pipeline

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -130,7 +130,15 @@ func main() {
 	challengePackReadManager := api.NewChallengePackReadManager(repo)
 	challengePackAuthoringManager := api.NewChallengePackAuthoringManager(repo, artifactStore)
 	publicShareManager := api.NewPublicShareManager(authorizer, repo, cfg.FrontendURL)
-	agentTryoutManager := api.NewAgentTryoutManager(authorizer, repo)
+	agentTryoutManager := api.NewAgentTryoutManager(authorizer, repo).WithExecution(
+		api.NewTemporalAgentHarnessExecutionWorkflowStarter(temporalClient),
+		api.AgentTryoutExecutionConfig{
+			PublicWorkspaceID:      cfg.AgentTryoutPublicWorkspaceID,
+			PublicCreatedByUserID:  cfg.AgentTryoutPublicCreatedByUserID,
+			E2BTemplateID:          cfg.AgentTryoutE2BTemplateID,
+			OpenAIAPIKeySecretName: cfg.AgentTryoutOpenAIAPIKeySecretName,
+		},
+	)
 	agentBuildManager := api.NewAgentBuildManager(repo)
 	userManager := api.NewUserManager(repo)
 	orgAuthz := api.NewCallerOrganizationAuthorizer()

--- a/backend/internal/api/agent_tryouts.go
+++ b/backend/internal/api/agent_tryouts.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -342,7 +343,10 @@ func (d *agentTryoutExecutionDispatcher) dispatch(ctx context.Context, tryout re
 	if err != nil {
 		return repository.AgentTryout{}, err
 	}
-	runID := derefUUID(execution.RunID)
+	if execution.RunID == nil || *execution.RunID == uuid.Nil {
+		return d.failTryout(ctx, tryout, "execution_link_missing", "We could not link this tryout to an execution run. Please try again.")
+	}
+	runID := *execution.RunID
 	linked, err := d.repo.LinkAgentTryoutRunIfUnset(ctx, repository.LinkAgentTryoutRunParams{
 		ID:      tryout.ID,
 		RunID:   runID,
@@ -441,11 +445,19 @@ func (d *agentTryoutExecutionDispatcher) refresh(ctx context.Context, tryout rep
 		return repository.AgentTryout{}, err
 	}
 	status, redaction := agentTryoutStatusFromHarnessExecution(execution)
+	if agentTryoutTerminal(tryout.Status) && !agentTryoutTerminal(status) {
+		return tryout, nil
+	}
+	summary := agentTryoutExecutionSummary(execution)
+	latency := agentTryoutLatencyMS(execution)
+	if !agentTryoutRefreshChanged(tryout, status, summary, latency, redaction) {
+		return tryout, nil
+	}
 	return d.repo.UpdateAgentTryoutStatus(ctx, repository.UpdateAgentTryoutStatusParams{
 		ID:              tryout.ID,
 		Status:          status,
-		Summary:         agentTryoutExecutionSummary(execution),
-		LatencyMS:       agentTryoutLatencyMS(execution),
+		Summary:         summary,
+		LatencyMS:       latency,
 		RedactionStatus: redaction,
 	})
 }
@@ -579,11 +591,50 @@ func agentTryoutLatencyMS(execution repository.AgentHarnessExecution) *int64 {
 	return &value
 }
 
-func derefUUID(value *uuid.UUID) uuid.UUID {
-	if value == nil {
-		return uuid.Nil
+func agentTryoutTerminal(status repository.AgentTryoutStatus) bool {
+	switch status {
+	case repository.AgentTryoutStatusCompleted,
+		repository.AgentTryoutStatusFailed,
+		repository.AgentTryoutStatusCancelled:
+		return true
+	default:
+		return false
 	}
-	return *value
+}
+
+func agentTryoutRefreshChanged(tryout repository.AgentTryout, status repository.AgentTryoutStatus, summary json.RawMessage, latency *int64, redaction *repository.AgentTryoutRedactionStatus) bool {
+	if tryout.Status != status {
+		return true
+	}
+	if !agentTryoutJSONEqual(tryout.Summary, summary) {
+		return true
+	}
+	if !agentTryoutInt64PtrEqual(tryout.LatencyMS, latency) {
+		return true
+	}
+	return redaction != nil && tryout.RedactionStatus != *redaction
+}
+
+func agentTryoutJSONEqual(a json.RawMessage, b json.RawMessage) bool {
+	var left any
+	var right any
+	if len(a) == 0 || len(b) == 0 {
+		return string(a) == string(b)
+	}
+	if err := json.Unmarshal(a, &left); err != nil {
+		return string(a) == string(b)
+	}
+	if err := json.Unmarshal(b, &right); err != nil {
+		return string(a) == string(b)
+	}
+	return reflect.DeepEqual(left, right)
+}
+
+func agentTryoutInt64PtrEqual(a *int64, b *int64) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
 }
 
 func mustAgentTryoutJSON(value any) json.RawMessage {

--- a/backend/internal/api/agent_tryouts.go
+++ b/backend/internal/api/agent_tryouts.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/agentclash/agentclash/backend/internal/domain"
 	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -32,9 +33,17 @@ var (
 
 type AgentTryoutRepository interface {
 	GetOrganizationIDByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (uuid.UUID, error)
+	GetAgentHarnessByWorkspaceSlug(ctx context.Context, workspaceID uuid.UUID, slug string) (repository.AgentHarness, error)
+	CreateAgentHarness(ctx context.Context, p repository.CreateAgentHarnessParams) (repository.AgentHarness, error)
+	CreateAgentHarnessExecution(ctx context.Context, p repository.CreateAgentHarnessExecutionParams) (repository.AgentHarnessExecution, error)
+	SetAgentHarnessExecutionTemporalIDs(ctx context.Context, p repository.SetAgentHarnessExecutionTemporalIDsParams) (repository.AgentHarnessExecution, error)
+	TransitionAgentHarnessExecutionStatus(ctx context.Context, p repository.TransitionAgentHarnessExecutionStatusParams) (repository.AgentHarnessExecution, error)
+	GetAgentHarnessExecutionByRunID(ctx context.Context, runID uuid.UUID) (repository.AgentHarnessExecution, error)
 	CreateAgentTryout(ctx context.Context, params repository.CreateAgentTryoutParams) (repository.AgentTryout, error)
 	GetAgentTryoutByID(ctx context.Context, id uuid.UUID) (repository.AgentTryout, error)
 	ListAgentTryoutsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID, limit, offset int32) ([]repository.AgentTryout, error)
+	LinkAgentTryoutRunIfUnset(ctx context.Context, params repository.LinkAgentTryoutRunParams) (repository.AgentTryout, error)
+	UpdateAgentTryoutStatus(ctx context.Context, params repository.UpdateAgentTryoutStatusParams) (repository.AgentTryout, error)
 	ClaimAgentTryout(ctx context.Context, params repository.ClaimAgentTryoutParams) (repository.AgentTryout, error)
 	CreatePublicShareLink(ctx context.Context, params repository.CreatePublicShareLinkParams) (repository.PublicShareLink, error)
 }
@@ -89,11 +98,21 @@ type CreateAgentTryoutShareResult struct {
 	Token string
 }
 
+type AgentTryoutExecutionConfig struct {
+	PublicWorkspaceID      *uuid.UUID
+	HarnessKind            string
+	E2BTemplateID          string
+	OpenAIAPIKeySecretName string
+	PublicCreatedByUserID  *uuid.UUID
+	ConcurrencyLimit       int
+}
+
 type AgentTryoutManager struct {
 	authorizer WorkspaceAuthorizer
 	repo       AgentTryoutRepository
 	now        func() time.Time
 	templates  map[string]AgentTryoutTemplate
+	execution  *agentTryoutExecutionDispatcher
 }
 
 func NewAgentTryoutManager(authorizer WorkspaceAuthorizer, repo AgentTryoutRepository) *AgentTryoutManager {
@@ -108,6 +127,18 @@ func NewAgentTryoutManager(authorizer WorkspaceAuthorizer, repo AgentTryoutRepos
 		now:        time.Now,
 		templates:  bySlug,
 	}
+}
+
+func (m *AgentTryoutManager) WithExecution(starter AgentHarnessExecutionWorkflowStarter, config AgentTryoutExecutionConfig) *AgentTryoutManager {
+	if starter == nil {
+		return m
+	}
+	m.execution = &agentTryoutExecutionDispatcher{
+		repo:    m.repo,
+		starter: starter,
+		config:  normalizeAgentTryoutExecutionConfig(config),
+	}
+	return m
 }
 
 func (m *AgentTryoutManager) ListTemplates(context.Context) ([]AgentTryoutTemplate, error) {
@@ -132,7 +163,7 @@ func (m *AgentTryoutManager) CreateAnonymousTryout(ctx context.Context, input Cr
 	}
 	expiresAt := now.UTC().Add(defaultAgentTryoutTTL)
 	fingerprintHash := hashAnonymousFingerprint(input.AnonymousFingerprint)
-	return m.repo.CreateAgentTryout(ctx, repository.CreateAgentTryoutParams{
+	tryout, err := m.repo.CreateAgentTryout(ctx, repository.CreateAgentTryoutParams{
 		TemplateSlug:             template.Slug,
 		Status:                   repository.AgentTryoutStatusQueued,
 		InputSnapshot:            input.Input,
@@ -147,6 +178,10 @@ func (m *AgentTryoutManager) CreateAnonymousTryout(ctx context.Context, input Cr
 		AnonymousFingerprintHash: &fingerprintHash,
 		ExpiresAt:                &expiresAt,
 	})
+	if err != nil {
+		return repository.AgentTryout{}, err
+	}
+	return m.dispatchCreatedTryout(ctx, tryout, template)
 }
 
 func (m *AgentTryoutManager) CreateWorkspaceTryout(ctx context.Context, caller Caller, input CreateWorkspaceAgentTryoutInput) (repository.AgentTryout, error) {
@@ -165,7 +200,7 @@ func (m *AgentTryoutManager) CreateWorkspaceTryout(ctx context.Context, caller C
 		return repository.AgentTryout{}, err
 	}
 	callerID := caller.UserID
-	return m.repo.CreateAgentTryout(ctx, repository.CreateAgentTryoutParams{
+	tryout, err := m.repo.CreateAgentTryout(ctx, repository.CreateAgentTryoutParams{
 		OrganizationID:         &orgID,
 		WorkspaceID:            &input.WorkspaceID,
 		TemplateSlug:           template.Slug,
@@ -181,6 +216,10 @@ func (m *AgentTryoutManager) CreateWorkspaceTryout(ctx context.Context, caller C
 		MaxDurationSeconds:     template.MaxDurationSeconds,
 		CreatedByUserID:        &callerID,
 	})
+	if err != nil {
+		return repository.AgentTryout{}, err
+	}
+	return m.dispatchCreatedTryout(ctx, tryout, template)
 }
 
 func (m *AgentTryoutManager) GetPublicTryout(ctx context.Context, id uuid.UUID) (repository.AgentTryout, error) {
@@ -191,7 +230,7 @@ func (m *AgentTryoutManager) GetPublicTryout(ctx context.Context, id uuid.UUID) 
 	if tryout.WorkspaceID != nil {
 		return repository.AgentTryout{}, repository.ErrAgentTryoutNotFound
 	}
-	return tryout, nil
+	return m.refreshTryoutFromExecution(ctx, tryout), nil
 }
 
 func (m *AgentTryoutManager) GetWorkspaceTryout(ctx context.Context, caller Caller, id uuid.UUID) (repository.AgentTryout, error) {
@@ -205,7 +244,7 @@ func (m *AgentTryoutManager) GetWorkspaceTryout(ctx context.Context, caller Call
 	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, *tryout.WorkspaceID); err != nil {
 		return repository.AgentTryout{}, err
 	}
-	return tryout, nil
+	return m.refreshTryoutFromExecution(ctx, tryout), nil
 }
 
 func (m *AgentTryoutManager) ListWorkspaceTryouts(ctx context.Context, caller Caller, workspaceID uuid.UUID, limit, offset int32) ([]repository.AgentTryout, error) {
@@ -218,7 +257,338 @@ func (m *AgentTryoutManager) ListWorkspaceTryouts(ctx context.Context, caller Ca
 	if offset < 0 {
 		offset = 0
 	}
-	return m.repo.ListAgentTryoutsByWorkspaceID(ctx, workspaceID, limit, offset)
+	tryouts, err := m.repo.ListAgentTryoutsByWorkspaceID(ctx, workspaceID, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	for i := range tryouts {
+		tryouts[i] = m.refreshTryoutFromExecution(ctx, tryouts[i])
+	}
+	return tryouts, nil
+}
+
+func (m *AgentTryoutManager) dispatchCreatedTryout(ctx context.Context, tryout repository.AgentTryout, template AgentTryoutTemplate) (repository.AgentTryout, error) {
+	if m.execution == nil {
+		return tryout, nil
+	}
+	return m.execution.dispatch(ctx, tryout, template)
+}
+
+func (m *AgentTryoutManager) refreshTryoutFromExecution(ctx context.Context, tryout repository.AgentTryout) repository.AgentTryout {
+	if m.execution == nil || tryout.RunID == nil {
+		return tryout
+	}
+	refreshed, err := m.execution.refresh(ctx, tryout)
+	if err != nil {
+		return tryout
+	}
+	return refreshed
+}
+
+type agentTryoutExecutionDispatcher struct {
+	repo    AgentTryoutRepository
+	starter AgentHarnessExecutionWorkflowStarter
+	config  AgentTryoutExecutionConfig
+}
+
+func normalizeAgentTryoutExecutionConfig(config AgentTryoutExecutionConfig) AgentTryoutExecutionConfig {
+	if strings.TrimSpace(config.HarnessKind) == "" {
+		config.HarnessKind = domain.AgentHarnessKindCodexE2B
+	}
+	if strings.TrimSpace(config.E2BTemplateID) == "" {
+		config.E2BTemplateID = defaultCodexE2BTemplate
+	}
+	if strings.TrimSpace(config.OpenAIAPIKeySecretName) == "" {
+		config.OpenAIAPIKeySecretName = "OPENAI_API_KEY"
+	}
+	if config.ConcurrencyLimit <= 0 {
+		config.ConcurrencyLimit = 3
+	}
+	return config
+}
+
+func (d *agentTryoutExecutionDispatcher) dispatch(ctx context.Context, tryout repository.AgentTryout, template AgentTryoutTemplate) (repository.AgentTryout, error) {
+	if tryout.RunID != nil {
+		return d.refresh(ctx, tryout)
+	}
+	workspaceID, createdBy, ok := d.executionScope(tryout)
+	if !ok {
+		return d.failTryout(ctx, tryout, "execution_not_configured", "Agent tryouts are not configured for public execution yet.")
+	}
+	orgID, err := d.repo.GetOrganizationIDByWorkspaceID(ctx, workspaceID)
+	if err != nil {
+		return repository.AgentTryout{}, err
+	}
+	harness, err := d.getOrCreateTemplateHarness(ctx, orgID, workspaceID, createdBy, template)
+	if err != nil {
+		return repository.AgentTryout{}, err
+	}
+	executionConfig := d.executionConfig(template)
+	evaluationConfig := agentTryoutEvaluationConfig(template, tryout)
+	harnessSnapshot, err := d.harnessSnapshot(harness, template, tryout, executionConfig, evaluationConfig)
+	if err != nil {
+		return repository.AgentTryout{}, err
+	}
+	execution, err := d.repo.CreateAgentHarnessExecution(ctx, repository.CreateAgentHarnessExecutionParams{
+		OrganizationID:           orgID,
+		WorkspaceID:              workspaceID,
+		AgentHarnessID:           harness.ID,
+		CreatedByUserID:          createdBy,
+		HarnessSnapshot:          harnessSnapshot,
+		ExecutionConfigSnapshot:  executionConfig,
+		EvaluationConfigSnapshot: evaluationConfig,
+		ConcurrencyLimit:         d.config.ConcurrencyLimit,
+	})
+	if err != nil {
+		return repository.AgentTryout{}, err
+	}
+	runID := derefUUID(execution.RunID)
+	linked, err := d.repo.LinkAgentTryoutRunIfUnset(ctx, repository.LinkAgentTryoutRunParams{
+		ID:      tryout.ID,
+		RunID:   runID,
+		Status:  repository.AgentTryoutStatusRunning,
+		Summary: agentTryoutDispatchSummary(execution),
+	})
+	if err != nil {
+		return repository.AgentTryout{}, err
+	}
+	if linked.RunID == nil || *linked.RunID != runID {
+		return d.refresh(ctx, linked)
+	}
+	if err := d.startWorkflow(ctx, execution); err != nil {
+		reason := err.Error()
+		_, _ = d.repo.TransitionAgentHarnessExecutionStatus(ctx, repository.TransitionAgentHarnessExecutionStatusParams{
+			ExecutionID:     execution.ID,
+			ToStatus:        repository.AgentHarnessExecutionStatusFailed,
+			Reason:          &reason,
+			ChangedByUserID: createdBy,
+		})
+		return d.failTryout(ctx, linked, "execution_start_failed", "We could not start this tryout. Please try again.")
+	}
+	return d.refresh(ctx, linked)
+}
+
+func (d *agentTryoutExecutionDispatcher) executionScope(tryout repository.AgentTryout) (uuid.UUID, *uuid.UUID, bool) {
+	if tryout.WorkspaceID != nil {
+		return *tryout.WorkspaceID, tryout.CreatedByUserID, true
+	}
+	if d.config.PublicWorkspaceID == nil {
+		return uuid.Nil, nil, false
+	}
+	return *d.config.PublicWorkspaceID, d.config.PublicCreatedByUserID, true
+}
+
+func (d *agentTryoutExecutionDispatcher) getOrCreateTemplateHarness(ctx context.Context, orgID uuid.UUID, workspaceID uuid.UUID, createdBy *uuid.UUID, template AgentTryoutTemplate) (repository.AgentHarness, error) {
+	slug := agentTryoutHarnessSlug(template)
+	harness, err := d.repo.GetAgentHarnessByWorkspaceSlug(ctx, workspaceID, slug)
+	if err == nil {
+		return harness, nil
+	}
+	if !errors.Is(err, repository.ErrAgentHarnessNotFound) {
+		return repository.AgentHarness{}, err
+	}
+	harness, err = d.repo.CreateAgentHarness(ctx, repository.CreateAgentHarnessParams{
+		OrganizationID:         orgID,
+		WorkspaceID:            workspaceID,
+		CreatedByUserID:        createdBy,
+		Name:                   "Agent Tryout: " + template.Name,
+		Slug:                   slug,
+		Description:            "Internal harness used by AgentClash agent tryouts.",
+		HarnessKind:            d.config.HarnessKind,
+		TaskPrompt:             "AgentClash tryout template dispatcher.",
+		CodexTemplate:          d.config.E2BTemplateID,
+		AuthMode:               AgentHarnessAuthModeAPIKeySecret,
+		OpenAIAPIKeySecretName: optionalHarnessString(d.config.OpenAIAPIKeySecretName),
+		ExecutionConfig:        d.executionConfig(template),
+		EvaluationConfig:       agentTryoutEvaluationConfig(template, repository.AgentTryout{TemplateSlug: template.Slug}),
+	})
+	if errors.Is(err, repository.ErrAgentHarnessSlugConflict) {
+		return d.repo.GetAgentHarnessByWorkspaceSlug(ctx, workspaceID, slug)
+	}
+	return harness, err
+}
+
+func (d *agentTryoutExecutionDispatcher) startWorkflow(ctx context.Context, execution repository.AgentHarnessExecution) error {
+	ref, err := d.starter.StartAgentHarnessExecutionWorkflow(ctx, execution.ID, agentHarnessExecutionTimeoutSeconds(execution.ExecutionConfigSnapshot))
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(ref.WorkflowID) == "" {
+		ref.WorkflowID = defaultAgentHarnessExecutionWorkflowID(execution.ID)
+	}
+	_, err = d.repo.SetAgentHarnessExecutionTemporalIDs(ctx, repository.SetAgentHarnessExecutionTemporalIDsParams{
+		ExecutionID:        execution.ID,
+		TemporalWorkflowID: ref.WorkflowID,
+		TemporalRunID:      ref.RunID,
+	})
+	if err != nil {
+		if controller, ok := d.starter.(AgentHarnessExecutionWorkflowController); ok {
+			_ = controller.CancelAgentHarnessExecutionWorkflow(ctx, ref.WorkflowID, ref.RunID)
+		}
+	}
+	return err
+}
+
+func (d *agentTryoutExecutionDispatcher) refresh(ctx context.Context, tryout repository.AgentTryout) (repository.AgentTryout, error) {
+	if tryout.RunID == nil {
+		return tryout, nil
+	}
+	execution, err := d.repo.GetAgentHarnessExecutionByRunID(ctx, *tryout.RunID)
+	if err != nil {
+		if errors.Is(err, repository.ErrAgentHarnessExecutionNotFound) {
+			return tryout, nil
+		}
+		return repository.AgentTryout{}, err
+	}
+	status, redaction := agentTryoutStatusFromHarnessExecution(execution)
+	return d.repo.UpdateAgentTryoutStatus(ctx, repository.UpdateAgentTryoutStatusParams{
+		ID:              tryout.ID,
+		Status:          status,
+		Summary:         agentTryoutExecutionSummary(execution),
+		LatencyMS:       agentTryoutLatencyMS(execution),
+		RedactionStatus: redaction,
+	})
+}
+
+func (d *agentTryoutExecutionDispatcher) failTryout(ctx context.Context, tryout repository.AgentTryout, code string, message string) (repository.AgentTryout, error) {
+	redaction := repository.AgentTryoutRedactionNotRequired
+	return d.repo.UpdateAgentTryoutStatus(ctx, repository.UpdateAgentTryoutStatusParams{
+		ID:              tryout.ID,
+		Status:          repository.AgentTryoutStatusFailed,
+		Summary:         safeAgentTryoutFailureSummary(code, message),
+		RedactionStatus: &redaction,
+	})
+}
+
+func (d *agentTryoutExecutionDispatcher) executionConfig(template AgentTryoutTemplate) json.RawMessage {
+	payload, _ := json.Marshal(map[string]any{
+		"timeout_seconds": template.MaxDurationSeconds,
+		"agent_tryout": map[string]any{
+			"template_slug": template.Slug,
+		},
+	})
+	return payload
+}
+
+func (d *agentTryoutExecutionDispatcher) harnessSnapshot(harness repository.AgentHarness, template AgentTryoutTemplate, tryout repository.AgentTryout, executionConfig json.RawMessage, evaluationConfig json.RawMessage) (json.RawMessage, error) {
+	payload := map[string]any{
+		"id":                         harness.ID,
+		"workspace_id":               harness.WorkspaceID,
+		"organization_id":            harness.OrganizationID,
+		"harness_kind":               d.config.HarnessKind,
+		"task_prompt":                agentTryoutTaskPrompt(template, tryout.InputSnapshot),
+		"codex_template":             d.config.E2BTemplateID,
+		"auth_mode":                  AgentHarnessAuthModeAPIKeySecret,
+		"openai_api_key_secret_name": d.config.OpenAIAPIKeySecretName,
+		"execution_config":           json.RawMessage(executionConfig),
+		"evaluation_config":          json.RawMessage(evaluationConfig),
+	}
+	return json.Marshal(payload)
+}
+
+func agentTryoutHarnessSlug(template AgentTryoutTemplate) string {
+	return "agent-tryout-" + generateSlug(template.Slug)
+}
+
+func agentTryoutTaskPrompt(template AgentTryoutTemplate, input json.RawMessage) string {
+	return strings.Join([]string{
+		"You are running an AgentClash tryout template.",
+		"Template: " + template.Name + " (" + template.Slug + ")",
+		"Goal: " + template.Description,
+		"Use only the available sandbox tools and produce a concise, inspectable result for the user.",
+		"User input JSON:",
+		"```json",
+		string(input),
+		"```",
+	}, "\n")
+}
+
+func agentTryoutEvaluationConfig(template AgentTryoutTemplate, tryout repository.AgentTryout) json.RawMessage {
+	payload, _ := json.Marshal(map[string]any{
+		"template_evaluation_spec": json.RawMessage(template.EvaluationSpec),
+		"privacy": map[string]any{
+			"redact_replay":    true,
+			"redact_artifacts": true,
+			"retention_days":   1,
+		},
+		"result": map[string]any{
+			"kind":          "agent_tryout",
+			"template_slug": template.Slug,
+			"tryout_id":     tryout.ID,
+		},
+	})
+	return payload
+}
+
+func agentTryoutDispatchSummary(execution repository.AgentHarnessExecution) json.RawMessage {
+	return mustAgentTryoutJSON(map[string]any{
+		"code":          "execution_started",
+		"message":       "Tryout execution started.",
+		"execution_id":  execution.ID,
+		"run_id":        execution.RunID,
+		"run_agent_id":  execution.RunAgentID,
+		"status_source": "agent_harness_execution",
+	})
+}
+
+func agentTryoutExecutionSummary(execution repository.AgentHarnessExecution) json.RawMessage {
+	code := "execution_" + strings.TrimSpace(execution.Status)
+	message := "Tryout execution is " + strings.TrimSpace(execution.Status) + "."
+	if repository.AgentHarnessExecutionStatus(execution.Status) == repository.AgentHarnessExecutionStatusFailed {
+		code = "execution_failed"
+		message = "The tryout did not complete successfully. Inspect the run evidence for details."
+	}
+	return mustAgentTryoutJSON(map[string]any{
+		"code":          code,
+		"message":       message,
+		"execution_id":  execution.ID,
+		"run_id":        execution.RunID,
+		"run_agent_id":  execution.RunAgentID,
+		"status_source": "agent_harness_execution",
+	})
+}
+
+func safeAgentTryoutFailureSummary(code string, message string) json.RawMessage {
+	return mustAgentTryoutJSON(map[string]any{"code": code, "message": message})
+}
+
+func agentTryoutStatusFromHarnessExecution(execution repository.AgentHarnessExecution) (repository.AgentTryoutStatus, *repository.AgentTryoutRedactionStatus) {
+	switch repository.AgentHarnessExecutionStatus(execution.Status) {
+	case repository.AgentHarnessExecutionStatusCompleted:
+		redaction := repository.AgentTryoutRedactionPassed
+		return repository.AgentTryoutStatusCompleted, &redaction
+	case repository.AgentHarnessExecutionStatusFailed:
+		redaction := repository.AgentTryoutRedactionNotRequired
+		return repository.AgentTryoutStatusFailed, &redaction
+	case repository.AgentHarnessExecutionStatusCancelled:
+		redaction := repository.AgentTryoutRedactionNotRequired
+		return repository.AgentTryoutStatusCancelled, &redaction
+	default:
+		return repository.AgentTryoutStatusRunning, nil
+	}
+}
+
+func agentTryoutLatencyMS(execution repository.AgentHarnessExecution) *int64 {
+	if execution.StartedAt == nil || execution.CompletedAt == nil {
+		return nil
+	}
+	value := execution.CompletedAt.Sub(*execution.StartedAt).Milliseconds()
+	if value < 0 {
+		value = 0
+	}
+	return &value
+}
+
+func derefUUID(value *uuid.UUID) uuid.UUID {
+	if value == nil {
+		return uuid.Nil
+	}
+	return *value
+}
+
+func mustAgentTryoutJSON(value any) json.RawMessage {
+	payload, _ := json.Marshal(value)
+	return payload
 }
 
 func (m *AgentTryoutManager) ClaimTryout(ctx context.Context, caller Caller, input ClaimAgentTryoutInput) (repository.AgentTryout, error) {

--- a/backend/internal/api/agent_tryouts_test.go
+++ b/backend/internal/api/agent_tryouts_test.go
@@ -230,6 +230,65 @@ func TestAgentTryoutManagerMarksFailedWhenDispatchStartFails(t *testing.T) {
 	}
 }
 
+func TestAgentTryoutManagerDoesNotRevertFailedTryoutWhenHarnessTransitionFails(t *testing.T) {
+	ctx := context.Background()
+	orgID := uuid.New()
+	workspaceID := uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	repo.transitionErr = errors.New("transition failed")
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo).WithExecution(&fakeAgentHarnessWorkflowStarter{err: errors.New("temporal unavailable")}, AgentTryoutExecutionConfig{PublicWorkspaceID: &workspaceID})
+
+	tryout, err := manager.CreateAnonymousTryout(ctx, CreateAnonymousAgentTryoutInput{
+		TemplateSlug:         "meeting-minutes",
+		Input:                json.RawMessage(`{"notes":"fail and stay failed"}`),
+		AnonymousFingerprint: "203.0.113.10",
+	})
+	if err != nil {
+		t.Fatalf("CreateAnonymousTryout returned error: %v", err)
+	}
+	if tryout.Status != repository.AgentTryoutStatusFailed {
+		t.Fatalf("created status = %q, want failed", tryout.Status)
+	}
+	refreshed, err := manager.GetPublicTryout(ctx, tryout.ID)
+	if err != nil {
+		t.Fatalf("GetPublicTryout returned error: %v", err)
+	}
+	if refreshed.Status != repository.AgentTryoutStatusFailed {
+		t.Fatalf("refreshed status = %q, want failed", refreshed.Status)
+	}
+}
+
+func TestAgentTryoutManagerRejectsHarnessExecutionWithoutRunID(t *testing.T) {
+	ctx := context.Background()
+	orgID := uuid.New()
+	workspaceID := uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	repo.omitExecutionRunID = true
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo).WithExecution(&fakeAgentHarnessWorkflowStarter{}, AgentTryoutExecutionConfig{PublicWorkspaceID: &workspaceID})
+
+	tryout, err := manager.CreateAnonymousTryout(ctx, CreateAnonymousAgentTryoutInput{
+		TemplateSlug:         "meeting-minutes",
+		Input:                json.RawMessage(`{"notes":"missing run id"}`),
+		AnonymousFingerprint: "203.0.113.10",
+	})
+	if err != nil {
+		t.Fatalf("CreateAnonymousTryout returned error: %v", err)
+	}
+	if tryout.Status != repository.AgentTryoutStatusFailed {
+		t.Fatalf("status = %q, want failed", tryout.Status)
+	}
+	if tryout.RunID != nil {
+		t.Fatalf("run_id = %v, want nil when execution run id is missing", tryout.RunID)
+	}
+	var summary map[string]any
+	if err := json.Unmarshal(tryout.Summary, &summary); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+	if summary["code"] != "execution_link_missing" {
+		t.Fatalf("summary code = %v, want execution_link_missing", summary["code"])
+	}
+}
+
 func TestAgentTryoutManagerMapsHarnessExecutionStatusOnRead(t *testing.T) {
 	ctx := context.Background()
 	orgID := uuid.New()
@@ -262,6 +321,35 @@ func TestAgentTryoutManagerMapsHarnessExecutionStatusOnRead(t *testing.T) {
 	}
 	if refreshed.LatencyMS == nil || *refreshed.LatencyMS <= 0 {
 		t.Fatalf("latency_ms = %v, want positive", refreshed.LatencyMS)
+	}
+}
+
+func TestAgentTryoutManagerSkipsNoopRefreshWrite(t *testing.T) {
+	ctx := context.Background()
+	orgID := uuid.New()
+	workspaceID := uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo).WithExecution(&fakeAgentHarnessWorkflowStarter{}, AgentTryoutExecutionConfig{PublicWorkspaceID: &workspaceID})
+
+	tryout, err := manager.CreateAnonymousTryout(ctx, CreateAnonymousAgentTryoutInput{
+		TemplateSlug:         "meeting-minutes",
+		Input:                json.RawMessage(`{"notes":"avoid writes"}`),
+		AnonymousFingerprint: "203.0.113.10",
+	})
+	if err != nil {
+		t.Fatalf("CreateAnonymousTryout returned error: %v", err)
+	}
+	_, err = manager.GetPublicTryout(ctx, tryout.ID)
+	if err != nil {
+		t.Fatalf("first GetPublicTryout returned error: %v", err)
+	}
+	updatesAfterFirstRefresh := repo.updateStatusCalls
+	_, err = manager.GetPublicTryout(ctx, tryout.ID)
+	if err != nil {
+		t.Fatalf("second GetPublicTryout returned error: %v", err)
+	}
+	if repo.updateStatusCalls != updatesAfterFirstRefresh {
+		t.Fatalf("update calls = %d, want unchanged %d after noop refresh", repo.updateStatusCalls, updatesAfterFirstRefresh)
 	}
 }
 
@@ -429,6 +517,9 @@ type fakeAgentTryoutRepository struct {
 	createdExecutions  []repository.CreateAgentHarnessExecutionParams
 	transitionedStatus repository.AgentHarnessExecutionStatus
 	transitionedReason *string
+	transitionErr      error
+	omitExecutionRunID bool
+	updateStatusCalls  int
 	share              repository.PublicShareLink
 }
 
@@ -518,13 +609,17 @@ func (r *fakeAgentTryoutRepository) CreateAgentHarnessExecution(_ context.Contex
 	now := time.Now().UTC()
 	runID := uuid.New()
 	runAgentID := uuid.New()
+	var runIDPtr *uuid.UUID
+	if !r.omitExecutionRunID {
+		runIDPtr = &runID
+	}
 	execution := repository.AgentHarnessExecution{
 		ID:                       uuid.New(),
 		OrganizationID:           params.OrganizationID,
 		WorkspaceID:              params.WorkspaceID,
 		AgentHarnessID:           params.AgentHarnessID,
 		CreatedByUserID:          params.CreatedByUserID,
-		RunID:                    &runID,
+		RunID:                    runIDPtr,
 		RunAgentID:               &runAgentID,
 		Status:                   string(repository.AgentHarnessExecutionStatusQueued),
 		HarnessSnapshot:          params.HarnessSnapshot,
@@ -533,7 +628,9 @@ func (r *fakeAgentTryoutRepository) CreateAgentHarnessExecution(_ context.Contex
 		CreatedAt:                now,
 		UpdatedAt:                now,
 	}
-	r.executionsByRunID[runID] = execution
+	if execution.RunID != nil {
+		r.executionsByRunID[runID] = execution
+	}
 	return execution, nil
 }
 
@@ -554,6 +651,9 @@ func (r *fakeAgentTryoutRepository) SetAgentHarnessExecutionTemporalIDs(_ contex
 func (r *fakeAgentTryoutRepository) TransitionAgentHarnessExecutionStatus(_ context.Context, params repository.TransitionAgentHarnessExecutionStatusParams) (repository.AgentHarnessExecution, error) {
 	r.transitionedStatus = params.ToStatus
 	r.transitionedReason = params.Reason
+	if r.transitionErr != nil {
+		return repository.AgentHarnessExecution{}, r.transitionErr
+	}
 	for runID, execution := range r.executionsByRunID {
 		if execution.ID == params.ExecutionID {
 			execution.Status = string(params.ToStatus)
@@ -600,6 +700,7 @@ func (r *fakeAgentTryoutRepository) LinkAgentTryoutRunIfUnset(_ context.Context,
 }
 
 func (r *fakeAgentTryoutRepository) UpdateAgentTryoutStatus(_ context.Context, params repository.UpdateAgentTryoutStatusParams) (repository.AgentTryout, error) {
+	r.updateStatusCalls++
 	tryout, ok := r.tryouts[params.ID]
 	if !ok {
 		return repository.AgentTryout{}, repository.ErrAgentTryoutNotFound

--- a/backend/internal/api/agent_tryouts_test.go
+++ b/backend/internal/api/agent_tryouts_test.go
@@ -126,6 +126,178 @@ func TestAgentTryoutManagerCreateWorkspaceClaimAndShare(t *testing.T) {
 	}
 }
 
+func TestAgentTryoutManagerDispatchesAnonymousTryout(t *testing.T) {
+	ctx := context.Background()
+	orgID := uuid.New()
+	workspaceID := uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	starter := &fakeAgentHarnessWorkflowStarter{}
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo).WithExecution(starter, AgentTryoutExecutionConfig{
+		PublicWorkspaceID:      &workspaceID,
+		E2BTemplateID:          "agentclash-tryout-e2b",
+		OpenAIAPIKeySecretName: "TRYOUT_OPENAI_API_KEY",
+	})
+
+	tryout, err := manager.CreateAnonymousTryout(ctx, CreateAnonymousAgentTryoutInput{
+		TemplateSlug:         "meeting-minutes",
+		Input:                json.RawMessage(`{"notes":"ship the execution bridge"}`),
+		AnonymousFingerprint: "203.0.113.10",
+	})
+	if err != nil {
+		t.Fatalf("CreateAnonymousTryout returned error: %v", err)
+	}
+	if tryout.Status != repository.AgentTryoutStatusRunning {
+		t.Fatalf("status = %q, want running", tryout.Status)
+	}
+	if tryout.RunID == nil {
+		t.Fatal("run_id was not linked")
+	}
+	if len(repo.createdHarnesses) != 1 || len(repo.createdExecutions) != 1 {
+		t.Fatalf("created harnesses/executions = %d/%d, want 1/1", len(repo.createdHarnesses), len(repo.createdExecutions))
+	}
+	if starter.startedCount != 1 || starter.timeoutSeconds != 120 {
+		t.Fatalf("starter count/timeout = %d/%d, want 1/120", starter.startedCount, starter.timeoutSeconds)
+	}
+	var snapshot map[string]any
+	if err := json.Unmarshal(repo.createdExecutions[0].HarnessSnapshot, &snapshot); err != nil {
+		t.Fatalf("decode harness snapshot: %v", err)
+	}
+	if snapshot["codex_template"] != "agentclash-tryout-e2b" || snapshot["openai_api_key_secret_name"] != "TRYOUT_OPENAI_API_KEY" {
+		t.Fatalf("snapshot provider config = %#v", snapshot)
+	}
+	if !strings.Contains(snapshot["task_prompt"].(string), "ship the execution bridge") {
+		t.Fatalf("task prompt did not include input: %s", snapshot["task_prompt"])
+	}
+}
+
+func TestAgentTryoutManagerDispatchIsIdempotentWhenRunAlreadyLinked(t *testing.T) {
+	ctx := context.Background()
+	orgID := uuid.New()
+	workspaceID := uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	starter := &fakeAgentHarnessWorkflowStarter{}
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo).WithExecution(starter, AgentTryoutExecutionConfig{PublicWorkspaceID: &workspaceID})
+
+	tryout, err := manager.CreateAnonymousTryout(ctx, CreateAnonymousAgentTryoutInput{
+		TemplateSlug:         "meeting-minutes",
+		Input:                json.RawMessage(`{"notes":"first run"}`),
+		AnonymousFingerprint: "203.0.113.10",
+	})
+	if err != nil {
+		t.Fatalf("CreateAnonymousTryout returned error: %v", err)
+	}
+	template, _ := manager.lookupTemplate("meeting-minutes")
+	again, err := manager.execution.dispatch(ctx, tryout, template)
+	if err != nil {
+		t.Fatalf("second dispatch returned error: %v", err)
+	}
+	if again.RunID == nil || *again.RunID != *tryout.RunID {
+		t.Fatalf("second dispatch run_id = %v, want %s", again.RunID, *tryout.RunID)
+	}
+	if len(repo.createdExecutions) != 1 || starter.startedCount != 1 {
+		t.Fatalf("created executions/start count = %d/%d, want 1/1", len(repo.createdExecutions), starter.startedCount)
+	}
+}
+
+func TestAgentTryoutManagerMarksFailedWhenDispatchStartFails(t *testing.T) {
+	ctx := context.Background()
+	orgID := uuid.New()
+	workspaceID := uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	starterErr := errors.New("temporal unavailable")
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo).WithExecution(&fakeAgentHarnessWorkflowStarter{err: starterErr}, AgentTryoutExecutionConfig{PublicWorkspaceID: &workspaceID})
+
+	tryout, err := manager.CreateAnonymousTryout(ctx, CreateAnonymousAgentTryoutInput{
+		TemplateSlug:         "meeting-minutes",
+		Input:                json.RawMessage(`{"notes":"fail safely"}`),
+		AnonymousFingerprint: "203.0.113.10",
+	})
+	if err != nil {
+		t.Fatalf("CreateAnonymousTryout returned error: %v", err)
+	}
+	if tryout.Status != repository.AgentTryoutStatusFailed {
+		t.Fatalf("status = %q, want failed", tryout.Status)
+	}
+	if repo.transitionedStatus != repository.AgentHarnessExecutionStatusFailed {
+		t.Fatalf("harness status = %q, want failed", repo.transitionedStatus)
+	}
+	var summary map[string]any
+	if err := json.Unmarshal(tryout.Summary, &summary); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+	if summary["code"] != "execution_start_failed" || strings.Contains(string(tryout.Summary), starterErr.Error()) {
+		t.Fatalf("unsafe failure summary: %s", tryout.Summary)
+	}
+}
+
+func TestAgentTryoutManagerMapsHarnessExecutionStatusOnRead(t *testing.T) {
+	ctx := context.Background()
+	orgID := uuid.New()
+	workspaceID := uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo).WithExecution(&fakeAgentHarnessWorkflowStarter{}, AgentTryoutExecutionConfig{PublicWorkspaceID: &workspaceID})
+
+	tryout, err := manager.CreateAnonymousTryout(ctx, CreateAnonymousAgentTryoutInput{
+		TemplateSlug:         "meeting-minutes",
+		Input:                json.RawMessage(`{"notes":"complete it"}`),
+		AnonymousFingerprint: "203.0.113.10",
+	})
+	if err != nil {
+		t.Fatalf("CreateAnonymousTryout returned error: %v", err)
+	}
+	execution := repo.executionsByRunID[*tryout.RunID]
+	started := time.Now().UTC().Add(-2 * time.Second)
+	completed := time.Now().UTC()
+	execution.Status = string(repository.AgentHarnessExecutionStatusCompleted)
+	execution.StartedAt = &started
+	execution.CompletedAt = &completed
+	repo.executionsByRunID[*tryout.RunID] = execution
+
+	refreshed, err := manager.GetPublicTryout(ctx, tryout.ID)
+	if err != nil {
+		t.Fatalf("GetPublicTryout returned error: %v", err)
+	}
+	if refreshed.Status != repository.AgentTryoutStatusCompleted || refreshed.RedactionStatus != repository.AgentTryoutRedactionPassed {
+		t.Fatalf("refreshed tryout = %#v, want completed/passed", refreshed)
+	}
+	if refreshed.LatencyMS == nil || *refreshed.LatencyMS <= 0 {
+		t.Fatalf("latency_ms = %v, want positive", refreshed.LatencyMS)
+	}
+}
+
+func TestBuildAgentTryoutHarnessPayload(t *testing.T) {
+	template := builtinAgentTryoutTemplates()[0]
+	tryout := repository.AgentTryout{ID: uuid.New(), InputSnapshot: json.RawMessage(`{"notes":"turn this into actions"}`)}
+	repo := newFakeAgentTryoutRepository(uuid.New(), uuid.New())
+	dispatcher := agentTryoutExecutionDispatcher{repo: repo, starter: &fakeAgentHarnessWorkflowStarter{}, config: normalizeAgentTryoutExecutionConfig(AgentTryoutExecutionConfig{E2BTemplateID: "tryout-template"})}
+	harness := repository.AgentHarness{ID: uuid.New(), OrganizationID: repo.orgID, WorkspaceID: repo.workspaceID}
+	executionConfig := dispatcher.executionConfig(template)
+	evaluationConfig := agentTryoutEvaluationConfig(template, tryout)
+
+	snapshot, err := dispatcher.harnessSnapshot(harness, template, tryout, executionConfig, evaluationConfig)
+	if err != nil {
+		t.Fatalf("harnessSnapshot returned error: %v", err)
+	}
+	var decoded struct {
+		TaskPrompt       string          `json:"task_prompt"`
+		CodexTemplate    string          `json:"codex_template"`
+		ExecutionConfig  json.RawMessage `json:"execution_config"`
+		EvaluationConfig json.RawMessage `json:"evaluation_config"`
+	}
+	if err := json.Unmarshal(snapshot, &decoded); err != nil {
+		t.Fatalf("decode snapshot: %v", err)
+	}
+	if decoded.CodexTemplate != "tryout-template" || !strings.Contains(decoded.TaskPrompt, "turn this into actions") {
+		t.Fatalf("snapshot = %+v", decoded)
+	}
+	if !bytes.Contains(decoded.ExecutionConfig, []byte(`"timeout_seconds":120`)) {
+		t.Fatalf("execution config = %s, want timeout", decoded.ExecutionConfig)
+	}
+	if !bytes.Contains(decoded.EvaluationConfig, []byte(`"kind":"agent_tryout"`)) {
+		t.Fatalf("evaluation config = %s, want agent_tryout metadata", decoded.EvaluationConfig)
+	}
+}
+
 func TestCreateAnonymousAgentTryoutHandler(t *testing.T) {
 	service := &fakeAgentTryoutService{
 		tryout: repository.AgentTryout{
@@ -248,14 +420,26 @@ func TestGetWorkspaceAgentTryoutHandlerValidatesWorkspaceIDBeforeServiceCall(t *
 }
 
 type fakeAgentTryoutRepository struct {
-	orgID       uuid.UUID
-	workspaceID uuid.UUID
-	tryouts     map[uuid.UUID]repository.AgentTryout
-	share       repository.PublicShareLink
+	orgID              uuid.UUID
+	workspaceID        uuid.UUID
+	tryouts            map[uuid.UUID]repository.AgentTryout
+	harnessBySlug      map[string]repository.AgentHarness
+	executionsByRunID  map[uuid.UUID]repository.AgentHarnessExecution
+	createdHarnesses   []repository.CreateAgentHarnessParams
+	createdExecutions  []repository.CreateAgentHarnessExecutionParams
+	transitionedStatus repository.AgentHarnessExecutionStatus
+	transitionedReason *string
+	share              repository.PublicShareLink
 }
 
 func newFakeAgentTryoutRepository(orgID, workspaceID uuid.UUID) *fakeAgentTryoutRepository {
-	return &fakeAgentTryoutRepository{orgID: orgID, workspaceID: workspaceID, tryouts: map[uuid.UUID]repository.AgentTryout{}}
+	return &fakeAgentTryoutRepository{
+		orgID:             orgID,
+		workspaceID:       workspaceID,
+		tryouts:           map[uuid.UUID]repository.AgentTryout{},
+		harnessBySlug:     map[string]repository.AgentHarness{},
+		executionsByRunID: map[uuid.UUID]repository.AgentHarnessExecution{},
+	}
 }
 
 func (r *fakeAgentTryoutRepository) GetOrganizationIDByWorkspaceID(_ context.Context, workspaceID uuid.UUID) (uuid.UUID, error) {
@@ -295,11 +479,145 @@ func (r *fakeAgentTryoutRepository) CreateAgentTryout(_ context.Context, params 
 	return tryout, nil
 }
 
+func (r *fakeAgentTryoutRepository) GetAgentHarnessByWorkspaceSlug(_ context.Context, workspaceID uuid.UUID, slug string) (repository.AgentHarness, error) {
+	harness, ok := r.harnessBySlug[workspaceID.String()+"/"+slug]
+	if !ok {
+		return repository.AgentHarness{}, repository.ErrAgentHarnessNotFound
+	}
+	return harness, nil
+}
+
+func (r *fakeAgentTryoutRepository) CreateAgentHarness(_ context.Context, params repository.CreateAgentHarnessParams) (repository.AgentHarness, error) {
+	r.createdHarnesses = append(r.createdHarnesses, params)
+	now := time.Now().UTC()
+	harness := repository.AgentHarness{
+		ID:                     uuid.New(),
+		OrganizationID:         params.OrganizationID,
+		WorkspaceID:            params.WorkspaceID,
+		CreatedByUserID:        params.CreatedByUserID,
+		Name:                   params.Name,
+		Slug:                   params.Slug,
+		Description:            params.Description,
+		Status:                 "draft",
+		HarnessKind:            params.HarnessKind,
+		TaskPrompt:             params.TaskPrompt,
+		CodexTemplate:          params.CodexTemplate,
+		AuthMode:               params.AuthMode,
+		OpenAIAPIKeySecretName: params.OpenAIAPIKeySecretName,
+		ExecutionConfig:        params.ExecutionConfig,
+		EvaluationConfig:       params.EvaluationConfig,
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}
+	r.harnessBySlug[params.WorkspaceID.String()+"/"+params.Slug] = harness
+	return harness, nil
+}
+
+func (r *fakeAgentTryoutRepository) CreateAgentHarnessExecution(_ context.Context, params repository.CreateAgentHarnessExecutionParams) (repository.AgentHarnessExecution, error) {
+	r.createdExecutions = append(r.createdExecutions, params)
+	now := time.Now().UTC()
+	runID := uuid.New()
+	runAgentID := uuid.New()
+	execution := repository.AgentHarnessExecution{
+		ID:                       uuid.New(),
+		OrganizationID:           params.OrganizationID,
+		WorkspaceID:              params.WorkspaceID,
+		AgentHarnessID:           params.AgentHarnessID,
+		CreatedByUserID:          params.CreatedByUserID,
+		RunID:                    &runID,
+		RunAgentID:               &runAgentID,
+		Status:                   string(repository.AgentHarnessExecutionStatusQueued),
+		HarnessSnapshot:          params.HarnessSnapshot,
+		ExecutionConfigSnapshot:  params.ExecutionConfigSnapshot,
+		EvaluationConfigSnapshot: params.EvaluationConfigSnapshot,
+		CreatedAt:                now,
+		UpdatedAt:                now,
+	}
+	r.executionsByRunID[runID] = execution
+	return execution, nil
+}
+
+func (r *fakeAgentTryoutRepository) SetAgentHarnessExecutionTemporalIDs(_ context.Context, params repository.SetAgentHarnessExecutionTemporalIDsParams) (repository.AgentHarnessExecution, error) {
+	for runID, execution := range r.executionsByRunID {
+		if execution.ID == params.ExecutionID {
+			workflowID := params.TemporalWorkflowID
+			runIDValue := params.TemporalRunID
+			execution.TemporalWorkflowID = &workflowID
+			execution.TemporalRunID = &runIDValue
+			r.executionsByRunID[runID] = execution
+			return execution, nil
+		}
+	}
+	return repository.AgentHarnessExecution{}, repository.ErrAgentHarnessExecutionNotFound
+}
+
+func (r *fakeAgentTryoutRepository) TransitionAgentHarnessExecutionStatus(_ context.Context, params repository.TransitionAgentHarnessExecutionStatusParams) (repository.AgentHarnessExecution, error) {
+	r.transitionedStatus = params.ToStatus
+	r.transitionedReason = params.Reason
+	for runID, execution := range r.executionsByRunID {
+		if execution.ID == params.ExecutionID {
+			execution.Status = string(params.ToStatus)
+			execution.ErrorMessage = params.Reason
+			r.executionsByRunID[runID] = execution
+			return execution, nil
+		}
+	}
+	return repository.AgentHarnessExecution{}, repository.ErrAgentHarnessExecutionNotFound
+}
+
+func (r *fakeAgentTryoutRepository) GetAgentHarnessExecutionByRunID(_ context.Context, runID uuid.UUID) (repository.AgentHarnessExecution, error) {
+	execution, ok := r.executionsByRunID[runID]
+	if !ok {
+		return repository.AgentHarnessExecution{}, repository.ErrAgentHarnessExecutionNotFound
+	}
+	return execution, nil
+}
+
 func (r *fakeAgentTryoutRepository) GetAgentTryoutByID(_ context.Context, id uuid.UUID) (repository.AgentTryout, error) {
 	tryout, ok := r.tryouts[id]
 	if !ok {
 		return repository.AgentTryout{}, repository.ErrAgentTryoutNotFound
 	}
+	return tryout, nil
+}
+
+func (r *fakeAgentTryoutRepository) LinkAgentTryoutRunIfUnset(_ context.Context, params repository.LinkAgentTryoutRunParams) (repository.AgentTryout, error) {
+	tryout, ok := r.tryouts[params.ID]
+	if !ok {
+		return repository.AgentTryout{}, repository.ErrAgentTryoutNotFound
+	}
+	if tryout.RunID == nil {
+		tryout.RunID = &params.RunID
+		if tryout.Status == repository.AgentTryoutStatusQueued {
+			tryout.Status = params.Status
+		}
+		if len(params.Summary) > 0 {
+			tryout.Summary = params.Summary
+		}
+	}
+	r.tryouts[tryout.ID] = tryout
+	return tryout, nil
+}
+
+func (r *fakeAgentTryoutRepository) UpdateAgentTryoutStatus(_ context.Context, params repository.UpdateAgentTryoutStatusParams) (repository.AgentTryout, error) {
+	tryout, ok := r.tryouts[params.ID]
+	if !ok {
+		return repository.AgentTryout{}, repository.ErrAgentTryoutNotFound
+	}
+	tryout.Status = params.Status
+	if len(params.Summary) > 0 {
+		tryout.Summary = params.Summary
+	}
+	if params.ActualCostUSD != nil {
+		tryout.ActualCostUSD = params.ActualCostUSD
+	}
+	if params.LatencyMS != nil {
+		tryout.LatencyMS = params.LatencyMS
+	}
+	if params.RedactionStatus != nil {
+		tryout.RedactionStatus = *params.RedactionStatus
+	}
+	r.tryouts[tryout.ID] = tryout
 	return tryout, nil
 }
 

--- a/backend/internal/api/config.go
+++ b/backend/internal/api/config.go
@@ -14,6 +14,7 @@ import (
 
 	billingpkg "github.com/agentclash/agentclash/backend/internal/billing"
 	"github.com/agentclash/agentclash/backend/internal/secrets"
+	"github.com/google/uuid"
 )
 
 const (
@@ -41,46 +42,50 @@ const (
 var ErrInvalidConfig = errors.New("invalid api server config")
 
 type Config struct {
-	AppEnvironment            string
-	AuthMode                  string // "dev" or "workos"
-	WorkOSClientID            string // required when AuthMode is "workos"
-	WorkOSIssuer              string // optional; defaults to "https://api.workos.com/user_management/{ClientID}"
-	BindAddress               string
-	DatabaseURL               string
-	TemporalAddress           string
-	TemporalNamespace         string
-	HostedRunCallbackSecret   string
-	CORSAllowedOrigins        map[string]struct{} // parsed from CORS_ALLOWED_ORIGINS; empty means wildcard in dev, deny in prod
-	ShutdownTimeout           time.Duration
-	ArtifactStorageBackend    string
-	ArtifactStorageBucket     string
-	ArtifactFilesystemRoot    string
-	ArtifactS3Region          string
-	ArtifactS3Endpoint        string
-	ArtifactS3AccessKeyID     string
-	ArtifactS3SecretKey       string
-	ArtifactS3ForcePathStyle  bool
-	ArtifactSigningSecret     string
-	ArtifactSignedURLTTL      time.Duration
-	ArtifactMaxUploadBytes    int64
-	SecretsCipher             *secrets.AESGCMCipher
-	RateLimitRPS              float64
-	RateLimitBurst            int
-	RateLimitRunCreationRPM   float64
-	RateLimitRunCreationBurst int
-	ResendAPIKey              string
-	ResendFromEmail           string
-	FrontendURL               string
-	GitHubAppSlug             string
-	GitHubAppID               int64
-	GitHubAppPrivateKey       string
-	GitHubAppStateSecret      string
-	GitHubWebhookSecret       string
-	DodoPaymentsAPIKey        string
-	DodoPaymentsWebhookKey    string
-	DodoEnvironment           string
-	DodoProductIDs            billingpkg.DodoProductIDs
-	DodoAPIBaseURL            string
+	AppEnvironment                    string
+	AuthMode                          string // "dev" or "workos"
+	WorkOSClientID                    string // required when AuthMode is "workos"
+	WorkOSIssuer                      string // optional; defaults to "https://api.workos.com/user_management/{ClientID}"
+	BindAddress                       string
+	DatabaseURL                       string
+	TemporalAddress                   string
+	TemporalNamespace                 string
+	HostedRunCallbackSecret           string
+	CORSAllowedOrigins                map[string]struct{} // parsed from CORS_ALLOWED_ORIGINS; empty means wildcard in dev, deny in prod
+	ShutdownTimeout                   time.Duration
+	ArtifactStorageBackend            string
+	ArtifactStorageBucket             string
+	ArtifactFilesystemRoot            string
+	ArtifactS3Region                  string
+	ArtifactS3Endpoint                string
+	ArtifactS3AccessKeyID             string
+	ArtifactS3SecretKey               string
+	ArtifactS3ForcePathStyle          bool
+	ArtifactSigningSecret             string
+	ArtifactSignedURLTTL              time.Duration
+	ArtifactMaxUploadBytes            int64
+	SecretsCipher                     *secrets.AESGCMCipher
+	RateLimitRPS                      float64
+	RateLimitBurst                    int
+	RateLimitRunCreationRPM           float64
+	RateLimitRunCreationBurst         int
+	ResendAPIKey                      string
+	ResendFromEmail                   string
+	FrontendURL                       string
+	GitHubAppSlug                     string
+	GitHubAppID                       int64
+	GitHubAppPrivateKey               string
+	GitHubAppStateSecret              string
+	GitHubWebhookSecret               string
+	DodoPaymentsAPIKey                string
+	DodoPaymentsWebhookKey            string
+	DodoEnvironment                   string
+	DodoProductIDs                    billingpkg.DodoProductIDs
+	DodoAPIBaseURL                    string
+	AgentTryoutPublicWorkspaceID      *uuid.UUID
+	AgentTryoutPublicCreatedByUserID  *uuid.UUID
+	AgentTryoutE2BTemplateID          string
+	AgentTryoutOpenAIAPIKeySecretName string
 }
 
 func LoadConfigFromEnv() (Config, error) {
@@ -210,47 +215,59 @@ func LoadConfigFromEnv() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	agentTryoutPublicWorkspaceID, err := optionalUUIDEnv("AGENT_TRYOUT_PUBLIC_WORKSPACE_ID")
+	if err != nil {
+		return Config{}, err
+	}
+	agentTryoutPublicCreatedByUserID, err := optionalUUIDEnv("AGENT_TRYOUT_PUBLIC_CREATED_BY_USER_ID")
+	if err != nil {
+		return Config{}, err
+	}
 
 	cfg := Config{
-		AppEnvironment:            appEnvironment,
-		AuthMode:                  authMode,
-		WorkOSClientID:            workosClientID,
-		WorkOSIssuer:              workosIssuer,
-		BindAddress:               bindAddress,
-		DatabaseURL:               databaseURL,
-		TemporalAddress:           temporalAddress,
-		TemporalNamespace:         temporalNamespace,
-		HostedRunCallbackSecret:   hostedRunCallbackSecret,
-		CORSAllowedOrigins:        corsAllowedOrigins,
-		ShutdownTimeout:           defaultShutdownTime,
-		ArtifactStorageBackend:    artifactStorageBackend,
-		ArtifactStorageBucket:     artifactStorageBucket,
-		ArtifactFilesystemRoot:    artifactFilesystemRoot,
-		ArtifactS3Region:          artifactS3Region,
-		ArtifactS3Endpoint:        artifactS3Endpoint,
-		ArtifactS3AccessKeyID:     artifactS3AccessKeyID,
-		ArtifactS3SecretKey:       artifactS3SecretKey,
-		ArtifactS3ForcePathStyle:  artifactS3ForcePathStyle,
-		ArtifactSigningSecret:     artifactSigningSecret,
-		ArtifactSignedURLTTL:      artifactSignedURLTTL,
-		ArtifactMaxUploadBytes:    artifactMaxUploadBytes,
-		RateLimitRPS:              defaultRateLimitRPS,
-		RateLimitBurst:            defaultRateLimitBurst,
-		RateLimitRunCreationRPM:   defaultRateLimitRunCreationRPM,
-		RateLimitRunCreationBurst: defaultRateLimitRunCreationBurst,
-		ResendAPIKey:              resendAPIKey,
-		ResendFromEmail:           resendFromEmail,
-		FrontendURL:               frontendURL,
-		GitHubAppSlug:             os.Getenv("GITHUB_APP_SLUG"),
-		GitHubAppID:               githubAppID,
-		GitHubAppPrivateKey:       normalizePEMEnv(os.Getenv("GITHUB_APP_PRIVATE_KEY")),
-		GitHubAppStateSecret:      os.Getenv("GITHUB_APP_STATE_SECRET"),
-		GitHubWebhookSecret:       os.Getenv("GITHUB_WEBHOOK_SECRET"),
-		DodoPaymentsAPIKey:        dodoPaymentsAPIKey,
-		DodoPaymentsWebhookKey:    dodoPaymentsWebhookKey,
-		DodoEnvironment:           dodoEnvironment,
-		DodoProductIDs:            dodoProductIDs,
-		DodoAPIBaseURL:            os.Getenv("DODO_API_BASE_URL"),
+		AppEnvironment:                    appEnvironment,
+		AuthMode:                          authMode,
+		WorkOSClientID:                    workosClientID,
+		WorkOSIssuer:                      workosIssuer,
+		BindAddress:                       bindAddress,
+		DatabaseURL:                       databaseURL,
+		TemporalAddress:                   temporalAddress,
+		TemporalNamespace:                 temporalNamespace,
+		HostedRunCallbackSecret:           hostedRunCallbackSecret,
+		CORSAllowedOrigins:                corsAllowedOrigins,
+		ShutdownTimeout:                   defaultShutdownTime,
+		ArtifactStorageBackend:            artifactStorageBackend,
+		ArtifactStorageBucket:             artifactStorageBucket,
+		ArtifactFilesystemRoot:            artifactFilesystemRoot,
+		ArtifactS3Region:                  artifactS3Region,
+		ArtifactS3Endpoint:                artifactS3Endpoint,
+		ArtifactS3AccessKeyID:             artifactS3AccessKeyID,
+		ArtifactS3SecretKey:               artifactS3SecretKey,
+		ArtifactS3ForcePathStyle:          artifactS3ForcePathStyle,
+		ArtifactSigningSecret:             artifactSigningSecret,
+		ArtifactSignedURLTTL:              artifactSignedURLTTL,
+		ArtifactMaxUploadBytes:            artifactMaxUploadBytes,
+		RateLimitRPS:                      defaultRateLimitRPS,
+		RateLimitBurst:                    defaultRateLimitBurst,
+		RateLimitRunCreationRPM:           defaultRateLimitRunCreationRPM,
+		RateLimitRunCreationBurst:         defaultRateLimitRunCreationBurst,
+		ResendAPIKey:                      resendAPIKey,
+		ResendFromEmail:                   resendFromEmail,
+		FrontendURL:                       frontendURL,
+		GitHubAppSlug:                     os.Getenv("GITHUB_APP_SLUG"),
+		GitHubAppID:                       githubAppID,
+		GitHubAppPrivateKey:               normalizePEMEnv(os.Getenv("GITHUB_APP_PRIVATE_KEY")),
+		GitHubAppStateSecret:              os.Getenv("GITHUB_APP_STATE_SECRET"),
+		GitHubWebhookSecret:               os.Getenv("GITHUB_WEBHOOK_SECRET"),
+		DodoPaymentsAPIKey:                dodoPaymentsAPIKey,
+		DodoPaymentsWebhookKey:            dodoPaymentsWebhookKey,
+		DodoEnvironment:                   dodoEnvironment,
+		DodoProductIDs:                    dodoProductIDs,
+		DodoAPIBaseURL:                    os.Getenv("DODO_API_BASE_URL"),
+		AgentTryoutPublicWorkspaceID:      agentTryoutPublicWorkspaceID,
+		AgentTryoutPublicCreatedByUserID:  agentTryoutPublicCreatedByUserID,
+		AgentTryoutE2BTemplateID:          os.Getenv("AGENT_TRYOUT_E2B_TEMPLATE_ID"),
+		AgentTryoutOpenAIAPIKeySecretName: os.Getenv("AGENT_TRYOUT_OPENAI_API_KEY_SECRET_NAME"),
 	}
 
 	if err := validateArtifactConfig(cfg); err != nil {
@@ -279,6 +296,18 @@ func optionalInt64Env(key string) (int64, error) {
 		return 0, fmt.Errorf("%w: %s must be greater than zero", ErrInvalidConfig, key)
 	}
 	return parsed, nil
+}
+
+func optionalUUIDEnv(key string) (*uuid.UUID, error) {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return nil, nil
+	}
+	parsed, err := uuid.Parse(value)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s must be a UUID", ErrInvalidConfig, key)
+	}
+	return &parsed, nil
 }
 
 func normalizePEMEnv(value string) string {

--- a/backend/internal/repository/agent_harnesses.go
+++ b/backend/internal/repository/agent_harnesses.go
@@ -118,6 +118,19 @@ WHERE id = $1 AND archived_at IS NULL`, id)
 	return scanAgentHarness(row)
 }
 
+func (r *Repository) GetAgentHarnessByWorkspaceSlug(ctx context.Context, workspaceID uuid.UUID, slug string) (AgentHarness, error) {
+	row := r.db.QueryRow(ctx, `
+SELECT id, organization_id, workspace_id, created_by_user_id, name, slug, description,
+    status, harness_kind, task_prompt, codex_template, codex_model, auth_mode,
+    openai_api_key_secret_name, e2b_api_key_secret_name, repository_url, repository_provider,
+    github_repository_id, github_installation_id, repository_full_name, repository_clone_url, base_branch,
+    execution_config, evaluation_config, created_at, updated_at, archived_at
+FROM agent_harnesses
+WHERE workspace_id = $1 AND slug = $2 AND archived_at IS NULL
+LIMIT 1`, workspaceID, strings.TrimSpace(slug))
+	return scanAgentHarness(row)
+}
+
 func (r *Repository) ListAgentHarnessesByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]AgentHarness, error) {
 	rows, err := r.db.Query(ctx, `
 SELECT id, organization_id, workspace_id, created_by_user_id, name, slug, description,

--- a/backend/internal/repository/agent_tryouts.go
+++ b/backend/internal/repository/agent_tryouts.go
@@ -98,6 +98,13 @@ type UpdateAgentTryoutStatusParams struct {
 	RedactionStatus *AgentTryoutRedactionStatus
 }
 
+type LinkAgentTryoutRunParams struct {
+	ID      uuid.UUID
+	RunID   uuid.UUID
+	Status  AgentTryoutStatus
+	Summary json.RawMessage
+}
+
 func (r *Repository) CreateAgentTryout(ctx context.Context, params CreateAgentTryoutParams) (AgentTryout, error) {
 	costLimit, err := numericFromFloat(&params.CostLimitUSD)
 	if err != nil {
@@ -225,6 +232,92 @@ func (r *Repository) SetAgentTryoutRunID(ctx context.Context, id uuid.UUID, runI
 			return AgentTryout{}, ErrAgentTryoutNotFound
 		}
 		return AgentTryout{}, fmt.Errorf("set agent tryout run id: %w", err)
+	}
+	return mapAgentTryout(row)
+}
+
+func (r *Repository) LinkAgentTryoutRunIfUnset(ctx context.Context, params LinkAgentTryoutRunParams) (AgentTryout, error) {
+	status := params.Status
+	if status == "" {
+		status = AgentTryoutStatusRunning
+	}
+	row := r.db.QueryRow(ctx, `
+UPDATE agent_tryouts
+SET
+    run_id = COALESCE(run_id, $2),
+    status = CASE
+        WHEN run_id IS NULL AND status = 'queued' THEN $3
+        ELSE status
+    END,
+    summary = CASE
+        WHEN run_id IS NULL AND $4::jsonb IS NOT NULL THEN $4::jsonb
+        ELSE summary
+    END
+WHERE id = $1
+RETURNING id, organization_id, workspace_id, template_slug, status, input_snapshot,
+    template_snapshot, tool_policy_snapshot, evaluation_spec_snapshot, selected_model_policy,
+    summary, redaction_status, run_id, cost_limit_usd, actual_cost_usd, latency_ms,
+    max_duration_seconds, anonymous_fingerprint_hash, created_by_user_id,
+    claimed_by_user_id, claimed_at, expires_at, created_at, updated_at`,
+		params.ID, params.RunID, string(status), nullableJSON(params.Summary),
+	)
+	tryout, err := scanAgentTryoutRow(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return AgentTryout{}, ErrAgentTryoutNotFound
+		}
+		return AgentTryout{}, fmt.Errorf("link agent tryout run: %w", err)
+	}
+	return tryout, nil
+}
+
+func (r *Repository) GetAgentHarnessExecutionByRunID(ctx context.Context, runID uuid.UUID) (AgentHarnessExecution, error) {
+	row := r.db.QueryRow(ctx, `
+SELECT id, organization_id, workspace_id, agent_harness_id, created_by_user_id,
+    run_id, run_agent_id, evaluation_spec_id, temporal_workflow_id, temporal_run_id, retry_of_execution_id, retry_idempotency_key,
+    status, harness_snapshot, execution_config_snapshot, evaluation_config_snapshot,
+    error_message, started_at, completed_at, cancelled_at, created_at, updated_at
+FROM agent_harness_executions
+WHERE run_id = $1
+ORDER BY created_at ASC
+LIMIT 1`, runID)
+	return scanAgentHarnessExecution(row)
+}
+
+type agentTryoutScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanAgentTryoutRow(scanner agentTryoutScanner) (AgentTryout, error) {
+	var row repositorysqlc.AgentTryout
+	err := scanner.Scan(
+		&row.ID,
+		&row.OrganizationID,
+		&row.WorkspaceID,
+		&row.TemplateSlug,
+		&row.Status,
+		&row.InputSnapshot,
+		&row.TemplateSnapshot,
+		&row.ToolPolicySnapshot,
+		&row.EvaluationSpecSnapshot,
+		&row.SelectedModelPolicy,
+		&row.Summary,
+		&row.RedactionStatus,
+		&row.RunID,
+		&row.CostLimitUsd,
+		&row.ActualCostUsd,
+		&row.LatencyMs,
+		&row.MaxDurationSeconds,
+		&row.AnonymousFingerprintHash,
+		&row.CreatedByUserID,
+		&row.ClaimedByUserID,
+		&row.ClaimedAt,
+		&row.ExpiresAt,
+		&row.CreatedAt,
+		&row.UpdatedAt,
+	)
+	if err != nil {
+		return AgentTryout{}, err
 	}
 	return mapAgentTryout(row)
 }

--- a/backend/internal/repository/agent_tryouts_integration_test.go
+++ b/backend/internal/repository/agent_tryouts_integration_test.go
@@ -103,6 +103,24 @@ func TestRepositoryAgentTryoutLifecycle(t *testing.T) {
 	if withRun.RunID == nil || *withRun.RunID != runID {
 		t.Fatalf("run id = %v, want %s", withRun.RunID, runID)
 	}
+	linkedAgain, err := repo.LinkAgentTryoutRunIfUnset(ctx, repository.LinkAgentTryoutRunParams{
+		ID:      created.ID,
+		RunID:   runID,
+		Status:  repository.AgentTryoutStatusRunning,
+		Summary: []byte(`{"verdict":"should_not_overwrite"}`),
+	})
+	if err != nil {
+		t.Fatalf("LinkAgentTryoutRunIfUnset returned error: %v", err)
+	}
+	if linkedAgain.RunID == nil || *linkedAgain.RunID != runID {
+		t.Fatalf("idempotent link run id = %v, want %s", linkedAgain.RunID, runID)
+	}
+	if linkedAgain.Status != repository.AgentTryoutStatusCompleted {
+		t.Fatalf("idempotent link status = %q, want completed", linkedAgain.Status)
+	}
+	if string(linkedAgain.Summary) != `{"verdict": "ready_to_inspect"}` && string(linkedAgain.Summary) != `{"verdict":"ready_to_inspect"}` {
+		t.Fatalf("idempotent link summary = %s, want existing summary", linkedAgain.Summary)
+	}
 
 	listed, err := repo.ListAgentTryoutsByWorkspaceID(ctx, fixture.workspaceID, 20, 0)
 	if err != nil {

--- a/testing/codex-agent-tryouts-execution-pipeline.md
+++ b/testing/codex-agent-tryouts-execution-pipeline.md
@@ -1,0 +1,42 @@
+# codex/agent-tryouts-execution-pipeline - Test Contract
+
+## Functional Behavior
+- Creating an anonymous tryout for an anonymous-enabled template persists a tryout, dispatches one backend execution when a public execution target is configured, sets `run_id`, and returns a non-queued status once dispatch starts.
+- Creating a workspace tryout uses the same dispatch path, scoped to the caller workspace, and links the tryout to the canonical harness run created by the execution pipeline.
+- Dispatch is idempotent: retrying dispatch for the same tryout must not create a second execution/run and must return the existing linked tryout.
+- Tryout status mirrors execution lifecycle at user-facing read time: queued/provisioning/running/scoring map to `running`, completed maps to `completed`, failed maps to `failed`, and cancelled maps to `cancelled`.
+- Completion persists a safe summary with status, execution identifiers, cost/latency fields when known, and redaction status.
+- Execution startup failures are persisted as `failed` with a stable machine-readable code and safe user-facing message; raw internal errors must not leak to public responses.
+- Invalid templates, disabled anonymous templates, malformed UUIDs, oversized bodies, invalid JSON, duplicate JSON documents, unauthorized workspace access, already claimed tryouts, and missing tryouts return stable API error codes.
+
+## Unit Tests
+- `TestAgentTryoutManagerDispatchesAnonymousTryout` - creates a tryout, starts exactly one harness execution, sets `run_id`, and returns running tryout.
+- `TestAgentTryoutManagerDispatchIsIdempotentWhenRunAlreadyLinked` - duplicate dispatch does not create another execution.
+- `TestAgentTryoutManagerMarksTryoutFailedWhenDispatchFails` - startup failures produce safe summary code/message and failed status.
+- `TestAgentTryoutManagerMapsHarnessExecutionStatusOnRead` - read path maps active, completed, failed, and cancelled execution states to tryout statuses.
+- `TestBuildAgentTryoutHarnessPayload` - template and input produce the expected task prompt, execution config, evaluation config, and harness snapshot.
+
+## Integration / Functional Tests
+- Repository integration verifies setting `run_id` only when absent and no-op behavior when an existing run is already linked.
+- Repository integration verifies status/summary/cost/latency/redaction updates round-trip.
+- API handler tests verify anonymous and workspace create responses include linked execution metadata.
+
+## Smoke Tests
+- `go test -short -count=1 ./internal/api -run AgentTryout`
+- `go test -short -count=1 ./internal/repository -run AgentTryout`
+- `go test -short -count=1 ./...`
+- Local API `/healthz` returns 200.
+
+## E2E Tests
+- N/A - full sandbox execution requires provider credentials; this change must still curl the local API with dev auth and verify dispatch/failure behavior against the local backend.
+
+## Manual / cURL Tests
+- `GET /v1/agent-tryout-templates` returns built-in templates.
+- `POST /v1/agent-tryouts` with meeting-minutes input returns `201`, an id, status, and linked execution metadata when configured.
+- `GET /v1/agent-tryouts/{id}` returns the latest mapped status and summary.
+- `POST /v1/workspaces/{workspaceID}/agent-tryouts` with dev auth returns workspace-scoped tryout and linked execution metadata.
+- `GET /v1/workspaces/{workspaceID}/agent-tryouts?limit=1&offset=0` returns the created item.
+- `GET /v1/workspaces/{workspaceID}/agent-tryouts/{id}` returns the created workspace item.
+- `POST /v1/agent-tryouts/{anonymousID}/claim` claims an anonymous tryout once; the second claim returns conflict.
+- `POST /v1/agent-tryouts/{workspaceID}/share` and `GET /public/shares/{token}` expose the private share safely.
+- Error curls cover malformed JSON, duplicate JSON, invalid tryout id, unknown template, disabled anonymous template, oversized input, unauthenticated workspace create, forbidden workspace create, missing tryout, and wrong workspace.


### PR DESCRIPTION
## Summary
- Dispatches Agent Tryouts into the existing E2B-backed agent harness execution pipeline.
- Adds env-backed anonymous/free tryout execution via `AGENT_TRYOUT_PUBLIC_WORKSPACE_ID`, plus E2B template and provider secret-name config.
- Links `agent_tryouts.run_id` to the canonical harness run, refreshes tryout status from harness execution state, and stores safe user-facing summaries.
- Adds idempotent run-link repository primitive, harness lookup by workspace slug, and focused API/repository coverage.

## Verification
- `go test -short -count=1 ./internal/api -run AgentTryout`
- `go test -short -count=1 ./internal/repository -run AgentTryout`
- `go test -short -count=1 ./...`
- `go vet ./...`

## Local curl run
Local API was started at `http://127.0.0.1:18080` with dev auth and:

```bash
AGENT_TRYOUT_PUBLIC_WORKSPACE_ID=22222222-2222-2222-2222-222222222222
AGENT_TRYOUT_PUBLIC_CREATED_BY_USER_ID=11111111-1111-1111-1111-111111111111
AGENT_TRYOUT_E2B_TEMPLATE_ID=codex
AGENT_TRYOUT_OPENAI_API_KEY_SECRET_NAME=OPENAI_API_KEY
```

Happy path curl results:

```text
GET  /healthz                                                   -> 200 {"ok":true,"service":"api-server"}
GET  /v1/agent-tryout-templates                                -> 200
POST /v1/agent-tryouts                                         -> 201 status=running run_id=present
GET  /v1/agent-tryouts/{anonymousTryoutID}                     -> 200 summary.status_source=agent_harness_execution
POST /v1/workspaces/{workspaceID}/agent-tryouts                -> 201 status=running run_id=present
GET  /v1/workspaces/{workspaceID}/agent-tryouts/{tryoutID}     -> 200
GET  /v1/workspaces/{workspaceID}/agent-tryouts?limit=1&offset=0 -> 200
POST /v1/agent-tryouts/{anonymousTryoutID}/claim               -> 200
POST /v1/agent-tryouts/{anonymousTryoutID}/claim again         -> 409 agent_tryout_already_claimed
POST /v1/agent-tryouts/{workspaceTryoutID}/share               -> 201 token=present
GET  /public/shares/{token}                                    -> 200
```

Representative linked response fields:

```json
{
  "anonymous": {
    "status": "running",
    "run_id": "4eb147fd-d23e-412a-94cd-b1745999d825",
    "summary": {
      "code": "execution_queued",
      "message": "Tryout execution is queued.",
      "execution_id": "9792348b-0a18-4467-be6b-8175a696cfad",
      "run_agent_id": "444c9cf4-e261-41a7-86ec-2aa06ec7234d",
      "status_source": "agent_harness_execution"
    }
  },
  "workspace": {
    "status": "running",
    "run_id": "78c58f63-e0d3-4753-becb-cfbda0d5f9f1",
    "summary": {
      "code": "execution_queued",
      "message": "Tryout execution is queued.",
      "execution_id": "894bbd60-99d3-4ebb-b85d-6bd714218cf1",
      "run_agent_id": "07d80cd0-e81d-47d6-aeef-6e154335d2e2",
      "status_source": "agent_harness_execution"
    }
  }
}
```

Edge case curl results:

```text
unknown_template                 -> 404 template_not_found
disabled_anon                    -> 400 invalid_agent_tryout_input
malformed_json                   -> 400 invalid_request
duplicate_json                   -> 400 invalid_request
invalid_tryout_id                -> 400 invalid_tryout_id
missing_tryout                   -> 404 agent_tryout_not_found
public_workspace_tryout_hidden   -> 404 agent_tryout_not_found
oversized_input                  -> 400 invalid_agent_tryout_input
oversized_request                -> 400 invalid_request
workspace_noauth                 -> 401 unauthorized
workspace_forbidden              -> 403 forbidden
workspace_bad_uuid               -> 400 invalid_workspace_id
workspace_wrong_path             -> 404 agent_tryout_not_found
share_missing                    -> 404 agent_tryout_not_found
```

Terminal-state read refresh was simulated locally by updating harness execution rows after creation:

```json
{
  "completed": {
    "status": "completed",
    "redaction_status": "passed",
    "latency_ms": 2000,
    "summary": { "code": "execution_completed", "status_source": "agent_harness_execution" }
  },
  "failed": {
    "status": "failed",
    "redaction_status": "not_required",
    "summary": { "code": "execution_failed", "status_source": "agent_harness_execution" },
    "raw_internal_error_leaked": false
  }
}
```

## Review status
- Checked GitHub flat PR comments and thread-aware review threads after local curl update.
- No Greptile comments/review threads are currently present on this PR.

Contract: `testing/codex-agent-tryouts-execution-pipeline.md`
