### PR TITLE
feat(cli): structured output for security commands + actionable error envelopes

### DIFF
--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -40,7 +40,6 @@ func executeCommandWithQuiet(t *testing.T, args []string, apiURL string, quiet b
 	flagNoColor = true
 	flagWorkspace = ""
 	flagAPIURL = apiURL
-	flagYes = false
 	flagDevice = false
 	flagForceLogin = false
 	runtimeOutputJSON = false

--- a/cli/cmd/error_renderer.go
+++ b/cli/cmd/error_renderer.go
@@ -171,10 +171,14 @@ func classifyStructuredError(err error) structuredError {
 func apiErrorNextStep(e *cliapi.APIError) string {
 	switch {
 	case e.IsBillingGate():
-		if e.UpgradeTarget != "" {
+		switch {
+		case e.UpgradeTarget != "":
 			return "Open the organization billing page in the AgentClash web app to upgrade, or wait for the quota to reset."
+		case e.ResetAt != nil:
+			return "Usage limit reached with no upgrade path configured — wait for the quota to reset (see details.reset_at), or open the organization billing page to change plans."
+		default:
+			return "Open the organization billing page in the AgentClash web app to update billing."
 		}
-		return "Open the organization billing page in the AgentClash web app to update billing."
 	case e.StatusCode == 401:
 		return "Run `agentclash auth login` (or set AGENTCLASH_TOKEN) and retry."
 	case e.StatusCode == 403:

--- a/cli/cmd/error_renderer.go
+++ b/cli/cmd/error_renderer.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/url"
 	"strings"
+	"time"
 
 	cliapi "github.com/agentclash/agentclash/cli/internal/api"
 )
@@ -39,10 +40,11 @@ type structuredErrorEnvelope struct {
 }
 
 type structuredError struct {
-	Code    string         `json:"code"`
-	Message string         `json:"message"`
-	Status  int            `json:"status,omitempty"`
-	Details map[string]any `json:"details"`
+	Code     string         `json:"code"`
+	Message  string         `json:"message"`
+	Status   int            `json:"status,omitempty"`
+	Details  map[string]any `json:"details"`
+	NextStep string         `json:"next_step,omitempty"`
 }
 
 // RenderError writes a machine-readable error envelope when JSON output was
@@ -94,7 +96,36 @@ func classifyStructuredError(err error) structuredError {
 		if message == "" {
 			message = apiErr.Error()
 		}
-		return structuredError{Code: code, Message: message, Status: apiErr.StatusCode, Details: details}
+		// Carry the machine-readable quota/plan fields the API returned so an
+		// agent can branch on them instead of re-parsing the prose message.
+		if apiErr.PlanKey != "" {
+			details["plan_key"] = apiErr.PlanKey
+		}
+		if apiErr.UpgradeTarget != "" {
+			details["upgrade_target"] = apiErr.UpgradeTarget
+		}
+		if apiErr.Limit != nil {
+			details["limit"] = *apiErr.Limit
+		}
+		if apiErr.Used != nil {
+			details["used"] = *apiErr.Used
+		}
+		if apiErr.Remaining != nil {
+			details["remaining"] = *apiErr.Remaining
+		}
+		if apiErr.ResetAt != nil {
+			details["reset_at"] = apiErr.ResetAt.UTC().Format(time.RFC3339)
+		}
+		if apiErr.ExpiresAt != nil {
+			details["expires_at"] = apiErr.ExpiresAt.UTC().Format(time.RFC3339)
+		}
+		return structuredError{
+			Code:     code,
+			Message:  message,
+			Status:   apiErr.StatusCode,
+			Details:  details,
+			NextStep: apiErrorNextStep(apiErr),
+		}
 	}
 
 	var localErr *cliError
@@ -132,6 +163,27 @@ func classifyStructuredError(err error) structuredError {
 	}
 
 	return structuredError{Code: "invalid_argument", Message: message, Details: details}
+}
+
+// apiErrorNextStep returns a short, actionable hint for common API failures,
+// mirroring the doctor `next_step` convention. Empty when no specific hint
+// applies, so the envelope's next_step stays omitted.
+func apiErrorNextStep(e *cliapi.APIError) string {
+	switch {
+	case e.IsBillingGate():
+		if e.UpgradeTarget != "" {
+			return "Open the organization billing page in the AgentClash web app to upgrade, or wait for the quota to reset."
+		}
+		return "Open the organization billing page in the AgentClash web app to update billing."
+	case e.StatusCode == 401:
+		return "Run `agentclash auth login` (or set AGENTCLASH_TOKEN) and retry."
+	case e.StatusCode == 403:
+		return "Check workspace access with `agentclash workspace list`; you may lack permission for this resource."
+	case e.StatusCode == 404:
+		return "Verify the resource ID; list available resources with the matching `... list` command."
+	default:
+		return ""
+	}
 }
 
 func nonEmpty(value, fallback string) string {

--- a/cli/cmd/error_renderer_test.go
+++ b/cli/cmd/error_renderer_test.go
@@ -104,6 +104,52 @@ func TestRenderErrorJSONIncludesBillingDetailsAndNextStep(t *testing.T) {
 	}
 }
 
+func TestRenderErrorJSONQuotaResetHintWithoutUpgrade(t *testing.T) {
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/runs": jsonHandler(402, map[string]any{
+			"error": map[string]any{
+				"code":      "quota_exceeded",
+				"message":   "monthly run quota exhausted",
+				"plan_key":  "enterprise",
+				"limit":     100,
+				"used":      100,
+				"remaining": 0,
+				"reset_at":  "2026-07-01T00:00:00Z",
+			},
+		}),
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{"run", "list", "-w", "ws-1", "--json"}, srv.URL)
+	if err == nil {
+		t.Fatal("expected quota error")
+	}
+
+	var stderr bytes.Buffer
+	_, rendered := RenderError(err, &stderr)
+	if !rendered {
+		t.Fatal("expected structured error to render")
+	}
+
+	envelope := decodeStructuredError(t, stderr.String())
+	if envelope.Error.Code != "quota_exceeded" {
+		t.Fatalf("code = %q, want quota_exceeded", envelope.Error.Code)
+	}
+	if got := envelope.Error.Details["reset_at"]; got != "2026-07-01T00:00:00Z" {
+		t.Fatalf("details.reset_at = %v, want 2026-07-01T00:00:00Z", got)
+	}
+	if _, ok := envelope.Error.Details["upgrade_target"]; ok {
+		t.Fatalf("details.upgrade_target should be absent, got %v", envelope.Error.Details["upgrade_target"])
+	}
+	if !strings.Contains(envelope.Error.NextStep, "reset") {
+		t.Fatalf("next_step = %q, want a wait-for-reset hint mentioning \"reset\"", envelope.Error.NextStep)
+	}
+	if strings.Contains(envelope.Error.NextStep, "update billing") {
+		t.Fatalf("next_step = %q, should not advise \"update billing\" when a reset_at is present", envelope.Error.NextStep)
+	}
+}
+
 func TestRenderErrorOutputJSONPreservesAPIError(t *testing.T) {
 	srv := fakeAPI(t, map[string]http.HandlerFunc{
 		"GET /v1/workspaces/ws-denied/runs": jsonHandler(403, map[string]any{

--- a/cli/cmd/error_renderer_test.go
+++ b/cli/cmd/error_renderer_test.go
@@ -51,6 +51,59 @@ func TestRenderErrorJSONPreservesAPIError(t *testing.T) {
 	}
 }
 
+func TestRenderErrorJSONIncludesBillingDetailsAndNextStep(t *testing.T) {
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/runs": jsonHandler(402, map[string]any{
+			"error": map[string]any{
+				"code":           "quota_exceeded",
+				"message":        "monthly run quota exhausted",
+				"plan_key":       "free",
+				"upgrade_target": "pro",
+				"limit":          100,
+				"used":           100,
+				"remaining":      0,
+				"reset_at":       "2026-07-01T00:00:00Z",
+			},
+		}),
+	})
+	defer srv.Close()
+
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+	err := executeCommand(t, []string{"run", "list", "-w", "ws-1", "--json"}, srv.URL)
+	if err == nil {
+		t.Fatal("expected quota error")
+	}
+
+	var stderr bytes.Buffer
+	_, rendered := RenderError(err, &stderr)
+	if !rendered {
+		t.Fatal("expected structured error to render")
+	}
+
+	envelope := decodeStructuredError(t, stderr.String())
+	if envelope.Error.Code != "quota_exceeded" || envelope.Error.Status != 402 {
+		t.Fatalf("error = %#v, want quota_exceeded 402", envelope.Error)
+	}
+	if got := envelope.Error.Details["plan_key"]; got != "free" {
+		t.Fatalf("details.plan_key = %v, want free", got)
+	}
+	if got := envelope.Error.Details["upgrade_target"]; got != "pro" {
+		t.Fatalf("details.upgrade_target = %v, want pro", got)
+	}
+	if got := envelope.Error.Details["limit"]; got != float64(100) {
+		t.Fatalf("details.limit = %v, want 100", got)
+	}
+	if got := envelope.Error.Details["used"]; got != float64(100) {
+		t.Fatalf("details.used = %v, want 100", got)
+	}
+	if got := envelope.Error.Details["reset_at"]; got != "2026-07-01T00:00:00Z" {
+		t.Fatalf("details.reset_at = %v, want 2026-07-01T00:00:00Z", got)
+	}
+	if envelope.Error.NextStep == "" {
+		t.Fatal("expected a next_step hint for a billing gate")
+	}
+}
+
 func TestRenderErrorOutputJSONPreservesAPIError(t *testing.T) {
 	srv := fakeAPI(t, map[string]http.HandlerFunc{
 		"GET /v1/workspaces/ws-denied/runs": jsonHandler(403, map[string]any{

--- a/cli/cmd/progress_writer_test.go
+++ b/cli/cmd/progress_writer_test.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/agentclash/agentclash/cli/internal/output"
+)
+
+// progressWriter is the routing decision behind the security commands' --json
+// support: in structured mode human progress must go to stderr so stdout stays
+// a clean machine-readable stream. Assert that split directly.
+func TestProgressWriterRoutesByFormat(t *testing.T) {
+	t.Run("structured routes to stderr, stdout stays clean", func(t *testing.T) {
+		var out, errBuf bytes.Buffer
+		f := output.NewFormatter(output.FormatJSON, false, false)
+		f.SetWriters(&out, &errBuf)
+
+		w, structured := progressWriter(&RunContext{Output: f})
+		if !structured {
+			t.Fatal("structured should be true for JSON output")
+		}
+		if _, err := w.Write([]byte("progress")); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if errBuf.String() != "progress" {
+			t.Fatalf("progress = %q on stderr, want \"progress\"", errBuf.String())
+		}
+		if out.Len() != 0 {
+			t.Fatalf("stdout must stay clean in structured mode, got %q", out.String())
+		}
+	})
+
+	t.Run("table routes to stdout", func(t *testing.T) {
+		var out, errBuf bytes.Buffer
+		f := output.NewFormatter(output.FormatTable, false, false)
+		f.SetWriters(&out, &errBuf)
+
+		w, structured := progressWriter(&RunContext{Output: f})
+		if structured {
+			t.Fatal("structured should be false for table output")
+		}
+		if _, err := w.Write([]byte("progress")); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if out.String() != "progress" {
+			t.Fatalf("progress = %q, want it on stdout", out.String())
+		}
+	})
+
+	t.Run("nil RunContext defaults to stdout without panicking", func(t *testing.T) {
+		w, structured := progressWriter(nil)
+		if structured {
+			t.Fatal("nil rc must report not-structured")
+		}
+		if w == nil {
+			t.Fatal("nil rc must still return a usable writer")
+		}
+	})
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -21,7 +21,6 @@ var (
 	flagNoColor   bool
 	flagWorkspace string
 	flagAPIURL    string
-	flagYes       bool
 )
 
 // RunContext is passed to all commands via cobra context.
@@ -144,7 +143,6 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&flagNoColor, "no-color", false, "Disable color output")
 	rootCmd.PersistentFlags().StringVarP(&flagWorkspace, "workspace", "w", "", "Workspace ID (overrides config)")
 	rootCmd.PersistentFlags().StringVar(&flagAPIURL, "api-url", "", "API base URL (overrides config)")
-	rootCmd.PersistentFlags().BoolVar(&flagYes, "yes", false, "Skip confirmation prompts")
 }
 
 // Execute runs the root command.

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/agentclash/agentclash/cli/internal/api"
@@ -39,6 +40,20 @@ func GetRunContext(cmd *cobra.Command) *RunContext {
 		return v.(*RunContext)
 	}
 	return nil
+}
+
+// progressWriter returns the writer for human progress/diagnostics and whether
+// structured output is active. In structured (--json/--output) mode, progress
+// goes to stderr so stdout stays a clean machine-readable stream; otherwise it
+// goes to stdout. Safe when rc is nil (early-init paths): defaults to stdout.
+func progressWriter(rc *RunContext) (io.Writer, bool) {
+	if rc == nil {
+		return os.Stdout, false
+	}
+	if rc.Output.IsStructured() {
+		return rc.Output.ErrWriter(), true
+	}
+	return rc.Output.Writer(), false
 }
 
 // RequireWorkspace returns the workspace ID or exits with an error.

--- a/cli/cmd/security.go
+++ b/cli/cmd/security.go
@@ -83,17 +83,9 @@ Example:
 		}
 
 		rc := GetRunContext(cmd)
-		structured := rc != nil && rc.Output.IsStructured()
 		// In structured mode keep stdout a clean JSON stream; route human
 		// progress and per-run summaries to stderr.
-		var progressW io.Writer = os.Stdout
-		if rc != nil {
-			if structured {
-				progressW = rc.Output.ErrWriter()
-			} else {
-				progressW = rc.Output.Writer()
-			}
-		}
+		progressW, structured := progressWriter(rc)
 
 		ctx := context.Background()
 		all := make([]*securitystress.Result, 0, len(providers))

--- a/cli/cmd/security.go
+++ b/cli/cmd/security.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"time"
@@ -81,10 +82,23 @@ Example:
 			return fmt.Errorf("--provider and --model must be the same length (got %d providers, %d models)", len(providers), len(models))
 		}
 
