### PR TITLE
feat(agent-tryouts): capture and view produced output artifacts

### DIFF
--- a/backend/cmd/api-server/main.go
+++ b/backend/cmd/api-server/main.go
@@ -130,7 +130,7 @@ func main() {
 	challengePackReadManager := api.NewChallengePackReadManager(repo)
 	challengePackAuthoringManager := api.NewChallengePackAuthoringManager(repo, artifactStore)
 	publicShareManager := api.NewPublicShareManager(authorizer, repo, cfg.FrontendURL).WithArtifactSigner(artifactManager)
-	agentTryoutManager := api.NewAgentTryoutManager(authorizer, repo).WithQuota(api.AgentTryoutQuotaConfig{
+	agentTryoutManager := api.NewAgentTryoutManager(authorizer, repo).WithArtifactSigner(artifactManager).WithQuota(api.AgentTryoutQuotaConfig{
 		AnonymousLimit:            cfg.AgentTryoutAnonymousLimit,
 		AnonymousWindow:           cfg.AgentTryoutAnonymousWindow,
 		HostedDailySpendCapUSD:    cfg.AgentTryoutHostedDailySpendCapUSD,

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -170,7 +170,7 @@ func main() {
 		PromptEvalInvoker:  promptEvalInvoker,
 		ResponsesInvoker:   responsesInvoker,
 		MultiTurnInvoker:   multiTurnInvoker,
-	})
+	}, artifactStore)
 	orphanRunReaper := workerapp.NewRepositoryOrphanRunReaper(repo, cfg.OrphanRunReaperInterval, cfg.OrphanRunReaperThreshold, logger)
 	agentTryoutRetentionReaper := workerapp.NewRepositoryAgentTryoutRetentionReaper(repo, cfg.AgentTryoutRetentionReaperInterval, logger)
 

--- a/backend/internal/api/agent_tryout_conversions.go
+++ b/backend/internal/api/agent_tryout_conversions.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/go-chi/chi/v5"
@@ -465,6 +466,91 @@ func promoteAgentTryoutHandler(logger *slog.Logger, service AgentTryoutService) 
 			return
 		}
 		writeJSON(w, http.StatusCreated, result)
+	}
+}
+
+// AgentTryoutArtifact is one captured output file of a tryout, with a signed,
+// time-limited download URL when a signer is configured.
+type AgentTryoutArtifact struct {
+	ID                uuid.UUID  `json:"id"`
+	Key               string     `json:"key,omitempty"`
+	Path              string     `json:"path,omitempty"`
+	ArtifactType      string     `json:"artifact_type"`
+	ContentType       *string    `json:"content_type,omitempty"`
+	SizeBytes         *int64     `json:"size_bytes,omitempty"`
+	DownloadURL       string     `json:"download_url,omitempty"`
+	DownloadExpiresAt *time.Time `json:"download_expires_at,omitempty"`
+	CreatedAt         time.Time  `json:"created_at"`
+}
+
+// ListWorkspaceTryoutArtifacts returns the captured output files for a workspace
+// tryout (e.g. the slide deck the agent produced), each with a signed download
+// URL. Unlike the public share view, the workspace owner sees every captured
+// artifact — there is no template allowlist redaction here.
+func (m *AgentTryoutManager) ListWorkspaceTryoutArtifacts(ctx context.Context, caller Caller, tryoutID uuid.UUID, baseURL string) ([]AgentTryoutArtifact, error) {
+	tryout, err := m.repo.GetAgentTryoutByID(ctx, tryoutID)
+	if err != nil {
+		return nil, err
+	}
+	if tryout.WorkspaceID == nil {
+		return nil, ErrAgentTryoutSignInRequired
+	}
+	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, *tryout.WorkspaceID); err != nil {
+		return nil, err
+	}
+	if tryout.RunID == nil {
+		return []AgentTryoutArtifact{}, nil
+	}
+	artifacts, err := m.repo.ListArtifactsByRunID(ctx, *tryout.RunID)
+	if err != nil {
+		return nil, err
+	}
+	now := m.now()
+	out := make([]AgentTryoutArtifact, 0, len(artifacts))
+	for _, artifact := range artifacts {
+		key, path := artifactClaimedIdentity(artifact.Metadata)
+		item := AgentTryoutArtifact{
+			ID:           artifact.ID,
+			Key:          key,
+			Path:         path,
+			ArtifactType: artifact.ArtifactType,
+			ContentType:  artifact.ContentType,
+			SizeBytes:    artifact.SizeBytes,
+			CreatedAt:    artifact.CreatedAt,
+		}
+		if m.artifactSigner != nil {
+			if url, expiresAt, signErr := m.artifactSigner.SignedArtifactContentURL(artifact.ID, baseURL, now); signErr == nil {
+				item.DownloadURL = url
+				item.DownloadExpiresAt = &expiresAt
+			}
+		}
+		out = append(out, item)
+	}
+	return out, nil
+}
+
+type listAgentTryoutArtifactsResponse struct {
+	Items []AgentTryoutArtifact `json:"items"`
+}
+
+func listAgentTryoutArtifactsHandler(logger *slog.Logger, service AgentTryoutService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller, err := CallerFromContext(r.Context())
+		if err != nil {
+			writeAuthzError(w, err)
+			return
+		}
+		id, err := uuid.Parse(chi.URLParam(r, "tryoutID"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_tryout_id", "tryout_id must be a UUID")
+			return
+		}
+		artifacts, err := service.ListWorkspaceTryoutArtifacts(r.Context(), caller, id, requestBaseURL(r))
+		if err != nil {
+			writeAgentTryoutError(w, logger, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, listAgentTryoutArtifactsResponse{Items: artifacts})
 	}
 }
 

--- a/backend/internal/api/agent_tryout_conversions_test.go
+++ b/backend/internal/api/agent_tryout_conversions_test.go
@@ -6,10 +6,76 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/google/uuid"
 )
