### PR TITLE
feat(web): adapt auth CTA to sign in vs sign up for returning vs new visitors

### DIFF
--- a/web/src/app/auth/callback/route.ts
+++ b/web/src/app/auth/callback/route.ts
@@ -1,6 +1,8 @@
 import { handleAuth } from "@workos-inc/authkit-nextjs";
+import { cookies } from "next/headers";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { RETURNING_COOKIE } from "@/lib/auth/returning";
 
 function logAuthCallbackError(error: unknown, request: NextRequest) {
   console.error("[auth/callback]", {
@@ -14,6 +16,20 @@ function logAuthCallbackError(error: unknown, request: NextRequest) {
 
 export const GET = handleAuth({
   returnPathname: "/dashboard",
+  onSuccess: async () => {
+    // Mark this browser as a returning visitor so logged-out marketing surfaces
+    // can offer "Sign in" instead of "Sign up". Non-sensitive hint, not auth.
+    (await cookies()).set(RETURNING_COOKIE, "1", {
+      maxAge: 60 * 60 * 24 * 365,
+      path: "/",
+      sameSite: "lax",
+      secure: (process.env.NEXT_PUBLIC_WORKOS_REDIRECT_URI ?? "").startsWith(
+        "https://",
+      ),
+      domain: process.env.WORKOS_COOKIE_DOMAIN || undefined,
+      httpOnly: true,
+    });
+  },
   onError: ({ error, request }) => {
     logAuthCallbackError(error, request);
 

--- a/web/src/app/auth/login/actions.ts
+++ b/web/src/app/auth/login/actions.ts
@@ -1,16 +1,20 @@
 "use server";
 
-import { getSignInUrl } from "@workos-inc/authkit-nextjs";
+import { getSignInUrl, getSignUpUrl } from "@workos-inc/authkit-nextjs";
 import { redirect } from "next/navigation";
 import { sanitizeReturnTo } from "@/lib/auth/return-to";
 
-export async function signInAction(formData: FormData) {
-  const rawReturnTo = formData.get("returnTo");
-  const returnTo =
-    typeof rawReturnTo === "string"
-      ? sanitizeReturnTo(rawReturnTo)
-      : "/dashboard";
+function resolveReturnTo(formData: FormData): string {
+  const raw = formData.get("returnTo");
+  return typeof raw === "string" ? sanitizeReturnTo(raw) : "/dashboard";
+}
 
-  const url = await getSignInUrl({ returnTo });
+export async function signInAction(formData: FormData) {
+  const url = await getSignInUrl({ returnTo: resolveReturnTo(formData) });
+  redirect(url);
+}
+
+export async function signUpAction(formData: FormData) {
+  const url = await getSignUpUrl({ returnTo: resolveReturnTo(formData) });
   redirect(url);
 }

--- a/web/src/app/auth/login/page.tsx
+++ b/web/src/app/auth/login/page.tsx
@@ -1,6 +1,8 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
+import Link from "next/link";
 import { redirect } from "next/navigation";
 import { sanitizeReturnTo } from "@/lib/auth/return-to";
+import { isReturningVisitor } from "@/lib/auth/returning";
 import { ClashMark } from "@/components/marketing/clash-mark";
 import { LightSpeed } from "./lightspeed";
 import { SignInButton } from "./sign-in-button";
@@ -9,12 +11,33 @@ import { TiltCard } from "./tilt-card";
 export default async function LoginPage({
   searchParams,
 }: {
-  searchParams: Promise<{ returnTo?: string }>;
+  searchParams: Promise<{ returnTo?: string; mode?: string; error?: string }>;
 }) {
-  const { returnTo: rawReturnTo } = await searchParams;
+  const { returnTo: rawReturnTo, mode: rawMode, error } = await searchParams;
   const returnTo = sanitizeReturnTo(rawReturnTo);
   const { user } = await withAuth();
   if (user) redirect(returnTo);
+
+  // Choose sign-in vs sign-up: an explicit ?mode= wins, then the returning-visitor
+  // hint cookie, then default to sign-up for a brand-new visitor.
+  const returning = await isReturningVisitor();
+  const mode: "signin" | "signup" =
+    rawMode === "signin" || rawMode === "signup"
+      ? rawMode
+      : returning
+        ? "signin"
+        : "signup";
+
+  const heading = mode === "signup" ? "Create your account" : "Welcome back";
+  const subcopy =
+    mode === "signup"
+      ? "Run your first head-to-head agent race in minutes."
+      : "Continue to your AgentClash dashboard.";
+
+  const otherMode = mode === "signup" ? "signin" : "signup";
+  const toggleParams = new URLSearchParams({ mode: otherMode });
+  if (returnTo !== "/dashboard") toggleParams.set("returnTo", returnTo);
+  const toggleHref = `/auth/login?${toggleParams.toString()}`;
 
   return (
     <main className="relative min-h-screen overflow-hidden bg-[#060606] text-white">
@@ -50,16 +73,30 @@ export default async function LoginPage({
 
             <TiltCard>
               <div className="glass-card glass-shine rounded-2xl p-6 sm:p-8 lg:p-9">
-                <h2 className="text-2xl font-semibold text-white">
-                  Welcome back
-                </h2>
-                <p className="mt-2 text-sm leading-6 text-white/60">
-                  Continue to your AgentClash dashboard.
-                </p>
+                <h2 className="text-2xl font-semibold text-white">{heading}</h2>
+                <p className="mt-2 text-sm leading-6 text-white/60">{subcopy}</p>
+
+                {error === "callback_failed" && (
+                  <p className="mt-4 rounded-md border border-red-400/25 bg-red-400/10 px-3 py-2 text-sm text-red-200/90">
+                    Something went wrong signing you in. Please try again.
+                  </p>
+                )}
 
                 <div className="mt-6">
-                  <SignInButton returnTo={returnTo} />
+                  <SignInButton mode={mode} returnTo={returnTo} />
                 </div>
+
+                <p className="mt-5 text-center text-sm text-white/55">
+                  {mode === "signup"
+                    ? "Already have an account? "
+                    : "New to AgentClash? "}
+                  <Link
+                    href={toggleHref}
+                    className="font-medium text-white/85 underline-offset-4 hover:text-white hover:underline"
+                  >
+                    {mode === "signup" ? "Sign in" : "Create an account"}
+                  </Link>
+                </p>
               </div>
             </TiltCard>
 

--- a/web/src/app/auth/login/sign-in-button.test.tsx
+++ b/web/src/app/auth/login/sign-in-button.test.tsx
@@ -2,6 +2,7 @@ import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SignInButton } from "./sign-in-button";
+import { signInAction, signUpAction } from "./actions";
 
 vi.mock("./actions", () => ({
   signInAction: vi.fn(),
@@ -20,6 +21,13 @@ function render(element: React.ReactElement) {
   });
 }
 
+async function submitForm() {
+  const form = container?.querySelector("form");
+  await act(async () => {
+    form?.requestSubmit();
+  });
+}
+
 afterEach(() => {
   act(() => {
     root?.unmount();
@@ -27,6 +35,7 @@ afterEach(() => {
   container?.remove();
   root = null;
   container = null;
+  vi.clearAllMocks();
 });
 
 describe("SignInButton", () => {
@@ -46,14 +55,24 @@ describe("SignInButton", () => {
     expect(input?.value).toBe("/auth/device?user_code=ABCD-1234");
   });
 
-  it("renders sign-up mode with the shared AgentClash handoff branding", () => {
+  it("dispatches the sign-in action in the default mode", async () => {
+    render(<SignInButton returnTo="/dashboard" />);
+
+    await submitForm();
+
+    expect(signInAction).toHaveBeenCalledTimes(1);
+    expect(signUpAction).not.toHaveBeenCalled();
+  });
+
+  it("dispatches the sign-up action (with shared branding) in sign-up mode", async () => {
     render(<SignInButton mode="signup" returnTo="/dashboard" />);
 
     expect(container?.querySelector("form")).not.toBeNull();
     expect(container?.textContent).toContain("Continue with AgentClash");
-    const input = container?.querySelector<HTMLInputElement>(
-      'input[name="returnTo"]',
-    );
-    expect(input?.value).toBe("/dashboard");
+
+    await submitForm();
+
+    expect(signUpAction).toHaveBeenCalledTimes(1);
+    expect(signInAction).not.toHaveBeenCalled();
   });
 });

--- a/web/src/app/auth/login/sign-in-button.test.tsx
+++ b/web/src/app/auth/login/sign-in-button.test.tsx
@@ -5,6 +5,7 @@ import { SignInButton } from "./sign-in-button";
 
 vi.mock("./actions", () => ({
   signInAction: vi.fn(),
+  signUpAction: vi.fn(),
 }));
 
 let root: Root | null = null;
@@ -43,5 +44,16 @@ describe("SignInButton", () => {
       'input[name="returnTo"]',
     );
     expect(input?.value).toBe("/auth/device?user_code=ABCD-1234");
+  });
+
+  it("renders sign-up mode with the shared AgentClash handoff branding", () => {
+    render(<SignInButton mode="signup" returnTo="/dashboard" />);
+
+    expect(container?.querySelector("form")).not.toBeNull();
+    expect(container?.textContent).toContain("Continue with AgentClash");
+    const input = container?.querySelector<HTMLInputElement>(
+      'input[name="returnTo"]',
+    );
+    expect(input?.value).toBe("/dashboard");
   });
 });

--- a/web/src/app/auth/login/sign-in-button.tsx
+++ b/web/src/app/auth/login/sign-in-button.tsx
@@ -1,19 +1,26 @@
 "use client";
 
 import { ArrowRight } from "lucide-react";
-import { signInAction } from "./actions";
+import { signInAction, signUpAction } from "./actions";
 
 interface SignInButtonProps {
+  mode?: "signin" | "signup";
   label?: string;
   returnTo?: string;
 }
 
 export function SignInButton({
+  mode = "signin",
   label = "Continue with AgentClash",
   returnTo = "/dashboard",
 }: SignInButtonProps) {
+  // `mode` only selects the WorkOS handoff (sign-in vs create-account). The
+  // default copy is constant so it never echoes the card heading; callers like
+  // the CLI device flow override `label`.
+  const action = mode === "signup" ? signUpAction : signInAction;
+
   return (
-    <form action={signInAction}>
+    <form action={action}>
       <input type="hidden" name="returnTo" value={returnTo} />
       <button
         type="submit"

--- a/web/src/app/landing.tsx
+++ b/web/src/app/landing.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef } from "react";
 import Link from "next/link";
 import { getCalApi } from "@calcom/embed-react";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
-import { ArrowRight, Calendar, ExternalLink, LogIn, Star } from "lucide-react";
+import { ArrowRight, Calendar, ExternalLink, Star } from "lucide-react";
 import {
   Anthropic,
   Gemini,
@@ -14,6 +14,7 @@ import {
   OpenRouter,
   XAI,
 } from "@lobehub/icons";
+import { AuthCtaLink, authCta } from "@/components/marketing/auth-cta-link";
 import { LuminousGrid } from "@/components/marketing/luminous-grid";
 import { PricingBlock } from "@/components/marketing/pricing-block";
 import { ExpandedCardsBlock } from "@/components/marketing/expanded-cards-block";
@@ -1407,12 +1408,19 @@ const LANDING_FEATURES: Array<{
 
 export default function HomePage({
   showBenchmarks = false,
+  returning = false,
 }: {
   // Gated by the server page off `hasPublishedBenchmarks()`: hide the Benchmarks
   // nav link while the section is in its coming-soon state.
   showBenchmarks?: boolean;
-} = {}) {
+  returning?: boolean;
+}) {
   const { user, loading: authLoading } = useAuth();
+
+  // Logged-out CTA adapts to whether this browser has signed in before
+  // (server-provided returning-visitor hint cookie). The nav link uses the
+  // shared <AuthCtaLink>; the hero/closing CTAs reuse just its href.
+  const authHref = authCta(returning).href;
 
   useEffect(() => {
     (async () => {
@@ -1504,14 +1512,7 @@ export default function HomePage({
                 <ArrowRight className="size-3" />
               </Link>
             ) : (
-              <Link
-                href="/auth/login"
-                aria-label="Sign in"
-                className="inline-flex items-center gap-1.5 rounded-md border border-white/15 bg-white/[0.04] px-2 sm:px-3 py-1.5 text-white/75 hover:text-white hover:border-white/25 transition-colors"
-              >
-                <LogIn className="size-3.5" />
-                <span className="hidden sm:inline">Sign in</span>
-              </Link>
+              <AuthCtaLink returning={returning} />
             )}
           </nav>
         </div>
@@ -1568,7 +1569,7 @@ export default function HomePage({
               ) : (
                 <>
                   <Link
-                    href="/auth/login"
+                    href={authHref}
                     className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
                   >
                     Start first race
@@ -2304,7 +2305,7 @@ export default function HomePage({
               ) : (
                 <>
                   <Link
-                    href="/auth/login"
+                    href={authHref}
                     className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
                   >
                     Start your first race

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -13,6 +13,7 @@ import { hasPublishedBenchmarks } from "@/lib/benchmarks";
 import { getChangelogPeriods } from "@/lib/changelog";
 import { HOME_FAQ } from "@/lib/home-faq";
 import { AGENT_EVALUATION_FEATURES } from "@/lib/seo-features";
+import { isReturningVisitor } from "@/lib/auth/returning";
 import HomePage from "./landing";
 
 export const metadata: Metadata = {
@@ -49,6 +50,7 @@ const softwareApplicationSchema = {
 export default async function RootPage() {
   const { user } = await withAuth();
   if (user) redirect("/dashboard");
+  const returning = await isReturningVisitor();
   return (
     <>
       <JsonLd
@@ -60,7 +62,7 @@ export default async function RootPage() {
           faqSchema(HOME_FAQ),
         ]}
       />
-      <HomePage showBenchmarks={hasPublishedBenchmarks()} />
+      <HomePage showBenchmarks={hasPublishedBenchmarks()} returning={returning} />
     </>
   );
 }

--- a/web/src/components/marketing/auth-cta-link.tsx
+++ b/web/src/components/marketing/auth-cta-link.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import { LogIn, UserPlus, type LucideIcon } from "lucide-react";
+
+/**
+ * Single source of truth for the logged-out auth call-to-action. A returning
+ * visitor (has the `ac_returning` hint cookie) is sent to sign-in; a likely-new
+ * visitor is sent to sign-up. Pure and client-safe (no `next/headers`), so both
+ * the client homepage header and the server MarketingHeader can use it.
+ */
+export function authCta(returning: boolean): {
+  href: string;
+  label: string;
+  Icon: LucideIcon;
+} {
+  return returning
+    ? { href: "/auth/login?mode=signin", label: "Sign in", Icon: LogIn }
+    : { href: "/auth/login?mode=signup", label: "Sign up", Icon: UserPlus };
+}
+
+/** Compact nav auth CTA shared by the homepage header and MarketingHeader. */
+export function AuthCtaLink({ returning }: { returning: boolean }) {
+  const { href, label, Icon } = authCta(returning);
+  return (
+    <Link
+      href={href}
+      aria-label={label}
+      className="inline-flex items-center gap-1.5 rounded-md border border-white/15 bg-white/[0.04] px-2 sm:px-3 py-1.5 text-white/75 hover:text-white hover:border-white/25 transition-colors"
+    >
+      <Icon className="size-3.5" />
+      <span className="hidden sm:inline">{label}</span>
+    </Link>
+  );
+}

--- a/web/src/components/marketing/marketing-header.tsx
+++ b/web/src/components/marketing/marketing-header.tsx
@@ -1,7 +1,9 @@
 import Link from "next/link";
-import { ArrowRight, LogIn, Star } from "lucide-react";
+import { ArrowRight, Star } from "lucide-react";
 import { withAuth } from "@workos-inc/authkit-nextjs";
+import { isReturningVisitor } from "@/lib/auth/returning";
 import { hasPublishedBenchmarks } from "@/lib/benchmarks";
+import { AuthCtaLink } from "./auth-cta-link";
 import { ClashMark } from "./clash-mark";
 
 type NavLink = { href: string; label: string; external?: boolean };
@@ -20,6 +22,7 @@ type Props = {
 
 export async function MarketingHeader({ nav = DEFAULT_NAV }: Props) {
   const { user } = await withAuth();
+  const returning = await isReturningVisitor();
   // Hide Benchmarks until a real report ships (coming-soon state) so we never
   // funnel visitors to a placeholder; it reappears automatically once live.
   const visibleNav = hasPublishedBenchmarks()
@@ -80,14 +83,7 @@ export async function MarketingHeader({ nav = DEFAULT_NAV }: Props) {
               <ArrowRight className="size-3" />
             </Link>
           ) : (
-            <Link
-              href="/auth/login"
-              aria-label="Sign in"
-              className="inline-flex items-center gap-1.5 rounded-md border border-white/15 bg-white/[0.04] px-2 sm:px-3 py-1.5 text-white/75 hover:text-white hover:border-white/25 transition-colors"
-            >
-              <LogIn className="size-3.5" />
-              <span className="hidden sm:inline">Sign in</span>
-            </Link>
+            <AuthCtaLink returning={returning} />
           )}
         </nav>
       </div>

--- a/web/src/lib/auth/returning.ts
+++ b/web/src/lib/auth/returning.ts
@@ -1,0 +1,16 @@
+import { cookies } from "next/headers";
+
+/**
+ * First-party hint cookie marking a browser that has completed at least one
+ * successful login. It is NOT auth — WorkOS still fully enforces sessions — it
+ * only lets logged-out marketing surfaces choose between a "Sign in" affordance
+ * (returning visitor) and a "Sign up" affordance (likely new visitor).
+ *
+ * Set on the auth callback's onSuccess (see app/auth/callback/route.ts).
+ */
+export const RETURNING_COOKIE = "ac_returning";
+
+/** Read the returning-visitor hint. Server-only (reads the cookie store). */
+export async function isReturningVisitor(): Promise<boolean> {
+  return (await cookies()).get(RETURNING_COOKIE)?.value === "1";
+}


### PR DESCRIPTION
## What

Logged-out visitors now see the right auth affordance instead of always "Sign in":

- **New visitor** (no prior login on this browser) → **Sign up** / "Create your account"
- **Returning visitor** (has signed in before) → **Sign in** / "Welcome back"
- **Logged-in** → unchanged (redirected to `/dashboard`)

## How

A first-party `ac_returning` hint cookie is set on the WorkOS auth callback's `onSuccess` and read server-side by `isReturningVisitor()`. It is a non-sensitive UX hint — **not** auth; WorkOS still fully enforces sessions. An explicit `?mode=signin|signup` always overrides the cookie, with sign-up the default for an unknown browser.

- **`/auth/login` is dual-mode** — `getSignInUrl` vs `getSignUpUrl`, adaptive heading/subcopy, a sign-in/up toggle that preserves `returnTo`, and it now surfaces `?error=callback_failed`.
- **One source for the CTA** — the homepage header/hero and the shared `MarketingHeader` render a single `AuthCtaLink` / `authCta()` helper, so the label/route/icon can't drift between surfaces.
- The hint cookie's `secure` flag derives from the redirect-URI protocol (consistent with the WorkOS session cookie).

## Files

- **New:** `web/src/lib/auth/returning.ts`, `web/src/components/marketing/auth-cta-link.tsx`
- **Auth:** `web/src/app/auth/callback/route.ts`, `web/src/app/auth/login/{page,actions,sign-in-button}.tsx` (+ `sign-in-button.test.tsx`)
- **Surfaces:** `web/src/app/page.tsx`, `web/src/app/landing.tsx`, `web/src/components/marketing/marketing-header.tsx`

## Verification

- `npx tsc --noEmit` clean · `pnpm lint` 0 errors · `pnpm test` (vitest) 440 passed (incl. a new sign-up-mode test) · `pnpm build` passes.
- Booted the production build and verified via curl: new → **Sign up**, returning (`ac_returning`) → **Sign in** across the login page, homepage hero, and `MarketingHeader`; `?mode=` override; `returnTo` preserved through the toggle; `?error=callback_failed` message; and the benchmarks coming-soon gate stays consistent across header / footer / sitemap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
