### PR TITLE
fix(skills): correct agentclash-dataset-workflows command/flag drift

### DIFF
--- a/cli/internal/skills/snapshot/agentclash-dataset-workflows/SKILL.md
+++ b/cli/internal/skills/snapshot/agentclash-dataset-workflows/SKILL.md
@@ -54,7 +54,7 @@ agentclash dataset version list <dataset-id>
 agentclash dataset version create <dataset-id> --label "v2-seeds"
 agentclash dataset import <dataset-id> examples.jsonl
 agentclash dataset export <dataset-id> --version <version-id> > out.jsonl
-agentclash dataset example list <dataset-id> --version <version-id>
+agentclash dataset example list <dataset-id>
 agentclash dataset example add <dataset-id> --input '{"messages":[...]}' --expected '{"score":1}'
 agentclash dataset example edit <dataset-id> <example-id> --expected '{"score":1}'
 agentclash dataset example rm <dataset-id> <example-id>

--- a/cli/internal/skills/snapshot/agentclash-dataset-workflows/SKILL.md
+++ b/cli/internal/skills/snapshot/agentclash-dataset-workflows/SKILL.md
@@ -34,11 +34,11 @@ End-to-end dataset operations in a workspace: versioned example banks, eval runs
 export AGENTCLASH_API_URL="https://api.agentclash.dev"
 agentclash workspace use <WORKSPACE_ID>
 agentclash dataset list
-agentclash dataset get <DATASET_ID> --json
+agentclash dataset view <DATASET_ID> --json
 ```
 
 ## Procedure
-1. Inspect dataset and versions (`list`, `get`, `versions list`).
+1. Inspect dataset and versions (`list`, `view`, `version list`).
 2. Import or export examples; optionally create a version snapshot.
 3. Run a dataset eval or attach an existing run.
 4. Gate with `dataset test` against a baseline (CI-friendly `--format junit`).
@@ -49,15 +49,15 @@ agentclash dataset get <DATASET_ID> --json
 ### Inspect and mutate examples
 ```bash
 agentclash dataset list
-agentclash dataset get <dataset-id>
-agentclash dataset versions list <dataset-id>
-agentclash dataset versions create <dataset-id> --label "v2-seeds"
+agentclash dataset view <dataset-id>
+agentclash dataset version list <dataset-id>
+agentclash dataset version create <dataset-id> --label "v2-seeds"
 agentclash dataset import <dataset-id> examples.jsonl
-agentclash dataset export <dataset-id> --version <version-id> -o out.jsonl
-agentclash dataset examples list <dataset-id> --version <version-id>
-agentclash dataset examples add <dataset-id> --input '{"messages":[...]}' --expected '{"score":1}'
-agentclash dataset examples update <dataset-id> <example-id> --expected-file expected.json
-agentclash dataset examples delete <dataset-id> <example-id>
+agentclash dataset export <dataset-id> --version <version-id> > out.jsonl
+agentclash dataset example list <dataset-id> --version <version-id>
+agentclash dataset example add <dataset-id> --input '{"messages":[...]}' --expected '{"score":1}'
+agentclash dataset example edit <dataset-id> <example-id> --expected '{"score":1}'
+agentclash dataset example rm <dataset-id> <example-id>
 ```
 
 ### Eval and CI gate
@@ -102,7 +102,7 @@ agentclash dataset generate <dataset-id> \
 agentclash dataset import-traces <dataset-id> traces.json --source otel
 agentclash dataset import-traces <dataset-id> --source agentclash --run <run-id> --run-agent <run-agent-id>
 agentclash dataset trace-candidates list <dataset-id> --status pending
-agentclash dataset promote <dataset-id> <candidate-id> --tag production --expected-file edited.json
+agentclash dataset promote <dataset-id> <candidate-id> --tag production --expected '{"score":1}'
 ```
 
 ### Regression suite sync

