### PR TITLE
feat(web): revamp /enterprise page UI and ban display font on marketing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,3 +131,7 @@ Do not manually publish for normal releases.
 6. `.github/workflows/release-cli.yml` builds release assets, publishes npm, and runs smoke installs on Ubuntu, macOS, and Windows.
 
 The one-time npm Trusted Publishing bootstrap is documented in `docs/cli-distribution.md`. That bootstrap should not be part of routine releases.
+
+## Marketing site (web/)
+
+When editing public marketing pages under `web/`, read `web/AGENTS.md` first. It bans Instrument Serif (`--font-display`) on new marketing headlines and documents conversion layout patterns.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -1,0 +1,44 @@
+# AGENTS.md (web)
+
+Guidance for AI agents editing the Next.js marketing site under `web/`.
+
+## Typography
+
+### Banned on marketing pages
+
+Do **not** use `--font-display` (`Instrument Serif`) for headlines, hero copy, section titles, or CTAs on marketing pages (`web/src/app/**` routes that are public-facing: landing, `/enterprise`, `/pricing`, `/compare`, `/platform/*`, `/blog`, `/benchmarks`, etc.).
+
+Instrument Serif reads thin and editorial at marketing sizes. It undermines enterprise conversion pages that need crisp, confident hierarchy.
+
+**Use instead:**
+
+- Headlines: `font-sans font-semibold tracking-tight` (Geist). Scale with `text-[clamp(...)]` or `text-3xl sm:text-5xl`.
+- Body: default sans (`text-white/60`, `leading-7`).
+- Labels / eyebrows: `font-mono text-[11px] uppercase tracking-[0.14em] text-white/40`.
+
+`--font-display` remains allowed for the logo wordmark in `marketing-header.tsx` until a deliberate rebrand.
+
+### Copy
+
+- No em dashes (`—`) in marketing copy. Use periods, commas, colons, or parentheses.
+- Headlines: outcome-first ("Ship agents with evidence…"), not category jargon ("Governed agent release gates").
+- Keep paragraphs short (2–3 sentences). Enterprise buyers scan.
+
+## Layout patterns that convert (B2B)
+
+1. Hero: outcome headline + one-sentence proof + primary/secondary CTA + product visual (not abstract cards).
+2. Trust bar: MIT, BYOK, open source, pilot terms near the fold.
+3. Problem or buyer questions: numbered steps or scannable cards with clear hierarchy.
+4. How it works: 3–4 steps max.
+5. Offer block: one focal card for pilot/pricing, not a wall of equal-weight tiles.
+6. FAQ + final CTA with repeated primary action.
+
+Reference implementations: `web/src/app/platform/agent-evaluation/page.tsx`, revamped `web/src/app/enterprise/page.tsx`.
+
+## Commands
+
+```bash
+cd web && pnpm dev
+cd web && pnpm build
+cd web && pnpm exec vitest run src/app/public-canonical-metadata.test.ts src/app/sitemap.test.ts
+```

--- a/web/src/app/enterprise/page.tsx
+++ b/web/src/app/enterprise/page.tsx
@@ -3,79 +3,93 @@ import Link from "next/link";
 import {
   ArrowRight,
   CheckCircle2,
+  GitBranch,
+  Lock,
+  Play,
+  ShieldCheck,
+  Sparkles,
 } from "lucide-react";
 import { CalEmbedInit } from "@/components/marketing/cal-embed-init";
-import { ClosingCTA } from "@/components/marketing/closing-cta";
 import { EnterprisePageCTA } from "@/components/marketing/enterprise-page-cta";
+import { EnterpriseHeroVisual } from "@/components/marketing/enterprise/enterprise-hero-visual";
 import { FAQBlock } from "@/components/marketing/faq-block";
-import { FeatureGrid } from "@/components/marketing/feature-grid";
 import {
   JsonLd,
   breadcrumbSchema,
   productSchema,
 } from "@/components/marketing/json-ld";
 import { MarketingShell } from "@/components/marketing/marketing-shell";
