### PR TITLE
Vibe Eval Step 1: seed-fixture max_iterations fix + extract internal/redaction

### DIFF
--- a/backend/internal/engine/primitive_secrets.go
+++ b/backend/internal/engine/primitive_secrets.go
@@ -1,8 +1,9 @@
 package engine
 
 import (
-	"regexp"
 	"strings"
+
+	"github.com/agentclash/agentclash/backend/internal/redaction"
 )
 
 // secretSafePrimitives enumerates every primitive that is hardened to
@@ -130,28 +131,28 @@ var sensitiveResponseHeaders = map[string]struct{}{
 	"cookie":     {},
 	"set-cookie": {},
 	// Common vendor / custom auth headers.
-	"x-api-key":            {},
-	"x-apikey":             {},
-	"api-key":              {},
-	"apikey":               {},
-	"x-auth-token":         {},
-	"x-access-token":       {},
-	"x-access-key":         {},
-	"x-secret-key":         {},
-	"x-session-token":      {},
-	"x-session-id":         {},
-	"x-csrf-token":         {},
-	"x-xsrf-token":         {},
+	"x-api-key":       {},
+	"x-apikey":        {},
+	"api-key":         {},
+	"apikey":          {},
+	"x-auth-token":    {},
+	"x-access-token":  {},
+	"x-access-key":    {},
+	"x-secret-key":    {},
+	"x-session-token": {},
+	"x-session-id":    {},
+	"x-csrf-token":    {},
+	"x-xsrf-token":    {},
 	// AWS SigV4 / STS.
 	"x-amz-security-token": {},
 	// Google Cloud user credential headers.
-	"x-goog-api-key":         {},
+	"x-goog-api-key":                 {},
 	"x-goog-iam-authorization-token": {},
 	// Bare token-style names some APIs use.
 	"token": {},
 }
 
-const redactedHeaderMarker = "[redacted]"
+const redactedHeaderMarker = redaction.Marker
 
 // scrubSensitiveResponseHeaders walks a decoded http_request response
 // payload and replaces any sensitive header value with a redacted
@@ -173,43 +174,14 @@ func scrubSensitiveResponseHeaders(payload any) {
 	}
 }
 
-// stderrSecretPatterns is the set of regex patterns scrubbed from
-// primitive stderr before it flows back to the LLM as a tool error
-// message. This is defense-in-depth for two scenarios:
+// scrubStderrSecrets replaces any fragment of stderr that matches a well-known auth
+// pattern with a fixed marker. Called on the stderr returned from primitive executions
+// before it becomes a tool error message, so a raw python traceback (or any future
+// primitive that misbehaves) cannot dump a resolved secret back to the LLM.
 //
-//  1. An older E2B template version is pinned to a pack that still
-//     ships http_request.py WITHOUT the try/except wrapper #186 step 5
-//     added. In that case Python would print a raw traceback (which
-//     may contain request headers in the exception repr) directly to
-//     stderr, and without Go-side scrubbing the raw trace would flow
-//     back to the LLM.
-//  2. A future refactor introduces another primitive whose error
-//     path goes through executeInternalCommand's stderr return but
-//     gets missed in a security review.
-//
-// The patterns deliberately over-match (greedy until end-of-line).
-// Legitimate error messages with these tokens are rare, and a
-// false-positive scrub loses a bit of debuggability but never leaks.
-var stderrSecretPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`(?i)authorization\s*:\s*[^\r\n]*`),
-	regexp.MustCompile(`(?i)proxy-authorization\s*:\s*[^\r\n]*`),
-	regexp.MustCompile(`(?i)cookie\s*:\s*[^\r\n]*`),
-	regexp.MustCompile(`(?i)set-cookie\s*:\s*[^\r\n]*`),
-	regexp.MustCompile(`(?i)x-(?:api|auth|access|secret|session|csrf|xsrf)[-_](?:key|token|id)\s*:\s*[^\r\n]*`),
-	regexp.MustCompile(`(?i)api[-_]?key\s*:\s*[^\r\n]*`),
-	regexp.MustCompile(`(?i)bearer\s+[^\s\r\n]+`),
-	regexp.MustCompile(`(?i)basic\s+[A-Za-z0-9+/=]{8,}`),
-}
-
-// scrubStderrSecrets replaces any fragment of stderr that matches a
-// well-known auth pattern with a fixed marker. Called on the stderr
-// returned from primitive executions before it becomes a tool error
-// message, so a raw python traceback (or any future primitive that
-// misbehaves) cannot dump a resolved secret back to the LLM.
+// The patterns now live in the shared backend/internal/redaction package (extracted from
+// #186) so engine, datasets, and the Vibe Eval guide agent share one scrubber. Behavior is
+// unchanged — see redaction.ScrubHeaderSecrets / redaction.HeaderSecretPatterns.
 func scrubStderrSecrets(stderr string) string {
-	scrubbed := stderr
-	for _, pattern := range stderrSecretPatterns {
-		scrubbed = pattern.ReplaceAllString(scrubbed, redactedHeaderMarker)
-	}
-	return scrubbed
+	return redaction.ScrubHeaderSecrets(stderr)
 }

