### PR TITLE
fix(web): put /benchmarks in a coming-soon state (SEO-safe) until a real race ships

### DIFF
--- a/web/src/app/benchmarks/benchmarks-metadata.test.ts
+++ b/web/src/app/benchmarks/benchmarks-metadata.test.ts
@@ -69,7 +69,7 @@ describe("benchmarks index social metadata", () => {
 
 describe("benchmarks index indexability (coming-soon gate)", () => {
   it("noindexes the index while no real benchmark is published", () => {
-    hasPublishedBenchmarksMock.mockReturnValue(false);
+    hasPublishedBenchmarksMock.mockReturnValueOnce(false);
     expect(benchmarksIndexMetadata().robots).toEqual({
       index: false,
       follow: true,
@@ -77,7 +77,7 @@ describe("benchmarks index indexability (coming-soon gate)", () => {
   });
 
   it("leaves the index indexable once a real benchmark ships", () => {
-    hasPublishedBenchmarksMock.mockReturnValue(true);
+    hasPublishedBenchmarksMock.mockReturnValueOnce(true);
     expect(benchmarksIndexMetadata().robots).toBeUndefined();
   });
 });

--- a/web/src/app/benchmarks/benchmarks-metadata.test.ts
+++ b/web/src/app/benchmarks/benchmarks-metadata.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { benchmarkRssAlternate, ogImageUrl } from "@/lib/seo";
-import { metadata as benchmarksMetadata } from "./page";
+import { generateMetadata as benchmarksIndexMetadata } from "./page";
 import { generateMetadata } from "./[slug]/page";
 
 const getReportBySlugMock = vi.hoisted(() => vi.fn());
+const hasPublishedBenchmarksMock = vi.hoisted(() => vi.fn(() => false));
 
 vi.mock("@workos-inc/authkit-nextjs", () => ({
   withAuth: vi.fn(),
@@ -17,11 +18,12 @@ vi.mock("@/lib/benchmarks", () => ({
   getAllReports: vi.fn(() => []),
   getAllSlugs: vi.fn(() => []),
   getReportBySlug: getReportBySlugMock,
+  hasPublishedBenchmarks: hasPublishedBenchmarksMock,
 }));
 
 describe("benchmarks RSS autodiscovery metadata", () => {
   it("links the benchmarks RSS feed from the index metadata", () => {
-    expect(benchmarksMetadata.alternates).toMatchObject({
+    expect(benchmarksIndexMetadata().alternates).toMatchObject({
       canonical: "/benchmarks",
       types: benchmarkRssAlternate,
     });
@@ -52,7 +54,7 @@ describe("benchmarks RSS autodiscovery metadata", () => {
 
 describe("benchmarks index social metadata", () => {
   it("adds Open Graph and Twitter card metadata", () => {
-    expect(benchmarksMetadata).toMatchObject({
+    expect(benchmarksIndexMetadata()).toMatchObject({
       openGraph: {
         url: "/benchmarks",
         type: "website",
@@ -62,6 +64,21 @@ describe("benchmarks index social metadata", () => {
         card: "summary_large_image",
       },
     });
+  });
+});
+
+describe("benchmarks index indexability (coming-soon gate)", () => {
+  it("noindexes the index while no real benchmark is published", () => {
+    hasPublishedBenchmarksMock.mockReturnValue(false);
+    expect(benchmarksIndexMetadata().robots).toEqual({
+      index: false,
+      follow: true,
+    });
+  });
+
+  it("leaves the index indexable once a real benchmark ships", () => {
+    hasPublishedBenchmarksMock.mockReturnValue(true);
+    expect(benchmarksIndexMetadata().robots).toBeUndefined();
   });
 });
 

--- a/web/src/app/benchmarks/page.tsx
+++ b/web/src/app/benchmarks/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { JsonLd, benchmarkIndexSchema } from "@/components/marketing/json-ld";
-import { getAllReports } from "@/lib/benchmarks";
+import { getAllReports, hasPublishedBenchmarks } from "@/lib/benchmarks";
 import { benchmarkRssAlternate, ogImageUrl } from "@/lib/seo";
 
 const PAGE_TITLE = "AI Agent Benchmarks - Models Raced Head-to-Head | AgentClash";
@@ -14,38 +14,84 @@ const SOCIAL_IMAGE = ogImageUrl({
   kind: "Benchmark",
 });
 
-export const metadata: Metadata = {
-  title: PAGE_TITLE,
-  description: PAGE_DESCRIPTION,
-  alternates: {
-    canonical: "/benchmarks",
-    types: benchmarkRssAlternate,
-  },
-  openGraph: {
+export function generateMetadata(): Metadata {
+  const metadata: Metadata = {
     title: PAGE_TITLE,
     description: PAGE_DESCRIPTION,
-    url: "/benchmarks",
-    type: "website",
-    locale: "en_US",
-    siteName: "AgentClash",
-    images: [{ url: SOCIAL_IMAGE, width: 1200, height: 630, alt: PAGE_TITLE }],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: PAGE_TITLE,
-    description: PAGE_DESCRIPTION,
-    images: [{ url: SOCIAL_IMAGE, alt: PAGE_TITLE }],
-  },
-};
+    alternates: {
+      canonical: "/benchmarks",
+      types: benchmarkRssAlternate,
+    },
+    openGraph: {
+      title: PAGE_TITLE,
+      description: PAGE_DESCRIPTION,
+      url: "/benchmarks",
+      type: "website",
+      locale: "en_US",
+      siteName: "AgentClash",
+      images: [{ url: SOCIAL_IMAGE, width: 1200, height: 630, alt: PAGE_TITLE }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: PAGE_TITLE,
+      description: PAGE_DESCRIPTION,
+      images: [{ url: SOCIAL_IMAGE, alt: PAGE_TITLE }],
+    },
+  };
+
+  // Until a real race ships, the page shows a "coming soon" state — keep it
+  // crawlable (so engines actually read the noindex) but out of the index, the
+  // same way individual `sample` reports are handled. Indexability returns
+  // automatically when the first measured benchmark is published.
+  if (!hasPublishedBenchmarks()) {
+    metadata.robots = { index: false, follow: true };
+  }
+
+  return metadata;
+}
 
 export default function BenchmarksPage() {
   const reports = getAllReports();
+  // `sample` reports are illustrative only — never list them publicly. With no
+  // real report yet, the section shows a "coming soon" state instead.
+  const published = reports.filter((report) => !report.sample);
+
+  if (published.length === 0) {
+    return (
+      <MarketingShell>
+        <section className="mx-auto w-full max-w-3xl px-6 py-16">
+          <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35">
+            Benchmarks
+          </p>
+          <h1 className="mt-3 font-[family-name:var(--font-display)] text-3xl tracking-[-0.02em] leading-[1.15] sm:text-4xl">
+            Models, raced head-to-head
+          </h1>
+          <p className="mt-3 max-w-xl text-sm leading-relaxed text-white/45">
+            When a new model ships, we race it against the field on real agentic
+            tasks — same challenge, same tools — and score the whole trajectory
+            on correctness, reliability, latency, and cost.
+          </p>
+
+          <div className="mt-10 rounded-lg border border-white/[0.08] bg-white/[0.03] px-6 py-8">
+            <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/40">
+              Coming soon
+            </p>
+            <p className="mt-3 max-w-xl text-sm leading-relaxed text-white/55">
+              We&apos;re lining up the first head-to-head. The opening race drops
+              soon — real models on real agentic tasks, with the full scorecard
+              and replay. Check back shortly.
+            </p>
+          </div>
+        </section>
+      </MarketingShell>
+    );
+  }
 
   return (
     <MarketingShell>
       <JsonLd
         id="agentclash-benchmarks-index-schema"
-        data={benchmarkIndexSchema(reports.filter((report) => !report.sample))}
+        data={benchmarkIndexSchema(published)}
       />
       <section className="mx-auto w-full max-w-3xl px-6 py-16">
         <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35">
@@ -84,10 +130,6 @@ export default function BenchmarksPage() {
             </Link>
           ))}
         </div>
-
-        {reports.length === 0 && (
-          <p className="mt-10 text-xs text-white/20">No benchmarks yet.</p>
-        )}
       </section>
     </MarketingShell>
   );

--- a/web/src/app/landing.tsx
+++ b/web/src/app/landing.tsx
@@ -1405,7 +1405,13 @@ const LANDING_FEATURES: Array<{
 // COMPARISON_COLUMNS and COMPARISON_ROWS now live in @/lib/comparison-data,
 // shared with the /compare pages so the matrix never drifts between surfaces.
 
-export default function HomePage() {
+export default function HomePage({
+  showBenchmarks = false,
+}: {
+  // Gated by the server page off `hasPublishedBenchmarks()`: hide the Benchmarks
+  // nav link while the section is in its coming-soon state.
+  showBenchmarks?: boolean;
+} = {}) {
   const { user, loading: authLoading } = useAuth();
 
   useEffect(() => {
@@ -1462,12 +1468,14 @@ export default function HomePage() {
             >
               Docs
             </Link>
-            <Link
-              href="/benchmarks"
-              className="hidden sm:inline-flex px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"
-            >
-              Benchmarks
-            </Link>
+            {showBenchmarks && (
+              <Link
+                href="/benchmarks"
+                className="hidden sm:inline-flex px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"
+              >
+                Benchmarks
+              </Link>
+            )}
             <Link
               href="/blog"
               className="hidden sm:inline-flex px-3 py-1.5 text-white/55 hover:text-white/85 transition-colors"

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -9,6 +9,7 @@ import {
   productSchema,
   websiteSchema,
 } from "@/components/marketing/json-ld";
+import { hasPublishedBenchmarks } from "@/lib/benchmarks";
 import { getChangelogPeriods } from "@/lib/changelog";
 import { HOME_FAQ } from "@/lib/home-faq";
 import { AGENT_EVALUATION_FEATURES } from "@/lib/seo-features";
@@ -59,7 +60,7 @@ export default async function RootPage() {
           faqSchema(HOME_FAQ),
         ]}
       />
-      <HomePage />
+      <HomePage showBenchmarks={hasPublishedBenchmarks()} />
     </>
   );
 }

--- a/web/src/app/public-canonical-metadata.test.ts
+++ b/web/src/app/public-canonical-metadata.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { metadata as homeMetadata } from "./page";
 import { metadata as blogMetadata } from "./blog/page";
 import { generateMetadata as generateBlogPostMetadata } from "./blog/[slug]/page";
-import { metadata as benchmarksMetadata } from "./benchmarks/page";
+import { generateMetadata as generateBenchmarksIndexMetadata } from "./benchmarks/page";
 import { generateMetadata as generateBenchmarkMetadata } from "./benchmarks/[slug]/page";
 import { generateMetadata as generateDocsMetadata } from "./docs/[[...slug]]/page";
 import { metadata as agentEvaluationMetadata } from "./platform/agent-evaluation/page";
@@ -40,6 +40,7 @@ vi.mock("@/lib/benchmarks", () => ({
   getAllReports: vi.fn(() => []),
   getAllSlugs: vi.fn(() => []),
   getReportBySlug: getReportBySlugMock,
+  hasPublishedBenchmarks: vi.fn(() => false),
 }));
 
 vi.mock("@/lib/docs", () => ({
@@ -57,7 +58,7 @@ describe("public canonical metadata", () => {
   it("locks static public page canonicals", () => {
     expectCanonical(homeMetadata, "/");
     expectCanonical(blogMetadata, "/blog");
-    expectCanonical(benchmarksMetadata, "/benchmarks");
+    expectCanonical(generateBenchmarksIndexMetadata(), "/benchmarks");
     expectCanonical(agentEvaluationMetadata, "/platform/agent-evaluation");
     expectCanonical(
       agentRegressionTestingMetadata,

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { hasPublishedBenchmarks } from "@/lib/benchmarks";
 import { getChangelogLatestModified, getChangelogPeriods } from "@/lib/changelog";
 import sitemap from "./sitemap";
 
@@ -45,6 +46,9 @@ vi.mock("@/lib/benchmarks", () => ({
       sample: false,
     },
   ]),
+  // Two of the mocked reports are non-sample, so the section is "live" and the
+  // /benchmarks index belongs in the sitemap.
+  hasPublishedBenchmarks: vi.fn(() => true),
 }));
 
 describe("sitemap", () => {
@@ -182,6 +186,14 @@ describe("sitemap", () => {
     const image = report?.images?.[0] ?? "";
     expect(image.startsWith("https://www.agentclash.dev/og?")).toBe(true);
     expect(image).toContain("kind=Benchmark");
+  });
+
+  it("omits the benchmarks index while the section is coming-soon", () => {
+    vi.mocked(hasPublishedBenchmarks).mockReturnValueOnce(false);
+    const entries = sitemap();
+    const urls = new Set(entries.map((entry) => entry.url));
+
+    expect(urls.has("https://www.agentclash.dev/benchmarks")).toBe(false);
   });
 
   it("includes the comparison hub and per-competitor pages", () => {

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from "next";
 import { getAllPosts } from "@/lib/blog";
-import { getAllReports } from "@/lib/benchmarks";
+import { getAllReports, hasPublishedBenchmarks } from "@/lib/benchmarks";
 import {
   getChangelogLatestModified,
   getChangelogPeriodHref,
@@ -79,6 +79,27 @@ export default function sitemap(): MetadataRoute.Sitemap {
         ],
       };
     });
+  // Only list the /benchmarks index while a real report is published. With just
+  // illustrative `sample` reports, the page is a noindexed "coming soon" state,
+  // and a sitemap must never advertise a noindexed URL (Search Console flags it).
+  const benchmarkIndex = hasPublishedBenchmarks()
+    ? [
+        {
+          url: `${DOCS_ORIGIN}/benchmarks`,
+          lastModified: new Date(),
+          changeFrequency: "weekly" as const,
+          priority: 0.8,
+          images: [
+            ogImage({
+              title: "AI Agent Benchmarks",
+              subtitle:
+                "New models raced against the field on real agentic tasks",
+              kind: "Benchmark",
+            }),
+          ],
+        },
+      ]
+    : [];
   const docs = getAllDocPaths().map((docPath) => ({
     url: `${DOCS_ORIGIN}${docPath}`,
     lastModified: new Date(),
@@ -128,19 +149,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "weekly",
       priority: 0.8,
       images: [DEFAULT_OG],
-    },
-    {
-      url: `${DOCS_ORIGIN}/benchmarks`,
-      lastModified: new Date(),
-      changeFrequency: "weekly",
-      priority: 0.8,
-      images: [
-        ogImage({
-          title: "AI Agent Benchmarks",
-          subtitle: "New models raced against the field on real agentic tasks",
-          kind: "Benchmark",
-        }),
-      ],
     },
     {
       url: `${DOCS_ORIGIN}/changelog`,
@@ -252,6 +260,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     ...compare,
     ...docs,
     ...posts,
+    ...benchmarkIndex,
     ...benchmarks,
   ];
 }

--- a/web/src/components/marketing/marketing-footer.tsx
+++ b/web/src/components/marketing/marketing-footer.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { hasPublishedBenchmarks } from "@/lib/benchmarks";
 
 const COLUMNS: Array<{
   heading: string;
@@ -40,11 +41,20 @@ const COLUMNS: Array<{
 ];
 
 export function MarketingFooter() {
+  // Drop the Benchmarks link while the section is in its coming-soon state; it
+  // returns automatically once a real report is published.
+  const columns = hasPublishedBenchmarks()
+    ? COLUMNS
+    : COLUMNS.map((col) => ({
+        ...col,
+        links: col.links.filter((link) => link.href !== "/benchmarks"),
+      }));
+
   return (
     <footer className="mt-auto border-t border-white/[0.06] px-8 sm:px-12 pt-20 pb-10">
       <div className="mx-auto max-w-[1440px]">
         <div className="grid gap-12 sm:grid-cols-2 lg:grid-cols-4">
-          {COLUMNS.map((col) => (
+          {columns.map((col) => (
             <div key={col.heading}>
               <p className="text-[11px] font-[family-name:var(--font-mono)] uppercase tracking-[0.2em] text-white/35">
                 {col.heading}

--- a/web/src/components/marketing/marketing-header.tsx
+++ b/web/src/components/marketing/marketing-header.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { ArrowRight, LogIn, Star } from "lucide-react";
 import { withAuth } from "@workos-inc/authkit-nextjs";
+import { hasPublishedBenchmarks } from "@/lib/benchmarks";
 import { ClashMark } from "./clash-mark";
 
 type NavLink = { href: string; label: string; external?: boolean };
@@ -19,6 +20,11 @@ type Props = {
 
 export async function MarketingHeader({ nav = DEFAULT_NAV }: Props) {
   const { user } = await withAuth();
+  // Hide Benchmarks until a real report ships (coming-soon state) so we never
+  // funnel visitors to a placeholder; it reappears automatically once live.
+  const visibleNav = hasPublishedBenchmarks()
+    ? nav
+    : nav.filter((item) => item.href !== "/benchmarks");
 
   return (
     <header className="px-5 sm:px-12 py-5 sm:py-6 border-b border-white/[0.06]">
@@ -33,7 +39,7 @@ export async function MarketingHeader({ nav = DEFAULT_NAV }: Props) {
           </span>
         </Link>
         <nav className="flex items-center gap-0.5 sm:gap-2 text-xs">
-          {nav.map((item) =>
+          {visibleNav.map((item) =>
             item.external ? (
               <a
                 key={item.href}

--- a/web/src/lib/benchmarks.ts
+++ b/web/src/lib/benchmarks.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import { cache } from "react";
 import matter from "gray-matter";
 
 const CONTENT_DIR = path.join(process.cwd(), "content", "benchmarks");
@@ -238,7 +239,11 @@ function stripContent(report: BenchmarkReportWithContent): BenchmarkReport {
   return meta;
 }
 
-export function getAllReports(): BenchmarkReport[] {
+// `cache()` dedupes the filesystem scan within a single render/request: a
+// MarketingShell page reaches this through the header, the footer, and its own
+// metadata + body, so without it one request would scan content/benchmarks
+// several times over.
+export const getAllReports = cache((): BenchmarkReport[] => {
   if (!fs.existsSync(CONTENT_DIR)) return [];
   const files = fs.readdirSync(CONTENT_DIR).filter((f) => f.endsWith(".mdx"));
   const reports: BenchmarkReport[] = [];
@@ -250,7 +255,7 @@ export function getAllReports(): BenchmarkReport[] {
   }
 
   return reports.sort((a, b) => (a.date > b.date ? -1 : 1));
-}
+});
 
 export function getReportBySlug(slug: string): BenchmarkReportWithContent | null {
   return readReportBySlug(slug);

--- a/web/src/lib/benchmarks.ts
+++ b/web/src/lib/benchmarks.ts
@@ -259,3 +259,12 @@ export function getReportBySlug(slug: string): BenchmarkReportWithContent | null
 export function getAllSlugs(): string[] {
   return getAllReports().map((report) => report.slug);
 }
+
+// True once at least one real (non-`sample`) report is published. Single source
+// of truth for whether the Benchmarks section is "live": it gates public listing
+// (page, sitemap, nav links) and indexability. While only illustrative `sample`
+// reports exist, the section stays in a noindexed "coming soon" state and flips
+// on automatically the moment a measured benchmark ships.
+export function hasPublishedBenchmarks(): boolean {
+  return getAllReports().some((report) => !report.sample);
+}


### PR DESCRIPTION
## Why

The only benchmark report so far is `sample: true` (illustrative numbers), but `/benchmarks` was publicly listed, linked from the **navbar, footer, and homepage**, and its index URL was submitted in the **sitemap** — so our high-traffic homepage was funnelling visitors and crawlers to a page of fabricated data.

## What

Introduce `hasPublishedBenchmarks()` (= "any non-`sample` report exists") as the single source of truth, and key the section's visibility + indexability off it. The codebase already noindexed individual `sample` reports and excluded them from sitemap slugs — this extends that same pattern to the index page and nav.

| Surface | Coming-soon (now) | When a real report ships |
|---|---|---|
| `/benchmarks` page | "Coming soon" block, `robots: noindex, follow` | full list, indexable |
| Sitemap | index entry omitted | index re-listed |
| Navbar / footer / homepage | Benchmarks link hidden | link reappears |

**It reverts fully automatically** the moment a non-`sample` report is published — nothing to remember to undo.

## SEO reasoning

- `noindex, follow` (not `robots.txt Disallow`) → Google can still crawl the page and actually *read* the noindex; the classic mistake of disallowing means the noindex is never seen.
- Index entry pulled from the sitemap while noindexed → avoids the Search Console "submitted URL marked noindex" warning (sitemaps should only list indexable URLs).
- **No 404, no redirect** — route stays `200`, so no crawl errors and nothing to clean up. `robots.txt` stays fully open.

## Verification

- `tsc --noEmit`, `eslint`, full `vitest` suite (439 passed) — green.
- `next build` — succeeds; prerendered `sitemap.xml` confirmed to **exclude** `/benchmarks` (blog/changelog still present).
- `next start` + curl: `/benchmarks` → `200` with `<meta name="robots" content="noindex, follow">` and the coming-soon copy; **zero** `href="/benchmarks"` on the page or homepage; no sample numbers in the HTML.
- Failure/revert path covered by new unit tests: sitemap *omits index while coming-soon* / *lists it once published*, and index metadata *noindex while empty* / *indexable once real*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)