### PR TITLE
feat(cli): global --query/--jq field selection over structured output

### DIFF
--- a/cli/cmd/query_test.go
+++ b/cli/cmd/query_test.go
@@ -163,3 +163,4 @@ func TestQueryDoesNotFilterErrorEnvelope(t *testing.T) {
 		t.Fatalf("error = %v, want the forbidden API error", err)
 	}
 }
+

--- a/cli/cmd/query_test.go
+++ b/cli/cmd/query_test.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func queryTestServer(t *testing.T) (srv interface{ Close() }, url string, called *bool) {
+	t.Helper()
+	c := false
+	s := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/runs": func(w http.ResponseWriter, r *http.Request) {
+			c = true
+			jsonHandler(200, map[string]any{
+				"items": []map[string]any{
+					{"id": "run-1", "status": "completed"},
+					{"id": "run-2", "status": "running"},
+				},
+				"total": 17, "limit": 20, "offset": 0,
+			})(w, r)
+		},
+	})
+	return s, s.URL, &c
+}
+
+// WI-13 happy path: a jq projection over structured output; string results
+// print raw (gh --jq convention), one per line.
+func TestQueryProjectsStructuredOutput(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("AGENTCLASH_TOKEN", "tok")
+	t.Setenv("AGENTCLASH_WORKSPACE", "ws-1")
+
+	srv, url, _ := queryTestServer(t)
+	defer srv.Close()
+
+	cap := captureStdout(t)
+	err := executeCommand(t, []string{"run", "list", "--json", "--query", ".items[].id"}, url)
+	out := cap.finish()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != "run-1\nrun-2\n" {
+		t.Fatalf("stdout = %q, want raw id lines", out)
+	}
+}
+
+// The --jq alias normalizes onto --query.
+func TestQueryJQAliasWorks(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("AGENTCLASH_TOKEN", "tok")
+	t.Setenv("AGENTCLASH_WORKSPACE", "ws-1")
+
+	srv, url, _ := queryTestServer(t)
+	defer srv.Close()
+
+	cap := captureStdout(t)
+	err := executeCommand(t, []string{"run", "list", "--json", "--jq", ".items | length"}, url)
+	out := cap.finish()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(out) != "2" {
+		t.Fatalf("stdout = %q, want 2", out)
+	}
+}
+
+// Non-string results emit one compact JSON document per line.
+func TestQueryObjectResultsAreCompactJSONLines(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("AGENTCLASH_TOKEN", "tok")
+	t.Setenv("AGENTCLASH_WORKSPACE", "ws-1")
+
+	srv, url, _ := queryTestServer(t)
+	defer srv.Close()
+
+	cap := captureStdout(t)
+	err := executeCommand(t, []string{"run", "list", "--json", "--query", ".items[] | {id, status}"}, url)
+	out := cap.finish()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := `{"id":"run-1","status":"completed"}` + "\n" + `{"id":"run-2","status":"running"}` + "\n"
+	if out != want {
+		t.Fatalf("stdout = %q, want compact JSON lines:\n%s", out, want)
+	}
+}
+
+// --query also projects --output yaml (the projection defines the shape).
+func TestQueryAppliesToYAMLFormat(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("AGENTCLASH_TOKEN", "tok")
+	t.Setenv("AGENTCLASH_WORKSPACE", "ws-1")
+
+	srv, url, _ := queryTestServer(t)
+	defer srv.Close()
+
+	cap := captureStdout(t)
+	err := executeCommand(t, []string{"run", "list", "--output", "yaml", "--query", ".items | length"}, url)
+	out := cap.finish()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(out) != "2" {
+		t.Fatalf("stdout = %q, want 2", out)
+	}
+}
+
+// Failure paths: invalid expressions and missing structured mode fail fast
+// with a stable code and ZERO network calls.
+func TestQueryValidationFailsFast(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("AGENTCLASH_TOKEN", "tok")
+	t.Setenv("AGENTCLASH_WORKSPACE", "ws-1")
+
+	srv, url, called := queryTestServer(t)
+	defer srv.Close()
+
+	for _, args := range [][]string{
+		{"run", "list", "--json", "--query", ".items[+"}, // syntax error
+		{"run", "list", "--query", ".items"},             // no structured format
+	} {
+		err := executeCommand(t, args, url)
+		if err == nil {
+			t.Fatalf("%v: expected an error, got nil", args)
+		}
+		var ce *cliError
+		if !errors.As(err, &ce) || ce.Code != "invalid_argument" {
+			t.Fatalf("%v: error = %v, want cliError invalid_argument", args, err)
+		}
+	}
+	if *called {
+		t.Fatal("no network call may happen for an invalid --query")
+	}
+}
+
+// The structured ERROR envelope stays unfiltered — agents need a stable error
+// shape regardless of the projection they asked for.
+func TestQueryDoesNotFilterErrorEnvelope(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("AGENTCLASH_TOKEN", "tok")
+	t.Setenv("AGENTCLASH_WORKSPACE", "ws-1")
+
+	srv := fakeAPI(t, map[string]http.HandlerFunc{
+		"GET /v1/workspaces/ws-1/runs": jsonHandler(403, map[string]any{
+			"error": map[string]any{"code": "forbidden", "message": "no"},
+		}),
+	})
+	defer srv.Close()
+
+	stderr := captureStderr(t)
+	err := executeCommand(t, []string{"run", "list", "--json", "--query", ".items"}, srv.URL)
+	_ = stderr.finish()
+	if err == nil {
+		t.Fatal("expected the API error to propagate")
+	}
+	// The error must carry the API's code untouched — RenderError (main.go
+	// path) encodes the envelope outside the Formatter, so the projection
+	// cannot eat it. Asserting on the returned error is the command-level
+	// equivalent.
+	if !strings.Contains(err.Error(), "forbidden") {
+		t.Fatalf("error = %v, want the forbidden API error", err)
+	}
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -219,9 +219,10 @@ func init() {
 	// --jq is the de-facto name agents know from gh; normalize it onto --query
 	// so both spellings parse while the schema documents a single flag. The
 	// GLOBAL normalization func is required — a flag-set-local one would not
-	// propagate to subcommand parsing — and any prior func is chained so a
-	// second SetGlobalNormalizationFunc caller cannot silently drop this
-	// mapping (or vice versa).
+	// propagate to subcommand parsing — and we chain any prior func so this
+	// registration preserves an existing mapping rather than clobbering it.
+	// (A *future* un-chained SetGlobalNormalizationFunc caller could still
+	// drop ours; today this is the only caller.)
 	prior := rootCmd.GlobalNormalizationFunc()
 	rootCmd.SetGlobalNormalizationFunc(func(fs *pflag.FlagSet, name string) pflag.NormalizedName {
 		if prior != nil {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -219,8 +219,14 @@ func init() {
 	// --jq is the de-facto name agents know from gh; normalize it onto --query
 	// so both spellings parse while the schema documents a single flag. The
 	// GLOBAL normalization func is required — a flag-set-local one would not
-	// propagate to subcommand parsing.
+	// propagate to subcommand parsing — and any prior func is chained so a
+	// second SetGlobalNormalizationFunc caller cannot silently drop this
+	// mapping (or vice versa).
+	prior := rootCmd.GlobalNormalizationFunc()
 	rootCmd.SetGlobalNormalizationFunc(func(fs *pflag.FlagSet, name string) pflag.NormalizedName {
+		if prior != nil {
+			name = string(prior(fs, name))
+		}
 		if name == "jq" {
 			name = "query"
 		}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -11,7 +11,9 @@ import (
 	"github.com/agentclash/agentclash/cli/internal/auth"
 	"github.com/agentclash/agentclash/cli/internal/config"
 	"github.com/agentclash/agentclash/cli/internal/output"
+	"github.com/itchyny/gojq"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // Global flags.
@@ -24,6 +26,7 @@ var (
 	flagWorkspace      string
 	flagAPIURL         string
 	flagNonInteractive bool
+	flagQuery          string
 )
 
 // nonInteractiveMode reports whether the CLI must never prompt for input and
@@ -164,6 +167,32 @@ Get started:
 		formatter := output.NewFormatter(mgr.OutputFormat(), flagJSON, flagQuiet)
 		setRuntimeOutputFormat(formatter.Format())
 
+		// Validate --query before any work (and before any network call):
+		// a bad expression must be a fast, clean validation error.
+		if flagQuery != "" {
+			if !formatter.IsStructured() {
+				return &cliError{
+					Code:    "invalid_argument",
+					Message: "--query requires structured output; add --json or --output json|yaml",
+				}
+			}
+			parsed, err := gojq.Parse(flagQuery)
+			if err != nil {
+				return &cliError{
+					Code:    "invalid_argument",
+					Message: fmt.Sprintf("invalid --query expression: %v", err),
+				}
+			}
+			compiled, err := gojq.Compile(parsed)
+			if err != nil {
+				return &cliError{
+					Code:    "invalid_argument",
+					Message: fmt.Sprintf("invalid --query expression: %v", err),
+				}
+			}
+			formatter.SetQuery(compiled)
+		}
+
 		rc := &RunContext{
 			Client:    client,
 			Config:    mgr,
@@ -186,6 +215,17 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&flagWorkspace, "workspace", "w", "", "Workspace ID (overrides config)")
 	rootCmd.PersistentFlags().StringVar(&flagAPIURL, "api-url", "", "API base URL (overrides config)")
 	rootCmd.PersistentFlags().BoolVar(&flagNonInteractive, "non-interactive", false, "Never prompt; fail fast when interactive input is required (also set by AGENTCLASH_NONINTERACTIVE or CI)")
+	rootCmd.PersistentFlags().StringVar(&flagQuery, "query", "", "jq expression applied to structured output (alias: --jq); strings print raw, other results one compact JSON document per line. Requires --json or --output json|yaml.")
+	// --jq is the de-facto name agents know from gh; normalize it onto --query
+	// so both spellings parse while the schema documents a single flag. The
+	// GLOBAL normalization func is required — a flag-set-local one would not
+	// propagate to subcommand parsing.
+	rootCmd.SetGlobalNormalizationFunc(func(fs *pflag.FlagSet, name string) pflag.NormalizedName {
+		if name == "jq" {
+			name = "query"
+		}
+		return pflag.NormalizedName(name)
+	})
 }
 
 // Execute runs the root command.

--- a/cli/cmd/testdata/schema_snapshot.json
+++ b/cli/cmd/testdata/schema_snapshot.json
@@ -32,6 +32,11 @@
       "type": "string"
     },
     {
+      "name": "query",
+      "usage": "jq expression applied to structured output (alias: --jq); strings print raw, other results one compact JSON document per line. Requires --json or --output json|yaml.",
+      "type": "string"
+    },
+    {
       "name": "quiet",
       "shorthand": "q",
       "usage": "Suppress non-essential output",

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/briandowns/spinner v1.23.2
 	github.com/fatih/color v1.19.0
 	github.com/google/jsonschema-go v0.3.0
+	github.com/itchyny/gojq v0.12.19
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	golang.org/x/term v0.42.0
@@ -17,6 +18,7 @@ require (
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/itchyny/timefmt-go v0.1.8 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.21 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -22,6 +22,10 @@ github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/itchyny/gojq v0.12.19 h1:ttXA0XCLEMoaLOz5lSeFOZ6u6Q3QxmG46vfgI4O0DEs=
+github.com/itchyny/gojq v0.12.19/go.mod h1:5galtVPDywX8SPSOrqjGxkBeDhSxEW1gSxoy7tn1iZY=
+github.com/itchyny/timefmt-go v0.1.8 h1:1YEo1JvfXeAHKdjelbYr/uCuhkybaHCeTkH8Bo791OI=
+github.com/itchyny/timefmt-go v0.1.8/go.mod h1:5E46Q+zj7vbTgWY8o5YkMeYb4I6GeWLFnetPy5oBrAI=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/cli/internal/output/formatter.go
+++ b/cli/internal/output/formatter.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/itchyny/gojq"
 	"gopkg.in/yaml.v3"
 )
 
@@ -22,6 +23,53 @@ type Formatter struct {
 	quiet  bool
 	writer io.Writer
 	errw   io.Writer
+	query  *gojq.Code
+}
+
+// SetQuery installs a compiled jq expression that every structured success
+// document is filtered through (gh --jq semantics). Error envelopes are
+// rendered outside the Formatter and stay unfiltered by design — agents need
+// a stable error shape regardless of the projection they asked for.
+func (f *Formatter) SetQuery(code *gojq.Code) {
+	f.query = code
+}
+
+// printQueried runs the compiled jq expression over data and emits results
+// jq-style: strings print raw (no quotes), everything else as one compact
+// JSON document per line. data is round-tripped through encoding/json first
+// because gojq operates on plain JSON values, not Go structs.
+func (f *Formatter) printQueried(data any) error {
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	var plain any
+	if err := json.Unmarshal(raw, &plain); err != nil {
+		return err
+	}
+	iter := f.query.Run(plain)
+	for {
+		v, ok := iter.Next()
+		if !ok {
+			return nil
+		}
+		if iterErr, isErr := v.(error); isErr {
+			return fmt.Errorf("--query: %w", iterErr)
+		}
+		if s, isString := v.(string); isString {
+			if _, err := fmt.Fprintln(f.writer, s); err != nil {
+				return err
+			}
+			continue
+		}
+		line, err := json.Marshal(v)
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(f.writer, string(line)); err != nil {
+			return err
+		}
+	}
 }
 
 // NewFormatter creates a formatter with the given settings.
@@ -94,15 +142,24 @@ func (f *Formatter) PrintTable(columns []Column, rows [][]string) {
 	RenderTable(f.writer, columns, rows)
 }
 
-// PrintJSON renders data as indented JSON to stdout.
+// PrintJSON renders data as indented JSON to stdout, or jq-filtered output
+// when a --query expression is installed.
 func (f *Formatter) PrintJSON(data any) error {
+	if f.query != nil {
+		return f.printQueried(data)
+	}
 	enc := json.NewEncoder(f.writer)
 	enc.SetIndent("", "  ")
 	return enc.Encode(data)
 }
 
-// PrintYAML renders data as YAML to stdout.
+// PrintYAML renders data as YAML to stdout. A --query expression takes
+// precedence and emits jq-style output (raw strings / compact JSON lines) —
+// the projection defines the shape, not the container format.
 func (f *Formatter) PrintYAML(data any) error {
+	if f.query != nil {
+		return f.printQueried(data)
+	}
 	enc := yaml.NewEncoder(f.writer)
 	enc.SetIndent(2)
 	defer enc.Close()

--- a/cli/internal/output/formatter.go
+++ b/cli/internal/output/formatter.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -43,8 +44,14 @@ func (f *Formatter) printQueried(data any) error {
 	if err != nil {
 		return err
 	}
+	// Decode with UseNumber so integers larger than 2^53 survive: the default
+	// any-decode turns every JSON number into a float64, silently corrupting
+	// big int64 fields (e.g. event sequence numbers). gojq accepts json.Number
+	// as a first-class input value, so the projection is exact end-to-end.
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
 	var plain any
-	if err := json.Unmarshal(raw, &plain); err != nil {
+	if err := dec.Decode(&plain); err != nil {
 		return err
 	}
 	iter := f.query.Run(plain)

--- a/cli/internal/output/formatter_test.go
+++ b/cli/internal/output/formatter_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/itchyny/gojq"
 	"gopkg.in/yaml.v3"
 )
 
@@ -155,5 +156,37 @@ func TestFormatterPrintErrorAlwaysShows(t *testing.T) {
 	f.PrintError("critical failure")
 	if !strings.Contains(errBuf.String(), "critical failure") {
 		t.Fatalf("PrintError should show even in quiet mode, got:\n%s", errBuf.String())
+	}
+}
+
+// A typed int64 field larger than 2^53 must survive a --query projection.
+// The default any-decode in printQueried would turn it into float64 and
+// silently corrupt it; UseNumber + gojq's json.Number support keeps it exact.
+// This is the unit-level analog of the gh --jq contract: the projection itself
+// must not lose precision on data that reaches the formatter as a real int64.
+func TestPrintQueriedPreservesLargeInt64(t *testing.T) {
+	var buf bytes.Buffer
+	f := NewFormatter("json", false, false)
+	f.writer = &buf
+
+	q, err := gojq.Parse(".seq")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	code, err := gojq.Compile(q)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	f.SetQuery(code)
+
+	// 2^53+1 is the first integer float64 cannot represent exactly.
+	type payload struct {
+		Seq int64 `json:"seq"`
+	}
+	if err := f.PrintRaw(payload{Seq: 9007199254740993}); err != nil {
+		t.Fatalf("PrintRaw: %v", err)
+	}
+	if got := strings.TrimSpace(buf.String()); got != "9007199254740993" {
+		t.Fatalf("projected seq = %q, want exact 9007199254740993 (no float64 loss)", got)
 	}
 }


### PR DESCRIPTION
## ⚠️ Stacked PR

**Base is PR-2 (#974)** — both PRs extend the same `root.go` global-flag block, and the plan sequenced this after #974. Merge #974 first, then retarget to `main`. The commit to review here is `574926e7`.

## What (PR-10 of the CLI agent-readiness series — WI-13)

Field selection without shelling out to `jq`, matching the `gh --jq` contract agents already know — backed by the same library (`itchyny/gojq` v0.12.19).

- **Global `--query`** (alias `--jq`, normalized onto `--query` via cobra's global normalization func so both spellings parse while `schema` documents a single flag) applies a jq expression to every structured success document.
- **jq-style emission**: string results print **raw** (no quotes, one per line — `--query '.items[].id'` gives clean id lines); everything else emits one compact JSON document per line. Applies to `--output yaml` too — the projection defines the shape, not the container format.
- **Fail-fast validation** in `PersistentPreRunE`: an invalid expression or `--query` without `--json`/`--output` is a stable `invalid_argument` **before any network call** (mirrors `gh`'s "cannot use --jq without --json").
- **Error envelopes stay unfiltered** by design — `RenderError` encodes outside the Formatter, so agents keep a stable error shape regardless of the projection they asked for.

## Verification

- `TestQueryProjectsStructuredOutput` — raw string lines for `.items[].id`.
- `TestQueryJQAliasWorks` — `--jq` parses identically.
- `TestQueryObjectResultsAreCompactJSONLines` — exact compact-JSON-per-line bytes.
- `TestQueryAppliesToYAMLFormat` — projection wins over the yaml container.
- `TestQueryValidationFailsFast` — syntax error + missing structured format → `invalid_argument`, **zero** network calls.
- `TestQueryDoesNotFilterErrorEnvelope` — a 403 propagates untouched.
- `go mod tidy`; **govulncheck**: no vulnerabilities in gojq/timefmt-go — the reported advisories are pre-existing Go 1.26.2 **stdlib** items (`net/http`, `crypto/x509`, …) the CLI already had exposure to via its existing HTTP/SSE paths; fixed by a Go patch release, not this PR.
- Schema golden regenerated (the new global flag); full `go build && go vet && go test -short -race -count=1 ./...` green.

## Way to test by hand

```bash
cd cli
go run . run list --json --query '.items[].id'
go run . workspace list --json --jq '.items[] | {id, name}'
go run . run list --query '.x'            # invalid_argument: requires --json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)