### PR TITLE
feat(web): enterprise demo-first CTAs on blog, benchmarks, and homepage (#984)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ testing/*
 !testing/feat-sync-cli-skills-snapshot-p3.md
 !testing/feat-skills-export.md
 !testing/feat-integration-all-hosts.md
+!testing/feat-984-enterprise-ctas.md

--- a/testing/feat-984-enterprise-ctas.md
+++ b/testing/feat-984-enterprise-ctas.md
@@ -1,0 +1,44 @@
+# feat-984-enterprise-ctas — Test Contract
+
+Parent: #983 · Issue: #984
+
+## Functional Behavior
+
+Research-stage visitors (blog, benchmarks, homepage) see demo-first CTAs aligned with enterprise eval intent—not CLI-only conversion.
+
+- **Blog index (`/blog`)**: After intro copy, primary CTA is "Book eval workshop" (Cal.com via `DemoButton`); secondary links to `/platform/agent-evaluation`.
+- **Blog post (`/blog/[slug]`)**: After article body, panel with demo CTA plus link to `/platform/agent-evaluation`.
+- **Benchmarks index (`/benchmarks`)**: Demo CTA after intro (including coming-soon state).
+- **Benchmark report (`/benchmarks/[slug]`)**: After scoreboard (and at page end), "Run this benchmark on your agents" panel with demo booking.
+- **Homepage (`/`)**: Logged-out hero and closing sections use demo-first ordering; hero subcopy speaks to enterprise evaluators; auth/self-serve is secondary—not the white primary button.
+
+Cal.com embed must initialize on pages using `DemoButton` outside the homepage client shell.
+
+## Unit Tests
+
+- `CTAStrip` passes custom `demoLabel` through to `DemoButton` — add test if component test file exists; otherwise covered by render smoke in blog index test.
+- Existing blog index JSON-LD test still passes (`blog-index-schema.test.tsx`).
+- Existing benchmarks metadata tests still pass (`benchmarks-metadata.test.ts`).
+
+## Integration / Functional Tests
+
+- Blog index renders `data-cal-link` on demo button and `/platform/agent-evaluation` secondary link.
+- Benchmark report page renders benchmark-run CTA copy when report fixture is loaded.
+
+## Smoke Tests
+
+- `cd web && pnpm build` succeeds.
+- `cd web && pnpm lint` passes on touched files.
+- `cd web && npx tsc --noEmit` passes.
+
+## E2E Tests
+
+N/A — marketing CTA copy/layout only; manual browser verification sufficient.
+
+## Manual / cURL Tests
+
+1. Open `/blog` — confirm "Book eval workshop" is visible above post list; secondary links to enterprise evaluation page.
+2. Open any `/blog/{slug}` — confirm CTA panel after article with demo + platform link.
+3. Open `/benchmarks` — confirm demo CTA (coming-soon state OK).
+4. Open `/benchmarks/{slug}` for a sample report — confirm scoreboard footer CTA.
+5. Open `/` logged out — hero primary is demo booking; "Start first race" / auth is secondary styling.

--- a/web/src/app/benchmarks/[slug]/page.tsx
+++ b/web/src/app/benchmarks/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { MDXRemote } from "next-mdx-remote/rsc";
 import { ArrowUpRight } from "lucide-react";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
 import { BenchmarkScoreboard } from "@/components/marketing/benchmark-scoreboard";
+import { BenchmarkRunCTA } from "@/components/marketing/research-audience-cta";
 import {
   JsonLd,
   benchmarkReportSchema,
@@ -125,6 +126,7 @@ export default async function BenchmarkReportPage({ params }: Props) {
               <ArrowUpRight className="size-3" />
             </a>
           )}
+          <BenchmarkRunCTA className="mt-8" />
         </section>
 
         {report.tasks.length > 0 && (
@@ -160,6 +162,8 @@ export default async function BenchmarkReportPage({ params }: Props) {
         <div className="prose-agentclash mt-12">
           <MDXRemote source={report.content} options={mdxRemoteOptions} />
         </div>
+
+        <BenchmarkRunCTA className="mt-12" />
       </article>
     </MarketingShell>
   );

--- a/web/src/app/benchmarks/page.tsx
+++ b/web/src/app/benchmarks/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { ResearchAudienceCTA } from "@/components/marketing/research-audience-cta";
 import { JsonLd, benchmarkIndexSchema } from "@/components/marketing/json-ld";
 import { getAllReports, hasPublishedBenchmarks } from "@/lib/benchmarks";
 import { benchmarkRssAlternate, ogImageUrl } from "@/lib/seo";
@@ -72,6 +73,12 @@ export default function BenchmarksPage() {
             on correctness, reliability, latency, and cost.
           </p>
 
+          <ResearchAudienceCTA
+            className="mt-8"
+            headline="Want this benchmark on your agents?"
+            body="Book an eval workshop and we'll reproduce the race on your workloads with the same challenge pack, tools, and scorecard."
+          />
+
           <div className="mt-10 rounded-lg border border-white/[0.08] bg-white/[0.03] px-6 py-8">
             <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/40">
               Coming soon
@@ -105,6 +112,12 @@ export default function BenchmarksPage() {
           tasks — same challenge, same tools — and score the whole trajectory on
           correctness, reliability, latency, and cost. Here is who won.
         </p>
+
+        <ResearchAudienceCTA
+          className="mt-8"
+          headline="Want this benchmark on your agents?"
+          body="Book an eval workshop and we'll reproduce the race on your workloads with the same challenge pack, tools, and scorecard."
+        />
 
         <div className="mt-10 flex flex-col gap-3">
           {reports.map((report) => (

--- a/web/src/app/blog/[slug]/page.tsx
+++ b/web/src/app/blog/[slug]/page.tsx
@@ -7,6 +7,8 @@ import {
   articleSchema,
   breadcrumbSchema,
 } from "@/components/marketing/json-ld";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { ResearchAudienceCTA } from "@/components/marketing/research-audience-cta";
 import { getAllSlugs, getPostBySlug } from "@/lib/blog";
 import { mdxRemoteOptions } from "@/lib/mdx-options";
 import { blogRssAlternate, ogImageUrl } from "@/lib/seo";
@@ -76,7 +78,7 @@ export default async function BlogPostPage({ params }: Props) {
   if (!post) notFound();
 
   return (
-    <main className="min-h-screen flex flex-col items-center px-6 py-16">
+    <MarketingShell>
       <JsonLd
         id={`agentclash-blog-${post.slug}-schema`}
         data={[
@@ -94,12 +96,19 @@ export default async function BlogPostPage({ params }: Props) {
           }),
         ]}
       />
-      <article className="w-full max-w-lg">
-        <header className="mb-8">
-          <p className="font-[family-name:var(--font-mono)] text-[11px] text-white/20">
+      <article className="mx-auto w-full max-w-3xl px-6 py-16">
+        <Link
+          href="/blog"
+          className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35 transition-colors hover:text-white/55"
+        >
+          &larr; Blog
+        </Link>
+
+        <header className="mt-6 mb-8">
+          <p className="font-[family-name:var(--font-mono)] text-[11px] text-white/40">
             {post.date} &middot; {post.author}
           </p>
-          <h1 className="mt-2 font-[family-name:var(--font-display)] text-2xl sm:text-3xl tracking-[-0.02em] leading-[1.15]">
+          <h1 className="mt-3 font-[family-name:var(--font-display)] text-3xl tracking-[-0.02em] leading-[1.15] sm:text-4xl">
             {post.title}
           </h1>
         </header>
@@ -107,14 +116,13 @@ export default async function BlogPostPage({ params }: Props) {
         <div className="prose-agentclash">
           <MDXRemote source={post.content} options={mdxRemoteOptions} />
         </div>
-      </article>
 
-      <Link
-        href="/blog"
-        className="mt-12 text-xs text-white/30 hover:text-white/50 transition-colors"
-      >
-        &larr; All posts
-      </Link>
-    </main>
+        <ResearchAudienceCTA
+          className="mt-12"
+          headline="Ready to evaluate agents on your workloads?"
+          body="Book an eval workshop to map your agents to challenge packs, baselines, and release gates — or explore how enterprise teams run governed evals on AgentClash."
+        />
+      </article>
+    </MarketingShell>
   );
 }

--- a/web/src/app/blog/blog-index-schema.test.tsx
+++ b/web/src/app/blog/blog-index-schema.test.tsx
@@ -4,6 +4,16 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { SITE_URL } from "@/components/marketing/json-ld";
 import BlogPage from "./page";
 
+vi.mock("@/components/marketing/marketing-shell", () => ({
+  MarketingShell: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/components/marketing/research-audience-cta", () => ({
+  ResearchAudienceCTA: () => <div data-testid="research-audience-cta" />,
+}));
+
 vi.mock("@/lib/blog", () => ({
   getAllPosts: vi.fn(() => [
     {

--- a/web/src/app/blog/blog-metadata.test.ts
+++ b/web/src/app/blog/blog-metadata.test.ts
@@ -3,6 +3,14 @@ import { blogRssAlternate, ogImageUrl } from "@/lib/seo";
 import { metadata as blogMetadata } from "./page";
 import { generateMetadata } from "./[slug]/page";
 
+vi.mock("@/components/marketing/marketing-shell", () => ({
+  MarketingShell: ({ children }: { children: unknown }) => children,
+}));
+
+vi.mock("@/components/marketing/research-audience-cta", () => ({
+  ResearchAudienceCTA: () => null,
+}));
+
 const getPostBySlugMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/blog", () => ({

--- a/web/src/app/blog/blog-post-schema.test.tsx
+++ b/web/src/app/blog/blog-post-schema.test.tsx
@@ -4,6 +4,16 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { SITE_URL } from "@/components/marketing/json-ld";
 import BlogPostPage from "./[slug]/page";
 
+vi.mock("@/components/marketing/marketing-shell", () => ({
+  MarketingShell: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/components/marketing/research-audience-cta", () => ({
+  ResearchAudienceCTA: () => <div data-testid="research-audience-cta" />,
+}));
+
 vi.mock("next-mdx-remote/rsc", () => ({
   MDXRemote: ({ source }: { source: string }) => <div>{source}</div>,
 }));

--- a/web/src/app/blog/page.tsx
+++ b/web/src/app/blog/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { JsonLd, blogIndexSchema } from "@/components/marketing/json-ld";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { ResearchAudienceCTA } from "@/components/marketing/research-audience-cta";
 import { getAllPosts } from "@/lib/blog";
 import { blogRssAlternate } from "@/lib/seo";
 
@@ -50,17 +52,24 @@ export default function BlogPage() {
   const posts = getAllPosts();
 
   return (
-    <>
+    <MarketingShell>
       <JsonLd id="agentclash-blog-index-schema" data={blogIndexSchema(posts)} />
-      <main className="min-h-screen flex flex-col items-center px-6 py-16">
-        <h1 className="font-[family-name:var(--font-display)] text-3xl sm:text-4xl text-center tracking-[-0.02em] leading-[1.15]">
+      <section className="mx-auto w-full max-w-3xl px-6 py-16">
+        <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35">
           Blog
+        </p>
+        <h1 className="mt-3 font-[family-name:var(--font-display)] text-3xl tracking-[-0.02em] leading-[1.15] sm:text-4xl">
+          AI agent evaluation, in practice
         </h1>
-        <p className="mt-3 text-sm text-white/25">
-          Engineering notes from the team.
+        <p className="mt-3 max-w-xl text-sm leading-relaxed text-white/45">
+          Engineering notes on head-to-head agent evals, replayable failures,
+          scorecards, and release gates — for teams deciding which agents to
+          ship.
         </p>
 
-        <div className="mt-10 w-full max-w-lg flex flex-col gap-3">
+        <ResearchAudienceCTA className="mt-8" />
+
+        <div className="mt-10 flex flex-col gap-3">
           {posts.map((post) => (
             <Link
               key={post.slug}
@@ -83,14 +92,7 @@ export default function BlogPage() {
         {posts.length === 0 && (
           <p className="mt-10 text-xs text-white/20">No posts yet.</p>
         )}
-
-        <Link
-          href="/"
-          className="mt-10 text-xs text-white/30 hover:text-white/50 transition-colors"
-        >
-          &larr; Back to AgentClash
-        </Link>
-      </main>
-    </>
+      </section>
+    </MarketingShell>
   );
 }

--- a/web/src/app/landing.tsx
+++ b/web/src/app/landing.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef } from "react";
 import Link from "next/link";
 import { getCalApi } from "@calcom/embed-react";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
-import { ArrowRight, Calendar, ExternalLink, Star } from "lucide-react";
+import { ArrowRight, ExternalLink, Star } from "lucide-react";
 import {
   Anthropic,
   Gemini,
@@ -15,6 +15,7 @@ import {
   XAI,
 } from "@lobehub/icons";
 import { AuthCtaLink, authCta } from "@/components/marketing/auth-cta-link";
+import { CTAStrip } from "@/components/marketing/cta-strip";
 import { LuminousGrid } from "@/components/marketing/luminous-grid";
 import { PricingBlock } from "@/components/marketing/pricing-block";
 import { ExpandedCardsBlock } from "@/components/marketing/expanded-cards-block";
@@ -23,23 +24,6 @@ import { TryCliBanner } from "@/components/marketing/try-cli-banner";
 import { MatrixMark } from "@/components/marketing/matrix-mark";
 import { COMPARISON_COLUMNS, COMPARISON_ROWS } from "@/lib/comparison-data";
 import { HOME_FAQ } from "@/lib/home-faq";
-
-const DEMO_LINK = "atharva-kanherkar-epgztu/agentclash-demo";
-const DEMO_BUTTON_CONFIG = JSON.stringify({ layout: "month_view" });
-
-function DemoPopupButton({ className }: { className: string }) {
-  return (
-    <button
-      type="button"
-      data-cal-link={DEMO_LINK}
-      data-cal-config={DEMO_BUTTON_CONFIG}
-      className={className}
-    >
-      <Calendar className="size-4" />
-      Book a demo
-    </button>
-  );
-}
 
 function ClashMark({
   className = "",
@@ -1421,6 +1405,7 @@ export default function HomePage({
   // (server-provided returning-visitor hint cookie). The nav link uses the
   // shared <AuthCtaLink>; the hero/closing CTAs reuse just its href.
   const authHref = authCta(returning).href;
+  const authLabel = authCta(returning).label;
 
   useEffect(() => {
     (async () => {
@@ -1541,9 +1526,9 @@ export default function HomePage({
             </h1>
 
             <p className="mt-10 max-w-[46ch] text-lg sm:text-xl leading-[1.5] text-white/55">
-              Race agents head-to-head with the same tools, same constraints,
-              and same time budget. Replay every tool call, score the
-              trajectory, and fail CI when a candidate regresses.
+              Governed head-to-head benchmarks for teams evaluating coding and
+              support agents. Same tools, same constraints — replay every
+              trajectory and gate releases on scorecards leadership can trust.
             </p>
 
             <div className="mt-10 flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3">
@@ -1567,25 +1552,12 @@ export default function HomePage({
                   </a>
                 </>
               ) : (
-                <>
-                  <Link
-                    href={authHref}
-                    className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
-                  >
-                    Start first race
-                    <ArrowRight className="size-4" />
-                  </Link>
-                  <DemoPopupButton className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors" />
-                  <a
-                    href="https://github.com/agentclash/agentclash"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center justify-center gap-2 rounded-md border border-white/[0.08] bg-white/[0.02] px-6 py-3 text-sm font-medium text-white/60 hover:text-white/90 hover:border-white/20 transition-colors"
-                  >
-                    <Star className="size-4" />
-                    GitHub
-                  </a>
-                </>
+                <CTAStrip
+                  variant="demo-first"
+                  demoLabel="Book eval workshop"
+                  secondaryHref={authHref}
+                  secondaryLabel={authLabel}
+                />
               )}
             </div>
           </div>
@@ -2289,9 +2261,9 @@ export default function HomePage({
               <span className="text-white/40">Start racing.</span>
             </h2>
             <p className="mt-6 max-w-[44ch] text-base leading-[1.6] text-white/50">
-              Run open-source, head-to-head AI agent evaluations on real tasks —
-              replay every tool call, score the trajectory, and gate every model
-              in CI.
+              Book an eval workshop to baseline your agents on real workloads —
+              or start racing in the hosted product when your team is ready to
+              self-serve.
             </p>
             <div className="mt-10 flex flex-col sm:flex-row sm:flex-wrap gap-3">
               {user ? (
@@ -2303,16 +2275,12 @@ export default function HomePage({
                   <ArrowRight className="size-4" />
                 </Link>
               ) : (
-                <>
-                  <Link
-                    href={authHref}
-                    className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-7 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
-                  >
-                    Start your first race
-                    <ArrowRight className="size-4" />
-                  </Link>
-                  <DemoPopupButton className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-7 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors" />
-                </>
+                <CTAStrip
+                  variant="demo-first"
+                  demoLabel="Book eval workshop"
+                  secondaryHref={authHref}
+                  secondaryLabel={authLabel}
+                />
               )}
               <a
                 href="https://github.com/agentclash/agentclash"

--- a/web/src/components/marketing/cta-strip.tsx
+++ b/web/src/components/marketing/cta-strip.tsx
@@ -6,6 +6,7 @@ type Variant = "demo-first" | "cli-first" | "github-first";
 
 type Props = {
   variant?: Variant;
+  demoLabel?: string;
   primaryLabel?: string;
   primaryHref?: string;
   secondaryLabel?: string;
@@ -15,6 +16,7 @@ type Props = {
 
 export function CTAStrip({
   variant = "demo-first",
+  demoLabel,
   primaryLabel,
   primaryHref,
   secondaryLabel,
@@ -23,7 +25,7 @@ export function CTAStrip({
 }: Props) {
   const primaryCTA =
     variant === "demo-first" ? (
-      <DemoButton />
+      <DemoButton label={demoLabel} />
     ) : primaryHref ? (
       <Link
         href={primaryHref}

--- a/web/src/components/marketing/research-audience-cta.tsx
+++ b/web/src/components/marketing/research-audience-cta.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { CalEmbedInit } from "./cal-embed-init";
+import { CTAStrip } from "./cta-strip";
+
+const DEFAULT_SECONDARY_HREF = "/platform/agent-evaluation";
+const DEFAULT_SECONDARY_LABEL = "Enterprise evaluation";
+const DEFAULT_DEMO_LABEL = "Book eval workshop";
+
+type Props = {
+  headline?: string;
+  body?: string;
+  demoLabel?: string;
+  secondaryHref?: string;
+  secondaryLabel?: string;
+  showGithub?: boolean;
+  className?: string;
+};
+
+export function ResearchAudienceCTA({
+  headline = "Evaluating agents for your team?",
+  body = "Book a 30-minute eval architecture review. We'll map your workflows to challenge packs, release gates, and a pilot plan.",
+  demoLabel = DEFAULT_DEMO_LABEL,
+  secondaryHref = DEFAULT_SECONDARY_HREF,
+  secondaryLabel = DEFAULT_SECONDARY_LABEL,
+  showGithub = false,
+  className = "",
+}: Props) {
+  return (
+    <aside
+      className={`rounded-lg border border-white/[0.08] bg-white/[0.03] px-5 py-6 sm:px-6 ${className}`}
+    >
+      <CalEmbedInit />
+      {headline ? (
+        <h2 className="text-base font-medium text-white">{headline}</h2>
+      ) : null}
+      {body ? (
+        <p className="mt-2 text-sm leading-relaxed text-white/50">{body}</p>
+      ) : null}
+      <div className="mt-5">
+        <CTAStrip
+          variant="demo-first"
+          demoLabel={demoLabel}
+          secondaryHref={secondaryHref}
+          secondaryLabel={secondaryLabel}
+          showGithub={showGithub}
+        />
+      </div>
+    </aside>
+  );
+}
+
+export function BenchmarkRunCTA({ className }: { className?: string }) {
+  return (
+    <ResearchAudienceCTA
+      headline="Run this benchmark on your agents"
+      body="We'll set up the same challenge pack on your workloads, baseline your current agent, and deliver a scorecard your team can gate on."
+      className={className}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

Implements [#984](https://github.com/agentclash/agentclash/issues/984) under the [#983](https://github.com/agentclash/agentclash/issues/983) organic-traffic strategy: research-stage visitors (blog, benchmarks, homepage) now see **Book eval workshop** as the primary CTA, with **Enterprise evaluation** (`/platform/agent-evaluation`) as secondary—not CLI/auth-first conversion.

- Add reusable `ResearchAudienceCTA` / `BenchmarkRunCTA` (Cal.com embed + `CTAStrip`) and extend `CTAStrip` with `demoLabel`
- **Blog index + posts**: demo panel after intro / article body; pages use `MarketingShell` for consistent chrome
- **Benchmarks hub + reports**: demo CTA after intro; "Run this benchmark on your agents" after scoreboard and article
- **Homepage**: logged-out hero + closing sections use demo-first `CTAStrip`; hero subcopy targets enterprise evaluators

Test contract: `testing/feat-984-enterprise-ctas.md`

## Test plan

- [x] `cd web && pnpm exec vitest run src/app/blog src/app/benchmarks`
- [x] `cd web && pnpm build`
- [ ] Manual: `/blog` — "Book eval workshop" visible before post list; secondary → `/platform/agent-evaluation`
- [ ] Manual: `/blog/{slug}` — CTA panel after article
- [ ] Manual: `/benchmarks` — demo CTA in coming-soon state
- [ ] Manual: `/benchmarks/{slug}` — benchmark-run CTA after scoreboard
- [ ] Manual: `/` logged out — demo button is primary (white); auth is secondary