--- a/cli/internal/skills/snapshot/agentclash-hub/SKILL.md
+++ b/cli/internal/skills/snapshot/agentclash-hub/SKILL.md
@@ -41,6 +41,22 @@ Portable bundle install (copy skills to another agent host without the integrati
 3. Follow dependency order for setup → pack → run → review → regression → CI.
 4. Send the user to the matching UI page when they need a visual surface.
 
+## Drive The CLI Like An Agent
+When you (a coding agent) drive AgentClash non-interactively, lean on the machine contract:
+
+- **Ask for machine output.** Pass `--json` (or `-o json`) on every command. Data goes to
+  **stdout**; human progress and diagnostics go to **stderr** — parse stdout only.
+- **Discover the surface first.** `agentclash schema --json` returns the full command tree, flags,
+  and documented exit codes. Prefer it over scraping `--help` prose.
+- **Branch on structured errors, never on prose.** On failure the CLI prints a JSON envelope:
+  `error.code` is a stable machine key — branch on it; `error.next_step` is the remediation to act
+  on; `error.details` carries specifics (quota `limit`/`used`/`remaining`, `reset_at`, `plan_key`).
+- **Gate readiness on `agentclash doctor`.** It exits non-zero when the environment isn't ready.
+  `agentclash quickstart --json` is informational and exits 0 even when `ready:false` — use `doctor`
+  as the hard gate in CI/agent flows.
+- **Stay headless.** Set `AGENTCLASH_TOKEN`, `AGENTCLASH_WORKSPACE`, and `AGENTCLASH_API_URL` in the
+  environment so no command needs an interactive prompt.
+
 ## End-To-End Eval Workflow (CLI)
 
 ```text

--- a/cli/internal/skills/snapshot/manifest.json
+++ b/cli/internal/skills/snapshot/manifest.json
@@ -1,5 +1,5 @@
 {
-  "snapshot_version": "ffb3bfecd515",
+  "snapshot_version": "c08a76ce9fd6",
   "skills": [
     {
       "name": "agentclash-agent-build-author",
@@ -89,7 +89,7 @@
       "name": "agentclash-dataset-workflows",
       "role": "dataset",
       "requires_cli": true,
-      "sha256": "7eff177c475f47c6e224ea9dfe7854418d2d99d11ac941f10e601ac1964820a6"
+      "sha256": "084f68ccaaa17bcb463300adc8dcc2f0b9e29afb0eec5bf14250046dec12a31c"
     },
     {
       "name": "agentclash-eval-runner",

--- a/cli/internal/skills/snapshot/manifest.json
+++ b/cli/internal/skills/snapshot/manifest.json
@@ -1,5 +1,5 @@
 {
-  "snapshot_version": "83229acecb3d",
+  "snapshot_version": "ffb3bfecd515",
   "skills": [
     {
       "name": "agentclash-agent-build-author",
@@ -89,7 +89,7 @@
       "name": "agentclash-dataset-workflows",
       "role": "dataset",
       "requires_cli": true,
-      "sha256": "4947e24a77204157ac9233ee5dddd9ea3fa791abc463e5079ff21f43fe43b99b"
+      "sha256": "7eff177c475f47c6e224ea9dfe7854418d2d99d11ac941f10e601ac1964820a6"
     },
     {
       "name": "agentclash-eval-runner",
@@ -101,7 +101,7 @@
       "name": "agentclash-hub",
       "role": "hub",
       "requires_cli": false,
-      "sha256": "b721744119811406a1fe5b4792faff4e33a9c4d2d4b50c32b0b528f19696abb3"
+      "sha256": "90813adc0753b190a2a5614a4dfefa39670f643de04a1f8f4c5a25fc2de4c36d"
     },
     {
       "name": "agentclash-multi-turn-operator",

--- a/web/content/agent-skills/agentclash-dataset-workflows/SKILL.md
+++ b/web/content/agent-skills/agentclash-dataset-workflows/SKILL.md
@@ -54,7 +54,7 @@ agentclash dataset version list <dataset-id>
 agentclash dataset version create <dataset-id> --label "v2-seeds"
 agentclash dataset import <dataset-id> examples.jsonl
 agentclash dataset export <dataset-id> --version <version-id> > out.jsonl
-agentclash dataset example list <dataset-id> --version <version-id>
+agentclash dataset example list <dataset-id>
 agentclash dataset example add <dataset-id> --input '{"messages":[...]}' --expected '{"score":1}'
 agentclash dataset example edit <dataset-id> <example-id> --expected '{"score":1}'
 agentclash dataset example rm <dataset-id> <example-id>

--- a/web/content/agent-skills/agentclash-dataset-workflows/SKILL.md
+++ b/web/content/agent-skills/agentclash-dataset-workflows/SKILL.md
@@ -34,11 +34,11 @@ End-to-end dataset operations in a workspace: versioned example banks, eval runs
 export AGENTCLASH_API_URL="https://api.agentclash.dev"
 agentclash workspace use <WORKSPACE_ID>
 agentclash dataset list
-agentclash dataset get <DATASET_ID> --json
+agentclash dataset view <DATASET_ID> --json
 ```
 
 ## Procedure
-1. Inspect dataset and versions (`list`, `get`, `versions list`).
+1. Inspect dataset and versions (`list`, `view`, `version list`).
 2. Import or export examples; optionally create a version snapshot.
 3. Run a dataset eval or attach an existing run.
 4. Gate with `dataset test` against a baseline (CI-friendly `--format junit`).
@@ -49,15 +49,15 @@ agentclash dataset get <DATASET_ID> --json
 ### Inspect and mutate examples
 ```bash
 agentclash dataset list
-agentclash dataset get <dataset-id>
-agentclash dataset versions list <dataset-id>
-agentclash dataset versions create <dataset-id> --label "v2-seeds"
+agentclash dataset view <dataset-id>
+agentclash dataset version list <dataset-id>
+agentclash dataset version create <dataset-id> --label "v2-seeds"
 agentclash dataset import <dataset-id> examples.jsonl
-agentclash dataset export <dataset-id> --version <version-id> -o out.jsonl
-agentclash dataset examples list <dataset-id> --version <version-id>
-agentclash dataset examples add <dataset-id> --input '{"messages":[...]}' --expected '{"score":1}'
-agentclash dataset examples update <dataset-id> <example-id> --expected-file expected.json
-agentclash dataset examples delete <dataset-id> <example-id>
+agentclash dataset export <dataset-id> --version <version-id> > out.jsonl
+agentclash dataset example list <dataset-id> --version <version-id>
+agentclash dataset example add <dataset-id> --input '{"messages":[...]}' --expected '{"score":1}'
+agentclash dataset example edit <dataset-id> <example-id> --expected '{"score":1}'
+agentclash dataset example rm <dataset-id> <example-id>
 ```
 
 ### Eval and CI gate
@@ -102,7 +102,7 @@ agentclash dataset generate <dataset-id> \
 agentclash dataset import-traces <dataset-id> traces.json --source otel
 agentclash dataset import-traces <dataset-id> --source agentclash --run <run-id> --run-agent <run-agent-id>
 agentclash dataset trace-candidates list <dataset-id> --status pending
-agentclash dataset promote <dataset-id> <candidate-id> --tag production --expected-file edited.json
+agentclash dataset promote <dataset-id> <candidate-id> --tag production --expected '{"score":1}'
 ```
 
 ### Regression suite sync

--- a/web/content/agent-skills/agentclash-hub/SKILL.md
+++ b/web/content/agent-skills/agentclash-hub/SKILL.md
@@ -41,6 +41,22 @@ Portable bundle install (copy skills to another agent host without the integrati
 3. Follow dependency order for setup → pack → run → review → regression → CI.
 4. Send the user to the matching UI page when they need a visual surface.
 
+## Drive The CLI Like An Agent
+When you (a coding agent) drive AgentClash non-interactively, lean on the machine contract:
+
+- **Ask for machine output.** Pass `--json` (or `-o json`) on every command. Data goes to
+  **stdout**; human progress and diagnostics go to **stderr** — parse stdout only.
+- **Discover the surface first.** `agentclash schema --json` returns the full command tree, flags,
+  and documented exit codes. Prefer it over scraping `--help` prose.
+- **Branch on structured errors, never on prose.** On failure the CLI prints a JSON envelope:
+  `error.code` is a stable machine key — branch on it; `error.next_step` is the remediation to act
+  on; `error.details` carries specifics (quota `limit`/`used`/`remaining`, `reset_at`, `plan_key`).
+- **Gate readiness on `agentclash doctor`.** It exits non-zero when the environment isn't ready.
+  `agentclash quickstart --json` is informational and exits 0 even when `ready:false` — use `doctor`
+  as the hard gate in CI/agent flows.
+- **Stay headless.** Set `AGENTCLASH_TOKEN`, `AGENTCLASH_WORKSPACE`, and `AGENTCLASH_API_URL` in the
+  environment so no command needs an interactive prompt.
+
 ## End-To-End Eval Workflow (CLI)
 
 ```text


### PR DESCRIPTION
## What

The `agentclash-dataset-workflows` Agent Skill instructed commands and flags that **do not exist** in the CLI, so a coding agent following it verbatim would fail every dataset mutation. Verified against the real cobra command tree (`cli/cmd/dataset.go`, `cli/cmd/dataset_trace.go`):

| Skill said | Reality | Fix |
|---|---|---|
| `dataset get` | verb is `view` | `dataset view` |
| `dataset versions {list,create}` | group is `version` | `dataset version {list,create}` |
| `dataset examples {list,add,update,delete}` | group is `example`; verbs are `edit`/`rm` | `dataset example {list,add,edit,rm}` |
| `export … -o out.jsonl` | `-o` is the global output-**format** flag (table/json/yaml); export writes JSONL to stdout | `export … > out.jsonl` |
| `--expected-file <file>` | no such flag; the real flag is `--expected` (inline JSON) | `--expected '<json>'` on `example edit` and `promote` |

Also adds a **"Drive the CLI like an agent"** section to `agentclash-hub` teaching the *already-shipped* machine contract: `--json`, `agentclash schema --json`, branch on `error.code`/`next_step`/`details`, gate readiness on `agentclash doctor` (not `quickstart`), and headless via `AGENTCLASH_TOKEN`/`AGENTCLASH_WORKSPACE`/`AGENTCLASH_API_URL`. (Deliberately does **not** advertise `--non-interactive`/`retryable`/`--query` — those land in later PRs; documenting them now would be a dead reference.)

## Context

First of a series finishing the CLI agent-contract gaps an external readiness audit found. The audit predated the four discoverability PRs (#963/#969/#970/#971), so this series implements only the re-verified remaining work. WI-4's hub half (the `agentclash-skill-catalog` phantom ref + `schema --json` pointer) was already fixed in #963; this closes the dataset-workflows half.

## Verification

- Every `agentclash dataset …` invocation in the skill resolves against `<cmd> --help`.
- Source edited under `web/content/agent-skills/` (source of truth); snapshot regenerated via `node scripts/sync-cli-skills-snapshot.mjs` and confirmed **idempotent**.
- `go build ./...`, `go test -short -race ./internal/skills/... ./cmd -run TestIntegration` — green.
- `integration claude install` into a temp `HOME` → **25/25** created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)