### PR TITLE
feat(agent-tryouts): rerun, compare, and promote-to-eval conversion flows

### DIFF
--- a/backend/db/migrations/00057_agent_tryout_parent_lineage.sql
+++ b/backend/db/migrations/00057_agent_tryout_parent_lineage.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+
+-- Track rerun lineage: a tryout created by "rerun with another model" points back
+-- to the tryout it was derived from. Nullable for original (non-rerun) tryouts.
+ALTER TABLE agent_tryouts
+ADD COLUMN parent_tryout_id uuid REFERENCES agent_tryouts (id) ON DELETE SET NULL;
+
+CREATE INDEX idx_agent_tryouts_parent_tryout_id
+ON agent_tryouts (parent_tryout_id)
+WHERE parent_tryout_id IS NOT NULL;
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_agent_tryouts_parent_tryout_id;
+
+ALTER TABLE agent_tryouts
+DROP COLUMN IF EXISTS parent_tryout_id;

--- a/backend/db/queries/agent_tryouts.sql
+++ b/backend/db/queries/agent_tryouts.sql
@@ -18,6 +18,7 @@ INSERT INTO agent_tryouts (
     max_duration_seconds,
     anonymous_fingerprint_hash,
     created_by_user_id,
+    parent_tryout_id,
     expires_at
 )
 VALUES (
@@ -39,6 +40,7 @@ VALUES (
     @max_duration_seconds,
     sqlc.narg('anonymous_fingerprint_hash'),
     sqlc.narg('created_by_user_id'),
+    sqlc.narg('parent_tryout_id'),
     sqlc.narg('expires_at')
 )
 RETURNING *;

--- a/backend/internal/api/agent_tryout_conversions.go
+++ b/backend/internal/api/agent_tryout_conversions.go
@@ -186,20 +186,27 @@ type AgentTryoutCompareResult struct {
 // never mutated. Any id outside the workspace (or missing) fails closed as
 // not-found so existence isn't leaked across workspaces.
 func (m *AgentTryoutManager) CompareWorkspaceTryouts(ctx context.Context, caller Caller, input CompareAgentTryoutsInput) (AgentTryoutCompareResult, error) {
-	if len(input.TryoutIDs) < 2 || len(input.TryoutIDs) > 4 {
+	// Deduplicate before the cardinality check so the 2-4 bound is enforced on
+	// distinct tryouts — otherwise ["id-A","id-A"] would slip past len()>=2 and
+	// return a single participant, violating the contract.
+	seen := make(map[uuid.UUID]bool, len(input.TryoutIDs))
+	distinctIDs := make([]uuid.UUID, 0, len(input.TryoutIDs))
+	for _, id := range input.TryoutIDs {
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		distinctIDs = append(distinctIDs, id)
+	}
+	if len(distinctIDs) < 2 || len(distinctIDs) > 4 {
 		return AgentTryoutCompareResult{}, ErrAgentTryoutCompareCardinality
 	}
 	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, input.WorkspaceID, ActionReadWorkspace); err != nil {
 		return AgentTryoutCompareResult{}, err
 	}
 
-	seen := make(map[uuid.UUID]bool, len(input.TryoutIDs))
-	participants := make([]AgentTryoutCompareParticipant, 0, len(input.TryoutIDs))
-	for _, id := range input.TryoutIDs {
-		if seen[id] {
-			continue
-		}
-		seen[id] = true
+	participants := make([]AgentTryoutCompareParticipant, 0, len(distinctIDs))
+	for _, id := range distinctIDs {
 		tryout, err := m.repo.GetAgentTryoutByID(ctx, id)
 		if err != nil {
 			return AgentTryoutCompareResult{}, err
@@ -266,6 +273,17 @@ func (m *AgentTryoutManager) PromoteTryoutToEval(ctx context.Context, caller Cal
 	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, *source.WorkspaceID); err != nil {
 		return AgentTryoutPromotionResult{}, err
 	}
+	// Only completed tryouts carry the execution evidence worth promoting; a
+	// queued/running/failed tryout would seed a draft backed by partial or no
+	// results.
+	if source.Status != repository.AgentTryoutStatusCompleted {
+		return AgentTryoutPromotionResult{}, fmt.Errorf("%w: status %q", ErrAgentTryoutNotPromotable, source.Status)
+	}
+
+	content, err := promotionDraftContent(source)
+	if err != nil {
+		return AgentTryoutPromotionResult{}, err
+	}
 
 	title := strings.TrimSpace(input.Title)
 	if title == "" {
@@ -283,7 +301,6 @@ func (m *AgentTryoutManager) PromoteTryoutToEval(ctx context.Context, caller Cal
 		return AgentTryoutPromotionResult{}, err
 	}
 
-	content := promotionDraftContent(source)
 	draft, err := m.repo.CreateVibeEvalDraft(ctx, repository.CreateVibeEvalDraftParams{
 		OrganizationID:   *source.OrganizationID,
 		WorkspaceID:      *source.WorkspaceID,
@@ -305,7 +322,7 @@ func (m *AgentTryoutManager) PromoteTryoutToEval(ctx context.Context, caller Cal
 // draft body. It includes only the durable, workspace-owned definition (no run
 // ids, costs, or identifiers) so the draft is a clean starting point for a
 // repeatable eval.
-func promotionDraftContent(source repository.AgentTryout) json.RawMessage {
+func promotionDraftContent(source repository.AgentTryout) (json.RawMessage, error) {
 	body := map[string]any{
 		"kind":                     "agent_tryout_promotion",
 		"source_tryout_id":         source.ID.String(),
@@ -317,9 +334,10 @@ func promotionDraftContent(source repository.AgentTryout) json.RawMessage {
 	}
 	encoded, err := json.Marshal(body)
 	if err != nil {
-		return json.RawMessage(`{}`)
+		// Surface the failure instead of persisting an empty draft + false 201.
+		return nil, fmt.Errorf("marshal promotion draft content: %w", err)
 	}
-	return encoded
+	return encoded, nil
 }
 
 // templateExpectedArtifacts extracts runtime.expected_artifacts from a stored

--- a/backend/internal/api/agent_tryout_conversions.go
+++ b/backend/internal/api/agent_tryout_conversions.go
@@ -1,0 +1,467 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+// AgentTryoutRerunGate authorizes a rerun against billing/provider entitlements
+// (active plan, provider key availability, sufficient credits). It is optional
+// and injected via WithRerunGate, mirroring WithExecution/WithQuota: when no gate
+// is configured, reruns proceed (dev/default). Implementations return the
+// product-facing sentinel errors below so handlers can map them to HTTP codes.
+type AgentTryoutRerunGate interface {
+	AuthorizeRerun(ctx context.Context, caller Caller, workspaceID uuid.UUID, selectedModelPolicy json.RawMessage) error
+}
+
+// WithRerunGate attaches a billing/provider gate that reruns must pass.
+func (m *AgentTryoutManager) WithRerunGate(gate AgentTryoutRerunGate) *AgentTryoutManager {
+	m.rerunGate = gate
+	return m
+}
+
+// knownTryoutProviderKeys is the set of provider keys a rerun model policy may
+// reference. It mirrors the provider router's registered adapters.
+var knownTryoutProviderKeys = map[string]bool{
+	"openai":     true,
+	"anthropic":  true,
+	"gemini":     true,
+	"xai":        true,
+	"openrouter": true,
+	"mistral":    true,
+}
+
+// tryoutModelPolicy is the validated shape of a rerun's selected model policy.
+type tryoutModelPolicy struct {
+	Mode      string `json:"mode"`
+	MaxModels *int   `json:"max_models"`
+	Models    []struct {
+		Provider string `json:"provider"`
+		Model    string `json:"model"`
+	} `json:"models"`
+}
+
+// validateTryoutModelPolicy checks that a requested rerun model policy is a
+// well-formed object that names at least a mode or an explicit model, and that
+// any explicit models reference known providers. Returns
+// ErrAgentTryoutModelPolicyInvalid for malformed input and
+// ErrAgentTryoutModelUnavailable for unknown providers / empty model ids.
+func validateTryoutModelPolicy(raw json.RawMessage) error {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return fmt.Errorf("%w: model policy is required", ErrAgentTryoutModelPolicyInvalid)
+	}
+	if trimmed[0] != '{' {
+		return fmt.Errorf("%w: model policy must be a JSON object", ErrAgentTryoutModelPolicyInvalid)
+	}
+	var policy tryoutModelPolicy
+	decoder := json.NewDecoder(strings.NewReader(trimmed))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&policy); err != nil {
+		return fmt.Errorf("%w: %v", ErrAgentTryoutModelPolicyInvalid, err)
+	}
+	mode := strings.TrimSpace(policy.Mode)
+	if mode == "" && len(policy.Models) == 0 {
+		return fmt.Errorf("%w: model policy must set a mode or at least one model", ErrAgentTryoutModelPolicyInvalid)
+	}
+	if policy.MaxModels != nil && (*policy.MaxModels < 1 || *policy.MaxModels > 8) {
+		return fmt.Errorf("%w: max_models must be between 1 and 8", ErrAgentTryoutModelPolicyInvalid)
+	}
+	for _, entry := range policy.Models {
+		provider := strings.TrimSpace(entry.Provider)
+		model := strings.TrimSpace(entry.Model)
+		if provider == "" || model == "" {
+			return fmt.Errorf("%w: each model needs a provider and model id", ErrAgentTryoutModelPolicyInvalid)
+		}
+		if !knownTryoutProviderKeys[provider] {
+			return fmt.Errorf("%w: provider %q is not available", ErrAgentTryoutModelUnavailable, provider)
+		}
+	}
+	return nil
+}
+
+// RerunAgentTryoutInput requests a rerun of an existing workspace tryout with a
+// different model policy.
+type RerunAgentTryoutInput struct {
+	SourceTryoutID      uuid.UUID
+	SelectedModelPolicy json.RawMessage
+}
+
+// RerunWorkspaceTryout creates a new tryout that reuses the source tryout's
+// template + input but runs under a different model policy, linked back to the
+// source via parent_tryout_id. The rerun is independent immutable evidence; the
+// source is never mutated.
+func (m *AgentTryoutManager) RerunWorkspaceTryout(ctx context.Context, caller Caller, input RerunAgentTryoutInput) (repository.AgentTryout, error) {
+	source, err := m.repo.GetAgentTryoutByID(ctx, input.SourceTryoutID)
+	if err != nil {
+		return repository.AgentTryout{}, err
+	}
+	// Anonymous/unclaimed tryouts have no workspace — rerun is a signed-in action.
+	if source.WorkspaceID == nil || source.OrganizationID == nil {
+		return repository.AgentTryout{}, ErrAgentTryoutSignInRequired
+	}
+	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, *source.WorkspaceID); err != nil {
+		return repository.AgentTryout{}, err
+	}
+	template, err := m.lookupTemplate(source.TemplateSlug)
+	if err != nil {
+		return repository.AgentTryout{}, err
+	}
+	if err := ensureAgentTryoutTemplateAvailable(template); err != nil {
+		return repository.AgentTryout{}, err
+	}
+	if err := validateTryoutModelPolicy(input.SelectedModelPolicy); err != nil {
+		return repository.AgentTryout{}, err
+	}
+	if m.rerunGate != nil {
+		if err := m.rerunGate.AuthorizeRerun(ctx, caller, *source.WorkspaceID, input.SelectedModelPolicy); err != nil {
+			return repository.AgentTryout{}, err
+		}
+	}
+
+	callerID := caller.UserID
+	parentID := source.ID
+	tryout, err := m.repo.CreateAgentTryout(ctx, repository.CreateAgentTryoutParams{
+		OrganizationID:         source.OrganizationID,
+		WorkspaceID:            source.WorkspaceID,
+		TemplateSlug:           template.Slug,
+		Status:                 repository.AgentTryoutStatusQueued,
+		InputSnapshot:          cloneRawJSON(source.InputSnapshot),
+		TemplateSnapshot:       templateSnapshot(template),
+		ToolPolicySnapshot:     template.ToolPolicy,
+		EvaluationSpecSnapshot: template.EvaluationSpec,
+		SelectedModelPolicy:    input.SelectedModelPolicy,
+		Summary:                json.RawMessage(`{}`),
+		RedactionStatus:        repository.AgentTryoutRedactionPending,
+		CostLimitUSD:           template.MaxCostUSD,
+		MaxDurationSeconds:     template.MaxDurationSeconds,
+		CreatedByUserID:        &callerID,
+		ParentTryoutID:         &parentID,
+	})
+	if err != nil {
+		return repository.AgentTryout{}, err
+	}
+	return m.dispatchCreatedTryout(ctx, tryout, template)
+}
+
+// CompareAgentTryoutsInput requests a side-by-side comparison of 2-4 workspace
+// tryouts.
+type CompareAgentTryoutsInput struct {
+	WorkspaceID uuid.UUID
+	TryoutIDs   []uuid.UUID
+}
+
+// AgentTryoutCompareParticipant is one tryout's slice of a comparison payload.
+type AgentTryoutCompareParticipant struct {
+	ID                  uuid.UUID                             `json:"id"`
+	TemplateSlug        string                                `json:"template_slug"`
+	Status              repository.AgentTryoutStatus          `json:"status"`
+	RedactionStatus     repository.AgentTryoutRedactionStatus `json:"redaction_status"`
+	SelectedModelPolicy json.RawMessage                       `json:"selected_model_policy"`
+	RunID               *uuid.UUID                            `json:"run_id,omitempty"`
+	ParentTryoutID      *uuid.UUID                            `json:"parent_tryout_id,omitempty"`
+	CostLimitUSD        float64                               `json:"cost_limit_usd"`
+	ActualCostUSD       *float64                              `json:"actual_cost_usd,omitempty"`
+	LatencyMS           *int64                                `json:"latency_ms,omitempty"`
+	Summary             json.RawMessage                       `json:"summary"`
+	EventsURL           string                                `json:"events_url"`
+}
+
+// AgentTryoutCompareResult is the aggregated side-by-side comparison.
+type AgentTryoutCompareResult struct {
+	WorkspaceID  uuid.UUID                       `json:"workspace_id"`
+	Participants []AgentTryoutCompareParticipant `json:"participants"`
+}
+
+// CompareWorkspaceTryouts loads 2-4 tryouts that all belong to the workspace and
+// returns a side-by-side payload. It is read-only — reruns being compared are
+// never mutated. Any id outside the workspace (or missing) fails closed as
+// not-found so existence isn't leaked across workspaces.
+func (m *AgentTryoutManager) CompareWorkspaceTryouts(ctx context.Context, caller Caller, input CompareAgentTryoutsInput) (AgentTryoutCompareResult, error) {
+	if len(input.TryoutIDs) < 2 || len(input.TryoutIDs) > 4 {
+		return AgentTryoutCompareResult{}, ErrAgentTryoutCompareCardinality
+	}
+	if err := AuthorizeWorkspaceAction(ctx, m.authorizer, caller, input.WorkspaceID, ActionReadWorkspace); err != nil {
+		return AgentTryoutCompareResult{}, err
+	}
+
+	seen := make(map[uuid.UUID]bool, len(input.TryoutIDs))
+	participants := make([]AgentTryoutCompareParticipant, 0, len(input.TryoutIDs))
+	for _, id := range input.TryoutIDs {
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		tryout, err := m.repo.GetAgentTryoutByID(ctx, id)
+		if err != nil {
+			return AgentTryoutCompareResult{}, err
+		}
+		// Fail closed across workspaces: a tryout that isn't owned by this
+		// workspace is reported as not-found rather than leaking its existence.
+		if tryout.WorkspaceID == nil || *tryout.WorkspaceID != input.WorkspaceID {
+			return AgentTryoutCompareResult{}, repository.ErrAgentTryoutNotFound
+		}
+		tryout = m.refreshTryoutFromExecution(ctx, tryout)
+		participants = append(participants, AgentTryoutCompareParticipant{
+			ID:                  tryout.ID,
+			TemplateSlug:        tryout.TemplateSlug,
+			Status:              tryout.Status,
+			RedactionStatus:     tryout.RedactionStatus,
+			SelectedModelPolicy: tryout.SelectedModelPolicy,
+			RunID:               tryout.RunID,
+			ParentTryoutID:      tryout.ParentTryoutID,
+			CostLimitUSD:        tryout.CostLimitUSD,
+			ActualCostUSD:       tryout.ActualCostUSD,
+			LatencyMS:           tryout.LatencyMS,
+			Summary:             tryout.Summary,
+			EventsURL:           fmt.Sprintf("/v1/workspaces/%s/agent-tryouts/%s/events", input.WorkspaceID, tryout.ID),
+		})
+	}
+	return AgentTryoutCompareResult{WorkspaceID: input.WorkspaceID, Participants: participants}, nil
+}
+
+// PromoteAgentTryoutInput requests promoting a tryout into a repeatable eval.
+type PromoteAgentTryoutInput struct {
+	SourceTryoutID uuid.UUID
+	Target         string
+	Title          string
+}
+
+// AgentTryoutPromotionResult references the durable workspace draft a promotion
+// produced.
+type AgentTryoutPromotionResult struct {
+	Target         string    `json:"target"`
+	ConversationID uuid.UUID `json:"conversation_id"`
+	DraftID        uuid.UUID `json:"draft_id"`
+}
+
+// PromoteTryoutToEval converts a completed workspace tryout into a durable
+// Vibe Eval draft, preserving its template/input/tool-policy/evaluation-spec and
+// the template's expected artifacts so the eval can be run again later. v1
+// supports only the "vibe_eval" target.
+func (m *AgentTryoutManager) PromoteTryoutToEval(ctx context.Context, caller Caller, input PromoteAgentTryoutInput) (AgentTryoutPromotionResult, error) {
+	target := strings.TrimSpace(input.Target)
+	if target == "" {
+		target = "vibe_eval"
+	}
+	if target != "vibe_eval" {
+		return AgentTryoutPromotionResult{}, fmt.Errorf("%w: %q", ErrAgentTryoutPromotionTargetUnsupported, target)
+	}
+
+	source, err := m.repo.GetAgentTryoutByID(ctx, input.SourceTryoutID)
+	if err != nil {
+		return AgentTryoutPromotionResult{}, err
+	}
+	if source.WorkspaceID == nil || source.OrganizationID == nil {
+		return AgentTryoutPromotionResult{}, ErrAgentTryoutSignInRequired
+	}
+	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, *source.WorkspaceID); err != nil {
+		return AgentTryoutPromotionResult{}, err
+	}
+
+	title := strings.TrimSpace(input.Title)
+	if title == "" {
+		title = fmt.Sprintf("Tryout: %s", source.TemplateSlug)
+	}
+	conversation, err := m.repo.CreateVibeEvalConversation(ctx, repository.CreateVibeEvalConversationParams{
+		OrganizationID:  *source.OrganizationID,
+		WorkspaceID:     *source.WorkspaceID,
+		CreatedByUserID: caller.UserID,
+		Title:           title,
+		Phase:           "plan",
+		Status:          "active",
+	})
+	if err != nil {
+		return AgentTryoutPromotionResult{}, err
+	}
+
+	content := promotionDraftContent(source)
+	draft, err := m.repo.CreateVibeEvalDraft(ctx, repository.CreateVibeEvalDraftParams{
+		OrganizationID:   *source.OrganizationID,
+		WorkspaceID:      *source.WorkspaceID,
+		ConversationID:   conversation.ID,
+		DraftKind:        "eval_plan",
+		Content:          content,
+		ValidationState:  "unknown",
+		ValidationErrors: json.RawMessage(`[]`),
+		CreatedByUserID:  caller.UserID,
+		UpdatedByUserID:  caller.UserID,
+	})
+	if err != nil {
+		return AgentTryoutPromotionResult{}, err
+	}
+	return AgentTryoutPromotionResult{Target: target, ConversationID: conversation.ID, DraftID: draft.ID}, nil
+}
+
+// promotionDraftContent packs a tryout's reusable definition into a Vibe Eval
+// draft body. It includes only the durable, workspace-owned definition (no run
+// ids, costs, or identifiers) so the draft is a clean starting point for a
+// repeatable eval.
+func promotionDraftContent(source repository.AgentTryout) json.RawMessage {
+	body := map[string]any{
+		"kind":                     "agent_tryout_promotion",
+		"source_tryout_id":         source.ID.String(),
+		"template_slug":            source.TemplateSlug,
+		"input_snapshot":           rawOrNull(source.InputSnapshot),
+		"tool_policy_snapshot":     rawOrNull(source.ToolPolicySnapshot),
+		"evaluation_spec_snapshot": rawOrNull(source.EvaluationSpecSnapshot),
+		"expected_artifacts":       templateExpectedArtifacts(source.TemplateSnapshot),
+	}
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		return json.RawMessage(`{}`)
+	}
+	return encoded
+}
+
+// templateExpectedArtifacts extracts runtime.expected_artifacts from a stored
+// template snapshot so the promoted eval records the expected outputs. Returns
+// an empty slice when none are declared.
+func templateExpectedArtifacts(templateSnapshot json.RawMessage) []map[string]any {
+	out := []map[string]any{}
+	if len(templateSnapshot) == 0 {
+		return out
+	}
+	var snapshot struct {
+		Runtime struct {
+			ExpectedArtifacts []map[string]any `json:"expected_artifacts"`
+		} `json:"runtime"`
+	}
+	if err := json.Unmarshal(templateSnapshot, &snapshot); err != nil {
+		return out
+	}
+	if snapshot.Runtime.ExpectedArtifacts != nil {
+		return snapshot.Runtime.ExpectedArtifacts
+	}
+	return out
+}
+
+// --- HTTP handlers ---
+
+type rerunAgentTryoutRequest struct {
+	SelectedModelPolicy json.RawMessage `json:"selected_model_policy"`
+}
+
+func rerunAgentTryoutHandler(logger *slog.Logger, service AgentTryoutService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		id, err := uuid.Parse(chi.URLParam(r, "tryoutID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_tryout_id", "tryout_id must be a UUID")
+			return
+		}
+		var req rerunAgentTryoutRequest
+		if err := decodeAgentTryoutJSON(r, &req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+			return
+		}
+		tryout, err := service.RerunWorkspaceTryout(r.Context(), caller, RerunAgentTryoutInput{
+			SourceTryoutID:      id,
+			SelectedModelPolicy: req.SelectedModelPolicy,
+		})
+		if err != nil {
+			writeAgentTryoutError(w, logger, err)
+			return
+		}
+		writeJSON(w, http.StatusCreated, mapAgentTryoutResponse(tryout))
+	}
+}
+
+type compareAgentTryoutsRequest struct {
+	TryoutIDs []uuid.UUID `json:"tryout_ids"`
+}
+
+func compareAgentTryoutsHandler(logger *slog.Logger, service AgentTryoutService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		workspaceID, err := uuid.Parse(chi.URLParam(r, "workspaceID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_workspace_id", "workspace_id must be a UUID")
+			return
+		}
+		var req compareAgentTryoutsRequest
+		if err := decodeAgentTryoutJSON(r, &req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+			return
+		}
+		result, err := service.CompareWorkspaceTryouts(r.Context(), caller, CompareAgentTryoutsInput{
+			WorkspaceID: workspaceID,
+			TryoutIDs:   req.TryoutIDs,
+		})
+		if err != nil {
+			writeAgentTryoutError(w, logger, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+type promoteAgentTryoutRequest struct {
+	Target string `json:"target"`
+	Title  string `json:"title"`
+}
+
+func promoteAgentTryoutHandler(logger *slog.Logger, service AgentTryoutService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		id, err := uuid.Parse(chi.URLParam(r, "tryoutID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_tryout_id", "tryout_id must be a UUID")
+			return
+		}
+		var req promoteAgentTryoutRequest
+		// The body is optional — an empty POST promotes to the default target.
+		if r.ContentLength != 0 {
+			if err := decodeAgentTryoutJSON(r, &req); err != nil {
+				writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+				return
+			}
+		}
+		result, err := service.PromoteTryoutToEval(r.Context(), caller, PromoteAgentTryoutInput{
+			SourceTryoutID: id,
+			Target:         req.Target,
+			Title:          req.Title,
+		})
+		if err != nil {
+			writeAgentTryoutError(w, logger, err)
+			return
+		}
+		writeJSON(w, http.StatusCreated, result)
+	}
+}
+
+func cloneRawJSON(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return json.RawMessage(`{}`)
+	}
+	cloned := make(json.RawMessage, len(raw))
+	copy(cloned, raw)
+	return cloned
+}
+
+func rawOrNull(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return json.RawMessage(`null`)
+	}
+	return raw
+}

--- a/backend/internal/api/agent_tryout_conversions_test.go
+++ b/backend/internal/api/agent_tryout_conversions_test.go
@@ -219,6 +219,27 @@ func TestAgentTryoutCompareRejectsCardinality(t *testing.T) {
 	if _, err := manager.CompareWorkspaceTryouts(ctx, callerWithWorkspace(workspaceID), CompareAgentTryoutsInput{WorkspaceID: workspaceID, TryoutIDs: five}); !errors.Is(err, ErrAgentTryoutCompareCardinality) {
 		t.Fatalf("five-id error = %v, want ErrAgentTryoutCompareCardinality", err)
 	}
+	// Duplicate ids must not slip past the bound by collapsing to one distinct id.
+	dup := []uuid.UUID{source.ID, source.ID}
+	if _, err := manager.CompareWorkspaceTryouts(ctx, callerWithWorkspace(workspaceID), CompareAgentTryoutsInput{WorkspaceID: workspaceID, TryoutIDs: dup}); !errors.Is(err, ErrAgentTryoutCompareCardinality) {
+		t.Fatalf("duplicate-id error = %v, want ErrAgentTryoutCompareCardinality", err)
+	}
+}
+
+func TestAgentTryoutPromoteRejectsNonCompleted(t *testing.T) {
+	ctx := context.Background()
+	orgID, workspaceID := uuid.New(), uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	source := seedWorkspaceTryout(repo, orgID, workspaceID, "tiny-bugfix")
+	// Force a still-running source.
+	running := repo.tryouts[source.ID]
+	running.Status = repository.AgentTryoutStatusRunning
+	repo.tryouts[source.ID] = running
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	if _, err := manager.PromoteTryoutToEval(ctx, callerWithWorkspace(workspaceID), PromoteAgentTryoutInput{SourceTryoutID: source.ID, Target: "vibe_eval"}); !errors.Is(err, ErrAgentTryoutNotPromotable) {
+		t.Fatalf("error = %v, want ErrAgentTryoutNotPromotable", err)
+	}
 }
 
 func TestAgentTryoutCompareRejectsCrossWorkspace(t *testing.T) {

--- a/backend/internal/api/agent_tryout_conversions_test.go
+++ b/backend/internal/api/agent_tryout_conversions_test.go
@@ -1,0 +1,293 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/agentclash/agentclash/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+func seedWorkspaceTryout(repo *fakeAgentTryoutRepository, orgID, workspaceID uuid.UUID, slug string) repository.AgentTryout {
+	id := uuid.New()
+	tryout := repository.AgentTryout{
+		ID:                     id,
+		OrganizationID:         &orgID,
+		WorkspaceID:            &workspaceID,
+		TemplateSlug:           slug,
+		Status:                 repository.AgentTryoutStatusCompleted,
+		RedactionStatus:        repository.AgentTryoutRedactionPassed,
+		InputSnapshot:          json.RawMessage(`{"task":"fix a nil check"}`),
+		TemplateSnapshot:       json.RawMessage(`{"slug":"` + slug + `","runtime":{"expected_artifacts":[{"key":"diff","type":"patch","path":"changes.patch"}]}}`),
+		ToolPolicySnapshot:     json.RawMessage(`{"tools":["file_editor"]}`),
+		EvaluationSpecSnapshot: json.RawMessage(`{"validators":[]}`),
+		SelectedModelPolicy:    json.RawMessage(`{"mode":"hosted_default","max_models":1}`),
+		Summary:                json.RawMessage(`{"verdict":"ready"}`),
+		CostLimitUSD:           0.75,
+		MaxDurationSeconds:     120,
+	}
+	repo.tryouts[id] = tryout
+	return tryout
+}
+
+func TestAgentTryoutRerunClonesSnapshotsWithNewModelPolicy(t *testing.T) {
+	ctx := context.Background()
+	orgID, workspaceID := uuid.New(), uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	source := seedWorkspaceTryout(repo, orgID, workspaceID, "tiny-bugfix")
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	policy := json.RawMessage(`{"mode":"hosted_default","models":[{"provider":"anthropic","model":"claude-opus-4-8"}]}`)
+	rerun, err := manager.RerunWorkspaceTryout(ctx, callerWithWorkspace(workspaceID), RerunAgentTryoutInput{
+		SourceTryoutID:      source.ID,
+		SelectedModelPolicy: policy,
+	})
+	if err != nil {
+		t.Fatalf("RerunWorkspaceTryout returned error: %v", err)
+	}
+	if rerun.ID == source.ID {
+		t.Fatalf("rerun must be a new tryout, got same id as source")
+	}
+	if rerun.ParentTryoutID == nil || *rerun.ParentTryoutID != source.ID {
+		t.Fatalf("rerun parent_tryout_id = %v, want %s", rerun.ParentTryoutID, source.ID)
+	}
+	if string(rerun.SelectedModelPolicy) != string(policy) {
+		t.Fatalf("rerun model policy = %s, want %s", rerun.SelectedModelPolicy, policy)
+	}
+	if string(rerun.InputSnapshot) != string(source.InputSnapshot) {
+		t.Fatalf("rerun should reuse source input; got %s", rerun.InputSnapshot)
+	}
+	if rerun.WorkspaceID == nil || *rerun.WorkspaceID != workspaceID {
+		t.Fatalf("rerun workspace = %v, want %s", rerun.WorkspaceID, workspaceID)
+	}
+	if rerun.Status != repository.AgentTryoutStatusQueued {
+		t.Fatalf("rerun status = %q, want queued", rerun.Status)
+	}
+	if rerun.RedactionStatus != repository.AgentTryoutRedactionPending {
+		t.Fatalf("rerun redaction = %q, want pending", rerun.RedactionStatus)
+	}
+}
+
+func TestAgentTryoutRerunRejectsAnonymousSource(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeAgentTryoutRepository(uuid.New(), uuid.New())
+	id := uuid.New()
+	repo.tryouts[id] = repository.AgentTryout{ID: id, TemplateSlug: "tiny-bugfix"} // no workspace
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	_, err := manager.RerunWorkspaceTryout(ctx, callerWithWorkspace(uuid.New()), RerunAgentTryoutInput{
+		SourceTryoutID:      id,
+		SelectedModelPolicy: json.RawMessage(`{"mode":"hosted_default"}`),
+	})
+	if !errors.Is(err, ErrAgentTryoutSignInRequired) {
+		t.Fatalf("error = %v, want ErrAgentTryoutSignInRequired", err)
+	}
+}
+
+func TestAgentTryoutRerunRejectsCrossWorkspace(t *testing.T) {
+	ctx := context.Background()
+	orgID, workspaceID := uuid.New(), uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	source := seedWorkspaceTryout(repo, orgID, workspaceID, "tiny-bugfix")
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	_, err := manager.RerunWorkspaceTryout(ctx, callerWithWorkspace(uuid.New()), RerunAgentTryoutInput{
+		SourceTryoutID:      source.ID,
+		SelectedModelPolicy: json.RawMessage(`{"mode":"hosted_default"}`),
+	})
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("error = %v, want ErrForbidden", err)
+	}
+}
+
+func TestAgentTryoutRerunValidatesModelPolicy(t *testing.T) {
+	ctx := context.Background()
+	orgID, workspaceID := uuid.New(), uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	source := seedWorkspaceTryout(repo, orgID, workspaceID, "tiny-bugfix")
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+	caller := callerWithWorkspace(workspaceID)
+
+	// Empty policy → invalid.
+	if _, err := manager.RerunWorkspaceTryout(ctx, caller, RerunAgentTryoutInput{SourceTryoutID: source.ID, SelectedModelPolicy: json.RawMessage(`{}`)}); !errors.Is(err, ErrAgentTryoutModelPolicyInvalid) {
+		t.Fatalf("empty policy error = %v, want ErrAgentTryoutModelPolicyInvalid", err)
+	}
+	// Unknown provider → unavailable.
+	if _, err := manager.RerunWorkspaceTryout(ctx, caller, RerunAgentTryoutInput{SourceTryoutID: source.ID, SelectedModelPolicy: json.RawMessage(`{"models":[{"provider":"acme","model":"x"}]}`)}); !errors.Is(err, ErrAgentTryoutModelUnavailable) {
+		t.Fatalf("unknown provider error = %v, want ErrAgentTryoutModelUnavailable", err)
+	}
+}
+
+type fakeRerunGate struct{ err error }
+
+func (g fakeRerunGate) AuthorizeRerun(context.Context, Caller, uuid.UUID, json.RawMessage) error {
+	return g.err
+}
+
+func TestAgentTryoutRerunGateDenial(t *testing.T) {
+	ctx := context.Background()
+	orgID, workspaceID := uuid.New(), uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	source := seedWorkspaceTryout(repo, orgID, workspaceID, "tiny-bugfix")
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo).
+		WithRerunGate(fakeRerunGate{err: ErrAgentTryoutRerunInsufficientCredits})
+
+	_, err := manager.RerunWorkspaceTryout(ctx, callerWithWorkspace(workspaceID), RerunAgentTryoutInput{
+		SourceTryoutID:      source.ID,
+		SelectedModelPolicy: json.RawMessage(`{"mode":"hosted_default"}`),
+	})
+	if !errors.Is(err, ErrAgentTryoutRerunInsufficientCredits) {
+		t.Fatalf("error = %v, want ErrAgentTryoutRerunInsufficientCredits", err)
+	}
+}
+
+func TestValidateTryoutModelPolicy(t *testing.T) {
+	cases := []struct {
+		name    string
+		policy  string
+		wantErr error
+	}{
+		{"valid mode", `{"mode":"hosted_default","max_models":1}`, nil},
+		{"valid explicit model", `{"models":[{"provider":"openai","model":"gpt-5"}]}`, nil},
+		{"empty object", `{}`, ErrAgentTryoutModelPolicyInvalid},
+		{"empty input", ``, ErrAgentTryoutModelPolicyInvalid},
+		{"null", `null`, ErrAgentTryoutModelPolicyInvalid},
+		{"not object", `[1,2]`, ErrAgentTryoutModelPolicyInvalid},
+		{"bad max_models", `{"mode":"x","max_models":0}`, ErrAgentTryoutModelPolicyInvalid},
+		{"unknown field", `{"mode":"x","bogus":true}`, ErrAgentTryoutModelPolicyInvalid},
+		{"unknown provider", `{"models":[{"provider":"acme","model":"x"}]}`, ErrAgentTryoutModelUnavailable},
+		{"missing model id", `{"models":[{"provider":"openai","model":""}]}`, ErrAgentTryoutModelPolicyInvalid},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateTryoutModelPolicy(json.RawMessage(tc.policy))
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestAgentTryoutCompareAggregatesParticipants(t *testing.T) {
+	ctx := context.Background()
+	orgID, workspaceID := uuid.New(), uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	t1 := seedWorkspaceTryout(repo, orgID, workspaceID, "tiny-bugfix")
+	t2 := seedWorkspaceTryout(repo, orgID, workspaceID, "meeting-minutes")
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	result, err := manager.CompareWorkspaceTryouts(ctx, callerWithWorkspace(workspaceID), CompareAgentTryoutsInput{
+		WorkspaceID: workspaceID,
+		TryoutIDs:   []uuid.UUID{t1.ID, t2.ID},
+	})
+	if err != nil {
+		t.Fatalf("CompareWorkspaceTryouts returned error: %v", err)
+	}
+	if len(result.Participants) != 2 {
+		t.Fatalf("participants = %d, want 2", len(result.Participants))
+	}
+	for _, p := range result.Participants {
+		if p.EventsURL == "" || !strings.Contains(p.EventsURL, p.ID.String()) {
+			t.Fatalf("participant %s missing events_url: %q", p.ID, p.EventsURL)
+		}
+		if len(p.SelectedModelPolicy) == 0 {
+			t.Fatalf("participant %s missing model policy", p.ID)
+		}
+	}
+}
+
+func TestAgentTryoutCompareRejectsCardinality(t *testing.T) {
+	ctx := context.Background()
+	orgID, workspaceID := uuid.New(), uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	source := seedWorkspaceTryout(repo, orgID, workspaceID, "tiny-bugfix")
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	if _, err := manager.CompareWorkspaceTryouts(ctx, callerWithWorkspace(workspaceID), CompareAgentTryoutsInput{WorkspaceID: workspaceID, TryoutIDs: []uuid.UUID{source.ID}}); !errors.Is(err, ErrAgentTryoutCompareCardinality) {
+		t.Fatalf("single-id error = %v, want ErrAgentTryoutCompareCardinality", err)
+	}
+	five := []uuid.UUID{uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()}
+	if _, err := manager.CompareWorkspaceTryouts(ctx, callerWithWorkspace(workspaceID), CompareAgentTryoutsInput{WorkspaceID: workspaceID, TryoutIDs: five}); !errors.Is(err, ErrAgentTryoutCompareCardinality) {
+		t.Fatalf("five-id error = %v, want ErrAgentTryoutCompareCardinality", err)
+	}
+}
+
+func TestAgentTryoutCompareRejectsCrossWorkspace(t *testing.T) {
+	ctx := context.Background()
+	orgID, workspaceID := uuid.New(), uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	mine := seedWorkspaceTryout(repo, orgID, workspaceID, "tiny-bugfix")
+	// A tryout owned by a different workspace.
+	otherWS := uuid.New()
+	other := seedWorkspaceTryout(repo, orgID, otherWS, "meeting-minutes")
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	_, err := manager.CompareWorkspaceTryouts(ctx, callerWithWorkspace(workspaceID), CompareAgentTryoutsInput{
+		WorkspaceID: workspaceID,
+		TryoutIDs:   []uuid.UUID{mine.ID, other.ID},
+	})
+	if !errors.Is(err, repository.ErrAgentTryoutNotFound) {
+		t.Fatalf("cross-workspace compare error = %v, want ErrAgentTryoutNotFound", err)
+	}
+}
+
+func TestAgentTryoutPromoteCreatesVibeEvalDraft(t *testing.T) {
+	ctx := context.Background()
+	orgID, workspaceID := uuid.New(), uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	source := seedWorkspaceTryout(repo, orgID, workspaceID, "tiny-bugfix")
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	result, err := manager.PromoteTryoutToEval(ctx, callerWithWorkspace(workspaceID), PromoteAgentTryoutInput{
+		SourceTryoutID: source.ID,
+		Target:         "vibe_eval",
+	})
+	if err != nil {
+		t.Fatalf("PromoteTryoutToEval returned error: %v", err)
+	}
+	if result.Target != "vibe_eval" || result.ConversationID == uuid.Nil || result.DraftID == uuid.Nil {
+		t.Fatalf("unexpected promotion result: %+v", result)
+	}
+	if repo.createdDraft.DraftKind != "eval_plan" {
+		t.Fatalf("draft kind = %q, want eval_plan", repo.createdDraft.DraftKind)
+	}
+	content := string(repo.createdDraft.Content)
+	for _, want := range []string{source.ID.String(), "tiny-bugfix", "expected_artifacts", "changes.patch", "evaluation_spec_snapshot"} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("promotion draft content missing %q: %s", want, content)
+		}
+	}
+}
+
+func TestAgentTryoutPromoteRejectsUnsupportedTarget(t *testing.T) {
+	ctx := context.Background()
+	orgID, workspaceID := uuid.New(), uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	source := seedWorkspaceTryout(repo, orgID, workspaceID, "tiny-bugfix")
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	if _, err := manager.PromoteTryoutToEval(ctx, callerWithWorkspace(workspaceID), PromoteAgentTryoutInput{SourceTryoutID: source.ID, Target: "challenge_pack"}); !errors.Is(err, ErrAgentTryoutPromotionTargetUnsupported) {
+		t.Fatalf("error = %v, want ErrAgentTryoutPromotionTargetUnsupported", err)
+	}
+}
+
+func TestAgentTryoutPromoteRejectsAnonymousSource(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeAgentTryoutRepository(uuid.New(), uuid.New())
+	id := uuid.New()
+	repo.tryouts[id] = repository.AgentTryout{ID: id, TemplateSlug: "tiny-bugfix"}
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo)
+
+	if _, err := manager.PromoteTryoutToEval(ctx, callerWithWorkspace(uuid.New()), PromoteAgentTryoutInput{SourceTryoutID: id, Target: "vibe_eval"}); !errors.Is(err, ErrAgentTryoutSignInRequired) {
+		t.Fatalf("error = %v, want ErrAgentTryoutSignInRequired", err)
+	}
+}

--- a/backend/internal/api/agent_tryouts.go
+++ b/backend/internal/api/agent_tryouts.go
@@ -37,6 +37,15 @@ var (
 	ErrAgentTryoutHostedSpendExhausted      = errors.New("agent tryout hosted spend exhausted")
 	ErrAgentTryoutCostCapExceeded           = errors.New("agent tryout cost cap exceeded")
 	ErrAgentTryoutRedactionNotReady         = errors.New("agent tryout redaction not ready")
+
+	// Conversion-flow errors (#947: rerun / compare / promote-to-eval).
+	ErrAgentTryoutSignInRequired              = errors.New("agent tryout sign-in required")
+	ErrAgentTryoutModelPolicyInvalid          = errors.New("agent tryout model policy invalid")
+	ErrAgentTryoutModelUnavailable            = errors.New("agent tryout model unavailable")
+	ErrAgentTryoutRerunProviderKeyRequired    = errors.New("agent tryout rerun provider key required")
+	ErrAgentTryoutRerunInsufficientCredits    = errors.New("agent tryout rerun insufficient credits")
+	ErrAgentTryoutCompareCardinality          = errors.New("agent tryout compare requires 2-4 tryouts")
+	ErrAgentTryoutPromotionTargetUnsupported  = errors.New("agent tryout promotion target unsupported")
 )
 
 type AgentTryoutRepository interface {
@@ -59,6 +68,8 @@ type AgentTryoutRepository interface {
 	ClaimAgentTryout(ctx context.Context, params repository.ClaimAgentTryoutParams) (repository.AgentTryout, error)
 	CreatePublicShareLink(ctx context.Context, params repository.CreatePublicShareLinkParams) (repository.PublicShareLink, error)
 	GetActivePublicShareLinkByKey(ctx context.Context, key string) (repository.PublicShareLink, error)
+	CreateVibeEvalConversation(ctx context.Context, params repository.CreateVibeEvalConversationParams) (repository.VibeEvalConversation, error)
+	CreateVibeEvalDraft(ctx context.Context, params repository.CreateVibeEvalDraftParams) (repository.VibeEvalDraft, error)
 }
 
 type AgentTryoutService interface {
@@ -73,6 +84,9 @@ type AgentTryoutService interface {
 	ListWorkspaceTryouts(ctx context.Context, caller Caller, workspaceID uuid.UUID, limit, offset int32) ([]repository.AgentTryout, error)
 	ClaimTryout(ctx context.Context, caller Caller, input ClaimAgentTryoutInput) (repository.AgentTryout, error)
 	CreatePrivateShare(ctx context.Context, caller Caller, id uuid.UUID) (CreateAgentTryoutShareResult, error)
+	RerunWorkspaceTryout(ctx context.Context, caller Caller, input RerunAgentTryoutInput) (repository.AgentTryout, error)
+	CompareWorkspaceTryouts(ctx context.Context, caller Caller, input CompareAgentTryoutsInput) (AgentTryoutCompareResult, error)
+	PromoteTryoutToEval(ctx context.Context, caller Caller, input PromoteAgentTryoutInput) (AgentTryoutPromotionResult, error)
 }
 
 type AgentTryoutTemplate struct {
@@ -140,6 +154,7 @@ type AgentTryoutManager struct {
 	templates  map[string]AgentTryoutTemplate
 	execution  *agentTryoutExecutionDispatcher
 	quota      *AgentTryoutQuotaConfig
+	rerunGate  AgentTryoutRerunGate
 }
 
 func NewAgentTryoutManager(authorizer WorkspaceAuthorizer, repo AgentTryoutRepository) *AgentTryoutManager {
@@ -913,6 +928,9 @@ func registerProtectedAgentTryoutRoutes(router chi.Router, logger *slog.Logger, 
 	router.Get("/workspaces/{workspaceID}/agent-tryouts/{tryoutID}/events", getWorkspaceAgentTryoutEventsHandler(logger, service))
 	router.Post("/agent-tryouts/{tryoutID}/claim", claimAgentTryoutHandler(logger, service))
 	router.Post("/agent-tryouts/{tryoutID}/share", createAgentTryoutShareHandler(logger, service))
+	router.Post("/agent-tryouts/{tryoutID}/rerun", rerunAgentTryoutHandler(logger, service))
+	router.Post("/agent-tryouts/{tryoutID}/promote-to-eval", promoteAgentTryoutHandler(logger, service))
+	router.Post("/workspaces/{workspaceID}/agent-tryouts/compare", compareAgentTryoutsHandler(logger, service))
 }
 
 func listAgentTryoutTemplatesHandler(logger *slog.Logger, service AgentTryoutService) http.HandlerFunc {
@@ -1260,6 +1278,20 @@ func writeAgentTryoutError(w http.ResponseWriter, logger *slog.Logger, err error
 		writeError(w, http.StatusConflict, "agent_tryout_already_claimed", "agent tryout is already claimed")
 	case errors.Is(err, ErrAgentTryoutRedactionNotReady):
 		writeError(w, http.StatusConflict, "agent_tryout_redaction_not_ready", "This tryout's evidence is still being redacted for safe sharing. Try again once it has finished.")
+	case errors.Is(err, ErrAgentTryoutSignInRequired):
+		writeError(w, http.StatusUnauthorized, "sign_in_required", "Sign in to rerun, compare, or promote tryouts.")
+	case errors.Is(err, ErrAgentTryoutModelPolicyInvalid):
+		writeError(w, http.StatusBadRequest, "invalid_model_policy", err.Error())
+	case errors.Is(err, ErrAgentTryoutModelUnavailable):
+		writeError(w, http.StatusUnprocessableEntity, "model_unavailable", err.Error())
+	case errors.Is(err, ErrAgentTryoutRerunProviderKeyRequired):
+		writeError(w, http.StatusPaymentRequired, "provider_key_required", "Connect a provider key for this model to rerun.")
+	case errors.Is(err, ErrAgentTryoutRerunInsufficientCredits):
+		writeError(w, http.StatusPaymentRequired, "insufficient_credits", "Not enough hosted credits to rerun. Add credits or connect a provider key.")
+	case errors.Is(err, ErrAgentTryoutCompareCardinality):
+		writeError(w, http.StatusBadRequest, "compare_cardinality", "Compare requires between 2 and 4 tryouts.")
+	case errors.Is(err, ErrAgentTryoutPromotionTargetUnsupported):
+		writeError(w, http.StatusBadRequest, "promotion_target_unsupported", err.Error())
 	case errors.Is(err, ErrInvalidAgentTryoutInput):
 		writeError(w, http.StatusBadRequest, "invalid_agent_tryout_input", err.Error())
 	case errors.Is(err, ErrForbidden):

--- a/backend/internal/api/agent_tryouts.go
+++ b/backend/internal/api/agent_tryouts.go
@@ -46,6 +46,7 @@ var (
 	ErrAgentTryoutRerunInsufficientCredits    = errors.New("agent tryout rerun insufficient credits")
 	ErrAgentTryoutCompareCardinality          = errors.New("agent tryout compare requires 2-4 tryouts")
 	ErrAgentTryoutPromotionTargetUnsupported  = errors.New("agent tryout promotion target unsupported")
+	ErrAgentTryoutNotPromotable               = errors.New("agent tryout is not completed")
 )
 
 type AgentTryoutRepository interface {
@@ -1292,6 +1293,8 @@ func writeAgentTryoutError(w http.ResponseWriter, logger *slog.Logger, err error
 		writeError(w, http.StatusBadRequest, "compare_cardinality", "Compare requires between 2 and 4 tryouts.")
 	case errors.Is(err, ErrAgentTryoutPromotionTargetUnsupported):
 		writeError(w, http.StatusBadRequest, "promotion_target_unsupported", err.Error())
+	case errors.Is(err, ErrAgentTryoutNotPromotable):
+		writeError(w, http.StatusConflict, "agent_tryout_not_promotable", "Only completed tryouts can be promoted to an eval.")
 	case errors.Is(err, ErrInvalidAgentTryoutInput):
 		writeError(w, http.StatusBadRequest, "invalid_agent_tryout_input", err.Error())
 	case errors.Is(err, ErrForbidden):

--- a/backend/internal/api/agent_tryouts_test.go
+++ b/backend/internal/api/agent_tryouts_test.go
@@ -921,8 +921,10 @@ type fakeAgentTryoutRepository struct {
 	countAnonymousErr  error
 	sumAnonymousErr    error
 	hostedSpendUSD     float64
-	runEvents          []repository.RunEvent
-	runEventsErr       error
+	runEvents           []repository.RunEvent
+	runEventsErr        error
+	createdConversation repository.CreateVibeEvalConversationParams
+	createdDraft        repository.CreateVibeEvalDraftParams
 }
 
 func newFakeAgentTryoutRepository(orgID, workspaceID uuid.UUID) *fakeAgentTryoutRepository {
@@ -981,6 +983,7 @@ func (r *fakeAgentTryoutRepository) CreateAgentTryout(_ context.Context, params 
 		MaxDurationSeconds:       params.MaxDurationSeconds,
 		AnonymousFingerprintHash: params.AnonymousFingerprintHash,
 		CreatedByUserID:          params.CreatedByUserID,
+		ParentTryoutID:           params.ParentTryoutID,
 		ExpiresAt:                params.ExpiresAt,
 		CreatedAt:                now,
 		UpdatedAt:                now,
@@ -1236,6 +1239,30 @@ func (r *fakeAgentTryoutRepository) GetActivePublicShareLinkByKey(_ context.Cont
 	return repository.PublicShareLink{}, repository.ErrPublicShareLinkNotFound
 }
 
+func (r *fakeAgentTryoutRepository) CreateVibeEvalConversation(_ context.Context, params repository.CreateVibeEvalConversationParams) (repository.VibeEvalConversation, error) {
+	r.createdConversation = params
+	return repository.VibeEvalConversation{
+		ID:             uuid.New(),
+		OrganizationID: params.OrganizationID,
+		WorkspaceID:    params.WorkspaceID,
+		Title:          params.Title,
+		Phase:          params.Phase,
+		Status:         params.Status,
+	}, nil
+}
+
+func (r *fakeAgentTryoutRepository) CreateVibeEvalDraft(_ context.Context, params repository.CreateVibeEvalDraftParams) (repository.VibeEvalDraft, error) {
+	r.createdDraft = params
+	return repository.VibeEvalDraft{
+		ID:             uuid.New(),
+		OrganizationID: params.OrganizationID,
+		WorkspaceID:    params.WorkspaceID,
+		ConversationID: params.ConversationID,
+		DraftKind:      params.DraftKind,
+		Content:        params.Content,
+	}, nil
+}
+
 type fakeAgentTryoutService struct {
 	tryout               repository.AgentTryout
 	templates            []AgentTryoutTemplate
@@ -1310,4 +1337,16 @@ func (s *fakeAgentTryoutService) ClaimTryout(context.Context, Caller, ClaimAgent
 
 func (s *fakeAgentTryoutService) CreatePrivateShare(context.Context, Caller, uuid.UUID) (CreateAgentTryoutShareResult, error) {
 	return CreateAgentTryoutShareResult{}, nil
+}
+
+func (s *fakeAgentTryoutService) RerunWorkspaceTryout(context.Context, Caller, RerunAgentTryoutInput) (repository.AgentTryout, error) {
+	return repository.AgentTryout{}, nil
+}
+
+func (s *fakeAgentTryoutService) CompareWorkspaceTryouts(context.Context, Caller, CompareAgentTryoutsInput) (AgentTryoutCompareResult, error) {
+	return AgentTryoutCompareResult{}, nil
+}
+
+func (s *fakeAgentTryoutService) PromoteTryoutToEval(context.Context, Caller, PromoteAgentTryoutInput) (AgentTryoutPromotionResult, error) {
+	return AgentTryoutPromotionResult{}, nil
 }

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -452,6 +452,18 @@ func (noopAgentTryoutService) GetSharedTryoutEvents(context.Context, string, Try
 	return AgentTryoutEventsResult{}, errors.New("agent tryout service is not configured")
 }
 
+func (noopAgentTryoutService) RerunWorkspaceTryout(context.Context, Caller, RerunAgentTryoutInput) (repository.AgentTryout, error) {
+	return repository.AgentTryout{}, errors.New("agent tryout service is not configured")
+}
+
+func (noopAgentTryoutService) CompareWorkspaceTryouts(context.Context, Caller, CompareAgentTryoutsInput) (AgentTryoutCompareResult, error) {
+	return AgentTryoutCompareResult{}, errors.New("agent tryout service is not configured")
+}
+
+func (noopAgentTryoutService) PromoteTryoutToEval(context.Context, Caller, PromoteAgentTryoutInput) (AgentTryoutPromotionResult, error) {
+	return AgentTryoutPromotionResult{}, errors.New("agent tryout service is not configured")
+}
+
 func (noopAgentTryoutService) GetWorkspaceTryoutEvents(context.Context, Caller, uuid.UUID, TryoutEventsCursor) (AgentTryoutEventsResult, error) {
 	return AgentTryoutEventsResult{}, errors.New("agent tryout service is not configured")
 }

--- a/backend/internal/repository/agent_tryouts.go
+++ b/backend/internal/repository/agent_tryouts.go
@@ -61,6 +61,7 @@ type AgentTryout struct {
 	MaxDurationSeconds       int32
 	AnonymousFingerprintHash *string
 	CreatedByUserID          *uuid.UUID
+	ParentTryoutID           *uuid.UUID
 	ClaimedByUserID          *uuid.UUID
 	ClaimedAt                *time.Time
 	ExpiresAt                *time.Time
@@ -87,6 +88,7 @@ type CreateAgentTryoutParams struct {
 	MaxDurationSeconds       int32
 	AnonymousFingerprintHash *string
 	CreatedByUserID          *uuid.UUID
+	ParentTryoutID           *uuid.UUID
 	ExpiresAt                *time.Time
 }
 
@@ -153,6 +155,7 @@ func createAgentTryout(ctx context.Context, queries *repositorysqlc.Queries, par
 		MaxDurationSeconds:       params.MaxDurationSeconds,
 		AnonymousFingerprintHash: cloneStringPtr(params.AnonymousFingerprintHash),
 		CreatedByUserID:          cloneUUIDPtr(params.CreatedByUserID),
+		ParentTryoutID:           cloneUUIDPtr(params.ParentTryoutID),
 		ExpiresAt:                toPGTimestamp(params.ExpiresAt),
 	})
 	if err != nil {
@@ -572,6 +575,7 @@ func mapAgentTryout(row repositorysqlc.AgentTryout) (AgentTryout, error) {
 		MaxDurationSeconds:       row.MaxDurationSeconds,
 		AnonymousFingerprintHash: cloneStringPtr(row.AnonymousFingerprintHash),
 		CreatedByUserID:          cloneUUIDPtr(row.CreatedByUserID),
+		ParentTryoutID:           cloneUUIDPtr(row.ParentTryoutID),
 		ClaimedByUserID:          cloneUUIDPtr(row.ClaimedByUserID),
 		ClaimedAt:                optionalTime(row.ClaimedAt),
 		ExpiresAt:                optionalTime(row.ExpiresAt),

--- a/backend/internal/repository/agent_tryouts_integration_test.go
+++ b/backend/internal/repository/agent_tryouts_integration_test.go
@@ -79,6 +79,59 @@ func TestRepositoryAgentTryoutAnonymousQuotaLedger(t *testing.T) {
 	}
 }
 
+func TestRepositoryCreateAgentTryoutWithParent(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	fixture := seedFixture(t, ctx, db)
+	repo := repository.New(db)
+
+	base := func() repository.CreateAgentTryoutParams {
+		return repository.CreateAgentTryoutParams{
+			OrganizationID:         &fixture.organizationID,
+			WorkspaceID:            &fixture.workspaceID,
+			TemplateSlug:           "meeting-minutes",
+			Status:                 repository.AgentTryoutStatusCompleted,
+			InputSnapshot:          []byte(`{"notes":"original"}`),
+			TemplateSnapshot:       []byte(`{"slug":"meeting-minutes"}`),
+			ToolPolicySnapshot:     []byte(`{"tools":[]}`),
+			EvaluationSpecSnapshot: []byte(`{"validators":[]}`),
+			SelectedModelPolicy:    []byte(`{"mode":"hosted_default"}`),
+			Summary:                []byte(`{}`),
+			RedactionStatus:        repository.AgentTryoutRedactionPassed,
+			CostLimitUSD:           0.25,
+			MaxDurationSeconds:     120,
+			CreatedByUserID:        &fixture.userID,
+		}
+	}
+
+	parent, err := repo.CreateAgentTryout(ctx, base())
+	if err != nil {
+		t.Fatalf("create parent tryout: %v", err)
+	}
+	if parent.ParentTryoutID != nil {
+		t.Fatalf("original tryout should have nil parent, got %v", parent.ParentTryoutID)
+	}
+
+	childParams := base()
+	childParams.SelectedModelPolicy = []byte(`{"mode":"hosted_default","models":[{"provider":"anthropic","model":"claude-opus-4-8"}]}`)
+	childParams.ParentTryoutID = &parent.ID
+	child, err := repo.CreateAgentTryout(ctx, childParams)
+	if err != nil {
+		t.Fatalf("create child (rerun) tryout: %v", err)
+	}
+	if child.ParentTryoutID == nil || *child.ParentTryoutID != parent.ID {
+		t.Fatalf("child parent_tryout_id = %v, want %s", child.ParentTryoutID, parent.ID)
+	}
+
+	reloaded, err := repo.GetAgentTryoutByID(ctx, child.ID)
+	if err != nil {
+		t.Fatalf("reload child: %v", err)
+	}
+	if reloaded.ParentTryoutID == nil || *reloaded.ParentTryoutID != parent.ID {
+		t.Fatalf("reloaded parent_tryout_id = %v, want %s", reloaded.ParentTryoutID, parent.ID)
+	}
+}
+
 func TestRepositoryExpireAnonymousAgentTryouts(t *testing.T) {
 	ctx := context.Background()
 	db := openTestDB(t)

--- a/backend/internal/repository/sqlc/agent_tryouts.sql.go
+++ b/backend/internal/repository/sqlc/agent_tryouts.sql.go
@@ -25,7 +25,7 @@ WHERE id = $5
   AND organization_id IS NULL
   AND workspace_id IS NULL
   AND claimed_by_user_id IS NULL
-RETURNING id, organization_id, workspace_id, template_slug, status, input_snapshot, template_snapshot, tool_policy_snapshot, evaluation_spec_snapshot, selected_model_policy, summary, redaction_status, run_id, cost_limit_usd, actual_cost_usd, latency_ms, max_duration_seconds, anonymous_fingerprint_hash, created_by_user_id, claimed_by_user_id, claimed_at, expires_at, created_at, updated_at
+RETURNING id, organization_id, workspace_id, template_slug, status, input_snapshot, template_snapshot, tool_policy_snapshot, evaluation_spec_snapshot, selected_model_policy, summary, redaction_status, run_id, cost_limit_usd, actual_cost_usd, latency_ms, max_duration_seconds, anonymous_fingerprint_hash, created_by_user_id, claimed_by_user_id, claimed_at, expires_at, created_at, updated_at, parent_tryout_id
 `
 
 type ClaimAgentTryoutParams struct {
@@ -70,6 +70,7 @@ func (q *Queries) ClaimAgentTryout(ctx context.Context, arg ClaimAgentTryoutPara
 		&i.ExpiresAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ParentTryoutID,
 	)
 	return i, err
 }
@@ -94,6 +95,7 @@ INSERT INTO agent_tryouts (
     max_duration_seconds,
     anonymous_fingerprint_hash,
     created_by_user_id,
+    parent_tryout_id,
     expires_at
 )
 VALUES (
@@ -115,9 +117,10 @@ VALUES (
     $16,
     $17,
     $18,
-    $19
+    $19,
+    $20
 )
-RETURNING id, organization_id, workspace_id, template_slug, status, input_snapshot, template_snapshot, tool_policy_snapshot, evaluation_spec_snapshot, selected_model_policy, summary, redaction_status, run_id, cost_limit_usd, actual_cost_usd, latency_ms, max_duration_seconds, anonymous_fingerprint_hash, created_by_user_id, claimed_by_user_id, claimed_at, expires_at, created_at, updated_at
+RETURNING id, organization_id, workspace_id, template_slug, status, input_snapshot, template_snapshot, tool_policy_snapshot, evaluation_spec_snapshot, selected_model_policy, summary, redaction_status, run_id, cost_limit_usd, actual_cost_usd, latency_ms, max_duration_seconds, anonymous_fingerprint_hash, created_by_user_id, claimed_by_user_id, claimed_at, expires_at, created_at, updated_at, parent_tryout_id
 `
 
 type CreateAgentTryoutParams struct {
@@ -139,6 +142,7 @@ type CreateAgentTryoutParams struct {
 	MaxDurationSeconds       int32
 	AnonymousFingerprintHash *string
 	CreatedByUserID          *uuid.UUID
+	ParentTryoutID           *uuid.UUID
 	ExpiresAt                pgtype.Timestamptz
 }
 
@@ -162,6 +166,7 @@ func (q *Queries) CreateAgentTryout(ctx context.Context, arg CreateAgentTryoutPa
 		arg.MaxDurationSeconds,
 		arg.AnonymousFingerprintHash,
 		arg.CreatedByUserID,
+		arg.ParentTryoutID,
 		arg.ExpiresAt,
 	)
 	var i AgentTryout
@@ -190,12 +195,13 @@ func (q *Queries) CreateAgentTryout(ctx context.Context, arg CreateAgentTryoutPa
 		&i.ExpiresAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ParentTryoutID,
 	)
 	return i, err
 }
 
 const getAgentTryoutByID = `-- name: GetAgentTryoutByID :one
-SELECT id, organization_id, workspace_id, template_slug, status, input_snapshot, template_snapshot, tool_policy_snapshot, evaluation_spec_snapshot, selected_model_policy, summary, redaction_status, run_id, cost_limit_usd, actual_cost_usd, latency_ms, max_duration_seconds, anonymous_fingerprint_hash, created_by_user_id, claimed_by_user_id, claimed_at, expires_at, created_at, updated_at
+SELECT id, organization_id, workspace_id, template_slug, status, input_snapshot, template_snapshot, tool_policy_snapshot, evaluation_spec_snapshot, selected_model_policy, summary, redaction_status, run_id, cost_limit_usd, actual_cost_usd, latency_ms, max_duration_seconds, anonymous_fingerprint_hash, created_by_user_id, claimed_by_user_id, claimed_at, expires_at, created_at, updated_at, parent_tryout_id
 FROM agent_tryouts
 WHERE id = $1
 LIMIT 1
@@ -233,12 +239,13 @@ func (q *Queries) GetAgentTryoutByID(ctx context.Context, arg GetAgentTryoutByID
 		&i.ExpiresAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ParentTryoutID,
 	)
 	return i, err
 }
 
 const listAgentTryoutsByWorkspaceID = `-- name: ListAgentTryoutsByWorkspaceID :many
-SELECT id, organization_id, workspace_id, template_slug, status, input_snapshot, template_snapshot, tool_policy_snapshot, evaluation_spec_snapshot, selected_model_policy, summary, redaction_status, run_id, cost_limit_usd, actual_cost_usd, latency_ms, max_duration_seconds, anonymous_fingerprint_hash, created_by_user_id, claimed_by_user_id, claimed_at, expires_at, created_at, updated_at
+SELECT id, organization_id, workspace_id, template_slug, status, input_snapshot, template_snapshot, tool_policy_snapshot, evaluation_spec_snapshot, selected_model_policy, summary, redaction_status, run_id, cost_limit_usd, actual_cost_usd, latency_ms, max_duration_seconds, anonymous_fingerprint_hash, created_by_user_id, claimed_by_user_id, claimed_at, expires_at, created_at, updated_at, parent_tryout_id
 FROM agent_tryouts
 WHERE workspace_id = $1
 ORDER BY created_at DESC
@@ -285,6 +292,7 @@ func (q *Queries) ListAgentTryoutsByWorkspaceID(ctx context.Context, arg ListAge
 			&i.ExpiresAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.ParentTryoutID,
 		); err != nil {
 			return nil, err
 		}
@@ -300,7 +308,7 @@ const setAgentTryoutRunID = `-- name: SetAgentTryoutRunID :one
 UPDATE agent_tryouts
 SET run_id = $1
 WHERE id = $2
-RETURNING id, organization_id, workspace_id, template_slug, status, input_snapshot, template_snapshot, tool_policy_snapshot, evaluation_spec_snapshot, selected_model_policy, summary, redaction_status, run_id, cost_limit_usd, actual_cost_usd, latency_ms, max_duration_seconds, anonymous_fingerprint_hash, created_by_user_id, claimed_by_user_id, claimed_at, expires_at, created_at, updated_at
+RETURNING id, organization_id, workspace_id, template_slug, status, input_snapshot, template_snapshot, tool_policy_snapshot, evaluation_spec_snapshot, selected_model_policy, summary, redaction_status, run_id, cost_limit_usd, actual_cost_usd, latency_ms, max_duration_seconds, anonymous_fingerprint_hash, created_by_user_id, claimed_by_user_id, claimed_at, expires_at, created_at, updated_at, parent_tryout_id
 `
 
 type SetAgentTryoutRunIDParams struct {
@@ -336,6 +344,7 @@ func (q *Queries) SetAgentTryoutRunID(ctx context.Context, arg SetAgentTryoutRun
 		&i.ExpiresAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ParentTryoutID,
 	)
 	return i, err
 }
@@ -349,7 +358,7 @@ SET
     latency_ms = COALESCE($4, latency_ms),
     redaction_status = COALESCE($5, redaction_status)
 WHERE id = $6
-RETURNING id, organization_id, workspace_id, template_slug, status, input_snapshot, template_snapshot, tool_policy_snapshot, evaluation_spec_snapshot, selected_model_policy, summary, redaction_status, run_id, cost_limit_usd, actual_cost_usd, latency_ms, max_duration_seconds, anonymous_fingerprint_hash, created_by_user_id, claimed_by_user_id, claimed_at, expires_at, created_at, updated_at
+RETURNING id, organization_id, workspace_id, template_slug, status, input_snapshot, template_snapshot, tool_policy_snapshot, evaluation_spec_snapshot, selected_model_policy, summary, redaction_status, run_id, cost_limit_usd, actual_cost_usd, latency_ms, max_duration_seconds, anonymous_fingerprint_hash, created_by_user_id, claimed_by_user_id, claimed_at, expires_at, created_at, updated_at, parent_tryout_id
 `
 
 type UpdateAgentTryoutStatusParams struct {
@@ -396,6 +405,7 @@ func (q *Queries) UpdateAgentTryoutStatus(ctx context.Context, arg UpdateAgentTr
 		&i.ExpiresAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ParentTryoutID,
 	)
 	return i, err
 }

--- a/backend/internal/repository/sqlc/models.go
+++ b/backend/internal/repository/sqlc/models.go
@@ -94,6 +94,7 @@ type AgentTryout struct {
 	ExpiresAt                pgtype.Timestamptz
 	CreatedAt                pgtype.Timestamptz
 	UpdatedAt                pgtype.Timestamptz
+	ParentTryoutID           *uuid.UUID
 }
 
 type BillingAccount struct {

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -5436,6 +5436,128 @@ paths:
         "409":
           $ref: "#/components/responses/ConflictError"
 
+  /v1/agent-tryouts/{id}/rerun:
+    post:
+      operationId: rerunAgentTryout
+      summary: Rerun a workspace tryout with a different model policy
+      description: >-
+        Creates a new tryout that reuses the source tryout's template and input
+        but runs under a different model policy, linked to the source via
+        `parent_tryout_id`. The source is never mutated. Anonymous/unclaimed
+        source tryouts return a sign-in-required error; an invalid model policy
+        or an unavailable provider/model returns a product error.
+      tags: [AgentTryouts]
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/ResourceID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RerunAgentTryoutRequest"
+      responses:
+        "201":
+          description: Rerun tryout queued
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentTryoutResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "402":
+          description: Provider key required or insufficient credits to rerun.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "422":
+          description: The requested model/provider is unavailable.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+
+  /v1/agent-tryouts/{id}/promote-to-eval:
+    post:
+      operationId: promoteAgentTryoutToEval
+      summary: Promote a workspace tryout into a repeatable eval draft
+      description: >-
+        Converts a completed workspace tryout into a durable Vibe Eval draft,
+        preserving its template, input, tool policy, evaluation spec, and the
+        template's expected artifacts so the eval can be run again later. v1
+        supports only the `vibe_eval` target; any other target returns 400. The
+        request body is optional (an empty POST uses the default target).
+      tags: [AgentTryouts]
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/ResourceID"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PromoteAgentTryoutRequest"
+      responses:
+        "201":
+          description: Promotion draft created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentTryoutPromotionResult"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
+  /v1/workspaces/{workspaceID}/agent-tryouts/compare:
+    post:
+      operationId: compareAgentTryouts
+      summary: Compare 2-4 workspace tryouts side by side
+      description: >-
+        Returns a read-only side-by-side comparison of 2–4 tryouts that all
+        belong to the workspace: per-tryout model policy, status, cost, latency,
+        summary, and a link to the full event evidence. Any id outside the
+        workspace fails closed as not-found.
+      tags: [AgentTryouts]
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CompareAgentTryoutsRequest"
+      responses:
+        "200":
+          description: Side-by-side comparison
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentTryoutCompareResult"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
   /v1/workspaces/{workspaceID}/playgrounds:
     post:
       operationId: createPlayground
@@ -13071,6 +13193,107 @@ components:
           $ref: "#/components/schemas/AgentTryoutShareLink"
         token:
           type: string
+
+    RerunAgentTryoutRequest:
+      type: object
+      required: [selected_model_policy]
+      properties:
+        selected_model_policy:
+          type: object
+          additionalProperties: true
+          description: >-
+            The model policy to rerun under. Must set a `mode` or at least one
+            explicit `models[]` entry; explicit models must name a known
+            provider.
+
+    PromoteAgentTryoutRequest:
+      type: object
+      properties:
+        target:
+          type: string
+          enum: [vibe_eval]
+          default: vibe_eval
+          description: Promotion target. Only `vibe_eval` is supported in v1.
+        title:
+          type: string
+          description: Optional title for the created draft conversation.
+
+    AgentTryoutPromotionResult:
+      type: object
+      required: [target, conversation_id, draft_id]
+      properties:
+        target:
+          type: string
+        conversation_id:
+          type: string
+          format: uuid
+        draft_id:
+          type: string
+          format: uuid
+
+    CompareAgentTryoutsRequest:
+      type: object
+      required: [tryout_ids]
+      properties:
+        tryout_ids:
+          type: array
+          minItems: 2
+          maxItems: 4
+          items:
+            type: string
+            format: uuid
+
+    AgentTryoutCompareParticipant:
+      type: object
+      required: [id, template_slug, status, redaction_status, selected_model_policy, cost_limit_usd, summary, events_url]
+      properties:
+        id:
+          type: string
+          format: uuid
+        template_slug:
+          type: string
+        status:
+          type: string
+          enum: [queued, running, completed, failed, cancelled]
+        redaction_status:
+          type: string
+          enum: [pending, passed, failed, not_required]
+        selected_model_policy:
+          type: object
+          additionalProperties: true
+        run_id:
+          type: string
+          format: uuid
+        parent_tryout_id:
+          type: string
+          format: uuid
+        cost_limit_usd:
+          type: number
+          format: double
+        actual_cost_usd:
+          type: number
+          format: double
+        latency_ms:
+          type: integer
+          format: int64
+        summary:
+          type: object
+          additionalProperties: true
+        events_url:
+          type: string
+          description: Link to the workspace events timeline for full evidence.
+
+    AgentTryoutCompareResult:
+      type: object
+      required: [workspace_id, participants]
+      properties:
+        workspace_id:
+          type: string
+          format: uuid
+        participants:
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentTryoutCompareParticipant"
 
     # --- Playgrounds ---
 

--- a/testing/feat-agent-tryout-rerun-compare-promote.md
+++ b/testing/feat-agent-tryout-rerun-compare-promote.md
@@ -1,0 +1,116 @@
+# feat/agent-tryout-rerun-compare-promote — Test Contract
+
+Implements issue #947 (build order 6 of 6 under epic #940): rerun, compare, and
+promote-to-eval conversion flows for Agent Tryouts. Locked before implementation.
+
+## Scope decisions (v1)
+
+- **Rerun lineage** is tracked with a new nullable `agent_tryouts.parent_tryout_id`.
+- **Compare** is a read-time aggregation over 2–4 workspace tryouts (no new
+  persistence) — reruns are immutable evidence, so compare never mutates them.
+- **Promote-to-eval** targets a **Vibe Eval draft** (the lowest-friction durable
+  workspace draft). `vibe_eval` is the only supported target in v1; any other
+  target returns a stable product error.
+- **Billing/provider enforcement** is an optional injected gate
+  (`AgentTryoutRerunGate`, mirroring `WithExecution`/`WithQuota`). When configured
+  and it denies, rerun returns a product-facing error; when unconfigured, rerun
+  proceeds (dev/default), consistent with existing optional-service wiring.
+
+## Functional Behavior
+
+### Rerun — `POST /v1/agent-tryouts/{tryoutID}/rerun`
+- Auth: signed-in workspace caller. Body: `{ "selected_model_policy": {...} }`.
+- Loads the source tryout; authorizes the caller against the source tryout's
+  workspace.
+- Anonymous/unclaimed source tryout (no workspace) → `401`-class sign-in-required
+  product error (`ErrAgentTryoutSignInRequired`).
+- Cross-workspace caller → `403` (ErrForbidden via AuthorizeWorkspace).
+- Validates the requested model policy. Invalid shape → `400`
+  (`ErrAgentTryoutModelPolicyInvalid`). Unknown provider/model →
+  `422`/`400` (`ErrAgentTryoutModelUnavailable`).
+- Optional rerun gate denial → product error (provider key required / insufficient
+  credits) mapped to `402`/`403`/`429`.
+- On success: creates a NEW tryout that clones the source's `template_slug`,
+  `InputSnapshot`, `TemplateSnapshot`, `ToolPolicySnapshot`,
+  `EvaluationSpecSnapshot`, `CostLimitUSD`, `MaxDurationSeconds`, sets
+  `SelectedModelPolicy` to the requested policy, `ParentTryoutID` = source id,
+  `RedactionStatus = pending`, `Status = queued`, same workspace/org. Dispatches
+  via the existing execution path. Returns the new tryout (201).
+- The rerun is independent immutable evidence — it does not mutate the source.
+
+### Compare — `POST /v1/workspaces/{workspaceID}/agent-tryouts/compare`
+- Auth: signed-in workspace member. Body: `{ "tryout_ids": ["...", "..."] }`.
+- Requires 2–4 ids → otherwise `400` (`ErrAgentTryoutCompareCardinality`).
+- Every id must belong to `{workspaceID}`; any id in another workspace or missing
+  → `404` (not found) / `403`. (Fail closed; don't leak existence cross-workspace.)
+- Returns a side-by-side payload: per tryout `{ id, template_slug,
+  selected_model_policy, status, redaction_status, run_id, cost_limit_usd,
+  actual_cost_usd, latency_ms, summary, events_url }`. `events_url` links to the
+  workspace events endpoint for full evidence.
+
+### Promote-to-eval — `POST /v1/agent-tryouts/{tryoutID}/promote-to-eval`
+- Auth: signed-in workspace caller. Body: `{ "target": "vibe_eval", "title": "..." (optional) }`.
+- Anonymous/unclaimed source → sign-in-required product error.
+- Cross-workspace caller → `403`.
+- Unsupported target (anything != `vibe_eval`) → `400`
+  (`ErrAgentTryoutPromotionTargetUnsupported`).
+- On success: creates a Vibe Eval conversation + an `eval_plan` draft whose content
+  captures `source_tryout_id`, `template_slug`, `input_snapshot`,
+  `tool_policy_snapshot`, `evaluation_spec_snapshot`, and the template's
+  `expected_artifacts`. Returns `{ conversation_id, draft_id, target }` (201).
+- The draft is durable workspace data with enough to re-run later.
+
+## Unit Tests (api package, fake repo)
+- `TestAgentTryoutRerunClonesSnapshotsWithNewModelPolicy` — new tryout clones
+  source snapshots, overrides model policy, sets parent_tryout_id, dispatches.
+- `TestAgentTryoutRerunRejectsAnonymousSource` — unclaimed/anonymous source →
+  ErrAgentTryoutSignInRequired.
+- `TestAgentTryoutRerunRejectsCrossWorkspace` — non-member caller → ErrForbidden.
+- `TestAgentTryoutRerunValidatesModelPolicy` — invalid policy →
+  ErrAgentTryoutModelPolicyInvalid; unknown provider → ErrAgentTryoutModelUnavailable.
+- `TestAgentTryoutRerunGateDenial` — injected gate denial → mapped product error.
+- `TestAgentTryoutCompareAggregatesParticipants` — 2–4 tryouts → per-tryout fields
+  present; events_url populated.
+- `TestAgentTryoutCompareRejectsCardinality` — <2 or >4 ids → ErrAgentTryoutCompareCardinality.
+- `TestAgentTryoutCompareRejectsCrossWorkspace` — id in another workspace → not found/forbidden.
+- `TestAgentTryoutPromoteCreatesVibeEvalDraft` — creates conversation + eval_plan
+  draft with snapshot content.
+- `TestAgentTryoutPromoteRejectsUnsupportedTarget` — bad target →
+  ErrAgentTryoutPromotionTargetUnsupported.
+- `TestAgentTryoutPromoteRejectsAnonymousSource` — anonymous source → sign-in-required.
+- `TestValidateTryoutModelPolicy` — table-driven: valid/invalid shapes, unknown providers.
+- Handler-level: rerun/compare/promote return correct HTTP status codes for each error.
+
+## Integration / Functional Tests (repository, DB-gated)
+- `TestRepositoryCreateAgentTryoutWithParent` — create a tryout with
+  `ParentTryoutID` set; round-trips and `GetAgentTryoutByID` returns it.
+- (Rerun creating a linked tryout is exercised at the manager level with the fake
+  repo asserting parent linkage + dispatch; full DB round-trip of parent linkage
+  is covered by the repo test above.)
+
+## Smoke Tests
+- `go build ./...`, `go vet ./...`, `go test -short -race ./internal/api/... ./internal/repository/...` pass.
+- `sqlc generate` produces no unexpected diff beyond the new query/column.
+
+## E2E Tests
+- N/A for this backend PR — covered by the frontend conversion flows separately.
+
+## Manual / cURL Tests (against a local stack)
+```bash
+# Rerun with a different model policy
+curl -sX POST "$API/v1/agent-tryouts/$TRYOUT/rerun" -H "Authorization: Bearer $JWT" \
+  -d '{"selected_model_policy":{"mode":"hosted_default","max_models":1}}'
+# Compare 2 tryouts
+curl -sX POST "$API/v1/workspaces/$WS/agent-tryouts/compare" -H "Authorization: Bearer $JWT" \
+  -d '{"tryout_ids":["'$T1'","'$T2'"]}'
+# Promote to a Vibe Eval draft
+curl -sX POST "$API/v1/agent-tryouts/$TRYOUT/promote-to-eval" -H "Authorization: Bearer $JWT" \
+  -d '{"target":"vibe_eval"}'
+# Anonymous (no auth) → sign-in-required
+curl -sX POST "$API/v1/agent-tryouts/$TRYOUT/rerun" -d '{"selected_model_policy":{}}'
+```
+
+## OpenAPI
+- New paths: rerun, compare, promote-to-eval, with request/response schemas and
+  the new error responses (sign-in-required, model unavailable, unsupported target,
+  compare cardinality).


### PR DESCRIPTION
Closes #947. Build order 6 of 6 (final) under the Agent Tryouts epic (#940), on top of #946.

Adds the post-tryout conversion actions that make AgentClash valuable for teams: **rerun with another model**, **compare**, and **promote a one-off tryout into a repeatable eval**.

Implemented with the **review-checkpoint** workflow — the test contract (`testing/feat-agent-tryout-rerun-compare-promote.md`) was committed first, each step was self- and cumulative-reviewed against it, and the final verdict was `ready` before this PR was opened.

## What this adds

### Rerun — `POST /v1/agent-tryouts/{id}/rerun`
Creates a new tryout that reuses the source's template + input but runs under a different model policy, linked via a new `agent_tryouts.parent_tryout_id`. The source is never mutated (immutable evidence). Anonymous/unclaimed source → sign-in-required; cross-workspace → forbidden; invalid policy → 400; unknown provider/model → 422. An optional, injected `AgentTryoutRerunGate` (mirrors `WithExecution`/`WithQuota`) enforces billing/provider entitlements and surfaces provider-key-required / insufficient-credits product errors (402).

### Compare — `POST /v1/workspaces/{workspaceID}/agent-tryouts/compare`
Read-only side-by-side aggregation of 2–4 workspace tryouts: per-tryout model policy, status, cost, latency, summary, and a link to the full event evidence. Requires 2–4 ids; any id outside the workspace fails closed as not-found.

### Promote-to-eval — `POST /v1/agent-tryouts/{id}/promote-to-eval`
Converts a completed workspace tryout into a durable **Vibe Eval draft** (conversation + `eval_plan` draft) preserving the template, input, tool policy, evaluation spec, and the template's expected artifacts — enough to run again later. `vibe_eval` is the only v1 target; others return a product error. (Vibe Eval is the lowest-friction durable workspace draft; challenge-pack / regression-suite promotion can build on it later.)

## Acceptance criteria
- ✅ Signed-in users rerun a claimed/workspace tryout with a different model policy.
- ✅ Reruns inherit the original template/input but create new immutable evidence (parent-linked).
- ✅ Compare payload includes per-model policy, status, cost, latency, summary, and evidence links.
- ✅ Promotion creates a durable workspace draft with enough data to run again.
- ✅ Anonymous users hitting rerun/compare/promote get sign-in-required errors.
- ✅ Authorization prevents cross-workspace rerun, compare, and promotion.
- ✅ Product-facing errors for unavailable model, provider key, insufficient credits, unsupported promotion target.

## Tests
- **Unit (16 new):** rerun clone+parent+policy/anonymous/cross-workspace/gate; model-policy validation table; compare aggregation/cardinality/cross-workspace; promote draft content/unsupported-target/anonymous. Plus handler error-code coverage.
- **Integration (DB-gated):** `TestRepositoryCreateAgentTryoutWithParent` — parent_tryout_id round-trips against local Postgres.

`go build`, `go vet`, and `go test -short -race ./...` pass. The lone `challengepack/cli-smoke-ruff.yaml` failure is from a pre-existing untracked local example file (not on this branch, not in CI). sqlc regenerated at **v1.31.1** (only `agent_tryouts.sql.go` + `models.go`, no version drift). OpenAPI updated with the three paths + schemas; redocly shows only the pre-existing 5 datasets `ErrorResponse` ref errors.

## Notes / follow-ups
- Compare is a read-time aggregation (no new persistence) — reruns being compared stay immutable.
- Challenge-pack and regression-suite promotion targets can be layered on the Vibe Eval draft later.
- Wiring a concrete `AgentTryoutRerunGate` to the billing entitlement service is a small follow-up; the hook + product errors are in place and tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
