### PR TITLE
feat(cli): headless auth determinism (fail-fast login, no-token short-circuit, clean auth status --json)

### DIFF
--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -72,15 +72,20 @@ For CI/CD, set the AGENTCLASH_TOKEN environment variable instead.`,
 			rc.Output.PrintWarning("Stored credentials are invalid; starting a new browser login.")
 		}
 
-		// The browser device flow needs a human; never enter its multi-minute
-		// poll loop in a non-interactive/headless context. Fail fast and name the
-		// headless path instead.
-		if nonInteractiveMode() && os.Getenv("AGENTCLASH_TOKEN") == "" {
+		// Everything past this point is the browser device flow, which a
+		// non-interactive/headless context can never complete — fail fast no
+		// matter how we got here (no credential, invalid stored credential, or
+		// --force explicitly requesting a fresh browser login).
+		if nonInteractiveMode() {
+			nextStep := "Set AGENTCLASH_TOKEN to a CLI token (create one in the AgentClash web app), or run `agentclash auth login` in an interactive terminal."
+			if flagForceLogin && rc.Client.Token() != "" {
+				nextStep = "Drop --force to reuse the existing credential, or run `agentclash auth login --force` in an interactive terminal."
+			}
 			return &cliError{
 				Code:     "interactive_input_required",
 				Message:  "browser login needs an interactive terminal; set AGENTCLASH_TOKEN for headless or CI use",
 				Details:  map[string]any{"env": "AGENTCLASH_TOKEN"},
-				NextStep: "Set AGENTCLASH_TOKEN to a CLI token (create one in the AgentClash web app), or run `agentclash auth login` in an interactive terminal.",
+				NextStep: nextStep,
 			}
 		}
 

--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -72,6 +72,18 @@ For CI/CD, set the AGENTCLASH_TOKEN environment variable instead.`,
 			rc.Output.PrintWarning("Stored credentials are invalid; starting a new browser login.")
 		}
 