-import { SplitSection } from "@/components/marketing/split-section";
 import { PRICING_TIERS } from "@/lib/pricing-data";
 import { ogImageUrl } from "@/lib/seo";
 
 const PAGE_PATH = "/enterprise";
 const PAGE_TITLE =
-  "Enterprise AI Agent Evaluation — Governed Release Gates | AgentClash";
+  "Enterprise AI Agent Evaluation — Release Gates & Pilot | AgentClash";
 const PAGE_DESCRIPTION =
-  "Prove which agent is safe to ship with governed benchmarks, replay evidence, scorecards, and CI release gates. 45-day Team pilot — no credit card.";
+  "Prove which agent is safe to ship with governed benchmarks, replay evidence, scorecards, and CI release gates. Start a 45-day Team pilot with no credit card.";
 const SOCIAL_IMAGE = ogImageUrl({
   title: "Enterprise Agent Evaluation",
-  subtitle: "Governed release gates for platform teams",
+  subtitle: "Release gates platform teams can defend",
   kind: "Enterprise",
 });
 
 const enterpriseTier = PRICING_TIERS.find((tier) => tier.name === "Enterprise");
 
+const trustItems = [
+  "MIT open source",
+  "Bring your own keys",
+  "45-day Team pilot",
+  "No token markup",
+];
+
 const buyerQuestions = [
   {
-    label: "Trust",
+    num: "01",
     title: "Which agent should we trust?",
-    body: "Compare baseline, candidate, and vendor agents inside one frozen challenge pack — not disconnected eval jobs.",
+    body: "Race baseline, candidate, and vendor agents on the same frozen challenge pack instead of disconnected eval jobs.",
   },
   {
-    label: "Constraints",
-    title: "Under which runtime constraints?",
-    body: "Attach release policy to the benchmark: latency, TTFT, cost ceilings, and automatic fails on policy violations.",
+    num: "02",
+    title: "Under which constraints?",
+    body: "Attach latency, cost, and policy ceilings to the benchmark. Fail the run when a candidate breaks your release rules.",
   },
   {
-    label: "Cost",
+    num: "03",
     title: "At what cost?",
-    body: "See cost per successful task alongside correctness and reliability — not token spend in isolation.",
+    body: "See cost per successful task next to correctness and reliability. Not token spend in isolation.",
   },
   {
-    label: "Evidence",
+    num: "04",
     title: "Why did it fail?",
-    body: "Replay explains divergences: routing fallbacks, tool paths, artifacts, and scorecard axes — not raw log dumps.",
+    body: "Replay shows routing, tool paths, artifacts, and scorecard axes. Not another log dump.",
   },
   {
-    label: "Defense",
+    num: "05",
     title: "Can we defend the decision?",
     body: "Export pass/fail recommendations, scorecards, and redacted evidence for security, finance, and engineering leadership.",
   },
 ];
 
