### PR TITLE
feat(blog): comparison and agent-eval post batch (#987)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ testing/*
 !testing/feat-984-enterprise-ctas.md
 !testing/feat-985-enterprise-page.md
 !testing/feat-services-eval-program.md
+!testing/feat-blog-batch-987.md

--- a/testing/feat-blog-batch-987.md
+++ b/testing/feat-blog-batch-987.md
@@ -1,0 +1,48 @@
+# feat/blog-batch-987 — Test Contract
+
+## Functional Behavior
+
+Five new MDX posts in `web/content/blog/` targeting comparison and agent-eval search intent:
+
+1. Agent evaluation vs prompt evaluation (Braintrust workflow fit)
+2. Benchmark AI agents on your own data (not public leaderboards)
+3. pass@k / pass^k for enterprise teams (extends existing pass-at-k post)
+4. Evaluating coding agents on private repos (checklist)
+5. AgentClash vs LangSmith vs Braintrust for production testing (links to `/compare`)
+
+Each post includes:
+- Frontmatter: `title`, `date`, `description`, `author`
+- Internal links to SEO pages: `/agent-evals`, `/llm-agent-evaluation`, `/use-cases/coding-agent-evaluation`, `/compare`
+- Link to `/enterprise` and conversion path (benchmarks or compare where relevant)
+- Related resources block at end
+
+At least 2 posts link to `/compare/agentclash-vs-*` competitor pages.
+
+Blog index auto-lists via `getAllPosts()` (no manual index edit required).
+
+## Unit Tests
+
+- Existing `public-canonical-metadata.test.ts` blog post fixture still passes with new slugs if referenced
+- `getAllPosts()` returns 11 posts (6 existing + 5 new) when parsed
+
+## Integration / Functional Tests
+
+- `web/src/app/blog/page.tsx` renders new posts in index (sorted by date)
+- Blog post pages render MDX without frontmatter errors
+
+## Smoke Tests
+
+```bash
+cd web && pnpm build
+cd web && pnpm exec vitest run src/app/public-canonical-metadata.test.ts
+```
+
+## E2E Tests
+
+N/A — content-only change.
+
+## Manual / cURL Tests
+
+- Open `/blog` and confirm 5 new titles appear
+- Open each new slug URL and verify internal links resolve
+- Confirm posts 1 and 5 link to `/compare/agentclash-vs-braintrust` or `/compare/agentclash-vs-langsmith`

--- a/web/content/blog/agent-evaluation-vs-prompt-evaluation-braintrust.mdx
+++ b/web/content/blog/agent-evaluation-vs-prompt-evaluation-braintrust.mdx
@@ -1,13 +1,9 @@
 ---
 title: "Agent Evaluation vs Prompt Evaluation: When Braintrust Isn't Enough"
 date: "2026-06-11"
-description: "Prompt evaluation tools like Braintrust excel at scoring model outputs. Production agents need trajectory evals on real tasks — here's how to know when to add sandboxed agent testing."
+description: "Prompt evaluation tools like Braintrust excel at scoring model outputs. Production agents need trajectory evals on real tasks: here's how to know when to add sandboxed agent testing."
 author: "Atharva"
 ---
-
-**Target query:** agent evaluation vs prompt evaluation  
-**Reader stage:** Evaluating tools; has prompt-level evals running  
-**Proof artifact:** Challenge pack + replay timeline from a multi-tool agent run
 
 Braintrust is a strong fit when the unit you evaluate is a prompt, a dataset row, or a logged model response. That workflow breaks when the product you ship is an agent: multi-turn, tool-using, stateful, and sensitive to sandbox conditions.
 

--- a/web/content/blog/agent-evaluation-vs-prompt-evaluation-braintrust.mdx
+++ b/web/content/blog/agent-evaluation-vs-prompt-evaluation-braintrust.mdx
@@ -1,0 +1,80 @@
+---
+title: "Agent Evaluation vs Prompt Evaluation: When Braintrust Isn't Enough"
+date: "2026-06-11"
+description: "Prompt evaluation tools like Braintrust excel at scoring model outputs. Production agents need trajectory evals on real tasks — here's how to know when to add sandboxed agent testing."
+author: "Atharva"
+---
+
+**Target query:** agent evaluation vs prompt evaluation  
+**Reader stage:** Evaluating tools; has prompt-level evals running  
+**Proof artifact:** Challenge pack + replay timeline from a multi-tool agent run
+
+Braintrust is a strong fit when the unit you evaluate is a prompt, a dataset row, or a logged model response. That workflow breaks when the product you ship is an agent: multi-turn, tool-using, stateful, and sensitive to sandbox conditions.
+
+This post is not a product dunk. It is a workflow map. Many teams should keep Braintrust for prompt iteration and add a separate layer for agent release gates.
+
+## What prompt evaluation answers well
+
+Prompt evaluation answers: *given this input, is the model's output acceptable?*
+
+That is the right question for:
+
+- copy and classification tasks
+- RAG answer quality on fixed contexts
+- prompt regression during model upgrades
+- scoring functions over traces you already log
+
+See [LLM agent evaluation](/llm-agent-evaluation) for how that layer differs once tools enter the picture.
+
+## What changes when you ship an agent
+
+Agents answer a different question: *can this system complete the job under policy, budget, and tool constraints?*
+
+That requires evidence prompt evals usually do not capture:
+
+- tool call sequences and retries
+- files and artifacts the agent created or edited
+- latency and cost per successful task
+- failures that happen mid-trajectory, not in the final string
+
+Two runs can share a "good" final answer while one violated your refund policy in step three. Prompt graders miss that unless you reconstruct the whole path.
+
+## When Braintrust is enough
+
+Stay prompt-first when:
+
+- your surface is mostly single-turn generation
+- tools are thin wrappers around one API call
+- humans review every high-risk output before it ships
+- your regression signal is text quality, not operational behavior
+
+For a deeper side-by-side on workflow fit, read [AgentClash vs Braintrust](/compare/agentclash-vs-braintrust).
+
+## When to add agent evaluation
+
+Add sandboxed agent evaluation when:
+
+- the agent edits code, tickets, or customer records
+- you need same-tools comparison between models or harnesses
+- CI should block a release when behavior regresses
+- compliance asks for replay evidence, not screenshots of scores
+
+That is the gap [agent evals](/agent-evals) and the [agent evaluation platform](/platform/agent-evaluation) are built for: frozen workloads, head-to-head races, replay, and gates.
+
+## A practical split for platform teams
+
+| Layer | Question | Typical owner |
+| --- | --- | --- |
+| Prompt eval (e.g. Braintrust) | Is this output good on logged inputs? | App / ML team |
+| Agent eval (e.g. AgentClash) | Does the agent complete the task safely and repeatably? | Platform / release committee |
+
+Run both. Do not ask prompt eval to stand in for release gates on tool-using agents.
+
+## Related resources
+
+- [Agent evals hub](/agent-evals)
+- [Compare eval tools](/compare)
+- [AI agent evaluation regression testing](/blog/ai-agent-evaluation-regression-testing)
+- [Enterprise pilot](/enterprise): 45-day Team access to run governed benchmarks on your workloads
+
+Book a discovery call from any post footer, or start the [enterprise pilot](/enterprise) if you want self-serve product access first.

--- a/web/content/blog/agentclash-vs-langsmith-braintrust-production.mdx
+++ b/web/content/blog/agentclash-vs-langsmith-braintrust-production.mdx
@@ -1,13 +1,9 @@
 ---
 title: "AgentClash vs LangSmith vs Braintrust for Production Agent Testing"
 date: "2026-06-07"
-description: "LangSmith traces chains, Braintrust scores prompts, AgentClash races tool-using agents on real tasks with replay and CI gates — an honest workflow comparison for production agent testing."
+description: "LangSmith traces chains, Braintrust scores prompts, AgentClash races tool-using agents on real tasks with replay and CI gates: an honest workflow comparison for production agent testing."
 author: "Atharva"
 ---
-
-**Target query:** AgentClash vs LangSmith vs Braintrust production agent testing  
-**Reader stage:** Shortlisting eval stack for agents going to production  
-**Proof artifact:** Compare matrix + link to head-to-head race replay
 
 This post is an SEO wrapper around the detailed pages on [/compare](/compare). It compares **workflow fit**, not feature checklists we cannot verify for your tenant.
 

--- a/web/content/blog/agentclash-vs-langsmith-braintrust-production.mdx
+++ b/web/content/blog/agentclash-vs-langsmith-braintrust-production.mdx
@@ -1,0 +1,85 @@
+---
+title: "AgentClash vs LangSmith vs Braintrust for Production Agent Testing"
+date: "2026-06-07"
+description: "LangSmith traces chains, Braintrust scores prompts, AgentClash races tool-using agents on real tasks with replay and CI gates — an honest workflow comparison for production agent testing."
+author: "Atharva"
+---
+
+**Target query:** AgentClash vs LangSmith vs Braintrust production agent testing  
+**Reader stage:** Shortlisting eval stack for agents going to production  
+**Proof artifact:** Compare matrix + link to head-to-head race replay
+
+This post is an SEO wrapper around the detailed pages on [/compare](/compare). It compares **workflow fit**, not feature checklists we cannot verify for your tenant.
+
+## Three different default questions
+
+| Tool | Default question | Best when |
+| --- | --- | --- |
+| [LangSmith](/compare/agentclash-vs-langsmith) | What happened in this chain, and how good was the output? | LangChain apps, trace-first debugging, prompt/dataset evals |
+| [Braintrust](/compare/agentclash-vs-braintrust) | How do prompts score on curated datasets? | Prompt iteration, logging, scoring functions over responses |
+| AgentClash | Which agent should ship on this real task under policy? | Multi-turn agents, sandboxed tools, release gates |
+
+Many production teams use LangSmith or Braintrust **and** add a sandboxed agent benchmark layer. They are complements until your release committee asks for same-tools races and CI blocks.
+
+## Where LangSmith fits
+
+LangSmith excels when you need deep observability over chains and prompts you already run. Reach for it when:
+
+- tracing production failures is the daily job
+- eval units are logged LLM calls or chain steps
+- you live inside the LangChain ecosystem
+
+Read the full [AgentClash vs LangSmith](/compare/agentclash-vs-langsmith) page for row-by-row notes.
+
+## Where Braintrust fits
+
+Braintrust excels when the eval loop is: dataset row → model call → scorer. Reach for it when:
+
+- product quality is mostly output grading
+- you iterate prompts with human or LLM judges
+- you want strong experiment logging without running sandboxes
+
+Read [AgentClash vs Braintrust](/compare/agentclash-vs-braintrust) for the workflow contrast.
+
+## Where AgentClash fits
+
+AgentClash is purpose-built when the shipped unit is an **agent**:
+
+- same challenge pack for every candidate
+- isolated sandboxes with explicit tool policy
+- replay timelines and scorecards per run
+- baseline vs candidate comparison
+- CI regression gates
+
+That maps to [agent evals](/agent-evals), [LLM agent evaluation](/llm-agent-evaluation), and the [agent evaluation platform](/platform/agent-evaluation).
+
+## Production testing workflow (combined stack)
+
+A pattern we see on platform teams:
+
+1. **Trace in production** with LangSmith (or your APM) to find failures.
+2. **Score prompt changes** with Braintrust while iterating copy and judges.
+3. **Promote failures into challenge packs** and race agents before merge.
+4. **Gate CI** when the candidate regresses against baseline.
+
+AgentClash owns steps 3–4. It does not replace your tracing or prompt lab.
+
+## What not to claim
+
+Avoid these mistakes when shopping tools:
+
+- Treating a prompt score as proof the agent completes the job
+- Comparing models on different days without frozen packs
+- Skipping artifact review on coding or ops agents
+
+Compare on workflow fit. Run a head-to-head on *your* pack when the decision is close.
+
+## Related resources
+
+- [Compare hub](/compare)
+- [Coding agent evaluation](/use-cases/coding-agent-evaluation)
+- [AI agent benchmark](/ai-agent-benchmark)
+- [Benchmarks field reports](/benchmarks)
+- [Enterprise pilot](/enterprise)
+
+Book an eval architecture review from the post footer, or explore [eval services](/services) for fixed-scope pack and gate setup.

--- a/web/content/blog/benchmark-ai-agents-on-your-own-data.mdx
+++ b/web/content/blog/benchmark-ai-agents-on-your-own-data.mdx
@@ -1,0 +1,73 @@
+---
+title: "How to Benchmark AI Agents on Your Own Data (Not Public Leaderboards)"
+date: "2026-06-10"
+description: "Public leaderboards answer a general model question. Shipping agents requires benchmarks on your workflows, tools, and failure modes — a practical playbook."
+author: "Atharva"
+---
+
+**Target query:** benchmark AI agents on your own data  
+**Reader stage:** Has agents in staging; distrusts generic leaderboards  
+**Proof artifact:** Versioned challenge pack with baseline vs candidate scorecard
+
+Public leaderboards are useful for orientation. They are a poor release gate for the agent your customers actually use.
+
+Leaderboards optimize for tasks that are public, static, and comparable across vendors. Your agent optimizes for private repos, internal APIs, ticket schemas, and policies that never appear on LMSYS.
+
+## Step 1: Pick workloads, not models
+
+Start from three real jobs your agent must complete:
+
+- a support refund with policy checks
+- a coding fix in a service your team owns
+- an internal ops workflow with approvals
+
+Each job becomes a [challenge pack](/docs/guides/write-a-challenge-pack) case: inputs, tools, validators, artifacts. That is how [agent evals](/agent-evals) turn anecdotes into coverage.
+
+## Step 2: Freeze the benchmark
+
+Version the pack before you race candidates. If the task drifts every week, you are comparing runs that never met on the same track.
+
+Freeze:
+
+- fixtures and seed data
+- tool allowlists and network policy
+- scoring rules and pass thresholds
+- time and token budgets
+
+This is the same discipline public benchmarks use — except the workload is yours.
+
+## Step 3: Run head-to-head, not staggered
+
+Run baseline and candidate agents concurrently on the same pack. Staggered comparisons leak cache warmth, provider weather, and prompt drift into the verdict.
+
+AgentClash races agents on the same task at the same time in isolated sandboxes. See [why we race agents head-to-head](/blog/why-agentclash-races-agents-head-to-head).
+
+## Step 4: Capture replay, not just scores
+
+A number without a trajectory is not actionable. Reviewers need:
+
+- tool paths and retries
+- produced files and logs
+- cost and latency per successful task
+- judge or validator evidence
+
+That replay is what makes a benchmark defensible to security and platform leads. The [LLM agent evaluation](/llm-agent-evaluation) page outlines the product surface.
+
+## Step 5: Promote failures into gates
+
+When a candidate regresses, promote the failure into permanent coverage and wire a CI gate. Benchmarks that nobody gates on become slide deck decorations.
+
+Follow [CI/CD agent gates](/docs/guides/ci-cd-agent-gates) once you have a baseline you trust.
+
+## Feeding `/benchmarks` without fiction
+
+We publish field reports on [/benchmarks](/benchmarks) when we have reproducible packs and honest sample sizes. Your private benchmark should follow the same rule: publish internal scorecards, not vibes.
+
+If you want help freezing the first pack, see [eval services](/services) or the free [enterprise pilot](/enterprise).
+
+## Related resources
+
+- [Agent reliability benchmark](/agent-reliability-benchmark)
+- [Coding agent evaluation use case](/use-cases/coding-agent-evaluation)
+- [Compare AgentClash to prompt-eval stacks](/compare)
+- [Enterprise pilot](/enterprise)

--- a/web/content/blog/benchmark-ai-agents-on-your-own-data.mdx
+++ b/web/content/blog/benchmark-ai-agents-on-your-own-data.mdx
@@ -1,13 +1,9 @@
 ---
 title: "How to Benchmark AI Agents on Your Own Data (Not Public Leaderboards)"
 date: "2026-06-10"
-description: "Public leaderboards answer a general model question. Shipping agents requires benchmarks on your workflows, tools, and failure modes — a practical playbook."
+description: "Public leaderboards answer a general model question. Shipping agents requires benchmarks on your workflows, tools, and failure modes: a practical playbook."
 author: "Atharva"
 ---
-
-**Target query:** benchmark AI agents on your own data  
-**Reader stage:** Has agents in staging; distrusts generic leaderboards  
-**Proof artifact:** Versioned challenge pack with baseline vs candidate scorecard
 
 Public leaderboards are useful for orientation. They are a poor release gate for the agent your customers actually use.
 

--- a/web/content/blog/evaluating-coding-agents-private-repos-checklist.mdx
+++ b/web/content/blog/evaluating-coding-agents-private-repos-checklist.mdx
@@ -1,13 +1,9 @@
 ---
 title: "Evaluating Coding Agents on Private Repos: A Practical Checklist"
 date: "2026-06-08"
-description: "Coding agents on private repositories need evals that respect your layout, tests, and policies — not public leaderboard tasks. A checklist for platform and developer-experience teams."
+description: "Coding agents on private repositories need evals that respect your layout, tests, and policies (not public leaderboard tasks). A checklist for platform and developer-experience teams."
 author: "Atharva"
 ---
-
-**Target query:** evaluate coding agents private repository  
-**Reader stage:** DX or platform team piloting coding agents internally  
-**Proof artifact:** Challenge pack case with repo fixture, test command, and artifact diff
 
 Public coding benchmarks tell you how a model performs on leaked-style tasks. They do not tell you whether an agent can fix *your* service, run *your* test suite, or respect *your* merge policy.
 

--- a/web/content/blog/evaluating-coding-agents-private-repos-checklist.mdx
+++ b/web/content/blog/evaluating-coding-agents-private-repos-checklist.mdx
@@ -1,0 +1,91 @@
+---
+title: "Evaluating Coding Agents on Private Repos: A Practical Checklist"
+date: "2026-06-08"
+description: "Coding agents on private repositories need evals that respect your layout, tests, and policies — not public leaderboard tasks. A checklist for platform and developer-experience teams."
+author: "Atharva"
+---
+
+**Target query:** evaluate coding agents private repository  
+**Reader stage:** DX or platform team piloting coding agents internally  
+**Proof artifact:** Challenge pack case with repo fixture, test command, and artifact diff
+
+Public coding benchmarks tell you how a model performs on leaked-style tasks. They do not tell you whether an agent can fix *your* service, run *your* test suite, or respect *your* merge policy.
+
+Use this checklist before you trust a coding agent on private repos.
+
+## 1. Define the job, not the model
+
+Pick one shippable workflow:
+
+- fix a failing test in a known module
+- implement a small API change with contract tests
+- refactor with lint and typecheck gates
+
+Encode it in a [challenge pack](/docs/guides/write-a-challenge-pack) with explicit success validators (tests green, file present, no forbidden paths touched). The [coding agent evaluation](/use-cases/coding-agent-evaluation) use case page has patterns.
+
+## 2. Mirror real repo shape
+
+Your fixture should include:
+
+- dependency files your CI actually uses
+- realistic directory depth and naming
+- secrets replaced with safe stubs (never real tokens in packs)
+- the same test runner command developers use locally
+
+If the sandbox image drifts from production CI, scores lie.
+
+## 3. Set tool and network policy explicitly
+
+Coding agents fail in boring ways: wrong package manager, blocked registry, over-broad file writes.
+
+Document:
+
+- which directories are writable
+- whether network is allowed and to which hosts
+- max wall-clock time and tool-call budget
+
+AgentClash applies tool policy per pack so every candidate races under the same rules. See [agent evals](/agent-evals).
+
+## 4. Capture artifacts, not chat transcripts
+
+Reviewers need:
+
+- diff or patch output
+- test logs
+- build artifacts
+- cost and duration
+
+Replay should show *what changed in the repo*, not just the agent's summary message.
+
+## 5. Compare harnesses, not just models
+
+The same model with different harnesses (CLI, IDE agent, custom orchestrator) is a different product surface. Race harnesses head-to-head on the same pack before you standardize on one.
+
+## 6. Promote every production failure
+
+When an agent breaks staging, promote the incident into a pack case within a week. That is how coding agent eval compounds.
+
+Wire the pack into [CI/CD agent gates](/docs/guides/ci-cd-agent-gates) once you have a baseline.
+
+## 7. Plan for human review on high-risk merges
+
+Even strong pass^k scores do not remove code review. Evals tell you the agent completed the task under policy; humans still own merge approval for sensitive paths.
+
+## Quick reference checklist
+
+- [ ] Real repo fixture with safe secrets
+- [ ] Validators tied to tests or artifacts
+- [ ] Tool/network policy matches production intent
+- [ ] Baseline harness and model pinned
+- [ ] Replay retained per security policy
+- [ ] Regression case for last production miss
+- [ ] Release gate owner named on the scorecard
+
+Start self-serve on the [enterprise pilot](/enterprise), or ask about [challenge pack build](/services) if you want hands-on help encoding your repos.
+
+## Related resources
+
+- [LLM agent evaluation](/llm-agent-evaluation)
+- [AI agent testing](/ai-agent-testing)
+- [Compare coding-agent eval approaches](/compare)
+- [Enterprise pilot](/enterprise)

--- a/web/content/blog/pass-k-reliability-enterprise-teams.mdx
+++ b/web/content/blog/pass-k-reliability-enterprise-teams.mdx
@@ -1,13 +1,9 @@
 ---
 title: "pass@k, pass^k, and Reliability: What Enterprise Teams Should Measure"
 date: "2026-06-09"
-description: "Enterprise agent releases need explicit reliability metrics. A practical guide to pass@k and pass^k for platform teams — extending the pass@k vs pass^k primer with release-gate examples."
+description: "Enterprise agent releases need explicit reliability metrics. A practical guide to pass@k and pass^k for platform teams, extending the pass@k vs pass^k primer with release-gate examples."
 author: "Atharva"
 ---
-
-**Target query:** pass@k pass^k agent reliability enterprise  
-**Reader stage:** Platform or release committee defining gates  
-**Proof artifact:** Scorecard showing pass@k and pass^k on the same challenge pack
 
 We covered the definitions in [pass@k vs pass^k](/blog/pass-at-k-vs-pass-power-k). This post extends that primer for enterprise teams deciding what to gate in CI.
 

--- a/web/content/blog/pass-k-reliability-enterprise-teams.mdx
+++ b/web/content/blog/pass-k-reliability-enterprise-teams.mdx
@@ -1,0 +1,76 @@
+---
+title: "pass@k, pass^k, and Reliability: What Enterprise Teams Should Measure"
+date: "2026-06-09"
+description: "Enterprise agent releases need explicit reliability metrics. A practical guide to pass@k and pass^k for platform teams — extending the pass@k vs pass^k primer with release-gate examples."
+author: "Atharva"
+---
+
+**Target query:** pass@k pass^k agent reliability enterprise  
+**Reader stage:** Platform or release committee defining gates  
+**Proof artifact:** Scorecard showing pass@k and pass^k on the same challenge pack
+
+We covered the definitions in [pass@k vs pass^k](/blog/pass-at-k-vs-pass-power-k). This post extends that primer for enterprise teams deciding what to gate in CI.
+
+The short version:
+
+- **pass@k** — at least one success in *k* independent tries
+- **pass^k** — success on *all k* tries
+
+Same symbols, different release contracts.
+
+## What enterprise buyers actually ask
+
+Release committees rarely ask for a leaderboard score. They ask:
+
+1. Can we ship this agent without a human in the loop for this workload?
+2. What happens on the second and third attempt?
+3. If it fails, can we explain why with evidence?
+
+pass@k and pass^k answer questions 2 and 3 when paired with replay. Question 1 still needs policy, cost ceilings, and artifact checks on the scorecard.
+
+## Mapping metrics to product promises
+
+| Product promise | Primary metric | Gate posture |
+| --- | --- | --- |
+| "Usually works if the user retries" | pass@k with bounded k | Warn on pass^k regression |
+| "Must not fail twice in a row" | pass^k | Block release on any strict failure |
+| "Expensive failures are unacceptable" | pass^k + cost-per-success | Block on cost regression |
+
+Document the promise in the challenge pack README so evaluators do not argue about the metric after the run.
+
+## How to run both without gaming
+
+1. **Freeze the pack** so every attempt sees the same tools and fixtures.
+2. **Run k independent sandboxes** per candidate (no shared warm state).
+3. **Inspect disagreement** in replay when pass@k is high but pass^k is low.
+4. **Promote clustered failures** into new cases before widening k.
+
+AgentClash keeps pack version, replay, and scorecards together so you can audit whether a "pass" was lucky or repeatable. See [agent reliability benchmark](/agent-reliability-benchmark).
+
+## When to tighten from pass@k to pass^k
+
+Teams often start with pass@k while discovering the workload, then tighten once:
+
+- tool strategy stabilizes
+- validators cover the known failure modes
+- cost per success is predictable
+
+That transition is a maturity signal, not a moral judgment. Early exploration should not be blocked by pass^k before you understand the task.
+
+## Enterprise checklist before you gate
+
+- [ ] Workload encoded as a versioned challenge pack
+- [ ] Baseline agent frozen with explicit model and harness IDs
+- [ ] k chosen to match real retry policy (not "whatever fits the slide")
+- [ ] Replay retention policy agreed with security
+- [ ] Scorecard dimensions match the release committee questions
+- [ ] CI gate documented in the PR template
+
+Need a baseline and gate wired in two weeks? See [Benchmark & Gate Setup](/services) or start the [enterprise pilot](/enterprise).
+
+## Related resources
+
+- [pass@k vs pass^k primer](/blog/pass-at-k-vs-pass-power-k)
+- [Agent evals](/agent-evals)
+- [AI agent regression testing](/platform/agent-regression-testing)
+- [Compare eval tools](/compare)


### PR DESCRIPTION
## Summary

- Adds 5 MDX posts in `web/content/blog/` targeting comparison and agent-eval search intent (Braintrust workflow fit, private benchmarks, enterprise pass@k/pass^k, coding-agent checklist, LangSmith/Braintrust compare wrapper).
- Each post includes frontmatter, internal links to `/agent-evals`, `/llm-agent-evaluation`, `/use-cases/coding-agent-evaluation`, `/compare`, and `/enterprise`; posts 1 and 5 link to `/compare/agentclash-vs-braintrust` and `/compare/agentclash-vs-langsmith`.
- Blog index auto-lists new posts via `getAllPosts()`.

Closes #987.

Test contract: `testing/feat-blog-batch-987.md`

## Test plan

- [x] `cd web && pnpm exec vitest run src/app/public-canonical-metadata.test.ts`
- [x] `cd web && pnpm build`
- [ ] Manual: open `/blog` and each new slug; verify compare and enterprise links

## New posts

1. `/blog/agent-evaluation-vs-prompt-evaluation-braintrust`
2. `/blog/benchmark-ai-agents-on-your-own-data`
3. `/blog/pass-k-reliability-enterprise-teams`
4. `/blog/evaluating-coding-agents-private-repos-checklist`
5. `/blog/agentclash-vs-langsmith-braintrust-production`