### PR TITLE
ci(web): cache .next/cache in Frontend CI build

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -53,5 +53,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: web/.next/cache
+          # New cache when packages or source change; restore-keys lets a source-only
+          # change fall back to the most recent cache for the same lockfile.
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/src/**/*.{js,jsx,ts,tsx}') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('web/package-lock.json') }}-
+
       - name: Build
         run: npm run build

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -59,7 +59,7 @@ jobs:
           path: web/.next/cache
           # New cache when packages or source change; restore-keys lets a source-only
           # change fall back to the most recent cache for the same lockfile.
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/src/**/*.{js,jsx,ts,tsx}') }}
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/src/**/*.{js,jsx,ts,tsx}', 'web/*.config.{js,ts,mjs,cjs}') }}
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('web/package-lock.json') }}-
 


### PR DESCRIPTION
## Problem

GitHub Actions logs show:

> ⚠ No build cache found. Please configure build caching for faster rebuilds.

The `build` job in `.github/workflows/frontend.yml` runs `next build` with no persisted Next.js build cache. `actions/setup-node` already caches the npm store (`~/.npm`), but nothing caches `.next/cache` — the directory holding Next.js's incremental compiler cache (SWC transforms, webpack module cache, minifier output). So every CI run recompiles from scratch and logs the warning.

It's a warning, not a failure — but the recompile is wasted CI time.

## Change

Add a single `actions/cache@v4` step (the pattern from the official Next.js CI docs, adapted for the `web/` subdir):

- Caches `web/.next/cache` — path is relative to repo root, **not** `working-directory: web`, because `defaults.run.working-directory` doesn't apply to `uses:` action steps.
- Key: lockfile hash (`web/package-lock.json`, matching the existing `cache-dependency-path`) + `web/src/**` source hash, so the key rotates on real code changes.
- `restore-keys` fallback lets a source-only change still seed from the most recent cache (warm incremental compile).

Only the `build` job needs it; `lint-typecheck` doesn't run `next build`. No Vercel change needed — Vercel manages its own build cache.

## Verification

- **First run after merge:** cache miss (none exists yet) → step *saves* `web/.next/cache`. Warning may still appear — expected.
- **Second run:** "Cache restored from key: …", the warning is gone, and the build is faster. That's the real proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)