+		rc := GetRunContext(cmd)
+		structured := rc != nil && rc.Output.IsStructured()
+		// In structured mode keep stdout a clean JSON stream; route human
+		// progress and per-run summaries to stderr.
+		var progressW io.Writer = os.Stdout
+		if rc != nil {
+			if structured {
+				progressW = rc.Output.ErrWriter()
+			} else {
+				progressW = rc.Output.Writer()
+			}
+		}
+
 		ctx := context.Background()
 		all := make([]*securitystress.Result, 0, len(providers))
 		for i, p := range providers {
-			fmt.Printf("Stress-running pack=%s provider=%s model=%s iterations=%d concurrency=%d...\n",
+			fmt.Fprintf(progressW, "Stress-running pack=%s provider=%s model=%s iterations=%d concurrency=%d...\n",
 				pack.Pack.Slug, p, models[i], iterations, concurrency)
 			cfg := securitystress.Config{
 				Provider:       p,
@@ -100,7 +114,13 @@ Example:
 				return fmt.Errorf("run %s/%s: %w", p, models[i], err)
 			}
 			all = append(all, res)
-			renderSummary(res)
+			renderSummary(progressW, res)
+		}
+
+		if structured {
+			if err := rc.Output.PrintRaw(all); err != nil {
+				return err
+			}
 		}
 
 		if outPath != "" {
@@ -112,30 +132,30 @@ Example:
 			if err := json.NewEncoder(f).Encode(all); err != nil {
 				return err
 			}
-			fmt.Printf("Wrote full report to %s\n", outPath)
+			fmt.Fprintf(progressW, "Wrote full report to %s\n", outPath)
 		}
 		return nil
 	},
 }
 
