### PR TITLE
feat(agent-tryouts): redaction, artifact retention, and share safety

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -129,7 +129,7 @@ func main() {
 	})
 	challengePackReadManager := api.NewChallengePackReadManager(repo)
 	challengePackAuthoringManager := api.NewChallengePackAuthoringManager(repo, artifactStore)
-	publicShareManager := api.NewPublicShareManager(authorizer, repo, cfg.FrontendURL)
+	publicShareManager := api.NewPublicShareManager(authorizer, repo, cfg.FrontendURL).WithArtifactSigner(artifactManager)
 	agentTryoutManager := api.NewAgentTryoutManager(authorizer, repo).WithQuota(api.AgentTryoutQuotaConfig{
 		AnonymousLimit:            cfg.AgentTryoutAnonymousLimit,
 		AnonymousWindow:           cfg.AgentTryoutAnonymousWindow,

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -172,11 +172,12 @@ func main() {
 		MultiTurnInvoker:   multiTurnInvoker,
 	})
 	orphanRunReaper := workerapp.NewRepositoryOrphanRunReaper(repo, cfg.OrphanRunReaperInterval, cfg.OrphanRunReaperThreshold, logger)
+	agentTryoutRetentionReaper := workerapp.NewRepositoryAgentTryoutRetentionReaper(repo, cfg.AgentTryoutRetentionReaperInterval, logger)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	if err := workerapp.RunWithReaper(ctx, cfg, temporalWorker, orphanRunReaper, logger); err != nil {
+	if err := workerapp.RunWithReaper(ctx, cfg, temporalWorker, logger, orphanRunReaper, agentTryoutRetentionReaper); err != nil {
 		logger.Error("worker stopped with error", "error", err)
 		os.Exit(1)
 	}

--- a/backend/internal/api/agent_tryout_events.go
+++ b/backend/internal/api/agent_tryout_events.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -327,6 +328,39 @@ func (m *AgentTryoutManager) GetPublicTryoutEvents(ctx context.Context, id uuid.
 	return m.buildTryoutEvents(ctx, tryout, cursor, true)
 }
 
+// GetSharedTryoutEvents returns the redacted timeline for a tryout exposed
+// behind a public share token. The token is resolved to an active share link,
+// which must reference an agent tryout whose redaction has cleared
+// (ShareReady); payloads are always redacted because the endpoint is
+// unauthenticated. A token that is missing, revoked, expired, points at a
+// non-tryout resource, or references a not-yet-redacted tryout is reported as a
+// missing share so callers cannot probe redaction state.
+func (m *AgentTryoutManager) GetSharedTryoutEvents(ctx context.Context, token string, cursor TryoutEventsCursor) (AgentTryoutEventsResult, error) {
+	key := strings.TrimSpace(token)
+	if key == "" {
+		return AgentTryoutEventsResult{}, repository.ErrPublicShareLinkNotFound
+	}
+	share, err := m.repo.GetActivePublicShareLinkByKey(ctx, key)
+	if err != nil {
+		return AgentTryoutEventsResult{}, err
+	}
+	if share.ResourceType != repository.PublicShareResourceAgentTryout {
+		return AgentTryoutEventsResult{}, repository.ErrPublicShareLinkNotFound
+	}
+	tryout, err := m.repo.GetAgentTryoutByID(ctx, share.ResourceID)
+	if err != nil {
+		if errors.Is(err, repository.ErrAgentTryoutNotFound) {
+			return AgentTryoutEventsResult{}, repository.ErrPublicShareLinkNotFound
+		}
+		return AgentTryoutEventsResult{}, err
+	}
+	if !tryout.RedactionStatus.ShareReady() {
+		return AgentTryoutEventsResult{}, repository.ErrPublicShareLinkNotFound
+	}
+	tryout = m.refreshTryoutFromExecution(ctx, tryout)
+	return m.buildTryoutEvents(ctx, tryout, cursor, true)
+}
+
 // GetWorkspaceTryoutEvents returns the timeline for a workspace-owned tryout
 // after authorizing the caller. Workspace members receive full event payloads.
 func (m *AgentTryoutManager) GetWorkspaceTryoutEvents(ctx context.Context, caller Caller, id uuid.UUID, cursor TryoutEventsCursor) (AgentTryoutEventsResult, error) {
@@ -448,6 +482,26 @@ func getPublicAgentTryoutEventsHandler(logger *slog.Logger, service AgentTryoutS
 		}
 		result, err := service.GetPublicTryoutEvents(r.Context(), id, parseTryoutEventsCursor(r))
 		if err != nil {
+			writeAgentTryoutError(w, logger, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, mapAgentTryoutEventsResponse(result))
+	}
+}
+
+func getSharedAgentTryoutEventsHandler(logger *slog.Logger, service AgentTryoutService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		token := strings.TrimSpace(chi.URLParam(r, "token"))
+		if token == "" {
+			writeError(w, http.StatusNotFound, "not_found", "shared resource not found")
+			return
+		}
+		result, err := service.GetSharedTryoutEvents(r.Context(), token, parseTryoutEventsCursor(r))
+		if err != nil {
+			if errors.Is(err, repository.ErrPublicShareLinkNotFound) {
+				writeError(w, http.StatusNotFound, "not_found", "shared resource not found")
+				return
+			}
 			writeAgentTryoutError(w, logger, err)
 			return
 		}

--- a/backend/internal/api/agent_tryout_events_test.go
+++ b/backend/internal/api/agent_tryout_events_test.go
@@ -162,6 +162,71 @@ func TestGetPublicTryoutEventsRejectsWorkspaceTryout(t *testing.T) {
 	}
 }
 
+func TestGetSharedTryoutEventsRedactsAndGatesOnRedaction(t *testing.T) {
+	ctx := context.Background()
+	workspaceID := uuid.New()
+	repo := newFakeAgentTryoutRepository(uuid.New(), workspaceID)
+	runID := uuid.New()
+	tryoutID := uuid.New()
+	repo.tryouts[tryoutID] = repository.AgentTryout{
+		ID:              tryoutID,
+		WorkspaceID:     &workspaceID,
+		Status:          repository.AgentTryoutStatusCompleted,
+		RedactionStatus: repository.AgentTryoutRedactionPassed,
+		RunID:           &runID,
+	}
+	repo.share = repository.PublicShareLink{
+		Key:          "tryout-token",
+		ResourceType: repository.PublicShareResourceAgentTryout,
+		ResourceID:   tryoutID,
+		IsActive:     true,
+	}
+	repo.runEvents = []repository.RunEvent{
+		tryoutRunEvent(1, runID, 1, runevents.EventTypeToolCallCompleted, `{"tool_name":"writer","stdout":"secret"}`),
+	}
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	result, err := manager.GetSharedTryoutEvents(ctx, "tryout-token", TryoutEventsCursor{})
+	if err != nil {
+		t.Fatalf("GetSharedTryoutEvents returned error: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("events = %d, want 1", len(result.Events))
+	}
+	if strings.Contains(string(result.Events[0].Payload), "secret") {
+		t.Fatalf("shared timeline leaked secret: %s", result.Events[0].Payload)
+	}
+
+	// Unknown token → reported as missing share.
+	if _, err := manager.GetSharedTryoutEvents(ctx, "nope", TryoutEventsCursor{}); !errors.Is(err, repository.ErrPublicShareLinkNotFound) {
+		t.Fatalf("unknown token error = %v, want ErrPublicShareLinkNotFound", err)
+	}
+
+	// Redaction regressed → fail closed as missing share rather than leaking.
+	pending := repo.tryouts[tryoutID]
+	pending.RedactionStatus = repository.AgentTryoutRedactionPending
+	repo.tryouts[tryoutID] = pending
+	if _, err := manager.GetSharedTryoutEvents(ctx, "tryout-token", TryoutEventsCursor{}); !errors.Is(err, repository.ErrPublicShareLinkNotFound) {
+		t.Fatalf("pending-redaction error = %v, want ErrPublicShareLinkNotFound", err)
+	}
+}
+
+func TestGetSharedTryoutEventsRejectsNonTryoutShare(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeAgentTryoutRepository(uuid.New(), uuid.New())
+	repo.share = repository.PublicShareLink{
+		Key:          "scorecard-token",
+		ResourceType: repository.PublicShareResourceRunScorecard,
+		ResourceID:   uuid.New(),
+		IsActive:     true,
+	}
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	if _, err := manager.GetSharedTryoutEvents(ctx, "scorecard-token", TryoutEventsCursor{}); !errors.Is(err, repository.ErrPublicShareLinkNotFound) {
+		t.Fatalf("non-tryout share error = %v, want ErrPublicShareLinkNotFound", err)
+	}
+}
+
 func TestGetWorkspaceTryoutEventsAuthorization(t *testing.T) {
 	ctx := context.Background()
 	orgID := uuid.New()

--- a/backend/internal/api/agent_tryout_share_safety.go
+++ b/backend/internal/api/agent_tryout_share_safety.go
@@ -1,0 +1,229 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+// ArtifactContentSigner mints signed, time-limited public content URLs for
+// artifacts so they can be embedded in shared (unauthenticated) tryout
+// payloads. Implemented by *ArtifactManager. It performs NO authorization;
+// callers must independently confirm the artifact is safe to expose (here:
+// template-allowlisted on a redaction-passed share).
+type ArtifactContentSigner interface {
+	SignedArtifactContentURL(artifactID uuid.UUID, baseURL string, now time.Time) (url string, expiresAt time.Time, err error)
+}
+
+// sharedAgentTryoutResponse is the public, redaction-safe view of a tryout
+// rendered behind a share token. It embeds the public tryout fields (which
+// already omit org/workspace/user identifiers) and adds the template-approved,
+// redacted, signed artifact descriptors.
+type sharedAgentTryoutResponse struct {
+	publicAgentTryoutResponse
+	Artifacts []sharedAgentTryoutArtifact `json:"artifacts"`
+}
+
+// sharedAgentTryoutArtifact is a redacted artifact descriptor safe for public
+// shares. Its key/type/path come from the template allowlist (trusted,
+// template-defined) rather than raw artifact metadata; storage bucket/key,
+// org/workspace/run identifiers, and arbitrary metadata are never included.
+type sharedAgentTryoutArtifact struct {
+	Key               string     `json:"key"`
+	Type              string     `json:"type"`
+	Path              string     `json:"path"`
+	ContentType       *string    `json:"content_type,omitempty"`
+	SizeBytes         *int64     `json:"size_bytes,omitempty"`
+	ChecksumSHA256    *string    `json:"checksum_sha256,omitempty"`
+	DownloadURL       string     `json:"download_url,omitempty"`
+	DownloadExpiresAt *time.Time `json:"download_expires_at,omitempty"`
+}
+
+// sensitiveSummaryKeySubstrings lists object-key substrings whose values must
+// never appear in a public tryout summary. Matching is by key name (not value)
+// so it stays resilient to the execution-defined, evolving summary schema.
+var sensitiveSummaryKeySubstrings = []string{
+	"secret", "token", "credential", "password", "api_key", "apikey",
+	"authorization", "bearer", "private_key", "access_key", "session",
+	"cookie", "organization_id", "org_id", "workspace_id", "user_id",
+	"created_by", "claimed_by", "fingerprint",
+}
+
+func sensitiveSummaryKey(name string) bool {
+	lower := strings.ToLower(name)
+	for _, substr := range sensitiveSummaryKeySubstrings {
+		if strings.Contains(lower, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// redactTryoutSummaryForPublic recursively strips object keys whose names look
+// sensitive from a tryout summary before public exposure. The summary has
+// already cleared the execution-side redaction pipeline (share rendering is
+// gated on AgentTryoutRedactionStatus.ShareReady), so this is defense-in-depth
+// against identifier/secret leakage rather than the primary control. Invalid
+// JSON is dropped entirely rather than passed through.
+func redactTryoutSummaryForPublic(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return raw
+	}
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return nil
+	}
+	cleaned, err := json.Marshal(scrubSensitiveSummary(decoded))
+	if err != nil {
+		return nil
+	}
+	return cleaned
+}
+
+func scrubSensitiveSummary(value any) any {
+	switch v := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for key, item := range v {
+			if sensitiveSummaryKey(key) {
+				continue
+			}
+			out[key] = scrubSensitiveSummary(item)
+		}
+		return out
+	case []any:
+		out := make([]any, len(v))
+		for i, item := range v {
+			out[i] = scrubSensitiveSummary(item)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+// templateAllowedArtifact is one entry of a template's expected/approved
+// artifact outputs, used as the allowlist for shared/downloadable artifacts.
+type templateAllowedArtifact struct {
+	Key  string
+	Type string
+	Path string
+}
+
+// parseTemplateArtifactAllowlist extracts the per-template artifact allowlist
+// from a stored template snapshot (runtime.expected_artifacts). An empty result
+// means nothing is approved for public download (default-deny).
+func parseTemplateArtifactAllowlist(templateSnapshot json.RawMessage) []templateAllowedArtifact {
+	if len(templateSnapshot) == 0 {
+		return nil
+	}
+	var snapshot struct {
+		Runtime struct {
+			ExpectedArtifacts []struct {
+				Key  string `json:"key"`
+				Type string `json:"type"`
+				Path string `json:"path"`
+			} `json:"expected_artifacts"`
+		} `json:"runtime"`
+	}
+	if err := json.Unmarshal(templateSnapshot, &snapshot); err != nil {
+		return nil
+	}
+	allow := make([]templateAllowedArtifact, 0, len(snapshot.Runtime.ExpectedArtifacts))
+	for _, entry := range snapshot.Runtime.ExpectedArtifacts {
+		key := strings.TrimSpace(entry.Key)
+		path := strings.TrimSpace(entry.Path)
+		if key == "" && path == "" {
+			continue
+		}
+		allow = append(allow, templateAllowedArtifact{Key: key, Type: strings.TrimSpace(entry.Type), Path: path})
+	}
+	if len(allow) == 0 {
+		return nil
+	}
+	return allow
+}
+
+// artifactClaimedIdentity extracts the logical key/path an artifact claims via
+// its metadata, used to match it against the template allowlist. Returns empty
+// strings when the artifact carries no recognized identity, which (combined
+// with allowlist matching) yields default-deny.
+func artifactClaimedIdentity(metadata json.RawMessage) (key string, path string) {
+	if len(metadata) == 0 {
+		return "", ""
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(metadata, &meta); err != nil {
+		return "", ""
+	}
+	key = metadataString(meta, "artifact_key")
+	path = metadataString(meta, "relative_path")
+	if path == "" {
+		path = metadataString(meta, "path")
+	}
+	return key, path
+}
+
+func metadataString(meta map[string]any, key string) string {
+	if value, ok := meta[key].(string); ok {
+		return strings.TrimSpace(value)
+	}
+	return ""
+}
+
+// buildSharedTryoutArtifacts filters a run's artifacts down to the
+// template-approved allowlist, emits redacted descriptors (canonical key/type/
+// path from the template, non-sensitive size/checksum/content-type from the
+// artifact row), and attaches signed download URLs when a signer is available.
+// Unmatched artifacts are dropped (default-deny) so non-approved outputs are
+// never exposed on a public share.
+func buildSharedTryoutArtifacts(artifacts []repository.Artifact, allow []templateAllowedArtifact, signer ArtifactContentSigner, baseURL string, now time.Time) []sharedAgentTryoutArtifact {
+	if len(allow) == 0 || len(artifacts) == 0 {
+		return nil
+	}
+	byKey := make(map[string]templateAllowedArtifact, len(allow))
+	byPath := make(map[string]templateAllowedArtifact, len(allow))
+	for _, entry := range allow {
+		if entry.Key != "" {
+			byKey[entry.Key] = entry
+		}
+		if entry.Path != "" {
+			byPath[entry.Path] = entry
+		}
+	}
+
+	var out []sharedAgentTryoutArtifact
+	for _, artifact := range artifacts {
+		key, path := artifactClaimedIdentity(artifact.Metadata)
+		matched, ok := templateAllowedArtifact{}, false
+		if key != "" {
+			matched, ok = byKey[key]
+		}
+		if !ok && path != "" {
+			matched, ok = byPath[path]
+		}
+		if !ok {
+			continue
+		}
+		descriptor := sharedAgentTryoutArtifact{
+			Key:            matched.Key,
+			Type:           matched.Type,
+			Path:           matched.Path,
+			ContentType:    artifact.ContentType,
+			SizeBytes:      artifact.SizeBytes,
+			ChecksumSHA256: artifact.ChecksumSHA256,
+		}
+		if signer != nil && baseURL != "" {
+			if signedURL, expiresAt, err := signer.SignedArtifactContentURL(artifact.ID, baseURL, now); err == nil {
+				expires := expiresAt
+				descriptor.DownloadURL = signedURL
+				descriptor.DownloadExpiresAt = &expires
+			}
+		}
+		out = append(out, descriptor)
+	}
+	return out
+}

--- a/backend/internal/api/agent_tryout_share_safety.go
+++ b/backend/internal/api/agent_tryout_share_safety.go
@@ -45,9 +45,13 @@ type sharedAgentTryoutArtifact struct {
 // sensitiveSummaryKeySubstrings lists object-key substrings whose values must
 // never appear in a public tryout summary. Matching is by key name (not value)
 // so it stays resilient to the execution-defined, evolving summary schema.
+// Entries are targeted (e.g. "access_token", "session_id") rather than bare
+// "token"/"session" so legitimate public metrics like "total_tokens",
+// "output_tokens", or "session_count" survive redaction.
 var sensitiveSummaryKeySubstrings = []string{
-	"secret", "token", "credential", "password", "api_key", "apikey",
-	"authorization", "bearer", "private_key", "access_key", "session",
+	"secret", "credential", "password", "api_key", "apikey",
+	"access_token", "auth_token", "session_token", "id_token", "refresh_token",
+	"authorization", "bearer", "private_key", "access_key", "session_id",
 	"cookie", "organization_id", "org_id", "workspace_id", "user_id",
 	"created_by", "claimed_by", "fingerprint",
 }

--- a/backend/internal/api/agent_tryout_share_safety_test.go
+++ b/backend/internal/api/agent_tryout_share_safety_test.go
@@ -35,6 +35,29 @@ func TestRedactTryoutSummaryForPublicStripsSensitiveKeys(t *testing.T) {
 	}
 }
 
+func TestRedactTryoutSummaryForPublicKeepsTokenUsageMetrics(t *testing.T) {
+	// Token-usage metrics are legitimate public data and must survive the
+	// key-name redactor — only credential-shaped *_token / *_id keys are dropped.
+	raw := json.RawMessage(`{
+		"total_tokens": 1234,
+		"input_tokens": 1000,
+		"output_tokens": 234,
+		"token_count": 1234,
+		"session_count": 2,
+		"access_token": "should-drop"
+	}`)
+	got := string(redactTryoutSummaryForPublic(raw))
+
+	for _, kept := range []string{"total_tokens", "input_tokens", "output_tokens", "token_count", "session_count"} {
+		if !strings.Contains(got, kept) {
+			t.Fatalf("redaction dropped legitimate metric %q: %s", kept, got)
+		}
+	}
+	if strings.Contains(got, "access_token") || strings.Contains(got, "should-drop") {
+		t.Fatalf("redaction kept a credential-shaped key: %s", got)
+	}
+}
+
 func TestRedactTryoutSummaryForPublicDropsInvalidJSON(t *testing.T) {
 	if out := redactTryoutSummaryForPublic(json.RawMessage(`{not json`)); out != nil {
 		t.Fatalf("invalid summary JSON should be dropped, got %s", out)

--- a/backend/internal/api/agent_tryout_share_safety_test.go
+++ b/backend/internal/api/agent_tryout_share_safety_test.go
@@ -1,0 +1,151 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+func TestRedactTryoutSummaryForPublicStripsSensitiveKeys(t *testing.T) {
+	raw := json.RawMessage(`{
+		"verdict": "ready_to_inspect",
+		"score": 0.92,
+		"workspace_id": "ws-secret",
+		"created_by_user_id": "user-secret",
+		"nested": {"api_key": "sk-live-xxx", "tool_calls": 4, "fingerprint_hash": "deadbeef"},
+		"steps": [{"summary": "planned", "session_token": "tok"}]
+	}`)
+
+	cleaned := redactTryoutSummaryForPublic(raw)
+	got := string(cleaned)
+
+	for _, banned := range []string{"workspace_id", "created_by_user_id", "api_key", "fingerprint_hash", "session_token", "sk-live-xxx", "ws-secret", "user-secret"} {
+		if strings.Contains(got, banned) {
+			t.Fatalf("redacted summary leaked %q: %s", banned, got)
+		}
+	}
+	for _, kept := range []string{"verdict", "ready_to_inspect", "score", "tool_calls", "steps", "planned"} {
+		if !strings.Contains(got, kept) {
+			t.Fatalf("redacted summary dropped safe field %q: %s", kept, got)
+		}
+	}
+}
+
+func TestRedactTryoutSummaryForPublicDropsInvalidJSON(t *testing.T) {
+	if out := redactTryoutSummaryForPublic(json.RawMessage(`{not json`)); out != nil {
+		t.Fatalf("invalid summary JSON should be dropped, got %s", out)
+	}
+	if out := redactTryoutSummaryForPublic(nil); out != nil {
+		t.Fatalf("nil summary should stay nil, got %s", out)
+	}
+}
+
+func TestParseTemplateArtifactAllowlist(t *testing.T) {
+	snapshot := json.RawMessage(`{
+		"slug": "meeting-minutes",
+		"runtime": {
+			"expected_artifacts": [
+				{"key": "action_plan", "type": "markdown", "path": "action-plan.md"},
+				{"key": "structured_minutes", "type": "json", "path": "minutes.json"},
+				{"type": "json"}
+			]
+		}
+	}`)
+
+	allow := parseTemplateArtifactAllowlist(snapshot)
+	if len(allow) != 2 {
+		t.Fatalf("expected 2 allowlist entries (one dropped for empty key+path), got %d: %+v", len(allow), allow)
+	}
+	if allow[0].Key != "action_plan" || allow[0].Path != "action-plan.md" || allow[0].Type != "markdown" {
+		t.Fatalf("unexpected first allowlist entry: %+v", allow[0])
+	}
+
+	if got := parseTemplateArtifactAllowlist(json.RawMessage(`{"runtime":{}}`)); got != nil {
+		t.Fatalf("empty runtime should yield nil allowlist, got %+v", got)
+	}
+}
+
+type fakeArtifactContentSigner struct {
+	expiresAt time.Time
+}
+
+func (s fakeArtifactContentSigner) SignedArtifactContentURL(artifactID uuid.UUID, baseURL string, _ time.Time) (string, time.Time, error) {
+	return baseURL + "/artifacts/" + artifactID.String() + "/content?signature=test", s.expiresAt, nil
+}
+
+func TestBuildSharedTryoutArtifactsDefaultDeny(t *testing.T) {
+	allow := []templateAllowedArtifact{
+		{Key: "action_plan", Type: "markdown", Path: "action-plan.md"},
+	}
+	approvedID := uuid.New()
+	contentType := "text/markdown"
+	size := int64(2048)
+	checksum := "abc123"
+	signer := fakeArtifactContentSigner{expiresAt: time.Unix(1_700_000_000, 0).UTC()}
+
+	artifacts := []repository.Artifact{
+		{
+			ID:             approvedID,
+			StorageBucket:  "secret-bucket",
+			StorageKey:     "workspaces/ws/secret/key",
+			ContentType:    &contentType,
+			SizeBytes:      &size,
+			ChecksumSHA256: &checksum,
+			Metadata:       json.RawMessage(`{"artifact_key":"action_plan","original_filename":"action-plan.md"}`),
+		},
+		{
+			// Not in the allowlist → must be dropped (default-deny).
+			ID:       uuid.New(),
+			Metadata: json.RawMessage(`{"artifact_key":"internal_debug_dump"}`),
+		},
+		{
+			// No recognized identity → must be dropped.
+			ID:       uuid.New(),
+			Metadata: json.RawMessage(`{"foo":"bar"}`),
+		},
+	}
+
+	out := buildSharedTryoutArtifacts(artifacts, allow, signer, "https://api.test", time.Now())
+	if len(out) != 1 {
+		t.Fatalf("expected exactly 1 approved artifact, got %d: %+v", len(out), out)
+	}
+	got := out[0]
+	if got.Key != "action_plan" || got.Type != "markdown" || got.Path != "action-plan.md" {
+		t.Fatalf("descriptor uses template-canonical identity; got %+v", got)
+	}
+	if got.SizeBytes == nil || *got.SizeBytes != size || got.ChecksumSHA256 == nil || *got.ChecksumSHA256 != checksum {
+		t.Fatalf("descriptor should carry non-sensitive artifact facts; got %+v", got)
+	}
+	if !strings.Contains(got.DownloadURL, approvedID.String()) {
+		t.Fatalf("descriptor should carry a signed download URL; got %q", got.DownloadURL)
+	}
+
+	encoded, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal artifacts: %v", err)
+	}
+	for _, leaked := range []string{"secret-bucket", "workspaces/ws/secret/key", "storage_key", "storage_bucket", "internal_debug_dump", "original_filename"} {
+		if strings.Contains(string(encoded), leaked) {
+			t.Fatalf("shared artifact descriptor leaked %q: %s", leaked, encoded)
+		}
+	}
+}
+
+func TestBuildSharedTryoutArtifactsMatchesByPath(t *testing.T) {
+	allow := []templateAllowedArtifact{{Key: "diff", Type: "patch", Path: "changes.patch"}}
+	artifacts := []repository.Artifact{{
+		ID:       uuid.New(),
+		Metadata: json.RawMessage(`{"relative_path":"changes.patch"}`),
+	}}
+	out := buildSharedTryoutArtifacts(artifacts, allow, nil, "", time.Now())
+	if len(out) != 1 || out[0].Key != "diff" {
+		t.Fatalf("expected path-matched approved artifact, got %+v", out)
+	}
+	if out[0].DownloadURL != "" {
+		t.Fatalf("no signer/baseURL should yield no download URL, got %q", out[0].DownloadURL)
+	}
+}

--- a/backend/internal/api/agent_tryouts.go
+++ b/backend/internal/api/agent_tryouts.go
@@ -36,6 +36,7 @@ var (
 	ErrAgentTryoutHostedSpendUnavailable    = errors.New("agent tryout hosted spend unavailable")
 	ErrAgentTryoutHostedSpendExhausted      = errors.New("agent tryout hosted spend exhausted")
 	ErrAgentTryoutCostCapExceeded           = errors.New("agent tryout cost cap exceeded")
+	ErrAgentTryoutRedactionNotReady         = errors.New("agent tryout redaction not ready")
 )
 
 type AgentTryoutRepository interface {
@@ -57,6 +58,7 @@ type AgentTryoutRepository interface {
 	UpdateAgentTryoutStatus(ctx context.Context, params repository.UpdateAgentTryoutStatusParams) (repository.AgentTryout, error)
 	ClaimAgentTryout(ctx context.Context, params repository.ClaimAgentTryoutParams) (repository.AgentTryout, error)
 	CreatePublicShareLink(ctx context.Context, params repository.CreatePublicShareLinkParams) (repository.PublicShareLink, error)
+	GetActivePublicShareLinkByKey(ctx context.Context, key string) (repository.PublicShareLink, error)
 }
 
 type AgentTryoutService interface {
@@ -66,6 +68,7 @@ type AgentTryoutService interface {
 	GetPublicTryout(ctx context.Context, id uuid.UUID) (repository.AgentTryout, error)
 	GetWorkspaceTryout(ctx context.Context, caller Caller, id uuid.UUID) (repository.AgentTryout, error)
 	GetPublicTryoutEvents(ctx context.Context, id uuid.UUID, cursor TryoutEventsCursor) (AgentTryoutEventsResult, error)
+	GetSharedTryoutEvents(ctx context.Context, token string, cursor TryoutEventsCursor) (AgentTryoutEventsResult, error)
 	GetWorkspaceTryoutEvents(ctx context.Context, caller Caller, id uuid.UUID, cursor TryoutEventsCursor) (AgentTryoutEventsResult, error)
 	ListWorkspaceTryouts(ctx context.Context, caller Caller, workspaceID uuid.UUID, limit, offset int32) ([]repository.AgentTryout, error)
 	ClaimTryout(ctx context.Context, caller Caller, input ClaimAgentTryoutInput) (repository.AgentTryout, error)
@@ -796,6 +799,9 @@ func (m *AgentTryoutManager) CreatePrivateShare(ctx context.Context, caller Call
 	if tryout.OrganizationID == nil || tryout.WorkspaceID == nil {
 		return CreateAgentTryoutShareResult{}, repository.ErrAgentTryoutNotFound
 	}
+	if !tryout.RedactionStatus.ShareReady() {
+		return CreateAgentTryoutShareResult{}, ErrAgentTryoutRedactionNotReady
+	}
 	key, err := newShareKey()
 	if err != nil {
 		return CreateAgentTryoutShareResult{}, err
@@ -897,6 +903,7 @@ func registerPublicAgentTryoutRoutes(router chi.Router, logger *slog.Logger, ser
 	router.Post("/agent-tryouts", createAnonymousAgentTryoutHandler(logger, service))
 	router.Get("/agent-tryouts/{tryoutID}", getPublicAgentTryoutHandler(logger, service))
 	router.Get("/agent-tryouts/{tryoutID}/events", getPublicAgentTryoutEventsHandler(logger, service))
+	router.Get("/agent-tryouts/shared/{token}/events", getSharedAgentTryoutEventsHandler(logger, service))
 }
 
 func registerProtectedAgentTryoutRoutes(router chi.Router, logger *slog.Logger, service AgentTryoutService) {
@@ -1251,6 +1258,8 @@ func writeAgentTryoutError(w http.ResponseWriter, logger *slog.Logger, err error
 		writeError(w, http.StatusNotFound, "agent_tryout_not_found", "agent tryout not found")
 	case errors.Is(err, repository.ErrAgentTryoutAlreadyClaimed):
 		writeError(w, http.StatusConflict, "agent_tryout_already_claimed", "agent tryout is already claimed")
+	case errors.Is(err, ErrAgentTryoutRedactionNotReady):
+		writeError(w, http.StatusConflict, "agent_tryout_redaction_not_ready", "This tryout's evidence is still being redacted for safe sharing. Try again once it has finished.")
 	case errors.Is(err, ErrInvalidAgentTryoutInput):
 		writeError(w, http.StatusBadRequest, "invalid_agent_tryout_input", err.Error())
 	case errors.Is(err, ErrForbidden):

--- a/backend/internal/api/agent_tryouts_test.go
+++ b/backend/internal/api/agent_tryouts_test.go
@@ -396,6 +396,17 @@ func TestAgentTryoutManagerCreateWorkspaceClaimAndShare(t *testing.T) {
 		t.Fatalf("claimed_by_user_id = %v, want %s", claimed.ClaimedByUserID, caller.UserID)
 	}
 
+	// A freshly created tryout is redaction_status=pending and must not be
+	// shareable until its evidence has cleared redaction.
+	if _, err := manager.CreatePrivateShare(ctx, caller, tryout.ID); !errors.Is(err, ErrAgentTryoutRedactionNotReady) {
+		t.Fatalf("CreatePrivateShare while pending error = %v, want ErrAgentTryoutRedactionNotReady", err)
+	}
+
+	// Once redaction passes the share can be created.
+	shareable := repo.tryouts[tryout.ID]
+	shareable.RedactionStatus = repository.AgentTryoutRedactionPassed
+	repo.tryouts[tryout.ID] = shareable
+
 	result, err := manager.CreatePrivateShare(ctx, caller, tryout.ID)
 	if err != nil {
 		t.Fatalf("CreatePrivateShare returned error: %v", err)
@@ -1218,6 +1229,13 @@ func (r *fakeAgentTryoutRepository) CreatePublicShareLink(_ context.Context, par
 	return r.share, nil
 }
 
+func (r *fakeAgentTryoutRepository) GetActivePublicShareLinkByKey(_ context.Context, key string) (repository.PublicShareLink, error) {
+	if r.share.Key == key && r.share.IsActive {
+		return r.share, nil
+	}
+	return repository.PublicShareLink{}, repository.ErrPublicShareLinkNotFound
+}
+
 type fakeAgentTryoutService struct {
 	tryout               repository.AgentTryout
 	templates            []AgentTryoutTemplate
@@ -1257,6 +1275,14 @@ func (s *fakeAgentTryoutService) GetWorkspaceTryout(context.Context, Caller, uui
 }
 
 func (s *fakeAgentTryoutService) GetPublicTryoutEvents(_ context.Context, _ uuid.UUID, cursor TryoutEventsCursor) (AgentTryoutEventsResult, error) {
+	s.eventsCursor = cursor
+	if s.eventsErr != nil {
+		return AgentTryoutEventsResult{}, s.eventsErr
+	}
+	return s.eventsResult, nil
+}
+
+func (s *fakeAgentTryoutService) GetSharedTryoutEvents(_ context.Context, _ string, cursor TryoutEventsCursor) (AgentTryoutEventsResult, error) {
 	s.eventsCursor = cursor
 	if s.eventsErr != nil {
 		return AgentTryoutEventsResult{}, s.eventsErr

--- a/backend/internal/api/artifacts.go
+++ b/backend/internal/api/artifacts.go
@@ -430,6 +430,22 @@ func buildSignedArtifactURL(baseURL string, artifactID uuid.UUID, expiresAt time
 	return parsed.String(), nil
 }
 
+// SignedArtifactContentURL produces a signed, time-limited public content URL
+// for an artifact so it can be embedded in shared (unauthenticated) tryout
+// payloads. It performs NO authorization — the caller must have already
+// established that the artifact is safe to expose (e.g. it is template-
+// allowlisted on a redaction-passed share). The HMAC signature scopes the URL
+// to exactly this artifact for the returned expiry.
+func (m *ArtifactManager) SignedArtifactContentURL(artifactID uuid.UUID, baseURL string, now time.Time) (string, time.Time, error) {
+	expiresAt := now.Add(m.signedURLTTL).UTC()
+	signature := m.signArtifactToken(artifactID, expiresAt)
+	signedURL, err := buildSignedArtifactURL(baseURL, artifactID, expiresAt, signature)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	return signedURL, expiresAt, nil
+}
+
 func (m *ArtifactManager) signArtifactToken(artifactID uuid.UUID, expiresAt time.Time) string {
 	mac := hmac.New(sha256.New, m.signingSecret)
 	_, _ = mac.Write([]byte(artifactID.String()))

--- a/backend/internal/api/public_shares.go
+++ b/backend/internal/api/public_shares.go
@@ -33,6 +33,7 @@ type PublicShareRepository interface {
 	GetRunAgentScorecardByRunAgentID(ctx context.Context, runAgentID uuid.UUID) (repository.RunAgentScorecard, error)
 	GetRunAgentReplayByRunAgentID(ctx context.Context, runAgentID uuid.UUID) (repository.RunAgentReplay, error)
 	GetAgentTryoutByID(ctx context.Context, id uuid.UUID) (repository.AgentTryout, error)
+	ListArtifactsByRunID(ctx context.Context, runID uuid.UUID) ([]repository.Artifact, error)
 	GetPublicChallengePackVersionSnapshot(ctx context.Context, versionID uuid.UUID) (repository.PublicChallengePackVersionSnapshot, error)
 	GetPublicRunScorecardSnapshot(ctx context.Context, runID uuid.UUID) (repository.PublicRunScorecardSnapshot, error)
 	GetPublicRunAgentScorecardSnapshot(ctx context.Context, runAgentID uuid.UUID) (repository.PublicRunAgentScorecardSnapshot, error)
@@ -42,7 +43,7 @@ type PublicShareRepository interface {
 type PublicShareService interface {
 	CreateShareLink(ctx context.Context, caller Caller, input CreateShareLinkInput) (CreateShareLinkResult, error)
 	RevokeShareLink(ctx context.Context, caller Caller, shareID uuid.UUID) error
-	GetPublicShare(ctx context.Context, token string) (PublicSharePayload, error)
+	GetPublicShare(ctx context.Context, token string, baseURL string) (PublicSharePayload, error)
 }
 
 type CreateShareLinkInput struct {
@@ -64,9 +65,11 @@ type PublicSharePayload struct {
 }
 
 type PublicShareManager struct {
-	authorizer  WorkspaceAuthorizer
-	repo        PublicShareRepository
-	frontendURL string
+	authorizer     WorkspaceAuthorizer
+	repo           PublicShareRepository
+	frontendURL    string
+	artifactSigner ArtifactContentSigner
+	now            func() time.Time
 }
 
 func NewPublicShareManager(authorizer WorkspaceAuthorizer, repo PublicShareRepository, frontendURL string) *PublicShareManager {
@@ -74,7 +77,16 @@ func NewPublicShareManager(authorizer WorkspaceAuthorizer, repo PublicShareRepos
 		authorizer:  authorizer,
 		repo:        repo,
 		frontendURL: strings.TrimRight(frontendURL, "/"),
+		now:         time.Now,
 	}
+}
+
+// WithArtifactSigner enables signed download URLs for template-allowlisted
+// artifacts on shared tryout pages. When no signer is configured, shared
+// payloads still list approved artifact descriptors but omit download URLs.
+func (m *PublicShareManager) WithArtifactSigner(signer ArtifactContentSigner) *PublicShareManager {
+	m.artifactSigner = signer
+	return m
 }
 
 func (m *PublicShareManager) CreateShareLink(ctx context.Context, caller Caller, input CreateShareLinkInput) (CreateShareLinkResult, error) {
@@ -120,7 +132,7 @@ func (m *PublicShareManager) RevokeShareLink(ctx context.Context, caller Caller,
 	return m.repo.RevokePublicShareLink(ctx, shareID)
 }
 
-func (m *PublicShareManager) GetPublicShare(ctx context.Context, token string) (PublicSharePayload, error) {
+func (m *PublicShareManager) GetPublicShare(ctx context.Context, token string, baseURL string) (PublicSharePayload, error) {
 	key := strings.TrimSpace(token)
 	if key == "" {
 		return PublicSharePayload{}, repository.ErrPublicShareLinkNotFound
@@ -130,7 +142,7 @@ func (m *PublicShareManager) GetPublicShare(ctx context.Context, token string) (
 		return PublicSharePayload{}, err
 	}
 
-	resource, err := m.publicResource(ctx, share)
+	resource, err := m.publicResource(ctx, share, baseURL)
 	if err != nil {
 		return PublicSharePayload{}, err
 	}
@@ -205,13 +217,16 @@ func (m *PublicShareManager) authorizedResourceScope(ctx context.Context, caller
 		if err := m.authorizer.AuthorizeWorkspace(ctx, caller, *tryout.WorkspaceID); err != nil {
 			return uuid.Nil, uuid.Nil, err
 		}
+		if !tryout.RedactionStatus.ShareReady() {
+			return uuid.Nil, uuid.Nil, ErrAgentTryoutRedactionNotReady
+		}
 		return *tryout.OrganizationID, *tryout.WorkspaceID, nil
 	default:
 		return uuid.Nil, uuid.Nil, errInvalidShareResourceType
 	}
 }
 
-func (m *PublicShareManager) publicResource(ctx context.Context, share repository.PublicShareLink) (any, error) {
+func (m *PublicShareManager) publicResource(ctx context.Context, share repository.PublicShareLink, baseURL string) (any, error) {
 	switch share.ResourceType {
 	case repository.PublicShareResourceChallengePackVersion:
 		snapshot, err := m.repo.GetPublicChallengePackVersionSnapshot(ctx, share.ResourceID)
@@ -245,10 +260,44 @@ func (m *PublicShareManager) publicResource(ctx context.Context, share repositor
 		if tryout.WorkspaceID == nil {
 			return nil, repository.ErrAgentTryoutNotFound
 		}
-		return mapPublicAgentTryoutResponse(tryout), nil
+		// Fail closed: a share whose redaction has regressed (or never passed)
+		// must not render unredacted content, even though creation already
+		// gated on this. Treat it as an unavailable share rather than leaking.
+		if !tryout.RedactionStatus.ShareReady() {
+			return nil, repository.ErrPublicShareLinkNotFound
+		}
+		return m.publicAgentTryout(ctx, tryout, baseURL)
 	default:
 		return nil, repository.ErrPublicShareLinkNotFound
 	}
+}
+
+// publicAgentTryout builds the redaction-safe, shareable view of a tryout:
+// the public payload (no org/workspace/user identifiers) with a defensively
+// re-redacted summary, plus the template-allowlisted, redacted artifact
+// descriptors (with signed download URLs when a signer is configured).
+func (m *PublicShareManager) publicAgentTryout(ctx context.Context, tryout repository.AgentTryout, baseURL string) (sharedAgentTryoutResponse, error) {
+	payload := mapPublicAgentTryoutResponse(tryout)
+	payload.Summary = redactTryoutSummaryForPublic(payload.Summary)
+	resp := sharedAgentTryoutResponse{publicAgentTryoutResponse: payload}
+
+	allow := parseTemplateArtifactAllowlist(tryout.TemplateSnapshot)
+	if tryout.RunID == nil || len(allow) == 0 {
+		return resp, nil
+	}
+	artifacts, err := m.repo.ListArtifactsByRunID(ctx, *tryout.RunID)
+	if err != nil {
+		return sharedAgentTryoutResponse{}, err
+	}
+	resp.Artifacts = buildSharedTryoutArtifacts(artifacts, allow, m.artifactSigner, baseURL, m.clock())
+	return resp, nil
+}
+
+func (m *PublicShareManager) clock() time.Time {
+	if m.now != nil {
+		return m.now()
+	}
+	return time.Now()
 }
 
 func (m *PublicShareManager) shareURL(token string) string {
@@ -349,7 +398,7 @@ func revokeShareLinkHandler(logger *slog.Logger, service PublicShareService) htt
 func getPublicShareHandler(logger *slog.Logger, service PublicShareService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := chi.URLParam(r, "token")
-		result, err := service.GetPublicShare(r.Context(), token)
+		result, err := service.GetPublicShare(r.Context(), token, requestBaseURL(r))
 		if err != nil {
 			writeShareError(w, logger, r, err)
 			return
@@ -372,6 +421,10 @@ func writeShareError(w http.ResponseWriter, logger *slog.Logger, r *http.Request
 		writeError(w, http.StatusNotFound, "not_found", "shared resource not found")
 	case errors.Is(err, errInvalidShareResourceType):
 		writeError(w, http.StatusBadRequest, "invalid_share_request", "unsupported resource_type")
+	case errors.Is(err, repository.ErrAgentTryoutNotFound):
+		writeError(w, http.StatusNotFound, "not_found", "shared resource not found")
+	case errors.Is(err, ErrAgentTryoutRedactionNotReady):
+		writeError(w, http.StatusConflict, "agent_tryout_redaction_not_ready", "This tryout's evidence is still being redacted for safe sharing. Try again once it has finished.")
 	default:
 		logger.Error("public share request failed", "method", r.Method, "path", r.URL.Path, "error", err)
 		writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")

--- a/backend/internal/api/public_shares_test.go
+++ b/backend/internal/api/public_shares_test.go
@@ -159,7 +159,7 @@ func TestPublicShareManager_GetPublicShareReturnsNarrowPayload(t *testing.T) {
 	repo.runScorecard = repository.RunScorecard{ID: uuid.New(), RunID: runID, Scorecard: json.RawMessage(`{"summary":"public"}`)}
 	manager := NewPublicShareManager(NewCallerWorkspaceAuthorizer(), repo, "https://agentclash.dev")
 
-	payload, err := manager.GetPublicShare(ctx, "share-key")
+	payload, err := manager.GetPublicShare(ctx, "share-key", "https://api.test")
 	if err != nil {
 		t.Fatalf("GetPublicShare returned error: %v", err)
 	}
@@ -262,7 +262,7 @@ func TestPublicShareManager_GetPublicShareKeepsReplayAgentDistinct(t *testing.T)
 	}
 	manager := NewPublicShareManager(NewCallerWorkspaceAuthorizer(), repo, "https://agentclash.dev")
 
-	payload, err := manager.GetPublicShare(ctx, "second-agent-replay")
+	payload, err := manager.GetPublicShare(ctx, "second-agent-replay", "https://api.test")
 	if err != nil {
 		t.Fatalf("GetPublicShare returned error: %v", err)
 	}
@@ -320,7 +320,7 @@ func TestPublicShareManager_GetPublicShareAgentTryoutReturnsNarrowPayload(t *tes
 	}
 	manager := NewPublicShareManager(NewCallerWorkspaceAuthorizer(), repo, "https://agentclash.dev")
 
-	payload, err := manager.GetPublicShare(ctx, "tryout-share")
+	payload, err := manager.GetPublicShare(ctx, "tryout-share", "https://api.test")
 	if err != nil {
 		t.Fatalf("GetPublicShare returned error: %v", err)
 	}
@@ -405,6 +405,11 @@ type fakePublicShareRepository struct {
 	agentScorecard repository.RunAgentScorecard
 	replay         repository.RunAgentReplay
 	agentTryout    repository.AgentTryout
+	runArtifacts   []repository.Artifact
+}
+
+func (r *fakePublicShareRepository) ListArtifactsByRunID(_ context.Context, _ uuid.UUID) ([]repository.Artifact, error) {
+	return r.runArtifacts, nil
 }
 
 func newFakePublicShareRepository(orgID, workspaceID uuid.UUID) *fakePublicShareRepository {

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -418,7 +418,7 @@ func (noopPublicShareService) RevokeShareLink(context.Context, Caller, uuid.UUID
 	return errors.New("public share service is not configured")
 }
 
-func (noopPublicShareService) GetPublicShare(context.Context, string) (PublicSharePayload, error) {
+func (noopPublicShareService) GetPublicShare(context.Context, string, string) (PublicSharePayload, error) {
 	return PublicSharePayload{}, errors.New("public share service is not configured")
 }
 
@@ -445,6 +445,10 @@ func (noopAgentTryoutService) GetWorkspaceTryout(context.Context, Caller, uuid.U
 }
 
 func (noopAgentTryoutService) GetPublicTryoutEvents(context.Context, uuid.UUID, TryoutEventsCursor) (AgentTryoutEventsResult, error) {
+	return AgentTryoutEventsResult{}, errors.New("agent tryout service is not configured")
+}
+
+func (noopAgentTryoutService) GetSharedTryoutEvents(context.Context, string, TryoutEventsCursor) (AgentTryoutEventsResult, error) {
 	return AgentTryoutEventsResult{}, errors.New("agent tryout service is not configured")
 }
 

--- a/backend/internal/repository/agent_tryouts.go
+++ b/backend/internal/repository/agent_tryouts.go
@@ -286,43 +286,53 @@ func (r *Repository) ExpireAnonymousAgentTryouts(ctx context.Context, params Exp
 	}
 	defer rollback(ctx, tx)
 
-	rows, err := tx.Query(ctx, `
-		SELECT id, run_id
-		FROM agent_tryouts
-		WHERE expires_at IS NOT NULL
-		  AND expires_at <= $1
-		  AND claimed_by_user_id IS NULL
-		  AND workspace_id IS NULL
-		ORDER BY expires_at ASC, id ASC
-		LIMIT $2
-		FOR UPDATE SKIP LOCKED
-	`, params.Now.UTC(), limit)
+	// Collect the eligible rows in a scoped closure that defers rows.Close():
+	// the cursor MUST be fully closed before the UPDATE/DELETE below, because a
+	// single transaction can only have one query in flight at a time. Scoping
+	// the deferred close here guarantees that ordering by construction.
+	tryoutIDs, runIDs, err := func() ([]uuid.UUID, []uuid.UUID, error) {
+		rows, err := tx.Query(ctx, `
+			SELECT id, run_id
+			FROM agent_tryouts
+			WHERE expires_at IS NOT NULL
+			  AND expires_at <= $1
+			  AND claimed_by_user_id IS NULL
+			  AND workspace_id IS NULL
+			ORDER BY expires_at ASC, id ASC
+			LIMIT $2
+			FOR UPDATE SKIP LOCKED
+		`, params.Now.UTC(), limit)
+		if err != nil {
+			return nil, nil, fmt.Errorf("select expired anonymous agent tryouts: %w", err)
+		}
+		defer rows.Close()
+
+		var (
+			tryoutIDs []uuid.UUID
+			runIDs    []uuid.UUID
+		)
+		for rows.Next() {
+			var (
+				id    uuid.UUID
+				runID *uuid.UUID
+			)
+			if err := rows.Scan(&id, &runID); err != nil {
+				return nil, nil, fmt.Errorf("scan expired anonymous agent tryout: %w", err)
+			}
+			tryoutIDs = append(tryoutIDs, id)
+			if runID != nil {
+				runIDs = append(runIDs, *runID)
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return nil, nil, fmt.Errorf("iterate expired anonymous agent tryouts: %w", err)
+		}
+		return tryoutIDs, runIDs, nil
+	}()
 	if err != nil {
-		return 0, fmt.Errorf("select expired anonymous agent tryouts: %w", err)
+		return 0, err
 	}
 
-	var (
-		tryoutIDs []uuid.UUID
-		runIDs    []uuid.UUID
-	)
-	for rows.Next() {
-		var (
-			id    uuid.UUID
-			runID *uuid.UUID
-		)
-		if err := rows.Scan(&id, &runID); err != nil {
-			rows.Close()
-			return 0, fmt.Errorf("scan expired anonymous agent tryout: %w", err)
-		}
-		tryoutIDs = append(tryoutIDs, id)
-		if runID != nil {
-			runIDs = append(runIDs, *runID)
-		}
-	}
-	rows.Close()
-	if err := rows.Err(); err != nil {
-		return 0, fmt.Errorf("iterate expired anonymous agent tryouts: %w", err)
-	}
 	if len(tryoutIDs) == 0 {
 		if err := tx.Commit(ctx); err != nil {
 			return 0, fmt.Errorf("commit agent tryout retention transaction: %w", err)

--- a/backend/internal/repository/agent_tryouts.go
+++ b/backend/internal/repository/agent_tryouts.go
@@ -32,6 +32,15 @@ const (
 	AgentTryoutRedactionNotRequired AgentTryoutRedactionStatus = "not_required"
 )
 
+// ShareReady reports whether a tryout's redaction status permits public
+// exposure (share creation and public/share-token rendering). Only tryouts
+// whose payloads have cleared redaction — or that never required it — may be
+// shared; pending/failed tryouts must fail closed so unredacted content is
+// never published.
+func (s AgentTryoutRedactionStatus) ShareReady() bool {
+	return s == AgentTryoutRedactionPassed || s == AgentTryoutRedactionNotRequired
+}
+
 type AgentTryout struct {
 	ID                       uuid.UUID
 	OrganizationID           *uuid.UUID
@@ -248,6 +257,99 @@ func (r *Repository) WithinAnonymousAgentTryoutQuotaLock(ctx context.Context, fn
 		return fmt.Errorf("commit anonymous agent tryout quota transaction: %w", err)
 	}
 	return nil
+}
+
+// ExpireAnonymousAgentTryoutsParams configures one retention sweep batch.
+type ExpireAnonymousAgentTryoutsParams struct {
+	// Now is the comparison instant; tryouts with expires_at <= Now are eligible.
+	Now time.Time
+	// Limit bounds the rows processed per call so the sweep stays incremental.
+	Limit int32
+}
+
+// ExpireAnonymousAgentTryouts deletes one batch of expired, unclaimed anonymous
+// tryouts and schedules their run artifacts for deletion, returning the number
+// of tryouts removed. Claimed tryouts have expires_at cleared (see
+// ClaimAgentTryout) and are never matched, so claimed/workspace tryouts are
+// retained. Artifacts are soft-expired (retention_status -> scheduled_for_deletion)
+// rather than hard-deleted so downstream storage cleanup can reclaim objects.
+// Rows are locked FOR UPDATE SKIP LOCKED so concurrent sweeps don't contend.
+func (r *Repository) ExpireAnonymousAgentTryouts(ctx context.Context, params ExpireAnonymousAgentTryoutsParams) (int64, error) {
+	limit := params.Limit
+	if limit <= 0 {
+		limit = 500
+	}
+
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("begin agent tryout retention transaction: %w", err)
+	}
+	defer rollback(ctx, tx)
+
+	rows, err := tx.Query(ctx, `
+		SELECT id, run_id
+		FROM agent_tryouts
+		WHERE expires_at IS NOT NULL
+		  AND expires_at <= $1
+		  AND claimed_by_user_id IS NULL
+		  AND workspace_id IS NULL
+		ORDER BY expires_at ASC, id ASC
+		LIMIT $2
+		FOR UPDATE SKIP LOCKED
+	`, params.Now.UTC(), limit)
+	if err != nil {
+		return 0, fmt.Errorf("select expired anonymous agent tryouts: %w", err)
+	}
+
+	var (
+		tryoutIDs []uuid.UUID
+		runIDs    []uuid.UUID
+	)
+	for rows.Next() {
+		var (
+			id    uuid.UUID
+			runID *uuid.UUID
+		)
+		if err := rows.Scan(&id, &runID); err != nil {
+			rows.Close()
+			return 0, fmt.Errorf("scan expired anonymous agent tryout: %w", err)
+		}
+		tryoutIDs = append(tryoutIDs, id)
+		if runID != nil {
+			runIDs = append(runIDs, *runID)
+		}
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate expired anonymous agent tryouts: %w", err)
+	}
+	if len(tryoutIDs) == 0 {
+		if err := tx.Commit(ctx); err != nil {
+			return 0, fmt.Errorf("commit agent tryout retention transaction: %w", err)
+		}
+		return 0, nil
+	}
+
+	if len(runIDs) > 0 {
+		if _, err := tx.Exec(ctx, `
+			UPDATE artifacts
+			SET retention_status = 'scheduled_for_deletion', updated_at = now()
+			WHERE run_id = ANY($1::uuid[])
+			  AND retention_status = 'active'
+		`, runIDs); err != nil {
+			return 0, fmt.Errorf("schedule expired anonymous artifacts for deletion: %w", err)
+		}
+	}
+
+	tag, err := tx.Exec(ctx, `DELETE FROM agent_tryouts WHERE id = ANY($1::uuid[])`, tryoutIDs)
+	if err != nil {
+		return 0, fmt.Errorf("delete expired anonymous agent tryouts: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("commit agent tryout retention transaction: %w", err)
+	}
+	return tag.RowsAffected(), nil
 }
 
 func (r *Repository) GetAgentTryoutByID(ctx context.Context, id uuid.UUID) (AgentTryout, error) {

--- a/backend/internal/repository/agent_tryouts_integration_test.go
+++ b/backend/internal/repository/agent_tryouts_integration_test.go
@@ -79,6 +79,80 @@ func TestRepositoryAgentTryoutAnonymousQuotaLedger(t *testing.T) {
 	}
 }
 
+func TestRepositoryExpireAnonymousAgentTryouts(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	newAnon := func(expiresAt time.Time) repository.AgentTryout {
+		fingerprint := "retention-" + uuid.NewString()
+		tryout, err := repo.CreateAgentTryout(ctx, repository.CreateAgentTryoutParams{
+			TemplateSlug:             "meeting-minutes",
+			Status:                   repository.AgentTryoutStatusCompleted,
+			InputSnapshot:            []byte(`{"notes":"anon"}`),
+			TemplateSnapshot:         []byte(`{"slug":"meeting-minutes"}`),
+			ToolPolicySnapshot:       []byte(`{"tools":[]}`),
+			EvaluationSpecSnapshot:   []byte(`{"validators":[]}`),
+			SelectedModelPolicy:      []byte(`{"mode":"hosted_default"}`),
+			Summary:                  []byte(`{}`),
+			RedactionStatus:          repository.AgentTryoutRedactionPassed,
+			CostLimitUSD:             0.25,
+			MaxDurationSeconds:       120,
+			AnonymousFingerprintHash: &fingerprint,
+			ExpiresAt:                &expiresAt,
+		})
+		if err != nil {
+			t.Fatalf("CreateAgentTryout anonymous returned error: %v", err)
+		}
+		return tryout
+	}
+
+	expired := newAnon(time.Now().UTC().Add(-time.Hour))
+	future := newAnon(time.Now().UTC().Add(24 * time.Hour))
+
+	workspaceTryout, err := repo.CreateAgentTryout(ctx, repository.CreateAgentTryoutParams{
+		OrganizationID:         &fixture.organizationID,
+		WorkspaceID:            &fixture.workspaceID,
+		TemplateSlug:           "meeting-minutes",
+		Status:                 repository.AgentTryoutStatusCompleted,
+		InputSnapshot:          []byte(`{"notes":"workspace"}`),
+		TemplateSnapshot:       []byte(`{"slug":"meeting-minutes"}`),
+		ToolPolicySnapshot:     []byte(`{"tools":[]}`),
+		EvaluationSpecSnapshot: []byte(`{"validators":[]}`),
+		SelectedModelPolicy:    []byte(`{"mode":"hosted_default"}`),
+		Summary:                []byte(`{}`),
+		RedactionStatus:        repository.AgentTryoutRedactionPassed,
+		CostLimitUSD:           10,
+		MaxDurationSeconds:     120,
+		CreatedByUserID:        &fixture.userID,
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentTryout workspace returned error: %v", err)
+	}
+
+	deleted, err := repo.ExpireAnonymousAgentTryouts(ctx, repository.ExpireAnonymousAgentTryoutsParams{
+		Now:   time.Now().UTC(),
+		Limit: 100,
+	})
+	if err != nil {
+		t.Fatalf("ExpireAnonymousAgentTryouts returned error: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1 (only the expired unclaimed anonymous tryout)", deleted)
+	}
+
+	if _, err := repo.GetAgentTryoutByID(ctx, expired.ID); !errors.Is(err, repository.ErrAgentTryoutNotFound) {
+		t.Fatalf("expired tryout lookup error = %v, want ErrAgentTryoutNotFound", err)
+	}
+	if _, err := repo.GetAgentTryoutByID(ctx, future.ID); err != nil {
+		t.Fatalf("future anonymous tryout should be retained, got %v", err)
+	}
+	if _, err := repo.GetAgentTryoutByID(ctx, workspaceTryout.ID); err != nil {
+		t.Fatalf("workspace tryout should be retained, got %v", err)
+	}
+}
+
 // TestRepositoryAgentTryoutQuotaLockSerializesCreation exercises
 // WithinAnonymousAgentTryoutQuotaLock under concurrent load to prove the
 // advisory lock closes the check-then-create TOCTOU window: many goroutines

--- a/backend/internal/repository/artifacts.go
+++ b/backend/internal/repository/artifacts.go
@@ -147,6 +147,52 @@ func (r *Repository) ListArtifactsByWorkspaceID(ctx context.Context, workspaceID
 	return artifacts, nil
 }
 
+// ListArtifactsByRunID returns the active (non-expired) artifacts produced by a
+// run, ordered oldest-first for stable rendering. Used to surface a tryout's
+// downloadable artifacts (a tryout links to a single run).
+func (r *Repository) ListArtifactsByRunID(ctx context.Context, runID uuid.UUID) ([]Artifact, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT
+			id,
+			organization_id,
+			workspace_id,
+			run_id,
+			run_agent_id,
+			artifact_type,
+			storage_bucket,
+			storage_key,
+			content_type,
+			size_bytes,
+			checksum_sha256,
+			visibility,
+			retention_status,
+			metadata,
+			created_at,
+			updated_at
+		FROM artifacts
+		WHERE run_id = $1
+		  AND retention_status = 'active'
+		ORDER BY created_at ASC, id ASC
+	`, runID)
+	if err != nil {
+		return nil, fmt.Errorf("list artifacts by run: %w", err)
+	}
+	defer rows.Close()
+
+	var artifacts []Artifact
+	for rows.Next() {
+		artifact, err := scanArtifact(rows)
+		if err != nil {
+			return nil, fmt.Errorf("list artifacts by run: scan: %w", err)
+		}
+		artifacts = append(artifacts, artifact)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list artifacts by run: rows: %w", err)
+	}
+	return artifacts, nil
+}
+
 func (r *Repository) GetArtifactByID(ctx context.Context, artifactID uuid.UUID) (Artifact, error) {
 	row := r.db.QueryRow(ctx, `
 		SELECT

--- a/backend/internal/worker/agent_tryout_retention_reaper.go
+++ b/backend/internal/worker/agent_tryout_retention_reaper.go
@@ -1,0 +1,85 @@
+package worker
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+)
+
+type AgentTryoutRetentionReaperRepository interface {
+	ExpireAnonymousAgentTryouts(ctx context.Context, params repository.ExpireAnonymousAgentTryoutsParams) (int64, error)
+}
+
+const (
+	agentTryoutRetentionBatchLimit = 500
+	agentTryoutRetentionMaxBatches = 20
+)
+
+// RepositoryAgentTryoutRetentionReaper periodically deletes expired, unclaimed
+// anonymous agent tryouts and schedules their artifacts for deletion, enforcing
+// the anonymous retention policy. Claimed tryouts have their expiry cleared and
+// are never swept. It mirrors RepositoryOrphanRunReaper: a ticker-driven
+// goroutine that processes work in bounded batches.
+type RepositoryAgentTryoutRetentionReaper struct {
+	repo     AgentTryoutRetentionReaperRepository
+	interval time.Duration
+	logger   *slog.Logger
+	now      func() time.Time
+}
+
+func NewRepositoryAgentTryoutRetentionReaper(
+	repo AgentTryoutRetentionReaperRepository,
+	interval time.Duration,
+	logger *slog.Logger,
+) *RepositoryAgentTryoutRetentionReaper {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &RepositoryAgentTryoutRetentionReaper{
+		repo:     repo,
+		interval: interval,
+		logger:   logger,
+		now:      time.Now,
+	}
+}
+
+func (r *RepositoryAgentTryoutRetentionReaper) Start(ctx context.Context) {
+	if r == nil || r.repo == nil || r.interval <= 0 {
+		return
+	}
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.reapOnce(ctx)
+		}
+	}
+}
+
+func (r *RepositoryAgentTryoutRetentionReaper) reapOnce(ctx context.Context) {
+	now := r.now().UTC()
+	var totalDeleted int64
+	for batch := 0; batch < agentTryoutRetentionMaxBatches; batch++ {
+		deleted, err := r.repo.ExpireAnonymousAgentTryouts(ctx, repository.ExpireAnonymousAgentTryoutsParams{
+			Now:   now,
+			Limit: agentTryoutRetentionBatchLimit,
+		})
+		if err != nil {
+			r.logger.Error("agent tryout retention reaper failed", "error", err)
+			return
+		}
+		totalDeleted += deleted
+		// A short final batch means the backlog is drained for this tick.
+		if deleted < agentTryoutRetentionBatchLimit {
+			break
+		}
+	}
+	if totalDeleted > 0 {
+		r.logger.Info("agent tryout retention reaper swept expired anonymous tryouts", "deleted", totalDeleted)
+	}
+}

--- a/backend/internal/worker/agent_tryout_retention_reaper_test.go
+++ b/backend/internal/worker/agent_tryout_retention_reaper_test.go
@@ -1,0 +1,67 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+)
+
+type fakeTryoutRetentionRepo struct {
+	// batches drives successive ExpireAnonymousAgentTryouts return values.
+	batches []int64
+	errs    []error
+	calls   int
+}
+
+func (r *fakeTryoutRetentionRepo) ExpireAnonymousAgentTryouts(_ context.Context, _ repository.ExpireAnonymousAgentTryoutsParams) (int64, error) {
+	idx := r.calls
+	r.calls++
+	if idx < len(r.errs) && r.errs[idx] != nil {
+		return 0, r.errs[idx]
+	}
+	if idx < len(r.batches) {
+		return r.batches[idx], nil
+	}
+	return 0, nil
+}
+
+func TestAgentTryoutRetentionReaperDrainsBatchesUntilShort(t *testing.T) {
+	repo := &fakeTryoutRetentionRepo{batches: []int64{agentTryoutRetentionBatchLimit, agentTryoutRetentionBatchLimit, 7}}
+	reaper := NewRepositoryAgentTryoutRetentionReaper(repo, time.Minute, nil)
+
+	reaper.reapOnce(context.Background())
+
+	if repo.calls != 3 {
+		t.Fatalf("expected 3 batch calls (two full + one short), got %d", repo.calls)
+	}
+}
+
+func TestAgentTryoutRetentionReaperStopsOnError(t *testing.T) {
+	repo := &fakeTryoutRetentionRepo{
+		batches: []int64{agentTryoutRetentionBatchLimit, 0},
+		errs:    []error{nil, errors.New("db down")},
+	}
+	reaper := NewRepositoryAgentTryoutRetentionReaper(repo, time.Minute, nil)
+
+	reaper.reapOnce(context.Background())
+
+	if repo.calls != 2 {
+		t.Fatalf("expected reaper to stop after the erroring batch, got %d calls", repo.calls)
+	}
+}
+
+func TestAgentTryoutRetentionReaperDisabledWithZeroInterval(t *testing.T) {
+	repo := &fakeTryoutRetentionRepo{batches: []int64{1}}
+	reaper := NewRepositoryAgentTryoutRetentionReaper(repo, 0, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	reaper.Start(ctx) // returns immediately; no ticker scheduled
+
+	if repo.calls != 0 {
+		t.Fatalf("zero interval should disable the reaper, got %d calls", repo.calls)
+	}
+}

--- a/backend/internal/worker/config.go
+++ b/backend/internal/worker/config.go
@@ -28,6 +28,9 @@ const (
 	defaultArtifactMaxAssetBytes    = 100 << 20
 	defaultOrphanRunReaperInterval  = 5 * time.Minute
 	defaultOrphanRunReaperThreshold = 15 * time.Minute
+	// Anonymous agent tryouts carry an expires_at (default 24h, cleared on
+	// claim). The retention reaper sweeps expired, unclaimed tryouts hourly.
+	defaultAgentTryoutRetentionReaperInterval = time.Hour
 )
 
 var ErrInvalidConfig = errors.New("invalid worker config")
@@ -46,6 +49,8 @@ type Config struct {
 	ShutdownTimeout          time.Duration
 	OrphanRunReaperInterval  time.Duration
 	OrphanRunReaperThreshold time.Duration
+
+	AgentTryoutRetentionReaperInterval time.Duration
 	ArtifactStorage          ArtifactStorageConfig
 	Sandbox                  SandboxConfig
 	SecretsCipher            *secrets.AESGCMCipher
@@ -120,6 +125,10 @@ func LoadConfigFromEnv() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	agentTryoutRetentionReaperInterval, err := durationEnvOrDefaultAllowZero("WORKER_AGENT_TRYOUT_RETENTION_REAPER_INTERVAL", defaultAgentTryoutRetentionReaperInterval)
+	if err != nil {
+		return Config{}, err
+	}
 	sandboxProvider, err := envOrDefault("SANDBOX_PROVIDER", "unconfigured")
 	if err != nil {
 		return Config{}, err
@@ -188,6 +197,8 @@ func LoadConfigFromEnv() (Config, error) {
 		ShutdownTimeout:          shutdownTimeout,
 		OrphanRunReaperInterval:  orphanRunReaperInterval,
 		OrphanRunReaperThreshold: orphanRunReaperThreshold,
+
+		AgentTryoutRetentionReaperInterval: agentTryoutRetentionReaperInterval,
 		ArtifactStorage: ArtifactStorageConfig{
 			Backend:          artifactStorageBackend,
 			Bucket:           artifactStorageBucket,

--- a/backend/internal/worker/service.go
+++ b/backend/internal/worker/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/provider"
@@ -49,10 +50,13 @@ func NewTemporalWorker(
 }
 
 func Run(ctx context.Context, cfg Config, temporalWorker TemporalWorker, logger *slog.Logger) error {
-	return RunWithReaper(ctx, cfg, temporalWorker, nil, logger)
+	return RunWithReaper(ctx, cfg, temporalWorker, logger)
 }
 
-func RunWithReaper(ctx context.Context, cfg Config, temporalWorker TemporalWorker, reaper OrphanRunReaper, logger *slog.Logger) error {
+// RunWithReaper starts the temporal worker plus any number of background
+// reapers (orphan-run cleanup, anonymous tryout retention, ...), each on its
+// own goroutine, and blocks until ctx is cancelled. nil reapers are ignored.
+func RunWithReaper(ctx context.Context, cfg Config, temporalWorker TemporalWorker, logger *slog.Logger, reapers ...OrphanRunReaper) error {
 	logger.Info("starting worker",
 		"task_queue", cfg.TaskQueue,
 		"identity", cfg.Identity,
@@ -65,10 +69,24 @@ func RunWithReaper(ctx context.Context, cfg Config, temporalWorker TemporalWorke
 	}
 
 	reaperDoneCh := make(chan struct{})
-	if reaper != nil {
+	active := make([]OrphanRunReaper, 0, len(reapers))
+	for _, reaper := range reapers {
+		if reaper != nil {
+			active = append(active, reaper)
+		}
+	}
+	if len(active) > 0 {
+		var wg sync.WaitGroup
+		wg.Add(len(active))
+		for _, reaper := range active {
+			go func(reaper OrphanRunReaper) {
+				defer wg.Done()
+				reaper.Start(ctx)
+			}(reaper)
+		}
 		go func() {
-			defer close(reaperDoneCh)
-			reaper.Start(ctx)
+			wg.Wait()
+			close(reaperDoneCh)
 		}()
 	} else {
 		close(reaperDoneCh)

--- a/backend/internal/worker/service_test.go
+++ b/backend/internal/worker/service_test.go
@@ -63,7 +63,7 @@ func TestRunWithReaperStartsAndStopsReaper(t *testing.T) {
 			Identity:        "worker-test",
 			TemporalAddress: "localhost:7233",
 			ShutdownTimeout: time.Second,
-		}, fakeWorker, reaper, logger)
+		}, fakeWorker, logger, reaper)
 	}()
 
 	waitForCondition(t, time.Second, func() bool {
@@ -158,7 +158,7 @@ func TestRunWithReaperReturnsShutdownTimeoutWhenReaperBlocks(t *testing.T) {
 			Identity:        "worker-test",
 			TemporalAddress: "localhost:7233",
 			ShutdownTimeout: 10 * time.Millisecond,
-		}, fakeWorker, reaper, logger)
+		}, fakeWorker, logger, reaper)
 	}()
 
 	waitForCondition(t, time.Second, func() bool {

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -5215,6 +5215,40 @@ paths:
         "404":
           $ref: "#/components/responses/NotFoundError"
 
+  /v1/agent-tryouts/shared/{token}/events:
+    get:
+      operationId: getSharedAgentTryoutEvents
+      summary: Get the redacted evidence timeline for a shared agent tryout
+      description: >-
+        Returns a cursor-paginated, redacted timeline for a tryout exposed
+        behind a public share token. The token is resolved to an active share
+        link that must reference an agent tryout whose redaction has cleared.
+        Event payloads are always redacted to a non-sensitive allow-list because
+        this endpoint is unauthenticated. A token that is missing, revoked,
+        expired, points at a non-tryout resource, or references a tryout whose
+        redaction has not passed returns 404 so callers cannot probe redaction
+        state. Poll with the returned `next_cursor` as `after` to resume.
+      tags: [AgentTryouts]
+      security: []
+      parameters:
+        - name: token
+          in: path
+          required: true
+          description: The opaque public share token for the tryout.
+          schema:
+            type: string
+        - $ref: "#/components/parameters/TryoutEventsAfter"
+        - $ref: "#/components/parameters/TryoutEventsLimit"
+      responses:
+        "200":
+          description: Redacted tryout event timeline page
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentTryoutEventsResponse"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
   /v1/workspaces/{workspaceID}/agent-tryouts:
     post:
       operationId: createWorkspaceAgentTryout
@@ -5376,6 +5410,11 @@ paths:
     post:
       operationId: createAgentTryoutShare
       summary: Create a noindex share link for a workspace tryout
+      description: >-
+        Creates a private (noindex) share link for a completed workspace tryout.
+        Share creation is gated on redaction: a tryout whose `redaction_status`
+        is `pending` or `failed` returns 409 so unredacted evidence is never
+        published. Only `passed`/`not_required` tryouts can be shared.
       tags: [AgentTryouts]
       security:
         - bearerJWT: []
@@ -5394,6 +5433,8 @@ paths:
           $ref: "#/components/responses/ForbiddenError"
         "404":
           $ref: "#/components/responses/NotFoundError"
+        "409":
+          $ref: "#/components/responses/ConflictError"
 
   /v1/workspaces/{workspaceID}/playgrounds:
     post:


### PR DESCRIPTION
Closes #946. Build order 5 of 6 under the Agent Tryouts epic (#940), on top of #945.

Makes anonymous/shared agent-tryout evidence safe by default: shares can't be created or rendered until redaction passes, public payloads never carry private identifiers, shared timeline evidence is redacted, shared artifacts are limited to template-approved outputs, and expired anonymous tryouts are swept on a schedule.

## What this adds

### Redaction-gated sharing (fail closed)
- New `AgentTryoutRedactionStatus.ShareReady()` (`passed` / `not_required` only).
- `CreatePrivateShare` and the generic `PublicShareManager` agent-tryout path now return a stable **409** (`agent_tryout_redaction_not_ready`) when `redaction_status` is `pending`/`failed`.
- The public **share render** (`/public/shares/{token}`) also fails closed (404) if a share's redaction later regresses, so unredacted content is never served even if a share already exists.

### Public-safe payloads + summary redaction
- The shared tryout payload already omits org/workspace/user ids and the anonymous fingerprint; added a regression test asserting none of those leak (keys or values).
- Added a schema-agnostic, recursive `redactTryoutSummaryForPublic` that strips sensitive-looking keys (secrets/tokens/credentials/ids/fingerprints) from the summary before public exposure — defense-in-depth on top of the execution-side redaction pipeline.

### Redacted shared timeline feed
- New `GET /v1/agent-tryouts/shared/{token}/events` resolves a share token → agent tryout → `ShareReady` → the existing redacted timeline builder (reuses #945's allow-list). Missing/revoked/expired tokens, non-tryout resources, and not-yet-redacted tryouts all 404 so callers can't probe redaction state.

### Per-template artifact allowlist (default-deny)
- New `ListArtifactsByRunID` repo method (active artifacts only).
- Shared payloads now include redacted artifact descriptors built **default-deny**: only artifacts whose metadata matches the template's `expected_artifacts` (by `artifact_key` or `relative_path`/`path`) are exposed, using the template's canonical key/type/path plus non-sensitive size/checksum/content-type. Storage bucket/key, ids, and raw metadata are never included.
- When an artifact signer is configured, descriptors carry signed, time-limited content URLs (reusing the existing HMAC-signed public `/artifacts/{id}/content` endpoint), so shared downloads are limited to approved outputs.

### Anonymous retention sweep
- New `ExpireAnonymousAgentTryouts` repo method: in one transaction, schedules the run's artifacts for deletion (`retention_status -> scheduled_for_deletion`) and hard-deletes expired, unclaimed anonymous tryouts (`FOR UPDATE SKIP LOCKED`, batched). Claimed tryouts already have `expires_at` cleared on claim, so claimed/workspace tryouts are always retained.
- New `RepositoryAgentTryoutRetentionReaper` worker (mirrors the orphan-run reaper) on an hourly default interval (`WORKER_AGENT_TRYOUT_RETENTION_REAPER_INTERVAL`). `RunWithReaper` is generalized to run multiple background reapers.

## Acceptance criteria
- ✅ Share creation with `failed`/`pending` redaction is blocked with a stable not-ready (409) error.
- ✅ Shared tryout payload contains only public-safe fields (no org/workspace/user/fingerprint).
- ✅ Shared timeline events are redacted and summarized.
- ✅ Shared artifacts are limited to template-approved outputs (default-deny).
- ✅ Anonymous tryouts/artifacts expire on a retention schedule unless claimed.
- ✅ Tests cover secret patterns and workspace/user identifier leaks.

## Tests
- **Unit:** summary redaction (sensitive keys/values stripped, safe fields kept, invalid JSON dropped); template allowlist parsing; default-deny artifact descriptor building (unmatched dropped, metadata redacted, signed URL attached, match-by-path); shared events redaction + token/redaction gating + non-tryout-share rejection; share-creation 409 when pending; retention reaper batch-drain / stop-on-error / disabled.
- **Integration (DB-gated):** `TestRepositoryExpireAnonymousAgentTryouts` verifies expired-unclaimed deletion vs future-anonymous and workspace retention — run green against local Postgres.

`go build`, `go vet`, and `go test -short -race ./...` pass (the one unrelated `challengepack` `cli-smoke-ruff.yaml` failure is pre-existing, from a duplicate `version` key, and is noted in #945's PR too). OpenAPI updated with the new shared-events path + 409 on share creation (validates; the 5 lint errors are the pre-existing undefined-`ErrorResponse` refs in the datasets paths, untouched here).

## Follow-ups (not in scope)
- Optional SSE/push transport for the shared events feed (reuse run SSE).
- Storage-object reclamation for artifacts marked `scheduled_for_deletion` (this PR marks; a separate sweeper deletes objects).
- Build order 6 of 6: #947 (rerun / compare / promote-to-eval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
