### PR TITLE
feat(blog): enterprise pain & release gates batch (#988)

### DIFF
--- a/web/content/blog/ai-agent-approval-security-compliance.mdx
+++ b/web/content/blog/ai-agent-approval-security-compliance.mdx
@@ -1,0 +1,97 @@
+---
+title: "How to Get AI Agent Approval from Security and Compliance"
+date: "2026-06-10"
+description: "Security and compliance teams need replay evidence, frozen workloads, and gate verdicts before they approve an AI agent. A practical approval checklist for platform leads."
+author: "Atharva"
+---
+
+Security reviewers do not block AI agents because they dislike automation. They block agents when the approval packet is a demo recording and a slide that says "eval score improved."
+
+Enterprise approval needs a defensible artifact: what was tested, under which policy, with what evidence, and what the gate verdict was.
+
+## What security actually asks
+
+In most regulated enterprises, the approval conversation converges on five questions:
+
+1. What agent build and deployment are we approving?
+2. What workload proves it is safe for our environment?
+3. What evidence can we audit after the fact?
+4. What happens when the agent fails or routes to a fallback model?
+5. Who owns the release decision if production regresses?
+
+Observability dashboards answer parts of question 4. Prompt evals answer parts of question 2. Neither alone produces a packet compliance can sign.
+
+## Bring a benchmark decision, not a trace export
+
+The enterprise pattern that works is a **governed benchmark decision**: frozen challenge pack version, pinned baseline, named candidate, explicit gate policy, and a pass or fail verdict with replay attached.
+
+Picture a platform lead preparing a coding agent release. They do not send security a LangSmith project link and hope for the best. They attach:
+
+- the challenge pack version and input set approved for the quarter
+- baseline and candidate deployment IDs
+- scorecard deltas (correctness, cost, latency, evidence tier)
+- replay links for the cases that drove the verdict
+- the gate policy (for example: no correctness regression, cost cap, automatic fail on policy violations)
+
+That mirrors the buyer workflow in our [enterprise pilot](/enterprise) narrative: benchmark first, replay second, gate third.
+
+AgentClash supports review with immutable run history and replay shaped for decisions, not raw span dumps. See [AI agent regression testing](/platform/agent-regression-testing) for the product surface.
+
+## The evidence bundle compliance expects
+
+Structure the approval packet so each stakeholder finds their slice without re-interpreting chat logs.
+
+| Stakeholder | What they need from the bundle |
+| --- | --- |
+| Security | Tool policy, network bounds, secrets handling, evidence tier per agent |
+| Compliance | Traceability from approved workload to verdict, retention policy |
+| Engineering | Replay of divergences, routing fallbacks, sandbox failures |
+| Finance | Cost per successful task vs baseline |
+
+Include a one-page gate summary: **ship, block, or conditional ship** with the single metric that forced the call.
+
+Industry surveys consistently show a gap between documented AI policy and production approval. [Gravitee's 2026 agent security report](https://www.gravitee.io/blog/state-of-ai-agent-security-2026-report-when-adoption-outpaces-control) found most agent fleets lack full security oversight. Your packet should close that gap for *your* agent, not claim industry-wide certification.
+
+## Approval checklist (copy into your review ticket)
+
+- [ ] Named candidate build and deployment (not "latest prod")
+- [ ] Frozen challenge pack version and input set
+- [ ] Baseline run ID with max age policy documented
+- [ ] Gate policy written in scorecard dimensions, not prose
+- [ ] Replay retained per security retention rules
+- [ ] Evidence tier labeled for hosted vs native agents (`black_box`, `structured_trace`, `native_full_replay`)
+- [ ] Automatic fail conditions listed (policy violations, forbidden paths, cost ceiling)
+- [ ] Release owner and rollback owner named
+
+Use careful language: AgentClash **supports review and evidence collection**. It does not replace your SOC 2 program, legal sign-off, or industry-specific control frameworks.
+
+## How eval becomes an ongoing control
+
+One-time approval is not enough. Connect the benchmark to [CI/CD agent evaluation](/ci-cd-agent-evaluation) so every material agent change re-runs the approved workload.
+
+The [CI/CD agent gates](/docs/guides/ci-cd-agent-gates) guide shows how a repo-tracked manifest names the candidate, baseline, workload, and fail threshold. Security cares because the same contract runs in CI that ran for the original approval.
+
+## FAQ
+
+### Do we need human-in-the-loop for every agent action?
+
+No. Separate **runtime policy** (what executes in production) from **release evidence** (what proved the build before go-live). Many teams use human approval queues for high-risk tool calls while still gating releases with benchmark replay.
+
+### Can we approve a hosted vendor agent with limited observability?
+
+Yes, with explicit evidence tier labeling. Black-box runs can inform procurement, but native full replay should gate production-critical workloads when your policy requires it.
+
+### What if we have no baseline yet?
+
+Run an exploratory benchmark, record the green run as baseline, then attach the manifest. The [CI gates guide](/docs/guides/ci-cd-agent-gates) notes that missing baseline is informational during setup, not a reason to skip approval structure.
+
+## Next step
+
+Need a governed benchmark your security team can replay? Start the [enterprise pilot](/enterprise) or book a demo to walk through a sample gate verdict on your workload.
+
+## Related resources
+
+- [Enterprise pilot](/enterprise)
+- [AI agent regression testing](/platform/agent-regression-testing)
+- [CI/CD agent evaluation](/ci-cd-agent-evaluation)
+- [CI/CD agent gates](/docs/guides/ci-cd-agent-gates)

--- a/web/content/blog/ai-agent-approval-security-compliance.mdx
+++ b/web/content/blog/ai-agent-approval-security-compliance.mdx
@@ -59,7 +59,7 @@ Industry surveys consistently show a gap between documented AI policy and produc
 - [ ] Baseline run ID with max age policy documented
 - [ ] Gate policy written in scorecard dimensions, not prose
 - [ ] Replay retained per security retention rules
-- [ ] Evidence tier labeled for hosted vs native agents (`black_box`, `structured_trace`, `native_full_replay`)
+- [ ] Evidence tier labeled for hosted vs native agents (`native_structured`, `hosted_structured`, `hosted_black_box`)
 - [ ] Automatic fail conditions listed (policy violations, forbidden paths, cost ceiling)
 - [ ] Release owner and rollback owner named
 
@@ -79,15 +79,15 @@ No. Separate **runtime policy** (what executes in production) from **release evi
 
 ### Can we approve a hosted vendor agent with limited observability?
 
-Yes, with explicit evidence tier labeling. Black-box runs can inform procurement, but native full replay should gate production-critical workloads when your policy requires it.
+Yes, with explicit evidence tier labeling. `hosted_black_box` runs can inform procurement, but `native_structured` evidence should gate production-critical workloads when your policy requires full trajectory replay.
 
 ### What if we have no baseline yet?
 
-Run an exploratory benchmark, record the green run as baseline, then attach the manifest. The [CI gates guide](/docs/guides/ci-cd-agent-gates) notes that missing baseline is informational during setup, not a reason to skip approval structure.
+Run an exploratory benchmark, record the green run as baseline, then pin `baseline.run_id` in the manifest. Until that exists, `agentclash ci validate` flags a missing baseline selector. Separately, `agentclash doctor` treats a missing eval baseline bookmark as informational only ([eval workflows and gates](/docs/challenge-packs/eval-workflows-and-gates)).
 
 ## Next step
 
-Need a governed benchmark your security team can replay? Start the [enterprise pilot](/enterprise) or book a demo to walk through a sample gate verdict on your workload.
+Need a governed benchmark your security team can replay? Start the [enterprise pilot](/enterprise) or ask about [Benchmark & Gate Setup](/services) for a guided first gate.
 
 ## Related resources
 

--- a/web/content/blog/ai-platform-lead-agent-release-gates.mdx
+++ b/web/content/blog/ai-platform-lead-agent-release-gates.mdx
@@ -1,0 +1,124 @@
+---
+title: "The AI Platform Lead's Guide to Agent Release Gates"
+date: "2026-06-11"
+description: "Release gates for AI agents need frozen workloads, baseline comparison, replay evidence, and CI handoff. A guide for platform leads shipping governed agent systems."
+author: "Atharva"
+---
+
+Platform leads own the unglamorous question: **can this agent revision go to production without a war room next Tuesday?**
+
+A release gate turns that question into a machine-checkable contract instead of a calendar hold and a prayer.
+
+## Release gates are not prompt checks
+
+Prompt diff tools excel when the only variable is text. Agent releases change more than prompts:
+
+- tool bindings and permissions
+- model aliases and routing fallbacks
+- harness code and retry policy
+- sandbox images and network policy
+- output schemas and guardrails
+
+A gate must name the **full agent system under test**, the **workload**, the **baseline**, and the **fail policy**. Anything less becomes a false green.
+
+```text
+agent build/deployment = thing under test
+challenge pack/regression suite = workload
+release gate = decision policy
+```
+
+That separation is how [CI/CD agent gates](/docs/guides/ci-cd-agent-gates) are documented. Treat the manifest as the contract your platform team and release committee both read.
+
+## The gate workflow platform leads actually run
+
+### 1. Define the benchmark decision once
+
+Select for this release train:
+
+- workspace and owners
+- challenge pack version (frozen)
+- input set approved for the period
+- production baseline deployment
+- release candidate deployment
+- optional vendor agents under evaluation
+
+Attach numeric policy: max correctness regression, cost ceiling, latency and TTFT bounds, automatic fail on security-policy violations.
+
+This is the "Monday morning release problem" from the enterprise buyer story: the candidate claims lower cost and better patch quality. The gate exists so you do not ship on demo optics.
+
+### 2. Run in a frozen environment
+
+Provision sandboxes with the same tool policy for every lane. Mark evidence tier for hosted agents so compare views stay honest.
+
+During the run, platform leads watch what changes decisions: routing fallbacks after rate limits, skipped tool use, recovery paths, token cost, sandbox failures.
+
+### 3. Open replay, not just dashboards
+
+When the run finishes, reviewers need decision-shaped replay:
+
+- where candidate diverged from baseline
+- which tool path changed
+- when latency spiked or the route changed models
+- whether artifacts match release policy
+
+Replay is the explanation layer for stakeholders who will not read raw traces.
+
+### 4. Read the compare view and gate verdict
+
+The compare screen should answer: who wins on correctness, cost, latency, reliability, and evidence completeness?
+
+The gate verdict should answer: **ship or block**, with the dimension that failed.
+
+Example from the enterprise narrative: candidate beats baseline on cost but fails the gate because correctness regressed on a critical challenge family and TTFT exceeded policy after a routing fallback. That is a defensible block.
+
+## Wire the gate into CI
+
+Ad hoc benchmarks rot. Promote the approved workload into a repo-tracked manifest and run it on pull requests that touch agent surfaces.
+
+AgentClash CI gates compare candidate runs against a locked baseline and emit artifacts your pipeline can fail on. Product overview: [CI/CD agent evaluation](/ci-cd-agent-evaluation). Implementation: [CI/CD agent gates](/docs/guides/ci-cd-agent-gates).
+
+Minimum GitHub Actions handoff:
+
+1. `agentclash ci validate --remote` on manifest changes
+2. `agentclash ci should-run` on path filters
+3. `agentclash ci run` with gate exit codes blocking merge
+4. Upload `gate.json` and replay links to the PR
+
+Regression promotion policy belongs in the same manifest so failed cases become coverage instead of Slack archaeology.
+
+## Release gate checklist
+
+- [ ] Manifest checked into `.agentclash/ci.yaml`
+- [ ] Baseline run ID with refresh and max-age rules
+- [ ] Gate `fail_on` matches release committee language
+- [ ] Scorecard dimensions map to policy (not ad hoc after the run)
+- [ ] Replay links attached to PR or change ticket
+- [ ] Hosted agents labeled by evidence tier
+- [ ] Owner named for baseline refresh and gate exceptions
+
+Pair gates with [AI agent regression testing](/platform/agent-regression-testing) so production misses flow back into the workload.
+
+## FAQ
+
+### When should a gate block vs warn?
+
+Block on correctness regression, policy violations, and hard cost or latency ceilings. Warn on exploratory metrics while the workload is still stabilizing. Document the mode in the manifest so CI behavior matches committee expectations.
+
+### How do we gate vendor agents we do not control?
+
+Run them in the same challenge pack with explicit evidence tier limits. Use compare for procurement; use native replay for production gates when policy requires full trajectory evidence.
+
+### What is the fastest path to a first gate?
+
+Freeze one real task as a challenge pack, record a baseline run, init the CI manifest, and gate a single agent repo. The [enterprise pilot](/enterprise) includes Team access to run this loop self-serve.
+
+## Next step
+
+Platform lead shipping agent revisions this quarter? Start the [enterprise pilot](/enterprise) or request a demo walkthrough of manifest setup and gate verdict export.
+
+## Related resources
+
+- [CI/CD agent gates](/docs/guides/ci-cd-agent-gates)
+- [CI/CD agent evaluation](/ci-cd-agent-evaluation)
+- [AI agent regression testing](/platform/agent-regression-testing)
+- [Enterprise pilot](/enterprise)

--- a/web/content/blog/ai-platform-lead-agent-release-gates.mdx
+++ b/web/content/blog/ai-platform-lead-agent-release-gates.mdx
@@ -77,12 +77,12 @@ Ad hoc benchmarks rot. Promote the approved workload into a repo-tracked manifes
 
 AgentClash CI gates compare candidate runs against a locked baseline and emit artifacts your pipeline can fail on. Product overview: [CI/CD agent evaluation](/ci-cd-agent-evaluation). Implementation: [CI/CD agent gates](/docs/guides/ci-cd-agent-gates).
 
-Minimum GitHub Actions handoff:
+Minimum GitHub Actions handoff (see the [CI/CD agent gates](/docs/guides/ci-cd-agent-gates) sketch):
 
-1. `agentclash ci validate --remote` on manifest changes
-2. `agentclash ci should-run` on path filters
-3. `agentclash ci run` with gate exit codes blocking merge
-4. Upload `gate.json` and replay links to the PR
+1. `agentclash ci validate .agentclash/ci.yaml --remote` on manifest changes
+2. `agentclash ci should-run --manifest .agentclash/ci.yaml` on path filters
+3. `agentclash ci run --manifest .agentclash/ci.yaml --artifact-dir agentclash-artifacts` when matched; nonzero exit codes block merge
+4. Upload `agentclash-artifacts/gate.json`, scorecard JSON, and replay links to the PR (the bundled `agentclash-ci` action handles this)
 
 Regression promotion policy belongs in the same manifest so failed cases become coverage instead of Slack archaeology.
 
@@ -110,11 +110,11 @@ Run them in the same challenge pack with explicit evidence tier limits. Use comp
 
 ### What is the fastest path to a first gate?
 
-Freeze one real task as a challenge pack, record a baseline run, init the CI manifest, and gate a single agent repo. The [enterprise pilot](/enterprise) includes Team access to run this loop self-serve.
+Freeze one real task as a challenge pack, record a baseline run, init the CI manifest, and gate a single agent repo. The [enterprise pilot](/enterprise) includes a 45-day Team pilot to run this loop self-serve.
 
 ## Next step
 
-Platform lead shipping agent revisions this quarter? Start the [enterprise pilot](/enterprise) or request a demo walkthrough of manifest setup and gate verdict export.
+Platform lead shipping agent revisions this quarter? Start the [enterprise pilot](/enterprise) or ask about a [Benchmark & Gate Setup](/services) sprint for manifest and gate wiring.
 
 ## Related resources
 

--- a/web/content/blog/building-agent-eval-program-regulated-enterprise.mdx
+++ b/web/content/blog/building-agent-eval-program-regulated-enterprise.mdx
@@ -1,0 +1,129 @@
+---
+title: "Building an Agent Eval Program in a Regulated Enterprise"
+date: "2026-06-13"
+description: "Regulated enterprises need versioned workloads, audit-friendly replay, baseline gates, and CI handoff. A phased plan to stand up a governed agent eval program."
+author: "Atharva"
+---
+
+Regulated enterprises do not get permission to "move fast and fix agents in prod." They get permission to ship **when evidence supports the decision**.
+
+An agent eval program is how platform teams make that evidence repeatable across business units, vendors, and release trains.
+
+## Phase 0: Align on the decision object
+
+Before you buy tools, align leadership on what a release decision contains:
+
+- frozen workload (challenge pack version + input set)
+- candidate and baseline agent builds
+- scorecard with policy dimensions
+- replay evidence for material divergences
+- gate verdict (ship, block, conditional)
+
+If compliance, security, and engineering cannot point at the same artifact, the program will stall in slide decks.
+
+AgentClash models that object end to end. Start with the [enterprise pilot](/enterprise) if you need a self-serve environment to socialize the shape.
+
+## Phase 1: Inventory workloads worth gating
+
+Not every agent deserves a full benchmark on day one. Prioritize workloads where failure is expensive or audited:
+
+- customer-facing actions with tool use
+- coding or data agents that mutate repositories
+- retrieval agents bound to regulated data classes
+- vendor agents executing under your brand
+
+For each, document: owner, data class, retry policy, and current "proof" (usually demos or ad hoc evals).
+
+## Phase 2: Encode workloads as challenge packs
+
+Turn the top one or two workflows into versioned packs:
+
+- explicit tool and network policy
+- fixtures that mirror production shape (with safe secrets)
+- validators tied to tests, artifacts, or judges
+- scorecard dimensions that map to release policy
+
+When production misses, promote cases within a week. That is how eval coverage compounds in regulated settings.
+
+Product context: [AI agent regression testing](/platform/agent-regression-testing). Authoring: [write a challenge pack](/docs/guides/write-a-challenge-pack).
+
+## Phase 3: Establish baselines and compare discipline
+
+Regulated programs fail when every team picks its own baseline week. Central platform teams should:
+
+- name baseline deployments per workload
+- set baseline refresh rules (manual vs scheduled, max age)
+- require compare runs before committee review
+- label evidence tier for hosted agents
+
+The compare view should show tradeoffs clearly: correctness, cost per success, latency, TTFT, reliability, evidence completeness.
+
+## Phase 4: Connect benchmarks to CI gates
+
+An eval program without CI becomes a quarterly ritual. Wire gates when baselines exist:
+
+1. Repo-tracked `.agentclash/ci.yaml` manifest
+2. Remote validation in CI for resource visibility
+3. `agentclash ci run` on agent-changing paths
+4. Artifact upload: gate JSON, scorecard, replay links
+
+This is the handoff from **program** to **control**. Implementation guide: [CI/CD agent gates](/docs/guides/ci-cd-agent-gates). Product page: [CI/CD agent evaluation](/ci-cd-agent-evaluation).
+
+```yaml
+gate:
+  fail_on: regression
+baseline:
+  refresh: manual
+  max_age_days: 30
+```
+
+Adjust refresh policy to match your change control board. Document exceptions in the ticket, not in Slack.
+
+## Phase 5: Operate the program
+
+| Cadence | Activity |
+| --- | --- |
+| Weekly | Review failed gates; promote cases |
+| Monthly | Refresh baseline candidates; retire stale packs |
+| Quarterly | Audit evidence retention and access controls |
+| Per release | Attach gate summary to change record |
+
+Use language compliance teams accept: AgentClash **supports evidence collection and review**. Map controls to your framework (SOC 2, ISO 42001, internal AI policy) in your own risk register. Do not overclaim certification from a benchmark tool.
+
+External context: enterprises face fragmented AI regulation and rising expectations for identity and audit trails ([Lasso Security, 2026 predictions](https://www.lasso.security/blog/enterprise-ai-security-predictions-2026)). Your program should produce attributable logs of *what you tested*, not replace legal interpretation.
+
+## Regulated enterprise checklist
+
+- [ ] Decision object agreed with security and compliance
+- [ ] Top workloads encoded as versioned packs
+- [ ] Baseline registry with owners and refresh rules
+- [ ] Replay retention aligned with records management
+- [ ] CI manifest on agent repos that gate production paths
+- [ ] Evidence tier policy for vendor agents
+- [ ] Regression promotion workflow documented
+- [ ] Executive summary template (verdict + three deltas + replay link)
+
+## FAQ
+
+### How is this different from our existing ML model validation?
+
+Models are one component. Agents add tools, state, routing, cost, and recovery behavior. The eval program tests the **system**, not an isolated completion score.
+
+### Can business units run their own benchmarks?
+
+Yes, inside workspace boundaries with shared pack standards. Platform teams should own gate policy templates and baseline hygiene.
+
+### Where do human approvals fit?
+
+Human-in-the-loop belongs in runtime policy for high-risk actions. Release gates prove the build before those runtime controls apply.
+
+## Next step
+
+Standing up a governed eval program this half? Start the [enterprise pilot](/enterprise) or book a demo to map your first workload to a gate-ready benchmark.
+
+## Related resources
+
+- [Enterprise pilot](/enterprise)
+- [CI/CD agent gates](/docs/guides/ci-cd-agent-gates)
+- [CI/CD agent evaluation](/ci-cd-agent-evaluation)
+- [AI agent regression testing](/platform/agent-regression-testing)

--- a/web/content/blog/building-agent-eval-program-regulated-enterprise.mdx
+++ b/web/content/blog/building-agent-eval-program-regulated-enterprise.mdx
@@ -62,10 +62,10 @@ The compare view should show tradeoffs clearly: correctness, cost per success, l
 
 An eval program without CI becomes a quarterly ritual. Wire gates when baselines exist:
 
-1. Repo-tracked `.agentclash/ci.yaml` manifest
-2. Remote validation in CI for resource visibility
-3. `agentclash ci run` on agent-changing paths
-4. Artifact upload: gate JSON, scorecard, replay links
+1. Repo-tracked `.agentclash/ci.yaml` manifest with `baseline.run_id` pinned
+2. Remote validation in CI: `agentclash ci validate .agentclash/ci.yaml --remote`
+3. `agentclash ci should-run --manifest .agentclash/ci.yaml` on agent-changing paths, then `agentclash ci run --manifest .agentclash/ci.yaml --artifact-dir agentclash-artifacts` when matched
+4. Artifact upload: `gate.json`, scorecard JSON, replay links (or use the bundled GitHub Action)
 
 This is the handoff from **program** to **control**. Implementation guide: [CI/CD agent gates](/docs/guides/ci-cd-agent-gates). Product page: [CI/CD agent evaluation](/ci-cd-agent-evaluation).
 
@@ -119,7 +119,7 @@ Human-in-the-loop belongs in runtime policy for high-risk actions. Release gates
 
 ## Next step
 
-Standing up a governed eval program this half? Start the [enterprise pilot](/enterprise) or book a demo to map your first workload to a gate-ready benchmark.
+Standing up a governed eval program this half? Start the [enterprise pilot](/enterprise) or ask about [Benchmark & Gate Setup](/services) for hands-on pack and gate wiring.
 
 ## Related resources
 

--- a/web/content/blog/why-ai-pilot-failed-agent-eval-second-attempt.mdx
+++ b/web/content/blog/why-ai-pilot-failed-agent-eval-second-attempt.mdx
@@ -55,7 +55,7 @@ That is the difference between "the pilot felt good" and "the gate failed on rec
 | Great demo, bad staging | Workload mismatch | New case from staging incident |
 | Inconsistent scores across days | Unfrozen pack or warm state | Pin pack version; independent sandboxes per attempt |
 | Security slow-walked approval | No audit artifact | Gate summary + replay bundle |
-| Vendor looked best | Black-box lane without evidence tier | Label tiers; gate native workloads on full replay |
+| Vendor looked best | Black-box lane without evidence tier | Label tiers (`hosted_black_box` vs `native_structured`); gate native workloads on structured replay |
 | Team lost interest | No CI handoff | Manifest gate on agent repo |
 
 ## How eval compounds after the second run

--- a/web/content/blog/why-ai-pilot-failed-agent-eval-second-attempt.mdx
+++ b/web/content/blog/why-ai-pilot-failed-agent-eval-second-attempt.mdx
@@ -1,0 +1,97 @@
+---
+title: "Why Your AI Pilot Failed (and How Eval Fixes the Second Attempt)"
+date: "2026-06-12"
+description: "Most AI agent pilots fail on workload mismatch, missing baselines, and unreviewable evidence. How to redesign the second attempt with governed benchmarks and replay."
+author: "Atharva"
+---
+
+The first AI agent pilot rarely fails because the model is "bad." It fails because the team optimized for a demo shape that does not survive contact with production.
+
+Second attempts win when they replace enthusiasm with a **repeatable benchmark loop**: frozen workload, baseline comparison, replay evidence, and a gate verdict everyone can inspect.
+
+## The four failure modes we see in first pilots
+
+### 1. Wrong workload
+
+The pilot used generic public tasks while production needs your repo layout, tools, approvals, and failure recovery. Scores looked fine. Shipped behavior did not.
+
+**Fix:** Encode one shippable workflow in a [challenge pack](/docs/guides/write-a-challenge-pack) with validators tied to tests or artifacts, not final-string matching.
+
+### 2. No baseline
+
+Teams compared candidates to vibes or to a vendor slide. When the pilot "succeeded," nobody could prove what improved or regressed.
+
+**Fix:** Pin a baseline deployment and re-run every candidate against it. Record the green run as the reference for CI.
+
+### 3. Evidence nobody trusts
+
+Security and engineering got chat transcripts or aggregate eval scores without trajectory proof. Disagreements ended in meetings, not diffs.
+
+**Fix:** Capture replay with tool calls, artifacts, routing, cost, and latency. Use the compare view to show *why* one agent won.
+
+### 4. No path from pilot to production
+
+The pilot ended with a recommendation deck. Production kept shipping agent changes without re-running the workload.
+
+**Fix:** Promote the pilot benchmark into [CI/CD agent evaluation](/ci-cd-agent-evaluation) with a manifest gate. See [AI agent regression testing](/platform/agent-regression-testing) for the regression layer.
+
+## Redesign the second attempt as a benchmark decision
+
+Use the enterprise buyer loop as your pilot template:
+
+1. **Monday problem:** name the release decision (for example, coding agent RC vs production baseline).
+2. **Freeze once:** challenge pack version, input set, tool policy, gate thresholds.
+3. **Race fairly:** baseline, candidate, and any vendors under the same sandbox contract.
+4. **Watch live:** routing fallbacks, tool efficiency, cost drift, sandbox failures.
+5. **Decide with replay:** open divergences, attach scorecard, export evidence bundle.
+6. **Close the loop:** block or ship with a named reason; promote failures into regression cases.
+
+That is the difference between "the pilot felt good" and "the gate failed on recovery reliability after a model fallback."
+
+## Failure-mode worksheet (use in your pilot retro)
+
+| Pilot symptom | Likely root cause | Second-attempt action |
+| --- | --- | --- |
+| Great demo, bad staging | Workload mismatch | New case from staging incident |
+| Inconsistent scores across days | Unfrozen pack or warm state | Pin pack version; independent sandboxes per attempt |
+| Security slow-walked approval | No audit artifact | Gate summary + replay bundle |
+| Vendor looked best | Black-box lane without evidence tier | Label tiers; gate native workloads on full replay |
+| Team lost interest | No CI handoff | Manifest gate on agent repo |
+
+## How eval compounds after the second run
+
+Every meaningful miss becomes a case. Every case becomes a regression. Every regression tightens the next gate.
+
+Wire the manifest when the second benchmark goes green:
+
+```bash
+agentclash ci init .agentclash/ci.yaml
+agentclash ci validate .agentclash/ci.yaml --remote
+```
+
+Full recipe: [CI/CD agent gates](/docs/guides/ci-cd-agent-gates).
+
+## FAQ
+
+### Should we rerun the same pilot with a better model?
+
+Only if the workload was right the first time. If the workload was wrong, a better model just fails faster on the wrong test.
+
+### How long should the second attempt take?
+
+Many platform teams freeze the first real task in one sprint and gate CI in the next. [Benchmark & Gate Setup](/services) is available if you want hands-on help.
+
+### What metric should executives see?
+
+One gate verdict plus three deltas vs baseline: correctness, cost per success, and median latency. Link replay for the case that drove the call.
+
+## Next step
+
+Restarting after a stalled pilot? Start the [enterprise pilot](/enterprise) and rerun your workload as a governed benchmark with replay and gate export.
+
+## Related resources
+
+- [Enterprise pilot](/enterprise)
+- [CI/CD agent evaluation](/ci-cd-agent-evaluation)
+- [AI agent regression testing](/platform/agent-regression-testing)
+- [Write a challenge pack](/docs/guides/write-a-challenge-pack)


### PR DESCRIPTION
## Summary

- Adds four enterprise-focused blog posts for issue #988, written with the [seo-research-blog-skill](https://github.com/Atharva-Kanherkar/seo-research-blog-skill) workflow (keyword intent, citation hygiene, no em dashes).
- Each post anchors in the enterprise buyer loop from `docs/product/enterprise-user-pov.md`: benchmark decision, replay evidence, and gate verdict.
- Required links included: `/platform/agent-regression-testing`, `/ci-cd-agent-evaluation`, `/enterprise`, plus CI gates docs on multiple posts.

## Posts

1. `/blog/ai-agent-approval-security-compliance` — security/compliance approval checklist and evidence bundle
2. `/blog/ai-platform-lead-agent-release-gates` — platform lead guide to manifest-based release gates
3. `/blog/why-ai-pilot-failed-agent-eval-second-attempt` — pilot failure modes and second-attempt benchmark loop
4. `/blog/building-agent-eval-program-regulated-enterprise` — phased eval program for regulated enterprises

## Test plan

- [x] `python3 check_no_emdash.py` on all four MDX files (pass)
- [x] `pnpm exec vitest run src/app/public-canonical-metadata.test.ts src/app/sitemap.test.ts` (15/15 pass)
- [ ] Preview blog routes on Vercel preview after merge

Closes #988