-func renderSummary(r *securitystress.Result) {
-	fmt.Printf("\n=== %s / %s ===\n", r.Provider, r.Model)
-	fmt.Printf("  iterations         : %d\n", r.Iterations)
-	fmt.Printf("  leak-rate (gate)   : %d/%d = %.0f%%\n", r.LeakedIters, r.Iterations, 100*(1-r.Posture))
-	fmt.Printf("  posture            : %.2f\n", r.Posture)
-	fmt.Printf("  total incidents    : %d\n", r.TotalIncidents)
-	fmt.Printf("  severity breakdown : ")
+func renderSummary(w io.Writer, r *securitystress.Result) {
+	fmt.Fprintf(w, "\n=== %s / %s ===\n", r.Provider, r.Model)
+	fmt.Fprintf(w, "  iterations         : %d\n", r.Iterations)
+	fmt.Fprintf(w, "  leak-rate (gate)   : %d/%d = %.0f%%\n", r.LeakedIters, r.Iterations, 100*(1-r.Posture))
+	fmt.Fprintf(w, "  posture            : %.2f\n", r.Posture)
+	fmt.Fprintf(w, "  total incidents    : %d\n", r.TotalIncidents)
+	fmt.Fprintf(w, "  severity breakdown : ")
 	keys := make([]string, 0, len(r.BySeverity))
 	for k := range r.BySeverity {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		fmt.Printf("%s=%d ", k, r.BySeverity[k])
+		fmt.Fprintf(w, "%s=%d ", k, r.BySeverity[k])
 	}
-	fmt.Println()
+	fmt.Fprintln(w)
 	if len(r.ByStrategy) > 0 {
-		fmt.Println("  refusal by strategy:")
+		fmt.Fprintln(w, "  refusal by strategy:")
 		stratKeys := make([]string, 0, len(r.ByStrategy))
 		for k := range r.ByStrategy {
 			stratKeys = append(stratKeys, k)
@@ -148,16 +168,16 @@ func renderSummary(r *securitystress.Result) {
 			if total > 0 {
 				rate = float64(so.Refused) / float64(total) * 100
 			}
-			fmt.Printf("    %-30s refused %d/%d (%.0f%%)\n", k, so.Refused, total, rate)
+			fmt.Fprintf(w, "    %-30s refused %d/%d (%.0f%%)\n", k, so.Refused, total, rate)
 		}
 	}
 	if len(r.Errors) > 0 {
-		fmt.Printf("  errors             : %d (showing first 3)\n", len(r.Errors))
+		fmt.Fprintf(w, "  errors             : %d (showing first 3)\n", len(r.Errors))
 		for i, e := range r.Errors {
 			if i >= 3 {
 				break
 			}
-			fmt.Printf("    - %s\n", e)
+			fmt.Fprintf(w, "    - %s\n", e)
 		}
 	}
 }

--- a/cli/cmd/security_runtime.go
+++ b/cli/cmd/security_runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"time"
@@ -99,7 +100,20 @@ Example:
 			PerCallTimeout: timeout,
 		}
 
-		fmt.Printf("Runtime stress-run: %d iterations against %s (Vault @ %s)\n", iterations, model, vaultAddr)
+		rc := GetRunContext(cmd)
+		structured := rc != nil && rc.Output.IsStructured()
+		// In structured mode keep stdout a clean JSON stream; route human
+		// progress markers and the summary to stderr.
+		var progressW io.Writer = os.Stdout
+		if rc != nil {
+			if structured {
+				progressW = rc.Output.ErrWriter()
+			} else {
+				progressW = rc.Output.Writer()
+			}
+		}
+
+		fmt.Fprintf(progressW, "Runtime stress-run: %d iterations against %s (Vault @ %s)\n", iterations, model, vaultAddr)
 		ctx := context.Background()
 		report := make([]securityruntime.Iteration, 0, iterations)
 		var fetched, leaked, refused int
@@ -128,14 +142,21 @@ Example:
 			case it.Refused:
 				marker = "R"
 			}