-const productProof = [
+const workflow = [
   {
-    title: "Evidence, not debug logs",
-    body: "Inspect tool trajectories, routing, latency spikes, and artifacts in a replay shaped for ship decisions.",
+    icon: GitBranch,
+    title: "Freeze the benchmark",
+    text: "Version challenge packs and inputs so every run compares against the same approved workload.",
   },
   {
-    title: "Benchmark outcomes you can gate on",
-    body: "Completion, correctness, cost, reliability, and challenge-specific policy checks in one scorecard.",
+    icon: Play,
+    title: "Race candidates",
+    text: "Run agents in sandbox with the same tools, time budget, and scoring rules.",
   },
   {
-    title: "Your workloads, versioned",
-    body: "Freeze challenge packs and input sets so every run compares against the same approved benchmark.",
+    icon: Sparkles,
+    title: "Review replay evidence",
+    text: "Inspect trajectories, artifacts, cost, and scorecards before anyone argues from vibes.",
   },
   {
-    title: "Block regressions before prod",
-    body: "Fail builds when a candidate regresses against baseline on the scorecard your team already trusts.",
+    icon: ShieldCheck,
+    title: "Gate the release",
+    text: "Fail CI when a candidate regresses against baseline on the scorecard your team already trusts.",
   },
 ];
 
@@ -93,12 +107,12 @@ const faqItems = [
   {
     question: "What about data residency for UAE and other regions?",
     answer:
-      "Hosted pilots run on our standard cloud regions today. Enterprise contracts can discuss dedicated deployment, private networking, and residency requirements during the architecture review — contact hello@agentclash.dev.",
+      "Hosted pilots run on our standard cloud regions today. Enterprise contracts can discuss dedicated deployment, private networking, and residency requirements during the architecture review. Contact hello@agentclash.dev.",
   },
   {
     question: "How is the 45-day Team pilot different from a services engagement?",
     answer:
-      "The pilot is product access on the Team tier — your workspace, challenge packs, and gates — with no credit card required. Optional hands-on eval sprints (pack build, benchmark setup) are fixed-scope services; ask us about a 2-week eval sprint intro.",
+      "The pilot is product access on the Team tier: your workspace, challenge packs, and gates, with no credit card required. Optional hands-on eval sprints (pack build, benchmark setup) are fixed-scope services. Ask us about a 2-week eval sprint intro.",
   },
 ];
 
@@ -166,160 +180,224 @@ export default function EnterprisePage() {
         ]}
       />
 
