### PR TITLE
feat(benchmarks): publish first real benchmark — GPT generations on expression-evaluator

### DIFF
--- a/examples/challenge-packs/expr-eval-arena.yaml
+++ b/examples/challenge-packs/expr-eval-arena.yaml
@@ -1,0 +1,283 @@
+###############################################################################
+# Challenge Pack: Expression Evaluator Arena
+#
+# A genuinely differentiating coding task: implement an integer expression
+# evaluator with operator precedence, parentheses, and unary minus, where
+# division must TRUNCATE TOWARD ZERO (not Python's floor //). Careless
+# implementations that reach for `//` or `eval` pass the basic and unary tiers
+# but fail the division tier on negative operands (e.g. -7/2 == -3, not -4).
+#
+# Correctness is graded across three code_execution tiers (basic, unary,
+# division) and is intentionally NOT a hard gate, so partial credit produces a
+# real ranking spread instead of an all-pass tie. Companion to the
+# fibonacci-e2e-showcase pack, which is deliberately saturated.
+###############################################################################
+
+pack:
+  slug: expr-eval-arena
+  name: Expression Evaluator Arena
+  family: coding
+
+version:
+  number: 1
+  execution_mode: native
+  sandbox:
+    network_access: false
+
+  tool_policy:
+    allow_shell: true
+    allowed_tool_kinds:
+      - file
+
+  evaluation_spec:
+    name: expr-eval-arena-v1
+    version_number: 1
+    judge_mode: hybrid
+
+    post_execution_checks:
+      - key: solution
+        type: file_capture
+        path: /workspace/solution.py
+
+    validators:
+      # === final_output contract ===========================================
+      - key: final_output_mentions_precedence
+        type: regex_match
+        target: final_output
+        expected_from: "literal:(?i)precedence"
+
+      - key: final_output_schema
+        type: json_schema
+        target: final_output
+        expected_from: "literal:{\"type\":\"object\",\"required\":[\"approach\",\"division_semantics\",\"sample_evaluations\",\"explanation\"],\"properties\":{\"approach\":{\"type\":\"string\"},\"division_semantics\":{\"type\":\"string\"},\"sample_evaluations\":{\"type\":\"array\",\"minItems\":3,\"items\":{\"type\":\"object\",\"required\":[\"expr\",\"value\"],\"properties\":{\"expr\":{\"type\":\"string\"},\"value\":{\"type\":\"integer\"}}}},\"explanation\":{\"type\":\"string\",\"minLength\":40}}}"
+
+      - key: final_output_division_semantics
+        type: json_path_match
+        target: final_output
+        expected_from: "literal:{\"path\":\"$.division_semantics\",\"comparator\":\"equals\",\"value\":\"truncate-toward-zero\"}"
+
+      # === file validator — source.kind = tool_call ========================
+      - key: solution_defines_function
+        type: file_content_match
+        target: file:solution
+        expected_from: "literal:def evaluate"
+        config:
+          mode: contains
+
+      # === code_execution tiers — the differentiators ======================
+      - key: tests_basic
+        type: code_execution
+        target: file:solution
+        config:
+          test_command: "python3 -c \"import sys; sys.path.insert(0,'/workspace'); from solution import evaluate; assert evaluate('2+3')==5; assert evaluate('2*3+4')==10; assert evaluate('10-2-3')==5; assert evaluate('2+3*4')==14; assert evaluate('(2+3)*4')==20; assert evaluate('2*(3+(4-1))')==12; assert evaluate(' 12 + 34 ')==46; print('OK')\""
+          scoring: all_or_nothing
+
+      - key: tests_unary
+        type: code_execution
+        target: file:solution
+        config:
+          test_command: "python3 -c \"import sys; sys.path.insert(0,'/workspace'); from solution import evaluate; assert evaluate('-5+3')==-2; assert evaluate('3 + -2')==1; assert evaluate('-(3+4)')==-7; assert evaluate('2--3')==5; print('OK')\""
+          scoring: all_or_nothing
+
+      - key: tests_division
+        type: code_execution
+        target: file:solution
+        config:
+          test_command: "python3 -c \"import sys; sys.path.insert(0,'/workspace'); from solution import evaluate; assert evaluate('7/2')==3; assert evaluate('-7/2')==-3; assert evaluate('7/-2')==-3; assert evaluate('-8/-2')==4; print('OK')\""
+          scoring: all_or_nothing
+
+    metrics:
+      - key: completed
+        type: boolean
+        collector: run_completed_successfully
+      - key: total_latency_ms
+        type: numeric
+        collector: run_total_latency_ms
+        unit: ms
+      - key: total_tokens
+        type: numeric
+        collector: run_total_tokens
+
+    llm_judges:
+      - key: code_quality
+        mode: reference
+        model: claude-sonnet-4-6
+        samples: 2
+        context_from:
+          - final_output
+          - case.expectations.reference_solution
+        reference_from: case.expectations.reference_solution
+        rubric: |
+          Score the submitted expression evaluator from 1 to 5 against the
+          reference. Reward a clean recursive-descent or shunting-yard parser
+          with correct operator precedence, parentheses, unary minus, and
+          division that truncates toward zero. Penalize use of `eval`, floor
+          division `//` (wrong on negative operands), missing unary-minus
+          handling, or unsafe parsing.
+
+      - key: explanation_clarity
+        mode: assertion
+        model: claude-haiku-4-5-20251001
+        samples: 3
+        context_from:
+          - final_output
+        assertion: |
+          The `explanation` field describes the parsing approach in plain
+          language, names how operator precedence and parentheses are handled,
+          and explains the division-toward-zero rule — not just restates it.
+          One-sentence descriptions that just say "it parses the string"
+          should fail.
+
+    runtime_limits:
+      max_duration_ms: 240000
+      max_total_tokens: 40000
+
+    scorecard:
+      strategy: hybrid
+      judge_limits:
+        max_samples_per_judge: 3
+        max_tokens: 8000
+      dimensions:
+        - key: correctness
+          source: validators
+          validators:
+            - solution_defines_function
+            - tests_basic
+            - tests_unary
+            - tests_division
+          better_direction: higher
+          gate: true
+          pass_threshold: 0.5
+          weight: 0.6
+
+        - key: output_contract
+          source: validators
+          validators:
+            - final_output_mentions_precedence
+            - final_output_schema
+            - final_output_division_semantics
+          better_direction: higher
+          weight: 0.15
+
+        - key: code_quality
+          source: llm_judge
+          judge_key: code_quality
+          better_direction: higher
+          weight: 0.15
+
+        - key: explanation_clarity
+          source: llm_judge
+          judge_key: explanation_clarity
+          better_direction: higher
+          weight: 0.1
+
+      pass_threshold: 0.5
+
+challenges:
+  - key: expr-eval
+    title: Implement an integer expression evaluator in Python
+    category: coding
+    difficulty: medium
+    instructions: |
+      Write a Python module at `/workspace/solution.py` that exports a function
+      `evaluate(expr: str) -> int` which evaluates an arithmetic expression
+      over integers and returns the integer result.
+
+      Requirements (read carefully — the edge cases matter):
+
+        - Operators: `+`, `-`, `*`, `/`, with standard precedence (`*` and `/`
+          bind tighter than `+` and `-`) and left-to-right associativity.
+        - Parentheses `(` `)` group sub-expressions and may be nested.
+        - Unary minus is supported, including before parentheses and after
+          another operator. Examples: `-5+3 == -2`, `3 + -2 == 1`,
+          `-(3+4) == -7`, `2--3 == 5`.
+        - Division `/` is INTEGER division that TRUNCATES TOWARD ZERO (NOT
+          Python's floor `//`). So `7/2 == 3`, `-7/2 == -3`, `7/-2 == -3`,
+          `-8/-2 == 4`. Do not use `eval`.
+        - Division by zero must raise `ValueError`.
+        - Whitespace is insignificant and multi-digit integers are supported:
+          `" 12 + 34 " == 46`.
+
+      After writing the file, emit a single final JSON answer matching this
+      shape EXACTLY (no surrounding prose, no code fences):
+
+          {
+            "approach": "recursive-descent" | "shunting-yard" | "other",
+            "division_semantics": "truncate-toward-zero",
+            "sample_evaluations": [
+              { "expr": "2+3*4", "value": 14 },
+              { "expr": "-7/2", "value": -3 },
+              { "expr": "2--3", "value": 5 }
+            ],
+            "explanation": "Plain-language description of how you parse, how operator precedence and parentheses are handled, and why division truncates toward zero. At least a few sentences."
+          }
+
+      The `sample_evaluations` list must include at least three entries with
+      correct integer results.
+
+input_sets:
+  - key: default
+    name: Default Input Set
+    cases:
+      - challenge_key: expr-eval
+        case_key: default
+        expectations:
+          - key: allowed_approaches
+            kind: text
+            value: "recursive-descent, shunting-yard, other"
+          - key: reference_solution
+            kind: text
+            value: |
+              Reference implementation (recursive descent, truncate-toward-zero
+              division, raises ValueError on divide-by-zero):
+
+                  def _trunc_div(a: int, b: int) -> int:
+                      if b == 0:
+                          raise ValueError("division by zero")
+                      q = abs(a) // abs(b)
+                      return -q if (a < 0) != (b < 0) else q
+
+                  def evaluate(expr: str) -> int:
+                      s = expr.replace(" ", "")
+                      pos = 0
+                      def peek():
+                          return s[pos] if pos < len(s) else ""
+                      def number():
+                          nonlocal pos
+                          start = pos
+                          while pos < len(s) and s[pos].isdigit():
+                              pos += 1
+                          return int(s[start:pos])
+                      def factor():
+                          nonlocal pos
+                          if peek() == "-":
+                              pos += 1
+                              return -factor()
+                          if peek() == "(":
+                              pos += 1
+                              v = expr_()
+                              if peek() == ")":
+                                  pos += 1
+                              return v
+                          return number()
+                      def term():
+                          nonlocal pos
+                          v = factor()
+                          while peek() in ("*", "/"):
+                              op = s[pos]; pos += 1
+                              r = factor()
+                              v = v * r if op == "*" else _trunc_div(v, r)
+                          return v
+                      def expr_():
+                          nonlocal pos
+                          v = term()
+                          while peek() in ("+", "-"):
+                              op = s[pos]; pos += 1
+                              r = term()
+                              v = v + r if op == "+" else v - r
+                          return v
+                      return expr_()
+
+              Precedence is encoded by the expr_ -> term -> factor call chain;
+              division truncates toward zero via _trunc_div, which differs from
+              Python's floor // on negative operands.

--- a/examples/challenge-packs/expr-eval-arena.yaml
+++ b/examples/challenge-packs/expr-eval-arena.yaml
@@ -8,7 +8,8 @@
 # but fail the division tier on negative operands (e.g. -7/2 == -3, not -4).
 #
 # Correctness is graded across three code_execution tiers (basic, unary,
-# division) and is intentionally NOT a hard gate, so partial credit produces a
+# division) and gated leniently (gate: true, pass_threshold: 0.5), so a model
+# that handles the basics still passes the gate while partial credit produces a
 # real ranking spread instead of an all-pass tie. Companion to the
 # fibonacci-e2e-showcase pack, which is deliberately saturated.
 ###############################################################################

--- a/web/content/benchmarks/gpt-generations-expression-evaluator.mdx
+++ b/web/content/benchmarks/gpt-generations-expression-evaluator.mdx
@@ -1,0 +1,116 @@
+---
+title: "We raced four GPT generations on a real coding task — GPT-5.4 won on efficiency"
+date: "2026-06-07"
+description: "A head-to-head AgentClash race of GPT-4.1, GPT-5, GPT-5.4, and GPT-5.5 on a real agentic coding task — building an integer expression evaluator with truncating division — scored on correctness, reliability, and token efficiency."
+author: "AgentClash"
+featuredModel: "GPT-5.4"
+verdict: "GPT-5.4 solved the task in 2 turns and ~8K tokens; GPT-5 and GPT-5.5 also passed, while GPT-4.1 thrashed for its full budget and failed to submit."
+challengePack: "Expression Evaluator Arena v1"
+sample: false
+tasks:
+  - id: expr-eval
+    name: "Build an integer expression evaluator"
+    summary: "Implement evaluate(expr) with operator precedence, parentheses, and unary minus — where division must truncate toward zero (not Python's floor //) and divide-by-zero must raise. Graded by a hidden three-tier test suite plus a strict output contract and LLM judges."
+results:
+  - model: "GPT-5.4"
+    provider: "OpenAI"
+    rank: 1
+    winner: true
+    composite: 1.0
+    correctness: 1.0
+    reliability: 1.0
+    cost: 1.0
+  - model: "GPT-5"
+    provider: "OpenAI"
+    rank: 2
+    composite: 1.0
+    correctness: 1.0
+    reliability: 1.0
+    cost: 0.55
+  - model: "GPT-5.5"
+    provider: "OpenAI"
+    rank: 3
+    composite: 0.88
+    correctness: 1.0
+    reliability: 1.0
+    cost: 0.46
+  - model: "GPT-4.1"
+    provider: "OpenAI"
+    rank: 4
+    reliability: 0.0
+    cost: 0.2
+---
+
+## How the race worked
+
+All four models got the **same task, the same sandbox, and the same tools** — a
+shell and a filesystem, a ten-iteration budget, no network. The task is a real
+slice of coding work with a verifiable outcome, not a trivia question: write a
+working program, and a hidden test suite decides whether it actually runs.
+
+AgentClash scored the whole trajectory across four vantages — deterministic
+checks (the hidden tests), the output contract, behavioral signals (did the run
+complete cleanly), and LLM judges on code quality and explanation — and folded
+them into one composite. (More on that in
+[how AgentClash scores agent trajectories](/blog/how-agentclash-scores-agent-trajectories).)
+
+## The task
+
+Implement `evaluate(expr: str) -> int` in Python: operator precedence,
+parentheses, and unary minus, where **division truncates toward zero** — so
+`-7/2 == -3`, not Python's floor-division `-4` — and divide-by-zero raises. The
+trap is deliberate: the lazy implementation reaches for Python's `//` or `eval`,
+which sails through the basic and unary tiers and then fails on negative
+division. Correctness is graded across three hidden test tiers (basic
+precedence, unary minus, truncating division), so a near-miss scores partial
+credit instead of a flat pass/fail.
+
+## What we saw
+
+**The trap didn't catch the frontier models.** GPT-5, GPT-5.4, and GPT-5.5 all
+landed full correctness — they handled truncating division correctly rather than
+defaulting to floor division. The separation showed up everywhere else: how
+*efficiently* they got there, and whether the oldest model could finish at all.
+
+**GPT-5.4 won on efficiency.** It submitted a correct, complete solution in
+**2 model calls and ~8K tokens** — a perfect score with the leanest trajectory
+in the field.
+
+**GPT-4.1 thrashed and failed.** It never converged: it burned all ten
+iterations in a debugging loop of repeated shell calls, spent **~41K tokens —
+five times the winner — and still never submitted a valid solution.** The harder
+task surfaced the gap in agentic coding that the saturated tasks hide.
+
+**GPT-5.5 was correct but sloppy on the contract.** It solved the problem but
+slipped on the strict final-output JSON shape, costing it the `output_contract`
+dimension and dropping its composite to 0.88.
+
+The measured trajectory cost (raw, no price assumptions):
+
+| Model    | Model calls | Total tokens | Outcome                          |
+| -------- | ----------- | ------------ | -------------------------------- |
+| GPT-5.4  | 2           | 8,134        | ✅ solved — leanest run          |
+| GPT-5    | 3           | 14,695       | ✅ solved                        |
+| GPT-5.5  | 4           | 17,693       | ✅ correct, slipped on contract  |
+| GPT-4.1  | 10 (cap)    | 40,932       | ❌ failed — never submitted      |
+
+The **Cost** column in the scoreboard is a token-efficiency score normalized to
+the leanest run (fewer tokens → higher); we don't assert dollar prices here.
+
+## Caveats
+
+This is a deliberately small first race: **one task, a single run per model**
+(n=1), and an OpenAI-only field. The LLM-judge dimensions carry per-run variance,
+and one task can't rank models in general. Read it as a worked example of the
+format and a real, reproducible result — not a verdict on the models. Wider
+fields (including cross-provider and cheaper open-weight models) follow as the
+backend grows to support them.
+
+## Takeaway
+
+A single benchmark number hides the trade-off that actually decides which model
+you ship. On this task every passing model was "correct" — but one solved it in
+two turns and another couldn't solve it at all. Race them on *your* tasks, with
+your tools, and read the whole scoreboard before you pick.
+
+[Run your own race →](/try)

--- a/web/content/benchmarks/gpt-generations-expression-evaluator.mdx
+++ b/web/content/benchmarks/gpt-generations-expression-evaluator.mdx
@@ -37,6 +37,8 @@ results:
   - model: "GPT-4.1"
     provider: "OpenAI"
     rank: 4
+    composite: 0.0
+    correctness: 0.0
     reliability: 0.0
     cost: 0.2
 ---


### PR DESCRIPTION
## What & why

Ships AgentClash's **first measured (non-sample) benchmark report**. Because it's `sample: false`, `hasPublishedBenchmarks()` flips the entire `/benchmarks` section from the "coming soon" gate to **live** — indexable, in the navbar/footer, sitemap, and RSS feed.

This is a real 4-model race run on `api.agentclash.dev` (not hand-authored numbers).

## The race

A new challenge pack, **Expression Evaluator Arena** (`examples/challenge-packs/expr-eval-arena.yaml`): implement `evaluate(expr) -> int` with operator precedence, parentheses, unary minus, and **division that truncates toward zero** (the trap: lazy `//`/`eval` passes the easy tiers and fails negative division). Correctness is graded across three hidden test tiers and gated leniently, so partial credit yields a real spread instead of an all-pass tie.

| Model | Calls | Tokens | Outcome |
|---|---|---|---|
| **GPT-5.4** 🏆 | 2 | 8,134 | solved — leanest |
| GPT-5 | 3 | 14,695 | solved |
| GPT-5.5 | 4 | 17,693 | correct, slipped on output contract (0.88) |
| GPT-4.1 | 10 (cap) | 40,932 | **failed** — thrashed, never submitted |

## Honesty / scope

- Scoreboard values are **measured**: `composite = overall_score`, `correctness`, reliability (clean completion), and a token-efficiency "Cost" score normalized to the leanest run.
- **Latency** (sandbox-dominated, ~equal) and **$/correct** (no sourced per-token prices for these models) are intentionally left blank → render as "—".
- Caveats stated in the report body: **n=1, one task, OpenAI-only.** Cross-provider / cheaper open-weight models follow once the backend supports them.

## Verification

- `npx tsc --noEmit` ✓ (clean)
- `pnpm lint` ✓ (0 errors; 3 pre-existing warnings in unrelated files)
- `pnpm build` ✓ — both reports statically generated under `/benchmarks/[slug]`; `/benchmarks` builds live with the real report.

## Files

- `examples/challenge-packs/expr-eval-arena.yaml` — new pack (reproducible)
- `web/content/benchmarks/gpt-generations-expression-evaluator.mdx` — the report

🤖 Generated with [Claude Code](https://claude.com/claude-code)