+		// The browser device flow needs a human; never enter its multi-minute
+		// poll loop in a non-interactive/headless context. Fail fast and name the
+		// headless path instead.
+		if nonInteractiveMode() && os.Getenv("AGENTCLASH_TOKEN") == "" {
+			return &cliError{
+				Code:     "interactive_input_required",
+				Message:  "browser login needs an interactive terminal; set AGENTCLASH_TOKEN for headless or CI use",
+				Details:  map[string]any{"env": "AGENTCLASH_TOKEN"},
+				NextStep: "Set AGENTCLASH_TOKEN to a CLI token (create one in the AgentClash web app), or run `agentclash auth login` in an interactive terminal.",
+			}
+		}
+
 		autoOpen := !flagDevice && auth.CanOpenBrowser()
 		result, token, err := auth.VerificationLogin(cmd.Context(), rc.Client, autoOpen)
 		if err != nil {
@@ -146,8 +158,15 @@ var authStatusCmd = &cobra.Command{
 			return fmt.Errorf("checking auth: %w", err)
 		}
 		if apiErr := resp.ParseError(); apiErr != nil {
+			// In structured mode, return the API error directly so the JSON
+			// envelope carries the real auth code (e.g. 401/unauthorized) and a
+			// next_step — never a stray prose line on stderr alongside the JSON.
+			if rc.Output.IsStructured() {
+				return apiErr
+			}
 			rc.Output.PrintError("Not logged in. Run 'agentclash auth login' to authenticate.")
-			return fmt.Errorf("not authenticated")
+			// Silent: the human-readable message is already printed above.
+			return &ExitCodeError{Code: 1}
 		}
 
 		var session map[string]any

--- a/cli/cmd/auth_determinism_test.go
+++ b/cli/cmd/auth_determinism_test.go
@@ -47,6 +47,45 @@ func TestAuthLoginFailsFastWhenNonInteractiveWithoutToken(t *testing.T) {
 // Covered by TestAuthLoginInvalidStoredTokenStartsDeviceFlow et al. (they call
 // forceInteractiveTTY); this case asserts the fail-fast does not regress them.
 
+// WI-1 regression (Greptile P1 on #974): --force skips the already-authenticated
+// early return, so even with AGENTCLASH_TOKEN set the command would fall through
+// into the browser device flow. Non-interactive mode must fail fast there too —
+// a headless context can never complete a browser login, token or not.
+func TestAuthLoginForceFailsFastNonInteractiveEvenWithToken(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("AGENTCLASH_TOKEN", "valid-env-token")
+	t.Setenv("AGENTCLASH_NONINTERACTIVE", "1")
+
+	deviceCalled := false
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/cli-auth/device": func(w http.ResponseWriter, r *http.Request) {
+			deviceCalled = true
+			jsonHandler(201, map[string]any{
+				"device_code":      "dc",
+				"user_code":        "ABCD-EFGH",
+				"verification_uri": "https://agentclash.dev/device",
+				"expires_in":       60,
+			})(w, r)
+		},
+	})
+	defer srv.Close()
+
+	err := executeCommand(t, []string{"auth", "login", "--force", "--json"}, srv.URL)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	var ce *cliError
+	if !errors.As(err, &ce) || ce.Code != "interactive_input_required" {
+		t.Fatalf("error = %v, want cliError code interactive_input_required", err)
+	}
+	if !strings.Contains(ce.NextStep, "--force") {
+		t.Fatalf("next_step should explain the --force interaction; got %q", ce.NextStep)
+	}
+	if deviceCalled {
+		t.Fatal("device-code endpoint must not be hit in non-interactive mode, even with --force")
+	}
+}
+
 // WI-9: an auth-requiring command with no credentials returns a deterministic
 // `unauthenticated` error before any network call.
 func TestUnauthenticatedCommandShortCircuitsWithoutNetwork(t *testing.T) {

--- a/cli/cmd/auth_determinism_test.go
+++ b/cli/cmd/auth_determinism_test.go
@@ -1,0 +1,136 @@
+package cmd
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	cliapi "github.com/agentclash/agentclash/cli/internal/api"
+)
+
+// WI-1: auth login must fail fast (not enter the device-poll loop) when there is
+// no token and no interactive terminal.
+func TestAuthLoginFailsFastWhenNonInteractiveWithoutToken(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("AGENTCLASH_TOKEN", "")
+	t.Setenv("AGENTCLASH_NONINTERACTIVE", "1")
+
+	deviceCalled := false
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/cli-auth/device": func(w http.ResponseWriter, r *http.Request) {
+			deviceCalled = true
+			jsonHandler(201, map[string]any{
+				"device_code":      "dc",
+				"user_code":        "ABCD-EFGH",
+				"verification_uri": "https://agentclash.dev/device",
+				"expires_in":       60,
+			})(w, r)
+		},
+	})
+	defer srv.Close()
+
+	err := executeCommand(t, []string{"auth", "login", "--json"}, srv.URL)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	var ce *cliError
+	if !errors.As(err, &ce) || ce.Code != "interactive_input_required" {
+		t.Fatalf("error = %v, want cliError code interactive_input_required", err)
+	}
+	if deviceCalled {
+		t.Fatal("device-code endpoint must not be hit in non-interactive mode")
+	}
+}
+
+// WI-1 (happy): with an interactive terminal the device flow proceeds normally.
+// Covered by TestAuthLoginInvalidStoredTokenStartsDeviceFlow et al. (they call
+// forceInteractiveTTY); this case asserts the fail-fast does not regress them.
+
+// WI-9: an auth-requiring command with no credentials returns a deterministic
+// `unauthenticated` error before any network call.
+func TestUnauthenticatedCommandShortCircuitsWithoutNetwork(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("AGENTCLASH_TOKEN", "")
+	t.Setenv("AGENTCLASH_WORKSPACE", "ws-test")
+
+	called := false
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-test/runs": func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			jsonHandler(200, map[string]any{"items": []any{}})(w, r)
+		},
+	})
+	defer srv.Close()
+
+	err := executeCommand(t, []string{"run", "list", "--json"}, srv.URL)
+	if err == nil {
+		t.Fatal("expected an unauthenticated error, got nil")
+	}
+	var apiErr *cliapi.APIError
+	if !errors.As(err, &apiErr) || apiErr.Code != "unauthenticated" {
+		t.Fatalf("error = %v, want APIError code unauthenticated", err)
+	}
+	if called {
+		t.Fatal("no network call must be made when unauthenticated")
+	}
+}
+
+// WI-11: `auth status --json` returns the API's real error code (e.g. 401
+// unauthorized) and never leaks a prose line onto stderr alongside the JSON.
+func TestAuthStatusJSONReturnsAPIErrorCodeWithoutProse(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("AGENTCLASH_TOKEN", "stale-token")
+
+	stderr := captureStderr(t)
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/auth/session": jsonHandler(401, map[string]any{
+			"error": map[string]any{"code": "unauthorized", "message": "token expired"},
+		}),
+	})
+	defer srv.Close()
+
+	err := executeCommand(t, []string{"auth", "status", "--json"}, srv.URL)
+	out := stderr.finish()
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	var apiErr *cliapi.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %v, want *APIError", err)
+	}
+	if apiErr.Code != "unauthorized" {
+		t.Fatalf("code = %q, want the server code 'unauthorized' (not invalid_argument)", apiErr.Code)
+	}
+	if strings.Contains(out, "Not logged in") {
+		t.Fatalf("structured mode leaked a prose line to stderr: %q", out)
+	}
+}
+
+// WI-11 (human mode): keep the friendly message, exit non-zero silently (so
+// main does not print a second raw line).
+func TestAuthStatusHumanPrintsFriendlyMessageAndExitsSilently(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("AGENTCLASH_TOKEN", "stale-token")
+
+	stderr := captureStderr(t)
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/auth/session": jsonHandler(401, map[string]any{
+			"error": map[string]any{"code": "unauthorized", "message": "token expired"},
+		}),
+	})
+	defer srv.Close()
+
+	err := executeCommandWithQuiet(t, []string{"auth", "status"}, srv.URL, false)
+	out := stderr.finish()
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) || !exitErr.Silent() {
+		t.Fatalf("error = %v, want a silent ExitCodeError", err)
+	}
+	if !strings.Contains(out, "Not logged in") {
+		t.Fatalf("human mode should print the friendly message; stderr = %q", out)
+	}
+}