-      <section className="px-6 pt-20 sm:px-12 sm:pt-28">
-        <div className="mx-auto max-w-[1080px]">
-          <nav className="flex items-center gap-2 text-xs text-white/35">
-            <Link href="/" className="transition-colors hover:text-white/70">
-              Home
-            </Link>
-            <span>/</span>
-            <span>Enterprise</span>
-          </nav>
-          <p className="mt-10 font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-normal text-cyan-200/70">
-            Enterprise
-          </p>
-          <h1 className="mt-5 max-w-[18ch] font-[family-name:var(--font-display)] text-4xl font-normal leading-[1.05] tracking-tight text-white sm:text-6xl">
-            Governed agent release gates
-          </h1>
-          <p className="mt-8 max-w-[62ch] text-base leading-8 text-white/62 sm:text-lg">
-            Prove which agent is safe to ship — with replay evidence, scorecards,
-            and CI gates your platform, security, and finance teams can defend.
-            Not another trace dashboard. A benchmark control room for agent trust.
-          </p>
-          <EnterprisePageCTA className="mt-10" />
-        </div>
-      </section>
-
-      <section className="border-t border-white/[0.06] px-6 py-16 sm:px-12 sm:py-24">
-        <div className="mx-auto max-w-[1080px]">
-          <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35">
-            The decision loop
-          </p>
-          <h2 className="mt-4 max-w-[24ch] font-[family-name:var(--font-display)] text-3xl tracking-[-0.02em] text-white sm:text-4xl">
-            Five questions every release needs answered
-          </h2>
-          <p className="mt-4 max-w-[58ch] text-sm leading-relaxed text-white/50">
-            Platform leads and vendor committees do not need another eval score.
-            They need governed evidence that connects benchmark → replay → gate →
-            ship or block.
-          </p>
-        </div>
-        <div className="mt-12">
-          <FeatureGrid features={buyerQuestions} columns={2} />
-        </div>
-      </section>
-
-      <SplitSection
-        eyebrow="Product proof"
-        title="From live run to release gate — one system"
-        body={
-          <>
-            <p>
-              AgentClash turns agent behavior into a decision artifact: frozen
-              challenge versions, sandbox execution, replay, scorecards, and
-              release gates — without stitching traces, evals, and policy in
-              separate tools.
+      <section className="px-6 pt-16 sm:px-12 sm:pt-24">
+        <div className="mx-auto grid max-w-[1200px] gap-14 lg:grid-cols-[1fr_0.95fr] lg:items-center">
+          <div>
+            <nav className="flex items-center gap-2 text-xs text-white/35">
+              <Link href="/" className="transition-colors hover:text-white/70">
+                Home
+              </Link>
+              <span>/</span>
+              <span>Enterprise</span>
+            </nav>
+            <p className="mt-8 font-mono text-[11px] uppercase tracking-[0.14em] text-cyan-200/80">
+              Enterprise evaluation
             </p>
-            <ul className="mt-6 space-y-3 text-sm text-white/55">
-              {productProof.map((item) => (
-                <li key={item.title} className="flex gap-2">
-                  <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-cyan-200/80" />
-                  <span>
-                    <span className="font-medium text-white/80">{item.title}.</span>{" "}
-                    {item.body}
-                  </span>
+            <h1 className="mt-4 max-w-[14ch] text-[clamp(2.25rem,5vw,3.75rem)] font-sans font-semibold leading-[1.08] tracking-[-0.03em] text-white">
+              Ship agents with evidence your team can defend
+            </h1>
+            <p className="mt-6 max-w-[52ch] text-base leading-7 text-white/60 sm:text-lg sm:leading-8">
+              AgentClash turns agent behavior into a release decision: frozen
+              benchmarks, replay, scorecards, and CI gates. Built for platform,
+              security, and vendor review committees, not another trace dashboard.
+            </p>
+            <EnterprisePageCTA className="mt-8" />
+            <ul className="mt-8 flex flex-wrap gap-x-5 gap-y-2 border-t border-white/[0.06] pt-6">
+              {trustItems.map((item) => (
+                <li
+                  key={item}
+                  className="flex items-center gap-2 text-xs text-white/45"
+                >
+                  <CheckCircle2 className="size-3.5 shrink-0 text-emerald-300/80" />
+                  {item}
                 </li>
               ))}
             </ul>
-          </>
-        }
-        aside={
-          enterpriseTier ? (
-            <div className="rounded-lg border border-white/[0.08] bg-white/[0.03] p-6">
-              <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/40">
-                Enterprise tier
-              </p>
-              <p className="mt-3 text-sm leading-relaxed text-white/55">
-                {enterpriseTier.blurb}
-              </p>
-              <ul className="mt-6 space-y-2.5 text-sm text-white/70">
-                {enterpriseTier.features.map((feature) => (
-                  <li key={feature} className="flex gap-2">
-                    <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-emerald-300/80" />
-                    {feature}
-                  </li>
-                ))}
-              </ul>
-              <Link
-                href="/pricing"
-                className="mt-6 inline-flex items-center gap-1.5 text-sm text-cyan-200/80 transition-colors hover:text-cyan-100"
-              >
-                View full pricing
-                <ArrowRight className="size-3.5" />
-              </Link>
-            </div>
-          ) : null
-        }
-      />
-
-      <section className="border-t border-white/[0.06] px-6 py-16 sm:px-12 sm:py-24">
-        <div className="mx-auto max-w-[960px]">
-          <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35">
-            Pilot offer
-          </p>
-          <h2 className="mt-4 font-[family-name:var(--font-display)] text-3xl tracking-[-0.02em] text-white sm:text-4xl">
-            Start with a 45-day Team pilot
-          </h2>
-          <p className="mt-4 max-w-[62ch] text-sm leading-7 text-white/55">
-            Run governed benchmarks on your workloads in a dedicated workspace —
-            challenge packs, replay retention, CI integration, and workspace audit
-            logs. No credit card required.
-          </p>
-          <div className="mt-8 flex flex-col gap-4 sm:flex-row sm:flex-wrap">
-            <Link
-              href="/auth/login?plan=team"
-              className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-medium text-[#060606] hover:bg-white/90 transition-colors"
-            >
-              Start Team pilot
-              <ArrowRight className="size-4" />
-            </Link>
-            <a
-              href="mailto:hello@agentclash.dev?subject=AgentClash%202-week%20eval%20sprint"
-              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 bg-white/[0.04] px-6 py-3 text-sm font-medium text-white/80 hover:text-white hover:border-white/30 transition-colors"
-            >
-              Ask about a 2-week eval sprint
-              <ArrowRight className="size-4" />
-            </a>
           </div>
-          <p className="mt-4 text-xs leading-relaxed text-white/40">
-            Product pilot vs services: the Team pilot is self-serve product access.
-            Fixed-scope eval sprints (pack build, benchmark setup) are optional
-            services engagements — we&apos;ll scope them on the architecture review.
+          <EnterpriseHeroVisual />
+        </div>
+      </section>
+
+      <section className="border-t border-white/[0.06] px-6 py-20 sm:px-12 sm:py-28">
+        <div className="mx-auto max-w-[1200px]">
+          <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-white/40">
+            Release committee
           </p>
+          <h2 className="mt-3 max-w-[20ch] text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+            Five questions every agent release needs answered
+          </h2>
+          <p className="mt-4 max-w-[56ch] text-sm leading-7 text-white/55 sm:text-base">
+            Platform leads do not need another leaderboard. They need governed
+            evidence that connects benchmark, replay, gate, and ship or block.
+          </p>
+          <ol className="mt-12 grid gap-4 sm:grid-cols-2">
+            {buyerQuestions.map((item) => (
+              <li
+                key={item.num}
+                className="group relative overflow-hidden rounded-xl border border-white/[0.08] bg-gradient-to-br from-white/[0.04] to-transparent p-6 transition-colors hover:border-white/[0.14]"
+              >
+                <span className="font-mono text-[11px] tabular-nums text-cyan-200/70">
+                  {item.num}
+                </span>
+                <h3 className="mt-3 text-lg font-semibold tracking-tight text-white">
+                  {item.title}
+                </h3>
+                <p className="mt-2 text-sm leading-6 text-white/55">{item.body}</p>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
+
+      <section className="border-t border-white/[0.06] px-6 py-20 sm:px-12 sm:py-28">
+        <div className="mx-auto max-w-[1200px]">
+          <div className="grid gap-12 lg:grid-cols-[0.85fr_1.15fr] lg:items-start">
+            <div>
+              <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-white/40">
+                How it works
+              </p>
+              <h2 className="mt-3 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+                From live run to release gate in one system
+              </h2>
+              <p className="mt-4 text-sm leading-7 text-white/55 sm:text-base">
+                No stitching traces, eval spreadsheets, and policy docs in
+                separate tools. AgentClash produces one decision artifact your
+                team can gate on.
+              </p>
+              {enterpriseTier ? (
+                <div className="mt-10 rounded-xl border border-white/[0.08] bg-white/[0.03] p-6">
+                  <div className="flex items-center gap-2">
+                    <Lock className="size-4 text-white/50" />
+                    <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-white/45">
+                      Enterprise tier
+                    </p>
+                  </div>
+                  <p className="mt-3 text-sm leading-relaxed text-white/55">
+                    {enterpriseTier.blurb}
+                  </p>
+                  <ul className="mt-5 space-y-2.5 text-sm text-white/75">
+                    {enterpriseTier.features.map((feature) => (
+                      <li key={feature} className="flex gap-2">
+                        <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-emerald-300/80" />
+                        {feature}
+                      </li>
+                    ))}
+                  </ul>
+                  <Link
+                    href="/pricing"
+                    className="mt-6 inline-flex items-center gap-1.5 text-sm font-medium text-cyan-200/90 transition-colors hover:text-cyan-100"
+                  >
+                    View full pricing
+                    <ArrowRight className="size-3.5" />
+                  </Link>
+                </div>
+              ) : null}
+            </div>
+            <ol className="space-y-4">
+              {workflow.map((step, index) => {
+                const Icon = step.icon;
+                return (
+                  <li
+                    key={step.title}
+                    className="flex gap-4 rounded-xl border border-white/[0.08] bg-[#0a0a0a] p-5"
+                  >
+                    <div className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-white/[0.1] bg-white/[0.04]">
+                      <Icon className="size-4 text-white/70" strokeWidth={1.5} />
+                    </div>
+                    <div>
+                      <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-white/35">
+                        Step {index + 1}
+                      </p>
+                      <h3 className="mt-1 text-base font-semibold text-white">
+                        {step.title}
+                      </h3>
+                      <p className="mt-1.5 text-sm leading-6 text-white/55">
+                        {step.text}
+                      </p>
+                    </div>
+                  </li>
+                );
+              })}
+            </ol>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-white/[0.06] px-6 py-20 sm:px-12">
+        <div className="mx-auto max-w-[960px]">
+          <div className="overflow-hidden rounded-2xl border border-white/[0.1] bg-gradient-to-br from-cyan-500/[0.08] via-transparent to-transparent p-8 sm:p-10">
+            <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-cyan-200/80">
+              Pilot offer
+            </p>
+            <h2 className="mt-3 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+              Start with a 45-day Team pilot
+            </h2>
+            <p className="mt-4 max-w-[58ch] text-sm leading-7 text-white/60 sm:text-base">
+              Run governed benchmarks on your workloads in a dedicated workspace:
+              challenge packs, replay retention, CI integration, and workspace
+              audit logs. No credit card required.
+            </p>
+            <ul className="mt-6 grid gap-2 sm:grid-cols-2">
+              {[
+                "Dedicated workspace on Team tier",
+                "Challenge packs and replay retention",
+                "CI integration and audit logs",
+                "Architecture review with our team",
+              ].map((item) => (
+                <li key={item} className="flex gap-2 text-sm text-white/70">
+                  <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-emerald-300/80" />
+                  {item}
+                </li>
+              ))}
+            </ul>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+              <Link
+                href="/auth/login?plan=team"
+                className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3.5 text-sm font-semibold text-[#060606] transition-colors hover:bg-white/90"
+              >
+                Start Team pilot
+                <ArrowRight className="size-4" />
+              </Link>
+              <a
+                href="mailto:hello@agentclash.dev?subject=AgentClash%202-week%20eval%20sprint"
+                className="inline-flex items-center justify-center gap-2 rounded-lg border border-white/20 bg-black/20 px-6 py-3.5 text-sm font-medium text-white/85 transition-colors hover:border-white/35 hover:text-white"
+              >
+                Ask about a 2-week eval sprint
+                <ArrowRight className="size-4" />
+              </a>
+            </div>
+            <p className="mt-5 text-xs leading-relaxed text-white/45">
+              The Team pilot is self-serve product access. Fixed-scope eval
+              sprints are optional services we scope on the architecture review.
+            </p>
+          </div>
         </div>
       </section>
 
       <section className="border-t border-white/[0.06] px-6 py-16 sm:px-12">
         <div className="mx-auto max-w-[960px]">
-          <p className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.14em] text-white/35">
+          <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-white/40">
             Explore
           </p>
-          <h2 className="mt-4 text-2xl font-semibold tracking-tight text-white sm:text-3xl">
+          <h2 className="mt-3 text-2xl font-semibold tracking-tight text-white sm:text-3xl">
             Related resources
           </h2>
-          <ul className="mt-8 grid gap-4 sm:grid-cols-2">
+          <ul className="mt-8 grid gap-3 sm:grid-cols-2">
             {crossLinks.map((link) => (
               <li key={link.href}>
                 <Link
                   href={link.href}
-                  className="group flex h-full flex-col rounded-lg border border-white/[0.08] bg-white/[0.03] px-5 py-4 transition-colors hover:border-white/15"
+                  className="group flex h-full items-start justify-between gap-4 rounded-xl border border-white/[0.08] bg-white/[0.02] px-5 py-4 transition-all hover:border-white/16 hover:bg-white/[0.04]"
                 >
-                  <span className="text-sm font-medium text-white group-hover:text-white/90">
-                    {link.label}
-                  </span>
-                  <span className="mt-2 text-xs leading-relaxed text-white/45">
-                    {link.description}
-                  </span>
+                  <div>
+                    <span className="text-sm font-semibold text-white group-hover:text-white">
+                      {link.label}
+                    </span>
+                    <span className="mt-1.5 block text-xs leading-relaxed text-white/45">
+                      {link.description}
+                    </span>
+                  </div>
+                  <ArrowRight className="mt-0.5 size-4 shrink-0 text-white/30 transition-transform group-hover:translate-x-0.5 group-hover:text-white/60" />
                 </Link>
               </li>
             ))}
@@ -332,20 +410,21 @@ export default function EnterprisePage() {
         eyebrow="FAQ"
         title="Enterprise evaluation questions"
         items={faqItems}
+        sansHeadlines
       />
 
-      <ClosingCTA
-        title={
-          <>
-            Ready to gate
-            <br />
-            <span className="text-white/40">your next agent release?</span>
-          </>
-        }
-        body="Book a 30-minute eval architecture review or email us to scope a Team pilot on your workloads."
-      >
-        <EnterprisePageCTA />
-      </ClosingCTA>
+      <section className="border-t border-white/[0.06] px-6 py-20 sm:px-12 sm:py-28">
+        <div className="mx-auto max-w-[960px]">
+          <h2 className="max-w-[16ch] text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+            Ready to gate your next agent release?
+          </h2>
+          <p className="mt-4 max-w-[52ch] text-base leading-7 text-white/55">
+            Book a 30-minute eval architecture review or email us to scope a Team
+            pilot on your workloads.
+          </p>
+          <EnterprisePageCTA className="mt-8" />
+        </div>
+      </section>
     </MarketingShell>
   );
 }

--- a/web/src/components/marketing/enterprise/enterprise-hero-visual.tsx
+++ b/web/src/components/marketing/enterprise/enterprise-hero-visual.tsx
@@ -1,0 +1,63 @@
+import { ShieldCheck } from "lucide-react";
+
+const gateRows = [
+  { agent: "baseline-gpt-4.1", score: "94", status: "pass", delta: "baseline" },
+  { agent: "candidate-claude", score: "91", status: "pass", delta: "+2 cost" },
+  { agent: "vendor-preview", score: "78", status: "fail", delta: "-12 correctness" },
+];
+
+export function EnterpriseHeroVisual() {
+  return (
+    <div className="relative overflow-hidden rounded-xl border border-white/[0.1] bg-[#0a0a0a] p-1 shadow-[0_24px_80px_rgba(0,0,0,0.45)]">
+      <div className="rounded-[10px] border border-white/[0.06] bg-gradient-to-b from-white/[0.04] to-transparent px-5 py-4">
+        <div className="flex items-center justify-between gap-4 border-b border-white/[0.06] pb-4">
+          <div>
+            <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-white/40">
+              Release gate preview
+            </p>
+            <p className="mt-1 text-sm font-medium text-white/90">
+              refund-recovery-v3
+            </p>
+          </div>
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-amber-400/25 bg-amber-400/10 px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-amber-200">
+            <ShieldCheck className="size-3" />
+            Block candidate
+          </span>
+        </div>
+        <div className="mt-4 space-y-2">
+          {gateRows.map((row) => (
+            <div
+              key={row.agent}
+              className="flex items-center justify-between gap-3 rounded-md border border-white/[0.06] bg-black/40 px-3 py-2.5"
+            >
+              <div className="min-w-0">
+                <p className="truncate font-mono text-[11px] text-white/75">
+                  {row.agent}
+                </p>
+                <p className="mt-0.5 text-[10px] text-white/35">{row.delta}</p>
+              </div>
+              <div className="flex items-center gap-3 shrink-0">
+                <span className="font-mono text-sm tabular-nums text-white/80">
+                  {row.score}
+                </span>
+                <span
+                  className={`rounded px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.1em] ${
+                    row.status === "pass"
+                      ? "bg-emerald-400/10 text-emerald-300"
+                      : "bg-red-400/10 text-red-300"
+                  }`}
+                >
+                  {row.status}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+        <p className="mt-4 text-[11px] leading-relaxed text-white/40">
+          Scorecard, replay, and policy checks in one gate verdict your team can
+          export.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/marketing/faq-block.tsx
+++ b/web/src/components/marketing/faq-block.tsx
@@ -7,6 +7,8 @@ type Props = {
   eyebrow?: string;
   items: FAQ[];
   schemaId: string;
+  /** Use Geist sans for FAQ headings (required on /enterprise and new marketing pages). */
+  sansHeadlines?: boolean;
 };
 
 export function FAQBlock({
@@ -14,7 +16,14 @@ export function FAQBlock({
   eyebrow = "FAQ",
   items,
   schemaId,
+  sansHeadlines = false,
 }: Props) {
+  const sectionTitleClass = sansHeadlines
+    ? "text-3xl font-semibold tracking-tight text-white sm:text-4xl max-w-[22ch]"
+    : "font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2.25rem,5vw,4rem)] max-w-[22ch]";
+  const questionClass = sansHeadlines
+    ? "text-lg font-semibold tracking-tight text-white/90 sm:text-xl"
+    : "font-[family-name:var(--font-display)] text-[18px] sm:text-[22px] leading-[1.3] tracking-[-0.01em] text-white/90";
   return (
     <section className="border-t border-white/[0.06] px-8 sm:px-12 py-32 sm:py-48">
       <JsonLd id={schemaId} data={faqSchema(items)} />
@@ -23,14 +32,14 @@ export function FAQBlock({
           <span className="inline-block size-1 rounded-full bg-white/60" />
           {eyebrow}
         </p>
-        <h2 className="font-[family-name:var(--font-display)] font-normal tracking-[-0.03em] leading-[1.02] text-[clamp(2.25rem,5vw,4rem)] max-w-[22ch]">
+        <h2 className={sectionTitleClass}>
           {title}
         </h2>
 
         <dl className="mt-16 divide-y divide-white/[0.08] border-y border-white/[0.08]">
           {items.map((qa) => (
             <div key={qa.question} className="py-8">
-              <dt className="font-[family-name:var(--font-display)] text-[18px] sm:text-[22px] leading-[1.3] tracking-[-0.01em] text-white/90">
+              <dt className={questionClass}>
                 {qa.question}
               </dt>
               <dd className="mt-3 max-w-[68ch] text-[14px] sm:text-[15px] leading-[1.7] text-white/55">


### PR DESCRIPTION
## Summary
- Adds `web/AGENTS.md` banning `--font-display` (Instrument Serif) on marketing headlines; links from root `AGENTS.md`
- Rebuilds `/enterprise` for B2B conversion: outcome-first sans hero, trust bar, numbered buyer cards, workflow steps, focal pilot offer, arrow cross-links, sans FAQ/closing
- Adds `EnterpriseHeroVisual` (release gate preview mock) and `sansHeadlines` option on `FAQBlock` for enterprise use

## Design rationale
- Instrument Serif at marketing sizes read thin/editorial; enterprise pages follow platform/pricing patterns (Geist semibold, tight tracking)
- Removed em dashes from copy; shorter scannable sections aligned with common B2B landing hierarchy (hero → trust → questions → workflow → offer → FAQ → CTA)

## Test plan
- [x] `cd web && pnpm exec vitest run src/app/public-canonical-metadata.test.ts src/app/sitemap.test.ts`
- [x] `cd web && pnpm build`
- [ ] Manual: https://www.agentclash.dev/enterprise (after deploy) — hero visual, card hierarchy, CTAs, no serif headlines
- [ ] Manual: FAQ and closing sections use sans typography