### PR TITLE
feat: limit/offset pagination for agent-deployments and artifacts lists

### DIFF
--- a/backend/db/queries/agent_deployments.sql
+++ b/backend/db/queries/agent_deployments.sql
@@ -17,4 +17,12 @@ LEFT JOIN agent_deployment_snapshots ads
 WHERE ad.workspace_id = @workspace_id
   AND ad.status = 'active'
   AND ad.archived_at IS NULL
-ORDER BY ad.id, ads.created_at DESC, ads.id DESC;
+ORDER BY ad.id, ads.created_at DESC, ads.id DESC
+LIMIT @limit_count OFFSET @offset_count;
+
+-- name: CountActiveAgentDeploymentsByWorkspaceID :one
+SELECT COUNT(*)
+FROM agent_deployments
+WHERE workspace_id = @workspace_id
+  AND status = 'active'
+  AND archived_at IS NULL;

--- a/backend/internal/api/agent_deployments.go
+++ b/backend/internal/api/agent_deployments.go
@@ -11,15 +11,19 @@ import (
 )
 
 type AgentDeploymentReadRepository interface {
-	ListActiveAgentDeploymentsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]repository.AgentDeploymentSummary, error)
+	ListActiveAgentDeploymentsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID, limit, offset int32) ([]repository.AgentDeploymentSummary, error)
+	CountActiveAgentDeploymentsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (int64, error)
 }
 
 type AgentDeploymentReadService interface {
-	ListAgentDeployments(ctx context.Context, workspaceID uuid.UUID) (ListAgentDeploymentsResult, error)
+	ListAgentDeployments(ctx context.Context, workspaceID uuid.UUID, limit, offset int32) (ListAgentDeploymentsResult, error)
 }
 
 type ListAgentDeploymentsResult struct {
 	Deployments []repository.AgentDeploymentSummary
+	Total       int64
+	Limit       int32
+	Offset      int32
 }
 
 type AgentDeploymentReadManager struct {
@@ -32,14 +36,21 @@ func NewAgentDeploymentReadManager(repo AgentDeploymentReadRepository) *AgentDep
 	}
 }
 
-func (m *AgentDeploymentReadManager) ListAgentDeployments(ctx context.Context, workspaceID uuid.UUID) (ListAgentDeploymentsResult, error) {
-	deployments, err := m.repo.ListActiveAgentDeploymentsByWorkspaceID(ctx, workspaceID)
+func (m *AgentDeploymentReadManager) ListAgentDeployments(ctx context.Context, workspaceID uuid.UUID, limit, offset int32) (ListAgentDeploymentsResult, error) {
+	deployments, err := m.repo.ListActiveAgentDeploymentsByWorkspaceID(ctx, workspaceID, limit, offset)
+	if err != nil {
+		return ListAgentDeploymentsResult{}, err
+	}
+	total, err := m.repo.CountActiveAgentDeploymentsByWorkspaceID(ctx, workspaceID)
 	if err != nil {
 		return ListAgentDeploymentsResult{}, err
 	}
 
 	return ListAgentDeploymentsResult{
 		Deployments: deployments,
+		Total:       total,
+		Limit:       limit,
+		Offset:      offset,
 	}, nil
 }
 
@@ -56,7 +67,10 @@ type agentDeploymentResponse struct {
 }
 
 type listAgentDeploymentsResponse struct {
-	Items []agentDeploymentResponse `json:"items"`
+	Items  []agentDeploymentResponse `json:"items"`
+	Total  int64                     `json:"total"`
+	Limit  int32                     `json:"limit"`
+	Offset int32                     `json:"offset"`
 }
 
 func listAgentDeploymentsHandler(logger *slog.Logger, service AgentDeploymentReadService) http.HandlerFunc {
@@ -67,7 +81,8 @@ func listAgentDeploymentsHandler(logger *slog.Logger, service AgentDeploymentRea
 			return
 		}
 
-		result, err := service.ListAgentDeployments(r.Context(), workspaceID)
+		limit, offset := parseListLimitOffset(r)
+		result, err := service.ListAgentDeployments(r.Context(), workspaceID, limit, offset)
 		if err != nil {
 			logger.Error("list agent deployments request failed",
 				"method", r.Method,
@@ -94,6 +109,11 @@ func listAgentDeploymentsHandler(logger *slog.Logger, service AgentDeploymentRea
 			})
 		}
 
-		writeJSON(w, http.StatusOK, listAgentDeploymentsResponse{Items: responseItems})
+		writeJSON(w, http.StatusOK, listAgentDeploymentsResponse{
+			Items:  responseItems,
+			Total:  result.Total,
+			Limit:  result.Limit,
+			Offset: result.Offset,
+		})
 	}
 }

