### PR TITLE
feat(blog): UAE/regional enterprise angles batch (#989)

### DIFF
--- a/web/content/blog/ai-agent-governance-middle-east-enterprises.mdx
+++ b/web/content/blog/ai-agent-governance-middle-east-enterprises.mdx
@@ -91,5 +91,6 @@ Evaluating agents for a UAE or GCC rollout? Start the [enterprise pilot](/enterp
 
 - [Enterprise pilot](/enterprise)
 - [Support agent evaluation](/use-cases/support-agent-evaluation)
+- [Evaluating bilingual customer support agents](/blog/evaluating-bilingual-customer-support-agents)
 - [AI agent approval from security and compliance](/blog/ai-agent-approval-security-compliance)
 - [CI/CD agent gates](/docs/guides/ci-cd-agent-gates)

--- a/web/content/blog/ai-agent-governance-middle-east-enterprises.mdx
+++ b/web/content/blog/ai-agent-governance-middle-east-enterprises.mdx
@@ -1,0 +1,95 @@
+---
+title: "AI Agent Governance for Middle East Enterprises: Residency, Evidence, and Release Gates"
+date: "2026-06-14"
+description: "UAE and GCC buyers need clear separation between data residency, sovereign cloud, and agent release evidence. A governance checklist grounded in repeatable eval workflows."
+author: "Atharva"
+---
+
+Middle East enterprise teams often get one slide that mixes three different problems: where data lives, who runs the cloud, and whether an AI agent is safe to ship.
+
+Those are related, but they are not the same decision. Governance breaks when procurement, security, and platform engineering argue past each other using one overloaded word like "compliance."
+
+## Separate the four questions buyers actually ask
+
+| Question | What it covers | What it does not prove |
+| --- | --- | --- |
+| Data residency | Where prompts, logs, and artifacts are stored and processed | That the agent resolves tickets correctly |
+| Sovereign or regional hosting | Who operates infrastructure and under which legal framework | That your vendor model behaves the same in Arabic and English |
+| Agent release evidence | Frozen workload, replay, scorecard, gate verdict | ISO certification by itself |
+| Government or sector procurement | Audit trail format, retention, approval workflow | A generic public benchmark score |
+
+AgentClash sits primarily in the **release evidence** column. It helps teams run governed benchmarks, preserve replay, compare baselines, and export gate artifacts stakeholders can review. It supports evaluation and release-gate workflows; it does not replace PDPL legal review, sector regulators, or your cloud residency contract.
+
+Regional context: UAE and wider GCC buyers increasingly treat residency and AI governance as board-level topics alongside frameworks such as PDPL and sector rules from bodies like TDRA, CBUAE, ADGM, and DIFC. Your architecture review still owns the legal mapping; your eval program owns the proof that a specific agent build behaved acceptably on your workload.
+
+## What hosted AgentClash offers today (and what to discuss separately)
+
+Be precise about deployment options:
+
+- **Hosted Team pilot:** runs on AgentClash standard cloud regions today, with BYOK so provider tokens bill to your accounts directly.
+- **Self-host or hybrid:** AgentClash is MIT-licensed; many enterprises run the stack in environments they control after the pilot.
+- **Enterprise architecture review:** dedicated deployment, private networking, and residency requirements can be discussed for enterprise contracts. See the [enterprise pilot FAQ](/enterprise) and contact `hello@agentclash.dev` for residency conversations.
+
+Do not read those options as "AgentClash is certified for every UAE sector." Read them as deployment paths your team can align with legal and infra decisions you already own.
+
+## The governance artifact GCC reviewers expect
+
+Whether the buyer is in financial services, telecom, healthcare, or government-adjacent operations, the release packet shape is similar:
+
+1. **Frozen workload:** challenge pack version, input set, tool policy
+2. **Named builds:** baseline and candidate agent deployments
+3. **Replay evidence:** trajectory proof for cases that drove the decision
+4. **Scorecard deltas:** correctness, cost, latency, policy dimensions
+5. **Gate verdict:** ship, block, or conditional with a named owner
+
+That loop matches the enterprise buyer narrative in our [security approval checklist](/blog/ai-agent-approval-security-compliance) and [regulated eval program guide](/blog/building-agent-eval-program-regulated-enterprise).
+
+For customer-facing agents, encode real ticket flows in [support agent evaluation](/use-cases/support-agent-evaluation) packs before you debate model vendors.
+
+## Checklist for platform and compliance leads
+
+- [ ] Residency decision documented separately from agent release decision
+- [ ] BYOK and log retention policy attached to the eval workspace
+- [ ] Challenge pack version frozen for the approval period
+- [ ] Baseline run ID pinned in CI manifest when gates apply
+- [ ] Evidence tier labeled for hosted vs native agents (`native_structured`, `hosted_structured`, `hosted_black_box`)
+- [ ] Gate summary translated for non-engineering stakeholders (Arabic executive summary optional; replay remains source of truth)
+- [ ] Self-host or dedicated deployment path evaluated if hosted regions are insufficient
+
+## Wire governance into CI without overclaiming
+
+Once leadership accepts the evidence shape, promote the approved workload into repo-tracked gates:
+
+```bash
+agentclash ci init .agentclash/ci.yaml
+agentclash ci validate .agentclash/ci.yaml --remote
+agentclash ci should-run --manifest .agentclash/ci.yaml
+agentclash ci run --manifest .agentclash/ci.yaml --artifact-dir agentclash-artifacts
+```
+
+Implementation details: [CI/CD agent gates](/docs/guides/ci-cd-agent-gates). Product overview: [AI agent regression testing](/platform/agent-regression-testing).
+
+## FAQ
+
+### Does AgentClash guarantee UAE data residency on the hosted pilot?
+
+No. Hosted pilots use standard cloud regions today. Discuss residency, private networking, or self-host during an enterprise architecture review, or run the open-source stack in infrastructure you control.
+
+### How is this different from sovereign AI infrastructure selection?
+
+Infrastructure answers where compute runs. Agent governance answers whether a specific agent revision is safe to release on your workload, with replay and gate evidence. You need both conversations; neither replaces the other.
+
+### Can we use this for government procurement readouts?
+
+AgentClash exports replay, scorecards, and gate verdicts that support audit-friendly readouts. Your procurement template still defines the final evidence format and retention rules.
+
+## Next step
+
+Evaluating agents for a UAE or GCC rollout? Start the [enterprise pilot](/enterprise) to run governed benchmarks, or ask about [Benchmark & Gate Setup](/services) if you want help encoding your first residency-aware workload.
+
+## Related resources
+
+- [Enterprise pilot](/enterprise)
+- [Support agent evaluation](/use-cases/support-agent-evaluation)
+- [AI agent approval from security and compliance](/blog/ai-agent-approval-security-compliance)
+- [CI/CD agent gates](/docs/guides/ci-cd-agent-gates)

--- a/web/content/blog/evaluating-bilingual-customer-support-agents.mdx
+++ b/web/content/blog/evaluating-bilingual-customer-support-agents.mdx
@@ -1,0 +1,117 @@
+---
+title: "Evaluating Bilingual Customer Support Agents: Arabic, English, and Release Evidence"
+date: "2026-06-15"
+description: "Bilingual support agents need evals on real ticket flows in each language, not a single translated prompt. How to build Arabic and English cases with replay and gates."
+author: "Atharva"
+---
+
+A support agent that sounds fluent in a demo can still fail in production when the customer writes in Arabic, code-switches mid-ticket, or expects policy language that matches your regulated market.
+
+Bilingual evaluation is not "run the English pack through Google Translate." It is running **the same resolution workflow** with language-specific cases, validators, and replay evidence for each lane you ship.
+
+## What bilingual support eval must prove
+
+Before you approve a support agent for UAE or wider GCC operations, stakeholders usually need evidence on:
+
+1. **Resolution correctness:** did the agent solve the ticket under policy?
+2. **Language fit:** is the reply intelligible and appropriately formal in each language?
+3. **Tool discipline:** did it call refund, CRM, or escalation tools correctly?
+4. **Audit trail:** can compliance replay the trajectory later?
+
+Prompt-only evals catch tone. They miss tool misuse, wrong escalation, or an English reply to an Arabic ticket. The [support agent evaluation](/use-cases/support-agent-evaluation) use case page describes the full trajectory model AgentClash uses for ticket workflows.
+
+## Build separate cases, not translated duplicates
+
+Structure bilingual coverage in a challenge pack input set:
+
+| Lane | What to encode | Example signal |
+| --- | --- | --- |
+| English ticket | Standard refund or status flow | Validators on required fields and policy phrases |
+| Arabic ticket | Same workflow, Arabic customer messages | `contains` or judge rubric on Arabic output quality |
+| Code-switch | Arabic opener, English product IDs | Ensures the agent handles mixed input |
+| Escalation | Frustrated customer, policy boundary | Multi-turn scripted phases |
+
+Use `execution_mode: multi_turn` when the workflow needs back-and-forth, not a single-shot answer. The reference pack `examples/challenge-packs/multi-turn-refund-recovery.yaml` shows scripted user phases and validators on refund language; mirror that pattern with Arabic message fixtures your team approves.
+
+Deterministic checks can gate schema and required actions:
+
+```yaml
+validators:
+  - key: mentions_refund
+    type: contains
+    target: final_output
+    expected_from: "literal:refund"
+```
+
+Add LLM judge rubrics for language quality when deterministic string match is too brittle:
+
+```yaml
+llm_judges:
+  - key: arabic_clarity
+    mode: rubric
+    model: gpt-4.1
+    rubric: Score whether the reply is clear, polite Modern Standard Arabic appropriate for customer support.
+    context_from:
+      - challenge_input
+      - final_output
+```
+
+Hybrid scorecards can gate on policy validators first, then score language quality as a weighted dimension.
+
+## Compare baselines per language lane
+
+Race candidate and baseline agents on the **same pack version** with the same tool policy. The compare view should answer:
+
+- Did Arabic lane correctness regress while English improved?
+- Did cost or latency spike on multi-turn cases?
+- Did the agent skip tool calls in one language only?
+
+Replay is what settles disagreements between CX, compliance, and engineering. Export the cases that drove a block, not aggregate sentiment scores.
+
+## Connect bilingual eval to release gates
+
+When both language lanes pass policy, pin the green run as baseline and wire CI:
+
+```bash
+agentclash ci init .agentclash/ci.yaml
+agentclash ci validate .agentclash/ci.yaml --remote
+```
+
+Full gate recipe: [CI/CD agent gates](/docs/guides/ci-cd-agent-gates). Pair with [AI agent regression testing](/platform/agent-regression-testing) so every production miss in Arabic or English becomes a regression case.
+
+For regional governance framing (residency vs release evidence), see [AI agent governance for Middle East enterprises](/blog/ai-agent-governance-middle-east-enterprises).
+
+## Bilingual support eval checklist
+
+- [ ] Arabic and English cases cover the same business outcomes, not literal translations only
+- [ ] Tool and network policy identical across lanes
+- [ ] Validators gate policy actions; judges score language where needed
+- [ ] Multi-turn flows encoded for escalation scenarios
+- [ ] Baseline run recorded before vendor or model changes
+- [ ] Replay retention aligned with your records policy
+- [ ] Executive readout includes gate verdict plus per-lane deltas
+
+## FAQ
+
+### Does AgentClash ship a built-in Arabic benchmark?
+
+No. You author cases in challenge packs with your approved fixtures and policies. That keeps eval aligned with your products, refund rules, and tone guidelines.
+
+### Can we evaluate hosted vendor support agents with limited observability?
+
+Yes. Label evidence tier (`hosted_black_box` vs `native_structured`) and gate production paths on the evidence level your policy requires.
+
+### Where does data residency fit?
+
+Residency is a deployment and legal decision. Bilingual eval proves behavioral readiness on your workload. See the [enterprise pilot](/enterprise) FAQ for hosted regions and enterprise residency discussions.
+
+## Next step
+
+Shipping bilingual support agents in the Gulf? Start the [enterprise pilot](/enterprise), build cases on the [support agent evaluation](/use-cases/support-agent-evaluation) workflow, or ask about [Benchmark & Gate Setup](/services) for pack authoring help.
+
+## Related resources
+
+- [Support agent evaluation](/use-cases/support-agent-evaluation)
+- [Enterprise pilot](/enterprise)
+- [Write a challenge pack](/docs/guides/write-a-challenge-pack)
+- [Multi-turn challenge packs](/docs/challenge-packs/multi-turn)


### PR DESCRIPTION
## Summary

- Adds two blog posts for issue #989 targeting UAE/Middle East enterprise search intent without overstating residency or compliance guarantees.
- Separates data residency, sovereign hosting, release evidence, and procurement; connects regional concerns to challenge packs, replay, and CI gates.
- Links required pages: `/use-cases/support-agent-evaluation`, `/enterprise`, plus cross-links to #988 enterprise posts and CI docs.

## Posts

1. `/blog/ai-agent-governance-middle-east-enterprises` — residency vs release evidence governance checklist (aligned with enterprise FAQ)
2. `/blog/evaluating-bilingual-customer-support-agents` — Arabic/English support eval with multi-turn packs, validators, and judges

## Accuracy notes

- Hosted pilot described as standard cloud regions; enterprise residency/self-host paths match `/enterprise` FAQ
- Evidence tiers use API enums (`native_structured`, `hosted_structured`, `hosted_black_box`)
- CI snippets use correct `ci validate|should-run|run` manifest paths (post-#988 review fixes)
- No implied regional compliance certification

## Test plan

- [x] Em-dash validation on both MDX files
- [x] `pnpm exec vitest run src/app/public-canonical-metadata.test.ts src/app/sitemap.test.ts` (15/15 pass)
- [ ] Preview blog routes on Vercel preview

Closes #989