### PR TITLE
feat(cli): schema v2 — positional args, flag enums, error/status registries, subtree lookup

### DIFF
--- a/cli/cmd/agent_harness.go
+++ b/cli/cmd/agent_harness.go
@@ -237,14 +237,22 @@ var agentHarnessRunCmd = &cobra.Command{
 			return err
 		}
 
-		if rc.Output.IsStructured() {
-			return rc.Output.PrintRaw(execution)
-		}
-
-		rc.Output.PrintSuccess(fmt.Sprintf("Started agent harness execution %s", str(execution["id"])))
-		rc.Output.PrintDetail("Harness", str(execution["agent_harness_id"]))
-		rc.Output.PrintDetail("Status", output.StatusColor(str(execution["status"])))
+		// The follow decision must come before the structured early-return:
+		// `--json --follow` previously printed the non-terminal execution and
+		// exited 0 without ever polling.
 		follow, _ := cmd.Flags().GetBool("follow")
+
+		if rc.Output.IsStructured() {
+			// ID-first: emit the initial execution immediately so an agent can
+			// recover the execution id even if the follow loop dies.
+			if err := rc.Output.PrintRaw(execution); err != nil {
+				return err
+			}
+		} else {
+			rc.Output.PrintSuccess(fmt.Sprintf("Started agent harness execution %s", str(execution["id"])))
+			rc.Output.PrintDetail("Harness", str(execution["agent_harness_id"]))
+			rc.Output.PrintDetail("Status", output.StatusColor(str(execution["status"])))
+		}
 		if !follow {
 			return nil
 		}
@@ -272,8 +280,14 @@ func followAgentHarnessExecution(cmd *cobra.Command, workspaceID, executionID st
 			return err
 		}
 		status := str(execution["status"])
-		rc.Output.PrintDetail("Status", output.StatusColor(status))
-		if isTerminalAgentHarnessExecutionStatus(status) {
+		if !rc.Output.IsStructured() {
+			rc.Output.PrintDetail("Status", output.StatusColor(status))
+		}
+		if isTerminalRunStatus(status) {
+			if rc.Output.IsStructured() {
+				// Second and final NDJSON document: the terminal execution.
+				return rc.Output.PrintRaw(execution)
+			}
 			return nil
 		}
 
@@ -284,15 +298,6 @@ func followAgentHarnessExecution(cmd *cobra.Command, workspaceID, executionID st
 			return cmd.Context().Err()
 		case <-timer.C:
 		}
-	}
-}
-
-func isTerminalAgentHarnessExecutionStatus(status string) bool {
-	switch status {
-	case "completed", "failed", "cancelled":
-		return true
-	default:
-		return false
 	}
 }
 

--- a/cli/cmd/dataset_generate.go
+++ b/cli/cmd/dataset_generate.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -17,6 +19,8 @@ func init() {
 	datasetGenerateCmd.Flags().Bool("create-version", false, "Snapshot a dataset version when generation completes")
 	datasetGenerateCmd.Flags().String("version-label", "", "Optional label for the generated dataset version")
 	datasetGenerateCmd.Flags().Bool("follow", false, "Poll generation job status until it finishes")
+	datasetGenerateCmd.Flags().Duration("poll-interval", 2*time.Second, "Polling interval for --follow")
+	datasetGenerateCmd.Flags().Duration("timeout", 0, "Give up on --follow after this duration (0 = wait indefinitely)")
 }
 
 var datasetGenerateCmd = &cobra.Command{
@@ -85,9 +89,30 @@ var datasetGenerateCmd = &cobra.Command{
 			return nil
 		}
 
+		pollInterval, _ := cmd.Flags().GetDuration("poll-interval")
+		if pollInterval <= 0 {
+			pollInterval = 2 * time.Second
+		}
+		timeout, _ := cmd.Flags().GetDuration("timeout")
+		ctx := cmd.Context()
+		if timeout > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, timeout)
+			defer cancel()
+		}
+		followTimeoutErr := func() error {
+			return &cliError{
+				Code:    "follow_timeout",
+				Message: fmt.Sprintf("generation job %s did not reach a terminal status within %s; it keeps running server-side", jobID, timeout),
+			}
+		}
+
 		for {
-			statusResp, pollErr := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+wsID+"/datasets/"+datasetID+"/generations/"+jobID, nil)
+			statusResp, pollErr := rc.Client.Get(ctx, "/v1/workspaces/"+wsID+"/datasets/"+datasetID+"/generations/"+jobID, nil)
 			if pollErr != nil {
+				if timeout > 0 && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+					return followTimeoutErr()
+				}
 				return pollErr
 			}
 			if apiErr := statusResp.ParseError(); apiErr != nil {
@@ -101,14 +126,25 @@ var datasetGenerateCmd = &cobra.Command{
 			if !rc.Output.IsStructured() {
 				fmt.Fprintf(rc.Output.Writer(), "status: %s accepted=%v rejected=%v\n", status, current["accepted_count"], current["rejected_count"])
 			}
-			switch status {
-			case "completed", "failed":
+			// Shared terminal set — the old hand-rolled switch was missing
+			// "cancelled" and looped forever on a cancelled job.
+			if isTerminalRunStatus(status) {
 				if rc.Output.IsStructured() {
 					return rc.Output.PrintRaw(current)
 				}
 				return nil
 			}
-			time.Sleep(2 * time.Second)
+
+			timer := time.NewTimer(pollInterval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				if timeout > 0 && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+					return followTimeoutErr()
+				}
+				return ctx.Err()
+			case <-timer.C:
+			}
 		}
 	},
 }

--- a/cli/cmd/error_codes.go
+++ b/cli/cmd/error_codes.go
@@ -1,0 +1,25 @@
+package cmd
+
+// ErrorCode documents a stable error code the CLI itself can synthesize in
+// the structured error envelope (`error.code`). Backend error codes pass
+// through verbatim and are not enumerable here — agents should treat this
+// registry as the CLI-local vocabulary and branch on `error.code` strings,
+// never on message prose. Published via `agentclash schema`.
+type ErrorCode struct {
+	Code        string `json:"code" yaml:"code"`
+	Description string `json:"description" yaml:"description"`
+	Retryable   bool   `json:"retryable,omitempty" yaml:"retryable,omitempty"`
+}
+
+var documentedErrorCodes = []ErrorCode{
+	{Code: "invalid_argument", Description: "Invalid flags, arguments, or input; also the default classification for unrecognized local errors."},
+	{Code: "invalid_config", Description: "The CLI configuration file failed to load or parse."},
+	{Code: "file_not_found", Description: "A referenced local file does not exist."},
+	{Code: "permission_denied", Description: "A local file or directory was not accessible."},
+	{Code: "request_failed", Description: "The HTTP request could not complete (network/transport failure).", Retryable: true},
+	{Code: "api_error", Description: "The server returned an error envelope without a code."},
+	{Code: "command_failed", Description: "A command finished with a command-specific non-zero exit (see exit_codes)."},
+	{Code: "missing_workspace", Description: "No workspace resolved; pass --workspace, set AGENTCLASH_WORKSPACE, or run 'agentclash link'."},
+	{Code: "follow_timeout", Description: "A --follow loop gave up after --timeout; the underlying job keeps running server-side.", Retryable: true},
+	{Code: "stream_reconnect_exhausted", Description: "The SSE event stream dropped repeatedly without delivering events; resume with `run events --since <id>`.", Retryable: true},
+}

--- a/cli/cmd/error_codes.go
+++ b/cli/cmd/error_codes.go
@@ -20,6 +20,12 @@ var documentedErrorCodes = []ErrorCode{
 	{Code: "api_error", Description: "The server returned an error envelope without a code."},
 	{Code: "command_failed", Description: "A command finished with a command-specific non-zero exit (see exit_codes)."},
 	{Code: "missing_workspace", Description: "No workspace resolved; pass --workspace, set AGENTCLASH_WORKSPACE, or run 'agentclash link'."},
-	{Code: "follow_timeout", Description: "A --follow loop gave up after --timeout; the underlying job keeps running server-side.", Retryable: true},
-	{Code: "stream_reconnect_exhausted", Description: "The SSE event stream dropped repeatedly without delivering events; resume with `run events --since <id>`.", Retryable: true},
+	// follow_timeout / stream_reconnect_exhausted are NOT marked retryable: the
+	// CLI emits them with retryable:false and exit 64 (they are local deadline /
+	// reconnect-budget conditions, not transient transport failures), and the
+	// "exit 75 ⟺ retryable:true" invariant must hold. The recovery action lives
+	// in the description (re-check status / resume with --since), not in a blind
+	// retryable bit.
+	{Code: "follow_timeout", Description: "A --follow loop gave up after --timeout; the underlying job keeps running server-side — re-check its status rather than blindly retrying."},
+	{Code: "stream_reconnect_exhausted", Description: "The SSE event stream dropped repeatedly without delivering events; resume with `run events --since <id>`."},
 }