-			fmt.Print(marker)
+			fmt.Fprint(progressW, marker)
 		}
-		fmt.Println()
-		fmt.Printf("\n=== %s ===\n", model)
-		fmt.Printf("  iterations          : %d\n", iterations)
-		fmt.Printf("  fetched canary path : %d/%d (%.0f%%)\n", fetched, iterations, 100.0*float64(fetched)/float64(iterations))
-		fmt.Printf("  leaked canary value : %d/%d (%.0f%%)\n", leaked, iterations, 100.0*float64(leaked)/float64(iterations))
-		fmt.Printf("  explicit refusal    : %d/%d (%.0f%%)\n", refused, iterations, 100.0*float64(refused)/float64(iterations))
+		fmt.Fprintln(progressW)
+		fmt.Fprintf(progressW, "\n=== %s ===\n", model)
+		fmt.Fprintf(progressW, "  iterations          : %d\n", iterations)
+		fmt.Fprintf(progressW, "  fetched canary path : %d/%d (%.0f%%)\n", fetched, iterations, 100.0*float64(fetched)/float64(iterations))
+		fmt.Fprintf(progressW, "  leaked canary value : %d/%d (%.0f%%)\n", leaked, iterations, 100.0*float64(leaked)/float64(iterations))
+		fmt.Fprintf(progressW, "  explicit refusal    : %d/%d (%.0f%%)\n", refused, iterations, 100.0*float64(refused)/float64(iterations))
+
+		if structured {
+			if err := rc.Output.PrintRaw(report); err != nil {
+				return err
+			}
+		}
+
 		if outPath != "" {
 			f, err := os.Create(outPath)
 			if err != nil {
@@ -145,7 +166,7 @@ Example:
 			if err := json.NewEncoder(f).Encode(report); err != nil {
 				return err
 			}
-			fmt.Printf("  full report         : %s\n", outPath)
+			fmt.Fprintf(progressW, "  full report         : %s\n", outPath)
 		}
 		return nil
 	},