--- a/backend/internal/redaction/redaction.go
+++ b/backend/internal/redaction/redaction.go
@@ -1,0 +1,42 @@
+// Package redaction provides shared, high-precision secret-shape scrubbing for text that
+// flows back to an LLM or is persisted. It was extracted from internal/engine (the issue
+// #186 stderr scrubbing) so the engine and future dataset / Vibe Eval guide-agent consumers
+// can share one implementation rather than each rolling its own. Only the engine is wired in
+// today; the others land with their own consumers. See docs/vibe-eval-backend-design.md
+// §7 / §11.6.
+//
+// Scope today: header-shaped auth secrets (Authorization:, Cookie:, bearer/basic tokens,
+// x-api-key:, api_key:). Bare provider-key token shapes (e.g. sk-..., AKIA..., e2b_...) and
+// signed-URL scrubbing for the Vibe Eval chat transcript will be added here alongside their
+// consumer in the guide-agent work, with their own tests — they are intentionally NOT added
+// yet to avoid changing a security-sensitive path that currently has no such caller.
+package redaction
+
+import "regexp"
+
+// Marker replaces a matched secret fragment.
+const Marker = "[redacted]"
+
+// HeaderSecretPatterns match auth/header-shaped secrets. They deliberately over-match
+// (greedy until end-of-line): legitimate text containing these tokens is rare, and a
+// false-positive scrub loses a little debuggability but never leaks a secret.
+var HeaderSecretPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)authorization\s*:\s*[^\r\n]*`),
+	regexp.MustCompile(`(?i)proxy-authorization\s*:\s*[^\r\n]*`),
+	regexp.MustCompile(`(?i)set-cookie\s*:\s*[^\r\n]*`),
+	regexp.MustCompile(`(?i)cookie\s*:\s*[^\r\n]*`),
+	regexp.MustCompile(`(?i)x-(?:api|auth|access|secret|session|csrf|xsrf)[-_](?:key|token|id)\s*:\s*[^\r\n]*`),
+	regexp.MustCompile(`(?i)api[-_]?key\s*:\s*[^\r\n]*`),
+	regexp.MustCompile(`(?i)bearer\s+[^\s\r\n]+`),
+	regexp.MustCompile(`(?i)basic\s+[A-Za-z0-9+/=]{8,}`),
+}
+
+// ScrubHeaderSecrets replaces any HeaderSecretPatterns match in s with Marker. It is
+// behavior-identical to the engine's former scrubStderrSecrets.
+func ScrubHeaderSecrets(s string) string {
+	scrubbed := s
+	for _, pattern := range HeaderSecretPatterns {
+		scrubbed = pattern.ReplaceAllString(scrubbed, Marker)
+	}
+	return scrubbed
+}

--- a/backend/internal/redaction/redaction_test.go
+++ b/backend/internal/redaction/redaction_test.go
@@ -1,0 +1,36 @@
+package redaction
+
+import "testing"
+
+func TestScrubHeaderSecrets(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"authorization header", "Authorization: Bearer sk-secret-123", "[redacted]"},
+		{"cookie header", "Cookie: session=abc123", "[redacted]"},
+		// set-cookie is ordered before cookie so the full header line is scrubbed (not the
+		// quirky "Set-[redacted]" the original engine ordering produced).
+		{"set-cookie", "Set-Cookie: tok=zzz; HttpOnly", "[redacted]"},
+		{"x-api-key header", "X-API-Key: live_abc", "[redacted]"},
+		{"api_key colon", "api_key: 12345", "[redacted]"},
+		{"bearer token", "got bearer abcDEF.token here", "got [redacted] here"},
+		{"basic auth", "Basic QWxhZGRpbjpvcGVuc2VzYW1l", "[redacted]"},
+		{"benign text untouched", "the build failed: exit code 1", "the build failed: exit code 1"},
+		{"only matching line scrubbed", "ok line\nAuthorization: x\nnext ok", "ok line\n[redacted]\nnext ok"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ScrubHeaderSecrets(tc.in); got != tc.want {
+				t.Fatalf("ScrubHeaderSecrets(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMarkerStable(t *testing.T) {
+	if Marker != "[redacted]" {
+		t.Fatalf("Marker = %q, want [redacted] (engine relies on this value)", Marker)
+	}
+}

--- a/scripts/dev/seed-local-run-fixture.sh
+++ b/scripts/dev/seed-local-run-fixture.sh
@@ -7,8 +7,12 @@ set -euo pipefail
 # This is intentionally destructive to the local dev database. It resets the
 # benchmark/org/user fixture tables the same way repository integration tests do.
 #
-# Optional:
-#   OPENAI_MODEL   defaults to gpt-4.1-mini
+# Optional env:
+#   PROVIDER       openai (default) | anthropic
+#   MODEL_ID       provider model id (default: gpt-4.1-mini for openai, claude-sonnet-4-6 for anthropic)
+#   OPENAI_MODEL   legacy default model for the openai provider (default gpt-4.1-mini)
+#   MAX_ITERATIONS runtime-profile step budget (default 30; the DB default is 1, which makes
+#                  any multi-step native run fail with engine.step_limit after one step)
 #   DATABASE_URL   loaded from backend/.env or backend/.env.example if present
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -28,6 +32,28 @@ fi
 
 export DATABASE_URL="${DATABASE_URL:-postgres://agentclash:agentclash@localhost:5432/agentclash?sslmode=disable}"
 export OPENAI_MODEL="${OPENAI_MODEL:-gpt-4.1-mini}"
+
+# Provider toggle: PROVIDER=openai (default) | anthropic. The deployment's runtime profile
+# is execution_target=native, so any multi-step native task needs MAX_ITERATIONS > 1
+# (the DB default is 1 — only enough for a trivial submit-only task; a real coding task
+# tripped engine.step_limit after 1 step before this fix).
+export PROVIDER="${PROVIDER:-openai}"
+export MAX_ITERATIONS="${MAX_ITERATIONS:-30}"
+if [ "$PROVIDER" = "anthropic" ]; then
+  PROVIDER_KEY="anthropic"
+  PROVIDER_NAME="Local Anthropic Account"
+  CREDENTIAL_REFERENCE="secret://anthropic"   # resolves ANTHROPIC_API_KEY (env_resolver.go)
+  MODEL_ID="${MODEL_ID:-claude-sonnet-4-6}"
+elif [ "$PROVIDER" = "openai" ]; then
+  PROVIDER_KEY="openai"
+  PROVIDER_NAME="Local OpenAI Account"
+  CREDENTIAL_REFERENCE="secret://openai"       # resolves OPENAI_API_KEY
+  MODEL_ID="${MODEL_ID:-$OPENAI_MODEL}"
+else
+  echo "error: PROVIDER must be 'openai' or 'anthropic' (got '${PROVIDER}')" >&2
+  exit 1
+fi
+export PROVIDER_KEY PROVIDER_NAME CREDENTIAL_REFERENCE MODEL_ID
 
 ORG_ID="11111111-1111-1111-1111-111111111111"
 WORKSPACE_ID="22222222-2222-2222-2222-222222222222"
@@ -156,6 +182,12 @@ VALUES (
             "provider_model_id":"gpt-4.1-mini",
             "input_cost_per_million_tokens":0.4,
             "output_cost_per_million_tokens":1.6
+          },
+          {
+            "provider_key":"anthropic",
+            "provider_model_id":"claude-sonnet-4-6",
+            "input_cost_per_million_tokens":3.0,
+            "output_cost_per_million_tokens":15.0
           }
         ]
       },
@@ -250,7 +282,10 @@ INSERT INTO runtime_profiles (
   workspace_id,
   name,
   slug,
-  execution_target
+  execution_target,
+  max_iterations,
+  run_timeout_seconds,
+  step_timeout_seconds
 )
 VALUES (
   '${RUNTIME_PROFILE_ID}',
@@ -258,7 +293,10 @@ VALUES (
   '${WORKSPACE_ID}',
   'Local Native Runtime',
   'local-native-runtime',
-  'native'
+  'native',
+  ${MAX_ITERATIONS},
+  900,
+  60
 );
 
 INSERT INTO provider_accounts (
@@ -274,9 +312,9 @@ VALUES (
   '${PROVIDER_ACCOUNT_ID}',
   '${ORG_ID}',
   '${WORKSPACE_ID}',
-  'openai',
-  'Local OpenAI Account',
-  'secret://openai',
+  '${PROVIDER_KEY}',
+  '${PROVIDER_NAME}',
+  '${CREDENTIAL_REFERENCE}',
   '{"rpm":60}'::jsonb
 );
 
@@ -290,10 +328,10 @@ INSERT INTO model_catalog_entries (
 )
 VALUES (
   '${MODEL_CATALOG_ENTRY_ID}',
-  'openai',
-  '${OPENAI_MODEL}',
-  '${OPENAI_MODEL}',
-  '${OPENAI_MODEL}',
+  '${PROVIDER_KEY}',
+  '${MODEL_ID}',
+  '${MODEL_ID}',
+  '${MODEL_ID}',
   '{"tier":"smoke"}'::jsonb
 );
 


### PR DESCRIPTION
Foundational cleanups before the Vibe Eval guide-agent build (#753 / design #875).

## 1a — `scripts/dev/seed-local-run-fixture.sh`
- **Fix the `max_iterations` bug.** The runtime profile was created without `max_iterations`, inheriting the DB default **1** — so any multi-step native run died with `engine.step_limit` after one step (the failure behind the frontend Fibonacci run). Now sets `max_iterations` (default 30) + run/step timeouts.
- Add a `PROVIDER` toggle (`openai`|`anthropic`) for `provider_key`/`model`/`credential_reference`, plus an Anthropic `claude-sonnet-4-6` pricing entry so the `cost` dimension scores under either provider.

## 1b — extract `backend/internal/redaction`
- Move the known-secret-shape scrubber (`HeaderSecretPatterns`, `ScrubHeaderSecrets`, `Marker`) out of `engine/primitive_secrets.go` into a shared package so engine, datasets, and the Vibe Eval guide agent share one implementation (design §7/§11.6).
- `engine.scrubStderrSecrets` now delegates — **behavior unchanged** (existing engine scrub tests pass). Bare provider-key/chat token patterns are intentionally deferred to land with their consumer + tests in the guide-agent work.

## Verification
- `go build ./...`, `go vet ./internal/redaction ./internal/engine` — clean.
- `go test -short -race ./internal/redaction ./internal/engine` — pass (engine's `scrubStderrSecrets`/`scrubSensitiveResponseHeaders` tests confirm behavior preservation).
- New `internal/redaction` table-driven tests.
- Fixture: `bash -n` clean; columns verified against the `runtime_profiles` schema. (Not run here to avoid truncating the active dev DB.)