--- a/cli/cmd/eval_session_read.go
+++ b/cli/cmd/eval_session_read.go
@@ -290,12 +290,7 @@ func renderEvalSessionWarnings(rc *RunContext, warnings []string) {
 }
 
 func evalSessionStatusTerminal(status string) bool {
-	switch status {
-	case "completed", "failed", "cancelled", "canceled":
-		return true
-	default:
-		return false
-	}
+	return isTerminalRunStatus(status)
 }
 
 func evalSessionRunCountsLabel(counts map[string]any) string {

--- a/cli/cmd/follow_fixes_test.go
+++ b/cli/cmd/follow_fixes_test.go
@@ -1,0 +1,231 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// WI-8a: `agent harness run --json --follow` previously printed the initial
+// execution and exited 0 before ever polling. It must emit the initial object
+// (ID-first), poll to a terminal status, and emit the terminal object.
+func TestAgentHarnessRunJSONFollowPollsToTerminal(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("AGENTCLASH_TOKEN", "tok")
+	t.Setenv("AGENTCLASH_WORKSPACE", "ws-1")
+
+	var polls atomic.Int32
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/workspaces/ws-1/agent-harnesses/h-1/executions": jsonHandler(201, map[string]any{
+			"id": "exec-1", "agent_harness_id": "h-1", "status": "running",
+		}),
+		"GET /v1/workspaces/ws-1/agent-harness-executions/exec-1": func(w http.ResponseWriter, r *http.Request) {
+			status := "running"
+			if polls.Add(1) >= 2 {
+				status = "completed"
+			}
+			jsonHandler(200, map[string]any{"id": "exec-1", "status": status})(w, r)
+		},
+	})
+	defer srv.Close()
+
+	cap := captureStdout(t)
+	err := executeCommand(t, []string{"agent-harness", "run", "h-1", "--json", "--follow", "--poll-interval", "10ms"}, srv.URL)
+	out := cap.finish()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := polls.Load(); got < 2 {
+		t.Fatalf("polls = %d, want >= 2 (must keep polling to terminal)", got)
+	}
+
+	docs := decodeJSONStream(t, out)
+	if len(docs) != 2 {
+		t.Fatalf("stdout docs = %d, want exactly 2 (initial + terminal):\n%s", len(docs), out)
+	}
+	if docs[0]["id"] != "exec-1" || docs[0]["status"] != "running" {
+		t.Fatalf("first doc = %v, want the ID-first initial execution", docs[0])
+	}
+	if docs[1]["status"] != "completed" {
+		t.Fatalf("last doc status = %v, want completed", docs[1]["status"])
+	}
+}
+
+// decodeJSONStream parses stdout as a stream of concatenated JSON documents
+// (the PrintRaw convention — pretty-printed, one after another).
+func decodeJSONStream(t *testing.T, out string) []map[string]any {
+	t.Helper()
+	dec := json.NewDecoder(strings.NewReader(out))
+	var docs []map[string]any
+	for dec.More() {
+		var doc map[string]any
+		if err := dec.Decode(&doc); err != nil {
+			t.Fatalf("stdout is not a valid JSON document stream: %v\n%s", err, out)
+		}
+		docs = append(docs, doc)
+	}
+	return docs
+}
+
+// WI-8b regression: a cancelled generation job terminated the follow loop —
+// the old switch only knew completed/failed and polled forever.
+func TestDatasetGenerateFollowStopsOnCancelled(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("AGENTCLASH_TOKEN", "tok")
+	t.Setenv("AGENTCLASH_WORKSPACE", "ws-1")
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/workspaces/ws-1/datasets/ds-1/generate": jsonHandler(201, map[string]any{"id": "job-1", "status": "running"}),
+		"GET /v1/workspaces/ws-1/datasets/ds-1/generations/job-1": jsonHandler(200, map[string]any{
+			"id": "job-1", "status": "cancelled", "accepted_count": 3, "rejected_count": 1,
+		}),
+	})
+	defer srv.Close()
+
+	cap := captureStdout(t)
+	done := make(chan error, 1)
+	go func() {
+		done <- executeCommand(t, []string{
+			"dataset", "generate", "ds-1",
+			"--count", "5", "--provider-account", "pa-1", "--model-alias", "ma-1",
+			"--follow", "--poll-interval", "10ms", "--json",
+		}, srv.URL)
+	}()
+
+	select {
+	case err := <-done:
+		out := cap.finish()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(out, `"cancelled"`) {
+			t.Fatalf("structured output should carry the terminal cancelled job:\n%s", out)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("follow loop did not terminate on a cancelled job (pre-fix infinite loop)")
+	}
+}
+
+// WI-8b: --timeout aborts the follow loop with the documented follow_timeout
+// code instead of polling forever.
+func TestDatasetGenerateFollowTimesOutWithDocumentedCode(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("AGENTCLASH_TOKEN", "tok")
+	t.Setenv("AGENTCLASH_WORKSPACE", "ws-1")
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"POST /v1/workspaces/ws-1/datasets/ds-1/generate": jsonHandler(201, map[string]any{"id": "job-1", "status": "running"}),
+		"GET /v1/workspaces/ws-1/datasets/ds-1/generations/job-1": jsonHandler(200, map[string]any{
+			"id": "job-1", "status": "running",
+		}),
+	})
+	defer srv.Close()
+
+	start := time.Now()
+	err := executeCommand(t, []string{
+		"dataset", "generate", "ds-1",
+		"--count", "5", "--provider-account", "pa-1", "--model-alias", "ma-1",
+		"--follow", "--poll-interval", "10ms", "--timeout", "150ms", "--json",
+	}, srv.URL)
+	if err == nil {
+		t.Fatal("expected a follow_timeout error, got nil")
+	}
+	var ce *cliError
+	if !errors.As(err, &ce) || ce.Code != "follow_timeout" {
+		t.Fatalf("error = %v, want cliError code follow_timeout", err)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("timeout took %v, want ~150ms", elapsed)
+	}
+}
+
+// The canonical terminal set: one helper, both spellings of cancelled, and
+// non-terminal statuses keep polling.
+func TestIsTerminalRunStatus(t *testing.T) {
+	for _, s := range []string{"completed", "failed", "cancelled", "canceled"} {
+		if !isTerminalRunStatus(s) {
+			t.Errorf("isTerminalRunStatus(%q) = false, want true", s)
+		}
+	}
+	for _, s := range []string{"pending", "running", "queued", ""} {
+		if isTerminalRunStatus(s) {
+			t.Errorf("isTerminalRunStatus(%q) = true, want false", s)
+		}
+	}
+}
+
+// WI-10: a dropped SSE connection resumes with Last-Event-ID instead of losing
+// (or duplicating) events; --since seeds the first connection. The fake server
+// drops after one event; the run-status probe says the run is still live, so
+// the client reconnects from ev-1 and then finishes when the run turns
+// terminal.
+func TestRunEventsReconnectsWithLastEventID(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("AGENTCLASH_TOKEN", "tok")
+	t.Setenv("AGENTCLASH_WORKSPACE", "ws-1")
+
+	var connections atomic.Int32
+	var firstLastEventID, secondLastEventID string
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/runs/run-1/events/stream": func(w http.ResponseWriter, r *http.Request) {
+			n := connections.Add(1)
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			flusher := w.(http.Flusher)
+			switch n {
+			case 1:
+				firstLastEventID = r.Header.Get("Last-Event-ID")
+				fmt.Fprint(w, "id: ev-1\nevent: run.event\ndata: {\"seq\":1}\n\n")
+				flusher.Flush()
+				// Drop the connection mid-run.
+			default:
+				secondLastEventID = r.Header.Get("Last-Event-ID")
+				fmt.Fprint(w, "id: ev-2\nevent: run.event\ndata: {\"seq\":2}\n\n")
+				flusher.Flush()
+			}
+		},
+		"GET /v1/runs/run-1": func(w http.ResponseWriter, r *http.Request) {
+			status := "running"
+			if connections.Load() >= 2 {
+				status = "completed"
+			}
+			jsonHandler(200, map[string]any{"id": "run-1", "status": status})(w, r)
+		},
+	})
+	defer srv.Close()
+
+	cap := captureStdout(t)
+	err := executeCommand(t, []string{"run", "events", "run-1", "--json", "--since", "ev-0"}, srv.URL)
+	out := cap.finish()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := connections.Load(); got != 2 {
+		t.Fatalf("SSE connections = %d, want 2 (initial + one resume)", got)
+	}
+	if firstLastEventID != "ev-0" {
+		t.Fatalf("first connection Last-Event-ID = %q, want the --since value ev-0", firstLastEventID)
+	}
+	if secondLastEventID != "ev-1" {
+		t.Fatalf("resume connection Last-Event-ID = %q, want ev-1 (the last received event)", secondLastEventID)
+	}
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 || !strings.Contains(lines[0], `"seq":1`) || !strings.Contains(lines[1], `"seq":2`) {
+		t.Fatalf("expected both events exactly once in order, got:\n%s", out)
+	}
+}
+
+func nonEmptyLines(s string) []string {
+	var lines []string
+	for _, line := range strings.Split(s, "\n") {
+		if strings.TrimSpace(line) != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -809,14 +809,27 @@ func streamRunEvents(cmd *cobra.Command, rc *RunContext, runID string, patterns 
 		if probeErr != nil || terminal {
 			break
 		}
+		// Tell the operator why the CLI is pausing BEFORE any backoff sleep —
+		// silence followed by a reconnect line reads like a hang.
+		if !rc.Output.IsStructured() {
+			resumeFrom := lastEventID
+			if resumeFrom == "" {
+				resumeFrom = "the live tail"
+			}
+			fmt.Fprintf(os.Stderr, "%s Stream dropped; reconnecting from %s\n", output.Faint("▸"), resumeFrom)
+		}
 		if received {
 			eventlessReconnects = 0
 		} else {
 			eventlessReconnects++
 			if eventlessReconnects >= maxEventlessReconnects {
+				retryHint := fmt.Sprintf("retry with `agentclash run events %s`", runID)
+				if lastEventID != "" {
+					retryHint = fmt.Sprintf("retry with `agentclash run events %s --since %s`", runID, lastEventID)
+				}
 				return &cliError{
 					Code:    "stream_reconnect_exhausted",
-					Message: fmt.Sprintf("event stream for run %s dropped %d times in a row without delivering an event; retry with `agentclash run events %s --since %s`", runID, eventlessReconnects, runID, lastEventID),
+					Message: fmt.Sprintf("event stream for run %s dropped %d times in a row without delivering an event; %s", runID, eventlessReconnects, retryHint),
 				}
 			}
 			// Context-aware backoff: 1s, 2s, 4s, 8s between eventless re-dials.
@@ -828,13 +841,6 @@ func streamRunEvents(cmd *cobra.Command, rc *RunContext, runID string, patterns 
 				return nil
 			case <-timer.C:
 			}
-		}
-		if !rc.Output.IsStructured() {
-			resumeFrom := lastEventID
-			if resumeFrom == "" {
-				resumeFrom = "the live tail"
-			}
-			fmt.Fprintf(os.Stderr, "%s Stream dropped; reconnecting from %s\n", output.Faint("▸"), resumeFrom)
 		}
 	}
 

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -49,6 +49,7 @@ func init() {
 	runCreateCmd.Flags().Int("seeds", 0, "Create a seeded eval session with N child runs, one per seed (1-100). 0 creates a single run.")
 	runCreateCmd.Flags().String("mode", "", "Voice eval mode: text-sim (future: audio-sim, live-call, replay-import)")
 	runEventsCmd.Flags().StringSlice("filter", nil, "Filter streamed events by event type pattern (exact, comma-separated, or glob; '*' matches any non-slash chars, so 'model.*' matches 'model.call.started'; repeatable)")
+	runEventsCmd.Flags().String("since", "", "Resume the stream after this event ID (sent as Last-Event-ID; the server replays everything recorded after it)")
 
 	runRankingCmd.Flags().String("sort-by", "", "Sort by: composite, correctness, reliability, latency, cost")
 	runFailuresCmd.Flags().String("agent", "", "Filter by run agent ID")
@@ -769,17 +770,112 @@ var runPromoteFailureCmd = &cobra.Command{
 	},
 }
 
+// maxEventlessReconnects bounds how many consecutive times streamRunEvents
+// will re-dial a connection that dropped without delivering a single event.
+// A reconnect after real progress resets the budget.
+const maxEventlessReconnects = 5
+
 func streamRunEvents(cmd *cobra.Command, rc *RunContext, runID string, patterns []string) error {
-	ch, err := rc.Client.StreamSSE(cmd.Context(), "/v1/runs/"+runID+"/events/stream", nil)
-	if err != nil {
-		return fmt.Errorf("connecting to event stream: %w", err)
+	// --since is only registered on `run events`; the other follow paths
+	// (eval start, run create, ci run) share this function without it.
+	lastEventID := ""
+	if f := cmd.Flags().Lookup("since"); f != nil {
+		lastEventID = strings.TrimSpace(f.Value.String())
 	}
 
 	if !rc.Output.IsStructured() {
 		fmt.Fprintf(os.Stderr, "%s Streaming events for run %s (Ctrl+C to stop)\n", output.Cyan("▸"), runID)
 	}
 
+	eventlessReconnects := 0
+	for {
+		received, err := streamRunEventsOnce(cmd, rc, runID, patterns, &lastEventID)
+		if err != nil {
+			return err
+		}
+		if cmd.Context().Err() != nil {
+			// Ctrl+C / cancellation: not an error for a live tail.
+			break
+		}
+
+		// The server closed the stream. That is either the natural end (the
+		// run reached a terminal status) or a dropped connection — probe the
+		// run to tell the two apart, then resume from the last received ID.
+		// Reconnect ONLY on a positive "still live" answer: if the probe
+		// errors (run not readable, transient failure), fall back to the
+		// pre-resume behavior where a closed stream simply ends the tail —
+		// anything else risks an unbounded reconnect loop.
+		terminal, probeErr := runReachedTerminalStatus(cmd, rc, runID)
+		if probeErr != nil || terminal {
+			break
+		}
+		if received {
+			eventlessReconnects = 0
+		} else {
+			eventlessReconnects++
+			if eventlessReconnects >= maxEventlessReconnects {
+				return &cliError{
+					Code:    "stream_reconnect_exhausted",
+					Message: fmt.Sprintf("event stream for run %s dropped %d times in a row without delivering an event; retry with `agentclash run events %s --since %s`", runID, eventlessReconnects, runID, lastEventID),
+				}
+			}
+			// Context-aware backoff: 1s, 2s, 4s, 8s between eventless re-dials.
+			backoff := time.Duration(1<<(eventlessReconnects-1)) * time.Second
+			timer := time.NewTimer(backoff)
+			select {
+			case <-cmd.Context().Done():
+				timer.Stop()
+				return nil
+			case <-timer.C:
+			}
+		}
+		if !rc.Output.IsStructured() {
+			resumeFrom := lastEventID
+			if resumeFrom == "" {
+				resumeFrom = "the live tail"
+			}
+			fmt.Fprintf(os.Stderr, "%s Stream dropped; reconnecting from %s\n", output.Faint("▸"), resumeFrom)
+		}
+	}
+
+	if !rc.Output.IsStructured() {
+		fmt.Fprintf(os.Stderr, "%s Stream ended\n", output.Faint("▸"))
+	}
+	return nil
+}
+
+// runReachedTerminalStatus probes the run's status once via REST so a closed
+// SSE connection can be classified as "run finished" vs "connection dropped".
+func runReachedTerminalStatus(cmd *cobra.Command, rc *RunContext, runID string) (bool, error) {
+	resp, err := rc.Client.Get(cmd.Context(), "/v1/runs/"+runID, nil)
+	if err != nil {
+		return false, err
+	}
+	if apiErr := resp.ParseError(); apiErr != nil {
+		return false, apiErr
+	}
+	var run map[string]any
+	if err := resp.DecodeJSON(&run); err != nil {
+		return false, err
+	}
+	return isTerminalRunStatus(str(run["status"])), nil
+}
+
+// streamRunEventsOnce runs a single SSE connection to completion, rendering
+// events as they arrive. It reports whether any event was received and keeps
+// *lastEventID current so the caller can resume a dropped connection.
+func streamRunEventsOnce(cmd *cobra.Command, rc *RunContext, runID string, patterns []string, lastEventID *string) (bool, error) {
+	ch, err := rc.Client.StreamSSEFrom(cmd.Context(), "/v1/runs/"+runID+"/events/stream", nil, *lastEventID)
+	if err != nil {
+		return false, fmt.Errorf("connecting to event stream: %w", err)
+	}
+
+	received := false
 	for event := range ch {
+		received = true
+		if event.ID != "" {
+			*lastEventID = event.ID
+		}
 		if !runEventMatchesFilters(event.Event, event.Data, patterns) {
 			continue
 		}
@@ -799,7 +895,7 @@ func streamRunEvents(cmd *cobra.Command, rc *RunContext, runID string, patterns 
 			}
 			out, err := yaml.Marshal(doc)
 			if err != nil {
-				return fmt.Errorf("encoding event as yaml: %w", err)
+				return received, fmt.Errorf("encoding event as yaml: %w", err)
 			}
 			fmt.Fprint(rc.Output.Writer(), "---\n")
 			fmt.Fprint(rc.Output.Writer(), string(out))
@@ -823,11 +919,7 @@ func streamRunEvents(cmd *cobra.Command, rc *RunContext, runID string, patterns 
 			)
 		}
 	}
-
-	if !rc.Output.IsStructured() {
-		fmt.Fprintf(os.Stderr, "%s Stream ended\n", output.Faint("▸"))
-	}
-	return nil
+	return received, nil
 }
 
 func runEventMatchesFilters(sseEvent string, data []byte, patterns []string) bool {

--- a/cli/cmd/run_status.go
+++ b/cli/cmd/run_status.go
@@ -4,8 +4,9 @@ package cmd
 // machine (backend/internal/domain/run.go). Every follow/poll loop in the CLI
 // must use isTerminalRunStatus rather than hand-rolling its own switch — the
 // divergent copies are exactly how `dataset generate --follow` looped forever
-// on a cancelled job. The `schema` command's status registry consumes these
-// same constants, so the documented contract and the code cannot drift.
+// on a cancelled job. These constants are the single vocabulary the `schema`
+// status registry builds on in a later PR; keeping them here means that
+// registry references the same source the follow loops do.
 const (
 	runStatusPending   = "pending"
 	runStatusRunning   = "running"

--- a/cli/cmd/run_status.go
+++ b/cli/cmd/run_status.go
@@ -1,0 +1,28 @@
+package cmd
+
+// Canonical run/job lifecycle statuses, aligned with the backend's run state
+// machine (backend/internal/domain/run.go). Every follow/poll loop in the CLI
+// must use isTerminalRunStatus rather than hand-rolling its own switch — the
+// divergent copies are exactly how `dataset generate --follow` looped forever
+// on a cancelled job. The `schema` command's status registry consumes these
+// same constants, so the documented contract and the code cannot drift.
+const (
+	runStatusPending   = "pending"
+	runStatusRunning   = "running"
+	runStatusCompleted = "completed"
+	runStatusFailed    = "failed"
+	runStatusCancelled = "cancelled"
+)
+
+// isTerminalRunStatus reports whether a run/job/execution status is final —
+// no follow loop should keep polling past it. The single-l "canceled" is
+// accepted defensively: the backend's canonical spelling is "cancelled", but
+// an alias here costs nothing and an omission means an infinite poll loop.
+func isTerminalRunStatus(status string) bool {
+	switch status {
+	case runStatusCompleted, runStatusFailed, runStatusCancelled, "canceled":
+		return true
+	default:
+		return false
+	}
+}

--- a/cli/cmd/schema.go
+++ b/cli/cmd/schema.go
@@ -68,12 +68,21 @@ type cliSchema struct {
 // "agentclash run create") scopes a local flag. Only add entries whose set is
 // authoritative (enforced by validation or the backend) — a speculative or
 // stale enum is worse for an agent than none.
+// runScopeValues is the closed set the shared run-create validator enforces
+// (run_create_helpers.go). Both `run create` and `eval start` parse flags
+// through it, so they reference one source here rather than two literals that
+// could drift.
+var runScopeValues = []string{"full", "suite_only"}
+
 var flagAllowedValues = map[string]map[string][]string{
 	"": {
 		"output": {"table", "json", "yaml"},
 	},
 	"agentclash run create": {
-		"scope": {"full", "suite_only"},
+		"scope": runScopeValues,
+	},
+	"agentclash eval start": {
+		"scope": runScopeValues,
 	},
 }
 

--- a/cli/cmd/schema.go
+++ b/cli/cmd/schema.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -12,7 +14,10 @@ import (
 // schemaDocVersion is the version of the schema DOCUMENT shape (not the CLI).
 // Bump it when the JSON structure below changes incompatibly so consumers can
 // detect breaking changes independent of the CLI version.
-const schemaDocVersion = 1
+//
+// v2: positional args, per-flag allowed_values, command examples, and the
+// top-level error_codes and status_enums registries.
+const schemaDocVersion = 2
 
 type flagSchema struct {
 	Name      string `json:"name" yaml:"name"`
@@ -21,6 +26,19 @@ type flagSchema struct {
 	Type      string `json:"type" yaml:"type"`
 	Default   string `json:"default,omitempty" yaml:"default,omitempty"`
 	Required  bool   `json:"required,omitempty" yaml:"required,omitempty"`
+	// AllowedValues is the closed value set for enum-like flags, populated
+	// from flagAllowedValues — only flags with an authoritative, validated
+	// set are listed; absence means "free-form", not "unknown".
+	AllowedValues []string `json:"allowed_values,omitempty" yaml:"allowed_values,omitempty"`
+}
+
+// argSchema describes one positional argument, parsed from the command's Use
+// line: `<x>` is required, `[x]` is optional, and a trailing `...` marks the
+// argument as variadic.
+type argSchema struct {
+	Name     string `json:"name" yaml:"name"`
+	Required bool   `json:"required" yaml:"required"`
+	Variadic bool   `json:"variadic,omitempty" yaml:"variadic,omitempty"`
 }
 
 type commandSchema struct {
@@ -29,6 +47,8 @@ type commandSchema struct {
 	Short       string          `json:"short" yaml:"short"`
 	Aliases     []string        `json:"aliases,omitempty" yaml:"aliases,omitempty"`
 	Runnable    bool            `json:"runnable" yaml:"runnable"`
+	Args        []argSchema     `json:"args,omitempty" yaml:"args,omitempty"`
+	Example     string          `json:"example,omitempty" yaml:"example,omitempty"`
 	Flags       []flagSchema    `json:"flags,omitempty" yaml:"flags,omitempty"`
 	Subcommands []commandSchema `json:"subcommands,omitempty" yaml:"subcommands,omitempty"`
 }
@@ -39,12 +59,64 @@ type cliSchema struct {
 	GlobalFlags   []flagSchema    `json:"global_flags" yaml:"global_flags"`
 	Commands      []commandSchema `json:"commands" yaml:"commands"`
 	ExitCodes     []ExitCode      `json:"exit_codes" yaml:"exit_codes"`
+	ErrorCodes    []ErrorCode     `json:"error_codes" yaml:"error_codes"`
+	StatusEnums   []StatusEnum    `json:"status_enums" yaml:"status_enums"`
+}
+
+// flagAllowedValues registers the closed value sets for enum-like flags.
+// Key "" scopes a global persistent flag; a command path (e.g.
+// "agentclash run create") scopes a local flag. Only add entries whose set is
+// authoritative (enforced by validation or the backend) — a speculative or
+// stale enum is worse for an agent than none.
+var flagAllowedValues = map[string]map[string][]string{
+	"": {
+		"output": {"table", "json", "yaml"},
+	},
+	"agentclash run create": {
+		"scope": {"full", "suite_only"},
+	},
+}
+
+// parseArgsFromUse extracts positional arguments from a cobra Use line.
+// Tokens after the command name follow the conventional grammar:
+// `<name>` required, `[name]` optional, trailing `...` (inside or outside the
+// brackets) variadic. Plain tokens (subcommand words) are ignored.
+func parseArgsFromUse(use string) []argSchema {
+	// Normalize "<x> ..." / "[x ...]" so the ellipsis stays attached to its
+	// argument token through Fields.
+	use = strings.ReplaceAll(use, " ...", "...")
+	fields := strings.Fields(use)
+	if len(fields) < 2 {
+		return nil
+	}
+	var out []argSchema
+	for _, tok := range fields[1:] {
+		variadic := strings.Contains(tok, "...")
+		tok = strings.ReplaceAll(tok, "...", "")
+		var name string
+		var required bool
+		switch {
+		case strings.HasPrefix(tok, "<") && strings.HasSuffix(tok, ">"):
+			name, required = tok[1:len(tok)-1], true
+		case strings.HasPrefix(tok, "[") && strings.HasSuffix(tok, "]"):
+			name, required = tok[1:len(tok)-1], false
+		default:
+			continue
+		}
+		if name == "" {
+			continue
+		}
+		out = append(out, argSchema{Name: name, Required: required, Variadic: variadic})
+	}
+	return out
 }
 
 // flagsOf serialises a flag set deterministically, skipping hidden flags and any
 // flag whose name is in skip (used to keep the global persistent flags from being
-// repeated on every command).
-func flagsOf(fs *pflag.FlagSet, skip map[string]bool) []flagSchema {
+// repeated on every command). scope selects the flagAllowedValues entry: "" for
+// globals, the command path for local flags.
+func flagsOf(fs *pflag.FlagSet, skip map[string]bool, scope string) []flagSchema {
+	enums := flagAllowedValues[scope]
 	var out []flagSchema
 	fs.VisitAll(func(f *pflag.Flag) {
 		// Skip the `--help` flag cobra injects onto every command during
@@ -54,12 +126,13 @@ func flagsOf(fs *pflag.FlagSet, skip map[string]bool) []flagSchema {
 			return
 		}
 		out = append(out, flagSchema{
-			Name:      f.Name,
-			Shorthand: f.Shorthand,
-			Usage:     f.Usage,
-			Type:      f.Value.Type(),
-			Default:   f.DefValue,
-			Required:  f.Annotations[cobra.BashCompOneRequiredFlag] != nil,
+			Name:          f.Name,
+			Shorthand:     f.Shorthand,
+			Usage:         f.Usage,
+			Type:          f.Value.Type(),
+			Default:       f.DefValue,
+			Required:      f.Annotations[cobra.BashCompOneRequiredFlag] != nil,
+			AllowedValues: enums[f.Name],
 		})
 	})
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
@@ -93,7 +166,9 @@ func commandsOf(parent *cobra.Command, globals map[string]bool) []commandSchema 
 			Short:       c.Short,
 			Aliases:     c.Aliases,
 			Runnable:    c.Runnable(),
-			Flags:       flagsOf(c.LocalFlags(), globals),
+			Args:        parseArgsFromUse(c.Use),
+			Example:     c.Example,
+			Flags:       flagsOf(c.LocalFlags(), globals, c.CommandPath()),
 			Subcommands: commandsOf(c, globals),
 		})
 	}
@@ -106,7 +181,7 @@ func commandsOf(parent *cobra.Command, globals map[string]bool) []commandSchema 
 // codes. version is injected (rather than read from cliVersion) so tests can pin
 // a stable value for the golden snapshot.
 func buildCLISchema(root *cobra.Command, version string) cliSchema {
-	globalFlags := flagsOf(root.PersistentFlags(), nil)
+	globalFlags := flagsOf(root.PersistentFlags(), nil, "")
 	globalNames := make(map[string]bool, len(globalFlags))
 	for _, f := range globalFlags {
 		globalNames[f.Name] = true
@@ -117,7 +192,39 @@ func buildCLISchema(root *cobra.Command, version string) cliSchema {
 		GlobalFlags:   globalFlags,
 		Commands:      commandsOf(root, globalNames),
 		ExitCodes:     documentedExitCodes,
+		ErrorCodes:    documentedErrorCodes,
+		StatusEnums:   documentedStatusEnums,
 	}
+}
+
+// findSchemaSubtree resolves a command path (e.g. ["run", "get"]) against the
+// schema tree, matching names and aliases.
+func findSchemaSubtree(cmds []commandSchema, path []string) *commandSchema {
+	if len(path) == 0 {
+		return nil
+	}
+	for i := range cmds {
+		if !schemaNameMatches(&cmds[i], path[0]) {
+			continue
+		}
+		if len(path) == 1 {
+			return &cmds[i]
+		}
+		return findSchemaSubtree(cmds[i].Subcommands, path[1:])
+	}
+	return nil
+}
+
+func schemaNameMatches(c *commandSchema, name string) bool {
+	if c.Name == name {
+		return true
+	}
+	for _, alias := range c.Aliases {
+		if alias == name {
+			return true
+		}
+	}
+	return false
 }
 
 func init() {
@@ -125,25 +232,42 @@ func init() {
 }
 
 var schemaCmd = &cobra.Command{
-	Use:   "schema",
+	Use:   "schema [command ...]",
 	Short: "Print the CLI command tree as machine-readable JSON",
-	Long: `Print the full command tree — every command, its flags (with types and
-defaults), and the documented process exit codes — as a single machine-readable
-JSON document, so agents and scripts can introspect the CLI without parsing
---help text.
+	Long: `Print the full command tree — every command, its positional args and flags
+(with types, defaults, and enum values), the documented process exit codes,
+the CLI-local error codes, and the resource status enums — as a single
+machine-readable JSON document, so agents and scripts can introspect the CLI
+without parsing --help text.
+
+Pass a command path to print just that subtree:
+  agentclash schema run get
 
 Output is always structured (JSON by default, or YAML with --output yaml); the
 format is NOT auto-switched based on whether stdout is a pipe — pass --json or
 --output explicitly, consistent with every other AgentClash command.`,
-	Args: cobra.NoArgs,
+	Args: cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		doc := buildCLISchema(rootCmd, cliVersion)
+
+		var payload any = doc
+		if len(args) > 0 {
+			sub := findSchemaSubtree(doc.Commands, args)
+			if sub == nil {
+				return &cliError{
+					Code:    "invalid_argument",
+					Message: fmt.Sprintf("unknown command path %q; run `agentclash schema` for the full tree", strings.Join(args, " ")),
+				}
+			}
+			payload = sub
+		}
+
 		if rc := GetRunContext(cmd); rc != nil {
-			return rc.Output.PrintRaw(doc)
+			return rc.Output.PrintRaw(payload)
 		}
 		// Defensive fallback (RunContext is always set via PersistentPreRunE).
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		return enc.Encode(doc)
+		return enc.Encode(payload)
 	},
 }

--- a/cli/cmd/schema_v2_test.go
+++ b/cli/cmd/schema_v2_test.go
@@ -140,3 +140,37 @@ func TestSchemaSubtreeLookup(t *testing.T) {
 		t.Fatalf("unknown path error = %v, want cliError invalid_argument", err)
 	}
 }
+
+// The error_codes registry's `retryable` flags must match what the CLI
+// actually emits — a published `retryable:true` that the runtime contradicts
+// (retryable:false + exit 64) is the exact contract lie schema v2 exists to
+// prevent. Codes the CLI synthesizes as a cliError are checked end-to-end.
+func TestErrorCodeRegistryRetryableMatchesRuntime(t *testing.T) {
+	reg := map[string]bool{}
+	for _, ec := range documentedErrorCodes {
+		reg[ec.Code] = ec.Retryable
+	}
+
+	// cliError-synthesized codes: build the error, classify it, compare.
+	for _, code := range []string{"follow_timeout", "stream_reconnect_exhausted", "missing_workspace", "invalid_argument"} {
+		want, documented := reg[code]
+		if !documented {
+			t.Errorf("error code %q is emitted but absent from the registry", code)
+			continue
+		}
+		se := classifyStructuredError(&cliError{Code: code, Message: "x"})
+		if se.Retryable != want {
+			t.Errorf("code %q: registry retryable=%v, runtime envelope retryable=%v", code, want, se.Retryable)
+		}
+		// The exit-75 ⟺ retryable invariant must also hold for these.
+		gotExit := exitCodeForError(&cliError{Code: code, Message: "x"})
+		if (gotExit == exitRetryableFailure) != want {
+			t.Errorf("code %q: exit %d vs registry retryable=%v breaks the exit-75-iff-retryable invariant", code, gotExit, want)
+		}
+	}
+
+	// Transport failures genuinely are retryable, and the registry must say so.
+	if !reg["request_failed"] {
+		t.Error("request_failed must be marked retryable in the registry")
+	}
+}

--- a/cli/cmd/schema_v2_test.go
+++ b/cli/cmd/schema_v2_test.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestParseArgsFromUse(t *testing.T) {
+	cases := []struct {
+		use  string
+		want []argSchema
+	}{
+		{"list", nil},
+		{"get <runId>", []argSchema{{Name: "runId", Required: true}}},
+		{"import <datasetId> <file>", []argSchema{{Name: "datasetId", Required: true}, {Name: "file", Required: true}}},
+		{"logs [pod]", []argSchema{{Name: "pod", Required: false}}},
+		{"add <files>...", []argSchema{{Name: "files", Required: true, Variadic: true}}},
+		{"add [files...]", []argSchema{{Name: "files", Required: false, Variadic: true}}},
+		{"schema [command ...]", []argSchema{{Name: "command", Required: false, Variadic: true}}},
+	}
+	for _, tc := range cases {
+		if got := parseArgsFromUse(tc.use); !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("parseArgsFromUse(%q) = %+v, want %+v", tc.use, got, tc.want)
+		}
+	}
+}
+
+// WI-3 acceptance: `run get` is invocable from the schema alone — the
+// positional arg is visible and required.
+func TestSchemaExposesPositionalArgs(t *testing.T) {
+	doc := buildCLISchema(rootCmd, "test")
+	runGet := findCommandByPath(doc.Commands, "agentclash run get")
+	if runGet == nil {
+		t.Fatal("agentclash run get missing from schema")
+	}
+	if len(runGet.Args) != 1 || !runGet.Args[0].Required {
+		t.Fatalf("run get args = %+v, want one required positional", runGet.Args)
+	}
+}
+
+// WI-3: --output exposes its closed value set; enum-less flags stay bare.
+func TestSchemaExposesAllowedValues(t *testing.T) {
+	doc := buildCLISchema(rootCmd, "test")
+
+	var outputFlag *flagSchema
+	for i := range doc.GlobalFlags {
+		if doc.GlobalFlags[i].Name == "output" {
+			outputFlag = &doc.GlobalFlags[i]
+		}
+	}
+	if outputFlag == nil {
+		t.Fatal("global --output missing from schema")
+	}
+	if !reflect.DeepEqual(outputFlag.AllowedValues, []string{"table", "json", "yaml"}) {
+		t.Fatalf("--output allowed_values = %v, want [table json yaml]", outputFlag.AllowedValues)
+	}
+
+	runCreate := findCommandByPath(doc.Commands, "agentclash run create")
+	if runCreate == nil {
+		t.Fatal("agentclash run create missing from schema")
+	}
+	for _, f := range runCreate.Flags {
+		if f.Name == "scope" && !reflect.DeepEqual(f.AllowedValues, []string{"full", "suite_only"}) {
+			t.Fatalf("run create --scope allowed_values = %v, want [full suite_only]", f.AllowedValues)
+		}
+		if f.Name == "name" && f.AllowedValues != nil {
+			t.Fatalf("free-form flag --name must not claim allowed_values; got %v", f.AllowedValues)
+		}
+	}
+}
+
+// WI-3: the error-code and status-enum registries are published, and the
+// status registry stays in lockstep with isTerminalRunStatus — the same
+// helper every --follow loop uses.
+func TestSchemaPublishesErrorAndStatusRegistries(t *testing.T) {
+	doc := buildCLISchema(rootCmd, "test")
+	if len(doc.ErrorCodes) == 0 || len(doc.StatusEnums) == 0 {
+		t.Fatalf("error_codes/status_enums missing: %d/%d entries", len(doc.ErrorCodes), len(doc.StatusEnums))
+	}
+
+	codes := map[string]bool{}
+	for _, ec := range doc.ErrorCodes {
+		codes[ec.Code] = true
+	}
+	for _, want := range []string{"invalid_argument", "request_failed", "follow_timeout", "stream_reconnect_exhausted", "missing_workspace"} {
+		if !codes[want] {
+			t.Errorf("error_codes missing %q", want)
+		}
+	}
+
+	for _, se := range doc.StatusEnums {
+		terminal := map[string]bool{}
+		for _, s := range se.Terminal {
+			if !isTerminalRunStatus(s) {
+				t.Errorf("status_enums[%s] lists %q terminal, but isTerminalRunStatus disagrees", se.Resource, s)
+			}
+			terminal[s] = true
+		}
+		for _, s := range se.Values {
+			if isTerminalRunStatus(s) && !terminal[s] {
+				t.Errorf("status_enums[%s]: %q is terminal in code but not in the registry", se.Resource, s)
+			}
+		}
+	}
+}
+
+// WI-14: `schema <command-path>` returns just that subtree; aliases resolve;
+// unknown paths fail with a stable code.
+func TestSchemaSubtreeLookup(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cap := captureStdout(t)
+	err := executeCommand(t, []string{"schema", "run", "get", "--json"}, "http://unused.invalid")
+	out := cap.finish()
+	if err != nil {
+		t.Fatalf("schema run get: %v", err)
+	}
+	var sub commandSchema
+	if uerr := json.Unmarshal([]byte(out), &sub); uerr != nil {
+		t.Fatalf("subtree output is not a single JSON doc: %v\n%s", uerr, out)
+	}
+	if sub.Path != "agentclash run get" || len(sub.Args) != 1 {
+		t.Fatalf("subtree = path %q args %+v, want agentclash run get with one arg", sub.Path, sub.Args)
+	}
+
+	// Alias resolution: `harness` aliases `agent-harness`.
+	cap = captureStdout(t)
+	if err := executeCommand(t, []string{"schema", "harness", "run", "--json"}, "http://unused.invalid"); err != nil {
+		t.Fatalf("schema harness run (alias): %v", err)
+	}
+	if uerr := json.Unmarshal([]byte(cap.finish()), &sub); uerr != nil || sub.Path != "agentclash agent-harness run" {
+		t.Fatalf("alias lookup = %q (err %v), want agentclash agent-harness run", sub.Path, uerr)
+	}
+
+	err = executeCommand(t, []string{"schema", "bogus", "--json"}, "http://unused.invalid")
+	var ce *cliError
+	if !errors.As(err, &ce) || ce.Code != "invalid_argument" {
+		t.Fatalf("unknown path error = %v, want cliError invalid_argument", err)
+	}
+}

--- a/cli/cmd/status_enums.go
+++ b/cli/cmd/status_enums.go
@@ -16,6 +16,10 @@ var documentedStatusEnums = []StatusEnum{
 	{
 		// Runs, run-agent executions, agent-harness executions, eval
 		// sessions, and dataset generation jobs all share this lifecycle.
+		// The registry lists CANONICAL values only: the single-l "canceled"
+		// is accepted defensively by isTerminalRunStatus but is not part of
+		// the published contract — teaching agents a non-canonical spelling
+		// would be worse than tolerating one.
 		Resource: "run",
 		Values:   []string{runStatusPending, runStatusRunning, runStatusCompleted, runStatusFailed, runStatusCancelled},
 		Terminal: []string{runStatusCompleted, runStatusFailed, runStatusCancelled},

--- a/cli/cmd/status_enums.go
+++ b/cli/cmd/status_enums.go
@@ -1,0 +1,23 @@
+package cmd
+
+// StatusEnum documents the lifecycle statuses of a polled resource and which
+// of them are terminal — the set every --follow loop stops on. The values
+// reference the canonical constants in run_status.go (the same source
+// isTerminalRunStatus uses), and a lockstep test keeps the two aligned, so
+// the published contract cannot drift from the code. Published via
+// `agentclash schema`.
+type StatusEnum struct {
+	Resource string   `json:"resource" yaml:"resource"`
+	Values   []string `json:"values" yaml:"values"`
+	Terminal []string `json:"terminal" yaml:"terminal"`
+}
+
+var documentedStatusEnums = []StatusEnum{
+	{
+		// Runs, run-agent executions, agent-harness executions, eval
+		// sessions, and dataset generation jobs all share this lifecycle.
+		Resource: "run",
+		Values:   []string{runStatusPending, runStatusRunning, runStatusCompleted, runStatusFailed, runStatusCancelled},
+		Terminal: []string{runStatusCompleted, runStatusFailed, runStatusCancelled},
+	},
+}

--- a/cli/cmd/testdata/schema_snapshot.json
+++ b/cli/cmd/testdata/schema_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "cli_version": "test",
   "global_flags": [
     {
@@ -23,7 +23,12 @@
       "name": "output",
       "shorthand": "o",
       "usage": "Output format: table, json, yaml",
-      "type": "string"
+      "type": "string",
+      "allowed_values": [
+        "table",
+        "json",
+        "yaml"
+      ]
     },
     {
       "name": "quiet",
@@ -151,7 +156,13 @@
               "name": "cancel",
               "path": "agentclash agent-harness execution cancel",
               "short": "Cancel an Agent Harness execution",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "execution-id",
+                  "required": true
+                }
+              ]
             },
             {
               "name": "failure-review",
@@ -163,13 +174,25 @@
                   "name": "get",
                   "path": "agentclash agent-harness execution failure-review get",
                   "short": "Get Agent Harness failure review",
-                  "runnable": true
+                  "runnable": true,
+                  "args": [
+                    {
+                      "name": "execution-id",
+                      "required": true
+                    }
+                  ]
                 },
                 {
                   "name": "update",
                   "path": "agentclash agent-harness execution failure-review update",
                   "short": "Update Agent Harness failure review annotations",
                   "runnable": true,
+                  "args": [
+                    {
+                      "name": "execution-id",
+                      "required": true
+                    }
+                  ],
                   "flags": [
                     {
                       "name": "from-file",
@@ -224,13 +247,25 @@
               "name": "get",
               "path": "agentclash agent-harness execution get",
               "short": "Get an agent harness execution",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "execution-id",
+                  "required": true
+                }
+              ]
             },
             {
               "name": "promote-task",
               "path": "agentclash agent-harness execution promote-task",
               "short": "Promote a prior harness run into a private suite task",
               "runnable": true,
+              "args": [
+                {
+                  "name": "execution-id",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "failure-class",
@@ -274,6 +309,12 @@
               "path": "agentclash agent-harness execution retry",
               "short": "Retry a terminal Agent Harness execution",
               "runnable": true,
+              "args": [
+                {
+                  "name": "execution-id",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "idempotency-key",
@@ -288,7 +329,13 @@
           "name": "executions",
           "path": "agentclash agent-harness executions",
           "short": "List executions for an agent harness",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "harness-id",
+              "required": true
+            }
+          ]
         },
         {
           "name": "failures",
@@ -308,7 +355,13 @@
           "name": "get",
           "path": "agentclash agent-harness get",
           "short": "Get an agent harness",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "id",
+              "required": true
+            }
+          ]
         },
         {
           "name": "list",
@@ -321,6 +374,12 @@
           "path": "agentclash agent-harness run",
           "short": "Start an agent harness execution",
           "runnable": true,
+          "args": [
+            {
+              "name": "harness-id",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "follow",
@@ -392,6 +451,12 @@
               "path": "agentclash agent-harness suite rankings",
               "short": "Get Agent Harness suite rankings",
               "runnable": true,
+              "args": [
+                {
+                  "name": "suite-id",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "k",
@@ -411,6 +476,12 @@
               "path": "agentclash agent-harness suite run",
               "short": "Start suite runs across one or more harnesses",
               "runnable": true,
+              "args": [
+                {
+                  "name": "suite-id",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "harness",
@@ -430,7 +501,13 @@
               "name": "tasks",
               "path": "agentclash agent-harness suite tasks",
               "short": "List public tasks for an Agent Harness suite",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "suite-id",
+                  "required": true
+                }
+              ]
             }
           ]
         }
@@ -446,7 +523,13 @@
           "name": "download",
           "path": "agentclash artifact download",
           "short": "Download an artifact",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "artifactId",
+              "required": true
+            }
+          ]
         },
         {
           "name": "list",
@@ -459,6 +542,12 @@
           "path": "agentclash artifact upload",
           "short": "Upload an artifact",
           "runnable": true,
+          "args": [
+            {
+              "name": "file",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "metadata",
@@ -487,13 +576,25 @@
           "name": "validate-voice-manifest",
           "path": "agentclash artifact validate-voice-manifest",
           "short": "Validate a voice artifact manifest JSON file against the AgentClash schema",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "file",
+              "required": true
+            }
+          ]
         },
         {
           "name": "validate-voice-report",
           "path": "agentclash artifact validate-voice-report",
           "short": "Validate a voice report JSON file against an AgentClash schema",
           "runnable": true,
+          "args": [
+            {
+              "name": "file",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "schema",
@@ -558,7 +659,13 @@
               "name": "revoke",
               "path": "agentclash auth tokens revoke",
               "short": "Revoke a CLI token",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "token-id",
+                  "required": true
+                }
+              ]
             }
           ]
         }
@@ -581,6 +688,12 @@
           "path": "agentclash baseline set",
           "short": "Bookmark a run as the default baseline for the current workspace",
           "runnable": true,
+          "args": [
+            {
+              "name": "run",
+              "required": false
+            }
+          ],
           "flags": [
             {
               "name": "agent",
@@ -626,7 +739,13 @@
           "name": "get",
           "path": "agentclash build get",
           "short": "Get agent build with version history",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "id",
+              "required": true
+            }
+          ]
         },
         {
           "name": "list",
@@ -645,6 +764,12 @@
               "path": "agentclash build version create",
               "short": "Create a new draft version",
               "runnable": true,
+              "args": [
+                {
+                  "name": "buildId",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "agent-kind",
@@ -667,13 +792,25 @@
               "name": "get",
               "path": "agentclash build version get",
               "short": "Get a build version",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "versionId",
+                  "required": true
+                }
+              ]
             },
             {
               "name": "ready",
               "path": "agentclash build version ready",
               "short": "Mark a version as ready (immutable, deployable)",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "versionId",
+                  "required": true
+                }
+              ]
             },
             {
               "name": "templates",
@@ -686,6 +823,12 @@
               "path": "agentclash build version update",
               "short": "Update a draft build version",
               "runnable": true,
+              "args": [
+                {
+                  "name": "versionId",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "spec-file",
@@ -698,7 +841,13 @@
               "name": "validate",
               "path": "agentclash build version validate",
               "short": "Validate a build version",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "versionId",
+                  "required": true
+                }
+              ]
             }
           ]
         }
@@ -718,6 +867,12 @@
           "path": "agentclash challenge-pack init",
           "short": "Scaffold a minimal challenge pack YAML bundle",
           "runnable": true,
+          "args": [
+            {
+              "name": "file",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "force",
@@ -753,13 +908,25 @@
           "name": "publish",
           "path": "agentclash challenge-pack publish",
           "short": "Publish a challenge pack YAML bundle",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "file",
+              "required": true
+            }
+          ]
         },
         {
           "name": "validate",
           "path": "agentclash challenge-pack validate",
           "short": "Validate a challenge pack YAML bundle",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "file",
+              "required": true
+            }
+          ]
         }
       ]
     },
@@ -788,6 +955,12 @@
           "path": "agentclash ci init",
           "short": "Write a sample AgentClash CI manifest",
           "runnable": true,
+          "args": [
+            {
+              "name": "file",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "force",
@@ -958,6 +1131,12 @@
           "path": "agentclash ci validate",
           "short": "Validate an AgentClash CI manifest",
           "runnable": true,
+          "args": [
+            {
+              "name": "file",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "remote",
@@ -1076,7 +1255,13 @@
           "name": "get",
           "path": "agentclash config get",
           "short": "Get a config value",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "key",
+              "required": true
+            }
+          ]
         },
         {
           "name": "list",
@@ -1088,7 +1273,17 @@
           "name": "set",
           "path": "agentclash config set",
           "short": "Set a config value",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "key",
+              "required": true
+            },
+            {
+              "name": "value",
+              "required": true
+            }
+          ]
         }
       ]
     },
@@ -1146,13 +1341,25 @@
           "name": "delete",
           "path": "agentclash dataset delete",
           "short": "Archive a dataset",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "datasetId",
+              "required": true
+            }
+          ]
         },
         {
           "name": "eval",
           "path": "agentclash dataset eval",
           "short": "Run an eval over a dataset version",
           "runnable": true,
+          "args": [
+            {
+              "name": "datasetId",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "challenge",
@@ -1204,6 +1411,12 @@
               "path": "agentclash dataset example add",
               "short": "Add or upsert a dataset example",
               "runnable": true,
+              "args": [
+                {
+                  "name": "datasetId",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "expected",
@@ -1248,6 +1461,16 @@
               "path": "agentclash dataset example edit",
               "short": "Edit a dataset example",
               "runnable": true,
+              "args": [
+                {
+                  "name": "datasetId",
+                  "required": true
+                },
+                {
+                  "name": "exampleId",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "expected",
@@ -1291,13 +1514,29 @@
               "name": "list",
               "path": "agentclash dataset example list",
               "short": "List dataset examples",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "datasetId",
+                  "required": true
+                }
+              ]
             },
             {
               "name": "rm",
               "path": "agentclash dataset example rm",
               "short": "Archive a dataset example",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "datasetId",
+                  "required": true
+                },
+                {
+                  "name": "exampleId",
+                  "required": true
+                }
+              ]
             }
           ]
         },
@@ -1306,6 +1545,12 @@
           "path": "agentclash dataset export",
           "short": "Export dataset examples",
           "runnable": true,
+          "args": [
+            {
+              "name": "datasetId",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "format",
@@ -1325,6 +1570,12 @@
           "path": "agentclash dataset generate",
           "short": "Start in-house synthetic dataset generation",
           "runnable": true,
+          "args": [
+            {
+              "name": "datasetId",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "count",
@@ -1389,6 +1640,16 @@
           "path": "agentclash dataset import",
           "short": "Import examples into a dataset",
           "runnable": true,
+          "args": [
+            {
+              "name": "datasetId",
+              "required": true
+            },
+            {
+              "name": "file",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "dry-run",
@@ -1425,6 +1686,16 @@
           "path": "agentclash dataset import-traces",
           "short": "Import production traces as reviewable dataset candidates",
           "runnable": true,
+          "args": [
+            {
+              "name": "datasetId",
+              "required": true
+            },
+            {
+              "name": "file",
+              "required": false
+            }
+          ],
           "flags": [
             {
               "name": "artifact",
@@ -1469,6 +1740,16 @@
           "path": "agentclash dataset promote",
           "short": "Promote a trace candidate into a dataset example",
           "runnable": true,
+          "args": [
+            {
+              "name": "datasetId",
+              "required": true
+            },
+            {
+              "name": "candidateId",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "expected",
@@ -1493,6 +1774,12 @@
           "path": "agentclash dataset sync-regression-suite",
           "short": "Promote dataset examples into a linked regression suite",
           "runnable": true,
+          "args": [
+            {
+              "name": "datasetId",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "challenge",
@@ -1532,6 +1819,12 @@
           "path": "agentclash dataset test",
           "short": "Run a dataset eval gate against a baseline",
           "runnable": true,
+          "args": [
+            {
+              "name": "datasetId",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "baseline",
@@ -1613,6 +1906,12 @@
               "path": "agentclash dataset trace-candidates list",
               "short": "List trace candidates awaiting promotion",
               "runnable": true,
+              "args": [
+                {
+                  "name": "datasetId",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "status",
@@ -1634,6 +1933,12 @@
               "path": "agentclash dataset version create",
               "short": "Snapshot the current dataset examples",
               "runnable": true,
+              "args": [
+                {
+                  "name": "datasetId",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "label",
@@ -1646,7 +1951,13 @@
               "name": "list",
               "path": "agentclash dataset version list",
               "short": "List dataset versions",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "datasetId",
+                  "required": true
+                }
+              ]
             }
           ]
         },
@@ -1654,7 +1965,13 @@
           "name": "view",
           "path": "agentclash dataset view",
           "short": "View a dataset",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "datasetId",
+              "required": true
+            }
+          ]
         }
       ]
     },
@@ -1742,6 +2059,12 @@
           "path": "agentclash eval scorecard",
           "short": "Show a run-first scorecard and compare against the bookmarked baseline",
           "runnable": true,
+          "args": [
+            {
+              "name": "run",
+              "required": false
+            }
+          ],
           "flags": [
             {
               "name": "agent",
@@ -1764,6 +2087,12 @@
               "path": "agentclash eval session follow",
               "short": "Poll a repeated eval session until aggregation finishes",
               "runnable": true,
+              "args": [
+                {
+                  "name": "evalSessionId",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "poll-interval",
@@ -1783,7 +2112,13 @@
               "name": "get",
               "path": "agentclash eval session get",
               "short": "Show repeated eval session details and aggregate metrics",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "evalSessionId",
+                  "required": true
+                }
+              ]
             },
             {
               "name": "list",
@@ -1914,7 +2249,13 @@
               "name": "get",
               "path": "agentclash infra knowledge-source get",
               "short": "Get a knowledge-source",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "id",
+                  "required": true
+                }
+              ]
             },
             {
               "name": "list",
@@ -1967,13 +2308,25 @@
               "name": "delete",
               "path": "agentclash infra model-alias delete",
               "short": "Delete a model-alias",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "id",
+                  "required": true
+                }
+              ]
             },
             {
               "name": "get",
               "path": "agentclash infra model-alias get",
               "short": "Get a model-alias",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "id",
+                  "required": true
+                }
+              ]
             },
             {
               "name": "list",
@@ -1996,7 +2349,13 @@
               "name": "get",
               "path": "agentclash infra model-catalog get",
               "short": "Get a model catalog entry",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "id",
+                  "required": true
+                }
+              ]
             },
             {
               "name": "list",
@@ -2029,13 +2388,25 @@
               "name": "delete",
               "path": "agentclash infra provider-account delete",
               "short": "Delete a provider-account",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "id",
+                  "required": true
+                }
+              ]
             },
             {
               "name": "get",
               "path": "agentclash infra provider-account get",
               "short": "Get a provider-account",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "id",
+                  "required": true
+                }
+              ]
             },
             {
               "name": "list",
@@ -2048,6 +2419,12 @@
               "path": "agentclash infra provider-account test",
               "short": "Smoke test provider account credentials",
               "runnable": true,
+              "args": [
+                {
+                  "name": "id",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "model",
@@ -2101,7 +2478,13 @@
               "name": "archive",
               "path": "agentclash infra runtime-profile archive",
               "short": "Archive a runtime-profile",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "id",
+                  "required": true
+                }
+              ]
             },
             {
               "name": "create",
@@ -2120,7 +2503,13 @@
               "name": "get",
               "path": "agentclash infra runtime-profile get",
               "short": "Get a runtime-profile",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "id",
+                  "required": true
+                }
+              ]
             },
             {
               "name": "list",
@@ -2180,7 +2569,13 @@
               "name": "get",
               "path": "agentclash infra tool get",
               "short": "Get a tool",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "id",
+                  "required": true
+                }
+              ]
             },
             {
               "name": "list",
@@ -2498,7 +2893,13 @@
       "name": "link",
       "path": "agentclash link",
       "short": "Choose and save your default workspace",
-      "runnable": true
+      "runnable": true,
+      "args": [
+        {
+          "name": "workspace",
+          "required": false
+        }
+      ]
     },
     {
       "name": "org",
@@ -2532,7 +2933,13 @@
           "name": "get",
           "path": "agentclash org get",
           "short": "Get organization details",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "id",
+              "required": true
+            }
+          ]
         },
         {
           "name": "list",
@@ -2551,6 +2958,12 @@
               "path": "agentclash org members invite",
               "short": "Invite a member to the organization",
               "runnable": true,
+              "args": [
+                {
+                  "name": "orgId",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "email",
@@ -2570,13 +2983,25 @@
               "name": "list",
               "path": "agentclash org members list",
               "short": "List organization members",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "orgId",
+                  "required": true
+                }
+              ]
             },
             {
               "name": "update",
               "path": "agentclash org members update",
               "short": "Update an organization membership",
               "runnable": true,
+              "args": [
+                {
+                  "name": "membershipId",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "role",
@@ -2597,6 +3022,12 @@
           "path": "agentclash org update",
           "short": "Update an organization",
           "runnable": true,
+          "args": [
+            {
+              "name": "id",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "name",
@@ -2643,7 +3074,13 @@
           "name": "delete",
           "path": "agentclash playground delete",
           "short": "Delete a playground",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "id",
+              "required": true
+            }
+          ]
         },
         {
           "name": "experiment",
@@ -2659,6 +3096,12 @@
               "path": "agentclash playground experiment batch",
               "short": "Create experiments in batch (one per model)",
               "runnable": true,
+              "args": [
+                {
+                  "name": "playgroundId",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "from-file",
@@ -2692,6 +3135,12 @@
               "path": "agentclash playground experiment create",
               "short": "Create an experiment",
               "runnable": true,
+              "args": [
+                {
+                  "name": "playgroundId",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "from-file",
@@ -2704,19 +3153,37 @@
               "name": "get",
               "path": "agentclash playground experiment get",
               "short": "Get an experiment",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "experimentId",
+                  "required": true
+                }
+              ]
             },
             {
               "name": "list",
               "path": "agentclash playground experiment list",
               "short": "List experiments",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "playgroundId",
+                  "required": true
+                }
+              ]
             },
             {
               "name": "results",
               "path": "agentclash playground experiment results",
               "short": "List results for an experiment",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "experimentId",
+                  "required": true
+                }
+              ]
             }
           ]
         },
@@ -2724,7 +3191,13 @@
           "name": "get",
           "path": "agentclash playground get",
           "short": "Get a playground",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "id",
+              "required": true
+            }
+          ]
         },
         {
           "name": "list",
@@ -2746,6 +3219,12 @@
               "path": "agentclash playground test-case create",
               "short": "Create a test case",
               "runnable": true,
+              "args": [
+                {
+                  "name": "playgroundId",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "from-file",
@@ -2758,19 +3237,37 @@
               "name": "delete",
               "path": "agentclash playground test-case delete",
               "short": "Delete a test case",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "testCaseId",
+                  "required": true
+                }
+              ]
             },
             {
               "name": "list",
               "path": "agentclash playground test-case list",
               "short": "List test cases",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "playgroundId",
+                  "required": true
+                }
+              ]
             },
             {
               "name": "update",
               "path": "agentclash playground test-case update",
               "short": "Update a test case",
               "runnable": true,
+              "args": [
+                {
+                  "name": "testCaseId",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "from-file",
@@ -2786,6 +3283,12 @@
           "path": "agentclash playground update",
           "short": "Update a playground",
           "runnable": true,
+          "args": [
+            {
+              "name": "id",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "from-file",
@@ -2807,6 +3310,12 @@
           "path": "agentclash prompt-eval import-promptfoo",
           "short": "Convert a safe Promptfoo subset into an AgentClash prompt eval config",
           "runnable": true,
+          "args": [
+            {
+              "name": "file",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "force",
@@ -2843,6 +3352,12 @@
           "path": "agentclash prompt-eval init",
           "short": "Scaffold a prompt eval YAML config",
           "runnable": true,
+          "args": [
+            {
+              "name": "file",
+              "required": false
+            }
+          ],
           "flags": [
             {
               "name": "force",
@@ -2862,6 +3377,12 @@
           "path": "agentclash prompt-eval results",
           "short": "Fetch prompt eval experiment results",
           "runnable": true,
+          "args": [
+            {
+              "name": "experiment-id",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "threshold",
@@ -2876,6 +3397,12 @@
           "path": "agentclash prompt-eval run",
           "short": "Compile a prompt eval config and launch playground experiments",
           "runnable": true,
+          "args": [
+            {
+              "name": "file",
+              "required": false
+            }
+          ],
           "flags": [
             {
               "name": "ci",
@@ -2920,6 +3447,12 @@
           "path": "agentclash prompt-eval validate",
           "short": "Validate a prompt eval YAML config locally",
           "runnable": true,
+          "args": [
+            {
+              "name": "file",
+              "required": false
+            }
+          ],
           "flags": [
             {
               "name": "ci",
@@ -2975,6 +3508,12 @@
               "path": "agentclash regression-suite case capture-production",
               "short": "Capture a production failure as a proposed regression case",
               "runnable": true,
+              "args": [
+                {
+                  "name": "suiteId",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "evidence-tier",
@@ -3063,6 +3602,12 @@
               "path": "agentclash regression-suite case update",
               "short": "Update a regression case",
               "runnable": true,
+              "args": [
+                {
+                  "name": "caseId",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "description",
@@ -3097,7 +3642,13 @@
           "name": "cases",
           "path": "agentclash regression-suite cases",
           "short": "List regression cases in a suite",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "suiteId",
+              "required": true
+            }
+          ]
         },
         {
           "name": "create",
@@ -3136,7 +3687,13 @@
           "name": "get",
           "path": "agentclash regression-suite get",
           "short": "Get a regression suite",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "suiteId",
+              "required": true
+            }
+          ]
         },
         {
           "name": "list",
@@ -3149,6 +3706,12 @@
           "path": "agentclash regression-suite update",
           "short": "Update a regression suite",
           "runnable": true,
+          "args": [
+            {
+              "name": "suiteId",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "default-gate-severity",
@@ -3219,6 +3782,12 @@
           "path": "agentclash replay get",
           "short": "Get execution replay steps",
           "runnable": true,
+          "args": [
+            {
+              "name": "runAgentId",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "cursor",
@@ -3239,6 +3808,12 @@
           "path": "agentclash replay triage",
           "short": "Summarize ranking, failures, scorecard, replay, and artifacts for debugging",
           "runnable": true,
+          "args": [
+            {
+              "name": "run",
+              "required": false
+            }
+          ],
           "flags": [
             {
               "name": "agent",
@@ -3271,13 +3846,25 @@
           "name": "agents",
           "path": "agentclash run agents",
           "short": "List agents in a run",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "runId",
+              "required": true
+            }
+          ]
         },
         {
           "name": "cancel",
           "path": "agentclash run cancel",
           "short": "Cancel an active run",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "id",
+              "required": true
+            }
+          ]
         },
         {
           "name": "compare",
@@ -3392,7 +3979,11 @@
               "name": "scope",
               "usage": "Run scope: full or suite_only",
               "type": "string",
-              "default": "full"
+              "default": "full",
+              "allowed_values": [
+                "full",
+                "suite_only"
+              ]
             },
             {
               "name": "seeds",
@@ -3413,6 +4004,12 @@
           "path": "agentclash run events",
           "short": "Stream live run events via SSE",
           "runnable": true,
+          "args": [
+            {
+              "name": "runId",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "filter",
@@ -3431,7 +4028,13 @@
               "name": "export",
               "path": "agentclash run events export",
               "short": "Export persisted run events as JSONL",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "runId",
+                  "required": true
+                }
+              ]
             }
           ]
         },
@@ -3440,6 +4043,12 @@
           "path": "agentclash run failures",
           "short": "List failure review items for a run",
           "runnable": true,
+          "args": [
+            {
+              "name": "runId",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "agent",
@@ -3483,7 +4092,13 @@
           "name": "get",
           "path": "agentclash run get",
           "short": "Get run details",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "id",
+              "required": true
+            }
+          ]
         },
         {
           "name": "list",
@@ -3496,6 +4111,16 @@
           "path": "agentclash run promote-failure",
           "short": "Promote a run failure into a regression case",
           "runnable": true,
+          "args": [
+            {
+              "name": "runId",
+              "required": true
+            },
+            {
+              "name": "challengeIdentityId",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "failure-summary",
@@ -3539,6 +4164,12 @@
           "path": "agentclash run ranking",
           "short": "Get run ranking and composite scores",
           "runnable": true,
+          "args": [
+            {
+              "name": "runId",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "sort-by",
@@ -3552,6 +4183,12 @@
           "path": "agentclash run replay",
           "short": "Inspect replay steps for a run agent",
           "runnable": true,
+          "args": [
+            {
+              "name": "run-agent-id",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "cursor",
@@ -3571,7 +4208,13 @@
           "name": "scorecard",
           "path": "agentclash run scorecard",
           "short": "Get agent scorecard",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "runAgentId",
+              "required": true
+            }
+          ]
         },
         {
           "name": "series",
@@ -3624,7 +4267,13 @@
               "name": "report",
               "path": "agentclash run series report",
               "short": "Show aggregate score, correctness, and cost for a race series",
-              "runnable": true
+              "runnable": true,
+              "args": [
+                {
+                  "name": "eval-session-id",
+                  "required": true
+                }
+              ]
             }
           ]
         },
@@ -3632,7 +4281,13 @@
           "name": "transcript",
           "path": "agentclash run transcript",
           "short": "Export a Markdown run transcript",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "runId",
+              "required": true
+            }
+          ]
         },
         {
           "name": "turn",
@@ -3645,6 +4300,12 @@
               "path": "agentclash run turn status",
               "short": "Check whether a run agent is awaiting human input",
               "runnable": true,
+              "args": [
+                {
+                  "name": "runAgentId",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "run",
@@ -3658,6 +4319,12 @@
               "path": "agentclash run turn submit",
               "short": "Submit a human user message for an awaiting multi_turn phase",
               "runnable": true,
+              "args": [
+                {
+                  "name": "runAgentId",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "message",
@@ -3679,7 +4346,14 @@
       "name": "schema",
       "path": "agentclash schema",
       "short": "Print the CLI command tree as machine-readable JSON",
-      "runnable": true
+      "runnable": true,
+      "args": [
+        {
+          "name": "command",
+          "required": false,
+          "variadic": true
+        }
+      ]
     },
     {
       "name": "secret",
@@ -3691,7 +4365,13 @@
           "name": "delete",
           "path": "agentclash secret delete",
           "short": "Delete a secret",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "key",
+              "required": true
+            }
+          ]
         },
         {
           "name": "list",
@@ -3704,6 +4384,12 @@
           "path": "agentclash secret set",
           "short": "Create or update a secret",
           "runnable": true,
+          "args": [
+            {
+              "name": "key",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "value",
@@ -3932,6 +4618,12 @@
           "path": "agentclash security stress-run",
           "short": "Run a security pack N times against an LLM provider and aggregate the leak rate",
           "runnable": true,
+          "args": [
+            {
+              "name": "pack-yaml",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "api-key-env",
@@ -4059,7 +4751,13 @@
           "name": "get",
           "path": "agentclash workspace get",
           "short": "Get workspace details",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "id",
+              "required": true
+            }
+          ]
         },
         {
           "name": "list",
@@ -4111,6 +4809,12 @@
               "path": "agentclash workspace members update",
               "short": "Update a workspace membership",
               "runnable": true,
+              "args": [
+                {
+                  "name": "membershipId",
+                  "required": true
+                }
+              ],
               "flags": [
                 {
                   "name": "role",
@@ -4131,6 +4835,12 @@
           "path": "agentclash workspace update",
           "short": "Update a workspace",
           "runnable": true,
+          "args": [
+            {
+              "name": "id",
+              "required": true
+            }
+          ],
           "flags": [
             {
               "name": "name",
@@ -4154,7 +4864,13 @@
           "name": "use",
           "path": "agentclash workspace use",
           "short": "Set the default workspace",
-          "runnable": true
+          "runnable": true,
+          "args": [
+            {
+              "name": "id",
+              "required": true
+            }
+          ]
         }
       ]
     }
@@ -4273,6 +4989,68 @@
       "description": "ci run: a candidate run finished in a failed state.",
       "commands": [
         "ci run"
+      ]
+    }
+  ],
+  "error_codes": [
+    {
+      "code": "invalid_argument",
+      "description": "Invalid flags, arguments, or input; also the default classification for unrecognized local errors."
+    },
+    {
+      "code": "invalid_config",
+      "description": "The CLI configuration file failed to load or parse."
+    },
+    {
+      "code": "file_not_found",
+      "description": "A referenced local file does not exist."
+    },
+    {
+      "code": "permission_denied",
+      "description": "A local file or directory was not accessible."
+    },
+    {
+      "code": "request_failed",
+      "description": "The HTTP request could not complete (network/transport failure).",
+      "retryable": true
+    },
+    {
+      "code": "api_error",
+      "description": "The server returned an error envelope without a code."
+    },
+    {
+      "code": "command_failed",
+      "description": "A command finished with a command-specific non-zero exit (see exit_codes)."
+    },
+    {
+      "code": "missing_workspace",
+      "description": "No workspace resolved; pass --workspace, set AGENTCLASH_WORKSPACE, or run 'agentclash link'."
+    },
+    {
+      "code": "follow_timeout",
+      "description": "A --follow loop gave up after --timeout; the underlying job keeps running server-side.",
+      "retryable": true
+    },
+    {
+      "code": "stream_reconnect_exhausted",
+      "description": "The SSE event stream dropped repeatedly without delivering events; resume with `run events --since \u003cid\u003e`.",
+      "retryable": true
+    }
+  ],
+  "status_enums": [
+    {
+      "resource": "run",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ],
+      "terminal": [
+        "completed",
+        "failed",
+        "cancelled"
       ]
     }
   ]

--- a/cli/cmd/testdata/schema_snapshot.json
+++ b/cli/cmd/testdata/schema_snapshot.json
@@ -1350,6 +1350,12 @@
               "type": "string"
             },
             {
+              "name": "poll-interval",
+              "usage": "Polling interval for --follow",
+              "type": "duration",
+              "default": "2s"
+            },
+            {
               "name": "provider-account",
               "usage": "Provider account ID",
               "type": "string"
@@ -1364,6 +1370,12 @@
               "usage": "Generation strategy (v1: self-instruct)",
               "type": "string",
               "default": "self-instruct"
+            },
+            {
+              "name": "timeout",
+              "usage": "Give up on --follow after this duration (0 = wait indefinitely)",
+              "type": "duration",
+              "default": "0s"
             },
             {
               "name": "version-label",
@@ -3407,6 +3419,11 @@
               "usage": "Filter streamed events by event type pattern (exact, comma-separated, or glob; '*' matches any non-slash chars, so 'model.*' matches 'model.call.started'; repeatable)",
               "type": "stringSlice",
               "default": "[]"
+            },
+            {
+              "name": "since",
+              "usage": "Resume the stream after this event ID (sent as Last-Event-ID; the server replays everything recorded after it)",
+              "type": "string"
             }
           ],
           "subcommands": [

--- a/cli/cmd/testdata/schema_snapshot.json
+++ b/cli/cmd/testdata/schema_snapshot.json
@@ -2208,7 +2208,11 @@
               "name": "scope",
               "usage": "Run scope: full or suite_only",
               "type": "string",
-              "default": "full"
+              "default": "full",
+              "allowed_values": [
+                "full",
+                "suite_only"
+              ]
             },
             {
               "name": "suite",
@@ -5028,13 +5032,11 @@
     },
     {
       "code": "follow_timeout",
-      "description": "A --follow loop gave up after --timeout; the underlying job keeps running server-side.",
-      "retryable": true
+      "description": "A --follow loop gave up after --timeout; the underlying job keeps running server-side — re-check its status rather than blindly retrying."
     },
     {
       "code": "stream_reconnect_exhausted",
-      "description": "The SSE event stream dropped repeatedly without delivering events; resume with `run events --since \u003cid\u003e`.",
-      "retryable": true
+      "description": "The SSE event stream dropped repeatedly without delivering events; resume with `run events --since \u003cid\u003e`."
     }
   ],
   "status_enums": [

--- a/cli/internal/api/sse.go
+++ b/cli/internal/api/sse.go
@@ -19,6 +19,16 @@ type SSEEvent struct {
 // StreamSSE opens an SSE connection and sends events to a channel.
 // The channel is closed when the connection ends or the context is cancelled.
 func (c *Client) StreamSSE(ctx context.Context, path string, query url.Values) (<-chan SSEEvent, error) {
+	return c.StreamSSEFrom(ctx, path, query, "")
+}
+
+// StreamSSEFrom opens an SSE connection resuming after lastEventID: the value
+// is sent as the Last-Event-ID header (the standard SSE resume mechanism), and
+// the server replays every event recorded after it before going live. Pass ""
+// to start from the live tail. The channel is closed when the connection ends
+// or the context is cancelled — callers that want a seamless stream reconnect
+// with the last ID they received.
+func (c *Client) StreamSSEFrom(ctx context.Context, path string, query url.Values, lastEventID string) (<-chan SSEEvent, error) {
 	fullURL := c.baseURL + path
 	if len(query) > 0 {
 		fullURL += "?" + query.Encode()
@@ -30,6 +40,9 @@ func (c *Client) StreamSSE(ctx context.Context, path string, query url.Values) (
 	}
 	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("Cache-Control", "no-cache")
+	if lastEventID != "" {
+		req.Header.Set("Last-Event-ID", lastEventID)
+	}
 	c.setAuth(req)
 
 	// Streaming client: share the main client's transport (proxy / TLS


### PR DESCRIPTION
## ⚠️ Stacked PR

**Base is PR-3 (#975), and this branch also merges PR-6 (#976)** — schema v2 publishes PR-3's error/exit taxonomy and consumes PR-6's canonical status constants, so both are prerequisites. Merge order: #975 and #976 first, then retarget this to `main` (the diff collapses to just the schema work). The commit to review here is `b381766e`.

## What (PR-4 of the CLI agent-readiness series — WI-3 + WI-14)

`schemaDocVersion` 1 → 2:

- **Positional args** parsed from each command's `Use` line (`<x>` required, `[x]` optional, `...` variadic). The headline gap: an agent could see `run get` in the schema but not learn it needs `<id>`. **113 commands** now expose invocable args.
- **`allowed_values`** on enum-like flags from an explicit, authoritative registry (global `--output` → `[table,json,yaml]`; `run create --scope` → `[full,suite_only]`). Deliberately conservative: absence means *free-form*, not *unknown* — a speculative or stale enum misleads an agent worse than none (this is why the old prototype deferred it; the registry keeps it honest and extensible).
- **Command examples** (cobra `Example`) included.
- **`error_codes` registry** (top-level): the 10 CLI-local envelope codes incl. PR-3's `retryable` semantics and PR-6's `follow_timeout`/`stream_reconnect_exhausted`. Backend codes pass through verbatim and are documented as non-enumerable.
- **`status_enums` registry** (top-level): sourced from `run_status.go` constants — **lockstep-tested against `isTerminalRunStatus`**, the same helper every `--follow` loop uses, so the published terminal set cannot drift from runtime behavior.
- **WI-14**: `agentclash schema run get` prints just that subtree; aliases resolve (`schema harness run` → `agent-harness run`); unknown paths → stable `invalid_argument`.

## Verification

- `TestParseArgsFromUse` — grammar table incl. `<x>`, `[x]`, `<x>...`, `[x ...]`, no-arg commands.
- `TestSchemaExposesPositionalArgs` — the WI-3 acceptance: `run get` shows one required arg.
- `TestSchemaExposesAllowedValues` — `--output` exact set; `--scope` exact set; free-form flags assert **no** claimed enum.
- `TestSchemaPublishesErrorAndStatusRegistries` — both registries present; every published terminal status agrees with `isTerminalRunStatus` *and* every code-terminal value appears in the registry (bidirectional lockstep).
- `TestSchemaSubtreeLookup` — subtree doc, alias resolution, unknown-path failure code. Existing `TestSchemaUnknownSubcommandFails` keeps passing (new failure mechanism, same contract).
- Golden regenerated (+836/−58 — the diff IS the contract change); full `go build && go vet && go test -short -race -count=1 ./...` green.

## Way to test by hand

```bash
cd cli
go run . schema --json | jq '.. | objects | select(.path?=="agentclash run get") | .args'
go run . schema run get --json | jq '{path, args}'
go run . schema --json | jq '{v: .schema_version, errs: (.error_codes|length), statuses: .status_enums}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)