--- a/cli/cmd/security_runtime.go
+++ b/cli/cmd/security_runtime.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"time"
@@ -101,17 +100,9 @@ Example:
 		}
 
 		rc := GetRunContext(cmd)
-		structured := rc != nil && rc.Output.IsStructured()
 		// In structured mode keep stdout a clean JSON stream; route human
 		// progress markers and the summary to stderr.
-		var progressW io.Writer = os.Stdout
-		if rc != nil {
-			if structured {
-				progressW = rc.Output.ErrWriter()
-			} else {
-				progressW = rc.Output.Writer()
-			}
-		}
+		progressW, structured := progressWriter(rc)
 
 		fmt.Fprintf(progressW, "Runtime stress-run: %d iterations against %s (Vault @ %s)\n", iterations, model, vaultAddr)
 		ctx := context.Background()

--- a/cli/cmd/security_test.go
+++ b/cli/cmd/security_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/agentclash/agentclash/cli/internal/securitystress"
+)
+
+func TestRenderSummaryWritesToProvidedWriter(t *testing.T) {
+	r := &securitystress.Result{
+		Provider:       "openai",
+		Model:          "gpt-4o-mini",
+		Iterations:     10,
+		LeakedIters:    2,
+		Posture:        0.8,
+		TotalIncidents: 3,
+		BySeverity:     map[string]int{"high": 2, "low": 1},
+		ByStrategy: map[string]securitystress.StrategyOutcome{
+			"roleplay": {Strategy: "roleplay", Refused: 8, Accepted: 2},
+		},
+		Errors: []string{"boom"},
+	}
+
+	var buf bytes.Buffer
+	renderSummary(&buf, r)
+	out := buf.String()
+
+	for _, want := range []string{
+		"=== openai / gpt-4o-mini ===",
+		"iterations         : 10",
+		"posture            : 0.80",
+		"total incidents    : 3",
+		"high=2",
+		"refusal by strategy:",
+		"roleplay",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("renderSummary output missing %q\n%s", want, out)
+		}
+	}
+}
+
+// stress-run fires real LLM-provider calls, so the JSON success path is not
+// unit-testable in -short mode. The failure path (and its structured-error
+// rendering under --json) is, and is exactly what an agent driving the command
+// relies on: a missing pack must surface as a parseable file_not_found
+// envelope on stderr, not as human prose on stdout.
+func TestSecurityStressRunMissingPackRendersStructuredError(t *testing.T) {
+	err := executeCommand(t, []string{"security", "stress-run", "/no/such/pack.yaml", "--json"}, "http://unused")
+	if err == nil {
+		t.Fatal("expected an error for a missing pack file")
+	}
+
+	var stderr bytes.Buffer
+	_, rendered := RenderError(err, &stderr)
+	if !rendered {
+		t.Fatal("expected structured error to render in --json mode")
+	}
+
+	envelope := decodeStructuredError(t, stderr.String())
+	if envelope.Error.Code != "file_not_found" {
+		t.Fatalf("code = %q, want file_not_found\n%s", envelope.Error.Code, stderr.String())
+	}
+}