+
+type stubArtifactSigner struct{}
+
+func (stubArtifactSigner) SignedArtifactContentURL(artifactID uuid.UUID, baseURL string, now time.Time) (string, time.Time, error) {
+	return baseURL + "/v1/artifacts/" + artifactID.String() + "/content?sig=test", now.Add(time.Hour), nil
+}
+
+func ptrUUID(id uuid.UUID) *uuid.UUID { return &id }
+
+func TestAgentTryoutListArtifactsReturnsCapturedOutputs(t *testing.T) {
+	ctx := context.Background()
+	orgID, workspaceID := uuid.New(), uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	source := seedWorkspaceTryout(repo, orgID, workspaceID, "slide-deck")
+	runID := uuid.New()
+	source.RunID = &runID
+	repo.tryouts[source.ID] = source
+
+	contentType := "text/markdown; charset=utf-8"
+	size := int64(42)
+	repo.artifacts = []repository.Artifact{{
+		ID:           uuid.New(),
+		RunID:        &runID,
+		ArtifactType: "agent_tryout_markdown",
+		ContentType:  &contentType,
+		SizeBytes:    &size,
+		Metadata:     json.RawMessage(`{"source":"agent_tryout","artifact_key":"deck_outline","relative_path":"deck.md"}`),
+	}, {
+		ID:           uuid.New(),
+		RunID:        ptrUUID(uuid.New()), // different run; must be excluded
+		ArtifactType: "agent_tryout_json",
+	}}
+
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo).WithArtifactSigner(stubArtifactSigner{})
+	artifacts, err := manager.ListWorkspaceTryoutArtifacts(ctx, callerWithWorkspace(workspaceID), source.ID, "https://api.example.com")
+	if err != nil {
+		t.Fatalf("ListWorkspaceTryoutArtifacts returned error: %v", err)
+	}
+	if len(artifacts) != 1 {
+		t.Fatalf("artifacts = %d, want 1 (only the run's artifact)", len(artifacts))
+	}
+	got := artifacts[0]
+	if got.Key != "deck_outline" || got.Path != "deck.md" {
+		t.Fatalf("artifact identity = %q/%q, want deck_outline/deck.md", got.Key, got.Path)
+	}
+	if got.DownloadURL == "" || got.DownloadExpiresAt == nil {
+		t.Fatalf("expected a signed download URL, got %q (expires=%v)", got.DownloadURL, got.DownloadExpiresAt)
+	}
+}
+
+func TestAgentTryoutListArtifactsEmptyWhenNoRun(t *testing.T) {
+	ctx := context.Background()
+	orgID, workspaceID := uuid.New(), uuid.New()
+	repo := newFakeAgentTryoutRepository(orgID, workspaceID)
+	source := seedWorkspaceTryout(repo, orgID, workspaceID, "slide-deck") // no run_id
+
+	manager := NewAgentTryoutManager(NewCallerWorkspaceAuthorizer(), repo).WithArtifactSigner(stubArtifactSigner{})
+	artifacts, err := manager.ListWorkspaceTryoutArtifacts(ctx, callerWithWorkspace(workspaceID), source.ID, "https://api.example.com")
+	if err != nil {
+		t.Fatalf("ListWorkspaceTryoutArtifacts returned error: %v", err)
+	}
+	if len(artifacts) != 0 {
+		t.Fatalf("artifacts = %d, want 0 for a tryout with no run", len(artifacts))
+	}
+}
 
 func seedWorkspaceTryout(repo *fakeAgentTryoutRepository, orgID, workspaceID uuid.UUID, slug string) repository.AgentTryout {
 	id := uuid.New()

--- a/backend/internal/api/agent_tryouts.go
+++ b/backend/internal/api/agent_tryouts.go
@@ -39,14 +39,14 @@ var (
 	ErrAgentTryoutRedactionNotReady         = errors.New("agent tryout redaction not ready")
 
 	// Conversion-flow errors (#947: rerun / compare / promote-to-eval).
-	ErrAgentTryoutSignInRequired              = errors.New("agent tryout sign-in required")
-	ErrAgentTryoutModelPolicyInvalid          = errors.New("agent tryout model policy invalid")
-	ErrAgentTryoutModelUnavailable            = errors.New("agent tryout model unavailable")
-	ErrAgentTryoutRerunProviderKeyRequired    = errors.New("agent tryout rerun provider key required")
-	ErrAgentTryoutRerunInsufficientCredits    = errors.New("agent tryout rerun insufficient credits")
-	ErrAgentTryoutCompareCardinality          = errors.New("agent tryout compare requires 2-4 tryouts")
-	ErrAgentTryoutPromotionTargetUnsupported  = errors.New("agent tryout promotion target unsupported")
-	ErrAgentTryoutNotPromotable               = errors.New("agent tryout is not completed")
+	ErrAgentTryoutSignInRequired             = errors.New("agent tryout sign-in required")
+	ErrAgentTryoutModelPolicyInvalid         = errors.New("agent tryout model policy invalid")
+	ErrAgentTryoutModelUnavailable           = errors.New("agent tryout model unavailable")
+	ErrAgentTryoutRerunProviderKeyRequired   = errors.New("agent tryout rerun provider key required")
+	ErrAgentTryoutRerunInsufficientCredits   = errors.New("agent tryout rerun insufficient credits")
+	ErrAgentTryoutCompareCardinality         = errors.New("agent tryout compare requires 2-4 tryouts")
+	ErrAgentTryoutPromotionTargetUnsupported = errors.New("agent tryout promotion target unsupported")
+	ErrAgentTryoutNotPromotable              = errors.New("agent tryout is not completed")
 )
 
 type AgentTryoutRepository interface {
@@ -63,6 +63,7 @@ type AgentTryoutRepository interface {
 	WithinAnonymousAgentTryoutQuotaLock(ctx context.Context, fn func(repository.AnonymousAgentTryoutQuotaTx) error) error
 	GetAgentTryoutByID(ctx context.Context, id uuid.UUID) (repository.AgentTryout, error)
 	ListRunEventsByRunIDAfter(ctx context.Context, runID uuid.UUID, afterID int64, limit int32) ([]repository.RunEvent, error)
+	ListArtifactsByRunID(ctx context.Context, runID uuid.UUID) ([]repository.Artifact, error)
 	ListAgentTryoutsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID, limit, offset int32) ([]repository.AgentTryout, error)
 	LinkAgentTryoutRunIfUnset(ctx context.Context, params repository.LinkAgentTryoutRunParams) (repository.AgentTryout, error)
 	UpdateAgentTryoutStatus(ctx context.Context, params repository.UpdateAgentTryoutStatusParams) (repository.AgentTryout, error)
@@ -88,6 +89,7 @@ type AgentTryoutService interface {
 	RerunWorkspaceTryout(ctx context.Context, caller Caller, input RerunAgentTryoutInput) (repository.AgentTryout, error)
 	CompareWorkspaceTryouts(ctx context.Context, caller Caller, input CompareAgentTryoutsInput) (AgentTryoutCompareResult, error)
 	PromoteTryoutToEval(ctx context.Context, caller Caller, input PromoteAgentTryoutInput) (AgentTryoutPromotionResult, error)
+	ListWorkspaceTryoutArtifacts(ctx context.Context, caller Caller, tryoutID uuid.UUID, baseURL string) ([]AgentTryoutArtifact, error)
 }
 
 type AgentTryoutTemplate struct {
@@ -149,13 +151,21 @@ type AgentTryoutQuotaConfig struct {
 }
 
 type AgentTryoutManager struct {
-	authorizer WorkspaceAuthorizer
-	repo       AgentTryoutRepository
-	now        func() time.Time
-	templates  map[string]AgentTryoutTemplate
-	execution  *agentTryoutExecutionDispatcher
-	quota      *AgentTryoutQuotaConfig
-	rerunGate  AgentTryoutRerunGate
+	authorizer     WorkspaceAuthorizer
+	repo           AgentTryoutRepository
+	now            func() time.Time
+	templates      map[string]AgentTryoutTemplate
+	execution      *agentTryoutExecutionDispatcher
+	quota          *AgentTryoutQuotaConfig
+	rerunGate      AgentTryoutRerunGate
+	artifactSigner ArtifactContentSigner
+}
+
+// WithArtifactSigner enables signed download URLs on a tryout's captured output
+// artifacts. Without it, artifact listing still works but omits download links.
+func (m *AgentTryoutManager) WithArtifactSigner(signer ArtifactContentSigner) *AgentTryoutManager {
+	m.artifactSigner = signer
+	return m
 }
 
 func NewAgentTryoutManager(authorizer WorkspaceAuthorizer, repo AgentTryoutRepository) *AgentTryoutManager {
@@ -928,6 +938,7 @@ func registerProtectedAgentTryoutRoutes(router chi.Router, logger *slog.Logger, 
 	router.Get("/workspaces/{workspaceID}/agent-tryouts", listWorkspaceAgentTryoutsHandler(logger, service))
 	router.Get("/workspaces/{workspaceID}/agent-tryouts/{tryoutID}", getWorkspaceAgentTryoutHandler(logger, service))
 	router.Get("/workspaces/{workspaceID}/agent-tryouts/{tryoutID}/events", getWorkspaceAgentTryoutEventsHandler(logger, service))
+	router.Get("/workspaces/{workspaceID}/agent-tryouts/{tryoutID}/artifacts", listAgentTryoutArtifactsHandler(logger, service))
 	router.Post("/agent-tryouts/{tryoutID}/claim", claimAgentTryoutHandler(logger, service))
 	router.Post("/agent-tryouts/{tryoutID}/share", createAgentTryoutShareHandler(logger, service))
 	router.Post("/agent-tryouts/{tryoutID}/rerun", rerunAgentTryoutHandler(logger, service))

--- a/backend/internal/api/agent_tryouts_test.go
+++ b/backend/internal/api/agent_tryouts_test.go
@@ -979,6 +979,8 @@ type fakeAgentTryoutRepository struct {
 	hostedSpendUSD     float64
 	runEvents           []repository.RunEvent
 	runEventsErr        error
+	artifacts           []repository.Artifact
+	artifactsErr        error
 	createdConversation repository.CreateVibeEvalConversationParams
 	createdDraft        repository.CreateVibeEvalDraftParams
 }
@@ -1012,6 +1014,19 @@ func (r *fakeAgentTryoutRepository) ListRunEventsByRunIDAfter(_ context.Context,
 		out = append(out, event)
 		if int32(len(out)) == limit {
 			break
+		}
+	}
+	return out, nil
+}
+
+func (r *fakeAgentTryoutRepository) ListArtifactsByRunID(_ context.Context, runID uuid.UUID) ([]repository.Artifact, error) {
+	if r.artifactsErr != nil {
+		return nil, r.artifactsErr
+	}
+	out := make([]repository.Artifact, 0, len(r.artifacts))
+	for _, artifact := range r.artifacts {
+		if artifact.RunID != nil && *artifact.RunID == runID {
+			out = append(out, artifact)
 		}
 	}
 	return out, nil
@@ -1393,6 +1408,10 @@ func (s *fakeAgentTryoutService) ClaimTryout(context.Context, Caller, ClaimAgent
 
 func (s *fakeAgentTryoutService) CreatePrivateShare(context.Context, Caller, uuid.UUID) (CreateAgentTryoutShareResult, error) {
 	return CreateAgentTryoutShareResult{}, nil
+}
+
+func (s *fakeAgentTryoutService) ListWorkspaceTryoutArtifacts(context.Context, Caller, uuid.UUID, string) ([]AgentTryoutArtifact, error) {
+	return nil, nil
 }
 
 func (s *fakeAgentTryoutService) RerunWorkspaceTryout(context.Context, Caller, RerunAgentTryoutInput) (repository.AgentTryout, error) {

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -464,6 +464,10 @@ func (noopAgentTryoutService) PromoteTryoutToEval(context.Context, Caller, Promo
 	return AgentTryoutPromotionResult{}, errors.New("agent tryout service is not configured")
 }
 
+func (noopAgentTryoutService) ListWorkspaceTryoutArtifacts(context.Context, Caller, uuid.UUID, string) ([]AgentTryoutArtifact, error) {
+	return nil, errors.New("agent tryout service is not configured")
+}
+
 func (noopAgentTryoutService) GetWorkspaceTryoutEvents(context.Context, Caller, uuid.UUID, TryoutEventsCursor) (AgentTryoutEventsResult, error) {
 	return AgentTryoutEventsResult{}, errors.New("agent tryout service is not configured")
 }

--- a/backend/internal/worker/service.go
+++ b/backend/internal/worker/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/agentclash/agentclash/backend/internal/provider"
 	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/agentclash/agentclash/backend/internal/sandbox"
+	"github.com/agentclash/agentclash/backend/internal/storage"
 	workflowpkg "github.com/agentclash/agentclash/backend/internal/workflow"
 	temporalsdk "go.temporal.io/sdk/client"
 	sdkworker "go.temporal.io/sdk/worker"
@@ -34,6 +35,7 @@ func NewTemporalWorker(
 	sandboxProvider sandbox.Provider,
 	githubClient workflowpkg.GitHubPullRequestClient,
 	executionHooks workflowpkg.FakeWorkHooks,
+	artifactStore storage.Store,
 ) sdkworker.Worker {
 	temporalWorker := sdkworker.New(client, cfg.TaskQueue, sdkworker.Options{
 		Identity: cfg.Identity,
@@ -41,7 +43,8 @@ func NewTemporalWorker(
 
 	activities := workflowpkg.NewActivities(repo, executionHooks, playgroundClient).
 		WithSandboxProvider(sandboxProvider).
-		WithGitHubPullRequestClient(githubClient)
+		WithGitHubPullRequestClient(githubClient).
+		WithArtifactStore(artifactStore)
 	workflowpkg.Register(temporalWorker, activities)
 	workflowpkg.RegisterPlayground(temporalWorker, workflowpkg.NewPlaygroundActivities(repo, playgroundClient, repo))
 	workflowpkg.RegisterDatasetGeneration(temporalWorker, workflowpkg.NewDatasetGenerationActivities(repo, playgroundClient, repo))

--- a/backend/internal/workflow/activities.go
+++ b/backend/internal/workflow/activities.go
@@ -13,6 +13,7 @@ import (
 	"github.com/agentclash/agentclash/backend/internal/repository"
 	"github.com/agentclash/agentclash/backend/internal/sandbox"
 	"github.com/agentclash/agentclash/backend/internal/scoring"
+	"github.com/agentclash/agentclash/backend/internal/storage"
 	"github.com/google/uuid"
 	"go.temporal.io/sdk/temporal"
 )
@@ -96,6 +97,8 @@ type Activities struct {
 	judgeClient      provider.Client
 	sandboxProvider  sandbox.Provider
 	githubClient     GitHubPullRequestClient
+	artifactStore    storage.Store
+	artifactWriter   ArtifactWriter
 }
 
 type LoadEvalSessionInput struct {
@@ -190,14 +193,27 @@ func NewActivities(repo RunRepository, hooks FakeWorkHooks, judgeClients ...prov
 	if candidate, ok := repo.(AgentHarnessExecutionRepository); ok {
 		agentHarnessRepo = candidate
 	}
+	var artifactWriter ArtifactWriter
+	if candidate, ok := repo.(ArtifactWriter); ok {
+		artifactWriter = candidate
+	}
 	return &Activities{
 		repo:             repo,
 		evalSessionRepo:  evalSessionRepo,
 		agentHarnessRepo: agentHarnessRepo,
+		artifactWriter:   artifactWriter,
 		hooks:            hooks,
 		judgeClient:      judgeClient,
 		sandboxProvider:  sandbox.UnconfiguredProvider{},
 	}
+}
+
+// WithArtifactStore wires the object store the harness uploads captured output
+// files to. Without it (or without an ArtifactWriter repo), artifact capture is
+// skipped silently and execution is otherwise unaffected.
+func (a *Activities) WithArtifactStore(store storage.Store) *Activities {
+	a.artifactStore = store
+	return a
 }
 
 func (a *Activities) WithSandboxProvider(provider sandbox.Provider) *Activities {

--- a/backend/internal/workflow/agent_harness_execution_workflow.go
+++ b/backend/internal/workflow/agent_harness_execution_workflow.go
@@ -1,10 +1,15 @@
 package workflow
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"mime"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -15,9 +20,15 @@ import (
 	"github.com/agentclash/agentclash/backend/internal/runevents"
 	"github.com/agentclash/agentclash/backend/internal/sandbox"
 	"github.com/agentclash/agentclash/backend/internal/scoring"
+	"github.com/agentclash/agentclash/backend/internal/storage"
 	"github.com/google/uuid"
 	sdkworkflow "go.temporal.io/sdk/workflow"
 )
+
+// maxCapturedArtifactBytes bounds a single captured output file. Office tryout
+// outputs are small documents; this guards against a runaway file filling
+// storage while staying well above any real deck/spreadsheet/report.
+const maxCapturedArtifactBytes = 10 * 1024 * 1024
 
 const (
 	agentHarnessWorkspaceDir          = "/workspace"
@@ -363,6 +374,11 @@ func (a *Activities) ExecuteAgentHarnessExecution(ctx context.Context, input Exe
 		}
 	}
 
+	// Capture the agent's produced output files (e.g. an agent tryout's slide
+	// deck) as durable, downloadable artifacts before the sandbox is torn down.
+	// Best-effort: a capture failure is recorded but never fails the run.
+	a.captureAgentHarnessArtifacts(ctx, execution, session, workdir)
+
 	if _, err := a.TransitionAgentHarnessExecutionStatus(ctx, TransitionAgentHarnessExecutionStatusInput{
 		ExecutionID: execution.ID,
 		ToStatus:    repository.AgentHarnessExecutionStatusScoring,
@@ -374,6 +390,172 @@ func (a *Activities) ExecuteAgentHarnessExecution(ctx context.Context, input Exe
 	}
 
 	return nil
+}
+
+// capturedArtifactSpec is one expected output file declared by a template's
+// runtime.expected_artifacts.
+type capturedArtifactSpec struct {
+	Key  string `json:"key"`
+	Type string `json:"type"`
+	Path string `json:"path"`
+}
+
+// expectedArtifactsFromExecutionConfig parses the agent-tryout output manifest
+// (agent_tryout.runtime.expected_artifacts) from the execution config snapshot.
+// Returns nil for non-tryout runs, which have no agent_tryout block — so capture
+// is a no-op for ordinary harness executions.
+func expectedArtifactsFromExecutionConfig(raw json.RawMessage) []capturedArtifactSpec {
+	if len(raw) == 0 {
+		return nil
+	}
+	var config struct {
+		AgentTryout struct {
+			Runtime struct {
+				ExpectedArtifacts []capturedArtifactSpec `json:"expected_artifacts"`
+			} `json:"runtime"`
+		} `json:"agent_tryout"`
+	}
+	if err := json.Unmarshal(raw, &config); err != nil {
+		return nil
+	}
+	return config.AgentTryout.Runtime.ExpectedArtifacts
+}
+
+// captureAgentHarnessArtifacts reads each template-declared output file out of
+// the sandbox and persists it as a durable, downloadable artifact linked to the
+// run, before the sandbox is destroyed. It is best-effort: missing files and
+// upload errors are recorded as events but never fail the execution. It is a
+// no-op when no object store / artifact writer is configured or the template
+// declares no expected artifacts (i.e. all non-tryout runs).
+func (a *Activities) captureAgentHarnessArtifacts(ctx context.Context, execution repository.AgentHarnessExecution, session sandbox.Session, workdir string) {
+	if a.artifactStore == nil || a.artifactWriter == nil || execution.RunID == nil {
+		return
+	}
+	specs := expectedArtifactsFromExecutionConfig(execution.ExecutionConfigSnapshot)
+	if len(specs) == 0 {
+		return
+	}
+	for _, spec := range specs {
+		rel := strings.TrimSpace(spec.Path)
+		if rel == "" {
+			continue
+		}
+		absPath := rel
+		if !path.IsAbs(rel) {
+			absPath = path.Join(workdir, rel)
+		}
+		data, err := session.DownloadFile(ctx, absPath)
+		if err != nil {
+			_ = a.recordAgentHarnessEvent(ctx, execution.ID, "artifact.capture.skipped", "worker", map[string]any{
+				"artifact_key":  spec.Key,
+				"relative_path": rel,
+				"reason":        "not_produced",
+			})
+			continue
+		}
+		if len(data) == 0 {
+			continue
+		}
+		if len(data) > maxCapturedArtifactBytes {
+			_ = a.recordAgentHarnessEvent(ctx, execution.ID, "artifact.capture.skipped", "worker", map[string]any{
+				"artifact_key":  spec.Key,
+				"relative_path": rel,
+				"reason":        "too_large",
+				"size_bytes":    len(data),
+			})
+			continue
+		}
+		if err := a.persistCapturedArtifact(ctx, execution, spec, rel, data); err != nil {
+			_ = a.recordAgentHarnessEvent(ctx, execution.ID, "artifact.capture.failed", "worker", map[string]any{
+				"artifact_key":  spec.Key,
+				"relative_path": rel,
+				"error":         err.Error(),
+			})
+		}
+	}
+}
+
+func (a *Activities) persistCapturedArtifact(ctx context.Context, execution repository.AgentHarnessExecution, spec capturedArtifactSpec, rel string, data []byte) error {
+	sum := sha256.Sum256(data)
+	checksum := hex.EncodeToString(sum[:])
+	contentType := capturedArtifactContentType(rel)
+	storageKey := fmt.Sprintf("agent-tryouts/%s/%s", execution.RunID.String(), checksum)
+
+	objectMeta, err := a.artifactStore.PutObject(ctx, storage.PutObjectInput{
+		Key:         storageKey,
+		Body:        bytes.NewReader(data),
+		SizeBytes:   int64(len(data)),
+		ContentType: contentType,
+	})
+	if err != nil {
+		return fmt.Errorf("store captured artifact object: %w", err)
+	}
+
+	size := int64(len(data))
+	metadata, _ := json.Marshal(map[string]any{
+		"source":        "agent_tryout",
+		"artifact_key":  spec.Key,
+		"relative_path": rel,
+	})
+	artifact, err := a.artifactWriter.CreateArtifact(ctx, repository.CreateArtifactParams{
+		OrganizationID:  execution.OrganizationID,
+		WorkspaceID:     execution.WorkspaceID,
+		RunID:           execution.RunID,
+		RunAgentID:      execution.RunAgentID,
+		ArtifactType:    capturedArtifactType(spec.Type),
+		StorageBucket:   objectMeta.Bucket,
+		StorageKey:      objectMeta.Key,
+		ContentType:     &contentType,
+		SizeBytes:       &size,
+		ChecksumSHA256:  &checksum,
+		Visibility:      "private",
+		RetentionStatus: "active",
+		Metadata:        metadata,
+	})
+	if err != nil {
+		if cleanupErr := a.artifactStore.DeleteObject(ctx, objectMeta.Key); cleanupErr != nil && !errors.Is(cleanupErr, storage.ErrObjectNotFound) {
+			return fmt.Errorf("create captured artifact metadata: %w (cleanup failed: %v)", err, cleanupErr)
+		}
+		return fmt.Errorf("create captured artifact metadata: %w", err)
+	}
+	return a.recordAgentHarnessEvent(ctx, execution.ID, "artifact.captured", "worker", map[string]any{
+		"artifact_id":   artifact.ID.String(),
+		"artifact_key":  spec.Key,
+		"relative_path": rel,
+		"size_bytes":    size,
+		"content_type":  contentType,
+	})
+}
+
+// capturedArtifactType maps a template artifact type to a storable artifact_type
+// string (lowercase, matches the artifacts table convention). Falls back to a
+// generic value when the template type is missing or non-conforming.
+func capturedArtifactType(templateType string) string {
+	t := strings.ToLower(strings.TrimSpace(templateType))
+	switch t {
+	case "markdown", "json", "csv", "patch", "text":
+		return "agent_tryout_" + t
+	default:
+		return "agent_tryout_output"
+	}
+}
+
+func capturedArtifactContentType(rel string) string {
+	if ct := mime.TypeByExtension(strings.ToLower(filepath.Ext(rel))); ct != "" {
+		return ct
+	}
+	switch strings.ToLower(filepath.Ext(rel)) {
+	case ".md":
+		return "text/markdown; charset=utf-8"
+	case ".json":
+		return "application/json"
+	case ".csv":
+		return "text/csv; charset=utf-8"
+	case ".patch", ".diff":
+		return "text/x-patch"
+	default:
+		return "application/octet-stream"
+	}
 }
 
 func (a *Activities) buildAgentHarnessReplayBestEffort(ctx context.Context, execution repository.AgentHarnessExecution) {

--- a/backend/internal/workflow/agent_harness_execution_workflow_test.go
+++ b/backend/internal/workflow/agent_harness_execution_workflow_test.go
@@ -1592,3 +1592,38 @@ func (f *fakeGitHubPullRequestClient) CreatePullRequest(_ context.Context, input
 	f.pullRequestInput = input
 	return GitHubPullRequest{Number: 12, HTMLURL: "https://github.com/acme/repo/pull/12", State: "open", Draft: true}, nil
 }
+
+func TestExpectedArtifactsFromExecutionConfig(t *testing.T) {
+	config := []byte(`{"timeout_seconds":180,"agent_tryout":{"template_slug":"slide-deck","runtime":{"expected_artifacts":[{"key":"deck_outline","type":"markdown","path":"deck.md"},{"key":"structured_deck","type":"json","path":"deck.json"}]}}}`)
+	specs := expectedArtifactsFromExecutionConfig(config)
+	if len(specs) != 2 {
+		t.Fatalf("specs = %d, want 2", len(specs))
+	}
+	if specs[0].Key != "deck_outline" || specs[0].Path != "deck.md" || specs[0].Type != "markdown" {
+		t.Fatalf("first spec = %+v, want deck_outline/deck.md/markdown", specs[0])
+	}
+
+	// Non-tryout runs (no agent_tryout block) yield no capture work.
+	if got := expectedArtifactsFromExecutionConfig([]byte(`{"timeout_seconds":120}`)); got != nil {
+		t.Fatalf("non-tryout config should yield nil specs, got %+v", got)
+	}
+	if got := expectedArtifactsFromExecutionConfig(nil); got != nil {
+		t.Fatalf("empty config should yield nil specs, got %+v", got)
+	}
+}
+
+func TestCapturedArtifactContentType(t *testing.T) {
+	cases := map[string]string{
+		"deck.md":      "text/markdown",
+		"deck.json":    "application/json",
+		"data.csv":     "text/csv",
+		"changes.diff": "text/x-patch",
+		"mystery.xyz":  "application/octet-stream",
+	}
+	for path, wantPrefix := range cases {
+		got := capturedArtifactContentType(path)
+		if !strings.HasPrefix(got, wantPrefix) {
+			t.Fatalf("content type for %q = %q, want prefix %q", path, got, wantPrefix)
+		}
+	}
+}

--- a/backend/internal/workflow/repository.go
+++ b/backend/internal/workflow/repository.go
@@ -65,6 +65,13 @@ type AgentHarnessExecutionRepository interface {
 	RecordAgentHarnessExecutionEvent(ctx context.Context, params repository.RecordAgentHarnessExecutionEventParams) (repository.AgentHarnessExecutionEvent, error)
 }
 
+// ArtifactWriter persists produced files as durable, downloadable artifact rows.
+// It is the subset of the repository the harness needs to capture agent output
+// (e.g. an agent tryout's slide deck) before the sandbox is torn down.
+type ArtifactWriter interface {
+	CreateArtifact(ctx context.Context, params repository.CreateArtifactParams) (repository.Artifact, error)
+}
+
 type HostedRunStarter interface {
 	Start(ctx context.Context, input HostedRunStartInput) (hostedruns.StartResponse, error)
 }

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -5373,6 +5373,36 @@ paths:
         "404":
           $ref: "#/components/responses/NotFoundError"
 
+  /v1/workspaces/{workspaceID}/agent-tryouts/{id}/artifacts:
+    get:
+      operationId: listWorkspaceAgentTryoutArtifacts
+      summary: List the captured output artifacts of a workspace agent tryout
+      description: >-
+        Returns the durable output files the agent produced during a tryout
+        (e.g. a slide deck or spreadsheet), each with a signed, time-limited
+        download URL. Workspace members see every captured artifact (no public
+        template allowlist redaction). Empty when the tryout has no linked run
+        or produced no files.
+      tags: [AgentTryouts]
+      security:
+        - bearerJWT: []
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceID"
+        - $ref: "#/components/parameters/ResourceID"
+      responses:
+        "200":
+          description: Captured tryout artifacts
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListAgentTryoutArtifactsResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
   /v1/agent-tryouts/{id}/claim:
     post:
       operationId: claimAgentTryout
@@ -13298,6 +13328,45 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AgentTryoutCompareParticipant"
+
+    AgentTryoutArtifact:
+      type: object
+      required: [id, artifact_type, created_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+        key:
+          type: string
+          description: Template-defined logical name of the output (e.g. "deck_outline").
+        path:
+          type: string
+          description: Sandbox-relative path the file was produced at (e.g. "deck.md").
+        artifact_type:
+          type: string
+        content_type:
+          type: string
+        size_bytes:
+          type: integer
+          format: int64
+        download_url:
+          type: string
+          description: Signed, time-limited URL to fetch the artifact content. Absent if no signer is configured.
+        download_expires_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+
+    ListAgentTryoutArtifactsResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentTryoutArtifact"
 
     # --- Playgrounds ---
 

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/agent-tryouts/[tryoutId]/artifacts-section.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/agent-tryouts/[tryoutId]/artifacts-section.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Download, FileText, Loader2 } from "lucide-react";
+
+import type {
+  AgentTryout,
+  AgentTryoutArtifact,
+  ListAgentTryoutArtifactsResponse,
+} from "@/lib/api/types";
+import { useApiQuery } from "@/lib/api/swr";
+import { Button } from "@/components/ui/button";
+import { tryoutIsActive } from "../status";
+
+export function ArtifactsSection({
+  workspaceId,
+  tryout,
+}: {
+  workspaceId: string;
+  tryout: AgentTryout;
+}) {
+  const { data } = useApiQuery<ListAgentTryoutArtifactsResponse>(
+    `/v1/workspaces/${workspaceId}/agent-tryouts/${tryout.id}/artifacts`,
+    undefined,
+    {
+      // Outputs land when the run finishes — keep polling while it's active.
+      refreshInterval: tryoutIsActive(tryout.status) ? 3000 : 0,
+    },
+  );
+  const artifacts = data?.items ?? [];
+
+  return (
+    <section>
+      <h2 className="mb-3 text-sm font-semibold tracking-tight">Output</h2>
+      {artifacts.length === 0 ? (
+        <div className="rounded-lg border border-border p-4 text-sm text-muted-foreground">
+          {tryoutIsActive(tryout.status)
+            ? "The agent is still working — output files will appear here when it finishes."
+            : tryout.status === "completed"
+              ? "This tryout completed without producing any downloadable output files."
+              : "No output was captured for this tryout."}
+        </div>
+      ) : (
+        <ul className="space-y-4">
+          {artifacts.map((artifact) => (
+            <ArtifactCard key={artifact.id} artifact={artifact} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+const PREVIEWABLE = ["text/", "application/json"];
+const MAX_PREVIEW_BYTES = 512 * 1024;
+
+function isPreviewable(artifact: AgentTryoutArtifact): boolean {
+  const ct = artifact.content_type ?? "";
+  if (!PREVIEWABLE.some((prefix) => ct.startsWith(prefix))) return false;
+  return (artifact.size_bytes ?? 0) <= MAX_PREVIEW_BYTES;
+}
+
+function ArtifactCard({ artifact }: { artifact: AgentTryoutArtifact }) {
+  const label = artifact.path || artifact.key || artifact.artifact_type;
+  const previewable = isPreviewable(artifact) && Boolean(artifact.download_url);
+  const isJson = (artifact.content_type ?? "").startsWith("application/json");
+
+  const [preview, setPreview] = useState<string>();
+  const [previewError, setPreviewError] = useState(false);
+  const [loading, setLoading] = useState(previewable);
+
+  useEffect(() => {
+    if (!previewable || !artifact.download_url) return;
+    let cancelled = false;
+    fetch(artifact.download_url)
+      .then((res) => (res.ok ? res.text() : Promise.reject(new Error())))
+      .then((text) => {
+        if (cancelled) return;
+        setPreview(isJson ? prettyJson(text) : text);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setPreviewError(true);
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [previewable, artifact.download_url, isJson]);
+
+  return (
+    <li className="overflow-hidden rounded-lg border border-border">
+      <div className="flex items-center justify-between gap-3 border-b border-border bg-muted/20 px-4 py-2.5">
+        <div className="flex min-w-0 items-center gap-2">
+          <FileText className="size-4 shrink-0 text-muted-foreground" />
+          <span className="truncate text-sm font-medium">{label}</span>
+          {typeof artifact.size_bytes === "number" ? (
+            <span className="shrink-0 text-xs text-muted-foreground">
+              {formatBytes(artifact.size_bytes)}
+            </span>
+          ) : null}
+        </div>
+        {artifact.download_url ? (
+          <Button
+            size="xs"
+            variant="outline"
+            render={
+              <a href={artifact.download_url} download={label} target="_blank" rel="noreferrer" />
+            }
+          >
+            <Download data-icon="inline-start" className="size-3.5" />
+            Download
+          </Button>
+        ) : null}
+      </div>
+      {previewable ? (
+        loading ? (
+          <div className="flex justify-center py-6">
+            <Loader2 className="size-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : previewError ? (
+          <p className="px-4 py-3 text-sm text-muted-foreground">
+            Preview unavailable — use Download to view this file.
+          </p>
+        ) : (
+          <pre className="max-h-96 overflow-auto bg-muted/10 p-4 text-xs leading-relaxed whitespace-pre-wrap">
+            {preview}
+          </pre>
+        )
+      ) : (
+        <p className="px-4 py-3 text-sm text-muted-foreground">
+          {artifact.content_type ?? "binary"} — download to view.
+        </p>
+      )}
+    </li>
+  );
+}
+
+function prettyJson(text: string): string {
+  try {
+    return JSON.stringify(JSON.parse(text), null, 2);
+  } catch {
+    return text;
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/web/src/app/(workspace)/workspaces/[workspaceId]/agent-tryouts/[tryoutId]/tryout-detail-client.tsx
+++ b/web/src/app/(workspace)/workspaces/[workspaceId]/agent-tryouts/[tryoutId]/tryout-detail-client.tsx
@@ -30,6 +30,7 @@ import {
   tryoutModelLabel,
   tryoutStatusVariant,
 } from "../status";
+import { ArtifactsSection } from "./artifacts-section";
 import { PromoteTryoutDialog } from "./promote-tryout-dialog";
 import { RerunTryoutDialog } from "./rerun-tryout-dialog";
 
@@ -145,6 +146,8 @@ export function TryoutDetailClient({
           value={new Date(tryout.created_at).toLocaleString()}
         />
       </dl>
+
+      <ArtifactsSection workspaceId={workspaceId} tryout={tryout} />
 
       <section>
         <h2 className="mb-3 text-sm font-semibold tracking-tight">Timeline</h2>

--- a/web/src/lib/api/agent-tryouts.ts
+++ b/web/src/lib/api/agent-tryouts.ts
@@ -6,6 +6,7 @@ import type {
   AgentTryoutPromotionResult,
   AgentTryoutTemplate,
   CreateAgentTryoutInput,
+  ListAgentTryoutArtifactsResponse,
   PromoteAgentTryoutInput,
   RerunAgentTryoutInput,
 } from "./types";
@@ -57,6 +58,16 @@ export function getWorkspaceAgentTryoutEvents(
   return api.get<AgentTryoutEventsResponse>(
     `${workspaceAgentTryoutsPath(workspaceId)}/${tryoutId}/events`,
     { params: { after: opts?.after, limit: opts?.limit } },
+  );
+}
+
+export function listWorkspaceAgentTryoutArtifacts(
+  api: ApiClient,
+  workspaceId: string,
+  tryoutId: string,
+): Promise<ListAgentTryoutArtifactsResponse> {
+  return api.get<ListAgentTryoutArtifactsResponse>(
+    `${workspaceAgentTryoutsPath(workspaceId)}/${tryoutId}/artifacts`,
   );
 }
 

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -140,6 +140,7 @@ export {
   getWorkspaceAgentTryoutEvents,
   listAgentTryoutTemplates,
   listWorkspaceAgentTryouts,
+  listWorkspaceAgentTryoutArtifacts,
   promoteAgentTryoutToEval,
   rerunAgentTryout,
   workspaceAgentTryoutsPath,

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -2793,6 +2793,22 @@ export interface AgentTryoutCompareResult {
   participants: AgentTryoutCompareParticipant[];
 }
 
+export interface AgentTryoutArtifact {
+  id: string;
+  key?: string;
+  path?: string;
+  artifact_type: string;
+  content_type?: string;
+  size_bytes?: number;
+  download_url?: string;
+  download_expires_at?: string;
+  created_at: string;
+}
+
+export interface ListAgentTryoutArtifactsResponse {
+  items: AgentTryoutArtifact[];
+}
+
 // --- Errors ---
 
 /** Standard error envelope returned by all backend error responses. */


### PR DESCRIPTION
## Why

Tryouts ran the task, scored it, then **threw the output away**. The agent wrote `deck.md`/`deck.json` into the sandbox, the scorer read them, and then the sandbox was destroyed — nothing persisted the produced files, so there was no way to see or download the slide deck the agent actually made. The download scaffolding (signed URLs, public-share artifact path, template `expected_artifacts` allowlist) already existed, but nothing fed it: no code path uploaded a tryout's output files as artifacts. This PR connects the producer.

## What

**1. Harness captures output (the missing producer).** After the agent finishes and before the sandbox is torn down, the harness reads each template-declared `expected_artifacts` path out of the sandbox, uploads it to object storage, and persists an `Artifact` row linked to the run. Best-effort: a missing/oversized file or upload error is recorded as an event and never fails the run. No-op for non-tryout runs (they declare no `expected_artifacts`) and when no store is configured.
  - `Activities` gains an injected `storage.Store` (`WithArtifactStore`) and a type-asserted `ArtifactWriter`, wired through `NewTemporalWorker` from the store the worker already builds.
  - Metadata carries `artifact_key` + `relative_path` so the existing public-share allowlist matching keeps working.

**2. Workspace endpoint to list a tryout's artifacts.** `GET /v1/workspaces/{ws}/agent-tryouts/{id}/artifacts` → `ListArtifactsByRunID` + signed content URLs (via the existing `ArtifactManager` signer). Workspace owners see every captured artifact (no public-share redaction). Empty when the tryout has no run or produced nothing. OpenAPI updated.

**3. Detail-page viewer.** New **Output** section on the tryout detail page: inline preview for text/markdown/json/csv (fetched from the signed URL, JSON pretty-printed, capped at 512KB), a Download button per file, and honest empty states (still-running vs completed-with-no-output). Polls while the run is active so output appears as soon as it lands.

## Tests
- Backend: `ListWorkspaceTryoutArtifacts` returns only the run's artifacts with signed URLs / empty when no run; `expectedArtifactsFromExecutionConfig` parses the tryout manifest and ignores non-tryout configs; content-type mapping. `go build/vet`, `go test -race ./internal/api ./internal/workflow ./internal/worker` all pass.
- Web: `tsc`, `eslint` (0 errors), `next build` — all three tryout routes compile.
- OpenAPI: no new lint findings (the 5 pre-existing unresolved `ErrorResponse` refs in dataset paths are untouched).

Stacks conceptually on #967 (already merged to main); branched fresh off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)