### PR TITLE
feat(agent-tryouts): add executable template runtime policies

### DIFF
--- a/backend/internal/api/agent_tryouts.go
+++ b/backend/internal/api/agent_tryouts.go
@@ -1047,7 +1047,8 @@ func validateAgentTryoutInputSchema(template AgentTryoutTemplate, object map[str
 		return fmt.Errorf("%w: template input schema must describe an object", ErrInvalidAgentTryoutInput)
 	}
 	for _, key := range schema.Required {
-		if _, ok := object[key]; !ok {
+		value, ok := object[key]
+		if !ok || value == nil {
 			return fmt.Errorf("%w: missing required field %q", ErrInvalidAgentTryoutInput, key)
 		}
 	}
@@ -1060,8 +1061,11 @@ func validateAgentTryoutInputSchema(template AgentTryoutTemplate, object map[str
 	}
 	for key, property := range schema.Properties {
 		value, ok := object[key]
-		if !ok || value == nil || strings.TrimSpace(property.Type) == "" {
+		if !ok || strings.TrimSpace(property.Type) == "" {
 			continue
+		}
+		if value == nil {
+			return fmt.Errorf("%w: field %q must be %s", ErrInvalidAgentTryoutInput, key, property.Type)
 		}
 		if !agentTryoutInputValueMatchesType(value, property.Type) {
 			return fmt.Errorf("%w: field %q must be %s", ErrInvalidAgentTryoutInput, key, property.Type)
@@ -1120,7 +1124,7 @@ func writeAgentTryoutError(w http.ResponseWriter, logger *slog.Logger, err error
 	case errors.Is(err, ErrAgentTryoutTemplateNotFound):
 		writeError(w, http.StatusNotFound, "template_not_found", "agent tryout template not found")
 	case errors.Is(err, ErrAgentTryoutTemplateUnavailable):
-		writeError(w, http.StatusConflict, "template_unavailable", err.Error())
+		writeError(w, http.StatusConflict, "template_unavailable", agentTryoutTemplateUnavailableMessage(err))
 	case errors.Is(err, repository.ErrAgentTryoutNotFound):
 		writeError(w, http.StatusNotFound, "agent_tryout_not_found", "agent tryout not found")
 	case errors.Is(err, repository.ErrAgentTryoutAlreadyClaimed):
@@ -1133,6 +1137,14 @@ func writeAgentTryoutError(w http.ResponseWriter, logger *slog.Logger, err error
 		logger.Error("agent tryout request failed", "error", err)
 		writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
 	}
+}
+
+func agentTryoutTemplateUnavailableMessage(err error) string {
+	message := strings.TrimPrefix(err.Error(), ErrAgentTryoutTemplateUnavailable.Error()+": ")
+	if strings.TrimSpace(message) == "" {
+		return "agent tryout template is unavailable"
+	}
+	return message
 }
 
 func mapAgentTryoutResponse(tryout repository.AgentTryout) agentTryoutResponse {

--- a/backend/internal/api/agent_tryouts.go
+++ b/backend/internal/api/agent_tryouts.go
@@ -28,8 +28,9 @@ const (
 )
 
 var (
-	ErrAgentTryoutTemplateNotFound = errors.New("agent tryout template not found")
-	ErrInvalidAgentTryoutInput     = errors.New("invalid agent tryout input")
+	ErrAgentTryoutTemplateNotFound    = errors.New("agent tryout template not found")
+	ErrAgentTryoutTemplateUnavailable = errors.New("agent tryout template unavailable")
+	ErrInvalidAgentTryoutInput        = errors.New("invalid agent tryout input")
 )
 
 type AgentTryoutRepository interface {
@@ -64,8 +65,11 @@ type AgentTryoutTemplate struct {
 	Slug               string          `json:"slug"`
 	Name               string          `json:"name"`
 	Description        string          `json:"description"`
+	Available          bool            `json:"available"`
+	UnavailableReason  string          `json:"unavailable_reason,omitempty"`
 	InputSchema        json.RawMessage `json:"input_schema"`
 	ToolPolicy         json.RawMessage `json:"tool_policy"`
+	Runtime            json.RawMessage `json:"runtime"`
 	EvaluationSpec     json.RawMessage `json:"evaluation_spec"`
 	DefaultModelPolicy json.RawMessage `json:"default_model_policy"`
 	AnonymousEnabled   bool            `json:"anonymous_enabled"`
@@ -152,6 +156,9 @@ func (m *AgentTryoutManager) CreateAnonymousTryout(ctx context.Context, input Cr
 	if err != nil {
 		return repository.AgentTryout{}, err
 	}
+	if err := ensureAgentTryoutTemplateAvailable(template); err != nil {
+		return repository.AgentTryout{}, err
+	}
 	if !template.AnonymousEnabled {
 		return repository.AgentTryout{}, fmt.Errorf("%w: template does not allow anonymous tryouts", ErrInvalidAgentTryoutInput)
 	}
@@ -191,6 +198,9 @@ func (m *AgentTryoutManager) CreateWorkspaceTryout(ctx context.Context, caller C
 	}
 	template, err := m.lookupTemplate(input.TemplateSlug)
 	if err != nil {
+		return repository.AgentTryout{}, err
+	}
+	if err := ensureAgentTryoutTemplateAvailable(template); err != nil {
 		return repository.AgentTryout{}, err
 	}
 	if err := validateAgentTryoutInput(template, input.Input); err != nil {
@@ -477,6 +487,8 @@ func (d *agentTryoutExecutionDispatcher) executionConfig(template AgentTryoutTem
 		"timeout_seconds": template.MaxDurationSeconds,
 		"agent_tryout": map[string]any{
 			"template_slug": template.Slug,
+			"runtime":       json.RawMessage(template.Runtime),
+			"tool_policy":   json.RawMessage(template.ToolPolicy),
 		},
 	})
 	return payload
@@ -492,6 +504,8 @@ func (d *agentTryoutExecutionDispatcher) harnessSnapshot(harness repository.Agen
 		"codex_template":             d.config.E2BTemplateID,
 		"auth_mode":                  AgentHarnessAuthModeAPIKeySecret,
 		"openai_api_key_secret_name": d.config.OpenAIAPIKeySecretName,
+		"template_runtime":           json.RawMessage(template.Runtime),
+		"tool_policy":                json.RawMessage(template.ToolPolicy),
 		"execution_config":           json.RawMessage(executionConfig),
 		"evaluation_config":          json.RawMessage(evaluationConfig),
 	}
@@ -518,6 +532,7 @@ func agentTryoutTaskPrompt(template AgentTryoutTemplate, input json.RawMessage) 
 func agentTryoutEvaluationConfig(template AgentTryoutTemplate, tryout repository.AgentTryout) json.RawMessage {
 	payload, _ := json.Marshal(map[string]any{
 		"template_evaluation_spec": json.RawMessage(template.EvaluationSpec),
+		"template_runtime":         json.RawMessage(template.Runtime),
 		"privacy": map[string]any{
 			"redact_replay":    true,
 			"redact_artifacts": true,
@@ -995,7 +1010,89 @@ func validateAgentTryoutInput(template AgentTryoutTemplate, raw json.RawMessage)
 	if object == nil {
 		return fmt.Errorf("%w: input must be a JSON object", ErrInvalidAgentTryoutInput)
 	}
+	if err := validateAgentTryoutInputSchema(template, object); err != nil {
+		return err
+	}
 	return nil
+}
+
+func ensureAgentTryoutTemplateAvailable(template AgentTryoutTemplate) error {
+	if template.Available {
+		return nil
+	}
+	reason := strings.TrimSpace(template.UnavailableReason)
+	if reason == "" {
+		reason = "template runtime is not available"
+	}
+	return fmt.Errorf("%w: %s", ErrAgentTryoutTemplateUnavailable, reason)
+}
+
+type agentTryoutInputSchema struct {
+	Type                 string                                    `json:"type"`
+	Required             []string                                  `json:"required"`
+	Properties           map[string]agentTryoutInputPropertySchema `json:"properties"`
+	AdditionalProperties *bool                                     `json:"additionalProperties"`
+}
+
+type agentTryoutInputPropertySchema struct {
+	Type string `json:"type"`
+}
+
+func validateAgentTryoutInputSchema(template AgentTryoutTemplate, object map[string]any) error {
+	var schema agentTryoutInputSchema
+	if err := json.Unmarshal(template.InputSchema, &schema); err != nil {
+		return fmt.Errorf("%w: template input schema is invalid", ErrInvalidAgentTryoutInput)
+	}
+	if schema.Type != "" && schema.Type != "object" {
+		return fmt.Errorf("%w: template input schema must describe an object", ErrInvalidAgentTryoutInput)
+	}
+	for _, key := range schema.Required {
+		if _, ok := object[key]; !ok {
+			return fmt.Errorf("%w: missing required field %q", ErrInvalidAgentTryoutInput, key)
+		}
+	}
+	if schema.AdditionalProperties != nil && !*schema.AdditionalProperties {
+		for key := range object {
+			if _, ok := schema.Properties[key]; !ok {
+				return fmt.Errorf("%w: unsupported field %q", ErrInvalidAgentTryoutInput, key)
+			}
+		}
+	}
+	for key, property := range schema.Properties {
+		value, ok := object[key]
+		if !ok || value == nil || strings.TrimSpace(property.Type) == "" {
+			continue
+		}
+		if !agentTryoutInputValueMatchesType(value, property.Type) {
+			return fmt.Errorf("%w: field %q must be %s", ErrInvalidAgentTryoutInput, key, property.Type)
+		}
+	}
+	return nil
+}
+
+func agentTryoutInputValueMatchesType(value any, schemaType string) bool {
+	switch schemaType {
+	case "string":
+		_, ok := value.(string)
+		return ok
+	case "object":
+		_, ok := value.(map[string]any)
+		return ok
+	case "array":
+		_, ok := value.([]any)
+		return ok
+	case "boolean":
+		_, ok := value.(bool)
+		return ok
+	case "number":
+		_, ok := value.(float64)
+		return ok
+	case "integer":
+		number, ok := value.(float64)
+		return ok && number == float64(int64(number))
+	default:
+		return true
+	}
 }
 
 func decodeAgentTryoutJSON(r *http.Request, dest any) error {
@@ -1022,6 +1119,8 @@ func writeAgentTryoutError(w http.ResponseWriter, logger *slog.Logger, err error
 	switch {
 	case errors.Is(err, ErrAgentTryoutTemplateNotFound):
 		writeError(w, http.StatusNotFound, "template_not_found", "agent tryout template not found")
+	case errors.Is(err, ErrAgentTryoutTemplateUnavailable):
+		writeError(w, http.StatusConflict, "template_unavailable", err.Error())
 	case errors.Is(err, repository.ErrAgentTryoutNotFound):
 		writeError(w, http.StatusNotFound, "agent_tryout_not_found", "agent tryout not found")
 	case errors.Is(err, repository.ErrAgentTryoutAlreadyClaimed):
@@ -1091,6 +1190,9 @@ func templateSnapshot(template AgentTryoutTemplate) json.RawMessage {
 		"slug":                 template.Slug,
 		"name":                 template.Name,
 		"description":          template.Description,
+		"available":            template.Available,
+		"unavailable_reason":   template.UnavailableReason,
+		"runtime":              json.RawMessage(template.Runtime),
 		"anonymous_enabled":    template.AnonymousEnabled,
 		"max_input_bytes":      template.MaxInputBytes,
 		"max_duration_seconds": template.MaxDurationSeconds,
@@ -1128,9 +1230,11 @@ func builtinAgentTryoutTemplates() []AgentTryoutTemplate {
 			Slug:               "meeting-minutes",
 			Name:               "Meeting Minutes to Action Plan",
 			Description:        "Turn notes or a transcript into minutes, decisions, risks, and action items.",
-			InputSchema:        json.RawMessage(`{"type":"object","required":["notes"],"properties":{"notes":{"type":"string"},"audience":{"type":"string"}}}`),
-			ToolPolicy:         json.RawMessage(`{"tools":["file_writer"],"network":"disabled","external_side_effects":false}`),
-			EvaluationSpec:     json.RawMessage(`{"validators":[{"key":"has_action_items","type":"jsonpath","path":"$.action_items"}],"scorecard":{"dimensions":["correctness","reliability","latency","cost"]}}`),
+			Available:          true,
+			InputSchema:        json.RawMessage(`{"type":"object","required":["notes"],"additionalProperties":false,"properties":{"notes":{"type":"string"},"audience":{"type":"string"}}}`),
+			ToolPolicy:         json.RawMessage(`{"tools":["file_writer"],"sandbox":{"filesystem":"workspace","shell":"disabled"},"network":{"mode":"disabled"},"external_side_effects":false}`),
+			Runtime:            json.RawMessage(`{"adapter":"meeting_minutes_v1","sandbox":{"filesystem":"workspace","shell":"disabled","network":"disabled"},"expected_artifacts":[{"key":"action_plan","type":"markdown","path":"action-plan.md"},{"key":"structured_minutes","type":"json","path":"minutes.json"}],"validation":{"validators":[{"key":"has_summary","type":"json_field","field":"summary"},{"key":"has_action_items","type":"json_field","field":"action_items"}],"score_dimensions":["correctness","reliability","latency","cost"]}}`),
+			EvaluationSpec:     json.RawMessage(`{"validators":[{"key":"has_summary","type":"json_field","field":"summary"},{"key":"has_action_items","type":"json_field","field":"action_items"}],"scorecard":{"dimensions":["correctness","reliability","latency","cost"]}}`),
 			DefaultModelPolicy: json.RawMessage(`{"mode":"hosted_default","max_models":1}`),
 			AnonymousEnabled:   true,
 			MaxInputBytes:      64 * 1024,
@@ -1141,8 +1245,11 @@ func builtinAgentTryoutTemplates() []AgentTryoutTemplate {
 			Slug:               "structured-data",
 			Name:               "Extract Structured Data",
 			Description:        "Extract rows from messy text into JSON or CSV and validate the shape.",
-			InputSchema:        json.RawMessage(`{"type":"object","required":["text"],"properties":{"text":{"type":"string"},"schema":{"type":"object"}}}`),
-			ToolPolicy:         json.RawMessage(`{"tools":["schema_validator","file_writer"],"network":"disabled","external_side_effects":false}`),
+			Available:          false,
+			UnavailableReason:  "structured data validator runtime is not enabled yet",
+			InputSchema:        json.RawMessage(`{"type":"object","required":["text"],"additionalProperties":false,"properties":{"text":{"type":"string"},"schema":{"type":"object"}}}`),
+			ToolPolicy:         json.RawMessage(`{"tools":["schema_validator","file_writer"],"sandbox":{"filesystem":"workspace","shell":"disabled"},"network":{"mode":"disabled"},"external_side_effects":false}`),
+			Runtime:            json.RawMessage(`{"adapter":"structured_data_v1","sandbox":{"filesystem":"workspace","shell":"disabled","network":"disabled"},"expected_artifacts":[{"key":"extracted_rows","type":"json","path":"extracted-rows.json"}],"validation":{"validators":[{"key":"valid_json","type":"json_schema"}],"score_dimensions":["correctness","reliability","latency","cost"]}}`),
 			EvaluationSpec:     json.RawMessage(`{"validators":[{"key":"valid_json","type":"json_schema"}],"scorecard":{"dimensions":["correctness","reliability","latency","cost"]}}`),
 			DefaultModelPolicy: json.RawMessage(`{"mode":"hosted_default","max_models":1}`),
 			AnonymousEnabled:   true,
@@ -1154,8 +1261,10 @@ func builtinAgentTryoutTemplates() []AgentTryoutTemplate {
 			Slug:               "tiny-bugfix",
 			Name:               "Fix a Tiny Bug",
 			Description:        "Run an agent against a small fixture, inspect the diff, and see whether tests pass.",
-			InputSchema:        json.RawMessage(`{"type":"object","required":["task"],"properties":{"task":{"type":"string"},"fixture":{"type":"string"}}}`),
-			ToolPolicy:         json.RawMessage(`{"tools":["sandbox_shell","file_editor"],"network":"disabled","external_side_effects":false}`),
+			Available:          true,
+			InputSchema:        json.RawMessage(`{"type":"object","required":["task"],"additionalProperties":false,"properties":{"task":{"type":"string"},"fixture":{"type":"string"}}}`),
+			ToolPolicy:         json.RawMessage(`{"tools":["sandbox_shell","file_editor"],"sandbox":{"filesystem":"workspace","shell":"allowed"},"network":{"mode":"disabled"},"external_side_effects":false}`),
+			Runtime:            json.RawMessage(`{"adapter":"tiny_bugfix_v1","sandbox":{"filesystem":"workspace","shell":"allowed","network":"disabled"},"expected_artifacts":[{"key":"diff","type":"patch","path":"changes.patch"},{"key":"test_result","type":"json","path":"test-result.json"}],"validation":{"validators":[{"key":"tests_pass","type":"command_exit_code"}],"score_dimensions":["correctness","reliability","latency","cost"]}}`),
 			EvaluationSpec:     json.RawMessage(`{"validators":[{"key":"tests_pass","type":"command_exit_code"}],"scorecard":{"dimensions":["correctness","reliability","latency","cost"]}}`),
 			DefaultModelPolicy: json.RawMessage(`{"mode":"hosted_default","max_models":1}`),
 			AnonymousEnabled:   false,

--- a/backend/internal/api/agent_tryouts_test.go
+++ b/backend/internal/api/agent_tryouts_test.go
@@ -106,13 +106,24 @@ func TestAgentTryoutManagerRejectsInvalidTemplateInputBeforeCreate(t *testing.T)
 	repo := newFakeAgentTryoutRepository(uuid.New(), uuid.New())
 	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
 
-	_, err := manager.CreateAnonymousTryout(context.Background(), CreateAnonymousAgentTryoutInput{
-		TemplateSlug:         "meeting-minutes",
-		Input:                json.RawMessage(`{"audience":"execs"}`),
-		AnonymousFingerprint: "203.0.113.10",
-	})
-	if !errors.Is(err, ErrInvalidAgentTryoutInput) {
-		t.Fatalf("CreateAnonymousTryout error = %v, want ErrInvalidAgentTryoutInput", err)
+	for _, tc := range []struct {
+		name  string
+		input json.RawMessage
+	}{
+		{name: "missing required field", input: json.RawMessage(`{"audience":"execs"}`)},
+		{name: "required null field", input: json.RawMessage(`{"notes":null}`)},
+		{name: "optional null field", input: json.RawMessage(`{"notes":"hello","audience":null}`)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := manager.CreateAnonymousTryout(context.Background(), CreateAnonymousAgentTryoutInput{
+				TemplateSlug:         "meeting-minutes",
+				Input:                tc.input,
+				AnonymousFingerprint: "203.0.113.10",
+			})
+			if !errors.Is(err, ErrInvalidAgentTryoutInput) {
+				t.Fatalf("CreateAnonymousTryout error = %v, want ErrInvalidAgentTryoutInput", err)
+			}
+		})
 	}
 	if len(repo.tryouts) != 0 || len(repo.createdExecutions) != 0 {
 		t.Fatalf("invalid input should not create or dispatch tryouts: tryouts=%d executions=%d", len(repo.tryouts), len(repo.createdExecutions))
@@ -552,6 +563,10 @@ func TestCreateAnonymousAgentTryoutHandlerMapsUnavailableTemplate(t *testing.T) 
 	}
 	if !strings.Contains(rr.Body.String(), `"code":"template_unavailable"`) {
 		t.Fatalf("body = %s, want template_unavailable", rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), ErrAgentTryoutTemplateUnavailable.Error()) ||
+		!strings.Contains(rr.Body.String(), `"message":"structured data validator runtime is not enabled yet"`) {
+		t.Fatalf("body = %s, want product-facing reason without sentinel prefix", rr.Body.String())
 	}
 }
 

--- a/backend/internal/api/agent_tryouts_test.go
+++ b/backend/internal/api/agent_tryouts_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -47,6 +48,11 @@ func TestAgentTryoutManagerCreateAnonymousPersistsGuardrailSnapshots(t *testing.
 	if len(tryout.TemplateSnapshot) == 0 || len(tryout.ToolPolicySnapshot) == 0 || len(tryout.EvaluationSpecSnapshot) == 0 {
 		t.Fatalf("tryout should persist template/tool/evaluation snapshots: %+v", tryout)
 	}
+	if !bytes.Contains(tryout.TemplateSnapshot, []byte(`"available":true`)) ||
+		!bytes.Contains(tryout.TemplateSnapshot, []byte(`"expected_artifacts"`)) ||
+		!bytes.Contains(tryout.ToolPolicySnapshot, []byte(`"network":{"mode":"disabled"`)) {
+		t.Fatalf("tryout snapshots should include runtime policy: template=%s tool=%s", tryout.TemplateSnapshot, tryout.ToolPolicySnapshot)
+	}
 }
 
 func TestAgentTryoutManagerRejectsAnonymousWhenTemplateDisabled(t *testing.T) {
@@ -60,6 +66,90 @@ func TestAgentTryoutManagerRejectsAnonymousWhenTemplateDisabled(t *testing.T) {
 	})
 	if !errors.Is(err, ErrInvalidAgentTryoutInput) {
 		t.Fatalf("CreateAnonymousTryout error = %v, want ErrInvalidAgentTryoutInput", err)
+	}
+}
+
+func TestAgentTryoutTemplatesExposeRuntimeMetadata(t *testing.T) {
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), newFakeAgentTryoutRepository(uuid.New(), uuid.New()))
+	templates, err := manager.ListTemplates(context.Background())
+	if err != nil {
+		t.Fatalf("ListTemplates returned error: %v", err)
+	}
+	if len(templates) == 0 {
+		t.Fatal("ListTemplates returned no templates")
+	}
+	var meeting AgentTryoutTemplate
+	for _, template := range templates {
+		if template.Slug == "meeting-minutes" {
+			meeting = template
+			break
+		}
+	}
+	if meeting.Slug == "" {
+		t.Fatal("meeting-minutes template not found")
+	}
+	if !meeting.Available || meeting.UnavailableReason != "" {
+		t.Fatalf("meeting availability = %v reason=%q, want available", meeting.Available, meeting.UnavailableReason)
+	}
+	if !bytes.Contains(meeting.ToolPolicy, []byte(`"file_writer"`)) ||
+		!bytes.Contains(meeting.ToolPolicy, []byte(`"network":{"mode":"disabled"`)) {
+		t.Fatalf("meeting tool policy = %s, want file writer with disabled network", meeting.ToolPolicy)
+	}
+	if !bytes.Contains(meeting.Runtime, []byte(`"expected_artifacts"`)) ||
+		!bytes.Contains(meeting.Runtime, []byte(`"validation"`)) ||
+		!bytes.Contains(meeting.Runtime, []byte(`"sandbox"`)) {
+		t.Fatalf("meeting runtime = %s, want artifacts, validation, and sandbox policy", meeting.Runtime)
+	}
+}
+
+func TestAgentTryoutManagerRejectsInvalidTemplateInputBeforeCreate(t *testing.T) {
+	repo := newFakeAgentTryoutRepository(uuid.New(), uuid.New())
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	_, err := manager.CreateAnonymousTryout(context.Background(), CreateAnonymousAgentTryoutInput{
+		TemplateSlug:         "meeting-minutes",
+		Input:                json.RawMessage(`{"audience":"execs"}`),
+		AnonymousFingerprint: "203.0.113.10",
+	})
+	if !errors.Is(err, ErrInvalidAgentTryoutInput) {
+		t.Fatalf("CreateAnonymousTryout error = %v, want ErrInvalidAgentTryoutInput", err)
+	}
+	if len(repo.tryouts) != 0 || len(repo.createdExecutions) != 0 {
+		t.Fatalf("invalid input should not create or dispatch tryouts: tryouts=%d executions=%d", len(repo.tryouts), len(repo.createdExecutions))
+	}
+}
+
+func TestAgentTryoutManagerRejectsUnavailableTemplateBeforeCreate(t *testing.T) {
+	repo := newFakeAgentTryoutRepository(uuid.New(), uuid.New())
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	_, err := manager.CreateAnonymousTryout(context.Background(), CreateAnonymousAgentTryoutInput{
+		TemplateSlug:         "structured-data",
+		Input:                json.RawMessage(`{"text":"name: Ada"}`),
+		AnonymousFingerprint: "203.0.113.10",
+	})
+	if !errors.Is(err, ErrAgentTryoutTemplateUnavailable) {
+		t.Fatalf("CreateAnonymousTryout error = %v, want ErrAgentTryoutTemplateUnavailable", err)
+	}
+	if len(repo.tryouts) != 0 || len(repo.createdExecutions) != 0 {
+		t.Fatalf("unavailable template should not create or dispatch tryouts: tryouts=%d executions=%d", len(repo.tryouts), len(repo.createdExecutions))
+	}
+}
+
+func TestAgentTryoutManagerRejectsClientRuntimePolicyFields(t *testing.T) {
+	repo := newFakeAgentTryoutRepository(uuid.New(), uuid.New())
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	_, err := manager.CreateAnonymousTryout(context.Background(), CreateAnonymousAgentTryoutInput{
+		TemplateSlug:         "meeting-minutes",
+		Input:                json.RawMessage(`{"notes":"hello","tools":["sandbox_shell"],"network":"enabled","cost_limit_usd":99}`),
+		AnonymousFingerprint: "203.0.113.10",
+	})
+	if !errors.Is(err, ErrInvalidAgentTryoutInput) {
+		t.Fatalf("CreateAnonymousTryout error = %v, want ErrInvalidAgentTryoutInput", err)
+	}
+	if len(repo.tryouts) != 0 {
+		t.Fatalf("client runtime policy override should not create tryout, created %d", len(repo.tryouts))
 	}
 }
 
@@ -381,8 +471,16 @@ func TestBuildAgentTryoutHarnessPayload(t *testing.T) {
 	if !bytes.Contains(decoded.ExecutionConfig, []byte(`"timeout_seconds":120`)) {
 		t.Fatalf("execution config = %s, want timeout", decoded.ExecutionConfig)
 	}
+	if !bytes.Contains(decoded.ExecutionConfig, []byte(`"runtime"`)) ||
+		!bytes.Contains(decoded.ExecutionConfig, []byte(`"tool_policy"`)) ||
+		!bytes.Contains(decoded.ExecutionConfig, []byte(`"expected_artifacts"`)) {
+		t.Fatalf("execution config = %s, want runtime policy", decoded.ExecutionConfig)
+	}
 	if !bytes.Contains(decoded.EvaluationConfig, []byte(`"kind":"agent_tryout"`)) {
 		t.Fatalf("evaluation config = %s, want agent_tryout metadata", decoded.EvaluationConfig)
+	}
+	if !bytes.Contains(decoded.EvaluationConfig, []byte(`"validation"`)) {
+		t.Fatalf("evaluation config = %s, want template validation metadata", decoded.EvaluationConfig)
 	}
 }
 
@@ -420,6 +518,40 @@ func TestCreateAnonymousAgentTryoutHandler(t *testing.T) {
 	}
 	if service.createAnonymousInput.AnonymousFingerprint != "203.0.113.10" {
 		t.Fatalf("fingerprint = %q, want first forwarded IP", service.createAnonymousInput.AnonymousFingerprint)
+	}
+}
+
+func TestListAgentTryoutTemplatesHandlerReturnsRuntimeMetadata(t *testing.T) {
+	service := &fakeAgentTryoutService{templates: builtinAgentTryoutTemplates()}
+	handler := listAgentTryoutTemplatesHandler(slog.Default(), service)
+	req := httptest.NewRequest(http.MethodGet, "/v1/agent-tryout-templates", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"available":true`) ||
+		!strings.Contains(rr.Body.String(), `"runtime"`) ||
+		!strings.Contains(rr.Body.String(), `"expected_artifacts"`) {
+		t.Fatalf("template response missing runtime metadata: %s", rr.Body.String())
+	}
+}
+
+func TestCreateAnonymousAgentTryoutHandlerMapsUnavailableTemplate(t *testing.T) {
+	service := &fakeAgentTryoutService{createAnonymousErr: fmt.Errorf("%w: structured data validator runtime is not enabled yet", ErrAgentTryoutTemplateUnavailable)}
+	handler := createAnonymousAgentTryoutHandler(slog.Default(), service)
+	req := httptest.NewRequest(http.MethodPost, "/v1/agent-tryouts", bytes.NewBufferString(`{"template_slug":"structured-data","input":{"text":"name: Ada"}}`))
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status = %d body=%s, want 409", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"code":"template_unavailable"`) {
+		t.Fatalf("body = %s, want template_unavailable", rr.Body.String())
 	}
 }
 
@@ -774,6 +906,8 @@ func (r *fakeAgentTryoutRepository) CreatePublicShareLink(_ context.Context, par
 
 type fakeAgentTryoutService struct {
 	tryout               repository.AgentTryout
+	templates            []AgentTryoutTemplate
+	createAnonymousErr   error
 	createAnonymousInput CreateAnonymousAgentTryoutInput
 	listLimit            int32
 	listOffset           int32
@@ -781,11 +915,14 @@ type fakeAgentTryoutService struct {
 }
 
 func (s *fakeAgentTryoutService) ListTemplates(context.Context) ([]AgentTryoutTemplate, error) {
-	return nil, nil
+	return s.templates, nil
 }
 
 func (s *fakeAgentTryoutService) CreateAnonymousTryout(_ context.Context, input CreateAnonymousAgentTryoutInput) (repository.AgentTryout, error) {
 	s.createAnonymousInput = input
+	if s.createAnonymousErr != nil {
+		return repository.AgentTryout{}, s.createAnonymousErr
+	}
 	return s.tryout, nil
 }
 

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -12633,7 +12633,7 @@ components:
 
     AgentTryoutTemplate:
       type: object
-      required: [slug, name, description, input_schema, tool_policy, evaluation_spec, default_model_policy, anonymous_enabled, max_input_bytes, max_duration_seconds, max_cost_usd]
+      required: [slug, name, description, available, input_schema, tool_policy, runtime, evaluation_spec, default_model_policy, anonymous_enabled, max_input_bytes, max_duration_seconds, max_cost_usd]
       properties:
         slug:
           type: string
@@ -12641,12 +12641,22 @@ components:
           type: string
         description:
           type: string
+        available:
+          type: boolean
+          description: Whether this template can currently be executed by the hosted tryout runtime.
+        unavailable_reason:
+          type: string
+          description: Product-facing reason shown when a template is not executable in the current environment.
         input_schema:
           type: object
           additionalProperties: true
         tool_policy:
           type: object
           additionalProperties: true
+        runtime:
+          type: object
+          additionalProperties: true
+          description: Server-owned runtime policy including adapter, sandbox policy, expected artifacts, and validation metadata.
         evaluation_spec:
           type: object
           additionalProperties: true

--- a/testing/codex-agent-tryout-template-runtimes.md
+++ b/testing/codex-agent-tryout-template-runtimes.md
@@ -1,0 +1,38 @@
+# codex-agent-tryout-template-runtimes - Test Contract
+
+## Functional Behavior
+- Agent tryout templates expose executable runtime metadata, not just static catalog JSON: availability, unavailable reason, input schema, tool allowlist, sandbox/network policy, expected artifacts, validation strategy, max cost, and max duration.
+- Creating anonymous or workspace tryouts rejects malformed template input before persistence or execution with a stable `invalid_input` response.
+- Creating tryouts rejects unavailable templates before persistence or execution with a stable `template_unavailable` response and a user-readable reason.
+- Server-side runtime policy is authoritative: client input cannot add arbitrary tools, commands, network access, artifact paths, model policy, cost limit, or duration.
+- The harness execution payload includes the resolved runtime definition so workers/templates can enforce task-specific tools, sandbox limits, expected artifacts, and validators.
+- At least the first production template, `meeting-minutes`, is marked executable and includes concrete schema, tool policy, expected artifact metadata, and validation metadata.
+- Network access is disabled by default for executable templates unless explicitly enabled by the server-owned runtime definition.
+
+## Unit Tests
+- `TestAgentTryoutTemplatesExposeRuntimeMetadata` - list templates includes availability, runtime/tool/sandbox/artifact/validation metadata, and `meeting-minutes` is executable.
+- `TestAgentTryoutManagerRejectsInvalidTemplateInputBeforeCreate` - malformed input for a template returns `ErrInvalidAgentTryoutInput` and does not create a tryout.
+- `TestAgentTryoutManagerRejectsUnavailableTemplateBeforeCreate` - unavailable templates return `ErrAgentTryoutTemplateUnavailable` and do not create/dispatch.
+- `TestAgentTryoutManagerIgnoresClientRuntimePolicyFields` - extra input fields attempting to set tools/network/commands/model/cost are rejected or ignored and cannot alter snapshots.
+- `TestBuildAgentTryoutHarnessPayloadIncludesRuntimePolicy` - harness snapshot and execution config include the resolved runtime policy, expected artifacts, validators, sandbox policy, and template slug.
+
+## Integration / Functional Tests
+- Existing agent tryout repository tests continue to round-trip template, tool, model, and evaluation snapshots.
+- Existing create/dispatch manager tests continue to prove exactly one execution is linked for executable templates.
+- API handler tests cover `template_unavailable` and malformed input responses.
+
+## Smoke Tests
+- `go test -short -count=1 ./internal/api -run 'AgentTryout|TemplateRuntime'`
+- `go test -short -count=1 ./internal/repository -run AgentTryout`
+- `go test -short -count=1 ./...`
+- `go vet ./...`
+
+## E2E Tests
+- N/A - full E2B/provider execution requires external credentials. This change must still curl local API routes with dev/local configuration to verify template metadata and validation behavior.
+
+## Manual / cURL Tests
+- `GET /v1/agent-tryout-templates` returns runtime metadata for templates, including `meeting-minutes.available=true`, expected artifacts, sandbox policy, and validators.
+- `POST /v1/agent-tryouts` with valid `meeting-minutes` input returns `201` and snapshots server-owned runtime/tool/evaluation policy.
+- `POST /v1/agent-tryouts` with malformed `meeting-minutes` input returns `400 invalid_input` and creates no tryout.
+- `POST /v1/agent-tryouts` for an unavailable template returns `409 template_unavailable` or equivalent stable product-facing error without dispatching work.
+- `POST /v1/agent-tryouts` with extra client-supplied runtime/tool/network fields cannot enable arbitrary tools or network access.

--- a/testing/codex-agent-tryout-template-runtimes.md
+++ b/testing/codex-agent-tryout-template-runtimes.md
@@ -13,8 +13,8 @@
 - `TestAgentTryoutTemplatesExposeRuntimeMetadata` - list templates includes availability, runtime/tool/sandbox/artifact/validation metadata, and `meeting-minutes` is executable.
 - `TestAgentTryoutManagerRejectsInvalidTemplateInputBeforeCreate` - malformed input for a template returns `ErrInvalidAgentTryoutInput` and does not create a tryout.
 - `TestAgentTryoutManagerRejectsUnavailableTemplateBeforeCreate` - unavailable templates return `ErrAgentTryoutTemplateUnavailable` and do not create/dispatch.
-- `TestAgentTryoutManagerIgnoresClientRuntimePolicyFields` - extra input fields attempting to set tools/network/commands/model/cost are rejected or ignored and cannot alter snapshots.
-- `TestBuildAgentTryoutHarnessPayloadIncludesRuntimePolicy` - harness snapshot and execution config include the resolved runtime policy, expected artifacts, validators, sandbox policy, and template slug.
+- `TestAgentTryoutManagerRejectsClientRuntimePolicyFields` - extra input fields attempting to set tools/network/commands/model/cost are rejected and cannot alter snapshots.
+- `TestBuildAgentTryoutHarnessPayload` - harness snapshot and execution config include the resolved runtime policy, expected artifacts, validators, sandbox policy, and template slug.
 
 ## Integration / Functional Tests
 - Existing agent tryout repository tests continue to round-trip template, tool, model, and evaluation snapshots.


### PR DESCRIPTION
## Summary

Closes #943.

This starts the executable template runtime layer for Agent Tryouts:

- adds server-owned template availability metadata (`available`, `unavailable_reason`)
- adds `runtime` metadata with adapter, sandbox policy, expected artifacts, and validation strategy
- marks `meeting-minutes` as the first executable production template
- marks `structured-data` unavailable until its validator runtime exists
- enforces template input schemas before persistence/dispatch
- rejects client attempts to smuggle runtime/tool/network/cost fields through tryout input
- carries runtime/tool policy into harness execution and evaluation payloads
- updates OpenAPI for the expanded template response shape

## User-facing behavior

- `GET /v1/agent-tryout-templates` now tells the UI what can actually run, why something is unavailable, which tools are allowed, whether network is disabled, and what artifacts/validators to expect.
- A valid `meeting-minutes` request persists with server-owned snapshots.
- Malformed input returns stable `invalid_agent_tryout_input` errors before any run is created.
- Unavailable templates return `template_unavailable` before dispatching doomed work.

## Contract

Locked before implementation in `testing/codex-agent-tryout-template-runtimes.md`.

## Validation

Automated:

```bash
go test -short -count=1 ./internal/api -run 'AgentTryout|TemplateRuntime'
go test -short -count=1 ./internal/repository -run AgentTryout
go test -short -count=1 ./...
go vet ./...
git diff --check
```

Local curl matrix against `127.0.0.1:18080`:

```bash
curl -i http://127.0.0.1:18080/healthz
# 200 {"ok":true,"service":"api-server"}

curl http://127.0.0.1:18080/v1/agent-tryout-templates
# 3 templates; meeting-minutes available=true with runtime/tool_policy/expected_artifacts;
# structured-data available=false with reason "structured data validator runtime is not enabled yet"

curl -i -X POST http://127.0.0.1:18080/v1/agent-tryouts \
  -H 'Content-Type: application/json' \
  --data '{"template_slug":"meeting-minutes","input":{"notes":"Alice owns launch notes. Bob follows up on pricing.","audience":"execs"}}'
# 201; local env fail-closed as expected with summary.code=execution_not_configured;
# response includes runtime/tool/evaluation snapshots

curl -i http://127.0.0.1:18080/v1/agent-tryouts/f4aaaec6-f88e-4e04-8820-c2ce078b4410
# 200; returns persisted safe tryout response with runtime snapshots

curl -i -X POST http://127.0.0.1:18080/v1/agent-tryouts \
  -H 'Content-Type: application/json' \
  --data '{"template_slug":"meeting-minutes","input":{"audience":"execs"}}'
# 400 invalid_agent_tryout_input: missing required field "notes"

curl -i -X POST http://127.0.0.1:18080/v1/agent-tryouts \
  -H 'Content-Type: application/json' \
  --data '{"template_slug":"meeting-minutes","input":{"notes":123}}'
# 400 invalid_agent_tryout_input: field "notes" must be string

curl -i -X POST http://127.0.0.1:18080/v1/agent-tryouts \
  -H 'Content-Type: application/json' \
  --data '{"template_slug":"meeting-minutes","input":{"notes":"hello","tools":["sandbox_shell"],"network":"enabled","cost_limit_usd":99}}'
# 400 invalid_agent_tryout_input: unsupported field "tools"

curl -i -X POST http://127.0.0.1:18080/v1/agent-tryouts \
  -H 'Content-Type: application/json' \
  --data '{"template_slug":"structured-data","input":{"text":"name: Ada"}}'
# 409 template_unavailable

curl -i -X POST http://127.0.0.1:18080/v1/agent-tryouts \
  -H 'Content-Type: application/json' \
  --data '{"template_slug":"does-not-exist","input":{"notes":"hello"}}'
# 404 template_not_found
```

## Notes

Full E2B execution still depends on configured hosted workspace/provider credentials. This PR deliberately fails closed in unconfigured local mode while validating template runtime behavior.