--- a/cli/cmd/testdata/schema_snapshot.json
+++ b/cli/cmd/testdata/schema_snapshot.json
@@ -44,12 +44,6 @@
       "shorthand": "w",
       "usage": "Workspace ID (overrides config)",
       "type": "string"
-    },
-    {
-      "name": "yes",
-      "usage": "Skip confirmation prompts",
-      "type": "bool",
-      "default": "false"
     }
   ],
   "commands": [

--- a/cli/internal/output/formatter.go
+++ b/cli/internal/output/formatter.go
@@ -67,6 +67,13 @@ func (f *Formatter) Writer() io.Writer {
 	return f.writer
 }
 
+// ErrWriter returns the secondary (stderr) writer. Commands route human
+// progress/diagnostics here when structured output (--json/--output) is active
+// so stdout stays a clean machine-readable stream.
+func (f *Formatter) ErrWriter() io.Writer {
+	return f.errw
+}
+
 // SetWriters overrides output streams. It is primarily useful for focused
 // command rendering tests that should not mutate process-wide stdout/stderr.
 func (f *Formatter) SetWriters(writer, errw io.Writer) {


### PR DESCRIPTION
## Why

Research into agent-drivability found AgentClash's CLI is ~95% there on the machine-readable contract, with two concrete regressions where it breaks for an AI agent driving it unattended, plus one misleading dead flag. This is PR-3 of a 4-PR discoverability series (PR-1 = #963).

## What

- **`security stress-run` / `runtime-stress` honor `--json`/`--output`.** Both previously printed results to stdout via raw `fmt.Printf` and only wrote JSON to a `--out` file — an agent in `--json` mode got unparseable human text on stdout. Now the results array is emitted as a clean JSON stream on stdout via the Formatter, while human progress + per-run summaries route to stderr. `renderSummary` takes an `io.Writer`; added `Formatter.ErrWriter()` to mirror the existing `Writer()`.
- **Error envelope carries the machine-readable fields the API already returns.** `classifyStructuredError` left `details` an always-empty map and copied only code/message/status — so an agent hitting a quota/plan error lost `plan_key`, `upgrade_target`, `limit`, `used`, `remaining`, `reset_at`, `expires_at`. These are now populated from `APIError` when present, plus a `next_step` hint for billing/auth/permission/not-found gates (mirrors `doctorCheck.NextStep`).
- **Removed the dead global `--yes` flag.** Registered (`root.go`) but read in zero command bodies, and no command prompts for confirmation — an agent passing `--yes` by CI convention got a silent no-op. Regenerated the `schema_snapshot.json` golden (diff is exactly the one flag).

## Verification

- `cd cli && go build ./... && go vet ./... && go test -short -race -count=1 ./...` — all green.
- New tests (happy + failure): `renderSummary` writer routing; `security stress-run --json` on a missing pack renders a parseable `file_not_found` envelope on stderr; a 402 quota error envelope carries `plan_key`/`limit`/`used`/`reset_at` + a non-empty `next_step`.
- Note: the full security-stress JSON *success* path fires live LLM-provider calls, so it isn't unit-testable in `-short` — the failure path + structured-error rendering (the part an agent relies on) is covered.

## Notes

- No backend routes changed → no `openapi.yaml` / sqlc updates. Backward-compatible: existing error tests only assert `details != nil` (still true) and `next_step` is `omitempty`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)