### PR TITLE
feat(web): add /services eval program page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ testing/*
 !testing/feat-integration-all-hosts.md
 !testing/feat-984-enterprise-ctas.md
 !testing/feat-985-enterprise-page.md
+!testing/feat-services-eval-program.md

--- a/testing/feat-services-eval-program.md
+++ b/testing/feat-services-eval-program.md
@@ -1,0 +1,48 @@
+# feat/services-eval-program — Test Contract
+
+## Functional Behavior
+
+- `/services` is a public marketing page that productizes AgentClash adoption services (not generic consulting).
+- Hero states: AgentClash is the platform; our team gets you to a first governed benchmark in 2 weeks.
+- Four fixed offerings are listed with explicit duration, deliverable, and qualification criteria:
+  1. **Eval Discovery** (1 week): audit agents, 5 failure modes, pack roadmap
+  2. **Challenge Pack Build** (2–4 weeks): 3–10 custom packs from real workflows
+  3. **Benchmark & Gate Setup** (2 weeks): baseline run, CI gate, exec scorecard template
+  4. **Managed Eval Retainer** (monthly): release benchmarks + reliability report
+- Guardrails section: every engagement produces customer-owned packs, baseline evidence, gate policy, or CI handoff in the customer workspace.
+- Intake section lists what discovery captures: agent workflow, failure examples, compliance constraints, target release decision, current tooling, success criteria.
+- CTAs: Book discovery call (Cal.com embed) and email `hello@agentclash.dev`.
+- Cross-links to `/enterprise` (pilot) and `/pricing`.
+- Typography follows `web/AGENTS.md`: sans headlines, no Instrument Serif, no em dashes in copy.
+
+## Unit Tests
+
+- `public-canonical-metadata.test.ts` — `/services` metadata has canonical `/services`.
+- `sitemap.test.ts` — `/services` appears in sitemap with monthly changeFrequency and priority ≥ 0.75.
+
+## Integration / Functional Tests
+
+- Enterprise page links to `/services` from pilot/services context.
+- Blog post CTA (`ResearchAudienceCTA`) includes a path to `/services` for eval workshop buyers.
+
+## Smoke Tests
+
+- `cd web && pnpm build` completes without errors.
+- `cd web && pnpm exec vitest run src/app/public-canonical-metadata.test.ts src/app/sitemap.test.ts` passes.
+
+## E2E Tests
+
+N/A — static marketing page; manual browser check of `/services` layout and CTAs.
+
+## Manual / cURL Tests
+
+```bash
+cd web && pnpm build
+cd web && pnpm exec vitest run src/app/public-canonical-metadata.test.ts src/app/sitemap.test.ts
+```
+
+- Open `http://localhost:3000/services` and verify:
+  - Four offering cards with duration + deliverable
+  - Guardrails and intake sections visible
+  - Primary CTA opens Cal.com; secondary mailto works
+  - Links to `/enterprise` and `/pricing` resolve

--- a/web/src/app/blog/[slug]/page.tsx
+++ b/web/src/app/blog/[slug]/page.tsx
@@ -120,7 +120,9 @@ export default async function BlogPostPage({ params }: Props) {
         <ResearchAudienceCTA
           className="mt-12"
           headline="Ready to evaluate agents on your workloads?"
-          body="Book an eval workshop to map your agents to challenge packs, baselines, and release gates — or explore how enterprise teams run governed evals on AgentClash."
+          body="Book an eval workshop to map your agents to challenge packs, baselines, and release gates. Or see fixed-scope eval services and the enterprise pilot."
+          secondaryHref="/services"
+          secondaryLabel="Eval services"
         />
       </article>
     </MarketingShell>

--- a/web/src/app/enterprise/page.tsx
+++ b/web/src/app/enterprise/page.tsx
@@ -134,6 +134,11 @@ const crossLinks = [
     label: "Pricing",
     description: "Free, Pro, Team, and custom Enterprise tiers.",
   },
+  {
+    href: "/services",
+    label: "Eval services",
+    description: "Fixed-scope pack build, benchmark setup, and managed eval retainers.",
+  },
 ];
 
 export const metadata: Metadata = {
@@ -352,7 +357,14 @@ export default function EnterprisePage() {
             </div>
             <p className="mt-6 max-w-[64ch] text-sm leading-6 text-white/45">
               The Team pilot is self-serve product access. Fixed-scope eval
-              sprints are optional services we scope on the architecture review.
+              sprints are optional{" "}
+              <Link
+                href="/services"
+                className="text-white/65 underline decoration-white/20 underline-offset-4 transition-colors hover:text-white/85"
+              >
+                services packages
+              </Link>{" "}
+              we scope on the architecture review.
             </p>
           </div>
         </div>

--- a/web/src/app/public-canonical-metadata.test.ts
+++ b/web/src/app/public-canonical-metadata.test.ts
@@ -7,6 +7,7 @@ import { generateMetadata as generateBenchmarksIndexMetadata } from "./benchmark
 import { generateMetadata as generateBenchmarkMetadata } from "./benchmarks/[slug]/page";
 import { generateMetadata as generateDocsMetadata } from "./docs/[[...slug]]/page";
 import { metadata as enterpriseMetadata } from "./enterprise/page";
+import { metadata as servicesMetadata } from "./services/page";
 import { metadata as agentEvaluationMetadata } from "./platform/agent-evaluation/page";
 import { metadata as agentRegressionTestingMetadata } from "./platform/agent-regression-testing/page";
 import { metadata as sitemapMetadata } from "./sitemap/page";
@@ -61,6 +62,7 @@ describe("public canonical metadata", () => {
     expectCanonical(blogMetadata, "/blog");
     expectCanonical(generateBenchmarksIndexMetadata(), "/benchmarks");
     expectCanonical(enterpriseMetadata, "/enterprise");
+    expectCanonical(servicesMetadata, "/services");
     expectCanonical(agentEvaluationMetadata, "/platform/agent-evaluation");
     expectCanonical(
       agentRegressionTestingMetadata,

--- a/web/src/app/services/page.tsx
+++ b/web/src/app/services/page.tsx
@@ -63,7 +63,7 @@ const offerings = [
 const guardrails = [
   "Every engagement produces artifacts in your AgentClash workspace: packs, baselines, gates, or CI handoff.",
   "We do not run black-box evals outside your tenancy. You own the packs and the evidence.",
-  "Services accelerate platform adoption. The 45-day Team pilot on /enterprise is still the default starting path.",
+  "Services are paid engagements. The free 45-day Team pilot is still the default path if you want to self-serve first.",
   "No vague SOWs. Each package above has a fixed duration and named deliverable.",
 ];
 
@@ -119,6 +119,11 @@ const faqItems = [
     question: "What do you need before discovery?",
     answer:
       "A short description of the agent workflow, one or two real failure examples, and who signs the release decision. We handle the rest on the first call.",
+  },
+  {
+    question: "Are services free?",
+    answer:
+      "No. The four packages above are paid, fixed-scope engagements. The discovery call is free. Product access starts free on the Team pilot and paid tiers on the pricing page.",
   },
 ];
 
@@ -184,6 +189,16 @@ export default function ServicesPage() {
             frozen challenge packs, baseline evidence, and CI gates in your
             workspace. Fixed offerings, not open-ended consulting.
           </p>
+          <p className="mt-4 max-w-[58ch] text-sm leading-6 text-white/45">
+            These packages are paid engagements, scoped after discovery. The{" "}
+            <Link
+              href="/enterprise"
+              className="text-white/65 underline decoration-white/20 underline-offset-4 transition-colors hover:text-white/85"
+            >
+              Team pilot
+            </Link>{" "}
+            is free self-serve product access if you want to start on your own.
+          </p>
           <EnterprisePageCTA className="mt-10" />
         </div>
       </section>
@@ -195,8 +210,9 @@ export default function ServicesPage() {
             Four fixed packages
           </h2>
           <p className="mt-5 max-w-[56ch] text-base leading-7 text-white/55">
-            Each engagement ends with customer-owned artifacts in your
-            workspace. Pick the scope that matches where you are today.
+            Each package is a paid, fixed-scope engagement that ends with
+            customer-owned artifacts in your workspace. We quote scope on
+            discovery; no public rate card.
           </p>
           <ul className="mt-14 grid gap-px overflow-hidden rounded-xl border border-white/[0.08] bg-white/[0.08] sm:grid-cols-2">
             {offerings.map((offering) => (
@@ -252,8 +268,8 @@ export default function ServicesPage() {
             What we capture on the first call
           </h2>
           <p className="mt-5 max-w-[56ch] text-base leading-7 text-white/55">
-            A 30-minute discovery maps your agents to the right package. Bring
-            what you have; we structure the benchmark plan.
+            A free 30-minute discovery maps your agents to the right package and
+            quotes scope. Bring what you have; we structure the benchmark plan.
           </p>
           <ul className="mt-10 grid gap-3 sm:grid-cols-2">
             {intakeFields.map((field) => (

--- a/web/src/app/services/page.tsx
+++ b/web/src/app/services/page.tsx
@@ -1,0 +1,328 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { CalEmbedInit } from "@/components/marketing/cal-embed-init";
+import { EnterprisePageCTA } from "@/components/marketing/enterprise-page-cta";
+import { FAQBlock } from "@/components/marketing/faq-block";
+import {
+  JsonLd,
+  breadcrumbSchema,
+  productSchema,
+} from "@/components/marketing/json-ld";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { ogImageUrl } from "@/lib/seo";
+
+const PAGE_PATH = "/services";
+const PAGE_TITLE = "Agent Evaluation Services — Fixed Offerings | AgentClash";
+const PAGE_DESCRIPTION =
+  "Fixed-scope eval services that end in customer-owned challenge packs, baselines, and CI gates. First governed benchmark in 2 weeks on the AgentClash platform.";
+const SOCIAL_IMAGE = ogImageUrl({
+  title: "Agent Evaluation Services",
+  subtitle: "Platform adoption, not generic consulting",
+  kind: "Services",
+});
+
+const offerings = [
+  {
+    id: "eval-discovery",
+    name: "Eval Discovery",
+    duration: "1 week",
+    deliverable:
+      "Audit your agents, document 5 concrete failure modes, and deliver a prioritized challenge pack roadmap.",
+    fit: "You have agents in production but no frozen benchmark yet.",
+    emailSubject: "AgentClash%20Eval%20Discovery",
+  },
+  {
+    id: "challenge-pack-build",
+    name: "Challenge Pack Build",
+    duration: "2 to 4 weeks",
+    deliverable:
+      "Ship 3–10 custom challenge packs from your real workflows, scored and versioned in your workspace.",
+    fit: "You know what to test and need packs built from live tasks and tools.",
+    emailSubject: "AgentClash%20Challenge%20Pack%20Build",
+  },
+  {
+    id: "benchmark-gate-setup",
+    name: "Benchmark & Gate Setup",
+    duration: "2 weeks",
+    deliverable:
+      "Run a baseline, wire a CI release gate, and hand off an executive scorecard template your committee can defend.",
+    fit: "You have packs and need a governed release decision in CI.",
+    emailSubject: "AgentClash%20Benchmark%20%26%20Gate%20Setup",
+  },
+  {
+    id: "managed-eval-retainer",
+    name: "Managed Eval Retainer",
+    duration: "Monthly",
+    deliverable:
+      "Release benchmarks on every ship candidate plus a monthly reliability report with regression trends.",
+    fit: "You ship agents often and want ongoing benchmark coverage without building an eval team.",
+    emailSubject: "AgentClash%20Managed%20Eval%20Retainer",
+  },
+] as const;
+
+const guardrails = [
+  "Every engagement produces artifacts in your AgentClash workspace: packs, baselines, gates, or CI handoff.",
+  "We do not run black-box evals outside your tenancy. You own the packs and the evidence.",
+  "Services accelerate platform adoption. The 45-day Team pilot on /enterprise is still the default starting path.",
+  "No vague SOWs. Each package above has a fixed duration and named deliverable.",
+];
+
+const intakeFields = [
+  "Agent workflow and tools in scope",
+  "Recent failure examples or incident tickets",
+  "Compliance, residency, or policy constraints",
+  "Target release decision and stakeholders",
+  "Current eval or observability tooling",
+  "Success criteria for the first governed benchmark",
+];
+
+const crossLinks = [
+  {
+    href: "/enterprise",
+    label: "Enterprise pilot",
+    description: "45-day Team pilot with no credit card. Self-serve product access first.",
+  },
+  {
+    href: "/pricing",
+    label: "Product pricing",
+    description: "Free, Pro, Team, and Enterprise tiers. BYOK on every plan.",
+  },
+  {
+    href: "/platform/agent-evaluation",
+    label: "Evaluation platform",
+    description: "Same-tools races, sandbox execution, replay, and scorecards.",
+  },
+  {
+    href: "/docs",
+    label: "Documentation",
+    description: "Challenge packs, CI gates, and self-host guides.",
+  },
+];
+
+const faqItems = [
+  {
+    question: "How is this different from the Team pilot?",
+    answer:
+      "The Team pilot is product access in your workspace. Services are fixed-scope engagements where our team builds packs, baselines, or gates with you. Many teams start the pilot and add a 2-week Benchmark & Gate Setup sprint.",
+  },
+  {
+    question: "Do we keep the challenge packs after the engagement?",
+    answer:
+      "Yes. All packs, baselines, scorecards, and gate configs live in your workspace. You can extend them without us.",
+  },
+  {
+    question: "Can we self-host instead of hosted AgentClash?",
+    answer:
+      "Yes. AgentClash is MIT-licensed. We can deliver packs and gate templates against your self-hosted stack. Discuss deployment during discovery.",
+  },
+  {
+    question: "What do you need before discovery?",
+    answer:
+      "A short description of the agent workflow, one or two real failure examples, and who signs the release decision. We handle the rest on the first call.",
+  },
+];
+
+export const metadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  alternates: { canonical: PAGE_PATH },
+  openGraph: {
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: PAGE_PATH,
+    type: "website",
+    locale: "en_US",
+    siteName: "AgentClash",
+    images: [{ url: SOCIAL_IMAGE, width: 1200, height: 630, alt: PAGE_TITLE }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    images: [{ url: SOCIAL_IMAGE, alt: PAGE_TITLE }],
+  },
+};
+
+const eyebrowClass =
+  "font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.16em] text-white/40";
+
+export default function ServicesPage() {
+  return (
+    <MarketingShell>
+      <CalEmbedInit />
+      <JsonLd
+        id="agentclash-services-schema"
+        data={[
+          breadcrumbSchema([
+            { name: "Home", url: "/" },
+            { name: "Services", url: PAGE_PATH },
+          ]),
+          productSchema({
+            name: "AgentClash Evaluation Services",
+            description: PAGE_DESCRIPTION,
+            url: `https://www.agentclash.dev${PAGE_PATH}`,
+            applicationSubCategory: "AI agent evaluation services",
+          }),
+        ]}
+      />
+
+      <section className="px-6 pt-20 sm:px-12 sm:pt-32">
+        <div className="mx-auto max-w-[960px]">
+          <nav className="flex items-center gap-2 text-xs text-white/35">
+            <Link href="/" className="transition-colors hover:text-white/70">
+              Home
+            </Link>
+            <span aria-hidden>/</span>
+            <span>Services</span>
+          </nav>
+          <p className={`mt-12 ${eyebrowClass}`}>Eval program</p>
+          <h1 className="mt-6 max-w-[18ch] text-[clamp(2.25rem,5.5vw,4rem)] font-sans font-semibold leading-[1.06] tracking-[-0.03em] text-white">
+            First governed benchmark in 2 weeks
+          </h1>
+          <p className="mt-8 max-w-[58ch] text-lg leading-8 text-white/60">
+            AgentClash is the platform. Our team gets you from live agents to
+            frozen challenge packs, baseline evidence, and CI gates in your
+            workspace. Fixed offerings, not open-ended consulting.
+          </p>
+          <EnterprisePageCTA className="mt-10" />
+        </div>
+      </section>
+
+      <section className="px-6 pt-28 sm:px-12 sm:pt-40">
+        <div className="mx-auto max-w-[1080px]">
+          <p className={eyebrowClass}>Offerings</p>
+          <h2 className="mt-4 max-w-[20ch] text-3xl font-sans font-semibold tracking-[-0.02em] text-white sm:text-[2.5rem] sm:leading-[1.1]">
+            Four fixed packages
+          </h2>
+          <p className="mt-5 max-w-[56ch] text-base leading-7 text-white/55">
+            Each engagement ends with customer-owned artifacts in your
+            workspace. Pick the scope that matches where you are today.
+          </p>
+          <ul className="mt-14 grid gap-px overflow-hidden rounded-xl border border-white/[0.08] bg-white/[0.08] sm:grid-cols-2">
+            {offerings.map((offering) => (
+              <li key={offering.id} className="bg-[#060606]">
+                <div className="flex h-full flex-col px-6 py-7 sm:px-7">
+                  <div className="flex flex-wrap items-baseline justify-between gap-3">
+                    <h3 className="text-lg font-sans font-semibold tracking-[-0.01em] text-white">
+                      {offering.name}
+                    </h3>
+                    <span className="font-[family-name:var(--font-mono)] text-[11px] uppercase tracking-[0.12em] text-white/40">
+                      {offering.duration}
+                    </span>
+                  </div>
+                  <p className="mt-4 text-base leading-7 text-white/65">
+                    {offering.deliverable}
+                  </p>
+                  <p className="mt-4 text-sm leading-6 text-white/45">
+                    Best when: {offering.fit}
+                  </p>
+                  <a
+                    href={`mailto:hello@agentclash.dev?subject=${offering.emailSubject}`}
+                    className="mt-6 inline-flex text-sm font-medium text-white/70 underline decoration-white/20 underline-offset-4 transition-colors hover:text-white hover:decoration-white/50"
+                  >
+                    Email about {offering.name}
+                  </a>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      <section className="px-6 pt-28 sm:px-12 sm:pt-40">
+        <div className="mx-auto max-w-[960px]">
+          <p className={eyebrowClass}>Guardrails</p>
+          <h2 className="mt-4 max-w-[22ch] text-3xl font-sans font-semibold tracking-[-0.02em] text-white sm:text-[2.25rem] sm:leading-[1.1]">
+            Platform adoption, not a consulting shop
+          </h2>
+          <ul className="mt-10 divide-y divide-white/[0.08] border-t border-white/[0.08]">
+            {guardrails.map((item) => (
+              <li key={item} className="py-5 text-base leading-7 text-white/60">
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      <section className="px-6 pt-28 sm:px-12 sm:pt-40">
+        <div className="mx-auto max-w-[960px]">
+          <p className={eyebrowClass}>Discovery intake</p>
+          <h2 className="mt-4 max-w-[20ch] text-3xl font-sans font-semibold tracking-[-0.02em] text-white sm:text-[2.25rem] sm:leading-[1.1]">
+            What we capture on the first call
+          </h2>
+          <p className="mt-5 max-w-[56ch] text-base leading-7 text-white/55">
+            A 30-minute discovery maps your agents to the right package. Bring
+            what you have; we structure the benchmark plan.
+          </p>
+          <ul className="mt-10 grid gap-3 sm:grid-cols-2">
+            {intakeFields.map((field) => (
+              <li
+                key={field}
+                className="rounded-lg border border-white/[0.08] bg-white/[0.02] px-4 py-3.5 text-sm leading-6 text-white/70"
+              >
+                {field}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      <section className="px-6 pt-28 sm:px-12 sm:pt-40">
+        <div className="mx-auto max-w-[1080px]">
+          <p className={eyebrowClass}>Explore</p>
+          <h2 className="mt-4 text-2xl font-sans font-semibold tracking-[-0.02em] text-white sm:text-3xl">
+            Product paths
+          </h2>
+          <ul className="mt-10 grid gap-px overflow-hidden rounded-xl border border-white/[0.08] bg-white/[0.08] sm:grid-cols-2">
+            {crossLinks.map((link) => (
+              <li key={link.href}>
+                <Link
+                  href={link.href}
+                  className="flex h-full flex-col bg-[#060606] px-6 py-6 transition-colors hover:bg-white/[0.025]"
+                >
+                  <span className="text-base font-sans font-semibold text-white">
+                    {link.label}
+                  </span>
+                  <span className="mt-2 text-sm leading-6 text-white/45">
+                    {link.description}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      <div className="mt-28 sm:mt-40">
+        <FAQBlock
+          schemaId="agentclash-services-faq-schema"
+          eyebrow="FAQ"
+          title="Eval services questions"
+          items={faqItems}
+          sansHeadlines
+        />
+      </div>
+
+      <section className="border-t border-white/[0.06] px-6 py-28 sm:px-12 sm:py-40">
+        <div className="mx-auto max-w-[960px]">
+          <h2 className="max-w-[18ch] text-[clamp(2rem,4.5vw,3.25rem)] font-sans font-semibold leading-[1.08] tracking-[-0.03em] text-white">
+            Book a discovery call
+          </h2>
+          <p className="mt-6 max-w-[52ch] text-lg leading-8 text-white/55">
+            Tell us about your agents and release process. We will recommend a
+            package and timeline, or point you to the{" "}
+            <Link
+              href="/enterprise"
+              className="text-white/80 underline decoration-white/25 underline-offset-4 transition-colors hover:text-white"
+            >
+              Team pilot
+            </Link>{" "}
+            if that is the better first step.
+          </p>
+          <EnterprisePageCTA className="mt-10" />
+        </div>
+      </section>
+    </MarketingShell>
+  );
+}

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -98,6 +98,10 @@ describe("sitemap", () => {
       changeFrequency: "monthly",
       priority: 0.82,
     });
+    expect(byUrl.get("https://www.agentclash.dev/services")).toMatchObject({
+      changeFrequency: "monthly",
+      priority: 0.78,
+    });
     expect(
       byUrl.get("https://www.agentclash.dev/platform/agent-evaluation"),
     ).toMatchObject({

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -212,6 +212,19 @@ export default function sitemap(): MetadataRoute.Sitemap {
       ],
     },
     {
+      url: `${DOCS_ORIGIN}/services`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.78,
+      images: [
+        ogImage({
+          title: "Agent Evaluation Services",
+          subtitle: "Fixed offerings for platform adoption",
+          kind: "Services",
+        }),
+      ],
+    },
+    {
       url: `${DOCS_ORIGIN}/platform/agent-evaluation`,
       lastModified: new Date(),
       changeFrequency: "monthly",

--- a/web/src/components/marketing/marketing-footer.tsx
+++ b/web/src/components/marketing/marketing-footer.tsx
@@ -10,6 +10,7 @@ const COLUMNS: Array<{
     links: [
       { href: "/#features", label: "Features" },
       { href: "/enterprise", label: "Enterprise" },
+      { href: "/services", label: "Services" },
       { href: "/platform/agent-evaluation", label: "Agent evaluation" },
       { href: "/compare", label: "Compare tools" },
       { href: "/docs", label: "Docs" },


### PR DESCRIPTION
## Summary

- Adds `/services`, a minimal marketing page that productizes fixed-scope AgentClash eval offerings (Eval Discovery, Challenge Pack Build, Benchmark & Gate Setup, Managed Eval Retainer) with explicit duration and deliverables.
- Links the page from `/enterprise`, blog post CTAs, footer, and sitemap; includes SEO metadata and canonical tests per `testing/feat-services-eval-program.md`.

Closes #986.

## Test plan

- [x] `cd web && pnpm exec vitest run src/app/public-canonical-metadata.test.ts src/app/sitemap.test.ts`
- [x] `cd web && pnpm build`
- [ ] Manual: open `/services`, verify four offering cards, guardrails, intake, Cal.com + mailto CTAs, links to `/enterprise` and `/pricing`