--- a/backend/internal/api/artifacts.go
+++ b/backend/internal/api/artifacts.go
@@ -58,7 +58,8 @@ var disallowedArtifactMediaTypes = map[string]struct{}{
 type ArtifactRepository interface {
 	CreateArtifact(ctx context.Context, params repository.CreateArtifactParams) (repository.Artifact, error)
 	GetArtifactByID(ctx context.Context, artifactID uuid.UUID) (repository.Artifact, error)
-	ListArtifactsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]repository.Artifact, error)
+	ListArtifactsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID, limit, offset int32) ([]repository.Artifact, error)
+	CountArtifactsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (int64, error)
 	GetRunByID(ctx context.Context, runID uuid.UUID) (domain.Run, error)
 	GetRunAgentByID(ctx context.Context, runAgentID uuid.UUID) (domain.RunAgent, error)
 	GetOrganizationIDByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (uuid.UUID, error)
@@ -66,7 +67,7 @@ type ArtifactRepository interface {
 
 type ArtifactService interface {
 	UploadArtifact(ctx context.Context, caller Caller, input UploadArtifactInput) (UploadArtifactResult, error)
-	ListWorkspaceArtifacts(ctx context.Context, caller Caller, workspaceID uuid.UUID) ([]repository.Artifact, error)
+	ListWorkspaceArtifacts(ctx context.Context, caller Caller, workspaceID uuid.UUID, limit, offset int32) (ListWorkspaceArtifactsResult, error)
 	GetArtifactDownload(ctx context.Context, caller Caller, artifactID uuid.UUID, baseURL string) (GetArtifactDownloadResult, error)
 	GetArtifactContent(ctx context.Context, artifactID uuid.UUID, expiresAt time.Time, signature string) (GetArtifactContentResult, error)
 }
@@ -183,18 +184,36 @@ func (m *ArtifactManager) UploadArtifact(ctx context.Context, caller Caller, inp
 	return UploadArtifactResult{Artifact: artifact}, nil
 }
 
-func (m *ArtifactManager) ListWorkspaceArtifacts(ctx context.Context, caller Caller, workspaceID uuid.UUID) ([]repository.Artifact, error) {
+// ListWorkspaceArtifactsResult carries one page of artifacts plus the
+// pagination envelope fields.
+type ListWorkspaceArtifactsResult struct {
+	Artifacts []repository.Artifact
+	Total     int64
+	Limit     int32
+	Offset    int32
+}
+
+func (m *ArtifactManager) ListWorkspaceArtifacts(ctx context.Context, caller Caller, workspaceID uuid.UUID, limit, offset int32) (ListWorkspaceArtifactsResult, error) {
 	if err := m.authorizer.AuthorizeWorkspace(ctx, caller, workspaceID); err != nil {
-		return nil, err
+		return ListWorkspaceArtifactsResult{}, err
 	}
-	artifacts, err := m.repo.ListArtifactsByWorkspaceID(ctx, workspaceID)
+	artifacts, err := m.repo.ListArtifactsByWorkspaceID(ctx, workspaceID, limit, offset)
 	if err != nil {
-		return nil, fmt.Errorf("list workspace artifacts: %w", err)
+		return ListWorkspaceArtifactsResult{}, fmt.Errorf("list workspace artifacts: %w", err)
 	}
 	if artifacts == nil {
 		artifacts = []repository.Artifact{}
 	}
-	return artifacts, nil
+	total, err := m.repo.CountArtifactsByWorkspaceID(ctx, workspaceID)
+	if err != nil {
+		return ListWorkspaceArtifactsResult{}, fmt.Errorf("count workspace artifacts: %w", err)
+	}
+	return ListWorkspaceArtifactsResult{
+		Artifacts: artifacts,
+		Total:     total,
+		Limit:     limit,
+		Offset:    offset,
+	}, nil
 }
 
 func (m *ArtifactManager) GetArtifactDownload(ctx context.Context, caller Caller, artifactID uuid.UUID, baseURL string) (GetArtifactDownloadResult, error) {
@@ -576,7 +595,8 @@ func listWorkspaceArtifactsHandler(logger *slog.Logger, service ArtifactService)
 			return
 		}
 
-		artifacts, err := service.ListWorkspaceArtifacts(r.Context(), caller, workspaceID)
+		limit, offset := parseListLimitOffset(r)
+		result, err := service.ListWorkspaceArtifacts(r.Context(), caller, workspaceID, limit, offset)
 		if err != nil {
 			if errors.Is(err, ErrForbidden) {
 				writeAuthzError(w, err)
@@ -592,11 +612,16 @@ func listWorkspaceArtifactsHandler(logger *slog.Logger, service ArtifactService)
 			return
 		}
 
-		items := make([]uploadArtifactResponse, len(artifacts))
-		for i, a := range artifacts {
+		items := make([]uploadArtifactResponse, len(result.Artifacts))
+		for i, a := range result.Artifacts {
 			items[i] = buildUploadArtifactResponse(a, nil)
 		}
-		writeJSON(w, http.StatusOK, map[string]any{"items": items})
+		writeJSON(w, http.StatusOK, map[string]any{
+			"items":  items,
+			"total":  result.Total,
+			"limit":  result.Limit,
+			"offset": result.Offset,
+		})
 	}
 }
 

--- a/backend/internal/api/artifacts_test.go
+++ b/backend/internal/api/artifacts_test.go
@@ -295,11 +295,18 @@ func (r *fakeArtifactRepository) GetRunAgentByID(_ context.Context, runAgentID u
 	return domain.RunAgent{}, repository.ErrRunAgentNotFound
 }
 
-func (r *fakeArtifactRepository) ListArtifactsByWorkspaceID(_ context.Context, _ uuid.UUID) ([]repository.Artifact, error) {
+func (r *fakeArtifactRepository) ListArtifactsByWorkspaceID(_ context.Context, _ uuid.UUID, _, _ int32) ([]repository.Artifact, error) {
 	if r.artifact.ID != uuid.Nil {
 		return []repository.Artifact{r.artifact}, nil
 	}
 	return []repository.Artifact{}, nil
+}
+
+func (r *fakeArtifactRepository) CountArtifactsByWorkspaceID(_ context.Context, _ uuid.UUID) (int64, error) {
+	if r.artifact.ID != uuid.Nil {
+		return 1, nil
+	}
+	return 0, nil
 }
 
 func (r *fakeArtifactRepository) GetOrganizationIDByWorkspaceID(_ context.Context, workspaceID uuid.UUID) (uuid.UUID, error) {

--- a/backend/internal/api/list_pagination.go
+++ b/backend/internal/api/list_pagination.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+)
+
+// parseListLimitOffset reads the standard limit/offset query parameters for
+// list endpoints: limit defaults to 20 and is capped at 100, offset defaults
+// to 0. Invalid or negative values fall back to the defaults — the same
+// behavior the runs list has always had — so existing callers can never be
+// broken by garbage input.
+func parseListLimitOffset(r *http.Request) (limit, offset int32) {
+	limit = 20
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+			limit = int32(parsed)
+		}
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	offset = 0
+	if raw := r.URL.Query().Get("offset"); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+			offset = int32(parsed)
+		}
+	}
+	return limit, offset
+}

