### PR TITLE
[codex] Cap anonymous agent tryout spend

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -130,7 +130,12 @@ func main() {
 	challengePackReadManager := api.NewChallengePackReadManager(repo)
 	challengePackAuthoringManager := api.NewChallengePackAuthoringManager(repo, artifactStore)
 	publicShareManager := api.NewPublicShareManager(authorizer, repo, cfg.FrontendURL)
-	agentTryoutManager := api.NewAgentTryoutManager(authorizer, repo).WithExecution(
+	agentTryoutManager := api.NewAgentTryoutManager(authorizer, repo).WithQuota(api.AgentTryoutQuotaConfig{
+		AnonymousLimit:            cfg.AgentTryoutAnonymousLimit,
+		AnonymousWindow:           cfg.AgentTryoutAnonymousWindow,
+		HostedDailySpendCapUSD:    cfg.AgentTryoutHostedDailySpendCapUSD,
+		AnonymousPerRunCostCapUSD: cfg.AgentTryoutAnonymousPerRunCostCapUSD,
+	}).WithExecution(
 		api.NewTemporalAgentHarnessExecutionWorkflowStarter(temporalClient),
 		api.AgentTryoutExecutionConfig{
 			PublicWorkspaceID:      cfg.AgentTryoutPublicWorkspaceID,

--- a/backend/internal/api/agent_tryouts.go
+++ b/backend/internal/api/agent_tryouts.go
@@ -28,9 +28,13 @@ const (
 )
 
 var (
-	ErrAgentTryoutTemplateNotFound    = errors.New("agent tryout template not found")
-	ErrAgentTryoutTemplateUnavailable = errors.New("agent tryout template unavailable")
-	ErrInvalidAgentTryoutInput        = errors.New("invalid agent tryout input")
+	ErrAgentTryoutTemplateNotFound        = errors.New("agent tryout template not found")
+	ErrAgentTryoutTemplateUnavailable     = errors.New("agent tryout template unavailable")
+	ErrInvalidAgentTryoutInput            = errors.New("invalid agent tryout input")
+	ErrAgentTryoutAnonymousQuotaExhausted = errors.New("agent tryout anonymous quota exhausted")
+	ErrAgentTryoutHostedSpendUnavailable  = errors.New("agent tryout hosted spend unavailable")
+	ErrAgentTryoutHostedSpendExhausted    = errors.New("agent tryout hosted spend exhausted")
+	ErrAgentTryoutCostCapExceeded         = errors.New("agent tryout cost cap exceeded")
 )
 
 type AgentTryoutRepository interface {
@@ -42,6 +46,8 @@ type AgentTryoutRepository interface {
 	TransitionAgentHarnessExecutionStatus(ctx context.Context, p repository.TransitionAgentHarnessExecutionStatusParams) (repository.AgentHarnessExecution, error)
 	GetAgentHarnessExecutionByRunID(ctx context.Context, runID uuid.UUID) (repository.AgentHarnessExecution, error)
 	CreateAgentTryout(ctx context.Context, params repository.CreateAgentTryoutParams) (repository.AgentTryout, error)
+	CountAnonymousAgentTryoutsByFingerprint(ctx context.Context, fingerprintHash string, since time.Time) (int64, error)
+	SumAnonymousAgentTryoutCostLimitUSD(ctx context.Context, windowStart, windowEnd time.Time) (float64, error)
 	GetAgentTryoutByID(ctx context.Context, id uuid.UUID) (repository.AgentTryout, error)
 	ListAgentTryoutsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID, limit, offset int32) ([]repository.AgentTryout, error)
 	LinkAgentTryoutRunIfUnset(ctx context.Context, params repository.LinkAgentTryoutRunParams) (repository.AgentTryout, error)
@@ -112,12 +118,20 @@ type AgentTryoutExecutionConfig struct {
 	ConcurrencyLimit       int
 }
 
+type AgentTryoutQuotaConfig struct {
+	AnonymousLimit            int
+	AnonymousWindow           time.Duration
+	HostedDailySpendCapUSD    float64
+	AnonymousPerRunCostCapUSD float64
+}
+
 type AgentTryoutManager struct {
 	authorizer WorkspaceAuthorizer
 	repo       AgentTryoutRepository
 	now        func() time.Time
 	templates  map[string]AgentTryoutTemplate
 	execution  *agentTryoutExecutionDispatcher
+	quota      *AgentTryoutQuotaConfig
 }
 
 func NewAgentTryoutManager(authorizer WorkspaceAuthorizer, repo AgentTryoutRepository) *AgentTryoutManager {
@@ -146,6 +160,12 @@ func (m *AgentTryoutManager) WithExecution(starter AgentHarnessExecutionWorkflow
 	return m
 }
 
+func (m *AgentTryoutManager) WithQuota(config AgentTryoutQuotaConfig) *AgentTryoutManager {
+	normalized := normalizeAgentTryoutQuotaConfig(config)
+	m.quota = &normalized
+	return m
+}
+
 func (m *AgentTryoutManager) ListTemplates(context.Context) ([]AgentTryoutTemplate, error) {
 	templates := builtinAgentTryoutTemplates()
 	return templates, nil
@@ -171,6 +191,9 @@ func (m *AgentTryoutManager) CreateAnonymousTryout(ctx context.Context, input Cr
 	}
 	expiresAt := now.UTC().Add(defaultAgentTryoutTTL)
 	fingerprintHash := hashAnonymousFingerprint(input.AnonymousFingerprint)
+	if err := m.enforceAnonymousQuota(ctx, template, fingerprintHash, now); err != nil {
+		return repository.AgentTryout{}, err
+	}
 	tryout, err := m.repo.CreateAgentTryout(ctx, repository.CreateAgentTryoutParams{
 		TemplateSlug:             template.Slug,
 		Status:                   repository.AgentTryoutStatusQueued,
@@ -294,6 +317,49 @@ func (m *AgentTryoutManager) refreshTryoutFromExecution(ctx context.Context, try
 		return tryout
 	}
 	return refreshed
+}
+
+func normalizeAgentTryoutQuotaConfig(config AgentTryoutQuotaConfig) AgentTryoutQuotaConfig {
+	if config.AnonymousLimit < 0 {
+		config.AnonymousLimit = 0
+	}
+	if config.AnonymousWindow <= 0 {
+		config.AnonymousWindow = 24 * time.Hour
+	}
+	if config.HostedDailySpendCapUSD < 0 {
+		config.HostedDailySpendCapUSD = 0
+	}
+	if config.AnonymousPerRunCostCapUSD < 0 {
+		config.AnonymousPerRunCostCapUSD = 0
+	}
+	return config
+}
+
+func (m *AgentTryoutManager) enforceAnonymousQuota(ctx context.Context, template AgentTryoutTemplate, fingerprintHash string, now time.Time) error {
+	if m.quota == nil {
+		return nil
+	}
+	config := *m.quota
+	if template.MaxCostUSD > config.AnonymousPerRunCostCapUSD {
+		return fmt.Errorf("%w: template cost limit %.4f exceeds anonymous per-run cap %.4f", ErrAgentTryoutCostCapExceeded, template.MaxCostUSD, config.AnonymousPerRunCostCapUSD)
+	}
+	count, err := m.repo.CountAnonymousAgentTryoutsByFingerprint(ctx, fingerprintHash, now.UTC().Add(-config.AnonymousWindow))
+	if err != nil {
+		return fmt.Errorf("%w: count anonymous tryouts: %v", ErrAgentTryoutHostedSpendUnavailable, err)
+	}
+	if count >= int64(config.AnonymousLimit) {
+		return ErrAgentTryoutAnonymousQuotaExhausted
+	}
+	windowStart := time.Date(now.UTC().Year(), now.UTC().Month(), now.UTC().Day(), 0, 0, 0, 0, time.UTC)
+	windowEnd := windowStart.Add(24 * time.Hour)
+	spend, err := m.repo.SumAnonymousAgentTryoutCostLimitUSD(ctx, windowStart, windowEnd)
+	if err != nil {
+		return fmt.Errorf("%w: sum hosted spend: %v", ErrAgentTryoutHostedSpendUnavailable, err)
+	}
+	if spend+template.MaxCostUSD > config.HostedDailySpendCapUSD {
+		return ErrAgentTryoutHostedSpendExhausted
+	}
+	return nil
 }
 
 type agentTryoutExecutionDispatcher struct {
@@ -1125,6 +1191,14 @@ func writeAgentTryoutError(w http.ResponseWriter, logger *slog.Logger, err error
 		writeError(w, http.StatusNotFound, "template_not_found", "agent tryout template not found")
 	case errors.Is(err, ErrAgentTryoutTemplateUnavailable):
 		writeError(w, http.StatusConflict, "template_unavailable", agentTryoutTemplateUnavailableMessage(err))
+	case errors.Is(err, ErrAgentTryoutAnonymousQuotaExhausted):
+		writeError(w, http.StatusTooManyRequests, "anonymous_quota_exhausted", "Free tryout limit reached. Sign in to save and rerun tryouts, or try again later.")
+	case errors.Is(err, ErrAgentTryoutHostedSpendUnavailable):
+		writeError(w, http.StatusServiceUnavailable, "hosted_spend_unavailable", "Hosted tryout spend accounting is unavailable. Please try again later.")
+	case errors.Is(err, ErrAgentTryoutHostedSpendExhausted):
+		writeError(w, http.StatusTooManyRequests, "hosted_spend_exhausted", "Hosted free tryouts are temporarily unavailable. Please try again later.")
+	case errors.Is(err, ErrAgentTryoutCostCapExceeded):
+		writeError(w, http.StatusBadRequest, "tryout_cost_cap_exceeded", "This template exceeds the hosted free tryout cost cap.")
 	case errors.Is(err, repository.ErrAgentTryoutNotFound):
 		writeError(w, http.StatusNotFound, "agent_tryout_not_found", "agent tryout not found")
 	case errors.Is(err, repository.ErrAgentTryoutAlreadyClaimed):

--- a/backend/internal/api/agent_tryouts.go
+++ b/backend/internal/api/agent_tryouts.go
@@ -28,13 +28,14 @@ const (
 )
 
 var (
-	ErrAgentTryoutTemplateNotFound        = errors.New("agent tryout template not found")
-	ErrAgentTryoutTemplateUnavailable     = errors.New("agent tryout template unavailable")
-	ErrInvalidAgentTryoutInput            = errors.New("invalid agent tryout input")
-	ErrAgentTryoutAnonymousQuotaExhausted = errors.New("agent tryout anonymous quota exhausted")
-	ErrAgentTryoutHostedSpendUnavailable  = errors.New("agent tryout hosted spend unavailable")
-	ErrAgentTryoutHostedSpendExhausted    = errors.New("agent tryout hosted spend exhausted")
-	ErrAgentTryoutCostCapExceeded         = errors.New("agent tryout cost cap exceeded")
+	ErrAgentTryoutTemplateNotFound          = errors.New("agent tryout template not found")
+	ErrAgentTryoutTemplateUnavailable       = errors.New("agent tryout template unavailable")
+	ErrInvalidAgentTryoutInput              = errors.New("invalid agent tryout input")
+	ErrAgentTryoutAnonymousQuotaExhausted   = errors.New("agent tryout anonymous quota exhausted")
+	ErrAgentTryoutAnonymousQuotaUnavailable = errors.New("agent tryout anonymous quota unavailable")
+	ErrAgentTryoutHostedSpendUnavailable    = errors.New("agent tryout hosted spend unavailable")
+	ErrAgentTryoutHostedSpendExhausted      = errors.New("agent tryout hosted spend exhausted")
+	ErrAgentTryoutCostCapExceeded           = errors.New("agent tryout cost cap exceeded")
 )
 
 type AgentTryoutRepository interface {
@@ -48,6 +49,7 @@ type AgentTryoutRepository interface {
 	CreateAgentTryout(ctx context.Context, params repository.CreateAgentTryoutParams) (repository.AgentTryout, error)
 	CountAnonymousAgentTryoutsByFingerprint(ctx context.Context, fingerprintHash string, since time.Time) (int64, error)
 	SumAnonymousAgentTryoutCostLimitUSD(ctx context.Context, windowStart, windowEnd time.Time) (float64, error)
+	WithinAnonymousAgentTryoutQuotaLock(ctx context.Context, fn func(repository.AnonymousAgentTryoutQuotaTx) error) error
 	GetAgentTryoutByID(ctx context.Context, id uuid.UUID) (repository.AgentTryout, error)
 	ListAgentTryoutsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID, limit, offset int32) ([]repository.AgentTryout, error)
 	LinkAgentTryoutRunIfUnset(ctx context.Context, params repository.LinkAgentTryoutRunParams) (repository.AgentTryout, error)
@@ -191,10 +193,7 @@ func (m *AgentTryoutManager) CreateAnonymousTryout(ctx context.Context, input Cr
 	}
 	expiresAt := now.UTC().Add(defaultAgentTryoutTTL)
 	fingerprintHash := hashAnonymousFingerprint(input.AnonymousFingerprint)
-	if err := m.enforceAnonymousQuota(ctx, template, fingerprintHash, now); err != nil {
-		return repository.AgentTryout{}, err
-	}
-	tryout, err := m.repo.CreateAgentTryout(ctx, repository.CreateAgentTryoutParams{
+	createParams := repository.CreateAgentTryoutParams{
 		TemplateSlug:             template.Slug,
 		Status:                   repository.AgentTryoutStatusQueued,
 		InputSnapshot:            input.Input,
@@ -208,6 +207,36 @@ func (m *AgentTryoutManager) CreateAnonymousTryout(ctx context.Context, input Cr
 		MaxDurationSeconds:       template.MaxDurationSeconds,
 		AnonymousFingerprintHash: &fingerprintHash,
 		ExpiresAt:                &expiresAt,
+	}
+
+	// When quotas are disabled there is nothing to serialize, so skip the lock.
+	if m.quota == nil {
+		tryout, err := m.repo.CreateAgentTryout(ctx, createParams)
+		if err != nil {
+			return repository.AgentTryout{}, err
+		}
+		return m.dispatchCreatedTryout(ctx, tryout, template)
+	}
+
+	// Fail fast on the static per-run cost cap before taking the global lock.
+	if err := m.enforceAnonymousPerRunCostCap(template); err != nil {
+		return repository.AgentTryout{}, err
+	}
+
+	// Enforce the per-fingerprint quota and hosted daily-spend cap, then create
+	// the tryout, all under a single advisory lock so concurrent requests cannot
+	// both pass the gate before either commits (TOCTOU-safe).
+	var tryout repository.AgentTryout
+	err = m.repo.WithinAnonymousAgentTryoutQuotaLock(ctx, func(qtx repository.AnonymousAgentTryoutQuotaTx) error {
+		if err := m.enforceAnonymousQuota(ctx, qtx, template, fingerprintHash, now); err != nil {
+			return err
+		}
+		created, err := qtx.CreateAgentTryout(ctx, createParams)
+		if err != nil {
+			return err
+		}
+		tryout = created
+		return nil
 	})
 	if err != nil {
 		return repository.AgentTryout{}, err
@@ -335,24 +364,36 @@ func normalizeAgentTryoutQuotaConfig(config AgentTryoutQuotaConfig) AgentTryoutQ
 	return config
 }
 
-func (m *AgentTryoutManager) enforceAnonymousQuota(ctx context.Context, template AgentTryoutTemplate, fingerprintHash string, now time.Time) error {
-	if m.quota == nil {
-		return nil
+// enforceAnonymousPerRunCostCap rejects templates whose per-run cost limit
+// exceeds the configured anonymous cap. It is pure (no DB access) so callers can
+// run it before acquiring the quota lock.
+func (m *AgentTryoutManager) enforceAnonymousPerRunCostCap(template AgentTryoutTemplate) error {
+	if template.MaxCostUSD > m.quota.AnonymousPerRunCostCapUSD {
+		return fmt.Errorf("%w: template cost limit %.4f exceeds anonymous per-run cap %.4f", ErrAgentTryoutCostCapExceeded, template.MaxCostUSD, m.quota.AnonymousPerRunCostCapUSD)
 	}
+	return nil
+}
+
+// enforceAnonymousQuota checks the per-fingerprint quota and hosted daily-spend
+// cap against qtx. Callers must invoke it inside WithinAnonymousAgentTryoutQuotaLock
+// (and create the tryout via the same qtx) so the reads and the insert are atomic.
+func (m *AgentTryoutManager) enforceAnonymousQuota(ctx context.Context, qtx repository.AnonymousAgentTryoutQuotaTx, template AgentTryoutTemplate, fingerprintHash string, now time.Time) error {
 	config := *m.quota
-	if template.MaxCostUSD > config.AnonymousPerRunCostCapUSD {
-		return fmt.Errorf("%w: template cost limit %.4f exceeds anonymous per-run cap %.4f", ErrAgentTryoutCostCapExceeded, template.MaxCostUSD, config.AnonymousPerRunCostCapUSD)
-	}
-	count, err := m.repo.CountAnonymousAgentTryoutsByFingerprint(ctx, fingerprintHash, now.UTC().Add(-config.AnonymousWindow))
+	count, err := qtx.CountAnonymousAgentTryoutsByFingerprint(ctx, fingerprintHash, now.UTC().Add(-config.AnonymousWindow))
 	if err != nil {
-		return fmt.Errorf("%w: count anonymous tryouts: %v", ErrAgentTryoutHostedSpendUnavailable, err)
+		return fmt.Errorf("%w: count anonymous tryouts: %v", ErrAgentTryoutAnonymousQuotaUnavailable, err)
 	}
 	if count >= int64(config.AnonymousLimit) {
 		return ErrAgentTryoutAnonymousQuotaExhausted
 	}
+	// The hosted spend cap is intentionally a fixed UTC calendar-day budget
+	// (HostedDailySpendCapUSD resets at UTC midnight), independent of the rolling
+	// per-fingerprint AnonymousWindow above. The two windows serve different
+	// purposes — abuse throttling per visitor vs. a global daily spend ceiling —
+	// so they are not derived from one another.
 	windowStart := time.Date(now.UTC().Year(), now.UTC().Month(), now.UTC().Day(), 0, 0, 0, 0, time.UTC)
 	windowEnd := windowStart.Add(24 * time.Hour)
-	spend, err := m.repo.SumAnonymousAgentTryoutCostLimitUSD(ctx, windowStart, windowEnd)
+	spend, err := qtx.SumAnonymousAgentTryoutCostLimitUSD(ctx, windowStart, windowEnd)
 	if err != nil {
 		return fmt.Errorf("%w: sum hosted spend: %v", ErrAgentTryoutHostedSpendUnavailable, err)
 	}
@@ -1193,6 +1234,8 @@ func writeAgentTryoutError(w http.ResponseWriter, logger *slog.Logger, err error
 		writeError(w, http.StatusConflict, "template_unavailable", agentTryoutTemplateUnavailableMessage(err))
 	case errors.Is(err, ErrAgentTryoutAnonymousQuotaExhausted):
 		writeError(w, http.StatusTooManyRequests, "anonymous_quota_exhausted", "Free tryout limit reached. Sign in to save and rerun tryouts, or try again later.")
+	case errors.Is(err, ErrAgentTryoutAnonymousQuotaUnavailable):
+		writeError(w, http.StatusServiceUnavailable, "anonymous_quota_unavailable", "Free tryout quota accounting is unavailable. Please try again later.")
 	case errors.Is(err, ErrAgentTryoutHostedSpendUnavailable):
 		writeError(w, http.StatusServiceUnavailable, "hosted_spend_unavailable", "Hosted tryout spend accounting is unavailable. Please try again later.")
 	case errors.Is(err, ErrAgentTryoutHostedSpendExhausted):

--- a/backend/internal/api/agent_tryouts_test.go
+++ b/backend/internal/api/agent_tryouts_test.go
@@ -179,6 +179,182 @@ func TestAgentTryoutManagerRejectsOversizedInput(t *testing.T) {
 	}
 }
 
+func TestAgentTryoutManagerAllowsAnonymousWithinQuotaAndSpendCaps(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeAgentTryoutRepository(uuid.New(), uuid.New())
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo).WithQuota(AgentTryoutQuotaConfig{
+		AnonymousLimit:            1,
+		AnonymousWindow:           24 * time.Hour,
+		HostedDailySpendCapUSD:    1,
+		AnonymousPerRunCostCapUSD: 1,
+	})
+
+	tryout, err := manager.CreateAnonymousTryout(ctx, CreateAnonymousAgentTryoutInput{
+		TemplateSlug:         "meeting-minutes",
+		Input:                json.RawMessage(`{"notes":"within cap"}`),
+		AnonymousFingerprint: "203.0.113.10",
+	})
+	if err != nil {
+		t.Fatalf("CreateAnonymousTryout returned error: %v", err)
+	}
+	if tryout.CostLimitUSD != 0.25 {
+		t.Fatalf("cost limit = %v, want template limit 0.25", tryout.CostLimitUSD)
+	}
+	if len(repo.tryouts) != 1 {
+		t.Fatalf("tryouts created = %d, want 1", len(repo.tryouts))
+	}
+}
+
+func TestAgentTryoutManagerRejectsAnonymousQuotaExhaustedBeforeCreate(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeAgentTryoutRepository(uuid.New(), uuid.New())
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo).WithQuota(AgentTryoutQuotaConfig{
+		AnonymousLimit:            1,
+		AnonymousWindow:           24 * time.Hour,
+		HostedDailySpendCapUSD:    1,
+		AnonymousPerRunCostCapUSD: 1,
+	})
+	input := CreateAnonymousAgentTryoutInput{
+		TemplateSlug:         "meeting-minutes",
+		Input:                json.RawMessage(`{"notes":"first"}`),
+		AnonymousFingerprint: "203.0.113.10",
+	}
+	if _, err := manager.CreateAnonymousTryout(ctx, input); err != nil {
+		t.Fatalf("first CreateAnonymousTryout returned error: %v", err)
+	}
+	input.Input = json.RawMessage(`{"notes":"second"}`)
+	_, err := manager.CreateAnonymousTryout(ctx, input)
+	if !errors.Is(err, ErrAgentTryoutAnonymousQuotaExhausted) {
+		t.Fatalf("second CreateAnonymousTryout error = %v, want ErrAgentTryoutAnonymousQuotaExhausted", err)
+	}
+	if len(repo.tryouts) != 1 {
+		t.Fatalf("tryouts created = %d, want still 1 after quota block", len(repo.tryouts))
+	}
+}
+
+func TestAgentTryoutManagerRejectsHostedSpendUnavailableBeforeCreate(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*fakeAgentTryoutRepository)
+	}{
+		{
+			name: "fingerprint count fails",
+			setup: func(repo *fakeAgentTryoutRepository) {
+				repo.countAnonymousErr = errors.New("count unavailable")
+			},
+		},
+		{
+			name: "hosted spend sum fails",
+			setup: func(repo *fakeAgentTryoutRepository) {
+				repo.sumAnonymousErr = errors.New("sum unavailable")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			repo := newFakeAgentTryoutRepository(uuid.New(), uuid.New())
+			tt.setup(repo)
+			manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo).WithQuota(AgentTryoutQuotaConfig{
+				AnonymousLimit:            1,
+				AnonymousWindow:           24 * time.Hour,
+				HostedDailySpendCapUSD:    1,
+				AnonymousPerRunCostCapUSD: 1,
+			})
+
+			_, err := manager.CreateAnonymousTryout(ctx, CreateAnonymousAgentTryoutInput{
+				TemplateSlug:         "meeting-minutes",
+				Input:                json.RawMessage(`{"notes":"fail closed"}`),
+				AnonymousFingerprint: "203.0.113.10",
+			})
+			if !errors.Is(err, ErrAgentTryoutHostedSpendUnavailable) {
+				t.Fatalf("CreateAnonymousTryout error = %v, want ErrAgentTryoutHostedSpendUnavailable", err)
+			}
+			if len(repo.tryouts) != 0 {
+				t.Fatalf("tryouts created = %d, want 0 when spend accounting unavailable", len(repo.tryouts))
+			}
+		})
+	}
+}
+
+func TestAgentTryoutManagerRejectsHostedSpendCapExceededBeforeCreate(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeAgentTryoutRepository(uuid.New(), uuid.New())
+	repo.hostedSpendUSD = 0.90
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo).WithQuota(AgentTryoutQuotaConfig{
+		AnonymousLimit:            1,
+		AnonymousWindow:           24 * time.Hour,
+		HostedDailySpendCapUSD:    1,
+		AnonymousPerRunCostCapUSD: 1,
+	})
+
+	_, err := manager.CreateAnonymousTryout(ctx, CreateAnonymousAgentTryoutInput{
+		TemplateSlug:         "meeting-minutes",
+		Input:                json.RawMessage(`{"notes":"over daily cap"}`),
+		AnonymousFingerprint: "203.0.113.10",
+	})
+	if !errors.Is(err, ErrAgentTryoutHostedSpendExhausted) {
+		t.Fatalf("CreateAnonymousTryout error = %v, want ErrAgentTryoutHostedSpendExhausted", err)
+	}
+	if len(repo.tryouts) != 0 {
+		t.Fatalf("tryouts created = %d, want 0 when daily cap exhausted", len(repo.tryouts))
+	}
+}
+
+func TestAgentTryoutManagerRejectsPerRunCostCapExceededBeforeCreate(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeAgentTryoutRepository(uuid.New(), uuid.New())
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo).WithQuota(AgentTryoutQuotaConfig{
+		AnonymousLimit:            1,
+		AnonymousWindow:           24 * time.Hour,
+		HostedDailySpendCapUSD:    1,
+		AnonymousPerRunCostCapUSD: 0.10,
+	})
+
+	_, err := manager.CreateAnonymousTryout(ctx, CreateAnonymousAgentTryoutInput{
+		TemplateSlug:         "meeting-minutes",
+		Input:                json.RawMessage(`{"notes":"over per run cap"}`),
+		AnonymousFingerprint: "203.0.113.10",
+	})
+	if !errors.Is(err, ErrAgentTryoutCostCapExceeded) {
+		t.Fatalf("CreateAnonymousTryout error = %v, want ErrAgentTryoutCostCapExceeded", err)
+	}
+	if len(repo.tryouts) != 0 {
+		t.Fatalf("tryouts created = %d, want 0 when per-run cap exceeded", len(repo.tryouts))
+	}
+}
+
+func TestAgentTryoutManagerDoesNotApplyAnonymousQuotaToWorkspaceTryout(t *testing.T) {
+	ctx := context.Background()
+	orgID := uuid.New()
+	workspaceID := uuid.New()
+	userID := uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo).WithQuota(AgentTryoutQuotaConfig{
+		AnonymousLimit:            0,
+		AnonymousWindow:           24 * time.Hour,
+		HostedDailySpendCapUSD:    0,
+		AnonymousPerRunCostCapUSD: 0,
+	})
+
+	tryout, err := manager.CreateWorkspaceTryout(ctx, Caller{
+		UserID: userID,
+		WorkspaceMemberships: map[uuid.UUID]WorkspaceMembership{
+			workspaceID: {WorkspaceID: workspaceID, Role: RoleWorkspaceMember},
+		},
+	}, CreateWorkspaceAgentTryoutInput{
+		WorkspaceID:  workspaceID,
+		TemplateSlug: "meeting-minutes",
+		Input:        json.RawMessage(`{"notes":"workspace tryout"}`),
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkspaceTryout returned error: %v", err)
+	}
+	if tryout.WorkspaceID == nil || *tryout.WorkspaceID != workspaceID {
+		t.Fatalf("workspace id = %v, want %s", tryout.WorkspaceID, workspaceID)
+	}
+}
+
 func TestAgentTryoutManagerCreateWorkspaceClaimAndShare(t *testing.T) {
 	ctx := context.Background()
 	orgID := uuid.New()
@@ -570,6 +746,58 @@ func TestCreateAnonymousAgentTryoutHandlerMapsUnavailableTemplate(t *testing.T) 
 	}
 }
 
+func TestCreateAnonymousAgentTryoutHandlerMapsQuotaAndSpendErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "anonymous quota exhausted",
+			err:        ErrAgentTryoutAnonymousQuotaExhausted,
+			wantStatus: http.StatusTooManyRequests,
+			wantCode:   "anonymous_quota_exhausted",
+		},
+		{
+			name:       "hosted spend unavailable",
+			err:        ErrAgentTryoutHostedSpendUnavailable,
+			wantStatus: http.StatusServiceUnavailable,
+			wantCode:   "hosted_spend_unavailable",
+		},
+		{
+			name:       "hosted spend exhausted",
+			err:        ErrAgentTryoutHostedSpendExhausted,
+			wantStatus: http.StatusTooManyRequests,
+			wantCode:   "hosted_spend_exhausted",
+		},
+		{
+			name:       "tryout cost cap exceeded",
+			err:        ErrAgentTryoutCostCapExceeded,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "tryout_cost_cap_exceeded",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &fakeAgentTryoutService{createAnonymousErr: tt.err}
+			handler := createAnonymousAgentTryoutHandler(slog.Default(), service)
+			req := httptest.NewRequest(http.MethodPost, "/v1/agent-tryouts", strings.NewReader(`{"template_slug":"meeting-minutes","input":{"notes":"quota"}}`))
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d; body=%s", rr.Code, tt.wantStatus, rr.Body.String())
+			}
+			if !strings.Contains(rr.Body.String(), tt.wantCode) {
+				t.Fatalf("body = %s, want code %q", rr.Body.String(), tt.wantCode)
+			}
+		})
+	}
+}
+
 func TestGetPublicAgentTryoutHandlerReturnsNarrowResponse(t *testing.T) {
 	expiresAt := time.Now().UTC().Add(defaultAgentTryoutTTL)
 	service := &fakeAgentTryoutService{
@@ -668,6 +896,9 @@ type fakeAgentTryoutRepository struct {
 	omitExecutionRunID bool
 	updateStatusCalls  int
 	share              repository.PublicShareLink
+	countAnonymousErr  error
+	sumAnonymousErr    error
+	hostedSpendUSD     float64
 }
 
 func newFakeAgentTryoutRepository(orgID, workspaceID uuid.UUID) *fakeAgentTryoutRepository {
@@ -715,6 +946,40 @@ func (r *fakeAgentTryoutRepository) CreateAgentTryout(_ context.Context, params 
 	}
 	r.tryouts[tryout.ID] = tryout
 	return tryout, nil
+}
+
+func (r *fakeAgentTryoutRepository) CountAnonymousAgentTryoutsByFingerprint(_ context.Context, fingerprintHash string, since time.Time) (int64, error) {
+	if r.countAnonymousErr != nil {
+		return 0, r.countAnonymousErr
+	}
+	var count int64
+	for _, tryout := range r.tryouts {
+		if tryout.WorkspaceID == nil &&
+			tryout.OrganizationID == nil &&
+			tryout.AnonymousFingerprintHash != nil &&
+			*tryout.AnonymousFingerprintHash == fingerprintHash &&
+			!tryout.CreatedAt.Before(since) {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (r *fakeAgentTryoutRepository) SumAnonymousAgentTryoutCostLimitUSD(_ context.Context, windowStart, windowEnd time.Time) (float64, error) {
+	if r.sumAnonymousErr != nil {
+		return 0, r.sumAnonymousErr
+	}
+	total := r.hostedSpendUSD
+	for _, tryout := range r.tryouts {
+		if tryout.WorkspaceID == nil &&
+			tryout.OrganizationID == nil &&
+			tryout.AnonymousFingerprintHash != nil &&
+			!tryout.CreatedAt.Before(windowStart) &&
+			tryout.CreatedAt.Before(windowEnd) {
+			total += tryout.CostLimitUSD
+		}
+	}
+	return total, nil
 }
 
 func (r *fakeAgentTryoutRepository) GetAgentHarnessByWorkspaceSlug(_ context.Context, workspaceID uuid.UUID, slug string) (repository.AgentHarness, error) {

--- a/backend/internal/api/agent_tryouts_test.go
+++ b/backend/internal/api/agent_tryouts_test.go
@@ -232,22 +232,27 @@ func TestAgentTryoutManagerRejectsAnonymousQuotaExhaustedBeforeCreate(t *testing
 	}
 }
 
-func TestAgentTryoutManagerRejectsHostedSpendUnavailableBeforeCreate(t *testing.T) {
+func TestAgentTryoutManagerRejectsQuotaAccountingUnavailableBeforeCreate(t *testing.T) {
 	tests := []struct {
-		name  string
-		setup func(*fakeAgentTryoutRepository)
+		name    string
+		setup   func(*fakeAgentTryoutRepository)
+		wantErr error
 	}{
 		{
 			name: "fingerprint count fails",
 			setup: func(repo *fakeAgentTryoutRepository) {
 				repo.countAnonymousErr = errors.New("count unavailable")
 			},
+			// A quota-read failure must surface as a quota-specific error, not as
+			// the hosted-spend sentinel — the spend sum never ran.
+			wantErr: ErrAgentTryoutAnonymousQuotaUnavailable,
 		},
 		{
 			name: "hosted spend sum fails",
 			setup: func(repo *fakeAgentTryoutRepository) {
 				repo.sumAnonymousErr = errors.New("sum unavailable")
 			},
+			wantErr: ErrAgentTryoutHostedSpendUnavailable,
 		},
 	}
 	for _, tt := range tests {
@@ -267,11 +272,11 @@ func TestAgentTryoutManagerRejectsHostedSpendUnavailableBeforeCreate(t *testing.
 				Input:                json.RawMessage(`{"notes":"fail closed"}`),
 				AnonymousFingerprint: "203.0.113.10",
 			})
-			if !errors.Is(err, ErrAgentTryoutHostedSpendUnavailable) {
-				t.Fatalf("CreateAnonymousTryout error = %v, want ErrAgentTryoutHostedSpendUnavailable", err)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("CreateAnonymousTryout error = %v, want %v", err, tt.wantErr)
 			}
 			if len(repo.tryouts) != 0 {
-				t.Fatalf("tryouts created = %d, want 0 when spend accounting unavailable", len(repo.tryouts))
+				t.Fatalf("tryouts created = %d, want 0 when quota accounting unavailable", len(repo.tryouts))
 			}
 		})
 	}
@@ -760,6 +765,12 @@ func TestCreateAnonymousAgentTryoutHandlerMapsQuotaAndSpendErrors(t *testing.T) 
 			wantCode:   "anonymous_quota_exhausted",
 		},
 		{
+			name:       "anonymous quota unavailable",
+			err:        ErrAgentTryoutAnonymousQuotaUnavailable,
+			wantStatus: http.StatusServiceUnavailable,
+			wantCode:   "anonymous_quota_unavailable",
+		},
+		{
 			name:       "hosted spend unavailable",
 			err:        ErrAgentTryoutHostedSpendUnavailable,
 			wantStatus: http.StatusServiceUnavailable,
@@ -980,6 +991,10 @@ func (r *fakeAgentTryoutRepository) SumAnonymousAgentTryoutCostLimitUSD(_ contex
 		}
 	}
 	return total, nil
+}
+
+func (r *fakeAgentTryoutRepository) WithinAnonymousAgentTryoutQuotaLock(_ context.Context, fn func(repository.AnonymousAgentTryoutQuotaTx) error) error {
+	return fn(r)
 }
 
 func (r *fakeAgentTryoutRepository) GetAgentHarnessByWorkspaceSlug(_ context.Context, workspaceID uuid.UUID, slug string) (repository.AgentHarness, error) {

--- a/backend/internal/api/config.go
+++ b/backend/internal/api/config.go
@@ -18,74 +18,82 @@ import (
 )
 
 const (
-	defaultBindAddress               = ":8080"
-	defaultDatabaseURL               = "postgres://agentclash:agentclash@localhost:5432/agentclash?sslmode=disable"
-	defaultTemporalTarget            = "localhost:7233"
-	defaultNamespace                 = "default"
-	defaultAppEnvironment            = "development"
-	defaultAuthMode                  = "dev"
-	defaultShutdownTime              = 10 * time.Second
-	defaultHostedRunCallbackSecret   = "agentclash-dev-hosted-callback-secret"
-	minArtifactSigningSecretLength   = 32
-	defaultArtifactStorageBackend    = "filesystem"
-	defaultArtifactStorageBucket     = "agentclash-dev-artifacts"
-	defaultArtifactSignedURLTTL      = 5 * time.Minute
-	defaultArtifactMaxUploadBytes    = 100 << 20
-	defaultRateLimitRPS              = 10.0
-	defaultRateLimitBurst            = 20
-	defaultRateLimitRunCreationRPM   = 30.0
-	defaultRateLimitRunCreationBurst = 10
-	defaultDodoWebhookKey            = "whsec_YWdlbnRjbGFzaC1kZXYtZG9kby13ZWJob29rLXNlY3JldA=="
-	defaultDodoEnvironment           = "test"
+	defaultBindAddress                          = ":8080"
+	defaultDatabaseURL                          = "postgres://agentclash:agentclash@localhost:5432/agentclash?sslmode=disable"
+	defaultTemporalTarget                       = "localhost:7233"
+	defaultNamespace                            = "default"
+	defaultAppEnvironment                       = "development"
+	defaultAuthMode                             = "dev"
+	defaultShutdownTime                         = 10 * time.Second
+	defaultHostedRunCallbackSecret              = "agentclash-dev-hosted-callback-secret"
+	minArtifactSigningSecretLength              = 32
+	defaultArtifactStorageBackend               = "filesystem"
+	defaultArtifactStorageBucket                = "agentclash-dev-artifacts"
+	defaultArtifactSignedURLTTL                 = 5 * time.Minute
+	defaultArtifactMaxUploadBytes               = 100 << 20
+	defaultRateLimitRPS                         = 10.0
+	defaultRateLimitBurst                       = 20
+	defaultRateLimitRunCreationRPM              = 30.0
+	defaultRateLimitRunCreationBurst            = 10
+	defaultDodoWebhookKey                       = "whsec_YWdlbnRjbGFzaC1kZXYtZG9kby13ZWJob29rLXNlY3JldA=="
+	defaultDodoEnvironment                      = "test"
+	defaultAgentTryoutAnonymousLimit            = 1
+	defaultAgentTryoutAnonymousWindow           = 24 * time.Hour
+	defaultAgentTryoutHostedDailySpendCapUSD    = 25.0
+	defaultAgentTryoutAnonymousPerRunCostCapUSD = 1.0
 )
 
 var ErrInvalidConfig = errors.New("invalid api server config")
 
 type Config struct {
-	AppEnvironment                    string
-	AuthMode                          string // "dev" or "workos"
-	WorkOSClientID                    string // required when AuthMode is "workos"
-	WorkOSIssuer                      string // optional; defaults to "https://api.workos.com"
-	BindAddress                       string
-	DatabaseURL                       string
-	TemporalAddress                   string
-	TemporalNamespace                 string
-	HostedRunCallbackSecret           string
-	CORSAllowedOrigins                map[string]struct{} // parsed from CORS_ALLOWED_ORIGINS; empty means wildcard in dev, deny in prod
-	ShutdownTimeout                   time.Duration
-	ArtifactStorageBackend            string
-	ArtifactStorageBucket             string
-	ArtifactFilesystemRoot            string
-	ArtifactS3Region                  string
-	ArtifactS3Endpoint                string
-	ArtifactS3AccessKeyID             string
-	ArtifactS3SecretKey               string
-	ArtifactS3ForcePathStyle          bool
-	ArtifactSigningSecret             string
-	ArtifactSignedURLTTL              time.Duration
-	ArtifactMaxUploadBytes            int64
-	SecretsCipher                     *secrets.AESGCMCipher
-	RateLimitRPS                      float64
-	RateLimitBurst                    int
-	RateLimitRunCreationRPM           float64
-	RateLimitRunCreationBurst         int
-	ResendAPIKey                      string
-	ResendFromEmail                   string
-	FrontendURL                       string
-	GitHubAppSlug                     string
-	GitHubAppID                       int64
-	GitHubAppPrivateKey               string
-	GitHubAppStateSecret              string
-	GitHubWebhookSecret               string
-	DodoPaymentsAPIKey                string
-	DodoPaymentsWebhookKey            string
-	DodoEnvironment                   string
-	DodoProductIDs                    billingpkg.DodoProductIDs
-	DodoAPIBaseURL                    string
-	AgentTryoutPublicWorkspaceID      *uuid.UUID
-	AgentTryoutPublicCreatedByUserID  *uuid.UUID
-	AgentTryoutE2BTemplateID          string
-	AgentTryoutOpenAIAPIKeySecretName string
+	AppEnvironment                       string
+	AuthMode                             string // "dev" or "workos"
+	WorkOSClientID                       string // required when AuthMode is "workos"
+	WorkOSIssuer                         string // optional; defaults to "https://api.workos.com"
+	BindAddress                          string
+	DatabaseURL                          string
+	TemporalAddress                      string
+	TemporalNamespace                    string
+	HostedRunCallbackSecret              string
+	CORSAllowedOrigins                   map[string]struct{} // parsed from CORS_ALLOWED_ORIGINS; empty means wildcard in dev, deny in prod
+	ShutdownTimeout                      time.Duration
+	ArtifactStorageBackend               string
+	ArtifactStorageBucket                string
+	ArtifactFilesystemRoot               string
+	ArtifactS3Region                     string
+	ArtifactS3Endpoint                   string
+	ArtifactS3AccessKeyID                string
+	ArtifactS3SecretKey                  string
+	ArtifactS3ForcePathStyle             bool
+	ArtifactSigningSecret                string
+	ArtifactSignedURLTTL                 time.Duration
+	ArtifactMaxUploadBytes               int64
+	SecretsCipher                        *secrets.AESGCMCipher
+	RateLimitRPS                         float64
+	RateLimitBurst                       int
+	RateLimitRunCreationRPM              float64
+	RateLimitRunCreationBurst            int
+	ResendAPIKey                         string
+	ResendFromEmail                      string
+	FrontendURL                          string
+	GitHubAppSlug                        string
+	GitHubAppID                          int64
+	GitHubAppPrivateKey                  string
+	GitHubAppStateSecret                 string
+	GitHubWebhookSecret                  string
+	DodoPaymentsAPIKey                   string
+	DodoPaymentsWebhookKey               string
+	DodoEnvironment                      string
+	DodoProductIDs                       billingpkg.DodoProductIDs
+	DodoAPIBaseURL                       string
+	AgentTryoutPublicWorkspaceID         *uuid.UUID
+	AgentTryoutPublicCreatedByUserID     *uuid.UUID
+	AgentTryoutE2BTemplateID             string
+	AgentTryoutOpenAIAPIKeySecretName    string
+	AgentTryoutAnonymousLimit            int
+	AgentTryoutAnonymousWindow           time.Duration
+	AgentTryoutHostedDailySpendCapUSD    float64
+	AgentTryoutAnonymousPerRunCostCapUSD float64
 }
 
 func LoadConfigFromEnv() (Config, error) {
@@ -223,51 +231,71 @@ func LoadConfigFromEnv() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	agentTryoutAnonymousLimit, err := nonNegativeIntEnvOrDefault("AGENT_TRYOUT_ANONYMOUS_LIMIT", defaultAgentTryoutAnonymousLimit)
+	if err != nil {
+		return Config{}, err
+	}
+	agentTryoutAnonymousWindow, err := durationSecondsEnvOrDefault("AGENT_TRYOUT_ANONYMOUS_WINDOW_SECONDS", defaultAgentTryoutAnonymousWindow)
+	if err != nil {
+		return Config{}, err
+	}
+	agentTryoutHostedDailySpendCapUSD, err := nonNegativeFloatEnvOrDefault("AGENT_TRYOUT_HOSTED_DAILY_SPEND_CAP_USD", defaultAgentTryoutHostedDailySpendCapUSD)
+	if err != nil {
+		return Config{}, err
+	}
+	agentTryoutAnonymousPerRunCostCapUSD, err := nonNegativeFloatEnvOrDefault("AGENT_TRYOUT_ANONYMOUS_PER_RUN_COST_CAP_USD", defaultAgentTryoutAnonymousPerRunCostCapUSD)
+	if err != nil {
+		return Config{}, err
+	}
 
 	cfg := Config{
-		AppEnvironment:                    appEnvironment,
-		AuthMode:                          authMode,
-		WorkOSClientID:                    workosClientID,
-		WorkOSIssuer:                      workosIssuer,
-		BindAddress:                       bindAddress,
-		DatabaseURL:                       databaseURL,
-		TemporalAddress:                   temporalAddress,
-		TemporalNamespace:                 temporalNamespace,
-		HostedRunCallbackSecret:           hostedRunCallbackSecret,
-		CORSAllowedOrigins:                corsAllowedOrigins,
-		ShutdownTimeout:                   defaultShutdownTime,
-		ArtifactStorageBackend:            artifactStorageBackend,
-		ArtifactStorageBucket:             artifactStorageBucket,
-		ArtifactFilesystemRoot:            artifactFilesystemRoot,
-		ArtifactS3Region:                  artifactS3Region,
-		ArtifactS3Endpoint:                artifactS3Endpoint,
-		ArtifactS3AccessKeyID:             artifactS3AccessKeyID,
-		ArtifactS3SecretKey:               artifactS3SecretKey,
-		ArtifactS3ForcePathStyle:          artifactS3ForcePathStyle,
-		ArtifactSigningSecret:             artifactSigningSecret,
-		ArtifactSignedURLTTL:              artifactSignedURLTTL,
-		ArtifactMaxUploadBytes:            artifactMaxUploadBytes,
-		RateLimitRPS:                      defaultRateLimitRPS,
-		RateLimitBurst:                    defaultRateLimitBurst,
-		RateLimitRunCreationRPM:           defaultRateLimitRunCreationRPM,
-		RateLimitRunCreationBurst:         defaultRateLimitRunCreationBurst,
-		ResendAPIKey:                      resendAPIKey,
-		ResendFromEmail:                   resendFromEmail,
-		FrontendURL:                       frontendURL,
-		GitHubAppSlug:                     os.Getenv("GITHUB_APP_SLUG"),
-		GitHubAppID:                       githubAppID,
-		GitHubAppPrivateKey:               normalizePEMEnv(os.Getenv("GITHUB_APP_PRIVATE_KEY")),
-		GitHubAppStateSecret:              os.Getenv("GITHUB_APP_STATE_SECRET"),
-		GitHubWebhookSecret:               os.Getenv("GITHUB_WEBHOOK_SECRET"),
-		DodoPaymentsAPIKey:                dodoPaymentsAPIKey,
-		DodoPaymentsWebhookKey:            dodoPaymentsWebhookKey,
-		DodoEnvironment:                   dodoEnvironment,
-		DodoProductIDs:                    dodoProductIDs,
-		DodoAPIBaseURL:                    os.Getenv("DODO_API_BASE_URL"),
-		AgentTryoutPublicWorkspaceID:      agentTryoutPublicWorkspaceID,
-		AgentTryoutPublicCreatedByUserID:  agentTryoutPublicCreatedByUserID,
-		AgentTryoutE2BTemplateID:          os.Getenv("AGENT_TRYOUT_E2B_TEMPLATE_ID"),
-		AgentTryoutOpenAIAPIKeySecretName: os.Getenv("AGENT_TRYOUT_OPENAI_API_KEY_SECRET_NAME"),
+		AppEnvironment:                       appEnvironment,
+		AuthMode:                             authMode,
+		WorkOSClientID:                       workosClientID,
+		WorkOSIssuer:                         workosIssuer,
+		BindAddress:                          bindAddress,
+		DatabaseURL:                          databaseURL,
+		TemporalAddress:                      temporalAddress,
+		TemporalNamespace:                    temporalNamespace,
+		HostedRunCallbackSecret:              hostedRunCallbackSecret,
+		CORSAllowedOrigins:                   corsAllowedOrigins,
+		ShutdownTimeout:                      defaultShutdownTime,
+		ArtifactStorageBackend:               artifactStorageBackend,
+		ArtifactStorageBucket:                artifactStorageBucket,
+		ArtifactFilesystemRoot:               artifactFilesystemRoot,
+		ArtifactS3Region:                     artifactS3Region,
+		ArtifactS3Endpoint:                   artifactS3Endpoint,
+		ArtifactS3AccessKeyID:                artifactS3AccessKeyID,
+		ArtifactS3SecretKey:                  artifactS3SecretKey,
+		ArtifactS3ForcePathStyle:             artifactS3ForcePathStyle,
+		ArtifactSigningSecret:                artifactSigningSecret,
+		ArtifactSignedURLTTL:                 artifactSignedURLTTL,
+		ArtifactMaxUploadBytes:               artifactMaxUploadBytes,
+		RateLimitRPS:                         defaultRateLimitRPS,
+		RateLimitBurst:                       defaultRateLimitBurst,
+		RateLimitRunCreationRPM:              defaultRateLimitRunCreationRPM,
+		RateLimitRunCreationBurst:            defaultRateLimitRunCreationBurst,
+		ResendAPIKey:                         resendAPIKey,
+		ResendFromEmail:                      resendFromEmail,
+		FrontendURL:                          frontendURL,
+		GitHubAppSlug:                        os.Getenv("GITHUB_APP_SLUG"),
+		GitHubAppID:                          githubAppID,
+		GitHubAppPrivateKey:                  normalizePEMEnv(os.Getenv("GITHUB_APP_PRIVATE_KEY")),
+		GitHubAppStateSecret:                 os.Getenv("GITHUB_APP_STATE_SECRET"),
+		GitHubWebhookSecret:                  os.Getenv("GITHUB_WEBHOOK_SECRET"),
+		DodoPaymentsAPIKey:                   dodoPaymentsAPIKey,
+		DodoPaymentsWebhookKey:               dodoPaymentsWebhookKey,
+		DodoEnvironment:                      dodoEnvironment,
+		DodoProductIDs:                       dodoProductIDs,
+		DodoAPIBaseURL:                       os.Getenv("DODO_API_BASE_URL"),
+		AgentTryoutPublicWorkspaceID:         agentTryoutPublicWorkspaceID,
+		AgentTryoutPublicCreatedByUserID:     agentTryoutPublicCreatedByUserID,
+		AgentTryoutE2BTemplateID:             os.Getenv("AGENT_TRYOUT_E2B_TEMPLATE_ID"),
+		AgentTryoutOpenAIAPIKeySecretName:    os.Getenv("AGENT_TRYOUT_OPENAI_API_KEY_SECRET_NAME"),
+		AgentTryoutAnonymousLimit:            agentTryoutAnonymousLimit,
+		AgentTryoutAnonymousWindow:           agentTryoutAnonymousWindow,
+		AgentTryoutHostedDailySpendCapUSD:    agentTryoutHostedDailySpendCapUSD,
+		AgentTryoutAnonymousPerRunCostCapUSD: agentTryoutAnonymousPerRunCostCapUSD,
 	}
 
 	if err := validateArtifactConfig(cfg); err != nil {
@@ -360,6 +388,42 @@ func int64EnvOrDefault(key string, fallback int64) (int64, error) {
 		return 0, fmt.Errorf("%w: %s must be greater than zero", ErrInvalidConfig, key)
 	}
 
+	return parsed, nil
+}
+
+func nonNegativeIntEnvOrDefault(key string, fallback int) (int, error) {
+	value, ok := os.LookupEnv(key)
+	if !ok {
+		return fallback, nil
+	}
+	if value == "" {
+		return 0, fmt.Errorf("%w: %s cannot be empty", ErrInvalidConfig, key)
+	}
+	parsed, err := strconv.ParseInt(value, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %s must be an integer", ErrInvalidConfig, key)
+	}
+	if parsed < 0 {
+		return 0, fmt.Errorf("%w: %s must be zero or greater", ErrInvalidConfig, key)
+	}
+	return int(parsed), nil
+}
+
+func nonNegativeFloatEnvOrDefault(key string, fallback float64) (float64, error) {
+	value, ok := os.LookupEnv(key)
+	if !ok {
+		return fallback, nil
+	}
+	if value == "" {
+		return 0, fmt.Errorf("%w: %s cannot be empty", ErrInvalidConfig, key)
+	}
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %s must be a number", ErrInvalidConfig, key)
+	}
+	if parsed < 0 {
+		return 0, fmt.Errorf("%w: %s must be zero or greater", ErrInvalidConfig, key)
+	}
 	return parsed, nil
 }
 

--- a/backend/internal/repository/agent_tryouts.go
+++ b/backend/internal/repository/agent_tryouts.go
@@ -141,6 +141,37 @@ func (r *Repository) CreateAgentTryout(ctx context.Context, params CreateAgentTr
 	return mapAgentTryout(row)
 }
 
+func (r *Repository) CountAnonymousAgentTryoutsByFingerprint(ctx context.Context, fingerprintHash string, since time.Time) (int64, error) {
+	var count int64
+	err := r.db.QueryRow(ctx, `
+SELECT COUNT(*)
+FROM agent_tryouts
+WHERE organization_id IS NULL
+  AND workspace_id IS NULL
+  AND anonymous_fingerprint_hash = $1
+  AND created_at >= $2`, fingerprintHash, since.UTC()).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count anonymous agent tryouts by fingerprint: %w", err)
+	}
+	return count, nil
+}
+
+func (r *Repository) SumAnonymousAgentTryoutCostLimitUSD(ctx context.Context, windowStart, windowEnd time.Time) (float64, error) {
+	var total pgtype.Numeric
+	err := r.db.QueryRow(ctx, `
+SELECT COALESCE(SUM(cost_limit_usd), 0)
+FROM agent_tryouts
+WHERE organization_id IS NULL
+  AND workspace_id IS NULL
+  AND anonymous_fingerprint_hash IS NOT NULL
+  AND created_at >= $1
+  AND created_at < $2`, windowStart.UTC(), windowEnd.UTC()).Scan(&total)
+	if err != nil {
+		return 0, fmt.Errorf("sum anonymous agent tryout cost limits: %w", err)
+	}
+	return derefFloat64(numericPtr(total)), nil
+}
+
 func (r *Repository) GetAgentTryoutByID(ctx context.Context, id uuid.UUID) (AgentTryout, error) {
 	row, err := r.queries.GetAgentTryoutByID(ctx, repositorysqlc.GetAgentTryoutByIDParams{ID: id})
 	if err != nil {

--- a/backend/internal/repository/agent_tryouts.go
+++ b/backend/internal/repository/agent_tryouts.go
@@ -105,7 +105,18 @@ type LinkAgentTryoutRunParams struct {
 	Summary json.RawMessage
 }
 
+// tryoutRowQuerier is satisfied by both *pgxpool.Pool and pgx.Tx, letting the
+// hand-written anonymous quota queries run either standalone or inside the
+// advisory-locked transaction used by WithinAnonymousAgentTryoutQuotaLock.
+type tryoutRowQuerier interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
 func (r *Repository) CreateAgentTryout(ctx context.Context, params CreateAgentTryoutParams) (AgentTryout, error) {
+	return createAgentTryout(ctx, r.queries, params)
+}
+
+func createAgentTryout(ctx context.Context, queries *repositorysqlc.Queries, params CreateAgentTryoutParams) (AgentTryout, error) {
 	costLimit, err := numericFromFloat(&params.CostLimitUSD)
 	if err != nil {
 		return AgentTryout{}, fmt.Errorf("encode agent tryout cost limit: %w", err)
@@ -114,7 +125,7 @@ func (r *Repository) CreateAgentTryout(ctx context.Context, params CreateAgentTr
 	if err != nil {
 		return AgentTryout{}, fmt.Errorf("encode agent tryout actual cost: %w", err)
 	}
-	row, err := r.queries.CreateAgentTryout(ctx, repositorysqlc.CreateAgentTryoutParams{
+	row, err := queries.CreateAgentTryout(ctx, repositorysqlc.CreateAgentTryoutParams{
 		OrganizationID:           cloneUUIDPtr(params.OrganizationID),
 		WorkspaceID:              cloneUUIDPtr(params.WorkspaceID),
 		TemplateSlug:             params.TemplateSlug,
@@ -142,8 +153,12 @@ func (r *Repository) CreateAgentTryout(ctx context.Context, params CreateAgentTr
 }
 
 func (r *Repository) CountAnonymousAgentTryoutsByFingerprint(ctx context.Context, fingerprintHash string, since time.Time) (int64, error) {
+	return countAnonymousAgentTryoutsByFingerprint(ctx, r.db, fingerprintHash, since)
+}
+
+func countAnonymousAgentTryoutsByFingerprint(ctx context.Context, q tryoutRowQuerier, fingerprintHash string, since time.Time) (int64, error) {
 	var count int64
-	err := r.db.QueryRow(ctx, `
+	err := q.QueryRow(ctx, `
 SELECT COUNT(*)
 FROM agent_tryouts
 WHERE organization_id IS NULL
@@ -157,8 +172,12 @@ WHERE organization_id IS NULL
 }
 
 func (r *Repository) SumAnonymousAgentTryoutCostLimitUSD(ctx context.Context, windowStart, windowEnd time.Time) (float64, error) {
+	return sumAnonymousAgentTryoutCostLimitUSD(ctx, r.db, windowStart, windowEnd)
+}
+
+func sumAnonymousAgentTryoutCostLimitUSD(ctx context.Context, q tryoutRowQuerier, windowStart, windowEnd time.Time) (float64, error) {
 	var total pgtype.Numeric
-	err := r.db.QueryRow(ctx, `
+	err := q.QueryRow(ctx, `
 SELECT COALESCE(SUM(cost_limit_usd), 0)
 FROM agent_tryouts
 WHERE organization_id IS NULL
@@ -170,6 +189,65 @@ WHERE organization_id IS NULL
 		return 0, fmt.Errorf("sum anonymous agent tryout cost limits: %w", err)
 	}
 	return derefFloat64(numericPtr(total)), nil
+}
+
+// AnonymousAgentTryoutQuotaTx exposes the anonymous-tryout reads and the create
+// write as a single transactional unit. Implementations run every call inside
+// one transaction that holds a global advisory lock, so the per-fingerprint
+// quota count, the hosted daily-spend sum, and the insert are atomic with
+// respect to other anonymous-tryout creations — closing the check-then-create
+// TOCTOU window.
+type AnonymousAgentTryoutQuotaTx interface {
+	CountAnonymousAgentTryoutsByFingerprint(ctx context.Context, fingerprintHash string, since time.Time) (int64, error)
+	SumAnonymousAgentTryoutCostLimitUSD(ctx context.Context, windowStart, windowEnd time.Time) (float64, error)
+	CreateAgentTryout(ctx context.Context, params CreateAgentTryoutParams) (AgentTryout, error)
+}
+
+type anonymousAgentTryoutQuotaTx struct {
+	repo *Repository
+	tx   pgx.Tx
+}
+
+func (q anonymousAgentTryoutQuotaTx) CountAnonymousAgentTryoutsByFingerprint(ctx context.Context, fingerprintHash string, since time.Time) (int64, error) {
+	return countAnonymousAgentTryoutsByFingerprint(ctx, q.tx, fingerprintHash, since)
+}
+
+func (q anonymousAgentTryoutQuotaTx) SumAnonymousAgentTryoutCostLimitUSD(ctx context.Context, windowStart, windowEnd time.Time) (float64, error) {
+	return sumAnonymousAgentTryoutCostLimitUSD(ctx, q.tx, windowStart, windowEnd)
+}
+
+func (q anonymousAgentTryoutQuotaTx) CreateAgentTryout(ctx context.Context, params CreateAgentTryoutParams) (AgentTryout, error) {
+	return createAgentTryout(ctx, q.repo.queries.WithTx(q.tx), params)
+}
+
+// WithinAnonymousAgentTryoutQuotaLock runs fn inside a transaction that first
+// takes a global advisory lock shared by all anonymous tryout creations. Both
+// the per-fingerprint quota and the global hosted daily-spend cap are protected:
+// concurrent anonymous creations serialize on the lock, so reads observe every
+// previously committed tryout before the next insert. If fn returns an error the
+// transaction rolls back and no tryout is created.
+func (r *Repository) WithinAnonymousAgentTryoutQuotaLock(ctx context.Context, fn func(AnonymousAgentTryoutQuotaTx) error) error {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin anonymous agent tryout quota transaction: %w", err)
+	}
+	defer rollback(ctx, tx)
+
+	// Global serialization point for anonymous tryout creation. Keyed on a fixed
+	// string (not the fingerprint) because the hosted daily-spend cap is a single
+	// global counter that every anonymous creation contends for.
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended('anonymous_agent_tryout_quota', 451))`); err != nil {
+		return fmt.Errorf("lock anonymous agent tryout quota: %w", err)
+	}
+
+	if err := fn(anonymousAgentTryoutQuotaTx{repo: r, tx: tx}); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit anonymous agent tryout quota transaction: %w", err)
+	}
+	return nil
 }
 
 func (r *Repository) GetAgentTryoutByID(ctx context.Context, id uuid.UUID) (AgentTryout, error) {

--- a/backend/internal/repository/agent_tryouts_integration_test.go
+++ b/backend/internal/repository/agent_tryouts_integration_test.go
@@ -3,12 +3,78 @@ package repository_test
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/google/uuid"
 )
+
+func TestRepositoryAgentTryoutAnonymousQuotaLedger(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	fingerprintHash := "anon-ledger-" + uuid.NewString()
+	expiresAt := time.Now().UTC().Add(24 * time.Hour)
+	for _, costLimit := range []float64{0.25, 0.30} {
+		_, err := repo.CreateAgentTryout(ctx, repository.CreateAgentTryoutParams{
+			TemplateSlug:             "meeting-minutes",
+			Status:                   repository.AgentTryoutStatusQueued,
+			InputSnapshot:            []byte(`{"notes":"anonymous"}`),
+			TemplateSnapshot:         []byte(`{"slug":"meeting-minutes"}`),
+			ToolPolicySnapshot:       []byte(`{"tools":[]}`),
+			EvaluationSpecSnapshot:   []byte(`{"validators":[]}`),
+			SelectedModelPolicy:      []byte(`{"mode":"hosted_default"}`),
+			Summary:                  []byte(`{}`),
+			RedactionStatus:          repository.AgentTryoutRedactionPending,
+			CostLimitUSD:             costLimit,
+			MaxDurationSeconds:       120,
+			AnonymousFingerprintHash: &fingerprintHash,
+			ExpiresAt:                &expiresAt,
+		})
+		if err != nil {
+			t.Fatalf("CreateAgentTryout anonymous returned error: %v", err)
+		}
+	}
+	_, err := repo.CreateAgentTryout(ctx, repository.CreateAgentTryoutParams{
+		OrganizationID:         &fixture.organizationID,
+		WorkspaceID:            &fixture.workspaceID,
+		TemplateSlug:           "meeting-minutes",
+		Status:                 repository.AgentTryoutStatusQueued,
+		InputSnapshot:          []byte(`{"notes":"workspace"}`),
+		TemplateSnapshot:       []byte(`{"slug":"meeting-minutes"}`),
+		ToolPolicySnapshot:     []byte(`{"tools":[]}`),
+		EvaluationSpecSnapshot: []byte(`{"validators":[]}`),
+		SelectedModelPolicy:    []byte(`{"mode":"hosted_default"}`),
+		Summary:                []byte(`{}`),
+		RedactionStatus:        repository.AgentTryoutRedactionPending,
+		CostLimitUSD:           10,
+		MaxDurationSeconds:     120,
+		CreatedByUserID:        &fixture.userID,
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentTryout workspace returned error: %v", err)
+	}
+
+	count, err := repo.CountAnonymousAgentTryoutsByFingerprint(ctx, fingerprintHash, time.Now().UTC().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("CountAnonymousAgentTryoutsByFingerprint returned error: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("anonymous count = %d, want 2", count)
+	}
+	windowStart := time.Now().UTC().Truncate(24 * time.Hour)
+	total, err := repo.SumAnonymousAgentTryoutCostLimitUSD(ctx, windowStart, windowStart.Add(24*time.Hour))
+	if err != nil {
+		t.Fatalf("SumAnonymousAgentTryoutCostLimitUSD returned error: %v", err)
+	}
+	if math.Abs(total-0.55) > 0.000001 {
+		t.Fatalf("anonymous hosted spend = %v, want 0.55", total)
+	}
+}
 
 func TestRepositoryAgentTryoutLifecycle(t *testing.T) {
 	ctx := context.Background()

--- a/backend/internal/repository/agent_tryouts_integration_test.go
+++ b/backend/internal/repository/agent_tryouts_integration_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"math"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -73,6 +75,88 @@ func TestRepositoryAgentTryoutAnonymousQuotaLedger(t *testing.T) {
 	}
 	if math.Abs(total-0.55) > 0.000001 {
 		t.Fatalf("anonymous hosted spend = %v, want 0.55", total)
+	}
+}
+
+// TestRepositoryAgentTryoutQuotaLockSerializesCreation exercises
+// WithinAnonymousAgentTryoutQuotaLock under concurrent load to prove the
+// advisory lock closes the check-then-create TOCTOU window: many goroutines
+// share one fingerprint and gate on a per-fingerprint limit of 1, so exactly
+// one must win even though they all start before any commits.
+func TestRepositoryAgentTryoutQuotaLockSerializesCreation(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := repository.New(db)
+
+	fingerprintHash := "anon-race-" + uuid.NewString()
+	expiresAt := time.Now().UTC().Add(24 * time.Hour)
+	const (
+		concurrency      = 16
+		perFingerprint   = 1
+		perRunCostUSD    = 0.10
+		dailySpendCapUSD = 100.0
+	)
+	window := time.Now().UTC().Add(-time.Hour)
+	dayStart := time.Now().UTC().Truncate(24 * time.Hour)
+	dayEnd := dayStart.Add(24 * time.Hour)
+
+	var wg sync.WaitGroup
+	var created int64
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := repo.WithinAnonymousAgentTryoutQuotaLock(ctx, func(qtx repository.AnonymousAgentTryoutQuotaTx) error {
+				count, err := qtx.CountAnonymousAgentTryoutsByFingerprint(ctx, fingerprintHash, window)
+				if err != nil {
+					return err
+				}
+				if count >= perFingerprint {
+					return nil // quota reached — do not create
+				}
+				spend, err := qtx.SumAnonymousAgentTryoutCostLimitUSD(ctx, dayStart, dayEnd)
+				if err != nil {
+					return err
+				}
+				if spend+perRunCostUSD > dailySpendCapUSD {
+					return nil
+				}
+				if _, err := qtx.CreateAgentTryout(ctx, repository.CreateAgentTryoutParams{
+					TemplateSlug:             "meeting-minutes",
+					Status:                   repository.AgentTryoutStatusQueued,
+					InputSnapshot:            []byte(`{"notes":"race"}`),
+					TemplateSnapshot:         []byte(`{"slug":"meeting-minutes"}`),
+					ToolPolicySnapshot:       []byte(`{"tools":[]}`),
+					EvaluationSpecSnapshot:   []byte(`{"validators":[]}`),
+					SelectedModelPolicy:      []byte(`{"mode":"hosted_default"}`),
+					Summary:                  []byte(`{}`),
+					RedactionStatus:          repository.AgentTryoutRedactionPending,
+					CostLimitUSD:             perRunCostUSD,
+					MaxDurationSeconds:       120,
+					AnonymousFingerprintHash: &fingerprintHash,
+					ExpiresAt:                &expiresAt,
+				}); err != nil {
+					return err
+				}
+				atomic.AddInt64(&created, 1)
+				return nil
+			})
+			if err != nil {
+				t.Errorf("WithinAnonymousAgentTryoutQuotaLock returned error: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt64(&created); got != perFingerprint {
+		t.Fatalf("created tryouts = %d, want %d (lock failed to serialize)", got, perFingerprint)
+	}
+	count, err := repo.CountAnonymousAgentTryoutsByFingerprint(ctx, fingerprintHash, window)
+	if err != nil {
+		t.Fatalf("CountAnonymousAgentTryoutsByFingerprint returned error: %v", err)
+	}
+	if count != perFingerprint {
+		t.Fatalf("persisted anonymous tryouts = %d, want %d", count, perFingerprint)
 	}
 }
 

--- a/testing/codex-agent-tryout-quota-spend-caps.md
+++ b/testing/codex-agent-tryout-quota-spend-caps.md
@@ -1,0 +1,39 @@
+# codex-agent-tryout-quota-spend-caps - Test Contract
+
+## Functional Behavior
+- Anonymous tryouts are gated before persistence and before paid execution using a hashed fingerprint and a rolling 24 hour window.
+- Anonymous quota exhaustion returns a stable product-facing `anonymous_quota_exhausted` error that the UI can render as sign-in or try-again-later.
+- Global hosted anonymous spend is checked before persistence/dispatch using existing anonymous tryout rows as the durable ledger.
+- Hosted spend accounting fails closed: if the repository cannot read quota/spend state, the API returns a stable `hosted_spend_unavailable` error and does not create a tryout.
+- Global spend cap exhaustion returns a stable `hosted_spend_exhausted` error and does not create a tryout.
+- Per-template `max_cost_usd` must not exceed the configured anonymous per-run cap; oversized templates fail with `tryout_cost_cap_exceeded` before persistence.
+- Existing workspace tryout behavior remains authorized by workspace permissions and is not blocked by anonymous fingerprint quota.
+- Tryout snapshots continue to persist server-owned cost limits and runtime/tool/evaluation policy.
+
+## Unit Tests
+- `TestAgentTryoutManagerAllowsAnonymousWithinQuotaAndSpendCaps` - creates one anonymous tryout when quota and spend checks pass.
+- `TestAgentTryoutManagerRejectsAnonymousQuotaExhaustedBeforeCreate` - second anonymous tryout within the window fails before persistence/dispatch.
+- `TestAgentTryoutManagerRejectsHostedSpendUnavailableBeforeCreate` - repository quota/spend read errors fail closed.
+- `TestAgentTryoutManagerRejectsHostedSpendCapExceededBeforeCreate` - projected daily spend over cap fails before persistence/dispatch.
+- `TestAgentTryoutManagerRejectsPerRunCostCapExceededBeforeCreate` - template cost above configured per-run cap fails before persistence/dispatch.
+- `TestCreateAnonymousAgentTryoutHandlerMapsQuotaAndSpendErrors` - handler returns stable UI error codes for quota/spend/cost cap failures.
+
+## Integration / Functional Tests
+- Repository tests verify counting anonymous tryouts by fingerprint and summing anonymous cost-limit ledger rows across a time window.
+- Existing agent tryout repository tests continue to pass.
+
+## Smoke Tests
+- `go test -short -count=1 ./internal/api -run 'AgentTryout|Quota|Spend|CostCap'`
+- `go test -short -count=1 ./internal/repository -run AgentTryout`
+- `go test -short -count=1 ./...`
+- `go vet ./...`
+
+## E2E Tests
+- N/A - full E2B/provider execution requires external credentials. This change must still curl local API routes to verify quota, spend, and cost-cap responses.
+
+## Manual / cURL Tests
+- With default config, `POST /v1/agent-tryouts` for valid `meeting-minutes` input returns `201` and preserves `cost_limit_usd`.
+- With anonymous quota set to zero, `POST /v1/agent-tryouts` returns `429 anonymous_quota_exhausted`.
+- With daily hosted spend cap set below the template cost limit, `POST /v1/agent-tryouts` returns `429 hosted_spend_exhausted`.
+- With per-run cap set below the template cost limit, `POST /v1/agent-tryouts` returns `400 tryout_cost_cap_exceeded`.
+- Repeating the same anonymous fingerprint after one successful create returns `429 anonymous_quota_exhausted`.


### PR DESCRIPTION
## Summary

Implements the backend quota and spend cap guardrails for anonymous Agent Tryouts.

- Adds anonymous fingerprint quota enforcement before persistence or dispatch.
- Adds hosted anonymous spend accounting from existing `agent_tryouts.cost_limit_usd` rows.
- Adds product-facing HTTP responses for quota exhaustion, spend accounting outage, hosted spend exhaustion, and per-run cost cap failures.
- Wires API env config:
  - `AGENT_TRYOUT_ANONYMOUS_LIMIT` default `1`
  - `AGENT_TRYOUT_ANONYMOUS_WINDOW_SECONDS` default `86400`
  - `AGENT_TRYOUT_HOSTED_DAILY_SPEND_CAP_USD` default `25`
  - `AGENT_TRYOUT_ANONYMOUS_PER_RUN_COST_CAP_USD` default `1`

Closes #944.

## User-facing behavior

- First anonymous tryout from a fingerprint can proceed if the template fits caps.
- Re-running anonymously from the same fingerprint in the rolling window returns `429 anonymous_quota_exhausted`.
- If hosted spend accounting cannot be read, anonymous tryouts fail closed with `503 hosted_spend_unavailable`.
- If global hosted free spend is exhausted, anonymous tryouts return `429 hosted_spend_exhausted`.
- If a template is above the anonymous per-run cap, anonymous tryouts return `400 tryout_cost_cap_exceeded`.
- Workspace/authenticated tryouts are not blocked by anonymous quota or anonymous hosted spend caps.

## Local curl evidence

Server:

```bash
API_SERVER_BIND_ADDRESS=:18080 AUTH_MODE=dev APP_ENV=development go run ./cmd/api-server
```

Health:

```bash
curl -i http://127.0.0.1:18080/healthz
# HTTP/1.1 200 OK
# {"ok":true,"service":"api-server"}
```

Templates:

```bash
curl -i http://127.0.0.1:18080/v1/agent-tryout-templates
# HTTP/1.1 200 OK
# response includes meeting-minutes runtime/tool/evaluation metadata
```

Allowed anonymous tryout:

```bash
curl -i -X POST http://127.0.0.1:18080/v1/agent-tryouts \
  -H 'Content-Type: application/json' \
  -H 'X-Forwarded-For: 198.51.100.44' \
  --data '{"template_slug":"meeting-minutes","input":{"notes":"Met with design. Ship quota caps. Follow up with QA."}}'
# HTTP/1.1 201 Created
# status failed locally with summary.code=execution_not_configured because public execution workspace is intentionally not configured
# cost_limit_usd=0.25
```

Same anonymous fingerprint:

```bash
curl -i -X POST http://127.0.0.1:18080/v1/agent-tryouts \
  -H 'Content-Type: application/json' \
  -H 'X-Forwarded-For: 198.51.100.44' \
  --data '{"template_slug":"meeting-minutes","input":{"notes":"Repeat same anonymous fingerprint."}}'
# HTTP/1.1 429 Too Many Requests
# {"error":{"code":"anonymous_quota_exhausted",...}}
```

Per-run cap:

```bash
API_SERVER_BIND_ADDRESS=:18080 AUTH_MODE=dev APP_ENV=development \
AGENT_TRYOUT_ANONYMOUS_PER_RUN_COST_CAP_USD=0.10 \
go run ./cmd/api-server

curl -i -X POST http://127.0.0.1:18080/v1/agent-tryouts \
  -H 'Content-Type: application/json' \
  -H 'X-Forwarded-For: 198.51.100.45' \
  --data '{"template_slug":"meeting-minutes","input":{"notes":"Cost cap should block before create."}}'
# HTTP/1.1 400 Bad Request
# {"error":{"code":"tryout_cost_cap_exceeded",...}}
```

Hosted daily spend cap:

```bash
API_SERVER_BIND_ADDRESS=:18080 AUTH_MODE=dev APP_ENV=development \
AGENT_TRYOUT_HOSTED_DAILY_SPEND_CAP_USD=0.10 \
go run ./cmd/api-server

curl -i -X POST http://127.0.0.1:18080/v1/agent-tryouts \
  -H 'Content-Type: application/json' \
  -H 'X-Forwarded-For: 198.51.100.46' \
  --data '{"template_slug":"meeting-minutes","input":{"notes":"Daily spend cap should block globally."}}'
# HTTP/1.1 429 Too Many Requests
# {"error":{"code":"hosted_spend_exhausted",...}}
```

## Validation

```bash
go test -short -count=1 ./internal/api -run 'AgentTryout|Quota|Spend|CostCap'
go test -short -count=1 ./internal/repository -run 'AgentTryout'
go test -short -count=1 ./...
go vet ./...
git diff --check
```