--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -42,6 +42,7 @@ func executeCommandWithQuiet(t *testing.T, args []string, apiURL string, quiet b
 	flagAPIURL = apiURL
 	flagDevice = false
 	flagForceLogin = false
+	flagNonInteractive = false
 	runtimeOutputJSON = false
 
 	rootCmd.SetArgs(args)
@@ -49,6 +50,20 @@ func executeCommandWithQuiet(t *testing.T, args []string, apiURL string, quiet b
 }
 
 var cmdMu sync.Mutex
+
+// forceInteractiveTTY makes the CLI treat the session as an interactive terminal
+// for the duration of a test, and clears the env signals that would otherwise
+// force non-interactive mode (e.g. CI=true on the runner). Device-flow login
+// fails fast in non-interactive contexts, so tests that exercise the real device
+// flow must opt back into interactive behavior.
+func forceInteractiveTTY(t *testing.T) {
+	t.Helper()
+	t.Setenv("CI", "")
+	t.Setenv("AGENTCLASH_NONINTERACTIVE", "")
+	prev := stdioIsInteractive
+	stdioIsInteractive = func() bool { return true }
+	t.Cleanup(func() { stdioIsInteractive = prev })
+}
 
 func resetCommandFlags(cmd *cobra.Command) {
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
@@ -909,6 +924,7 @@ func TestAuthLoginSkipsDeviceFlowWhenEnvTokenValid(t *testing.T) {
 }
 
 func TestAuthLoginInvalidStoredTokenStartsDeviceFlow(t *testing.T) {
+	forceInteractiveTTY(t)
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 	t.Setenv("AGENTCLASH_TOKEN", "")
@@ -967,6 +983,7 @@ func TestAuthLoginInvalidStoredTokenStartsDeviceFlow(t *testing.T) {
 }
 
 func TestAuthLoginForceStartsDeviceFlowWhenStoredTokenValid(t *testing.T) {
+	forceInteractiveTTY(t)
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 	t.Setenv("AGENTCLASH_TOKEN", "")
@@ -1022,6 +1039,7 @@ func TestAuthLoginForceStartsDeviceFlowWhenStoredTokenValid(t *testing.T) {
 }
 
 func TestAuthLoginFallsBackToEmailWhenDisplayNameMissing(t *testing.T) {
+	forceInteractiveTTY(t)
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 	t.Setenv("AGENTCLASH_TOKEN", "")
@@ -1058,6 +1076,7 @@ func TestAuthLoginFallsBackToEmailWhenDisplayNameMissing(t *testing.T) {
 }
 
 func TestAuthLoginFallsBackToUserIDWhenIdentityMissing(t *testing.T) {
+	forceInteractiveTTY(t)
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 	t.Setenv("AGENTCLASH_TOKEN", "")

--- a/cli/cmd/error_renderer.go
+++ b/cli/cmd/error_renderer.go
@@ -16,9 +16,11 @@ import (
 var runtimeOutputJSON bool
 
 type cliError struct {
-	Code    string
-	Message string
-	Err     error
+	Code     string
+	Message  string
+	Details  map[string]any
+	NextStep string
+	Err      error
 }
 
 func (e *cliError) Error() string {
@@ -130,7 +132,10 @@ func classifyStructuredError(err error) structuredError {
 
 	var localErr *cliError
 	if errors.As(err, &localErr) {
-		return structuredError{Code: nonEmpty(localErr.Code, "invalid_argument"), Message: localErr.Error(), Details: details}
+		if localErr.Details != nil {
+			details = localErr.Details
+		}
+		return structuredError{Code: nonEmpty(localErr.Code, "invalid_argument"), Message: localErr.Error(), Details: details, NextStep: localErr.NextStep}
 	}
 
 	var exitErr *ExitCodeError

--- a/cli/cmd/picker.go
+++ b/cli/cmd/picker.go
@@ -22,11 +22,17 @@ type interactivePicker interface {
 
 var surveyAskOne = survey.AskOne
 
+// stdioIsInteractive reports whether both stdin and stdout are TTYs. It is a
+// var so tests can simulate a terminal. nonInteractiveMode builds on it.
+var stdioIsInteractive = func() bool {
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+}
+
 var isInteractiveTerminal = func(rc *RunContext) bool {
 	if rc == nil || rc.Output == nil || rc.Output.IsStructured() {
 		return false
 	}
-	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+	return !nonInteractiveMode()
 }
 
 var newInteractivePicker = func() interactivePicker {

--- a/cli/cmd/prompt_eval_test.go
+++ b/cli/cmd/prompt_eval_test.go
@@ -960,8 +960,20 @@ type promptEvalRemoteFakeOptions struct {
 	PaginateAliases  bool
 }
 
+// promptEvalAuthEnv makes a prompt-eval test hermetic and authenticated:
+// it isolates the config dir so the test can never pick up the developer's
+// real stored credentials, and sets a dummy token so the client's
+// no-credential short-circuit (ensureAuth) lets the request reach the fake
+// server. The fakes do not check the token; its value is irrelevant.
+func promptEvalAuthEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("AGENTCLASH_TOKEN", "test-tok")
+}
+
 func promptEvalRemoteFakeAPI(t *testing.T, options promptEvalRemoteFakeOptions) *httptest.Server {
 	t.Helper()
+	promptEvalAuthEnv(t)
 	modelAliases := options.ModelAliases
 	if modelAliases == nil {
 		modelAliases = []map[string]any{{"id": "alias-1", "alias_key": "gpt-5.5", "provider_key": "openai", "provider_account_id": "pa-1"}}
@@ -1064,6 +1076,7 @@ type promptEvalRunFake struct {
 
 func newPromptEvalRunFake(t *testing.T, state *promptEvalRunFakeState) *promptEvalRunFake {
 	t.Helper()
+	promptEvalAuthEnv(t)
 	f := &promptEvalRunFake{nextPlaygroundID: 1, nextExperimentID: 1}
 	if state != nil {
 		f.playgrounds = append(f.playgrounds, state.playgrounds...)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/agentclash/agentclash/cli/internal/api"
 	"github.com/agentclash/agentclash/cli/internal/auth"
@@ -15,14 +16,40 @@ import (
 
 // Global flags.
 var (
-	flagJSON      bool
-	flagOutput    string
-	flagQuiet     bool
-	flagVerbose   bool
-	flagNoColor   bool
-	flagWorkspace string
-	flagAPIURL    string
+	flagJSON           bool
+	flagOutput         string
+	flagQuiet          bool
+	flagVerbose        bool
+	flagNoColor        bool
+	flagWorkspace      string
+	flagAPIURL         string
+	flagNonInteractive bool
 )
+
+// nonInteractiveMode reports whether the CLI must never prompt for input and
+// should fail fast when interactive input would otherwise be required. It is
+// driven by the explicit --non-interactive flag, the AGENTCLASH_NONINTERACTIVE
+// or CI environment variables, or a non-TTY stdin/stdout. Note: --json/--output
+// alone does NOT imply non-interactive — a human at a real terminal can still
+// run an interactive flow and ask for a machine-readable result.
+func nonInteractiveMode() bool {
+	if flagNonInteractive || envTruthy(os.Getenv("AGENTCLASH_NONINTERACTIVE")) || envTruthy(os.Getenv("CI")) {
+		return true
+	}
+	return !stdioIsInteractive()
+}
+
+// envTruthy treats empty, "0", "false", "no", and "off" (case-insensitive) as
+// false; any other non-empty value is true. This matches the de-facto CI
+// convention (e.g. GitHub Actions sets CI=true).
+func envTruthy(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "", "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
+}
 
 // RunContext is passed to all commands via cobra context.
 type RunContext struct {
@@ -158,6 +185,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&flagNoColor, "no-color", false, "Disable color output")
 	rootCmd.PersistentFlags().StringVarP(&flagWorkspace, "workspace", "w", "", "Workspace ID (overrides config)")
 	rootCmd.PersistentFlags().StringVar(&flagAPIURL, "api-url", "", "API base URL (overrides config)")
+	rootCmd.PersistentFlags().BoolVar(&flagNonInteractive, "non-interactive", false, "Never prompt; fail fast when interactive input is required (also set by AGENTCLASH_NONINTERACTIVE or CI)")
 }
 
 // Execute runs the root command.

--- a/cli/cmd/testdata/schema_snapshot.json
+++ b/cli/cmd/testdata/schema_snapshot.json
@@ -20,6 +20,12 @@
       "default": "false"
     },
     {
+      "name": "non-interactive",
+      "usage": "Never prompt; fail fast when interactive input is required (also set by AGENTCLASH_NONINTERACTIVE or CI)",
+      "type": "bool",
+      "default": "false"
+    },
+    {
       "name": "output",
       "shorthand": "o",
       "usage": "Output format: table, json, yaml",

--- a/cli/internal/api/auth_gate_test.go
+++ b/cli/internal/api/auth_gate_test.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Failure path: no token + no dev mode + non-public path => synthesized
+// unauthenticated error, with no network call.
+func TestEnsureAuthShortCircuitsUnauthenticatedRequests(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	_, err := NewClient(srv.URL, "").Get(context.Background(), "/v1/runs", nil)
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.Code != "unauthenticated" {
+		t.Fatalf("err = %v, want *APIError code unauthenticated", err)
+	}
+	if apiErr.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", apiErr.StatusCode)
+	}
+	if called {
+		t.Fatal("no network call should be made when unauthenticated")
+	}
+}
+
+// Happy paths: public device endpoint (no token), an authenticated token, and
+// dev mode all reach the server.
+func TestEnsureAuthAllowsPublicTokenAndDevRequests(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	if _, err := NewClient(srv.URL, "").Post(context.Background(), "/v1/cli-auth/device", map[string]any{}); err != nil {
+		t.Fatalf("public device path should be allowed without a token: %v", err)
+	}
+	if _, err := NewClient(srv.URL, "tok").Get(context.Background(), "/v1/runs", nil); err != nil {
+		t.Fatalf("token path should be allowed: %v", err)
+	}
+	if _, err := NewClient(srv.URL, "", WithDevMode("user-uuid", "", "")).Get(context.Background(), "/v1/runs", nil); err != nil {
+		t.Fatalf("dev mode should be allowed: %v", err)
+	}
+	if hits != 3 {
+		t.Fatalf("network calls = %d, want 3", hits)
+	}
+}

--- a/cli/internal/api/auth_gate_test.go
+++ b/cli/internal/api/auth_gate_test.go
@@ -31,6 +31,28 @@ func TestEnsureAuthShortCircuitsUnauthenticatedRequests(t *testing.T) {
 	}
 }
 
+// Greptile P2 on #974: the credential-free exemption must match the two RFC 8628
+// endpoints exactly — a prefix match would silently exempt any future
+// /v1/cli-auth/device* route from authentication.
+func TestPublicAPIPathExactMatchOnly(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/v1/cli-auth/device", true},
+		{"/v1/cli-auth/device/token", true},
+		{"/v1/cli-auth/device-management", false},
+		{"/v1/cli-auth/device-keys", false},
+		{"/v1/cli-auth/device/token/refresh", false},
+		{"/v1/cli-auth/devices", false},
+	}
+	for _, tc := range cases {
+		if got := publicAPIPath(tc.path); got != tc.want {
+			t.Errorf("publicAPIPath(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
 // Happy paths: public device endpoint (no token), an authenticated token, and
 // dev mode all reach the server.
 func TestEnsureAuthAllowsPublicTokenAndDevRequests(t *testing.T) {

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -314,6 +314,9 @@ func (c *Client) Delete(ctx context.Context, path string) (*Response, error) {
 
 // PostRaw performs a POST with a raw body and custom content type.
 func (c *Client) PostRaw(ctx context.Context, path string, contentType string, body io.Reader) (*Response, error) {
+	if err := c.ensureAuth(path); err != nil {
+		return nil, err
+	}
 	fullURL := c.baseURL + path
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, body)
 	if err != nil {
@@ -341,6 +344,9 @@ type FileUpload struct {
 //  3. A `GetBody` implementation so Go can replay the body on same-origin
 //     307/308 redirects instead of silently failing.
 func (c *Client) PostMultipart(ctx context.Context, path string, fields map[string]string, files map[string]FileUpload) (*Response, error) {
+	if err := c.ensureAuth(path); err != nil {
+		return nil, err
+	}
 	spool, err := os.CreateTemp("", "agentclash-multipart-*")
 	if err != nil {
 		return nil, fmt.Errorf("creating multipart spool: %w", err)
@@ -406,6 +412,9 @@ func (c *Client) PostMultipart(ctx context.Context, path string, fields map[stri
 }
 
 func (c *Client) doJSON(ctx context.Context, method, path string, body any) (*Response, error) {
+	if err := c.ensureAuth(path); err != nil {
+		return nil, err
+	}
 	var bodyReader io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)
@@ -428,6 +437,9 @@ func (c *Client) doJSON(ctx context.Context, method, path string, body any) (*Re
 }
 
 func (c *Client) do(ctx context.Context, method, path string, query url.Values, body io.Reader) (*Response, error) {
+	if err := c.ensureAuth(path); err != nil {
+		return nil, err
+	}
 	fullURL := c.baseURL + path
 	if len(query) > 0 {
 		fullURL += "?" + query.Encode()
@@ -439,6 +451,30 @@ func (c *Client) do(ctx context.Context, method, path string, query url.Values, 
 	}
 	c.setAuth(req)
 	return c.executeWithRetry(req)
+}
+
+// publicAPIPath reports whether path is reachable without credentials. Only the
+// RFC 8628 device-authorization endpoints qualify — they MINT a CLI token, so
+// requiring a token to reach them would be circular.
+func publicAPIPath(path string) bool {
+	return strings.HasPrefix(path, "/v1/cli-auth/device")
+}
+
+// ensureAuth fails fast with a synthesized 401 when the client has no way to
+// authenticate (no bearer token and not in dev mode) for a non-public path.
+// This makes "not logged in" a deterministic, network-free error instead of a
+// doomed request that returns a confusing transport error or passthrough 401,
+// and it covers every authenticated call (REST + SSE) from one place rather
+// than per-command classification.
+func (c *Client) ensureAuth(path string) error {
+	if c.token != "" || c.devUserID != "" || publicAPIPath(path) {
+		return nil
+	}
+	return &APIError{
+		StatusCode: http.StatusUnauthorized,
+		Code:       "unauthenticated",
+		Message:    "not authenticated: set AGENTCLASH_TOKEN or run 'agentclash auth login'",
+	}
 }
 
 func (c *Client) setAuth(req *http.Request) {

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -454,10 +454,11 @@ func (c *Client) do(ctx context.Context, method, path string, query url.Values, 
 }
 
 // publicAPIPath reports whether path is reachable without credentials. Only the
-// RFC 8628 device-authorization endpoints qualify — they MINT a CLI token, so
-// requiring a token to reach them would be circular.
+// two RFC 8628 device-authorization endpoints qualify — they MINT a CLI token,
+// so requiring a token to reach them would be circular. Exact matches only: a
+// prefix match would silently exempt any future /v1/cli-auth/device* route.
 func publicAPIPath(path string) bool {
-	return strings.HasPrefix(path, "/v1/cli-auth/device")
+	return path == "/v1/cli-auth/device" || path == "/v1/cli-auth/device/token"
 }
 
 // ensureAuth fails fast with a synthesized 401 when the client has no way to

--- a/cli/internal/api/multipart_test.go
+++ b/cli/internal/api/multipart_test.go
@@ -53,7 +53,7 @@ func TestPostMultipartSendsContentLengthAndSupportsGetBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(srv.URL, "")
+	client := NewClient(srv.URL, "test-token")
 	payload := strings.Repeat("0123456789", 10_000) // 100 KB, well beyond a header line
 	resp, err := client.PostMultipart(context.Background(), "/upload",
 		map[string]string{"note": "hello"},

--- a/cli/internal/api/sse.go
+++ b/cli/internal/api/sse.go
@@ -19,6 +19,9 @@ type SSEEvent struct {
 // StreamSSE opens an SSE connection and sends events to a channel.
 // The channel is closed when the connection ends or the context is cancelled.
 func (c *Client) StreamSSE(ctx context.Context, path string, query url.Values) (<-chan SSEEvent, error) {
+	if err := c.ensureAuth(path); err != nil {
+		return nil, err
+	}
 	fullURL := c.baseURL + path
 	if len(query) > 0 {
 		fullURL += "?" + query.Encode()


### PR DESCRIPTION
## What

Three fixes so an autonomous/headless agent isn't broken in its first five minutes (WI-1/WI-9/WI-11 from the CLI agent-readiness audit).

### WI-1 — `auth login` no longer hangs headless
Today `auth login` enters a ~10-minute device-code poll loop with no TTY check. This adds a global `--non-interactive` flag (also driven by `AGENTCLASH_NONINTERACTIVE`, `CI`, or a non-TTY stdin/stdout). In non-interactive mode with no `AGENTCLASH_TOKEN`, login fails fast with a structured `interactive_input_required` error instead of polling. `--json`/`--output` alone does **not** imply non-interactive (a human at a terminal can still run the flow and ask for JSON). The flag also suppresses interactive pickers.

### WI-9 — deterministic, network-free `unauthenticated`
Unauthenticated commands fired a doomed request and surfaced a non-deterministic transport error or passthrough 401. The check now lives in `api.Client.ensureAuth` — covering **REST + SSE + every helper/delegation from one place** — and exempts the public RFC 8628 device endpoints and dev mode.

> **Design note:** I deliberately did *not* use per-command "requires auth" annotations. Verifying the tree showed many groups have **local** subcommands (`baseline` is entirely config-local, `replay triage`, `ci validate`, `challenge-pack init`, `prompt-eval validate`, `workspace use`…). A client-level check is precise to *actual* authenticated calls and never breaks local commands.

### WI-11 — clean `auth status --json`
Returns the API's real error code (e.g. 401 `unauthorized`) instead of a bogus `invalid_argument`, and never leaks a prose line onto stderr alongside the JSON. Human mode keeps the friendly message and exits non-zero silently.

Local `cliError`s now thread optional `details` + `next_step` so their envelopes are actionable too.

## Behavior changes (additive, not breaking)
- Commands that need auth and have no token now exit 1 with a structured `unauthenticated` envelope **before** any network call (previously: a network/401 error after a round-trip).
- `auth login` in CI/headless exits 1 with `interactive_input_required` instead of blocking. Set `AGENTCLASH_TOKEN` for headless use (already the documented CI path).

## Verification (happy + failure)
- `go build ./... && go vet ./... && go test -short -race -count=1 ./...` — all green.
- New tests: headless login fail-fast never hits the device endpoint; existing device-flow tests opt back in via `forceInteractiveTTY`; `run list` (no token) → `unauthenticated`, no network; `auth status --json` carries the server code with no prose; `auth status` human mode prints the friendly line + silent exit; api-level `ensureAuth` unit tests cover device-exempt/token/dev happy paths.
- Manual e2e (bounded by `perl alarm`): headless `auth login --json` returns `interactive_input_required` instantly (no 10-min poll); `run list --json` against a **dead URL** returns `unauthenticated` (not `request_failed`) — proving zero network; `auth status --json` with a bogus token against prod returns `{"code":"unauthorized","status":401,"next_step":...}`.
- Schema golden regenerated; diff is **only** the new `--non-interactive` flag.

## Context
Second in the CLI agent-contract series (after #973). The audit predated #963/#969/#970/#971, so this implements only the re-verified remaining work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)