### PR TITLE
fix(web): add Benchmarks link to the homepage navbar

### DIFF
--- a/web/src/app/landing.tsx
+++ b/web/src/app/landing.tsx
@@ -1463,6 +1463,12 @@ export default function HomePage() {
               Docs
             </Link>
             <Link
+              href="/benchmarks"
+              className="hidden sm:inline-flex px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"
+            >
+              Benchmarks
+            </Link>
+            <Link
               href="/blog"
               className="hidden sm:inline-flex px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"
             >


### PR DESCRIPTION
## What
Adds a **Benchmarks** link to the homepage navbar (between Docs and Blog).

## Why
#938 added Benchmarks to the **shared** marketing header (`marketing-header.tsx`), which renders on `/blog`, `/benchmarks`, `/compare`, etc. — but the **landing page has its own hand-rolled `<nav>`** in `web/src/app/landing.tsx` that wasn't updated, so the homepage navbar had no Benchmarks entry. This completes the nav wiring and gives the site's highest-authority page a direct link to `/benchmarks` (human discovery + an internal link for SEO/AEO).

## Change
One `<Link href="/benchmarks">` in `landing.tsx`, styled identically to the adjacent Blog link (`hidden sm:inline-flex` — visible on the desktop nav, hidden on the cramped mobile nav, consistent with Features/Why/Blog).

## Verification
- `npx tsc --noEmit` — clean
- `pnpm lint` — 0 errors
- `pnpm build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