--- a/backend/internal/api/list_pagination.go
+++ b/backend/internal/api/list_pagination.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"math"
 	"net/http"
 	"strconv"
 )
@@ -12,8 +13,10 @@ import (
 // broken by garbage input.
 func parseListLimitOffset(r *http.Request) (limit, offset int32) {
 	limit = 20
+	// Bound before the int32 cast: 2^31 would wrap negative, bypass the cap,
+	// and hand PostgreSQL a negative LIMIT (a 500).
 	if raw := r.URL.Query().Get("limit"); raw != "" {
-		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 && parsed <= math.MaxInt32 {
 			limit = int32(parsed)
 		}
 	}
@@ -23,7 +26,7 @@ func parseListLimitOffset(r *http.Request) (limit, offset int32) {
 
 	offset = 0
 	if raw := r.URL.Query().Get("offset"); raw != "" {
-		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed >= 0 && parsed <= math.MaxInt32 {
 			offset = int32(parsed)
 		}
 	}

--- a/backend/internal/api/list_pagination_test.go
+++ b/backend/internal/api/list_pagination_test.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseListLimitOffset(t *testing.T) {
+	cases := []struct {
+		url        string
+		wantLimit  int32
+		wantOffset int32
+	}{
+		{"/x", 20, 0},
+		{"/x?limit=5&offset=10", 5, 10},
+		{"/x?limit=100", 100, 0},
+		{"/x?limit=101", 100, 0},    // capped
+		{"/x?limit=0", 20, 0},       // non-positive → default
+		{"/x?limit=-3", 20, 0},      // negative → default
+		{"/x?limit=abc", 20, 0},     // garbage → default
+		{"/x?offset=-1", 20, 0},     // negative → default
+		{"/x?offset=banana", 20, 0}, // garbage → default
+	}
+	for _, tc := range cases {
+		r := httptest.NewRequest("GET", tc.url, nil)
+		limit, offset := parseListLimitOffset(r)
+		if limit != tc.wantLimit || offset != tc.wantOffset {
+			t.Errorf("parseListLimitOffset(%q) = (%d, %d), want (%d, %d)", tc.url, limit, offset, tc.wantLimit, tc.wantOffset)
+		}
+	}
+}

--- a/backend/internal/api/list_pagination_test.go
+++ b/backend/internal/api/list_pagination_test.go
@@ -14,12 +14,16 @@ func TestParseListLimitOffset(t *testing.T) {
 		{"/x", 20, 0},
 		{"/x?limit=5&offset=10", 5, 10},
 		{"/x?limit=100", 100, 0},
-		{"/x?limit=101", 100, 0},    // capped
-		{"/x?limit=0", 20, 0},       // non-positive → default
-		{"/x?limit=-3", 20, 0},      // negative → default
-		{"/x?limit=abc", 20, 0},     // garbage → default
-		{"/x?offset=-1", 20, 0},     // negative → default
-		{"/x?offset=banana", 20, 0}, // garbage → default
+		{"/x?limit=101", 100, 0},                // capped
+		{"/x?limit=0", 20, 0},                   // non-positive → default
+		{"/x?limit=-3", 20, 0},                  // negative → default
+		{"/x?limit=abc", 20, 0},                 // garbage → default
+		{"/x?offset=-1", 20, 0},                 // negative → default
+		{"/x?offset=banana", 20, 0},             // garbage → default
+		{"/x?limit=2147483648", 20, 0},          // int32 wrap → rejected, default
+		{"/x?offset=2147483648", 20, 0},         // int32 wrap → default
+		{"/x?offset=0", 20, 0},                  // explicit 0 accepted
+		{"/x?limit=9223372036854775807", 20, 0}, // max int64 → rejected, default
 	}
 	for _, tc := range cases {
 		r := httptest.NewRequest("GET", tc.url, nil)

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -616,8 +616,8 @@ func (noopArtifactService) UploadArtifact(_ context.Context, _ Caller, _ UploadA
 	return UploadArtifactResult{}, errors.New("artifact service is not configured")
 }
 
-func (noopArtifactService) ListWorkspaceArtifacts(_ context.Context, _ Caller, _ uuid.UUID) ([]repository.Artifact, error) {
-	return nil, errors.New("artifact service is not configured")
+func (noopArtifactService) ListWorkspaceArtifacts(_ context.Context, _ Caller, _ uuid.UUID, _, _ int32) (ListWorkspaceArtifactsResult, error) {
+	return ListWorkspaceArtifactsResult{}, errors.New("artifact service is not configured")
 }
 
 func (noopArtifactService) GetArtifactDownload(_ context.Context, _ Caller, _ uuid.UUID, _ string) (GetArtifactDownloadResult, error) {

--- a/backend/internal/api/server_test.go
+++ b/backend/internal/api/server_test.go
@@ -64,7 +64,7 @@ func (stubRunReadService) ListRuns(_ context.Context, _ Caller, _ ListRunsInput)
 
 type stubAgentDeploymentReadService struct{}
 
-func (stubAgentDeploymentReadService) ListAgentDeployments(_ context.Context, _ uuid.UUID) (ListAgentDeploymentsResult, error) {
+func (stubAgentDeploymentReadService) ListAgentDeployments(_ context.Context, _ uuid.UUID, _, _ int32) (ListAgentDeploymentsResult, error) {
 	return ListAgentDeploymentsResult{}, errors.New("not implemented")
 }
 

--- a/backend/internal/repository/artifacts.go
+++ b/backend/internal/repository/artifacts.go
@@ -104,7 +104,7 @@ func (r *Repository) CreateArtifact(ctx context.Context, params CreateArtifactPa
 	return artifact, nil
 }
 
-func (r *Repository) ListArtifactsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]Artifact, error) {
+func (r *Repository) ListArtifactsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID, limit, offset int32) ([]Artifact, error) {
 	rows, err := r.db.Query(ctx, `
 		SELECT
 			id,
@@ -126,8 +126,9 @@ func (r *Repository) ListArtifactsByWorkspaceID(ctx context.Context, workspaceID
 		FROM artifacts
 		WHERE workspace_id = $1
 		  AND retention_status = 'active'
-		ORDER BY created_at DESC
-	`, workspaceID)
+		ORDER BY created_at DESC, id DESC
+		LIMIT $2 OFFSET $3
+	`, workspaceID, limit, offset)
 	if err != nil {
 		return nil, fmt.Errorf("list artifacts by workspace: %w", err)
 	}
@@ -145,6 +146,22 @@ func (r *Repository) ListArtifactsByWorkspaceID(ctx context.Context, workspaceID
 		return nil, fmt.Errorf("list artifacts by workspace: rows: %w", err)
 	}
 	return artifacts, nil
+}
+
+// CountArtifactsByWorkspaceID returns the total number of active artifacts in
+// the workspace, for list pagination.
+func (r *Repository) CountArtifactsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (int64, error) {
+	var total int64
+	err := r.db.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM artifacts
+		WHERE workspace_id = $1
+		  AND retention_status = 'active'
+	`, workspaceID).Scan(&total)
+	if err != nil {
+		return 0, fmt.Errorf("count artifacts by workspace: %w", err)
+	}
+	return total, nil
 }
 
 // ListArtifactsByRunID returns the active (non-expired) artifacts produced by a

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -2917,9 +2917,11 @@ type AgentDeploymentSummary struct {
 	LatestSnapshotID      *uuid.UUID
 }
 
-func (r *Repository) ListActiveAgentDeploymentsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]AgentDeploymentSummary, error) {
+func (r *Repository) ListActiveAgentDeploymentsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID, limit, offset int32) ([]AgentDeploymentSummary, error) {
 	rows, err := r.queries.ListActiveAgentDeploymentsByWorkspaceID(ctx, repositorysqlc.ListActiveAgentDeploymentsByWorkspaceIDParams{
 		WorkspaceID: workspaceID,
+		LimitCount:  limit,
+		OffsetCount: offset,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list active agent deployments by workspace id: %w", err)
@@ -2950,6 +2952,16 @@ func (r *Repository) ListActiveAgentDeploymentsByWorkspaceID(ctx context.Context
 	}
 
 	return deployments, nil
+}
+
+func (r *Repository) CountActiveAgentDeploymentsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (int64, error) {
+	total, err := r.queries.CountActiveAgentDeploymentsByWorkspaceID(ctx, repositorysqlc.CountActiveAgentDeploymentsByWorkspaceIDParams{
+		WorkspaceID: workspaceID,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("count active agent deployments by workspace id: %w", err)
+	}
+	return total, nil
 }
 
 type ChallengePackSummary struct {

--- a/backend/internal/repository/sqlc/agent_deployments.sql.go
+++ b/backend/internal/repository/sqlc/agent_deployments.sql.go
@@ -12,6 +12,25 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const countActiveAgentDeploymentsByWorkspaceID = `-- name: CountActiveAgentDeploymentsByWorkspaceID :one
+SELECT COUNT(*)
+FROM agent_deployments
+WHERE workspace_id = $1
+  AND status = 'active'
+  AND archived_at IS NULL
+`
+
+type CountActiveAgentDeploymentsByWorkspaceIDParams struct {
+	WorkspaceID uuid.UUID
+}
+
+func (q *Queries) CountActiveAgentDeploymentsByWorkspaceID(ctx context.Context, arg CountActiveAgentDeploymentsByWorkspaceIDParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countActiveAgentDeploymentsByWorkspaceID, arg.WorkspaceID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const listActiveAgentDeploymentsByWorkspaceID = `-- name: ListActiveAgentDeploymentsByWorkspaceID :many
 SELECT DISTINCT ON (ad.id)
     ad.id,
@@ -32,10 +51,13 @@ WHERE ad.workspace_id = $1
   AND ad.status = 'active'
   AND ad.archived_at IS NULL
 ORDER BY ad.id, ads.created_at DESC, ads.id DESC
+LIMIT $3 OFFSET $2
 `
 
 type ListActiveAgentDeploymentsByWorkspaceIDParams struct {
 	WorkspaceID uuid.UUID
+	OffsetCount int32
+	LimitCount  int32
 }
 
 type ListActiveAgentDeploymentsByWorkspaceIDRow struct {
@@ -51,7 +73,7 @@ type ListActiveAgentDeploymentsByWorkspaceIDRow struct {
 }
 
 func (q *Queries) ListActiveAgentDeploymentsByWorkspaceID(ctx context.Context, arg ListActiveAgentDeploymentsByWorkspaceIDParams) ([]ListActiveAgentDeploymentsByWorkspaceIDRow, error) {
-	rows, err := q.db.Query(ctx, listActiveAgentDeploymentsByWorkspaceID, arg.WorkspaceID)
+	rows, err := q.db.Query(ctx, listActiveAgentDeploymentsByWorkspaceID, arg.WorkspaceID, arg.OffsetCount, arg.LimitCount)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/repository/sqlc/querier.go
+++ b/backend/internal/repository/sqlc/querier.go
@@ -16,6 +16,7 @@ type Querier interface {
 	AttachRunToEvalSession(ctx context.Context, arg AttachRunToEvalSessionParams) (Run, error)
 	BeginBillingWebhookEvent(ctx context.Context, arg BeginBillingWebhookEventParams) (string, error)
 	ClaimAgentTryout(ctx context.Context, arg ClaimAgentTryoutParams) (AgentTryout, error)
+	CountActiveAgentDeploymentsByWorkspaceID(ctx context.Context, arg CountActiveAgentDeploymentsByWorkspaceIDParams) (int64, error)
 	CountActiveOrgMembers(ctx context.Context, arg CountActiveOrgMembersParams) (int32, error)
 	CountActiveWorkspaceRuns(ctx context.Context, arg CountActiveWorkspaceRunsParams) (int32, error)
 	CountActiveWorkspaces(ctx context.Context, arg CountActiveWorkspacesParams) (int32, error)

--- a/cli/cmd/artifact.go
+++ b/cli/cmd/artifact.go
@@ -16,6 +16,7 @@ import (
 func init() {
 	rootCmd.AddCommand(artifactCmd)
 	artifactCmd.AddCommand(artifactListCmd)
+	registerListPaginationFlags(artifactListCmd)
 	artifactCmd.AddCommand(artifactUploadCmd)
 	artifactCmd.AddCommand(artifactDownloadCmd)
 
@@ -40,7 +41,11 @@ var artifactListCmd = &cobra.Command{
 		rc := GetRunContext(cmd)
 		wsID := RequireWorkspace(cmd)
 
-		resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+wsID+"/artifacts", nil)
+		q, err := listPaginationQuery(cmd)
+		if err != nil {
+			return err
+		}
+		resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+wsID+"/artifacts", q)
 		if err != nil {
 			return err
 		}
@@ -49,14 +54,18 @@ var artifactListCmd = &cobra.Command{
 		}
 
 		var result struct {
-			Items []map[string]any `json:"items"`
+			Items  []map[string]any `json:"items"`
+			Total  int64            `json:"total"`
+			Limit  int              `json:"limit"`
+			Offset int              `json:"offset"`
 		}
 		if err := resp.DecodeJSON(&result); err != nil {
 			return err
 		}
+		list := newPaginatedList(result.Items, result.Total, result.Limit, result.Offset)
 
 		if rc.Output.IsStructured() {
-			return rc.Output.PrintRaw(result)
+			return rc.Output.PrintRaw(list)
 		}
 
 		cols := []output.Column{{Header: "ID"}, {Header: "Type"}, {Header: "Size"}, {Header: "Run"}, {Header: "Run Agent"}, {Header: "Created"}}
@@ -72,6 +81,7 @@ var artifactListCmd = &cobra.Command{
 			}
 		}
 		rc.Output.PrintTable(cols, rows)
+		printListPagingHint(rc, list)
 		return nil
 	},
 }

--- a/cli/cmd/deployment.go
+++ b/cli/cmd/deployment.go
@@ -13,6 +13,7 @@ import (
 func init() {
 	rootCmd.AddCommand(deploymentCmd)
 	deploymentCmd.AddCommand(deploymentListCmd)
+	registerListPaginationFlags(deploymentListCmd)
 	deploymentCmd.AddCommand(deploymentCreateCmd)
 
 	deploymentCreateCmd.Flags().String("from-file", "", "JSON file with deployment spec")
@@ -37,7 +38,11 @@ var deploymentListCmd = &cobra.Command{
 		rc := GetRunContext(cmd)
 		wsID := RequireWorkspace(cmd)
 
-		resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+wsID+"/agent-deployments", nil)
+		q, err := listPaginationQuery(cmd)
+		if err != nil {
+			return err
+		}
+		resp, err := rc.Client.Get(cmd.Context(), "/v1/workspaces/"+wsID+"/agent-deployments", q)
 		if err != nil {
 			return err
 		}
@@ -46,14 +51,18 @@ var deploymentListCmd = &cobra.Command{
 		}
 
 		var result struct {
-			Items []map[string]any `json:"items"`
+			Items  []map[string]any `json:"items"`
+			Total  int64            `json:"total"`
+			Limit  int              `json:"limit"`
+			Offset int              `json:"offset"`
 		}
 		if err := resp.DecodeJSON(&result); err != nil {
 			return err
 		}
+		list := newPaginatedList(result.Items, result.Total, result.Limit, result.Offset)
 
 		if rc.Output.IsStructured() {
-			return rc.Output.PrintRaw(result)
+			return rc.Output.PrintRaw(list)
 		}
 
 		cols := []output.Column{{Header: "ID"}, {Header: "Name"}, {Header: "Status"}, {Header: "Build Version"}, {Header: "Created"}}
@@ -68,6 +77,7 @@ var deploymentListCmd = &cobra.Command{
 			}
 		}
 		rc.Output.PrintTable(cols, rows)
+		printListPagingHint(rc, list)
 		return nil
 	},
 }

--- a/cli/cmd/list_pagination_test.go
+++ b/cli/cmd/list_pagination_test.go
@@ -65,9 +65,11 @@ func TestOtherListCommandsPassPagination(t *testing.T) {
 	t.Setenv("AGENTCLASH_WORKSPACE", "ws-1")
 
 	srv := fakeAPI(t, map[string]http.HandlerFunc{
-		"GET /v1/organizations/org-1/workspaces": paginatedItemsHandler(t, "5", "10", 11),
-		"GET /v1/organizations":                  paginatedItemsHandler(t, "5", "10", 11),
-		"GET /v1/workspaces/ws-1/datasets":       paginatedItemsHandler(t, "5", "10", 11),
+		"GET /v1/organizations/org-1/workspaces":    paginatedItemsHandler(t, "5", "10", 11),
+		"GET /v1/organizations":                     paginatedItemsHandler(t, "5", "10", 11),
+		"GET /v1/workspaces/ws-1/datasets":          paginatedItemsHandler(t, "5", "10", 11),
+		"GET /v1/workspaces/ws-1/agent-deployments": paginatedItemsHandler(t, "5", "10", 11),
+		"GET /v1/workspaces/ws-1/artifacts":         paginatedItemsHandler(t, "5", "10", 11),
 	})
 	defer srv.Close()
 
@@ -75,6 +77,8 @@ func TestOtherListCommandsPassPagination(t *testing.T) {
 		{"workspace", "list", "--org", "org-1", "--json", "--limit", "5", "--offset", "10"},
 		{"org", "list", "--json", "--limit", "5", "--offset", "10"},
 		{"dataset", "list", "--json", "--limit", "5", "--offset", "10"},
+		{"deployment", "list", "--json", "--limit", "5", "--offset", "10"},
+		{"artifact", "list", "--json", "--limit", "5", "--offset", "10"},
 	} {
 		cap := captureStdout(t)
 		err := executeCommand(t, args, srv.URL)

--- a/cli/cmd/testdata/schema_snapshot.json
+++ b/cli/cmd/testdata/schema_snapshot.json
@@ -452,7 +452,21 @@
           "name": "list",
           "path": "agentclash artifact list",
           "short": "List artifacts in the workspace",
-          "runnable": true
+          "runnable": true,
+          "flags": [
+            {
+              "name": "limit",
+              "usage": "Maximum items to return (1-100; 0 = server default of 20)",
+              "type": "int",
+              "default": "0"
+            },
+            {
+              "name": "offset",
+              "usage": "Number of items to skip before the first result",
+              "type": "int",
+              "default": "0"
+            }
+          ]
         },
         {
           "name": "upload",
@@ -1716,7 +1730,21 @@
           "name": "list",
           "path": "agentclash deployment list",
           "short": "List agent deployments",
-          "runnable": true
+          "runnable": true,
+          "flags": [
+            {
+              "name": "limit",
+              "usage": "Maximum items to return (1-100; 0 = server default of 20)",
+              "type": "int",
+              "default": "0"
+            },
+            {
+              "name": "offset",
+              "usage": "Number of items to skip before the first result",
+              "type": "int",
+              "default": "0"
+            }
+          ]
         }
       ]
     },

--- a/docs/api-server/openapi.yaml
+++ b/docs/api-server/openapi.yaml
@@ -2348,12 +2348,29 @@ paths:
       tags: [Artifacts]
       summary: List workspace artifacts
       description: >
-        Returns all active artifacts belonging to the workspace, ordered by
-        creation date descending.
+        Returns one page of the workspace's active artifacts, ordered by
+        creation date descending, with the total count for pagination.
       security:
         - bearerJWT: []
       parameters:
         - $ref: "#/components/parameters/WorkspaceID"
+        - name: limit
+          in: query
+          description: Page size (server default 20, capped at 100).
+          schema:
+            type: integer
+            format: int32
+            default: 20
+            minimum: 1
+            maximum: 100
+        - name: offset
+          in: query
+          description: Number of items to skip before the first result.
+          schema:
+            type: integer
+            format: int32
+            default: 0
+            minimum: 0
       responses:
         "200":
           description: List of artifacts
@@ -4900,6 +4917,23 @@ paths:
         - bearerJWT: []
       parameters:
         - $ref: "#/components/parameters/WorkspaceID"
+        - name: limit
+          in: query
+          description: Page size (server default 20, capped at 100).
+          schema:
+            type: integer
+            format: int32
+            default: 20
+            minimum: 1
+            maximum: 100
+        - name: offset
+          in: query
+          description: Number of items to skip before the first result.
+          schema:
+            type: integer
+            format: int32
+            default: 0
+            minimum: 0
       responses:
         "200":
           description: List of agent deployments
@@ -12215,12 +12249,21 @@ components:
 
     ListArtifactsResponse:
       type: object
-      required: [items]
+      required: [items, total, limit, offset]
       properties:
         items:
           type: array
           items:
             $ref: "#/components/schemas/ArtifactUploadResponse"
+        total:
+          type: integer
+          format: int64
+        limit:
+          type: integer
+          format: int32
+        offset:
+          type: integer
+          format: int32
 
     ArtifactUploadResponse:
       type: object
@@ -12654,12 +12697,21 @@ components:
 
     ListAgentDeploymentsResponse:
       type: object
-      required: [items]
+      required: [items, total, limit, offset]
       properties:
         items:
           type: array
           items:
             $ref: "#/components/schemas/AgentDeployment"
+        total:
+          type: integer
+          format: int64
+        limit:
+          type: integer
+          format: int32
+        offset:
+          type: integer
+          format: int32
 
     CreateAgentDeploymentRequest:
       type: object


### PR DESCRIPTION
## ⚠️ Stacked PR

**Base is PR-7 (#978)** — the CLI side reuses #978's shared pagination helpers. Merge #978 first, then retarget this to `main`. The commit to review here is `9fceba5b`.

## What (PR-8 of the CLI agent-readiness series — WI-7 part 2)

The two list endpoints that lacked server-side pagination, now brought to the same `{items, total, limit, offset}` contract as runs/workspaces/orgs/datasets — both planes.

### Backend
- **Deployments** (sqlc): `ListActiveAgentDeploymentsByWorkspaceID` gains `LIMIT/OFFSET`; new `CountActiveAgentDeploymentsByWorkspaceID`; manager returns the paged result; handler parses the params and emits the envelope. `sqlc generate` committed.
- **Artifacts** (inline repo SQL — that file's existing convention): `LIMIT/OFFSET` + `CountArtifactsByWorkspaceID`. The `ORDER BY created_at DESC` gains a tie-breaking `id DESC` — without a total order, `created_at` ties can shuffle rows across pages.
- **Shared `parseListLimitOffset`** (default 20, cap 100, garbage-tolerant — byte-identical semantics to the existing runs list, so no caller can be broken by invalid input).
- **OpenAPI**: both paths gain `limit`/`offset` query params; both response schemas gain required `total/limit/offset`. `redocly lint`: **same 5 pre-existing errors as `main`** (unresolved `ErrorResponse` refs on dataset paths — not mine, verified by linting the base), zero new.

### CLI
- `deployment list` / `artifact list` wire `--limit/--offset` through #978's helpers: validated client-side (`invalid_argument`, no network call), `total`/`has_more` in structured output, human next-page hint. Schema golden regenerated.

## Verification

- `TestParseListLimitOffset` — 9-case table: defaults, cap at 100, zero/negative/garbage for both params.
- CLI `TestOtherListCommandsPassPagination` extended to `deployment list` + `artifact list` (query passthrough asserted server-side; exact-last-page boundary).
- Existing artifact handler tests updated for the new repo interface (fake gains `Count…`).
- `cd backend && go build && go vet && go test -short -race ./internal/api/ ./internal/repository/` green. Full backend suite has **one pre-existing, environment-dependent failure** (`TestCapturedArtifactContentType` — this Mac's MIME db maps `.xyz`→`chemical/x-xyz`; fails identically on clean `main`, unrelated to this PR).
- `cd cli && go build && go vet && go test -short -race ./...` green.

## Way to test by hand

```bash
make db-up && make db-migrate && make api-server   # terminal 1
cd cli && go run . artifact list --json --limit 2 | jq '{total, has_more}'
curl -s "localhost:8080/v1/workspaces/<ws>/agent-deployments?limit=1&offset=1" | jq '{total, limit, offset}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)