### PR TITLE
docs(discovery): SoftwareSourceCode JSON-LD, llms.txt install line, README badges, community-health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Report something that isn't working as expected
+title: "bug: "
+labels: bug
+---
+
+**Component**
+<!-- backend API / Temporal worker / CLI / web / docs -->
+
+**What happened**
+<!-- A clear description of the bug. -->
+
+**Steps to reproduce**
+1.
+2.
+3.
+
+**Expected behavior**
+<!-- What you expected instead. -->
+
+**Environment**
+- AgentClash version / commit:
+- CLI version (`agentclash version`) if relevant:
+- OS:
+- Hosted (agentclash.dev) or self-hosted:
+
+**Logs / output**
+<!-- Paste relevant logs, errors, or a `--json` payload. Redact secrets. -->
+
+> For security vulnerabilities, do not open a public issue — see SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://www.agentclash.dev/docs
+    about: Quickstart, guides, CLI reference, and challenge-pack authoring.
+  - name: Security vulnerability
+    url: https://github.com/agentclash/agentclash/security/advisories/new
+    about: Report a vulnerability privately — please do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+title: "feat: "
+labels: enhancement
+---
+
+**Problem / motivation**
+<!-- What are you trying to do? What's painful or missing today? -->
+
+**Proposed solution**
+<!-- What you'd like to see. -->
+
+**Alternatives considered**
+<!-- Other approaches you thought about. -->
+
+**Area**
+<!-- backend / CLI / web / challenge packs / docs -->
+
+**Additional context**
+<!-- Anything else: examples, links, mockups. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!-- Thanks for contributing to AgentClash! Keep PRs focused. -->
+
+## What & why
+
+<!-- What does this change and why? Link any related issue (e.g. Closes #123). -->
+
+## Type
+
+<!-- Conventional Commit type used in the title: fix / feat / feat! / docs / chore / ci / refactor / test -->
+
+## Areas touched
+
+- [ ] Backend (`backend/`)
+- [ ] CLI (`cli/`)
+- [ ] Frontend (`web/`)
+- [ ] Docs / other
+
+## Verification
+
+<!-- How did you test this? Paste commands/output. -->
+
+- [ ] Builds, `vet`/`lint`, and type checks pass for every part I touched
+- [ ] Tests added/updated (happy path and a failure path where applicable)
+- [ ] If a backend route changed, `docs/api-server/openapi.yaml` is updated
+- [ ] If DB queries changed, `sqlc generate` was run
+
+## Notes for reviewers
+
+<!-- Anything reviewers should focus on, follow-ups, or known gaps. -->

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+message: "If you use AgentClash in your research, please cite it as below."
+title: AgentClash
+abstract: >-
+  Open-source race engine that pits AI models and agents against each other on
+  real tasks with live scoring: sandboxed tools, replay, scorecards, and CI
+  regression gates.
+type: software
+url: "https://www.agentclash.dev"
+repository-code: "https://github.com/agentclash/agentclash"
+license: MIT
+keywords:
+  - ai-agent-evaluation
+  - llm-evaluation
+  - agent-benchmark
+  - regression-testing
+  - eval
+authors:
+  - name: "The AgentClash Authors"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,6 +9,8 @@ type: software
 url: "https://www.agentclash.dev"
 repository-code: "https://github.com/agentclash/agentclash"
 license: MIT
+version: 0.29.0
+date-released: "2026-06-02"
 keywords:
   - ai-agent-evaluation
   - llm-evaluation

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Code of Conduct
+
+AgentClash adopts the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, as its Code of Conduct. The full text is available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.
+
+## Our pledge (summary)
+
+We are committed to making participation in this project a harassment-free,
+welcoming, and inclusive experience for everyone, regardless of background or
+identity. We expect all participants to be respectful, constructive, and
+considerate in issues, pull requests, and other community spaces.
+
+## Reporting
+
+To report a concern or a violation, contact the maintainers privately by opening
+a [private security advisory](https://github.com/agentclash/agentclash/security/advisories/new)
+(it is a private channel) or by reaching a maintainer directly. All reports will
+be reviewed and handled confidentially.
+
+> Maintainers: replace the reporting channel above with a dedicated contact email
+> when one is available.
+
+## Enforcement
+
+Maintainers are responsible for clarifying and enforcing standards of acceptable
+behavior and may take appropriate, fair corrective action — including warnings,
+temporary bans, or permanent bans — in response to behavior they deem
+inappropriate, in line with the Contributor Covenant's Enforcement Guidelines.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to AgentClash
+
+Thanks for your interest in improving AgentClash — an open-source race engine
+that pits AI models and agents against each other on real tasks with live
+scoring. This guide covers how to get set up and what we expect in a
+contribution.
+
+By participating you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Repository layout
+
+AgentClash is a monorepo with three independently buildable parts:
+
+- **Backend (Go)** — `backend/`: REST API server + Temporal worker.
+- **CLI (Go)** — `cli/`: a **separate Go module**, distributed as the `agentclash`
+  npm package. Run Go commands from inside `cli/`.
+- **Frontend (Next.js)** — `web/`.
+
+Because the backend and CLI are separate Go modules, a change that spans both
+must build and test from **each** directory.
+
+## Prerequisites
+
+- Go 1.25+
+- Node.js 18+ and `pnpm`
+- Docker (for Postgres/Temporal in the full local stack)
+- Temporal CLI (`brew install temporal`) for the full stack
+
+## Build & test
+
+```bash
+# Backend
+cd backend && go build ./... && go vet ./... && go test -short -race -count=1 ./...
+
+# CLI (from the cli/ module)
+cd cli && go build ./... && go vet ./... && go test -short -race -count=1 ./...
+
+# Frontend
+cd web && pnpm install && pnpm lint && npx tsc --noEmit && pnpm test
+```
+
+Useful entry points: `make api-server`, `make worker`, `./scripts/dev/start-local-stack.sh`.
+See `CLAUDE.md` and `AGENTS.md` for the fuller command reference and architecture notes.
+
+If you change DB queries, regenerate code with `cd backend && sqlc generate`.
+If you add/modify a backend API route, update `docs/api-server/openapi.yaml`.
+
+## Pull requests
+
+1. Branch off `main`.
+2. Use [Conventional Commits](https://www.conventionalcommits.org/): `fix:` (patch),
+   `feat:` (minor), `feat!:` (major). Release Please uses these to version releases.
+3. Keep PRs focused; include tests for behavior changes (happy path **and** a
+   failure path where it applies).
+4. Make sure builds, `vet`/`lint`, type checks, and tests pass for every part you
+   touched.
+5. Open the PR against `main` and fill in the template.
+
+## Reporting bugs & requesting features
+
+Use the issue templates under **New issue**. For security issues, do **not** open
+a public issue — see [SECURITY.md](SECURITY.md).
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+project's [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Open-source AI agent evaluation for real tasks. AgentClash lets you race agents 
 
 [Website](https://www.agentclash.dev) · [Docs](https://www.agentclash.dev/docs) · [Changelog](https://www.agentclash.dev/changelog) · [CLI Distribution](docs/cli-distribution.md) · [Challenge Packs](docs/evaluation/challenge-pack-v0.md) · [CI Gates](web/content/docs/guides/ci-cd-agent-gates.mdx)
 
+[![npm version](https://img.shields.io/npm/v/agentclash?logo=npm&color=cb3837)](https://www.npmjs.com/package/agentclash)
+[![npm downloads](https://img.shields.io/npm/dm/agentclash?logo=npm&color=cb3837)](https://www.npmjs.com/package/agentclash)
+[![License: MIT](https://img.shields.io/github/license/agentclash/agentclash?color=blue)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/agentclash/agentclash?style=flat&logo=github)](https://github.com/agentclash/agentclash)
+
 ## What AgentClash Does
 
 AgentClash is built for teams shipping agents, not leaderboard demos. It evaluates the whole run: the final answer, the tool choices, the artifacts, the latency, the cost, and the evidence trail that explains why one agent passed while another failed.
@@ -226,8 +231,6 @@ Typical workflow:
 2. Inspect scorecards, replays, and failure details.
 3. Promote important failures into a regression suite.
 4. Re-run the suite whenever prompts, models, tools, or agent code changes.
-
-> Screenshot placeholder: add a failure review or regression suite screenshot here.
 
 ## Gate Agent Changes In CI
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, use GitHub's private vulnerability reporting:
+
+1. Go to the repository's **Security** tab.
+2. Click **Report a vulnerability** to open a private advisory.
+
+Include as much of the following as you can:
+
+- A description of the issue and its impact.
+- Steps to reproduce (proof-of-concept, affected component: backend API, Temporal
+  worker, CLI, or web).
+- Affected version(s) / commit, and any relevant configuration.
+
+We aim to acknowledge a report within a few business days and will keep you
+updated as we triage and fix. Please give us a reasonable window to ship a fix
+before any public disclosure, and let us know if you'd like to be credited.
+
+## Scope
+
+AgentClash runs untrusted agent code in sandboxes and brokers provider/API
+credentials, so we are especially interested in: sandbox escape, secret/credential
+exposure, tenant isolation breaks, authentication/authorization bypass, and
+injection in the API or workflow layer.
+
+## Supported versions
+
+This is an actively developed pre-1.0 project; security fixes target the latest
+`main` and the most recent release. Please test against the latest version before
+reporting.

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -7,6 +7,7 @@ import {
   faqSchema,
   organizationSchema,
   productSchema,
+  softwareSourceCodeSchema,
   websiteSchema,
 } from "@/components/marketing/json-ld";
 import { hasPublishedBenchmarks } from "@/lib/benchmarks";
@@ -57,6 +58,7 @@ export default async function RootPage() {
         id="agentclash-homepage-schema"
         data={[
           softwareApplicationSchema,
+          softwareSourceCodeSchema(),
           organizationSchema(),
           websiteSchema(),
           faqSchema(HOME_FAQ),

--- a/web/src/components/marketing/json-ld.tsx
+++ b/web/src/components/marketing/json-ld.tsx
@@ -223,6 +223,26 @@ export function websiteSchema(): Record<string, unknown> {
   };
 }
 
+// SoftwareSourceCode is the schema.org type purpose-built for an open-source
+// repository — it links the named entity to its code, languages, and license,
+// which the SoftwareApplication node does not express. Emitted on the homepage.
+export function softwareSourceCodeSchema(): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "SoftwareSourceCode",
+    name: "AgentClash",
+    alternateName: "Agent Clash",
+    description:
+      "Open-source race engine that pits AI models and agents against each other on real tasks with sandboxed tools, replay, scorecards, and CI regression gates.",
+    url: SITE_URL,
+    codeRepository: "https://github.com/agentclash/agentclash",
+    programmingLanguage: ["Go", "TypeScript"],
+    runtimePlatform: ["Go", "Node.js", "Next.js"],
+    license: "https://opensource.org/licenses/MIT",
+    author: publisherSchema(),
+  };
+}
+
 export function articleSchema({
   headline,
   description,

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -1764,7 +1764,7 @@ export function buildLlmsIndex(origin = DOCS_ORIGIN) {
     `- [CLI Reference](${origin}/docs-md/reference/cli) - generated command reference.`,
     `- [Config Reference](${origin}/docs-md/reference/config) - generated environment and precedence reference.`,
     `- [Agent Skills](${origin}/docs-md/agent-skills) - copyable AgentClash skills for coding agents.`,
-    "- Set up in your coding agent: `npm i -g agentclash && agentclash integration <agent> install` (claude, codex, cursor, openclaw, hermes, opencode).",
+    `- [Integration setup](${origin}/docs-md/agent-skills) - \`npm i -g agentclash && agentclash integration <agent> install\` (claude, codex, cursor, openclaw, hermes, opencode).`,
     `- [Full bundle](${origin}/llms-full.txt) - all shipped docs in one file.`,
     "",
     "## Public product pages",

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -1764,7 +1764,7 @@ export function buildLlmsIndex(origin = DOCS_ORIGIN) {
     `- [CLI Reference](${origin}/docs-md/reference/cli) - generated command reference.`,
     `- [Config Reference](${origin}/docs-md/reference/config) - generated environment and precedence reference.`,
     `- [Agent Skills](${origin}/docs-md/agent-skills) - copyable AgentClash skills for coding agents.`,
-    `- [Integration setup](${origin}/docs-md/agent-skills) - \`npm i -g agentclash && agentclash integration <agent> install\` (claude, codex, cursor, openclaw, hermes, opencode).`,
+    `- [Integration setup](${origin}/docs-md/guides/use-with-ai-tools) - \`npm i -g agentclash && agentclash integration <agent> install\` (claude, codex, cursor, openclaw, hermes, opencode).`,
     `- [Full bundle](${origin}/llms-full.txt) - all shipped docs in one file.`,
     "",
     "## Public product pages",

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -1764,6 +1764,7 @@ export function buildLlmsIndex(origin = DOCS_ORIGIN) {
     `- [CLI Reference](${origin}/docs-md/reference/cli) - generated command reference.`,
     `- [Config Reference](${origin}/docs-md/reference/config) - generated environment and precedence reference.`,
     `- [Agent Skills](${origin}/docs-md/agent-skills) - copyable AgentClash skills for coding agents.`,
+    "- Set up in your coding agent: `npm i -g agentclash && agentclash integration <agent> install` (claude, codex, cursor, openclaw, hermes, opencode).",
     `- [Full bundle](${origin}/llms-full.txt) - all shipped docs in one file.`,
     "",
     "## Public product pages",


### PR DESCRIPTION
## Why

The discoverability research found AgentClash's on-site SEO is already advanced, but it's missing the open-source credibility signals (community-health files, README badges) and the one schema.org type built for OSS repos. PR-4 of the series — closes the cheap, repo-side human/AEO gaps.

## What

- **`SoftwareSourceCode` JSON-LD** (`json-ld.tsx`) emitted on the homepage: `codeRepository`, `programmingLanguage` (Go, TypeScript), `runtimePlatform`, MIT `license`. This is the schema.org type purpose-built for an OSS repository, which the existing `SoftwareApplication` node doesn't express. `sameAs` left as GitHub+npm — expanding it needs **real** off-site profiles (X/Wikidata/etc.), so it's tracked as off-site follow-up rather than fabricated here.
- **llms.txt install line** (`docs.ts` `buildLlmsIndex`): surfaces `npm i -g agentclash && agentclash integration <agent> install` in Core entrypoints.
- **README**: npm-version / npm-downloads / license / stars badges under the links bar; removed the literal "Screenshot placeholder" line (no real asset yet — a placeholder on the most-viewed surface is worse than nothing).
- **Community-health files** (near-mandatory for awesome-list inclusion + LLM/human credibility): `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1 by reference), `SECURITY.md` (private-advisory reporting), `CITATION.cff`, PR template, bug/feature issue templates + config.

## Verification

- `cd web && npx tsc --noEmit` — clean.
- `vitest run json-ld.test.ts docs.test.ts` — 50 tests pass (productSchema `sameAs` unchanged; homepage schema array not pinned; `buildLlmsIndex` checks are `toContain`).
- `npm run lint` — 0 errors (3 pre-existing warnings in untouched files).
- New YAML (`CITATION.cff`, issue-template `config.yml`) parse cleanly.

## Deferred (noted, not in this PR)

- **Answer-capsule on `/ai-agent-benchmark`** (plan 4f): the most component-surgical item, and that page already has strong `SoftwareApplication` + FAQ schema + content — deferred to keep this PR reviewable.
- **`FUNDING.yml`**: needs a real GitHub Sponsors / OpenCollective account you own — not fabricated.
- **Expanding `sameAs`** depends on the off-site footprint work (Wikipedia/Wikidata/awesome-lists), which is the ongoing non-repo track.
- The `use-with-ai-tools` `--project` doc fix (plan 4c) ships in PR #963 to avoid a conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)